### PR TITLE
fix(release): repair publication recovery

### DIFF
--- a/.github/workflows/release-distribution.yml
+++ b/.github/workflows/release-distribution.yml
@@ -23,6 +23,11 @@ on:
         default: stable
         type: choice
         options: [stable, prerelease]
+      pypi_recovery_only:
+        description: Rebuild and publish PyPI from immutable v2.0.7 on main without signing or release publication
+        required: false
+        default: false
+        type: boolean
       sequence:
         description: Monotonic signed descriptor sequence
         required: true
@@ -76,11 +81,20 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ inputs.release_tag || github.ref_name }}
+          RELEASE_CHANNEL: ${{ inputs.channel || 'stable' }}
+          PYPI_RECOVERY_ONLY: ${{ inputs.pypi_recovery_only || false }}
         run: |
           set -euo pipefail
           head_sha="$(git rev-parse HEAD)"
-          test "$GITHUB_REF" = "refs/tags/$RELEASE_TAG"
-          test "$GITHUB_SHA" = "$head_sha"
+          if [[ "$PYPI_RECOVERY_ONLY" = true ]]; then
+            test "$GITHUB_EVENT_NAME" = workflow_dispatch
+            test "$GITHUB_REF" = refs/heads/main
+            test "$RELEASE_TAG" = v2.0.7
+            test "$RELEASE_CHANNEL" = stable
+          else
+            test "$GITHUB_REF" = "refs/tags/$RELEASE_TAG"
+            test "$GITHUB_SHA" = "$head_sha"
+          fi
           main_relation="$(gh api "repos/$GITHUB_REPOSITORY/compare/$head_sha...main" --jq '.status')"
           [[ "$main_relation" = ahead || "$main_relation" = identical ]]
           test "$(gh api "repos/$GITHUB_REPOSITORY/commits/$RELEASE_TAG" --jq '.sha')" = "$head_sha"
@@ -120,6 +134,7 @@ jobs:
   publication-preflight:
     name: Preflight checkout-free GitHub publication access
     needs: resolve
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.pypi_recovery_only != true }}
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -150,6 +165,7 @@ jobs:
   prepare:
     name: Build unsigned candidate once
     needs: resolve
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.pypi_recovery_only != true }}
     runs-on: macos-15
     permissions:
       actions: read
@@ -248,6 +264,7 @@ jobs:
   sign:
     name: Sign and notarize on a fresh protected runner
     needs: [resolve, publication-preflight, prepare]
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.pypi_recovery_only != true }}
     runs-on: macos-15
     environment: release-signing
     outputs:
@@ -466,6 +483,7 @@ jobs:
   package-signed-candidate:
     name: Package signed audit evidence without credentials
     needs: [resolve, sign]
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.pypi_recovery_only != true }}
     runs-on: ubuntu-24.04
     permissions:
       actions: read
@@ -529,6 +547,7 @@ jobs:
   publish-immutable:
     name: Publish the signed immutable candidate from a fresh runner
     needs: [resolve, sign, package-signed-candidate]
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.pypi_recovery_only != true }}
     runs-on: ubuntu-24.04
     environment: release-publication
     permissions:
@@ -706,6 +725,7 @@ jobs:
   smoke-and-verify:
     name: Smoke public assets and verify the native and Homebrew lifecycles
     needs: [resolve, sign, package-signed-candidate, publish-immutable]
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.pypi_recovery_only != true }}
     runs-on: macos-15
     permissions:
       actions: read
@@ -823,9 +843,9 @@ jobs:
           retention-days: 14
 
   sync-homebrew:
-    name: Sync verified stable Homebrew formula
+    name: Verify stable Homebrew formula without tap credentials
     needs: [resolve, sign, package-signed-candidate, smoke-and-verify, promote-channel-pointer]
-    if: ${{ (inputs.channel || 'stable') == 'stable' }}
+    if: ${{ (github.event_name != 'workflow_dispatch' || inputs.pypi_recovery_only != true) && (inputs.channel || 'stable') == 'stable' }}
     uses: ./.github/workflows/sync-homebrew-tap.yml
     with:
       release_artifact_name: jobctrl-release-candidate-${{ github.run_id }}
@@ -834,10 +854,100 @@ jobs:
       release_ref: ${{ needs.resolve.outputs.release_ref }}
       release_tag: ${{ inputs.release_tag || github.ref_name }}
       expected_formula_sha256: ${{ needs.sign.outputs.formula_sha256 }}
+
+  publish-homebrew:
+    name: Publish the verified stable Homebrew formula
+    needs: [resolve, sign, sync-homebrew, promote-channel-pointer]
+    if: ${{ (github.event_name != 'workflow_dispatch' || inputs.pypi_recovery_only != true) && (inputs.channel || 'stable') == 'stable' }}
+    runs-on: ubuntu-24.04
+    environment: release-publication
+    permissions:
+      actions: read
+      contents: read
+    env:
+      RELEASE_REF: ${{ needs.resolve.outputs.release_ref }}
+      RELEASE_TAG: ${{ inputs.release_tag || github.ref_name }}
+      EXPECTED_FORMULA_SHA256: ${{ needs.sign.outputs.formula_sha256 }}
+    steps:
+      - name: Download the exact verified formula
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: jobctrl-homebrew-verified-${{ github.run_id }}
+          path: ${{ runner.temp }}/jobctrl-verified
+
+      - name: Verify the sealed formula checksum
+        run: |
+          set -euo pipefail
+          verified="$RUNNER_TEMP/jobctrl-verified"
+          test -f "$verified/jobctrl.rb" && test ! -L "$verified/jobctrl.rb"
+          test -f "$verified/jobctrl.rb.sha256" && test ! -L "$verified/jobctrl.rb.sha256"
+          (
+            cd "$verified"
+            shasum -a 256 -c jobctrl.rb.sha256
+          )
+          test "$(shasum -a 256 "$verified/jobctrl.rb" | awk '{print $1}')" = "$EXPECTED_FORMULA_SHA256"
+
+      - name: Reassert the audited source lineage before loading the tap deploy key
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          main_relation="$(gh api "repos/$GITHUB_REPOSITORY/compare/$RELEASE_REF...main" --jq '.status')"
+          [[ "$main_relation" = ahead || "$main_relation" = identical ]]
+          test "$(gh api "repos/$GITHUB_REPOSITORY/commits/$RELEASE_TAG" --jq '.sha')" = "$RELEASE_REF"
+
+      - name: Require the protected Homebrew tap deploy key
+        env:
+          HOMEBREW_TAP_DEPLOY_KEY: ${{ secrets.HOMEBREW_TAP_DEPLOY_KEY }}
+        run: |
+          set -euo pipefail
+          test -n "$HOMEBREW_TAP_DEPLOY_KEY"
+
+      - name: Check out Homebrew tap
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          repository: ebarti/homebrew-tap
+          path: homebrew-tap
+          ssh-key: ${{ secrets.HOMEBREW_TAP_DEPLOY_KEY }}
+
+      - name: Require the SSH Homebrew tap origin
+        run: |
+          set -euo pipefail
+          test "$(git -C homebrew-tap remote get-url origin)" = "git@github.com:ebarti/homebrew-tap.git"
+
+      - name: Synchronize the verified rendered formula
+        run: |
+          set -euo pipefail
+          install -m 0644 "$RUNNER_TEMP/jobctrl-verified/jobctrl.rb" homebrew-tap/Formula/jobctrl.rb
+          git -C homebrew-tap diff --check
+
+      - name: Reassert the audited source lineage immediately before tap publication
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          main_relation="$(gh api "repos/$GITHUB_REPOSITORY/compare/$RELEASE_REF...main" --jq '.status')"
+          [[ "$main_relation" = ahead || "$main_relation" = identical ]]
+          test "$(gh api "repos/$GITHUB_REPOSITORY/commits/$RELEASE_TAG" --jq '.sha')" = "$RELEASE_REF"
+
+      - name: Commit synchronized formula
+        working-directory: homebrew-tap
+        run: |
+          set -euo pipefail
+          if [[ -z "$(git status --short --untracked-files=all -- Formula/jobctrl.rb)" ]]; then
+            echo "Formula/jobctrl.rb already matches the P6-verified render."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add Formula/jobctrl.rb
+          git commit -m "chore: sync JobCtrl stable formula"
+          git push origin HEAD:main
+
   promote-channel-pointer:
     name: Atomically promote only the signer-rooted pointer
     needs: [resolve, sign, package-signed-candidate, smoke-and-verify]
-    if: ${{ always() && needs.sign.result == 'success' && needs['package-signed-candidate'].result == 'success' && needs['smoke-and-verify'].result == 'success' }}
+    if: ${{ (github.event_name != 'workflow_dispatch' || inputs.pypi_recovery_only != true) && always() && needs.sign.result == 'success' && needs['package-signed-candidate'].result == 'success' && needs['smoke-and-verify'].result == 'success' }}
     runs-on: ubuntu-24.04
     environment: release-publication
     permissions:
@@ -1025,8 +1135,8 @@ jobs:
 
   publish-github-release:
     name: Publish the verified GitHub Release
-    needs: [resolve, sign, package-signed-candidate, smoke-and-verify, sync-homebrew, promote-channel-pointer]
-    if: ${{ always() && needs['smoke-and-verify'].result == 'success' && needs['promote-channel-pointer'].result == 'success' && (needs['sync-homebrew'].result == 'success' || needs['sync-homebrew'].result == 'skipped') }}
+    needs: [resolve, sign, package-signed-candidate, smoke-and-verify, publish-homebrew, promote-channel-pointer]
+    if: ${{ (github.event_name != 'workflow_dispatch' || inputs.pypi_recovery_only != true) && always() && needs['smoke-and-verify'].result == 'success' && needs['promote-channel-pointer'].result == 'success' && (needs['publish-homebrew'].result == 'success' || needs['publish-homebrew'].result == 'skipped') }}
     runs-on: ubuntu-24.04
     environment: release-publication
     permissions:
@@ -1132,10 +1242,40 @@ jobs:
           done
           gh release verify "$RELEASE_TAG"
 
+  pypi-recovery-preflight:
+    name: Prove immutable v2.0.7 release before PyPI recovery
+    needs: resolve
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.pypi_recovery_only == true }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    env:
+      RELEASE_TAG: ${{ inputs.release_tag }}
+      RELEASE_REF: ${{ needs.resolve.outputs.release_ref }}
+    steps:
+      - name: Prove the existing stable release is exact, ancestral, immutable, and verified
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          test "$RELEASE_TAG" = v2.0.7
+          tag_sha="$(gh api "repos/$GITHUB_REPOSITORY/commits/$RELEASE_TAG" --jq '.sha')"
+          test "$tag_sha" = "$RELEASE_REF"
+          main_relation="$(gh api "repos/$GITHUB_REPOSITORY/compare/$RELEASE_REF...main" --jq '.status')"
+          [[ "$main_relation" = ahead || "$main_relation" = identical ]]
+          release="$RUNNER_TEMP/recovery-release.json"
+          gh release view "$RELEASE_TAG" --json isDraft,isImmutable,isPrerelease,targetCommitish,tagName > "$release"
+          test "$(jq -r '.tagName' "$release")" = "$RELEASE_TAG"
+          test "$(jq -r '.targetCommitish' "$release")" = "$RELEASE_REF"
+          test "$(jq -r '.isDraft' "$release")" = false
+          test "$(jq -r '.isPrerelease' "$release")" = false
+          test "$(jq -r '.isImmutable' "$release")" = true
+          gh release verify "$RELEASE_TAG"
+
   pypi-resolve:
     name: Verify the immutable signed stable release for PyPI
-    needs: [resolve, publish-github-release]
-    if: ${{ (inputs.channel || 'stable') == 'stable' && needs['publish-github-release'].result == 'success' }}
+    needs: [resolve, publish-github-release, pypi-recovery-preflight]
+    if: ${{ always() && needs.resolve.result == 'success' && (inputs.channel || 'stable') == 'stable' && (((github.event_name != 'workflow_dispatch' || inputs.pypi_recovery_only != true) && needs['publish-github-release'].result == 'success') || (github.event_name == 'workflow_dispatch' && inputs.pypi_recovery_only == true && needs['pypi-recovery-preflight'].result == 'success')) }}
     runs-on: ubuntu-24.04
     outputs:
       source_commit: ${{ steps.identity.outputs.source_commit }}
@@ -1358,6 +1498,6 @@ jobs:
           )
 
       - name: Publish verified distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@6733eb7d741f0b11ec6a39b58540dab7590f9b7d # v1.14.0
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           packages-dir: ${{ runner.temp }}/jobctrl-pypi-dists/packages

--- a/.github/workflows/sync-homebrew-tap.yml
+++ b/.github/workflows/sync-homebrew-tap.yml
@@ -3,8 +3,8 @@ name: Sync Homebrew Tap
 # This is deliberately reusable only after P6 has downloaded the candidate
 # from the public HTTPS origin. Callers pass an Actions artifact name, never
 # workspace file paths: the formula, descriptor, trust registry, and smoke
-# evidence are authenticated again on this clean runner before tap credentials
-# are loaded.
+# evidence are authenticated again on this clean runner. The caller publishes
+# the sealed formula from its protected environment after this verification.
 on:
   workflow_call:
     inputs:
@@ -126,79 +126,3 @@ jobs:
           path: ${{ runner.temp }}/jobctrl-verified
           if-no-files-found: error
           retention-days: 14
-
-  publish:
-    name: Publish only the sealed formula on a fresh runner
-    needs: verify
-    runs-on: ubuntu-24.04
-    environment: release-publication
-    permissions:
-      actions: read
-      contents: read
-    env:
-      RELEASE_REF: ${{ inputs.release_ref }}
-      RELEASE_TAG: ${{ inputs.release_tag }}
-      EXPECTED_FORMULA_SHA256: ${{ inputs.expected_formula_sha256 }}
-    steps:
-      - name: Download the exact verified formula
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
-        with:
-          name: jobctrl-homebrew-verified-${{ github.run_id }}
-          path: ${{ runner.temp }}/jobctrl-verified
-
-      - name: Verify the sealed formula checksum
-        run: |
-          set -euo pipefail
-          verified="$RUNNER_TEMP/jobctrl-verified"
-          test -f "$verified/jobctrl.rb" && test ! -L "$verified/jobctrl.rb"
-          test -f "$verified/jobctrl.rb.sha256" && test ! -L "$verified/jobctrl.rb.sha256"
-          (
-            cd "$verified"
-            shasum -a 256 -c jobctrl.rb.sha256
-          )
-          test "$(shasum -a 256 "$verified/jobctrl.rb" | awk '{print $1}')" = "$EXPECTED_FORMULA_SHA256"
-
-      - name: Reassert the audited source lineage before loading the tap deploy key
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          main_relation="$(gh api "repos/$GITHUB_REPOSITORY/compare/$RELEASE_REF...main" --jq '.status')"
-          [[ "$main_relation" = ahead || "$main_relation" = identical ]]
-          test "$(gh api "repos/$GITHUB_REPOSITORY/commits/$RELEASE_TAG" --jq '.sha')" = "$RELEASE_REF"
-
-      - name: Check out Homebrew tap
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-        with:
-          repository: ebarti/homebrew-tap
-          path: homebrew-tap
-          ssh-key: ${{ secrets.HOMEBREW_TAP_DEPLOY_KEY }}
-
-      - name: Synchronize the verified rendered formula
-        run: |
-          set -euo pipefail
-          install -m 0644 "$RUNNER_TEMP/jobctrl-verified/jobctrl.rb" homebrew-tap/Formula/jobctrl.rb
-          git -C homebrew-tap diff --check
-
-      - name: Reassert the audited source lineage immediately before tap publication
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          main_relation="$(gh api "repos/$GITHUB_REPOSITORY/compare/$RELEASE_REF...main" --jq '.status')"
-          [[ "$main_relation" = ahead || "$main_relation" = identical ]]
-          test "$(gh api "repos/$GITHUB_REPOSITORY/commits/$RELEASE_TAG" --jq '.sha')" = "$RELEASE_REF"
-
-      - name: Commit synchronized formula
-        working-directory: homebrew-tap
-        run: |
-          set -euo pipefail
-          if [[ -z "$(git status --short --untracked-files=all -- Formula/jobctrl.rb)" ]]; then
-            echo "Formula/jobctrl.rb already matches the P6-verified render."
-            exit 0
-          fi
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add Formula/jobctrl.rb
-          git commit -m "chore: sync JobCtrl stable formula"
-          git push origin HEAD:main

--- a/docs/plans/2026-07-10-bundled-jobctrl-distribution-plan.md
+++ b/docs/plans/2026-07-10-bundled-jobctrl-distribution-plan.md
@@ -1,14 +1,17 @@
 # Bundled JobCtrl Distribution Plan
 
 - **Date:** 2026-07-10
-- **Status (2026-07-12):** Active / implementation landed, publication not
-  complete. The plan (#394) and P0–P7 stack (#396, #399–#405) are merged to
-  `main`. Local payload, launcher, capability, acquisition, lifecycle,
-  supply-chain, and source-vs-bundled documentation gates passed in their
-  delivery PRs. No signed/notarized stable artifact has been published, so
+- **Status (2026-07-24):** Active / implementation and stable release landed;
+  published-artifact acceptance remains open. The plan (#394) and P0–P7 stack
+  (#396, #399–#405) are merged to `main`. The signed and notarized `v2.0.7`
+  release is immutable on GitHub, its signed assets and stable pointer are
+  public on R2, and its verified Homebrew formula is live. The initial PyPI
+  upload stopped before publication because of a publisher-action pin defect;
+  recover that missing channel against the existing `v2.0.7` release rather
+  than creating a new product version. Canonical installer/docs cutover,
   clean-machine curl/Homebrew, update/rollback/uninstall, and real-path TTFV QA
   against the published artifact remain open. This plan stays top-level until
-  those release-authority and published-artifact gates pass.
+  those published-artifact gates pass.
 - **Anchors:** Current behavior and file ownership verified against
   `main @ 771f40c0`. Re-verify all paths against the implementation base before
   starting each phase.

--- a/docs/publish-checklist.md
+++ b/docs/publish-checklist.md
@@ -288,12 +288,17 @@ especially §§11–14. This is a release precondition, not permission to publis
   installation, so the stable pointer, public GitHub Release, Homebrew tap, and
   PyPI package were not published.
   Do not move, delete, or dispatch any of these tags again.
-- **Action.** Fetch `origin/main` and tags, verify that the audited local commit
-  and `origin/main` resolve to the same SHA, then create and push the exact
-  `v2.0.7` tag on that commit. Verify the remote tag resolves to that exact SHA
-  and the tagged commit remains identical to or an ancestor of current `main`.
-  Pushing this exact tag starts `Release distribution` with these
-  first-release defaults; the manual dispatch path remains available:
+- **Current release record.** `v2.0.7` is the first published stable release.
+  Its immutable GitHub Release, signed R2 assets, stable channel pointer, native
+  lifecycle proof, and verified Homebrew formula were published from audited
+  commit `db257efe1087ec00ac2ec49b846a95d2423aecc2`. The initial PyPI upload
+  stopped before publication because the publisher action referenced the
+  annotated `v1.14.0` tag object rather than its peeled executable commit.
+  This is a publication-pipeline defect, not a product change: preserve
+  `v2.0.7` and do not create another product version to recover the missing
+  PyPI channel.
+- **Original release inputs.** The exact `v2.0.7` tag-triggered run used these
+  first-release defaults:
 
   ```text
   release_tag=v2.0.7
@@ -304,13 +309,29 @@ especially §§11–14. This is a release precondition, not permission to publis
   expected_channel_pointer_sha256=absent
   ```
 
-  The final `absent` value is required because the live stable pointer currently
-  returns 404; it is the workflow's explicit conditional-create precondition.
+  The final `absent` value was required because the live stable pointer did not
+  exist before this first promotion; it was the workflow's explicit
+  conditional-create precondition.
   After immutable GitHub publication, the credential-free `pypi-resolve` job
   verifies the exact ref, release attestation, audit evidence, and public trust
   before the single clean PyPI builder produces checksum-bound distributions.
   The `pypi` job then publishes only those unchanged bytes through OIDC. Verify
   the PyPI package and immutable GitHub Release after the workflow succeeds.
+- **PyPI-only recovery.** Dispatch `Release distribution` from `main` with the
+  original stable inputs, `release_tag=v2.0.7`, and
+  `pypi_recovery_only=true`. The resolver must require that exact tag and
+  stable channel, prove the tag remains in `main`, and verify the existing
+  immutable public Release before any build. In this mode the workflow must
+  skip signing, notarization, R2 publication, native and Homebrew smoke, stable
+  pointer promotion, Homebrew publication, and GitHub Release publication. It
+  may run only the read-only recovery preflight and the existing
+  `pypi-resolve`, `pypi-build`, and OIDC `publish-pypi` chain. Because the
+  corrected workflow definition exists on `main` while the immutable release
+  tag retains its original workflow, temporarily admit the `main` branch to
+  only the `release-verification` and `pypi` environments for this recovery.
+  Remove those two temporary branch policies immediately after the run reaches
+  a terminal state and verify both environments again admit only `v*` tags.
+  Do not change the policies of `release-signing` or `release-publication`.
 - **Rollback.** Preserve the immutable Release and tag as audit evidence. Yank
   a bad PyPI file/version when necessary, then publish a new higher-sequence
   signed release that explicitly revokes or supersedes the affected build.
@@ -361,9 +382,9 @@ exact SHA-256. A credential-free job smoke-tests that formula and published ZIP
 without re-rendering either. The reusable tap workflow receives the untouched
 signed candidate and separate smoke evidence,
 re-verifies the signer-rooted formula digest, and seals the exact formula
-without tap credentials before handing only the formula and checksum to a
-fresh deploy-key job. It never triggers from `main` or merely from a published
-GitHub Release.
+without tap credentials before handing only the formula and checksum to the
+protected deploy-key job in the top-level release workflow. It never triggers
+from `main` or merely from a published GitHub Release.
 The formula writes only its Homebrew prefix: its `bin/jobctrl` target is a
 native first-invocation bootstrap holding the signed descriptor resources and
 cached ZIP. It must not create `~/.jobctrl`, mutate a Cellar payload, or link a
@@ -625,8 +646,8 @@ rollback evidence, and publish corrections where a public claim proved wrong.
 | 9.1 Visibility flip | Owner | Run the exact-tree local gate, make the repository public, then rerun every standard hosted gate with real executed steps. |
 | 9.2 Docs-site verification | Owner | Docs are already public and deploy is enabled; dispatch at the gated `main` SHA and record the public deployment proof. |
 | 9.3 Rename redirect | Owner | Verify old-URL redirects after the flip and repair any stale repository links. |
-| 9.4 Release and PyPI | Owner | Preserve failed `v2.0.0`, `v2.0.1`, `v2.0.4`, `v2.0.5`, and `v2.0.6`, unpublished `v2.0.2`, and partial `v2.0.3`; create `v2.0.7` on audited `main`, then verify the exact tag-triggered run uses the recorded first-release defaults and completes the signed release. |
-| 9.5 Homebrew tap | Signed workflow | Replace the legacy formula only with the verified signed render after release-origin smoke passes. |
+| 9.4 Release and PyPI | Owner | Keep the published `v2.0.7` GitHub/R2/Homebrew release unchanged; merge the peeled PyPI action pin and isolated recovery path, then run the `v2.0.7` PyPI-only recovery and verify the public wheel and source distribution. |
+| 9.5 Homebrew tap | Signed workflow | Completed for `v2.0.7`; retain the verified formula and land the protected top-level deploy-key publication fix for future releases. |
 | 9.6 Installer and artifact acceptance | Owner | Verify immutable `install.sh` from R, land matching `scripts/get` and `docs/public/install.sh` in a separate post-release PR, validate/deploy D, then run public curl/Homebrew smoke. |
 | 9.7 Public live demo | Owner | The demo is already public and deploy is enabled; verify the audited deployment externally and record its release evidence. |
 | 10 Publicization | Owner | Prepare factual assets and platform access today; on launch day announce only after the public release and command smoke pass, then cover responses and record the 1h–72h metrics. |

--- a/scripts/distribution-release.test.mjs
+++ b/scripts/distribution-release.test.mjs
@@ -768,6 +768,7 @@ test("release workflows use protected manual signing, artifact handoff, candidat
   assert.match(releaseWorkflow, /\$\{\{ inputs\.minimum_safe_sequence \|\| '1' \}\}/);
   assert.match(releaseWorkflow, /\$\{\{ inputs\.revoked_build_ids \|\| '\[\]' \}\}/);
   assert.match(releaseWorkflow, /\$\{\{ inputs\.expected_channel_pointer_sha256 \|\| 'absent' \}\}/);
+  assert.match(releaseWorkflow, /pypi_recovery_only:/);
   for (const marker of [
     "runs-on: macos-15",
     "environment: release-signing",
@@ -826,15 +827,41 @@ test("release workflows use protected manual signing, artifact handoff, candidat
   assert.doesNotMatch(homebrewWorkflow, /workflow_dispatch:/);
   assert.match(homebrewWorkflow, /actions\/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093/);
   assert.match(homebrewWorkflow, /--trust "\$TRUST_PATH"/);
-  assert.match(homebrewWorkflow, /environment: release-publication/);
+  assert.doesNotMatch(homebrewWorkflow, /environment: release-publication|HOMEBREW_TAP_DEPLOY_KEY|^  publish:/m);
+  const syncHomebrew = releaseWorkflow.slice(
+    releaseWorkflow.indexOf("  sync-homebrew:"),
+    releaseWorkflow.indexOf("  publish-homebrew:"),
+  );
+  const publishHomebrew = releaseWorkflow.slice(
+    releaseWorkflow.indexOf("  publish-homebrew:"),
+    releaseWorkflow.indexOf("  promote-channel-pointer:"),
+  );
+  const githubRelease = releaseWorkflow.slice(
+    releaseWorkflow.indexOf("  publish-github-release:"),
+    releaseWorkflow.indexOf("  pypi-resolve:"),
+  );
+  assert.match(syncHomebrew, /uses: \.\/\.github\/workflows\/sync-homebrew-tap\.yml/);
+  assert.doesNotMatch(syncHomebrew, /HOMEBREW_TAP_DEPLOY_KEY|environment: release-publication/);
+  assert.match(publishHomebrew, /needs: \[resolve, sign, sync-homebrew, promote-channel-pointer\]/);
+  assert.match(publishHomebrew, /environment: release-publication/);
+  assert.match(publishHomebrew, /test -n "\$HOMEBREW_TAP_DEPLOY_KEY"/);
+  assert.match(publishHomebrew, /ssh-key: \$\{\{ secrets\.HOMEBREW_TAP_DEPLOY_KEY \}\}/);
+  assert.match(publishHomebrew, /git -C homebrew-tap remote get-url origin\)" = "git@github\.com:ebarti\/homebrew-tap\.git"/);
+  assert.ok(
+    publishHomebrew.indexOf("Require the SSH Homebrew tap origin") < publishHomebrew.indexOf("Commit synchronized formula"),
+    "the tap checkout must prove its SSH origin before commit or push",
+  );
+  assert.match(githubRelease, /needs: \[resolve, sign, package-signed-candidate, smoke-and-verify, publish-homebrew, promote-channel-pointer\]/);
+  assert.match(githubRelease, /needs\['publish-homebrew'\]\.result == 'success'/);
   assert.doesNotMatch(`${releaseWorkflow}\n${homebrewWorkflow}`, /uses:\s+[^\s@]+@(?![0-9a-f]{40}(?:\s|$|#))/);
   const releaseGate = releaseWorkflow.indexOf("distribution-release.finalizer.bundle.mjs verify-pypi-gate");
   const buildDependencies = releaseWorkflow.indexOf("--only-group release-build");
-  const publish = releaseWorkflow.indexOf("uses: pypa/gh-action-pypi-publish@6733eb7d741f0b11ec6a39b58540dab7590f9b7d");
+  const publish = releaseWorkflow.indexOf("uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b");
   assert.ok(
     releaseGate >= 0 && releaseGate < buildDependencies && buildDependencies < publish,
     "PyPI must verify signed evidence before build dependencies and upload",
   );
+  assert.doesNotMatch(releaseWorkflow, /pypa\/gh-action-pypi-publish@6733eb7d741f0b11ec6a39b58540dab7590f9b7d/);
   assert.match(releaseWorkflow, /JOBCTRL_RELEASE_PUBLIC_KEY: \$\{\{ needs\.resolve\.outputs\.release_public_key \}\}/);
   assert.match(releaseWorkflow, /JOBCTRL_RELEASE_KEY_ID: \$\{\{ needs\.resolve\.outputs\.release_key_id \}\}/);
   assert.match(releaseWorkflow, /filter="data"/);
@@ -842,7 +869,42 @@ test("release workflows use protected manual signing, artifact handoff, candidat
     releaseWorkflow.indexOf("  pypi-resolve:"),
     releaseWorkflow.indexOf("  pypi-build:"),
   );
+  assert.match(pypiResolve, /needs: \[resolve, publish-github-release, pypi-recovery-preflight\]/);
+  assert.match(pypiResolve, /needs\['publish-github-release'\]\.result == 'success'/);
+  assert.match(pypiResolve, /needs\['pypi-recovery-preflight'\]\.result == 'success'/);
   assert.doesNotMatch(pypiResolve, /(?:corepack|pnpm|npm|npx|uv|pip)\s/);
+
+  const releaseJob = (name) => {
+    const start = releaseWorkflow.indexOf(`  ${name}:\n`);
+    assert.ok(start >= 0, `missing ${name} job`);
+    const remainder = releaseWorkflow.slice(start + 1);
+    const next = remainder.search(/\n  [A-Za-z0-9-]+:\n/);
+    return next < 0 ? remainder : remainder.slice(0, next);
+  };
+  const recoveryExclusion = "github.event_name != 'workflow_dispatch' || inputs.pypi_recovery_only != true";
+  for (const jobName of [
+    "publication-preflight",
+    "prepare",
+    "sign",
+    "package-signed-candidate",
+    "publish-immutable",
+    "smoke-and-verify",
+    "sync-homebrew",
+    "publish-homebrew",
+    "promote-channel-pointer",
+    "publish-github-release",
+  ]) assert.ok(releaseJob(jobName).includes(recoveryExclusion), `${jobName} must skip PyPI recovery`);
+  const recovery = releaseJob("pypi-recovery-preflight");
+  assert.match(recovery, /github\.event_name == 'workflow_dispatch' && inputs\.pypi_recovery_only == true/);
+  for (const marker of [
+    'test "$RELEASE_TAG" = v2.0.7',
+    "compare/$RELEASE_REF...main",
+    "isDraft",
+    "isPrerelease",
+    "isImmutable",
+    'gh release verify "$RELEASE_TAG"',
+  ]) assert.ok(recovery.includes(marker), `recovery must prove ${marker}`);
+  assert.doesNotMatch(recovery, /\baws\b|git push|gh release (?:create|edit|upload)/);
 });
 
 test("release lineage allows main to advance without loosening exact tag identity", async () => {

--- a/scripts/release_check.py
+++ b/scripts/release_check.py
@@ -906,17 +906,11 @@ def _homebrew_sync_findings(root: Path) -> list[str]:
     required_markers = {
         "workflow_call:": "is not reusable by the P6 release workflow",
         "  verify:": "does not isolate signed-render verification in a credential-free job",
-        "  publish:": "does not publish from a fresh tap-only job",
-        "needs: verify": "does not require credential-free verification before tap publication",
-        'repository: ebarti/homebrew-tap': "does not target ebarti/homebrew-tap",
-        'ssh-key: ${{ secrets.HOMEBREW_TAP_DEPLOY_KEY }}': "does not use the write-scoped tap deploy key",
         "node scripts/distribution-homebrew.mjs verify-promotion": "does not independently verify signed descriptor and promotion evidence",
         "jobctrl-verified": "does not stage the verified formula at a fixed runner path",
-        "jobctrl.rb.sha256": "does not seal the exact verified formula for the publish job",
+        "jobctrl.rb.sha256": "does not seal the exact verified formula for the protected caller job",
         "expected_formula_sha256:": "does not require the signer-rooted formula digest",
         "smoke_artifact_name:": "does not consume smoke as a separate gate artifact",
-        "homebrew-tap/Formula/jobctrl.rb": "does not write the tap formula path",
-        "git status --short --untracked-files=all -- Formula/jobctrl.rb": "does not detect an absent or untracked tap formula",
         "actions/download-artifact@": "does not download the immutable P6 artifact on its own runner",
         '--trust "$TRUST_PATH"': "does not verify against the candidate-provided release trust registry",
         'compare/$RELEASE_REF...main': "does not preserve release lineage while allowing later main commits",
@@ -932,13 +926,12 @@ def _homebrew_sync_findings(root: Path) -> list[str]:
             f"{HOMEBREW_SYNC_WORKFLOW_PATH}: tap sync must verify main ancestry without requiring the live main head to remain frozen"
         )
     verify = _workflow_job_body(workflow, "verify")
-    publish = _workflow_job_body(workflow, "publish")
     call_interface = workflow.partition("\njobs:")[0]
     if "HOMEBREW_TAP_DEPLOY_KEY" in call_interface or re.search(
         r"(?m)^\s{4}secrets:\s*$", call_interface
     ):
         findings.append(
-            f"{HOMEBREW_SYNC_WORKFLOW_PATH}: tap deploy key must be an environment secret resolved only by publish, not a workflow_call secret"
+            f"{HOMEBREW_SYNC_WORKFLOW_PATH}: tap deploy key must be an environment secret resolved only by the protected caller job, not a workflow_call secret"
         )
     if verify is None:
         findings.append(f"{HOMEBREW_SYNC_WORKFLOW_PATH}: missing credential-free verify job")
@@ -955,31 +948,14 @@ def _homebrew_sync_findings(root: Path) -> list[str]:
         }.items():
             if marker not in verify:
                 findings.append(f"{HOMEBREW_SYNC_WORKFLOW_PATH}: {message}")
-    if publish is None:
-        findings.append(f"{HOMEBREW_SYNC_WORKFLOW_PATH}: missing fresh tap publish job")
-    else:
-        executable = _workflow_executable_text(publish)
-        if "HOMEBREW_TAP_DEPLOY_KEY" not in publish:
-            findings.append(f"{HOMEBREW_SYNC_WORKFLOW_PATH}: publish job does not receive the tap deploy key")
-        if "environment: release-publication" not in publish:
-            findings.append(
-                f"{HOMEBREW_SYNC_WORKFLOW_PATH}: tap publish job must resolve its deploy key behind release-publication approval"
-            )
-        if "Check out JobCtrl" in publish or re.search(
-            r"(?im)^\s+(?:run:\s*)?(?:corepack|pnpm|npm|npx|uv|pip|python(?:3)?|node)\b",
-            executable,
-        ) or re.search(r"(?m)^\s+run:.*(?:scripts|workers|apps|launcher)/", executable):
-            findings.append(
-                f"{HOMEBREW_SYNC_WORKFLOW_PATH}: tap publish job executes JobCtrl or dependency code with the deploy key"
-            )
-        if "actions/download-artifact@" not in publish or "jobctrl.rb.sha256" not in publish:
-            findings.append(
-                f"{HOMEBREW_SYNC_WORKFLOW_PATH}: tap publish job does not consume and checksum the sealed formula artifact"
-            )
-        if "EXPECTED_FORMULA_SHA256" not in publish:
-            findings.append(
-                f"{HOMEBREW_SYNC_WORKFLOW_PATH}: tap publish job does not recheck the signer-rooted formula digest"
-            )
+    if (
+        _workflow_job_body(workflow, "publish") is not None
+        or "HOMEBREW_TAP_DEPLOY_KEY" in workflow
+        or "environment: release-publication" in workflow
+    ):
+        findings.append(
+            f"{HOMEBREW_SYNC_WORKFLOW_PATH}: reusable tap verification must remain credential-free; the caller owns protected publication"
+        )
     if "workflow_dispatch:" in workflow or re.search(r"(?m)^\s*push\s*:", workflow) or "types: [published]" in workflow:
         findings.append(f"{HOMEBREW_SYNC_WORKFLOW_PATH}: must be workflow_call-only and never expose a manual secret-bearing promotion path")
     return findings
@@ -1046,6 +1022,7 @@ def _release_distribution_findings(root: Path) -> list[str]:
         return [f"{RELEASE_DISTRIBUTION_WORKFLOW_PATH}: missing P6 signed distribution workflow"]
     required_markers = {
         "workflow_dispatch:": "has no owner-controlled manual release path",
+        "pypi_recovery_only:": "has no tightly scoped PyPI recovery mode",
         "GH_REPO: ${{ github.repository }}": "does not bind checkout-free GitHub CLI release operations to the audited repository",
         "group: release-distribution-${{ inputs.channel || 'stable' }}-darwin-arm64": "does not serialize release mutation by channel and platform",
         'test "$GITHUB_REF" = "refs/tags/$RELEASE_TAG"': "does not bind the workflow definition ref to the selected release tag",
@@ -1094,6 +1071,7 @@ def _release_distribution_findings(root: Path) -> list[str]:
         "immutable-releases": "does not fail closed unless immutable GitHub Releases are enabled",
         "gh release verify-asset": "does not compare post-lock release assets to local trusted bytes",
         "gh release verify \"$RELEASE_TAG\"": "does not verify the immutable release attestation",
+        "Prove immutable v2.0.7 release before PyPI recovery": "does not isolate read-only immutable-release recovery preflight",
         "uses: ./.github/workflows/sync-homebrew-tap.yml": "does not call the artifact-only Homebrew promotion workflow",
         "tap_name=\"jobctrl/release-smoke-${GITHUB_RUN_ID}\"": "does not isolate the temporary verification tap by release run",
         "brew tap-new --no-git \"$tap_name\"": "does not create an isolated temporary tap for formula verification without CI Git side effects",
@@ -1123,6 +1101,9 @@ def _release_distribution_findings(root: Path) -> list[str]:
         "smoke-and-verify",
         "promote-channel-pointer",
         "publish-github-release",
+        "sync-homebrew",
+        "publish-homebrew",
+        "pypi-recovery-preflight",
         "pypi-resolve",
         "pypi-build",
         "publish-pypi",
@@ -1141,6 +1122,26 @@ def _release_distribution_findings(root: Path) -> list[str]:
         findings.append(
             f"{RELEASE_DISTRIBUTION_WORKFLOW_PATH}: signing, publication, and smoke must not share combined jobs"
         )
+
+    recovery_exclusion = "github.event_name != 'workflow_dispatch' || inputs.pypi_recovery_only != true"
+    for job_name in (
+        "publication-preflight",
+        "prepare",
+        "sign",
+        "package-signed-candidate",
+        "publish-immutable",
+        "smoke-and-verify",
+        "sync-homebrew",
+        "publish-homebrew",
+        "promote-channel-pointer",
+        "publish-github-release",
+    ):
+        body = jobs.get(job_name)
+        header = body.partition("\n    steps:")[0] if body is not None else ""
+        if recovery_exclusion not in header:
+            findings.append(
+                f"{RELEASE_DISTRIBUTION_WORKFLOW_PATH}: {job_name} must be explicitly skipped by PyPI recovery"
+            )
 
     resolve = jobs.get("resolve")
     if resolve is not None:
@@ -1343,6 +1344,60 @@ def _release_distribution_findings(root: Path) -> list[str]:
         findings.append(
             f"{RELEASE_DISTRIBUTION_WORKFLOW_PATH}: Homebrew publication must bind the base candidate formula to the signer digest without passing the environment-scoped deploy key"
         )
+    homebrew_publish = jobs.get("publish-homebrew")
+    if homebrew_publish is None or any(
+        marker not in homebrew_publish
+        for marker in (
+            "needs: [resolve, sign, sync-homebrew, promote-channel-pointer]",
+            "environment: release-publication",
+            "HOMEBREW_TAP_DEPLOY_KEY: ${{ secrets.HOMEBREW_TAP_DEPLOY_KEY }}",
+            'test -n "$HOMEBREW_TAP_DEPLOY_KEY"',
+            "jobctrl-homebrew-verified-",
+            "jobctrl.rb.sha256",
+            "repository: ebarti/homebrew-tap",
+            "ssh-key: ${{ secrets.HOMEBREW_TAP_DEPLOY_KEY }}",
+            'test "$(git -C homebrew-tap remote get-url origin)" = "git@github.com:ebarti/homebrew-tap.git"',
+            "homebrew-tap/Formula/jobctrl.rb",
+            "git status --short --untracked-files=all -- Formula/jobctrl.rb",
+        )
+    ):
+        findings.append(
+            f"{RELEASE_DISTRIBUTION_WORKFLOW_PATH}: protected Homebrew publication must consume the sealed formula with a nonempty deploy key and SSH tap origin"
+        )
+    elif (
+        homebrew_publish.index("Require the SSH Homebrew tap origin")
+        > homebrew_publish.index("Commit synchronized formula")
+        or re.search(
+            r"(?im)^\s+(?:run:\s*)?(?:corepack|pnpm|npm|npx|uv|pip|python(?:3)?|node)\b",
+            _workflow_executable_text(homebrew_publish),
+        )
+    ):
+        findings.append(
+            f"{RELEASE_DISTRIBUTION_WORKFLOW_PATH}: protected Homebrew publication must prove its SSH origin before commit and never execute repository code"
+        )
+    recovery = jobs.get("pypi-recovery-preflight")
+    if recovery is not None:
+        for marker in (
+            "needs: resolve",
+            "inputs.pypi_recovery_only == true",
+            'test "$RELEASE_TAG" = v2.0.7',
+            'compare/$RELEASE_REF...main',
+            'commits/$RELEASE_TAG',
+            "targetCommitish",
+            "isDraft",
+            "isPrerelease",
+            "isImmutable",
+            'gh release verify "$RELEASE_TAG"',
+        ):
+            if marker not in recovery:
+                findings.append(
+                    f"{RELEASE_DISTRIBUTION_WORKFLOW_PATH}: PyPI recovery must prove the exact ancestral immutable GitHub Release before building"
+                )
+                break
+        if re.search(r"\b(?:aws|git\s+push|gh\s+release\s+(?:create|edit|upload))\b", _workflow_executable_text(recovery)):
+            findings.append(
+                f"{RELEASE_DISTRIBUTION_WORKFLOW_PATH}: PyPI recovery preflight must remain read-only"
+            )
     smoke = jobs.get("smoke-and-verify")
     if smoke is not None and "distribution-homebrew.mjs render" in _workflow_executable_text(smoke):
         findings.append(
@@ -1379,6 +1434,7 @@ def _pypi_release_workflow_findings(workflow: str) -> list[str]:
         name: _workflow_job_body(workflow, name)
         for name in (
             "pypi-resolve",
+            "pypi-recovery-preflight",
             "pypi-build",
             "publish-pypi",
         )
@@ -1391,8 +1447,11 @@ def _pypi_release_workflow_findings(workflow: str) -> list[str]:
     resolve = jobs["pypi-resolve"]
     if resolve is not None:
         for marker in (
-            "needs: [resolve, publish-github-release]",
+            "needs: [resolve, publish-github-release, pypi-recovery-preflight]",
             "(inputs.channel || 'stable') == 'stable'",
+            "always()",
+            "needs['publish-github-release'].result == 'success'",
+            "needs['pypi-recovery-preflight'].result == 'success'",
             "persist-credentials: false",
             "actions/setup-node@",
             "isImmutable",
@@ -1463,10 +1522,14 @@ def _pypi_release_workflow_findings(workflow: str) -> list[str]:
         "jobctrl-pypi-distributions-": "does not consume only the checksum-bound build artifact",
         "EXPECTED_SOURCE_COMMIT: ${{ needs.pypi-resolve.outputs.source_commit }}": "does not bind publication to the resolved source commit",
         "packages-dir: ${{ runner.temp }}/jobctrl-pypi-dists/packages": "does not limit PyPI to the verified package directory",
-        "uses: pypa/gh-action-pypi-publish@6733eb7d741f0b11ec6a39b58540dab7590f9b7d": "does not use the pinned PyPI publisher",
+        "uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b": "does not use the peeled v1.14.0 PyPI publisher commit",
     }.items():
         if marker not in publish:
             findings.append(f"{RELEASE_DISTRIBUTION_WORKFLOW_PATH}: {message}")
+    if "pypa/gh-action-pypi-publish@6733eb7d741f0b11ec6a39b58540dab7590f9b7d" in publish:
+        findings.append(
+            f"{RELEASE_DISTRIBUTION_WORKFLOW_PATH}: PyPI publisher must pin the peeled v1.14.0 commit, not its annotated tag object"
+        )
     for marker, message in {
         "actions/checkout@": "must not check out source in the OIDC publication job",
         "actions/setup-python@": "must not install Python tooling in the OIDC publication job",

--- a/workers/automation/tests/test_release_check.py
+++ b/workers/automation/tests/test_release_check.py
@@ -686,20 +686,21 @@ def test_homebrew_tap_key_is_resolved_only_behind_publication_environment() -> N
     ).read_text(encoding="utf-8")
     interface = workflow.partition("\njobs:")[0]
     verify = release_check._workflow_job_body(workflow, "verify")
-    publish = release_check._workflow_job_body(workflow, "publish")
 
     assert "HOMEBREW_TAP_DEPLOY_KEY" not in interface
     assert verify is not None and "HOMEBREW_TAP_DEPLOY_KEY" not in verify
-    assert publish is not None
-    assert "environment: release-publication" in publish
-    assert "secrets.HOMEBREW_TAP_DEPLOY_KEY" in publish
+    assert release_check._workflow_job_body(workflow, "publish") is None
     release_workflow = (
         release_check.ROOT / release_check.RELEASE_DISTRIBUTION_WORKFLOW_PATH
     ).read_text(encoding="utf-8")
     caller = release_check._workflow_job_body(release_workflow, "sync-homebrew")
+    publish = release_check._workflow_job_body(release_workflow, "publish-homebrew")
     assert caller is not None
     assert "HOMEBREW_TAP_DEPLOY_KEY" not in caller
     assert "secrets:" not in caller
+    assert publish is not None
+    assert "environment: release-publication" in publish
+    assert "secrets.HOMEBREW_TAP_DEPLOY_KEY" in publish
 
 
 def test_homebrew_tap_key_cannot_be_a_workflow_call_secret(tmp_path: Path) -> None:
@@ -713,12 +714,11 @@ def test_homebrew_tap_key_cannot_be_a_workflow_call_secret(tmp_path: Path) -> No
         "        required: true\n"
         "\npermissions:\n",
         1,
-    ).replace("    environment: release-publication\n", "", 1)
+    )
     _write_homebrew_p4_contract(tmp_path, workflow)
 
     findings = release_check._homebrew_sync_findings(tmp_path)
     assert any("must be an environment secret" in finding for finding in findings)
-    assert any("behind release-publication approval" in finding for finding in findings)
 
 
 def test_homebrew_template_rejects_toolchain_or_head_spec(tmp_path: Path) -> None:
@@ -750,12 +750,6 @@ def test_homebrew_tap_publish_cannot_mix_verification_with_deploy_key(
         "    env:\n      LEAKED_TAP_KEY: ${{ secrets.HOMEBREW_TAP_DEPLOY_KEY }}\n"
         "    permissions:\n      actions: read\n      contents: read\n",
         1,
-    ).replace(
-        "      - name: Download the exact verified formula\n",
-        "      - name: Execute forbidden JobCtrl verification\n"
-        "        run: node scripts/distribution-homebrew.mjs verify-promotion\n\n"
-        "      - name: Download the exact verified formula\n",
-        1,
     )
     _write_homebrew_p4_contract(
         tmp_path,
@@ -767,10 +761,7 @@ def test_homebrew_tap_publish_cannot_mix_verification_with_deploy_key(
         "verify job must not receive tap publication credentials" in finding
         for finding in findings
     )
-    assert any(
-        "tap publish job executes JobCtrl or dependency code" in finding
-        for finding in findings
-    )
+    assert any("must remain credential-free" in finding for finding in findings)
 
 
 def test_pypi_workflow_keeps_build_verification_outside_oidc_publication() -> None:
@@ -786,7 +777,7 @@ def test_pypi_workflow_keeps_build_verification_outside_oidc_publication() -> No
     assert publish is not None
     assert not (release_check.ROOT / release_check.PUBLISH_WORKFLOW_PATH).exists()
 
-    assert "needs: [resolve, publish-github-release]" in resolve
+    assert "needs: [resolve, publish-github-release, pypi-recovery-preflight]" in resolve
     assert "persist-credentials: false" in resolve
     assert "distribution-release.finalizer.bundle.mjs.sha256" in resolve
     assert "distribution-release-authority-bundles.NOTICE.txt" in resolve
@@ -842,7 +833,8 @@ def test_pypi_workflow_keeps_build_verification_outside_oidc_publication() -> No
     assert "packages-dir: ${{ runner.temp }}/jobctrl-pypi-dists/packages" in publish
     assert "SHA256SUMS" in publish
     assert "jobctrl-pypi-distributions-" in publish
-    assert "uses: pypa/gh-action-pypi-publish@6733eb7d741f0b11ec6a39b58540dab7590f9b7d" in publish
+    assert "uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b" in publish
+    assert "uses: pypa/gh-action-pypi-publish@6733eb7d741f0b11ec6a39b58540dab7590f9b7d" not in publish
 
 
 def test_pypi_no_isolation_backend_is_exactly_pinned_and_locked() -> None:


### PR DESCRIPTION
## Summary

- pin the PyPI publisher to the peeled v1.14.0 commit
- add a main-only, stable, exact-v2.0.7 PyPI recovery path that skips every release mutation job
- keep reusable Homebrew verification credential-free and publish from the protected top-level environment
- record the current v2.0.7 release and recovery procedure in the active launch documentation

## Why

The immutable v2.0.7 GitHub Release, R2 assets, stable pointer, and Homebrew formula are already public. PyPI publication stopped before upload because the action referenced an annotated tag object whose GHCR manifest does not exist. The Homebrew tap also previously received an empty deploy key inside a reusable workflow. Neither defect changes product code or warrants a new version.

## Validation

- 129 script tests
- 52 focused release-check tests
- distribution audit
- strict v2.0.7 release check
- full TypeScript, Python lint, and launcher checks
- docs build, link checks, and redirect checks
- actionlint and YAML parsing
- independent Tier 3 review and QA: zero Blocker or High findings