### PR TITLE
fix(demo): queue Google tag commands correctly

### DIFF
--- a/apps/web/src/demo/consent/DemoGoogleAnalytics.test.ts
+++ b/apps/web/src/demo/consent/DemoGoogleAnalytics.test.ts
@@ -6,7 +6,7 @@ import {
 } from "./DemoGoogleAnalytics.js";
 
 interface GoogleAnalyticsWindow extends Window {
-  dataLayer?: unknown[][];
+  dataLayer?: IArguments[];
   gtag?: (...command: unknown[]) => void;
 }
 
@@ -32,7 +32,9 @@ describe("loadDemoGoogleAnalytics", () => {
     );
     expect((scripts[0] as HTMLScriptElement).async).toBe(true);
 
-    const commands = (window as GoogleAnalyticsWindow).dataLayer;
+    const queuedCommands = (window as GoogleAnalyticsWindow).dataLayer;
+    expect(Array.isArray(queuedCommands?.[0])).toBe(false);
+    const commands = queuedCommands?.map((command) => Array.from(command));
     expect(commands?.[0]).toEqual([
       "consent",
       "default",

--- a/apps/web/src/demo/consent/DemoGoogleAnalytics.ts
+++ b/apps/web/src/demo/consent/DemoGoogleAnalytics.ts
@@ -6,7 +6,7 @@ const GOOGLE_ANALYTICS_COOKIE_MAX_AGE_SECONDS = 15_544_800;
 type GoogleTag = (...command: unknown[]) => void;
 
 interface GoogleAnalyticsWindow extends Window {
-  dataLayer?: unknown[][];
+  dataLayer?: IArguments[];
   gtag?: GoogleTag;
 }
 
@@ -26,11 +26,13 @@ export function loadDemoGoogleAnalytics(
   try {
     const dataLayer = windowRef.dataLayer ?? [];
     windowRef.dataLayer = dataLayer;
-    const googleTag =
+    const googleTag: GoogleTag =
       windowRef.gtag ??
-      ((...command: unknown[]) => {
-        dataLayer.push(command);
-      });
+      function googleTag() {
+        // Google processes queued commands as the `arguments` objects produced
+        // by its canonical snippet. Plain arrays load the tag but are ignored.
+        dataLayer.push(arguments);
+      };
     windowRef.gtag = googleTag;
 
     googleTag("consent", "default", {


### PR DESCRIPTION
## What changed

- queue Google tag commands as `arguments` objects, matching Google’s canonical `gtag` snippet
- add a regression that rejects plain-array command entries

## Why

The consent-gated tag script loaded successfully in production, but Google ignored the queued consent and configuration commands because they were plain arrays. A live browser probe confirmed that no collection request or GA cookie appeared until the commands were replayed in the canonical `arguments` shape.

## Validation

- focused GA unit test — 1 passed
- web typecheck — passed
- `corepack pnpm demo:build` — passed
- `git diff --check` — passed
- production diagnosis: no Google requests/cookies before consent; canonical command replay produced a `204` GA4 collection response and `_ga` / `_ga_6MJGD17JN0` cookies