### PR TITLE
fix(apply): wait for stable Chrome readiness

### DIFF
--- a/workers/automation/src/jobctrl/apply/chrome.py
+++ b/workers/automation/src/jobctrl/apply/chrome.py
@@ -29,6 +29,9 @@ logger = logging.getLogger(__name__)
 
 # CDP port base — each worker uses BASE_CDP_PORT + worker_id
 BASE_CDP_PORT = 9222
+_CDP_READY_TIMEOUT_SECONDS = 10.0
+_CDP_READY_POLL_SECONDS = 0.1
+_CDP_READY_STABLE_PROBES = 10
 
 # Track Chrome processes per worker for cleanup
 _chrome_procs: dict[int, subprocess.Popen] = {}
@@ -233,11 +236,12 @@ def launch_chrome(
     with _chrome_lock:
         _chrome_procs[worker_id] = proc
 
-    # Give Chrome time to start and open the debug port. The synchronous guard
-    # startup below does not return until every initial page acknowledges
-    # Fetch.enable and browser-level paused auto-attach protects future pages.
-    time.sleep(3)
     try:
+        # Readiness is condition-based because a cold browser can take longer
+        # than a fixed delay. The synchronous guard startup below does not
+        # return until every initial page acknowledges Fetch.enable and
+        # browser-level paused auto-attach protects future pages.
+        _wait_for_browser_cdp_endpoint(port, proc)
         if dry_run:
             install_dry_run_cdp_guard(
                 port,
@@ -258,6 +262,46 @@ def launch_chrome(
     logger.info("[worker-%d] Chrome started on port %d (pid %d)",
                 worker_id, port, proc.pid)
     return proc
+
+
+def _wait_for_browser_cdp_endpoint(
+    port: int,
+    process: subprocess.Popen,
+    *,
+    timeout_seconds: float = _CDP_READY_TIMEOUT_SECONDS,
+    poll_seconds: float = _CDP_READY_POLL_SECONDS,
+    stable_probes: int = _CDP_READY_STABLE_PROBES,
+) -> None:
+    deadline = time.monotonic() + timeout_seconds
+    ready_url = ""
+    ready_count = 0
+    while True:
+        version = _cdp_json(port, "/json/version")
+        candidate_url = (
+            str(version.get("webSocketDebuggerUrl") or "")
+            if isinstance(version, dict)
+            else ""
+        )
+        if candidate_url and candidate_url == ready_url:
+            ready_count += 1
+        elif candidate_url:
+            ready_url = candidate_url
+            ready_count = 1
+        else:
+            ready_url = ""
+            ready_count = 0
+        if ready_count >= stable_probes:
+            return
+        if process.poll() is not None:
+            raise BrowserCapabilityError(
+                "Chrome exited before its browser-level CDP endpoint became ready"
+            )
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise BrowserCapabilityError(
+                "Chrome browser-level CDP endpoint did not become ready"
+            )
+        time.sleep(min(poll_seconds, remaining))
 
 
 _FORM_SUBMIT_GUARD_SOURCE = """

--- a/workers/automation/tests/test_apply_chrome_dry_run_guard.py
+++ b/workers/automation/tests/test_apply_chrome_dry_run_guard.py
@@ -512,6 +512,11 @@ def test_launch_chrome_installs_public_destination_guard_for_live_runs(tmp_path,
     monkeypatch.setattr(chrome, "_suppress_restore_nag", lambda _profile: None)
     monkeypatch.setattr(chrome.config, "get_chrome_path", lambda: "/bin/echo")
     monkeypatch.setattr(chrome.subprocess, "Popen", lambda *_args, **_kwargs: _FakeProcess())
+    monkeypatch.setattr(
+        chrome,
+        "_cdp_json",
+        lambda _port, _path: {"webSocketDebuggerUrl": "ws://ready"},
+    )
     monkeypatch.setattr(chrome.time, "sleep", lambda _seconds: None)
     monkeypatch.setattr(
         chrome,
@@ -535,6 +540,118 @@ def test_launch_chrome_installs_public_destination_guard_for_live_runs(tmp_path,
     assert calls == [("public", 9555)]
 
 
+def test_launch_chrome_waits_for_browser_cdp_endpoint(tmp_path, monkeypatch):
+    probes: list[tuple[int, str]] = []
+    sleeps: list[float] = []
+    installs: list[int] = []
+    versions = iter(
+        [
+            [],
+            [],
+            *[
+                {"webSocketDebuggerUrl": "ws://127.0.0.1/devtools/browser/ready"}
+                for _ in range(chrome._CDP_READY_STABLE_PROBES)
+            ],
+        ]
+    )
+
+    class _FakeProcess:
+        pid = 4243
+
+        def poll(self) -> None:
+            return None
+
+    def setup_profile(worker_id: int) -> Path:
+        profile = tmp_path / f"profile-{worker_id}"
+        (profile / "Default").mkdir(parents=True, exist_ok=True)
+        return profile
+
+    def cdp_json(port: int, path: str):
+        probes.append((port, path))
+        return next(versions)
+
+    monkeypatch.setattr(chrome, "setup_worker_profile", setup_profile)
+    monkeypatch.setattr(chrome, "_kill_on_port", lambda _port: None)
+    monkeypatch.setattr(chrome, "_suppress_restore_nag", lambda _profile: None)
+    monkeypatch.setattr(chrome.config, "get_chrome_path", lambda: "/bin/echo")
+    monkeypatch.setattr(chrome.subprocess, "Popen", lambda *_args, **_kwargs: _FakeProcess())
+    monkeypatch.setattr(chrome, "_cdp_json", cdp_json)
+    monkeypatch.setattr(chrome.time, "sleep", sleeps.append)
+    monkeypatch.setattr(
+        chrome,
+        "install_public_destination_cdp_guard",
+        lambda port, **_ownership: installs.append(port),
+    )
+
+    chrome.launch_chrome(
+        worker_id=906,
+        port=9777,
+        headless=True,
+        dry_run=False,
+        approved_application_url="https://apply.example.com/job",
+    )
+
+    assert probes == [
+        (9777, "/json/version")
+        for _ in range(2 + chrome._CDP_READY_STABLE_PROBES)
+    ]
+    assert sleeps == [
+        chrome._CDP_READY_POLL_SECONDS
+        for _ in range(1 + chrome._CDP_READY_STABLE_PROBES)
+    ]
+    assert installs == [9777]
+
+
+def test_launch_chrome_cleans_up_when_cdp_process_exits(tmp_path, monkeypatch):
+    cleaned: list[tuple[int, int]] = []
+    installs: list[int] = []
+
+    class _ExitedProcess:
+        pid = 4244
+
+        def poll(self) -> int:
+            return 1
+
+    process = _ExitedProcess()
+
+    def setup_profile(worker_id: int) -> Path:
+        profile = tmp_path / f"profile-{worker_id}"
+        (profile / "Default").mkdir(parents=True, exist_ok=True)
+        return profile
+
+    monkeypatch.setattr(chrome, "setup_worker_profile", setup_profile)
+    monkeypatch.setattr(chrome, "_kill_on_port", lambda _port: None)
+    monkeypatch.setattr(chrome, "_suppress_restore_nag", lambda _profile: None)
+    monkeypatch.setattr(chrome.config, "get_chrome_path", lambda: "/bin/echo")
+    monkeypatch.setattr(chrome.subprocess, "Popen", lambda *_args, **_kwargs: process)
+    monkeypatch.setattr(chrome, "_cdp_json", lambda _port, _path: [])
+    monkeypatch.setattr(
+        chrome,
+        "install_public_destination_cdp_guard",
+        lambda port, **_ownership: installs.append(port),
+    )
+    monkeypatch.setattr(
+        chrome,
+        "cleanup_worker",
+        lambda worker_id, proc: cleaned.append((worker_id, proc.pid)),
+    )
+
+    with pytest.raises(
+        chrome.BrowserCapabilityError,
+        match="exited before its browser-level CDP endpoint became ready",
+    ):
+        chrome.launch_chrome(
+            worker_id=907,
+            port=9888,
+            headless=True,
+            dry_run=False,
+            approved_application_url="https://apply.example.com/job",
+        )
+
+    assert installs == []
+    assert cleaned == [(907, 4244)]
+
+
 def test_launch_chrome_uses_combined_dry_run_guard_for_dry_runs(tmp_path, monkeypatch):
     calls: list[tuple[str, int]] = []
 
@@ -554,6 +671,11 @@ def test_launch_chrome_uses_combined_dry_run_guard_for_dry_runs(tmp_path, monkey
     monkeypatch.setattr(chrome, "_suppress_restore_nag", lambda _profile: None)
     monkeypatch.setattr(chrome.config, "get_chrome_path", lambda: "/bin/echo")
     monkeypatch.setattr(chrome.subprocess, "Popen", lambda *_args, **_kwargs: _FakeProcess())
+    monkeypatch.setattr(
+        chrome,
+        "_cdp_json",
+        lambda _port, _path: {"webSocketDebuggerUrl": "ws://ready"},
+    )
     monkeypatch.setattr(chrome.time, "sleep", lambda _seconds: None)
     monkeypatch.setattr(
         chrome,

--- a/workers/automation/tests/test_browser_capabilities.py
+++ b/workers/automation/tests/test_browser_capabilities.py
@@ -206,8 +206,8 @@ def test_enabled_auto_apply_launch_uses_a_clean_owned_profile_without_host_copy(
     class _FakeProcess:
         pid = 4242
 
-        def poll(self) -> int:
-            return 0
+        def poll(self) -> None:
+            return None
 
     enable_system_browser_capability("auto-apply-browser", browser_executable, app_dir=tmp_path)
     worker_root = tmp_path / "apply-workers"
@@ -225,6 +225,11 @@ def test_enabled_auto_apply_launch_uses_a_clean_owned_profile_without_host_copy(
     monkeypatch.setattr(chrome, "_kill_on_port", lambda _port: None)
     monkeypatch.setattr(chrome, "_suppress_restore_nag", lambda _profile: None)
     monkeypatch.setattr(chrome.subprocess, "Popen", lambda *_args, **_kwargs: _FakeProcess())
+    monkeypatch.setattr(
+        chrome,
+        "_cdp_json",
+        lambda _port, _path: {"webSocketDebuggerUrl": "ws://ready"},
+    )
     monkeypatch.setattr(chrome.time, "sleep", lambda _seconds: None)
     monkeypatch.setattr(
         chrome,


### PR DESCRIPTION
## What changed

- replace the fixed three-second Chrome startup delay with bounded CDP readiness polling
- require a stable browser-level debugger endpoint before installing the apply guard
- abort and clean up if Chrome exits or the endpoint never becomes ready
- add delayed-readiness and fail-closed cleanup regressions

## Why

Cold Chrome launches can take longer than a fixed delay, while the first endpoint response can arrive before the browser target is stable. The apply guard needs condition-based readiness without weakening its fail-closed behavior.

## Stack

Depends on #527. The effective diff for this PR is one commit and three files.

## Validation

- focused apply/browser suite — 40 passed, 2 opt-in tests skipped
- real system-browser security smoke — 2/2 passed on the first final-candidate run
- full Python suite — 2,644 passed, 2 opt-in browser tests skipped
- `pnpm check`
- Ruff on all touched Python files