### PR TITLE
fix(demo): allow consented Google Analytics traffic

### DIFF
--- a/apps/web/public/_headers
+++ b/apps/web/public/_headers
@@ -1,6 +1,6 @@
 /*
   Cache-Control: no-transform
-  Content-Security-Policy: default-src 'self'; base-uri 'none'; connect-src 'self'; font-src 'self' data:; form-action 'self'; frame-ancestors 'none'; frame-src 'self' blob:; img-src 'self' data: blob:; manifest-src 'self'; object-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; worker-src 'self' blob:; upgrade-insecure-requests
+  Content-Security-Policy: default-src 'self'; base-uri 'none'; connect-src 'self' https://*.google-analytics.com; font-src 'self' data:; form-action 'self'; frame-ancestors 'none'; frame-src 'self' blob:; img-src 'self' data: blob: https://*.google-analytics.com; manifest-src 'self'; object-src 'none'; script-src 'self' https://www.googletagmanager.com; style-src 'self' 'unsafe-inline'; worker-src 'self' blob:; upgrade-insecure-requests
   Cross-Origin-Opener-Policy: same-origin
   Cross-Origin-Resource-Policy: same-origin
   Origin-Agent-Cluster: ?1

--- a/scripts/demo-deployment.test.mjs
+++ b/scripts/demo-deployment.test.mjs
@@ -24,9 +24,11 @@ test("demo build and Pages files select the fail-closed demo composition", async
   assert.match(headers, /\/\*\n  Cache-Control: no-transform/);
   for (const required of [
     "Content-Security-Policy: default-src 'self'",
-    "connect-src 'self'",
+    "connect-src 'self' https://*.google-analytics.com",
     "frame-ancestors 'none'",
+    "img-src 'self' data: blob: https://*.google-analytics.com",
     "Referrer-Policy: no-referrer",
+    "script-src 'self' https://www.googletagmanager.com",
     "X-Content-Type-Options: nosniff",
   ]) {
     assert.match(headers, new RegExp(required.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));

--- a/scripts/demo-smoke.mjs
+++ b/scripts/demo-smoke.mjs
@@ -11,6 +11,9 @@ export const DEMO_SHELL_READY_WINDOW_MS = 5 * 60_000;
 export const DEMO_SHELL_READY_DELAY_MS = 3_000;
 export const DEMO_SHELL_READY_ATTEMPTS = DEMO_SHELL_READY_WINDOW_MS / DEMO_SHELL_READY_DELAY_MS + 1;
 export const DEMO_SHELL_REQUEST_TIMEOUT_MS = 15_000;
+export const DEMO_CONSENT_READY_WINDOW_MS = 60_000;
+export const DEMO_CONSENT_READY_DELAY_MS = 3_000;
+export const DEMO_CONSENT_READY_ATTEMPTS = DEMO_CONSENT_READY_WINDOW_MS / DEMO_CONSENT_READY_DELAY_MS + 1;
 const SYNTHETIC_HTML_ASSETS = [
   "/demo/application-preview.html",
   "/demo/profile-resume.html",
@@ -88,6 +91,58 @@ export async function waitForDemoShell(
   );
 }
 
+export async function waitForDemoConsentContract(
+  fetchConsent,
+  {
+    expectedVersion = "v2",
+    attempts = DEMO_CONSENT_READY_ATTEMPTS,
+    timeoutMs = DEMO_CONSENT_READY_WINDOW_MS,
+    delayMs = DEMO_CONSENT_READY_DELAY_MS,
+    requestTimeoutMs = DEMO_SHELL_REQUEST_TIMEOUT_MS,
+    sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+    now = Date.now,
+    createAbortSignal = (timeout) => AbortSignal.timeout(timeout),
+    log = console.warn,
+  } = {},
+) {
+  const startedAt = now();
+  const deadlineAt = startedAt + timeoutMs;
+  let lastObservation = "unknown";
+
+  for (let attempt = 1; attempt <= attempts && now() < deadlineAt; attempt += 1) {
+    const remainingBeforeRequestMs = deadlineAt - now();
+    const signal = createAbortSignal(Math.min(requestTimeoutMs, remainingBeforeRequestMs));
+
+    try {
+      const response = await fetchConsent({ signal });
+      if (response.ok) {
+        const state = await response.json();
+        if (state?.choice === "unknown" && state?.version === expectedVersion) return state;
+        lastObservation = `choice=${state?.choice ?? "invalid"}, version=${state?.version ?? "invalid"}`;
+      } else {
+        lastObservation = `status=${response.status}`;
+        await response.body?.cancel?.();
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      lastObservation = `request error: ${message}`;
+    }
+
+    const remainingBeforeRetryMs = deadlineAt - now();
+    if (attempt < attempts && remainingBeforeRetryMs > 0) {
+      log(
+        `Demo consent contract is not ready (attempt ${attempt}/${attempts}; ${Math.ceil(remainingBeforeRetryMs / 1_000)}s remaining): ${lastObservation}`,
+      );
+      await sleep(Math.min(delayMs, remainingBeforeRetryMs));
+    }
+  }
+
+  const elapsedMs = Math.max(0, now() - startedAt);
+  assert.fail(
+    `demo consent contract ${expectedVersion} was not ready within ${timeoutMs}ms after ${elapsedMs}ms: ${lastObservation}`,
+  );
+}
+
 async function runDemoSmoke() {
   const baseUrl = new URL(process.env.DEMO_BASE_URL ?? process.argv[2] ?? "");
   assert.equal(baseUrl.protocol, "https:", "DEMO_BASE_URL must use HTTPS");
@@ -108,7 +163,11 @@ async function runDemoSmoke() {
   const shellHtml = await shell.text();
   assert.match(shellHtml, /<div id="root"><\/div>/);
   assertNoCloudflareInjection("/", shellHtml);
-  assert.match(shell.headers.get("content-security-policy") ?? "", /default-src 'self'/);
+  const contentSecurityPolicy = shell.headers.get("content-security-policy") ?? "";
+  assert.match(contentSecurityPolicy, /default-src 'self'/);
+  assert.match(contentSecurityPolicy, /connect-src 'self' https:\/\/\*\.google-analytics\.com/);
+  assert.match(contentSecurityPolicy, /img-src 'self' data: blob: https:\/\/\*\.google-analytics\.com/);
+  assert.match(contentSecurityPolicy, /script-src 'self' https:\/\/www\.googletagmanager\.com/);
   assert.equal(shell.headers.get("referrer-policy"), "no-referrer");
   assert.equal(shell.headers.get("x-content-type-options"), "nosniff");
 
@@ -119,14 +178,16 @@ async function runDemoSmoke() {
 
   await assertSyntheticHtmlAssetsAreClean(request);
 
-  const initial = await request("/api/demo-consent", {
-    headers: {
-      accept: "application/json",
-      origin: baseUrl.origin,
-      "sec-fetch-site": "same-origin",
-    },
-  });
-  assert.deepEqual(await initial.json(), { choice: "unknown", version: "v2" });
+  const initialState = await waitForDemoConsentContract(({ signal }) =>
+    fetchPath("/api/demo-consent", {
+      signal,
+      headers: {
+        accept: "application/json",
+        origin: baseUrl.origin,
+        "sec-fetch-site": "same-origin",
+      },
+    }));
+  assert.deepEqual(initialState, { choice: "unknown", version: "v2" });
 
   const operationKey = () => randomBytes(24).toString("base64url");
   const choose = (choice) => request("/api/demo-consent", {

--- a/scripts/demo-smoke.test.mjs
+++ b/scripts/demo-smoke.test.mjs
@@ -8,8 +8,38 @@ import {
   DEMO_SHELL_READY_DELAY_MS,
   DEMO_SHELL_REQUEST_TIMEOUT_MS,
   DEMO_SHELL_READY_WINDOW_MS,
+  DEMO_CONSENT_READY_DELAY_MS,
+  waitForDemoConsentContract,
   waitForDemoShell,
 } from "./demo-smoke.mjs";
+
+test("demo smoke waits for the deployed consent contract to replace the previous version", async () => {
+  const states = [
+    { choice: "unknown", version: "v1" },
+    { choice: "unknown", version: "v2" },
+  ];
+  const delays = [];
+  let elapsedMs = 0;
+
+  const state = await waitForDemoConsentContract(
+    async () => ({
+      ok: true,
+      json: async () => states.shift(),
+    }),
+    {
+      sleep: async (delayMs) => {
+        delays.push(delayMs);
+        elapsedMs += delayMs;
+      },
+      now: () => elapsedMs,
+      createAbortSignal: () => new AbortController().signal,
+      log: () => {},
+    },
+  );
+
+  assert.deepEqual(state, { choice: "unknown", version: "v2" });
+  assert.deepEqual(delays, [DEMO_CONSENT_READY_DELAY_MS]);
+});
 
 test("demo smoke waits through custom-domain propagation longer than the former 90-second window", async () => {
   const statuses = [...Array.from({ length: 32 }, () => 403), 200];


### PR DESCRIPTION
## What changed

- allow the Google tag script and GA collection endpoints in the production demo CSP
- keep the allowlist narrow to `www.googletagmanager.com` and `*.google-analytics.com`
- make the production smoke verify the deployed CSP
- poll for consent-contract propagation so a freshly deployed Worker cannot fail the smoke by briefly serving the prior contract version

## Why

The GA4 integration merged in #497 loaded only after consent, but the existing production CSP blocked the external script and collection request. The first post-merge smoke also raced Cloudflare Worker propagation: deployment succeeded, but the one-shot assertion briefly observed `v1` before `v2` converged.

## Validation

- `node --test scripts/demo-deployment.test.mjs scripts/demo-smoke.test.mjs` — 11 passed
- `node --check scripts/demo-smoke.mjs`
- `corepack pnpm demo:build`
- `git diff --check`
- full `corepack pnpm scripts:test`: 125/127 passed; the two unrelated screenshot-workspace containment tests fail only because this isolated checkout itself lives under `/private/tmp`
