### PR TITLE
feat(docs): add consent-gated analytics

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -322,7 +322,7 @@ export default withMermaid(
       sidebar: SIDEBAR,
       socialLinks: [{ icon: "github", link: REPO_URL }],
       footer: {
-        copyright: `Copyright © 2026 Eloi Barti and JobCtrl contributors. Licensed under <a href="${REPO_URL}/blob/main/LICENSE">AGPL-3.0-only</a>. <a href="${REPO_URL}">Source code</a>.`,
+        copyright: `Copyright © 2026 Eloi Barti and JobCtrl contributors. Licensed under <a href="${REPO_URL}/blob/main/LICENSE">AGPL-3.0-only</a>. <a href="${REPO_URL}">Source code</a>. <button type="button" class="jh-cookie-settings-link" data-jh-cookie-settings>Cookie settings</button>.`,
       },
       search: {
         provider: "local",

--- a/docs/.vitepress/theme/DocsAnalyticsConsent.vue
+++ b/docs/.vitepress/theme/DocsAnalyticsConsent.vue
@@ -1,0 +1,143 @@
+<script setup lang="ts">
+import {
+  inject,
+  nextTick,
+  onBeforeUnmount,
+  onMounted,
+  ref,
+} from "vue";
+import {
+  docsAnalyticsControllerKey,
+  type DocsAnalyticsConsentChoice,
+} from "./docs-analytics";
+
+const controller = inject(docsAnalyticsControllerKey);
+if (!controller) {
+  throw new Error("Docs analytics controller is unavailable.");
+}
+
+const mounted = ref(false);
+const open = ref(false);
+const choice = ref<DocsAnalyticsConsentChoice | null>(null);
+const heading = ref<HTMLHeadingElement | null>(null);
+const announcement = ref("");
+let returnFocus: HTMLElement | null = null;
+
+function focusSettings(): void {
+  void nextTick(() => heading.value?.focus());
+}
+
+function openSettings(event: MouseEvent): void {
+  const target = event.target;
+  if (!(target instanceof Element)) return;
+  const trigger = target.closest<HTMLElement>("[data-jh-cookie-settings]");
+  if (!trigger) return;
+
+  event.preventDefault();
+  returnFocus = trigger;
+  open.value = true;
+  focusSettings();
+}
+
+function closeSettings(): void {
+  if (choice.value === null) return;
+  open.value = false;
+  const target = returnFocus;
+  returnFocus = null;
+  void nextTick(() => {
+    const fallback = document.querySelector<HTMLElement>(
+      ".VPNavBarTitle .title",
+    );
+    (target ?? fallback)?.focus();
+  });
+}
+
+function selectChoice(nextChoice: DocsAnalyticsConsentChoice): void {
+  let reloadToUnloadAnalytics = false;
+  if (nextChoice === "denied") {
+    // An explicit decline is authoritative even if this tab has stale UI
+    // state from before another tab changed the origin-wide stored choice.
+    reloadToUnloadAnalytics = controller.deny();
+    announcement.value = "Documentation analytics disabled.";
+    choice.value = nextChoice;
+  } else if (nextChoice !== choice.value) {
+    controller.grant();
+    announcement.value = "Documentation analytics enabled.";
+    choice.value = nextChoice;
+  }
+  if (reloadToUnloadAnalytics) {
+    window.location.reload();
+    return;
+  }
+  closeSettings();
+}
+
+onMounted(() => {
+  mounted.value = true;
+  choice.value = controller.getConsentChoice();
+  open.value = choice.value === null;
+  document.addEventListener("click", openSettings);
+});
+
+onBeforeUnmount(() => {
+  document.removeEventListener("click", openSettings);
+});
+</script>
+
+<template>
+  <p class="jh-visually-hidden" aria-live="polite">{{ announcement }}</p>
+  <aside
+    v-if="mounted && open"
+    class="jh-cookie-banner"
+    aria-labelledby="jh-cookie-banner-title"
+    data-jh-cookie-banner
+  >
+    <button
+      v-if="choice !== null"
+      type="button"
+      class="jh-cookie-banner__close"
+      aria-label="Close cookie settings"
+      @click="closeSettings"
+    >
+      <span aria-hidden="true">×</span>
+    </button>
+    <div class="jh-cookie-banner__copy">
+      <p class="jh-cookie-banner__eyebrow">Your privacy choice</p>
+      <h2
+        id="jh-cookie-banner-title"
+        ref="heading"
+        tabindex="-1"
+      >
+        Optional documentation analytics
+      </h2>
+      <p>
+        Google Analytics helps us understand which docs are useful. It stays
+        off until you accept, and advertising and personalization signals are
+        disabled.
+      </p>
+      <p v-if="choice !== null" class="jh-cookie-banner__current">
+        Current choice:
+        <strong>{{ choice === "granted" ? "analytics enabled" : "analytics disabled" }}</strong>.
+      </p>
+      <a href="/user/data-and-safety#documentation-site-analytics">
+        Read the analytics and cookie details
+      </a>
+    </div>
+    <div class="jh-cookie-banner__actions">
+      <button
+        type="button"
+        class="jh-cookie-banner__button jh-cookie-banner__button--secondary"
+        @click="selectChoice('denied')"
+      >
+        Decline analytics
+      </button>
+      <button
+        type="button"
+        class="jh-cookie-banner__button jh-cookie-banner__button--primary"
+        @click="selectChoice('granted')"
+      >
+        Accept analytics
+      </button>
+    </div>
+  </aside>
+</template>

--- a/docs/.vitepress/theme/JobCtrlLayout.vue
+++ b/docs/.vitepress/theme/JobCtrlLayout.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { nextTick, onBeforeUnmount, onMounted, ref, watch } from "vue";
 import DefaultTheme from "vitepress/theme";
+import DocsAnalyticsConsent from "./DocsAnalyticsConsent.vue";
 
 const VitePressLayout = DefaultTheme.Layout;
 
@@ -201,6 +202,7 @@ watch([sidebarExpanded, sidebarWidth], () => {
           </svg>
         </button>
       </div>
+      <DocsAnalyticsConsent />
     </template>
   </VitePressLayout>
 </template>

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -1464,16 +1464,222 @@ html[data-jh-workflow-surface="cli"] .jh-channel-panel[data-jh-channel-panel="cl
 }
 
 /* --------------------------------------------------------------------------
-   Site-wide notice: VitePress hides its footer on sidebar pages by default,
-   but these docs carry the same copyright/license notice everywhere.
+   Site-wide footer and optional analytics consent.
    -------------------------------------------------------------------------- */
 .Layout .VPFooter.has-sidebar {
   display: block !important;
   margin-left: var(--vp-sidebar-width);
 }
 
+.jh-cookie-settings-link {
+  margin: 0;
+  border: 0;
+  padding: 0;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  cursor: pointer;
+}
+
+.jh-cookie-settings-link:hover {
+  color: var(--vp-c-text-1);
+}
+
+.jh-cookie-settings-link:focus-visible {
+  border-radius: 3px;
+  outline: 2px solid var(--vp-c-brand-1);
+  outline-offset: 3px;
+}
+
+.jh-cookie-banner {
+  position: fixed;
+  z-index: 100;
+  right: max(16px, env(safe-area-inset-right));
+  bottom: max(16px, env(safe-area-inset-bottom));
+  left: max(16px, env(safe-area-inset-left));
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 20px 28px;
+  width: min(760px, calc(100% - 32px));
+  margin-inline: auto;
+  border: 1px solid var(--jh-doc-frame);
+  border-radius: 12px;
+  padding: 20px;
+  background: var(--vp-c-bg);
+  box-shadow:
+    0 18px 48px rgb(15 23 42 / 18%),
+    0 4px 12px rgb(15 23 42 / 10%);
+  color: var(--vp-c-text-1);
+}
+
+.jh-cookie-banner__copy {
+  min-width: 0;
+}
+
+.jh-cookie-banner__eyebrow {
+  margin: 0 0 3px;
+  color: var(--vp-c-brand-1);
+  font-size: 12px;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  line-height: 1.4;
+  text-transform: uppercase;
+}
+
+.jh-cookie-banner h2 {
+  margin: 0 36px 8px 0;
+  border: 0;
+  padding: 0;
+  font-size: 19px;
+  line-height: 1.35;
+  letter-spacing: -0.01em;
+}
+
+.jh-cookie-banner h2:focus {
+  outline: none;
+}
+
+.jh-cookie-banner__copy > p:not(.jh-cookie-banner__eyebrow) {
+  margin: 0 0 8px;
+  color: var(--vp-c-text-2);
+  font-size: 14px;
+  line-height: 1.55;
+}
+
+.jh-cookie-banner__copy > a {
+  color: var(--vp-c-brand-1);
+  font-size: 14px;
+  font-weight: 700;
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
+.jh-cookie-banner__copy > a:focus-visible {
+  border-radius: 3px;
+  outline: 2px solid var(--vp-c-brand-1);
+  outline-offset: 3px;
+}
+
+.jh-cookie-banner__current strong {
+  color: var(--vp-c-text-1);
+}
+
+.jh-cookie-banner__actions {
+  align-self: end;
+  display: flex;
+  flex-direction: column-reverse;
+  gap: 8px;
+  min-width: 176px;
+}
+
+.jh-cookie-banner__button,
+.jh-cookie-banner__close {
+  border: 1px solid transparent;
+  font: inherit;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.jh-cookie-banner__button {
+  min-height: 42px;
+  border-radius: 8px;
+  padding: 9px 14px;
+  font-size: 14px;
+  line-height: 1.3;
+}
+
+.jh-cookie-banner__button--primary {
+  border-color: var(--vp-button-brand-border);
+  background: var(--vp-button-brand-bg);
+  color: var(--vp-button-brand-text);
+}
+
+.jh-cookie-banner__button--primary:hover {
+  border-color: var(--vp-button-brand-hover-border);
+  background: var(--vp-button-brand-hover-bg);
+}
+
+.jh-cookie-banner__button--secondary {
+  border-color: var(--vp-c-divider);
+  background: var(--vp-c-bg);
+  color: var(--vp-c-text-1);
+}
+
+.jh-cookie-banner__button--secondary:hover {
+  border-color: var(--vp-c-brand-1);
+  background: var(--vp-c-brand-soft);
+}
+
+.jh-cookie-banner__button:focus-visible,
+.jh-cookie-banner__close:focus-visible {
+  outline: 3px solid var(--vp-c-brand-1);
+  outline-offset: 2px;
+}
+
+.jh-cookie-banner__close {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  display: grid;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  place-items: center;
+  background: transparent;
+  color: var(--vp-c-text-2);
+  font-size: 22px;
+  line-height: 1;
+}
+
+.jh-cookie-banner__close:hover {
+  background: var(--vp-c-bg-soft);
+  color: var(--vp-c-text-1);
+}
+
+.jh-visually-hidden {
+  position: fixed !important;
+  width: 1px !important;
+  height: 1px !important;
+  overflow: hidden !important;
+  clip: rect(0 0 0 0) !important;
+  clip-path: inset(50%) !important;
+  white-space: nowrap !important;
+}
+
+@media (max-width: 639px) {
+  .jh-cookie-banner {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 16px;
+    max-height: calc(100dvh - 32px);
+    overflow-y: auto;
+    padding: 18px;
+  }
+
+  .jh-cookie-banner__actions {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    min-width: 0;
+  }
+}
+
 @media (max-width: 959px) {
   .Layout .VPFooter.has-sidebar {
     margin-left: 0;
+  }
+}
+
+@media (max-width: 420px) {
+  .jh-cookie-banner__actions {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+
+@media (forced-colors: active) {
+  .jh-cookie-banner,
+  .jh-cookie-banner__button,
+  .jh-cookie-banner__close {
+    border-color: ButtonText;
   }
 }

--- a/docs/.vitepress/theme/docs-analytics.ts
+++ b/docs/.vitepress/theme/docs-analytics.ts
@@ -1,0 +1,310 @@
+import type { InjectionKey } from "vue";
+import type { Router } from "vitepress";
+
+export const DOCS_GOOGLE_ANALYTICS_MEASUREMENT_ID = "G-KB495KG6MS";
+export const DOCS_ANALYTICS_CONSENT_STORAGE_KEY =
+  "jobctrl-docs-analytics-consent-v1";
+
+const GOOGLE_TAG_SCRIPT_ID = "jobctrl-docs-google-analytics";
+const GOOGLE_ANALYTICS_COOKIE_MAX_AGE_SECONDS = 15_544_800;
+const GOOGLE_ANALYTICS_COOKIE_PREFIXES = ["_ga", "_gid", "_gat"];
+
+export type DocsAnalyticsConsentChoice = "granted" | "denied";
+
+type GoogleTag = (...command: unknown[]) => void;
+
+interface DocsAnalyticsWindow extends Window {
+  dataLayer?: IArguments[];
+  gtag?: GoogleTag;
+}
+
+export interface DocsAnalyticsController {
+  getConsentChoice(): DocsAnalyticsConsentChoice | null;
+  install(): void;
+  grant(): void;
+  deny(): boolean;
+}
+
+export const docsAnalyticsControllerKey: InjectionKey<DocsAnalyticsController> =
+  Symbol("docsAnalyticsController");
+
+function browserStorage(windowRef: Window): Storage | null {
+  try {
+    return windowRef.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+function readStoredChoice(
+  storage: Storage | null,
+): DocsAnalyticsConsentChoice | null {
+  if (!storage) return null;
+  try {
+    const choice = storage.getItem(DOCS_ANALYTICS_CONSENT_STORAGE_KEY);
+    return choice === "granted" || choice === "denied" ? choice : null;
+  } catch {
+    return null;
+  }
+}
+
+function persistChoice(
+  storage: Storage | null,
+  choice: DocsAnalyticsConsentChoice,
+): void {
+  if (!storage) return;
+  try {
+    storage.setItem(DOCS_ANALYTICS_CONSENT_STORAGE_KEY, choice);
+  } catch {
+    // Storage can be unavailable in private or hardened browser modes. The
+    // choice still applies to this page session through the controller state.
+  }
+}
+
+function queueGoogleTag(windowRef: DocsAnalyticsWindow): GoogleTag {
+  const dataLayer = windowRef.dataLayer ?? [];
+  windowRef.dataLayer = dataLayer;
+  const googleTag: GoogleTag =
+    windowRef.gtag ??
+    function googleTag() {
+      // Google processes the `arguments` objects produced by its canonical
+      // snippet. Plain arrays load the tag but are ignored by the library.
+      dataLayer.push(arguments);
+    };
+  windowRef.gtag = googleTag;
+  return googleTag;
+}
+
+function grantedConsent(): Record<string, "granted" | "denied"> {
+  return {
+    analytics_storage: "granted",
+    ad_storage: "denied",
+    ad_user_data: "denied",
+    ad_personalization: "denied",
+  };
+}
+
+function deniedConsent(): Record<string, "denied"> {
+  return {
+    analytics_storage: "denied",
+    ad_storage: "denied",
+    ad_user_data: "denied",
+    ad_personalization: "denied",
+  };
+}
+
+function currentPageLocation(windowRef: Window): string {
+  // Query strings and fragments are unnecessary for documentation analytics
+  // and can contain user-entered search or navigation text.
+  return `${windowRef.location.origin}${windowRef.location.pathname}`;
+}
+
+function loadGoogleAnalytics(
+  documentRef: Document,
+  windowRef: DocsAnalyticsWindow,
+): void {
+  if (documentRef.getElementById(GOOGLE_TAG_SCRIPT_ID)) return;
+
+  try {
+    const googleTag = queueGoogleTag(windowRef);
+    googleTag("consent", "default", grantedConsent());
+    googleTag("js", new Date());
+    // This theme emits sanitized manual views after VitePress route changes.
+    // The matching GA4 stream must therefore disable Enhanced Measurement's
+    // "Page changes based on browser history events" option; send_page_view
+    // only suppresses the config command's automatic load-time view.
+    googleTag("config", DOCS_GOOGLE_ANALYTICS_MEASUREMENT_ID, {
+      allow_google_signals: false,
+      allow_ad_personalization_signals: false,
+      anonymize_ip: true,
+      // Host-only cookies keep docs consent on jobctrl.dev from crossing into
+      // demo.jobctrl.dev, which has its own independent consent contract.
+      cookie_domain: "none",
+      cookie_expires: GOOGLE_ANALYTICS_COOKIE_MAX_AGE_SECONDS,
+      cookie_flags: "SameSite=Lax;Secure",
+      cookie_update: false,
+      send_page_view: false,
+    });
+
+    const script = documentRef.createElement("script");
+    script.id = GOOGLE_TAG_SCRIPT_ID;
+    script.async = true;
+    script.referrerPolicy = "strict-origin-when-cross-origin";
+    script.src =
+      `https://www.googletagmanager.com/gtag/js?id=` +
+      encodeURIComponent(DOCS_GOOGLE_ANALYTICS_MEASUREMENT_ID);
+    documentRef.head.append(script);
+  } catch {
+    // Optional third-party analytics must never break documentation access.
+  }
+}
+
+function sendPageView(
+  documentRef: Document,
+  windowRef: DocsAnalyticsWindow,
+  pageReferrer: string,
+): string {
+  const pageLocation = currentPageLocation(windowRef);
+  try {
+    windowRef.gtag?.("event", "page_view", {
+      page_location: pageLocation,
+      page_path: windowRef.location.pathname,
+      page_referrer: pageReferrer,
+      page_title: documentRef.title,
+    });
+  } catch {
+    // Third-party analytics must not interfere with client-side navigation.
+  }
+  return pageLocation;
+}
+
+function cookieDomainCandidates(hostname: string): string[] {
+  if (
+    hostname === "localhost" ||
+    /^[\d.]+$/.test(hostname) ||
+    hostname.includes(":")
+  ) {
+    return [];
+  }
+
+  const labels = hostname.split(".");
+  const candidates = new Set<string>([hostname]);
+  if (labels.length > 2) {
+    candidates.add(labels.slice(-2).join("."));
+  }
+  return [...candidates];
+}
+
+function deleteGoogleAnalyticsCookies(
+  documentRef: Document,
+  windowRef: Window,
+): void {
+  try {
+    const secure =
+      windowRef.location.protocol === "https:" ? "; Secure" : "";
+    const cookieNames = documentRef.cookie
+      .split(";")
+      .map((cookie) => cookie.split("=", 1)[0]?.trim())
+      .filter(
+        (name): name is string =>
+          Boolean(name) &&
+          GOOGLE_ANALYTICS_COOKIE_PREFIXES.some((prefix) =>
+            name.startsWith(prefix),
+          ),
+      );
+
+    for (const name of cookieNames) {
+      documentRef.cookie =
+        `${name}=; Max-Age=0; Path=/; SameSite=Lax${secure}`;
+      for (const domain of cookieDomainCandidates(
+        windowRef.location.hostname,
+      )) {
+        documentRef.cookie =
+          `${name}=; Max-Age=0; Path=/; Domain=${domain}; SameSite=Lax${secure}`;
+      }
+    }
+  } catch {
+    // Cookie access can be blocked. Consent remains denied in controller state,
+    // so no further documentation page views are emitted.
+  }
+}
+
+function disableGoogleAnalytics(
+  documentRef: Document,
+  windowRef: DocsAnalyticsWindow,
+): void {
+  try {
+    windowRef.gtag?.("consent", "update", deniedConsent());
+  } catch {
+    // Continue with local cleanup even if a third-party script misbehaves.
+  }
+
+  documentRef.getElementById(GOOGLE_TAG_SCRIPT_ID)?.remove();
+  deleteGoogleAnalyticsCookies(documentRef, windowRef);
+  delete windowRef.gtag;
+  delete windowRef.dataLayer;
+}
+
+export function createDocsAnalyticsController(
+  router: Router,
+): DocsAnalyticsController {
+  let choice: DocsAnalyticsConsentChoice | null = null;
+  let installed = false;
+  let previousPageLocation: string | null = null;
+
+  const recordPageView = (): void => {
+    previousPageLocation = sendPageView(
+      document,
+      window as DocsAnalyticsWindow,
+      previousPageLocation ?? document.referrer,
+    );
+  };
+
+  const enable = (sendCurrentPageView: boolean): void => {
+    loadGoogleAnalytics(document, window as DocsAnalyticsWindow);
+    if (sendCurrentPageView) {
+      recordPageView();
+    }
+  };
+
+  return {
+    getConsentChoice() {
+      if (!installed) {
+        choice = readStoredChoice(browserStorage(window));
+      }
+      return choice;
+    },
+
+    install() {
+      if (installed) return;
+      installed = true;
+      choice = readStoredChoice(browserStorage(window));
+
+      const prior = router.onAfterRouteChange;
+      router.onAfterRouteChange = async (to) => {
+        await prior?.(to);
+        if (choice === "granted") {
+          recordPageView();
+        }
+      };
+
+      window.addEventListener("storage", (event) => {
+        if (event.key !== DOCS_ANALYTICS_CONSENT_STORAGE_KEY) {
+          return;
+        }
+
+        // Consent is origin-wide, so every open docs tab must reflect the same
+        // stored choice. Reloading also cleanly installs a newly granted tag
+        // or unloads a denied tag before it can emit from stale in-memory state.
+        choice = event.newValue === "granted" ? "granted" : "denied";
+        previousPageLocation = null;
+        if (choice === "denied") {
+          disableGoogleAnalytics(document, window as DocsAnalyticsWindow);
+        }
+        window.location.reload();
+      });
+
+      if (choice === "granted") {
+        // VitePress invokes the route hook for the initial hydrated route.
+        // Loading here and recording there avoids a duplicate hard-reload view.
+        enable(false);
+      }
+    },
+
+    grant() {
+      choice = "granted";
+      persistChoice(browserStorage(window), choice);
+      // The current route has already settled when a visitor clicks Accept.
+      enable(true);
+    },
+
+    deny() {
+      const requiresReload = choice === "granted";
+      choice = "denied";
+      previousPageLocation = null;
+      persistChoice(browserStorage(window), choice);
+      disableGoogleAnalytics(document, window as DocsAnalyticsWindow);
+      return requiresReload;
+    },
+  };
+}

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -8,6 +8,10 @@ import WorkflowSurfacePanel from "./WorkflowSurfacePanel.vue";
 import WorkflowSurfaceSelector from "./WorkflowSurfaceSelector.vue";
 import { setupAriaCurrent } from "./aria-current";
 import { setupChannelSelector } from "./channel-selector";
+import {
+  createDocsAnalyticsController,
+  docsAnalyticsControllerKey,
+} from "./docs-analytics";
 import { setupLightbox } from "./lightbox";
 import { setupSearchA11y } from "./search-a11y";
 import "./custom.css";
@@ -23,11 +27,14 @@ export default {
   extends: DefaultTheme,
   Layout: JobCtrlLayout,
   enhanceApp({ app, router }) {
+    const docsAnalytics = createDocsAnalyticsController(router);
+    app.provide(docsAnalyticsControllerKey, docsAnalytics);
     app.component("ComparisonScreenshotCarousel", ComparisonScreenshotCarousel);
     app.component("Mermaid", MermaidRenderer);
     app.component("WorkflowSurfacePanel", WorkflowSurfacePanel);
     app.component("WorkflowSurfaceSelector", WorkflowSurfaceSelector);
     if (inBrowser) {
+      docsAnalytics.install();
       setupLightbox();
       setupAriaCurrent(router);
       setupChannelSelector(router);

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -542,12 +542,25 @@ the browser, so a build that passes can still contain a diagram that fails to
 parse. `pnpm docs:check:runtime` starts a fresh preview and checks hydration,
 images, navigation, responsive diagrams, search, the comparison screenshot-carousel
 interaction, and the desktop/mobile comparison layout (including keyboard access to
-its wide table) in Chromium;
+its wide table) in Chromium. It also intercepts the Google tag and proves the
+documentation cookie banner makes no analytics request before acceptance,
+persists both choices, emits SPA page views only after acceptance, and stops
+tracking plus clears site analytics cookies after withdrawal;
 run it after `pnpm docs:build` for public-doc changes. Note that
 `pnpm docs:preview` snapshots the built file list at startup: after any
 rebuild, restart the preview server or hashed assets will 404. Deploys to
 Cloudflare Pages run from `main` once the `DOCS_DEPLOY_ENABLED` repository
 variable and the Cloudflare credentials are configured.
+
+The docs theme sends its own sanitized `page_view` for the initial accepted
+route and each VitePress navigation. In the GA4 web data stream for
+`G-KB495KG6MS`, keep **Enhanced measurement → Page views → Page changes based
+on browser history events** disabled. The tag's `send_page_view: false`
+setting suppresses only its automatic load-time view; leaving GA4's separate
+history listener enabled would double-count client-side navigations. The
+repository runtime check stubs Google and proves the manual client contract;
+the matching data-stream setting and live event count are owner-side
+deployment checks.
 
 ## Documentation Screenshots
 

--- a/docs/publish-checklist.md
+++ b/docs/publish-checklist.md
@@ -231,13 +231,22 @@ especially §§11–14. This is a release precondition, not permission to publis
   - The release record names the same SHA and tree used by 9.1. Stable install
     wording remains provisional until the post-release installer cutover and
     public smoke in 9.6 pass.
+  - In the GA4 web data stream for `G-KB495KG6MS`, **Enhanced measurement →
+    Page views → Page changes based on browser history events** is disabled.
+    The docs theme sends one sanitized manual view per accepted VitePress
+    route; GA4's independent history listener would otherwise double-count it.
 - **Action.** Manually dispatch `Docs Site` at the audited `main` ref; do not
   toggle the already-enabled variable or wait for an unrelated push.
 - **Verification.** Confirm the dispatched run SHA equals the gated and frozen
   `main` SHA, the `deploy` job runs rather than skips, and `pnpm docs:build` +
   `pnpm docs:check:runtime` are green on that built artifact. Record this
   deployment SHA separately from the immutable release/tag SHA when the later
-  post-release installer/docs cutover in 9.6 changes `main`.
+  post-release installer/docs cutover in 9.6 changes `main`. In a fresh browser
+  profile, verify the hosted site makes no Google request before consent,
+  declining leaves the guide available, and acceptance records exactly one
+  initial view plus one view per client-side route in GA4 Realtime or
+  Tag Assistant. Reopen **Cookie settings**, withdraw, and verify later routes
+  send no views.
 - **Rollback.** Redeploy the previous known-good `docs-site-dist` artifact or a
   corrective audited commit. Do not represent a reverted deployment as stable
   release evidence.

--- a/docs/user/data-and-safety.md
+++ b/docs/user/data-and-safety.md
@@ -22,7 +22,8 @@ providers, precedence, and spend controls live in
 | Are the database and generated files stored locally? | ✓ **Yes, by default.** They live under `JOBCTRL_DIR` (normally `~/.jobctrl/`). |
 | Does JobCtrl call AI models or other providers automatically? | ◐ **Only when you use a configured feature.** Generation and opted-in research call providers during runs you start or schedules you explicitly enable. |
 | Does Discovery make network requests? | ✓ **Yes—that is how it searches configured job sources and, for AI-assisted steps, communicates with the model providers you selected.** Requests occur during runs you start or schedules you explicitly enable. |
-| Is telemetry enabled by default? | ✕ **No.** Langfuse requires configuration; `LANGFUSE_DISABLE=1` overrides it. |
+| Is product telemetry enabled by default? | ✕ **No.** Langfuse requires configuration; `LANGFUSE_DISABLE=1` overrides it. |
+| Does this documentation site use analytics? | ◐ **Only after you accept.** The optional Google Analytics tag stays unloaded until you choose **Accept analytics**; declining keeps the documentation fully available. |
 | Can Discovery or enrichment launch a browser? | ◐ **Only when needed.** Smart extraction and some detail enrichment use Playwright during runs you start or schedules you explicitly enable. |
 | Does application-submission browser automation run continuously? | ✕ **No.** It starts only through apply/dry-run work you initiate or a standing loop you explicitly enable. |
 | Does JobCtrl submit applications or send employer-facing email by default? | ✕ **No.** Browser submission and Gmail application sending are explicit guarded actions. |
@@ -32,6 +33,38 @@ Local-first does not mean offline. Discovery fetches sources, generation calls
 models, and live apply contacts an employer only when you use those features.
 
 <DataBoundaryMap />
+
+## Documentation Site Analytics
+
+The documentation at `https://jobctrl.dev` uses optional Google Analytics 4
+measurement only after consent. On a first visit, the cookie banner offers
+**Decline analytics** and **Accept analytics** without blocking the guide.
+Before acceptance, the site does not load or contact Google Analytics.
+
+The consent choice is stored in browser local storage under the versioned key
+`jobctrl-docs-analytics-consent-v1`. The footer's **Cookie settings** control
+reopens the choice at any time. Declining or withdrawing consent stops new page
+views, removes the Google tag from the page, and attempts to delete the
+documentation site's `_ga`, `_gid`, and `_gat` cookies. Withdrawing reloads the
+current documentation page so the previously loaded third-party runtime is no
+longer present. It cannot delete measurement data Google already received.
+
+After acceptance, the site loads Google tag `G-KB495KG6MS`. Page views contain
+the documentation path and page title, without URL query strings or fragments.
+Google may also receive the referrer, browser/device details, interaction data,
+and an IP address used for geolocation before it is discarded. JobCtrl disables
+Google Signals plus advertising and personalization signals, and configures
+host-only Google Analytics cookies that are not sent to `demo.jobctrl.dev` and
+expire within six months. A denial or withdrawal in one documentation tab
+reloads other open documentation tabs so none keep a stale consented tag.
+Google's handling of that data is described in
+[Safeguarding your data](https://support.google.com/analytics/answer/6004245).
+
+The data controller for this documentation measurement is Eloi Barti, acting as
+an individual. For privacy questions, contact
+[me@eloibarti.com](mailto:me@eloibarti.com). This hosted documentation
+measurement is separate from JobCtrl's local product telemetry and from the
+public demo measurement described below.
 
 ## Public Demo
 

--- a/docs/user/security.md
+++ b/docs/user/security.md
@@ -43,9 +43,10 @@ The hosted public demo uses synthetic data in a browser-local workspace. Its
 shortcuts and actions are simulations: they do not contact employers, send
 messages, or make external changes.
 
-For the demo's analytics-cookie consent, Google Analytics scope, retention,
-data-controller identity, and privacy contact, read the canonical
-[Public Demo data notice](data-and-safety.md#public-demo).
+For the documentation site's optional analytics consent and the demo's separate
+analytics-cookie gate, Google Analytics scope, retention, data-controller
+identity, and privacy contact, read the canonical
+[Data, Privacy & Safety notice](data-and-safety.md#documentation-site-analytics).
 
 ## What Leaves Your Machine
 

--- a/scripts/check-docs-site-runtime.mjs
+++ b/scripts/check-docs-site-runtime.mjs
@@ -102,6 +102,11 @@ const SOCIAL_METADATA_ROUTES = new Set([
 const SOCIAL_IMAGE_URL = "https://jobctrl.dev/assets/brand/social-preview.png";
 const SOCIAL_IMAGE_ALT =
   "JobCtrl: run your job search, keep your data, and inspect key AI-assisted decisions.";
+const DOCS_GOOGLE_TAG_ORIGIN = "https://www.googletagmanager.com";
+const DOCS_GOOGLE_TAG_MEASUREMENT_ID = "G-KB495KG6MS";
+const DOCS_GOOGLE_TAG_SCRIPT_ID = "jobctrl-docs-google-analytics";
+const DOCS_ANALYTICS_CONSENT_STORAGE_KEY =
+  "jobctrl-docs-analytics-consent-v1";
 
 const LIFECYCLE_EXPLANATION_CONTRACTS = [
   {
@@ -380,6 +385,600 @@ async function assertSocialMetadata(page, route) {
   }
 }
 
+async function assertDocsAnalyticsConsent(page, baseUrl, fail) {
+  const googleTagRequests = [];
+  const stubGoogleTag = async (route) => {
+    googleTagRequests.push(route.request().url());
+    await route.fulfill({
+      contentType: "application/javascript",
+      body: "",
+    });
+  };
+  await page.route(`${DOCS_GOOGLE_TAG_ORIGIN}/**`, stubGoogleTag);
+
+  await page.setViewportSize(MOBILE_VIEWPORT);
+  await page.goto(`${baseUrl}/`, { waitUntil: "networkidle" });
+  const initialState = await page.evaluate(
+    ({ scriptId, storageKey }) => {
+      const banner = document.querySelector("[data-jh-cookie-banner]");
+      const box = banner?.getBoundingClientRect();
+      return {
+        banner: box
+          ? {
+              bottom: box.bottom,
+              left: box.left,
+              right: box.right,
+              top: box.top,
+            }
+          : null,
+        choice: localStorage.getItem(storageKey),
+        dataLayerPresent: "dataLayer" in window,
+        gtagPresent: "gtag" in window,
+        pageOverflows:
+          document.documentElement.scrollWidth > window.innerWidth,
+        scriptCount: document.querySelectorAll(`#${scriptId}`).length,
+      };
+    },
+    {
+      scriptId: DOCS_GOOGLE_TAG_SCRIPT_ID,
+      storageKey: DOCS_ANALYTICS_CONSENT_STORAGE_KEY,
+    },
+  );
+  const initialActions = await page
+    .locator("[data-jh-cookie-banner] button")
+    .allTextContents();
+  if (
+    !initialState.banner ||
+    initialState.banner.left < 0 ||
+    initialState.banner.right > MOBILE_VIEWPORT.width + 1 ||
+    initialState.banner.top < 0 ||
+    initialState.banner.bottom > MOBILE_VIEWPORT.height + 1 ||
+    initialState.pageOverflows ||
+    initialState.choice !== null ||
+    initialState.scriptCount !== 0 ||
+    initialState.dataLayerPresent ||
+    initialState.gtagPresent ||
+    googleTagRequests.length !== 0 ||
+    !initialActions.some((label) => label.includes("Decline analytics")) ||
+    !initialActions.some((label) => label.includes("Accept analytics"))
+  ) {
+    fail(
+      `/: analytics consent did not start private, optional, and viewport-contained (${JSON.stringify(
+        { initialState, initialActions, googleTagRequests },
+      )})`,
+    );
+  } else {
+    console.log("ok    / analytics defaults to no Google request");
+  }
+
+  await page
+    .getByRole("button", { name: "Decline analytics", exact: true })
+    .click();
+  const declinedState = await page.evaluate(
+    ({ scriptId, storageKey }) => ({
+      activeHref: document.activeElement?.getAttribute("href") ?? "",
+      bannerCount: document.querySelectorAll("[data-jh-cookie-banner]").length,
+      choice: localStorage.getItem(storageKey),
+      dataLayerPresent: "dataLayer" in window,
+      gtagPresent: "gtag" in window,
+      scriptCount: document.querySelectorAll(`#${scriptId}`).length,
+    }),
+    {
+      scriptId: DOCS_GOOGLE_TAG_SCRIPT_ID,
+      storageKey: DOCS_ANALYTICS_CONSENT_STORAGE_KEY,
+    },
+  );
+  if (
+    declinedState.activeHref !== "/" ||
+    declinedState.bannerCount !== 0 ||
+    declinedState.choice !== "denied" ||
+    declinedState.scriptCount !== 0 ||
+    declinedState.dataLayerPresent ||
+    declinedState.gtagPresent ||
+    googleTagRequests.length !== 0
+  ) {
+    fail(
+      `/: declining analytics loaded or retained the Google tag (${JSON.stringify(
+        { declinedState, googleTagRequests },
+      )})`,
+    );
+  } else {
+    console.log("ok    / analytics decline persists without Google");
+  }
+
+  await page
+    .getByRole("button", { name: "Cookie settings", exact: true })
+    .click();
+  await page
+    .getByRole("heading", {
+      name: "Optional documentation analytics",
+      exact: true,
+    })
+    .waitFor({ state: "visible" });
+  await page
+    .getByRole("button", { name: "Accept analytics", exact: true })
+    .click();
+  await page.waitForFunction(
+    (scriptId) => Boolean(document.getElementById(scriptId)),
+    DOCS_GOOGLE_TAG_SCRIPT_ID,
+  );
+  await page.waitForTimeout(100);
+
+  const acceptedState = await page.evaluate(
+    ({ measurementId, scriptId, storageKey }) => {
+      const commands = (window.dataLayer ?? []).map((command) =>
+        Array.from(command),
+      );
+      return {
+        choice: localStorage.getItem(storageKey),
+        config: commands.find(
+          (command) =>
+            command[0] === "config" && command[1] === measurementId,
+        ),
+        consent: commands.find(
+          (command) =>
+            command[0] === "consent" && command[1] === "default",
+        ),
+        pageViews: commands.filter(
+          (command) =>
+            command[0] === "event" && command[1] === "page_view",
+        ),
+        scriptSrc: document
+          .getElementById(scriptId)
+          ?.getAttribute("src"),
+      };
+    },
+    {
+      measurementId: DOCS_GOOGLE_TAG_MEASUREMENT_ID,
+      scriptId: DOCS_GOOGLE_TAG_SCRIPT_ID,
+      storageKey: DOCS_ANALYTICS_CONSENT_STORAGE_KEY,
+    },
+  );
+  const acceptedConfig = acceptedState.config?.[2];
+  const acceptedConsent = acceptedState.consent?.[2];
+  if (
+    acceptedState.choice !== "granted" ||
+    acceptedState.scriptSrc !==
+      `${DOCS_GOOGLE_TAG_ORIGIN}/gtag/js?id=${DOCS_GOOGLE_TAG_MEASUREMENT_ID}` ||
+    googleTagRequests.length !== 1 ||
+    googleTagRequests[0] !==
+      `${DOCS_GOOGLE_TAG_ORIGIN}/gtag/js?id=${DOCS_GOOGLE_TAG_MEASUREMENT_ID}` ||
+    acceptedState.pageViews.length !== 1 ||
+    acceptedState.pageViews[0]?.[2]?.page_path !== "/" ||
+    acceptedState.pageViews[0]?.[2]?.page_location !== `${baseUrl}/` ||
+    acceptedConfig?.send_page_view !== false ||
+    acceptedConfig?.allow_google_signals !== false ||
+    acceptedConfig?.allow_ad_personalization_signals !== false ||
+    acceptedConfig?.cookie_domain !== "none" ||
+    acceptedConfig?.cookie_expires !== 15_544_800 ||
+    acceptedConfig?.cookie_update !== false ||
+    acceptedConsent?.analytics_storage !== "granted" ||
+    acceptedConsent?.ad_storage !== "denied" ||
+    acceptedConsent?.ad_user_data !== "denied" ||
+    acceptedConsent?.ad_personalization !== "denied"
+  ) {
+    fail(
+      `/: accepting analytics did not load the bounded Google tag (${JSON.stringify(
+        { acceptedState, googleTagRequests },
+      )})`,
+    );
+  } else {
+    console.log("ok    / analytics accept loads the bounded Google tag");
+  }
+
+  await page.setViewportSize(BASE_VIEWPORT);
+  await page
+    .locator('.VPHome .VPHero a[href="/user/product-tour"]')
+    .click();
+  await page.waitForURL(`${baseUrl}/user/product-tour`);
+  await page.waitForFunction(
+    () =>
+      (window.dataLayer ?? []).filter(
+        (command) =>
+          command[0] === "event" && command[1] === "page_view",
+      ).length === 2,
+  );
+  const spaPageViews = await page.evaluate(() =>
+    (window.dataLayer ?? [])
+      .filter(
+        (command) =>
+          command[0] === "event" && command[1] === "page_view",
+      )
+      .map((command) => Array.from(command)),
+  );
+  if (
+    spaPageViews.at(-1)?.[2]?.page_path !== "/user/product-tour" ||
+    spaPageViews.at(-1)?.[2]?.page_location !==
+      `${baseUrl}/user/product-tour` ||
+    spaPageViews.at(-1)?.[2]?.page_referrer !== `${baseUrl}/` ||
+    !String(spaPageViews.at(-1)?.[2]?.page_title).includes("Product Tour")
+  ) {
+    fail(
+      `/user/product-tour: SPA analytics page view was missing or overbroad (${JSON.stringify(
+        spaPageViews,
+      )})`,
+    );
+  } else {
+    console.log("ok    /user/product-tour analytics tracks SPA navigation");
+  }
+
+  await page.reload({ waitUntil: "networkidle" });
+  await page.waitForFunction(
+    (scriptId) => Boolean(document.getElementById(scriptId)),
+    DOCS_GOOGLE_TAG_SCRIPT_ID,
+  );
+  await page.waitForTimeout(100);
+  const restoredGrant = await page.evaluate(
+    ({ storageKey }) => ({
+      bannerCount: document.querySelectorAll("[data-jh-cookie-banner]").length,
+      choice: localStorage.getItem(storageKey),
+      pageViews: (window.dataLayer ?? []).filter(
+        (command) =>
+          command[0] === "event" && command[1] === "page_view",
+      ).length,
+    }),
+    { storageKey: DOCS_ANALYTICS_CONSENT_STORAGE_KEY },
+  );
+  if (
+    restoredGrant.choice !== "granted" ||
+    restoredGrant.bannerCount !== 0 ||
+    restoredGrant.pageViews !== 1 ||
+    googleTagRequests.length !== 2
+  ) {
+    fail(
+      `/user/product-tour: analytics grant did not restore cleanly (${JSON.stringify(
+        { restoredGrant, googleTagRequests },
+      )})`,
+    );
+  } else {
+    console.log("ok    / analytics grant restores without reopening banner");
+  }
+
+  await page.evaluate(() => {
+    document.cookie = "_ga=GA1.1.test; Path=/; SameSite=Lax";
+    document.cookie = "_ga_KB495KG6MS=GS1.1.test; Path=/; SameSite=Lax";
+    document.cookie = "_gid=test; Path=/; SameSite=Lax";
+  });
+  await page
+    .getByRole("button", { name: "Cookie settings", exact: true })
+    .click();
+  await Promise.all([
+    page.waitForNavigation({ waitUntil: "networkidle" }),
+    page
+      .getByRole("button", { name: "Decline analytics", exact: true })
+      .click(),
+  ]);
+  const withdrawnState = await page.evaluate(
+    ({ scriptId, storageKey }) => ({
+      analyticsCookies: document.cookie
+        .split(";")
+        .map((cookie) => cookie.split("=", 1)[0]?.trim())
+        .filter(
+          (name) =>
+            name?.startsWith("_ga") ||
+            name?.startsWith("_gid") ||
+            name?.startsWith("_gat"),
+        ),
+      bannerCount: document.querySelectorAll("[data-jh-cookie-banner]").length,
+      choice: localStorage.getItem(storageKey),
+      dataLayerPresent: "dataLayer" in window,
+      gtagPresent: "gtag" in window,
+      scriptCount: document.querySelectorAll(`#${scriptId}`).length,
+    }),
+    {
+      scriptId: DOCS_GOOGLE_TAG_SCRIPT_ID,
+      storageKey: DOCS_ANALYTICS_CONSENT_STORAGE_KEY,
+    },
+  );
+  if (
+    withdrawnState.choice !== "denied" ||
+    withdrawnState.bannerCount !== 0 ||
+    withdrawnState.scriptCount !== 0 ||
+    withdrawnState.dataLayerPresent ||
+    withdrawnState.gtagPresent ||
+    withdrawnState.analyticsCookies.length !== 0
+  ) {
+    fail(
+      `/user/product-tour: analytics withdrawal did not stop and clean up tracking (${JSON.stringify(
+        withdrawnState,
+      )})`,
+    );
+  } else {
+    console.log("ok    / analytics withdrawal stops tracking and clears cookies");
+  }
+
+  await page
+    .locator('.VPNavBarTitle a[href="/"]')
+    .click();
+  await page.waitForURL(`${baseUrl}/`);
+  const postWithdrawalState = await page.evaluate(
+    ({ scriptId, storageKey }) => ({
+      choice: localStorage.getItem(storageKey),
+      dataLayerPresent: "dataLayer" in window,
+      gtagPresent: "gtag" in window,
+      scriptCount: document.querySelectorAll(`#${scriptId}`).length,
+    }),
+    {
+      scriptId: DOCS_GOOGLE_TAG_SCRIPT_ID,
+      storageKey: DOCS_ANALYTICS_CONSENT_STORAGE_KEY,
+    },
+  );
+  if (
+    postWithdrawalState.choice !== "denied" ||
+    postWithdrawalState.scriptCount !== 0 ||
+    postWithdrawalState.dataLayerPresent ||
+    postWithdrawalState.gtagPresent ||
+    googleTagRequests.length !== 2
+  ) {
+    fail(
+      `/: tracking resumed after withdrawal (${JSON.stringify(
+        { postWithdrawalState, googleTagRequests },
+      )})`,
+    );
+  } else {
+    console.log("ok    / analytics remains disabled after SPA navigation");
+  }
+
+  await page.reload({ waitUntil: "networkidle" });
+  const restoredDenial = await page.evaluate(
+    ({ scriptId, storageKey }) => ({
+      bannerCount: document.querySelectorAll("[data-jh-cookie-banner]").length,
+      choice: localStorage.getItem(storageKey),
+      dataLayerPresent: "dataLayer" in window,
+      gtagPresent: "gtag" in window,
+      scriptCount: document.querySelectorAll(`#${scriptId}`).length,
+    }),
+    {
+      scriptId: DOCS_GOOGLE_TAG_SCRIPT_ID,
+      storageKey: DOCS_ANALYTICS_CONSENT_STORAGE_KEY,
+    },
+  );
+  if (
+    restoredDenial.choice !== "denied" ||
+    restoredDenial.bannerCount !== 0 ||
+    restoredDenial.scriptCount !== 0 ||
+    restoredDenial.dataLayerPresent ||
+    restoredDenial.gtagPresent ||
+    googleTagRequests.length !== 2
+  ) {
+    fail(
+      `/: analytics denial did not persist across reload (${JSON.stringify(
+        { restoredDenial, googleTagRequests },
+      )})`,
+    );
+  } else {
+    console.log("ok    / analytics denial persists across reload");
+  }
+
+  await page
+    .getByRole("button", { name: "Cookie settings", exact: true })
+    .click();
+  await page
+    .getByRole("button", { name: "Accept analytics", exact: true })
+    .click();
+  await page.waitForFunction(
+    (scriptId) => Boolean(document.getElementById(scriptId)),
+    DOCS_GOOGLE_TAG_SCRIPT_ID,
+  );
+
+  const secondPage = await page.context().newPage();
+  await secondPage.setViewportSize(BASE_VIEWPORT);
+  await secondPage.route(`${DOCS_GOOGLE_TAG_ORIGIN}/**`, stubGoogleTag);
+  await secondPage.goto(`${baseUrl}/`, { waitUntil: "networkidle" });
+  await secondPage.waitForFunction(
+    (scriptId) => Boolean(document.getElementById(scriptId)),
+    DOCS_GOOGLE_TAG_SCRIPT_ID,
+  );
+
+  const consentedTabStates = await Promise.all(
+    [page, secondPage].map((tab) =>
+      tab.evaluate(
+        ({ scriptId, storageKey }) => ({
+          choice: localStorage.getItem(storageKey),
+          pageViews: (window.dataLayer ?? []).filter(
+            (command) =>
+              command[0] === "event" && command[1] === "page_view",
+          ).length,
+          scriptCount: document.querySelectorAll(`#${scriptId}`).length,
+        }),
+        {
+          scriptId: DOCS_GOOGLE_TAG_SCRIPT_ID,
+          storageKey: DOCS_ANALYTICS_CONSENT_STORAGE_KEY,
+        },
+      ),
+    ),
+  );
+
+  await page
+    .getByRole("button", { name: "Cookie settings", exact: true })
+    .click();
+  await Promise.all([
+    page.waitForNavigation({ waitUntil: "networkidle" }),
+    secondPage.waitForNavigation({ waitUntil: "networkidle" }),
+    page
+      .getByRole("button", { name: "Decline analytics", exact: true })
+      .click(),
+  ]);
+
+  const deniedTabStates = await Promise.all(
+    [page, secondPage].map((tab) =>
+      tab.evaluate(
+        ({ scriptId, storageKey }) => ({
+          bannerCount:
+            document.querySelectorAll("[data-jh-cookie-banner]").length,
+          choice: localStorage.getItem(storageKey),
+          dataLayerPresent: "dataLayer" in window,
+          gtagPresent: "gtag" in window,
+          scriptCount: document.querySelectorAll(`#${scriptId}`).length,
+        }),
+        {
+          scriptId: DOCS_GOOGLE_TAG_SCRIPT_ID,
+          storageKey: DOCS_ANALYTICS_CONSENT_STORAGE_KEY,
+        },
+      ),
+    ),
+  );
+  const requestsAfterCrossTabDenial = googleTagRequests.length;
+
+  await secondPage
+    .locator('.VPHome .VPHero a[href="/user/product-tour"]')
+    .click();
+  await secondPage.waitForURL(`${baseUrl}/user/product-tour`);
+  const secondTabPostDenial = await secondPage.evaluate(
+    ({ scriptId, storageKey }) => ({
+      choice: localStorage.getItem(storageKey),
+      dataLayerPresent: "dataLayer" in window,
+      gtagPresent: "gtag" in window,
+      scriptCount: document.querySelectorAll(`#${scriptId}`).length,
+    }),
+    {
+      scriptId: DOCS_GOOGLE_TAG_SCRIPT_ID,
+      storageKey: DOCS_ANALYTICS_CONSENT_STORAGE_KEY,
+    },
+  );
+
+  await page
+    .getByRole("button", { name: "Cookie settings", exact: true })
+    .click();
+  await Promise.all([
+    secondPage.waitForNavigation({ waitUntil: "networkidle" }),
+    page
+      .getByRole("button", { name: "Accept analytics", exact: true })
+      .click(),
+  ]);
+  await Promise.all(
+    [page, secondPage].map((tab) =>
+      tab.waitForFunction(
+        (scriptId) => Boolean(document.getElementById(scriptId)),
+        DOCS_GOOGLE_TAG_SCRIPT_ID,
+      ),
+    ),
+  );
+
+  await secondPage
+    .getByRole("button", { name: "Cookie settings", exact: true })
+    .click();
+  const synchronizedGrantState = await secondPage.evaluate(
+    ({ scriptId, storageKey }) => ({
+      bannerText:
+        document.querySelector("[data-jh-cookie-banner]")?.textContent ?? "",
+      choice: localStorage.getItem(storageKey),
+      pageViews: (window.dataLayer ?? []).filter(
+        (command) =>
+          command[0] === "event" && command[1] === "page_view",
+      ).length,
+      scriptCount: document.querySelectorAll(`#${scriptId}`).length,
+    }),
+    {
+      scriptId: DOCS_GOOGLE_TAG_SCRIPT_ID,
+      storageKey: DOCS_ANALYTICS_CONSENT_STORAGE_KEY,
+    },
+  );
+
+  await Promise.all([
+    page.waitForNavigation({ waitUntil: "networkidle" }),
+    secondPage.waitForNavigation({ waitUntil: "networkidle" }),
+    secondPage
+      .getByRole("button", { name: "Decline analytics", exact: true })
+      .click(),
+  ]);
+  const synchronizedDenialStates = await Promise.all(
+    [page, secondPage].map((tab) =>
+      tab.evaluate(
+        ({ scriptId, storageKey }) => ({
+          bannerCount:
+            document.querySelectorAll("[data-jh-cookie-banner]").length,
+          choice: localStorage.getItem(storageKey),
+          dataLayerPresent: "dataLayer" in window,
+          gtagPresent: "gtag" in window,
+          scriptCount: document.querySelectorAll(`#${scriptId}`).length,
+        }),
+        {
+          scriptId: DOCS_GOOGLE_TAG_SCRIPT_ID,
+          storageKey: DOCS_ANALYTICS_CONSENT_STORAGE_KEY,
+        },
+      ),
+    ),
+  );
+  const requestsAfterSynchronizedDenial = googleTagRequests.length;
+
+  await secondPage
+    .locator('.VPNavBarTitle a[href="/"]')
+    .click();
+  await secondPage.waitForURL(`${baseUrl}/`);
+  const secondTabAfterSynchronizedDenial = await secondPage.evaluate(
+    ({ scriptId, storageKey }) => ({
+      choice: localStorage.getItem(storageKey),
+      dataLayerPresent: "dataLayer" in window,
+      gtagPresent: "gtag" in window,
+      scriptCount: document.querySelectorAll(`#${scriptId}`).length,
+    }),
+    {
+      scriptId: DOCS_GOOGLE_TAG_SCRIPT_ID,
+      storageKey: DOCS_ANALYTICS_CONSENT_STORAGE_KEY,
+    },
+  );
+  await secondPage.close();
+
+  if (
+    consentedTabStates.some(
+      (state) =>
+        state.choice !== "granted" ||
+        state.pageViews !== 1 ||
+        state.scriptCount !== 1,
+    ) ||
+    deniedTabStates.some(
+      (state) =>
+        state.choice !== "denied" ||
+        state.bannerCount !== 0 ||
+        state.scriptCount !== 0 ||
+        state.dataLayerPresent ||
+        state.gtagPresent,
+    ) ||
+    requestsAfterCrossTabDenial !== 4 ||
+    secondTabPostDenial.choice !== "denied" ||
+    secondTabPostDenial.scriptCount !== 0 ||
+    secondTabPostDenial.dataLayerPresent ||
+    secondTabPostDenial.gtagPresent ||
+    synchronizedGrantState.choice !== "granted" ||
+    synchronizedGrantState.scriptCount !== 1 ||
+    synchronizedGrantState.pageViews !== 1 ||
+    !synchronizedGrantState.bannerText.includes(
+      "Current choice: analytics enabled",
+    ) ||
+    synchronizedDenialStates.some(
+      (state) =>
+        state.choice !== "denied" ||
+        state.bannerCount !== 0 ||
+        state.scriptCount !== 0 ||
+        state.dataLayerPresent ||
+        state.gtagPresent,
+    ) ||
+    requestsAfterSynchronizedDenial !== 6 ||
+    secondTabAfterSynchronizedDenial.choice !== "denied" ||
+    secondTabAfterSynchronizedDenial.scriptCount !== 0 ||
+    secondTabAfterSynchronizedDenial.dataLayerPresent ||
+    secondTabAfterSynchronizedDenial.gtagPresent ||
+    googleTagRequests.length !== requestsAfterSynchronizedDenial
+  ) {
+    fail(
+      `/: cross-tab analytics withdrawal left stale consent (${JSON.stringify(
+        {
+          consentedTabStates,
+          deniedTabStates,
+          secondTabPostDenial,
+          synchronizedGrantState,
+          synchronizedDenialStates,
+          secondTabAfterSynchronizedDenial,
+          googleTagRequests,
+        },
+      )})`,
+    );
+  } else {
+    console.log("ok    / analytics consent synchronizes across open docs tabs");
+  }
+}
+
 const port = await freePort();
 const preview = spawn(
   "corepack",
@@ -420,7 +1019,8 @@ if (
 
 const browser = await chromium.launch();
 try {
-  const page = await browser.newPage({ viewport: BASE_VIEWPORT });
+  const context = await browser.newContext({ viewport: BASE_VIEWPORT });
+  const page = await context.newPage();
   const badRequests = [];
   page.on("requestfailed", (r) =>
     badRequests.push(`${r.url()} ${r.failure()?.errorText ?? ""}`),
@@ -428,6 +1028,12 @@ try {
   page.on("response", (r) => {
     if (r.status() >= 400) badRequests.push(`${r.url()} HTTP ${r.status()}`);
   });
+
+  await assertDocsAnalyticsConsent(
+    page,
+    `http://127.0.0.1:${port}`,
+    fail,
+  );
 
   for (const spec of PAGES) {
     badRequests.length = 0;
@@ -589,6 +1195,7 @@ try {
     !footerText.includes("Copyright © 2026 Eloi Barti") ||
     !footerText.includes("AGPL-3.0-only") ||
     !footerText.includes("Source code") ||
+    !footerText.includes("Cookie settings") ||
     footerText.includes(obsoleteFooterMessage)
   ) {
     fail(
@@ -1184,6 +1791,16 @@ try {
         text.includes("not that a credential is absent"),
       hasRetryBoundary: text.includes("unlock it and retry"),
       hasDefaultProtection: text.includes("Protected by default"),
+      hasDocsAnalyticsDisclosure:
+        Boolean(document.querySelector("#documentation-site-analytics")) &&
+        text.includes("G-KB495KG6MS") &&
+        text.includes("Before acceptance") &&
+        text.includes("does not load or contact Google Analytics") &&
+        text.includes("jobctrl-docs-analytics-consent-v1") &&
+        text.includes("Cookie settings") &&
+        text.includes("without URL query strings or fragments") &&
+        text.includes("within six months") &&
+        text.includes("separate from JobCtrl's local product telemetry"),
     };
   });
   const requiredQuickAnswers = [
@@ -1191,7 +1808,8 @@ try {
     "Are the database and generated files stored locally?",
     "Does JobCtrl call AI models or other providers automatically?",
     "Does Discovery make network requests?",
-    "Is telemetry enabled by default?",
+    "Is product telemetry enabled by default?",
+    "Does this documentation site use analytics?",
     "Can Discovery or enrichment launch a browser?",
     "Does application-submission browser automation run continuously?",
     "Does JobCtrl submit applications or send employer-facing email by default?",
@@ -1222,7 +1840,8 @@ try {
     !privacyContract.hasLinuxBoundary ||
     !privacyContract.hasInspectionFailureBoundary ||
     !privacyContract.hasRetryBoundary ||
-    !privacyContract.hasDefaultProtection
+    !privacyContract.hasDefaultProtection ||
+    !privacyContract.hasDocsAnalyticsDisclosure
   ) {
     fail(
       `/user/data-and-safety: privacy/path/credential contract regressed (${JSON.stringify(privacyContract)})`,
@@ -1676,6 +2295,17 @@ try {
           "[data-jh-comparison-carousel] .jh-comparison-screenshot-carousel__status",
         )
         ?.textContent?.trim() === "2 of 2",
+  );
+  await page.waitForFunction(
+    () => {
+      const image = document.querySelector(
+        "[data-jh-comparison-carousel] img",
+      );
+      if (!(image instanceof HTMLImageElement)) return false;
+      const box = image.getBoundingClientRect();
+      return image.complete && image.naturalWidth > 100 && box.width > 220;
+    },
+    { timeout: 5000 },
   );
   const comparisonMobile = await page.evaluate(() => {
     const cards = [...document.querySelectorAll(".jh-compare-card")].map(


### PR DESCRIPTION
## Summary

- add consent-gated GA4 (`G-KB495KG6MS`) to the documentation site without loading Google before opt-in
- add an optional, persistent cookie banner and footer settings control with cross-tab consent synchronization and withdrawal cleanup
- emit sanitized manual VitePress page views with advertising signals disabled and host-only analytics cookies
- document the privacy boundary and deployment requirements, and extend the browser runtime regression suite

## Validation

- `corepack pnpm docs:build` — PASS; 338 files emitted and 8,238 references resolved
- `corepack pnpm docs:check:runtime` — PASS; consent, SPA views, withdrawal, cookie cleanup, cross-tab synchronization, mobile layout, social metadata, and launch CTA assertions all green
- independent reviewer gate — PASS; Blocker 0, High 0
- independent QA gate — PASS; Blocker 0, High 0
- `git diff --cached --check` — PASS before commit

## Deployment note

GA4 Enhanced Measurement must keep “Page changes based on browser history events” disabled because the docs theme sends sanitized manual SPA page views. The publish checklist records the required live verification.

## Checklist

- [x] DCO signing is not applicable to this repository-owner commit.
- [x] I ran the relevant local checks and listed them above.
- [x] I did not include secrets, private profile data, resumes, generated application materials, raw logs, browser profiles, SQLite databases, or local paths.