### PR TITLE
feat(demo): add consent-gated Google Analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,10 @@ scoring evidence, tailored materials, dry-run rehearsals, and workflow history
 before installing JobCtrl. Demo actions are simulated and cannot contact
 employers, providers, Gmail, job boards, or the local JobCtrl app.
 
-The demo requires first-party analytics-cookie acceptance before it
-creates its browser-local workspace. Declining returns to `jobctrl.dev`; a
-later visit asks again. Read the
+The demo requires analytics-cookie acceptance before it creates its
+browser-local workspace. Acceptance enables bounded first-party demo
+measurement and Google Analytics with advertising and personalization signals
+disabled. Declining returns to `jobctrl.dev`; a later visit asks again. Read the
 [demo data notice](https://jobctrl.dev/user/data-and-safety#public-demo) before
 entering, and do not type personal data, credentials, or secrets.
 When a deployment updates the canonical synthetic examples, the next demo load

--- a/apps/demo-edge/src/contracts.ts
+++ b/apps/demo-edge/src/contracts.ts
@@ -1,4 +1,4 @@
-export const CONSENT_CONTRACT_VERSION = "v1";
+export const CONSENT_CONTRACT_VERSION = "v2";
 export const CONSENT_MAX_AGE_SECONDS = 60 * 60 * 24 * 180;
 export const MAX_REQUEST_BYTES = 2_048;
 export const OPERATIONAL_RATE_LIMIT_PER_MINUTE = 120;

--- a/apps/demo-edge/test/demo-edge.test.ts
+++ b/apps/demo-edge/test/demo-edge.test.ts
@@ -244,7 +244,7 @@ describe("API Worker consent and telemetry boundaries", () => {
     const granted = await dispatchDemoApi(grantedContext.request, testEnv);
     expect(granted.status).toBe(200);
     const cookies = setCookies(granted);
-    expect(cookies).toContain("__Host-jobctrl_demo_consent=v1.granted; Max-Age=15544800; Path=/; Secure; SameSite=Lax");
+    expect(cookies).toContain("__Host-jobctrl_demo_consent=v2.granted; Max-Age=15544800; Path=/; Secure; SameSite=Lax");
     expect(cookies).toEqual(expect.arrayContaining([
       expect.stringMatching(/^__Host-jobctrl_demo_vid=[A-Za-z0-9_-]{32,128}; Max-Age=15544800; Path=\/; Secure; SameSite=Lax; HttpOnly$/),
       expect.stringMatching(/^__Host-jobctrl_demo_session=[A-Za-z0-9_-]{32,128}; Path=\/; Secure; SameSite=Lax; HttpOnly$/),
@@ -275,7 +275,7 @@ describe("API Worker consent and telemetry boundaries", () => {
     }, cookieHeader("granted")), repeatedAt);
     expect(response.status).toBe(200);
     expect(setCookies(response)).toEqual([
-      "__Host-jobctrl_demo_consent=v1.granted; Max-Age=15544800; Path=/; Secure; SameSite=Lax",
+      "__Host-jobctrl_demo_consent=v2.granted; Max-Age=15544800; Path=/; Secure; SameSite=Lax",
       `__Host-jobctrl_demo_vid=${visitorId}; Max-Age=15544800; Path=/; Secure; SameSite=Lax; HttpOnly`,
     ]);
     expect(await eventCount()).toBe(1);
@@ -357,7 +357,7 @@ describe("API Worker consent and telemetry boundaries", () => {
 
     expect(response.status).toBe(200);
     expect(setCookies(response)).toEqual([
-      "__Host-jobctrl_demo_consent=v1.denied; Max-Age=15544800; Path=/; Secure; SameSite=Lax",
+      "__Host-jobctrl_demo_consent=v2.denied; Max-Age=15544800; Path=/; Secure; SameSite=Lax",
     ]);
     expect(await activeIdentityCount()).toBe(0);
   });
@@ -442,7 +442,7 @@ describe("API Worker consent and telemetry boundaries", () => {
 
   it("returns unknown and immediately expires identifiers for a stale consent contract", async () => {
     const staleCookies = [
-      "__Host-jobctrl_demo_consent=v0.granted",
+      "__Host-jobctrl_demo_consent=v1.granted",
       `__Host-jobctrl_demo_vid=${visitorId}`,
       `__Host-jobctrl_demo_session=${sessionId}`,
     ].join("; ");

--- a/apps/web/e2e/demo-workspace-tests/demo-workspace.spec.ts
+++ b/apps/web/e2e/demo-workspace-tests/demo-workspace.spec.ts
@@ -19,6 +19,8 @@ const MODULE_URLS = {
 } as const;
 const STATIC_HOST = "/demo/source-preview.html";
 const CURRENT_DEMO_SEED_VERSION = "2026-07-12.2";
+const GOOGLE_TAG_ORIGIN = "https://www.googletagmanager.com";
+const GOOGLE_TAG_MEASUREMENT_ID = "G-6MJGD17JN0";
 
 function configuredOrigin(baseURL: string | undefined): string {
   if (!baseURL) throw new Error("Demo Playwright baseURL is required.");
@@ -36,7 +38,7 @@ const scenarioTest = test.extend<{ demoNetworkBoundary: void }>({
         if (requestUrl.origin === demoOrigin && requestUrl.pathname === "/api/demo-consent") {
           await route.fulfill({
             contentType: "application/json",
-            body: JSON.stringify({ choice: "granted", version: "v1" }),
+            body: JSON.stringify({ choice: "granted", version: "v2" }),
           });
           return;
         }
@@ -46,6 +48,14 @@ const scenarioTest = test.extend<{ demoNetworkBoundary: void }>({
             requestUrl.pathname === "/api/demo-telemetry")
         ) {
           await route.fulfill({ status: 204, body: "" });
+          return;
+        }
+        if (
+          requestUrl.origin === GOOGLE_TAG_ORIGIN &&
+          requestUrl.pathname === "/gtag/js" &&
+          requestUrl.searchParams.get("id") === GOOGLE_TAG_MEASUREMENT_ID
+        ) {
+          await route.fulfill({ contentType: "application/javascript", body: "" });
           return;
         }
         const forbidden =
@@ -264,11 +274,16 @@ scenarioTest("pipeline demo capability actions stay contained at 320 CSS pixels"
   ).toBeLessThanOrEqual(layout.viewportWidth + 1);
 });
 
-test("consent grant precedes IndexedDB, health, telemetry, and populated demo entry", async ({
+test("consent grant precedes Google Analytics, IndexedDB, health, telemetry, and populated demo entry", async ({
   page,
   context,
 }) => {
   const requests: Array<{ path: string; method: string; body: unknown }> = [];
+  const googleTagRequests: string[] = [];
+  await context.route("**/gtag/js**", async (route) => {
+    googleTagRequests.push(route.request().url());
+    await route.fulfill({ contentType: "application/javascript", body: "" });
+  });
   await context.route("**/api/demo-consent", async (route) => {
     const request = route.request();
     requests.push({
@@ -280,7 +295,7 @@ test("consent grant precedes IndexedDB, health, telemetry, and populated demo en
       contentType: "application/json",
       body: JSON.stringify({
         choice: request.method() === "POST" ? "granted" : "unknown",
-        version: "v1",
+        version: "v2",
       }),
     });
   });
@@ -299,6 +314,7 @@ test("consent grant precedes IndexedDB, health, telemetry, and populated demo en
   await expect(page.getByRole("heading", { name: /Explore JobCtrl/i })).toBeVisible();
   await expect(page.getByText(/demo can only be used after accepting.*analytics cookies/i)).toBeVisible();
   expect(requests.map(({ path }) => path)).toEqual(["/api/demo-consent"]);
+  expect(googleTagRequests).toEqual([]);
   expect(await page.evaluate(async () =>
     (await indexedDB.databases()).some((database) => database.name === "jobctrl-demo"),
   )).toBe(false);
@@ -310,6 +326,8 @@ test("consent grant precedes IndexedDB, health, telemetry, and populated demo en
   )).toBe(true);
   await expect.poll(() => requests.some(({ path }) => path === "/api/demo-health")).toBe(true);
   await expect.poll(() => requests.some(({ path }) => path === "/api/demo-telemetry")).toBe(true);
+  await expect.poll(() => googleTagRequests).toHaveLength(1);
+  expect(new URL(googleTagRequests[0]!).searchParams.get("id")).toBe(GOOGLE_TAG_MEASUREMENT_ID);
 
   const grantIndex = requests.findIndex(({ path, method }) =>
     path === "/api/demo-consent" && method === "POST");
@@ -326,6 +344,11 @@ test("decline stays anonymous and redirects even when consent measurement fails"
   context,
 }) => {
   const requests: Array<{ path: string; body: unknown }> = [];
+  const googleTagRequests: string[] = [];
+  await context.route("**/gtag/js**", (route) => {
+    googleTagRequests.push(route.request().url());
+    return route.abort("blockedbyclient");
+  });
   await context.route("**/api/demo-consent", async (route) => {
     const request = route.request();
     requests.push({
@@ -338,7 +361,7 @@ test("decline stays anonymous and redirects even when consent measurement fails"
     }
     await route.fulfill({
       contentType: "application/json",
-      body: JSON.stringify({ choice: "unknown", version: "v1" }),
+      body: JSON.stringify({ choice: "unknown", version: "v2" }),
     });
   });
   await context.route("https://jobctrl.dev/**", (route) =>
@@ -355,6 +378,7 @@ test("decline stays anonymous and redirects even when consent measurement fails"
     choice: "denied",
     operationKey: expect.stringMatching(/^[A-Za-z0-9_-]{32,128}$/),
   });
+  expect(googleTagRequests).toEqual([]);
   expect(await page.evaluate(async () =>
     (await indexedDB.databases()).some((database) => database.name === "jobctrl-demo"),
   )).toBe(false);
@@ -365,7 +389,7 @@ test("a denied revisit reopens the acceptance-required gate", async ({ page, con
   await context.route("**/api/demo-consent", (route) =>
     route.fulfill({
       contentType: "application/json",
-      body: JSON.stringify({ choice: "denied", version: "v1" }),
+      body: JSON.stringify({ choice: "denied", version: "v2" }),
     }),
   );
   for (const path of ["/api/demo-health", "/api/demo-telemetry"] as const) {
@@ -427,14 +451,14 @@ test("a fresh grant wins over a stale denied consent read", async ({ page, conte
     if (route.request().method() === "POST") {
       await route.fulfill({
         contentType: "application/json",
-        body: JSON.stringify({ choice: "granted", version: "v1" }),
+        body: JSON.stringify({ choice: "granted", version: "v2" }),
       });
       return;
     }
     await stalledRead;
     await route.fulfill({
       contentType: "application/json",
-      body: JSON.stringify({ choice: "denied", version: "v1" }),
+      body: JSON.stringify({ choice: "denied", version: "v2" }),
     });
     confirmReadResponse?.();
   });

--- a/apps/web/src/demo/consent/DemoConsentClient.test.ts
+++ b/apps/web/src/demo/consent/DemoConsentClient.test.ts
@@ -9,10 +9,10 @@ const KEY = "k".repeat(32);
 
 describe("DemoConsentClient", () => {
   it("reads the versioned same-origin consent choice", async () => {
-    const fetcher = vi.fn(async () => json({ choice: "denied", version: "v1" }));
+    const fetcher = vi.fn(async () => json({ choice: "denied", version: "v2" }));
     const client = new DemoConsentClient({ fetcher: fetcher as typeof fetch });
 
-    await expect(client.getChoice()).resolves.toEqual({ choice: "denied", version: "v1" });
+    await expect(client.getChoice()).resolves.toEqual({ choice: "denied", version: "v2" });
     expect(fetcher).toHaveBeenCalledWith("/api/demo-consent", expect.objectContaining({
       method: "GET",
       credentials: "same-origin",
@@ -22,7 +22,7 @@ describe("DemoConsentClient", () => {
   it("retains one operation key across a failed grant retry", async () => {
     const fetcher = vi.fn()
       .mockResolvedValueOnce(new Response(null, { status: 503 }))
-      .mockResolvedValueOnce(json({ choice: "granted", version: "v1" }));
+      .mockResolvedValueOnce(json({ choice: "granted", version: "v2" }));
     const client = new DemoConsentClient({
       fetcher: fetcher as typeof fetch,
       createOperationKey: () => KEY,
@@ -41,7 +41,7 @@ describe("DemoConsentClient", () => {
     const fetcher = vi.fn()
       .mockResolvedValueOnce(new Response(null, { status: 503 }))
       .mockResolvedValueOnce(new Response(null, { status: 204 }))
-      .mockResolvedValueOnce(json({ choice: "granted", version: "v2" }));
+      .mockResolvedValueOnce(json({ choice: "granted", version: "v1" }));
     const client = new DemoConsentClient({
       fetcher: fetcher as typeof fetch,
       createOperationKey: () => KEY,
@@ -71,7 +71,7 @@ describe("DemoConsentClient", () => {
   it("bounds a never-settling grant and retains its operation key for retry", async () => {
     const fetcher = vi.fn()
       .mockImplementationOnce(() => new Promise<Response>(() => undefined))
-      .mockResolvedValueOnce(json({ choice: "granted", version: "v1" }));
+      .mockResolvedValueOnce(json({ choice: "granted", version: "v2" }));
     const client = new DemoConsentClient({
       fetcher: fetcher as typeof fetch,
       createOperationKey: () => KEY,

--- a/apps/web/src/demo/consent/DemoConsentClient.ts
+++ b/apps/web/src/demo/consent/DemoConsentClient.ts
@@ -1,4 +1,4 @@
-export const DEMO_CONSENT_VERSION = "v1" as const;
+export const DEMO_CONSENT_VERSION = "v2" as const;
 export const DEMO_CONSENT_REQUEST_TIMEOUT_MS = 3_000;
 
 export type DemoConsentChoice = "unknown" | "granted" | "denied";

--- a/apps/web/src/demo/consent/DemoConsentGate.test.tsx
+++ b/apps/web/src/demo/consent/DemoConsentGate.test.tsx
@@ -11,7 +11,7 @@ describe("DemoConsentGate", () => {
   it("discloses the hard gate and retries a failed acceptance without entering", async () => {
     const fetcher = vi.fn()
       .mockResolvedValueOnce(new Response(null, { status: 503 }))
-      .mockResolvedValueOnce(json({ choice: "granted", version: "v1" }));
+      .mockResolvedValueOnce(json({ choice: "granted", version: "v2" }));
     const onGranted = vi.fn();
     render(
       <DemoConsentGate
@@ -23,7 +23,8 @@ describe("DemoConsentGate", () => {
     );
     const user = userEvent.setup();
 
-    expect(screen.getByText(/demo can only be used after accepting first-party analytics cookies/i)).toBeVisible();
+    expect(screen.getByText(/demo can only be used after accepting analytics cookies/i)).toBeVisible();
+    expect(screen.getByText(/coarse demo measurement and Google Analytics/i)).toBeVisible();
     expect(screen.getByText(/data controller: eloi barti, acting as an individual/i)).toBeVisible();
     expect(screen.getByRole("link", { name: "me@eloibarti.com" })).toHaveAttribute(
       "href",

--- a/apps/web/src/demo/consent/DemoConsentGate.tsx
+++ b/apps/web/src/demo/consent/DemoConsentGate.tsx
@@ -57,11 +57,12 @@ export function DemoConsentGate({
         <p className="demo-consent-kicker">JobCtrl public demo</p>
         <h1 id="demo-consent-title">Explore JobCtrl with synthetic data</h1>
         <p className="demo-consent-requirement">
-          The live demo can only be used after accepting first-party analytics cookies.
+          The live demo can only be used after accepting analytics cookies.
         </p>
         <p>
-          Acceptance lets us measure coarse routes and demo actions so we can improve the
-          experience. The demo uses synthetic jobs and stays in this browser; do not enter
+          Acceptance enables JobCtrl&apos;s coarse demo measurement and Google Analytics so
+          we can improve the experience. Advertising and personalization signals are
+          disabled. The demo uses synthetic jobs and stays in this browser; do not enter
           personal data, credentials, or secrets.
         </p>
         <p>

--- a/apps/web/src/demo/consent/DemoGoogleAnalytics.test.ts
+++ b/apps/web/src/demo/consent/DemoGoogleAnalytics.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  DEMO_GOOGLE_ANALYTICS_MEASUREMENT_ID,
+  loadDemoGoogleAnalytics,
+} from "./DemoGoogleAnalytics.js";
+
+interface GoogleAnalyticsWindow extends Window {
+  dataLayer?: unknown[][];
+  gtag?: (...command: unknown[]) => void;
+}
+
+const SCRIPT_ID = "jobctrl-google-analytics";
+
+describe("loadDemoGoogleAnalytics", () => {
+  afterEach(() => {
+    document.getElementById(SCRIPT_ID)?.remove();
+    const analyticsWindow = window as GoogleAnalyticsWindow;
+    delete analyticsWindow.dataLayer;
+    delete analyticsWindow.gtag;
+  });
+
+  it("loads the configured Google tag once with ads disabled and bounded cookies", () => {
+    loadDemoGoogleAnalytics();
+    loadDemoGoogleAnalytics();
+
+    const scripts = document.querySelectorAll(`#${SCRIPT_ID}`);
+    expect(scripts).toHaveLength(1);
+    expect(scripts[0]).toHaveAttribute(
+      "src",
+      `https://www.googletagmanager.com/gtag/js?id=${DEMO_GOOGLE_ANALYTICS_MEASUREMENT_ID}`,
+    );
+    expect((scripts[0] as HTMLScriptElement).async).toBe(true);
+
+    const commands = (window as GoogleAnalyticsWindow).dataLayer;
+    expect(commands?.[0]).toEqual([
+      "consent",
+      "default",
+      {
+        analytics_storage: "granted",
+        ad_storage: "denied",
+        ad_user_data: "denied",
+        ad_personalization: "denied",
+      },
+    ]);
+    expect(commands?.[2]).toEqual([
+      "config",
+      DEMO_GOOGLE_ANALYTICS_MEASUREMENT_ID,
+      expect.objectContaining({
+        allow_google_signals: false,
+        allow_ad_personalization_signals: false,
+        anonymize_ip: true,
+        cookie_expires: 15_544_800,
+      }),
+    ]);
+  });
+});

--- a/apps/web/src/demo/consent/DemoGoogleAnalytics.ts
+++ b/apps/web/src/demo/consent/DemoGoogleAnalytics.ts
@@ -1,0 +1,61 @@
+export const DEMO_GOOGLE_ANALYTICS_MEASUREMENT_ID = "G-6MJGD17JN0";
+
+const GOOGLE_TAG_SCRIPT_ID = "jobctrl-google-analytics";
+const GOOGLE_ANALYTICS_COOKIE_MAX_AGE_SECONDS = 15_544_800;
+
+type GoogleTag = (...command: unknown[]) => void;
+
+interface GoogleAnalyticsWindow extends Window {
+  dataLayer?: unknown[][];
+  gtag?: GoogleTag;
+}
+
+interface DemoGoogleAnalyticsOptions {
+  readonly document?: Document;
+  readonly window?: Window;
+}
+
+/** Load GA4 only after the demo consent service has confirmed acceptance. */
+export function loadDemoGoogleAnalytics(
+  options: DemoGoogleAnalyticsOptions = {},
+): void {
+  const documentRef = options.document ?? document;
+  const windowRef = (options.window ?? window) as GoogleAnalyticsWindow;
+  if (documentRef.getElementById(GOOGLE_TAG_SCRIPT_ID)) return;
+
+  try {
+    const dataLayer = windowRef.dataLayer ?? [];
+    windowRef.dataLayer = dataLayer;
+    const googleTag =
+      windowRef.gtag ??
+      ((...command: unknown[]) => {
+        dataLayer.push(command);
+      });
+    windowRef.gtag = googleTag;
+
+    googleTag("consent", "default", {
+      analytics_storage: "granted",
+      ad_storage: "denied",
+      ad_user_data: "denied",
+      ad_personalization: "denied",
+    });
+    googleTag("js", new Date());
+    googleTag("config", DEMO_GOOGLE_ANALYTICS_MEASUREMENT_ID, {
+      allow_google_signals: false,
+      allow_ad_personalization_signals: false,
+      anonymize_ip: true,
+      cookie_domain: windowRef.location.hostname,
+      cookie_expires: GOOGLE_ANALYTICS_COOKIE_MAX_AGE_SECONDS,
+      cookie_flags: "SameSite=Lax;Secure",
+    });
+
+    const script = documentRef.createElement("script");
+    script.id = GOOGLE_TAG_SCRIPT_ID;
+    script.async = true;
+    script.referrerPolicy = "strict-origin-when-cross-origin";
+    script.src = `https://www.googletagmanager.com/gtag/js?id=${encodeURIComponent(DEMO_GOOGLE_ANALYTICS_MEASUREMENT_ID)}`;
+    documentRef.head.append(script);
+  } catch {
+    // Third-party analytics must never block entry to the accepted demo.
+  }
+}

--- a/apps/web/src/demo/consent/index.ts
+++ b/apps/web/src/demo/consent/index.ts
@@ -1,3 +1,4 @@
 export * from "./DemoConsentClient.js";
 export * from "./DemoConsentGate.js";
+export * from "./DemoGoogleAnalytics.js";
 export * from "./DemoTelemetryAdapter.js";

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -7,6 +7,7 @@ import {
   DemoConsentClient,
   DemoConsentGate,
   DemoTelemetryAdapter,
+  loadDemoGoogleAnalytics,
   type DemoConsentChoice,
 } from "./demo/consent/index.js";
 import { createAppComposition, resolveAppMode } from "./demo/portFactory.js";
@@ -89,6 +90,7 @@ function renderConsentGate(client: DemoConsentClient, initialChoice: DemoConsent
 }
 
 function enterDemo(client: DemoConsentClient): Promise<void> {
+  loadDemoGoogleAnalytics();
   demoAdmission ??= mountApplication(client);
   return demoAdmission;
 }

--- a/docs/architecture/observability.md
+++ b/docs/architecture/observability.md
@@ -164,7 +164,10 @@ Both Worker configs disable automatic invocation logs and traces. The Workers
 emit only closed lifecycle fields and never log request bodies, cookies, IPs,
 URLs, user agents, or referrers. Optional product measurement uses the typed,
 consent-gated D1 event contract; non-linkable operational counters and
-consented reports remain separate populations.
+consented reports remain separate populations. After the versioned consent
+service confirms acceptance, the demo also loads GA4 tag `G-6MJGD17JN0` with
+Google Signals, advertising, and personalization disabled. The Google tag is a
+separate third-party measurement boundary and is never loaded before consent.
 
 ## Out of Scope
 

--- a/docs/user/data-and-safety.md
+++ b/docs/user/data-and-safety.md
@@ -36,28 +36,38 @@ models, and live apply contacts an employer only when you use those features.
 ## Public Demo
 
 The hosted synthetic demo is separate from the local product described above.
-It can only be used after accepting first-party analytics cookies. Declining
-returns to `https://jobctrl.dev`; opening the demo again shows the choice again.
-The demo does not initialize its browser-local workspace until the consent
-service confirms acceptance.
+It can only be used after accepting analytics cookies for JobCtrl's bounded
+first-party demo measurement and Google Analytics. Declining returns to
+`https://jobctrl.dev`; opening the demo again shows the choice again. The demo
+does not initialize its browser-local workspace or load the Google tag until
+the consent service confirms acceptance. The `v2` consent contract replaces the
+earlier first-party-only choice, so existing visitors are asked again once.
 
 The data controller for the public demo is Eloi Barti, acting as an individual.
 For privacy questions, contact [me@eloibarti.com](mailto:me@eloibarti.com).
 
 After acceptance, Cloudflare sets a versioned consent cookie plus random
-HttpOnly visitor and session identifiers. The persistent cookies expire within
-six months, the session cookie at the end of the browser session, and raw demo
-events and non-linkable operational counters expire within 90 days. Events use
-closed route/action/result categories: they exclude names, contact details,
-profile or resume text, job/company content, URLs, searches, comments, local
-paths, raw errors, and demo entity/workspace identifiers. IP addresses may be
-used transiently by Cloudflare rate limiting but are not written to D1 or
-application logs.
+HttpOnly visitor and session identifiers. JobCtrl's persistent cookies expire
+within six months, the session cookie at the end of the browser session, and raw
+demo events and non-linkable operational counters expire within 90 days. Those
+first-party events use closed route/action/result categories: they exclude
+names, contact details, profile or resume text, job/company content, URLs,
+searches, comments, local paths, raw errors, and demo entity/workspace
+identifiers. IP addresses may be used transiently by Cloudflare rate limiting
+but are not written to D1 or application logs.
+
+The accepted page also loads Google tag `G-6MJGD17JN0`. Google Analytics may set
+`_ga` cookies scoped to the demo host for up to six months and receive standard
+web-measurement data such as page location, referrer, browser/device details,
+interaction data, and an IP address used for geolocation before it is discarded.
+JobCtrl disables Google Signals plus advertising and personalization signals in
+the tag configuration. Google's handling of that data is described in
+[Safeguarding your data](https://support.google.com/analytics/answer/6004245).
 
 The demo contains synthetic data. Do not enter personal data, credentials, or
 secrets. Post-accept withdrawal and immediate visitor-event deletion are not
-yet available in this MVP; retained data expires on the schedules above. The
-consent screen links to this disclosure before entry.
+yet available in this MVP; retained data and cookies expire on the schedules
+above. The consent screen links to this disclosure before entry.
 
 After entry, the compact **Demo guide** links to seeded scoring evidence,
 tailored-material review, Apply Review/dry-run, and run history. Every shortcut

--- a/docs/user/security.md
+++ b/docs/user/security.md
@@ -43,8 +43,9 @@ The hosted public demo uses synthetic data in a browser-local workspace. Its
 shortcuts and actions are simulations: they do not contact employers, send
 messages, or make external changes.
 
-For the demo's first-party cookie consent, retention, data-controller identity,
-and privacy contact, read the canonical [Public Demo data notice](data-and-safety.md#public-demo).
+For the demo's analytics-cookie consent, Google Analytics scope, retention,
+data-controller identity, and privacy contact, read the canonical
+[Public Demo data notice](data-and-safety.md#public-demo).
 
 ## What Leaves Your Machine
 

--- a/scripts/demo-smoke.mjs
+++ b/scripts/demo-smoke.mjs
@@ -126,7 +126,7 @@ async function runDemoSmoke() {
       "sec-fetch-site": "same-origin",
     },
   });
-  assert.deepEqual(await initial.json(), { choice: "unknown", version: "v1" });
+  assert.deepEqual(await initial.json(), { choice: "unknown", version: "v2" });
 
   const operationKey = () => randomBytes(24).toString("base64url");
   const choose = (choice) => request("/api/demo-consent", {
@@ -141,16 +141,16 @@ async function runDemoSmoke() {
   });
 
   const denied = await choose("denied");
-  assert.deepEqual(await denied.json(), { choice: "denied", version: "v1" });
+  assert.deepEqual(await denied.json(), { choice: "denied", version: "v2" });
   const deniedCookies = denied.headers.get("set-cookie") ?? "";
-  assert.match(deniedCookies, /__Host-jobctrl_demo_consent=v1\.denied/);
+  assert.match(deniedCookies, /__Host-jobctrl_demo_consent=v2\.denied/);
   assert.doesNotMatch(deniedCookies, /__Host-jobctrl_demo_(?:vid|session)=/);
 
   const granted = await choose("granted");
-  assert.deepEqual(await granted.json(), { choice: "granted", version: "v1" });
+  assert.deepEqual(await granted.json(), { choice: "granted", version: "v2" });
   const grantedCookies = granted.headers.get("set-cookie") ?? "";
   for (const cookie of [
-    "__Host-jobctrl_demo_consent=v1.granted",
+    "__Host-jobctrl_demo_consent=v2.granted",
     "__Host-jobctrl_demo_vid=",
     "__Host-jobctrl_demo_session=",
   ]) {


### PR DESCRIPTION
## What changed

- load Google tag `G-6MJGD17JN0` only after the demo consent service confirms acceptance
- keep advertising, personalization, and Google Signals disabled and cap GA cookies at six months
- version the consent contract from `v1` to `v2` so prior first-party-only grants are not silently reused
- update the public consent copy, privacy notice, security documentation, and demo smoke contract
- add unit and Chromium regression coverage for accept and decline paths

## Why

The public demo had first-party, consent-gated telemetry but no Google Analytics integration. The existing consent wording covered only first-party measurement, so enabling GA requires an explicit revised consent contract.

## Validation

- `corepack pnpm --filter @jobctrl/web exec vitest run src/demo/consent/DemoGoogleAnalytics.test.ts src/demo/consent/DemoConsentClient.test.ts src/demo/consent/DemoConsentGate.test.tsx`
- `corepack pnpm web:check`
- `corepack pnpm demo:build`
- `corepack pnpm demo-edge:check`
- `corepack pnpm demo-edge:test`
- focused Playwright accept-path test: tag absent before consent and loaded once after acceptance
- focused Playwright decline-path test: tag remains unloaded
- `corepack pnpm docs:build`
- `git diff --check`
