### PR TITLE
feat(scoring): migrate score references to stable JobIds

### DIFF
--- a/apps/api/src/db.ts
+++ b/apps/api/src/db.ts
@@ -9,7 +9,7 @@ export type SqliteValue = string | number | bigint | null;
 // writer that stamps ``PRAGMA user_version``; the API only reads it to fail
 // closed on a database written by a newer build. Bump both constants together
 // whenever the schema shape changes.
-export const SUPPORTED_SCHEMA_VERSION = 11;
+export const SUPPORTED_SCHEMA_VERSION = 12;
 
 export class IncompatibleSchemaVersionError extends Error {
   constructor(current: number) {
@@ -68,6 +68,67 @@ export function tableExists(db: SqliteDatabase, tableName: string): boolean {
     .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?")
     .get(tableName) as { name?: string } | undefined;
   return row?.name === tableName;
+}
+
+export type JobReferenceColumn = "job_id" | "job_url";
+
+export function tableColumnSet(db: SqliteDatabase, tableName: string): Set<string> {
+  if (!tableExists(db, tableName)) return new Set();
+  return new Set(
+    (db.prepare(`PRAGMA table_info(${quoteIdentifier(tableName)})`).all() as Array<{ name: string }>)
+      .map((row) => row.name),
+  );
+}
+
+export function jobReferenceColumn(
+  db: SqliteDatabase,
+  tableName: string,
+): JobReferenceColumn {
+  const columns = tableColumnSet(db, tableName);
+  if (columns.has("job_id")) return "job_id";
+  if (columns.has("job_url")) return "job_url";
+  throw new Error(`${tableName} has no Job identity column.`);
+}
+
+export function stableJobIdForUrl(
+  db: SqliteDatabase,
+  jobUrl: string,
+  tenantId = "local",
+): string | null {
+  const direct = db.prepare(
+    `SELECT job_id
+       FROM jobs
+      WHERE tenant_id = ? AND url = ?
+      LIMIT 1`,
+  ).get(tenantId, jobUrl) as { job_id?: string } | undefined;
+  if (direct?.job_id) return direct.job_id;
+  if (!tableExists(db, "job_identity_aliases")) return null;
+  const alias = db.prepare(
+    `SELECT alias.job_id
+       FROM job_identity_aliases alias
+       JOIN jobs j
+         ON j.tenant_id = alias.tenant_id
+        AND j.job_id = alias.job_id
+      WHERE alias.tenant_id = ?
+        AND alias.alias_kind = 'posting_url'
+        AND alias.alias_value = ?
+      LIMIT 1`,
+  ).get(tenantId, jobUrl) as { job_id?: string } | undefined;
+  return alias?.job_id ?? null;
+}
+
+export function jobReferenceForUrl(
+  db: SqliteDatabase,
+  tableName: string,
+  jobUrl: string,
+  tenantId = "local",
+): string {
+  if (jobReferenceColumn(db, tableName) === "job_url") return jobUrl;
+  const jobId = stableJobIdForUrl(db, jobUrl, tenantId);
+  if (!jobId) {
+    throw new Error(`No stable Job identity for ${jobUrl}.`);
+  }
+  return jobId;
 }
 
 export function hasCompositeJobIdForeignKey(

--- a/apps/api/src/discovery-controls.ts
+++ b/apps/api/src/discovery-controls.ts
@@ -47,7 +47,14 @@ import {
   SOURCE_PRIORITY_VALUES,
   SOURCE_STATE_VALUES,
 } from "./contracts.js";
-import { allRows, getRow, tableExists, type SqliteDatabase, type SqliteValue } from "./db.js";
+import {
+  allRows,
+  getRow,
+  jobReferenceColumn,
+  tableExists,
+  type SqliteDatabase,
+  type SqliteValue,
+} from "./db.js";
 import { emptyPolitenessOutcomes, politenessOutcomesBySource } from "./source-politeness.js";
 import type { SourcePolitenessOutcomes } from "@jobctrl/contracts";
 import { refreshProjections } from "./projections.js";
@@ -1484,13 +1491,17 @@ function lowScoreJobRows(db: SqliteDatabase): LowScoreJobRow[] {
       : "''";
   const siteExpr = columns.has("site") ? "COALESCE(j.site, '')" : "''";
   const strategyExpr = columns.has("strategy") ? "COALESCE(j.strategy, '')" : "''";
+  const scoreReference = jobReferenceColumn(db, "job_scores");
+  const jobJoin = scoreReference === "job_id"
+    ? "j.tenant_id = s.tenant_id AND j.job_id = s.job_id"
+    : "j.tenant_id = s.tenant_id AND j.url = s.job_url";
   return allRows<LowScoreJobRow>(
     db,
     `WITH latest_scores AS (
-       SELECT job_url, MAX(version) AS version
+       SELECT tenant_id, ${scoreReference}, MAX(version) AS version
        FROM job_scores
        WHERE tenant_id = ?
-       GROUP BY job_url
+       GROUP BY tenant_id, ${scoreReference}
      )
      SELECT j.url AS job_key,
             ${titleExpr} AS title,
@@ -1501,8 +1512,11 @@ function lowScoreJobRows(db: SqliteDatabase): LowScoreJobRow[] {
             s.breakdown_json,
             s.scored_at
      FROM latest_scores latest
-     JOIN job_scores s ON s.job_url = latest.job_url AND s.version = latest.version
-     JOIN jobs j ON j.url = s.job_url
+     JOIN job_scores s
+       ON s.tenant_id = latest.tenant_id
+      AND s.${scoreReference} = latest.${scoreReference}
+      AND s.version = latest.version
+     JOIN jobs j ON ${jobJoin}
      WHERE s.tenant_id = ?
        AND s.fit_score <= 2
      ORDER BY s.scored_at DESC

--- a/apps/api/src/projections.ts
+++ b/apps/api/src/projections.ts
@@ -25,6 +25,8 @@ import {
   allRows,
   getRow,
   hasCompositeJobIdForeignKey,
+  jobReferenceColumn,
+  jobReferenceForUrl,
   tableExists,
   type SqliteDatabase,
   type SqliteValue,
@@ -1892,16 +1894,31 @@ function loadRequirementFitReportJson(
 ): string | null {
   if (!tableExists(db, "job_requirement_fit_reports")) return null;
   if (!tableExists(db, "job_requirement_fit_items")) return null;
+  const reportReference = jobReferenceColumn(db, "job_requirement_fit_reports");
+  const itemReference = jobReferenceColumn(db, "job_requirement_fit_items");
+  const referenceValue = jobReferenceForUrl(
+    db,
+    "job_requirement_fit_reports",
+    jobUrl,
+    tenantId,
+  );
+  const itemReferenceValue = jobReferenceForUrl(
+    db,
+    "job_requirement_fit_items",
+    jobUrl,
+    tenantId,
+  );
   const row = getRow<RequirementFitReportRow>(
     db,
-    `SELECT job_url, score_version, tenant_id, employer_analysis_generation,
+    `SELECT ${reportReference} AS job_reference,
+            score_version, tenant_id, employer_analysis_generation,
             profile_snapshot_version, scoring_policy_version, formula_version,
             resolved_fit_score, fit_band, confidence, summary_json
        FROM job_requirement_fit_reports
-      WHERE tenant_id = ? AND job_url = ?
+      WHERE tenant_id = ? AND ${reportReference} = ?
       ORDER BY score_version DESC
       LIMIT 1`,
-    [tenantId, jobUrl],
+    [tenantId, referenceValue],
   );
   if (!row) return null;
   const scoreVersion = Number(row.score_version);
@@ -1910,12 +1927,12 @@ function loadRequirementFitReportJson(
     `SELECT requirement_id, requirement_text, tier, weight, job_evidence_span,
             fit_json, contribution_json, tailoring_json, artifact_coverage_json
        FROM job_requirement_fit_items
-      WHERE tenant_id = ? AND job_url = ? AND score_version = ?
+      WHERE tenant_id = ? AND ${itemReference} = ? AND score_version = ?
       ORDER BY position ASC, requirement_id ASC`,
-    [tenantId, jobUrl, scoreVersion],
+    [tenantId, itemReferenceValue, scoreVersion],
   );
   const readModel = {
-    jobKey: row.job_url,
+    jobKey: jobUrl,
     scoreVersion,
     employerAnalysisGeneration: Number(row.employer_analysis_generation ?? 0),
     profileSnapshotVersion: Number(row.profile_snapshot_version ?? 0),
@@ -1936,14 +1953,24 @@ function loadLatestRequirementFitBand(
   jobUrl: string,
 ): string | null {
   if (!tableExists(db, "job_requirement_fit_reports")) return null;
+  const referenceColumn = jobReferenceColumn(
+    db,
+    "job_requirement_fit_reports",
+  );
+  const referenceValue = jobReferenceForUrl(
+    db,
+    "job_requirement_fit_reports",
+    jobUrl,
+    tenantId,
+  );
   const row = getRow<{ fit_band: string | null }>(
     db,
     `SELECT fit_band
        FROM job_requirement_fit_reports
-      WHERE tenant_id = ? AND job_url = ?
+      WHERE tenant_id = ? AND ${referenceColumn} = ?
       ORDER BY score_version DESC
       LIMIT 1`,
-    [tenantId, jobUrl],
+    [tenantId, referenceValue],
   );
   return nullableString(row?.fit_band);
 }
@@ -2467,8 +2494,17 @@ function attachRequirementUsagesAndGaps(
   gaps: Map<string, EvidenceGapPayload>,
 ): void {
   if (!tableExists(db, "job_requirement_fit_reports") || !tableExists(db, "job_requirement_fit_items")) return;
-  const jobMetadata = jobMetadataJoinSql(db, "items.job_url");
-  const lifecycle = jobLifecycleExclusionSql(db, "items.job_url");
+  const itemReference = jobReferenceColumn(db, "job_requirement_fit_items");
+  const reportReference = jobReferenceColumn(db, "job_requirement_fit_reports");
+  const stableReferences = itemReference === "job_id";
+  const jobUrlExpression = stableReferences ? "score_jobs.url" : "items.job_url";
+  const stableJobJoin = stableReferences
+    ? `JOIN jobs AS score_jobs
+         ON score_jobs.tenant_id = items.tenant_id
+        AND score_jobs.job_id = items.job_id`
+    : "";
+  const jobMetadata = jobMetadataJoinSql(db, jobUrlExpression);
+  const lifecycle = jobLifecycleExclusionSql(db, jobUrlExpression);
   const rows = allRows<RequirementFitItemRow & {
     job_url: string;
     score_version: number;
@@ -2476,21 +2512,23 @@ function attachRequirementUsagesAndGaps(
     employer: string | null;
   }>(
     db,
-    `SELECT items.job_url, items.score_version, items.requirement_id,
+    `SELECT ${jobUrlExpression} AS job_url,
+            items.score_version, items.requirement_id,
             items.requirement_text, items.tier, items.weight, items.job_evidence_span,
             items.fit_json, items.contribution_json, items.tailoring_json,
             items.artifact_coverage_json,
             ${jobMetadata.selectSql}
        FROM job_requirement_fit_items AS items
+       ${stableJobJoin}
        ${jobMetadata.joinSql}${lifecycle.joinSql}
       WHERE items.tenant_id = ?${lifecycle.whereSql}
         AND items.score_version = (
           SELECT MAX(report.score_version)
-            FROM job_requirement_fit_reports AS report
+           FROM job_requirement_fit_reports AS report
            WHERE report.tenant_id = items.tenant_id
-             AND report.job_url = items.job_url
+             AND report.${reportReference} = items.${itemReference}
         )
-      ORDER BY items.job_url, items.position, items.requirement_id`,
+      ORDER BY ${jobUrlExpression}, items.position, items.requirement_id`,
     [tenantId],
   );
   for (const row of rows) {
@@ -2709,6 +2747,8 @@ function loadLatestScore(db: SqliteDatabase, jobUrl: string): ScoreLatest {
   if (!tableExists(db, "job_scores")) {
     return emptyScore();
   }
+  const referenceColumn = jobReferenceColumn(db, "job_scores");
+  const referenceValue = jobReferenceForUrl(db, "job_scores", jobUrl);
   const row = getRow<{
     fit_score: number;
     version: number;
@@ -2722,8 +2762,11 @@ function loadLatestScore(db: SqliteDatabase, jobUrl: string): ScoreLatest {
     db,
     `SELECT fit_score, version, breakdown_json, keywords_json, scored_at,
             correction_json, criteria_json, trace_json
-     FROM job_scores WHERE job_url = ? ORDER BY version DESC LIMIT 1`,
-    [jobUrl],
+     FROM job_scores
+     WHERE tenant_id = 'local'
+       AND ${referenceColumn} = ?
+     ORDER BY version DESC LIMIT 1`,
+    [referenceValue],
   );
   if (!row) {
     return emptyScore();

--- a/apps/api/src/read-model.ts
+++ b/apps/api/src/read-model.ts
@@ -76,6 +76,7 @@ import {
   allRows,
   getRow,
   hasCompositeJobIdForeignKey,
+  jobReferenceColumn,
   tableExists,
   type SqliteDatabase,
   type SqliteValue,
@@ -908,45 +909,96 @@ function countOutdatedScores(
   if (activeJobs.size === 0) return 0;
 
   if (tableExists(db, "job_score_staleness")) {
+    const staleReference = jobReferenceColumn(db, "job_score_staleness");
+    const stableReferences = staleReference === "job_id";
     const rows = tableExists(db, "job_scores")
-      ? allRows<{ job_url: string }>(
-          db,
-          `SELECT DISTINCT stale.job_url
-             FROM job_score_staleness stale
-             JOIN (
-               SELECT job_url, MAX(version) AS max_version
-               FROM job_scores
-               WHERE tenant_id = ?
-               GROUP BY job_url
-             ) latest ON latest.job_url = stale.job_url
-             JOIN job_scores s
-               ON s.tenant_id = stale.tenant_id
-              AND s.job_url = stale.job_url
-              AND s.version = latest.max_version
-            WHERE stale.tenant_id = ?
-              AND stale.resolved = 0
-              AND (s.correction_json IS NULL OR TRIM(s.correction_json) = '')`,
-          [tenantId, tenantId],
-        )
-      : allRows<{ job_url: string }>(
-          db,
-          "SELECT DISTINCT job_url FROM job_score_staleness WHERE tenant_id = ? AND resolved = 0",
-          [tenantId],
-        );
+      ? (
+        stableReferences
+          ? allRows<{ job_url: string }>(
+              db,
+              `SELECT DISTINCT jobs.url AS job_url
+                 FROM job_score_staleness stale
+                 JOIN jobs
+                   ON jobs.tenant_id = stale.tenant_id
+                  AND jobs.job_id = stale.job_id
+                 JOIN (
+                   SELECT tenant_id, job_id, MAX(version) AS max_version
+                   FROM job_scores
+                   WHERE tenant_id = ?
+                   GROUP BY tenant_id, job_id
+                 ) latest
+                   ON latest.tenant_id = stale.tenant_id
+                  AND latest.job_id = stale.job_id
+                 JOIN job_scores s
+                   ON s.tenant_id = stale.tenant_id
+                  AND s.job_id = stale.job_id
+                  AND s.version = latest.max_version
+                WHERE stale.tenant_id = ?
+                  AND stale.resolved = 0
+                  AND (s.correction_json IS NULL OR TRIM(s.correction_json) = '')`,
+              [tenantId, tenantId],
+            )
+          : allRows<{ job_url: string }>(
+              db,
+              `SELECT DISTINCT stale.job_url
+                 FROM job_score_staleness stale
+                 JOIN (
+                   SELECT job_url, MAX(version) AS max_version
+                   FROM job_scores
+                   WHERE tenant_id = ?
+                   GROUP BY job_url
+                 ) latest ON latest.job_url = stale.job_url
+                 JOIN job_scores s
+                   ON s.tenant_id = stale.tenant_id
+                  AND s.job_url = stale.job_url
+                  AND s.version = latest.max_version
+                WHERE stale.tenant_id = ?
+                  AND stale.resolved = 0
+                  AND (s.correction_json IS NULL OR TRIM(s.correction_json) = '')`,
+              [tenantId, tenantId],
+            )
+      )
+      : (
+        stableReferences
+          ? allRows<{ job_url: string }>(
+              db,
+              `SELECT DISTINCT jobs.url AS job_url
+                 FROM job_score_staleness stale
+                 JOIN jobs
+                   ON jobs.tenant_id = stale.tenant_id
+                  AND jobs.job_id = stale.job_id
+                WHERE stale.tenant_id = ? AND stale.resolved = 0`,
+              [tenantId],
+            )
+          : allRows<{ job_url: string }>(
+              db,
+              "SELECT DISTINCT job_url FROM job_score_staleness WHERE tenant_id = ? AND resolved = 0",
+              [tenantId],
+            )
+      );
     return rows.filter((row) => activeJobs.has(row.job_url)).length;
   }
 
   if (currentPolicyVersion === null || !tableExists(db, "job_scores")) return 0;
+  const scoreReference = jobReferenceColumn(db, "job_scores");
+  const stableScores = scoreReference === "job_id";
   const rows = allRows<{ job_url: string; trace_json: string | null; correction_json: string | null }>(
     db,
-    `SELECT s.job_url, s.trace_json, s.correction_json
+    `SELECT ${stableScores ? "jobs.url" : "s.job_url"} AS job_url,
+            s.trace_json, s.correction_json
        FROM job_scores s
+       ${stableScores
+         ? "JOIN jobs ON jobs.tenant_id = s.tenant_id AND jobs.job_id = s.job_id"
+         : ""}
        JOIN (
-         SELECT job_url, MAX(version) AS max_version
+         SELECT tenant_id, ${scoreReference}, MAX(version) AS max_version
          FROM job_scores
          WHERE tenant_id = ?
-         GROUP BY job_url
-       ) latest ON latest.job_url = s.job_url AND latest.max_version = s.version
+         GROUP BY tenant_id, ${scoreReference}
+       ) latest
+         ON latest.tenant_id = s.tenant_id
+        AND latest.${scoreReference} = s.${scoreReference}
+        AND latest.max_version = s.version
       WHERE s.tenant_id = ?`,
     [tenantId, tenantId],
   );
@@ -4737,32 +4789,42 @@ function jobProjectionSelect(db: SqliteDatabase): string {
            AND h.unhidden_at IS NULL
          LIMIT 1) AS hidden_at`
     : "NULL AS hidden_at";
+  const staleReference = tableExists(db, "job_score_staleness")
+    ? jobReferenceColumn(db, "job_score_staleness")
+    : "job_url";
+  const staleJobReference = staleReference === "job_id"
+    ? `(SELECT j.job_id
+          FROM jobs j
+         WHERE j.tenant_id = job_list_projections.tenant_id
+           AND j.url = job_list_projections.job_id
+         LIMIT 1)`
+    : "job_list_projections.job_id";
   const stalenessSelect = tableExists(db, "job_score_staleness")
     ? `(SELECT s.stale_reason
           FROM job_score_staleness s
          WHERE s.tenant_id = job_list_projections.tenant_id
-           AND s.job_url = job_list_projections.job_id
+           AND s.${staleReference} = ${staleJobReference}
            AND s.resolved = 0
          ORDER BY s.marked_at DESC
          LIMIT 1) AS score_stale_reason,
        (SELECT s.old_policy_version
           FROM job_score_staleness s
          WHERE s.tenant_id = job_list_projections.tenant_id
-           AND s.job_url = job_list_projections.job_id
+           AND s.${staleReference} = ${staleJobReference}
            AND s.resolved = 0
          ORDER BY s.marked_at DESC
          LIMIT 1) AS score_stale_old_policy_version,
        (SELECT s.new_policy_version
           FROM job_score_staleness s
          WHERE s.tenant_id = job_list_projections.tenant_id
-           AND s.job_url = job_list_projections.job_id
+           AND s.${staleReference} = ${staleJobReference}
            AND s.resolved = 0
          ORDER BY s.marked_at DESC
          LIMIT 1) AS score_stale_new_policy_version,
        (SELECT s.marked_at
           FROM job_score_staleness s
          WHERE s.tenant_id = job_list_projections.tenant_id
-           AND s.job_url = job_list_projections.job_id
+           AND s.${staleReference} = ${staleJobReference}
            AND s.resolved = 0
          ORDER BY s.marked_at DESC
          LIMIT 1) AS score_stale_marked_at`

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -150,7 +150,11 @@ import {
   readCompensationSourcePreferences,
   updateCompensationSourcePolicy,
 } from "./compensation-source-policy.js";
-import { databaseExists, openDatabase } from "./db.js";
+import {
+  databaseExists,
+  jobReferenceColumn,
+  openDatabase,
+} from "./db.js";
 import { ConfigFileInputError } from "./config-file.js";
 import { getMarketCompensationEstimate } from "./market-compensation-estimates.js";
 import { getPostedCompensationFact } from "./posted-compensation-facts.js";
@@ -3614,11 +3618,14 @@ function preparationPickupEligibility(
   if (!tableExists(db, "job_list_projections")) {
     return ineligiblePickup("projection_unavailable", "Preparation pickup is waiting for job projections.");
   }
+  const staleReference = tableExists(db, "job_score_staleness")
+    ? jobReferenceColumn(db, "job_score_staleness")
+    : "job_url";
   const staleScoreSelect = tableExists(db, "job_score_staleness")
     ? `(SELECT COUNT(*)
         FROM job_score_staleness stale
         WHERE stale.tenant_id = 'local'
-          AND stale.job_url = jobs.url
+          AND stale.${staleReference} = jobs.${staleReference === "job_id" ? "job_id" : "url"}
           AND stale.resolved = 0)`
     : "0";
   const row = db

--- a/apps/api/src/write-model.ts
+++ b/apps/api/src/write-model.ts
@@ -26,6 +26,8 @@ import {
   allRows,
   getRow,
   hasCompositeJobIdForeignKey,
+  jobReferenceColumn,
+  jobReferenceForUrl,
   tableExists,
   type SqliteDatabase,
   type SqliteValue,
@@ -353,12 +355,14 @@ export function correctScore(
   }
   ensureJobScoresTable(db);
   ensureScoreStalenessTable(db);
+  const scoreReferenceColumn = jobReferenceColumn(db, "job_scores");
+  const scoreReference = jobReferenceForUrl(db, "job_scores", jobUrl);
   const latest = getRow<Record<string, unknown>>(
     db,
     `SELECT * FROM job_scores
-     WHERE tenant_id = 'local' AND job_url = ?
+     WHERE tenant_id = 'local' AND ${scoreReferenceColumn} = ?
      ORDER BY version DESC LIMIT 1`,
-    [jobUrl],
+    [scoreReference],
   );
   if (!latest) {
     throw new InputError("Score correction requires an existing score.");
@@ -381,11 +385,12 @@ export function correctScore(
   const transaction = db.transaction(() => {
     db.prepare(
       `INSERT INTO job_scores (
-         job_url, version, tenant_id, fit_score, breakdown_json, keywords_json,
+         ${scoreReferenceColumn}, version, tenant_id,
+         fit_score, breakdown_json, keywords_json,
          scored_at, correction_json, criteria_json, trace_json
        ) VALUES (?, ?, 'local', ?, ?, ?, ?, ?, ?, ?)`,
     ).run(
-      jobUrl,
+      scoreReference,
       nextVersion,
       request.correctedScore,
       String(latest.breakdown_json ?? "{}"),
@@ -434,17 +439,34 @@ export function resetStaleScoresForRescore(
   ensureScoreStalenessTable(db);
   const limit = Math.max(0, Math.floor(request.limit ?? 0));
   const jobKeysFilter = [...new Set((request.jobKeys ?? []).map((key) => key.trim()).filter(Boolean))];
+  const staleReferenceColumn = jobReferenceColumn(db, "job_score_staleness");
+  const selectedReferences = jobKeysFilter
+    .map((key) => resolveJobUrl(db, key))
+    .filter((jobUrl): jobUrl is string => Boolean(jobUrl))
+    .map((jobUrl) => jobReferenceForUrl(db, "job_score_staleness", jobUrl));
   const selectedWhere = jobKeysFilter.length
-    ? ` AND job_url IN (${jobKeysFilter.map(() => "?").join(", ")})`
+    ? (
+      selectedReferences.length
+        ? ` AND stale.${staleReferenceColumn} IN (${selectedReferences.map(() => "?").join(", ")})`
+        : " AND 0 = 1"
+    )
     : "";
+  const identityJoin = staleReferenceColumn === "job_id"
+    ? "JOIN jobs ON jobs.tenant_id = stale.tenant_id AND jobs.job_id = stale.job_id"
+    : "";
+  const jobUrlSelect = staleReferenceColumn === "job_id"
+    ? "jobs.url"
+    : "stale.job_url";
   const rows = allRows<Record<string, unknown>>(
     db,
-    `SELECT job_url, stale_reason, old_policy_version, new_policy_version
-     FROM job_score_staleness
-     WHERE tenant_id = 'local' AND resolved = 0
+    `SELECT ${jobUrlSelect} AS job_url, stale.${staleReferenceColumn} AS job_reference,
+            stale.stale_reason, stale.old_policy_version, stale.new_policy_version
+     FROM job_score_staleness stale
+     ${identityJoin}
+     WHERE stale.tenant_id = 'local' AND stale.resolved = 0
        ${selectedWhere}
-     ORDER BY marked_at ASC${limit > 0 ? " LIMIT ?" : ""}`,
-    [...jobKeysFilter, ...(limit > 0 ? [limit] : [])],
+     ORDER BY stale.marked_at ASC${limit > 0 ? " LIMIT ?" : ""}`,
+    [...selectedReferences, ...(limit > 0 ? [limit] : [])],
   );
   const now = new Date().toISOString();
   const jobKeys = rows.map((row) => String(row.job_url ?? "")).filter(Boolean);
@@ -463,13 +485,13 @@ export function resetStaleScoresForRescore(
           SET resolved = 1,
               resolved_at = ?
         WHERE tenant_id = 'local'
-          AND job_url = ?
+          AND ${staleReferenceColumn} = ?
           AND stale_reason = ?
           AND old_policy_version = ?
           AND new_policy_version = ?`,
     ).run(
       now,
-      jobUrl,
+      String(row.job_reference ?? ""),
       String(row.stale_reason ?? ""),
       Number(row.old_policy_version ?? 0),
       Number(row.new_policy_version ?? 0),
@@ -806,8 +828,7 @@ function purgeJobRows(db: SqliteDatabase, jobUrl: string): void {
   deleteWhere(db, "job_stage_states", "job_url = ?", [jobUrl]);
   deleteWhere(db, "job_events", "job_url = ?", [jobUrl]);
   deleteWhere(db, "job_artifacts", "job_url = ?", [jobUrl]);
-  deleteWhere(db, "job_scores", "job_url = ?", [jobUrl]);
-  deleteWhere(db, "job_score_staleness", "job_url = ?", [jobUrl]);
+  deleteScoringJobReferences(db, jobId, jobUrl);
   deleteWhere(db, "job_materials_artifacts", "job_url = ?", [jobUrl]);
   deleteWhere(db, "job_materials", "job_url = ?", [jobUrl]);
   deleteEnrichmentJobReferences(db, jobId, jobUrl);
@@ -939,22 +960,60 @@ function deleteWhere(db: SqliteDatabase, tableName: string, whereSql: string, pa
   db.prepare(`DELETE FROM ${tableName} WHERE ${whereSql}`).run(...params);
 }
 
+function deleteScoringJobReferences(
+  db: SqliteDatabase,
+  jobId: string | undefined,
+  jobUrl: string,
+): void {
+  for (const tableName of [
+    "job_requirement_fit_items",
+    "job_requirement_fit_reports",
+    "job_score_staleness",
+    "job_scores",
+  ]) {
+    if (!tableExists(db, tableName)) continue;
+    const referenceColumn = jobReferenceColumn(db, tableName);
+    const reference = referenceColumn === "job_id" ? jobId : jobUrl;
+    if (!reference) continue;
+    deleteWhere(db, tableName, `${referenceColumn} = ?`, [reference]);
+  }
+}
+
 function ensureJobScoresTable(db: SqliteDatabase): void {
-  db.exec(`
-    CREATE TABLE IF NOT EXISTS job_scores (
-      job_url TEXT NOT NULL,
-      version INTEGER NOT NULL,
-      tenant_id TEXT NOT NULL DEFAULT 'local',
-      fit_score INTEGER NOT NULL,
-      breakdown_json TEXT NOT NULL,
-      keywords_json TEXT NOT NULL,
-      scored_at TEXT NOT NULL,
-      correction_json TEXT,
-      criteria_json TEXT NOT NULL DEFAULT '{}',
-      trace_json TEXT NOT NULL DEFAULT '{}',
-      PRIMARY KEY (job_url, version)
-    )
-  `);
+  const schemaVersion = db.pragma("user_version", { simple: true }) as number;
+  db.exec(schemaVersion >= 12
+    ? `
+      CREATE TABLE IF NOT EXISTS job_scores (
+        tenant_id TEXT NOT NULL DEFAULT 'local',
+        job_id TEXT NOT NULL,
+        version INTEGER NOT NULL CHECK(version > 0),
+        fit_score INTEGER NOT NULL CHECK(fit_score BETWEEN 1 AND 10),
+        breakdown_json TEXT NOT NULL,
+        keywords_json TEXT NOT NULL,
+        scored_at TEXT NOT NULL,
+        correction_json TEXT,
+        criteria_json TEXT NOT NULL DEFAULT '{}',
+        trace_json TEXT NOT NULL DEFAULT '{}',
+        PRIMARY KEY (tenant_id, job_id, version),
+        FOREIGN KEY (tenant_id, job_id)
+          REFERENCES jobs(tenant_id, job_id) ON DELETE CASCADE
+      )
+    `
+    : `
+      CREATE TABLE IF NOT EXISTS job_scores (
+        job_url TEXT NOT NULL,
+        version INTEGER NOT NULL,
+        tenant_id TEXT NOT NULL DEFAULT 'local',
+        fit_score INTEGER NOT NULL,
+        breakdown_json TEXT NOT NULL,
+        keywords_json TEXT NOT NULL,
+        scored_at TEXT NOT NULL,
+        correction_json TEXT,
+        criteria_json TEXT NOT NULL DEFAULT '{}',
+        trace_json TEXT NOT NULL DEFAULT '{}',
+        PRIMARY KEY (job_url, version)
+      )
+    `);
   const columns = columnNames(db, "job_scores");
   if (!columns.has("criteria_json")) {
     db.exec("ALTER TABLE job_scores ADD COLUMN criteria_json TEXT NOT NULL DEFAULT '{}'");
@@ -965,32 +1024,56 @@ function ensureJobScoresTable(db: SqliteDatabase): void {
 }
 
 function ensureScoreStalenessTable(db: SqliteDatabase): void {
-  db.exec(`
-    CREATE TABLE IF NOT EXISTS job_score_staleness (
-      tenant_id TEXT NOT NULL DEFAULT 'local',
-      job_url TEXT NOT NULL,
-      stale_reason TEXT NOT NULL,
-      old_policy_id TEXT NOT NULL DEFAULT '',
-      old_policy_version INTEGER NOT NULL,
-      new_policy_id TEXT NOT NULL DEFAULT '',
-      new_policy_version INTEGER NOT NULL,
-      marked_at TEXT NOT NULL,
-      resolved INTEGER NOT NULL DEFAULT 0,
-      resolved_at TEXT,
-      resolved_by_score_version INTEGER,
-      PRIMARY KEY (
-        tenant_id, job_url, stale_reason,
-        old_policy_version, new_policy_version
+  const schemaVersion = db.pragma("user_version", { simple: true }) as number;
+  db.exec(schemaVersion >= 12
+    ? `
+      CREATE TABLE IF NOT EXISTS job_score_staleness (
+        tenant_id TEXT NOT NULL DEFAULT 'local',
+        job_id TEXT NOT NULL,
+        stale_reason TEXT NOT NULL,
+        old_policy_id TEXT NOT NULL DEFAULT '',
+        old_policy_version INTEGER NOT NULL,
+        new_policy_id TEXT NOT NULL DEFAULT '',
+        new_policy_version INTEGER NOT NULL,
+        marked_at TEXT NOT NULL,
+        resolved INTEGER NOT NULL DEFAULT 0 CHECK(resolved IN (0, 1)),
+        resolved_at TEXT,
+        resolved_by_score_version INTEGER,
+        PRIMARY KEY (
+          tenant_id, job_id, stale_reason,
+          old_policy_version, new_policy_version
+        ),
+        FOREIGN KEY (tenant_id, job_id)
+          REFERENCES jobs(tenant_id, job_id) ON DELETE CASCADE
       )
-    )
-  `);
+    `
+    : `
+      CREATE TABLE IF NOT EXISTS job_score_staleness (
+        tenant_id TEXT NOT NULL DEFAULT 'local',
+        job_url TEXT NOT NULL,
+        stale_reason TEXT NOT NULL,
+        old_policy_id TEXT NOT NULL DEFAULT '',
+        old_policy_version INTEGER NOT NULL,
+        new_policy_id TEXT NOT NULL DEFAULT '',
+        new_policy_version INTEGER NOT NULL,
+        marked_at TEXT NOT NULL,
+        resolved INTEGER NOT NULL DEFAULT 0,
+        resolved_at TEXT,
+        resolved_by_score_version INTEGER,
+        PRIMARY KEY (
+          tenant_id, job_url, stale_reason,
+          old_policy_version, new_policy_version
+        )
+      )
+    `);
+  const referenceColumn = jobReferenceColumn(db, "job_score_staleness");
   db.exec(`
     CREATE INDEX IF NOT EXISTS idx_job_score_staleness_unresolved
     ON job_score_staleness(tenant_id, resolved, marked_at DESC)
   `);
   db.exec(`
     CREATE INDEX IF NOT EXISTS idx_job_score_staleness_job
-    ON job_score_staleness(tenant_id, job_url, resolved)
+    ON job_score_staleness(tenant_id, ${referenceColumn}, resolved)
   `);
 }
 
@@ -1076,17 +1159,28 @@ function markComparableScoresStale(
   },
 ): void {
   ensureScoreStalenessTable(db);
+  const scoreReferenceColumn = jobReferenceColumn(db, "job_scores");
+  const staleReferenceColumn = jobReferenceColumn(db, "job_score_staleness");
+  const identityJoin = scoreReferenceColumn === "job_id"
+    ? "JOIN jobs ON jobs.tenant_id = s.tenant_id AND jobs.job_id = s.job_id"
+    : "";
+  const jobUrlSelect = scoreReferenceColumn === "job_id"
+    ? "jobs.url"
+    : "s.job_url";
   const latestRows = allRows<Record<string, unknown>>(
     db,
-    `SELECT s.job_url, s.trace_json
+    `SELECT ${jobUrlSelect} AS job_url, s.trace_json
      FROM job_scores s
+     ${identityJoin}
      INNER JOIN (
-       SELECT job_url, MAX(version) AS max_version
+       SELECT tenant_id, ${scoreReferenceColumn}, MAX(version) AS max_version
        FROM job_scores
        WHERE tenant_id = 'local'
-       GROUP BY job_url
+       GROUP BY tenant_id, ${scoreReferenceColumn}
      ) latest
-       ON latest.job_url = s.job_url AND latest.max_version = s.version
+       ON latest.tenant_id = s.tenant_id
+      AND latest.${scoreReferenceColumn} = s.${scoreReferenceColumn}
+      AND latest.max_version = s.version
      WHERE s.tenant_id = 'local'
        AND (s.correction_json IS NULL OR TRIM(s.correction_json) = '')`,
   );
@@ -1102,17 +1196,22 @@ function markComparableScoresStale(
     }
     const staleReason = "scoring_policy_changed";
     const oldPolicyId = String(trace.scoring_policy_id ?? "");
+    const staleReference = jobReferenceForUrl(
+      db,
+      "job_score_staleness",
+      jobUrl,
+    );
     const result = db
       .prepare(
         `INSERT OR IGNORE INTO job_score_staleness (
-           tenant_id, job_url, stale_reason,
+           tenant_id, ${staleReferenceColumn}, stale_reason,
            old_policy_id, old_policy_version,
            new_policy_id, new_policy_version,
            marked_at, resolved, resolved_at, resolved_by_score_version
          ) VALUES ('local', ?, ?, ?, ?, ?, ?, ?, 0, NULL, NULL)`,
       )
       .run(
-        jobUrl,
+        staleReference,
         staleReason,
         oldPolicyId,
         oldPolicyVersion,

--- a/apps/api/test/projections.test.ts
+++ b/apps/api/test/projections.test.ts
@@ -2390,15 +2390,26 @@ describe("apply_run_projections without legacy apply_runs table", () => {
     }
   });
 
-  it("serves the canonical requirement fit report from projection rows", async () => {
+  it.each([
+    { label: "v11 URL references", stableReferences: false },
+    { label: "v12 stable JobId references", stableReferences: true },
+  ])("serves the canonical requirement fit report from $label", async ({ stableReferences }) => {
     const { dbPath, cleanup } = withTempDb();
     const jobUrl = "https://example.com/jobs/event-driven";
     try {
       seedSchema(dbPath);
       const db = new Database(dbPath);
+      const referenceColumn = stableReferences ? "job_id" : "job_url";
+      const referenceValue = stableReferences
+        ? (
+            db.prepare(
+              "SELECT job_id FROM jobs WHERE tenant_id = 'local' AND url = ?",
+            ).get(jobUrl) as { job_id: string }
+          ).job_id
+        : jobUrl;
       db.exec(`
         CREATE TABLE job_requirement_fit_reports (
-          job_url TEXT NOT NULL,
+          ${referenceColumn} TEXT NOT NULL,
           score_version INTEGER NOT NULL,
           tenant_id TEXT NOT NULL DEFAULT 'local',
           employer_analysis_generation INTEGER NOT NULL,
@@ -2410,10 +2421,10 @@ describe("apply_run_projections without legacy apply_runs table", () => {
           confidence TEXT NOT NULL,
           summary_json TEXT NOT NULL DEFAULT '{}',
           created_at TEXT NOT NULL,
-          PRIMARY KEY (job_url, score_version, tenant_id)
+          PRIMARY KEY (${referenceColumn}, score_version, tenant_id)
         );
         CREATE TABLE job_requirement_fit_items (
-          job_url TEXT NOT NULL,
+          ${referenceColumn} TEXT NOT NULL,
           score_version INTEGER NOT NULL,
           tenant_id TEXT NOT NULL DEFAULT 'local',
           requirement_id TEXT NOT NULL,
@@ -2426,18 +2437,18 @@ describe("apply_run_projections without legacy apply_runs table", () => {
           tailoring_json TEXT NOT NULL DEFAULT '{}',
           artifact_coverage_json TEXT,
           position INTEGER NOT NULL DEFAULT 0,
-          PRIMARY KEY (job_url, score_version, tenant_id, requirement_id)
+          PRIMARY KEY (${referenceColumn}, score_version, tenant_id, requirement_id)
         );
       `);
       const insertReport = db.prepare(
         `INSERT INTO job_requirement_fit_reports (
-          job_url, score_version, tenant_id, employer_analysis_generation,
+          ${referenceColumn}, score_version, tenant_id, employer_analysis_generation,
           profile_snapshot_version, scoring_policy_version, formula_version,
           resolved_fit_score, fit_band, confidence, summary_json, created_at
         ) VALUES (?, ?, 'local', ?, ?, ?, 'requirement-fit-v1', ?, ?, ?, ?, ?)`,
       );
       insertReport.run(
-        jobUrl,
+        referenceValue,
         1,
         1,
         2,
@@ -2454,7 +2465,7 @@ describe("apply_run_projections without legacy apply_runs table", () => {
         "2026-05-04T11:00:00+00:00",
       );
       insertReport.run(
-        jobUrl,
+        referenceValue,
         2,
         2,
         3,
@@ -2472,12 +2483,12 @@ describe("apply_run_projections without legacy apply_runs table", () => {
       );
       db.prepare(
         `INSERT INTO job_requirement_fit_items (
-          job_url, score_version, tenant_id, requirement_id, requirement_text,
+          ${referenceColumn}, score_version, tenant_id, requirement_id, requirement_text,
           tier, weight, job_evidence_span, fit_json, contribution_json,
           tailoring_json, artifact_coverage_json, position
         ) VALUES (?, 2, 'local', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       ).run(
-        jobUrl,
+        referenceValue,
         "r1",
         "5+ years Python",
         "must_have",

--- a/apps/api/test/server.test.ts
+++ b/apps/api/test/server.test.ts
@@ -4007,6 +4007,83 @@ describe("local TypeScript API", () => {
     }
   });
 
+  it("writes and resets score policy staleness through v12 stable JobIds", async () => {
+    const comparableUrl = "https://example.com/jobs/stable-comparable";
+    const seedDb = new Database(options.dbPath);
+    insertJob(seedDb, {
+      url: comparableUrl,
+      title: "Stable Comparable Engineer",
+      site: "ExampleCo",
+      fitScore: 7,
+    });
+    insertScore(seedDb, comparableUrl, 1, 7);
+    insertStage(seedDb, comparableUrl, "score", "succeeded");
+    migrateSeededScoringReferencesToV12(seedDb);
+    seedDb.close();
+
+    const app = buildApp(options);
+    const correctedUrl = "https://example.com/jobs/ready";
+    const correctionResponse = await app.inject({
+      method: "POST",
+      url: `/v1/jobs/${encodeURIComponent(correctedUrl)}/score-correction`,
+      payload: {
+        correctedScore: 6,
+        reason: "Synthetic v12 stable identity correction.",
+      },
+    });
+    expect(correctionResponse.statusCode, correctionResponse.body).toBe(200);
+
+    const resetResponse = await app.inject({
+      method: "POST",
+      url: "/v1/scoring/stale-scores/actions/reset-for-rescore",
+      payload: { limit: 1, jobKeys: [comparableUrl] },
+    });
+    expect(resetResponse.statusCode, resetResponse.body).toBe(200);
+    expect(resetResponse.json()).toMatchObject({
+      ok: true,
+      count: 1,
+      jobKeys: [comparableUrl],
+    });
+
+    const db = new Database(options.dbPath);
+    try {
+      const correctedJobId = (
+        db.prepare("SELECT job_id FROM jobs WHERE tenant_id = 'local' AND url = ?")
+          .get(correctedUrl) as { job_id: string }
+      ).job_id;
+      const comparableJobId = (
+        db.prepare("SELECT job_id FROM jobs WHERE tenant_id = 'local' AND url = ?")
+          .get(comparableUrl) as { job_id: string }
+      ).job_id;
+      expect(
+        db.prepare(
+          "SELECT version, fit_score FROM job_scores "
+            + "WHERE tenant_id = 'local' AND job_id = ? ORDER BY version",
+        ).all(correctedJobId),
+      ).toEqual([
+        { version: 1, fit_score: 9 },
+        { version: 2, fit_score: 6 },
+      ]);
+      expect(
+        db.prepare(
+          "SELECT resolved, resolved_at FROM job_score_staleness "
+            + "WHERE tenant_id = 'local' AND job_id = ?",
+        ).get(comparableJobId),
+      ).toMatchObject({ resolved: 1, resolved_at: expect.any(String) });
+      expect(
+        db.prepare("PRAGMA table_info(job_scores)").all()
+          .map((row) => String((row as { name: unknown }).name)),
+      ).not.toContain("job_url");
+      expect(
+        db.prepare("PRAGMA table_info(job_score_staleness)").all()
+          .map((row) => String((row as { name: unknown }).name)),
+      ).not.toContain("job_url");
+    } finally {
+      db.close();
+      await app.close();
+    }
+  });
+
   it("rolls back the whole score correction when a later staleness write fails", async () => {
     const comparableUrl = "https://example.com/jobs/comparable-atomic";
     const seedDb = new Database(options.dbPath);
@@ -10967,6 +11044,43 @@ function createScoreStalenessTable(db: Database.Database): void {
         old_policy_version, new_policy_version
       )
     )
+  `);
+}
+
+function migrateSeededScoringReferencesToV12(db: Database.Database): void {
+  db.exec(`
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_jobs_tenant_job_id
+      ON jobs(tenant_id, job_id);
+    ALTER TABLE job_scores RENAME TO job_scores_v11;
+    CREATE TABLE job_scores (
+      tenant_id TEXT NOT NULL DEFAULT 'local',
+      job_id TEXT NOT NULL,
+      version INTEGER NOT NULL CHECK(version > 0),
+      fit_score INTEGER NOT NULL CHECK(fit_score BETWEEN 1 AND 10),
+      breakdown_json TEXT NOT NULL,
+      keywords_json TEXT NOT NULL,
+      scored_at TEXT NOT NULL,
+      correction_json TEXT,
+      criteria_json TEXT NOT NULL DEFAULT '{}',
+      trace_json TEXT NOT NULL DEFAULT '{}',
+      PRIMARY KEY (tenant_id, job_id, version),
+      FOREIGN KEY (tenant_id, job_id)
+        REFERENCES jobs(tenant_id, job_id) ON DELETE CASCADE
+    );
+    INSERT INTO job_scores (
+      tenant_id, job_id, version, fit_score, breakdown_json, keywords_json,
+      scored_at, correction_json, criteria_json, trace_json
+    )
+    SELECT
+      jobs.tenant_id, jobs.job_id, legacy.version, legacy.fit_score,
+      legacy.breakdown_json, legacy.keywords_json, legacy.scored_at,
+      legacy.correction_json, legacy.criteria_json, legacy.trace_json
+    FROM job_scores_v11 AS legacy
+    JOIN jobs
+      ON jobs.tenant_id = legacy.tenant_id
+     AND jobs.url = legacy.job_url;
+    DROP TABLE job_scores_v11;
+    PRAGMA user_version = 12;
   `);
 }
 

--- a/workers/automation/src/jobctrl/database.py
+++ b/workers/automation/src/jobctrl/database.py
@@ -49,7 +49,10 @@ from jobctrl.config import DB_PATH, DEFAULTS, migrate_legacy_job_tables
 # v11 (enrichment references): JobEnrichment and PostingSnapshotSet authorities
 # reference ``(tenant_id, job_id)``; embedded snapshot aggregate identity and
 # duplicate-candidate references are upcast in the same transaction.
-SCHEMA_VERSION = 11
+# v12 (scoring references): score history, staleness markers, and requirement-fit
+# authorities reference ``(tenant_id, job_id)`` with dependent score versions
+# remapped atomically when multiple historical URL aliases collapse.
+SCHEMA_VERSION = 12
 
 
 class IncompatibleSchemaVersionError(RuntimeError):
@@ -191,6 +194,7 @@ def _schema_migrations() -> tuple[
         (9, ensure_execution_search_references_v9),
         (10, ensure_preparation_references_v10),
         (11, ensure_enrichment_snapshot_references_v11),
+        (12, ensure_scoring_references_v12),
     )
 
 
@@ -2002,35 +2006,43 @@ def ensure_score_tables(conn: sqlite3.Connection | None = None) -> list[str]:
     if conn is None:
         conn = get_connection()
 
-    conn.execute("""
-        CREATE TABLE IF NOT EXISTS job_scores (
-            job_url             TEXT NOT NULL,
-            version             INTEGER NOT NULL,
-            tenant_id           TEXT NOT NULL DEFAULT 'local',
-            fit_score           INTEGER NOT NULL CHECK(fit_score BETWEEN 1 AND 10),
-            breakdown_json      TEXT NOT NULL,
-            keywords_json       TEXT NOT NULL,
-            scored_at           TEXT NOT NULL,
-            correction_json     TEXT,
-            criteria_json       TEXT NOT NULL DEFAULT '{}',
-            trace_json          TEXT NOT NULL DEFAULT '{}',
-            PRIMARY KEY (job_url, version),
-            FOREIGN KEY (job_url) REFERENCES jobs(url) ON DELETE CASCADE
-        )
-    """)
-    existing_score_cols = {row[1] for row in conn.execute("PRAGMA table_info(job_scores)").fetchall()}
-    if "criteria_json" not in existing_score_cols:
-        conn.execute("ALTER TABLE job_scores ADD COLUMN criteria_json TEXT NOT NULL DEFAULT '{}'")
-    if "trace_json" not in existing_score_cols:
-        conn.execute("ALTER TABLE job_scores ADD COLUMN trace_json TEXT NOT NULL DEFAULT '{}'")
-    conn.execute("""
-        CREATE INDEX IF NOT EXISTS idx_job_scores_tenant_score
-        ON job_scores(tenant_id, fit_score DESC, scored_at DESC)
-    """)
-    conn.execute("""
-        CREATE INDEX IF NOT EXISTS idx_job_scores_job_version
-        ON job_scores(job_url, version DESC)
-    """)
+    current_version = int(conn.execute("PRAGMA user_version").fetchone()[0])
+    if current_version >= _SCORING_REFERENCE_SCHEMA_VERSION:
+        _create_job_scores_v12(conn)
+    else:
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS job_scores (
+                job_url             TEXT NOT NULL,
+                version             INTEGER NOT NULL,
+                tenant_id           TEXT NOT NULL DEFAULT 'local',
+                fit_score           INTEGER NOT NULL CHECK(fit_score BETWEEN 1 AND 10),
+                breakdown_json      TEXT NOT NULL,
+                keywords_json       TEXT NOT NULL,
+                scored_at           TEXT NOT NULL,
+                correction_json     TEXT,
+                criteria_json       TEXT NOT NULL DEFAULT '{}',
+                trace_json          TEXT NOT NULL DEFAULT '{}',
+                PRIMARY KEY (job_url, version),
+                FOREIGN KEY (job_url) REFERENCES jobs(url) ON DELETE CASCADE
+            )
+        """)
+        existing_score_cols = {
+            row[1]
+            for row in conn.execute(
+                "PRAGMA table_info(job_scores)"
+            ).fetchall()
+        }
+        if "criteria_json" not in existing_score_cols:
+            conn.execute(
+                "ALTER TABLE job_scores ADD COLUMN "
+                "criteria_json TEXT NOT NULL DEFAULT '{}'"
+            )
+        if "trace_json" not in existing_score_cols:
+            conn.execute(
+                "ALTER TABLE job_scores ADD COLUMN "
+                "trace_json TEXT NOT NULL DEFAULT '{}'"
+            )
+    _create_job_score_indexes(conn)
     ensure_scoring_policy_tables(conn)
     ensure_score_staleness_tables(conn)
     ensure_requirement_fit_tables(conn)
@@ -2039,9 +2051,16 @@ def ensure_score_tables(conn: sqlite3.Connection | None = None) -> list[str]:
     # job_scores has no rows AND there are jobs with a legacy fit_score.
     backfill_count = conn.execute("SELECT COUNT(*) FROM job_scores").fetchone()[0]
     if backfill_count == 0:
+        jobs_columns = _table_columns(conn, "jobs")
+        tenant_select = (
+            "tenant_id" if "tenant_id" in jobs_columns else "'local'"
+        )
+        job_id_select = "job_id" if "job_id" in jobs_columns else "NULL"
         legacy_rows = conn.execute(
-            """
-            SELECT url, fit_score, score_reasoning, scored_at
+            f"""
+            SELECT url, fit_score, score_reasoning, scored_at,
+                   {tenant_select} AS tenant_id,
+                   {job_id_select} AS job_id
             FROM jobs
             WHERE fit_score IS NOT NULL
               AND fit_score BETWEEN 1 AND 10
@@ -2054,6 +2073,16 @@ def ensure_score_tables(conn: sqlite3.Connection | None = None) -> list[str]:
                 fit = row["fit_score"] if isinstance(row, sqlite3.Row) else row[1]
                 reasoning = row["score_reasoning"] if isinstance(row, sqlite3.Row) else row[2]
                 scored_at = row["scored_at"] if isinstance(row, sqlite3.Row) else row[3]
+                tenant_id = (
+                    str(row["tenant_id"] or "local")
+                    if isinstance(row, sqlite3.Row)
+                    else str(row[4] or "local")
+                )
+                stable_job_id = (
+                    str(row["job_id"] or "")
+                    if isinstance(row, sqlite3.Row)
+                    else str(row[5] or "")
+                )
                 breakdown_json = json.dumps(
                     {
                         "technical_fit": 0,
@@ -2068,16 +2097,29 @@ def ensure_score_tables(conn: sqlite3.Connection | None = None) -> list[str]:
                 # non-empty" invariant (round-1 review M1) intact for
                 # backfilled rows that pre-date keyword extraction.
                 keywords_json = json.dumps(["legacy"])
+                reference_column = (
+                    "job_id"
+                    if "job_id" in _table_columns(conn, "job_scores")
+                    else "job_url"
+                )
+                job_reference = (
+                    stable_job_id if reference_column == "job_id" else str(url)
+                )
+                if not job_reference:
+                    raise RuntimeError(
+                        "score backfill requires stable JobId on schema v12"
+                    )
                 conn.execute(
-                    """
+                    f"""
                     INSERT OR IGNORE INTO job_scores (
-                        job_url, version, tenant_id, fit_score,
+                        {reference_column}, version, tenant_id, fit_score,
                         breakdown_json, keywords_json, scored_at, correction_json,
                         criteria_json, trace_json
-                    ) VALUES (?, 1, 'local', ?, ?, ?, ?, NULL, ?, ?)
+                    ) VALUES (?, 1, ?, ?, ?, ?, ?, NULL, ?, ?)
                     """,
                     (
-                        url,
+                        job_reference,
+                        tenant_id,
                         int(fit),
                         breakdown_json,
                         keywords_json,
@@ -2117,57 +2159,62 @@ def ensure_requirement_fit_tables(conn: sqlite3.Connection | None = None) -> lis
     if conn is None:
         conn = get_connection()
 
-    conn.execute("""
-        CREATE TABLE IF NOT EXISTS job_requirement_fit_reports (
-            job_url                       TEXT NOT NULL,
-            score_version                 INTEGER NOT NULL,
-            tenant_id                     TEXT NOT NULL DEFAULT 'local',
-            employer_analysis_generation  INTEGER NOT NULL,
-            profile_snapshot_version      INTEGER NOT NULL,
-            scoring_policy_version        INTEGER NOT NULL,
-            formula_version               TEXT NOT NULL,
-            resolved_fit_score            INTEGER CHECK(
-                resolved_fit_score IS NULL
-                OR resolved_fit_score BETWEEN 1 AND 10
-            ),
-            fit_band                      TEXT NOT NULL,
-            confidence                    TEXT NOT NULL,
-            summary_json                  TEXT NOT NULL DEFAULT '{}',
-            created_at                    TEXT NOT NULL,
-            PRIMARY KEY (job_url, score_version, tenant_id),
-            FOREIGN KEY (job_url, score_version)
-                REFERENCES job_scores(job_url, version) ON DELETE CASCADE
-        )
-    """)
-    conn.execute("""
-        CREATE TABLE IF NOT EXISTS job_requirement_fit_items (
-            job_url                 TEXT NOT NULL,
-            score_version           INTEGER NOT NULL,
-            tenant_id               TEXT NOT NULL DEFAULT 'local',
-            requirement_id          TEXT NOT NULL,
-            requirement_text        TEXT NOT NULL,
-            tier                    TEXT NOT NULL CHECK(tier IN ('must_have', 'nice_to_have')),
-            weight                  REAL NOT NULL CHECK(weight >= 0 AND weight <= 1),
-            job_evidence_span       TEXT NOT NULL,
-            fit_json                TEXT NOT NULL,
-            contribution_json       TEXT NOT NULL,
-            tailoring_json          TEXT NOT NULL,
-            artifact_coverage_json  TEXT,
-            position                INTEGER NOT NULL DEFAULT 0,
-            PRIMARY KEY (job_url, score_version, tenant_id, requirement_id),
-            FOREIGN KEY (job_url, score_version, tenant_id)
-                REFERENCES job_requirement_fit_reports(job_url, score_version, tenant_id)
-                ON DELETE CASCADE
-        )
-    """)
-    conn.execute("""
-        CREATE INDEX IF NOT EXISTS idx_requirement_fit_reports_tenant_job
-        ON job_requirement_fit_reports(tenant_id, job_url, score_version DESC)
-    """)
-    conn.execute("""
-        CREATE INDEX IF NOT EXISTS idx_requirement_fit_items_requirement
-        ON job_requirement_fit_items(tenant_id, requirement_id)
-    """)
+    current_version = int(conn.execute("PRAGMA user_version").fetchone()[0])
+    if current_version >= _SCORING_REFERENCE_SCHEMA_VERSION:
+        _create_requirement_fit_tables_v12(conn)
+    else:
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS job_requirement_fit_reports (
+                job_url                       TEXT NOT NULL,
+                score_version                 INTEGER NOT NULL,
+                tenant_id                     TEXT NOT NULL DEFAULT 'local',
+                employer_analysis_generation  INTEGER NOT NULL,
+                profile_snapshot_version      INTEGER NOT NULL,
+                scoring_policy_version        INTEGER NOT NULL,
+                formula_version               TEXT NOT NULL,
+                resolved_fit_score            INTEGER CHECK(
+                    resolved_fit_score IS NULL
+                    OR resolved_fit_score BETWEEN 1 AND 10
+                ),
+                fit_band                      TEXT NOT NULL,
+                confidence                    TEXT NOT NULL,
+                summary_json                  TEXT NOT NULL DEFAULT '{}',
+                created_at                    TEXT NOT NULL,
+                PRIMARY KEY (job_url, score_version, tenant_id),
+                FOREIGN KEY (job_url, score_version)
+                    REFERENCES job_scores(job_url, version) ON DELETE CASCADE
+            )
+        """)
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS job_requirement_fit_items (
+                job_url                 TEXT NOT NULL,
+                score_version           INTEGER NOT NULL,
+                tenant_id               TEXT NOT NULL DEFAULT 'local',
+                requirement_id          TEXT NOT NULL,
+                requirement_text        TEXT NOT NULL,
+                tier                    TEXT NOT NULL CHECK(
+                    tier IN ('must_have', 'nice_to_have')
+                ),
+                weight                  REAL NOT NULL CHECK(
+                    weight >= 0 AND weight <= 1
+                ),
+                job_evidence_span       TEXT NOT NULL,
+                fit_json                TEXT NOT NULL,
+                contribution_json       TEXT NOT NULL,
+                tailoring_json          TEXT NOT NULL,
+                artifact_coverage_json  TEXT,
+                position                INTEGER NOT NULL DEFAULT 0,
+                PRIMARY KEY (
+                    job_url, score_version, tenant_id, requirement_id
+                ),
+                FOREIGN KEY (job_url, score_version, tenant_id)
+                    REFERENCES job_requirement_fit_reports(
+                        job_url, score_version, tenant_id
+                    )
+                    ON DELETE CASCADE
+            )
+        """)
+    _create_requirement_fit_indexes(conn)
     conn.commit()
     return ["job_requirement_fit_reports", "job_requirement_fit_items"]
 
@@ -2209,40 +2256,33 @@ def ensure_score_staleness_tables(conn: sqlite3.Connection | None = None) -> lis
     if conn is None:
         conn = get_connection()
 
-    conn.execute(
-        """
-        CREATE TABLE IF NOT EXISTS job_score_staleness (
-            tenant_id                 TEXT NOT NULL DEFAULT 'local',
-            job_url                   TEXT NOT NULL,
-            stale_reason              TEXT NOT NULL,
-            old_policy_id             TEXT NOT NULL DEFAULT '',
-            old_policy_version        INTEGER NOT NULL,
-            new_policy_id             TEXT NOT NULL DEFAULT '',
-            new_policy_version        INTEGER NOT NULL,
-            marked_at                 TEXT NOT NULL,
-            resolved                  INTEGER NOT NULL DEFAULT 0,
-            resolved_at               TEXT,
-            resolved_by_score_version INTEGER,
-            PRIMARY KEY (
-                tenant_id, job_url, stale_reason,
-                old_policy_version, new_policy_version
-            ),
-            FOREIGN KEY (job_url) REFERENCES jobs(url) ON DELETE CASCADE
+    current_version = int(conn.execute("PRAGMA user_version").fetchone()[0])
+    if current_version >= _SCORING_REFERENCE_SCHEMA_VERSION:
+        _create_score_staleness_v12(conn)
+    else:
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS job_score_staleness (
+                tenant_id                 TEXT NOT NULL DEFAULT 'local',
+                job_url                   TEXT NOT NULL,
+                stale_reason              TEXT NOT NULL,
+                old_policy_id             TEXT NOT NULL DEFAULT '',
+                old_policy_version        INTEGER NOT NULL,
+                new_policy_id             TEXT NOT NULL DEFAULT '',
+                new_policy_version        INTEGER NOT NULL,
+                marked_at                 TEXT NOT NULL,
+                resolved                  INTEGER NOT NULL DEFAULT 0,
+                resolved_at               TEXT,
+                resolved_by_score_version INTEGER,
+                PRIMARY KEY (
+                    tenant_id, job_url, stale_reason,
+                    old_policy_version, new_policy_version
+                ),
+                FOREIGN KEY (job_url) REFERENCES jobs(url) ON DELETE CASCADE
+            )
+            """
         )
-        """
-    )
-    conn.execute(
-        """
-        CREATE INDEX IF NOT EXISTS idx_job_score_staleness_unresolved
-        ON job_score_staleness(tenant_id, resolved, marked_at DESC)
-        """
-    )
-    conn.execute(
-        """
-        CREATE INDEX IF NOT EXISTS idx_job_score_staleness_job
-        ON job_score_staleness(tenant_id, job_url, resolved)
-        """
-    )
+    _create_score_staleness_indexes(conn)
     conn.commit()
     return ["job_score_staleness"]
 
@@ -4219,6 +4259,13 @@ def _reassign_discovery_identity_references(
         )
     if _has_enrichment_snapshot_reference_schema_v11(conn):
         _reassign_enrichment_snapshot_references_v11(
+            conn,
+            tenant_id=tenant_id,
+            losing_job_id=losing_job_id,
+            surviving_job_id=surviving_job_id,
+        )
+    if _has_scoring_reference_schema_v12(conn):
+        _reassign_scoring_references_v12(
             conn,
             tenant_id=tenant_id,
             losing_job_id=losing_job_id,
@@ -6491,6 +6538,1355 @@ def _verify_enrichment_snapshot_references_v11(
         )
 
 
+_SCORING_REFERENCE_SCHEMA_VERSION = 12
+_SCORING_REFERENCE_TABLES = (
+    "job_scores",
+    "job_score_staleness",
+    "job_requirement_fit_reports",
+    "job_requirement_fit_items",
+)
+
+
+def _create_job_scores_v12(
+    conn: sqlite3.Connection,
+    *,
+    table_name: str = "job_scores",
+) -> None:
+    conn.execute(
+        f"""
+        CREATE TABLE IF NOT EXISTS {table_name} (
+            tenant_id        TEXT NOT NULL DEFAULT 'local',
+            job_id           TEXT NOT NULL,
+            version          INTEGER NOT NULL CHECK(version > 0),
+            fit_score        INTEGER NOT NULL CHECK(fit_score BETWEEN 1 AND 10),
+            breakdown_json   TEXT NOT NULL,
+            keywords_json    TEXT NOT NULL,
+            scored_at        TEXT NOT NULL,
+            correction_json  TEXT,
+            criteria_json    TEXT NOT NULL DEFAULT '{{}}',
+            trace_json       TEXT NOT NULL DEFAULT '{{}}',
+            PRIMARY KEY (tenant_id, job_id, version),
+            FOREIGN KEY (tenant_id, job_id)
+                REFERENCES jobs(tenant_id, job_id) ON DELETE CASCADE
+        )
+        """
+    )
+
+
+def _create_score_staleness_v12(
+    conn: sqlite3.Connection,
+    *,
+    table_name: str = "job_score_staleness",
+) -> None:
+    conn.execute(
+        f"""
+        CREATE TABLE IF NOT EXISTS {table_name} (
+            tenant_id                 TEXT NOT NULL DEFAULT 'local',
+            job_id                   TEXT NOT NULL,
+            stale_reason              TEXT NOT NULL,
+            old_policy_id             TEXT NOT NULL DEFAULT '',
+            old_policy_version        INTEGER NOT NULL,
+            new_policy_id             TEXT NOT NULL DEFAULT '',
+            new_policy_version        INTEGER NOT NULL,
+            marked_at                 TEXT NOT NULL,
+            resolved                  INTEGER NOT NULL DEFAULT 0
+                CHECK(resolved IN (0, 1)),
+            resolved_at               TEXT,
+            resolved_by_score_version INTEGER,
+            PRIMARY KEY (
+                tenant_id, job_id, stale_reason,
+                old_policy_version, new_policy_version
+            ),
+            FOREIGN KEY (tenant_id, job_id)
+                REFERENCES jobs(tenant_id, job_id) ON DELETE CASCADE
+        )
+        """
+    )
+
+
+def _create_requirement_fit_tables_v12(
+    conn: sqlite3.Connection,
+    *,
+    reports_table_name: str = "job_requirement_fit_reports",
+    items_table_name: str = "job_requirement_fit_items",
+    scores_table_name: str = "job_scores",
+) -> None:
+    conn.execute(
+        f"""
+        CREATE TABLE IF NOT EXISTS {reports_table_name} (
+            tenant_id                     TEXT NOT NULL DEFAULT 'local',
+            job_id                        TEXT NOT NULL,
+            score_version                 INTEGER NOT NULL,
+            employer_analysis_generation  INTEGER NOT NULL,
+            profile_snapshot_version      INTEGER NOT NULL,
+            scoring_policy_version        INTEGER NOT NULL,
+            formula_version               TEXT NOT NULL,
+            resolved_fit_score            INTEGER CHECK(
+                resolved_fit_score IS NULL
+                OR resolved_fit_score BETWEEN 1 AND 10
+            ),
+            fit_band                      TEXT NOT NULL,
+            confidence                    TEXT NOT NULL,
+            summary_json                  TEXT NOT NULL DEFAULT '{{}}',
+            created_at                    TEXT NOT NULL,
+            PRIMARY KEY (tenant_id, job_id, score_version),
+            FOREIGN KEY (tenant_id, job_id, score_version)
+                REFERENCES {scores_table_name}(
+                    tenant_id, job_id, version
+                ) ON DELETE CASCADE
+        )
+        """
+    )
+    conn.execute(
+        f"""
+        CREATE TABLE IF NOT EXISTS {items_table_name} (
+            tenant_id              TEXT NOT NULL DEFAULT 'local',
+            job_id                 TEXT NOT NULL,
+            score_version          INTEGER NOT NULL,
+            requirement_id         TEXT NOT NULL,
+            requirement_text       TEXT NOT NULL,
+            tier                   TEXT NOT NULL CHECK(
+                tier IN ('must_have', 'nice_to_have')
+            ),
+            weight                 REAL NOT NULL CHECK(
+                weight >= 0 AND weight <= 1
+            ),
+            job_evidence_span       TEXT NOT NULL,
+            fit_json                TEXT NOT NULL,
+            contribution_json       TEXT NOT NULL,
+            tailoring_json          TEXT NOT NULL,
+            artifact_coverage_json  TEXT,
+            position                INTEGER NOT NULL DEFAULT 0,
+            PRIMARY KEY (
+                tenant_id, job_id, score_version, requirement_id
+            ),
+            FOREIGN KEY (tenant_id, job_id, score_version)
+                REFERENCES {reports_table_name}(
+                    tenant_id, job_id, score_version
+                ) ON DELETE CASCADE
+        )
+        """
+    )
+
+
+def _create_job_score_indexes(conn: sqlite3.Connection) -> None:
+    reference = (
+        "job_id" if "job_id" in _table_columns(conn, "job_scores") else "job_url"
+    )
+    conn.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_job_scores_tenant_score
+        ON job_scores(tenant_id, fit_score DESC, scored_at DESC)
+        """
+    )
+    conn.execute(
+        f"""
+        CREATE INDEX IF NOT EXISTS idx_job_scores_job_version
+        ON job_scores(tenant_id, {reference}, version DESC)
+        """
+    )
+
+
+def _create_score_staleness_indexes(conn: sqlite3.Connection) -> None:
+    reference = (
+        "job_id"
+        if "job_id" in _table_columns(conn, "job_score_staleness")
+        else "job_url"
+    )
+    conn.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_job_score_staleness_unresolved
+        ON job_score_staleness(tenant_id, resolved, marked_at DESC)
+        """
+    )
+    conn.execute(
+        f"""
+        CREATE INDEX IF NOT EXISTS idx_job_score_staleness_job
+        ON job_score_staleness(tenant_id, {reference}, resolved)
+        """
+    )
+
+
+def _create_requirement_fit_indexes(conn: sqlite3.Connection) -> None:
+    reference = (
+        "job_id"
+        if "job_id" in _table_columns(conn, "job_requirement_fit_reports")
+        else "job_url"
+    )
+    conn.execute(
+        f"""
+        CREATE INDEX IF NOT EXISTS idx_requirement_fit_reports_tenant_job
+        ON job_requirement_fit_reports(
+            tenant_id, {reference}, score_version DESC
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_requirement_fit_items_requirement
+        ON job_requirement_fit_items(tenant_id, requirement_id)
+        """
+    )
+
+
+def _has_composite_foreign_key(
+    conn: sqlite3.Connection,
+    table: str,
+    referenced_table: str,
+    columns: set[tuple[str, str]],
+    *,
+    on_delete: str,
+) -> bool:
+    groups: dict[int, set[tuple[str, str]]] = {}
+    deletes: dict[int, str] = {}
+    for row in conn.execute(f'PRAGMA foreign_key_list("{table}")').fetchall():
+        if str(row[2]) != referenced_table:
+            continue
+        foreign_key_id = int(row[0])
+        groups.setdefault(foreign_key_id, set()).add((str(row[3]), str(row[4])))
+        deletes[foreign_key_id] = str(row[6]).upper()
+    return any(
+        group == columns and deletes.get(foreign_key_id) == on_delete.upper()
+        for foreign_key_id, group in groups.items()
+    )
+
+
+def _has_scoring_reference_schema_v12(conn: sqlite3.Connection) -> bool:
+    return (
+        "job_id" in _table_columns(conn, "job_scores")
+        and "job_url" not in _table_columns(conn, "job_scores")
+        and _primary_key_columns(conn, "job_scores")
+        == ("tenant_id", "job_id", "version")
+        and _has_composite_job_id_foreign_key(conn, "job_scores", "job_id")
+        and _has_index(
+            conn,
+            "job_scores",
+            "idx_job_scores_tenant_score",
+            ("tenant_id", "fit_score", "scored_at"),
+            unique=False,
+        )
+        and _has_index(
+            conn,
+            "job_scores",
+            "idx_job_scores_job_version",
+            ("tenant_id", "job_id", "version"),
+            unique=False,
+        )
+        and "job_id" in _table_columns(conn, "job_score_staleness")
+        and "job_url" not in _table_columns(conn, "job_score_staleness")
+        and _primary_key_columns(conn, "job_score_staleness")
+        == (
+            "tenant_id",
+            "job_id",
+            "stale_reason",
+            "old_policy_version",
+            "new_policy_version",
+        )
+        and _has_composite_job_id_foreign_key(
+            conn,
+            "job_score_staleness",
+            "job_id",
+        )
+        and _has_index(
+            conn,
+            "job_score_staleness",
+            "idx_job_score_staleness_unresolved",
+            ("tenant_id", "resolved", "marked_at"),
+            unique=False,
+        )
+        and _has_index(
+            conn,
+            "job_score_staleness",
+            "idx_job_score_staleness_job",
+            ("tenant_id", "job_id", "resolved"),
+            unique=False,
+        )
+        and "job_id" in _table_columns(
+            conn,
+            "job_requirement_fit_reports",
+        )
+        and "job_url" not in _table_columns(
+            conn,
+            "job_requirement_fit_reports",
+        )
+        and _primary_key_columns(conn, "job_requirement_fit_reports")
+        == ("tenant_id", "job_id", "score_version")
+        and _has_composite_foreign_key(
+            conn,
+            "job_requirement_fit_reports",
+            "job_scores",
+            {
+                ("tenant_id", "tenant_id"),
+                ("job_id", "job_id"),
+                ("score_version", "version"),
+            },
+            on_delete="CASCADE",
+        )
+        and _has_index(
+            conn,
+            "job_requirement_fit_reports",
+            "idx_requirement_fit_reports_tenant_job",
+            ("tenant_id", "job_id", "score_version"),
+            unique=False,
+        )
+        and "job_id" in _table_columns(
+            conn,
+            "job_requirement_fit_items",
+        )
+        and "job_url" not in _table_columns(
+            conn,
+            "job_requirement_fit_items",
+        )
+        and _primary_key_columns(conn, "job_requirement_fit_items")
+        == ("tenant_id", "job_id", "score_version", "requirement_id")
+        and _has_composite_foreign_key(
+            conn,
+            "job_requirement_fit_items",
+            "job_requirement_fit_reports",
+            {
+                ("tenant_id", "tenant_id"),
+                ("job_id", "job_id"),
+                ("score_version", "score_version"),
+            },
+            on_delete="CASCADE",
+        )
+        and _has_index(
+            conn,
+            "job_requirement_fit_items",
+            "idx_requirement_fit_items_requirement",
+            ("tenant_id", "requirement_id"),
+            unique=False,
+        )
+    )
+
+
+def ensure_scoring_references_v12(
+    conn: sqlite3.Connection | None = None,
+) -> list[str]:
+    """Move scoring history and its dependants to stable JobId references.
+
+    Multiple historical posting URLs may resolve to one JobId. Their score
+    histories are therefore ordered deterministically and renumbered together;
+    requirement-fit reports, items, and resolved staleness markers are remapped
+    through the same version map before any legacy table is replaced.
+    """
+    if conn is None:
+        conn = get_connection()
+
+    current = _assert_schema_version_supported(conn)
+    if current >= _SCORING_REFERENCE_SCHEMA_VERSION:
+        return []
+    if current != _ENRICHMENT_SNAPSHOT_REFERENCE_SCHEMA_VERSION:
+        raise RuntimeError(
+            "scoring reference migration requires enrichment/snapshot "
+            "schema v11"
+        )
+
+    conn.execute("SAVEPOINT scoring_references_v12")
+    try:
+        _verify_scoring_prerequisites_v12(conn)
+        before_counts = {
+            table: int(
+                conn.execute(f'SELECT COUNT(*) FROM "{table}"').fetchone()[0]
+            )
+            for table in _SCORING_REFERENCE_TABLES
+        }
+        expected_counts = dict(before_counts)
+
+        if not _has_scoring_reference_schema_v12(conn):
+            score_reference = _legacy_or_stable_reference_column(
+                conn,
+                "job_scores",
+                stable="job_id",
+                legacy="job_url",
+            )
+            staleness_reference = _legacy_or_stable_reference_column(
+                conn,
+                "job_score_staleness",
+                stable="job_id",
+                legacy="job_url",
+            )
+            report_reference = _legacy_or_stable_reference_column(
+                conn,
+                "job_requirement_fit_reports",
+                stable="job_id",
+                legacy="job_url",
+            )
+            item_reference = _legacy_or_stable_reference_column(
+                conn,
+                "job_requirement_fit_items",
+                stable="job_id",
+                legacy="job_url",
+            )
+            reference_columns = {
+                "job_scores": score_reference,
+                "job_score_staleness": staleness_reference,
+                "job_requirement_fit_reports": report_reference,
+                "job_requirement_fit_items": item_reference,
+            }
+            for table, reference_column in reference_columns.items():
+                unresolved = conn.execute(
+                    f"""
+                    SELECT source.{reference_column}
+                    FROM {table} AS source
+                    WHERE {
+                        _resolved_job_id_sql(
+                            "source",
+                            reference_column,
+                            legacy_url=reference_column == "job_url",
+                        )
+                    } IS NULL
+                    LIMIT 1
+                    """
+                ).fetchone()
+                if unresolved is not None:
+                    raise RuntimeError(
+                        "scoring reference migration could not resolve "
+                        f"{table}.{reference_column}={unresolved[0]!r}"
+                    )
+
+            (
+                score_rows,
+                version_map,
+            ) = _canonical_score_rows_v12(
+                conn,
+                reference_column=score_reference,
+            )
+            report_rows = _remapped_requirement_report_rows_v12(
+                conn,
+                reference_column=report_reference,
+                version_map=version_map,
+            )
+            item_rows = _remapped_requirement_item_rows_v12(
+                conn,
+                reference_column=item_reference,
+                version_map=version_map,
+            )
+            staleness_rows = _canonical_staleness_rows_v12(
+                conn,
+                reference_column=staleness_reference,
+                version_map=version_map,
+            )
+            expected_counts["job_score_staleness"] = len(staleness_rows)
+
+            for table in (
+                "job_requirement_fit_items_v12",
+                "job_requirement_fit_reports_v12",
+                "job_score_staleness_v12",
+                "job_scores_v12",
+            ):
+                conn.execute(f'DROP TABLE IF EXISTS "{table}"')
+            _create_job_scores_v12(conn, table_name="job_scores_v12")
+            _create_requirement_fit_tables_v12(
+                conn,
+                reports_table_name="job_requirement_fit_reports_v12",
+                items_table_name="job_requirement_fit_items_v12",
+                scores_table_name="job_scores_v12",
+            )
+            _create_score_staleness_v12(
+                conn,
+                table_name="job_score_staleness_v12",
+            )
+            conn.executemany(
+                """
+                INSERT INTO job_scores_v12 (
+                    tenant_id, job_id, version, fit_score, breakdown_json,
+                    keywords_json, scored_at, correction_json,
+                    criteria_json, trace_json
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                score_rows,
+            )
+            conn.executemany(
+                """
+                INSERT INTO job_requirement_fit_reports_v12 (
+                    tenant_id, job_id, score_version,
+                    employer_analysis_generation, profile_snapshot_version,
+                    scoring_policy_version, formula_version,
+                    resolved_fit_score, fit_band, confidence, summary_json,
+                    created_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                report_rows,
+            )
+            conn.executemany(
+                """
+                INSERT INTO job_requirement_fit_items_v12 (
+                    tenant_id, job_id, score_version, requirement_id,
+                    requirement_text, tier, weight, job_evidence_span,
+                    fit_json, contribution_json, tailoring_json,
+                    artifact_coverage_json, position
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                item_rows,
+            )
+            conn.executemany(
+                """
+                INSERT INTO job_score_staleness_v12 (
+                    tenant_id, job_id, stale_reason,
+                    old_policy_id, old_policy_version,
+                    new_policy_id, new_policy_version,
+                    marked_at, resolved, resolved_at,
+                    resolved_by_score_version
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                staleness_rows,
+            )
+
+            for table in (
+                "job_requirement_fit_items",
+                "job_requirement_fit_reports",
+                "job_score_staleness",
+                "job_scores",
+            ):
+                conn.execute(f'DROP TABLE "{table}"')
+            for table in (
+                "job_scores",
+                "job_requirement_fit_reports",
+                "job_requirement_fit_items",
+                "job_score_staleness",
+            ):
+                conn.execute(
+                    f'ALTER TABLE "{table}_v12" RENAME TO "{table}"'
+                )
+            _create_job_score_indexes(conn)
+            _create_requirement_fit_indexes(conn)
+            _create_score_staleness_indexes(conn)
+
+        _verify_scoring_references_v12(
+            conn,
+            expected_counts=expected_counts,
+        )
+        conn.execute(
+            f"PRAGMA user_version = {_SCORING_REFERENCE_SCHEMA_VERSION}"
+        )
+        conn.execute("RELEASE SAVEPOINT scoring_references_v12")
+        conn.commit()
+    except BaseException:
+        conn.execute("ROLLBACK TO SAVEPOINT scoring_references_v12")
+        conn.execute("RELEASE SAVEPOINT scoring_references_v12")
+        raise
+
+    return list(_SCORING_REFERENCE_TABLES)
+
+
+def _verify_scoring_prerequisites_v12(
+    conn: sqlite3.Connection,
+) -> None:
+    """Verify v11-owned authority without rejecting migratable URL aliases."""
+    if not _has_enrichment_snapshot_reference_schema_v11(conn):
+        raise RuntimeError(
+            "scoring reference migration requires the stable "
+            "enrichment/snapshot reference schema"
+        )
+    for table in _ENRICHMENT_SNAPSHOT_REFERENCE_TABLES:
+        orphan = conn.execute(
+            f"""
+            SELECT source.job_id
+            FROM {table} AS source
+            LEFT JOIN jobs j
+              ON j.tenant_id = source.tenant_id
+             AND j.job_id = source.job_id
+            WHERE j.job_id IS NULL
+            LIMIT 1
+            """
+        ).fetchone()
+        if orphan is not None:
+            raise RuntimeError(
+                "scoring reference migration found an unresolved "
+                f"{table}.job_id prerequisite"
+            )
+
+
+def _canonical_score_rows_v12(
+    conn: sqlite3.Connection,
+    *,
+    reference_column: str,
+) -> tuple[
+    list[tuple[Any, ...]],
+    dict[tuple[str, str, int], int],
+]:
+    rows = conn.execute(
+        f"""
+        SELECT tenant_id, {reference_column}, version, fit_score,
+               breakdown_json, keywords_json, scored_at, correction_json,
+               criteria_json, trace_json
+        FROM job_scores
+        ORDER BY tenant_id, {reference_column}, version
+        """
+    ).fetchall()
+    grouped: dict[
+        tuple[str, str],
+        list[tuple[str, int, tuple[Any, ...]]],
+    ] = {}
+    for row in rows:
+        tenant_id = str(row[0])
+        raw_reference = str(row[1])
+        old_version = int(row[2])
+        if old_version <= 0:
+            raise RuntimeError(
+                "scoring reference migration found a non-positive score "
+                "version"
+            )
+        stable_job_id = _resolve_job_reference_value(
+            conn,
+            tenant_id=tenant_id,
+            reference=raw_reference,
+            legacy_url=reference_column == "job_url",
+        )
+        if stable_job_id is None:
+            raise RuntimeError(
+                "scoring reference migration could not resolve score "
+                f"identity {raw_reference!r}"
+            )
+        _validate_job_uuid(stable_job_id)
+        grouped.setdefault((tenant_id, stable_job_id), []).append(
+            (
+                raw_reference,
+                old_version,
+                (
+                    int(row[3]),
+                    str(row[4]),
+                    str(row[5]),
+                    str(row[6]),
+                    row[7],
+                    str(row[8] or "{}"),
+                    str(row[9] or "{}"),
+                ),
+            )
+        )
+
+    canonical: list[tuple[Any, ...]] = []
+    version_map: dict[tuple[str, str, int], int] = {}
+    for (tenant_id, stable_job_id), history in sorted(grouped.items()):
+        ordered_history = _merge_score_histories_preserving_version_order(
+            history
+        )
+        for new_version, (
+            raw_reference,
+            old_version,
+            values,
+        ) in enumerate(ordered_history, start=1):
+            version_map[(tenant_id, raw_reference, old_version)] = new_version
+            canonical.append(
+                (
+                    tenant_id,
+                    stable_job_id,
+                    new_version,
+                    *values,
+                )
+            )
+    return canonical, version_map
+
+
+def _merge_score_histories_preserving_version_order(
+    history: list[tuple[str, int, tuple[Any, ...]]],
+) -> list[tuple[str, int, tuple[Any, ...]]]:
+    """Deterministically interleave aliases without reversing one history.
+
+    ``version`` is the authoritative order within one scoring aggregate.
+    Timestamps are useful only to choose between the next eligible row from
+    different aliases because older databases do not constrain timestamp
+    monotonicity. This is a stable topological merge: every alias retains its
+    original version order even when its timestamps move backwards.
+    """
+    by_reference: dict[str, list[tuple[str, int, tuple[Any, ...]]]] = {}
+    for entry in history:
+        by_reference.setdefault(entry[0], []).append(entry)
+    for entries in by_reference.values():
+        entries.sort(key=lambda entry: entry[1])
+
+    offsets = {reference: 0 for reference in by_reference}
+    merged: list[tuple[str, int, tuple[Any, ...]]] = []
+    while len(merged) < len(history):
+        eligible = [
+            entries[offsets[reference]]
+            for reference, entries in by_reference.items()
+            if offsets[reference] < len(entries)
+        ]
+        selected = min(
+            eligible,
+            key=lambda entry: (
+                str(entry[2][3]),
+                entry[0],
+                entry[1],
+            ),
+        )
+        merged.append(selected)
+        offsets[selected[0]] += 1
+    return merged
+
+
+def _remapped_requirement_report_rows_v12(
+    conn: sqlite3.Connection,
+    *,
+    reference_column: str,
+    version_map: dict[tuple[str, str, int], int],
+) -> list[tuple[Any, ...]]:
+    rows = conn.execute(
+        f"""
+        SELECT tenant_id, {reference_column}, score_version,
+               employer_analysis_generation, profile_snapshot_version,
+               scoring_policy_version, formula_version, resolved_fit_score,
+               fit_band, confidence, summary_json, created_at
+        FROM job_requirement_fit_reports
+        ORDER BY tenant_id, {reference_column}, score_version
+        """
+    ).fetchall()
+    remapped: list[tuple[Any, ...]] = []
+    for row in rows:
+        tenant_id = str(row[0])
+        raw_reference = str(row[1])
+        old_version = int(row[2])
+        new_version = version_map.get(
+            (tenant_id, raw_reference, old_version)
+        )
+        if new_version is None:
+            raise RuntimeError(
+                "scoring reference migration found a requirement-fit "
+                "report without its score history"
+            )
+        stable_job_id = _resolve_job_reference_value(
+            conn,
+            tenant_id=tenant_id,
+            reference=raw_reference,
+            legacy_url=reference_column == "job_url",
+        )
+        if stable_job_id is None:
+            raise RuntimeError(
+                "scoring reference migration could not resolve a "
+                "requirement-fit report"
+            )
+        remapped.append(
+            (
+                tenant_id,
+                stable_job_id,
+                new_version,
+                *tuple(row[3:]),
+            )
+        )
+    return remapped
+
+
+def _remapped_requirement_item_rows_v12(
+    conn: sqlite3.Connection,
+    *,
+    reference_column: str,
+    version_map: dict[tuple[str, str, int], int],
+) -> list[tuple[Any, ...]]:
+    rows = conn.execute(
+        f"""
+        SELECT tenant_id, {reference_column}, score_version,
+               requirement_id, requirement_text, tier, weight,
+               job_evidence_span, fit_json, contribution_json,
+               tailoring_json, artifact_coverage_json, position
+        FROM job_requirement_fit_items
+        ORDER BY tenant_id, {reference_column}, score_version, position,
+                 requirement_id
+        """
+    ).fetchall()
+    remapped: list[tuple[Any, ...]] = []
+    for row in rows:
+        tenant_id = str(row[0])
+        raw_reference = str(row[1])
+        old_version = int(row[2])
+        new_version = version_map.get(
+            (tenant_id, raw_reference, old_version)
+        )
+        if new_version is None:
+            raise RuntimeError(
+                "scoring reference migration found a requirement-fit item "
+                "without its score history"
+            )
+        stable_job_id = _resolve_job_reference_value(
+            conn,
+            tenant_id=tenant_id,
+            reference=raw_reference,
+            legacy_url=reference_column == "job_url",
+        )
+        if stable_job_id is None:
+            raise RuntimeError(
+                "scoring reference migration could not resolve a "
+                "requirement-fit item"
+            )
+        remapped.append(
+            (
+                tenant_id,
+                stable_job_id,
+                new_version,
+                *tuple(row[3:]),
+            )
+        )
+    return remapped
+
+
+def _canonical_staleness_rows_v12(
+    conn: sqlite3.Connection,
+    *,
+    reference_column: str,
+    version_map: dict[tuple[str, str, int], int],
+) -> list[tuple[Any, ...]]:
+    rows = conn.execute(
+        f"""
+        SELECT tenant_id, {reference_column}, stale_reason,
+               old_policy_id, old_policy_version,
+               new_policy_id, new_policy_version,
+               marked_at, resolved, resolved_at,
+               resolved_by_score_version
+        FROM job_score_staleness
+        ORDER BY tenant_id, {reference_column}, marked_at
+        """
+    ).fetchall()
+    canonical: dict[
+        tuple[str, str, str, int, int],
+        dict[str, Any],
+    ] = {}
+    for row in rows:
+        tenant_id = str(row[0])
+        raw_reference = str(row[1])
+        stable_job_id = _resolve_job_reference_value(
+            conn,
+            tenant_id=tenant_id,
+            reference=raw_reference,
+            legacy_url=reference_column == "job_url",
+        )
+        if stable_job_id is None:
+            raise RuntimeError(
+                "scoring reference migration could not resolve a score "
+                "staleness marker"
+            )
+        resolved = bool(row[8])
+        old_resolved_version = (
+            int(row[10]) if row[10] is not None else None
+        )
+        resolved_version = None
+        if old_resolved_version is not None:
+            resolved_version = version_map.get(
+                (tenant_id, raw_reference, old_resolved_version)
+            )
+            if resolved_version is None:
+                raise RuntimeError(
+                    "scoring reference migration found a staleness marker "
+                    "resolved by a missing score version"
+                )
+        if not resolved and (
+            row[9] is not None or old_resolved_version is not None
+        ):
+            raise RuntimeError(
+                "scoring reference migration found an unresolved marker "
+                "with resolution evidence"
+            )
+
+        key = (
+            tenant_id,
+            stable_job_id,
+            str(row[2]),
+            int(row[4]),
+            int(row[6]),
+        )
+        candidate = {
+            "old_policy_id": str(row[3] or ""),
+            "new_policy_id": str(row[5] or ""),
+            "marked_at": str(row[7]),
+            "resolved": resolved,
+            "resolved_at": str(row[9]) if row[9] is not None else None,
+            "resolved_version": resolved_version,
+        }
+        existing = canonical.get(key)
+        if existing is None:
+            canonical[key] = candidate
+            continue
+        if (
+            existing["old_policy_id"] != candidate["old_policy_id"]
+            or existing["new_policy_id"] != candidate["new_policy_id"]
+        ):
+            raise RuntimeError(
+                "scoring reference migration found conflicting policy "
+                "identity on duplicate staleness markers"
+            )
+        existing["marked_at"] = min(
+            existing["marked_at"],
+            candidate["marked_at"],
+        )
+        if not candidate["resolved"]:
+            existing["resolved"] = False
+            existing["resolved_at"] = None
+            existing["resolved_version"] = None
+        elif existing["resolved"]:
+            resolved_times = [
+                value
+                for value in (
+                    existing["resolved_at"],
+                    candidate["resolved_at"],
+                )
+                if value is not None
+            ]
+            existing["resolved_at"] = (
+                max(resolved_times) if resolved_times else None
+            )
+            resolved_versions = [
+                value
+                for value in (
+                    existing["resolved_version"],
+                    candidate["resolved_version"],
+                )
+                if value is not None
+            ]
+            existing["resolved_version"] = (
+                max(resolved_versions) if resolved_versions else None
+            )
+
+    return [
+        (
+            tenant_id,
+            stable_job_id,
+            stale_reason,
+            values["old_policy_id"],
+            old_policy_version,
+            values["new_policy_id"],
+            new_policy_version,
+            values["marked_at"],
+            int(values["resolved"]),
+            values["resolved_at"],
+            values["resolved_version"],
+        )
+        for (
+            tenant_id,
+            stable_job_id,
+            stale_reason,
+            old_policy_version,
+            new_policy_version,
+        ), values in sorted(canonical.items())
+    ]
+
+
+def _verify_scoring_references_v12(
+    conn: sqlite3.Connection,
+    *,
+    expected_counts: dict[str, int],
+) -> None:
+    if not _has_scoring_reference_schema_v12(conn):
+        raise RuntimeError(
+            "scoring reference migration did not create the stable "
+            "reference schema"
+        )
+    for table, expected_count in expected_counts.items():
+        observed_count = int(
+            conn.execute(f'SELECT COUNT(*) FROM "{table}"').fetchone()[0]
+        )
+        if observed_count != expected_count:
+            raise RuntimeError(
+                "scoring reference migration changed row count for "
+                f"{table}: expected {expected_count}, found {observed_count}"
+            )
+        invalid_identity = conn.execute(
+            f"""
+            SELECT source.job_id
+            FROM {table} AS source
+            LEFT JOIN jobs j
+              ON j.tenant_id = source.tenant_id
+             AND j.job_id = source.job_id
+            WHERE j.job_id IS NULL
+            LIMIT 1
+            """
+        ).fetchone()
+        if invalid_identity is not None:
+            raise RuntimeError(
+                "scoring reference migration left an unresolved reference "
+                f"in {table}.job_id"
+            )
+
+    invalid_history = conn.execute(
+        """
+        SELECT tenant_id, job_id
+        FROM job_scores
+        GROUP BY tenant_id, job_id
+        HAVING MIN(version) <> 1
+            OR MAX(version) <> COUNT(*)
+            OR COUNT(DISTINCT version) <> COUNT(*)
+        LIMIT 1
+        """
+    ).fetchone()
+    if invalid_history is not None:
+        raise RuntimeError(
+            "scoring reference migration did not preserve a contiguous "
+            "score history"
+        )
+    orphan_report = conn.execute(
+        """
+        SELECT report.job_id
+        FROM job_requirement_fit_reports AS report
+        LEFT JOIN job_scores AS score
+          ON score.tenant_id = report.tenant_id
+         AND score.job_id = report.job_id
+         AND score.version = report.score_version
+        WHERE score.job_id IS NULL
+        LIMIT 1
+        """
+    ).fetchone()
+    if orphan_report is not None:
+        raise RuntimeError(
+            "scoring reference migration left a requirement-fit report "
+            "without its score"
+        )
+    orphan_item = conn.execute(
+        """
+        SELECT item.job_id
+        FROM job_requirement_fit_items AS item
+        LEFT JOIN job_requirement_fit_reports AS report
+          ON report.tenant_id = item.tenant_id
+         AND report.job_id = item.job_id
+         AND report.score_version = item.score_version
+        WHERE report.job_id IS NULL
+        LIMIT 1
+        """
+    ).fetchone()
+    if orphan_item is not None:
+        raise RuntimeError(
+            "scoring reference migration left a requirement-fit item "
+            "without its report"
+        )
+    invalid_resolution = conn.execute(
+        """
+        SELECT marker.job_id
+        FROM job_score_staleness AS marker
+        LEFT JOIN job_scores AS score
+          ON score.tenant_id = marker.tenant_id
+         AND score.job_id = marker.job_id
+         AND score.version = marker.resolved_by_score_version
+        WHERE marker.resolved_by_score_version IS NOT NULL
+          AND score.job_id IS NULL
+        LIMIT 1
+        """
+    ).fetchone()
+    if invalid_resolution is not None:
+        raise RuntimeError(
+            "scoring reference migration left a staleness marker resolved "
+            "by a missing score"
+        )
+    for row in conn.execute(
+        """
+        SELECT job_id FROM job_scores
+        UNION
+        SELECT job_id FROM job_score_staleness
+        UNION
+        SELECT job_id FROM job_requirement_fit_reports
+        UNION
+        SELECT job_id FROM job_requirement_fit_items
+        """
+    ).fetchall():
+        _validate_job_uuid(str(row[0]))
+
+    foreign_key_error = conn.execute("PRAGMA foreign_key_check").fetchone()
+    if foreign_key_error is not None:
+        raise RuntimeError(
+            "scoring reference migration found a foreign-key violation"
+        )
+
+
+def _reassign_scoring_references_v12(
+    conn: sqlite3.Connection,
+    *,
+    tenant_id: str,
+    losing_job_id: str,
+    surviving_job_id: str,
+) -> None:
+    """Merge two stable scoring histories without overwriting either one."""
+    if losing_job_id == surviving_job_id:
+        return
+
+    before_counts = {
+        table: int(
+            conn.execute(f'SELECT COUNT(*) FROM "{table}"').fetchone()[0]
+        )
+        for table in _SCORING_REFERENCE_TABLES
+    }
+    selected_staleness_count = int(
+        conn.execute(
+            """
+            SELECT COUNT(*)
+            FROM job_score_staleness
+            WHERE tenant_id = ? AND job_id IN (?, ?)
+            """,
+            (tenant_id, losing_job_id, surviving_job_id),
+        ).fetchone()[0]
+    )
+
+    raw_scores = conn.execute(
+        """
+        SELECT job_id, version, fit_score, breakdown_json, keywords_json,
+               scored_at, correction_json, criteria_json, trace_json
+        FROM job_scores
+        WHERE tenant_id = ? AND job_id IN (?, ?)
+        ORDER BY scored_at, job_id, version
+        """,
+        (tenant_id, losing_job_id, surviving_job_id),
+    ).fetchall()
+    ordered_scores = _merge_score_histories_preserving_version_order(
+        [
+            (
+                str(row[0]),
+                int(row[1]),
+                tuple(row[2:]),
+            )
+            for row in raw_scores
+        ]
+    )
+    version_map: dict[tuple[str, int], int] = {}
+    score_rows: list[tuple[Any, ...]] = []
+    for new_version, (
+        source_job_id,
+        old_version,
+        values,
+    ) in enumerate(ordered_scores, start=1):
+        version_map[(source_job_id, old_version)] = new_version
+        score_rows.append(
+            (
+                tenant_id,
+                surviving_job_id,
+                new_version,
+                *values,
+            )
+        )
+
+    raw_reports = conn.execute(
+        """
+        SELECT job_id, score_version, employer_analysis_generation,
+               profile_snapshot_version, scoring_policy_version,
+               formula_version, resolved_fit_score, fit_band, confidence,
+               summary_json, created_at
+        FROM job_requirement_fit_reports
+        WHERE tenant_id = ? AND job_id IN (?, ?)
+        ORDER BY job_id, score_version
+        """,
+        (tenant_id, losing_job_id, surviving_job_id),
+    ).fetchall()
+    report_rows: list[tuple[Any, ...]] = []
+    for row in raw_reports:
+        new_version = version_map.get((str(row[0]), int(row[1])))
+        if new_version is None:
+            raise RuntimeError(
+                "URL collision merge found a requirement-fit report "
+                "without its score history"
+            )
+        report_rows.append(
+            (
+                tenant_id,
+                surviving_job_id,
+                new_version,
+                *tuple(row[2:]),
+            )
+        )
+
+    raw_items = conn.execute(
+        """
+        SELECT job_id, score_version, requirement_id, requirement_text,
+               tier, weight, job_evidence_span, fit_json, contribution_json,
+               tailoring_json, artifact_coverage_json, position
+        FROM job_requirement_fit_items
+        WHERE tenant_id = ? AND job_id IN (?, ?)
+        ORDER BY job_id, score_version, position, requirement_id
+        """,
+        (tenant_id, losing_job_id, surviving_job_id),
+    ).fetchall()
+    item_rows: list[tuple[Any, ...]] = []
+    for row in raw_items:
+        new_version = version_map.get((str(row[0]), int(row[1])))
+        if new_version is None:
+            raise RuntimeError(
+                "URL collision merge found a requirement-fit item "
+                "without its score history"
+            )
+        item_rows.append(
+            (
+                tenant_id,
+                surviving_job_id,
+                new_version,
+                *tuple(row[2:]),
+            )
+        )
+
+    raw_staleness = conn.execute(
+        """
+        SELECT job_id, stale_reason, old_policy_id, old_policy_version,
+               new_policy_id, new_policy_version, marked_at, resolved,
+               resolved_at, resolved_by_score_version
+        FROM job_score_staleness
+        WHERE tenant_id = ? AND job_id IN (?, ?)
+        ORDER BY job_id, marked_at
+        """,
+        (tenant_id, losing_job_id, surviving_job_id),
+    ).fetchall()
+    canonical_staleness: dict[
+        tuple[str, int, int],
+        dict[str, Any],
+    ] = {}
+    for row in raw_staleness:
+        source_job_id = str(row[0])
+        resolved = bool(row[7])
+        old_resolved_version = (
+            int(row[9]) if row[9] is not None else None
+        )
+        resolved_version = None
+        if old_resolved_version is not None:
+            resolved_version = version_map.get(
+                (source_job_id, old_resolved_version)
+            )
+            if resolved_version is None:
+                raise RuntimeError(
+                    "URL collision merge found a staleness marker resolved "
+                    "by a missing score version"
+                )
+        if not resolved and (
+            row[8] is not None or old_resolved_version is not None
+        ):
+            raise RuntimeError(
+                "URL collision merge found an unresolved score marker "
+                "with resolution evidence"
+            )
+        key = (str(row[1]), int(row[3]), int(row[5]))
+        candidate = {
+            "old_policy_id": str(row[2] or ""),
+            "new_policy_id": str(row[4] or ""),
+            "marked_at": str(row[6]),
+            "resolved": resolved,
+            "resolved_at": str(row[8]) if row[8] is not None else None,
+            "resolved_version": resolved_version,
+        }
+        existing = canonical_staleness.get(key)
+        if existing is None:
+            canonical_staleness[key] = candidate
+            continue
+        if (
+            existing["old_policy_id"] != candidate["old_policy_id"]
+            or existing["new_policy_id"] != candidate["new_policy_id"]
+        ):
+            raise RuntimeError(
+                "URL collision merge found conflicting policy identity "
+                "on duplicate staleness markers"
+            )
+        existing["marked_at"] = min(
+            existing["marked_at"],
+            candidate["marked_at"],
+        )
+        if not candidate["resolved"]:
+            existing["resolved"] = False
+            existing["resolved_at"] = None
+            existing["resolved_version"] = None
+        elif existing["resolved"]:
+            resolved_times = [
+                value
+                for value in (
+                    existing["resolved_at"],
+                    candidate["resolved_at"],
+                )
+                if value is not None
+            ]
+            existing["resolved_at"] = (
+                max(resolved_times) if resolved_times else None
+            )
+            resolved_versions = [
+                value
+                for value in (
+                    existing["resolved_version"],
+                    candidate["resolved_version"],
+                )
+                if value is not None
+            ]
+            existing["resolved_version"] = (
+                max(resolved_versions) if resolved_versions else None
+            )
+    staleness_rows = [
+        (
+            tenant_id,
+            surviving_job_id,
+            stale_reason,
+            values["old_policy_id"],
+            old_policy_version,
+            values["new_policy_id"],
+            new_policy_version,
+            values["marked_at"],
+            int(values["resolved"]),
+            values["resolved_at"],
+            values["resolved_version"],
+        )
+        for (
+            stale_reason,
+            old_policy_version,
+            new_policy_version,
+        ), values in sorted(canonical_staleness.items())
+    ]
+
+    for table in (
+        "job_requirement_fit_items",
+        "job_requirement_fit_reports",
+        "job_score_staleness",
+        "job_scores",
+    ):
+        conn.execute(
+            f"""
+            DELETE FROM {table}
+            WHERE tenant_id = ? AND job_id IN (?, ?)
+            """,
+            (tenant_id, losing_job_id, surviving_job_id),
+        )
+    conn.executemany(
+        """
+        INSERT INTO job_scores (
+            tenant_id, job_id, version, fit_score, breakdown_json,
+            keywords_json, scored_at, correction_json,
+            criteria_json, trace_json
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        score_rows,
+    )
+    conn.executemany(
+        """
+        INSERT INTO job_requirement_fit_reports (
+            tenant_id, job_id, score_version,
+            employer_analysis_generation, profile_snapshot_version,
+            scoring_policy_version, formula_version, resolved_fit_score,
+            fit_band, confidence, summary_json, created_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        report_rows,
+    )
+    conn.executemany(
+        """
+        INSERT INTO job_requirement_fit_items (
+            tenant_id, job_id, score_version, requirement_id,
+            requirement_text, tier, weight, job_evidence_span,
+            fit_json, contribution_json, tailoring_json,
+            artifact_coverage_json, position
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        item_rows,
+    )
+    conn.executemany(
+        """
+        INSERT INTO job_score_staleness (
+            tenant_id, job_id, stale_reason,
+            old_policy_id, old_policy_version,
+            new_policy_id, new_policy_version,
+            marked_at, resolved, resolved_at,
+            resolved_by_score_version
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        staleness_rows,
+    )
+
+    expected_counts = dict(before_counts)
+    expected_counts["job_score_staleness"] = (
+        before_counts["job_score_staleness"]
+        - selected_staleness_count
+        + len(staleness_rows)
+    )
+    _verify_scoring_references_v12(
+        conn,
+        expected_counts=expected_counts,
+    )
+
+
 # ---------------------------------------------------------------------------
 # job_enrichments read fragments — used by every selector / stat that
 # previously read bare ``jobs.full_description`` / ``jobs.application_url``
@@ -6668,12 +8064,14 @@ _SCORE_DOWNSTREAM_STATE_JOIN: str = (
     "FROM job_stage_states WHERE stage = 'score'"
     ") jss_s ON jss_s.jss_s_job_url = jobs.url "
     "LEFT JOIN ("
-    "SELECT DISTINCT job_url AS jss_stale_job_url "
+    "SELECT DISTINCT tenant_id AS jss_stale_tenant_id, "
+    "job_id AS jss_stale_job_id "
     "FROM job_score_staleness WHERE resolved = 0"
-    ") jss_stale ON jss_stale.jss_stale_job_url = jobs.url"
+    ") jss_stale ON jss_stale.jss_stale_tenant_id = jobs.tenant_id "
+    "AND jss_stale.jss_stale_job_id = jobs.job_id"
 )
 _SCORE_CURRENT_FOR_DOWNSTREAM: str = (
-    "(jss_stale.jss_stale_job_url IS NULL "
+    "(jss_stale.jss_stale_job_id IS NULL "
     "AND (jss_s.jss_s_state IS NULL "
     "OR jss_s.jss_s_state = 'succeeded' "
     "OR (js.js_fit_score IS NULL AND jss_s.jss_s_state != 'stale')))"
@@ -6689,7 +8087,7 @@ _EFFECTIVE_SCORE_ATTEMPTS: str = "COALESCE(jss_s.jss_s_attempts, 0)"
 # ---------------------------------------------------------------------------
 # job_scores read fragments — used by every selector / stat that previously
 # read bare ``jobs.fit_score``. After Phase 5 the canonical fit score lives
-# in ``job_scores`` (latest version per ``job_url``); the legacy
+# in ``job_scores`` (latest version per stable ``JobId``); the legacy
 # ``jobs.fit_score`` column stays as a read-only fallback for historical
 # rows that were never re-scored. ``_EFFECTIVE_FIT_SCORE`` is the COALESCE
 # expression every WHERE / ORDER BY / aggregate query should use instead of
@@ -6700,7 +8098,8 @@ _EFFECTIVE_SCORE_ATTEMPTS: str = "COALESCE(jss_s.jss_s_attempts, 0)"
 
 _LATEST_SCORE_JOIN: str = (
     "LEFT JOIN ("
-    "SELECT s.job_url AS js_job_url, s.fit_score AS js_fit_score, "
+    "SELECT s.tenant_id AS js_tenant_id, s.job_id AS js_job_id, "
+    "s.fit_score AS js_fit_score, "
     "CASE WHEN json_valid(s.breakdown_json) "
     "THEN LOWER(COALESCE(CAST(json_extract(s.breakdown_json, '$.eligibility.status') AS TEXT), '')) "
     "ELSE '' END AS js_eligibility_status, "
@@ -6712,9 +8111,12 @@ _LATEST_SCORE_JOIN: str = (
     "0) ELSE 0 END AS js_hard_blocker_count "
     "FROM job_scores s "
     "INNER JOIN ("
-    "SELECT job_url, MAX(version) AS max_version FROM job_scores GROUP BY job_url"
-    ") latest ON latest.job_url = s.job_url AND latest.max_version = s.version"
-    ") js ON js.js_job_url = jobs.url"
+    "SELECT tenant_id, job_id, MAX(version) AS max_version "
+    "FROM job_scores GROUP BY tenant_id, job_id"
+    ") latest ON latest.tenant_id = s.tenant_id "
+    "AND latest.job_id = s.job_id AND latest.max_version = s.version"
+    ") js ON js.js_tenant_id = jobs.tenant_id "
+    "AND js.js_job_id = jobs.job_id"
 )
 
 _EFFECTIVE_FIT_SCORE: str = "COALESCE(js.js_fit_score, jobs.fit_score)"

--- a/workers/automation/src/jobctrl/digest.py
+++ b/workers/automation/src/jobctrl/digest.py
@@ -624,9 +624,42 @@ def _count_stale_scores(conn: sqlite3.Connection) -> int:
     if not active_jobs:
         return 0
     if _table_exists(conn, "job_score_staleness"):
+        stale_columns = {
+            str(row[1])
+            for row in conn.execute(
+                "PRAGMA table_info(job_score_staleness)"
+            ).fetchall()
+        }
+        stable_references = "job_id" in stale_columns
         if _table_exists(conn, "job_scores"):
-            rows = conn.execute(
+            sql = (
                 """
+                SELECT DISTINCT jobs.url AS job_url
+                FROM job_score_staleness stale
+                JOIN jobs
+                  ON jobs.tenant_id = stale.tenant_id
+                 AND jobs.job_id = stale.job_id
+                JOIN (
+                    SELECT tenant_id, job_id, MAX(version) AS max_version
+                    FROM job_scores
+                    WHERE tenant_id = ?
+                    GROUP BY tenant_id, job_id
+                ) latest
+                  ON latest.tenant_id = stale.tenant_id
+                 AND latest.job_id = stale.job_id
+                JOIN job_scores scores
+                  ON scores.tenant_id = stale.tenant_id
+                 AND scores.job_id = stale.job_id
+                 AND scores.version = latest.max_version
+                WHERE stale.tenant_id = ?
+                  AND stale.resolved = 0
+                  AND (
+                    scores.correction_json IS NULL
+                    OR TRIM(scores.correction_json) = ''
+                  )
+                """
+                if stable_references
+                else """
                 SELECT DISTINCT stale.job_url
                 FROM job_score_staleness stale
                 JOIN (
@@ -641,20 +674,33 @@ def _count_stale_scores(conn: sqlite3.Connection) -> int:
                  AND scores.version = latest.max_version
                 WHERE stale.tenant_id = ?
                   AND stale.resolved = 0
-                  AND (scores.correction_json IS NULL OR TRIM(scores.correction_json) = '')
-                """,
-                [TENANT_ID, TENANT_ID],
-            ).fetchall()
+                  AND (
+                    scores.correction_json IS NULL
+                    OR TRIM(scores.correction_json) = ''
+                  )
+                """
+            )
+            rows = conn.execute(sql, [TENANT_ID, TENANT_ID]).fetchall()
             return sum(1 for row in rows if _row_get(row, "job_url") in active_jobs)
-        rows = conn.execute(
+        sql = (
             """
+            SELECT DISTINCT jobs.url AS job_url
+            FROM job_score_staleness stale
+            JOIN jobs
+              ON jobs.tenant_id = stale.tenant_id
+             AND jobs.job_id = stale.job_id
+            WHERE stale.tenant_id = ?
+              AND stale.resolved = 0
+            """
+            if stable_references
+            else """
             SELECT DISTINCT job_url
             FROM job_score_staleness
             WHERE tenant_id = ?
               AND resolved = 0
-            """,
-            [TENANT_ID],
-        ).fetchall()
+            """
+        )
+        rows = conn.execute(sql, [TENANT_ID]).fetchall()
         return sum(1 for row in rows if _row_get(row, "job_url") in active_jobs)
     if _table_exists(conn, "job_list_projections"):
         rows = conn.execute(

--- a/workers/automation/src/jobctrl/domain/materials/quality.py
+++ b/workers/automation/src/jobctrl/domain/materials/quality.py
@@ -986,8 +986,13 @@ def _requirement_fit_report_matches(
 ) -> bool:
     if requirement_fit_report is None:
         return False
-    job_url = str(job.get("url") or "").strip()
-    if job_url and str(getattr(requirement_fit_report, "job_id", "") or "") != job_url:
+    expected_job_id = str(
+        job.get("job_id") or job.get("url") or ""
+    ).strip()
+    if expected_job_id and (
+        str(getattr(requirement_fit_report, "job_id", "") or "")
+        != expected_job_id
+    ):
         return False
     generation = int(getattr(requirement_fit_report, "employer_analysis_generation", 0) or 0)
     return generation == employer_analysis.generation

--- a/workers/automation/src/jobctrl/domain/materials/requirement_coverage.py
+++ b/workers/automation/src/jobctrl/domain/materials/requirement_coverage.py
@@ -728,7 +728,12 @@ def build_target_profile(
     nice_to_have = tuple(requirement for requirement in requirements if requirement.tier != "must_have")
     job_skills = _clean_string_tuple(job.get("skills", ()))
     return TargetProfile(
-        job_id=str(job.get("url") or getattr(requirement_fit_report, "job_id", "") or ""),
+        job_id=str(
+            job.get("job_id")
+            or job.get("url")
+            or getattr(requirement_fit_report, "job_id", "")
+            or ""
+        ),
         target_role=str(job.get("title") or job.get("role_title") or ""),
         seniority=str(employer_analysis.canonical.inferred_seniority or ""),
         must_have_requirements=must_have,

--- a/workers/automation/src/jobctrl/domain/materials/use_cases.py
+++ b/workers/automation/src/jobctrl/domain/materials/use_cases.py
@@ -1574,6 +1574,9 @@ class TailorResumeUseCase:
         requirement_fit_report: "RequirementFitReport | None" = None,
     ) -> TailorOutcome:
         job_id = JobId(str(job["url"]))
+        scoring_job_id = JobId(
+            str(job.get("job_id") or job["url"])
+        )
         # D-20: run/reuse the canonical employer analysis as the front-half
         # sub-step of tailor (cache-backed, so a re-tailor reuses it). The
         # analysis drives keyword selection in ``build_tailoring_plan``.
@@ -1583,7 +1586,7 @@ class TailorResumeUseCase:
         if requirement_fit_report is None and self._requirement_fit_repository is not None:
             requirement_fit_report = self._requirement_fit_repository.load(
                 tenant_id,
-                job_id,
+                scoring_job_id,
             )
         previous = self._repository.load(tenant_id, job_id)
         created_at = _utc_now()
@@ -1849,7 +1852,9 @@ class TailorResumeUseCase:
 
         if record_provenance and self._provenance_repository is not None:
             self._record_requirement_artifact_coverage(
-                materials=materials, bullets=provenance_rows
+                materials=materials,
+                scoring_job_id=scoring_job_id,
+                bullets=provenance_rows,
             )
             self._publish_provenance(
                 materials,
@@ -3223,6 +3228,7 @@ class TailorResumeUseCase:
         self,
         *,
         materials: MaterialsSet,
+        scoring_job_id: JobId,
         bullets: tuple[BulletProvenance, ...],
     ) -> None:
         """Map accepted artifact provenance back onto the latest requirement fit report."""
@@ -3231,7 +3237,7 @@ class TailorResumeUseCase:
         try:
             report = self._requirement_fit_repository.load(
                 materials.tenant_id,
-                materials.job_id,
+                scoring_job_id,
             )
             if report is None:
                 return

--- a/workers/automation/src/jobctrl/domain/scoring/use_cases.py
+++ b/workers/automation/src/jobctrl/domain/scoring/use_cases.py
@@ -559,7 +559,7 @@ class ScoreJobUseCase:
                 error=parse.error or "Unknown parse error",
             )
 
-        job_id = JobId(str(job["url"]))
+        job_id = _job_id_from_record(job)
         resolved_parse = (
             self._resolve_with_requirement_fit(
                 parse=parse,
@@ -708,7 +708,7 @@ class ScoreJobUseCase:
         parse: ScoreParseResult,
         scored_at: str,
     ) -> JobScore:
-        job_id = JobId(str(job["url"]))
+        job_id = _job_id_from_record(job)
         previous = self._repository.load(tenant_id, job_id)
         # Type guard: parse.ok is True at this point (caller checks).
         assert parse.fit_score is not None
@@ -1042,6 +1042,14 @@ def _policy_evidence_from_score(score: JobScore) -> dict[str, Any]:
         "missing_signal_count": len(score.breakdown.missing_signals),
         "transferable_signal_count": len(score.breakdown.transferable_signals),
     }
+
+
+def _job_id_from_record(job: dict[str, Any]) -> JobId:
+    """Prefer canonical identity while retaining generic-port test fixtures."""
+    reference = str(job.get("job_id") or job.get("url") or "").strip()
+    if not reference:
+        raise ValueError("job requires job_id or url")
+    return JobId(reference)
 
 
 __all__ = [

--- a/workers/automation/src/jobctrl/infrastructure/materials/sqlite_repository.py
+++ b/workers/automation/src/jobctrl/infrastructure/materials/sqlite_repository.py
@@ -236,7 +236,8 @@ class SqliteMaterialsRepository:
         # this adapter stays self-contained.
         score_join = (
             "LEFT JOIN ("
-            "SELECT s.job_url AS sj_job_url, s.fit_score AS sj_fit_score, "
+            "SELECT s.tenant_id AS sj_tenant_id, s.job_id AS sj_job_id, "
+            "s.fit_score AS sj_fit_score, "
             "CASE WHEN json_valid(s.breakdown_json) "
             "THEN LOWER(COALESCE(CAST(json_extract(s.breakdown_json, '$.eligibility.status') AS TEXT), '')) "
             "ELSE '' END AS sj_eligibility_status, "
@@ -248,10 +249,13 @@ class SqliteMaterialsRepository:
             "0) ELSE 0 END AS sj_hard_blocker_count "
             "FROM job_scores s "
             "INNER JOIN ("
-            "SELECT job_url, MAX(version) AS max_version FROM job_scores GROUP BY job_url"
-            ") latest ON latest.job_url = s.job_url AND latest.max_version = s.version "
+            "SELECT tenant_id, job_id, MAX(version) AS max_version "
+            "FROM job_scores GROUP BY tenant_id, job_id"
+            ") latest ON latest.tenant_id = s.tenant_id "
+            "AND latest.job_id = s.job_id AND latest.max_version = s.version "
             "WHERE s.tenant_id = ?"
-            ") sj ON sj.sj_job_url = j.url"
+            ") sj ON sj.sj_tenant_id = j.tenant_id "
+            "AND sj.sj_job_id = j.job_id"
         )
         materials_join = (
             "LEFT JOIN ("
@@ -306,7 +310,8 @@ class SqliteMaterialsRepository:
         params: list[Any] = [str(tenant_id)]
         score_join = (
             "LEFT JOIN ("
-            "SELECT s.job_url AS sj_job_url, s.fit_score AS sj_fit_score, "
+            "SELECT s.tenant_id AS sj_tenant_id, s.job_id AS sj_job_id, "
+            "s.fit_score AS sj_fit_score, "
             "CASE WHEN json_valid(s.breakdown_json) "
             "THEN LOWER(COALESCE(CAST(json_extract(s.breakdown_json, '$.eligibility.status') AS TEXT), '')) "
             "ELSE '' END AS sj_eligibility_status, "
@@ -318,10 +323,13 @@ class SqliteMaterialsRepository:
             "0) ELSE 0 END AS sj_hard_blocker_count "
             "FROM job_scores s "
             "INNER JOIN ("
-            "SELECT job_url, MAX(version) AS max_version FROM job_scores GROUP BY job_url"
-            ") latest ON latest.job_url = s.job_url AND latest.max_version = s.version "
+            "SELECT tenant_id, job_id, MAX(version) AS max_version "
+            "FROM job_scores GROUP BY tenant_id, job_id"
+            ") latest ON latest.tenant_id = s.tenant_id "
+            "AND latest.job_id = s.job_id AND latest.max_version = s.version "
             "WHERE s.tenant_id = ?"
-            ") sj ON sj.sj_job_url = j.url"
+            ") sj ON sj.sj_tenant_id = j.tenant_id "
+            "AND sj.sj_job_id = j.job_id"
         )
         params.append(str(tenant_id))
         materials_join = (

--- a/workers/automation/src/jobctrl/infrastructure/projections/projection_builder.py
+++ b/workers/automation/src/jobctrl/infrastructure/projections/projection_builder.py
@@ -45,6 +45,7 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any, Callable
 
+from jobctrl.domain.discovery.value_objects import PostingUrl
 from jobctrl.domain.events.base import DomainEvent
 from jobctrl.domain.identifiers import JobId
 from jobctrl.domain.operations.projections import (
@@ -1805,24 +1806,34 @@ class ProjectionBuilder:
             self._conn, "job_requirement_fit_items"
         ):
             return
-        job_metadata = _job_metadata_join_sql(self._conn, "items.job_url")
-        lifecycle = _job_lifecycle_exclusion_sql(self._conn, "items.job_url")
+        job_metadata = _job_metadata_join_sql(
+            self._conn,
+            "score_jobs.url",
+        )
+        lifecycle = _job_lifecycle_exclusion_sql(
+            self._conn,
+            "score_jobs.url",
+        )
         rows = self._conn.execute(
             f"""
-            SELECT items.job_url, items.score_version, items.requirement_id,
+            SELECT score_jobs.url AS job_url, items.score_version,
+                   items.requirement_id,
                    items.requirement_text, items.tier, items.weight,
                    items.fit_json, items.artifact_coverage_json,
                    {job_metadata['select_sql']}
               FROM job_requirement_fit_items AS items
+              JOIN jobs AS score_jobs
+                ON score_jobs.tenant_id = items.tenant_id
+               AND score_jobs.job_id = items.job_id
               {job_metadata['join_sql']}{lifecycle['join_sql']}
              WHERE items.tenant_id = ?{lifecycle['where_sql']}
                AND items.score_version = (
                  SELECT MAX(report.score_version)
                    FROM job_requirement_fit_reports AS report
                   WHERE report.tenant_id = items.tenant_id
-                    AND report.job_url = items.job_url
+                    AND report.job_id = items.job_id
                )
-             ORDER BY items.job_url, items.position, items.requirement_id
+             ORDER BY score_jobs.url, items.position, items.requirement_id
             """,
             (str(self._tenant_id),),
         ).fetchall()
@@ -2154,11 +2165,15 @@ class ProjectionBuilder:
                        s.keywords_json, s.criteria_json, s.trace_json,
                        s.correction_json
                 FROM job_scores s
-                WHERE s.job_url = ?
+                JOIN jobs j
+                  ON j.tenant_id = s.tenant_id
+                 AND j.job_id = s.job_id
+                WHERE j.tenant_id = ?
+                  AND j.url = ?
                 ORDER BY s.version DESC
                 LIMIT 1
                 """,
-                (job_url,),
+                (str(self._tenant_id), job_url),
             ).fetchone()
         except sqlite3.OperationalError:
             return {}
@@ -2422,14 +2437,22 @@ class ProjectionBuilder:
         from jobctrl.infrastructure.scoring import SqliteRequirementFitReportRepository
 
         try:
-            record = SqliteRequirementFitReportRepository(self._conn).load(
-                self._tenant_id, JobId(job_url)
+            record = SqliteRequirementFitReportRepository(
+                self._conn
+            ).load_by_posting_url(
+                self._tenant_id,
+                PostingUrl(job_url),
             )
         except sqlite3.OperationalError:
             return None
         if record is None:
             return None
-        return json.dumps(record.to_read_model(), ensure_ascii=False)
+        read_model = record.to_read_model()
+        # Operations projections remain URL-keyed until their dedicated
+        # identity cutover; keep that compatibility projection explicit while
+        # the scoring authority itself is keyed by stable JobId.
+        read_model["jobKey"] = job_url
+        return json.dumps(read_model, ensure_ascii=False)
 
     def _load_interview_prep(self, job_url: str) -> str | None:
         """Project the latest accepted interview-prep read shape.
@@ -2733,7 +2756,12 @@ class ProjectionBuilder:
                 """
                 SELECT p.job_id
                 FROM job_list_projections p
-                JOIN job_scores s ON s.job_url = p.job_id
+                JOIN jobs j
+                  ON j.tenant_id = p.tenant_id
+                 AND j.url = p.job_id
+                JOIN job_scores s
+                  ON s.tenant_id = j.tenant_id
+                 AND s.job_id = j.job_id
                 WHERE p.tenant_id = ?
                   AND p.score_criteria_json IS NULL
                 """,

--- a/workers/automation/src/jobctrl/infrastructure/scoring/feedback.py
+++ b/workers/automation/src/jobctrl/infrastructure/scoring/feedback.py
@@ -79,11 +79,29 @@ def rank_jobs_with_feedback(
 def _correction_signals(conn: sqlite3.Connection) -> list[ScoringFeedbackSignal]:
     if not _table_exists(conn, "job_scores"):
         return []
+    columns = {
+        str(row[1])
+        for row in conn.execute("PRAGMA table_info(job_scores)").fetchall()
+    }
+    stable_references = "job_id" in columns
+    identity_select = "jobs.url" if stable_references else "score.job_url"
+    identity_join = (
+        """
+        JOIN jobs
+          ON jobs.tenant_id = score.tenant_id
+         AND jobs.job_id = score.job_id
+        """
+        if stable_references
+        else ""
+    )
     rows = conn.execute(
-        """SELECT job_url, fit_score, correction_json, trace_json
-           FROM job_scores
-           WHERE correction_json IS NOT NULL AND correction_json != ''
-           ORDER BY job_url, version"""
+        f"""SELECT {identity_select} AS job_url, score.fit_score,
+                  score.correction_json, score.trace_json
+           FROM job_scores score
+           {identity_join}
+           WHERE score.correction_json IS NOT NULL
+             AND score.correction_json != ''
+           ORDER BY {identity_select}, score.version"""
     ).fetchall()
     signals: list[ScoringFeedbackSignal] = []
     for row in rows:

--- a/workers/automation/src/jobctrl/infrastructure/scoring/sqlite_repository.py
+++ b/workers/automation/src/jobctrl/infrastructure/scoring/sqlite_repository.py
@@ -7,9 +7,9 @@ every ``save`` call must hand in an aggregate whose ``version`` is exactly
 adapter raises ``ScoreVersionConflict`` so callers cannot accidentally
 overwrite history.
 
-Local-mode treats ``job_id`` as the legacy ``jobs.url`` primary key. When
-the cloud cutover (Phase 9) introduces stable system-generated ``JobId``
-values, the adapter swaps the column without touching the port.
+The aggregate identity and table primary key are both
+``(tenant_id, job_id, version)``. Posting URLs are resolved only through
+explicit compatibility methods while legacy workflow inputs are cut over.
 
 See ddd-target.md §7.1 / §7.2 (per-aggregate repository, schema decoupling).
 """
@@ -26,7 +26,8 @@ from jobctrl.database import (
     ensure_score_staleness_tables,
     ensure_scoring_policy_tables,
 )
-from jobctrl.domain.identifiers import JobId
+from jobctrl.domain.discovery.value_objects import PostingUrl
+from jobctrl.domain.identifiers import JobId, canonical_job_id
 from jobctrl.domain.scoring.aggregate import JobScore, ScoreStaleMarker
 from jobctrl.domain.scoring.policy import CorrectionSignal, ScoringPolicy
 from jobctrl.domain.scoring.value_objects import (
@@ -71,6 +72,14 @@ class SqliteScoreStalenessRepository:
     def __init__(self, conn: sqlite3.Connection) -> None:
         self._conn = conn
         ensure_score_staleness_tables(conn)
+        self._reference_column = _job_reference_column(
+            conn,
+            "job_score_staleness",
+        )
+        self._score_reference_column = _job_reference_column(
+            conn,
+            "job_scores",
+        )
 
     def mark_comparable_scores_stale(
         self,
@@ -86,24 +95,33 @@ class SqliteScoreStalenessRepository:
             return []
 
         marked: list[ScoreStaleMarker] = []
+        score_reference = self._score_reference_column
+        identity_select, identity_join = _stable_identity_select(
+            score_reference,
+            source_alias="s",
+        )
         rows = self._conn.execute(
-            """
-            SELECT s.job_url, s.trace_json
+            f"""
+            SELECT {identity_select} AS job_id, s.trace_json
             FROM job_scores s
+            {identity_join}
             INNER JOIN (
-                SELECT job_url, MAX(version) AS max_version
+                SELECT tenant_id, {score_reference},
+                       MAX(version) AS max_version
                 FROM job_scores
                 WHERE tenant_id = ?
-                GROUP BY job_url
+                GROUP BY tenant_id, {score_reference}
             ) latest
-              ON latest.job_url = s.job_url AND latest.max_version = s.version
+              ON latest.tenant_id = s.tenant_id
+             AND latest.{score_reference} = s.{score_reference}
+             AND latest.max_version = s.version
             WHERE s.tenant_id = ?
               AND (s.correction_json IS NULL OR TRIM(s.correction_json) = '')
             """,
             (str(tenant_id), str(tenant_id)),
         ).fetchall()
         for row in rows:
-            job_url = _row_value(row, "job_url", 0)
+            stable_job_id = _row_value(row, "job_id", 0)
             trace = _json_object(_row_value(row, "trace_json", 1))
             old_policy_version = _int_or_default(trace.get("scoring_policy_version"), 0)
             if old_policy_version >= new_policy_version:
@@ -111,7 +129,7 @@ class SqliteScoreStalenessRepository:
 
             marker = ScoreStaleMarker(
                 tenant_id=tenant_id,
-                job_id=JobId(str(job_url)),
+                job_id=JobId(str(stable_job_id)),
                 stale_reason=stale_reason,
                 old_policy_id=str(trace.get("scoring_policy_id") or ""),
                 old_policy_version=old_policy_version,
@@ -119,10 +137,16 @@ class SqliteScoreStalenessRepository:
                 new_policy_version=new_policy_version,
                 marked_at=marked_at,
             )
+            reference_value = _reference_value_for_job_id(
+                self._conn,
+                tenant_id,
+                marker.job_id,
+                self._reference_column,
+            )
             inserted = self._conn.execute(
-                """
+                f"""
                 INSERT OR IGNORE INTO job_score_staleness (
-                    tenant_id, job_url, stale_reason,
+                    tenant_id, {self._reference_column}, stale_reason,
                     old_policy_id, old_policy_version,
                     new_policy_id, new_policy_version,
                     marked_at, resolved, resolved_at, resolved_by_score_version
@@ -130,7 +154,7 @@ class SqliteScoreStalenessRepository:
                 """,
                 (
                     str(marker.tenant_id),
-                    str(marker.job_id),
+                    reference_value,
                     marker.stale_reason,
                     marker.old_policy_id,
                     marker.old_policy_version,
@@ -152,14 +176,20 @@ class SqliteScoreStalenessRepository:
         if score.correction is not None or score.trace.scoring_policy_version <= 0:
             return 0
         now = _utc_now()
+        reference_value = _reference_value_for_job_id(
+            self._conn,
+            score.tenant_id,
+            score.job_id,
+            self._reference_column,
+        )
         result = self._conn.execute(
-            """
+            f"""
             UPDATE job_score_staleness
                SET resolved = 1,
                    resolved_at = ?,
                    resolved_by_score_version = ?
              WHERE tenant_id = ?
-               AND job_url = ?
+               AND {self._reference_column} = ?
                AND resolved = 0
                AND new_policy_version <= ?
             """,
@@ -167,13 +197,18 @@ class SqliteScoreStalenessRepository:
                 now,
                 score.version,
                 str(score.tenant_id),
-                str(score.job_id),
+                reference_value,
                 score.trace.scoring_policy_version,
             ),
         )
         if result.rowcount > 0:
+            job_url = _storage_url_for_job_id(
+                self._conn,
+                score.tenant_id,
+                score.job_id,
+            )
             self._record_score_event(
-                str(score.job_id),
+                job_url,
                 "ScoreStalenessResolved",
                 "Score stale marker resolved by a fresh score.",
                 {
@@ -195,12 +230,18 @@ class SqliteScoreStalenessRepository:
     ) -> list[ScoreStaleMarker]:
         """Clear active markers and reset their score stage for explicit rescore."""
         now = reset_at or _utc_now()
+        identity_select, identity_join = _stable_identity_select(
+            self._reference_column,
+            source_alias="stale",
+        )
         sql = (
-            "SELECT tenant_id, job_url, stale_reason, old_policy_id, "
+            f"SELECT stale.tenant_id, {identity_select} AS job_id, "
+            "stale.stale_reason, stale.old_policy_id, "
             "old_policy_version, new_policy_id, new_policy_version, marked_at, "
             "resolved, resolved_at, resolved_by_score_version "
-            "FROM job_score_staleness "
-            "WHERE tenant_id = ? AND resolved = 0 "
+            "FROM job_score_staleness stale "
+            f"{identity_join} "
+            "WHERE stale.tenant_id = ? AND stale.resolved = 0 "
             "ORDER BY marked_at ASC"
         )
         params: list[Any] = [str(tenant_id)]
@@ -210,7 +251,17 @@ class SqliteScoreStalenessRepository:
         rows = self._conn.execute(sql, params).fetchall()
         markers = [self._row_to_marker(row) for row in rows]
         for marker in markers:
-            job_url = str(marker.job_id)
+            job_url = _storage_url_for_job_id(
+                self._conn,
+                marker.tenant_id,
+                marker.job_id,
+            )
+            reference_value = _reference_value_for_job_id(
+                self._conn,
+                marker.tenant_id,
+                marker.job_id,
+                self._reference_column,
+            )
             set_stage_state(
                 self._conn,
                 job_url,
@@ -225,12 +276,12 @@ class SqliteScoreStalenessRepository:
                 validate_transition=False,
             )
             self._conn.execute(
-                """
+                f"""
                 UPDATE job_score_staleness
                    SET resolved = 1,
                        resolved_at = ?
                  WHERE tenant_id = ?
-                   AND job_url = ?
+                   AND {self._reference_column} = ?
                    AND stale_reason = ?
                    AND old_policy_version = ?
                    AND new_policy_version = ?
@@ -238,7 +289,7 @@ class SqliteScoreStalenessRepository:
                 (
                     now,
                     str(marker.tenant_id),
-                    job_url,
+                    reference_value,
                     marker.stale_reason,
                     marker.old_policy_version,
                     marker.new_policy_version,
@@ -250,7 +301,7 @@ class SqliteScoreStalenessRepository:
                 "Stale score reset for explicit rescore.",
                 {
                     "tenantId": str(marker.tenant_id),
-                    "jobId": job_url,
+                    "jobId": str(marker.job_id),
                     "staleReason": marker.stale_reason,
                     "oldPolicyVersion": marker.old_policy_version,
                     "newPolicyVersion": marker.new_policy_version,
@@ -261,7 +312,11 @@ class SqliteScoreStalenessRepository:
         return markers
 
     def _mark_score_stage_stale(self, marker: ScoreStaleMarker) -> None:
-        job_url = str(marker.job_id)
+        job_url = _storage_url_for_job_id(
+            self._conn,
+            marker.tenant_id,
+            marker.job_id,
+        )
         row = self._conn.execute(
             "SELECT state FROM job_stage_states WHERE job_url = ? AND stage = 'score'",
             (job_url,),
@@ -285,7 +340,7 @@ class SqliteScoreStalenessRepository:
             "Score marked stale after scoring policy changed.",
             {
                 "tenantId": str(marker.tenant_id),
-                "jobId": job_url,
+                "jobId": str(marker.job_id),
                 "staleReason": marker.stale_reason,
                 "oldPolicyId": marker.old_policy_id,
                 "oldPolicyVersion": marker.old_policy_version,
@@ -317,7 +372,7 @@ class SqliteScoreStalenessRepository:
     def _row_to_marker(row: Any) -> ScoreStaleMarker:
         return ScoreStaleMarker(
             tenant_id=TenantId(str(_row_value(row, "tenant_id", 0))),
-            job_id=JobId(str(_row_value(row, "job_url", 1))),
+            job_id=JobId(str(_row_value(row, "job_id", 1))),
             stale_reason=str(_row_value(row, "stale_reason", 2)),
             old_policy_id=str(_row_value(row, "old_policy_id", 3) or ""),
             old_policy_version=int(_row_value(row, "old_policy_version", 4) or 0),
@@ -336,6 +391,10 @@ class SqliteRequirementFitReportRepository:
     def __init__(self, conn: sqlite3.Connection) -> None:
         self._conn = conn
         ensure_requirement_fit_tables(conn)
+        self._reference_column = _job_reference_column(
+            conn,
+            "job_requirement_fit_reports",
+        )
 
     def load(
         self,
@@ -344,57 +403,75 @@ class SqliteRequirementFitReportRepository:
         *,
         score_version: int | None = None,
     ) -> RequirementFitReport | None:
+        resolved_job_id = _resolve_job_id(
+            self._conn,
+            tenant_id,
+            job_id,
+        )
+        if resolved_job_id is None:
+            return None
+        reference_value = _reference_value_for_job_id(
+            self._conn,
+            tenant_id,
+            resolved_job_id,
+            self._reference_column,
+        )
         if score_version is None:
             row = self._conn.execute(
-                """
-                SELECT job_url, score_version, tenant_id,
+                f"""
+                SELECT {self._reference_column} AS job_reference,
+                       score_version, tenant_id,
                        employer_analysis_generation, profile_snapshot_version,
                        scoring_policy_version, formula_version,
                        resolved_fit_score, fit_band, confidence, summary_json
                   FROM job_requirement_fit_reports
                  WHERE tenant_id = ?
-                   AND job_url = ?
+                   AND {self._reference_column} = ?
                  ORDER BY score_version DESC
                  LIMIT 1
                 """,
-                (str(tenant_id), str(job_id)),
+                (str(tenant_id), reference_value),
             ).fetchone()
         else:
             row = self._conn.execute(
-                """
-                SELECT job_url, score_version, tenant_id,
+                f"""
+                SELECT {self._reference_column} AS job_reference,
+                       score_version, tenant_id,
                        employer_analysis_generation, profile_snapshot_version,
                        scoring_policy_version, formula_version,
                        resolved_fit_score, fit_band, confidence, summary_json
                   FROM job_requirement_fit_reports
                  WHERE tenant_id = ?
-                   AND job_url = ?
+                   AND {self._reference_column} = ?
                    AND score_version = ?
                  LIMIT 1
                 """,
-                (str(tenant_id), str(job_id), score_version),
+                (str(tenant_id), reference_value, score_version),
             ).fetchone()
         if row is None:
             return None
 
-        job_url = str(_row_value(row, "job_url", 0))
         version = _int_or_default(_row_value(row, "score_version", 1), 0)
+        item_reference = _job_reference_column(
+            self._conn,
+            "job_requirement_fit_items",
+        )
         item_rows = self._conn.execute(
-            """
+            f"""
             SELECT requirement_id, requirement_text, tier, weight,
                    job_evidence_span, fit_json, contribution_json,
                    tailoring_json, artifact_coverage_json
               FROM job_requirement_fit_items
              WHERE tenant_id = ?
-               AND job_url = ?
+               AND {item_reference} = ?
                AND score_version = ?
              ORDER BY position ASC, requirement_id ASC
             """,
-            (str(tenant_id), job_url, version),
+            (str(tenant_id), reference_value, version),
         ).fetchall()
         assessments = tuple(self._row_to_assessment(item) for item in item_rows)
         return RequirementFitReport(
-            job_id=job_url,
+            job_id=str(resolved_job_id),
             score_version=version,
             employer_analysis_generation=_int_or_default(
                 _row_value(row, "employer_analysis_generation", 3),
@@ -416,17 +493,72 @@ class SqliteRequirementFitReportRepository:
             assessments=assessments,
         )
 
+    def load_by_posting_url(
+        self,
+        tenant_id: TenantId,
+        posting_url: PostingUrl,
+        *,
+        score_version: int | None = None,
+    ) -> RequirementFitReport | None:
+        stable_job_id = self.job_id_for_posting_url(
+            tenant_id,
+            posting_url,
+        )
+        return self.load(
+            tenant_id,
+            stable_job_id,
+            score_version=score_version,
+        )
+
+    def job_id_for_posting_url(
+        self,
+        tenant_id: TenantId,
+        posting_url: PostingUrl,
+    ) -> JobId:
+        stable_job_id = _job_id_for_posting_url(
+            self._conn,
+            tenant_id,
+            posting_url,
+        )
+        if stable_job_id is None:
+            raise KeyError(
+                "No stable Job identity for requirement-fit report: "
+                f"{posting_url.value}"
+            )
+        return stable_job_id
+
     def save(self, tenant_id: TenantId, report: RequirementFitReport) -> None:
         now = _utc_now()
+        stable_job_id = _resolve_job_id(
+            self._conn,
+            tenant_id,
+            JobId(str(report.job_id)),
+        )
+        if stable_job_id is None:
+            raise KeyError(
+                "No stable Job identity for requirement-fit report: "
+                f"{report.job_id}"
+            )
+        reference_value = _reference_value_for_job_id(
+            self._conn,
+            tenant_id,
+            stable_job_id,
+            self._reference_column,
+        )
+        conflict_columns = (
+            "tenant_id, job_id, score_version"
+            if self._reference_column == "job_id"
+            else "job_url, score_version, tenant_id"
+        )
         self._conn.execute(
-            """
+            f"""
             INSERT INTO job_requirement_fit_reports (
-                job_url, score_version, tenant_id,
+                {self._reference_column}, score_version, tenant_id,
                 employer_analysis_generation, profile_snapshot_version,
                 scoring_policy_version, formula_version, resolved_fit_score,
                 fit_band, confidence, summary_json, created_at
             ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            ON CONFLICT(job_url, score_version, tenant_id) DO UPDATE SET
+            ON CONFLICT({conflict_columns}) DO UPDATE SET
                 employer_analysis_generation = excluded.employer_analysis_generation,
                 profile_snapshot_version = excluded.profile_snapshot_version,
                 scoring_policy_version = excluded.scoring_policy_version,
@@ -438,7 +570,7 @@ class SqliteRequirementFitReportRepository:
                 created_at = excluded.created_at
             """,
             (
-                report.job_id,
+                reference_value,
                 report.score_version,
                 str(tenant_id),
                 report.employer_analysis_generation,
@@ -454,27 +586,31 @@ class SqliteRequirementFitReportRepository:
                 now,
             ),
         )
+        item_reference = _job_reference_column(
+            self._conn,
+            "job_requirement_fit_items",
+        )
         self._conn.execute(
-            """
+            f"""
             DELETE FROM job_requirement_fit_items
-             WHERE job_url = ?
+             WHERE {item_reference} = ?
                AND score_version = ?
                AND tenant_id = ?
             """,
-            (report.job_id, report.score_version, str(tenant_id)),
+            (reference_value, report.score_version, str(tenant_id)),
         )
         for position, assessment in enumerate(report.assessments):
             self._conn.execute(
-                """
+                f"""
                 INSERT INTO job_requirement_fit_items (
-                    job_url, score_version, tenant_id, requirement_id,
+                    {item_reference}, score_version, tenant_id, requirement_id,
                     requirement_text, tier, weight, job_evidence_span,
                     fit_json, contribution_json, tailoring_json,
                     artifact_coverage_json, position
                 ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
-                    report.job_id,
+                    reference_value,
                     report.score_version,
                     str(tenant_id),
                     assessment.requirement_id,
@@ -531,6 +667,10 @@ class SqliteScoreRepository:
 
     def __init__(self, conn: sqlite3.Connection) -> None:
         self._conn = conn
+        self._reference_column = _job_reference_column(
+            conn,
+            "job_scores",
+        )
         self._staleness = SqliteScoreStalenessRepository(conn)
 
     @property
@@ -543,28 +683,97 @@ class SqliteScoreRepository:
     # ------------------------------------------------------------------
 
     def load(self, tenant_id: TenantId, job_id: JobId) -> JobScore | None:
+        resolved_job_id = _resolve_job_id(
+            self._conn,
+            tenant_id,
+            job_id,
+        )
+        if resolved_job_id is None:
+            return None
+        return self._load_resolved(tenant_id, resolved_job_id)
+
+    def load_by_posting_url(
+        self,
+        tenant_id: TenantId,
+        posting_url: PostingUrl,
+    ) -> JobScore | None:
+        """Resolve one bounded legacy URL input before stable lookup."""
+        stable_job_id = _job_id_for_posting_url(
+            self._conn,
+            tenant_id,
+            posting_url,
+        )
+        if stable_job_id is None:
+            return None
+        return self._load_resolved(tenant_id, stable_job_id)
+
+    def job_id_for_posting_url(
+        self,
+        tenant_id: TenantId,
+        posting_url: PostingUrl,
+    ) -> JobId:
+        """Return the stable identity owned by a legacy posting URL."""
+        stable_job_id = _job_id_for_posting_url(
+            self._conn,
+            tenant_id,
+            posting_url,
+        )
+        if stable_job_id is None:
+            raise KeyError(
+                f"No stable Job identity for scoring: {posting_url.value}"
+            )
+        return stable_job_id
+
+    def _load_resolved(
+        self,
+        tenant_id: TenantId,
+        job_id: JobId,
+    ) -> JobScore | None:
+        reference_value = _reference_value_for_job_id(
+            self._conn,
+            tenant_id,
+            job_id,
+            self._reference_column,
+        )
         row = self._conn.execute(
-            """
-            SELECT job_url, version, fit_score, breakdown_json, keywords_json,
+            f"""
+            SELECT {self._reference_column} AS job_reference,
+                   version, fit_score, breakdown_json, keywords_json,
                    scored_at, correction_json, criteria_json, trace_json
             FROM job_scores
-            WHERE job_url = ? AND tenant_id = ?
+            WHERE {self._reference_column} = ? AND tenant_id = ?
             ORDER BY version DESC
             LIMIT 1
             """,
-            (str(job_id), str(tenant_id)),
+            (reference_value, str(tenant_id)),
         ).fetchone()
         if row is None:
             return None
-        return self._row_to_score(row, tenant_id)
+        return self._row_to_score(
+            row,
+            tenant_id,
+            job_id=job_id,
+        )
 
     def list_pending(self, tenant_id: TenantId, *, limit: int = 0) -> list[JobId]:
-        """Return job URLs that have a description but no score row yet."""
+        """Return stable JobIds that have a description but no score."""
         params: list[Any] = [str(tenant_id)]
+        if self._reference_column == "job_id":
+            score_join = (
+                "s.job_id = j.job_id AND s.tenant_id = j.tenant_id"
+            )
+            missing_score = "s.job_id IS NULL"
+        else:
+            score_join = (
+                "s.job_url = j.url AND s.tenant_id = j.tenant_id"
+            )
+            missing_score = "s.job_url IS NULL"
         sql = (
-            "SELECT j.url FROM jobs j "
-            "LEFT JOIN job_scores s ON s.job_url = j.url AND s.tenant_id = ? "
-            "WHERE j.full_description IS NOT NULL AND s.job_url IS NULL "
+            "SELECT j.job_id FROM jobs j "
+            f"LEFT JOIN job_scores s ON {score_join} "
+            "WHERE j.tenant_id = ? "
+            "AND j.full_description IS NOT NULL "
+            f"AND {missing_score} "
             "ORDER BY j.discovered_at DESC NULLS LAST"
         )
         if limit > 0:
@@ -587,19 +796,28 @@ class SqliteScoreRepository:
                 f"max_score must satisfy min_score <= max_score <= 10, got {max_score}"
             )
 
+        reference = self._reference_column
+        identity_select, identity_join = _stable_identity_select(
+            reference,
+            source_alias="s",
+        )
         rows = self._conn.execute(
-            """
-            SELECT s.job_url, s.version, s.fit_score, s.breakdown_json,
+            f"""
+            SELECT {identity_select} AS job_id,
+                   s.version, s.fit_score, s.breakdown_json,
                    s.keywords_json, s.scored_at, s.correction_json,
                    s.criteria_json, s.trace_json
             FROM job_scores s
+            {identity_join}
             INNER JOIN (
-                SELECT job_url, MAX(version) AS max_version
+                SELECT tenant_id, {reference}, MAX(version) AS max_version
                 FROM job_scores
                 WHERE tenant_id = ?
-                GROUP BY job_url
+                GROUP BY tenant_id, {reference}
             ) latest
-              ON latest.job_url = s.job_url AND latest.max_version = s.version
+              ON latest.tenant_id = s.tenant_id
+             AND latest.{reference} = s.{reference}
+             AND latest.max_version = s.version
             WHERE s.tenant_id = ?
               AND s.fit_score BETWEEN ? AND ?
             ORDER BY s.fit_score DESC, s.scored_at DESC
@@ -613,10 +831,25 @@ class SqliteScoreRepository:
     # ------------------------------------------------------------------
 
     def save(self, score: JobScore) -> None:
+        stable_job_id = _resolve_job_id(
+            self._conn,
+            score.tenant_id,
+            score.job_id,
+        )
+        if stable_job_id is None:
+            raise KeyError(
+                f"No stable Job identity for scoring: {score.job_id}"
+            )
+        reference_value = _reference_value_for_job_id(
+            self._conn,
+            score.tenant_id,
+            stable_job_id,
+            self._reference_column,
+        )
         latest = self._conn.execute(
             "SELECT COALESCE(MAX(version), 0) AS v FROM job_scores "
-            "WHERE job_url = ? AND tenant_id = ?",
-            (str(score.job_id), str(score.tenant_id)),
+            f"WHERE {self._reference_column} = ? AND tenant_id = ?",
+            (reference_value, str(score.tenant_id)),
         ).fetchone()
         current_max = int(latest[0] if latest else 0)
         expected = current_max + 1
@@ -628,14 +861,15 @@ class SqliteScoreRepository:
             )
 
         self._conn.execute(
-            """
+            f"""
             INSERT INTO job_scores (
-                job_url, version, tenant_id, fit_score, breakdown_json,
+                {self._reference_column}, version, tenant_id,
+                fit_score, breakdown_json,
                 keywords_json, scored_at, correction_json, criteria_json, trace_json
             ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
-                str(score.job_id),
+                reference_value,
                 score.version,
                 str(score.tenant_id),
                 score.fit_score.value,
@@ -651,6 +885,19 @@ class SqliteScoreRepository:
                 json.dumps(score.trace.to_dict(), sort_keys=True),
             ),
         )
+        if stable_job_id != score.job_id:
+            score = JobScore(
+                tenant_id=score.tenant_id,
+                job_id=stable_job_id,
+                version=score.version,
+                fit_score=score.fit_score,
+                breakdown=score.breakdown,
+                matched_keywords=score.matched_keywords,
+                scored_at=score.scored_at,
+                criteria=score.criteria,
+                trace=score.trace,
+                correction=score.correction,
+            )
         self._staleness.resolve_for_score(score)
         self._conn.commit()
 
@@ -659,9 +906,18 @@ class SqliteScoreRepository:
     # ------------------------------------------------------------------
 
     @staticmethod
-    def _row_to_score(row: Any, tenant_id: TenantId | None = None) -> JobScore:
+    def _row_to_score(
+        row: Any,
+        tenant_id: TenantId | None = None,
+        *,
+        job_id: JobId | None = None,
+    ) -> JobScore:
         if isinstance(row, sqlite3.Row):
-            job_url = row["job_url"]
+            raw_job_reference = (
+                row["job_id"]
+                if "job_id" in row.keys()
+                else row["job_reference"]
+            )
             version = row["version"]
             fit_score = row["fit_score"]
             breakdown_json = row["breakdown_json"]
@@ -673,7 +929,7 @@ class SqliteScoreRepository:
         else:
             if len(row) >= 9:
                 (
-                    job_url,
+                    raw_job_reference,
                     version,
                     fit_score,
                     breakdown_json,
@@ -684,7 +940,7 @@ class SqliteScoreRepository:
                     trace_json,
                 ) = row
             else:
-                job_url, version, fit_score, breakdown_json, keywords_json, scored_at, correction_json = row
+                raw_job_reference, version, fit_score, breakdown_json, keywords_json, scored_at, correction_json = row
                 criteria_json = None
                 trace_json = None
 
@@ -696,7 +952,7 @@ class SqliteScoreRepository:
 
         return JobScore(
             tenant_id=tenant_id or LOCAL_TENANT,
-            job_id=JobId(str(job_url)),
+            job_id=job_id or JobId(str(raw_job_reference)),
             version=int(version),
             fit_score=FitScore(value=int(fit_score)),
             breakdown=ScoreBreakdown.from_dict(breakdown_data),
@@ -818,3 +1074,147 @@ def _table_exists(conn: sqlite3.Connection, table_name: str) -> bool:
         (table_name,),
     ).fetchone()
     return row is not None
+
+
+def _job_reference_column(
+    conn: sqlite3.Connection,
+    table_name: str,
+) -> str:
+    columns = {
+        str(row[1])
+        for row in conn.execute(
+            f'PRAGMA table_info("{table_name}")'
+        ).fetchall()
+    }
+    if "job_id" in columns:
+        return "job_id"
+    if "job_url" in columns:
+        return "job_url"
+    raise RuntimeError(f"{table_name} has no Job identity column")
+
+
+def _stable_identity_select(
+    reference_column: str,
+    *,
+    source_alias: str,
+) -> tuple[str, str]:
+    if reference_column == "job_id":
+        return f"{source_alias}.job_id", ""
+    expression = f"""
+        COALESCE(
+            (
+                SELECT j.job_id
+                FROM jobs j
+                WHERE j.tenant_id = {source_alias}.tenant_id
+                  AND j.url = {source_alias}.job_url
+                LIMIT 1
+            ),
+            (
+                SELECT alias.job_id
+                FROM job_identity_aliases alias
+                JOIN jobs j
+                  ON j.tenant_id = alias.tenant_id
+                 AND j.job_id = alias.job_id
+                WHERE alias.tenant_id = {source_alias}.tenant_id
+                  AND alias.alias_kind = 'posting_url'
+                  AND alias.alias_value = {source_alias}.job_url
+                LIMIT 1
+            )
+        )
+    """
+    return expression, ""
+
+
+def _resolve_job_id(
+    conn: sqlite3.Connection,
+    tenant_id: TenantId,
+    job_id: JobId,
+) -> JobId | None:
+    raw_reference = str(job_id or "").strip()
+    if not raw_reference:
+        raise ValueError("job_id must be non-empty")
+    try:
+        stable_job_id = canonical_job_id(raw_reference)
+    except ValueError:
+        stable_job_id = None
+    if stable_job_id is not None:
+        row = conn.execute(
+            """
+            SELECT job_id
+            FROM jobs
+            WHERE tenant_id = ? AND job_id = ?
+            LIMIT 1
+            """,
+            (str(tenant_id), str(stable_job_id)),
+        ).fetchone()
+        if row is not None:
+            return JobId(str(row[0]))
+        # UUID-shaped posting URLs are intentionally not guessed here.
+        return None
+    return _job_id_for_posting_url(
+        conn,
+        tenant_id,
+        PostingUrl(raw_reference),
+    )
+
+
+def _job_id_for_posting_url(
+    conn: sqlite3.Connection,
+    tenant_id: TenantId,
+    posting_url: PostingUrl,
+) -> JobId | None:
+    row = conn.execute(
+        """
+        SELECT job_id
+        FROM jobs
+        WHERE tenant_id = ? AND url = ?
+        LIMIT 1
+        """,
+        (str(tenant_id), posting_url.value),
+    ).fetchone()
+    if row is None:
+        row = conn.execute(
+            """
+            SELECT alias.job_id
+            FROM job_identity_aliases alias
+            JOIN jobs j
+              ON j.tenant_id = alias.tenant_id
+             AND j.job_id = alias.job_id
+            WHERE alias.tenant_id = ?
+              AND alias.alias_kind = 'posting_url'
+              AND alias.alias_value = ?
+            LIMIT 1
+            """,
+            (str(tenant_id), posting_url.value),
+        ).fetchone()
+    return JobId(str(row[0])) if row is not None else None
+
+
+def _storage_url_for_job_id(
+    conn: sqlite3.Connection,
+    tenant_id: TenantId,
+    job_id: JobId,
+) -> str:
+    row = conn.execute(
+        """
+        SELECT url
+        FROM jobs
+        WHERE tenant_id = ? AND job_id = ?
+        LIMIT 1
+        """,
+        (str(tenant_id), str(job_id)),
+    ).fetchone()
+    if row is None:
+        raise KeyError(f"No storage URL for stable Job identity: {job_id}")
+    return str(row[0])
+
+
+def _reference_value_for_job_id(
+    conn: sqlite3.Connection,
+    tenant_id: TenantId,
+    job_id: JobId,
+    reference_column: str,
+) -> str:
+    if reference_column == "job_id":
+        return str(job_id)
+    return _storage_url_for_job_id(conn, tenant_id, job_id)

--- a/workers/automation/src/jobctrl/interview/activities.py
+++ b/workers/automation/src/jobctrl/interview/activities.py
@@ -239,15 +239,31 @@ def _load_requirements(
             SELECT requirement_id, requirement_text, tier, weight, fit_json
             FROM job_requirement_fit_items
             WHERE tenant_id = ?
-              AND job_url = ?
+              AND job_id = (
+                SELECT job_id FROM jobs
+                WHERE tenant_id = ? AND url = ?
+                LIMIT 1
+              )
               AND score_version = (
                 SELECT MAX(score_version)
                 FROM job_requirement_fit_reports
-                WHERE tenant_id = ? AND job_url = ?
+                WHERE tenant_id = ?
+                  AND job_id = (
+                    SELECT job_id FROM jobs
+                    WHERE tenant_id = ? AND url = ?
+                    LIMIT 1
+                  )
               )
             ORDER BY position, requirement_id
             """,
-            (str(tenant_id), job_url, str(tenant_id), job_url),
+            (
+                str(tenant_id),
+                str(tenant_id),
+                job_url,
+                str(tenant_id),
+                str(tenant_id),
+                job_url,
+            ),
         ).fetchall()
     except sqlite3.OperationalError:
         return ()

--- a/workers/automation/src/jobctrl/pipeline/current_policy_selectors.py
+++ b/workers/automation/src/jobctrl/pipeline/current_policy_selectors.py
@@ -40,22 +40,26 @@ def scoring_current_policy_job_urls(
           ON je.tenant_id = j.tenant_id
          AND je.job_id = j.job_id
         LEFT JOIN (
-            SELECT s.job_url, s.trace_json, s.correction_json
+            SELECT s.tenant_id, s.job_id, s.trace_json, s.correction_json
             FROM job_scores s
             INNER JOIN (
-                SELECT job_url, MAX(version) AS max_version
+                SELECT tenant_id, job_id, MAX(version) AS max_version
                 FROM job_scores
                 WHERE tenant_id = ?
-                GROUP BY job_url
+                GROUP BY tenant_id, job_id
             ) latest
-              ON latest.job_url = s.job_url AND latest.max_version = s.version
+              ON latest.tenant_id = s.tenant_id
+             AND latest.job_id = s.job_id
+             AND latest.max_version = s.version
             WHERE s.tenant_id = ?
-        ) latest_score ON latest_score.job_url = j.url
+        ) latest_score
+          ON latest_score.tenant_id = j.tenant_id
+         AND latest_score.job_id = j.job_id
         WHERE COALESCE(je.full_description, j.full_description) IS NOT NULL
           {active_sql}
           {requested_sql}
           AND (
-            latest_score.job_url IS NULL
+            latest_score.job_id IS NULL
             OR (
               (latest_score.correction_json IS NULL OR TRIM(latest_score.correction_json) = '')
               AND {_score_policy_version_expr("latest_score.trace_json")} != ?
@@ -105,23 +109,29 @@ def tailoring_current_policy_job_urls(
           ON je.tenant_id = j.tenant_id
          AND je.job_id = j.job_id
         LEFT JOIN (
-            SELECT s.job_url, s.fit_score, s.breakdown_json
+            SELECT s.tenant_id, s.job_id, s.fit_score, s.breakdown_json
             FROM job_scores s
             INNER JOIN (
-                SELECT job_url, MAX(version) AS max_version
+                SELECT tenant_id, job_id, MAX(version) AS max_version
                 FROM job_scores
                 WHERE tenant_id = ?
-                GROUP BY job_url
+                GROUP BY tenant_id, job_id
             ) latest
-              ON latest.job_url = s.job_url AND latest.max_version = s.version
+              ON latest.tenant_id = s.tenant_id
+             AND latest.job_id = s.job_id
+             AND latest.max_version = s.version
             WHERE s.tenant_id = ?
-        ) latest_score ON latest_score.job_url = j.url
+        ) latest_score
+          ON latest_score.tenant_id = j.tenant_id
+         AND latest_score.job_id = j.job_id
         LEFT JOIN (
-            SELECT job_url AS stale_job_url
+            SELECT tenant_id AS stale_tenant_id, job_id AS stale_job_id
             FROM job_score_staleness
             WHERE tenant_id = ? AND resolved = 0
-            GROUP BY job_url
-        ) stale_score ON stale_score.stale_job_url = j.url
+            GROUP BY tenant_id, job_id
+        ) stale_score
+          ON stale_score.stale_tenant_id = j.tenant_id
+         AND stale_score.stale_job_id = j.job_id
         LEFT JOIN job_stage_states score_state
           ON score_state.job_url = j.url AND score_state.stage = 'score'
         LEFT JOIN job_stage_states tailor_state
@@ -150,7 +160,7 @@ def tailoring_current_policy_job_urls(
           {requested_sql}
           AND COALESCE(latest_score.fit_score, j.fit_score) >= ?
           AND {_score_eligible_expr("latest_score.breakdown_json")}
-          AND stale_score.stale_job_url IS NULL
+          AND stale_score.stale_job_id IS NULL
           AND (
             score_state.state IS NULL
             OR score_state.state = 'succeeded'

--- a/workers/automation/src/jobctrl/scoring/scorer.py
+++ b/workers/automation/src/jobctrl/scoring/scorer.py
@@ -599,7 +599,7 @@ def score_job_by_url(
         repository = SqliteScoreRepository(conn)
     if policy_repository is None:
         policy_repository = SqliteScoringPolicyRepository(conn)
-    existing = repository.load(tenant_id, JobId(job_url))
+    existing = repository.load(tenant_id, _job_id_from_record(job))
     reusable_repost_score = _preferred_direct_score_for_repost(
         conn=conn,
         job=job,
@@ -736,7 +736,9 @@ def _ensure_existing_score_stage_succeeded(
     score: JobScore,
     tenant_id: TenantId,
 ) -> None:
-    job_url = str(score.job_id)
+    job_url = str(job.get("url") or "").strip()
+    if not job_url:
+        raise ValueError("score stage state requires the job storage URL")
     if _has_unresolved_score_staleness(conn, tenant_id=tenant_id, job_url=job_url):
         return
 
@@ -786,7 +788,9 @@ def _record_score_stage_succeeded(
     finished_at: str | None = None,
     validate_transition: bool = False,
 ) -> None:
-    job_url = str(score.job_id)
+    job_url = str(job.get("url") or "").strip()
+    if not job_url:
+        raise ValueError("score stage state requires the job storage URL")
     finished_at = finished_at or utc_now()
     ensure_job_stage_rows(conn, job_url, discovered_at=job.get("discovered_at"))
     set_stage_state(
@@ -835,16 +839,27 @@ def _has_unresolved_score_staleness(
     tenant_id: TenantId,
     job_url: str,
 ) -> bool:
+    identity = conn.execute(
+        """
+        SELECT job_id
+        FROM jobs
+        WHERE tenant_id = ? AND url = ?
+        LIMIT 1
+        """,
+        (str(tenant_id), job_url),
+    ).fetchone()
+    if identity is None:
+        return False
     row = conn.execute(
         """
         SELECT 1
         FROM job_score_staleness
         WHERE tenant_id = ?
-          AND job_url = ?
+          AND job_id = ?
           AND resolved = 0
         LIMIT 1
         """,
-        (str(tenant_id), job_url),
+        (str(tenant_id), str(identity[0])),
     ).fetchone()
     return row is not None
 
@@ -1010,7 +1025,7 @@ def _preferred_direct_score_for_repost(
     deleted_filter = "AND d.job_url IS NULL" if deleted_join else ""
     rows = conn.execute(
         f"""
-        SELECT j.url, j.title, j.location,
+        SELECT j.url, j.job_id, j.title, j.location,
                COALESCE(je.application_url, j.application_url) AS application_url,
                COALESCE(c.ats_kind, 'other') AS ats_kind,
                s.scored_at
@@ -1022,14 +1037,16 @@ def _preferred_direct_score_for_repost(
           ON c.tenant_id = ? AND c.job_id = j.job_id
         {deleted_join}
         INNER JOIN (
-            SELECT job_url, MAX(version) AS max_version
+            SELECT tenant_id, job_id, MAX(version) AS max_version
             FROM job_scores
             WHERE tenant_id = ?
-            GROUP BY job_url
-        ) latest ON latest.job_url = j.url
+            GROUP BY tenant_id, job_id
+        ) latest
+          ON latest.tenant_id = j.tenant_id
+         AND latest.job_id = j.job_id
         INNER JOIN job_scores s
           ON s.tenant_id = ?
-         AND s.job_url = latest.job_url
+         AND s.job_id = latest.job_id
          AND s.version = latest.max_version
         WHERE j.url != ?
           {deleted_filter}
@@ -1047,7 +1064,10 @@ def _preferred_direct_score_for_repost(
         candidate = dict(row)
         if not _same_reference_repost_opportunity(job, candidate):
             continue
-        score = repository.load(tenant_id, JobId(str(candidate["url"])))
+        score = repository.load(
+            tenant_id,
+            _job_id_from_record(candidate),
+        )
         if score is None:
             continue
         if not _score_matches_context(
@@ -1141,20 +1161,22 @@ def _reusable_scores_by_content_key(
         return {}
     rows = conn.execute(
         """
-        SELECT j.url, j.title, j.company,
+        SELECT j.url, j.job_id, j.title, j.company,
                COALESCE(je.full_description, j.full_description) AS full_description
         FROM jobs j
         LEFT JOIN job_enrichments je
           ON je.tenant_id = j.tenant_id
          AND je.job_id = j.job_id
         INNER JOIN (
-            SELECT s.job_url, MAX(s.version) AS max_version
+            SELECT s.tenant_id, s.job_id, MAX(s.version) AS max_version
             FROM job_scores s
             WHERE s.tenant_id = ?
-            GROUP BY s.job_url
-        ) latest ON latest.job_url = j.url
+            GROUP BY s.tenant_id, s.job_id
+        ) latest
+          ON latest.tenant_id = j.tenant_id
+         AND latest.job_id = j.job_id
         INNER JOIN job_scores s
-            ON s.job_url = latest.job_url
+            ON s.job_id = latest.job_id
            AND s.version = latest.max_version
            AND s.tenant_id = ?
         ORDER BY s.scored_at DESC
@@ -1168,7 +1190,7 @@ def _reusable_scores_by_content_key(
         key = _score_content_key(job)
         if key is None or key not in wanted_keys or key in reusable:
             continue
-        score = repository.load(tenant_id, JobId(str(job["url"])))
+        score = repository.load(tenant_id, _job_id_from_record(job))
         if score is None or not _score_matches_context(
             score=score,
             criteria=criteria,
@@ -1199,7 +1221,7 @@ def _persist_reused_score(
     job: dict[str, Any],
     source_score: JobScore,
 ) -> ScoreJobOutcome:
-    job_id = JobId(str(job["url"]))
+    job_id = _job_id_from_record(job)
     previous = repository.load(tenant_id, job_id)
     scored_at = utc_now()
     if previous is None:
@@ -1224,6 +1246,13 @@ def _persist_reused_score(
         )
     repository.save(copied)
     return ScoreJobOutcome(ok=True, score=copied)
+
+
+def _job_id_from_record(job: dict[str, Any]) -> JobId:
+    reference = str(job.get("job_id") or job.get("url") or "").strip()
+    if not reference:
+        raise ValueError("job requires job_id or url")
+    return JobId(reference)
 
 
 # ---------------------------------------------------------------------------

--- a/workers/automation/src/jobctrl/scoring/tailor.py
+++ b/workers/automation/src/jobctrl/scoring/tailor.py
@@ -34,6 +34,7 @@ from jobctrl import database as db_module
 from jobctrl import config
 from jobctrl.config import TAILORED_DIR
 from jobctrl.database import get_connection, get_jobs_by_stage
+from jobctrl.domain.discovery.value_objects import PostingUrl
 from jobctrl.domain.identifiers import JobId
 from jobctrl.domain.materials.services import ContentValidator, ResumeAssembler
 from jobctrl.domain.materials.use_cases import (
@@ -209,12 +210,12 @@ def _build_pdf_renderer() -> PdfRendererPort:
 
 
 def _load_requirement_fit_report_for_job(*, tenant_id: TenantId, job: dict):
-    job_url = str(job.get("url") or "").strip()
-    if not job_url:
+    job_reference = str(job.get("job_id") or job.get("url") or "").strip()
+    if not job_reference:
         return None
     return SqliteRequirementFitReportRepository(get_connection()).load(
         tenant_id,
-        JobId(job_url),
+        JobId(job_reference),
     )
 
 
@@ -781,7 +782,10 @@ def _reconcile_score_eligibility_skip(
     job_url: str,
     tenant_id: TenantId,
 ) -> bool:
-    score = SqliteScoreRepository(conn).load(tenant_id, JobId(job_url))
+    score = SqliteScoreRepository(conn).load_by_posting_url(
+        tenant_id,
+        PostingUrl(job_url),
+    )
     if score is None:
         return False
     eligibility = score.breakdown.eligibility

--- a/workers/automation/tests/test_apply_queue_selectors.py
+++ b/workers/automation/tests/test_apply_queue_selectors.py
@@ -152,9 +152,12 @@ def _insert_blocked_score(conn, url: str, *, fit_score: int = 9) -> None:
     conn.execute(
         """
         INSERT INTO job_scores (
-            job_url, version, tenant_id, fit_score, breakdown_json,
+            job_id, version, tenant_id, fit_score, breakdown_json,
             keywords_json, scored_at, correction_json, criteria_json, trace_json
-        ) VALUES (?, 1, 'local', ?, ?, '["python"]', ?, NULL, '{}', '{}')
+        ) VALUES (
+            (SELECT job_id FROM jobs WHERE tenant_id = 'local' AND url = ?),
+            1, 'local', ?, ?, '["python"]', ?, NULL, '{}', '{}'
+        )
         """,
         (
             url,
@@ -180,9 +183,12 @@ def _insert_allowed_score(conn, url: str, *, fit_score: int = 9) -> None:
     conn.execute(
         """
         INSERT INTO job_scores (
-            job_url, version, tenant_id, fit_score, breakdown_json,
+            job_id, version, tenant_id, fit_score, breakdown_json,
             keywords_json, scored_at, correction_json, criteria_json, trace_json
-        ) VALUES (?, 1, 'local', ?, ?, '["python"]', ?, NULL, '{}', '{}')
+        ) VALUES (
+            (SELECT job_id FROM jobs WHERE tenant_id = 'local' AND url = ?),
+            1, 'local', ?, ?, '["python"]', ?, NULL, '{}', '{}'
+        )
         """,
         (
             url,
@@ -208,14 +214,19 @@ def _insert_active_score_staleness_marker(conn, url: str) -> None:
     conn.execute(
         """
         INSERT INTO job_score_staleness (
-            tenant_id, job_url, stale_reason,
+            tenant_id, job_id, stale_reason,
             old_policy_id, old_policy_version,
             new_policy_id, new_policy_version,
             marked_at, resolved, resolved_at, resolved_by_score_version
-        ) VALUES (?, ?, 'scoring_policy_changed', 'local:scoring-policy-v1', 1,
-                  'local:scoring-policy-v2', 2, '2026-05-19T00:00:00+00:00', 0, NULL, NULL)
+        ) VALUES (
+            ?,
+            (SELECT job_id FROM jobs WHERE tenant_id = ? AND url = ?),
+            'scoring_policy_changed', 'local:scoring-policy-v1', 1,
+            'local:scoring-policy-v2', 2, '2026-05-19T00:00:00+00:00',
+            0, NULL, NULL
+        )
         """,
-        (str(LOCAL_TENANT), url),
+        (str(LOCAL_TENANT), str(LOCAL_TENANT), url),
     )
     conn.commit()
 

--- a/workers/automation/tests/test_apply_regressions.py
+++ b/workers/automation/tests/test_apply_regressions.py
@@ -99,9 +99,12 @@ def _insert_blocked_score(conn, url: str, *, fit_score: int = 9) -> None:
     conn.execute(
         """
         INSERT INTO job_scores (
-            job_url, version, tenant_id, fit_score, breakdown_json,
+            job_id, version, tenant_id, fit_score, breakdown_json,
             keywords_json, scored_at, correction_json, criteria_json, trace_json
-        ) VALUES (?, 1, 'local', ?, ?, '["python"]', ?, NULL, '{}', '{}')
+        ) VALUES (
+            (SELECT job_id FROM jobs WHERE tenant_id = 'local' AND url = ?),
+            1, 'local', ?, ?, '["python"]', ?, NULL, '{}', '{}'
+        )
         """,
         (
             url,

--- a/workers/automation/tests/test_audit_projection_parity.py
+++ b/workers/automation/tests/test_audit_projection_parity.py
@@ -103,9 +103,12 @@ def _seed_rows(conn: sqlite3.Connection, fixture: dict[str, Any]) -> None:
         conn.execute(
             """
             INSERT INTO job_scores (
-                job_url, version, tenant_id, fit_score, breakdown_json,
+                job_id, version, tenant_id, fit_score, breakdown_json,
                 keywords_json, scored_at, correction_json, criteria_json, trace_json
-            ) VALUES (?, ?, 'local', ?, ?, ?, ?, ?, ?, ?)
+            ) VALUES (
+                (SELECT job_id FROM jobs WHERE tenant_id = 'local' AND url = ?),
+                ?, 'local', ?, ?, ?, ?, ?, ?, ?
+            )
             """,
             (
                 job_url,
@@ -374,9 +377,12 @@ def _seed_rows(conn: sqlite3.Connection, fixture: dict[str, Any]) -> None:
             conn.execute(
                 """
                 INSERT INTO job_scores (
-                    job_url, version, tenant_id, fit_score, breakdown_json,
+                    job_id, version, tenant_id, fit_score, breakdown_json,
                     keywords_json, scored_at, correction_json, criteria_json, trace_json
-                ) VALUES (?, 1, 'local', ?, ?, '[]', ?, NULL, '{}', '{}')
+                ) VALUES (
+                    (SELECT job_id FROM jobs WHERE tenant_id = 'local' AND url = ?),
+                    1, 'local', ?, ?, '[]', ?, NULL, '{}', '{}'
+                )
                 """,
                 (
                     agg["url"],

--- a/workers/automation/tests/test_dashboard_projection.py
+++ b/workers/automation/tests/test_dashboard_projection.py
@@ -175,9 +175,12 @@ def test_score_distribution_groups_by_score(conn: sqlite3.Connection) -> None:
         _seed_job(conn, url)
         conn.execute(
             """
-            INSERT INTO job_scores (job_url, version, tenant_id, fit_score,
+            INSERT INTO job_scores (job_id, version, tenant_id, fit_score,
                                     breakdown_json, keywords_json, scored_at)
-            VALUES (?, 1, 'local', ?, ?, ?, ?)
+            VALUES (
+                (SELECT job_id FROM jobs WHERE tenant_id = 'local' AND url = ?),
+                1, 'local', ?, ?, ?, ?
+            )
             """,
             (url, score, json.dumps({}), json.dumps([]), utc_now()),
         )
@@ -381,9 +384,12 @@ def _apply_job(
     at = applied_at or utc_now()
     conn.execute(
         """
-        INSERT INTO job_scores (job_url, version, tenant_id, fit_score,
+        INSERT INTO job_scores (job_id, version, tenant_id, fit_score,
                                 breakdown_json, keywords_json, scored_at)
-        VALUES (?, 1, 'local', ?, '{}', '[]', ?)
+        VALUES (
+            (SELECT job_id FROM jobs WHERE tenant_id = 'local' AND url = ?),
+            1, 'local', ?, '{}', '[]', ?
+        )
         """,
         (url, fit_score, utc_now()),
     )
@@ -410,9 +416,12 @@ def _mark_manual_applied(
     at = applied_at or utc_now()
     conn.execute(
         """
-        INSERT INTO job_scores (job_url, version, tenant_id, fit_score,
+        INSERT INTO job_scores (job_id, version, tenant_id, fit_score,
                                 breakdown_json, keywords_json, scored_at)
-        VALUES (?, 1, 'local', ?, '{}', '[]', ?)
+        VALUES (
+            (SELECT job_id FROM jobs WHERE tenant_id = 'local' AND url = ?),
+            1, 'local', ?, '{}', '[]', ?
+        )
         """,
         (url, fit_score, utc_now()),
     )
@@ -435,9 +444,12 @@ def _mark_external_confirmed(
     at = applied_at or utc_now()
     conn.execute(
         """
-        INSERT INTO job_scores (job_url, version, tenant_id, fit_score,
+        INSERT INTO job_scores (job_id, version, tenant_id, fit_score,
                                 breakdown_json, keywords_json, scored_at)
-        VALUES (?, 1, 'local', ?, '{}', '[]', ?)
+        VALUES (
+            (SELECT job_id FROM jobs WHERE tenant_id = 'local' AND url = ?),
+            1, 'local', ?, '{}', '[]', ?
+        )
         """,
         (url, fit_score, utc_now()),
     )
@@ -452,10 +464,13 @@ def _record_fit_band(conn: sqlite3.Connection, url: str, fit_score: int, fit_ban
     conn.execute(
         """
         INSERT INTO job_requirement_fit_reports (
-            job_url, score_version, tenant_id, employer_analysis_generation,
+            job_id, score_version, tenant_id, employer_analysis_generation,
             profile_snapshot_version, scoring_policy_version, formula_version,
             resolved_fit_score, fit_band, confidence, summary_json, created_at
-        ) VALUES (?, 1, 'local', 1, 1, 1, 'test', ?, ?, 'medium', '{}', ?)
+        ) VALUES (
+            (SELECT job_id FROM jobs WHERE tenant_id = 'local' AND url = ?),
+            1, 'local', 1, 1, 1, 'test', ?, ?, 'medium', '{}', ?
+        )
         """,
         (url, fit_score, fit_band, utc_now()),
     )

--- a/workers/automation/tests/test_discovery_identity_reference_migration.py
+++ b/workers/automation/tests/test_discovery_identity_reference_migration.py
@@ -220,7 +220,7 @@ def test_v7_discovery_references_migrate_to_stable_job_id_and_reopen(
     init_db(db_path)
     close_connection(db_path)
 
-    assert _user_version(db_path) == SCHEMA_VERSION == 11
+    assert _user_version(db_path) == SCHEMA_VERSION == 12
     assert "job_id" in _columns(db_path, "job_source_observations")
     assert "job_url" not in _columns(db_path, "job_source_observations")
     assert "job_id" in _columns(db_path, "job_canonical_identities")

--- a/workers/automation/tests/test_enrichment_snapshot_identity_reference_migration.py
+++ b/workers/automation/tests/test_enrichment_snapshot_identity_reference_migration.py
@@ -322,7 +322,7 @@ def test_v10_enrichment_snapshot_references_migrate_and_reopen(
     init_db(db_path)
     close_connection(db_path)
 
-    assert _user_version(db_path) == SCHEMA_VERSION == 11
+    assert _user_version(db_path) == SCHEMA_VERSION == 12
     check = sqlite3.connect(db_path)
     try:
         enrichment_rows = check.execute(

--- a/workers/automation/tests/test_execution_search_identity_reference_migration.py
+++ b/workers/automation/tests/test_execution_search_identity_reference_migration.py
@@ -261,7 +261,7 @@ def test_v8_execution_and_receipts_migrate_to_stable_job_id_and_reopen(
     init_db(db_path)
     close_connection(db_path)
 
-    assert _user_version(db_path) == SCHEMA_VERSION == 11
+    assert _user_version(db_path) == SCHEMA_VERSION == 12
     assert "job_id" in _columns(db_path, "discovery_execution_jobs")
     assert "job_url" not in _columns(db_path, "discovery_execution_jobs")
     assert "job_id" in _columns(db_path, "discovery_search_unit_jobs")

--- a/workers/automation/tests/test_job_list_projection.py
+++ b/workers/automation/tests/test_job_list_projection.py
@@ -271,11 +271,15 @@ def test_score_event_populates_fit_score(conn: sqlite3.Connection) -> None:
     _seed_job(conn, url)
     conn.execute(
         """
-        INSERT INTO job_scores (job_url, version, tenant_id, fit_score,
+        INSERT INTO job_scores (job_id, version, tenant_id, fit_score,
                                 breakdown_json, keywords_json, scored_at)
-        VALUES (?, ?, ?, ?, ?, ?, ?)
+        VALUES (
+            (SELECT job_id FROM jobs WHERE tenant_id = ? AND url = ?),
+            ?, ?, ?, ?, ?, ?
+        )
         """,
         (
+            "local",
             url,
             1,
             "local",
@@ -343,11 +347,15 @@ def test_score_evidence_schema_migration_backfills_existing_projection(
     _seed_job(conn, url)
     conn.execute(
         """
-        INSERT INTO job_scores (job_url, version, tenant_id, fit_score,
+        INSERT INTO job_scores (job_id, version, tenant_id, fit_score,
                                 breakdown_json, keywords_json, scored_at)
-        VALUES (?, ?, ?, ?, ?, ?, ?)
+        VALUES (
+            (SELECT job_id FROM jobs WHERE tenant_id = ? AND url = ?),
+            ?, ?, ?, ?, ?, ?
+        )
         """,
         (
+            "local",
             url,
             1,
             "local",

--- a/workers/automation/tests/test_jsonrpc_handlers.py
+++ b/workers/automation/tests/test_jsonrpc_handlers.py
@@ -1719,10 +1719,13 @@ def _seed_score(
     conn.execute(
         """
         INSERT INTO job_scores (
-            job_url, version, tenant_id, fit_score, breakdown_json, keywords_json,
+            job_id, version, tenant_id, fit_score, breakdown_json, keywords_json,
             scored_at, correction_json, criteria_json, trace_json
-        ) VALUES (?, 1, 'local', ?, ?, '[]', '2026-05-26T10:00:00+00:00',
-            ?, '{}', ?)
+        ) VALUES (
+            (SELECT job_id FROM jobs WHERE tenant_id = 'local' AND url = ?),
+            1, 'local', ?, ?, '[]', '2026-05-26T10:00:00+00:00',
+            ?, '{}', ?
+        )
         """,
         (
             url,

--- a/workers/automation/tests/test_materials_repository.py
+++ b/workers/automation/tests/test_materials_repository.py
@@ -607,9 +607,12 @@ def _seed_blocked_latest_score(conn: sqlite3.Connection, url: str, fit_score: in
     conn.execute(
         """
         INSERT INTO job_scores (
-            job_url, version, tenant_id, fit_score, breakdown_json,
+            job_id, version, tenant_id, fit_score, breakdown_json,
             keywords_json, scored_at, correction_json, criteria_json, trace_json
-        ) VALUES (?, 1, 'local', ?, ?, '["python"]', ?, NULL, '{}', '{}')
+        ) VALUES (
+            (SELECT job_id FROM jobs WHERE tenant_id = 'local' AND url = ?),
+            1, 'local', ?, ?, '["python"]', ?, NULL, '{}', '{}'
+        )
         """,
         (
             url,

--- a/workers/automation/tests/test_preparation_identity_reference_migration.py
+++ b/workers/automation/tests/test_preparation_identity_reference_migration.py
@@ -177,7 +177,7 @@ def test_v9_preparation_references_migrate_to_stable_job_ids_and_reopen(
     init_db(db_path)
     close_connection(db_path)
 
-    assert _user_version(db_path) == SCHEMA_VERSION == 11
+    assert _user_version(db_path) == SCHEMA_VERSION == 12
     check = sqlite3.connect(db_path)
     try:
         rows = check.execute(

--- a/workers/automation/tests/test_projection_builder.py
+++ b/workers/automation/tests/test_projection_builder.py
@@ -184,11 +184,12 @@ def test_evidence_usage_projection_inverts_profile_provenance_and_requirement_fi
     conn.execute(
         """
         INSERT INTO job_requirement_fit_reports (
-            job_url, score_version, tenant_id, employer_analysis_generation,
+            job_id, score_version, tenant_id, employer_analysis_generation,
             profile_snapshot_version, scoring_policy_version, formula_version,
             resolved_fit_score, fit_band, confidence, summary_json, created_at
         ) VALUES (
-            ?, 2, 'local', 1, 1, 1, 'v1', 8, 'strong', 'high',
+            (SELECT job_id FROM jobs WHERE tenant_id = 'local' AND url = ?),
+            2, 'local', 1, 1, 1, 'v1', 8, 'strong', 'high',
             '{"weighted_fit":0.8,"must_have_coverage":0.5,"blocker_count":0,"missing_high_weight_count":1}',
             '2026-07-05T12:20:00Z'
         )
@@ -198,11 +199,12 @@ def test_evidence_usage_projection_inverts_profile_provenance_and_requirement_fi
     conn.execute(
         """
         INSERT INTO job_requirement_fit_items (
-            job_url, score_version, tenant_id, requirement_id, requirement_text,
+            job_id, score_version, tenant_id, requirement_id, requirement_text,
             tier, weight, job_evidence_span, fit_json, contribution_json,
             tailoring_json, artifact_coverage_json, position
         ) VALUES (
-            ?, 2, 'local', 'req-platform', 'Own platform migrations',
+            (SELECT job_id FROM jobs WHERE tenant_id = 'local' AND url = ?),
+            2, 'local', 'req-platform', 'Own platform migrations',
             'must_have', 0.8, 'platform migrations',
             '{"kind":"matched","evidence_ids":["ev_platform"],"strength":"direct"}',
             '{}', '{}',
@@ -215,11 +217,12 @@ def test_evidence_usage_projection_inverts_profile_provenance_and_requirement_fi
     conn.execute(
         """
         INSERT INTO job_requirement_fit_items (
-            job_url, score_version, tenant_id, requirement_id, requirement_text,
+            job_id, score_version, tenant_id, requirement_id, requirement_text,
             tier, weight, job_evidence_span, fit_json, contribution_json,
             tailoring_json, artifact_coverage_json, position
         ) VALUES (
-            ?, 2, 'local', 'req-kubernetes', 'Run Kubernetes clusters',
+            (SELECT job_id FROM jobs WHERE tenant_id = 'local' AND url = ?),
+            2, 'local', 'req-kubernetes', 'Run Kubernetes clusters',
             'must_have', 0.7, 'Kubernetes clusters',
             '{"kind":"missing","reason":"No Kubernetes profile evidence."}',
             '{}', '{}',
@@ -408,11 +411,12 @@ def test_evidence_map_excludes_soft_deleted_and_hidden_jobs(
         conn.execute(
             """
             INSERT INTO job_requirement_fit_reports (
-                job_url, score_version, tenant_id, employer_analysis_generation,
+                job_id, score_version, tenant_id, employer_analysis_generation,
                 profile_snapshot_version, scoring_policy_version, formula_version,
                 resolved_fit_score, fit_band, confidence, summary_json, created_at
             ) VALUES (
-                ?, 2, 'local', 1, 1, 1, 'v1', 8, 'strong', 'high',
+                (SELECT job_id FROM jobs WHERE tenant_id = 'local' AND url = ?),
+                2, 'local', 1, 1, 1, 'v1', 8, 'strong', 'high',
                 '{"weighted_fit":0.8,"must_have_coverage":0.5,"blocker_count":0,"missing_high_weight_count":1}',
                 '2026-07-05T12:20:00Z'
             )
@@ -422,11 +426,12 @@ def test_evidence_map_excludes_soft_deleted_and_hidden_jobs(
         conn.execute(
             """
             INSERT INTO job_requirement_fit_items (
-                job_url, score_version, tenant_id, requirement_id, requirement_text,
+                job_id, score_version, tenant_id, requirement_id, requirement_text,
                 tier, weight, job_evidence_span, fit_json, contribution_json,
                 tailoring_json, artifact_coverage_json, position
             ) VALUES (
-                ?, 2, 'local', 'req-platform', 'Own platform migrations',
+                (SELECT job_id FROM jobs WHERE tenant_id = 'local' AND url = ?),
+                2, 'local', 'req-platform', 'Own platform migrations',
                 'must_have', 0.8, 'platform migrations',
                 '{"kind":"matched","evidence_ids":["ev_platform"],"strength":"direct"}',
                 '{}', '{}',
@@ -439,11 +444,12 @@ def test_evidence_map_excludes_soft_deleted_and_hidden_jobs(
         conn.execute(
             """
             INSERT INTO job_requirement_fit_items (
-                job_url, score_version, tenant_id, requirement_id, requirement_text,
+                job_id, score_version, tenant_id, requirement_id, requirement_text,
                 tier, weight, job_evidence_span, fit_json, contribution_json,
                 tailoring_json, artifact_coverage_json, position
             ) VALUES (
-                ?, 2, 'local', 'req-kubernetes', 'Run Kubernetes clusters',
+                (SELECT job_id FROM jobs WHERE tenant_id = 'local' AND url = ?),
+                2, 'local', 'req-kubernetes', 'Run Kubernetes clusters',
                 'must_have', 0.7, 'Kubernetes clusters',
                 '{"kind":"missing","reason":"No Kubernetes profile evidence."}',
                 '{}', '{}',
@@ -676,10 +682,13 @@ def _insert_score(
 ) -> None:
     conn.execute(
         """
-        INSERT INTO job_scores (job_url, version, tenant_id, fit_score,
+        INSERT INTO job_scores (job_id, version, tenant_id, fit_score,
                                 breakdown_json, keywords_json, scored_at,
                                 correction_json, criteria_json, trace_json)
-        VALUES (?, 1, 'local', ?, ?, ?, ?, ?, ?, ?)
+        VALUES (
+            (SELECT job_id FROM jobs WHERE tenant_id = 'local' AND url = ?),
+            1, 'local', ?, ?, ?, ?, ?, ?, ?
+        )
         """,
         (
             job_url,

--- a/workers/automation/tests/test_repeat_application_prevention.py
+++ b/workers/automation/tests/test_repeat_application_prevention.py
@@ -750,7 +750,7 @@ def test_schema_v5_migrates_additively_without_changing_application_facts(
         (PRIOR,),
     ).fetchall()
 
-    assert int(migrated.execute("PRAGMA user_version").fetchone()[0]) == SCHEMA_VERSION == 11
+    assert int(migrated.execute("PRAGMA user_version").fetchone()[0]) == SCHEMA_VERSION == 12
     assert [tuple(row) for row in after] == [tuple(row) for row in before]
     assert "metadata_json" in {
         str(row[1]) for row in migrated.execute("PRAGMA table_info(job_stage_states)").fetchall()

--- a/workers/automation/tests/test_score_queue_selectors.py
+++ b/workers/automation/tests/test_score_queue_selectors.py
@@ -101,17 +101,25 @@ def _save_score(
 
 
 def _insert_active_score_staleness_marker(conn: sqlite3.Connection, url: str) -> None:
+    job_id = conn.execute(
+        "SELECT job_id FROM jobs WHERE tenant_id = ? AND url = ?",
+        (str(LOCAL_TENANT), url),
+    ).fetchone()[0]
     conn.execute(
         """
         INSERT INTO job_score_staleness (
-            tenant_id, job_url, stale_reason,
+            tenant_id, job_id, stale_reason,
             old_policy_id, old_policy_version,
             new_policy_id, new_policy_version,
             marked_at, resolved, resolved_at, resolved_by_score_version
         ) VALUES (?, ?, 'scoring_policy_changed', 'local:scoring-policy-v1', 1,
                   'local:scoring-policy-v2', 2, ?, 0, NULL, NULL)
         """,
-        (str(LOCAL_TENANT), url, datetime.now(timezone.utc).isoformat()),
+        (
+            str(LOCAL_TENANT),
+            job_id,
+            datetime.now(timezone.utc).isoformat(),
+        ),
     )
     conn.commit()
 

--- a/workers/automation/tests/test_score_repository.py
+++ b/workers/automation/tests/test_score_repository.py
@@ -63,6 +63,15 @@ def _seed_job(conn: sqlite3.Connection, url: str = "https://example.com/job/1") 
     return url
 
 
+def _stable_job_id(conn: sqlite3.Connection, url: str) -> str:
+    return str(
+        conn.execute(
+            "SELECT job_id FROM jobs WHERE tenant_id = ? AND url = ?",
+            (str(LOCAL_TENANT), url),
+        ).fetchone()[0]
+    )
+
+
 def _build_score(
     url: str,
     version: int = 1,
@@ -263,15 +272,16 @@ def test_save_and_load_round_trips_criteria_and_trace(conn: sqlite3.Connection) 
 
 def test_load_legacy_trace_without_policy_metadata(conn: sqlite3.Connection) -> None:
     url = _seed_job(conn)
+    job_id = _stable_job_id(conn, url)
     conn.execute(
         """
         INSERT INTO job_scores (
-            job_url, version, tenant_id, fit_score, breakdown_json,
+            job_id, version, tenant_id, fit_score, breakdown_json,
             keywords_json, scored_at, correction_json, criteria_json, trace_json
         ) VALUES (?, 1, ?, 7, ?, ?, ?, NULL, ?, ?)
         """,
         (
-            url,
+            job_id,
             str(LOCAL_TENANT),
             '{"technical_fit": 7, "experience_fit": 7, "role_fit": 7, "reasoning": "legacy"}',
             '["python"]',
@@ -324,12 +334,17 @@ def test_init_db_creates_requirement_fit_tables(conn: sqlite3.Connection) -> Non
 def test_requirement_fit_report_repository_round_trips(conn: sqlite3.Connection) -> None:
     url = _seed_job(conn)
     SqliteScoreRepository(conn).save(_build_score(url, fit=8))
-    report = _requirement_report(url)
+    stable_job_id = _stable_job_id(conn, url)
+    report = _requirement_report(stable_job_id)
 
     repo = SqliteRequirementFitReportRepository(conn)
     repo.save(LOCAL_TENANT, report)
 
-    loaded = repo.load(LOCAL_TENANT, JobId(url), score_version=1)
+    loaded = repo.load(
+        LOCAL_TENANT,
+        JobId(stable_job_id),
+        score_version=1,
+    )
 
     assert loaded == report
     assert loaded is not None
@@ -445,7 +460,7 @@ def test_list_pending_returns_jobs_without_score(conn: sqlite3.Connection) -> No
     repo.save(_build_score(url_scored))
 
     pending = repo.list_pending(LOCAL_TENANT)
-    assert pending == [JobId(url_pending)]
+    assert pending == [JobId(_stable_job_id(conn, url_pending))]
 
 
 def test_list_pending_respects_limit(conn: sqlite3.Connection) -> None:
@@ -533,9 +548,13 @@ def test_score_correction_marks_comparable_uncorrected_scores_stale_and_resolve_
 
     rows = conn.execute(
         """
-        SELECT job_url, stale_reason, old_policy_version, new_policy_version, resolved
-        FROM job_score_staleness
-        ORDER BY job_url
+        SELECT jobs.url AS job_url, stale_reason, old_policy_version,
+               new_policy_version, resolved
+        FROM job_score_staleness stale
+        JOIN jobs
+          ON jobs.tenant_id = stale.tenant_id
+         AND jobs.job_id = stale.job_id
+        ORDER BY jobs.url
         """
     ).fetchall()
     assert [row["job_url"] for row in rows] == [comparable_url]
@@ -560,12 +579,25 @@ def test_score_correction_marks_comparable_uncorrected_scores_stale_and_resolve_
         """
         SELECT resolved, resolved_by_score_version
         FROM job_score_staleness
-        WHERE job_url = ?
+        WHERE job_id = ?
         """,
-        (comparable_url,),
+        (_stable_job_id(conn, comparable_url),),
     ).fetchone()
     assert resolved["resolved"] == 1
     assert resolved["resolved_by_score_version"] == 2
+    resolved_event = conn.execute(
+        """
+        SELECT job_url, payload_json
+        FROM job_events
+        WHERE event_type = 'ScoreStalenessResolved'
+        ORDER BY event_id DESC
+        LIMIT 1
+        """
+    ).fetchone()
+    assert resolved_event["job_url"] == comparable_url
+    assert json.loads(resolved_event["payload_json"])["jobId"] == (
+        _stable_job_id(conn, comparable_url)
+    )
 
 
 def test_score_correction_governance_report_and_downstream_staleness_gate(
@@ -693,7 +725,9 @@ def test_score_correction_governance_report_and_downstream_staleness_gate(
         row["url"]
         for row in get_jobs_by_stage(conn, "pending_tailor", min_score=7, limit=0)
     }
-    assert [str(marker.job_id) for marker in markers] == [comparable_url]
+    assert [str(marker.job_id) for marker in markers] == [
+        _stable_job_id(conn, comparable_url)
+    ]
     assert comparable_url not in pending_after_reset
 
     refreshed_resolution = policy_v2.resolve(
@@ -771,8 +805,8 @@ def test_backfill_is_idempotent(tmp_path: Path) -> None:
     ensure_score_tables(conn)
 
     count = conn.execute(
-        "SELECT COUNT(*) FROM job_scores WHERE job_url = ?",
-        ("https://example.com/legacy",),
+        "SELECT COUNT(*) FROM job_scores WHERE job_id = ?",
+        (_stable_job_id(conn, "https://example.com/legacy"),),
     ).fetchone()[0]
     assert count == 1
 

--- a/workers/automation/tests/test_scoring_eval_feedback.py
+++ b/workers/automation/tests/test_scoring_eval_feedback.py
@@ -73,13 +73,19 @@ def test_feedback_adjustments_affect_downstream_selector_order(tmp_path: Path) -
             "VALUES (?, ?, ?, ?, ?)",
             (url, "Engineer", "Acme", "Need Python.", "2026-05-14T00:00:00+00:00"),
         )
+    job_ids = {
+        str(row["url"]): str(row["job_id"])
+        for row in conn.execute(
+            "SELECT url, job_id FROM jobs WHERE tenant_id = 'local'"
+        ).fetchall()
+    }
     conn.execute(
         """INSERT INTO job_scores (
-          job_url, version, tenant_id, fit_score, breakdown_json, keywords_json, scored_at,
+          job_id, version, tenant_id, fit_score, breakdown_json, keywords_json, scored_at,
           correction_json, criteria_json, trace_json
         ) VALUES (?, 2, 'local', 9, ?, '["python"]', ?, ?, '{}', ?)""",
         (
-            corrected,
+            job_ids[corrected],
             json.dumps({"reasoning": "Corrected after review.", "eligibility": {"status": "eligible"}}),
             "2026-05-14T10:00:00+00:00",
             json.dumps({"corrected_fit_score": 9, "rationale": "Better leadership fit."}),
@@ -88,11 +94,11 @@ def test_feedback_adjustments_affect_downstream_selector_order(tmp_path: Path) -
     )
     conn.execute(
         """INSERT INTO job_scores (
-          job_url, version, tenant_id, fit_score, breakdown_json, keywords_json, scored_at,
+          job_id, version, tenant_id, fit_score, breakdown_json, keywords_json, scored_at,
           correction_json, criteria_json, trace_json
         ) VALUES (?, 1, 'local', 10, ?, '["python"]', ?, NULL, '{}', '{}')""",
         (
-            skipped,
+            job_ids[skipped],
             json.dumps({"reasoning": "High raw score.", "eligibility": {"status": "eligible"}}),
             "2026-05-14T10:00:00+00:00",
         ),

--- a/workers/automation/tests/test_scoring_identity_reference_migration.py
+++ b/workers/automation/tests/test_scoring_identity_reference_migration.py
@@ -1,0 +1,615 @@
+"""Schema-v12 scoring identity and score-history migration contracts."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import uuid
+from pathlib import Path
+
+import pytest
+
+import jobctrl.database as database_module
+from jobctrl.database import (
+    SCHEMA_VERSION,
+    _reassign_scoring_references_v12,
+    close_connection,
+    init_db,
+)
+from jobctrl.domain.discovery import (
+    Employer,
+    Job,
+    JobMetadata,
+    PostingUrl,
+    SearchStrategy,
+    Source,
+)
+from jobctrl.domain.identifiers import JobId
+from jobctrl.domain.tenant import LOCAL_TENANT
+from jobctrl.infrastructure.discovery import SqliteJobRepository
+from jobctrl.infrastructure.scoring import SqliteScoreRepository
+
+
+PREVIOUS_SCHEMA_VERSION = 11
+
+
+def _discovered_job(posting_url: str, job_id: JobId) -> Job:
+    return Job.discover(
+        tenant_id=LOCAL_TENANT,
+        job_id=job_id,
+        posting_url=PostingUrl(value=posting_url),
+        source=Source(board="example"),
+        employer=Employer(name="Example"),
+        search_strategy=SearchStrategy.JOBSPY,
+        metadata=JobMetadata(title="Platform Engineer"),
+        discovered_at="2026-07-29T10:00:00+00:00",
+    )
+
+
+def _downgrade_scoring_references_to_v11(
+    conn: sqlite3.Connection,
+) -> None:
+    for table in (
+        "job_requirement_fit_items",
+        "job_requirement_fit_reports",
+        "job_score_staleness",
+        "job_scores",
+    ):
+        conn.execute(f'DROP TABLE "{table}"')
+    conn.executescript(
+        """
+        CREATE TABLE job_scores (
+            job_url             TEXT NOT NULL,
+            version             INTEGER NOT NULL,
+            tenant_id           TEXT NOT NULL DEFAULT 'local',
+            fit_score           INTEGER NOT NULL CHECK(fit_score BETWEEN 1 AND 10),
+            breakdown_json      TEXT NOT NULL,
+            keywords_json       TEXT NOT NULL,
+            scored_at           TEXT NOT NULL,
+            correction_json     TEXT,
+            criteria_json       TEXT NOT NULL DEFAULT '{}',
+            trace_json          TEXT NOT NULL DEFAULT '{}',
+            PRIMARY KEY (job_url, version),
+            FOREIGN KEY (job_url) REFERENCES jobs(url) ON DELETE CASCADE
+        );
+        CREATE INDEX idx_job_scores_tenant_score
+            ON job_scores(tenant_id, fit_score DESC, scored_at DESC);
+        CREATE INDEX idx_job_scores_job_version
+            ON job_scores(job_url, version DESC);
+
+        CREATE TABLE job_requirement_fit_reports (
+            job_url                       TEXT NOT NULL,
+            score_version                 INTEGER NOT NULL,
+            tenant_id                     TEXT NOT NULL DEFAULT 'local',
+            employer_analysis_generation  INTEGER NOT NULL,
+            profile_snapshot_version      INTEGER NOT NULL,
+            scoring_policy_version        INTEGER NOT NULL,
+            formula_version               TEXT NOT NULL,
+            resolved_fit_score            INTEGER,
+            fit_band                      TEXT NOT NULL,
+            confidence                    TEXT NOT NULL,
+            summary_json                  TEXT NOT NULL DEFAULT '{}',
+            created_at                    TEXT NOT NULL,
+            PRIMARY KEY (job_url, score_version, tenant_id),
+            FOREIGN KEY (job_url, score_version)
+                REFERENCES job_scores(job_url, version) ON DELETE CASCADE
+        );
+        CREATE TABLE job_requirement_fit_items (
+            job_url                 TEXT NOT NULL,
+            score_version           INTEGER NOT NULL,
+            tenant_id               TEXT NOT NULL DEFAULT 'local',
+            requirement_id          TEXT NOT NULL,
+            requirement_text        TEXT NOT NULL,
+            tier                    TEXT NOT NULL,
+            weight                  REAL NOT NULL,
+            job_evidence_span       TEXT NOT NULL,
+            fit_json                TEXT NOT NULL,
+            contribution_json       TEXT NOT NULL,
+            tailoring_json          TEXT NOT NULL,
+            artifact_coverage_json  TEXT,
+            position                INTEGER NOT NULL DEFAULT 0,
+            PRIMARY KEY (
+                job_url, score_version, tenant_id, requirement_id
+            ),
+            FOREIGN KEY (job_url, score_version, tenant_id)
+                REFERENCES job_requirement_fit_reports(
+                    job_url, score_version, tenant_id
+                ) ON DELETE CASCADE
+        );
+        CREATE INDEX idx_requirement_fit_reports_tenant_job
+            ON job_requirement_fit_reports(
+                tenant_id, job_url, score_version DESC
+            );
+        CREATE INDEX idx_requirement_fit_items_requirement
+            ON job_requirement_fit_items(tenant_id, requirement_id);
+
+        CREATE TABLE job_score_staleness (
+            tenant_id                 TEXT NOT NULL DEFAULT 'local',
+            job_url                   TEXT NOT NULL,
+            stale_reason              TEXT NOT NULL,
+            old_policy_id             TEXT NOT NULL DEFAULT '',
+            old_policy_version        INTEGER NOT NULL,
+            new_policy_id             TEXT NOT NULL DEFAULT '',
+            new_policy_version        INTEGER NOT NULL,
+            marked_at                 TEXT NOT NULL,
+            resolved                  INTEGER NOT NULL DEFAULT 0,
+            resolved_at               TEXT,
+            resolved_by_score_version INTEGER,
+            PRIMARY KEY (
+                tenant_id, job_url, stale_reason,
+                old_policy_version, new_policy_version
+            ),
+            FOREIGN KEY (job_url) REFERENCES jobs(url) ON DELETE CASCADE
+        );
+        CREATE INDEX idx_job_score_staleness_unresolved
+            ON job_score_staleness(tenant_id, resolved, marked_at DESC);
+        CREATE INDEX idx_job_score_staleness_job
+            ON job_score_staleness(tenant_id, job_url, resolved);
+        """
+    )
+    conn.execute(f"PRAGMA user_version = {PREVIOUS_SCHEMA_VERSION}")
+    conn.commit()
+
+
+def _insert_score(
+    conn: sqlite3.Connection,
+    job_url: str,
+    *,
+    version: int = 1,
+    fit_score: int,
+    scored_at: str,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO job_scores (
+            job_url, version, tenant_id, fit_score, breakdown_json,
+            keywords_json, scored_at, correction_json,
+            criteria_json, trace_json
+        ) VALUES (?, ?, 'local', ?, ?, '["python"]', ?, NULL, '{}', '{}')
+        """,
+        (
+            job_url,
+            version,
+            fit_score,
+            json.dumps(
+                {
+                    "technical_fit": fit_score,
+                    "experience_fit": fit_score,
+                    "role_fit": fit_score,
+                    "reasoning": job_url,
+                },
+                sort_keys=True,
+            ),
+            scored_at,
+        ),
+    )
+
+
+def _insert_requirement_fit(
+    conn: sqlite3.Connection,
+    job_url: str,
+    requirement_id: str,
+    *,
+    score_version: int = 1,
+    created_at: str,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO job_requirement_fit_reports (
+            job_url, score_version, tenant_id,
+            employer_analysis_generation, profile_snapshot_version,
+            scoring_policy_version, formula_version, resolved_fit_score,
+            fit_band, confidence, summary_json, created_at
+        ) VALUES (?, ?, 'local', 1, 1, 1, 'v1', 8,
+                  'strong', 'high', '{}', ?)
+        """,
+        (job_url, score_version, created_at),
+    )
+    conn.execute(
+        """
+        INSERT INTO job_requirement_fit_items (
+            job_url, score_version, tenant_id, requirement_id,
+            requirement_text, tier, weight, job_evidence_span,
+            fit_json, contribution_json, tailoring_json,
+            artifact_coverage_json, position
+        ) VALUES (?, ?, 'local', ?, 'Python', 'must_have', 1,
+                  'Python', '{}', '{}', '{}', NULL, 0)
+        """,
+        (job_url, score_version, requirement_id),
+    )
+
+
+def _insert_staleness(
+    conn: sqlite3.Connection,
+    job_url: str,
+    *,
+    stale_reason: str,
+    resolved: bool,
+    marked_at: str,
+    resolved_by_score_version: int = 1,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO job_score_staleness (
+            tenant_id, job_url, stale_reason, old_policy_id,
+            old_policy_version, new_policy_id, new_policy_version,
+            marked_at, resolved, resolved_at,
+            resolved_by_score_version
+        ) VALUES ('local', ?, ?, 'policy-v1', 1, 'policy-v2', 2,
+                  ?, ?, ?, ?)
+        """,
+        (
+            job_url,
+            stale_reason,
+            marked_at,
+            int(resolved),
+            marked_at if resolved else None,
+            resolved_by_score_version if resolved else None,
+        ),
+    )
+
+
+def _columns(conn: sqlite3.Connection, table: str) -> set[str]:
+    return {
+        str(row[1])
+        for row in conn.execute(f'PRAGMA table_info("{table}")').fetchall()
+    }
+
+
+def test_v11_scoring_references_migrate_alias_histories_and_reopen(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    conn = init_db(db_path)
+    jobs = SqliteJobRepository(conn)
+
+    stable_job_id = JobId(str(uuid.uuid4()))
+    original_url = "https://boards.example/jobs/123"
+    current_url = "https://careers.example/jobs/platform-engineer"
+    jobs.save(_discovered_job(original_url, stable_job_id))
+    jobs.save(_discovered_job(current_url, stable_job_id))
+
+    uuid_shaped_url = str(uuid.uuid4())
+    uuid_url_owner = JobId(str(uuid.uuid4()))
+    jobs.save(_discovered_job(uuid_shaped_url, uuid_url_owner))
+    jobs.save(
+        _discovered_job(
+            "https://example.com/jobs/id-text-collision",
+            JobId(uuid_shaped_url),
+        )
+    )
+
+    _downgrade_scoring_references_to_v11(conn)
+    _insert_score(
+        conn,
+        original_url,
+        fit_score=6,
+        scored_at="2026-07-29T10:00:00+00:00",
+    )
+    _insert_score(
+        conn,
+        current_url,
+        fit_score=8,
+        scored_at="2026-07-29T10:01:00+00:00",
+    )
+    _insert_score(
+        conn,
+        uuid_shaped_url,
+        fit_score=7,
+        scored_at="2026-07-29T10:02:00+00:00",
+    )
+    _insert_requirement_fit(
+        conn,
+        original_url,
+        "original",
+        created_at="2026-07-29T10:00:00+00:00",
+    )
+    _insert_requirement_fit(
+        conn,
+        current_url,
+        "current",
+        created_at="2026-07-29T10:01:00+00:00",
+    )
+    _insert_staleness(
+        conn,
+        original_url,
+        stale_reason="scoring_policy_changed",
+        resolved=True,
+        marked_at="2026-07-29T10:02:00+00:00",
+    )
+    _insert_staleness(
+        conn,
+        current_url,
+        stale_reason="scoring_policy_changed",
+        resolved=False,
+        marked_at="2026-07-29T10:03:00+00:00",
+    )
+    _insert_staleness(
+        conn,
+        current_url,
+        stale_reason="manual_review",
+        resolved=True,
+        marked_at="2026-07-29T10:04:00+00:00",
+    )
+    conn.commit()
+    close_connection(db_path)
+
+    migrated = init_db(db_path)
+    assert (
+        int(migrated.execute("PRAGMA user_version").fetchone()[0])
+        == SCHEMA_VERSION
+        == 12
+    )
+    assert _columns(migrated, "job_scores") >= {"tenant_id", "job_id"}
+    assert "job_url" not in _columns(migrated, "job_scores")
+    assert [
+        tuple(row)
+        for row in migrated.execute(
+        """
+        SELECT version, fit_score
+        FROM job_scores
+        WHERE tenant_id = 'local' AND job_id = ?
+        ORDER BY version
+        """,
+        (str(stable_job_id),),
+        ).fetchall()
+    ] == [(1, 6), (2, 8)]
+    assert [
+        tuple(row)
+        for row in migrated.execute(
+        """
+        SELECT score_version, requirement_id
+        FROM job_requirement_fit_items
+        WHERE tenant_id = 'local' AND job_id = ?
+        ORDER BY score_version
+        """,
+        (str(stable_job_id),),
+        ).fetchall()
+    ] == [(1, "original"), (2, "current")]
+    assert [
+        tuple(row)
+        for row in migrated.execute(
+        """
+        SELECT stale_reason, resolved, resolved_by_score_version
+        FROM job_score_staleness
+        WHERE tenant_id = 'local' AND job_id = ?
+        ORDER BY stale_reason
+        """,
+        (str(stable_job_id),),
+        ).fetchall()
+    ] == [
+        ("manual_review", 1, 2),
+        ("scoring_policy_changed", 0, None),
+    ]
+    assert migrated.execute(
+        """
+        SELECT job_id
+        FROM job_scores
+        WHERE fit_score = 7
+        """
+    ).fetchone()[0] == str(uuid_url_owner)
+    assert migrated.execute("PRAGMA foreign_key_check").fetchone() is None
+
+    repository = SqliteScoreRepository(migrated)
+    assert repository.load(LOCAL_TENANT, stable_job_id).version == 2
+    uuid_url_score = repository.load_by_posting_url(
+        LOCAL_TENANT,
+        PostingUrl(uuid_shaped_url),
+    )
+    assert uuid_url_score is not None
+    assert uuid_url_score.job_id == uuid_url_owner
+
+    close_connection(db_path)
+    reopened = init_db(db_path)
+    assert int(reopened.execute("PRAGMA user_version").fetchone()[0]) == 12
+
+
+def test_v11_scoring_migration_preserves_each_alias_version_order(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    conn = init_db(db_path)
+    jobs = SqliteJobRepository(conn)
+    stable_job_id = JobId(str(uuid.uuid4()))
+    original_url = "https://boards.example/jobs/version-order"
+    alias_url = "https://careers.example/jobs/version-order"
+    jobs.save(_discovered_job(original_url, stable_job_id))
+    jobs.save(_discovered_job(alias_url, stable_job_id))
+    _downgrade_scoring_references_to_v11(conn)
+
+    _insert_score(
+        conn,
+        original_url,
+        version=1,
+        fit_score=9,
+        scored_at="2026-07-29T11:00:00+00:00",
+    )
+    _insert_score(
+        conn,
+        original_url,
+        version=2,
+        fit_score=3,
+        scored_at="2026-07-29T10:00:00+00:00",
+    )
+    _insert_score(
+        conn,
+        alias_url,
+        version=1,
+        fit_score=7,
+        scored_at="2026-07-29T10:30:00+00:00",
+    )
+    _insert_requirement_fit(
+        conn,
+        original_url,
+        "latest-original",
+        score_version=2,
+        created_at="2026-07-29T11:05:00+00:00",
+    )
+    _insert_staleness(
+        conn,
+        original_url,
+        stale_reason="manual_review",
+        resolved=True,
+        marked_at="2026-07-29T11:10:00+00:00",
+        resolved_by_score_version=2,
+    )
+    conn.commit()
+    close_connection(db_path)
+
+    migrated = init_db(db_path)
+    assert [
+        tuple(row)
+        for row in migrated.execute(
+            """
+            SELECT version, fit_score
+            FROM job_scores
+            WHERE tenant_id = 'local' AND job_id = ?
+            ORDER BY version
+            """,
+            (str(stable_job_id),),
+        ).fetchall()
+    ] == [(1, 7), (2, 9), (3, 3)]
+    assert migrated.execute(
+        """
+        SELECT score_version
+        FROM job_requirement_fit_reports
+        WHERE tenant_id = 'local' AND job_id = ?
+        """,
+        (str(stable_job_id),),
+    ).fetchone()[0] == 3
+    assert migrated.execute(
+        """
+        SELECT resolved_by_score_version
+        FROM job_score_staleness
+        WHERE tenant_id = 'local' AND job_id = ?
+        """,
+        (str(stable_job_id),),
+    ).fetchone()[0] == 3
+    latest = SqliteScoreRepository(migrated).load(
+        LOCAL_TENANT,
+        stable_job_id,
+    )
+    assert latest is not None
+    assert latest.version == 3
+    assert latest.fit_score.value == 3
+
+
+def test_scoring_migration_rolls_back_and_retries_after_verification_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    conn = init_db(db_path)
+    job_id = JobId(str(uuid.uuid4()))
+    job_url = "https://example.com/jobs/retry"
+    SqliteJobRepository(conn).save(_discovered_job(job_url, job_id))
+    _downgrade_scoring_references_to_v11(conn)
+    _insert_score(
+        conn,
+        job_url,
+        fit_score=8,
+        scored_at="2026-07-29T10:00:00+00:00",
+    )
+    conn.commit()
+    close_connection(db_path)
+
+    original_verify = database_module._verify_scoring_references_v12
+
+    def fail_verification(*_args: object, **_kwargs: object) -> None:
+        raise RuntimeError("forced scoring verification failure")
+
+    monkeypatch.setattr(
+        database_module,
+        "_verify_scoring_references_v12",
+        fail_verification,
+    )
+    with pytest.raises(
+        RuntimeError,
+        match="forced scoring verification failure",
+    ):
+        init_db(db_path)
+    close_connection(db_path)
+
+    rolled_back = sqlite3.connect(db_path)
+    try:
+        assert int(
+            rolled_back.execute("PRAGMA user_version").fetchone()[0]
+        ) == PREVIOUS_SCHEMA_VERSION
+        assert "job_url" in _columns(rolled_back, "job_scores")
+        assert "job_id" not in _columns(rolled_back, "job_scores")
+    finally:
+        rolled_back.close()
+
+    monkeypatch.setattr(
+        database_module,
+        "_verify_scoring_references_v12",
+        original_verify,
+    )
+    retried = init_db(db_path)
+    assert int(retried.execute("PRAGMA user_version").fetchone()[0]) == 12
+    assert [
+        tuple(row)
+        for row in retried.execute(
+            "SELECT job_id, version FROM job_scores"
+        ).fetchall()
+    ] == [(str(job_id), 1)]
+
+
+def test_runtime_scoring_collision_merge_preserves_both_histories(
+    tmp_path: Path,
+) -> None:
+    conn = init_db(tmp_path / "jobctrl.db")
+    jobs = SqliteJobRepository(conn)
+    losing_job_id = JobId(str(uuid.uuid4()))
+    surviving_job_id = JobId(str(uuid.uuid4()))
+    jobs.save(
+        _discovered_job(
+            "https://example.com/jobs/losing",
+            losing_job_id,
+        )
+    )
+    jobs.save(
+        _discovered_job(
+            "https://example.com/jobs/surviving",
+            surviving_job_id,
+        )
+    )
+    for job_id, version, fit_score, scored_at in (
+        (losing_job_id, 1, 6, "2026-07-29T11:00:00+00:00"),
+        (losing_job_id, 2, 5, "2026-07-29T10:00:00+00:00"),
+        (surviving_job_id, 1, 8, "2026-07-29T10:30:00+00:00"),
+    ):
+        conn.execute(
+            """
+            INSERT INTO job_scores (
+                tenant_id, job_id, version, fit_score, breakdown_json,
+                keywords_json, scored_at, correction_json,
+                criteria_json, trace_json
+            ) VALUES ('local', ?, ?, ?, '{}', '["python"]', ?,
+                      NULL, '{}', '{}')
+            """,
+            (str(job_id), version, fit_score, scored_at),
+        )
+    conn.commit()
+
+    _reassign_scoring_references_v12(
+        conn,
+        tenant_id="local",
+        losing_job_id=str(losing_job_id),
+        surviving_job_id=str(surviving_job_id),
+    )
+
+    assert [
+        tuple(row)
+        for row in conn.execute(
+        """
+        SELECT job_id, version, fit_score
+        FROM job_scores
+        ORDER BY version
+        """
+        ).fetchall()
+    ] == [
+        (str(surviving_job_id), 1, 8),
+        (str(surviving_job_id), 2, 6),
+        (str(surviving_job_id), 3, 5),
+    ]

--- a/workers/automation/tests/test_stable_job_identity_migration.py
+++ b/workers/automation/tests/test_stable_job_identity_migration.py
@@ -129,12 +129,12 @@ def _create_representative_v6_pair(
     conn.execute(
         """
         INSERT INTO job_scores (
-            job_url, version, tenant_id, fit_score, breakdown_json,
+            job_id, version, tenant_id, fit_score, breakdown_json,
             keywords_json, scored_at, criteria_json, trace_json
         ) VALUES (?, 1, 'local', 8, ?, ?, ?, ?, ?)
         """,
         (
-            job_url,
+            job_id,
             '{"technical_fit":8}',
             '["python","sqlite"]',
             "2026-07-01T10:05:00+00:00",
@@ -212,6 +212,27 @@ def _create_representative_v6_pair(
 
     raw = sqlite3.connect(db_path)
     try:
+        score_rows = raw.execute(
+            """
+            SELECT
+                scores.job_id,
+                jobs.url,
+                scores.version,
+                scores.tenant_id,
+                scores.fit_score,
+                scores.breakdown_json,
+                scores.keywords_json,
+                scores.scored_at,
+                scores.correction_json,
+                scores.criteria_json,
+                scores.trace_json
+            FROM job_scores AS scores
+            JOIN jobs
+              ON jobs.tenant_id = scores.tenant_id
+             AND jobs.job_id = scores.job_id
+            ORDER BY scores.tenant_id, scores.job_id, scores.version
+            """
+        ).fetchall()
         source_rows = raw.execute(
             """
             SELECT
@@ -362,6 +383,52 @@ def _create_representative_v6_pair(
             """,
             source_rows,
         )
+        raw.execute("DROP TABLE job_requirement_fit_items")
+        raw.execute("DROP TABLE job_requirement_fit_reports")
+        raw.execute("DROP TABLE job_score_staleness")
+        raw.execute("DROP TABLE job_scores")
+        raw.execute(
+            """
+            CREATE TABLE job_scores (
+                job_url         TEXT NOT NULL,
+                version         INTEGER NOT NULL,
+                tenant_id       TEXT NOT NULL DEFAULT 'local',
+                fit_score       INTEGER NOT NULL CHECK(fit_score BETWEEN 1 AND 10),
+                breakdown_json  TEXT NOT NULL,
+                keywords_json   TEXT NOT NULL,
+                scored_at       TEXT NOT NULL,
+                correction_json TEXT,
+                criteria_json   TEXT NOT NULL DEFAULT '{}',
+                trace_json      TEXT NOT NULL DEFAULT '{}',
+                PRIMARY KEY (job_url, version),
+                FOREIGN KEY (job_url) REFERENCES jobs(url) ON DELETE CASCADE
+            )
+            """
+        )
+        raw.executemany(
+            """
+            INSERT INTO job_scores (
+                job_url, version, tenant_id, fit_score, breakdown_json,
+                keywords_json, scored_at, correction_json, criteria_json,
+                trace_json
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                (
+                    row[1],
+                    row[2],
+                    row[3],
+                    row[4],
+                    row[5],
+                    row[6],
+                    row[7],
+                    row[8],
+                    row[9],
+                    row[10],
+                )
+                for row in score_rows
+            ),
+        )
         for trigger_name in database_module._STABLE_JOB_IDENTITY_TRIGGER_NAMES:
             raw.execute(f'DROP TRIGGER IF EXISTS "{trigger_name}"')
         raw.execute("DROP INDEX IF EXISTS idx_jobs_tenant_job_id")
@@ -433,6 +500,34 @@ def _reference_snapshot(db_path: Path) -> dict[str, list[tuple[object, ...]]]:
                     """
                 ).fetchall()
             ]
+        score_columns = {
+            str(row[1])
+            for row in conn.execute("PRAGMA table_info(job_scores)").fetchall()
+        }
+        if "job_id" in score_columns:
+            snapshot["job_scores"] = [
+                tuple(row)
+                for row in conn.execute(
+                    """
+                    SELECT
+                        jobs.url,
+                        scores.version,
+                        scores.tenant_id,
+                        scores.fit_score,
+                        scores.breakdown_json,
+                        scores.keywords_json,
+                        scores.scored_at,
+                        scores.correction_json,
+                        scores.criteria_json,
+                        scores.trace_json
+                    FROM job_scores AS scores
+                    JOIN jobs
+                      ON jobs.tenant_id = scores.tenant_id
+                     AND jobs.job_id = scores.job_id
+                    ORDER BY scores.tenant_id, scores.job_id, scores.version
+                    """
+                ).fetchall()
+            ]
         snapshot["jobs"] = [
             tuple(row)
             for row in conn.execute(
@@ -473,7 +568,7 @@ def test_v6_jobs_gain_stable_uuid_and_posting_url_alias_once(
     init_db(db_path)
     close_connection(db_path)
 
-    assert _user_version(db_path) == SCHEMA_VERSION == 11
+    assert _user_version(db_path) == SCHEMA_VERSION == 12
     first_ids = _identity_rows(db_path)
     assert [row[0] for row in first_ids] == ["local", "local"]
     for _tenant_id, job_id, _url in first_ids:

--- a/workers/automation/tests/test_tailor_provenance_integration.py
+++ b/workers/automation/tests/test_tailor_provenance_integration.py
@@ -182,6 +182,23 @@ class _FakeRequirementFitRepo:
         self.saved.append(report)
 
 
+class _CollisionRequirementFitRepo:
+    def __init__(self, reports: tuple[RequirementFitReport, ...]) -> None:
+        self._reports = {str(report.job_id): report for report in reports}
+        self.loaded_job_ids: list[str] = []
+        self.saved: list[RequirementFitReport] = []
+
+    def load(self, tenant_id, job_id, *, score_version=None) -> RequirementFitReport | None:
+        _ = tenant_id, score_version
+        self.loaded_job_ids.append(str(job_id))
+        return self._reports.get(str(job_id))
+
+    def save(self, tenant_id, report: RequirementFitReport) -> None:
+        _ = tenant_id
+        self._reports[str(report.job_id)] = report
+        self.saved.append(report)
+
+
 class _ScriptedLlm:
     def __init__(self, responses: list[str]) -> None:
         self._responses = list(responses)
@@ -647,6 +664,58 @@ def test_accepted_resume_updates_requirement_fit_artifact_coverage(tmp_path: Pat
     assert platform_coverage.state == "missing_from_resume"
     assert salesforce_coverage is not None
     assert salesforce_coverage.state == "missing_from_profile"
+
+
+def test_requirement_coverage_keeps_stable_id_when_posting_url_is_another_job_id(
+    tmp_path: Path,
+) -> None:
+    posting_url = "11111111-1111-4111-8111-111111111111"
+    stable_job_id = "22222222-2222-4222-8222-222222222222"
+    intended_report = replace(
+        _requirement_fit_report(),
+        job_id=stable_job_id,
+        fit_band="strong",
+    )
+    other_job_report = replace(
+        _requirement_fit_report(),
+        job_id=posting_url,
+        fit_band="poor",
+    )
+    requirement_fit_repo = _CollisionRequirementFitRepo(
+        (intended_report, other_job_report)
+    )
+    outcome = _use_case(
+        _FakeMaterialsRepo(),
+        _FakeProvenanceRepo(),
+        _ScriptedLlm(
+            [
+                _payload(
+                    "Owned the API and cut latency 40% with Python by "
+                    "replacing synchronous calls."
+                ),
+                _judge_pass(),
+            ]
+        ),
+        _RecordingPublisher(),
+        requirement_fit_repo=requirement_fit_repo,
+    ).execute(
+        job={
+            **_job(),
+            "url": posting_url,
+            "job_id": stable_job_id,
+        },
+        profile_snapshot=_snapshot(),
+        tailored_dir=tmp_path,
+    )
+
+    assert outcome.status == "approved"
+    assert requirement_fit_repo.loaded_job_ids == [
+        stable_job_id,
+        stable_job_id,
+    ]
+    assert len(requirement_fit_repo.saved) == 1
+    assert requirement_fit_repo.saved[0].job_id == stable_job_id
+    assert requirement_fit_repo.saved[0].fit_band == "strong"
 
 
 def test_suffixed_bare_magnitude_is_hard_rejected_by_detector_and_writes_no_provenance(

--- a/workers/automation/tests/test_tailor_retailor.py
+++ b/workers/automation/tests/test_tailor_retailor.py
@@ -58,9 +58,12 @@ def _insert_blocked_score(conn, *, url: str, blocker: str = "No sponsorship.") -
     conn.execute(
         """
         INSERT INTO job_scores (
-            job_url, version, tenant_id, fit_score, breakdown_json,
+            job_id, version, tenant_id, fit_score, breakdown_json,
             keywords_json, scored_at, correction_json, criteria_json, trace_json
-        ) VALUES (?, 1, 'local', 10, ?, '[]', ?, NULL, '{}', '{}')
+        ) VALUES (
+            (SELECT job_id FROM jobs WHERE tenant_id = 'local' AND url = ?),
+            1, 'local', 10, ?, '[]', ?, NULL, '{}', '{}'
+        )
         """,
         (
             url,


### PR DESCRIPTION
## Summary

- migrate scoring authority to stable tenant-scoped JobIds in schema v12, including scores, staleness, requirement-fit reports, and requirement-fit items
- preserve each alias history's authoritative version order during deduplication, deterministically merge histories, and remap dependent score versions
- keep bounded schema-v11 Python and TypeScript compatibility while making current writes and reads use stable identity
- preserve explicit URL storage boundaries for deferred URL-facing events/projections, while carrying stable `jobId` in payloads
- add regression coverage for UUID-shaped URL collisions, reverse-timestamp score histories, runtime identity merges, and direct schema-v12 API behavior

## Stack

- stacked on #536 (`feat/job-id-enrichment-snapshot-references`)
- this is an intermediate phase in the approved unreleased JobId migration stack; canonical product documentation and cumulative product QA remain on the final PR

## Validation

- `.venv/bin/python -m pytest -q` — **2678 passed, 2 skipped**
- `pnpm --filter @jobctrl/api test` — **45 files, 660 tests passed**
- `pnpm --filter @jobctrl/api check` — passed
- focused Ruff checks for touched Python surfaces — passed
- `git diff --check` — passed
- independent review — **Gate: PASS**, Blocker=0, High=0, Medium=0, Low=0