### PR TITLE
feat(materials): migrate resume-template references to stable JobIds

### DIFF
--- a/apps/api/src/db.ts
+++ b/apps/api/src/db.ts
@@ -9,7 +9,7 @@ export type SqliteValue = string | number | bigint | null;
 // writer that stamps ``PRAGMA user_version``; the API only reads it to fail
 // closed on a database written by a newer build. Bump both constants together
 // whenever the schema shape changes.
-export const SUPPORTED_SCHEMA_VERSION = 16;
+export const SUPPORTED_SCHEMA_VERSION = 17;
 
 export class IncompatibleSchemaVersionError extends Error {
   constructor(current: number) {

--- a/apps/api/src/resume-templates.ts
+++ b/apps/api/src/resume-templates.ts
@@ -91,7 +91,6 @@ interface MaterialArtifactRow extends Record<string, unknown> {
 
 interface RefreshAttemptRow extends Record<string, unknown> {
   attempt_id: string;
-  job_url: string;
   status: string;
   from_generation: number | null;
   to_generation: number | null;
@@ -127,6 +126,39 @@ export const BUILT_IN_RESUME_TEMPLATE_THEME: ResumeTemplateTheme =
 const EMPTY_LAYOUT: ResumeTemplateLayout = ResumeTemplateLayoutSchema.parse({});
 
 export function ensureResumeTemplateTables(db: SqliteDatabase): void {
+  const schemaVersion = db.pragma("user_version", {
+    simple: true,
+  }) as number;
+  const assignmentColumns = tableColumnSet(
+    db,
+    "job_resume_template_assignments",
+  );
+  const assignmentReference =
+    assignmentColumns.includes("job_id") ||
+    (!assignmentColumns.length && schemaVersion >= 17)
+      ? "job_id"
+      : "job_url";
+  const refreshColumns = tableColumnSet(
+    db,
+    "resume_template_refresh_attempts",
+  );
+  const refreshReference =
+    refreshColumns.includes("job_id") ||
+    (!refreshColumns.length && schemaVersion >= 17)
+      ? "job_id"
+      : "job_url";
+  const assignmentForeignKey =
+    assignmentReference === "job_id"
+      ? `,
+      FOREIGN KEY (tenant_id, job_id)
+        REFERENCES jobs(tenant_id, job_id) ON DELETE CASCADE`
+      : "";
+  const refreshForeignKey =
+    refreshReference === "job_id"
+      ? `,
+      FOREIGN KEY (tenant_id, job_id)
+        REFERENCES jobs(tenant_id, job_id) ON DELETE CASCADE`
+      : "";
   db.exec(`
     CREATE TABLE IF NOT EXISTS resume_templates (
       tenant_id    TEXT NOT NULL DEFAULT 'local',
@@ -166,11 +198,12 @@ export function ensureResumeTemplateTables(db: SqliteDatabase): void {
 
     CREATE TABLE IF NOT EXISTS job_resume_template_assignments (
       tenant_id   TEXT NOT NULL DEFAULT 'local',
-      job_url     TEXT NOT NULL,
+      ${assignmentReference} TEXT NOT NULL,
       template_id TEXT NOT NULL,
       version_id  TEXT NOT NULL,
       updated_at  TEXT NOT NULL,
-      PRIMARY KEY (tenant_id, job_url)
+      PRIMARY KEY (tenant_id, ${assignmentReference})
+      ${assignmentForeignKey}
     );
     CREATE INDEX IF NOT EXISTS idx_job_resume_template_assignments_template
       ON job_resume_template_assignments(tenant_id, template_id, version_id);
@@ -178,7 +211,7 @@ export function ensureResumeTemplateTables(db: SqliteDatabase): void {
     CREATE TABLE IF NOT EXISTS resume_template_refresh_attempts (
       tenant_id           TEXT NOT NULL DEFAULT 'local',
       attempt_id          TEXT NOT NULL,
-      job_url             TEXT NOT NULL,
+      ${refreshReference} TEXT NOT NULL,
       status              TEXT NOT NULL,
       from_generation     INTEGER,
       to_generation       INTEGER,
@@ -190,9 +223,12 @@ export function ensureResumeTemplateTables(db: SqliteDatabase): void {
       created_at          TEXT NOT NULL,
       completed_at        TEXT,
       PRIMARY KEY (tenant_id, attempt_id)
+      ${refreshForeignKey}
     );
     CREATE INDEX IF NOT EXISTS idx_resume_template_refresh_attempts_job
-      ON resume_template_refresh_attempts(tenant_id, job_url, created_at DESC);
+      ON resume_template_refresh_attempts(
+        tenant_id, ${refreshReference}, created_at DESC
+      );
   `);
   seedBuiltInResumeTemplate(db);
 }
@@ -319,14 +355,24 @@ export function setJobResumeTemplateAssignment(
   let overrideTemplate: ResumeTemplateMetadata | null = null;
 
   if (request.templateId === null) {
+    const assignmentReference = jobReferencePredicateForUrl(
+      db,
+      "job_resume_template_assignments",
+      jobKey,
+      DEFAULT_TENANT,
+    );
     db.prepare(
-      "DELETE FROM job_resume_template_assignments WHERE tenant_id = ? AND job_url = ?",
-    ).run(DEFAULT_TENANT, jobKey);
+      `DELETE FROM job_resume_template_assignments
+        WHERE ${assignmentReference.sql}`,
+    ).run(...assignmentReference.params);
   } else if (request.templateId) {
     const effective = resolveTemplateByRequest(db, request.templateId, request.versionId ?? undefined, "job_override");
     insertDynamicRow(db, "job_resume_template_assignments", {
-      tenant_id: DEFAULT_TENANT,
-      job_url: jobKey,
+      ...materialIdentityValues(
+        db,
+        "job_resume_template_assignments",
+        jobKey,
+      ),
       template_id: effective.metadata.templateId,
       version_id: effective.metadata.templateVersionId,
       updated_at: now,
@@ -360,12 +406,18 @@ export function setJobResumeTemplateAssignment(
 export function resolveEffectiveResumeTemplate(db: SqliteDatabase, jobKey?: string | null): EffectiveTemplate {
   ensureResumeTemplateTables(db);
   if (jobKey) {
+    const assignmentReference = jobReferencePredicateForUrl(
+      db,
+      "job_resume_template_assignments",
+      jobKey,
+      DEFAULT_TENANT,
+    );
     const assignment = getRow<AssignmentRow>(
       db,
       `SELECT template_id, version_id, updated_at
          FROM job_resume_template_assignments
-        WHERE tenant_id = ? AND job_url = ?`,
-      [DEFAULT_TENANT, jobKey],
+        WHERE ${assignmentReference.sql}`,
+      assignmentReference.params,
     );
     if (assignment?.template_id && assignment.version_id) {
       return resolveTemplateByRequest(db, assignment.template_id, assignment.version_id, "job_override");
@@ -968,16 +1020,24 @@ function reasonForTemplateState(
 
 function latestRefreshAttempt(db: SqliteDatabase, jobKey: string): ResumeTemplateRefreshAttempt | null {
   if (!tableExists(db, "resume_template_refresh_attempts")) return null;
+  const refreshReference = jobReferencePredicateForUrl(
+    db,
+    "resume_template_refresh_attempts",
+    jobKey,
+    DEFAULT_TENANT,
+  );
   const row = getRow<RefreshAttemptRow>(
     db,
     `SELECT *
        FROM resume_template_refresh_attempts
-      WHERE tenant_id = ? AND job_url = ?
-      ORDER BY created_at DESC, attempt_id DESC
+      WHERE ${refreshReference.sql}
+      ORDER BY created_at DESC,
+               CASE WHEN completed_at IS NULL THEN 1 ELSE 0 END,
+               attempt_id DESC
       LIMIT 1`,
-    [DEFAULT_TENANT, jobKey],
+    refreshReference.params,
   );
-  return row ? refreshAttemptFromRow(row) : null;
+  return row ? refreshAttemptFromRow(row, jobKey) : null;
 }
 
 function recordRefreshAttempt(
@@ -994,9 +1054,12 @@ function recordRefreshAttempt(
   const now = new Date().toISOString();
   const attemptId = `template_refresh_${crypto.randomUUID()}`;
   insertDynamicRow(db, "resume_template_refresh_attempts", {
-    tenant_id: DEFAULT_TENANT,
+    ...materialIdentityValues(
+      db,
+      "resume_template_refresh_attempts",
+      input.jobKey,
+    ),
     attempt_id: attemptId,
-    job_url: input.jobKey,
     status: input.status,
     from_generation: input.fromGeneration,
     to_generation: input.toGeneration,
@@ -1014,14 +1077,17 @@ function recordRefreshAttempt(
     [DEFAULT_TENANT, attemptId],
   );
   if (!row) throw new Error("Template refresh attempt was not persisted.");
-  return refreshAttemptFromRow(row);
+  return refreshAttemptFromRow(row, input.jobKey);
 }
 
-function refreshAttemptFromRow(row: RefreshAttemptRow): ResumeTemplateRefreshAttempt {
+function refreshAttemptFromRow(
+  row: RefreshAttemptRow,
+  jobKey: string,
+): ResumeTemplateRefreshAttempt {
   const status = stringValue(row.status);
   return {
     attemptId: row.attempt_id,
-    jobKey: row.job_url,
+    jobKey,
     status:
       status === "queued" ||
       status === "completed" ||

--- a/apps/api/src/write-model.ts
+++ b/apps/api/src/write-model.ts
@@ -860,6 +860,8 @@ function purgeJobRows(db: SqliteDatabase, jobUrl: string): void {
     "job_employer_analysis_sub_analyses",
     "job_employer_analysis_failures",
     "job_employer_analysis",
+    "resume_template_refresh_attempts",
+    "job_resume_template_assignments",
   ]) {
     deleteJobReferences(db, tableName, jobId, jobUrl);
   }

--- a/apps/api/test/resume-templates.test.ts
+++ b/apps/api/test/resume-templates.test.ts
@@ -17,8 +17,11 @@ import {
   setJobResumeTemplateAssignment,
 } from "../src/resume-templates.js";
 import type { ResumeHtmlPdfRenderer } from "../src/resume-pdf-render.js";
+import { permanentlyDeleteJob } from "../src/write-model.js";
 
 const JOB_KEY = "https://example.com/jobs/template-engineer";
+const JOB_ID = "11111111-1111-4111-8111-111111111111";
+const UUID_URL_OWNER_JOB_ID = "22222222-2222-4222-8222-222222222222";
 const NOW = "2026-06-24T10:00:00.000Z";
 
 // Stand-in for the Playwright HTML-to-PDF subprocess: it renders the exact HTML
@@ -310,7 +313,131 @@ describe("resume template service", () => {
       .get() as { payload_json: string } | undefined;
     expect(failedEvent?.payload_json).toContain("failed");
   });
+
+  it("persists v17 assignments and refresh attempts by stable JobId", () => {
+    upgradeJobFixtureToV17(db);
+    const saved = createResumeTemplateVersion(db, {
+      displayName: "Stable identity template",
+      theme: {
+        ...BUILT_IN_RESUME_TEMPLATE_THEME,
+        fontFamily: "serif",
+      },
+      layout: {},
+    });
+
+    setJobResumeTemplateAssignment(db, JOB_KEY, {
+      templateId: saved.template.templateId,
+      versionId: saved.template.activeVersion.versionId,
+    });
+    const refresh = ensureCurrentResumeTemplateMaterials(
+      db,
+      JOB_KEY,
+      {},
+      renderHtmlToPdf,
+    );
+
+    expect(refresh.status).toBe("completed");
+    expect(refresh.attempt?.jobKey).toBe(JOB_KEY);
+    expect(
+      db.prepare(
+        "SELECT job_id FROM job_resume_template_assignments",
+      ).get(),
+    ).toEqual({ job_id: JOB_ID });
+    expect(
+      db.prepare(
+        "SELECT DISTINCT job_id FROM resume_template_refresh_attempts",
+      ).all(),
+    ).toEqual([{ job_id: JOB_ID }]);
+    expect(
+      db.prepare(
+        "SELECT name FROM pragma_table_info('job_resume_template_assignments')",
+      ).all(),
+    ).toContainEqual({ name: "job_id" });
+  });
+
+  it("assigns a UUID-shaped posting URL to its URL owner", () => {
+    upgradeJobFixtureToV17(db);
+    db.prepare(
+      `INSERT INTO jobs (
+         url, tenant_id, job_id, title, company, discovered_at
+       ) VALUES (?, 'local', ?, 'URL owner', 'Example', ?)`,
+    ).run(JOB_ID, UUID_URL_OWNER_JOB_ID, NOW);
+    const saved = createResumeTemplateVersion(db, {
+      displayName: "Slate serif",
+      theme: {
+        ...BUILT_IN_RESUME_TEMPLATE_THEME,
+        fontFamily: "serif",
+      },
+      layout: {},
+    });
+
+    setJobResumeTemplateAssignment(db, JOB_ID, {
+      templateId: saved.template.templateId,
+      versionId: saved.template.activeVersion.versionId,
+    });
+
+    expect(
+      db.prepare(
+        "SELECT job_id FROM job_resume_template_assignments",
+      ).all(),
+    ).toEqual([{ job_id: UUID_URL_OWNER_JOB_ID }]);
+  });
+
+  it("permanently deletes stable template configuration without FK cascades", () => {
+    upgradeJobFixtureToV17(db);
+    db.pragma("foreign_keys = OFF");
+    const saved = createResumeTemplateVersion(db, {
+      displayName: "Delete template",
+      theme: {
+        ...BUILT_IN_RESUME_TEMPLATE_THEME,
+        fontFamily: "serif",
+      },
+      layout: {},
+    });
+    setJobResumeTemplateAssignment(db, JOB_KEY, {
+      templateId: saved.template.templateId,
+      versionId: saved.template.activeVersion.versionId,
+    });
+    ensureCurrentResumeTemplateMaterials(
+      db,
+      JOB_KEY,
+      {},
+      renderHtmlToPdf,
+    );
+
+    expect(permanentlyDeleteJob(db, JOB_KEY)).toMatchObject({
+      ok: true,
+      count: 1,
+    });
+
+    expect(
+      db.prepare(
+        "SELECT COUNT(*) AS count FROM job_resume_template_assignments",
+      ).get(),
+    ).toEqual({ count: 0 });
+    expect(
+      db.prepare(
+        "SELECT COUNT(*) AS count FROM resume_template_refresh_attempts",
+      ).get(),
+    ).toEqual({ count: 0 });
+  });
 });
+
+function upgradeJobFixtureToV17(database: Database.Database): void {
+  database.exec(`
+    ALTER TABLE jobs
+      ADD COLUMN tenant_id TEXT NOT NULL DEFAULT 'local';
+    ALTER TABLE jobs ADD COLUMN job_id TEXT;
+  `);
+  database.prepare(
+    "UPDATE jobs SET job_id = ? WHERE url = ?",
+  ).run(JOB_ID, JOB_KEY);
+  database.exec(`
+    CREATE UNIQUE INDEX idx_jobs_tenant_job_id_template_fixture
+      ON jobs(tenant_id, job_id);
+    PRAGMA user_version = 17;
+  `);
+}
 
 function seedDatabase(database: Database.Database): void {
   const resumePath = path.join(tempDir, "resume-v1.txt");

--- a/apps/api/test/schema-version-guard.test.ts
+++ b/apps/api/test/schema-version-guard.test.ts
@@ -63,7 +63,7 @@ describe("schema version guard at DB open", () => {
   });
 
   it("opens the worker-owned schema-v14 artifact registry", () => {
-    expect(SUPPORTED_SCHEMA_VERSION).toBe(16);
+    expect(SUPPORTED_SCHEMA_VERSION).toBe(17);
     const { dbPath, cleanup } = makeDbWithUserVersion(14);
     try {
       openDatabase(dbPath).close();

--- a/workers/automation/src/jobctrl/database.py
+++ b/workers/automation/src/jobctrl/database.py
@@ -65,7 +65,9 @@ from jobctrl.config import DB_PATH, DEFAULTS, migrate_legacy_job_tables
 # v16 (employer-analysis references): canonical employer-analysis generations
 # plus their per-model drafts and failures reference the stable Job aggregate.
 # Identity collapse preserves and deterministically renumbers complete histories.
-SCHEMA_VERSION = 16
+# v17 (resume-template references): the mutable per-job assignment and every
+# render-only refresh attempt reference the tenant-scoped stable Job aggregate.
+SCHEMA_VERSION = 17
 
 
 class IncompatibleSchemaVersionError(RuntimeError):
@@ -212,6 +214,7 @@ def _schema_migrations() -> tuple[
         (14, ensure_artifact_registry_references_v14),
         (15, ensure_materials_references_v15),
         (16, ensure_employer_analysis_references_v16),
+        (17, ensure_resume_template_references_v17),
     )
 
 
@@ -2621,6 +2624,9 @@ def _backfill_legacy_materials_if_empty(
         _backfill_one_materials_row(conn, row, now)
 
 
+_RESUME_TEMPLATE_REFERENCE_SCHEMA_VERSION = 17
+
+
 def ensure_resume_template_tables(conn: sqlite3.Connection | None = None) -> list[str]:
     """Create local resume-template configuration tables.
 
@@ -2630,6 +2636,7 @@ def ensure_resume_template_tables(conn: sqlite3.Connection | None = None) -> lis
     """
     if conn is None:
         conn = get_connection()
+    current_schema_version = _assert_schema_version_supported(conn)
 
     conn.execute(
         """
@@ -2681,15 +2688,37 @@ def ensure_resume_template_tables(conn: sqlite3.Connection | None = None) -> lis
         )
         """
     )
+    assignment_columns = _table_columns(
+        conn,
+        "job_resume_template_assignments",
+    )
+    assignment_reference = (
+        "job_id"
+        if "job_id" in assignment_columns
+        or (
+            not assignment_columns
+            and current_schema_version
+            >= _RESUME_TEMPLATE_REFERENCE_SCHEMA_VERSION
+        )
+        else "job_url"
+    )
+    assignment_foreign_key = (
+        """,
+            FOREIGN KEY (tenant_id, job_id)
+                REFERENCES jobs(tenant_id, job_id) ON DELETE CASCADE"""
+        if assignment_reference == "job_id"
+        else ""
+    )
     conn.execute(
-        """
+        f"""
         CREATE TABLE IF NOT EXISTS job_resume_template_assignments (
             tenant_id   TEXT NOT NULL DEFAULT 'local',
-            job_url     TEXT NOT NULL,
+            {assignment_reference} TEXT NOT NULL,
             template_id TEXT NOT NULL,
             version_id  TEXT NOT NULL,
             updated_at  TEXT NOT NULL,
-            PRIMARY KEY (tenant_id, job_url)
+            PRIMARY KEY (tenant_id, {assignment_reference})
+            {assignment_foreign_key}
         )
         """
     )
@@ -2699,12 +2728,33 @@ def ensure_resume_template_tables(conn: sqlite3.Connection | None = None) -> lis
         ON job_resume_template_assignments(tenant_id, template_id, version_id)
         """
     )
+    refresh_columns = _table_columns(
+        conn,
+        "resume_template_refresh_attempts",
+    )
+    refresh_reference = (
+        "job_id"
+        if "job_id" in refresh_columns
+        or (
+            not refresh_columns
+            and current_schema_version
+            >= _RESUME_TEMPLATE_REFERENCE_SCHEMA_VERSION
+        )
+        else "job_url"
+    )
+    refresh_foreign_key = (
+        """,
+            FOREIGN KEY (tenant_id, job_id)
+                REFERENCES jobs(tenant_id, job_id) ON DELETE CASCADE"""
+        if refresh_reference == "job_id"
+        else ""
+    )
     conn.execute(
-        """
+        f"""
         CREATE TABLE IF NOT EXISTS resume_template_refresh_attempts (
             tenant_id           TEXT NOT NULL DEFAULT 'local',
             attempt_id          TEXT NOT NULL,
-            job_url             TEXT NOT NULL,
+            {refresh_reference} TEXT NOT NULL,
             status              TEXT NOT NULL,
             from_generation     INTEGER,
             to_generation       INTEGER,
@@ -2712,17 +2762,20 @@ def ensure_resume_template_tables(conn: sqlite3.Connection | None = None) -> lis
             template_version_id TEXT,
             template_hash       TEXT,
             error_message       TEXT,
-            metadata_json       TEXT NOT NULL DEFAULT '{}',
+            metadata_json       TEXT NOT NULL DEFAULT '{{}}',
             created_at          TEXT NOT NULL,
             completed_at        TEXT,
             PRIMARY KEY (tenant_id, attempt_id)
+            {refresh_foreign_key}
         )
         """
     )
     conn.execute(
-        """
+        f"""
         CREATE INDEX IF NOT EXISTS idx_resume_template_refresh_attempts_job
-        ON resume_template_refresh_attempts(tenant_id, job_url, created_at DESC)
+        ON resume_template_refresh_attempts(
+            tenant_id, {refresh_reference}, created_at DESC
+        )
         """
     )
 
@@ -4457,6 +4510,22 @@ def _reassign_discovery_identity_references(
                 surviving_job_id=surviving_job_id,
             )
         )
+    material_generation_map: dict[tuple[str, int], int] = {}
+    if _has_materials_reference_schema_v15(conn):
+        material_generation_map = _reassign_materials_references_v15(
+            conn,
+            tenant_id=tenant_id,
+            losing_job_id=losing_job_id,
+            surviving_job_id=surviving_job_id,
+        )
+    if _has_resume_template_reference_schema_v17(conn):
+        _reassign_resume_template_references_v17(
+            conn,
+            tenant_id=tenant_id,
+            losing_job_id=losing_job_id,
+            surviving_job_id=surviving_job_id,
+            material_generation_map=material_generation_map,
+        )
     if _has_scoring_reference_schema_v12(conn):
         _reassign_scoring_references_v12(
             conn,
@@ -4476,13 +4545,6 @@ def _reassign_discovery_identity_references(
         )
     if _has_artifact_registry_reference_schema_v14(conn):
         _reassign_artifact_registry_references_v14(
-            conn,
-            tenant_id=tenant_id,
-            losing_job_id=losing_job_id,
-            surviving_job_id=surviving_job_id,
-        )
-    if _has_materials_reference_schema_v15(conn):
-        _reassign_materials_references_v15(
             conn,
             tenant_id=tenant_id,
             losing_job_id=losing_job_id,
@@ -9467,7 +9529,6 @@ def ensure_materials_references_v15(
                 conn,
                 generation_map=generation_map,
             )
-
             for table in (
                 "job_bullet_provenance_v15",
                 "job_material_layout_boxes_v15",
@@ -9619,10 +9680,10 @@ def _reassign_materials_references_v15(
     tenant_id: str,
     losing_job_id: str,
     surviving_job_id: str,
-) -> None:
+) -> dict[tuple[str, int], int]:
     """Merge complete material histories during stable Job identity collapse."""
     if losing_job_id == surviving_job_id:
-        return
+        return {}
     before_counts = {
         table: int(
             conn.execute(f'SELECT COUNT(*) FROM "{table}"').fetchone()[0]
@@ -9640,7 +9701,7 @@ def _reassign_materials_references_v15(
         (tenant_id, losing_job_id, surviving_job_id),
     ).fetchall()
     if not parent_rows:
-        return
+        return {}
 
     history = [
         (
@@ -9800,6 +9861,7 @@ def _reassign_materials_references_v15(
         conn,
         expected_counts=before_counts,
     )
+    return generation_map
 
 
 _EMPLOYER_ANALYSIS_REFERENCE_SCHEMA_VERSION = 16
@@ -10473,6 +10535,537 @@ def _reassign_employer_analysis_references_v16(
         expected_counts=before_counts,
     )
     return generation_map
+
+
+_RESUME_TEMPLATE_REFERENCE_TABLES = (
+    "job_resume_template_assignments",
+    "resume_template_refresh_attempts",
+)
+
+
+def _create_resume_template_reference_tables_v17(
+    conn: sqlite3.Connection,
+    *,
+    assignments_table: str = "job_resume_template_assignments",
+    refresh_attempts_table: str = "resume_template_refresh_attempts",
+) -> None:
+    conn.execute(
+        f"""
+        CREATE TABLE IF NOT EXISTS {assignments_table} (
+            tenant_id   TEXT NOT NULL DEFAULT 'local',
+            job_id      TEXT NOT NULL,
+            template_id TEXT NOT NULL,
+            version_id  TEXT NOT NULL,
+            updated_at  TEXT NOT NULL,
+            PRIMARY KEY (tenant_id, job_id),
+            FOREIGN KEY (tenant_id, job_id)
+                REFERENCES jobs(tenant_id, job_id) ON DELETE CASCADE
+        )
+        """
+    )
+    conn.execute(
+        f"""
+        CREATE TABLE IF NOT EXISTS {refresh_attempts_table} (
+            tenant_id           TEXT NOT NULL DEFAULT 'local',
+            attempt_id          TEXT NOT NULL,
+            job_id              TEXT NOT NULL,
+            status              TEXT NOT NULL,
+            from_generation     INTEGER,
+            to_generation       INTEGER,
+            template_id         TEXT,
+            template_version_id TEXT,
+            template_hash       TEXT,
+            error_message       TEXT,
+            metadata_json       TEXT NOT NULL DEFAULT '{{}}',
+            created_at          TEXT NOT NULL,
+            completed_at        TEXT,
+            PRIMARY KEY (tenant_id, attempt_id),
+            FOREIGN KEY (tenant_id, job_id)
+                REFERENCES jobs(tenant_id, job_id) ON DELETE CASCADE
+        )
+        """
+    )
+
+
+def _create_resume_template_reference_indexes_v17(
+    conn: sqlite3.Connection,
+) -> None:
+    conn.execute(
+        """
+        CREATE INDEX IF NOT EXISTS
+            idx_job_resume_template_assignments_template
+        ON job_resume_template_assignments(
+            tenant_id, template_id, version_id
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE INDEX IF NOT EXISTS
+            idx_resume_template_refresh_attempts_job
+        ON resume_template_refresh_attempts(
+            tenant_id, job_id, created_at DESC
+        )
+        """
+    )
+
+
+def _has_resume_template_reference_schema_v17(
+    conn: sqlite3.Connection,
+) -> bool:
+    return (
+        "job_id"
+        in _table_columns(
+            conn,
+            "job_resume_template_assignments",
+        )
+        and "job_url"
+        not in _table_columns(
+            conn,
+            "job_resume_template_assignments",
+        )
+        and _primary_key_columns(
+            conn,
+            "job_resume_template_assignments",
+        )
+        == ("tenant_id", "job_id")
+        and _has_composite_job_id_foreign_key(
+            conn,
+            "job_resume_template_assignments",
+            "job_id",
+        )
+        and "job_id"
+        in _table_columns(
+            conn,
+            "resume_template_refresh_attempts",
+        )
+        and "job_url"
+        not in _table_columns(
+            conn,
+            "resume_template_refresh_attempts",
+        )
+        and _primary_key_columns(
+            conn,
+            "resume_template_refresh_attempts",
+        )
+        == ("tenant_id", "attempt_id")
+        and _has_composite_job_id_foreign_key(
+            conn,
+            "resume_template_refresh_attempts",
+            "job_id",
+        )
+        and _has_index(
+            conn,
+            "job_resume_template_assignments",
+            "idx_job_resume_template_assignments_template",
+            ("tenant_id", "template_id", "version_id"),
+            unique=False,
+        )
+        and _has_index(
+            conn,
+            "resume_template_refresh_attempts",
+            "idx_resume_template_refresh_attempts_job",
+            ("tenant_id", "job_id", "created_at"),
+            unique=False,
+        )
+    )
+
+
+def _canonical_resume_template_assignments_v17(
+    conn: sqlite3.Connection,
+) -> list[tuple[Any, ...]]:
+    rows = conn.execute(
+        """
+        SELECT tenant_id, job_url, template_id, version_id, updated_at
+        FROM job_resume_template_assignments
+        ORDER BY tenant_id, job_url
+        """
+    ).fetchall()
+    canonical: dict[tuple[str, str], tuple[Any, ...]] = {}
+    source_order: dict[
+        tuple[str, str],
+        tuple[str, bool, str],
+    ] = {}
+    for row in rows:
+        tenant_id = str(row[0])
+        raw_reference = str(row[1])
+        stable_job_id = _resolve_job_reference_value(
+            conn,
+            tenant_id=tenant_id,
+            reference=raw_reference,
+            legacy_url=True,
+        )
+        if stable_job_id is None:
+            raise RuntimeError(
+                "resume-template reference migration could not resolve "
+                f"job_resume_template_assignments.job_url="
+                f"{raw_reference!r}"
+            )
+        _validate_job_uuid(stable_job_id)
+        key = (tenant_id, stable_job_id)
+        storage_row = conn.execute(
+            """
+            SELECT url
+            FROM jobs
+            WHERE tenant_id = ? AND job_id = ?
+            LIMIT 1
+            """,
+            (tenant_id, stable_job_id),
+        ).fetchone()
+        storage_url = (
+            str(storage_row[0])
+            if storage_row is not None
+            else ""
+        )
+        candidate_order = (
+            str(row[4]),
+            raw_reference == storage_url,
+            raw_reference,
+        )
+        if key not in canonical or candidate_order > source_order[key]:
+            canonical[key] = (
+                tenant_id,
+                stable_job_id,
+                str(row[2]),
+                str(row[3]),
+                str(row[4]),
+            )
+            source_order[key] = candidate_order
+    return [
+        canonical[key]
+        for key in sorted(canonical)
+    ]
+
+
+def _canonical_resume_template_refresh_attempts_v17(
+    conn: sqlite3.Connection,
+) -> list[tuple[Any, ...]]:
+    rows = conn.execute(
+        """
+        SELECT tenant_id, attempt_id, job_url, status, from_generation,
+               to_generation, template_id, template_version_id,
+               template_hash, error_message, metadata_json, created_at,
+               completed_at
+        FROM resume_template_refresh_attempts
+        ORDER BY tenant_id, attempt_id
+        """
+    ).fetchall()
+    canonical: list[tuple[Any, ...]] = []
+    for row in rows:
+        tenant_id = str(row[0])
+        raw_reference = str(row[2])
+        stable_job_id = _resolve_job_reference_value(
+            conn,
+            tenant_id=tenant_id,
+            reference=raw_reference,
+            legacy_url=True,
+        )
+        if stable_job_id is None:
+            raise RuntimeError(
+                "resume-template reference migration could not resolve "
+                f"resume_template_refresh_attempts.job_url="
+                f"{raw_reference!r}"
+            )
+        _validate_job_uuid(stable_job_id)
+        canonical.append(
+            (
+                tenant_id,
+                str(row[1]),
+                stable_job_id,
+                *tuple(row[3:]),
+            )
+        )
+    return canonical
+
+
+def ensure_resume_template_references_v17(
+    conn: sqlite3.Connection | None = None,
+) -> list[str]:
+    """Move job-owned resume-template configuration to stable JobIds."""
+    if conn is None:
+        conn = get_connection()
+
+    current = _assert_schema_version_supported(conn)
+    if current >= _RESUME_TEMPLATE_REFERENCE_SCHEMA_VERSION:
+        return []
+    if current != _EMPLOYER_ANALYSIS_REFERENCE_SCHEMA_VERSION:
+        raise RuntimeError(
+            "resume-template reference migration requires employer-analysis "
+            "schema v16"
+        )
+
+    conn.execute("SAVEPOINT resume_template_references_v17")
+    try:
+        if not _has_employer_analysis_reference_schema_v16(conn):
+            raise RuntimeError(
+                "resume-template reference migration requires the stable "
+                "employer-analysis reference schema"
+            )
+        before_counts = {
+            table: int(
+                conn.execute(
+                    f'SELECT COUNT(*) FROM "{table}"'
+                ).fetchone()[0]
+            )
+            for table in _RESUME_TEMPLATE_REFERENCE_TABLES
+        }
+        expected_counts = dict(before_counts)
+
+        if not _has_resume_template_reference_schema_v17(conn):
+            assignment_rows = (
+                _canonical_resume_template_assignments_v17(conn)
+            )
+            refresh_attempt_rows = (
+                _canonical_resume_template_refresh_attempts_v17(conn)
+            )
+            expected_counts[
+                "job_resume_template_assignments"
+            ] = len(assignment_rows)
+
+            for table in (
+                "job_resume_template_assignments_v17",
+                "resume_template_refresh_attempts_v17",
+            ):
+                conn.execute(f'DROP TABLE IF EXISTS "{table}"')
+            _create_resume_template_reference_tables_v17(
+                conn,
+                assignments_table=(
+                    "job_resume_template_assignments_v17"
+                ),
+                refresh_attempts_table=(
+                    "resume_template_refresh_attempts_v17"
+                ),
+            )
+            conn.executemany(
+                """
+                INSERT INTO job_resume_template_assignments_v17 (
+                    tenant_id, job_id, template_id, version_id, updated_at
+                ) VALUES (?, ?, ?, ?, ?)
+                """,
+                assignment_rows,
+            )
+            conn.executemany(
+                """
+                INSERT INTO resume_template_refresh_attempts_v17 (
+                    tenant_id, attempt_id, job_id, status,
+                    from_generation, to_generation, template_id,
+                    template_version_id, template_hash, error_message,
+                    metadata_json, created_at, completed_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                refresh_attempt_rows,
+            )
+            for table in _RESUME_TEMPLATE_REFERENCE_TABLES:
+                conn.execute(f'DROP TABLE "{table}"')
+            for table in _RESUME_TEMPLATE_REFERENCE_TABLES:
+                conn.execute(
+                    f'ALTER TABLE "{table}_v17" RENAME TO "{table}"'
+                )
+            _create_resume_template_reference_indexes_v17(conn)
+
+        _verify_resume_template_references_v17(
+            conn,
+            expected_counts=expected_counts,
+        )
+        conn.execute(
+            f"PRAGMA user_version = "
+            f"{_RESUME_TEMPLATE_REFERENCE_SCHEMA_VERSION}"
+        )
+        conn.execute(
+            "RELEASE SAVEPOINT resume_template_references_v17"
+        )
+        conn.commit()
+    except BaseException:
+        conn.execute(
+            "ROLLBACK TO SAVEPOINT resume_template_references_v17"
+        )
+        conn.execute(
+            "RELEASE SAVEPOINT resume_template_references_v17"
+        )
+        raise
+
+    return list(_RESUME_TEMPLATE_REFERENCE_TABLES)
+
+
+def _verify_resume_template_references_v17(
+    conn: sqlite3.Connection,
+    *,
+    expected_counts: dict[str, int],
+) -> None:
+    if not _has_resume_template_reference_schema_v17(conn):
+        raise RuntimeError(
+            "resume-template reference migration did not install the "
+            "canonical schema"
+        )
+    for table, expected_count in expected_counts.items():
+        observed_count = int(
+            conn.execute(
+                f'SELECT COUNT(*) FROM "{table}"'
+            ).fetchone()[0]
+        )
+        if observed_count != expected_count:
+            raise RuntimeError(
+                "resume-template reference migration changed the "
+                f"{table} row count: expected {expected_count}, "
+                f"found {observed_count}"
+            )
+    for table in _RESUME_TEMPLATE_REFERENCE_TABLES:
+        orphan = conn.execute(
+            f"""
+            SELECT owned.job_id
+            FROM {table} AS owned
+            LEFT JOIN jobs
+              ON jobs.tenant_id = owned.tenant_id
+             AND jobs.job_id = owned.job_id
+            WHERE jobs.job_id IS NULL
+            LIMIT 1
+            """
+        ).fetchone()
+        if orphan is not None:
+            raise RuntimeError(
+                "resume-template reference migration left an "
+                f"unresolved {table}.job_id"
+            )
+        for row in conn.execute(
+            f'SELECT DISTINCT job_id FROM "{table}"'
+        ).fetchall():
+            _validate_job_uuid(str(row[0]))
+    foreign_key_error = conn.execute(
+        "PRAGMA foreign_key_check"
+    ).fetchone()
+    if foreign_key_error is not None:
+        raise RuntimeError(
+            "resume-template reference migration found a foreign-key "
+            "violation"
+        )
+
+
+def _reassign_resume_template_references_v17(
+    conn: sqlite3.Connection,
+    *,
+    tenant_id: str,
+    losing_job_id: str,
+    surviving_job_id: str,
+    material_generation_map: dict[tuple[str, int], int],
+) -> None:
+    """Preserve current template choice and every refresh attempt."""
+    if losing_job_id == surviving_job_id:
+        return
+    before_counts = {
+        table: int(
+            conn.execute(f'SELECT COUNT(*) FROM "{table}"').fetchone()[0]
+        )
+        for table in _RESUME_TEMPLATE_REFERENCE_TABLES
+    }
+    assignments = conn.execute(
+        """
+        SELECT job_id, template_id, version_id, updated_at
+        FROM job_resume_template_assignments
+        WHERE tenant_id = ? AND job_id IN (?, ?)
+        ORDER BY updated_at, job_id
+        """,
+        (tenant_id, losing_job_id, surviving_job_id),
+    ).fetchall()
+    if assignments:
+        selected = max(
+            assignments,
+            key=lambda row: (
+                str(row[3]),
+                str(row[0]) == surviving_job_id,
+                str(row[0]),
+            ),
+        )
+        conn.execute(
+            """
+            DELETE FROM job_resume_template_assignments
+            WHERE tenant_id = ? AND job_id IN (?, ?)
+            """,
+            (tenant_id, losing_job_id, surviving_job_id),
+        )
+        conn.execute(
+            """
+            INSERT INTO job_resume_template_assignments (
+                tenant_id, job_id, template_id, version_id, updated_at
+            ) VALUES (?, ?, ?, ?, ?)
+            """,
+            (
+                tenant_id,
+                surviving_job_id,
+                str(selected[1]),
+                str(selected[2]),
+                str(selected[3]),
+            ),
+        )
+    attempts = conn.execute(
+        """
+        SELECT attempt_id, job_id, from_generation, to_generation
+        FROM resume_template_refresh_attempts
+        WHERE tenant_id = ? AND job_id IN (?, ?)
+        ORDER BY attempt_id
+        """,
+        (tenant_id, losing_job_id, surviving_job_id),
+    ).fetchall()
+
+    def _mapped_generation(
+        *,
+        source_job_id: str,
+        attempt_id: str,
+        field: str,
+        value: Any,
+    ) -> int | None:
+        if value is None:
+            return None
+        generation = int(value)
+        if generation <= 0:
+            return generation
+        mapped = material_generation_map.get(
+            (source_job_id, generation)
+        )
+        if mapped is None:
+            raise RuntimeError(
+                "resume-template identity collapse could not preserve "
+                f"refresh attempt {attempt_id!r} {field}={generation} "
+                f"for job_id={source_job_id!r}"
+            )
+        return mapped
+
+    for row in attempts:
+        attempt_id = str(row[0])
+        source_job_id = str(row[1])
+        conn.execute(
+            """
+            UPDATE resume_template_refresh_attempts
+            SET job_id = ?, from_generation = ?, to_generation = ?
+            WHERE tenant_id = ? AND attempt_id = ?
+            """,
+            (
+                surviving_job_id,
+                _mapped_generation(
+                    source_job_id=source_job_id,
+                    attempt_id=attempt_id,
+                    field="from_generation",
+                    value=row[2],
+                ),
+                _mapped_generation(
+                    source_job_id=source_job_id,
+                    attempt_id=attempt_id,
+                    field="to_generation",
+                    value=row[3],
+                ),
+                tenant_id,
+                attempt_id,
+            ),
+        )
+    expected_counts = dict(before_counts)
+    expected_counts["job_resume_template_assignments"] = (
+        before_counts["job_resume_template_assignments"]
+        - len(assignments)
+        + (1 if assignments else 0)
+    )
+    _verify_resume_template_references_v17(
+        conn,
+        expected_counts=expected_counts,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/workers/automation/src/jobctrl/infrastructure/materials/sqlite_repository.py
+++ b/workers/automation/src/jobctrl/infrastructure/materials/sqlite_repository.py
@@ -236,13 +236,30 @@ class SqliteMaterialsRepository:
             raise ValueError(
                 f"no stable Job identity for template reference: {job_id}"
             )
+        assignment_reference = (
+            "job_id"
+            if "job_id"
+            in {
+                str(row[1])
+                for row in self._conn.execute(
+                    "PRAGMA table_info(job_resume_template_assignments)"
+                ).fetchall()
+            }
+            else "job_url"
+        )
+        assignment_value = (
+            str(identity.job_id)
+            if assignment_reference == "job_id"
+            else identity.storage_url.value
+        )
         assignment = self._conn.execute(
-            """
+            f"""
             SELECT template_id, version_id
               FROM job_resume_template_assignments
-             WHERE tenant_id = 'local' AND job_url = ?
+             WHERE tenant_id = 'local'
+               AND {assignment_reference} = ?
             """,
-            (identity.storage_url.value,),
+            (assignment_value,),
         ).fetchone()
         if assignment is not None:
             resolved = self._template_by_id(

--- a/workers/automation/tests/test_discovery_identity_reference_migration.py
+++ b/workers/automation/tests/test_discovery_identity_reference_migration.py
@@ -220,7 +220,7 @@ def test_v7_discovery_references_migrate_to_stable_job_id_and_reopen(
     init_db(db_path)
     close_connection(db_path)
 
-    assert _user_version(db_path) == SCHEMA_VERSION == 16
+    assert _user_version(db_path) == SCHEMA_VERSION == 17
     assert "job_id" in _columns(db_path, "job_source_observations")
     assert "job_url" not in _columns(db_path, "job_source_observations")
     assert "job_id" in _columns(db_path, "job_canonical_identities")

--- a/workers/automation/tests/test_employer_analysis_identity_reference_migration.py
+++ b/workers/automation/tests/test_employer_analysis_identity_reference_migration.py
@@ -242,7 +242,7 @@ def test_v15_employer_analysis_migrates_alias_histories_and_uuid_urls(
     assert (
         reopened.execute("PRAGMA user_version").fetchone()[0]
         == SCHEMA_VERSION
-        == 16
+        == 17
     )
     for table in database_module._EMPLOYER_ANALYSIS_REFERENCE_TABLES:
         assert "job_id" in _columns(reopened, table)

--- a/workers/automation/tests/test_enrichment_snapshot_identity_reference_migration.py
+++ b/workers/automation/tests/test_enrichment_snapshot_identity_reference_migration.py
@@ -322,7 +322,7 @@ def test_v10_enrichment_snapshot_references_migrate_and_reopen(
     init_db(db_path)
     close_connection(db_path)
 
-    assert _user_version(db_path) == SCHEMA_VERSION == 16
+    assert _user_version(db_path) == SCHEMA_VERSION == 17
     check = sqlite3.connect(db_path)
     try:
         enrichment_rows = check.execute(

--- a/workers/automation/tests/test_execution_search_identity_reference_migration.py
+++ b/workers/automation/tests/test_execution_search_identity_reference_migration.py
@@ -261,7 +261,7 @@ def test_v8_execution_and_receipts_migrate_to_stable_job_id_and_reopen(
     init_db(db_path)
     close_connection(db_path)
 
-    assert _user_version(db_path) == SCHEMA_VERSION == 16
+    assert _user_version(db_path) == SCHEMA_VERSION == 17
     assert "job_id" in _columns(db_path, "discovery_execution_jobs")
     assert "job_url" not in _columns(db_path, "discovery_execution_jobs")
     assert "job_id" in _columns(db_path, "discovery_search_unit_jobs")

--- a/workers/automation/tests/test_materials_identity_reference_migration.py
+++ b/workers/automation/tests/test_materials_identity_reference_migration.py
@@ -293,7 +293,7 @@ def test_v14_materials_migrate_alias_histories_and_uuid_shaped_urls(
     close_connection(db_path)
 
     reopened = init_db(db_path)
-    assert reopened.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_VERSION == 16
+    assert reopened.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_VERSION == 17
     for table in database_module._MATERIALS_REFERENCE_TABLES:
         assert "job_id" in _columns(reopened, table)
         assert "job_url" not in _columns(reopened, table)

--- a/workers/automation/tests/test_preparation_identity_reference_migration.py
+++ b/workers/automation/tests/test_preparation_identity_reference_migration.py
@@ -177,7 +177,7 @@ def test_v9_preparation_references_migrate_to_stable_job_ids_and_reopen(
     init_db(db_path)
     close_connection(db_path)
 
-    assert _user_version(db_path) == SCHEMA_VERSION == 16
+    assert _user_version(db_path) == SCHEMA_VERSION == 17
     check = sqlite3.connect(db_path)
     try:
         rows = check.execute(

--- a/workers/automation/tests/test_repeat_application_prevention.py
+++ b/workers/automation/tests/test_repeat_application_prevention.py
@@ -750,7 +750,7 @@ def test_schema_v5_migrates_additively_without_changing_application_facts(
         (PRIOR,),
     ).fetchall()
 
-    assert int(migrated.execute("PRAGMA user_version").fetchone()[0]) == SCHEMA_VERSION == 16
+    assert int(migrated.execute("PRAGMA user_version").fetchone()[0]) == SCHEMA_VERSION == 17
     assert [tuple(row) for row in after] == [tuple(row) for row in before]
     assert "metadata_json" in {
         str(row[1]) for row in migrated.execute("PRAGMA table_info(job_stage_states)").fetchall()

--- a/workers/automation/tests/test_resume_template_identity_reference_migration.py
+++ b/workers/automation/tests/test_resume_template_identity_reference_migration.py
@@ -1,0 +1,541 @@
+"""Schema-v17 resume-template JobId reference contracts."""
+
+from __future__ import annotations
+
+import sqlite3
+import uuid
+from pathlib import Path
+
+import pytest
+
+import jobctrl.database as database_module
+from jobctrl.database import (
+    SCHEMA_VERSION,
+    close_connection,
+    ensure_resume_template_references_v17,
+    init_db,
+    reassign_discovery_identity_references,
+)
+from jobctrl.domain.discovery import (
+    Employer,
+    Job,
+    JobMetadata,
+    PostingUrl,
+    SearchStrategy,
+    Source,
+)
+from jobctrl.domain.identifiers import JobId
+from jobctrl.domain.tenant import LOCAL_TENANT
+from jobctrl.infrastructure.discovery import SqliteJobRepository
+from jobctrl.infrastructure.materials import SqliteMaterialsRepository
+
+
+PREVIOUS_SCHEMA_VERSION = 16
+BUILT_IN_TEMPLATE = "built_in:modern-html"
+BUILT_IN_VERSION = "built_in:modern-html:v1"
+CUSTOM_TEMPLATE = "template:compact"
+CUSTOM_VERSION = "template:compact:v1"
+
+
+def _discovered_job(posting_url: str, job_id: JobId) -> Job:
+    return Job.discover(
+        tenant_id=LOCAL_TENANT,
+        job_id=job_id,
+        posting_url=PostingUrl(value=posting_url),
+        source=Source(board="example"),
+        employer=Employer(name="Example"),
+        search_strategy=SearchStrategy.JOBSPY,
+        metadata=JobMetadata(title="Platform Engineer"),
+        discovered_at="2026-07-29T10:00:00+00:00",
+    )
+
+
+def _insert_custom_template(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        """
+        INSERT OR IGNORE INTO resume_templates (
+            tenant_id, template_id, display_name, status, built_in,
+            created_at, updated_at
+        ) VALUES (
+            'local', ?, 'Compact', 'active', 0,
+            '2026-07-29T09:00:00+00:00',
+            '2026-07-29T09:00:00+00:00'
+        )
+        """,
+        (CUSTOM_TEMPLATE,),
+    )
+    conn.execute(
+        """
+        INSERT OR IGNORE INTO resume_template_versions (
+            tenant_id, version_id, template_id, version_number,
+            display_name, status, theme_json, layout_json,
+            content_hash, created_at
+        ) VALUES (
+            'local', ?, ?, 1, 'Compact', 'active', '{}', '{}',
+            'compact-hash', '2026-07-29T09:00:00+00:00'
+        )
+        """,
+        (CUSTOM_VERSION, CUSTOM_TEMPLATE),
+    )
+
+
+def _downgrade_resume_template_references_to_v16(
+    conn: sqlite3.Connection,
+) -> None:
+    conn.execute("DROP TABLE job_resume_template_assignments")
+    conn.execute("DROP TABLE resume_template_refresh_attempts")
+    conn.executescript(
+        """
+        CREATE TABLE job_resume_template_assignments (
+            tenant_id   TEXT NOT NULL DEFAULT 'local',
+            job_url     TEXT NOT NULL,
+            template_id TEXT NOT NULL,
+            version_id  TEXT NOT NULL,
+            updated_at  TEXT NOT NULL,
+            PRIMARY KEY (tenant_id, job_url)
+        );
+        CREATE INDEX idx_job_resume_template_assignments_template
+            ON job_resume_template_assignments(
+                tenant_id, template_id, version_id
+            );
+        CREATE TABLE resume_template_refresh_attempts (
+            tenant_id           TEXT NOT NULL DEFAULT 'local',
+            attempt_id          TEXT NOT NULL,
+            job_url             TEXT NOT NULL,
+            status              TEXT NOT NULL,
+            from_generation     INTEGER,
+            to_generation       INTEGER,
+            template_id         TEXT,
+            template_version_id TEXT,
+            template_hash       TEXT,
+            error_message       TEXT,
+            metadata_json       TEXT NOT NULL DEFAULT '{}',
+            created_at          TEXT NOT NULL,
+            completed_at        TEXT,
+            PRIMARY KEY (tenant_id, attempt_id)
+        );
+        CREATE INDEX idx_resume_template_refresh_attempts_job
+            ON resume_template_refresh_attempts(
+                tenant_id, job_url, created_at DESC
+            );
+        """
+    )
+    conn.execute(f"PRAGMA user_version = {PREVIOUS_SCHEMA_VERSION}")
+    conn.commit()
+
+
+def _insert_assignment(
+    conn: sqlite3.Connection,
+    *,
+    job_url: str,
+    template_id: str,
+    version_id: str,
+    updated_at: str,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO job_resume_template_assignments (
+            tenant_id, job_url, template_id, version_id, updated_at
+        ) VALUES ('local', ?, ?, ?, ?)
+        """,
+        (job_url, template_id, version_id, updated_at),
+    )
+
+
+def _insert_attempt(
+    conn: sqlite3.Connection,
+    *,
+    attempt_id: str,
+    job_url: str,
+    created_at: str,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO resume_template_refresh_attempts (
+            tenant_id, attempt_id, job_url, status, from_generation,
+            to_generation, template_id, template_version_id,
+            template_hash, error_message, metadata_json, created_at,
+            completed_at
+        ) VALUES (
+            'local', ?, ?, 'completed', 1, 2, ?, ?, 'compact-hash',
+            NULL, '{"source":"test"}', ?, ?
+        )
+        """,
+        (
+            attempt_id,
+            job_url,
+            CUSTOM_TEMPLATE,
+            CUSTOM_VERSION,
+            created_at,
+            created_at,
+        ),
+    )
+
+
+def _columns(
+    conn: sqlite3.Connection,
+    table_name: str,
+) -> set[str]:
+    return {
+        str(row[1])
+        for row in conn.execute(
+            f'PRAGMA table_info("{table_name}")'
+        ).fetchall()
+    }
+
+
+def test_v16_template_references_migrate_aliases_and_uuid_urls(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    conn = init_db(db_path)
+    jobs = SqliteJobRepository(conn)
+    stable_job_id = JobId(str(uuid.uuid4()))
+    original_url = "https://boards.example/jobs/123"
+    current_url = "https://careers.example/jobs/platform"
+    jobs.save(_discovered_job(original_url, stable_job_id))
+    jobs.save(_discovered_job(current_url, stable_job_id))
+
+    uuid_shaped_url = str(uuid.uuid4())
+    uuid_url_owner = JobId(str(uuid.uuid4()))
+    jobs.save(_discovered_job(uuid_shaped_url, uuid_url_owner))
+    jobs.save(
+        _discovered_job(
+            "https://example.com/jobs/id-text-owner",
+            JobId(uuid_shaped_url),
+        )
+    )
+    _insert_custom_template(conn)
+    _downgrade_resume_template_references_to_v16(conn)
+    _insert_assignment(
+        conn,
+        job_url=original_url,
+        template_id=BUILT_IN_TEMPLATE,
+        version_id=BUILT_IN_VERSION,
+        updated_at="2026-07-29T10:00:00+00:00",
+    )
+    _insert_assignment(
+        conn,
+        job_url=current_url,
+        template_id=CUSTOM_TEMPLATE,
+        version_id=CUSTOM_VERSION,
+        updated_at="2026-07-29T10:01:00+00:00",
+    )
+    _insert_assignment(
+        conn,
+        job_url=uuid_shaped_url,
+        template_id=BUILT_IN_TEMPLATE,
+        version_id=BUILT_IN_VERSION,
+        updated_at="2026-07-29T10:02:00+00:00",
+    )
+    _insert_attempt(
+        conn,
+        attempt_id="attempt-original",
+        job_url=original_url,
+        created_at="2026-07-29T10:00:00+00:00",
+    )
+    _insert_attempt(
+        conn,
+        attempt_id="attempt-current",
+        job_url=current_url,
+        created_at="2026-07-29T10:01:00+00:00",
+    )
+    _insert_attempt(
+        conn,
+        attempt_id="attempt-uuid-url",
+        job_url=uuid_shaped_url,
+        created_at="2026-07-29T10:02:00+00:00",
+    )
+    conn.commit()
+    close_connection(db_path)
+
+    reopened = init_db(db_path)
+
+    assert (
+        reopened.execute("PRAGMA user_version").fetchone()[0]
+        == SCHEMA_VERSION
+        == 17
+    )
+    for table in database_module._RESUME_TEMPLATE_REFERENCE_TABLES:
+        assert "job_id" in _columns(reopened, table)
+        assert "job_url" not in _columns(reopened, table)
+    assert reopened.execute(
+        "SELECT COUNT(*) FROM job_resume_template_assignments"
+    ).fetchone()[0] == 2
+    assert reopened.execute(
+        "SELECT COUNT(*) FROM resume_template_refresh_attempts"
+    ).fetchone()[0] == 3
+    assignment = reopened.execute(
+        """
+        SELECT template_id, version_id
+        FROM job_resume_template_assignments
+        WHERE tenant_id = 'local' AND job_id = ?
+        """,
+        (str(stable_job_id),),
+    ).fetchone()
+    assert tuple(assignment) == (CUSTOM_TEMPLATE, CUSTOM_VERSION)
+    uuid_owner = reopened.execute(
+        """
+        SELECT job_id
+        FROM job_resume_template_assignments
+        WHERE template_id = ? AND job_id != ?
+        """,
+        (BUILT_IN_TEMPLATE, str(stable_job_id)),
+    ).fetchone()
+    assert uuid_owner[0] == str(uuid_url_owner)
+    assert {
+        row[0]
+        for row in reopened.execute(
+            """
+            SELECT job_id
+            FROM resume_template_refresh_attempts
+            WHERE attempt_id IN ('attempt-original', 'attempt-current')
+            """
+        ).fetchall()
+    } == {str(stable_job_id)}
+    effective = SqliteMaterialsRepository(
+        reopened
+    ).resolve_effective_resume_template(stable_job_id)
+    assert effective["metadata"]["templateId"] == CUSTOM_TEMPLATE
+    assert effective["metadata"]["assignmentSource"] == "job_override"
+    assert reopened.execute("PRAGMA foreign_key_check").fetchone() is None
+    close_connection(db_path)
+
+    reopened_again = init_db(db_path)
+    assert reopened_again.execute(
+        "SELECT COUNT(*) FROM resume_template_refresh_attempts"
+    ).fetchone()[0] == 3
+    close_connection(db_path)
+
+
+def test_v17_template_reference_migration_rolls_back_and_retries(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    conn = init_db(db_path)
+    job_id = JobId(str(uuid.uuid4()))
+    job_url = "https://example.com/jobs/retry"
+    SqliteJobRepository(conn).save(_discovered_job(job_url, job_id))
+    _downgrade_resume_template_references_to_v16(conn)
+    _insert_assignment(
+        conn,
+        job_url=job_url,
+        template_id=BUILT_IN_TEMPLATE,
+        version_id=BUILT_IN_VERSION,
+        updated_at="2026-07-29T10:00:00+00:00",
+    )
+    conn.commit()
+    original_verify = (
+        database_module._verify_resume_template_references_v17
+    )
+
+    def _fail_verification(
+        _conn: sqlite3.Connection,
+        *,
+        expected_counts: dict[str, int],
+    ) -> None:
+        del expected_counts
+        raise RuntimeError("injected template verification failure")
+
+    monkeypatch.setattr(
+        database_module,
+        "_verify_resume_template_references_v17",
+        _fail_verification,
+    )
+    with pytest.raises(
+        RuntimeError,
+        match="injected template verification failure",
+    ):
+        ensure_resume_template_references_v17(conn)
+    assert conn.execute("PRAGMA user_version").fetchone()[0] == 16
+    assert "job_url" in _columns(
+        conn,
+        "job_resume_template_assignments",
+    )
+    assert conn.execute(
+        "SELECT COUNT(*) FROM job_resume_template_assignments"
+    ).fetchone()[0] == 1
+
+    monkeypatch.setattr(
+        database_module,
+        "_verify_resume_template_references_v17",
+        original_verify,
+    )
+    assert ensure_resume_template_references_v17(conn) == list(
+        database_module._RESUME_TEMPLATE_REFERENCE_TABLES
+    )
+    assert conn.execute("PRAGMA user_version").fetchone()[0] == 17
+    assert conn.execute("PRAGMA foreign_key_check").fetchone() is None
+    close_connection(db_path)
+
+
+def test_runtime_template_reference_merge_keeps_latest_assignment_and_attempts(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    conn = init_db(db_path)
+    jobs = SqliteJobRepository(conn)
+    losing_id = JobId(str(uuid.uuid4()))
+    surviving_id = JobId(str(uuid.uuid4()))
+    other_tenant_job_id = JobId(str(uuid.uuid4()))
+    losing_url = "https://example.com/jobs/losing"
+    surviving_url = "https://example.com/jobs/surviving"
+    jobs.save(_discovered_job(losing_url, losing_id))
+    jobs.save(_discovered_job(surviving_url, surviving_id))
+    conn.execute(
+        """
+        INSERT INTO jobs (
+            url, tenant_id, job_id, title, company, site, strategy,
+            discovered_at
+        ) VALUES (?, 'tenant-b', ?, 'Platform Engineer', 'Example',
+                  'example', 'jobspy', ?)
+        """,
+        (
+            "https://tenant-b.example/jobs/stable",
+            str(other_tenant_job_id),
+            "2026-07-29T10:00:00+00:00",
+        ),
+    )
+    _insert_custom_template(conn)
+    conn.executemany(
+        """
+        INSERT INTO job_resume_template_assignments (
+            tenant_id, job_id, template_id, version_id, updated_at
+        ) VALUES ('local', ?, ?, ?, ?)
+        """,
+        (
+            (
+                str(surviving_id),
+                BUILT_IN_TEMPLATE,
+                BUILT_IN_VERSION,
+                "2026-07-29T10:00:00+00:00",
+            ),
+            (
+                str(losing_id),
+                CUSTOM_TEMPLATE,
+                CUSTOM_VERSION,
+                "2026-07-29T10:01:00+00:00",
+            ),
+        ),
+    )
+    conn.executemany(
+        """
+        INSERT INTO job_materials (
+            tenant_id, job_id, generation, status, created_at, updated_at,
+            last_validation_json, last_verdict_json, metadata_json
+        ) VALUES (?, ?, 1, 'resume_approved', ?, ?, '{}', '{}', '{}')
+        """,
+        (
+            (
+                "local",
+                str(surviving_id),
+                "2026-07-29T10:00:00+00:00",
+                "2026-07-29T10:00:00+00:00",
+            ),
+            (
+                "local",
+                str(losing_id),
+                "2026-07-29T10:01:00+00:00",
+                "2026-07-29T10:01:00+00:00",
+            ),
+            (
+                "tenant-b",
+                str(other_tenant_job_id),
+                "2026-07-29T10:02:00+00:00",
+                "2026-07-29T10:02:00+00:00",
+            ),
+        ),
+    )
+    conn.executemany(
+        """
+        INSERT INTO resume_template_refresh_attempts (
+            tenant_id, attempt_id, job_id, status, from_generation,
+            to_generation, metadata_json, created_at
+        ) VALUES (?, ?, ?, 'completed', ?, ?, '{}', ?)
+        """,
+        (
+            (
+                "local",
+                "attempt-surviving",
+                str(surviving_id),
+                1,
+                None,
+                "2026-07-29T10:00:00+00:00",
+            ),
+            (
+                "local",
+                "attempt-losing",
+                str(losing_id),
+                1,
+                1,
+                "2026-07-29T10:01:00+00:00",
+            ),
+            (
+                "tenant-b",
+                "attempt-other-tenant",
+                str(other_tenant_job_id),
+                1,
+                1,
+                "2026-07-29T10:02:00+00:00",
+            ),
+        ),
+    )
+    conn.commit()
+
+    reassign_discovery_identity_references(
+        conn,
+        losing_job_url=losing_url,
+        surviving_job_url=surviving_url,
+    )
+
+    assignment = conn.execute(
+        """
+        SELECT job_id, template_id, version_id
+        FROM job_resume_template_assignments
+        """
+    ).fetchone()
+    assert tuple(assignment) == (
+        str(surviving_id),
+        CUSTOM_TEMPLATE,
+        CUSTOM_VERSION,
+    )
+    attempts = conn.execute(
+        """
+        SELECT attempt_id, job_id, from_generation, to_generation
+        FROM resume_template_refresh_attempts
+        WHERE tenant_id = 'local'
+        ORDER BY attempt_id
+        """
+    ).fetchall()
+    assert [tuple(row) for row in attempts] == [
+        ("attempt-losing", str(surviving_id), 2, 2),
+        ("attempt-surviving", str(surviving_id), 1, None),
+    ]
+    assert tuple(
+        conn.execute(
+            """
+            SELECT job_id, from_generation, to_generation
+            FROM resume_template_refresh_attempts
+            WHERE tenant_id = 'tenant-b'
+              AND attempt_id = 'attempt-other-tenant'
+            """
+        ).fetchone()
+    ) == (str(other_tenant_job_id), 1, 1)
+    assert [
+        tuple(row)
+        for row in conn.execute(
+            """
+            SELECT generation, created_at
+            FROM job_materials
+            WHERE tenant_id = 'local' AND job_id = ?
+            ORDER BY generation
+            """,
+            (str(surviving_id),),
+        ).fetchall()
+    ] == [
+        (1, "2026-07-29T10:00:00+00:00"),
+        (2, "2026-07-29T10:01:00+00:00"),
+    ]
+    assert conn.execute("PRAGMA foreign_key_check").fetchone() is None
+    close_connection(db_path)

--- a/workers/automation/tests/test_scoring_identity_reference_migration.py
+++ b/workers/automation/tests/test_scoring_identity_reference_migration.py
@@ -338,7 +338,7 @@ def test_v11_scoring_references_migrate_alias_histories_and_reopen(
     assert (
         int(migrated.execute("PRAGMA user_version").fetchone()[0])
         == SCHEMA_VERSION
-        == 16
+        == 17
     )
     assert _columns(migrated, "job_scores") >= {"tenant_id", "job_id"}
     assert "job_url" not in _columns(migrated, "job_scores")
@@ -404,7 +404,7 @@ def test_v11_scoring_references_migrate_alias_histories_and_reopen(
     assert (
         int(reopened.execute("PRAGMA user_version").fetchone()[0])
         == SCHEMA_VERSION
-        == 16
+        == 17
     )
 
 
@@ -553,7 +553,7 @@ def test_scoring_migration_rolls_back_and_retries_after_verification_failure(
     assert (
         int(retried.execute("PRAGMA user_version").fetchone()[0])
         == SCHEMA_VERSION
-        == 16
+        == 17
     )
     assert [
         tuple(row)

--- a/workers/automation/tests/test_stable_job_identity_migration.py
+++ b/workers/automation/tests/test_stable_job_identity_migration.py
@@ -743,7 +743,7 @@ def test_v6_jobs_gain_stable_uuid_and_posting_url_alias_once(
     init_db(db_path)
     close_connection(db_path)
 
-    assert _user_version(db_path) == SCHEMA_VERSION == 16
+    assert _user_version(db_path) == SCHEMA_VERSION == 17
     first_ids = _identity_rows(db_path)
     assert [row[0] for row in first_ids] == ["local", "local"]
     for _tenant_id, job_id, _url in first_ids:


### PR DESCRIPTION
## Summary

- migrate `job_resume_template_assignments` and `resume_template_refresh_attempts` from URL-shaped job references to tenant-scoped stable `JobId` references (schema v17)
- preserve the newest mutable assignment while retaining every refresh-attempt audit row
- keep posting URLs at the TypeScript API compatibility boundary while storing stable identities internally
- preserve refresh-to-material generation bindings when duplicate identities collapse by applying the materials generation map first
- explicitly remove both reference tables during permanent deletion, including when SQLite foreign keys are disabled

## Safety and regressions

- URL-first alias resolution prevents UUID-shaped posting URLs from binding to an unrelated JobId
- transactional migration rollback/retry, reopen idempotency, FK/index/UUID/orphan validation
- collision regression proves losing `1 -> 1` material references become `2 -> 2`, survivor `1 -> null` remains `1 -> null`, and another tenant remains unchanged
- timestamp-tied terminal refresh attempts outrank queued attempts

## Validation

- Python full suite: 2,696 passed, 2 skipped
- API full suite: 673 passed
- focused materials/resume-template migration suite: 6 passed
- API resume-template suite: 11 passed
- TypeScript API check: passed
- Ruff: passed
- `git diff --check`: passed
- independent reviewer: PASS (0 Blocker / 0 High / 0 Medium / 0 Low)
- independent QA: PASS (0 Blocker / 0 High / 0 Medium / 0 Low)

## Stack

- base: #541
- canonical product docs and cumulative stack QA remain deferred to the final approved stack PR
- next identity slices cover interview preparation, compensation, Apply/repeat evidence, contacts/outreach/feedback/tombstones, then the canonical jobs rebuild and Phase 4 cutover