### PR TITLE
fix(release): harden v2.0.2 publication

### DIFF
--- a/.github/workflows/release-distribution.yml
+++ b/.github/workflows/release-distribution.yml
@@ -40,6 +40,10 @@ permissions:
   actions: read
   contents: read
 
+env:
+  # Checkout-free publication jobs must never rely on gh inferring a repository.
+  GH_REPO: ${{ github.repository }}
+
 concurrency:
   group: release-distribution-${{ inputs.channel }}-darwin-arm64
   cancel-in-progress: false
@@ -107,173 +111,40 @@ jobs:
           test "$(jq -r '.manifestSigning.publicKeyStatus' packaging/distribution/signing-policy.json)" = unprovisioned
           test "$(jq -r '.appleSigning.teamIdStatus' packaging/distribution/signing-policy.json)" = unprovisioned
 
-  prepare-a:
-    name: Build unsigned candidate A on an independent runner
+  publication-preflight:
+    name: Preflight checkout-free GitHub publication access
     needs: resolve
-    runs-on: macos-15
-    permissions:
-      actions: read
-      contents: read
-    env:
-      RELEASE_TAG: ${{ inputs.release_tag }}
-      RELEASE_CHANNEL: ${{ inputs.channel }}
-      RELEASE_REF: ${{ needs.resolve.outputs.release_ref }}
-      RELEASE_BUILD_ID: ${{ needs.resolve.outputs.release_build_id }}
-      SOURCE_DATE_EPOCH: ${{ needs.resolve.outputs.source_date_epoch }}
-      JOBCTRL_RELEASE_PUBLIC_KEY: ${{ needs.resolve.outputs.release_public_key }}
-    steps:
-      - name: Check out the exact audited source
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-        with:
-          ref: ${{ needs.resolve.outputs.release_ref }}
-          fetch-depth: 0
-          persist-credentials: false
-
-      - name: Set up pinned build runtimes
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-        with:
-          node-version: 22.21.1
-
-      - name: Set up pinned uv
-        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
-        with:
-          version: 0.11.7
-
-      - name: Reassert audited refs before dependency execution
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          test "$(git rev-parse HEAD)" = "$RELEASE_REF"
-          test "$(gh api "repos/$GITHUB_REPOSITORY/commits/main" --jq '.sha')" = "$RELEASE_REF"
-          test "$(gh api "repos/$GITHUB_REPOSITORY/commits/$RELEASE_TAG" --jq '.sha')" = "$RELEASE_REF"
-
-      - name: Install locked workspace dependencies
-        run: corepack pnpm install --frozen-lockfile
-
-      - name: Rebuild and verify tracked release-authority bundles
-        run: |
-          set -euo pipefail
-          corepack pnpm exec esbuild scripts/distribution-release-finalizer-entry.mjs --bundle --platform=node --format=esm --target=node22 --outfile="$RUNNER_TEMP/distribution-release.finalizer.bundle.mjs"
-          corepack pnpm exec esbuild scripts/distribution-homebrew-render-entry.mjs --bundle --platform=node --format=esm --target=node22 --outfile="$RUNNER_TEMP/distribution-homebrew.render.bundle.mjs"
-          cmp scripts/distribution-release.finalizer.bundle.mjs "$RUNNER_TEMP/distribution-release.finalizer.bundle.mjs"
-          cmp scripts/distribution-homebrew.render.bundle.mjs "$RUNNER_TEMP/distribution-homebrew.render.bundle.mjs"
-          (
-            cd scripts
-            shasum -a 256 -c distribution-release.finalizer.bundle.mjs.sha256
-            shasum -a 256 -c distribution-homebrew.render.bundle.mjs.sha256
-          )
-
-      - name: Run pre-sign release gates
-        run: |
-          set -euo pipefail
-          corepack pnpm distribution:audit
-          corepack pnpm scripts:test
-          python3 scripts/release_check.py --strict-prompt --release-tag "$RELEASE_TAG"
-
-      - name: Build unsigned candidate A
-        run: node scripts/distribution-release.mjs prepare --output "$RUNNER_TEMP/pre-sign" --channel "$RELEASE_CHANNEL" --build-id "$RELEASE_BUILD_ID" --source-date-epoch "$SOURCE_DATE_EPOCH"
-
-      - name: Upload only candidate A data
-        run: |
-          set -euo pipefail
-          mkdir -p "$RUNNER_TEMP/build-a"
-          COPYFILE_DISABLE=1 tar -cf "$RUNNER_TEMP/build-a/prepared-candidate.tar" -C "$RUNNER_TEMP" pre-sign
-
-      - name: Retain candidate A
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: jobctrl-prepared-a-${{ github.run_id }}
-          path: ${{ runner.temp }}/build-a
-          if-no-files-found: error
-          retention-days: 14
-
-  prepare-b:
-    name: Build unsigned candidate B on an independent runner
-    needs: resolve
-    runs-on: macos-15
-    permissions:
-      actions: read
-      contents: read
-    env:
-      RELEASE_TAG: ${{ inputs.release_tag }}
-      RELEASE_CHANNEL: ${{ inputs.channel }}
-      RELEASE_REF: ${{ needs.resolve.outputs.release_ref }}
-      RELEASE_BUILD_ID: ${{ needs.resolve.outputs.release_build_id }}
-      SOURCE_DATE_EPOCH: ${{ needs.resolve.outputs.source_date_epoch }}
-      JOBCTRL_RELEASE_PUBLIC_KEY: ${{ needs.resolve.outputs.release_public_key }}
-    steps:
-      - name: Check out the exact audited source
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-        with:
-          ref: ${{ needs.resolve.outputs.release_ref }}
-          fetch-depth: 0
-          persist-credentials: false
-
-      - name: Set up pinned build runtimes
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-        with:
-          node-version: 22.21.1
-
-      - name: Set up pinned uv
-        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
-        with:
-          version: 0.11.7
-
-      - name: Reassert audited refs before dependency execution
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          test "$(git rev-parse HEAD)" = "$RELEASE_REF"
-          test "$(gh api "repos/$GITHUB_REPOSITORY/commits/main" --jq '.sha')" = "$RELEASE_REF"
-          test "$(gh api "repos/$GITHUB_REPOSITORY/commits/$RELEASE_TAG" --jq '.sha')" = "$RELEASE_REF"
-
-      - name: Install locked workspace dependencies
-        run: corepack pnpm install --frozen-lockfile
-
-      - name: Rebuild and verify tracked release-authority bundles
-        run: |
-          set -euo pipefail
-          corepack pnpm exec esbuild scripts/distribution-release-finalizer-entry.mjs --bundle --platform=node --format=esm --target=node22 --outfile="$RUNNER_TEMP/distribution-release.finalizer.bundle.mjs"
-          corepack pnpm exec esbuild scripts/distribution-homebrew-render-entry.mjs --bundle --platform=node --format=esm --target=node22 --outfile="$RUNNER_TEMP/distribution-homebrew.render.bundle.mjs"
-          cmp scripts/distribution-release.finalizer.bundle.mjs "$RUNNER_TEMP/distribution-release.finalizer.bundle.mjs"
-          cmp scripts/distribution-homebrew.render.bundle.mjs "$RUNNER_TEMP/distribution-homebrew.render.bundle.mjs"
-          (
-            cd scripts
-            shasum -a 256 -c distribution-release.finalizer.bundle.mjs.sha256
-            shasum -a 256 -c distribution-homebrew.render.bundle.mjs.sha256
-          )
-
-      - name: Run pre-sign release gates
-        run: |
-          set -euo pipefail
-          corepack pnpm distribution:audit
-          corepack pnpm scripts:test
-          python3 scripts/release_check.py --strict-prompt --release-tag "$RELEASE_TAG"
-
-      - name: Build unsigned candidate B
-        run: node scripts/distribution-release.mjs prepare --output "$RUNNER_TEMP/pre-sign" --channel "$RELEASE_CHANNEL" --build-id "$RELEASE_BUILD_ID" --source-date-epoch "$SOURCE_DATE_EPOCH"
-
-      - name: Upload only candidate B data
-        run: |
-          set -euo pipefail
-          mkdir -p "$RUNNER_TEMP/build-b"
-          COPYFILE_DISABLE=1 tar -cf "$RUNNER_TEMP/build-b/prepared-candidate.tar" -C "$RUNNER_TEMP" pre-sign
-
-      - name: Retain candidate B
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: jobctrl-prepared-b-${{ github.run_id }}
-          path: ${{ runner.temp }}/build-b
-          if-no-files-found: error
-          retention-days: 14
-
-  compare:
-    name: Compare two independent candidates with checkout-rooted code
-    needs: [resolve, prepare-a, prepare-b]
     runs-on: ubuntu-24.04
     permissions:
+      contents: read
+    env:
+      RELEASE_TAG: ${{ inputs.release_tag }}
+      RELEASE_REF: ${{ needs.resolve.outputs.release_ref }}
+    steps:
+      - name: Prove checkout-free release commands before signing
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          test "$GH_REPO" = "$GITHUB_REPOSITORY"
+          test "$(gh repo view "$GH_REPO" --json nameWithOwner --jq '.nameWithOwner')" = "$GITHUB_REPOSITORY"
+          test "$(gh api "repos/$GITHUB_REPOSITORY/commits/main" --jq '.sha')" = "$RELEASE_REF"
+          test "$(gh api "repos/$GITHUB_REPOSITORY/commits/$RELEASE_TAG" --jq '.sha')" = "$RELEASE_REF"
+          release="$RUNNER_TEMP/preflight-release.json"
+          error="$RUNNER_TEMP/preflight-release.err"
+          if gh release view "$RELEASE_TAG" --json isDraft,targetCommitish,tagName > "$release" 2> "$error"; then
+            test "$(jq -r '.tagName' "$release")" = "$RELEASE_TAG"
+            test "$(jq -r '.targetCommitish' "$release")" = "$RELEASE_REF"
+          elif ! grep -Eqi 'HTTP 404|release not found' "$error"; then
+            cat "$error" >&2
+            exit 1
+          fi
+
+  prepare:
+    name: Build unsigned candidate once
+    needs: resolve
+    runs-on: macos-15
+    permissions:
       actions: read
       contents: read
     env:
@@ -282,39 +153,27 @@ jobs:
       RELEASE_REF: ${{ needs.resolve.outputs.release_ref }}
       RELEASE_BUILD_ID: ${{ needs.resolve.outputs.release_build_id }}
       SOURCE_DATE_EPOCH: ${{ needs.resolve.outputs.source_date_epoch }}
-      EXPECTED_RELEASE_PUBLIC_KEY: ${{ needs.resolve.outputs.release_public_key }}
+      JOBCTRL_RELEASE_PUBLIC_KEY: ${{ needs.resolve.outputs.release_public_key }}
       EXPECTED_RELEASE_KEY_ID: ${{ needs.resolve.outputs.release_key_id }}
     steps:
-      - name: Check out only the exact audited comparison code
+      - name: Check out the exact audited source
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ needs.resolve.outputs.release_ref }}
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Set up the pinned audited runtimes
+      - name: Set up pinned build runtimes
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22.21.1
 
-      - name: Set up safe archive extraction
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+      - name: Set up pinned uv
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
         with:
-          python-version: "3.12.13"
+          version: 0.11.7
 
-      - name: Download candidate A data
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
-        with:
-          name: jobctrl-prepared-a-${{ github.run_id }}
-          path: ${{ runner.temp }}/build-a
-
-      - name: Download candidate B data
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
-        with:
-          name: jobctrl-prepared-b-${{ github.run_id }}
-          path: ${{ runner.temp }}/build-b
-
-      - name: Reassert audited refs before comparison
+      - name: Reassert audited refs before dependency execution
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -323,81 +182,64 @@ jobs:
           test "$(gh api "repos/$GITHUB_REPOSITORY/commits/main" --jq '.sha')" = "$RELEASE_REF"
           test "$(gh api "repos/$GITHUB_REPOSITORY/commits/$RELEASE_TAG" --jq '.sha')" = "$RELEASE_REF"
 
-      - name: Verify checkout-rooted release authority
+      - name: Install locked workspace dependencies
+        run: corepack pnpm install --frozen-lockfile
+
+      - name: Rebuild and verify tracked release-authority bundles
         run: |
           set -euo pipefail
+          corepack pnpm exec esbuild scripts/distribution-release-finalizer-entry.mjs --bundle --platform=node --format=esm --target=node22 --outfile="$RUNNER_TEMP/distribution-release.finalizer.bundle.mjs"
+          corepack pnpm exec esbuild scripts/distribution-homebrew-render-entry.mjs --bundle --platform=node --format=esm --target=node22 --outfile="$RUNNER_TEMP/distribution-homebrew.render.bundle.mjs"
+          cmp scripts/distribution-release.finalizer.bundle.mjs "$RUNNER_TEMP/distribution-release.finalizer.bundle.mjs"
+          cmp scripts/distribution-homebrew.render.bundle.mjs "$RUNNER_TEMP/distribution-homebrew.render.bundle.mjs"
           (
             cd scripts
             shasum -a 256 -c distribution-release.finalizer.bundle.mjs.sha256
             shasum -a 256 -c distribution-homebrew.render.bundle.mjs.sha256
           )
 
-      - name: Safely unpack candidate data
+      - name: Run pre-sign release gates
         run: |
           set -euo pipefail
-          for label in a b; do
-            archive="$RUNNER_TEMP/build-$label/prepared-candidate.tar"
-            destination="$RUNNER_TEMP/compare-$label"
-            test -f "$archive" && test ! -L "$archive"
-            mkdir -p "$destination"
-            python3 - "$archive" "$destination" <<'PY'
-          import pathlib
-          import sys
-          import tarfile
+          corepack pnpm distribution:audit
+          corepack pnpm scripts:test
+          python3 scripts/release_check.py --strict-prompt --release-tag "$RELEASE_TAG"
 
-          archive_path, destination = sys.argv[1:]
-          with tarfile.open(archive_path, "r:") as archive:
-              members = archive.getmembers()
-              if not members:
-                  raise SystemExit("prepared candidate archive is empty")
-              seen = set()
-              for member in members:
-                  path = pathlib.PurePosixPath(member.name)
-                  if path.is_absolute() or not path.parts or path.parts[0] != "pre-sign":
-                      raise SystemExit(f"unsafe prepared candidate path: {member.name}")
-                  if ".." in path.parts or member.name in seen:
-                      raise SystemExit(f"unsafe or duplicate prepared candidate path: {member.name}")
-                  seen.add(member.name)
-              archive.extractall(destination, members=members, filter="data")
-          PY
-          done
+      - name: Build unsigned candidate
+        run: node scripts/distribution-release.mjs prepare --output "$RUNNER_TEMP/pre-sign" --channel "$RELEASE_CHANNEL" --build-id "$RELEASE_BUILD_ID" --source-date-epoch "$SOURCE_DATE_EPOCH"
 
-      - name: Compare independent candidate bytes with the tracked finalizer
-        run: node scripts/distribution-release.finalizer.bundle.mjs compare --first "$RUNNER_TEMP/compare-a/pre-sign" --second "$RUNNER_TEMP/compare-b/pre-sign" --channel "$RELEASE_CHANNEL" --public-key "$EXPECTED_RELEASE_PUBLIC_KEY" --output "$RUNNER_TEMP/pre-sign-comparison.json"
-
-      - name: Seal only compared candidate data
+      - name: Package the prepared handoff
         run: |
           set -euo pipefail
-          sealed="$RUNNER_TEMP/compared-candidate"
-          mkdir -p "$sealed"
-          COPYFILE_DISABLE=1 tar -cf "$sealed/prepared-candidate.tar" -C "$RUNNER_TEMP/compare-a" pre-sign
-          install -m 0644 "$RUNNER_TEMP/pre-sign-comparison.json" "$sealed/pre-sign-comparison.json"
+          handoff="$RUNNER_TEMP/prepared-candidate"
+          mkdir -p "$handoff"
+          COPYFILE_DISABLE=1 tar -cf "$handoff/prepared-candidate.tar" -C "$RUNNER_TEMP" pre-sign
           jq -n \
             --arg releaseTag "$RELEASE_TAG" \
             --arg releaseRef "$RELEASE_REF" \
             --arg releaseChannel "$RELEASE_CHANNEL" \
             --arg releaseBuildId "$RELEASE_BUILD_ID" \
             --arg sourceDateEpoch "$SOURCE_DATE_EPOCH" \
-            --arg releasePublicKey "$EXPECTED_RELEASE_PUBLIC_KEY" \
+            --arg releasePublicKey "$JOBCTRL_RELEASE_PUBLIC_KEY" \
             --arg releaseKeyId "$EXPECTED_RELEASE_KEY_ID" \
             '{schemaVersion: 1, releaseTag: $releaseTag, releaseRef: $releaseRef, releaseChannel: $releaseChannel, releaseBuildId: $releaseBuildId, sourceDateEpoch: $sourceDateEpoch, releasePublicKey: $releasePublicKey, releaseKeyId: $releaseKeyId}' \
-            > "$sealed/release-contract.json"
+            > "$handoff/release-contract.json"
           (
-            cd "$sealed"
-            shasum -a 256 prepared-candidate.tar pre-sign-comparison.json release-contract.json > COMPARE_SHA256SUMS
+            cd "$handoff"
+            shasum -a 256 prepared-candidate.tar release-contract.json > PREPARED_SHA256SUMS
           )
 
-      - name: Upload the independently compared handoff
+      - name: Retain the prepared candidate
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: jobctrl-compared-candidate-${{ github.run_id }}
-          path: ${{ runner.temp }}/compared-candidate
+          name: jobctrl-prepared-candidate-${{ github.run_id }}
+          path: ${{ runner.temp }}/prepared-candidate
           if-no-files-found: error
           retention-days: 14
 
   sign:
     name: Sign and notarize on a fresh protected runner
-    needs: [resolve, compare]
+    needs: [resolve, publication-preflight, prepare]
     runs-on: macos-15
     environment: release-signing
     outputs:
@@ -432,11 +274,11 @@ jobs:
         with:
           python-version: "3.12.10"
 
-      - name: Download the independently compared candidate
+      - name: Download the prepared candidate
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
-          name: jobctrl-compared-candidate-${{ github.run_id }}
-          path: ${{ runner.temp }}/compared-candidate
+          name: jobctrl-prepared-candidate-${{ github.run_id }}
+          path: ${{ runner.temp }}/prepared-candidate
 
       - name: Reassert the audited source before accepting the prepared handoff
         env:
@@ -447,7 +289,7 @@ jobs:
           test "$(gh api "repos/$GITHUB_REPOSITORY/commits/main" --jq '.sha')" = "$RELEASE_REF"
           test "$(gh api "repos/$GITHUB_REPOSITORY/commits/$RELEASE_TAG" --jq '.sha')" = "$RELEASE_REF"
 
-      - name: Verify checkout-rooted release authority and the compared handoff
+      - name: Verify checkout-rooted release authority and the prepared handoff
         run: |
           set -euo pipefail
           (
@@ -455,13 +297,13 @@ jobs:
             shasum -a 256 -c distribution-release.finalizer.bundle.mjs.sha256
             shasum -a 256 -c distribution-homebrew.render.bundle.mjs.sha256
           )
-          artifact="$RUNNER_TEMP/compared-candidate"
-          for path in COMPARE_SHA256SUMS pre-sign-comparison.json prepared-candidate.tar release-contract.json; do
+          artifact="$RUNNER_TEMP/prepared-candidate"
+          for path in PREPARED_SHA256SUMS prepared-candidate.tar release-contract.json; do
             test -f "$artifact/$path" && test ! -L "$artifact/$path"
           done
           (
             cd "$artifact"
-            shasum -a 256 -c COMPARE_SHA256SUMS
+            shasum -a 256 -c PREPARED_SHA256SUMS
           )
           mkdir -p "$RUNNER_TEMP/prepared"
           python3 - "$artifact/prepared-candidate.tar" "$RUNNER_TEMP/prepared" <<'PY'
@@ -473,14 +315,14 @@ jobs:
           with tarfile.open(archive_path, "r:") as archive:
               members = archive.getmembers()
               if not members:
-                  raise SystemExit("compared candidate archive is empty")
+                  raise SystemExit("prepared candidate archive is empty")
               seen = set()
               for member in members:
                   path = pathlib.PurePosixPath(member.name)
                   if path.is_absolute() or not path.parts or path.parts[0] != "pre-sign":
-                      raise SystemExit(f"unsafe compared candidate path: {member.name}")
+                      raise SystemExit(f"unsafe prepared candidate path: {member.name}")
                   if ".." in path.parts or member.name in seen:
-                      raise SystemExit(f"unsafe or duplicate compared candidate path: {member.name}")
+                      raise SystemExit(f"unsafe or duplicate prepared candidate path: {member.name}")
                   seen.add(member.name)
               archive.extractall(destination, members=members, filter="data")
           PY
@@ -494,7 +336,15 @@ jobs:
           test "$(git rev-parse HEAD)" = "$RELEASE_REF"
 
       - name: Reverify the selected candidate tree before any signing secret
-        run: node scripts/distribution-release.finalizer.bundle.mjs verify-prepared --prepared "$RUNNER_TEMP/prepared/pre-sign" --channel "$RELEASE_CHANNEL" --public-key "$EXPECTED_RELEASE_PUBLIC_KEY"
+        run: |
+          set -euo pipefail
+          artifact="$RUNNER_TEMP/prepared-candidate"
+          node scripts/distribution-release.finalizer.bundle.mjs verify-prepared \
+            --prepared "$RUNNER_TEMP/prepared/pre-sign" \
+            --channel "$RELEASE_CHANNEL" \
+            --public-key "$EXPECTED_RELEASE_PUBLIC_KEY" \
+            > "$artifact/pre-sign-verification.json"
+          test -s "$artifact/pre-sign-verification.json"
 
       - name: Bind the protected private key to the configured public trust
         env:
@@ -550,7 +400,7 @@ jobs:
           # Bundled equivalent of: node scripts/distribution-release.mjs finalize
           node scripts/distribution-release.finalizer.bundle.mjs finalize \
             --prepared "$RUNNER_TEMP/prepared/pre-sign" \
-            --comparison "$RUNNER_TEMP/compared-candidate/pre-sign-comparison.json" \
+            --verification "$RUNNER_TEMP/prepared-candidate/pre-sign-verification.json" \
             --output "$RUNNER_TEMP/release" \
             --channel "$RELEASE_CHANNEL" \
             --sequence "$RELEASE_SEQUENCE" \
@@ -559,7 +409,7 @@ jobs:
             --source-date-epoch "$SOURCE_DATE_EPOCH" \
             --source-commit "$(git rev-parse HEAD)"
           test -f "$RUNNER_TEMP/release/audit/notary-log.json"
-          test -f "$RUNNER_TEMP/release/audit/pre-sign-comparison.json"
+          test -f "$RUNNER_TEMP/release/audit/pre-sign-verification.json"
           test -f "$RUNNER_TEMP/release/SHA256SUMS"
 
       - name: Root pointer and stable formula identity in the audited signer
@@ -1323,8 +1173,8 @@ jobs:
           echo "source_commit=$EXPECTED_SOURCE_COMMIT" >> "$GITHUB_OUTPUT"
           echo "source_date_epoch=$EXPECTED_SOURCE_DATE_EPOCH" >> "$GITHUB_OUTPUT"
 
-  pypi-build-a:
-    name: Build PyPI distributions on independent runner A
+  pypi-build:
+    name: Build and seal PyPI distributions once
     needs: pypi-resolve
     runs-on: ubuntu-24.04
     permissions:
@@ -1376,149 +1226,29 @@ jobs:
         run: |
           set -euo pipefail
           shopt -s nullglob
-          artifact_root="$RUNNER_TEMP/jobctrl-pypi-a/packages"
+          artifact_root="$RUNNER_TEMP/jobctrl-pypi-dists/packages"
           mkdir -p "$artifact_root"
           wheels=(workers/automation/dist/*.whl)
           sdists=(workers/automation/dist/*.tar.gz)
           test "${#wheels[@]}" = 1
           test "${#sdists[@]}" = 1
           install -m 0644 "${wheels[0]}" "${sdists[0]}" "$artifact_root/"
-
-      - name: Upload only build A package bytes
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: jobctrl-pypi-a-${{ github.run_id }}
-          path: ${{ runner.temp }}/jobctrl-pypi-a
-          if-no-files-found: error
-          retention-days: 14
-
-  pypi-build-b:
-    name: Build PyPI distributions on independent runner B
-    needs: pypi-resolve
-    runs-on: ubuntu-24.04
-    permissions:
-      contents: read
-    env:
-      RELEASE_TAG: ${{ inputs.release_tag }}
-      RELEASE_REF: ${{ needs.pypi-resolve.outputs.source_commit }}
-      SOURCE_DATE_EPOCH: ${{ needs.pypi-resolve.outputs.source_date_epoch }}
-    steps:
-      - name: Check out the exact audited source
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-        with:
-          ref: ${{ needs.pypi-resolve.outputs.source_commit }}
-          fetch-depth: 0
-          persist-credentials: false
-
-      - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
-        with:
-          python-version: "3.12.13"
-
-      - name: Set up pinned uv
-        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
-        with:
-          version: 0.11.7
-
-      - name: Reassert audited refs before dependency execution
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          test "$(git rev-parse HEAD)" = "$RELEASE_REF"
-          test "$(gh api "repos/$GITHUB_REPOSITORY/commits/main" --jq '.sha')" = "$RELEASE_REF"
-          test "$(gh api "repos/$GITHUB_REPOSITORY/commits/$RELEASE_TAG" --jq '.sha')" = "$RELEASE_REF"
-
-      - name: Set up only the exact locked release-build dependencies
-        run: uv --project workers/automation sync --python 3.12.13 --locked --no-default-groups --only-group release-build --no-install-project
-
-      - name: Build exact fixed-epoch PyPI distributions without isolation
-        run: |
-          set -euo pipefail
-          rm -rf workers/automation/dist
-          uv --project workers/automation run --python 3.12.13 --no-sync python -m build --no-isolation workers/automation
-
-      - name: Scan source and built distributions
-        run: python3 scripts/release_check.py --strict-prompt --release-tag "$RELEASE_TAG"
-
-      - name: Stage exactly one wheel and one source distribution
-        run: |
-          set -euo pipefail
-          shopt -s nullglob
-          artifact_root="$RUNNER_TEMP/jobctrl-pypi-b/packages"
-          mkdir -p "$artifact_root"
-          wheels=(workers/automation/dist/*.whl)
-          sdists=(workers/automation/dist/*.tar.gz)
-          test "${#wheels[@]}" = 1
-          test "${#sdists[@]}" = 1
-          install -m 0644 "${wheels[0]}" "${sdists[0]}" "$artifact_root/"
-
-      - name: Upload only build B package bytes
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: jobctrl-pypi-b-${{ github.run_id }}
-          path: ${{ runner.temp }}/jobctrl-pypi-b
-          if-no-files-found: error
-          retention-days: 14
-
-  pypi-compare:
-    name: Compare and seal independent PyPI builds
-    needs: [pypi-resolve, pypi-build-a, pypi-build-b]
-    runs-on: ubuntu-24.04
-    permissions:
-      actions: read
-      contents: read
-    steps:
-      - name: Download build A bytes
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
-        with:
-          name: jobctrl-pypi-a-${{ github.run_id }}
-          path: ${{ runner.temp }}/pypi-a
-
-      - name: Download build B bytes
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
-        with:
-          name: jobctrl-pypi-b-${{ github.run_id }}
-          path: ${{ runner.temp }}/pypi-b
-
-      - name: Require exact byte-identical wheel and source archive
-        run: |
-          set -euo pipefail
-          a="$RUNNER_TEMP/pypi-a/packages"
-          b="$RUNNER_TEMP/pypi-b/packages"
-          for root in "$a" "$b"; do
-            test -d "$root" && test ! -L "$root"
-            test -z "$(find "$root" -mindepth 1 ! -type f -print)"
-            test "$(find "$root" -mindepth 1 -maxdepth 1 -type f | wc -l | tr -d ' ')" = 2
-            test "$(find "$root" -mindepth 1 -maxdepth 1 -type f -name '*.whl' | wc -l | tr -d ' ')" = 1
-            test "$(find "$root" -mindepth 1 -maxdepth 1 -type f -name '*.tar.gz' | wc -l | tr -d ' ')" = 1
-          done
-          find "$a" -mindepth 1 -maxdepth 1 -type f -exec basename {} \; | sort > "$RUNNER_TEMP/names-a"
-          find "$b" -mindepth 1 -maxdepth 1 -type f -exec basename {} \; | sort > "$RUNNER_TEMP/names-b"
-          cmp "$RUNNER_TEMP/names-a" "$RUNNER_TEMP/names-b"
-          sealed="$RUNNER_TEMP/jobctrl-pypi-sealed"
-          mkdir -p "$sealed/packages"
-          while IFS= read -r name; do
-            [[ "$name" != */* && "$name" != .* ]]
-            cmp "$a/$name" "$b/$name"
-            install -m 0644 "$a/$name" "$sealed/packages/$name"
-          done < "$RUNNER_TEMP/names-a"
           (
-            cd "$sealed"
+            cd "$RUNNER_TEMP/jobctrl-pypi-dists"
             shasum -a 256 packages/* > SHA256SUMS
           )
 
-      - name: Upload only compare-sealed PyPI bytes
+      - name: Upload only built package bytes
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: jobctrl-pypi-sealed-${{ github.run_id }}
-          path: ${{ runner.temp }}/jobctrl-pypi-sealed
+          name: jobctrl-pypi-distributions-${{ github.run_id }}
+          path: ${{ runner.temp }}/jobctrl-pypi-dists
           if-no-files-found: error
           retention-days: 14
 
   publish-pypi:
-    name: Publish only compare-sealed packages with PyPI OIDC
-    needs: [pypi-resolve, pypi-compare]
+    name: Publish verified packages with PyPI OIDC
+    needs: [pypi-resolve, pypi-build]
     runs-on: ubuntu-24.04
     environment: pypi
     permissions:
@@ -1526,13 +1256,13 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - name: Download only compare-sealed distributions
+      - name: Download only built distributions
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
-          name: jobctrl-pypi-sealed-${{ github.run_id }}
+          name: jobctrl-pypi-distributions-${{ github.run_id }}
           path: ${{ runner.temp }}/jobctrl-pypi-dists
 
-      - name: Reassert refs and verify the compare-authored closure
+      - name: Reassert refs and verify the built closure
         env:
           RELEASE_TAG: ${{ inputs.release_tag }}
           GH_TOKEN: ${{ github.token }}
@@ -1556,7 +1286,7 @@ jobs:
             shasum -a 256 -c SHA256SUMS
           )
 
-      - name: Publish compare-sealed distributions to PyPI
+      - name: Publish verified distributions to PyPI
         uses: pypa/gh-action-pypi-publish@6733eb7d741f0b11ec6a39b58540dab7590f9b7d # v1.14.0
         with:
           packages-dir: ${{ runner.temp }}/jobctrl-pypi-dists/packages

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jobctrl/api",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jobctrl/extension",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/extension/public/manifest.json
+++ b/apps/extension/public/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "JobCtrl",
   "description": "Save job postings from the browser into the local JobCtrl app.",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "action": {
     "default_popup": "popup.html"
   },

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jobctrl/web",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/docs/publish-checklist.md
+++ b/docs/publish-checklist.md
@@ -258,18 +258,21 @@ especially §§11–14. This is a release precondition, not permission to publis
   plus its QA/deploy evidence, and every protected release environment in 9.4a
   is configured. The PyPI Trusted Publisher is already configured; verify its
   mapping rather than creating a second publisher or using a PyPI API token.
-- **Recovery note.** Preserve the failed `v2.0.0` tag at its original commit as
-  audit evidence. Its release workflow stopped before signing or publication
-  because the signing runner requested an unavailable Python build. Do not
-  move, delete, or dispatch that tag again.
+- **Recovery note.** Preserve the failed `v2.0.0` and `v2.0.1` tags at their
+  original commits as audit evidence. `v2.0.0` stopped before signing because
+  the signing runner requested an unavailable Python build. `v2.0.1` completed
+  its builds, signing, Apple notarization, stapling, and audit packaging, then
+  stopped before GitHub draft creation or R2 upload because a checkout-free
+  publication job did not bind GitHub CLI to the repository. Do not move,
+  delete, or dispatch either tag again.
 - **Action.** Fetch `origin/main` and tags, verify that the audited local commit
   and `origin/main` resolve to the same SHA, then create and push the exact
-  `v2.0.1` tag on that commit. Verify the remote tag and `main` still resolve to
+  `v2.0.2` tag on that commit. Verify the remote tag and `main` still resolve to
   that SHA before dispatch. Dispatch `Release distribution` with the workflow
-  ref `v2.0.1` and these first-release inputs:
+  ref `v2.0.2` and these first-release inputs:
 
   ```text
-  release_tag=v2.0.1
+  release_tag=v2.0.2
   channel=stable
   sequence=1
   minimum_safe_sequence=1
@@ -281,7 +284,7 @@ especially §§11–14. This is a release precondition, not permission to publis
   returns 404; it is the workflow's explicit conditional-create precondition.
   After immutable GitHub publication, the credential-free `pypi-resolve` job
   verifies the exact ref, release attestation, audit evidence, and public trust
-  before the two independent PyPI builders compare and seal the distributions.
+  before the single clean PyPI builder produces checksum-bound distributions.
   The `pypi` job then publishes only those unchanged bytes through OIDC. Verify
   the PyPI package and immutable GitHub Release after the workflow succeeds.
 - **Rollback.** Preserve the immutable Release and tag as audit evidence. Yank
@@ -366,7 +369,7 @@ Phase 7 and its Definition of Done.
   `renderPinnedInstallScript` regression fix. Its contract must replace an
   existing release's URL, SHA-256, and version pins with the next release's
   values, not only replace empty pins; its regression coverage must prove a
-  `v2.0.1` render cannot retain `v2.0.0` pins. Do not use a manually edited
+  `v2.0.2` render cannot retain `v2.0.1` pins. Do not use a manually edited
   installer as a workaround.
 - **Action.** Run and record the plan's published-artifact acceptance matrix:
   clean Apple-silicon macOS installs through both curl and Homebrew; no source
@@ -380,7 +383,7 @@ Phase 7 and its Definition of Done.
 - **Mandatory canonical-installer cutover.** Treat the immutable signed release
   and the public installer deployment as two linked but different records:
 
-  1. Record the immutable `v2.0.1` tag/release SHA and tree as **R**. Retrieve
+  1. Record the immutable `v2.0.2` tag/release SHA and tree as **R**. Retrieve
      that release's immutable pinned `install.sh` and `SHA256SUMS`, verify
      `install.sh` against its published SHA-256, and retain the verified asset
      URL and checksum with R. Do not reconstruct or edit the retrieved script.
@@ -536,9 +539,9 @@ Perform the following in order and stop at the first failed gate:
    after the exact-tree local gate passes.
 2. Rerun the standard hosted workflows on the recorded SHA and require green
    runs with executed steps.
-3. On that final validated `main` SHA, create and push `v2.0.1`, verify the
+3. On that final validated `main` SHA, create and push `v2.0.2`, verify the
    remote tag and `origin/main` resolve to that same SHA, then dispatch `Release
-   distribution` with `--ref v2.0.1` and the six recorded first-release inputs
+   distribution` with `--ref v2.0.2` and the six recorded first-release inputs
    in 9.4. Complete the signed release, channel-pointer promotion, PyPI
    publication, Homebrew formula sync, and immutable release evidence as R.
 4. Complete the separate post-release installer/docs PR in 9.6, merge it, and
@@ -597,7 +600,7 @@ rollback evidence, and publish corrections where a public claim proved wrong.
 | 9.1 Visibility flip | Owner | Run the exact-tree local gate, make the repository public, then rerun every standard hosted gate with real executed steps. |
 | 9.2 Docs-site verification | Owner | Docs are already public and deploy is enabled; dispatch at the gated `main` SHA and record the public deployment proof. |
 | 9.3 Rename redirect | Owner | Verify old-URL redirects after the flip and repair any stale repository links. |
-| 9.4 Release and PyPI | Owner | Preserve the failed `v2.0.0` tag, create `v2.0.1` on audited `main`, then dispatch with the recorded first-release inputs and verify the signed release. |
+| 9.4 Release and PyPI | Owner | Preserve the failed `v2.0.0` and `v2.0.1` tags, create `v2.0.2` on audited `main`, then dispatch with the recorded first-release inputs and verify the signed release. |
 | 9.5 Homebrew tap | Signed workflow | Replace the legacy formula only with the verified signed render after release-origin smoke passes. |
 | 9.6 Installer and artifact acceptance | Owner | Verify immutable `install.sh` from R, land matching `scripts/get` and `docs/public/install.sh` in a separate post-release PR, validate/deploy D, then run public curl/Homebrew smoke. |
 | 9.7 Public live demo | Owner | The demo is already public and deploy is enabled; verify the audited deployment externally and record its release evidence. |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jobctrl",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "private": true,
   "description": "AI-powered end-to-end job application pipeline",
   "type": "module",

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jobctrl/api-client",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jobctrl/contracts",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/domain-types/package.json
+++ b/packages/domain-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jobctrl/domain-types",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jobctrl/tsconfig",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "private": true,
   "type": "module",
   "exports": {

--- a/packaging/distribution/README.md
+++ b/packaging/distribution/README.md
@@ -111,11 +111,13 @@ Stable artifacts require:
 
 ## P6 release transport and recovery
 
-The owner-only `release-distribution.yml` path builds the unsigned candidate on
-two independent macOS runners and byte-compares their data on a third runner
-before any signing credentials are available. Tracked, checksum-bound bundles
-are the only JobCtrl authority code executed by the comparison and signing
-jobs. It must be dispatched from `refs/tags/<release_tag>`, with the workflow
+The owner-only `release-distribution.yml` path builds the unsigned candidate
+once on a clean macOS runner. A fresh protected signing runner safely extracts
+the checksum-bound handoff and independently verifies its manifest, payload,
+archive, native channel, and embedded public key before any signing credential
+is used. Tracked, checksum-bound bundles are the only JobCtrl authority code
+executed by that verification and signing job. It must be dispatched from
+`refs/tags/<release_tag>`, with the workflow
 SHA equal to that audited tag's current-main commit; every release environment
 admits protected `v*` tags and no branches. The path separates
 `release-signing` (the Ed25519 private key, Developer
@@ -156,11 +158,11 @@ Stable PyPI publication is the last lane of the same workflow. A clean gate
 first checks out the exact immutable-release source, checksum-verifies the
 tracked finalizer bundle and its third-party notice, safely extracts the signed
 release audit, and verifies the candidate with the protected Ed25519 key and
-key ID before any project dependencies run. Two independent builders then
-install only the locked `release-build` group under Python 3.12.13, build
-fixed-epoch wheel and source archives, and hand only package bytes to a fresh
-byte-comparison job. The minimal OIDC publisher consumes only that
-compare-sealed artifact.
+key ID before any project dependencies run. One clean builder then installs
+only the locked `release-build` group under Python 3.12.13, builds the wheel and
+source archive, and hands only their checksum-bound bytes to the minimal OIDC
+publisher. The publisher reasserts the immutable tag and release before it
+uploads those unchanged package bytes.
 
 Local artifacts remain explicitly unsigned and cannot be promoted to the stable
 channel. Prerelease artifacts use the same release manifest key, Developer ID

--- a/scripts/distribution-homebrew.render.bundle.mjs
+++ b/scripts/distribution-homebrew.render.bundle.mjs
@@ -12708,7 +12708,7 @@ var FINAL_RELEASE_ASSETS = [
   "audit/notarization.json",
   "audit/notary-log.json",
   "audit/publication-status.json",
-  "audit/pre-sign-comparison.json",
+  "audit/pre-sign-verification.json",
   "audit/size-report.json"
 ];
 function domainMessage(domain, raw) {
@@ -13120,40 +13120,6 @@ async function verifyPreparedCandidate({ preparedDirectory, channel, publicKeyBa
     nativeBinding
   };
 }
-async function comparePreparedBuilds(firstDirectory, secondDirectory, { channel, publicKeyBase64, root = REPO_ROOT2, runner = defaultCommandRunner } = {}) {
-  const [first, second] = await Promise.all([
-    verifyPreparedCandidate({ preparedDirectory: firstDirectory, channel, publicKeyBase64, root, runner }),
-    verifyPreparedCandidate({ preparedDirectory: secondDirectory, channel, publicKeyBase64, root, runner })
-  ]);
-  const fields = [
-    "buildId",
-    "appVersion",
-    "sourceDateEpoch",
-    "archiveSha256",
-    "manifestSha256",
-    "compressedBytes",
-    "installedBytes",
-    "nativeLauncherReleaseChannel",
-    "nativeLauncherReleaseTrustKeySha256"
-  ];
-  const mismatches = fields.filter((field) => first[field] !== second[field]);
-  invariant4(mismatches.length === 0, `unsigned pre-sign builds differ: ${mismatches.join(", ")}`);
-  return {
-    schemaVersion: 1,
-    status: "identical-unsigned-pre-sign-builds",
-    comparedFields: fields,
-    buildId: first.buildId,
-    appVersion: first.appVersion,
-    sourceDateEpoch: first.sourceDateEpoch,
-    archiveSha256: first.archiveSha256,
-    manifestSha256: first.manifestSha256,
-    compressedBytes: first.compressedBytes,
-    installedBytes: first.installedBytes,
-    nativeLauncherReleaseChannel: first.nativeLauncherReleaseChannel,
-    nativeLauncherReleaseTrustKeySha256: first.nativeLauncherReleaseTrustKeySha256,
-    note: "Signed and stapled ZIP bytes are intentionally not compared for deterministic equality."
-  };
-}
 async function verifyPreparedNativeBinding({ preparedDirectory, channel, publicKeyBase64, runner = defaultCommandRunner }) {
   invariant4(channel === "stable" || channel === "prerelease", "prepared native binding requires a network channel");
   requireNetworkReleasePublicKey(publicKeyBase64, "prepared native binding");
@@ -13173,8 +13139,8 @@ async function verifyPreparedNativeBinding({ preparedDirectory, channel, publicK
   }
   return { binaries, channel, publicKeySha256: prepared.nativeLauncherReleaseTrustKeySha256 };
 }
-function assertPreSignComparisonMatches(prepared, comparison) {
-  invariant4(comparison?.status === "identical-unsigned-pre-sign-builds", "a passing unsigned pre-sign build comparison is required before signing");
+function assertPreSignVerificationMatches(prepared, verification) {
+  invariant4(verification?.status === "verified-unsigned-pre-sign-candidate", "a passing unsigned pre-sign verification is required before signing");
   const fields = [
     "buildId",
     "archiveSha256",
@@ -13184,7 +13150,7 @@ function assertPreSignComparisonMatches(prepared, comparison) {
     "nativeLauncherReleaseChannel",
     "nativeLauncherReleaseTrustKeySha256"
   ];
-  for (const field of fields) invariant4(comparison[field] === prepared[field], `pre-sign comparison does not bind prepared ${field}`);
+  for (const field of fields) invariant4(verification[field] === prepared[field], `pre-sign verification does not bind prepared ${field}`);
   return true;
 }
 function networkDescriptor({ channel, sequence, minimumSafeSequence, revokedBuildIds = [], buildId, appVersion, sourceCommit, archiveUrl, archiveSha256, archiveSizeBytes, manifestSha256 }) {
@@ -13392,7 +13358,7 @@ async function finalizeNetworkRelease({
   notaryProfile,
   sourceDateEpoch,
   sourceCommit,
-  preSignComparison,
+  preSignVerification,
   runner = defaultCommandRunner,
   root = REPO_ROOT2
 }) {
@@ -13410,11 +13376,11 @@ async function finalizeNetworkRelease({
   });
   const prepared = JSON.parse(await readFile4(path4.join(preparedDirectory, "build-result.json"), "utf8"));
   invariant4(prepared.releaseChannel === "local" && prepared.nativeLauncherReleaseChannel === channel, "prepared build is not a matching unsigned pre-sign network build");
-  assertPreSignComparisonMatches(verifiedPrepared, preSignComparison);
+  assertPreSignVerificationMatches(verifiedPrepared, preSignVerification);
   const nativeBinding = verifiedPrepared.nativeBinding;
   const payloadRoot = path4.join(preparedDirectory, "payload");
   const preparedManifest = JSON.parse(await readFile4(path4.join(payloadRoot, "manifest.json"), "utf8"));
-  invariant4(preparedManifest.sourceDateEpoch === sourceDateEpoch, "finalization SOURCE_DATE_EPOCH must match the compared pre-sign build");
+  invariant4(preparedManifest.sourceDateEpoch === sourceDateEpoch, "finalization SOURCE_DATE_EPOCH must match the verified pre-sign build");
   const archiveFileName = `jobctrl-${preparedManifest.appVersion}-darwin-arm64.zip`;
   const urls = canonicalReleaseUrls(channel, archiveFileName, prepared.buildId);
   const notaryArchive = path4.join(preparedDirectory, `notary-${archiveFileName}`);
@@ -13482,7 +13448,7 @@ async function finalizeNetworkRelease({
     copyFile2(path4.join(preparedDirectory, "size-report.json"), path4.join(releaseDirectory, "audit", "size-report.json")),
     writeFile3(path4.join(releaseDirectory, "audit", "notarization.json"), notarizationEvidenceRaw, { mode: 420 }),
     writeFile3(path4.join(releaseDirectory, "audit", "notary-log.json"), notarization.logRaw, { mode: 420 }),
-    writeFile3(path4.join(releaseDirectory, "audit", "pre-sign-comparison.json"), canonicalJson2(preSignComparison), { mode: 420 })
+    writeFile3(path4.join(releaseDirectory, "audit", "pre-sign-verification.json"), canonicalJson2(preSignVerification), { mode: 420 })
   ]);
   await copyReleaseMetadata(payloadRoot, path4.join(releaseDirectory, "audit"));
   const channelPointer = createReleaseChannelPointer({
@@ -13513,7 +13479,7 @@ async function finalizeNetworkRelease({
     manifest: { sha256: sha256Bytes(Buffer.from(manifestRaw, "utf8")), keyId: contracts.signingPolicy.manifestSigning.keyId },
     descriptor: { sha256: sha256Bytes(Buffer.from(descriptorRaw, "utf8")), keyId: contracts.signingPolicy.manifestSigning.keyId },
     channelPointer: { sha256: sha256Bytes(Buffer.from(channelPointerRaw, "utf8")), url: urls.immutableChannelPointerUrl },
-    signing: { codeSigning: "Developer ID Application", notarization: "nested-apps-stapled", unsignedBuildComparisonRequired: true, nativeBinding: publicNativeBinding }
+    signing: { codeSigning: "Developer ID Application", notarization: "nested-apps-stapled", independentPreSignVerificationRequired: true, nativeBinding: publicNativeBinding }
   };
   const installScript = renderPinnedInstallScript({
     templateRaw: await readFile4(path4.join(root, "scripts", "get"), "utf8"),
@@ -13813,16 +13779,6 @@ async function main3(argv = process3.argv.slice(2)) {
     process3.stdout.write(canonicalJson2({ status: "prepared", buildId: result.buildId, archiveSha256: result.archiveSha256, manifestSha256: result.manifestSha256, nativeLauncherReleaseChannel: result.nativeLauncherReleaseChannel, nativeLauncherReleaseTrustKeySha256: result.nativeLauncherReleaseTrustKeySha256 }));
     return;
   }
-  if (command === "compare") {
-    requireOptions(options, ["first", "second", "channel", "public-key", "output"], command);
-    const comparison = await comparePreparedBuilds(path4.resolve(options.first), path4.resolve(options.second), {
-      channel: options.channel,
-      publicKeyBase64: options["public-key"]
-    });
-    await writeFile3(path4.resolve(options.output), canonicalJson2(comparison), { mode: 420 });
-    process3.stdout.write(canonicalJson2(comparison));
-    return;
-  }
   if (command === "verify-prepared") {
     requireOptions(options, ["prepared", "channel", "public-key"], command);
     const verification = await verifyPreparedCandidate({
@@ -13834,8 +13790,8 @@ async function main3(argv = process3.argv.slice(2)) {
     return;
   }
   if (command === "finalize") {
-    requireOptions(options, ["prepared", "comparison", "output", "channel", "sequence", "minimum-safe-sequence", "revoked-build-ids", "source-date-epoch", "source-commit"], command);
-    const comparison = JSON.parse(await readFile4(path4.resolve(options.comparison), "utf8"));
+    requireOptions(options, ["prepared", "verification", "output", "channel", "sequence", "minimum-safe-sequence", "revoked-build-ids", "source-date-epoch", "source-commit"], command);
+    const verification = JSON.parse(await readFile4(path4.resolve(options.verification), "utf8"));
     const result = await finalizeNetworkRelease({
       preparedDirectory: path4.resolve(options.prepared),
       releaseDirectory: path4.resolve(options.output),
@@ -13845,7 +13801,7 @@ async function main3(argv = process3.argv.slice(2)) {
       revokedBuildIds: JSON.parse(options["revoked-build-ids"]),
       sourceDateEpoch: parseCanonicalIntegerOption(options["source-date-epoch"], "source-date-epoch"),
       sourceCommit: options["source-commit"],
-      preSignComparison: comparison,
+      preSignVerification: verification,
       signingKeyBase64: process3.env.JOBCTRL_RELEASE_SIGNING_KEY ?? "",
       appleIdentity: process3.env.JOBCTRL_APPLE_SIGNING_IDENTITY ?? "",
       notaryProfile: process3.env.JOBCTRL_APPLE_NOTARY_PROFILE ?? ""
@@ -13899,7 +13855,7 @@ async function main3(argv = process3.argv.slice(2)) {
     })));
     return;
   }
-  throw new Error("usage: distribution-release.mjs inspect|validate-pointer|prepare|compare|verify-prepared|finalize|smoke|record-smoke|pointer|verify-pypi-gate");
+  throw new Error("usage: distribution-release.mjs inspect|validate-pointer|prepare|verify-prepared|finalize|smoke|record-smoke|pointer|verify-pypi-gate");
 }
 var invokedPath3 = process3.argv[1] ? pathToFileURL3(path4.resolve(process3.argv[1])).href : "";
 if (import.meta.url === invokedPath3 && path4.basename(process3.argv[1] ?? "") === "distribution-release.mjs") {

--- a/scripts/distribution-homebrew.render.bundle.mjs.sha256
+++ b/scripts/distribution-homebrew.render.bundle.mjs.sha256
@@ -1,2 +1,2 @@
-717f33a0df6c953649ec68a991b46ace72804025cf63f02ede81bdf3220167f2  distribution-homebrew.render.bundle.mjs
+f1549bf1f61e0bd6fc96f7f79b2677d59a168f5f2977457d465b6f57df69091c  distribution-homebrew.render.bundle.mjs
 9fccd02acf8b52c9a28b4e1956f791f8ec126230e2c336f534191f1bcb646ebd  distribution-release-authority-bundles.NOTICE.txt

--- a/scripts/distribution-manifest.test.mjs
+++ b/scripts/distribution-manifest.test.mjs
@@ -97,7 +97,7 @@ test("distribution contracts are complete and every version source resolves", as
   assert.equal(report.nodeLicenseEvidenceCount, 13);
   assert.equal(report.capabilityCount, 3);
   assert.deepEqual(report.platforms, ["darwin-arm64"]);
-  assert.equal(report.versions["jobctrl-launcher"], "2.0.1");
+  assert.equal(report.versions["jobctrl-launcher"], "2.0.2");
   assert.equal(report.versions["playwright-python"], "1.58.0");
   assert.equal(report.versions["font-geist"], "5.2.9");
   assert.equal(report.versions["font-jetbrains-mono"], "5.2.8");

--- a/scripts/distribution-release.finalizer.bundle.mjs
+++ b/scripts/distribution-release.finalizer.bundle.mjs
@@ -12683,7 +12683,7 @@ var FINAL_RELEASE_ASSETS = [
   "audit/notarization.json",
   "audit/notary-log.json",
   "audit/publication-status.json",
-  "audit/pre-sign-comparison.json",
+  "audit/pre-sign-verification.json",
   "audit/size-report.json"
 ];
 function domainMessage(domain, raw) {
@@ -13095,40 +13095,6 @@ async function verifyPreparedCandidate({ preparedDirectory, channel, publicKeyBa
     nativeBinding
   };
 }
-async function comparePreparedBuilds(firstDirectory, secondDirectory, { channel, publicKeyBase64, root = REPO_ROOT2, runner = defaultCommandRunner } = {}) {
-  const [first, second] = await Promise.all([
-    verifyPreparedCandidate({ preparedDirectory: firstDirectory, channel, publicKeyBase64, root, runner }),
-    verifyPreparedCandidate({ preparedDirectory: secondDirectory, channel, publicKeyBase64, root, runner })
-  ]);
-  const fields = [
-    "buildId",
-    "appVersion",
-    "sourceDateEpoch",
-    "archiveSha256",
-    "manifestSha256",
-    "compressedBytes",
-    "installedBytes",
-    "nativeLauncherReleaseChannel",
-    "nativeLauncherReleaseTrustKeySha256"
-  ];
-  const mismatches = fields.filter((field) => first[field] !== second[field]);
-  invariant4(mismatches.length === 0, `unsigned pre-sign builds differ: ${mismatches.join(", ")}`);
-  return {
-    schemaVersion: 1,
-    status: "identical-unsigned-pre-sign-builds",
-    comparedFields: fields,
-    buildId: first.buildId,
-    appVersion: first.appVersion,
-    sourceDateEpoch: first.sourceDateEpoch,
-    archiveSha256: first.archiveSha256,
-    manifestSha256: first.manifestSha256,
-    compressedBytes: first.compressedBytes,
-    installedBytes: first.installedBytes,
-    nativeLauncherReleaseChannel: first.nativeLauncherReleaseChannel,
-    nativeLauncherReleaseTrustKeySha256: first.nativeLauncherReleaseTrustKeySha256,
-    note: "Signed and stapled ZIP bytes are intentionally not compared for deterministic equality."
-  };
-}
 async function verifyPreparedNativeBinding({ preparedDirectory, channel, publicKeyBase64, runner = defaultCommandRunner }) {
   invariant4(channel === "stable" || channel === "prerelease", "prepared native binding requires a network channel");
   requireNetworkReleasePublicKey(publicKeyBase64, "prepared native binding");
@@ -13148,8 +13114,8 @@ async function verifyPreparedNativeBinding({ preparedDirectory, channel, publicK
   }
   return { binaries, channel, publicKeySha256: prepared.nativeLauncherReleaseTrustKeySha256 };
 }
-function assertPreSignComparisonMatches(prepared, comparison) {
-  invariant4(comparison?.status === "identical-unsigned-pre-sign-builds", "a passing unsigned pre-sign build comparison is required before signing");
+function assertPreSignVerificationMatches(prepared, verification) {
+  invariant4(verification?.status === "verified-unsigned-pre-sign-candidate", "a passing unsigned pre-sign verification is required before signing");
   const fields = [
     "buildId",
     "archiveSha256",
@@ -13159,7 +13125,7 @@ function assertPreSignComparisonMatches(prepared, comparison) {
     "nativeLauncherReleaseChannel",
     "nativeLauncherReleaseTrustKeySha256"
   ];
-  for (const field of fields) invariant4(comparison[field] === prepared[field], `pre-sign comparison does not bind prepared ${field}`);
+  for (const field of fields) invariant4(verification[field] === prepared[field], `pre-sign verification does not bind prepared ${field}`);
   return true;
 }
 function networkDescriptor({ channel, sequence, minimumSafeSequence, revokedBuildIds = [], buildId, appVersion, sourceCommit, archiveUrl, archiveSha256, archiveSizeBytes, manifestSha256 }) {
@@ -13367,7 +13333,7 @@ async function finalizeNetworkRelease({
   notaryProfile,
   sourceDateEpoch,
   sourceCommit,
-  preSignComparison,
+  preSignVerification,
   runner = defaultCommandRunner,
   root = REPO_ROOT2
 }) {
@@ -13385,11 +13351,11 @@ async function finalizeNetworkRelease({
   });
   const prepared = JSON.parse(await readFile4(path4.join(preparedDirectory, "build-result.json"), "utf8"));
   invariant4(prepared.releaseChannel === "local" && prepared.nativeLauncherReleaseChannel === channel, "prepared build is not a matching unsigned pre-sign network build");
-  assertPreSignComparisonMatches(verifiedPrepared, preSignComparison);
+  assertPreSignVerificationMatches(verifiedPrepared, preSignVerification);
   const nativeBinding = verifiedPrepared.nativeBinding;
   const payloadRoot = path4.join(preparedDirectory, "payload");
   const preparedManifest = JSON.parse(await readFile4(path4.join(payloadRoot, "manifest.json"), "utf8"));
-  invariant4(preparedManifest.sourceDateEpoch === sourceDateEpoch, "finalization SOURCE_DATE_EPOCH must match the compared pre-sign build");
+  invariant4(preparedManifest.sourceDateEpoch === sourceDateEpoch, "finalization SOURCE_DATE_EPOCH must match the verified pre-sign build");
   const archiveFileName = `jobctrl-${preparedManifest.appVersion}-darwin-arm64.zip`;
   const urls = canonicalReleaseUrls(channel, archiveFileName, prepared.buildId);
   const notaryArchive = path4.join(preparedDirectory, `notary-${archiveFileName}`);
@@ -13457,7 +13423,7 @@ async function finalizeNetworkRelease({
     copyFile2(path4.join(preparedDirectory, "size-report.json"), path4.join(releaseDirectory, "audit", "size-report.json")),
     writeFile3(path4.join(releaseDirectory, "audit", "notarization.json"), notarizationEvidenceRaw, { mode: 420 }),
     writeFile3(path4.join(releaseDirectory, "audit", "notary-log.json"), notarization.logRaw, { mode: 420 }),
-    writeFile3(path4.join(releaseDirectory, "audit", "pre-sign-comparison.json"), canonicalJson2(preSignComparison), { mode: 420 })
+    writeFile3(path4.join(releaseDirectory, "audit", "pre-sign-verification.json"), canonicalJson2(preSignVerification), { mode: 420 })
   ]);
   await copyReleaseMetadata(payloadRoot, path4.join(releaseDirectory, "audit"));
   const channelPointer = createReleaseChannelPointer({
@@ -13488,7 +13454,7 @@ async function finalizeNetworkRelease({
     manifest: { sha256: sha256Bytes(Buffer.from(manifestRaw, "utf8")), keyId: contracts.signingPolicy.manifestSigning.keyId },
     descriptor: { sha256: sha256Bytes(Buffer.from(descriptorRaw, "utf8")), keyId: contracts.signingPolicy.manifestSigning.keyId },
     channelPointer: { sha256: sha256Bytes(Buffer.from(channelPointerRaw, "utf8")), url: urls.immutableChannelPointerUrl },
-    signing: { codeSigning: "Developer ID Application", notarization: "nested-apps-stapled", unsignedBuildComparisonRequired: true, nativeBinding: publicNativeBinding }
+    signing: { codeSigning: "Developer ID Application", notarization: "nested-apps-stapled", independentPreSignVerificationRequired: true, nativeBinding: publicNativeBinding }
   };
   const installScript = renderPinnedInstallScript({
     templateRaw: await readFile4(path4.join(root, "scripts", "get"), "utf8"),
@@ -13788,16 +13754,6 @@ async function main3(argv = process3.argv.slice(2)) {
     process3.stdout.write(canonicalJson2({ status: "prepared", buildId: result.buildId, archiveSha256: result.archiveSha256, manifestSha256: result.manifestSha256, nativeLauncherReleaseChannel: result.nativeLauncherReleaseChannel, nativeLauncherReleaseTrustKeySha256: result.nativeLauncherReleaseTrustKeySha256 }));
     return;
   }
-  if (command === "compare") {
-    requireOptions(options, ["first", "second", "channel", "public-key", "output"], command);
-    const comparison = await comparePreparedBuilds(path4.resolve(options.first), path4.resolve(options.second), {
-      channel: options.channel,
-      publicKeyBase64: options["public-key"]
-    });
-    await writeFile3(path4.resolve(options.output), canonicalJson2(comparison), { mode: 420 });
-    process3.stdout.write(canonicalJson2(comparison));
-    return;
-  }
   if (command === "verify-prepared") {
     requireOptions(options, ["prepared", "channel", "public-key"], command);
     const verification = await verifyPreparedCandidate({
@@ -13809,8 +13765,8 @@ async function main3(argv = process3.argv.slice(2)) {
     return;
   }
   if (command === "finalize") {
-    requireOptions(options, ["prepared", "comparison", "output", "channel", "sequence", "minimum-safe-sequence", "revoked-build-ids", "source-date-epoch", "source-commit"], command);
-    const comparison = JSON.parse(await readFile4(path4.resolve(options.comparison), "utf8"));
+    requireOptions(options, ["prepared", "verification", "output", "channel", "sequence", "minimum-safe-sequence", "revoked-build-ids", "source-date-epoch", "source-commit"], command);
+    const verification = JSON.parse(await readFile4(path4.resolve(options.verification), "utf8"));
     const result = await finalizeNetworkRelease({
       preparedDirectory: path4.resolve(options.prepared),
       releaseDirectory: path4.resolve(options.output),
@@ -13820,7 +13776,7 @@ async function main3(argv = process3.argv.slice(2)) {
       revokedBuildIds: JSON.parse(options["revoked-build-ids"]),
       sourceDateEpoch: parseCanonicalIntegerOption(options["source-date-epoch"], "source-date-epoch"),
       sourceCommit: options["source-commit"],
-      preSignComparison: comparison,
+      preSignVerification: verification,
       signingKeyBase64: process3.env.JOBCTRL_RELEASE_SIGNING_KEY ?? "",
       appleIdentity: process3.env.JOBCTRL_APPLE_SIGNING_IDENTITY ?? "",
       notaryProfile: process3.env.JOBCTRL_APPLE_NOTARY_PROFILE ?? ""
@@ -13874,7 +13830,7 @@ async function main3(argv = process3.argv.slice(2)) {
     })));
     return;
   }
-  throw new Error("usage: distribution-release.mjs inspect|validate-pointer|prepare|compare|verify-prepared|finalize|smoke|record-smoke|pointer|verify-pypi-gate");
+  throw new Error("usage: distribution-release.mjs inspect|validate-pointer|prepare|verify-prepared|finalize|smoke|record-smoke|pointer|verify-pypi-gate");
 }
 var invokedPath3 = process3.argv[1] ? pathToFileURL3(path4.resolve(process3.argv[1])).href : "";
 if (import.meta.url === invokedPath3 && path4.basename(process3.argv[1] ?? "") === "distribution-release.mjs") {

--- a/scripts/distribution-release.finalizer.bundle.mjs.sha256
+++ b/scripts/distribution-release.finalizer.bundle.mjs.sha256
@@ -1,2 +1,2 @@
-17abb43a0a42f92e12a08de956dc379ffc205f9ccff70cfaac7c6808a0403dc7  distribution-release.finalizer.bundle.mjs
+26a7b838c5c66c0f854e5473df36e24448905eeae01cf8092c6a0f16b924d0e5  distribution-release.finalizer.bundle.mjs
 9fccd02acf8b52c9a28b4e1956f791f8ec126230e2c336f534191f1bcb646ebd  distribution-release-authority-bundles.NOTICE.txt

--- a/scripts/distribution-release.mjs
+++ b/scripts/distribution-release.mjs
@@ -307,7 +307,7 @@ const FINAL_RELEASE_ASSETS = [
   "audit/notarization.json",
   "audit/notary-log.json",
   "audit/publication-status.json",
-  "audit/pre-sign-comparison.json",
+  "audit/pre-sign-verification.json",
   "audit/size-report.json",
 ];
 
@@ -768,41 +768,6 @@ export async function verifyPreparedCandidate({ preparedDirectory, channel, publ
   };
 }
 
-export async function comparePreparedBuilds(firstDirectory, secondDirectory, { channel, publicKeyBase64, root = REPO_ROOT, runner = defaultCommandRunner } = {}) {
-  const [first, second] = await Promise.all([
-    verifyPreparedCandidate({ preparedDirectory: firstDirectory, channel, publicKeyBase64, root, runner }),
-    verifyPreparedCandidate({ preparedDirectory: secondDirectory, channel, publicKeyBase64, root, runner }),
-  ]);
-  const fields = [
-    "buildId",
-    "appVersion",
-    "sourceDateEpoch",
-    "archiveSha256",
-    "manifestSha256",
-    "compressedBytes",
-    "installedBytes",
-    "nativeLauncherReleaseChannel",
-    "nativeLauncherReleaseTrustKeySha256",
-  ];
-  const mismatches = fields.filter((field) => first[field] !== second[field]);
-  invariant(mismatches.length === 0, `unsigned pre-sign builds differ: ${mismatches.join(", ")}`);
-  return {
-    schemaVersion: 1,
-    status: "identical-unsigned-pre-sign-builds",
-    comparedFields: fields,
-    buildId: first.buildId,
-    appVersion: first.appVersion,
-    sourceDateEpoch: first.sourceDateEpoch,
-    archiveSha256: first.archiveSha256,
-    manifestSha256: first.manifestSha256,
-    compressedBytes: first.compressedBytes,
-    installedBytes: first.installedBytes,
-    nativeLauncherReleaseChannel: first.nativeLauncherReleaseChannel,
-    nativeLauncherReleaseTrustKeySha256: first.nativeLauncherReleaseTrustKeySha256,
-    note: "Signed and stapled ZIP bytes are intentionally not compared for deterministic equality.",
-  };
-}
-
 export async function verifyPreparedNativeBinding({ preparedDirectory, channel, publicKeyBase64, runner = defaultCommandRunner }) {
   invariant(channel === "stable" || channel === "prerelease", "prepared native binding requires a network channel");
   requireNetworkReleasePublicKey(publicKeyBase64, "prepared native binding");
@@ -823,8 +788,8 @@ export async function verifyPreparedNativeBinding({ preparedDirectory, channel, 
   return { binaries, channel, publicKeySha256: prepared.nativeLauncherReleaseTrustKeySha256 };
 }
 
-export function assertPreSignComparisonMatches(prepared, comparison) {
-  invariant(comparison?.status === "identical-unsigned-pre-sign-builds", "a passing unsigned pre-sign build comparison is required before signing");
+export function assertPreSignVerificationMatches(prepared, verification) {
+  invariant(verification?.status === "verified-unsigned-pre-sign-candidate", "a passing unsigned pre-sign verification is required before signing");
   const fields = [
     "buildId",
     "archiveSha256",
@@ -834,7 +799,7 @@ export function assertPreSignComparisonMatches(prepared, comparison) {
     "nativeLauncherReleaseChannel",
     "nativeLauncherReleaseTrustKeySha256",
   ];
-  for (const field of fields) invariant(comparison[field] === prepared[field], `pre-sign comparison does not bind prepared ${field}`);
+  for (const field of fields) invariant(verification[field] === prepared[field], `pre-sign verification does not bind prepared ${field}`);
   return true;
 }
 
@@ -1059,7 +1024,7 @@ export async function finalizeNetworkRelease({
   notaryProfile,
   sourceDateEpoch,
   sourceCommit,
-  preSignComparison,
+  preSignVerification,
   runner = defaultCommandRunner,
   root = REPO_ROOT,
 }) {
@@ -1077,11 +1042,11 @@ export async function finalizeNetworkRelease({
   });
   const prepared = JSON.parse(await readFile(path.join(preparedDirectory, "build-result.json"), "utf8"));
   invariant(prepared.releaseChannel === "local" && prepared.nativeLauncherReleaseChannel === channel, "prepared build is not a matching unsigned pre-sign network build");
-  assertPreSignComparisonMatches(verifiedPrepared, preSignComparison);
+  assertPreSignVerificationMatches(verifiedPrepared, preSignVerification);
   const nativeBinding = verifiedPrepared.nativeBinding;
   const payloadRoot = path.join(preparedDirectory, "payload");
   const preparedManifest = JSON.parse(await readFile(path.join(payloadRoot, "manifest.json"), "utf8"));
-  invariant(preparedManifest.sourceDateEpoch === sourceDateEpoch, "finalization SOURCE_DATE_EPOCH must match the compared pre-sign build");
+  invariant(preparedManifest.sourceDateEpoch === sourceDateEpoch, "finalization SOURCE_DATE_EPOCH must match the verified pre-sign build");
   const archiveFileName = `jobctrl-${preparedManifest.appVersion}-darwin-arm64.zip`;
   const urls = canonicalReleaseUrls(channel, archiveFileName, prepared.buildId);
   const notaryArchive = path.join(preparedDirectory, `notary-${archiveFileName}`);
@@ -1150,7 +1115,7 @@ export async function finalizeNetworkRelease({
     copyFile(path.join(preparedDirectory, "size-report.json"), path.join(releaseDirectory, "audit", "size-report.json")),
     writeFile(path.join(releaseDirectory, "audit", "notarization.json"), notarizationEvidenceRaw, { mode: 0o644 }),
     writeFile(path.join(releaseDirectory, "audit", "notary-log.json"), notarization.logRaw, { mode: 0o644 }),
-    writeFile(path.join(releaseDirectory, "audit", "pre-sign-comparison.json"), canonicalJson(preSignComparison), { mode: 0o644 }),
+    writeFile(path.join(releaseDirectory, "audit", "pre-sign-verification.json"), canonicalJson(preSignVerification), { mode: 0o644 }),
   ]);
   await copyReleaseMetadata(payloadRoot, path.join(releaseDirectory, "audit"));
   const channelPointer = createReleaseChannelPointer({
@@ -1181,7 +1146,7 @@ export async function finalizeNetworkRelease({
     manifest: { sha256: sha256Bytes(Buffer.from(manifestRaw, "utf8")), keyId: contracts.signingPolicy.manifestSigning.keyId },
     descriptor: { sha256: sha256Bytes(Buffer.from(descriptorRaw, "utf8")), keyId: contracts.signingPolicy.manifestSigning.keyId },
     channelPointer: { sha256: sha256Bytes(Buffer.from(channelPointerRaw, "utf8")), url: urls.immutableChannelPointerUrl },
-    signing: { codeSigning: "Developer ID Application", notarization: "nested-apps-stapled", unsignedBuildComparisonRequired: true, nativeBinding: publicNativeBinding },
+    signing: { codeSigning: "Developer ID Application", notarization: "nested-apps-stapled", independentPreSignVerificationRequired: true, nativeBinding: publicNativeBinding },
   };
   const installScript = renderPinnedInstallScript({
     templateRaw: await readFile(path.join(root, "scripts", "get"), "utf8"),
@@ -1210,13 +1175,6 @@ export async function finalizeNetworkRelease({
   await writeChecksumFile(releaseDirectory, (await releaseRegularFiles(releaseDirectory)).filter((file) => file !== "SHA256SUMS"));
   const inventory = await assertReleaseAssetInventory(releaseDirectory, { archiveFileName });
   return { archivePath: finalArchivePath, archiveFileName, descriptorRaw, descriptorSignature, channelPointer, manifestRaw, manifestSignature, releaseKeys, metadata, inventory };
-}
-
-export async function writePreSignComparison({ firstDirectory, secondDirectory, releaseDirectory, channel, publicKeyBase64, root = REPO_ROOT, runner = defaultCommandRunner }) {
-  const comparison = await comparePreparedBuilds(firstDirectory, secondDirectory, { channel, publicKeyBase64, root, runner });
-  await mkdir(path.join(releaseDirectory, "audit"), { recursive: true, mode: 0o755 });
-  await writeFile(path.join(releaseDirectory, "audit", "pre-sign-comparison.json"), canonicalJson(comparison), { mode: 0o644 });
-  return comparison;
 }
 
 export function publishedCandidateSmokePlan({ descriptorUrl, installerPath, outputHome }) {
@@ -1509,16 +1467,6 @@ export async function main(argv = process.argv.slice(2)) {
     process.stdout.write(canonicalJson({ status: "prepared", buildId: result.buildId, archiveSha256: result.archiveSha256, manifestSha256: result.manifestSha256, nativeLauncherReleaseChannel: result.nativeLauncherReleaseChannel, nativeLauncherReleaseTrustKeySha256: result.nativeLauncherReleaseTrustKeySha256 }));
     return;
   }
-  if (command === "compare") {
-    requireOptions(options, ["first", "second", "channel", "public-key", "output"], command);
-    const comparison = await comparePreparedBuilds(path.resolve(options.first), path.resolve(options.second), {
-      channel: options.channel,
-      publicKeyBase64: options["public-key"],
-    });
-    await writeFile(path.resolve(options.output), canonicalJson(comparison), { mode: 0o644 });
-    process.stdout.write(canonicalJson(comparison));
-    return;
-  }
   if (command === "verify-prepared") {
     requireOptions(options, ["prepared", "channel", "public-key"], command);
     const verification = await verifyPreparedCandidate({
@@ -1530,8 +1478,8 @@ export async function main(argv = process.argv.slice(2)) {
     return;
   }
   if (command === "finalize") {
-    requireOptions(options, ["prepared", "comparison", "output", "channel", "sequence", "minimum-safe-sequence", "revoked-build-ids", "source-date-epoch", "source-commit"], command);
-    const comparison = JSON.parse(await readFile(path.resolve(options.comparison), "utf8"));
+    requireOptions(options, ["prepared", "verification", "output", "channel", "sequence", "minimum-safe-sequence", "revoked-build-ids", "source-date-epoch", "source-commit"], command);
+    const verification = JSON.parse(await readFile(path.resolve(options.verification), "utf8"));
     const result = await finalizeNetworkRelease({
       preparedDirectory: path.resolve(options.prepared),
       releaseDirectory: path.resolve(options.output),
@@ -1541,7 +1489,7 @@ export async function main(argv = process.argv.slice(2)) {
       revokedBuildIds: JSON.parse(options["revoked-build-ids"]),
       sourceDateEpoch: parseCanonicalIntegerOption(options["source-date-epoch"], "source-date-epoch"),
       sourceCommit: options["source-commit"],
-      preSignComparison: comparison,
+      preSignVerification: verification,
       signingKeyBase64: process.env.JOBCTRL_RELEASE_SIGNING_KEY ?? "",
       appleIdentity: process.env.JOBCTRL_APPLE_SIGNING_IDENTITY ?? "",
       notaryProfile: process.env.JOBCTRL_APPLE_NOTARY_PROFILE ?? "",
@@ -1595,7 +1543,7 @@ export async function main(argv = process.argv.slice(2)) {
     })));
     return;
   }
-  throw new Error("usage: distribution-release.mjs inspect|validate-pointer|prepare|compare|verify-prepared|finalize|smoke|record-smoke|pointer|verify-pypi-gate");
+  throw new Error("usage: distribution-release.mjs inspect|validate-pointer|prepare|verify-prepared|finalize|smoke|record-smoke|pointer|verify-pypi-gate");
 }
 
 const invokedPath = process.argv[1] ? pathToFileURL(path.resolve(process.argv[1])).href : "";

--- a/scripts/distribution-release.test.mjs
+++ b/scripts/distribution-release.test.mjs
@@ -14,12 +14,11 @@ import {
   chromiumEntitlementsForTarget,
   assertCandidateIdentity,
   assertPublishedVersion,
-  assertPreSignComparisonMatches,
+  assertPreSignVerificationMatches,
   assertRunningStatus,
   assertStoppedStatus,
   candidateIdentityFromDescriptor,
   classifyAppleSigningTargets,
-  comparePreparedBuilds,
   createReleaseChannelPointer,
   createAppleSigningPlan,
   notarizeAndStaplePayload,
@@ -36,6 +35,7 @@ import {
   validateReleaseDescriptor,
   validateReleaseChannelPointer,
   validateReleaseDescriptorSignature,
+  verifyPreparedCandidate,
 } from "./distribution-release.mjs";
 
 const sha256 = (value) => createHash("sha256").update(value).digest("hex");
@@ -61,6 +61,15 @@ test("release signing accepts standard canonical Ed25519 PKCS#8 DER", () => {
   const { privateKey: ecPrivateKey } = generateKeyPairSync("ec", { namedCurve: "prime256v1" });
   const ecPrivateKeyBase64 = Buffer.from(ecPrivateKey.export({ format: "der", type: "pkcs8" })).toString("base64");
   assert.throws(() => privateKeyFromBase64(ecPrivateKeyBase64), /release signing key must be Ed25519/);
+});
+
+test("public release metadata describes the independent pre-sign verification gate", async () => {
+  const source = await readFile(
+    path.join(process.cwd(), "scripts", "distribution-release.mjs"),
+    "utf8",
+  );
+  assert.match(source, /independentPreSignVerificationRequired: true/);
+  assert.doesNotMatch(source, /unsignedBuildComparisonRequired/);
 });
 
 test("tracked release-authority bundles are byte-reproducible with pinned esbuild", async (context) => {
@@ -154,12 +163,12 @@ test("tracked release-authority bundles dispatch exactly one intended CLI", asyn
 test("release CLI rejects non-canonical owner-supplied integers", async (context) => {
   const root = await mkdtemp(path.join(os.tmpdir(), "jobctrl-release-integers-"));
   context.after(async () => rm(root, { recursive: true, force: true }));
-  const comparison = path.join(root, "comparison.json");
-  await writeFile(comparison, "{}\n");
+  const verification = path.join(root, "verification.json");
+  await writeFile(verification, "{}\n");
   const args = (sequence, minimumSafeSequence, sourceDateEpoch) => [
     "finalize",
     "--prepared", path.join(root, "prepared"),
-    "--comparison", comparison,
+    "--verification", verification,
     "--output", path.join(root, "release"),
     "--channel", "stable",
     "--sequence", sequence,
@@ -289,10 +298,10 @@ test("local fixture release descriptor, signature, and curl contract bind one ZI
     minimumSafeSequence: 0,
     revokedBuildIds: [],
     buildId: "fixture-build-0001",
-    appVersion: "2.0.1",
+    appVersion: "2.0.2",
     platform: { id: "darwin-arm64", os: "darwin", arch: "arm64" },
     artifact: {
-      url: "file:///jobctrl-local-release/jobctrl-2.0.1-darwin-arm64.zip",
+      url: "file:///jobctrl-local-release/jobctrl-2.0.2-darwin-arm64.zip",
       sha256: build.archiveSha256,
       sizeBytes: build.compressedBytes,
       archiveType: "zip",
@@ -482,8 +491,8 @@ test("Apple verification codesigns every Mach-O and uses notarization verificati
   assert.equal(result.notarizationVerifiedStandaloneExecutables, 1);
 });
 
-test("pre-sign comparison binds release channel and compiled public-key digest", async (context) => {
-  const root = await mkdtemp(path.join(os.tmpdir(), "jobctrl-compare-"));
+test("pre-sign verification binds release channel and compiled public-key digest", async (context) => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "jobctrl-verify-"));
   context.after(async () => rm(root, { recursive: true, force: true }));
   const { privateKey } = generateKeyPairSync("ed25519");
   const publicKeyBase64 = releasePublicKeyBase64(privateKey);
@@ -510,27 +519,18 @@ test("pre-sign comparison binds release channel and compiled public-key digest",
     assert.equal(command, "/usr/bin/strings");
     return { stdout: `${publicKeyBase64}\nstable\n`, stderr: "" };
   };
-  const one = await writePreparedFixture("one", "fixture-build-0001");
-  const two = await writePreparedFixture("two", "fixture-build-0001");
-  const comparison = await comparePreparedBuilds(one, two, {
+  const prepared = await writePreparedFixture("candidate", "fixture-build-0001");
+  const verification = await verifyPreparedCandidate({
+    preparedDirectory: prepared,
     channel: "stable",
     publicKeyBase64,
     runner,
   });
-  assert.equal(comparison.status, "identical-unsigned-pre-sign-builds");
-  assert.equal(comparison.nativeLauncherReleaseTrustKeySha256, trustKeySha256);
-  await writePreparedFixture("two", "fixture-build-0002");
-  await assert.rejects(
-    comparePreparedBuilds(one, two, {
-      channel: "stable",
-      publicKeyBase64,
-      runner,
-    }),
-    /unsigned pre-sign builds differ:.*buildId/,
-  );
+  assert.equal(verification.status, "verified-unsigned-pre-sign-candidate");
+  assert.equal(verification.nativeLauncherReleaseTrustKeySha256, trustKeySha256);
 });
 
-test("finalization cannot reuse a passing pre-sign comparison for another build", () => {
+test("finalization cannot reuse a passing pre-sign verification for another build", () => {
   const prepared = {
     buildId: "fixture-build-0001",
     archiveSha256: "a".repeat(64),
@@ -540,9 +540,9 @@ test("finalization cannot reuse a passing pre-sign comparison for another build"
     nativeLauncherReleaseChannel: "stable",
     nativeLauncherReleaseTrustKeySha256: "c".repeat(64),
   };
-  const comparison = { schemaVersion: 1, status: "identical-unsigned-pre-sign-builds", ...prepared };
-  assert.doesNotThrow(() => assertPreSignComparisonMatches(prepared, comparison));
-  assert.throws(() => assertPreSignComparisonMatches(prepared, { ...comparison, buildId: "fixture-build-0002" }), /prepared buildId/);
+  const verification = { schemaVersion: 1, status: "verified-unsigned-pre-sign-candidate", ...prepared };
+  assert.doesNotThrow(() => assertPreSignVerificationMatches(prepared, verification));
+  assert.throws(() => assertPreSignVerificationMatches(prepared, { ...verification, buildId: "fixture-build-0002" }), /prepared buildId/);
 });
 
 test("published paths, installer pins, and smoke contract use canonical HTTPS assets and lifecycle commands", () => {
@@ -766,8 +766,11 @@ test("release workflows use protected manual signing, artifact handoff, candidat
     "runs-on: macos-15",
     "environment: release-signing",
     "environment: release-publication",
+    "GH_REPO: ${{ github.repository }}",
+    "Preflight checkout-free GitHub publication access",
+    "gh repo view \"$GH_REPO\" --json nameWithOwner",
     "distribution-release.mjs prepare",
-    "distribution-release.finalizer.bundle.mjs compare",
+    "distribution-release.finalizer.bundle.mjs verify-prepared",
     "distribution-release.finalizer.bundle.mjs finalize",
     "distribution-release.mjs smoke",
     "actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02",
@@ -786,6 +789,19 @@ test("release workflows use protected manual signing, artifact handoff, candidat
     "immutableDescriptorUrl",
     "brew audit --strict --formula \"$release/jobctrl.rb\"",
   ]) assert.ok(releaseWorkflow.includes(marker), `missing release workflow marker ${marker}`);
+  for (const removedJob of ["prepare-a", "prepare-b", "pypi-build-a", "pypi-build-b", "pypi-compare"]) {
+    assert.doesNotMatch(releaseWorkflow, new RegExp(`^  ${removedJob}:`, "m"));
+  }
+  assert.match(releaseWorkflow, /^  prepare:/m);
+  assert.match(releaseWorkflow, /^  pypi-build:/m);
+  const publicationPreflight = releaseWorkflow.slice(
+    releaseWorkflow.indexOf("  publication-preflight:"),
+    releaseWorkflow.indexOf("  prepare:"),
+  );
+  assert.match(publicationPreflight, /needs: resolve/);
+  assert.match(publicationPreflight, /gh release view "\$RELEASE_TAG"/);
+  assert.doesNotMatch(publicationPreflight, /actions\/checkout@/);
+  assert.match(releaseWorkflow, /needs: \[resolve, publication-preflight, prepare\]/);
   assert.doesNotMatch(releaseWorkflow, /JOBCTRL_RELEASE_UPLOAD_BASE_URL/);
   assert.doesNotMatch(homebrewWorkflow, /workflow_dispatch:/);
   assert.match(homebrewWorkflow, /actions\/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093/);
@@ -804,7 +820,7 @@ test("release workflows use protected manual signing, artifact handoff, candidat
   assert.match(releaseWorkflow, /filter="data"/);
   const pypiResolve = releaseWorkflow.slice(
     releaseWorkflow.indexOf("  pypi-resolve:"),
-    releaseWorkflow.indexOf("  pypi-build-a:"),
+    releaseWorkflow.indexOf("  pypi-build:"),
   );
   assert.doesNotMatch(pypiResolve, /(?:corepack|pnpm|npm|npx|uv|pip)\s/);
 });

--- a/scripts/release_check.py
+++ b/scripts/release_check.py
@@ -1040,6 +1040,7 @@ def _release_distribution_findings(root: Path) -> list[str]:
         return [f"{RELEASE_DISTRIBUTION_WORKFLOW_PATH}: missing P6 signed distribution workflow"]
     required_markers = {
         "workflow_dispatch:": "has no owner-controlled manual release path",
+        "GH_REPO: ${{ github.repository }}": "does not bind checkout-free GitHub CLI release operations to the audited repository",
         "group: release-distribution-${{ inputs.channel }}-darwin-arm64": "does not serialize release mutation by channel and platform",
         'test "$GITHUB_REF" = "refs/tags/$RELEASE_TAG"': "does not bind the workflow definition ref to the selected release tag",
         'test "$GITHUB_SHA" = "$head_sha"': "does not bind the workflow definition SHA to the audited release commit",
@@ -1054,9 +1055,8 @@ def _release_distribution_findings(root: Path) -> list[str]:
         "environment: release-publication": "does not isolate public-release side effects from signing credentials",
         "JOBCTRL_RELEASE_PUBLIC_KEY: ${{ vars.JOBCTRL_RELEASE_PUBLIC_KEY }}": "does not prepare against the protected public release key",
         "JOBCTRL_RELEASE_KEY_ID: ${{ vars.JOBCTRL_RELEASE_KEY_ID }}": "does not prepare against the protected release key ID",
-        "node scripts/distribution-release.mjs prepare": "does not build pre-sign candidates",
-        "node scripts/distribution-release.finalizer.bundle.mjs compare": "does not compare independent unsigned builds with checkout-rooted code",
-        "node scripts/distribution-release.finalizer.bundle.mjs verify-prepared": "does not reverify selected candidate bytes before signing credentials",
+        "node scripts/distribution-release.mjs prepare": "does not build the pre-sign candidate",
+        "node scripts/distribution-release.finalizer.bundle.mjs verify-prepared": "does not independently verify the selected candidate before signing credentials",
         "corepack pnpm exec esbuild scripts/distribution-release-finalizer-entry.mjs --bundle --platform=node --format=esm --target=node22": "does not reproduce the tracked audited finalizer",
         "distribution-release.finalizer.bundle.mjs.sha256": "does not bind the tracked audited finalizer and third-party notice",
         "distribution-homebrew.render.bundle.mjs.sha256": "does not bind the tracked audited Homebrew renderer and third-party notice",
@@ -1097,9 +1097,8 @@ def _release_distribution_findings(root: Path) -> list[str]:
     ]
     required_jobs = (
         "resolve",
-        "prepare-a",
-        "prepare-b",
-        "compare",
+        "publication-preflight",
+        "prepare",
         "sign",
         "package-signed-candidate",
         "publish-immutable",
@@ -1107,9 +1106,7 @@ def _release_distribution_findings(root: Path) -> list[str]:
         "promote-channel-pointer",
         "publish-github-release",
         "pypi-resolve",
-        "pypi-build-a",
-        "pypi-build-b",
-        "pypi-compare",
+        "pypi-build",
         "publish-pypi",
     )
     jobs: dict[str, str] = {}
@@ -1145,38 +1142,45 @@ def _release_distribution_findings(root: Path) -> list[str]:
                 f"{RELEASE_DISTRIBUTION_WORKFLOW_PATH}: resolve must prove the executing workflow comes from the audited release tag and commit"
             )
 
-    for job_name, artifact_name in (
-        ("prepare-a", "jobctrl-prepared-a-"),
-        ("prepare-b", "jobctrl-prepared-b-"),
-    ):
-        body = jobs.get(job_name)
-        if body is None:
-            continue
-        if "persist-credentials: false" not in body or artifact_name not in body:
-            findings.append(
-                f"{RELEASE_DISTRIBUTION_WORKFLOW_PATH}: {job_name} must independently build and upload only its candidate data"
-            )
-    compare = jobs.get("compare")
-    if compare is not None:
+    publication_preflight = jobs.get("publication-preflight")
+    if publication_preflight is not None:
         for marker in (
-            "needs: [resolve, prepare-a, prepare-b]",
-            "jobctrl-prepared-a-",
-            "jobctrl-prepared-b-",
-            "distribution-release.finalizer.bundle.mjs compare",
-            "COMPARE_SHA256SUMS",
+            "needs: resolve",
+            'gh repo view "$GH_REPO" --json nameWithOwner',
+            'gh release view "$RELEASE_TAG"',
+            'test "$GH_REPO" = "$GITHUB_REPOSITORY"',
         ):
-            if marker not in compare:
+            if marker not in publication_preflight:
                 findings.append(
-                    f"{RELEASE_DISTRIBUTION_WORKFLOW_PATH}: compare job does not independently authenticate both prepared candidates"
+                    f"{RELEASE_DISTRIBUTION_WORKFLOW_PATH}: publication preflight does not prove checkout-free GitHub release access before signing"
                 )
                 break
-        if re.search(r"(?im)^\s+(?:run:\s*)?(?:corepack|pnpm|npm|npx|uv|pip)\b", _workflow_executable_text(compare)):
+        if "actions/checkout@" in publication_preflight:
             findings.append(
-                f"{RELEASE_DISTRIBUTION_WORKFLOW_PATH}: compare job must not install dependency tooling"
+                f"{RELEASE_DISTRIBUTION_WORKFLOW_PATH}: publication preflight must reproduce a checkout-free publication runner"
             )
+
+    prepare = jobs.get("prepare")
+    if prepare is not None:
+        for marker in (
+            "persist-credentials: false",
+            "jobctrl-prepared-candidate-",
+            "PREPARED_SHA256SUMS",
+            "prepared-candidate.tar",
+            "release-contract.json",
+        ):
+            if marker not in prepare:
+                findings.append(
+                    f"{RELEASE_DISTRIBUTION_WORKFLOW_PATH}: prepare must build one candidate and upload a checksum-bound handoff"
+                )
+                break
 
     sign = jobs.get("sign")
     if sign is not None:
+        if "needs: [resolve, publication-preflight, prepare]" not in sign:
+            findings.append(
+                f"{RELEASE_DISTRIBUTION_WORKFLOW_PATH}: sign job must wait for checkout-free publication preflight"
+            )
         executable = _workflow_executable_text(sign)
         if 'python-version: "3.12.10"' not in sign:
             findings.append(
@@ -1203,21 +1207,23 @@ def _release_distribution_findings(root: Path) -> list[str]:
                 f"{RELEASE_DISTRIBUTION_WORKFLOW_PATH}: sign job does not execute the sealed bundled finalizer"
             )
 
-        if "jobctrl-compared-candidate-" not in sign or "scripts/distribution-release.bundle.mjs" in sign:
+        if (
+            "jobctrl-prepared-candidate-" not in sign
+            or "PREPARED_SHA256SUMS" not in sign
+            or "pre-sign-verification.json" not in sign
+            or "--verification" not in sign
+            or "scripts/distribution-release.bundle.mjs" in sign
+        ):
             findings.append(
-                f"{RELEASE_DISTRIBUTION_WORKFLOW_PATH}: sign job must consume only compared data and checkout-rooted authority code"
+                f"{RELEASE_DISTRIBUTION_WORKFLOW_PATH}: sign job must consume one checksum-bound candidate and independently verify it with checkout-rooted authority code"
             )
 
     for job_name in (
-        "prepare-a",
-        "prepare-b",
-        "compare",
+        "prepare",
         "package-signed-candidate",
         "smoke-and-verify",
         "pypi-resolve",
-        "pypi-build-a",
-        "pypi-build-b",
-        "pypi-compare",
+        "pypi-build",
     ):
         body = jobs.get(job_name)
         if body is None:
@@ -1349,15 +1355,13 @@ def _release_distribution_findings(root: Path) -> list[str]:
 
 
 def _pypi_release_workflow_findings(workflow: str) -> list[str]:
-    """Require a clean signed-release gate, two builders, and minimal OIDC."""
+    """Require a clean signed-release gate, one checksum-bound build, and minimal OIDC."""
     findings: list[str] = []
     jobs = {
         name: _workflow_job_body(workflow, name)
         for name in (
             "pypi-resolve",
-            "pypi-build-a",
-            "pypi-build-b",
-            "pypi-compare",
+            "pypi-build",
             "publish-pypi",
         )
     }
@@ -1386,7 +1390,7 @@ def _pypi_release_workflow_findings(workflow: str) -> list[str]:
         ):
             if marker not in resolve:
                 findings.append(
-                    f"{RELEASE_DISTRIBUTION_WORKFLOW_PATH}: PyPI resolution must cleanly verify the immutable signed release before builders run"
+                    f"{RELEASE_DISTRIBUTION_WORKFLOW_PATH}: PyPI resolution must cleanly verify the immutable signed release before the builder runs"
                 )
                 break
         executable = _workflow_executable_text(resolve)
@@ -1399,28 +1403,23 @@ def _pypi_release_workflow_findings(workflow: str) -> list[str]:
             findings.append(
                 f"{RELEASE_DISTRIBUTION_WORKFLOW_PATH}: PyPI signed-release gate must run before all project dependency execution and use only the tracked bundled verifier"
             )
-    for name, artifact in (
-        ("pypi-build-a", "jobctrl-pypi-a-"),
-        ("pypi-build-b", "jobctrl-pypi-b-"),
-    ):
-        build = jobs[name]
-        if build is None:
-            continue
+    build = jobs["pypi-build"]
+    if build is not None:
         for marker in (
             "needs: pypi-resolve",
             "SOURCE_DATE_EPOCH:",
             "uv --project workers/automation sync --python 3.12.13 --locked --no-default-groups --only-group release-build --no-install-project",
             "uv --project workers/automation run --python 3.12.13 --no-sync python -m build --no-isolation workers/automation",
-            artifact,
+            "jobctrl-pypi-distributions-",
+            "shasum -a 256 packages/* > SHA256SUMS",
         ):
             if marker not in build:
                 findings.append(
-                    f"{RELEASE_DISTRIBUTION_WORKFLOW_PATH}: {name} does not independently verify and build the fixed-epoch distributions"
+                    f"{RELEASE_DISTRIBUTION_WORKFLOW_PATH}: pypi-build does not build and checksum the fixed-epoch distributions"
                 )
                 break
         if (
-            "shasum -a 256 packages/" in build
-            or "id-token: write" in build
+            "id-token: write" in build
             or "environment: pypi" in build
             or "verify-pypi-gate" in build
             or "gh release download" in build
@@ -1431,23 +1430,8 @@ def _pypi_release_workflow_findings(workflow: str) -> list[str]:
             or "--extra dev" in build
         ):
             findings.append(
-                f"{RELEASE_DISTRIBUTION_WORKFLOW_PATH}: {name} must only build after the clean shared gate and must not receive verification or publication authority"
+                f"{RELEASE_DISTRIBUTION_WORKFLOW_PATH}: pypi-build must only build after the clean shared gate and must not receive verification or publication authority"
             )
-    compare = jobs["pypi-compare"]
-    if compare is not None:
-        for marker in (
-            "needs: [pypi-resolve, pypi-build-a, pypi-build-b]",
-            "jobctrl-pypi-a-",
-            "jobctrl-pypi-b-",
-            'cmp "$a/$name" "$b/$name"',
-            "jobctrl-pypi-sealed-",
-            "shasum -a 256 packages/* > SHA256SUMS",
-        ):
-            if marker not in compare:
-                findings.append(
-                    f"{RELEASE_DISTRIBUTION_WORKFLOW_PATH}: PyPI compare job does not byte-compare and seal both builders"
-                )
-                break
     publish = jobs["publish-pypi"]
     if publish is None:
         return findings
@@ -1458,9 +1442,9 @@ def _pypi_release_workflow_findings(workflow: str) -> list[str]:
     for marker, message in {
         "environment: pypi": "does not put OIDC publication behind the PyPI environment",
         "id-token: write": "does not request PyPI OIDC only in the publication job",
-        "jobctrl-pypi-sealed-": "does not consume only the compare-sealed artifact",
+        "jobctrl-pypi-distributions-": "does not consume only the checksum-bound build artifact",
         "EXPECTED_SOURCE_COMMIT: ${{ needs.pypi-resolve.outputs.source_commit }}": "does not bind publication to the resolved source commit",
-        "packages-dir: ${{ runner.temp }}/jobctrl-pypi-dists/packages": "does not limit PyPI to the sealed package directory",
+        "packages-dir: ${{ runner.temp }}/jobctrl-pypi-dists/packages": "does not limit PyPI to the verified package directory",
         "uses: pypa/gh-action-pypi-publish@6733eb7d741f0b11ec6a39b58540dab7590f9b7d": "does not use the pinned PyPI publisher",
     }.items():
         if marker not in publish:

--- a/workers/automation/pyproject.toml
+++ b/workers/automation/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jobctrl"
-version = "2.0.1"
+version = "2.0.2"
 description = "AI-powered end-to-end job application pipeline"
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/workers/automation/src/jobctrl/__init__.py
+++ b/workers/automation/src/jobctrl/__init__.py
@@ -1,3 +1,3 @@
 """JobCtrl — AI-powered end-to-end job application pipeline."""
 
-__version__ = "2.0.1"
+__version__ = "2.0.2"

--- a/workers/automation/tests/test_release_check.py
+++ b/workers/automation/tests/test_release_check.py
@@ -778,11 +778,11 @@ def test_pypi_workflow_keeps_build_verification_outside_oidc_publication() -> No
         release_check.ROOT / release_check.RELEASE_DISTRIBUTION_WORKFLOW_PATH
     ).read_text(encoding="utf-8")
     resolve = release_check._workflow_job_body(workflow, "pypi-resolve")
-    compare = release_check._workflow_job_body(workflow, "pypi-compare")
+    build = release_check._workflow_job_body(workflow, "pypi-build")
     publish = release_check._workflow_job_body(workflow, "publish-pypi")
 
     assert resolve is not None
-    assert compare is not None
+    assert build is not None
     assert publish is not None
     assert not (release_check.ROOT / release_check.PUBLISH_WORKFLOW_PATH).exists()
 
@@ -800,34 +800,30 @@ def test_pypi_workflow_keeps_build_verification_outside_oidc_publication() -> No
     assert "corepack pnpm" not in resolve
     assert "uv --project" not in resolve
 
-    for job_name, artifact in (
-        ("pypi-build-a", "jobctrl-pypi-a-"),
-        ("pypi-build-b", "jobctrl-pypi-b-"),
-    ):
-        build = release_check._workflow_job_body(workflow, job_name)
-        assert build is not None
-        assert "needs: pypi-resolve" in build
-        assert "actions/setup-python@" in build
-        assert "astral-sh/setup-uv@" in build
-        assert "actions/setup-node@" not in build
-        assert "corepack pnpm" not in build
-        assert "verify-pypi-gate" not in build
-        assert "JOBCTRL_RELEASE_PUBLIC_KEY" not in build
-        assert "JOBCTRL_RELEASE_KEY_ID" not in build
-        sync = "uv --project workers/automation sync --python 3.12.13 --locked --no-default-groups --only-group release-build --no-install-project"
-        build_command = "uv --project workers/automation run --python 3.12.13 --no-sync python -m build --no-isolation workers/automation"
-        assert sync in build
-        assert build_command in build
-        assert build.index(sync) < build.index(build_command) < build.index(
-            "python3 scripts/release_check.py --strict-prompt"
-        ) < build.index("actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02")
-        assert artifact in build
-
-    assert "needs: [pypi-resolve, pypi-build-a, pypi-build-b]" in compare
-    assert 'cmp "$a/$name" "$b/$name"' in compare
-    assert "shasum -a 256 packages/* > SHA256SUMS" in compare
+    assert "needs: pypi-resolve" in build
+    assert "actions/setup-python@" in build
+    assert "astral-sh/setup-uv@" in build
+    assert "actions/setup-node@" not in build
+    assert "corepack pnpm" not in build
+    assert "verify-pypi-gate" not in build
+    assert "JOBCTRL_RELEASE_PUBLIC_KEY" not in build
+    assert "JOBCTRL_RELEASE_KEY_ID" not in build
+    sync = "uv --project workers/automation sync --python 3.12.13 --locked --no-default-groups --only-group release-build --no-install-project"
+    build_command = "uv --project workers/automation run --python 3.12.13 --no-sync python -m build --no-isolation workers/automation"
+    assert sync in build
+    assert build_command in build
+    assert build.index(sync) < build.index(build_command) < build.index(
+        "python3 scripts/release_check.py --strict-prompt"
+    ) < build.index("shasum -a 256 packages/* > SHA256SUMS") < build.index(
+        "actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02"
+    )
+    assert "jobctrl-pypi-distributions-" in build
+    assert "pypi-build-a" not in workflow
+    assert "pypi-build-b" not in workflow
+    assert "pypi-compare" not in workflow
 
     assert "environment: pypi" in publish
+    assert "needs: [pypi-resolve, pypi-build]" in publish
     assert "id-token: write" in publish
     assert "actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093" in publish
     assert "actions/checkout@" not in publish
@@ -845,6 +841,7 @@ def test_pypi_workflow_keeps_build_verification_outside_oidc_publication() -> No
     assert 'test "$tag_sha" = "$main_sha"' in publish
     assert "packages-dir: ${{ runner.temp }}/jobctrl-pypi-dists/packages" in publish
     assert "SHA256SUMS" in publish
+    assert "jobctrl-pypi-distributions-" in publish
     assert "uses: pypa/gh-action-pypi-publish@6733eb7d741f0b11ec6a39b58540dab7590f9b7d" in publish
 
 
@@ -904,12 +901,12 @@ def test_distribution_privileged_jobs_reject_dependency_or_repo_execution(
         encoding="utf-8"
     )
     workflow = workflow.replace(
-        "      - name: Download the independently compared candidate\n",
+        "      - name: Download the prepared candidate\n",
         "      - name: Install forbidden signing dependencies\n"
         "        run: |\n"
         "          corepack pnpm install --frozen-lockfile\n"
         "          node scripts/distribution-release.mjs inspect fixture fixture\n\n"
-        "      - name: Download the independently compared candidate\n",
+        "      - name: Download the prepared candidate\n",
         1,
     ).replace(
         "      - name: Download the immutable signed candidate\n",
@@ -943,6 +940,59 @@ def test_distribution_privileged_jobs_reject_dependency_or_repo_execution(
     )
     assert any(
         "credential-free job smoke-and-verify receives signing or publication authority"
+        in item
+        for item in findings
+    )
+
+
+def test_distribution_checkout_free_jobs_bind_github_cli_repository(
+    tmp_path: Path,
+) -> None:
+    workflow = (
+        release_check.ROOT / release_check.RELEASE_DISTRIBUTION_WORKFLOW_PATH
+    ).read_text(encoding="utf-8")
+    policy = (release_check.ROOT / release_check.SIGNING_POLICY_PATH).read_text(
+        encoding="utf-8"
+    )
+    workflow = workflow.replace(
+        "env:\n"
+        "  # Checkout-free publication jobs must never rely on gh inferring a repository.\n"
+        "  GH_REPO: ${{ github.repository }}\n\n",
+        "",
+        1,
+    )
+    _write(tmp_path / release_check.RELEASE_DISTRIBUTION_WORKFLOW_PATH, workflow)
+    _write(tmp_path / release_check.SIGNING_POLICY_PATH, policy)
+
+    findings = release_check._release_distribution_findings(tmp_path)
+
+    assert any(
+        "does not bind checkout-free GitHub CLI release operations" in item
+        for item in findings
+    )
+
+
+def test_distribution_preflights_checkout_free_release_access_before_signing(
+    tmp_path: Path,
+) -> None:
+    workflow = (
+        release_check.ROOT / release_check.RELEASE_DISTRIBUTION_WORKFLOW_PATH
+    ).read_text(encoding="utf-8")
+    policy = (release_check.ROOT / release_check.SIGNING_POLICY_PATH).read_text(
+        encoding="utf-8"
+    )
+    workflow = workflow.replace(
+        "          test \"$(gh repo view \"$GH_REPO\" --json nameWithOwner --jq '.nameWithOwner')\" = \"$GITHUB_REPOSITORY\"\n",
+        "",
+        1,
+    )
+    _write(tmp_path / release_check.RELEASE_DISTRIBUTION_WORKFLOW_PATH, workflow)
+    _write(tmp_path / release_check.SIGNING_POLICY_PATH, policy)
+
+    findings = release_check._release_distribution_findings(tmp_path)
+
+    assert any(
+        "publication preflight does not prove checkout-free GitHub release access"
         in item
         for item in findings
     )

--- a/workers/automation/uv.lock
+++ b/workers/automation/uv.lock
@@ -586,7 +586,7 @@ wheels = [
 
 [[package]]
 name = "jobctrl"
-version = "2.0.1"
+version = "2.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## What changed

- replaces duplicate macOS and PyPI builds with one locked build plus independent checksum and pre-sign verification
- binds every checkout-free GitHub CLI release operation to `ebarti/JobCtrl`
- adds a checkout-free publication preflight that runs alongside the build and must pass before signing
- preserves signing, Apple notarization, immutable R2 publication, channel CAS, public smoke, Homebrew, GitHub Release, and PyPI OIDC gates
- bumps all release identity surfaces to `2.0.2` and records the failed `v2.0.1` attempt without moving its tag
- updates release audit metadata to describe the actual independent verification gate

## Why

The `v2.0.1` workflow completed build, signing, notarization, stapling, and audit packaging, then failed before any public upload because a checkout-free publication runner called `gh release` without an explicit repository. The revised topology fails that class of issue before signing and removes redundant byte-for-byte duplicate builds.

## Validation

- 42 distribution/manifest tests passed
- 52 release-policy tests passed
- strict `v2.0.2` release check passed
- distribution audit passed
- exact locked wheel and sdist build passed
- docs build, 8,239-link check, and redirect check passed
- workflow YAML parse and authority-bundle checksum verification passed
- independent reviewer and release QA gates passed with no findings

The aggregate script suite passed 123/125 locally; the two remaining screenshot guard tests are specific to this worktree being under `/private/tmp`. Hosted CI runs outside the canonical temporary root and must pass them before merge.