### PR TITLE
fix(release): continue PyPI recovery jobs

### DIFF
--- a/.github/workflows/release-distribution.yml
+++ b/.github/workflows/release-distribution.yml
@@ -1275,7 +1275,7 @@ jobs:
   pypi-resolve:
     name: Verify the immutable signed stable release for PyPI
     needs: [resolve, publish-github-release, pypi-recovery-preflight]
-    if: ${{ always() && needs.resolve.result == 'success' && (inputs.channel || 'stable') == 'stable' && (((github.event_name != 'workflow_dispatch' || inputs.pypi_recovery_only != true) && needs['publish-github-release'].result == 'success') || (github.event_name == 'workflow_dispatch' && inputs.pypi_recovery_only == true && needs['pypi-recovery-preflight'].result == 'success')) }}
+    if: ${{ !cancelled() && needs.resolve.result == 'success' && (inputs.channel || 'stable') == 'stable' && (((github.event_name != 'workflow_dispatch' || inputs.pypi_recovery_only != true) && needs['publish-github-release'].result == 'success') || (github.event_name == 'workflow_dispatch' && inputs.pypi_recovery_only == true && needs['pypi-recovery-preflight'].result == 'success')) }}
     runs-on: ubuntu-24.04
     outputs:
       source_commit: ${{ steps.identity.outputs.source_commit }}
@@ -1386,6 +1386,7 @@ jobs:
   pypi-build:
     name: Build and seal PyPI distributions once
     needs: pypi-resolve
+    if: ${{ !cancelled() && needs.pypi-resolve.result == 'success' }}
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -1460,6 +1461,7 @@ jobs:
   publish-pypi:
     name: Publish verified packages with PyPI OIDC
     needs: [pypi-resolve, pypi-build]
+    if: ${{ !cancelled() && needs.pypi-resolve.result == 'success' && needs.pypi-build.result == 'success' }}
     runs-on: ubuntu-24.04
     environment: pypi
     permissions:

--- a/docs/publish-checklist.md
+++ b/docs/publish-checklist.md
@@ -325,7 +325,11 @@ especially §§11–14. This is a release precondition, not permission to publis
   skip signing, notarization, R2 publication, native and Homebrew smoke, stable
   pointer promotion, Homebrew publication, and GitHub Release publication. It
   may run only the read-only recovery preflight and the existing
-  `pypi-resolve`, `pypi-build`, and OIDC `publish-pypi` chain. Because the
+  `pypi-resolve`, `pypi-build`, and OIDC `publish-pypi` chain. Each downstream
+  PyPI job must explicitly require its direct PyPI dependency to succeed while
+  using `!cancelled()` to override skip propagation from the intentionally
+  skipped release-mutation branch without overriding an operator cancellation.
+  Because the
   corrected workflow definition exists on `main` while the immutable release
   tag retains its original workflow, temporarily admit the `main` branch to
   only the `release-verification` and `pypi` environments for this recovery.

--- a/scripts/distribution-release.test.mjs
+++ b/scripts/distribution-release.test.mjs
@@ -869,18 +869,24 @@ test("release workflows use protected manual signing, artifact handoff, candidat
     releaseWorkflow.indexOf("  pypi-resolve:"),
     releaseWorkflow.indexOf("  pypi-build:"),
   );
+  const pypiBuild = releaseJob("pypi-build");
+  const pypiPublish = releaseJob("publish-pypi");
   assert.match(pypiResolve, /needs: \[resolve, publish-github-release, pypi-recovery-preflight\]/);
   assert.match(pypiResolve, /needs\['publish-github-release'\]\.result == 'success'/);
   assert.match(pypiResolve, /needs\['pypi-recovery-preflight'\]\.result == 'success'/);
+  assert.match(pypiResolve, /if: \$\{\{ !cancelled\(\) && needs\.resolve\.result == 'success'/);
+  assert.match(pypiBuild, /if: \$\{\{ !cancelled\(\) && needs\.pypi-resolve\.result == 'success' \}\}/);
+  assert.match(pypiPublish, /if: \$\{\{ !cancelled\(\) && needs\.pypi-resolve\.result == 'success' && needs\.pypi-build\.result == 'success' \}\}/);
+  assert.doesNotMatch(`${pypiResolve}\n${pypiBuild}\n${pypiPublish}`, /\balways\(\)/);
   assert.doesNotMatch(pypiResolve, /(?:corepack|pnpm|npm|npx|uv|pip)\s/);
 
-  const releaseJob = (name) => {
+  function releaseJob(name) {
     const start = releaseWorkflow.indexOf(`  ${name}:\n`);
     assert.ok(start >= 0, `missing ${name} job`);
     const remainder = releaseWorkflow.slice(start + 1);
     const next = remainder.search(/\n  [A-Za-z0-9-]+:\n/);
     return next < 0 ? remainder : remainder.slice(0, next);
-  };
+  }
   const recoveryExclusion = "github.event_name != 'workflow_dispatch' || inputs.pypi_recovery_only != true";
   for (const jobName of [
     "publication-preflight",

--- a/scripts/release_check.py
+++ b/scripts/release_check.py
@@ -1449,7 +1449,7 @@ def _pypi_release_workflow_findings(workflow: str) -> list[str]:
         for marker in (
             "needs: [resolve, publish-github-release, pypi-recovery-preflight]",
             "(inputs.channel || 'stable') == 'stable'",
-            "always()",
+            "!cancelled()",
             "needs['publish-github-release'].result == 'success'",
             "needs['pypi-recovery-preflight'].result == 'success'",
             "persist-credentials: false",
@@ -1484,6 +1484,7 @@ def _pypi_release_workflow_findings(workflow: str) -> list[str]:
     if build is not None:
         for marker in (
             "needs: pypi-resolve",
+            "if: ${{ !cancelled() && needs.pypi-resolve.result == 'success' }}",
             "SOURCE_DATE_EPOCH:",
             "uv --project workers/automation sync --python 3.12.13 --locked --no-default-groups --only-group release-build --no-install-project",
             "uv --project workers/automation run --python 3.12.13 --no-sync python -m build --no-isolation workers/automation",
@@ -1517,6 +1518,7 @@ def _pypi_release_workflow_findings(workflow: str) -> list[str]:
             f"{RELEASE_DISTRIBUTION_WORKFLOW_PATH}: PyPI OIDC job must not receive release verification inputs"
         )
     for marker, message in {
+        "if: ${{ !cancelled() && needs.pypi-resolve.result == 'success' && needs.pypi-build.result == 'success' }}": "does not explicitly continue past the intentionally skipped release branch after successful PyPI verification and build without overriding cancellation",
         "environment: pypi": "does not put OIDC publication behind the PyPI environment",
         "id-token: write": "does not request PyPI OIDC only in the publication job",
         "jobctrl-pypi-distributions-": "does not consume only the checksum-bound build artifact",

--- a/workers/automation/tests/test_release_check.py
+++ b/workers/automation/tests/test_release_check.py
@@ -792,6 +792,7 @@ def test_pypi_workflow_keeps_build_verification_outside_oidc_publication() -> No
     assert "uv --project" not in resolve
 
     assert "needs: pypi-resolve" in build
+    assert "if: ${{ !cancelled() && needs.pypi-resolve.result == 'success' }}" in build
     assert "actions/setup-python@" in build
     assert "astral-sh/setup-uv@" in build
     assert "actions/setup-node@" not in build
@@ -815,6 +816,10 @@ def test_pypi_workflow_keeps_build_verification_outside_oidc_publication() -> No
 
     assert "environment: pypi" in publish
     assert "needs: [pypi-resolve, pypi-build]" in publish
+    assert (
+        "if: ${{ !cancelled() && needs.pypi-resolve.result == 'success' && "
+        "needs.pypi-build.result == 'success' }}" in publish
+    )
     assert "id-token: write" in publish
     assert "actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093" in publish
     assert "actions/checkout@" not in publish


### PR DESCRIPTION
## Summary

- make the PyPI verification, build, and OIDC publication chain continue past intentionally skipped release-mutation ancestors
- require each direct dependency to succeed and preserve operator cancellation with !cancelled()
- lock the scheduler contract in JavaScript and Python release checks

## Why

Recovery run 30113988138 verified the immutable v2.0.7 release but GitHub skipped the downstream PyPI build and upload because skipped ancestors propagate through needs chains. The release artifacts are valid and unchanged; this is scheduler topology only.

## Validation

- 129 script tests
- 52 focused release-check tests
- strict v2.0.7 release check
- docs build and 8,239 link checks
- YAML parse and lockfile validation
- 32-case dependency-result and cancellation matrix
- independent Tier 3 review and QA: zero findings