### PR TITLE
chore(release): publish canonical v2.0.8 installer

### DIFF
--- a/docs/public/install.sh
+++ b/docs/public/install.sh
@@ -4,9 +4,9 @@ set -euo pipefail
 
 # P6 renders these from the signed publication. Empty pins fail closed.
 # BEGIN JOBCTRL RELEASE PINS
-INSTALLER_URL="https://releases.jobctrl.dev/v1/artifacts/2.0.7-db257efe1087ec00ac2ec49b846a95d2423aecc2-darwin-arm64/jobctrl-installer"
-INSTALLER_SHA256="d862a8edc7fa68aa23b6f32a98af6d06f5e8f2898966f71e0146a29ec24ee749"
-INSTALLER_VERSION="2.0.7"
+INSTALLER_URL="https://releases.jobctrl.dev/v1/artifacts/2.0.8-92770fe5fcc99e73c0a06e73315acbb7b506a7af-darwin-arm64/jobctrl-installer"
+INSTALLER_SHA256="be91015004c63d0f26f9ed6891d70e393058e99cc975cd4737a4e907a8229ccb"
+INSTALLER_VERSION="2.0.8"
 # END JOBCTRL RELEASE PINS
 
 usage() {

--- a/scripts/get
+++ b/scripts/get
@@ -4,9 +4,9 @@ set -euo pipefail
 
 # P6 renders these from the signed publication. Empty pins fail closed.
 # BEGIN JOBCTRL RELEASE PINS
-INSTALLER_URL="https://releases.jobctrl.dev/v1/artifacts/2.0.7-db257efe1087ec00ac2ec49b846a95d2423aecc2-darwin-arm64/jobctrl-installer"
-INSTALLER_SHA256="d862a8edc7fa68aa23b6f32a98af6d06f5e8f2898966f71e0146a29ec24ee749"
-INSTALLER_VERSION="2.0.7"
+INSTALLER_URL="https://releases.jobctrl.dev/v1/artifacts/2.0.8-92770fe5fcc99e73c0a06e73315acbb7b506a7af-darwin-arm64/jobctrl-installer"
+INSTALLER_SHA256="be91015004c63d0f26f9ed6891d70e393058e99cc975cd4737a4e907a8229ccb"
+INSTALLER_VERSION="2.0.8"
 # END JOBCTRL RELEASE PINS
 
 usage() {

--- a/scripts/get.test.mjs
+++ b/scripts/get.test.mjs
@@ -157,9 +157,9 @@ test("local fixture mode cannot select a network release and the released path c
     assert.equal(local.status, 1);
     assert.match(local.stderr, /cannot use --release-url/);
     const source = readFileSync(GET, "utf8");
-    assert.match(source, /^INSTALLER_URL="https:\/\/releases\.jobctrl\.dev\/v1\/artifacts\/2\.0\.7-db257efe1087ec00ac2ec49b846a95d2423aecc2-darwin-arm64\/jobctrl-installer"$/m);
-    assert.match(source, /^INSTALLER_SHA256="d862a8edc7fa68aa23b6f32a98af6d06f5e8f2898966f71e0146a29ec24ee749"$/m);
-    assert.match(source, /^INSTALLER_VERSION="2\.0\.7"$/m);
+    assert.match(source, /^INSTALLER_URL="https:\/\/releases\.jobctrl\.dev\/v1\/artifacts\/2\.0\.8-92770fe5fcc99e73c0a06e73315acbb7b506a7af-darwin-arm64\/jobctrl-installer"$/m);
+    assert.match(source, /^INSTALLER_SHA256="be91015004c63d0f26f9ed6891d70e393058e99cc975cd4737a4e907a8229ccb"$/m);
+    assert.match(source, /^INSTALLER_VERSION="2\.0\.8"$/m);
     assert.doesNotMatch(source, /^INSTALLER_URL=""$/m);
   } finally { rmSync(root, { recursive: true, force: true }); }
 });


### PR DESCRIPTION
## Summary

- copy the immutable v2.0.8 `install.sh` release asset byte-for-byte into both canonical installer locations
- pin the public bootstrap to the signed v2.0.8 native installer
- update the exact-pin regression assertion for the new release

## Why

This completes the required post-release canonical-installer cutover. The immutable release remains rooted at `92770fe5fcc99e73c0a06e73315acbb7b506a7af`; this PR only deploys its already published and verified bootstrap bytes through `jobctrl.dev/install.sh`.

Release evidence:

- GitHub Release: https://github.com/ebarti/JobCtrl/releases/tag/v2.0.8
- immutable `install.sh` SHA-256: `7230c7539ccc0551b19c00200c9715b340577240f5c1f5db05af4d9ece1aa47e`
- pinned native installer SHA-256: `be91015004c63d0f26f9ed6891d70e393058e99cc975cd4737a4e907a8229ccb`

## Validation

- `node scripts/get.test.mjs` — 7/7 passed
- `node scripts/check-install-asset.mjs` — passed
- `python3 scripts/release_check.py --strict-prompt` — passed
- `corepack pnpm docs:build` — passed; 8,238 links checked
- `corepack pnpm docs:check:runtime` — passed
- `git diff --check` — passed
- independent security review and QA gates — PASS, zero findings