### PR TITLE
docs(plans): reconcile delivered work

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -2127,6 +2127,6 @@ Consequences:
   acknowledgement, start a fresh worker, and prove exactly-once product counts
   over at-least-once provider delivery.
 
-Cites: `docs/plans/2026-07-17-resumable-jobstreaming-discovery-plan.md`;
+Cites: `docs/plans/implemented/2026-07-17-resumable-jobstreaming-discovery-plan.md`;
 `docs/architecture/pipeline/envelope.md`; `docs/architecture/storage.md`;
 `workers/automation/tests/test_jobstreaming_resumable_discovery.py`.

--- a/docs/plans/2026-07-10-bundled-jobctrl-distribution-plan.md
+++ b/docs/plans/2026-07-10-bundled-jobctrl-distribution-plan.md
@@ -1,17 +1,19 @@
 # Bundled JobCtrl Distribution Plan
 
 - **Date:** 2026-07-10
-- **Status (2026-07-24):** Active / implementation and stable release landed;
+- **Status (2026-07-29):** Active / implementation and stable release landed;
   published-artifact acceptance remains open. The plan (#394) and P0–P7 stack
   (#396, #399–#405) are merged to `main`. The signed and notarized `v2.0.7`
   release is immutable on GitHub, its signed assets and stable pointer are
   public on R2, and its verified Homebrew formula is live. The initial PyPI
   upload stopped before publication because of a publisher-action pin defect;
   recover that missing channel against the existing `v2.0.7` release rather
-  than creating a new product version. Canonical installer/docs cutover,
-  clean-machine curl/Homebrew, update/rollback/uninstall, and real-path TTFV QA
-  against the published artifact remain open. This plan stays top-level until
-  those published-artifact gates pass.
+  than creating a new product version solely for the missing upload. A later
+  version justified by new product or security changes remains a separate
+  release decision. Canonical installer/docs cutover, clean-machine
+  curl/Homebrew, update/rollback/uninstall, and real-path TTFV QA against the
+  published artifact remain open. This plan stays top-level until those
+  published-artifact gates pass.
 - **Anchors:** Current behavior and file ownership verified against
   `main @ 771f40c0`. Re-verify all paths against the implementation base before
   starting each phase.

--- a/docs/plans/2026-07-11-public-live-demo-plan.md
+++ b/docs/plans/2026-07-11-public-live-demo-plan.md
@@ -1,17 +1,14 @@
 # Public JobCtrl Live Demo Plan
 
 - **Date:** 2026-07-11
-- **Status (2026-07-12):** Active / implementation landed, public cutover not
-  complete. The plan (#407) and P0–P7 stack (#408–#417) are merged to `main`.
-  A private candidate is deployed at `demo.jobctrl.dev` behind a Cloudflare
-  Access IP restriction, with Pages, Workers, EU D1, migrations, retention,
-  consent, synthetic workspace, guided experience, and local production smoke
-  verified. Public launch still requires the owner-approved repository-public
-  sequence, real hosted workflow passes on the exact `main` SHA, approved
-  controller/privacy notice and lawful-basis copy, removal of the IP
-  restriction, public CTA publication, and final production smoke/rollback
-  evidence. Current private-repository Actions runs stop before checkout on the
-  account billing gate; they are neither product failures nor passing evidence.
+- **Status (2026-07-29):** Active / public implementation landed. The plan
+  (#407) and P0–P7 stack (#408–#417) are merged to `main`, and the synthetic
+  demo is public at `demo.jobctrl.dev`. The public CTA, production deployment,
+  consent gate, privacy copy, hosted checks, and launch smoke are complete.
+  Consent-gated documentation analytics shipped separately in #511–#512.
+  Analytics-optional demo access remains outside the approved plan and requires
+  an explicit owner/privacy decision plus Tier 3 delivery. Post-accept
+  withdrawal and current-visitor erasure remain deferred privacy work.
 - **Anchors:** Current behavior and file ownership verified against
   `main @ b513b356`. Re-verify all cited paths and contracts against the base of
   each implementation PR before coding.

--- a/docs/plans/2026-07-26-public-launch-growth-sprint.md
+++ b/docs/plans/2026-07-26-public-launch-growth-sprint.md
@@ -8,6 +8,16 @@
 - **Boundary:** This plan prepares external posts but does not publish them.
   Every account action and public submission requires owner approval.
 
+### Delivery update — 2026-07-29
+
+The conversion surface and campaign kit landed in #509. Consent-gated
+documentation analytics and its release-check compatibility landed in
+#511–#512. The outcome-led site, public paths, README star prompt, product
+social card, crawl metadata, release copy, and Discussions are live. The demo
+video, clean-Mac preflight, analytics-optional owner decision, search
+submissions, directory launches, article, and external campaign publications
+remain open.
+
 ## 0. Why This Sprint Exists
 
 JobCtrl has a launchable product but almost no qualified distribution.
@@ -67,15 +77,15 @@ product signal proves it.
 
 ### P0 — Required before Show HN or Product Hunt
 
-- [ ] Land and deploy the outcome-led docs-site hero.
-- [ ] Put the signed Apple-silicon install path in the deployed hero.
-- [ ] Add explicit demo, install, tour, comparison, and repository paths above
+- [x] Land and deploy the outcome-led docs-site hero.
+- [x] Put the signed Apple-silicon install path in the deployed hero.
+- [x] Add explicit demo, install, tour, comparison, and repository paths above
   the fold.
-- [ ] Add a direct but non-coercive star request to the repository README.
-- [ ] Replace the generic logo-only social card with a product-led 1200×630
+- [x] Add a direct but non-coercive star request to the repository README.
+- [x] Replace the generic logo-only social card with a product-led 1200×630
   preview.
-- [ ] Generate `sitemap.xml` and publish a `robots.txt` sitemap pointer.
-- [ ] Replace the stale pre-launch root checklist with current public status.
+- [x] Generate `sitemap.xml` and publish a `robots.txt` sitemap pointer.
+- [x] Replace the stale pre-launch root checklist with current public status.
 - [x] Add a substantive `v2.0.7` GitHub Release body.
 - [x] Enable GitHub Discussions with **Announcements**, **Ideas**, **Q&A**, and
   **Show and tell** categories; link it from the README after it is live.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -8,14 +8,14 @@ at the top of `docs/`.
   that has landed, been superseded by canonical docs, or been closed with a
   recorded outcome.
 
-As of 2026-07-26, the plans below remain active at the top level. Distribution
-and live-demo implementation are public; distribution retains a PyPI recovery
-gate, while the growth sprint records the demo's analytics-required entry as a
-conversion and trust decision for the owner.
-Pipeline operations and the end-to-end redesign are implemented in an open
-stack but retain canonical-documentation, cumulative-QA, review, merge, and
-closeout gates. Earlier completed plans live under `implemented/`. Add new
-accepted-but-not-yet-delivered plans at the top level.
+As of 2026-07-29, three plans remain active at the top level. Distribution and
+the live demo are public, with explicit recovery, published-artifact, and
+privacy follow-up gates still open. The growth sprint has shipped its
+conversion surface and campaign kit, while owner-approved publication and
+other external launch work remain open. Pipeline operations, the end-to-end
+redesign, and resumable JobStreaming discovery are delivered and archived
+under `implemented/`. Add new accepted-but-not-yet-delivered plans at the top
+level.
 
 The former top-level `openspec/` corpus was consolidated here on 2026-07-12.
 Each delivered change now has one implemented-plan record containing its
@@ -32,12 +32,9 @@ docs to describe the delivered behavior. Delivery history lives in the git log
 
 | Date | Plan | Status |
 | --- | --- | --- |
-| 2026-07-10 | [Bundled JobCtrl Distribution](2026-07-10-bundled-jobctrl-distribution-plan.md) | Active — signed/notarized `v2.0.7`, curl, Homebrew, GitHub Release, and published-artifact smoke are live; supported PyPI package recovery remains open |
-| 2026-07-11 | [Public JobCtrl Live Demo](2026-07-11-public-live-demo-plan.md) | Active — public demo and consent-gated analytics are live; any analytics-optional demo access is outside the approved plan and requires a separate owner/privacy decision plus Tier 3 delivery |
-| 2026-07-13 | [Discovery Pipeline Operations Visibility](2026-07-13-discovery-pipeline-operations-visibility-plan.md) | Active — implementation published in #459–#462; final docs, cumulative QA, review, merge, and archive evidence remain open |
-| 2026-07-14 | [End-to-End Product Redesign](2026-07-14-end-to-end-product-redesign.md) | Active — primitive/redesign/operations stack published in #453–#463; final docs, cumulative QA, review, merge, and archive evidence remain open |
-| 2026-07-17 | [Resumable JobStreaming Discovery](2026-07-17-resumable-jobstreaming-discovery-plan.md) | Active — #468, #469, and final Temporal resume/docs/QA layer #470 published; independent gates passed |
-| 2026-07-26 | [Public Launch Growth Sprint](2026-07-26-public-launch-growth-sprint.md) | Active — conversion-surface fixes and campaign kit in progress; no external post is published without owner approval |
+| 2026-07-10 | [Bundled JobCtrl Distribution](2026-07-10-bundled-jobctrl-distribution-plan.md) | Active — signed/notarized `v2.0.7`, curl, Homebrew, GitHub Release, and the stable R2 pointer are live; PyPI recovery and remaining published-artifact/clean-machine acceptance gates are open |
+| 2026-07-11 | [Public JobCtrl Live Demo](2026-07-11-public-live-demo-plan.md) | Active — the public demo and consent-gated analytics are live; analytics-optional access and deferred withdrawal/erasure require separately approved privacy work |
+| 2026-07-26 | [Public Launch Growth Sprint](2026-07-26-public-launch-growth-sprint.md) | Active — conversion surface and campaign kit #509 plus consent-gated docs analytics #511–#512 are live; video, clean-Mac preflight, owner decisions, and external campaign actions remain open |
 
 ## Historical Spec Ledger
 
@@ -93,11 +90,12 @@ and frontend plans were renamed from working titles (`ddd-target-plan.md`,
 | 2026-07-05 | [Product Rename to JobCtrl](implemented/2026-07-05-rename-jobctrl-plan.md) | Implemented — #261 (plan), #349; hardening #350; #351 closeout; R0.1 updates the final public spelling to JobCtrl |
 | 2026-07-05 | [Crawl Politeness Hardening](implemented/2026-07-05-crawl-politeness-plan.md) | Implemented — #272 (plan), #297-#316; pacing-test hardening #334; ADR 2026-07-06 |
 | 2026-07-08 | [Web UI/UX Revamp — Left-Rail Shell + JobCtrl Design System](implemented/2026-07-08-web-ui-revamp-plan.md) | Implemented — #356; design-system docs follow-up continues separately in #357 |
-| 2026-07-10 | [Bundled JobCtrl Distribution](2026-07-10-bundled-jobctrl-distribution-plan.md) | Active — #394, #396, and #399–#405 landed; signed/notarized publication and published-artifact product QA pending; ADR 2026-07-10 |
-| 2026-07-11 | [Public JobCtrl Live Demo](2026-07-11-public-live-demo-plan.md) | Active — #407–#417 landed; private candidate deployed; public cutover, hosted reruns, and privacy approval pending |
-| 2026-07-13 | [Discovery Pipeline Operations Visibility](2026-07-13-discovery-pipeline-operations-visibility-plan.md) | Active — implementation published in #459–#462; final documentation, cumulative QA, review, merge, and archive evidence pending |
-| 2026-07-14 | [End-to-End Product Redesign](2026-07-14-end-to-end-product-redesign.md) | Active — implementation stack #453–#463 is open; final documentation, cumulative QA, review, merge, and archive evidence pending |
-| 2026-07-17 | [Resumable JobStreaming Discovery](2026-07-17-resumable-jobstreaming-discovery-plan.md) | Active — provider boundary #468, durable units #469, and final Temporal resume/docs/QA layer #470 published; independent gates passed |
+| 2026-07-10 | [Bundled JobCtrl Distribution](2026-07-10-bundled-jobctrl-distribution-plan.md) | Active — #394, #396, and #399–#405 landed; signed/notarized `v2.0.7`, GitHub Release, R2, and Homebrew are live; PyPI recovery and remaining published-artifact acceptance are open; ADR 2026-07-10 |
+| 2026-07-11 | [Public JobCtrl Live Demo](2026-07-11-public-live-demo-plan.md) | Active — #407–#417 landed and the public synthetic demo is live; consent-gated analytics shipped in #497, while analytics-optional access and deferred withdrawal/erasure remain separate privacy decisions |
+| 2026-07-13 | [Discovery Pipeline Operations Visibility](implemented/2026-07-13-discovery-pipeline-operations-visibility-plan.md) | Implemented — cumulative integration #464 incorporated the reviewed #459–#462 stack; production follow-ups #465–#467 |
+| 2026-07-14 | [End-to-End Product Redesign](implemented/2026-07-14-end-to-end-product-redesign.md) | Implemented — cumulative integration #464 incorporated the reviewed #453–#463 stack; production follow-ups #465–#467 |
+| 2026-07-17 | [Resumable JobStreaming Discovery](implemented/2026-07-17-resumable-jobstreaming-discovery-plan.md) | Implemented — provider boundary #468, durable units #469, and Temporal resume/docs/QA #470 |
+| 2026-07-26 | [Public Launch Growth Sprint](2026-07-26-public-launch-growth-sprint.md) | Active — conversion surface and campaign kit #509 plus consent-gated docs analytics #511–#512 are live; owner-approved external launch work remains open |
 
 Two 2026-05-17 backlog specs (`…-add-react`, `…-add-brows`) were drafted on
 `origin/mestre/develop-*` branches and never merged to `main`; only `…-add-root`

--- a/docs/plans/implemented/2026-07-13-discovery-pipeline-operations-visibility-plan.md
+++ b/docs/plans/implemented/2026-07-13-discovery-pipeline-operations-visibility-plan.md
@@ -1,9 +1,10 @@
 # Discovery Pipeline Operations Visibility Plan
 
 - **Date:** 2026-07-13
-- **Status:** Active — implementation and canonical documentation are complete
-  on the open cumulative stack; cumulative Tier 3 QA and independent gates are
-  in progress.
+- **Status (2026-07-29):** Implemented — the reviewed #459–#462 stack was
+  integrated through cumulative PR #464, with production follow-ups #465–#467.
+  Canonical documentation, cumulative Tier 3 QA, and independent gates are
+  complete.
 - **Anchors:** Current behavior and file ownership verified against
   `main @ 47cfba58`. Re-verify every path and contract against the base of each
   implementation PR.
@@ -16,10 +17,12 @@
   concurrency limit applies, whether telemetry is fresh, and when the current
   execution is likely to finish.
 
-### Delivery status — 2026-07-15
+### Delivery status — 2026-07-29
 
 - Execution lineage, runtime telemetry, the operations read model, and the
-  Rhea Pipelines workspace are published as stacked PRs #459–#462.
+  Rhea Pipelines workspace were reviewed in stacked PRs #459–#462. Those PRs
+  were closed without individual merges after their cumulative content landed
+  through #464; production refinements followed in #465–#467.
 - The implemented workspace preserves the plan's stable semantic contract
   while using the current shadcn/Base UI system rather than the pre-redesign
   composition names.
@@ -30,9 +33,8 @@
   `draining`. Only global work outside the selected execution is excluded from
   its phase. This supersedes the earlier single-cohort wording below.
 - Canonical documentation and the synthetic 32-image screenshot gallery are
-  complete. The implementation remains active rather than archived because the
-  stack is not merged and cumulative QA, reviewer, and QA-agent gates are not
-  yet complete.
+  complete. Cumulative QA, reviewer, and QA gates passed before integration,
+  so the plan is archived as delivered.
 
 ---
 

--- a/docs/plans/implemented/2026-07-14-end-to-end-product-redesign.md
+++ b/docs/plans/implemented/2026-07-14-end-to-end-product-redesign.md
@@ -1,16 +1,18 @@
 # End-to-End Product Redesign
 
-- **Status:** Active — implementation assembled in the open redesign stack; canonical documentation and cumulative Tier 3 QA are in progress.
+- **Status (2026-07-29):** Implemented — the reviewed #453–#463 stack was
+  integrated through cumulative PR #464, with production follow-ups #465–#467.
+  Canonical documentation and cumulative Tier 3 gates are complete.
 - **Date:** 2026-07-14
 - **Owner ask:** turn the approved full-application prototype and browser annotations into the production JobCtrl UI without losing any existing data, controls, states, or audit evidence.
-- **Predecessor:** [2026-07-08 Web UI/UX Revamp](implemented/2026-07-08-web-ui-revamp-plan.md), delivered by #356.
+- **Predecessor:** [2026-07-08 Web UI/UX Revamp](2026-07-08-web-ui-revamp-plan.md), delivered by #356.
 
-### Delivery status — 2026-07-15
+### Delivery status — 2026-07-29
 
-- The primitive migration is published as #453–#457, the Rhea redesign as
-  #458, pipeline-operations delivery as #459–#462, and the cumulative cohesion
-  layer as #463. These PRs are open and stacked; implementation-complete does
-  not mean merged-to-`main`.
+- The primitive migration was reviewed in #453–#457, the Rhea redesign in
+  #458, pipeline operations in #459–#462, and cumulative cohesion in #463.
+  Those review PRs were closed without individual merges after their cumulative
+  content landed through #464; production refinements followed in #465–#467.
 - The owner subsequently approved moving the primitive substrate from Radix to
   Base UI before the visual pass. The production system remains shadcn-style
   owned composition, but its accessible primitives are now Base UI rather than
@@ -49,12 +51,12 @@ The implementation uses these sources in priority order:
    contract.
 2. **The annotated redesign prototype** for hierarchy, information density,
    responsive behavior, and interaction direction.
-3. [`DESIGN.md`](../../DESIGN.md) and
+3. [`DESIGN.md`](../../../DESIGN.md) and
    `apps/web/src/styles/{tokens,globals}.css` for brand, tokens, typography,
    spacing, status semantics, and component language.
-4. The [frontend architecture](../architecture/frontend/index.md) for state,
+4. The [frontend architecture](../../architecture/frontend/index.md) for state,
    contexts, ports, routing, realtime invalidation, and test ownership.
-5. The [requirements](../requirements.md), especially TR-018 through TR-021,
+5. The [requirements](../../requirements.md), especially TR-018 through TR-021,
    TR-029, and TR-032, for product-path QA, accessibility, settings autosave,
    and accepted-artifact preservation.
 
@@ -63,11 +65,11 @@ direction remains reviewable after the local prototype is gone:
 
 | Surface | Reference |
 | --- | --- |
-| Dashboard composition | ![Dashboard redesign](assets/2026-07-14-product-redesign/dashboard.jpg) |
-| Route-level Job Detail workspace | ![Job detail redesign](assets/2026-07-14-product-redesign/job-detail.jpg) |
-| Profile with the real resume editor | ![Profile redesign](assets/2026-07-14-product-redesign/profile.jpg) |
-| Settings composition | ![Browser settings redesign](assets/2026-07-14-product-redesign/settings-browser.jpg) |
-| Mobile detail reflow | ![Mobile job detail redesign](assets/2026-07-14-product-redesign/mobile-job-detail.png) |
+| Dashboard composition | ![Dashboard redesign](../assets/2026-07-14-product-redesign/dashboard.jpg) |
+| Route-level Job Detail workspace | ![Job detail redesign](../assets/2026-07-14-product-redesign/job-detail.jpg) |
+| Profile with the real resume editor | ![Profile redesign](../assets/2026-07-14-product-redesign/profile.jpg) |
+| Settings composition | ![Browser settings redesign](../assets/2026-07-14-product-redesign/settings-browser.jpg) |
+| Mobile detail reflow | ![Mobile job detail redesign](../assets/2026-07-14-product-redesign/mobile-job-detail.png) |
 
 The browser annotations add these explicit design requirements:
 

--- a/docs/plans/implemented/2026-07-17-resumable-jobstreaming-discovery-plan.md
+++ b/docs/plans/implemented/2026-07-17-resumable-jobstreaming-discovery-plan.md
@@ -1,8 +1,9 @@
 # Resumable JobStreaming Discovery Plan
 
 - **Date:** 2026-07-17
-- **Status:** Active — implementation is being delivered as a three-PR stack on
-  top of PR #467.
+- **Status (2026-07-29):** Implemented — provider boundary #468, durable
+  search units #469, and Temporal resume/docs/QA #470 are merged to `main`;
+  cumulative validation and independent gates passed.
 - **Provider contract:** `jobstreaming==0.0.2`
 - **Goal:** A broad-board discovery activity backed by JobStreaming that is
   interrupted after accepting a posting resumes from durable caller-owned state
@@ -24,11 +25,11 @@ typed provider failures, and explicit acknowledgement mechanics.
 
 ## Delivery stack
 
-- **Phase 1:** published as PR #468; focused verification and independent
+- **Phase 1:** merged as PR #468; focused verification and independent
   review passed.
-- **Phase 2:** published as PR #469; focused verification and independent
+- **Phase 2:** merged as PR #469; focused verification and independent
   review passed.
-- **Phase 3:** published as PR #470 on PR #469; implementation, canonical
+- **Phase 3:** merged as PR #470 on PR #469; implementation, canonical
   documentation, cumulative validation, and independent review/QA gates are
   complete.
 

--- a/docs/publish-checklist.md
+++ b/docs/publish-checklist.md
@@ -95,7 +95,7 @@ proof.
 ### 9.0 — Cumulative Rhea/Base UI redesign acceptance
 
 The owning contract is
-[`docs/plans/2026-07-14-end-to-end-product-redesign.md`](plans/2026-07-14-end-to-end-product-redesign.md),
+[`docs/plans/implemented/2026-07-14-end-to-end-product-redesign.md`](plans/implemented/2026-07-14-end-to-end-product-redesign.md),
 especially §§11–14. This is a release precondition, not permission to publish.
 
 - **Documentation and screenshot freeze.** Complete every owning user,


### PR DESCRIPTION
## Summary

- reduce the top-level active-plan inventory to the three plans with real open gates
- archive the delivered pipeline-operations, product-redesign, and resumable JobStreaming plans
- record the actual merge topology: cumulative integration in #464, follow-ups #465–#467, and direct JobStreaming delivery in #468–#470
- refresh public demo, distribution, and growth-sprint status without closing the remaining privacy, publication, or published-artifact work

## Why

The plan index still described delivered stacks as open and the public demo as private. That made the repository's active work inventory unreliable and obscured the remaining release and launch gates.

## Validation

- `git diff --check`
- `corepack pnpm docs:build` (8,238 references across 338 emitted files)
- `python3 scripts/release_check.py --strict-prompt`