### PR TITLE
test(docs): align supervised apply copy contract

### DIFF
--- a/scripts/docs-launch-copy.test.mjs
+++ b/scripts/docs-launch-copy.test.mjs
@@ -79,7 +79,7 @@ test("comparison omits the annotated recommendation and methodology sections", a
   assert.match(comparison, /^## Appendix: evidence-backed capability matrix$/m);
 });
 
-test("homepage describes live submission approval as the default", async () => {
+test("homepage describes supervised browser and email submission", async () => {
   const homepage = await read("docs/index.md");
 
   assert.match(homepage, /text: Run your job search\. Keep your data\./);
@@ -87,10 +87,10 @@ test("homepage describes live submission approval as the default", async () => {
   assert.match(homepage, /text: Install on Apple silicon\s+link: \/user\/getting-started/);
   assert.match(homepage, /text: See How It Works\s+link: \/user\/product-tour/);
   assert.match(homepage, /text: View on GitHub\s+link: https:\/\/github\.com\/ebarti\/JobCtrl/);
-  assert.match(homepage, /require explicit approval for live submissions by default/i);
   assert.match(homepage, /keep live submission behind your approval by default/i);
-  assert.match(homepage, /browser-level guard blocks dry-run submits/i);
-  assert.match(homepage, /no application is ever submitted twice/i);
+  assert.match(homepage, /keep final browser submission manual/i);
+  assert.match(homepage, /allow only exact-approved email applications/i);
+  assert.match(homepage, /owned at-most-once sender/i);
   assert.doesNotMatch(homepage, /approve every live submission explicitly/i);
   assert.doesNotMatch(homepage, /Run From Source \/ Release Status/i);
 });


### PR DESCRIPTION
## Summary
- align the launch-copy regression with the current supervised application contract
- assert manual browser final submission, exact-approved email applications, and the owned at-most-once sender
- remove obsolete homepage wording assertions that made the demo verification job fail

## Why
The homepage copy was intentionally tightened by the preceding security changes, but the launch-copy regression still expected superseded phrases. Keeping this as a test-only stack layer preserves the small review scope of the functional PRs.

## Validation
- pnpm scripts:test (130 passed)
- node --test scripts/docs-launch-copy.test.mjs (8 passed)
- git diff --check
- independent review: PASS (0 findings)