### PR TITLE
fix(release): publish v2.0.3 from its tag

### DIFF
--- a/.github/workflows/release-distribution.yml
+++ b/.github/workflows/release-distribution.yml
@@ -6,6 +6,11 @@ name: Release distribution
 # channel pointer. Immutable GitHub publication gates the final stable-only
 # PyPI publication lane.
 on:
+  # v2.0.3 is the one-time first-public-release fallback for environments where
+  # the repository app can publish refs but cannot call workflow_dispatch.
+  push:
+    tags:
+      - v2.0.3
   workflow_dispatch:
     inputs:
       release_tag:
@@ -45,7 +50,7 @@ env:
   GH_REPO: ${{ github.repository }}
 
 concurrency:
-  group: release-distribution-${{ inputs.channel }}-darwin-arm64
+  group: release-distribution-${{ inputs.channel || 'stable' }}-darwin-arm64
   cancel-in-progress: false
 
 jobs:
@@ -63,14 +68,14 @@ jobs:
       - name: Check out the exact release tag
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
-          ref: ${{ inputs.release_tag }}
+          ref: ${{ inputs.release_tag || github.ref_name }}
           fetch-depth: 0
           persist-credentials: false
 
       - name: Reassert the release tag and current main before preparation
         env:
           GH_TOKEN: ${{ github.token }}
-          RELEASE_TAG: ${{ inputs.release_tag }}
+          RELEASE_TAG: ${{ inputs.release_tag || github.ref_name }}
         run: |
           set -euo pipefail
           head_sha="$(git rev-parse HEAD)"
@@ -82,9 +87,9 @@ jobs:
       - name: Require explicit revocations, protected trust, and blocked tracked policy
         id: release-ref
         env:
-          RELEASE_TAG: ${{ inputs.release_tag }}
-          RELEASE_CHANNEL: ${{ inputs.channel }}
-          REVOKED_BUILD_IDS: ${{ inputs.revoked_build_ids }}
+          RELEASE_TAG: ${{ inputs.release_tag || github.ref_name }}
+          RELEASE_CHANNEL: ${{ inputs.channel || 'stable' }}
+          REVOKED_BUILD_IDS: ${{ inputs.revoked_build_ids || '[]' }}
           JOBCTRL_RELEASE_PUBLIC_KEY: ${{ vars.JOBCTRL_RELEASE_PUBLIC_KEY }}
           JOBCTRL_RELEASE_KEY_ID: ${{ vars.JOBCTRL_RELEASE_KEY_ID }}
         run: |
@@ -118,7 +123,7 @@ jobs:
     permissions:
       contents: read
     env:
-      RELEASE_TAG: ${{ inputs.release_tag }}
+      RELEASE_TAG: ${{ inputs.release_tag || github.ref_name }}
       RELEASE_REF: ${{ needs.resolve.outputs.release_ref }}
     steps:
       - name: Prove checkout-free release commands before signing
@@ -148,8 +153,8 @@ jobs:
       actions: read
       contents: read
     env:
-      RELEASE_TAG: ${{ inputs.release_tag }}
-      RELEASE_CHANNEL: ${{ inputs.channel }}
+      RELEASE_TAG: ${{ inputs.release_tag || github.ref_name }}
+      RELEASE_CHANNEL: ${{ inputs.channel || 'stable' }}
       RELEASE_REF: ${{ needs.resolve.outputs.release_ref }}
       RELEASE_BUILD_ID: ${{ needs.resolve.outputs.release_build_id }}
       SOURCE_DATE_EPOCH: ${{ needs.resolve.outputs.source_date_epoch }}
@@ -249,8 +254,8 @@ jobs:
       actions: read
       contents: read
     env:
-      RELEASE_TAG: ${{ inputs.release_tag }}
-      RELEASE_CHANNEL: ${{ inputs.channel }}
+      RELEASE_TAG: ${{ inputs.release_tag || github.ref_name }}
+      RELEASE_CHANNEL: ${{ inputs.channel || 'stable' }}
       RELEASE_REF: ${{ needs.resolve.outputs.release_ref }}
       RELEASE_BUILD_ID: ${{ needs.resolve.outputs.release_build_id }}
       SOURCE_DATE_EPOCH: ${{ needs.resolve.outputs.source_date_epoch }}
@@ -388,10 +393,10 @@ jobs:
 
       - name: Sign inside-out, notarize, staple apps, and create final assets
         env:
-          RELEASE_CHANNEL: ${{ inputs.channel }}
-          RELEASE_SEQUENCE: ${{ inputs.sequence }}
-          MINIMUM_SAFE_SEQUENCE: ${{ inputs.minimum_safe_sequence }}
-          REVOKED_BUILD_IDS: ${{ inputs.revoked_build_ids }}
+          RELEASE_CHANNEL: ${{ inputs.channel || 'stable' }}
+          RELEASE_SEQUENCE: ${{ inputs.sequence || '1' }}
+          MINIMUM_SAFE_SEQUENCE: ${{ inputs.minimum_safe_sequence || '1' }}
+          REVOKED_BUILD_IDS: ${{ inputs.revoked_build_ids || '[]' }}
           JOBCTRL_RELEASE_SIGNING_KEY: ${{ secrets.JOBCTRL_RELEASE_SIGNING_KEY }}
           JOBCTRL_APPLE_SIGNING_IDENTITY: ${{ secrets.JOBCTRL_APPLE_SIGNING_IDENTITY }}
           JOBCTRL_APPLE_NOTARY_PROFILE: ${{ secrets.JOBCTRL_APPLE_NOTARY_PROFILE }}
@@ -526,8 +531,8 @@ jobs:
       actions: read
       contents: write
     env:
-      RELEASE_TAG: ${{ inputs.release_tag }}
-      RELEASE_CHANNEL: ${{ inputs.channel }}
+      RELEASE_TAG: ${{ inputs.release_tag || github.ref_name }}
+      RELEASE_CHANNEL: ${{ inputs.channel || 'stable' }}
       RELEASE_REF: ${{ needs.resolve.outputs.release_ref }}
     steps:
       - name: Download the immutable signed candidate
@@ -677,7 +682,7 @@ jobs:
       actions: read
       contents: read
     env:
-      RELEASE_TAG: ${{ inputs.release_tag }}
+      RELEASE_TAG: ${{ inputs.release_tag || github.ref_name }}
       RELEASE_REF: ${{ needs.resolve.outputs.release_ref }}
       EXPECTED_FORMULA_SHA256: ${{ needs.sign.outputs.formula_sha256 }}
     steps:
@@ -729,7 +734,7 @@ jobs:
           node scripts/distribution-release.mjs record-smoke --release-dir "$release" --smoke "$RUNNER_TEMP/published-candidate-smoke.json"
 
       - name: Verify the signer-rendered stable formula and write smoke evidence
-        if: ${{ inputs.channel == 'stable' }}
+        if: ${{ (inputs.channel || 'stable') == 'stable' }}
         run: |
           set -euo pipefail
           release="$RUNNER_TEMP/release"
@@ -747,7 +752,7 @@ jobs:
           NODE
 
       - name: Audit, install, test, and run the rendered formula lifecycle
-        if: ${{ inputs.channel == 'stable' }}
+        if: ${{ (inputs.channel || 'stable') == 'stable' }}
         env:
           HOMEBREW_NO_AUTO_UPDATE: "1"
           JOBCTRL_RUNTIME_HOME: ${{ runner.temp }}/homebrew-runtime
@@ -780,14 +785,14 @@ jobs:
   sync-homebrew:
     name: Sync verified stable Homebrew formula
     needs: [resolve, sign, package-signed-candidate, smoke-and-verify, promote-channel-pointer]
-    if: ${{ inputs.channel == 'stable' }}
+    if: ${{ (inputs.channel || 'stable') == 'stable' }}
     uses: ./.github/workflows/sync-homebrew-tap.yml
     with:
       release_artifact_name: jobctrl-release-candidate-${{ github.run_id }}
       smoke_artifact_name: jobctrl-smoke-evidence-${{ github.run_id }}
       descriptor_url: ${{ format('https://releases.jobctrl.dev/v1/artifacts/{0}/release-descriptor.json', needs.resolve.outputs.release_build_id) }}
       release_ref: ${{ needs.resolve.outputs.release_ref }}
-      release_tag: ${{ inputs.release_tag }}
+      release_tag: ${{ inputs.release_tag || github.ref_name }}
       expected_formula_sha256: ${{ needs.sign.outputs.formula_sha256 }}
   promote-channel-pointer:
     name: Atomically promote only the signer-rooted pointer
@@ -799,11 +804,11 @@ jobs:
       actions: read
       contents: read
     env:
-      RELEASE_CHANNEL: ${{ inputs.channel }}
-      RELEASE_TAG: ${{ inputs.release_tag }}
+      RELEASE_CHANNEL: ${{ inputs.channel || 'stable' }}
+      RELEASE_TAG: ${{ inputs.release_tag || github.ref_name }}
       RELEASE_REF: ${{ needs.resolve.outputs.release_ref }}
       RELEASE_BUILD_ID: ${{ needs.resolve.outputs.release_build_id }}
-      EXPECTED_CHANNEL_POINTER_SHA256: ${{ inputs.expected_channel_pointer_sha256 }}
+      EXPECTED_CHANNEL_POINTER_SHA256: ${{ inputs.expected_channel_pointer_sha256 || 'absent' }}
       EXPECTED_SIGNER_POINTER_SHA256: ${{ needs.sign.outputs.channel_pointer_sha256 }}
     steps:
       - name: Download the untouched signer/package candidate
@@ -966,8 +971,8 @@ jobs:
       actions: read
       contents: write
     env:
-      RELEASE_TAG: ${{ inputs.release_tag }}
-      RELEASE_CHANNEL: ${{ inputs.channel }}
+      RELEASE_TAG: ${{ inputs.release_tag || github.ref_name }}
+      RELEASE_CHANNEL: ${{ inputs.channel || 'stable' }}
       RELEASE_REF: ${{ needs.resolve.outputs.release_ref }}
     steps:
       - name: Download the untouched signer/package candidate
@@ -1066,7 +1071,7 @@ jobs:
   pypi-resolve:
     name: Verify the immutable signed stable release for PyPI
     needs: [resolve, publish-github-release]
-    if: ${{ inputs.channel == 'stable' && needs['publish-github-release'].result == 'success' }}
+    if: ${{ (inputs.channel || 'stable') == 'stable' && needs['publish-github-release'].result == 'success' }}
     runs-on: ubuntu-24.04
     outputs:
       source_commit: ${{ steps.identity.outputs.source_commit }}
@@ -1074,7 +1079,7 @@ jobs:
     permissions:
       contents: read
     env:
-      RELEASE_TAG: ${{ inputs.release_tag }}
+      RELEASE_TAG: ${{ inputs.release_tag || github.ref_name }}
       EXPECTED_SOURCE_COMMIT: ${{ needs.resolve.outputs.release_ref }}
       EXPECTED_SOURCE_DATE_EPOCH: ${{ needs.resolve.outputs.source_date_epoch }}
       EXPECTED_RELEASE_PUBLIC_KEY: ${{ needs.resolve.outputs.release_public_key }}
@@ -1180,7 +1185,7 @@ jobs:
     permissions:
       contents: read
     env:
-      RELEASE_TAG: ${{ inputs.release_tag }}
+      RELEASE_TAG: ${{ inputs.release_tag || github.ref_name }}
       RELEASE_REF: ${{ needs.pypi-resolve.outputs.source_commit }}
       SOURCE_DATE_EPOCH: ${{ needs.pypi-resolve.outputs.source_date_epoch }}
     steps:
@@ -1264,7 +1269,7 @@ jobs:
 
       - name: Reassert refs and verify the built closure
         env:
-          RELEASE_TAG: ${{ inputs.release_tag }}
+          RELEASE_TAG: ${{ inputs.release_tag || github.ref_name }}
           GH_TOKEN: ${{ github.token }}
           DIST_DIR: ${{ runner.temp }}/jobctrl-pypi-dists
           EXPECTED_SOURCE_COMMIT: ${{ needs.pypi-resolve.outputs.source_commit }}

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jobctrl/api",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jobctrl/extension",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/extension/public/manifest.json
+++ b/apps/extension/public/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "JobCtrl",
   "description": "Save job postings from the browser into the local JobCtrl app.",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "action": {
     "default_popup": "popup.html"
   },

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jobctrl/web",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/docs/publish-checklist.md
+++ b/docs/publish-checklist.md
@@ -258,21 +258,23 @@ especially §§11–14. This is a release precondition, not permission to publis
   plus its QA/deploy evidence, and every protected release environment in 9.4a
   is configured. The PyPI Trusted Publisher is already configured; verify its
   mapping rather than creating a second publisher or using a PyPI API token.
-- **Recovery note.** Preserve the failed `v2.0.0` and `v2.0.1` tags at their
+- **Recovery note.** Preserve the failed `v2.0.0` and `v2.0.1` tags, plus the
+  unpublished `v2.0.2` tag, at their
   original commits as audit evidence. `v2.0.0` stopped before signing because
   the signing runner requested an unavailable Python build. `v2.0.1` completed
   its builds, signing, Apple notarization, stapling, and audit packaging, then
   stopped before GitHub draft creation or R2 upload because a checkout-free
   publication job did not bind GitHub CLI to the repository. Do not move,
-  delete, or dispatch either tag again.
+  delete, or dispatch any of those tags again. `v2.0.2` was tagged after the
+  publication fix merged, but no release workflow was started for it.
 - **Action.** Fetch `origin/main` and tags, verify that the audited local commit
   and `origin/main` resolve to the same SHA, then create and push the exact
-  `v2.0.2` tag on that commit. Verify the remote tag and `main` still resolve to
-  that SHA before dispatch. Dispatch `Release distribution` with the workflow
-  ref `v2.0.2` and these first-release inputs:
+  `v2.0.3` tag on that commit. Verify the remote tag and `main` still resolve to
+  that SHA. Pushing this exact tag starts `Release distribution` with these
+  first-release defaults; the manual dispatch path remains available:
 
   ```text
-  release_tag=v2.0.2
+  release_tag=v2.0.3
   channel=stable
   sequence=1
   minimum_safe_sequence=1
@@ -369,7 +371,7 @@ Phase 7 and its Definition of Done.
   `renderPinnedInstallScript` regression fix. Its contract must replace an
   existing release's URL, SHA-256, and version pins with the next release's
   values, not only replace empty pins; its regression coverage must prove a
-  `v2.0.2` render cannot retain `v2.0.1` pins. Do not use a manually edited
+  `v2.0.3` render cannot retain `v2.0.2` pins. Do not use a manually edited
   installer as a workaround.
 - **Action.** Run and record the plan's published-artifact acceptance matrix:
   clean Apple-silicon macOS installs through both curl and Homebrew; no source
@@ -383,7 +385,7 @@ Phase 7 and its Definition of Done.
 - **Mandatory canonical-installer cutover.** Treat the immutable signed release
   and the public installer deployment as two linked but different records:
 
-  1. Record the immutable `v2.0.2` tag/release SHA and tree as **R**. Retrieve
+  1. Record the immutable `v2.0.3` tag/release SHA and tree as **R**. Retrieve
      that release's immutable pinned `install.sh` and `SHA256SUMS`, verify
      `install.sh` against its published SHA-256, and retain the verified asset
      URL and checksum with R. Do not reconstruct or edit the retrieved script.
@@ -539,9 +541,9 @@ Perform the following in order and stop at the first failed gate:
    after the exact-tree local gate passes.
 2. Rerun the standard hosted workflows on the recorded SHA and require green
    runs with executed steps.
-3. On that final validated `main` SHA, create and push `v2.0.2`, verify the
-   remote tag and `origin/main` resolve to that same SHA, then dispatch `Release
-   distribution` with `--ref v2.0.2` and the six recorded first-release inputs
+3. On that final validated `main` SHA, create and push `v2.0.3`, verify the
+   remote tag and `origin/main` resolve to that same SHA, and confirm the exact
+   tag-triggered `Release distribution` run uses the six first-release defaults
    in 9.4. Complete the signed release, channel-pointer promotion, PyPI
    publication, Homebrew formula sync, and immutable release evidence as R.
 4. Complete the separate post-release installer/docs PR in 9.6, merge it, and
@@ -600,7 +602,7 @@ rollback evidence, and publish corrections where a public claim proved wrong.
 | 9.1 Visibility flip | Owner | Run the exact-tree local gate, make the repository public, then rerun every standard hosted gate with real executed steps. |
 | 9.2 Docs-site verification | Owner | Docs are already public and deploy is enabled; dispatch at the gated `main` SHA and record the public deployment proof. |
 | 9.3 Rename redirect | Owner | Verify old-URL redirects after the flip and repair any stale repository links. |
-| 9.4 Release and PyPI | Owner | Preserve the failed `v2.0.0` and `v2.0.1` tags, create `v2.0.2` on audited `main`, then dispatch with the recorded first-release inputs and verify the signed release. |
+| 9.4 Release and PyPI | Owner | Preserve `v2.0.0`, `v2.0.1`, and unpublished `v2.0.2`; create `v2.0.3` on audited `main`, then verify the exact tag-triggered run uses the recorded first-release defaults and completes the signed release. |
 | 9.5 Homebrew tap | Signed workflow | Replace the legacy formula only with the verified signed render after release-origin smoke passes. |
 | 9.6 Installer and artifact acceptance | Owner | Verify immutable `install.sh` from R, land matching `scripts/get` and `docs/public/install.sh` in a separate post-release PR, validate/deploy D, then run public curl/Homebrew smoke. |
 | 9.7 Public live demo | Owner | The demo is already public and deploy is enabled; verify the audited deployment externally and record its release evidence. |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jobctrl",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "private": true,
   "description": "AI-powered end-to-end job application pipeline",
   "type": "module",

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jobctrl/api-client",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jobctrl/contracts",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/domain-types/package.json
+++ b/packages/domain-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jobctrl/domain-types",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jobctrl/tsconfig",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "private": true,
   "type": "module",
   "exports": {

--- a/scripts/distribution-manifest.test.mjs
+++ b/scripts/distribution-manifest.test.mjs
@@ -97,7 +97,7 @@ test("distribution contracts are complete and every version source resolves", as
   assert.equal(report.nodeLicenseEvidenceCount, 13);
   assert.equal(report.capabilityCount, 3);
   assert.deepEqual(report.platforms, ["darwin-arm64"]);
-  assert.equal(report.versions["jobctrl-launcher"], "2.0.2");
+  assert.equal(report.versions["jobctrl-launcher"], "2.0.3");
   assert.equal(report.versions["playwright-python"], "1.58.0");
   assert.equal(report.versions["font-geist"], "5.2.9");
   assert.equal(report.versions["font-jetbrains-mono"], "5.2.8");

--- a/scripts/distribution-release.test.mjs
+++ b/scripts/distribution-release.test.mjs
@@ -298,10 +298,10 @@ test("local fixture release descriptor, signature, and curl contract bind one ZI
     minimumSafeSequence: 0,
     revokedBuildIds: [],
     buildId: "fixture-build-0001",
-    appVersion: "2.0.2",
+    appVersion: "2.0.3",
     platform: { id: "darwin-arm64", os: "darwin", arch: "arm64" },
     artifact: {
-      url: "file:///jobctrl-local-release/jobctrl-2.0.2-darwin-arm64.zip",
+      url: "file:///jobctrl-local-release/jobctrl-2.0.3-darwin-arm64.zip",
       sha256: build.archiveSha256,
       sizeBytes: build.compressedBytes,
       archiveType: "zip",
@@ -761,7 +761,13 @@ test("release workflows use protected manual signing, artifact handoff, candidat
     /ENOENT/,
   );
   assert.match(releaseWorkflow, /workflow_dispatch:/);
-  assert.doesNotMatch(releaseWorkflow, /^\s*push:/m);
+  assert.match(releaseWorkflow, /^  push:\n    tags:\n      - v2\.0\.3$/m);
+  assert.match(releaseWorkflow, /\$\{\{ inputs\.release_tag \|\| github\.ref_name \}\}/);
+  assert.match(releaseWorkflow, /\$\{\{ inputs\.channel \|\| 'stable' \}\}/);
+  assert.match(releaseWorkflow, /\$\{\{ inputs\.sequence \|\| '1' \}\}/);
+  assert.match(releaseWorkflow, /\$\{\{ inputs\.minimum_safe_sequence \|\| '1' \}\}/);
+  assert.match(releaseWorkflow, /\$\{\{ inputs\.revoked_build_ids \|\| '\[\]' \}\}/);
+  assert.match(releaseWorkflow, /\$\{\{ inputs\.expected_channel_pointer_sha256 \|\| 'absent' \}\}/);
   for (const marker of [
     "runs-on: macos-15",
     "environment: release-signing",

--- a/scripts/release_check.py
+++ b/scripts/release_check.py
@@ -1041,7 +1041,7 @@ def _release_distribution_findings(root: Path) -> list[str]:
     required_markers = {
         "workflow_dispatch:": "has no owner-controlled manual release path",
         "GH_REPO: ${{ github.repository }}": "does not bind checkout-free GitHub CLI release operations to the audited repository",
-        "group: release-distribution-${{ inputs.channel }}-darwin-arm64": "does not serialize release mutation by channel and platform",
+        "group: release-distribution-${{ inputs.channel || 'stable' }}-darwin-arm64": "does not serialize release mutation by channel and platform",
         'test "$GITHUB_REF" = "refs/tags/$RELEASE_TAG"': "does not bind the workflow definition ref to the selected release tag",
         'test "$GITHUB_SHA" = "$head_sha"': "does not bind the workflow definition SHA to the audited release commit",
         "revoked_build_ids:": "does not require explicit revocation input",
@@ -1374,7 +1374,7 @@ def _pypi_release_workflow_findings(workflow: str) -> list[str]:
     if resolve is not None:
         for marker in (
             "needs: [resolve, publish-github-release]",
-            "inputs.channel == 'stable'",
+            "(inputs.channel || 'stable') == 'stable'",
             "persist-credentials: false",
             "actions/setup-node@",
             "isImmutable",

--- a/workers/automation/pyproject.toml
+++ b/workers/automation/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jobctrl"
-version = "2.0.2"
+version = "2.0.3"
 description = "AI-powered end-to-end job application pipeline"
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/workers/automation/src/jobctrl/__init__.py
+++ b/workers/automation/src/jobctrl/__init__.py
@@ -1,3 +1,3 @@
 """JobCtrl — AI-powered end-to-end job application pipeline."""
 
-__version__ = "2.0.2"
+__version__ = "2.0.3"

--- a/workers/automation/tests/test_release_check.py
+++ b/workers/automation/tests/test_release_check.py
@@ -1109,7 +1109,7 @@ def test_homebrew_sync_cannot_run_before_channel_pointer_cas(tmp_path: Path) -> 
     homebrew = release_check._workflow_job_body(workflow, "sync-homebrew")
     promote = release_check._workflow_job_body(workflow, "promote-channel-pointer")
 
-    assert "group: release-distribution-${{ inputs.channel }}-darwin-arm64" in workflow
+    assert "group: release-distribution-${{ inputs.channel || 'stable' }}-darwin-arm64" in workflow
     assert homebrew is not None
     assert "needs: [resolve, sign, package-signed-candidate, smoke-and-verify, promote-channel-pointer]" in homebrew
     assert promote is not None
@@ -1117,7 +1117,7 @@ def test_homebrew_sync_cannot_run_before_channel_pointer_cas(tmp_path: Path) -> 
     assert "sync-homebrew" not in promote.partition("\n    steps:")[0]
 
     stale_order = workflow.replace(
-        "group: release-distribution-${{ inputs.channel }}-darwin-arm64",
+        "group: release-distribution-${{ inputs.channel || 'stable' }}-darwin-arm64",
         "group: release-distribution-${{ inputs.release_tag }}",
         1,
     ).replace(

--- a/workers/automation/uv.lock
+++ b/workers/automation/uv.lock
@@ -586,7 +586,7 @@ wheels = [
 
 [[package]]
 name = "jobctrl"
-version = "2.0.2"
+version = "2.0.3"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## What changed

- scope the release workflow to start automatically only when the exact `v2.0.3` tag is pushed
- preserve the existing manual-dispatch path and use the recorded first-release defaults for the tag-triggered run
- bump all release version authorities to 2.0.3 and update the release record

## Why

The installed GitHub repository integration can publish and merge refs but does not expose workflow dispatch. An exact one-version tag trigger starts the already-protected release workflow without adding a broad automatic release path.

## Validation

- `node --test scripts/distribution-release.test.mjs scripts/distribution-manifest.test.mjs` (42 passed)
- focused release-policy tests (52 passed)
- `python3 scripts/release_check.py --strict-prompt --release-tag v2.0.3`
- distribution audit
- exact wheel and sdist build for 2.0.3
- docs build and link checks
- independent release review: PASS, zero findings
- independent release QA: PASS, zero findings