### PR TITLE
fix(ci): pin the audited Ruff version

### DIFF
--- a/workers/automation/pyproject.toml
+++ b/workers/automation/pyproject.toml
@@ -55,7 +55,7 @@ dev = [
     "pytest>=7.0",
     "pytest-asyncio>=0.23",
     "pytest-randomly>=4.0",
-    "ruff>=0.1",
+    "ruff==0.15.8",
 ]
 providers = [
     "claude-agent-sdk==0.2.115",

--- a/workers/automation/uv.lock
+++ b/workers/automation/uv.lock
@@ -667,7 +667,7 @@ requires-dist = [
     { name = "python-dotenv", specifier = ">=1.0" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "rich", specifier = ">=13.0" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = "==0.15.8" },
     { name = "temporalio", specifier = ">=1.6" },
     { name = "typer", specifier = ">=0.9.0" },
     { name = "websocket-client", specifier = ">=1.8" },


### PR DESCRIPTION
## What changed

Pin the Python development linter to Ruff 0.15.8, matching the checked-in `uv.lock` and the version used by local validation.

## Root cause

Python CI installs editable extras with `pip`, so the open `ruff>=0.1` range resolved the newly published Ruff 0.16.0 instead of the audited lockfile version. Ruff 0.16.0 introduced a changed lint surface and failed the unchanged tree with 1,194 new findings.

## Validation

- fresh Python 3.12 virtual environment with `pip install -e 'workers/automation[dev,providers]'`
- installed Ruff version: 0.15.8
- `ruff check workers/automation/src workers/automation/tests` — passed
- `env -u UV_EXCLUDE_NEWER uv --project workers/automation lock --check` — passed
- `git diff --check` — passed