### PR TITLE
fix(release): harden v2.0.4 publication

### DIFF
--- a/.github/workflows/release-distribution.yml
+++ b/.github/workflows/release-distribution.yml
@@ -6,11 +6,11 @@ name: Release distribution
 # channel pointer. Immutable GitHub publication gates the final stable-only
 # PyPI publication lane.
 on:
-  # v2.0.3 is the one-time first-public-release fallback for environments where
+  # v2.0.4 is the one-time first-public-release fallback for environments where
   # the repository app can publish refs but cannot call workflow_dispatch.
   push:
     tags:
-      - v2.0.3
+      - v2.0.4
   workflow_dispatch:
     inputs:
       release_tag:
@@ -634,6 +634,26 @@ jobs:
           [[ "$R2_BUCKET" =~ ^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$ ]]
           r2_endpoint="https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com"
           release="$RUNNER_TEMP/release"
+          verify_public_immutable() {
+            local destination="$1" expected="$2" existing="$3" actual status
+            for attempt in {1..24}; do
+              status="$(curl --silent --show-error --output "$existing" --write-out '%{http_code}' --proto '=https' --tlsv1.2 "https://releases.jobctrl.dev/$destination" || true)"
+              if [[ "$status" = 200 ]]; then
+                actual="$(shasum -a 256 "$existing" | awk '{print $1}')"
+                test "$actual" = "$expected"
+                return
+              fi
+              if [[ "$status" != 404 ]]; then
+                echo "failed to read immutable release path $destination (HTTP $status)" >&2
+                exit 1
+              fi
+              if [[ "$attempt" -lt 24 ]]; then
+                sleep 5
+              fi
+            done
+            echo "immutable release path $destination did not become public after upload" >&2
+            exit 1
+          }
           upload_immutable() {
             local source="$1" destination="$2" expected actual existing status
             expected="$(shasum -a 256 "$source" | awk '{print $1}')"
@@ -655,12 +675,9 @@ jobs:
               --body "$source" \
               --if-none-match '*' \
               --no-cli-pager >/dev/null; then
-              actual="$(curl --fail --silent --show-error --proto '=https' --tlsv1.2 "https://releases.jobctrl.dev/$destination" | shasum -a 256 | awk '{print $1}')"
-              test "$actual" = "$expected"
-              return
+              echo "immutable object creation did not complete; checking for a concurrent or delayed public object" >&2
             fi
-            actual="$(curl --fail --silent --show-error --proto '=https' --tlsv1.2 "https://releases.jobctrl.dev/$destination" | shasum -a 256 | awk '{print $1}')"
-            test "$actual" = "$expected"
+            verify_public_immutable "$destination" "$expected" "$existing"
           }
           build_id="$(jq -r '.buildId' "$release/release-metadata.json")"
           archive="$(jq -r '.archive.file' "$release/release-metadata.json")"
@@ -760,11 +777,21 @@ jobs:
         run: |
           set -euo pipefail
           release="$RUNNER_TEMP/release"
+          tap_name="jobctrl/release-smoke-${GITHUB_RUN_ID}"
+          brew tap-new --no-git "$tap_name"
+          tap_repo="$(brew --repository "$tap_name")"
+          install -m 0644 "$release/jobctrl.rb" "$tap_repo/Formula/jobctrl.rb"
+          formula="$tap_name/jobctrl"
           formula_bin="$(brew --prefix)/bin/jobctrl"
-          trap '"$formula_bin" stop >/dev/null 2>&1 || true; brew uninstall --formula jobctrl >/dev/null 2>&1 || true' EXIT
-          brew audit --strict --formula "$release/jobctrl.rb"
-          brew install --formula "$release/jobctrl.rb"
-          brew test jobctrl
+          cleanup() {
+            "$formula_bin" stop >/dev/null 2>&1 || true
+            brew uninstall --formula "$formula" >/dev/null 2>&1 || true
+            brew untap "$tap_name" >/dev/null 2>&1 || true
+          }
+          trap cleanup EXIT
+          brew audit --strict --formula "$formula"
+          brew install --formula "$formula"
+          brew test "$formula"
           "$formula_bin" start --no-open
           status="$("$formula_bin" status --json)"
           STATUS="$status" node -e 'const status=JSON.parse(process.env.STATUS); if (status.status !== "running" || !["temporal", "worker", "api"].every((name) => status.components?.[name]?.state === "running")) process.exit(1)'

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jobctrl/api",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jobctrl/extension",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/extension/public/manifest.json
+++ b/apps/extension/public/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "JobCtrl",
   "description": "Save job postings from the browser into the local JobCtrl app.",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "action": {
     "default_popup": "popup.html"
   },

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jobctrl/web",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/docs/publish-checklist.md
+++ b/docs/publish-checklist.md
@@ -258,8 +258,8 @@ especially §§11–14. This is a release precondition, not permission to publis
   plus its QA/deploy evidence, and every protected release environment in 9.4a
   is configured. The PyPI Trusted Publisher is already configured; verify its
   mapping rather than creating a second publisher or using a PyPI API token.
-- **Recovery note.** Preserve the failed `v2.0.0` and `v2.0.1` tags, plus the
-  unpublished `v2.0.2` tag, at their
+- **Recovery note.** Preserve the failed `v2.0.0` and `v2.0.1` tags, the
+  unpublished `v2.0.2` tag, and the partially published `v2.0.3` tag at their
   original commits as audit evidence. `v2.0.0` stopped before signing because
   the signing runner requested an unavailable Python build. `v2.0.1` completed
   its builds, signing, Apple notarization, stapling, and audit packaging, then
@@ -267,14 +267,20 @@ especially §§11–14. This is a release precondition, not permission to publis
   publication job did not bind GitHub CLI to the repository. Do not move,
   delete, or dispatch any of those tags again. `v2.0.2` was tagged after the
   publication fix merged, but no release workflow was started for it.
+  `v2.0.3` completed signing, Apple notarization, stapling, audit packaging,
+  draft creation, and immutable R2 upload. It did not promote the stable
+  pointer or publish the GitHub Release, Homebrew formula, or PyPI package
+  because the current Homebrew CLI rejects auditing a formula by file path.
+  Its immutable objects and draft are recovery evidence, not a stable release.
+  Do not move, delete, or dispatch any of these tags again.
 - **Action.** Fetch `origin/main` and tags, verify that the audited local commit
   and `origin/main` resolve to the same SHA, then create and push the exact
-  `v2.0.3` tag on that commit. Verify the remote tag and `main` still resolve to
+  `v2.0.4` tag on that commit. Verify the remote tag and `main` still resolve to
   that SHA. Pushing this exact tag starts `Release distribution` with these
   first-release defaults; the manual dispatch path remains available:
 
   ```text
-  release_tag=v2.0.3
+  release_tag=v2.0.4
   channel=stable
   sequence=1
   minimum_safe_sequence=1
@@ -371,7 +377,7 @@ Phase 7 and its Definition of Done.
   `renderPinnedInstallScript` regression fix. Its contract must replace an
   existing release's URL, SHA-256, and version pins with the next release's
   values, not only replace empty pins; its regression coverage must prove a
-  `v2.0.3` render cannot retain `v2.0.2` pins. Do not use a manually edited
+  `v2.0.4` render cannot retain `v2.0.3` pins. Do not use a manually edited
   installer as a workaround.
 - **Action.** Run and record the plan's published-artifact acceptance matrix:
   clean Apple-silicon macOS installs through both curl and Homebrew; no source
@@ -385,7 +391,7 @@ Phase 7 and its Definition of Done.
 - **Mandatory canonical-installer cutover.** Treat the immutable signed release
   and the public installer deployment as two linked but different records:
 
-  1. Record the immutable `v2.0.3` tag/release SHA and tree as **R**. Retrieve
+  1. Record the immutable `v2.0.4` tag/release SHA and tree as **R**. Retrieve
      that release's immutable pinned `install.sh` and `SHA256SUMS`, verify
      `install.sh` against its published SHA-256, and retain the verified asset
      URL and checksum with R. Do not reconstruct or edit the retrieved script.
@@ -541,7 +547,7 @@ Perform the following in order and stop at the first failed gate:
    after the exact-tree local gate passes.
 2. Rerun the standard hosted workflows on the recorded SHA and require green
    runs with executed steps.
-3. On that final validated `main` SHA, create and push `v2.0.3`, verify the
+3. On that final validated `main` SHA, create and push `v2.0.4`, verify the
    remote tag and `origin/main` resolve to that same SHA, and confirm the exact
    tag-triggered `Release distribution` run uses the six first-release defaults
    in 9.4. Complete the signed release, channel-pointer promotion, PyPI
@@ -602,7 +608,7 @@ rollback evidence, and publish corrections where a public claim proved wrong.
 | 9.1 Visibility flip | Owner | Run the exact-tree local gate, make the repository public, then rerun every standard hosted gate with real executed steps. |
 | 9.2 Docs-site verification | Owner | Docs are already public and deploy is enabled; dispatch at the gated `main` SHA and record the public deployment proof. |
 | 9.3 Rename redirect | Owner | Verify old-URL redirects after the flip and repair any stale repository links. |
-| 9.4 Release and PyPI | Owner | Preserve `v2.0.0`, `v2.0.1`, and unpublished `v2.0.2`; create `v2.0.3` on audited `main`, then verify the exact tag-triggered run uses the recorded first-release defaults and completes the signed release. |
+| 9.4 Release and PyPI | Owner | Preserve `v2.0.0`, `v2.0.1`, unpublished `v2.0.2`, and partial `v2.0.3`; create `v2.0.4` on audited `main`, then verify the exact tag-triggered run uses the recorded first-release defaults and completes the signed release. |
 | 9.5 Homebrew tap | Signed workflow | Replace the legacy formula only with the verified signed render after release-origin smoke passes. |
 | 9.6 Installer and artifact acceptance | Owner | Verify immutable `install.sh` from R, land matching `scripts/get` and `docs/public/install.sh` in a separate post-release PR, validate/deploy D, then run public curl/Homebrew smoke. |
 | 9.7 Public live demo | Owner | The demo is already public and deploy is enabled; verify the audited deployment externally and record its release evidence. |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jobctrl",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "private": true,
   "description": "AI-powered end-to-end job application pipeline",
   "type": "module",

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jobctrl/api-client",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jobctrl/contracts",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/domain-types/package.json
+++ b/packages/domain-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jobctrl/domain-types",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jobctrl/tsconfig",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "private": true,
   "type": "module",
   "exports": {

--- a/scripts/distribution-manifest.test.mjs
+++ b/scripts/distribution-manifest.test.mjs
@@ -97,7 +97,7 @@ test("distribution contracts are complete and every version source resolves", as
   assert.equal(report.nodeLicenseEvidenceCount, 13);
   assert.equal(report.capabilityCount, 3);
   assert.deepEqual(report.platforms, ["darwin-arm64"]);
-  assert.equal(report.versions["jobctrl-launcher"], "2.0.3");
+  assert.equal(report.versions["jobctrl-launcher"], "2.0.4");
   assert.equal(report.versions["playwright-python"], "1.58.0");
   assert.equal(report.versions["font-geist"], "5.2.9");
   assert.equal(report.versions["font-jetbrains-mono"], "5.2.8");

--- a/scripts/distribution-release.test.mjs
+++ b/scripts/distribution-release.test.mjs
@@ -298,10 +298,10 @@ test("local fixture release descriptor, signature, and curl contract bind one ZI
     minimumSafeSequence: 0,
     revokedBuildIds: [],
     buildId: "fixture-build-0001",
-    appVersion: "2.0.3",
+    appVersion: "2.0.4",
     platform: { id: "darwin-arm64", os: "darwin", arch: "arm64" },
     artifact: {
-      url: "file:///jobctrl-local-release/jobctrl-2.0.3-darwin-arm64.zip",
+      url: "file:///jobctrl-local-release/jobctrl-2.0.4-darwin-arm64.zip",
       sha256: build.archiveSha256,
       sizeBytes: build.compressedBytes,
       archiveType: "zip",
@@ -761,7 +761,7 @@ test("release workflows use protected manual signing, artifact handoff, candidat
     /ENOENT/,
   );
   assert.match(releaseWorkflow, /workflow_dispatch:/);
-  assert.match(releaseWorkflow, /^  push:\n    tags:\n      - v2\.0\.3$/m);
+  assert.match(releaseWorkflow, /^  push:\n    tags:\n      - v2\.0\.4$/m);
   assert.match(releaseWorkflow, /\$\{\{ inputs\.release_tag \|\| github\.ref_name \}\}/);
   assert.match(releaseWorkflow, /\$\{\{ inputs\.channel \|\| 'stable' \}\}/);
   assert.match(releaseWorkflow, /\$\{\{ inputs\.sequence \|\| '1' \}\}/);
@@ -793,8 +793,18 @@ test("release workflows use protected manual signing, artifact handoff, candidat
     "JOBCTRL_R2_BUCKET",
     "channel-promotion-evidence.json",
     "immutableDescriptorUrl",
-    "brew audit --strict --formula \"$release/jobctrl.rb\"",
+    "tap_name=\"jobctrl/release-smoke-${GITHUB_RUN_ID}\"",
+    "brew tap-new --no-git \"$tap_name\"",
+    "install -m 0644 \"$release/jobctrl.rb\" \"$tap_repo/Formula/jobctrl.rb\"",
+    "formula=\"$tap_name/jobctrl\"",
+    "brew audit --strict --formula \"$formula\"",
+    "brew install --formula \"$formula\"",
+    "brew test \"$formula\"",
+    "for attempt in {1..24}",
+    "sleep 5",
   ]) assert.ok(releaseWorkflow.includes(marker), `missing release workflow marker ${marker}`);
+  assert.doesNotMatch(releaseWorkflow, /brew audit --strict --formula \"\$release\/jobctrl\.rb\"/);
+  assert.doesNotMatch(releaseWorkflow, /brew install --formula \"\$release\/jobctrl\.rb\"/);
   for (const removedJob of ["prepare-a", "prepare-b", "pypi-build-a", "pypi-build-b", "pypi-compare"]) {
     assert.doesNotMatch(releaseWorkflow, new RegExp(`^  ${removedJob}:`, "m"));
   }

--- a/scripts/release_check.py
+++ b/scripts/release_check.py
@@ -1087,8 +1087,14 @@ def _release_distribution_findings(root: Path) -> list[str]:
         "gh release verify-asset": "does not compare post-lock release assets to local trusted bytes",
         "gh release verify \"$RELEASE_TAG\"": "does not verify the immutable release attestation",
         "uses: ./.github/workflows/sync-homebrew-tap.yml": "does not call the artifact-only Homebrew promotion workflow",
-        "brew audit --strict --formula \"$release/jobctrl.rb\"": "does not audit the rendered Homebrew formula before tap credentials are used",
-        "brew test jobctrl": "does not run the rendered Homebrew formula test before tap credentials are used",
+        "tap_name=\"jobctrl/release-smoke-${GITHUB_RUN_ID}\"": "does not isolate the temporary verification tap by release run",
+        "brew tap-new --no-git \"$tap_name\"": "does not create an isolated temporary tap for formula verification without CI Git side effects",
+        "install -m 0644 \"$release/jobctrl.rb\" \"$tap_repo/Formula/jobctrl.rb\"": "does not install the signed render into the isolated verification tap",
+        "formula=\"$tap_name/jobctrl\"": "does not address the rendered formula through its temporary tap name",
+        "brew audit --strict --formula \"$formula\"": "does not audit the rendered Homebrew formula by its supported formula name before tap credentials are used",
+        "brew test \"$formula\"": "does not run the rendered Homebrew formula test before tap credentials are used",
+        "for attempt in {1..24}": "does not bound retries while waiting for immutable R2 objects to become public",
+        "sleep 5": "does not wait for immutable R2 public propagation before verification",
     }
     findings = [
         f"{RELEASE_DISTRIBUTION_WORKFLOW_PATH}: {message}"

--- a/workers/automation/pyproject.toml
+++ b/workers/automation/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jobctrl"
-version = "2.0.3"
+version = "2.0.4"
 description = "AI-powered end-to-end job application pipeline"
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/workers/automation/src/jobctrl/__init__.py
+++ b/workers/automation/src/jobctrl/__init__.py
@@ -1,3 +1,3 @@
 """JobCtrl — AI-powered end-to-end job application pipeline."""
 
-__version__ = "2.0.3"
+__version__ = "2.0.4"

--- a/workers/automation/uv.lock
+++ b/workers/automation/uv.lock
@@ -586,7 +586,7 @@ wheels = [
 
 [[package]]
 name = "jobctrl"
-version = "2.0.3"
+version = "2.0.4"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## What changed

- bump the release identity and exact tag fallback to v2.0.4
- audit, install, and test the rendered Homebrew formula by qualified name through an isolated per-run temporary tap
- retry checksum-verified public reads after immutable R2 uploads to tolerate bounded CDN propagation delay
- add regression coverage for both release failures and update the release recovery record

## Why

The v2.0.3 release completed signing, notarization, stapling, audit packaging, draft creation, and immutable R2 upload, but stopped before stable promotion. The current Homebrew CLI rejects auditing a formula by file path, and the first immutable R2 read can briefly return 404 after a successful upload.

v2.0.3 remains untouched as partial release evidence. v2.0.4 is the next release candidate.

## Validation

- `node --test scripts/distribution-release.test.mjs scripts/distribution-manifest.test.mjs` — 42 passed
- focused Python release-policy tests — 52 passed
- strict release/privacy check for `v2.0.4` — passed
- Python lock check — passed
- provider lock, distribution manifest, and distribution build audits — passed
- exact wheel and sdist build — passed
- workflow YAML parse and `git diff --check` — passed
- docs build, link check, and redirect check — passed (8,239 references)
