### PR TITLE
feat(storage): migrate execution identity references

### DIFF
--- a/apps/api/src/db.ts
+++ b/apps/api/src/db.ts
@@ -9,7 +9,7 @@ export type SqliteValue = string | number | bigint | null;
 // writer that stamps ``PRAGMA user_version``; the API only reads it to fail
 // closed on a database written by a newer build. Bump both constants together
 // whenever the schema shape changes.
-export const SUPPORTED_SCHEMA_VERSION = 8;
+export const SUPPORTED_SCHEMA_VERSION = 9;
 
 export class IncompatibleSchemaVersionError extends Error {
   constructor(current: number) {

--- a/apps/api/src/pipeline-operations.ts
+++ b/apps/api/src/pipeline-operations.ts
@@ -388,11 +388,30 @@ function loadMemberships(
   runId: string,
 ): MembershipRow[] {
   if (!tableExists(db, "discovery_execution_jobs")) return [];
+  if (!hasColumns(db, "discovery_execution_jobs", ["job_id"])) {
+    return allRows<MembershipRow>(
+      db,
+      `SELECT job_url, cohort_kind, preparation_workflow_id,
+              work_plan_state, required_steps_json
+         FROM discovery_execution_jobs
+        WHERE tenant_id = ?
+          AND discover_workflow_id = ?
+          AND discover_run_id = ?`,
+      [tenantId, workflowId, runId],
+    );
+  }
   return allRows<MembershipRow>(
     db,
-    `SELECT job_url, cohort_kind, preparation_workflow_id, work_plan_state, required_steps_json
-       FROM discovery_execution_jobs
-      WHERE tenant_id = ? AND discover_workflow_id = ? AND discover_run_id = ?`,
+    `SELECT jobs.url AS job_url, execution.cohort_kind,
+            execution.preparation_workflow_id, execution.work_plan_state,
+            execution.required_steps_json
+       FROM discovery_execution_jobs AS execution
+       JOIN jobs
+         ON jobs.tenant_id = execution.tenant_id
+        AND jobs.job_id = execution.job_id
+      WHERE execution.tenant_id = ?
+        AND execution.discover_workflow_id = ?
+        AND execution.discover_run_id = ?`,
     [tenantId, workflowId, runId],
   );
 }
@@ -1230,21 +1249,30 @@ function loadUniqueGlobalPreparationOwners(
   const candidates = new Map(jobUrls.map((jobUrl) => [jobUrl, new Set<string>()] as const));
   const ambiguous = new Set<string>();
   for (const group of chunks(jobUrls, 500)) {
+    if (!hasColumns(db, "discovery_execution_jobs", ["job_id"])) {
+      const rows = allRows<{ job_url: string; preparation_workflow_id: string | null }>(
+        db,
+        `SELECT job_url, preparation_workflow_id
+           FROM discovery_execution_jobs
+          WHERE tenant_id = ?
+            AND job_url IN (${group.map(() => "?").join(", ")})`,
+        [tenantId, ...group],
+      );
+      collectPreparationOwners(rows, candidates, ambiguous);
+      continue;
+    }
     const rows = allRows<{ job_url: string; preparation_workflow_id: string | null }>(
       db,
-      `SELECT job_url, preparation_workflow_id
-         FROM discovery_execution_jobs
-        WHERE tenant_id = ? AND job_url IN (${group.map(() => "?").join(", ")})`,
+      `SELECT jobs.url AS job_url, execution.preparation_workflow_id
+         FROM discovery_execution_jobs AS execution
+         JOIN jobs
+           ON jobs.tenant_id = execution.tenant_id
+          AND jobs.job_id = execution.job_id
+        WHERE execution.tenant_id = ?
+          AND jobs.url IN (${group.map(() => "?").join(", ")})`,
       [tenantId, ...group],
     );
-    for (const row of rows) {
-      const workflowId = nullableText(row.preparation_workflow_id);
-      if (!workflowId) {
-        ambiguous.add(row.job_url);
-        continue;
-      }
-      candidates.get(row.job_url)?.add(workflowId);
-    }
+    collectPreparationOwners(rows, candidates, ambiguous);
   }
   for (const jobUrl of jobUrls) {
     const workflowIds = candidates.get(jobUrl);
@@ -1254,6 +1282,21 @@ function loadUniqueGlobalPreparationOwners(
     }
   }
   return owners;
+}
+
+function collectPreparationOwners(
+  rows: Array<{ job_url: string; preparation_workflow_id: string | null }>,
+  candidates: Map<string, Set<string>>,
+  ambiguous: Set<string>,
+): void {
+  for (const row of rows) {
+    const workflowId = nullableText(row.preparation_workflow_id);
+    if (!workflowId) {
+      ambiguous.add(row.job_url);
+      continue;
+    }
+    candidates.get(row.job_url)?.add(workflowId);
+  }
 }
 
 function loadPreparationWorkflowStatusById(

--- a/apps/api/src/write-model.ts
+++ b/apps/api/src/write-model.ts
@@ -804,6 +804,18 @@ function purgeJobRows(db: SqliteDatabase, jobUrl: string): void {
   if (jobId) {
     deleteWhere(db, "job_source_observations", "job_id = ?", [jobId]);
     deleteWhere(db, "job_canonical_identities", "job_id = ?", [jobId]);
+    deleteDiscoveryJobReferences(
+      db,
+      "discovery_execution_jobs",
+      jobId,
+      jobUrl,
+    );
+    deleteDiscoveryJobReferences(
+      db,
+      "discovery_search_unit_jobs",
+      jobId,
+      jobUrl,
+    );
     deleteWhere(db, "job_rejected_duplicate_links", "owner_job_id = ?", [jobId]);
     deleteWhere(
       db,
@@ -823,6 +835,31 @@ function purgeJobRows(db: SqliteDatabase, jobUrl: string): void {
   ]);
   deleteWhere(db, "discovery_feedback", "job_key = ?", [jobUrl]);
   deleteWhere(db, "jobs", "url = ?", [jobUrl]);
+}
+
+function deleteDiscoveryJobReferences(
+  db: SqliteDatabase,
+  tableName: "discovery_execution_jobs" | "discovery_search_unit_jobs",
+  jobId: string,
+  jobUrl: string,
+): void {
+  const columns = columnNames(db, tableName);
+  const tenantScoped = columns.has("tenant_id");
+  if (columns.has("job_id")) {
+    deleteWhere(
+      db,
+      tableName,
+      tenantScoped ? "tenant_id = 'local' AND job_id = ?" : "job_id = ?",
+      [jobId],
+    );
+  } else if (columns.has("job_url")) {
+    deleteWhere(
+      db,
+      tableName,
+      tenantScoped ? "tenant_id = 'local' AND job_url = ?" : "job_url = ?",
+      [jobUrl],
+    );
+  }
 }
 
 function invalidateOperationsProjections(db: SqliteDatabase): void {

--- a/apps/api/test/pipeline-operations.test.ts
+++ b/apps/api/test/pipeline-operations.test.ts
@@ -20,6 +20,7 @@ interface Fixture {
   dbPath: string;
   configPath: string;
   db: Database.Database;
+  legacyExecutionReferences: boolean;
 }
 
 afterEach(() => {
@@ -30,6 +31,25 @@ afterEach(() => {
 });
 
 describe("pipeline operations read model", () => {
+  it("reads v8 URL memberships while the worker migration is pending", () => {
+    const fixture = createFixture({ legacyExecutionReferences: true });
+    insertExecution(fixture, { status: "succeeded" });
+    insertMember(fixture, {
+      key: "v8-upgrade-window",
+      cohort: "observed_this_run",
+      requiredSteps: ["score"],
+    });
+    insertStageState(fixture, "v8-upgrade-window", "score", "pending");
+
+    expect(snapshot(fixture).execution).toMatchObject({
+      currentExecution: {
+        members: 1,
+        planned: 1,
+        remaining: 1,
+      },
+    });
+  });
+
   it("keeps projection coverage absent only when fresh telemetry proves no selected execution or runtime work", () => {
     const fixture = createFixture();
     insertHeartbeat(fixture, { activeSlots: 0, counts: {}, details: [] });
@@ -1113,13 +1133,27 @@ describe("pipeline operations read model", () => {
   });
 });
 
-function createFixture(): Fixture {
+function createFixture(
+  options: { legacyExecutionReferences?: boolean } = {},
+): Fixture {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "jobctrl-pipeline-operations-"));
   const dbPath = path.join(directory, "jobctrl.db");
   const configPath = path.join(directory, "config.json");
   fs.writeFileSync(configPath, JSON.stringify({ daily_budget_usd: 25 }));
   const db = new Database(dbPath);
+  const legacyExecutionReferences = options.legacyExecutionReferences === true;
+  const executionReferenceColumn = legacyExecutionReferences
+    ? "job_url TEXT NOT NULL"
+    : "job_id TEXT NOT NULL";
   db.exec(`
+    CREATE TABLE fixture_jobs (
+      url TEXT PRIMARY KEY,
+      tenant_id TEXT NOT NULL,
+      job_id TEXT NOT NULL,
+      UNIQUE (tenant_id, job_id)
+    );
+    CREATE VIEW jobs AS
+      SELECT url, tenant_id, job_id FROM fixture_jobs;
     CREATE TABLE job_stage_states (
       job_url TEXT NOT NULL,
       stage TEXT NOT NULL,
@@ -1140,7 +1174,7 @@ function createFixture(): Fixture {
       tenant_id TEXT NOT NULL,
       discover_workflow_id TEXT NOT NULL,
       discover_run_id TEXT NOT NULL,
-      job_url TEXT NOT NULL,
+      ${executionReferenceColumn},
       cohort_kind TEXT NOT NULL,
       preparation_workflow_id TEXT,
       work_plan_state TEXT NOT NULL,
@@ -1186,7 +1220,13 @@ function createFixture(): Fixture {
     );
   `);
   ensureProjectionTables(db);
-  const fixture = { directory, dbPath, configPath, db };
+  const fixture = {
+    directory,
+    dbPath,
+    configPath,
+    db,
+    legacyExecutionReferences,
+  };
   fixtures.push(fixture);
   return fixture;
 }
@@ -1207,10 +1247,24 @@ function insertReadyRecoveryCheckpoints(fixture: Fixture): void {
         AND temporal_run_id IS NOT NULL`,
   ).all() as Array<{ workflow_id: string; temporal_run_id: string }>;
   for (const execution of executions) {
+    const membershipSql = fixture.legacyExecutionReferences
+      ? `SELECT job_url
+           FROM discovery_execution_jobs
+          WHERE tenant_id = 'local'
+            AND discover_workflow_id = ?
+            AND discover_run_id = ?
+          ORDER BY job_url`
+      : `SELECT jobs.url AS job_url
+           FROM discovery_execution_jobs AS execution
+           JOIN jobs
+             ON jobs.tenant_id = execution.tenant_id
+            AND jobs.job_id = execution.job_id
+          WHERE execution.tenant_id = 'local'
+            AND execution.discover_workflow_id = ?
+            AND execution.discover_run_id = ?
+          ORDER BY jobs.url`;
     const memberships = (fixture.db.prepare(
-      `SELECT job_url FROM discovery_execution_jobs
-        WHERE tenant_id = 'local' AND discover_workflow_id = ? AND discover_run_id = ?
-        ORDER BY job_url`,
+      membershipSql,
     ).all(execution.workflow_id, execution.temporal_run_id) as Array<{ job_url: string }>)
       .map((row) => row.job_url);
     const steps = (fixture.db.prepare(
@@ -1339,20 +1393,38 @@ function insertMember(
   },
 ): { preparationWorkflowId: string } {
   const preparationWorkflowId = `prep-preparation:${createHash("sha256").update(input.key).digest("hex")}`;
+  const jobUrl = input.jobUrl ?? `https://private.invalid/${input.key}`;
+  const jobId = stableJobId(jobUrl);
+  fixture.db.prepare(
+    `INSERT OR IGNORE INTO fixture_jobs (url, tenant_id, job_id)
+     VALUES (?, 'local', ?)`,
+  ).run(jobUrl, jobId);
   fixture.db.prepare(
     `INSERT INTO discovery_execution_jobs (
-       tenant_id, discover_workflow_id, discover_run_id, job_url, cohort_kind,
+       tenant_id, discover_workflow_id, discover_run_id,
+       ${fixture.legacyExecutionReferences ? "job_url" : "job_id"}, cohort_kind,
        preparation_workflow_id, work_plan_state, required_steps_json
      ) VALUES ('local', ?, ?, ?, ?, ?, 'planned', ?)`,
   ).run(
     input.workflowId ?? DISCOVER_WORKFLOW_ID,
     input.runId ?? DISCOVER_RUN_ID,
-    input.jobUrl ?? `https://private.invalid/${input.key}`,
+    fixture.legacyExecutionReferences ? jobUrl : jobId,
     input.cohort ?? "observed_this_run",
     preparationWorkflowId,
     JSON.stringify(input.requiredSteps),
   );
   return { preparationWorkflowId };
+}
+
+function stableJobId(jobUrl: string): string {
+  const digest = createHash("sha256").update(jobUrl).digest("hex");
+  return [
+    digest.slice(0, 8),
+    digest.slice(8, 12),
+    `4${digest.slice(13, 16)}`,
+    `8${digest.slice(17, 20)}`,
+    digest.slice(20, 32),
+  ].join("-");
 }
 
 function insertStageState(

--- a/apps/api/test/qa-seed.ts
+++ b/apps/api/test/qa-seed.ts
@@ -233,6 +233,8 @@ export function seedQaDatabase(dbPath: string, options: QaSeedOptions = {}): voi
   db.exec(`
     CREATE TABLE jobs (
       url TEXT PRIMARY KEY,
+      tenant_id TEXT NOT NULL DEFAULT 'local',
+      job_id TEXT NOT NULL,
       title TEXT,
       site TEXT,
       strategy TEXT,
@@ -255,7 +257,8 @@ export function seedQaDatabase(dbPath: string, options: QaSeedOptions = {}): voi
       cover_attempts INTEGER,
       apply_status TEXT,
       apply_error TEXT,
-      applied_at TEXT
+      applied_at TEXT,
+      UNIQUE (tenant_id, job_id)
     );
     CREATE TABLE job_stage_states (
       job_url TEXT NOT NULL,
@@ -351,7 +354,7 @@ export function seedQaDatabase(dbPath: string, options: QaSeedOptions = {}): voi
       tenant_id                TEXT NOT NULL,
       discover_workflow_id     TEXT NOT NULL,
       discover_run_id          TEXT NOT NULL,
-      job_url                  TEXT NOT NULL,
+      job_id                   TEXT NOT NULL,
       cohort_kind              TEXT NOT NULL
           CHECK (cohort_kind IN ('observed_this_run', 'existing_backlog')),
       source_family            TEXT,
@@ -362,8 +365,9 @@ export function seedQaDatabase(dbPath: string, options: QaSeedOptions = {}): voi
       required_steps_json      TEXT,
       work_plan_reason         TEXT,
       linked_at                TEXT NOT NULL,
-      PRIMARY KEY (tenant_id, discover_workflow_id, discover_run_id, job_url),
-      FOREIGN KEY (job_url) REFERENCES jobs(url) ON DELETE CASCADE
+      PRIMARY KEY (tenant_id, discover_workflow_id, discover_run_id, job_id),
+      FOREIGN KEY (tenant_id, job_id)
+        REFERENCES jobs(tenant_id, job_id) ON DELETE CASCADE
     );
     CREATE TABLE pipeline_step_projections (
       tenant_id              TEXT NOT NULL,
@@ -1283,7 +1287,7 @@ function seedPipelineOperations(db: Database.Database, dbPath: string): void {
 
   const insertMember = db.prepare(
     `INSERT INTO discovery_execution_jobs (
-      tenant_id, discover_workflow_id, discover_run_id, job_url, cohort_kind,
+      tenant_id, discover_workflow_id, discover_run_id, job_id, cohort_kind,
       source_family, source_run_id, preparation_workflow_id, work_plan_state,
       required_steps_json, work_plan_reason, linked_at
     ) VALUES ('local', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
@@ -1291,7 +1295,7 @@ function seedPipelineOperations(db: Database.Database, dbPath: string): void {
   insertMember.run(
     discoverWorkflowId,
     discoverRunId,
-    QA_PLATFORM_JOB_URL,
+    stableJobId(QA_PLATFORM_JOB_URL),
     "observed_this_run",
     "greenhouse",
     "qa-greenhouse-run",
@@ -1304,7 +1308,7 @@ function seedPipelineOperations(db: Database.Database, dbPath: string): void {
   insertMember.run(
     discoverWorkflowId,
     discoverRunId,
-    "https://talent.com/view?id=qa-marketing-director",
+    stableJobId("https://talent.com/view?id=qa-marketing-director"),
     "observed_this_run",
     "talent",
     "qa-talent-run",
@@ -1317,7 +1321,7 @@ function seedPipelineOperations(db: Database.Database, dbPath: string): void {
   insertMember.run(
     discoverWorkflowId,
     discoverRunId,
-    "https://linkedin.com/jobs/view/qa-risk-manager",
+    stableJobId("https://linkedin.com/jobs/view/qa-risk-manager"),
     "existing_backlog",
     "linkedin",
     "qa-linkedin-run",
@@ -1330,7 +1334,7 @@ function seedPipelineOperations(db: Database.Database, dbPath: string): void {
   insertMember.run(
     discoverWorkflowId,
     discoverRunId,
-    "https://motorolasolutions.com/careers/qa-command-center",
+    stableJobId("https://motorolasolutions.com/careers/qa-command-center"),
     "observed_this_run",
     "greenhouse",
     "qa-greenhouse-run",
@@ -1451,9 +1455,15 @@ function seedPipelineOperations(db: Database.Database, dbPath: string): void {
   const recoveryMemberships = (
     db
       .prepare(
-        `SELECT job_url FROM discovery_execution_jobs
-          WHERE tenant_id = 'local' AND discover_workflow_id = ? AND discover_run_id = ?
-          ORDER BY job_url`,
+        `SELECT jobs.url AS job_url
+           FROM discovery_execution_jobs AS execution
+           JOIN jobs
+             ON jobs.tenant_id = execution.tenant_id
+            AND jobs.job_id = execution.job_id
+          WHERE execution.tenant_id = 'local'
+            AND execution.discover_workflow_id = ?
+            AND execution.discover_run_id = ?
+          ORDER BY jobs.url`,
       )
       .all(discoverWorkflowId, discoverRunId) as Array<{ job_url: string }>
   ).map((row) => row.job_url);
@@ -2043,12 +2053,14 @@ function seedWorkerHeartbeat(db: Database.Database, dbPath: string): void {
 function insertJob(db: Database.Database, job: QaJobSeed): void {
   db.prepare(
     `INSERT INTO jobs (
-      url, title, site, strategy, location, salary, discovered_at, application_url,
+      url, tenant_id, job_id, title, site, strategy, location, salary,
+      discovered_at, application_url,
       description, full_description, detail_scraped_at, fit_score, score_reasoning,
       scored_at, tailored_resume_path, tailored_at
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    ) VALUES (?, 'local', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   ).run(
     job.url,
+    stableJobId(job.url),
     job.title,
     job.site,
     job.strategy ?? "qa",
@@ -2065,6 +2077,17 @@ function insertJob(db: Database.Database, job: QaJobSeed): void {
     null,
     null,
   );
+}
+
+function stableJobId(jobUrl: string): string {
+  const digest = createHash("sha256").update(jobUrl).digest("hex");
+  return [
+    digest.slice(0, 8),
+    digest.slice(8, 12),
+    `4${digest.slice(13, 16)}`,
+    `8${digest.slice(17, 20)}`,
+    digest.slice(20, 32),
+  ].join("-");
 }
 
 function insertStage(db: Database.Database, jobUrl: string, stage: string, state: string, errorCode: string | null = null): void {

--- a/apps/api/test/server.test.ts
+++ b/apps/api/test/server.test.ts
@@ -2740,9 +2740,23 @@ describe("local TypeScript API", () => {
   });
 
   it("permanently deletes job rows and clears delete/hide tombstones so rediscovery can add them again", async () => {
-    const app = buildApp(options);
     const readyUrl = "https://example.com/jobs/ready";
     const blockedUrl = "https://example.com/jobs/blocked-tailor";
+    const readyJobId = `test-job:${readyUrl}`;
+    const blockedJobId = `test-job:${blockedUrl}`;
+    const setup = new Database(options.dbPath);
+    setup.exec(`
+      CREATE TABLE discovery_execution_jobs (job_id TEXT NOT NULL);
+      CREATE TABLE discovery_search_unit_jobs (job_url TEXT NOT NULL);
+    `);
+    setup
+      .prepare("INSERT INTO discovery_execution_jobs (job_id) VALUES (?), (?)")
+      .run(readyJobId, blockedJobId);
+    setup
+      .prepare("INSERT INTO discovery_search_unit_jobs (job_url) VALUES (?), (?)")
+      .run(readyUrl, blockedUrl);
+    setup.close();
+    const app = buildApp(options);
 
     const softDelete = await app.inject({
       method: "POST",
@@ -2786,6 +2800,10 @@ describe("local TypeScript API", () => {
     expect(countRows(db, "jobctrl_hidden_jobs", "job_url", blockedUrl)).toBe(0);
     expect(countRows(db, "job_stage_states", "job_url", readyUrl)).toBe(0);
     expect(countRows(db, "job_scores", "job_url", readyUrl)).toBe(0);
+    expect(countRows(db, "discovery_execution_jobs", "job_id", readyJobId)).toBe(0);
+    expect(countRows(db, "discovery_execution_jobs", "job_id", blockedJobId)).toBe(0);
+    expect(countRows(db, "discovery_search_unit_jobs", "job_url", readyUrl)).toBe(0);
+    expect(countRows(db, "discovery_search_unit_jobs", "job_url", blockedUrl)).toBe(0);
 
     insertJob(db, {
       url: readyUrl,

--- a/workers/automation/src/jobctrl/database.py
+++ b/workers/automation/src/jobctrl/database.py
@@ -41,7 +41,9 @@ from jobctrl.config import DB_PATH, DEFAULTS, migrate_legacy_job_tables
 # v8 (discovery identity references): source observations, canonical identity,
 # and duplicate-link authorities reference ``(tenant_id, job_id)`` rather than
 # storing a posting URL as aggregate identity.
-SCHEMA_VERSION = 8
+# v9 (execution and search receipts): Discover execution membership and
+# accepted JobStreaming receipts reference the same stable identity.
+SCHEMA_VERSION = 9
 
 
 class IncompatibleSchemaVersionError(RuntimeError):
@@ -180,6 +182,7 @@ def _schema_migrations() -> tuple[
     return (
         (7, ensure_stable_job_identity_v7),
         (8, ensure_discovery_identity_references_v8),
+        (9, ensure_execution_search_references_v9),
     )
 
 
@@ -3567,7 +3570,7 @@ def ensure_discovery_execution_tables(conn: sqlite3.Connection | None = None) ->
             tenant_id                TEXT NOT NULL,
             discover_workflow_id     TEXT NOT NULL,
             discover_run_id          TEXT NOT NULL,
-            job_url                  TEXT NOT NULL,
+            job_id                   TEXT NOT NULL,
             cohort_kind              TEXT NOT NULL
                 CHECK (cohort_kind IN ('observed_this_run', 'existing_backlog')),
             source_family            TEXT,
@@ -3578,8 +3581,9 @@ def ensure_discovery_execution_tables(conn: sqlite3.Connection | None = None) ->
             required_steps_json      TEXT,
             work_plan_reason         TEXT,
             linked_at                TEXT NOT NULL,
-            PRIMARY KEY (tenant_id, discover_workflow_id, discover_run_id, job_url),
-            FOREIGN KEY (job_url) REFERENCES jobs(url) ON DELETE CASCADE
+            PRIMARY KEY (tenant_id, discover_workflow_id, discover_run_id, job_id),
+            FOREIGN KEY (tenant_id, job_id)
+                REFERENCES jobs(tenant_id, job_id) ON DELETE CASCADE
         )
         """
     )
@@ -3599,10 +3603,15 @@ def ensure_discovery_execution_tables(conn: sqlite3.Connection | None = None) ->
         )
         """
     )
+    execution_reference = (
+        "job_id"
+        if "job_id" in _table_columns(conn, "discovery_execution_jobs")
+        else "job_url"
+    )
     conn.execute(
-        """
+        f"""
         CREATE INDEX IF NOT EXISTS idx_discovery_execution_jobs_job
-        ON discovery_execution_jobs(tenant_id, job_url, linked_at)
+        ON discovery_execution_jobs(tenant_id, {execution_reference}, linked_at)
         """
     )
     conn.commit()
@@ -3691,18 +3700,19 @@ def ensure_discovery_search_unit_tables(
             discover_workflow_id   TEXT NOT NULL,
             discover_run_id        TEXT NOT NULL,
             unit_id                TEXT NOT NULL,
-            job_url                TEXT NOT NULL,
+            job_id                 TEXT NOT NULL,
             was_new                INTEGER NOT NULL CHECK (was_new IN (0, 1)),
             accepted_at            TEXT NOT NULL,
             PRIMARY KEY (
-                tenant_id, discover_workflow_id, discover_run_id, unit_id, job_url
+                tenant_id, discover_workflow_id, discover_run_id, unit_id, job_id
             ),
             FOREIGN KEY (
                 tenant_id, discover_workflow_id, discover_run_id, unit_id
             ) REFERENCES discovery_search_units(
                 tenant_id, discover_workflow_id, discover_run_id, unit_id
             ) ON DELETE CASCADE,
-            FOREIGN KEY (job_url) REFERENCES jobs(url) ON DELETE CASCADE
+            FOREIGN KEY (tenant_id, job_id)
+                REFERENCES jobs(tenant_id, job_id) ON DELETE CASCADE
         )
         """
     )
@@ -4014,6 +4024,26 @@ def reassign_discovery_identity_references(
     losing aggregate's discovery evidence under the surviving stable JobId
     before deleting the losing row.
     """
+    conn.execute("SAVEPOINT reassign_discovery_identity_references")
+    try:
+        _reassign_discovery_identity_references(
+            conn,
+            losing_job_url=losing_job_url,
+            surviving_job_url=surviving_job_url,
+        )
+        conn.execute("RELEASE SAVEPOINT reassign_discovery_identity_references")
+    except BaseException:
+        conn.execute("ROLLBACK TO SAVEPOINT reassign_discovery_identity_references")
+        conn.execute("RELEASE SAVEPOINT reassign_discovery_identity_references")
+        raise
+
+
+def _reassign_discovery_identity_references(
+    conn: sqlite3.Connection,
+    *,
+    losing_job_url: str,
+    surviving_job_url: str,
+) -> None:
     if losing_job_url == surviving_job_url:
         return
     identities = conn.execute(
@@ -4124,7 +4154,254 @@ def reassign_discovery_identity_references(
         """,
         (surviving_job_id, tenant_id, losing_job_id),
     )
+    if "job_id" in _table_columns(conn, "discovery_execution_jobs"):
+        _reassign_execution_memberships(
+            conn,
+            tenant_id=tenant_id,
+            losing_job_id=losing_job_id,
+            surviving_job_id=surviving_job_id,
+        )
+    if "job_id" in _table_columns(conn, "discovery_search_unit_jobs"):
+        _reassign_search_unit_receipts(
+            conn,
+            tenant_id=tenant_id,
+            losing_job_id=losing_job_id,
+            surviving_job_id=surviving_job_id,
+        )
 
+
+def _reassign_execution_memberships(
+    conn: sqlite3.Connection,
+    *,
+    tenant_id: str,
+    losing_job_id: str,
+    surviving_job_id: str,
+) -> None:
+    losing_rows = conn.execute(
+        """
+        SELECT discover_workflow_id, discover_run_id, cohort_kind,
+               source_family, source_run_id, preparation_workflow_id,
+               work_plan_state, required_steps_json, work_plan_reason,
+               linked_at
+        FROM discovery_execution_jobs
+        WHERE tenant_id = ? AND job_id = ?
+        """,
+        (tenant_id, losing_job_id),
+    ).fetchall()
+    for losing in losing_rows:
+        workflow_id = str(losing[0])
+        run_id = str(losing[1])
+        surviving = conn.execute(
+            """
+            SELECT discover_workflow_id, discover_run_id, cohort_kind,
+                   source_family, source_run_id, preparation_workflow_id,
+                   work_plan_state, required_steps_json, work_plan_reason,
+                   linked_at
+            FROM discovery_execution_jobs
+            WHERE tenant_id = ?
+              AND discover_workflow_id = ?
+              AND discover_run_id = ?
+              AND job_id = ?
+            """,
+            (tenant_id, workflow_id, run_id, surviving_job_id),
+        ).fetchone()
+        if surviving is None:
+            conn.execute(
+                """
+                UPDATE discovery_execution_jobs
+                SET job_id = ?
+                WHERE tenant_id = ?
+                  AND discover_workflow_id = ?
+                  AND discover_run_id = ?
+                  AND job_id = ?
+                """,
+                (
+                    surviving_job_id,
+                    tenant_id,
+                    workflow_id,
+                    run_id,
+                    losing_job_id,
+                ),
+            )
+            continue
+
+        cohort_kind = (
+            "observed_this_run"
+            if "observed_this_run" in {str(surviving[2]), str(losing[2])}
+            else "existing_backlog"
+        )
+        if str(surviving[2]) == "observed_this_run":
+            source_family = surviving[3]
+            source_run_id = surviving[4]
+        elif str(losing[2]) == "observed_this_run":
+            source_family = losing[3]
+            source_run_id = losing[4]
+        else:
+            source_family = surviving[3] or losing[3]
+            source_run_id = surviving[4] or losing[4]
+
+        work_plan = _merged_execution_work_plan(surviving, losing)
+        linked_at = min(str(surviving[9]), str(losing[9]))
+        conn.execute(
+            """
+            UPDATE discovery_execution_jobs
+            SET cohort_kind = ?,
+                source_family = ?,
+                source_run_id = ?,
+                preparation_workflow_id = ?,
+                work_plan_state = ?,
+                required_steps_json = ?,
+                work_plan_reason = ?,
+                linked_at = ?
+            WHERE tenant_id = ?
+              AND discover_workflow_id = ?
+              AND discover_run_id = ?
+              AND job_id = ?
+            """,
+            (
+                cohort_kind,
+                source_family,
+                source_run_id,
+                *work_plan,
+                linked_at,
+                tenant_id,
+                workflow_id,
+                run_id,
+                surviving_job_id,
+            ),
+        )
+        conn.execute(
+            """
+            DELETE FROM discovery_execution_jobs
+            WHERE tenant_id = ?
+              AND discover_workflow_id = ?
+              AND discover_run_id = ?
+              AND job_id = ?
+            """,
+            (tenant_id, workflow_id, run_id, losing_job_id),
+        )
+
+def _merged_execution_work_plan(
+    surviving: sqlite3.Row | tuple[Any, ...],
+    losing: sqlite3.Row | tuple[Any, ...],
+) -> tuple[Any, str, Any, Any]:
+    def plan(row: sqlite3.Row | tuple[Any, ...]) -> tuple[Any, str, Any, Any]:
+        return (row[5], str(row[6]), row[7], row[8])
+
+    surviving_plan = plan(surviving)
+    losing_plan = plan(losing)
+    surviving_decided = surviving_plan[1] in {"planned", "not_eligible"}
+    losing_decided = losing_plan[1] in {"planned", "not_eligible"}
+    if surviving_decided and losing_decided:
+        if surviving_plan != losing_plan:
+            raise RuntimeError("URL collision merge found conflicting decided execution work plans")
+        return surviving_plan
+    if surviving_decided:
+        return surviving_plan
+    if losing_decided:
+        return losing_plan
+
+    surviving_workflow = surviving_plan[0]
+    losing_workflow = losing_plan[0]
+    if surviving_workflow is not None and losing_workflow is not None and surviving_workflow != losing_workflow:
+        raise RuntimeError("URL collision merge found conflicting preparation workflow owners")
+    if surviving_workflow is None and losing_workflow is not None:
+        return losing_plan
+    if surviving_plan[1] == "pending" and losing_plan[1] == "failed":
+        return losing_plan
+    return surviving_plan
+
+def _reassign_search_unit_receipts(
+    conn: sqlite3.Connection,
+    *,
+    tenant_id: str,
+    losing_job_id: str,
+    surviving_job_id: str,
+) -> None:
+    losing_rows = conn.execute(
+        """
+        SELECT discover_workflow_id, discover_run_id, unit_id,
+               was_new, accepted_at
+        FROM discovery_search_unit_jobs
+        WHERE tenant_id = ? AND job_id = ?
+        """,
+        (tenant_id, losing_job_id),
+    ).fetchall()
+    for losing in losing_rows:
+        workflow_id = str(losing[0])
+        run_id = str(losing[1])
+        unit_id = str(losing[2])
+        surviving = conn.execute(
+            """
+            SELECT was_new, accepted_at
+            FROM discovery_search_unit_jobs
+            WHERE tenant_id = ?
+              AND discover_workflow_id = ?
+              AND discover_run_id = ?
+              AND unit_id = ?
+              AND job_id = ?
+            """,
+            (
+                tenant_id,
+                workflow_id,
+                run_id,
+                unit_id,
+                surviving_job_id,
+            ),
+        ).fetchone()
+        if surviving is None:
+            conn.execute(
+                """
+                UPDATE discovery_search_unit_jobs
+                SET job_id = ?
+                WHERE tenant_id = ?
+                  AND discover_workflow_id = ?
+                  AND discover_run_id = ?
+                  AND unit_id = ?
+                  AND job_id = ?
+                """,
+                (
+                    surviving_job_id,
+                    tenant_id,
+                    workflow_id,
+                    run_id,
+                    unit_id,
+                    losing_job_id,
+                ),
+            )
+            continue
+        conn.execute(
+            """
+            UPDATE discovery_search_unit_jobs
+            SET was_new = ?,
+                accepted_at = ?
+            WHERE tenant_id = ?
+              AND discover_workflow_id = ?
+              AND discover_run_id = ?
+              AND unit_id = ?
+              AND job_id = ?
+            """,
+            (
+                max(int(surviving[0]), int(losing[3])),
+                min(str(surviving[1]), str(losing[4])),
+                tenant_id,
+                workflow_id,
+                run_id,
+                unit_id,
+                surviving_job_id,
+            ),
+        )
+        conn.execute(
+            """
+            DELETE FROM discovery_search_unit_jobs
+            WHERE tenant_id = ?
+              AND discover_workflow_id = ?
+              AND discover_run_id = ?
+              AND unit_id = ?
+              AND job_id = ?
+            """,
+            (tenant_id, workflow_id, run_id, unit_id, losing_job_id),
+        )
 
 def _table_columns(conn: sqlite3.Connection, table_name: str) -> set[str]:
     return {
@@ -4150,40 +4427,55 @@ def _legacy_or_stable_reference_column(
     )
 
 
-def _resolved_job_id_sql(table_alias: str, reference_column: str) -> str:
+def _resolved_job_id_sql(
+    table_alias: str,
+    reference_column: str,
+    *,
+    legacy_url: bool = False,
+) -> str:
     """Return a correlated SQL expression resolving a legacy or stable key."""
 
     reference = f"{table_alias}.{reference_column}"
     tenant = f"{table_alias}.tenant_id"
-    return f"""
-        COALESCE(
-            (
-                SELECT j.job_id
-                FROM jobs j
-                WHERE j.tenant_id = {tenant}
-                  AND j.job_id = {reference}
-                LIMIT 1
-            ),
-            (
-                SELECT j.job_id
-                FROM jobs j
-                WHERE j.tenant_id = {tenant}
-                  AND j.url = {reference}
-                LIMIT 1
-            ),
-            (
-                SELECT a.job_id
-                FROM job_identity_aliases a
-                JOIN jobs j
-                  ON j.tenant_id = a.tenant_id
-                 AND j.job_id = a.job_id
-                WHERE a.tenant_id = {tenant}
-                  AND a.alias_kind = 'posting_url'
-                  AND a.alias_value = {reference}
-                LIMIT 1
-            )
+    by_job_id = f"""
+        (
+            SELECT j.job_id
+            FROM jobs j
+            WHERE j.tenant_id = {tenant}
+              AND j.job_id = {reference}
+            LIMIT 1
         )
     """
+    by_storage_url = f"""
+        (
+            SELECT j.job_id
+            FROM jobs j
+            WHERE j.tenant_id = {tenant}
+              AND j.url = {reference}
+            LIMIT 1
+        )
+    """
+    by_posting_alias = f"""
+        (
+            SELECT a.job_id
+            FROM job_identity_aliases a
+            JOIN jobs j
+              ON j.tenant_id = a.tenant_id
+             AND j.job_id = a.job_id
+            WHERE a.tenant_id = {tenant}
+              AND a.alias_kind = 'posting_url'
+              AND a.alias_value = {reference}
+            LIMIT 1
+        )
+    """
+    # A legacy URL token can itself be UUID-shaped. Resolve it through URL
+    # ownership before considering a same-text JobId owned by another
+    # aggregate. Stable or historically ambiguous columns retain the
+    # migration framework's JobId-first behavior.
+    lookups = (
+        (by_storage_url, by_posting_alias, by_job_id) if legacy_url else (by_job_id, by_storage_url, by_posting_alias)
+    )
+    return f"COALESCE({','.join(lookups)})"
 
 
 def _create_discovery_identity_v8_rebuild_tables(
@@ -4433,15 +4725,12 @@ def _verify_discovery_identity_references_v8(
     conn: sqlite3.Connection,
     *,
     expected_counts: dict[str, int],
+    check_all_foreign_keys: bool = True,
 ) -> None:
     if not _has_discovery_identity_reference_schema_v8(conn):
-        raise RuntimeError(
-            "discovery identity migration did not create the stable reference schema"
-        )
+        raise RuntimeError("discovery identity migration did not create the stable reference schema")
     for table, expected_count in expected_counts.items():
-        observed_count = int(
-            conn.execute(f'SELECT COUNT(*) FROM "{table}"').fetchone()[0]
-        )
+        observed_count = int(conn.execute(f'SELECT COUNT(*) FROM "{table}"').fetchone()[0])
         if observed_count != expected_count:
             raise RuntimeError(
                 "discovery identity migration changed row count for "
@@ -4467,17 +4756,386 @@ def _verify_discovery_identity_references_v8(
             """
         ).fetchone()
         if orphan is not None:
-            raise RuntimeError(
-                "discovery identity migration left an unresolved reference in "
-                f"{table}.{column}"
+            raise RuntimeError(f"discovery identity migration left an unresolved reference in {table}.{column}")
+
+    if check_all_foreign_keys:
+        foreign_key_error = conn.execute("PRAGMA foreign_key_check").fetchone()
+        if foreign_key_error is not None:
+            raise RuntimeError("discovery identity migration found a foreign-key violation")
+
+
+_EXECUTION_SEARCH_REFERENCE_SCHEMA_VERSION = 9
+_EXECUTION_SEARCH_REFERENCE_TABLES = (
+    "discovery_execution_jobs",
+    "discovery_search_unit_jobs",
+)
+
+
+def ensure_execution_search_references_v9(
+    conn: sqlite3.Connection | None = None,
+) -> list[str]:
+    """Move Discover membership and accepted receipts to stable JobIds."""
+    if conn is None:
+        conn = get_connection()
+
+    current = _assert_schema_version_supported(conn)
+    if current >= _EXECUTION_SEARCH_REFERENCE_SCHEMA_VERSION:
+        return []
+    if current != _DISCOVERY_IDENTITY_REFERENCE_SCHEMA_VERSION:
+        raise RuntimeError("execution/search reference migration requires discovery identity schema v8")
+
+    conn.execute("SAVEPOINT execution_search_references_v9")
+    try:
+        _verify_discovery_identity_references_v8(
+            conn,
+            expected_counts={
+                table: int(conn.execute(f'SELECT COUNT(*) FROM "{table}"').fetchone()[0])
+                for table in _DISCOVERY_IDENTITY_REFERENCE_TABLES
+            },
+            check_all_foreign_keys=False,
+        )
+        before_counts = {
+            table: int(conn.execute(f'SELECT COUNT(*) FROM "{table}"').fetchone()[0])
+            for table in _EXECUTION_SEARCH_REFERENCE_TABLES
+        }
+
+        if not _has_execution_search_reference_schema_v9(conn):
+            execution_reference = _legacy_or_stable_reference_column(
+                conn,
+                "discovery_execution_jobs",
+                stable="job_id",
+                legacy="job_url",
             )
+            receipt_reference = _legacy_or_stable_reference_column(
+                conn,
+                "discovery_search_unit_jobs",
+                stable="job_id",
+                legacy="job_url",
+            )
+            for table, reference_column in (
+                ("discovery_execution_jobs", execution_reference),
+                ("discovery_search_unit_jobs", receipt_reference),
+            ):
+                unresolved = conn.execute(
+                    f"""
+                    SELECT source.{reference_column}
+                    FROM {table} AS source
+                    WHERE {
+                        _resolved_job_id_sql(
+                            "source",
+                            reference_column,
+                            legacy_url=reference_column == "job_url",
+                        )
+                    }
+                          IS NULL
+                    LIMIT 1
+                    """
+                ).fetchone()
+                if unresolved is not None:
+                    raise RuntimeError(
+                        "execution/search reference migration could not resolve "
+                        f"{table}.{reference_column}={unresolved[0]!r}"
+                    )
+
+            _create_execution_search_v9_rebuild_tables(conn)
+            conn.execute(
+                f"""
+                INSERT INTO discovery_execution_jobs_v9 (
+                    tenant_id, discover_workflow_id, discover_run_id, job_id,
+                    cohort_kind, source_family, source_run_id,
+                    preparation_workflow_id, work_plan_state,
+                    required_steps_json, work_plan_reason, linked_at
+                )
+                SELECT
+                    source.tenant_id,
+                    source.discover_workflow_id,
+                    source.discover_run_id,
+                    {
+                    _resolved_job_id_sql(
+                        "source",
+                        execution_reference,
+                        legacy_url=execution_reference == "job_url",
+                    )
+                },
+                    source.cohort_kind,
+                    source.source_family,
+                    source.source_run_id,
+                    source.preparation_workflow_id,
+                    source.work_plan_state,
+                    source.required_steps_json,
+                    source.work_plan_reason,
+                    source.linked_at
+                FROM discovery_execution_jobs AS source
+                """
+            )
+            conn.execute(
+                f"""
+                INSERT INTO discovery_search_unit_jobs_v9 (
+                    tenant_id, discover_workflow_id, discover_run_id,
+                    unit_id, job_id, was_new, accepted_at
+                )
+                SELECT
+                    source.tenant_id,
+                    source.discover_workflow_id,
+                    source.discover_run_id,
+                    source.unit_id,
+                    {
+                    _resolved_job_id_sql(
+                        "source",
+                        receipt_reference,
+                        legacy_url=receipt_reference == "job_url",
+                    )
+                },
+                    source.was_new,
+                    source.accepted_at
+                FROM discovery_search_unit_jobs AS source
+                """
+            )
+
+            for table in _EXECUTION_SEARCH_REFERENCE_TABLES:
+                conn.execute(f'DROP TABLE "{table}"')
+                conn.execute(f'ALTER TABLE "{table}_v9" RENAME TO "{table}"')
+            _create_execution_search_v9_indexes(conn)
+
+        _verify_execution_search_references_v9(
+            conn,
+            expected_counts=before_counts,
+        )
+        conn.execute(f"PRAGMA user_version = {_EXECUTION_SEARCH_REFERENCE_SCHEMA_VERSION}")
+        conn.execute("RELEASE SAVEPOINT execution_search_references_v9")
+        conn.commit()
+    except BaseException:
+        conn.execute("ROLLBACK TO SAVEPOINT execution_search_references_v9")
+        conn.execute("RELEASE SAVEPOINT execution_search_references_v9")
+        raise
+
+    return list(_EXECUTION_SEARCH_REFERENCE_TABLES)
+
+
+def _create_execution_search_v9_rebuild_tables(
+    conn: sqlite3.Connection,
+) -> None:
+    for table in _EXECUTION_SEARCH_REFERENCE_TABLES:
+        conn.execute(f'DROP TABLE IF EXISTS "{table}_v9"')
+    conn.execute(
+        """
+        CREATE TABLE discovery_execution_jobs_v9 (
+            tenant_id                TEXT NOT NULL,
+            discover_workflow_id     TEXT NOT NULL,
+            discover_run_id          TEXT NOT NULL,
+            job_id                   TEXT NOT NULL,
+            cohort_kind              TEXT NOT NULL
+                CHECK (cohort_kind IN (
+                    'observed_this_run', 'existing_backlog'
+                )),
+            source_family            TEXT,
+            source_run_id            TEXT,
+            preparation_workflow_id  TEXT,
+            work_plan_state          TEXT NOT NULL DEFAULT 'pending'
+                CHECK (work_plan_state IN (
+                    'pending', 'planned', 'not_eligible', 'failed'
+                )),
+            required_steps_json      TEXT,
+            work_plan_reason         TEXT,
+            linked_at                TEXT NOT NULL,
+            PRIMARY KEY (
+                tenant_id, discover_workflow_id, discover_run_id, job_id
+            ),
+            FOREIGN KEY (tenant_id, job_id)
+                REFERENCES jobs(tenant_id, job_id) ON DELETE CASCADE
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE discovery_search_unit_jobs_v9 (
+            tenant_id              TEXT NOT NULL,
+            discover_workflow_id   TEXT NOT NULL,
+            discover_run_id        TEXT NOT NULL,
+            unit_id                TEXT NOT NULL,
+            job_id                 TEXT NOT NULL,
+            was_new                INTEGER NOT NULL CHECK (was_new IN (0, 1)),
+            accepted_at            TEXT NOT NULL,
+            PRIMARY KEY (
+                tenant_id, discover_workflow_id, discover_run_id,
+                unit_id, job_id
+            ),
+            FOREIGN KEY (
+                tenant_id, discover_workflow_id, discover_run_id, unit_id
+            ) REFERENCES discovery_search_units(
+                tenant_id, discover_workflow_id, discover_run_id, unit_id
+            ) ON DELETE CASCADE,
+            FOREIGN KEY (tenant_id, job_id)
+                REFERENCES jobs(tenant_id, job_id) ON DELETE CASCADE
+        )
+        """
+    )
+
+
+def _create_execution_search_v9_indexes(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_discovery_execution_jobs_cohort
+        ON discovery_execution_jobs(
+            tenant_id, discover_workflow_id, discover_run_id, cohort_kind
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_discovery_execution_jobs_plan
+        ON discovery_execution_jobs(
+            tenant_id, discover_workflow_id, discover_run_id, work_plan_state
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_discovery_execution_jobs_job
+        ON discovery_execution_jobs(tenant_id, job_id, linked_at)
+        """
+    )
+    conn.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_discovery_search_unit_jobs_execution
+        ON discovery_search_unit_jobs(
+            tenant_id, discover_workflow_id, discover_run_id, was_new
+        )
+        """
+    )
+
+
+def _has_search_unit_foreign_key(conn: sqlite3.Connection) -> bool:
+    groups: dict[int, set[tuple[str, str]]] = {}
+    cascades: dict[int, bool] = {}
+    for row in conn.execute('PRAGMA foreign_key_list("discovery_search_unit_jobs")').fetchall():
+        if str(row[2]) != "discovery_search_units":
+            continue
+        foreign_key_id = int(row[0])
+        groups.setdefault(foreign_key_id, set()).add((str(row[3]), str(row[4])))
+        cascades[foreign_key_id] = str(row[6]).upper() == "CASCADE"
+    expected = {
+        ("tenant_id", "tenant_id"),
+        ("discover_workflow_id", "discover_workflow_id"),
+        ("discover_run_id", "discover_run_id"),
+        ("unit_id", "unit_id"),
+    }
+    return any(
+        columns == expected and cascades.get(foreign_key_id, False) for foreign_key_id, columns in groups.items()
+    )
+
+
+def _has_execution_search_reference_schema_v9(
+    conn: sqlite3.Connection,
+) -> bool:
+    return (
+        "job_id" in _table_columns(conn, "discovery_execution_jobs")
+        and "job_url" not in _table_columns(conn, "discovery_execution_jobs")
+        and _primary_key_columns(conn, "discovery_execution_jobs")
+        == (
+            "tenant_id",
+            "discover_workflow_id",
+            "discover_run_id",
+            "job_id",
+        )
+        and _has_composite_job_id_foreign_key(
+            conn,
+            "discovery_execution_jobs",
+            "job_id",
+        )
+        and _has_index(
+            conn,
+            "discovery_execution_jobs",
+            "idx_discovery_execution_jobs_cohort",
+            (
+                "tenant_id",
+                "discover_workflow_id",
+                "discover_run_id",
+                "cohort_kind",
+            ),
+            unique=False,
+        )
+        and _has_index(
+            conn,
+            "discovery_execution_jobs",
+            "idx_discovery_execution_jobs_plan",
+            (
+                "tenant_id",
+                "discover_workflow_id",
+                "discover_run_id",
+                "work_plan_state",
+            ),
+            unique=False,
+        )
+        and _has_index(
+            conn,
+            "discovery_execution_jobs",
+            "idx_discovery_execution_jobs_job",
+            ("tenant_id", "job_id", "linked_at"),
+            unique=False,
+        )
+        and "job_id" in _table_columns(conn, "discovery_search_unit_jobs")
+        and "job_url" not in _table_columns(conn, "discovery_search_unit_jobs")
+        and _primary_key_columns(conn, "discovery_search_unit_jobs")
+        == (
+            "tenant_id",
+            "discover_workflow_id",
+            "discover_run_id",
+            "unit_id",
+            "job_id",
+        )
+        and _has_search_unit_foreign_key(conn)
+        and _has_composite_job_id_foreign_key(
+            conn,
+            "discovery_search_unit_jobs",
+            "job_id",
+        )
+        and _has_index(
+            conn,
+            "discovery_search_unit_jobs",
+            "idx_discovery_search_unit_jobs_execution",
+            (
+                "tenant_id",
+                "discover_workflow_id",
+                "discover_run_id",
+                "was_new",
+            ),
+            unique=False,
+        )
+    )
+
+
+def _verify_execution_search_references_v9(
+    conn: sqlite3.Connection,
+    *,
+    expected_counts: dict[str, int],
+) -> None:
+    if not _has_execution_search_reference_schema_v9(conn):
+        raise RuntimeError("execution/search reference migration did not create the stable reference schema")
+    for table, expected_count in expected_counts.items():
+        observed_count = int(conn.execute(f'SELECT COUNT(*) FROM "{table}"').fetchone()[0])
+        if observed_count != expected_count:
+            raise RuntimeError(
+                "execution/search reference migration changed row count for "
+                f"{table}: expected {expected_count}, found {observed_count}"
+            )
+        orphan = conn.execute(
+            f"""
+            SELECT source.job_id
+            FROM {table} AS source
+            LEFT JOIN jobs j
+              ON j.tenant_id = source.tenant_id
+             AND j.job_id = source.job_id
+            WHERE j.job_id IS NULL
+            LIMIT 1
+            """
+        ).fetchone()
+        if orphan is not None:
+            raise RuntimeError(f"execution/search reference migration left an unresolved reference in {table}.job_id")
 
     foreign_key_error = conn.execute("PRAGMA foreign_key_check").fetchone()
     if foreign_key_error is not None:
-        raise RuntimeError(
-            "discovery identity migration found a foreign-key violation"
-        )
-
+        raise RuntimeError("execution/search reference migration found a foreign-key violation")
 
 # ---------------------------------------------------------------------------
 # job_enrichments read fragments — used by every selector / stat that

--- a/workers/automation/src/jobctrl/discovery/execution_reconciliation.py
+++ b/workers/automation/src/jobctrl/discovery/execution_reconciliation.py
@@ -1133,8 +1133,14 @@ def _persisted_membership_keys(
         str(row["job_url"])
         for row in conn.execute(
             """
-            SELECT job_url FROM discovery_execution_jobs
-            WHERE tenant_id = ? AND discover_workflow_id = ? AND discover_run_id = ?
+            SELECT jobs.url AS job_url
+            FROM discovery_execution_jobs AS execution
+            JOIN jobs
+              ON jobs.tenant_id = execution.tenant_id
+             AND jobs.job_id = execution.job_id
+            WHERE execution.tenant_id = ?
+              AND execution.discover_workflow_id = ?
+              AND execution.discover_run_id = ?
             """,
             (tenant_id, workflow_id, temporal_run_id),
         ).fetchall()

--- a/workers/automation/src/jobctrl/infrastructure/discovery/sqlite_execution_repository.py
+++ b/workers/automation/src/jobctrl/infrastructure/discovery/sqlite_execution_repository.py
@@ -18,12 +18,21 @@ from jobctrl.domain.discovery.execution import (
     validate_safe_reason_code,
     validate_work_plan_state,
 )
+from jobctrl.domain.discovery.value_objects import PostingUrl
+from jobctrl.domain.identifiers import canonical_job_id
+from jobctrl.domain.tenant import TenantId
+from jobctrl.infrastructure.discovery.sqlite_identity_resolver import (
+    SqliteJobIdentityResolver,
+)
 
 
 _SELECT_COLUMNS = """
-    tenant_id, discover_workflow_id, discover_run_id, job_url, cohort_kind,
-    source_family, source_run_id, preparation_workflow_id, work_plan_state,
-    required_steps_json, work_plan_reason, linked_at
+    execution.tenant_id, execution.discover_workflow_id,
+    execution.discover_run_id, jobs.url AS job_url, execution.cohort_kind,
+    execution.source_family, execution.source_run_id,
+    execution.preparation_workflow_id, execution.work_plan_state,
+    execution.required_steps_json, execution.work_plan_reason,
+    execution.linked_at
 """
 
 
@@ -58,16 +67,19 @@ class SqliteDiscoveryExecutionRepository:
         if resolved_cohort == "observed_this_run" and normalized_family is None:
             raise ValueError("source_family is required for an observed execution job")
         linked = linked_at or datetime.now(timezone.utc).isoformat()
+        stable_job_id = self._resolve_job_id(execution, normalized_job_url)
 
         with self._conn:
             self._conn.execute(
                 """
                 INSERT INTO discovery_execution_jobs (
-                    tenant_id, discover_workflow_id, discover_run_id, job_url,
+                    tenant_id, discover_workflow_id, discover_run_id, job_id,
                     cohort_kind, source_family, source_run_id, work_plan_state,
                     linked_at
                 ) VALUES (?, ?, ?, ?, ?, ?, ?, 'pending', ?)
-                ON CONFLICT (tenant_id, discover_workflow_id, discover_run_id, job_url)
+                ON CONFLICT (
+                    tenant_id, discover_workflow_id, discover_run_id, job_id
+                )
                 DO UPDATE SET
                     cohort_kind = CASE
                         WHEN excluded.cohort_kind = 'observed_this_run'
@@ -93,7 +105,7 @@ class SqliteDiscoveryExecutionRepository:
                     execution.tenant_id,
                     execution.workflow_id,
                     execution.temporal_run_id,
-                    normalized_job_url,
+                    stable_job_id,
                     resolved_cohort,
                     normalized_family,
                     normalized_source_run_id,
@@ -145,14 +157,13 @@ class SqliteDiscoveryExecutionRepository:
             raise ValueError(f"{resolved_state} work cannot name a preparation workflow")
 
         normalized_job_url = _required_text(job_url, "job_url")
+        stable_job_id = self._resolve_job_id(execution, normalized_job_url)
         existing = self.get(execution, normalized_job_url)
         if existing is None:
             raise KeyError(f"Job is not linked to discovery execution: {normalized_job_url}")
 
         desired_steps_json = (
-            json.dumps(list(normalized_steps), separators=(",", ":"))
-            if normalized_steps is not None
-            else None
+            json.dumps(list(normalized_steps), separators=(",", ":")) if normalized_steps is not None else None
         )
         if existing.work_plan_state in {"planned", "not_eligible"}:
             desired = (
@@ -171,10 +182,7 @@ class SqliteDiscoveryExecutionRepository:
                 raise ValueError("A decided discovery execution work plan is immutable")
             return existing
 
-        if (
-            existing.preparation_workflow_id is not None
-            and normalized_workflow_id != existing.preparation_workflow_id
-        ):
+        if existing.preparation_workflow_id is not None and normalized_workflow_id != existing.preparation_workflow_id:
             raise ValueError("preparation_workflow_id is immutable once assigned")
 
         with self._conn:
@@ -188,7 +196,7 @@ class SqliteDiscoveryExecutionRepository:
                  WHERE tenant_id = ?
                    AND discover_workflow_id = ?
                    AND discover_run_id = ?
-                   AND job_url = ?
+                   AND job_id = ?
                    AND work_plan_state IN ('pending', 'failed')
                 """,
                 (
@@ -199,7 +207,7 @@ class SqliteDiscoveryExecutionRepository:
                     execution.tenant_id,
                     execution.workflow_id,
                     execution.temporal_run_id,
-                    normalized_job_url,
+                    stable_job_id,
                 ),
             )
             if updated.rowcount != 1:
@@ -224,20 +232,27 @@ class SqliteDiscoveryExecutionRepository:
         return result
 
     def get(self, execution: DiscoveryExecutionRef, job_url: str) -> DiscoveryExecutionJob | None:
+        try:
+            stable_job_id = self._resolve_job_id(execution, job_url)
+        except KeyError:
+            return None
         row = self._conn.execute(
             f"""
             SELECT {_SELECT_COLUMNS}
-              FROM discovery_execution_jobs
-             WHERE tenant_id = ?
-               AND discover_workflow_id = ?
-               AND discover_run_id = ?
-               AND job_url = ?
+              FROM discovery_execution_jobs AS execution
+              JOIN jobs
+                ON jobs.tenant_id = execution.tenant_id
+               AND jobs.job_id = execution.job_id
+             WHERE execution.tenant_id = ?
+               AND execution.discover_workflow_id = ?
+               AND execution.discover_run_id = ?
+               AND execution.job_id = ?
             """,
             (
                 execution.tenant_id,
                 execution.workflow_id,
                 execution.temporal_run_id,
-                job_url,
+                stable_job_id,
             ),
         ).fetchone()
         return _row_to_execution_job(row) if row is not None else None
@@ -246,18 +261,48 @@ class SqliteDiscoveryExecutionRepository:
         rows = self._conn.execute(
             f"""
             SELECT {_SELECT_COLUMNS}
-              FROM discovery_execution_jobs
-             WHERE tenant_id = ?
-               AND discover_workflow_id = ?
-               AND discover_run_id = ?
-             ORDER BY job_url
+              FROM discovery_execution_jobs AS execution
+              JOIN jobs
+                ON jobs.tenant_id = execution.tenant_id
+               AND jobs.job_id = execution.job_id
+             WHERE execution.tenant_id = ?
+               AND execution.discover_workflow_id = ?
+               AND execution.discover_run_id = ?
+             ORDER BY jobs.url
             """,
             (execution.tenant_id, execution.workflow_id, execution.temporal_run_id),
         ).fetchall()
         return [_row_to_execution_job(row) for row in rows]
 
+    def _resolve_job_id(
+        self,
+        execution: DiscoveryExecutionRef,
+        job_reference: str,
+    ) -> str:
+        normalized = _required_text(job_reference, "job_url")
+        resolver = SqliteJobIdentityResolver(self._conn)
+        identity = resolver.resolve_by_posting_url(
+            TenantId(execution.tenant_id),
+            PostingUrl(normalized),
+        )
+        if identity is None:
+            try:
+                stable_job_id = canonical_job_id(normalized)
+            except ValueError:
+                stable_job_id = None
+            if stable_job_id is not None:
+                identity = resolver.resolve_by_job_id(
+                    TenantId(execution.tenant_id),
+                    stable_job_id,
+                )
+        if identity is None:
+            raise KeyError(f"No stable Job identity for discovery execution member: {normalized}")
+        return str(identity.job_id)
 
-def _row_to_execution_job(row: sqlite3.Row | tuple[object, ...]) -> DiscoveryExecutionJob:
+
+def _row_to_execution_job(
+    row: sqlite3.Row | tuple[object, ...],
+) -> DiscoveryExecutionJob:
     raw_steps = row[9]
     steps: tuple[DiscoveryPreparationStep, ...] | None = None
     if raw_steps is not None:

--- a/workers/automation/src/jobctrl/infrastructure/discovery/sqlite_search_unit_repository.py
+++ b/workers/automation/src/jobctrl/infrastructure/discovery/sqlite_search_unit_repository.py
@@ -16,6 +16,7 @@ from jobstreaming import (
 )
 
 from jobctrl.database import ensure_discovery_search_unit_tables
+from jobctrl.domain.discovery.value_objects import PostingUrl
 from jobctrl.domain.discovery.execution import DiscoveryExecutionRef
 from jobctrl.domain.discovery.search_units import (
     DiscoverySearchSpec,
@@ -24,6 +25,11 @@ from jobctrl.domain.discovery.search_units import (
     search_unit_id,
     validate_search_unit_state,
     validate_unit_id,
+)
+from jobctrl.domain.identifiers import canonical_job_id
+from jobctrl.domain.tenant import TenantId
+from jobctrl.infrastructure.discovery.sqlite_identity_resolver import (
+    SqliteJobIdentityResolver,
 )
 
 
@@ -37,7 +43,7 @@ _SELECT_UNIT = """
            u.last_error_retryable, u.reset_checkpoint,
            u.reset_checkpoint_after_revision,
            u.created_at, u.updated_at, u.completed_at,
-           COUNT(j.job_url) AS accepted_jobs,
+           COUNT(j.job_id) AS accepted_jobs,
            COALESCE(SUM(j.was_new), 0) AS new_jobs
       FROM discovery_search_units u
       LEFT JOIN discovery_search_unit_jobs j
@@ -84,7 +90,13 @@ class SqliteDiscoverySearchUnitRepository:
 
         planned_at = created_at or _utc_now()
         desired = [
-            (search_unit_id(ordinal, spec), ordinal, spec, spec.to_json(), spec.fingerprint())
+            (
+                search_unit_id(ordinal, spec),
+                ordinal,
+                spec,
+                spec.to_json(),
+                spec.fingerprint(),
+            )
             for ordinal, spec in enumerate(specs)
         ]
         with self._conn:
@@ -399,9 +411,7 @@ class SqliteDiscoverySearchUnitRepository:
             return False
         current_revision = int(row[1]) if row[1] is not None else None
         required_revision = int(row[2]) if row[2] is not None else None
-        if required_revision is not None and (
-            current_revision is None or current_revision < required_revision
-        ):
+        if required_revision is not None and (current_revision is None or current_revision < required_revision):
             return False
         self.clear_checkpoint(lease)
         return True
@@ -416,31 +426,59 @@ class SqliteDiscoverySearchUnitRepository:
     ) -> None:
         """Record an idempotent accepted-job receipt under the current fence."""
 
-        normalized_url = job_url.strip()
-        if not normalized_url:
-            raise ValueError("job_url must be non-empty")
+        stable_job_id = self._resolve_job_id(
+            lease.execution,
+            job_url,
+        )
         with self._conn:
             self.fence_write(lease)
             self._conn.execute(
                 """
                 INSERT INTO discovery_search_unit_jobs (
                     tenant_id, discover_workflow_id, discover_run_id,
-                    unit_id, job_url, was_new, accepted_at
+                    unit_id, job_id, was_new, accepted_at
                 ) VALUES (?, ?, ?, ?, ?, ?, ?)
                 ON CONFLICT (
                     tenant_id, discover_workflow_id, discover_run_id,
-                    unit_id, job_url
+                    unit_id, job_id
                 ) DO UPDATE SET
                     was_new = MAX(discovery_search_unit_jobs.was_new, excluded.was_new)
                 """,
                 (
                     *_execution_params(lease.execution),
                     lease.unit_id,
-                    normalized_url,
+                    stable_job_id,
                     int(was_new),
                     accepted_at or _utc_now(),
                 ),
             )
+
+    def _resolve_job_id(
+        self,
+        execution: DiscoveryExecutionRef,
+        job_url: str,
+    ) -> str:
+        normalized = job_url.strip()
+        if not normalized:
+            raise ValueError("job_url must be non-empty")
+        resolver = SqliteJobIdentityResolver(self._conn)
+        identity = resolver.resolve_by_posting_url(
+            TenantId(execution.tenant_id),
+            PostingUrl(normalized),
+        )
+        if identity is None:
+            try:
+                stable_job_id = canonical_job_id(normalized)
+            except ValueError:
+                stable_job_id = None
+            if stable_job_id is not None:
+                identity = resolver.resolve_by_job_id(
+                    TenantId(execution.tenant_id),
+                    stable_job_id,
+                )
+        if identity is None:
+            raise KeyError(f"No stable Job identity for accepted search result: {normalized}")
+        return str(identity.job_id)
 
     def record_filtered_result(
         self,
@@ -515,13 +553,11 @@ class SqliteDiscoverySearchUnitRepository:
                 (*_execution_params(lease.execution), lease.unit_id),
             ).fetchone()
             current_revision = (
-                int(checkpoint_row[0])
-                if checkpoint_row is not None and checkpoint_row[0] is not None
-                else None
+                int(checkpoint_row[0]) if checkpoint_row is not None and checkpoint_row[0] is not None else None
             )
             reset_after_revision = (
-                (current_revision + 1) if current_revision is not None else 1
-            ) if reset_checkpoint else None
+                ((current_revision + 1) if current_revision is not None else 1) if reset_checkpoint else None
+            )
             self._conn.execute(
                 """
                 UPDATE discovery_search_units
@@ -737,12 +773,8 @@ class SqliteDiscoverySearchUnitRepository:
             try:
                 checkpoint = SearchCheckpoint.model_validate_json(str(row[1]))
             except Exception as exc:
-                raise CheckpointError(
-                    f"unable to read checkpoint for search unit {row[0]}"
-                ) from exc
-            total += sum(
-                adapter.emitted_count for adapter in checkpoint.adapters.values()
-            )
+                raise CheckpointError(f"unable to read checkpoint for search unit {row[0]}") from exc
+            total += sum(adapter.emitted_count for adapter in checkpoint.adapters.values())
         return total
 
     def execution_filtered_count(
@@ -826,9 +858,7 @@ class SqliteDiscoverySearchUnitRepository:
             last_error_type=str(row[14]) if row[14] is not None else None,
             last_error_retryable=(bool(row[15]) if row[15] is not None else None),
             reset_checkpoint=bool(row[16]),
-            reset_checkpoint_after_revision=(
-                int(row[17]) if row[17] is not None else None
-            ),
+            reset_checkpoint_after_revision=(int(row[17]) if row[17] is not None else None),
             created_at=str(row[18]),
             updated_at=str(row[19]),
             completed_at=str(row[20]) if row[20] is not None else None,

--- a/workers/automation/tests/test_discovery_execution_reconciliation.py
+++ b/workers/automation/tests/test_discovery_execution_reconciliation.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import sqlite3
+import uuid
 
 import pytest
 
@@ -329,6 +330,9 @@ def _append_workflow_started(
     temporal_run_id: str,
     input_summary: dict[str, object],
 ) -> None:
+    job_url = input_summary.get("jobUrl")
+    if isinstance(job_url, str):
+        _ensure_job_identity(conn, job_url)
     record_job_event(
         conn,
         None,
@@ -342,6 +346,37 @@ def _append_workflow_started(
             "inputSummary": input_summary,
         },
         occurred_at=occurred_at,
+    )
+
+
+def _ensure_job_identity(
+    conn: sqlite3.Connection,
+    job_url: str,
+    *,
+    tenant_id: str = "local",
+) -> None:
+    if conn.execute("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'jobs'").fetchone() is None:
+        return
+    job_id = str(uuid.uuid5(uuid.NAMESPACE_URL, f"{tenant_id}:{job_url}"))
+    conn.execute(
+        """
+        INSERT OR IGNORE INTO jobs (url, tenant_id, job_id, title)
+        VALUES (?, ?, ?, 'Recovery fixture')
+        """,
+        (job_url, tenant_id, job_id),
+    )
+    row = conn.execute(
+        "SELECT job_id FROM jobs WHERE tenant_id = ? AND url = ?",
+        (tenant_id, job_url),
+    ).fetchone()
+    assert row is not None
+    conn.execute(
+        """
+        INSERT OR IGNORE INTO job_identity_aliases (
+            tenant_id, alias_kind, alias_value, job_id, created_at
+        ) VALUES (?, 'posting_url', ?, ?, '2026-07-16T00:00:00+00:00')
+        """,
+        (tenant_id, job_url, str(row["job_id"])),
     )
 
 
@@ -577,7 +612,12 @@ async def test_decoder_v2_recovers_exact_legacy_fanouts_and_resumes_partial_repl
         *(("preparation_fanout", f"streaming:pass-{index}") for index in range(1, 5)),
     }
     native_step_keys = {step_key for _, _, step_key, _ in native_specs}
-    assert [step.item_count for step in legacy_steps if step.step_kind == "preparation_fanout"] == [0, 71, 67, 34]
+    assert [step.item_count for step in legacy_steps if step.step_kind == "preparation_fanout"] == [
+        0,
+        71,
+        67,
+        34,
+    ]
     assert skipped_native == 4
     assert legacy_step_keys == expected_legacy_step_keys
     assert len(legacy_step_keys) == 12
@@ -736,10 +776,17 @@ async def test_decoder_v2_recovers_exact_legacy_fanouts_and_resumes_partial_repl
 
     memberships = conn.execute(
         """
-        SELECT job_url, work_plan_state, required_steps_json,
-               preparation_workflow_id, work_plan_reason
-        FROM discovery_execution_jobs
-        WHERE tenant_id = ? AND discover_workflow_id = ? AND discover_run_id = ?
+        SELECT jobs.url AS job_url, execution.work_plan_state,
+               execution.required_steps_json,
+               execution.preparation_workflow_id,
+               execution.work_plan_reason
+        FROM discovery_execution_jobs AS execution
+        JOIN jobs
+          ON jobs.tenant_id = execution.tenant_id
+         AND jobs.job_id = execution.job_id
+        WHERE execution.tenant_id = ?
+          AND execution.discover_workflow_id = ?
+          AND execution.discover_run_id = ?
         """,
         (execution.tenant_id, execution.workflow_id, execution.temporal_run_id),
     ).fetchall()
@@ -1060,6 +1107,7 @@ async def test_ready_manifest_retries_history_read_without_losing_durable_proof(
         temporal_run_id="run-history-retry",
     )
     repository = SqliteDiscoveryExecutionRepository(conn)
+    _ensure_job_identity(conn, "job:durable")
     repository.link_job(
         execution,
         "job:durable",
@@ -1299,7 +1347,14 @@ async def test_retried_fanout_recovers_exact_work_without_inventing_queue_time(
     assert result.jobs_linked == 1
     assert result.work_plans_recovered == 1
     membership = conn.execute(
-        "SELECT * FROM discovery_execution_jobs WHERE job_url = 'job:retried'"
+        """
+        SELECT execution.*
+        FROM discovery_execution_jobs AS execution
+        JOIN jobs
+          ON jobs.tenant_id = execution.tenant_id
+         AND jobs.job_id = execution.job_id
+        WHERE jobs.url = 'job:retried'
+        """
     ).fetchone()
     assert membership["work_plan_state"] == "planned"
     assert membership["preparation_workflow_id"] == "prep-retried"
@@ -1671,7 +1726,14 @@ async def test_terminal_failed_fanout_persists_exact_partial_incomplete_coverage
     assert result.jobs_linked == 1
     assert result.work_plans_recovered == 1
     membership = conn.execute(
-        "SELECT * FROM discovery_execution_jobs WHERE job_url = 'job:partial'"
+        """
+        SELECT execution.*
+        FROM discovery_execution_jobs AS execution
+        JOIN jobs
+          ON jobs.tenant_id = execution.tenant_id
+         AND jobs.job_id = execution.job_id
+        WHERE jobs.url = 'job:partial'
+        """
     ).fetchone()
     assert membership["work_plan_state"] == "planned"
     assert membership["preparation_workflow_id"] == "prep-partial"
@@ -1724,6 +1786,7 @@ async def test_reconciliation_repairs_stale_ready_manifest(tmp_path, monkeypatch
         workflow_id="discover-local",
         temporal_run_id="run-stale",
     )
+    _ensure_job_identity(conn, "job:new")
     SqliteDiscoveryExecutionRepository(conn).link_job(
         execution,
         "job:new",

--- a/workers/automation/tests/test_discovery_identity_reference_migration.py
+++ b/workers/automation/tests/test_discovery_identity_reference_migration.py
@@ -220,7 +220,7 @@ def test_v7_discovery_references_migrate_to_stable_job_id_and_reopen(
     init_db(db_path)
     close_connection(db_path)
 
-    assert _user_version(db_path) == SCHEMA_VERSION == 8
+    assert _user_version(db_path) == SCHEMA_VERSION == 9
     assert "job_id" in _columns(db_path, "job_source_observations")
     assert "job_url" not in _columns(db_path, "job_source_observations")
     assert "job_id" in _columns(db_path, "job_canonical_identities")

--- a/workers/automation/tests/test_execution_search_identity_reference_migration.py
+++ b/workers/automation/tests/test_execution_search_identity_reference_migration.py
@@ -1,0 +1,509 @@
+"""Schema-v9 execution and accepted-search-receipt migration contracts."""
+
+from __future__ import annotations
+
+import shutil
+import sqlite3
+import uuid
+from pathlib import Path
+
+import pytest
+
+from jobctrl.database import (
+    SCHEMA_VERSION,
+    _assert_schema_version_supported,
+    close_connection,
+    init_db,
+)
+from jobctrl.domain.discovery import (
+    Employer,
+    Job,
+    JobMetadata,
+    PostingUrl,
+    SearchStrategy,
+    Source,
+)
+from jobctrl.domain.discovery.execution import DiscoveryExecutionRef
+from jobctrl.domain.discovery.search_units import DiscoverySearchUnitLease
+from jobctrl.domain.identifiers import JobId
+from jobctrl.domain.tenant import LOCAL_TENANT
+from jobctrl.infrastructure.discovery import SqliteJobRepository
+from jobctrl.infrastructure.discovery.sqlite_execution_repository import (
+    SqliteDiscoveryExecutionRepository,
+)
+from jobctrl.infrastructure.discovery.sqlite_search_unit_repository import (
+    SqliteDiscoverySearchUnitRepository,
+)
+
+
+PREVIOUS_SCHEMA_VERSION = 8
+REFERENCE_TABLES = (
+    "discovery_execution_jobs",
+    "discovery_search_unit_jobs",
+)
+
+
+def _downgrade_execution_search_references_to_v8(
+    conn: sqlite3.Connection,
+) -> None:
+    conn.execute("DROP TABLE discovery_search_unit_jobs")
+    conn.execute("DROP TABLE discovery_execution_jobs")
+    conn.executescript(
+        """
+        CREATE TABLE discovery_execution_jobs (
+            tenant_id                TEXT NOT NULL,
+            discover_workflow_id     TEXT NOT NULL,
+            discover_run_id          TEXT NOT NULL,
+            job_url                  TEXT NOT NULL,
+            cohort_kind              TEXT NOT NULL
+                CHECK (cohort_kind IN (
+                    'observed_this_run', 'existing_backlog'
+                )),
+            source_family            TEXT,
+            source_run_id            TEXT,
+            preparation_workflow_id  TEXT,
+            work_plan_state          TEXT NOT NULL DEFAULT 'pending'
+                CHECK (work_plan_state IN (
+                    'pending', 'planned', 'not_eligible', 'failed'
+                )),
+            required_steps_json      TEXT,
+            work_plan_reason         TEXT,
+            linked_at                TEXT NOT NULL,
+            PRIMARY KEY (
+                tenant_id, discover_workflow_id, discover_run_id, job_url
+            ),
+            FOREIGN KEY (job_url) REFERENCES jobs(url) ON DELETE CASCADE
+        );
+        CREATE INDEX idx_discovery_execution_jobs_cohort
+            ON discovery_execution_jobs(
+                tenant_id, discover_workflow_id, discover_run_id, cohort_kind
+            );
+        CREATE INDEX idx_discovery_execution_jobs_plan
+            ON discovery_execution_jobs(
+                tenant_id, discover_workflow_id, discover_run_id,
+                work_plan_state
+            );
+        CREATE INDEX idx_discovery_execution_jobs_job
+            ON discovery_execution_jobs(tenant_id, job_url, linked_at);
+
+        CREATE TABLE discovery_search_unit_jobs (
+            tenant_id              TEXT NOT NULL,
+            discover_workflow_id   TEXT NOT NULL,
+            discover_run_id        TEXT NOT NULL,
+            unit_id                TEXT NOT NULL,
+            job_url                TEXT NOT NULL,
+            was_new                INTEGER NOT NULL CHECK (was_new IN (0, 1)),
+            accepted_at            TEXT NOT NULL,
+            PRIMARY KEY (
+                tenant_id, discover_workflow_id, discover_run_id,
+                unit_id, job_url
+            ),
+            FOREIGN KEY (
+                tenant_id, discover_workflow_id, discover_run_id, unit_id
+            ) REFERENCES discovery_search_units(
+                tenant_id, discover_workflow_id, discover_run_id, unit_id
+            ) ON DELETE CASCADE,
+            FOREIGN KEY (job_url) REFERENCES jobs(url) ON DELETE CASCADE
+        );
+        CREATE INDEX idx_discovery_search_unit_jobs_execution
+            ON discovery_search_unit_jobs(
+                tenant_id, discover_workflow_id, discover_run_id, was_new
+            );
+        """
+    )
+    conn.execute(f"PRAGMA user_version = {PREVIOUS_SCHEMA_VERSION}")
+    conn.commit()
+
+
+def _discovered_job(posting_url: str, job_id: JobId) -> Job:
+    return Job.discover(
+        tenant_id=LOCAL_TENANT,
+        job_id=job_id,
+        posting_url=PostingUrl(value=posting_url),
+        source=Source(board="example"),
+        employer=Employer(name="Example"),
+        search_strategy=SearchStrategy.JOBSPY,
+        metadata=JobMetadata(title="Platform Engineer"),
+        discovered_at="2026-07-29T10:00:00+00:00",
+    )
+
+
+def _user_version(db_path: Path) -> int:
+    conn = sqlite3.connect(db_path)
+    try:
+        return int(conn.execute("PRAGMA user_version").fetchone()[0])
+    finally:
+        conn.close()
+
+
+def _columns(db_path: Path, table: str) -> set[str]:
+    conn = sqlite3.connect(db_path)
+    try:
+        return {str(row[1]) for row in conn.execute(f'PRAGMA table_info("{table}")').fetchall()}
+    finally:
+        conn.close()
+
+
+def _insert_search_unit(
+    conn: sqlite3.Connection,
+    *,
+    workflow_id: str,
+    run_id: str,
+    unit_id: str,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO discovery_search_units (
+            tenant_id, discover_workflow_id, discover_run_id, unit_id,
+            ordinal, request_json, request_fingerprint, state,
+            created_at, updated_at
+        ) VALUES (
+            'local', ?, ?, ?, 0, '{}', 'fixture-fingerprint', 'completed',
+            '2026-07-29T10:00:00+00:00',
+            '2026-07-29T10:05:00+00:00'
+        )
+        """,
+        (workflow_id, run_id, unit_id),
+    )
+
+
+def test_v8_execution_and_receipts_migrate_to_stable_job_id_and_reopen(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    pre_upgrade = tmp_path / "jobctrl-v8.db"
+    conn = init_db(db_path)
+    job_id = str(uuid.uuid4())
+    storage_url = "https://boards.example/jobs/123"
+    current_url = "https://careers.example/jobs/platform-engineer"
+    repository = SqliteJobRepository(conn)
+    repository.save(_discovered_job(storage_url, JobId(job_id)))
+    repository.save(_discovered_job(current_url, JobId(job_id)))
+    uuid_shaped_url = str(uuid.uuid4())
+    uuid_url_owner_job_id = JobId(str(uuid.uuid4()))
+    repository.save(_discovered_job(uuid_shaped_url, uuid_url_owner_job_id))
+    repository.save(
+        _discovered_job(
+            "https://example.com/jobs/id-text-collision",
+            JobId(uuid_shaped_url),
+        )
+    )
+    _downgrade_execution_search_references_to_v8(conn)
+
+    workflow_id = "discover-local"
+    run_id = "temporal-run-1"
+    unit_id = "unit-1"
+    _insert_search_unit(
+        conn,
+        workflow_id=workflow_id,
+        run_id=run_id,
+        unit_id=unit_id,
+    )
+    conn.execute(
+        """
+        INSERT INTO discovery_execution_jobs (
+            tenant_id, discover_workflow_id, discover_run_id, job_url,
+            cohort_kind, source_family, source_run_id,
+            preparation_workflow_id, work_plan_state,
+            required_steps_json, work_plan_reason, linked_at
+        ) VALUES (
+            'local', ?, ?, ?, 'observed_this_run', 'greenhouse',
+            'source-run-1', 'prepare-job-1', 'planned',
+            '["enrich","score"]', 'selected_for_preparation',
+            '2026-07-29T10:01:00+00:00'
+        )
+        """,
+        (workflow_id, run_id, current_url),
+    )
+    conn.execute(
+        """
+        INSERT INTO discovery_search_unit_jobs (
+            tenant_id, discover_workflow_id, discover_run_id,
+            unit_id, job_url, was_new, accepted_at
+        ) VALUES (
+            'local', ?, ?, ?, ?, 1, '2026-07-29T10:02:00+00:00'
+        )
+        """,
+        (workflow_id, run_id, unit_id, storage_url),
+    )
+    conn.execute(
+        """
+        INSERT INTO discovery_execution_jobs (
+            tenant_id, discover_workflow_id, discover_run_id, job_url,
+            cohort_kind, source_family, source_run_id,
+            work_plan_state, linked_at
+        ) VALUES (
+            'local', ?, ?, ?, 'observed_this_run', 'synthetic',
+            'source-run-uuid-url', 'pending',
+            '2026-07-29T10:03:00+00:00'
+        )
+        """,
+        (workflow_id, run_id, uuid_shaped_url),
+    )
+    conn.execute(
+        """
+        INSERT INTO discovery_search_unit_jobs (
+            tenant_id, discover_workflow_id, discover_run_id,
+            unit_id, job_url, was_new, accepted_at
+        ) VALUES (
+            'local', ?, ?, ?, ?, 0, '2026-07-29T10:04:00+00:00'
+        )
+        """,
+        (workflow_id, run_id, unit_id, uuid_shaped_url),
+    )
+    conn.commit()
+    before_counts = {
+        table: int(conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]) for table in REFERENCE_TABLES
+    }
+    close_connection(db_path)
+    shutil.copy2(db_path, pre_upgrade)
+
+    init_db(db_path)
+    close_connection(db_path)
+
+    assert _user_version(db_path) == SCHEMA_VERSION == 9
+    assert "job_id" in _columns(db_path, "discovery_execution_jobs")
+    assert "job_url" not in _columns(db_path, "discovery_execution_jobs")
+    assert "job_id" in _columns(db_path, "discovery_search_unit_jobs")
+    assert "job_url" not in _columns(db_path, "discovery_search_unit_jobs")
+
+    check = sqlite3.connect(db_path)
+    try:
+        after_counts = {
+            table: int(check.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]) for table in REFERENCE_TABLES
+        }
+        assert after_counts == before_counts
+        assert check.execute(
+            """
+            SELECT job_id, cohort_kind, source_family, source_run_id,
+                   preparation_workflow_id, work_plan_state,
+                   required_steps_json, work_plan_reason, linked_at
+            FROM discovery_execution_jobs
+            WHERE source_run_id = 'source-run-1'
+            """
+        ).fetchone() == (
+            job_id,
+            "observed_this_run",
+            "greenhouse",
+            "source-run-1",
+            "prepare-job-1",
+            "planned",
+            '["enrich","score"]',
+            "selected_for_preparation",
+            "2026-07-29T10:01:00+00:00",
+        )
+        assert check.execute(
+            """
+            SELECT job_id
+            FROM discovery_execution_jobs
+            WHERE source_run_id = 'source-run-uuid-url'
+            """
+        ).fetchone() == (str(uuid_url_owner_job_id),)
+        assert check.execute(
+            """
+            SELECT job_id, was_new, accepted_at
+            FROM discovery_search_unit_jobs
+            WHERE accepted_at = '2026-07-29T10:02:00+00:00'
+            """
+        ).fetchone() == (
+            job_id,
+            1,
+            "2026-07-29T10:02:00+00:00",
+        )
+        assert check.execute(
+            """
+            SELECT job_id
+            FROM discovery_search_unit_jobs
+            WHERE accepted_at = '2026-07-29T10:04:00+00:00'
+            """
+        ).fetchone() == (str(uuid_url_owner_job_id),)
+        assert check.execute("PRAGMA foreign_key_check").fetchone() is None
+    finally:
+        check.close()
+
+    init_db(db_path)
+    close_connection(db_path)
+    assert _user_version(db_path) == SCHEMA_VERSION
+
+    previous = sqlite3.connect(pre_upgrade)
+    try:
+        assert (
+            _assert_schema_version_supported(
+                previous,
+                supported_version=PREVIOUS_SCHEMA_VERSION,
+            )
+            == PREVIOUS_SCHEMA_VERSION
+        )
+        assert "job_url" in {
+            str(row[1]) for row in previous.execute("PRAGMA table_info(discovery_execution_jobs)").fetchall()
+        }
+        assert "job_url" in {
+            str(row[1]) for row in previous.execute("PRAGMA table_info(discovery_search_unit_jobs)").fetchall()
+        }
+    finally:
+        previous.close()
+
+
+def test_unresolved_v8_receipt_rolls_back_and_remains_retryable(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    conn = init_db(db_path)
+    job_id = str(uuid.uuid4())
+    job_url = "https://example.com/jobs/valid"
+    conn.execute(
+        """
+        INSERT INTO jobs (url, tenant_id, job_id, title)
+        VALUES (?, 'local', ?, 'Engineer')
+        """,
+        (job_url, job_id),
+    )
+    conn.commit()
+    _downgrade_execution_search_references_to_v8(conn)
+    _insert_search_unit(
+        conn,
+        workflow_id="discover-local",
+        run_id="temporal-run-1",
+        unit_id="unit-1",
+    )
+    conn.execute(
+        """
+        INSERT INTO discovery_search_unit_jobs (
+            tenant_id, discover_workflow_id, discover_run_id,
+            unit_id, job_url, was_new, accepted_at
+        ) VALUES (
+            'local', 'discover-local', 'temporal-run-1', 'unit-1',
+            'https://example.com/jobs/missing', 0,
+            '2026-07-29T10:02:00+00:00'
+        )
+        """
+    )
+    conn.commit()
+    close_connection(db_path)
+
+    with pytest.raises(
+        RuntimeError,
+        match="could not resolve discovery_search_unit_jobs.job_url",
+    ):
+        init_db(db_path)
+    close_connection(db_path)
+
+    assert _user_version(db_path) == PREVIOUS_SCHEMA_VERSION
+    assert "job_url" in _columns(db_path, "discovery_execution_jobs")
+    assert "job_url" in _columns(db_path, "discovery_search_unit_jobs")
+    check = sqlite3.connect(db_path)
+    try:
+        assert check.execute("SELECT COUNT(*) FROM discovery_search_unit_jobs").fetchone()[0] == 1
+        assert not check.execute(
+            """
+            SELECT 1
+            FROM sqlite_master
+            WHERE type = 'table' AND name LIKE '%_v9'
+            """
+        ).fetchall()
+        check.execute(
+            """
+            UPDATE discovery_search_unit_jobs
+            SET job_url = ?
+            WHERE unit_id = 'unit-1'
+            """,
+            (job_url,),
+        )
+        check.commit()
+    finally:
+        check.close()
+
+    init_db(db_path)
+    close_connection(db_path)
+    assert _user_version(db_path) == SCHEMA_VERSION
+    migrated = sqlite3.connect(db_path)
+    try:
+        assert migrated.execute(
+            """
+            SELECT job_id
+            FROM discovery_search_unit_jobs
+            WHERE unit_id = 'unit-1'
+            """
+        ).fetchone() == (job_id,)
+    finally:
+        migrated.close()
+
+
+def test_live_writes_prefer_uuid_shaped_posting_url_over_same_text_job_id(
+    tmp_path: Path,
+) -> None:
+    conn = init_db(tmp_path / "jobctrl.db")
+    uuid_shaped_url = str(uuid.uuid4())
+    url_owner_job_id = JobId(str(uuid.uuid4()))
+    repository = SqliteJobRepository(conn)
+    repository.save(_discovered_job(uuid_shaped_url, url_owner_job_id))
+    repository.save(
+        _discovered_job(
+            "https://example.com/jobs/id-text-collision",
+            JobId(uuid_shaped_url),
+        )
+    )
+    execution = DiscoveryExecutionRef(
+        tenant_id="local",
+        workflow_id="discover-local",
+        temporal_run_id="temporal-run-uuid-url",
+    )
+
+    execution_repository = SqliteDiscoveryExecutionRepository(conn)
+    execution_repository.link_job(
+        execution,
+        uuid_shaped_url,
+        cohort_kind="existing_backlog",
+        linked_at="2026-07-29T11:00:00+00:00",
+    )
+    assert conn.execute(
+        """
+        SELECT job_id
+        FROM discovery_execution_jobs
+        WHERE discover_run_id = ?
+        """,
+        (execution.temporal_run_id,),
+    ).fetchone()[0] == str(url_owner_job_id)
+    membership = execution_repository.get(execution, uuid_shaped_url)
+    assert membership is not None
+    assert membership.job_url == uuid_shaped_url
+
+    _insert_search_unit(
+        conn,
+        workflow_id=execution.workflow_id,
+        run_id=execution.temporal_run_id,
+        unit_id="search-0000-0123456789abcdef",
+    )
+    conn.execute(
+        """
+        UPDATE discovery_search_units
+        SET state = 'running',
+            lease_owner = 'attempt-1',
+            lease_attempt = 1,
+            lease_epoch = 1
+        WHERE discover_run_id = ?
+          AND unit_id = 'search-0000-0123456789abcdef'
+        """,
+        (execution.temporal_run_id,),
+    )
+    lease = DiscoverySearchUnitLease(
+        execution=execution,
+        unit_id="search-0000-0123456789abcdef",
+        owner_token="attempt-1",
+        attempt=1,
+        epoch=1,
+    )
+    SqliteDiscoverySearchUnitRepository(conn).record_accepted_job(
+        lease,
+        uuid_shaped_url,
+        was_new=True,
+        accepted_at="2026-07-29T11:01:00+00:00",
+    )
+    assert conn.execute(
+        """
+        SELECT job_id
+        FROM discovery_search_unit_jobs
+        WHERE discover_run_id = ?
+        """,
+        (execution.temporal_run_id,),
+    ).fetchone()[0] == str(url_owner_job_id)

--- a/workers/automation/tests/test_repeat_application_prevention.py
+++ b/workers/automation/tests/test_repeat_application_prevention.py
@@ -750,7 +750,7 @@ def test_schema_v5_migrates_additively_without_changing_application_facts(
         (PRIOR,),
     ).fetchall()
 
-    assert int(migrated.execute("PRAGMA user_version").fetchone()[0]) == SCHEMA_VERSION == 8
+    assert int(migrated.execute("PRAGMA user_version").fetchone()[0]) == SCHEMA_VERSION == 9
     assert [tuple(row) for row in after] == [tuple(row) for row in before]
     assert "metadata_json" in {
         str(row[1]) for row in migrated.execute("PRAGMA table_info(job_stage_states)").fetchall()

--- a/workers/automation/tests/test_stable_job_identity_migration.py
+++ b/workers/automation/tests/test_stable_job_identity_migration.py
@@ -95,6 +95,12 @@ def _create_representative_v6_pair(
             "2026-07-01T10:05:00+00:00",
         ),
     )
+    job_id = str(
+        conn.execute(
+            "SELECT job_id FROM jobs WHERE url = ?",
+            (job_url,),
+        ).fetchone()[0]
+    )
     database_module.ensure_source_observation_tables(conn)
     conn.execute(
         """
@@ -153,7 +159,7 @@ def _create_representative_v6_pair(
     conn.execute(
         """
         INSERT INTO discovery_execution_jobs (
-            tenant_id, discover_workflow_id, discover_run_id, job_url,
+            tenant_id, discover_workflow_id, discover_run_id, job_id,
             cohort_kind, source_family, preparation_workflow_id,
             work_plan_state, required_steps_json, linked_at
         ) VALUES (
@@ -162,7 +168,7 @@ def _create_representative_v6_pair(
             'planned', '["enrich","score"]', ?
         )
         """,
-        (job_url, "2026-07-01T10:01:00+00:00"),
+        (job_id, "2026-07-01T10:01:00+00:00"),
     )
     conn.execute(
         """
@@ -218,6 +224,81 @@ def _create_representative_v6_pair(
              AND j.job_id = o.job_id
             """
         ).fetchall()
+        execution_rows = raw.execute(
+            """
+            SELECT
+                execution.tenant_id,
+                execution.discover_workflow_id,
+                execution.discover_run_id,
+                jobs.url,
+                execution.cohort_kind,
+                execution.source_family,
+                execution.source_run_id,
+                execution.preparation_workflow_id,
+                execution.work_plan_state,
+                execution.required_steps_json,
+                execution.work_plan_reason,
+                execution.linked_at
+            FROM discovery_execution_jobs AS execution
+            JOIN jobs
+              ON jobs.tenant_id = execution.tenant_id
+             AND jobs.job_id = execution.job_id
+            """
+        ).fetchall()
+        raw.execute("DROP TABLE discovery_execution_jobs")
+        raw.execute("DROP TABLE discovery_search_unit_jobs")
+        raw.executescript(
+            """
+            CREATE TABLE discovery_execution_jobs (
+                tenant_id                TEXT NOT NULL,
+                discover_workflow_id     TEXT NOT NULL,
+                discover_run_id          TEXT NOT NULL,
+                job_url                  TEXT NOT NULL,
+                cohort_kind              TEXT NOT NULL,
+                source_family            TEXT,
+                source_run_id            TEXT,
+                preparation_workflow_id  TEXT,
+                work_plan_state          TEXT NOT NULL DEFAULT 'pending',
+                required_steps_json      TEXT,
+                work_plan_reason         TEXT,
+                linked_at                TEXT NOT NULL,
+                PRIMARY KEY (
+                    tenant_id, discover_workflow_id, discover_run_id, job_url
+                ),
+                FOREIGN KEY (job_url) REFERENCES jobs(url) ON DELETE CASCADE
+            );
+            CREATE TABLE discovery_search_unit_jobs (
+                tenant_id              TEXT NOT NULL,
+                discover_workflow_id   TEXT NOT NULL,
+                discover_run_id        TEXT NOT NULL,
+                unit_id                TEXT NOT NULL,
+                job_url                TEXT NOT NULL,
+                was_new                INTEGER NOT NULL,
+                accepted_at            TEXT NOT NULL,
+                PRIMARY KEY (
+                    tenant_id, discover_workflow_id, discover_run_id,
+                    unit_id, job_url
+                ),
+                FOREIGN KEY (
+                    tenant_id, discover_workflow_id, discover_run_id, unit_id
+                ) REFERENCES discovery_search_units(
+                    tenant_id, discover_workflow_id, discover_run_id, unit_id
+                ) ON DELETE CASCADE,
+                FOREIGN KEY (job_url) REFERENCES jobs(url) ON DELETE CASCADE
+            );
+            """
+        )
+        raw.executemany(
+            """
+            INSERT INTO discovery_execution_jobs (
+                tenant_id, discover_workflow_id, discover_run_id, job_url,
+                cohort_kind, source_family, source_run_id,
+                preparation_workflow_id, work_plan_state,
+                required_steps_json, work_plan_reason, linked_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            execution_rows,
+        )
         for table in (
             "job_rejected_duplicate_links",
             "job_duplicate_links",
@@ -320,14 +401,38 @@ def _reference_snapshot(db_path: Path) -> dict[str, list[tuple[object, ...]]]:
     conn = sqlite3.connect(db_path)
     try:
         snapshot = {
-            table: [
-                tuple(row)
-                for row in conn.execute(
-                    f'SELECT * FROM "{table}" ORDER BY rowid'
-                ).fetchall()
-            ]
+            table: [tuple(row) for row in conn.execute(f'SELECT * FROM "{table}" ORDER BY rowid').fetchall()]
             for table in REFERENCE_TABLES
         }
+        execution_columns = {
+            str(row[1]) for row in conn.execute("PRAGMA table_info(discovery_execution_jobs)").fetchall()
+        }
+        if "job_id" in execution_columns:
+            snapshot["discovery_execution_jobs"] = [
+                tuple(row)
+                for row in conn.execute(
+                    """
+                    SELECT
+                        execution.tenant_id,
+                        execution.discover_workflow_id,
+                        execution.discover_run_id,
+                        jobs.url,
+                        execution.cohort_kind,
+                        execution.source_family,
+                        execution.source_run_id,
+                        execution.preparation_workflow_id,
+                        execution.work_plan_state,
+                        execution.required_steps_json,
+                        execution.work_plan_reason,
+                        execution.linked_at
+                    FROM discovery_execution_jobs AS execution
+                    JOIN jobs
+                      ON jobs.tenant_id = execution.tenant_id
+                     AND jobs.job_id = execution.job_id
+                    ORDER BY execution.rowid
+                    """
+                ).fetchall()
+            ]
         snapshot["jobs"] = [
             tuple(row)
             for row in conn.execute(
@@ -368,7 +473,7 @@ def test_v6_jobs_gain_stable_uuid_and_posting_url_alias_once(
     init_db(db_path)
     close_connection(db_path)
 
-    assert _user_version(db_path) == SCHEMA_VERSION == 8
+    assert _user_version(db_path) == SCHEMA_VERSION == 9
     first_ids = _identity_rows(db_path)
     assert [row[0] for row in first_ids] == ["local", "local"]
     for _tenant_id, job_id, _url in first_ids:
@@ -624,6 +729,70 @@ def test_production_url_collision_cleans_aliases_and_allows_rediscovery(
         """,
         ((surviving_job_id,), (losing_job_id,)),
     )
+    conn.execute(
+        """
+        INSERT INTO discovery_search_units (
+            tenant_id, discover_workflow_id, discover_run_id, unit_id,
+            ordinal, request_json, request_fingerprint, state,
+            created_at, updated_at
+        ) VALUES (
+            'local', 'discover-local', 'discover-run', 'unit-1',
+            0, '{}', 'collision-fixture', 'completed',
+            '2026-07-29T09:00:00+00:00',
+            '2026-07-29T10:00:00+00:00'
+        )
+        """
+    )
+    conn.executemany(
+        """
+        INSERT INTO discovery_execution_jobs (
+            tenant_id, discover_workflow_id, discover_run_id, job_id,
+            cohort_kind, source_family, source_run_id,
+            preparation_workflow_id, work_plan_state,
+            required_steps_json, work_plan_reason, linked_at
+        ) VALUES (
+            'local', 'discover-local', 'discover-run', ?, ?, ?, ?, ?, ?, ?, ?, ?
+        )
+        """,
+        (
+            (
+                surviving_job_id,
+                "existing_backlog",
+                None,
+                None,
+                None,
+                "pending",
+                None,
+                None,
+                "2026-07-29T10:05:00+00:00",
+            ),
+            (
+                losing_job_id,
+                "observed_this_run",
+                "synthetic",
+                "source-run-relative",
+                "prepare-relative",
+                "planned",
+                '["score","tailor"]',
+                "selected_for_preparation",
+                "2026-07-29T10:00:00+00:00",
+            ),
+        ),
+    )
+    conn.executemany(
+        """
+        INSERT INTO discovery_search_unit_jobs (
+            tenant_id, discover_workflow_id, discover_run_id,
+            unit_id, job_id, was_new, accepted_at
+        ) VALUES (
+            'local', 'discover-local', 'discover-run', 'unit-1', ?, ?, ?
+        )
+        """,
+        (
+            (surviving_job_id, 0, "2026-07-29T10:04:00+00:00"),
+            (losing_job_id, 1, "2026-07-29T10:01:00+00:00"),
+        ),
+    )
     conn.commit()
     monkeypatch.setattr(
         detail,
@@ -670,6 +839,38 @@ def test_production_url_collision_cleans_aliases_and_allows_rediscovery(
             """
         ).fetchall()
     ] == [(surviving_job_id,)]
+    assert tuple(
+        conn.execute(
+            """
+            SELECT job_id, cohort_kind, source_family, source_run_id,
+                   preparation_workflow_id, work_plan_state,
+                   required_steps_json, work_plan_reason, linked_at
+            FROM discovery_execution_jobs
+            """
+        ).fetchone()
+    ) == (
+        surviving_job_id,
+        "observed_this_run",
+        "synthetic",
+        "source-run-relative",
+        "prepare-relative",
+        "planned",
+        '["score","tailor"]',
+        "selected_for_preparation",
+        "2026-07-29T10:00:00+00:00",
+    )
+    assert tuple(
+        conn.execute(
+            """
+            SELECT job_id, was_new, accepted_at
+            FROM discovery_search_unit_jobs
+            """
+        ).fetchone()
+    ) == (
+        surviving_job_id,
+        1,
+        "2026-07-29T10:01:00+00:00",
+    )
     assert conn.execute("PRAGMA foreign_key_check").fetchone() is None
     active_orphans = conn.execute(
         """

--- a/workers/automation/tests/test_worker_heartbeat_loop.py
+++ b/workers/automation/tests/test_worker_heartbeat_loop.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import sqlite3
+import uuid
 from datetime import UTC, datetime
 from types import SimpleNamespace
 
@@ -79,7 +80,13 @@ def _recovery_connection() -> sqlite3.Connection:
             tenant_id TEXT NOT NULL,
             discover_workflow_id TEXT NOT NULL,
             discover_run_id TEXT NOT NULL,
-            job_url TEXT NOT NULL
+            job_id TEXT NOT NULL
+        );
+        CREATE TABLE jobs (
+            url TEXT PRIMARY KEY,
+            tenant_id TEXT NOT NULL,
+            job_id TEXT NOT NULL,
+            UNIQUE (tenant_id, job_id)
         );
         CREATE TABLE pipeline_step_projections (
             tenant_id TEXT NOT NULL,
@@ -110,6 +117,30 @@ def _recovery_connection() -> sqlite3.Connection:
     return conn
 
 
+def _insert_membership(
+    conn: sqlite3.Connection,
+    workflow_id: str,
+    run_id: str,
+    job_url: str,
+) -> None:
+    job_id = str(uuid.uuid5(uuid.NAMESPACE_URL, job_url))
+    conn.execute(
+        """
+        INSERT OR IGNORE INTO jobs (url, tenant_id, job_id)
+        VALUES (?, 'local', ?)
+        """,
+        (job_url, job_id),
+    )
+    conn.execute(
+        """
+        INSERT INTO discovery_execution_jobs (
+            tenant_id, discover_workflow_id, discover_run_id, job_id
+        ) VALUES ('local', ?, ?, ?)
+        """,
+        (workflow_id, run_id, job_id),
+    )
+
+
 def test_recovery_candidates_keep_open_runs_and_only_latest_incomplete_terminal() -> None:
     conn = _recovery_connection()
     rows = (
@@ -129,14 +160,15 @@ def test_recovery_candidates_keep_open_runs_and_only_latest_incomplete_terminal(
     # even after partial durable recovery.
     for table in ("discovery_execution_jobs", "pipeline_step_projections"):
         if table == "discovery_execution_jobs":
-            conn.execute(
-                f"INSERT INTO {table} VALUES "
-                "('local', 'discover-open', 'run-open', 'job:open')"
+            _insert_membership(
+                conn,
+                "discover-open",
+                "run-open",
+                "job:open",
             )
         else:
             conn.execute(
-                f"INSERT INTO {table} VALUES "
-                "('local', 'discover-open', 'run-open', 'source_planning', 'plan')"
+                f"INSERT INTO {table} VALUES ('local', 'discover-open', 'run-open', 'source_planning', 'plan')"
             )
 
     assert cli._legacy_discovery_recovery_candidates(conn, tenant_id="local") == [
@@ -180,9 +212,11 @@ def test_recovery_candidates_skip_terminal_incomplete_checkpoint() -> None:
         """
     )
     digest = execution_reconciliation._recovery_key_digest({"job:partial"}, set())
-    conn.execute(
-        "INSERT INTO discovery_execution_jobs VALUES "
-        "('local', 'discover-incomplete', 'run-incomplete', 'job:partial')"
+    _insert_membership(
+        conn,
+        "discover-incomplete",
+        "run-incomplete",
+        "job:partial",
     )
     conn.execute(
         """
@@ -208,12 +242,11 @@ def test_recovery_candidates_repair_stale_ready_checkpoint() -> None:
                   '2026-07-16T09:00:00Z', 'run-stale')
         """
     )
-    conn.execute(
-        """
-        INSERT INTO discovery_execution_jobs VALUES (
-            'local', 'discover-stale', 'run-stale', 'job:new'
-        )
-        """
+    _insert_membership(
+        conn,
+        "discover-stale",
+        "run-stale",
+        "job:new",
     )
     stale_digest = execution_reconciliation._recovery_key_digest({"job:old"}, set())
     conn.execute(
@@ -241,9 +274,11 @@ def test_recovery_candidates_do_not_infer_readiness_from_projection_counts() -> 
                   '2026-07-16T09:00:00Z', 'run-partial')
         """
     )
-    conn.execute(
-        "INSERT INTO discovery_execution_jobs VALUES "
-        "('local', 'discover-partial', 'run-partial', 'job:partial')"
+    _insert_membership(
+        conn,
+        "discover-partial",
+        "run-partial",
+        "job:partial",
     )
     conn.execute(
         "INSERT INTO pipeline_step_projections VALUES "


### PR DESCRIPTION
## Summary

- migrate discovery execution memberships and accepted JobStreaming receipts from URL keys to stable `(tenant_id, job_id)` references in schema v9
- preserve URL-shaped Python/API compatibility reads, including bounded schema-v8 upgrade-window reads and permanent-purge support
- preserve and merge execution plans and search receipts during collision rehoming, with URL-first resolution for UUID-shaped posting URLs

## Validation

- `workers/automation/.venv/bin/python -m pytest -q` — 2661 passed, 2 skipped
- `corepack pnpm api:test` — 649 passed
- focused migration/repository suite — 105 passed
- API and web typechecks passed
- Ruff and `git diff --check` passed
- independent reviewer — Gate: PASS, 0 findings
- independent QA — Gate: PASS, 0 findings

## Stack

- Depends on #533
- Canonical docs and cumulative product QA are deferred to the final unreleased stack PR per repository policy.