### PR TITLE
feat(materials): migrate employer-analysis references to stable JobIds

### DIFF
--- a/apps/api/src/application-feedback.ts
+++ b/apps/api/src/application-feedback.ts
@@ -300,14 +300,18 @@ export function listApplyReviewQueue(db: SqliteDatabase): ApplyReviewQueueRespon
     : "";
   const closedParams = tableExists(db, "posting_snapshot_sets") ? CLOSED_ACTIVE_STATES : [];
   const hasEmployerAnalysis = tableExists(db, "job_employer_analysis");
+  const employerAnalysisReference = hasEmployerAnalysis
+    ? jobReferenceColumn(db, "job_employer_analysis")
+    : "job_url";
   const employerAnalysisCte = hasEmployerAnalysis
     ? `,
     latest_employer_analysis AS (
-      SELECT job_url, ideal_candidate_narrative, requirements_json
+      SELECT job_reference, ideal_candidate_narrative, requirements_json
       FROM (
-        SELECT job_url, ideal_candidate_narrative, requirements_json,
+        SELECT ${employerAnalysisReference} AS job_reference,
+               ideal_candidate_narrative, requirements_json,
                ROW_NUMBER() OVER (
-                 PARTITION BY tenant_id, job_url
+                 PARTITION BY tenant_id, ${employerAnalysisReference}
                  ORDER BY generation DESC
                ) AS row_num
         FROM job_employer_analysis
@@ -324,7 +328,14 @@ export function listApplyReviewQueue(db: SqliteDatabase): ApplyReviewQueueRespon
            NULL AS employer_ideal_candidate_narrative,
            NULL AS employer_requirements_json`;
   const employerAnalysisJoin = hasEmployerAnalysis
-    ? "LEFT JOIN latest_employer_analysis ON latest_employer_analysis.job_url = jlp.job_id"
+    ? employerAnalysisReference === "job_id"
+      ? `LEFT JOIN jobs employer_analysis_job
+           ON employer_analysis_job.tenant_id = jlp.tenant_id
+          AND employer_analysis_job.url = jlp.job_id
+         LEFT JOIN latest_employer_analysis
+           ON latest_employer_analysis.job_reference =
+              employer_analysis_job.job_id`
+      : "LEFT JOIN latest_employer_analysis ON latest_employer_analysis.job_reference = jlp.job_id"
     : "";
   const stableStageReferences = jobReferenceColumn(
     db,

--- a/apps/api/src/db.ts
+++ b/apps/api/src/db.ts
@@ -9,7 +9,7 @@ export type SqliteValue = string | number | bigint | null;
 // writer that stamps ``PRAGMA user_version``; the API only reads it to fail
 // closed on a database written by a newer build. Bump both constants together
 // whenever the schema shape changes.
-export const SUPPORTED_SCHEMA_VERSION = 15;
+export const SUPPORTED_SCHEMA_VERSION = 16;
 
 export class IncompatibleSchemaVersionError extends Error {
   constructor(current: number) {

--- a/apps/api/src/projections.ts
+++ b/apps/api/src/projections.ts
@@ -29,6 +29,7 @@ import {
   jobReferenceForUrl,
   jobReferenceJoinToJobs,
   jobReferencePredicateForUrl,
+  tableColumnSet,
   tableExists,
   type SqliteDatabase,
   type SqliteValue,
@@ -1969,31 +1970,66 @@ interface EvidenceGapPayload {
  * ``EmployerAnalysis.to_read_model()`` — the cross-runtime projection parity
  * test asserts both builders agree. Returns null when no analysis exists.
  */
-function loadEmployerAnalysisJson(db: SqliteDatabase, jobUrl: string): string | null {
+function loadEmployerAnalysisJson(
+  db: SqliteDatabase,
+  tenantId: string,
+  jobUrl: string,
+): string | null {
   if (!tableExists(db, "job_employer_analysis")) return null;
+  const referenceColumn = jobReferenceColumn(
+    db,
+    "job_employer_analysis",
+  );
+  const predicate = jobReferencePredicateForUrl(
+    db,
+    "job_employer_analysis",
+    jobUrl,
+    tenantId,
+    "analysis",
+  );
   const row = getRow<EmployerAnalysisRow>(
     db,
-    `SELECT * FROM job_employer_analysis WHERE job_url = ?
+    `SELECT * FROM job_employer_analysis AS analysis
+      WHERE ${predicate.sql}
       ORDER BY generation DESC LIMIT 1`,
-    [jobUrl],
+    predicate.params,
   );
   if (!row) return null;
+  const reference = String(row[referenceColumn]);
   const generation = Number(row.generation);
   const legsAttempted = Number(row.legs_attempted);
   const legsSucceeded = Number(row.legs_succeeded);
   const agreement = parseAnalysisAgreement(row.agreement_json);
+  const subAnalysisHasTenant = tableColumnSet(
+    db,
+    "job_employer_analysis_sub_analyses",
+  ).has("tenant_id");
+  const failureHasTenant = tableColumnSet(
+    db,
+    "job_employer_analysis_failures",
+  ).has("tenant_id");
 
   const subRows = allRows<{ model_id: string; analysis_json: string }>(
     db,
     `SELECT model_id, analysis_json FROM job_employer_analysis_sub_analyses
-      WHERE job_url = ? AND generation = ? ORDER BY model_id`,
-    [jobUrl, generation],
+      WHERE ${subAnalysisHasTenant ? "tenant_id = ? AND " : ""}${referenceColumn} = ?
+        AND generation = ? ORDER BY model_id`,
+    [
+      ...(subAnalysisHasTenant ? [tenantId] : []),
+      reference,
+      generation,
+    ],
   );
   const failureRows = allRows<{ model_id: string; error: string; raw_output: string | null }>(
     db,
     `SELECT model_id, error, raw_output FROM job_employer_analysis_failures
-      WHERE job_url = ? AND generation = ? ORDER BY model_id`,
-    [jobUrl, generation],
+      WHERE ${failureHasTenant ? "tenant_id = ? AND " : ""}${referenceColumn} = ?
+        AND generation = ? ORDER BY model_id`,
+    [
+      ...(failureHasTenant ? [tenantId] : []),
+      reference,
+      generation,
+    ],
   );
 
   const readModel = {
@@ -3405,7 +3441,11 @@ function rebuildJobProjections(db: SqliteDatabase, tenantId: string, jobUrl: str
   const score = loadLatestScore(db, jobUrl);
   const materials = loadLatestMaterials(db, jobUrl);
   const materialAnalytics = loadMaterialAnalytics(db, jobUrl);
-  const employerAnalysisJson = loadEmployerAnalysisJson(db, jobUrl);
+  const employerAnalysisJson = loadEmployerAnalysisJson(
+    db,
+    tenantId,
+    jobUrl,
+  );
   const requirementFitReportJson = loadRequirementFitReportJson(db, tenantId, jobUrl);
   const requirementFitBand = fitBand(loadLatestRequirementFitBand(db, tenantId, jobUrl));
   const interviewPrepJson = loadInterviewPrepJson(db, tenantId, jobUrl);

--- a/apps/api/src/write-model.ts
+++ b/apps/api/src/write-model.ts
@@ -857,6 +857,9 @@ function purgeJobRows(db: SqliteDatabase, jobUrl: string): void {
     "job_material_layout_boxes",
     "job_materials_artifacts",
     "job_materials",
+    "job_employer_analysis_sub_analyses",
+    "job_employer_analysis_failures",
+    "job_employer_analysis",
   ]) {
     deleteJobReferences(db, tableName, jobId, jobUrl);
   }

--- a/apps/api/test/application-feedback.test.ts
+++ b/apps/api/test/application-feedback.test.ts
@@ -5,7 +5,10 @@ import path from "node:path";
 import Database from "better-sqlite3";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { ensureApplicationFeedbackTables } from "../src/application-feedback.js";
+import {
+  ensureApplicationFeedbackTables,
+  listApplyReviewQueue,
+} from "../src/application-feedback.js";
 import type { ApplyReviewQueueResponse } from "../src/contracts.js";
 import { GmailFeedbackScanError, type GmailFeedbackScanner } from "../src/gmail-feedback-worker.js";
 import { type ActionDispatcher, type ActionDispatchResult } from "../src/local-actions.js";
@@ -205,6 +208,143 @@ describe("application feedback API", () => {
     });
 
     await app.close();
+  });
+
+  it("uses the URL owner when a review URL equals another stable JobId", () => {
+    const db = new Database(options.dbPath);
+    const uuidShapedUrl = "11111111-1111-4111-8111-111111111111";
+    const urlOwnerJobId = "22222222-2222-4222-8222-222222222222";
+    const idTextOwnerUrl = "https://example.com/jobs/id-text-owner";
+    db.exec(`
+      ALTER TABLE jobs ADD COLUMN tenant_id TEXT NOT NULL DEFAULT 'local';
+      ALTER TABLE jobs ADD COLUMN job_id TEXT;
+    `);
+    const existingJobs = db.prepare("SELECT url FROM jobs ORDER BY url").all() as Array<{
+      url: string;
+    }>;
+    const setJobId = db.prepare("UPDATE jobs SET job_id = ? WHERE url = ?");
+    for (const job of existingJobs) {
+      setJobId.run(crypto.randomUUID(), job.url);
+    }
+    db.exec(`
+      CREATE UNIQUE INDEX idx_jobs_tenant_job_id_collision_fixture
+        ON jobs(tenant_id, job_id);
+    `);
+    db.prepare(
+      `INSERT INTO jobs (
+         url, title, site, strategy, location, salary, discovered_at,
+         application_url, description, full_description,
+         detail_scraped_at, detail_error, fit_score, score_reasoning,
+         scored_at, tailored_resume_path, tailored_at, tailor_attempts,
+         cover_letter_path, cover_letter_at, cover_attempts,
+         apply_status, apply_error, applied_at, tenant_id, job_id
+       )
+       SELECT ?, title, site, strategy, location, salary, discovered_at,
+              ?, description, full_description, detail_scraped_at,
+              detail_error, fit_score, score_reasoning, scored_at,
+              tailored_resume_path, tailored_at, tailor_attempts,
+              cover_letter_path, cover_letter_at, cover_attempts,
+              apply_status, apply_error, applied_at, 'local', ?
+       FROM jobs
+       WHERE url = ?`,
+    ).run(
+      uuidShapedUrl,
+      uuidShapedUrl,
+      urlOwnerJobId,
+      READY_JOB,
+    );
+    db.prepare(
+      `INSERT INTO jobs (
+         url, title, site, discovered_at, tenant_id, job_id
+       ) VALUES (?, 'ID text owner', 'example', ?, 'local', ?)`,
+    ).run(idTextOwnerUrl, NOW, uuidShapedUrl);
+    db.prepare(
+      `INSERT INTO job_stage_states (
+         job_url, stage, state, attempt_count, max_attempts, started_at,
+         updated_at, finished_at, duration_ms, error_code, error_message,
+         retryable, blocked_by_json, next_action, metadata_json
+       )
+       SELECT ?, stage, state, attempt_count, max_attempts, started_at,
+              updated_at, finished_at, duration_ms, error_code,
+              error_message, retryable, blocked_by_json, next_action,
+              metadata_json
+       FROM job_stage_states
+       WHERE job_url = ?`,
+    ).run(uuidShapedUrl, READY_JOB);
+    db.exec(`
+      DROP TABLE job_employer_analysis_sub_analyses;
+      DROP TABLE job_employer_analysis_failures;
+      DROP TABLE job_employer_analysis;
+      CREATE TABLE job_employer_analysis (
+        tenant_id TEXT NOT NULL DEFAULT 'local',
+        job_id TEXT NOT NULL,
+        generation INTEGER NOT NULL,
+        snapshot_hash TEXT NOT NULL,
+        prompt_version TEXT NOT NULL,
+        sdk_set_version TEXT NOT NULL,
+        cache_key TEXT NOT NULL,
+        role_framing TEXT NOT NULL DEFAULT '',
+        inferred_seniority TEXT NOT NULL DEFAULT '',
+        ideal_candidate_narrative TEXT NOT NULL DEFAULT '',
+        requirements_json TEXT NOT NULL DEFAULT '[]',
+        keywords_json TEXT NOT NULL DEFAULT '[]',
+        agreement_json TEXT NOT NULL DEFAULT '{}',
+        eeo_screen_json TEXT NOT NULL DEFAULT '[]',
+        legs_attempted INTEGER NOT NULL,
+        legs_succeeded INTEGER NOT NULL,
+        created_at TEXT NOT NULL,
+        PRIMARY KEY (tenant_id, job_id, generation)
+      );
+      CREATE TABLE job_employer_analysis_sub_analyses (
+        tenant_id TEXT NOT NULL DEFAULT 'local',
+        job_id TEXT NOT NULL,
+        generation INTEGER NOT NULL,
+        model_id TEXT NOT NULL,
+        analysis_json TEXT NOT NULL,
+        PRIMARY KEY (tenant_id, job_id, generation, model_id)
+      );
+      CREATE TABLE job_employer_analysis_failures (
+        tenant_id TEXT NOT NULL DEFAULT 'local',
+        job_id TEXT NOT NULL,
+        generation INTEGER NOT NULL,
+        model_id TEXT NOT NULL,
+        error TEXT NOT NULL,
+        raw_output TEXT,
+        PRIMARY KEY (tenant_id, job_id, generation, model_id)
+      );
+    `);
+    const insertAnalysis = db.prepare(
+      `INSERT INTO job_employer_analysis (
+         tenant_id, job_id, generation, snapshot_hash, prompt_version,
+         sdk_set_version, cache_key, ideal_candidate_narrative,
+         requirements_json, legs_attempted, legs_succeeded, created_at
+       ) VALUES ('local', ?, 1, ?, 'prompt-v1', 'sdk-v1', ?, ?, '[]', 1, 1, ?)`,
+    );
+    insertAnalysis.run(
+      urlOwnerJobId,
+      "url-owner",
+      "cache:url-owner",
+      "Analysis owned by the UUID-shaped URL.",
+      NOW,
+    );
+    insertAnalysis.run(
+      uuidShapedUrl,
+      "id-owner",
+      "cache:id-owner",
+      "Analysis owned by the colliding JobId.",
+      NOW,
+    );
+
+    const queue = listApplyReviewQueue(db);
+
+    expect(
+      queue.items.find((item) => item.jobKey === uuidShapedUrl),
+    ).toMatchObject({
+      position: {
+        idealCandidate: "Analysis owned by the UUID-shaped URL.",
+      },
+    });
+    db.close();
   });
 
   it("excludes closed jobs through stable snapshot JobId references", async () => {

--- a/apps/api/test/employer-analysis-v16-write-model.test.ts
+++ b/apps/api/test/employer-analysis-v16-write-model.test.ts
@@ -1,0 +1,140 @@
+import Database from "better-sqlite3";
+import { describe, expect, it } from "vitest";
+
+import { permanentlyDeleteJob } from "../src/write-model.js";
+
+const UUID_SHAPED_URL = "11111111-1111-4111-8111-111111111111";
+const URL_OWNER_JOB_ID = "22222222-2222-4222-8222-222222222222";
+const ID_TEXT_OWNER_URL = "https://example.com/jobs/id-text-owner";
+
+function createSchema(db: Database.Database): void {
+  db.pragma("foreign_keys = OFF");
+  expect(db.pragma("foreign_keys", { simple: true })).toBe(0);
+  db.pragma("user_version = 16");
+  db.exec(`
+    CREATE TABLE jobs (
+      url TEXT PRIMARY KEY,
+      tenant_id TEXT NOT NULL DEFAULT 'local',
+      job_id TEXT NOT NULL,
+      title TEXT,
+      application_url TEXT,
+      UNIQUE (tenant_id, job_id)
+    );
+    CREATE TABLE job_employer_analysis (
+      tenant_id TEXT NOT NULL DEFAULT 'local',
+      job_id TEXT NOT NULL,
+      generation INTEGER NOT NULL,
+      snapshot_hash TEXT NOT NULL,
+      prompt_version TEXT NOT NULL,
+      sdk_set_version TEXT NOT NULL,
+      cache_key TEXT NOT NULL,
+      role_framing TEXT NOT NULL DEFAULT '',
+      inferred_seniority TEXT NOT NULL DEFAULT '',
+      ideal_candidate_narrative TEXT NOT NULL DEFAULT '',
+      requirements_json TEXT NOT NULL DEFAULT '[]',
+      keywords_json TEXT NOT NULL DEFAULT '[]',
+      agreement_json TEXT NOT NULL DEFAULT '{}',
+      eeo_screen_json TEXT NOT NULL DEFAULT '[]',
+      legs_attempted INTEGER NOT NULL,
+      legs_succeeded INTEGER NOT NULL,
+      created_at TEXT NOT NULL,
+      PRIMARY KEY (tenant_id, job_id, generation),
+      FOREIGN KEY (tenant_id, job_id)
+        REFERENCES jobs(tenant_id, job_id) ON DELETE CASCADE
+    );
+    CREATE TABLE job_employer_analysis_sub_analyses (
+      tenant_id TEXT NOT NULL DEFAULT 'local',
+      job_id TEXT NOT NULL,
+      generation INTEGER NOT NULL,
+      model_id TEXT NOT NULL,
+      analysis_json TEXT NOT NULL,
+      PRIMARY KEY (tenant_id, job_id, generation, model_id),
+      FOREIGN KEY (tenant_id, job_id, generation)
+        REFERENCES job_employer_analysis(tenant_id, job_id, generation)
+        ON DELETE CASCADE
+    );
+    CREATE TABLE job_employer_analysis_failures (
+      tenant_id TEXT NOT NULL DEFAULT 'local',
+      job_id TEXT NOT NULL,
+      generation INTEGER NOT NULL,
+      model_id TEXT NOT NULL,
+      error TEXT NOT NULL,
+      raw_output TEXT,
+      PRIMARY KEY (tenant_id, job_id, generation, model_id),
+      FOREIGN KEY (tenant_id, job_id, generation)
+        REFERENCES job_employer_analysis(tenant_id, job_id, generation)
+        ON DELETE CASCADE
+    );
+  `);
+}
+
+function seedAnalysis(
+  db: Database.Database,
+  input: { url: string; jobId: string; marker: string },
+): void {
+  db.prepare(
+    `INSERT INTO jobs (url, tenant_id, job_id, title)
+     VALUES (?, 'local', ?, 'Platform Engineer')`,
+  ).run(input.url, input.jobId);
+  db.prepare(
+    `INSERT INTO job_employer_analysis (
+       tenant_id, job_id, generation, snapshot_hash, prompt_version,
+       sdk_set_version, cache_key, role_framing, inferred_seniority,
+       ideal_candidate_narrative, requirements_json, keywords_json,
+       agreement_json, eeo_screen_json, legs_attempted, legs_succeeded,
+       created_at
+     ) VALUES (
+       'local', ?, 1, ?, 'prompt-v1', 'sdk-v1', ?, '', '', '',
+       '[]', '[]', '{}', '[]', 2, 1, '2026-07-29T10:00:00.000Z'
+     )`,
+  ).run(input.jobId, input.marker, `cache:${input.marker}`);
+  db.prepare(
+    `INSERT INTO job_employer_analysis_sub_analyses (
+       tenant_id, job_id, generation, model_id, analysis_json
+     ) VALUES ('local', ?, 1, ?, '{}')`,
+  ).run(input.jobId, `draft:${input.marker}`);
+  db.prepare(
+    `INSERT INTO job_employer_analysis_failures (
+       tenant_id, job_id, generation, model_id, error, raw_output
+     ) VALUES ('local', ?, 1, ?, 'timeout', NULL)`,
+  ).run(input.jobId, `failure:${input.marker}`);
+}
+
+describe("schema-v16 employer-analysis writes", () => {
+  it("permanently deletes only the UUID-shaped URL owner's analysis graph", () => {
+    const db = new Database(":memory:");
+    createSchema(db);
+    seedAnalysis(db, {
+      url: UUID_SHAPED_URL,
+      jobId: URL_OWNER_JOB_ID,
+      marker: "url-owner",
+    });
+    seedAnalysis(db, {
+      url: ID_TEXT_OWNER_URL,
+      jobId: UUID_SHAPED_URL,
+      marker: "id-owner",
+    });
+
+    expect(permanentlyDeleteJob(db, UUID_SHAPED_URL)).toEqual({
+      ok: true,
+      count: 1,
+      jobKeys: [UUID_SHAPED_URL],
+    });
+    expect(
+      db.prepare("SELECT url FROM jobs ORDER BY url").all(),
+    ).toEqual([{ url: ID_TEXT_OWNER_URL }]);
+    for (const tableName of [
+      "job_employer_analysis",
+      "job_employer_analysis_sub_analyses",
+      "job_employer_analysis_failures",
+    ]) {
+      expect(
+        db.prepare(
+          `SELECT DISTINCT job_id FROM ${tableName}`,
+        ).all(),
+      ).toEqual([{ job_id: UUID_SHAPED_URL }]);
+    }
+    expect(db.pragma("foreign_key_check")).toEqual([]);
+    db.close();
+  });
+});

--- a/apps/api/test/projections.test.ts
+++ b/apps/api/test/projections.test.ts
@@ -2244,7 +2244,21 @@ describe("apply_run_projections without legacy apply_runs table", () => {
     }
   });
 
-  it("serves the canonical employer analysis from projection rows (TS↔Python parity)", async () => {
+  it.each([
+    {
+      label: "schema-v15 URL references",
+      referenceColumn: "job_url",
+      stableReferences: false,
+    },
+    {
+      label: "schema-v16 stable JobId references",
+      referenceColumn: "job_id",
+      stableReferences: true,
+    },
+  ])("serves canonical employer analysis from $label (TS↔Python parity)", async ({
+    referenceColumn,
+    stableReferences,
+  }) => {
     // AUDIT-02-style cross-runtime parity: seed the canonical
     // ``job_employer_analysis`` rows exactly as the Python repository writes
     // them, then assert the TS projection builder + read model reconstruct the
@@ -2254,9 +2268,19 @@ describe("apply_run_projections without legacy apply_runs table", () => {
     try {
       seedSchema(dbPath);
       const db = new Database(dbPath);
+      if (stableReferences) db.pragma("user_version = 16");
+      const jobReference = stableReferences
+        ? String(
+            (
+              db.prepare("SELECT job_id FROM jobs WHERE url = ?").get(jobUrl) as {
+                job_id: string;
+              }
+            ).job_id,
+          )
+        : jobUrl;
       db.exec(`
         CREATE TABLE job_employer_analysis (
-          job_url TEXT NOT NULL,
+          ${referenceColumn} TEXT NOT NULL,
           generation INTEGER NOT NULL,
           tenant_id TEXT NOT NULL DEFAULT 'local',
           snapshot_hash TEXT NOT NULL,
@@ -2272,24 +2296,24 @@ describe("apply_run_projections without legacy apply_runs table", () => {
           legs_attempted INTEGER NOT NULL,
           legs_succeeded INTEGER NOT NULL,
           created_at TEXT NOT NULL,
-          PRIMARY KEY (job_url, generation)
+          PRIMARY KEY (${stableReferences ? `tenant_id, ${referenceColumn}, generation` : `${referenceColumn}, generation`})
         );
         CREATE TABLE job_employer_analysis_sub_analyses (
-          job_url TEXT NOT NULL,
+          ${referenceColumn} TEXT NOT NULL,
           generation INTEGER NOT NULL,
           model_id TEXT NOT NULL,
           tenant_id TEXT NOT NULL DEFAULT 'local',
           analysis_json TEXT NOT NULL,
-          PRIMARY KEY (job_url, generation, model_id)
+          PRIMARY KEY (${stableReferences ? `tenant_id, ${referenceColumn}, generation, model_id` : `${referenceColumn}, generation, model_id`})
         );
         CREATE TABLE job_employer_analysis_failures (
-          job_url TEXT NOT NULL,
+          ${referenceColumn} TEXT NOT NULL,
           generation INTEGER NOT NULL,
           model_id TEXT NOT NULL,
           tenant_id TEXT NOT NULL DEFAULT 'local',
           error TEXT NOT NULL,
           raw_output TEXT,
-          PRIMARY KEY (job_url, generation, model_id)
+          PRIMARY KEY (${stableReferences ? `tenant_id, ${referenceColumn}, generation, model_id` : `${referenceColumn}, generation, model_id`})
         );
       `);
       const requirements = [
@@ -2313,29 +2337,29 @@ describe("apply_run_projections without legacy apply_runs table", () => {
       // Two generations prove "load latest" + supersede-not-destroy (D-13).
       const insertAnalysis = db.prepare(
         `INSERT INTO job_employer_analysis (
-          job_url, generation, tenant_id, snapshot_hash, prompt_version, sdk_set_version,
+          ${referenceColumn}, generation, tenant_id, snapshot_hash, prompt_version, sdk_set_version,
           cache_key, role_framing, inferred_seniority, ideal_candidate_narrative,
           requirements_json, keywords_json, agreement_json, legs_attempted, legs_succeeded, created_at
         ) VALUES (?, ?, 'local', ?, 'employer-analysis-v1', 'claude+codex-v1', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       );
       insertAnalysis.run(
-        jobUrl, 1, "hash-old", "hash-old:employer-analysis-v1:claude+codex-v1",
+        jobReference, 1, "hash-old", "hash-old:employer-analysis-v1:claude+codex-v1",
         "Old framing.", "mid", "Old narrative.",
         "[]", "[]", JSON.stringify({ score: 0.5, flagged_requirements: [], flagged_keywords: [] }),
         2, 2, "2026-05-04T12:00:00+00:00",
       );
       insertAnalysis.run(
-        jobUrl, 2, "hash-new", "hash-new:employer-analysis-v1:claude+codex-v1",
+        jobReference, 2, "hash-new", "hash-new:employer-analysis-v1:claude+codex-v1",
         "Own the event platform.", "senior", "A hands-on platform owner.",
         JSON.stringify(requirements), JSON.stringify(keywords),
         JSON.stringify({ score: 0.8, flagged_requirements: [], flagged_keywords: ["kafka"] }),
         2, 1, "2026-05-04T13:00:00+00:00",
       );
       db.prepare(
-        `INSERT INTO job_employer_analysis_sub_analyses (job_url, generation, model_id, tenant_id, analysis_json)
+        `INSERT INTO job_employer_analysis_sub_analyses (${referenceColumn}, generation, model_id, tenant_id, analysis_json)
          VALUES (?, 2, 'claude-opus-4-8', 'local', ?)`,
       ).run(
-        jobUrl,
+        jobReference,
         JSON.stringify({
           role_framing: "Own the event platform.",
           inferred_seniority: "senior",
@@ -2345,9 +2369,9 @@ describe("apply_run_projections without legacy apply_runs table", () => {
         }),
       );
       db.prepare(
-        `INSERT INTO job_employer_analysis_failures (job_url, generation, model_id, tenant_id, error, raw_output)
+        `INSERT INTO job_employer_analysis_failures (${referenceColumn}, generation, model_id, tenant_id, error, raw_output)
          VALUES (?, 2, 'gpt-5.4', 'local', 'codex app-server timeout', NULL)`,
-      ).run(jobUrl);
+      ).run(jobReference);
       db.close();
 
       const app = buildApp({

--- a/apps/api/test/schema-version-guard.test.ts
+++ b/apps/api/test/schema-version-guard.test.ts
@@ -63,7 +63,7 @@ describe("schema version guard at DB open", () => {
   });
 
   it("opens the worker-owned schema-v14 artifact registry", () => {
-    expect(SUPPORTED_SCHEMA_VERSION).toBe(15);
+    expect(SUPPORTED_SCHEMA_VERSION).toBe(16);
     const { dbPath, cleanup } = makeDbWithUserVersion(14);
     try {
       openDatabase(dbPath).close();

--- a/workers/automation/src/jobctrl/database.py
+++ b/workers/automation/src/jobctrl/database.py
@@ -62,7 +62,10 @@ from jobctrl.config import DB_PATH, DEFAULTS, migrate_legacy_job_tables
 # slots, PDF layout audit boxes, and bullet provenance reference the stable Job
 # aggregate. Alias histories are deterministically interleaved and renumbered
 # together so no generation or dependent audit row is discarded.
-SCHEMA_VERSION = 15
+# v16 (employer-analysis references): canonical employer-analysis generations
+# plus their per-model drafts and failures reference the stable Job aggregate.
+# Identity collapse preserves and deterministically renumbers complete histories.
+SCHEMA_VERSION = 16
 
 
 class IncompatibleSchemaVersionError(RuntimeError):
@@ -208,6 +211,7 @@ def _schema_migrations() -> tuple[
         (13, ensure_stage_state_references_v13),
         (14, ensure_artifact_registry_references_v14),
         (15, ensure_materials_references_v15),
+        (16, ensure_employer_analysis_references_v16),
     )
 
 
@@ -2929,12 +2933,12 @@ def ensure_employer_analysis_tables(conn: sqlite3.Connection | None = None) -> l
     and drives downstream tailoring. Per D-09 the analysis is stored as CANONICAL
     ROWS — never inside an artifact ``metadata_json`` blob:
 
-      * ``job_employer_analysis`` — one row per ``(job_url, generation)``. Holds
-        the reconciled canonical analysis (role framing / seniority / narrative
-        / requirements / keywords as structured columns + JSON arrays), the
-        snapshot+version cache key (D-11/D-12), the cross-model agreement signal,
-        and the ``legs_attempted`` / ``legs_succeeded`` ensemble-completeness
-        counters (D-08).
+      * ``job_employer_analysis`` — one row per tenant-scoped stable
+        ``(job_id, generation)``. Holds the reconciled canonical analysis (role
+        framing / seniority / narrative / requirements / keywords as structured
+        columns + JSON arrays), the snapshot+version cache key (D-11/D-12), the
+        cross-model agreement signal, and the ``legs_attempted`` /
+        ``legs_succeeded`` ensemble-completeness counters (D-08).
       * ``job_employer_analysis_sub_analyses`` — one row per per-model draft that
         contributed to the canonical record (D-08 audit trail).
       * ``job_employer_analysis_failures`` — one row per leg that errored /
@@ -2948,6 +2952,16 @@ def ensure_employer_analysis_tables(conn: sqlite3.Connection | None = None) -> l
     """
     if conn is None:
         conn = get_connection()
+
+    current_schema_version = _assert_schema_version_supported(conn)
+    if (
+        current_schema_version
+        >= _EMPLOYER_ANALYSIS_REFERENCE_SCHEMA_VERSION
+    ):
+        _create_employer_analysis_tables_v16(conn)
+        _create_employer_analysis_indexes_v16(conn)
+        conn.commit()
+        return list(_EMPLOYER_ANALYSIS_REFERENCE_TABLES)
 
     conn.execute(
         """
@@ -4431,12 +4445,27 @@ def _reassign_discovery_identity_references(
             losing_job_id=losing_job_id,
             surviving_job_id=surviving_job_id,
         )
+    employer_analysis_generation_map: (
+        dict[tuple[str, int], int] | None
+    ) = None
+    if _has_employer_analysis_reference_schema_v16(conn):
+        employer_analysis_generation_map = (
+            _reassign_employer_analysis_references_v16(
+                conn,
+                tenant_id=tenant_id,
+                losing_job_id=losing_job_id,
+                surviving_job_id=surviving_job_id,
+            )
+        )
     if _has_scoring_reference_schema_v12(conn):
         _reassign_scoring_references_v12(
             conn,
             tenant_id=tenant_id,
             losing_job_id=losing_job_id,
             surviving_job_id=surviving_job_id,
+            employer_analysis_generation_map=(
+                employer_analysis_generation_map
+            ),
         )
     if _has_stage_state_reference_schema_v13(conn):
         _reassign_stage_state_references_v13(
@@ -4459,8 +4488,6 @@ def _reassign_discovery_identity_references(
             losing_job_id=losing_job_id,
             surviving_job_id=surviving_job_id,
         )
-
-
 def _reassign_enrichment_snapshot_references_v11(
     conn: sqlite3.Connection,
     *,
@@ -7778,6 +7805,9 @@ def _reassign_scoring_references_v12(
     tenant_id: str,
     losing_job_id: str,
     surviving_job_id: str,
+    employer_analysis_generation_map: (
+        dict[tuple[str, int], int] | None
+    ) = None,
 ) -> None:
     """Merge two stable scoring histories without overwriting either one."""
     if losing_job_id == surviving_job_id:
@@ -7851,18 +7881,40 @@ def _reassign_scoring_references_v12(
     ).fetchall()
     report_rows: list[tuple[Any, ...]] = []
     for row in raw_reports:
-        new_version = version_map.get((str(row[0]), int(row[1])))
+        source_job_id = str(row[0])
+        new_version = version_map.get(
+            (source_job_id, int(row[1]))
+        )
         if new_version is None:
             raise RuntimeError(
                 "URL collision merge found a requirement-fit report "
                 "without its score history"
             )
+        old_analysis_generation = int(row[2])
+        new_analysis_generation = old_analysis_generation
+        if (
+            employer_analysis_generation_map is not None
+            and old_analysis_generation > 0
+        ):
+            mapped_generation = (
+                employer_analysis_generation_map.get(
+                    (source_job_id, old_analysis_generation)
+                )
+            )
+            if mapped_generation is None:
+                raise RuntimeError(
+                    "URL collision merge found a requirement-fit "
+                    "report bound to a missing employer-analysis "
+                    "generation"
+                )
+            new_analysis_generation = mapped_generation
         report_rows.append(
             (
                 tenant_id,
                 surviving_job_id,
                 new_version,
-                *tuple(row[2:]),
+                new_analysis_generation,
+                *tuple(row[3:]),
             )
         )
 
@@ -9748,6 +9800,679 @@ def _reassign_materials_references_v15(
         conn,
         expected_counts=before_counts,
     )
+
+
+_EMPLOYER_ANALYSIS_REFERENCE_SCHEMA_VERSION = 16
+_EMPLOYER_ANALYSIS_REFERENCE_TABLES = (
+    "job_employer_analysis",
+    "job_employer_analysis_sub_analyses",
+    "job_employer_analysis_failures",
+)
+
+
+def _create_employer_analysis_tables_v16(
+    conn: sqlite3.Connection,
+    *,
+    analysis_table: str = "job_employer_analysis",
+    sub_analyses_table: str = "job_employer_analysis_sub_analyses",
+    failures_table: str = "job_employer_analysis_failures",
+) -> None:
+    conn.execute(
+        f"""
+        CREATE TABLE IF NOT EXISTS {analysis_table} (
+            tenant_id                 TEXT NOT NULL DEFAULT 'local',
+            job_id                    TEXT NOT NULL,
+            generation                INTEGER NOT NULL CHECK(generation > 0),
+            snapshot_hash             TEXT NOT NULL,
+            prompt_version            TEXT NOT NULL,
+            sdk_set_version           TEXT NOT NULL,
+            cache_key                 TEXT NOT NULL,
+            role_framing              TEXT NOT NULL DEFAULT '',
+            inferred_seniority        TEXT NOT NULL DEFAULT '',
+            ideal_candidate_narrative TEXT NOT NULL DEFAULT '',
+            requirements_json         TEXT NOT NULL DEFAULT '[]',
+            keywords_json             TEXT NOT NULL DEFAULT '[]',
+            agreement_json            TEXT NOT NULL DEFAULT '{{}}',
+            eeo_screen_json           TEXT NOT NULL DEFAULT '[]',
+            legs_attempted            INTEGER NOT NULL,
+            legs_succeeded            INTEGER NOT NULL,
+            created_at                TEXT NOT NULL,
+            PRIMARY KEY (tenant_id, job_id, generation),
+            FOREIGN KEY (tenant_id, job_id)
+                REFERENCES jobs(tenant_id, job_id) ON DELETE CASCADE
+        )
+        """
+    )
+    conn.execute(
+        f"""
+        CREATE TABLE IF NOT EXISTS {sub_analyses_table} (
+            tenant_id    TEXT NOT NULL DEFAULT 'local',
+            job_id       TEXT NOT NULL,
+            generation   INTEGER NOT NULL CHECK(generation > 0),
+            model_id     TEXT NOT NULL,
+            analysis_json TEXT NOT NULL,
+            PRIMARY KEY (tenant_id, job_id, generation, model_id),
+            FOREIGN KEY (tenant_id, job_id, generation)
+                REFERENCES {analysis_table}(
+                    tenant_id, job_id, generation
+                ) ON DELETE CASCADE
+        )
+        """
+    )
+    conn.execute(
+        f"""
+        CREATE TABLE IF NOT EXISTS {failures_table} (
+            tenant_id  TEXT NOT NULL DEFAULT 'local',
+            job_id     TEXT NOT NULL,
+            generation INTEGER NOT NULL CHECK(generation > 0),
+            model_id   TEXT NOT NULL,
+            error      TEXT NOT NULL,
+            raw_output TEXT,
+            PRIMARY KEY (tenant_id, job_id, generation, model_id),
+            FOREIGN KEY (tenant_id, job_id, generation)
+                REFERENCES {analysis_table}(
+                    tenant_id, job_id, generation
+                ) ON DELETE CASCADE
+        )
+        """
+    )
+
+
+def _create_employer_analysis_indexes_v16(
+    conn: sqlite3.Connection,
+) -> None:
+    conn.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_job_employer_analysis_cache_key
+        ON job_employer_analysis(tenant_id, job_id, cache_key)
+        """
+    )
+    conn.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_job_employer_analysis_tenant_job_gen
+        ON job_employer_analysis(tenant_id, job_id, generation DESC)
+        """
+    )
+
+
+def _has_employer_analysis_reference_schema_v16(
+    conn: sqlite3.Connection,
+) -> bool:
+    return (
+        "job_id" in _table_columns(conn, "job_employer_analysis")
+        and "job_url" not in _table_columns(
+            conn,
+            "job_employer_analysis",
+        )
+        and _primary_key_columns(conn, "job_employer_analysis")
+        == ("tenant_id", "job_id", "generation")
+        and _has_composite_job_id_foreign_key(
+            conn,
+            "job_employer_analysis",
+            "job_id",
+        )
+        and "job_id" in _table_columns(
+            conn,
+            "job_employer_analysis_sub_analyses",
+        )
+        and "job_url" not in _table_columns(
+            conn,
+            "job_employer_analysis_sub_analyses",
+        )
+        and _primary_key_columns(
+            conn,
+            "job_employer_analysis_sub_analyses",
+        )
+        == ("tenant_id", "job_id", "generation", "model_id")
+        and _has_composite_foreign_key(
+            conn,
+            "job_employer_analysis_sub_analyses",
+            "job_employer_analysis",
+            {
+                ("tenant_id", "tenant_id"),
+                ("job_id", "job_id"),
+                ("generation", "generation"),
+            },
+            on_delete="CASCADE",
+        )
+        and "job_id" in _table_columns(
+            conn,
+            "job_employer_analysis_failures",
+        )
+        and "job_url" not in _table_columns(
+            conn,
+            "job_employer_analysis_failures",
+        )
+        and _primary_key_columns(
+            conn,
+            "job_employer_analysis_failures",
+        )
+        == ("tenant_id", "job_id", "generation", "model_id")
+        and _has_composite_foreign_key(
+            conn,
+            "job_employer_analysis_failures",
+            "job_employer_analysis",
+            {
+                ("tenant_id", "tenant_id"),
+                ("job_id", "job_id"),
+                ("generation", "generation"),
+            },
+            on_delete="CASCADE",
+        )
+        and _has_index(
+            conn,
+            "job_employer_analysis",
+            "idx_job_employer_analysis_cache_key",
+            ("tenant_id", "job_id", "cache_key"),
+            unique=False,
+        )
+        and _has_index(
+            conn,
+            "job_employer_analysis",
+            "idx_job_employer_analysis_tenant_job_gen",
+            ("tenant_id", "job_id", "generation"),
+            unique=False,
+        )
+    )
+
+
+def _merge_employer_analysis_histories_preserving_order_v16(
+    history: list[tuple[str, int, tuple[Any, ...]]],
+) -> list[tuple[str, int, tuple[Any, ...]]]:
+    """Interleave analysis histories without reversing either history."""
+    by_reference: dict[str, list[tuple[str, int, tuple[Any, ...]]]] = {}
+    for entry in history:
+        by_reference.setdefault(entry[0], []).append(entry)
+    for entries in by_reference.values():
+        entries.sort(key=lambda entry: entry[1])
+
+    offsets = {reference: 0 for reference in by_reference}
+    merged: list[tuple[str, int, tuple[Any, ...]]] = []
+    while len(merged) < len(history):
+        eligible = [
+            entries[offsets[reference]]
+            for reference, entries in by_reference.items()
+            if offsets[reference] < len(entries)
+        ]
+        selected = min(
+            eligible,
+            key=lambda entry: (
+                str(entry[2][-1]),
+                entry[0],
+                entry[1],
+            ),
+        )
+        merged.append(selected)
+        offsets[selected[0]] += 1
+    return merged
+
+
+def _canonical_employer_analysis_rows_v16(
+    conn: sqlite3.Connection,
+) -> tuple[
+    list[tuple[Any, ...]],
+    dict[tuple[str, str, int], int],
+]:
+    rows = conn.execute(
+        """
+        SELECT tenant_id, job_url, generation, snapshot_hash,
+               prompt_version, sdk_set_version, cache_key, role_framing,
+               inferred_seniority, ideal_candidate_narrative,
+               requirements_json, keywords_json, agreement_json,
+               eeo_screen_json, legs_attempted, legs_succeeded, created_at
+        FROM job_employer_analysis
+        ORDER BY tenant_id, job_url, generation
+        """
+    ).fetchall()
+    grouped: dict[
+        tuple[str, str],
+        list[tuple[str, int, tuple[Any, ...]]],
+    ] = {}
+    for row in rows:
+        tenant_id = str(row[0])
+        raw_reference = str(row[1])
+        old_generation = int(row[2])
+        if old_generation <= 0:
+            raise RuntimeError(
+                "employer-analysis reference migration found a "
+                "non-positive generation"
+            )
+        stable_job_id = _resolve_job_reference_value(
+            conn,
+            tenant_id=tenant_id,
+            reference=raw_reference,
+            legacy_url=True,
+        )
+        if stable_job_id is None:
+            raise RuntimeError(
+                "employer-analysis reference migration could not resolve "
+                f"job_employer_analysis.job_url={raw_reference!r}"
+            )
+        _validate_job_uuid(stable_job_id)
+        grouped.setdefault((tenant_id, stable_job_id), []).append(
+            (
+                raw_reference,
+                old_generation,
+                tuple(row[3:]),
+            )
+        )
+
+    canonical: list[tuple[Any, ...]] = []
+    generation_map: dict[tuple[str, str, int], int] = {}
+    for (tenant_id, stable_job_id), history in sorted(grouped.items()):
+        ordered = (
+            _merge_employer_analysis_histories_preserving_order_v16(
+                history
+            )
+        )
+        for new_generation, (
+            raw_reference,
+            old_generation,
+            values,
+        ) in enumerate(ordered, start=1):
+            generation_map[
+                (tenant_id, raw_reference, old_generation)
+            ] = new_generation
+            canonical.append(
+                (
+                    tenant_id,
+                    stable_job_id,
+                    new_generation,
+                    *values,
+                )
+            )
+    return canonical, generation_map
+
+
+def _canonical_employer_analysis_child_rows_v16(
+    conn: sqlite3.Connection,
+    *,
+    table_name: str,
+    value_columns: str,
+    generation_map: dict[tuple[str, str, int], int],
+) -> list[tuple[Any, ...]]:
+    rows = conn.execute(
+        f"""
+        SELECT parent.tenant_id, child.job_url, child.generation,
+               {value_columns}
+        FROM {table_name} AS child
+        JOIN job_employer_analysis AS parent
+          ON parent.job_url = child.job_url
+         AND parent.generation = child.generation
+        ORDER BY parent.tenant_id, child.job_url, child.generation,
+                 child.model_id
+        """
+    ).fetchall()
+    canonical: list[tuple[Any, ...]] = []
+    for row in rows:
+        tenant_id = str(row[0])
+        raw_reference = str(row[1])
+        old_generation = int(row[2])
+        new_generation = generation_map.get(
+            (tenant_id, raw_reference, old_generation)
+        )
+        stable_job_id = _resolve_job_reference_value(
+            conn,
+            tenant_id=tenant_id,
+            reference=raw_reference,
+            legacy_url=True,
+        )
+        if new_generation is None or stable_job_id is None:
+            raise RuntimeError(
+                "employer-analysis reference migration found a child "
+                "without its parent generation"
+            )
+        canonical.append(
+            (
+                tenant_id,
+                stable_job_id,
+                new_generation,
+                *tuple(row[3:]),
+            )
+        )
+    return canonical
+
+
+def ensure_employer_analysis_references_v16(
+    conn: sqlite3.Connection | None = None,
+) -> list[str]:
+    """Move employer-analysis authorities to stable JobId references."""
+    if conn is None:
+        conn = get_connection()
+
+    current = _assert_schema_version_supported(conn)
+    if current >= _EMPLOYER_ANALYSIS_REFERENCE_SCHEMA_VERSION:
+        return []
+    if current != _MATERIALS_REFERENCE_SCHEMA_VERSION:
+        raise RuntimeError(
+            "employer-analysis reference migration requires materials "
+            "schema v15"
+        )
+
+    conn.execute("SAVEPOINT employer_analysis_references_v16")
+    try:
+        if not _has_materials_reference_schema_v15(conn):
+            raise RuntimeError(
+                "employer-analysis reference migration requires the "
+                "stable materials reference schema"
+            )
+        before_counts = {
+            table: int(
+                conn.execute(f'SELECT COUNT(*) FROM "{table}"').fetchone()[0]
+            )
+            for table in _EMPLOYER_ANALYSIS_REFERENCE_TABLES
+        }
+
+        if not _has_employer_analysis_reference_schema_v16(conn):
+            (
+                analysis_rows,
+                generation_map,
+            ) = _canonical_employer_analysis_rows_v16(conn)
+            sub_analysis_rows = (
+                _canonical_employer_analysis_child_rows_v16(
+                    conn,
+                    table_name="job_employer_analysis_sub_analyses",
+                    value_columns="child.model_id, child.analysis_json",
+                    generation_map=generation_map,
+                )
+            )
+            failure_rows = _canonical_employer_analysis_child_rows_v16(
+                conn,
+                table_name="job_employer_analysis_failures",
+                value_columns=(
+                    "child.model_id, child.error, child.raw_output"
+                ),
+                generation_map=generation_map,
+            )
+
+            for table in (
+                "job_employer_analysis_sub_analyses_v16",
+                "job_employer_analysis_failures_v16",
+                "job_employer_analysis_v16",
+            ):
+                conn.execute(f'DROP TABLE IF EXISTS "{table}"')
+            _create_employer_analysis_tables_v16(
+                conn,
+                analysis_table="job_employer_analysis_v16",
+                sub_analyses_table=(
+                    "job_employer_analysis_sub_analyses_v16"
+                ),
+                failures_table="job_employer_analysis_failures_v16",
+            )
+            conn.executemany(
+                """
+                INSERT INTO job_employer_analysis_v16 (
+                    tenant_id, job_id, generation, snapshot_hash,
+                    prompt_version, sdk_set_version, cache_key,
+                    role_framing, inferred_seniority,
+                    ideal_candidate_narrative, requirements_json,
+                    keywords_json, agreement_json, eeo_screen_json,
+                    legs_attempted, legs_succeeded, created_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                analysis_rows,
+            )
+            conn.executemany(
+                """
+                INSERT INTO job_employer_analysis_sub_analyses_v16 (
+                    tenant_id, job_id, generation, model_id, analysis_json
+                ) VALUES (?, ?, ?, ?, ?)
+                """,
+                sub_analysis_rows,
+            )
+            conn.executemany(
+                """
+                INSERT INTO job_employer_analysis_failures_v16 (
+                    tenant_id, job_id, generation, model_id, error,
+                    raw_output
+                ) VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                failure_rows,
+            )
+
+            for table in (
+                "job_employer_analysis_sub_analyses",
+                "job_employer_analysis_failures",
+                "job_employer_analysis",
+            ):
+                conn.execute(f'DROP TABLE "{table}"')
+            for table in (
+                "job_employer_analysis",
+                "job_employer_analysis_sub_analyses",
+                "job_employer_analysis_failures",
+            ):
+                conn.execute(
+                    f'ALTER TABLE "{table}_v16" RENAME TO "{table}"'
+                )
+            _create_employer_analysis_indexes_v16(conn)
+
+        _verify_employer_analysis_references_v16(
+            conn,
+            expected_counts=before_counts,
+        )
+        conn.execute(
+            f"PRAGMA user_version = "
+            f"{_EMPLOYER_ANALYSIS_REFERENCE_SCHEMA_VERSION}"
+        )
+        conn.execute(
+            "RELEASE SAVEPOINT employer_analysis_references_v16"
+        )
+        conn.commit()
+    except BaseException:
+        conn.execute(
+            "ROLLBACK TO SAVEPOINT employer_analysis_references_v16"
+        )
+        conn.execute(
+            "RELEASE SAVEPOINT employer_analysis_references_v16"
+        )
+        raise
+
+    return list(_EMPLOYER_ANALYSIS_REFERENCE_TABLES)
+
+
+def _verify_employer_analysis_references_v16(
+    conn: sqlite3.Connection,
+    *,
+    expected_counts: dict[str, int],
+) -> None:
+    if not _has_employer_analysis_reference_schema_v16(conn):
+        raise RuntimeError(
+            "employer-analysis reference migration did not install the "
+            "canonical schema"
+        )
+    for table, expected_count in expected_counts.items():
+        observed_count = int(
+            conn.execute(f'SELECT COUNT(*) FROM "{table}"').fetchone()[0]
+        )
+        if observed_count != expected_count:
+            raise RuntimeError(
+                "employer-analysis reference migration changed the "
+                f"{table} row count: expected {expected_count}, "
+                f"found {observed_count}"
+            )
+    orphan = conn.execute(
+        """
+        SELECT analysis.job_id
+        FROM job_employer_analysis AS analysis
+        LEFT JOIN jobs j
+          ON j.tenant_id = analysis.tenant_id
+         AND j.job_id = analysis.job_id
+        WHERE j.job_id IS NULL
+        LIMIT 1
+        """
+    ).fetchone()
+    if orphan is not None:
+        raise RuntimeError(
+            "employer-analysis reference migration left an unresolved "
+            "JobId"
+        )
+    for table in _EMPLOYER_ANALYSIS_REFERENCE_TABLES:
+        for row in conn.execute(
+            f'SELECT DISTINCT job_id FROM "{table}"'
+        ).fetchall():
+            _validate_job_uuid(str(row[0]))
+    foreign_key_error = conn.execute(
+        "PRAGMA foreign_key_check"
+    ).fetchone()
+    if foreign_key_error is not None:
+        raise RuntimeError(
+            "employer-analysis reference migration found a foreign-key "
+            "violation"
+        )
+
+
+def _reassign_employer_analysis_references_v16(
+    conn: sqlite3.Connection,
+    *,
+    tenant_id: str,
+    losing_job_id: str,
+    surviving_job_id: str,
+) -> dict[tuple[str, int], int]:
+    """Merge full employer-analysis histories during identity collapse."""
+    if losing_job_id == surviving_job_id:
+        return {}
+    before_counts = {
+        table: int(
+            conn.execute(f'SELECT COUNT(*) FROM "{table}"').fetchone()[0]
+        )
+        for table in _EMPLOYER_ANALYSIS_REFERENCE_TABLES
+    }
+    parent_rows = conn.execute(
+        """
+        SELECT job_id, generation, snapshot_hash, prompt_version,
+               sdk_set_version, cache_key, role_framing,
+               inferred_seniority, ideal_candidate_narrative,
+               requirements_json, keywords_json, agreement_json,
+               eeo_screen_json, legs_attempted, legs_succeeded, created_at
+        FROM job_employer_analysis
+        WHERE tenant_id = ? AND job_id IN (?, ?)
+        ORDER BY job_id, generation
+        """,
+        (tenant_id, losing_job_id, surviving_job_id),
+    ).fetchall()
+    if not parent_rows:
+        return {}
+
+    history = [
+        (
+            str(row[0]),
+            int(row[1]),
+            tuple(row[2:]),
+        )
+        for row in parent_rows
+    ]
+    ordered = _merge_employer_analysis_histories_preserving_order_v16(
+        history
+    )
+    generation_map: dict[tuple[str, int], int] = {}
+    analysis_rows: list[tuple[Any, ...]] = []
+    for new_generation, (
+        old_job_id,
+        old_generation,
+        values,
+    ) in enumerate(ordered, start=1):
+        generation_map[(old_job_id, old_generation)] = new_generation
+        analysis_rows.append(
+            (
+                tenant_id,
+                surviving_job_id,
+                new_generation,
+                *values,
+            )
+        )
+
+    sub_analysis_source = conn.execute(
+        """
+        SELECT job_id, generation, model_id, analysis_json
+        FROM job_employer_analysis_sub_analyses
+        WHERE tenant_id = ? AND job_id IN (?, ?)
+        ORDER BY job_id, generation, model_id
+        """,
+        (tenant_id, losing_job_id, surviving_job_id),
+    ).fetchall()
+    failure_source = conn.execute(
+        """
+        SELECT job_id, generation, model_id, error, raw_output
+        FROM job_employer_analysis_failures
+        WHERE tenant_id = ? AND job_id IN (?, ?)
+        ORDER BY job_id, generation, model_id
+        """,
+        (tenant_id, losing_job_id, surviving_job_id),
+    ).fetchall()
+
+    def _new_generation(row: sqlite3.Row) -> int:
+        mapped = generation_map.get((str(row[0]), int(row[1])))
+        if mapped is None:
+            raise RuntimeError(
+                "employer-analysis identity collapse found a child "
+                "without its parent generation"
+            )
+        return mapped
+
+    sub_analysis_rows = [
+        (
+            tenant_id,
+            surviving_job_id,
+            _new_generation(row),
+            *tuple(row[2:]),
+        )
+        for row in sub_analysis_source
+    ]
+    failure_rows = [
+        (
+            tenant_id,
+            surviving_job_id,
+            _new_generation(row),
+            *tuple(row[2:]),
+        )
+        for row in failure_source
+    ]
+
+    for table in (
+        "job_employer_analysis_sub_analyses",
+        "job_employer_analysis_failures",
+        "job_employer_analysis",
+    ):
+        conn.execute(
+            f"""
+            DELETE FROM {table}
+            WHERE tenant_id = ? AND job_id IN (?, ?)
+            """,
+            (tenant_id, losing_job_id, surviving_job_id),
+        )
+    conn.executemany(
+        """
+        INSERT INTO job_employer_analysis (
+            tenant_id, job_id, generation, snapshot_hash,
+            prompt_version, sdk_set_version, cache_key, role_framing,
+            inferred_seniority, ideal_candidate_narrative,
+            requirements_json, keywords_json, agreement_json,
+            eeo_screen_json, legs_attempted, legs_succeeded, created_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        analysis_rows,
+    )
+    conn.executemany(
+        """
+        INSERT INTO job_employer_analysis_sub_analyses (
+            tenant_id, job_id, generation, model_id, analysis_json
+        ) VALUES (?, ?, ?, ?, ?)
+        """,
+        sub_analysis_rows,
+    )
+    conn.executemany(
+        """
+        INSERT INTO job_employer_analysis_failures (
+            tenant_id, job_id, generation, model_id, error, raw_output
+        ) VALUES (?, ?, ?, ?, ?, ?)
+        """,
+        failure_rows,
+    )
+    _verify_employer_analysis_references_v16(
+        conn,
+        expected_counts=before_counts,
+    )
+    return generation_map
 
 
 # ---------------------------------------------------------------------------

--- a/workers/automation/src/jobctrl/domain/materials/analyze_use_case.py
+++ b/workers/automation/src/jobctrl/domain/materials/analyze_use_case.py
@@ -135,7 +135,7 @@ class AnalyzeJobUseCase:
         tenant_id: TenantId = LOCAL_TENANT,
         force: bool = False,
     ) -> AnalyzeJobOutcome:
-        job_id = JobId(str(job["url"]))
+        job_id = JobId(str(job.get("job_id") or job["url"]))
         jd_snapshot = build_jd_snapshot(job)
         snapshot_hash = compute_snapshot_hash(jd_snapshot)
         from jobctrl.domain.materials.analysis import cache_key as _cache_key

--- a/workers/automation/src/jobctrl/domain/materials/use_cases.py
+++ b/workers/automation/src/jobctrl/domain/materials/use_cases.py
@@ -3437,7 +3437,7 @@ class GenerateCoverLetterUseCase:
         tenant_id: TenantId = LOCAL_TENANT,
     ) -> CoverLetterOutcome:
         job_id = JobId(str(job.get("job_id") or job["url"]))
-        analysis_job_id = JobId(str(job["url"]))
+        analysis_job_id = job_id
         materials = _load_current_approved_materials(self._repository, tenant_id, job_id)
         if materials is None:
             return CoverLetterOutcome(

--- a/workers/automation/src/jobctrl/domain/scoring/use_cases.py
+++ b/workers/automation/src/jobctrl/domain/scoring/use_cases.py
@@ -307,12 +307,19 @@ def _build_requirement_fit_inputs_blob(
 ) -> str:
     if employer_analysis is None:
         return ""
-    job_url = str(job.get("url") or "").strip()
-    if job_url and str(employer_analysis.job_id) != job_url:
+    job_references = {
+        str(reference).strip()
+        for reference in (job.get("job_id"), job.get("url"))
+        if str(reference or "").strip()
+    }
+    if (
+        job_references
+        and str(employer_analysis.job_id) not in job_references
+    ):
         log.warning(
             "Ignoring employer analysis for %s while scoring %s",
             employer_analysis.job_id,
-            job_url,
+            sorted(job_references),
         )
         return ""
 

--- a/workers/automation/src/jobctrl/infrastructure/materials/employer_analysis_repository.py
+++ b/workers/automation/src/jobctrl/infrastructure/materials/employer_analysis_repository.py
@@ -9,6 +9,11 @@ monotonic generation allocation, and supersede-not-destroy semantics (D-13).
 The cache short-circuit (D-11/D-12) is served by :meth:`get_by_cache_key`,
 which returns the latest analysis matching a snapshot+version cache key so a
 re-tailor reuses the persisted record instead of re-reasoning.
+
+The adapter persists tenant-scoped stable ``JobId`` references. During the
+bounded schema-v15 compatibility window it translates stable IDs back to the
+legacy physical URL key; historical URL inputs are resolved only at this
+repository boundary.
 """
 
 from __future__ import annotations
@@ -18,7 +23,8 @@ import sqlite3
 from typing import Any
 
 from jobctrl.database import ensure_employer_analysis_tables
-from jobctrl.domain.identifiers import JobId
+from jobctrl.domain.discovery.value_objects import PostingUrl
+from jobctrl.domain.identifiers import JobId, canonical_job_id
 from jobctrl.domain.materials.analysis import (
     AnalysisAgreement,
     AnalysisFailure,
@@ -28,6 +34,9 @@ from jobctrl.domain.materials.analysis import (
     JobAnalysisDraft,
 )
 from jobctrl.domain.tenant import TenantId
+from jobctrl.infrastructure.discovery.sqlite_identity_resolver import (
+    SqliteJobIdentityResolver,
+)
 
 
 class SqliteEmployerAnalysisRepository:
@@ -37,6 +46,139 @@ class SqliteEmployerAnalysisRepository:
         self._conn = conn
         # Idempotent — safe if init_db already ran; keeps test setup minimal.
         ensure_employer_analysis_tables(conn)
+        self._reference_column = (
+            "job_id"
+            if "job_id"
+            in {
+                str(row[1])
+                for row in conn.execute(
+                    "PRAGMA table_info(job_employer_analysis)"
+                ).fetchall()
+            }
+            else "job_url"
+        )
+        self._identity_resolver = SqliteJobIdentityResolver(conn)
+        job_columns = {
+            str(row[1])
+            for row in conn.execute("PRAGMA table_info(jobs)").fetchall()
+        }
+        self._has_stable_identity = {
+            "tenant_id",
+            "job_id",
+        }.issubset(job_columns)
+
+    def _resolved_identity(
+        self,
+        tenant_id: TenantId,
+        reference: JobId,
+    ):
+        if not self._has_stable_identity:
+            return None
+        raw_reference = str(reference or "").strip()
+        if not raw_reference:
+            raise ValueError("job_id must be non-empty")
+        try:
+            stable_candidate = canonical_job_id(raw_reference)
+        except ValueError:
+            stable_candidate = None
+        identity = (
+            self._identity_resolver.resolve_by_job_id(
+                tenant_id,
+                stable_candidate,
+            )
+            if stable_candidate is not None
+            else None
+        )
+        if identity is None:
+            identity = self._identity_resolver.resolve_by_posting_url(
+                tenant_id,
+                PostingUrl(raw_reference),
+            )
+        if identity is None:
+            row = self._conn.execute(
+                """
+                SELECT job_id
+                FROM jobs
+                WHERE tenant_id = ? AND url = ?
+                LIMIT 1
+                """,
+                (str(tenant_id), raw_reference),
+            ).fetchone()
+            if row is not None:
+                identity = self._identity_resolver.resolve_by_job_id(
+                    tenant_id,
+                    JobId(str(row[0])),
+                )
+        return identity
+
+    def _resolved_posting_url_identity(
+        self,
+        tenant_id: TenantId,
+        posting_url: PostingUrl,
+    ):
+        """Resolve an explicitly URL-shaped input without UUID ambiguity."""
+        if not self._has_stable_identity:
+            return None
+        raw_url = str(posting_url.value or "").strip()
+        if not raw_url:
+            raise ValueError("posting_url must be non-empty")
+        direct = self._conn.execute(
+            """
+            SELECT job_id
+            FROM jobs
+            WHERE tenant_id = ? AND url = ?
+            LIMIT 1
+            """,
+            (str(tenant_id), raw_url),
+        ).fetchone()
+        if direct is not None and str(direct[0] or "").strip():
+            return self._identity_resolver.resolve_by_job_id(
+                tenant_id,
+                JobId(str(direct[0])),
+            )
+        return self._identity_resolver.resolve_by_posting_url(
+            tenant_id,
+            posting_url,
+        )
+
+    def _reference_for_read(
+        self,
+        tenant_id: TenantId,
+        reference: JobId,
+        *,
+        posting_url_first: bool = False,
+    ) -> tuple[str, JobId] | None:
+        raw_reference = str(reference or "").strip()
+        if not raw_reference:
+            raise ValueError("job_id must be non-empty")
+        identity = (
+            self._resolved_posting_url_identity(
+                tenant_id,
+                PostingUrl(raw_reference),
+            )
+            if posting_url_first
+            else self._resolved_identity(tenant_id, reference)
+        )
+        if self._reference_column == "job_id":
+            if identity is None:
+                return None
+            return str(identity.job_id), identity.job_id
+        if identity is not None:
+            return identity.storage_url.value, identity.job_id
+        return raw_reference, JobId(raw_reference)
+
+    def _reference_for_write(
+        self,
+        tenant_id: TenantId,
+        reference: JobId,
+    ) -> tuple[str, JobId]:
+        resolved = self._reference_for_read(tenant_id, reference)
+        if resolved is None:
+            raise ValueError(
+                "no stable Job identity for employer-analysis reference: "
+                f"{reference}"
+            )
+        return resolved
 
     # ------------------------------------------------------------------ read
 
@@ -47,27 +189,75 @@ class SqliteEmployerAnalysisRepository:
         *,
         generation: int | None = None,
     ) -> EmployerAnalysis | None:
+        return self._load(
+            tenant_id,
+            job_id,
+            generation=generation,
+            posting_url_first=False,
+        )
+
+    def load_by_posting_url(
+        self,
+        tenant_id: TenantId,
+        posting_url: PostingUrl,
+        *,
+        generation: int | None = None,
+    ) -> EmployerAnalysis | None:
+        """Load through the legacy URL projection boundary, URL-first."""
+        return self._load(
+            tenant_id,
+            JobId(posting_url.value),
+            generation=generation,
+            posting_url_first=True,
+        )
+
+    def _load(
+        self,
+        tenant_id: TenantId,
+        reference_input: JobId,
+        *,
+        generation: int | None,
+        posting_url_first: bool,
+    ) -> EmployerAnalysis | None:
+        resolved = self._reference_for_read(
+            tenant_id,
+            reference_input,
+            posting_url_first=posting_url_first,
+        )
+        if resolved is None:
+            return None
+        reference, stable_job_id = resolved
+        predicate = (
+            "tenant_id = ? AND job_id = ?"
+            if self._reference_column == "job_id"
+            else "tenant_id = ? AND job_url = ?"
+        )
         if generation is None:
             row = self._conn.execute(
-                """
+                f"""
                 SELECT * FROM job_employer_analysis
-                WHERE job_url = ? AND tenant_id = ?
+                WHERE {predicate}
                 ORDER BY generation DESC
                 LIMIT 1
                 """,
-                (str(job_id), str(tenant_id)),
+                (str(tenant_id), reference),
             ).fetchone()
         else:
             row = self._conn.execute(
-                """
+                f"""
                 SELECT * FROM job_employer_analysis
-                WHERE job_url = ? AND tenant_id = ? AND generation = ?
+                WHERE {predicate} AND generation = ?
                 """,
-                (str(job_id), str(tenant_id), int(generation)),
+                (str(tenant_id), reference, int(generation)),
             ).fetchone()
         if row is None:
             return None
-        return self._row_to_analysis(row, tenant_id, job_id)
+        return self._row_to_analysis(
+            row,
+            tenant_id,
+            stable_job_id,
+            reference=reference,
+        )
 
     def get_by_cache_key(
         self,
@@ -75,18 +265,28 @@ class SqliteEmployerAnalysisRepository:
         job_id: JobId,
         cache_key: str,
     ) -> EmployerAnalysis | None:
+        resolved = self._reference_for_read(tenant_id, job_id)
+        if resolved is None:
+            return None
+        reference, stable_job_id = resolved
         row = self._conn.execute(
-            """
+            f"""
             SELECT * FROM job_employer_analysis
-            WHERE job_url = ? AND tenant_id = ? AND cache_key = ?
+            WHERE tenant_id = ? AND {self._reference_column} = ?
+              AND cache_key = ?
             ORDER BY generation DESC
             LIMIT 1
             """,
-            (str(job_id), str(tenant_id), cache_key),
+            (str(tenant_id), reference, cache_key),
         ).fetchone()
         if row is None:
             return None
-        return self._row_to_analysis(row, tenant_id, job_id)
+        return self._row_to_analysis(
+            row,
+            tenant_id,
+            stable_job_id,
+            reference=reference,
+        )
 
     # ----------------------------------------------------------------- write
 
@@ -98,21 +298,30 @@ class SqliteEmployerAnalysisRepository:
         generation again overwrites the canonical row + replaces its child rows.
         Prior generations are NEVER deleted — they remain audit history.
         """
-        job_url = str(analysis.job_id)
         tenant = str(analysis.tenant_id)
+        reference, _stable_job_id = self._reference_for_write(
+            analysis.tenant_id,
+            analysis.job_id,
+        )
         generation = analysis.generation
         canonical = analysis.canonical
+        conflict_columns = (
+            "tenant_id, job_id, generation"
+            if self._reference_column == "job_id"
+            else "job_url, generation"
+        )
 
         self._conn.execute(
-            """
+            f"""
             INSERT INTO job_employer_analysis (
-                job_url, generation, tenant_id, snapshot_hash, prompt_version,
+                tenant_id, {self._reference_column}, generation,
+                snapshot_hash, prompt_version,
                 sdk_set_version, cache_key, role_framing, inferred_seniority,
                 ideal_candidate_narrative, requirements_json, keywords_json,
                 agreement_json, eeo_screen_json, legs_attempted, legs_succeeded,
                 created_at
             ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            ON CONFLICT(job_url, generation) DO UPDATE SET
+            ON CONFLICT({conflict_columns}) DO UPDATE SET
                 snapshot_hash             = excluded.snapshot_hash,
                 prompt_version            = excluded.prompt_version,
                 sdk_set_version           = excluded.sdk_set_version,
@@ -129,9 +338,9 @@ class SqliteEmployerAnalysisRepository:
                 created_at                = excluded.created_at
             """,
             (
-                job_url,
-                generation,
                 tenant,
+                reference,
+                generation,
                 analysis.snapshot_hash,
                 analysis.prompt_version,
                 analysis.sdk_set_version,
@@ -153,49 +362,70 @@ class SqliteEmployerAnalysisRepository:
 
         # Replace child rows for this generation (idempotent re-save).
         self._conn.execute(
-            "DELETE FROM job_employer_analysis_sub_analyses WHERE job_url = ? AND generation = ?",
-            (job_url, generation),
+            f"""
+            DELETE FROM job_employer_analysis_sub_analyses
+            WHERE tenant_id = ? AND {self._reference_column} = ?
+              AND generation = ?
+            """,
+            (tenant, reference, generation),
         )
         for draft in analysis.sub_analyses:
             self._conn.execute(
-                """
+                f"""
                 INSERT INTO job_employer_analysis_sub_analyses (
-                    job_url, generation, model_id, tenant_id, analysis_json
+                    tenant_id, {self._reference_column}, generation,
+                    model_id, analysis_json
                 ) VALUES (?, ?, ?, ?, ?)
                 """,
                 (
-                    job_url,
+                    tenant,
+                    reference,
                     generation,
                     draft.model_id,
-                    tenant,
                     json.dumps(draft.model_dump(exclude={"model_id"}), ensure_ascii=False),
                 ),
             )
 
         self._conn.execute(
-            "DELETE FROM job_employer_analysis_failures WHERE job_url = ? AND generation = ?",
-            (job_url, generation),
+            f"""
+            DELETE FROM job_employer_analysis_failures
+            WHERE tenant_id = ? AND {self._reference_column} = ?
+              AND generation = ?
+            """,
+            (tenant, reference, generation),
         )
         for failure in analysis.failures:
             self._conn.execute(
-                """
+                f"""
                 INSERT INTO job_employer_analysis_failures (
-                    job_url, generation, model_id, tenant_id, error, raw_output
+                    tenant_id, {self._reference_column}, generation,
+                    model_id, error, raw_output
                 ) VALUES (?, ?, ?, ?, ?, ?)
                 """,
-                (job_url, generation, failure.model_id, tenant, failure.error, failure.raw_output),
+                (
+                    tenant,
+                    reference,
+                    generation,
+                    failure.model_id,
+                    failure.error,
+                    failure.raw_output,
+                ),
             )
 
         self._conn.commit()
 
     def next_generation(self, tenant_id: TenantId, job_id: JobId) -> int:
         """Return the next generation to write for ``(tenant, job)`` (>= 1)."""
+        resolved = self._reference_for_read(tenant_id, job_id)
+        if resolved is None:
+            return 1
+        reference, _stable_job_id = resolved
         row = self._conn.execute(
-            """
+            f"""
             SELECT MAX(generation) FROM job_employer_analysis
-            WHERE job_url = ? AND tenant_id = ?
+            WHERE tenant_id = ? AND {self._reference_column} = ?
             """,
-            (str(job_id), str(tenant_id)),
+            (str(tenant_id), reference),
         ).fetchone()
         current = row[0] if row is not None else None
         return int(current) + 1 if current is not None else 1
@@ -207,6 +437,8 @@ class SqliteEmployerAnalysisRepository:
         row: sqlite3.Row,
         tenant_id: TenantId,
         job_id: JobId,
+        *,
+        reference: str,
     ) -> EmployerAnalysis:
         generation = int(row["generation"])
         canonical = JobAnalysis(
@@ -217,24 +449,26 @@ class SqliteEmployerAnalysisRepository:
             keywords=json.loads(row["keywords_json"]),
         )
         sub_rows = self._conn.execute(
-            """
+            f"""
             SELECT model_id, analysis_json FROM job_employer_analysis_sub_analyses
-            WHERE job_url = ? AND generation = ?
+            WHERE tenant_id = ? AND {self._reference_column} = ?
+              AND generation = ?
             ORDER BY model_id
             """,
-            (str(job_id), generation),
+            (str(tenant_id), reference, generation),
         ).fetchall()
         sub_analyses = tuple(
             JobAnalysisDraft(model_id=sub["model_id"], **json.loads(sub["analysis_json"]))
             for sub in sub_rows
         )
         failure_rows = self._conn.execute(
-            """
+            f"""
             SELECT model_id, error, raw_output FROM job_employer_analysis_failures
-            WHERE job_url = ? AND generation = ?
+            WHERE tenant_id = ? AND {self._reference_column} = ?
+              AND generation = ?
             ORDER BY model_id
             """,
-            (str(job_id), generation),
+            (str(tenant_id), reference, generation),
         ).fetchall()
         failures = tuple(
             AnalysisFailure(

--- a/workers/automation/src/jobctrl/infrastructure/projections/projection_builder.py
+++ b/workers/automation/src/jobctrl/infrastructure/projections/projection_builder.py
@@ -2453,8 +2453,13 @@ class ProjectionBuilder:
         )
 
         try:
-            record = SqliteEmployerAnalysisRepository(self._conn).load(
-                self._tenant_id, JobId(job_url)
+            record = (
+                SqliteEmployerAnalysisRepository(
+                    self._conn
+                ).load_by_posting_url(
+                    self._tenant_id,
+                    PostingUrl(job_url),
+                )
             )
         except sqlite3.OperationalError:
             return None

--- a/workers/automation/src/jobctrl/scoring/employer_analysis.py
+++ b/workers/automation/src/jobctrl/scoring/employer_analysis.py
@@ -9,7 +9,13 @@ from __future__ import annotations
 
 import sqlite3
 
+from jobctrl.domain.discovery.value_objects import PostingUrl
+from jobctrl.domain.identifiers import JobId
 from jobctrl.domain.ports.events import EventPublisher
+from jobctrl.domain.tenant import TenantId
+from jobctrl.infrastructure.discovery.sqlite_identity_resolver import (
+    SqliteJobIdentityResolver,
+)
 from jobctrl.infrastructure.materials import SqliteEmployerAnalysisRepository
 from jobctrl.infrastructure.setup_probes import analysis_sdk_set_version, enabled_analysis_legs
 from jobctrl.state import record_job_event
@@ -26,9 +32,44 @@ class EmployerAnalyzedEventRecorder:
         if getattr(event, "event_type", None) != "EmployerAnalyzed":
             return
         payload = dict(getattr(event, "payload", {}) or {})
-        job_url = str(payload.get("job_id") or "")
-        if not job_url:
+        raw_reference = str(payload.get("job_id") or "").strip()
+        if not raw_reference:
             return
+        tenant_id = TenantId(str(getattr(event, "tenant_id", "local")))
+        resolver = SqliteJobIdentityResolver(self._conn)
+        identity = resolver.resolve_by_job_id(
+            tenant_id,
+            JobId(raw_reference),
+        )
+        if identity is None:
+            direct = self._conn.execute(
+                """
+                SELECT job_id
+                FROM jobs
+                WHERE tenant_id = ? AND url = ?
+                LIMIT 1
+                """,
+                (str(tenant_id), raw_reference),
+            ).fetchone()
+            if direct is not None and str(direct[0] or "").strip():
+                identity = resolver.resolve_by_job_id(
+                    tenant_id,
+                    JobId(str(direct[0])),
+                )
+        if identity is None:
+            identity = resolver.resolve_by_posting_url(
+                tenant_id,
+                PostingUrl(raw_reference),
+            )
+        job_url = (
+            identity.storage_url.value
+            if identity is not None
+            else raw_reference
+        )
+        # ``job_events`` remains URL-keyed until the Phase-4 event cutover.
+        # Keep the domain event canonical in memory, but persist its legacy
+        # payload and routing key with URL semantics.
+        payload["job_id"] = job_url
         completeness = f"{payload.get('legs_succeeded')}/{payload.get('legs_attempted')}"
         record_job_event(
             self._conn,

--- a/workers/automation/src/jobctrl/scoring/scorer.py
+++ b/workers/automation/src/jobctrl/scoring/scorer.py
@@ -931,12 +931,16 @@ def _is_usable_employer_analysis(
 ) -> bool:
     if analysis is None:
         return False
-    job_url = str(job.get("url") or "").strip()
-    if job_url and str(analysis.job_id) != job_url:
+    job_references = {
+        str(reference).strip()
+        for reference in (job.get("job_id"), job.get("url"))
+        if str(reference or "").strip()
+    }
+    if job_references and str(analysis.job_id) not in job_references:
         log.warning(
             "Ignoring employer analysis for %s while scoring %s",
             analysis.job_id,
-            job_url,
+            sorted(job_references),
         )
         return False
     return bool(analysis.canonical.requirements)
@@ -948,10 +952,12 @@ def _load_employer_analysis_for_job(
     tenant_id: TenantId,
     job: dict[str, Any],
 ) -> EmployerAnalysis | None:
-    job_url = str(job.get("url") or "").strip()
-    if not job_url:
+    job_reference = str(
+        job.get("job_id") or job.get("url") or ""
+    ).strip()
+    if not job_reference:
         return None
-    analysis = repository.load(tenant_id, JobId(job_url))
+    analysis = repository.load(tenant_id, JobId(job_reference))
     if not _is_usable_employer_analysis(analysis, job):
         return None
     return analysis

--- a/workers/automation/tests/test_audit_projection_parity.py
+++ b/workers/automation/tests/test_audit_projection_parity.py
@@ -163,14 +163,14 @@ def _seed_rows(conn: sqlite3.Connection, fixture: dict[str, Any]) -> None:
         conn.execute(
             """
             INSERT INTO job_employer_analysis (
-                job_url, generation, tenant_id, snapshot_hash, prompt_version,
+                job_id, generation, tenant_id, snapshot_hash, prompt_version,
                 sdk_set_version, cache_key, role_framing, inferred_seniority,
                 ideal_candidate_narrative, requirements_json, keywords_json,
                 agreement_json, legs_attempted, legs_succeeded, created_at
             ) VALUES (?, ?, 'local', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
-                job_url,
+                job_id,
                 row["generation"],
                 row["snapshot_hash"],
                 row["prompt_version"],
@@ -191,20 +191,20 @@ def _seed_rows(conn: sqlite3.Connection, fixture: dict[str, Any]) -> None:
         conn.execute(
             """
             INSERT INTO job_employer_analysis_sub_analyses (
-                job_url, generation, model_id, tenant_id, analysis_json
+                job_id, generation, model_id, tenant_id, analysis_json
             ) VALUES (?, ?, ?, 'local', ?)
             """,
-            (job_url, sub["generation"], sub["model_id"], sub["analysis_json"]),
+            (job_id, sub["generation"], sub["model_id"], sub["analysis_json"]),
         )
     for failure in rows["jobEmployerAnalysisFailures"]:
         conn.execute(
             """
             INSERT INTO job_employer_analysis_failures (
-                job_url, generation, model_id, tenant_id, error, raw_output
+                job_id, generation, model_id, tenant_id, error, raw_output
             ) VALUES (?, ?, ?, 'local', ?, ?)
             """,
             (
-                job_url,
+                job_id,
                 failure["generation"],
                 failure["model_id"],
                 failure["error"],

--- a/workers/automation/tests/test_discovery_identity_reference_migration.py
+++ b/workers/automation/tests/test_discovery_identity_reference_migration.py
@@ -220,7 +220,7 @@ def test_v7_discovery_references_migrate_to_stable_job_id_and_reopen(
     init_db(db_path)
     close_connection(db_path)
 
-    assert _user_version(db_path) == SCHEMA_VERSION == 15
+    assert _user_version(db_path) == SCHEMA_VERSION == 16
     assert "job_id" in _columns(db_path, "job_source_observations")
     assert "job_url" not in _columns(db_path, "job_source_observations")
     assert "job_id" in _columns(db_path, "job_canonical_identities")

--- a/workers/automation/tests/test_employer_analysis_identity_reference_migration.py
+++ b/workers/automation/tests/test_employer_analysis_identity_reference_migration.py
@@ -1,0 +1,532 @@
+"""Schema-v16 employer-analysis identity migration contracts."""
+
+from __future__ import annotations
+
+import sqlite3
+import uuid
+from pathlib import Path
+
+import pytest
+
+import jobctrl.database as database_module
+from jobctrl.database import (
+    SCHEMA_VERSION,
+    close_connection,
+    ensure_employer_analysis_references_v16,
+    init_db,
+    reassign_discovery_identity_references,
+)
+from jobctrl.domain.discovery import (
+    Employer,
+    Job,
+    JobMetadata,
+    PostingUrl,
+    SearchStrategy,
+    Source,
+)
+from jobctrl.domain.identifiers import JobId
+from jobctrl.domain.tenant import LOCAL_TENANT
+from jobctrl.infrastructure.discovery import SqliteJobRepository
+
+
+PREVIOUS_SCHEMA_VERSION = 15
+
+
+def _discovered_job(posting_url: str, job_id: JobId) -> Job:
+    return Job.discover(
+        tenant_id=LOCAL_TENANT,
+        job_id=job_id,
+        posting_url=PostingUrl(value=posting_url),
+        source=Source(board="example"),
+        employer=Employer(name="Example"),
+        search_strategy=SearchStrategy.JOBSPY,
+        metadata=JobMetadata(title="Platform Engineer"),
+        discovered_at="2026-07-29T10:00:00+00:00",
+    )
+
+
+def _downgrade_employer_analysis_references_to_v15(
+    conn: sqlite3.Connection,
+) -> None:
+    for table in (
+        "job_employer_analysis_sub_analyses",
+        "job_employer_analysis_failures",
+        "job_employer_analysis",
+    ):
+        conn.execute(f'DROP TABLE "{table}"')
+    conn.executescript(
+        """
+        CREATE TABLE job_employer_analysis (
+            job_url                   TEXT NOT NULL,
+            generation                INTEGER NOT NULL,
+            tenant_id                 TEXT NOT NULL DEFAULT 'local',
+            snapshot_hash             TEXT NOT NULL,
+            prompt_version            TEXT NOT NULL,
+            sdk_set_version           TEXT NOT NULL,
+            cache_key                 TEXT NOT NULL,
+            role_framing              TEXT NOT NULL DEFAULT '',
+            inferred_seniority        TEXT NOT NULL DEFAULT '',
+            ideal_candidate_narrative TEXT NOT NULL DEFAULT '',
+            requirements_json         TEXT NOT NULL DEFAULT '[]',
+            keywords_json             TEXT NOT NULL DEFAULT '[]',
+            agreement_json            TEXT NOT NULL DEFAULT '{}',
+            eeo_screen_json           TEXT NOT NULL DEFAULT '[]',
+            legs_attempted            INTEGER NOT NULL,
+            legs_succeeded            INTEGER NOT NULL,
+            created_at                TEXT NOT NULL,
+            PRIMARY KEY (job_url, generation),
+            FOREIGN KEY (job_url) REFERENCES jobs(url) ON DELETE CASCADE
+        );
+        CREATE TABLE job_employer_analysis_sub_analyses (
+            job_url       TEXT NOT NULL,
+            generation    INTEGER NOT NULL,
+            model_id      TEXT NOT NULL,
+            tenant_id     TEXT NOT NULL DEFAULT 'local',
+            analysis_json TEXT NOT NULL,
+            PRIMARY KEY (job_url, generation, model_id),
+            FOREIGN KEY (job_url, generation)
+                REFERENCES job_employer_analysis(job_url, generation)
+                ON DELETE CASCADE
+        );
+        CREATE TABLE job_employer_analysis_failures (
+            job_url    TEXT NOT NULL,
+            generation INTEGER NOT NULL,
+            model_id   TEXT NOT NULL,
+            tenant_id  TEXT NOT NULL DEFAULT 'local',
+            error      TEXT NOT NULL,
+            raw_output TEXT,
+            PRIMARY KEY (job_url, generation, model_id),
+            FOREIGN KEY (job_url, generation)
+                REFERENCES job_employer_analysis(job_url, generation)
+                ON DELETE CASCADE
+        );
+        CREATE INDEX idx_job_employer_analysis_cache_key
+            ON job_employer_analysis(tenant_id, job_url, cache_key);
+        CREATE INDEX idx_job_employer_analysis_tenant_job_gen
+            ON job_employer_analysis(
+                tenant_id, job_url, generation DESC
+            );
+        """
+    )
+    conn.execute(f"PRAGMA user_version = {PREVIOUS_SCHEMA_VERSION}")
+    conn.commit()
+
+
+def _insert_legacy_analysis(
+    conn: sqlite3.Connection,
+    *,
+    job_url: str,
+    generation: int,
+    marker: str,
+    created_at: str,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO job_employer_analysis (
+            job_url, generation, tenant_id, snapshot_hash,
+            prompt_version, sdk_set_version, cache_key, role_framing,
+            inferred_seniority, ideal_candidate_narrative,
+            requirements_json, keywords_json, agreement_json,
+            eeo_screen_json, legs_attempted, legs_succeeded, created_at
+        ) VALUES (
+            ?, ?, 'local', ?, 'prompt-v1', 'sdk-v1', ?, ?, 'staff', ?,
+            '[]', '[]', '{}', '[]', 2, 1, ?
+        )
+        """,
+        (
+            job_url,
+            generation,
+            marker,
+            f"cache:{marker}",
+            f"role:{marker}",
+            f"narrative:{marker}",
+            created_at,
+        ),
+    )
+    conn.execute(
+        """
+        INSERT INTO job_employer_analysis_sub_analyses (
+            job_url, generation, model_id, tenant_id, analysis_json
+        ) VALUES (?, ?, ?, 'local', ?)
+        """,
+        (
+            job_url,
+            generation,
+            f"draft:{marker}",
+            f'{{"marker":"{marker}"}}',
+        ),
+    )
+    conn.execute(
+        """
+        INSERT INTO job_employer_analysis_failures (
+            job_url, generation, model_id, tenant_id, error, raw_output
+        ) VALUES (?, ?, ?, 'local', ?, NULL)
+        """,
+        (
+            job_url,
+            generation,
+            f"failure:{marker}",
+            f"error:{marker}",
+        ),
+    )
+
+
+def _columns(
+    conn: sqlite3.Connection,
+    table_name: str,
+) -> set[str]:
+    return {
+        str(row[1])
+        for row in conn.execute(
+            f'PRAGMA table_info("{table_name}")'
+        ).fetchall()
+    }
+
+
+def test_v15_employer_analysis_migrates_alias_histories_and_uuid_urls(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    conn = init_db(db_path)
+    jobs = SqliteJobRepository(conn)
+
+    stable_job_id = JobId(str(uuid.uuid4()))
+    original_url = "https://boards.example/jobs/123"
+    current_url = "https://careers.example/jobs/platform-engineer"
+    jobs.save(_discovered_job(original_url, stable_job_id))
+    jobs.save(_discovered_job(current_url, stable_job_id))
+
+    uuid_shaped_url = str(uuid.uuid4())
+    uuid_url_owner = JobId(str(uuid.uuid4()))
+    jobs.save(_discovered_job(uuid_shaped_url, uuid_url_owner))
+    jobs.save(
+        _discovered_job(
+            "https://example.com/jobs/id-text-collision",
+            JobId(uuid_shaped_url),
+        )
+    )
+
+    _downgrade_employer_analysis_references_to_v15(conn)
+    _insert_legacy_analysis(
+        conn,
+        job_url=original_url,
+        generation=1,
+        marker="original-1",
+        created_at="2026-07-29T10:00:00+00:00",
+    )
+    _insert_legacy_analysis(
+        conn,
+        job_url=current_url,
+        generation=1,
+        marker="current-1",
+        created_at="2026-07-29T10:01:00+00:00",
+    )
+    _insert_legacy_analysis(
+        conn,
+        job_url=original_url,
+        generation=2,
+        marker="original-2",
+        created_at="2026-07-29T10:02:00+00:00",
+    )
+    _insert_legacy_analysis(
+        conn,
+        job_url=uuid_shaped_url,
+        generation=1,
+        marker="uuid-url-owner",
+        created_at="2026-07-29T10:03:00+00:00",
+    )
+    conn.commit()
+    close_connection(db_path)
+
+    reopened = init_db(db_path)
+    assert (
+        reopened.execute("PRAGMA user_version").fetchone()[0]
+        == SCHEMA_VERSION
+        == 16
+    )
+    for table in database_module._EMPLOYER_ANALYSIS_REFERENCE_TABLES:
+        assert "job_id" in _columns(reopened, table)
+        assert "job_url" not in _columns(reopened, table)
+        assert reopened.execute(
+            f'SELECT COUNT(*) FROM "{table}"'
+        ).fetchone()[0] == 4
+
+    merged = reopened.execute(
+        """
+        SELECT generation, snapshot_hash
+        FROM job_employer_analysis
+        WHERE tenant_id = 'local' AND job_id = ?
+        ORDER BY generation
+        """,
+        (str(stable_job_id),),
+    ).fetchall()
+    assert [tuple(row) for row in merged] == [
+        (1, "original-1"),
+        (2, "current-1"),
+        (3, "original-2"),
+    ]
+    assert reopened.execute(
+        """
+        SELECT job_id
+        FROM job_employer_analysis
+        WHERE snapshot_hash = 'uuid-url-owner'
+        """
+    ).fetchone()[0] == str(uuid_url_owner)
+    assert reopened.execute("PRAGMA foreign_key_check").fetchone() is None
+    close_connection(db_path)
+
+    reopened_again = init_db(db_path)
+    assert (
+        reopened_again.execute("PRAGMA user_version").fetchone()[0]
+        == SCHEMA_VERSION
+    )
+    assert reopened_again.execute(
+        "SELECT COUNT(*) FROM job_employer_analysis"
+    ).fetchone()[0] == 4
+    close_connection(db_path)
+
+
+def test_v16_employer_analysis_migration_rolls_back_and_retries(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    conn = init_db(db_path)
+    job_id = JobId(str(uuid.uuid4()))
+    job_url = "https://example.com/jobs/retry"
+    SqliteJobRepository(conn).save(_discovered_job(job_url, job_id))
+    _downgrade_employer_analysis_references_to_v15(conn)
+    _insert_legacy_analysis(
+        conn,
+        job_url=job_url,
+        generation=1,
+        marker="retry",
+        created_at="2026-07-29T10:00:00+00:00",
+    )
+    conn.commit()
+
+    original_verify = (
+        database_module._verify_employer_analysis_references_v16
+    )
+
+    def _fail_verification(
+        _conn: sqlite3.Connection,
+        *,
+        expected_counts: dict[str, int],
+    ) -> None:
+        del expected_counts
+        raise RuntimeError("injected employer-analysis verification failure")
+
+    monkeypatch.setattr(
+        database_module,
+        "_verify_employer_analysis_references_v16",
+        _fail_verification,
+    )
+    with pytest.raises(
+        RuntimeError,
+        match="injected employer-analysis verification failure",
+    ):
+        ensure_employer_analysis_references_v16(conn)
+    assert conn.execute("PRAGMA user_version").fetchone()[0] == 15
+    assert "job_url" in _columns(conn, "job_employer_analysis")
+    assert conn.execute(
+        "SELECT COUNT(*) FROM job_employer_analysis"
+    ).fetchone()[0] == 1
+
+    monkeypatch.setattr(
+        database_module,
+        "_verify_employer_analysis_references_v16",
+        original_verify,
+    )
+    assert ensure_employer_analysis_references_v16(conn) == list(
+        database_module._EMPLOYER_ANALYSIS_REFERENCE_TABLES
+    )
+    assert conn.execute("PRAGMA user_version").fetchone()[0] == 16
+    assert "job_id" in _columns(conn, "job_employer_analysis")
+    assert conn.execute("PRAGMA foreign_key_check").fetchone() is None
+    close_connection(db_path)
+
+
+def test_runtime_employer_analysis_merge_preserves_all_histories(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    conn = init_db(db_path)
+    jobs = SqliteJobRepository(conn)
+    losing_id = JobId(str(uuid.uuid4()))
+    surviving_id = JobId(str(uuid.uuid4()))
+    losing_url = "https://example.com/jobs/losing"
+    surviving_url = "https://example.com/jobs/surviving"
+    jobs.save(
+        _discovered_job(
+            losing_url,
+            losing_id,
+        )
+    )
+    jobs.save(
+        _discovered_job(
+            surviving_url,
+            surviving_id,
+        )
+    )
+
+    def _insert_stable(
+        *,
+        job_id: JobId,
+        generation: int,
+        marker: str,
+        created_at: str,
+    ) -> None:
+        conn.execute(
+            """
+            INSERT INTO job_employer_analysis (
+                tenant_id, job_id, generation, snapshot_hash,
+                prompt_version, sdk_set_version, cache_key,
+                role_framing, inferred_seniority,
+                ideal_candidate_narrative, requirements_json,
+                keywords_json, agreement_json, eeo_screen_json,
+                legs_attempted, legs_succeeded, created_at
+            ) VALUES (
+                'local', ?, ?, ?, 'prompt-v1', 'sdk-v1', ?, ?, 'staff',
+                ?, '[]', '[]', '{}', '[]', 2, 1, ?
+            )
+            """,
+            (
+                str(job_id),
+                generation,
+                marker,
+                f"cache:{marker}",
+                f"role:{marker}",
+                f"narrative:{marker}",
+                created_at,
+            ),
+        )
+        conn.execute(
+            """
+            INSERT INTO job_employer_analysis_sub_analyses (
+                tenant_id, job_id, generation, model_id, analysis_json
+            ) VALUES ('local', ?, ?, ?, '{}')
+            """,
+            (str(job_id), generation, f"draft:{marker}"),
+        )
+        conn.execute(
+            """
+            INSERT INTO job_employer_analysis_failures (
+                tenant_id, job_id, generation, model_id, error, raw_output
+            ) VALUES ('local', ?, ?, ?, ?, NULL)
+            """,
+            (
+                str(job_id),
+                generation,
+                f"failure:{marker}",
+                f"error:{marker}",
+            ),
+        )
+
+    _insert_stable(
+        job_id=losing_id,
+        generation=1,
+        marker="losing-1",
+        created_at="2026-07-29T10:00:00+00:00",
+    )
+    _insert_stable(
+        job_id=surviving_id,
+        generation=1,
+        marker="surviving-1",
+        created_at="2026-07-29T10:01:00+00:00",
+    )
+    _insert_stable(
+        job_id=losing_id,
+        generation=2,
+        marker="losing-2",
+        created_at="2026-07-29T10:02:00+00:00",
+    )
+    conn.executemany(
+        """
+        INSERT INTO job_scores (
+            tenant_id, job_id, version, fit_score, breakdown_json,
+            keywords_json, scored_at, correction_json,
+            criteria_json, trace_json
+        ) VALUES ('local', ?, 1, ?, '{}', '[]', ?, NULL, '{}', '{}')
+        """,
+        (
+            (
+                str(losing_id),
+                7,
+                "2026-07-29T10:10:00+00:00",
+            ),
+            (
+                str(surviving_id),
+                8,
+                "2026-07-29T10:11:00+00:00",
+            ),
+        ),
+    )
+    conn.executemany(
+        """
+        INSERT INTO job_requirement_fit_reports (
+            tenant_id, job_id, score_version,
+            employer_analysis_generation, profile_snapshot_version,
+            scoring_policy_version, formula_version, resolved_fit_score,
+            fit_band, confidence, summary_json, created_at
+        ) VALUES (
+            'local', ?, 1, 1, 1, 1, 'v1', ?, 'strong', 'high', ?, ?
+        )
+        """,
+        (
+            (
+                str(losing_id),
+                7,
+                '{"source":"losing"}',
+                "2026-07-29T10:10:00+00:00",
+            ),
+            (
+                str(surviving_id),
+                8,
+                '{"source":"surviving"}',
+                "2026-07-29T10:11:00+00:00",
+            ),
+        ),
+    )
+    conn.commit()
+
+    reassign_discovery_identity_references(
+        conn,
+        losing_job_url=losing_url,
+        surviving_job_url=surviving_url,
+    )
+    for table in database_module._EMPLOYER_ANALYSIS_REFERENCE_TABLES:
+        assert conn.execute(
+            f'SELECT COUNT(*) FROM "{table}"'
+        ).fetchone()[0] == 3
+        assert {
+            row[0]
+            for row in conn.execute(
+                f'SELECT DISTINCT job_id FROM "{table}"'
+            ).fetchall()
+        } == {str(surviving_id)}
+    analyses = conn.execute(
+        """
+        SELECT generation, snapshot_hash
+        FROM job_employer_analysis
+        ORDER BY generation
+        """
+    ).fetchall()
+    assert [tuple(row) for row in analyses] == [
+        (1, "losing-1"),
+        (2, "surviving-1"),
+        (3, "losing-2"),
+    ]
+    report_bindings = conn.execute(
+        """
+        SELECT score_version, employer_analysis_generation, summary_json
+        FROM job_requirement_fit_reports
+        ORDER BY score_version
+        """
+    ).fetchall()
+    assert [tuple(row) for row in report_bindings] == [
+        (1, 1, '{"source":"losing"}'),
+        (2, 2, '{"source":"surviving"}'),
+    ]
+    assert conn.execute("PRAGMA foreign_key_check").fetchone() is None
+    close_connection(db_path)

--- a/workers/automation/tests/test_employer_analysis_projection.py
+++ b/workers/automation/tests/test_employer_analysis_projection.py
@@ -18,6 +18,10 @@ from collections.abc import Iterator
 import pytest
 
 from jobctrl.database import close_connection, init_db
+from jobctrl.domain.events import (
+    EmployerAnalyzedPayload,
+    create_employer_analyzed,
+)
 from jobctrl.domain.identifiers import JobId
 from jobctrl.domain.materials.analysis import (
     AnalysisAgreement,
@@ -43,6 +47,7 @@ from jobctrl.domain.tenant import LOCAL_TENANT
 from jobctrl.infrastructure.materials import SqliteEmployerAnalysisRepository
 from jobctrl.infrastructure.projections.projection_builder import ProjectionBuilder
 from jobctrl.infrastructure.scoring import SqliteRequirementFitReportRepository
+from jobctrl.scoring.employer_analysis import EmployerAnalyzedEventRecorder
 
 JOB_URL = "https://example.com/jobs/event-driven"
 JD = "Senior Event Engineer. Requires 5+ years Python. Kafka is a plus."
@@ -61,11 +66,16 @@ def conn(tmp_path) -> Iterator[sqlite3.Connection]:
     close_connection()
 
 
-def _analysis(generation: int) -> EmployerAnalysis:
+def _analysis(
+    generation: int,
+    *,
+    job_id: str = JOB_URL,
+    narrative: str = "A hands-on platform owner.",
+) -> EmployerAnalysis:
     canonical = JobAnalysis(
         role_framing="Own the event platform.",
         inferred_seniority="senior",
-        ideal_candidate_narrative="A hands-on platform owner.",
+        ideal_candidate_narrative=narrative,
         requirements=[
             Requirement(
                 id="r1",
@@ -81,7 +91,7 @@ def _analysis(generation: int) -> EmployerAnalysis:
     )
     return EmployerAnalysis.build(
         tenant_id=LOCAL_TENANT,
-        job_id=JobId(JOB_URL),
+        job_id=JobId(job_id),
         generation=generation,
         snapshot_hash=compute_snapshot_hash(JD),
         canonical=canonical,
@@ -175,6 +185,140 @@ def test_projection_serves_latest_canonical_analysis_read_model(conn: sqlite3.Co
     assert served["is_degraded"] is True
     assert served["requirements"][0]["tier"] == "must_have"
     assert served["failures"][0]["model_id"] == "gpt-5.4"
+
+
+def test_stable_analysis_event_keeps_legacy_url_and_refreshes_incrementally(
+    conn: sqlite3.Connection,
+) -> None:
+    builder = ProjectionBuilder(conn_factory=lambda: conn)
+    builder.refresh()
+    stable_job_id = str(
+        conn.execute(
+            """
+            SELECT job_id
+            FROM jobs
+            WHERE tenant_id = 'local' AND url = ?
+            """,
+            (JOB_URL,),
+        ).fetchone()[0]
+    )
+    record = _analysis(generation=1, job_id=stable_job_id)
+    SqliteEmployerAnalysisRepository(conn).save(record)
+    event = create_employer_analyzed(
+        LOCAL_TENANT,
+        EmployerAnalyzedPayload(
+            job_id=stable_job_id,
+            generation=record.generation,
+            snapshot_hash=record.snapshot_hash,
+            cache_key=record.cache_key,
+            legs_attempted=record.legs_attempted,
+            legs_succeeded=record.legs_succeeded,
+            analyzed_at="2026-07-29T12:00:00+00:00",
+        ),
+    )
+
+    EmployerAnalyzedEventRecorder(conn, stage="score").publish(event)
+
+    stored_event = conn.execute(
+        """
+        SELECT job_url, payload_json
+        FROM job_events
+        WHERE event_type = 'EmployerAnalyzed'
+        ORDER BY event_id DESC
+        LIMIT 1
+        """
+    ).fetchone()
+    assert stored_event["job_url"] == JOB_URL
+    assert json.loads(stored_event["payload_json"])["job_id"] == JOB_URL
+
+    assert builder.refresh() == 1
+    projected = conn.execute(
+        """
+        SELECT employer_analysis_json
+        FROM job_detail_projections
+        WHERE tenant_id = 'local' AND job_id = ?
+        """,
+        (JOB_URL,),
+    ).fetchone()
+    assert projected is not None
+    assert json.loads(projected["employer_analysis_json"])[
+        "generation"
+    ] == 1
+
+
+def test_projection_resolves_uuid_shaped_posting_url_before_job_id(
+    tmp_path,
+) -> None:
+    db_path = tmp_path / "uuid-url.db"
+    connection = init_db(db_path)
+    uuid_url = "11111111-1111-4111-8111-111111111111"
+    url_owner_id = "22222222-2222-4222-8222-222222222222"
+    id_owner_url = "https://example.com/jobs/id-text-owner"
+    connection.executemany(
+        """
+        INSERT INTO jobs (
+            url, tenant_id, job_id, title, site, discovered_at
+        ) VALUES (?, 'local', ?, ?, 'example', ?)
+        """,
+        (
+            (
+                uuid_url,
+                url_owner_id,
+                "URL owner",
+                "2026-07-29T10:00:00+00:00",
+            ),
+            (
+                id_owner_url,
+                uuid_url,
+                "ID-text owner",
+                "2026-07-29T10:01:00+00:00",
+            ),
+        ),
+    )
+    repository = SqliteEmployerAnalysisRepository(connection)
+    repository.save(
+        _analysis(
+            1,
+            job_id=url_owner_id,
+            narrative="Analysis owned by the UUID-shaped URL.",
+        )
+    )
+    repository.save(
+        _analysis(
+            1,
+            job_id=uuid_url,
+            narrative="Analysis owned by the colliding JobId.",
+        )
+    )
+    connection.execute(
+        """
+        INSERT INTO job_events (
+            job_url, stage, event_type, level, message,
+            occurred_at, payload_json
+        ) VALUES (
+            ?, 'score', 'EmployerAnalyzed', 'info', 'analyzed',
+            '2026-07-29T12:00:00+00:00', '{}'
+        )
+        """,
+        (uuid_url,),
+    )
+    connection.commit()
+
+    ProjectionBuilder(conn_factory=lambda: connection).refresh()
+
+    projection = connection.execute(
+        """
+        SELECT employer_analysis_json
+        FROM job_detail_projections
+        WHERE tenant_id = 'local' AND job_id = ?
+        """,
+        (uuid_url,),
+    ).fetchone()
+    assert projection is not None
+    assert json.loads(projection["employer_analysis_json"])[
+        "ideal_candidate_narrative"
+    ] == "Analysis owned by the UUID-shaped URL."
+    close_connection(db_path)
 
 
 def test_projection_analysis_is_null_when_no_analysis_exists(conn: sqlite3.Connection) -> None:

--- a/workers/automation/tests/test_employer_analysis_repository.py
+++ b/workers/automation/tests/test_employer_analysis_repository.py
@@ -86,6 +86,14 @@ def test_round_trip_preserves_canonical_subanalyses_failures(conn: sqlite3.Conne
 
     loaded = repo.load(LOCAL_TENANT, JobId(JOB_URL))
     assert loaded is not None
+    stable_job_id = conn.execute(
+        "SELECT job_id FROM jobs WHERE url = ?",
+        (JOB_URL,),
+    ).fetchone()[0]
+    assert str(loaded.job_id) == stable_job_id
+    assert conn.execute(
+        "SELECT job_id FROM job_employer_analysis"
+    ).fetchone()[0] == stable_job_id
     assert loaded.generation == 1
     assert loaded.canonical.requirements[0].tier == "must_have"
     assert loaded.canonical.requirements[0].weight == 0.95

--- a/workers/automation/tests/test_enrichment_snapshot_identity_reference_migration.py
+++ b/workers/automation/tests/test_enrichment_snapshot_identity_reference_migration.py
@@ -322,7 +322,7 @@ def test_v10_enrichment_snapshot_references_migrate_and_reopen(
     init_db(db_path)
     close_connection(db_path)
 
-    assert _user_version(db_path) == SCHEMA_VERSION == 15
+    assert _user_version(db_path) == SCHEMA_VERSION == 16
     check = sqlite3.connect(db_path)
     try:
         enrichment_rows = check.execute(

--- a/workers/automation/tests/test_execution_search_identity_reference_migration.py
+++ b/workers/automation/tests/test_execution_search_identity_reference_migration.py
@@ -261,7 +261,7 @@ def test_v8_execution_and_receipts_migrate_to_stable_job_id_and_reopen(
     init_db(db_path)
     close_connection(db_path)
 
-    assert _user_version(db_path) == SCHEMA_VERSION == 15
+    assert _user_version(db_path) == SCHEMA_VERSION == 16
     assert "job_id" in _columns(db_path, "discovery_execution_jobs")
     assert "job_url" not in _columns(db_path, "discovery_execution_jobs")
     assert "job_id" in _columns(db_path, "discovery_search_unit_jobs")

--- a/workers/automation/tests/test_materials_identity_reference_migration.py
+++ b/workers/automation/tests/test_materials_identity_reference_migration.py
@@ -293,7 +293,7 @@ def test_v14_materials_migrate_alias_histories_and_uuid_shaped_urls(
     close_connection(db_path)
 
     reopened = init_db(db_path)
-    assert reopened.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_VERSION == 15
+    assert reopened.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_VERSION == 16
     for table in database_module._MATERIALS_REFERENCE_TABLES:
         assert "job_id" in _columns(reopened, table)
         assert "job_url" not in _columns(reopened, table)

--- a/workers/automation/tests/test_preparation_identity_reference_migration.py
+++ b/workers/automation/tests/test_preparation_identity_reference_migration.py
@@ -177,7 +177,7 @@ def test_v9_preparation_references_migrate_to_stable_job_ids_and_reopen(
     init_db(db_path)
     close_connection(db_path)
 
-    assert _user_version(db_path) == SCHEMA_VERSION == 15
+    assert _user_version(db_path) == SCHEMA_VERSION == 16
     check = sqlite3.connect(db_path)
     try:
         rows = check.execute(

--- a/workers/automation/tests/test_repeat_application_prevention.py
+++ b/workers/automation/tests/test_repeat_application_prevention.py
@@ -750,7 +750,7 @@ def test_schema_v5_migrates_additively_without_changing_application_facts(
         (PRIOR,),
     ).fetchall()
 
-    assert int(migrated.execute("PRAGMA user_version").fetchone()[0]) == SCHEMA_VERSION == 15
+    assert int(migrated.execute("PRAGMA user_version").fetchone()[0]) == SCHEMA_VERSION == 16
     assert [tuple(row) for row in after] == [tuple(row) for row in before]
     assert "metadata_json" in {
         str(row[1]) for row in migrated.execute("PRAGMA table_info(job_stage_states)").fetchall()

--- a/workers/automation/tests/test_scoring_identity_reference_migration.py
+++ b/workers/automation/tests/test_scoring_identity_reference_migration.py
@@ -338,7 +338,7 @@ def test_v11_scoring_references_migrate_alias_histories_and_reopen(
     assert (
         int(migrated.execute("PRAGMA user_version").fetchone()[0])
         == SCHEMA_VERSION
-        == 15
+        == 16
     )
     assert _columns(migrated, "job_scores") >= {"tenant_id", "job_id"}
     assert "job_url" not in _columns(migrated, "job_scores")
@@ -404,7 +404,7 @@ def test_v11_scoring_references_migrate_alias_histories_and_reopen(
     assert (
         int(reopened.execute("PRAGMA user_version").fetchone()[0])
         == SCHEMA_VERSION
-        == 15
+        == 16
     )
 
 
@@ -553,7 +553,7 @@ def test_scoring_migration_rolls_back_and_retries_after_verification_failure(
     assert (
         int(retried.execute("PRAGMA user_version").fetchone()[0])
         == SCHEMA_VERSION
-        == 15
+        == 16
     )
     assert [
         tuple(row)

--- a/workers/automation/tests/test_stable_job_identity_migration.py
+++ b/workers/automation/tests/test_stable_job_identity_migration.py
@@ -743,7 +743,7 @@ def test_v6_jobs_gain_stable_uuid_and_posting_url_alias_once(
     init_db(db_path)
     close_connection(db_path)
 
-    assert _user_version(db_path) == SCHEMA_VERSION == 15
+    assert _user_version(db_path) == SCHEMA_VERSION == 16
     first_ids = _identity_rows(db_path)
     assert [row[0] for row in first_ids] == ["local", "local"]
     for _tenant_id, job_id, _url in first_ids:


### PR DESCRIPTION
## Summary
- migrate `job_employer_analysis` and both child tables from URL-shaped keys to tenant-scoped stable `JobId` references in schema v16
- preserve and deterministically merge every analysis generation, sub-analysis, failure, and requirement-fit generation binding during identity collapse
- keep the pre-Phase-4 `job_events` contract URL-keyed at its adapter boundary while domain records stay JobId-based
- make Python projections and the Apply review queue resolve URL inputs URL-first, including UUID-shaped URL/JobId collisions
- explicitly purge employer-analysis children during permanent deletion even when SQLite foreign-key enforcement is disabled

## Why
This is the next small Phase-3 slice in the stable Job identity stack. Employer analysis is an auditable aggregate with downstream scoring bindings, so its complete graph must move before workflow/event/API identity is cut over.

## Migration guarantees
- transactional v15 -> v16 migration with rollback/retry and reopen idempotency
- exact parent/child row-count preservation and foreign-key verification
- URL-alias histories retain source ordering during deterministic generation renumbering
- UUID-shaped posting URLs remain owned by the URL match, never by a colliding JobId
- runtime identity collapse remaps requirement-fit reports to the correct renumbered analysis generation

## Validation
- `PYTHONPATH=src .../.venv/bin/python -m pytest -q` — 2693 passed, 2 skipped
- `pnpm --dir apps/api exec vitest run` — 670 passed
- focused adjacent Python suites — 142 passed
- focused deletion and URL-collision API regressions — 2 passed
- `pnpm --dir apps/api check` — passed
- `ruff check src tests` — passed
- `git diff --check` — passed
- independent review — PASS, Blocker/High/Medium/Low = 0/0/0/0
- independent QA — PASS, Blocker/High/Medium/Low = 0/0/0/0

## Stack
Base: `feat/job-id-materials-references` (#540).

Remaining Phase-3 authority families (template refresh, interview prep, compensation, Apply/outcomes, contacts/outreach/feedback, and the final jobs authority rebuild) stay in later small stacked PRs. Canonical product docs and cumulative Tier-3 QA remain deferred to the final approved stack PR.