### PR TITLE
feat(storage): migrate discovery identity references

### DIFF
--- a/apps/api/src/db.ts
+++ b/apps/api/src/db.ts
@@ -9,7 +9,7 @@ export type SqliteValue = string | number | bigint | null;
 // writer that stamps ``PRAGMA user_version``; the API only reads it to fail
 // closed on a database written by a newer build. Bump both constants together
 // whenever the schema shape changes.
-export const SUPPORTED_SCHEMA_VERSION = 7;
+export const SUPPORTED_SCHEMA_VERSION = 8;
 
 export class IncompatibleSchemaVersionError extends Error {
   constructor(current: number) {

--- a/apps/api/src/discovery-controls.ts
+++ b/apps/api/src/discovery-controls.ts
@@ -1290,10 +1290,12 @@ export function previewDiscoverySource(
 
   const rows = allRows<PreviewObservationRow>(
     db,
-    `SELECT o.job_url, o.observed_url, o.observed_at,
+    `SELECT j.url AS job_url, o.observed_url, o.observed_at,
             j.title, j.site, j.location
      FROM job_source_observations o
-     LEFT JOIN jobs j ON j.url = o.job_url
+     JOIN jobs j
+       ON j.tenant_id = o.tenant_id
+      AND j.job_id = o.job_id
      WHERE o.tenant_id = ? AND o.source_id = ?
      ORDER BY o.observed_at DESC, o.source_observation_id DESC
      LIMIT 10`,
@@ -1515,11 +1517,14 @@ function latestSourceIdsByJobKey(db: SqliteDatabase): Map<string, string> {
   }
   const rows = allRows<{ job_url: string; source_id: string }>(
     db,
-    `SELECT job_url, source_id
-     FROM job_source_observations
-     WHERE tenant_id = ?
-       AND source_id != ''
-     ORDER BY observed_at DESC, source_observation_id DESC`,
+    `SELECT j.url AS job_url, o.source_id
+     FROM job_source_observations o
+     JOIN jobs j
+       ON j.tenant_id = o.tenant_id
+      AND j.job_id = o.job_id
+     WHERE o.tenant_id = ?
+       AND o.source_id != ''
+     ORDER BY o.observed_at DESC, o.source_observation_id DESC`,
     [DEFAULT_TENANT],
   );
   const result = new Map<string, string>();

--- a/apps/api/src/read-model.ts
+++ b/apps/api/src/read-model.ts
@@ -4795,8 +4795,11 @@ function discoverySourceSqlExpression(db: SqliteDatabase): string {
 function latestSourceObservationSql(): string {
   return `(SELECT o.source_id
              FROM job_source_observations o
+             JOIN jobs j
+               ON j.tenant_id = o.tenant_id
+              AND j.job_id = o.job_id
             WHERE o.tenant_id = job_list_projections.tenant_id
-              AND o.job_url = job_list_projections.job_id
+              AND j.url = job_list_projections.job_id
             ORDER BY o.observed_at DESC, o.source_observation_id DESC
             LIMIT 1)`;
 }
@@ -4805,8 +4808,11 @@ function postingSourceUrlSqlExpression(db: SqliteDatabase): string {
   if (!tableExists(db, "job_canonical_identities")) return "NULL";
   return `(SELECT c.canonical_url
              FROM job_canonical_identities c
+             JOIN jobs j
+               ON j.tenant_id = c.tenant_id
+              AND j.job_id = c.job_id
             WHERE c.tenant_id = job_list_projections.tenant_id
-              AND c.job_url = job_list_projections.job_id
+              AND j.url = job_list_projections.job_id
             LIMIT 1)`;
 }
 
@@ -4814,8 +4820,11 @@ function postingSourceAtsKindSqlExpression(db: SqliteDatabase): string {
   if (!tableExists(db, "job_canonical_identities")) return "NULL";
   return `(SELECT c.ats_kind
              FROM job_canonical_identities c
+             JOIN jobs j
+               ON j.tenant_id = c.tenant_id
+              AND j.job_id = c.job_id
             WHERE c.tenant_id = job_list_projections.tenant_id
-              AND c.job_url = job_list_projections.job_id
+              AND j.url = job_list_projections.job_id
             LIMIT 1)`;
 }
 

--- a/apps/api/src/repeat-application.ts
+++ b/apps/api/src/repeat-application.ts
@@ -452,9 +452,13 @@ function canonicalIdentityRelationship(
   if (!tableExists(db, "job_canonical_identities")) return null;
   const rows = allRows<CanonicalIdentityRow>(
     db,
-    `SELECT job_url, canonical_url, ats_kind, source_native_id
-       FROM job_canonical_identities
-      WHERE tenant_id = ? AND job_url IN (?, ?)`,
+    `SELECT j.url AS job_url, c.canonical_url, c.ats_kind,
+            c.source_native_id
+       FROM job_canonical_identities c
+       JOIN jobs j
+         ON j.tenant_id = c.tenant_id
+        AND j.job_id = c.job_id
+      WHERE c.tenant_id = ? AND j.url IN (?, ?)`,
     [DEFAULT_TENANT, targetJobKey, priorJobKey],
   );
   const target = rows.find((row) => row.job_url === targetJobKey);
@@ -506,12 +510,31 @@ function acceptedDuplicateRelationship(
 
 function jobAliases(db: SqliteDatabase, jobKey: string): Set<string> {
   const aliases = new Set([jobKey]);
+  const job = getRow<{ job_id: string }>(
+    db,
+    `SELECT job_id
+       FROM jobs
+      WHERE tenant_id = ? AND url = ?`,
+    [DEFAULT_TENANT, jobKey],
+  );
+  if (!job) return aliases;
+  aliases.add(job.job_id);
+  if (tableExists(db, "job_identity_aliases")) {
+    const postingAliases = allRows<{ alias_value: string }>(
+      db,
+      `SELECT alias_value
+         FROM job_identity_aliases
+        WHERE tenant_id = ? AND job_id = ?`,
+      [DEFAULT_TENANT, job.job_id],
+    );
+    for (const alias of postingAliases) aliases.add(alias.alias_value);
+  }
   if (!tableExists(db, "job_source_observations")) return aliases;
   const rows = allRows<Record<string, unknown>>(
     db,
     `SELECT source_observation_id, observed_url, normalized_observed_url
-       FROM job_source_observations WHERE tenant_id = ? AND job_url = ?`,
-    [DEFAULT_TENANT, jobKey],
+       FROM job_source_observations WHERE tenant_id = ? AND job_id = ?`,
+    [DEFAULT_TENANT, job.job_id],
   );
   for (const row of rows) {
     for (const value of [row.source_observation_id, row.observed_url, row.normalized_observed_url]) {

--- a/apps/api/src/write-model.ts
+++ b/apps/api/src/write-model.ts
@@ -783,6 +783,14 @@ function uniqueJobKeys(jobKeys: string[]): string[] {
 }
 
 function purgeJobRows(db: SqliteDatabase, jobUrl: string): void {
+  const identity = getRow<{ job_id: string }>(
+    db,
+    `SELECT job_id
+       FROM jobs
+      WHERE tenant_id = 'local' AND url = ?`,
+    [jobUrl],
+  );
+  const jobId = identity?.job_id;
   deleteWhere(db, "jobctrl_deleted_jobs", "job_url = ?", [jobUrl]);
   deleteWhere(db, "jobctrl_hidden_jobs", "job_url = ?", [jobUrl]);
   deleteWhere(db, "job_stage_states", "job_url = ?", [jobUrl]);
@@ -793,12 +801,17 @@ function purgeJobRows(db: SqliteDatabase, jobUrl: string): void {
   deleteWhere(db, "job_materials_artifacts", "job_url = ?", [jobUrl]);
   deleteWhere(db, "job_materials", "job_url = ?", [jobUrl]);
   deleteWhere(db, "job_enrichments", "job_url = ?", [jobUrl]);
-  deleteWhere(db, "job_source_observations", "job_url = ?", [jobUrl]);
-  deleteWhere(db, "job_canonical_identities", "job_url = ?", [jobUrl]);
-  deleteWhere(db, "job_duplicate_links", "surviving_job_id = ? OR superseded_job_or_observation_id = ?", [
-    jobUrl,
-    jobUrl,
-  ]);
+  if (jobId) {
+    deleteWhere(db, "job_source_observations", "job_id = ?", [jobId]);
+    deleteWhere(db, "job_canonical_identities", "job_id = ?", [jobId]);
+    deleteWhere(db, "job_rejected_duplicate_links", "owner_job_id = ?", [jobId]);
+    deleteWhere(
+      db,
+      "job_duplicate_links",
+      "surviving_job_id = ? OR superseded_job_or_observation_id IN (?, ?)",
+      [jobId, jobId, jobUrl],
+    );
+  }
   deleteWhere(db, "apply_run_projections", "job_id = ?", [jobUrl]);
   deleteWhere(db, "artifact_list_projections", "job_id = ?", [jobUrl]);
   deleteWhere(db, "job_detail_projections", "job_id = ?", [jobUrl]);

--- a/apps/api/test/discovery-controls.test.ts
+++ b/apps/api/test/discovery-controls.test.ts
@@ -21,6 +21,8 @@ function withTempDb(): { dbPath: string; dir: string; cleanup: () => void } {
   db.exec(`
     CREATE TABLE jobs (
       url TEXT PRIMARY KEY,
+      tenant_id TEXT NOT NULL DEFAULT 'local',
+      job_id TEXT NOT NULL UNIQUE,
       title TEXT,
       site TEXT,
       strategy TEXT,
@@ -58,7 +60,7 @@ function withTempDb(): { dbPath: string; dir: string; cleanup: () => void } {
     CREATE TABLE job_source_observations (
       tenant_id TEXT NOT NULL DEFAULT 'local',
       source_observation_id TEXT NOT NULL,
-      job_url TEXT NOT NULL,
+      job_id TEXT NOT NULL,
       source_id TEXT NOT NULL,
       source_native_id TEXT NOT NULL,
       observed_url TEXT NOT NULL,
@@ -704,9 +706,10 @@ describe("discovery product controls API", () => {
       await app.inject({ method: "GET", url: "/v1/discovery/sources" });
       const db = new Database(dbPath);
       db.prepare(
-        "INSERT INTO jobs (url, title, site, location, discovered_at) VALUES (?, ?, ?, ?, ?)",
+        "INSERT INTO jobs (url, job_id, title, site, location, discovered_at) VALUES (?, ?, ?, ?, ?, ?)",
       ).run(
         "https://example.com/jobs/1",
+        "test-job-1",
         "Product Engineer",
         "ExampleCo",
         "Remote",
@@ -714,13 +717,13 @@ describe("discovery product controls API", () => {
       );
       db.prepare(
         `INSERT INTO job_source_observations (
-           tenant_id, source_observation_id, job_url, source_id, source_native_id,
+           tenant_id, source_observation_id, job_id, source_id, source_native_id,
            observed_url, normalized_observed_url, run_id, observed_at
          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       ).run(
         "local",
         "observation-1",
-        "https://example.com/jobs/1",
+        "test-job-1",
         "greenhouse:example-com",
         "native-1",
         "https://example.com/jobs/1",

--- a/apps/api/test/projections.test.ts
+++ b/apps/api/test/projections.test.ts
@@ -29,6 +29,8 @@ function seedSchema(dbPath: string): void {
   db.exec(`
     CREATE TABLE jobs (
       url TEXT PRIMARY KEY,
+      tenant_id TEXT NOT NULL DEFAULT 'local',
+      job_id TEXT,
       title TEXT,
       company TEXT,
       site TEXT,
@@ -148,9 +150,10 @@ function seedSchema(dbPath: string): void {
     );
   `);
   db.prepare(
-    "INSERT INTO jobs (url, title, site, fit_score, score_reasoning, application_url) VALUES (?, ?, ?, ?, ?, ?)",
+    "INSERT INTO jobs (url, job_id, title, site, fit_score, score_reasoning, application_url) VALUES (?, ?, ?, ?, ?, ?, ?)",
   ).run(
     "https://example.com/jobs/event-driven",
+    "test-job-event-driven",
     "Event-Driven Engineer",
     "ExampleCo",
     9,
@@ -2055,7 +2058,7 @@ describe("apply_run_projections without legacy apply_runs table", () => {
         CREATE TABLE job_source_observations (
           tenant_id TEXT NOT NULL DEFAULT 'local',
           source_observation_id TEXT NOT NULL,
-          job_url TEXT NOT NULL,
+          job_id TEXT NOT NULL,
           source_id TEXT NOT NULL,
           source_native_id TEXT NOT NULL,
           observed_url TEXT NOT NULL,
@@ -2066,25 +2069,25 @@ describe("apply_run_projections without legacy apply_runs table", () => {
         );
         CREATE TABLE job_canonical_identities (
           tenant_id TEXT NOT NULL DEFAULT 'local',
-          job_url TEXT NOT NULL,
+          job_id TEXT NOT NULL,
           canonical_url TEXT NOT NULL,
           ats_kind TEXT NOT NULL,
           source_native_id TEXT NOT NULL,
           confidence REAL NOT NULL,
           resolved_at TEXT NOT NULL,
-          PRIMARY KEY (tenant_id, job_url)
+          PRIMARY KEY (tenant_id, job_id)
         );
       `);
       db.prepare(
         `INSERT INTO job_source_observations (
-          tenant_id, source_observation_id, job_url, source_id,
+          tenant_id, source_observation_id, job_id, source_id,
           source_native_id, observed_url, normalized_observed_url,
           run_id, observed_at
         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       ).run(
         "local",
         "obs-linkedin",
-        "https://example.com/jobs/event-driven",
+        "test-job-event-driven",
         "jobspy:linkedin",
         "https://www.linkedin.com/jobs/view/1",
         "https://www.linkedin.com/jobs/view/1",
@@ -2094,12 +2097,12 @@ describe("apply_run_projections without legacy apply_runs table", () => {
       );
       db.prepare(
         `INSERT INTO job_canonical_identities (
-          tenant_id, job_url, canonical_url, ats_kind, source_native_id,
+          tenant_id, job_id, canonical_url, ats_kind, source_native_id,
           confidence, resolved_at
         ) VALUES (?, ?, ?, ?, ?, ?, ?)`,
       ).run(
         "local",
-        "https://example.com/jobs/event-driven",
+        "test-job-event-driven",
         "https://boards.greenhouse.io/acme/jobs/123456",
         "greenhouse",
         "123456",

--- a/apps/api/test/repeat-application.test.ts
+++ b/apps/api/test/repeat-application.test.ts
@@ -24,6 +24,8 @@ beforeEach(() => {
   db.exec(`
     CREATE TABLE jobs (
       url TEXT PRIMARY KEY,
+      tenant_id TEXT NOT NULL DEFAULT 'local',
+      job_id TEXT NOT NULL UNIQUE,
       title TEXT,
       company TEXT,
       application_url TEXT,
@@ -65,7 +67,7 @@ beforeEach(() => {
     );
     CREATE TABLE job_canonical_identities (
       tenant_id TEXT NOT NULL,
-      job_url TEXT NOT NULL,
+      job_id TEXT NOT NULL,
       canonical_url TEXT NOT NULL,
       ats_kind TEXT NOT NULL,
       source_native_id TEXT NOT NULL
@@ -73,7 +75,7 @@ beforeEach(() => {
     CREATE TABLE job_source_observations (
       tenant_id TEXT NOT NULL,
       source_observation_id TEXT NOT NULL,
-      job_url TEXT NOT NULL,
+      job_id TEXT NOT NULL,
       observed_url TEXT NOT NULL,
       normalized_observed_url TEXT NOT NULL
     );
@@ -97,9 +99,14 @@ afterEach(() => {
 
 function insertJob(url: string, title: string, company: string): void {
   db.prepare(
-    `INSERT INTO jobs (url, title, company, application_url, discovered_at)
-     VALUES (?, ?, ?, ?, ?)`,
-  ).run(url, title, company, `${url}/apply`, NOW);
+    `INSERT INTO jobs (
+       url, tenant_id, job_id, title, company, application_url, discovered_at
+     ) VALUES (?, 'local', ?, ?, ?, ?, ?)`,
+  ).run(url, testJobId(url), title, company, `${url}/apply`, NOW);
+}
+
+function testJobId(url: string): string {
+  return `test-job:${url}`;
 }
 
 function confirmPrior(kind: "ApplicationSubmitted" | "ApplicationManuallyMarked" = "ApplicationSubmitted"): void {
@@ -138,11 +145,11 @@ describe("repeat application evidence", () => {
     confirmPrior();
     const identity = db.prepare(
       `INSERT INTO job_canonical_identities
-       (tenant_id, job_url, canonical_url, ats_kind, source_native_id)
+       (tenant_id, job_id, canonical_url, ats_kind, source_native_id)
        VALUES ('local', ?, ?, 'greenhouse', 'gh-123')`,
     );
-    identity.run(PRIOR, "https://boards.example.test/jobs/123");
-    identity.run(TARGET, "https://boards.example.test/jobs/123");
+    identity.run(testJobId(PRIOR), "https://boards.example.test/jobs/123");
+    identity.run(testJobId(TARGET), "https://boards.example.test/jobs/123");
 
     const assessment = evaluateRepeatApplication(db, TARGET);
 
@@ -163,15 +170,15 @@ describe("repeat application evidence", () => {
     confirmPrior("ApplicationManuallyMarked");
     db.prepare(
       `INSERT INTO job_source_observations
-       (tenant_id, source_observation_id, job_url, observed_url, normalized_observed_url)
+       (tenant_id, source_observation_id, job_id, observed_url, normalized_observed_url)
        VALUES ('local', 'prior-observation', ?, ?, ?)`,
-    ).run(PRIOR, `${PRIOR}?source=board`, PRIOR);
+    ).run(testJobId(PRIOR), `${PRIOR}?source=board`, PRIOR);
     db.prepare(
       `INSERT INTO job_duplicate_links
        (tenant_id, duplicate_link_id, surviving_job_id,
         superseded_job_or_observation_id, reason, confidence, linked_at)
        VALUES ('local', 'link-1', ?, 'prior-observation', 'accepted_content_identity', 0.99, ?)`,
-    ).run(TARGET, NOW);
+    ).run(testJobId(TARGET), NOW);
 
     expect(evaluateRepeatApplication(db, TARGET)).toMatchObject({
       status: "blocked",

--- a/apps/api/test/server.test.ts
+++ b/apps/api/test/server.test.ts
@@ -9743,6 +9743,8 @@ function seedDatabase(dbPath: string): void {
   db.exec(`
     CREATE TABLE jobs (
       url TEXT PRIMARY KEY,
+      tenant_id TEXT NOT NULL DEFAULT 'local',
+      job_id TEXT NOT NULL UNIQUE,
       title TEXT,
       site TEXT,
       strategy TEXT,
@@ -10095,12 +10097,13 @@ function insertJob(
 ): void {
   db.prepare(
     `INSERT INTO jobs (
-      url, title, site, strategy, location, salary, discovered_at, application_url,
+      url, tenant_id, job_id, title, site, strategy, location, salary, discovered_at, application_url,
       description, full_description, detail_scraped_at, fit_score, score_reasoning,
       scored_at, tailored_resume_path, tailored_at
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    ) VALUES (?, 'local', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   ).run(
     job.url,
+    `test-job:${job.url}`,
     job.title,
     job.site,
     "test",

--- a/apps/web/e2e/tests/repeat-application.spec.ts
+++ b/apps/web/e2e/tests/repeat-application.spec.ts
@@ -1,4 +1,5 @@
 import { execFileSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
 import path from "node:path";
 
 import { expect, test } from "@playwright/test";
@@ -63,20 +64,26 @@ test("repeat application block and reasoned override reach only the simulated su
   db.exec(`
     CREATE TABLE IF NOT EXISTS job_canonical_identities (
       tenant_id TEXT NOT NULL DEFAULT 'local',
-      job_url TEXT NOT NULL,
+      job_id TEXT NOT NULL,
       canonical_url TEXT NOT NULL,
       ats_kind TEXT NOT NULL,
       source_native_id TEXT NOT NULL,
       confidence REAL NOT NULL,
       resolved_at TEXT NOT NULL,
-      PRIMARY KEY (tenant_id, job_url),
-      FOREIGN KEY (job_url) REFERENCES jobs(url) ON DELETE CASCADE
+      PRIMARY KEY (tenant_id, job_id),
+      FOREIGN KEY (tenant_id, job_id)
+        REFERENCES jobs(tenant_id, job_id) ON DELETE CASCADE
     )
   `);
   const originalIdentity = hadCanonicalIdentityTable
     ? (db
         .prepare(
-          "SELECT * FROM job_canonical_identities WHERE tenant_id = 'local' AND job_url = ?",
+          `SELECT c.*
+             FROM job_canonical_identities c
+             JOIN jobs j
+               ON j.tenant_id = c.tenant_id
+              AND j.job_id = c.job_id
+            WHERE c.tenant_id = 'local' AND j.url = ?`,
         )
         .get(TARGET) as Record<string, unknown> | undefined)
     : undefined;
@@ -110,6 +117,8 @@ test("repeat application block and reasoned override reach only the simulated su
         .all(TARGET) as Array<Record<string, unknown>>)
     : [];
   let originalTargetApplication: Record<string, unknown> | undefined;
+  let targetJobId = "";
+  let priorJobId = "";
 
   try {
     if (hasRepeatApplicationTables) clearRepeatApplicationState(db);
@@ -118,6 +127,7 @@ test("repeat application block and reasoned override reach only the simulated su
       unknown
     >;
     if (!target) throw new Error("QA target job is missing");
+    targetJobId = String(target.job_id);
     originalTargetApplication = {
       apply_status: target.apply_status,
       applied_at: target.applied_at,
@@ -129,6 +139,7 @@ test("repeat application block and reasoned override reach only the simulated su
     const prior: Record<string, unknown> = {
       ...target,
       url: PRIOR,
+      job_id: randomUUID(),
       application_url: `${PRIOR}/apply`,
       apply_status: "applied",
       applied_at: CONFIRMED_AT,
@@ -138,6 +149,7 @@ test("repeat application block and reasoned override reach only the simulated su
       `INSERT OR REPLACE INTO jobs (${columns.map((column) => `"${column}"`).join(", ")})
        VALUES (${columns.map(() => "?").join(", ")})`,
     ).run(...columns.map((column) => prior[column]));
+    priorJobId = String(prior.job_id);
     db.prepare(
       `INSERT INTO job_events
        (job_url, stage, event_type, level, message, occurred_at, payload_json)
@@ -161,11 +173,11 @@ test("repeat application block and reasoned override reach only the simulated su
     }
     const identity = db.prepare(
       `INSERT OR REPLACE INTO job_canonical_identities
-       (tenant_id, job_url, canonical_url, ats_kind, source_native_id, confidence, resolved_at)
+       (tenant_id, job_id, canonical_url, ats_kind, source_native_id, confidence, resolved_at)
        VALUES ('local', ?, ?, 'greenhouse', 'qa-platform-director', 1, ?)`,
     );
-    identity.run(TARGET, CANONICAL, CONFIRMED_AT);
-    identity.run(PRIOR, CANONICAL, CONFIRMED_AT);
+    identity.run(targetJobId, CANONICAL, CONFIRMED_AT);
+    identity.run(priorJobId, CANONICAL, CONFIRMED_AT);
 
     await page.goto(`/apply-review?jobKey=${encodeURIComponent(TARGET)}`);
     await expect(page.getByText("Repeat application blocked", { exact: true })).toBeVisible();
@@ -371,8 +383,8 @@ print(job["url"])
       restoreRows(db, "application_repeat_audit", originalRepeatAudit);
     }
     db.prepare(
-      "DELETE FROM job_canonical_identities WHERE tenant_id = 'local' AND job_url IN (?, ?)",
-    ).run(TARGET, PRIOR);
+      "DELETE FROM job_canonical_identities WHERE tenant_id = 'local' AND job_id IN (?, ?)",
+    ).run(targetJobId, priorJobId);
     if (originalIdentity) {
       const columns = Object.keys(originalIdentity);
       db.prepare(

--- a/docs/plans/2026-07-29-stable-job-identity-workflow-feedback-learning.md
+++ b/docs/plans/2026-07-29-stable-job-identity-workflow-feedback-learning.md
@@ -148,8 +148,9 @@ caused an outcome.
 
 - Migrate references as separate stacked PRs with before/after count and reopen
   fixtures:
-  1. discovery observations, dedup identity, search-unit receipts, and
-     preparation/orchestration state;
+  1. discovery foundations, split into three independently reviewable
+     migrations: source observations plus dedup identity; execution plus
+     search-unit receipts; then preparation/orchestration state;
   2. enrichment, scoring, materials, artifacts, and stage state;
   3. Apply review, outcomes, repeat-application evidence, contacts, outreach,
      tombstones, and remaining job-owned authorities.

--- a/workers/automation/src/jobctrl/database.py
+++ b/workers/automation/src/jobctrl/database.py
@@ -37,9 +37,11 @@ from jobctrl.config import DB_PATH, DEFAULTS, migrate_legacy_job_tables
 # v6 (repeat-application prevention): evidence-bound confirmations,
 # one-attempt consumption, and immutable protection audit records.
 # v7 (stable job identity foundation): additive opaque job UUIDs, the
-# tenant-scoped posting-URL alias map, and insert/update guards. URL-keyed
-# authorities remain compatibility storage until their own bounded migrations.
-SCHEMA_VERSION = 7
+# tenant-scoped posting-URL alias map, and insert/update guards.
+# v8 (discovery identity references): source observations, canonical identity,
+# and duplicate-link authorities reference ``(tenant_id, job_id)`` rather than
+# storing a posting URL as aggregate identity.
+SCHEMA_VERSION = 8
 
 
 class IncompatibleSchemaVersionError(RuntimeError):
@@ -175,7 +177,10 @@ def _schema_migrations() -> tuple[
     ...,
 ]:
     """Return the ordered schema migrations known to this build."""
-    return ((7, ensure_stable_job_identity_v7),)
+    return (
+        (7, ensure_stable_job_identity_v7),
+        (8, ensure_discovery_identity_references_v8),
+    )
 
 
 def _assert_schema_migration_path(current_version: int) -> None:
@@ -1023,7 +1028,7 @@ def _verify_stable_job_identity_v7(
     if duplicate is not None:
         raise RuntimeError("stable JobId migration produced duplicate job IDs")
 
-    missing_alias = conn.execute(
+    missing_storage_alias = conn.execute(
         """
         SELECT j.tenant_id, j.url
         FROM jobs j
@@ -1032,13 +1037,32 @@ def _verify_stable_job_identity_v7(
          AND a.alias_kind = 'posting_url'
          AND a.alias_value = j.url
          AND a.job_id = j.job_id
+        WHERE a.job_id IS NULL
+        LIMIT 1
+        """
+    ).fetchone()
+    if missing_storage_alias is not None:
+        raise RuntimeError(
+            "stable JobId migration left a job without its storage URL alias"
+        )
+
+    missing_active_alias = conn.execute(
+        """
+        SELECT j.tenant_id, j.job_id
+        FROM jobs j
+        LEFT JOIN job_identity_aliases a
+          ON a.tenant_id = j.tenant_id
+         AND a.alias_kind = 'posting_url'
+         AND a.job_id = j.job_id
          AND a.retired_at IS NULL
         WHERE a.job_id IS NULL
         LIMIT 1
         """
     ).fetchone()
-    if missing_alias is not None:
-        raise RuntimeError("stable JobId migration left a job without its URL alias")
+    if missing_active_alias is not None:
+        raise RuntimeError(
+            "stable JobId migration left a job without an active posting URL alias"
+        )
 
     trigger_rows = conn.execute(
         """
@@ -3356,10 +3380,9 @@ def ensure_source_observation_tables(conn: sqlite3.Connection | None = None) -> 
     See PR 2 of the Job Search Discovery RFC
     (`docs/plans/implemented/2026-05-12-job-search-discovery-rfc.md`).
 
-    The migration is purely additive — the legacy ``jobs.url`` PRIMARY
-    KEY remains the canonical posting URL during the compatibility
-    window so ``load_by_url`` can resolve either a canonical URL or an
-    observation URL without a coordinated cutover.
+    These discovery-owned authorities use stable ``JobId`` references. The
+    legacy ``jobs.url`` primary key remains compatibility storage for table
+    families that have not yet completed their bounded migration.
 
     Backfill is idempotent: if ``job_source_observations`` is empty AND
     the ``jobs`` table has rows, every existing job seeds exactly one
@@ -3376,7 +3399,7 @@ def ensure_source_observation_tables(conn: sqlite3.Connection | None = None) -> 
         CREATE TABLE IF NOT EXISTS job_source_observations (
             tenant_id                TEXT NOT NULL DEFAULT 'local',
             source_observation_id    TEXT NOT NULL,
-            job_url                  TEXT NOT NULL,
+            job_id                   TEXT NOT NULL,
             source_id                TEXT NOT NULL,
             source_native_id         TEXT NOT NULL,
             observed_url             TEXT NOT NULL,
@@ -3384,7 +3407,8 @@ def ensure_source_observation_tables(conn: sqlite3.Connection | None = None) -> 
             run_id                   TEXT NOT NULL DEFAULT '',
             observed_at              TEXT NOT NULL,
             PRIMARY KEY (tenant_id, source_observation_id),
-            FOREIGN KEY (job_url) REFERENCES jobs(url) ON DELETE CASCADE
+            FOREIGN KEY (tenant_id, job_id)
+                REFERENCES jobs(tenant_id, job_id) ON DELETE CASCADE
         )
         """
     )
@@ -3400,10 +3424,15 @@ def ensure_source_observation_tables(conn: sqlite3.Connection | None = None) -> 
         ON job_source_observations(tenant_id, normalized_observed_url)
         """
     )
+    observation_reference = (
+        "job_id"
+        if "job_id" in _table_columns(conn, "job_source_observations")
+        else "job_url"
+    )
     conn.execute(
-        """
+        f"""
         CREATE INDEX IF NOT EXISTS idx_job_source_observations_job
-        ON job_source_observations(tenant_id, job_url)
+        ON job_source_observations(tenant_id, {observation_reference})
         """
     )
 
@@ -3411,14 +3440,15 @@ def ensure_source_observation_tables(conn: sqlite3.Connection | None = None) -> 
         """
         CREATE TABLE IF NOT EXISTS job_canonical_identities (
             tenant_id          TEXT NOT NULL DEFAULT 'local',
-            job_url            TEXT NOT NULL,
+            job_id             TEXT NOT NULL,
             canonical_url      TEXT NOT NULL,
             ats_kind           TEXT NOT NULL,
             source_native_id   TEXT NOT NULL,
             confidence         REAL NOT NULL,
             resolved_at        TEXT NOT NULL,
-            PRIMARY KEY (tenant_id, job_url),
-            FOREIGN KEY (job_url) REFERENCES jobs(url) ON DELETE CASCADE
+            PRIMARY KEY (tenant_id, job_id),
+            FOREIGN KEY (tenant_id, job_id)
+                REFERENCES jobs(tenant_id, job_id) ON DELETE CASCADE
         )
         """
     )
@@ -3439,7 +3469,9 @@ def ensure_source_observation_tables(conn: sqlite3.Connection | None = None) -> 
             reason                                 TEXT NOT NULL,
             confidence                             REAL NOT NULL,
             linked_at                              TEXT NOT NULL,
-            PRIMARY KEY (tenant_id, duplicate_link_id)
+            PRIMARY KEY (tenant_id, duplicate_link_id),
+            FOREIGN KEY (tenant_id, surviving_job_id)
+                REFERENCES jobs(tenant_id, job_id) ON DELETE CASCADE
         )
         """
     )
@@ -3454,20 +3486,55 @@ def ensure_source_observation_tables(conn: sqlite3.Connection | None = None) -> 
         """
         CREATE TABLE IF NOT EXISTS job_rejected_duplicate_links (
             tenant_id       TEXT NOT NULL DEFAULT 'local',
-            owner_job_url   TEXT NOT NULL,
+            owner_job_id    TEXT NOT NULL,
             candidate_url   TEXT NOT NULL,
             reason          TEXT NOT NULL,
             rejected_at     TEXT NOT NULL,
-            PRIMARY KEY (tenant_id, owner_job_url, candidate_url)
+            PRIMARY KEY (tenant_id, owner_job_id, candidate_url),
+            FOREIGN KEY (tenant_id, owner_job_id)
+                REFERENCES jobs(tenant_id, job_id) ON DELETE CASCADE
         )
         """
     )
 
     # Idempotent one-shot backfill: every existing jobs row gets one
-    # observation row using its legacy URL / site / discovered_at.
+    # observation row using its stable ID plus legacy URL / site / discovered_at.
     backfilled = conn.execute("SELECT COUNT(*) FROM job_source_observations").fetchone()[0]
-    if backfilled == 0:
-        legacy_jobs = conn.execute("SELECT url, site, strategy, discovered_at FROM jobs").fetchall()
+    current_schema_version = int(
+        conn.execute("PRAGMA user_version").fetchone()[0]
+    )
+    if (
+        backfilled == 0
+        and current_schema_version >= _DISCOVERY_IDENTITY_REFERENCE_SCHEMA_VERSION
+    ):
+        observation_columns = _table_columns(conn, "job_source_observations")
+        job_columns = _table_columns(conn, "jobs")
+        stable_schema = "job_id" in observation_columns
+        stable_jobs_ready = {"tenant_id", "job_id"}.issubset(job_columns) and (
+            int(
+                conn.execute(
+                    """
+                    SELECT COUNT(*)
+                    FROM jobs
+                    WHERE tenant_id IS NULL OR trim(tenant_id) = ''
+                       OR job_id IS NULL OR trim(job_id) = ''
+                    """
+                ).fetchone()[0]
+            )
+            == 0
+        )
+        legacy_jobs: list[sqlite3.Row] | list[tuple[Any, ...]] = []
+        if not stable_schema:
+            legacy_jobs = conn.execute(
+                "SELECT url, site, strategy, discovered_at FROM jobs"
+            ).fetchall()
+        elif stable_jobs_ready:
+            legacy_jobs = conn.execute(
+                """
+                SELECT url, site, strategy, discovered_at, tenant_id, job_id
+                FROM jobs
+                """
+            ).fetchall()
         if legacy_jobs:
             now = datetime.now(timezone.utc).isoformat()
             for row in legacy_jobs:
@@ -3702,19 +3769,36 @@ def _backfill_one_observation_row(
     discovered_at = (row["discovered_at"] if isinstance(row, sqlite3.Row) else row[3]) or now
     if not url:
         return
+    observation_columns = _table_columns(conn, "job_source_observations")
+    reference_column = "job_id" if "job_id" in observation_columns else "job_url"
+    if reference_column == "job_id":
+        if isinstance(row, sqlite3.Row):
+            tenant_id = str(row["tenant_id"] or "").strip()
+            job_reference = str(row["job_id"] or "").strip()
+        else:
+            tenant_id = str(row[4] or "").strip()
+            job_reference = str(row[5] or "").strip()
+        if not tenant_id or not job_reference:
+            raise RuntimeError(
+                "source-observation backfill requires a stable tenant and JobId"
+            )
+    else:
+        tenant_id = "local"
+        job_reference = str(url)
     source_native_id = url  # fall back to the URL when we have nothing better
     source_observation_id = f"backfill:{url}"
     conn.execute(
-        """
+        f"""
         INSERT OR IGNORE INTO job_source_observations (
-            tenant_id, source_observation_id, job_url, source_id,
+            tenant_id, source_observation_id, {reference_column}, source_id,
             source_native_id, observed_url, normalized_observed_url,
             run_id, observed_at
-        ) VALUES ('local', ?, ?, ?, ?, ?, ?, 'backfill', ?)
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, 'backfill', ?)
         """,
         (
+            tenant_id,
             source_observation_id,
-            url,
+            job_reference,
             str(site),
             str(source_native_id),
             url,
@@ -3722,6 +3806,677 @@ def _backfill_one_observation_row(
             discovered_at,
         ),
     )
+
+
+_DISCOVERY_IDENTITY_REFERENCE_SCHEMA_VERSION = 8
+_DISCOVERY_IDENTITY_REFERENCE_TABLES = (
+    "job_source_observations",
+    "job_canonical_identities",
+    "job_duplicate_links",
+    "job_rejected_duplicate_links",
+)
+
+
+def ensure_discovery_identity_references_v8(
+    conn: sqlite3.Connection | None = None,
+) -> list[str]:
+    """Move discovery-owned job references from posting URLs to stable IDs.
+
+    Every old reference is resolved through the canonical jobs row or its
+    tenant-scoped posting-URL aliases before any table is replaced. The four
+    authority tables are rebuilt and verified in one savepoint; unresolved
+    references, row-count drift, or any foreign-key error leaves schema v7
+    untouched and retryable.
+    """
+    if conn is None:
+        conn = get_connection()
+
+    current = _assert_schema_version_supported(conn)
+    if current >= _DISCOVERY_IDENTITY_REFERENCE_SCHEMA_VERSION:
+        return []
+    if current != _STABLE_JOB_IDENTITY_SCHEMA_VERSION:
+        raise RuntimeError(
+            "discovery identity migration requires stable JobId schema v7"
+        )
+
+    conn.execute("SAVEPOINT discovery_identity_references_v8")
+    try:
+        _verify_stable_job_identity_v7(conn)
+        before_counts = {
+            table: int(conn.execute(f'SELECT COUNT(*) FROM "{table}"').fetchone()[0])
+            for table in _DISCOVERY_IDENTITY_REFERENCE_TABLES
+        }
+
+        if not _has_discovery_identity_reference_schema_v8(conn):
+            source_reference = _legacy_or_stable_reference_column(
+                conn,
+                "job_source_observations",
+                stable="job_id",
+                legacy="job_url",
+            )
+            canonical_reference = _legacy_or_stable_reference_column(
+                conn,
+                "job_canonical_identities",
+                stable="job_id",
+                legacy="job_url",
+            )
+            rejected_reference = _legacy_or_stable_reference_column(
+                conn,
+                "job_rejected_duplicate_links",
+                stable="owner_job_id",
+                legacy="owner_job_url",
+            )
+            reference_columns = {
+                "job_source_observations": source_reference,
+                "job_canonical_identities": canonical_reference,
+                "job_duplicate_links": "surviving_job_id",
+                "job_rejected_duplicate_links": rejected_reference,
+            }
+            for table, reference_column in reference_columns.items():
+                unresolved = conn.execute(
+                    f"""
+                    SELECT {reference_column}
+                    FROM {table} AS source
+                    WHERE {_resolved_job_id_sql("source", reference_column)}
+                          IS NULL
+                    LIMIT 1
+                    """
+                ).fetchone()
+                if unresolved is not None:
+                    raise RuntimeError(
+                        "discovery identity migration could not resolve "
+                        f"{table}.{reference_column}={unresolved[0]!r}"
+                    )
+
+            _create_discovery_identity_v8_rebuild_tables(conn)
+            conn.execute(
+                f"""
+                INSERT INTO job_source_observations_v8 (
+                    tenant_id, source_observation_id, job_id, source_id,
+                    source_native_id, observed_url, normalized_observed_url,
+                    run_id, observed_at
+                )
+                SELECT
+                    source.tenant_id,
+                    source.source_observation_id,
+                    {_resolved_job_id_sql("source", source_reference)},
+                    source.source_id,
+                    source.source_native_id,
+                    source.observed_url,
+                    source.normalized_observed_url,
+                    source.run_id,
+                    source.observed_at
+                FROM job_source_observations AS source
+                """
+            )
+            conn.execute(
+                f"""
+                INSERT INTO job_canonical_identities_v8 (
+                    tenant_id, job_id, canonical_url, ats_kind,
+                    source_native_id, confidence, resolved_at
+                )
+                SELECT
+                    source.tenant_id,
+                    {_resolved_job_id_sql("source", canonical_reference)},
+                    source.canonical_url,
+                    source.ats_kind,
+                    source.source_native_id,
+                    source.confidence,
+                    source.resolved_at
+                FROM job_canonical_identities AS source
+                """
+            )
+            conn.execute(
+                f"""
+                INSERT INTO job_duplicate_links_v8 (
+                    tenant_id, duplicate_link_id, surviving_job_id,
+                    superseded_job_or_observation_id, reason, confidence,
+                    linked_at
+                )
+                SELECT
+                    source.tenant_id,
+                    source.duplicate_link_id,
+                    {_resolved_job_id_sql("source", "surviving_job_id")},
+                    source.superseded_job_or_observation_id,
+                    source.reason,
+                    source.confidence,
+                    source.linked_at
+                FROM job_duplicate_links AS source
+                """
+            )
+            conn.execute(
+                f"""
+                INSERT INTO job_rejected_duplicate_links_v8 (
+                    tenant_id, owner_job_id, candidate_url, reason, rejected_at
+                )
+                SELECT
+                    source.tenant_id,
+                    {_resolved_job_id_sql("source", rejected_reference)},
+                    source.candidate_url,
+                    source.reason,
+                    source.rejected_at
+                FROM job_rejected_duplicate_links AS source
+                """
+            )
+
+            for table in _DISCOVERY_IDENTITY_REFERENCE_TABLES:
+                conn.execute(f'DROP TABLE "{table}"')
+                conn.execute(f'ALTER TABLE "{table}_v8" RENAME TO "{table}"')
+            _create_discovery_identity_v8_indexes(conn)
+
+        if before_counts["job_source_observations"] == 0:
+            now = datetime.now(timezone.utc).isoformat()
+            jobs = conn.execute(
+                """
+                SELECT url, site, strategy, discovered_at, tenant_id, job_id
+                FROM jobs
+                """
+            ).fetchall()
+            for row in jobs:
+                _backfill_one_observation_row(conn, row, now)
+
+        expected_counts = dict(before_counts)
+        if before_counts["job_source_observations"] == 0:
+            expected_counts["job_source_observations"] = int(
+                conn.execute(
+                    "SELECT COUNT(*) FROM job_source_observations"
+                ).fetchone()[0]
+            )
+        _verify_discovery_identity_references_v8(
+            conn,
+            expected_counts=expected_counts,
+        )
+        conn.execute(
+            f"PRAGMA user_version = "
+            f"{_DISCOVERY_IDENTITY_REFERENCE_SCHEMA_VERSION}"
+        )
+        conn.execute("RELEASE SAVEPOINT discovery_identity_references_v8")
+        conn.commit()
+    except BaseException:
+        conn.execute("ROLLBACK TO SAVEPOINT discovery_identity_references_v8")
+        conn.execute("RELEASE SAVEPOINT discovery_identity_references_v8")
+        raise
+
+    return list(_DISCOVERY_IDENTITY_REFERENCE_TABLES)
+
+
+def reassign_discovery_identity_references(
+    conn: sqlite3.Connection,
+    *,
+    losing_job_url: str,
+    surviving_job_url: str,
+) -> None:
+    """Re-home discovery authority rows before a legacy URL collision merge.
+
+    URL normalization still merges duplicate legacy ``jobs`` rows in place.
+    Because Python's compatibility connections do not yet enforce SQLite
+    foreign-key actions globally, the merge must explicitly preserve the
+    losing aggregate's discovery evidence under the surviving stable JobId
+    before deleting the losing row.
+    """
+    if losing_job_url == surviving_job_url:
+        return
+    identities = conn.execute(
+        """
+        SELECT url, tenant_id, job_id
+        FROM jobs
+        WHERE url IN (?, ?)
+        """,
+        (losing_job_url, surviving_job_url),
+    ).fetchall()
+    by_url = {
+        str(row["url"] if isinstance(row, sqlite3.Row) else row[0]): (
+            str(row["tenant_id"] if isinstance(row, sqlite3.Row) else row[1]),
+            str(row["job_id"] if isinstance(row, sqlite3.Row) else row[2]),
+        )
+        for row in identities
+    }
+    losing_identity = by_url.get(losing_job_url)
+    surviving_identity = by_url.get(surviving_job_url)
+    if losing_identity is None or surviving_identity is None:
+        raise RuntimeError(
+            "URL collision merge requires both losing and surviving jobs"
+        )
+    losing_tenant, losing_job_id = losing_identity
+    surviving_tenant, surviving_job_id = surviving_identity
+    if losing_tenant != surviving_tenant:
+        raise RuntimeError(
+            "URL collision merge cannot cross tenant boundaries"
+        )
+    if not losing_job_id or not surviving_job_id:
+        raise RuntimeError(
+            "URL collision merge requires stable JobIds"
+        )
+
+    tenant_id = losing_tenant
+    conn.execute(
+        """
+        UPDATE job_source_observations
+        SET job_id = ?
+        WHERE tenant_id = ? AND job_id = ?
+        """,
+        (surviving_job_id, tenant_id, losing_job_id),
+    )
+
+    losing_canonical = conn.execute(
+        """
+        SELECT 1
+        FROM job_canonical_identities
+        WHERE tenant_id = ? AND job_id = ?
+        """,
+        (tenant_id, losing_job_id),
+    ).fetchone()
+    if losing_canonical is not None:
+        surviving_canonical = conn.execute(
+            """
+            SELECT 1
+            FROM job_canonical_identities
+            WHERE tenant_id = ? AND job_id = ?
+            """,
+            (tenant_id, surviving_job_id),
+        ).fetchone()
+        if surviving_canonical is None:
+            conn.execute(
+                """
+                UPDATE job_canonical_identities
+                SET job_id = ?
+                WHERE tenant_id = ? AND job_id = ?
+                """,
+                (surviving_job_id, tenant_id, losing_job_id),
+            )
+        else:
+            conn.execute(
+                """
+                DELETE FROM job_canonical_identities
+                WHERE tenant_id = ? AND job_id = ?
+                """,
+                (tenant_id, losing_job_id),
+            )
+
+    conn.execute(
+        """
+        UPDATE job_duplicate_links
+        SET surviving_job_id = ?
+        WHERE tenant_id = ? AND surviving_job_id = ?
+        """,
+        (surviving_job_id, tenant_id, losing_job_id),
+    )
+    conn.execute(
+        """
+        DELETE FROM job_rejected_duplicate_links AS losing
+        WHERE losing.tenant_id = ?
+          AND losing.owner_job_id = ?
+          AND EXISTS (
+              SELECT 1
+              FROM job_rejected_duplicate_links AS surviving
+              WHERE surviving.tenant_id = losing.tenant_id
+                AND surviving.owner_job_id = ?
+                AND surviving.candidate_url = losing.candidate_url
+          )
+        """,
+        (tenant_id, losing_job_id, surviving_job_id),
+    )
+    conn.execute(
+        """
+        UPDATE job_rejected_duplicate_links
+        SET owner_job_id = ?
+        WHERE tenant_id = ? AND owner_job_id = ?
+        """,
+        (surviving_job_id, tenant_id, losing_job_id),
+    )
+
+
+def _table_columns(conn: sqlite3.Connection, table_name: str) -> set[str]:
+    return {
+        str(row[1])
+        for row in conn.execute(f'PRAGMA table_info("{table_name}")').fetchall()
+    }
+
+
+def _legacy_or_stable_reference_column(
+    conn: sqlite3.Connection,
+    table: str,
+    *,
+    stable: str,
+    legacy: str,
+) -> str:
+    columns = _table_columns(conn, table)
+    if stable in columns:
+        return stable
+    if legacy in columns:
+        return legacy
+    raise RuntimeError(
+        f"discovery identity migration found no job reference in {table}"
+    )
+
+
+def _resolved_job_id_sql(table_alias: str, reference_column: str) -> str:
+    """Return a correlated SQL expression resolving a legacy or stable key."""
+
+    reference = f"{table_alias}.{reference_column}"
+    tenant = f"{table_alias}.tenant_id"
+    return f"""
+        COALESCE(
+            (
+                SELECT j.job_id
+                FROM jobs j
+                WHERE j.tenant_id = {tenant}
+                  AND j.job_id = {reference}
+                LIMIT 1
+            ),
+            (
+                SELECT j.job_id
+                FROM jobs j
+                WHERE j.tenant_id = {tenant}
+                  AND j.url = {reference}
+                LIMIT 1
+            ),
+            (
+                SELECT a.job_id
+                FROM job_identity_aliases a
+                JOIN jobs j
+                  ON j.tenant_id = a.tenant_id
+                 AND j.job_id = a.job_id
+                WHERE a.tenant_id = {tenant}
+                  AND a.alias_kind = 'posting_url'
+                  AND a.alias_value = {reference}
+                LIMIT 1
+            )
+        )
+    """
+
+
+def _create_discovery_identity_v8_rebuild_tables(
+    conn: sqlite3.Connection,
+) -> None:
+    for table in _DISCOVERY_IDENTITY_REFERENCE_TABLES:
+        conn.execute(f'DROP TABLE IF EXISTS "{table}_v8"')
+    conn.execute(
+        """
+        CREATE TABLE job_source_observations_v8 (
+            tenant_id                TEXT NOT NULL DEFAULT 'local',
+            source_observation_id    TEXT NOT NULL,
+            job_id                   TEXT NOT NULL,
+            source_id                TEXT NOT NULL,
+            source_native_id         TEXT NOT NULL,
+            observed_url             TEXT NOT NULL,
+            normalized_observed_url  TEXT NOT NULL,
+            run_id                   TEXT NOT NULL DEFAULT '',
+            observed_at              TEXT NOT NULL,
+            PRIMARY KEY (tenant_id, source_observation_id),
+            FOREIGN KEY (tenant_id, job_id)
+                REFERENCES jobs(tenant_id, job_id) ON DELETE CASCADE
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE job_canonical_identities_v8 (
+            tenant_id          TEXT NOT NULL DEFAULT 'local',
+            job_id             TEXT NOT NULL,
+            canonical_url      TEXT NOT NULL,
+            ats_kind           TEXT NOT NULL,
+            source_native_id   TEXT NOT NULL,
+            confidence         REAL NOT NULL,
+            resolved_at        TEXT NOT NULL,
+            PRIMARY KEY (tenant_id, job_id),
+            FOREIGN KEY (tenant_id, job_id)
+                REFERENCES jobs(tenant_id, job_id) ON DELETE CASCADE
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE job_duplicate_links_v8 (
+            tenant_id                              TEXT NOT NULL DEFAULT 'local',
+            duplicate_link_id                      TEXT NOT NULL,
+            surviving_job_id                       TEXT NOT NULL,
+            superseded_job_or_observation_id       TEXT NOT NULL,
+            reason                                 TEXT NOT NULL,
+            confidence                             REAL NOT NULL,
+            linked_at                              TEXT NOT NULL,
+            PRIMARY KEY (tenant_id, duplicate_link_id),
+            FOREIGN KEY (tenant_id, surviving_job_id)
+                REFERENCES jobs(tenant_id, job_id) ON DELETE CASCADE
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE job_rejected_duplicate_links_v8 (
+            tenant_id       TEXT NOT NULL DEFAULT 'local',
+            owner_job_id    TEXT NOT NULL,
+            candidate_url   TEXT NOT NULL,
+            reason          TEXT NOT NULL,
+            rejected_at     TEXT NOT NULL,
+            PRIMARY KEY (tenant_id, owner_job_id, candidate_url),
+            FOREIGN KEY (tenant_id, owner_job_id)
+                REFERENCES jobs(tenant_id, job_id) ON DELETE CASCADE
+        )
+        """
+    )
+
+
+def _create_discovery_identity_v8_indexes(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        """
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_job_source_observations_native
+        ON job_source_observations(tenant_id, source_id, source_native_id)
+        """
+    )
+    conn.execute(
+        """
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_job_source_observations_normalized_url
+        ON job_source_observations(tenant_id, normalized_observed_url)
+        """
+    )
+    conn.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_job_source_observations_job
+        ON job_source_observations(tenant_id, job_id)
+        """
+    )
+    conn.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_job_canonical_identities_canonical_url
+        ON job_canonical_identities(tenant_id, canonical_url)
+        """
+    )
+    conn.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_job_duplicate_links_surviving
+        ON job_duplicate_links(tenant_id, surviving_job_id)
+        """
+    )
+
+
+def _has_composite_job_id_foreign_key(
+    conn: sqlite3.Connection,
+    table: str,
+    reference_column: str,
+) -> bool:
+    groups: dict[int, set[tuple[str, str]]] = {}
+    cascades: dict[int, bool] = {}
+    for row in conn.execute(f'PRAGMA foreign_key_list("{table}")').fetchall():
+        if str(row[2]) != "jobs":
+            continue
+        foreign_key_id = int(row[0])
+        groups.setdefault(foreign_key_id, set()).add(
+            (str(row[3]), str(row[4]))
+        )
+        cascades[foreign_key_id] = str(row[6]).upper() == "CASCADE"
+    expected = {("tenant_id", "tenant_id"), (reference_column, "job_id")}
+    return any(
+        columns == expected and cascades.get(foreign_key_id, False)
+        for foreign_key_id, columns in groups.items()
+    )
+
+
+def _primary_key_columns(
+    conn: sqlite3.Connection,
+    table: str,
+) -> tuple[str, ...]:
+    keyed = [
+        (int(row[5]), str(row[1]))
+        for row in conn.execute(f'PRAGMA table_info("{table}")').fetchall()
+        if int(row[5]) > 0
+    ]
+    return tuple(column for _position, column in sorted(keyed))
+
+
+def _has_index(
+    conn: sqlite3.Connection,
+    table: str,
+    name: str,
+    columns: tuple[str, ...],
+    *,
+    unique: bool,
+) -> bool:
+    index_row = next(
+        (
+            row
+            for row in conn.execute(
+                f'PRAGMA index_list("{table}")'
+            ).fetchall()
+            if str(row[1]) == name
+        ),
+        None,
+    )
+    if index_row is None or bool(index_row[2]) is not unique:
+        return False
+    actual_columns = tuple(
+        str(row[2])
+        for row in conn.execute(f'PRAGMA index_info("{name}")').fetchall()
+    )
+    return actual_columns == columns
+
+
+def _has_discovery_identity_reference_schema_v8(
+    conn: sqlite3.Connection,
+) -> bool:
+    return (
+        "job_id" in _table_columns(conn, "job_source_observations")
+        and "job_url" not in _table_columns(conn, "job_source_observations")
+        and _primary_key_columns(conn, "job_source_observations")
+        == ("tenant_id", "source_observation_id")
+        and _has_composite_job_id_foreign_key(
+            conn,
+            "job_source_observations",
+            "job_id",
+        )
+        and _has_index(
+            conn,
+            "job_source_observations",
+            "idx_job_source_observations_native",
+            ("tenant_id", "source_id", "source_native_id"),
+            unique=True,
+        )
+        and _has_index(
+            conn,
+            "job_source_observations",
+            "idx_job_source_observations_normalized_url",
+            ("tenant_id", "normalized_observed_url"),
+            unique=True,
+        )
+        and _has_index(
+            conn,
+            "job_source_observations",
+            "idx_job_source_observations_job",
+            ("tenant_id", "job_id"),
+            unique=False,
+        )
+        and "job_id" in _table_columns(conn, "job_canonical_identities")
+        and "job_url" not in _table_columns(conn, "job_canonical_identities")
+        and _primary_key_columns(conn, "job_canonical_identities")
+        == ("tenant_id", "job_id")
+        and _has_composite_job_id_foreign_key(
+            conn,
+            "job_canonical_identities",
+            "job_id",
+        )
+        and _has_index(
+            conn,
+            "job_canonical_identities",
+            "idx_job_canonical_identities_canonical_url",
+            ("tenant_id", "canonical_url"),
+            unique=False,
+        )
+        and _primary_key_columns(conn, "job_duplicate_links")
+        == ("tenant_id", "duplicate_link_id")
+        and _has_composite_job_id_foreign_key(
+            conn,
+            "job_duplicate_links",
+            "surviving_job_id",
+        )
+        and _has_index(
+            conn,
+            "job_duplicate_links",
+            "idx_job_duplicate_links_surviving",
+            ("tenant_id", "surviving_job_id"),
+            unique=False,
+        )
+        and "owner_job_id"
+        in _table_columns(conn, "job_rejected_duplicate_links")
+        and "owner_job_url"
+        not in _table_columns(conn, "job_rejected_duplicate_links")
+        and _primary_key_columns(conn, "job_rejected_duplicate_links")
+        == ("tenant_id", "owner_job_id", "candidate_url")
+        and _has_composite_job_id_foreign_key(
+            conn,
+            "job_rejected_duplicate_links",
+            "owner_job_id",
+        )
+    )
+
+
+def _verify_discovery_identity_references_v8(
+    conn: sqlite3.Connection,
+    *,
+    expected_counts: dict[str, int],
+) -> None:
+    if not _has_discovery_identity_reference_schema_v8(conn):
+        raise RuntimeError(
+            "discovery identity migration did not create the stable reference schema"
+        )
+    for table, expected_count in expected_counts.items():
+        observed_count = int(
+            conn.execute(f'SELECT COUNT(*) FROM "{table}"').fetchone()[0]
+        )
+        if observed_count != expected_count:
+            raise RuntimeError(
+                "discovery identity migration changed row count for "
+                f"{table}: expected {expected_count}, found {observed_count}"
+            )
+
+    references = (
+        ("job_source_observations", "job_id"),
+        ("job_canonical_identities", "job_id"),
+        ("job_duplicate_links", "surviving_job_id"),
+        ("job_rejected_duplicate_links", "owner_job_id"),
+    )
+    for table, column in references:
+        orphan = conn.execute(
+            f"""
+            SELECT source.{column}
+            FROM {table} source
+            LEFT JOIN jobs j
+              ON j.tenant_id = source.tenant_id
+             AND j.job_id = source.{column}
+            WHERE j.job_id IS NULL
+            LIMIT 1
+            """
+        ).fetchone()
+        if orphan is not None:
+            raise RuntimeError(
+                "discovery identity migration left an unresolved reference in "
+                f"{table}.{column}"
+            )
+
+    foreign_key_error = conn.execute("PRAGMA foreign_key_check").fetchone()
+    if foreign_key_error is not None:
+        raise RuntimeError(
+            "discovery identity migration found a foreign-key violation"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/workers/automation/src/jobctrl/discovery/jobspy.py
+++ b/workers/automation/src/jobctrl/discovery/jobspy.py
@@ -908,6 +908,19 @@ def _record_content_duplicate_link(
     _apply_write_fence(write_fence)
     duplicate_link_id = "content:" + link_key[:32]
     normalized_url = normalize_observed_url(duplicate_url)
+    owner = conn.execute(
+        """
+        SELECT job_id
+        FROM jobs
+        WHERE tenant_id = 'local' AND url = ?
+        """,
+        (surviving_url,),
+    ).fetchone()
+    if owner is None or not str(owner[0] or "").strip():
+        raise RuntimeError(
+            "content duplicate owner is missing its stable JobId"
+        )
+    surviving_job_id = str(owner[0])
     conn.execute(
         """
         INSERT OR IGNORE INTO job_duplicate_links (
@@ -915,19 +928,19 @@ def _record_content_duplicate_link(
             superseded_job_or_observation_id, reason, confidence, linked_at
         ) VALUES ('local', ?, ?, ?, 'content_fingerprint_match', 0.95, ?)
         """,
-        (duplicate_link_id, surviving_url, duplicate_url, observed_at),
+        (duplicate_link_id, surviving_job_id, duplicate_url, observed_at),
     )
     conn.execute(
         """
         INSERT OR IGNORE INTO job_source_observations (
-            tenant_id, source_observation_id, job_url, source_id,
+            tenant_id, source_observation_id, job_id, source_id,
             source_native_id, observed_url, normalized_observed_url,
             run_id, observed_at
         ) VALUES ('local', ?, ?, ?, ?, ?, ?, 'jobspy', ?)
         """,
         (
             f"content-duplicate:{duplicate_link_id}",
-            surviving_url,
+            surviving_job_id,
             source,
             duplicate_url,
             duplicate_url,

--- a/workers/automation/src/jobctrl/domain/apply/repeat_application.py
+++ b/workers/automation/src/jobctrl/domain/apply/repeat_application.py
@@ -449,9 +449,13 @@ def _canonical_identity_relationship(conn, target_job_key: str, prior_job_key: s
         return None
     rows = conn.execute(
         """
-        SELECT job_url, canonical_url, ats_kind, source_native_id
-          FROM job_canonical_identities
-         WHERE tenant_id = ? AND job_url IN (?, ?)
+        SELECT j.url AS job_url, c.canonical_url, c.ats_kind,
+               c.source_native_id
+          FROM job_canonical_identities c
+          JOIN jobs j
+            ON j.tenant_id = c.tenant_id
+           AND j.job_id = c.job_id
+         WHERE c.tenant_id = ? AND j.url IN (?, ?)
         """,
         (LOCAL_TENANT, target_job_key, prior_job_key),
     ).fetchall()
@@ -500,14 +504,38 @@ def _accepted_duplicate_relationship(conn, target_job_key: str, prior_job_key: s
 
 def _job_aliases(conn, job_key: str) -> set[str]:
     aliases = {job_key}
+    job = conn.execute(
+        """
+        SELECT job_id
+        FROM jobs
+        WHERE tenant_id = ? AND url = ?
+        """,
+        (LOCAL_TENANT, job_key),
+    ).fetchone()
+    if job is None:
+        return aliases
+    job_id = str(job["job_id"])
+    aliases.add(job_id)
+    if _table_exists(conn, "job_identity_aliases"):
+        aliases.update(
+            str(row["alias_value"])
+            for row in conn.execute(
+                """
+                SELECT alias_value
+                FROM job_identity_aliases
+                WHERE tenant_id = ? AND job_id = ?
+                """,
+                (LOCAL_TENANT, job_id),
+            ).fetchall()
+        )
     if not _table_exists(conn, "job_source_observations"):
         return aliases
     rows = conn.execute(
         """
         SELECT source_observation_id, observed_url, normalized_observed_url
-          FROM job_source_observations WHERE tenant_id = ? AND job_url = ?
+          FROM job_source_observations WHERE tenant_id = ? AND job_id = ?
         """,
-        (LOCAL_TENANT, job_key),
+        (LOCAL_TENANT, job_id),
     ).fetchall()
     for row in rows:
         aliases.update(str(value) for value in row if value)

--- a/workers/automation/src/jobctrl/enrichment/detail.py
+++ b/workers/automation/src/jobctrl/enrichment/detail.py
@@ -36,7 +36,11 @@ from urllib.parse import urljoin, urlparse
 from playwright.sync_api import sync_playwright
 
 from jobctrl import database as db_module
-from jobctrl.database import ensure_discovery_control_tables, init_db
+from jobctrl.database import (
+    ensure_discovery_control_tables,
+    init_db,
+    reassign_discovery_identity_references,
+)
 from jobctrl.domain.enrichment import (
     ActiveState,
     DetailPage,
@@ -260,6 +264,11 @@ def resolve_all_urls(conn: sqlite3.Connection) -> dict:
                 conn.execute("UPDATE jobs SET url = ? WHERE url = ?", (new_url, url))
                 resolved += 1
             except sqlite3.IntegrityError:
+                reassign_discovery_identity_references(
+                    conn,
+                    losing_job_url=url,
+                    surviving_job_url=new_url,
+                )
                 conn.execute("DELETE FROM jobs WHERE url = ?", (url,))
                 resolved += 1
         else:
@@ -350,6 +359,11 @@ def resolve_wttj_urls(conn: sqlite3.Connection) -> int:
                 )
                 updated += 1
             except sqlite3.IntegrityError:
+                reassign_discovery_identity_references(
+                    conn,
+                    losing_job_url=old_url,
+                    surviving_job_url=match["url"],
+                )
                 conn.execute("DELETE FROM jobs WHERE url = ?", (old_url,))
                 updated += 1
         else:
@@ -362,6 +376,11 @@ def resolve_wttj_urls(conn: sqlite3.Connection) -> int:
                         )
                         updated += 1
                     except sqlite3.IntegrityError:
+                        reassign_discovery_identity_references(
+                            conn,
+                            losing_job_url=old_url,
+                            surviving_job_url=data["url"],
+                        )
                         conn.execute("DELETE FROM jobs WHERE url = ?", (old_url,))
                         updated += 1
                     break
@@ -1761,9 +1780,12 @@ def _source_id_for_enriched_job(
     try:
         row = conn.execute(
             """
-            SELECT source_id
-            FROM job_source_observations
-            WHERE tenant_id = ? AND job_url = ?
+            SELECT o.source_id
+            FROM job_source_observations o
+            JOIN jobs j
+              ON j.tenant_id = o.tenant_id
+             AND j.job_id = o.job_id
+            WHERE o.tenant_id = ? AND j.url = ?
             ORDER BY observed_at DESC, source_observation_id DESC
             LIMIT 1
             """,

--- a/workers/automation/src/jobctrl/infrastructure/discovery/production_wiring.py
+++ b/workers/automation/src/jobctrl/infrastructure/discovery/production_wiring.py
@@ -784,9 +784,9 @@ def retire_invalid_source_jobs(
         LEFT JOIN job_enrichments e
           ON e.tenant_id = ? AND e.job_url = j.url
         LEFT JOIN job_canonical_identities c
-          ON c.tenant_id = ? AND c.job_url = j.url
+          ON c.tenant_id = ? AND c.job_id = j.job_id
         LEFT JOIN job_source_observations o
-          ON o.tenant_id = ? AND o.job_url = j.url
+          ON o.tenant_id = ? AND o.job_id = j.job_id
         LEFT JOIN jobctrl_deleted_jobs d
           ON d.job_url = j.url
          AND (d.restored_at IS NULL OR julianday(d.restored_at) <= julianday(d.deleted_at))
@@ -1150,7 +1150,7 @@ def build_discovery_acceptance_report(
     lead_yield = _scalar_int(
         conn,
         """
-        SELECT COUNT(DISTINCT job_url)
+        SELECT COUNT(DISTINCT job_id)
         FROM job_source_observations
         WHERE tenant_id = ? AND run_id != 'backfill'
         """,
@@ -1177,7 +1177,7 @@ def build_discovery_acceptance_report(
     )
     canonical_jobs = _scalar_int(
         conn,
-        "SELECT COUNT(DISTINCT job_url) FROM job_canonical_identities WHERE tenant_id = ?",
+        "SELECT COUNT(DISTINCT job_id) FROM job_canonical_identities WHERE tenant_id = ?",
         (tenant,),
     )
     canonical_verification_rate = round(canonical_jobs / lead_yield, 4) if lead_yield else 0.0

--- a/workers/automation/src/jobctrl/infrastructure/discovery/sqlite_repository.py
+++ b/workers/automation/src/jobctrl/infrastructure/discovery/sqlite_repository.py
@@ -231,7 +231,7 @@ class SqliteJobRepository:
             SELECT j.job_id
             FROM jobs j
             JOIN job_source_observations o
-              ON o.job_url = j.url AND o.tenant_id = ?
+              ON o.job_id = j.job_id AND o.tenant_id = ?
             WHERE j.tenant_id = ?
               AND o.normalized_observed_url = ?
             LIMIT 1
@@ -667,7 +667,7 @@ class SqliteJobRepository:
                 FROM job_source_observations o
                 JOIN jobs j
                   ON j.tenant_id = o.tenant_id
-                 AND j.url = o.job_url
+                 AND j.job_id = o.job_id
                 WHERE o.tenant_id = ?
                   AND o.source_id = ?
                   AND o.source_native_id = ?
@@ -694,7 +694,7 @@ class SqliteJobRepository:
                 FROM job_canonical_identities c
                 JOIN jobs j
                   ON j.tenant_id = c.tenant_id
-                 AND j.url = c.job_url
+                 AND j.job_id = c.job_id
                 WHERE c.tenant_id = ? AND c.canonical_url = ?
                 LIMIT 1
                 """,
@@ -713,7 +713,7 @@ class SqliteJobRepository:
                     FROM job_source_observations o
                     JOIN jobs j
                       ON j.tenant_id = o.tenant_id
-                     AND j.url = o.job_url
+                     AND j.job_id = o.job_id
                     WHERE o.tenant_id = ?
                       AND o.normalized_observed_url = ?
                     LIMIT 1
@@ -829,6 +829,7 @@ class SqliteJobRepository:
         """
 
         identity = self._require_identity(tenant_id, job_id)
+        stable_job_id = str(identity.job_id)
         job_url = identity.storage_url.value
         self._fence_search_unit_write()
         normalized = normalize_observed_url(observation.observed_url)
@@ -836,7 +837,7 @@ class SqliteJobRepository:
             """
             UPDATE job_source_observations SET
                 source_observation_id = ?,
-                job_url = ?,
+                job_id = ?,
                 observed_url = ?,
                 normalized_observed_url = ?,
                 run_id = ?,
@@ -845,7 +846,7 @@ class SqliteJobRepository:
             """,
             (
                 observation.source_observation_id,
-                job_url,
+                stable_job_id,
                 observation.observed_url,
                 normalized,
                 observation.run_id,
@@ -860,7 +861,7 @@ class SqliteJobRepository:
                 """
                 UPDATE job_source_observations SET
                     source_observation_id = ?,
-                    job_url = ?,
+                    job_id = ?,
                     source_id = ?,
                     source_native_id = ?,
                     observed_url = ?,
@@ -870,7 +871,7 @@ class SqliteJobRepository:
                 """,
                 (
                     observation.source_observation_id,
-                    job_url,
+                    stable_job_id,
                     observation.source_id,
                     observation.source_native_id,
                     observation.observed_url,
@@ -884,7 +885,7 @@ class SqliteJobRepository:
             self._conn.execute(
                 """
                 INSERT INTO job_source_observations (
-                    tenant_id, source_observation_id, job_url, source_id,
+                    tenant_id, source_observation_id, job_id, source_id,
                     source_native_id, observed_url, normalized_observed_url,
                     run_id, observed_at
                 ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
@@ -892,7 +893,7 @@ class SqliteJobRepository:
                 (
                     str(tenant_id),
                     observation.source_observation_id,
-                    job_url,
+                    stable_job_id,
                     observation.source_id,
                     observation.source_native_id,
                     observation.observed_url,
@@ -940,10 +941,10 @@ class SqliteJobRepository:
         self._conn.execute(
             """
             INSERT INTO job_canonical_identities (
-                tenant_id, job_url, canonical_url, ats_kind,
+                tenant_id, job_id, canonical_url, ats_kind,
                 source_native_id, confidence, resolved_at
             ) VALUES (?, ?, ?, ?, ?, ?, ?)
-            ON CONFLICT (tenant_id, job_url) DO UPDATE SET
+            ON CONFLICT (tenant_id, job_id) DO UPDATE SET
                 canonical_url = excluded.canonical_url,
                 ats_kind = excluded.ats_kind,
                 source_native_id = excluded.source_native_id,
@@ -952,7 +953,7 @@ class SqliteJobRepository:
             """,
             (
                 str(tenant_id),
-                resolved.storage_url.value,
+                str(resolved.job_id),
                 identity.canonical_url,
                 identity.ats_kind.value,
                 identity.source_native_id,
@@ -992,7 +993,7 @@ class SqliteJobRepository:
             (
                 str(tenant_id),
                 link.duplicate_link_id,
-                owner.storage_url.value,
+                str(owner.job_id),
                 link.superseded_job_or_observation_id,
                 link.reason,
                 float(link.confidence),
@@ -1025,13 +1026,13 @@ class SqliteJobRepository:
         self._conn.execute(
             """
             INSERT INTO job_rejected_duplicate_links (
-                tenant_id, owner_job_url, candidate_url, reason, rejected_at
+                tenant_id, owner_job_id, candidate_url, reason, rejected_at
             ) VALUES (?, ?, ?, ?, ?)
-            ON CONFLICT (tenant_id, owner_job_url, candidate_url) DO NOTHING
+            ON CONFLICT (tenant_id, owner_job_id, candidate_url) DO NOTHING
             """,
             (
                 str(tenant_id),
-                owner.storage_url.value,
+                str(owner.job_id),
                 str(candidate_url),
                 reason,
                 rejected_at,
@@ -1055,10 +1056,10 @@ class SqliteJobRepository:
             SELECT source_observation_id, source_id, source_native_id,
                    observed_url, run_id, observed_at
             FROM job_source_observations
-            WHERE tenant_id = ? AND job_url = ?
+            WHERE tenant_id = ? AND job_id = ?
             ORDER BY observed_at ASC
             """,
-            (str(tenant_id), identity.storage_url.value),
+            (str(tenant_id), str(identity.job_id)),
         ).fetchall()
         return [
             JobSourceObservation(
@@ -1086,10 +1087,10 @@ class SqliteJobRepository:
             """
             SELECT canonical_url, ats_kind, source_native_id, confidence
             FROM job_canonical_identities
-            WHERE tenant_id = ? AND job_url = ?
+            WHERE tenant_id = ? AND job_id = ?
             LIMIT 1
             """,
-            (str(tenant_id), identity.storage_url.value),
+            (str(tenant_id), str(identity.job_id)),
         ).fetchone()
         if row is None:
             return None

--- a/workers/automation/src/jobctrl/scoring/scorer.py
+++ b/workers/automation/src/jobctrl/scoring/scorer.py
@@ -1017,7 +1017,7 @@ def _preferred_direct_score_for_repost(
         FROM jobs j
         LEFT JOIN job_enrichments je ON je.job_url = j.url
         LEFT JOIN job_canonical_identities c
-          ON c.tenant_id = ? AND c.job_url = j.url
+          ON c.tenant_id = ? AND c.job_id = j.job_id
         {deleted_join}
         INNER JOIN (
             SELECT job_url, MAX(version) AS max_version
@@ -1074,8 +1074,11 @@ def _is_reference_repost_candidate(
     row = conn.execute(
         """
         SELECT ats_kind
-        FROM job_canonical_identities
-        WHERE tenant_id = ? AND job_url = ?
+        FROM job_canonical_identities c
+        JOIN jobs j
+          ON j.tenant_id = c.tenant_id
+         AND j.job_id = c.job_id
+        WHERE c.tenant_id = ? AND j.url = ?
         ORDER BY confidence DESC
         LIMIT 1
         """,

--- a/workers/automation/tests/test_discovery_execution_lineage.py
+++ b/workers/automation/tests/test_discovery_execution_lineage.py
@@ -168,7 +168,11 @@ def test_source_observation_retry_links_once_without_rewriting_first_link(
     # The source observation remains mutable metadata and is intentionally not
     # the authority for the immutable execution link above.
     source_row = conn.execute(
-        "SELECT run_id, observed_at FROM job_source_observations WHERE job_url = ?",
+        """
+        SELECT run_id, observed_at
+        FROM job_source_observations
+        WHERE job_id = (SELECT job_id FROM jobs WHERE url = ?)
+        """,
         (job_url,),
     ).fetchone()
     assert tuple(source_row) == ("source-run-retry", "2026-07-14T09:05:00+00:00")

--- a/workers/automation/tests/test_discovery_identity.py
+++ b/workers/automation/tests/test_discovery_identity.py
@@ -121,20 +121,21 @@ def _long_description(marker: str, tokens: int = 90) -> str:
 
 def test_source_observation_backfill_seeds_legacy_jobs(conn: sqlite3.Connection) -> None:
     repo = SqliteJobRepository(conn)
-    repo.save(_job())
+    stable_job_id = repo.save(_job())
 
     ensure_source_observation_tables(conn)
 
     row = conn.execute(
         """
-        SELECT source_observation_id, job_url, source_id, source_native_id,
+        SELECT source_observation_id, job_id, source_id, source_native_id,
                observed_url, normalized_observed_url, run_id, observed_at
         FROM job_source_observations
-        WHERE job_url = ?
+        WHERE job_id = ?
         """,
-        ("https://boards.greenhouse.io/acme/jobs/123",),
+        (str(stable_job_id),),
     ).fetchone()
     assert row is not None
+    assert row["job_id"] == str(stable_job_id)
     assert row["source_observation_id"] == "backfill:https://boards.greenhouse.io/acme/jobs/123"
     assert row["source_id"] == "greenhouse"
     assert row["source_native_id"] == "https://boards.greenhouse.io/acme/jobs/123"
@@ -352,9 +353,7 @@ def test_duplicate_links_are_persisted(conn: sqlite3.Connection) -> None:
         """
     ).fetchone()
     assert row is not None
-    # The domain call above carries the stable id; the adapter alone translates
-    # it to the compatibility-era URL column.
-    assert row["surviving_job_id"] == str(job.job_id)
+    assert row["surviving_job_id"] == str(stable_job_id)
     assert row["superseded_job_or_observation_id"] == "obs-2"
     assert row["reason"] == "canonical_url_match"
     assert row["confidence"] == 0.91
@@ -934,7 +933,9 @@ def test_discover_jobs_use_case_collapses_jobspy_job_rediscovered_by_canonical_s
         "workday:acme",
     ]
     link = conn.execute("SELECT surviving_job_id, reason, confidence FROM job_duplicate_links").fetchone()
-    assert link["surviving_job_id"] == survivor
+    surviving_job = repo.load(LOCAL_TENANT, JobId(survivor))
+    assert surviving_job is not None
+    assert link["surviving_job_id"] == str(surviving_job.job_id)
     assert link["reason"] == "content_fingerprint_match"
     assert link["confidence"] == 0.95
     assert [event.event_type for event in publisher.events] == [
@@ -1009,7 +1010,7 @@ def test_discover_jobs_use_case_collapses_reworded_cross_source_description(
     assert duplicate_lookup is not None
     assert duplicate_lookup.job_id == surviving_job.job_id
     link = conn.execute("SELECT surviving_job_id, reason, confidence FROM job_duplicate_links").fetchone()
-    assert link["surviving_job_id"] == survivor
+    assert link["surviving_job_id"] == str(surviving_job.job_id)
     assert link["reason"] == "content_shingle_match"
     assert link["confidence"] == 0.85
 
@@ -1092,8 +1093,10 @@ def test_discover_jobs_use_case_matches_fresh_listing_against_enriched_owner(
     assert summary.observed == 1
     assert summary.duplicates_linked == 1
     assert conn.execute("SELECT COUNT(*) FROM jobs").fetchone()[0] == 1
+    surviving_job = repo.load(LOCAL_TENANT, JobId(survivor))
+    assert surviving_job is not None
     link = conn.execute("SELECT surviving_job_id, reason, confidence FROM job_duplicate_links").fetchone()
-    assert link["surviving_job_id"] == survivor
+    assert link["surviving_job_id"] == str(surviving_job.job_id)
     assert link["reason"] == "content_shingle_match"
     assert link["confidence"] == 0.85
 

--- a/workers/automation/tests/test_discovery_identity_reference_migration.py
+++ b/workers/automation/tests/test_discovery_identity_reference_migration.py
@@ -1,0 +1,420 @@
+"""Schema-v8 discovery identity-reference migration contracts."""
+
+from __future__ import annotations
+
+import shutil
+import sqlite3
+import uuid
+from pathlib import Path
+
+import pytest
+
+from jobctrl.database import (
+    SCHEMA_VERSION,
+    _assert_schema_version_supported,
+    close_connection,
+    init_db,
+)
+from jobctrl.domain.discovery import (
+    Employer,
+    Job,
+    JobMetadata,
+    PostingUrl,
+    SearchStrategy,
+    Source,
+)
+from jobctrl.domain.identifiers import JobId
+from jobctrl.domain.tenant import LOCAL_TENANT
+from jobctrl.infrastructure.discovery import SqliteJobRepository
+
+
+PREVIOUS_SCHEMA_VERSION = 7
+REFERENCE_TABLES = (
+    "job_source_observations",
+    "job_canonical_identities",
+    "job_duplicate_links",
+    "job_rejected_duplicate_links",
+)
+
+
+def _downgrade_discovery_references_to_v7(conn: sqlite3.Connection) -> None:
+    for table in reversed(REFERENCE_TABLES):
+        conn.execute(f'DROP TABLE "{table}"')
+    conn.executescript(
+        """
+        CREATE TABLE job_source_observations (
+            tenant_id                TEXT NOT NULL DEFAULT 'local',
+            source_observation_id    TEXT NOT NULL,
+            job_url                  TEXT NOT NULL,
+            source_id                TEXT NOT NULL,
+            source_native_id         TEXT NOT NULL,
+            observed_url             TEXT NOT NULL,
+            normalized_observed_url  TEXT NOT NULL,
+            run_id                   TEXT NOT NULL DEFAULT '',
+            observed_at              TEXT NOT NULL,
+            PRIMARY KEY (tenant_id, source_observation_id),
+            FOREIGN KEY (job_url) REFERENCES jobs(url) ON DELETE CASCADE
+        );
+        CREATE UNIQUE INDEX idx_job_source_observations_native
+            ON job_source_observations(
+                tenant_id, source_id, source_native_id
+            );
+        CREATE UNIQUE INDEX idx_job_source_observations_normalized_url
+            ON job_source_observations(
+                tenant_id, normalized_observed_url
+            );
+        CREATE INDEX idx_job_source_observations_job
+            ON job_source_observations(tenant_id, job_url);
+
+        CREATE TABLE job_canonical_identities (
+            tenant_id          TEXT NOT NULL DEFAULT 'local',
+            job_url            TEXT NOT NULL,
+            canonical_url      TEXT NOT NULL,
+            ats_kind           TEXT NOT NULL,
+            source_native_id   TEXT NOT NULL,
+            confidence         REAL NOT NULL,
+            resolved_at        TEXT NOT NULL,
+            PRIMARY KEY (tenant_id, job_url),
+            FOREIGN KEY (job_url) REFERENCES jobs(url) ON DELETE CASCADE
+        );
+        CREATE INDEX idx_job_canonical_identities_canonical_url
+            ON job_canonical_identities(tenant_id, canonical_url);
+
+        CREATE TABLE job_duplicate_links (
+            tenant_id                        TEXT NOT NULL DEFAULT 'local',
+            duplicate_link_id                TEXT NOT NULL,
+            surviving_job_id                 TEXT NOT NULL,
+            superseded_job_or_observation_id TEXT NOT NULL,
+            reason                           TEXT NOT NULL,
+            confidence                       REAL NOT NULL,
+            linked_at                        TEXT NOT NULL,
+            PRIMARY KEY (tenant_id, duplicate_link_id)
+        );
+        CREATE INDEX idx_job_duplicate_links_surviving
+            ON job_duplicate_links(tenant_id, surviving_job_id);
+
+        CREATE TABLE job_rejected_duplicate_links (
+            tenant_id     TEXT NOT NULL DEFAULT 'local',
+            owner_job_url TEXT NOT NULL,
+            candidate_url TEXT NOT NULL,
+            reason        TEXT NOT NULL,
+            rejected_at   TEXT NOT NULL,
+            PRIMARY KEY (tenant_id, owner_job_url, candidate_url)
+        );
+        """
+    )
+    conn.execute(f"PRAGMA user_version = {PREVIOUS_SCHEMA_VERSION}")
+    conn.commit()
+
+
+def _user_version(db_path: Path) -> int:
+    conn = sqlite3.connect(db_path)
+    try:
+        return int(conn.execute("PRAGMA user_version").fetchone()[0])
+    finally:
+        conn.close()
+
+
+def _columns(db_path: Path, table: str) -> set[str]:
+    conn = sqlite3.connect(db_path)
+    try:
+        return {
+            str(row[1])
+            for row in conn.execute(f'PRAGMA table_info("{table}")').fetchall()
+        }
+    finally:
+        conn.close()
+
+
+def _discovered_job(posting_url: str, job_id: JobId) -> Job:
+    return Job.discover(
+        tenant_id=LOCAL_TENANT,
+        job_id=job_id,
+        posting_url=PostingUrl(value=posting_url),
+        source=Source(board="example"),
+        employer=Employer(name="Example"),
+        search_strategy=SearchStrategy.JOBSPY,
+        metadata=JobMetadata(title="Platform Engineer"),
+        discovered_at="2026-07-28T10:00:00+00:00",
+    )
+
+
+def test_v7_discovery_references_migrate_to_stable_job_id_and_reopen(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    pre_upgrade = tmp_path / "jobctrl-v7.db"
+    conn = init_db(db_path)
+    job_id = str(uuid.uuid4())
+    storage_url = "https://boards.example/jobs/123"
+    current_url = "https://careers.example/jobs/platform-engineer"
+    observed_url = "https://aggregator.example/view/123?ref=feed"
+    normalized_observed_url = "https://aggregator.example/view/123"
+    candidate_url = "https://another.example/jobs/duplicate"
+    stable_job_id = JobId(job_id)
+    repository = SqliteJobRepository(conn)
+    repository.save(_discovered_job(storage_url, stable_job_id))
+    repository.save(_discovered_job(current_url, stable_job_id))
+    aliases = conn.execute(
+        """
+        SELECT alias_value, retired_at
+        FROM job_identity_aliases
+        WHERE tenant_id = 'local' AND job_id = ?
+        """,
+        (job_id,),
+    ).fetchall()
+    assert {str(row[0]): row[1] is None for row in aliases} == {
+        storage_url: False,
+        current_url: True,
+    }
+    _downgrade_discovery_references_to_v7(conn)
+    conn.execute(
+        """
+        INSERT INTO job_source_observations (
+            tenant_id, source_observation_id, job_url, source_id,
+            source_native_id, observed_url, normalized_observed_url,
+            run_id, observed_at
+        ) VALUES ('local', 'obs-1', ?, 'feed:example', 'native-123', ?, ?,
+                  'discover-run', '2026-07-28T10:01:00+00:00')
+        """,
+        (storage_url, observed_url, normalized_observed_url),
+    )
+    conn.execute(
+        """
+        INSERT INTO job_canonical_identities (
+            tenant_id, job_url, canonical_url, ats_kind, source_native_id,
+            confidence, resolved_at
+        ) VALUES ('local', ?, ?, 'greenhouse', 'native-123', 0.98,
+                  '2026-07-28T10:02:00+00:00')
+        """,
+        (storage_url, current_url),
+    )
+    conn.execute(
+        """
+        INSERT INTO job_duplicate_links (
+            tenant_id, duplicate_link_id, surviving_job_id,
+            superseded_job_or_observation_id, reason, confidence, linked_at
+        ) VALUES ('local', 'dup-1', ?, 'obs-duplicate',
+                  'canonical_url_match', 0.95,
+                  '2026-07-28T10:03:00+00:00')
+        """,
+        (current_url,),
+    )
+    conn.execute(
+        """
+        INSERT INTO job_rejected_duplicate_links (
+            tenant_id, owner_job_url, candidate_url, reason, rejected_at
+        ) VALUES ('local', ?, ?, 'employer_mismatch',
+                  '2026-07-28T10:04:00+00:00')
+        """,
+        (current_url, candidate_url),
+    )
+    conn.commit()
+    before_counts = {
+        table: int(conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0])
+        for table in REFERENCE_TABLES
+    }
+    close_connection(db_path)
+    shutil.copy2(db_path, pre_upgrade)
+
+    init_db(db_path)
+    close_connection(db_path)
+
+    assert _user_version(db_path) == SCHEMA_VERSION == 8
+    assert "job_id" in _columns(db_path, "job_source_observations")
+    assert "job_url" not in _columns(db_path, "job_source_observations")
+    assert "job_id" in _columns(db_path, "job_canonical_identities")
+    assert "job_url" not in _columns(db_path, "job_canonical_identities")
+    assert "owner_job_id" in _columns(
+        db_path,
+        "job_rejected_duplicate_links",
+    )
+    assert "owner_job_url" not in _columns(
+        db_path,
+        "job_rejected_duplicate_links",
+    )
+
+    check = sqlite3.connect(db_path)
+    check.row_factory = sqlite3.Row
+    try:
+        after_counts = {
+            table: int(
+                check.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]
+            )
+            for table in REFERENCE_TABLES
+        }
+        assert after_counts == before_counts
+        observation = check.execute(
+            """
+            SELECT job_id, observed_url, normalized_observed_url
+            FROM job_source_observations
+            """
+        ).fetchone()
+        canonical = check.execute(
+            """
+            SELECT job_id, canonical_url
+            FROM job_canonical_identities
+            """
+        ).fetchone()
+        duplicate = check.execute(
+            """
+            SELECT surviving_job_id, superseded_job_or_observation_id
+            FROM job_duplicate_links
+            """
+        ).fetchone()
+        rejected = check.execute(
+            """
+            SELECT owner_job_id, candidate_url
+            FROM job_rejected_duplicate_links
+            """
+        ).fetchone()
+        assert tuple(observation) == (
+            job_id,
+            observed_url,
+            normalized_observed_url,
+        )
+        assert tuple(canonical) == (job_id, current_url)
+        assert tuple(duplicate) == (job_id, "obs-duplicate")
+        assert tuple(rejected) == (job_id, candidate_url)
+        assert check.execute("PRAGMA foreign_key_check").fetchone() is None
+    finally:
+        check.close()
+
+    first_check = sqlite3.connect(db_path)
+    try:
+        first_rows = first_check.execute(
+            """
+            SELECT job_id, observed_url
+            FROM job_source_observations
+            """
+        ).fetchall()
+    finally:
+        first_check.close()
+    init_db(db_path)
+    close_connection(db_path)
+    reopened = sqlite3.connect(db_path)
+    try:
+        assert (
+            reopened.execute(
+                """
+                SELECT job_id, observed_url
+                FROM job_source_observations
+                """
+            ).fetchall()
+            == first_rows
+        )
+    finally:
+        reopened.close()
+
+    previous = sqlite3.connect(pre_upgrade)
+    try:
+        assert (
+            _assert_schema_version_supported(
+                previous,
+                supported_version=PREVIOUS_SCHEMA_VERSION,
+            )
+            == PREVIOUS_SCHEMA_VERSION
+        )
+        assert "job_url" in {
+            str(row[1])
+            for row in previous.execute(
+                "PRAGMA table_info(job_source_observations)"
+            ).fetchall()
+        }
+    finally:
+        previous.close()
+
+
+def test_unresolved_v7_reference_rolls_back_and_remains_retryable(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    conn = init_db(db_path)
+    job_id = str(uuid.uuid4())
+    job_url = "https://example.com/jobs/valid"
+    conn.execute(
+        """
+        INSERT INTO jobs (url, tenant_id, job_id, title)
+        VALUES (?, 'local', ?, 'Engineer')
+        """,
+        (job_url, job_id),
+    )
+    conn.commit()
+    _downgrade_discovery_references_to_v7(conn)
+    conn.execute(
+        """
+        INSERT INTO job_duplicate_links (
+            tenant_id, duplicate_link_id, surviving_job_id,
+            superseded_job_or_observation_id, reason, confidence, linked_at
+        ) VALUES ('local', 'dup-orphan', 'https://example.com/jobs/missing',
+                  'obs-missing', 'canonical_url_match', 0.9,
+                  '2026-07-28T10:00:00+00:00')
+        """
+    )
+    conn.commit()
+    close_connection(db_path)
+
+    with pytest.raises(
+        RuntimeError,
+        match="could not resolve job_duplicate_links.surviving_job_id",
+    ):
+        init_db(db_path)
+    close_connection(db_path)
+
+    assert _user_version(db_path) == PREVIOUS_SCHEMA_VERSION
+    assert "job_url" in _columns(db_path, "job_source_observations")
+    check = sqlite3.connect(db_path)
+    try:
+        row = check.execute(
+            """
+            SELECT surviving_job_id
+            FROM job_duplicate_links
+            WHERE duplicate_link_id = 'dup-orphan'
+            """
+        ).fetchone()
+        assert row == ("https://example.com/jobs/missing",)
+        assert (
+            check.execute(
+                "SELECT COUNT(*) FROM job_source_observations"
+            ).fetchone()[0]
+            == 0
+        )
+        assert not check.execute(
+            """
+            SELECT 1
+            FROM sqlite_master
+            WHERE type = 'table' AND name LIKE '%_v8'
+            """
+        ).fetchall()
+        check.execute(
+            """
+            UPDATE job_duplicate_links
+            SET surviving_job_id = ?
+            WHERE duplicate_link_id = 'dup-orphan'
+            """,
+            (job_url,),
+        )
+        check.commit()
+    finally:
+        check.close()
+
+    init_db(db_path)
+    close_connection(db_path)
+    assert _user_version(db_path) == SCHEMA_VERSION
+    migrated = sqlite3.connect(db_path)
+    try:
+        assert migrated.execute(
+            """
+            SELECT surviving_job_id
+            FROM job_duplicate_links
+            WHERE duplicate_link_id = 'dup-orphan'
+            """
+        ).fetchone() == (job_id,)
+        assert migrated.execute(
+            """
+            SELECT job_id, observed_url, run_id
+            FROM job_source_observations
+            """
+        ).fetchone() == (job_id, job_url, "backfill")
+    finally:
+        migrated.close()

--- a/workers/automation/tests/test_discovery_limits.py
+++ b/workers/automation/tests/test_discovery_limits.py
@@ -30,6 +30,15 @@ def _jobspy_frame(rows: list[dict]) -> pd.DataFrame:
     return pd.DataFrame([{"description": _JOBSPY_DESCRIPTION, **row} for row in rows])
 
 
+def _stable_job_id(conn, job_url: str) -> str:
+    row = conn.execute(
+        "SELECT job_id FROM jobs WHERE tenant_id = 'local' AND url = ?",
+        (job_url,),
+    ).fetchone()
+    assert row is not None
+    return str(row["job_id"])
+
+
 def test_jobspy_limit_stops_after_one_new_job(monkeypatch):
     calls: list[tuple[str, str, list[str], int, int]] = []
 
@@ -526,7 +535,7 @@ def test_jobspy_dedups_against_ats_first_null_company_owner(tmp_path):
         link = conn.execute(
             "SELECT surviving_job_id FROM job_duplicate_links"
         ).fetchone()
-        assert link["surviving_job_id"] == owner_url
+        assert link["surviving_job_id"] == _stable_job_id(conn, owner_url)
     finally:
         close_connection(db_path)
 
@@ -1031,7 +1040,7 @@ def test_jobspy_learns_posting_owner_source_from_direct_ats_url(tmp_path):
             """
             SELECT source_id, observed_url, run_id
             FROM job_source_observations
-            WHERE job_url = ?
+            WHERE job_id = (SELECT job_id FROM jobs WHERE url = ?)
             """,
             ("https://www.linkedin.com/jobs/view/4416248661",),
         ).fetchone()
@@ -1043,7 +1052,7 @@ def test_jobspy_learns_posting_owner_source_from_direct_ats_url(tmp_path):
             """
             SELECT canonical_url, ats_kind, source_native_id, confidence
             FROM job_canonical_identities
-            WHERE job_url = ?
+            WHERE job_id = (SELECT job_id FROM jobs WHERE url = ?)
             """,
             ("https://www.linkedin.com/jobs/view/4416248661",),
         ).fetchone()
@@ -1227,7 +1236,7 @@ def test_jobspy_keeps_learned_workday_sources_in_review_until_runnable(tmp_path)
             """
             SELECT canonical_url, ats_kind, source_native_id
             FROM job_canonical_identities
-            WHERE job_url = ?
+            WHERE job_id = (SELECT job_id FROM jobs WHERE url = ?)
             """,
             ("https://www.linkedin.com/jobs/view/12",),
         ).fetchone()
@@ -1340,11 +1349,18 @@ def test_jobspy_rejects_same_content_location_variants(tmp_path):
             "SELECT surviving_job_id, superseded_job_or_observation_id, reason "
             "FROM job_duplicate_links"
         ).fetchone()
-        assert link["surviving_job_id"] == "https://www.linkedin.com/jobs/view/4416248661"
+        assert link["surviving_job_id"] == _stable_job_id(
+            conn,
+            "https://www.linkedin.com/jobs/view/4416248661",
+        )
         assert link["superseded_job_or_observation_id"] == "https://www.linkedin.com/jobs/view/4416235850"
         assert link["reason"] == "content_fingerprint_match"
         observation = conn.execute(
-            "SELECT source_id FROM job_source_observations WHERE job_url = ?",
+            """
+            SELECT source_id
+            FROM job_source_observations
+            WHERE job_id = (SELECT job_id FROM jobs WHERE url = ?)
+            """,
             ("https://www.linkedin.com/jobs/view/4416248661",),
         ).fetchone()
         assert observation["source_id"] == "jobspy:linkedin"
@@ -1436,11 +1452,19 @@ def test_jobspy_rejects_cross_board_markdown_description_variants(tmp_path):
         link = conn.execute(
             "SELECT surviving_job_id, superseded_job_or_observation_id, reason FROM job_duplicate_links"
         ).fetchone()
-        assert link["surviving_job_id"] == "https://es.indeed.com/viewjob?jk=6b34cd5504dac130"
+        assert link["surviving_job_id"] == _stable_job_id(
+            conn,
+            "https://es.indeed.com/viewjob?jk=6b34cd5504dac130",
+        )
         assert link["superseded_job_or_observation_id"] == "https://www.linkedin.com/jobs/view/4409381449"
         assert link["reason"] == "content_fingerprint_match"
         observations = conn.execute(
-            "SELECT source_id FROM job_source_observations WHERE job_url = ? ORDER BY source_id",
+            """
+            SELECT source_id
+            FROM job_source_observations
+            WHERE job_id = (SELECT job_id FROM jobs WHERE url = ?)
+            ORDER BY source_id
+            """,
             ("https://es.indeed.com/viewjob?jk=6b34cd5504dac130",),
         ).fetchall()
         assert [row["source_id"] for row in observations] == ["jobspy:indeed", "jobspy:linkedin"]
@@ -1567,7 +1591,7 @@ def test_jobspy_exact_rediscovery_keeps_deleted_content_duplicate_suppressed(tmp
         link = conn.execute(
             "SELECT surviving_job_id, superseded_job_or_observation_id, reason FROM job_duplicate_links"
         ).fetchone()
-        assert link["surviving_job_id"] == survivor_url
+        assert link["surviving_job_id"] == _stable_job_id(conn, survivor_url)
         assert link["superseded_job_or_observation_id"] == duplicate_url
         assert link["reason"] == "content_fingerprint_match"
     finally:

--- a/workers/automation/tests/test_discovery_production_wiring.py
+++ b/workers/automation/tests/test_discovery_production_wiring.py
@@ -55,6 +55,15 @@ def conn(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[sqlite3.Co
     close_connection(db_path)
 
 
+def _stable_job_id(conn: sqlite3.Connection, job_url: str) -> str:
+    row = conn.execute(
+        "SELECT job_id FROM jobs WHERE tenant_id = 'local' AND url = ?",
+        (job_url,),
+    ).fetchone()
+    assert row is not None
+    return str(row["job_id"])
+
+
 def _barcelona_registry():
     return config.load_source_registry(
         search_cfg={"boards": []},
@@ -335,10 +344,18 @@ def test_worker_seeds_api_visible_locator_and_manual_queues(
 def test_worker_auto_approves_parseable_sources_from_broad_board_observations(
     conn: sqlite3.Connection,
 ) -> None:
+    job_url = "https://boards.greenhouse.io/acme/jobs/123"
+    conn.execute(
+        """
+        INSERT INTO jobs (url, title, site, strategy, discovered_at)
+        VALUES (?, 'Engineer', 'greenhouse', 'jobspy', ?)
+        """,
+        (job_url, "2026-05-12T10:00:00+00:00"),
+    )
     conn.execute(
         """
         INSERT INTO job_source_observations (
-          tenant_id, source_observation_id, job_url, source_id,
+          tenant_id, source_observation_id, job_id, source_id,
           source_native_id, observed_url, normalized_observed_url,
           run_id, observed_at
         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
@@ -346,11 +363,11 @@ def test_worker_auto_approves_parseable_sources_from_broad_board_observations(
         (
             "local",
             "obs-1",
-            "https://boards.greenhouse.io/acme/jobs/123",
+            _stable_job_id(conn, job_url),
             "jobspy:linkedin",
             "123",
-            "https://boards.greenhouse.io/acme/jobs/123",
-            "https://boards.greenhouse.io/acme/jobs/123",
+            job_url,
+            job_url,
             "run-1",
             "2026-05-12T10:00:00+00:00",
         ),
@@ -617,22 +634,30 @@ def test_discovery_hygiene_retires_existing_invalid_canonical_ats_rows(
         conn.execute(
             """
             INSERT INTO job_canonical_identities (
-                tenant_id, job_url, canonical_url, ats_kind, source_native_id, confidence, resolved_at
+                tenant_id, job_id, canonical_url, ats_kind, source_native_id, confidence, resolved_at
             ) VALUES (?, ?, ?, ?, ?, ?, ?)
             """,
-            ("local", url, url, "greenhouse", f"gh-{index}", 1.0, "2026-05-20T00:00:00+00:00"),
+            (
+                "local",
+                _stable_job_id(conn, url),
+                url,
+                "greenhouse",
+                f"gh-{index}",
+                1.0,
+                "2026-05-20T00:00:00+00:00",
+            ),
         )
         conn.execute(
             """
             INSERT INTO job_source_observations (
-                tenant_id, source_observation_id, job_url, source_id, source_native_id,
+                tenant_id, source_observation_id, job_id, source_id, source_native_id,
                 observed_url, normalized_observed_url, run_id, observed_at
             ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 "local",
                 f"obs-{index}",
-                url,
+                _stable_job_id(conn, url),
                 "greenhouse:acme",
                 f"gh-{index}",
                 url,
@@ -696,22 +721,30 @@ def test_discovery_hygiene_retires_ashby_business_travel_portugal_rows(
         conn.execute(
             """
             INSERT INTO job_canonical_identities (
-                tenant_id, job_url, canonical_url, ats_kind, source_native_id, confidence, resolved_at
+                tenant_id, job_id, canonical_url, ats_kind, source_native_id, confidence, resolved_at
             ) VALUES (?, ?, ?, ?, ?, ?, ?)
             """,
-            ("local", url, url, "ashby", native_id, 0.9, "2026-05-25T21:35:55+00:00"),
+            (
+                "local",
+                _stable_job_id(conn, url),
+                url,
+                "ashby",
+                native_id,
+                0.9,
+                "2026-05-25T21:35:55+00:00",
+            ),
         )
         conn.execute(
             """
             INSERT INTO job_source_observations (
-                tenant_id, source_observation_id, job_url, source_id, source_native_id,
+                tenant_id, source_observation_id, job_id, source_id, source_native_id,
                 observed_url, normalized_observed_url, run_id, observed_at
             ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 "local",
                 f"obs-{native_id}",
-                url,
+                _stable_job_id(conn, url),
                 "ashby:perk",
                 native_id,
                 url,
@@ -797,14 +830,14 @@ def test_discovery_hygiene_retires_invalid_jobspy_rows(
         conn.execute(
             """
             INSERT INTO job_source_observations (
-                tenant_id, source_observation_id, job_url, source_id, source_native_id,
+                tenant_id, source_observation_id, job_id, source_id, source_native_id,
                 observed_url, normalized_observed_url, run_id, observed_at
             ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 "local",
                 f"jobspy-obs-{index}",
-                url,
+                _stable_job_id(conn, url),
                 source_id,
                 f"li-{index}",
                 url,
@@ -899,14 +932,14 @@ def test_discovery_hygiene_treats_serialized_null_descriptions_as_missing(
         conn.execute(
             """
             INSERT INTO job_source_observations (
-                tenant_id, source_observation_id, job_url, source_id, source_native_id,
+                tenant_id, source_observation_id, job_id, source_id, source_native_id,
                 observed_url, normalized_observed_url, run_id, observed_at
             ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 "local",
                 f"jobspy-sentinel-obs-{index}",
-                url,
+                _stable_job_id(conn, url),
                 "jobspy:linkedin",
                 f"li-sentinel-{index}",
                 url,
@@ -1032,14 +1065,14 @@ def test_discovery_hygiene_applies_to_workday_and_smart_extract_rows(
         conn.execute(
             """
             INSERT INTO job_source_observations (
-                tenant_id, source_observation_id, job_url, source_id, source_native_id,
+                tenant_id, source_observation_id, job_id, source_id, source_native_id,
                 observed_url, normalized_observed_url, run_id, observed_at
             ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 "local",
                 f"source-family-obs-{index}",
-                url,
+                _stable_job_id(conn, url),
                 source_id,
                 f"native-{index}",
                 url,
@@ -1299,7 +1332,8 @@ def test_enrichment_snapshot_success_uses_observed_source_id(
         SELECT jobs.url, jobs.title, jobs.site, job_source_observations.source_id
         FROM jobs
         JOIN job_source_observations
-            ON job_source_observations.job_url = jobs.url
+            ON job_source_observations.tenant_id = jobs.tenant_id
+           AND job_source_observations.job_id = jobs.job_id
         WHERE job_source_observations.source_id = ?
         LIMIT 1
         """,

--- a/workers/automation/tests/test_discovery_search_units.py
+++ b/workers/automation/tests/test_discovery_search_units.py
@@ -629,7 +629,11 @@ def test_mid_event_supersession_is_fenced_and_retry_repairs_audit_rows(
     )
     assert (
         search_db.execute(
-            "SELECT COUNT(*) FROM job_canonical_identities WHERE job_url = ?",
+            """
+            SELECT COUNT(*)
+            FROM job_canonical_identities
+            WHERE job_id = (SELECT job_id FROM jobs WHERE url = ?)
+            """,
             ("https://example.test/jobs/mid-event",),
         ).fetchone()[0]
         == 0
@@ -649,14 +653,22 @@ def test_mid_event_supersession_is_fenced_and_retry_repairs_audit_rows(
     assert resumed == (0, 1)
     assert (
         search_db.execute(
-            "SELECT COUNT(*) FROM job_canonical_identities WHERE job_url = ?",
+            """
+            SELECT COUNT(*)
+            FROM job_canonical_identities
+            WHERE job_id = (SELECT job_id FROM jobs WHERE url = ?)
+            """,
             ("https://example.test/jobs/mid-event",),
         ).fetchone()[0]
         == 1
     )
     assert (
         search_db.execute(
-            "SELECT COUNT(*) FROM job_source_observations WHERE job_url = ?",
+            """
+            SELECT COUNT(*)
+            FROM job_source_observations
+            WHERE job_id = (SELECT job_id FROM jobs WHERE url = ?)
+            """,
             ("https://example.test/jobs/mid-event",),
         ).fetchone()[0]
         == 1

--- a/workers/automation/tests/test_job_repository.py
+++ b/workers/automation/tests/test_job_repository.py
@@ -158,7 +158,7 @@ def test_identity_resolver_keeps_job_id_stable_across_url_aliases(
     ).fetchall()
     observation_row = conn.execute(
         """
-        SELECT job_url
+        SELECT job_id
         FROM job_source_observations
         WHERE source_observation_id = 'obs-original'
         """
@@ -174,7 +174,7 @@ def test_identity_resolver_keeps_job_id_stable_across_url_aliases(
         original_url.value: False,
         replacement_url.value: True,
     }
-    assert observation_row["job_url"] == original_url.value
+    assert observation_row["job_id"] == str(stable_id)
     loaded_by_original_url = repo.load(
         LOCAL_TENANT,
         JobId(original_url.value),

--- a/workers/automation/tests/test_repeat_application_prevention.py
+++ b/workers/automation/tests/test_repeat_application_prevention.py
@@ -179,10 +179,17 @@ def test_exact_canonical_and_accepted_duplicate_identities_block(tmp_path: Path)
         conn.execute(
             """
             INSERT INTO job_canonical_identities (
-              tenant_id, job_url, canonical_url, ats_kind, source_native_id,
+              tenant_id, job_id, canonical_url, ats_kind, source_native_id,
               confidence, resolved_at
-            ) VALUES ('local', ?, 'https://boards.example.test/jobs/123',
-                      'greenhouse', 'gh-123', 1, ?)
+            ) VALUES (
+              'local',
+              (SELECT job_id FROM jobs WHERE url = ?),
+              'https://boards.example.test/jobs/123',
+              'greenhouse',
+              'gh-123',
+              1,
+              ?
+            )
             """,
             (job_key, NOW),
         )
@@ -198,7 +205,15 @@ def test_exact_canonical_and_accepted_duplicate_identities_block(tmp_path: Path)
         INSERT INTO job_duplicate_links (
           tenant_id, duplicate_link_id, surviving_job_id,
           superseded_job_or_observation_id, reason, confidence, linked_at
-        ) VALUES ('local', 'accepted-link', ?, ?, 'accepted_content_identity', 0.99, ?)
+        ) VALUES (
+          'local',
+          'accepted-link',
+          (SELECT job_id FROM jobs WHERE url = ?),
+          ?,
+          'accepted_content_identity',
+          0.99,
+          ?
+        )
         """,
         (TARGET, PRIOR, NOW),
     )
@@ -735,7 +750,7 @@ def test_schema_v5_migrates_additively_without_changing_application_facts(
         (PRIOR,),
     ).fetchall()
 
-    assert int(migrated.execute("PRAGMA user_version").fetchone()[0]) == SCHEMA_VERSION == 7
+    assert int(migrated.execute("PRAGMA user_version").fetchone()[0]) == SCHEMA_VERSION == 8
     assert [tuple(row) for row in after] == [tuple(row) for row in before]
     assert "metadata_json" in {
         str(row[1]) for row in migrated.execute("PRAGMA table_info(job_stage_states)").fetchall()

--- a/workers/automation/tests/test_scorer.py
+++ b/workers/automation/tests/test_scorer.py
@@ -473,8 +473,16 @@ def test_score_job_by_url_reuses_direct_score_for_reference_repost(
     conn.execute(
         """
         INSERT INTO job_canonical_identities (
-            tenant_id, job_url, canonical_url, ats_kind, source_native_id, confidence, resolved_at
-        ) VALUES ('local', ?, ?, 'workday', 'AI-Security-Director_R53680', 0.82, ?)
+            tenant_id, job_id, canonical_url, ats_kind, source_native_id, confidence, resolved_at
+        ) VALUES (
+            'local',
+            (SELECT job_id FROM jobs WHERE url = ?),
+            ?,
+            'workday',
+            'AI-Security-Director_R53680',
+            0.82,
+            ?
+        )
         """,
         (
             direct_url,
@@ -995,8 +1003,16 @@ def test_run_scoring_reuses_direct_score_for_reference_repost_without_llm(
     conn.execute(
         """
         INSERT INTO job_canonical_identities (
-            tenant_id, job_url, canonical_url, ats_kind, source_native_id, confidence, resolved_at
-        ) VALUES ('local', ?, ?, 'workday', 'AI-Security-Director_R53680', 0.82, ?)
+            tenant_id, job_id, canonical_url, ats_kind, source_native_id, confidence, resolved_at
+        ) VALUES (
+            'local',
+            (SELECT job_id FROM jobs WHERE url = ?),
+            ?,
+            'workday',
+            'AI-Security-Director_R53680',
+            0.82,
+            ?
+        )
         """,
         (
             direct_url,

--- a/workers/automation/tests/test_smartextract_discovery.py
+++ b/workers/automation/tests/test_smartextract_discovery.py
@@ -25,6 +25,15 @@ from jobctrl.infrastructure.discovery import SqliteJobRepository
 from jobctrl.infrastructure.discovery.production_wiring import DurableJobEventPublisher
 
 
+def _stable_job_id(conn, job_url: str) -> str:
+    row = conn.execute(
+        "SELECT job_id FROM jobs WHERE tenant_id = 'local' AND url = ?",
+        (job_url,),
+    ).fetchone()
+    assert row is not None
+    return str(row["job_id"])
+
+
 def test_short_headless_html_never_retries_headful_in_the_bundled_core(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -544,16 +553,16 @@ def test_smart_extract_current_alias_refreshes_and_restores_storage_owner(
         }
         assert event_urls == {storage_url}
         observation_urls = {
-            row["job_url"]
+            row["job_id"]
             for row in conn.execute(
                 """
-                SELECT job_url
+                SELECT job_id
                 FROM job_source_observations
                 WHERE source_id = 'smartextract:Acme Careers'
                 """
             ).fetchall()
         }
-        assert observation_urls == {storage_url}
+        assert observation_urls == {str(stable_job_id)}
     finally:
         close_connection(db_path)
 
@@ -773,7 +782,7 @@ def test_smart_extract_dedups_against_ats_first_content_owner(
         assert domain_links[0].surviving_job_id == str(owner_identity.job_id)
         assert conn.execute("SELECT COUNT(*) FROM jobs").fetchone()[0] == 1
         link = conn.execute("SELECT surviving_job_id, reason, confidence FROM job_duplicate_links").fetchone()
-        assert link["surviving_job_id"] == owner_url
+        assert link["surviving_job_id"] == str(owner_identity.job_id)
         assert link["reason"] == "content_fingerprint_match"
         assert link["confidence"] == 0.95
         linked_events = conn.execute(
@@ -839,7 +848,7 @@ def test_ats_dedups_against_smart_extract_first_content_owner(
         assert summary.duplicates_linked == 1
         assert conn.execute("SELECT COUNT(*) FROM jobs").fetchone()[0] == 1
         link = conn.execute("SELECT surviving_job_id, reason FROM job_duplicate_links").fetchone()
-        assert link["surviving_job_id"] == smart_url
+        assert link["surviving_job_id"] == _stable_job_id(conn, smart_url)
         assert link["reason"] == "content_fingerprint_match"
     finally:
         close_connection(db_path)

--- a/workers/automation/tests/test_stable_job_identity_migration.py
+++ b/workers/automation/tests/test_stable_job_identity_migration.py
@@ -1,4 +1,4 @@
-"""Schema-v7 stable JobId foundation and recovery contracts."""
+"""Stable JobId foundation and previous-release recovery contracts."""
 
 from __future__ import annotations
 
@@ -25,7 +25,6 @@ REFERENCE_TABLES = (
     "job_events",
     "job_scores",
     "job_artifacts",
-    "job_source_observations",
     "discovery_execution_jobs",
     "workflow_run_projections",
     "application_outcomes",
@@ -207,6 +206,81 @@ def _create_representative_v6_pair(
 
     raw = sqlite3.connect(db_path)
     try:
+        source_rows = raw.execute(
+            """
+            SELECT
+                o.tenant_id, o.source_observation_id, j.url,
+                o.source_id, o.source_native_id, o.observed_url,
+                o.normalized_observed_url, o.run_id, o.observed_at
+            FROM job_source_observations o
+            JOIN jobs j
+              ON j.tenant_id = o.tenant_id
+             AND j.job_id = o.job_id
+            """
+        ).fetchall()
+        for table in (
+            "job_rejected_duplicate_links",
+            "job_duplicate_links",
+            "job_canonical_identities",
+            "job_source_observations",
+        ):
+            raw.execute(f'DROP TABLE "{table}"')
+        raw.executescript(
+            """
+            CREATE TABLE job_source_observations (
+                tenant_id                TEXT NOT NULL DEFAULT 'local',
+                source_observation_id    TEXT NOT NULL,
+                job_url                  TEXT NOT NULL,
+                source_id                TEXT NOT NULL,
+                source_native_id         TEXT NOT NULL,
+                observed_url             TEXT NOT NULL,
+                normalized_observed_url  TEXT NOT NULL,
+                run_id                   TEXT NOT NULL DEFAULT '',
+                observed_at              TEXT NOT NULL,
+                PRIMARY KEY (tenant_id, source_observation_id),
+                FOREIGN KEY (job_url) REFERENCES jobs(url) ON DELETE CASCADE
+            );
+            CREATE TABLE job_canonical_identities (
+                tenant_id          TEXT NOT NULL DEFAULT 'local',
+                job_url            TEXT NOT NULL,
+                canonical_url      TEXT NOT NULL,
+                ats_kind           TEXT NOT NULL,
+                source_native_id   TEXT NOT NULL,
+                confidence         REAL NOT NULL,
+                resolved_at        TEXT NOT NULL,
+                PRIMARY KEY (tenant_id, job_url),
+                FOREIGN KEY (job_url) REFERENCES jobs(url) ON DELETE CASCADE
+            );
+            CREATE TABLE job_duplicate_links (
+                tenant_id                        TEXT NOT NULL DEFAULT 'local',
+                duplicate_link_id                TEXT NOT NULL,
+                surviving_job_id                 TEXT NOT NULL,
+                superseded_job_or_observation_id TEXT NOT NULL,
+                reason                           TEXT NOT NULL,
+                confidence                       REAL NOT NULL,
+                linked_at                        TEXT NOT NULL,
+                PRIMARY KEY (tenant_id, duplicate_link_id)
+            );
+            CREATE TABLE job_rejected_duplicate_links (
+                tenant_id     TEXT NOT NULL DEFAULT 'local',
+                owner_job_url TEXT NOT NULL,
+                candidate_url TEXT NOT NULL,
+                reason        TEXT NOT NULL,
+                rejected_at   TEXT NOT NULL,
+                PRIMARY KEY (tenant_id, owner_job_url, candidate_url)
+            );
+            """
+        )
+        raw.executemany(
+            """
+            INSERT INTO job_source_observations (
+                tenant_id, source_observation_id, job_url, source_id,
+                source_native_id, observed_url, normalized_observed_url,
+                run_id, observed_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            source_rows,
+        )
         for trigger_name in database_module._STABLE_JOB_IDENTITY_TRIGGER_NAMES:
             raw.execute(f'DROP TRIGGER IF EXISTS "{trigger_name}"')
         raw.execute("DROP INDEX IF EXISTS idx_jobs_tenant_job_id")
@@ -294,7 +368,7 @@ def test_v6_jobs_gain_stable_uuid_and_posting_url_alias_once(
     init_db(db_path)
     close_connection(db_path)
 
-    assert _user_version(db_path) == SCHEMA_VERSION == 7
+    assert _user_version(db_path) == SCHEMA_VERSION == 8
     first_ids = _identity_rows(db_path)
     assert [row[0] for row in first_ids] == ["local", "local"]
     for _tenant_id, job_id, _url in first_ids:
@@ -481,6 +555,75 @@ def test_production_url_collision_cleans_aliases_and_allows_rediscovery(
             (relative_url, "Relative duplicate", "Synthetic"),
         ),
     )
+    job_ids = {
+        str(row["url"]): str(row["job_id"])
+        for row in conn.execute(
+            "SELECT url, job_id FROM jobs WHERE url IN (?, ?)",
+            (canonical_url, relative_url),
+        ).fetchall()
+    }
+    surviving_job_id = job_ids[canonical_url]
+    losing_job_id = job_ids[relative_url]
+    conn.execute(
+        """
+        INSERT INTO job_source_observations (
+            tenant_id, source_observation_id, job_id, source_id,
+            source_native_id, observed_url, normalized_observed_url,
+            run_id, observed_at
+        ) VALUES (
+            'local', 'obs-relative', ?, 'synthetic', 'relative',
+            ?, ?, 'discover-run', '2026-07-29T10:00:00+00:00'
+        )
+        """,
+        (losing_job_id, relative_url, relative_url),
+    )
+    conn.executemany(
+        """
+        INSERT INTO job_canonical_identities (
+            tenant_id, job_id, canonical_url, ats_kind, source_native_id,
+            confidence, resolved_at
+        ) VALUES ('local', ?, ?, 'synthetic', ?, ?, ?)
+        """,
+        (
+            (
+                surviving_job_id,
+                canonical_url,
+                "canonical",
+                1.0,
+                "2026-07-29T10:00:00+00:00",
+            ),
+            (
+                losing_job_id,
+                relative_url,
+                "relative",
+                0.5,
+                "2026-07-29T09:00:00+00:00",
+            ),
+        ),
+    )
+    conn.execute(
+        """
+        INSERT INTO job_duplicate_links (
+            tenant_id, duplicate_link_id, surviving_job_id,
+            superseded_job_or_observation_id, reason, confidence, linked_at
+        ) VALUES (
+            'local', 'dup-relative', ?, 'obs-superseded',
+            'canonical_url_match', 0.9, '2026-07-29T10:00:00+00:00'
+        )
+        """,
+        (losing_job_id,),
+    )
+    conn.executemany(
+        """
+        INSERT INTO job_rejected_duplicate_links (
+            tenant_id, owner_job_id, candidate_url, reason, rejected_at
+        ) VALUES (
+            'local', ?, 'https://example.com/jobs/candidate',
+            'employer_mismatch', '2026-07-29T10:00:00+00:00'
+        )
+        """,
+        ((surviving_job_id,), (losing_job_id,)),
+    )
     conn.commit()
     monkeypatch.setattr(
         detail,
@@ -495,6 +638,39 @@ def test_production_url_collision_cleans_aliases_and_allows_rediscovery(
         "app_resolved": 0,
     }
     assert conn.execute("SELECT COUNT(*) FROM jobs").fetchone()[0] == 1
+    assert conn.execute(
+        """
+        SELECT job_id
+        FROM job_source_observations
+        WHERE source_observation_id = 'obs-relative'
+        """
+    ).fetchone()[0] == surviving_job_id
+    assert [
+        tuple(row)
+        for row in conn.execute(
+            """
+            SELECT job_id, canonical_url
+            FROM job_canonical_identities
+            """
+        ).fetchall()
+    ] == [(surviving_job_id, canonical_url)]
+    assert conn.execute(
+        """
+        SELECT surviving_job_id
+        FROM job_duplicate_links
+        WHERE duplicate_link_id = 'dup-relative'
+        """
+    ).fetchone()[0] == surviving_job_id
+    assert [
+        tuple(row)
+        for row in conn.execute(
+            """
+            SELECT owner_job_id
+            FROM job_rejected_duplicate_links
+            """
+        ).fetchall()
+    ] == [(surviving_job_id,)]
+    assert conn.execute("PRAGMA foreign_key_check").fetchone() is None
     active_orphans = conn.execute(
         """
         SELECT COUNT(*)


### PR DESCRIPTION
## Summary

- migrate schema v8 discovery authorities from URL-shaped ownership to tenant-scoped stable `JobId` references
- resolve existing rows through canonical jobs and historical posting-URL aliases in one verified, rollback-safe migration
- cut Python and TypeScript consumers over while preserving URL compatibility at public read/route boundaries
- preserve discovery evidence when legacy URL normalization merges duplicate job rows
- split the remaining Phase 3 work into execution/search-unit and preparation-state follow-up PRs

## Stack

- Parent: #532 (`feat/job-id-repository-compatibility`)
- This PR: discovery observations, canonical identity, accepted duplicate links, and rejected duplicate links
- Next: execution/search-unit receipts, then preparation/orchestration state

## Safety and migration proof

- validates v7 identity prerequisites before rebuilding tables
- refuses unresolved references and rolls back to a retryable v7 database
- verifies row counts, primary keys, indexes, composite foreign keys, orphan absence, and reopen behavior before stamping v8
- accepts the valid rotated-alias state where the physical storage URL is historical and another posting URL is current
- re-homes all four migrated authorities to the surviving stable identity before legacy URL-collision deletion

## Validation

- `workers/automation/.venv/bin/python -m pytest -q` — 2,658 passed, 2 skipped
- `pnpm api:test` — 648 passed
- `pnpm api:check` — passed
- `pnpm web:check` — passed
- `.venv/bin/ruff check <changed Python surfaces>` — passed
- `git diff --check` — passed
- independent reviewer — PASS, 0 findings
- independent QA — PASS, 0 findings

Browser E2E is deferred because the web change only adapts the repeat-application fixture to the stable schema; cumulative product QA remains required on the final unreleased stack PR.