### PR TITLE
fix(demo): wait for Pages policy propagation

### DIFF
--- a/scripts/demo-smoke.mjs
+++ b/scripts/demo-smoke.mjs
@@ -14,6 +14,11 @@ export const DEMO_SHELL_REQUEST_TIMEOUT_MS = 15_000;
 export const DEMO_CONSENT_READY_WINDOW_MS = 60_000;
 export const DEMO_CONSENT_READY_DELAY_MS = 3_000;
 export const DEMO_CONSENT_READY_ATTEMPTS = DEMO_CONSENT_READY_WINDOW_MS / DEMO_CONSENT_READY_DELAY_MS + 1;
+const GOOGLE_ANALYTICS_CSP = {
+  connect: "connect-src 'self' https://*.google-analytics.com",
+  image: "img-src 'self' data: blob: https://*.google-analytics.com",
+  script: "script-src 'self' https://www.googletagmanager.com",
+};
 const SYNTHETIC_HTML_ASSETS = [
   "/demo/application-preview.html",
   "/demo/profile-resume.html",
@@ -46,6 +51,7 @@ export async function waitForDemoShell(
     sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
     now = Date.now,
     createAbortSignal = (timeout) => AbortSignal.timeout(timeout),
+    isReady = (response) => response.ok,
     log = console.warn,
   } = {},
 ) {
@@ -60,11 +66,11 @@ export async function waitForDemoShell(
 
     try {
       const response = await fetchShell({ signal });
-      if (response.ok) {
+      if (response.ok && isReady(response)) {
         return response;
       }
 
-      lastStatus = response.status;
+      lastStatus = response.ok ? `${response.status} (deployment marker pending)` : response.status;
       observedStatuses.set(lastStatus, (observedStatuses.get(lastStatus) ?? 0) + 1);
       await response.body?.cancel?.();
     } catch (error) {
@@ -89,6 +95,11 @@ export async function waitForDemoShell(
   assert.fail(
     `demo shell was not ready within ${timeoutMs}ms after ${elapsedMs}ms: / last observation ${lastStatus}; observed statuses: ${observedSummary || "none"}`,
   );
+}
+
+export function hasGoogleAnalyticsCsp(response) {
+  const policy = response.headers.get("content-security-policy") ?? "";
+  return Object.values(GOOGLE_ANALYTICS_CSP).every((directive) => policy.includes(directive));
 }
 
 export async function waitForDemoConsentContract(
@@ -159,15 +170,18 @@ async function runDemoSmoke() {
     return response;
   };
 
-  const shell = await waitForDemoShell(({ signal }) => fetchPath("/", { signal }));
+  const shell = await waitForDemoShell(
+    ({ signal }) => fetchPath("/", { signal }),
+    { isReady: hasGoogleAnalyticsCsp },
+  );
   const shellHtml = await shell.text();
   assert.match(shellHtml, /<div id="root"><\/div>/);
   assertNoCloudflareInjection("/", shellHtml);
   const contentSecurityPolicy = shell.headers.get("content-security-policy") ?? "";
   assert.match(contentSecurityPolicy, /default-src 'self'/);
-  assert.match(contentSecurityPolicy, /connect-src 'self' https:\/\/\*\.google-analytics\.com/);
-  assert.match(contentSecurityPolicy, /img-src 'self' data: blob: https:\/\/\*\.google-analytics\.com/);
-  assert.match(contentSecurityPolicy, /script-src 'self' https:\/\/www\.googletagmanager\.com/);
+  for (const directive of Object.values(GOOGLE_ANALYTICS_CSP)) {
+    assert.ok(contentSecurityPolicy.includes(directive), `CSP is missing ${directive}`);
+  }
   assert.equal(shell.headers.get("referrer-policy"), "no-referrer");
   assert.equal(shell.headers.get("x-content-type-options"), "nosniff");
 

--- a/scripts/demo-smoke.test.mjs
+++ b/scripts/demo-smoke.test.mjs
@@ -9,6 +9,7 @@ import {
   DEMO_SHELL_REQUEST_TIMEOUT_MS,
   DEMO_SHELL_READY_WINDOW_MS,
   DEMO_CONSENT_READY_DELAY_MS,
+  hasGoogleAnalyticsCsp,
   waitForDemoConsentContract,
   waitForDemoShell,
 } from "./demo-smoke.mjs";
@@ -67,6 +68,37 @@ test("demo smoke waits through custom-domain propagation longer than the former 
   assert.equal(DEMO_SHELL_READY_ATTEMPTS, 101);
   assert.equal(DEMO_SHELL_READY_WINDOW_MS, 5 * 60_000);
   assert.equal(DEMO_SHELL_REQUEST_TIMEOUT_MS, 15_000);
+});
+
+test("demo smoke waits until the custom domain serves the deployed analytics CSP", async () => {
+  const policies = [
+    "default-src 'self'; connect-src 'self'; script-src 'self'",
+    "default-src 'self'; connect-src 'self' https://*.google-analytics.com; img-src 'self' data: blob: https://*.google-analytics.com; script-src 'self' https://www.googletagmanager.com",
+  ];
+  const delays = [];
+  let elapsedMs = 0;
+
+  const response = await waitForDemoShell(
+    async () => ({
+      ok: true,
+      status: 200,
+      headers: new Headers({ "content-security-policy": policies.shift() }),
+    }),
+    {
+      isReady: hasGoogleAnalyticsCsp,
+      sleep: async (delayMs) => {
+        delays.push(delayMs);
+        elapsedMs += delayMs;
+      },
+      now: () => elapsedMs,
+      createAbortSignal: () => new AbortController().signal,
+      log: () => {},
+    },
+  );
+
+  assert.equal(response.status, 200);
+  assert.equal(hasGoogleAnalyticsCsp(response), true);
+  assert.deepEqual(delays, [DEMO_SHELL_READY_DELAY_MS]);
 });
 
 test("demo smoke still fails after the bounded readiness window", async () => {


### PR DESCRIPTION
## What changed

- make the production smoke wait for the deployed Google Analytics CSP, not merely any successful shell response
- keep the existing five-minute custom-domain propagation window
- add a regression covering an old `200` response followed by the current policy

## Why

Cloudflare Pages published the site successfully, but `demo.jobctrl.dev` briefly served the previous response headers. The smoke accepted that stale `200` immediately and then failed its CSP assertion. The custom domain converged shortly afterward and the production smoke passed locally.

## Validation

- `node --test scripts/demo-smoke.test.mjs` — 9 passed
- `node --check scripts/demo-smoke.mjs`
- `git diff --check`
- `DEMO_BASE_URL=https://demo.jobctrl.dev node scripts/demo-smoke.mjs` — passed against production