### PR TITLE
feat(storage): migrate enrichment identity references

### DIFF
--- a/apps/api/src/application-feedback.ts
+++ b/apps/api/src/application-feedback.ts
@@ -44,7 +44,14 @@ import {
   STAGE_STATES,
 } from "./contracts.js";
 import { buildApplyAudit } from "./apply-audit.js";
-import { allRows, getRow, tableExists, type SqliteDatabase, type SqliteValue } from "./db.js";
+import {
+  allRows,
+  getRow,
+  hasCompositeJobIdForeignKey,
+  tableExists,
+  type SqliteDatabase,
+  type SqliteValue,
+} from "./db.js";
 import { refreshProjections } from "./projections.js";
 import {
   ensureRepeatApplicationTables,
@@ -268,10 +275,23 @@ export function listApplyReviewQueue(db: SqliteDatabase): ApplyReviewQueueRespon
          WHERE h.job_url = jlp.job_id AND h.unhidden_at IS NULL
        )`
     : "";
+  const stableSnapshotReference = hasCompositeJobIdForeignKey(
+    db,
+    "posting_snapshot_sets",
+  );
   const closedWhere = tableExists(db, "posting_snapshot_sets")
     ? `AND NOT EXISTS (
          SELECT 1 FROM posting_snapshot_sets pss
-         WHERE pss.job_url = jlp.job_id
+         WHERE pss.tenant_id = jlp.tenant_id
+           AND pss.${stableSnapshotReference ? "job_id" : "job_url"} = ${
+             stableSnapshotReference
+               ? `(SELECT j.job_id
+                     FROM jobs j
+                    WHERE j.tenant_id = jlp.tenant_id
+                      AND j.url = jlp.job_id
+                    LIMIT 1)`
+               : "jlp.job_id"
+           }
            AND pss.latest_active_state IN (${CLOSED_ACTIVE_STATES.map(() => "?").join(", ")})
        )`
     : "";

--- a/apps/api/src/db.ts
+++ b/apps/api/src/db.ts
@@ -9,7 +9,7 @@ export type SqliteValue = string | number | bigint | null;
 // writer that stamps ``PRAGMA user_version``; the API only reads it to fail
 // closed on a database written by a newer build. Bump both constants together
 // whenever the schema shape changes.
-export const SUPPORTED_SCHEMA_VERSION = 10;
+export const SUPPORTED_SCHEMA_VERSION = 11;
 
 export class IncompatibleSchemaVersionError extends Error {
   constructor(current: number) {

--- a/apps/api/src/projections.ts
+++ b/apps/api/src/projections.ts
@@ -21,7 +21,14 @@
  * materialises it.
  */
 import { PROJECTION_WATERMARK_NAME, STAGES } from "./contracts.js";
-import { allRows, getRow, tableExists, type SqliteDatabase, type SqliteValue } from "./db.js";
+import {
+  allRows,
+  getRow,
+  hasCompositeJobIdForeignKey,
+  tableExists,
+  type SqliteDatabase,
+  type SqliteValue,
+} from "./db.js";
 import { normalizeJobLocation } from "./location-normalization.js";
 import { getMarketCompensationEstimate } from "./market-compensation-estimates.js";
 import { getPostedCompensationFact } from "./posted-compensation-facts.js";
@@ -2851,7 +2858,11 @@ interface EnrichmentLatest {
   currentStatus: string | null;
 }
 
-function loadEnrichment(db: SqliteDatabase, jobUrl: string): EnrichmentLatest {
+function loadEnrichment(
+  db: SqliteDatabase,
+  tenantId: string,
+  jobUrl: string,
+): EnrichmentLatest {
   const empty: EnrichmentLatest = {
     fullDescription: null,
     applicationUrl: null,
@@ -2861,6 +2872,10 @@ function loadEnrichment(db: SqliteDatabase, jobUrl: string): EnrichmentLatest {
   if (!tableExists(db, "job_enrichments")) {
     return empty;
   }
+  const stableReference = hasCompositeJobIdForeignKey(
+    db,
+    "job_enrichments",
+  );
   const row = getRow<{
     full_description: string | null;
     application_url: string | null;
@@ -2868,8 +2883,18 @@ function loadEnrichment(db: SqliteDatabase, jobUrl: string): EnrichmentLatest {
     current_status: string | null;
   }>(
     db,
-    "SELECT full_description, application_url, enriched_at, current_status FROM job_enrichments WHERE job_url = ?",
-    [jobUrl],
+    `SELECT je.full_description, je.application_url,
+            je.enriched_at, je.current_status
+       FROM job_enrichments je
+       ${stableReference
+         ? `JOIN jobs j
+              ON j.tenant_id = je.tenant_id
+             AND j.job_id = je.job_id`
+         : ""}
+      WHERE ${stableReference
+        ? "je.tenant_id = ? AND j.url = ?"
+        : "je.tenant_id = ? AND je.job_url = ?"}`,
+    [tenantId, jobUrl],
   );
   if (!row) return empty;
   return {
@@ -3146,7 +3171,7 @@ function rebuildJobProjections(db: SqliteDatabase, tenantId: string, jobUrl: str
   const requirementFitReportJson = loadRequirementFitReportJson(db, tenantId, jobUrl);
   const requirementFitBand = fitBand(loadLatestRequirementFitBand(db, tenantId, jobUrl));
   const interviewPrepJson = loadInterviewPrepJson(db, tenantId, jobUrl);
-  const enrichment = loadEnrichment(db, jobUrl);
+  const enrichment = loadEnrichment(db, tenantId, jobUrl);
   const apply = loadLatestApplyRun(db, jobUrl);
   const deletedAt = loadDeletedAt(db, jobUrl);
   const stages = loadStages(db, jobUrl);
@@ -4101,11 +4126,23 @@ function rebuildDashboardProjection(db: SqliteDatabase, tenantId: string): void 
          WHERE h.job_url = jlp.job_id AND h.unhidden_at IS NULL
        )`
     : "";
+  const stableSnapshotReference = hasCompositeJobIdForeignKey(
+    db,
+    "posting_snapshot_sets",
+  );
   const closedWhere = tableExists(db, "posting_snapshot_sets")
     ? `AND NOT EXISTS (
          SELECT 1 FROM posting_snapshot_sets pss
          WHERE pss.tenant_id = jlp.tenant_id
-           AND pss.job_url = jlp.job_id
+           AND pss.${stableSnapshotReference ? "job_id" : "job_url"} = ${
+             stableSnapshotReference
+               ? `(SELECT j.job_id
+                     FROM jobs j
+                    WHERE j.tenant_id = jlp.tenant_id
+                      AND j.url = jlp.job_id
+                    LIMIT 1)`
+               : "jlp.job_id"
+           }
            AND pss.latest_active_state IN (${CLOSED_ACTIVE_STATES.map((state) => `'${state}'`).join(", ")})
        )`
     : "";
@@ -4166,7 +4203,9 @@ function rebuildDashboardProjection(db: SqliteDatabase, tenantId: string): void 
         ? " LEFT JOIN jobctrl_hidden_jobs h ON h.job_url = arp.job_id AND h.unhidden_at IS NULL"
         : "";
       const snapshotJoin = hasSnapshots
-        ? " LEFT JOIN posting_snapshot_sets pss ON pss.tenant_id = arp.tenant_id AND pss.job_url = arp.job_id"
+        ? stableSnapshotReference
+          ? " LEFT JOIN jobs snapshot_job ON snapshot_job.tenant_id = arp.tenant_id AND snapshot_job.url = arp.job_id LEFT JOIN posting_snapshot_sets pss ON pss.tenant_id = arp.tenant_id AND pss.job_id = snapshot_job.job_id"
+          : " LEFT JOIN posting_snapshot_sets pss ON pss.tenant_id = arp.tenant_id AND pss.job_url = arp.job_id"
         : "";
       const lifecycleWhere = [
         hasDeleted ? "d.job_url IS NULL" : "",

--- a/apps/api/src/read-model.ts
+++ b/apps/api/src/read-model.ts
@@ -4710,12 +4710,19 @@ function closedActiveStatePredicate(
     return null;
   }
   const placeholders = CLOSED_ACTIVE_STATES.map(() => "?").join(", ");
+  const jobReference = hasCompositeJobIdForeignKey(db, "posting_snapshot_sets")
+    ? `(SELECT j.job_id
+          FROM jobs j
+         WHERE j.tenant_id = ${tenantColumn}
+           AND j.url = ${jobColumn}
+         LIMIT 1)`
+    : jobColumn;
   return {
     sql: `EXISTS (
       SELECT 1
       FROM posting_snapshot_sets pss
       WHERE pss.tenant_id = ${tenantColumn}
-        AND pss.job_url = ${jobColumn}
+        AND pss.${hasCompositeJobIdForeignKey(db, "posting_snapshot_sets") ? "job_id" : "job_url"} = ${jobReference}
         AND pss.latest_active_state IN (${placeholders})
     )`,
     params: [...CLOSED_ACTIVE_STATES],
@@ -4763,11 +4770,23 @@ function jobProjectionSelect(db: SqliteDatabase): string {
        NULL AS score_stale_old_policy_version,
        NULL AS score_stale_new_policy_version,
        NULL AS score_stale_marked_at`;
+  const stableSnapshotReference = hasCompositeJobIdForeignKey(
+    db,
+    "posting_snapshot_sets",
+  );
   const activeStateSelect = tableExists(db, "posting_snapshot_sets")
     ? `(SELECT pss.latest_active_state
           FROM posting_snapshot_sets pss
          WHERE pss.tenant_id = job_list_projections.tenant_id
-           AND pss.job_url = job_list_projections.job_id
+           AND pss.${stableSnapshotReference ? "job_id" : "job_url"} = ${
+             stableSnapshotReference
+               ? `(SELECT j.job_id
+                     FROM jobs j
+                    WHERE j.tenant_id = job_list_projections.tenant_id
+                      AND j.url = job_list_projections.job_id
+                    LIMIT 1)`
+               : "job_list_projections.job_id"
+           }
          LIMIT 1) AS active_state`
     : "'unknown' AS active_state";
   return `job_list_projections.*,

--- a/apps/api/src/repeat-application.ts
+++ b/apps/api/src/repeat-application.ts
@@ -11,7 +11,13 @@ import type {
   RepeatApplicationOverrideResponse,
   RepeatApplicationRelationship,
 } from "./contracts.js";
-import { allRows, getRow, tableExists, type SqliteDatabase } from "./db.js";
+import {
+  allRows,
+  getRow,
+  hasCompositeJobIdForeignKey,
+  tableExists,
+  type SqliteDatabase,
+} from "./db.js";
 import { InputError } from "./write-model.js";
 
 const DEFAULT_TENANT = "local";
@@ -295,7 +301,8 @@ function jobIdentity(db: SqliteDatabase, jobKey: string): JobIdentityRow | null 
   const enrichmentExpression = tableExists(db, "job_enrichments")
     ? `(SELECT je.application_url
           FROM job_enrichments je
-         WHERE je.job_url = j.url AND je.tenant_id = ?
+         WHERE je.${hasCompositeJobIdForeignKey(db, "job_enrichments") ? "job_id = j.job_id" : "job_url = j.url"}
+           AND je.tenant_id = ?
          ORDER BY je.updated_at DESC LIMIT 1),`
     : "";
   const params = [

--- a/apps/api/src/write-model.ts
+++ b/apps/api/src/write-model.ts
@@ -740,6 +740,7 @@ function resetEnrichmentAggregate(db: SqliteDatabase, jobUrl: string): void {
     return;
   }
   const now = new Date().toISOString();
+  const stableReference = hasCompositeJobIdForeignKey(db, "job_enrichments");
   db.prepare(
     `UPDATE job_enrichments
        SET current_status = 'pending',
@@ -748,7 +749,9 @@ function resetEnrichmentAggregate(db: SqliteDatabase, jobUrl: string): void {
            enriched_at = NULL,
            extraction_tier = NULL,
            updated_at = ?
-     WHERE job_url = ?`,
+     WHERE ${stableReference
+       ? "tenant_id = 'local' AND job_id = (SELECT job_id FROM jobs WHERE tenant_id = 'local' AND url = ? LIMIT 1)"
+       : "job_url = ?"}`,
   ).run(now, jobUrl);
 }
 
@@ -807,7 +810,7 @@ function purgeJobRows(db: SqliteDatabase, jobUrl: string): void {
   deleteWhere(db, "job_score_staleness", "job_url = ?", [jobUrl]);
   deleteWhere(db, "job_materials_artifacts", "job_url = ?", [jobUrl]);
   deleteWhere(db, "job_materials", "job_url = ?", [jobUrl]);
-  deleteWhere(db, "job_enrichments", "job_url = ?", [jobUrl]);
+  deleteEnrichmentJobReferences(db, jobId, jobUrl);
   deletePreparationJobReferences(db, jobId, jobUrl);
   if (jobId) {
     deleteWhere(db, "job_source_observations", "job_id = ?", [jobId]);
@@ -843,6 +846,31 @@ function purgeJobRows(db: SqliteDatabase, jobUrl: string): void {
   ]);
   deleteWhere(db, "discovery_feedback", "job_key = ?", [jobUrl]);
   deleteWhere(db, "jobs", "url = ?", [jobUrl]);
+}
+
+function deleteEnrichmentJobReferences(
+  db: SqliteDatabase,
+  jobId: string | undefined,
+  jobUrl: string,
+): void {
+  for (const tableName of ["job_enrichments", "posting_snapshot_sets"] as const) {
+    if (!tableExists(db, tableName)) continue;
+    if (jobId && hasCompositeJobIdForeignKey(db, tableName)) {
+      deleteWhere(
+        db,
+        tableName,
+        "tenant_id = 'local' AND job_id = ?",
+        [jobId],
+      );
+      continue;
+    }
+    deleteWhere(
+      db,
+      tableName,
+      `tenant_id = 'local' AND job_url = ?`,
+      [jobUrl],
+    );
+  }
 }
 
 function deletePreparationJobReferences(

--- a/apps/api/test/application-feedback.test.ts
+++ b/apps/api/test/application-feedback.test.ts
@@ -207,6 +207,59 @@ describe("application feedback API", () => {
     await app.close();
   });
 
+  it("excludes closed jobs through stable snapshot JobId references", async () => {
+    const db = new Database(options.dbPath);
+    db.exec(`
+      ALTER TABLE jobs ADD COLUMN tenant_id TEXT NOT NULL DEFAULT 'local';
+      ALTER TABLE jobs ADD COLUMN job_id TEXT;
+      UPDATE jobs SET job_id = 'stable:' || url;
+      CREATE UNIQUE INDEX idx_jobs_tenant_job_id_fixture
+        ON jobs(tenant_id, job_id);
+      CREATE TABLE posting_snapshot_sets (
+        tenant_id TEXT NOT NULL DEFAULT 'local',
+        job_id TEXT NOT NULL,
+        snapshot_set_json TEXT NOT NULL,
+        latest_snapshot_version INTEGER NOT NULL DEFAULT 0,
+        latest_active_state TEXT NOT NULL DEFAULT 'unknown',
+        updated_at TEXT NOT NULL,
+        PRIMARY KEY (tenant_id, job_id),
+        FOREIGN KEY (tenant_id, job_id)
+          REFERENCES jobs(tenant_id, job_id) ON DELETE CASCADE
+      );
+    `);
+    db.prepare(
+      `INSERT INTO posting_snapshot_sets (
+        tenant_id, job_id, snapshot_set_json, latest_snapshot_version,
+        latest_active_state, updated_at
+      ) VALUES ('local', ?, ?, 0, 'removed', ?)`,
+    ).run(
+      `stable:${READY_JOB}`,
+      JSON.stringify({
+        tenant_id: "local",
+        job_id: `stable:${READY_JOB}`,
+        snapshots: [],
+        failures: [],
+        duplicate_candidates: [],
+        latest_active_state: "removed",
+      }),
+      NOW,
+    );
+    db.close();
+
+    const app = buildApp(options);
+    const response = await app.inject({
+      method: "GET",
+      url: "/v1/apply/review-queue",
+    });
+
+    expect(response.statusCode, response.body).toBe(200);
+    expect(
+      response.json().items.map((item: { jobKey: string }) => item.jobKey),
+    ).toEqual([DRY_RUN_JOB]);
+
+    await app.close();
+  });
+
   it("keeps jobs in review queue while existing materials are being refreshed", async () => {
     const db = new Database(options.dbPath);
     db.prepare(

--- a/apps/api/test/repeat-application.test.ts
+++ b/apps/api/test/repeat-application.test.ts
@@ -221,6 +221,42 @@ describe("repeat application evidence", () => {
     expect(assessment.matches[0]?.identityEvidence).toContain("employer:acme");
   });
 
+  it("loads application evidence through stable enrichment JobId references", () => {
+    insertJob(PRIOR, "Senior Backend Engineer", "Acme Inc");
+    insertJob(TARGET, "Backend Senior Eng", "Acme Inc");
+    confirmPrior();
+    db.exec(`
+      DROP TABLE job_enrichments;
+      CREATE UNIQUE INDEX idx_jobs_tenant_job_id_fixture
+        ON jobs(tenant_id, job_id);
+      CREATE TABLE job_enrichments (
+        tenant_id TEXT NOT NULL DEFAULT 'local',
+        job_id TEXT NOT NULL,
+        application_url TEXT,
+        updated_at TEXT NOT NULL,
+        PRIMARY KEY (tenant_id, job_id),
+        FOREIGN KEY (tenant_id, job_id)
+          REFERENCES jobs(tenant_id, job_id) ON DELETE CASCADE
+      );
+    `);
+    db.prepare(
+      `INSERT INTO job_enrichments (
+        tenant_id, job_id, application_url, updated_at
+      ) VALUES ('local', ?, ?, ?)`,
+    ).run(
+      testJobId(PRIOR),
+      "https://apply.example.test/canonical-prior",
+      NOW,
+    );
+
+    const assessment = evaluateRepeatApplication(db, TARGET);
+
+    expect(assessment.status).toBe("confirmation_required");
+    expect(assessment.matches[0]?.priorApplication.applicationUrl).toBe(
+      "https://apply.example.test/canonical-prior",
+    );
+  });
+
   it.each([
     ["Engineering Manager", "Acme Inc", "distinct role"],
     ["Senior Backend Engineer", "Acme Health", "similar employer"],

--- a/apps/api/test/server.test.ts
+++ b/apps/api/test/server.test.ts
@@ -2739,6 +2739,240 @@ describe("local TypeScript API", () => {
     await app.close();
   });
 
+  it("separates closed postings through stable snapshot JobId references", async () => {
+    const jobUrl = "https://example.com/jobs/failed-score";
+    const jobId = `test-job:${jobUrl}`;
+    const db = new Database(options.dbPath);
+    db.exec(`
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_jobs_tenant_job_id_fixture
+        ON jobs(tenant_id, job_id);
+      CREATE TABLE posting_snapshot_sets (
+        tenant_id TEXT NOT NULL DEFAULT 'local',
+        job_id TEXT NOT NULL,
+        snapshot_set_json TEXT NOT NULL,
+        latest_snapshot_version INTEGER NOT NULL DEFAULT 0,
+        latest_active_state TEXT NOT NULL DEFAULT 'unknown',
+        updated_at TEXT NOT NULL,
+        PRIMARY KEY (tenant_id, job_id),
+        FOREIGN KEY (tenant_id, job_id)
+          REFERENCES jobs(tenant_id, job_id) ON DELETE CASCADE
+      );
+    `);
+    db.prepare(
+      `INSERT INTO posting_snapshot_sets (
+        tenant_id, job_id, snapshot_set_json, latest_snapshot_version,
+        latest_active_state, updated_at
+      ) VALUES (?, ?, ?, ?, ?, ?)`,
+    ).run(
+      "local",
+      jobId,
+      JSON.stringify({
+        tenant_id: "local",
+        job_id: jobId,
+        latest_active_state: "removed",
+      }),
+      0,
+      "removed",
+      "2026-07-29T10:00:00+00:00",
+    );
+    db.close();
+
+    const app = buildApp(options);
+    const active = await app.inject({
+      method: "GET",
+      url: "/v1/jobs?deleted=active&sort=title&dir=asc",
+    });
+    const closed = await app.inject({
+      method: "GET",
+      url: "/v1/jobs?deleted=closed",
+    });
+    const summary = await app.inject({
+      method: "GET",
+      url: "/v1/dashboard/summary",
+    });
+
+    expect(active.statusCode, active.body).toBe(200);
+    expect(
+      active.json().items.map((job: { jobKey: string }) => job.jobKey),
+    ).not.toContain(jobUrl);
+    expect(closed.statusCode, closed.body).toBe(200);
+    expect(closed.json().items).toEqual([
+      expect.objectContaining({
+        jobKey: jobUrl,
+        activeState: "removed",
+      }),
+    ]);
+    expect(summary.statusCode, summary.body).toBe(200);
+    expect(summary.json().totals).toMatchObject({
+      jobs: 2,
+      failures: 0,
+      blocked: 1,
+      ready: 1,
+    });
+
+    await app.close();
+  });
+
+  it("permanently deletes stable enrichment and snapshot references", async () => {
+    const jobUrl = "https://example.com/jobs/ready";
+    const jobId = `test-job:${jobUrl}`;
+    const setup = new Database(options.dbPath);
+    setup.exec(`
+      DROP TABLE job_enrichments;
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_jobs_tenant_job_id_fixture
+        ON jobs(tenant_id, job_id);
+      CREATE TABLE job_enrichments (
+        tenant_id TEXT NOT NULL DEFAULT 'local',
+        job_id TEXT NOT NULL,
+        current_status TEXT NOT NULL,
+        full_description TEXT,
+        application_url TEXT,
+        enriched_at TEXT,
+        extraction_tier TEXT,
+        attempts_json TEXT NOT NULL DEFAULT '[]',
+        updated_at TEXT NOT NULL,
+        PRIMARY KEY (tenant_id, job_id),
+        FOREIGN KEY (tenant_id, job_id)
+          REFERENCES jobs(tenant_id, job_id) ON DELETE CASCADE
+      );
+      CREATE TABLE posting_snapshot_sets (
+        tenant_id TEXT NOT NULL DEFAULT 'local',
+        job_id TEXT NOT NULL,
+        snapshot_set_json TEXT NOT NULL,
+        latest_snapshot_version INTEGER NOT NULL DEFAULT 0,
+        latest_active_state TEXT NOT NULL DEFAULT 'unknown',
+        updated_at TEXT NOT NULL,
+        PRIMARY KEY (tenant_id, job_id),
+        FOREIGN KEY (tenant_id, job_id)
+          REFERENCES jobs(tenant_id, job_id) ON DELETE CASCADE
+      );
+    `);
+    setup
+      .prepare(
+        `INSERT INTO job_enrichments (
+          tenant_id, job_id, current_status, full_description,
+          application_url, enriched_at, extraction_tier,
+          attempts_json, updated_at
+        ) VALUES ('local', ?, 'enriched', 'description', ?, ?, 'json_ld', '[]', ?)`,
+      )
+      .run(
+        jobId,
+        `${jobUrl}/apply`,
+        "2026-07-29T10:00:00+00:00",
+        "2026-07-29T10:00:00+00:00",
+      );
+    setup
+      .prepare(
+        `INSERT INTO posting_snapshot_sets (
+          tenant_id, job_id, snapshot_set_json, latest_snapshot_version,
+          latest_active_state, updated_at
+        ) VALUES ('local', ?, ?, 0, 'active', ?)`,
+      )
+      .run(
+        jobId,
+        JSON.stringify({
+          tenant_id: "local",
+          job_id: jobId,
+          snapshots: [],
+          failures: [],
+          duplicate_candidates: [],
+          latest_active_state: "active",
+        }),
+        "2026-07-29T10:00:00+00:00",
+      );
+    setup.close();
+
+    const app = buildApp(options);
+    const response = await app.inject({
+      method: "POST",
+      url: "/v1/jobs/bulk-delete-permanent",
+      payload: { allMatching: false, jobKeys: [jobUrl] },
+    });
+    expect(response.statusCode, response.body).toBe(200);
+    await app.close();
+
+    const verify = new Database(options.dbPath);
+    try {
+      expect(countRows(verify, "job_enrichments", "job_id", jobId)).toBe(0);
+      expect(countRows(verify, "posting_snapshot_sets", "job_id", jobId)).toBe(
+        0,
+      );
+      expect(countRows(verify, "jobs", "url", jobUrl)).toBe(0);
+    } finally {
+      verify.close();
+    }
+  });
+
+  it("permanently deletes schema-v10 URL enrichment and snapshot references", async () => {
+    const jobUrl = "https://example.com/jobs/ready";
+    const setup = new Database(options.dbPath);
+    setup.exec(`
+      CREATE TABLE posting_snapshot_sets (
+        tenant_id TEXT NOT NULL DEFAULT 'local',
+        job_url TEXT NOT NULL,
+        snapshot_set_json TEXT NOT NULL,
+        latest_snapshot_version INTEGER NOT NULL DEFAULT 0,
+        latest_active_state TEXT NOT NULL DEFAULT 'unknown',
+        updated_at TEXT NOT NULL,
+        PRIMARY KEY (tenant_id, job_url)
+      );
+    `);
+    setup
+      .prepare(
+        `INSERT INTO job_enrichments (
+          job_url, tenant_id, current_status, full_description,
+          application_url, enriched_at, extraction_tier,
+          attempts_json, updated_at
+        ) VALUES (?, 'local', 'enriched', 'description', ?, ?, 'json_ld', '[]', ?)`,
+      )
+      .run(
+        jobUrl,
+        `${jobUrl}/apply`,
+        "2026-07-29T10:00:00+00:00",
+        "2026-07-29T10:00:00+00:00",
+      );
+    setup
+      .prepare(
+        `INSERT INTO posting_snapshot_sets (
+          tenant_id, job_url, snapshot_set_json, latest_snapshot_version,
+          latest_active_state, updated_at
+        ) VALUES ('local', ?, ?, 0, 'active', ?)`,
+      )
+      .run(
+        jobUrl,
+        JSON.stringify({
+          tenant_id: "local",
+          job_id: jobUrl,
+          snapshots: [],
+          failures: [],
+          duplicate_candidates: [],
+          latest_active_state: "active",
+        }),
+        "2026-07-29T10:00:00+00:00",
+      );
+    setup.close();
+
+    const app = buildApp(options);
+    const response = await app.inject({
+      method: "POST",
+      url: "/v1/jobs/bulk-delete-permanent",
+      payload: { allMatching: false, jobKeys: [jobUrl] },
+    });
+    expect(response.statusCode, response.body).toBe(200);
+    await app.close();
+
+    const verify = new Database(options.dbPath);
+    try {
+      expect(countRows(verify, "job_enrichments", "job_url", jobUrl)).toBe(0);
+      expect(countRows(verify, "posting_snapshot_sets", "job_url", jobUrl)).toBe(
+        0,
+      );
+      expect(countRows(verify, "jobs", "url", jobUrl)).toBe(0);
+    } finally {
+      verify.close();
+    }
+  });
+
   it("permanently deletes job rows and clears delete/hide tombstones so rediscovery can add them again", async () => {
     const readyUrl = "https://example.com/jobs/ready";
     const blockedUrl = "https://example.com/jobs/blocked-tailor";
@@ -3068,6 +3302,78 @@ describe("local TypeScript API", () => {
       type: "tailored_resume_txt",
       status: "active",
       size: "12b",
+    });
+
+    await app.close();
+  });
+
+  it("projects stable enrichment fields through the JobId owner", async () => {
+    const jobUrl = "https://example.com/jobs/ready";
+    const jobId = `test-job:${jobUrl}`;
+    const seedDb = new Database(options.dbPath);
+    seedDb.exec(`
+      DROP TABLE job_enrichments;
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_jobs_tenant_job_id_fixture
+        ON jobs(tenant_id, job_id);
+      CREATE TABLE job_enrichments (
+        tenant_id TEXT NOT NULL DEFAULT 'local',
+        job_id TEXT NOT NULL,
+        current_status TEXT NOT NULL,
+        full_description TEXT,
+        application_url TEXT,
+        enriched_at TEXT,
+        extraction_tier TEXT,
+        attempts_json TEXT NOT NULL DEFAULT '[]',
+        updated_at TEXT NOT NULL,
+        PRIMARY KEY (tenant_id, job_id),
+        FOREIGN KEY (tenant_id, job_id)
+          REFERENCES jobs(tenant_id, job_id) ON DELETE CASCADE
+      );
+    `);
+    seedDb
+      .prepare(
+        `INSERT INTO job_enrichments (
+          tenant_id, job_id, current_status, full_description,
+          application_url, enriched_at, extraction_tier,
+          attempts_json, updated_at
+        ) VALUES ('local', ?, 'enriched', ?, ?, ?, 'json_ld', '[]', ?)`,
+      )
+      .run(
+        jobId,
+        "Stable aggregate description",
+        "https://apply.example.com/stable-owner",
+        "2026-07-29T10:00:00+00:00",
+        "2026-07-29T10:00:00+00:00",
+      );
+    seedDb.close();
+
+    const app = buildApp(options);
+    const response = await app.inject({
+      method: "GET",
+      url: `/v1/jobs/${encodeURIComponent(jobUrl)}`,
+    });
+
+    expect(response.statusCode, response.body).toBe(200);
+    expect(response.json().job).toMatchObject({
+      jobKey: jobUrl,
+      applicationUrl: "https://apply.example.com/stable-owner",
+    });
+
+    const verify = new Database(options.dbPath);
+    const projection = verify
+      .prepare(
+        `SELECT application_url, full_description
+           FROM job_list_projections
+          WHERE tenant_id = 'local' AND job_id = ?`,
+      )
+      .get(jobUrl) as {
+      application_url: string;
+      full_description: string;
+    };
+    verify.close();
+    expect(projection).toEqual({
+      application_url: "https://apply.example.com/stable-owner",
+      full_description: "Stable aggregate description",
     });
 
     await app.close();
@@ -6975,6 +7281,81 @@ describe("local TypeScript API", () => {
     expect(enrichment.extraction_tier).toBeNull();
     expect(legacyJob.detail_scraped_at).toBeNull();
     expect(legacyJob.detail_error).toBeNull();
+
+    await app.close();
+  });
+
+  it("retry-enrich resets a stable JobId enrichment aggregate", async () => {
+    const jobUrl = "https://example.com/jobs/failed-score";
+    const jobId = `test-job:${jobUrl}`;
+    const seedDb = new Database(options.dbPath);
+    seedDb.exec(`
+      DROP TABLE job_enrichments;
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_jobs_tenant_job_id_fixture
+        ON jobs(tenant_id, job_id);
+      CREATE TABLE job_enrichments (
+        tenant_id TEXT NOT NULL DEFAULT 'local',
+        job_id TEXT NOT NULL,
+        current_status TEXT NOT NULL,
+        full_description TEXT,
+        application_url TEXT,
+        enriched_at TEXT,
+        extraction_tier TEXT,
+        attempts_json TEXT NOT NULL DEFAULT '[]',
+        updated_at TEXT NOT NULL,
+        PRIMARY KEY (tenant_id, job_id),
+        FOREIGN KEY (tenant_id, job_id)
+          REFERENCES jobs(tenant_id, job_id) ON DELETE CASCADE
+      );
+    `);
+    seedDb
+      .prepare(
+        `INSERT INTO job_enrichments (
+          tenant_id, job_id, current_status, full_description,
+          application_url, enriched_at, extraction_tier,
+          attempts_json, updated_at
+        ) VALUES ('local', ?, 'enriched', 'description', ?, ?, 'json_ld', '[]', ?)`,
+      )
+      .run(
+        jobId,
+        `${jobUrl}/apply`,
+        "2026-07-29T10:00:00+00:00",
+        "2026-07-29T10:00:00+00:00",
+      );
+    seedDb.close();
+
+    const app = buildApp(options);
+    const response = await app.inject({
+      method: "POST",
+      url: `/v1/jobs/${encodeURIComponent(jobUrl)}/actions/retry-stage`,
+      payload: { stage: "enrich", resetAttempts: true },
+    });
+    expect(response.statusCode, response.body).toBe(200);
+
+    const db = new Database(options.dbPath);
+    const enrichment = db
+      .prepare(
+        `SELECT current_status, full_description, application_url,
+                enriched_at, extraction_tier
+           FROM job_enrichments
+          WHERE tenant_id = 'local' AND job_id = ?`,
+      )
+      .get(jobId) as {
+      current_status: string;
+      full_description: string | null;
+      application_url: string | null;
+      enriched_at: string | null;
+      extraction_tier: string | null;
+    };
+    db.close();
+
+    expect(enrichment).toEqual({
+      current_status: "pending",
+      full_description: null,
+      application_url: null,
+      enriched_at: null,
+      extraction_tier: null,
+    });
 
     await app.close();
   });

--- a/workers/automation/src/jobctrl/database.py
+++ b/workers/automation/src/jobctrl/database.py
@@ -46,7 +46,10 @@ from jobctrl.config import DB_PATH, DEFAULTS, migrate_legacy_job_tables
 # v10 (preparation references): the legacy preparation work-item ledger
 # references ``(tenant_id, job_id)`` while preserving its opaque historical
 # idempotency keys for the later quiescent workflow cutover.
-SCHEMA_VERSION = 10
+# v11 (enrichment references): JobEnrichment and PostingSnapshotSet authorities
+# reference ``(tenant_id, job_id)``; embedded snapshot aggregate identity and
+# duplicate-candidate references are upcast in the same transaction.
+SCHEMA_VERSION = 11
 
 
 class IncompatibleSchemaVersionError(RuntimeError):
@@ -187,6 +190,7 @@ def _schema_migrations() -> tuple[
         (8, ensure_discovery_identity_references_v8),
         (9, ensure_execution_search_references_v9),
         (10, ensure_preparation_references_v10),
+        (11, ensure_enrichment_snapshot_references_v11),
     )
 
 
@@ -3028,42 +3032,43 @@ def ensure_enrichment_tables(conn: sqlite3.Connection | None = None) -> list[str
     if conn is None:
         conn = get_connection()
 
-    conn.execute(
-        """
-        CREATE TABLE IF NOT EXISTS job_enrichments (
-            job_url             TEXT PRIMARY KEY,
-            tenant_id           TEXT NOT NULL DEFAULT 'local',
-            current_status      TEXT NOT NULL,
-            full_description    TEXT,
-            application_url     TEXT,
-            enriched_at         TEXT,
-            extraction_tier     TEXT,
-            attempts_json       TEXT NOT NULL DEFAULT '[]',
-            updated_at          TEXT NOT NULL,
-            FOREIGN KEY (job_url) REFERENCES jobs(url) ON DELETE CASCADE
+    current_version = int(conn.execute("PRAGMA user_version").fetchone()[0])
+    if current_version >= _ENRICHMENT_SNAPSHOT_REFERENCE_SCHEMA_VERSION:
+        _create_job_enrichments_v11(conn)
+    else:
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS job_enrichments (
+                job_url             TEXT PRIMARY KEY,
+                tenant_id           TEXT NOT NULL DEFAULT 'local',
+                current_status      TEXT NOT NULL,
+                full_description    TEXT,
+                application_url     TEXT,
+                enriched_at         TEXT,
+                extraction_tier     TEXT,
+                attempts_json       TEXT NOT NULL DEFAULT '[]',
+                updated_at          TEXT NOT NULL,
+                FOREIGN KEY (job_url) REFERENCES jobs(url) ON DELETE CASCADE
+            )
+            """
         )
-        """
-    )
-    conn.execute(
-        """
-        CREATE INDEX IF NOT EXISTS idx_job_enrichments_tenant_status
-        ON job_enrichments(tenant_id, current_status, updated_at DESC)
-        """
-    )
-    conn.execute(
-        """
-        CREATE INDEX IF NOT EXISTS idx_job_enrichments_enriched_at
-        ON job_enrichments(enriched_at DESC)
-        """
-    )
+    _create_job_enrichment_indexes(conn)
 
     # Idempotent one-shot backfill from the legacy columns.
     backfill_count = conn.execute("SELECT COUNT(*) FROM job_enrichments").fetchone()[0]
     if backfill_count == 0:
+        job_columns = _table_columns(conn, "jobs")
+        tenant_select = (
+            "tenant_id" if "tenant_id" in job_columns else "'local' AS tenant_id"
+        )
+        job_id_select = (
+            "job_id" if "job_id" in job_columns else "NULL AS job_id"
+        )
         legacy_rows = conn.execute(
-            """
+            f"""
             SELECT url, full_description, application_url,
-                   detail_scraped_at, detail_error
+                   detail_scraped_at, detail_error,
+                   {tenant_select}, {job_id_select}
             FROM jobs
             WHERE full_description IS NOT NULL
                OR application_url IS NOT NULL
@@ -3090,28 +3095,27 @@ def ensure_posting_snapshot_tables(conn: sqlite3.Connection | None = None) -> li
     if conn is None:
         conn = get_connection()
 
-    conn.execute(
-        """
-        CREATE TABLE IF NOT EXISTS posting_snapshot_sets (
-            tenant_id                TEXT NOT NULL DEFAULT 'local',
-            job_url                  TEXT NOT NULL,
-            snapshot_set_json        TEXT NOT NULL,
-            latest_snapshot_version  INTEGER NOT NULL DEFAULT 0,
-            latest_active_state      TEXT NOT NULL DEFAULT 'unknown',
-            latest_confidence        TEXT,
-            latest_quarantine_reason TEXT,
-            updated_at               TEXT NOT NULL,
-            PRIMARY KEY (tenant_id, job_url),
-            FOREIGN KEY (job_url) REFERENCES jobs(url) ON DELETE CASCADE
+    current_version = int(conn.execute("PRAGMA user_version").fetchone()[0])
+    if current_version >= _ENRICHMENT_SNAPSHOT_REFERENCE_SCHEMA_VERSION:
+        _create_posting_snapshot_sets_v11(conn)
+    else:
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS posting_snapshot_sets (
+                tenant_id                TEXT NOT NULL DEFAULT 'local',
+                job_url                  TEXT NOT NULL,
+                snapshot_set_json        TEXT NOT NULL,
+                latest_snapshot_version  INTEGER NOT NULL DEFAULT 0,
+                latest_active_state      TEXT NOT NULL DEFAULT 'unknown',
+                latest_confidence        TEXT,
+                latest_quarantine_reason TEXT,
+                updated_at               TEXT NOT NULL,
+                PRIMARY KEY (tenant_id, job_url),
+                FOREIGN KEY (job_url) REFERENCES jobs(url) ON DELETE CASCADE
+            )
+            """
         )
-        """
-    )
-    conn.execute(
-        """
-        CREATE INDEX IF NOT EXISTS idx_posting_snapshot_sets_updated
-        ON posting_snapshot_sets(tenant_id, updated_at DESC)
-        """
-    )
+    _create_posting_snapshot_set_indexes(conn)
     # The latest snapshot's confidence + quarantine reason are promoted onto
     # the row so the read model can gate the tailoring queue and surface the
     # enrichment quality signal without parsing snapshot_set_json per read.
@@ -3139,8 +3143,14 @@ def _backfill_latest_snapshot_quality(conn: sqlite3.Connection) -> None:
     Runs once when the columns are first added so pre-existing snapshot rows
     carry the same quality signal new writes persist directly.
     """
+    reference_column = (
+        "job_id"
+        if "job_id" in _table_columns(conn, "posting_snapshot_sets")
+        else "job_url"
+    )
     rows = conn.execute(
-        "SELECT tenant_id, job_url, snapshot_set_json FROM posting_snapshot_sets"
+        f"SELECT tenant_id, {reference_column}, snapshot_set_json "
+        "FROM posting_snapshot_sets"
     ).fetchall()
     for row in rows:
         raw_json = row["snapshot_set_json"] if isinstance(row, sqlite3.Row) else row[2]
@@ -3154,12 +3164,12 @@ def _backfill_latest_snapshot_quality(conn: sqlite3.Connection) -> None:
         conn.execute(
             "UPDATE posting_snapshot_sets "
             "SET latest_confidence = ?, latest_quarantine_reason = ? "
-            "WHERE tenant_id = ? AND job_url = ?",
+            f"WHERE tenant_id = ? AND {reference_column} = ?",
             (
                 latest.get("confidence"),
                 latest.get("quarantine_reason"),
                 row["tenant_id"] if isinstance(row, sqlite3.Row) else row[0],
-                row["job_url"] if isinstance(row, sqlite3.Row) else row[1],
+                row[reference_column] if isinstance(row, sqlite3.Row) else row[1],
             ),
         )
 
@@ -3325,6 +3335,16 @@ def _backfill_one_enrichment_row(
     application_url = row["application_url"] if isinstance(row, sqlite3.Row) else row[2]
     detail_scraped_at = row["detail_scraped_at"] if isinstance(row, sqlite3.Row) else row[3]
     detail_error = row["detail_error"] if isinstance(row, sqlite3.Row) else row[4]
+    tenant_id = (
+        str(row["tenant_id"] or "local")
+        if isinstance(row, sqlite3.Row)
+        else str(row[5] or "local")
+    )
+    stable_job_id = (
+        str(row["job_id"] or "")
+        if isinstance(row, sqlite3.Row)
+        else str(row[6] or "")
+    )
 
     enriched_at: str | None = None
     extraction_tier: str | None = None
@@ -3367,16 +3387,25 @@ def _backfill_one_enrichment_row(
         current_status = "pending"
         attempts = []
 
+    reference_column = (
+        "job_id" if "job_id" in _table_columns(conn, "job_enrichments") else "job_url"
+    )
+    job_reference = stable_job_id if reference_column == "job_id" else str(url)
+    if not job_reference:
+        raise RuntimeError(
+            "enrichment backfill requires stable JobId on schema v11"
+        )
     conn.execute(
-        """
+        f"""
         INSERT OR IGNORE INTO job_enrichments (
-            job_url, tenant_id, current_status, full_description,
+            {reference_column}, tenant_id, current_status, full_description,
             application_url, enriched_at, extraction_tier,
             attempts_json, updated_at
-        ) VALUES (?, 'local', ?, ?, ?, ?, ?, ?, ?)
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
         """,
         (
-            url,
+            job_reference,
+            tenant_id,
             current_status,
             full_description if full_description else None,
             application_url if application_url else None,
@@ -4188,6 +4217,413 @@ def _reassign_discovery_identity_references(
             """,
             (surviving_job_id, tenant_id, losing_job_id),
         )
+    if _has_enrichment_snapshot_reference_schema_v11(conn):
+        _reassign_enrichment_snapshot_references_v11(
+            conn,
+            tenant_id=tenant_id,
+            losing_job_id=losing_job_id,
+            surviving_job_id=surviving_job_id,
+        )
+
+
+def _reassign_enrichment_snapshot_references_v11(
+    conn: sqlite3.Connection,
+    *,
+    tenant_id: str,
+    losing_job_id: str,
+    surviving_job_id: str,
+) -> None:
+    _merge_enrichment_rows_v11(
+        conn,
+        tenant_id=tenant_id,
+        losing_job_id=losing_job_id,
+        surviving_job_id=surviving_job_id,
+    )
+    _merge_snapshot_rows_v11(
+        conn,
+        tenant_id=tenant_id,
+        losing_job_id=losing_job_id,
+        surviving_job_id=surviving_job_id,
+    )
+
+
+def _merge_enrichment_rows_v11(
+    conn: sqlite3.Connection,
+    *,
+    tenant_id: str,
+    losing_job_id: str,
+    surviving_job_id: str,
+) -> None:
+    rows = conn.execute(
+        """
+        SELECT job_id, current_status, full_description, application_url,
+               enriched_at, extraction_tier, attempts_json, updated_at
+        FROM job_enrichments
+        WHERE tenant_id = ? AND job_id IN (?, ?)
+        """,
+        (tenant_id, losing_job_id, surviving_job_id),
+    ).fetchall()
+    by_job_id = {str(row[0]): row for row in rows}
+    losing = by_job_id.get(losing_job_id)
+    if losing is None:
+        return
+    surviving = by_job_id.get(surviving_job_id)
+    if surviving is None:
+        conn.execute(
+            """
+            UPDATE job_enrichments
+            SET job_id = ?
+            WHERE tenant_id = ? AND job_id = ?
+            """,
+            (surviving_job_id, tenant_id, losing_job_id),
+        )
+        return
+
+    merged_values = _merged_enrichment_values_v11(
+        surviving=surviving,
+        losing=losing,
+    )
+    conn.execute(
+        """
+        UPDATE job_enrichments
+        SET current_status = ?,
+            full_description = ?,
+            application_url = ?,
+            enriched_at = ?,
+            extraction_tier = ?,
+            attempts_json = ?,
+            updated_at = ?
+        WHERE tenant_id = ? AND job_id = ?
+        """,
+        (
+            *merged_values,
+            tenant_id,
+            surviving_job_id,
+        ),
+    )
+    conn.execute(
+        """
+        DELETE FROM job_enrichments
+        WHERE tenant_id = ? AND job_id = ?
+        """,
+        (tenant_id, losing_job_id),
+    )
+
+
+def _merged_enrichment_values_v11(
+    *,
+    surviving: Any,
+    losing: Any,
+    allow_conflicting_descriptions: bool = False,
+) -> tuple[str, Any, Any, Any, Any, str, str]:
+    """Merge two enrichment authorities without discarding newer facts."""
+    surviving_description = surviving[2]
+    losing_description = losing[2]
+    if (
+        surviving_description
+        and losing_description
+        and str(surviving_description) != str(losing_description)
+        and not allow_conflicting_descriptions
+    ):
+        raise RuntimeError(
+            "URL collision merge found conflicting canonical enrichment "
+            "descriptions"
+        )
+
+    attempts: list[dict[str, Any]] = []
+    for source_index, row in enumerate((surviving, losing)):
+        try:
+            source_attempts = json.loads(str(row[6] or "[]"))
+        except (TypeError, ValueError) as exc:
+            raise RuntimeError(
+                "URL collision merge found invalid enrichment attempt history"
+            ) from exc
+        if not isinstance(source_attempts, list) or any(
+            not isinstance(attempt, dict) for attempt in source_attempts
+        ):
+            raise RuntimeError(
+                "URL collision merge found invalid enrichment attempt history"
+            )
+        for attempt_index, attempt in enumerate(source_attempts):
+            copied = dict(attempt)
+            copied["_merge_order"] = (source_index, attempt_index)
+            attempts.append(copied)
+    attempts.sort(
+        key=lambda attempt: (
+            str(attempt.get("started_at") or ""),
+            attempt["_merge_order"],
+        )
+    )
+    if sum(
+        1 for attempt in attempts if str(attempt.get("status")) == "running"
+    ) > 1:
+        raise RuntimeError(
+            "URL collision merge found multiple running enrichment attempts"
+        )
+    for number, attempt in enumerate(attempts, start=1):
+        attempt.pop("_merge_order", None)
+        attempt["attempt_number"] = number
+
+    canonical_rows = [
+        row
+        for row in (surviving, losing)
+        if row[2] or str(row[1]) == "enriched"
+    ]
+    authority = max(
+        canonical_rows or [surviving, losing],
+        key=lambda row: (
+            str(row[4] or ""),
+            str(row[7] or ""),
+            row is surviving,
+        ),
+    )
+    fallback = losing if authority is surviving else surviving
+    return (
+        str(authority[1]),
+        authority[2] or fallback[2],
+        authority[3] or fallback[3],
+        authority[4] or fallback[4],
+        authority[5] or fallback[5],
+        json.dumps(attempts, sort_keys=True),
+        max(str(surviving[7]), str(losing[7])),
+    )
+
+
+def _merge_snapshot_rows_v11(
+    conn: sqlite3.Connection,
+    *,
+    tenant_id: str,
+    losing_job_id: str,
+    surviving_job_id: str,
+) -> None:
+    rows = conn.execute(
+        """
+        SELECT job_id, snapshot_set_json, latest_snapshot_version,
+               latest_active_state, latest_confidence,
+               latest_quarantine_reason, updated_at
+        FROM posting_snapshot_sets
+        WHERE tenant_id = ? AND job_id IN (?, ?)
+        """,
+        (tenant_id, losing_job_id, surviving_job_id),
+    ).fetchall()
+    by_job_id = {str(row[0]): row for row in rows}
+    losing = by_job_id.get(losing_job_id)
+    surviving = by_job_id.get(surviving_job_id)
+    if losing is not None and surviving is None:
+        data = _snapshot_json_object_for_merge(losing[1])
+        data["tenant_id"] = tenant_id
+        data["job_id"] = surviving_job_id
+        conn.execute(
+            """
+            UPDATE posting_snapshot_sets
+            SET job_id = ?, snapshot_set_json = ?
+            WHERE tenant_id = ? AND job_id = ?
+            """,
+            (
+                surviving_job_id,
+                json.dumps(data, sort_keys=True),
+                tenant_id,
+                losing_job_id,
+            ),
+        )
+    elif losing is not None and surviving is not None:
+        merged_values = _merged_snapshot_record_values_v11(
+            surviving=tuple(surviving),
+            losing=tuple(losing),
+            tenant_id=tenant_id,
+            surviving_job_id=surviving_job_id,
+            losing_job_id=losing_job_id,
+        )
+        conn.execute(
+            """
+            UPDATE posting_snapshot_sets
+            SET snapshot_set_json = ?,
+                latest_snapshot_version = ?,
+                latest_active_state = ?,
+                latest_confidence = ?,
+                latest_quarantine_reason = ?,
+                updated_at = ?
+            WHERE tenant_id = ? AND job_id = ?
+            """,
+            (
+                *merged_values[1:],
+                tenant_id,
+                surviving_job_id,
+            ),
+        )
+        conn.execute(
+            """
+            DELETE FROM posting_snapshot_sets
+            WHERE tenant_id = ? AND job_id = ?
+            """,
+            (tenant_id, losing_job_id),
+        )
+
+    snapshot_rows = conn.execute(
+        """
+        SELECT job_id, snapshot_set_json
+        FROM posting_snapshot_sets
+        WHERE tenant_id = ?
+        """,
+        (tenant_id,),
+    ).fetchall()
+    for row in snapshot_rows:
+        owner_job_id = str(row[0])
+        data = _snapshot_json_object_for_merge(row[1])
+        changed = False
+        candidates = data.get("duplicate_candidates") or []
+        if not isinstance(candidates, list):
+            raise RuntimeError(
+                "URL collision merge found invalid duplicate candidates"
+            )
+        rewritten_candidates: dict[str, dict[str, Any]] = {}
+        for candidate in candidates:
+            if not isinstance(candidate, dict):
+                raise RuntimeError(
+                    "URL collision merge found an invalid duplicate candidate"
+                )
+            candidate_job_id = str(
+                candidate.get("candidate_job_id") or ""
+            )
+            if candidate_job_id == losing_job_id:
+                candidate_job_id = surviving_job_id
+                changed = True
+            if candidate_job_id == owner_job_id:
+                changed = True
+                continue
+            copied = dict(candidate)
+            copied["candidate_job_id"] = candidate_job_id
+            if candidate_job_id in rewritten_candidates:
+                changed = True
+                continue
+            rewritten_candidates[candidate_job_id] = copied
+        if changed:
+            data["tenant_id"] = tenant_id
+            data["job_id"] = owner_job_id
+            data["duplicate_candidates"] = list(
+                rewritten_candidates.values()
+            )
+            conn.execute(
+                """
+                UPDATE posting_snapshot_sets
+                SET snapshot_set_json = ?
+                WHERE tenant_id = ? AND job_id = ?
+                """,
+                (json.dumps(data, sort_keys=True), tenant_id, owner_job_id),
+            )
+
+
+def _snapshot_json_object_for_merge(raw_json: Any) -> dict[str, Any]:
+    try:
+        data = json.loads(str(raw_json))
+    except (TypeError, ValueError) as exc:
+        raise RuntimeError(
+            "URL collision merge found invalid snapshot aggregate JSON"
+        ) from exc
+    if not isinstance(data, dict):
+        raise RuntimeError(
+            "URL collision merge found non-object snapshot aggregate JSON"
+        )
+    for field in ("snapshots", "failures", "duplicate_candidates"):
+        value = data.get(field) or []
+        if not isinstance(value, list):
+            raise RuntimeError(
+                f"URL collision merge found invalid snapshot {field}"
+            )
+        if any(not isinstance(item, dict) for item in value):
+            raise RuntimeError(
+                f"URL collision merge found invalid item in snapshot {field}"
+            )
+    return data
+
+
+def _merged_snapshot_record_values_v11(
+    *,
+    surviving: tuple[str, str, int, str, Any, Any, str],
+    losing: tuple[str, str, int, str, Any, Any, str],
+    tenant_id: str,
+    surviving_job_id: str,
+    losing_job_id: str,
+) -> tuple[str, str, int, str, Any, Any, str]:
+    """Merge two snapshot authorities while retaining every history item."""
+    surviving_data = _snapshot_json_object_for_merge(surviving[1])
+    losing_data = _snapshot_json_object_for_merge(losing[1])
+    snapshots = [
+        dict(snapshot)
+        for data in (surviving_data, losing_data)
+        for snapshot in data.get("snapshots") or []
+    ]
+    snapshots.sort(key=lambda snapshot: str(snapshot.get("captured_at") or ""))
+    for version, snapshot in enumerate(snapshots, start=1):
+        snapshot["snapshot_version"] = version
+    failures = [
+        dict(failure)
+        for data in (surviving_data, losing_data)
+        for failure in data.get("failures") or []
+    ]
+    failures.sort(key=lambda failure: str(failure.get("failed_at") or ""))
+
+    authority, fallback = (
+        (surviving, losing)
+        if (str(surviving[6]), True) >= (str(losing[6]), False)
+        else (losing, surviving)
+    )
+    authority_data = (
+        surviving_data if authority is surviving else losing_data
+    )
+    fallback_data = losing_data if authority is surviving else surviving_data
+    candidate_by_job_id: dict[str, dict[str, Any]] = {}
+    for data in (authority_data, fallback_data):
+        for candidate in data.get("duplicate_candidates") or []:
+            candidate_job_id = str(
+                candidate.get("candidate_job_id") or ""
+            )
+            if candidate_job_id == losing_job_id:
+                candidate_job_id = surviving_job_id
+            if candidate_job_id == surviving_job_id:
+                continue
+            copied = dict(candidate)
+            copied["candidate_job_id"] = candidate_job_id
+            candidate_by_job_id.setdefault(candidate_job_id, copied)
+
+    updated_at = max(str(surviving[6]), str(losing[6]))
+    latest = snapshots[-1] if snapshots else None
+    latest_state = (
+        str(latest.get("active_state") or "unknown")
+        if latest is not None
+        else str(authority[3] or "unknown")
+    )
+    latest_confidence = (
+        latest.get("confidence")
+        if latest is not None
+        else authority[4] or fallback[4]
+    )
+    latest_quarantine_reason = (
+        latest.get("quarantine_reason")
+        if latest is not None
+        else authority[5] or fallback[5]
+    )
+    merged = dict(authority_data)
+    merged.update(
+        {
+            "tenant_id": tenant_id,
+            "job_id": surviving_job_id,
+            "snapshots": snapshots,
+            "failures": failures,
+            "duplicate_candidates": list(candidate_by_job_id.values()),
+            "latest_active_state": latest_state,
+            "updated_at": updated_at,
+        }
+    )
+    return (
+        surviving_job_id,
+        json.dumps(merged, sort_keys=True),
+        len(snapshots),
+        latest_state,
+        latest_confidence,
+        latest_quarantine_reason,
+        updated_at,
+    )
 
 
 def _reassign_execution_memberships(
@@ -5402,6 +5838,659 @@ def _verify_preparation_references_v10(
             "preparation reference migration found a foreign-key violation"
         )
 
+
+_ENRICHMENT_SNAPSHOT_REFERENCE_SCHEMA_VERSION = 11
+_ENRICHMENT_SNAPSHOT_REFERENCE_TABLES = (
+    "job_enrichments",
+    "posting_snapshot_sets",
+)
+
+
+def ensure_enrichment_snapshot_references_v11(
+    conn: sqlite3.Connection | None = None,
+) -> list[str]:
+    """Move Enrichment-owned references and embedded identity to JobIds."""
+    if conn is None:
+        conn = get_connection()
+
+    current = _assert_schema_version_supported(conn)
+    if current >= _ENRICHMENT_SNAPSHOT_REFERENCE_SCHEMA_VERSION:
+        return []
+    if current != _PREPARATION_REFERENCE_SCHEMA_VERSION:
+        raise RuntimeError(
+            "enrichment/snapshot reference migration requires preparation "
+            "schema v10"
+        )
+
+    conn.execute("SAVEPOINT enrichment_snapshot_references_v11")
+    try:
+        _verify_enrichment_snapshot_prerequisites_v11(conn)
+        before_counts = {
+            table: int(
+                conn.execute(f'SELECT COUNT(*) FROM "{table}"').fetchone()[0]
+            )
+            for table in _ENRICHMENT_SNAPSHOT_REFERENCE_TABLES
+        }
+        expected_counts = dict(before_counts)
+
+        if not _has_enrichment_snapshot_reference_schema_v11(conn):
+            enrichment_reference = _enrichment_snapshot_reference_column(
+                conn,
+                "job_enrichments",
+            )
+            snapshot_reference = _enrichment_snapshot_reference_column(
+                conn,
+                "posting_snapshot_sets",
+            )
+            reference_columns = {
+                "job_enrichments": enrichment_reference,
+                "posting_snapshot_sets": snapshot_reference,
+            }
+            for table, reference_column in reference_columns.items():
+                legacy_url = reference_column == "job_url"
+                resolved_job_id = _resolved_job_id_sql(
+                    "source",
+                    reference_column,
+                    legacy_url=legacy_url,
+                )
+                unresolved = conn.execute(
+                    f"""
+                    SELECT source.{reference_column}
+                    FROM {table} AS source
+                    WHERE {resolved_job_id} IS NULL
+                    LIMIT 1
+                    """
+                ).fetchone()
+                if unresolved is not None:
+                    raise RuntimeError(
+                        "enrichment/snapshot reference migration could not "
+                        f"resolve {table}.{reference_column}={unresolved[0]!r}"
+                    )
+
+            conn.execute("DROP TABLE IF EXISTS job_enrichments_v11")
+            conn.execute("DROP TABLE IF EXISTS posting_snapshot_sets_v11")
+            _create_job_enrichments_v11(
+                conn,
+                table_name="job_enrichments_v11",
+            )
+            _create_posting_snapshot_sets_v11(
+                conn,
+                table_name="posting_snapshot_sets_v11",
+            )
+
+            enrichment_rows = conn.execute(
+                f"""
+                SELECT
+                    source.tenant_id,
+                    source.{enrichment_reference},
+                    source.current_status,
+                    source.full_description,
+                    source.application_url,
+                    source.enriched_at,
+                    source.extraction_tier,
+                    source.attempts_json,
+                    source.updated_at
+                FROM job_enrichments AS source
+                ORDER BY source.tenant_id, source.{enrichment_reference}
+                """
+            ).fetchall()
+            canonical_enrichments: dict[
+                tuple[str, str],
+                tuple[str, str, Any, Any, Any, Any, str, str],
+            ] = {}
+            for row in enrichment_rows:
+                tenant_id = str(row[0])
+                raw_reference = str(row[1])
+                stable_job_id = _resolve_job_reference_value(
+                    conn,
+                    tenant_id=tenant_id,
+                    reference=raw_reference,
+                    legacy_url=enrichment_reference == "job_url",
+                )
+                if stable_job_id is None:
+                    raise RuntimeError(
+                        "enrichment/snapshot reference migration could not "
+                        "resolve job_enrichments identity for "
+                        f"{raw_reference!r}"
+                    )
+                candidate = (
+                    stable_job_id,
+                    str(row[2]),
+                    row[3],
+                    row[4],
+                    row[5],
+                    row[6],
+                    str(row[7] or "[]"),
+                    str(row[8]),
+                )
+                key = (tenant_id, stable_job_id)
+                existing = canonical_enrichments.get(key)
+                if existing is not None:
+                    candidate = (
+                        stable_job_id,
+                        *_merged_enrichment_values_v11(
+                            surviving=existing,
+                            losing=candidate,
+                            allow_conflicting_descriptions=True,
+                        ),
+                    )
+                canonical_enrichments[key] = candidate
+            conn.executemany(
+                """
+                INSERT INTO job_enrichments_v11 (
+                    tenant_id, job_id, current_status, full_description,
+                    application_url, enriched_at, extraction_tier,
+                    attempts_json, updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    (tenant_id, *record)
+                    for (tenant_id, _job_id), record
+                    in canonical_enrichments.items()
+                ),
+            )
+            expected_counts["job_enrichments"] = len(
+                canonical_enrichments
+            )
+
+            snapshot_rows = conn.execute(
+                f"""
+                SELECT
+                    source.tenant_id,
+                    source.{snapshot_reference},
+                    source.snapshot_set_json,
+                    source.latest_snapshot_version,
+                    source.latest_active_state,
+                    source.latest_confidence,
+                    source.latest_quarantine_reason,
+                    source.updated_at
+                FROM posting_snapshot_sets AS source
+                ORDER BY source.tenant_id, source.{snapshot_reference}
+                """
+            ).fetchall()
+            canonical_snapshots: dict[
+                tuple[str, str],
+                tuple[str, str, int, str, Any, Any, str],
+            ] = {}
+            for row in snapshot_rows:
+                tenant_id = str(row[0])
+                raw_reference = str(row[1])
+                stable_job_id = _resolve_job_reference_value(
+                    conn,
+                    tenant_id=tenant_id,
+                    reference=raw_reference,
+                    legacy_url=snapshot_reference == "job_url",
+                )
+                if stable_job_id is None:
+                    raise RuntimeError(
+                        "enrichment/snapshot reference migration could not "
+                        "resolve posting_snapshot_sets embedded identity for "
+                        f"{raw_reference!r}"
+                    )
+                rewritten_json = _rewrite_snapshot_set_identity_v11(
+                    conn,
+                    tenant_id=tenant_id,
+                    stable_job_id=stable_job_id,
+                    raw_json=str(row[2]),
+                    legacy_url=snapshot_reference == "job_url",
+                )
+                candidate = (
+                    stable_job_id,
+                    rewritten_json,
+                    int(row[3]),
+                    str(row[4]),
+                    row[5],
+                    row[6],
+                    str(row[7]),
+                )
+                key = (tenant_id, stable_job_id)
+                existing = canonical_snapshots.get(key)
+                if existing is not None:
+                    candidate = _merged_snapshot_record_values_v11(
+                        surviving=existing,
+                        losing=candidate,
+                        tenant_id=tenant_id,
+                        surviving_job_id=stable_job_id,
+                        losing_job_id=stable_job_id,
+                    )
+                canonical_snapshots[key] = candidate
+            conn.executemany(
+                """
+                INSERT INTO posting_snapshot_sets_v11 (
+                    tenant_id, job_id, snapshot_set_json,
+                    latest_snapshot_version, latest_active_state,
+                    latest_confidence, latest_quarantine_reason, updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    (tenant_id, *record)
+                    for (tenant_id, _job_id), record
+                    in canonical_snapshots.items()
+                ),
+            )
+            expected_counts["posting_snapshot_sets"] = len(
+                canonical_snapshots
+            )
+
+            for table in _ENRICHMENT_SNAPSHOT_REFERENCE_TABLES:
+                conn.execute(f'DROP TABLE "{table}"')
+                conn.execute(
+                    f'ALTER TABLE "{table}_v11" RENAME TO "{table}"'
+                )
+            _create_job_enrichment_indexes(conn)
+            _create_posting_snapshot_set_indexes(conn)
+
+        _verify_enrichment_snapshot_references_v11(
+            conn,
+            expected_counts=expected_counts,
+        )
+        conn.execute(
+            f"PRAGMA user_version = "
+            f"{_ENRICHMENT_SNAPSHOT_REFERENCE_SCHEMA_VERSION}"
+        )
+        conn.execute("RELEASE SAVEPOINT enrichment_snapshot_references_v11")
+        conn.commit()
+    except BaseException:
+        conn.execute("ROLLBACK TO SAVEPOINT enrichment_snapshot_references_v11")
+        conn.execute("RELEASE SAVEPOINT enrichment_snapshot_references_v11")
+        raise
+
+    return list(_ENRICHMENT_SNAPSHOT_REFERENCE_TABLES)
+
+
+def _verify_enrichment_snapshot_prerequisites_v11(
+    conn: sqlite3.Connection,
+) -> None:
+    """Verify the v10 authority without inspecting v11 migration targets."""
+    if not _has_preparation_reference_schema_v10(conn):
+        raise RuntimeError(
+            "enrichment/snapshot reference migration requires the stable "
+            "preparation reference schema"
+        )
+    orphan = conn.execute(
+        """
+        SELECT source.job_id
+        FROM preparation_work_items AS source
+        LEFT JOIN jobs j
+          ON j.tenant_id = source.tenant_id
+         AND j.job_id = source.job_id
+        WHERE j.job_id IS NULL
+        LIMIT 1
+        """
+    ).fetchone()
+    if orphan is not None:
+        raise RuntimeError(
+            "enrichment/snapshot reference migration found an unresolved "
+            "preparation_work_items.job_id prerequisite"
+        )
+
+
+def _enrichment_snapshot_reference_column(
+    conn: sqlite3.Connection,
+    table: str,
+) -> str:
+    columns = _table_columns(conn, table)
+    if "job_id" in columns:
+        return "job_id"
+    if "job_url" in columns:
+        return "job_url"
+    raise RuntimeError(
+        "enrichment/snapshot reference migration found no job reference "
+        f"in {table}"
+    )
+
+
+def _create_job_enrichments_v11(
+    conn: sqlite3.Connection,
+    *,
+    table_name: str = "job_enrichments",
+) -> None:
+    conn.execute(
+        f"""
+        CREATE TABLE IF NOT EXISTS {table_name} (
+            tenant_id           TEXT NOT NULL DEFAULT 'local',
+            job_id              TEXT NOT NULL,
+            current_status      TEXT NOT NULL,
+            full_description    TEXT,
+            application_url     TEXT,
+            enriched_at         TEXT,
+            extraction_tier     TEXT,
+            attempts_json       TEXT NOT NULL DEFAULT '[]',
+            updated_at          TEXT NOT NULL,
+            PRIMARY KEY (tenant_id, job_id),
+            FOREIGN KEY (tenant_id, job_id)
+                REFERENCES jobs(tenant_id, job_id) ON DELETE CASCADE
+        )
+        """
+    )
+
+
+def _create_posting_snapshot_sets_v11(
+    conn: sqlite3.Connection,
+    *,
+    table_name: str = "posting_snapshot_sets",
+) -> None:
+    conn.execute(
+        f"""
+        CREATE TABLE IF NOT EXISTS {table_name} (
+            tenant_id                TEXT NOT NULL DEFAULT 'local',
+            job_id                   TEXT NOT NULL,
+            snapshot_set_json        TEXT NOT NULL,
+            latest_snapshot_version  INTEGER NOT NULL DEFAULT 0,
+            latest_active_state      TEXT NOT NULL DEFAULT 'unknown',
+            latest_confidence        TEXT,
+            latest_quarantine_reason TEXT,
+            updated_at               TEXT NOT NULL,
+            PRIMARY KEY (tenant_id, job_id),
+            FOREIGN KEY (tenant_id, job_id)
+                REFERENCES jobs(tenant_id, job_id) ON DELETE CASCADE
+        )
+        """
+    )
+
+
+def _create_job_enrichment_indexes(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_job_enrichments_tenant_status
+        ON job_enrichments(tenant_id, current_status, updated_at DESC)
+        """
+    )
+    conn.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_job_enrichments_enriched_at
+        ON job_enrichments(enriched_at DESC)
+        """
+    )
+
+
+def _create_posting_snapshot_set_indexes(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_posting_snapshot_sets_updated
+        ON posting_snapshot_sets(tenant_id, updated_at DESC)
+        """
+    )
+
+
+def _has_enrichment_snapshot_reference_schema_v11(
+    conn: sqlite3.Connection,
+) -> bool:
+    return (
+        "job_id" in _table_columns(conn, "job_enrichments")
+        and "job_url" not in _table_columns(conn, "job_enrichments")
+        and _primary_key_columns(conn, "job_enrichments")
+        == ("tenant_id", "job_id")
+        and _has_composite_job_id_foreign_key(
+            conn,
+            "job_enrichments",
+            "job_id",
+        )
+        and _has_index(
+            conn,
+            "job_enrichments",
+            "idx_job_enrichments_tenant_status",
+            ("tenant_id", "current_status", "updated_at"),
+            unique=False,
+        )
+        and _has_index(
+            conn,
+            "job_enrichments",
+            "idx_job_enrichments_enriched_at",
+            ("enriched_at",),
+            unique=False,
+        )
+        and "job_id" in _table_columns(conn, "posting_snapshot_sets")
+        and "job_url" not in _table_columns(conn, "posting_snapshot_sets")
+        and _primary_key_columns(conn, "posting_snapshot_sets")
+        == ("tenant_id", "job_id")
+        and _has_composite_job_id_foreign_key(
+            conn,
+            "posting_snapshot_sets",
+            "job_id",
+        )
+        and _has_index(
+            conn,
+            "posting_snapshot_sets",
+            "idx_posting_snapshot_sets_updated",
+            ("tenant_id", "updated_at"),
+            unique=False,
+        )
+    )
+
+
+def _resolve_job_reference_value(
+    conn: sqlite3.Connection,
+    *,
+    tenant_id: str,
+    reference: str,
+    legacy_url: bool,
+) -> str | None:
+    by_job_id = (
+        "SELECT job_id FROM jobs "
+        "WHERE tenant_id = ? AND job_id = ? LIMIT 1"
+    )
+    by_storage_url = (
+        "SELECT job_id FROM jobs "
+        "WHERE tenant_id = ? AND url = ? LIMIT 1"
+    )
+    by_posting_alias = """
+        SELECT a.job_id
+        FROM job_identity_aliases a
+        JOIN jobs j
+          ON j.tenant_id = a.tenant_id
+         AND j.job_id = a.job_id
+        WHERE a.tenant_id = ?
+          AND a.alias_kind = 'posting_url'
+          AND a.alias_value = ?
+        LIMIT 1
+    """
+    lookups = (
+        (by_storage_url, by_posting_alias, by_job_id)
+        if legacy_url
+        else (by_job_id, by_storage_url, by_posting_alias)
+    )
+    for sql in lookups:
+        row = conn.execute(sql, (tenant_id, reference)).fetchone()
+        if row is not None:
+            return str(row[0])
+    return None
+
+
+def _rewrite_snapshot_set_identity_v11(
+    conn: sqlite3.Connection,
+    *,
+    tenant_id: str,
+    stable_job_id: str,
+    raw_json: str,
+    legacy_url: bool,
+) -> str:
+    try:
+        data = json.loads(raw_json)
+    except (TypeError, ValueError) as exc:
+        raise RuntimeError(
+            "enrichment/snapshot reference migration found invalid "
+            "posting_snapshot_sets.snapshot_set_json"
+        ) from exc
+    if not isinstance(data, dict):
+        raise RuntimeError(
+            "enrichment/snapshot reference migration requires snapshot JSON "
+            "to be an object"
+        )
+
+    embedded_tenant = str(data.get("tenant_id") or tenant_id)
+    if embedded_tenant != tenant_id:
+        raise RuntimeError(
+            "enrichment/snapshot reference migration found a snapshot tenant "
+            "that does not match its row"
+        )
+    embedded_reference = str(data.get("job_id") or "").strip()
+    if embedded_reference:
+        embedded_job_id = _resolve_job_reference_value(
+            conn,
+            tenant_id=tenant_id,
+            reference=embedded_reference,
+            legacy_url=legacy_url,
+        )
+        if embedded_job_id != stable_job_id:
+            raise RuntimeError(
+                "enrichment/snapshot reference migration found embedded "
+                "snapshot identity that does not match its row"
+            )
+
+    candidates = data.get("duplicate_candidates") or []
+    if not isinstance(candidates, list):
+        raise RuntimeError(
+            "enrichment/snapshot reference migration requires "
+            "duplicate_candidates to be a list"
+        )
+    rewritten_candidates: dict[str, dict[str, Any]] = {}
+    for candidate in candidates:
+        if not isinstance(candidate, dict):
+            raise RuntimeError(
+                "enrichment/snapshot reference migration found an invalid "
+                "duplicate candidate"
+            )
+        candidate_reference = str(
+            candidate.get("candidate_job_id") or ""
+        ).strip()
+        candidate_job_id = _resolve_job_reference_value(
+            conn,
+            tenant_id=tenant_id,
+            reference=candidate_reference,
+            legacy_url=legacy_url,
+        )
+        if candidate_job_id is None:
+            raise RuntimeError(
+                "enrichment/snapshot reference migration could not resolve "
+                "embedded duplicate candidate "
+                f"{candidate_reference!r}"
+            )
+        if candidate_job_id == stable_job_id:
+            continue
+        copied = dict(candidate)
+        copied["candidate_job_id"] = candidate_job_id
+        rewritten_candidates.setdefault(candidate_job_id, copied)
+
+    data["tenant_id"] = tenant_id
+    data["job_id"] = stable_job_id
+    data["duplicate_candidates"] = list(rewritten_candidates.values())
+    return json.dumps(data, sort_keys=True)
+
+
+def _verify_enrichment_snapshot_references_v11(
+    conn: sqlite3.Connection,
+    *,
+    expected_counts: dict[str, int],
+) -> None:
+    if not _has_enrichment_snapshot_reference_schema_v11(conn):
+        raise RuntimeError(
+            "enrichment/snapshot reference migration did not create the "
+            "stable reference schema"
+        )
+    for table, expected_count in expected_counts.items():
+        observed_count = int(
+            conn.execute(f'SELECT COUNT(*) FROM "{table}"').fetchone()[0]
+        )
+        if observed_count != expected_count:
+            raise RuntimeError(
+                "enrichment/snapshot reference migration changed row count "
+                f"for {table}: expected {expected_count}, found {observed_count}"
+            )
+        orphan = conn.execute(
+            f"""
+            SELECT source.job_id
+            FROM {table} AS source
+            LEFT JOIN jobs j
+              ON j.tenant_id = source.tenant_id
+             AND j.job_id = source.job_id
+            WHERE j.job_id IS NULL
+            LIMIT 1
+            """
+        ).fetchone()
+        if orphan is not None:
+            raise RuntimeError(
+                "enrichment/snapshot reference migration left an unresolved "
+                f"reference in {table}.job_id"
+            )
+
+    snapshot_rows = conn.execute(
+        """
+        SELECT tenant_id, job_id, snapshot_set_json, latest_snapshot_version
+        FROM posting_snapshot_sets
+        """
+    ).fetchall()
+    for row in snapshot_rows:
+        tenant_id = str(row[0])
+        job_id = str(row[1])
+        _validate_job_uuid(job_id)
+        try:
+            data = json.loads(str(row[2]))
+        except (TypeError, ValueError) as exc:
+            raise RuntimeError(
+                "enrichment/snapshot reference migration persisted invalid "
+                "snapshot JSON"
+            ) from exc
+        if not isinstance(data, dict):
+            raise RuntimeError(
+                "enrichment/snapshot reference migration persisted non-object "
+                "snapshot JSON"
+            )
+        if str(data.get("tenant_id") or "") != tenant_id:
+            raise RuntimeError(
+                "enrichment/snapshot reference migration persisted mismatched "
+                "snapshot tenant identity"
+            )
+        if str(data.get("job_id") or "") != job_id:
+            raise RuntimeError(
+                "enrichment/snapshot reference migration persisted mismatched "
+                "snapshot JobId"
+            )
+        snapshots = data.get("snapshots") or []
+        if not isinstance(snapshots, list) or len(snapshots) != int(row[3]):
+            raise RuntimeError(
+                "enrichment/snapshot reference migration changed snapshot "
+                "version history"
+            )
+        candidates = data.get("duplicate_candidates") or []
+        if not isinstance(candidates, list):
+            raise RuntimeError(
+                "enrichment/snapshot reference migration persisted invalid "
+                "duplicate candidates"
+            )
+        for candidate in candidates:
+            candidate_job_id = str(
+                candidate.get("candidate_job_id") if isinstance(candidate, dict) else ""
+            )
+            _validate_job_uuid(candidate_job_id)
+            if candidate_job_id == job_id:
+                raise RuntimeError(
+                    "enrichment/snapshot reference migration persisted a "
+                    "self-referential duplicate candidate"
+                )
+            exists = conn.execute(
+                """
+                SELECT 1
+                FROM jobs
+                WHERE tenant_id = ? AND job_id = ?
+                LIMIT 1
+                """,
+                (tenant_id, candidate_job_id),
+            ).fetchone()
+            if exists is None:
+                raise RuntimeError(
+                    "enrichment/snapshot reference migration persisted an "
+                    "unresolved duplicate candidate"
+                )
+
+    foreign_key_error = conn.execute("PRAGMA foreign_key_check").fetchone()
+    if foreign_key_error is not None:
+        raise RuntimeError(
+            "enrichment/snapshot reference migration found a foreign-key "
+            "violation"
+        )
+
+
 # ---------------------------------------------------------------------------
 # job_enrichments read fragments — used by every selector / stat that
 # previously read bare ``jobs.full_description`` / ``jobs.application_url``
@@ -5414,7 +6503,8 @@ def _verify_preparation_references_v10(
 # ---------------------------------------------------------------------------
 
 _ENRICHMENT_JOIN: str = (
-    "LEFT JOIN job_enrichments je ON je.job_url = jobs.url "
+    "LEFT JOIN job_enrichments je "
+    "ON je.tenant_id = jobs.tenant_id AND je.job_id = jobs.job_id "
     "LEFT JOIN job_stage_states jss_enrich "
     "ON jss_enrich.job_url = jobs.url AND jss_enrich.stage = 'enrich'"
 )
@@ -5437,7 +6527,7 @@ _ENRICHMENT_DONE: str = "(je.current_status = 'enriched' OR jobs.detail_scraped_
 # rejects succeeded -> running. A reset clears the stage row back to pending,
 # so retries still work even when legacy detail columns remain populated.
 _ENRICHMENT_PENDING: str = (
-    "(je.job_url IS NULL OR je.current_status = 'pending') "
+    "(je.job_id IS NULL OR je.current_status = 'pending') "
     "AND COALESCE(jss_enrich.state, CASE WHEN jobs.detail_scraped_at IS NOT NULL THEN 'succeeded' ELSE 'pending' END) = 'pending'"
 )
 
@@ -5447,7 +6537,7 @@ _ENRICHMENT_PENDING: str = (
 _CLOSED_ACTIVE_STATES_SQL = "'closed', 'expired', 'removed', 'location_incompatible'"
 _ACTIVE_STATE_JOIN: str = (
     "LEFT JOIN posting_snapshot_sets pss "
-    "ON pss.tenant_id = 'local' AND pss.job_url = jobs.url"
+    "ON pss.tenant_id = jobs.tenant_id AND pss.job_id = jobs.job_id"
 )
 _NOT_CLOSED_ACTIVE_STATE: str = (
     f"(pss.latest_active_state IS NULL OR pss.latest_active_state NOT IN ({_CLOSED_ACTIVE_STATES_SQL}))"

--- a/workers/automation/src/jobctrl/digest.py
+++ b/workers/automation/src/jobctrl/digest.py
@@ -451,11 +451,23 @@ def _active_job_clauses(conn: sqlite3.Connection, alias: str) -> tuple[list[str]
         )
     if _table_exists(conn, "posting_snapshot_sets"):
         placeholders = ", ".join("?" for _ in _CLOSED_ACTIVE_STATES)
+        stable_reference = (
+            "job_id" in _table_columns(conn, "posting_snapshot_sets")
+        )
+        reference_predicate = (
+            "pss.job_id = ("
+            "SELECT j.job_id FROM jobs j "
+            f"WHERE j.tenant_id = {alias}.tenant_id "
+            f"AND j.url = {alias}.job_id LIMIT 1"
+            ")"
+            if stable_reference
+            else f"pss.job_url = {alias}.job_id"
+        )
         clauses.append(
             "NOT EXISTS ("
             "SELECT 1 FROM posting_snapshot_sets pss "
             f"WHERE pss.tenant_id = {alias}.tenant_id "
-            f"AND pss.job_url = {alias}.job_id "
+            f"AND {reference_predicate} "
             f"AND pss.latest_active_state IN ({placeholders})"
             ")"
         )

--- a/workers/automation/src/jobctrl/discovery/jobspy.py
+++ b/workers/automation/src/jobctrl/discovery/jobspy.py
@@ -789,7 +789,9 @@ def _find_stored_content_duplicate_survivor(conn: sqlite3.Connection, *, url: st
         SELECT j.title, j.company, j.site,
                COALESCE(je.full_description, j.full_description, j.description) AS description
         FROM jobs j
-        LEFT JOIN job_enrichments je ON je.job_url = j.url
+        LEFT JOIN job_enrichments je
+          ON je.tenant_id = j.tenant_id
+         AND je.job_id = j.job_id
         WHERE j.url = ?
         """,
         (url,),
@@ -841,7 +843,9 @@ def _find_content_duplicate_survivor(
                COALESCE(je.full_description, j.full_description) AS enriched_description,
                CASE WHEN d.job_url IS NULL THEN 0 ELSE 1 END AS is_deleted
         FROM jobs j
-        LEFT JOIN job_enrichments je ON je.job_url = j.url
+        LEFT JOIN job_enrichments je
+          ON je.tenant_id = j.tenant_id
+         AND je.job_id = j.job_id
         LEFT JOIN jobctrl_deleted_jobs d
           ON d.job_url = j.url
          AND (d.restored_at IS NULL OR julianday(d.restored_at) <= julianday(d.deleted_at))

--- a/workers/automation/src/jobctrl/domain/apply/repeat_application.py
+++ b/workers/automation/src/jobctrl/domain/apply/repeat_application.py
@@ -316,7 +316,7 @@ def _job_identity(conn, job_key: str) -> dict[str, Any] | None:
                COALESCE(
                  (SELECT je.application_url
                     FROM job_enrichments je
-                   WHERE je.job_url = j.url AND je.tenant_id = ?
+                   WHERE je.job_id = j.job_id AND je.tenant_id = ?
                    ORDER BY je.updated_at DESC LIMIT 1),
                  j.application_url,
                  j.url

--- a/workers/automation/src/jobctrl/enrichment/detail.py
+++ b/workers/automation/src/jobctrl/enrichment/detail.py
@@ -37,6 +37,7 @@ from playwright.sync_api import sync_playwright
 
 from jobctrl import database as db_module
 from jobctrl.database import (
+    close_connection,
     ensure_discovery_control_tables,
     init_db,
     reassign_discovery_identity_references,
@@ -67,7 +68,7 @@ from jobctrl.domain.enrichment.value_objects import (
     ApplicationUrl,
     FullDescription,
 )
-from jobctrl.domain.identifiers import JobId
+from jobctrl.domain.discovery.value_objects import PostingUrl
 from jobctrl.domain.errors import ConfigurationError, TransientNetworkError
 from jobctrl.domain.tenant import LOCAL_TENANT
 from jobctrl.infrastructure.enrichment import SqliteEnrichmentRepository
@@ -883,7 +884,7 @@ def _record_enrich_politeness_deferral(
     message = str(cascade_result.get("error") or "request budget exhausted; will retry")[:500]
     error = EnrichmentError(code="ENRICH_POLITENESS_DEFERRED", message=message, retryable=True)
     failed = aggregate.fail_attempt(error=error, finished_at=finished_at)
-    repo.save(failed)
+    repo.save_by_posting_url(failed, PostingUrl(value=url))
     set_stage_state(
         conn,
         url,
@@ -963,7 +964,10 @@ def _record_enrich_aggregate_failure(
 ) -> None:
     """Persist the canonical failed JobEnrichment attempt for an isolated crash."""
     repo = SqliteEnrichmentRepository(conn)
-    existing = repo.load(LOCAL_TENANT, JobId(url))
+    existing = repo.load_by_posting_url(
+        LOCAL_TENANT,
+        PostingUrl(value=url),
+    )
     if existing is not None and existing.is_enriched:
         # Do not destroy an accepted enrichment artifact from a later audit-only
         # failure path. The stage event below still preserves the crash.
@@ -976,7 +980,10 @@ def _record_enrich_aggregate_failure(
     )
     aggregate = existing or JobEnrichment.empty(
         tenant_id=LOCAL_TENANT,
-        job_id=JobId(url),
+        job_id=repo.job_id_for_posting_url(
+            LOCAL_TENANT,
+            PostingUrl(value=url),
+        ),
         updated_at=finished_at,
     )
     running = (
@@ -987,7 +994,10 @@ def _record_enrich_aggregate_failure(
             started_at=finished_at,
         )
     )
-    repo.save(running.fail_attempt(error=error, finished_at=finished_at))
+    repo.save_by_posting_url(
+        running.fail_attempt(error=error, finished_at=finished_at),
+        PostingUrl(value=url),
+    )
 
 
 def scrape_site_batch(
@@ -1143,7 +1153,10 @@ def scrape_site_batch(
 
                 # Already-enriched rows need no navigation — reaffirm and skip
                 # before the gate so a robots change can't relabel finished work.
-                aggregate = repo.load(LOCAL_TENANT, JobId(url))
+                aggregate = repo.load_by_posting_url(
+                    LOCAL_TENANT,
+                    PostingUrl(value=url),
+                )
                 if aggregate is not None and aggregate.is_enriched:
                     stats["processed"] += 1
                     stats["ok"] += 1
@@ -1193,7 +1206,10 @@ def scrape_site_batch(
 
                     aggregate = aggregate or JobEnrichment.empty(
                         tenant_id=LOCAL_TENANT,
-                        job_id=JobId(url),
+                        job_id=repo.job_id_for_posting_url(
+                            LOCAL_TENANT,
+                            PostingUrl(value=url),
+                        ),
                         updated_at=started_at,
                     )
                     aggregate = aggregate.start_attempt(
@@ -1283,7 +1299,10 @@ def scrape_site_batch(
                             extraction_tier=_tier_from_legacy(tier),
                             finished_at=finished_at,
                         )
-                        repo.save(succeeded)
+                        repo.save_by_posting_url(
+                            succeeded,
+                            PostingUrl(value=url),
+                        )
                         _record_posting_snapshot_from_cascade(
                             conn,
                             url=url,
@@ -1352,7 +1371,10 @@ def scrape_site_batch(
                         failed = aggregate.fail_attempt(
                             error=err, finished_at=finished_at
                         )
-                        repo.save(failed)
+                        repo.save_by_posting_url(
+                            failed,
+                            PostingUrl(value=url),
+                        )
                         set_stage_state(
                             conn,
                             url,
@@ -1413,7 +1435,10 @@ def scrape_site_batch(
                         failed = aggregate.fail_attempt(
                             error=err, finished_at=finished_at
                         )
-                        repo.save(failed)
+                        repo.save_by_posting_url(
+                            failed,
+                            PostingUrl(value=url),
+                        )
                         set_stage_state(
                             conn,
                             url,
@@ -1532,9 +1557,13 @@ def _record_posting_snapshot_from_cascade(
     resolved_source_id = _source_id_for_enriched_job(conn, url, fallback=source_id)
     try:
         repo = SqlitePostingSnapshotSetRepository(conn)
-        snapshot_set = repo.load(LOCAL_TENANT, JobId(url)) or PostingSnapshotSet.empty(
+        posting_url = PostingUrl(value=url)
+        snapshot_set = repo.load_by_posting_url(
+            LOCAL_TENANT,
+            posting_url,
+        ) or PostingSnapshotSet.empty(
             tenant_id=LOCAL_TENANT,
-            job_id=JobId(url),
+            job_id=repo.job_id_for_posting_url(LOCAL_TENANT, posting_url),
             updated_at=captured_at,
         )
         previous_active = snapshot_set.latest_active_state
@@ -1576,7 +1605,7 @@ def _record_posting_snapshot_from_cascade(
                 f"apply_url_present:{str(apply_url is not None).lower()}",
             ),
         )
-        repo.save(snapshot_set)
+        repo.save_by_posting_url(snapshot_set, posting_url)
 
         from jobctrl.state import record_job_event
 
@@ -1684,9 +1713,13 @@ def _record_posting_snapshot_failure_from_cascade(
     resolved_source_id = _source_id_for_enriched_job(conn, url, fallback=source_id)
     try:
         repo = SqlitePostingSnapshotSetRepository(conn)
-        snapshot_set = repo.load(LOCAL_TENANT, JobId(url)) or PostingSnapshotSet.empty(
+        posting_url = PostingUrl(value=url)
+        snapshot_set = repo.load_by_posting_url(
+            LOCAL_TENANT,
+            posting_url,
+        ) or PostingSnapshotSet.empty(
             tenant_id=LOCAL_TENANT,
-            job_id=JobId(url),
+            job_id=repo.job_id_for_posting_url(LOCAL_TENANT, posting_url),
             updated_at=failed_at,
         )
         error_class = str(cascade_result.get("error") or "DETAIL_ERROR")[:120]
@@ -1702,7 +1735,7 @@ def _record_posting_snapshot_failure_from_cascade(
             active_state=active_state,
             verified_at=failed_at,
         )
-        repo.save(snapshot_set)
+        repo.save_by_posting_url(snapshot_set, posting_url)
 
         from jobctrl.state import record_job_event
 
@@ -1908,7 +1941,9 @@ def _reset_authenticated_linkedin_retry_candidates(
         f"""
         SELECT j.url, e.current_status, e.application_url, e.attempts_json
         FROM jobs j
-        JOIN job_enrichments e ON e.job_url = j.url
+        JOIN job_enrichments e
+          ON e.tenant_id = j.tenant_id
+         AND e.job_id = j.job_id
         WHERE {' AND '.join(where)}
         ORDER BY e.updated_at DESC
         """,
@@ -1938,7 +1973,10 @@ def _reset_authenticated_linkedin_retry_candidates(
                     continue
                 url = str(row["url"] if isinstance(row, sqlite3.Row) else row[0])
                 now = utc_now()
-                aggregate = repo.load(LOCAL_TENANT, JobId(url))
+                aggregate = repo.load_by_posting_url(
+                    LOCAL_TENANT,
+                    PostingUrl(value=url),
+                )
                 if aggregate is None:
                     continue
 
@@ -1985,13 +2023,14 @@ def _reset_authenticated_linkedin_retry_candidates(
                     # never-resolving row is bounded by attempt count exactly
                     # like the extraction cascade; the description is never
                     # touched.
-                    repo.save(
+                    repo.save_by_posting_url(
                         aggregate.record_apply_url_recovery(
                             application_url=recovered,
                             extraction_tier=ExtractionTier.CSS_SELECTORS,
                             started_at=now,
                             finished_at=utc_now(),
-                        )
+                        ),
+                        PostingUrl(value=url),
                     )
                     record_job_event(
                         conn,
@@ -2022,7 +2061,10 @@ def _reset_authenticated_linkedin_retry_candidates(
                         break
                     continue
 
-                repo.save(aggregate.reset(reset_at=now))
+                repo.save_by_posting_url(
+                    aggregate.reset(reset_at=now),
+                    PostingUrl(value=url),
+                )
                 conn.execute(
                     "UPDATE jobs SET detail_error = NULL, detail_scraped_at = NULL WHERE url = ?",
                     (url,),
@@ -2230,24 +2272,26 @@ def _run_detail_scraper(
     gateway = PolitenessGateway()
 
     if workers > 1 and len(order) > 1:
+        database_row = conn.execute("PRAGMA database_list").fetchone()
+        worker_db_path = (
+            str(database_row[2] or "")
+            if database_row is not None and len(database_row) > 2
+            else ""
+        )
+        if not worker_db_path:
+            raise ConfigurationError(
+                "parallel enrichment requires a file-backed SQLite database"
+            )
+
         def _scrape_site(site: str) -> dict:
             if cancel_event is not None and cancel_event.is_set():
                 raise TransientNetworkError("enrichment canceled")
             jobs = site_jobs[site]
             log.info("%s -- %d jobs", site, len(jobs))
-            if cancel_event is None:
+            worker_conn = init_db(worker_db_path)
+            try:
                 stats = scrape_site_batch(
-                    None,
-                    site,
-                    jobs,
-                    max_jobs=max_per_site,
-                    gateway=gateway,
-                    run_budget=run_budget,
-                    on_job_enriched=on_job_enriched,
-                )
-            else:
-                stats = scrape_site_batch(
-                    None,
+                    worker_conn,
                     site,
                     jobs,
                     max_jobs=max_per_site,
@@ -2256,6 +2300,8 @@ def _run_detail_scraper(
                     run_budget=run_budget,
                     on_job_enriched=on_job_enriched,
                 )
+            finally:
+                close_connection(worker_db_path)
             log.info(
                 "%s summary: %d ok, %d partial, %d error | T1=%d T2=%d T3=%d",
                 site,

--- a/workers/automation/src/jobctrl/infrastructure/discovery/production_wiring.py
+++ b/workers/automation/src/jobctrl/infrastructure/discovery/production_wiring.py
@@ -782,18 +782,18 @@ def retire_invalid_source_jobs(
             COALESCE(MIN(o.source_id), '') AS source_id
         FROM jobs j
         LEFT JOIN job_enrichments e
-          ON e.tenant_id = ? AND e.job_url = j.url
+          ON e.tenant_id = j.tenant_id AND e.job_id = j.job_id
         LEFT JOIN job_canonical_identities c
-          ON c.tenant_id = ? AND c.job_id = j.job_id
+          ON c.tenant_id = j.tenant_id AND c.job_id = j.job_id
         LEFT JOIN job_source_observations o
-          ON o.tenant_id = ? AND o.job_id = j.job_id
+          ON o.tenant_id = j.tenant_id AND o.job_id = j.job_id
         LEFT JOIN jobctrl_deleted_jobs d
           ON d.job_url = j.url
          AND (d.restored_at IS NULL OR julianday(d.restored_at) <= julianday(d.deleted_at))
-        WHERE d.job_url IS NULL
+        WHERE j.tenant_id = ? AND d.job_url IS NULL
         GROUP BY j.url
         """,
-        (str(LOCAL_TENANT), str(LOCAL_TENANT), str(LOCAL_TENANT)),
+        (str(LOCAL_TENANT),),
     ).fetchall()
 
     for row in rows:
@@ -1204,10 +1204,13 @@ def build_discovery_acceptance_report(
         """
         SELECT COUNT(*)
         FROM jobs j
-        JOIN job_enrichments e ON e.job_url = j.url AND e.tenant_id = ?
+        JOIN job_enrichments e
+          ON e.tenant_id = j.tenant_id
+         AND e.job_id = j.job_id
         LEFT JOIN discovery_quarantine_entries q
           ON q.tenant_id = ? AND q.job_id = j.url AND q.status = 'pending'
-        WHERE e.current_status = 'enriched'
+        WHERE j.tenant_id = ?
+          AND e.current_status = 'enriched'
           AND j.fit_score IS NULL
           AND q.job_id IS NULL
         """,

--- a/workers/automation/src/jobctrl/infrastructure/discovery/sqlite_repository.py
+++ b/workers/automation/src/jobctrl/infrastructure/discovery/sqlite_repository.py
@@ -779,7 +779,9 @@ class SqliteJobRepository:
                        AS enriched_description,
                    CASE WHEN d.job_url IS NULL THEN 0 ELSE 1 END AS is_deleted
             FROM jobs j
-            LEFT JOIN job_enrichments je ON je.job_url = j.url
+            LEFT JOIN job_enrichments je
+              ON je.tenant_id = j.tenant_id
+             AND je.job_id = j.job_id
             LEFT JOIN jobctrl_deleted_jobs d
               ON d.job_url = j.url
              AND (d.restored_at IS NULL OR julianday(d.restored_at) <= julianday(d.deleted_at))

--- a/workers/automation/src/jobctrl/infrastructure/enrichment/sqlite_repository.py
+++ b/workers/automation/src/jobctrl/infrastructure/enrichment/sqlite_repository.py
@@ -2,9 +2,9 @@
 
 Persists ``JobEnrichment`` aggregates to the ``job_enrichments`` table
 created by ``database.ensure_enrichment_tables``. The aggregate identity
-is ``(tenant_id, job_id)`` and the table primary key is ``job_url``;
-local mode collapses ``JobId`` onto the legacy ``jobs.url`` per the
-migration plan §8 (deferred narrowing).
+and table primary key are both ``(tenant_id, job_id)``. Posting URLs are
+resolved only through explicit compatibility methods while legacy workflow
+inputs are cut over.
 
 The repository is an upsert on every save — versioning is per-attempt
 inside the aggregate's ``attempts_json`` blob, not per-row.
@@ -14,8 +14,10 @@ from __future__ import annotations
 
 import json
 import sqlite3
+from dataclasses import replace
 from typing import Any
 
+from jobctrl.domain.discovery.value_objects import PostingUrl
 from jobctrl.domain.enrichment.aggregate import (
     EnrichmentLifecycle,
     JobEnrichment,
@@ -43,7 +45,7 @@ from jobctrl.domain.enrichment.value_objects import (
     ExtractionTier,
     FullDescription,
 )
-from jobctrl.domain.identifiers import JobId
+from jobctrl.domain.identifiers import JobId, canonical_job_id
 from jobctrl.domain.tenant import LOCAL_TENANT, TenantId
 
 
@@ -57,20 +59,65 @@ class SqliteEnrichmentRepository:
     """
 
     def __init__(self, conn: sqlite3.Connection) -> None:
+        from jobctrl.infrastructure.discovery.sqlite_identity_resolver import (
+            SqliteJobIdentityResolver,
+        )
+
         self._conn = conn
+        self._identity_resolver = SqliteJobIdentityResolver(conn)
 
     # ------------------------------------------------------------------
     # Read
     # ------------------------------------------------------------------
 
     def load(self, tenant_id: TenantId, job_id: JobId) -> JobEnrichment | None:
+        resolved_job_id = self._resolve_job_id(tenant_id, job_id)
+        if resolved_job_id is None:
+            return None
+        return self._load_resolved(tenant_id, resolved_job_id)
+
+    def load_by_posting_url(
+        self,
+        tenant_id: TenantId,
+        posting_url: PostingUrl,
+    ) -> JobEnrichment | None:
+        """Resolve one bounded legacy URL input before stable lookup."""
+        identity = self._identity_resolver.resolve_by_posting_url(
+            tenant_id,
+            posting_url,
+        )
+        if identity is None:
+            return None
+        return self._load_resolved(tenant_id, identity.job_id)
+
+    def job_id_for_posting_url(
+        self,
+        tenant_id: TenantId,
+        posting_url: PostingUrl,
+    ) -> JobId:
+        """Return the stable identity owned by a legacy posting URL."""
+        identity = self._identity_resolver.resolve_by_posting_url(
+            tenant_id,
+            posting_url,
+        )
+        if identity is None:
+            raise KeyError(
+                f"No stable Job identity for enrichment: {posting_url.value}"
+            )
+        return identity.job_id
+
+    def _load_resolved(
+        self,
+        tenant_id: TenantId,
+        job_id: JobId,
+    ) -> JobEnrichment | None:
         row = self._conn.execute(
             """
-            SELECT job_url, tenant_id, current_status, full_description,
+            SELECT job_id, tenant_id, current_status, full_description,
                    application_url, enriched_at, extraction_tier,
                    attempts_json, updated_at
             FROM job_enrichments
-            WHERE job_url = ? AND tenant_id = ?
+            WHERE job_id = ? AND tenant_id = ?
             LIMIT 1
             """,
             (str(job_id), str(tenant_id)),
@@ -92,12 +139,13 @@ class SqliteEnrichmentRepository:
         flight) or ``failed`` (the orchestrator has the failed list to
         decide whether to retry).
         """
-        params: list[Any] = [str(tenant_id)]
+        params: list[Any] = [str(tenant_id), str(tenant_id)]
         sql = (
-            "SELECT j.url FROM jobs j "
+            "SELECT j.job_id FROM jobs j "
             "LEFT JOIN job_enrichments e "
-            "  ON e.job_url = j.url AND e.tenant_id = ? "
-            "WHERE e.job_url IS NULL OR e.current_status = 'pending' "
+            "  ON e.job_id = j.job_id AND e.tenant_id = ? "
+            "WHERE j.tenant_id = ? "
+            "  AND (e.job_id IS NULL OR e.current_status = 'pending') "
             "ORDER BY j.discovered_at DESC NULLS LAST"
         )
         if limit > 0:
@@ -109,7 +157,7 @@ class SqliteEnrichmentRepository:
     def list_failed(self, tenant_id: TenantId, *, limit: int = 0) -> list[JobEnrichment]:
         params: list[Any] = [str(tenant_id)]
         sql = (
-            "SELECT job_url, tenant_id, current_status, full_description, "
+            "SELECT job_id, tenant_id, current_status, full_description, "
             "application_url, enriched_at, extraction_tier, attempts_json, "
             "updated_at "
             "FROM job_enrichments "
@@ -127,6 +175,34 @@ class SqliteEnrichmentRepository:
     # ------------------------------------------------------------------
 
     def save(self, enrichment: JobEnrichment) -> None:
+        resolved_job_id = self._resolve_job_id(
+            enrichment.tenant_id,
+            enrichment.job_id,
+        )
+        if resolved_job_id is None:
+            raise KeyError(
+                "No stable Job identity for enrichment: "
+                f"{enrichment.job_id}"
+            )
+        self._save_resolved(
+            replace(enrichment, job_id=resolved_job_id),
+        )
+
+    def save_by_posting_url(
+        self,
+        enrichment: JobEnrichment,
+        posting_url: PostingUrl,
+    ) -> None:
+        """Persist an aggregate supplied by a legacy URL-bearing caller."""
+        stable_job_id = self.job_id_for_posting_url(
+            enrichment.tenant_id,
+            posting_url,
+        )
+        self._save_resolved(
+            replace(enrichment, job_id=stable_job_id),
+        )
+
+    def _save_resolved(self, enrichment: JobEnrichment) -> None:
         attempts_json = json.dumps(
             [a.to_dict() for a in enrichment.attempts],
             sort_keys=True,
@@ -134,12 +210,11 @@ class SqliteEnrichmentRepository:
         self._conn.execute(
             """
             INSERT INTO job_enrichments (
-                job_url, tenant_id, current_status, full_description,
+                job_id, tenant_id, current_status, full_description,
                 application_url, enriched_at, extraction_tier,
                 attempts_json, updated_at
             ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-            ON CONFLICT(job_url) DO UPDATE SET
-                tenant_id = excluded.tenant_id,
+            ON CONFLICT(tenant_id, job_id) DO UPDATE SET
                 current_status = excluded.current_status,
                 full_description = excluded.full_description,
                 application_url = excluded.application_url,
@@ -178,10 +253,39 @@ class SqliteEnrichmentRepository:
     # Internal helpers
     # ------------------------------------------------------------------
 
+    def _resolve_job_id(
+        self,
+        tenant_id: TenantId,
+        job_id: JobId,
+    ) -> JobId | None:
+        raw_reference = str(job_id or "").strip()
+        if not raw_reference:
+            raise ValueError("job_id must be non-empty")
+        try:
+            stable_job_id = canonical_job_id(raw_reference)
+        except ValueError:
+            stable_job_id = None
+        identity = (
+            self._identity_resolver.resolve_by_job_id(
+                tenant_id,
+                stable_job_id,
+            )
+            if stable_job_id is not None
+            else None
+        )
+        if identity is None:
+            # Non-UUID legacy references are unambiguous. UUID-shaped posting
+            # URLs must use ``load_by_posting_url`` / ``save_by_posting_url``.
+            identity = self._identity_resolver.resolve_by_posting_url(
+                tenant_id,
+                PostingUrl(raw_reference),
+            )
+        return identity.job_id if identity is not None else None
+
     @staticmethod
     def _row_to_enrichment(row: Any, tenant_id: TenantId | None = None) -> JobEnrichment:
         if isinstance(row, sqlite3.Row):
-            job_url = row["job_url"]
+            job_id = row["job_id"]
             current_status = row["current_status"]
             full_description = row["full_description"]
             application_url = row["application_url"]
@@ -191,7 +295,7 @@ class SqliteEnrichmentRepository:
             updated_at = row["updated_at"]
         else:
             (
-                job_url,
+                job_id,
                 _tenant,
                 current_status,
                 full_description,
@@ -210,7 +314,7 @@ class SqliteEnrichmentRepository:
         # to surface that as a clear error rather than a silent rewrite.
         return JobEnrichment(
             tenant_id=tenant_id or LOCAL_TENANT,
-            job_id=JobId(str(job_url)),
+            job_id=JobId(str(job_id)),
             current_status=str(current_status or EnrichmentLifecycle.PENDING),
             attempts=attempts,
             full_description=(
@@ -229,14 +333,59 @@ class SqlitePostingSnapshotSetRepository:
     """SQLite-backed ``PostingSnapshotSetRepository`` implementation."""
 
     def __init__(self, conn: sqlite3.Connection) -> None:
+        from jobctrl.infrastructure.discovery.sqlite_identity_resolver import (
+            SqliteJobIdentityResolver,
+        )
+
         self._conn = conn
+        self._identity_resolver = SqliteJobIdentityResolver(conn)
 
     def load(self, tenant_id: TenantId, job_id: JobId) -> PostingSnapshotSet | None:
+        resolved_job_id = self._resolve_job_id(tenant_id, job_id)
+        if resolved_job_id is None:
+            return None
+        return self._load_resolved(tenant_id, resolved_job_id)
+
+    def load_by_posting_url(
+        self,
+        tenant_id: TenantId,
+        posting_url: PostingUrl,
+    ) -> PostingSnapshotSet | None:
+        """Resolve one bounded legacy URL input before stable lookup."""
+        identity = self._identity_resolver.resolve_by_posting_url(
+            tenant_id,
+            posting_url,
+        )
+        if identity is None:
+            return None
+        return self._load_resolved(tenant_id, identity.job_id)
+
+    def job_id_for_posting_url(
+        self,
+        tenant_id: TenantId,
+        posting_url: PostingUrl,
+    ) -> JobId:
+        identity = self._identity_resolver.resolve_by_posting_url(
+            tenant_id,
+            posting_url,
+        )
+        if identity is None:
+            raise KeyError(
+                "No stable Job identity for posting snapshot: "
+                f"{posting_url.value}"
+            )
+        return identity.job_id
+
+    def _load_resolved(
+        self,
+        tenant_id: TenantId,
+        job_id: JobId,
+    ) -> PostingSnapshotSet | None:
         row = self._conn.execute(
             """
             SELECT snapshot_set_json
             FROM posting_snapshot_sets
-            WHERE tenant_id = ? AND job_url = ?
+            WHERE tenant_id = ? AND job_id = ?
             LIMIT 1
             """,
             (str(tenant_id), str(job_id)),
@@ -248,15 +397,42 @@ class SqlitePostingSnapshotSetRepository:
         return _snapshot_set_from_dict(data)
 
     def save(self, snapshot_set: PostingSnapshotSet) -> None:
+        resolved_job_id = self._resolve_job_id(
+            snapshot_set.tenant_id,
+            snapshot_set.job_id,
+        )
+        if resolved_job_id is None:
+            raise KeyError(
+                "No stable Job identity for posting snapshot: "
+                f"{snapshot_set.job_id}"
+            )
+        self._save_resolved(
+            replace(snapshot_set, job_id=resolved_job_id),
+        )
+
+    def save_by_posting_url(
+        self,
+        snapshot_set: PostingSnapshotSet,
+        posting_url: PostingUrl,
+    ) -> None:
+        stable_job_id = self.job_id_for_posting_url(
+            snapshot_set.tenant_id,
+            posting_url,
+        )
+        self._save_resolved(
+            replace(snapshot_set, job_id=stable_job_id),
+        )
+
+    def _save_resolved(self, snapshot_set: PostingSnapshotSet) -> None:
         latest = snapshot_set.latest_snapshot
         self._conn.execute(
             """
             INSERT INTO posting_snapshot_sets (
-                tenant_id, job_url, snapshot_set_json, latest_snapshot_version,
+                tenant_id, job_id, snapshot_set_json, latest_snapshot_version,
                 latest_active_state, latest_confidence, latest_quarantine_reason,
                 updated_at
             ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-            ON CONFLICT(tenant_id, job_url) DO UPDATE SET
+            ON CONFLICT(tenant_id, job_id) DO UPDATE SET
                 snapshot_set_json = excluded.snapshot_set_json,
                 latest_snapshot_version = excluded.latest_snapshot_version,
                 latest_active_state = excluded.latest_active_state,
@@ -285,7 +461,7 @@ class SqlitePostingSnapshotSetRepository:
     ) -> list[DedupeIndexEntry]:
         rows = self._conn.execute(
             """
-            SELECT job_url, snapshot_set_json
+            SELECT job_id, snapshot_set_json
             FROM posting_snapshot_sets
             WHERE tenant_id = ?
             ORDER BY updated_at DESC
@@ -294,8 +470,8 @@ class SqlitePostingSnapshotSetRepository:
         ).fetchall()
         entries: list[DedupeIndexEntry] = []
         for row in rows:
-            job_url = row["job_url"] if isinstance(row, sqlite3.Row) else row[0]
-            if exclude_job_id is not None and str(job_url) == str(exclude_job_id):
+            job_id = row["job_id"] if isinstance(row, sqlite3.Row) else row[0]
+            if exclude_job_id is not None and str(job_id) == str(exclude_job_id):
                 continue
             raw_json = row["snapshot_set_json"] if isinstance(row, sqlite3.Row) else row[1]
             data = json.loads(raw_json) if raw_json else {}
@@ -311,6 +487,33 @@ class SqlitePostingSnapshotSetRepository:
                 )
             )
         return entries
+
+    def _resolve_job_id(
+        self,
+        tenant_id: TenantId,
+        job_id: JobId,
+    ) -> JobId | None:
+        raw_reference = str(job_id or "").strip()
+        if not raw_reference:
+            raise ValueError("job_id must be non-empty")
+        try:
+            stable_job_id = canonical_job_id(raw_reference)
+        except ValueError:
+            stable_job_id = None
+        identity = (
+            self._identity_resolver.resolve_by_job_id(
+                tenant_id,
+                stable_job_id,
+            )
+            if stable_job_id is not None
+            else None
+        )
+        if identity is None:
+            identity = self._identity_resolver.resolve_by_posting_url(
+                tenant_id,
+                PostingUrl(raw_reference),
+            )
+        return identity.job_id if identity is not None else None
 
 
 def _snapshot_set_from_dict(data: dict[str, Any]) -> PostingSnapshotSet:

--- a/workers/automation/src/jobctrl/infrastructure/projections/projection_builder.py
+++ b/workers/automation/src/jobctrl/infrastructure/projections/projection_builder.py
@@ -2517,13 +2517,30 @@ class ProjectionBuilder:
 
     def _load_enrichment(self, job_url: str) -> dict:
         try:
+            stable_reference = _has_column(
+                self._conn,
+                "job_enrichments",
+                "job_id",
+            )
             row = self._conn.execute(
-                """
+                (
+                    """
+                SELECT full_description, application_url, enriched_at,
+                       current_status, extraction_tier
+                FROM job_enrichments je
+                JOIN jobs j
+                  ON j.tenant_id = je.tenant_id
+                 AND j.job_id = je.job_id
+                WHERE j.url = ?
+                    """
+                    if stable_reference
+                    else """
                 SELECT full_description, application_url, enriched_at,
                        current_status, extraction_tier
                 FROM job_enrichments
                 WHERE job_url = ?
-                """,
+                    """
+                ),
                 (job_url,),
             ).fetchone()
         except sqlite3.OperationalError:
@@ -2732,15 +2749,34 @@ class ProjectionBuilder:
 
     def _closed_projection_jobs(self) -> set[str]:
         try:
+            stable_reference = _has_column(
+                self._conn,
+                "posting_snapshot_sets",
+                "job_id",
+            )
             rows = self._conn.execute(
-                """
+                (
+                    """
+                SELECT j.url AS job_url
+                FROM posting_snapshot_sets pss
+                JOIN jobs j
+                  ON j.tenant_id = pss.tenant_id
+                 AND j.job_id = pss.job_id
+                WHERE pss.tenant_id = ?
+                  AND pss.latest_active_state IN (
+                    'closed', 'expired', 'removed', 'location_incompatible'
+                  )
+                    """
+                    if stable_reference
+                    else """
                 SELECT job_url
                 FROM posting_snapshot_sets
                 WHERE tenant_id = ?
                   AND latest_active_state IN (
                     'closed', 'expired', 'removed', 'location_incompatible'
                   )
-                """,
+                    """
+                ),
                 (str(self._tenant_id),),
             ).fetchall()
         except sqlite3.OperationalError:
@@ -2920,17 +2956,36 @@ class ProjectionBuilder:
         # ``jobctrl_deleted_jobs`` so the user-visible value agrees
         # regardless of which writer (Python or TS) ran last.
         try:
+            stable_snapshot_reference = _has_column(
+                self._conn,
+                "posting_snapshot_sets",
+                "job_id",
+            )
+            snapshot_join = (
+                """
+                    LEFT JOIN jobs snapshot_job
+                        ON snapshot_job.tenant_id = arp.tenant_id
+                       AND snapshot_job.url = arp.job_id
+                    LEFT JOIN posting_snapshot_sets pss
+                        ON pss.tenant_id = arp.tenant_id
+                       AND pss.job_id = snapshot_job.job_id
+                """
+                if stable_snapshot_reference
+                else """
+                    LEFT JOIN posting_snapshot_sets pss
+                        ON pss.tenant_id = arp.tenant_id
+                       AND pss.job_url = arp.job_id
+                """
+            )
             dry_runs = int(
                 self._conn.execute(
-                    """
+                    f"""
                     SELECT COUNT(*)
                     FROM apply_run_projections arp
                     LEFT JOIN jobctrl_deleted_jobs d
                         ON d.job_url = arp.job_id
                        AND (d.restored_at IS NULL OR julianday(d.restored_at) <= julianday(d.deleted_at))
-                    LEFT JOIN posting_snapshot_sets pss
-                        ON pss.tenant_id = arp.tenant_id
-                       AND pss.job_url = arp.job_id
+                    {snapshot_join}
                     WHERE arp.dry_run = 1
                       AND d.job_url IS NULL
                       AND (

--- a/workers/automation/src/jobctrl/pipeline/current_policy_selectors.py
+++ b/workers/automation/src/jobctrl/pipeline/current_policy_selectors.py
@@ -24,14 +24,21 @@ def scoring_current_policy_job_urls(
     current_version = _current_scoring_policy_version(conn, tenant_id)
     requested = _clean_job_urls(job_urls)
     requested_sql, requested_params = _requested_filter("j.url", requested)
-    active_sql = _active_job_filter(conn, "j.url")
+    active_sql = _active_job_filter(
+        conn,
+        "j.url",
+        tenant_expr="j.tenant_id",
+        job_id_expr="j.job_id",
+    )
     limit_sql, limit_params = _limit_filter(limit)
 
     rows = conn.execute(
         f"""
         SELECT j.url
         FROM jobs j
-        LEFT JOIN job_enrichments je ON je.job_url = j.url
+        LEFT JOIN job_enrichments je
+          ON je.tenant_id = j.tenant_id
+         AND je.job_id = j.job_id
         LEFT JOIN (
             SELECT s.job_url, s.trace_json, s.correction_json
             FROM job_scores s
@@ -76,7 +83,12 @@ def tailoring_current_policy_job_urls(
     current_version = _current_tailoring_policy_version(conn, tenant_id)
     requested = _clean_job_urls(job_urls)
     requested_sql, requested_params = _requested_filter("j.url", requested)
-    active_sql = _active_job_filter(conn, "j.url")
+    active_sql = _active_job_filter(
+        conn,
+        "j.url",
+        tenant_expr="j.tenant_id",
+        job_id_expr="j.job_id",
+    )
     limit_sql, limit_params = _limit_filter(limit)
     effective_tailor_path = (
         "((lm.materials_job_url IS NOT NULL AND lm.tailored_resume_path IS NOT NULL "
@@ -89,7 +101,9 @@ def tailoring_current_policy_job_urls(
         f"""
         SELECT j.url
         FROM jobs j
-        LEFT JOIN job_enrichments je ON je.job_url = j.url
+        LEFT JOIN job_enrichments je
+          ON je.tenant_id = j.tenant_id
+         AND je.job_id = j.job_id
         LEFT JOIN (
             SELECT s.job_url, s.fit_score, s.breakdown_json
             FROM job_scores s
@@ -187,7 +201,13 @@ def _current_tailoring_policy_version(conn: sqlite3.Connection, tenant_id: str) 
     return _positive_int(row[0] if row else None, default=1)
 
 
-def _active_job_filter(conn: sqlite3.Connection, job_url_expr: str) -> str:
+def _active_job_filter(
+    conn: sqlite3.Connection,
+    job_url_expr: str,
+    *,
+    tenant_expr: str,
+    job_id_expr: str,
+) -> str:
     clauses: list[str] = []
     if _table_exists(conn, "jobctrl_deleted_jobs"):
         clauses.append(
@@ -208,7 +228,8 @@ def _active_job_filter(conn: sqlite3.Connection, job_url_expr: str) -> str:
         clauses.append(
             "NOT EXISTS ("
             "SELECT 1 FROM posting_snapshot_sets pss "
-            f"WHERE pss.tenant_id = 'local' AND pss.job_url = {job_url_expr} "
+            f"WHERE pss.tenant_id = {tenant_expr} "
+            f"AND pss.job_id = {job_id_expr} "
             "AND pss.latest_active_state IN "
             "('closed', 'expired', 'removed', 'location_incompatible')"
             ")"

--- a/workers/automation/src/jobctrl/scoring/scorer.py
+++ b/workers/automation/src/jobctrl/scoring/scorer.py
@@ -1015,7 +1015,9 @@ def _preferred_direct_score_for_repost(
                COALESCE(c.ats_kind, 'other') AS ats_kind,
                s.scored_at
         FROM jobs j
-        LEFT JOIN job_enrichments je ON je.job_url = j.url
+        LEFT JOIN job_enrichments je
+          ON je.tenant_id = j.tenant_id
+         AND je.job_id = j.job_id
         LEFT JOIN job_canonical_identities c
           ON c.tenant_id = ? AND c.job_id = j.job_id
         {deleted_join}
@@ -1142,7 +1144,9 @@ def _reusable_scores_by_content_key(
         SELECT j.url, j.title, j.company,
                COALESCE(je.full_description, j.full_description) AS full_description
         FROM jobs j
-        LEFT JOIN job_enrichments je ON je.job_url = j.url
+        LEFT JOIN job_enrichments je
+          ON je.tenant_id = j.tenant_id
+         AND je.job_id = j.job_id
         INNER JOIN (
             SELECT s.job_url, MAX(s.version) AS max_version
             FROM job_scores s

--- a/workers/automation/src/jobctrl/state.py
+++ b/workers/automation/src/jobctrl/state.py
@@ -855,19 +855,23 @@ def _reset_enrichment_aggregate(conn, job_url: str) -> None:
     The repository is loaded inline so we don't hit a circular import
     (the enrichment package imports ``state``).
     """
-    from jobctrl.domain.identifiers import JobId
+    from jobctrl.domain.discovery.value_objects import PostingUrl
     from jobctrl.domain.tenant import LOCAL_TENANT
     from jobctrl.infrastructure.enrichment import SqliteEnrichmentRepository
 
     repo = SqliteEnrichmentRepository(conn)
-    aggregate = repo.load(LOCAL_TENANT, JobId(job_url))
+    posting_url = PostingUrl(value=job_url)
+    aggregate = repo.load_by_posting_url(LOCAL_TENANT, posting_url)
     if aggregate is None:
         # Nothing to reset — the next pipeline run will create the row
         # in the empty state when start_attempt fires.
         return
     if aggregate.is_pending and aggregate.full_description is None:
         return
-    repo.save(aggregate.reset(reset_at=utc_now()))
+    repo.save_by_posting_url(
+        aggregate.reset(reset_at=utc_now()),
+        posting_url,
+    )
 
 
 def _resettable_material_generation(conn, job_url: str, stage: str) -> int | None:

--- a/workers/automation/tests/test_apply_queue_selectors.py
+++ b/workers/automation/tests/test_apply_queue_selectors.py
@@ -69,17 +69,21 @@ def _insert_apply_ready_job(
 
 
 def _mark_closed(conn, url: str, state: str = "removed") -> None:
+    job_id = conn.execute(
+        "SELECT job_id FROM jobs WHERE tenant_id = ? AND url = ?",
+        (str(LOCAL_TENANT), url),
+    ).fetchone()[0]
     conn.execute(
         """
         INSERT INTO posting_snapshot_sets (
-            tenant_id, job_url, snapshot_set_json, latest_snapshot_version,
+            tenant_id, job_id, snapshot_set_json, latest_snapshot_version,
             latest_active_state, updated_at
         ) VALUES (?, ?, '{}', 0, ?, ?)
-        ON CONFLICT(tenant_id, job_url) DO UPDATE SET
+        ON CONFLICT(tenant_id, job_id) DO UPDATE SET
             latest_active_state = excluded.latest_active_state,
             updated_at = excluded.updated_at
         """,
-        (str(LOCAL_TENANT), url, state, utc_now()),
+        (str(LOCAL_TENANT), job_id, state, utc_now()),
     )
     conn.commit()
 

--- a/workers/automation/tests/test_apply_regressions.py
+++ b/workers/automation/tests/test_apply_regressions.py
@@ -130,17 +130,21 @@ def test_unsafe_url_failure_is_permanent() -> None:
 
 
 def _mark_closed(conn: sqlite3.Connection, url: str, state: str = "removed") -> None:
+    job_id = conn.execute(
+        "SELECT job_id FROM jobs WHERE tenant_id = 'local' AND url = ?",
+        (url,),
+    ).fetchone()[0]
     conn.execute(
         """
         INSERT INTO posting_snapshot_sets (
-            tenant_id, job_url, snapshot_set_json, latest_snapshot_version,
+            tenant_id, job_id, snapshot_set_json, latest_snapshot_version,
             latest_active_state, updated_at
         ) VALUES ('local', ?, '{}', 0, ?, ?)
-        ON CONFLICT(tenant_id, job_url) DO UPDATE SET
+        ON CONFLICT(tenant_id, job_id) DO UPDATE SET
             latest_active_state = excluded.latest_active_state,
             updated_at = excluded.updated_at
         """,
-        (url, state, utc_now()),
+        (job_id, state, utc_now()),
     )
     conn.commit()
 

--- a/workers/automation/tests/test_dashboard_projection.py
+++ b/workers/automation/tests/test_dashboard_projection.py
@@ -35,17 +35,21 @@ def _seed_job(conn: sqlite3.Connection, url: str, *, site: str = "ExampleCo") ->
 
 
 def _mark_closed(conn: sqlite3.Connection, url: str, state: str = "removed") -> None:
+    job_id = conn.execute(
+        "SELECT job_id FROM jobs WHERE tenant_id = 'local' AND url = ?",
+        (url,),
+    ).fetchone()[0]
     conn.execute(
         """
         INSERT INTO posting_snapshot_sets (
-            tenant_id, job_url, snapshot_set_json, latest_snapshot_version,
+            tenant_id, job_id, snapshot_set_json, latest_snapshot_version,
             latest_active_state, updated_at
         ) VALUES ('local', ?, '{}', 0, ?, ?)
-        ON CONFLICT(tenant_id, job_url) DO UPDATE SET
+        ON CONFLICT(tenant_id, job_id) DO UPDATE SET
             latest_active_state = excluded.latest_active_state,
             updated_at = excluded.updated_at
         """,
-        (url, state, utc_now()),
+        (job_id, state, utc_now()),
     )
     conn.commit()
 

--- a/workers/automation/tests/test_discover_reliability.py
+++ b/workers/automation/tests/test_discover_reliability.py
@@ -517,9 +517,12 @@ def test_scrape_site_batch_isolates_single_job_failure(
 
         bad_enrichment = conn.execute(
             """
-            SELECT current_status, attempts_json
-            FROM job_enrichments
-            WHERE job_url = ?
+            SELECT je.current_status, je.attempts_json
+            FROM job_enrichments je
+            JOIN jobs j
+              ON j.tenant_id = je.tenant_id
+             AND j.job_id = je.job_id
+            WHERE j.url = ?
             """,
             (bad_url,),
         ).fetchone()
@@ -544,7 +547,14 @@ def test_scrape_site_batch_isolates_single_job_failure(
         assert payload["retryable"] is True
 
         good = conn.execute(
-            "SELECT current_status FROM job_enrichments WHERE job_url = ?",
+            """
+            SELECT je.current_status
+            FROM job_enrichments je
+            JOIN jobs j
+              ON j.tenant_id = je.tenant_id
+             AND j.job_id = je.job_id
+            WHERE j.url = ?
+            """,
             (good_url,),
         ).fetchone()
         assert good["current_status"] == "enriched"

--- a/workers/automation/tests/test_discovery_identity.py
+++ b/workers/automation/tests/test_discovery_identity.py
@@ -1058,14 +1058,23 @@ def test_discover_jobs_use_case_matches_fresh_listing_against_enriched_owner(
         ],
         run_id="run-greenhouse",
     )
+    survivor_job_id = conn.execute(
+        "SELECT job_id FROM jobs WHERE tenant_id = 'local' AND url = ?",
+        (survivor,),
+    ).fetchone()[0]
     conn.execute(
         """
         INSERT INTO job_enrichments (
-            job_url, tenant_id, current_status, full_description,
+            job_id, tenant_id, current_status, full_description,
             enriched_at, updated_at
         ) VALUES (?, 'local', 'enriched', ?, ?, ?)
         """,
-        (survivor, enriched, "2026-05-12T01:00:00Z", "2026-05-12T01:00:00Z"),
+        (
+            survivor_job_id,
+            enriched,
+            "2026-05-12T01:00:00Z",
+            "2026-05-12T01:00:00Z",
+        ),
     )
     conn.commit()
     publisher.events.clear()

--- a/workers/automation/tests/test_discovery_identity_reference_migration.py
+++ b/workers/automation/tests/test_discovery_identity_reference_migration.py
@@ -220,7 +220,7 @@ def test_v7_discovery_references_migrate_to_stable_job_id_and_reopen(
     init_db(db_path)
     close_connection(db_path)
 
-    assert _user_version(db_path) == SCHEMA_VERSION == 10
+    assert _user_version(db_path) == SCHEMA_VERSION == 11
     assert "job_id" in _columns(db_path, "job_source_observations")
     assert "job_url" not in _columns(db_path, "job_source_observations")
     assert "job_id" in _columns(db_path, "job_canonical_identities")

--- a/workers/automation/tests/test_discovery_production_wiring.py
+++ b/workers/automation/tests/test_discovery_production_wiring.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import sqlite3
 import sys
+import uuid
 from io import StringIO
 from pathlib import Path
 from typing import Any, Iterator
@@ -497,8 +498,12 @@ def test_canonical_ats_scheduler_routes_postings_through_discovery_use_case(
     }
     enrichments = conn.execute(
         """
-        SELECT job_url, current_status, full_description, extraction_tier
-        FROM job_enrichments
+        SELECT j.url AS job_url, je.current_status, je.full_description,
+               je.extraction_tier
+        FROM job_enrichments je
+        JOIN jobs j
+          ON j.tenant_id = je.tenant_id
+         AND j.job_id = je.job_id
         """
     ).fetchall()
     assert {row["job_url"] for row in enrichments} == expected_urls
@@ -951,11 +956,14 @@ def test_discovery_hygiene_treats_serialized_null_descriptions_as_missing(
     conn.execute(
         """
         INSERT INTO job_enrichments (
-            job_url, tenant_id, current_status, full_description, updated_at
+            job_id, tenant_id, current_status, full_description, updated_at
         ) VALUES (?, ?, ?, ?, ?)
         """,
         (
-            "https://www.linkedin.com/jobs/view/enrichment-sentinel-with-fallback",
+            _stable_job_id(
+                conn,
+                "https://www.linkedin.com/jobs/view/enrichment-sentinel-with-fallback",
+            ),
             "local",
             "success",
             "<NA>",
@@ -993,6 +1001,132 @@ def test_discovery_hygiene_treats_serialized_null_descriptions_as_missing(
     assert "missing_description" in deleted[
         "https://www.linkedin.com/jobs/view/nan-description"
     ]
+
+
+def test_discovery_hygiene_does_not_join_jobs_across_tenants(
+    conn: sqlite3.Connection,
+) -> None:
+    shared_job_id = str(uuid.uuid4())
+    local_url = "https://example.com/jobs/local-engineering-manager"
+    foreign_url = "https://example.com/jobs/foreign-sales-manager"
+    conn.executemany(
+        """
+        INSERT INTO jobs (
+            url, tenant_id, job_id, title, description, location,
+            site, strategy, discovered_at
+        ) VALUES (?, ?, ?, ?, ?, ?, 'linkedin', 'jobspy', ?)
+        """,
+        (
+            (
+                local_url,
+                "local",
+                shared_job_id,
+                "Engineering Manager",
+                "Lead engineering teams in Barcelona.",
+                "Barcelona, Spain",
+                "2026-07-29T10:00:00+00:00",
+            ),
+            (
+                foreign_url,
+                "other-tenant",
+                shared_job_id,
+                "Sales Manager",
+                "Lead enterprise sales in the United States.",
+                "United States",
+                "2026-07-29T10:00:00+00:00",
+            ),
+        ),
+    )
+    conn.execute(
+        """
+        INSERT INTO job_source_observations (
+            tenant_id, source_observation_id, job_id, source_id,
+            source_native_id, observed_url, normalized_observed_url,
+            run_id, observed_at
+        ) VALUES (
+            'local', 'tenant-isolation-observation', ?,
+            'jobspy:linkedin', 'local-job', ?, ?,
+            'tenant-isolation', '2026-07-29T10:00:00+00:00'
+        )
+        """,
+        (shared_job_id, local_url, local_url),
+    )
+    conn.execute(
+        """
+        INSERT INTO job_enrichments (
+            tenant_id, job_id, current_status, full_description, updated_at
+        ) VALUES (
+            'local', ?, 'enriched',
+            'Lead engineering teams in Barcelona.',
+            '2026-07-29T10:01:00+00:00'
+        )
+        """,
+        (shared_job_id,),
+    )
+    conn.commit()
+
+    result = retire_invalid_source_jobs(
+        conn,
+        search_cfg={
+            "queries": [{"query": "Engineering Manager", "tier": 1}],
+            "locations": [{"location": "Spain"}],
+            "location_accept": ["Spain", "Barcelona, Spain"],
+            "location_reject_non_remote": [
+                "United States",
+                "USA",
+                "US only",
+            ],
+        },
+        run_id="hygiene:tenant-isolation",
+    )
+
+    assert result["retired_jobs"] == 0
+    assert conn.execute(
+        "SELECT COUNT(*) FROM jobctrl_deleted_jobs"
+    ).fetchone()[0] == 0
+
+
+def test_acceptance_report_scoring_handoff_is_tenant_scoped(
+    conn: sqlite3.Connection,
+) -> None:
+    shared_job_id = str(uuid.uuid4())
+    conn.executemany(
+        """
+        INSERT INTO jobs (
+            url, tenant_id, job_id, title, discovered_at
+        ) VALUES (?, ?, ?, 'Engineering Manager', ?)
+        """,
+        (
+            (
+                "https://example.com/jobs/local-handoff",
+                "local",
+                shared_job_id,
+                "2026-07-29T10:00:00+00:00",
+            ),
+            (
+                "https://example.com/jobs/foreign-handoff",
+                "other-tenant",
+                shared_job_id,
+                "2026-07-29T10:00:00+00:00",
+            ),
+        ),
+    )
+    conn.execute(
+        """
+        INSERT INTO job_enrichments (
+            tenant_id, job_id, current_status, full_description, updated_at
+        ) VALUES (
+            'local', ?, 'enriched', 'Canonical description',
+            '2026-07-29T10:01:00+00:00'
+        )
+        """,
+        (shared_job_id,),
+    )
+    conn.commit()
+
+    report = build_discovery_acceptance_report(conn)
+
+    assert report.scoring_handoff_count == 1
 
 
 def test_discovery_hygiene_applies_to_workday_and_smart_extract_rows(
@@ -1423,18 +1557,24 @@ def test_manual_capture_import_runs_discovery_enrichment_and_snapshot_pipeline(
     ).fetchone()["strategy"] == "manual"
     enrichment_row = conn.execute(
         """
-        SELECT current_status, extraction_tier
-        FROM job_enrichments
-        WHERE job_url = ?
+        SELECT je.current_status, je.extraction_tier
+        FROM job_enrichments je
+        JOIN jobs j
+          ON j.tenant_id = je.tenant_id
+         AND j.job_id = je.job_id
+        WHERE j.url = ?
         """,
         (outcome.job_id,),
     ).fetchone()
     assert tuple(enrichment_row) == ("enriched", "json_ld")
     snapshot_row = conn.execute(
         """
-        SELECT latest_snapshot_version, latest_active_state
-        FROM posting_snapshot_sets
-        WHERE job_url = ?
+        SELECT pss.latest_snapshot_version, pss.latest_active_state
+        FROM posting_snapshot_sets pss
+        JOIN jobs j
+          ON j.tenant_id = pss.tenant_id
+         AND j.job_id = pss.job_id
+        WHERE j.url = ?
         """,
         (outcome.job_id,),
     ).fetchone()
@@ -1569,7 +1709,14 @@ def test_manual_capture_import_cli_routes_api_bridge_through_worker_pipeline(
         )
         assert (
             verify_conn.execute(
-                "SELECT current_status FROM job_enrichments WHERE job_url = ?",
+                """
+                SELECT je.current_status
+                FROM job_enrichments je
+                JOIN jobs j
+                  ON j.tenant_id = je.tenant_id
+                 AND j.job_id = je.job_id
+                WHERE j.url = ?
+                """,
                 ("https://login.protected.example/jobs/vp-engineering",),
             ).fetchone()["current_status"]
             == "enriched"

--- a/workers/automation/tests/test_enrichment_detail_staleness.py
+++ b/workers/automation/tests/test_enrichment_detail_staleness.py
@@ -228,9 +228,12 @@ def test_scrape_site_batch_uses_discovery_description_when_detail_extracts_no_da
 
         enrichment = conn.execute(
             """
-            SELECT current_status, full_description, attempts_json
-            FROM job_enrichments
-            WHERE job_url = ?
+            SELECT je.current_status, je.full_description, je.attempts_json
+            FROM job_enrichments je
+            JOIN jobs j
+              ON j.tenant_id = je.tenant_id
+             AND j.job_id = je.job_id
+            WHERE j.url = ?
             """,
             (job_url,),
         ).fetchone()
@@ -311,9 +314,18 @@ def test_inactive_cascade_snapshot_persists_closed_state(tmp_path: Path) -> None
     db_path = tmp_path / "jobs.db"
     conn = init_db(db_path)
     try:
+        job_url = "https://example.com/jobs/closed"
+        conn.execute(
+            """
+            INSERT INTO jobs (url, title, site, discovered_at)
+            VALUES (?, 'Closed engineering role', 'jobspy', ?)
+            """,
+            (job_url, "2026-05-29T11:00:00+00:00"),
+        )
+        conn.commit()
         _record_posting_snapshot_from_cascade(
             conn,
-            url="https://example.com/jobs/closed",
+            url=job_url,
             source_id="jobspy",
             title="Closed engineering role",
             cascade_result={
@@ -330,10 +342,13 @@ def test_inactive_cascade_snapshot_persists_closed_state(tmp_path: Path) -> None
         snapshot_set = conn.execute(
             """
             SELECT latest_active_state
-            FROM posting_snapshot_sets
-            WHERE tenant_id = 'local' AND job_url = ?
+            FROM posting_snapshot_sets pss
+            JOIN jobs j
+              ON j.tenant_id = pss.tenant_id
+             AND j.job_id = pss.job_id
+            WHERE pss.tenant_id = 'local' AND j.url = ?
             """,
-            ("https://example.com/jobs/closed",),
+            (job_url,),
         ).fetchone()
         event = conn.execute(
             """

--- a/workers/automation/tests/test_enrichment_politeness_gate.py
+++ b/workers/automation/tests/test_enrichment_politeness_gate.py
@@ -77,7 +77,15 @@ def _blocked_metric(conn: sqlite3.Connection, url: str) -> sqlite3.Row | None:
 
 def _enrichment_status(conn: sqlite3.Connection, url: str) -> str | None:
     row = conn.execute(
-        "SELECT current_status FROM job_enrichments WHERE job_url = ?", (url,)
+        """
+        SELECT je.current_status
+        FROM job_enrichments je
+        JOIN jobs j
+          ON j.tenant_id = je.tenant_id
+         AND j.job_id = je.job_id
+        WHERE j.url = ?
+        """,
+        (url,),
     ).fetchone()
     return None if row is None else row[0]
 

--- a/workers/automation/tests/test_enrichment_quarantine_gating.py
+++ b/workers/automation/tests/test_enrichment_quarantine_gating.py
@@ -289,7 +289,9 @@ def test_repository_persists_latest_confidence_and_quarantine(
 
     row = conn.execute(
         "SELECT latest_confidence, latest_quarantine_reason "
-        "FROM posting_snapshot_sets WHERE job_url = ?",
+        "FROM posting_snapshot_sets pss "
+        "JOIN jobs j ON j.tenant_id = pss.tenant_id AND j.job_id = pss.job_id "
+        "WHERE j.url = ?",
         (url,),
     ).fetchone()
     assert row["latest_confidence"] == "low"

--- a/workers/automation/tests/test_enrichment_queue_selectors.py
+++ b/workers/automation/tests/test_enrichment_queue_selectors.py
@@ -60,17 +60,21 @@ def _seed_discovered(conn: sqlite3.Connection, url: str) -> None:
 
 
 def _mark_closed(conn: sqlite3.Connection, url: str, state: str = "removed") -> None:
+    job_id = conn.execute(
+        "SELECT job_id FROM jobs WHERE tenant_id = ? AND url = ?",
+        (str(LOCAL_TENANT), url),
+    ).fetchone()[0]
     conn.execute(
         """
         INSERT INTO posting_snapshot_sets (
-            tenant_id, job_url, snapshot_set_json, latest_snapshot_version,
+            tenant_id, job_id, snapshot_set_json, latest_snapshot_version,
             latest_active_state, updated_at
         ) VALUES (?, ?, '{}', 0, ?, ?)
-        ON CONFLICT(tenant_id, job_url) DO UPDATE SET
+        ON CONFLICT(tenant_id, job_id) DO UPDATE SET
             latest_active_state = excluded.latest_active_state,
             updated_at = excluded.updated_at
         """,
-        (str(LOCAL_TENANT), url, state, utc_now()),
+        (str(LOCAL_TENANT), job_id, state, utc_now()),
     )
     conn.commit()
 

--- a/workers/automation/tests/test_enrichment_repository.py
+++ b/workers/automation/tests/test_enrichment_repository.py
@@ -47,6 +47,15 @@ def _insert_job(conn: sqlite3.Connection, url: str, **legacy_cols) -> None:
     conn.commit()
 
 
+def _stable_job_id(conn: sqlite3.Connection, url: str) -> JobId:
+    row = conn.execute(
+        "SELECT job_id FROM jobs WHERE tenant_id = ? AND url = ?",
+        (str(LOCAL_TENANT), url),
+    ).fetchone()
+    assert row is not None
+    return JobId(str(row[0]))
+
+
 def _make_enriched(url: str = "https://example.com/jobs/1") -> JobEnrichment:
     agg = JobEnrichment.empty(
         tenant_id=LOCAL_TENANT,
@@ -116,7 +125,7 @@ def test_list_pending_includes_jobs_with_no_enrichment(conn: sqlite3.Connection)
     # Save an enrichment for A only
     repo.save(_make_enriched("https://example.com/jobs/A"))
     pending = repo.list_pending(LOCAL_TENANT)
-    assert pending == [JobId("https://example.com/jobs/B")]
+    assert pending == [_stable_job_id(conn, "https://example.com/jobs/B")]
 
 
 def test_list_pending_includes_jobs_with_pending_status(conn: sqlite3.Connection) -> None:
@@ -129,7 +138,33 @@ def test_list_pending_includes_jobs_with_pending_status(conn: sqlite3.Connection
     )
     repo.save(pending_agg)
     pending = repo.list_pending(LOCAL_TENANT)
-    assert pending == [JobId("https://example.com/jobs/A")]
+    assert pending == [_stable_job_id(conn, "https://example.com/jobs/A")]
+
+
+def test_list_pending_does_not_cross_tenant_boundary(
+    conn: sqlite3.Connection,
+) -> None:
+    local_url = "https://example.com/jobs/local"
+    _insert_job(conn, local_url)
+    conn.execute(
+        """
+        INSERT INTO jobs (
+            url, tenant_id, job_id, title, site, discovered_at
+        ) VALUES (
+            'https://example.com/jobs/other-tenant',
+            'other-tenant',
+            '00000000-0000-4000-8000-000000000002',
+            'Other tenant role',
+            'greenhouse',
+            '2026-05-02T00:00:00+00:00'
+        )
+        """
+    )
+    conn.commit()
+
+    assert SqliteEnrichmentRepository(conn).list_pending(
+        LOCAL_TENANT,
+    ) == [_stable_job_id(conn, local_url)]
 
 
 def test_list_pending_excludes_running_and_failed(conn: sqlite3.Connection) -> None:
@@ -268,7 +303,14 @@ def test_backfill_creates_enriched_rows_from_legacy_columns(tmp_path) -> None:
     assert loaded.last_attempt.succeeded
     # The attempts_json carries the "backfilled": true flag
     raw = conn.execute(
-        "SELECT attempts_json FROM job_enrichments WHERE job_url = ?",
+        """
+        SELECT je.attempts_json
+        FROM job_enrichments je
+        JOIN jobs j
+          ON j.tenant_id = je.tenant_id
+         AND j.job_id = je.job_id
+        WHERE j.url = ?
+        """,
         ("https://example.com/jobs/1",),
     ).fetchone()
     payload = json.loads(raw[0])

--- a/workers/automation/tests/test_enrichment_snapshot_identity_reference_migration.py
+++ b/workers/automation/tests/test_enrichment_snapshot_identity_reference_migration.py
@@ -1,0 +1,865 @@
+"""Schema-v11 enrichment and snapshot identity migration contracts."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import sqlite3
+import uuid
+from pathlib import Path
+
+import pytest
+
+import jobctrl.database as database_module
+from jobctrl.database import (
+    SCHEMA_VERSION,
+    _assert_schema_version_supported,
+    _reassign_enrichment_snapshot_references_v11,
+    close_connection,
+    init_db,
+)
+from jobctrl.domain.discovery import (
+    Employer,
+    Job,
+    JobMetadata,
+    PostingUrl,
+    SearchStrategy,
+    Source,
+)
+from jobctrl.domain.enrichment import (
+    ActiveState,
+    ApplicationUrl,
+    ExtractionTier,
+    FullDescription,
+    JobEnrichment,
+    PostingSnapshotSet,
+    QuarantineReason,
+    SnapshotApplyUrl,
+    SnapshotConfidence,
+    SnapshotDescriptionHash,
+)
+from jobctrl.domain.identifiers import JobId
+from jobctrl.domain.tenant import LOCAL_TENANT
+from jobctrl.infrastructure.discovery import SqliteJobRepository
+from jobctrl.infrastructure.enrichment import (
+    SqliteEnrichmentRepository,
+    SqlitePostingSnapshotSetRepository,
+)
+
+
+PREVIOUS_SCHEMA_VERSION = 10
+
+
+def _downgrade_enrichment_snapshot_references_to_v10(
+    conn: sqlite3.Connection,
+) -> None:
+    conn.execute("DROP TABLE job_enrichments")
+    conn.execute("DROP TABLE posting_snapshot_sets")
+    conn.executescript(
+        """
+        CREATE TABLE job_enrichments (
+            job_url             TEXT PRIMARY KEY,
+            tenant_id           TEXT NOT NULL DEFAULT 'local',
+            current_status      TEXT NOT NULL,
+            full_description    TEXT,
+            application_url     TEXT,
+            enriched_at         TEXT,
+            extraction_tier     TEXT,
+            attempts_json       TEXT NOT NULL DEFAULT '[]',
+            updated_at          TEXT NOT NULL,
+            FOREIGN KEY (job_url) REFERENCES jobs(url) ON DELETE CASCADE
+        );
+        CREATE INDEX idx_job_enrichments_tenant_status
+            ON job_enrichments(
+                tenant_id, current_status, updated_at DESC
+            );
+        CREATE INDEX idx_job_enrichments_enriched_at
+            ON job_enrichments(enriched_at DESC);
+
+        CREATE TABLE posting_snapshot_sets (
+            tenant_id                TEXT NOT NULL DEFAULT 'local',
+            job_url                  TEXT NOT NULL,
+            snapshot_set_json        TEXT NOT NULL,
+            latest_snapshot_version  INTEGER NOT NULL DEFAULT 0,
+            latest_active_state      TEXT NOT NULL DEFAULT 'unknown',
+            latest_confidence        TEXT,
+            latest_quarantine_reason TEXT,
+            updated_at               TEXT NOT NULL,
+            PRIMARY KEY (tenant_id, job_url),
+            FOREIGN KEY (job_url) REFERENCES jobs(url) ON DELETE CASCADE
+        );
+        CREATE INDEX idx_posting_snapshot_sets_updated
+            ON posting_snapshot_sets(tenant_id, updated_at DESC);
+        """
+    )
+    conn.execute(f"PRAGMA user_version = {PREVIOUS_SCHEMA_VERSION}")
+    conn.commit()
+
+
+def _discovered_job(posting_url: str, job_id: JobId) -> Job:
+    return Job.discover(
+        tenant_id=LOCAL_TENANT,
+        job_id=job_id,
+        posting_url=PostingUrl(value=posting_url),
+        source=Source(board="example"),
+        employer=Employer(name="Example"),
+        search_strategy=SearchStrategy.JOBSPY,
+        metadata=JobMetadata(title="Platform Engineer"),
+        discovered_at="2026-07-29T10:00:00+00:00",
+    )
+
+
+def _snapshot_json(
+    job_reference: str,
+    *,
+    captured_at: str,
+    candidate_reference: str | None = None,
+) -> str:
+    candidates = []
+    if candidate_reference is not None:
+        candidates.append(
+            {
+                "candidate_job_id": candidate_reference,
+                "evidence": [
+                    {
+                        "kind": "description_hash_match",
+                        "matched_value": "shared-description",
+                        "confidence": 0.93,
+                    }
+                ],
+                "confidence": 0.93,
+                "detected_at": captured_at,
+            }
+        )
+    return json.dumps(
+        {
+            "tenant_id": "local",
+            "job_id": job_reference,
+            "snapshots": [
+                {
+                    "snapshot_version": 1,
+                    "source_id": "example",
+                    "extraction_tier": "css_selectors",
+                    "description_hash": "a" * 64,
+                    "apply_url": "https://apply.example/jobs/1",
+                    "active_state": "active",
+                    "confidence": "high",
+                    "quarantine_reason": "none",
+                    "captured_at": captured_at,
+                    "raw_text_hash": "b" * 64,
+                    "filter_override": None,
+                    "evidence": ["fixture"],
+                }
+            ],
+            "failures": [],
+            "duplicate_candidates": candidates,
+            "latest_active_state": "active",
+            "updated_at": captured_at,
+        },
+        sort_keys=True,
+    )
+
+
+def _insert_legacy_enrichment(
+    conn: sqlite3.Connection,
+    *,
+    job_url: str,
+    application_url: str = "https://apply.example/jobs/1",
+    full_description: str = "Canonical description",
+    updated_at: str,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO job_enrichments (
+            job_url, tenant_id, current_status, full_description,
+            application_url, enriched_at, extraction_tier,
+            attempts_json, updated_at
+        ) VALUES (
+            ?, 'local', 'enriched', ?,
+            ?, ?, 'css_selectors',
+            ?, ?
+        )
+        """,
+        (
+            job_url,
+            full_description,
+            application_url,
+            updated_at,
+            json.dumps(
+                [
+                    {
+                        "attempt_number": 1,
+                        "extraction_tier": "css_selectors",
+                        "status": "succeeded",
+                        "started_at": updated_at,
+                        "finished_at": updated_at,
+                        "error": None,
+                    }
+                ],
+                sort_keys=True,
+            ),
+            updated_at,
+        ),
+    )
+
+
+def _insert_legacy_snapshot(
+    conn: sqlite3.Connection,
+    *,
+    job_url: str,
+    candidate_reference: str | None,
+    updated_at: str,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO posting_snapshot_sets (
+            tenant_id, job_url, snapshot_set_json,
+            latest_snapshot_version, latest_active_state,
+            latest_confidence, latest_quarantine_reason, updated_at
+        ) VALUES ('local', ?, ?, 1, 'active', 'high', 'none', ?)
+        """,
+        (
+            job_url,
+            _snapshot_json(
+                job_url,
+                captured_at=updated_at,
+                candidate_reference=candidate_reference,
+            ),
+            updated_at,
+        ),
+    )
+
+
+def _user_version(db_path: Path) -> int:
+    conn = sqlite3.connect(db_path)
+    try:
+        return int(conn.execute("PRAGMA user_version").fetchone()[0])
+    finally:
+        conn.close()
+
+
+def _foreign_job_reference(
+    conn: sqlite3.Connection,
+    table: str,
+) -> set[tuple[str, str, str]]:
+    return {
+        (str(row[3]), str(row[4]), str(row[6]).upper())
+        for row in conn.execute(f"PRAGMA foreign_key_list({table})").fetchall()
+        if str(row[2]) == "jobs"
+    }
+
+
+def test_v10_enrichment_snapshot_references_migrate_and_reopen(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    pre_upgrade = tmp_path / "jobctrl-v10.db"
+    conn = init_db(db_path)
+    jobs = SqliteJobRepository(conn)
+
+    stable_job_id = JobId(str(uuid.uuid4()))
+    storage_url = "https://boards.example/jobs/123"
+    current_url = "https://careers.example/jobs/platform-engineer"
+    jobs.save(_discovered_job(storage_url, stable_job_id))
+    jobs.save(_discovered_job(current_url, stable_job_id))
+
+    duplicate_job_id = JobId(str(uuid.uuid4()))
+    duplicate_url = "https://example.com/jobs/duplicate"
+    jobs.save(_discovered_job(duplicate_url, duplicate_job_id))
+
+    uuid_shaped_url = str(uuid.uuid4())
+    uuid_url_owner_job_id = JobId(str(uuid.uuid4()))
+    jobs.save(_discovered_job(uuid_shaped_url, uuid_url_owner_job_id))
+    jobs.save(
+        _discovered_job(
+            "https://example.com/jobs/id-text-collision",
+            JobId(uuid_shaped_url),
+        )
+    )
+
+    _downgrade_enrichment_snapshot_references_to_v10(conn)
+    _insert_legacy_enrichment(
+        conn,
+        job_url=storage_url,
+        application_url="https://apply.example/jobs/original",
+        full_description="Original description",
+        updated_at="2026-07-29T10:00:00+00:00",
+    )
+    _insert_legacy_enrichment(
+        conn,
+        job_url=current_url,
+        application_url="https://apply.example/jobs/corrected",
+        full_description="Corrected description",
+        updated_at="2026-07-29T10:01:00+00:00",
+    )
+    _insert_legacy_enrichment(
+        conn,
+        job_url=uuid_shaped_url,
+        updated_at="2026-07-29T10:02:00+00:00",
+    )
+    _insert_legacy_snapshot(
+        conn,
+        job_url=storage_url,
+        candidate_reference=current_url,
+        updated_at="2026-07-29T10:00:00+00:00",
+    )
+    _insert_legacy_snapshot(
+        conn,
+        job_url=current_url,
+        candidate_reference=duplicate_url,
+        updated_at="2026-07-29T10:03:00+00:00",
+    )
+    _insert_legacy_snapshot(
+        conn,
+        job_url=uuid_shaped_url,
+        candidate_reference=current_url,
+        updated_at="2026-07-29T10:04:00+00:00",
+    )
+    conn.commit()
+    close_connection(db_path)
+    shutil.copy2(db_path, pre_upgrade)
+
+    init_db(db_path)
+    close_connection(db_path)
+
+    assert _user_version(db_path) == SCHEMA_VERSION == 11
+    check = sqlite3.connect(db_path)
+    try:
+        enrichment_rows = check.execute(
+            """
+            SELECT job_id, current_status, full_description,
+                   application_url, extraction_tier, attempts_json, updated_at
+            FROM job_enrichments
+            ORDER BY updated_at
+            """
+        ).fetchall()
+        assert [str(row[0]) for row in enrichment_rows] == [
+            str(stable_job_id),
+            str(uuid_url_owner_job_id),
+        ]
+        assert all(str(row[1]) == "enriched" for row in enrichment_rows)
+        assert enrichment_rows[0][2] == "Corrected description"
+        assert enrichment_rows[1][2] == "Canonical description"
+        assert enrichment_rows[0][3] == (
+            "https://apply.example/jobs/corrected"
+        )
+        assert all(str(row[4]) == "css_selectors" for row in enrichment_rows)
+        merged_attempts = json.loads(str(enrichment_rows[0][5]))
+        assert [attempt["attempt_number"] for attempt in merged_attempts] == [1, 2]
+        assert all(attempt["status"] == "succeeded" for attempt in merged_attempts)
+        assert len(json.loads(str(enrichment_rows[1][5]))) == 1
+
+        snapshot_rows = check.execute(
+            """
+            SELECT job_id, snapshot_set_json, latest_snapshot_version,
+                   latest_active_state, latest_confidence,
+                   latest_quarantine_reason
+            FROM posting_snapshot_sets
+            ORDER BY updated_at
+            """
+        ).fetchall()
+        assert [str(row[0]) for row in snapshot_rows] == [
+            str(stable_job_id),
+            str(uuid_url_owner_job_id),
+        ]
+        first_snapshot = json.loads(str(snapshot_rows[0][1]))
+        assert first_snapshot["job_id"] == str(stable_job_id)
+        assert [item["snapshot_version"] for item in first_snapshot["snapshots"]] == [
+            1,
+            2,
+        ]
+        assert first_snapshot["duplicate_candidates"][0]["candidate_job_id"] == str(
+            duplicate_job_id
+        )
+        assert len(first_snapshot["duplicate_candidates"]) == 1
+        second_snapshot = json.loads(str(snapshot_rows[1][1]))
+        assert second_snapshot["job_id"] == str(uuid_url_owner_job_id)
+        assert second_snapshot["duplicate_candidates"][0]["candidate_job_id"] == str(
+            stable_job_id
+        )
+        assert tuple(snapshot_rows[0][2:]) == (2, "active", "high", "none")
+        assert tuple(snapshot_rows[1][2:]) == (1, "active", "high", "none")
+        assert _foreign_job_reference(check, "job_enrichments") == {
+            ("tenant_id", "tenant_id", "CASCADE"),
+            ("job_id", "job_id", "CASCADE"),
+        }
+        assert _foreign_job_reference(check, "posting_snapshot_sets") == {
+            ("tenant_id", "tenant_id", "CASCADE"),
+            ("job_id", "job_id", "CASCADE"),
+        }
+        assert check.execute("PRAGMA foreign_key_check").fetchone() is None
+    finally:
+        check.close()
+
+    init_db(db_path)
+    close_connection(db_path)
+    assert _user_version(db_path) == SCHEMA_VERSION
+
+    previous = sqlite3.connect(pre_upgrade)
+    try:
+        assert (
+            _assert_schema_version_supported(
+                previous,
+                supported_version=PREVIOUS_SCHEMA_VERSION,
+            )
+            == PREVIOUS_SCHEMA_VERSION
+        )
+        assert previous.execute(
+            "SELECT job_url FROM job_enrichments ORDER BY updated_at"
+        ).fetchall() == [(storage_url,), (current_url,), (uuid_shaped_url,)]
+        raw_snapshot = json.loads(
+            str(
+                previous.execute(
+                    """
+                    SELECT snapshot_set_json
+                    FROM posting_snapshot_sets
+                    WHERE job_url = ?
+                    """,
+                    (current_url,),
+                ).fetchone()[0]
+            )
+        )
+        assert raw_snapshot["job_id"] == current_url
+        assert (
+            raw_snapshot["duplicate_candidates"][0]["candidate_job_id"]
+            == duplicate_url
+        )
+    finally:
+        previous.close()
+
+
+def test_unresolved_v10_reference_rolls_back_and_retries(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    conn = init_db(db_path)
+    stable_job_id = str(uuid.uuid4())
+    job_url = "https://example.com/jobs/valid"
+    conn.execute(
+        """
+        INSERT INTO jobs (url, tenant_id, job_id, title)
+        VALUES (?, 'local', ?, 'Engineer')
+        """,
+        (job_url, stable_job_id),
+    )
+    conn.commit()
+    _downgrade_enrichment_snapshot_references_to_v10(conn)
+    _insert_legacy_enrichment(
+        conn,
+        job_url="https://example.com/jobs/missing",
+        updated_at="2026-07-29T10:01:00+00:00",
+    )
+    conn.commit()
+    close_connection(db_path)
+
+    with pytest.raises(
+        RuntimeError,
+        match="could not resolve job_enrichments.job_url",
+    ):
+        init_db(db_path)
+    close_connection(db_path)
+
+    assert _user_version(db_path) == PREVIOUS_SCHEMA_VERSION
+    rolled_back = sqlite3.connect(db_path)
+    try:
+        assert rolled_back.execute(
+            "SELECT job_url FROM job_enrichments"
+        ).fetchone() == ("https://example.com/jobs/missing",)
+        assert "job_id" not in {
+            str(row[1])
+            for row in rolled_back.execute(
+                "PRAGMA table_info(job_enrichments)"
+            ).fetchall()
+        }
+        assert not rolled_back.execute(
+            """
+            SELECT 1
+            FROM sqlite_master
+            WHERE type = 'table' AND name = 'job_enrichments_v11'
+            """
+        ).fetchall()
+        rolled_back.execute(
+            "UPDATE job_enrichments SET job_url = ?",
+            (job_url,),
+        )
+        rolled_back.commit()
+    finally:
+        rolled_back.close()
+
+    init_db(db_path)
+    close_connection(db_path)
+    assert _user_version(db_path) == SCHEMA_VERSION
+    migrated = sqlite3.connect(db_path)
+    try:
+        assert migrated.execute(
+            "SELECT job_id FROM job_enrichments"
+        ).fetchone() == (stable_job_id,)
+    finally:
+        migrated.close()
+
+
+def test_v11_verification_failure_rolls_back_rebuild_and_retries(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    conn = init_db(db_path)
+    stable_job_id = str(uuid.uuid4())
+    job_url = "https://example.com/jobs/retry-after-verification"
+    conn.execute(
+        """
+        INSERT INTO jobs (url, tenant_id, job_id, title)
+        VALUES (?, 'local', ?, 'Engineer')
+        """,
+        (job_url, stable_job_id),
+    )
+    conn.commit()
+    _downgrade_enrichment_snapshot_references_to_v10(conn)
+    _insert_legacy_enrichment(
+        conn,
+        job_url=job_url,
+        updated_at="2026-07-29T10:01:00+00:00",
+    )
+    _insert_legacy_snapshot(
+        conn,
+        job_url=job_url,
+        candidate_reference=None,
+        updated_at="2026-07-29T10:02:00+00:00",
+    )
+    conn.commit()
+    close_connection(db_path)
+
+    original_verify = (
+        database_module._verify_enrichment_snapshot_references_v11
+    )
+
+    def fail_verification(
+        _conn: sqlite3.Connection,
+        *,
+        expected_counts: dict[str, int],
+    ) -> None:
+        del expected_counts
+        raise RuntimeError("synthetic enrichment verification failure")
+
+    monkeypatch.setattr(
+        database_module,
+        "_verify_enrichment_snapshot_references_v11",
+        fail_verification,
+    )
+    with pytest.raises(
+        RuntimeError,
+        match="synthetic enrichment verification failure",
+    ):
+        init_db(db_path)
+    close_connection(db_path)
+
+    assert _user_version(db_path) == PREVIOUS_SCHEMA_VERSION
+    rolled_back = sqlite3.connect(db_path)
+    try:
+        assert rolled_back.execute(
+            "SELECT job_url FROM job_enrichments"
+        ).fetchone() == (job_url,)
+        assert rolled_back.execute(
+            "SELECT job_url FROM posting_snapshot_sets"
+        ).fetchone() == (job_url,)
+        assert not rolled_back.execute(
+            """
+            SELECT 1
+            FROM sqlite_master
+            WHERE type = 'table' AND name LIKE '%_v11'
+            """
+        ).fetchall()
+    finally:
+        rolled_back.close()
+
+    monkeypatch.setattr(
+        database_module,
+        "_verify_enrichment_snapshot_references_v11",
+        original_verify,
+    )
+    init_db(db_path)
+    close_connection(db_path)
+    assert _user_version(db_path) == SCHEMA_VERSION
+    migrated = sqlite3.connect(db_path)
+    try:
+        assert migrated.execute(
+            "SELECT job_id FROM job_enrichments"
+        ).fetchone() == (stable_job_id,)
+        snapshot = migrated.execute(
+            "SELECT job_id, snapshot_set_json FROM posting_snapshot_sets"
+        ).fetchone()
+        assert snapshot[0] == stable_job_id
+        assert json.loads(str(snapshot[1]))["job_id"] == stable_job_id
+    finally:
+        migrated.close()
+
+
+def _enriched(reference: str, *, finished_at: str) -> JobEnrichment:
+    enrichment = JobEnrichment.empty(
+        tenant_id=LOCAL_TENANT,
+        job_id=JobId(reference),
+        updated_at=finished_at,
+    )
+    enrichment = enrichment.start_attempt(
+        extraction_tier=ExtractionTier.CSS_SELECTORS,
+        started_at=finished_at,
+    )
+    return enrichment.succeed_attempt(
+        full_description=FullDescription(text="Canonical description"),
+        application_url=ApplicationUrl(
+            value="https://apply.example/jobs/1"
+        ),
+        extraction_tier=ExtractionTier.CSS_SELECTORS,
+        finished_at=finished_at,
+    )
+
+
+def _snapshot_set(reference: str, *, captured_at: str) -> PostingSnapshotSet:
+    snapshot_set = PostingSnapshotSet.empty(
+        tenant_id=LOCAL_TENANT,
+        job_id=JobId(reference),
+        updated_at=captured_at,
+    )
+    snapshot_set, _ = snapshot_set.record_snapshot(
+        source_id="example",
+        extraction_tier="css_selectors",
+        description_hash=SnapshotDescriptionHash.from_text(
+            "Canonical description"
+        ),
+        apply_url=SnapshotApplyUrl(
+            value="https://apply.example/jobs/1"
+        ),
+        active_state=ActiveState.ACTIVE,
+        confidence=SnapshotConfidence.HIGH,
+        quarantine_reason=QuarantineReason.NONE,
+        captured_at=captured_at,
+        evidence=("fixture",),
+    )
+    return snapshot_set
+
+
+def test_repositories_use_stable_ids_and_explicit_uuid_url_compatibility(
+    tmp_path: Path,
+) -> None:
+    conn = init_db(tmp_path / "jobctrl.db")
+    jobs = SqliteJobRepository(conn)
+    stable_job_id = JobId(str(uuid.uuid4()))
+    stable_url = "https://example.com/jobs/stable"
+    jobs.save(_discovered_job(stable_url, stable_job_id))
+
+    uuid_shaped_url = str(uuid.uuid4())
+    uuid_url_owner_job_id = JobId(str(uuid.uuid4()))
+    jobs.save(_discovered_job(uuid_shaped_url, uuid_url_owner_job_id))
+    jobs.save(
+        _discovered_job(
+            "https://example.com/jobs/id-text-collision",
+            JobId(uuid_shaped_url),
+        )
+    )
+
+    enrichments = SqliteEnrichmentRepository(conn)
+    snapshots = SqlitePostingSnapshotSetRepository(conn)
+    enrichments.save(_enriched(stable_url, finished_at="2026-07-29T11:00:00+00:00"))
+    snapshots.save(_snapshot_set(stable_url, captured_at="2026-07-29T11:01:00+00:00"))
+    enrichments.save_by_posting_url(
+        _enriched(uuid_shaped_url, finished_at="2026-07-29T11:02:00+00:00"),
+        PostingUrl(uuid_shaped_url),
+    )
+    snapshots.save_by_posting_url(
+        _snapshot_set(uuid_shaped_url, captured_at="2026-07-29T11:03:00+00:00"),
+        PostingUrl(uuid_shaped_url),
+    )
+
+    assert enrichments.load(LOCAL_TENANT, stable_job_id).job_id == stable_job_id
+    assert snapshots.load(LOCAL_TENANT, stable_job_id).job_id == stable_job_id
+    assert (
+        enrichments.load_by_posting_url(
+            LOCAL_TENANT,
+            PostingUrl(uuid_shaped_url),
+        ).job_id
+        == uuid_url_owner_job_id
+    )
+    assert (
+        snapshots.load_by_posting_url(
+            LOCAL_TENANT,
+            PostingUrl(uuid_shaped_url),
+        ).job_id
+        == uuid_url_owner_job_id
+    )
+    assert conn.execute(
+        """
+        SELECT job_id
+        FROM job_enrichments
+        WHERE updated_at = '2026-07-29T11:02:00+00:00'
+        """
+    ).fetchone()[0] == str(uuid_url_owner_job_id)
+    assert conn.execute(
+        """
+        SELECT job_id
+        FROM posting_snapshot_sets
+        WHERE updated_at = '2026-07-29T11:03:00+00:00'
+        """
+    ).fetchone()[0] == str(uuid_url_owner_job_id)
+
+
+def test_collision_merge_preserves_histories_and_removes_self_candidates(
+    tmp_path: Path,
+) -> None:
+    conn = init_db(tmp_path / "jobctrl.db")
+    jobs = SqliteJobRepository(conn)
+    surviving_job_id = JobId(str(uuid.uuid4()))
+    losing_job_id = JobId(str(uuid.uuid4()))
+    external_job_id = JobId(str(uuid.uuid4()))
+    jobs.save(
+        _discovered_job(
+            "https://example.com/jobs/surviving",
+            surviving_job_id,
+        )
+    )
+    jobs.save(
+        _discovered_job(
+            "https://example.com/jobs/losing",
+            losing_job_id,
+        )
+    )
+    jobs.save(
+        _discovered_job(
+            "https://example.com/jobs/external",
+            external_job_id,
+        )
+    )
+
+    conn.executemany(
+        """
+        INSERT INTO job_enrichments (
+            tenant_id, job_id, current_status, full_description,
+            application_url, enriched_at, extraction_tier,
+            attempts_json, updated_at
+        ) VALUES ('local', ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            (
+                str(surviving_job_id),
+                "enriched",
+                "Canonical description",
+                "https://apply.example/jobs/original",
+                "2026-07-29T10:01:00+00:00",
+                "css_selectors",
+                json.dumps(
+                    [
+                        {
+                            "attempt_number": 1,
+                            "extraction_tier": "css_selectors",
+                            "status": "succeeded",
+                            "started_at": "2026-07-29T10:00:00+00:00",
+                            "finished_at": "2026-07-29T10:01:00+00:00",
+                            "error": None,
+                        }
+                    ]
+                ),
+                "2026-07-29T10:01:00+00:00",
+            ),
+            (
+                str(losing_job_id),
+                "enriched",
+                "Canonical description",
+                "https://apply.example/jobs/corrected",
+                "2026-07-29T10:03:00+00:00",
+                "json_ld",
+                json.dumps(
+                    [
+                        {
+                            "attempt_number": 1,
+                            "extraction_tier": "json_ld",
+                            "status": "succeeded",
+                            "started_at": "2026-07-29T10:02:00+00:00",
+                            "finished_at": "2026-07-29T10:03:00+00:00",
+                            "error": None,
+                        }
+                    ]
+                ),
+                "2026-07-29T10:03:00+00:00",
+            ),
+        ),
+    )
+    conn.executemany(
+        """
+        INSERT INTO posting_snapshot_sets (
+            tenant_id, job_id, snapshot_set_json,
+            latest_snapshot_version, latest_active_state,
+            latest_confidence, latest_quarantine_reason, updated_at
+        ) VALUES ('local', ?, ?, 1, 'active', 'high', 'none', ?)
+        """,
+        (
+            (
+                str(surviving_job_id),
+                _snapshot_json(
+                    str(surviving_job_id),
+                    captured_at="2026-07-29T10:01:00+00:00",
+                    candidate_reference=str(losing_job_id),
+                ),
+                "2026-07-29T10:01:00+00:00",
+            ),
+            (
+                str(losing_job_id),
+                _snapshot_json(
+                    str(losing_job_id),
+                    captured_at="2026-07-29T10:03:00+00:00",
+                    candidate_reference=str(external_job_id),
+                ),
+                "2026-07-29T10:03:00+00:00",
+            ),
+        ),
+    )
+    conn.commit()
+
+    _reassign_enrichment_snapshot_references_v11(
+        conn,
+        tenant_id="local",
+        losing_job_id=str(losing_job_id),
+        surviving_job_id=str(surviving_job_id),
+    )
+    conn.commit()
+
+    enrichment = conn.execute(
+        """
+        SELECT job_id, current_status, full_description, application_url,
+               enriched_at, extraction_tier, attempts_json
+        FROM job_enrichments
+        """
+    ).fetchone()
+    assert tuple(enrichment[:3]) == (
+        str(surviving_job_id),
+        "enriched",
+        "Canonical description",
+    )
+    assert tuple(enrichment[3:6]) == (
+        "https://apply.example/jobs/corrected",
+        "2026-07-29T10:03:00+00:00",
+        "json_ld",
+    )
+    attempts = json.loads(str(enrichment[6]))
+    assert [attempt["attempt_number"] for attempt in attempts] == [1, 2]
+    assert [attempt["status"] for attempt in attempts] == [
+        "succeeded",
+        "succeeded",
+    ]
+
+    snapshot_row = conn.execute(
+        """
+        SELECT job_id, snapshot_set_json, latest_snapshot_version
+        FROM posting_snapshot_sets
+        """
+    ).fetchone()
+    assert snapshot_row[0] == str(surviving_job_id)
+    assert snapshot_row[2] == 2
+    snapshot_data = json.loads(str(snapshot_row[1]))
+    assert [item["snapshot_version"] for item in snapshot_data["snapshots"]] == [
+        1,
+        2,
+    ]
+    assert [
+        item["candidate_job_id"]
+        for item in snapshot_data["duplicate_candidates"]
+    ] == [str(external_job_id)]
+    assert conn.execute("PRAGMA foreign_key_check").fetchone() is None

--- a/workers/automation/tests/test_execution_search_identity_reference_migration.py
+++ b/workers/automation/tests/test_execution_search_identity_reference_migration.py
@@ -261,7 +261,7 @@ def test_v8_execution_and_receipts_migrate_to_stable_job_id_and_reopen(
     init_db(db_path)
     close_connection(db_path)
 
-    assert _user_version(db_path) == SCHEMA_VERSION == 10
+    assert _user_version(db_path) == SCHEMA_VERSION == 11
     assert "job_id" in _columns(db_path, "discovery_execution_jobs")
     assert "job_url" not in _columns(db_path, "discovery_execution_jobs")
     assert "job_id" in _columns(db_path, "discovery_search_unit_jobs")

--- a/workers/automation/tests/test_manual_capture_workflow.py
+++ b/workers/automation/tests/test_manual_capture_workflow.py
@@ -172,7 +172,14 @@ def test_activity_reconstructs_exact_result_after_import_commit(tmp_path: Path) 
             "SELECT COUNT(*) FROM job_events"
         ).fetchone()[0]
         snapshot_version_before_replay = conn.execute(
-            "SELECT latest_snapshot_version FROM posting_snapshot_sets WHERE job_url = ?",
+            """
+            SELECT pss.latest_snapshot_version
+            FROM posting_snapshot_sets pss
+            JOIN jobs j
+              ON j.tenant_id = pss.tenant_id
+             AND j.job_id = pss.job_id
+            WHERE j.url = ?
+            """,
             (_CAPTURE_URL,),
         ).fetchone()[0]
         replay = execute_manual_capture_import(payload, conn=conn)
@@ -180,7 +187,14 @@ def test_activity_reconstructs_exact_result_after_import_commit(tmp_path: Path) 
             "SELECT COUNT(*) FROM job_events"
         ).fetchone()[0]
         snapshot_version_after_replay = conn.execute(
-            "SELECT latest_snapshot_version FROM posting_snapshot_sets WHERE job_url = ?",
+            """
+            SELECT pss.latest_snapshot_version
+            FROM posting_snapshot_sets pss
+            JOIN jobs j
+              ON j.tenant_id = pss.tenant_id
+             AND j.job_id = pss.job_id
+            WHERE j.url = ?
+            """,
             (_CAPTURE_URL,),
         ).fetchone()[0]
         row = conn.execute(

--- a/workers/automation/tests/test_preparation_identity_reference_migration.py
+++ b/workers/automation/tests/test_preparation_identity_reference_migration.py
@@ -177,7 +177,7 @@ def test_v9_preparation_references_migrate_to_stable_job_ids_and_reopen(
     init_db(db_path)
     close_connection(db_path)
 
-    assert _user_version(db_path) == SCHEMA_VERSION == 10
+    assert _user_version(db_path) == SCHEMA_VERSION == 11
     check = sqlite3.connect(db_path)
     try:
         rows = check.execute(

--- a/workers/automation/tests/test_repeat_application_prevention.py
+++ b/workers/automation/tests/test_repeat_application_prevention.py
@@ -750,7 +750,7 @@ def test_schema_v5_migrates_additively_without_changing_application_facts(
         (PRIOR,),
     ).fetchall()
 
-    assert int(migrated.execute("PRAGMA user_version").fetchone()[0]) == SCHEMA_VERSION == 10
+    assert int(migrated.execute("PRAGMA user_version").fetchone()[0]) == SCHEMA_VERSION == 11
     assert [tuple(row) for row in after] == [tuple(row) for row in before]
     assert "metadata_json" in {
         str(row[1]) for row in migrated.execute("PRAGMA table_info(job_stage_states)").fetchall()

--- a/workers/automation/tests/test_score_queue_selectors.py
+++ b/workers/automation/tests/test_score_queue_selectors.py
@@ -60,17 +60,21 @@ def _seed_enriched_job(conn: sqlite3.Connection, url: str) -> None:
 
 
 def _mark_closed(conn: sqlite3.Connection, url: str, state: str = "removed") -> None:
+    job_id = conn.execute(
+        "SELECT job_id FROM jobs WHERE tenant_id = ? AND url = ?",
+        (str(LOCAL_TENANT), url),
+    ).fetchone()[0]
     conn.execute(
         """
         INSERT INTO posting_snapshot_sets (
-            tenant_id, job_url, snapshot_set_json, latest_snapshot_version,
+            tenant_id, job_id, snapshot_set_json, latest_snapshot_version,
             latest_active_state, updated_at
         ) VALUES (?, ?, '{}', 0, ?, ?)
-        ON CONFLICT(tenant_id, job_url) DO UPDATE SET
+        ON CONFLICT(tenant_id, job_id) DO UPDATE SET
             latest_active_state = excluded.latest_active_state,
             updated_at = excluded.updated_at
         """,
-        (str(LOCAL_TENANT), url, state, utc_now()),
+        (str(LOCAL_TENANT), job_id, state, utc_now()),
     )
     conn.commit()
 

--- a/workers/automation/tests/test_stable_job_identity_migration.py
+++ b/workers/automation/tests/test_stable_job_identity_migration.py
@@ -473,7 +473,7 @@ def test_v6_jobs_gain_stable_uuid_and_posting_url_alias_once(
     init_db(db_path)
     close_connection(db_path)
 
-    assert _user_version(db_path) == SCHEMA_VERSION == 10
+    assert _user_version(db_path) == SCHEMA_VERSION == 11
     first_ids = _identity_rows(db_path)
     assert [row[0] for row in first_ids] == ["local", "local"]
     for _tenant_id, job_id, _url in first_ids:


### PR DESCRIPTION
## What changed

- migrates `job_enrichments` and `posting_snapshot_sets` to tenant-scoped stable `JobId` references in schema v11
- atomically resolves legacy URL aliases, merges same-owner enrichment and snapshot histories, preserves the newest canonical fields, and rewrites embedded duplicate-candidate identities
- keeps distinct-JobId collision merging conservative while removing self-referential and duplicate snapshot candidates
- moves enrichment repositories and worker/API consumers to stable identity, retaining explicit posting-URL compatibility adapters for legacy callers and schema-v10 reads
- fixes parallel enrichment connections to open the actual worker database path and scopes stable joins to the owning tenant
- adds migration rollback/retry, UUID-shaped URL ambiguity, collision, tenant-isolation, projection, deletion/reset, feedback, and repeat-application regressions

## Why

Enrichment and snapshot authority was still keyed by mutable posting URLs. A single stable job can legitimately accumulate multiple posting aliases and revised descriptions/application URLs, so URL-keyed rows could conflict, become orphaned, or project stale data during the broader identity cutover. This phase makes stable `JobId` ownership explicit without removing the bounded compatibility window.

## Validation

- `workers/automation/.venv/bin/python -m pytest -q` — 2,673 passed, 2 skipped
- `workers/automation/.venv/bin/ruff check src tests` — passed
- `corepack pnpm --filter @jobctrl/api check` — passed
- `corepack pnpm --filter @jobctrl/api test` — 658 passed
- `git diff --check` — passed
- independent review gate — PASS (Blocker 0, High 0, Medium 0, Low 0)

## Stack

- stacked on #535 (`feat/job-id-preparation-orchestration-references`)
- canonical product documentation and cumulative product QA remain intentionally deferred to the final PR in the approved unreleased feature stack
