### PR TITLE
fix(release): bypass stale R2 readback cache

### DIFF
--- a/.github/workflows/release-distribution.yml
+++ b/.github/workflows/release-distribution.yml
@@ -6,11 +6,11 @@ name: Release distribution
 # channel pointer. Immutable GitHub publication gates the final stable-only
 # PyPI publication lane.
 on:
-  # v2.0.5 is the one-time first-public-release fallback for environments where
+  # v2.0.6 is the one-time first-public-release fallback for environments where
   # the repository app can publish refs but cannot call workflow_dispatch.
   push:
     tags:
-      - v2.0.5
+      - v2.0.6
   workflow_dispatch:
     inputs:
       release_tag:
@@ -638,12 +638,17 @@ jobs:
           test -n "$AWS_SECRET_ACCESS_KEY"
           [[ "$R2_ACCOUNT_ID" =~ ^[a-f0-9]{32}$ ]]
           [[ "$R2_BUCKET" =~ ^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$ ]]
+          [[ "$GITHUB_RUN_ID" =~ ^[0-9]+$ ]]
+          [[ "$GITHUB_RUN_ATTEMPT" =~ ^[0-9]+$ ]]
           r2_endpoint="https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com"
           release="$RUNNER_TEMP/release"
+          # Cloudflare can cache a first-read 404 longer than this bounded
+          # verifier waits. Use a fresh cache key after the immutable write.
           verify_public_immutable() {
-            local destination="$1" expected="$2" existing="$3" actual status
+            local destination="$1" expected="$2" existing="$3" actual readback_url status
             for attempt in {1..24}; do
-              status="$(curl --silent --show-error --output "$existing" --write-out '%{http_code}' --proto '=https' --tlsv1.2 "https://releases.jobctrl.dev/$destination" || true)"
+              readback_url="https://releases.jobctrl.dev/$destination?jobctrl-release-readback=${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-post-${attempt}"
+              status="$(curl --silent --show-error --output "$existing" --write-out '%{http_code}' --proto '=https' --tlsv1.2 "$readback_url" || true)"
               if [[ "$status" = 200 ]]; then
                 actual="$(shasum -a 256 "$existing" | awk '{print $1}')"
                 test "$actual" = "$expected"
@@ -661,10 +666,11 @@ jobs:
             exit 1
           }
           upload_immutable() {
-            local source="$1" destination="$2" expected actual existing status
+            local source="$1" destination="$2" expected actual existing precheck_url status
             expected="$(shasum -a 256 "$source" | awk '{print $1}')"
             existing="$RUNNER_TEMP/immutable-${destination//\//_}"
-            status="$(curl --silent --show-error --output "$existing" --write-out '%{http_code}' --proto '=https' --tlsv1.2 "https://releases.jobctrl.dev/$destination" || true)"
+            precheck_url="https://releases.jobctrl.dev/$destination?jobctrl-release-readback=${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-pre"
+            status="$(curl --silent --show-error --output "$existing" --write-out '%{http_code}' --proto '=https' --tlsv1.2 "$precheck_url" || true)"
             if [[ "$status" = 200 ]]; then
               actual="$(shasum -a 256 "$existing" | awk '{print $1}')"
               test "$actual" = "$expected"
@@ -879,9 +885,12 @@ jobs:
           next_sequence="$(jq -er '.sequence' "$pointer")"
           destination="v1/$RELEASE_CHANNEL/darwin-arm64.json"
           public_url="https://releases.jobctrl.dev/$destination"
+          # Keep this existence check from poisoning the post-write readback
+          # with Cloudflare's negative cache for a first channel publication.
+          precheck_url="${public_url}?jobctrl-release-readback=${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-channel-pre"
           headers="$RUNNER_TEMP/channel-pointer.headers"
           current="$RUNNER_TEMP/channel-pointer.current"
-          status="$(curl --silent --show-error --output "$current" --dump-header "$headers" --write-out '%{http_code}' --proto '=https' --tlsv1.2 "$public_url" || true)"
+          status="$(curl --silent --show-error --output "$current" --dump-header "$headers" --write-out '%{http_code}' --proto '=https' --tlsv1.2 "$precheck_url" || true)"
           prior_sha=""
           etag=""
           requires_write=false
@@ -979,7 +988,25 @@ jobs:
           set -euo pipefail
           public_url="https://releases.jobctrl.dev/v1/$RELEASE_CHANNEL/darwin-arm64.json"
           pointer_sha="$EXPECTED_SIGNER_POINTER_SHA256"
-          readback_sha="$(curl --fail --silent --show-error --proto '=https' --tlsv1.2 "$public_url" | shasum -a 256 | awk '{print $1}')"
+          readback="$RUNNER_TEMP/channel-pointer.readback"
+          readback_sha=""
+          for attempt in {1..24}; do
+            readback_url="${public_url}?jobctrl-release-readback=${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-channel-post-${attempt}"
+            status="$(curl --silent --show-error --output "$readback" --write-out '%{http_code}' --proto '=https' --tlsv1.2 "$readback_url" || true)"
+            if [[ "$status" = 200 ]]; then
+              candidate_sha="$(shasum -a 256 "$readback" | awk '{print $1}')"
+              if [[ "$candidate_sha" = "$pointer_sha" ]]; then
+                readback_sha="$candidate_sha"
+                break
+              fi
+            elif [[ "$status" != 404 ]]; then
+              echo "failed to read promoted channel pointer (HTTP $status)" >&2
+              exit 1
+            fi
+            if [[ "$attempt" -lt 24 ]]; then
+              sleep 5
+            fi
+          done
           test "$readback_sha" = "$pointer_sha"
           status="$(<"$RUNNER_TEMP/channel-prior-status")"
           prior_sha="$(<"$RUNNER_TEMP/channel-prior-sha256")"

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jobctrl/api",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jobctrl/extension",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/extension/public/manifest.json
+++ b/apps/extension/public/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "JobCtrl",
   "description": "Save job postings from the browser into the local JobCtrl app.",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "action": {
     "default_popup": "popup.html"
   },

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jobctrl/web",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "private": true,
   "type": "module",
   "scripts": {

--- a/docs/publish-checklist.md
+++ b/docs/publish-checklist.md
@@ -258,9 +258,10 @@ especially §§11–14. This is a release precondition, not permission to publis
   plus its QA/deploy evidence, and every protected release environment in 9.4a
   is configured. The PyPI Trusted Publisher is already configured; verify its
   mapping rather than creating a second publisher or using a PyPI API token.
-- **Recovery note.** Preserve the failed `v2.0.0`, `v2.0.1`, and `v2.0.4`
-  tags, the unpublished `v2.0.2` tag, and the partially published `v2.0.3` tag at their
-  original commits as audit evidence. `v2.0.0` stopped before signing because
+- **Recovery note.** Preserve the failed `v2.0.0`, `v2.0.1`, `v2.0.4`, and
+  `v2.0.5` tags, the unpublished `v2.0.2` tag, and the partially published
+  `v2.0.3` tag at their original commits as audit evidence. `v2.0.0` stopped
+  before signing because
   the signing runner requested an unavailable Python build. `v2.0.1` completed
   its builds, signing, Apple notarization, stapling, and audit packaging, then
   stopped before GitHub draft creation or R2 upload because a checkout-free
@@ -276,16 +277,21 @@ especially §§11–14. This is a release precondition, not permission to publis
   stopped before signing when another merged PR advanced `main` during the
   candidate handoff. The tag and candidate stayed exact; the obsolete live-head
   equality check caused the failure. Nothing was signed or published.
+  `v2.0.5` completed its build, signing, Apple notarization, stapling, and audit
+  packaging, then uploaded its immutable archive to R2. Its public readback
+  failed because the workflow's pre-upload 404 remained cached longer than the
+  post-upload verification window; the GitHub Release, stable pointer,
+  Homebrew formula, and PyPI package were not published.
   Do not move, delete, or dispatch any of these tags again.
 - **Action.** Fetch `origin/main` and tags, verify that the audited local commit
   and `origin/main` resolve to the same SHA, then create and push the exact
-  `v2.0.5` tag on that commit. Verify the remote tag resolves to that exact SHA
+  `v2.0.6` tag on that commit. Verify the remote tag resolves to that exact SHA
   and the tagged commit remains identical to or an ancestor of current `main`.
   Pushing this exact tag starts `Release distribution` with these
   first-release defaults; the manual dispatch path remains available:
 
   ```text
-  release_tag=v2.0.5
+  release_tag=v2.0.6
   channel=stable
   sequence=1
   minimum_safe_sequence=1
@@ -382,7 +388,7 @@ Phase 7 and its Definition of Done.
   `renderPinnedInstallScript` regression fix. Its contract must replace an
   existing release's URL, SHA-256, and version pins with the next release's
   values, not only replace empty pins; its regression coverage must prove a
-  `v2.0.5` render cannot retain `v2.0.4` pins. Do not use a manually edited
+  `v2.0.6` render cannot retain `v2.0.5` pins. Do not use a manually edited
   installer as a workaround.
 - **Action.** Run and record the plan's published-artifact acceptance matrix:
   clean Apple-silicon macOS installs through both curl and Homebrew; no source
@@ -396,7 +402,7 @@ Phase 7 and its Definition of Done.
 - **Mandatory canonical-installer cutover.** Treat the immutable signed release
   and the public installer deployment as two linked but different records:
 
-  1. Record the immutable `v2.0.5` tag/release SHA and tree as **R**. Retrieve
+  1. Record the immutable `v2.0.6` tag/release SHA and tree as **R**. Retrieve
      that release's immutable pinned `install.sh` and `SHA256SUMS`, verify
      `install.sh` against its published SHA-256, and retain the verified asset
      URL and checksum with R. Do not reconstruct or edit the retrieved script.
@@ -552,7 +558,7 @@ Perform the following in order and stop at the first failed gate:
    after the exact-tree local gate passes.
 2. Rerun the standard hosted workflows on the recorded SHA and require green
    runs with executed steps.
-3. On that final validated `main` SHA, create and push `v2.0.5`, verify the
+3. On that final validated `main` SHA, create and push `v2.0.6`, verify the
    remote tag resolves to that exact SHA and remains in `origin/main` history,
    and confirm the exact
    tag-triggered `Release distribution` run uses the six first-release defaults
@@ -614,7 +620,7 @@ rollback evidence, and publish corrections where a public claim proved wrong.
 | 9.1 Visibility flip | Owner | Run the exact-tree local gate, make the repository public, then rerun every standard hosted gate with real executed steps. |
 | 9.2 Docs-site verification | Owner | Docs are already public and deploy is enabled; dispatch at the gated `main` SHA and record the public deployment proof. |
 | 9.3 Rename redirect | Owner | Verify old-URL redirects after the flip and repair any stale repository links. |
-| 9.4 Release and PyPI | Owner | Preserve failed `v2.0.0`, `v2.0.1`, and `v2.0.4`, unpublished `v2.0.2`, and partial `v2.0.3`; create `v2.0.5` on audited `main`, then verify the exact tag-triggered run uses the recorded first-release defaults and completes the signed release. |
+| 9.4 Release and PyPI | Owner | Preserve failed `v2.0.0`, `v2.0.1`, `v2.0.4`, and `v2.0.5`, unpublished `v2.0.2`, and partial `v2.0.3`; create `v2.0.6` on audited `main`, then verify the exact tag-triggered run uses the recorded first-release defaults and completes the signed release. |
 | 9.5 Homebrew tap | Signed workflow | Replace the legacy formula only with the verified signed render after release-origin smoke passes. |
 | 9.6 Installer and artifact acceptance | Owner | Verify immutable `install.sh` from R, land matching `scripts/get` and `docs/public/install.sh` in a separate post-release PR, validate/deploy D, then run public curl/Homebrew smoke. |
 | 9.7 Public live demo | Owner | The demo is already public and deploy is enabled; verify the audited deployment externally and record its release evidence. |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jobctrl",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "private": true,
   "description": "AI-powered end-to-end job application pipeline",
   "type": "module",

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jobctrl/api-client",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jobctrl/contracts",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/domain-types/package.json
+++ b/packages/domain-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jobctrl/domain-types",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jobctrl/tsconfig",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "private": true,
   "type": "module",
   "exports": {

--- a/scripts/distribution-manifest.test.mjs
+++ b/scripts/distribution-manifest.test.mjs
@@ -97,7 +97,7 @@ test("distribution contracts are complete and every version source resolves", as
   assert.equal(report.nodeLicenseEvidenceCount, 13);
   assert.equal(report.capabilityCount, 3);
   assert.deepEqual(report.platforms, ["darwin-arm64"]);
-  assert.equal(report.versions["jobctrl-launcher"], "2.0.5");
+  assert.equal(report.versions["jobctrl-launcher"], "2.0.6");
   assert.equal(report.versions["playwright-python"], "1.58.0");
   assert.equal(report.versions["font-geist"], "5.2.9");
   assert.equal(report.versions["font-jetbrains-mono"], "5.2.8");

--- a/scripts/distribution-release.test.mjs
+++ b/scripts/distribution-release.test.mjs
@@ -298,10 +298,10 @@ test("local fixture release descriptor, signature, and curl contract bind one ZI
     minimumSafeSequence: 0,
     revokedBuildIds: [],
     buildId: "fixture-build-0001",
-    appVersion: "2.0.5",
+    appVersion: "2.0.6",
     platform: { id: "darwin-arm64", os: "darwin", arch: "arm64" },
     artifact: {
-      url: "file:///jobctrl-local-release/jobctrl-2.0.5-darwin-arm64.zip",
+      url: "file:///jobctrl-local-release/jobctrl-2.0.6-darwin-arm64.zip",
       sha256: build.archiveSha256,
       sizeBytes: build.compressedBytes,
       archiveType: "zip",
@@ -761,7 +761,7 @@ test("release workflows use protected manual signing, artifact handoff, candidat
     /ENOENT/,
   );
   assert.match(releaseWorkflow, /workflow_dispatch:/);
-  assert.match(releaseWorkflow, /^  push:\n    tags:\n      - v2\.0\.5$/m);
+  assert.match(releaseWorkflow, /^  push:\n    tags:\n      - v2\.0\.6$/m);
   assert.match(releaseWorkflow, /\$\{\{ inputs\.release_tag \|\| github\.ref_name \}\}/);
   assert.match(releaseWorkflow, /\$\{\{ inputs\.channel \|\| 'stable' \}\}/);
   assert.match(releaseWorkflow, /\$\{\{ inputs\.sequence \|\| '1' \}\}/);
@@ -802,6 +802,10 @@ test("release workflows use protected manual signing, artifact handoff, candidat
     "brew test \"$formula\"",
     "for attempt in {1..24}",
     "sleep 5",
+    "jobctrl-release-readback=${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-pre",
+    "jobctrl-release-readback=${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-post-${attempt}",
+    "jobctrl-release-readback=${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-channel-pre",
+    "jobctrl-release-readback=${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-channel-post-${attempt}",
   ]) assert.ok(releaseWorkflow.includes(marker), `missing release workflow marker ${marker}`);
   assert.doesNotMatch(releaseWorkflow, /brew audit --strict --formula \"\$release\/jobctrl\.rb\"/);
   assert.doesNotMatch(releaseWorkflow, /brew install --formula \"\$release\/jobctrl\.rb\"/);

--- a/workers/automation/pyproject.toml
+++ b/workers/automation/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jobctrl"
-version = "2.0.5"
+version = "2.0.6"
 description = "AI-powered end-to-end job application pipeline"
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/workers/automation/src/jobctrl/__init__.py
+++ b/workers/automation/src/jobctrl/__init__.py
@@ -1,3 +1,3 @@
 """JobCtrl — AI-powered end-to-end job application pipeline."""
 
-__version__ = "2.0.5"
+__version__ = "2.0.6"

--- a/workers/automation/uv.lock
+++ b/workers/automation/uv.lock
@@ -586,7 +586,7 @@ wheels = [
 
 [[package]]
 name = "jobctrl"
-version = "2.0.5"
+version = "2.0.6"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## What changed

- use phase-scoped cache-busting query keys for immutable R2 prechecks and post-write checksum verification
- apply the same protection and bounded retry loop to stable channel-pointer promotion
- add workflow contract coverage for distinct pre- and post-write readback keys
- advance release metadata and the launch checklist to v2.0.6

## Root cause

The v2.0.5 release successfully built, signed, notarized, stapled, and uploaded its first immutable archive. The workflow had already requested that public URL before upload, however, so Cloudflare cached the initial 404 longer than the workflow's 120-second post-upload verification window. The object became public after the job failed.

## Validation

- `corepack pnpm scripts:test` — 129 passed
- `corepack pnpm distribution:audit` — passed
- `python3 scripts/release_check.py --strict-prompt --release-tag v2.0.6` — passed
- `corepack pnpm check` — passed
- `corepack pnpm docs:build` — passed
- `go test ./...` in `launcher/` — passed
- workflow YAML parse and `git diff --check` — passed