### PR TITLE
fix(release): allow main to advance during publication

### DIFF
--- a/.github/workflows/release-distribution.yml
+++ b/.github/workflows/release-distribution.yml
@@ -1,20 +1,20 @@
 name: Release distribution
 
-# The sole public-release path. A release tag must resolve to the current
-# audited main commit. Candidate bytes are staged under an immutable build ID,
+# The sole public-release path. A release tag must resolve to an audited commit
+# that remains in current main history. Candidate bytes are staged under an immutable build ID,
 # exercised from that immutable URL, and only then atomically promoted as a
 # channel pointer. Immutable GitHub publication gates the final stable-only
 # PyPI publication lane.
 on:
-  # v2.0.4 is the one-time first-public-release fallback for environments where
+  # v2.0.5 is the one-time first-public-release fallback for environments where
   # the repository app can publish refs but cannot call workflow_dispatch.
   push:
     tags:
-      - v2.0.4
+      - v2.0.5
   workflow_dispatch:
     inputs:
       release_tag:
-        description: Existing v<semver> tag that resolves to current main
+        description: Existing v<semver> tag whose commit remains in current main history
         required: true
         type: string
       channel:
@@ -72,7 +72,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Reassert the release tag and current main before preparation
+      - name: Reassert the release tag and current main lineage before preparation
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ inputs.release_tag || github.ref_name }}
@@ -81,7 +81,8 @@ jobs:
           head_sha="$(git rev-parse HEAD)"
           test "$GITHUB_REF" = "refs/tags/$RELEASE_TAG"
           test "$GITHUB_SHA" = "$head_sha"
-          test "$(gh api "repos/$GITHUB_REPOSITORY/commits/main" --jq '.sha')" = "$head_sha"
+          main_relation="$(gh api "repos/$GITHUB_REPOSITORY/compare/$head_sha...main" --jq '.status')"
+          [[ "$main_relation" = ahead || "$main_relation" = identical ]]
           test "$(gh api "repos/$GITHUB_REPOSITORY/commits/$RELEASE_TAG" --jq '.sha')" = "$head_sha"
 
       - name: Require explicit revocations, protected trust, and blocked tracked policy
@@ -133,7 +134,8 @@ jobs:
           set -euo pipefail
           test "$GH_REPO" = "$GITHUB_REPOSITORY"
           test "$(gh repo view "$GH_REPO" --json nameWithOwner --jq '.nameWithOwner')" = "$GITHUB_REPOSITORY"
-          test "$(gh api "repos/$GITHUB_REPOSITORY/commits/main" --jq '.sha')" = "$RELEASE_REF"
+          main_relation="$(gh api "repos/$GITHUB_REPOSITORY/compare/$RELEASE_REF...main" --jq '.status')"
+          [[ "$main_relation" = ahead || "$main_relation" = identical ]]
           test "$(gh api "repos/$GITHUB_REPOSITORY/commits/$RELEASE_TAG" --jq '.sha')" = "$RELEASE_REF"
           release="$RUNNER_TEMP/preflight-release.json"
           error="$RUNNER_TEMP/preflight-release.err"
@@ -184,7 +186,8 @@ jobs:
         run: |
           set -euo pipefail
           test "$(git rev-parse HEAD)" = "$RELEASE_REF"
-          test "$(gh api "repos/$GITHUB_REPOSITORY/commits/main" --jq '.sha')" = "$RELEASE_REF"
+          main_relation="$(gh api "repos/$GITHUB_REPOSITORY/compare/$RELEASE_REF...main" --jq '.status')"
+          [[ "$main_relation" = ahead || "$main_relation" = identical ]]
           test "$(gh api "repos/$GITHUB_REPOSITORY/commits/$RELEASE_TAG" --jq '.sha')" = "$RELEASE_REF"
 
       - name: Install locked workspace dependencies
@@ -291,7 +294,8 @@ jobs:
         run: |
           set -euo pipefail
           test "$(git rev-parse HEAD)" = "$RELEASE_REF"
-          test "$(gh api "repos/$GITHUB_REPOSITORY/commits/main" --jq '.sha')" = "$RELEASE_REF"
+          main_relation="$(gh api "repos/$GITHUB_REPOSITORY/compare/$RELEASE_REF...main" --jq '.status')"
+          [[ "$main_relation" = ahead || "$main_relation" = identical ]]
           test "$(gh api "repos/$GITHUB_REPOSITORY/commits/$RELEASE_TAG" --jq '.sha')" = "$RELEASE_REF"
 
       - name: Verify checkout-rooted release authority and the prepared handoff
@@ -563,7 +567,8 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          test "$(gh api "repos/$GITHUB_REPOSITORY/commits/main" --jq '.sha')" = "$RELEASE_REF"
+          main_relation="$(gh api "repos/$GITHUB_REPOSITORY/compare/$RELEASE_REF...main" --jq '.status')"
+          [[ "$main_relation" = ahead || "$main_relation" = identical ]]
           test "$(gh api "repos/$GITHUB_REPOSITORY/commits/$RELEASE_TAG" --jq '.sha')" = "$RELEASE_REF"
           release="$RUNNER_TEMP/release"
           draft="$RUNNER_TEMP/release-draft.json"
@@ -611,12 +616,13 @@ jobs:
             exit 1
           fi
 
-      - name: Reassert audited tag and main before immutable host upload
+      - name: Reassert audited tag and main lineage before immutable host upload
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          test "$(gh api "repos/$GITHUB_REPOSITORY/commits/main" --jq '.sha')" = "$RELEASE_REF"
+          main_relation="$(gh api "repos/$GITHUB_REPOSITORY/compare/$RELEASE_REF...main" --jq '.status')"
+          [[ "$main_relation" = ahead || "$main_relation" = identical ]]
           test "$(gh api "repos/$GITHUB_REPOSITORY/commits/$RELEASE_TAG" --jq '.sha')" = "$RELEASE_REF"
 
       - name: Publish checksum-checked immutable candidate assets to R2
@@ -724,7 +730,8 @@ jobs:
         run: |
           set -euo pipefail
           test "$(git rev-parse HEAD)" = "$RELEASE_REF"
-          test "$(gh api "repos/$GITHUB_REPOSITORY/commits/main" --jq '.sha')" = "$RELEASE_REF"
+          main_relation="$(gh api "repos/$GITHUB_REPOSITORY/compare/$RELEASE_REF...main" --jq '.status')"
+          [[ "$main_relation" = ahead || "$main_relation" = identical ]]
           test "$(gh api "repos/$GITHUB_REPOSITORY/commits/$RELEASE_TAG" --jq '.sha')" = "$RELEASE_REF"
 
       - name: Download the signed candidate metadata
@@ -922,12 +929,13 @@ jobs:
           printf '%s\n' "$promotion_result" > "$RUNNER_TEMP/channel-result"
           echo "requires_write=$requires_write" >> "$GITHUB_OUTPUT"
 
-      - name: Reassert audited tag and main before channel promotion
+      - name: Reassert audited tag and main lineage before channel promotion
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          test "$(gh api "repos/$GITHUB_REPOSITORY/commits/main" --jq '.sha')" = "$RELEASE_REF"
+          main_relation="$(gh api "repos/$GITHUB_REPOSITORY/compare/$RELEASE_REF...main" --jq '.status')"
+          [[ "$main_relation" = ahead || "$main_relation" = identical ]]
           test "$(gh api "repos/$GITHUB_REPOSITORY/commits/$RELEASE_TAG" --jq '.sha')" = "$RELEASE_REF"
 
       - name: Atomically promote one R2 channel pointer with compare-and-swap
@@ -1030,7 +1038,8 @@ jobs:
         run: |
           set -euo pipefail
           test -n "$ADMIN_READ_TOKEN"
-          test "$(gh api "repos/$GITHUB_REPOSITORY/commits/main" --jq '.sha')" = "$RELEASE_REF"
+          main_relation="$(gh api "repos/$GITHUB_REPOSITORY/compare/$RELEASE_REF...main" --jq '.status')"
+          [[ "$main_relation" = ahead || "$main_relation" = identical ]]
           test "$(gh api "repos/$GITHUB_REPOSITORY/commits/$RELEASE_TAG" --jq '.sha')" = "$RELEASE_REF"
           candidate="$RUNNER_TEMP/release"
           smoke="$RUNNER_TEMP/smoke-evidence/published-candidate-smoke.json"
@@ -1069,7 +1078,8 @@ jobs:
             cmp "$asset" "$downloaded/${asset##*/}"
           done
           cmp "$smoke" "$downloaded/published-candidate-smoke.json"
-          test "$(gh api "repos/$GITHUB_REPOSITORY/commits/main" --jq '.sha')" = "$RELEASE_REF"
+          main_relation="$(gh api "repos/$GITHUB_REPOSITORY/compare/$RELEASE_REF...main" --jq '.status')"
+          [[ "$main_relation" = ahead || "$main_relation" = identical ]]
           test "$(gh api "repos/$GITHUB_REPOSITORY/commits/$RELEASE_TAG" --jq '.sha')" = "$RELEASE_REF"
           test "$(GH_TOKEN="$ADMIN_READ_TOKEN" gh api -H 'X-GitHub-Api-Version: 2026-03-10' "repos/$GITHUB_REPOSITORY/immutable-releases" --jq '.enabled')" = true
           if [[ "$(jq -r '.isDraft' "$release")" = true ]]; then
@@ -1130,7 +1140,8 @@ jobs:
         run: |
           set -euo pipefail
           test "$(git rev-parse HEAD)" = "$EXPECTED_SOURCE_COMMIT"
-          test "$(gh api "repos/$GITHUB_REPOSITORY/commits/main" --jq '.sha')" = "$EXPECTED_SOURCE_COMMIT"
+          main_relation="$(gh api "repos/$GITHUB_REPOSITORY/compare/$EXPECTED_SOURCE_COMMIT...main" --jq '.status')"
+          [[ "$main_relation" = ahead || "$main_relation" = identical ]]
           test "$(gh api "repos/$GITHUB_REPOSITORY/commits/$RELEASE_TAG" --jq '.sha')" = "$EXPECTED_SOURCE_COMMIT"
           test "$(gh release view "$RELEASE_TAG" --json isImmutable --jq '.isImmutable')" = true
           gh release verify "$RELEASE_TAG"
@@ -1239,7 +1250,8 @@ jobs:
         run: |
           set -euo pipefail
           test "$(git rev-parse HEAD)" = "$RELEASE_REF"
-          test "$(gh api "repos/$GITHUB_REPOSITORY/commits/main" --jq '.sha')" = "$RELEASE_REF"
+          main_relation="$(gh api "repos/$GITHUB_REPOSITORY/compare/$RELEASE_REF...main" --jq '.status')"
+          [[ "$main_relation" = ahead || "$main_relation" = identical ]]
           test "$(gh api "repos/$GITHUB_REPOSITORY/commits/$RELEASE_TAG" --jq '.sha')" = "$RELEASE_REF"
 
       - name: Set up only the exact locked release-build dependencies
@@ -1303,9 +1315,9 @@ jobs:
         run: |
           set -euo pipefail
           tag_sha="$(gh api "repos/$GITHUB_REPOSITORY/commits/$RELEASE_TAG" --jq '.sha')"
-          main_sha="$(gh api "repos/$GITHUB_REPOSITORY/commits/main" --jq '.sha')"
+          main_relation="$(gh api "repos/$GITHUB_REPOSITORY/compare/$tag_sha...main" --jq '.status')"
           test "$EXPECTED_SOURCE_COMMIT" = "$tag_sha"
-          test "$tag_sha" = "$main_sha"
+          [[ "$main_relation" = ahead || "$main_relation" = identical ]]
           test "$(gh release view "$RELEASE_TAG" --json isImmutable --jq '.isImmutable')" = true
           test -f "$DIST_DIR/SHA256SUMS" && test ! -L "$DIST_DIR/SHA256SUMS"
           packages="$DIST_DIR/packages"

--- a/.github/workflows/sync-homebrew-tap.yml
+++ b/.github/workflows/sync-homebrew-tap.yml
@@ -57,13 +57,14 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Verify the propagated audited commit
+      - name: Verify the propagated audited commit remains in main history
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           test "$(git rev-parse HEAD)" = "$RELEASE_REF"
-          test "$(gh api "repos/$GITHUB_REPOSITORY/commits/main" --jq '.sha')" = "$RELEASE_REF"
+          main_relation="$(gh api "repos/$GITHUB_REPOSITORY/compare/$RELEASE_REF...main" --jq '.status')"
+          [[ "$main_relation" = ahead || "$main_relation" = identical ]]
           test "$(gh api "repos/$GITHUB_REPOSITORY/commits/$RELEASE_TAG" --jq '.sha')" = "$RELEASE_REF"
 
       - name: Set up pinned Node for signed-render verification
@@ -157,12 +158,13 @@ jobs:
           )
           test "$(shasum -a 256 "$verified/jobctrl.rb" | awk '{print $1}')" = "$EXPECTED_FORMULA_SHA256"
 
-      - name: Reassert the audited source before loading the tap deploy key
+      - name: Reassert the audited source lineage before loading the tap deploy key
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          test "$(gh api "repos/$GITHUB_REPOSITORY/commits/main" --jq '.sha')" = "$RELEASE_REF"
+          main_relation="$(gh api "repos/$GITHUB_REPOSITORY/compare/$RELEASE_REF...main" --jq '.status')"
+          [[ "$main_relation" = ahead || "$main_relation" = identical ]]
           test "$(gh api "repos/$GITHUB_REPOSITORY/commits/$RELEASE_TAG" --jq '.sha')" = "$RELEASE_REF"
 
       - name: Check out Homebrew tap
@@ -178,12 +180,13 @@ jobs:
           install -m 0644 "$RUNNER_TEMP/jobctrl-verified/jobctrl.rb" homebrew-tap/Formula/jobctrl.rb
           git -C homebrew-tap diff --check
 
-      - name: Reassert the audited source immediately before tap publication
+      - name: Reassert the audited source lineage immediately before tap publication
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          test "$(gh api "repos/$GITHUB_REPOSITORY/commits/main" --jq '.sha')" = "$RELEASE_REF"
+          main_relation="$(gh api "repos/$GITHUB_REPOSITORY/compare/$RELEASE_REF...main" --jq '.status')"
+          [[ "$main_relation" = ahead || "$main_relation" = identical ]]
           test "$(gh api "repos/$GITHUB_REPOSITORY/commits/$RELEASE_TAG" --jq '.sha')" = "$RELEASE_REF"
 
       - name: Commit synchronized formula

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jobctrl/api",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jobctrl/extension",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/extension/public/manifest.json
+++ b/apps/extension/public/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "JobCtrl",
   "description": "Save job postings from the browser into the local JobCtrl app.",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "action": {
     "default_popup": "popup.html"
   },

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jobctrl/web",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "private": true,
   "type": "module",
   "scripts": {

--- a/docs/publish-checklist.md
+++ b/docs/publish-checklist.md
@@ -258,8 +258,8 @@ especially §§11–14. This is a release precondition, not permission to publis
   plus its QA/deploy evidence, and every protected release environment in 9.4a
   is configured. The PyPI Trusted Publisher is already configured; verify its
   mapping rather than creating a second publisher or using a PyPI API token.
-- **Recovery note.** Preserve the failed `v2.0.0` and `v2.0.1` tags, the
-  unpublished `v2.0.2` tag, and the partially published `v2.0.3` tag at their
+- **Recovery note.** Preserve the failed `v2.0.0`, `v2.0.1`, and `v2.0.4`
+  tags, the unpublished `v2.0.2` tag, and the partially published `v2.0.3` tag at their
   original commits as audit evidence. `v2.0.0` stopped before signing because
   the signing runner requested an unavailable Python build. `v2.0.1` completed
   its builds, signing, Apple notarization, stapling, and audit packaging, then
@@ -272,15 +272,20 @@ especially §§11–14. This is a release precondition, not permission to publis
   pointer or publish the GitHub Release, Homebrew formula, or PyPI package
   because the current Homebrew CLI rejects auditing a formula by file path.
   Its immutable objects and draft are recovery evidence, not a stable release.
+  `v2.0.4` passed identity, preflight, and the single candidate build, then
+  stopped before signing when another merged PR advanced `main` during the
+  candidate handoff. The tag and candidate stayed exact; the obsolete live-head
+  equality check caused the failure. Nothing was signed or published.
   Do not move, delete, or dispatch any of these tags again.
 - **Action.** Fetch `origin/main` and tags, verify that the audited local commit
   and `origin/main` resolve to the same SHA, then create and push the exact
-  `v2.0.4` tag on that commit. Verify the remote tag and `main` still resolve to
-  that SHA. Pushing this exact tag starts `Release distribution` with these
+  `v2.0.5` tag on that commit. Verify the remote tag resolves to that exact SHA
+  and the tagged commit remains identical to or an ancestor of current `main`.
+  Pushing this exact tag starts `Release distribution` with these
   first-release defaults; the manual dispatch path remains available:
 
   ```text
-  release_tag=v2.0.4
+  release_tag=v2.0.5
   channel=stable
   sequence=1
   minimum_safe_sequence=1
@@ -377,7 +382,7 @@ Phase 7 and its Definition of Done.
   `renderPinnedInstallScript` regression fix. Its contract must replace an
   existing release's URL, SHA-256, and version pins with the next release's
   values, not only replace empty pins; its regression coverage must prove a
-  `v2.0.4` render cannot retain `v2.0.3` pins. Do not use a manually edited
+  `v2.0.5` render cannot retain `v2.0.4` pins. Do not use a manually edited
   installer as a workaround.
 - **Action.** Run and record the plan's published-artifact acceptance matrix:
   clean Apple-silicon macOS installs through both curl and Homebrew; no source
@@ -391,7 +396,7 @@ Phase 7 and its Definition of Done.
 - **Mandatory canonical-installer cutover.** Treat the immutable signed release
   and the public installer deployment as two linked but different records:
 
-  1. Record the immutable `v2.0.4` tag/release SHA and tree as **R**. Retrieve
+  1. Record the immutable `v2.0.5` tag/release SHA and tree as **R**. Retrieve
      that release's immutable pinned `install.sh` and `SHA256SUMS`, verify
      `install.sh` against its published SHA-256, and retain the verified asset
      URL and checksum with R. Do not reconstruct or edit the retrieved script.
@@ -547,8 +552,9 @@ Perform the following in order and stop at the first failed gate:
    after the exact-tree local gate passes.
 2. Rerun the standard hosted workflows on the recorded SHA and require green
    runs with executed steps.
-3. On that final validated `main` SHA, create and push `v2.0.4`, verify the
-   remote tag and `origin/main` resolve to that same SHA, and confirm the exact
+3. On that final validated `main` SHA, create and push `v2.0.5`, verify the
+   remote tag resolves to that exact SHA and remains in `origin/main` history,
+   and confirm the exact
    tag-triggered `Release distribution` run uses the six first-release defaults
    in 9.4. Complete the signed release, channel-pointer promotion, PyPI
    publication, Homebrew formula sync, and immutable release evidence as R.
@@ -608,7 +614,7 @@ rollback evidence, and publish corrections where a public claim proved wrong.
 | 9.1 Visibility flip | Owner | Run the exact-tree local gate, make the repository public, then rerun every standard hosted gate with real executed steps. |
 | 9.2 Docs-site verification | Owner | Docs are already public and deploy is enabled; dispatch at the gated `main` SHA and record the public deployment proof. |
 | 9.3 Rename redirect | Owner | Verify old-URL redirects after the flip and repair any stale repository links. |
-| 9.4 Release and PyPI | Owner | Preserve `v2.0.0`, `v2.0.1`, unpublished `v2.0.2`, and partial `v2.0.3`; create `v2.0.4` on audited `main`, then verify the exact tag-triggered run uses the recorded first-release defaults and completes the signed release. |
+| 9.4 Release and PyPI | Owner | Preserve failed `v2.0.0`, `v2.0.1`, and `v2.0.4`, unpublished `v2.0.2`, and partial `v2.0.3`; create `v2.0.5` on audited `main`, then verify the exact tag-triggered run uses the recorded first-release defaults and completes the signed release. |
 | 9.5 Homebrew tap | Signed workflow | Replace the legacy formula only with the verified signed render after release-origin smoke passes. |
 | 9.6 Installer and artifact acceptance | Owner | Verify immutable `install.sh` from R, land matching `scripts/get` and `docs/public/install.sh` in a separate post-release PR, validate/deploy D, then run public curl/Homebrew smoke. |
 | 9.7 Public live demo | Owner | The demo is already public and deploy is enabled; verify the audited deployment externally and record its release evidence. |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jobctrl",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "private": true,
   "description": "AI-powered end-to-end job application pipeline",
   "type": "module",

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jobctrl/api-client",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jobctrl/contracts",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/domain-types/package.json
+++ b/packages/domain-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jobctrl/domain-types",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jobctrl/tsconfig",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "private": true,
   "type": "module",
   "exports": {

--- a/scripts/distribution-manifest.test.mjs
+++ b/scripts/distribution-manifest.test.mjs
@@ -97,7 +97,7 @@ test("distribution contracts are complete and every version source resolves", as
   assert.equal(report.nodeLicenseEvidenceCount, 13);
   assert.equal(report.capabilityCount, 3);
   assert.deepEqual(report.platforms, ["darwin-arm64"]);
-  assert.equal(report.versions["jobctrl-launcher"], "2.0.4");
+  assert.equal(report.versions["jobctrl-launcher"], "2.0.5");
   assert.equal(report.versions["playwright-python"], "1.58.0");
   assert.equal(report.versions["font-geist"], "5.2.9");
   assert.equal(report.versions["font-jetbrains-mono"], "5.2.8");

--- a/scripts/distribution-release.test.mjs
+++ b/scripts/distribution-release.test.mjs
@@ -298,10 +298,10 @@ test("local fixture release descriptor, signature, and curl contract bind one ZI
     minimumSafeSequence: 0,
     revokedBuildIds: [],
     buildId: "fixture-build-0001",
-    appVersion: "2.0.4",
+    appVersion: "2.0.5",
     platform: { id: "darwin-arm64", os: "darwin", arch: "arm64" },
     artifact: {
-      url: "file:///jobctrl-local-release/jobctrl-2.0.4-darwin-arm64.zip",
+      url: "file:///jobctrl-local-release/jobctrl-2.0.5-darwin-arm64.zip",
       sha256: build.archiveSha256,
       sizeBytes: build.compressedBytes,
       archiveType: "zip",
@@ -761,7 +761,7 @@ test("release workflows use protected manual signing, artifact handoff, candidat
     /ENOENT/,
   );
   assert.match(releaseWorkflow, /workflow_dispatch:/);
-  assert.match(releaseWorkflow, /^  push:\n    tags:\n      - v2\.0\.4$/m);
+  assert.match(releaseWorkflow, /^  push:\n    tags:\n      - v2\.0\.5$/m);
   assert.match(releaseWorkflow, /\$\{\{ inputs\.release_tag \|\| github\.ref_name \}\}/);
   assert.match(releaseWorkflow, /\$\{\{ inputs\.channel \|\| 'stable' \}\}/);
   assert.match(releaseWorkflow, /\$\{\{ inputs\.sequence \|\| '1' \}\}/);
@@ -839,4 +839,22 @@ test("release workflows use protected manual signing, artifact handoff, candidat
     releaseWorkflow.indexOf("  pypi-build:"),
   );
   assert.doesNotMatch(pypiResolve, /(?:corepack|pnpm|npm|npx|uv|pip)\s/);
+});
+
+test("release lineage allows main to advance without loosening exact tag identity", async () => {
+  const [releaseWorkflow, homebrewWorkflow] = await Promise.all([
+    readFile(path.join(process.cwd(), ".github", "workflows", "release-distribution.yml"), "utf8"),
+    readFile(path.join(process.cwd(), ".github", "workflows", "sync-homebrew-tap.yml"), "utf8"),
+  ]);
+  const workflows = `${releaseWorkflow}\n${homebrewWorkflow}`;
+  assert.doesNotMatch(workflows, /repos\/\$GITHUB_REPOSITORY\/commits\/main/);
+  for (const marker of [
+    "compare/$head_sha...main",
+    "compare/$RELEASE_REF...main",
+    "compare/$EXPECTED_SOURCE_COMMIT...main",
+    "compare/$tag_sha...main",
+    "commits/$RELEASE_TAG",
+  ]) assert.ok(workflows.includes(marker), `missing release-lineage marker ${marker}`);
+  const lineageAssertions = workflows.match(/\[\[ "\$main_relation" = ahead \|\| "\$main_relation" = identical \]\]/g) ?? [];
+  assert.ok(lineageAssertions.length >= 16, "every release side-effect boundary must preserve main ancestry");
 });

--- a/scripts/release_check.py
+++ b/scripts/release_check.py
@@ -919,12 +919,18 @@ def _homebrew_sync_findings(root: Path) -> list[str]:
         "git status --short --untracked-files=all -- Formula/jobctrl.rb": "does not detect an absent or untracked tap formula",
         "actions/download-artifact@": "does not download the immutable P6 artifact on its own runner",
         '--trust "$TRUST_PATH"': "does not verify against the candidate-provided release trust registry",
+        'compare/$RELEASE_REF...main': "does not preserve release lineage while allowing later main commits",
+        '[[ "$main_relation" = ahead || "$main_relation" = identical ]]': "does not reject a release commit outside current main history",
     }
     findings.extend(
         f"{HOMEBREW_SYNC_WORKFLOW_PATH}: {message}"
         for marker, message in required_markers.items()
         if marker not in workflow
     )
+    if 'commits/main' in workflow:
+        findings.append(
+            f"{HOMEBREW_SYNC_WORKFLOW_PATH}: tap sync must verify main ancestry without requiring the live main head to remain frozen"
+        )
     verify = _workflow_job_body(workflow, "verify")
     publish = _workflow_job_body(workflow, "publish")
     call_interface = workflow.partition("\njobs:")[0]
@@ -1046,7 +1052,9 @@ def _release_distribution_findings(root: Path) -> list[str]:
         'test "$GITHUB_SHA" = "$head_sha"': "does not bind the workflow definition SHA to the audited release commit",
         "revoked_build_ids:": "does not require explicit revocation input",
         "expected_channel_pointer_sha256:": "does not require a compare-and-swap precondition for channel promotion",
-        'gh api "repos/$GITHUB_REPOSITORY/commits/main"': "does not reassert current main through bounded authenticated reads",
+        'compare/$head_sha...main': "does not prove the release commit remains in current main history",
+        'compare/$RELEASE_REF...main': "does not reassert release lineage through bounded authenticated reads",
+        '[[ "$main_relation" = ahead || "$main_relation" = identical ]]': "does not reject release commits outside current main history",
         'gh api "repos/$GITHUB_REPOSITORY/commits/$RELEASE_TAG"': "does not reassert the release tag through bounded authenticated reads",
         "release_build_id=\"${RELEASE_TAG#v}-${sha}-darwin-arm64\"": "does not bind the build ID to the full immutable commit SHA",
         "runs-on: macos-15": "does not use a clean macOS signing/notarization runner",
@@ -1101,6 +1109,10 @@ def _release_distribution_findings(root: Path) -> list[str]:
         for marker, message in required_markers.items()
         if marker not in workflow
     ]
+    if 'commits/main' in workflow:
+        findings.append(
+            f"{RELEASE_DISTRIBUTION_WORKFLOW_PATH}: release jobs must verify main ancestry without requiring the live main head to remain frozen"
+        )
     required_jobs = (
         "resolve",
         "publication-preflight",

--- a/workers/automation/pyproject.toml
+++ b/workers/automation/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jobctrl"
-version = "2.0.4"
+version = "2.0.5"
 description = "AI-powered end-to-end job application pipeline"
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/workers/automation/src/jobctrl/__init__.py
+++ b/workers/automation/src/jobctrl/__init__.py
@@ -1,3 +1,3 @@
 """JobCtrl — AI-powered end-to-end job application pipeline."""
 
-__version__ = "2.0.4"
+__version__ = "2.0.5"

--- a/workers/automation/tests/test_release_check.py
+++ b/workers/automation/tests/test_release_check.py
@@ -836,9 +836,9 @@ def test_pypi_workflow_keeps_build_verification_outside_oidc_publication() -> No
     assert "JOBCTRL_RELEASE_KEY_ID" not in publish
     assert "EXPECTED_SOURCE_COMMIT: ${{ needs.pypi-resolve.outputs.source_commit }}" in publish
     assert 'gh api "repos/$GITHUB_REPOSITORY/commits/$RELEASE_TAG"' in publish
-    assert 'gh api "repos/$GITHUB_REPOSITORY/commits/main"' in publish
+    assert 'gh api "repos/$GITHUB_REPOSITORY/compare/$tag_sha...main"' in publish
     assert 'test "$EXPECTED_SOURCE_COMMIT" = "$tag_sha"' in publish
-    assert 'test "$tag_sha" = "$main_sha"' in publish
+    assert '[[ "$main_relation" = ahead || "$main_relation" = identical ]]' in publish
     assert "packages-dir: ${{ runner.temp }}/jobctrl-pypi-dists/packages" in publish
     assert "SHA256SUMS" in publish
     assert "jobctrl-pypi-distributions-" in publish

--- a/workers/automation/uv.lock
+++ b/workers/automation/uv.lock
@@ -586,7 +586,7 @@ wheels = [
 
 [[package]]
 name = "jobctrl"
-version = "2.0.4"
+version = "2.0.5"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## What changed

- advance the release candidate and exact tag trigger to v2.0.5
- replace live `main == release SHA` assertions with an ancestor-or-identical lineage check across signing, R2, GitHub Release, Homebrew, and PyPI
- keep the tag, checkout, release contract, draft target, and artifacts pinned to the exact release SHA
- add a regression that forbids live-main equality checks and covers every release side-effect boundary
- record the failed v2.0.4 attempt and recovery rule

## Why

The v2.0.4 run passed identity, preflight, and its single 706 MB candidate build. While the candidate downloaded onto the signing runner, another pull request advanced `main`. The tag and candidate remained exact, but a downstream equality assertion stopped the workflow before signing.

A tagged release must remain on current main history; it does not require the branch head to stay frozen for the duration of a long release.

## Validation

- release/distribution tests — 43 passed
- focused Python release-policy tests — 52 passed
- strict release/privacy check for `v2.0.5` — passed
- exact wheel and sdist build — passed
- Python lock, provider lock, manifest, and distribution audits — passed
- both workflow YAML files parse; `git diff --check` passed
- docs build, link check, and redirect check — passed (8,239 references)
- live GitHub compare proof: failed v2.0.4 SHA reports `ahead` with current main two commits later
