### PR TITLE
fix(ci): allow docs analytics privacy disclosure

### DIFF
--- a/scripts/release_check.py
+++ b/scripts/release_check.py
@@ -346,25 +346,34 @@ PUBLIC_COPYRIGHT_SNIPPETS = (
     f"Copyright (C) 2026 {PUBLIC_COPYRIGHT_HOLDER}",
     f"Copyright © 2026 {PUBLIC_COPYRIGHT_HOLDER}",
 )
-PUBLIC_DEMO_CONTROLLER_NAME = "El" + "oi Barti"
-PUBLIC_DEMO_CONTROLLER_EMAIL = "me@" + "el" + "oi" + "barti" + ".com"
-PUBLIC_DEMO_CONTROLLER_SOURCE_SNIPPETS = {
+PUBLIC_CONTROLLER_NAME = "El" + "oi Barti"
+PUBLIC_CONTROLLER_EMAIL = "me@" + "el" + "oi" + "barti" + ".com"
+PUBLIC_CONTROLLER_SOURCE_SNIPPETS = {
     Path("apps/web/src/demo/consent/DemoConsentGate.tsx"): (
-        f"Data controller: {PUBLIC_DEMO_CONTROLLER_NAME}, acting as an individual. Privacy questions:",
-        f'<a href="mailto:{PUBLIC_DEMO_CONTROLLER_EMAIL}">{PUBLIC_DEMO_CONTROLLER_EMAIL}</a>',
+        f"Data controller: {PUBLIC_CONTROLLER_NAME}, acting as an individual. Privacy questions:",
+        f'<a href="mailto:{PUBLIC_CONTROLLER_EMAIL}">{PUBLIC_CONTROLLER_EMAIL}</a>',
     ),
     Path("apps/web/src/demo/consent/DemoConsentGate.test.tsx"): (
-        f"screen.getByText(/data controller: {PUBLIC_DEMO_CONTROLLER_NAME.lower()}, acting as an individual/i)",
-        f'name: "{PUBLIC_DEMO_CONTROLLER_EMAIL}"',
-        f'"mailto:{PUBLIC_DEMO_CONTROLLER_EMAIL}"',
+        f"screen.getByText(/data controller: {PUBLIC_CONTROLLER_NAME.lower()}, acting as an individual/i)",
+        f'name: "{PUBLIC_CONTROLLER_EMAIL}"',
+        f'"mailto:{PUBLIC_CONTROLLER_EMAIL}"',
     ),
     Path("docs/user/data-and-safety.md"): (
-        f"The data controller for the public demo is {PUBLIC_DEMO_CONTROLLER_NAME}, acting as an individual.\n"
-        f"For privacy questions, contact [{PUBLIC_DEMO_CONTROLLER_EMAIL}](mailto:{PUBLIC_DEMO_CONTROLLER_EMAIL}).",
+        f"The data controller for the public demo is {PUBLIC_CONTROLLER_NAME}, acting as an individual.\n"
+        f"For privacy questions, contact [{PUBLIC_CONTROLLER_EMAIL}](mailto:{PUBLIC_CONTROLLER_EMAIL}).",
+        f"The data controller for this documentation measurement is {PUBLIC_CONTROLLER_NAME}, acting as\n"
+        "an individual. For privacy questions, contact\n"
+        f"[{PUBLIC_CONTROLLER_EMAIL}](mailto:{PUBLIC_CONTROLLER_EMAIL}).",
     ),
     Path("docs/.vitepress/dist/user/data-and-safety.html"): (
-        f"The data controller for the public demo is {PUBLIC_DEMO_CONTROLLER_NAME}, acting as an individual.",
-        f'href="mailto:{PUBLIC_DEMO_CONTROLLER_EMAIL}">{PUBLIC_DEMO_CONTROLLER_EMAIL}</a>',
+        f"The data controller for the public demo is {PUBLIC_CONTROLLER_NAME}, acting as an individual. "
+        "For privacy questions, contact "
+        f'<a href="mailto:{PUBLIC_CONTROLLER_EMAIL}" target="_blank" rel="noreferrer">'
+        f"{PUBLIC_CONTROLLER_EMAIL}</a>.",
+        f"The data controller for this documentation measurement is {PUBLIC_CONTROLLER_NAME}, acting as an individual. "
+        "For privacy questions, contact "
+        f'<a href="mailto:{PUBLIC_CONTROLLER_EMAIL}" target="_blank" rel="noreferrer">'
+        f"{PUBLIC_CONTROLLER_EMAIL}</a>.",
     ),
 }
 PUBLIC_DEMO_CONTROLLER_BUILD_ASSET_PREFIXES = (
@@ -373,12 +382,12 @@ PUBLIC_DEMO_CONTROLLER_BUILD_ASSET_PREFIXES = (
     Path("apps/web/dist/assets"),
 )
 PUBLIC_DEMO_CONTROLLER_BUILD_SNIPPETS = (
-    f"Data controller: {PUBLIC_DEMO_CONTROLLER_NAME}, acting as an individual. Privacy questions:",
-    f'href:"mailto:{PUBLIC_DEMO_CONTROLLER_EMAIL}",children:"{PUBLIC_DEMO_CONTROLLER_EMAIL}"',
+    f"Data controller: {PUBLIC_CONTROLLER_NAME}, acting as an individual. Privacy questions:",
+    f'href:"mailto:{PUBLIC_CONTROLLER_EMAIL}",children:"{PUBLIC_CONTROLLER_EMAIL}"',
 )
 PUBLIC_DEMO_CONTROLLER_BUILD_SOURCE_MAP_SNIPPETS = (
-    f"Data controller: {PUBLIC_DEMO_CONTROLLER_NAME}, acting as an individual. Privacy questions:",
-    f'href=\\"mailto:{PUBLIC_DEMO_CONTROLLER_EMAIL}\\">{PUBLIC_DEMO_CONTROLLER_EMAIL}</a>',
+    f"Data controller: {PUBLIC_CONTROLLER_NAME}, acting as an individual. Privacy questions:",
+    f'href=\\"mailto:{PUBLIC_CONTROLLER_EMAIL}\\">{PUBLIC_CONTROLLER_EMAIL}</a>',
 )
 
 
@@ -616,7 +625,7 @@ def scan_text(
 ) -> list[str]:
     """Scan text content for forbidden strings and non-empty secret assignments."""
     findings = []
-    redacted_text = _redact_public_demo_controller_disclosure(text, rel)
+    redacted_text = _redact_public_controller_disclosures(text, rel)
     for needle in needles:
         scan_target = _redact_public_attribution(redacted_text, rel, needle)
         if _contains_needle(scan_target, needle):
@@ -627,9 +636,9 @@ def scan_text(
     return findings
 
 
-def _redact_public_demo_controller_disclosure(text: str, rel: Path) -> str:
-    """Exclude the approved controller disclosure only at its public release surfaces."""
-    snippets = PUBLIC_DEMO_CONTROLLER_SOURCE_SNIPPETS.get(rel)
+def _redact_public_controller_disclosures(text: str, rel: Path) -> str:
+    """Exclude approved controller disclosures only at their public release surfaces."""
+    snippets = PUBLIC_CONTROLLER_SOURCE_SNIPPETS.get(rel)
     if snippets is None and _is_public_demo_controller_build_asset(rel):
         snippets = (
             PUBLIC_DEMO_CONTROLLER_BUILD_SOURCE_MAP_SNIPPETS

--- a/workers/automation/tests/test_release_check.py
+++ b/workers/automation/tests/test_release_check.py
@@ -46,7 +46,7 @@ def test_public_copyright_attribution_does_not_disable_private_name_detection() 
     ) == ["README.md: contains private first name"]
 
 
-def test_public_demo_controller_disclosure_is_limited_to_exact_public_surfaces() -> None:
+def test_public_controller_disclosures_are_limited_to_exact_public_surfaces() -> None:
     controller = "El" + "oi Barti"
     email = "me@" + "el" + "oi" + "barti" + ".com"
     source_disclosure = (
@@ -56,6 +56,11 @@ def test_public_demo_controller_disclosure_is_limited_to_exact_public_surfaces()
     docs_disclosure = (
         f"The data controller for the public demo is {controller}, acting as an individual.\n"
         f"For privacy questions, contact [{email}](mailto:{email})."
+    )
+    docs_analytics_disclosure = (
+        f"The data controller for this documentation measurement is {controller}, acting as\n"
+        "an individual. For privacy questions, contact\n"
+        f"[{email}](mailto:{email})."
     )
     test_disclosure = (
         f"screen.getByText(/data controller: {controller.lower()}, acting as an individual/i)\n"
@@ -78,6 +83,11 @@ def test_public_demo_controller_disclosure_is_limited_to_exact_public_surfaces()
         Path("docs/user/data-and-safety.md"),
     ) == []
     assert release_check.scan_text(
+        "docs/user/data-and-safety.md",
+        docs_analytics_disclosure,
+        Path("docs/user/data-and-safety.md"),
+    ) == []
+    assert release_check.scan_text(
         "apps/web/src/demo/consent/DemoConsentGate.test.tsx",
         test_disclosure,
         Path("apps/web/src/demo/consent/DemoConsentGate.test.tsx"),
@@ -95,8 +105,18 @@ def test_public_demo_controller_disclosure_is_limited_to_exact_public_surfaces()
     assert release_check.scan_text(
         "docs/.vitepress/dist/user/data-and-safety.html",
         (
-            f"The data controller for the public demo is {controller}, acting as an individual.\n"
-            f'<a href="mailto:{email}">{email}</a>'
+            f"The data controller for the public demo is {controller}, acting as an individual. "
+            "For privacy questions, contact "
+            f'<a href="mailto:{email}" target="_blank" rel="noreferrer">{email}</a>.'
+        ),
+        Path("docs/.vitepress/dist/user/data-and-safety.html"),
+    ) == []
+    assert release_check.scan_text(
+        "docs/.vitepress/dist/user/data-and-safety.html",
+        (
+            f"The data controller for this documentation measurement is {controller}, "
+            "acting as an individual. For privacy questions, contact "
+            f'<a href="mailto:{email}" target="_blank" rel="noreferrer">{email}</a>.'
         ),
         Path("docs/.vitepress/dist/user/data-and-safety.html"),
     ) == []
@@ -106,6 +126,23 @@ def test_public_demo_controller_disclosure_is_limited_to_exact_public_surfaces()
         "contains private first name",
         "contains private personal domain",
     }
+    same_page_findings = release_check.scan_text(
+        "docs/user/data-and-safety.md",
+        f"Unapproved controller reference: {controller} {email}",
+        Path("docs/user/data-and-safety.md"),
+    )
+    assert {finding.split(": ", 1)[1] for finding in same_page_findings} == expected
+    emitted_same_page_findings = release_check.scan_text(
+        "docs/.vitepress/dist/user/data-and-safety.html",
+        (
+            "Unapproved contact: "
+            f'<a href="mailto:{email}" target="_blank" rel="noreferrer">{email}</a>'
+        ),
+        Path("docs/.vitepress/dist/user/data-and-safety.html"),
+    )
+    assert {
+        finding.split(": ", 1)[1] for finding in emitted_same_page_findings
+    } == expected
     for label, rel in (
         ("docs/unrelated.md", Path("docs/unrelated.md")),
         ("dist/web/assets/unrelated.js", Path("dist/web/assets/unrelated.js")),


### PR DESCRIPTION
## What changed

- recognize the exact public documentation analytics controller disclosure in the release scanner
- recognize the exact VitePress-rendered disclosure without weakening the global privacy needles
- add negative controls for altered wording, contact-only HTML, and unrelated paths

## Why

The consent-gated docs analytics change added a required privacy disclosure, but the release scanner only recognized the existing public-demo disclosure. Python CI therefore failed on the merged docs commit even though the disclosure is intentionally public.

## Validation

- `uv --project workers/automation run pytest -q --noconftest workers/automation/tests/test_release_check.py` (52 passed)
- `uv --project workers/automation run ruff check scripts/release_check.py workers/automation/tests/test_release_check.py`
- `python scripts/release_check.py`
- `python scripts/release_check.py --strict-prompt`
- `corepack pnpm docs:build`
- direct scan of the generated `docs/.vitepress/dist/user/data-and-safety.html`
- independent privacy/release review and QA gates: PASS