### PR TITLE
feat(pipeline): migrate stage-state references to stable JobIds

### DIFF
--- a/apps/api/src/application-feedback.ts
+++ b/apps/api/src/application-feedback.ts
@@ -48,6 +48,8 @@ import {
   allRows,
   getRow,
   hasCompositeJobIdForeignKey,
+  jobReferenceColumn,
+  jobReferenceJoinToJobs,
   tableExists,
   type SqliteDatabase,
   type SqliteValue,
@@ -323,6 +325,10 @@ export function listApplyReviewQueue(db: SqliteDatabase): ApplyReviewQueueRespon
   const employerAnalysisJoin = hasEmployerAnalysis
     ? "LEFT JOIN latest_employer_analysis ON latest_employer_analysis.job_url = jlp.job_id"
     : "";
+  const stableStageReferences = jobReferenceColumn(
+    db,
+    "job_stage_states",
+  ) === "job_id";
   const rows = allRows<ReviewQueueRow>(
     db,
     `
@@ -357,15 +363,31 @@ export function listApplyReviewQueue(db: SqliteDatabase): ApplyReviewQueueRespon
       WHERE row_num = 1
     ),
     apply_stage AS (
-      SELECT job_url, state
+      SELECT tenant_id, job_url, state
       FROM (
-        SELECT job_url, state,
+        SELECT ${stableStageReferences ? "stage_jobs.tenant_id" : `'${DEFAULT_TENANT}'`} AS tenant_id,
+               ${stableStageReferences ? "stage_jobs.url" : "stage_state.job_url"} AS job_url,
+               stage_state.state,
                ROW_NUMBER() OVER (
-                 PARTITION BY job_url
-                 ORDER BY COALESCE(updated_at, '') DESC, rowid DESC
+                 PARTITION BY ${
+                   stableStageReferences
+                     ? "stage_state.tenant_id, stage_state.job_id"
+                     : "stage_state.job_url"
+                 }
+                 ORDER BY COALESCE(stage_state.updated_at, '') DESC,
+                          stage_state.rowid DESC
                ) AS row_num
-        FROM job_stage_states
-        WHERE stage = 'apply'
+        FROM job_stage_states stage_state
+        ${stableStageReferences
+          ? `JOIN jobs stage_jobs
+               ON ${jobReferenceJoinToJobs(
+                 db,
+                 "job_stage_states",
+                 "stage_state",
+                 "stage_jobs",
+               )}`
+          : ""}
+        WHERE stage_state.stage = 'apply'
       )
       WHERE row_num = 1
     )
@@ -396,7 +418,9 @@ export function listApplyReviewQueue(db: SqliteDatabase): ApplyReviewQueueRespon
     LEFT JOIN job_detail_projections jdp ON jdp.tenant_id = jlp.tenant_id AND jdp.job_id = jlp.job_id
     LEFT JOIN latest_decision ON latest_decision.job_key = jlp.job_id
     LEFT JOIN latest_apply_run ON latest_apply_run.job_id = jlp.job_id
-    INNER JOIN apply_stage ON apply_stage.job_url = jlp.job_id
+    INNER JOIN apply_stage
+      ON apply_stage.tenant_id = jlp.tenant_id
+     AND apply_stage.job_url = jlp.job_id
     ${employerAnalysisJoin}
     WHERE jlp.tenant_id = ?
       AND jlp.deleted_at IS NULL

--- a/apps/api/src/db.ts
+++ b/apps/api/src/db.ts
@@ -9,7 +9,7 @@ export type SqliteValue = string | number | bigint | null;
 // writer that stamps ``PRAGMA user_version``; the API only reads it to fail
 // closed on a database written by a newer build. Bump both constants together
 // whenever the schema shape changes.
-export const SUPPORTED_SCHEMA_VERSION = 12;
+export const SUPPORTED_SCHEMA_VERSION = 13;
 
 export class IncompatibleSchemaVersionError extends Error {
   constructor(current: number) {
@@ -129,6 +129,44 @@ export function jobReferenceForUrl(
     throw new Error(`No stable Job identity for ${jobUrl}.`);
   }
   return jobId;
+}
+
+export function jobReferencePredicateForUrl(
+  db: SqliteDatabase,
+  tableName: string,
+  jobUrl: string,
+  tenantId = "local",
+  alias = "",
+): { sql: string; params: SqliteValue[] } {
+  const prefix = alias ? `${alias}.` : "";
+  const referenceColumn = jobReferenceColumn(db, tableName);
+  const reference = jobReferenceForUrl(
+    db,
+    tableName,
+    jobUrl,
+    tenantId,
+  );
+  if (referenceColumn === "job_url") {
+    return {
+      sql: `${prefix}job_url = ?`,
+      params: [reference],
+    };
+  }
+  return {
+    sql: `${prefix}tenant_id = ? AND ${prefix}job_id = ?`,
+    params: [tenantId, reference],
+  };
+}
+
+export function jobReferenceJoinToJobs(
+  db: SqliteDatabase,
+  tableName: string,
+  sourceAlias: string,
+  jobsAlias: string,
+): string {
+  return jobReferenceColumn(db, tableName) === "job_id"
+    ? `${sourceAlias}.tenant_id = ${jobsAlias}.tenant_id AND ${sourceAlias}.job_id = ${jobsAlias}.job_id`
+    : `${sourceAlias}.job_url = ${jobsAlias}.url`;
 }
 
 export function hasCompositeJobIdForeignKey(

--- a/apps/api/src/pipeline-operations.ts
+++ b/apps/api/src/pipeline-operations.ts
@@ -12,7 +12,14 @@ import type {
   PipelineProjectionCoverage,
   PipelineStageCounts,
 } from "./contracts.js";
-import { allRows, tableExists, type SqliteDatabase, type SqliteValue } from "./db.js";
+import {
+  allRows,
+  jobReferenceColumn,
+  jobReferenceJoinToJobs,
+  tableExists,
+  type SqliteDatabase,
+  type SqliteValue,
+} from "./db.js";
 import {
   estimatePipelineEta,
   type PipelineEtaEstimatorInput,
@@ -359,7 +366,11 @@ function materializeExecution(
   const runId = nullableText(row.temporal_run_id);
   if (!runId) return null;
   const memberships = loadMemberships(db, tenantId, row.workflow_id, runId);
-  const stageStates = loadStageStates(db, memberships.map((membership) => membership.job_url));
+  const stageStates = loadStageStates(
+    db,
+    tenantId,
+    memberships.map((membership) => membership.job_url),
+  );
   const preparationWorkflows = loadPreparationWorkflows(db, tenantId, memberships);
   const steps = loadPipelineSteps(db, tenantId, row.workflow_id, runId);
   const current = cohort(
@@ -416,17 +427,29 @@ function loadMemberships(
   );
 }
 
-function loadStageStates(db: SqliteDatabase, jobUrls: string[]): Map<string, Map<string, StageStateRow>> {
+function loadStageStates(
+  db: SqliteDatabase,
+  tenantId: string,
+  jobUrls: string[],
+): Map<string, Map<string, StageStateRow>> {
   const grouped = new Map<string, Map<string, StageStateRow>>();
   if (jobUrls.length === 0 || !tableExists(db, "job_stage_states")) return grouped;
+  const stableReferences = jobReferenceColumn(db, "job_stage_states") === "job_id";
   for (const group of chunks(jobUrls, 500)) {
     const placeholders = group.map(() => "?").join(", ");
     const rows = allRows<StageStateRow>(
       db,
-      `SELECT job_url, stage, state, duration_ms, finished_at, retryable
-         FROM job_stage_states
-        WHERE job_url IN (${placeholders})`,
-      group,
+      `SELECT ${stableReferences ? "stage_jobs.url" : "states.job_url"} AS job_url,
+              states.stage, states.state,
+              states.duration_ms, states.finished_at, states.retryable
+         FROM job_stage_states states
+         ${stableReferences
+           ? `JOIN jobs stage_jobs
+                ON ${jobReferenceJoinToJobs(db, "job_stage_states", "states", "stage_jobs")}`
+           : ""}
+        WHERE ${stableReferences ? "stage_jobs.tenant_id = ? AND stage_jobs.url" : "states.job_url"}
+              IN (${placeholders})`,
+      stableReferences ? [tenantId, ...group] : group,
     );
     for (const row of rows) {
       const stages = grouped.get(row.job_url) ?? new Map<string, StageStateRow>();
@@ -1174,17 +1197,28 @@ function globalStageCounts(
   const counts = new Map<(typeof OPERATIONAL_STAGES)[number], PipelineStageCounts>();
   for (const stage of OPERATIONAL_STAGES) counts.set(stage, emptyCounts());
   if (!tableExists(db, "job_stage_states")) return counts;
+  const stableReferences = jobReferenceColumn(db, "job_stage_states") === "job_id";
+  const jobUrlExpression = stableReferences ? "stage_jobs.url" : "jss.job_url";
   const excluded = selected.current.members.concat(selected.sweep.members).map((member) => member.job_url);
   const where = ["jss.stage IN ('enrich', 'score', 'tailor', 'cover')"];
   const params: SqliteValue[] = [];
+  if (stableReferences) {
+    where.unshift("stage_jobs.tenant_id = ?");
+    params.push(tenantId);
+  }
   if (excluded.length > 0) {
-    where.push(`jss.job_url NOT IN (${excluded.map(() => "?").join(", ")})`);
+    where.push(`${jobUrlExpression} NOT IN (${excluded.map(() => "?").join(", ")})`);
     params.push(...excluded);
   }
   const rows = allRows<StageStateRow>(
     db,
-    `SELECT jss.job_url, jss.stage, jss.state, jss.duration_ms, jss.finished_at
+    `SELECT ${jobUrlExpression} AS job_url, jss.stage, jss.state,
+            jss.duration_ms, jss.finished_at
        FROM job_stage_states jss
+       ${stableReferences
+         ? `JOIN jobs stage_jobs
+              ON ${jobReferenceJoinToJobs(db, "job_stage_states", "jss", "stage_jobs")}`
+         : ""}
       WHERE ${where.join(" AND ")}`,
     params,
   );
@@ -1203,16 +1237,32 @@ function loadGlobalRetryability(
   selected: SelectedExecution,
 ): GlobalRetryability {
   if (!tableExists(db, "job_stage_states")) return { hasUnboundedRetryableDemand: false };
+  const stableReferences = jobReferenceColumn(db, "job_stage_states") === "job_id";
+  const jobUrlExpression = stableReferences ? "stage_jobs.url" : "states.job_url";
   const excluded = selected.current.members.concat(selected.sweep.members).map((member) => member.job_url);
-  const where = ["stage IN ('enrich', 'score', 'tailor', 'cover')", "state = 'failed'", "retryable = 1"];
+  const where = [
+    "states.stage IN ('enrich', 'score', 'tailor', 'cover')",
+    "states.state = 'failed'",
+    "states.retryable = 1",
+  ];
   const params: SqliteValue[] = [];
+  if (stableReferences) {
+    where.unshift("stage_jobs.tenant_id = ?");
+    params.push(tenantId);
+  }
   if (excluded.length > 0) {
-    where.push(`job_url NOT IN (${excluded.map(() => "?").join(", ")})`);
+    where.push(`${jobUrlExpression} NOT IN (${excluded.map(() => "?").join(", ")})`);
     params.push(...excluded);
   }
   const rows = allRows<{ job_url: string }>(
     db,
-    `SELECT job_url FROM job_stage_states WHERE ${where.join(" AND ")}`,
+    `SELECT ${jobUrlExpression} AS job_url
+       FROM job_stage_states states
+       ${stableReferences
+         ? `JOIN jobs stage_jobs
+              ON ${jobReferenceJoinToJobs(db, "job_stage_states", "states", "stage_jobs")}`
+         : ""}
+      WHERE ${where.join(" AND ")}`,
     params,
   );
   if (rows.length === 0) return { hasUnboundedRetryableDemand: false };
@@ -1905,10 +1955,12 @@ function jobStageSamples(db: SqliteDatabase, stage: string, now: Date): EtaSampl
   if (!tableExists(db, "job_stage_states")) return [];
   const rows = allRows<StageStateRow>(
     db,
-    `SELECT job_url, stage, state, duration_ms, finished_at
-       FROM job_stage_states
-      WHERE stage = ? AND state = 'succeeded' AND duration_ms > 0 AND finished_at IS NOT NULL
-      ORDER BY finished_at DESC
+    `SELECT '' AS job_url, states.stage, states.state,
+            states.duration_ms, states.finished_at
+       FROM job_stage_states states
+      WHERE states.stage = ? AND states.state = 'succeeded'
+        AND states.duration_ms > 0 AND states.finished_at IS NOT NULL
+      ORDER BY states.finished_at DESC
       LIMIT ?`,
     [stage, ETA_SAMPLE_LIMIT],
   );

--- a/apps/api/src/projections.ts
+++ b/apps/api/src/projections.ts
@@ -27,6 +27,8 @@ import {
   hasCompositeJobIdForeignKey,
   jobReferenceColumn,
   jobReferenceForUrl,
+  jobReferenceJoinToJobs,
+  jobReferencePredicateForUrl,
   tableExists,
   type SqliteDatabase,
   type SqliteValue,
@@ -161,6 +163,8 @@ const DEPENDENCY_BLOCKER_MESSAGES: Record<string, Array<{ downstream: string; me
 
 interface BackfillOpts {
   jobUrl: string;
+  tenantId?: string;
+  jobId?: string;
   stage: string;
   attemptCount?: number;
   finishedAt?: string | null;
@@ -181,7 +185,19 @@ interface BackfillOpts {
  */
 function backfillLegacyStageStates(db: SqliteDatabase): void {
   if (!tableExists(db, "jobs") || !tableExists(db, "job_stage_states")) return;
+  const stageJoin = jobReferenceJoinToJobs(
+    db,
+    "job_stage_states",
+    "jss",
+    "j",
+  );
+  const stableStageReferences = jobReferenceColumn(
+    db,
+    "job_stage_states",
+  ) === "job_id";
   const legacyJobs = allRows<{
+    tenant_id: string;
+    job_id: string;
     url: string;
     discovered_at: string | null;
     full_description: string | null;
@@ -197,14 +213,17 @@ function backfillLegacyStageStates(db: SqliteDatabase): void {
     apply_error: string | null;
   }>(
     db,
-    `SELECT j.url, j.discovered_at, j.full_description, j.detail_scraped_at,
+    `SELECT ${stableStageReferences ? "j.tenant_id" : "'local'"} AS tenant_id,
+            ${stableStageReferences ? "j.job_id" : "j.url"} AS job_id,
+            j.url, j.discovered_at,
+            j.full_description, j.detail_scraped_at,
             j.detail_error, j.fit_score,
             j.tailored_resume_path, j.tailor_attempts,
             j.cover_letter_path, j.cover_attempts,
             j.applied_at, j.apply_status, j.apply_error
      FROM jobs j
-     LEFT JOIN job_stage_states jss ON jss.job_url = j.url
-     GROUP BY j.url
+     LEFT JOIN job_stage_states jss ON ${stageJoin}
+     GROUP BY ${stableStageReferences ? "j.tenant_id, j.job_id, " : ""}j.url
      HAVING COUNT(jss.stage) = 0`,
   );
   if (legacyJobs.length === 0) return;
@@ -226,6 +245,8 @@ function backfillLegacyStageStates(db: SqliteDatabase): void {
     allRows<{ name: string }>(db, "PRAGMA table_info(job_stage_states)").map((r) => r.name),
   );
   const allColumnSpecs: Array<[string, (state: string, opts: BackfillOpts) => SqliteValue]> = [
+    ["tenant_id", (_s, o) => o.tenantId ?? "local"],
+    ["job_id", (_s, o) => o.jobId ?? ""],
     ["job_url", (_s, o) => o.jobUrl],
     ["stage", (_s, o) => o.stage],
     ["state", (s) => s],
@@ -255,7 +276,19 @@ function backfillLegacyStageStates(db: SqliteDatabase): void {
     state: string,
     opts: Omit<BackfillOpts, "jobUrl" | "stage"> = {},
   ): void => {
-    const fullOpts: BackfillOpts = { ...opts, jobUrl, stage };
+    const tenantId = opts.tenantId ?? "local";
+    const fullOpts: BackfillOpts = {
+      ...opts,
+      jobUrl,
+      tenantId,
+      jobId: opts.jobId ?? jobReferenceForUrl(
+        db,
+        "job_stage_states",
+        jobUrl,
+        tenantId,
+      ),
+      stage,
+    };
     const values = presentColumns.map(([, fn]) => fn(state, fullOpts));
     insert.run(...values);
   };
@@ -263,6 +296,8 @@ function backfillLegacyStageStates(db: SqliteDatabase): void {
   for (const row of legacyJobs) {
     if (!row.url) continue;
     insertStage(row.url, "discover", "succeeded", {
+      tenantId: row.tenant_id,
+      jobId: row.job_id,
       attemptCount: 1,
       finishedAt: row.discovered_at ?? now,
     });
@@ -376,17 +411,37 @@ function reconcileDependencyBlockers(db: SqliteDatabase): Set<string> {
     columns.has("next_action") ? "next_action = NULL" : null,
     columns.has("metadata_json") ? "metadata_json = NULL" : null,
   ].filter((assignment): assignment is string => Boolean(assignment));
-  const updateSql = `UPDATE job_stage_states SET ${assignments.join(", ")} WHERE job_url = ? AND stage = ?`;
+  const stableReferences = jobReferenceColumn(
+    db,
+    "job_stage_states",
+  ) === "job_id";
+  const updateIdentity = stableReferences
+    ? "tenant_id = ? AND job_id = ?"
+    : "job_url = ?";
+  const updateSql = `UPDATE job_stage_states SET ${assignments.join(", ")} WHERE ${updateIdentity} AND stage = ?`;
   const update = db.prepare(updateSql);
   const now = new Date().toISOString();
 
   for (const [upstream, downstreams] of Object.entries(DEPENDENCY_BLOCKER_MESSAGES)) {
     for (const { downstream, messages } of downstreams) {
       const placeholders = messages.map(() => "?").join(", ");
-      const rows = allRows<{ job_url: string; stage: string }>(
+      const rows = allRows<{
+        job_url: string;
+        tenant_id: string | null;
+        job_id: string | null;
+        stage: string;
+      }>(
         db,
-        `SELECT downstream.job_url, downstream.stage
+        `SELECT ${stableReferences ? "jobs.url" : "downstream.job_url"} AS job_url,
+                ${stableReferences ? "downstream.tenant_id" : "NULL"} AS tenant_id,
+                ${stableReferences ? "downstream.job_id" : "NULL"} AS job_id,
+                downstream.stage
            FROM job_stage_states AS downstream
+           ${stableReferences
+             ? `JOIN jobs
+                  ON jobs.tenant_id = downstream.tenant_id
+                 AND jobs.job_id = downstream.job_id`
+             : ""}
           WHERE downstream.stage = ?
             AND downstream.state = 'blocked'
             AND downstream.error_code = 'BLOCKED'
@@ -394,14 +449,23 @@ function reconcileDependencyBlockers(db: SqliteDatabase): Set<string> {
             AND EXISTS (
               SELECT 1
                 FROM job_stage_states AS upstream
-               WHERE upstream.job_url = downstream.job_url
+               WHERE ${stableReferences
+                 ? "upstream.tenant_id = downstream.tenant_id AND upstream.job_id = downstream.job_id"
+                 : "upstream.job_url = downstream.job_url"}
                  AND upstream.stage = ?
                  AND upstream.state = 'succeeded'
             )`,
         [downstream, ...messages, upstream],
       );
       for (const row of rows) {
-        update.run(...(columns.has("updated_at") ? [now] : []), row.job_url, row.stage);
+        const identityParams: SqliteValue[] = stableReferences
+          ? [row.tenant_id, row.job_id]
+          : [row.job_url];
+        update.run(
+          ...(columns.has("updated_at") ? [now] : []),
+          ...identityParams,
+          row.stage,
+        );
         repairedJobs.add(row.job_url);
       }
     }
@@ -419,14 +483,23 @@ function reconcileObsoleteCoverGenerationConflicts(db: SqliteDatabase): Set<stri
   const columns = new Set(
     allRows<{ name: string }>(db, "PRAGMA table_info(job_stage_states)").map((row) => row.name),
   );
+  const stableReferences = jobReferenceColumn(
+    db,
+    "job_stage_states",
+  ) === "job_id";
+  const stageJobUrl = stableReferences ? "stage_jobs.url" : "s.job_url";
   const rows = allRows<{
     job_url: string;
+    tenant_id: string | null;
+    job_id: string | null;
     error_message: string | null;
     has_cover_letter: number | string | null;
   }>(
     db,
     `
-    SELECT s.job_url,
+    SELECT ${stageJobUrl} AS job_url,
+           ${stableReferences ? "s.tenant_id" : "NULL"} AS tenant_id,
+           ${stableReferences ? "s.job_id" : "NULL"} AS job_id,
            s.error_message,
            EXISTS (
              SELECT 1
@@ -443,12 +516,17 @@ function reconcileObsoleteCoverGenerationConflicts(db: SqliteDatabase): Set<stri
                 AND cover.artifact_type = 'cover_letter'
                 AND cover.status = 'approved'
                 AND COALESCE(TRIM(cover.path), '') != ''
-              WHERE tr.job_url = s.job_url
+              WHERE tr.job_url = ${stageJobUrl}
                 AND tr.artifact_type = 'tailored_resume'
                 AND tr.status = 'approved'
                 AND COALESCE(TRIM(tr.path), '') != ''
            ) AS has_cover_letter
       FROM job_stage_states s
+      ${stableReferences
+        ? `JOIN jobs stage_jobs
+             ON stage_jobs.tenant_id = s.tenant_id
+            AND stage_jobs.job_id = s.job_id`
+        : ""}
      WHERE s.stage = 'cover'
        AND s.state = 'failed'
        AND s.error_code = 'COVER_FAILED'
@@ -463,7 +541,7 @@ function reconcileObsoleteCoverGenerationConflicts(db: SqliteDatabase): Set<stri
                 AND pdf.artifact_type = 'resume_pdf'
                 AND pdf.status = 'approved'
                 AND COALESCE(TRIM(pdf.path), '') != ''
-              WHERE tr.job_url = s.job_url
+              WHERE tr.job_url = ${stageJobUrl}
                 AND tr.artifact_type = 'tailored_resume'
                 AND tr.status = 'approved'
                 AND COALESCE(TRIM(tr.path), '') != ''
@@ -486,7 +564,9 @@ function reconcileObsoleteCoverGenerationConflicts(db: SqliteDatabase): Set<stri
   const update = db.prepare(
     `UPDATE job_stage_states
         SET ${assignments.join(", ")}
-      WHERE job_url = ?
+      WHERE ${stableReferences
+        ? "tenant_id = ? AND job_id = ?"
+        : "job_url = ?"}
         AND stage = 'cover'
         AND state = 'failed'
         AND error_code = 'COVER_FAILED'`,
@@ -509,7 +589,12 @@ function reconcileObsoleteCoverGenerationConflicts(db: SqliteDatabase): Set<stri
         }),
       );
     }
-    update.run(...values, row.job_url);
+    update.run(
+      ...values,
+      ...(stableReferences
+        ? [row.tenant_id, row.job_id]
+        : [row.job_url]),
+    );
     repairedJobs.add(row.job_url);
   }
 
@@ -3064,18 +3149,28 @@ function staleStageProjectionJobs(db: SqliteDatabase, tenantId: string): string[
   if (!tableExists(db, "jobs") || !tableExists(db, "job_stage_states") || !tableExists(db, "job_list_projections")) {
     return [];
   }
+  const stageReference = jobReferenceColumn(db, "job_stage_states");
+  const stageJoin = jobReferenceJoinToJobs(
+    db,
+    "job_stage_states",
+    "s",
+    "j",
+  );
+  const stageIdentity = stageReference === "job_id"
+    ? "s.job_id"
+    : "s.job_url";
 
   const rows = allRows<{ job_id: string }>(
     db,
-    `SELECT DISTINCT s.job_url AS job_id
+    `SELECT DISTINCT j.url AS job_id
        FROM job_stage_states s
        JOIN jobs j
-         ON j.url = s.job_url
+         ON ${stageJoin}
        LEFT JOIN job_list_projections p
          ON p.tenant_id = ?
-        AND p.job_id = s.job_url
-      WHERE s.job_url IS NOT NULL
-        AND TRIM(s.job_url) != ''
+        AND p.job_id = j.url
+      WHERE ${stageIdentity} IS NOT NULL
+        AND TRIM(${stageIdentity}) != ''
         AND (
           p.job_id IS NULL
           OR (
@@ -3128,10 +3223,15 @@ interface NormalizedStage {
 function loadStages(db: SqliteDatabase, jobUrl: string): NormalizedStage[] {
   const explicit = new Map<string, StageRow>();
   if (tableExists(db, "job_stage_states")) {
+    const reference = jobReferencePredicateForUrl(
+      db,
+      "job_stage_states",
+      jobUrl,
+    );
     for (const row of allRows<StageRow>(
       db,
-      "SELECT * FROM job_stage_states WHERE job_url = ?",
-      [jobUrl],
+      `SELECT * FROM job_stage_states WHERE ${reference.sql}`,
+      reference.params,
     )) {
       if (row.stage) explicit.set(String(row.stage), row);
     }

--- a/apps/api/src/read-model.ts
+++ b/apps/api/src/read-model.ts
@@ -439,9 +439,17 @@ function dashboardWorkSummary(db: SqliteDatabase): DashboardSummary["work"] {
     ? "stage_state.started_at AS stage_started_at, stage_state.updated_at AS stage_updated_at"
     : "NULL AS stage_started_at, NULL AS stage_updated_at";
   const stageJoin = hasStageState
-    ? `LEFT JOIN job_stage_states AS stage_state
-         ON stage_state.job_url = job_list_projections.job_id
-        AND stage_state.stage = job_list_projections.current_substage`
+    ? jobReferenceColumn(db, "job_stage_states") === "job_id"
+      ? `LEFT JOIN jobs AS stage_jobs
+           ON stage_jobs.tenant_id = job_list_projections.tenant_id
+          AND stage_jobs.url = job_list_projections.job_id
+         LEFT JOIN job_stage_states AS stage_state
+           ON stage_state.tenant_id = stage_jobs.tenant_id
+          AND stage_state.job_id = stage_jobs.job_id
+          AND stage_state.stage = job_list_projections.current_substage`
+      : `LEFT JOIN job_stage_states AS stage_state
+           ON stage_state.job_url = job_list_projections.job_id
+          AND stage_state.stage = job_list_projections.current_substage`
     : "";
   const rows = allRows<DashboardWorkRow>(
     db,

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -3628,6 +3628,13 @@ function preparationPickupEligibility(
           AND stale.${staleReference} = jobs.${staleReference === "job_id" ? "job_id" : "url"}
           AND stale.resolved = 0)`
     : "0";
+  const stageReference = jobReferenceColumn(db, "job_stage_states");
+  const stageIdentityJoin = stageReference === "job_id"
+    ? "stage_state.tenant_id = jobs.tenant_id AND stage_state.job_id = jobs.job_id"
+    : "stage_state.job_url = jobs.url";
+  const scoreIdentityJoin = stageReference === "job_id"
+    ? "score_state.tenant_id = jobs.tenant_id AND score_state.job_id = jobs.job_id"
+    : "score_state.job_url = jobs.url";
   const row = db
     .prepare(
       `SELECT
@@ -3647,9 +3654,9 @@ function preparationPickupEligibility(
        LEFT JOIN job_list_projections projections
          ON projections.tenant_id = 'local' AND projections.job_id = jobs.url
        LEFT JOIN job_stage_states stage_state
-         ON stage_state.job_url = jobs.url AND stage_state.stage = ?
+         ON ${stageIdentityJoin} AND stage_state.stage = ?
        LEFT JOIN job_stage_states score_state
-         ON score_state.job_url = jobs.url AND score_state.stage = 'score'
+         ON ${scoreIdentityJoin} AND score_state.stage = 'score'
        WHERE jobs.url = ?
        LIMIT 1`,
     )

--- a/apps/api/src/write-model.ts
+++ b/apps/api/src/write-model.ts
@@ -28,6 +28,7 @@ import {
   hasCompositeJobIdForeignKey,
   jobReferenceColumn,
   jobReferenceForUrl,
+  jobReferencePredicateForUrl,
   tableExists,
   type SqliteDatabase,
   type SqliteValue,
@@ -93,10 +94,15 @@ export function validateStageTransition(
   if (!tableExists(db, "job_stage_states")) {
     return;
   }
+  const reference = jobReferencePredicateForUrl(
+    db,
+    "job_stage_states",
+    jobUrl,
+  );
   const row = getRow<{ state?: string }>(
     db,
-    "SELECT state FROM job_stage_states WHERE job_url = ? AND stage = ?",
-    [jobUrl, stage],
+    `SELECT state FROM job_stage_states WHERE ${reference.sql} AND stage = ?`,
+    [...reference.params, stage],
   );
   if (!row || !row.state) {
     return; // No existing row — INSERT path, always valid.
@@ -215,10 +221,15 @@ export function queueRetriedJobsForWorkflow(
   const source = workflow.source ?? "bulk_retry_failed";
   const transaction = db.transaction((rows: readonly RetryFailedJobTarget[]) => {
     for (const target of rows) {
+      const reference = jobReferencePredicateForUrl(
+        db,
+        "job_stage_states",
+        target.jobUrl,
+      );
       const current = getRow<{ state?: string }>(
         db,
-        "SELECT state FROM job_stage_states WHERE job_url = ? AND stage = ?",
-        [target.jobUrl, target.stage],
+        `SELECT state FROM job_stage_states WHERE ${reference.sql} AND stage = ?`,
+        [...reference.params, target.stage],
       );
       if (current?.state && current.state !== "pending") {
         continue;
@@ -825,7 +836,19 @@ function purgeJobRows(db: SqliteDatabase, jobUrl: string): void {
   const jobId = identity?.job_id;
   deleteWhere(db, "jobctrl_deleted_jobs", "job_url = ?", [jobUrl]);
   deleteWhere(db, "jobctrl_hidden_jobs", "job_url = ?", [jobUrl]);
-  deleteWhere(db, "job_stage_states", "job_url = ?", [jobUrl]);
+  if (tableExists(db, "job_stage_states")) {
+    const stageReference = jobReferenceColumn(db, "job_stage_states");
+    if (stageReference === "job_id" && jobId) {
+      deleteWhere(
+        db,
+        "job_stage_states",
+        "tenant_id = ? AND job_id = ?",
+        ["local", jobId],
+      );
+    } else {
+      deleteWhere(db, "job_stage_states", "job_url = ?", [jobUrl]);
+    }
+  }
   deleteWhere(db, "job_events", "job_url = ?", [jobUrl]);
   deleteWhere(db, "job_artifacts", "job_url = ?", [jobUrl]);
   deleteScoringJobReferences(db, jobId, jobUrl);
@@ -1245,10 +1268,15 @@ function markScoreStageStale(
     markedAt: string;
   },
 ): void {
+  const stageReference = jobReferencePredicateForUrl(
+    db,
+    "job_stage_states",
+    jobUrl,
+  );
   const current = getRow<{ state?: string }>(
     db,
-    "SELECT state FROM job_stage_states WHERE job_url = ? AND stage = 'score'",
-    [jobUrl],
+    `SELECT state FROM job_stage_states WHERE ${stageReference.sql} AND stage = 'score'`,
+    stageReference.params,
   );
   if (!current || current.state === "succeeded") {
     upsertStageState(db, jobUrl, "score", "stale");
@@ -1611,6 +1639,12 @@ function upsertStageState(
     validateStageTransition(db, jobUrl, stage, state);
   }
   const columns = columnNames(db, "job_stage_states");
+  const referenceColumn = jobReferenceColumn(db, "job_stage_states");
+  const reference = jobReferencePredicateForUrl(
+    db,
+    "job_stage_states",
+    jobUrl,
+  );
   const now = new Date().toISOString();
   const updates: Record<string, SqliteValue> = {
     state,
@@ -1635,9 +1669,9 @@ function upsertStageState(
 
   const updateEntries = Object.entries(updates).filter(([name]) => columns.has(name));
   const assignments = updateEntries.map(([name]) => `${name} = ?`).join(", ");
-  const result = db.prepare(`UPDATE job_stage_states SET ${assignments} WHERE job_url = ? AND stage = ?`).run(
+  const result = db.prepare(`UPDATE job_stage_states SET ${assignments} WHERE ${reference.sql} AND stage = ?`).run(
     ...updateEntries.map(([, value]) => value),
-    jobUrl,
+    ...reference.params,
     stage,
   );
   if (result.changes > 0) {
@@ -1645,7 +1679,6 @@ function upsertStageState(
   }
 
   const insert: Record<string, SqliteValue> = {
-    job_url: jobUrl,
     stage,
     state,
     attempt_count: options.attemptCount ?? 0,
@@ -1654,6 +1687,16 @@ function upsertStageState(
     retryable: options.retryable === false ? 0 : 1,
     blocked_by_json: "[]",
   };
+  if (referenceColumn === "job_id") {
+    insert.tenant_id = "local";
+    insert.job_id = jobReferenceForUrl(
+      db,
+      "job_stage_states",
+      jobUrl,
+    );
+  } else {
+    insert.job_url = jobUrl;
+  }
   if (options.finishedAt) {
     insert.finished_at = options.finishedAt;
   }
@@ -1669,10 +1712,15 @@ function getStageState(db: SqliteDatabase, jobUrl: string, stage: Stage): StageS
   if (!tableExists(db, "job_stage_states")) {
     return defaultStage(stage, "pending");
   }
+  const reference = jobReferencePredicateForUrl(
+    db,
+    "job_stage_states",
+    jobUrl,
+  );
   const row = getRow<Record<string, unknown>>(
     db,
-    "SELECT * FROM job_stage_states WHERE job_url = ? AND stage = ? LIMIT 1",
-    [jobUrl, stage],
+    `SELECT * FROM job_stage_states WHERE ${reference.sql} AND stage = ? LIMIT 1`,
+    [...reference.params, stage],
   );
   if (!row) {
     return defaultStage(stage, "pending");
@@ -1698,10 +1746,15 @@ function currentMutableStage(db: SqliteDatabase, jobUrl: string): Stage {
   if (!tableExists(db, "job_stage_states")) {
     return "apply";
   }
+  const reference = jobReferencePredicateForUrl(
+    db,
+    "job_stage_states",
+    jobUrl,
+  );
   const rows = allRows<Record<string, unknown>>(
     db,
-    "SELECT stage, state FROM job_stage_states WHERE job_url = ? ORDER BY rowid",
-    [jobUrl],
+    `SELECT stage, state FROM job_stage_states WHERE ${reference.sql} ORDER BY rowid`,
+    reference.params,
   );
   const active = rows.find((row) => ["queued", "running"].includes(String(row.state ?? "")));
   if (active && STAGES.includes(active.stage as Stage)) {
@@ -1714,10 +1767,15 @@ function currentFailedStage(db: SqliteDatabase, jobUrl: string): Stage | null {
   if (!tableExists(db, "job_stage_states")) {
     return null;
   }
+  const reference = jobReferencePredicateForUrl(
+    db,
+    "job_stage_states",
+    jobUrl,
+  );
   const rows = allRows<{ stage: Stage; state: string; retryable: number | null }>(
     db,
-    "SELECT stage, state, retryable FROM job_stage_states WHERE job_url = ?",
-    [jobUrl],
+    `SELECT stage, state, retryable FROM job_stage_states WHERE ${reference.sql}`,
+    reference.params,
   );
   const failedStages = new Set(
     rows

--- a/apps/api/test/pipeline-operations.test.ts
+++ b/apps/api/test/pipeline-operations.test.ts
@@ -21,6 +21,7 @@ interface Fixture {
   configPath: string;
   db: Database.Database;
   legacyExecutionReferences: boolean;
+  stableStageReferences: boolean;
 }
 
 afterEach(() => {
@@ -31,6 +32,30 @@ afterEach(() => {
 });
 
 describe("pipeline operations read model", () => {
+  it("reads v13 stable JobId stage states through the canonical job URL", () => {
+    const fixture = createFixture({ stableStageReferences: true });
+    insertExecution(fixture, { status: "in_progress" });
+    insertMember(fixture, {
+      key: "v13-stage-reference",
+      cohort: "observed_this_run",
+      requiredSteps: ["score"],
+    });
+    insertStageState(fixture, "v13-stage-reference", "score", "pending");
+
+    const result = snapshot(fixture);
+    expect(result.execution).toMatchObject({
+      currentExecution: {
+        members: 1,
+        planned: 1,
+        remaining: 1,
+      },
+    });
+    expect(stage(result, "score", "current_execution").currentExecution).toMatchObject({
+      eligible: 1,
+      waiting: 1,
+    });
+  });
+
   it("reads v8 URL memberships while the worker migration is pending", () => {
     const fixture = createFixture({ legacyExecutionReferences: true });
     insertExecution(fixture, { status: "succeeded" });
@@ -1134,7 +1159,10 @@ describe("pipeline operations read model", () => {
 });
 
 function createFixture(
-  options: { legacyExecutionReferences?: boolean } = {},
+  options: {
+    legacyExecutionReferences?: boolean;
+    stableStageReferences?: boolean;
+  } = {},
 ): Fixture {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "jobctrl-pipeline-operations-"));
   const dbPath = path.join(directory, "jobctrl.db");
@@ -1142,9 +1170,16 @@ function createFixture(
   fs.writeFileSync(configPath, JSON.stringify({ daily_budget_usd: 25 }));
   const db = new Database(dbPath);
   const legacyExecutionReferences = options.legacyExecutionReferences === true;
+  const stableStageReferences = options.stableStageReferences === true;
   const executionReferenceColumn = legacyExecutionReferences
     ? "job_url TEXT NOT NULL"
     : "job_id TEXT NOT NULL";
+  const stageReferenceColumns = stableStageReferences
+    ? "tenant_id TEXT NOT NULL, job_id TEXT NOT NULL"
+    : "job_url TEXT NOT NULL";
+  const stagePrimaryKey = stableStageReferences
+    ? "tenant_id, job_id, stage"
+    : "job_url, stage";
   db.exec(`
     CREATE TABLE fixture_jobs (
       url TEXT PRIMARY KEY,
@@ -1155,7 +1190,7 @@ function createFixture(
     CREATE VIEW jobs AS
       SELECT url, tenant_id, job_id FROM fixture_jobs;
     CREATE TABLE job_stage_states (
-      job_url TEXT NOT NULL,
+      ${stageReferenceColumns},
       stage TEXT NOT NULL,
       state TEXT,
       attempt_count INTEGER,
@@ -1168,7 +1203,8 @@ function createFixture(
       error_message TEXT,
       retryable INTEGER,
       blocked_by_json TEXT,
-      next_action TEXT
+      next_action TEXT,
+      PRIMARY KEY (${stagePrimaryKey})
     );
     CREATE TABLE discovery_execution_jobs (
       tenant_id TEXT NOT NULL,
@@ -1226,6 +1262,7 @@ function createFixture(
     configPath,
     db,
     legacyExecutionReferences,
+    stableStageReferences,
   };
   fixtures.push(fixture);
   return fixture;
@@ -1436,11 +1473,20 @@ function insertStageState(
   finishedAt: string | null = null,
   retryable = 0,
 ): void {
+  const jobUrl = `https://private.invalid/${key}`;
+  const referenceColumns = fixture.stableStageReferences
+    ? "tenant_id, job_id"
+    : "job_url";
+  const referencePlaceholders = fixture.stableStageReferences ? "?, ?" : "?";
+  const referenceValues = fixture.stableStageReferences
+    ? ["local", stableJobId(jobUrl)]
+    : [jobUrl];
   fixture.db.prepare(
     `INSERT INTO job_stage_states (
-       job_url, stage, state, attempt_count, max_attempts, updated_at, finished_at, duration_ms, retryable
-     ) VALUES (?, ?, ?, 1, 3, ?, ?, ?, ?)`,
-  ).run(`https://private.invalid/${key}`, stage, state, NOW.toISOString(), finishedAt, durationMs, retryable);
+       ${referenceColumns}, stage, state, attempt_count, max_attempts,
+       updated_at, finished_at, duration_ms, retryable
+     ) VALUES (${referencePlaceholders}, ?, ?, 1, 3, ?, ?, ?, ?)`,
+  ).run(...referenceValues, stage, state, NOW.toISOString(), finishedAt, durationMs, retryable);
 }
 
 function insertStep(

--- a/apps/api/test/stage-state-v13-write-model.test.ts
+++ b/apps/api/test/stage-state-v13-write-model.test.ts
@@ -1,0 +1,123 @@
+import Database from "better-sqlite3";
+import { describe, expect, it } from "vitest";
+
+import {
+  markJobApplied,
+  permanentlyDeleteJob,
+} from "../src/write-model.js";
+
+describe("schema-v13 stage-state writes", () => {
+  it("mutates and deletes the URL owner when its URL equals another JobId", () => {
+    const db = new Database(":memory:");
+    db.pragma("foreign_keys = ON");
+    db.pragma("user_version = 13");
+    db.exec(`
+      CREATE TABLE jobs (
+        url TEXT PRIMARY KEY,
+        tenant_id TEXT NOT NULL DEFAULT 'local',
+        job_id TEXT NOT NULL,
+        application_url TEXT,
+        apply_status TEXT,
+        apply_error TEXT,
+        applied_at TEXT,
+        UNIQUE (tenant_id, job_id)
+      );
+      CREATE TABLE job_stage_states (
+        tenant_id TEXT NOT NULL DEFAULT 'local',
+        job_id TEXT NOT NULL,
+        stage TEXT NOT NULL,
+        state TEXT NOT NULL DEFAULT 'pending',
+        attempt_count INTEGER DEFAULT 0,
+        max_attempts INTEGER,
+        started_at TEXT,
+        updated_at TEXT NOT NULL,
+        finished_at TEXT,
+        duration_ms INTEGER,
+        error_code TEXT,
+        error_message TEXT,
+        retryable INTEGER DEFAULT 1,
+        blocked_by_json TEXT,
+        next_action TEXT,
+        metadata_json TEXT,
+        version INTEGER NOT NULL DEFAULT 0,
+        PRIMARY KEY (tenant_id, job_id, stage),
+        FOREIGN KEY (tenant_id, job_id)
+          REFERENCES jobs(tenant_id, job_id) ON DELETE CASCADE
+      );
+      CREATE TABLE job_events (
+        event_id INTEGER PRIMARY KEY AUTOINCREMENT,
+        job_url TEXT,
+        stage TEXT,
+        event_type TEXT NOT NULL,
+        level TEXT NOT NULL,
+        message TEXT,
+        occurred_at TEXT NOT NULL,
+        payload_json TEXT
+      );
+    `);
+
+    const uuidShapedUrl = "11111111-1111-4111-8111-111111111111";
+    const urlOwnerJobId = "22222222-2222-4222-8222-222222222222";
+    const idTextOwnerUrl = "https://example.com/jobs/id-text-owner";
+    db.prepare(
+      `INSERT INTO jobs (url, tenant_id, job_id, application_url)
+       VALUES (?, 'local', ?, ?), (?, 'local', ?, ?)`,
+    ).run(
+      uuidShapedUrl,
+      urlOwnerJobId,
+      `${uuidShapedUrl}/apply`,
+      idTextOwnerUrl,
+      uuidShapedUrl,
+      `${idTextOwnerUrl}/apply`,
+    );
+    const insertStage = db.prepare(
+      `INSERT INTO job_stage_states (
+         tenant_id, job_id, stage, state, updated_at
+       ) VALUES ('local', ?, 'apply', ?, '2026-07-29T10:00:00.000Z')`,
+    );
+    insertStage.run(urlOwnerJobId, "failed");
+    insertStage.run(uuidShapedUrl, "pending");
+
+    expect(
+      markJobApplied(db, uuidShapedUrl, { reason: "manual fixture" }),
+    ).toMatchObject({
+      jobUrl: uuidShapedUrl,
+      stage: { state: "succeeded" },
+    });
+    expect(
+      db.prepare(
+        `SELECT state
+           FROM job_stage_states
+          WHERE tenant_id = 'local' AND job_id = ? AND stage = 'apply'`,
+      ).get(urlOwnerJobId),
+    ).toMatchObject({ state: "succeeded" });
+    expect(
+      db.prepare(
+        `SELECT state
+           FROM job_stage_states
+          WHERE tenant_id = 'local' AND job_id = ? AND stage = 'apply'`,
+      ).get(uuidShapedUrl),
+    ).toMatchObject({ state: "pending" });
+
+    expect(permanentlyDeleteJob(db, uuidShapedUrl)).toEqual({
+      ok: true,
+      count: 1,
+      jobKeys: [uuidShapedUrl],
+    });
+    expect(
+      db.prepare("SELECT COUNT(*) AS count FROM jobs WHERE job_id = ?").get(
+        urlOwnerJobId,
+      ),
+    ).toEqual({ count: 0 });
+    expect(
+      db.prepare("SELECT url FROM jobs WHERE job_id = ?").get(uuidShapedUrl),
+    ).toEqual({ url: idTextOwnerUrl });
+    expect(
+      db.prepare(
+        "SELECT state FROM job_stage_states WHERE tenant_id = 'local' AND job_id = ?",
+      ).get(uuidShapedUrl),
+    ).toEqual({ state: "pending" });
+
+    db.close();
+  });
+});

--- a/workers/automation/src/jobctrl/apply/launcher.py
+++ b/workers/automation/src/jobctrl/apply/launcher.py
@@ -93,6 +93,8 @@ from jobctrl.domain.profile.snapshot import ProfileSnapshot
 from jobctrl.operational_metrics import record_operational_attempt_metric
 from jobctrl.state import (
     ensure_job_stage_rows,
+    get_stage_state_job_urls,
+    get_stage_state_row,
     record_job_artifact,
     record_job_event,
     set_stage_state,
@@ -143,42 +145,28 @@ def _has_active_apply(conn, url: str) -> bool:
     The §4.6 invariant — at most one in-progress apply per JobId —
     is enforced by checking the canonical stage state row.
     """
-    row = conn.execute(
-        "SELECT 1 FROM job_stage_states "
-        "WHERE job_url = ? AND stage = 'apply' AND state = 'running' LIMIT 1",
-        (url,),
-    ).fetchone()
-    return row is not None
+    row = get_stage_state_row(conn, url, "apply")
+    return bool(row is not None and str(row["state"]) == "running")
 
 
 def _has_succeeded_apply(conn, url: str) -> bool:
     """True when the canonical apply stage row is succeeded for ``url``."""
-    row = conn.execute(
-        "SELECT 1 FROM job_stage_states "
-        "WHERE job_url = ? AND stage = 'apply' AND state = 'succeeded' LIMIT 1",
-        (url,),
-    ).fetchone()
-    return row is not None
+    row = get_stage_state_row(conn, url, "apply")
+    return bool(row is not None and str(row["state"]) == "succeeded")
 
 
 def _has_needs_verification_apply(conn, url: str) -> bool:
     """True when a live apply is parked for manual verification."""
-    row = conn.execute(
-        "SELECT 1 FROM job_stage_states "
-        "WHERE job_url = ? AND stage = 'apply' AND state = 'needs_verification' LIMIT 1",
-        (url,),
-    ).fetchone()
-    return row is not None
+    row = get_stage_state_row(conn, url, "apply")
+    return bool(
+        row is not None and str(row["state"]) == "needs_verification"
+    )
 
 
 def _attempt_count_for(conn, url: str) -> int:
     """Return the canonical attempt count from ``job_stage_states.apply``."""
-    row = conn.execute(
-        "SELECT attempt_count FROM job_stage_states "
-        "WHERE job_url = ? AND stage = 'apply' LIMIT 1",
-        (url,),
-    ).fetchone()
-    return int(row[0] or 0) if row else 0
+    row = get_stage_state_row(conn, url, "apply")
+    return int(row["attempt_count"] or 0) if row else 0
 
 
 def _latest_apply_review_decision(conn, *, tenant_id: str, job_key: str) -> dict[str, Any] | None:
@@ -609,7 +597,9 @@ def _apply_candidate_select_parts() -> tuple[str, str]:
     attempts_subquery = (
         "(SELECT COALESCE(jss_a.attempt_count, 0) "
         "FROM job_stage_states jss_a "
-        "WHERE jss_a.job_url = jobs.url AND jss_a.stage = 'apply' LIMIT 1) AS apply_attempts"
+        "WHERE jss_a.tenant_id = jobs.tenant_id "
+        "AND jss_a.job_id = jobs.job_id "
+        "AND jss_a.stage = 'apply' LIMIT 1) AS apply_attempts"
     )
     columns = (
         f"jobs.url AS url, jobs.title AS title, jobs.site AS site, "
@@ -699,13 +689,16 @@ def acquire_job(
                   AND {_EFFECTIVE_APPLY_TARGET_URL} != ''
                   AND NOT EXISTS (
                       SELECT 1 FROM job_stage_states jss_active
-                      WHERE jss_active.job_url = jobs.url
+                      WHERE jss_active.tenant_id = jobs.tenant_id
+                        AND jss_active.job_id = jobs.job_id
                         AND jss_active.stage = 'apply'
                         AND jss_active.state IN ('running', 'succeeded', 'needs_verification')
                   )
                   AND COALESCE(
                       (SELECT jss_a.attempt_count FROM job_stage_states jss_a
-                       WHERE jss_a.job_url = jobs.url AND jss_a.stage = 'apply'
+                       WHERE jss_a.tenant_id = jobs.tenant_id
+                         AND jss_a.job_id = jobs.job_id
+                         AND jss_a.stage = 'apply'
                        LIMIT 1), 0
                   ) < ?
                   AND {_EFFECTIVE_FIT_SCORE} >= ?
@@ -849,12 +842,8 @@ def acquire_job(
         # Reset prior retryable terminal state (failed / exhausted /
         # canceled / skipped) back to pending so the §8.5 state machine accepts
         # the pending → running transition.
-        prior_row = conn.execute(
-            "SELECT state FROM job_stage_states "
-            "WHERE job_url = ? AND stage = 'apply' LIMIT 1",
-            (url,),
-        ).fetchone()
-        if prior_row is not None and prior_row[0] not in {
+        prior_row = get_stage_state_row(conn, url, "apply")
+        if prior_row is not None and prior_row["state"] not in {
             "pending",
             "running",
             "succeeded",
@@ -1201,13 +1190,13 @@ def recover_ambiguous_running_apply(console: Console | None = None) -> int:
     """Recover apply rows inherited from a prior dead workflow/activity."""
     try:
         conn = get_connection()
-        rows = conn.execute(
-            "SELECT job_url FROM job_stage_states "
-            "WHERE stage = 'apply' AND state = 'running'"
-        ).fetchall()
+        urls = get_stage_state_job_urls(
+            conn,
+            stage="apply",
+            states=("running",),
+        )
         recovered = 0
-        for row in rows:
-            url = str(row["job_url"] if hasattr(row, "keys") else row[0])
+        for url in urls:
             try:
                 run_id, workflow_id = _latest_apply_run_started_identity(conn, url)
                 if not _workflow_terminal_or_gone(conn, workflow_id or run_id):
@@ -1376,15 +1365,13 @@ def reset_failed() -> int:
     jobs reset.
     """
     conn = get_connection()
-    rows = conn.execute(
-        """
-        SELECT job_url FROM job_stage_states
-        WHERE stage = 'apply' AND state IN ('failed', 'exhausted')
-        """
-    ).fetchall()
+    urls = get_stage_state_job_urls(
+        conn,
+        stage="apply",
+        states=("failed", "exhausted"),
+    )
     count = 0
-    for row in rows:
-        url = row["job_url"]
+    for url in urls:
         # Skip jobs that already succeeded on a prior run.
         if _has_succeeded_apply(conn, url):
             continue

--- a/workers/automation/src/jobctrl/database.py
+++ b/workers/automation/src/jobctrl/database.py
@@ -52,7 +52,10 @@ from jobctrl.config import DB_PATH, DEFAULTS, migrate_legacy_job_tables
 # v12 (scoring references): score history, staleness markers, and requirement-fit
 # authorities reference ``(tenant_id, job_id)`` with dependent score versions
 # remapped atomically when multiple historical URL aliases collapse.
-SCHEMA_VERSION = 12
+# v13 (stage-state references): the canonical per-stage lifecycle row references
+# ``(tenant_id, job_id)``. Alias collisions keep the most recently updated
+# lifecycle fact while preserving monotonic attempt and optimistic-lock counts.
+SCHEMA_VERSION = 13
 
 
 class IncompatibleSchemaVersionError(RuntimeError):
@@ -195,6 +198,7 @@ def _schema_migrations() -> tuple[
         (10, ensure_preparation_references_v10),
         (11, ensure_enrichment_snapshot_references_v11),
         (12, ensure_scoring_references_v12),
+        (13, ensure_stage_state_references_v13),
     )
 
 
@@ -1342,28 +1346,34 @@ def ensure_state_tables(conn: sqlite3.Connection | None = None) -> list[str]:
     if conn is None:
         conn = get_connection()
 
-    conn.execute("""
-        CREATE TABLE IF NOT EXISTS job_stage_states (
-            job_url             TEXT NOT NULL,
-            stage               TEXT NOT NULL,
-            state               TEXT NOT NULL DEFAULT 'pending',
-            attempt_count       INTEGER DEFAULT 0,
-            max_attempts        INTEGER,
-            started_at          TEXT,
-            updated_at          TEXT NOT NULL,
-            finished_at         TEXT,
-            duration_ms         INTEGER,
-            error_code          TEXT,
-            error_message       TEXT,
-            retryable           INTEGER DEFAULT 1,
-            blocked_by_json     TEXT,
-            next_action         TEXT,
-            metadata_json       TEXT,
-            version             INTEGER NOT NULL DEFAULT 0,
-            PRIMARY KEY (job_url, stage),
-            FOREIGN KEY (job_url) REFERENCES jobs(url) ON DELETE CASCADE
-        )
-    """)
+    current_schema_version = int(
+        conn.execute("PRAGMA user_version").fetchone()[0]
+    )
+    if current_schema_version >= _STAGE_STATE_REFERENCE_SCHEMA_VERSION:
+        _create_job_stage_states_v13(conn)
+    else:
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS job_stage_states (
+                job_url             TEXT NOT NULL,
+                stage               TEXT NOT NULL,
+                state               TEXT NOT NULL DEFAULT 'pending',
+                attempt_count       INTEGER DEFAULT 0,
+                max_attempts        INTEGER,
+                started_at          TEXT,
+                updated_at          TEXT NOT NULL,
+                finished_at         TEXT,
+                duration_ms         INTEGER,
+                error_code          TEXT,
+                error_message       TEXT,
+                retryable           INTEGER DEFAULT 1,
+                blocked_by_json     TEXT,
+                next_action         TEXT,
+                metadata_json       TEXT,
+                version             INTEGER NOT NULL DEFAULT 0,
+                PRIMARY KEY (job_url, stage),
+                FOREIGN KEY (job_url) REFERENCES jobs(url) ON DELETE CASCADE
+            )
+        """)
     # Forward-migrate columns added after the initial normalized stage table.
     # This is deliberately additive: existing lifecycle rows and application
     # facts are preserved while API-seeded or older local databases become
@@ -1425,10 +1435,16 @@ def ensure_state_tables(conn: sqlite3.Connection | None = None) -> list[str]:
         CREATE INDEX IF NOT EXISTS idx_job_stage_states_stage_state
         ON job_stage_states(stage, state, updated_at DESC)
     """)
-    conn.execute("""
+    stage_reference = (
+        "job_id" if "job_id" in existing_cols else "job_url"
+    )
+    tenant_prefix = "tenant_id, " if stage_reference == "job_id" else ""
+    conn.execute(
+        f"""
         CREATE INDEX IF NOT EXISTS idx_job_stage_states_job
-        ON job_stage_states(job_url, stage)
-    """)
+        ON job_stage_states({tenant_prefix}{stage_reference}, stage)
+        """
+    )
     conn.execute("""
         CREATE INDEX IF NOT EXISTS idx_job_events_job_time
         ON job_events(job_url, occurred_at DESC, event_id DESC)
@@ -1835,15 +1851,22 @@ def _backfill_legacy_stage_states(conn: sqlite3.Connection) -> None:
     """
     # Find legacy jobs (any row in ``jobs``) that have NO existing stage
     # rows.  This is the universe to backfill.
+    stage_state_columns = _table_columns(conn, "job_stage_states")
+    stable_stage_references = "job_id" in stage_state_columns
+    stage_join = (
+        "jss.tenant_id = j.tenant_id AND jss.job_id = j.job_id"
+        if stable_stage_references
+        else "jss.job_url = j.url"
+    )
     legacy_jobs = conn.execute(
-        """
+        f"""
         SELECT j.url, j.discovered_at, j.full_description, j.detail_scraped_at,
                j.detail_error, j.fit_score, j.scored_at,
                j.tailored_resume_path, j.tailored_at, j.tailor_attempts,
                j.cover_letter_path, j.cover_letter_at, j.cover_attempts,
                j.applied_at, j.apply_status, j.apply_error
         FROM jobs j
-        LEFT JOIN job_stage_states jss ON jss.job_url = j.url
+        LEFT JOIN job_stage_states jss ON {stage_join}
         GROUP BY j.url
         HAVING COUNT(jss.stage) = 0
         """
@@ -1865,17 +1888,44 @@ def _backfill_legacy_stage_states(conn: sqlite3.Connection) -> None:
         started_at: str | None = None,
         finished_at: str | None = None,
     ) -> None:
+        if stable_stage_references:
+            identity = conn.execute(
+                """
+                SELECT tenant_id, job_id
+                FROM jobs
+                WHERE url = ?
+                LIMIT 1
+                """,
+                (job_url,),
+            ).fetchone()
+            if identity is None:
+                raise RuntimeError(
+                    "stage-state backfill could not resolve stable identity"
+                )
+            reference_columns = "tenant_id, job_id"
+            reference_values: tuple[Any, ...] = (
+                str(identity[0]),
+                str(identity[1]),
+            )
+            reference_placeholders = "?, ?"
+        else:
+            reference_columns = "job_url"
+            reference_values = (job_url,)
+            reference_placeholders = "?"
         conn.execute(
-            """
+            f"""
             INSERT OR IGNORE INTO job_stage_states (
-                job_url, stage, state, attempt_count, max_attempts,
+                {reference_columns}, stage, state, attempt_count, max_attempts,
                 started_at, updated_at, finished_at, duration_ms,
                 error_code, error_message, retryable, blocked_by_json,
                 next_action, metadata_json, version
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL, ?, ?, ?, NULL, NULL, NULL, 0)
+            ) VALUES (
+                {reference_placeholders}, ?, ?, ?, ?, ?, ?, ?, NULL,
+                ?, ?, ?, NULL, NULL, NULL, 0
+            )
             """,
             (
-                job_url,
+                *reference_values,
                 stage,
                 state,
                 attempt_count,
@@ -4266,6 +4316,13 @@ def _reassign_discovery_identity_references(
         )
     if _has_scoring_reference_schema_v12(conn):
         _reassign_scoring_references_v12(
+            conn,
+            tenant_id=tenant_id,
+            losing_job_id=losing_job_id,
+            surviving_job_id=surviving_job_id,
+        )
+    if _has_stage_state_reference_schema_v13(conn):
+        _reassign_stage_state_references_v13(
             conn,
             tenant_id=tenant_id,
             losing_job_id=losing_job_id,
@@ -7887,6 +7944,421 @@ def _reassign_scoring_references_v12(
     )
 
 
+_STAGE_STATE_REFERENCE_SCHEMA_VERSION = 13
+_STAGE_STATE_REFERENCE_TABLES = ("job_stage_states",)
+_STAGE_STATE_VALUE_COLUMNS = (
+    "state",
+    "attempt_count",
+    "max_attempts",
+    "started_at",
+    "updated_at",
+    "finished_at",
+    "duration_ms",
+    "error_code",
+    "error_message",
+    "retryable",
+    "blocked_by_json",
+    "next_action",
+    "metadata_json",
+    "version",
+)
+
+
+def _create_job_stage_states_v13(
+    conn: sqlite3.Connection,
+    *,
+    table_name: str = "job_stage_states",
+) -> None:
+    conn.execute(
+        f"""
+        CREATE TABLE IF NOT EXISTS {table_name} (
+            tenant_id          TEXT NOT NULL DEFAULT 'local',
+            job_id             TEXT NOT NULL,
+            stage              TEXT NOT NULL,
+            state              TEXT NOT NULL DEFAULT 'pending',
+            attempt_count      INTEGER DEFAULT 0,
+            max_attempts       INTEGER,
+            started_at         TEXT,
+            updated_at         TEXT NOT NULL,
+            finished_at        TEXT,
+            duration_ms        INTEGER,
+            error_code         TEXT,
+            error_message      TEXT,
+            retryable          INTEGER DEFAULT 1,
+            blocked_by_json    TEXT,
+            next_action        TEXT,
+            metadata_json      TEXT,
+            version            INTEGER NOT NULL DEFAULT 0,
+            PRIMARY KEY (tenant_id, job_id, stage),
+            FOREIGN KEY (tenant_id, job_id)
+                REFERENCES jobs(tenant_id, job_id) ON DELETE CASCADE
+        )
+        """
+    )
+
+
+def _create_job_stage_state_indexes_v13(
+    conn: sqlite3.Connection,
+) -> None:
+    conn.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_job_stage_states_stage_state
+        ON job_stage_states(stage, state, updated_at DESC)
+        """
+    )
+    conn.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_job_stage_states_job
+        ON job_stage_states(tenant_id, job_id, stage)
+        """
+    )
+
+
+def _has_stage_state_reference_schema_v13(
+    conn: sqlite3.Connection,
+) -> bool:
+    return (
+        "job_id" in _table_columns(conn, "job_stage_states")
+        and "job_url" not in _table_columns(conn, "job_stage_states")
+        and _primary_key_columns(conn, "job_stage_states")
+        == ("tenant_id", "job_id", "stage")
+        and _has_composite_job_id_foreign_key(
+            conn,
+            "job_stage_states",
+            "job_id",
+        )
+        and _has_index(
+            conn,
+            "job_stage_states",
+            "idx_job_stage_states_stage_state",
+            ("stage", "state", "updated_at"),
+            unique=False,
+        )
+        and _has_index(
+            conn,
+            "job_stage_states",
+            "idx_job_stage_states_job",
+            ("tenant_id", "job_id", "stage"),
+            unique=False,
+        )
+    )
+
+
+def _stage_state_timestamp_rank(value: Any) -> tuple[float, str]:
+    raw = str(value or "")
+    try:
+        parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        timestamp = parsed.astimezone(timezone.utc).timestamp()
+    except (OverflowError, ValueError):
+        timestamp = float("-inf")
+    return timestamp, raw
+
+
+def _merge_stage_state_rows_v13(
+    rows: list[tuple[str, int, tuple[Any, ...]]],
+) -> tuple[Any, ...]:
+    """Select one current lifecycle fact without lowering safety counters."""
+    if not rows:
+        raise RuntimeError("stage-state merge requires at least one row")
+    selected_source, selected_rowid, selected_values = max(
+        rows,
+        key=lambda item: (
+            _stage_state_timestamp_rank(
+                item[2][_STAGE_STATE_VALUE_COLUMNS.index("updated_at")]
+            ),
+            int(item[2][_STAGE_STATE_VALUE_COLUMNS.index("version")] or 0),
+            item[0],
+            item[1],
+        ),
+    )
+    del selected_source, selected_rowid
+    merged = list(selected_values)
+    attempt_index = _STAGE_STATE_VALUE_COLUMNS.index("attempt_count")
+    version_index = _STAGE_STATE_VALUE_COLUMNS.index("version")
+    merged[attempt_index] = max(
+        int(values[attempt_index] or 0)
+        for _source, _rowid, values in rows
+    )
+    merged[version_index] = max(
+        int(values[version_index] or 0)
+        for _source, _rowid, values in rows
+    )
+    return tuple(merged)
+
+
+def _normalize_stage_state_aggregate_versions_v13(
+    rows: list[tuple[Any, ...]],
+) -> list[tuple[Any, ...]]:
+    """Keep the optimistic-lock version uniform across every Job aggregate."""
+    version_index = 3 + _STAGE_STATE_VALUE_COLUMNS.index("version")
+    aggregate_versions: dict[tuple[str, str], int] = {}
+    for row in rows:
+        aggregate_key = (str(row[0]), str(row[1]))
+        aggregate_versions[aggregate_key] = max(
+            aggregate_versions.get(aggregate_key, 0),
+            int(row[version_index] or 0),
+        )
+    normalized: list[tuple[Any, ...]] = []
+    for row in rows:
+        values = list(row)
+        values[version_index] = aggregate_versions[
+            (str(row[0]), str(row[1]))
+        ]
+        normalized.append(tuple(values))
+    return normalized
+
+
+def _normalize_persisted_stage_state_versions_v13(
+    conn: sqlite3.Connection,
+) -> None:
+    conn.execute(
+        """
+        UPDATE job_stage_states AS state
+        SET version = (
+            SELECT MAX(peer.version)
+            FROM job_stage_states AS peer
+            WHERE peer.tenant_id = state.tenant_id
+              AND peer.job_id = state.job_id
+        )
+        """
+    )
+
+
+def _canonical_stage_state_rows_v13(
+    conn: sqlite3.Connection,
+) -> list[tuple[Any, ...]]:
+    rows = conn.execute(
+        f"""
+        SELECT rowid, job_url, stage, {", ".join(_STAGE_STATE_VALUE_COLUMNS)}
+        FROM job_stage_states
+        ORDER BY job_url, stage, rowid
+        """
+    ).fetchall()
+    grouped: dict[
+        tuple[str, str, str],
+        list[tuple[str, int, tuple[Any, ...]]],
+    ] = {}
+    for row in rows:
+        job_url = str(row[1])
+        stage = str(row[2])
+        stable_job_id = _resolve_job_reference_value(
+            conn,
+            tenant_id="local",
+            reference=job_url,
+            legacy_url=True,
+        )
+        if stable_job_id is None:
+            raise RuntimeError(
+                "stage-state reference migration could not resolve "
+                f"job_stage_states.job_url={job_url!r}"
+            )
+        grouped.setdefault(
+            ("local", stable_job_id, stage),
+            [],
+        ).append(
+            (
+                job_url,
+                int(row[0]),
+                tuple(row[index] for index in range(3, len(row))),
+            )
+        )
+    return _normalize_stage_state_aggregate_versions_v13(
+        [
+            (
+                tenant_id,
+                job_id,
+                stage,
+                *_merge_stage_state_rows_v13(group_rows),
+            )
+            for (tenant_id, job_id, stage), group_rows in sorted(grouped.items())
+        ]
+    )
+
+
+def ensure_stage_state_references_v13(
+    conn: sqlite3.Connection | None = None,
+) -> list[str]:
+    """Move canonical per-stage lifecycle state to stable JobId references."""
+    if conn is None:
+        conn = get_connection()
+
+    current = _assert_schema_version_supported(conn)
+    if current >= _STAGE_STATE_REFERENCE_SCHEMA_VERSION:
+        return []
+    if current != _SCORING_REFERENCE_SCHEMA_VERSION:
+        raise RuntimeError(
+            "stage-state reference migration requires scoring schema v12"
+        )
+
+    conn.execute("SAVEPOINT stage_state_references_v13")
+    try:
+        if not _has_scoring_reference_schema_v12(conn):
+            raise RuntimeError(
+                "stage-state reference migration requires the stable "
+                "scoring reference schema"
+            )
+        if _has_stage_state_reference_schema_v13(conn):
+            expected_count = int(
+                conn.execute(
+                    "SELECT COUNT(*) FROM job_stage_states"
+                ).fetchone()[0]
+            )
+            _normalize_persisted_stage_state_versions_v13(conn)
+        else:
+            canonical_rows = _canonical_stage_state_rows_v13(conn)
+            expected_count = len(canonical_rows)
+            conn.execute("DROP TABLE IF EXISTS job_stage_states_v13")
+            _create_job_stage_states_v13(
+                conn,
+                table_name="job_stage_states_v13",
+            )
+            conn.executemany(
+                f"""
+                INSERT INTO job_stage_states_v13 (
+                    tenant_id, job_id, stage,
+                    {", ".join(_STAGE_STATE_VALUE_COLUMNS)}
+                ) VALUES ({", ".join("?" for _ in range(17))})
+                """,
+                canonical_rows,
+            )
+            conn.execute("DROP TABLE job_stage_states")
+            conn.execute(
+                "ALTER TABLE job_stage_states_v13 "
+                "RENAME TO job_stage_states"
+            )
+            _create_job_stage_state_indexes_v13(conn)
+        _verify_stage_state_references_v13(
+            conn,
+            expected_count=expected_count,
+        )
+        conn.execute(
+            f"PRAGMA user_version = "
+            f"{_STAGE_STATE_REFERENCE_SCHEMA_VERSION}"
+        )
+        conn.execute("RELEASE SAVEPOINT stage_state_references_v13")
+        conn.commit()
+    except BaseException:
+        conn.execute("ROLLBACK TO SAVEPOINT stage_state_references_v13")
+        conn.execute("RELEASE SAVEPOINT stage_state_references_v13")
+        raise
+
+    return list(_STAGE_STATE_REFERENCE_TABLES)
+
+
+def _verify_stage_state_references_v13(
+    conn: sqlite3.Connection,
+    *,
+    expected_count: int,
+) -> None:
+    if not _has_stage_state_reference_schema_v13(conn):
+        raise RuntimeError(
+            "stage-state reference migration did not install the "
+            "canonical schema"
+        )
+    observed_count = int(
+        conn.execute("SELECT COUNT(*) FROM job_stage_states").fetchone()[0]
+    )
+    if observed_count != expected_count:
+        raise RuntimeError(
+            "stage-state reference migration changed the canonical row "
+            f"count: expected {expected_count}, found {observed_count}"
+        )
+    orphan = conn.execute(
+        """
+        SELECT state.job_id
+        FROM job_stage_states AS state
+        LEFT JOIN jobs j
+          ON j.tenant_id = state.tenant_id
+         AND j.job_id = state.job_id
+        WHERE j.job_id IS NULL
+        LIMIT 1
+        """
+    ).fetchone()
+    if orphan is not None:
+        raise RuntimeError(
+            "stage-state reference migration left an unresolved JobId"
+        )
+    for row in conn.execute(
+        "SELECT DISTINCT job_id FROM job_stage_states"
+    ).fetchall():
+        _validate_job_uuid(str(row[0]))
+    foreign_key_error = conn.execute("PRAGMA foreign_key_check").fetchone()
+    if foreign_key_error is not None:
+        raise RuntimeError(
+            "stage-state reference migration found a foreign-key violation"
+        )
+
+
+def _reassign_stage_state_references_v13(
+    conn: sqlite3.Connection,
+    *,
+    tenant_id: str,
+    losing_job_id: str,
+    surviving_job_id: str,
+) -> None:
+    """Merge current lifecycle rows for an in-place identity collision."""
+    if losing_job_id == surviving_job_id:
+        return
+    before_count = int(
+        conn.execute("SELECT COUNT(*) FROM job_stage_states").fetchone()[0]
+    )
+    raw_rows = conn.execute(
+        f"""
+        SELECT rowid, job_id, stage, {", ".join(_STAGE_STATE_VALUE_COLUMNS)}
+        FROM job_stage_states
+        WHERE tenant_id = ? AND job_id IN (?, ?)
+        ORDER BY job_id, stage, rowid
+        """,
+        (tenant_id, losing_job_id, surviving_job_id),
+    ).fetchall()
+    grouped: dict[
+        str,
+        list[tuple[str, int, tuple[Any, ...]]],
+    ] = {}
+    for row in raw_rows:
+        grouped.setdefault(str(row[2]), []).append(
+            (
+                str(row[1]),
+                int(row[0]),
+                tuple(row[index] for index in range(3, len(row))),
+            )
+        )
+    merged_rows = _normalize_stage_state_aggregate_versions_v13(
+        [
+            (
+                tenant_id,
+                surviving_job_id,
+                stage,
+                *_merge_stage_state_rows_v13(stage_rows),
+            )
+            for stage, stage_rows in sorted(grouped.items())
+        ]
+    )
+    conn.execute(
+        """
+        DELETE FROM job_stage_states
+        WHERE tenant_id = ? AND job_id IN (?, ?)
+        """,
+        (tenant_id, losing_job_id, surviving_job_id),
+    )
+    conn.executemany(
+        f"""
+        INSERT INTO job_stage_states (
+            tenant_id, job_id, stage,
+            {", ".join(_STAGE_STATE_VALUE_COLUMNS)}
+        ) VALUES ({", ".join("?" for _ in range(17))})
+        """,
+        merged_rows,
+    )
+    expected_count = before_count - len(raw_rows) + len(merged_rows)
+    _verify_stage_state_references_v13(
+        conn,
+        expected_count=expected_count,
+    )
+
+
 # ---------------------------------------------------------------------------
 # job_enrichments read fragments — used by every selector / stat that
 # previously read bare ``jobs.full_description`` / ``jobs.application_url``
@@ -7902,7 +8374,9 @@ _ENRICHMENT_JOIN: str = (
     "LEFT JOIN job_enrichments je "
     "ON je.tenant_id = jobs.tenant_id AND je.job_id = jobs.job_id "
     "LEFT JOIN job_stage_states jss_enrich "
-    "ON jss_enrich.job_url = jobs.url AND jss_enrich.stage = 'enrich'"
+    "ON jss_enrich.tenant_id = jobs.tenant_id "
+    "AND jss_enrich.job_id = jobs.job_id "
+    "AND jss_enrich.stage = 'enrich'"
 )
 
 _EFFECTIVE_FULL_DESCRIPTION: str = "COALESCE(je.full_description, jobs.full_description)"
@@ -8034,13 +8508,17 @@ _READY_TAILORED_RESUME_WITH_PDF: str = (
 
 _LATEST_STAGE_ATTEMPTS_JOIN: str = (
     "LEFT JOIN ("
-    "SELECT job_url AS jss_t_job_url, attempt_count AS jss_t_attempts, state AS jss_t_state "
+    "SELECT tenant_id AS jss_t_tenant_id, job_id AS jss_t_job_id, "
+    "attempt_count AS jss_t_attempts, state AS jss_t_state "
     "FROM job_stage_states WHERE stage = 'tailor'"
-    ") jss_t ON jss_t.jss_t_job_url = jobs.url "
+    ") jss_t ON jss_t.jss_t_tenant_id = jobs.tenant_id "
+    "AND jss_t.jss_t_job_id = jobs.job_id "
     "LEFT JOIN ("
-    "SELECT job_url AS jss_c_job_url, attempt_count AS jss_c_attempts, state AS jss_c_state "
+    "SELECT tenant_id AS jss_c_tenant_id, job_id AS jss_c_job_id, "
+    "attempt_count AS jss_c_attempts, state AS jss_c_state "
     "FROM job_stage_states WHERE stage = 'cover'"
-    ") jss_c ON jss_c.jss_c_job_url = jobs.url"
+    ") jss_c ON jss_c.jss_c_tenant_id = jobs.tenant_id "
+    "AND jss_c.jss_c_job_id = jobs.job_id"
 )
 
 # COALESCE picks the canonical (job_stage_states) counter first, falling
@@ -8059,10 +8537,12 @@ _COVER_NOT_EXHAUSTED: str = "(jss_c.jss_c_state IS NULL OR jss_c.jss_c_state != 
 # ``job_scores``, downstream work requires a succeeded score-stage row.
 _SCORE_DOWNSTREAM_STATE_JOIN: str = (
     "LEFT JOIN ("
-    "SELECT job_url AS jss_s_job_url, state AS jss_s_state, "
+    "SELECT tenant_id AS jss_s_tenant_id, job_id AS jss_s_job_id, "
+    "state AS jss_s_state, "
     "attempt_count AS jss_s_attempts "
     "FROM job_stage_states WHERE stage = 'score'"
-    ") jss_s ON jss_s.jss_s_job_url = jobs.url "
+    ") jss_s ON jss_s.jss_s_tenant_id = jobs.tenant_id "
+    "AND jss_s.jss_s_job_id = jobs.job_id "
     "LEFT JOIN ("
     "SELECT DISTINCT tenant_id AS jss_stale_tenant_id, "
     "job_id AS jss_stale_job_id "
@@ -8395,13 +8875,16 @@ def count_ready_to_apply(
         _ENRICHMENT_NOT_QUARANTINED,
         "NOT EXISTS ("
         "SELECT 1 FROM job_stage_states jss_active "
-        "WHERE jss_active.job_url = jobs.url "
+        "WHERE jss_active.tenant_id = jobs.tenant_id "
+        "AND jss_active.job_id = jobs.job_id "
         "AND jss_active.stage = 'apply' "
         "AND jss_active.state IN ('running', 'succeeded')"
         ")",
         "COALESCE(("
         "SELECT jss_a.attempt_count FROM job_stage_states jss_a "
-        "WHERE jss_a.job_url = jobs.url AND jss_a.stage = 'apply' LIMIT 1"
+        "WHERE jss_a.tenant_id = jobs.tenant_id "
+        "AND jss_a.job_id = jobs.job_id "
+        "AND jss_a.stage = 'apply' LIMIT 1"
         "), 0) < ?",
         "(ar.ar_status IS NULL OR ar.ar_status NOT IN ('starting', 'in_progress'))",
     ]

--- a/workers/automation/src/jobctrl/digest.py
+++ b/workers/automation/src/jobctrl/digest.py
@@ -383,6 +383,34 @@ def _count_pending_approvals(conn: sqlite3.Connection) -> int:
 def _apply_queue_rows(conn: sqlite3.Connection) -> list[Any]:
     if not _table_exists(conn, "job_list_projections") or not _table_exists(conn, "job_stage_states"):
         return []
+    stable_stage_references = (
+        "job_id" in _table_columns(conn, "job_stage_states")
+        and _table_exists(conn, "jobs")
+    )
+    apply_stage_source_sql = (
+        """
+                SELECT s.tenant_id, j.url AS job_url, s.state,
+                       ROW_NUMBER() OVER (
+                           PARTITION BY s.tenant_id, s.job_id
+                           ORDER BY COALESCE(s.updated_at, '') DESC, s.rowid DESC
+                       ) AS row_num
+                FROM job_stage_states s
+                JOIN jobs j
+                  ON j.tenant_id = s.tenant_id
+                 AND j.job_id = s.job_id
+                WHERE s.stage = 'apply'
+        """
+        if stable_stage_references
+        else """
+                SELECT 'local' AS tenant_id, s.job_url, s.state,
+                       ROW_NUMBER() OVER (
+                           PARTITION BY s.job_url
+                           ORDER BY COALESCE(s.updated_at, '') DESC, s.rowid DESC
+                       ) AS row_num
+                FROM job_stage_states s
+                WHERE s.stage = 'apply'
+        """
+    )
     latest_decision_sql, latest_decision_params = _latest_decision_cte(conn)
     latest_apply_run_sql = _latest_apply_run_cte(conn)
     active_clauses, active_params = _active_job_clauses(conn, "jlp")
@@ -392,15 +420,9 @@ def _apply_queue_rows(conn: sqlite3.Connection) -> list[Any]:
         + latest_apply_run_sql
         + f"""
         , latest_digest_apply_stage AS (
-            SELECT job_url, state
+            SELECT tenant_id, job_url, state
             FROM (
-                SELECT job_url, state,
-                       ROW_NUMBER() OVER (
-                           PARTITION BY job_url
-                           ORDER BY COALESCE(updated_at, '') DESC, rowid DESC
-                       ) AS row_num
-                FROM job_stage_states
-                WHERE stage = 'apply'
+                {apply_stage_source_sql}
             )
             WHERE row_num = 1
         )
@@ -418,7 +440,8 @@ def _apply_queue_rows(conn: sqlite3.Connection) -> list[Any]:
                latest_apply_run.result AS apply_run_result
         FROM job_list_projections jlp
         INNER JOIN latest_digest_apply_stage apply_stage
-          ON apply_stage.job_url = jlp.job_id
+          ON apply_stage.tenant_id = jlp.tenant_id
+         AND apply_stage.job_url = jlp.job_id
         LEFT JOIN latest_digest_decision latest_decision
           ON latest_decision.job_key = jlp.job_id
         LEFT JOIN latest_digest_apply_run latest_apply_run

--- a/workers/automation/src/jobctrl/enrichment/detail.py
+++ b/workers/automation/src/jobctrl/enrichment/detail.py
@@ -840,15 +840,16 @@ def _unblock_enrich_stage_if_blocked(conn: sqlite3.Connection, url: str) -> None
     valid, honoring this feature's "a later run re-evaluates robots" promise.
     No-op unless the stage is currently ``blocked``.
     """
-    from jobctrl.state import record_job_event, set_stage_state
+    from jobctrl.state import (
+        get_stage_state_row,
+        record_job_event,
+        set_stage_state,
+    )
 
-    row = conn.execute(
-        "SELECT state FROM job_stage_states WHERE job_url = ? AND stage = 'enrich'",
-        (url,),
-    ).fetchone()
+    row = get_stage_state_row(conn, url, "enrich")
     if row is None:
         return
-    current = row[0] if not isinstance(row, dict) else row["state"]
+    current = row["state"]
     if current != "blocked":
         return
     set_stage_state(conn, url, "enrich", "pending")

--- a/workers/automation/src/jobctrl/infrastructure/discovery/production_wiring.py
+++ b/workers/automation/src/jobctrl/infrastructure/discovery/production_wiring.py
@@ -86,7 +86,12 @@ from jobctrl.infrastructure.enrichment import (
     SqliteEnrichmentRepository,
     SqlitePostingSnapshotSetRepository,
 )
-from jobctrl.state import ensure_job_stage_rows, record_job_event, set_stage_state
+from jobctrl.state import (
+    ensure_job_stage_rows,
+    get_stage_state_row,
+    record_job_event,
+    set_stage_state,
+)
 
 
 def utc_now() -> str:
@@ -698,10 +703,7 @@ def _promote_ats_source_description_to_enrichment(
 
     job_url = resolved_job.storage_url.value
     ensure_job_stage_rows(conn, job_url, discovered_at=observed_at)
-    stage_row = conn.execute(
-        "SELECT state FROM job_stage_states WHERE job_url = ? AND stage = 'enrich'",
-        (job_url,),
-    ).fetchone()
+    stage_row = get_stage_state_row(conn, job_url, "enrich")
     stage_state = str(stage_row["state"] or "") if stage_row is not None else ""
     if stage_state != "succeeded":
         if stage_state != "running":

--- a/workers/automation/src/jobctrl/infrastructure/pipeline/sqlite_repository.py
+++ b/workers/automation/src/jobctrl/infrastructure/pipeline/sqlite_repository.py
@@ -33,7 +33,13 @@ from jobctrl.domain.pipeline_types import (
     serialize_stage_state,
 )
 from jobctrl.domain.tenant import TenantId
-from jobctrl.state import reconcile_dependency_blockers, record_job_event, set_stage_state
+from jobctrl.state import (
+    _stage_state_predicate,
+    get_stage_state_job_urls,
+    reconcile_dependency_blockers,
+    record_job_event,
+    set_stage_state,
+)
 
 
 def _json_loads(value: str | None, default: Any) -> Any:
@@ -235,9 +241,17 @@ class SqlitePipelineStateRepository:
     # -- port methods ---------------------------------------------------------
 
     def load(self, tenant_id: TenantId, job_url: str) -> JobPipelineState | None:
+        try:
+            predicate, params = _stage_state_predicate(
+                self._conn,
+                job_url,
+                tenant_id=str(tenant_id),
+            )
+        except ValueError:
+            return None
         rows = self._conn.execute(
-            "SELECT * FROM job_stage_states WHERE job_url = ?",
-            (job_url,),
+            f"SELECT * FROM job_stage_states WHERE {predicate}",
+            params,
         ).fetchall()
         if not rows:
             return None
@@ -315,20 +329,15 @@ class SqlitePipelineStateRepository:
         stage: str,
         state_filter: str | None = None,
     ) -> list[JobPipelineState]:
-        if state_filter:
-            rows = self._conn.execute(
-                "SELECT DISTINCT job_url FROM job_stage_states WHERE stage = ? AND state = ?",
-                (stage, state_filter),
-            ).fetchall()
-        else:
-            rows = self._conn.execute(
-                "SELECT DISTINCT job_url FROM job_stage_states WHERE stage = ?",
-                (stage,),
-            ).fetchall()
+        job_urls = get_stage_state_job_urls(
+            self._conn,
+            stage=stage,
+            states=(state_filter,) if state_filter else None,
+            tenant_id=str(tenant_id),
+        )
 
         results: list[JobPipelineState] = []
-        for row in rows:
-            job_url = row[0] if not isinstance(row, dict) else row["job_url"]
+        for job_url in job_urls:
             agg = self.load(tenant_id, job_url)
             if agg is not None:
                 results.append(agg)
@@ -338,9 +347,13 @@ class SqlitePipelineStateRepository:
 
     def _existing_state_strings(self, job_url: str) -> dict[str, str]:
         """Return the persisted ``stage -> state`` map for change detection."""
+        predicate, params = _stage_state_predicate(
+            self._conn,
+            job_url,
+        )
         rows = self._conn.execute(
-            "SELECT stage, state FROM job_stage_states WHERE job_url = ?",
-            (job_url,),
+            f"SELECT stage, state FROM job_stage_states WHERE {predicate}",
+            params,
         ).fetchall()
         return {row["stage"]: row["state"] for row in rows}
 

--- a/workers/automation/src/jobctrl/infrastructure/projections/projection_builder.py
+++ b/workers/automation/src/jobctrl/infrastructure/projections/projection_builder.py
@@ -2113,8 +2113,15 @@ class ProjectionBuilder:
     def _load_stage_projections(self, job_url: str) -> list[StageProjection]:
         try:
             rows = self._conn.execute(
-                "SELECT * FROM job_stage_states WHERE job_url = ?",
-                (job_url,),
+                """
+                SELECT s.*
+                FROM job_stage_states s
+                JOIN jobs j
+                  ON j.tenant_id = s.tenant_id
+                 AND j.job_id = s.job_id
+                WHERE j.tenant_id = ? AND j.url = ?
+                """,
+                (str(self._tenant_id), job_url),
             ).fetchall()
         except sqlite3.OperationalError:
             rows = []
@@ -2696,15 +2703,16 @@ class ProjectionBuilder:
         try:
             rows = self._conn.execute(
                 """
-                SELECT DISTINCT s.job_url AS job_id
+                SELECT DISTINCT j.url AS job_id
                   FROM job_stage_states s
                   JOIN jobs j
-                    ON j.url = s.job_url
+                    ON j.tenant_id = s.tenant_id
+                   AND j.job_id = s.job_id
                   LEFT JOIN job_list_projections p
                     ON p.tenant_id = ?
-                   AND p.job_id = s.job_url
-                 WHERE s.job_url IS NOT NULL
-                   AND TRIM(s.job_url) != ''
+                   AND p.job_id = j.url
+                 WHERE s.job_id IS NOT NULL
+                   AND TRIM(s.job_id) != ''
                    AND (
                      p.job_id IS NULL
                      OR (

--- a/workers/automation/src/jobctrl/infrastructure/scoring/sqlite_repository.py
+++ b/workers/automation/src/jobctrl/infrastructure/scoring/sqlite_repository.py
@@ -46,7 +46,7 @@ from jobctrl.domain.scoring.value_objects import (
     ScoringCriteria,
 )
 from jobctrl.domain.tenant import LOCAL_TENANT, TenantId
-from jobctrl.state import record_job_event, set_stage_state
+from jobctrl.state import get_stage_state_row, record_job_event, set_stage_state
 
 
 class ScoreVersionConflict(ValueError):
@@ -317,10 +317,7 @@ class SqliteScoreStalenessRepository:
             marker.tenant_id,
             marker.job_id,
         )
-        row = self._conn.execute(
-            "SELECT state FROM job_stage_states WHERE job_url = ? AND stage = 'score'",
-            (job_url,),
-        ).fetchone()
+        row = get_stage_state_row(self._conn, job_url, "score")
         state = _row_value(row, "state", 0) if row is not None else None
         if state in (None, "succeeded"):
             set_stage_state(

--- a/workers/automation/src/jobctrl/pipeline/current_policy_selectors.py
+++ b/workers/automation/src/jobctrl/pipeline/current_policy_selectors.py
@@ -133,9 +133,13 @@ def tailoring_current_policy_job_urls(
           ON stale_score.stale_tenant_id = j.tenant_id
          AND stale_score.stale_job_id = j.job_id
         LEFT JOIN job_stage_states score_state
-          ON score_state.job_url = j.url AND score_state.stage = 'score'
+          ON score_state.tenant_id = j.tenant_id
+         AND score_state.job_id = j.job_id
+         AND score_state.stage = 'score'
         LEFT JOIN job_stage_states tailor_state
-          ON tailor_state.job_url = j.url AND tailor_state.stage = 'tailor'
+          ON tailor_state.tenant_id = j.tenant_id
+         AND tailor_state.job_id = j.job_id
+         AND tailor_state.stage = 'tailor'
         LEFT JOIN (
             SELECT m.job_url AS materials_job_url, tr.path AS tailored_resume_path,
                    tr.metadata_json AS tailored_resume_metadata

--- a/workers/automation/src/jobctrl/pipeline/preparation.py
+++ b/workers/automation/src/jobctrl/pipeline/preparation.py
@@ -45,7 +45,7 @@ from jobctrl.preparation.workflow import (
     JobPreparationWorkflow,
     preparation_workflow_id,
 )
-from jobctrl.state import utc_now
+from jobctrl.state import get_stage_state_row, utc_now
 
 log = logging.getLogger(__name__)
 
@@ -651,16 +651,12 @@ def _unselected_work_plan_outcome(
     if row["resume_pdf_path"] and row["cover_pdf_path"]:
         return ("not_eligible", "preparation_already_accounted")
 
-    stage_rows = conn.execute(
-        """
-        SELECT stage, state
-          FROM job_stage_states
-         WHERE job_url = ?
-           AND stage IN ('score', 'tailor', 'cover', 'apply')
-        """,
-        (job_url,),
-    ).fetchall()
-    stage_states = {str(stage_row["stage"]): str(stage_row["state"]) for stage_row in stage_rows}
+    stage_states = {
+        stage: str(stage_row["state"])
+        for stage in ("score", "tailor", "cover", "apply")
+        if (stage_row := get_stage_state_row(conn, job_url, stage))
+        is not None
+    }
     if stage_states.get("apply") == "succeeded":
         return ("not_eligible", "preparation_already_accounted")
     if (

--- a/workers/automation/src/jobctrl/scoring/cover_letter.py
+++ b/workers/automation/src/jobctrl/scoring/cover_letter.py
@@ -45,6 +45,7 @@ from jobctrl.infrastructure.materials import (
 from jobctrl.model_defaults import DEFAULT_PIPELINE_LLM_MODEL_SPEC
 from jobctrl.state import (
     ensure_job_stage_rows,
+    get_stage_state_row,
     record_job_event,
     set_stage_state,
     utc_now,
@@ -318,10 +319,7 @@ def cover_letter_by_url(
 
 
 def _cover_stage_succeeded(conn, job_url: str) -> bool:
-    row = conn.execute(
-        "SELECT state FROM job_stage_states WHERE job_url = ? AND stage = 'cover'",
-        (job_url,),
-    ).fetchone()
+    row = get_stage_state_row(conn, job_url, "cover")
     if row is None:
         return False
     return str(row["state"] if hasattr(row, "keys") else row[0]) == "succeeded"

--- a/workers/automation/src/jobctrl/scoring/scorer.py
+++ b/workers/automation/src/jobctrl/scoring/scorer.py
@@ -67,6 +67,7 @@ from jobctrl.infrastructure.scoring import (
 )
 from jobctrl.state import (
     ensure_job_stage_rows,
+    get_stage_state_row,
     reconcile_score_eligibility_blockers,
     record_job_event,
     set_stage_state,
@@ -743,11 +744,7 @@ def _ensure_existing_score_stage_succeeded(
         return
 
     ensure_job_stage_rows(conn, job_url, discovered_at=job.get("discovered_at"))
-    row = conn.execute(
-        "SELECT state, started_at, attempt_count "
-        "FROM job_stage_states WHERE job_url = ? AND stage = 'score'",
-        (job_url,),
-    ).fetchone()
+    row = get_stage_state_row(conn, job_url, "score")
     state = _row_value(row, "state", 0)
     if state == "succeeded":
         _sync_score_eligibility_stage_state(conn, job_url, score)
@@ -882,10 +879,7 @@ def _score_attempt_count(conn: sqlite3.Connection, job_url: str) -> int:
     the ``pending_score`` ``< 5`` cap can engage and stop a permanently-
     failing job from re-billing the LLM on every batch.
     """
-    row = conn.execute(
-        "SELECT attempt_count FROM job_stage_states WHERE job_url = ? AND stage = 'score'",
-        (job_url,),
-    ).fetchone()
+    row = get_stage_state_row(conn, job_url, "score")
     return int(_row_value(row, "attempt_count", 0) or 0)
 
 

--- a/workers/automation/src/jobctrl/scoring/tailor.py
+++ b/workers/automation/src/jobctrl/scoring/tailor.py
@@ -68,6 +68,7 @@ from jobctrl.infrastructure.scoring import (
 from jobctrl.model_defaults import DEFAULT_PIPELINE_LLM_MODEL_SPEC
 from jobctrl.scoring.employer_analysis import build_analyze_use_case
 from jobctrl.state import (
+    _stage_state_predicate,
     ensure_job_stage_rows,
     reconcile_score_eligibility_blockers,
     record_job_event,
@@ -252,8 +253,9 @@ def _mark_cover_pending_after_tailor_success(
         "WHERE url = ?",
         (job_url,),
     )
+    stage_predicate, stage_params = _stage_state_predicate(conn, job_url)
     conn.execute(
-        """
+        f"""
         UPDATE job_stage_states
         SET state = 'pending',
             attempt_count = 0,
@@ -268,9 +270,9 @@ def _mark_cover_pending_after_tailor_success(
             blocked_by_json = '[]',
             next_action = NULL,
             metadata_json = ?
-        WHERE job_url = ? AND stage = 'cover'
+        WHERE {stage_predicate} AND stage = 'cover'
         """,
-        (now, metadata, job_url),
+        (now, metadata, *stage_params),
     )
     record_job_event(
         conn,

--- a/workers/automation/src/jobctrl/state.py
+++ b/workers/automation/src/jobctrl/state.py
@@ -141,6 +141,154 @@ def _table_exists(conn, table_name: str) -> bool:
     return row is not None
 
 
+def _stage_state_reference_column(conn) -> str:
+    columns = {
+        str(row[1])
+        for row in conn.execute(
+            "PRAGMA table_info(job_stage_states)"
+        ).fetchall()
+    }
+    if "job_id" in columns:
+        return "job_id"
+    if "job_url" in columns:
+        return "job_url"
+    raise RuntimeError("job_stage_states has no Job identity column")
+
+
+def _stable_stage_identity_for_url(
+    conn,
+    job_url: str,
+    *,
+    tenant_id: str = str(LOCAL_TENANT),
+) -> tuple[str, str]:
+    """Resolve an explicit posting URL without confusing UUID-shaped URLs."""
+    row = conn.execute(
+        """
+        SELECT j.tenant_id, j.job_id
+        FROM jobs j
+        WHERE j.tenant_id = ? AND j.url = ?
+        UNION ALL
+        SELECT a.tenant_id, a.job_id
+        FROM job_identity_aliases a
+        JOIN jobs j
+          ON j.tenant_id = a.tenant_id
+         AND j.job_id = a.job_id
+        WHERE a.tenant_id = ?
+          AND a.alias_kind = 'posting_url'
+          AND a.alias_value = ?
+        LIMIT 1
+        """,
+        (tenant_id, job_url, tenant_id, job_url),
+    ).fetchone()
+    if row is None:
+        raise ValueError(f"no stable Job identity for posting URL: {job_url}")
+    return str(row[0]), str(row[1])
+
+
+def _stage_state_reference(
+    conn,
+    job_url: str,
+    *,
+    tenant_id: str = str(LOCAL_TENANT),
+) -> tuple[str, tuple[str, ...]]:
+    if _stage_state_reference_column(conn) == "job_url":
+        return "job_url", (job_url,)
+    resolved_tenant_id, job_id = _stable_stage_identity_for_url(
+        conn,
+        job_url,
+        tenant_id=tenant_id,
+    )
+    return "job_id", (resolved_tenant_id, job_id)
+
+
+def _stage_state_predicate(
+    conn,
+    job_url: str,
+    *,
+    alias: str = "",
+    tenant_id: str = str(LOCAL_TENANT),
+) -> tuple[str, tuple[str, ...]]:
+    prefix = f"{alias}." if alias else ""
+    reference_column, values = _stage_state_reference(
+        conn,
+        job_url,
+        tenant_id=tenant_id,
+    )
+    if reference_column == "job_url":
+        return f"{prefix}job_url = ?", values
+    return (
+        f"{prefix}tenant_id = ? AND {prefix}job_id = ?",
+        values,
+    )
+
+
+def get_stage_state_row(
+    conn,
+    job_url: str,
+    stage: str,
+    *,
+    tenant_id: str = str(LOCAL_TENANT),
+):
+    """Load one canonical stage row through the URL compatibility boundary."""
+    predicate, params = _stage_state_predicate(
+        conn,
+        job_url,
+        tenant_id=tenant_id,
+    )
+    return conn.execute(
+        f"""
+        SELECT *
+        FROM job_stage_states
+        WHERE {predicate} AND stage = ?
+        LIMIT 1
+        """,
+        (*params, stage),
+    ).fetchone()
+
+
+def get_stage_state_job_urls(
+    conn,
+    *,
+    stage: str,
+    states: tuple[str, ...] | None = None,
+    tenant_id: str = str(LOCAL_TENANT),
+) -> list[str]:
+    """Return current storage URLs for stage rows selected by lifecycle state."""
+    reference_column = _stage_state_reference_column(conn)
+    state_filter = ""
+    params: list[Any] = [stage]
+    if states:
+        state_filter = (
+            f" AND s.state IN ({', '.join('?' for _ in states)})"
+        )
+        params.extend(states)
+    if reference_column == "job_url":
+        rows = conn.execute(
+            f"""
+            SELECT DISTINCT s.job_url
+            FROM job_stage_states s
+            WHERE s.stage = ?{state_filter}
+            ORDER BY s.job_url
+            """,
+            params,
+        ).fetchall()
+    else:
+        params.insert(0, tenant_id)
+        rows = conn.execute(
+            f"""
+            SELECT DISTINCT j.url
+            FROM job_stage_states s
+            JOIN jobs j
+              ON j.tenant_id = s.tenant_id
+             AND j.job_id = s.job_id
+            WHERE s.tenant_id = ? AND s.stage = ?{state_filter}
+            ORDER BY j.url
+            """,
+            params,
+        ).fetchall()
+    return [str(row[0]) for row in rows]
+
+
 def _source_from_discovery_run_id(run_id: str) -> str:
     parts = run_id.split(":")
     if len(parts) >= 3 and parts[0] == "discovery":
@@ -211,15 +359,16 @@ def _validate_stage_transition(conn, job_url: str, stage: str, target_state: str
     the transition is always allowed. If a row exists and the state is
     already the target, the call is idempotent — also allowed.
     """
-    row = conn.execute(
-        "SELECT state FROM job_stage_states WHERE job_url = ? AND stage = ?",
-        (job_url, stage),
-    ).fetchone()
+    row = get_stage_state_row(conn, job_url, stage)
     if row is None:
         # No existing row — this is an INSERT, always valid.
         return
 
-    current_state_str: str = row[0] if not isinstance(row, dict) else row["state"]
+    current_state_str = str(
+        row["state"]
+        if hasattr(row, "keys") and "state" in row.keys()
+        else row[0]
+    )
     if current_state_str == target_state:
         # Idempotent write — same state, always allowed.
         return
@@ -247,18 +396,51 @@ def _validate_stage_transition(conn, job_url: str, stage: str, target_state: str
 def ensure_job_stage_rows(conn, job_url: str, *, discovered_at: str | None = None) -> None:
     """Ensure a row exists for every stage for one job."""
     now = utc_now()
+    reference_column, reference_values = _stage_state_reference(
+        conn,
+        job_url,
+    )
+    if reference_column == "job_url":
+        reference_columns = "job_url"
+        reference_placeholders = "?"
+        reference_predicate = "job_url = ?"
+    else:
+        reference_columns = "tenant_id, job_id"
+        reference_placeholders = "?, ?"
+        reference_predicate = "tenant_id = ? AND job_id = ?"
+    aggregate_version = int(
+        conn.execute(
+            f"""
+            SELECT COALESCE(MAX(version), 0)
+            FROM job_stage_states
+            WHERE {reference_predicate}
+            """,
+            reference_values,
+        ).fetchone()[0]
+    )
     for stage in STAGE_ORDER:
         state = "succeeded" if stage == "discover" else "pending"
         attempt_count = 1 if stage == "discover" and discovered_at else 0
         started_at = discovered_at if stage == "discover" else None
         finished_at = discovered_at if stage == "discover" else None
         conn.execute(
-            """
+            f"""
             INSERT OR IGNORE INTO job_stage_states (
-                job_url, stage, state, attempt_count, max_attempts, started_at, updated_at, finished_at
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                {reference_columns}, stage, state, attempt_count, max_attempts,
+                started_at, updated_at, finished_at, version
+            ) VALUES ({reference_placeholders}, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
-            (job_url, stage, state, attempt_count, MAX_ATTEMPTS.get(stage), started_at, now, finished_at),
+            (
+                *reference_values,
+                stage,
+                state,
+                attempt_count,
+                MAX_ATTEMPTS.get(stage),
+                started_at,
+                now,
+                finished_at,
+                aggregate_version,
+            ),
         )
 
 
@@ -319,20 +501,39 @@ def set_stage_state(
         if expected_version is not None
         else ""
     )
+    reference_column, reference_values = _stage_state_reference(
+        conn,
+        job_url,
+    )
+    if reference_column == "job_url":
+        reference_columns = "job_url"
+        reference_parameters = ":job_url"
+        conflict_columns = "job_url, stage"
+        reference_bindings: dict[str, Any] = {"job_url": job_url}
+    else:
+        reference_columns = "tenant_id, job_id"
+        reference_parameters = ":tenant_id, :job_id"
+        conflict_columns = "tenant_id, job_id, stage"
+        reference_bindings = {
+            "tenant_id": reference_values[0],
+            "job_id": reference_values[1],
+        }
 
     cur = conn.execute(
         f"""
         INSERT INTO job_stage_states (
-            job_url, stage, state, attempt_count, max_attempts, started_at, updated_at,
+            {reference_columns}, stage, state, attempt_count, max_attempts,
+            started_at, updated_at,
             finished_at, duration_ms, error_code, error_message, retryable,
             blocked_by_json, next_action, metadata_json, version
         ) VALUES (
-            :job_url, :stage, :state, COALESCE(:attempt_count, 0), :max_attempts,
+            {reference_parameters}, :stage, :state,
+            COALESCE(:attempt_count, 0), :max_attempts,
             :started_at, :now, :finished_at, :duration, :error_code, :error_message,
             COALESCE(:retry_value, 1), :blocked_by_json, :next_action, :metadata_json,
             :new_version
         )
-        ON CONFLICT(job_url, stage) DO UPDATE SET
+        ON CONFLICT({conflict_columns}) DO UPDATE SET
             state = excluded.state,
             attempt_count = COALESCE(excluded.attempt_count, job_stage_states.attempt_count),
             max_attempts = COALESCE(excluded.max_attempts, job_stage_states.max_attempts),
@@ -353,7 +554,7 @@ def set_stage_state(
         {version_guard}
         """,
         {
-            "job_url": job_url,
+            **reference_bindings,
             "stage": stage,
             "state": state,
             "attempt_count": attempt_count,
@@ -374,13 +575,8 @@ def set_stage_state(
     )
 
     if expected_version is not None and cur.rowcount == 0:
-        existing = conn.execute(
-            "SELECT version FROM job_stage_states WHERE job_url = ? AND stage = ?",
-            (job_url, stage),
-        ).fetchone()
-        actual = 0 if existing is None else (
-            existing[0] if not isinstance(existing, dict) else existing["version"]
-        )
+        existing = get_stage_state_row(conn, job_url, stage)
+        actual = 0 if existing is None else existing["version"]
         raise OptimisticLockError(job_url, expected_version, actual or 0)
 
     if state == "succeeded":
@@ -410,6 +606,26 @@ def reconcile_dependency_blockers(
         if completed_stage is not None
         else tuple(_DEPENDENCY_BLOCKER_MESSAGES)
     )
+    stable_references = (
+        _stage_state_reference_column(conn) == "job_id"
+    )
+    identity_select = (
+        "jobs.url AS job_url"
+        if stable_references
+        else "downstream.job_url AS job_url"
+    )
+    identity_join = (
+        "JOIN jobs ON jobs.tenant_id = downstream.tenant_id "
+        "AND jobs.job_id = downstream.job_id"
+        if stable_references
+        else ""
+    )
+    same_job = (
+        "upstream.tenant_id = downstream.tenant_id "
+        "AND upstream.job_id = downstream.job_id"
+        if stable_references
+        else "upstream.job_url = downstream.job_url"
+    )
     updated_at = now or utc_now()
     repaired = 0
     for upstream in completed_stages:
@@ -418,13 +634,20 @@ def reconcile_dependency_blockers(
             params: list[Any] = [downstream, *messages]
             job_filter = ""
             if job_url is not None:
-                job_filter = "AND downstream.job_url = ?"
-                params.append(job_url)
+                predicate, job_params = _stage_state_predicate(
+                    conn,
+                    job_url,
+                    alias="downstream",
+                )
+                job_filter = f"AND {predicate}"
+                params.extend(job_params)
             params.append(upstream)
             rows = conn.execute(
                 f"""
-                SELECT downstream.job_url, downstream.stage, downstream.attempt_count
+                SELECT {identity_select}, downstream.stage,
+                       downstream.attempt_count
                   FROM job_stage_states AS downstream
+                  {identity_join}
                  WHERE downstream.stage = ?
                    AND downstream.state = 'blocked'
                    AND downstream.error_code = 'BLOCKED'
@@ -433,7 +656,7 @@ def reconcile_dependency_blockers(
                    AND EXISTS (
                        SELECT 1
                          FROM job_stage_states AS upstream
-                        WHERE upstream.job_url = downstream.job_url
+                        WHERE {same_job}
                           AND upstream.stage = ?
                           AND upstream.state = 'succeeded'
                    )
@@ -485,14 +708,15 @@ def reconcile_score_eligibility_blockers(
     reason = ", ".join(blockers) if blockers else str(eligibility_status or "blocked")
     message = f"{SCORE_ELIGIBILITY_BLOCKED_MESSAGE_PREFIX}: {reason}"
     changed = 0
+    predicate, identity_params = _stage_state_predicate(conn, job_url)
     rows = conn.execute(
         f"""
         SELECT stage, state, attempt_count
           FROM job_stage_states
-         WHERE job_url = ?
+         WHERE {predicate}
            AND stage IN ({", ".join("?" for _ in _SCORE_ELIGIBILITY_DOWNSTREAM_STAGES)})
         """,
-        (job_url, *_SCORE_ELIGIBILITY_DOWNSTREAM_STAGES),
+        (*identity_params, *_SCORE_ELIGIBILITY_DOWNSTREAM_STAGES),
     ).fetchall()
     for row in rows:
         stage = str(row["stage"])
@@ -537,15 +761,16 @@ def reconcile_score_eligibility_blockers(
 
 
 def _clear_score_eligibility_blockers(conn, *, job_url: str, now: str) -> int:
+    predicate, identity_params = _stage_state_predicate(conn, job_url)
     rows = conn.execute(
-        """
+        f"""
         SELECT stage, attempt_count
           FROM job_stage_states
-         WHERE job_url = ?
+         WHERE {predicate}
            AND state = 'blocked'
            AND error_code = ?
         """,
-        (job_url, SCORE_ELIGIBILITY_BLOCKED_ERROR_CODE),
+        (*identity_params, SCORE_ELIGIBILITY_BLOCKED_ERROR_CODE),
     ).fetchall()
     cleared = 0
     for row in rows:
@@ -597,10 +822,7 @@ def _restored_state_after_score_eligibility_cleared(conn, *, job_url: str, stage
 
 
 def _stage_is_succeeded(conn, *, job_url: str, stage: str) -> bool:
-    row = conn.execute(
-        "SELECT state FROM job_stage_states WHERE job_url = ? AND stage = ?",
-        (job_url, stage),
-    ).fetchone()
+    row = get_stage_state_row(conn, job_url, stage)
     return bool(row and str(row["state"]) == "succeeded")
 
 
@@ -784,9 +1006,10 @@ def record_job_artifact(
 
 def _load_explicit_states(conn, job_url: str) -> dict[str, dict[str, Any]]:
     """Load all stage rows from ``job_stage_states`` for one job."""
+    predicate, params = _stage_state_predicate(conn, job_url)
     rows = conn.execute(
-        "SELECT * FROM job_stage_states WHERE job_url = ?",
-        (job_url,),
+        f"SELECT * FROM job_stage_states WHERE {predicate}",
+        params,
     ).fetchall()
     explicit: dict[str, dict[str, Any]] = {}
     for row in rows:

--- a/workers/automation/tests/test_apply_regressions.py
+++ b/workers/automation/tests/test_apply_regressions.py
@@ -32,7 +32,13 @@ from jobctrl.apply.dashboard import get_recent_events
 from jobctrl.apply.origins import canonical_http_url
 from jobctrl.database import close_connection, get_connection, init_db
 from jobctrl.infrastructure.projections.projection_builder import ProjectionBuilder
-from jobctrl.state import ensure_job_stage_rows, record_job_event, set_stage_state, utc_now
+from jobctrl.state import (
+    ensure_job_stage_rows,
+    get_stage_state_row,
+    record_job_event,
+    set_stage_state,
+    utc_now,
+)
 from jobctrl.workflow_specs import StartedWorkflowResult
 
 
@@ -298,11 +304,7 @@ def test_targeted_apply_takes_canonical_stage_lock(tmp_path, monkeypatch):
         ).fetchone()
         assert legacy["apply_status"] is None
         # Canonical lock: stage row in 'running'.
-        stage = conn.execute(
-            "SELECT state FROM job_stage_states "
-            "WHERE job_url = ? AND stage = 'apply'",
-            (job["url"],),
-        ).fetchone()
+        stage = get_stage_state_row(conn, job["url"], "apply")
         assert stage is not None
         assert stage["state"] == "running"
         # ApplyRunStarted event recorded with the same run_id.
@@ -344,10 +346,7 @@ def test_apply_approval_gate_blocks_live_without_approval(tmp_path, monkeypatch)
         )
         prior_event_count = len(get_recent_events())
         assert acquire_job(target_url="https://example.com/job", worker_id=1) is None
-        row = conn.execute(
-            "SELECT state FROM job_stage_states WHERE job_url = ? AND stage = 'apply'",
-            ("https://example.com/job",),
-        ).fetchone()
+        row = get_stage_state_row(conn, "https://example.com/job", "apply")
         assert row is None or row["state"] == "pending"
         assert any(
             "Awaiting apply approval" in event
@@ -382,10 +381,7 @@ def test_approval_required_apply_loop_never_runs_browser_for_unapproved_job(
         )
 
         assert (applied, failed) == (0, 0)
-        row = conn.execute(
-            "SELECT state FROM job_stage_states WHERE job_url = ? AND stage = 'apply'",
-            ("https://example.com/job",),
-        ).fetchone()
+        row = get_stage_state_row(conn, "https://example.com/job", "apply")
         assert row is None or row["state"] == "pending"
     finally:
         close_connection(db_path)
@@ -1128,11 +1124,7 @@ def test_dry_run_result_does_not_mark_job_applied(tmp_path, monkeypatch):
             "SELECT apply_status, applied_at, apply_task_id FROM jobs WHERE url = ?",
             ("https://example.com/job",),
         ).fetchone()
-        state = conn.execute(
-            "SELECT state, error_code FROM job_stage_states "
-            "WHERE job_url = ? AND stage = 'apply'",
-            ("https://example.com/job",),
-        ).fetchone()
+        state = get_stage_state_row(conn, "https://example.com/job", "apply")
         # Legacy columns stay NULL on the new write path.
         assert row["apply_status"] is None
         assert row["applied_at"] is None
@@ -1180,11 +1172,7 @@ def test_acquire_job_then_mark_result_dry_run_completes_end_to_end(
         )
         assert job is not None
         # Sanity: the lock acquired -> Running.
-        before = conn.execute(
-            "SELECT state FROM job_stage_states "
-            "WHERE job_url = ? AND stage = 'apply'",
-            (job["url"],),
-        ).fetchone()
+        before = get_stage_state_row(conn, job["url"], "apply")
         assert before["state"] == "running"
 
         # Production sequence -- this used to raise ValueError.
@@ -1197,11 +1185,7 @@ def test_acquire_job_then_mark_result_dry_run_completes_end_to_end(
 
         # (a) No exception (we got here).
         # (b) Stage row landed on Skipped.
-        after = conn.execute(
-            "SELECT state, error_code FROM job_stage_states "
-            "WHERE job_url = ? AND stage = 'apply'",
-            (job["url"],),
-        ).fetchone()
+        after = get_stage_state_row(conn, job["url"], "apply")
         assert after["state"] == "skipped"
         assert after["error_code"] == "DRY_RUN"
 
@@ -1239,20 +1223,12 @@ def test_release_lock_does_not_rewind_running_row(tmp_path, monkeypatch):
             approval_required=False,
         )
         assert job is not None
-        before = conn.execute(
-            "SELECT state FROM job_stage_states "
-            "WHERE job_url = ? AND stage = 'apply'",
-            (job["url"],),
-        ).fetchone()
+        before = get_stage_state_row(conn, job["url"], "apply")
         assert before["state"] == "running"
 
         release_lock(job["url"], run_ctx=run_ctx)
 
-        after = conn.execute(
-            "SELECT state FROM job_stage_states "
-            "WHERE job_url = ? AND stage = 'apply'",
-            (job["url"],),
-        ).fetchone()
+        after = get_stage_state_row(conn, job["url"], "apply")
         assert after["state"] == "running"
     finally:
         close_connection(db_path)
@@ -1280,10 +1256,7 @@ def test_apply_recovery_rewinds_before_submit_intent(tmp_path, monkeypatch):
         assert job is not None
         recovered = recover_ambiguous_running_apply()
         assert recovered == 1
-        row = conn.execute(
-            "SELECT state FROM job_stage_states WHERE job_url = ? AND stage = 'apply'",
-            (job["url"],),
-        ).fetchone()
+        row = get_stage_state_row(conn, job["url"], "apply")
         assert row["state"] == "pending"
     finally:
         close_connection(db_path)
@@ -1325,10 +1298,7 @@ def test_apply_recovery_after_submit_intent_needs_verification(tmp_path, monkeyp
 
         recovered = recover_ambiguous_running_apply()
         assert recovered == 1
-        row = conn.execute(
-            "SELECT state, error_code FROM job_stage_states WHERE job_url = ? AND stage = 'apply'",
-            (job["url"],),
-        ).fetchone()
+        row = get_stage_state_row(conn, job["url"], "apply")
         assert row["state"] == "needs_verification"
         assert row["error_code"] == "APPLY_NEEDS_VERIFICATION"
 
@@ -1350,10 +1320,7 @@ def test_apply_recovery_after_submit_intent_needs_verification(tmp_path, monkeyp
             )
             is None
         )
-        parked = conn.execute(
-            "SELECT state FROM job_stage_states WHERE job_url = ? AND stage = 'apply'",
-            (job["url"],),
-        ).fetchone()
+        parked = get_stage_state_row(conn, job["url"], "apply")
         assert parked["state"] == "needs_verification"
     finally:
         close_connection(db_path)
@@ -1406,11 +1373,7 @@ def test_failed_result_after_submit_intent_parks_without_reclaim(
             run_ctx=run_ctx,
         )
 
-        row = conn.execute(
-            "SELECT state, error_code, retryable, next_action "
-            "FROM job_stage_states WHERE job_url = ? AND stage = 'apply'",
-            (job["url"],),
-        ).fetchone()
+        row = get_stage_state_row(conn, job["url"], "apply")
         assert row["state"] == "needs_verification"
         assert row["error_code"] == "APPLY_NEEDS_VERIFICATION"
         assert row["retryable"] == 0
@@ -1496,12 +1459,13 @@ def test_acquire_job_concurrent_workers_only_one_succeeds(tmp_path, monkeypatch)
 
         # Exactly one ``running`` row in ``job_stage_states.apply``.
         check_conn = get_connection(db_path)
-        running_count = check_conn.execute(
-            "SELECT COUNT(*) FROM job_stage_states "
-            "WHERE job_url = ? AND stage = 'apply' AND state = 'running'",
-            ("https://example.com/job",),
-        ).fetchone()[0]
-        assert running_count == 1
+        running_row = get_stage_state_row(
+            check_conn,
+            "https://example.com/job",
+            "apply",
+        )
+        assert running_row is not None
+        assert running_row["state"] == "running"
     finally:
         close_connection(db_path)
 

--- a/workers/automation/tests/test_audit_projection_parity.py
+++ b/workers/automation/tests/test_audit_projection_parity.py
@@ -126,10 +126,14 @@ def _seed_rows(conn: sqlite3.Connection, fixture: dict[str, Any]) -> None:
         conn.execute(
             """
             INSERT INTO job_stage_states (
-                job_url, stage, state, attempt_count, max_attempts, started_at,
+                tenant_id, job_id, stage, state, attempt_count, max_attempts, started_at,
                 updated_at, finished_at, duration_ms, error_code, error_message,
                 retryable, blocked_by_json, next_action
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ) VALUES (
+                'local',
+                (SELECT job_id FROM jobs WHERE tenant_id = 'local' AND url = ?),
+                ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+            )
             """,
             (
                 job_url,
@@ -360,9 +364,13 @@ def _seed_rows(conn: sqlite3.Connection, fixture: dict[str, Any]) -> None:
             conn.execute(
                 """
                 INSERT INTO job_stage_states (
-                    job_url, stage, state, attempt_count, max_attempts,
+                    tenant_id, job_id, stage, state, attempt_count, max_attempts,
                     started_at, updated_at, finished_at, duration_ms, retryable
-                ) VALUES (?, ?, ?, 1, 1, ?, ?, ?, 0, 1)
+                ) VALUES (
+                    'local',
+                    (SELECT job_id FROM jobs WHERE tenant_id = 'local' AND url = ?),
+                    ?, ?, 1, 1, ?, ?, ?, 0, 1
+                )
                 """,
                 (
                     agg["url"],
@@ -470,10 +478,14 @@ def _seed_conversion_rows(conn: sqlite3.Connection, fixture: dict[str, Any]) -> 
             conn.execute(
                 """
                 INSERT INTO job_stage_states (
-                    job_url, stage, state, attempt_count, max_attempts, started_at,
+                    tenant_id, job_id, stage, state, attempt_count, max_attempts, started_at,
                     updated_at, finished_at, duration_ms, error_code, error_message,
                     retryable, blocked_by_json, next_action
-                ) VALUES (?, ?, 'succeeded', 1, ?, ?, ?, ?, 1000, NULL, NULL, 1, NULL, NULL)
+                ) VALUES (
+                    'local',
+                    (SELECT job_id FROM jobs WHERE tenant_id = 'local' AND url = ?),
+                    ?, 'succeeded', 1, ?, ?, ?, ?, 1000, NULL, NULL, 1, NULL, NULL
+                )
                 """,
                 (job["url"], stage, max_attempts, job["appliedAt"], job["appliedAt"], job["appliedAt"]),
             )

--- a/workers/automation/tests/test_discover_reliability.py
+++ b/workers/automation/tests/test_discover_reliability.py
@@ -28,6 +28,7 @@ from jobctrl.discovery.activities import (
 from jobctrl.domain.errors import ConfigurationError, TransientNetworkError
 from jobctrl.enrichment import detail
 from jobctrl.pipeline import runner
+from jobctrl.state import get_stage_state_row
 
 from .politeness_helpers import offline_gateway
 
@@ -508,10 +509,7 @@ def test_scrape_site_batch_isolates_single_job_failure(
         assert stats["error"] == 1
         assert stats["ok"] == 1
 
-        bad_state = conn.execute(
-            "SELECT state, error_code FROM job_stage_states WHERE job_url = ? AND stage = 'enrich'",
-            (bad_url,),
-        ).fetchone()
+        bad_state = get_stage_state_row(conn, bad_url, "enrich")
         assert bad_state["state"] == "failed"
         assert bad_state["error_code"] == "ENRICH_INTERNAL_ERROR"
 
@@ -673,10 +671,7 @@ def test_scrape_site_batch_handoff_error_does_not_break_enrichment(
 
         assert stats["ok"] == 1
         assert stats["error"] == 0
-        state = conn.execute(
-            "SELECT state FROM job_stage_states WHERE job_url = ? AND stage = 'enrich'",
-            (url,),
-        ).fetchone()
+        state = get_stage_state_row(conn, url, "enrich")
         assert state["state"] == "succeeded"
     finally:
         close_connection(db_path)

--- a/workers/automation/tests/test_discovery_identity_reference_migration.py
+++ b/workers/automation/tests/test_discovery_identity_reference_migration.py
@@ -220,7 +220,7 @@ def test_v7_discovery_references_migrate_to_stable_job_id_and_reopen(
     init_db(db_path)
     close_connection(db_path)
 
-    assert _user_version(db_path) == SCHEMA_VERSION == 12
+    assert _user_version(db_path) == SCHEMA_VERSION == 13
     assert "job_id" in _columns(db_path, "job_source_observations")
     assert "job_url" not in _columns(db_path, "job_source_observations")
     assert "job_id" in _columns(db_path, "job_canonical_identities")

--- a/workers/automation/tests/test_discovery_production_wiring.py
+++ b/workers/automation/tests/test_discovery_production_wiring.py
@@ -512,9 +512,12 @@ def test_canonical_ats_scheduler_routes_postings_through_discovery_use_case(
     assert all(str(row["full_description"] or "").strip() for row in enrichments)
     stage_rows = conn.execute(
         """
-        SELECT job_url, state
-        FROM job_stage_states
-        WHERE stage = 'enrich'
+        SELECT jobs.url AS job_url, states.state
+        FROM job_stage_states states
+        JOIN jobs
+          ON jobs.tenant_id = states.tenant_id
+         AND jobs.job_id = states.job_id
+        WHERE states.stage = 'enrich'
         """
     ).fetchall()
     assert {row["job_url"] for row in stage_rows} == expected_urls

--- a/workers/automation/tests/test_enrichment_detail_staleness.py
+++ b/workers/automation/tests/test_enrichment_detail_staleness.py
@@ -13,6 +13,7 @@ from jobctrl.enrichment.detail import (
     scrape_detail_page,
 )
 from jobctrl.infrastructure.network import PublicUrlDecision
+from jobctrl.state import get_stage_state_row
 
 from .politeness_helpers import offline_gateway, offline_session
 
@@ -242,14 +243,7 @@ def test_scrape_site_batch_uses_discovery_description_when_detail_extracts_no_da
         attempts = json.loads(enrichment["attempts_json"])
         assert attempts[-1]["status"] == "succeeded"
 
-        stage = conn.execute(
-            """
-            SELECT state, metadata_json
-            FROM job_stage_states
-            WHERE job_url = ? AND stage = 'enrich'
-            """,
-            (job_url,),
-        ).fetchone()
+        stage = get_stage_state_row(conn, job_url, "enrich")
         assert stage["state"] == "succeeded"
         assert json.loads(stage["metadata_json"]) == {
             "fallbackSource": "discovery",

--- a/workers/automation/tests/test_enrichment_politeness_gate.py
+++ b/workers/automation/tests/test_enrichment_politeness_gate.py
@@ -32,6 +32,7 @@ from jobctrl.infrastructure.network import (
     RobotsCache,
     RunBudgetCounter,
 )
+from jobctrl.state import get_stage_state_row
 
 from .politeness_helpers import (
     AllowAllRobots,
@@ -60,10 +61,7 @@ def _seed_pending(conn: sqlite3.Connection, url: str, site: str = "RemoteOK") ->
 
 def _enrich_stage(conn: sqlite3.Connection, url: str) -> sqlite3.Row:
     conn.row_factory = sqlite3.Row
-    return conn.execute(
-        "SELECT state, error_code, next_action FROM job_stage_states WHERE job_url = ? AND stage = 'enrich'",
-        (url,),
-    ).fetchone()
+    return get_stage_state_row(conn, url, "enrich")
 
 
 def _blocked_metric(conn: sqlite3.Connection, url: str) -> sqlite3.Row | None:

--- a/workers/automation/tests/test_enrichment_snapshot_identity_reference_migration.py
+++ b/workers/automation/tests/test_enrichment_snapshot_identity_reference_migration.py
@@ -322,7 +322,7 @@ def test_v10_enrichment_snapshot_references_migrate_and_reopen(
     init_db(db_path)
     close_connection(db_path)
 
-    assert _user_version(db_path) == SCHEMA_VERSION == 12
+    assert _user_version(db_path) == SCHEMA_VERSION == 13
     check = sqlite3.connect(db_path)
     try:
         enrichment_rows = check.execute(

--- a/workers/automation/tests/test_execution_search_identity_reference_migration.py
+++ b/workers/automation/tests/test_execution_search_identity_reference_migration.py
@@ -261,7 +261,7 @@ def test_v8_execution_and_receipts_migrate_to_stable_job_id_and_reopen(
     init_db(db_path)
     close_connection(db_path)
 
-    assert _user_version(db_path) == SCHEMA_VERSION == 12
+    assert _user_version(db_path) == SCHEMA_VERSION == 13
     assert "job_id" in _columns(db_path, "discovery_execution_jobs")
     assert "job_url" not in _columns(db_path, "discovery_execution_jobs")
     assert "job_id" in _columns(db_path, "discovery_search_unit_jobs")

--- a/workers/automation/tests/test_pipeline_repository.py
+++ b/workers/automation/tests/test_pipeline_repository.py
@@ -19,7 +19,7 @@ from jobctrl.domain.pipeline_types import (
 )
 from jobctrl.domain.tenant import LOCAL_TENANT
 from jobctrl.infrastructure.pipeline.sqlite_repository import SqlitePipelineStateRepository
-from jobctrl.state import ensure_job_stage_rows, set_stage_state
+from jobctrl.state import ensure_job_stage_rows, get_stage_state_row, set_stage_state
 
 
 def _insert_job(conn, url: str = "https://example.com/job") -> None:
@@ -276,11 +276,7 @@ def test_save_event_emission_matches_canonical_helper(db):
         Succeeded(attempt_count=1, finished_at="2026-05-01T00:01:00Z", duration_ms=60000),
     )
     repo.save(agg)
-    repo_row = db.execute(
-        "SELECT state, attempt_count, started_at, finished_at, duration_ms "
-        "FROM job_stage_states WHERE job_url = ? AND stage = 'enrich'",
-        ("https://example.com/job",),
-    ).fetchone()
+    repo_row = get_stage_state_row(db, "https://example.com/job", "enrich")
 
     # Path B: identical writes via canonical set_stage_state on a sibling job.
     _insert_job(db, url="https://example.com/twin")
@@ -305,13 +301,27 @@ def test_save_event_emission_matches_canonical_helper(db):
         duration_ms=60000,
     )
     db.commit()
-    twin_row = db.execute(
-        "SELECT state, attempt_count, started_at, finished_at, duration_ms "
-        "FROM job_stage_states WHERE job_url = ? AND stage = 'enrich'",
-        ("https://example.com/twin",),
-    ).fetchone()
+    twin_row = get_stage_state_row(db, "https://example.com/twin", "enrich")
 
-    assert dict(repo_row) == dict(twin_row)
+    lifecycle_columns = (
+        "state",
+        "attempt_count",
+        "max_attempts",
+        "started_at",
+        "finished_at",
+        "duration_ms",
+        "error_code",
+        "error_message",
+        "retryable",
+        "blocked_by_json",
+        "next_action",
+        "metadata_json",
+    )
+    assert {
+        column: repo_row[column] for column in lifecycle_columns
+    } == {
+        column: twin_row[column] for column in lifecycle_columns
+    }
 
 
 def test_save_attempts_counter_progresses_across_calls(db):
@@ -432,10 +442,7 @@ def test_set_stage_state_with_expected_version_round_trip(db):
     )
     db.commit()
 
-    row = db.execute(
-        "SELECT state, version FROM job_stage_states WHERE job_url = ? AND stage = 'enrich'",
-        ("https://example.com/job",),
-    ).fetchone()
+    row = get_stage_state_row(db, "https://example.com/job", "enrich")
     assert row["state"] == "running"
     assert row["version"] == 1
 
@@ -487,9 +494,6 @@ def test_set_stage_state_expected_version_inserts_when_missing(db):
     )
     db.commit()
 
-    row = db.execute(
-        "SELECT state, version FROM job_stage_states WHERE job_url = ? AND stage = 'enrich'",
-        ("https://example.com/fresh",),
-    ).fetchone()
+    row = get_stage_state_row(db, "https://example.com/fresh", "enrich")
     assert row["state"] == "pending"
     assert row["version"] == 1

--- a/workers/automation/tests/test_preparation_identity_reference_migration.py
+++ b/workers/automation/tests/test_preparation_identity_reference_migration.py
@@ -177,7 +177,7 @@ def test_v9_preparation_references_migrate_to_stable_job_ids_and_reopen(
     init_db(db_path)
     close_connection(db_path)
 
-    assert _user_version(db_path) == SCHEMA_VERSION == 12
+    assert _user_version(db_path) == SCHEMA_VERSION == 13
     check = sqlite3.connect(db_path)
     try:
         rows = check.execute(

--- a/workers/automation/tests/test_repeat_application_prevention.py
+++ b/workers/automation/tests/test_repeat_application_prevention.py
@@ -24,7 +24,7 @@ from jobctrl.domain.apply.repeat_application import (
     repeat_evidence_fingerprint,
 )
 from jobctrl.domain.apply.value_objects import ApplyPrompt
-from jobctrl.state import ensure_job_stage_rows, record_job_event
+from jobctrl.state import ensure_job_stage_rows, get_stage_state_row, record_job_event
 
 PRIOR = "https://jobs.example.test/prior"
 TARGET = "https://careers.example.test/target"
@@ -350,10 +350,7 @@ def test_manual_mark_is_a_user_attested_confirmed_fact_not_a_submission(
     ).fetchall()
     assert [row["event_type"] for row in events] == ["ApplicationManuallyMarked"]
     assert json.loads(events[0]["payload_json"])["source"] == "user_attestation"
-    assert conn.execute(
-        "SELECT state FROM job_stage_states WHERE job_url = ? AND stage = 'apply'",
-        (PRIOR,),
-    ).fetchone()[0] == "succeeded"
+    assert get_stage_state_row(conn, PRIOR, "apply")["state"] == "succeeded"
     assessment = evaluate_repeat_application(conn, TARGET)
     assert assessment["status"] == "confirmation_required"
     assert assessment["matches"][0]["priorApplication"]["factKind"] == (
@@ -640,10 +637,7 @@ def test_gen_prompt_is_read_only_and_cannot_consume_repeat_override(
         == 0
     )
     assert (
-        conn.execute(
-            "SELECT state FROM job_stage_states WHERE job_url = ? AND stage = 'apply'",
-            (TARGET,),
-        ).fetchone()[0]
+        get_stage_state_row(conn, TARGET, "apply")["state"]
         == "pending"
     )
 
@@ -750,7 +744,7 @@ def test_schema_v5_migrates_additively_without_changing_application_facts(
         (PRIOR,),
     ).fetchall()
 
-    assert int(migrated.execute("PRAGMA user_version").fetchone()[0]) == SCHEMA_VERSION == 12
+    assert int(migrated.execute("PRAGMA user_version").fetchone()[0]) == SCHEMA_VERSION == 13
     assert [tuple(row) for row in after] == [tuple(row) for row in before]
     assert "metadata_json" in {
         str(row[1]) for row in migrated.execute("PRAGMA table_info(job_stage_states)").fetchall()

--- a/workers/automation/tests/test_score_eligibility_stage_state.py
+++ b/workers/automation/tests/test_score_eligibility_stage_state.py
@@ -36,9 +36,13 @@ def _seed_scored_job(conn: sqlite3.Connection, url: str) -> None:
 def _stage_rows(conn: sqlite3.Connection, url: str) -> dict[str, sqlite3.Row]:
     rows = conn.execute(
         """
-        SELECT stage, state, error_code, error_message, retryable, blocked_by_json
-        FROM job_stage_states
-        WHERE job_url = ?
+        SELECT states.stage, states.state, states.error_code,
+               states.error_message, states.retryable, states.blocked_by_json
+        FROM job_stage_states states
+        JOIN jobs
+          ON jobs.tenant_id = states.tenant_id
+         AND jobs.job_id = states.job_id
+        WHERE jobs.tenant_id = 'local' AND jobs.url = ?
         """,
         (url,),
     ).fetchall()

--- a/workers/automation/tests/test_score_repository.py
+++ b/workers/automation/tests/test_score_repository.py
@@ -44,7 +44,7 @@ from jobctrl.infrastructure.scoring import (
 )
 from jobctrl.infrastructure.scoring.sqlite_repository import ScoreVersionConflict
 from jobctrl.scoring.eval import build_scoring_governance_report
-from jobctrl.state import set_stage_state
+from jobctrl.state import get_stage_state_row, set_stage_state
 
 
 @pytest.fixture()
@@ -562,10 +562,7 @@ def test_score_correction_marks_comparable_uncorrected_scores_stale_and_resolve_
     assert rows[0]["old_policy_version"] == 1
     assert rows[0]["new_policy_version"] == 2
     assert rows[0]["resolved"] == 0
-    stale_stage = conn.execute(
-        "SELECT state FROM job_stage_states WHERE job_url = ? AND stage = 'score'",
-        (comparable_url,),
-    ).fetchone()
+    stale_stage = get_stage_state_row(conn, comparable_url, "score")
     assert stale_stage["state"] == "stale"
     stale_event = conn.execute(
         "SELECT event_type FROM job_events WHERE job_url = ? ORDER BY event_id DESC LIMIT 1",

--- a/workers/automation/tests/test_scorer.py
+++ b/workers/automation/tests/test_scorer.py
@@ -44,7 +44,7 @@ from jobctrl.infrastructure.scoring import (
 )
 from jobctrl.infrastructure.materials import SqliteEmployerAnalysisRepository
 from jobctrl.scoring import scorer as scorer_module
-from jobctrl.state import set_stage_state
+from jobctrl.state import get_stage_state_row, set_stage_state
 
 
 class _ScriptedLlm:
@@ -374,11 +374,7 @@ def test_score_job_by_url_repairs_existing_score_stage_state(
     assert outcome.score is not None
     assert outcome.score.fit_score.value == 8
     assert llm.calls == 0
-    stage_row = conn.execute(
-        "SELECT state, error_code, error_message "
-        "FROM job_stage_states WHERE job_url = ? AND stage = 'score'",
-        (url,),
-    ).fetchone()
+    stage_row = get_stage_state_row(conn, url, "score")
     assert stage_row["state"] == "succeeded"
     assert stage_row["error_code"] is None
     assert stage_row["error_message"] is None
@@ -428,9 +424,14 @@ def test_score_job_by_url_syncs_existing_blocked_score_to_downstream_stages(
     rows = conn.execute(
         """
         SELECT stage, state, error_code, error_message
-        FROM job_stage_states
-        WHERE job_url = ? AND stage IN ('tailor', 'cover', 'apply')
-        ORDER BY stage
+        FROM job_stage_states states
+        JOIN jobs
+          ON jobs.tenant_id = states.tenant_id
+         AND jobs.job_id = states.job_id
+        WHERE jobs.tenant_id = 'local'
+          AND jobs.url = ?
+          AND states.stage IN ('tailor', 'cover', 'apply')
+        ORDER BY states.stage
         """,
         (url,),
     ).fetchall()
@@ -639,10 +640,7 @@ def test_run_scoring_persists_via_repository_only(
     assert legacy["scored_at"] is None
 
     # Stage state row reflects success.
-    stage_row = conn.execute(
-        "SELECT state FROM job_stage_states WHERE job_url=? AND stage='score'",
-        (url,),
-    ).fetchone()
+    stage_row = get_stage_state_row(conn, url, "score")
     assert stage_row["state"] == "succeeded"
 
 
@@ -838,11 +836,7 @@ def test_run_scoring_fails_before_llm_when_employer_analysis_fails(
     assert summary["errors"] == 1
     assert analyze.calls == 1
     assert llm.calls == 0
-    stage_row = conn.execute(
-        "SELECT state, error_code, error_message "
-        "FROM job_stage_states WHERE job_url = ? AND stage = 'score'",
-        (url,),
-    ).fetchone()
+    stage_row = get_stage_state_row(conn, url, "score")
     assert stage_row["state"] == "failed"
     assert stage_row["error_code"] == "SCORE_FAILED"
     assert "analysis unavailable" in stage_row["error_message"]
@@ -1092,10 +1086,7 @@ def test_run_scoring_records_failure_state_when_llm_returns_garbage(
     assert summary["errors"] == 1
     assert repo.load(LOCAL_TENANT, JobId(url)) is None
 
-    stage_row = conn.execute(
-        "SELECT state, error_message FROM job_stage_states WHERE job_url=? AND stage='score'",
-        (url,),
-    ).fetchone()
+    stage_row = get_stage_state_row(conn, url, "score")
     assert stage_row["state"] == "failed"
     assert "outside" in (stage_row["error_message"] or "").lower()
 
@@ -1154,10 +1145,7 @@ def test_run_scoring_preselects_retrieval_top_k_before_llm(
 
 
 def _score_attempt_count(conn: sqlite3.Connection, url: str) -> int:
-    row = conn.execute(
-        "SELECT attempt_count FROM job_stage_states WHERE job_url=? AND stage='score'",
-        (url,),
-    ).fetchone()
+    row = get_stage_state_row(conn, url, "score")
     return int(row["attempt_count"]) if row is not None else 0
 
 

--- a/workers/automation/tests/test_scoring_identity_reference_migration.py
+++ b/workers/automation/tests/test_scoring_identity_reference_migration.py
@@ -338,7 +338,7 @@ def test_v11_scoring_references_migrate_alias_histories_and_reopen(
     assert (
         int(migrated.execute("PRAGMA user_version").fetchone()[0])
         == SCHEMA_VERSION
-        == 12
+        == 13
     )
     assert _columns(migrated, "job_scores") >= {"tenant_id", "job_id"}
     assert "job_url" not in _columns(migrated, "job_scores")
@@ -401,7 +401,11 @@ def test_v11_scoring_references_migrate_alias_histories_and_reopen(
 
     close_connection(db_path)
     reopened = init_db(db_path)
-    assert int(reopened.execute("PRAGMA user_version").fetchone()[0]) == 12
+    assert (
+        int(reopened.execute("PRAGMA user_version").fetchone()[0])
+        == SCHEMA_VERSION
+        == 13
+    )
 
 
 def test_v11_scoring_migration_preserves_each_alias_version_order(
@@ -546,7 +550,11 @@ def test_scoring_migration_rolls_back_and_retries_after_verification_failure(
         original_verify,
     )
     retried = init_db(db_path)
-    assert int(retried.execute("PRAGMA user_version").fetchone()[0]) == 12
+    assert (
+        int(retried.execute("PRAGMA user_version").fetchone()[0])
+        == SCHEMA_VERSION
+        == 13
+    )
     assert [
         tuple(row)
         for row in retried.execute(

--- a/workers/automation/tests/test_stable_job_identity_migration.py
+++ b/workers/automation/tests/test_stable_job_identity_migration.py
@@ -105,11 +105,11 @@ def _create_representative_v6_pair(
     conn.execute(
         """
         INSERT INTO job_stage_states (
-            job_url, stage, state, attempt_count, updated_at,
+            tenant_id, job_id, stage, state, attempt_count, updated_at,
             metadata_json, version
-        ) VALUES (?, 'score', 'succeeded', 1, ?, '{"fixture":true}', 3)
+        ) VALUES ('local', ?, 'score', 'succeeded', 1, ?, '{"fixture":true}', 3)
         """,
-        (job_url, "2026-07-01T10:06:00+00:00"),
+        (job_id, "2026-07-01T10:06:00+00:00"),
     )
     conn.execute(
         """
@@ -212,6 +212,32 @@ def _create_representative_v6_pair(
 
     raw = sqlite3.connect(db_path)
     try:
+        stage_rows = raw.execute(
+            """
+            SELECT
+                jobs.url,
+                states.stage,
+                states.state,
+                states.attempt_count,
+                states.max_attempts,
+                states.started_at,
+                states.updated_at,
+                states.finished_at,
+                states.duration_ms,
+                states.error_code,
+                states.error_message,
+                states.retryable,
+                states.blocked_by_json,
+                states.next_action,
+                states.metadata_json,
+                states.version
+            FROM job_stage_states AS states
+            JOIN jobs
+              ON jobs.tenant_id = states.tenant_id
+             AND jobs.job_id = states.job_id
+            ORDER BY states.tenant_id, states.job_id, states.stage
+            """
+        ).fetchall()
         score_rows = raw.execute(
             """
             SELECT
@@ -429,6 +455,42 @@ def _create_representative_v6_pair(
                 for row in score_rows
             ),
         )
+        raw.execute("DROP TABLE job_stage_states")
+        raw.execute(
+            """
+            CREATE TABLE job_stage_states (
+                job_url         TEXT NOT NULL,
+                stage           TEXT NOT NULL,
+                state           TEXT NOT NULL DEFAULT 'pending',
+                attempt_count   INTEGER DEFAULT 0,
+                max_attempts    INTEGER,
+                started_at      TEXT,
+                updated_at      TEXT NOT NULL,
+                finished_at     TEXT,
+                duration_ms     INTEGER,
+                error_code      TEXT,
+                error_message   TEXT,
+                retryable       INTEGER DEFAULT 1,
+                blocked_by_json TEXT,
+                next_action     TEXT,
+                metadata_json   TEXT,
+                version         INTEGER NOT NULL DEFAULT 0,
+                PRIMARY KEY (job_url, stage),
+                FOREIGN KEY (job_url) REFERENCES jobs(url) ON DELETE CASCADE
+            )
+            """
+        )
+        raw.executemany(
+            """
+            INSERT INTO job_stage_states (
+                job_url, stage, state, attempt_count, max_attempts,
+                started_at, updated_at, finished_at, duration_ms,
+                error_code, error_message, retryable, blocked_by_json,
+                next_action, metadata_json, version
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            stage_rows,
+        )
         for trigger_name in database_module._STABLE_JOB_IDENTITY_TRIGGER_NAMES:
             raw.execute(f'DROP TRIGGER IF EXISTS "{trigger_name}"')
         raw.execute("DROP INDEX IF EXISTS idx_jobs_tenant_job_id")
@@ -471,6 +533,42 @@ def _reference_snapshot(db_path: Path) -> dict[str, list[tuple[object, ...]]]:
             table: [tuple(row) for row in conn.execute(f'SELECT * FROM "{table}" ORDER BY rowid').fetchall()]
             for table in REFERENCE_TABLES
         }
+        stage_columns = {
+            str(row[1])
+            for row in conn.execute(
+                "PRAGMA table_info(job_stage_states)"
+            ).fetchall()
+        }
+        if "job_id" in stage_columns:
+            snapshot["job_stage_states"] = [
+                tuple(row)
+                for row in conn.execute(
+                    """
+                    SELECT
+                        jobs.url,
+                        states.stage,
+                        states.state,
+                        states.attempt_count,
+                        states.max_attempts,
+                        states.started_at,
+                        states.updated_at,
+                        states.finished_at,
+                        states.duration_ms,
+                        states.error_code,
+                        states.error_message,
+                        states.retryable,
+                        states.blocked_by_json,
+                        states.next_action,
+                        states.metadata_json,
+                        states.version
+                    FROM job_stage_states AS states
+                    JOIN jobs
+                      ON jobs.tenant_id = states.tenant_id
+                     AND jobs.job_id = states.job_id
+                    ORDER BY states.rowid
+                    """
+                ).fetchall()
+            ]
         execution_columns = {
             str(row[1]) for row in conn.execute("PRAGMA table_info(discovery_execution_jobs)").fetchall()
         }
@@ -568,7 +666,7 @@ def test_v6_jobs_gain_stable_uuid_and_posting_url_alias_once(
     init_db(db_path)
     close_connection(db_path)
 
-    assert _user_version(db_path) == SCHEMA_VERSION == 12
+    assert _user_version(db_path) == SCHEMA_VERSION == 13
     first_ids = _identity_rows(db_path)
     assert [row[0] for row in first_ids] == ["local", "local"]
     for _tenant_id, job_id, _url in first_ids:

--- a/workers/automation/tests/test_stage_runner_thread_safety.py
+++ b/workers/automation/tests/test_stage_runner_thread_safety.py
@@ -27,7 +27,7 @@ import pytest
 from jobctrl.database import get_connection, init_db
 from jobctrl.infrastructure.materials import SqliteMaterialsRepository
 from jobctrl.infrastructure.profile import factory as profile_factory
-from jobctrl.state import set_stage_state, ensure_job_stage_rows
+from jobctrl.state import ensure_job_stage_rows, get_stage_state_row, set_stage_state
 
 
 @pytest.fixture()
@@ -111,6 +111,13 @@ def test_failed_to_running_transition_skips_validation(
     production."""
 
     url = "https://example.com/job/1"
+    db.execute(
+        """
+        INSERT INTO jobs (url, title, site, discovered_at)
+        VALUES (?, 'Engineer', 'Example', '2026-01-01T00:00:00+00:00')
+        """,
+        (url,),
+    )
     ensure_job_stage_rows(db, url, discovered_at="2026-01-01T00:00:00+00:00")
     # Seed the row in 'failed' state via the validation bypass — the
     # canonical state machine doesn't permit pending -> failed directly,
@@ -128,8 +135,5 @@ def test_failed_to_running_transition_skips_validation(
 
     # Bypass path: runners pass validate_transition=False and survive.
     set_stage_state(db, url, "tailor", "running", validate_transition=False)
-    row = db.execute(
-        "SELECT state FROM job_stage_states WHERE job_url = ? AND stage = ?",
-        (url, "tailor"),
-    ).fetchone()
+    row = get_stage_state_row(db, url, "tailor")
     assert row["state"] == "running"

--- a/workers/automation/tests/test_stage_state_identity_reference_migration.py
+++ b/workers/automation/tests/test_stage_state_identity_reference_migration.py
@@ -1,0 +1,437 @@
+"""Schema-v13 stage-state identity migration contracts."""
+
+from __future__ import annotations
+
+import sqlite3
+import uuid
+from pathlib import Path
+
+import pytest
+
+import jobctrl.database as database_module
+from jobctrl.database import (
+    SCHEMA_VERSION,
+    _reassign_stage_state_references_v13,
+    close_connection,
+    ensure_stage_state_references_v13,
+    init_db,
+)
+from jobctrl.domain.discovery import (
+    Employer,
+    Job,
+    JobMetadata,
+    PostingUrl,
+    SearchStrategy,
+    Source,
+)
+from jobctrl.domain.identifiers import JobId
+from jobctrl.domain.tenant import LOCAL_TENANT
+from jobctrl.infrastructure.discovery import SqliteJobRepository
+from jobctrl.infrastructure.pipeline.sqlite_repository import (
+    SqlitePipelineStateRepository,
+)
+from jobctrl.state import (
+    ensure_job_stage_rows,
+    get_stage_state_row,
+    set_stage_state,
+)
+
+
+PREVIOUS_SCHEMA_VERSION = 12
+
+
+def _discovered_job(posting_url: str, job_id: JobId) -> Job:
+    return Job.discover(
+        tenant_id=LOCAL_TENANT,
+        job_id=job_id,
+        posting_url=PostingUrl(value=posting_url),
+        source=Source(board="example"),
+        employer=Employer(name="Example"),
+        search_strategy=SearchStrategy.JOBSPY,
+        metadata=JobMetadata(title="Platform Engineer"),
+        discovered_at="2026-07-29T10:00:00+00:00",
+    )
+
+
+def _downgrade_stage_state_references_to_v12(
+    conn: sqlite3.Connection,
+) -> None:
+    conn.execute("DROP TABLE job_stage_states")
+    conn.executescript(
+        """
+        CREATE TABLE job_stage_states (
+            job_url             TEXT NOT NULL,
+            stage               TEXT NOT NULL,
+            state               TEXT NOT NULL DEFAULT 'pending',
+            attempt_count       INTEGER DEFAULT 0,
+            max_attempts        INTEGER,
+            started_at          TEXT,
+            updated_at          TEXT NOT NULL,
+            finished_at         TEXT,
+            duration_ms         INTEGER,
+            error_code          TEXT,
+            error_message       TEXT,
+            retryable           INTEGER DEFAULT 1,
+            blocked_by_json     TEXT,
+            next_action         TEXT,
+            metadata_json       TEXT,
+            version             INTEGER NOT NULL DEFAULT 0,
+            PRIMARY KEY (job_url, stage),
+            FOREIGN KEY (job_url) REFERENCES jobs(url) ON DELETE CASCADE
+        );
+        CREATE INDEX idx_job_stage_states_stage_state
+            ON job_stage_states(stage, state, updated_at DESC);
+        CREATE INDEX idx_job_stage_states_job
+            ON job_stage_states(job_url, stage);
+        """
+    )
+    conn.execute(f"PRAGMA user_version = {PREVIOUS_SCHEMA_VERSION}")
+    conn.commit()
+
+
+def _insert_stage(
+    conn: sqlite3.Connection,
+    *,
+    job_url: str,
+    stage: str,
+    state: str,
+    attempt_count: int,
+    updated_at: str,
+    version: int,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO job_stage_states (
+            job_url, stage, state, attempt_count, max_attempts,
+            started_at, updated_at, finished_at, duration_ms,
+            error_code, error_message, retryable, blocked_by_json,
+            next_action, metadata_json, version
+        ) VALUES (?, ?, ?, ?, 5, ?, ?, ?, 100, ?, ?, 1, '[]', NULL, '{}', ?)
+        """,
+        (
+            job_url,
+            stage,
+            state,
+            attempt_count,
+            updated_at,
+            updated_at,
+            updated_at if state == "succeeded" else None,
+            "FIXTURE_FAILURE" if state == "failed" else None,
+            "fixture failed" if state == "failed" else None,
+            version,
+        ),
+    )
+
+
+def _columns(conn: sqlite3.Connection) -> set[str]:
+    return {
+        str(row[1])
+        for row in conn.execute(
+            "PRAGMA table_info(job_stage_states)"
+        ).fetchall()
+    }
+
+
+def test_v12_stage_states_migrate_alias_collisions_and_reopen(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    conn = init_db(db_path)
+    jobs = SqliteJobRepository(conn)
+
+    stable_job_id = JobId(str(uuid.uuid4()))
+    original_url = "https://boards.example/jobs/123"
+    current_url = "https://careers.example/jobs/platform-engineer"
+    jobs.save(_discovered_job(original_url, stable_job_id))
+    jobs.save(_discovered_job(current_url, stable_job_id))
+
+    uuid_shaped_url = str(uuid.uuid4())
+    uuid_url_owner = JobId(str(uuid.uuid4()))
+    id_text_collision_url = (
+        "https://example.com/jobs/id-text-collision"
+    )
+    jobs.save(_discovered_job(uuid_shaped_url, uuid_url_owner))
+    jobs.save(
+        _discovered_job(
+            id_text_collision_url,
+            JobId(uuid_shaped_url),
+        )
+    )
+
+    _downgrade_stage_state_references_to_v12(conn)
+    _insert_stage(
+        conn,
+        job_url=original_url,
+        stage="score",
+        state="succeeded",
+        attempt_count=4,
+        updated_at="2026-07-29T10:00:00+00:00",
+        version=7,
+    )
+    _insert_stage(
+        conn,
+        job_url=current_url,
+        stage="score",
+        state="failed",
+        attempt_count=2,
+        updated_at="2026-07-29T10:05:00+00:00",
+        version=3,
+    )
+    _insert_stage(
+        conn,
+        job_url=original_url,
+        stage="cover",
+        state="pending",
+        attempt_count=1,
+        updated_at="2026-07-29T10:01:00+00:00",
+        version=2,
+    )
+    _insert_stage(
+        conn,
+        job_url=uuid_shaped_url,
+        stage="apply",
+        state="pending",
+        attempt_count=0,
+        updated_at="2026-07-29T10:02:00+00:00",
+        version=1,
+    )
+    _insert_stage(
+        conn,
+        job_url=id_text_collision_url,
+        stage="discover",
+        state="succeeded",
+        attempt_count=1,
+        updated_at="2026-07-29T10:03:00+00:00",
+        version=1,
+    )
+    conn.commit()
+    close_connection(db_path)
+
+    reopened = init_db(db_path)
+    assert reopened.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_VERSION
+    assert "job_id" in _columns(reopened)
+    assert "job_url" not in _columns(reopened)
+    assert reopened.execute(
+        "SELECT COUNT(*) FROM job_stage_states"
+    ).fetchone()[0] == 4
+
+    score = reopened.execute(
+        """
+        SELECT state, attempt_count, version
+        FROM job_stage_states
+        WHERE tenant_id = 'local' AND job_id = ? AND stage = 'score'
+        """,
+        (str(stable_job_id),),
+    ).fetchone()
+    assert tuple(score) == ("failed", 4, 7)
+    assert [
+        tuple(row)
+        for row in reopened.execute(
+            """
+            SELECT version
+            FROM job_stage_states
+            WHERE tenant_id = 'local' AND job_id = ?
+            ORDER BY stage
+            """,
+            (str(stable_job_id),),
+        ).fetchall()
+    ] == [(7,), (7,)]
+    assert (
+        reopened.execute(
+            """
+            SELECT job_id
+            FROM job_stage_states
+            WHERE tenant_id = 'local' AND stage = 'apply'
+            """
+        ).fetchone()[0]
+        == str(uuid_url_owner)
+    )
+
+    assert get_stage_state_row(
+        reopened,
+        original_url,
+        "score",
+    )["state"] == "failed"
+    set_stage_state(
+        reopened,
+        original_url,
+        "score",
+        "pending",
+        validate_transition=False,
+    )
+    assert get_stage_state_row(
+        reopened,
+        current_url,
+        "score",
+    )["state"] == "pending"
+    assert reopened.execute(
+        """
+        SELECT COUNT(*)
+        FROM job_stage_states
+        WHERE tenant_id = 'local' AND job_id = ? AND stage = 'score'
+        """,
+        (str(stable_job_id),),
+    ).fetchone()[0] == 1
+
+    ensure_job_stage_rows(reopened, original_url)
+    aggregate = SqlitePipelineStateRepository(reopened).load(
+        LOCAL_TENANT,
+        original_url,
+    )
+    assert aggregate is not None
+    assert aggregate.version == 7
+    SqlitePipelineStateRepository(reopened).save(aggregate)
+    assert {
+        int(row[0])
+        for row in reopened.execute(
+            """
+            SELECT version
+            FROM job_stage_states
+            WHERE tenant_id = 'local' AND job_id = ?
+            """,
+            (str(stable_job_id),),
+        ).fetchall()
+    } == {8}
+    close_connection(db_path)
+
+
+def test_v13_stage_state_migration_rolls_back_and_retries(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    conn = init_db(db_path)
+    job_id = JobId(str(uuid.uuid4()))
+    job_url = "https://example.com/jobs/retry"
+    SqliteJobRepository(conn).save(_discovered_job(job_url, job_id))
+    _downgrade_stage_state_references_to_v12(conn)
+    _insert_stage(
+        conn,
+        job_url=job_url,
+        stage="score",
+        state="pending",
+        attempt_count=1,
+        updated_at="2026-07-29T10:00:00+00:00",
+        version=1,
+    )
+    conn.commit()
+
+    original_verify = (
+        database_module._verify_stage_state_references_v13
+    )
+
+    def _fail_verification(
+        _conn: sqlite3.Connection,
+        *,
+        expected_count: int,
+    ) -> None:
+        del expected_count
+        raise RuntimeError("injected stage-state verification failure")
+
+    monkeypatch.setattr(
+        database_module,
+        "_verify_stage_state_references_v13",
+        _fail_verification,
+    )
+    with pytest.raises(
+        RuntimeError,
+        match="injected stage-state verification failure",
+    ):
+        ensure_stage_state_references_v13(conn)
+    assert conn.execute("PRAGMA user_version").fetchone()[0] == 12
+    assert "job_url" in _columns(conn)
+    assert conn.execute(
+        "SELECT COUNT(*) FROM job_stage_states"
+    ).fetchone()[0] == 1
+
+    monkeypatch.setattr(
+        database_module,
+        "_verify_stage_state_references_v13",
+        original_verify,
+    )
+    assert ensure_stage_state_references_v13(conn) == [
+        "job_stage_states"
+    ]
+    assert conn.execute("PRAGMA user_version").fetchone()[0] == 13
+    assert "job_id" in _columns(conn)
+    close_connection(db_path)
+
+
+def test_runtime_stage_state_merge_preserves_latest_fact_and_counters(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    conn = init_db(db_path)
+    jobs = SqliteJobRepository(conn)
+    losing_id = JobId(str(uuid.uuid4()))
+    surviving_id = JobId(str(uuid.uuid4()))
+    losing_url = "https://example.com/jobs/losing"
+    surviving_url = "https://example.com/jobs/surviving"
+    jobs.save(_discovered_job(losing_url, losing_id))
+    jobs.save(_discovered_job(surviving_url, surviving_id))
+
+    _insert_stable_stage(
+        conn,
+        job_id=losing_id,
+        state="succeeded",
+        attempts=6,
+        updated_at="2026-07-29T10:00:00+00:00",
+        version=9,
+    )
+    _insert_stable_stage(
+        conn,
+        job_id=surviving_id,
+        state="failed",
+        attempts=2,
+        updated_at="2026-07-29T10:05:00+00:00",
+        version=3,
+    )
+    conn.commit()
+
+    _reassign_stage_state_references_v13(
+        conn,
+        tenant_id="local",
+        losing_job_id=str(losing_id),
+        surviving_job_id=str(surviving_id),
+    )
+    row = conn.execute(
+        """
+        SELECT job_id, state, attempt_count, version
+        FROM job_stage_states
+        WHERE tenant_id = 'local' AND stage = 'score'
+        """
+    ).fetchone()
+    assert tuple(row) == (str(surviving_id), "failed", 6, 9)
+    close_connection(db_path)
+
+
+def _insert_stable_stage(
+    conn: sqlite3.Connection,
+    *,
+    job_id: JobId,
+    state: str,
+    attempts: int,
+    updated_at: str,
+    version: int,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO job_stage_states (
+            tenant_id, job_id, stage, state, attempt_count, max_attempts,
+            started_at, updated_at, finished_at, duration_ms,
+            error_code, error_message, retryable, blocked_by_json,
+            next_action, metadata_json, version
+        ) VALUES (
+            'local', ?, 'score', ?, ?, 5, ?, ?, NULL, 100,
+            NULL, NULL, 1, '[]', NULL, '{}', ?
+        )
+        """,
+        (
+            str(job_id),
+            state,
+            attempts,
+            updated_at,
+            updated_at,
+            version,
+        ),
+    )

--- a/workers/automation/tests/test_state_dashboard.py
+++ b/workers/automation/tests/test_state_dashboard.py
@@ -7,6 +7,7 @@ from jobctrl.database import close_connection, get_connection, init_db
 from jobctrl.state import (
     ensure_job_stage_rows,
     get_job_stage_states,
+    get_stage_state_row,
     reconcile_dependency_blockers,
     set_stage_state,
 )
@@ -140,10 +141,11 @@ def test_retry_command_resets_stage_state(tmp_path, monkeypatch):
             "SELECT detail_error, detail_scraped_at FROM jobs WHERE url = ?",
             ("https://example.com/job",),
         ).fetchone()
-        state = conn.execute(
-            "SELECT state FROM job_stage_states WHERE job_url = ? AND stage = 'enrich'",
-            ("https://example.com/job",),
-        ).fetchone()
+        state = get_stage_state_row(
+            conn,
+            "https://example.com/job",
+            "enrich",
+        )
         assert result.exit_code == 0
         assert row["detail_error"] is None
         assert row["detail_scraped_at"] is None
@@ -239,11 +241,7 @@ def test_score_success_unblocks_tailor_waiting_on_score(tmp_path):
         set_stage_state(conn, job["url"], "score", "succeeded", finished_at="2026-04-29T10:02:00+00:00")
         conn.commit()
 
-        row = conn.execute(
-            "SELECT state, error_code, error_message, retryable "
-            "FROM job_stage_states WHERE job_url = ? AND stage = 'tailor'",
-            (job["url"],),
-        ).fetchone()
+        row = get_stage_state_row(conn, job["url"], "tailor")
         assert row["state"] == "pending"
         assert row["error_code"] is None
         assert row["error_message"] is None
@@ -272,11 +270,7 @@ def test_tailor_success_unblocks_cover_waiting_on_tailor(tmp_path):
         set_stage_state(conn, job["url"], "tailor", "succeeded", finished_at="2026-04-29T10:04:00+00:00")
         conn.commit()
 
-        rows = conn.execute(
-            "SELECT stage, state, error_message FROM job_stage_states "
-            "WHERE job_url = ? AND stage = 'cover' ORDER BY stage",
-            (job["url"],),
-        ).fetchall()
+        rows = [get_stage_state_row(conn, job["url"], "cover")]
         assert [(row["stage"], row["state"], row["error_message"]) for row in rows] == [
             ("cover", "pending", None),
         ]
@@ -304,11 +298,7 @@ def test_tailor_success_unblocks_apply_waiting_on_materials(tmp_path):
         set_stage_state(conn, job["url"], "tailor", "succeeded", finished_at="2026-04-29T10:04:00+00:00")
         conn.commit()
 
-        row = conn.execute(
-            "SELECT state, error_code, error_message FROM job_stage_states "
-            "WHERE job_url = ? AND stage = 'apply'",
-            (job["url"],),
-        ).fetchone()
+        row = get_stage_state_row(conn, job["url"], "apply")
         assert row["state"] == "pending"
         assert row["error_code"] is None
         assert row["error_message"] is None
@@ -336,11 +326,7 @@ def test_dependency_reconciliation_preserves_unrelated_blockers(tmp_path):
         set_stage_state(conn, job["url"], "score", "succeeded", finished_at="2026-04-29T10:02:00+00:00")
         conn.commit()
 
-        row = conn.execute(
-            "SELECT state, error_code, error_message FROM job_stage_states "
-            "WHERE job_url = ? AND stage = 'tailor'",
-            (job["url"],),
-        ).fetchone()
+        row = get_stage_state_row(conn, job["url"], "tailor")
         assert row["state"] == "blocked"
         assert row["error_code"] == "MIN_SCORE"
         assert row["error_message"] == "Fit score is below the tailoring threshold."
@@ -375,11 +361,7 @@ def test_dependency_reconciliation_repairs_existing_stale_rows(tmp_path):
         repaired = reconcile_dependency_blockers(conn)
         conn.commit()
 
-        row = conn.execute(
-            "SELECT state, error_message FROM job_stage_states "
-            "WHERE job_url = ? AND stage = 'tailor'",
-            (job["url"],),
-        ).fetchone()
+        row = get_stage_state_row(conn, job["url"], "tailor")
         assert repaired == 1
         assert row["state"] == "pending"
         assert row["error_message"] is None
@@ -414,11 +396,7 @@ def test_dependency_reconciliation_repairs_existing_apply_material_blocker(tmp_p
         repaired = reconcile_dependency_blockers(conn)
         conn.commit()
 
-        row = conn.execute(
-            "SELECT state, error_message FROM job_stage_states "
-            "WHERE job_url = ? AND stage = 'apply'",
-            (job["url"],),
-        ).fetchone()
+        row = get_stage_state_row(conn, job["url"], "apply")
         assert repaired == 1
         assert row["state"] == "pending"
         assert row["error_message"] is None

--- a/workers/automation/tests/test_tailor_retailor.py
+++ b/workers/automation/tests/test_tailor_retailor.py
@@ -23,7 +23,7 @@ from jobctrl.domain.profile.aggregate import Profile
 from jobctrl.domain.profile.snapshot import ProfileSnapshot
 from jobctrl.domain.tenant import LOCAL_TENANT
 from jobctrl.pipeline import _count_pending
-from jobctrl.state import ensure_job_stage_rows, set_stage_state
+from jobctrl.state import ensure_job_stage_rows, get_stage_state_row, set_stage_state
 from jobctrl.scoring.tailor import (
     _build_pdf_renderer,
     _build_llm_policy,
@@ -184,10 +184,7 @@ def test_tailor_job_by_url_does_not_enumerate_unrelated_pending_jobs(tmp_path, m
 
         assert result["status"] == "approved"
         assert calls == [target_url]
-        unrelated_stage = conn.execute(
-            "SELECT state FROM job_stage_states WHERE job_url = ? AND stage = 'tailor'",
-            (unrelated_url,),
-        ).fetchone()
+        unrelated_stage = get_stage_state_row(conn, unrelated_url, "tailor")
         assert unrelated_stage is None
     finally:
         close_connection(db_path)
@@ -258,16 +255,18 @@ def test_tailor_job_by_url_resets_stale_cover_success_after_new_resume(
         )
 
         assert result["status"] == "approved"
-        cover = conn.execute(
-            """
-            SELECT state, attempt_count, started_at, finished_at, duration_ms,
-                   error_code, error_message, next_action
-            FROM job_stage_states
-            WHERE job_url = ? AND stage = 'cover'
-            """,
-            (target_url,),
-        ).fetchone()
-        assert dict(cover) == {
+        cover = get_stage_state_row(conn, target_url, "cover")
+        audited_columns = (
+            "state",
+            "attempt_count",
+            "started_at",
+            "finished_at",
+            "duration_ms",
+            "error_code",
+            "error_message",
+            "next_action",
+        )
+        assert {column: cover[column] for column in audited_columns} == {
             "state": "pending",
             "attempt_count": 0,
             "started_at": None,
@@ -390,9 +389,14 @@ def test_tailor_job_by_url_surfaces_blocked_score_eligibility(tmp_path, monkeypa
         rows = conn.execute(
             """
             SELECT stage, state, error_code, error_message, blocked_by_json, next_action
-            FROM job_stage_states
-            WHERE job_url = ? AND stage IN ('tailor', 'cover', 'apply')
-            ORDER BY stage
+            FROM job_stage_states states
+            JOIN jobs
+              ON jobs.tenant_id = states.tenant_id
+             AND jobs.job_id = states.job_id
+            WHERE jobs.tenant_id = 'local'
+              AND jobs.url = ?
+              AND states.stage IN ('tailor', 'cover', 'apply')
+            ORDER BY states.stage
             """,
             (target_url,),
         ).fetchall()


### PR DESCRIPTION
## Summary

- migrate `job_stage_states` from URL-shaped keys to `(tenant_id, job_id, stage)` in schema v13
- preserve the latest lifecycle fact while retaining maximum attempt counters and a uniform aggregate optimistic-lock version during alias collisions
- update Python and TypeScript readers/writers for stable references, with bounded API compatibility for schema v12 databases
- cover rollback/retry, UUID-shaped URL collisions, runtime identity merges, aggregate saves, API mutation/delete isolation, and projection/read-model compatibility

## Why

Stage state is the canonical pipeline lifecycle authority. Keeping it keyed by posting URL left identity aliases able to split one Job aggregate across rows and made collision cleanup unsafe. This phase attaches lifecycle state to the stable JobId while preserving existing facts and concurrency guards.

## Validation

- `workers/automation/.venv/bin/python -m pytest -q` — 2681 passed, 2 skipped
- `pnpm --filter @jobctrl/api test` — 662 passed
- `workers/automation/.venv/bin/ruff check src tests` — passed
- `pnpm --filter @jobctrl/api check` — passed
- `git diff --check` — passed
- independent Tier 3 review — Gate: PASS, 0 findings

## Stack

- stacked on #537 (`feat/job-id-scoring-references`)
- canonical product docs and cumulative product QA remain deferred to the final approved stack PR