### PR TITLE
fix(distribution): publish v2.0.7 installer

### DIFF
--- a/docs/public/install.sh
+++ b/docs/public/install.sh
@@ -4,9 +4,9 @@ set -euo pipefail
 
 # P6 renders these from the signed publication. Empty pins fail closed.
 # BEGIN JOBCTRL RELEASE PINS
-INSTALLER_URL=""
-INSTALLER_SHA256=""
-INSTALLER_VERSION=""
+INSTALLER_URL="https://releases.jobctrl.dev/v1/artifacts/2.0.7-db257efe1087ec00ac2ec49b846a95d2423aecc2-darwin-arm64/jobctrl-installer"
+INSTALLER_SHA256="d862a8edc7fa68aa23b6f32a98af6d06f5e8f2898966f71e0146a29ec24ee749"
+INSTALLER_VERSION="2.0.7"
 # END JOBCTRL RELEASE PINS
 
 usage() {

--- a/scripts/distribution-release.test.mjs
+++ b/scripts/distribution-release.test.mjs
@@ -591,7 +591,7 @@ test("install-script rendering advances the actual bounded pin header without ch
 
   assert.throws(
     () => renderPinnedInstallScript({
-      templateRaw: template.replace('INSTALLER_URL=""', "INSTALLER_URL=https://releases.jobctrl.dev/jobctrl-installer"),
+      templateRaw: template.replace(/^INSTALLER_URL=.*$/m, "INSTALLER_URL=https://releases.jobctrl.dev/jobctrl-installer"),
       installerUrl: "https://releases.jobctrl.dev/v1/artifacts/stable-build-0000043/jobctrl-installer",
       installerSha256: "b".repeat(64),
       installerVersion: "2.0.1",
@@ -600,7 +600,7 @@ test("install-script rendering advances the actual bounded pin header without ch
   );
   assert.throws(
     () => renderPinnedInstallScript({
-      templateRaw: template.replace('INSTALLER_VERSION=""', 'INSTALLER_VERSION="2.0.0"\nexport INSTALLER_VERSION="2.0.1"'),
+      templateRaw: template.replace(/^INSTALLER_VERSION=.*$/m, '$&\nexport INSTALLER_VERSION="2.0.1"'),
       installerUrl: "https://releases.jobctrl.dev/v1/artifacts/stable-build-0000043/jobctrl-installer",
       installerSha256: "b".repeat(64),
       installerVersion: "2.0.1",

--- a/scripts/get
+++ b/scripts/get
@@ -4,9 +4,9 @@ set -euo pipefail
 
 # P6 renders these from the signed publication. Empty pins fail closed.
 # BEGIN JOBCTRL RELEASE PINS
-INSTALLER_URL=""
-INSTALLER_SHA256=""
-INSTALLER_VERSION=""
+INSTALLER_URL="https://releases.jobctrl.dev/v1/artifacts/2.0.7-db257efe1087ec00ac2ec49b846a95d2423aecc2-darwin-arm64/jobctrl-installer"
+INSTALLER_SHA256="d862a8edc7fa68aa23b6f32a98af6d06f5e8f2898966f71e0146a29ec24ee749"
+INSTALLER_VERSION="2.0.7"
 # END JOBCTRL RELEASE PINS
 
 usage() {

--- a/scripts/get.test.mjs
+++ b/scripts/get.test.mjs
@@ -150,14 +150,16 @@ test("get rejects tampered installer bytes and does not execute them", () => {
   } finally { rmSync(root, { recursive: true, force: true }); }
 });
 
-test("local fixture mode cannot select a network release and normal mode fails closed before P6", () => {
+test("local fixture mode cannot select a network release and the released path carries immutable P6 pins", () => {
   const root = makeTmp(); try {
     const value = fixture(root);
     const local = run(["--local-fixture-contract", value.contract, "--release-url", "https://attacker.example/release"], value.env);
     assert.equal(local.status, 1);
     assert.match(local.stderr, /cannot use --release-url/);
-    const normal = run([], value.env);
-    assert.equal(normal.status, 1);
-    assert.match(normal.stderr, /no signed native installer is published yet/);
+    const source = readFileSync(GET, "utf8");
+    assert.match(source, /^INSTALLER_URL="https:\/\/releases\.jobctrl\.dev\/v1\/artifacts\/2\.0\.7-db257efe1087ec00ac2ec49b846a95d2423aecc2-darwin-arm64\/jobctrl-installer"$/m);
+    assert.match(source, /^INSTALLER_SHA256="d862a8edc7fa68aa23b6f32a98af6d06f5e8f2898966f71e0146a29ec24ee749"$/m);
+    assert.match(source, /^INSTALLER_VERSION="2\.0\.7"$/m);
+    assert.doesNotMatch(source, /^INSTALLER_URL=""$/m);
   } finally { rmSync(root, { recursive: true, force: true }); }
 });


### PR DESCRIPTION
## Summary

- cut over the canonical curl installer to the immutable v2.0.7 native installer
- keep scripts/get and docs/public/install.sh byte-identical to the verified GitHub Release asset
- make installer and pin-rendering tests hermetic against the published pins

## Release identity

- release source: db257efe1087ec00ac2ec49b846a95d2423aecc2
- install.sh SHA-256: cd239f09f4bb4098a56845e721e69efba4b7e2e3047645553b210b693c67eae9
- native installer SHA-256: d862a8edc7fa68aa23b6f32a98af6d06f5e8f2898966f71e0146a29ec24ee749

## Validation

- all 182 published SHA256SUMS records
- 129 script tests
- installer asset equality and Bash syntax
- strict v2.0.7 release check
- docs build, runtime, links, and redirects
- isolated real install and version proof without user-state or service startup
- independent Tier 3 review and QA: zero findings