### PR TITLE
feat(storage): migrate preparation identity references

### DIFF
--- a/apps/api/src/db.ts
+++ b/apps/api/src/db.ts
@@ -9,7 +9,7 @@ export type SqliteValue = string | number | bigint | null;
 // writer that stamps ``PRAGMA user_version``; the API only reads it to fail
 // closed on a database written by a newer build. Bump both constants together
 // whenever the schema shape changes.
-export const SUPPORTED_SCHEMA_VERSION = 9;
+export const SUPPORTED_SCHEMA_VERSION = 10;
 
 export class IncompatibleSchemaVersionError extends Error {
   constructor(current: number) {
@@ -68,6 +68,41 @@ export function tableExists(db: SqliteDatabase, tableName: string): boolean {
     .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?")
     .get(tableName) as { name?: string } | undefined;
   return row?.name === tableName;
+}
+
+export function hasCompositeJobIdForeignKey(
+  db: SqliteDatabase,
+  tableName: string,
+  referenceColumn = "job_id",
+): boolean {
+  if (!tableExists(db, tableName)) return false;
+  const rows = db
+    .prepare(`PRAGMA foreign_key_list(${quoteIdentifier(tableName)})`)
+    .all() as Array<{
+      id: number;
+      table: string;
+      from: string;
+      to: string;
+      on_delete: string;
+    }>;
+  const groups = new Map<number, Set<string>>();
+  const cascades = new Map<number, boolean>();
+  for (const row of rows) {
+    if (row.table !== "jobs") continue;
+    const columns = groups.get(row.id) ?? new Set<string>();
+    columns.add(`${row.from}:${row.to}`);
+    groups.set(row.id, columns);
+    cascades.set(row.id, row.on_delete.toUpperCase() === "CASCADE");
+  }
+  const expected = new Set([
+    "tenant_id:tenant_id",
+    `${referenceColumn}:job_id`,
+  ]);
+  return [...groups.entries()].some(([id, columns]) => (
+    cascades.get(id) === true
+    && columns.size === expected.size
+    && [...expected].every((column) => columns.has(column))
+  ));
 }
 
 const legacyProductTokens = ["job" + "ctl", "job" + "hunter"] as const;

--- a/apps/api/src/read-model.ts
+++ b/apps/api/src/read-model.ts
@@ -72,7 +72,14 @@ import {
 } from "./contracts.js";
 import { buildApplyAudit, type ApplyAuditLatestRun } from "./apply-audit.js";
 import { evaluateRepeatApplication } from "./repeat-application.js";
-import { allRows, getRow, tableExists, type SqliteDatabase, type SqliteValue } from "./db.js";
+import {
+  allRows,
+  getRow,
+  hasCompositeJobIdForeignKey,
+  tableExists,
+  type SqliteDatabase,
+  type SqliteValue,
+} from "./db.js";
 import { emptyPolitenessOutcomes, politenessOutcomesBySource } from "./source-politeness.js";
 import type { SourcePolitenessOutcomes } from "@jobctrl/contracts";
 import { normalizeJobLocation } from "./location-normalization.js";
@@ -1002,16 +1009,32 @@ function countPreparationWorkItems(
   if (!tableExists(db, "preparation_work_items")) return counts;
   const activeJobs = activeJobUrlSet(db);
   if (activeJobs.size === 0) return counts;
-  const rows = allRows<{ job_id: string; state: string }>(
+  const stableReferences = hasCompositeJobIdForeignKey(
     db,
-    `SELECT job_id, state
-       FROM preparation_work_items
-      WHERE tenant_id = ?
-        AND state IN ('queued', 'running', 'failed')`,
-    [tenantId],
+    "preparation_work_items",
   );
+  const rows = stableReferences
+    ? allRows<{ job_url: string; state: string }>(
+        db,
+        `SELECT jobs.url AS job_url, work.state
+           FROM preparation_work_items AS work
+           JOIN jobs
+             ON jobs.tenant_id = work.tenant_id
+            AND jobs.job_id = work.job_id
+          WHERE work.tenant_id = ?
+            AND work.state IN ('queued', 'running', 'failed')`,
+        [tenantId],
+      )
+    : allRows<{ job_url: string; state: string }>(
+        db,
+        `SELECT job_id AS job_url, state
+           FROM preparation_work_items
+          WHERE tenant_id = ?
+            AND state IN ('queued', 'running', 'failed')`,
+        [tenantId],
+      );
   for (const row of rows) {
-    if (!activeJobs.has(row.job_id)) continue;
+    if (!activeJobs.has(row.job_url)) continue;
     if (row.state === "queued" || row.state === "running" || row.state === "failed") {
       counts[row.state] += 1;
     }

--- a/apps/api/src/write-model.ts
+++ b/apps/api/src/write-model.ts
@@ -22,7 +22,14 @@ import {
   deserializeStageStateKind,
   type StageStateKind,
 } from "@jobctrl/domain-types";
-import { allRows, getRow, tableExists, type SqliteDatabase, type SqliteValue } from "./db.js";
+import {
+  allRows,
+  getRow,
+  hasCompositeJobIdForeignKey,
+  tableExists,
+  type SqliteDatabase,
+  type SqliteValue,
+} from "./db.js";
 import { matchingJobKeys, readSettingsConfig } from "./read-model.js";
 import { updateConfigObject } from "./config-file.js";
 
@@ -801,6 +808,7 @@ function purgeJobRows(db: SqliteDatabase, jobUrl: string): void {
   deleteWhere(db, "job_materials_artifacts", "job_url = ?", [jobUrl]);
   deleteWhere(db, "job_materials", "job_url = ?", [jobUrl]);
   deleteWhere(db, "job_enrichments", "job_url = ?", [jobUrl]);
+  deletePreparationJobReferences(db, jobId, jobUrl);
   if (jobId) {
     deleteWhere(db, "job_source_observations", "job_id = ?", [jobId]);
     deleteWhere(db, "job_canonical_identities", "job_id = ?", [jobId]);
@@ -835,6 +843,32 @@ function purgeJobRows(db: SqliteDatabase, jobUrl: string): void {
   ]);
   deleteWhere(db, "discovery_feedback", "job_key = ?", [jobUrl]);
   deleteWhere(db, "jobs", "url = ?", [jobUrl]);
+}
+
+function deletePreparationJobReferences(
+  db: SqliteDatabase,
+  jobId: string | undefined,
+  jobUrl: string,
+): void {
+  if (!tableExists(db, "preparation_work_items")) return;
+  if (
+    jobId
+    && hasCompositeJobIdForeignKey(db, "preparation_work_items")
+  ) {
+    deleteWhere(
+      db,
+      "preparation_work_items",
+      "tenant_id = 'local' AND job_id = ?",
+      [jobId],
+    );
+    return;
+  }
+  deleteWhere(
+    db,
+    "preparation_work_items",
+    "tenant_id = 'local' AND job_id = ?",
+    [jobUrl],
+  );
 }
 
 function deleteDiscoveryJobReferences(

--- a/apps/api/test/server.test.ts
+++ b/apps/api/test/server.test.ts
@@ -2746,8 +2746,27 @@ describe("local TypeScript API", () => {
     const blockedJobId = `test-job:${blockedUrl}`;
     const setup = new Database(options.dbPath);
     setup.exec(`
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_jobs_tenant_job_id_fixture
+        ON jobs(tenant_id, job_id);
       CREATE TABLE discovery_execution_jobs (job_id TEXT NOT NULL);
       CREATE TABLE discovery_search_unit_jobs (job_url TEXT NOT NULL);
+      CREATE TABLE preparation_work_items (
+        item_id TEXT NOT NULL PRIMARY KEY,
+        tenant_id TEXT NOT NULL DEFAULT 'local',
+        job_id TEXT NOT NULL,
+        kind TEXT NOT NULL,
+        target_version INTEGER NOT NULL,
+        source_event_id TEXT NOT NULL DEFAULT '',
+        state TEXT NOT NULL,
+        idempotency_key TEXT NOT NULL,
+        attempts INTEGER NOT NULL DEFAULT 0,
+        last_error TEXT NOT NULL DEFAULT '',
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL,
+        available_at TEXT NOT NULL,
+        FOREIGN KEY (tenant_id, job_id)
+          REFERENCES jobs(tenant_id, job_id) ON DELETE CASCADE
+      );
     `);
     setup
       .prepare("INSERT INTO discovery_execution_jobs (job_id) VALUES (?), (?)")
@@ -2755,6 +2774,20 @@ describe("local TypeScript API", () => {
     setup
       .prepare("INSERT INTO discovery_search_unit_jobs (job_url) VALUES (?), (?)")
       .run(readyUrl, blockedUrl);
+    const insertPreparationReference = setup.prepare(
+      `INSERT INTO preparation_work_items (
+         item_id, tenant_id, job_id, kind, target_version, source_event_id,
+         state, idempotency_key, attempts, last_error, created_at,
+         updated_at, available_at
+       ) VALUES (
+         ?, 'local', ?, 'score_job', 3, 'event-delete', 'completed', ?,
+         1, '', '2026-07-29T10:00:00+00:00',
+         '2026-07-29T10:01:00+00:00',
+         '2026-07-29T10:00:00+00:00'
+       )`,
+    );
+    insertPreparationReference.run("prep-ready", readyJobId, "prep-ready-key");
+    insertPreparationReference.run("prep-blocked", blockedJobId, "prep-blocked-key");
     setup.close();
     const app = buildApp(options);
 
@@ -2804,6 +2837,8 @@ describe("local TypeScript API", () => {
     expect(countRows(db, "discovery_execution_jobs", "job_id", blockedJobId)).toBe(0);
     expect(countRows(db, "discovery_search_unit_jobs", "job_url", readyUrl)).toBe(0);
     expect(countRows(db, "discovery_search_unit_jobs", "job_url", blockedUrl)).toBe(0);
+    expect(countRows(db, "preparation_work_items", "job_id", readyJobId)).toBe(0);
+    expect(countRows(db, "preparation_work_items", "job_id", blockedJobId)).toBe(0);
 
     insertJob(db, {
       url: readyUrl,
@@ -2830,6 +2865,61 @@ describe("local TypeScript API", () => {
     });
 
     await app.close();
+  });
+
+  it("permanently deletes schema-v9 URL-shaped preparation references during upgrade", async () => {
+    const jobUrl = "https://example.com/jobs/ready";
+    const setup = new Database(options.dbPath);
+    setup.exec(`
+      CREATE TABLE preparation_work_items (
+        item_id TEXT NOT NULL PRIMARY KEY,
+        tenant_id TEXT NOT NULL DEFAULT 'local',
+        job_id TEXT NOT NULL,
+        kind TEXT NOT NULL,
+        target_version INTEGER NOT NULL,
+        source_event_id TEXT NOT NULL DEFAULT '',
+        state TEXT NOT NULL,
+        idempotency_key TEXT NOT NULL,
+        attempts INTEGER NOT NULL DEFAULT 0,
+        last_error TEXT NOT NULL DEFAULT '',
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL,
+        available_at TEXT NOT NULL
+      );
+    `);
+    setup
+      .prepare(
+        `INSERT INTO preparation_work_items (
+           item_id, tenant_id, job_id, kind, target_version, source_event_id,
+           state, idempotency_key, attempts, last_error, created_at,
+           updated_at, available_at
+         ) VALUES (
+           'legacy-prep', 'local', ?, 'score_job', 3, 'event-legacy',
+           'completed', 'legacy-prep-key', 1, '',
+           '2026-07-29T10:00:00+00:00',
+           '2026-07-29T10:01:00+00:00',
+           '2026-07-29T10:00:00+00:00'
+         )`,
+      )
+      .run(jobUrl);
+    setup.close();
+
+    const app = buildApp(options);
+    const response = await app.inject({
+      method: "POST",
+      url: "/v1/jobs/bulk-delete-permanent",
+      payload: { allMatching: false, jobKeys: [jobUrl] },
+    });
+    expect(response.statusCode, response.body).toBe(200);
+    await app.close();
+
+    const verify = new Database(options.dbPath);
+    try {
+      expect(countRows(verify, "preparation_work_items", "job_id", jobUrl)).toBe(0);
+      expect(countRows(verify, "jobs", "url", jobUrl)).toBe(0);
+    } finally {
+      verify.close();
+    }
   });
 
   it("derives apply state from apply_run_projections when legacy jobs columns are NULL", async () => {
@@ -5103,6 +5193,74 @@ describe("local TypeScript API", () => {
         outdatedScoreCount: 1,
         outdatedTailoredArtifactCount: 1,
         workItems: { queued: 1, running: 1, failed: 1 },
+      });
+    } finally {
+      await app.close();
+    }
+  });
+
+  it("counts stable preparation JobId references against active job projections", async () => {
+    const seedDb = new Database(options.dbPath);
+    seedDb.exec(`
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_jobs_tenant_job_id_fixture
+        ON jobs(tenant_id, job_id);
+      CREATE TABLE preparation_work_items (
+        item_id TEXT NOT NULL PRIMARY KEY,
+        tenant_id TEXT NOT NULL DEFAULT 'local',
+        job_id TEXT NOT NULL,
+        kind TEXT NOT NULL,
+        target_version INTEGER NOT NULL,
+        source_event_id TEXT NOT NULL DEFAULT '',
+        state TEXT NOT NULL,
+        idempotency_key TEXT NOT NULL,
+        attempts INTEGER NOT NULL DEFAULT 0,
+        last_error TEXT NOT NULL DEFAULT '',
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL,
+        available_at TEXT NOT NULL,
+        FOREIGN KEY (tenant_id, job_id)
+          REFERENCES jobs(tenant_id, job_id) ON DELETE CASCADE
+      );
+    `);
+    const insert = seedDb.prepare(
+      `INSERT INTO preparation_work_items (
+         item_id, tenant_id, job_id, kind, target_version, source_event_id,
+         state, idempotency_key, attempts, last_error, created_at,
+         updated_at, available_at
+       )
+       SELECT ?, tenant_id, job_id, 'score_job', 3, 'event-stable',
+              ?, ?, 0, '', ?, ?, ?
+         FROM jobs
+        WHERE tenant_id = 'local' AND url = ?`,
+    );
+    for (const [itemId, state, jobUrl] of [
+      ["stable-queued", "queued", "https://example.com/jobs/ready"],
+      ["stable-running", "running", "https://example.com/jobs/failed-score"],
+      ["stable-failed", "failed", "https://example.com/jobs/blocked-tailor"],
+    ] as const) {
+      insert.run(
+        itemId,
+        state,
+        `${itemId}-key`,
+        "2026-07-29T10:00:00+00:00",
+        "2026-07-29T10:00:00+00:00",
+        "2026-07-29T10:00:00+00:00",
+        jobUrl,
+      );
+    }
+    seedDb.close();
+
+    const app = buildApp(options);
+    try {
+      const response = await app.inject({
+        method: "GET",
+        url: "/v1/dashboard/summary",
+      });
+      expect(response.statusCode, response.body).toBe(200);
+      expect(response.json().preparation.workItems).toEqual({
+        queued: 1,
+        running: 1,
+        failed: 1,
       });
     } finally {
       await app.close();

--- a/workers/automation/src/jobctrl/database.py
+++ b/workers/automation/src/jobctrl/database.py
@@ -43,7 +43,10 @@ from jobctrl.config import DB_PATH, DEFAULTS, migrate_legacy_job_tables
 # storing a posting URL as aggregate identity.
 # v9 (execution and search receipts): Discover execution membership and
 # accepted JobStreaming receipts reference the same stable identity.
-SCHEMA_VERSION = 9
+# v10 (preparation references): the legacy preparation work-item ledger
+# references ``(tenant_id, job_id)`` while preserving its opaque historical
+# idempotency keys for the later quiescent workflow cutover.
+SCHEMA_VERSION = 10
 
 
 class IncompatibleSchemaVersionError(RuntimeError):
@@ -183,6 +186,7 @@ def _schema_migrations() -> tuple[
         (7, ensure_stable_job_identity_v7),
         (8, ensure_discovery_identity_references_v8),
         (9, ensure_execution_search_references_v9),
+        (10, ensure_preparation_references_v10),
     )
 
 
@@ -2278,7 +2282,12 @@ def ensure_tailoring_policy_tables(conn: sqlite3.Connection | None = None) -> li
 
 
 def ensure_preparation_work_item_tables(conn: sqlite3.Connection | None = None) -> list[str]:
-    """Create Pipeline/Preparation durable work-item persistence tables."""
+    """Create the legacy Pipeline/Preparation work-item ledger.
+
+    New databases use stable JobId references immediately. Existing schema-v9
+    databases keep their URL-shaped ``job_id`` values until the versioned v10
+    migration resolves and verifies every row transactionally.
+    """
     if conn is None:
         conn = get_connection()
 
@@ -2297,7 +2306,9 @@ def ensure_preparation_work_item_tables(conn: sqlite3.Connection | None = None) 
             last_error       TEXT NOT NULL DEFAULT '',
             created_at       TEXT NOT NULL,
             updated_at       TEXT NOT NULL,
-            available_at     TEXT NOT NULL
+            available_at     TEXT NOT NULL,
+            FOREIGN KEY (tenant_id, job_id)
+                REFERENCES jobs(tenant_id, job_id) ON DELETE CASCADE
         )
         """
     )
@@ -4168,6 +4179,15 @@ def _reassign_discovery_identity_references(
             losing_job_id=losing_job_id,
             surviving_job_id=surviving_job_id,
         )
+    if _has_preparation_reference_schema_v10(conn):
+        conn.execute(
+            """
+            UPDATE preparation_work_items
+            SET job_id = ?
+            WHERE tenant_id = ? AND job_id = ?
+            """,
+            (surviving_job_id, tenant_id, losing_job_id),
+        )
 
 
 def _reassign_execution_memberships(
@@ -5136,6 +5156,251 @@ def _verify_execution_search_references_v9(
     foreign_key_error = conn.execute("PRAGMA foreign_key_check").fetchone()
     if foreign_key_error is not None:
         raise RuntimeError("execution/search reference migration found a foreign-key violation")
+
+
+_PREPARATION_REFERENCE_SCHEMA_VERSION = 10
+
+
+def ensure_preparation_references_v10(
+    conn: sqlite3.Connection | None = None,
+) -> list[str]:
+    """Move legacy preparation work-item references to stable JobIds.
+
+    The table's historical idempotency keys are opaque workflow-association
+    facts and remain byte-for-byte unchanged. The later quiescent workflow
+    cutover owns the transition to stable-ID-derived Temporal workflow keys.
+    """
+    if conn is None:
+        conn = get_connection()
+
+    current = _assert_schema_version_supported(conn)
+    if current >= _PREPARATION_REFERENCE_SCHEMA_VERSION:
+        return []
+    if current != _EXECUTION_SEARCH_REFERENCE_SCHEMA_VERSION:
+        raise RuntimeError(
+            "preparation reference migration requires execution/search schema v9"
+        )
+
+    conn.execute("SAVEPOINT preparation_references_v10")
+    try:
+        _verify_execution_search_references_v9(
+            conn,
+            expected_counts={
+                table: int(
+                    conn.execute(f'SELECT COUNT(*) FROM "{table}"').fetchone()[0]
+                )
+                for table in _EXECUTION_SEARCH_REFERENCE_TABLES
+            },
+        )
+        before_count = int(
+            conn.execute("SELECT COUNT(*) FROM preparation_work_items").fetchone()[0]
+        )
+
+        if not _has_preparation_reference_schema_v10(conn):
+            columns = _table_columns(conn, "preparation_work_items")
+            if "job_id" not in columns:
+                raise RuntimeError(
+                    "preparation reference migration found no job reference "
+                    "in preparation_work_items"
+                )
+            resolved_job_id = _resolved_job_id_sql(
+                "source",
+                "job_id",
+                legacy_url=True,
+            )
+            unresolved = conn.execute(
+                f"""
+                SELECT source.job_id
+                FROM preparation_work_items AS source
+                WHERE {resolved_job_id} IS NULL
+                LIMIT 1
+                """
+            ).fetchone()
+            if unresolved is not None:
+                raise RuntimeError(
+                    "preparation reference migration could not resolve "
+                    f"preparation_work_items.job_id={unresolved[0]!r}"
+                )
+
+            conn.execute("DROP TABLE IF EXISTS preparation_work_items_v10")
+            _create_preparation_work_items_v10(
+                conn,
+                table_name="preparation_work_items_v10",
+            )
+            conn.execute(
+                f"""
+                INSERT INTO preparation_work_items_v10 (
+                    item_id, tenant_id, job_id, kind, target_version,
+                    source_event_id, state, idempotency_key, attempts,
+                    last_error, created_at, updated_at, available_at
+                )
+                SELECT
+                    source.item_id,
+                    source.tenant_id,
+                    {resolved_job_id},
+                    source.kind,
+                    source.target_version,
+                    source.source_event_id,
+                    source.state,
+                    source.idempotency_key,
+                    source.attempts,
+                    source.last_error,
+                    source.created_at,
+                    source.updated_at,
+                    source.available_at
+                FROM preparation_work_items AS source
+                """
+            )
+            conn.execute("DROP TABLE preparation_work_items")
+            conn.execute(
+                "ALTER TABLE preparation_work_items_v10 "
+                "RENAME TO preparation_work_items"
+            )
+            _create_preparation_work_item_indexes(conn)
+
+        _verify_preparation_references_v10(
+            conn,
+            expected_count=before_count,
+        )
+        conn.execute(
+            f"PRAGMA user_version = {_PREPARATION_REFERENCE_SCHEMA_VERSION}"
+        )
+        conn.execute("RELEASE SAVEPOINT preparation_references_v10")
+        conn.commit()
+    except BaseException:
+        conn.execute("ROLLBACK TO SAVEPOINT preparation_references_v10")
+        conn.execute("RELEASE SAVEPOINT preparation_references_v10")
+        raise
+
+    return ["preparation_work_items"]
+
+
+def _create_preparation_work_items_v10(
+    conn: sqlite3.Connection,
+    *,
+    table_name: str = "preparation_work_items",
+) -> None:
+    conn.execute(
+        f"""
+        CREATE TABLE {table_name} (
+            item_id          TEXT NOT NULL PRIMARY KEY,
+            tenant_id        TEXT NOT NULL DEFAULT 'local',
+            job_id           TEXT NOT NULL,
+            kind             TEXT NOT NULL,
+            target_version   INTEGER NOT NULL,
+            source_event_id  TEXT NOT NULL DEFAULT '',
+            state            TEXT NOT NULL,
+            idempotency_key  TEXT NOT NULL,
+            attempts         INTEGER NOT NULL DEFAULT 0,
+            last_error       TEXT NOT NULL DEFAULT '',
+            created_at       TEXT NOT NULL,
+            updated_at       TEXT NOT NULL,
+            available_at     TEXT NOT NULL,
+            FOREIGN KEY (tenant_id, job_id)
+                REFERENCES jobs(tenant_id, job_id) ON DELETE CASCADE
+        )
+        """
+    )
+
+
+def _create_preparation_work_item_indexes(
+    conn: sqlite3.Connection,
+) -> None:
+    conn.execute(
+        """
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_preparation_work_items_idempotency
+        ON preparation_work_items(tenant_id, idempotency_key)
+        """
+    )
+    conn.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_preparation_work_items_claim
+        ON preparation_work_items(tenant_id, state, kind, available_at)
+        """
+    )
+    conn.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_preparation_work_items_job_target
+        ON preparation_work_items(tenant_id, job_id, kind, target_version)
+        """
+    )
+
+
+def _has_preparation_reference_schema_v10(
+    conn: sqlite3.Connection,
+) -> bool:
+    return (
+        "job_id" in _table_columns(conn, "preparation_work_items")
+        and _primary_key_columns(conn, "preparation_work_items") == ("item_id",)
+        and _has_composite_job_id_foreign_key(
+            conn,
+            "preparation_work_items",
+            "job_id",
+        )
+        and _has_index(
+            conn,
+            "preparation_work_items",
+            "idx_preparation_work_items_idempotency",
+            ("tenant_id", "idempotency_key"),
+            unique=True,
+        )
+        and _has_index(
+            conn,
+            "preparation_work_items",
+            "idx_preparation_work_items_claim",
+            ("tenant_id", "state", "kind", "available_at"),
+            unique=False,
+        )
+        and _has_index(
+            conn,
+            "preparation_work_items",
+            "idx_preparation_work_items_job_target",
+            ("tenant_id", "job_id", "kind", "target_version"),
+            unique=False,
+        )
+    )
+
+
+def _verify_preparation_references_v10(
+    conn: sqlite3.Connection,
+    *,
+    expected_count: int,
+) -> None:
+    if not _has_preparation_reference_schema_v10(conn):
+        raise RuntimeError(
+            "preparation reference migration did not create the stable "
+            "reference schema"
+        )
+    observed_count = int(
+        conn.execute("SELECT COUNT(*) FROM preparation_work_items").fetchone()[0]
+    )
+    if observed_count != expected_count:
+        raise RuntimeError(
+            "preparation reference migration changed row count for "
+            "preparation_work_items: "
+            f"expected {expected_count}, found {observed_count}"
+        )
+    orphan = conn.execute(
+        """
+        SELECT source.job_id
+        FROM preparation_work_items AS source
+        LEFT JOIN jobs j
+          ON j.tenant_id = source.tenant_id
+         AND j.job_id = source.job_id
+        WHERE j.job_id IS NULL
+        LIMIT 1
+        """
+    ).fetchone()
+    if orphan is not None:
+        raise RuntimeError(
+            "preparation reference migration left an unresolved reference "
+            "in preparation_work_items.job_id"
+        )
+    foreign_key_error = conn.execute("PRAGMA foreign_key_check").fetchone()
+    if foreign_key_error is not None:
+        raise RuntimeError(
+            "preparation reference migration found a foreign-key violation"
+        )
 
 # ---------------------------------------------------------------------------
 # job_enrichments read fragments — used by every selector / stat that

--- a/workers/automation/src/jobctrl/domain/ports/preparation.py
+++ b/workers/automation/src/jobctrl/domain/ports/preparation.py
@@ -26,7 +26,7 @@ class PreparationWorkItemRepository(Protocol):
         available_at: str | None = None,
         now: str | None = None,
     ) -> PreparationWorkItem:
-        """Create or return the existing idempotent queued work item."""
+        """Create or return one idempotent item for a stable job."""
         ...
 
 

--- a/workers/automation/src/jobctrl/infrastructure/preparation/sqlite_repository.py
+++ b/workers/automation/src/jobctrl/infrastructure/preparation/sqlite_repository.py
@@ -7,7 +7,8 @@ from datetime import datetime, timezone
 from typing import Any
 
 from jobctrl.database import ensure_preparation_work_item_tables
-from jobctrl.domain.identifiers import JobId
+from jobctrl.domain.discovery.value_objects import PostingUrl
+from jobctrl.domain.identifiers import JobId, canonical_job_id
 from jobctrl.domain.preparation import (
     PreparationWorkItem,
     PreparationWorkItemKind,
@@ -15,6 +16,9 @@ from jobctrl.domain.preparation import (
     make_preparation_idempotency_key,
 )
 from jobctrl.domain.tenant import TenantId
+from jobctrl.infrastructure.discovery.sqlite_identity_resolver import (
+    SqliteJobIdentityResolver,
+)
 
 
 class SqlitePreparationWorkItemRepository:
@@ -35,14 +39,74 @@ class SqlitePreparationWorkItemRepository:
         available_at: str | None = None,
         now: str | None = None,
     ) -> PreparationWorkItem:
+        resolved_job_id = self._resolve_job_id(
+            tenant_id=tenant_id,
+            job_id=job_id,
+        )
+        return self._enqueue_resolved(
+            tenant_id=tenant_id,
+            job_id=resolved_job_id,
+            kind=kind,
+            target_version=target_version,
+            source_event_id=source_event_id,
+            available_at=available_at,
+            now=now,
+        )
+
+    def enqueue_by_posting_url(
+        self,
+        *,
+        tenant_id: TenantId,
+        posting_url: PostingUrl,
+        kind: PreparationWorkItemKind,
+        target_version: int,
+        source_event_id: str = "",
+        available_at: str | None = None,
+        now: str | None = None,
+    ) -> PreparationWorkItem:
+        """Resolve the bounded legacy URL input before stable persistence."""
+        identity = SqliteJobIdentityResolver(self._conn).resolve_by_posting_url(tenant_id, posting_url)
+        if identity is None:
+            raise KeyError(f"No stable Job identity for preparation work item: {posting_url.value}")
+        return self._enqueue_resolved(
+            tenant_id=tenant_id,
+            job_id=identity.job_id,
+            kind=kind,
+            target_version=target_version,
+            source_event_id=source_event_id,
+            available_at=available_at,
+            now=now,
+        )
+
+    def _enqueue_resolved(
+        self,
+        *,
+        tenant_id: TenantId,
+        job_id: JobId,
+        kind: PreparationWorkItemKind,
+        target_version: int,
+        source_event_id: str,
+        available_at: str | None,
+        now: str | None,
+    ) -> PreparationWorkItem:
         created_at = now or _utc_now()
         available = available_at or created_at
+        normalized_source_event_id = str(source_event_id or "").strip()
+        existing = self._get_by_semantic_key(
+            tenant_id=tenant_id,
+            job_id=job_id,
+            kind=kind,
+            target_version=target_version,
+            source_event_id=normalized_source_event_id,
+        )
+        if existing is not None:
+            return existing
         item = PreparationWorkItem.queued(
             tenant_id=tenant_id,
             job_id=job_id,
             kind=kind,
             target_version=target_version,
-            source_event_id=source_event_id,
+            source_event_id=normalized_source_event_id,
             created_at=created_at,
             available_at=available,
             idempotency_key=make_preparation_idempotency_key(
@@ -50,7 +114,7 @@ class SqlitePreparationWorkItemRepository:
                 job_id=job_id,
                 kind=kind,
                 target_version=target_version,
-                source_event_id=source_event_id,
+                source_event_id=normalized_source_event_id,
             ),
         )
         self._conn.execute(
@@ -79,6 +143,40 @@ class SqlitePreparationWorkItemRepository:
         )
         self._conn.commit()
         return self._get_by_idempotency_key(tenant_id, item.idempotency_key)
+
+    def _get_by_semantic_key(
+        self,
+        *,
+        tenant_id: TenantId,
+        job_id: JobId,
+        kind: PreparationWorkItemKind,
+        target_version: int,
+        source_event_id: str,
+    ) -> PreparationWorkItem | None:
+        """Find migrated legacy work without rewriting its historical key."""
+        row = self._conn.execute(
+            """
+            SELECT item_id, tenant_id, job_id, kind, target_version,
+                   source_event_id, state, idempotency_key, attempts,
+                   last_error, created_at, updated_at, available_at
+            FROM preparation_work_items
+            WHERE tenant_id = ?
+              AND job_id = ?
+              AND kind = ?
+              AND target_version = ?
+              AND source_event_id = ?
+            ORDER BY created_at, item_id
+            LIMIT 1
+            """,
+            (
+                str(tenant_id),
+                str(job_id),
+                PreparationWorkItemKind(kind).value,
+                int(target_version),
+                source_event_id,
+            ),
+        ).fetchone()
+        return _row_to_item(row) if row is not None else None
 
     def _get_by_idempotency_key(
         self,
@@ -115,6 +213,34 @@ class SqlitePreparationWorkItemRepository:
             (str(tenant_id), item_id),
         ).fetchone()
         return _row_to_item(row) if row is not None else None
+
+    def _resolve_job_id(
+        self,
+        *,
+        tenant_id: TenantId,
+        job_id: JobId,
+    ) -> JobId:
+        resolver = SqliteJobIdentityResolver(self._conn)
+        raw_reference = str(job_id or "").strip()
+        if not raw_reference:
+            raise ValueError("job_id must be non-empty")
+        try:
+            stable_job_id = canonical_job_id(raw_reference)
+        except ValueError:
+            stable_job_id = None
+        identity = resolver.resolve_by_job_id(tenant_id, stable_job_id) if stable_job_id is not None else None
+        if identity is None:
+            # Compatibility for the historically URL-shaped JobId call site.
+            # UUID-shaped URLs use ``enqueue_by_posting_url`` so precedence is
+            # explicit rather than data-dependent.
+            identity = resolver.resolve_by_posting_url(
+                tenant_id,
+                PostingUrl(raw_reference),
+            )
+
+        if identity is None:
+            raise KeyError(f"No stable Job identity for preparation work item: {raw_reference}")
+        return identity.job_id
 
 
 def _row_to_item(row: Any) -> PreparationWorkItem:

--- a/workers/automation/tests/test_discovery_identity_reference_migration.py
+++ b/workers/automation/tests/test_discovery_identity_reference_migration.py
@@ -220,7 +220,7 @@ def test_v7_discovery_references_migrate_to_stable_job_id_and_reopen(
     init_db(db_path)
     close_connection(db_path)
 
-    assert _user_version(db_path) == SCHEMA_VERSION == 9
+    assert _user_version(db_path) == SCHEMA_VERSION == 10
     assert "job_id" in _columns(db_path, "job_source_observations")
     assert "job_url" not in _columns(db_path, "job_source_observations")
     assert "job_id" in _columns(db_path, "job_canonical_identities")

--- a/workers/automation/tests/test_execution_search_identity_reference_migration.py
+++ b/workers/automation/tests/test_execution_search_identity_reference_migration.py
@@ -261,7 +261,7 @@ def test_v8_execution_and_receipts_migrate_to_stable_job_id_and_reopen(
     init_db(db_path)
     close_connection(db_path)
 
-    assert _user_version(db_path) == SCHEMA_VERSION == 9
+    assert _user_version(db_path) == SCHEMA_VERSION == 10
     assert "job_id" in _columns(db_path, "discovery_execution_jobs")
     assert "job_url" not in _columns(db_path, "discovery_execution_jobs")
     assert "job_id" in _columns(db_path, "discovery_search_unit_jobs")

--- a/workers/automation/tests/test_preparation_identity_reference_migration.py
+++ b/workers/automation/tests/test_preparation_identity_reference_migration.py
@@ -1,0 +1,487 @@
+"""Schema-v10 preparation work-item identity migration contracts."""
+
+from __future__ import annotations
+
+import shutil
+import sqlite3
+import uuid
+from pathlib import Path
+
+import pytest
+
+import jobctrl.database as database_module
+from jobctrl.database import (
+    SCHEMA_VERSION,
+    _assert_schema_version_supported,
+    close_connection,
+    init_db,
+)
+from jobctrl.domain.discovery import (
+    Employer,
+    Job,
+    JobMetadata,
+    PostingUrl,
+    SearchStrategy,
+    Source,
+)
+from jobctrl.domain.identifiers import JobId
+from jobctrl.domain.preparation import PreparationWorkItemKind
+from jobctrl.domain.tenant import LOCAL_TENANT
+from jobctrl.infrastructure.discovery import SqliteJobRepository
+from jobctrl.infrastructure.preparation import (
+    SqlitePreparationWorkItemRepository,
+)
+
+
+PREVIOUS_SCHEMA_VERSION = 9
+
+
+def _downgrade_preparation_references_to_v9(
+    conn: sqlite3.Connection,
+) -> None:
+    conn.execute("DROP TABLE preparation_work_items")
+    conn.executescript(
+        """
+        CREATE TABLE preparation_work_items (
+            item_id          TEXT NOT NULL PRIMARY KEY,
+            tenant_id        TEXT NOT NULL DEFAULT 'local',
+            job_id           TEXT NOT NULL,
+            kind             TEXT NOT NULL,
+            target_version   INTEGER NOT NULL,
+            source_event_id  TEXT NOT NULL DEFAULT '',
+            state            TEXT NOT NULL,
+            idempotency_key  TEXT NOT NULL,
+            attempts         INTEGER NOT NULL DEFAULT 0,
+            last_error       TEXT NOT NULL DEFAULT '',
+            created_at       TEXT NOT NULL,
+            updated_at       TEXT NOT NULL,
+            available_at     TEXT NOT NULL
+        );
+        CREATE UNIQUE INDEX idx_preparation_work_items_idempotency
+            ON preparation_work_items(tenant_id, idempotency_key);
+        CREATE INDEX idx_preparation_work_items_claim
+            ON preparation_work_items(
+                tenant_id, state, kind, available_at
+            );
+        CREATE INDEX idx_preparation_work_items_job_target
+            ON preparation_work_items(
+                tenant_id, job_id, kind, target_version
+            );
+        """
+    )
+    conn.execute(f"PRAGMA user_version = {PREVIOUS_SCHEMA_VERSION}")
+    conn.commit()
+
+
+def _discovered_job(posting_url: str, job_id: JobId) -> Job:
+    return Job.discover(
+        tenant_id=LOCAL_TENANT,
+        job_id=job_id,
+        posting_url=PostingUrl(value=posting_url),
+        source=Source(board="example"),
+        employer=Employer(name="Example"),
+        search_strategy=SearchStrategy.JOBSPY,
+        metadata=JobMetadata(title="Platform Engineer"),
+        discovered_at="2026-07-29T10:00:00+00:00",
+    )
+
+
+def _user_version(db_path: Path) -> int:
+    conn = sqlite3.connect(db_path)
+    try:
+        return int(conn.execute("PRAGMA user_version").fetchone()[0])
+    finally:
+        conn.close()
+
+
+def _insert_legacy_work_item(
+    conn: sqlite3.Connection,
+    *,
+    item_id: str,
+    job_url: str,
+    state: str,
+    idempotency_key: str,
+    source_event_id: str,
+    created_at: str,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO preparation_work_items (
+            item_id, tenant_id, job_id, kind, target_version,
+            source_event_id, state, idempotency_key, attempts,
+            last_error, created_at, updated_at, available_at
+        ) VALUES (
+            ?, 'local', ?, 'score_job', 3, ?, ?, ?, 1,
+            'synthetic-error', ?, ?, ?
+        )
+        """,
+        (
+            item_id,
+            job_url,
+            source_event_id,
+            state,
+            idempotency_key,
+            created_at,
+            created_at,
+            created_at,
+        ),
+    )
+
+
+def test_v9_preparation_references_migrate_to_stable_job_ids_and_reopen(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    pre_upgrade = tmp_path / "jobctrl-v9.db"
+    conn = init_db(db_path)
+    repository = SqliteJobRepository(conn)
+
+    stable_job_id = JobId(str(uuid.uuid4()))
+    storage_url = "https://boards.example/jobs/123"
+    current_url = "https://careers.example/jobs/platform-engineer"
+    repository.save(_discovered_job(storage_url, stable_job_id))
+    repository.save(_discovered_job(current_url, stable_job_id))
+
+    uuid_shaped_url = str(uuid.uuid4())
+    uuid_url_owner_job_id = JobId(str(uuid.uuid4()))
+    repository.save(_discovered_job(uuid_shaped_url, uuid_url_owner_job_id))
+    repository.save(
+        _discovered_job(
+            "https://example.com/jobs/id-text-collision",
+            JobId(uuid_shaped_url),
+        )
+    )
+    _downgrade_preparation_references_to_v9(conn)
+    _insert_legacy_work_item(
+        conn,
+        item_id="prep-current-alias",
+        job_url=current_url,
+        state="queued",
+        idempotency_key="legacy-key-current-alias",
+        source_event_id="event-current",
+        created_at="2026-07-29T10:01:00+00:00",
+    )
+    _insert_legacy_work_item(
+        conn,
+        item_id="prep-uuid-url",
+        job_url=uuid_shaped_url,
+        state="failed",
+        idempotency_key="legacy-key-uuid-url",
+        source_event_id="event-uuid-url",
+        created_at="2026-07-29T10:02:00+00:00",
+    )
+    conn.commit()
+    close_connection(db_path)
+    shutil.copy2(db_path, pre_upgrade)
+
+    init_db(db_path)
+    close_connection(db_path)
+
+    assert _user_version(db_path) == SCHEMA_VERSION == 10
+    check = sqlite3.connect(db_path)
+    try:
+        rows = check.execute(
+            """
+            SELECT item_id, job_id, state, idempotency_key, attempts,
+                   last_error, source_event_id
+            FROM preparation_work_items
+            ORDER BY item_id
+            """
+        ).fetchall()
+        assert rows == [
+            (
+                "prep-current-alias",
+                str(stable_job_id),
+                "queued",
+                "legacy-key-current-alias",
+                1,
+                "synthetic-error",
+                "event-current",
+            ),
+            (
+                "prep-uuid-url",
+                str(uuid_url_owner_job_id),
+                "failed",
+                "legacy-key-uuid-url",
+                1,
+                "synthetic-error",
+                "event-uuid-url",
+            ),
+        ]
+        foreign_keys = check.execute("PRAGMA foreign_key_list(preparation_work_items)").fetchall()
+        job_reference = {
+            (str(row[3]), str(row[4]), str(row[6]).upper()) for row in foreign_keys if str(row[2]) == "jobs"
+        }
+        assert job_reference == {
+            ("tenant_id", "tenant_id", "CASCADE"),
+            ("job_id", "job_id", "CASCADE"),
+        }
+        assert check.execute("PRAGMA foreign_key_check").fetchone() is None
+    finally:
+        check.close()
+
+    init_db(db_path)
+    close_connection(db_path)
+    assert _user_version(db_path) == SCHEMA_VERSION
+
+    previous = sqlite3.connect(pre_upgrade)
+    try:
+        assert (
+            _assert_schema_version_supported(
+                previous,
+                supported_version=PREVIOUS_SCHEMA_VERSION,
+            )
+            == PREVIOUS_SCHEMA_VERSION
+        )
+        assert previous.execute(
+            """
+            SELECT job_id, idempotency_key
+            FROM preparation_work_items
+            ORDER BY item_id
+            """
+        ).fetchall() == [
+            (current_url, "legacy-key-current-alias"),
+            (uuid_shaped_url, "legacy-key-uuid-url"),
+        ]
+    finally:
+        previous.close()
+
+
+def test_unresolved_v9_preparation_reference_rolls_back_and_retries(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    conn = init_db(db_path)
+    job_id = str(uuid.uuid4())
+    job_url = "https://example.com/jobs/valid"
+    conn.execute(
+        """
+        INSERT INTO jobs (url, tenant_id, job_id, title)
+        VALUES (?, 'local', ?, 'Engineer')
+        """,
+        (job_url, job_id),
+    )
+    conn.commit()
+    _downgrade_preparation_references_to_v9(conn)
+    _insert_legacy_work_item(
+        conn,
+        item_id="prep-unresolved",
+        job_url="https://example.com/jobs/missing",
+        state="queued",
+        idempotency_key="legacy-key-unresolved",
+        source_event_id="event-unresolved",
+        created_at="2026-07-29T10:01:00+00:00",
+    )
+    conn.commit()
+    close_connection(db_path)
+
+    with pytest.raises(
+        RuntimeError,
+        match="could not resolve preparation_work_items.job_id",
+    ):
+        init_db(db_path)
+    close_connection(db_path)
+
+    assert _user_version(db_path) == PREVIOUS_SCHEMA_VERSION
+    check = sqlite3.connect(db_path)
+    try:
+        assert check.execute("SELECT job_id FROM preparation_work_items").fetchone() == (
+            "https://example.com/jobs/missing",
+        )
+        assert not check.execute(
+            """
+            SELECT 1
+            FROM sqlite_master
+            WHERE type = 'table' AND name = 'preparation_work_items_v10'
+            """
+        ).fetchall()
+        check.execute(
+            "UPDATE preparation_work_items SET job_id = ?",
+            (job_url,),
+        )
+        check.commit()
+    finally:
+        check.close()
+
+    init_db(db_path)
+    close_connection(db_path)
+    assert _user_version(db_path) == SCHEMA_VERSION
+    migrated = sqlite3.connect(db_path)
+    try:
+        assert migrated.execute("SELECT job_id FROM preparation_work_items").fetchone() == (job_id,)
+    finally:
+        migrated.close()
+
+
+def test_v10_verification_failure_rolls_back_rebuild_and_retries(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    conn = init_db(db_path)
+    job_id = str(uuid.uuid4())
+    job_url = "https://example.com/jobs/retry-after-verification"
+    conn.execute(
+        """
+        INSERT INTO jobs (url, tenant_id, job_id, title)
+        VALUES (?, 'local', ?, 'Engineer')
+        """,
+        (job_url, job_id),
+    )
+    conn.commit()
+    _downgrade_preparation_references_to_v9(conn)
+    _insert_legacy_work_item(
+        conn,
+        item_id="prep-verification-retry",
+        job_url=job_url,
+        state="completed",
+        idempotency_key="legacy-key-verification-retry",
+        source_event_id="event-verification-retry",
+        created_at="2026-07-29T10:01:00+00:00",
+    )
+    conn.commit()
+    close_connection(db_path)
+
+    original_verify = database_module._verify_preparation_references_v10
+
+    def fail_verification(
+        _conn: sqlite3.Connection,
+        *,
+        expected_count: int,
+    ) -> None:
+        del expected_count
+        raise RuntimeError("synthetic preparation verification failure")
+
+    monkeypatch.setattr(
+        database_module,
+        "_verify_preparation_references_v10",
+        fail_verification,
+    )
+    with pytest.raises(
+        RuntimeError,
+        match="synthetic preparation verification failure",
+    ):
+        init_db(db_path)
+    close_connection(db_path)
+
+    assert _user_version(db_path) == PREVIOUS_SCHEMA_VERSION
+    rolled_back = sqlite3.connect(db_path)
+    try:
+        assert rolled_back.execute("SELECT job_id, idempotency_key FROM preparation_work_items").fetchone() == (
+            job_url,
+            "legacy-key-verification-retry",
+        )
+        assert rolled_back.execute("PRAGMA foreign_key_list(preparation_work_items)").fetchall() == []
+        assert not rolled_back.execute(
+            """
+            SELECT 1
+            FROM sqlite_master
+            WHERE type = 'table' AND name = 'preparation_work_items_v10'
+            """
+        ).fetchall()
+    finally:
+        rolled_back.close()
+
+    monkeypatch.setattr(
+        database_module,
+        "_verify_preparation_references_v10",
+        original_verify,
+    )
+    init_db(db_path)
+    close_connection(db_path)
+    assert _user_version(db_path) == SCHEMA_VERSION
+    migrated = sqlite3.connect(db_path)
+    try:
+        assert migrated.execute("SELECT job_id, idempotency_key FROM preparation_work_items").fetchone() == (
+            job_id,
+            "legacy-key-verification-retry",
+        )
+    finally:
+        migrated.close()
+
+
+def test_repository_uses_stable_ids_and_explicit_url_compatibility(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    conn = init_db(db_path)
+    jobs = SqliteJobRepository(conn)
+    stable_job_id = JobId(str(uuid.uuid4()))
+    stable_job_url = "https://example.com/jobs/stable"
+    jobs.save(_discovered_job(stable_job_url, stable_job_id))
+
+    uuid_shaped_url = str(uuid.uuid4())
+    uuid_url_owner_job_id = JobId(str(uuid.uuid4()))
+    jobs.save(_discovered_job(uuid_shaped_url, uuid_url_owner_job_id))
+    jobs.save(
+        _discovered_job(
+            "https://example.com/jobs/id-text-collision",
+            JobId(uuid_shaped_url),
+        )
+    )
+    repository = SqlitePreparationWorkItemRepository(conn)
+
+    stable_item = repository.enqueue(
+        tenant_id=LOCAL_TENANT,
+        job_id=stable_job_id,
+        kind=PreparationWorkItemKind.SCORE_JOB,
+        target_version=3,
+        source_event_id="event-stable",
+        now="2026-07-29T11:00:00+00:00",
+    )
+    legacy_url_item = repository.enqueue(
+        tenant_id=LOCAL_TENANT,
+        job_id=JobId(stable_job_url),
+        kind=PreparationWorkItemKind.TAILOR_RESUME,
+        target_version=4,
+        source_event_id="event-url",
+        now="2026-07-29T11:01:00+00:00",
+    )
+    explicit_uuid_url_item = repository.enqueue_by_posting_url(
+        tenant_id=LOCAL_TENANT,
+        posting_url=PostingUrl(uuid_shaped_url),
+        kind=PreparationWorkItemKind.SCORE_JOB,
+        target_version=5,
+        source_event_id="event-uuid-url",
+        now="2026-07-29T11:02:00+00:00",
+    )
+
+    assert stable_item.job_id == stable_job_id
+    assert legacy_url_item.job_id == stable_job_id
+    assert explicit_uuid_url_item.job_id == uuid_url_owner_job_id
+    assert conn.execute(
+        """
+        SELECT job_id
+        FROM preparation_work_items
+        WHERE item_id = ?
+        """,
+        (explicit_uuid_url_item.item_id,),
+    ).fetchone()[0] == str(uuid_url_owner_job_id)
+
+    conn.execute(
+        """
+        INSERT INTO preparation_work_items (
+            item_id, tenant_id, job_id, kind, target_version,
+            source_event_id, state, idempotency_key, attempts,
+            last_error, created_at, updated_at, available_at
+        ) VALUES (
+            'migrated-item', 'local', ?, 'score_job', 8,
+            'event-migrated', 'completed', 'legacy-opaque-key', 1,
+            '', '2026-07-29T09:00:00+00:00',
+            '2026-07-29T09:05:00+00:00',
+            '2026-07-29T09:00:00+00:00'
+        )
+        """,
+        (str(stable_job_id),),
+    )
+    conn.commit()
+    replay = repository.enqueue(
+        tenant_id=LOCAL_TENANT,
+        job_id=stable_job_id,
+        kind=PreparationWorkItemKind.SCORE_JOB,
+        target_version=8,
+        source_event_id="event-migrated",
+        now="2026-07-29T12:00:00+00:00",
+    )
+    assert replay.item_id == "migrated-item"
+    assert replay.idempotency_key == "legacy-opaque-key"

--- a/workers/automation/tests/test_preparation_work_items.py
+++ b/workers/automation/tests/test_preparation_work_items.py
@@ -16,7 +16,16 @@ from jobctrl.infrastructure.preparation import SqlitePreparationWorkItemReposito
 
 @pytest.fixture()
 def conn(tmp_path: Path) -> sqlite3.Connection:
-    return init_db(tmp_path / "jobctrl.db")
+    connection = init_db(tmp_path / "jobctrl.db")
+    connection.executemany(
+        "INSERT INTO jobs (url, title) VALUES (?, 'Synthetic preparation job')",
+        (
+            ("https://example.com/job/1",),
+            ("https://example.com/job/2",),
+        ),
+    )
+    connection.commit()
+    return connection
 
 
 def test_enqueue_is_idempotent_for_work_item_key(conn: sqlite3.Connection) -> None:

--- a/workers/automation/tests/test_repeat_application_prevention.py
+++ b/workers/automation/tests/test_repeat_application_prevention.py
@@ -750,7 +750,7 @@ def test_schema_v5_migrates_additively_without_changing_application_facts(
         (PRIOR,),
     ).fetchall()
 
-    assert int(migrated.execute("PRAGMA user_version").fetchone()[0]) == SCHEMA_VERSION == 9
+    assert int(migrated.execute("PRAGMA user_version").fetchone()[0]) == SCHEMA_VERSION == 10
     assert [tuple(row) for row in after] == [tuple(row) for row in before]
     assert "metadata_json" in {
         str(row[1]) for row in migrated.execute("PRAGMA table_info(job_stage_states)").fetchall()

--- a/workers/automation/tests/test_stable_job_identity_migration.py
+++ b/workers/automation/tests/test_stable_job_identity_migration.py
@@ -473,7 +473,7 @@ def test_v6_jobs_gain_stable_uuid_and_posting_url_alias_once(
     init_db(db_path)
     close_connection(db_path)
 
-    assert _user_version(db_path) == SCHEMA_VERSION == 9
+    assert _user_version(db_path) == SCHEMA_VERSION == 10
     first_ids = _identity_rows(db_path)
     assert [row[0] for row in first_ids] == ["local", "local"]
     for _tenant_id, job_id, _url in first_ids:
@@ -793,6 +793,38 @@ def test_production_url_collision_cleans_aliases_and_allows_rediscovery(
             (losing_job_id, 1, "2026-07-29T10:01:00+00:00"),
         ),
     )
+    conn.executemany(
+        """
+        INSERT INTO preparation_work_items (
+            item_id, tenant_id, job_id, kind, target_version,
+            source_event_id, state, idempotency_key, attempts,
+            last_error, created_at, updated_at, available_at
+        ) VALUES (
+            ?, 'local', ?, 'score_job', 3, ?, 'completed', ?, 1,
+            '', ?, ?, ?
+        )
+        """,
+        (
+            (
+                "prep-surviving",
+                surviving_job_id,
+                "event-surviving",
+                "key-surviving",
+                "2026-07-29T09:00:00+00:00",
+                "2026-07-29T09:05:00+00:00",
+                "2026-07-29T09:00:00+00:00",
+            ),
+            (
+                "prep-losing",
+                losing_job_id,
+                "event-losing",
+                "key-losing",
+                "2026-07-29T09:01:00+00:00",
+                "2026-07-29T09:06:00+00:00",
+                "2026-07-29T09:01:00+00:00",
+            ),
+        ),
+    )
     conn.commit()
     monkeypatch.setattr(
         detail,
@@ -871,6 +903,19 @@ def test_production_url_collision_cleans_aliases_and_allows_rediscovery(
         1,
         "2026-07-29T10:01:00+00:00",
     )
+    assert [
+        tuple(row)
+        for row in conn.execute(
+            """
+            SELECT item_id, job_id, idempotency_key
+            FROM preparation_work_items
+            ORDER BY item_id
+            """
+        ).fetchall()
+    ] == [
+        ("prep-losing", surviving_job_id, "key-losing"),
+        ("prep-surviving", surviving_job_id, "key-surviving"),
+    ]
     assert conn.execute("PRAGMA foreign_key_check").fetchone() is None
     active_orphans = conn.execute(
         """


### PR DESCRIPTION
## Summary
- migrate legacy `preparation_work_items` references to stable `(tenant_id, job_id)` identity in schema v10
- preserve every historical work item and its opaque idempotency key while retaining schema-v9 API read/delete compatibility during rolling upgrades
- resolve explicit posting-URL compatibility inside the SQLite adapter and rehome preparation rows transactionally during URL-collision merges

## Why
Preparation work items were the next URL-shaped persistence boundary after execution/search references. Leaving them URL-authoritative would keep mutable posting locations embedded in durable orchestration state and would make stable job identity incomplete.

## User and developer impact
- preparation queues now follow stable job identity even when a posting URL changes
- old schema-v9 databases remain readable and deletable during the upgrade window
- legacy callers retain bounded URL compatibility without weakening the domain port
- Temporal workflow IDs, serialized inputs, events, and idempotency cutover remain deferred to the registry-derived quiescent Phase 4 cutover

## Validation
- `workers/automation/.venv/bin/python -m pytest -q` — 2664 passed, 2 skipped
- focused preparation migration/repository/collision checks — 37 passed, including the post-DDL rollback/retry fixture added after the full Python run
- `corepack pnpm api:test` — 651 passed
- focused API compatibility checks — 12 passed
- API and web TypeScript checks — passed
- focused Python Ruff and `git diff --check` — passed
- independent review — Gate PASS; Blocker 0, High 0, Medium 0, Low 0

## Stack
- depends on #534
- this is an intermediate unreleased stack layer; canonical documentation and cumulative product QA are intentionally deferred to the final PR