### PR TITLE
feat(storage): add stable job identity foundation

### DIFF
--- a/apps/api/src/db.ts
+++ b/apps/api/src/db.ts
@@ -9,7 +9,7 @@ export type SqliteValue = string | number | bigint | null;
 // writer that stamps ``PRAGMA user_version``; the API only reads it to fail
 // closed on a database written by a newer build. Bump both constants together
 // whenever the schema shape changes.
-export const SUPPORTED_SCHEMA_VERSION = 6;
+export const SUPPORTED_SCHEMA_VERSION = 7;
 
 export class IncompatibleSchemaVersionError extends Error {
   constructor(current: number) {

--- a/docs/architecture/storage.md
+++ b/docs/architecture/storage.md
@@ -55,8 +55,12 @@ flowchart LR
     MATERIALS -->|writes| FILES
 ```
 
-Within the job-owned families, one `jobs` row (keyed by posting URL) is the hub:
-stage state, events, scores, analysis, materials, and apply records hang off it.
+Within the job-owned families, one `jobs` row is the compatibility hub: stage
+state, events, scores, analysis, materials, and apply records hang off it.
+Schema version 7 assigns that row an immutable tenant-scoped `job_id` UUID and
+records posting URLs as aliases. The physical primary key and the downstream
+authorities remain URL-keyed during the bounded additive migration; they do not
+become stable-ID authorities until their later cutover slices.
 
 The remaining tables group by owner:
 
@@ -105,6 +109,44 @@ promoted into history. Existing databases advance additively from version 5 to
 6 while their prior application rows and events remain byte-for-byte unchanged.
 Both the TypeScript API and Python worker can create the new tables
 idempotently, and both reject a database created by a newer schema version.
+
+### Stable job identity foundation
+
+Schema version 7 introduces the first additive part of the stable identity
+migration without changing repository, route, event, projection, or workflow
+identity yet:
+
+- every existing and newly inserted `jobs` row receives an immutable opaque
+  UUID in `job_id` and a non-empty `tenant_id`;
+- `job_identity_aliases` maps each tenant-scoped posting URL to that stable ID
+  and retains an earlier URL if the canonical posting locator changes;
+- compatibility triggers cover legacy writers that still insert only a URL,
+  reject any byte-level identity reassignment, and remove aliases with a
+  physically deleted compatibility row so later URL-only rediscovery remains
+  valid; and
+- `jobs.url` remains the physical primary key in this slice. URL-keyed child
+  tables remain unchanged behind the existing repositories.
+
+The Python worker checks the current `PRAGMA user_version` and verifies that its
+ordered migration registry can reach the build's declared schema version before
+any schema write. Each migration owns its version stamp. The v7 DDL, UUID and
+alias backfill, canonical job-count check, UUID and alias checks, trigger check,
+foreign-key check, and version stamp then run in one savepoint. A
+representative-reference fixture proves the surrounding authorities remain
+byte-for-byte unchanged. A failed v7 migration rolls back those identity
+changes and leaves the earlier version retryable; the version is stamped only
+after every check passes. A future build that bumps the declared version
+without registering its migration fails closed instead of accidentally
+rerunning v7 under a new number. The TypeScript API remains a reader of the
+same version guard and fails closed on a database written by newer code.
+
+Forward reopen and previous-release rollback are different operations. Reopen
+with v7 retains the generated IDs. A previous release must use the paired
+pre-upgrade `jobctrl.db` and `temporal.db` snapshot; it rejects the v7 database,
+and there is no in-place down-migration. The authoritative Temporal quiescence
+preflight and paired live snapshot belong to the later identity-cutover slice,
+before workflow IDs, event payloads, projections, routes, or child references
+change.
 
 For a live run, the Python launcher opens `BEGIN IMMEDIATE`, recomputes the
 current evidence, performs the existing active-run and approval checks, and

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1083,9 +1083,11 @@ Status: accepted
 
 Decision: the local database ships a first-class backup command and a
 schema-version guard. `jobctrl backup` (`cli.py`) writes a consistent copy via
-`backup_database` (`database.py`); every connection runs `_ensure_schema_version`,
-which stamps `PRAGMA user_version` to the code's `SCHEMA_VERSION` and refuses to
-open a database whose schema is newer than the running code.
+`backup_database` (`database.py`); every connection checks
+`PRAGMA user_version` and refuses to open a database whose schema is newer than
+the running code. Schema v7 amends the original eager-stamp implementation:
+each versioned migration now owns its stamp and writes it only after the
+migration and its integrity checks succeed.
 
 Rationale:
 
@@ -1099,7 +1101,8 @@ Consequences:
 
 - users can snapshot the workspace before destructive or upgrade operations
 - a newer-than-code database raises a clear error rather than being written
-- an older or unstamped database is adopted by stamping the current version
+- an older or unstamped database is adopted by a successful current migration;
+  a failed migration retains its prior version for recovery and retry
 
 Cites: PR #206.
 

--- a/docs/developer/qa/regression-catalog.md
+++ b/docs/developer/qa/regression-catalog.md
@@ -11,7 +11,7 @@ individual regression to exact test files.
 | --- | --- | --- |
 | Apply safety | Model-driven browsers never own final submit and direct use-case/saga/adapter calls fail closed; their prompt contains no profile, job-description, resume, cover-letter, generated prose, or local artifact paths; reviewed materials are not staged in the agent worker; artifact upload, generic form entry, credentials, and verification-code tools are explicitly denied and absent from the default MCP configuration; no owned email send occurs without exact approval; every Apply page/request stays on the reviewed canonical origin; dry-run grants only one exact reviewed initial navigation, records it, and cannot write; only one exact dedicated terminal result record affects state, and a model-only dry-run claim remains partial evidence; owned submit intent is at most once; confirmed prior applications block or require an evidence-bound one-attempt confirmation. | Apply use-case/saga/adapter tests plus a disposable browser harness. |
 | Durable workflows | Accepted work resumes or terminalizes correctly across restart, cancellation, and history loss. | Workflow tests plus targeted fault injection. |
-| Storage and projections | Schema versions are guarded; canonical writes and read projections agree; accepted artifacts survive retries, including failed cover-letter refreshes whose rejected bytes remain on separate audit paths. | Repository/projection tests and API readback. |
+| Storage and projections | Schema versions are guarded and stamped only after verified migration; stable job IDs and URL aliases backfill exactly once, remain immutable, and survive forward reopen; failed migration remains retryable; canonical writes and read projections agree; accepted artifacts survive retries, including failed cover-letter refreshes whose rejected bytes remain on separate audit paths. | Stable-identity migration, backup/reopen, repository/projection, and API schema-guard tests. |
 | Credentials and privacy | Secrets, profile content, raw mail, contact values, paths, and artifacts do not leak into settings, events, logs, or projections. | Boundary tests plus response/event inspection. |
 | Scoring and materials | Evidence, policy version, provenance, judge output, and fabrication gates remain inspectable and honest; free-form review/prior-output text remains audit-only while retries use bounded code-owned guidance. | Deterministic fixtures, quality evals, retry prompt-boundary regressions, and inspector smoke. |
 | Frontend state | URL/server/client state stay in their owning layers; every event and stage state has a handler/rendering path. | Hook/component/type tests plus parity tests. |
@@ -35,6 +35,16 @@ For the affected workflow, prove four outcomes:
 The [complete matrix](complete-checklist.md#temporal-fault-injection-matrix)
 lists the exact tests for Discover, Pipeline, Preparation, Apply, Profile Import,
 Compensation Refresh, and Interview Prep workflows.
+
+For schema-v7 stable identity groundwork, use only synthetic SQLite fixtures.
+Prove exact pre/post job and representative-reference counts, canonical UUID and
+tenant backfill, URL alias ownership and history, legacy insert compatibility,
+exact byte-level identity immutability, duplicate-row deletion alias cleanup
+plus URL-only rediscovery, failed alias/foreign-key migration rollback, retry
+without an early version stamp, forward reopen, and previous-build rejection of
+the migrated database. A previous-build rollback test restores and opens the
+paired pre-upgrade JobCtrl/Temporal snapshot; it must not simulate an
+unsupported in-place down-migration.
 
 For JobStreaming broad-board discovery, killing the activity is not enough: the
 fault must land after JobCtrl commits an accepted posting and unit receipt but

--- a/docs/local-reliability-qa.md
+++ b/docs/local-reliability-qa.md
@@ -76,6 +76,24 @@ and accepted-artifact preservation. The
 [Regression Catalog](developer/qa/regression-catalog.md) explains which layer
 proves each class of invariant; the complete page maps every risk to exact tests.
 
+### Stable job identity migration
+
+Use disposable SQLite fixtures only. This matrix proves the additive schema-v7
+identity backfill, representative-reference retention, exact immutability,
+duplicate-delete alias cleanup and rediscovery, retry boundary, paired
+backup/reopen behavior, repository compatibility, and shared
+Python/TypeScript forward-version guard:
+
+```bash
+uv --project workers/automation run --extra dev pytest -q \
+  workers/automation/tests/test_stable_job_identity_migration.py \
+  workers/automation/tests/test_database_backup.py \
+  workers/automation/tests/test_job_repository.py \
+  workers/automation/tests/test_repeat_application_prevention.py
+corepack pnpm --filter @jobctrl/api exec vitest run \
+  test/schema-version-guard.test.ts
+```
+
 ### Repeat-application prevention
 
 Use disposable SQLite fixtures and the simulated web dispatch boundary; never

--- a/workers/automation/src/jobctrl/database.py
+++ b/workers/automation/src/jobctrl/database.py
@@ -11,9 +11,10 @@ persistent run and event telemetry.
 import json
 import sqlite3
 import threading
+import uuid
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 from jobctrl.config import DB_PATH, DEFAULTS, migrate_legacy_job_tables
 
@@ -35,7 +36,10 @@ from jobctrl.config import DB_PATH, DEFAULTS, migrate_legacy_job_tables
 # replay-idempotent receipts for caller-filtered provider results.
 # v6 (repeat-application prevention): evidence-bound confirmations,
 # one-attempt consumption, and immutable protection audit records.
-SCHEMA_VERSION = 6
+# v7 (stable job identity foundation): additive opaque job UUIDs, the
+# tenant-scoped posting-URL alias map, and insert/update guards. URL-keyed
+# authorities remain compatibility storage until their own bounded migrations.
+SCHEMA_VERSION = 7
 
 
 class IncompatibleSchemaVersionError(RuntimeError):
@@ -142,28 +146,66 @@ def _resolve_backup_destination(source: Path, output: Path | str | None) -> Path
     return target_dir / f"jobctrl-{timestamp}.db"
 
 
-def _ensure_schema_version(conn: sqlite3.Connection) -> int:
-    """Stamp ``PRAGMA user_version`` as a lightweight schema guard.
+def _assert_schema_version_supported(
+    conn: sqlite3.Connection,
+    *,
+    supported_version: int = SCHEMA_VERSION,
+) -> int:
+    """Refuse a database written by a newer build before schema writes.
 
     Databases created before this guard report ``user_version == 0`` and are
-    adopted by stamping ``SCHEMA_VERSION``; an equal version is a no-op. A
-    database whose version is newer than this build fails closed with
-    ``IncompatibleSchemaVersionError`` -- the caller (``init_db``) invokes this
-    before any table creation or migration, so a stale build never runs its
-    potentially destructive ``ensure_*`` migrations against a forward-migrated
-    file, and is never silently downgraded.
+    eligible for migration. A database whose version is newer than this build
+    fails closed with ``IncompatibleSchemaVersionError``. Version stamping is
+    deliberately owned by the versioned migration after its DDL, backfill, and
+    verification succeed; a failed migration therefore remains retryable at
+    the prior version.
     """
     current = int(conn.execute("PRAGMA user_version").fetchone()[0])
-    if current > SCHEMA_VERSION:
+    if current > supported_version:
         raise IncompatibleSchemaVersionError(
             f"database was written by a newer JobCtrl build "
-            f"(schema version {current} > code schema version {SCHEMA_VERSION}); "
+            f"(schema version {current} > code schema version {supported_version}); "
             f"upgrade JobCtrl or restore a compatible backup ('jobctrl backup')."
         )
-    if current < SCHEMA_VERSION:
-        conn.execute(f"PRAGMA user_version = {SCHEMA_VERSION}")
-        conn.commit()
-    return SCHEMA_VERSION
+    return current
+
+
+def _schema_migrations() -> tuple[
+    tuple[int, Callable[[sqlite3.Connection], list[str]]],
+    ...,
+]:
+    """Return the ordered schema migrations known to this build."""
+    return ((7, ensure_stable_job_identity_v7),)
+
+
+def _assert_schema_migration_path(current_version: int) -> None:
+    """Fail before schema writes when this build cannot reach its own version."""
+    reachable_version = current_version
+    for target_version, _migration in _schema_migrations():
+        if current_version < target_version <= SCHEMA_VERSION:
+            reachable_version = target_version
+    if reachable_version != SCHEMA_VERSION:
+        raise RuntimeError(
+            "JobCtrl has no schema migration path from "
+            f"version {current_version} to {SCHEMA_VERSION}"
+        )
+
+
+def _run_schema_migrations(conn: sqlite3.Connection) -> int:
+    """Run ordered migrations and require each one to stamp its own version."""
+    current_version = _assert_schema_version_supported(conn)
+    _assert_schema_migration_path(current_version)
+    for target_version, migration in _schema_migrations():
+        if current_version >= target_version:
+            continue
+        migration(conn)
+        observed_version = int(conn.execute("PRAGMA user_version").fetchone()[0])
+        if observed_version != target_version:
+            raise RuntimeError(
+                f"schema migration {target_version} did not stamp its version"
+            )
+        current_version = observed_version
+    return current_version
 
 
 def init_db(db_path: Path | str | None = None) -> sqlite3.Connection:
@@ -194,7 +236,8 @@ def init_db(db_path: Path | str | None = None) -> sqlite3.Connection:
     Path(path).parent.mkdir(parents=True, exist_ok=True)
 
     conn = get_connection(path)
-    _ensure_schema_version(conn)
+    current_version = _assert_schema_version_supported(conn)
+    _assert_schema_migration_path(current_version)
     migrate_legacy_job_tables(conn)
     conn.execute("""
         CREATE TABLE IF NOT EXISTS llm_spend (
@@ -208,6 +251,8 @@ def init_db(db_path: Path | str | None = None) -> sqlite3.Connection:
         CREATE TABLE IF NOT EXISTS jobs (
             -- Discovery stage (smart_extract / job_search)
             url                   TEXT PRIMARY KEY,
+            tenant_id             TEXT NOT NULL DEFAULT 'local',
+            job_id                TEXT,
             title                 TEXT,
             company               TEXT,
             salary                TEXT,
@@ -303,6 +348,7 @@ def init_db(db_path: Path | str | None = None) -> sqlite3.Connection:
     ensure_contact_tables(conn)
     ensure_projection_tables_in_db(conn)
     drop_legacy_apply_runs_tables(conn)
+    _run_schema_migrations(conn)
 
     return conn
 
@@ -632,6 +678,397 @@ def ensure_columns(conn: sqlite3.Connection | None = None) -> list[str]:
         conn.commit()
 
     return added
+
+
+_STABLE_JOB_IDENTITY_TRIGGER_NAMES = (
+    "jobs_stable_identity_validate_insert_v7",
+    "jobs_stable_identity_validate_update_v7",
+    "jobs_stable_identity_after_insert_v7",
+    "jobs_stable_identity_after_url_update_v7",
+    "jobs_stable_identity_after_delete_v7",
+)
+
+_STABLE_JOB_IDENTITY_SCHEMA_VERSION = 7
+
+_SQLITE_UUID_EXPRESSION = """
+    lower(hex(randomblob(4))) || '-' ||
+    lower(hex(randomblob(2))) || '-4' ||
+    substr(lower(hex(randomblob(2))), 2) || '-' ||
+    substr('89ab', abs(random() % 4) + 1, 1) ||
+    substr(lower(hex(randomblob(2))), 2) || '-' ||
+    lower(hex(randomblob(6)))
+"""
+
+
+def ensure_stable_job_identity_v7(
+    conn: sqlite3.Connection | None = None,
+) -> list[str]:
+    """Apply the additive stable-JobId foundation and stamp schema v7.
+
+    The legacy ``jobs.url`` primary key and URL-keyed authority tables remain in
+    place during this phase. Every job gains one opaque UUID plus a
+    tenant-scoped posting-URL alias. Triggers keep legacy raw INSERT paths
+    compatible until their repositories move to explicit JobId writes.
+
+    All v7 DDL, backfill, validation, and the ``user_version`` stamp live in one
+    savepoint. A failure rolls the v7 work back and leaves the prior schema
+    version retryable.
+    """
+    if conn is None:
+        conn = get_connection()
+
+    current = _assert_schema_version_supported(conn)
+    if current >= _STABLE_JOB_IDENTITY_SCHEMA_VERSION:
+        return []
+
+    migration_timestamp = datetime.now(timezone.utc).isoformat()
+    created: list[str] = []
+
+    conn.execute("SAVEPOINT stable_job_identity_v7")
+    try:
+        before_count = int(
+            conn.execute("SELECT COUNT(*) FROM jobs").fetchone()[0]
+        )
+        columns = {
+            str(row[1])
+            for row in conn.execute("PRAGMA table_info(jobs)").fetchall()
+        }
+        if "tenant_id" not in columns:
+            conn.execute(
+                "ALTER TABLE jobs ADD COLUMN tenant_id "
+                "TEXT NOT NULL DEFAULT 'local'"
+            )
+            created.append("jobs.tenant_id")
+        if "job_id" not in columns:
+            conn.execute("ALTER TABLE jobs ADD COLUMN job_id TEXT")
+            created.append("jobs.job_id")
+
+        rows = conn.execute(
+            "SELECT rowid, tenant_id, job_id FROM jobs ORDER BY rowid"
+        ).fetchall()
+        for row in rows:
+            rowid = int(row[0])
+            tenant_id = str(row[1] or "").strip() or "local"
+            existing_job_id = str(row[2] or "").strip().lower()
+            job_id = existing_job_id or str(uuid.uuid4())
+            _validate_job_uuid(job_id)
+            conn.execute(
+                "UPDATE jobs SET tenant_id = ?, job_id = ? WHERE rowid = ?",
+                (tenant_id, job_id, rowid),
+            )
+
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS job_identity_aliases (
+                tenant_id   TEXT NOT NULL,
+                alias_kind  TEXT NOT NULL,
+                alias_value TEXT NOT NULL,
+                job_id      TEXT NOT NULL,
+                created_at  TEXT NOT NULL,
+                retired_at  TEXT,
+                PRIMARY KEY (tenant_id, alias_kind, alias_value),
+                CHECK (alias_kind = 'posting_url')
+            )
+            """
+        )
+        created.append("job_identity_aliases")
+
+        conflict = conn.execute(
+            """
+            SELECT a.tenant_id, a.alias_value, a.job_id, j.job_id
+            FROM job_identity_aliases a
+            JOIN jobs j
+              ON j.tenant_id = a.tenant_id
+             AND j.url = a.alias_value
+            WHERE a.alias_kind = 'posting_url'
+              AND a.job_id != j.job_id
+            LIMIT 1
+            """
+        ).fetchone()
+        if conflict is not None:
+            raise RuntimeError(
+                "stable JobId migration found a posting URL alias owned by "
+                "a different job"
+            )
+
+        conn.execute(
+            """
+            INSERT INTO job_identity_aliases (
+                tenant_id, alias_kind, alias_value, job_id, created_at, retired_at
+            )
+            SELECT
+                tenant_id,
+                'posting_url',
+                url,
+                job_id,
+                COALESCE(NULLIF(discovered_at, ''), ?),
+                NULL
+            FROM jobs
+            WHERE 1
+            ON CONFLICT(tenant_id, alias_kind, alias_value) DO UPDATE SET
+                retired_at = NULL
+            WHERE job_identity_aliases.job_id = excluded.job_id
+            """,
+            (migration_timestamp,),
+        )
+        conn.execute(
+            """
+            CREATE UNIQUE INDEX IF NOT EXISTS idx_jobs_tenant_job_id
+            ON jobs(tenant_id, job_id)
+            """
+        )
+        conn.execute(
+            """
+            CREATE INDEX IF NOT EXISTS idx_job_identity_aliases_job
+            ON job_identity_aliases(tenant_id, job_id, alias_kind)
+            """
+        )
+        _create_stable_job_identity_triggers(conn)
+        _verify_stable_job_identity_v7(conn, expected_jobs=before_count)
+        conn.execute(
+            f"PRAGMA user_version = {_STABLE_JOB_IDENTITY_SCHEMA_VERSION}"
+        )
+        conn.execute("RELEASE SAVEPOINT stable_job_identity_v7")
+        conn.commit()
+    except BaseException:
+        conn.execute("ROLLBACK TO SAVEPOINT stable_job_identity_v7")
+        conn.execute("RELEASE SAVEPOINT stable_job_identity_v7")
+        raise
+
+    return created
+
+
+def _create_stable_job_identity_triggers(conn: sqlite3.Connection) -> None:
+    uuid_expression = " ".join(_SQLITE_UUID_EXPRESSION.split())
+    conn.execute(
+        """
+        CREATE TRIGGER IF NOT EXISTS jobs_stable_identity_validate_insert_v7
+        BEFORE INSERT ON jobs
+        BEGIN
+            SELECT CASE
+              WHEN NEW.job_id IS NOT NULL
+               AND (
+                    NEW.job_id != trim(NEW.job_id)
+                 OR NEW.job_id != lower(NEW.job_id)
+                 OR length(NEW.job_id) != 36
+                 OR substr(NEW.job_id, 9, 1) != '-'
+                 OR substr(NEW.job_id, 14, 1) != '-'
+                 OR substr(NEW.job_id, 19, 1) != '-'
+                 OR substr(NEW.job_id, 24, 1) != '-'
+                 OR length(replace(NEW.job_id, '-', '')) != 32
+                 OR replace(NEW.job_id, '-', '') GLOB '*[^0-9a-f]*'
+               )
+              THEN RAISE(ABORT, 'jobs.job_id must be a canonical UUID')
+            END;
+            SELECT CASE
+              WHEN NEW.tenant_id IS NULL
+                OR trim(NEW.tenant_id) = ''
+                OR NEW.tenant_id != trim(NEW.tenant_id)
+              THEN RAISE(ABORT, 'jobs.tenant_id must be canonical')
+            END;
+        END
+        """
+    )
+    conn.execute(
+        """
+        CREATE TRIGGER IF NOT EXISTS jobs_stable_identity_validate_update_v7
+        BEFORE UPDATE OF job_id, tenant_id ON jobs
+        BEGIN
+            SELECT CASE
+              WHEN OLD.job_id IS NOT NULL
+               AND NEW.job_id IS NOT OLD.job_id
+              THEN RAISE(ABORT, 'jobs.job_id is immutable')
+            END;
+            SELECT CASE
+              WHEN NEW.tenant_id IS NOT OLD.tenant_id
+              THEN RAISE(ABORT, 'jobs.tenant_id is immutable')
+            END;
+            SELECT CASE
+              WHEN NEW.job_id IS NULL
+                OR trim(NEW.job_id) = ''
+                OR length(trim(NEW.job_id)) != 36
+                OR substr(trim(NEW.job_id), 9, 1) != '-'
+                OR substr(trim(NEW.job_id), 14, 1) != '-'
+                OR substr(trim(NEW.job_id), 19, 1) != '-'
+                OR substr(trim(NEW.job_id), 24, 1) != '-'
+                OR length(replace(trim(NEW.job_id), '-', '')) != 32
+                OR lower(replace(trim(NEW.job_id), '-', '')) GLOB '*[^0-9a-f]*'
+              THEN RAISE(ABORT, 'jobs.job_id must be a UUID')
+            END;
+        END
+        """
+    )
+    conn.execute(
+        f"""
+        CREATE TRIGGER IF NOT EXISTS jobs_stable_identity_after_insert_v7
+        AFTER INSERT ON jobs
+        BEGIN
+            UPDATE jobs
+            SET job_id = {uuid_expression}
+            WHERE rowid = NEW.rowid
+              AND NEW.job_id IS NULL;
+
+            SELECT CASE
+              WHEN EXISTS (
+                SELECT 1
+                FROM job_identity_aliases a
+                JOIN jobs j ON j.rowid = NEW.rowid
+                WHERE a.tenant_id = j.tenant_id
+                  AND a.alias_kind = 'posting_url'
+                  AND a.alias_value = j.url
+                  AND a.job_id != j.job_id
+              )
+              THEN RAISE(ABORT, 'posting URL alias belongs to another job')
+            END;
+
+            INSERT INTO job_identity_aliases (
+                tenant_id, alias_kind, alias_value, job_id, created_at, retired_at
+            )
+            SELECT
+                tenant_id,
+                'posting_url',
+                url,
+                job_id,
+                COALESCE(
+                    NULLIF(discovered_at, ''),
+                    strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+                ),
+                NULL
+            FROM jobs
+            WHERE rowid = NEW.rowid
+            ON CONFLICT(tenant_id, alias_kind, alias_value) DO UPDATE SET
+                retired_at = NULL
+            WHERE job_identity_aliases.job_id = excluded.job_id;
+        END
+        """
+    )
+    conn.execute(
+        """
+        CREATE TRIGGER IF NOT EXISTS jobs_stable_identity_after_delete_v7
+        AFTER DELETE ON jobs
+        BEGIN
+            DELETE FROM job_identity_aliases
+            WHERE tenant_id = OLD.tenant_id
+              AND job_id = OLD.job_id;
+        END
+        """
+    )
+    conn.execute(
+        """
+        CREATE TRIGGER IF NOT EXISTS jobs_stable_identity_after_url_update_v7
+        AFTER UPDATE OF url ON jobs
+        WHEN NEW.url != OLD.url
+        BEGIN
+            SELECT CASE
+              WHEN EXISTS (
+                SELECT 1
+                FROM job_identity_aliases
+                WHERE tenant_id = NEW.tenant_id
+                  AND alias_kind = 'posting_url'
+                  AND alias_value = NEW.url
+                  AND job_id != NEW.job_id
+              )
+              THEN RAISE(ABORT, 'posting URL alias belongs to another job')
+            END;
+
+            INSERT INTO job_identity_aliases (
+                tenant_id, alias_kind, alias_value, job_id, created_at, retired_at
+            ) VALUES (
+                NEW.tenant_id,
+                'posting_url',
+                NEW.url,
+                NEW.job_id,
+                strftime('%Y-%m-%dT%H:%M:%fZ', 'now'),
+                NULL
+            )
+            ON CONFLICT(tenant_id, alias_kind, alias_value) DO UPDATE SET
+                retired_at = NULL
+            WHERE job_identity_aliases.job_id = excluded.job_id;
+        END
+        """
+    )
+
+
+def _verify_stable_job_identity_v7(
+    conn: sqlite3.Connection,
+    *,
+    expected_jobs: int | None = None,
+) -> None:
+    columns = {
+        str(row[1])
+        for row in conn.execute("PRAGMA table_info(jobs)").fetchall()
+    }
+    if not {"tenant_id", "job_id"}.issubset(columns):
+        raise RuntimeError("stable JobId migration is missing jobs identity columns")
+
+    rows = conn.execute(
+        "SELECT tenant_id, job_id, url FROM jobs ORDER BY rowid"
+    ).fetchall()
+    if expected_jobs is not None and len(rows) != expected_jobs:
+        raise RuntimeError("stable JobId migration changed the canonical job count")
+    for row in rows:
+        if not str(row[0] or "").strip():
+            raise RuntimeError("stable JobId migration produced an empty tenant")
+        _validate_job_uuid(str(row[1] or ""))
+
+    duplicate = conn.execute(
+        """
+        SELECT tenant_id, job_id
+        FROM jobs
+        GROUP BY tenant_id, job_id
+        HAVING COUNT(*) > 1
+        LIMIT 1
+        """
+    ).fetchone()
+    if duplicate is not None:
+        raise RuntimeError("stable JobId migration produced duplicate job IDs")
+
+    missing_alias = conn.execute(
+        """
+        SELECT j.tenant_id, j.url
+        FROM jobs j
+        LEFT JOIN job_identity_aliases a
+          ON a.tenant_id = j.tenant_id
+         AND a.alias_kind = 'posting_url'
+         AND a.alias_value = j.url
+         AND a.job_id = j.job_id
+         AND a.retired_at IS NULL
+        WHERE a.job_id IS NULL
+        LIMIT 1
+        """
+    ).fetchone()
+    if missing_alias is not None:
+        raise RuntimeError("stable JobId migration left a job without its URL alias")
+
+    trigger_rows = conn.execute(
+        """
+        SELECT name
+        FROM sqlite_master
+        WHERE type = 'trigger'
+          AND name IN (?, ?, ?, ?, ?)
+        """,
+        _STABLE_JOB_IDENTITY_TRIGGER_NAMES,
+    ).fetchall()
+    if {str(row[0]) for row in trigger_rows} != set(
+        _STABLE_JOB_IDENTITY_TRIGGER_NAMES
+    ):
+        raise RuntimeError("stable JobId migration is missing identity triggers")
+
+    foreign_key_error = conn.execute("PRAGMA foreign_key_check").fetchone()
+    if foreign_key_error is not None:
+        raise RuntimeError(
+            "stable JobId migration found an existing foreign-key violation"
+        )
+
+
+def _validate_job_uuid(value: str) -> None:
+    candidate = value.strip().lower()
+    try:
+        parsed = uuid.UUID(candidate)
+    except (AttributeError, ValueError) as exc:
+        raise RuntimeError("stable JobId migration found a non-UUID job_id") from exc
+    if str(parsed) != candidate:
+        raise RuntimeError("stable JobId migration found a non-canonical UUID")
 
 
 def ensure_posted_compensation_tables(conn: sqlite3.Connection | None = None) -> list[str]:

--- a/workers/automation/tests/test_repeat_application_prevention.py
+++ b/workers/automation/tests/test_repeat_application_prevention.py
@@ -735,7 +735,7 @@ def test_schema_v5_migrates_additively_without_changing_application_facts(
         (PRIOR,),
     ).fetchall()
 
-    assert int(migrated.execute("PRAGMA user_version").fetchone()[0]) == SCHEMA_VERSION == 6
+    assert int(migrated.execute("PRAGMA user_version").fetchone()[0]) == SCHEMA_VERSION == 7
     assert [tuple(row) for row in after] == [tuple(row) for row in before]
     assert "metadata_json" in {
         str(row[1]) for row in migrated.execute("PRAGMA table_info(job_stage_states)").fetchall()

--- a/workers/automation/tests/test_stable_job_identity_migration.py
+++ b/workers/automation/tests/test_stable_job_identity_migration.py
@@ -1,0 +1,795 @@
+"""Schema-v7 stable JobId foundation and recovery contracts."""
+
+from __future__ import annotations
+
+import shutil
+import sqlite3
+import uuid
+from pathlib import Path
+
+import pytest
+
+import jobctrl.database as database_module
+from jobctrl.database import (
+    IncompatibleSchemaVersionError,
+    SCHEMA_VERSION,
+    _assert_schema_version_supported,
+    close_connection,
+    init_db,
+)
+
+
+LEGACY_SCHEMA_VERSION = 6
+REFERENCE_TABLES = (
+    "job_stage_states",
+    "job_events",
+    "job_scores",
+    "job_artifacts",
+    "job_source_observations",
+    "discovery_execution_jobs",
+    "workflow_run_projections",
+    "application_outcomes",
+)
+
+
+def _create_legacy_database(
+    db_path: Path,
+    *,
+    jobs: tuple[tuple[str, str, str], ...] = (),
+) -> None:
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute(
+            """
+            CREATE TABLE jobs (
+                url           TEXT PRIMARY KEY,
+                title         TEXT,
+                discovered_at TEXT
+            )
+            """
+        )
+        conn.executemany(
+            "INSERT INTO jobs (url, title, discovered_at) VALUES (?, ?, ?)",
+            jobs,
+        )
+        conn.execute(f"PRAGMA user_version = {LEGACY_SCHEMA_VERSION}")
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _identity_rows(db_path: Path) -> list[tuple[str, str, str]]:
+    conn = sqlite3.connect(db_path)
+    try:
+        return [
+            (str(row[0]), str(row[1]), str(row[2]))
+            for row in conn.execute(
+                "SELECT tenant_id, job_id, url FROM jobs ORDER BY url"
+            ).fetchall()
+        ]
+    finally:
+        conn.close()
+
+
+def _create_representative_v6_pair(
+    db_path: Path,
+    temporal_path: Path,
+) -> str:
+    """Create real v6-shaped authorities plus a synthetic Temporal pair."""
+    job_url = "https://example.com/jobs/reference"
+    conn = init_db(db_path)
+    conn.execute(
+        """
+        INSERT INTO jobs (
+            url, title, company, site, discovered_at, fit_score,
+            score_reasoning, scored_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            job_url,
+            "Reference Engineer",
+            "Example Corp",
+            "Synthetic",
+            "2026-07-01T10:00:00+00:00",
+            8,
+            "Synthetic reference score",
+            "2026-07-01T10:05:00+00:00",
+        ),
+    )
+    database_module.ensure_source_observation_tables(conn)
+    conn.execute(
+        """
+        INSERT INTO job_stage_states (
+            job_url, stage, state, attempt_count, updated_at,
+            metadata_json, version
+        ) VALUES (?, 'score', 'succeeded', 1, ?, '{"fixture":true}', 3)
+        """,
+        (job_url, "2026-07-01T10:06:00+00:00"),
+    )
+    conn.execute(
+        """
+        INSERT INTO job_events (
+            job_url, stage, event_type, level, message, occurred_at,
+            payload_json, idempotency_key
+        ) VALUES (?, 'score', 'ScoreCompleted', 'info', ?, ?, ?, ?)
+        """,
+        (
+            job_url,
+            "Synthetic score completed",
+            "2026-07-01T10:06:00+00:00",
+            '{"score":8}',
+            "fixture-score-completed",
+        ),
+    )
+    conn.execute(
+        """
+        INSERT INTO job_scores (
+            job_url, version, tenant_id, fit_score, breakdown_json,
+            keywords_json, scored_at, criteria_json, trace_json
+        ) VALUES (?, 1, 'local', 8, ?, ?, ?, ?, ?)
+        """,
+        (
+            job_url,
+            '{"technical_fit":8}',
+            '["python","sqlite"]',
+            "2026-07-01T10:05:00+00:00",
+            '{"policy":"fixture"}',
+            '{"trace_id":"synthetic"}',
+        ),
+    )
+    conn.execute(
+        """
+        INSERT INTO job_artifacts (
+            job_url, stage, artifact_type, status, path, created_at,
+            size_bytes, metadata_json
+        ) VALUES (?, 'tailor', 'resume_pdf', 'accepted', ?, ?, 1024, ?)
+        """,
+        (
+            job_url,
+            "artifacts/synthetic-resume.pdf",
+            "2026-07-01T10:10:00+00:00",
+            '{"fixture":true}',
+        ),
+    )
+    conn.execute(
+        """
+        INSERT INTO discovery_execution_jobs (
+            tenant_id, discover_workflow_id, discover_run_id, job_url,
+            cohort_kind, source_family, preparation_workflow_id,
+            work_plan_state, required_steps_json, linked_at
+        ) VALUES (
+            'local', 'discover-fixture', 'run-fixture', ?,
+            'observed_this_run', 'synthetic', 'prepare-fixture',
+            'planned', '["enrich","score"]', ?
+        )
+        """,
+        (job_url, "2026-07-01T10:01:00+00:00"),
+    )
+    conn.execute(
+        """
+        INSERT INTO workflow_run_projections (
+            workflow_id, tenant_id, workflow_type, status,
+            input_summary_json, started_at, temporal_run_id, events_json
+        ) VALUES (
+            'prepare-fixture', 'local', 'JobPreparation', 'completed',
+            ?, ?, 'temporal-run-fixture', ?
+        )
+        """,
+        (
+            f'{{"jobUrl":"{job_url}"}}',
+            "2026-07-01T10:02:00+00:00",
+            '[{"eventType":"WorkflowCompleted"}]',
+        ),
+    )
+    from jobctrl.infrastructure.gmail.feedback import (
+        ensure_application_feedback_tables,
+    )
+
+    ensure_application_feedback_tables(conn)
+    conn.execute(
+        """
+        INSERT INTO application_outcomes (
+            tenant_id, outcome_id, job_key, kind, source, note,
+            occurred_at, recorded_at, created_by
+        ) VALUES (
+            'local', 'outcome-fixture', ?, 'interview', 'user',
+            'Synthetic outcome', ?, ?, 'user'
+        )
+        """,
+        (
+            job_url,
+            "2026-07-02T10:00:00+00:00",
+            "2026-07-02T10:01:00+00:00",
+        ),
+    )
+    conn.commit()
+    close_connection(db_path)
+
+    raw = sqlite3.connect(db_path)
+    try:
+        for trigger_name in database_module._STABLE_JOB_IDENTITY_TRIGGER_NAMES:
+            raw.execute(f'DROP TRIGGER IF EXISTS "{trigger_name}"')
+        raw.execute("DROP INDEX IF EXISTS idx_jobs_tenant_job_id")
+        raw.execute("DROP TABLE job_identity_aliases")
+        raw.execute("ALTER TABLE jobs DROP COLUMN job_id")
+        raw.execute("ALTER TABLE jobs DROP COLUMN tenant_id")
+        raw.execute(f"PRAGMA user_version = {LEGACY_SCHEMA_VERSION}")
+        raw.commit()
+    finally:
+        raw.close()
+
+    temporal = sqlite3.connect(temporal_path)
+    try:
+        temporal.execute(
+            """
+            CREATE TABLE workflow_history_marker (
+                workflow_id TEXT PRIMARY KEY,
+                job_url TEXT NOT NULL,
+                status TEXT NOT NULL
+            )
+            """
+        )
+        temporal.execute(
+            """
+            INSERT INTO workflow_history_marker (workflow_id, job_url, status)
+            VALUES ('prepare-fixture', ?, 'completed')
+            """,
+            (job_url,),
+        )
+        temporal.commit()
+    finally:
+        temporal.close()
+    return job_url
+
+
+def _reference_snapshot(db_path: Path) -> dict[str, list[tuple[object, ...]]]:
+    conn = sqlite3.connect(db_path)
+    try:
+        snapshot = {
+            table: [
+                tuple(row)
+                for row in conn.execute(
+                    f'SELECT * FROM "{table}" ORDER BY rowid'
+                ).fetchall()
+            ]
+            for table in REFERENCE_TABLES
+        }
+        snapshot["jobs"] = [
+            tuple(row)
+            for row in conn.execute(
+                """
+                SELECT
+                    url, title, company, site, discovered_at,
+                    fit_score, score_reasoning, scored_at
+                FROM jobs
+                ORDER BY url
+                """
+            ).fetchall()
+        ]
+        return snapshot
+    finally:
+        conn.close()
+
+
+def test_v6_jobs_gain_stable_uuid_and_posting_url_alias_once(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    _create_legacy_database(
+        db_path,
+        jobs=(
+            (
+                "https://example.com/jobs/alpha",
+                "Platform Engineer",
+                "2026-07-01T10:00:00+00:00",
+            ),
+            (
+                "https://example.com/jobs/beta",
+                "Staff Engineer",
+                "2026-07-02T10:00:00+00:00",
+            ),
+        ),
+    )
+
+    init_db(db_path)
+    close_connection(db_path)
+
+    assert _user_version(db_path) == SCHEMA_VERSION == 7
+    first_ids = _identity_rows(db_path)
+    assert [row[0] for row in first_ids] == ["local", "local"]
+    for _tenant_id, job_id, _url in first_ids:
+        parsed = uuid.UUID(job_id)
+        assert str(parsed) == job_id
+        assert parsed.version == 4
+
+    check = sqlite3.connect(db_path)
+    try:
+        aliases = check.execute(
+            """
+            SELECT tenant_id, alias_kind, alias_value, job_id
+            FROM job_identity_aliases
+            ORDER BY alias_value
+            """
+        ).fetchall()
+    finally:
+        check.close()
+    assert aliases == [
+        ("local", "posting_url", first_ids[0][2], first_ids[0][1]),
+        ("local", "posting_url", first_ids[1][2], first_ids[1][1]),
+    ]
+
+    init_db(db_path)
+    close_connection(db_path)
+    assert _identity_rows(db_path) == first_ids
+
+
+def test_missing_versioned_migration_fails_before_schema_writes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    _create_legacy_database(db_path)
+    monkeypatch.setattr(database_module, "_schema_migrations", lambda: ())
+
+    with pytest.raises(RuntimeError, match="no schema migration path"):
+        init_db(db_path)
+    close_connection(db_path)
+
+    check = sqlite3.connect(db_path)
+    try:
+        assert _user_version(db_path) == LEGACY_SCHEMA_VERSION
+        columns = {
+            str(row[1])
+            for row in check.execute("PRAGMA table_info(jobs)").fetchall()
+        }
+        assert "tenant_id" not in columns
+        assert "job_id" not in columns
+    finally:
+        check.close()
+
+
+def test_legacy_insert_gets_uuid_and_alias_without_changing_insert_shape(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    conn = init_db(db_path)
+    url = "https://example.com/jobs/legacy-insert"
+
+    conn.execute(
+        "INSERT INTO jobs (url, title, discovered_at) VALUES (?, ?, ?)",
+        (url, "Legacy writer", "2026-07-03T10:00:00+00:00"),
+    )
+    conn.commit()
+
+    row = conn.execute(
+        "SELECT tenant_id, job_id FROM jobs WHERE url = ?",
+        (url,),
+    ).fetchone()
+    assert row is not None
+    assert row["tenant_id"] == "local"
+    parsed = uuid.UUID(row["job_id"])
+    assert str(parsed) == row["job_id"]
+    assert parsed.version == 4
+    alias = conn.execute(
+        """
+        SELECT job_id
+        FROM job_identity_aliases
+        WHERE tenant_id = 'local'
+          AND alias_kind = 'posting_url'
+          AND alias_value = ?
+        """,
+        (url,),
+    ).fetchone()
+    assert alias is not None and alias["job_id"] == row["job_id"]
+
+
+def test_explicit_malformed_job_id_is_rejected(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    conn = init_db(db_path)
+
+    with pytest.raises(sqlite3.IntegrityError, match="canonical UUID"):
+        conn.execute(
+            "INSERT INTO jobs (url, job_id) VALUES (?, ?)",
+            (
+                "https://example.com/jobs/invalid-id",
+                "12345678-1234-1234-1234-123456789ab-",
+            ),
+        )
+
+    assert (
+        conn.execute(
+            "SELECT COUNT(*) FROM jobs WHERE url = ?",
+            ("https://example.com/jobs/invalid-id",),
+        ).fetchone()[0]
+        == 0
+    )
+
+
+def test_assigned_job_identity_is_immutable_and_url_history_is_retained(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    conn = init_db(db_path)
+    old_url = "https://example.com/jobs/original"
+    new_url = "https://careers.example.com/jobs/canonical"
+    conn.execute("INSERT INTO jobs (url, title) VALUES (?, ?)", (old_url, "Engineer"))
+    conn.commit()
+    job_id = str(
+        conn.execute(
+            "SELECT job_id FROM jobs WHERE url = ?",
+            (old_url,),
+        ).fetchone()[0]
+    )
+
+    with pytest.raises(sqlite3.IntegrityError, match="job_id is immutable"):
+        conn.execute(
+            "UPDATE jobs SET job_id = ? WHERE url = ?",
+            (str(uuid.uuid4()), old_url),
+        )
+    with pytest.raises(sqlite3.IntegrityError, match="job_id is immutable"):
+        conn.execute(
+            "UPDATE jobs SET job_id = upper(job_id) WHERE url = ?",
+            (old_url,),
+        )
+    with pytest.raises(sqlite3.IntegrityError, match="tenant_id is immutable"):
+        conn.execute(
+            "UPDATE jobs SET tenant_id = ' local ' WHERE url = ?",
+            (old_url,),
+        )
+
+    conn.execute("UPDATE jobs SET url = ? WHERE url = ?", (new_url, old_url))
+    conn.commit()
+    aliases = conn.execute(
+        """
+        SELECT alias_value
+        FROM job_identity_aliases
+        WHERE tenant_id = 'local' AND job_id = ?
+        ORDER BY alias_value
+        """,
+        (job_id,),
+    ).fetchall()
+    assert [str(row[0]) for row in aliases] == sorted([old_url, new_url])
+    active_aliases = conn.execute(
+        """
+        SELECT COUNT(*)
+        FROM job_identity_aliases a
+        JOIN jobs j
+          ON j.tenant_id = a.tenant_id
+         AND j.job_id = a.job_id
+        WHERE a.retired_at IS NULL
+        """
+    ).fetchone()[0]
+    assert active_aliases == 2
+
+
+def test_production_url_collision_cleans_aliases_and_allows_rediscovery(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from jobctrl.enrichment import detail
+
+    db_path = tmp_path / "jobctrl.db"
+    conn = init_db(db_path)
+    canonical_url = "https://example.com/jobs/collision"
+    relative_url = "/jobs/collision"
+    conn.executemany(
+        "INSERT INTO jobs (url, title, site) VALUES (?, ?, ?)",
+        (
+            (canonical_url, "Canonical", "Synthetic"),
+            (relative_url, "Relative duplicate", "Synthetic"),
+        ),
+    )
+    conn.commit()
+    monkeypatch.setattr(
+        detail,
+        "_load_base_urls",
+        lambda: {"Synthetic": "https://example.com"},
+    )
+
+    assert detail.resolve_all_urls(conn) == {
+        "resolved": 1,
+        "failed": 0,
+        "already_absolute": 1,
+        "app_resolved": 0,
+    }
+    assert conn.execute("SELECT COUNT(*) FROM jobs").fetchone()[0] == 1
+    active_orphans = conn.execute(
+        """
+        SELECT COUNT(*)
+        FROM job_identity_aliases a
+        LEFT JOIN jobs j
+          ON j.tenant_id = a.tenant_id
+         AND j.job_id = a.job_id
+        WHERE a.retired_at IS NULL
+          AND j.job_id IS NULL
+        """
+    ).fetchone()[0]
+    assert active_orphans == 0
+    removed = conn.execute(
+        """
+        SELECT job_id
+        FROM job_identity_aliases
+        WHERE alias_value = ?
+        """,
+        (relative_url,),
+    ).fetchone()
+    assert removed is None
+
+    conn.execute(
+        "INSERT INTO jobs (url, title, site) VALUES (?, ?, ?)",
+        (relative_url, "Rediscovered duplicate", "Synthetic"),
+    )
+    conn.commit()
+    rediscovered = conn.execute(
+        """
+        SELECT j.job_id, a.job_id
+        FROM jobs j
+        JOIN job_identity_aliases a
+          ON a.tenant_id = j.tenant_id
+         AND a.job_id = j.job_id
+         AND a.alias_kind = 'posting_url'
+         AND a.alias_value = j.url
+        WHERE j.url = ?
+        """,
+        (relative_url,),
+    ).fetchone()
+    assert rediscovered is not None
+    assert rediscovered[0] == rediscovered[1]
+
+
+def test_failed_alias_backfill_keeps_v6_retryable(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    url = "https://example.com/jobs/conflict"
+    _create_legacy_database(
+        db_path,
+        jobs=((url, "Engineer", "2026-07-01T10:00:00+00:00"),),
+    )
+    raw = sqlite3.connect(db_path)
+    try:
+        raw.execute(
+            """
+            CREATE TABLE job_identity_aliases (
+                tenant_id   TEXT NOT NULL,
+                alias_kind  TEXT NOT NULL,
+                alias_value TEXT NOT NULL,
+                job_id      TEXT NOT NULL,
+                created_at  TEXT NOT NULL,
+                retired_at  TEXT,
+                PRIMARY KEY (tenant_id, alias_kind, alias_value)
+            )
+            """
+        )
+        raw.execute(
+            """
+            INSERT INTO job_identity_aliases (
+                tenant_id, alias_kind, alias_value, job_id, created_at
+            ) VALUES ('local', 'posting_url', ?, ?, ?)
+            """,
+            (
+                url,
+                str(uuid.uuid4()),
+                "2026-07-01T10:00:00+00:00",
+            ),
+        )
+        raw.commit()
+    finally:
+        raw.close()
+
+    with pytest.raises(RuntimeError, match="alias owned by a different job"):
+        init_db(db_path)
+    close_connection(db_path)
+
+    assert _user_version(db_path) == LEGACY_SCHEMA_VERSION
+    check = sqlite3.connect(db_path)
+    try:
+        columns = {
+            str(row[1])
+            for row in check.execute("PRAGMA table_info(jobs)").fetchall()
+        }
+        assert "tenant_id" not in columns
+        assert "job_id" not in columns
+        check.execute("DELETE FROM job_identity_aliases")
+        check.commit()
+    finally:
+        check.close()
+
+    init_db(db_path)
+    close_connection(db_path)
+    assert _user_version(db_path) == SCHEMA_VERSION
+    assert str(uuid.UUID(_identity_rows(db_path)[0][1])) == _identity_rows(db_path)[0][1]
+
+
+def test_foreign_key_failure_does_not_stamp_or_leave_identity_columns(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    _create_legacy_database(
+        db_path,
+        jobs=(
+            (
+                "https://example.com/jobs/valid",
+                "Engineer",
+                "2026-07-01T10:00:00+00:00",
+            ),
+        ),
+    )
+    raw = sqlite3.connect(db_path)
+    try:
+        raw.execute(
+            """
+            CREATE TABLE migration_probe (
+                job_url TEXT NOT NULL REFERENCES jobs(url)
+            )
+            """
+        )
+        raw.execute(
+            "INSERT INTO migration_probe (job_url) VALUES (?)",
+            ("https://example.com/jobs/orphan",),
+        )
+        raw.commit()
+    finally:
+        raw.close()
+
+    with pytest.raises(RuntimeError, match="foreign-key violation"):
+        init_db(db_path)
+    close_connection(db_path)
+    assert _user_version(db_path) == LEGACY_SCHEMA_VERSION
+
+    check = sqlite3.connect(db_path)
+    try:
+        columns = {
+            str(row[1])
+            for row in check.execute("PRAGMA table_info(jobs)").fetchall()
+        }
+        assert "tenant_id" not in columns
+        assert "job_id" not in columns
+        check.execute("DELETE FROM migration_probe")
+        check.commit()
+    finally:
+        check.close()
+
+    init_db(db_path)
+    close_connection(db_path)
+    assert _user_version(db_path) == SCHEMA_VERSION
+
+
+def test_forward_reopen_retains_ids_and_previous_release_uses_snapshot(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    pre_upgrade = tmp_path / "jobctrl-v6.db"
+    _create_legacy_database(
+        db_path,
+        jobs=(
+            (
+                "https://example.com/jobs/rollback",
+                "Engineer",
+                "2026-07-01T10:00:00+00:00",
+            ),
+        ),
+    )
+    shutil.copy2(db_path, pre_upgrade)
+
+    init_db(db_path)
+    close_connection(db_path)
+    migrated_ids = _identity_rows(db_path)
+    init_db(db_path)
+    close_connection(db_path)
+    assert _identity_rows(db_path) == migrated_ids
+
+    migrated = sqlite3.connect(db_path)
+    try:
+        with pytest.raises(IncompatibleSchemaVersionError):
+            _assert_schema_version_supported(
+                migrated,
+                supported_version=LEGACY_SCHEMA_VERSION,
+            )
+    finally:
+        migrated.close()
+
+    snapshot = sqlite3.connect(pre_upgrade)
+    try:
+        assert (
+            _assert_schema_version_supported(
+                snapshot,
+                supported_version=LEGACY_SCHEMA_VERSION,
+            )
+            == LEGACY_SCHEMA_VERSION
+        )
+        columns = {
+            str(row[1])
+            for row in snapshot.execute("PRAGMA table_info(jobs)").fetchall()
+        }
+        assert "job_id" not in columns
+    finally:
+        snapshot.close()
+
+
+def test_representative_v6_references_and_paired_snapshot_restore(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    temporal_path = tmp_path / "temporal.db"
+    job_url = _create_representative_v6_pair(db_path, temporal_path)
+    before = _reference_snapshot(db_path)
+    assert all(before[table] for table in (*REFERENCE_TABLES, "jobs"))
+
+    pre_upgrade = tmp_path / "pre-upgrade"
+    pre_upgrade.mkdir()
+    db_snapshot = pre_upgrade / "jobctrl.db"
+    temporal_snapshot = pre_upgrade / "temporal.db"
+    shutil.copy2(db_path, db_snapshot)
+    shutil.copy2(temporal_path, temporal_snapshot)
+
+    init_db(db_path)
+    close_connection(db_path)
+    assert _user_version(db_path) == SCHEMA_VERSION
+    assert _reference_snapshot(db_path) == before
+    identities = _identity_rows(db_path)
+    assert len(identities) == 1
+    assert identities[0][0] == "local"
+    assert identities[0][2] == job_url
+    assert uuid.UUID(identities[0][1]).version == 4
+
+    temporal = sqlite3.connect(temporal_path)
+    try:
+        temporal.execute(
+            """
+            UPDATE workflow_history_marker
+            SET status = 'post-upgrade-write'
+            WHERE workflow_id = 'prepare-fixture'
+            """
+        )
+        temporal.commit()
+    finally:
+        temporal.close()
+
+    restored = tmp_path / "restored-pair"
+    restored.mkdir()
+    restored_db = restored / "jobctrl.db"
+    restored_temporal = restored / "temporal.db"
+    shutil.copy2(db_snapshot, restored_db)
+    shutil.copy2(temporal_snapshot, restored_temporal)
+
+    previous = sqlite3.connect(restored_db)
+    try:
+        assert (
+            _assert_schema_version_supported(
+                previous,
+                supported_version=LEGACY_SCHEMA_VERSION,
+            )
+            == LEGACY_SCHEMA_VERSION
+        )
+        columns = {
+            str(row[1])
+            for row in previous.execute("PRAGMA table_info(jobs)").fetchall()
+        }
+        assert "job_id" not in columns
+        assert "tenant_id" not in columns
+    finally:
+        previous.close()
+    assert _reference_snapshot(restored_db) == before
+
+    restored_history = sqlite3.connect(restored_temporal)
+    try:
+        marker = restored_history.execute(
+            """
+            SELECT workflow_id, job_url, status
+            FROM workflow_history_marker
+            """
+        ).fetchone()
+    finally:
+        restored_history.close()
+    assert marker == ("prepare-fixture", job_url, "completed")
+
+
+def _user_version(db_path: Path) -> int:
+    conn = sqlite3.connect(db_path)
+    try:
+        return int(conn.execute("PRAGMA user_version").fetchone()[0])
+    finally:
+        conn.close()


### PR DESCRIPTION
## Stack

- Parent: #526 — roadmap, domain contract, migration/rollback plan
- This PR: Phase 1 — schema runner and additive stable identity foundation
- Next: canonical repository/identity resolver compatibility

## What changed

- replace eager `PRAGMA user_version` stamping with an ordered migration runner that fails before writes when the declared schema version has no registered migration
- add schema v7 `tenant_id` + opaque UUIDv4 `job_id` fields and a tenant-scoped posting-URL alias map
- backfill existing jobs exactly once inside the verified migration savepoint
- keep every current URL-keyed repository, route, event, projection, child table, and workflow contract unchanged in this slice
- cover legacy URL-only inserts with stable-ID/alias triggers, reject malformed or byte-mutated identity, retain URL history on locator changes, and clean aliases when compatibility code physically deletes a duplicate so rediscovery still works
- keep Python and TypeScript forward-schema guards aligned at v7
- document the additive storage authority, rollback boundary, and focused high-risk QA matrix

## Migration and rollback

The v7 version stamp is written only after DDL, UUID/alias backfill, canonical row-count verification, trigger verification, and `foreign_key_check` all succeed in one savepoint. A failed attempt rolls the identity changes back and leaves the previous version retryable.

Forward reopen retains generated IDs. A previous release rejects v7 and must open the paired pre-upgrade `jobctrl.db` / `temporal.db` snapshot; there is no in-place down-migration. Temporal workflow IDs/inputs are not cut over in this PR.

## Validation

- `workers/automation/.venv/bin/python -m pytest -q` — **2,650 passed, 2 skipped**
- focused stable-identity/backup/repository/repeat-application matrix — **48 passed**
- `corepack pnpm api:test` — **648 passed**
- `corepack pnpm api:check` — passed
- API schema-version guard — **10 passed**
- targeted Ruff — passed
- `corepack pnpm docs:build` — 8,238 references across 338 files passed
- `git diff --check` — passed
- independent reviewer gate — **PASS**, Blocker/High/Medium/Low = 0/0/0/0
- independent QA gate — **PASS**, Blocker/High/Medium/Low = 0/0/0/0

All migration fixtures are synthetic. The paired-restore regression uses a synthetic SQLite Temporal-history marker; live Temporal snapshot reopen remains part of the later workflow-identity cutover gate.