### PR TITLE
feat(interview): migrate preparation references to stable JobIds

### DIFF
--- a/apps/api/src/application-feedback.ts
+++ b/apps/api/src/application-feedback.ts
@@ -841,16 +841,22 @@ function resolveInterviewPrepGeneration(
   if (!tableExists(db, "job_interview_prep")) {
     throw new InputError("Interview prep generation not found.");
   }
+  const reference = jobReferencePredicateForUrl(
+    db,
+    "job_interview_prep",
+    jobUrl,
+    DEFAULT_TENANT,
+  );
   const row = getRow<{ generation: number }>(
     db,
     `SELECT generation
        FROM job_interview_prep
       WHERE tenant_id = ?
-        AND job_url = ?
+        AND ${reference.sql}
         AND generation = ?
         AND status IN ('accepted', 'superseded')
       LIMIT 1`,
-    [DEFAULT_TENANT, jobUrl, generation],
+    [DEFAULT_TENANT, ...reference.params, generation],
   );
   if (!row) {
     throw new InputError("Interview prep generation not found.");

--- a/apps/api/src/db.ts
+++ b/apps/api/src/db.ts
@@ -9,7 +9,7 @@ export type SqliteValue = string | number | bigint | null;
 // writer that stamps ``PRAGMA user_version``; the API only reads it to fail
 // closed on a database written by a newer build. Bump both constants together
 // whenever the schema shape changes.
-export const SUPPORTED_SCHEMA_VERSION = 17;
+export const SUPPORTED_SCHEMA_VERSION = 18;
 
 export class IncompatibleSchemaVersionError extends Error {
   constructor(current: number) {

--- a/apps/api/src/projections.ts
+++ b/apps/api/src/projections.ts
@@ -1860,7 +1860,7 @@ interface RequirementFitItemRow extends Record<string, unknown> {
 }
 
 interface InterviewPrepRow extends Record<string, unknown> {
-  job_url: string;
+  job_reference: string;
   generation: number;
   status: string;
   model: string | null;
@@ -2157,16 +2157,38 @@ function loadInterviewPrepJson(
 ): string | null {
   if (!tableExists(db, "job_interview_prep")) return null;
   if (!tableExists(db, "job_interview_prep_items")) return null;
+  const prepReference = jobReferenceColumn(
+    db,
+    "job_interview_prep",
+  );
+  const itemReference = jobReferenceColumn(
+    db,
+    "job_interview_prep_items",
+  );
+  const prepReferenceValue = jobReferenceForUrl(
+    db,
+    "job_interview_prep",
+    jobUrl,
+    tenantId,
+  );
+  const itemReferenceValue = jobReferenceForUrl(
+    db,
+    "job_interview_prep_items",
+    jobUrl,
+    tenantId,
+  );
   const row = getRow<InterviewPrepRow>(
     db,
-    `SELECT job_url, generation, status, model, generated_at, gate_status,
+    `SELECT ${prepReference} AS job_reference,
+            generation, status, model, generated_at, gate_status,
             fabrication_findings_json, grounding_findings_json, judge_verdict,
             warnings_json
        FROM job_interview_prep
-      WHERE tenant_id = ? AND job_url = ? AND status = 'accepted'
+      WHERE tenant_id = ? AND ${prepReference} = ?
+        AND status = 'accepted'
       ORDER BY generation DESC
       LIMIT 1`,
-    [tenantId, jobUrl],
+    [tenantId, prepReferenceValue],
   );
   if (!row) return null;
   const generation = Number(row.generation);
@@ -2176,12 +2198,12 @@ function loadInterviewPrepJson(
             requirement_ids_json, source_text_json, transform_type, control,
             grounding_audit_json, warnings_json, position
        FROM job_interview_prep_items
-      WHERE tenant_id = ? AND job_url = ? AND generation = ?
+      WHERE tenant_id = ? AND ${itemReference} = ? AND generation = ?
       ORDER BY position ASC, item_id ASC`,
-    [tenantId, jobUrl, generation],
+    [tenantId, itemReferenceValue, generation],
   );
   const readModel = {
-    jobKey: row.job_url,
+    jobKey: jobUrl,
     generation,
     status: row.status,
     generatedAt: row.generated_at,

--- a/apps/api/src/write-model.ts
+++ b/apps/api/src/write-model.ts
@@ -853,6 +853,8 @@ function purgeJobRows(db: SqliteDatabase, jobUrl: string): void {
   deleteJobReferences(db, "job_artifacts", jobId, jobUrl);
   deleteScoringJobReferences(db, jobId, jobUrl);
   for (const tableName of [
+    "job_interview_prep_items",
+    "job_interview_prep",
     "job_bullet_provenance",
     "job_material_layout_boxes",
     "job_materials_artifacts",

--- a/apps/api/test/audit-projection-parity.test.ts
+++ b/apps/api/test/audit-projection-parity.test.ts
@@ -99,6 +99,11 @@ interface Fixture {
 }
 
 const fixture = JSON.parse(fs.readFileSync(FIXTURE_PATH, "utf8")) as Fixture;
+const PRIMARY_JOB_ID = "11111111-1111-4111-8111-111111111111";
+
+function fixtureJobId(index: number): string {
+  return `00000000-0000-4000-8000-${String(index).padStart(12, "0")}`;
+}
 
 function withTempDb(): { dbPath: string; cleanup: () => void } {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "jobctrl-api-audit-parity-"));
@@ -115,6 +120,8 @@ function seedSchema(dbPath: string): void {
   db.exec(`
     CREATE TABLE jobs (
       url TEXT PRIMARY KEY,
+      tenant_id TEXT NOT NULL DEFAULT 'local',
+      job_id TEXT,
       title TEXT,
       company TEXT,
       salary TEXT,
@@ -139,7 +146,8 @@ function seedSchema(dbPath: string): void {
       applied_at TEXT,
       apply_status TEXT,
       apply_error TEXT,
-      apply_attempts INTEGER DEFAULT 0
+      apply_attempts INTEGER DEFAULT 0,
+      UNIQUE (tenant_id, job_id)
     );
     CREATE TABLE job_events (
       event_id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -267,9 +275,9 @@ function seedSchema(dbPath: string): void {
       PRIMARY KEY (job_url, generation, bullet_id)
     );
     CREATE TABLE job_interview_prep (
-      job_url TEXT NOT NULL,
-      generation INTEGER NOT NULL,
       tenant_id TEXT NOT NULL DEFAULT 'local',
+      job_id TEXT NOT NULL,
+      generation INTEGER NOT NULL,
       status TEXT NOT NULL,
       model TEXT,
       generated_at TEXT NOT NULL,
@@ -279,13 +287,13 @@ function seedSchema(dbPath: string): void {
       judge_verdict TEXT,
       warnings_json TEXT NOT NULL DEFAULT '[]',
       failure_reason TEXT NOT NULL DEFAULT '',
-      PRIMARY KEY (job_url, generation)
+      PRIMARY KEY (tenant_id, job_id, generation)
     );
     CREATE TABLE job_interview_prep_items (
-      job_url TEXT NOT NULL,
+      tenant_id TEXT NOT NULL DEFAULT 'local',
+      job_id TEXT NOT NULL,
       generation INTEGER NOT NULL,
       item_id TEXT NOT NULL,
-      tenant_id TEXT NOT NULL DEFAULT 'local',
       kind TEXT NOT NULL,
       title TEXT NOT NULL,
       generated_text TEXT NOT NULL,
@@ -297,7 +305,7 @@ function seedSchema(dbPath: string): void {
       grounding_audit_json TEXT NOT NULL DEFAULT '[]',
       warnings_json TEXT NOT NULL DEFAULT '[]',
       position INTEGER NOT NULL DEFAULT 0,
-      PRIMARY KEY (job_url, generation, item_id)
+      PRIMARY KEY (tenant_id, job_id, generation, item_id)
     );
     CREATE TABLE jobctrl_hidden_jobs (
       job_url TEXT PRIMARY KEY,
@@ -345,14 +353,15 @@ function seedRows(dbPath: string): void {
   const jobUrl = fixture.job.url;
   db.prepare(
     `INSERT INTO jobs (
-       url, title, company, site, strategy, location, salary, description,
+       url, tenant_id, job_id, title, company, site, strategy, location, salary, description,
        full_description, application_url, apply_status, applied_at,
        score_reasoning, discovered_at
-     ) VALUES (@url, @title, @company, @site, @strategy, @location, @salary, @description,
+     ) VALUES (@url, 'local', @job_id, @title, @company, @site, @strategy, @location, @salary, @description,
        @full_description, @application_url, @apply_status, @applied_at,
        @score_reasoning, @discovered_at)`,
   ).run({
     url: jobUrl,
+    job_id: PRIMARY_JOB_ID,
     title: fixture.job.title,
     company: fixture.job.company,
     site: fixture.job.site,
@@ -452,27 +461,27 @@ function seedRows(dbPath: string): void {
   }
   const insertInterviewPrep = db.prepare(
     `INSERT INTO job_interview_prep (
-       job_url, generation, tenant_id, status, model, generated_at, gate_status,
+       tenant_id, job_id, generation, status, model, generated_at, gate_status,
        fabrication_findings_json, grounding_findings_json, judge_verdict,
        warnings_json, failure_reason
-     ) VALUES (@job_url, @generation, 'local', @status, @model, @generated_at, @gate_status,
+     ) VALUES ('local', @job_id, @generation, @status, @model, @generated_at, @gate_status,
        @fabrication_findings_json, @grounding_findings_json, @judge_verdict,
        @warnings_json, @failure_reason)`,
   );
   for (const prep of fixture.rows.jobInterviewPrep) {
-    insertInterviewPrep.run({ job_url: jobUrl, ...prep });
+    insertInterviewPrep.run({ job_id: PRIMARY_JOB_ID, ...prep });
   }
   const insertInterviewPrepItem = db.prepare(
     `INSERT INTO job_interview_prep_items (
-       job_url, generation, item_id, tenant_id, kind, title, generated_text,
+       tenant_id, job_id, generation, item_id, kind, title, generated_text,
        evidence_ids_json, requirement_ids_json, source_text_json, transform_type,
        control, grounding_audit_json, warnings_json, position
-     ) VALUES (@job_url, @generation, @item_id, 'local', @kind, @title, @generated_text,
+     ) VALUES ('local', @job_id, @generation, @item_id, @kind, @title, @generated_text,
        @evidence_ids_json, @requirement_ids_json, @source_text_json, @transform_type,
        @control, @grounding_audit_json, @warnings_json, @position)`,
   );
   for (const item of fixture.rows.jobInterviewPrepItems) {
-    insertInterviewPrepItem.run({ job_url: jobUrl, ...item });
+    insertInterviewPrepItem.run({ job_id: PRIMARY_JOB_ID, ...item });
   }
   db.prepare(
     `INSERT INTO job_events (job_url, stage, event_type, level, message, occurred_at, payload_json)
@@ -483,9 +492,9 @@ function seedRows(dbPath: string): void {
   // (the job_list/job_detail assertions target the primary job). See the fixture
   // `dashboardAggregateJobs` notes for the two divergences they cover.
   const insertAggJob = db.prepare(
-    `INSERT INTO jobs (url, title, company, site, strategy, location,
+    `INSERT INTO jobs (url, tenant_id, job_id, title, company, site, strategy, location,
        apply_status, applied_at, tailored_resume_path, discovered_at)
-     VALUES (@url, @title, @company, @site, @strategy, @location,
+     VALUES (@url, 'local', @job_id, @title, @company, @site, @strategy, @location,
        @apply_status, @applied_at, @tailored_resume_path, @discovered_at)`,
   );
   const insertAggStage = db.prepare(
@@ -502,9 +511,10 @@ function seedRows(dbPath: string): void {
     `INSERT INTO jobctrl_hidden_jobs (job_url, hidden_at, reason, unhidden_at)
      VALUES (?, ?, 'parity', NULL)`,
   );
-  for (const agg of fixture.dashboardAggregateJobs) {
+  for (const [index, agg] of fixture.dashboardAggregateJobs.entries()) {
     insertAggJob.run({
       url: agg.url,
+      job_id: fixtureJobId(index + 2),
       title: agg.title,
       company: agg.company,
       site: agg.site,
@@ -552,8 +562,13 @@ function seedRows(dbPath: string): void {
     ["apply", 3],
   ];
   const insertConversionJob = db.prepare(
-    `INSERT INTO jobs (url, title, site, fit_score, apply_status, applied_at, discovered_at)
-     VALUES (@url, @title, @site, @fit_score, 'applied', @applied_at, @discovered_at)`,
+    `INSERT INTO jobs (
+       url, tenant_id, job_id, title, site, fit_score, apply_status,
+       applied_at, discovered_at
+     ) VALUES (
+       @url, 'local', @job_id, @title, @site, @fit_score, 'applied',
+       @applied_at, @discovered_at
+     )`,
   );
   const insertConversionStage = db.prepare(
     `INSERT INTO job_stage_states (
@@ -561,9 +576,10 @@ function seedRows(dbPath: string): void {
        finished_at, duration_ms, retryable
      ) VALUES (@job_url, @stage, 'succeeded', 1, @max_attempts, @at, @at, @at, 1000, 1)`,
   );
-  for (const job of fixture.rows.conversionJobs) {
+  for (const [index, job] of fixture.rows.conversionJobs.entries()) {
     insertConversionJob.run({
       url: job.url,
+      job_id: fixtureJobId(index + 100),
       title: job.title,
       site: job.site,
       fit_score: job.fitScore,

--- a/apps/api/test/interview-prep-v18.test.ts
+++ b/apps/api/test/interview-prep-v18.test.ts
@@ -1,0 +1,161 @@
+import Database from "better-sqlite3";
+import { describe, expect, it } from "vitest";
+
+import {
+  recordManualApplicationOutcome,
+} from "../src/application-feedback.js";
+import {
+  InputError,
+  permanentlyDeleteJob,
+} from "../src/write-model.js";
+
+const UUID_SHAPED_URL = "11111111-1111-4111-8111-111111111111";
+const URL_OWNER_JOB_ID = "22222222-2222-4222-8222-222222222222";
+const ID_TEXT_OWNER_URL = "https://example.com/jobs/id-text-owner";
+
+function createSchema(db: Database.Database): void {
+  db.pragma("foreign_keys = OFF");
+  db.pragma("user_version = 18");
+  db.exec(`
+    CREATE TABLE jobs (
+      url TEXT PRIMARY KEY,
+      tenant_id TEXT NOT NULL DEFAULT 'local',
+      job_id TEXT NOT NULL,
+      title TEXT,
+      application_url TEXT,
+      UNIQUE (tenant_id, job_id)
+    );
+    CREATE TABLE job_interview_prep (
+      tenant_id TEXT NOT NULL DEFAULT 'local',
+      job_id TEXT NOT NULL,
+      generation INTEGER NOT NULL,
+      status TEXT NOT NULL,
+      model TEXT,
+      generated_at TEXT NOT NULL,
+      gate_status TEXT NOT NULL,
+      fabrication_findings_json TEXT NOT NULL DEFAULT '[]',
+      grounding_findings_json TEXT NOT NULL DEFAULT '[]',
+      judge_verdict TEXT,
+      warnings_json TEXT NOT NULL DEFAULT '[]',
+      failure_reason TEXT NOT NULL DEFAULT '',
+      origin_run_id TEXT NOT NULL DEFAULT '',
+      PRIMARY KEY (tenant_id, job_id, generation)
+    );
+    CREATE TABLE job_interview_prep_items (
+      tenant_id TEXT NOT NULL DEFAULT 'local',
+      job_id TEXT NOT NULL,
+      generation INTEGER NOT NULL,
+      item_id TEXT NOT NULL,
+      kind TEXT NOT NULL,
+      title TEXT NOT NULL,
+      generated_text TEXT NOT NULL,
+      evidence_ids_json TEXT NOT NULL DEFAULT '[]',
+      requirement_ids_json TEXT NOT NULL DEFAULT '[]',
+      source_text_json TEXT NOT NULL DEFAULT '[]',
+      transform_type TEXT NOT NULL DEFAULT 'grounded_prep',
+      control TEXT NOT NULL DEFAULT 'never_fabricate',
+      grounding_audit_json TEXT NOT NULL DEFAULT '[]',
+      warnings_json TEXT NOT NULL DEFAULT '[]',
+      position INTEGER NOT NULL DEFAULT 0,
+      PRIMARY KEY (tenant_id, job_id, generation, item_id)
+    );
+  `);
+}
+
+function seedPrep(
+  db: Database.Database,
+  input: { url: string; jobId: string; marker: string },
+): void {
+  db.prepare(
+    `INSERT INTO jobs (url, tenant_id, job_id, title)
+     VALUES (?, 'local', ?, 'Platform Engineer')`,
+  ).run(input.url, input.jobId);
+  db.prepare(
+    `INSERT INTO job_interview_prep (
+       tenant_id, job_id, generation, status, generated_at, gate_status,
+       origin_run_id
+     ) VALUES (
+       'local', ?, 2, 'accepted', '2026-07-29T10:00:00.000Z',
+       'passed', ?
+     )`,
+  ).run(input.jobId, `run:${input.marker}`);
+  db.prepare(
+    `INSERT INTO job_interview_prep_items (
+       tenant_id, job_id, generation, item_id, kind, title, generated_text
+     ) VALUES (
+       'local', ?, 2, ?, 'theme', 'Theme', 'Grounded preparation'
+     )`,
+  ).run(input.jobId, `item:${input.marker}`);
+}
+
+describe("schema-v18 Interview Preparation API compatibility", () => {
+  it("links a UUID-shaped posting URL to its URL owner's stable prep", () => {
+    const db = new Database(":memory:");
+    createSchema(db);
+    seedPrep(db, {
+      url: UUID_SHAPED_URL,
+      jobId: URL_OWNER_JOB_ID,
+      marker: "url-owner",
+    });
+    seedPrep(db, {
+      url: ID_TEXT_OWNER_URL,
+      jobId: UUID_SHAPED_URL,
+      marker: "id-owner",
+    });
+
+    expect(
+      recordManualApplicationOutcome(db, UUID_SHAPED_URL, {
+        kind: "interview",
+        occurredAt: "2026-07-29T11:00:00.000Z",
+        note: "Private reflection",
+        interviewPrepGeneration: 2,
+      }).outcome,
+    ).toMatchObject({
+      jobKey: UUID_SHAPED_URL,
+      interviewPrepGeneration: 2,
+    });
+    expect(() =>
+      recordManualApplicationOutcome(db, UUID_SHAPED_URL, {
+        kind: "interview",
+        occurredAt: "2026-07-29T11:01:00.000Z",
+        interviewPrepGeneration: 99,
+      }),
+    ).toThrowError(InputError);
+    db.close();
+  });
+
+  it("permanently deletes only the URL owner's prep with FK cascades off", () => {
+    const db = new Database(":memory:");
+    createSchema(db);
+    seedPrep(db, {
+      url: UUID_SHAPED_URL,
+      jobId: URL_OWNER_JOB_ID,
+      marker: "url-owner",
+    });
+    seedPrep(db, {
+      url: ID_TEXT_OWNER_URL,
+      jobId: UUID_SHAPED_URL,
+      marker: "id-owner",
+    });
+
+    expect(permanentlyDeleteJob(db, UUID_SHAPED_URL)).toEqual({
+      ok: true,
+      count: 1,
+      jobKeys: [UUID_SHAPED_URL],
+    });
+    expect(
+      db.prepare("SELECT url FROM jobs ORDER BY url").all(),
+    ).toEqual([{ url: ID_TEXT_OWNER_URL }]);
+    for (const tableName of [
+      "job_interview_prep",
+      "job_interview_prep_items",
+    ]) {
+      expect(
+        db.prepare(
+          `SELECT DISTINCT job_id FROM ${tableName}`,
+        ).all(),
+      ).toEqual([{ job_id: UUID_SHAPED_URL }]);
+    }
+    db.close();
+  });
+});

--- a/apps/api/test/schema-version-guard.test.ts
+++ b/apps/api/test/schema-version-guard.test.ts
@@ -63,7 +63,7 @@ describe("schema version guard at DB open", () => {
   });
 
   it("opens the worker-owned schema-v14 artifact registry", () => {
-    expect(SUPPORTED_SCHEMA_VERSION).toBe(17);
+    expect(SUPPORTED_SCHEMA_VERSION).toBe(18);
     const { dbPath, cleanup } = makeDbWithUserVersion(14);
     try {
       openDatabase(dbPath).close();

--- a/workers/automation/src/jobctrl/database.py
+++ b/workers/automation/src/jobctrl/database.py
@@ -67,7 +67,11 @@ from jobctrl.config import DB_PATH, DEFAULTS, migrate_legacy_job_tables
 # Identity collapse preserves and deterministically renumbers complete histories.
 # v17 (resume-template references): the mutable per-job assignment and every
 # render-only refresh attempt reference the tenant-scoped stable Job aggregate.
-SCHEMA_VERSION = 17
+# v18 (interview-preparation references): complete preparation histories and
+# their child audit rows reference the stable Job aggregate. Any immutable
+# application-outcome link to a preparation generation is remapped alongside
+# alias-history renumbering while its legacy URL key remains unchanged.
+SCHEMA_VERSION = 18
 
 
 class IncompatibleSchemaVersionError(RuntimeError):
@@ -215,6 +219,7 @@ def _schema_migrations() -> tuple[
         (15, ensure_materials_references_v15),
         (16, ensure_employer_analysis_references_v16),
         (17, ensure_resume_template_references_v17),
+        (18, ensure_interview_prep_references_v18),
     )
 
 
@@ -3197,24 +3202,55 @@ def ensure_bullet_provenance_tables(conn: sqlite3.Connection | None = None) -> l
     return ["job_bullet_provenance"]
 
 
-def ensure_interview_prep_tables(conn: sqlite3.Connection | None = None) -> list[str]:
-    """Create Interview Preparation canonical generation tables.
+_INTERVIEW_PREP_REFERENCE_SCHEMA_VERSION = 18
 
-    Interview prep is generated material, not a projection. Rows are versioned by
-    ``(job_url, generation)`` so a failed regenerate can be audited without
-    destroying the last accepted prep. Prompt/raw profile/job payloads are not
-    stored here; rows keep only the accepted/failed gate audit and item
-    provenance needed for later read-model projection.
-    """
-    if conn is None:
-        conn = get_connection()
 
+def _create_interview_prep_tables(
+    conn: sqlite3.Connection,
+    *,
+    prep_table: str,
+    items_table: str,
+    reference_column: str,
+) -> None:
+    stable_reference = reference_column == "job_id"
+    parent_primary_key = (
+        f"tenant_id, {reference_column}, generation"
+        if stable_reference
+        else f"{reference_column}, generation"
+    )
+    item_primary_key = (
+        f"tenant_id, {reference_column}, generation, item_id"
+        if stable_reference
+        else f"{reference_column}, generation, item_id"
+    )
+    job_foreign_key = (
+        f""",
+            FOREIGN KEY (tenant_id, {reference_column})
+                REFERENCES jobs(tenant_id, job_id) ON DELETE CASCADE"""
+        if stable_reference
+        else f""",
+            FOREIGN KEY ({reference_column})
+                REFERENCES jobs(url) ON DELETE CASCADE"""
+    )
+    parent_foreign_key = (
+        f""",
+            FOREIGN KEY (tenant_id, {reference_column}, generation)
+                REFERENCES {prep_table}(
+                    tenant_id, {reference_column}, generation
+                ) ON DELETE CASCADE"""
+        if stable_reference
+        else f""",
+            FOREIGN KEY ({reference_column}, generation)
+                REFERENCES {prep_table}(
+                    {reference_column}, generation
+                ) ON DELETE CASCADE"""
+    )
     conn.execute(
-        """
-        CREATE TABLE IF NOT EXISTS job_interview_prep (
-            job_url                    TEXT NOT NULL,
-            generation                 INTEGER NOT NULL,
+        f"""
+        CREATE TABLE IF NOT EXISTS {prep_table} (
             tenant_id                  TEXT NOT NULL DEFAULT 'local',
+            {reference_column}         TEXT NOT NULL,
+            generation                 INTEGER NOT NULL,
             status                     TEXT NOT NULL,
             model                      TEXT,
             generated_at               TEXT NOT NULL,
@@ -3225,23 +3261,18 @@ def ensure_interview_prep_tables(conn: sqlite3.Connection | None = None) -> list
             warnings_json              TEXT NOT NULL DEFAULT '[]',
             failure_reason             TEXT NOT NULL DEFAULT '',
             origin_run_id              TEXT NOT NULL DEFAULT '',
-            PRIMARY KEY (job_url, generation),
-            FOREIGN KEY (job_url) REFERENCES jobs(url) ON DELETE CASCADE
+            PRIMARY KEY ({parent_primary_key})
+            {job_foreign_key}
         )
         """
     )
-    prep_cols = {row[1] for row in conn.execute("PRAGMA table_info(job_interview_prep)").fetchall()}
-    if "origin_run_id" not in prep_cols:
-        conn.execute(
-            "ALTER TABLE job_interview_prep ADD COLUMN origin_run_id TEXT NOT NULL DEFAULT ''"
-        )
     conn.execute(
-        """
-        CREATE TABLE IF NOT EXISTS job_interview_prep_items (
-            job_url                    TEXT NOT NULL,
+        f"""
+        CREATE TABLE IF NOT EXISTS {items_table} (
+            tenant_id                  TEXT NOT NULL DEFAULT 'local',
+            {reference_column}         TEXT NOT NULL,
             generation                 INTEGER NOT NULL,
             item_id                    TEXT NOT NULL,
-            tenant_id                  TEXT NOT NULL DEFAULT 'local',
             kind                       TEXT NOT NULL,
             title                      TEXT NOT NULL,
             generated_text             TEXT NOT NULL,
@@ -3253,16 +3284,24 @@ def ensure_interview_prep_tables(conn: sqlite3.Connection | None = None) -> list
             grounding_audit_json       TEXT NOT NULL DEFAULT '[]',
             warnings_json              TEXT NOT NULL DEFAULT '[]',
             position                   INTEGER NOT NULL DEFAULT 0,
-            PRIMARY KEY (job_url, generation, item_id),
-            FOREIGN KEY (job_url, generation)
-                REFERENCES job_interview_prep(job_url, generation) ON DELETE CASCADE
+            PRIMARY KEY ({item_primary_key})
+            {parent_foreign_key}
         )
         """
     )
+
+
+def _create_interview_prep_indexes(
+    conn: sqlite3.Connection,
+    *,
+    reference_column: str,
+) -> None:
     conn.execute(
-        """
+        f"""
         CREATE INDEX IF NOT EXISTS idx_job_interview_prep_tenant_job_gen
-        ON job_interview_prep(tenant_id, job_url, generation DESC)
+        ON job_interview_prep(
+            tenant_id, {reference_column}, generation DESC
+        )
         """
     )
     conn.execute(
@@ -3272,9 +3311,11 @@ def ensure_interview_prep_tables(conn: sqlite3.Connection | None = None) -> list
         """
     )
     conn.execute(
-        """
+        f"""
         CREATE INDEX IF NOT EXISTS idx_job_interview_prep_origin_run
-        ON job_interview_prep(tenant_id, job_url, origin_run_id)
+        ON job_interview_prep(
+            tenant_id, {reference_column}, origin_run_id
+        )
         """
     )
     conn.execute(
@@ -3282,6 +3323,48 @@ def ensure_interview_prep_tables(conn: sqlite3.Connection | None = None) -> list
         CREATE INDEX IF NOT EXISTS idx_job_interview_prep_items_tenant_kind
         ON job_interview_prep_items(tenant_id, kind, position)
         """
+    )
+
+
+def ensure_interview_prep_tables(
+    conn: sqlite3.Connection | None = None,
+) -> list[str]:
+    """Create Interview Preparation canonical generation tables.
+
+    Interview prep is generated material, not a projection. Rows are versioned by
+    ``(job_url, generation)`` so a failed regenerate can be audited without
+    destroying the last accepted prep. Prompt/raw profile/job payloads are not
+    stored here; rows keep only the accepted/failed gate audit and item
+    provenance needed for later read-model projection.
+    """
+    if conn is None:
+        conn = get_connection()
+    current_schema_version = _assert_schema_version_supported(conn)
+    prep_columns = _table_columns(conn, "job_interview_prep")
+    reference_column = (
+        "job_id"
+        if "job_id" in prep_columns
+        or (
+            not prep_columns
+            and current_schema_version
+            >= _INTERVIEW_PREP_REFERENCE_SCHEMA_VERSION
+        )
+        else "job_url"
+    )
+    _create_interview_prep_tables(
+        conn,
+        prep_table="job_interview_prep",
+        items_table="job_interview_prep_items",
+        reference_column=reference_column,
+    )
+    prep_cols = {row[1] for row in conn.execute("PRAGMA table_info(job_interview_prep)").fetchall()}
+    if "origin_run_id" not in prep_cols:
+        conn.execute(
+            "ALTER TABLE job_interview_prep ADD COLUMN origin_run_id TEXT NOT NULL DEFAULT ''"
+        )
+    _create_interview_prep_indexes(
+        conn,
+        reference_column=reference_column,
     )
     conn.commit()
     return ["job_interview_prep", "job_interview_prep_items"]
@@ -4526,6 +4609,21 @@ def _reassign_discovery_identity_references(
             surviving_job_id=surviving_job_id,
             material_generation_map=material_generation_map,
         )
+    if _has_interview_prep_reference_schema_v18(conn):
+        _reassign_interview_prep_references_v18(
+            conn,
+            tenant_id=tenant_id,
+            losing_job_id=losing_job_id,
+            surviving_job_id=surviving_job_id,
+            losing_job_url=losing_job_url,
+            surviving_job_url=surviving_job_url,
+        )
+        _reassign_application_outcome_job_keys_v18(
+            conn,
+            tenant_id=tenant_id,
+            losing_job_url=losing_job_url,
+            surviving_job_url=surviving_job_url,
+        )
     if _has_scoring_reference_schema_v12(conn):
         _reassign_scoring_references_v12(
             conn,
@@ -4550,6 +4648,8 @@ def _reassign_discovery_identity_references(
             losing_job_id=losing_job_id,
             surviving_job_id=surviving_job_id,
         )
+
+
 def _reassign_enrichment_snapshot_references_v11(
     conn: sqlite3.Connection,
     *,
@@ -11066,6 +11166,741 @@ def _reassign_resume_template_references_v17(
         conn,
         expected_counts=expected_counts,
     )
+
+
+_INTERVIEW_PREP_REFERENCE_TABLES = (
+    "job_interview_prep",
+    "job_interview_prep_items",
+)
+
+
+def _has_interview_prep_parent_foreign_key_v18(
+    conn: sqlite3.Connection,
+) -> bool:
+    groups: dict[int, set[tuple[str, str]]] = {}
+    cascades: dict[int, bool] = {}
+    for row in conn.execute(
+        'PRAGMA foreign_key_list("job_interview_prep_items")'
+    ).fetchall():
+        if str(row[2]) != "job_interview_prep":
+            continue
+        foreign_key_id = int(row[0])
+        groups.setdefault(foreign_key_id, set()).add(
+            (str(row[3]), str(row[4]))
+        )
+        cascades[foreign_key_id] = str(row[6]).upper() == "CASCADE"
+    expected = {
+        ("tenant_id", "tenant_id"),
+        ("job_id", "job_id"),
+        ("generation", "generation"),
+    }
+    return any(
+        columns == expected and cascades.get(foreign_key_id, False)
+        for foreign_key_id, columns in groups.items()
+    )
+
+
+def _has_interview_prep_reference_schema_v18(
+    conn: sqlite3.Connection,
+) -> bool:
+    return (
+        "job_id" in _table_columns(conn, "job_interview_prep")
+        and "job_url" not in _table_columns(conn, "job_interview_prep")
+        and _primary_key_columns(conn, "job_interview_prep")
+        == ("tenant_id", "job_id", "generation")
+        and _has_composite_job_id_foreign_key(
+            conn,
+            "job_interview_prep",
+            "job_id",
+        )
+        and "job_id"
+        in _table_columns(conn, "job_interview_prep_items")
+        and "job_url"
+        not in _table_columns(conn, "job_interview_prep_items")
+        and _primary_key_columns(conn, "job_interview_prep_items")
+        == ("tenant_id", "job_id", "generation", "item_id")
+        and _has_interview_prep_parent_foreign_key_v18(conn)
+        and _has_index(
+            conn,
+            "job_interview_prep",
+            "idx_job_interview_prep_tenant_job_gen",
+            ("tenant_id", "job_id", "generation"),
+            unique=False,
+        )
+        and _has_index(
+            conn,
+            "job_interview_prep",
+            "idx_job_interview_prep_tenant_status",
+            ("tenant_id", "status", "generated_at"),
+            unique=False,
+        )
+        and _has_index(
+            conn,
+            "job_interview_prep",
+            "idx_job_interview_prep_origin_run",
+            ("tenant_id", "job_id", "origin_run_id"),
+            unique=False,
+        )
+        and _has_index(
+            conn,
+            "job_interview_prep_items",
+            "idx_job_interview_prep_items_tenant_kind",
+            ("tenant_id", "kind", "position"),
+            unique=False,
+        )
+    )
+
+
+def _merge_interview_prep_histories_v18(
+    history: list[tuple[str, int, tuple[Any, ...]]],
+) -> list[tuple[str, int, tuple[Any, ...]]]:
+    """Interleave prep histories without reversing either source history."""
+    by_reference: dict[
+        str,
+        list[tuple[str, int, tuple[Any, ...]]],
+    ] = {}
+    for entry in history:
+        by_reference.setdefault(entry[0], []).append(entry)
+    for entries in by_reference.values():
+        entries.sort(key=lambda entry: entry[1])
+
+    offsets = {reference: 0 for reference in by_reference}
+    merged: list[tuple[str, int, tuple[Any, ...]]] = []
+    while len(merged) < len(history):
+        eligible = [
+            entries[offsets[reference]]
+            for reference, entries in by_reference.items()
+            if offsets[reference] < len(entries)
+        ]
+        selected = min(
+            eligible,
+            key=lambda entry: (
+                str(entry[2][2]),
+                entry[0],
+                entry[1],
+            ),
+        )
+        merged.append(selected)
+        offsets[selected[0]] += 1
+    return merged
+
+
+def _latest_accepted_interview_prep_key_v18(
+    history: list[tuple[str, int, tuple[Any, ...]]],
+    *,
+    preferred_reference: str,
+) -> tuple[str, int] | None:
+    accepted = [
+        entry
+        for entry in history
+        if str(entry[2][0]) == "accepted"
+    ]
+    if not accepted:
+        return None
+    selected = max(
+        accepted,
+        key=lambda entry: (
+            str(entry[2][2]),
+            entry[0] == preferred_reference,
+            entry[0],
+            entry[1],
+        ),
+    )
+    return selected[0], selected[1]
+
+
+def _canonical_interview_prep_rows_v18(
+    conn: sqlite3.Connection,
+) -> tuple[
+    list[tuple[Any, ...]],
+    dict[tuple[str, str, int], int],
+]:
+    rows = conn.execute(
+        """
+        SELECT tenant_id, job_url, generation, status, model, generated_at,
+               gate_status, fabrication_findings_json,
+               grounding_findings_json, judge_verdict, warnings_json,
+               failure_reason, origin_run_id
+        FROM job_interview_prep
+        ORDER BY tenant_id, job_url, generation
+        """
+    ).fetchall()
+    grouped: dict[
+        tuple[str, str],
+        list[tuple[str, int, tuple[Any, ...]]],
+    ] = {}
+    for row in rows:
+        tenant_id = str(row[0])
+        raw_reference = str(row[1])
+        old_generation = int(row[2])
+        if old_generation <= 0:
+            raise RuntimeError(
+                "interview-prep reference migration found a non-positive "
+                "generation"
+            )
+        stable_job_id = _resolve_job_reference_value(
+            conn,
+            tenant_id=tenant_id,
+            reference=raw_reference,
+            legacy_url=True,
+        )
+        if stable_job_id is None:
+            raise RuntimeError(
+                "interview-prep reference migration could not resolve "
+                f"job_interview_prep.job_url={raw_reference!r}"
+            )
+        _validate_job_uuid(stable_job_id)
+        grouped.setdefault((tenant_id, stable_job_id), []).append(
+            (
+                raw_reference,
+                old_generation,
+                tuple(row[3:]),
+            )
+        )
+
+    canonical: list[tuple[Any, ...]] = []
+    generation_map: dict[tuple[str, str, int], int] = {}
+    for (tenant_id, stable_job_id), history in sorted(grouped.items()):
+        ordered = _merge_interview_prep_histories_v18(history)
+        storage_row = conn.execute(
+            """
+            SELECT url
+            FROM jobs
+            WHERE tenant_id = ? AND job_id = ?
+            LIMIT 1
+            """,
+            (tenant_id, stable_job_id),
+        ).fetchone()
+        preferred_reference = (
+            str(storage_row[0])
+            if storage_row is not None
+            else ""
+        )
+        latest_accepted = _latest_accepted_interview_prep_key_v18(
+            ordered,
+            preferred_reference=preferred_reference,
+        )
+        for index, (
+            raw_reference,
+            old_generation,
+            values,
+        ) in enumerate(ordered):
+            new_generation = index + 1
+            generation_map[
+                (tenant_id, raw_reference, old_generation)
+            ] = new_generation
+            normalized = list(values)
+            if (
+                str(normalized[0]) == "accepted"
+                and (raw_reference, old_generation) != latest_accepted
+            ):
+                normalized[0] = "superseded"
+            canonical.append(
+                (
+                    tenant_id,
+                    stable_job_id,
+                    new_generation,
+                    *normalized,
+                )
+            )
+    return canonical, generation_map
+
+
+def _canonical_interview_prep_item_rows_v18(
+    conn: sqlite3.Connection,
+    *,
+    generation_map: dict[tuple[str, str, int], int],
+) -> list[tuple[Any, ...]]:
+    rows = conn.execute(
+        """
+        SELECT tenant_id, job_url, generation, item_id, kind, title,
+               generated_text, evidence_ids_json, requirement_ids_json,
+               source_text_json, transform_type, control,
+               grounding_audit_json, warnings_json, position
+        FROM job_interview_prep_items
+        ORDER BY tenant_id, job_url, generation, position, item_id
+        """
+    ).fetchall()
+    canonical: list[tuple[Any, ...]] = []
+    for row in rows:
+        tenant_id = str(row[0])
+        raw_reference = str(row[1])
+        old_generation = int(row[2])
+        new_generation = generation_map.get(
+            (tenant_id, raw_reference, old_generation)
+        )
+        stable_job_id = _resolve_job_reference_value(
+            conn,
+            tenant_id=tenant_id,
+            reference=raw_reference,
+            legacy_url=True,
+        )
+        if new_generation is None or stable_job_id is None:
+            raise RuntimeError(
+                "interview-prep reference migration found an item without "
+                "its parent generation"
+            )
+        canonical.append(
+            (
+                tenant_id,
+                stable_job_id,
+                new_generation,
+                *tuple(row[3:]),
+            )
+        )
+    return canonical
+
+
+def _remap_application_outcome_interview_prep_generations_v18(
+    conn: sqlite3.Connection,
+    *,
+    generation_map: dict[tuple[str, str, int], int],
+) -> None:
+    """Preserve immutable outcome-to-preparation links during renumbering.
+
+    Application outcomes remain URL-keyed until their own identity-reference
+    migration. Only the linked preparation generation is rewritten here, using
+    the exact source URL/JobId that owned the generation before histories were
+    merged.
+    """
+    columns = _table_columns(conn, "application_outcomes")
+    required = {
+        "tenant_id",
+        "outcome_id",
+        "job_key",
+        "interview_prep_generation",
+    }
+    if not required.issubset(columns):
+        return
+
+    rows = conn.execute(
+        """
+        SELECT tenant_id, outcome_id, job_key,
+               interview_prep_generation
+        FROM application_outcomes
+        WHERE interview_prep_generation IS NOT NULL
+        ORDER BY tenant_id, outcome_id
+        """
+    ).fetchall()
+    for row in rows:
+        tenant_id = str(row[0])
+        outcome_id = str(row[1])
+        job_key = str(row[2])
+        old_generation = int(row[3])
+        new_generation = generation_map.get(
+            (tenant_id, job_key, old_generation)
+        )
+        if new_generation is None:
+            continue
+        updated = conn.execute(
+            """
+            UPDATE application_outcomes
+            SET interview_prep_generation = ?
+            WHERE tenant_id = ?
+              AND outcome_id = ?
+              AND job_key = ?
+              AND interview_prep_generation = ?
+            """,
+            (
+                new_generation,
+                tenant_id,
+                outcome_id,
+                job_key,
+                old_generation,
+            ),
+        )
+        if updated.rowcount != 1:
+            raise RuntimeError(
+                "interview-prep reference migration could not preserve "
+                f"application outcome {outcome_id!r}"
+            )
+
+
+def _reassign_application_outcome_job_keys_v18(
+    conn: sqlite3.Connection,
+    *,
+    tenant_id: str,
+    losing_job_url: str,
+    surviving_job_url: str,
+) -> None:
+    """Keep legacy URL-keyed outcomes reachable after a URL collision.
+
+    The outcome family remains URL-shaped until its later stable-reference
+    migration. Repointing only the legacy value to the surviving storage URL
+    preserves that compatibility contract and allows the v7 collision cleanup
+    to remove the losing alias without orphaning outcome reads.
+    """
+    columns = _table_columns(conn, "application_outcomes")
+    if not {"tenant_id", "job_key"}.issubset(columns):
+        return
+    conn.execute(
+        """
+        UPDATE application_outcomes
+        SET job_key = ?
+        WHERE tenant_id = ? AND job_key = ?
+        """,
+        (surviving_job_url, tenant_id, losing_job_url),
+    )
+
+
+def ensure_interview_prep_references_v18(
+    conn: sqlite3.Connection | None = None,
+) -> list[str]:
+    """Move Interview Preparation histories to stable JobId references."""
+    if conn is None:
+        conn = get_connection()
+
+    current = _assert_schema_version_supported(conn)
+    if current >= _INTERVIEW_PREP_REFERENCE_SCHEMA_VERSION:
+        return []
+    if current != _RESUME_TEMPLATE_REFERENCE_SCHEMA_VERSION:
+        raise RuntimeError(
+            "interview-prep reference migration requires resume-template "
+            "schema v17"
+        )
+
+    conn.execute("SAVEPOINT interview_prep_references_v18")
+    try:
+        if not _has_resume_template_reference_schema_v17(conn):
+            raise RuntimeError(
+                "interview-prep reference migration requires the stable "
+                "resume-template reference schema"
+            )
+        before_counts = {
+            table: int(
+                conn.execute(
+                    f'SELECT COUNT(*) FROM "{table}"'
+                ).fetchone()[0]
+            )
+            for table in _INTERVIEW_PREP_REFERENCE_TABLES
+        }
+
+        if not _has_interview_prep_reference_schema_v18(conn):
+            (
+                prep_rows,
+                generation_map,
+            ) = _canonical_interview_prep_rows_v18(conn)
+            item_rows = _canonical_interview_prep_item_rows_v18(
+                conn,
+                generation_map=generation_map,
+            )
+            for table in (
+                "job_interview_prep_items_v18",
+                "job_interview_prep_v18",
+            ):
+                conn.execute(f'DROP TABLE IF EXISTS "{table}"')
+            _create_interview_prep_tables(
+                conn,
+                prep_table="job_interview_prep_v18",
+                items_table="job_interview_prep_items_v18",
+                reference_column="job_id",
+            )
+            conn.executemany(
+                """
+                INSERT INTO job_interview_prep_v18 (
+                    tenant_id, job_id, generation, status, model,
+                    generated_at, gate_status,
+                    fabrication_findings_json,
+                    grounding_findings_json, judge_verdict,
+                    warnings_json, failure_reason, origin_run_id
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                prep_rows,
+            )
+            conn.executemany(
+                """
+                INSERT INTO job_interview_prep_items_v18 (
+                    tenant_id, job_id, generation, item_id, kind, title,
+                    generated_text, evidence_ids_json,
+                    requirement_ids_json, source_text_json,
+                    transform_type, control, grounding_audit_json,
+                    warnings_json, position
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                item_rows,
+            )
+            conn.execute('DROP TABLE "job_interview_prep_items"')
+            conn.execute('DROP TABLE "job_interview_prep"')
+            conn.execute(
+                'ALTER TABLE "job_interview_prep_v18" '
+                'RENAME TO "job_interview_prep"'
+            )
+            conn.execute(
+                'ALTER TABLE "job_interview_prep_items_v18" '
+                'RENAME TO "job_interview_prep_items"'
+            )
+            _create_interview_prep_indexes(
+                conn,
+                reference_column="job_id",
+            )
+            _remap_application_outcome_interview_prep_generations_v18(
+                conn,
+                generation_map=generation_map,
+            )
+
+        _verify_interview_prep_references_v18(
+            conn,
+            expected_counts=before_counts,
+        )
+        conn.execute(
+            f"PRAGMA user_version = "
+            f"{_INTERVIEW_PREP_REFERENCE_SCHEMA_VERSION}"
+        )
+        conn.execute(
+            "RELEASE SAVEPOINT interview_prep_references_v18"
+        )
+        conn.commit()
+    except BaseException:
+        conn.execute(
+            "ROLLBACK TO SAVEPOINT interview_prep_references_v18"
+        )
+        conn.execute(
+            "RELEASE SAVEPOINT interview_prep_references_v18"
+        )
+        raise
+
+    return list(_INTERVIEW_PREP_REFERENCE_TABLES)
+
+
+def _verify_interview_prep_references_v18(
+    conn: sqlite3.Connection,
+    *,
+    expected_counts: dict[str, int],
+) -> None:
+    if not _has_interview_prep_reference_schema_v18(conn):
+        raise RuntimeError(
+            "interview-prep reference migration did not create the stable "
+            "reference schema"
+        )
+    for table, expected_count in expected_counts.items():
+        observed_count = int(
+            conn.execute(f'SELECT COUNT(*) FROM "{table}"').fetchone()[0]
+        )
+        if observed_count != expected_count:
+            raise RuntimeError(
+                "interview-prep reference migration changed row count for "
+                f"{table}: expected {expected_count}, found {observed_count}"
+            )
+    orphan_parent = conn.execute(
+        """
+        SELECT prep.job_id
+        FROM job_interview_prep AS prep
+        LEFT JOIN jobs
+          ON jobs.tenant_id = prep.tenant_id
+         AND jobs.job_id = prep.job_id
+        WHERE jobs.job_id IS NULL
+        LIMIT 1
+        """
+    ).fetchone()
+    if orphan_parent is not None:
+        raise RuntimeError(
+            "interview-prep reference migration left an unresolved JobId"
+        )
+    orphan_item = conn.execute(
+        """
+        SELECT item.job_id
+        FROM job_interview_prep_items AS item
+        LEFT JOIN job_interview_prep AS prep
+          ON prep.tenant_id = item.tenant_id
+         AND prep.job_id = item.job_id
+         AND prep.generation = item.generation
+        WHERE prep.job_id IS NULL
+        LIMIT 1
+        """
+    ).fetchone()
+    if orphan_item is not None:
+        raise RuntimeError(
+            "interview-prep reference migration left an item without its "
+            "parent generation"
+        )
+    multiple_accepted = conn.execute(
+        """
+        SELECT tenant_id, job_id
+        FROM job_interview_prep
+        WHERE status = 'accepted'
+        GROUP BY tenant_id, job_id
+        HAVING COUNT(*) > 1
+        LIMIT 1
+        """
+    ).fetchone()
+    if multiple_accepted is not None:
+        raise RuntimeError(
+            "interview-prep reference migration left multiple accepted "
+            "generations for one job"
+        )
+    for table in _INTERVIEW_PREP_REFERENCE_TABLES:
+        for row in conn.execute(
+            f'SELECT DISTINCT job_id FROM "{table}"'
+        ).fetchall():
+            _validate_job_uuid(str(row[0]))
+    foreign_key_error = conn.execute(
+        "PRAGMA foreign_key_check"
+    ).fetchone()
+    if foreign_key_error is not None:
+        raise RuntimeError(
+            "interview-prep reference migration found a foreign-key "
+            "violation"
+        )
+
+
+def _reassign_interview_prep_references_v18(
+    conn: sqlite3.Connection,
+    *,
+    tenant_id: str,
+    losing_job_id: str,
+    surviving_job_id: str,
+    losing_job_url: str,
+    surviving_job_url: str,
+) -> dict[tuple[str, int], int]:
+    """Merge complete Interview Preparation histories during identity collapse."""
+    if losing_job_id == surviving_job_id:
+        return {}
+    before_counts = {
+        table: int(
+            conn.execute(f'SELECT COUNT(*) FROM "{table}"').fetchone()[0]
+        )
+        for table in _INTERVIEW_PREP_REFERENCE_TABLES
+    }
+    parent_rows = conn.execute(
+        """
+        SELECT job_id, generation, status, model, generated_at,
+               gate_status, fabrication_findings_json,
+               grounding_findings_json, judge_verdict, warnings_json,
+               failure_reason, origin_run_id
+        FROM job_interview_prep
+        WHERE tenant_id = ? AND job_id IN (?, ?)
+        ORDER BY job_id, generation
+        """,
+        (tenant_id, losing_job_id, surviving_job_id),
+    ).fetchall()
+    if not parent_rows:
+        return {}
+
+    history = [
+        (
+            str(row[0]),
+            int(row[1]),
+            tuple(row[2:]),
+        )
+        for row in parent_rows
+    ]
+    ordered = _merge_interview_prep_histories_v18(history)
+    latest_accepted = _latest_accepted_interview_prep_key_v18(
+        ordered,
+        preferred_reference=surviving_job_id,
+    )
+    generation_map: dict[tuple[str, int], int] = {}
+    canonical_parents: list[tuple[Any, ...]] = []
+    for index, (
+        old_job_id,
+        old_generation,
+        values,
+    ) in enumerate(ordered):
+        new_generation = index + 1
+        generation_map[(old_job_id, old_generation)] = new_generation
+        normalized = list(values)
+        if (
+            str(normalized[0]) == "accepted"
+            and (old_job_id, old_generation) != latest_accepted
+        ):
+            normalized[0] = "superseded"
+        canonical_parents.append(
+            (
+                tenant_id,
+                surviving_job_id,
+                new_generation,
+                *normalized,
+            )
+        )
+
+    item_source = conn.execute(
+        """
+        SELECT job_id, generation, item_id, kind, title, generated_text,
+               evidence_ids_json, requirement_ids_json, source_text_json,
+               transform_type, control, grounding_audit_json,
+               warnings_json, position
+        FROM job_interview_prep_items
+        WHERE tenant_id = ? AND job_id IN (?, ?)
+        ORDER BY job_id, generation, position, item_id
+        """,
+        (tenant_id, losing_job_id, surviving_job_id),
+    ).fetchall()
+    canonical_items: list[tuple[Any, ...]] = []
+    for row in item_source:
+        mapped = generation_map.get((str(row[0]), int(row[1])))
+        if mapped is None:
+            raise RuntimeError(
+                "interview-prep identity collapse found an item without "
+                "its parent generation"
+            )
+        canonical_items.append(
+            (
+                tenant_id,
+                surviving_job_id,
+                mapped,
+                *tuple(row[2:]),
+            )
+        )
+
+    conn.execute(
+        """
+        DELETE FROM job_interview_prep_items
+        WHERE tenant_id = ? AND job_id IN (?, ?)
+        """,
+        (tenant_id, losing_job_id, surviving_job_id),
+    )
+    conn.execute(
+        """
+        DELETE FROM job_interview_prep
+        WHERE tenant_id = ? AND job_id IN (?, ?)
+        """,
+        (tenant_id, losing_job_id, surviving_job_id),
+    )
+    conn.executemany(
+        """
+        INSERT INTO job_interview_prep (
+            tenant_id, job_id, generation, status, model, generated_at,
+            gate_status, fabrication_findings_json,
+            grounding_findings_json, judge_verdict, warnings_json,
+            failure_reason, origin_run_id
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        canonical_parents,
+    )
+    conn.executemany(
+        """
+        INSERT INTO job_interview_prep_items (
+            tenant_id, job_id, generation, item_id, kind, title,
+            generated_text, evidence_ids_json, requirement_ids_json,
+            source_text_json, transform_type, control,
+            grounding_audit_json, warnings_json, position
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        canonical_items,
+    )
+    _remap_application_outcome_interview_prep_generations_v18(
+        conn,
+        generation_map={
+            (
+                tenant_id,
+                (
+                    losing_job_url
+                    if old_job_id == losing_job_id
+                    else surviving_job_url
+                ),
+                old_generation,
+            ): new_generation
+            for (
+                old_job_id,
+                old_generation,
+            ), new_generation in generation_map.items()
+        },
+    )
+    _verify_interview_prep_references_v18(
+        conn,
+        expected_counts=before_counts,
+    )
+    return generation_map
 
 
 # ---------------------------------------------------------------------------

--- a/workers/automation/src/jobctrl/infrastructure/interview/sqlite_repository.py
+++ b/workers/automation/src/jobctrl/infrastructure/interview/sqlite_repository.py
@@ -1,4 +1,10 @@
-"""SQLite-backed Interview Preparation repository."""
+"""SQLite-backed Interview Preparation repository.
+
+The adapter persists tenant-scoped stable ``JobId`` references. Until the
+workflow/API identity cutover, URL-shaped ``JobId`` compatibility inputs are
+resolved URL-first at this boundary so even UUID-shaped posting URLs bind to
+their URL owner rather than an unrelated JobId.
+"""
 
 from __future__ import annotations
 
@@ -7,13 +13,17 @@ import sqlite3
 from typing import Any
 
 from jobctrl.database import ensure_interview_prep_tables
-from jobctrl.domain.identifiers import JobId
+from jobctrl.domain.discovery.value_objects import PostingUrl
+from jobctrl.domain.identifiers import JobId, canonical_job_id
 from jobctrl.domain.interview import (
     InterviewPrep,
     InterviewPrepGateAudit,
     InterviewPrepItem,
 )
 from jobctrl.domain.tenant import TenantId
+from jobctrl.infrastructure.discovery.sqlite_identity_resolver import (
+    SqliteJobIdentityResolver,
+)
 
 
 class SqliteInterviewPrepRepository:
@@ -27,14 +37,115 @@ class SqliteInterviewPrepRepository:
     def __init__(self, conn: sqlite3.Connection) -> None:
         self._conn = conn
         ensure_interview_prep_tables(conn)
+        self._reference_column = (
+            "job_id"
+            if "job_id"
+            in {
+                str(row[1])
+                for row in conn.execute(
+                    "PRAGMA table_info(job_interview_prep)"
+                ).fetchall()
+            }
+            else "job_url"
+        )
+        self._identity_resolver = SqliteJobIdentityResolver(conn)
+
+    def _resolved_identity(
+        self,
+        tenant_id: TenantId,
+        reference: JobId,
+    ):
+        """Resolve the current URL-shaped boundary before UUID interpretation."""
+        raw_reference = str(reference or "").strip()
+        if not raw_reference:
+            raise ValueError("job_id must be non-empty")
+        identity = self._identity_resolver.resolve_by_posting_url(
+            tenant_id,
+            PostingUrl(raw_reference),
+        )
+        if identity is not None:
+            return identity
+        direct = self._conn.execute(
+            """
+            SELECT job_id
+            FROM jobs
+            WHERE tenant_id = ? AND url = ?
+            LIMIT 1
+            """,
+            (str(tenant_id), raw_reference),
+        ).fetchone()
+        if direct is not None and str(direct[0] or "").strip():
+            identity = self._identity_resolver.resolve_by_job_id(
+                tenant_id,
+                JobId(str(direct[0])),
+            )
+            if identity is not None:
+                return identity
+        try:
+            stable_candidate = canonical_job_id(raw_reference)
+        except ValueError:
+            return None
+        return self._identity_resolver.resolve_by_job_id(
+            tenant_id,
+            stable_candidate,
+        )
+
+    def _reference_for_read(
+        self,
+        tenant_id: TenantId,
+        reference: JobId,
+    ) -> tuple[str, JobId] | None:
+        raw_reference = str(reference or "").strip()
+        identity = self._resolved_identity(tenant_id, reference)
+        if identity is None:
+            return None
+        if self._reference_column == "job_id":
+            return str(identity.job_id), identity.job_id
+        exact = self._conn.execute(
+            """
+            SELECT 1
+            FROM job_interview_prep
+            WHERE tenant_id = ? AND job_url = ?
+            LIMIT 1
+            """,
+            (str(tenant_id), raw_reference),
+        ).fetchone()
+        physical_reference = (
+            raw_reference
+            if exact is not None
+            else identity.storage_url.value
+        )
+        return physical_reference, identity.job_id
+
+    def _reference_for_write(
+        self,
+        tenant_id: TenantId,
+        reference: JobId,
+    ) -> tuple[str, JobId]:
+        identity = self._resolved_identity(tenant_id, reference)
+        if identity is None:
+            raise ValueError(
+                "no stable Job identity for interview-prep reference: "
+                f"{reference}"
+            )
+        physical_reference = (
+            str(identity.job_id)
+            if self._reference_column == "job_id"
+            else identity.storage_url.value
+        )
+        return physical_reference, identity.job_id
 
     def next_generation(self, tenant_id: TenantId, job_id: JobId) -> int:
+        resolved = self._reference_for_read(tenant_id, job_id)
+        if resolved is None:
+            resolved = self._reference_for_write(tenant_id, job_id)
+        reference, _stable_job_id = resolved
         row = self._conn.execute(
-            """
+            f"""
             SELECT MAX(generation) FROM job_interview_prep
-            WHERE tenant_id = ? AND job_url = ?
+            WHERE tenant_id = ? AND {self._reference_column} = ?
             """,
-            (str(tenant_id), str(job_id)),
+            (str(tenant_id), reference),
         ).fetchone()
         current = row[0] if row is not None else None
         return int(current or 0) + 1
@@ -53,18 +164,28 @@ class SqliteInterviewPrepRepository:
         """
         if not origin_run_id:
             return None
+        resolved = self._reference_for_read(tenant_id, job_id)
+        if resolved is None:
+            return None
+        reference, _stable_job_id = resolved
         row = self._conn.execute(
-            """
+            f"""
             SELECT * FROM job_interview_prep
-            WHERE tenant_id = ? AND job_url = ? AND origin_run_id = ?
+            WHERE tenant_id = ? AND {self._reference_column} = ?
+              AND origin_run_id = ?
             ORDER BY generation DESC
             LIMIT 1
             """,
-            (str(tenant_id), str(job_id), str(origin_run_id)),
+            (str(tenant_id), reference, str(origin_run_id)),
         ).fetchone()
         if row is None:
             return None
-        return self._row_to_prep(row, tenant_id)
+        return self._row_to_prep(
+            row,
+            tenant_id,
+            display_job_key=str(job_id),
+            reference=reference,
+        )
 
     def save(
         self,
@@ -73,28 +194,37 @@ class SqliteInterviewPrepRepository:
         tenant_id: TenantId,
         origin_run_id: str = "",
     ) -> None:
-        job_url = str(prep.job_key)
         tenant = str(tenant_id)
+        reference, _stable_job_id = self._reference_for_write(
+            tenant_id,
+            JobId(str(prep.job_key)),
+        )
         if prep.status == "accepted":
             self._conn.execute(
-                """
+                f"""
                 UPDATE job_interview_prep
                    SET status = 'superseded'
                  WHERE tenant_id = ?
-                   AND job_url = ?
+                   AND {self._reference_column} = ?
                    AND status = 'accepted'
                    AND generation < ?
                 """,
-                (tenant, job_url, prep.generation),
+                (tenant, reference, prep.generation),
             )
+        conflict_target = (
+            f"tenant_id, {self._reference_column}, generation"
+            if self._reference_column == "job_id"
+            else f"{self._reference_column}, generation"
+        )
         self._conn.execute(
-            """
+            f"""
             INSERT INTO job_interview_prep (
-                job_url, generation, tenant_id, status, model, generated_at,
+                tenant_id, {self._reference_column}, generation,
+                status, model, generated_at,
                 gate_status, fabrication_findings_json, grounding_findings_json,
                 judge_verdict, warnings_json, failure_reason, origin_run_id
             ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            ON CONFLICT(job_url, generation) DO UPDATE SET
+            ON CONFLICT({conflict_target}) DO UPDATE SET
                 tenant_id = excluded.tenant_id,
                 status = excluded.status,
                 model = excluded.model,
@@ -108,9 +238,9 @@ class SqliteInterviewPrepRepository:
                 origin_run_id = excluded.origin_run_id
             """,
             (
-                job_url,
-                prep.generation,
                 tenant,
+                reference,
+                prep.generation,
                 prep.status,
                 prep.model,
                 prep.generated_at,
@@ -124,27 +254,29 @@ class SqliteInterviewPrepRepository:
             ),
         )
         self._conn.execute(
-            """
+            f"""
             DELETE FROM job_interview_prep_items
-            WHERE tenant_id = ? AND job_url = ? AND generation = ?
+            WHERE tenant_id = ? AND {self._reference_column} = ?
+              AND generation = ?
             """,
-            (tenant, job_url, prep.generation),
+            (tenant, reference, prep.generation),
         )
         for position, item in enumerate(prep.items):
             self._conn.execute(
-                """
+                f"""
                 INSERT INTO job_interview_prep_items (
-                    job_url, generation, item_id, tenant_id, kind, title,
+                    tenant_id, {self._reference_column}, generation,
+                    item_id, kind, title,
                     generated_text, evidence_ids_json, requirement_ids_json,
                     source_text_json, transform_type, control,
                     grounding_audit_json, warnings_json, position
                 ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
-                    job_url,
+                    tenant,
+                    reference,
                     prep.generation,
                     item.item_id,
-                    tenant,
                     item.kind,
                     item.title,
                     item.generated_text,
@@ -167,7 +299,11 @@ class SqliteInterviewPrepRepository:
         *,
         status: str | None = "accepted",
     ) -> InterviewPrep | None:
-        params: list[Any] = [str(tenant_id), str(job_id)]
+        resolved = self._reference_for_read(tenant_id, job_id)
+        if resolved is None:
+            return None
+        reference, _stable_job_id = resolved
+        params: list[Any] = [str(tenant_id), reference]
         status_filter = ""
         if status is not None:
             status_filter = "AND status = ?"
@@ -175,7 +311,8 @@ class SqliteInterviewPrepRepository:
         row = self._conn.execute(
             f"""
             SELECT * FROM job_interview_prep
-            WHERE tenant_id = ? AND job_url = ? {status_filter}
+            WHERE tenant_id = ?
+              AND {self._reference_column} = ? {status_filter}
             ORDER BY generation DESC
             LIMIT 1
             """,
@@ -183,7 +320,12 @@ class SqliteInterviewPrepRepository:
         ).fetchone()
         if row is None:
             return None
-        return self._row_to_prep(row, tenant_id)
+        return self._row_to_prep(
+            row,
+            tenant_id,
+            display_job_key=str(job_id),
+            reference=reference,
+        )
 
     def load(
         self,
@@ -192,25 +334,43 @@ class SqliteInterviewPrepRepository:
         *,
         generation: int,
     ) -> InterviewPrep | None:
+        resolved = self._reference_for_read(tenant_id, job_id)
+        if resolved is None:
+            return None
+        reference, _stable_job_id = resolved
         row = self._conn.execute(
-            """
+            f"""
             SELECT * FROM job_interview_prep
-            WHERE tenant_id = ? AND job_url = ? AND generation = ?
+            WHERE tenant_id = ? AND {self._reference_column} = ?
+              AND generation = ?
             """,
-            (str(tenant_id), str(job_id), int(generation)),
+            (str(tenant_id), reference, int(generation)),
         ).fetchone()
         if row is None:
             return None
-        return self._row_to_prep(row, tenant_id)
+        return self._row_to_prep(
+            row,
+            tenant_id,
+            display_job_key=str(job_id),
+            reference=reference,
+        )
 
-    def _row_to_prep(self, row: sqlite3.Row, tenant_id: TenantId) -> InterviewPrep:
+    def _row_to_prep(
+        self,
+        row: sqlite3.Row,
+        tenant_id: TenantId,
+        *,
+        display_job_key: str,
+        reference: str,
+    ) -> InterviewPrep:
         item_rows = self._conn.execute(
-            """
+            f"""
             SELECT * FROM job_interview_prep_items
-            WHERE tenant_id = ? AND job_url = ? AND generation = ?
+            WHERE tenant_id = ? AND {self._reference_column} = ?
+              AND generation = ?
             ORDER BY position, item_id
             """,
-            (str(tenant_id), row["job_url"], int(row["generation"])),
+            (str(tenant_id), reference, int(row["generation"])),
         ).fetchall()
         gate = InterviewPrepGateAudit(
             status=row["gate_status"],
@@ -220,7 +380,7 @@ class SqliteInterviewPrepRepository:
             warnings=tuple(_load_list(row["warnings_json"])),
         )
         return InterviewPrep(
-            job_key=str(row["job_url"]),
+            job_key=display_job_key,
             generation=int(row["generation"]),
             status=str(row["status"]),  # type: ignore[arg-type]
             generated_at=str(row["generated_at"]),

--- a/workers/automation/tests/test_audit_projection_parity.py
+++ b/workers/automation/tests/test_audit_projection_parity.py
@@ -278,13 +278,13 @@ def _seed_rows(conn: sqlite3.Connection, fixture: dict[str, Any]) -> None:
         conn.execute(
             """
             INSERT INTO job_interview_prep (
-                job_url, generation, tenant_id, status, model, generated_at,
+                job_id, generation, tenant_id, status, model, generated_at,
                 gate_status, fabrication_findings_json, grounding_findings_json,
                 judge_verdict, warnings_json, failure_reason
             ) VALUES (?, ?, 'local', ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
-                job_url,
+                job_id,
                 prep["generation"],
                 prep["status"],
                 prep["model"],
@@ -301,14 +301,14 @@ def _seed_rows(conn: sqlite3.Connection, fixture: dict[str, Any]) -> None:
         conn.execute(
             """
             INSERT INTO job_interview_prep_items (
-                job_url, generation, item_id, tenant_id, kind, title,
+                job_id, generation, item_id, tenant_id, kind, title,
                 generated_text, evidence_ids_json, requirement_ids_json,
                 source_text_json, transform_type, control, grounding_audit_json,
                 warnings_json, position
             ) VALUES (?, ?, ?, 'local', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
-                job_url,
+                job_id,
                 item["generation"],
                 item["item_id"],
                 item["kind"],

--- a/workers/automation/tests/test_discovery_identity_reference_migration.py
+++ b/workers/automation/tests/test_discovery_identity_reference_migration.py
@@ -220,7 +220,7 @@ def test_v7_discovery_references_migrate_to_stable_job_id_and_reopen(
     init_db(db_path)
     close_connection(db_path)
 
-    assert _user_version(db_path) == SCHEMA_VERSION == 17
+    assert _user_version(db_path) == SCHEMA_VERSION == 18
     assert "job_id" in _columns(db_path, "job_source_observations")
     assert "job_url" not in _columns(db_path, "job_source_observations")
     assert "job_id" in _columns(db_path, "job_canonical_identities")

--- a/workers/automation/tests/test_employer_analysis_identity_reference_migration.py
+++ b/workers/automation/tests/test_employer_analysis_identity_reference_migration.py
@@ -242,7 +242,7 @@ def test_v15_employer_analysis_migrates_alias_histories_and_uuid_urls(
     assert (
         reopened.execute("PRAGMA user_version").fetchone()[0]
         == SCHEMA_VERSION
-        == 17
+        == 18
     )
     for table in database_module._EMPLOYER_ANALYSIS_REFERENCE_TABLES:
         assert "job_id" in _columns(reopened, table)

--- a/workers/automation/tests/test_enrichment_snapshot_identity_reference_migration.py
+++ b/workers/automation/tests/test_enrichment_snapshot_identity_reference_migration.py
@@ -322,7 +322,7 @@ def test_v10_enrichment_snapshot_references_migrate_and_reopen(
     init_db(db_path)
     close_connection(db_path)
 
-    assert _user_version(db_path) == SCHEMA_VERSION == 17
+    assert _user_version(db_path) == SCHEMA_VERSION == 18
     check = sqlite3.connect(db_path)
     try:
         enrichment_rows = check.execute(

--- a/workers/automation/tests/test_execution_search_identity_reference_migration.py
+++ b/workers/automation/tests/test_execution_search_identity_reference_migration.py
@@ -261,7 +261,7 @@ def test_v8_execution_and_receipts_migrate_to_stable_job_id_and_reopen(
     init_db(db_path)
     close_connection(db_path)
 
-    assert _user_version(db_path) == SCHEMA_VERSION == 17
+    assert _user_version(db_path) == SCHEMA_VERSION == 18
     assert "job_id" in _columns(db_path, "discovery_execution_jobs")
     assert "job_url" not in _columns(db_path, "discovery_execution_jobs")
     assert "job_id" in _columns(db_path, "discovery_search_unit_jobs")

--- a/workers/automation/tests/test_interview_prep_generation.py
+++ b/workers/automation/tests/test_interview_prep_generation.py
@@ -11,7 +11,7 @@ from typing import Any
 
 import pytest
 
-from jobctrl.database import close_connection, get_connection, init_db
+from jobctrl.database import close_connection, init_db
 from jobctrl.domain.events import (
     InterviewPrepGeneratedPayload,
     create_interview_prep_generated,
@@ -30,6 +30,9 @@ from jobctrl.interview.activities import (
     InterviewPrepEventRecorder,
     generate_interview_prep_activity,
 )
+
+TEST_JOB_URL = "https://example.test/job/1"
+TEST_JOB_ID = "11111111-1111-4111-8111-111111111111"
 
 
 class _FakeLlm:
@@ -365,8 +368,8 @@ def test_retry_with_same_origin_run_reuses_completed_generation(tmp_path: Path) 
         assert retry.prep.generation == 1
         assert len(llm.calls) == 2
         row_count = conn.execute(
-            "SELECT COUNT(*) FROM job_interview_prep WHERE job_url = ?",
-            ("https://example.test/job/1",),
+            "SELECT COUNT(*) FROM job_interview_prep WHERE job_id = ?",
+            (TEST_JOB_ID,),
         ).fetchone()[0]
         assert row_count == 1
         assert [event.event_type for event in publisher.events] == ["InterviewPrepGenerated"]
@@ -497,13 +500,22 @@ async def test_generate_activity_offloads_generation_and_heartbeats(
 
 def _init_conn(tmp_path: Path):
     db_path = tmp_path / "jobs.db"
-    init_db(db_path)
-    return get_connection(db_path)
+    conn = init_db(db_path)
+    conn.execute(
+        """
+        INSERT INTO jobs (
+            url, tenant_id, job_id, title, company, discovered_at
+        ) VALUES (?, 'local', ?, 'Backend Engineer', 'ExampleCo', ?)
+        """,
+        (TEST_JOB_URL, TEST_JOB_ID, "2026-07-29T10:00:00+00:00"),
+    )
+    conn.commit()
+    return conn
 
 
 def _job() -> dict[str, Any]:
     return {
-        "url": "https://example.test/job/1",
+        "url": TEST_JOB_URL,
         "title": "Backend Engineer",
         "company": "ExampleCo",
     }

--- a/workers/automation/tests/test_interview_prep_identity_reference_migration.py
+++ b/workers/automation/tests/test_interview_prep_identity_reference_migration.py
@@ -1,0 +1,812 @@
+"""Schema-v18 Interview Preparation JobId reference contracts."""
+
+from __future__ import annotations
+
+import sqlite3
+import uuid
+from pathlib import Path
+
+import pytest
+
+import jobctrl.database as database_module
+from jobctrl.database import (
+    SCHEMA_VERSION,
+    close_connection,
+    ensure_interview_prep_references_v18,
+    init_db,
+    reassign_discovery_identity_references,
+)
+from jobctrl.domain.discovery import (
+    Employer,
+    Job,
+    JobMetadata,
+    PostingUrl,
+    SearchStrategy,
+    Source,
+)
+from jobctrl.domain.identifiers import JobId
+from jobctrl.domain.tenant import LOCAL_TENANT
+from jobctrl.infrastructure.discovery import SqliteJobRepository
+from jobctrl.infrastructure.interview import SqliteInterviewPrepRepository
+
+
+PREVIOUS_SCHEMA_VERSION = 17
+
+
+def _discovered_job(posting_url: str, job_id: JobId) -> Job:
+    return Job.discover(
+        tenant_id=LOCAL_TENANT,
+        job_id=job_id,
+        posting_url=PostingUrl(value=posting_url),
+        source=Source(board="example"),
+        employer=Employer(name="Example"),
+        search_strategy=SearchStrategy.JOBSPY,
+        metadata=JobMetadata(title="Platform Engineer"),
+        discovered_at="2026-07-29T10:00:00+00:00",
+    )
+
+
+def _downgrade_interview_prep_references_to_v17(
+    conn: sqlite3.Connection,
+) -> None:
+    conn.execute("DROP TABLE job_interview_prep_items")
+    conn.execute("DROP TABLE job_interview_prep")
+    conn.executescript(
+        """
+        CREATE TABLE job_interview_prep (
+            job_url                    TEXT NOT NULL,
+            generation                 INTEGER NOT NULL,
+            tenant_id                  TEXT NOT NULL DEFAULT 'local',
+            status                     TEXT NOT NULL,
+            model                      TEXT,
+            generated_at               TEXT NOT NULL,
+            gate_status                TEXT NOT NULL,
+            fabrication_findings_json  TEXT NOT NULL DEFAULT '[]',
+            grounding_findings_json    TEXT NOT NULL DEFAULT '[]',
+            judge_verdict              TEXT,
+            warnings_json              TEXT NOT NULL DEFAULT '[]',
+            failure_reason             TEXT NOT NULL DEFAULT '',
+            origin_run_id              TEXT NOT NULL DEFAULT '',
+            PRIMARY KEY (job_url, generation),
+            FOREIGN KEY (job_url)
+                REFERENCES jobs(url) ON DELETE CASCADE
+        );
+        CREATE TABLE job_interview_prep_items (
+            job_url                    TEXT NOT NULL,
+            generation                 INTEGER NOT NULL,
+            item_id                    TEXT NOT NULL,
+            tenant_id                  TEXT NOT NULL DEFAULT 'local',
+            kind                       TEXT NOT NULL,
+            title                      TEXT NOT NULL,
+            generated_text             TEXT NOT NULL,
+            evidence_ids_json          TEXT NOT NULL DEFAULT '[]',
+            requirement_ids_json       TEXT NOT NULL DEFAULT '[]',
+            source_text_json           TEXT NOT NULL DEFAULT '[]',
+            transform_type             TEXT NOT NULL DEFAULT 'grounded_prep',
+            control                    TEXT NOT NULL DEFAULT 'never_fabricate',
+            grounding_audit_json       TEXT NOT NULL DEFAULT '[]',
+            warnings_json              TEXT NOT NULL DEFAULT '[]',
+            position                   INTEGER NOT NULL DEFAULT 0,
+            PRIMARY KEY (job_url, generation, item_id),
+            FOREIGN KEY (job_url, generation)
+                REFERENCES job_interview_prep(job_url, generation)
+                ON DELETE CASCADE
+        );
+        CREATE INDEX idx_job_interview_prep_tenant_job_gen
+            ON job_interview_prep(
+                tenant_id, job_url, generation DESC
+            );
+        CREATE INDEX idx_job_interview_prep_tenant_status
+            ON job_interview_prep(
+                tenant_id, status, generated_at DESC
+            );
+        CREATE INDEX idx_job_interview_prep_origin_run
+            ON job_interview_prep(
+                tenant_id, job_url, origin_run_id
+            );
+        CREATE INDEX idx_job_interview_prep_items_tenant_kind
+            ON job_interview_prep_items(
+                tenant_id, kind, position
+            );
+        """
+    )
+    conn.execute(f"PRAGMA user_version = {PREVIOUS_SCHEMA_VERSION}")
+    conn.commit()
+
+
+def _insert_legacy_prep(
+    conn: sqlite3.Connection,
+    *,
+    job_url: str,
+    generation: int,
+    status: str,
+    marker: str,
+    generated_at: str,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO job_interview_prep (
+            job_url, generation, tenant_id, status, model, generated_at,
+            gate_status, fabrication_findings_json,
+            grounding_findings_json, judge_verdict, warnings_json,
+            failure_reason, origin_run_id
+        ) VALUES (
+            ?, ?, 'local', ?, 'test-model', ?, 'passed', '[]', '[]',
+            'pass:1.00', '[]', '', ?
+        )
+        """,
+        (
+            job_url,
+            generation,
+            status,
+            generated_at,
+            f"run:{marker}",
+        ),
+    )
+    conn.execute(
+        """
+        INSERT INTO job_interview_prep_items (
+            job_url, generation, item_id, tenant_id, kind, title,
+            generated_text, evidence_ids_json, requirement_ids_json,
+            source_text_json, transform_type, control,
+            grounding_audit_json, warnings_json, position
+        ) VALUES (
+            ?, ?, ?, 'local', 'theme', ?, ?, '[]', '[]', '[]',
+            'grounded_interview_prep', 'never_fabricate', '[]', '[]', 0
+        )
+        """,
+        (
+            job_url,
+            generation,
+            f"item:{marker}",
+            f"Title {marker}",
+            f"Text {marker}",
+        ),
+    )
+
+
+def _insert_outcome_link(
+    conn: sqlite3.Connection,
+    *,
+    outcome_id: str,
+    job_key: str,
+    generation: int,
+    tenant_id: str = "local",
+) -> None:
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS application_outcomes (
+            tenant_id                TEXT NOT NULL DEFAULT 'local',
+            outcome_id               TEXT NOT NULL,
+            job_key                  TEXT NOT NULL,
+            kind                     TEXT NOT NULL,
+            source                   TEXT NOT NULL,
+            occurred_at              TEXT NOT NULL,
+            recorded_at              TEXT NOT NULL,
+            interview_prep_generation INTEGER,
+            PRIMARY KEY (tenant_id, outcome_id)
+        )
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO application_outcomes (
+            tenant_id, outcome_id, job_key, kind, source, occurred_at,
+            recorded_at, interview_prep_generation
+        ) VALUES (?, ?, ?, 'interview', 'manual', ?, ?, ?)
+        """,
+        (
+            tenant_id,
+            outcome_id,
+            job_key,
+            "2026-07-29T11:00:00+00:00",
+            "2026-07-29T11:00:00+00:00",
+            generation,
+        ),
+    )
+
+
+def _columns(
+    conn: sqlite3.Connection,
+    table_name: str,
+) -> set[str]:
+    return {
+        str(row[1])
+        for row in conn.execute(
+            f'PRAGMA table_info("{table_name}")'
+        ).fetchall()
+    }
+
+
+def test_v17_interview_prep_migrates_alias_histories_and_uuid_urls(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    conn = init_db(db_path)
+    jobs = SqliteJobRepository(conn)
+    stable_job_id = JobId(str(uuid.uuid4()))
+    original_url = "https://boards.example/jobs/123"
+    current_url = "https://careers.example/jobs/platform"
+    jobs.save(_discovered_job(original_url, stable_job_id))
+    jobs.save(_discovered_job(current_url, stable_job_id))
+
+    uuid_shaped_url = str(uuid.uuid4())
+    uuid_url_owner = JobId(str(uuid.uuid4()))
+    jobs.save(_discovered_job(uuid_shaped_url, uuid_url_owner))
+    jobs.save(
+        _discovered_job(
+            "https://example.com/jobs/id-text-owner",
+            JobId(uuid_shaped_url),
+        )
+    )
+    _downgrade_interview_prep_references_to_v17(conn)
+    _insert_legacy_prep(
+        conn,
+        job_url=original_url,
+        generation=1,
+        status="accepted",
+        marker="original-1",
+        generated_at="2026-07-29T10:00:00+00:00",
+    )
+    _insert_legacy_prep(
+        conn,
+        job_url=current_url,
+        generation=1,
+        status="accepted",
+        marker="current-1",
+        generated_at="2026-07-29T10:01:00+00:00",
+    )
+    _insert_legacy_prep(
+        conn,
+        job_url=original_url,
+        generation=2,
+        status="failed",
+        marker="original-2",
+        generated_at="2026-07-29T10:02:00+00:00",
+    )
+    _insert_legacy_prep(
+        conn,
+        job_url=uuid_shaped_url,
+        generation=1,
+        status="accepted",
+        marker="uuid-url-owner",
+        generated_at="2026-07-29T10:03:00+00:00",
+    )
+    _insert_outcome_link(
+        conn,
+        outcome_id="outcome-original",
+        job_key=original_url,
+        generation=1,
+    )
+    _insert_outcome_link(
+        conn,
+        outcome_id="outcome-current",
+        job_key=current_url,
+        generation=1,
+    )
+    _insert_outcome_link(
+        conn,
+        outcome_id="outcome-uuid-url",
+        job_key=uuid_shaped_url,
+        generation=1,
+    )
+    conn.commit()
+    close_connection(db_path)
+
+    reopened = init_db(db_path)
+    assert (
+        reopened.execute("PRAGMA user_version").fetchone()[0]
+        == SCHEMA_VERSION
+        == 18
+    )
+    for table in database_module._INTERVIEW_PREP_REFERENCE_TABLES:
+        assert "job_id" in _columns(reopened, table)
+        assert "job_url" not in _columns(reopened, table)
+        assert (
+            reopened.execute(
+                f'SELECT COUNT(*) FROM "{table}"'
+            ).fetchone()[0]
+            == 4
+        )
+    histories = reopened.execute(
+        """
+        SELECT generation, status, origin_run_id
+        FROM job_interview_prep
+        WHERE tenant_id = 'local' AND job_id = ?
+        ORDER BY generation
+        """,
+        (str(stable_job_id),),
+    ).fetchall()
+    assert [tuple(row) for row in histories] == [
+        (1, "superseded", "run:original-1"),
+        (2, "accepted", "run:current-1"),
+        (3, "failed", "run:original-2"),
+    ]
+    items = reopened.execute(
+        """
+        SELECT generation, item_id
+        FROM job_interview_prep_items
+        WHERE tenant_id = 'local' AND job_id = ?
+        ORDER BY generation
+        """,
+        (str(stable_job_id),),
+    ).fetchall()
+    assert [tuple(row) for row in items] == [
+        (1, "item:original-1"),
+        (2, "item:current-1"),
+        (3, "item:original-2"),
+    ]
+    assert reopened.execute(
+        """
+        SELECT job_id
+        FROM job_interview_prep
+        WHERE origin_run_id = 'run:uuid-url-owner'
+        """
+    ).fetchone()[0] == str(uuid_url_owner)
+    assert [
+        tuple(row)
+        for row in reopened.execute(
+            """
+            SELECT outcome_id, job_key, interview_prep_generation
+            FROM application_outcomes
+            ORDER BY outcome_id
+            """
+        ).fetchall()
+    ] == [
+        ("outcome-current", current_url, 2),
+        ("outcome-original", original_url, 1),
+        ("outcome-uuid-url", uuid_shaped_url, 1),
+    ]
+    repository = SqliteInterviewPrepRepository(reopened)
+    latest = repository.load_latest(
+        LOCAL_TENANT,
+        JobId(current_url),
+    )
+    assert latest is not None
+    assert latest.job_key == current_url
+    assert latest.generation == 2
+    uuid_owner_latest = repository.load_latest(
+        LOCAL_TENANT,
+        JobId(uuid_shaped_url),
+    )
+    assert uuid_owner_latest is not None
+    assert uuid_owner_latest.job_key == uuid_shaped_url
+    assert uuid_owner_latest.items[0].item_id == "item:uuid-url-owner"
+    assert reopened.execute("PRAGMA foreign_key_check").fetchone() is None
+    close_connection(db_path)
+
+    reopened_again = init_db(db_path)
+    assert reopened_again.execute(
+        "SELECT COUNT(*) FROM job_interview_prep_items"
+    ).fetchone()[0] == 4
+    close_connection(db_path)
+
+
+def test_v18_interview_prep_migration_rolls_back_and_retries(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    conn = init_db(db_path)
+    job_id = JobId(str(uuid.uuid4()))
+    job_url = "https://example.com/jobs/retry"
+    SqliteJobRepository(conn).save(_discovered_job(job_url, job_id))
+    _downgrade_interview_prep_references_to_v17(conn)
+    _insert_legacy_prep(
+        conn,
+        job_url=job_url,
+        generation=1,
+        status="accepted",
+        marker="retry",
+        generated_at="2026-07-29T10:00:00+00:00",
+    )
+    conn.commit()
+    original_verify = (
+        database_module._verify_interview_prep_references_v18
+    )
+
+    def _fail_verification(
+        _conn: sqlite3.Connection,
+        *,
+        expected_counts: dict[str, int],
+    ) -> None:
+        del expected_counts
+        raise RuntimeError("injected interview-prep verification failure")
+
+    monkeypatch.setattr(
+        database_module,
+        "_verify_interview_prep_references_v18",
+        _fail_verification,
+    )
+    with pytest.raises(
+        RuntimeError,
+        match="injected interview-prep verification failure",
+    ):
+        ensure_interview_prep_references_v18(conn)
+    assert conn.execute("PRAGMA user_version").fetchone()[0] == 17
+    assert "job_url" in _columns(conn, "job_interview_prep")
+    assert conn.execute(
+        "SELECT COUNT(*) FROM job_interview_prep_items"
+    ).fetchone()[0] == 1
+
+    monkeypatch.setattr(
+        database_module,
+        "_verify_interview_prep_references_v18",
+        original_verify,
+    )
+    assert ensure_interview_prep_references_v18(conn) == list(
+        database_module._INTERVIEW_PREP_REFERENCE_TABLES
+    )
+    assert conn.execute("PRAGMA user_version").fetchone()[0] == 18
+    assert "job_id" in _columns(conn, "job_interview_prep")
+    assert conn.execute("PRAGMA foreign_key_check").fetchone() is None
+    close_connection(db_path)
+
+
+def test_runtime_interview_prep_merge_preserves_histories_and_tenant(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    conn = init_db(db_path)
+    jobs = SqliteJobRepository(conn)
+    losing_id = JobId(str(uuid.uuid4()))
+    surviving_id = JobId(str(uuid.uuid4()))
+    other_tenant_job_id = JobId(str(uuid.uuid4()))
+    losing_url = "https://example.com/jobs/losing"
+    surviving_url = "https://example.com/jobs/surviving"
+    jobs.save(_discovered_job(losing_url, losing_id))
+    jobs.save(_discovered_job(surviving_url, surviving_id))
+    conn.execute(
+        """
+        INSERT INTO jobs (
+            url, tenant_id, job_id, title, company, discovered_at
+        ) VALUES (?, 'tenant-b', ?, 'Platform Engineer', 'Example', ?)
+        """,
+        (
+            "https://tenant-b.example/jobs/stable",
+            str(other_tenant_job_id),
+            "2026-07-29T10:00:00+00:00",
+        ),
+    )
+
+    def _insert_stable(
+        *,
+        tenant_id: str,
+        job_id: JobId,
+        generation: int,
+        status: str,
+        marker: str,
+        generated_at: str,
+    ) -> None:
+        conn.execute(
+            """
+            INSERT INTO job_interview_prep (
+                tenant_id, job_id, generation, status, model,
+                generated_at, gate_status, fabrication_findings_json,
+                grounding_findings_json, judge_verdict, warnings_json,
+                failure_reason, origin_run_id
+            ) VALUES (
+                ?, ?, ?, ?, 'test-model', ?, 'passed', '[]', '[]',
+                'pass:1.00', '[]', '', ?
+            )
+            """,
+            (
+                tenant_id,
+                str(job_id),
+                generation,
+                status,
+                generated_at,
+                f"run:{marker}",
+            ),
+        )
+        conn.execute(
+            """
+            INSERT INTO job_interview_prep_items (
+                tenant_id, job_id, generation, item_id, kind, title,
+                generated_text, evidence_ids_json,
+                requirement_ids_json, source_text_json, transform_type,
+                control, grounding_audit_json, warnings_json, position
+            ) VALUES (
+                ?, ?, ?, ?, 'theme', ?, ?, '[]', '[]', '[]',
+                'grounded_interview_prep', 'never_fabricate',
+                '[]', '[]', 0
+            )
+            """,
+            (
+                tenant_id,
+                str(job_id),
+                generation,
+                f"item:{marker}",
+                f"Title {marker}",
+                f"Text {marker}",
+            ),
+        )
+
+    _insert_stable(
+        tenant_id="local",
+        job_id=surviving_id,
+        generation=1,
+        status="accepted",
+        marker="surviving-1",
+        generated_at="2026-07-29T10:01:00+00:00",
+    )
+    _insert_stable(
+        tenant_id="local",
+        job_id=losing_id,
+        generation=1,
+        status="accepted",
+        marker="losing-1",
+        generated_at="2026-07-29T10:00:00+00:00",
+    )
+    _insert_stable(
+        tenant_id="local",
+        job_id=surviving_id,
+        generation=2,
+        status="failed",
+        marker="surviving-2",
+        generated_at="2026-07-29T10:02:00+00:00",
+    )
+    _insert_stable(
+        tenant_id="local",
+        job_id=losing_id,
+        generation=2,
+        status="failed",
+        marker="losing-2",
+        generated_at="2026-07-29T10:03:00+00:00",
+    )
+    _insert_stable(
+        tenant_id="tenant-b",
+        job_id=other_tenant_job_id,
+        generation=1,
+        status="accepted",
+        marker="other-tenant",
+        generated_at="2026-07-29T10:04:00+00:00",
+    )
+    _insert_outcome_link(
+        conn,
+        outcome_id="outcome-surviving",
+        job_key=surviving_url,
+        generation=1,
+    )
+    _insert_outcome_link(
+        conn,
+        outcome_id="outcome-losing",
+        job_key=losing_url,
+        generation=1,
+    )
+    _insert_outcome_link(
+        conn,
+        outcome_id="outcome-other-tenant",
+        job_key="https://tenant-b.example/jobs/stable",
+        generation=1,
+        tenant_id="tenant-b",
+    )
+    conn.commit()
+
+    reassign_discovery_identity_references(
+        conn,
+        losing_job_url=losing_url,
+        surviving_job_url=surviving_url,
+    )
+    conn.execute(
+        "DELETE FROM jobs WHERE tenant_id = 'local' AND url = ?",
+        (losing_url,),
+    )
+
+    histories = conn.execute(
+        """
+        SELECT generation, status, origin_run_id
+        FROM job_interview_prep
+        WHERE tenant_id = 'local'
+        ORDER BY generation
+        """
+    ).fetchall()
+    assert [tuple(row) for row in histories] == [
+        (1, "superseded", "run:losing-1"),
+        (2, "accepted", "run:surviving-1"),
+        (3, "failed", "run:surviving-2"),
+        (4, "failed", "run:losing-2"),
+    ]
+    assert [
+        tuple(row)
+        for row in conn.execute(
+            """
+            SELECT generation, item_id
+            FROM job_interview_prep_items
+            WHERE tenant_id = 'local'
+            ORDER BY generation
+            """
+        ).fetchall()
+    ] == [
+        (1, "item:losing-1"),
+        (2, "item:surviving-1"),
+        (3, "item:surviving-2"),
+        (4, "item:losing-2"),
+    ]
+    assert {
+        row[0]
+        for row in conn.execute(
+            """
+            SELECT DISTINCT job_id
+            FROM job_interview_prep
+            WHERE tenant_id = 'local'
+            """
+        ).fetchall()
+    } == {str(surviving_id)}
+    assert tuple(
+        conn.execute(
+            """
+            SELECT job_id, generation, origin_run_id
+            FROM job_interview_prep
+            WHERE tenant_id = 'tenant-b'
+            """
+        ).fetchone()
+    ) == (str(other_tenant_job_id), 1, "run:other-tenant")
+    assert [
+        tuple(row)
+        for row in conn.execute(
+            """
+            SELECT tenant_id, outcome_id, job_key,
+                   interview_prep_generation
+            FROM application_outcomes
+            ORDER BY tenant_id, outcome_id
+            """
+        ).fetchall()
+    ] == [
+        ("local", "outcome-losing", surviving_url, 1),
+        ("local", "outcome-surviving", surviving_url, 2),
+        (
+            "tenant-b",
+            "outcome-other-tenant",
+            "https://tenant-b.example/jobs/stable",
+            1,
+        ),
+    ]
+    assert conn.execute(
+        """
+        SELECT job_id
+        FROM job_identity_aliases
+        WHERE tenant_id = 'local'
+          AND alias_kind = 'posting_url'
+          AND alias_value = ?
+        """,
+        (losing_url,),
+    ).fetchone() is None
+    assert [
+        tuple(row)
+        for row in conn.execute(
+            """
+            SELECT outcome.outcome_id, prep.origin_run_id
+            FROM application_outcomes AS outcome
+            JOIN job_identity_aliases AS alias
+              ON alias.tenant_id = outcome.tenant_id
+             AND alias.alias_kind = 'posting_url'
+             AND alias.alias_value = outcome.job_key
+            JOIN job_interview_prep AS prep
+              ON prep.tenant_id = outcome.tenant_id
+             AND prep.job_id = alias.job_id
+             AND prep.generation =
+                 outcome.interview_prep_generation
+            WHERE outcome.tenant_id = 'local'
+            ORDER BY outcome.outcome_id
+            """
+        ).fetchall()
+    ] == [
+        ("outcome-losing", "run:losing-1"),
+        ("outcome-surviving", "run:surviving-1"),
+    ]
+    latest = SqliteInterviewPrepRepository(conn).load_latest(
+        LOCAL_TENANT,
+        JobId(surviving_url),
+    )
+    assert latest is not None
+    assert latest.job_key == surviving_url
+    assert latest.generation == 2
+    assert conn.execute("PRAGMA foreign_key_check").fetchone() is None
+    close_connection(db_path)
+
+
+def test_real_url_collision_keeps_outcome_link_reachable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from jobctrl.enrichment import detail
+
+    db_path = tmp_path / "jobctrl.db"
+    conn = init_db(db_path)
+    canonical_url = "https://example.com/jobs/interview-collision"
+    losing_url = "/jobs/interview-collision"
+    conn.executemany(
+        "INSERT INTO jobs (url, title, site) VALUES (?, ?, 'Synthetic')",
+        (
+            (canonical_url, "Canonical"),
+            (losing_url, "Relative duplicate"),
+        ),
+    )
+    job_ids = {
+        str(row[0]): str(row[1])
+        for row in conn.execute(
+            "SELECT url, job_id FROM jobs WHERE url IN (?, ?)",
+            (canonical_url, losing_url),
+        ).fetchall()
+    }
+    conn.executemany(
+        """
+        INSERT INTO job_interview_prep (
+            tenant_id, job_id, generation, status, model,
+            generated_at, gate_status, fabrication_findings_json,
+            grounding_findings_json, judge_verdict, warnings_json,
+            failure_reason, origin_run_id
+        ) VALUES (
+            'local', ?, 1, 'accepted', 'test-model', ?, 'passed',
+            '[]', '[]', 'pass:1.00', '[]', '', ?
+        )
+        """,
+        (
+            (
+                job_ids[losing_url],
+                "2026-07-29T10:00:00+00:00",
+                "run:losing",
+            ),
+            (
+                job_ids[canonical_url],
+                "2026-07-29T10:01:00+00:00",
+                "run:surviving",
+            ),
+        ),
+    )
+    _insert_outcome_link(
+        conn,
+        outcome_id="outcome-losing-url",
+        job_key=losing_url,
+        generation=1,
+    )
+    conn.commit()
+    monkeypatch.setattr(
+        detail,
+        "_load_base_urls",
+        lambda: {"Synthetic": "https://example.com"},
+    )
+
+    assert detail.resolve_all_urls(conn) == {
+        "resolved": 1,
+        "failed": 0,
+        "already_absolute": 1,
+        "app_resolved": 0,
+    }
+    outcome = conn.execute(
+        """
+        SELECT job_key, interview_prep_generation
+        FROM application_outcomes
+        WHERE outcome_id = 'outcome-losing-url'
+        """
+    ).fetchone()
+    assert tuple(outcome) == (canonical_url, 1)
+    linked = conn.execute(
+        """
+        SELECT prep.origin_run_id
+        FROM application_outcomes AS outcome
+        JOIN jobs
+          ON jobs.tenant_id = outcome.tenant_id
+         AND jobs.url = outcome.job_key
+        JOIN job_interview_prep AS prep
+          ON prep.tenant_id = jobs.tenant_id
+         AND prep.job_id = jobs.job_id
+         AND prep.generation = outcome.interview_prep_generation
+        WHERE outcome.outcome_id = 'outcome-losing-url'
+        """
+    ).fetchone()
+    assert linked is not None
+    assert linked[0] == "run:losing"
+    assert conn.execute(
+        """
+        SELECT 1
+        FROM job_identity_aliases
+        WHERE tenant_id = 'local'
+          AND alias_kind = 'posting_url'
+          AND alias_value = ?
+        """,
+        (losing_url,),
+    ).fetchone() is None
+    assert conn.execute("PRAGMA foreign_key_check").fetchone() is None
+    close_connection(db_path)

--- a/workers/automation/tests/test_materials_identity_reference_migration.py
+++ b/workers/automation/tests/test_materials_identity_reference_migration.py
@@ -293,7 +293,7 @@ def test_v14_materials_migrate_alias_histories_and_uuid_shaped_urls(
     close_connection(db_path)
 
     reopened = init_db(db_path)
-    assert reopened.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_VERSION == 17
+    assert reopened.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_VERSION == 18
     for table in database_module._MATERIALS_REFERENCE_TABLES:
         assert "job_id" in _columns(reopened, table)
         assert "job_url" not in _columns(reopened, table)

--- a/workers/automation/tests/test_preparation_identity_reference_migration.py
+++ b/workers/automation/tests/test_preparation_identity_reference_migration.py
@@ -177,7 +177,7 @@ def test_v9_preparation_references_migrate_to_stable_job_ids_and_reopen(
     init_db(db_path)
     close_connection(db_path)
 
-    assert _user_version(db_path) == SCHEMA_VERSION == 17
+    assert _user_version(db_path) == SCHEMA_VERSION == 18
     check = sqlite3.connect(db_path)
     try:
         rows = check.execute(

--- a/workers/automation/tests/test_repeat_application_prevention.py
+++ b/workers/automation/tests/test_repeat_application_prevention.py
@@ -750,7 +750,7 @@ def test_schema_v5_migrates_additively_without_changing_application_facts(
         (PRIOR,),
     ).fetchall()
 
-    assert int(migrated.execute("PRAGMA user_version").fetchone()[0]) == SCHEMA_VERSION == 17
+    assert int(migrated.execute("PRAGMA user_version").fetchone()[0]) == SCHEMA_VERSION == 18
     assert [tuple(row) for row in after] == [tuple(row) for row in before]
     assert "metadata_json" in {
         str(row[1]) for row in migrated.execute("PRAGMA table_info(job_stage_states)").fetchall()

--- a/workers/automation/tests/test_resume_template_identity_reference_migration.py
+++ b/workers/automation/tests/test_resume_template_identity_reference_migration.py
@@ -254,7 +254,7 @@ def test_v16_template_references_migrate_aliases_and_uuid_urls(
     assert (
         reopened.execute("PRAGMA user_version").fetchone()[0]
         == SCHEMA_VERSION
-        == 17
+        == 18
     )
     for table in database_module._RESUME_TEMPLATE_REFERENCE_TABLES:
         assert "job_id" in _columns(reopened, table)

--- a/workers/automation/tests/test_scoring_identity_reference_migration.py
+++ b/workers/automation/tests/test_scoring_identity_reference_migration.py
@@ -338,7 +338,7 @@ def test_v11_scoring_references_migrate_alias_histories_and_reopen(
     assert (
         int(migrated.execute("PRAGMA user_version").fetchone()[0])
         == SCHEMA_VERSION
-        == 17
+        == 18
     )
     assert _columns(migrated, "job_scores") >= {"tenant_id", "job_id"}
     assert "job_url" not in _columns(migrated, "job_scores")
@@ -404,7 +404,7 @@ def test_v11_scoring_references_migrate_alias_histories_and_reopen(
     assert (
         int(reopened.execute("PRAGMA user_version").fetchone()[0])
         == SCHEMA_VERSION
-        == 17
+        == 18
     )
 
 
@@ -553,7 +553,7 @@ def test_scoring_migration_rolls_back_and_retries_after_verification_failure(
     assert (
         int(retried.execute("PRAGMA user_version").fetchone()[0])
         == SCHEMA_VERSION
-        == 17
+        == 18
     )
     assert [
         tuple(row)

--- a/workers/automation/tests/test_stable_job_identity_migration.py
+++ b/workers/automation/tests/test_stable_job_identity_migration.py
@@ -743,7 +743,7 @@ def test_v6_jobs_gain_stable_uuid_and_posting_url_alias_once(
     init_db(db_path)
     close_connection(db_path)
 
-    assert _user_version(db_path) == SCHEMA_VERSION == 17
+    assert _user_version(db_path) == SCHEMA_VERSION == 18
     first_ids = _identity_rows(db_path)
     assert [row[0] for row in first_ids] == ["local", "local"]
     for _tenant_id, job_id, _url in first_ids:


### PR DESCRIPTION
## Summary

- migrate Interview Preparation histories and item audit rows to tenant-scoped stable `JobId` references in schema v18
- preserve complete alias histories, deterministic generation ordering, accepted/superseded/failed semantics, child audit data, UUID-shaped URL compatibility, and tenant isolation
- remap immutable application-outcome generation links during both v17→v18 migration and live identity collisions; canonicalize only a losing URL-valued outcome key so it remains reachable while the outcome family stays URL-keyed until Phase 4
- keep losing-alias cleanup and rediscovery compatibility intact, and explicitly delete prep children when permanent deletion runs with SQLite FK enforcement disabled

## Validation

- Python full suite: `2700 passed, 2 skipped`
- API full suite: `675 passed`
- migration-chain suite: `56 passed`
- focused Python interview/audit suite: `14 passed`
- real `resolve_all_urls()` collision regression plus existing alias cleanup/rediscovery regression: `5 passed`
- TypeScript API check: passed
- Ruff: passed
- `git diff --check`: passed
- independent reviewer: `PASS` — Blocker 0, High 0, Medium 0, Low 0
- independent Tier-3 QA: `PASS` — Blocker 0, High 0, Medium 0, Low 0

Canonical product documentation and cumulative end-to-end QA remain intentionally deferred to the final PR of this approved unreleased stack.