### PR TITLE
feat(artifacts): migrate registry references to stable JobIds

### DIFF
--- a/apps/api/src/application-feedback.ts
+++ b/apps/api/src/application-feedback.ts
@@ -50,6 +50,7 @@ import {
   hasCompositeJobIdForeignKey,
   jobReferenceColumn,
   jobReferenceJoinToJobs,
+  jobReferencePredicateForUrl,
   tableExists,
   type SqliteDatabase,
   type SqliteValue,
@@ -2663,6 +2664,11 @@ function materialArtifactCandidates(
   }
 
   if (tableExists(db, "job_artifacts")) {
+    const artifactReference = jobReferencePredicateForUrl(
+      db,
+      "job_artifacts",
+      jobKey,
+    );
     const rows = allRows<{
       created_at: string | null;
       path: string | null;
@@ -2671,14 +2677,14 @@ function materialArtifactCandidates(
       db,
       `SELECT rowid AS row_id, path, created_at
        FROM job_artifacts
-       WHERE job_url = ?
+       WHERE ${artifactReference.sql}
          AND artifact_type IN (${placeholders})
          AND COALESCE(status, 'active') NOT IN ('missing', 'failed', 'superseded', 'suppressed')
          AND path IS NOT NULL
          AND path != ''
        ORDER BY COALESCE(created_at, '') DESC, rowid DESC
        LIMIT 16`,
-      [jobKey, ...artifactTypes],
+      [...artifactReference.params, ...artifactTypes],
     );
     for (const [index, row] of rows.entries()) {
       pushMaterialCandidate(candidates, {

--- a/apps/api/src/db.ts
+++ b/apps/api/src/db.ts
@@ -9,7 +9,7 @@ export type SqliteValue = string | number | bigint | null;
 // writer that stamps ``PRAGMA user_version``; the API only reads it to fail
 // closed on a database written by a newer build. Bump both constants together
 // whenever the schema shape changes.
-export const SUPPORTED_SCHEMA_VERSION = 13;
+export const SUPPORTED_SCHEMA_VERSION = 14;
 
 export class IncompatibleSchemaVersionError extends Error {
   constructor(current: number) {

--- a/apps/api/src/projections.ts
+++ b/apps/api/src/projections.ts
@@ -3868,6 +3868,11 @@ function collectArtifacts(
     }
   }
   if (tableExists(db, "job_artifacts")) {
+    const artifactReference = jobReferencePredicateForUrl(
+      db,
+      "job_artifacts",
+      jobUrl,
+    );
     const rows = allRows<{
       row_id: number | string;
       artifact_type: string;
@@ -3878,8 +3883,8 @@ function collectArtifacts(
     }>(
       db,
       `SELECT rowid AS row_id, artifact_type, status, path, created_at, size_bytes
-       FROM job_artifacts WHERE job_url = ?`,
-      [jobUrl],
+       FROM job_artifacts WHERE ${artifactReference.sql}`,
+      artifactReference.params,
     );
     for (const row of rows) {
       if (!row.path) continue;

--- a/apps/api/src/write-model.ts
+++ b/apps/api/src/write-model.ts
@@ -850,7 +850,7 @@ function purgeJobRows(db: SqliteDatabase, jobUrl: string): void {
     }
   }
   deleteWhere(db, "job_events", "job_url = ?", [jobUrl]);
-  deleteWhere(db, "job_artifacts", "job_url = ?", [jobUrl]);
+  deleteJobReferences(db, "job_artifacts", jobId, jobUrl);
   deleteScoringJobReferences(db, jobId, jobUrl);
   deleteWhere(db, "job_materials_artifacts", "job_url = ?", [jobUrl]);
   deleteWhere(db, "job_materials", "job_url = ?", [jobUrl]);
@@ -1000,6 +1000,25 @@ function deleteScoringJobReferences(
     if (!reference) continue;
     deleteWhere(db, tableName, `${referenceColumn} = ?`, [reference]);
   }
+}
+
+function deleteJobReferences(
+  db: SqliteDatabase,
+  tableName: string,
+  jobId: string | undefined,
+  jobUrl: string,
+): void {
+  if (!tableExists(db, tableName)) return;
+  const referenceColumn = jobReferenceColumn(db, tableName);
+  const reference = referenceColumn === "job_id" ? jobId : jobUrl;
+  if (!reference) return;
+  const predicate = referenceColumn === "job_id"
+    ? "tenant_id = ? AND job_id = ?"
+    : "job_url = ?";
+  const params: SqliteValue[] = referenceColumn === "job_id"
+    ? ["local", reference]
+    : [reference];
+  deleteWhere(db, tableName, predicate, params);
 }
 
 function ensureJobScoresTable(db: SqliteDatabase): void {

--- a/apps/api/test/artifact-registry-v14-write-model.test.ts
+++ b/apps/api/test/artifact-registry-v14-write-model.test.ts
@@ -1,0 +1,93 @@
+import Database from "better-sqlite3";
+import { describe, expect, it } from "vitest";
+
+import { jobReferencePredicateForUrl } from "../src/db.js";
+import { permanentlyDeleteJob } from "../src/write-model.js";
+
+describe("schema-v14 artifact-registry writes", () => {
+  it("deletes only the URL owner's stable artifact registrations", () => {
+    const db = new Database(":memory:");
+    db.pragma("foreign_keys = ON");
+    db.pragma("user_version = 14");
+    db.exec(`
+      CREATE TABLE jobs (
+        url TEXT PRIMARY KEY,
+        tenant_id TEXT NOT NULL DEFAULT 'local',
+        job_id TEXT NOT NULL,
+        application_url TEXT,
+        apply_status TEXT,
+        apply_error TEXT,
+        applied_at TEXT,
+        UNIQUE (tenant_id, job_id)
+      );
+      CREATE TABLE job_artifacts (
+        artifact_id INTEGER PRIMARY KEY AUTOINCREMENT,
+        tenant_id TEXT NOT NULL DEFAULT 'local',
+        job_id TEXT NOT NULL,
+        stage TEXT NOT NULL,
+        artifact_type TEXT NOT NULL,
+        status TEXT NOT NULL DEFAULT 'candidate',
+        path TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        size_bytes INTEGER,
+        metadata_json TEXT,
+        FOREIGN KEY (tenant_id, job_id)
+          REFERENCES jobs(tenant_id, job_id) ON DELETE CASCADE
+      );
+      CREATE UNIQUE INDEX idx_job_artifacts_registry_key
+        ON job_artifacts(
+          tenant_id, job_id, stage, artifact_type, path
+        );
+    `);
+
+    const uuidShapedUrl = "11111111-1111-4111-8111-111111111111";
+    const urlOwnerJobId = "22222222-2222-4222-8222-222222222222";
+    const idTextOwnerUrl = "https://example.com/jobs/id-text-owner";
+    db.prepare(
+      `INSERT INTO jobs (url, tenant_id, job_id)
+       VALUES (?, 'local', ?), (?, 'local', ?)`,
+    ).run(
+      uuidShapedUrl,
+      urlOwnerJobId,
+      idTextOwnerUrl,
+      uuidShapedUrl,
+    );
+    db.prepare(
+      `INSERT INTO job_artifacts (
+         tenant_id, job_id, stage, artifact_type, status, path, created_at
+       ) VALUES
+         ('local', ?, 'apply', 'apply_log', 'active', '/tmp/url-owner.log',
+          '2026-07-29T10:00:00.000Z'),
+         ('local', ?, 'apply', 'apply_log', 'active', '/tmp/id-owner.log',
+          '2026-07-29T10:00:00.000Z')`,
+    ).run(urlOwnerJobId, uuidShapedUrl);
+
+    expect(
+      jobReferencePredicateForUrl(db, "job_artifacts", uuidShapedUrl),
+    ).toEqual({
+      sql: "tenant_id = ? AND job_id = ?",
+      params: ["local", urlOwnerJobId],
+    });
+
+    expect(permanentlyDeleteJob(db, uuidShapedUrl)).toEqual({
+      ok: true,
+      count: 1,
+      jobKeys: [uuidShapedUrl],
+    });
+    expect(
+      db.prepare("SELECT url FROM jobs ORDER BY url").all(),
+    ).toEqual([{ url: idTextOwnerUrl }]);
+    expect(
+      db.prepare(
+        "SELECT job_id, path FROM job_artifacts ORDER BY path",
+      ).all(),
+    ).toEqual([
+      {
+        job_id: uuidShapedUrl,
+        path: "/tmp/id-owner.log",
+      },
+    ]);
+
+    db.close();
+  });
+});

--- a/apps/api/test/schema-version-guard.test.ts
+++ b/apps/api/test/schema-version-guard.test.ts
@@ -62,6 +62,17 @@ describe("schema version guard at DB open", () => {
     }
   });
 
+  it("opens the worker-owned schema-v14 artifact registry", () => {
+    expect(SUPPORTED_SCHEMA_VERSION).toBe(14);
+    const { dbPath, cleanup } = makeDbWithUserVersion(14);
+    try {
+      openDatabase(dbPath).close();
+      openReadOnlyDatabase(dbPath).close();
+    } finally {
+      cleanup();
+    }
+  });
+
   it("never stamps user_version — stamping stays the worker's job", () => {
     const { dbPath, cleanup } = makeDbWithUserVersion(0);
     try {

--- a/workers/automation/src/jobctrl/database.py
+++ b/workers/automation/src/jobctrl/database.py
@@ -55,7 +55,10 @@ from jobctrl.config import DB_PATH, DEFAULTS, migrate_legacy_job_tables
 # v13 (stage-state references): the canonical per-stage lifecycle row references
 # ``(tenant_id, job_id)``. Alias collisions keep the most recently updated
 # lifecycle fact while preserving monotonic attempt and optimistic-lock counts.
-SCHEMA_VERSION = 13
+# v14 (artifact registry references): generic per-job artifact registrations
+# reference ``(tenant_id, job_id)``. Alias collisions retain one current row per
+# registry key using the same last-write-wins rule as runtime artifact upserts.
+SCHEMA_VERSION = 14
 
 
 class IncompatibleSchemaVersionError(RuntimeError):
@@ -199,6 +202,7 @@ def _schema_migrations() -> tuple[
         (11, ensure_enrichment_snapshot_references_v11),
         (12, ensure_scoring_references_v12),
         (13, ensure_stage_state_references_v13),
+        (14, ensure_artifact_registry_references_v14),
     )
 
 
@@ -1416,21 +1420,24 @@ def ensure_state_tables(conn: sqlite3.Connection | None = None) -> list[str]:
         WHERE idempotency_key IS NOT NULL
         """
     )
-    conn.execute("""
-        CREATE TABLE IF NOT EXISTS job_artifacts (
-            artifact_id         INTEGER PRIMARY KEY AUTOINCREMENT,
-            job_url             TEXT NOT NULL,
-            stage               TEXT NOT NULL,
-            artifact_type       TEXT NOT NULL,
-            status              TEXT NOT NULL DEFAULT 'candidate',
-            path                TEXT NOT NULL,
-            created_at          TEXT NOT NULL,
-            size_bytes          INTEGER,
-            metadata_json       TEXT,
-            UNIQUE(job_url, stage, artifact_type, path),
-            FOREIGN KEY (job_url) REFERENCES jobs(url) ON DELETE CASCADE
-        )
-    """)
+    if current_schema_version >= _ARTIFACT_REGISTRY_REFERENCE_SCHEMA_VERSION:
+        _create_job_artifacts_v14(conn)
+    else:
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS job_artifacts (
+                artifact_id         INTEGER PRIMARY KEY AUTOINCREMENT,
+                job_url             TEXT NOT NULL,
+                stage               TEXT NOT NULL,
+                artifact_type       TEXT NOT NULL,
+                status              TEXT NOT NULL DEFAULT 'candidate',
+                path                TEXT NOT NULL,
+                created_at          TEXT NOT NULL,
+                size_bytes          INTEGER,
+                metadata_json       TEXT,
+                UNIQUE(job_url, stage, artifact_type, path),
+                FOREIGN KEY (job_url) REFERENCES jobs(url) ON DELETE CASCADE
+            )
+        """)
     conn.execute("""
         CREATE INDEX IF NOT EXISTS idx_job_stage_states_stage_state
         ON job_stage_states(stage, state, updated_at DESC)
@@ -1457,10 +1464,14 @@ def ensure_state_tables(conn: sqlite3.Connection | None = None) -> list[str]:
         CREATE INDEX IF NOT EXISTS idx_job_events_entity
         ON job_events(entity_kind, entity_ref, occurred_at DESC, event_id DESC)
     """)
-    conn.execute("""
-        CREATE INDEX IF NOT EXISTS idx_job_artifacts_job_stage
-        ON job_artifacts(job_url, stage, status)
-    """)
+    artifact_columns = _table_columns(conn, "job_artifacts")
+    if "job_id" in artifact_columns:
+        _create_job_artifact_indexes_v14(conn)
+    else:
+        conn.execute("""
+            CREATE INDEX IF NOT EXISTS idx_job_artifacts_job_stage
+            ON job_artifacts(job_url, stage, status)
+        """)
     # Event-watermark tracking — used by Phase 9 projection builders to
     # remember the last event_id they consumed.  The row exists per
     # projection name and is updated atomically as events are processed.
@@ -4323,6 +4334,13 @@ def _reassign_discovery_identity_references(
         )
     if _has_stage_state_reference_schema_v13(conn):
         _reassign_stage_state_references_v13(
+            conn,
+            tenant_id=tenant_id,
+            losing_job_id=losing_job_id,
+            surviving_job_id=surviving_job_id,
+        )
+    if _has_artifact_registry_reference_schema_v14(conn):
+        _reassign_artifact_registry_references_v14(
             conn,
             tenant_id=tenant_id,
             losing_job_id=losing_job_id,
@@ -8354,6 +8372,352 @@ def _reassign_stage_state_references_v13(
     )
     expected_count = before_count - len(raw_rows) + len(merged_rows)
     _verify_stage_state_references_v13(
+        conn,
+        expected_count=expected_count,
+    )
+
+
+_ARTIFACT_REGISTRY_REFERENCE_SCHEMA_VERSION = 14
+_ARTIFACT_REGISTRY_REFERENCE_TABLES = ("job_artifacts",)
+
+
+def _create_job_artifacts_v14(
+    conn: sqlite3.Connection,
+    *,
+    table_name: str = "job_artifacts",
+) -> None:
+    conn.execute(
+        f"""
+        CREATE TABLE IF NOT EXISTS {table_name} (
+            artifact_id         INTEGER PRIMARY KEY AUTOINCREMENT,
+            tenant_id           TEXT NOT NULL DEFAULT 'local',
+            job_id              TEXT NOT NULL,
+            stage               TEXT NOT NULL,
+            artifact_type       TEXT NOT NULL,
+            status              TEXT NOT NULL DEFAULT 'candidate',
+            path                TEXT NOT NULL,
+            created_at          TEXT NOT NULL,
+            size_bytes          INTEGER,
+            metadata_json       TEXT,
+            FOREIGN KEY (tenant_id, job_id)
+                REFERENCES jobs(tenant_id, job_id) ON DELETE CASCADE
+        )
+        """
+    )
+
+
+def _create_job_artifact_indexes_v14(
+    conn: sqlite3.Connection,
+) -> None:
+    conn.execute(
+        """
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_job_artifacts_registry_key
+        ON job_artifacts(
+            tenant_id, job_id, stage, artifact_type, path
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_job_artifacts_job_stage
+        ON job_artifacts(tenant_id, job_id, stage, status)
+        """
+    )
+
+
+def _has_artifact_registry_reference_schema_v14(
+    conn: sqlite3.Connection,
+) -> bool:
+    return (
+        "job_id" in _table_columns(conn, "job_artifacts")
+        and "job_url" not in _table_columns(conn, "job_artifacts")
+        and _primary_key_columns(conn, "job_artifacts") == ("artifact_id",)
+        and _has_composite_job_id_foreign_key(
+            conn,
+            "job_artifacts",
+            "job_id",
+        )
+        and _has_index(
+            conn,
+            "job_artifacts",
+            "idx_job_artifacts_registry_key",
+            (
+                "tenant_id",
+                "job_id",
+                "stage",
+                "artifact_type",
+                "path",
+            ),
+            unique=True,
+        )
+        and _has_index(
+            conn,
+            "job_artifacts",
+            "idx_job_artifacts_job_stage",
+            ("tenant_id", "job_id", "stage", "status"),
+            unique=False,
+        )
+    )
+
+
+def _artifact_registry_row_rank_v14(
+    row: tuple[Any, ...],
+) -> tuple[tuple[float, str], int]:
+    return (
+        _stage_state_timestamp_rank(row[6]),
+        int(row[0]),
+    )
+
+
+def _canonical_artifact_registry_rows_v14(
+    conn: sqlite3.Connection,
+) -> list[tuple[Any, ...]]:
+    rows = conn.execute(
+        """
+        SELECT artifact_id, job_url, stage, artifact_type, status, path,
+               created_at, size_bytes, metadata_json
+        FROM job_artifacts
+        ORDER BY artifact_id
+        """
+    ).fetchall()
+    grouped: dict[
+        tuple[str, str, str, str, str],
+        list[tuple[Any, ...]],
+    ] = {}
+    for row in rows:
+        raw_reference = str(row[1])
+        stable_job_id = _resolve_job_reference_value(
+            conn,
+            tenant_id="local",
+            reference=raw_reference,
+            legacy_url=True,
+        )
+        if stable_job_id is None:
+            raise RuntimeError(
+                "artifact registry reference migration could not resolve "
+                f"job_artifacts.job_url={raw_reference!r}"
+            )
+        _validate_job_uuid(stable_job_id)
+        key = (
+            "local",
+            stable_job_id,
+            str(row[2]),
+            str(row[3]),
+            str(row[5]),
+        )
+        grouped.setdefault(key, []).append(tuple(row))
+
+    canonical: list[tuple[Any, ...]] = []
+    for (
+        tenant_id,
+        stable_job_id,
+        stage,
+        artifact_type,
+        path,
+    ), candidates in sorted(grouped.items()):
+        selected = max(candidates, key=_artifact_registry_row_rank_v14)
+        canonical.append(
+            (
+                int(selected[0]),
+                tenant_id,
+                stable_job_id,
+                stage,
+                artifact_type,
+                str(selected[4]),
+                path,
+                str(selected[6]),
+                selected[7],
+                selected[8],
+            )
+        )
+    return canonical
+
+
+def ensure_artifact_registry_references_v14(
+    conn: sqlite3.Connection | None = None,
+) -> list[str]:
+    """Move generic artifact registrations to stable JobId references."""
+    if conn is None:
+        conn = get_connection()
+
+    current = _assert_schema_version_supported(conn)
+    if current >= _ARTIFACT_REGISTRY_REFERENCE_SCHEMA_VERSION:
+        return []
+    if current != _STAGE_STATE_REFERENCE_SCHEMA_VERSION:
+        raise RuntimeError(
+            "artifact registry reference migration requires stage-state "
+            "schema v13"
+        )
+
+    conn.execute("SAVEPOINT artifact_registry_references_v14")
+    try:
+        if not _has_stage_state_reference_schema_v13(conn):
+            raise RuntimeError(
+                "artifact registry reference migration requires the stable "
+                "stage-state reference schema"
+            )
+        if _has_artifact_registry_reference_schema_v14(conn):
+            expected_count = int(
+                conn.execute("SELECT COUNT(*) FROM job_artifacts").fetchone()[0]
+            )
+        else:
+            canonical_rows = _canonical_artifact_registry_rows_v14(conn)
+            expected_count = len(canonical_rows)
+            conn.execute("DROP TABLE IF EXISTS job_artifacts_v14")
+            _create_job_artifacts_v14(
+                conn,
+                table_name="job_artifacts_v14",
+            )
+            conn.executemany(
+                """
+                INSERT INTO job_artifacts_v14 (
+                    artifact_id, tenant_id, job_id, stage, artifact_type,
+                    status, path, created_at, size_bytes, metadata_json
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                canonical_rows,
+            )
+            conn.execute("DROP TABLE job_artifacts")
+            conn.execute(
+                "ALTER TABLE job_artifacts_v14 RENAME TO job_artifacts"
+            )
+            _create_job_artifact_indexes_v14(conn)
+        _verify_artifact_registry_references_v14(
+            conn,
+            expected_count=expected_count,
+        )
+        conn.execute(
+            f"PRAGMA user_version = "
+            f"{_ARTIFACT_REGISTRY_REFERENCE_SCHEMA_VERSION}"
+        )
+        conn.execute("RELEASE SAVEPOINT artifact_registry_references_v14")
+        conn.commit()
+    except BaseException:
+        conn.execute("ROLLBACK TO SAVEPOINT artifact_registry_references_v14")
+        conn.execute("RELEASE SAVEPOINT artifact_registry_references_v14")
+        raise
+
+    return list(_ARTIFACT_REGISTRY_REFERENCE_TABLES)
+
+
+def _verify_artifact_registry_references_v14(
+    conn: sqlite3.Connection,
+    *,
+    expected_count: int,
+) -> None:
+    if not _has_artifact_registry_reference_schema_v14(conn):
+        raise RuntimeError(
+            "artifact registry reference migration did not install the "
+            "canonical schema"
+        )
+    observed_count = int(
+        conn.execute("SELECT COUNT(*) FROM job_artifacts").fetchone()[0]
+    )
+    if observed_count != expected_count:
+        raise RuntimeError(
+            "artifact registry reference migration changed the canonical "
+            f"row count: expected {expected_count}, found {observed_count}"
+        )
+    orphan = conn.execute(
+        """
+        SELECT artifact.job_id
+        FROM job_artifacts AS artifact
+        LEFT JOIN jobs j
+          ON j.tenant_id = artifact.tenant_id
+         AND j.job_id = artifact.job_id
+        WHERE j.job_id IS NULL
+        LIMIT 1
+        """
+    ).fetchone()
+    if orphan is not None:
+        raise RuntimeError(
+            "artifact registry reference migration left an unresolved JobId"
+        )
+    for row in conn.execute(
+        "SELECT DISTINCT job_id FROM job_artifacts"
+    ).fetchall():
+        _validate_job_uuid(str(row[0]))
+    foreign_key_error = conn.execute("PRAGMA foreign_key_check").fetchone()
+    if foreign_key_error is not None:
+        raise RuntimeError(
+            "artifact registry reference migration found a foreign-key "
+            "violation"
+        )
+
+
+def _reassign_artifact_registry_references_v14(
+    conn: sqlite3.Connection,
+    *,
+    tenant_id: str,
+    losing_job_id: str,
+    surviving_job_id: str,
+) -> None:
+    """Merge generic artifact registrations during Job identity collapse."""
+    if losing_job_id == surviving_job_id:
+        return
+    before_count = int(
+        conn.execute("SELECT COUNT(*) FROM job_artifacts").fetchone()[0]
+    )
+    rows = conn.execute(
+        """
+        SELECT artifact_id, tenant_id, job_id, stage, artifact_type,
+               status, path, created_at, size_bytes, metadata_json
+        FROM job_artifacts
+        WHERE tenant_id = ? AND job_id IN (?, ?)
+        ORDER BY artifact_id
+        """,
+        (tenant_id, losing_job_id, surviving_job_id),
+    ).fetchall()
+    grouped: dict[
+        tuple[str, str, str],
+        list[tuple[Any, ...]],
+    ] = {}
+    for row in rows:
+        grouped.setdefault(
+            (str(row[3]), str(row[4]), str(row[6])),
+            [],
+        ).append(tuple(row))
+    merged_rows: list[tuple[Any, ...]] = []
+    for (stage, artifact_type, path), candidates in sorted(grouped.items()):
+        selected = max(
+            candidates,
+            key=lambda row: (
+                _stage_state_timestamp_rank(row[7]),
+                int(row[0]),
+            ),
+        )
+        merged_rows.append(
+            (
+                int(selected[0]),
+                tenant_id,
+                surviving_job_id,
+                stage,
+                artifact_type,
+                str(selected[5]),
+                path,
+                str(selected[7]),
+                selected[8],
+                selected[9],
+            )
+        )
+    conn.execute(
+        """
+        DELETE FROM job_artifacts
+        WHERE tenant_id = ? AND job_id IN (?, ?)
+        """,
+        (tenant_id, losing_job_id, surviving_job_id),
+    )
+    conn.executemany(
+        """
+        INSERT INTO job_artifacts (
+            artifact_id, tenant_id, job_id, stage, artifact_type,
+            status, path, created_at, size_bytes, metadata_json
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        merged_rows,
+    )
+    expected_count = before_count - len(rows) + len(merged_rows)
+    _verify_artifact_registry_references_v14(
         conn,
         expected_count=expected_count,
     )

--- a/workers/automation/src/jobctrl/infrastructure/projections/projection_builder.py
+++ b/workers/automation/src/jobctrl/infrastructure/projections/projection_builder.py
@@ -2881,14 +2881,19 @@ class ProjectionBuilder:
         except sqlite3.OperationalError:
             pass
         try:
+            artifact_predicate, artifact_params = _job_reference_predicate_for_url(
+                self._conn,
+                "job_artifacts",
+                job_url,
+            )
             for row in self._conn.execute(
-                """
-                SELECT rowid AS row_id, job_url, stage, artifact_type, status,
+                f"""
+                SELECT rowid AS row_id, stage, artifact_type, status,
                        path, created_at, size_bytes
                 FROM job_artifacts
-                WHERE job_url = ?
+                WHERE {artifact_predicate}
                 """,
-                (job_url,),
+                artifact_params,
             ).fetchall():
                 local_path = _row_nullable_str(row, "path") or ""
                 atype = _row_nullable_str(row, "artifact_type") or "artifact"
@@ -4114,6 +4119,42 @@ def _has_column(conn: sqlite3.Connection, table_name: str, column_name: str) -> 
     return any(
         (row["name"] if isinstance(row, sqlite3.Row) else row[1]) == column_name
         for row in conn.execute(f"PRAGMA table_info({table_name})")
+    )
+
+
+def _job_reference_predicate_for_url(
+    conn: sqlite3.Connection,
+    table_name: str,
+    job_url: str,
+    *,
+    tenant_id: str = str(LOCAL_TENANT),
+) -> tuple[str, tuple[str, ...]]:
+    """Resolve one explicit posting URL for legacy or stable table shapes."""
+    if not _has_column(conn, table_name, "job_id"):
+        return "job_url = ?", (job_url,)
+    row = conn.execute(
+        """
+        SELECT j.tenant_id, j.job_id
+        FROM jobs j
+        WHERE j.tenant_id = ? AND j.url = ?
+        UNION ALL
+        SELECT alias.tenant_id, alias.job_id
+        FROM job_identity_aliases alias
+        JOIN jobs j
+          ON j.tenant_id = alias.tenant_id
+         AND j.job_id = alias.job_id
+        WHERE alias.tenant_id = ?
+          AND alias.alias_kind = 'posting_url'
+          AND alias.alias_value = ?
+        LIMIT 1
+        """,
+        (tenant_id, job_url, tenant_id, job_url),
+    ).fetchone()
+    if row is None:
+        raise ValueError(f"no stable Job identity for posting URL: {job_url}")
+    return "tenant_id = ? AND job_id = ?", (
+        str(row[0]),
+        str(row[1]),
     )
 
 

--- a/workers/automation/src/jobctrl/state.py
+++ b/workers/automation/src/jobctrl/state.py
@@ -975,10 +975,43 @@ def record_job_artifact(
 ) -> None:
     """Record or update one artifact with provenance."""
     path_str = str(path)
+    artifact_columns = {
+        str(row[1])
+        for row in conn.execute("PRAGMA table_info(job_artifacts)").fetchall()
+    }
+    values = (
+        stage,
+        artifact_type,
+        status,
+        path_str,
+        created_at or utc_now(),
+        _path_size(path_str),
+        _json_dumps(metadata),
+    )
+    if "job_id" in artifact_columns:
+        tenant_id, job_id = _stable_stage_identity_for_url(conn, job_url)
+        conn.execute(
+            """
+            INSERT INTO job_artifacts (
+                tenant_id, job_id, stage, artifact_type, status, path,
+                created_at, size_bytes, metadata_json
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(
+                tenant_id, job_id, stage, artifact_type, path
+            ) DO UPDATE SET
+                status = excluded.status,
+                created_at = excluded.created_at,
+                size_bytes = excluded.size_bytes,
+                metadata_json = excluded.metadata_json
+            """,
+            (tenant_id, job_id, *values),
+        )
+        return
     conn.execute(
         """
         INSERT INTO job_artifacts (
-            job_url, stage, artifact_type, status, path, created_at, size_bytes, metadata_json
+            job_url, stage, artifact_type, status, path, created_at,
+            size_bytes, metadata_json
         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
         ON CONFLICT(job_url, stage, artifact_type, path) DO UPDATE SET
             status = excluded.status,
@@ -986,16 +1019,7 @@ def record_job_artifact(
             size_bytes = excluded.size_bytes,
             metadata_json = excluded.metadata_json
         """,
-        (
-            job_url,
-            stage,
-            artifact_type,
-            status,
-            path_str,
-            created_at or utc_now(),
-            _path_size(path_str),
-            _json_dumps(metadata),
-        ),
+        (job_url, *values),
     )
 
 

--- a/workers/automation/tests/test_apply_log_artifact_registration.py
+++ b/workers/automation/tests/test_apply_log_artifact_registration.py
@@ -86,8 +86,10 @@ def test_mark_result_applied_registers_apply_log_artifact(
         )
 
         artifact_row = conn.execute(
-            "SELECT job_url, stage, artifact_type, status, path, size_bytes "
-            "FROM job_artifacts WHERE job_url = ? AND artifact_type = 'apply_log'",
+            "SELECT job_id, stage, artifact_type, status, path, size_bytes "
+            "FROM job_artifacts WHERE tenant_id = 'local' "
+            "AND job_id = (SELECT job_id FROM jobs WHERE url = ?) "
+            "AND artifact_type = 'apply_log'",
             ("https://example.com/job",),
         ).fetchone()
         assert artifact_row is not None
@@ -141,7 +143,9 @@ def test_mark_result_failed_registers_apply_log_artifact(tmp_path, monkeypatch):
 
         row = conn.execute(
             "SELECT path, size_bytes FROM job_artifacts "
-            "WHERE job_url = ? AND artifact_type = 'apply_log'",
+            "WHERE tenant_id = 'local' "
+            "AND job_id = (SELECT job_id FROM jobs WHERE url = ?) "
+            "AND artifact_type = 'apply_log'",
             ("https://example.com/job",),
         ).fetchone()
         assert row is not None
@@ -181,7 +185,9 @@ def test_mark_result_dry_run_registers_apply_log_artifact(
 
         row = conn.execute(
             "SELECT path FROM job_artifacts "
-            "WHERE job_url = ? AND artifact_type = 'apply_log'",
+            "WHERE tenant_id = 'local' "
+            "AND job_id = (SELECT job_id FROM jobs WHERE url = ?) "
+            "AND artifact_type = 'apply_log'",
             ("https://example.com/job",),
         ).fetchone()
         assert row is not None
@@ -246,7 +252,9 @@ def test_repository_persists_dry_run_blocked_channel_artifact(
 
         row = conn.execute(
             "SELECT path, metadata_json FROM job_artifacts "
-            "WHERE job_url = ? AND artifact_type = 'apply_dryrun_blocked'",
+            "WHERE tenant_id = 'local' "
+            "AND job_id = (SELECT job_id FROM jobs WHERE url = ?) "
+            "AND artifact_type = 'apply_dryrun_blocked'",
             ("https://example.com/job",),
         ).fetchone()
         assert row is not None
@@ -300,7 +308,8 @@ def test_mark_result_without_worker_id_skips_artifact_registration(
         )
 
         rows = conn.execute(
-            "SELECT 1 FROM job_artifacts WHERE job_url = ? "
+            "SELECT 1 FROM job_artifacts WHERE tenant_id = 'local' "
+            "AND job_id = (SELECT job_id FROM jobs WHERE url = ?) "
             "AND artifact_type = 'apply_log'",
             ("https://example.com/job",),
         ).fetchall()
@@ -376,7 +385,9 @@ def test_mark_result_apply_log_registration_is_idempotent(
 
         rows = conn.execute(
             "SELECT path, size_bytes FROM job_artifacts "
-            "WHERE job_url = ? AND artifact_type = 'apply_log'",
+            "WHERE tenant_id = 'local' "
+            "AND job_id = (SELECT job_id FROM jobs WHERE url = ?) "
+            "AND artifact_type = 'apply_log'",
             ("https://example.com/job",),
         ).fetchall()
         assert len(rows) == 1

--- a/workers/automation/tests/test_artifact_registry_identity_reference_migration.py
+++ b/workers/automation/tests/test_artifact_registry_identity_reference_migration.py
@@ -1,0 +1,364 @@
+"""Schema-v14 generic artifact-registry identity migration contracts."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import uuid
+from pathlib import Path
+
+import pytest
+
+import jobctrl.database as database_module
+from jobctrl.database import (
+    SCHEMA_VERSION,
+    _reassign_artifact_registry_references_v14,
+    close_connection,
+    ensure_artifact_registry_references_v14,
+    get_connection,
+    init_db,
+)
+from jobctrl.domain.discovery import (
+    Employer,
+    Job,
+    JobMetadata,
+    PostingUrl,
+    SearchStrategy,
+    Source,
+)
+from jobctrl.domain.identifiers import JobId
+from jobctrl.domain.tenant import LOCAL_TENANT
+from jobctrl.infrastructure.discovery import SqliteJobRepository
+from jobctrl.infrastructure.projections.projection_builder import (
+    ProjectionBuilder,
+)
+from jobctrl.state import record_job_artifact
+
+
+PREVIOUS_SCHEMA_VERSION = 13
+
+
+def _discovered_job(posting_url: str, job_id: JobId) -> Job:
+    return Job.discover(
+        tenant_id=LOCAL_TENANT,
+        job_id=job_id,
+        posting_url=PostingUrl(value=posting_url),
+        source=Source(board="example"),
+        employer=Employer(name="Example"),
+        search_strategy=SearchStrategy.JOBSPY,
+        metadata=JobMetadata(title="Platform Engineer"),
+        discovered_at="2026-07-29T10:00:00+00:00",
+    )
+
+
+def _downgrade_artifact_registry_to_v13(
+    conn: sqlite3.Connection,
+) -> None:
+    conn.execute("DROP TABLE job_artifacts")
+    conn.executescript(
+        """
+        CREATE TABLE job_artifacts (
+            artifact_id         INTEGER PRIMARY KEY AUTOINCREMENT,
+            job_url             TEXT NOT NULL,
+            stage               TEXT NOT NULL,
+            artifact_type       TEXT NOT NULL,
+            status              TEXT NOT NULL DEFAULT 'candidate',
+            path                TEXT NOT NULL,
+            created_at          TEXT NOT NULL,
+            size_bytes          INTEGER,
+            metadata_json       TEXT,
+            UNIQUE(job_url, stage, artifact_type, path),
+            FOREIGN KEY (job_url) REFERENCES jobs(url) ON DELETE CASCADE
+        );
+        CREATE INDEX idx_job_artifacts_job_stage
+            ON job_artifacts(job_url, stage, status);
+        """
+    )
+    conn.execute(f"PRAGMA user_version = {PREVIOUS_SCHEMA_VERSION}")
+    conn.commit()
+
+
+def _insert_legacy_artifact(
+    conn: sqlite3.Connection,
+    *,
+    job_url: str,
+    path: str,
+    created_at: str,
+    status: str = "active",
+    size_bytes: int = 10,
+    metadata: dict[str, object] | None = None,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO job_artifacts (
+            job_url, stage, artifact_type, status, path, created_at,
+            size_bytes, metadata_json
+        ) VALUES (?, 'apply', 'apply_log', ?, ?, ?, ?, ?)
+        """,
+        (
+            job_url,
+            status,
+            path,
+            created_at,
+            size_bytes,
+            json.dumps(metadata or {}, sort_keys=True),
+        ),
+    )
+
+
+def _columns(conn: sqlite3.Connection) -> set[str]:
+    return {str(row[1]) for row in conn.execute("PRAGMA table_info(job_artifacts)").fetchall()}
+
+
+def test_v13_artifact_registry_migrates_alias_collisions_and_reopens(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    conn = init_db(db_path)
+    jobs = SqliteJobRepository(conn)
+
+    stable_job_id = JobId(str(uuid.uuid4()))
+    original_url = "https://boards.example/jobs/123"
+    current_url = "https://careers.example/jobs/platform-engineer"
+    jobs.save(_discovered_job(original_url, stable_job_id))
+    jobs.save(_discovered_job(current_url, stable_job_id))
+
+    uuid_shaped_url = str(uuid.uuid4())
+    uuid_url_owner = JobId(str(uuid.uuid4()))
+    id_text_collision_url = "https://example.com/jobs/id-text-collision"
+    jobs.save(_discovered_job(uuid_shaped_url, uuid_url_owner))
+    jobs.save(
+        _discovered_job(
+            id_text_collision_url,
+            JobId(uuid_shaped_url),
+        )
+    )
+
+    _downgrade_artifact_registry_to_v13(conn)
+    _insert_legacy_artifact(
+        conn,
+        job_url=original_url,
+        path="/tmp/shared.log",
+        created_at="2026-07-29T10:00:00+00:00",
+        status="candidate",
+        size_bytes=5,
+        metadata={"source": "old"},
+    )
+    _insert_legacy_artifact(
+        conn,
+        job_url=current_url,
+        path="/tmp/shared.log",
+        created_at="2026-07-29T10:05:00+00:00",
+        status="active",
+        size_bytes=9,
+        metadata={"source": "new"},
+    )
+    _insert_legacy_artifact(
+        conn,
+        job_url=original_url,
+        path="/tmp/original-only.log",
+        created_at="2026-07-29T10:01:00+00:00",
+    )
+    _insert_legacy_artifact(
+        conn,
+        job_url=uuid_shaped_url,
+        path="/tmp/uuid-url-owner.log",
+        created_at="2026-07-29T10:02:00+00:00",
+    )
+    conn.commit()
+    close_connection(db_path)
+
+    reopened = init_db(db_path)
+    assert reopened.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_VERSION
+    assert "job_id" in _columns(reopened)
+    assert "job_url" not in _columns(reopened)
+    assert reopened.execute("SELECT COUNT(*) FROM job_artifacts").fetchone()[0] == 3
+
+    shared = reopened.execute(
+        """
+        SELECT status, size_bytes, metadata_json
+        FROM job_artifacts
+        WHERE tenant_id = 'local' AND job_id = ? AND path = ?
+        """,
+        (str(stable_job_id), "/tmp/shared.log"),
+    ).fetchone()
+    assert tuple(shared[:2]) == ("active", 9)
+    assert json.loads(shared["metadata_json"]) == {"source": "new"}
+    assert reopened.execute(
+        """
+            SELECT job_id
+            FROM job_artifacts
+            WHERE tenant_id = 'local' AND path = ?
+            """,
+        ("/tmp/uuid-url-owner.log",),
+    ).fetchone()[0] == str(uuid_url_owner)
+
+    record_job_artifact(
+        reopened,
+        original_url,
+        "apply",
+        "apply_log",
+        "/tmp/shared.log",
+        status="approved",
+        created_at="2026-07-29T10:10:00+00:00",
+        metadata={"source": "runtime"},
+    )
+    assert (
+        reopened.execute(
+            """
+        SELECT status
+        FROM job_artifacts
+        WHERE tenant_id = 'local' AND job_id = ? AND path = ?
+        """,
+            (str(stable_job_id), "/tmp/shared.log"),
+        ).fetchone()[0]
+        == "approved"
+    )
+
+    record_job_artifact(
+        reopened,
+        uuid_shaped_url,
+        "apply",
+        "apply_log",
+        "/tmp/uuid-url-runtime.log",
+        status="approved",
+        created_at="2026-07-29T10:10:00+00:00",
+    )
+    uuid_runtime = reopened.execute(
+        """
+        SELECT job_id, status
+        FROM job_artifacts
+        WHERE tenant_id = 'local' AND path = ?
+        """,
+        ("/tmp/uuid-url-runtime.log",),
+    ).fetchone()
+    assert tuple(uuid_runtime) == (str(uuid_url_owner), "approved")
+
+    ProjectionBuilder(conn_factory=lambda: get_connection(db_path)).refresh()
+    assert (
+        reopened.execute(
+            """
+        SELECT COUNT(*)
+        FROM artifact_list_projections
+        WHERE local_path = '/tmp/shared.log'
+        """
+        ).fetchone()[0]
+        == 1
+    )
+    close_connection(db_path)
+
+
+def test_v14_artifact_registry_migration_rolls_back_and_retries(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    conn = init_db(db_path)
+    job_id = JobId(str(uuid.uuid4()))
+    job_url = "https://example.com/jobs/retry"
+    SqliteJobRepository(conn).save(_discovered_job(job_url, job_id))
+    _downgrade_artifact_registry_to_v13(conn)
+    _insert_legacy_artifact(
+        conn,
+        job_url=job_url,
+        path="/tmp/retry.log",
+        created_at="2026-07-29T10:00:00+00:00",
+    )
+    conn.commit()
+
+    original_verify = database_module._verify_artifact_registry_references_v14
+
+    def _fail_verification(
+        _conn: sqlite3.Connection,
+        *,
+        expected_count: int,
+    ) -> None:
+        del expected_count
+        raise RuntimeError("injected artifact verification failure")
+
+    monkeypatch.setattr(
+        database_module,
+        "_verify_artifact_registry_references_v14",
+        _fail_verification,
+    )
+    with pytest.raises(
+        RuntimeError,
+        match="injected artifact verification failure",
+    ):
+        ensure_artifact_registry_references_v14(conn)
+    assert conn.execute("PRAGMA user_version").fetchone()[0] == 13
+    assert "job_url" in _columns(conn)
+    assert conn.execute("SELECT COUNT(*) FROM job_artifacts").fetchone()[0] == 1
+
+    monkeypatch.setattr(
+        database_module,
+        "_verify_artifact_registry_references_v14",
+        original_verify,
+    )
+    assert ensure_artifact_registry_references_v14(conn) == ["job_artifacts"]
+    assert conn.execute("PRAGMA user_version").fetchone()[0] == 14
+    assert "job_id" in _columns(conn)
+    close_connection(db_path)
+
+
+def test_runtime_artifact_registry_merge_preserves_latest_registration(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    conn = init_db(db_path)
+    jobs = SqliteJobRepository(conn)
+    losing_id = JobId(str(uuid.uuid4()))
+    surviving_id = JobId(str(uuid.uuid4()))
+    jobs.save(
+        _discovered_job(
+            "https://example.com/jobs/losing",
+            losing_id,
+        )
+    )
+    jobs.save(
+        _discovered_job(
+            "https://example.com/jobs/surviving",
+            surviving_id,
+        )
+    )
+    conn.execute(
+        """
+        INSERT INTO job_artifacts (
+            tenant_id, job_id, stage, artifact_type, status, path,
+            created_at, size_bytes, metadata_json
+        ) VALUES
+            ('local', ?, 'apply', 'apply_log', 'candidate', '/tmp/shared.log',
+             '2026-07-29T10:00:00+00:00', 5, '{"source":"losing"}'),
+            ('local', ?, 'apply', 'apply_log', 'active', '/tmp/shared.log',
+             '2026-07-29T10:05:00+00:00', 9, '{"source":"surviving"}'),
+            ('local', ?, 'apply', 'apply_log', 'active', '/tmp/only-losing.log',
+             '2026-07-29T10:01:00+00:00', 7, '{}')
+        """,
+        (
+            str(losing_id),
+            str(surviving_id),
+            str(losing_id),
+        ),
+    )
+    conn.commit()
+
+    _reassign_artifact_registry_references_v14(
+        conn,
+        tenant_id="local",
+        losing_job_id=str(losing_id),
+        surviving_job_id=str(surviving_id),
+    )
+    assert conn.execute("SELECT COUNT(*) FROM job_artifacts").fetchone()[0] == 2
+    rows = conn.execute(
+        """
+        SELECT job_id, status, path, size_bytes, metadata_json
+        FROM job_artifacts
+        ORDER BY path
+        """
+    ).fetchall()
+    assert {row["job_id"] for row in rows} == {str(surviving_id)}
+    shared = next(row for row in rows if row["path"] == "/tmp/shared.log")
+    assert shared["status"] == "active"
+    assert shared["size_bytes"] == 9
+    assert json.loads(shared["metadata_json"]) == {"source": "surviving"}
+    close_connection(db_path)

--- a/workers/automation/tests/test_discovery_identity_reference_migration.py
+++ b/workers/automation/tests/test_discovery_identity_reference_migration.py
@@ -220,7 +220,7 @@ def test_v7_discovery_references_migrate_to_stable_job_id_and_reopen(
     init_db(db_path)
     close_connection(db_path)
 
-    assert _user_version(db_path) == SCHEMA_VERSION == 13
+    assert _user_version(db_path) == SCHEMA_VERSION == 14
     assert "job_id" in _columns(db_path, "job_source_observations")
     assert "job_url" not in _columns(db_path, "job_source_observations")
     assert "job_id" in _columns(db_path, "job_canonical_identities")

--- a/workers/automation/tests/test_enrichment_snapshot_identity_reference_migration.py
+++ b/workers/automation/tests/test_enrichment_snapshot_identity_reference_migration.py
@@ -322,7 +322,7 @@ def test_v10_enrichment_snapshot_references_migrate_and_reopen(
     init_db(db_path)
     close_connection(db_path)
 
-    assert _user_version(db_path) == SCHEMA_VERSION == 13
+    assert _user_version(db_path) == SCHEMA_VERSION == 14
     check = sqlite3.connect(db_path)
     try:
         enrichment_rows = check.execute(

--- a/workers/automation/tests/test_execution_search_identity_reference_migration.py
+++ b/workers/automation/tests/test_execution_search_identity_reference_migration.py
@@ -261,7 +261,7 @@ def test_v8_execution_and_receipts_migrate_to_stable_job_id_and_reopen(
     init_db(db_path)
     close_connection(db_path)
 
-    assert _user_version(db_path) == SCHEMA_VERSION == 13
+    assert _user_version(db_path) == SCHEMA_VERSION == 14
     assert "job_id" in _columns(db_path, "discovery_execution_jobs")
     assert "job_url" not in _columns(db_path, "discovery_execution_jobs")
     assert "job_id" in _columns(db_path, "discovery_search_unit_jobs")

--- a/workers/automation/tests/test_preparation_identity_reference_migration.py
+++ b/workers/automation/tests/test_preparation_identity_reference_migration.py
@@ -177,7 +177,7 @@ def test_v9_preparation_references_migrate_to_stable_job_ids_and_reopen(
     init_db(db_path)
     close_connection(db_path)
 
-    assert _user_version(db_path) == SCHEMA_VERSION == 13
+    assert _user_version(db_path) == SCHEMA_VERSION == 14
     check = sqlite3.connect(db_path)
     try:
         rows = check.execute(

--- a/workers/automation/tests/test_repeat_application_prevention.py
+++ b/workers/automation/tests/test_repeat_application_prevention.py
@@ -744,7 +744,7 @@ def test_schema_v5_migrates_additively_without_changing_application_facts(
         (PRIOR,),
     ).fetchall()
 
-    assert int(migrated.execute("PRAGMA user_version").fetchone()[0]) == SCHEMA_VERSION == 13
+    assert int(migrated.execute("PRAGMA user_version").fetchone()[0]) == SCHEMA_VERSION == 14
     assert [tuple(row) for row in after] == [tuple(row) for row in before]
     assert "metadata_json" in {
         str(row[1]) for row in migrated.execute("PRAGMA table_info(job_stage_states)").fetchall()

--- a/workers/automation/tests/test_scoring_identity_reference_migration.py
+++ b/workers/automation/tests/test_scoring_identity_reference_migration.py
@@ -338,7 +338,7 @@ def test_v11_scoring_references_migrate_alias_histories_and_reopen(
     assert (
         int(migrated.execute("PRAGMA user_version").fetchone()[0])
         == SCHEMA_VERSION
-        == 13
+        == 14
     )
     assert _columns(migrated, "job_scores") >= {"tenant_id", "job_id"}
     assert "job_url" not in _columns(migrated, "job_scores")
@@ -404,7 +404,7 @@ def test_v11_scoring_references_migrate_alias_histories_and_reopen(
     assert (
         int(reopened.execute("PRAGMA user_version").fetchone()[0])
         == SCHEMA_VERSION
-        == 13
+        == 14
     )
 
 
@@ -553,7 +553,7 @@ def test_scoring_migration_rolls_back_and_retries_after_verification_failure(
     assert (
         int(retried.execute("PRAGMA user_version").fetchone()[0])
         == SCHEMA_VERSION
-        == 13
+        == 14
     )
     assert [
         tuple(row)

--- a/workers/automation/tests/test_stable_job_identity_migration.py
+++ b/workers/automation/tests/test_stable_job_identity_migration.py
@@ -145,12 +145,12 @@ def _create_representative_v6_pair(
     conn.execute(
         """
         INSERT INTO job_artifacts (
-            job_url, stage, artifact_type, status, path, created_at,
-            size_bytes, metadata_json
-        ) VALUES (?, 'tailor', 'resume_pdf', 'accepted', ?, ?, 1024, ?)
+            tenant_id, job_id, stage, artifact_type, status, path,
+            created_at, size_bytes, metadata_json
+        ) VALUES ('local', ?, 'tailor', 'resume_pdf', 'accepted', ?, ?, 1024, ?)
         """,
         (
-            job_url,
+            job_id,
             "artifacts/synthetic-resume.pdf",
             "2026-07-01T10:10:00+00:00",
             '{"fixture":true}',
@@ -257,6 +257,25 @@ def _create_representative_v6_pair(
               ON jobs.tenant_id = scores.tenant_id
              AND jobs.job_id = scores.job_id
             ORDER BY scores.tenant_id, scores.job_id, scores.version
+            """
+        ).fetchall()
+        artifact_rows = raw.execute(
+            """
+            SELECT
+                artifacts.artifact_id,
+                jobs.url,
+                artifacts.stage,
+                artifacts.artifact_type,
+                artifacts.status,
+                artifacts.path,
+                artifacts.created_at,
+                artifacts.size_bytes,
+                artifacts.metadata_json
+            FROM job_artifacts AS artifacts
+            JOIN jobs
+              ON jobs.tenant_id = artifacts.tenant_id
+             AND jobs.job_id = artifacts.job_id
+            ORDER BY artifacts.artifact_id
             """
         ).fetchall()
         source_rows = raw.execute(
@@ -491,6 +510,35 @@ def _create_representative_v6_pair(
             """,
             stage_rows,
         )
+        raw.execute("DROP TABLE job_artifacts")
+        raw.executescript(
+            """
+            CREATE TABLE job_artifacts (
+                artifact_id         INTEGER PRIMARY KEY AUTOINCREMENT,
+                job_url             TEXT NOT NULL,
+                stage               TEXT NOT NULL,
+                artifact_type       TEXT NOT NULL,
+                status              TEXT NOT NULL DEFAULT 'candidate',
+                path                TEXT NOT NULL,
+                created_at          TEXT NOT NULL,
+                size_bytes          INTEGER,
+                metadata_json       TEXT,
+                UNIQUE(job_url, stage, artifact_type, path),
+                FOREIGN KEY (job_url) REFERENCES jobs(url) ON DELETE CASCADE
+            );
+            CREATE INDEX idx_job_artifacts_job_stage
+                ON job_artifacts(job_url, stage, status);
+            """
+        )
+        raw.executemany(
+            """
+            INSERT INTO job_artifacts (
+                artifact_id, job_url, stage, artifact_type, status, path,
+                created_at, size_bytes, metadata_json
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            artifact_rows,
+        )
         for trigger_name in database_module._STABLE_JOB_IDENTITY_TRIGGER_NAMES:
             raw.execute(f'DROP TRIGGER IF EXISTS "{trigger_name}"')
         raw.execute("DROP INDEX IF EXISTS idx_jobs_tenant_job_id")
@@ -626,6 +674,33 @@ def _reference_snapshot(db_path: Path) -> dict[str, list[tuple[object, ...]]]:
                     """
                 ).fetchall()
             ]
+        artifact_columns = {
+            str(row[1])
+            for row in conn.execute("PRAGMA table_info(job_artifacts)").fetchall()
+        }
+        if "job_id" in artifact_columns:
+            snapshot["job_artifacts"] = [
+                tuple(row)
+                for row in conn.execute(
+                    """
+                    SELECT
+                        artifacts.artifact_id,
+                        jobs.url,
+                        artifacts.stage,
+                        artifacts.artifact_type,
+                        artifacts.status,
+                        artifacts.path,
+                        artifacts.created_at,
+                        artifacts.size_bytes,
+                        artifacts.metadata_json
+                    FROM job_artifacts AS artifacts
+                    JOIN jobs
+                      ON jobs.tenant_id = artifacts.tenant_id
+                     AND jobs.job_id = artifacts.job_id
+                    ORDER BY artifacts.rowid
+                    """
+                ).fetchall()
+            ]
         snapshot["jobs"] = [
             tuple(row)
             for row in conn.execute(
@@ -666,7 +741,7 @@ def test_v6_jobs_gain_stable_uuid_and_posting_url_alias_once(
     init_db(db_path)
     close_connection(db_path)
 
-    assert _user_version(db_path) == SCHEMA_VERSION == 13
+    assert _user_version(db_path) == SCHEMA_VERSION == 14
     first_ids = _identity_rows(db_path)
     assert [row[0] for row in first_ids] == ["local", "local"]
     for _tenant_id, job_id, _url in first_ids:


### PR DESCRIPTION
## Summary

- add schema v14 to migrate the generic `job_artifacts` registry from `job_url` to tenant-scoped `(tenant_id, job_id)` references
- preserve one current registration per stable registry key with deterministic last-write-wins collision handling, plus transactional verification and retry safety
- update Python artifact recording/projection/identity-collapse paths and TypeScript artifact reads/permanent deletion for v13/v14 compatibility
- keep UUID-shaped posting URLs URL-first across both runtimes and raise the API schema guard to the worker-owned v14 contract

## Why

Artifact registrations belong to a stable Job aggregate, not to a mutable posting URL. Keeping this registry URL-keyed allowed aliases to split one job's artifacts and made identity collapse unsafe. This phase moves only the generic registry; canonical materials, provenance, and layout references remain separate reviewable stack layers.

## Migration behavior

- stamps `PRAGMA user_version = 14` only after schema, row-count, UUID, foreign-key, and orphan verification succeed
- rolls back cleanly and can retry after an injected verification failure
- merges aliases that resolve to the same `(tenant, job, stage, type, path)` using newest `created_at`, then largest `artifact_id`, matching runtime upsert semantics
- preserves distinct registry keys and reassigns registrations safely during runtime identity collapse

## Validation

- focused Python migration/runtime/projection suite — 19 passed locally; independent reviewer rerun an expanded 34-test set
- full Python suite — 2684 passed, 2 skipped
- focused v14 artifact + schema-open Vitest suites — 12 passed
- full API suite — 661/663 passed in the restricted sandbox; the two environment-sensitive loopback/process-tree cases were rerun outside the sandbox and passed
- `corepack pnpm api:check` — passed
- focused Ruff checks — passed
- `git diff --check` — passed
- independent Tier 3 review — Gate: PASS, Blocker 0 / High 0 / Medium 0 / Low 0

## Residual risk

The v14 TypeScript artifact-read SQL is statically traced through the same URL-first resolver exercised by the v14 API regression; there is not yet a separate v14 projection-read fixture.

## Stack

- stacked on #538 (`feat/job-id-stage-state-references`)
- canonical product docs and cumulative product QA remain deferred to the final approved stack PR
- core materials, provenance, and layout references follow as smaller PRs