### PR TITLE
feat(storage): resolve stable job identities

### DIFF
--- a/workers/automation/src/jobctrl/discovery/smartextract.py
+++ b/workers/automation/src/jobctrl/discovery/smartextract.py
@@ -45,6 +45,7 @@ from jobctrl.domain.events import (
     create_duplicate_job_linked,
 )
 from jobctrl.domain.discovery.source_registry import SMART_EXTRACT_EXPERIMENTAL_POLICY
+from jobctrl.domain.discovery.value_objects import PostingUrl
 from jobctrl.domain.ports.discovery import ContentOwnerMatch
 from jobctrl.domain.tenant import LOCAL_TENANT
 from jobctrl.infrastructure.network import (
@@ -149,7 +150,16 @@ def _merge_smart_extract_content_duplicate(
     the surviving owner, resurface it if it was soft-deleted, and skip the
     insert.
     """
-    owner_url = str(owner_match.job_id)
+    owner = repository.load(LOCAL_TENANT, owner_match.job_id)
+    if owner is None:
+        raise LookupError(f"Content owner disappeared before merge: {owner_match.job_id!r}")
+    owner_identity = repository.resolve_by_job_id(
+        LOCAL_TENANT,
+        owner_match.job_id,
+    )
+    if owner_identity is None:
+        raise LookupError(f"Content owner identity disappeared before merge: {owner_match.job_id!r}")
+    owner_storage_url = owner_identity.storage_url.value
     if owner_match.basis == "fingerprint":
         reason = "content_fingerprint_match"
         confidence = CONTENT_MATCH_CONFIDENCE
@@ -161,7 +171,7 @@ def _merge_smart_extract_content_duplicate(
         LOCAL_TENANT,
         DuplicateJobLink(
             duplicate_link_id=duplicate_link_id,
-            surviving_job_id=owner_url,
+            surviving_job_id=str(owner_match.job_id),
             superseded_job_or_observation_id=url,
             reason=reason,
             confidence=confidence,
@@ -185,14 +195,18 @@ def _merge_smart_extract_content_duplicate(
             LOCAL_TENANT,
             DuplicateJobLinkedPayload(
                 duplicate_link_id=duplicate_link_id,
-                surviving_job_id=owner_url,
+                surviving_job_id=owner_storage_url,
                 superseded_job_or_observation_id=url,
                 reason=reason,
                 confidence=confidence,
             ),
         )
     )
-    resurface_deleted_job(conn, owner_url, resurfaced_at=observed_at)
+    resurface_deleted_job(
+        conn,
+        owner_storage_url,
+        resurfaced_at=observed_at,
+    )
 
 
 def _store_jobs_filtered(
@@ -237,25 +251,35 @@ def _store_jobs_filtered(
         if not description:
             missing_description += 1
             continue
+        url_identity = repository.resolve_by_posting_url(
+            LOCAL_TENANT,
+            PostingUrl(value=url),
+        )
         content_owner = repository.find_content_owner(
             LOCAL_TENANT,
             title=str(job.get("title") or ""),
             company=str(job.get("company") or ""),
             description=description,
         )
-        if content_owner is not None and str(content_owner.job_id) != url:
-            _merge_smart_extract_content_duplicate(
-                conn,
-                repository,
-                publisher,
-                content_owner,
-                url=url,
-                site=site,
-                observed_at=now,
-                run_id=run_id,
-            )
-            existing += 1
-            continue
+        if content_owner is not None:
+            resolved_owner = repository.load(LOCAL_TENANT, content_owner.job_id)
+            if resolved_owner is None:
+                raise LookupError(f"Content owner disappeared before comparison: {content_owner.job_id!r}")
+            if resolved_owner.posting_url.value != url and (
+                url_identity is None or url_identity.job_id != content_owner.job_id
+            ):
+                _merge_smart_extract_content_duplicate(
+                    conn,
+                    repository,
+                    publisher,
+                    content_owner,
+                    url=url,
+                    site=site,
+                    observed_at=now,
+                    run_id=run_id,
+                )
+                existing += 1
+                continue
         try:
             conn.execute(
                 "INSERT INTO jobs (url, title, company, salary, description, location, site, strategy, discovered_at) "
@@ -274,6 +298,15 @@ def _store_jobs_filtered(
             )
             new += 1
         except sqlite3.IntegrityError:
+            # The incoming locator may be a current or historical alias while
+            # every deferred child row (including the tombstone) still uses the
+            # physical jobs.url key. Resolve again after the failed INSERT so a
+            # concurrent winner is visible too.
+            url_identity = repository.resolve_by_posting_url(
+                LOCAL_TENANT,
+                PostingUrl(value=url),
+            )
+            storage_url = url_identity.storage_url.value if url_identity is not None else url
             company = str(job.get("company") or "").strip()
             title = str(job.get("title") or "").strip()
             location = str(job.get("location") or "").strip()
@@ -282,7 +315,9 @@ def _store_jobs_filtered(
             update_values: list[str] = []
             metadata_payload: dict[str, object] = {"source": site}
             if title:
-                update_fields.append("title = CASE WHEN title IS NULL OR title = '' OR title != ? THEN ? ELSE title END")
+                update_fields.append(
+                    "title = CASE WHEN title IS NULL OR title = '' OR title != ? THEN ? ELSE title END"
+                )
                 update_values.extend([title, title])
                 metadata_payload["title"] = title
             if company:
@@ -294,9 +329,7 @@ def _store_jobs_filtered(
                 update_values.append(salary)
                 metadata_payload["salary"] = True
             if description:
-                update_fields.append(
-                    f"description = CASE WHEN {_MISSING_DESCRIPTION_SQL} THEN ? ELSE description END"
-                )
+                update_fields.append(f"description = CASE WHEN {_MISSING_DESCRIPTION_SQL} THEN ? ELSE description END")
                 update_values.append(description)
                 metadata_payload["description"] = True
             if location:
@@ -323,28 +356,31 @@ def _store_jobs_filtered(
                 if location:
                     predicate_values.append(location)
                 cursor = conn.execute(
-                    f"UPDATE jobs SET {', '.join(update_fields)} WHERE url = ? "
-                    f"AND ({' OR '.join(update_predicates)})",
-                    (*update_values, url, *predicate_values),
+                    f"UPDATE jobs SET {', '.join(update_fields)} WHERE url = ? AND ({' OR '.join(update_predicates)})",
+                    (*update_values, storage_url, *predicate_values),
                 )
                 if cursor.rowcount:
                     from jobctrl.state import record_job_event
 
                     record_job_event(
                         conn,
-                        url,
+                        storage_url,
                         "discover",
                         "JobMetadataUpdated",
                         message="Job metadata refreshed from SmartExtract",
                         payload=metadata_payload,
                         occurred_at=now,
                     )
-            resurface_deleted_job(conn, url, resurfaced_at=now)
+            resurface_deleted_job(
+                conn,
+                storage_url,
+                resurfaced_at=now,
+            )
             existing += 1
 
         repository.attach_source_observation(
             LOCAL_TENANT,
-            JobId(url),
+            url_identity.job_id if url_identity is not None else JobId(url),
             JobSourceObservation(
                 source_observation_id=f"obs:{uuid.uuid4().hex}",
                 source_id=f"smartextract:{site}",
@@ -417,9 +453,7 @@ def _empty_page_intelligence(url: str) -> dict:
     }
 
 
-def collect_page_intelligence(
-    url: str, headless: bool = True, *, session: PolitenessSession | None = None
-) -> dict:
+def collect_page_intelligence(url: str, headless: bool = True, *, session: PolitenessSession | None = None) -> dict:
     """Load a page with Playwright and collect every signal a scraping engineer
     would look at in DevTools. Returns a structured intelligence report.
 
@@ -1335,7 +1369,9 @@ def _run_one_site(name: str, url: str, cancel_event: threading.Event | None = No
     salaries = sum(1 for j in jobs if j.get("salary"))
     descs = sum(1 for j in jobs if _job_description_text(j))
     usable = sum(1 for j in jobs if j.get("title") and j.get("url") and _job_description_text(j))
-    status = "PASS" if total > 0 and usable / max(total, 1) >= 0.8 else "FAIL" if total == 0 or usable == 0 else "PARTIAL"
+    status = (
+        "PASS" if total > 0 and usable / max(total, 1) >= 0.8 else "FAIL" if total == 0 or usable == 0 else "PARTIAL"
+    )
     log.info(
         "RESULT: %s -- %d jobs, %d usable, %d titles, %d urls, %d salaries, %d descriptions",
         status,

--- a/workers/automation/src/jobctrl/domain/discovery/use_cases.py
+++ b/workers/automation/src/jobctrl/domain/discovery/use_cases.py
@@ -59,7 +59,11 @@ from jobctrl.domain.events import (
     create_job_restored,
     create_job_source_observed,
 )
-from jobctrl.domain.identifiers import JobId
+from jobctrl.domain.identifiers import (
+    JobId,
+    canonical_job_id,
+    generate_job_id,
+)
 from jobctrl.domain.job_content_identity import is_genuine_employer_identity
 from jobctrl.domain.ports.discovery import (
     ContentOwnerMatch,
@@ -234,6 +238,7 @@ class DiscoverJobsUseCase:
         run_id_factory: object | None = None,
         clock: object | None = None,
         observation_id_factory: Callable[[], str] | None = None,
+        job_id_factory: Callable[[], JobId] | None = None,
         republish_canonical_identity: bool = False,
     ) -> None:
         self._repository = repository
@@ -243,6 +248,7 @@ class DiscoverJobsUseCase:
         self._run_id_factory = run_id_factory or (lambda: f"run:{uuid.uuid4().hex}")
         self._clock = clock or (lambda: datetime.now(timezone.utc).isoformat())
         self._observation_id_factory = observation_id_factory or (lambda: f"obs:{uuid.uuid4().hex}")
+        self._job_id_factory = job_id_factory or generate_job_id
         self._republish_canonical_identity = republish_canonical_identity
 
     def execute(
@@ -355,7 +361,10 @@ class DiscoverJobsUseCase:
         observed_at: str,
     ) -> DiscoveryDecision:
         canonical_posting_url = PostingUrl(value=identity.canonical_url)
-        job_id = JobId(canonical_posting_url.value)
+        try:
+            job_id = canonical_job_id(str(self._job_id_factory()))
+        except ValueError as exc:
+            raise ValueError("job_id_factory must return a canonical UUID JobId") from exc
         job = Job.discover(
             tenant_id=tenant_id,
             job_id=job_id,
@@ -373,7 +382,27 @@ class DiscoverJobsUseCase:
             result="new_job",
             confidence=identity.confidence,
         ):
-            self._repository.save(job)
+            persisted_job_id = self._repository.save(job)
+            if persisted_job_id != job_id:
+                return self._observe_existing_job(
+                    tenant_id=tenant_id,
+                    posting=posting,
+                    identity=identity,
+                    owner_id=persisted_job_id,
+                    run_id=run_id,
+                    observation_id=observation_id,
+                    observed_at=observed_at,
+                )
+            persisted_identity = self._repository.resolve_by_job_id(
+                tenant_id,
+                persisted_job_id,
+            )
+            if persisted_identity is None:
+                raise LookupError("New Job disappeared before identity metadata was persisted")
+            # Durable events remain URL-keyed until the quiescent
+            # event/projection cutover in Phase 4. Child writes are translated
+            # through this physical compatibility key too.
+            legacy_job_key = persisted_identity.storage_url.value
             self._repository.set_canonical_identity(tenant_id, job_id, identity)
             self._repository.attach_source_observation(
                 tenant_id,
@@ -391,7 +420,7 @@ class DiscoverJobsUseCase:
             create_job_discovered(
                 tenant_id,
                 JobDiscoveredPayload(
-                    job_id=str(job_id),
+                    job_id=legacy_job_key,
                     posting_url=canonical_posting_url.value,
                     source=posting.source.board,
                     employer="Unknown",
@@ -404,7 +433,7 @@ class DiscoverJobsUseCase:
             create_canonical_job_identity_resolved(
                 tenant_id,
                 CanonicalJobIdentityResolvedPayload(
-                    job_id=str(job_id),
+                    job_id=legacy_job_key,
                     canonical_url=identity.canonical_url,
                     ats_kind=identity.ats_kind.value,
                     source_native_id=identity.source_native_id,
@@ -416,7 +445,7 @@ class DiscoverJobsUseCase:
             create_job_source_observed(
                 tenant_id,
                 JobSourceObservedPayload(
-                    job_id=str(job_id),
+                    job_id=legacy_job_key,
                     source_observation_id=observation_id,
                     source_id=posting.source_id,
                     source_native_id=identity.source_native_id,
@@ -451,7 +480,21 @@ class DiscoverJobsUseCase:
         content_matched = content_match is not None
         observed_url = identity.canonical_url or posting.posting_url.value
         normalized_observed = normalize_observed_url(observed_url)
-        is_distinct_url = normalized_observed != normalize_observed_url(str(owner_id)) and normalized_observed != ""
+        owner_identity = self._repository.resolve_by_job_id(
+            tenant_id,
+            owner_id,
+        )
+        if owner_identity is None:
+            raise LookupError(f"Canonical owner disappeared before observation: {owner_id!r}")
+        existing = self._repository.load(tenant_id, owner_id)
+        if existing is None:
+            raise LookupError(f"Canonical owner disappeared before observation: {owner_id!r}")
+        # See the new-job path above: downstream durable events keep their
+        # current URL identity until the event upcaster and projection cutover.
+        legacy_job_key = owner_identity.storage_url.value
+        is_distinct_url = (
+            normalized_observed != normalize_observed_url(existing.posting_url.value) and normalized_observed != ""
+        )
 
         if not content_matched and identity.confidence < MIN_AUTO_MERGE_CONFIDENCE and is_distinct_url:
             with dedupe_span(
@@ -465,6 +508,7 @@ class DiscoverJobsUseCase:
             self._record_and_publish_rejected_duplicate(
                 tenant_id=tenant_id,
                 owner_id=owner_id,
+                legacy_job_key=legacy_job_key,
                 candidate_url=observed_url,
                 reason="confidence_below_threshold",
                 rejected_at=observed_at,
@@ -484,6 +528,7 @@ class DiscoverJobsUseCase:
             return self._reject_content_matched_duplicate(
                 tenant_id=tenant_id,
                 owner_id=owner_id,
+                legacy_job_key=legacy_job_key,
                 observation_id=observation_id,
                 candidate_url=observed_url,
                 confidence=identity.confidence,
@@ -497,7 +542,6 @@ class DiscoverJobsUseCase:
             result="observed" if acceptance.accepted else "policy_rejected",
             confidence=identity.confidence,
         ):
-            existing = self._repository.load(tenant_id, owner_id)
             if existing is not None:
                 if self._republish_canonical_identity:
                     stored_identity = self._repository.load_canonical_identity(
@@ -514,7 +558,7 @@ class DiscoverJobsUseCase:
                         create_canonical_job_identity_resolved(
                             tenant_id,
                             CanonicalJobIdentityResolvedPayload(
-                                job_id=str(owner_id),
+                                job_id=legacy_job_key,
                                 canonical_url=identity.canonical_url,
                                 ats_kind=identity.ats_kind.value,
                                 source_native_id=identity.source_native_id,
@@ -528,6 +572,7 @@ class DiscoverJobsUseCase:
                         self._soft_delete_policy_rejected_job(
                             tenant_id=tenant_id,
                             job_id=owner_id,
+                            legacy_job_key=legacy_job_key,
                             reason=reason,
                             deleted_at=observed_at,
                         )
@@ -545,7 +590,7 @@ class DiscoverJobsUseCase:
                     )
                     self._publish_source_observed(
                         tenant_id=tenant_id,
-                        job_id=owner_id,
+                        legacy_job_key=legacy_job_key,
                         observation_id=observation_id,
                         posting=posting,
                         identity=identity,
@@ -572,7 +617,7 @@ class DiscoverJobsUseCase:
                             create_job_restored(
                                 tenant_id,
                                 JobRestoredPayload(
-                                    job_id=str(owner_id),
+                                    job_id=legacy_job_key,
                                     restored_at=observed_at,
                                 ),
                             )
@@ -593,7 +638,7 @@ class DiscoverJobsUseCase:
             )
         self._publish_source_observed(
             tenant_id=tenant_id,
-            job_id=owner_id,
+            legacy_job_key=legacy_job_key,
             observation_id=observation_id,
             posting=posting,
             identity=identity,
@@ -635,7 +680,7 @@ class DiscoverJobsUseCase:
                     tenant_id,
                     DuplicateJobLinkedPayload(
                         duplicate_link_id=duplicate_link_id,
-                        surviving_job_id=str(owner_id),
+                        surviving_job_id=legacy_job_key,
                         superseded_job_or_observation_id=observation_id,
                         reason=link.reason,
                         confidence=link_confidence,
@@ -658,6 +703,7 @@ class DiscoverJobsUseCase:
         *,
         tenant_id: TenantId,
         owner_id: JobId,
+        legacy_job_key: str,
         observation_id: str,
         candidate_url: str,
         confidence: float,
@@ -687,6 +733,7 @@ class DiscoverJobsUseCase:
         self._record_and_publish_rejected_duplicate(
             tenant_id=tenant_id,
             owner_id=owner_id,
+            legacy_job_key=legacy_job_key,
             candidate_url=candidate_url,
             reason=f"content_match_policy_rejected: {_policy_rejection_reason(acceptance)}",
             rejected_at=rejected_at,
@@ -703,6 +750,7 @@ class DiscoverJobsUseCase:
         *,
         tenant_id: TenantId,
         owner_id: JobId,
+        legacy_job_key: str,
         candidate_url: str,
         reason: str,
         rejected_at: str,
@@ -728,7 +776,7 @@ class DiscoverJobsUseCase:
                 tenant_id,
                 DuplicateJobLinkRejectedPayload(
                     duplicate_link_id=f"dup:{uuid.uuid4().hex}",
-                    job_id=str(owner_id),
+                    job_id=legacy_job_key,
                     candidate_job_id=candidate_url,
                     reason=reason,
                     rejected_at=rejected_at,
@@ -740,7 +788,7 @@ class DiscoverJobsUseCase:
         self,
         *,
         tenant_id: TenantId,
-        job_id: JobId,
+        legacy_job_key: str,
         observation_id: str,
         posting: ScrapedJobPosting,
         identity: CanonicalJobIdentity,
@@ -752,7 +800,7 @@ class DiscoverJobsUseCase:
             create_job_source_observed(
                 tenant_id,
                 JobSourceObservedPayload(
-                    job_id=str(job_id),
+                    job_id=legacy_job_key,
                     source_observation_id=observation_id,
                     source_id=posting.source_id,
                     source_native_id=identity.source_native_id,
@@ -768,6 +816,7 @@ class DiscoverJobsUseCase:
         *,
         tenant_id: TenantId,
         job_id: JobId,
+        legacy_job_key: str,
         reason: str,
         deleted_at: str,
     ) -> None:
@@ -783,7 +832,7 @@ class DiscoverJobsUseCase:
             create_job_deleted(
                 tenant_id,
                 JobDeletedPayload(
-                    job_id=str(job_id),
+                    job_id=legacy_job_key,
                     reason=reason,
                     deleted_at=deleted_at,
                 ),

--- a/workers/automation/src/jobctrl/domain/identifiers.py
+++ b/workers/automation/src/jobctrl/domain/identifiers.py
@@ -12,6 +12,17 @@ from typing import NewType
 JobId = NewType("JobId", str)
 
 
+def canonical_job_id(value: str) -> JobId:
+    """Return ``value`` as a JobId only when it is a canonical UUID."""
+    try:
+        parsed = uuid.UUID(value)
+    except (ValueError, AttributeError) as exc:
+        raise ValueError("JobId must be a canonical UUID") from exc
+    if str(parsed) != value:
+        raise ValueError("JobId must be a canonical UUID")
+    return JobId(value)
+
+
 def generate_job_id() -> JobId:
     """Generate a new random JobId using uuid4."""
     return JobId(str(uuid.uuid4()))

--- a/workers/automation/src/jobctrl/domain/ports/discovery.py
+++ b/workers/automation/src/jobctrl/domain/ports/discovery.py
@@ -75,6 +75,44 @@ class ContentOwnerMatch:
     basis: ContentMatchBasis
 
 
+@dataclass(frozen=True)
+class ResolvedJobIdentity:
+    """Stable identity, current locator, and legacy storage key for one Job.
+
+    ``job_id`` is the canonical aggregate identifier and ``posting_url`` is
+    the mutable current external locator. ``storage_url`` is the physical
+    ``jobs.url`` key retained only because compatibility-era child tables
+    still reference it. Keeping all three values in one typed result prevents
+    callers from treating either the UUID or a new locator as the legacy
+    storage key while those tables are migrated in later slices.
+    """
+
+    tenant_id: TenantId
+    job_id: JobId
+    posting_url: PostingUrl
+    storage_url: PostingUrl
+
+
+class JobIdentityResolver(Protocol):
+    """Resolve stable Job identities without exposing persistence details."""
+
+    def resolve_by_job_id(
+        self,
+        tenant_id: TenantId,
+        job_id: JobId,
+    ) -> ResolvedJobIdentity | None:
+        """Resolve a canonical aggregate identifier."""
+        ...
+
+    def resolve_by_posting_url(
+        self,
+        tenant_id: TenantId,
+        posting_url: PostingUrl,
+    ) -> ResolvedJobIdentity | None:
+        """Resolve a current or historical posting-URL alias."""
+        ...
+
+
 class JobBoardScraperPort(Protocol):
     """Driven port for external job-board scraping.
 
@@ -111,19 +149,19 @@ class JobBoardScraperPort(Protocol):
         ...
 
 
-class JobRepository(Protocol):
+class JobRepository(JobIdentityResolver, Protocol):
     """Persistence port for the ``Job`` aggregate.
 
-    All methods are tenant-scoped. Local adapters accept ``tenant_id``
-    and ignore the value (single-tenant); hosted adapters use it for row
-    isolation.
+    All methods are tenant-scoped. The local adapter persists and enforces
+    the tenant alongside stable identity even though local mode normally uses
+    one tenant.
 
     Dedup contract:
 
-      * ``save`` enforces the §4.1 invariant — duplicate
-        ``(tenant_id, posting_url)`` is rejected. Callers should
-        ``load_by_url`` first if they want to update an existing job
-        rather than insert a new one.
+      * ``save`` atomically claims a new posting URL or upserts the Job that
+        already owns the stable id. When a concurrent writer wins the same URL,
+        it returns that winner's stable ``JobId`` so the caller can re-enter
+        the existing-owner flow.
       * ``load_by_url`` returns the canonical ``Job`` for a posting URL,
         regardless of tombstone state, so the URL-resolution flow in
         enrichment can find the row even after a soft-delete.
@@ -137,14 +175,16 @@ class JobRepository(Protocol):
         """Return the Job whose ``posting_url`` matches, or ``None``."""
         ...
 
-    def save(self, job: Job) -> None:
+    def save(self, job: Job) -> JobId:
         """Persist the aggregate.
 
         Inserts on first save; subsequent saves with the same
         ``(tenant_id, job_id)`` perform an upsert that preserves
         ``discovered_at``. The repository is responsible for refusing
         a save whose ``(tenant_id, posting_url)`` collides with a
-        DIFFERENT ``job_id``.
+        DIFFERENT ``job_id``. Returns the persisted stable id, which can differ
+        from ``job.job_id`` only when another concurrent writer won the same
+        posting URL.
         """
         ...
 

--- a/workers/automation/src/jobctrl/infrastructure/discovery/__init__.py
+++ b/workers/automation/src/jobctrl/infrastructure/discovery/__init__.py
@@ -24,6 +24,9 @@ from jobctrl.infrastructure.discovery.ats_adapters import (
 from jobctrl.infrastructure.discovery.sqlite_repository import (
     SqliteJobRepository,
 )
+from jobctrl.infrastructure.discovery.sqlite_identity_resolver import (
+    SqliteJobIdentityResolver,
+)
 from jobctrl.infrastructure.discovery.sqlite_execution_repository import (
     SqliteDiscoveryExecutionRepository,
 )
@@ -62,6 +65,7 @@ __all__ = [
     "SqliteDiscoveryExecutionRepository",
     "SqliteDiscoverySearchUnitCheckpointStore",
     "SqliteDiscoverySearchUnitRepository",
+    "SqliteJobIdentityResolver",
     "SqliteJobRepository",
     "StaleDiscoverySearchUnitLease",
     "WorkdayBoardAdapter",

--- a/workers/automation/src/jobctrl/infrastructure/discovery/production_wiring.py
+++ b/workers/automation/src/jobctrl/infrastructure/discovery/production_wiring.py
@@ -663,16 +663,26 @@ def _promote_ats_source_description_to_enrichment(
         source_native_id=identity.source_native_id,
         canonical_url=identity.canonical_url,
     ) or JobId(identity.canonical_url or posting.posting_url.value)
-    if job_repository.load(LOCAL_TENANT, job_id) is None:
+    job = job_repository.load(LOCAL_TENANT, job_id)
+    if job is None:
         return False
+    resolved_job = job_repository.resolve_by_job_id(
+        LOCAL_TENANT,
+        job.job_id,
+    )
+    if resolved_job is None:
+        return False
+    # Enrichment and stage tables remain URL-keyed until their dedicated
+    # migration slice. Do not leak the stable UUID into those child tables.
+    legacy_job_id = JobId(resolved_job.storage_url.value)
 
-    existing = enrichment_repository.load(LOCAL_TENANT, job_id)
+    existing = enrichment_repository.load(LOCAL_TENANT, legacy_job_id)
     if existing is not None and (existing.is_enriched or existing.is_running):
         return False
 
     base = existing or JobEnrichment.empty(
         tenant_id=LOCAL_TENANT,
-        job_id=job_id,
+        job_id=legacy_job_id,
         updated_at=observed_at,
     )
     succeeded = base.start_attempt(
@@ -686,7 +696,7 @@ def _promote_ats_source_description_to_enrichment(
     )
     enrichment_repository.save(succeeded)
 
-    job_url = str(job_id)
+    job_url = resolved_job.storage_url.value
     ensure_job_stage_rows(conn, job_url, discovered_at=observed_at)
     stage_row = conn.execute(
         "SELECT state FROM job_stage_states WHERE job_url = ? AND stage = 'enrich'",

--- a/workers/automation/src/jobctrl/infrastructure/discovery/sqlite_identity_resolver.py
+++ b/workers/automation/src/jobctrl/infrastructure/discovery/sqlite_identity_resolver.py
@@ -1,0 +1,113 @@
+"""SQLite adapter for stable Job identity resolution."""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import Any
+
+from jobctrl.domain.discovery.value_objects import PostingUrl
+from jobctrl.domain.identifiers import JobId
+from jobctrl.domain.ports.discovery import ResolvedJobIdentity
+from jobctrl.domain.tenant import TenantId
+
+
+_CURRENT_POSTING_URL_SQL = """
+COALESCE(
+    (
+        SELECT storage_alias.alias_value
+        FROM job_identity_aliases storage_alias
+        WHERE storage_alias.tenant_id = j.tenant_id
+          AND storage_alias.alias_kind = 'posting_url'
+          AND storage_alias.job_id = j.job_id
+          AND storage_alias.alias_value = j.url
+          AND storage_alias.retired_at IS NULL
+        LIMIT 1
+    ),
+    (
+        SELECT current_alias.alias_value
+        FROM job_identity_aliases current_alias
+        WHERE current_alias.tenant_id = j.tenant_id
+          AND current_alias.alias_kind = 'posting_url'
+          AND current_alias.job_id = j.job_id
+          AND current_alias.retired_at IS NULL
+        ORDER BY
+            current_alias.created_at DESC,
+            current_alias.alias_value ASC
+        LIMIT 1
+    ),
+    j.url
+)
+"""
+
+
+class SqliteJobIdentityResolver:
+    """Resolve UUID-backed Job identities and their posting-URL aliases."""
+
+    def __init__(self, conn: sqlite3.Connection) -> None:
+        self._conn = conn
+
+    def resolve_by_job_id(
+        self,
+        tenant_id: TenantId,
+        job_id: JobId,
+    ) -> ResolvedJobIdentity | None:
+        row = self._conn.execute(
+            f"""
+            SELECT
+                j.tenant_id,
+                j.job_id,
+                {_CURRENT_POSTING_URL_SQL} AS posting_url,
+                j.url AS storage_url
+            FROM jobs j
+            WHERE j.tenant_id = ? AND j.job_id = ?
+            LIMIT 1
+            """,
+            (str(tenant_id), str(job_id)),
+        ).fetchone()
+        return _resolved_identity(row)
+
+    def resolve_by_posting_url(
+        self,
+        tenant_id: TenantId,
+        posting_url: PostingUrl,
+    ) -> ResolvedJobIdentity | None:
+        row = self._conn.execute(
+            f"""
+            SELECT
+                j.tenant_id,
+                j.job_id,
+                {_CURRENT_POSTING_URL_SQL} AS posting_url,
+                j.url AS storage_url
+            FROM job_identity_aliases a
+            JOIN jobs j
+              ON j.tenant_id = a.tenant_id
+             AND j.job_id = a.job_id
+            WHERE a.tenant_id = ?
+              AND a.alias_kind = 'posting_url'
+              AND a.alias_value = ?
+            LIMIT 1
+            """,
+            (str(tenant_id), posting_url.value),
+        ).fetchone()
+        return _resolved_identity(row)
+
+
+def _resolved_identity(row: Any | None) -> ResolvedJobIdentity | None:
+    if row is None:
+        return None
+    if isinstance(row, sqlite3.Row):
+        tenant_id = row["tenant_id"]
+        job_id = row["job_id"]
+        posting_url = row["posting_url"]
+        storage_url = row["storage_url"]
+    else:
+        tenant_id, job_id, posting_url, storage_url = row
+    return ResolvedJobIdentity(
+        tenant_id=TenantId(str(tenant_id)),
+        job_id=JobId(str(job_id)),
+        posting_url=PostingUrl(value=str(posting_url)),
+        storage_url=PostingUrl(value=str(storage_url)),
+    )
+
+
+__all__ = ["SqliteJobIdentityResolver"]

--- a/workers/automation/src/jobctrl/infrastructure/discovery/sqlite_repository.py
+++ b/workers/automation/src/jobctrl/infrastructure/discovery/sqlite_repository.py
@@ -5,7 +5,9 @@ new table is introduced this phase per the migration plan §8 deferred
 scope). The adapter touches only the discovery-owned columns of the
 table:
 
-  ``url``           — ``Job.posting_url`` (still the legacy PRIMARY KEY).
+  ``tenant_id``     — tenant boundary for the aggregate.
+  ``job_id``        — stable, system-generated aggregate identifier.
+  ``url``           — legacy storage key (still the physical PRIMARY KEY).
   ``title``,
   ``salary``,
   ``description``,
@@ -53,15 +55,26 @@ from jobctrl.domain.discovery.value_objects import (
     SearchStrategy,
     Source,
 )
-from jobctrl.domain.identifiers import JobId
+from jobctrl.domain.identifiers import (
+    JobId,
+    canonical_job_id,
+    generate_job_id,
+)
 from jobctrl.domain.job_content_identity import (
     content_match_basis,
     is_genuine_employer_identity,
     job_content_fingerprint,
     normalize_identity_text,
 )
-from jobctrl.domain.ports.discovery import ContentOwnerMatch
-from jobctrl.domain.tenant import LOCAL_TENANT, TenantId
+from jobctrl.domain.ports.discovery import (
+    ContentOwnerMatch,
+    JobIdentityResolver,
+    ResolvedJobIdentity,
+)
+from jobctrl.domain.tenant import TenantId
+from jobctrl.infrastructure.discovery.sqlite_identity_resolver import (
+    SqliteJobIdentityResolver,
+)
 
 
 class JobUrlConflict(ValueError):
@@ -95,6 +108,7 @@ class SqliteJobRepository:
         discovery_execution: DiscoveryExecutionRef | None = None,
         source_family: str | None = None,
         search_unit_lease: DiscoverySearchUnitLease | None = None,
+        identity_resolver: JobIdentityResolver | None = None,
     ) -> None:
         if search_unit_lease is not None:
             if discovery_execution is None:
@@ -105,6 +119,7 @@ class SqliteJobRepository:
         self._discovery_execution = discovery_execution
         self._source_family = source_family.strip() if source_family else None
         self._search_unit_lease = search_unit_lease
+        self._identity_resolver = identity_resolver or SqliteJobIdentityResolver(conn)
         if discovery_execution is not None and self._source_family is None:
             raise ValueError("source_family is required with discovery_execution")
         self._ensure_deleted_jobs_table()
@@ -154,16 +169,37 @@ class SqliteJobRepository:
     # Read
     # ------------------------------------------------------------------
 
-    def load(self, tenant_id: TenantId, job_id: JobId) -> Job | None:
-        """Return a Job by aggregate id.
+    def resolve_by_job_id(
+        self,
+        tenant_id: TenantId,
+        job_id: JobId,
+    ) -> ResolvedJobIdentity | None:
+        return self._identity_resolver.resolve_by_job_id(tenant_id, job_id)
 
-        Local mode collapses ``JobId`` and ``PostingUrl`` onto the same
-        ``jobs.url`` column (per migration plan §8: stable ``JobId``
-        narrowing is deferred), so ``load`` and ``load_by_url`` use the
-        same lookup. The cloud cutover swaps in a system-generated UUID
-        column without touching the port.
+    def resolve_by_posting_url(
+        self,
+        tenant_id: TenantId,
+        posting_url: PostingUrl,
+    ) -> ResolvedJobIdentity | None:
+        return self._identity_resolver.resolve_by_posting_url(
+            tenant_id,
+            posting_url,
+        )
+
+    def load(self, tenant_id: TenantId, job_id: JobId) -> Job | None:
+        """Return a Job by stable id.
+
+        URL-shaped ``JobId`` values remain accepted only at this repository
+        boundary while legacy callers are migrated. They are resolved through
+        the alias index and the hydrated aggregate always carries its UUID.
         """
-        return self.load_by_url(tenant_id, PostingUrl(value=str(job_id)))
+        identity = self.resolve_by_job_id(tenant_id, job_id)
+        if identity is not None:
+            return self._load_resolved(identity)
+        return self.load_by_url(
+            tenant_id,
+            PostingUrl(value=str(job_id)),
+        )
 
     def load_by_url(self, tenant_id: TenantId, posting_url: PostingUrl) -> Job | None:
         """Resolve a posting URL to its canonical Job aggregate.
@@ -180,22 +216,9 @@ class SqliteJobRepository:
              we still want to find the canonical Job that owns it.
         """
 
-        row = self._conn.execute(
-            """
-            SELECT j.url, j.title, j.salary, j.description, j.location,
-                   j.site, j.strategy, j.discovered_at,
-                   d.deleted_at, d.reason
-            FROM jobs j
-            LEFT JOIN jobctrl_deleted_jobs d
-              ON d.job_url = j.url
-             AND (d.restored_at IS NULL OR julianday(d.restored_at) <= julianday(d.deleted_at))
-            WHERE j.url = ?
-            LIMIT 1
-            """,
-            (posting_url.value,),
-        ).fetchone()
-        if row is not None:
-            return self._row_to_job(row, tenant_id)
+        identity = self.resolve_by_posting_url(tenant_id, posting_url)
+        if identity is not None:
+            return self._load_resolved(identity)
 
         # Fall back to the observation index — this is the
         # compatibility seam that lets a broad-board URL resolve to
@@ -205,23 +228,23 @@ class SqliteJobRepository:
             return None
         row = self._conn.execute(
             """
-            SELECT j.url, j.title, j.salary, j.description, j.location,
-                   j.site, j.strategy, j.discovered_at,
-                   d.deleted_at, d.reason
+            SELECT j.job_id
             FROM jobs j
             JOIN job_source_observations o
               ON o.job_url = j.url AND o.tenant_id = ?
-            LEFT JOIN jobctrl_deleted_jobs d
-              ON d.job_url = j.url
-             AND (d.restored_at IS NULL OR julianday(d.restored_at) <= julianday(d.deleted_at))
-            WHERE o.normalized_observed_url = ?
+            WHERE j.tenant_id = ?
+              AND o.normalized_observed_url = ?
             LIMIT 1
             """,
-            (str(tenant_id), normalized),
+            (str(tenant_id), str(tenant_id), normalized),
         ).fetchone()
         if row is None:
             return None
-        return self._row_to_job(row, tenant_id)
+        resolved_job_id = JobId(str(row["job_id"])) if isinstance(row, sqlite3.Row) else JobId(str(row[0]))
+        identity = self.resolve_by_job_id(tenant_id, resolved_job_id)
+        if identity is None:
+            return None
+        return self._load_resolved(identity)
 
     def list_recent(
         self,
@@ -232,33 +255,48 @@ class SqliteJobRepository:
     ) -> list[Job]:
         if not include_deleted:
             sql = (
-                "SELECT j.url, j.title, j.salary, j.description, j.location, "
+                "SELECT j.tenant_id, j.job_id, j.url, "
+                "j.title, j.salary, j.description, j.location, "
                 "j.site, j.strategy, j.discovered_at, "
                 "d.deleted_at, d.reason "
                 "FROM jobs j "
                 "LEFT JOIN jobctrl_deleted_jobs d "
                 "  ON d.job_url = j.url "
                 " AND (d.restored_at IS NULL OR julianday(d.restored_at) <= julianday(d.deleted_at)) "
-                "WHERE d.job_url IS NULL "
+                "WHERE j.tenant_id = ? AND d.job_url IS NULL "
                 "ORDER BY j.discovered_at DESC NULLS LAST"
             )
         else:
             sql = (
-                "SELECT j.url, j.title, j.salary, j.description, j.location, "
+                "SELECT j.tenant_id, j.job_id, j.url, "
+                "j.title, j.salary, j.description, j.location, "
                 "j.site, j.strategy, j.discovered_at, "
                 "d.deleted_at, d.reason "
                 "FROM jobs j "
                 "LEFT JOIN jobctrl_deleted_jobs d "
                 "  ON d.job_url = j.url "
                 " AND (d.restored_at IS NULL OR julianday(d.restored_at) <= julianday(d.deleted_at)) "
+                "WHERE j.tenant_id = ? "
                 "ORDER BY j.discovered_at DESC NULLS LAST"
             )
-        params: list[Any] = []
+        params: list[Any] = [str(tenant_id)]
         if limit > 0:
             sql += " LIMIT ?"
             params.append(limit)
         rows = self._conn.execute(sql, params).fetchall()
-        return [self._row_to_job(row, tenant_id) for row in rows]
+        jobs: list[Job] = []
+        for row in rows:
+            row_job_id = JobId(str(row["job_id"])) if isinstance(row, sqlite3.Row) else JobId(str(row[1]))
+            identity = self.resolve_by_job_id(tenant_id, row_job_id)
+            if identity is None:
+                continue
+            jobs.append(
+                self._row_to_job(
+                    row,
+                    posting_url=identity.posting_url,
+                )
+            )
+        return jobs
 
     # ------------------------------------------------------------------
     # Write
@@ -270,69 +308,222 @@ class SqliteJobRepository:
         assert self._search_unit_lease is not None
         self._search_unit_repository.fence_write(self._search_unit_lease)
 
-    def save(self, job: Job) -> None:
-        """Insert / upsert a Job into the wide ``jobs`` table.
+    def save(self, job: Job) -> JobId:
+        """Persist ``job`` and leave no partial compatibility write on failure."""
 
-        Enforces the §4.1 dedup invariant in two ways:
+        try:
+            return self._save(job)
+        except BaseException:
+            self._conn.rollback()
+            raise
 
-          * If the URL already exists, the row's ``job_id`` (the URL
-            itself in local mode) MUST match — otherwise the call is
-            illegal.
-          * The upsert preserves ``discovered_at`` for already-known
-            URLs so a re-discovery doesn't reset the discovery
-            timestamp.
+    def _save(self, job: Job) -> JobId:
+        """Atomically insert or upsert a Job and return its stable owner id.
+
+        ``jobs.url`` remains the compatibility-era storage key for URL-keyed
+        child tables. A stable-id upsert may change the aggregate's current
+        ``posting_url`` by moving the active alias without rewriting that
+        physical key. URL-shaped ids are accepted only as lookup input and
+        cannot promote a historical alias back to current.
+
+        If another writer wins a first insert for the same posting URL after
+        this call's initial read, the unique constraints arbitrate ownership.
+        The losing call returns the winner's stable id instead of leaking a raw
+        ``sqlite3.IntegrityError``.
         """
-        existing = self._conn.execute(
-            "SELECT url, discovered_at FROM jobs WHERE url = ?",
-            (job.posting_url.value,),
-        ).fetchone()
-        was_new = existing is None
+        is_legacy_url_input = str(job.job_id) == job.posting_url.value
+        supplied_job_id: JobId | None
+        try:
+            supplied_job_id = canonical_job_id(str(job.job_id))
+        except ValueError:
+            if not is_legacy_url_input:
+                raise ValueError(
+                    "New Job.job_id must be a canonical UUID; "
+                    "URL-shaped ids are accepted only when equal to posting_url"
+                )
+            supplied_job_id = None
+
+        stable_owner = self.resolve_by_job_id(job.tenant_id, supplied_job_id) if supplied_job_id is not None else None
+        url_owner = self.resolve_by_posting_url(
+            job.tenant_id,
+            job.posting_url,
+        )
+        # Identity discovery is read-only. Fence immediately before the first
+        # possible mutation so parallel search units can both reach the atomic
+        # URL claim and the unique constraint can select one stable owner.
         self._fence_search_unit_write()
 
-        if existing is not None:
-            existing_url = existing["url"] if isinstance(existing, sqlite3.Row) else existing[0]
-            if existing_url != str(job.job_id):
+        if stable_owner is not None:
+            if url_owner is not None and url_owner.job_id != stable_owner.job_id:
                 raise JobUrlConflict(
                     posting_url=job.posting_url,
-                    owner=JobId(str(existing_url)),
-                    attempted=job.job_id,
+                    owner=url_owner.job_id,
+                    attempted=stable_owner.job_id,
                 )
-            existing_discovered_at = existing["discovered_at"] if isinstance(existing, sqlite3.Row) else existing[1]
-            preserved_discovered_at = existing_discovered_at or job.discovered_at
-            self._conn.execute(
-                """
-                UPDATE jobs SET
-                    title = ?,
-                    company = COALESCE(NULLIF(company, ''), ?),
-                    salary = ?,
-                    description = ?,
-                    location = ?,
-                    site = ?,
-                    strategy = ?,
-                    discovered_at = ?
-                WHERE url = ?
-                """,
-                (
-                    job.metadata.title,
-                    None if job.employer.is_unknown() else job.employer.name,
-                    job.metadata.salary,
-                    job.metadata.description,
-                    job.metadata.location,
-                    job.source.board,
-                    job.search_strategy.value,
-                    preserved_discovered_at,
-                    job.posting_url.value,
-                ),
+            persisted_identity = self._set_current_posting_url(
+                stable_owner,
+                job.posting_url,
             )
+            self._update_existing_job(job, persisted_identity)
+            was_new = False
+        elif url_owner is not None:
+            if supplied_job_id is not None and supplied_job_id != url_owner.job_id:
+                raise JobUrlConflict(
+                    posting_url=job.posting_url,
+                    owner=url_owner.job_id,
+                    attempted=supplied_job_id,
+                )
+            # A URL-shaped compatibility save resolves the owner but never
+            # changes which alias is the current external locator.
+            persisted_identity = url_owner
+            self._update_existing_job(job, persisted_identity)
+            was_new = False
         else:
+            candidate_job_id = supplied_job_id or generate_job_id()
+            persisted_identity, was_new = self._insert_or_resolve_winner(
+                job,
+                candidate_job_id,
+            )
+            if not was_new:
+                # No candidate state belongs on a concurrently-created owner.
+                # The application use case re-enters its existing-owner flow.
+                self._conn.commit()
+                return persisted_identity.job_id
+
+        self._sync_tombstone(job, persisted_identity)
+        if self._search_unit_repository is not None:
+            assert self._search_unit_lease is not None
+            self._search_unit_repository.record_accepted_job(
+                self._search_unit_lease,
+                persisted_identity.storage_url.value,
+                was_new=was_new,
+                accepted_at=job.discovered_at,
+            )
+        self._conn.commit()
+        return persisted_identity.job_id
+
+    def _set_current_posting_url(
+        self,
+        identity: ResolvedJobIdentity,
+        posting_url: PostingUrl,
+    ) -> ResolvedJobIdentity:
+        """Move the current locator while preserving the legacy storage key."""
+
+        if posting_url == identity.posting_url:
+            return identity
+        changed_at = datetime.now(timezone.utc).isoformat()
+        claimed = self._conn.execute(
+            """
+            INSERT INTO job_identity_aliases (
+                tenant_id, alias_kind, alias_value, job_id, created_at, retired_at
+            ) VALUES (?, 'posting_url', ?, ?, ?, NULL)
+            ON CONFLICT (tenant_id, alias_kind, alias_value) DO UPDATE SET
+                retired_at = NULL
+            WHERE job_identity_aliases.job_id = excluded.job_id
+            """,
+            (
+                str(identity.tenant_id),
+                posting_url.value,
+                str(identity.job_id),
+                changed_at,
+            ),
+        )
+        if claimed.rowcount != 1:
+            owner = self.resolve_by_posting_url(identity.tenant_id, posting_url)
+            if owner is not None:
+                raise JobUrlConflict(
+                    posting_url=posting_url,
+                    owner=owner.job_id,
+                    attempted=identity.job_id,
+                )
+            raise RuntimeError("Posting URL alias claim failed without a resolvable owner")
+        self._conn.execute(
+            """
+            UPDATE job_identity_aliases
+            SET retired_at = ?
+            WHERE tenant_id = ?
+              AND alias_kind = 'posting_url'
+              AND job_id = ?
+              AND alias_value != ?
+              AND retired_at IS NULL
+            """,
+            (
+                changed_at,
+                str(identity.tenant_id),
+                str(identity.job_id),
+                posting_url.value,
+            ),
+        )
+        return ResolvedJobIdentity(
+            tenant_id=identity.tenant_id,
+            job_id=identity.job_id,
+            posting_url=posting_url,
+            storage_url=identity.storage_url,
+        )
+
+    def _update_existing_job(
+        self,
+        job: Job,
+        identity: ResolvedJobIdentity,
+    ) -> None:
+        existing = self._conn.execute(
+            """
+            SELECT discovered_at
+            FROM jobs
+            WHERE tenant_id = ? AND job_id = ?
+            LIMIT 1
+            """,
+            (str(identity.tenant_id), str(identity.job_id)),
+        ).fetchone()
+        if existing is None:
+            raise LookupError("Stable Job owner disappeared before repository upsert")
+        existing_discovered_at = existing["discovered_at"] if isinstance(existing, sqlite3.Row) else existing[0]
+        preserved_discovered_at = existing_discovered_at or job.discovered_at
+        self._conn.execute(
+            """
+            UPDATE jobs SET
+                title = ?,
+                company = COALESCE(NULLIF(company, ''), ?),
+                salary = ?,
+                description = ?,
+                location = ?,
+                site = ?,
+                strategy = ?,
+                discovered_at = ?
+            WHERE tenant_id = ? AND job_id = ?
+            """,
+            (
+                job.metadata.title,
+                None if job.employer.is_unknown() else job.employer.name,
+                job.metadata.salary,
+                job.metadata.description,
+                job.metadata.location,
+                job.source.board,
+                job.search_strategy.value,
+                preserved_discovered_at,
+                str(identity.tenant_id),
+                str(identity.job_id),
+            ),
+        )
+
+    def _insert_or_resolve_winner(
+        self,
+        job: Job,
+        candidate_job_id: JobId,
+    ) -> tuple[ResolvedJobIdentity, bool]:
+        """Claim a first URL, returning a concurrent winner when one exists."""
+
+        try:
             self._conn.execute(
                 """
                 INSERT INTO jobs (
-                    url, title, company, salary, description, location,
-                    site, strategy, discovered_at
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    tenant_id, job_id, url, title, company, salary,
+                    description, location, site, strategy, discovered_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
+                    str(job.tenant_id),
+                    str(candidate_job_id),
                     job.posting_url.value,
                     job.metadata.title,
                     None if job.employer.is_unknown() else job.employer.name,
@@ -344,16 +535,53 @@ class SqliteJobRepository:
                     job.discovered_at,
                 ),
             )
-        self._sync_tombstone(job)
-        if self._search_unit_repository is not None:
-            assert self._search_unit_lease is not None
-            self._search_unit_repository.record_accepted_job(
-                self._search_unit_lease,
-                job.posting_url.value,
-                was_new=was_new,
-                accepted_at=job.discovered_at,
+        except sqlite3.IntegrityError:
+            winner = self.resolve_by_posting_url(
+                job.tenant_id,
+                job.posting_url,
             )
-        self._conn.commit()
+            if winner is not None:
+                return winner, False
+
+            stable_winner = self.resolve_by_job_id(
+                job.tenant_id,
+                candidate_job_id,
+            )
+            if stable_winner is not None:
+                url_owner = self.resolve_by_posting_url(
+                    job.tenant_id,
+                    job.posting_url,
+                )
+                if url_owner is not None and url_owner.job_id != candidate_job_id:
+                    raise JobUrlConflict(
+                        posting_url=job.posting_url,
+                        owner=url_owner.job_id,
+                        attempted=candidate_job_id,
+                    )
+                stable_winner = self._set_current_posting_url(
+                    stable_winner,
+                    job.posting_url,
+                )
+                self._update_existing_job(job, stable_winner)
+                return stable_winner, False
+
+            global_owner = self._conn.execute(
+                "SELECT job_id FROM jobs WHERE url = ? LIMIT 1",
+                (job.posting_url.value,),
+            ).fetchone()
+            if global_owner is not None:
+                owner_job_id = global_owner["job_id"] if isinstance(global_owner, sqlite3.Row) else global_owner[0]
+                raise JobUrlConflict(
+                    posting_url=job.posting_url,
+                    owner=JobId(str(owner_job_id)),
+                    attempted=candidate_job_id,
+                )
+            raise
+
+        identity = self.resolve_by_job_id(job.tenant_id, candidate_job_id)
+        if identity is None:
+            raise RuntimeError("Inserted Job is missing its stable identity alias")
+        return identity, True
 
     def soft_delete(
         self,
@@ -366,6 +594,7 @@ class SqliteJobRepository:
         existing = self.load(tenant_id, job_id)
         if existing is None:
             return None
+        identity = self._require_identity(tenant_id, existing.job_id)
         self._fence_search_unit_write()
         deleted = existing.soft_delete(reason=reason, deleted_at=deleted_at)
         self._conn.execute(
@@ -377,7 +606,11 @@ class SqliteJobRepository:
                 reason = excluded.reason,
                 restored_at = NULL
             """,
-            (str(deleted.job_id), deleted.deleted_at, deleted.delete_reason),
+            (
+                identity.storage_url.value,
+                deleted.deleted_at,
+                deleted.delete_reason,
+            ),
         )
         self._conn.commit()
         return deleted
@@ -392,6 +625,7 @@ class SqliteJobRepository:
         existing = self.load(tenant_id, job_id)
         if existing is None:
             return None
+        identity = self._require_identity(tenant_id, existing.job_id)
         self._fence_search_unit_write()
         restored = existing.restore()
         restore_timestamp = _restore_timestamp(restored_at, deleted_at=existing.deleted_at)
@@ -402,7 +636,7 @@ class SqliteJobRepository:
             "UPDATE jobctrl_deleted_jobs SET restored_at = ? "
             "WHERE job_url = ? "
             "AND (restored_at IS NULL OR julianday(restored_at) <= julianday(deleted_at))",
-            (restore_timestamp, str(restored.job_id)),
+            (restore_timestamp, identity.storage_url.value),
         )
         self._conn.commit()
         return restored
@@ -429,58 +663,67 @@ class SqliteJobRepository:
         if source_id and source_native_id:
             row = self._conn.execute(
                 """
-                SELECT job_url FROM job_source_observations
-                WHERE tenant_id = ? AND source_id = ? AND source_native_id = ?
+                SELECT j.job_id
+                FROM job_source_observations o
+                JOIN jobs j
+                  ON j.tenant_id = o.tenant_id
+                 AND j.url = o.job_url
+                WHERE o.tenant_id = ?
+                  AND o.source_id = ?
+                  AND o.source_native_id = ?
                 LIMIT 1
                 """,
                 (str(tenant_id), source_id, source_native_id),
             ).fetchone()
             if row is not None:
-                job_url = row["job_url"] if isinstance(row, sqlite3.Row) else row[0]
-                if job_url:
-                    return JobId(str(job_url))
+                job_id = row["job_id"] if isinstance(row, sqlite3.Row) else row[0]
+                if job_id:
+                    return JobId(str(job_id))
 
         if canonical_url:
-            row = self._conn.execute(
-                """
-                SELECT url FROM jobs
-                WHERE url = ?
-                LIMIT 1
-                """,
-                (canonical_url,),
-            ).fetchone()
-            if row is not None:
-                job_url = row["url"] if isinstance(row, sqlite3.Row) else row[0]
-                if job_url:
-                    return JobId(str(job_url))
+            direct = self._identity_resolver.resolve_by_posting_url(
+                tenant_id,
+                PostingUrl(value=canonical_url),
+            )
+            if direct is not None:
+                return direct.job_id
 
             row = self._conn.execute(
                 """
-                SELECT job_url FROM job_canonical_identities
-                WHERE tenant_id = ? AND canonical_url = ?
+                SELECT j.job_id
+                FROM job_canonical_identities c
+                JOIN jobs j
+                  ON j.tenant_id = c.tenant_id
+                 AND j.url = c.job_url
+                WHERE c.tenant_id = ? AND c.canonical_url = ?
                 LIMIT 1
                 """,
                 (str(tenant_id), canonical_url),
             ).fetchone()
             if row is not None:
-                job_url = row["job_url"] if isinstance(row, sqlite3.Row) else row[0]
-                if job_url:
-                    return JobId(str(job_url))
+                job_id = row["job_id"] if isinstance(row, sqlite3.Row) else row[0]
+                if job_id:
+                    return JobId(str(job_id))
 
             normalized = normalize_observed_url(canonical_url)
             if normalized:
                 row = self._conn.execute(
                     """
-                    SELECT job_url FROM job_source_observations
-                    WHERE tenant_id = ? AND normalized_observed_url = ?
+                    SELECT j.job_id
+                    FROM job_source_observations o
+                    JOIN jobs j
+                      ON j.tenant_id = o.tenant_id
+                     AND j.url = o.job_url
+                    WHERE o.tenant_id = ?
+                      AND o.normalized_observed_url = ?
                     LIMIT 1
                     """,
                     (str(tenant_id), normalized),
                 ).fetchone()
                 if row is not None:
-                    job_url = row["job_url"] if isinstance(row, sqlite3.Row) else row[0]
-                    if job_url:
-                        return JobId(str(job_url))
+                    job_id = row["job_id"] if isinstance(row, sqlite3.Row) else row[0]
+                    if job_id:
+                        return JobId(str(job_id))
 
         return None
 
@@ -530,7 +773,7 @@ class SqliteJobRepository:
         self._conn.create_function("jh_normalize_identity", 1, normalize_identity_text, deterministic=True)
         rows = self._conn.execute(
             """
-            SELECT j.url, j.title, j.company, j.site,
+            SELECT j.job_id, j.url, j.title, j.company, j.site,
                    j.description AS listing_description,
                    COALESCE(je.full_description, j.full_description)
                        AS enriched_description,
@@ -540,11 +783,16 @@ class SqliteJobRepository:
             LEFT JOIN jobctrl_deleted_jobs d
               ON d.job_url = j.url
              AND (d.restored_at IS NULL OR julianday(d.restored_at) <= julianday(d.deleted_at))
-            WHERE jh_normalize_identity(COALESCE(j.title, '')) = ?
+            WHERE j.tenant_id = ?
+              AND jh_normalize_identity(COALESCE(j.title, '')) = ?
               AND jh_normalize_identity(COALESCE(NULLIF(j.company, ''), j.site, '')) = ?
             ORDER BY is_deleted ASC, j.discovered_at ASC NULLS LAST, j.url ASC
             """,
-            (normalize_identity_text(title), normalize_identity_text(company)),
+            (
+                str(tenant_id),
+                normalize_identity_text(title),
+                normalize_identity_text(company),
+            ),
         ).fetchall()
         for existing in rows:
             stored_company = existing["company"]
@@ -562,7 +810,7 @@ class SqliteJobRepository:
                 ),
             )
             if basis is not None:
-                return ContentOwnerMatch(job_id=JobId(str(existing["url"])), basis=basis)
+                return ContentOwnerMatch(job_id=JobId(str(existing["job_id"])), basis=basis)
         return None
 
     def attach_source_observation(
@@ -580,6 +828,8 @@ class SqliteJobRepository:
         also collapses cosmetic URL variants.
         """
 
+        identity = self._require_identity(tenant_id, job_id)
+        job_url = identity.storage_url.value
         self._fence_search_unit_write()
         normalized = normalize_observed_url(observation.observed_url)
         updated = self._conn.execute(
@@ -595,7 +845,7 @@ class SqliteJobRepository:
             """,
             (
                 observation.source_observation_id,
-                str(job_id),
+                job_url,
                 observation.observed_url,
                 normalized,
                 observation.run_id,
@@ -620,7 +870,7 @@ class SqliteJobRepository:
                 """,
                 (
                     observation.source_observation_id,
-                    str(job_id),
+                    job_url,
                     observation.source_id,
                     observation.source_native_id,
                     observation.observed_url,
@@ -642,7 +892,7 @@ class SqliteJobRepository:
                 (
                     str(tenant_id),
                     observation.source_observation_id,
-                    str(job_id),
+                    job_url,
                     observation.source_id,
                     observation.source_native_id,
                     observation.observed_url,
@@ -655,7 +905,7 @@ class SqliteJobRepository:
             assert self._search_unit_lease is not None
             self._search_unit_repository.record_accepted_job(
                 self._search_unit_lease,
-                str(job_id),
+                job_url,
                 was_new=False,
                 accepted_at=observation.observed_at,
             )
@@ -669,7 +919,7 @@ class SqliteJobRepository:
             # updated independently in ``job_source_observations`` on retries.
             self._execution_repository.link_job(
                 self._discovery_execution,
-                str(job_id),
+                job_url,
                 cohort_kind="observed_this_run",
                 source_family=self._source_family,
                 source_run_id=observation.run_id,
@@ -685,6 +935,7 @@ class SqliteJobRepository:
     ) -> None:
         """Persist (or replace) the canonical identity decision for a Job."""
 
+        resolved = self._require_identity(tenant_id, job_id)
         self._fence_search_unit_write()
         self._conn.execute(
             """
@@ -701,7 +952,7 @@ class SqliteJobRepository:
             """,
             (
                 str(tenant_id),
-                str(job_id),
+                resolved.storage_url.value,
                 identity.canonical_url,
                 identity.ats_kind.value,
                 identity.source_native_id,
@@ -718,6 +969,10 @@ class SqliteJobRepository:
     ) -> None:
         """Persist a confirmed duplicate-link audit record."""
 
+        owner = self._require_identity(
+            tenant_id,
+            JobId(link.surviving_job_id),
+        )
         self._fence_search_unit_write()
         self._conn.execute(
             """
@@ -737,7 +992,7 @@ class SqliteJobRepository:
             (
                 str(tenant_id),
                 link.duplicate_link_id,
-                link.surviving_job_id,
+                owner.storage_url.value,
                 link.superseded_job_or_observation_id,
                 link.reason,
                 float(link.confidence),
@@ -764,6 +1019,7 @@ class SqliteJobRepository:
         mint a fresh event row (audit noise).
         """
 
+        owner = self._require_identity(tenant_id, owner_job_id)
         self._fence_search_unit_write()
         before = self._conn.total_changes
         self._conn.execute(
@@ -773,7 +1029,13 @@ class SqliteJobRepository:
             ) VALUES (?, ?, ?, ?, ?)
             ON CONFLICT (tenant_id, owner_job_url, candidate_url) DO NOTHING
             """,
-            (str(tenant_id), str(owner_job_id), str(candidate_url), reason, rejected_at),
+            (
+                str(tenant_id),
+                owner.storage_url.value,
+                str(candidate_url),
+                reason,
+                rejected_at,
+            ),
         )
         self._conn.commit()
         return self._conn.total_changes > before
@@ -785,6 +1047,9 @@ class SqliteJobRepository:
     ) -> list[JobSourceObservation]:
         """Read-side helper used by tests and the future Operations projection."""
 
+        identity = self._resolve_identity(tenant_id, job_id)
+        if identity is None:
+            return []
         rows = self._conn.execute(
             """
             SELECT source_observation_id, source_id, source_native_id,
@@ -793,7 +1058,7 @@ class SqliteJobRepository:
             WHERE tenant_id = ? AND job_url = ?
             ORDER BY observed_at ASC
             """,
-            (str(tenant_id), str(job_id)),
+            (str(tenant_id), identity.storage_url.value),
         ).fetchall()
         return [
             JobSourceObservation(
@@ -814,6 +1079,9 @@ class SqliteJobRepository:
     ) -> CanonicalJobIdentity | None:
         """Read-side helper used by tests and the future Operations projection."""
 
+        identity = self._resolve_identity(tenant_id, job_id)
+        if identity is None:
+            return None
         row = self._conn.execute(
             """
             SELECT canonical_url, ats_kind, source_native_id, confidence
@@ -821,7 +1089,7 @@ class SqliteJobRepository:
             WHERE tenant_id = ? AND job_url = ?
             LIMIT 1
             """,
-            (str(tenant_id), str(job_id)),
+            (str(tenant_id), identity.storage_url.value),
         ).fetchone()
         if row is None:
             return None
@@ -836,7 +1104,59 @@ class SqliteJobRepository:
     # Internals
     # ------------------------------------------------------------------
 
-    def _sync_tombstone(self, job: Job) -> None:
+    def _load_resolved(self, identity: ResolvedJobIdentity) -> Job | None:
+        row = self._conn.execute(
+            """
+            SELECT j.tenant_id, j.job_id, j.url,
+                   j.title, j.salary, j.description, j.location,
+                   j.site, j.strategy, j.discovered_at,
+                   d.deleted_at, d.reason
+            FROM jobs j
+            LEFT JOIN jobctrl_deleted_jobs d
+              ON d.job_url = j.url
+             AND (
+                    d.restored_at IS NULL
+                 OR julianday(d.restored_at) <= julianday(d.deleted_at)
+             )
+            WHERE j.tenant_id = ? AND j.job_id = ?
+            LIMIT 1
+            """,
+            (str(identity.tenant_id), str(identity.job_id)),
+        ).fetchone()
+        if row is None:
+            return None
+        return self._row_to_job(row, posting_url=identity.posting_url)
+
+    def _resolve_identity(
+        self,
+        tenant_id: TenantId,
+        job_id: JobId,
+    ) -> ResolvedJobIdentity | None:
+        identity = self._identity_resolver.resolve_by_job_id(tenant_id, job_id)
+        if identity is not None:
+            return identity
+        # Compatibility input only: callers that still pass jobs.url as a
+        # JobId are translated here and nowhere below the repository.
+        return self._identity_resolver.resolve_by_posting_url(
+            tenant_id,
+            PostingUrl(value=str(job_id)),
+        )
+
+    def _require_identity(
+        self,
+        tenant_id: TenantId,
+        job_id: JobId,
+    ) -> ResolvedJobIdentity:
+        identity = self._resolve_identity(tenant_id, job_id)
+        if identity is None:
+            raise LookupError(f"Unknown Job identity for tenant={tenant_id!r} job_id={job_id!r}")
+        return identity
+
+    def _sync_tombstone(
+        self,
+        job: Job,
+        identity: ResolvedJobIdentity,
+    ) -> None:
         """Reflect the aggregate's ``deleted_at`` field in the tombstone table.
 
         Called from ``save``. If the aggregate carries a deleted_at,
@@ -854,7 +1174,11 @@ class SqliteJobRepository:
                     reason = excluded.reason,
                     restored_at = NULL
                 """,
-                (str(job.job_id), job.deleted_at, job.delete_reason),
+                (
+                    identity.storage_url.value,
+                    job.deleted_at,
+                    job.delete_reason,
+                ),
             )
         else:
             # Keep legacy active-save behaviour, but timestamp-aware
@@ -864,12 +1188,18 @@ class SqliteJobRepository:
                 "UPDATE jobctrl_deleted_jobs SET restored_at = ? "
                 "WHERE job_url = ? "
                 "AND (restored_at IS NULL OR julianday(restored_at) <= julianday(deleted_at))",
-                (job.discovered_at, str(job.job_id)),
+                (job.discovered_at, identity.storage_url.value),
             )
 
     @staticmethod
-    def _row_to_job(row: Any, tenant_id: TenantId | None = None) -> Job:
+    def _row_to_job(
+        row: Any,
+        *,
+        posting_url: PostingUrl | None = None,
+    ) -> Job:
         if isinstance(row, sqlite3.Row):
+            tenant_id = row["tenant_id"]
+            job_id = row["job_id"]
             url = row["url"]
             title = row["title"]
             salary = row["salary"]
@@ -882,6 +1212,8 @@ class SqliteJobRepository:
             delete_reason = row["reason"] if "reason" in row.keys() else None
         else:
             (
+                tenant_id,
+                job_id,
                 url,
                 title,
                 salary,
@@ -901,9 +1233,9 @@ class SqliteJobRepository:
         # invariant holds.
         board = (site or "unknown").strip() or "unknown"
         return Job(
-            tenant_id=tenant_id or LOCAL_TENANT,
-            job_id=JobId(str(url)),
-            posting_url=PostingUrl(value=str(url)),
+            tenant_id=TenantId(str(tenant_id)),
+            job_id=JobId(str(job_id)),
+            posting_url=posting_url or PostingUrl(value=str(url)),
             source=Source(board=board),
             employer=Employer.unknown(),
             search_strategy=strategy,

--- a/workers/automation/tests/test_discovery_identity.py
+++ b/workers/automation/tests/test_discovery_identity.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import sqlite3
+import uuid
 from pathlib import Path
 
 import pytest
@@ -24,7 +25,7 @@ from jobctrl.domain.identifiers import JobId
 from jobctrl.domain.job_content_identity import is_genuine_employer_identity
 from jobctrl.domain.ports.discovery import ScrapedJobPosting
 from jobctrl.domain.ports.events import EventHandler, Subscription
-from jobctrl.domain.tenant import LOCAL_TENANT
+from jobctrl.domain.tenant import LOCAL_TENANT, TenantId
 from jobctrl.infrastructure.discovery import SqliteJobRepository
 from jobctrl.infrastructure.compensation import SqlitePostedCompensationRepository
 
@@ -166,7 +167,9 @@ def test_load_by_url_resolves_observation_url_to_canonical_job(conn: sqlite3.Con
     )
 
     assert found is not None
-    assert found.job_id == job.job_id
+    canonical = repo.load(LOCAL_TENANT, job.job_id)
+    assert canonical is not None
+    assert found.job_id == canonical.job_id
 
 
 def test_attach_source_observation_replaces_repeated_native_identity(
@@ -292,6 +295,8 @@ def test_find_canonical_owner_resolves_native_identity_then_canonical_and_observ
             observed_at="2026-05-12T00:00:00Z",
         ),
     )
+    persisted = repo.load(LOCAL_TENANT, job.job_id)
+    assert persisted is not None
 
     assert (
         repo.find_canonical_owner(
@@ -300,7 +305,7 @@ def test_find_canonical_owner_resolves_native_identity_then_canonical_and_observ
             source_native_id="123",
             canonical_url="",
         )
-        == job.job_id
+        == persisted.job_id
     )
     assert (
         repo.find_canonical_owner(
@@ -309,7 +314,7 @@ def test_find_canonical_owner_resolves_native_identity_then_canonical_and_observ
             source_native_id="different",
             canonical_url="https://boards.greenhouse.io/acme/jobs/123",
         )
-        == job.job_id
+        == persisted.job_id
     )
     assert (
         repo.find_canonical_owner(
@@ -318,20 +323,20 @@ def test_find_canonical_owner_resolves_native_identity_then_canonical_and_observ
             source_native_id="different",
             canonical_url="https://boards.greenhouse.io/acme/jobs/123?gh_jid=123",
         )
-        == job.job_id
+        == persisted.job_id
     )
 
 
 def test_duplicate_links_are_persisted(conn: sqlite3.Connection) -> None:
     repo = SqliteJobRepository(conn)
     job = _job()
-    repo.save(job)
+    stable_job_id = repo.save(job)
 
     repo.record_duplicate_link(
         LOCAL_TENANT,
         DuplicateJobLink(
             duplicate_link_id="dup-1",
-            surviving_job_id=str(job.job_id),
+            surviving_job_id=str(stable_job_id),
             superseded_job_or_observation_id="obs-2",
             reason="canonical_url_match",
             confidence=0.91,
@@ -347,6 +352,8 @@ def test_duplicate_links_are_persisted(conn: sqlite3.Connection) -> None:
         """
     ).fetchone()
     assert row is not None
+    # The domain call above carries the stable id; the adapter alone translates
+    # it to the compatibility-era URL column.
     assert row["surviving_job_id"] == str(job.job_id)
     assert row["superseded_job_or_observation_id"] == "obs-2"
     assert row["reason"] == "canonical_url_match"
@@ -360,10 +367,12 @@ def test_discover_jobs_use_case_creates_job_identity_and_first_observation(
     repo = SqliteJobRepository(conn)
     publisher = RecordingPublisher()
     current_time = "2026-05-12T00:00:00Z"
+    stable_job_id = JobId("d7c34823-22ac-42ac-b1a0-64fe00eb1014")
     use_case = DiscoverJobsUseCase(
         repository=repo,
         publisher=publisher,
         clock=lambda: current_time,
+        job_id_factory=lambda: stable_job_id,
     )
 
     summary = use_case.execute(
@@ -372,15 +381,19 @@ def test_discover_jobs_use_case_creates_job_identity_and_first_observation(
         run_id="run-1",
     )
 
-    job_id = JobId("https://boards.greenhouse.io/acme/jobs/123")
+    legacy_job_key = JobId("https://boards.greenhouse.io/acme/jobs/123")
     assert summary.total == 1
     assert summary.new_jobs == 1
     assert summary.observed == 0
-    assert repo.load(LOCAL_TENANT, job_id) is not None
-    identity = repo.load_canonical_identity(LOCAL_TENANT, job_id)
+    persisted = repo.load(LOCAL_TENANT, legacy_job_key)
+    assert persisted is not None
+    assert uuid.UUID(str(persisted.job_id)).version == 4
+    assert persisted.job_id == stable_job_id
+    assert persisted.job_id != legacy_job_key
+    identity = repo.load_canonical_identity(LOCAL_TENANT, persisted.job_id)
     assert identity is not None
     assert identity.ats_kind is AtsKind.GREENHOUSE
-    observations = repo.list_observations(LOCAL_TENANT, job_id)
+    observations = repo.list_observations(LOCAL_TENANT, persisted.job_id)
     assert len(observations) == 1
     assert observations[0].source_id == "greenhouse:acme"
     assert [event.event_type for event in publisher.events] == [
@@ -388,11 +401,103 @@ def test_discover_jobs_use_case_creates_job_identity_and_first_observation(
         "CanonicalJobIdentityResolved",
         "JobSourceObserved",
     ]
+    assert {event.payload["job_id"] for event in publisher.events} == {str(legacy_job_key)}
     assert publisher.events[-1].payload["run_id"] == "run-1"
+
+
+def test_discover_jobs_use_case_rejects_url_shaped_job_id_factory(
+    conn: sqlite3.Connection,
+) -> None:
+    repo = SqliteJobRepository(conn)
+    publisher = RecordingPublisher()
+    use_case = DiscoverJobsUseCase(
+        repository=repo,
+        publisher=publisher,
+        clock=lambda: "2026-05-12T00:00:00Z",
+        job_id_factory=lambda: JobId("https://boards.greenhouse.io/acme/jobs/123"),
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="job_id_factory must return a canonical UUID JobId",
+    ):
+        use_case.execute(
+            tenant_id=LOCAL_TENANT,
+            postings=[_posting()],
+            run_id="run-invalid-job-id",
+        )
+
+    assert conn.execute("SELECT COUNT(*) FROM jobs").fetchone()[0] == 0
+    assert publisher.events == []
+
+
+def test_discover_jobs_use_case_observes_concurrent_insert_winner(
+    conn: sqlite3.Connection,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = SqliteJobRepository(conn)
+    publisher = RecordingPublisher()
+    winner_job_id = JobId("6cc41ec6-8cb8-45ae-b563-bf3173c62f50")
+    candidate_job_id = JobId("b0216ed3-2b22-48db-a58d-262c31ae1c3d")
+    posting = _posting()
+    winner = Job.discover(
+        tenant_id=LOCAL_TENANT,
+        job_id=winner_job_id,
+        posting_url=posting.posting_url,
+        source=posting.source,
+        employer=Employer.unknown(),
+        search_strategy=posting.strategy,
+        metadata=posting.metadata,
+        discovered_at="2026-05-12T00:00:00Z",
+    )
+    assert repo.save(winner) == winner_job_id
+    repository_save = repo.save
+    first_save = True
+
+    def lose_first_insert(job: Job) -> JobId:
+        nonlocal first_save
+        if first_save:
+            first_save = False
+            return winner_job_id
+        return repository_save(job)
+
+    monkeypatch.setattr(
+        repo,
+        "find_canonical_owner",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        repo,
+        "find_content_owner",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(repo, "save", lose_first_insert)
+    use_case = DiscoverJobsUseCase(
+        repository=repo,
+        publisher=publisher,
+        clock=lambda: "2026-05-12T00:00:01Z",
+        observation_id_factory=lambda: "obs-race-loser",
+        job_id_factory=lambda: candidate_job_id,
+    )
+
+    summary = use_case.execute(
+        tenant_id=LOCAL_TENANT,
+        postings=[posting],
+        run_id="run-race-loser",
+    )
+
+    assert summary.new_jobs == 0
+    assert summary.observed == 1
+    assert conn.execute("SELECT COUNT(*) FROM jobs").fetchone()[0] == 1
+    observations = repo.list_observations(LOCAL_TENANT, winner_job_id)
+    assert [observation.source_observation_id for observation in observations] == ["obs-race-loser"]
+    assert [event.event_type for event in publisher.events] == ["JobSourceObserved"]
+    assert publisher.events[0].payload["job_id"] == posting.posting_url.value
 
 
 def test_discover_jobs_use_case_observes_existing_job_and_links_duplicate(
     conn: sqlite3.Connection,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     repo = SqliteJobRepository(conn)
     publisher = RecordingPublisher()
@@ -403,6 +508,22 @@ def test_discover_jobs_use_case_observes_existing_job_and_links_duplicate(
         clock=lambda: current_time,
     )
     use_case.execute(tenant_id=LOCAL_TENANT, postings=[_posting()], run_id="run-1")
+    owner = repo.resolve_by_posting_url(
+        LOCAL_TENANT,
+        PostingUrl(value="https://boards.greenhouse.io/acme/jobs/123"),
+    )
+    assert owner is not None
+    domain_links: list[DuplicateJobLink] = []
+    record_duplicate_link = repo.record_duplicate_link
+
+    def capture_duplicate_link(
+        tenant_id: TenantId,
+        link: DuplicateJobLink,
+    ) -> None:
+        domain_links.append(link)
+        record_duplicate_link(tenant_id, link)
+
+    monkeypatch.setattr(repo, "record_duplicate_link", capture_duplicate_link)
     publisher.events.clear()
 
     summary = use_case.execute(
@@ -426,6 +547,8 @@ def test_discover_jobs_use_case_observes_existing_job_and_links_duplicate(
         "DuplicateJobLinked",
     ]
     duplicate = publisher.events[-1]
+    assert len(domain_links) == 1
+    assert domain_links[0].surviving_job_id == str(owner.job_id)
     assert duplicate.payload["surviving_job_id"] == "https://boards.greenhouse.io/acme/jobs/123"
     assert duplicate.payload["reason"] == "canonical_url_match"
     duplicate_row = conn.execute("SELECT reason FROM job_duplicate_links").fetchone()
@@ -696,7 +819,10 @@ def test_discover_jobs_use_case_preserves_existing_salary_when_rediscovery_is_bl
 
     compensation_repo = SqlitePostedCompensationRepository(conn)
     compensation_repo.backfill_from_legacy_jobs(parsed_at="2026-06-19T10:00:00Z")
-    fact = compensation_repo.get_fact(str(LOCAL_TENANT), str(rediscovered.job_id))
+    fact = compensation_repo.get_fact(
+        str(LOCAL_TENANT),
+        rediscovered.posting_url.value,
+    )
     assert fact is not None
     assert fact.legacy_raw_salary == "$180,000"
     assert fact.minimum_amount == 180_000
@@ -807,9 +933,7 @@ def test_discover_jobs_use_case_collapses_jobspy_job_rediscovered_by_canonical_s
         "jobspy:linkedin",
         "workday:acme",
     ]
-    link = conn.execute(
-        "SELECT surviving_job_id, reason, confidence FROM job_duplicate_links"
-    ).fetchone()
+    link = conn.execute("SELECT surviving_job_id, reason, confidence FROM job_duplicate_links").fetchone()
     assert link["surviving_job_id"] == survivor
     assert link["reason"] == "content_fingerprint_match"
     assert link["confidence"] == 0.95
@@ -876,16 +1000,15 @@ def test_discover_jobs_use_case_collapses_reworded_cross_source_description(
     assert summary.observed == 1
     assert summary.duplicates_linked == 1
     assert conn.execute("SELECT COUNT(*) FROM jobs").fetchone()[0] == 1
-    assert (
-        repo.load(
-            LOCAL_TENANT,
-            JobId("https://jobs.lever.co/acme/staff-platform-engineer"),
-        ).job_id
-        == JobId(survivor)
+    surviving_job = repo.load(LOCAL_TENANT, JobId(survivor))
+    duplicate_lookup = repo.load(
+        LOCAL_TENANT,
+        JobId("https://jobs.lever.co/acme/staff-platform-engineer"),
     )
-    link = conn.execute(
-        "SELECT surviving_job_id, reason, confidence FROM job_duplicate_links"
-    ).fetchone()
+    assert surviving_job is not None
+    assert duplicate_lookup is not None
+    assert duplicate_lookup.job_id == surviving_job.job_id
+    link = conn.execute("SELECT surviving_job_id, reason, confidence FROM job_duplicate_links").fetchone()
     assert link["surviving_job_id"] == survivor
     assert link["reason"] == "content_shingle_match"
     assert link["confidence"] == 0.85
@@ -969,9 +1092,7 @@ def test_discover_jobs_use_case_matches_fresh_listing_against_enriched_owner(
     assert summary.observed == 1
     assert summary.duplicates_linked == 1
     assert conn.execute("SELECT COUNT(*) FROM jobs").fetchone()[0] == 1
-    link = conn.execute(
-        "SELECT surviving_job_id, reason, confidence FROM job_duplicate_links"
-    ).fetchone()
+    link = conn.execute("SELECT surviving_job_id, reason, confidence FROM job_duplicate_links").fetchone()
     assert link["surviving_job_id"] == survivor
     assert link["reason"] == "content_shingle_match"
     assert link["confidence"] == 0.85
@@ -1036,17 +1157,13 @@ def test_discover_jobs_use_case_keeps_accepted_owner_when_content_duplicate_reje
         ),
     )
 
-    created = use_case.execute(
-        tenant_id=LOCAL_TENANT, postings=[accepted], run_id="run-owner"
-    )
+    created = use_case.execute(tenant_id=LOCAL_TENANT, postings=[accepted], run_id="run-owner")
     assert created.new_jobs == 1
     owner = repo.load(LOCAL_TENANT, JobId(owner_url))
     assert owner is not None and owner.is_deleted is False
     publisher.events.clear()
 
-    summary = use_case.execute(
-        tenant_id=LOCAL_TENANT, postings=[india_duplicate], run_id="run-duplicate"
-    )
+    summary = use_case.execute(tenant_id=LOCAL_TENANT, postings=[india_duplicate], run_id="run-duplicate")
 
     assert summary.total == 1
     assert summary.new_jobs == 0
@@ -1058,7 +1175,7 @@ def test_discover_jobs_use_case_keeps_accepted_owner_when_content_duplicate_reje
     assert owner is not None
     assert owner.is_deleted is False
     assert owner.metadata.location == "Remote - US"
-    assert JobId(owner_url) in [job.job_id for job in repo.list_recent(LOCAL_TENANT)]
+    assert owner.job_id in [job.job_id for job in repo.list_recent(LOCAL_TENANT)]
     assert conn.execute("SELECT COUNT(*) FROM jobs").fetchone()[0] == 1
 
     # The rejected distinct posting is recorded as declined-duplicate audit
@@ -1069,22 +1186,18 @@ def test_discover_jobs_use_case_keeps_accepted_owner_when_content_duplicate_reje
     assert rejected.payload["job_id"] == owner_url
     assert rejected.payload["candidate_job_id"] == "https://jobs.lever.co/acme/staff-platform-engineer-india"
     assert "location_mismatch" in rejected.payload["reason"]
-    assert [obs.source_id for obs in repo.list_observations(LOCAL_TENANT, JobId(owner_url))] == [
-        "greenhouse:acme"
-    ]
+    assert [obs.source_id for obs in repo.list_observations(LOCAL_TENANT, JobId(owner_url))] == ["greenhouse:acme"]
 
     # Re-running the rejected duplicate must be stable: the owner stays active and
     # visible, proving the rejection left no re-observation trail to delete it. The
     # already-recorded (owner, candidate) rejection is idempotent, so no duplicate
     # audit event is appended on the repeat observation.
     publisher.events.clear()
-    resummary = use_case.execute(
-        tenant_id=LOCAL_TENANT, postings=[india_duplicate], run_id="run-duplicate-2"
-    )
+    resummary = use_case.execute(tenant_id=LOCAL_TENANT, postings=[india_duplicate], run_id="run-duplicate-2")
     assert resummary.observed == 0
     owner = repo.load(LOCAL_TENANT, JobId(owner_url))
     assert owner is not None and owner.is_deleted is False
-    assert JobId(owner_url) in [job.job_id for job in repo.list_recent(LOCAL_TENANT)]
+    assert owner.job_id in [job.job_id for job in repo.list_recent(LOCAL_TENANT)]
     assert "JobDeleted" not in [event.event_type for event in publisher.events]
     assert "DuplicateJobLinkRejected" not in [event.event_type for event in publisher.events]
 

--- a/workers/automation/tests/test_job_repository.py
+++ b/workers/automation/tests/test_job_repository.py
@@ -10,6 +10,10 @@ the aggregate's ``deleted_at`` field stays consistent with the
 from __future__ import annotations
 
 import sqlite3
+import threading
+import uuid
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
 
 import pytest
 
@@ -18,13 +22,17 @@ from jobctrl.domain.discovery import (
     Employer,
     Job,
     JobMetadata,
+    JobSourceObservation,
     PostingUrl,
     SearchStrategy,
     Source,
 )
 from jobctrl.domain.identifiers import JobId
-from jobctrl.domain.tenant import LOCAL_TENANT
-from jobctrl.infrastructure.discovery import SqliteJobRepository
+from jobctrl.domain.tenant import LOCAL_TENANT, TenantId
+from jobctrl.infrastructure.discovery import (
+    SqliteJobIdentityResolver,
+    SqliteJobRepository,
+)
 from jobctrl.infrastructure.discovery.sqlite_repository import JobUrlConflict
 
 
@@ -34,10 +42,14 @@ def conn(tmp_path) -> sqlite3.Connection:
     return init_db(db_path)
 
 
-def _make_job(url: str = "https://example.com/jobs/1") -> Job:
+def _make_job(
+    url: str = "https://example.com/jobs/1",
+    *,
+    job_id: JobId | None = None,
+) -> Job:
     return Job.discover(
         tenant_id=LOCAL_TENANT,
-        job_id=JobId(url),
+        job_id=job_id or JobId(url),
         posting_url=PostingUrl(value=url),
         source=Source(board="greenhouse"),
         employer=Employer(name="Acme Corp"),
@@ -75,7 +87,186 @@ def test_load_by_url_finds_jobs(conn: sqlite3.Connection) -> None:
     repo.save(job)
     found = repo.load_by_url(LOCAL_TENANT, job.posting_url)
     assert found is not None
-    assert found.job_id == job.job_id
+    assert found.posting_url == job.posting_url
+    assert uuid.UUID(str(found.job_id)).version == 4
+    assert str(found.job_id) != job.posting_url.value
+
+
+def test_save_preserves_supplied_stable_job_id(conn: sqlite3.Connection) -> None:
+    repo = SqliteJobRepository(conn)
+    stable_id = JobId("1d4d7064-21e7-49dc-b53c-90676906af6e")
+    job = _make_job(job_id=stable_id)
+
+    repo.save(job)
+
+    found_by_id = repo.load(LOCAL_TENANT, stable_id)
+    assert found_by_id is not None
+    assert found_by_id.job_id == stable_id
+    assert found_by_id.posting_url == job.posting_url
+    found_by_legacy_url = repo.load(LOCAL_TENANT, JobId(job.posting_url.value))
+    assert found_by_legacy_url is not None
+    assert found_by_legacy_url.job_id == stable_id
+
+
+def test_identity_resolver_keeps_job_id_stable_across_url_aliases(
+    conn: sqlite3.Connection,
+) -> None:
+    repo = SqliteJobRepository(conn)
+    resolver = SqliteJobIdentityResolver(conn)
+    stable_id = JobId("b1bdf251-a7a2-44b9-99fa-cb4097fe6942")
+    original_url = PostingUrl(value="https://example.com/jobs/original")
+    replacement_url = PostingUrl(value="https://example.com/jobs/current")
+    repo.save(_make_job(original_url.value, job_id=stable_id))
+    repo.attach_source_observation(
+        LOCAL_TENANT,
+        stable_id,
+        JobSourceObservation(
+            source_observation_id="obs-original",
+            source_id="greenhouse:acme",
+            source_native_id="original",
+            observed_url=original_url.value,
+            run_id="run-original",
+            observed_at="2026-05-01T00:00:00+00:00",
+        ),
+    )
+
+    returned_id = repo.save(
+        _make_job(
+            replacement_url.value,
+            job_id=stable_id,
+        )
+    )
+
+    by_id = resolver.resolve_by_job_id(LOCAL_TENANT, stable_id)
+    by_original_url = resolver.resolve_by_posting_url(LOCAL_TENANT, original_url)
+    by_replacement_url = resolver.resolve_by_posting_url(
+        LOCAL_TENANT,
+        replacement_url,
+    )
+    storage_row = conn.execute(
+        "SELECT url FROM jobs WHERE tenant_id = ? AND job_id = ?",
+        (str(LOCAL_TENANT), str(stable_id)),
+    ).fetchone()
+    alias_rows = conn.execute(
+        """
+        SELECT alias_value, retired_at
+        FROM job_identity_aliases
+        WHERE tenant_id = ? AND job_id = ?
+        ORDER BY alias_value
+        """,
+        (str(LOCAL_TENANT), str(stable_id)),
+    ).fetchall()
+    observation_row = conn.execute(
+        """
+        SELECT job_url
+        FROM job_source_observations
+        WHERE source_observation_id = 'obs-original'
+        """
+    ).fetchone()
+    assert returned_id == stable_id
+    assert by_id is not None
+    assert by_original_url == by_id
+    assert by_replacement_url == by_id
+    assert by_id.posting_url == replacement_url
+    assert by_id.storage_url == original_url
+    assert storage_row["url"] == original_url.value
+    assert {row["alias_value"]: row["retired_at"] is None for row in alias_rows} == {
+        original_url.value: False,
+        replacement_url.value: True,
+    }
+    assert observation_row["job_url"] == original_url.value
+    loaded_by_original_url = repo.load(
+        LOCAL_TENANT,
+        JobId(original_url.value),
+    )
+    assert loaded_by_original_url is not None
+    assert loaded_by_original_url.job_id == stable_id
+    assert loaded_by_original_url.posting_url == replacement_url
+    assert resolver.resolve_by_job_id(TenantId("other"), stable_id) is None
+    assert resolver.resolve_by_posting_url(TenantId("other"), replacement_url) is None
+
+
+def test_concurrent_first_save_returns_one_stable_url_owner(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "concurrent-jobctrl.db"
+    initialized = init_db(db_path)
+    initialized.close()
+    barrier = threading.Barrier(2)
+
+    class BarrierResolver:
+        def __init__(self, connection: sqlite3.Connection) -> None:
+            self._delegate = SqliteJobIdentityResolver(connection)
+            self._waited = False
+
+        def resolve_by_job_id(
+            self,
+            tenant_id: TenantId,
+            job_id: JobId,
+        ):
+            return self._delegate.resolve_by_job_id(tenant_id, job_id)
+
+        def resolve_by_posting_url(
+            self,
+            tenant_id: TenantId,
+            posting_url: PostingUrl,
+        ):
+            resolved = self._delegate.resolve_by_posting_url(
+                tenant_id,
+                posting_url,
+            )
+            if resolved is None and not self._waited:
+                self._waited = True
+                barrier.wait(timeout=5)
+            return resolved
+
+    connections = [
+        sqlite3.connect(
+            db_path,
+            timeout=10,
+            check_same_thread=False,
+        )
+        for _ in range(2)
+    ]
+    for connection in connections:
+        connection.row_factory = sqlite3.Row
+        connection.execute("PRAGMA foreign_keys = ON")
+        connection.execute("PRAGMA busy_timeout = 10000")
+    repositories = [
+        SqliteJobRepository(
+            connection,
+            identity_resolver=BarrierResolver(connection),
+        )
+        for connection in connections
+    ]
+    candidate_ids = [
+        JobId("b1e0e6f4-dafe-4a50-8c2f-55522e5a9ee5"),
+        JobId("ac03f977-cf3b-47a0-b060-51f50ec8de49"),
+    ]
+
+    def save_candidate(index: int) -> JobId:
+        return repositories[index].save(
+            _make_job(
+                "https://example.com/jobs/concurrent",
+                job_id=candidate_ids[index],
+            )
+        )
+
+    try:
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            returned_ids = list(executor.map(save_candidate, range(2)))
+        check = sqlite3.connect(db_path)
+        try:
+            rows = check.execute("SELECT job_id, url FROM jobs").fetchall()
+        finally:
+            check.close()
+    finally:
+        for connection in connections:
+            connection.close()
+
+    assert len(rows) == 1
+    assert returned_ids[0] == returned_ids[1] == JobId(str(rows[0][0]))
+    assert rows[0][1] == "https://example.com/jobs/concurrent"
 
 
 def test_load_by_url_returns_none_for_unknown(conn: sqlite3.Connection) -> None:
@@ -115,7 +306,7 @@ def test_save_rejects_url_owned_by_different_job(conn: sqlite3.Connection) -> No
     repo.save(_make_job())
     intruder = Job.discover(
         tenant_id=LOCAL_TENANT,
-        job_id=JobId("different-id"),
+        job_id=JobId("18a92504-89e8-4966-a765-ab641919cb6d"),
         posting_url=PostingUrl(value="https://example.com/jobs/1"),
         source=Source(board="linkedin"),
         employer=Employer.unknown(),
@@ -125,6 +316,13 @@ def test_save_rejects_url_owned_by_different_job(conn: sqlite3.Connection) -> No
     )
     with pytest.raises(JobUrlConflict):
         repo.save(intruder)
+    assert conn.in_transaction is False
+    owner = repo.load_by_url(
+        LOCAL_TENANT,
+        PostingUrl(value="https://example.com/jobs/1"),
+    )
+    assert owner is not None
+    assert owner.metadata.title == "Senior Engineer"
 
 
 def test_list_recent_orders_by_discovered_at_desc(conn: sqlite3.Connection) -> None:

--- a/workers/automation/tests/test_smartextract_discovery.py
+++ b/workers/automation/tests/test_smartextract_discovery.py
@@ -9,14 +9,18 @@ from jobctrl.database import close_connection, init_db
 from jobctrl.discovery import smartextract
 from jobctrl.domain.discovery import (
     AtsKind,
+    DuplicateJobLink,
+    Employer,
+    Job,
     JobMetadata,
     PostingUrl,
     SearchStrategy,
     Source,
 )
 from jobctrl.domain.discovery.use_cases import DiscoverJobsUseCase
+from jobctrl.domain.identifiers import JobId
 from jobctrl.domain.ports.discovery import ScrapedJobPosting
-from jobctrl.domain.tenant import LOCAL_TENANT
+from jobctrl.domain.tenant import LOCAL_TENANT, TenantId
 from jobctrl.infrastructure.discovery import SqliteJobRepository
 from jobctrl.infrastructure.discovery.production_wiring import DurableJobEventPublisher
 
@@ -28,7 +32,13 @@ def test_short_headless_html_never_retries_headful_in_the_bundled_core(
 
     def collect(_url: str, **kwargs: object) -> dict[str, object]:
         calls.append(kwargs)
-        return {"full_html": "<html>short</html>", "json_ld": [], "api_responses": [], "data_testids": [], "card_candidates": []}
+        return {
+            "full_html": "<html>short</html>",
+            "json_ld": [],
+            "api_responses": [],
+            "data_testids": [],
+            "card_candidates": [],
+        }
 
     monkeypatch.setattr(smartextract, "collect_page_intelligence", collect)
     monkeypatch.setattr(smartextract, "is_bundled_runtime", lambda: True)
@@ -445,6 +455,109 @@ def test_smart_extract_updates_existing_serialized_null_description(
         close_connection(db_path)
 
 
+def test_smart_extract_current_alias_refreshes_and_restores_storage_owner(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    monkeypatch.setattr(config, "DB_PATH", db_path)
+    conn = init_db(db_path)
+    try:
+        repository = SqliteJobRepository(conn)
+        stable_job_id = JobId("e02fc922-8320-4455-9f6b-ad839b9f7a8d")
+        storage_url = "https://example.com/jobs/original"
+        current_url = "https://example.com/jobs/current"
+        original = Job.discover(
+            tenant_id=LOCAL_TENANT,
+            job_id=stable_job_id,
+            posting_url=PostingUrl(value=storage_url),
+            source=Source(board="Acme Careers"),
+            employer=Employer(name="Acme"),
+            search_strategy=SearchStrategy.MANUAL,
+            metadata=JobMetadata(
+                title="Engineering Director",
+                description="Lead the engineering organization.",
+                location="Remote",
+            ),
+            discovered_at="2026-05-20T00:00:00+00:00",
+        )
+        assert repository.save(original) == stable_job_id
+        moved = Job.discover(
+            tenant_id=LOCAL_TENANT,
+            job_id=stable_job_id,
+            posting_url=PostingUrl(value=current_url),
+            source=original.source,
+            employer=original.employer,
+            search_strategy=original.search_strategy,
+            metadata=original.metadata,
+            discovered_at=original.discovered_at,
+        )
+        assert repository.save(moved) == stable_job_id
+        repository.soft_delete(
+            LOCAL_TENANT,
+            stable_job_id,
+            reason="temporarily hidden",
+            deleted_at="2026-05-21T00:00:00+00:00",
+        )
+
+        assert smartextract._store_jobs_filtered(
+            conn,
+            [
+                {
+                    "url": current_url,
+                    "title": "Head of Engineering",
+                    "company": "Acme",
+                    "location": "Barcelona, Spain",
+                    "description": "Lead the engineering organization.",
+                }
+            ],
+            "Acme Careers",
+            "static",
+            ["Barcelona, Spain", "Spain", "Europe", "EMEA"],
+            ["United States", "Canada"],
+            query="Head of Engineering",
+            run_id="run-current-alias",
+        ) == (0, 1)
+
+        loaded = repository.load(LOCAL_TENANT, stable_job_id)
+        assert loaded is not None
+        assert loaded.posting_url == PostingUrl(value=current_url)
+        assert loaded.metadata.title == "Head of Engineering"
+        assert loaded.metadata.location == "Barcelona, Spain"
+        assert loaded.is_deleted is False
+        physical = conn.execute(
+            "SELECT url FROM jobs WHERE job_id = ?",
+            (str(stable_job_id),),
+        ).fetchone()
+        assert physical["url"] == storage_url
+        tombstones = conn.execute("SELECT job_url, restored_at FROM jobctrl_deleted_jobs").fetchall()
+        assert [(row["job_url"], row["restored_at"] is not None) for row in tombstones] == [(storage_url, True)]
+        event_urls = {
+            row["job_url"]
+            for row in conn.execute(
+                """
+                SELECT job_url
+                FROM job_events
+                WHERE event_type IN ('JobMetadataUpdated', 'JobRestored')
+                """
+            ).fetchall()
+        }
+        assert event_urls == {storage_url}
+        observation_urls = {
+            row["job_url"]
+            for row in conn.execute(
+                """
+                SELECT job_url
+                FROM job_source_observations
+                WHERE source_id = 'smartextract:Acme Careers'
+                """
+            ).fetchall()
+        }
+        assert observation_urls == {storage_url}
+    finally:
+        close_connection(db_path)
+
+
 def test_smart_extract_refreshes_existing_title_location_before_restore(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -596,6 +709,47 @@ def test_smart_extract_dedups_against_ats_first_content_owner(
         )
         assert conn.execute("SELECT COUNT(*) FROM jobs").fetchone()[0] == 1
 
+        same_url_result = smartextract._store_jobs_filtered(
+            conn,
+            [
+                {
+                    "url": owner_url,
+                    "title": "Staff Platform Engineer",
+                    "company": "Acme",
+                    "location": "Barcelona, Spain",
+                    "description": description,
+                }
+            ],
+            "Acme Careers",
+            "static",
+            ["Barcelona, Spain", "Spain", "Europe", "EMEA"],
+            ["United States", "Canada"],
+            query="Staff Platform Engineer",
+        )
+        assert same_url_result == (0, 1)
+        assert conn.execute("SELECT COUNT(*) FROM job_duplicate_links").fetchone()[0] == 0
+
+        owner_identity = repository.resolve_by_posting_url(
+            LOCAL_TENANT,
+            PostingUrl(value=owner_url),
+        )
+        assert owner_identity is not None
+        domain_links: list[DuplicateJobLink] = []
+        record_duplicate_link = SqliteJobRepository.record_duplicate_link
+
+        def capture_duplicate_link(
+            self: SqliteJobRepository,
+            tenant_id: TenantId,
+            link: DuplicateJobLink,
+        ) -> None:
+            domain_links.append(link)
+            record_duplicate_link(self, tenant_id, link)
+
+        monkeypatch.setattr(
+            SqliteJobRepository,
+            "record_duplicate_link",
+            capture_duplicate_link,
+        )
         result = smartextract._store_jobs_filtered(
             conn,
             [
@@ -615,10 +769,10 @@ def test_smart_extract_dedups_against_ats_first_content_owner(
         )
 
         assert result == (0, 1)
+        assert len(domain_links) == 1
+        assert domain_links[0].surviving_job_id == str(owner_identity.job_id)
         assert conn.execute("SELECT COUNT(*) FROM jobs").fetchone()[0] == 1
-        link = conn.execute(
-            "SELECT surviving_job_id, reason, confidence FROM job_duplicate_links"
-        ).fetchone()
+        link = conn.execute("SELECT surviving_job_id, reason, confidence FROM job_duplicate_links").fetchone()
         assert link["surviving_job_id"] == owner_url
         assert link["reason"] == "content_fingerprint_match"
         assert link["confidence"] == 0.95
@@ -684,9 +838,7 @@ def test_ats_dedups_against_smart_extract_first_content_owner(
         assert summary.new_jobs == 0
         assert summary.duplicates_linked == 1
         assert conn.execute("SELECT COUNT(*) FROM jobs").fetchone()[0] == 1
-        link = conn.execute(
-            "SELECT surviving_job_id, reason FROM job_duplicate_links"
-        ).fetchone()
+        link = conn.execute("SELECT surviving_job_id, reason FROM job_duplicate_links").fetchone()
         assert link["surviving_job_id"] == smart_url
         assert link["reason"] == "content_fingerprint_match"
     finally:


### PR DESCRIPTION
## Summary

- add one tenant-scoped resolver for stable `JobId`, current posting locators, historical URL aliases, and the temporary physical URL storage key
- make the canonical Job repository allocate and hydrate UUID identities while preserving URL-shaped input only at the compatibility boundary
- support UUID-preserving posting-URL changes without disconnecting URL-keyed child rows
- make concurrent first writes converge on one stable owner and re-enter discovery as an observation rather than leaking SQLite errors
- keep duplicate-link domain writes UUID-backed while translating only in deferred URL-keyed adapters and pre-Phase-4 event payloads
- repair SmartExtract and ATS enrichment compatibility across current/historical aliases, including soft-delete resurfacing

## Why

This is Phase 2 of the accepted stable-identity stack. Phase 1 introduced and backfilled the schema foundation in #530; this slice moves the canonical repository and discovery boundary onto stable IDs without prematurely migrating downstream table families or historical events.

## Validation

- `workers/automation/.venv/bin/python -m pytest -q workers/automation/tests` — 2656 passed, 2 skipped
- `corepack pnpm api:test` — 648 passed
- `corepack pnpm api:check` — passed
- focused schema/repository/discovery/SmartExtract matrix — 119 passed
- targeted Ruff and `git diff --check` — passed
- independent reviewer gate — PASS, 0 findings
- independent QA gate — PASS, 0 findings; included 18 forced overlapping race scenarios and forced mid-upsert rollback

## Stack

- #526 — accepted implementation plan
- #530 — Phase 1 migration runner and stable identity foundation
- this PR — Phase 2 canonical repository compatibility

Canonical product documentation and cumulative cross-stack QA remain intentionally deferred to the final unreleased stack PR, as recorded in the accepted plan.