### PR TITLE
feat(materials): migrate generation references to stable JobIds

### DIFF
--- a/apps/api/src/application-feedback.ts
+++ b/apps/api/src/application-feedback.ts
@@ -1114,10 +1114,17 @@ function currentApplicationUrl(db: SqliteDatabase, jobKey: string): string | nul
 
 function latestMaterialsGeneration(db: SqliteDatabase, jobKey: string): number | null {
   if (!tableExists(db, "job_materials")) return null;
+  const reference = jobReferencePredicateForUrl(
+    db,
+    "job_materials",
+    jobKey,
+  );
   const row = getRow<{ generation: number | null }>(
     db,
-    "SELECT MAX(generation) AS generation FROM job_materials WHERE job_url = ?",
-    [jobKey],
+    `SELECT MAX(generation) AS generation
+       FROM job_materials
+      WHERE ${reference.sql}`,
+    reference.params,
   );
   return nullableNumber(row?.generation);
 }
@@ -1580,6 +1587,11 @@ function requirementsWithTailoredResumeCoverage(
       requirementWithFitAssessment(requirement, fitByRequirement.get(requirement.id), emptyRequirementCoverage()),
     );
   }
+  const provenanceReference = jobReferencePredicateForUrl(
+    db,
+    "job_bullet_provenance",
+    jobKey,
+  );
   const requirementIds = new Set(requirements.map((requirement) => requirement.id));
   const rows = allRows<{
     generated_text: string;
@@ -1588,11 +1600,10 @@ function requirementsWithTailoredResumeCoverage(
     db,
     `SELECT generated_text, requirement_ids_json
        FROM job_bullet_provenance
-      WHERE tenant_id = ?
-        AND job_url = ?
+      WHERE ${provenanceReference.sql}
         AND artifact_id = ?
       ORDER BY position, bullet_id`,
-    [DEFAULT_TENANT, jobKey, resumeTextArtifactId],
+    [...provenanceReference.params, resumeTextArtifactId],
   );
   if (!rows.length) {
     return requirements.map((requirement) =>
@@ -2145,6 +2156,11 @@ function failedRequirementLedAuditForJob(
   const placeholders = artifactTypes.map(() => "?").join(", ");
   const columns = tableColumnSet(db, "job_materials_artifacts");
   const metadataSelect = columns.has("metadata_json") ? "metadata_json" : "NULL AS metadata_json";
+  const artifactReference = jobReferencePredicateForUrl(
+    db,
+    "job_materials_artifacts",
+    jobKey,
+  );
   const rows = allRows<{
     artifact_id: string | null;
     created_at: string | null;
@@ -2155,14 +2171,14 @@ function failedRequirementLedAuditForJob(
     db,
     `SELECT artifact_id, path, generation, created_at, ${metadataSelect}
        FROM job_materials_artifacts
-      WHERE job_url = ?
+      WHERE ${artifactReference.sql}
         AND artifact_type IN (${placeholders})
         AND status = 'rejected'
         AND metadata_json IS NOT NULL
         AND metadata_json != ''
       ORDER BY COALESCE(generation, -1) DESC, COALESCE(created_at, '') DESC, rowid DESC
       LIMIT 8`,
-    [jobKey, ...artifactTypes],
+    [...artifactReference.params, ...artifactTypes],
   );
   for (const [index, row] of rows.entries()) {
     const audit = parseRequirementLedAuditMetadata(row.metadata_json);
@@ -2268,15 +2284,19 @@ function provenanceRowsForCandidate(
   jobKey: string,
   candidate: MaterialArtifactCandidate,
 ): Array<{ requirement_ids_json: string }> {
+  const provenanceReference = jobReferencePredicateForUrl(
+    db,
+    "job_bullet_provenance",
+    jobKey,
+  );
   const rowsByArtifact = candidate.artifactId
     ? allRows<{ requirement_ids_json: string }>(
         db,
         `SELECT requirement_ids_json
            FROM job_bullet_provenance
-          WHERE tenant_id = ?
-            AND job_url = ?
+          WHERE ${provenanceReference.sql}
             AND artifact_id = ?`,
-        [DEFAULT_TENANT, jobKey, candidate.artifactId],
+        [...provenanceReference.params, candidate.artifactId],
       )
     : [];
   if (rowsByArtifact.length || candidate.generation === null) {
@@ -2286,10 +2306,9 @@ function provenanceRowsForCandidate(
     db,
     `SELECT requirement_ids_json
        FROM job_bullet_provenance
-      WHERE tenant_id = ?
-        AND job_url = ?
+      WHERE ${provenanceReference.sql}
         AND generation = ?`,
-    [DEFAULT_TENANT, jobKey, candidate.generation],
+    [...provenanceReference.params, candidate.generation],
   );
 }
 
@@ -2626,6 +2645,11 @@ function materialArtifactCandidates(
   if (tableExists(db, "job_materials_artifacts")) {
     const columns = tableColumnSet(db, "job_materials_artifacts");
     const metadataSelect = columns.has("metadata_json") ? "metadata_json" : "NULL AS metadata_json";
+    const materialReference = jobReferencePredicateForUrl(
+      db,
+      "job_materials_artifacts",
+      jobKey,
+    );
     const rows = allRows<{
       artifact_id: string | null;
       created_at: string | null;
@@ -2637,14 +2661,14 @@ function materialArtifactCandidates(
       db,
       `SELECT artifact_id, path, generation, created_at, status, ${metadataSelect}
        FROM job_materials_artifacts
-       WHERE job_url = ?
+       WHERE ${materialReference.sql}
          AND artifact_type IN (${placeholders})
          AND COALESCE(status, 'approved') IN ('approved', 'active', 'candidate')
          AND path IS NOT NULL
          AND path != ''
        ORDER BY COALESCE(generation, -1) DESC, COALESCE(created_at, '') DESC, rowid DESC
        LIMIT 16`,
-      [jobKey, ...artifactTypes],
+      [...materialReference.params, ...artifactTypes],
     );
     for (const [index, row] of rows.entries()) {
       const reviewRequired = row.status === "candidate" && isReviewRequiredMaterialMetadata(row.metadata_json);

--- a/apps/api/src/db.ts
+++ b/apps/api/src/db.ts
@@ -9,7 +9,7 @@ export type SqliteValue = string | number | bigint | null;
 // writer that stamps ``PRAGMA user_version``; the API only reads it to fail
 // closed on a database written by a newer build. Bump both constants together
 // whenever the schema shape changes.
-export const SUPPORTED_SCHEMA_VERSION = 14;
+export const SUPPORTED_SCHEMA_VERSION = 15;
 
 export class IncompatibleSchemaVersionError extends Error {
   constructor(current: number) {

--- a/apps/api/src/projections.ts
+++ b/apps/api/src/projections.ts
@@ -487,7 +487,25 @@ function reconcileObsoleteCoverGenerationConflicts(db: SqliteDatabase): Set<stri
     db,
     "job_stage_states",
   ) === "job_id";
+  const stableMaterialReferences = jobReferenceColumn(
+    db,
+    "job_materials_artifacts",
+  ) === "job_id";
+  if (stableMaterialReferences && !stableReferences) {
+    throw new Error(
+      "Stable material references require stable job_stage_states references.",
+    );
+  }
   const stageJobUrl = stableReferences ? "stage_jobs.url" : "s.job_url";
+  const materialStageMatch = stableMaterialReferences
+    ? "tr.tenant_id = s.tenant_id AND tr.job_id = s.job_id"
+    : `tr.job_url = ${stageJobUrl}`;
+  const materialArtifactJoin = stableMaterialReferences
+    ? "pdf.tenant_id = tr.tenant_id AND pdf.job_id = tr.job_id"
+    : "pdf.job_url = tr.job_url";
+  const materialCoverJoin = stableMaterialReferences
+    ? "cover.tenant_id = tr.tenant_id AND cover.job_id = tr.job_id"
+    : "cover.job_url = tr.job_url";
   const rows = allRows<{
     job_url: string;
     tenant_id: string | null;
@@ -505,18 +523,18 @@ function reconcileObsoleteCoverGenerationConflicts(db: SqliteDatabase): Set<stri
              SELECT 1
                FROM job_materials_artifacts tr
                JOIN job_materials_artifacts pdf
-                 ON pdf.job_url = tr.job_url
+                 ON ${materialArtifactJoin}
                 AND pdf.generation = tr.generation
                 AND pdf.artifact_type = 'resume_pdf'
                 AND pdf.status = 'approved'
                 AND COALESCE(TRIM(pdf.path), '') != ''
                JOIN job_materials_artifacts cover
-                 ON cover.job_url = tr.job_url
+                 ON ${materialCoverJoin}
                 AND cover.generation = tr.generation
                 AND cover.artifact_type = 'cover_letter'
                 AND cover.status = 'approved'
                 AND COALESCE(TRIM(cover.path), '') != ''
-              WHERE tr.job_url = ${stageJobUrl}
+              WHERE ${materialStageMatch}
                 AND tr.artifact_type = 'tailored_resume'
                 AND tr.status = 'approved'
                 AND COALESCE(TRIM(tr.path), '') != ''
@@ -536,12 +554,12 @@ function reconcileObsoleteCoverGenerationConflicts(db: SqliteDatabase): Set<stri
              SELECT 1
                FROM job_materials_artifacts tr
                JOIN job_materials_artifacts pdf
-                 ON pdf.job_url = tr.job_url
+                 ON ${materialArtifactJoin}
                 AND pdf.generation = tr.generation
                 AND pdf.artifact_type = 'resume_pdf'
                 AND pdf.status = 'approved'
                 AND COALESCE(TRIM(pdf.path), '') != ''
-              WHERE tr.job_url = ${stageJobUrl}
+              WHERE ${materialStageMatch}
                 AND tr.artifact_type = 'tailored_resume'
                 AND tr.status = 'approved'
                 AND COALESCE(TRIM(tr.path), '') != ''
@@ -1527,24 +1545,29 @@ function loadLatestMaterials(db: SqliteDatabase, jobUrl: string): MaterialsLates
   if (!tableExists(db, "job_materials") || !tableExists(db, "job_materials_artifacts")) {
     return empty;
   }
+  const artifactReference = jobReferencePredicateForUrl(
+    db,
+    "job_materials_artifacts",
+    jobUrl,
+  );
   const hasCanonicalHistory = Boolean(
     getRow<{ c: number }>(
       db,
       `SELECT COUNT(*) AS c
          FROM job_materials_artifacts
-        WHERE job_url = ?
+        WHERE ${artifactReference.sql}
           AND artifact_type IN ('tailored_resume', 'cover_letter', 'resume_pdf', 'cover_letter_pdf')`,
-      [jobUrl],
+      artifactReference.params,
     )?.c,
   );
   const generationRow = getRow<{ max_generation: number }>(
     db,
     `SELECT MAX(generation) AS max_generation
        FROM job_materials_artifacts
-      WHERE job_url = ?
+      WHERE ${artifactReference.sql}
         AND status = 'approved'
         AND artifact_type IN ('tailored_resume', 'cover_letter', 'resume_pdf', 'cover_letter_pdf')`,
-    [jobUrl],
+    artifactReference.params,
   );
   const generation = generationRow ? generationRow.max_generation : null;
   if (generation === null || generation === undefined) {
@@ -1553,8 +1576,8 @@ function loadLatestMaterials(db: SqliteDatabase, jobUrl: string): MaterialsLates
   const artifacts = allRows<{ artifact_type: string; path: string; created_at: string | null }>(
     db,
     `SELECT artifact_type, path, created_at FROM job_materials_artifacts
-     WHERE job_url = ? AND generation = ? AND status = 'approved'`,
-    [jobUrl, Number(generation)],
+     WHERE ${artifactReference.sql} AND generation = ? AND status = 'approved'`,
+    [...artifactReference.params, Number(generation)],
   );
   const latest: MaterialsLatest = { ...empty, hasCanonicalHistory, generation: Number(generation) };
   for (const a of artifacts) {
@@ -1592,11 +1615,24 @@ function loadMaterialAnalytics(db: SqliteDatabase, jobUrl: string): MaterialAnal
   }
   const hasMaterialMetadata = tableExists(db, "job_materials") && hasColumn(db, "job_materials", "metadata_json");
   const materialMetadataSelect = hasMaterialMetadata ? "m.metadata_json AS material_metadata_json" : "NULL AS material_metadata_json";
+  const stableReferences = jobReferenceColumn(
+    db,
+    "job_materials_artifacts",
+  ) === "job_id";
   const materialMetadataJoin = hasMaterialMetadata
     ? `LEFT JOIN job_materials m
-             ON m.job_url = a.job_url
+             ON ${stableReferences
+               ? "m.tenant_id = a.tenant_id AND m.job_id = a.job_id"
+               : "m.job_url = a.job_url"}
             AND m.generation = a.generation`
     : "";
+  const artifactReference = jobReferencePredicateForUrl(
+    db,
+    "job_materials_artifacts",
+    jobUrl,
+    "local",
+    "a",
+  );
   const row = getRow<{
     artifact_id: string | null;
     generation: number | null;
@@ -1607,7 +1643,7 @@ function loadMaterialAnalytics(db: SqliteDatabase, jobUrl: string): MaterialAnal
     `SELECT a.artifact_id, a.generation, a.metadata_json, ${materialMetadataSelect}
        FROM job_materials_artifacts a
        ${materialMetadataJoin}
-      WHERE a.job_url = ?
+      WHERE ${artifactReference.sql}
         AND a.status = 'approved'
         AND a.artifact_type IN ('tailored_resume', 'tailored_resume_txt', 'resume_pdf')
       ORDER BY COALESCE(a.generation, -1) DESC,
@@ -1620,7 +1656,7 @@ function loadMaterialAnalytics(db: SqliteDatabase, jobUrl: string): MaterialAnal
                a.created_at DESC,
                a.rowid DESC
       LIMIT 1`,
-    [jobUrl],
+    artifactReference.params,
   );
   const metadataJsons = [row?.metadata_json ?? null, row?.material_metadata_json ?? null];
   const current = mergeMaterialAnalytics(metadataJsons);
@@ -1662,20 +1698,33 @@ function loadBaseMaterialMetadata(db: SqliteDatabase, jobUrl: string, metadataJs
     tableExists(db, "job_materials") &&
     hasColumn(db, "job_materials", "metadata_json")
   ) {
+    const materialReference = jobReferencePredicateForUrl(
+      db,
+      "job_materials",
+      jobUrl,
+    );
     const row = getRow<{ metadata_json: string | null }>(
       db,
-      "SELECT metadata_json FROM job_materials WHERE job_url = ? AND generation = ? LIMIT 1",
-      [jobUrl, references.baseGeneration],
+      `SELECT metadata_json
+         FROM job_materials
+        WHERE ${materialReference.sql} AND generation = ?
+        LIMIT 1`,
+      [...materialReference.params, references.baseGeneration],
     );
     metadata.push(row?.metadata_json ?? null);
   }
   if (references.baseGeneration !== null) {
+    const artifactReference = jobReferencePredicateForUrl(
+      db,
+      "job_materials_artifacts",
+      jobUrl,
+    );
     metadata.push(
       ...allRows<{ metadata_json: string | null }>(
         db,
         `SELECT metadata_json
            FROM job_materials_artifacts
-          WHERE job_url = ?
+          WHERE ${artifactReference.sql}
             AND generation = ?
             AND artifact_type IN ('tailored_resume', 'tailored_resume_txt', 'resume_pdf')
           ORDER BY CASE artifact_type
@@ -1685,18 +1734,23 @@ function loadBaseMaterialMetadata(db: SqliteDatabase, jobUrl: string, metadataJs
                      ELSE 3
                    END,
                    rowid DESC`,
-        [jobUrl, references.baseGeneration],
+        [...artifactReference.params, references.baseGeneration],
       ).map((row) => row.metadata_json),
     );
   }
   if (references.baseArtifactIds.length > 0) {
+    const artifactReference = jobReferencePredicateForUrl(
+      db,
+      "job_materials_artifacts",
+      jobUrl,
+    );
     const placeholders = references.baseArtifactIds.map(() => "?").join(", ");
     metadata.push(
       ...allRows<{ metadata_json: string | null }>(
         db,
         `SELECT metadata_json
            FROM job_materials_artifacts
-          WHERE job_url = ?
+          WHERE ${artifactReference.sql}
             AND artifact_id IN (${placeholders})
           ORDER BY COALESCE(generation, -1) DESC,
                    CASE artifact_type
@@ -1706,7 +1760,7 @@ function loadBaseMaterialMetadata(db: SqliteDatabase, jobUrl: string, metadataJs
                      ELSE 3
                    END,
                    rowid DESC`,
-        [jobUrl, ...references.baseArtifactIds],
+        [...artifactReference.params, ...references.baseArtifactIds],
       ).map((row) => row.metadata_json),
     );
   }
@@ -2217,12 +2271,18 @@ function loadBulletProvenanceByArtifact(
 ): Map<string, string> {
   const result = new Map<string, string>();
   if (!tableExists(db, "job_bullet_provenance")) return result;
+  const provenanceReference = jobReferencePredicateForUrl(
+    db,
+    "job_bullet_provenance",
+    jobUrl,
+    tenantId,
+  );
   const rows = allRows<BulletProvenanceRow>(
     db,
     `SELECT * FROM job_bullet_provenance
-      WHERE job_url = ? AND tenant_id = ?
+      WHERE tenant_id = ? AND ${provenanceReference.sql}
       ORDER BY generation, position, bullet_id`,
-    [jobUrl, tenantId],
+    [tenantId, ...provenanceReference.params],
   );
   if (rows.length === 0) return result;
   const byArtifact = new Map<string, Record<string, unknown>[]>();
@@ -2268,14 +2328,20 @@ function loadProvenanceAuxByArtifact(
   const coverage = new Map<string, string>();
   const voice = new Map<string, string>();
   if (!tableExists(db, "job_bullet_provenance")) return { coverage, voice };
+  const provenanceReference = jobReferencePredicateForUrl(
+    db,
+    "job_bullet_provenance",
+    jobUrl,
+    tenantId,
+  );
   let rows: Array<{ artifact_id: string; coverage_json: string | null; voice_json: string | null }> = [];
   try {
     rows = allRows<{ artifact_id: string; coverage_json: string | null; voice_json: string | null }>(
       db,
       `SELECT artifact_id, coverage_json, voice_json FROM job_bullet_provenance
-        WHERE job_url = ? AND tenant_id = ?
+        WHERE tenant_id = ? AND ${provenanceReference.sql}
         ORDER BY generation, position, bullet_id`,
-      [jobUrl, tenantId],
+      [tenantId, ...provenanceReference.params],
     );
   } catch {
     // Columns predate Phase 3 (a DB written before this migration ran) — no aux data.
@@ -2519,11 +2585,26 @@ function attachResumeUsages(
   entries: Map<string, EvidenceMapEntryPayload>,
 ): void {
   if (!tableExists(db, "job_bullet_provenance")) return;
-  const jobMetadata = jobMetadataJoinSql(db, "provenance.job_url");
-  const lifecycle = jobLifecycleExclusionSql(db, "provenance.job_url");
+  const stableReferences = jobReferenceColumn(
+    db,
+    "job_bullet_provenance",
+  ) === "job_id";
+  const jobUrlExpression = stableReferences
+    ? "provenance_jobs.url"
+    : "provenance.job_url";
+  const identityJoin = stableReferences
+    ? ` JOIN jobs AS provenance_jobs
+           ON provenance_jobs.tenant_id = provenance.tenant_id
+          AND provenance_jobs.job_id = provenance.job_id`
+    : "";
+  const jobMetadata = jobMetadataJoinSql(db, jobUrlExpression);
+  const lifecycle = jobLifecycleExclusionSql(db, jobUrlExpression);
+  const latestIdentityMatch = stableReferences
+    ? "latest.job_id = provenance.job_id"
+    : "latest.job_url = provenance.job_url";
   const rows = allRows<BulletProvenanceRow & { job_title: string | null; employer: string | null }>(
     db,
-    `SELECT provenance.job_url, provenance.artifact_id, provenance.generation,
+    `SELECT ${jobUrlExpression} AS job_url, provenance.artifact_id, provenance.generation,
             provenance.bullet_id, provenance.section, provenance.source_id,
             provenance.evidence_ids_json, provenance.requirement_ids_json,
             provenance.matched_keywords_json, provenance.transform_type,
@@ -2531,15 +2612,16 @@ function attachResumeUsages(
             provenance.position, provenance.created_at,
             ${jobMetadata.selectSql}
        FROM job_bullet_provenance AS provenance
+       ${identityJoin}
        ${jobMetadata.joinSql}${lifecycle.joinSql}
       WHERE provenance.tenant_id = ?${lifecycle.whereSql}
         AND provenance.generation = (
           SELECT MAX(latest.generation)
             FROM job_bullet_provenance AS latest
            WHERE latest.tenant_id = provenance.tenant_id
-             AND latest.job_url = provenance.job_url
+             AND ${latestIdentityMatch}
         )
-      ORDER BY provenance.job_url, provenance.position, provenance.bullet_id`,
+      ORDER BY ${jobUrlExpression}, provenance.position, provenance.bullet_id`,
     [tenantId],
   );
   for (const row of rows) {
@@ -3121,15 +3203,28 @@ function staleArtifactMetadataProjectionJobs(db: SqliteDatabase, tenantId: strin
     return [];
   }
 
+  const materialJoin = jobReferenceJoinToJobs(
+    db,
+    "job_materials_artifacts",
+    "a",
+    "j",
+  );
+  const stableMaterialReferences = jobReferenceColumn(
+    db,
+    "job_materials_artifacts",
+  ) === "job_id";
   const rows = allRows<{ job_id: string }>(
     db,
-    `SELECT DISTINCT a.job_url AS job_id
+    `SELECT DISTINCT j.url AS job_id
        FROM job_materials_artifacts a
+       JOIN jobs j
+         ON ${materialJoin}
        LEFT JOIN artifact_list_projections p
          ON p.tenant_id = ?
-        AND p.job_id = a.job_url
+        AND p.job_id = j.url
         AND p.artifact_id = COALESCE(NULLIF(a.artifact_id, ''), a.artifact_type || ':' || a.path)
-      WHERE a.artifact_type IN ('tailored_resume', 'tailored_resume_txt')
+      WHERE ${stableMaterialReferences ? "a.tenant_id = ? AND" : ""}
+        a.artifact_type IN ('tailored_resume', 'tailored_resume_txt')
         AND a.path IS NOT NULL
         AND TRIM(a.path) != ''
         AND a.metadata_json IS NOT NULL
@@ -3140,7 +3235,7 @@ function staleArtifactMetadataProjectionJobs(db: SqliteDatabase, tenantId: strin
           OR p.metadata_json IS NULL
           OR TRIM(p.metadata_json) != TRIM(a.metadata_json)
         )`,
-    [tenantId],
+    stableMaterialReferences ? [tenantId, tenantId] : [tenantId],
   );
   return rows.map((row) => row.job_id).filter(Boolean);
 }
@@ -3544,6 +3639,12 @@ function loadLayoutBoxesByArtifact(
 ): Map<string, string> {
   const result = new Map<string, string>();
   if (!tableExists(db, "job_material_layout_boxes")) return result;
+  const layoutReference = jobReferencePredicateForUrl(
+    db,
+    "job_material_layout_boxes",
+    jobUrl,
+    tenantId,
+  );
   const rows = allRows<{
     artifact_id: string;
     semantic_id: string;
@@ -3559,9 +3660,9 @@ function loadLayoutBoxesByArtifact(
     `SELECT artifact_id, semantic_id, page_number, line_number, text_excerpt,
             left_pct, top_pct, width_pct, height_pct
        FROM job_material_layout_boxes
-      WHERE tenant_id = ? AND job_url = ?
+      WHERE tenant_id = ? AND ${layoutReference.sql}
       ORDER BY artifact_id, page_number, box_index`,
-    [tenantId, jobUrl],
+    [tenantId, ...layoutReference.params],
   );
   const byArtifact = new Map<string, Array<Record<string, unknown>>>();
   for (const row of rows) {
@@ -3835,6 +3936,11 @@ function collectArtifacts(
     const metadataSelect = hasColumn(db, "job_materials_artifacts", "metadata_json")
       ? "metadata_json"
       : "NULL AS metadata_json";
+    const materialArtifactReference = jobReferencePredicateForUrl(
+      db,
+      "job_materials_artifacts",
+      jobUrl,
+    );
     const rows = allRows<{
       artifact_id: string;
       artifact_type: string;
@@ -3847,8 +3953,8 @@ function collectArtifacts(
     }>(
       db,
       `SELECT artifact_id, artifact_type, status, path, created_at, size_bytes, generation, ${metadataSelect}
-       FROM job_materials_artifacts WHERE job_url = ?`,
-      [jobUrl],
+       FROM job_materials_artifacts WHERE ${materialArtifactReference.sql}`,
+      materialArtifactReference.params,
     );
     for (const row of rows) {
       if (!row.path) continue;

--- a/apps/api/src/read-model.ts
+++ b/apps/api/src/read-model.ts
@@ -77,6 +77,7 @@ import {
   getRow,
   hasCompositeJobIdForeignKey,
   jobReferenceColumn,
+  tableColumnSet,
   tableExists,
   type SqliteDatabase,
   type SqliteValue,
@@ -1035,21 +1036,39 @@ function countOutdatedTailoredArtifacts(
   }
   const activeJobs = activeJobUrlSet(db);
   if (activeJobs.size === 0) return 0;
+  const materialReference = jobReferenceColumn(
+    db,
+    "job_materials_artifacts",
+  );
+  const stableMaterials = materialReference === "job_id";
+  const tenantScopedMaterials = tableColumnSet(
+    db,
+    "job_materials_artifacts",
+  ).has("tenant_id");
   const rows = allRows<{ job_url: string; metadata_json: string | null }>(
     db,
     `WITH latest AS (
-       SELECT job_url, MAX(generation) AS max_generation
+       SELECT ${tenantScopedMaterials ? "tenant_id, " : ""}${materialReference},
+              MAX(generation) AS max_generation
        FROM job_materials_artifacts
-       WHERE status = 'approved'
+       WHERE ${tenantScopedMaterials ? "tenant_id = ? AND " : ""}status = 'approved'
          AND artifact_type = 'tailored_resume'
-       GROUP BY job_url
+       GROUP BY ${tenantScopedMaterials ? "tenant_id, " : ""}${materialReference}
      )
-     SELECT a.job_url, a.metadata_json
+     SELECT ${stableMaterials ? "jobs.url" : "a.job_url"} AS job_url,
+            a.metadata_json
        FROM job_materials_artifacts a
-       JOIN latest ON latest.job_url = a.job_url AND latest.max_generation = a.generation
-      WHERE a.artifact_type = 'tailored_resume'
+       JOIN latest
+         ON ${tenantScopedMaterials ? "latest.tenant_id = a.tenant_id AND " : ""}
+            latest.${materialReference} = a.${materialReference}
+        AND latest.max_generation = a.generation
+       ${stableMaterials
+         ? "JOIN jobs ON jobs.tenant_id = a.tenant_id AND jobs.job_id = a.job_id"
+         : ""}
+      WHERE ${tenantScopedMaterials ? "a.tenant_id = ? AND " : ""}
+        a.artifact_type = 'tailored_resume'
         AND a.status = 'approved'`,
-    [],
+    tenantScopedMaterials ? [tenantId, tenantId] : [],
   );
   return rows.filter((row) => {
     if (!activeJobs.has(row.job_url)) return false;

--- a/apps/api/src/resume-review-drafts.ts
+++ b/apps/api/src/resume-review-drafts.ts
@@ -29,7 +29,16 @@ import type {
   TailoringFeedbackSignalKind,
   TailoringFeedbackSourceKind,
 } from "./contracts.js";
-import { allRows, getRow, tableExists, type SqliteDatabase, type SqliteValue } from "./db.js";
+import {
+  allRows,
+  getRow,
+  jobReferenceColumn,
+  jobReferenceForUrl,
+  jobReferencePredicateForUrl,
+  tableExists,
+  type SqliteDatabase,
+  type SqliteValue,
+} from "./db.js";
 import { defaultResumeHtmlPdfRenderer, type ResumeHtmlPdfRenderer } from "./resume-pdf-render.js";
 import { ensureCurrentResumeTemplateMaterials } from "./resume-templates.js";
 import { InputError } from "./write-model.js";
@@ -897,9 +906,8 @@ function persistRenderedDraftArtifacts(
   renderPdf({ htmlPath, pdfPath });
 
   insertDynamicRow(db, "job_materials", {
-    job_url: draft.job_key,
+    ...materialIdentityValues(db, "job_materials", draft.job_key),
     generation,
-    tenant_id: DEFAULT_TENANT,
     status: "resume_approved",
     created_at: now,
     updated_at: now,
@@ -913,7 +921,7 @@ function persistRenderedDraftArtifacts(
     }),
   });
   insertDynamicRow(db, "job_materials_artifacts", {
-    job_url: draft.job_key,
+    ...materialIdentityValues(db, "job_materials_artifacts", draft.job_key),
     generation,
     artifact_type: "tailored_resume",
     artifact_id: resumeTextArtifactId,
@@ -931,7 +939,7 @@ function persistRenderedDraftArtifacts(
     superseded_at: null,
   });
   insertDynamicRow(db, "job_materials_artifacts", {
-    job_url: draft.job_key,
+    ...materialIdentityValues(db, "job_materials_artifacts", draft.job_key),
     generation,
     artifact_type: "resume_pdf",
     artifact_id: resumePdfArtifactId,
@@ -975,14 +983,20 @@ function materialArtifactPath(
   artifactId: string | null,
 ): string | null {
   if (!artifactId || !tableExists(db, "job_materials_artifacts")) return null;
+  const artifactReference = jobReferencePredicateForUrl(
+    db,
+    "job_materials_artifacts",
+    jobKey,
+    DEFAULT_TENANT,
+  );
   const row = getRow<{ path: string | null }>(
     db,
     `SELECT path FROM job_materials_artifacts
-     WHERE job_url = ?
+     WHERE ${artifactReference.sql}
        AND generation = ?
        AND artifact_id = ?
      LIMIT 1`,
-    [jobKey, generation, artifactId],
+    [...artifactReference.params, generation, artifactId],
   );
   return row?.path?.trim() || null;
 }
@@ -990,20 +1004,36 @@ function materialArtifactPath(
 function nextMaterialGeneration(db: SqliteDatabase, jobKey: string): number {
   const generations: number[] = [];
   if (tableExists(db, "job_materials")) {
+    const materialReference = jobReferencePredicateForUrl(
+      db,
+      "job_materials",
+      jobKey,
+      DEFAULT_TENANT,
+    );
     const row = getRow<{ max_generation: number | null }>(
       db,
-      "SELECT MAX(generation) AS max_generation FROM job_materials WHERE job_url = ?",
-      [jobKey],
+      `SELECT MAX(generation) AS max_generation
+         FROM job_materials
+        WHERE ${materialReference.sql}`,
+      materialReference.params,
     );
     if (row?.max_generation !== null && row?.max_generation !== undefined) {
       generations.push(Number(row.max_generation));
     }
   }
   if (tableExists(db, "job_materials_artifacts")) {
+    const artifactReference = jobReferencePredicateForUrl(
+      db,
+      "job_materials_artifacts",
+      jobKey,
+      DEFAULT_TENANT,
+    );
     const row = getRow<{ max_generation: number | null }>(
       db,
-      "SELECT MAX(generation) AS max_generation FROM job_materials_artifacts WHERE job_url = ?",
-      [jobKey],
+      `SELECT MAX(generation) AS max_generation
+         FROM job_materials_artifacts
+        WHERE ${artifactReference.sql}`,
+      artifactReference.params,
     );
     if (row?.max_generation !== null && row?.max_generation !== undefined) {
       generations.push(Number(row.max_generation));
@@ -1035,16 +1065,22 @@ function replaceLayoutBoxes(
   createdAt: string,
 ): void {
   if (!tableExists(db, "job_material_layout_boxes")) return;
+  const layoutReference = jobReferencePredicateForUrl(
+    db,
+    "job_material_layout_boxes",
+    jobKey,
+    DEFAULT_TENANT,
+  );
   db.prepare(
-    "DELETE FROM job_material_layout_boxes WHERE job_url = ? AND generation = ? AND artifact_id = ?",
-  ).run(jobKey, generation, artifactId);
+    `DELETE FROM job_material_layout_boxes
+      WHERE ${layoutReference.sql} AND generation = ? AND artifact_id = ?`,
+  ).run(...layoutReference.params, generation, artifactId);
   for (const [index, box] of boxes.entries()) {
     insertDynamicRow(db, "job_material_layout_boxes", {
-      job_url: jobKey,
+      ...materialIdentityValues(db, "job_material_layout_boxes", jobKey),
       generation,
       artifact_id: artifactId,
       box_index: index,
-      tenant_id: DEFAULT_TENANT,
       semantic_id: box.semanticId,
       page_number: box.pageNumber,
       line_number: box.lineNumber,
@@ -1123,6 +1159,23 @@ function insertDynamicRow(
   db.prepare(
     `INSERT OR REPLACE INTO ${tableName} (${columns.join(", ")}) VALUES (${placeholders})`,
   ).run(...columns.map((column) => values[column] ?? null));
+}
+
+function materialIdentityValues(
+  db: SqliteDatabase,
+  tableName: string,
+  jobKey: string,
+): Record<string, SqliteValue> {
+  const referenceColumn = jobReferenceColumn(db, tableName);
+  return {
+    tenant_id: DEFAULT_TENANT,
+    [referenceColumn]: jobReferenceForUrl(
+      db,
+      tableName,
+      jobKey,
+      DEFAULT_TENANT,
+    ),
+  };
 }
 
 function tableColumnSet(db: SqliteDatabase, tableName: string): string[] {
@@ -1412,12 +1465,18 @@ function resolveBaseResumeMaterial(
   const columns = tableColumnSet(db, "job_materials_artifacts");
   const renderFormatSelect = columns.includes("render_format") ? "render_format" : "NULL AS render_format";
   const createdAtSelect = columns.includes("created_at") ? "created_at" : "NULL AS created_at";
+  const artifactReference = jobReferencePredicateForUrl(
+    db,
+    "job_materials_artifacts",
+    jobKey,
+    DEFAULT_TENANT,
+  );
   const rows = allRows<MaterialArtifactRow>(
     db,
     `SELECT artifact_id, artifact_type, generation, path,
             ${renderFormatSelect}, ${createdAtSelect}
        FROM job_materials_artifacts
-      WHERE job_url = ?
+      WHERE ${artifactReference.sql}
         AND COALESCE(status, 'approved') IN ('approved', 'active')
         AND artifact_type IN (
           'tailored_resume', 'tailored_resume_txt', 'resume_txt',
@@ -1426,7 +1485,7 @@ function resolveBaseResumeMaterial(
       ORDER BY COALESCE(generation, -1) DESC,
                COALESCE(created_at, '') DESC,
                artifact_id DESC`,
-    [jobKey],
+    artifactReference.params,
   );
   if (rows.length === 0) {
     throw new InputError(`No approved resume materials found for ${jobKey}.`);
@@ -1762,13 +1821,23 @@ function readBaseResumeText(db: SqliteDatabase, draft: ResumeReviewDraftRow): st
   if (!draft.base_resume_text_artifact_id || !tableExists(db, "job_materials_artifacts")) {
     return null;
   }
+  const artifactReference = jobReferencePredicateForUrl(
+    db,
+    "job_materials_artifacts",
+    draft.job_key,
+    DEFAULT_TENANT,
+  );
   const row = getRow<{ path: string | null }>(
     db,
     `SELECT path FROM job_materials_artifacts
-     WHERE job_url = ?
+     WHERE ${artifactReference.sql}
        AND generation = ?
        AND artifact_id = ?`,
-    [draft.job_key, draft.base_generation, draft.base_resume_text_artifact_id],
+    [
+      ...artifactReference.params,
+      draft.base_generation,
+      draft.base_resume_text_artifact_id,
+    ],
   );
   if (!row?.path || !fs.existsSync(row.path) || !fs.statSync(row.path).isFile()) {
     return null;

--- a/apps/api/src/resume-templates.ts
+++ b/apps/api/src/resume-templates.ts
@@ -27,7 +27,17 @@ import {
   ResumeTemplateLayoutSchema,
   ResumeTemplateThemeSchema,
 } from "./contracts.js";
-import { allRows, getRow, tableExists, type SqliteDatabase, type SqliteValue } from "./db.js";
+import {
+  allRows,
+  getRow,
+  jobReferenceColumn,
+  jobReferenceForUrl,
+  jobReferenceJoinToJobs,
+  jobReferencePredicateForUrl,
+  tableExists,
+  type SqliteDatabase,
+  type SqliteValue,
+} from "./db.js";
 import { defaultResumeHtmlPdfRenderer, type ResumeHtmlPdfRenderer } from "./resume-pdf-render.js";
 
 const DEFAULT_TENANT = "local";
@@ -555,7 +565,7 @@ export function resolveCurrentResumeArtifactIdForOpen(
   if (!tableExists(db, "job_materials_artifacts")) return artifactId;
   const columns = tableColumnSet(db, "job_materials_artifacts");
   if (
-    !columns.includes("job_url") ||
+    (!columns.includes("job_url") && !columns.includes("job_id")) ||
     !columns.includes("artifact_type") ||
     !columns.includes("artifact_id") ||
     !columns.includes("generation")
@@ -568,9 +578,20 @@ export function resolveCurrentResumeArtifactIdForOpen(
     generation: number | string | null;
   }>(
     db,
-    `SELECT job_url, artifact_type, generation
-       FROM job_materials_artifacts
-      WHERE artifact_id = ?`,
+    jobReferenceColumn(db, "job_materials_artifacts") === "job_id"
+      ? `SELECT jobs.url AS job_url, artifacts.artifact_type, artifacts.generation
+           FROM job_materials_artifacts AS artifacts
+           JOIN jobs
+             ON ${jobReferenceJoinToJobs(
+               db,
+               "job_materials_artifacts",
+               "artifacts",
+               "jobs",
+             )}
+          WHERE artifacts.artifact_id = ?`
+      : `SELECT job_url, artifact_type, generation
+           FROM job_materials_artifacts
+          WHERE artifact_id = ?`,
     [artifactId],
   );
   if (!row || (row.artifact_type !== "tailored_resume" && row.artifact_type !== "resume_pdf")) {
@@ -585,16 +606,22 @@ export function resolveCurrentResumeArtifactIdForOpen(
   const orderBy = columns.includes("created_at")
     ? "generation DESC, datetime(created_at) DESC, artifact_id DESC"
     : "generation DESC, artifact_id DESC";
+  const artifactReference = jobReferencePredicateForUrl(
+    db,
+    "job_materials_artifacts",
+    row.job_url,
+    DEFAULT_TENANT,
+  );
   const latest = getRow<{ artifact_id: string }>(
     db,
     `SELECT artifact_id
        FROM job_materials_artifacts
-      WHERE job_url = ?
+      WHERE ${artifactReference.sql}
         AND artifact_type = ?
         ${statusWhere}
       ORDER BY ${orderBy}
       LIMIT 1`,
-    [row.job_url, row.artifact_type],
+    [...artifactReference.params, row.artifact_type],
   );
   return latest?.artifact_id ?? artifactId;
 }
@@ -842,18 +869,23 @@ function latestResumeMaterial(
     columns.includes("metadata_json") ? "metadata_json" : "NULL AS metadata_json",
     columns.includes("created_at") ? "created_at" : "NULL AS created_at",
   ].join(", ");
-  const jobColumn = columns.includes("job_url") ? "job_url" : columns.includes("job_id") ? "job_id" : null;
-  if (!jobColumn) return null;
+  if (!columns.includes("job_url") && !columns.includes("job_id")) return null;
+  const artifactReference = jobReferencePredicateForUrl(
+    db,
+    "job_materials_artifacts",
+    jobKey,
+    DEFAULT_TENANT,
+  );
   const statusWhere = columns.includes("status") ? "AND COALESCE(status, 'approved') IN ('approved', 'active')" : "";
   const rows = allRows<MaterialArtifactRow>(
     db,
     `SELECT ${selectColumns}
        FROM job_materials_artifacts
-      WHERE ${jobColumn} = ?
+      WHERE ${artifactReference.sql}
         AND artifact_type IN ('tailored_resume', 'resume_pdf')
         ${statusWhere}
       ORDER BY generation DESC, CASE artifact_type WHEN 'resume_pdf' THEN 0 ELSE 1 END`,
-    [jobKey],
+    artifactReference.params,
   );
   const generation = rows[0]?.generation === undefined ? null : Number(rows[0].generation);
   if (!generation) return null;
@@ -1041,9 +1073,8 @@ function persistRenderOnlyRefresh(
   renderPdf({ htmlPath, pdfPath });
 
   insertDynamicRow(db, "job_materials", {
-    job_url: jobKey,
+    ...materialIdentityValues(db, "job_materials", jobKey),
     generation,
-    tenant_id: DEFAULT_TENANT,
     status: "resume_approved",
     created_at: now,
     updated_at: now,
@@ -1056,7 +1087,7 @@ function persistRenderOnlyRefresh(
     }),
   });
   insertDynamicRow(db, "job_materials_artifacts", {
-    job_url: jobKey,
+    ...materialIdentityValues(db, "job_materials_artifacts", jobKey),
     generation,
     artifact_type: "tailored_resume",
     artifact_id: textArtifactId,
@@ -1073,7 +1104,7 @@ function persistRenderOnlyRefresh(
     superseded_at: null,
   });
   insertDynamicRow(db, "job_materials_artifacts", {
-    job_url: jobKey,
+    ...materialIdentityValues(db, "job_materials_artifacts", jobKey),
     generation,
     artifact_type: "resume_pdf",
     artifact_id: pdfArtifactId,
@@ -1099,10 +1130,18 @@ function nextMaterialGeneration(db: SqliteDatabase, jobKey: string): number {
   const values: number[] = [];
   for (const table of ["job_materials", "job_materials_artifacts"]) {
     if (!tableExists(db, table)) continue;
+    const materialReference = jobReferencePredicateForUrl(
+      db,
+      table,
+      jobKey,
+      DEFAULT_TENANT,
+    );
     const row = getRow<{ max_generation: number | null }>(
       db,
-      `SELECT MAX(generation) AS max_generation FROM ${table} WHERE ${table === "job_materials" ? "job_url" : "job_url"} = ?`,
-      [jobKey],
+      `SELECT MAX(generation) AS max_generation
+         FROM ${table}
+        WHERE ${materialReference.sql}`,
+      materialReference.params,
     );
     if (row?.max_generation !== null && row?.max_generation !== undefined) values.push(Number(row.max_generation));
   }
@@ -1118,16 +1157,22 @@ function replaceLayoutBoxes(
   createdAt: string,
 ): void {
   if (!tableExists(db, "job_material_layout_boxes")) return;
+  const layoutReference = jobReferencePredicateForUrl(
+    db,
+    "job_material_layout_boxes",
+    jobKey,
+    DEFAULT_TENANT,
+  );
   db.prepare(
-    "DELETE FROM job_material_layout_boxes WHERE job_url = ? AND generation = ? AND artifact_id = ?",
-  ).run(jobKey, generation, artifactId);
+    `DELETE FROM job_material_layout_boxes
+      WHERE ${layoutReference.sql} AND generation = ? AND artifact_id = ?`,
+  ).run(...layoutReference.params, generation, artifactId);
   for (const [index, box] of boxes.entries()) {
     insertDynamicRow(db, "job_material_layout_boxes", {
-      job_url: jobKey,
+      ...materialIdentityValues(db, "job_material_layout_boxes", jobKey),
       generation,
       artifact_id: artifactId,
       box_index: index,
-      tenant_id: DEFAULT_TENANT,
       semantic_id: box.semanticId,
       page_number: box.pageNumber,
       line_number: box.lineNumber,
@@ -1275,6 +1320,23 @@ function insertDynamicRow(
   db.prepare(
     `INSERT OR REPLACE INTO ${tableName} (${columns.join(", ")}) VALUES (${placeholders})`,
   ).run(...columns.map((column) => values[column] ?? null));
+}
+
+function materialIdentityValues(
+  db: SqliteDatabase,
+  tableName: string,
+  jobKey: string,
+): Record<string, SqliteValue> {
+  const referenceColumn = jobReferenceColumn(db, tableName);
+  return {
+    tenant_id: DEFAULT_TENANT,
+    [referenceColumn]: jobReferenceForUrl(
+      db,
+      tableName,
+      jobKey,
+      DEFAULT_TENANT,
+    ),
+  };
 }
 
 function tableColumnSet(db: SqliteDatabase, tableName: string): string[] {

--- a/apps/api/src/write-model.ts
+++ b/apps/api/src/write-model.ts
@@ -852,8 +852,14 @@ function purgeJobRows(db: SqliteDatabase, jobUrl: string): void {
   deleteWhere(db, "job_events", "job_url = ?", [jobUrl]);
   deleteJobReferences(db, "job_artifacts", jobId, jobUrl);
   deleteScoringJobReferences(db, jobId, jobUrl);
-  deleteWhere(db, "job_materials_artifacts", "job_url = ?", [jobUrl]);
-  deleteWhere(db, "job_materials", "job_url = ?", [jobUrl]);
+  for (const tableName of [
+    "job_bullet_provenance",
+    "job_material_layout_boxes",
+    "job_materials_artifacts",
+    "job_materials",
+  ]) {
+    deleteJobReferences(db, tableName, jobId, jobUrl);
+  }
   deleteEnrichmentJobReferences(db, jobId, jobUrl);
   deletePreparationJobReferences(db, jobId, jobUrl);
   if (jobId) {

--- a/apps/api/test/materials-v15-write-model.test.ts
+++ b/apps/api/test/materials-v15-write-model.test.ts
@@ -1,0 +1,420 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import Database from "better-sqlite3";
+import { describe, expect, it } from "vitest";
+
+import {
+  createOrLoadResumeReviewDraft,
+  renderResumeReviewDraft,
+  saveResumeReviewDraftRevision,
+} from "../src/resume-review-drafts.js";
+import type { ResumeHtmlPdfRenderer } from "../src/resume-pdf-render.js";
+import {
+  BUILT_IN_RESUME_TEMPLATE_THEME,
+  createResumeTemplateVersion,
+  ensureCurrentResumeTemplateMaterials,
+  setDefaultResumeTemplate,
+  templateMetadataForMaterial,
+  templateMetadataPayload,
+} from "../src/resume-templates.js";
+import { jobReferencePredicateForUrl } from "../src/db.js";
+import { permanentlyDeleteJob } from "../src/write-model.js";
+
+const UUID_SHAPED_URL = "11111111-1111-4111-8111-111111111111";
+const URL_OWNER_JOB_ID = "22222222-2222-4222-8222-222222222222";
+const ID_TEXT_OWNER_URL = "https://example.com/jobs/id-text-owner";
+
+function createStableMaterialsSchema(db: Database.Database): void {
+  db.pragma("foreign_keys = ON");
+  db.pragma("user_version = 15");
+  db.exec(`
+    CREATE TABLE jobs (
+      url TEXT PRIMARY KEY,
+      tenant_id TEXT NOT NULL DEFAULT 'local',
+      job_id TEXT NOT NULL,
+      title TEXT,
+      company TEXT,
+      application_url TEXT,
+      discovered_at TEXT,
+      apply_status TEXT,
+      apply_error TEXT,
+      applied_at TEXT,
+      UNIQUE (tenant_id, job_id)
+    );
+    CREATE TABLE job_materials (
+      tenant_id TEXT NOT NULL DEFAULT 'local',
+      job_id TEXT NOT NULL,
+      generation INTEGER NOT NULL,
+      status TEXT NOT NULL,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
+      last_validation_json TEXT,
+      last_verdict_json TEXT,
+      metadata_json TEXT,
+      PRIMARY KEY (tenant_id, job_id, generation),
+      FOREIGN KEY (tenant_id, job_id)
+        REFERENCES jobs(tenant_id, job_id) ON DELETE CASCADE
+    );
+    CREATE TABLE job_materials_artifacts (
+      tenant_id TEXT NOT NULL DEFAULT 'local',
+      job_id TEXT NOT NULL,
+      generation INTEGER NOT NULL,
+      artifact_type TEXT NOT NULL,
+      artifact_id TEXT NOT NULL,
+      status TEXT NOT NULL,
+      path TEXT NOT NULL,
+      render_format TEXT NOT NULL,
+      size_bytes INTEGER,
+      metadata_json TEXT,
+      created_at TEXT NOT NULL,
+      superseded_at TEXT,
+      PRIMARY KEY (tenant_id, job_id, generation, artifact_type),
+      FOREIGN KEY (tenant_id, job_id, generation)
+        REFERENCES job_materials(tenant_id, job_id, generation)
+        ON DELETE CASCADE
+    );
+    CREATE TABLE job_material_layout_boxes (
+      tenant_id TEXT NOT NULL DEFAULT 'local',
+      job_id TEXT NOT NULL,
+      generation INTEGER NOT NULL,
+      artifact_id TEXT NOT NULL,
+      box_index INTEGER NOT NULL,
+      semantic_id TEXT NOT NULL,
+      page_number INTEGER NOT NULL,
+      line_number INTEGER,
+      text_excerpt TEXT NOT NULL,
+      left_pct REAL NOT NULL,
+      top_pct REAL NOT NULL,
+      width_pct REAL NOT NULL,
+      height_pct REAL NOT NULL,
+      audit_target_json TEXT NOT NULL DEFAULT '{}',
+      created_at TEXT NOT NULL,
+      PRIMARY KEY (
+        tenant_id, job_id, generation, artifact_id, box_index
+      ),
+      FOREIGN KEY (tenant_id, job_id, generation)
+        REFERENCES job_materials(tenant_id, job_id, generation)
+        ON DELETE CASCADE
+    );
+    CREATE TABLE job_bullet_provenance (
+      tenant_id TEXT NOT NULL DEFAULT 'local',
+      job_id TEXT NOT NULL,
+      generation INTEGER NOT NULL,
+      bullet_id TEXT NOT NULL,
+      artifact_id TEXT NOT NULL,
+      section TEXT NOT NULL,
+      source_id TEXT,
+      evidence_ids_json TEXT NOT NULL DEFAULT '[]',
+      requirement_ids_json TEXT NOT NULL DEFAULT '[]',
+      matched_keywords_json TEXT NOT NULL DEFAULT '[]',
+      transform_type TEXT NOT NULL,
+      control TEXT NOT NULL,
+      rationale TEXT NOT NULL DEFAULT '',
+      generated_text TEXT NOT NULL,
+      position INTEGER NOT NULL DEFAULT 0,
+      created_at TEXT NOT NULL,
+      coverage_json TEXT,
+      voice_json TEXT,
+      PRIMARY KEY (tenant_id, job_id, generation, bullet_id),
+      FOREIGN KEY (tenant_id, job_id, generation)
+        REFERENCES job_materials(tenant_id, job_id, generation)
+        ON DELETE CASCADE
+    );
+  `);
+}
+
+function seedJobAndMaterials(
+  db: Database.Database,
+  input: {
+    url: string;
+    jobId: string;
+    artifactPrefix: string;
+    artifactPath?: string;
+  },
+): void {
+  const {
+    url,
+    jobId,
+    artifactPrefix,
+    artifactPath = `/tmp/${input.artifactPrefix}.txt`,
+  } = input;
+  const now = "2026-07-29T10:00:00.000Z";
+  db.prepare(
+    `INSERT INTO jobs (url, tenant_id, job_id, title, company)
+     VALUES (?, 'local', ?, 'Platform Engineer', 'Example')`,
+  ).run(url, jobId);
+  db.prepare(
+    `INSERT INTO job_materials (
+       tenant_id, job_id, generation, status, created_at, updated_at,
+       last_validation_json, last_verdict_json, metadata_json
+     ) VALUES ('local', ?, 1, 'resume_approved', ?, ?, '{}', '{}', ?)`,
+  ).run(
+    jobId,
+    now,
+    now,
+    JSON.stringify({
+      resume_template: {
+        templateId: "built_in:modern-html",
+        templateVersionId: "built_in:modern-html:v1",
+        templateVersionNumber: 1,
+        templateName: "Modern HTML",
+        templateHash: "seed-hash",
+        assignmentSource: "built_in",
+      },
+    }),
+  );
+  db.prepare(
+    `INSERT INTO job_materials_artifacts (
+       tenant_id, job_id, generation, artifact_type, artifact_id, status,
+       path, render_format, size_bytes, metadata_json, created_at
+     ) VALUES ('local', ?, 1, 'tailored_resume', ?, 'approved', ?,
+               'text', 10, '{}', ?)`,
+  ).run(jobId, `${artifactPrefix}-text`, artifactPath, now);
+  db.prepare(
+    `INSERT INTO job_material_layout_boxes (
+       tenant_id, job_id, generation, artifact_id, box_index, semantic_id,
+       page_number, line_number, text_excerpt, left_pct, top_pct, width_pct,
+       height_pct, audit_target_json, created_at
+     ) VALUES ('local', ?, 1, ?, 0, 'line:1', 1, 1, 'Platform Engineer',
+               1, 2, 3, 4, '{}', ?)`,
+  ).run(jobId, `${artifactPrefix}-text`, now);
+  db.prepare(
+    `INSERT INTO job_bullet_provenance (
+       tenant_id, job_id, generation, bullet_id, artifact_id, section,
+       transform_type, control, generated_text, created_at
+     ) VALUES ('local', ?, 1, 'bullet:1', ?, 'experience', 'unchanged',
+               'preserve', 'Platform Engineer', ?)`,
+  ).run(jobId, `${artifactPrefix}-text`, now);
+}
+
+describe("schema-v15 generated-material writes", () => {
+  it("permanently deletes only the UUID-shaped URL owner's material graph", () => {
+    const db = new Database(":memory:");
+    createStableMaterialsSchema(db);
+    seedJobAndMaterials(
+      db,
+      {
+        url: UUID_SHAPED_URL,
+        jobId: URL_OWNER_JOB_ID,
+        artifactPrefix: "url-owner",
+      },
+    );
+    seedJobAndMaterials(
+      db,
+      {
+        url: ID_TEXT_OWNER_URL,
+        jobId: UUID_SHAPED_URL,
+        artifactPrefix: "id-owner",
+      },
+    );
+
+    expect(
+      jobReferencePredicateForUrl(
+        db,
+        "job_materials_artifacts",
+        UUID_SHAPED_URL,
+      ),
+    ).toEqual({
+      sql: "tenant_id = ? AND job_id = ?",
+      params: ["local", URL_OWNER_JOB_ID],
+    });
+
+    expect(permanentlyDeleteJob(db, UUID_SHAPED_URL)).toEqual({
+      ok: true,
+      count: 1,
+      jobKeys: [UUID_SHAPED_URL],
+    });
+    expect(
+      db.prepare("SELECT url FROM jobs ORDER BY url").all(),
+    ).toEqual([{ url: ID_TEXT_OWNER_URL }]);
+    for (const tableName of [
+      "job_materials",
+      "job_materials_artifacts",
+      "job_material_layout_boxes",
+      "job_bullet_provenance",
+    ]) {
+      expect(
+        db.prepare(
+          `SELECT DISTINCT job_id FROM ${tableName}`,
+        ).all(),
+      ).toEqual([{ job_id: UUID_SHAPED_URL }]);
+    }
+    expect(db.pragma("foreign_key_check")).toEqual([]);
+    db.close();
+  });
+
+  it("promotes an edited resume into a new stable-ID material generation", () => {
+    const tempDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "jobctrl-materials-v15-review-"),
+    );
+    const resumePath = path.join(tempDir, "resume.txt");
+    fs.writeFileSync(resumePath, "Jordan Candidate\nExperience\nLed platform work.");
+    const db = new Database(":memory:");
+    createStableMaterialsSchema(db);
+    seedJobAndMaterials(
+      db,
+      {
+        url: UUID_SHAPED_URL,
+        jobId: URL_OWNER_JOB_ID,
+        artifactPrefix: "base",
+        artifactPath: resumePath,
+      },
+    );
+    const renderPdf: ResumeHtmlPdfRenderer = ({ htmlPath, pdfPath }) => {
+      fs.writeFileSync(
+        pdfPath,
+        `%PDF-1.4 rendered\n${fs.readFileSync(htmlPath, "utf8")}`,
+      );
+    };
+    const currentTemplate = templateMetadataForMaterial(
+      db,
+      UUID_SHAPED_URL,
+    );
+    db.prepare(
+      `UPDATE job_materials
+          SET metadata_json = ?
+        WHERE tenant_id = 'local' AND job_id = ? AND generation = 1`,
+    ).run(
+      JSON.stringify({
+        resume_template: templateMetadataPayload(currentTemplate),
+      }),
+      URL_OWNER_JOB_ID,
+    );
+
+    const created = createOrLoadResumeReviewDraft(
+      db,
+      UUID_SHAPED_URL,
+      {},
+      renderPdf,
+    );
+    const saved = saveResumeReviewDraftRevision(
+      db,
+      created.draft.draftId,
+      {
+        editedText: [
+          "Jordan Candidate",
+          "Experience",
+          "Led platform reliability across critical services.",
+        ].join("\n"),
+        editDeltas: [],
+      },
+    );
+    const rendered = renderResumeReviewDraft(
+      db,
+      created.draft.draftId,
+      { draftRevisionId: saved.revision.revisionId },
+      renderPdf,
+    );
+
+    expect(rendered.ok).toBe(true);
+    expect(
+      db.prepare(
+        `SELECT generation, job_id
+           FROM job_materials
+          ORDER BY generation`,
+      ).all(),
+    ).toEqual([
+      { generation: 1, job_id: URL_OWNER_JOB_ID },
+      { generation: 2, job_id: URL_OWNER_JOB_ID },
+    ]);
+    expect(
+      db.prepare(
+        `SELECT artifact_type, job_id
+           FROM job_materials_artifacts
+          WHERE generation = 2
+          ORDER BY artifact_type`,
+      ).all(),
+    ).toEqual([
+      { artifact_type: "resume_pdf", job_id: URL_OWNER_JOB_ID },
+      { artifact_type: "tailored_resume", job_id: URL_OWNER_JOB_ID },
+    ]);
+    expect(
+      db.prepare(
+        `SELECT DISTINCT job_id
+           FROM job_material_layout_boxes
+          WHERE generation = 2`,
+      ).all(),
+    ).toEqual([{ job_id: URL_OWNER_JOB_ID }]);
+    expect(db.pragma("foreign_key_check")).toEqual([]);
+
+    db.close();
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("refreshes a resume template into stable-ID material and layout rows", () => {
+    const tempDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "jobctrl-materials-v15-template-"),
+    );
+    const resumePath = path.join(tempDir, "resume.txt");
+    fs.writeFileSync(resumePath, "Jordan Candidate\nExperience\nLed platform work.");
+    const db = new Database(":memory:");
+    createStableMaterialsSchema(db);
+    seedJobAndMaterials(
+      db,
+      {
+        url: UUID_SHAPED_URL,
+        jobId: URL_OWNER_JOB_ID,
+        artifactPrefix: "base",
+        artifactPath: resumePath,
+      },
+    );
+    const saved = createResumeTemplateVersion(db, {
+      displayName: "Stable-ID serif",
+      theme: {
+        ...BUILT_IN_RESUME_TEMPLATE_THEME,
+        fontFamily: "serif",
+      },
+      layout: {},
+    });
+    setDefaultResumeTemplate(db, {
+      templateId: saved.template.templateId,
+      versionId: saved.template.activeVersion.versionId,
+    });
+    const renderPdf: ResumeHtmlPdfRenderer = ({ htmlPath, pdfPath }) => {
+      fs.writeFileSync(
+        pdfPath,
+        `%PDF-1.4 rendered\n${fs.readFileSync(htmlPath, "utf8")}`,
+      );
+    };
+
+    const refreshed = ensureCurrentResumeTemplateMaterials(
+      db,
+      UUID_SHAPED_URL,
+      {},
+      renderPdf,
+    );
+
+    expect(refreshed).toMatchObject({
+      ok: true,
+      status: "completed",
+      generation: 2,
+    });
+    expect(
+      db.prepare(
+        `SELECT DISTINCT job_id
+           FROM job_materials
+          WHERE generation = 2`,
+      ).all(),
+    ).toEqual([{ job_id: URL_OWNER_JOB_ID }]);
+    expect(
+      db.prepare(
+        `SELECT DISTINCT job_id
+           FROM job_materials_artifacts
+          WHERE generation = 2`,
+      ).all(),
+    ).toEqual([{ job_id: URL_OWNER_JOB_ID }]);
+    expect(
+      db.prepare(
+        `SELECT DISTINCT job_id
+           FROM job_material_layout_boxes
+          WHERE generation = 2`,
+      ).all(),
+    ).toEqual([{ job_id: URL_OWNER_JOB_ID }]);
+    expect(db.pragma("foreign_key_check")).toEqual([]);
+
+    db.close();
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+});

--- a/apps/api/test/schema-version-guard.test.ts
+++ b/apps/api/test/schema-version-guard.test.ts
@@ -63,7 +63,7 @@ describe("schema version guard at DB open", () => {
   });
 
   it("opens the worker-owned schema-v14 artifact registry", () => {
-    expect(SUPPORTED_SCHEMA_VERSION).toBe(14);
+    expect(SUPPORTED_SCHEMA_VERSION).toBe(15);
     const { dbPath, cleanup } = makeDbWithUserVersion(14);
     try {
       openDatabase(dbPath).close();

--- a/workers/automation/src/jobctrl/database.py
+++ b/workers/automation/src/jobctrl/database.py
@@ -58,7 +58,11 @@ from jobctrl.config import DB_PATH, DEFAULTS, migrate_legacy_job_tables
 # v14 (artifact registry references): generic per-job artifact registrations
 # reference ``(tenant_id, job_id)``. Alias collisions retain one current row per
 # registry key using the same last-write-wins rule as runtime artifact upserts.
-SCHEMA_VERSION = 14
+# v15 (materials references): generated-material generations, their artifact
+# slots, PDF layout audit boxes, and bullet provenance reference the stable Job
+# aggregate. Alias histories are deterministically interleaved and renumbered
+# together so no generation or dependent audit row is discarded.
+SCHEMA_VERSION = 15
 
 
 class IncompatibleSchemaVersionError(RuntimeError):
@@ -203,6 +207,7 @@ def _schema_migrations() -> tuple[
         (12, ensure_scoring_references_v12),
         (13, ensure_stage_state_references_v13),
         (14, ensure_artifact_registry_references_v14),
+        (15, ensure_materials_references_v15),
     )
 
 
@@ -2445,7 +2450,8 @@ def ensure_materials_tables(conn: sqlite3.Connection | None = None) -> list[str]
     See ddd-target.md §4.5 / §7.2. Two tables form the persistence side
     of the Phase-6 :class:`MaterialsSet` aggregate:
 
-      * ``job_materials`` — one row per ``(job_url, generation)`` aggregate.
+      * ``job_materials`` — one row per tenant-scoped stable
+        ``(job_id, generation)`` aggregate.
       * ``job_materials_artifacts`` — one row per artifact slot per
         aggregate (``tailored_resume``, ``cover_letter``, ``resume_pdf``,
         ``cover_letter_pdf``).
@@ -2467,107 +2473,148 @@ def ensure_materials_tables(conn: sqlite3.Connection | None = None) -> list[str]
     if conn is None:
         conn = get_connection()
 
-    conn.execute(
-        """
-        CREATE TABLE IF NOT EXISTS job_materials (
-            job_url             TEXT NOT NULL,
-            generation          INTEGER NOT NULL,
-            tenant_id           TEXT NOT NULL DEFAULT 'local',
-            status              TEXT NOT NULL,
-            created_at          TEXT NOT NULL,
-            updated_at          TEXT NOT NULL,
-            last_validation_json TEXT,
-            last_verdict_json    TEXT,
-            metadata_json       TEXT,
-            PRIMARY KEY (job_url, generation),
-            FOREIGN KEY (job_url) REFERENCES jobs(url) ON DELETE CASCADE
+    current_schema_version = _assert_schema_version_supported(conn)
+    if current_schema_version >= _MATERIALS_REFERENCE_SCHEMA_VERSION:
+        _create_materials_tables_v15(conn)
+        _create_materials_indexes_v15(conn)
+    else:
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS job_materials (
+                job_url             TEXT NOT NULL,
+                generation          INTEGER NOT NULL,
+                tenant_id           TEXT NOT NULL DEFAULT 'local',
+                status              TEXT NOT NULL,
+                created_at          TEXT NOT NULL,
+                updated_at          TEXT NOT NULL,
+                last_validation_json TEXT,
+                last_verdict_json    TEXT,
+                metadata_json       TEXT,
+                PRIMARY KEY (job_url, generation),
+                FOREIGN KEY (job_url) REFERENCES jobs(url) ON DELETE CASCADE
+            )
+            """
         )
-        """
-    )
-    conn.execute(
-        """
-        CREATE TABLE IF NOT EXISTS job_materials_artifacts (
-            job_url             TEXT NOT NULL,
-            generation          INTEGER NOT NULL,
-            artifact_type       TEXT NOT NULL,
-            artifact_id         TEXT NOT NULL,
-            status              TEXT NOT NULL,
-            path                TEXT NOT NULL,
-            render_format       TEXT NOT NULL,
-            size_bytes          INTEGER,
-            metadata_json       TEXT,
-            created_at          TEXT NOT NULL,
-            superseded_at       TEXT,
-            PRIMARY KEY (job_url, generation, artifact_type),
-            FOREIGN KEY (job_url, generation) REFERENCES job_materials(job_url, generation)
-                ON DELETE CASCADE
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS job_materials_artifacts (
+                job_url             TEXT NOT NULL,
+                generation          INTEGER NOT NULL,
+                artifact_type       TEXT NOT NULL,
+                artifact_id         TEXT NOT NULL,
+                status              TEXT NOT NULL,
+                path                TEXT NOT NULL,
+                render_format       TEXT NOT NULL,
+                size_bytes          INTEGER,
+                metadata_json       TEXT,
+                created_at          TEXT NOT NULL,
+                superseded_at       TEXT,
+                PRIMARY KEY (job_url, generation, artifact_type),
+                FOREIGN KEY (job_url, generation)
+                    REFERENCES job_materials(job_url, generation)
+                    ON DELETE CASCADE
+            )
+            """
         )
-        """
-    )
-    conn.execute(
-        """
-        CREATE TABLE IF NOT EXISTS job_material_layout_boxes (
-            job_url             TEXT NOT NULL,
-            generation          INTEGER NOT NULL,
-            artifact_id         TEXT NOT NULL,
-            box_index           INTEGER NOT NULL,
-            tenant_id           TEXT NOT NULL DEFAULT 'local',
-            semantic_id         TEXT NOT NULL,
-            page_number         INTEGER NOT NULL,
-            line_number         INTEGER,
-            text_excerpt        TEXT NOT NULL,
-            left_pct            REAL NOT NULL,
-            top_pct             REAL NOT NULL,
-            width_pct           REAL NOT NULL,
-            height_pct          REAL NOT NULL,
-            audit_target_json   TEXT NOT NULL DEFAULT '{}',
-            created_at          TEXT NOT NULL,
-            PRIMARY KEY (job_url, generation, artifact_id, box_index),
-            FOREIGN KEY (job_url, generation) REFERENCES job_materials(job_url, generation)
-                ON DELETE CASCADE
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS job_material_layout_boxes (
+                job_url             TEXT NOT NULL,
+                generation          INTEGER NOT NULL,
+                artifact_id         TEXT NOT NULL,
+                box_index           INTEGER NOT NULL,
+                tenant_id           TEXT NOT NULL DEFAULT 'local',
+                semantic_id         TEXT NOT NULL,
+                page_number         INTEGER NOT NULL,
+                line_number         INTEGER,
+                text_excerpt        TEXT NOT NULL,
+                left_pct            REAL NOT NULL,
+                top_pct             REAL NOT NULL,
+                width_pct           REAL NOT NULL,
+                height_pct          REAL NOT NULL,
+                audit_target_json   TEXT NOT NULL DEFAULT '{}',
+                created_at          TEXT NOT NULL,
+                PRIMARY KEY (
+                    job_url, generation, artifact_id, box_index
+                ),
+                FOREIGN KEY (job_url, generation)
+                    REFERENCES job_materials(job_url, generation)
+                    ON DELETE CASCADE
+            )
+            """
         )
-        """
-    )
-    # Indexes for the queue selectors (mirror the §7.2 read fragments).
-    conn.execute(
-        """
-        CREATE INDEX IF NOT EXISTS idx_job_materials_tenant_job_gen
-        ON job_materials(tenant_id, job_url, generation DESC)
-        """
-    )
-    conn.execute(
-        """
-        CREATE INDEX IF NOT EXISTS idx_job_materials_artifacts_status
-        ON job_materials_artifacts(artifact_type, status, created_at DESC)
-        """
-    )
-    conn.execute(
-        """
-        CREATE INDEX IF NOT EXISTS idx_job_material_layout_boxes_artifact
-        ON job_material_layout_boxes(tenant_id, artifact_id, page_number, box_index)
-        """
-    )
+        # Indexes for the queue selectors (mirror the §7.2 read fragments).
+        conn.execute(
+            """
+            CREATE INDEX IF NOT EXISTS idx_job_materials_tenant_job_gen
+            ON job_materials(tenant_id, job_url, generation DESC)
+            """
+        )
+        conn.execute(
+            """
+            CREATE INDEX IF NOT EXISTS idx_job_materials_artifacts_status
+            ON job_materials_artifacts(
+                artifact_type, status, created_at DESC
+            )
+            """
+        )
+        conn.execute(
+            """
+            CREATE INDEX IF NOT EXISTS idx_job_material_layout_boxes_artifact
+            ON job_material_layout_boxes(
+                tenant_id, artifact_id, page_number, box_index
+            )
+            """
+        )
 
-    # Idempotent backfill from the legacy ``jobs`` columns. Fires only
-    # when ``job_materials`` is empty.
-    backfill_count = conn.execute("SELECT COUNT(*) FROM job_materials").fetchone()[0]
-    if backfill_count == 0:
-        legacy_rows = conn.execute(
-            """
-            SELECT url, tailored_resume_path, tailored_at,
-                   cover_letter_path, cover_letter_at
-            FROM jobs
-            WHERE tailored_resume_path IS NOT NULL
-              AND tailored_resume_path != ''
-            """
-        ).fetchall()
-        if legacy_rows:
-            now = datetime.now(timezone.utc).isoformat()
-            for row in legacy_rows:
-                _backfill_one_materials_row(conn, row, now)
+    _backfill_legacy_materials_if_empty(conn)
 
     conn.commit()
     return ["job_materials", "job_materials_artifacts", "job_material_layout_boxes"]
+
+
+def _backfill_legacy_materials_if_empty(
+    conn: sqlite3.Connection,
+) -> None:
+    """Backfill legacy paths once their owning job identity is available."""
+    backfill_count = conn.execute("SELECT COUNT(*) FROM job_materials").fetchone()[0]
+    if backfill_count != 0:
+        return
+
+    stable_schema = "job_id" in _table_columns(conn, "job_materials")
+    jobs_columns = _table_columns(conn, "jobs")
+    stable_jobs = {"tenant_id", "job_id"} <= jobs_columns
+    if stable_schema and not stable_jobs:
+        # A paired pre-v7 recovery snapshot can contain the newer material
+        # table shape while the jobs authority has been restored to v6.
+        # The ordered v15 migration retries this after stable identity exists.
+        return
+
+    legacy_rows = conn.execute(
+        """
+        SELECT tenant_id, job_id, url,
+               tailored_resume_path, tailored_at,
+               cover_letter_path, cover_letter_at
+        FROM jobs
+        WHERE tailored_resume_path IS NOT NULL
+          AND tailored_resume_path != ''
+        """
+        if stable_schema
+        else """
+        SELECT 'local' AS tenant_id, NULL AS job_id, url,
+               tailored_resume_path, tailored_at,
+               cover_letter_path, cover_letter_at
+        FROM jobs
+        WHERE tailored_resume_path IS NOT NULL
+          AND tailored_resume_path != ''
+        """
+    ).fetchall()
+    if not legacy_rows:
+        return
+
+    now = datetime.now(timezone.utc).isoformat()
+    for row in legacy_rows:
+        _backfill_one_materials_row(conn, row, now)
 
 
 def ensure_resume_template_tables(conn: sqlite3.Connection | None = None) -> list[str]:
@@ -2745,7 +2792,9 @@ def _backfill_one_materials_row(
     import os
     import uuid as _uuid
 
-    url = row["url"]
+    tenant_id = str(row["tenant_id"] or "local")
+    url = str(row["url"])
+    job_id = str(row["job_id"] or "")
     tailor_path = row["tailored_resume_path"]
     tailor_at = row["tailored_at"] or now
     cover_path = row["cover_letter_path"]
@@ -2772,22 +2821,44 @@ def _backfill_one_materials_row(
     if resume_pdf and cover_pdf and cover_path:
         status = "complete"
 
-    conn.execute(
-        """
-        INSERT OR IGNORE INTO job_materials (
-            job_url, generation, tenant_id, status,
-            created_at, updated_at,
-            last_validation_json, last_verdict_json, metadata_json
-        ) VALUES (?, 1, 'local', ?, ?, ?, NULL, NULL, ?)
-        """,
-        (
-            url,
-            status,
-            tailor_at,
-            cover_at if cover_path else tailor_at,
-            json.dumps({"backfilled": True}, sort_keys=True),
-        ),
-    )
+    stable_schema = "job_id" in _table_columns(conn, "job_materials")
+    if stable_schema:
+        _validate_job_uuid(job_id)
+        conn.execute(
+            """
+            INSERT OR IGNORE INTO job_materials (
+                tenant_id, job_id, generation, status,
+                created_at, updated_at,
+                last_validation_json, last_verdict_json, metadata_json
+            ) VALUES (?, ?, 1, ?, ?, ?, NULL, NULL, ?)
+            """,
+            (
+                tenant_id,
+                job_id,
+                status,
+                tailor_at,
+                cover_at if cover_path else tailor_at,
+                json.dumps({"backfilled": True}, sort_keys=True),
+            ),
+        )
+    else:
+        conn.execute(
+            """
+            INSERT OR IGNORE INTO job_materials (
+                job_url, generation, tenant_id, status,
+                created_at, updated_at,
+                last_validation_json, last_verdict_json, metadata_json
+            ) VALUES (?, 1, ?, ?, ?, ?, NULL, NULL, ?)
+            """,
+            (
+                url,
+                tenant_id,
+                status,
+                tailor_at,
+                cover_at if cover_path else tailor_at,
+                json.dumps({"backfilled": True}, sort_keys=True),
+            ),
+        )
 
     def _size(path: str | None) -> int | None:
         if not path:
@@ -2808,25 +2879,47 @@ def _backfill_one_materials_row(
         artifacts.append(("cover_letter_pdf", cover_pdf, "html_pdf", _size(cover_pdf), cover_at))
 
     for artifact_type, path, render_format, size, created in artifacts:
-        conn.execute(
-            """
-            INSERT OR IGNORE INTO job_materials_artifacts (
-                job_url, generation, artifact_type, artifact_id,
-                status, path, render_format, size_bytes,
-                metadata_json, created_at, superseded_at
-            ) VALUES (?, 1, ?, ?, 'approved', ?, ?, ?, ?, ?, NULL)
-            """,
-            (
-                url,
-                artifact_type,
-                _uuid.uuid4().hex,
-                path,
-                render_format,
-                size,
-                json.dumps({"backfilled": True}, sort_keys=True),
-                created,
-            ),
-        )
+        if stable_schema:
+            conn.execute(
+                """
+                INSERT OR IGNORE INTO job_materials_artifacts (
+                    tenant_id, job_id, generation, artifact_type,
+                    artifact_id, status, path, render_format, size_bytes,
+                    metadata_json, created_at, superseded_at
+                ) VALUES (?, ?, 1, ?, ?, 'approved', ?, ?, ?, ?, ?, NULL)
+                """,
+                (
+                    tenant_id,
+                    job_id,
+                    artifact_type,
+                    _uuid.uuid4().hex,
+                    path,
+                    render_format,
+                    size,
+                    json.dumps({"backfilled": True}, sort_keys=True),
+                    created,
+                ),
+            )
+        else:
+            conn.execute(
+                """
+                INSERT OR IGNORE INTO job_materials_artifacts (
+                    job_url, generation, artifact_type, artifact_id,
+                    status, path, render_format, size_bytes,
+                    metadata_json, created_at, superseded_at
+                ) VALUES (?, 1, ?, ?, 'approved', ?, ?, ?, ?, ?, NULL)
+                """,
+                (
+                    url,
+                    artifact_type,
+                    _uuid.uuid4().hex,
+                    path,
+                    render_format,
+                    size,
+                    json.dumps({"backfilled": True}, sort_keys=True),
+                    created,
+                ),
+            )
 
 
 def ensure_employer_analysis_tables(conn: sqlite3.Connection | None = None) -> list[str]:
@@ -2951,7 +3044,8 @@ def ensure_bullet_provenance_tables(conn: sqlite3.Connection | None = None) -> l
     audit data is stored as CANONICAL ROWS — never inside an artifact
     ``metadata_json`` blob:
 
-      * ``job_bullet_provenance`` — one row per ``(job_url, generation, bullet_id)``.
+      * ``job_bullet_provenance`` — one row per tenant-scoped stable
+        ``(job_id, generation, bullet_id)``.
         Bound to the ``job_materials`` generation it explains and to the specific
         ``artifact_id`` (the tailored resume) it was computed against. FK ids
         (``evidence_ids_json`` / ``requirement_ids_json``) reference real profile
@@ -2967,33 +3061,38 @@ def ensure_bullet_provenance_tables(conn: sqlite3.Connection | None = None) -> l
     if conn is None:
         conn = get_connection()
 
-    conn.execute(
-        """
-        CREATE TABLE IF NOT EXISTS job_bullet_provenance (
-            job_url             TEXT NOT NULL,
-            generation          INTEGER NOT NULL,
-            bullet_id           TEXT NOT NULL,
-            tenant_id           TEXT NOT NULL DEFAULT 'local',
-            artifact_id         TEXT NOT NULL,
-            section             TEXT NOT NULL,
-            source_id           TEXT,
-            evidence_ids_json   TEXT NOT NULL DEFAULT '[]',
-            requirement_ids_json TEXT NOT NULL DEFAULT '[]',
-            matched_keywords_json TEXT NOT NULL DEFAULT '[]',
-            transform_type      TEXT NOT NULL,
-            control             TEXT NOT NULL,
-            rationale           TEXT NOT NULL DEFAULT '',
-            generated_text      TEXT NOT NULL,
-            position            INTEGER NOT NULL DEFAULT 0,
-            created_at          TEXT NOT NULL,
-            coverage_json       TEXT,
-            voice_json          TEXT,
-            PRIMARY KEY (job_url, generation, bullet_id),
-            FOREIGN KEY (job_url, generation)
-                REFERENCES job_materials(job_url, generation) ON DELETE CASCADE
+    current_schema_version = _assert_schema_version_supported(conn)
+    if current_schema_version >= _MATERIALS_REFERENCE_SCHEMA_VERSION:
+        _create_bullet_provenance_v15(conn)
+    else:
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS job_bullet_provenance (
+                job_url             TEXT NOT NULL,
+                generation          INTEGER NOT NULL,
+                bullet_id           TEXT NOT NULL,
+                tenant_id           TEXT NOT NULL DEFAULT 'local',
+                artifact_id         TEXT NOT NULL,
+                section             TEXT NOT NULL,
+                source_id           TEXT,
+                evidence_ids_json   TEXT NOT NULL DEFAULT '[]',
+                requirement_ids_json TEXT NOT NULL DEFAULT '[]',
+                matched_keywords_json TEXT NOT NULL DEFAULT '[]',
+                transform_type      TEXT NOT NULL,
+                control             TEXT NOT NULL,
+                rationale           TEXT NOT NULL DEFAULT '',
+                generated_text      TEXT NOT NULL,
+                position            INTEGER NOT NULL DEFAULT 0,
+                created_at          TEXT NOT NULL,
+                coverage_json       TEXT,
+                voice_json          TEXT,
+                PRIMARY KEY (job_url, generation, bullet_id),
+                FOREIGN KEY (job_url, generation)
+                    REFERENCES job_materials(job_url, generation)
+                    ON DELETE CASCADE
+            )
+            """
         )
-        """
-    )
     # Phase 3: generation-time keyword coverage (GROUND-06) + voice-pass audit
     # (VOICE-02) are set-level facts stored alongside the bullets they were
     # computed against. They are denormalised onto every row of the generation
@@ -3008,10 +3107,17 @@ def ensure_bullet_provenance_tables(conn: sqlite3.Connection | None = None) -> l
     if "voice_json" not in existing_cols:
         conn.execute("ALTER TABLE job_bullet_provenance ADD COLUMN voice_json TEXT")
     # Selector for the read path: latest generation's rows for a job/artifact.
+    reference_column = (
+        "job_id"
+        if "job_id" in _table_columns(conn, "job_bullet_provenance")
+        else "job_url"
+    )
     conn.execute(
-        """
+        f"""
         CREATE INDEX IF NOT EXISTS idx_job_bullet_provenance_tenant_job_gen
-        ON job_bullet_provenance(tenant_id, job_url, generation DESC)
+        ON job_bullet_provenance(
+            tenant_id, {reference_column}, generation DESC
+        )
         """
     )
     conn.execute(
@@ -4341,6 +4447,13 @@ def _reassign_discovery_identity_references(
         )
     if _has_artifact_registry_reference_schema_v14(conn):
         _reassign_artifact_registry_references_v14(
+            conn,
+            tenant_id=tenant_id,
+            losing_job_id=losing_job_id,
+            surviving_job_id=surviving_job_id,
+        )
+    if _has_materials_reference_schema_v15(conn):
+        _reassign_materials_references_v15(
             conn,
             tenant_id=tenant_id,
             losing_job_id=losing_job_id,
@@ -8723,6 +8836,920 @@ def _reassign_artifact_registry_references_v14(
     )
 
 
+_MATERIALS_REFERENCE_SCHEMA_VERSION = 15
+_MATERIALS_REFERENCE_TABLES = (
+    "job_materials",
+    "job_materials_artifacts",
+    "job_material_layout_boxes",
+    "job_bullet_provenance",
+)
+
+
+def _create_materials_tables_v15(
+    conn: sqlite3.Connection,
+    *,
+    materials_table: str = "job_materials",
+    artifacts_table: str = "job_materials_artifacts",
+    layout_table: str = "job_material_layout_boxes",
+) -> None:
+    conn.execute(
+        f"""
+        CREATE TABLE IF NOT EXISTS {materials_table} (
+            tenant_id            TEXT NOT NULL DEFAULT 'local',
+            job_id               TEXT NOT NULL,
+            generation           INTEGER NOT NULL CHECK(generation > 0),
+            status               TEXT NOT NULL,
+            created_at           TEXT NOT NULL,
+            updated_at           TEXT NOT NULL,
+            last_validation_json TEXT,
+            last_verdict_json    TEXT,
+            metadata_json        TEXT,
+            PRIMARY KEY (tenant_id, job_id, generation),
+            FOREIGN KEY (tenant_id, job_id)
+                REFERENCES jobs(tenant_id, job_id) ON DELETE CASCADE
+        )
+        """
+    )
+    conn.execute(
+        f"""
+        CREATE TABLE IF NOT EXISTS {artifacts_table} (
+            tenant_id      TEXT NOT NULL DEFAULT 'local',
+            job_id         TEXT NOT NULL,
+            generation     INTEGER NOT NULL CHECK(generation > 0),
+            artifact_type  TEXT NOT NULL,
+            artifact_id    TEXT NOT NULL,
+            status         TEXT NOT NULL,
+            path           TEXT NOT NULL,
+            render_format  TEXT NOT NULL,
+            size_bytes     INTEGER,
+            metadata_json  TEXT,
+            created_at     TEXT NOT NULL,
+            superseded_at  TEXT,
+            PRIMARY KEY (
+                tenant_id, job_id, generation, artifact_type
+            ),
+            FOREIGN KEY (tenant_id, job_id, generation)
+                REFERENCES {materials_table}(
+                    tenant_id, job_id, generation
+                ) ON DELETE CASCADE
+        )
+        """
+    )
+    conn.execute(
+        f"""
+        CREATE TABLE IF NOT EXISTS {layout_table} (
+            tenant_id         TEXT NOT NULL DEFAULT 'local',
+            job_id            TEXT NOT NULL,
+            generation        INTEGER NOT NULL CHECK(generation > 0),
+            artifact_id       TEXT NOT NULL,
+            box_index         INTEGER NOT NULL,
+            semantic_id       TEXT NOT NULL,
+            page_number       INTEGER NOT NULL,
+            line_number       INTEGER,
+            text_excerpt      TEXT NOT NULL,
+            left_pct          REAL NOT NULL,
+            top_pct           REAL NOT NULL,
+            width_pct         REAL NOT NULL,
+            height_pct        REAL NOT NULL,
+            audit_target_json TEXT NOT NULL DEFAULT '{{}}',
+            created_at        TEXT NOT NULL,
+            PRIMARY KEY (
+                tenant_id, job_id, generation, artifact_id, box_index
+            ),
+            FOREIGN KEY (tenant_id, job_id, generation)
+                REFERENCES {materials_table}(
+                    tenant_id, job_id, generation
+                ) ON DELETE CASCADE
+        )
+        """
+    )
+
+
+def _create_bullet_provenance_v15(
+    conn: sqlite3.Connection,
+    *,
+    table_name: str = "job_bullet_provenance",
+    materials_table: str = "job_materials",
+) -> None:
+    conn.execute(
+        f"""
+        CREATE TABLE IF NOT EXISTS {table_name} (
+            tenant_id               TEXT NOT NULL DEFAULT 'local',
+            job_id                  TEXT NOT NULL,
+            generation              INTEGER NOT NULL CHECK(generation > 0),
+            bullet_id               TEXT NOT NULL,
+            artifact_id             TEXT NOT NULL,
+            section                 TEXT NOT NULL,
+            source_id               TEXT,
+            evidence_ids_json       TEXT NOT NULL DEFAULT '[]',
+            requirement_ids_json    TEXT NOT NULL DEFAULT '[]',
+            matched_keywords_json   TEXT NOT NULL DEFAULT '[]',
+            transform_type          TEXT NOT NULL,
+            control                 TEXT NOT NULL,
+            rationale               TEXT NOT NULL DEFAULT '',
+            generated_text          TEXT NOT NULL,
+            position                INTEGER NOT NULL DEFAULT 0,
+            created_at              TEXT NOT NULL,
+            coverage_json           TEXT,
+            voice_json              TEXT,
+            PRIMARY KEY (
+                tenant_id, job_id, generation, bullet_id
+            ),
+            FOREIGN KEY (tenant_id, job_id, generation)
+                REFERENCES {materials_table}(
+                    tenant_id, job_id, generation
+                ) ON DELETE CASCADE
+        )
+        """
+    )
+
+
+def _create_materials_indexes_v15(
+    conn: sqlite3.Connection,
+) -> None:
+    conn.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_job_materials_tenant_job_gen
+        ON job_materials(tenant_id, job_id, generation DESC)
+        """
+    )
+    conn.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_job_materials_artifacts_status
+        ON job_materials_artifacts(
+            artifact_type, status, created_at DESC
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_job_material_layout_boxes_artifact
+        ON job_material_layout_boxes(
+            tenant_id, artifact_id, page_number, box_index
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_job_bullet_provenance_tenant_job_gen
+        ON job_bullet_provenance(tenant_id, job_id, generation DESC)
+        """
+    )
+    conn.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_job_bullet_provenance_artifact
+        ON job_bullet_provenance(tenant_id, artifact_id)
+        """
+    )
+
+
+def _has_materials_reference_schema_v15(
+    conn: sqlite3.Connection,
+) -> bool:
+    return (
+        "job_id" in _table_columns(conn, "job_materials")
+        and "job_url" not in _table_columns(conn, "job_materials")
+        and _primary_key_columns(conn, "job_materials")
+        == ("tenant_id", "job_id", "generation")
+        and _has_composite_job_id_foreign_key(
+            conn,
+            "job_materials",
+            "job_id",
+        )
+        and "job_id" in _table_columns(
+            conn,
+            "job_materials_artifacts",
+        )
+        and "job_url" not in _table_columns(
+            conn,
+            "job_materials_artifacts",
+        )
+        and _primary_key_columns(conn, "job_materials_artifacts")
+        == ("tenant_id", "job_id", "generation", "artifact_type")
+        and _has_composite_foreign_key(
+            conn,
+            "job_materials_artifacts",
+            "job_materials",
+            {
+                ("tenant_id", "tenant_id"),
+                ("job_id", "job_id"),
+                ("generation", "generation"),
+            },
+            on_delete="CASCADE",
+        )
+        and "job_id" in _table_columns(
+            conn,
+            "job_material_layout_boxes",
+        )
+        and "job_url" not in _table_columns(
+            conn,
+            "job_material_layout_boxes",
+        )
+        and _primary_key_columns(conn, "job_material_layout_boxes")
+        == (
+            "tenant_id",
+            "job_id",
+            "generation",
+            "artifact_id",
+            "box_index",
+        )
+        and _has_composite_foreign_key(
+            conn,
+            "job_material_layout_boxes",
+            "job_materials",
+            {
+                ("tenant_id", "tenant_id"),
+                ("job_id", "job_id"),
+                ("generation", "generation"),
+            },
+            on_delete="CASCADE",
+        )
+        and "job_id" in _table_columns(
+            conn,
+            "job_bullet_provenance",
+        )
+        and "job_url" not in _table_columns(
+            conn,
+            "job_bullet_provenance",
+        )
+        and _primary_key_columns(conn, "job_bullet_provenance")
+        == ("tenant_id", "job_id", "generation", "bullet_id")
+        and _has_composite_foreign_key(
+            conn,
+            "job_bullet_provenance",
+            "job_materials",
+            {
+                ("tenant_id", "tenant_id"),
+                ("job_id", "job_id"),
+                ("generation", "generation"),
+            },
+            on_delete="CASCADE",
+        )
+        and _has_index(
+            conn,
+            "job_materials",
+            "idx_job_materials_tenant_job_gen",
+            ("tenant_id", "job_id", "generation"),
+            unique=False,
+        )
+        and _has_index(
+            conn,
+            "job_materials_artifacts",
+            "idx_job_materials_artifacts_status",
+            ("artifact_type", "status", "created_at"),
+            unique=False,
+        )
+        and _has_index(
+            conn,
+            "job_material_layout_boxes",
+            "idx_job_material_layout_boxes_artifact",
+            ("tenant_id", "artifact_id", "page_number", "box_index"),
+            unique=False,
+        )
+        and _has_index(
+            conn,
+            "job_bullet_provenance",
+            "idx_job_bullet_provenance_tenant_job_gen",
+            ("tenant_id", "job_id", "generation"),
+            unique=False,
+        )
+        and _has_index(
+            conn,
+            "job_bullet_provenance",
+            "idx_job_bullet_provenance_artifact",
+            ("tenant_id", "artifact_id"),
+            unique=False,
+        )
+    )
+
+
+def _merge_material_histories_preserving_generation_order_v15(
+    history: list[tuple[str, int, tuple[Any, ...]]],
+) -> list[tuple[str, int, tuple[Any, ...]]]:
+    """Interleave URL-alias histories without reversing either history."""
+    by_reference: dict[str, list[tuple[str, int, tuple[Any, ...]]]] = {}
+    for entry in history:
+        by_reference.setdefault(entry[0], []).append(entry)
+    for entries in by_reference.values():
+        entries.sort(key=lambda entry: entry[1])
+
+    offsets = {reference: 0 for reference in by_reference}
+    merged: list[tuple[str, int, tuple[Any, ...]]] = []
+    while len(merged) < len(history):
+        eligible = [
+            entries[offsets[reference]]
+            for reference, entries in by_reference.items()
+            if offsets[reference] < len(entries)
+        ]
+        selected = min(
+            eligible,
+            key=lambda entry: (
+                str(entry[2][1]),
+                entry[0],
+                entry[1],
+            ),
+        )
+        merged.append(selected)
+        offsets[selected[0]] += 1
+    return merged
+
+
+def _canonical_material_rows_v15(
+    conn: sqlite3.Connection,
+) -> tuple[
+    list[tuple[Any, ...]],
+    dict[tuple[str, str, int], int],
+]:
+    rows = conn.execute(
+        """
+        SELECT tenant_id, job_url, generation, status, created_at, updated_at,
+               last_validation_json, last_verdict_json, metadata_json
+        FROM job_materials
+        ORDER BY tenant_id, job_url, generation
+        """
+    ).fetchall()
+    grouped: dict[
+        tuple[str, str],
+        list[tuple[str, int, tuple[Any, ...]]],
+    ] = {}
+    for row in rows:
+        tenant_id = str(row[0])
+        raw_reference = str(row[1])
+        old_generation = int(row[2])
+        if old_generation <= 0:
+            raise RuntimeError(
+                "materials reference migration found a non-positive "
+                "generation"
+            )
+        stable_job_id = _resolve_job_reference_value(
+            conn,
+            tenant_id=tenant_id,
+            reference=raw_reference,
+            legacy_url=True,
+        )
+        if stable_job_id is None:
+            raise RuntimeError(
+                "materials reference migration could not resolve "
+                f"job_materials.job_url={raw_reference!r}"
+            )
+        _validate_job_uuid(stable_job_id)
+        grouped.setdefault((tenant_id, stable_job_id), []).append(
+            (
+                raw_reference,
+                old_generation,
+                tuple(row[3:]),
+            )
+        )
+
+    canonical: list[tuple[Any, ...]] = []
+    generation_map: dict[tuple[str, str, int], int] = {}
+    for (tenant_id, stable_job_id), history in sorted(grouped.items()):
+        ordered = _merge_material_histories_preserving_generation_order_v15(
+            history
+        )
+        for new_generation, (
+            raw_reference,
+            old_generation,
+            values,
+        ) in enumerate(ordered, start=1):
+            generation_map[
+                (tenant_id, raw_reference, old_generation)
+            ] = new_generation
+            canonical.append(
+                (
+                    tenant_id,
+                    stable_job_id,
+                    new_generation,
+                    *values,
+                )
+            )
+    return canonical, generation_map
+
+
+def _canonical_material_artifact_rows_v15(
+    conn: sqlite3.Connection,
+    *,
+    generation_map: dict[tuple[str, str, int], int],
+) -> list[tuple[Any, ...]]:
+    rows = conn.execute(
+        """
+        SELECT m.tenant_id, artifact.job_url, artifact.generation,
+               artifact.artifact_type, artifact.artifact_id,
+               artifact.status, artifact.path, artifact.render_format,
+               artifact.size_bytes, artifact.metadata_json,
+               artifact.created_at, artifact.superseded_at
+        FROM job_materials_artifacts AS artifact
+        JOIN job_materials AS m
+          ON m.job_url = artifact.job_url
+         AND m.generation = artifact.generation
+        ORDER BY m.tenant_id, artifact.job_url, artifact.generation,
+                 artifact.artifact_type
+        """
+    ).fetchall()
+    canonical: list[tuple[Any, ...]] = []
+    for row in rows:
+        tenant_id = str(row[0])
+        raw_reference = str(row[1])
+        old_generation = int(row[2])
+        new_generation = generation_map.get(
+            (tenant_id, raw_reference, old_generation)
+        )
+        stable_job_id = _resolve_job_reference_value(
+            conn,
+            tenant_id=tenant_id,
+            reference=raw_reference,
+            legacy_url=True,
+        )
+        if new_generation is None or stable_job_id is None:
+            raise RuntimeError(
+                "materials reference migration found an artifact without "
+                "its material generation"
+            )
+        canonical.append(
+            (
+                tenant_id,
+                stable_job_id,
+                new_generation,
+                *tuple(row[3:]),
+            )
+        )
+    return canonical
+
+
+def _canonical_material_layout_rows_v15(
+    conn: sqlite3.Connection,
+    *,
+    generation_map: dict[tuple[str, str, int], int],
+) -> list[tuple[Any, ...]]:
+    rows = conn.execute(
+        """
+        SELECT tenant_id, job_url, generation, artifact_id, box_index,
+               semantic_id, page_number, line_number, text_excerpt,
+               left_pct, top_pct, width_pct, height_pct,
+               audit_target_json, created_at
+        FROM job_material_layout_boxes
+        ORDER BY tenant_id, job_url, generation, artifact_id, box_index
+        """
+    ).fetchall()
+    canonical: list[tuple[Any, ...]] = []
+    for row in rows:
+        tenant_id = str(row[0])
+        raw_reference = str(row[1])
+        old_generation = int(row[2])
+        new_generation = generation_map.get(
+            (tenant_id, raw_reference, old_generation)
+        )
+        stable_job_id = _resolve_job_reference_value(
+            conn,
+            tenant_id=tenant_id,
+            reference=raw_reference,
+            legacy_url=True,
+        )
+        if new_generation is None or stable_job_id is None:
+            raise RuntimeError(
+                "materials reference migration found a layout box without "
+                "its material generation"
+            )
+        canonical.append(
+            (
+                tenant_id,
+                stable_job_id,
+                new_generation,
+                *tuple(row[3:]),
+            )
+        )
+    return canonical
+
+
+def _canonical_bullet_provenance_rows_v15(
+    conn: sqlite3.Connection,
+    *,
+    generation_map: dict[tuple[str, str, int], int],
+) -> list[tuple[Any, ...]]:
+    rows = conn.execute(
+        """
+        SELECT tenant_id, job_url, generation, bullet_id, artifact_id,
+               section, source_id, evidence_ids_json,
+               requirement_ids_json, matched_keywords_json,
+               transform_type, control, rationale, generated_text,
+               position, created_at, coverage_json, voice_json
+        FROM job_bullet_provenance
+        ORDER BY tenant_id, job_url, generation, bullet_id
+        """
+    ).fetchall()
+    canonical: list[tuple[Any, ...]] = []
+    for row in rows:
+        tenant_id = str(row[0])
+        raw_reference = str(row[1])
+        old_generation = int(row[2])
+        new_generation = generation_map.get(
+            (tenant_id, raw_reference, old_generation)
+        )
+        stable_job_id = _resolve_job_reference_value(
+            conn,
+            tenant_id=tenant_id,
+            reference=raw_reference,
+            legacy_url=True,
+        )
+        if new_generation is None or stable_job_id is None:
+            raise RuntimeError(
+                "materials reference migration found bullet provenance "
+                "without its material generation"
+            )
+        canonical.append(
+            (
+                tenant_id,
+                stable_job_id,
+                new_generation,
+                *tuple(row[3:]),
+            )
+        )
+    return canonical
+
+
+def ensure_materials_references_v15(
+    conn: sqlite3.Connection | None = None,
+) -> list[str]:
+    """Move generated-material authorities to stable JobId references."""
+    if conn is None:
+        conn = get_connection()
+
+    current = _assert_schema_version_supported(conn)
+    if current >= _MATERIALS_REFERENCE_SCHEMA_VERSION:
+        return []
+    if current != _ARTIFACT_REGISTRY_REFERENCE_SCHEMA_VERSION:
+        raise RuntimeError(
+            "materials reference migration requires artifact-registry "
+            "schema v14"
+        )
+
+    conn.execute("SAVEPOINT materials_references_v15")
+    try:
+        if not _has_artifact_registry_reference_schema_v14(conn):
+            raise RuntimeError(
+                "materials reference migration requires the stable "
+                "artifact-registry reference schema"
+            )
+        _backfill_legacy_materials_if_empty(conn)
+        before_counts = {
+            table: int(
+                conn.execute(f'SELECT COUNT(*) FROM "{table}"').fetchone()[0]
+            )
+            for table in _MATERIALS_REFERENCE_TABLES
+        }
+
+        if not _has_materials_reference_schema_v15(conn):
+            (
+                material_rows,
+                generation_map,
+            ) = _canonical_material_rows_v15(conn)
+            artifact_rows = _canonical_material_artifact_rows_v15(
+                conn,
+                generation_map=generation_map,
+            )
+            layout_rows = _canonical_material_layout_rows_v15(
+                conn,
+                generation_map=generation_map,
+            )
+            provenance_rows = _canonical_bullet_provenance_rows_v15(
+                conn,
+                generation_map=generation_map,
+            )
+
+            for table in (
+                "job_bullet_provenance_v15",
+                "job_material_layout_boxes_v15",
+                "job_materials_artifacts_v15",
+                "job_materials_v15",
+            ):
+                conn.execute(f'DROP TABLE IF EXISTS "{table}"')
+            _create_materials_tables_v15(
+                conn,
+                materials_table="job_materials_v15",
+                artifacts_table="job_materials_artifacts_v15",
+                layout_table="job_material_layout_boxes_v15",
+            )
+            _create_bullet_provenance_v15(
+                conn,
+                table_name="job_bullet_provenance_v15",
+                materials_table="job_materials_v15",
+            )
+            conn.executemany(
+                """
+                INSERT INTO job_materials_v15 (
+                    tenant_id, job_id, generation, status,
+                    created_at, updated_at, last_validation_json,
+                    last_verdict_json, metadata_json
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                material_rows,
+            )
+            conn.executemany(
+                """
+                INSERT INTO job_materials_artifacts_v15 (
+                    tenant_id, job_id, generation, artifact_type,
+                    artifact_id, status, path, render_format, size_bytes,
+                    metadata_json, created_at, superseded_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                artifact_rows,
+            )
+            conn.executemany(
+                """
+                INSERT INTO job_material_layout_boxes_v15 (
+                    tenant_id, job_id, generation, artifact_id, box_index,
+                    semantic_id, page_number, line_number, text_excerpt,
+                    left_pct, top_pct, width_pct, height_pct,
+                    audit_target_json, created_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                layout_rows,
+            )
+            conn.executemany(
+                """
+                INSERT INTO job_bullet_provenance_v15 (
+                    tenant_id, job_id, generation, bullet_id, artifact_id,
+                    section, source_id, evidence_ids_json,
+                    requirement_ids_json, matched_keywords_json,
+                    transform_type, control, rationale, generated_text,
+                    position, created_at, coverage_json, voice_json
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                provenance_rows,
+            )
+
+            for table in (
+                "job_bullet_provenance",
+                "job_material_layout_boxes",
+                "job_materials_artifacts",
+                "job_materials",
+            ):
+                conn.execute(f'DROP TABLE "{table}"')
+            for table in (
+                "job_materials",
+                "job_materials_artifacts",
+                "job_material_layout_boxes",
+                "job_bullet_provenance",
+            ):
+                conn.execute(
+                    f'ALTER TABLE "{table}_v15" RENAME TO "{table}"'
+                )
+            _create_materials_indexes_v15(conn)
+
+        _verify_materials_references_v15(
+            conn,
+            expected_counts=before_counts,
+        )
+        conn.execute(
+            f"PRAGMA user_version = "
+            f"{_MATERIALS_REFERENCE_SCHEMA_VERSION}"
+        )
+        conn.execute("RELEASE SAVEPOINT materials_references_v15")
+        conn.commit()
+    except BaseException:
+        conn.execute("ROLLBACK TO SAVEPOINT materials_references_v15")
+        conn.execute("RELEASE SAVEPOINT materials_references_v15")
+        raise
+
+    return list(_MATERIALS_REFERENCE_TABLES)
+
+
+def _verify_materials_references_v15(
+    conn: sqlite3.Connection,
+    *,
+    expected_counts: dict[str, int],
+) -> None:
+    if not _has_materials_reference_schema_v15(conn):
+        raise RuntimeError(
+            "materials reference migration did not install the canonical "
+            "schema"
+        )
+    for table, expected_count in expected_counts.items():
+        observed_count = int(
+            conn.execute(f'SELECT COUNT(*) FROM "{table}"').fetchone()[0]
+        )
+        if observed_count != expected_count:
+            raise RuntimeError(
+                "materials reference migration changed the canonical "
+                f"{table} row count: expected {expected_count}, "
+                f"found {observed_count}"
+            )
+    orphan = conn.execute(
+        """
+        SELECT materials.job_id
+        FROM job_materials AS materials
+        LEFT JOIN jobs j
+          ON j.tenant_id = materials.tenant_id
+         AND j.job_id = materials.job_id
+        WHERE j.job_id IS NULL
+        LIMIT 1
+        """
+    ).fetchone()
+    if orphan is not None:
+        raise RuntimeError(
+            "materials reference migration left an unresolved JobId"
+        )
+    for table in _MATERIALS_REFERENCE_TABLES:
+        for row in conn.execute(
+            f'SELECT DISTINCT job_id FROM "{table}"'
+        ).fetchall():
+            _validate_job_uuid(str(row[0]))
+    foreign_key_error = conn.execute("PRAGMA foreign_key_check").fetchone()
+    if foreign_key_error is not None:
+        raise RuntimeError(
+            "materials reference migration found a foreign-key violation"
+        )
+
+
+def _reassign_materials_references_v15(
+    conn: sqlite3.Connection,
+    *,
+    tenant_id: str,
+    losing_job_id: str,
+    surviving_job_id: str,
+) -> None:
+    """Merge complete material histories during stable Job identity collapse."""
+    if losing_job_id == surviving_job_id:
+        return
+    before_counts = {
+        table: int(
+            conn.execute(f'SELECT COUNT(*) FROM "{table}"').fetchone()[0]
+        )
+        for table in _MATERIALS_REFERENCE_TABLES
+    }
+    parent_rows = conn.execute(
+        """
+        SELECT job_id, generation, status, created_at, updated_at,
+               last_validation_json, last_verdict_json, metadata_json
+        FROM job_materials
+        WHERE tenant_id = ? AND job_id IN (?, ?)
+        ORDER BY job_id, generation
+        """,
+        (tenant_id, losing_job_id, surviving_job_id),
+    ).fetchall()
+    if not parent_rows:
+        return
+
+    history = [
+        (
+            str(row[0]),
+            int(row[1]),
+            tuple(row[2:]),
+        )
+        for row in parent_rows
+    ]
+    ordered = _merge_material_histories_preserving_generation_order_v15(
+        history
+    )
+    generation_map: dict[tuple[str, int], int] = {}
+    material_rows: list[tuple[Any, ...]] = []
+    for new_generation, (
+        old_job_id,
+        old_generation,
+        values,
+    ) in enumerate(ordered, start=1):
+        generation_map[(old_job_id, old_generation)] = new_generation
+        material_rows.append(
+            (
+                tenant_id,
+                surviving_job_id,
+                new_generation,
+                *values,
+            )
+        )
+
+    artifact_source = conn.execute(
+        """
+        SELECT job_id, generation, artifact_type, artifact_id, status, path,
+               render_format, size_bytes, metadata_json, created_at,
+               superseded_at
+        FROM job_materials_artifacts
+        WHERE tenant_id = ? AND job_id IN (?, ?)
+        ORDER BY job_id, generation, artifact_type
+        """,
+        (tenant_id, losing_job_id, surviving_job_id),
+    ).fetchall()
+    layout_source = conn.execute(
+        """
+        SELECT job_id, generation, artifact_id, box_index, semantic_id,
+               page_number, line_number, text_excerpt, left_pct, top_pct,
+               width_pct, height_pct, audit_target_json, created_at
+        FROM job_material_layout_boxes
+        WHERE tenant_id = ? AND job_id IN (?, ?)
+        ORDER BY job_id, generation, artifact_id, box_index
+        """,
+        (tenant_id, losing_job_id, surviving_job_id),
+    ).fetchall()
+    provenance_source = conn.execute(
+        """
+        SELECT job_id, generation, bullet_id, artifact_id, section, source_id,
+               evidence_ids_json, requirement_ids_json,
+               matched_keywords_json, transform_type, control, rationale,
+               generated_text, position, created_at, coverage_json, voice_json
+        FROM job_bullet_provenance
+        WHERE tenant_id = ? AND job_id IN (?, ?)
+        ORDER BY job_id, generation, bullet_id
+        """,
+        (tenant_id, losing_job_id, surviving_job_id),
+    ).fetchall()
+
+    def _new_generation(row: sqlite3.Row) -> int:
+        mapped = generation_map.get((str(row[0]), int(row[1])))
+        if mapped is None:
+            raise RuntimeError(
+                "materials identity collapse found a dependent row without "
+                "its material generation"
+            )
+        return mapped
+
+    artifact_rows = [
+        (
+            tenant_id,
+            surviving_job_id,
+            _new_generation(row),
+            *tuple(row[2:]),
+        )
+        for row in artifact_source
+    ]
+    layout_rows = [
+        (
+            tenant_id,
+            surviving_job_id,
+            _new_generation(row),
+            *tuple(row[2:]),
+        )
+        for row in layout_source
+    ]
+    provenance_rows = [
+        (
+            tenant_id,
+            surviving_job_id,
+            _new_generation(row),
+            *tuple(row[2:]),
+        )
+        for row in provenance_source
+    ]
+
+    for table in (
+        "job_bullet_provenance",
+        "job_material_layout_boxes",
+        "job_materials_artifacts",
+        "job_materials",
+    ):
+        conn.execute(
+            f"""
+            DELETE FROM {table}
+            WHERE tenant_id = ? AND job_id IN (?, ?)
+            """,
+            (tenant_id, losing_job_id, surviving_job_id),
+        )
+    conn.executemany(
+        """
+        INSERT INTO job_materials (
+            tenant_id, job_id, generation, status, created_at, updated_at,
+            last_validation_json, last_verdict_json, metadata_json
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        material_rows,
+    )
+    conn.executemany(
+        """
+        INSERT INTO job_materials_artifacts (
+            tenant_id, job_id, generation, artifact_type, artifact_id,
+            status, path, render_format, size_bytes, metadata_json,
+            created_at, superseded_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        artifact_rows,
+    )
+    conn.executemany(
+        """
+        INSERT INTO job_material_layout_boxes (
+            tenant_id, job_id, generation, artifact_id, box_index,
+            semantic_id, page_number, line_number, text_excerpt,
+            left_pct, top_pct, width_pct, height_pct, audit_target_json,
+            created_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        layout_rows,
+    )
+    conn.executemany(
+        """
+        INSERT INTO job_bullet_provenance (
+            tenant_id, job_id, generation, bullet_id, artifact_id,
+            section, source_id, evidence_ids_json, requirement_ids_json,
+            matched_keywords_json, transform_type, control, rationale,
+            generated_text, position, created_at, coverage_json, voice_json
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        provenance_rows,
+    )
+    _verify_materials_references_v15(
+        conn,
+        expected_counts=before_counts,
+    )
+
+
 # ---------------------------------------------------------------------------
 # job_enrichments read fragments — used by every selector / stat that
 # previously read bare ``jobs.full_description`` / ``jobs.application_url``
@@ -8798,7 +9825,7 @@ _ENRICHMENT_NOT_QUARANTINED: str = (
 # job_materials read fragments — used by the queue selectors that
 # previously read bare ``jobs.tailored_resume_path`` / ``cover_letter_path``.
 # After Phase 6 the canonical artifact paths live in ``job_materials_artifacts``
-# (latest generation per ``job_url``); the legacy ``jobs.*_path`` columns
+# (latest generation per stable JobId); the legacy ``jobs.*_path`` columns
 # stay as read-only fallback for historical rows that have no canonical
 # materials row. Once ``job_materials`` exists, approved artifacts are the
 # only active paths; suppressed artifacts must not fall through to legacy
@@ -8809,50 +9836,58 @@ _ENRICHMENT_NOT_QUARANTINED: str = (
 # cover-letter artifact paths under fixed aliases.
 _LATEST_MATERIALS_JOIN: str = (
     "LEFT JOIN ("
-    "SELECT history.job_url AS jm_job_url, latest.max_generation AS jm_generation, "
+    "SELECT history.tenant_id AS jm_tenant_id, "
+    "history.job_id AS jm_job_id, latest.max_generation AS jm_generation, "
     "m.status AS jm_status, "
     "tr.path AS jm_tailored_path, tr.created_at AS jm_tailored_at, "
     "cl.path AS jm_cover_path, cl.created_at AS jm_cover_at, "
     "rpdf.path AS jm_resume_pdf_path, rpdf.artifact_id AS jm_resume_pdf_artifact_id, "
     "cpdf.path AS jm_cover_pdf_path "
-    "FROM (SELECT DISTINCT job_url FROM job_materials) history "
+    "FROM (SELECT DISTINCT tenant_id, job_id FROM job_materials) history "
     "LEFT JOIN ("
-    "SELECT job_url, MAX(generation) AS max_generation "
+    "SELECT tenant_id, job_id, MAX(generation) AS max_generation "
     "FROM job_materials_artifacts "
     "WHERE status = 'approved' "
     "AND artifact_type IN ('tailored_resume', 'cover_letter', 'resume_pdf', 'cover_letter_pdf') "
-    "GROUP BY job_url"
-    ") latest ON latest.job_url = history.job_url "
+    "GROUP BY tenant_id, job_id"
+    ") latest ON latest.tenant_id = history.tenant_id "
+    "AND latest.job_id = history.job_id "
     "LEFT JOIN job_materials m "
-    "ON m.job_url = history.job_url AND m.generation = latest.max_generation "
+    "ON m.tenant_id = history.tenant_id AND m.job_id = history.job_id "
+    "AND m.generation = latest.max_generation "
     "LEFT JOIN job_materials_artifacts tr "
-    "ON tr.job_url = history.job_url AND tr.generation = latest.max_generation "
+    "ON tr.tenant_id = history.tenant_id AND tr.job_id = history.job_id "
+    "AND tr.generation = latest.max_generation "
     "AND tr.artifact_type = 'tailored_resume' AND tr.status = 'approved' "
     "LEFT JOIN job_materials_artifacts cl "
-    "ON cl.job_url = history.job_url AND cl.generation = latest.max_generation "
+    "ON cl.tenant_id = history.tenant_id AND cl.job_id = history.job_id "
+    "AND cl.generation = latest.max_generation "
     "AND cl.artifact_type = 'cover_letter' AND cl.status = 'approved' "
     "LEFT JOIN job_materials_artifacts rpdf "
-    "ON rpdf.job_url = history.job_url AND rpdf.generation = latest.max_generation "
+    "ON rpdf.tenant_id = history.tenant_id AND rpdf.job_id = history.job_id "
+    "AND rpdf.generation = latest.max_generation "
     "AND rpdf.artifact_type = 'resume_pdf' AND rpdf.status = 'approved' "
     "LEFT JOIN job_materials_artifacts cpdf "
-    "ON cpdf.job_url = history.job_url AND cpdf.generation = latest.max_generation "
+    "ON cpdf.tenant_id = history.tenant_id AND cpdf.job_id = history.job_id "
+    "AND cpdf.generation = latest.max_generation "
     "AND cpdf.artifact_type = 'cover_letter_pdf' AND cpdf.status = 'approved'"
-    ") jm ON jm.jm_job_url = jobs.url"
+    ") jm ON jm.jm_tenant_id = jobs.tenant_id "
+    "AND jm.jm_job_id = jobs.job_id"
 )
 
 _EFFECTIVE_TAILOR_PATH: str = (
-    "CASE WHEN jm.jm_job_url IS NOT NULL THEN jm.jm_tailored_path "
+    "CASE WHEN jm.jm_job_id IS NOT NULL THEN jm.jm_tailored_path "
     "ELSE jobs.tailored_resume_path END"
 )
 _EFFECTIVE_COVER_PATH: str = (
-    "CASE WHEN jm.jm_job_url IS NOT NULL THEN jm.jm_cover_path "
+    "CASE WHEN jm.jm_job_id IS NOT NULL THEN jm.jm_cover_path "
     "ELSE jobs.cover_letter_path END"
 )
 _READY_TAILORED_RESUME_WITH_PDF: str = (
-    "((jm.jm_job_url IS NOT NULL "
+    "((jm.jm_job_id IS NOT NULL "
     "AND jm.jm_tailored_path IS NOT NULL AND jm.jm_tailored_path != '' "
     "AND jm.jm_resume_pdf_path IS NOT NULL AND jm.jm_resume_pdf_path != '') "
-    "OR (jm.jm_job_url IS NULL "
+    "OR (jm.jm_job_id IS NULL "
     "AND jobs.tailored_resume_path IS NOT NULL AND jobs.tailored_resume_path != ''))"
 )
 
@@ -9613,7 +10648,7 @@ def get_jobs_by_stage(
     # round-trip through the repository.
     query = (
         f"SELECT jobs.*, js.js_fit_score AS js_fit_score, "
-        f"jm.jm_job_url AS jm_job_url, "
+        f"jm.jm_job_id AS jm_job_id, "
         f"jm.jm_tailored_path AS jm_tailored_path, "
         f"jm.jm_tailored_at AS jm_tailored_at, "
         f"jm.jm_cover_path AS jm_cover_path, "
@@ -9665,12 +10700,12 @@ def get_jobs_by_stage(
         js_value = record.pop("js_fit_score", None)
         if js_value is not None:
             record["fit_score"] = js_value
-        jm_job_url = record.pop("jm_job_url", None)
+        jm_job_id = record.pop("jm_job_id", None)
         jm_tailored = record.pop("jm_tailored_path", None)
         jm_tailored_at = record.pop("jm_tailored_at", None)
         jm_cover = record.pop("jm_cover_path", None)
         jm_cover_at = record.pop("jm_cover_at", None)
-        if jm_job_url is not None:
+        if jm_job_id is not None:
             record["tailored_resume_path"] = jm_tailored
             record["tailored_at"] = jm_tailored_at
             record["cover_letter_path"] = jm_cover

--- a/workers/automation/src/jobctrl/domain/materials/use_cases.py
+++ b/workers/automation/src/jobctrl/domain/materials/use_cases.py
@@ -1573,10 +1573,8 @@ class TailorResumeUseCase:
         employer_analysis: EmployerAnalysis | None = None,
         requirement_fit_report: "RequirementFitReport | None" = None,
     ) -> TailorOutcome:
-        job_id = JobId(str(job["url"]))
-        scoring_job_id = JobId(
-            str(job.get("job_id") or job["url"])
-        )
+        job_id = JobId(str(job.get("job_id") or job["url"]))
+        scoring_job_id = job_id
         # D-20: run/reuse the canonical employer analysis as the front-half
         # sub-step of tailor (cache-backed, so a re-tailor reuses it). The
         # analysis drives keyword selection in ``build_tailoring_plan``.
@@ -3438,7 +3436,8 @@ class GenerateCoverLetterUseCase:
         validation_mode: str = "normal",
         tenant_id: TenantId = LOCAL_TENANT,
     ) -> CoverLetterOutcome:
-        job_id = JobId(str(job["url"]))
+        job_id = JobId(str(job.get("job_id") or job["url"]))
+        analysis_job_id = JobId(str(job["url"]))
         materials = _load_current_approved_materials(self._repository, tenant_id, job_id)
         if materials is None:
             return CoverLetterOutcome(
@@ -3479,7 +3478,10 @@ class GenerateCoverLetterUseCase:
                 error=f"Could not read tailored resume {resume_path}: {exc}",
             )
 
-        target_skill_terms = self._load_target_skill_terms(tenant_id, job_id)
+        target_skill_terms = self._load_target_skill_terms(
+            tenant_id,
+            analysis_job_id,
+        )
         letter, validation, findings = self._run_attempts(
             job=job,
             resume_text=resume_text,

--- a/workers/automation/src/jobctrl/infrastructure/materials/bullet_provenance_repository.py
+++ b/workers/automation/src/jobctrl/infrastructure/materials/bullet_provenance_repository.py
@@ -18,11 +18,15 @@ import json
 import sqlite3
 
 from jobctrl.database import ensure_bullet_provenance_tables
-from jobctrl.domain.identifiers import JobId
+from jobctrl.domain.discovery.value_objects import PostingUrl
+from jobctrl.domain.identifiers import JobId, canonical_job_id
 from jobctrl.domain.materials.coverage_audit import KeywordCoverage
 from jobctrl.domain.materials.provenance import BulletProvenance, BulletProvenanceSet
 from jobctrl.domain.materials.voice import VoicePassRecord
 from jobctrl.domain.tenant import TenantId
+from jobctrl.infrastructure.discovery.sqlite_identity_resolver import (
+    SqliteJobIdentityResolver,
+)
 from jobctrl.infrastructure.materials.unit_of_work import SqliteUnitOfWork
 
 
@@ -42,8 +46,36 @@ class SqliteBulletProvenanceRepository:
     ) -> None:
         self._conn = conn
         self._unit_of_work = unit_of_work
+        self._identity_resolver = SqliteJobIdentityResolver(conn)
         # Idempotent — safe if init_db already ran; keeps test setup minimal.
         ensure_bullet_provenance_tables(conn)
+
+    def _resolve_job_id(
+        self,
+        tenant_id: TenantId,
+        reference: JobId,
+    ) -> JobId | None:
+        raw_reference = str(reference or "").strip()
+        if not raw_reference:
+            raise ValueError("job_id must be non-empty")
+        try:
+            stable_candidate = canonical_job_id(raw_reference)
+        except ValueError:
+            stable_candidate = None
+        identity = (
+            self._identity_resolver.resolve_by_job_id(
+                tenant_id,
+                stable_candidate,
+            )
+            if stable_candidate is not None
+            else None
+        )
+        if identity is None:
+            identity = self._identity_resolver.resolve_by_posting_url(
+                tenant_id,
+                PostingUrl(raw_reference),
+            )
+        return identity.job_id if identity is not None else None
 
     # ------------------------------------------------------------------ read
 
@@ -54,13 +86,16 @@ class SqliteBulletProvenanceRepository:
         *,
         generation: int | None = None,
     ) -> BulletProvenanceSet | None:
+        stable_job_id = self._resolve_job_id(tenant_id, job_id)
+        if stable_job_id is None:
+            return None
         if generation is None:
             gen_row = self._conn.execute(
                 """
                 SELECT MAX(generation) FROM job_bullet_provenance
-                WHERE job_url = ? AND tenant_id = ?
+                WHERE tenant_id = ? AND job_id = ?
                 """,
-                (str(job_id), str(tenant_id)),
+                (str(tenant_id), str(stable_job_id)),
             ).fetchone()
             current = gen_row[0] if gen_row is not None else None
             if current is None:
@@ -70,10 +105,10 @@ class SqliteBulletProvenanceRepository:
         rows = self._conn.execute(
             """
             SELECT * FROM job_bullet_provenance
-            WHERE job_url = ? AND tenant_id = ? AND generation = ?
+            WHERE tenant_id = ? AND job_id = ? AND generation = ?
             ORDER BY position, bullet_id
             """,
-            (str(job_id), str(tenant_id), int(generation)),
+            (str(tenant_id), str(stable_job_id), int(generation)),
         ).fetchall()
         if not rows:
             return None
@@ -90,7 +125,7 @@ class SqliteBulletProvenanceRepository:
         voice = VoicePassRecord.from_dict(_load_json(_row_value(first, "voice_json")))
         return BulletProvenanceSet(
             tenant_id=tenant_id,
-            job_id=job_id,
+            job_id=stable_job_id,
             generation=int(generation),
             artifact_id=str(first["artifact_id"]),
             bullets=bullets,
@@ -112,7 +147,15 @@ class SqliteBulletProvenanceRepository:
         if provenance.is_empty:
             return
 
-        job_url = str(provenance.job_id)
+        stable_job_id = self._resolve_job_id(
+            provenance.tenant_id,
+            provenance.job_id,
+        )
+        if stable_job_id is None:
+            raise ValueError(
+                "no stable Job identity for bullet provenance "
+                f"reference: {provenance.job_id}"
+            )
         tenant = str(provenance.tenant_id)
         generation = provenance.generation
 
@@ -122,24 +165,25 @@ class SqliteBulletProvenanceRepository:
         voice_json = _dump_json(provenance.voice_to_read_model())
 
         self._conn.execute(
-            "DELETE FROM job_bullet_provenance WHERE job_url = ? AND tenant_id = ? AND generation = ?",
-            (job_url, tenant, generation),
+            "DELETE FROM job_bullet_provenance "
+            "WHERE tenant_id = ? AND job_id = ? AND generation = ?",
+            (tenant, str(stable_job_id), generation),
         )
         for position, bullet in enumerate(provenance.bullets):
             self._conn.execute(
                 """
                 INSERT INTO job_bullet_provenance (
-                    job_url, generation, bullet_id, tenant_id, artifact_id,
+                    tenant_id, job_id, generation, bullet_id, artifact_id,
                     section, source_id, evidence_ids_json, requirement_ids_json,
                     matched_keywords_json, transform_type, control, rationale,
                     generated_text, position, created_at, coverage_json, voice_json
                 ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
-                    job_url,
+                    tenant,
+                    str(stable_job_id),
                     generation,
                     bullet.bullet_id,
-                    tenant,
                     provenance.artifact_id,
                     bullet.section,
                     bullet.source_id,

--- a/workers/automation/src/jobctrl/infrastructure/materials/resume_html_migration.py
+++ b/workers/automation/src/jobctrl/infrastructure/materials/resume_html_migration.py
@@ -294,20 +294,71 @@ def migrate_legacy_resume_pdfs(
     conn.row_factory = sqlite3.Row
     params: list[object] = []
     where = [
-        "artifact_type = 'resume_pdf'",
-        "status = 'approved'",
+        "artifact.artifact_type = 'resume_pdf'",
+        "artifact.status = 'approved'",
     ]
+    artifact_columns = {
+        str(row[1])
+        for row in conn.execute(
+            "PRAGMA table_info(job_materials_artifacts)"
+        ).fetchall()
+    }
+    stable_references = "job_id" in artifact_columns
     if not force:
-        where.append("COALESCE(render_format, '') != 'html_pdf'")
+        where.append("COALESCE(artifact.render_format, '') != 'html_pdf'")
     if job_url:
-        where.append("job_url = ?")
-        params.append(job_url)
-    sql = f"""
-        SELECT job_url, generation, artifact_id, path, render_format, metadata_json
-        FROM job_materials_artifacts
-        WHERE {' AND '.join(where)}
-        ORDER BY created_at DESC
-    """
+        if stable_references:
+            where.append(
+                """
+                EXISTS (
+                    SELECT 1
+                    FROM (
+                        SELECT tenant_id, job_id
+                        FROM jobs
+                        WHERE url = ?
+                        UNION
+                        SELECT tenant_id, job_id
+                        FROM job_identity_aliases
+                        WHERE alias_kind = 'posting_url'
+                          AND alias_value = ?
+                    ) AS selected_job
+                    WHERE selected_job.tenant_id = artifact.tenant_id
+                      AND selected_job.job_id = artifact.job_id
+                )
+                """
+            )
+            params.extend((job_url, job_url))
+        else:
+            where.append("artifact.job_url = ?")
+            params.append(job_url)
+    if stable_references:
+        sql = f"""
+            SELECT artifact.tenant_id, artifact.job_id AS job_reference,
+                   'job_id' AS reference_column, jobs.url AS job_url,
+                   artifact.generation, artifact.artifact_id, artifact.path,
+                   artifact.render_format, artifact.metadata_json
+            FROM job_materials_artifacts AS artifact
+            JOIN jobs
+              ON jobs.tenant_id = artifact.tenant_id
+             AND jobs.job_id = artifact.job_id
+            WHERE {' AND '.join(where)}
+            ORDER BY artifact.created_at DESC
+        """
+    else:
+        sql = f"""
+            SELECT material.tenant_id,
+                   artifact.job_url AS job_reference,
+                   'job_url' AS reference_column,
+                   artifact.job_url AS job_url,
+                   artifact.generation, artifact.artifact_id, artifact.path,
+                   artifact.render_format, artifact.metadata_json
+            FROM job_materials_artifacts AS artifact
+            JOIN job_materials AS material
+              ON material.job_url = artifact.job_url
+             AND material.generation = artifact.generation
+            WHERE {' AND '.join(where)}
+            ORDER BY artifact.created_at DESC
+        """
     if limit is not None:
         sql += " LIMIT ?"
         params.append(limit)
@@ -394,33 +445,56 @@ def _migrate_one(
             if backup_path.exists():
                 metadata["legacy_pdf_backup_path"] = str(backup_path)
         size_bytes = os.path.getsize(pdf_path)
+        reference_column = str(row["reference_column"])
+        if reference_column not in {"job_id", "job_url"}:
+            raise RuntimeError(
+                f"unsupported material Job reference: {reference_column}"
+            )
+        job_reference = str(row["job_reference"])
+        artifact_predicate = (
+            "tenant_id = ? AND job_id = ?"
+            if reference_column == "job_id"
+            else "job_url = ?"
+        )
+        artifact_params = (
+            (row["tenant_id"], job_reference)
+            if reference_column == "job_id"
+            else (job_reference,)
+        )
         conn.execute(
-            """
+            f"""
             UPDATE job_materials_artifacts
             SET render_format = 'html_pdf',
                 size_bytes = ?,
                 metadata_json = ?
-            WHERE job_url = ?
-              AND generation = ?
+            WHERE {artifact_predicate} AND generation = ?
               AND artifact_type = 'resume_pdf'
             """,
             (
                 size_bytes,
                 json.dumps(metadata, sort_keys=True),
-                row["job_url"],
+                *artifact_params,
                 row["generation"],
             ),
         )
         conn.execute(
-            """
+            f"""
             DELETE FROM job_material_layout_boxes
-            WHERE job_url = ? AND generation = ? AND artifact_id = ?
+            WHERE tenant_id = ? AND {reference_column} = ?
+              AND generation = ? AND artifact_id = ?
             """,
-            (row["job_url"], row["generation"], artifact_id),
+            (
+                row["tenant_id"],
+                job_reference,
+                row["generation"],
+                artifact_id,
+            ),
         )
         _insert_layout_boxes(
             conn,
-            job_url=str(row["job_url"]),
+            tenant_id=str(row["tenant_id"]),
+            reference_column=reference_column,
+            job_reference=job_reference,
             generation=int(row["generation"]),
             artifact_id=artifact_id,
             layout_boxes=layout_boxes,
@@ -470,24 +544,31 @@ def _validate_pdf_output(path: Path) -> None:
 def _insert_layout_boxes(
     conn: sqlite3.Connection,
     *,
-    job_url: str,
+    tenant_id: str,
+    reference_column: str,
+    job_reference: str,
     generation: int,
     artifact_id: str,
     layout_boxes: Iterable[LayoutBox],
     created_at: str,
 ) -> None:
+    if reference_column not in {"job_id", "job_url"}:
+        raise RuntimeError(
+            f"unsupported material Job reference: {reference_column}"
+        )
     for index, box in enumerate(layout_boxes):
         conn.execute(
-            """
+            f"""
             INSERT INTO job_material_layout_boxes (
-                job_url, generation, artifact_id, box_index, tenant_id,
+                tenant_id, {reference_column}, generation, artifact_id, box_index,
                 semantic_id, page_number, line_number, text_excerpt,
                 left_pct, top_pct, width_pct, height_pct,
                 audit_target_json, created_at
-            ) VALUES (?, ?, ?, ?, 'local', ?, ?, ?, ?, ?, ?, ?, ?, '{}', ?)
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, '{{}}', ?)
             """,
             (
-                job_url,
+                tenant_id,
+                job_reference,
                 generation,
                 artifact_id,
                 index,

--- a/workers/automation/src/jobctrl/infrastructure/materials/sqlite_repository.py
+++ b/workers/automation/src/jobctrl/infrastructure/materials/sqlite_repository.py
@@ -8,9 +8,10 @@ enforced at save time: a fresh aggregate must carry
 *same* generation again is allowed and overwrites the row — that's how
 use cases append cover letters / PDFs to an existing generation.
 
-Local-mode treats ``job_id`` as the legacy ``jobs.url`` primary key. When
-the cloud cutover (Phase 9) introduces stable system-generated ``JobId``
-values, the adapter swaps the column without touching the port.
+The adapter persists the stable tenant-scoped ``JobId``. During the bounded
+workflow migration window, non-UUID posting URLs passed through the historical
+``JobId``-typed port are resolved at this repository boundary; persisted
+aggregates and returned queue identities are always stable IDs.
 
 See ddd-target.md §7.1 / §7.2 (per-aggregate repository, schema decoupling).
 """
@@ -24,7 +25,8 @@ from datetime import datetime, timezone
 from typing import Any
 
 from jobctrl.database import effective_tailoring_min_score, ensure_tailoring_policy_tables
-from jobctrl.domain.identifiers import JobId
+from jobctrl.domain.discovery.value_objects import PostingUrl
+from jobctrl.domain.identifiers import JobId, canonical_job_id
 from jobctrl.domain.materials.aggregate import MaterialsSet
 from jobctrl.domain.materials.entities import Artifact
 from jobctrl.domain.materials.policy import TailoringPolicy
@@ -36,6 +38,9 @@ from jobctrl.domain.materials.value_objects import (
     ValidationResult,
 )
 from jobctrl.domain.tenant import LOCAL_TENANT, TenantId
+from jobctrl.infrastructure.discovery.sqlite_identity_resolver import (
+    SqliteJobIdentityResolver,
+)
 from jobctrl.infrastructure.materials.unit_of_work import SqliteUnitOfWork
 
 
@@ -87,6 +92,46 @@ class SqliteMaterialsRepository:
     ) -> None:
         self._conn = conn
         self._unit_of_work = unit_of_work
+        self._identity_resolver = SqliteJobIdentityResolver(conn)
+
+    def _resolve_job_id(
+        self,
+        tenant_id: TenantId,
+        reference: JobId,
+    ) -> JobId | None:
+        raw_reference = str(reference or "").strip()
+        if not raw_reference:
+            raise ValueError("job_id must be non-empty")
+        try:
+            stable_candidate = canonical_job_id(raw_reference)
+        except ValueError:
+            stable_candidate = None
+        identity = (
+            self._identity_resolver.resolve_by_job_id(
+                tenant_id,
+                stable_candidate,
+            )
+            if stable_candidate is not None
+            else None
+        )
+        if identity is None:
+            identity = self._identity_resolver.resolve_by_posting_url(
+                tenant_id,
+                PostingUrl(raw_reference),
+            )
+        return identity.job_id if identity is not None else None
+
+    def _require_job_id(
+        self,
+        tenant_id: TenantId,
+        reference: JobId,
+    ) -> JobId:
+        resolved = self._resolve_job_id(tenant_id, reference)
+        if resolved is None:
+            raise ValueError(
+                f"no stable Job identity for materials reference: {reference}"
+            )
+        return resolved
 
     # ------------------------------------------------------------------
     # Read
@@ -99,27 +144,30 @@ class SqliteMaterialsRepository:
         *,
         generation: int | None = None,
     ) -> MaterialsSet | None:
+        stable_job_id = self._resolve_job_id(tenant_id, job_id)
+        if stable_job_id is None:
+            return None
         if generation is None:
             row = self._conn.execute(
                 """
-                SELECT job_url, generation, status, created_at, updated_at,
+                SELECT job_id, generation, status, created_at, updated_at,
                        last_validation_json, last_verdict_json, metadata_json
                 FROM job_materials
-                WHERE job_url = ? AND tenant_id = ?
+                WHERE tenant_id = ? AND job_id = ?
                 ORDER BY generation DESC
                 LIMIT 1
                 """,
-                (str(job_id), str(tenant_id)),
+                (str(tenant_id), str(stable_job_id)),
             ).fetchone()
         else:
             row = self._conn.execute(
                 """
-                SELECT job_url, generation, status, created_at, updated_at,
+                SELECT job_id, generation, status, created_at, updated_at,
                        last_validation_json, last_verdict_json, metadata_json
                 FROM job_materials
-                WHERE job_url = ? AND tenant_id = ? AND generation = ?
+                WHERE tenant_id = ? AND job_id = ? AND generation = ?
                 """,
-                (str(job_id), str(tenant_id), int(generation)),
+                (str(tenant_id), str(stable_job_id), int(generation)),
             ).fetchone()
         if row is None:
             return None
@@ -137,24 +185,33 @@ class SqliteMaterialsRepository:
         such as cover/PDF generation need this approved-material view instead of
         the raw latest generation.
         """
+        stable_job_id = self._resolve_job_id(tenant_id, job_id)
+        if stable_job_id is None:
+            return None
         row = self._conn.execute(
             """
-            SELECT m.job_url, m.generation, m.status, m.created_at, m.updated_at,
+            SELECT m.job_id, m.generation, m.status, m.created_at, m.updated_at,
                    m.last_validation_json, m.last_verdict_json, m.metadata_json
             FROM job_materials m
             INNER JOIN (
-                SELECT job_url, MAX(generation) AS generation
+                SELECT tenant_id, job_id, MAX(generation) AS generation
                 FROM job_materials_artifacts
-                WHERE job_url = ?
+                WHERE tenant_id = ? AND job_id = ?
                   AND artifact_type = 'tailored_resume'
                   AND status = 'approved'
-                GROUP BY job_url
+                GROUP BY tenant_id, job_id
             ) current
-              ON current.job_url = m.job_url
+              ON current.tenant_id = m.tenant_id
+             AND current.job_id = m.job_id
              AND current.generation = m.generation
-            WHERE m.job_url = ? AND m.tenant_id = ?
+            WHERE m.tenant_id = ? AND m.job_id = ?
             """,
-            (str(job_id), str(job_id), str(tenant_id)),
+            (
+                str(tenant_id),
+                str(stable_job_id),
+                str(tenant_id),
+                str(stable_job_id),
+            ),
         ).fetchone()
         if row is None:
             return None
@@ -170,13 +227,22 @@ class SqliteMaterialsRepository:
         from jobctrl.database import ensure_resume_template_tables
 
         ensure_resume_template_tables(self._conn)
+        stable_job_id = self._require_job_id(LOCAL_TENANT, job_id)
+        identity = self._identity_resolver.resolve_by_job_id(
+            LOCAL_TENANT,
+            stable_job_id,
+        )
+        if identity is None:
+            raise ValueError(
+                f"no stable Job identity for template reference: {job_id}"
+            )
         assignment = self._conn.execute(
             """
             SELECT template_id, version_id
               FROM job_resume_template_assignments
              WHERE tenant_id = 'local' AND job_url = ?
             """,
-            (str(job_id),),
+            (identity.storage_url.value,),
         ).fetchone()
         if assignment is not None:
             resolved = self._template_by_id(
@@ -259,14 +325,18 @@ class SqliteMaterialsRepository:
         )
         materials_join = (
             "LEFT JOIN ("
-            "SELECT DISTINCT m.job_url AS mj_job_url, tr.status AS mj_resume_status "
+            "SELECT DISTINCT m.tenant_id AS mj_tenant_id, "
+            "m.job_id AS mj_job_id, tr.status AS mj_resume_status "
             "FROM job_materials m "
-            "INNER JOIN job_materials_artifacts tr ON tr.job_url = m.job_url "
+            "INNER JOIN job_materials_artifacts tr "
+            "ON tr.tenant_id = m.tenant_id "
+            "AND tr.job_id = m.job_id "
             "AND tr.generation = m.generation "
             "AND tr.artifact_type = 'tailored_resume' "
             "AND tr.status = 'approved' "
             "WHERE m.tenant_id = ?"
-            ") mj ON mj.mj_job_url = j.url"
+            ") mj ON mj.mj_tenant_id = j.tenant_id "
+            "AND mj.mj_job_id = j.job_id"
         )
         params.append(str(tenant_id))
 
@@ -287,7 +357,7 @@ class SqliteMaterialsRepository:
             )
         params.append(int(min_score))
         sql = (
-            f"SELECT j.url FROM jobs j {score_join} {materials_join} "
+            f"SELECT j.job_id FROM jobs j {score_join} {materials_join} "
             f"WHERE {where} "
             "ORDER BY COALESCE(sj.sj_fit_score, j.fit_score) DESC, j.discovered_at DESC"
         )
@@ -334,31 +404,37 @@ class SqliteMaterialsRepository:
         params.append(str(tenant_id))
         materials_join = (
             "INNER JOIN ("
-            "SELECT m.job_url AS mj_job_url, m.generation AS mj_gen, "
+            "SELECT m.tenant_id AS mj_tenant_id, m.job_id AS mj_job_id, "
+            "m.generation AS mj_gen, "
             "tr.status AS mj_resume_status, rpdf.status AS mj_resume_pdf_status, "
             "cl.status AS mj_cover_status "
             "FROM job_materials m "
             "INNER JOIN ("
-            "SELECT job_url, MAX(generation) AS mg "
+            "SELECT tenant_id, job_id, MAX(generation) AS mg "
             "FROM job_materials_artifacts "
             "WHERE artifact_type = 'tailored_resume' AND status = 'approved' "
-            "GROUP BY job_url"
-            ") latest ON latest.job_url = m.job_url AND latest.mg = m.generation "
-            "INNER JOIN job_materials_artifacts tr ON tr.job_url = m.job_url "
+            "GROUP BY tenant_id, job_id"
+            ") latest ON latest.tenant_id = m.tenant_id "
+            "AND latest.job_id = m.job_id AND latest.mg = m.generation "
+            "INNER JOIN job_materials_artifacts tr "
+            "ON tr.tenant_id = m.tenant_id AND tr.job_id = m.job_id "
             "AND tr.generation = m.generation AND tr.artifact_type = 'tailored_resume' "
             "AND tr.status = 'approved' "
-            "INNER JOIN job_materials_artifacts rpdf ON rpdf.job_url = m.job_url "
+            "INNER JOIN job_materials_artifacts rpdf "
+            "ON rpdf.tenant_id = m.tenant_id AND rpdf.job_id = m.job_id "
             "AND rpdf.generation = m.generation AND rpdf.artifact_type = 'resume_pdf' "
             "AND rpdf.status = 'approved' "
-            "LEFT JOIN job_materials_artifacts cl ON cl.job_url = m.job_url "
+            "LEFT JOIN job_materials_artifacts cl "
+            "ON cl.tenant_id = m.tenant_id AND cl.job_id = m.job_id "
             "AND cl.generation = m.generation AND cl.artifact_type = 'cover_letter' "
             "AND cl.status = 'approved' "
             "WHERE m.tenant_id = ?"
-            ") mj ON mj.mj_job_url = j.url"
+            ") mj ON mj.mj_tenant_id = j.tenant_id "
+            "AND mj.mj_job_id = j.job_id"
         )
         params.append(int(min_score))
         sql = (
-            f"SELECT j.url FROM jobs j {score_join} {materials_join} "
+            f"SELECT j.job_id FROM jobs j {score_join} {materials_join} "
             "WHERE COALESCE(sj.sj_fit_score, j.fit_score) >= ? "
             "AND COALESCE(sj.sj_eligibility_status, '') != 'blocked' "
             "AND COALESCE(sj.sj_hard_blocker_count, 0) = 0 "
@@ -381,23 +457,26 @@ class SqliteMaterialsRepository:
         is missing one or more PDFs."""
         params: list[Any] = [str(tenant_id)]
         sql = (
-            "SELECT m.job_url FROM job_materials m "
+            "SELECT m.job_id FROM job_materials m "
             "INNER JOIN ("
-            "SELECT job_url, MAX(generation) AS mg "
+            "SELECT tenant_id, job_id, MAX(generation) AS mg "
             "FROM job_materials_artifacts "
             "WHERE status = 'approved' "
             "AND artifact_type IN ('tailored_resume', 'cover_letter') "
-            "GROUP BY job_url"
-            ") latest ON latest.job_url = m.job_url AND latest.mg = m.generation "
-            "INNER JOIN job_materials_artifacts tr ON tr.job_url = m.job_url "
+            "GROUP BY tenant_id, job_id"
+            ") latest ON latest.tenant_id = m.tenant_id "
+            "AND latest.job_id = m.job_id AND latest.mg = m.generation "
+            "INNER JOIN job_materials_artifacts tr "
+            "ON tr.tenant_id = m.tenant_id AND tr.job_id = m.job_id "
             "AND tr.generation = m.generation AND tr.status = 'approved' "
             "AND tr.artifact_type IN ('tailored_resume', 'cover_letter') "
-            "LEFT JOIN job_materials_artifacts pdf ON pdf.job_url = m.job_url "
+            "LEFT JOIN job_materials_artifacts pdf "
+            "ON pdf.tenant_id = m.tenant_id AND pdf.job_id = m.job_id "
             "AND pdf.generation = m.generation AND pdf.status = 'approved' "
             "AND ((tr.artifact_type = 'tailored_resume' AND pdf.artifact_type = 'resume_pdf') "
             "  OR (tr.artifact_type = 'cover_letter' AND pdf.artifact_type = 'cover_letter_pdf')) "
             "WHERE m.tenant_id = ? AND pdf.path IS NULL "
-            "GROUP BY m.job_url "
+            "GROUP BY m.tenant_id, m.job_id "
             "ORDER BY MAX(m.updated_at) DESC"
         )
         if limit > 0:
@@ -421,13 +500,16 @@ class SqliteMaterialsRepository:
             )
         params: list[Any] = [str(tenant_id), status.value]
         sql = (
-            "SELECT m.job_url, m.generation, m.status, m.created_at, m.updated_at, "
+            "SELECT m.job_id, m.generation, m.status, m.created_at, m.updated_at, "
             "m.last_validation_json, m.last_verdict_json, m.metadata_json "
             "FROM job_materials m "
             "INNER JOIN ("
-            "SELECT job_url, MAX(generation) AS mg FROM job_materials GROUP BY job_url"
-            ") latest ON latest.job_url = m.job_url AND latest.mg = m.generation "
-            "INNER JOIN job_materials_artifacts tr ON tr.job_url = m.job_url "
+            "SELECT tenant_id, job_id, MAX(generation) AS mg "
+            "FROM job_materials GROUP BY tenant_id, job_id"
+            ") latest ON latest.tenant_id = m.tenant_id "
+            "AND latest.job_id = m.job_id AND latest.mg = m.generation "
+            "INNER JOIN job_materials_artifacts tr "
+            "ON tr.tenant_id = m.tenant_id AND tr.job_id = m.job_id "
             "AND tr.generation = m.generation AND tr.artifact_type = 'tailored_resume' "
             "AND tr.status = ? "
             "WHERE m.tenant_id = ? "
@@ -446,15 +528,24 @@ class SqliteMaterialsRepository:
     # ------------------------------------------------------------------
 
     def save(self, materials: MaterialsSet) -> None:
+        stable_job_id = self._require_job_id(
+            materials.tenant_id,
+            materials.job_id,
+        )
         latest = self._conn.execute(
             "SELECT COALESCE(MAX(generation), 0) AS g FROM job_materials "
-            "WHERE job_url = ? AND tenant_id = ?",
-            (str(materials.job_id), str(materials.tenant_id)),
+            "WHERE tenant_id = ? AND job_id = ?",
+            (str(materials.tenant_id), str(stable_job_id)),
         ).fetchone()
         current_max = int(latest[0] if latest else 0)
         existing = self._conn.execute(
-            "SELECT 1 FROM job_materials WHERE job_url = ? AND tenant_id = ? AND generation = ?",
-            (str(materials.job_id), str(materials.tenant_id), materials.generation),
+            "SELECT 1 FROM job_materials "
+            "WHERE tenant_id = ? AND job_id = ? AND generation = ?",
+            (
+                str(materials.tenant_id),
+                str(stable_job_id),
+                materials.generation,
+            ),
         ).fetchone()
         # Allow either: update an existing generation or mint exactly the next one.
         # Failed re-tailors can leave newer rejected generations while the last
@@ -470,11 +561,11 @@ class SqliteMaterialsRepository:
         self._conn.execute(
             """
             INSERT INTO job_materials (
-                job_url, generation, tenant_id, status,
+                tenant_id, job_id, generation, status,
                 created_at, updated_at,
                 last_validation_json, last_verdict_json, metadata_json
             ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-            ON CONFLICT(job_url, generation) DO UPDATE SET
+            ON CONFLICT(tenant_id, job_id, generation) DO UPDATE SET
                 status = excluded.status,
                 updated_at = excluded.updated_at,
                 last_validation_json = excluded.last_validation_json,
@@ -482,9 +573,9 @@ class SqliteMaterialsRepository:
                 metadata_json = excluded.metadata_json
             """,
             (
-                str(materials.job_id),
-                materials.generation,
                 str(materials.tenant_id),
+                str(stable_job_id),
+                materials.generation,
                 materials.status,
                 materials.created_at,
                 materials.updated_at,
@@ -502,7 +593,11 @@ class SqliteMaterialsRepository:
         # between two saves of the same generation are left untouched —
         # use cases append, never delete.
         for artifact in materials.artifacts:
-            self._upsert_artifact(materials, artifact)
+            self._upsert_artifact(
+                materials,
+                stable_job_id,
+                artifact,
+            )
 
         self._commit()
 
@@ -530,16 +625,23 @@ class SqliteMaterialsRepository:
     # Internals
     # ------------------------------------------------------------------
 
-    def _upsert_artifact(self, materials: MaterialsSet, artifact: Artifact) -> None:
+    def _upsert_artifact(
+        self,
+        materials: MaterialsSet,
+        stable_job_id: JobId,
+        artifact: Artifact,
+    ) -> None:
         metadata, layout_boxes = _metadata_and_layout_boxes(artifact.metadata)
         self._conn.execute(
             """
             INSERT INTO job_materials_artifacts (
-                job_url, generation, artifact_type, artifact_id,
+                tenant_id, job_id, generation, artifact_type, artifact_id,
                 status, path, render_format, size_bytes,
                 metadata_json, created_at, superseded_at
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            ON CONFLICT(job_url, generation, artifact_type) DO UPDATE SET
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(
+                tenant_id, job_id, generation, artifact_type
+            ) DO UPDATE SET
                 artifact_id = excluded.artifact_id,
                 status = excluded.status,
                 path = excluded.path,
@@ -550,7 +652,8 @@ class SqliteMaterialsRepository:
                 superseded_at = excluded.superseded_at
             """,
             (
-                str(materials.job_id),
+                str(materials.tenant_id),
+                str(stable_job_id),
                 materials.generation,
                 artifact.type.value,
                 artifact.artifact_id,
@@ -563,11 +666,17 @@ class SqliteMaterialsRepository:
                 artifact.superseded_at,
             ),
         )
-        self._replace_layout_boxes(materials, artifact, layout_boxes)
+        self._replace_layout_boxes(
+            materials,
+            stable_job_id,
+            artifact,
+            layout_boxes,
+        )
 
     def _replace_layout_boxes(
         self,
         materials: MaterialsSet,
+        stable_job_id: JobId,
         artifact: Artifact,
         layout_boxes: list[dict[str, Any]],
     ) -> None:
@@ -575,9 +684,15 @@ class SqliteMaterialsRepository:
             self._conn.execute(
                 """
                 DELETE FROM job_material_layout_boxes
-                WHERE job_url = ? AND generation = ? AND artifact_id = ?
+                WHERE tenant_id = ? AND job_id = ?
+                  AND generation = ? AND artifact_id = ?
                 """,
-                (str(materials.job_id), materials.generation, artifact.artifact_id),
+                (
+                    str(materials.tenant_id),
+                    str(stable_job_id),
+                    materials.generation,
+                    artifact.artifact_id,
+                ),
             )
         except sqlite3.OperationalError:
             return
@@ -585,11 +700,11 @@ class SqliteMaterialsRepository:
             return
         rows = [
             (
-                str(materials.job_id),
+                str(materials.tenant_id),
+                str(stable_job_id),
                 materials.generation,
                 artifact.artifact_id,
                 index,
-                str(materials.tenant_id),
                 box["semantic_id"],
                 box["page_number"],
                 box.get("line_number"),
@@ -606,7 +721,7 @@ class SqliteMaterialsRepository:
         self._conn.executemany(
             """
             INSERT INTO job_material_layout_boxes (
-                job_url, generation, artifact_id, box_index, tenant_id,
+                tenant_id, job_id, generation, artifact_id, box_index,
                 semantic_id, page_number, line_number, text_excerpt,
                 left_pct, top_pct, width_pct, height_pct, audit_target_json,
                 created_at
@@ -655,7 +770,7 @@ class SqliteMaterialsRepository:
 
     def _row_to_materials(self, row: Any, tenant_id: TenantId) -> MaterialsSet:
         if isinstance(row, sqlite3.Row):
-            job_url = row["job_url"]
+            job_id = row["job_id"]
             generation = row["generation"]
             status = row["status"]
             created_at = row["created_at"]
@@ -665,7 +780,7 @@ class SqliteMaterialsRepository:
             metadata_json = row["metadata_json"]
         else:
             (
-                job_url,
+                job_id,
                 generation,
                 status,
                 created_at,
@@ -680,9 +795,9 @@ class SqliteMaterialsRepository:
             SELECT artifact_type, artifact_id, status, path, render_format,
                    size_bytes, metadata_json, created_at, superseded_at
             FROM job_materials_artifacts
-            WHERE job_url = ? AND generation = ?
+            WHERE tenant_id = ? AND job_id = ? AND generation = ?
             """,
-            (str(job_url), int(generation)),
+            (str(tenant_id), str(job_id), int(generation)),
         ).fetchall()
 
         slot_kwargs: dict[str, Artifact | None] = {
@@ -722,7 +837,7 @@ class SqliteMaterialsRepository:
 
         return MaterialsSet(
             tenant_id=tenant_id or LOCAL_TENANT,
-            job_id=JobId(str(job_url)),
+            job_id=JobId(str(job_id)),
             generation=int(generation),
             status=str(status),
             created_at=str(created_at),

--- a/workers/automation/src/jobctrl/infrastructure/projections/projection_builder.py
+++ b/workers/automation/src/jobctrl/infrastructure/projections/projection_builder.py
@@ -1745,24 +1745,28 @@ class ProjectionBuilder:
     def _attach_resume_usages(self, entries: dict[str, dict[str, Any]]) -> None:
         if not _table_exists(self._conn, "job_bullet_provenance"):
             return
-        job_metadata = _job_metadata_join_sql(self._conn, "provenance.job_url")
-        lifecycle = _job_lifecycle_exclusion_sql(self._conn, "provenance.job_url")
+        job_metadata = _job_metadata_join_sql(self._conn, "identity.url")
+        lifecycle = _job_lifecycle_exclusion_sql(self._conn, "identity.url")
         rows = self._conn.execute(
             f"""
-            SELECT provenance.job_url, provenance.artifact_id, provenance.generation,
+            SELECT identity.url AS job_url, provenance.artifact_id,
+                   provenance.generation,
                    provenance.bullet_id, provenance.generated_text, provenance.created_at,
                    provenance.evidence_ids_json,
                    {job_metadata['select_sql']}
               FROM job_bullet_provenance AS provenance
+              JOIN jobs AS identity
+                ON identity.tenant_id = provenance.tenant_id
+               AND identity.job_id = provenance.job_id
               {job_metadata['join_sql']}{lifecycle['join_sql']}
              WHERE provenance.tenant_id = ?{lifecycle['where_sql']}
                AND provenance.generation = (
                  SELECT MAX(latest.generation)
                    FROM job_bullet_provenance AS latest
                   WHERE latest.tenant_id = provenance.tenant_id
-                    AND latest.job_url = provenance.job_url
+                    AND latest.job_id = provenance.job_id
                )
-             ORDER BY provenance.job_url, provenance.position, provenance.bullet_id
+             ORDER BY identity.url, provenance.position, provenance.bullet_id
             """,
             (str(self._tenant_id),),
         ).fetchall()
@@ -2208,46 +2212,30 @@ class ProjectionBuilder:
 
     def _load_latest_materials(self, job_url: str) -> dict:
         try:
+            material_predicate, material_params = (
+                _job_reference_predicate_for_url(
+                    self._conn,
+                    "job_materials_artifacts",
+                    job_url,
+                )
+            )
             generation_row = self._conn.execute(
-                """
+                f"""
                 SELECT MAX(generation)
                 FROM job_materials_artifacts
-                WHERE job_url = ?
+                WHERE {material_predicate}
                   AND status = 'approved'
                   AND artifact_type IN (
                     'tailored_resume',
                     'cover_letter',
                     'resume_pdf',
                     'cover_letter_pdf'
-                  )
+                )
                 """,
-                (job_url,),
+                material_params,
             ).fetchone()
         except sqlite3.OperationalError:
-            try:
-                row = self._conn.execute(
-                    """
-                    SELECT artifact_id, generation, metadata_json,
-                           NULL AS material_metadata_json
-                    FROM job_materials_artifacts
-                    WHERE job_url = ?
-                      AND status = 'approved'
-                      AND artifact_type IN ('tailored_resume', 'tailored_resume_txt', 'resume_pdf')
-                    ORDER BY COALESCE(generation, -1) DESC,
-                             CASE artifact_type
-                               WHEN 'tailored_resume' THEN 0
-                               WHEN 'tailored_resume_txt' THEN 1
-                               WHEN 'resume_pdf' THEN 2
-                               ELSE 3
-                             END,
-                             created_at DESC,
-                             rowid DESC
-                    LIMIT 1
-                    """,
-                    (job_url,),
-                ).fetchone()
-            except sqlite3.OperationalError:
-                return {}
+            return {}
         if generation_row is None:
             return {}
         max_generation = generation_row[0]
@@ -2255,12 +2243,13 @@ class ProjectionBuilder:
             return {}
         try:
             artifact_rows = self._conn.execute(
-                """
+                f"""
                 SELECT artifact_type, path, status, created_at
                 FROM job_materials_artifacts
-                WHERE job_url = ? AND generation = ? AND status = 'approved'
+                WHERE {material_predicate}
+                  AND generation = ? AND status = 'approved'
                 """,
-                (job_url, int(max_generation)),
+                (*material_params, int(max_generation)),
             ).fetchall()
         except sqlite3.OperationalError:
             return {}
@@ -2284,15 +2273,57 @@ class ProjectionBuilder:
 
     def _load_material_analytics(self, job_url: str) -> dict[str, object]:
         try:
+            artifact_predicate, artifact_params = (
+                _job_reference_predicate_for_url(
+                    self._conn,
+                    "job_materials_artifacts",
+                    job_url,
+                    alias="a",
+                )
+            )
+            has_material_metadata = (
+                _table_exists(self._conn, "job_materials")
+                and _has_column(
+                    self._conn,
+                    "job_materials",
+                    "metadata_json",
+                )
+            )
+            stable_references = _has_column(
+                self._conn,
+                "job_materials_artifacts",
+                "job_id",
+            )
+            material_metadata_select = (
+                "m.metadata_json AS material_metadata_json"
+                if has_material_metadata
+                else "NULL AS material_metadata_json"
+            )
+            material_metadata_join = (
+                (
+                    """
+                    LEFT JOIN job_materials m
+                      ON m.tenant_id = a.tenant_id
+                     AND m.job_id = a.job_id
+                     AND m.generation = a.generation
+                    """
+                    if stable_references
+                    else """
+                    LEFT JOIN job_materials m
+                      ON m.job_url = a.job_url
+                     AND m.generation = a.generation
+                    """
+                )
+                if has_material_metadata
+                else ""
+            )
             row = self._conn.execute(
-                """
+                f"""
                 SELECT a.artifact_id, a.generation, a.metadata_json,
-                       m.metadata_json AS material_metadata_json
+                       {material_metadata_select}
                 FROM job_materials_artifacts a
-                LEFT JOIN job_materials m
-                  ON m.job_url = a.job_url
-                 AND m.generation = a.generation
-                WHERE a.job_url = ?
+                {material_metadata_join}
+                WHERE {artifact_predicate}
                   AND a.status = 'approved'
                   AND a.artifact_type IN ('tailored_resume', 'tailored_resume_txt', 'resume_pdf')
                 ORDER BY COALESCE(a.generation, -1) DESC,
@@ -2306,33 +2337,10 @@ class ProjectionBuilder:
                          a.rowid DESC
                 LIMIT 1
                 """,
-                (job_url,),
+                artifact_params,
             ).fetchone()
         except sqlite3.OperationalError:
-            try:
-                row = self._conn.execute(
-                    """
-                    SELECT artifact_id, generation, metadata_json,
-                           NULL AS material_metadata_json
-                    FROM job_materials_artifacts
-                    WHERE job_url = ?
-                      AND status = 'approved'
-                      AND artifact_type IN ('tailored_resume', 'tailored_resume_txt', 'resume_pdf')
-                    ORDER BY COALESCE(generation, -1) DESC,
-                             CASE artifact_type
-                               WHEN 'tailored_resume' THEN 0
-                               WHEN 'tailored_resume_txt' THEN 1
-                               WHEN 'resume_pdf' THEN 2
-                               ELSE 3
-                             END,
-                             created_at DESC,
-                             rowid DESC
-                    LIMIT 1
-                    """,
-                    (job_url,),
-                ).fetchone()
-            except sqlite3.OperationalError:
-                return {}
+            return {}
         metadata_jsons = [
             _row_nullable_str(row, "metadata_json"),
             _row_nullable_str(row, "material_metadata_json"),
@@ -2353,24 +2361,38 @@ class ProjectionBuilder:
         metadata: list[str | None] = []
         if base_generation is not None:
             try:
+                material_predicate, material_params = (
+                    _job_reference_predicate_for_url(
+                        self._conn,
+                        "job_materials",
+                        job_url,
+                    )
+                )
                 row = self._conn.execute(
-                    """
+                    f"""
                     SELECT metadata_json
                     FROM job_materials
-                    WHERE job_url = ? AND generation = ?
+                    WHERE {material_predicate} AND generation = ?
                     LIMIT 1
                     """,
-                    (job_url, base_generation),
+                    (*material_params, base_generation),
                 ).fetchone()
             except sqlite3.OperationalError:
                 row = None
             metadata.append(_row_nullable_str(row, "metadata_json"))
             try:
+                artifact_predicate, artifact_params = (
+                    _job_reference_predicate_for_url(
+                        self._conn,
+                        "job_materials_artifacts",
+                        job_url,
+                    )
+                )
                 rows = self._conn.execute(
-                    """
+                    f"""
                     SELECT metadata_json
                     FROM job_materials_artifacts
-                    WHERE job_url = ?
+                    WHERE {artifact_predicate}
                       AND generation = ?
                       AND artifact_type IN ('tailored_resume', 'tailored_resume_txt', 'resume_pdf')
                     ORDER BY CASE artifact_type
@@ -2381,7 +2403,7 @@ class ProjectionBuilder:
                              END,
                              rowid DESC
                     """,
-                    (job_url, base_generation),
+                    (*artifact_params, base_generation),
                 ).fetchall()
             except sqlite3.OperationalError:
                 rows = []
@@ -2389,11 +2411,18 @@ class ProjectionBuilder:
         if base_artifact_ids:
             placeholders = ", ".join("?" for _ in base_artifact_ids)
             try:
+                artifact_predicate, artifact_params = (
+                    _job_reference_predicate_for_url(
+                        self._conn,
+                        "job_materials_artifacts",
+                        job_url,
+                    )
+                )
                 rows = self._conn.execute(
                     f"""
                     SELECT metadata_json
                     FROM job_materials_artifacts
-                    WHERE job_url = ?
+                    WHERE {artifact_predicate}
                       AND artifact_id IN ({placeholders})
                     ORDER BY COALESCE(generation, -1) DESC,
                              CASE artifact_type
@@ -2404,7 +2433,7 @@ class ProjectionBuilder:
                              END,
                              rowid DESC
                     """,
-                    (job_url, *base_artifact_ids),
+                    (*artifact_params, *base_artifact_ids),
                 ).fetchall()
             except sqlite3.OperationalError:
                 rows = []
@@ -2498,14 +2527,21 @@ class ProjectionBuilder:
 
         empty = _ProvenanceProjection(provenance={}, coverage={}, voice={})
         try:
+            provenance_predicate, provenance_params = (
+                _job_reference_predicate_for_url(
+                    self._conn,
+                    "job_bullet_provenance",
+                    job_url,
+                )
+            )
             generation_rows = self._conn.execute(
-                """
+                f"""
                 SELECT DISTINCT generation
                 FROM job_bullet_provenance
-                WHERE job_url = ? AND tenant_id = ?
+                WHERE {provenance_predicate}
                 ORDER BY generation
                 """,
-                (job_url, str(self._tenant_id)),
+                provenance_params,
             ).fetchall()
         except sqlite3.OperationalError:
             return empty
@@ -2515,10 +2551,11 @@ class ProjectionBuilder:
         provenance: dict[str, str] = {}
         coverage_by_artifact: dict[str, str] = {}
         voice_by_artifact: dict[str, str] = {}
+        stable_job_id = JobId(str(provenance_params[-1]))
         for row in generation_rows:
             record = repository.load(
                 self._tenant_id,
-                JobId(job_url),
+                stable_job_id,
                 generation=int(row["generation"]),
             )
             if record is None or record.is_empty:
@@ -2848,14 +2885,21 @@ class ProjectionBuilder:
         artifacts: list[dict] = []
         seen: set[tuple[str, str]] = set()
         try:
+            material_predicate, material_params = (
+                _job_reference_predicate_for_url(
+                    self._conn,
+                    "job_materials_artifacts",
+                    job_url,
+                )
+            )
             for row in self._conn.execute(
-                """
+                f"""
                 SELECT artifact_id, artifact_type, status, path, created_at,
                        size_bytes, generation, metadata_json
                 FROM job_materials_artifacts
-                WHERE job_url = ?
+                WHERE {material_predicate}
                 """,
-                (job_url,),
+                material_params,
             ).fetchall():
                 local_path = _row_nullable_str(row, "path") or ""
                 atype = _row_nullable_str(row, "artifact_type") or ""
@@ -2921,15 +2965,22 @@ class ProjectionBuilder:
 
     def _load_layout_boxes_by_artifact(self, job_url: str) -> dict[str, str]:
         try:
+            layout_predicate, layout_params = (
+                _job_reference_predicate_for_url(
+                    self._conn,
+                    "job_material_layout_boxes",
+                    job_url,
+                )
+            )
             rows = self._conn.execute(
-                """
+                f"""
                 SELECT artifact_id, semantic_id, page_number, line_number,
                        text_excerpt, left_pct, top_pct, width_pct, height_pct
                 FROM job_material_layout_boxes
-                WHERE job_url = ? AND tenant_id = ?
+                WHERE {layout_predicate}
                 ORDER BY artifact_id, page_number, box_index
                 """,
-                (job_url, str(self._tenant_id)),
+                layout_params,
             ).fetchall()
         except sqlite3.OperationalError:
             return {}
@@ -4128,10 +4179,12 @@ def _job_reference_predicate_for_url(
     job_url: str,
     *,
     tenant_id: str = str(LOCAL_TENANT),
+    alias: str = "",
 ) -> tuple[str, tuple[str, ...]]:
     """Resolve one explicit posting URL for legacy or stable table shapes."""
+    prefix = f"{alias}." if alias else ""
     if not _has_column(conn, table_name, "job_id"):
-        return "job_url = ?", (job_url,)
+        return f"{prefix}job_url = ?", (job_url,)
     row = conn.execute(
         """
         SELECT j.tenant_id, j.job_id
@@ -4152,7 +4205,7 @@ def _job_reference_predicate_for_url(
     ).fetchone()
     if row is None:
         raise ValueError(f"no stable Job identity for posting URL: {job_url}")
-    return "tenant_id = ? AND job_id = ?", (
+    return f"{prefix}tenant_id = ? AND {prefix}job_id = ?", (
         str(row[0]),
         str(row[1]),
     )

--- a/workers/automation/src/jobctrl/interview/activities.py
+++ b/workers/automation/src/jobctrl/interview/activities.py
@@ -10,9 +10,13 @@ from typing import Any
 from temporalio import activity
 
 from jobctrl.database import get_connection, load_job_with_enrichment
+from jobctrl.domain.discovery.value_objects import PostingUrl
 from jobctrl.domain.interview import GenerateInterviewPrepUseCase
 from jobctrl.domain.tenant import LOCAL_TENANT, TenantId
 from jobctrl.infrastructure.interview import SqliteInterviewPrepRepository
+from jobctrl.infrastructure.discovery.sqlite_identity_resolver import (
+    SqliteJobIdentityResolver,
+)
 from jobctrl.infrastructure.llm import LlmAdapter, get_llm_adapter
 from jobctrl.infrastructure.profile import get_profile_repository
 from jobctrl.infrastructure.projections.projection_builder import ProjectionBuilder
@@ -288,6 +292,12 @@ def _load_accepted_materials(
     tenant_id: TenantId,
     job_url: str,
 ) -> tuple[dict[str, Any], ...]:
+    identity = SqliteJobIdentityResolver(conn).resolve_by_posting_url(
+        tenant_id,
+        PostingUrl(job_url),
+    )
+    if identity is None:
+        return ()
     try:
         rows = conn.execute(
             """
@@ -295,15 +305,20 @@ def _load_accepted_materials(
                    requirement_ids_json, generated_text, position
             FROM job_bullet_provenance
             WHERE tenant_id = ?
-              AND job_url = ?
+              AND job_id = ?
               AND generation = (
                 SELECT MAX(generation)
                 FROM job_bullet_provenance
-                WHERE tenant_id = ? AND job_url = ?
+                WHERE tenant_id = ? AND job_id = ?
               )
             ORDER BY position, bullet_id
             """,
-            (str(tenant_id), job_url, str(tenant_id), job_url),
+            (
+                str(tenant_id),
+                str(identity.job_id),
+                str(tenant_id),
+                str(identity.job_id),
+            ),
         ).fetchall()
     except sqlite3.OperationalError:
         return ()

--- a/workers/automation/src/jobctrl/pipeline/current_policy_selectors.py
+++ b/workers/automation/src/jobctrl/pipeline/current_policy_selectors.py
@@ -95,9 +95,9 @@ def tailoring_current_policy_job_urls(
     )
     limit_sql, limit_params = _limit_filter(limit)
     effective_tailor_path = (
-        "((lm.materials_job_url IS NOT NULL AND lm.tailored_resume_path IS NOT NULL "
+        "((lm.materials_job_id IS NOT NULL AND lm.tailored_resume_path IS NOT NULL "
         "AND lm.tailored_resume_path != '') "
-        "OR (lm.materials_job_url IS NULL AND j.tailored_resume_path IS NOT NULL "
+        "OR (lm.materials_job_id IS NULL AND j.tailored_resume_path IS NOT NULL "
         "AND j.tailored_resume_path != ''))"
     )
 
@@ -141,24 +141,30 @@ def tailoring_current_policy_job_urls(
          AND tailor_state.job_id = j.job_id
          AND tailor_state.stage = 'tailor'
         LEFT JOIN (
-            SELECT m.job_url AS materials_job_url, tr.path AS tailored_resume_path,
+            SELECT m.tenant_id AS materials_tenant_id,
+                   m.job_id AS materials_job_id,
+                   tr.path AS tailored_resume_path,
                    tr.metadata_json AS tailored_resume_metadata
             FROM job_materials m
             INNER JOIN (
-                SELECT job_url, MAX(generation) AS max_generation
+                SELECT tenant_id, job_id, MAX(generation) AS max_generation
                 FROM job_materials
                 WHERE tenant_id = ?
-                GROUP BY job_url
+                GROUP BY tenant_id, job_id
             ) latest
-              ON latest.job_url = m.job_url AND latest.max_generation = m.generation
+              ON latest.tenant_id = m.tenant_id
+             AND latest.job_id = m.job_id
+             AND latest.max_generation = m.generation
             LEFT JOIN job_materials_artifacts tr
-              ON tr.job_url = m.job_url
+              ON tr.tenant_id = m.tenant_id
+             AND tr.job_id = m.job_id
              AND tr.generation = m.generation
              AND tr.artifact_type = 'tailored_resume'
              AND tr.status = 'approved'
              AND tr.superseded_at IS NULL
             WHERE m.tenant_id = ?
-        ) lm ON lm.materials_job_url = j.url
+        ) lm ON lm.materials_tenant_id = j.tenant_id
+            AND lm.materials_job_id = j.job_id
         WHERE COALESCE(je.full_description, j.full_description) IS NOT NULL
           {active_sql}
           {requested_sql}

--- a/workers/automation/src/jobctrl/scoring/tailor.py
+++ b/workers/automation/src/jobctrl/scoring/tailor.py
@@ -864,7 +864,7 @@ def _load_tailor_eligible_job_by_url(
     row = conn.execute(
         f"""
         SELECT jobs.*, js.js_fit_score AS js_fit_score,
-               jm.jm_job_url AS jm_job_url,
+               jm.jm_job_id AS jm_job_id,
                jm.jm_tailored_path AS jm_tailored_path,
                jm.jm_tailored_at AS jm_tailored_at,
                jm.jm_cover_path AS jm_cover_path,
@@ -896,12 +896,12 @@ def _promote_tailor_job_row(row: sqlite3.Row) -> dict:
     js_value = record.pop("js_fit_score", None)
     if js_value is not None:
         record["fit_score"] = js_value
-    jm_job_url = record.pop("jm_job_url", None)
+    jm_job_id = record.pop("jm_job_id", None)
     jm_tailored = record.pop("jm_tailored_path", None)
     jm_tailored_at = record.pop("jm_tailored_at", None)
     jm_cover = record.pop("jm_cover_path", None)
     jm_cover_at = record.pop("jm_cover_at", None)
-    if jm_job_url is not None:
+    if jm_job_id is not None:
         record["tailored_resume_path"] = jm_tailored
         record["tailored_at"] = jm_tailored_at
         record["cover_letter_path"] = jm_cover

--- a/workers/automation/src/jobctrl/state.py
+++ b/workers/automation/src/jobctrl/state.py
@@ -849,12 +849,13 @@ def _material_generation_completed_stage(conn, job_url: str, stage: str) -> int 
     else:
         return None
 
+    tenant_id, job_id = _stable_stage_identity_for_url(conn, job_url)
     placeholders = ", ".join("?" for _ in required_artifacts)
     row = conn.execute(
         f"""
         SELECT generation
         FROM job_materials_artifacts
-        WHERE job_url = ?
+        WHERE tenant_id = ? AND job_id = ?
           AND status = 'approved'
           AND artifact_type IN ({placeholders})
         GROUP BY generation
@@ -862,7 +863,12 @@ def _material_generation_completed_stage(conn, job_url: str, stage: str) -> int 
         ORDER BY generation DESC
         LIMIT 1
         """,
-        (job_url, *required_artifacts, len(required_artifacts)),
+        (
+            tenant_id,
+            job_id,
+            *required_artifacts,
+            len(required_artifacts),
+        ),
     ).fetchone()
     if row is None:
         return None
@@ -1122,16 +1128,18 @@ def _reset_enrichment_aggregate(conn, job_url: str) -> None:
 
 
 def _resettable_material_generation(conn, job_url: str, stage: str) -> int | None:
+    tenant_id, job_id = _stable_stage_identity_for_url(conn, job_url)
     if stage == "tailor":
         row = conn.execute(
             """
             SELECT m.generation
             FROM job_materials m
-            WHERE m.job_url = ?
+            WHERE m.tenant_id = ? AND m.job_id = ?
               AND NOT EXISTS (
                 SELECT 1
                 FROM job_materials_artifacts a
-                WHERE a.job_url = m.job_url
+                WHERE a.tenant_id = m.tenant_id
+                  AND a.job_id = m.job_id
                   AND a.generation = m.generation
                   AND a.artifact_type = 'tailored_resume'
                   AND a.status = 'approved'
@@ -1139,18 +1147,19 @@ def _resettable_material_generation(conn, job_url: str, stage: str) -> int | Non
             ORDER BY m.generation DESC
             LIMIT 1
             """,
-            (job_url,),
+            (tenant_id, job_id),
         ).fetchone()
     elif stage == "cover":
         row = conn.execute(
             """
             SELECT m.generation
             FROM job_materials m
-            WHERE m.job_url = ?
+            WHERE m.tenant_id = ? AND m.job_id = ?
               AND EXISTS (
                 SELECT 1
                 FROM job_materials_artifacts a
-                WHERE a.job_url = m.job_url
+                WHERE a.tenant_id = m.tenant_id
+                  AND a.job_id = m.job_id
                   AND a.generation = m.generation
                   AND a.artifact_type = 'tailored_resume'
                   AND a.status = 'approved'
@@ -1158,7 +1167,8 @@ def _resettable_material_generation(conn, job_url: str, stage: str) -> int | Non
               AND NOT EXISTS (
                 SELECT 1
                 FROM job_materials_artifacts a
-                WHERE a.job_url = m.job_url
+                WHERE a.tenant_id = m.tenant_id
+                  AND a.job_id = m.job_id
                   AND a.generation = m.generation
                   AND a.artifact_type = 'cover_letter'
                   AND a.status = 'approved'
@@ -1166,7 +1176,7 @@ def _resettable_material_generation(conn, job_url: str, stage: str) -> int | Non
             ORDER BY m.generation DESC
             LIMIT 1
             """,
-            (job_url,),
+            (tenant_id, job_id),
         ).fetchone()
     else:
         return None
@@ -1208,16 +1218,24 @@ def _reset_materials_artifacts(conn, job_url: str, stage: str) -> None:
         return
 
     placeholders = ", ".join("?" for _ in targets)
+    tenant_id, job_id = _stable_stage_identity_for_url(conn, job_url)
     conn.execute(
         f"DELETE FROM job_materials_artifacts "
-        f"WHERE job_url = ? AND generation = ? AND artifact_type IN ({placeholders})",
-        (job_url, generation, *targets),
+        f"WHERE tenant_id = ? AND job_id = ? "
+        f"AND generation = ? AND artifact_type IN ({placeholders})",
+        (tenant_id, job_id, generation, *targets),
     )
     if new_status is not None:
         conn.execute(
             "UPDATE job_materials SET status = ?, updated_at = ? "
-            "WHERE job_url = ? AND generation = ?",
-            (new_status, utc_now(), job_url, generation),
+            "WHERE tenant_id = ? AND job_id = ? AND generation = ?",
+            (
+                new_status,
+                utc_now(),
+                tenant_id,
+                job_id,
+                generation,
+            ),
         )
 
 

--- a/workers/automation/tests/test_apply_regressions.py
+++ b/workers/automation/tests/test_apply_regressions.py
@@ -213,8 +213,12 @@ def _seed_current_apply_binding(
     conn.execute(
         """
         INSERT OR REPLACE INTO job_materials (
-            job_url, generation, tenant_id, status, created_at, updated_at
-        ) VALUES (?, ?, 'local', 'approved', ?, ?)
+            tenant_id, job_id, generation, status, created_at, updated_at
+        ) VALUES (
+            'local',
+            (SELECT job_id FROM jobs WHERE tenant_id = 'local' AND url = ?),
+            ?, 'approved', ?, ?
+        )
         """,
         (job_key, generation, now, now),
     )
@@ -225,9 +229,13 @@ def _seed_current_apply_binding(
         conn.execute(
             """
             INSERT OR REPLACE INTO job_materials_artifacts (
-                job_url, generation, artifact_type, artifact_id, status, path,
-                render_format, created_at
-            ) VALUES (?, ?, ?, ?, 'approved', ?, 'text', ?)
+                tenant_id, job_id, generation, artifact_type, artifact_id,
+                status, path, render_format, created_at
+            ) VALUES (
+                'local',
+                (SELECT job_id FROM jobs WHERE tenant_id = 'local' AND url = ?),
+                ?, ?, ?, 'approved', ?, 'text', ?
+            )
             """,
             (job_key, generation, artifact_type, artifact_id, path, now),
         )

--- a/workers/automation/tests/test_audit_projection_parity.py
+++ b/workers/automation/tests/test_audit_projection_parity.py
@@ -97,6 +97,12 @@ def conn(fixture: dict[str, Any], tmp_path: Path) -> Iterator[sqlite3.Connection
 def _seed_rows(conn: sqlite3.Connection, fixture: dict[str, Any]) -> None:
     """Seed the canonical rows exactly as the Python repositories write them."""
     job_url = fixture["job"]["url"]
+    job_id = str(
+        conn.execute(
+            "SELECT job_id FROM jobs WHERE tenant_id = 'local' AND url = ?",
+            (job_url,),
+        ).fetchone()[0]
+    )
     rows = fixture["rows"]
 
     for score in rows["jobScores"]:
@@ -210,21 +216,23 @@ def _seed_rows(conn: sqlite3.Connection, fixture: dict[str, Any]) -> None:
     created_at = fixture["job"]["createdAt"]
     conn.execute(
         """
-        INSERT INTO job_materials (job_url, generation, tenant_id, status, created_at, updated_at)
-        VALUES (?, ?, 'local', 'complete', ?, ?)
+        INSERT INTO job_materials (
+            tenant_id, job_id, generation, status, created_at, updated_at
+        ) VALUES ('local', ?, ?, 'complete', ?, ?)
         """,
-        (job_url, generation, created_at, created_at),
+        (job_id, generation, created_at, created_at),
     )
     for artifact in rows["artifacts"]:
         conn.execute(
             """
             INSERT INTO job_materials_artifacts (
-                job_url, generation, artifact_type, artifact_id, status, path,
-                render_format, size_bytes, metadata_json, created_at
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                tenant_id, job_id, generation, artifact_type, artifact_id,
+                status, path, render_format, size_bytes, metadata_json,
+                created_at
+            ) VALUES ('local', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
-                job_url,
+                job_id,
                 generation,
                 artifact["artifact_type"],
                 artifact["artifact_id"],
@@ -240,14 +248,14 @@ def _seed_rows(conn: sqlite3.Connection, fixture: dict[str, Any]) -> None:
         conn.execute(
             """
             INSERT INTO job_bullet_provenance (
-                job_url, generation, bullet_id, tenant_id, artifact_id, section,
+                tenant_id, job_id, generation, bullet_id, artifact_id, section,
                 source_id, evidence_ids_json, requirement_ids_json,
                 matched_keywords_json, transform_type, control, rationale,
                 generated_text, position, created_at, coverage_json, voice_json
-            ) VALUES (?, ?, ?, 'local', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ) VALUES ('local', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
-                job_url,
+                job_id,
                 bullet["generation"],
                 bullet["bullet_id"],
                 bullet["artifact_id"],
@@ -596,13 +604,20 @@ def test_python_builder_projects_historical_artifact_generation_coverage_rows(
         """,
         (job_url, created_1),
     )
+    job_id = str(
+        conn.execute(
+            "SELECT job_id FROM jobs WHERE tenant_id = 'local' AND url = ?",
+            (job_url,),
+        ).fetchone()[0]
+    )
     for generation, created_at in ((1, created_1), (2, created_2)):
         conn.execute(
             """
-            INSERT INTO job_materials (job_url, generation, tenant_id, status, created_at, updated_at)
-            VALUES (?, ?, 'local', 'complete', ?, ?)
+            INSERT INTO job_materials (
+                tenant_id, job_id, generation, status, created_at, updated_at
+            ) VALUES ('local', ?, ?, 'complete', ?, ?)
             """,
-            (job_url, generation, created_at, created_at),
+            (job_id, generation, created_at, created_at),
         )
     artifacts = [
         (1, "tailored_resume", "resume-v1", "/tmp/historical-resume-v1.txt", "text", created_1),
@@ -613,11 +628,12 @@ def test_python_builder_projects_historical_artifact_generation_coverage_rows(
         conn.execute(
             """
             INSERT INTO job_materials_artifacts (
-                job_url, generation, artifact_type, artifact_id, status, path,
-                render_format, size_bytes, metadata_json, created_at
-            ) VALUES (?, ?, ?, ?, 'approved', ?, ?, 10, '{}', ?)
+                tenant_id, job_id, generation, artifact_type, artifact_id,
+                status, path, render_format, size_bytes, metadata_json,
+                created_at
+            ) VALUES ('local', ?, ?, ?, ?, 'approved', ?, ?, 10, '{}', ?)
             """,
-            (job_url, generation, artifact_type, artifact_id, path, render_format, created_at),
+            (job_id, generation, artifact_type, artifact_id, path, render_format, created_at),
         )
     coverage_v1 = {
         "computed_against": "rendered_text",
@@ -658,15 +674,15 @@ def test_python_builder_projects_historical_artifact_generation_coverage_rows(
         conn.execute(
             """
             INSERT INTO job_bullet_provenance (
-                job_url, generation, bullet_id, tenant_id, artifact_id, section,
+                tenant_id, job_id, generation, bullet_id, artifact_id, section,
                 source_id, evidence_ids_json, requirement_ids_json,
                 matched_keywords_json, transform_type, control, rationale,
                 generated_text, position, created_at, coverage_json, voice_json
-            ) VALUES (?, ?, ?, 'local', ?, 'experience', ?, '[]', '[]', ?, 'voice',
+            ) VALUES ('local', ?, ?, ?, ?, 'experience', ?, '[]', '[]', ?, 'voice',
                 'rephrase_allowed', 'Voiced bullet.', 'Generated text.', 0, ?, ?, ?)
             """,
             (
-                job_url,
+                job_id,
                 generation,
                 bullet_id,
                 artifact_id,

--- a/workers/automation/tests/test_bullet_provenance.py
+++ b/workers/automation/tests/test_bullet_provenance.py
@@ -1501,10 +1501,15 @@ def conn(tmp_path) -> Iterator[sqlite3.Connection]:
 
 def _seed_materials_generation(connection: sqlite3.Connection, generation: int, *, ts: str) -> None:
     """Insert the ``job_materials`` FK parent row for a generation."""
+    job_id = connection.execute(
+        "SELECT job_id FROM jobs WHERE tenant_id = 'local' AND url = ?",
+        (JOB_URL,),
+    ).fetchone()[0]
     connection.execute(
-        "INSERT INTO job_materials (job_url, generation, tenant_id, status, created_at, updated_at) "
-        "VALUES (?, ?, 'local', 'complete', ?, ?)",
-        (JOB_URL, generation, ts, ts),
+        "INSERT INTO job_materials "
+        "(tenant_id, job_id, generation, status, created_at, updated_at) "
+        "VALUES ('local', ?, ?, 'complete', ?, ?)",
+        (job_id, generation, ts, ts),
     )
     connection.commit()
 

--- a/workers/automation/tests/test_dashboard_projection.py
+++ b/workers/automation/tests/test_dashboard_projection.py
@@ -34,11 +34,17 @@ def _seed_job(conn: sqlite3.Connection, url: str, *, site: str = "ExampleCo") ->
     conn.commit()
 
 
+def _job_id(conn: sqlite3.Connection, url: str) -> str:
+    return str(
+        conn.execute(
+            "SELECT job_id FROM jobs WHERE tenant_id = 'local' AND url = ?",
+            (url,),
+        ).fetchone()[0]
+    )
+
+
 def _mark_closed(conn: sqlite3.Connection, url: str, state: str = "removed") -> None:
-    job_id = conn.execute(
-        "SELECT job_id FROM jobs WHERE tenant_id = 'local' AND url = ?",
-        (url,),
-    ).fetchone()[0]
+    job_id = _job_id(conn, url)
     conn.execute(
         """
         INSERT INTO posting_snapshot_sets (
@@ -201,28 +207,30 @@ def test_artifact_projection_preserves_material_metadata(conn: sqlite3.Connectio
     conn.execute(
         """
         INSERT INTO job_materials (
-            job_url, generation, tenant_id, status, created_at, updated_at, metadata_json
-        ) VALUES (?, 1, 'local', 'resume_approved', ?, ?, '{}')
+            tenant_id, job_id, generation, status, created_at, updated_at, metadata_json
+        ) VALUES ('local', ?, 1, 'resume_approved', ?, ?, '{}')
         """,
-        (url, utc_now(), utc_now()),
+        (_job_id(conn, url), utc_now(), utc_now()),
     )
     conn.execute(
         """
         INSERT INTO job_materials_artifacts (
-            job_url, generation, artifact_type, artifact_id, status, path,
-            render_format, size_bytes, metadata_json, created_at
-        ) VALUES (?, 1, 'tailored_resume', 'artifact-1', 'approved', ?, 'text', 12, ?, ?)
+            tenant_id, job_id, generation, artifact_type, artifact_id,
+            status, path, render_format, size_bytes, metadata_json, created_at
+        ) VALUES ('local', ?, 1, 'tailored_resume', 'artifact-1',
+                  'approved', ?, 'text', 12, ?, ?)
         """,
-        (url, "/tmp/resume.txt", json.dumps(metadata), utc_now()),
+        (_job_id(conn, url), "/tmp/resume.txt", json.dumps(metadata), utc_now()),
     )
     conn.execute(
         """
         INSERT INTO job_materials_artifacts (
-            job_url, generation, artifact_type, artifact_id, status, path,
-            render_format, size_bytes, metadata_json, created_at
-        ) VALUES (?, 1, 'resume_pdf', 'artifact-pdf', 'approved', ?, 'pdf', 120, '{}', ?)
+            tenant_id, job_id, generation, artifact_type, artifact_id,
+            status, path, render_format, size_bytes, metadata_json, created_at
+        ) VALUES ('local', ?, 1, 'resume_pdf', 'artifact-pdf',
+                  'approved', ?, 'pdf', 120, '{}', ?)
         """,
-        (url, "/tmp/resume.pdf", utc_now()),
+        (_job_id(conn, url), "/tmp/resume.pdf", utc_now()),
     )
     record_job_event(conn, url, "tailor", "MaterialsGenerated")
     conn.commit()
@@ -255,30 +263,32 @@ def test_artifact_projection_includes_resume_layout_boxes(conn: sqlite3.Connecti
     conn.execute(
         """
         INSERT INTO job_materials (
-            job_url, generation, tenant_id, status, created_at, updated_at, metadata_json
-        ) VALUES (?, 1, 'local', 'resume_approved', ?, ?, '{}')
+            tenant_id, job_id, generation, status, created_at, updated_at, metadata_json
+        ) VALUES ('local', ?, 1, 'resume_approved', ?, ?, '{}')
         """,
-        (url, now, now),
+        (_job_id(conn, url), now, now),
     )
     conn.execute(
         """
         INSERT INTO job_materials_artifacts (
-            job_url, generation, artifact_type, artifact_id, status, path,
-            render_format, size_bytes, metadata_json, created_at
-        ) VALUES (?, 1, 'resume_pdf', 'artifact-pdf', 'approved', ?, 'html_pdf', 120, '{}', ?)
+            tenant_id, job_id, generation, artifact_type, artifact_id,
+            status, path, render_format, size_bytes, metadata_json, created_at
+        ) VALUES ('local', ?, 1, 'resume_pdf', 'artifact-pdf',
+                  'approved', ?, 'html_pdf', 120, '{}', ?)
         """,
-        (url, "/tmp/resume.pdf", now),
+        (_job_id(conn, url), "/tmp/resume.pdf", now),
     )
     conn.execute(
         """
         INSERT INTO job_material_layout_boxes (
-            job_url, generation, artifact_id, box_index, tenant_id,
+            tenant_id, job_id, generation, artifact_id, box_index,
             semantic_id, page_number, line_number, text_excerpt,
             left_pct, top_pct, width_pct, height_pct, audit_target_json,
             created_at
-        ) VALUES (?, 1, 'artifact-pdf', 0, 'local', ?, 1, 6, ?, 12.5, 24.0, 62.0, 2.4, '{}', ?)
+        ) VALUES ('local', ?, 1, 'artifact-pdf', 0, ?, 1, 6, ?,
+                  12.5, 24.0, 62.0, 2.4, '{}', ?)
         """,
-        (url, "experience:acme:bullet:1", "Cut latency.", now),
+        (_job_id(conn, url), "experience:acme:bullet:1", "Cut latency.", now),
     )
     record_job_event(conn, url, "tailor", "PdfRendered")
     conn.commit()
@@ -515,20 +525,21 @@ def _record_material_metadata(
     conn.execute(
         """
         INSERT INTO job_materials (
-            job_url, generation, tenant_id, status, created_at, updated_at, metadata_json
-        ) VALUES (?, 1, 'local', 'resume_approved', ?, ?, '{}')
+            tenant_id, job_id, generation, status, created_at, updated_at, metadata_json
+        ) VALUES ('local', ?, 1, 'resume_approved', ?, ?, '{}')
         """,
-        (url, utc_now(), utc_now()),
+        (_job_id(conn, url), utc_now(), utc_now()),
     )
     conn.execute(
         """
         INSERT INTO job_materials_artifacts (
-            job_url, generation, artifact_type, artifact_id, status, path,
-            render_format, size_bytes, metadata_json, created_at
-        ) VALUES (?, 1, 'tailored_resume', ?, 'approved', ?, 'text', 12, ?, ?)
+            tenant_id, job_id, generation, artifact_type, artifact_id,
+            status, path, render_format, size_bytes, metadata_json, created_at
+        ) VALUES ('local', ?, 1, 'tailored_resume', ?, 'approved', ?,
+                  'text', 12, ?, ?)
         """,
         (
-            url,
+            _job_id(conn, url),
             f"resume-{url}",
             f"/tmp/{url.rsplit('/', 1)[-1]}.txt",
             json.dumps(metadata),
@@ -541,11 +552,11 @@ def _record_replacement_material_metadata(conn: sqlite3.Connection, url: str) ->
     conn.execute(
         """
         INSERT INTO job_materials (
-            job_url, generation, tenant_id, status, created_at, updated_at, metadata_json
-        ) VALUES (?, 2, 'local', 'resume_approved', ?, ?, ?)
+            tenant_id, job_id, generation, status, created_at, updated_at, metadata_json
+        ) VALUES ('local', ?, 2, 'resume_approved', ?, ?, ?)
         """,
         (
-            url,
+            _job_id(conn, url),
             utc_now(),
             utc_now(),
             json.dumps({"source": "resume_review_draft", "base_generation": 1}),
@@ -554,12 +565,13 @@ def _record_replacement_material_metadata(conn: sqlite3.Connection, url: str) ->
     conn.execute(
         """
         INSERT INTO job_materials_artifacts (
-            job_url, generation, artifact_type, artifact_id, status, path,
-            render_format, size_bytes, metadata_json, created_at
-        ) VALUES (?, 2, 'tailored_resume', ?, 'approved', ?, 'text', 12, ?, ?)
+            tenant_id, job_id, generation, artifact_type, artifact_id,
+            status, path, render_format, size_bytes, metadata_json, created_at
+        ) VALUES ('local', ?, 2, 'tailored_resume', ?, 'approved', ?,
+                  'text', 12, ?, ?)
         """,
         (
-            url,
+            _job_id(conn, url),
             f"replacement-{url}",
             f"/tmp/{url.rsplit('/', 1)[-1]}-replacement.txt",
             json.dumps(
@@ -804,8 +816,11 @@ def test_outcome_conversion_uses_artifact_metadata_without_parent_material_table
             template_name="Compatibility resume",
             policy_version=7,
         )
+    conn.commit()
+    conn.execute("PRAGMA foreign_keys = OFF")
     conn.execute("DROP TABLE job_materials")
     conn.commit()
+    conn.execute("PRAGMA foreign_keys = ON")
 
     ProjectionBuilder(conn_factory=lambda: conn).refresh()
     row = _dashboard(conn)

--- a/workers/automation/tests/test_discovery_identity_reference_migration.py
+++ b/workers/automation/tests/test_discovery_identity_reference_migration.py
@@ -220,7 +220,7 @@ def test_v7_discovery_references_migrate_to_stable_job_id_and_reopen(
     init_db(db_path)
     close_connection(db_path)
 
-    assert _user_version(db_path) == SCHEMA_VERSION == 14
+    assert _user_version(db_path) == SCHEMA_VERSION == 15
     assert "job_id" in _columns(db_path, "job_source_observations")
     assert "job_url" not in _columns(db_path, "job_source_observations")
     assert "job_id" in _columns(db_path, "job_canonical_identities")

--- a/workers/automation/tests/test_enrichment_snapshot_identity_reference_migration.py
+++ b/workers/automation/tests/test_enrichment_snapshot_identity_reference_migration.py
@@ -322,7 +322,7 @@ def test_v10_enrichment_snapshot_references_migrate_and_reopen(
     init_db(db_path)
     close_connection(db_path)
 
-    assert _user_version(db_path) == SCHEMA_VERSION == 14
+    assert _user_version(db_path) == SCHEMA_VERSION == 15
     check = sqlite3.connect(db_path)
     try:
         enrichment_rows = check.execute(

--- a/workers/automation/tests/test_execution_search_identity_reference_migration.py
+++ b/workers/automation/tests/test_execution_search_identity_reference_migration.py
@@ -261,7 +261,7 @@ def test_v8_execution_and_receipts_migrate_to_stable_job_id_and_reopen(
     init_db(db_path)
     close_connection(db_path)
 
-    assert _user_version(db_path) == SCHEMA_VERSION == 14
+    assert _user_version(db_path) == SCHEMA_VERSION == 15
     assert "job_id" in _columns(db_path, "discovery_execution_jobs")
     assert "job_url" not in _columns(db_path, "discovery_execution_jobs")
     assert "job_id" in _columns(db_path, "discovery_search_unit_jobs")

--- a/workers/automation/tests/test_jsonrpc_handlers.py
+++ b/workers/automation/tests/test_jsonrpc_handlers.py
@@ -1192,7 +1192,12 @@ def test_retailor_job_duplicate_dispatch_uses_existing_workflow_without_duplicat
     _seed_tailoring_policy(conn, version=3)
     _seed_tailored_artifact(conn, job_url, policy_version=3)
     before = conn.execute(
-        "SELECT COUNT(*), COUNT(DISTINCT artifact_id) FROM job_materials_artifacts WHERE job_url = ?",
+        """
+        SELECT COUNT(*), COUNT(DISTINCT artifact_id)
+        FROM job_materials_artifacts
+        WHERE tenant_id = 'local'
+          AND job_id = (SELECT job_id FROM jobs WHERE url = ?)
+        """,
         (job_url,),
     ).fetchone()
     seen: list[WorkflowStartSpec] = []
@@ -1227,7 +1232,12 @@ def test_retailor_job_duplicate_dispatch_uses_existing_workflow_without_duplicat
     assert seen[0].id_conflict_policy is WorkflowIDConflictPolicy.USE_EXISTING
     assert seen[1].id_conflict_policy is WorkflowIDConflictPolicy.USE_EXISTING
     after = conn.execute(
-        "SELECT COUNT(*), COUNT(DISTINCT artifact_id) FROM job_materials_artifacts WHERE job_url = ?",
+        """
+        SELECT COUNT(*), COUNT(DISTINCT artifact_id)
+        FROM job_materials_artifacts
+        WHERE tenant_id = 'local'
+          AND job_id = (SELECT job_id FROM jobs WHERE url = ?)
+        """,
         (job_url,),
     ).fetchone()
     assert tuple(before) == (1, 1)
@@ -1742,8 +1752,10 @@ def _seed_tailored_artifact(conn, url: str, *, policy_version: int) -> None:
     conn.execute(
         """
         INSERT INTO job_materials (
-            job_url, generation, tenant_id, status, created_at, updated_at, metadata_json
-        ) VALUES (?, 1, 'local', 'resume_approved',
+            tenant_id, job_id, generation, status, created_at, updated_at, metadata_json
+        ) VALUES ('local',
+            (SELECT job_id FROM jobs WHERE tenant_id = 'local' AND url = ?),
+            1, 'resume_approved',
             '2026-05-26T10:00:00+00:00', '2026-05-26T10:00:00+00:00', '{}')
         """,
         (url,),
@@ -1751,9 +1763,12 @@ def _seed_tailored_artifact(conn, url: str, *, policy_version: int) -> None:
     conn.execute(
         """
         INSERT INTO job_materials_artifacts (
-            job_url, generation, artifact_type, artifact_id, status, path,
-            render_format, size_bytes, metadata_json, created_at, superseded_at
-        ) VALUES (?, 1, 'tailored_resume', ?, 'approved', ?, 'text', 12, ?,
+            tenant_id, job_id, generation, artifact_type, artifact_id,
+            status, path, render_format, size_bytes, metadata_json,
+            created_at, superseded_at
+        ) VALUES ('local',
+            (SELECT job_id FROM jobs WHERE tenant_id = 'local' AND url = ?),
+            1, 'tailored_resume', ?, 'approved', ?, 'text', 12, ?,
             '2026-05-26T10:00:00+00:00', NULL)
         """,
         (

--- a/workers/automation/tests/test_materials_identity_reference_migration.py
+++ b/workers/automation/tests/test_materials_identity_reference_migration.py
@@ -1,0 +1,525 @@
+"""Schema-v15 generated-material identity migration contracts."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import uuid
+from pathlib import Path
+
+import pytest
+
+import jobctrl.database as database_module
+from jobctrl.database import (
+    SCHEMA_VERSION,
+    _reassign_materials_references_v15,
+    close_connection,
+    ensure_materials_references_v15,
+    init_db,
+)
+from jobctrl.domain.discovery import (
+    Employer,
+    Job,
+    JobMetadata,
+    PostingUrl,
+    SearchStrategy,
+    Source,
+)
+from jobctrl.domain.identifiers import JobId
+from jobctrl.domain.tenant import LOCAL_TENANT
+from jobctrl.infrastructure.discovery import SqliteJobRepository
+
+
+PREVIOUS_SCHEMA_VERSION = 14
+
+
+def _discovered_job(posting_url: str, job_id: JobId) -> Job:
+    return Job.discover(
+        tenant_id=LOCAL_TENANT,
+        job_id=job_id,
+        posting_url=PostingUrl(value=posting_url),
+        source=Source(board="example"),
+        employer=Employer(name="Example"),
+        search_strategy=SearchStrategy.JOBSPY,
+        metadata=JobMetadata(title="Platform Engineer"),
+        discovered_at="2026-07-29T10:00:00+00:00",
+    )
+
+
+def _downgrade_material_references_to_v14(
+    conn: sqlite3.Connection,
+) -> None:
+    for table in (
+        "job_bullet_provenance",
+        "job_material_layout_boxes",
+        "job_materials_artifacts",
+        "job_materials",
+    ):
+        conn.execute(f'DROP TABLE "{table}"')
+    conn.executescript(
+        """
+        CREATE TABLE job_materials (
+            job_url             TEXT NOT NULL,
+            generation          INTEGER NOT NULL,
+            tenant_id           TEXT NOT NULL DEFAULT 'local',
+            status              TEXT NOT NULL,
+            created_at          TEXT NOT NULL,
+            updated_at          TEXT NOT NULL,
+            last_validation_json TEXT,
+            last_verdict_json    TEXT,
+            metadata_json       TEXT,
+            PRIMARY KEY (job_url, generation),
+            FOREIGN KEY (job_url) REFERENCES jobs(url) ON DELETE CASCADE
+        );
+        CREATE TABLE job_materials_artifacts (
+            job_url             TEXT NOT NULL,
+            generation          INTEGER NOT NULL,
+            artifact_type       TEXT NOT NULL,
+            artifact_id         TEXT NOT NULL,
+            status              TEXT NOT NULL,
+            path                TEXT NOT NULL,
+            render_format       TEXT NOT NULL,
+            size_bytes          INTEGER,
+            metadata_json       TEXT,
+            created_at          TEXT NOT NULL,
+            superseded_at       TEXT,
+            PRIMARY KEY (job_url, generation, artifact_type),
+            FOREIGN KEY (job_url, generation)
+                REFERENCES job_materials(job_url, generation) ON DELETE CASCADE
+        );
+        CREATE TABLE job_material_layout_boxes (
+            job_url             TEXT NOT NULL,
+            generation          INTEGER NOT NULL,
+            artifact_id         TEXT NOT NULL,
+            box_index           INTEGER NOT NULL,
+            tenant_id           TEXT NOT NULL DEFAULT 'local',
+            semantic_id         TEXT NOT NULL,
+            page_number         INTEGER NOT NULL,
+            line_number         INTEGER,
+            text_excerpt        TEXT NOT NULL,
+            left_pct            REAL NOT NULL,
+            top_pct             REAL NOT NULL,
+            width_pct           REAL NOT NULL,
+            height_pct          REAL NOT NULL,
+            audit_target_json   TEXT NOT NULL DEFAULT '{}',
+            created_at          TEXT NOT NULL,
+            PRIMARY KEY (job_url, generation, artifact_id, box_index),
+            FOREIGN KEY (job_url, generation)
+                REFERENCES job_materials(job_url, generation) ON DELETE CASCADE
+        );
+        CREATE TABLE job_bullet_provenance (
+            job_url                 TEXT NOT NULL,
+            generation              INTEGER NOT NULL,
+            bullet_id               TEXT NOT NULL,
+            tenant_id               TEXT NOT NULL DEFAULT 'local',
+            artifact_id             TEXT NOT NULL,
+            section                 TEXT NOT NULL,
+            source_id               TEXT,
+            evidence_ids_json       TEXT NOT NULL DEFAULT '[]',
+            requirement_ids_json    TEXT NOT NULL DEFAULT '[]',
+            matched_keywords_json   TEXT NOT NULL DEFAULT '[]',
+            transform_type          TEXT NOT NULL,
+            control                 TEXT NOT NULL,
+            rationale               TEXT NOT NULL DEFAULT '',
+            generated_text          TEXT NOT NULL,
+            position                INTEGER NOT NULL DEFAULT 0,
+            created_at              TEXT NOT NULL,
+            coverage_json           TEXT,
+            voice_json              TEXT,
+            PRIMARY KEY (job_url, generation, bullet_id),
+            FOREIGN KEY (job_url, generation)
+                REFERENCES job_materials(job_url, generation) ON DELETE CASCADE
+        );
+        CREATE INDEX idx_job_materials_tenant_job_gen
+            ON job_materials(tenant_id, job_url, generation DESC);
+        CREATE INDEX idx_job_materials_artifacts_status
+            ON job_materials_artifacts(artifact_type, status, created_at DESC);
+        CREATE INDEX idx_job_material_layout_boxes_artifact
+            ON job_material_layout_boxes(
+                tenant_id, artifact_id, page_number, box_index
+            );
+        CREATE INDEX idx_job_bullet_provenance_tenant_job_gen
+            ON job_bullet_provenance(
+                tenant_id, job_url, generation DESC
+            );
+        CREATE INDEX idx_job_bullet_provenance_artifact
+            ON job_bullet_provenance(tenant_id, artifact_id);
+        """
+    )
+    conn.execute(f"PRAGMA user_version = {PREVIOUS_SCHEMA_VERSION}")
+    conn.commit()
+
+
+def _insert_legacy_generation(
+    conn: sqlite3.Connection,
+    *,
+    job_url: str,
+    generation: int,
+    artifact_id: str,
+    created_at: str,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO job_materials (
+            job_url, generation, tenant_id, status, created_at, updated_at,
+            last_validation_json, last_verdict_json, metadata_json
+        ) VALUES (?, ?, 'local', 'resume_approved', ?, ?, '{}', '{}', ?)
+        """,
+        (
+            job_url,
+            generation,
+            created_at,
+            created_at,
+            json.dumps({"source_artifact": artifact_id}, sort_keys=True),
+        ),
+    )
+    conn.execute(
+        """
+        INSERT INTO job_materials_artifacts (
+            job_url, generation, artifact_type, artifact_id, status, path,
+            render_format, size_bytes, metadata_json, created_at, superseded_at
+        ) VALUES (?, ?, 'tailored_resume', ?, 'approved', ?, 'text', 10,
+                  '{}', ?, NULL)
+        """,
+        (
+            job_url,
+            generation,
+            artifact_id,
+            f"/tmp/{artifact_id}.txt",
+            created_at,
+        ),
+    )
+    conn.execute(
+        """
+        INSERT INTO job_material_layout_boxes (
+            job_url, generation, artifact_id, box_index, tenant_id,
+            semantic_id, page_number, line_number, text_excerpt,
+            left_pct, top_pct, width_pct, height_pct, audit_target_json,
+            created_at
+        ) VALUES (?, ?, ?, 0, 'local', ?, 1, 1, ?, 1, 2, 3, 4, '{}', ?)
+        """,
+        (
+            job_url,
+            generation,
+            artifact_id,
+            f"box:{artifact_id}",
+            artifact_id,
+            created_at,
+        ),
+    )
+    conn.execute(
+        """
+        INSERT INTO job_bullet_provenance (
+            job_url, generation, bullet_id, tenant_id, artifact_id, section,
+            source_id, evidence_ids_json, requirement_ids_json,
+            matched_keywords_json, transform_type, control, rationale,
+            generated_text, position, created_at, coverage_json, voice_json
+        ) VALUES (?, ?, ?, 'local', ?, 'experience', NULL, '[]', '[]', '[]',
+                  'unchanged', 'preserve', '', ?, 0, ?, '{}', '{}')
+        """,
+        (
+            job_url,
+            generation,
+            f"bullet:{artifact_id}",
+            artifact_id,
+            artifact_id,
+            created_at,
+        ),
+    )
+
+
+def _columns(conn: sqlite3.Connection, table_name: str) -> set[str]:
+    return {
+        str(row[1])
+        for row in conn.execute(
+            f'PRAGMA table_info("{table_name}")'
+        ).fetchall()
+    }
+
+
+def test_v14_materials_migrate_alias_histories_and_uuid_shaped_urls(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    conn = init_db(db_path)
+    jobs = SqliteJobRepository(conn)
+
+    stable_job_id = JobId(str(uuid.uuid4()))
+    original_url = "https://boards.example/jobs/123"
+    current_url = "https://careers.example/jobs/platform-engineer"
+    jobs.save(_discovered_job(original_url, stable_job_id))
+    jobs.save(_discovered_job(current_url, stable_job_id))
+
+    uuid_shaped_url = str(uuid.uuid4())
+    uuid_url_owner = JobId(str(uuid.uuid4()))
+    jobs.save(_discovered_job(uuid_shaped_url, uuid_url_owner))
+    jobs.save(
+        _discovered_job(
+            "https://example.com/jobs/id-text-collision",
+            JobId(uuid_shaped_url),
+        )
+    )
+
+    _downgrade_material_references_to_v14(conn)
+    _insert_legacy_generation(
+        conn,
+        job_url=original_url,
+        generation=1,
+        artifact_id="original-1",
+        created_at="2026-07-29T10:00:00+00:00",
+    )
+    _insert_legacy_generation(
+        conn,
+        job_url=current_url,
+        generation=1,
+        artifact_id="current-1",
+        created_at="2026-07-29T10:01:00+00:00",
+    )
+    _insert_legacy_generation(
+        conn,
+        job_url=original_url,
+        generation=2,
+        artifact_id="original-2",
+        created_at="2026-07-29T10:02:00+00:00",
+    )
+    _insert_legacy_generation(
+        conn,
+        job_url=uuid_shaped_url,
+        generation=1,
+        artifact_id="uuid-url-owner",
+        created_at="2026-07-29T10:03:00+00:00",
+    )
+    conn.commit()
+    close_connection(db_path)
+
+    reopened = init_db(db_path)
+    assert reopened.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_VERSION == 15
+    for table in database_module._MATERIALS_REFERENCE_TABLES:
+        assert "job_id" in _columns(reopened, table)
+        assert "job_url" not in _columns(reopened, table)
+        assert reopened.execute(f'SELECT COUNT(*) FROM "{table}"').fetchone()[0] == 4
+
+    merged = reopened.execute(
+        """
+        SELECT generation, artifact_id
+        FROM job_materials_artifacts
+        WHERE tenant_id = 'local' AND job_id = ?
+        ORDER BY generation
+        """,
+        (str(stable_job_id),),
+    ).fetchall()
+    assert [tuple(row) for row in merged] == [
+        (1, "original-1"),
+        (2, "current-1"),
+        (3, "original-2"),
+    ]
+    assert reopened.execute(
+        """
+        SELECT job_id
+        FROM job_materials_artifacts
+        WHERE artifact_id = 'uuid-url-owner'
+        """
+    ).fetchone()[0] == str(uuid_url_owner)
+    assert reopened.execute("PRAGMA foreign_key_check").fetchone() is None
+    close_connection(db_path)
+
+    reopened_again = init_db(db_path)
+    assert reopened_again.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_VERSION
+    assert reopened_again.execute(
+        "SELECT COUNT(*) FROM job_materials_artifacts"
+    ).fetchone()[0] == 4
+    close_connection(db_path)
+
+
+def test_v15_materials_migration_rolls_back_and_retries(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    conn = init_db(db_path)
+    job_id = JobId(str(uuid.uuid4()))
+    job_url = "https://example.com/jobs/retry"
+    SqliteJobRepository(conn).save(_discovered_job(job_url, job_id))
+    _downgrade_material_references_to_v14(conn)
+    _insert_legacy_generation(
+        conn,
+        job_url=job_url,
+        generation=1,
+        artifact_id="retry",
+        created_at="2026-07-29T10:00:00+00:00",
+    )
+    conn.commit()
+
+    original_verify = database_module._verify_materials_references_v15
+
+    def _fail_verification(
+        _conn: sqlite3.Connection,
+        *,
+        expected_counts: dict[str, int],
+    ) -> None:
+        del expected_counts
+        raise RuntimeError("injected materials verification failure")
+
+    monkeypatch.setattr(
+        database_module,
+        "_verify_materials_references_v15",
+        _fail_verification,
+    )
+    with pytest.raises(
+        RuntimeError,
+        match="injected materials verification failure",
+    ):
+        ensure_materials_references_v15(conn)
+    assert conn.execute("PRAGMA user_version").fetchone()[0] == 14
+    assert "job_url" in _columns(conn, "job_materials")
+    assert conn.execute("SELECT COUNT(*) FROM job_materials").fetchone()[0] == 1
+
+    monkeypatch.setattr(
+        database_module,
+        "_verify_materials_references_v15",
+        original_verify,
+    )
+    assert ensure_materials_references_v15(conn) == list(
+        database_module._MATERIALS_REFERENCE_TABLES
+    )
+    assert conn.execute("PRAGMA user_version").fetchone()[0] == 15
+    assert "job_id" in _columns(conn, "job_materials")
+    assert conn.execute("PRAGMA foreign_key_check").fetchone() is None
+    close_connection(db_path)
+
+
+def test_runtime_material_identity_merge_preserves_all_histories(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    conn = init_db(db_path)
+    jobs = SqliteJobRepository(conn)
+    losing_id = JobId(str(uuid.uuid4()))
+    surviving_id = JobId(str(uuid.uuid4()))
+    jobs.save(
+        _discovered_job(
+            "https://example.com/jobs/losing",
+            losing_id,
+        )
+    )
+    jobs.save(
+        _discovered_job(
+            "https://example.com/jobs/surviving",
+            surviving_id,
+        )
+    )
+
+    def _insert_stable(
+        *,
+        job_id: JobId,
+        generation: int,
+        artifact_id: str,
+        created_at: str,
+    ) -> None:
+        conn.execute(
+            """
+            INSERT INTO job_materials (
+                tenant_id, job_id, generation, status, created_at, updated_at
+            ) VALUES ('local', ?, ?, 'resume_approved', ?, ?)
+            """,
+            (str(job_id), generation, created_at, created_at),
+        )
+        conn.execute(
+            """
+            INSERT INTO job_materials_artifacts (
+                tenant_id, job_id, generation, artifact_type, artifact_id,
+                status, path, render_format, created_at
+            ) VALUES ('local', ?, ?, 'tailored_resume', ?, 'approved', ?,
+                      'text', ?)
+            """,
+            (
+                str(job_id),
+                generation,
+                artifact_id,
+                f"/tmp/{artifact_id}.txt",
+                created_at,
+            ),
+        )
+        conn.execute(
+            """
+            INSERT INTO job_material_layout_boxes (
+                tenant_id, job_id, generation, artifact_id, box_index,
+                semantic_id, page_number, text_excerpt, left_pct, top_pct,
+                width_pct, height_pct, created_at
+            ) VALUES ('local', ?, ?, ?, 0, ?, 1, ?, 1, 2, 3, 4, ?)
+            """,
+            (
+                str(job_id),
+                generation,
+                artifact_id,
+                artifact_id,
+                artifact_id,
+                created_at,
+            ),
+        )
+        conn.execute(
+            """
+            INSERT INTO job_bullet_provenance (
+                tenant_id, job_id, generation, bullet_id, artifact_id,
+                section, transform_type, control, generated_text, created_at
+            ) VALUES ('local', ?, ?, ?, ?, 'experience', 'unchanged',
+                      'preserve', ?, ?)
+            """,
+            (
+                str(job_id),
+                generation,
+                f"bullet:{artifact_id}",
+                artifact_id,
+                artifact_id,
+                created_at,
+            ),
+        )
+
+    _insert_stable(
+        job_id=losing_id,
+        generation=1,
+        artifact_id="losing-1",
+        created_at="2026-07-29T10:00:00+00:00",
+    )
+    _insert_stable(
+        job_id=surviving_id,
+        generation=1,
+        artifact_id="surviving-1",
+        created_at="2026-07-29T10:01:00+00:00",
+    )
+    _insert_stable(
+        job_id=losing_id,
+        generation=2,
+        artifact_id="losing-2",
+        created_at="2026-07-29T10:02:00+00:00",
+    )
+    conn.commit()
+
+    _reassign_materials_references_v15(
+        conn,
+        tenant_id="local",
+        losing_job_id=str(losing_id),
+        surviving_job_id=str(surviving_id),
+    )
+    for table in database_module._MATERIALS_REFERENCE_TABLES:
+        assert conn.execute(f'SELECT COUNT(*) FROM "{table}"').fetchone()[0] == 3
+        assert {
+            row[0]
+            for row in conn.execute(
+                f'SELECT DISTINCT job_id FROM "{table}"'
+            ).fetchall()
+        } == {str(surviving_id)}
+    artifacts = conn.execute(
+        """
+        SELECT generation, artifact_id
+        FROM job_materials_artifacts
+        ORDER BY generation
+        """
+    ).fetchall()
+    assert [tuple(row) for row in artifacts] == [
+        (1, "losing-1"),
+        (2, "surviving-1"),
+        (3, "losing-2"),
+    ]
+    assert conn.execute("PRAGMA foreign_key_check").fetchone() is None
+    close_connection(db_path)

--- a/workers/automation/tests/test_materials_queue_selectors.py
+++ b/workers/automation/tests/test_materials_queue_selectors.py
@@ -45,6 +45,15 @@ def _seed_job(conn: sqlite3.Connection, url: str, fit_score: int = 9) -> str:
     return url
 
 
+def _stable_job_id(conn: sqlite3.Connection, url: str) -> str:
+    row = conn.execute(
+        "SELECT job_id FROM jobs WHERE tenant_id = 'local' AND url = ?",
+        (url,),
+    ).fetchone()
+    assert row is not None
+    return str(row[0])
+
+
 def _make_resume_artifact(path: str = "/tmp/r.txt") -> Artifact:
     return Artifact.create(
         type=ArtifactType.TAILORED_RESUME,
@@ -542,8 +551,11 @@ def test_reset_tailor_clears_rejected_attempt_artifacts(
 
     # Materials artifacts for the latest generation must be gone.
     artifact_count = conn.execute(
-        "SELECT COUNT(*) FROM job_materials_artifacts WHERE job_url = ?",
-        (url,),
+        """
+        SELECT COUNT(*) FROM job_materials_artifacts
+        WHERE tenant_id = 'local' AND job_id = ?
+        """,
+        (_stable_job_id(conn, url),),
     ).fetchone()[0]
     assert artifact_count == 0
 
@@ -575,8 +587,11 @@ def test_reset_tailor_preserves_approved_materials_until_replacement(
     pending_after = {row["url"] for row in get_jobs_by_stage(conn=conn, stage="pending_tailor", min_score=7)}
     assert url not in pending_after
     artifact_count = conn.execute(
-        "SELECT COUNT(*) FROM job_materials_artifacts WHERE job_url = ?",
-        (url,),
+        """
+        SELECT COUNT(*) FROM job_materials_artifacts
+        WHERE tenant_id = 'local' AND job_id = ?
+        """,
+        (_stable_job_id(conn, url),),
     ).fetchone()[0]
     assert artifact_count == 1
 
@@ -607,8 +622,11 @@ def test_reset_cover_clears_only_failed_cover_artifacts(conn: sqlite3.Connection
     reset_job_stage(conn, url, "cover")
 
     rows = conn.execute(
-        "SELECT artifact_type FROM job_materials_artifacts WHERE job_url = ?",
-        (url,),
+        """
+        SELECT artifact_type FROM job_materials_artifacts
+        WHERE tenant_id = 'local' AND job_id = ?
+        """,
+        (_stable_job_id(conn, url),),
     ).fetchall()
     types = {row[0] for row in rows}
     assert "tailored_resume" in types
@@ -643,8 +661,11 @@ def test_reset_cover_preserves_approved_cover_until_replacement(
     reset_job_stage(conn, url, "cover")
 
     rows = conn.execute(
-        "SELECT artifact_type FROM job_materials_artifacts WHERE job_url = ?",
-        (url,),
+        """
+        SELECT artifact_type FROM job_materials_artifacts
+        WHERE tenant_id = 'local' AND job_id = ?
+        """,
+        (_stable_job_id(conn, url),),
     ).fetchall()
     types = {row[0] for row in rows}
     assert "tailored_resume" in types

--- a/workers/automation/tests/test_materials_repository.py
+++ b/workers/automation/tests/test_materials_repository.py
@@ -66,6 +66,15 @@ def _seed_job(conn: sqlite3.Connection, url: str = "https://example.com/job/1") 
     return url
 
 
+def _stable_job_id(conn: sqlite3.Connection, url: str) -> JobId:
+    row = conn.execute(
+        "SELECT job_id FROM jobs WHERE tenant_id = 'local' AND url = ?",
+        (url,),
+    ).fetchone()
+    assert row is not None
+    return JobId(str(row[0]))
+
+
 def _make_artifact(
     artifact_type: ArtifactType,
     *,
@@ -277,7 +286,7 @@ def test_approved_cover_refresh_supersedes_stale_pdf_and_projects_pending_pdf(
     assert loaded.cover_letter_pdf is not None
     assert loaded.cover_letter_pdf.status is ArtifactStatus.SUPERSEDED
     assert loaded.status == "cover_letter_ready"
-    assert repo.list_pending_pdf(LOCAL_TENANT) == [JobId(url)]
+    assert repo.list_pending_pdf(LOCAL_TENANT) == [_stable_job_id(conn, url)]
     pending_pdf = get_jobs_by_stage(conn, stage="pending_pdf", limit=0)
     assert [row["url"] for row in pending_pdf] == [url]
     assert pending_pdf[0]["cover_letter_path"] == str(new_cover_path)
@@ -398,9 +407,9 @@ def test_save_persists_resume_layout_boxes_outside_artifact_metadata(
         """
         SELECT metadata_json
         FROM job_materials_artifacts
-        WHERE job_url = ? AND artifact_id = ?
+        WHERE tenant_id = 'local' AND job_id = ? AND artifact_id = ?
         """,
-        (url, pdf.artifact_id),
+        (str(_stable_job_id(conn, url)), pdf.artifact_id),
     ).fetchone()
     assert artifact_row is not None
     assert json.loads(artifact_row["metadata_json"]) == {"layout_source": "html_resume_dom"}
@@ -410,9 +419,9 @@ def test_save_persists_resume_layout_boxes_outside_artifact_metadata(
         SELECT semantic_id, page_number, line_number, text_excerpt,
                left_pct, top_pct, width_pct, height_pct, audit_target_json
         FROM job_material_layout_boxes
-        WHERE job_url = ? AND artifact_id = ?
+        WHERE tenant_id = 'local' AND job_id = ? AND artifact_id = ?
         """,
-        (url, pdf.artifact_id),
+        (str(_stable_job_id(conn, url)), pdf.artifact_id),
     ).fetchall()
     assert len(rows) == 1
     row = rows[0]
@@ -446,25 +455,26 @@ def test_loads_resume_review_promoted_generation_without_deleting_prior_material
     edited_resume.write_text("edited resume", encoding="utf-8")
     edited_pdf.write_text("%PDF edited", encoding="utf-8")
     now = "2026-06-24T10:00:00+00:00"
+    stable_job_id = str(_stable_job_id(conn, url))
 
     conn.execute(
         """
         INSERT INTO job_materials (
-            job_url, generation, tenant_id, status, created_at, updated_at,
+            tenant_id, job_id, generation, status, created_at, updated_at,
             last_validation_json, last_verdict_json, metadata_json
-        ) VALUES (?, 1, 'local', 'resume_approved', ?, ?, '{}', '{}', '{}')
+        ) VALUES ('local', ?, 1, 'resume_approved', ?, ?, '{}', '{}', '{}')
         """,
-        (url, now, now),
+        (stable_job_id, now, now),
     )
     conn.execute(
         """
         INSERT INTO job_materials (
-            job_url, generation, tenant_id, status, created_at, updated_at,
+            tenant_id, job_id, generation, status, created_at, updated_at,
             last_validation_json, last_verdict_json, metadata_json
-        ) VALUES (?, 2, 'local', 'resume_approved', ?, ?, ?, ?, ?)
+        ) VALUES ('local', ?, 2, 'resume_approved', ?, ?, ?, ?, ?)
         """,
         (
-            url,
+            stable_job_id,
             now,
             now,
             json.dumps({"passed": True, "errors": [], "warnings": []}),
@@ -482,13 +492,13 @@ def test_loads_resume_review_promoted_generation_without_deleting_prior_material
     conn.executemany(
         """
         INSERT INTO job_materials_artifacts (
-            job_url, generation, artifact_type, artifact_id, status, path,
+            tenant_id, job_id, generation, artifact_type, artifact_id, status, path,
             render_format, size_bytes, metadata_json, created_at, superseded_at
-        ) VALUES (?, ?, ?, ?, 'approved', ?, ?, ?, ?, ?, NULL)
+        ) VALUES ('local', ?, ?, ?, ?, 'approved', ?, ?, ?, ?, ?, NULL)
         """,
         [
             (
-                url,
+                stable_job_id,
                 1,
                 "tailored_resume",
                 "base-resume",
@@ -499,7 +509,7 @@ def test_loads_resume_review_promoted_generation_without_deleting_prior_material
                 now,
             ),
             (
-                url,
+                stable_job_id,
                 1,
                 "resume_pdf",
                 "base-pdf",
@@ -510,7 +520,7 @@ def test_loads_resume_review_promoted_generation_without_deleting_prior_material
                 now,
             ),
             (
-                url,
+                stable_job_id,
                 2,
                 "tailored_resume",
                 "edited-resume",
@@ -521,7 +531,7 @@ def test_loads_resume_review_promoted_generation_without_deleting_prior_material
                 now,
             ),
             (
-                url,
+                stable_job_id,
                 2,
                 "resume_pdf",
                 "edited-pdf",
@@ -542,14 +552,14 @@ def test_loads_resume_review_promoted_generation_without_deleting_prior_material
     conn.execute(
         """
         INSERT INTO job_material_layout_boxes (
-            job_url, generation, artifact_id, box_index, tenant_id,
+            tenant_id, job_id, generation, artifact_id, box_index,
             semantic_id, page_number, line_number, text_excerpt,
             left_pct, top_pct, width_pct, height_pct, audit_target_json, created_at
-        ) VALUES (?, 2, 'edited-pdf', 0, 'local',
+        ) VALUES ('local', ?, 2, 'edited-pdf', 0,
                   'edited:line:1', 1, 1, 'edited resume',
                   10, 8, 80, 1.7, '{}', ?)
         """,
-        (url, now),
+        (stable_job_id, now),
     )
     conn.commit()
 
@@ -567,19 +577,20 @@ def test_loads_resume_review_promoted_generation_without_deleting_prior_material
         """
         SELECT status
         FROM job_materials_artifacts
-        WHERE job_url = ? AND generation = 1
+        WHERE tenant_id = 'local' AND job_id = ? AND generation = 1
         ORDER BY artifact_type
         """,
-        (url,),
+        (stable_job_id,),
     ).fetchall()
     assert [row["status"] for row in prior_statuses] == ["approved", "approved"]
     box = conn.execute(
         """
         SELECT semantic_id, line_number, text_excerpt
         FROM job_material_layout_boxes
-        WHERE job_url = ? AND generation = 2 AND artifact_id = 'edited-pdf'
+        WHERE tenant_id = 'local' AND job_id = ?
+          AND generation = 2 AND artifact_id = 'edited-pdf'
         """,
-        (url,),
+        (stable_job_id,),
     ).fetchone()
     assert dict(box) == {
         "semantic_id": "edited:line:1",
@@ -641,7 +652,7 @@ def test_list_pending_tailor_returns_jobs_without_materials(conn: sqlite3.Connec
     repo.save(_approved(url_done))
 
     pending = repo.list_pending_tailor(LOCAL_TENANT, min_score=7)
-    assert pending == [JobId(url_pending)]
+    assert pending == [_stable_job_id(conn, url_pending)]
 
 
 def test_list_pending_tailor_excludes_score_five_by_default(conn: sqlite3.Connection) -> None:
@@ -651,8 +662,8 @@ def test_list_pending_tailor_excludes_score_five_by_default(conn: sqlite3.Connec
 
     pending = repo.list_pending_tailor(LOCAL_TENANT, min_score=5)
 
-    assert JobId(url_low) not in pending
-    assert JobId(url_ok) in pending
+    assert _stable_job_id(conn, url_low) not in pending
+    assert _stable_job_id(conn, url_ok) in pending
 
 
 def test_list_pending_tailor_excludes_blocked_scores(conn: sqlite3.Connection) -> None:
@@ -663,8 +674,8 @@ def test_list_pending_tailor_excludes_blocked_scores(conn: sqlite3.Connection) -
 
     pending = repo.list_pending_tailor(LOCAL_TENANT, min_score=7)
 
-    assert JobId(url_allowed) in pending
-    assert JobId(url_blocked) not in pending
+    assert _stable_job_id(conn, url_allowed) in pending
+    assert _stable_job_id(conn, url_blocked) not in pending
 
 
 def test_list_pending_tailor_with_retailor_includes_already_done(conn: sqlite3.Connection) -> None:
@@ -673,7 +684,7 @@ def test_list_pending_tailor_with_retailor_includes_already_done(conn: sqlite3.C
     repo.save(_approved(url_done))
 
     retailor_pending = repo.list_pending_tailor(LOCAL_TENANT, min_score=7, retailor=True)
-    assert JobId(url_done) in retailor_pending
+    assert _stable_job_id(conn, url_done) in retailor_pending
 
 
 def test_list_pending_tailor_excludes_prior_approved_when_latest_generation_rejected(
@@ -686,7 +697,7 @@ def test_list_pending_tailor_excludes_prior_approved_when_latest_generation_reje
 
     pending = repo.list_pending_tailor(LOCAL_TENANT, min_score=7)
 
-    assert JobId(url_done) not in pending
+    assert _stable_job_id(conn, url_done) not in pending
 
 
 def test_list_pending_cover_returns_only_jobs_with_resume_no_cover(
@@ -706,7 +717,7 @@ def test_list_pending_cover_returns_only_jobs_with_resume_no_cover(
     repo.save(full)
 
     pending = repo.list_pending_cover(LOCAL_TENANT, min_score=7)
-    assert pending == [JobId(url_resume_only)]
+    assert pending == [_stable_job_id(conn, url_resume_only)]
 
 
 def test_list_pending_cover_uses_prior_approved_generation_when_latest_rejected(
@@ -719,7 +730,7 @@ def test_list_pending_cover_uses_prior_approved_generation_when_latest_rejected(
 
     pending = repo.list_pending_cover(LOCAL_TENANT, min_score=7)
 
-    assert pending == [JobId(url)]
+    assert pending == [_stable_job_id(conn, url)]
 
 
 def test_list_pending_cover_excludes_score_five_by_default(conn: sqlite3.Connection) -> None:
@@ -731,8 +742,8 @@ def test_list_pending_cover_excludes_score_five_by_default(conn: sqlite3.Connect
 
     pending = repo.list_pending_cover(LOCAL_TENANT, min_score=5)
 
-    assert JobId(url_low) not in pending
-    assert JobId(url_ok) in pending
+    assert _stable_job_id(conn, url_low) not in pending
+    assert _stable_job_id(conn, url_ok) in pending
 
 
 def test_list_pending_cover_excludes_blocked_scores(conn: sqlite3.Connection) -> None:
@@ -745,8 +756,8 @@ def test_list_pending_cover_excludes_blocked_scores(conn: sqlite3.Connection) ->
 
     pending = repo.list_pending_cover(LOCAL_TENANT, min_score=7)
 
-    assert JobId(url_allowed) in pending
-    assert JobId(url_blocked) not in pending
+    assert _stable_job_id(conn, url_allowed) in pending
+    assert _stable_job_id(conn, url_blocked) not in pending
 
 
 def test_list_pending_pdf_returns_jobs_missing_a_pdf(conn: sqlite3.Connection) -> None:
@@ -755,7 +766,7 @@ def test_list_pending_pdf_returns_jobs_missing_a_pdf(conn: sqlite3.Connection) -
     materials = _approved(url)
     repo.save(materials)
     pending = repo.list_pending_pdf(LOCAL_TENANT)
-    assert pending == [JobId(url)]
+    assert pending == [_stable_job_id(conn, url)]
 
 
 def test_list_by_status_returns_aggregates_with_matching_artifact_status(
@@ -766,7 +777,7 @@ def test_list_by_status_returns_aggregates_with_matching_artifact_status(
     repo.save(_approved(url))
     matches = repo.list_by_status(LOCAL_TENANT, ArtifactStatus.APPROVED)
     assert len(matches) == 1
-    assert str(matches[0].job_id) == url
+    assert matches[0].job_id == _stable_job_id(conn, url)
 
 
 def test_suppress_active_artifacts_hides_without_deleting_history(conn: sqlite3.Connection) -> None:
@@ -786,11 +797,16 @@ def test_suppress_active_artifacts_hides_without_deleting_history(conn: sqlite3.
     assert suppressed.tailored_resume.status is ArtifactStatus.SUPPRESSED
     assert suppressed.tailored_resume.metadata["suppression"]["reason"] == "threshold_raised"
     row_count = conn.execute(
-        "SELECT COUNT(*) FROM job_materials_artifacts WHERE job_url = ?",
-        (url,),
+        """
+        SELECT COUNT(*) FROM job_materials_artifacts
+        WHERE tenant_id = 'local' AND job_id = ?
+        """,
+        (str(_stable_job_id(conn, url)),),
     ).fetchone()[0]
     assert row_count == 2
-    assert repo.list_pending_tailor(LOCAL_TENANT, min_score=7) == [JobId(url)]
+    assert repo.list_pending_tailor(LOCAL_TENANT, min_score=7) == [
+        _stable_job_id(conn, url)
+    ]
 
 
 def test_suppress_backfilled_legacy_job_makes_selectors_treat_paths_inactive(
@@ -994,7 +1010,13 @@ def test_backfill_is_idempotent(tmp_path: Path) -> None:
     ensure_materials_tables(conn)  # second call is a no-op
 
     count = conn.execute(
-        "SELECT COUNT(*) FROM job_materials WHERE job_url = ?",
+        """
+        SELECT COUNT(*) FROM job_materials
+        WHERE tenant_id = 'local' AND job_id = (
+            SELECT job_id FROM jobs
+            WHERE tenant_id = 'local' AND url = ?
+        )
+        """,
         ("https://example.com/legacy",),
     ).fetchone()[0]
     assert count == 1

--- a/workers/automation/tests/test_preparation_identity_reference_migration.py
+++ b/workers/automation/tests/test_preparation_identity_reference_migration.py
@@ -177,7 +177,7 @@ def test_v9_preparation_references_migrate_to_stable_job_ids_and_reopen(
     init_db(db_path)
     close_connection(db_path)
 
-    assert _user_version(db_path) == SCHEMA_VERSION == 14
+    assert _user_version(db_path) == SCHEMA_VERSION == 15
     check = sqlite3.connect(db_path)
     try:
         rows = check.execute(

--- a/workers/automation/tests/test_projection_builder.py
+++ b/workers/automation/tests/test_projection_builder.py
@@ -41,6 +41,15 @@ def _seed_job(conn: sqlite3.Connection, url: str) -> None:
     conn.commit()
 
 
+def _stable_job_id(conn: sqlite3.Connection, url: str) -> str:
+    row = conn.execute(
+        "SELECT job_id FROM jobs WHERE tenant_id = 'local' AND url = ?",
+        (url,),
+    ).fetchone()
+    assert row is not None
+    return str(row[0])
+
+
 def test_initial_watermark_is_zero(conn: sqlite3.Connection) -> None:
     repo = SqliteEventWatermarkRepository(conn)
     assert repo.get(PROJECTION_NAME) == 0
@@ -104,6 +113,7 @@ def test_evidence_usage_projection_inverts_profile_provenance_and_requirement_fi
 ) -> None:
     job_url = "https://example.com/evidence-map"
     _seed_job(conn, job_url)
+    stable_job_id = _stable_job_id(conn, job_url)
     conn.execute(
         """
         INSERT INTO candidate_profile_experience_entries (
@@ -146,31 +156,31 @@ def test_evidence_usage_projection_inverts_profile_provenance_and_requirement_fi
     conn.execute(
         """
         INSERT INTO job_materials (
-            job_url, generation, tenant_id, status, created_at, updated_at
-        ) VALUES (?, 1, 'local', 'complete',
+            tenant_id, job_id, generation, status, created_at, updated_at
+        ) VALUES ('local', ?, 1, 'complete',
                   '2026-07-05T12:00:00Z', '2026-07-05T12:10:00Z')
         """,
-        (job_url,),
+        (stable_job_id,),
     )
     conn.execute(
         """
         INSERT INTO job_materials_artifacts (
-            job_url, generation, artifact_type, artifact_id, status, path,
+            tenant_id, job_id, generation, artifact_type, artifact_id, status, path,
             render_format, size_bytes, metadata_json, created_at
-        ) VALUES (?, 1, 'tailored_resume', 'artifact-resume-1', 'approved',
+        ) VALUES ('local', ?, 1, 'tailored_resume', 'artifact-resume-1', 'approved',
                   '/tmp/resume.txt', 'text', 12, '{}', '2026-07-05T12:05:00Z')
         """,
-        (job_url,),
+        (stable_job_id,),
     )
     conn.execute(
         """
         INSERT INTO job_bullet_provenance (
-            job_url, generation, bullet_id, tenant_id, artifact_id, section,
+            tenant_id, job_id, generation, bullet_id, artifact_id, section,
             source_id, evidence_ids_json, requirement_ids_json,
             matched_keywords_json, transform_type, control, rationale,
             generated_text, position, created_at, coverage_json
         ) VALUES (
-            ?, 1, 'experience:exp-platform#0', 'local', 'artifact-resume-1',
+            'local', ?, 1, 'experience:exp-platform#0', 'artifact-resume-1',
             'experience', 'exp-platform', '["ev_platform"]',
             '["req-platform"]', '["latency"]', 'reframe',
             'rephrase_allowed', 'Used profile evidence.',
@@ -179,7 +189,7 @@ def test_evidence_usage_projection_inverts_profile_provenance_and_requirement_fi
             '{"covered":["Python"],"declared":[],"missing":["Kubernetes"]}'
         )
         """,
-        (job_url,),
+        (stable_job_id,),
     )
     conn.execute(
         """
@@ -371,34 +381,35 @@ def test_evidence_map_excludes_soft_deleted_and_hidden_jobs(
             """,
             (job_url, title, site, utc_now(), job_url),
         )
+        stable_job_id = _stable_job_id(conn, job_url)
         conn.execute(
             """
             INSERT INTO job_materials (
-                job_url, generation, tenant_id, status, created_at, updated_at
-            ) VALUES (?, 1, 'local', 'complete',
+                tenant_id, job_id, generation, status, created_at, updated_at
+            ) VALUES ('local', ?, 1, 'complete',
                       '2026-07-05T12:00:00Z', '2026-07-05T12:10:00Z')
             """,
-            (job_url,),
+            (stable_job_id,),
         )
         conn.execute(
             """
             INSERT INTO job_materials_artifacts (
-                job_url, generation, artifact_type, artifact_id, status, path,
+                tenant_id, job_id, generation, artifact_type, artifact_id, status, path,
                 render_format, size_bytes, metadata_json, created_at
-            ) VALUES (?, 1, 'tailored_resume', ?, 'approved',
+            ) VALUES ('local', ?, 1, 'tailored_resume', ?, 'approved',
                       '/tmp/resume.txt', 'text', 12, '{}', '2026-07-05T12:05:00Z')
             """,
-            (job_url, artifact_id),
+            (stable_job_id, artifact_id),
         )
         conn.execute(
             """
             INSERT INTO job_bullet_provenance (
-                job_url, generation, bullet_id, tenant_id, artifact_id, section,
+                tenant_id, job_id, generation, bullet_id, artifact_id, section,
                 source_id, evidence_ids_json, requirement_ids_json,
                 matched_keywords_json, transform_type, control, rationale,
                 generated_text, position, created_at, coverage_json
             ) VALUES (
-                ?, 1, 'experience:exp-platform#0', 'local', ?,
+                'local', ?, 1, 'experience:exp-platform#0', ?,
                 'experience', 'exp-platform', '["ev_platform"]',
                 '["req-platform"]', '["latency"]', 'reframe',
                 'rephrase_allowed', 'Used profile evidence.',
@@ -406,7 +417,7 @@ def test_evidence_map_excludes_soft_deleted_and_hidden_jobs(
                 '{"covered":["Python"],"declared":[],"missing":["Kubernetes"]}'
             )
             """,
-            (job_url, artifact_id, generated_text, created_at),
+            (stable_job_id, artifact_id, generated_text, created_at),
         )
         conn.execute(
             """

--- a/workers/automation/tests/test_repeat_application_prevention.py
+++ b/workers/automation/tests/test_repeat_application_prevention.py
@@ -59,6 +59,12 @@ def _insert_job(
         ),
     )
     if ready:
+        job_id = str(
+            conn.execute(
+                "SELECT job_id FROM jobs WHERE url = ?",
+                (url,),
+            ).fetchone()[0]
+        )
         conn.execute(
             """
             INSERT OR REPLACE INTO candidate_profiles (
@@ -70,10 +76,10 @@ def _insert_job(
         conn.execute(
             """
             INSERT INTO job_materials (
-              job_url, generation, tenant_id, status, created_at, updated_at
-            ) VALUES (?, 1, 'local', 'approved', ?, ?)
+              tenant_id, job_id, generation, status, created_at, updated_at
+            ) VALUES ('local', ?, 1, 'approved', ?, ?)
             """,
-            (url, NOW, NOW),
+            (job_id, NOW, NOW),
         )
         for artifact_type, artifact_id, path in (
             ("tailored_resume", f"resume-{url}", "/tmp/repeat-resume.txt"),
@@ -82,11 +88,11 @@ def _insert_job(
             conn.execute(
                 """
                 INSERT INTO job_materials_artifacts (
-                  job_url, generation, artifact_type, artifact_id, status, path,
-                  render_format, created_at
-                ) VALUES (?, 1, ?, ?, 'approved', ?, 'text', ?)
+                  tenant_id, job_id, generation, artifact_type, artifact_id,
+                  status, path, render_format, created_at
+                ) VALUES ('local', ?, 1, ?, ?, 'approved', ?, 'text', ?)
                 """,
-                (url, artifact_type, artifact_id, path, NOW),
+                (job_id, artifact_type, artifact_id, path, NOW),
             )
         ensure_job_stage_rows(conn, url)
     conn.commit()
@@ -744,7 +750,7 @@ def test_schema_v5_migrates_additively_without_changing_application_facts(
         (PRIOR,),
     ).fetchall()
 
-    assert int(migrated.execute("PRAGMA user_version").fetchone()[0]) == SCHEMA_VERSION == 14
+    assert int(migrated.execute("PRAGMA user_version").fetchone()[0]) == SCHEMA_VERSION == 15
     assert [tuple(row) for row in after] == [tuple(row) for row in before]
     assert "metadata_json" in {
         str(row[1]) for row in migrated.execute("PRAGMA table_info(job_stage_states)").fetchall()

--- a/workers/automation/tests/test_resume_html_migration.py
+++ b/workers/automation/tests/test_resume_html_migration.py
@@ -2,11 +2,12 @@ from __future__ import annotations
 
 import json
 import sqlite3
+import uuid
 from pathlib import Path
 
 import pytest
 
-from jobctrl.database import ensure_materials_tables
+from jobctrl.database import ensure_materials_tables, init_db
 from jobctrl.infrastructure.materials.resume_html_migration import (
     build_legacy_resume_html,
     migrate_legacy_resume_pdfs,
@@ -118,6 +119,70 @@ def test_migrate_legacy_resume_pdfs_updates_artifact_and_layout_boxes(tmp_path: 
     assert (tmp_path / "resume.legacy-latex.pdf").read_bytes() == b"%PDF legacy"
     layout_count = db.execute("SELECT COUNT(*) FROM job_material_layout_boxes WHERE artifact_id = 'artifact-1'").fetchone()[0]
     assert layout_count == 1
+
+
+def test_migrate_resume_pdfs_selects_stable_material_by_posting_url_alias(
+    tmp_path: Path,
+) -> None:
+    db = init_db(tmp_path / "jobctrl.db")
+    db.row_factory = sqlite3.Row
+    job_id = str(uuid.uuid4())
+    storage_url = "https://storage.example/jobs/original"
+    posting_url = "https://posting.example/jobs/current"
+    now = "2026-07-29T10:00:00+00:00"
+    pdf_path = tmp_path / "resume.pdf"
+    pdf_path.write_bytes(b"%PDF legacy")
+    pdf_path.with_suffix(".txt").write_text(
+        "Jordan Candidate\njordan@example.com\n",
+        encoding="utf-8",
+    )
+    db.execute(
+        """
+        INSERT INTO jobs (
+            url, tenant_id, job_id, title, company, discovered_at
+        ) VALUES (?, 'local', ?, 'Platform Engineer', 'Example', ?)
+        """,
+        (storage_url, job_id, now),
+    )
+    db.execute(
+        """
+        INSERT INTO job_identity_aliases (
+            tenant_id, alias_kind, alias_value, job_id, created_at, retired_at
+        ) VALUES ('local', 'posting_url', ?, ?, ?, NULL)
+        """,
+        (posting_url, job_id, now),
+    )
+    db.execute(
+        """
+        INSERT INTO job_materials (
+            tenant_id, job_id, generation, status, created_at, updated_at
+        ) VALUES ('local', ?, 1, 'resume_approved', ?, ?)
+        """,
+        (job_id, now, now),
+    )
+    db.execute(
+        """
+        INSERT INTO job_materials_artifacts (
+            tenant_id, job_id, generation, artifact_type, artifact_id, status,
+            path, render_format, size_bytes, metadata_json, created_at
+        ) VALUES (
+            'local', ?, 1, 'resume_pdf', 'artifact-1', 'approved', ?,
+            'latex_pdf', ?, '{}', ?
+        )
+        """,
+        (job_id, str(pdf_path), pdf_path.stat().st_size, now),
+    )
+    db.commit()
+
+    results = migrate_legacy_resume_pdfs(
+        db,
+        dry_run=True,
+        job_url=posting_url,
+    )
+
+    assert [(result.artifact_id, result.status) for result in results] == [
+        ("artifact-1", "would_migrate")
+    ]
 
 
 def test_force_refresh_reprints_existing_html_resume_without_replacing_legacy_backup(tmp_path: Path) -> None:

--- a/workers/automation/tests/test_scoring_identity_reference_migration.py
+++ b/workers/automation/tests/test_scoring_identity_reference_migration.py
@@ -338,7 +338,7 @@ def test_v11_scoring_references_migrate_alias_histories_and_reopen(
     assert (
         int(migrated.execute("PRAGMA user_version").fetchone()[0])
         == SCHEMA_VERSION
-        == 14
+        == 15
     )
     assert _columns(migrated, "job_scores") >= {"tenant_id", "job_id"}
     assert "job_url" not in _columns(migrated, "job_scores")
@@ -404,7 +404,7 @@ def test_v11_scoring_references_migrate_alias_histories_and_reopen(
     assert (
         int(reopened.execute("PRAGMA user_version").fetchone()[0])
         == SCHEMA_VERSION
-        == 14
+        == 15
     )
 
 
@@ -553,7 +553,7 @@ def test_scoring_migration_rolls_back_and_retries_after_verification_failure(
     assert (
         int(retried.execute("PRAGMA user_version").fetchone()[0])
         == SCHEMA_VERSION
-        == 14
+        == 15
     )
     assert [
         tuple(row)

--- a/workers/automation/tests/test_stable_job_identity_migration.py
+++ b/workers/automation/tests/test_stable_job_identity_migration.py
@@ -81,8 +81,8 @@ def _create_representative_v6_pair(
         """
         INSERT INTO jobs (
             url, title, company, site, discovered_at, fit_score,
-            score_reasoning, scored_at
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            score_reasoning, scored_at, tailored_resume_path, tailored_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """,
         (
             job_url,
@@ -93,6 +93,8 @@ def _create_representative_v6_pair(
             8,
             "Synthetic reference score",
             "2026-07-01T10:05:00+00:00",
+            "/tmp/reference-resume.txt",
+            "2026-07-01T10:07:00+00:00",
         ),
     )
     job_id = str(
@@ -741,7 +743,7 @@ def test_v6_jobs_gain_stable_uuid_and_posting_url_alias_once(
     init_db(db_path)
     close_connection(db_path)
 
-    assert _user_version(db_path) == SCHEMA_VERSION == 14
+    assert _user_version(db_path) == SCHEMA_VERSION == 15
     first_ids = _identity_rows(db_path)
     assert [row[0] for row in first_ids] == ["local", "local"]
     for _tenant_id, job_id, _url in first_ids:
@@ -1424,6 +1426,17 @@ def test_representative_v6_references_and_paired_snapshot_restore(
     assert identities[0][0] == "local"
     assert identities[0][2] == job_url
     assert uuid.UUID(identities[0][1]).version == 4
+    migrated = sqlite3.connect(db_path)
+    try:
+        material_reference = migrated.execute(
+            """
+            SELECT tenant_id, job_id, generation
+            FROM job_materials
+            """
+        ).fetchone()
+        assert material_reference == ("local", identities[0][1], 1)
+    finally:
+        migrated.close()
 
     temporal = sqlite3.connect(temporal_path)
     try:


### PR DESCRIPTION
## Summary

- add schema v15 to migrate the four-table material-generation aggregate (`job_materials`, `job_materials_artifacts`, `job_material_layout_boxes`, and `job_bullet_provenance`) from URL-shaped ownership to tenant-scoped stable `JobId` references
- preserve every material generation and dependent artifact/layout/provenance row during alias collisions, with deterministic interleaving and generation renumbering
- update Python repositories, selectors, projections, reset/interview paths, and TypeScript reads/writes/deletion to use stable identities while retaining bounded schema-v14 compatibility
- keep explicit URL inputs URL-first, including UUID-shaped posting URLs and active posting aliases

## Why

Generated materials belong to one stable Job aggregate even when its posting URL changes. URL-keyed ownership could split generations across aliases, orphan child rows during identity collapse, and let a UUID-shaped URL be mistaken for a JobId. This phase migrates the complete material-generation aggregate together so its parent/child invariants remain atomic.

## Migration and runtime behavior

- rebuilds and verifies all four tables inside a retryable savepoint before stamping `PRAGMA user_version = 15`
- preserves row counts, foreign keys, generation histories, and child ownership across migration and runtime identity merges
- deterministically interleaves colliding histories by creation time while preserving each source history's ordering
- supports stable-schema reopen and paired legacy recovery without duplicating or dropping generated materials
- makes `migrate-resume-html --job-url` resolve storage URLs and posting aliases to tenant-scoped JobIds before selecting artifacts

## Validation

- full Python suite — 2,687 passed, 2 skipped
- full API suite — 48 files, 667 tests passed
- focused resume HTML alias regression — 5 passed
- API TypeScript check — passed
- Ruff across `src` and `tests` — passed
- `git diff --check` — passed
- independent Tier 3 QA — Gate: PASS, Blocker 0 / High 0 / Medium 0 / Low 0
- independent Tier 3 review after the alias fix — Gate: PASS, Blocker 0 / High 0 / Medium 0 / Low 0

## Stack

- stacked on #539 (`feat/job-id-materials-artifact-references`)
- employer analysis, resume-template assignments, interview preparation, Apply, outcomes, workflow/event/projection cutover, and the feedback-learning loop remain separate reviewable layers
- canonical product docs and cumulative product QA remain deferred to the final approved unreleased stack PR