### PR TITLE
fix(release): satisfy current Homebrew audit

### DIFF
--- a/.github/workflows/release-distribution.yml
+++ b/.github/workflows/release-distribution.yml
@@ -6,11 +6,11 @@ name: Release distribution
 # channel pointer. Immutable GitHub publication gates the final stable-only
 # PyPI publication lane.
 on:
-  # v2.0.6 is the one-time first-public-release fallback for environments where
+  # v2.0.7 is the one-time first-public-release fallback for environments where
   # the repository app can publish refs but cannot call workflow_dispatch.
   push:
     tags:
-      - v2.0.6
+      - v2.0.7
   workflow_dispatch:
     inputs:
       release_tag:

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jobctrl/api",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jobctrl/extension",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/extension/public/manifest.json
+++ b/apps/extension/public/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "JobCtrl",
   "description": "Save job postings from the browser into the local JobCtrl app.",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "action": {
     "default_popup": "popup.html"
   },

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jobctrl/web",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "private": true,
   "type": "module",
   "scripts": {

--- a/docs/publish-checklist.md
+++ b/docs/publish-checklist.md
@@ -258,10 +258,10 @@ especially §§11–14. This is a release precondition, not permission to publis
   plus its QA/deploy evidence, and every protected release environment in 9.4a
   is configured. The PyPI Trusted Publisher is already configured; verify its
   mapping rather than creating a second publisher or using a PyPI API token.
-- **Recovery note.** Preserve the failed `v2.0.0`, `v2.0.1`, `v2.0.4`, and
-  `v2.0.5` tags, the unpublished `v2.0.2` tag, and the partially published
-  `v2.0.3` tag at their original commits as audit evidence. `v2.0.0` stopped
-  before signing because
+- **Recovery note.** Preserve the failed `v2.0.0`, `v2.0.1`, `v2.0.4`,
+  `v2.0.5`, and `v2.0.6` tags, the unpublished `v2.0.2` tag, and the partially
+  published `v2.0.3` tag at their original commits as audit evidence.
+  `v2.0.0` stopped before signing because
   the signing runner requested an unavailable Python build. `v2.0.1` completed
   its builds, signing, Apple notarization, stapling, and audit packaging, then
   stopped before GitHub draft creation or R2 upload because a checkout-free
@@ -282,16 +282,21 @@ especially §§11–14. This is a release precondition, not permission to publis
   failed because the workflow's pre-upload 404 remained cached longer than the
   post-upload verification window; the GitHub Release, stable pointer,
   Homebrew formula, and PyPI package were not published.
+  `v2.0.6` completed its build, signing, Apple notarization, stapling, audit
+  packaging, immutable R2 publication, and native installer lifecycle smoke.
+  Its strict Homebrew formula audit found new style violations before formula
+  installation, so the stable pointer, public GitHub Release, Homebrew tap, and
+  PyPI package were not published.
   Do not move, delete, or dispatch any of these tags again.
 - **Action.** Fetch `origin/main` and tags, verify that the audited local commit
   and `origin/main` resolve to the same SHA, then create and push the exact
-  `v2.0.6` tag on that commit. Verify the remote tag resolves to that exact SHA
+  `v2.0.7` tag on that commit. Verify the remote tag resolves to that exact SHA
   and the tagged commit remains identical to or an ancestor of current `main`.
   Pushing this exact tag starts `Release distribution` with these
   first-release defaults; the manual dispatch path remains available:
 
   ```text
-  release_tag=v2.0.6
+  release_tag=v2.0.7
   channel=stable
   sequence=1
   minimum_safe_sequence=1
@@ -388,7 +393,7 @@ Phase 7 and its Definition of Done.
   `renderPinnedInstallScript` regression fix. Its contract must replace an
   existing release's URL, SHA-256, and version pins with the next release's
   values, not only replace empty pins; its regression coverage must prove a
-  `v2.0.6` render cannot retain `v2.0.5` pins. Do not use a manually edited
+  `v2.0.7` render cannot retain `v2.0.6` pins. Do not use a manually edited
   installer as a workaround.
 - **Action.** Run and record the plan's published-artifact acceptance matrix:
   clean Apple-silicon macOS installs through both curl and Homebrew; no source
@@ -402,7 +407,7 @@ Phase 7 and its Definition of Done.
 - **Mandatory canonical-installer cutover.** Treat the immutable signed release
   and the public installer deployment as two linked but different records:
 
-  1. Record the immutable `v2.0.6` tag/release SHA and tree as **R**. Retrieve
+  1. Record the immutable `v2.0.7` tag/release SHA and tree as **R**. Retrieve
      that release's immutable pinned `install.sh` and `SHA256SUMS`, verify
      `install.sh` against its published SHA-256, and retain the verified asset
      URL and checksum with R. Do not reconstruct or edit the retrieved script.
@@ -558,7 +563,7 @@ Perform the following in order and stop at the first failed gate:
    after the exact-tree local gate passes.
 2. Rerun the standard hosted workflows on the recorded SHA and require green
    runs with executed steps.
-3. On that final validated `main` SHA, create and push `v2.0.6`, verify the
+3. On that final validated `main` SHA, create and push `v2.0.7`, verify the
    remote tag resolves to that exact SHA and remains in `origin/main` history,
    and confirm the exact
    tag-triggered `Release distribution` run uses the six first-release defaults
@@ -620,7 +625,7 @@ rollback evidence, and publish corrections where a public claim proved wrong.
 | 9.1 Visibility flip | Owner | Run the exact-tree local gate, make the repository public, then rerun every standard hosted gate with real executed steps. |
 | 9.2 Docs-site verification | Owner | Docs are already public and deploy is enabled; dispatch at the gated `main` SHA and record the public deployment proof. |
 | 9.3 Rename redirect | Owner | Verify old-URL redirects after the flip and repair any stale repository links. |
-| 9.4 Release and PyPI | Owner | Preserve failed `v2.0.0`, `v2.0.1`, `v2.0.4`, and `v2.0.5`, unpublished `v2.0.2`, and partial `v2.0.3`; create `v2.0.6` on audited `main`, then verify the exact tag-triggered run uses the recorded first-release defaults and completes the signed release. |
+| 9.4 Release and PyPI | Owner | Preserve failed `v2.0.0`, `v2.0.1`, `v2.0.4`, `v2.0.5`, and `v2.0.6`, unpublished `v2.0.2`, and partial `v2.0.3`; create `v2.0.7` on audited `main`, then verify the exact tag-triggered run uses the recorded first-release defaults and completes the signed release. |
 | 9.5 Homebrew tap | Signed workflow | Replace the legacy formula only with the verified signed render after release-origin smoke passes. |
 | 9.6 Installer and artifact acceptance | Owner | Verify immutable `install.sh` from R, land matching `scripts/get` and `docs/public/install.sh` in a separate post-release PR, validate/deploy D, then run public curl/Homebrew smoke. |
 | 9.7 Public live demo | Owner | The demo is already public and deploy is enabled; verify the audited deployment externally and record its release evidence. |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jobctrl",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "private": true,
   "description": "AI-powered end-to-end job application pipeline",
   "type": "module",

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jobctrl/api-client",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jobctrl/contracts",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/domain-types/package.json
+++ b/packages/domain-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jobctrl/domain-types",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jobctrl/tsconfig",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "private": true,
   "type": "module",
   "exports": {

--- a/packaging/homebrew/Formula/jobctrl.rb.tmpl
+++ b/packaging/homebrew/Formula/jobctrl.rb.tmpl
@@ -9,11 +9,11 @@ require "json"
 class Jobctrl < Formula
   desc "Local-first job search mission control: discover, score, tailor, apply"
   homepage "https://jobctrl.dev"
-  license "AGPL-3.0-only"
 
   url "{{ARTIFACT_URL}}"
-  sha256 "{{ARTIFACT_SHA256}}"
   version "{{APP_VERSION}}"
+  sha256 "{{ARTIFACT_SHA256}}"
+  license "AGPL-3.0-only"
 
   JOBCTRL_BUILD_ID = "{{BUILD_ID}}"
   JOBCTRL_MANIFEST_SHA256 = "{{MANIFEST_SHA256}}"
@@ -33,29 +33,51 @@ class Jobctrl < Formula
 
   def verify_notarized_app!(bundle)
     codesign_output, codesign_status = Open3.capture2e(
-      "/usr/bin/codesign", "--verify", "--deep", "--strict", "--check-notarization", "-R=notarized", "--verbose=2", bundle.to_s
+      "/usr/bin/codesign",
+      "--verify",
+      "--deep",
+      "--strict",
+      "--check-notarization",
+      "-R=notarized",
+      "--verbose=2",
+      bundle.to_s,
     )
-    odie "JobCtrl release signature verification failed for #{bundle}: #{codesign_output}" unless codesign_status.success?
+    unless codesign_status.success?
+      odie "JobCtrl release signature verification failed for #{bundle}: #{codesign_output}"
+    end
 
     gatekeeper_output, gatekeeper_status = Open3.capture2e(
-      "/usr/sbin/spctl", "--assess", "--type", "execute", "--verbose=4", bundle.to_s
+      "/usr/sbin/spctl",
+      "--assess",
+      "--type",
+      "execute",
+      "--verbose=4",
+      bundle.to_s,
     )
-    unless gatekeeper_status.success? && gatekeeper_output.include?("source=Notarized Developer ID")
+    if !gatekeeper_status.success? || gatekeeper_output.exclude?("source=Notarized Developer ID")
       odie "JobCtrl release is not Gatekeeper-notarized for #{bundle}: #{gatekeeper_output}"
     end
   end
 
   def verify_notarized_executable!(executable)
     codesign_output, codesign_status = Open3.capture2e(
-      "/usr/bin/codesign", "--verify", "--strict", "--check-notarization", "-R=notarized", "--verbose=2", executable.to_s
+      "/usr/bin/codesign",
+      "--verify",
+      "--strict",
+      "--check-notarization",
+      "-R=notarized",
+      "--verbose=2",
+      executable.to_s,
     )
-    odie "JobCtrl release executable signature verification failed for #{executable}: #{codesign_output}" unless codesign_status.success?
+    unless codesign_status.success?
+      odie "JobCtrl release executable signature verification failed for #{executable}: #{codesign_output}"
+    end
   end
 
   def managed_headless_shell
     candidates = Dir[(buildpath/"chromium").join("**", "chrome-headless-shell")]
     candidates.select! { |candidate| File.file?(candidate) && File.executable?(candidate) }
-    odie "JobCtrl release has no managed Chromium headless shell to verify" unless candidates.length == 1
+    odie "JobCtrl release has no managed Chromium headless shell to verify" if candidates.length != 1
     Pathname.new(candidates.first)
   end
 
@@ -71,17 +93,25 @@ class Jobctrl < Formula
     bootstrap.install buildpath/"launcher/jobctrl"
     bootstrap.install buildpath/"launcher/jobctrl-installer"
     bootstrap.install cached_download => "jobctrl-release.zip"
-    resource("jobctrl-release-descriptor").stage { bootstrap.install "release-descriptor.json" => "homebrew-release.json" }
-    resource("jobctrl-release-descriptor-signature").stage { bootstrap.install "release-descriptor.json.sig" => "homebrew-release.json.sig" }
-    (bootstrap/"homebrew-bootstrap.json").write(JSON.generate({
-      schemaVersion: 1,
-      descriptorUrl: JOBCTRL_DESCRIPTOR_URL,
-      descriptor: "homebrew-release.json",
-      signature: "homebrew-release.json.sig",
-      archive: "jobctrl-release.zip",
-      buildId: JOBCTRL_BUILD_ID,
-      descriptorSha256: JOBCTRL_DESCRIPTOR_SHA256
-    }))
+    resource("jobctrl-release-descriptor").stage do
+      bootstrap.install "release-descriptor.json" => "homebrew-release.json"
+    end
+    resource("jobctrl-release-descriptor-signature").stage do
+      bootstrap.install "release-descriptor.json.sig" => "homebrew-release.json.sig"
+    end
+    (bootstrap/"homebrew-bootstrap.json").write(
+      JSON.generate(
+        {
+          schemaVersion:    1,
+          descriptorUrl:    JOBCTRL_DESCRIPTOR_URL,
+          descriptor:       "homebrew-release.json",
+          signature:        "homebrew-release.json.sig",
+          archive:          "jobctrl-release.zip",
+          buildId:          JOBCTRL_BUILD_ID,
+          descriptorSha256: JOBCTRL_DESCRIPTOR_SHA256,
+        },
+      ),
+    )
     bin.install_symlink bootstrap/"jobctrl"
   end
 
@@ -97,7 +127,7 @@ class Jobctrl < Formula
   end
 
   test do
-    assert_predicate libexec/"bootstrap"/"homebrew-bootstrap.json", :exist?
+    assert_path_exists libexec/"bootstrap"/"homebrew-bootstrap.json"
     assert_predicate bin/"jobctrl", :symlink?
   end
 end

--- a/scripts/distribution-homebrew.mjs
+++ b/scripts/distribution-homebrew.mjs
@@ -139,10 +139,7 @@ export function validateRenderedHomebrewFormula({ formula, descriptor, descripto
     `JOBCTRL_DESCRIPTOR_SHA256 = "${values.DESCRIPTOR_SHA256}"`,
     `JOBCTRL_SIGNATURE_SHA256 = "${values.SIGNATURE_SHA256}"`,
     'require "open3"',
-    '"/usr/bin/codesign", "--verify", "--deep", "--strict", "--check-notarization", "-R=notarized", "--verbose=2", bundle.to_s',
-    '"/usr/bin/codesign", "--verify", "--strict", "--check-notarization", "-R=notarized", "--verbose=2", executable.to_s',
-    '"/usr/sbin/spctl", "--assess", "--type", "execute", "--verbose=4", bundle.to_s',
-    'gatekeeper_output.include?("source=Notarized Developer ID")',
+    'if !gatekeeper_status.success? || gatekeeper_output.exclude?("source=Notarized Developer ID")',
     "verify_notarized_executable!(buildpath/\"launcher/jobctrl\")",
     "verify_notarized_executable!(buildpath/\"launcher/jobctrl-installer\")",
     "managed_headless_shell",
@@ -156,6 +153,12 @@ export function validateRenderedHomebrewFormula({ formula, descriptor, descripto
     'bin.install_symlink bootstrap/"jobctrl"',
   ];
   for (const marker of required) invariant(formula.includes(marker), `rendered Homebrew formula is missing ${marker}`);
+  const requiredCalls = [
+    /Open3\.capture2e\(\s*"\/usr\/bin\/codesign",\s*"--verify",\s*"--deep",\s*"--strict",\s*"--check-notarization",\s*"-R=notarized",\s*"--verbose=2",\s*bundle\.to_s,?\s*\)/,
+    /Open3\.capture2e\(\s*"\/usr\/bin\/codesign",\s*"--verify",\s*"--strict",\s*"--check-notarization",\s*"-R=notarized",\s*"--verbose=2",\s*executable\.to_s,?\s*\)/,
+    /Open3\.capture2e\(\s*"\/usr\/sbin\/spctl",\s*"--assess",\s*"--type",\s*"execute",\s*"--verbose=4",\s*bundle\.to_s,?\s*\)/,
+  ];
+  for (const pattern of requiredCalls) invariant(pattern.test(formula), `rendered Homebrew formula is missing security call ${pattern}`);
   invariant(formula.includes("Formula installation remains entirely prefix-owned"), "rendered Homebrew formula must use first-invocation bootstrap");
   invariant(!formula.includes('verify_notarized_app!(buildpath/"launcher/jobctrl")'), "rendered Homebrew formula must not Gatekeeper-assess raw launcher executables");
   invariant(!formula.includes('Pathname.new(Dir.home)'), "rendered Homebrew formula must not write the user home during install");

--- a/scripts/distribution-homebrew.render.bundle.mjs
+++ b/scripts/distribution-homebrew.render.bundle.mjs
@@ -13982,10 +13982,7 @@ function validateRenderedHomebrewFormula({ formula, descriptor, descriptorRaw, s
     `JOBCTRL_DESCRIPTOR_SHA256 = "${values.DESCRIPTOR_SHA256}"`,
     `JOBCTRL_SIGNATURE_SHA256 = "${values.SIGNATURE_SHA256}"`,
     'require "open3"',
-    '"/usr/bin/codesign", "--verify", "--deep", "--strict", "--check-notarization", "-R=notarized", "--verbose=2", bundle.to_s',
-    '"/usr/bin/codesign", "--verify", "--strict", "--check-notarization", "-R=notarized", "--verbose=2", executable.to_s',
-    '"/usr/sbin/spctl", "--assess", "--type", "execute", "--verbose=4", bundle.to_s',
-    'gatekeeper_output.include?("source=Notarized Developer ID")',
+    'if !gatekeeper_status.success? || gatekeeper_output.exclude?("source=Notarized Developer ID")',
     'verify_notarized_executable!(buildpath/"launcher/jobctrl")',
     'verify_notarized_executable!(buildpath/"launcher/jobctrl-installer")',
     "managed_headless_shell",
@@ -13999,6 +13996,12 @@ function validateRenderedHomebrewFormula({ formula, descriptor, descriptorRaw, s
     'bin.install_symlink bootstrap/"jobctrl"'
   ];
   for (const marker of required) invariant5(formula.includes(marker), `rendered Homebrew formula is missing ${marker}`);
+  const requiredCalls = [
+    /Open3\.capture2e\(\s*"\/usr\/bin\/codesign",\s*"--verify",\s*"--deep",\s*"--strict",\s*"--check-notarization",\s*"-R=notarized",\s*"--verbose=2",\s*bundle\.to_s,?\s*\)/,
+    /Open3\.capture2e\(\s*"\/usr\/bin\/codesign",\s*"--verify",\s*"--strict",\s*"--check-notarization",\s*"-R=notarized",\s*"--verbose=2",\s*executable\.to_s,?\s*\)/,
+    /Open3\.capture2e\(\s*"\/usr\/sbin\/spctl",\s*"--assess",\s*"--type",\s*"execute",\s*"--verbose=4",\s*bundle\.to_s,?\s*\)/
+  ];
+  for (const pattern of requiredCalls) invariant5(pattern.test(formula), `rendered Homebrew formula is missing security call ${pattern}`);
   invariant5(formula.includes("Formula installation remains entirely prefix-owned"), "rendered Homebrew formula must use first-invocation bootstrap");
   invariant5(!formula.includes('verify_notarized_app!(buildpath/"launcher/jobctrl")'), "rendered Homebrew formula must not Gatekeeper-assess raw launcher executables");
   invariant5(!formula.includes("Pathname.new(Dir.home)"), "rendered Homebrew formula must not write the user home during install");

--- a/scripts/distribution-homebrew.render.bundle.mjs.sha256
+++ b/scripts/distribution-homebrew.render.bundle.mjs.sha256
@@ -1,2 +1,2 @@
-f1549bf1f61e0bd6fc96f7f79b2677d59a168f5f2977457d465b6f57df69091c  distribution-homebrew.render.bundle.mjs
+5508c8fc9954331d56e81a07b67162221312ead48d8820160865da4e95648d85  distribution-homebrew.render.bundle.mjs
 9fccd02acf8b52c9a28b4e1956f791f8ec126230e2c336f534191f1bcb646ebd  distribution-release-authority-bundles.NOTICE.txt

--- a/scripts/distribution-homebrew.test.mjs
+++ b/scripts/distribution-homebrew.test.mjs
@@ -80,9 +80,9 @@ test("Homebrew render uses the exact signed curl ZIP identity without a toolchai
   assert.match(rendered.formula, /bin\.install_symlink bootstrap\/"jobctrl"/);
   assert.doesNotMatch(rendered.formula, /Pathname\.new\(Dir\.home\)/);
   assert.match(rendered.formula, /Open3\.capture2e/);
-  assert.match(rendered.formula, /--verify", "--deep", "--strict", "--check-notarization", "-R=notarized/);
+  assert.match(rendered.formula, /"--verify",\s*"--deep",\s*"--strict",\s*"--check-notarization",\s*"-R=notarized"/);
   assert.match(rendered.formula, /def verify_notarized_executable!/);
-  assert.match(rendered.formula, /--assess", "--type", "execute", "--verbose=4/);
+  assert.match(rendered.formula, /"--assess",\s*"--type",\s*"execute",\s*"--verbose=4"/);
   assert.doesNotMatch(rendered.formula, /context:primary-signature/);
   assert.match(rendered.formula, /source=Notarized Developer ID/);
   assert.match(rendered.formula, /managed_headless_shell/);
@@ -223,8 +223,16 @@ test("Homebrew formula validation rejects a render that omits launcher or Chromi
     /launcher\/jobctrl/,
   );
   assert.throws(
-    () => validateRenderedHomebrewFormula({ formula: rendered.formula.replace('gatekeeper_output.include?("source=Notarized Developer ID")', "true"), descriptor: stableDescriptor(), descriptorRaw, signatureRaw, descriptorUrl }),
-    /source=Notarized Developer ID/,
+    () => validateRenderedHomebrewFormula({ formula: rendered.formula.replace('gatekeeper_output.exclude?("source=Notarized Developer ID")', "true"), descriptor: stableDescriptor(), descriptorRaw, signatureRaw, descriptorUrl }),
+    /gatekeeper_status/,
+  );
+  assert.throws(
+    () => validateRenderedHomebrewFormula({ formula: rendered.formula.replace("!gatekeeper_status.success? || ", ""), descriptor: stableDescriptor(), descriptorRaw, signatureRaw, descriptorUrl }),
+    /gatekeeper_status/,
+  );
+  assert.throws(
+    () => validateRenderedHomebrewFormula({ formula: rendered.formula.replace('"--check-notarization",', '"--notarization-unchecked",'), descriptor: stableDescriptor(), descriptorRaw, signatureRaw, descriptorUrl }),
+    /security call/,
   );
   assert.throws(
     () => validateRenderedHomebrewFormula({ formula: rendered.formula.replaceAll("managed_headless_shell", "chromium_headless"), descriptor: stableDescriptor(), descriptorRaw, signatureRaw, descriptorUrl }),

--- a/scripts/distribution-manifest.test.mjs
+++ b/scripts/distribution-manifest.test.mjs
@@ -97,7 +97,7 @@ test("distribution contracts are complete and every version source resolves", as
   assert.equal(report.nodeLicenseEvidenceCount, 13);
   assert.equal(report.capabilityCount, 3);
   assert.deepEqual(report.platforms, ["darwin-arm64"]);
-  assert.equal(report.versions["jobctrl-launcher"], "2.0.6");
+  assert.equal(report.versions["jobctrl-launcher"], "2.0.7");
   assert.equal(report.versions["playwright-python"], "1.58.0");
   assert.equal(report.versions["font-geist"], "5.2.9");
   assert.equal(report.versions["font-jetbrains-mono"], "5.2.8");

--- a/scripts/distribution-release.test.mjs
+++ b/scripts/distribution-release.test.mjs
@@ -298,10 +298,10 @@ test("local fixture release descriptor, signature, and curl contract bind one ZI
     minimumSafeSequence: 0,
     revokedBuildIds: [],
     buildId: "fixture-build-0001",
-    appVersion: "2.0.6",
+    appVersion: "2.0.7",
     platform: { id: "darwin-arm64", os: "darwin", arch: "arm64" },
     artifact: {
-      url: "file:///jobctrl-local-release/jobctrl-2.0.6-darwin-arm64.zip",
+      url: "file:///jobctrl-local-release/jobctrl-2.0.7-darwin-arm64.zip",
       sha256: build.archiveSha256,
       sizeBytes: build.compressedBytes,
       archiveType: "zip",
@@ -761,7 +761,7 @@ test("release workflows use protected manual signing, artifact handoff, candidat
     /ENOENT/,
   );
   assert.match(releaseWorkflow, /workflow_dispatch:/);
-  assert.match(releaseWorkflow, /^  push:\n    tags:\n      - v2\.0\.6$/m);
+  assert.match(releaseWorkflow, /^  push:\n    tags:\n      - v2\.0\.7$/m);
   assert.match(releaseWorkflow, /\$\{\{ inputs\.release_tag \|\| github\.ref_name \}\}/);
   assert.match(releaseWorkflow, /\$\{\{ inputs\.channel \|\| 'stable' \}\}/);
   assert.match(releaseWorkflow, /\$\{\{ inputs\.sequence \|\| '1' \}\}/);

--- a/workers/automation/pyproject.toml
+++ b/workers/automation/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jobctrl"
-version = "2.0.6"
+version = "2.0.7"
 description = "AI-powered end-to-end job application pipeline"
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/workers/automation/src/jobctrl/__init__.py
+++ b/workers/automation/src/jobctrl/__init__.py
@@ -1,3 +1,3 @@
 """JobCtrl — AI-powered end-to-end job application pipeline."""
 
-__version__ = "2.0.6"
+__version__ = "2.0.7"

--- a/workers/automation/uv.lock
+++ b/workers/automation/uv.lock
@@ -586,7 +586,7 @@ wheels = [
 
 [[package]]
 name = "jobctrl"
-version = "2.0.6"
+version = "2.0.7"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## What changed

- reformats the stable Homebrew formula to satisfy the current strict Homebrew audit without weakening signing, notarization, Gatekeeper, or managed-Chromium verification
- updates the formula validator and regression tests for the multiline security calls and full fail-closed Gatekeeper condition
- regenerates the pinned Homebrew render authority bundle and checksum
- advances the unreleased distribution identity and one-time tag trigger to v2.0.7
- records v2.0.6 as a partial release that stopped before stable/public promotion

## Why

The v2.0.6 release completed signing, Apple notarization, immutable R2 publication, and native installer lifecycle QA, then stopped because the rendered formula failed Homebrew's current strict style audit. This keeps the same release/security behavior while making the formula acceptable to the current Homebrew tooling.

## Validation

- `corepack pnpm scripts:test` — 129 passed
- `corepack pnpm distribution:audit` — passed
- `python3 scripts/release_check.py --strict-prompt --release-tag v2.0.7` — passed
- `env -u UV_EXCLUDE_NEWER uv --project workers/automation lock --check` — passed
- `corepack pnpm check` — passed
- `corepack pnpm docs:build` — passed
- `go test ./...` from `launcher/` — passed
- rendered signed fixture audited with `brew audit --strict --formula ...` — passed
- Ruby syntax and `git diff --check` — passed