### PR TITLE
feat(compensation): migrate evidence references to stable JobIds

### DIFF
--- a/apps/api/src/db.ts
+++ b/apps/api/src/db.ts
@@ -9,7 +9,7 @@ export type SqliteValue = string | number | bigint | null;
 // writer that stamps ``PRAGMA user_version``; the API only reads it to fail
 // closed on a database written by a newer build. Bump both constants together
 // whenever the schema shape changes.
-export const SUPPORTED_SCHEMA_VERSION = 18;
+export const SUPPORTED_SCHEMA_VERSION = 19;
 
 export class IncompatibleSchemaVersionError extends Error {
   constructor(current: number) {

--- a/apps/api/src/market-compensation-estimates.ts
+++ b/apps/api/src/market-compensation-estimates.ts
@@ -12,7 +12,13 @@ import type {
   MarketCompensationWarning,
   MarketCompensationWarningCode,
 } from "./contracts.js";
-import { getRow, tableExists, type SqliteDatabase } from "./db.js";
+import {
+  getRow,
+  jobReferenceColumn,
+  jobReferenceForUrl,
+  tableExists,
+  type SqliteDatabase,
+} from "./db.js";
 
 const DEFAULT_TENANT = "local";
 
@@ -203,10 +209,21 @@ export function getMarketCompensationEstimate(
     return notRequested(job);
   }
   const tableColumns = columnsFor(db, "job_market_compensation_estimates");
+  const referenceColumn = jobReferenceColumn(
+    db,
+    "job_market_compensation_estimates",
+  );
+  const reference = jobReferenceForUrl(
+    db,
+    "job_market_compensation_estimates",
+    jobKey,
+    DEFAULT_TENANT,
+  );
   const row = getRow<MarketCompensationEstimateRow>(
     db,
     `
-    SELECT tenant_id, job_url, estimate_state, currency, period, component,
+    SELECT tenant_id, ? AS job_url, estimate_state, currency, period,
+           component,
            minimum_amount, maximum_amount,
            ${columnOrNull(tableColumns, "confidence_interval_minimum_amount")} AS confidence_interval_minimum_amount,
            ${columnOrNull(tableColumns, "confidence_interval_maximum_amount")} AS confidence_interval_maximum_amount,
@@ -224,9 +241,9 @@ export function getMarketCompensationEstimate(
            ${columnOrDefault(tableColumns, "company_tier", "unknown")} AS company_tier,
            ${columnOrDefault(tableColumns, "match_scope", "none")} AS match_scope
     FROM job_market_compensation_estimates
-    WHERE tenant_id = ? AND job_url = ?
+    WHERE tenant_id = ? AND ${referenceColumn} = ?
     `,
-    [DEFAULT_TENANT, jobKey],
+    [jobKey, DEFAULT_TENANT, reference],
   );
   if (!row) {
     return notRequested(job);

--- a/apps/api/src/posted-compensation-facts.ts
+++ b/apps/api/src/posted-compensation-facts.ts
@@ -4,7 +4,13 @@ import type {
   PostedCompensationWarning,
   PostedCompensationWarningCode,
 } from "./contracts.js";
-import { getRow, tableExists, type SqliteDatabase } from "./db.js";
+import {
+  getRow,
+  jobReferenceColumn,
+  jobReferenceForUrl,
+  tableExists,
+  type SqliteDatabase,
+} from "./db.js";
 
 const DEFAULT_TENANT = "local";
 
@@ -62,18 +68,29 @@ export function getPostedCompensationFact(
   if (!tableExists(db, "job_posted_compensation_facts")) {
     return notRecorded(job);
   }
+  const referenceColumn = jobReferenceColumn(
+    db,
+    "job_posted_compensation_facts",
+  );
+  const reference = jobReferenceForUrl(
+    db,
+    "job_posted_compensation_facts",
+    jobKey,
+    DEFAULT_TENANT,
+  );
   const row = getRow<PostedCompensationFactRow>(
     db,
     `
-    SELECT tenant_id, job_url, source_field, source_text, legacy_raw_salary,
+    SELECT tenant_id, ? AS job_url, source_field, source_text,
+           legacy_raw_salary,
            parse_state, currency, period, component, minimum_amount,
            maximum_amount, annualized_minimum_amount, annualized_maximum_amount,
            annualization_assumption, confidence, warnings_json, parser_version,
            source_hash, parsed_at
     FROM job_posted_compensation_facts
-    WHERE tenant_id = ? AND job_url = ?
+    WHERE tenant_id = ? AND ${referenceColumn} = ?
     `,
-    [DEFAULT_TENANT, jobKey],
+    [jobKey, DEFAULT_TENANT, reference],
   );
   if (!row) {
     return notRecorded(job);

--- a/apps/api/src/write-model.ts
+++ b/apps/api/src/write-model.ts
@@ -864,6 +864,8 @@ function purgeJobRows(db: SqliteDatabase, jobUrl: string): void {
     "job_employer_analysis",
     "resume_template_refresh_attempts",
     "job_resume_template_assignments",
+    "job_posted_compensation_facts",
+    "job_market_compensation_estimates",
   ]) {
     deleteJobReferences(db, tableName, jobId, jobUrl);
   }

--- a/apps/api/test/compensation-v19.test.ts
+++ b/apps/api/test/compensation-v19.test.ts
@@ -1,0 +1,220 @@
+import Database from "better-sqlite3";
+import { describe, expect, it } from "vitest";
+
+import { getMarketCompensationEstimate } from "../src/market-compensation-estimates.js";
+import { getPostedCompensationFact } from "../src/posted-compensation-facts.js";
+import { permanentlyDeleteJob } from "../src/write-model.js";
+
+const UUID_SHAPED_URL = "11111111-1111-4111-8111-111111111111";
+const URL_OWNER_JOB_ID = "22222222-2222-4222-8222-222222222222";
+const ID_TEXT_OWNER_URL = "https://example.com/jobs/id-text-owner";
+const OTHER_TENANT_URL = "https://example.com/jobs/other-tenant";
+
+function createSchema(db: Database.Database): void {
+  db.pragma("foreign_keys = OFF");
+  expect(db.pragma("foreign_keys", { simple: true })).toBe(0);
+  db.pragma("user_version = 19");
+  db.exec(`
+    CREATE TABLE jobs (
+      url TEXT PRIMARY KEY,
+      tenant_id TEXT NOT NULL DEFAULT 'local',
+      job_id TEXT NOT NULL,
+      title TEXT,
+      salary TEXT,
+      application_url TEXT,
+      UNIQUE (tenant_id, job_id)
+    );
+    CREATE TABLE job_posted_compensation_facts (
+      tenant_id TEXT NOT NULL DEFAULT 'local',
+      job_id TEXT NOT NULL,
+      source_field TEXT NOT NULL DEFAULT 'jobs.salary',
+      source_text TEXT,
+      legacy_raw_salary TEXT,
+      parse_state TEXT NOT NULL,
+      currency TEXT,
+      period TEXT NOT NULL DEFAULT 'unknown',
+      component TEXT NOT NULL DEFAULT 'unknown',
+      minimum_amount INTEGER,
+      maximum_amount INTEGER,
+      annualized_minimum_amount INTEGER,
+      annualized_maximum_amount INTEGER,
+      annualization_assumption TEXT,
+      confidence TEXT NOT NULL DEFAULT 'none',
+      warnings_json TEXT NOT NULL DEFAULT '[]',
+      parser_version TEXT NOT NULL,
+      source_hash TEXT NOT NULL,
+      parsed_at TEXT NOT NULL,
+      PRIMARY KEY (tenant_id, job_id),
+      FOREIGN KEY (tenant_id, job_id)
+        REFERENCES jobs(tenant_id, job_id) ON DELETE CASCADE
+    );
+    CREATE TABLE job_market_compensation_estimates (
+      tenant_id TEXT NOT NULL DEFAULT 'local',
+      job_id TEXT NOT NULL,
+      estimate_state TEXT NOT NULL,
+      currency TEXT,
+      period TEXT NOT NULL DEFAULT 'year',
+      component TEXT NOT NULL DEFAULT 'total_compensation',
+      minimum_amount INTEGER,
+      maximum_amount INTEGER,
+      confidence_interval_minimum_amount INTEGER,
+      confidence_interval_maximum_amount INTEGER,
+      confidence_band TEXT NOT NULL DEFAULT 'none',
+      confidence_score REAL NOT NULL DEFAULT 0,
+      source_count INTEGER NOT NULL DEFAULT 0,
+      sample_count INTEGER,
+      aggregate_bucket TEXT,
+      geography_scope TEXT,
+      occupation_code TEXT,
+      occupation_label TEXT,
+      seniority_label TEXT,
+      source_snapshot_json TEXT NOT NULL DEFAULT '[]',
+      factor_reasons_json TEXT NOT NULL DEFAULT '[]',
+      selected_evidence_json TEXT NOT NULL DEFAULT '[]',
+      insufficient_reasons_json TEXT NOT NULL DEFAULT '[]',
+      unsupported_reasons_json TEXT NOT NULL DEFAULT '[]',
+      source_unavailable_reasons_json TEXT NOT NULL DEFAULT '[]',
+      warnings_json TEXT NOT NULL DEFAULT '[]',
+      estimator_version TEXT NOT NULL,
+      estimated_at TEXT NOT NULL,
+      company_name TEXT,
+      normalized_company TEXT,
+      role_title TEXT,
+      normalized_role TEXT,
+      company_tier TEXT NOT NULL DEFAULT 'unknown',
+      match_scope TEXT NOT NULL DEFAULT 'none',
+      PRIMARY KEY (tenant_id, job_id),
+      FOREIGN KEY (tenant_id, job_id)
+        REFERENCES jobs(tenant_id, job_id) ON DELETE CASCADE
+    );
+  `);
+}
+
+function seedCompensation(
+  db: Database.Database,
+  input: {
+    tenantId: string;
+    url: string;
+    jobId: string;
+    marker: string;
+  },
+): void {
+  db.prepare(
+    `INSERT INTO jobs (
+       url, tenant_id, job_id, title, salary, application_url
+     ) VALUES (?, ?, ?, 'Platform Engineer', 'EUR 100k', NULL)`,
+  ).run(input.url, input.tenantId, input.jobId);
+  db.prepare(
+    `INSERT INTO job_posted_compensation_facts (
+       tenant_id, job_id, source_text, legacy_raw_salary, parse_state,
+       currency, period, component, minimum_amount, maximum_amount,
+       annualized_minimum_amount, annualized_maximum_amount, confidence,
+       parser_version, source_hash, parsed_at
+     ) VALUES (
+       ?, ?, ?, 'EUR 100k', 'parsed_range', 'EUR', 'year', 'base_salary',
+       100000, 100000, 100000, 100000, 'high',
+       'posted-compensation-v1', ?, '2026-07-29T10:00:00.000Z'
+     )`,
+  ).run(
+    input.tenantId,
+    input.jobId,
+    `posted:${input.marker}`,
+    input.marker.repeat(64).slice(0, 64),
+  );
+  db.prepare(
+    `INSERT INTO job_market_compensation_estimates (
+       tenant_id, job_id, estimate_state, confidence_band, confidence_score,
+       source_count, unsupported_reasons_json, estimator_version,
+       estimated_at, company_name
+     ) VALUES (
+       ?, ?, 'unsupported', 'none', 0, 0, '["unsupported_source"]',
+       'company-role-reported-compensation-v1',
+       '2026-07-29T10:00:00.000Z', ?
+     )`,
+  ).run(input.tenantId, input.jobId, `market:${input.marker}`);
+}
+
+function seedCollisionGraph(db: Database.Database): void {
+  seedCompensation(db, {
+    tenantId: "local",
+    url: UUID_SHAPED_URL,
+    jobId: URL_OWNER_JOB_ID,
+    marker: "url-owner",
+  });
+  seedCompensation(db, {
+    tenantId: "local",
+    url: ID_TEXT_OWNER_URL,
+    jobId: UUID_SHAPED_URL,
+    marker: "id-owner",
+  });
+  seedCompensation(db, {
+    tenantId: "tenant-b",
+    url: OTHER_TENANT_URL,
+    jobId: URL_OWNER_JOB_ID,
+    marker: "other-tenant",
+  });
+}
+
+describe("schema-v19 compensation API compatibility", () => {
+  it("links a UUID-shaped posting URL to its URL owner's stable compensation", () => {
+    const db = new Database(":memory:");
+    createSchema(db);
+    seedCollisionGraph(db);
+
+    expect(getPostedCompensationFact(db, UUID_SHAPED_URL)).toMatchObject({
+      recordStatus: "recorded",
+      fact: {
+        jobKey: UUID_SHAPED_URL,
+        sourceText: "posted:url-owner",
+      },
+    });
+    expect(getMarketCompensationEstimate(db, UUID_SHAPED_URL)).toMatchObject({
+      recordStatus: "recorded",
+      estimate: {
+        jobKey: UUID_SHAPED_URL,
+        companyName: "market:url-owner",
+      },
+    });
+    db.close();
+  });
+
+  it("deletes only the URL owner's stable compensation with cascades off", () => {
+    const db = new Database(":memory:");
+    createSchema(db);
+    seedCollisionGraph(db);
+
+    expect(permanentlyDeleteJob(db, UUID_SHAPED_URL)).toEqual({
+      ok: true,
+      count: 1,
+      jobKeys: [UUID_SHAPED_URL],
+    });
+    expect(
+      db.prepare(
+        `SELECT tenant_id, job_id
+           FROM job_posted_compensation_facts
+          ORDER BY tenant_id, job_id`,
+      ).all(),
+    ).toEqual([
+      { tenant_id: "local", job_id: UUID_SHAPED_URL },
+      { tenant_id: "tenant-b", job_id: URL_OWNER_JOB_ID },
+    ]);
+    expect(
+      db.prepare(
+        `SELECT tenant_id, job_id
+           FROM job_market_compensation_estimates
+          ORDER BY tenant_id, job_id`,
+      ).all(),
+    ).toEqual([
+      { tenant_id: "local", job_id: UUID_SHAPED_URL },
+      { tenant_id: "tenant-b", job_id: URL_OWNER_JOB_ID },
+    ]);
+    expect(
+      db.prepare("SELECT url FROM jobs ORDER BY url").all(),
+    ).toEqual([
+      { url: ID_TEXT_OWNER_URL },
+      { url: OTHER_TENANT_URL },
+    ]);
+    expect(db.pragma("foreign_key_check")).toEqual([]);
+    db.close();
+  });
+});

--- a/apps/api/test/schema-version-guard.test.ts
+++ b/apps/api/test/schema-version-guard.test.ts
@@ -63,7 +63,7 @@ describe("schema version guard at DB open", () => {
   });
 
   it("opens the worker-owned schema-v14 artifact registry", () => {
-    expect(SUPPORTED_SCHEMA_VERSION).toBe(18);
+    expect(SUPPORTED_SCHEMA_VERSION).toBe(19);
     const { dbPath, cleanup } = makeDbWithUserVersion(14);
     try {
       openDatabase(dbPath).close();

--- a/workers/automation/src/jobctrl/database.py
+++ b/workers/automation/src/jobctrl/database.py
@@ -71,7 +71,10 @@ from jobctrl.config import DB_PATH, DEFAULTS, migrate_legacy_job_tables
 # their child audit rows reference the stable Job aggregate. Any immutable
 # application-outcome link to a preparation generation is remapped alongside
 # alias-history renumbering while its legacy URL key remains unchanged.
-SCHEMA_VERSION = 18
+# v19 (compensation references): canonical posted compensation facts and market
+# estimates reference the stable Job aggregate. Alias collisions keep the
+# newest recorded fact/estimate with a deterministic survivor tie-break.
+SCHEMA_VERSION = 19
 
 
 class IncompatibleSchemaVersionError(RuntimeError):
@@ -220,6 +223,7 @@ def _schema_migrations() -> tuple[
         (16, ensure_employer_analysis_references_v16),
         (17, ensure_resume_template_references_v17),
         (18, ensure_interview_prep_references_v18),
+        (19, ensure_compensation_references_v19),
     )
 
 
@@ -4623,6 +4627,13 @@ def _reassign_discovery_identity_references(
             tenant_id=tenant_id,
             losing_job_url=losing_job_url,
             surviving_job_url=surviving_job_url,
+        )
+    if _has_compensation_reference_schema_v19(conn):
+        _reassign_compensation_references_v19(
+            conn,
+            tenant_id=tenant_id,
+            losing_job_id=losing_job_id,
+            surviving_job_id=surviving_job_id,
         )
     if _has_scoring_reference_schema_v12(conn):
         _reassign_scoring_references_v12(
@@ -11901,6 +11912,547 @@ def _reassign_interview_prep_references_v18(
         expected_counts=before_counts,
     )
     return generation_map
+
+
+_COMPENSATION_REFERENCE_SCHEMA_VERSION = 19
+_COMPENSATION_REFERENCE_TABLES = (
+    "job_posted_compensation_facts",
+    "job_market_compensation_estimates",
+)
+_COMPENSATION_TIMESTAMP_COLUMNS = {
+    "job_posted_compensation_facts": "parsed_at",
+    "job_market_compensation_estimates": "estimated_at",
+}
+
+
+def _create_compensation_reference_tables_v19(
+    conn: sqlite3.Connection,
+    *,
+    posted_table: str,
+    market_table: str,
+) -> None:
+    conn.execute(
+        f"""
+        CREATE TABLE "{posted_table}" (
+            tenant_id                    TEXT NOT NULL DEFAULT 'local',
+            job_id                       TEXT NOT NULL,
+            source_field                 TEXT NOT NULL DEFAULT 'jobs.salary',
+            source_text                  TEXT,
+            legacy_raw_salary            TEXT,
+            parse_state                  TEXT NOT NULL,
+            currency                     TEXT,
+            period                       TEXT NOT NULL DEFAULT 'unknown',
+            component                    TEXT NOT NULL DEFAULT 'unknown',
+            minimum_amount               INTEGER,
+            maximum_amount               INTEGER,
+            annualized_minimum_amount    INTEGER,
+            annualized_maximum_amount    INTEGER,
+            annualization_assumption     TEXT,
+            confidence                   TEXT NOT NULL DEFAULT 'none',
+            warnings_json                TEXT NOT NULL DEFAULT '[]',
+            parser_version               TEXT NOT NULL,
+            source_hash                  TEXT NOT NULL,
+            parsed_at                    TEXT NOT NULL,
+            PRIMARY KEY (tenant_id, job_id),
+            FOREIGN KEY (tenant_id, job_id)
+                REFERENCES jobs(tenant_id, job_id) ON DELETE CASCADE
+        )
+        """
+    )
+    conn.execute(
+        f"""
+        CREATE TABLE "{market_table}" (
+            tenant_id                          TEXT NOT NULL DEFAULT 'local',
+            job_id                             TEXT NOT NULL,
+            estimate_state                     TEXT NOT NULL CHECK (
+                estimate_state IN (
+                    'unsupported',
+                    'source_unavailable',
+                    'insufficient_evidence',
+                    'estimated_range'
+                )
+            ),
+            currency                           TEXT,
+            period                             TEXT NOT NULL DEFAULT 'year'
+                CHECK (period IN ('year', 'month')),
+            component                          TEXT NOT NULL
+                DEFAULT 'total_compensation'
+                CHECK (
+                    component IN (
+                        'base_salary',
+                        'total_compensation'
+                    )
+                ),
+            minimum_amount                     INTEGER,
+            maximum_amount                     INTEGER,
+            confidence_interval_minimum_amount INTEGER,
+            confidence_interval_maximum_amount INTEGER,
+            confidence_band                    TEXT NOT NULL DEFAULT 'none'
+                CHECK (
+                    confidence_band IN (
+                        'none',
+                        'low',
+                        'medium',
+                        'high'
+                    )
+                ),
+            confidence_score                   REAL NOT NULL DEFAULT 0,
+            source_count                       INTEGER NOT NULL DEFAULT 0,
+            sample_count                       INTEGER,
+            aggregate_bucket                   TEXT,
+            geography_scope                    TEXT,
+            occupation_code                    TEXT,
+            occupation_label                   TEXT,
+            seniority_label                    TEXT,
+            source_snapshot_json               TEXT NOT NULL DEFAULT '[]',
+            factor_reasons_json                TEXT NOT NULL DEFAULT '[]',
+            selected_evidence_json             TEXT NOT NULL DEFAULT '[]',
+            insufficient_reasons_json          TEXT NOT NULL DEFAULT '[]',
+            unsupported_reasons_json           TEXT NOT NULL DEFAULT '[]',
+            source_unavailable_reasons_json    TEXT NOT NULL DEFAULT '[]',
+            warnings_json                      TEXT NOT NULL DEFAULT '[]',
+            estimator_version                  TEXT NOT NULL,
+            estimated_at                       TEXT NOT NULL,
+            company_name                       TEXT,
+            normalized_company                 TEXT,
+            role_title                         TEXT,
+            normalized_role                    TEXT,
+            company_tier                       TEXT NOT NULL DEFAULT 'unknown'
+                CHECK (
+                    company_tier IN (
+                        'tier_1_local',
+                        'tier_2_ambitious',
+                        'tier_3_top_of_market',
+                        'unknown'
+                    )
+                ),
+            match_scope                        TEXT NOT NULL DEFAULT 'none'
+                CHECK (
+                    match_scope IN (
+                        'exact_company_role',
+                        'same_location_role_fallback',
+                        'company_adjacent_role',
+                        'tier_role_fallback',
+                        'market_baseline_fallback',
+                        'none'
+                    )
+                ),
+            PRIMARY KEY (tenant_id, job_id),
+            FOREIGN KEY (tenant_id, job_id)
+                REFERENCES jobs(tenant_id, job_id) ON DELETE CASCADE
+        )
+        """
+    )
+
+
+def _create_compensation_reference_indexes_v19(
+    conn: sqlite3.Connection,
+) -> None:
+    conn.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_job_posted_compensation_parse_state
+        ON job_posted_compensation_facts (tenant_id, parse_state)
+        """
+    )
+    conn.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_job_market_compensation_state
+        ON job_market_compensation_estimates (tenant_id, estimate_state)
+        """
+    )
+    conn.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_job_market_compensation_company_role
+        ON job_market_compensation_estimates (
+            tenant_id,
+            normalized_company,
+            normalized_role
+        )
+        """
+    )
+
+
+def _has_compensation_reference_schema_v19(
+    conn: sqlite3.Connection,
+) -> bool:
+    return (
+        all(
+            "job_id" in _table_columns(conn, table)
+            and "job_url" not in _table_columns(conn, table)
+            and _primary_key_columns(conn, table)
+            == ("tenant_id", "job_id")
+            and _has_composite_job_id_foreign_key(
+                conn,
+                table,
+                "job_id",
+            )
+            for table in _COMPENSATION_REFERENCE_TABLES
+        )
+        and _has_index(
+            conn,
+            "job_posted_compensation_facts",
+            "idx_job_posted_compensation_parse_state",
+            ("tenant_id", "parse_state"),
+            unique=False,
+        )
+        and _has_index(
+            conn,
+            "job_market_compensation_estimates",
+            "idx_job_market_compensation_state",
+            ("tenant_id", "estimate_state"),
+            unique=False,
+        )
+        and _has_index(
+            conn,
+            "job_market_compensation_estimates",
+            "idx_job_market_compensation_company_role",
+            ("tenant_id", "normalized_company", "normalized_role"),
+            unique=False,
+        )
+    )
+
+
+def _canonical_compensation_rows_v19(
+    conn: sqlite3.Connection,
+    *,
+    table: str,
+    timestamp_column: str,
+) -> tuple[tuple[str, ...], list[tuple[Any, ...]]]:
+    columns = tuple(
+        str(row[1])
+        for row in conn.execute(
+            f'PRAGMA table_info("{table}")'
+        ).fetchall()
+        if str(row[1]) not in {"tenant_id", "job_url"}
+    )
+    timestamp_index = columns.index(timestamp_column)
+    select_columns = ", ".join(f'"{column}"' for column in columns)
+    rows = conn.execute(
+        f"""
+        SELECT tenant_id, job_url, {select_columns}
+        FROM "{table}"
+        ORDER BY tenant_id, job_url
+        """
+    ).fetchall()
+    grouped: dict[
+        tuple[str, str],
+        list[tuple[str, tuple[Any, ...]]],
+    ] = {}
+    for row in rows:
+        tenant_id = str(row[0])
+        raw_reference = str(row[1])
+        stable_job_id = _resolve_job_reference_value(
+            conn,
+            tenant_id=tenant_id,
+            reference=raw_reference,
+            legacy_url=True,
+        )
+        if stable_job_id is None:
+            raise RuntimeError(
+                "compensation reference migration could not resolve "
+                f"{table}.job_url={raw_reference!r}"
+            )
+        _validate_job_uuid(stable_job_id)
+        grouped.setdefault((tenant_id, stable_job_id), []).append(
+            (raw_reference, tuple(row[2:]))
+        )
+
+    canonical: list[tuple[Any, ...]] = []
+    for (tenant_id, stable_job_id), candidates in sorted(grouped.items()):
+        storage_row = conn.execute(
+            """
+            SELECT url
+            FROM jobs
+            WHERE tenant_id = ? AND job_id = ?
+            LIMIT 1
+            """,
+            (tenant_id, stable_job_id),
+        ).fetchone()
+        preferred_reference = (
+            str(storage_row[0])
+            if storage_row is not None
+            else ""
+        )
+        _selected_reference, selected_values = max(
+            candidates,
+            key=lambda candidate: (
+                str(candidate[1][timestamp_index]),
+                candidate[0] == preferred_reference,
+                candidate[0],
+            ),
+        )
+        canonical.append(
+            (tenant_id, stable_job_id, *selected_values)
+        )
+    return columns, canonical
+
+
+def ensure_compensation_references_v19(
+    conn: sqlite3.Connection | None = None,
+) -> list[str]:
+    """Move canonical compensation facts and estimates to stable JobIds."""
+    if conn is None:
+        conn = get_connection()
+
+    current = _assert_schema_version_supported(conn)
+    if current >= _COMPENSATION_REFERENCE_SCHEMA_VERSION:
+        return []
+    if current != _INTERVIEW_PREP_REFERENCE_SCHEMA_VERSION:
+        raise RuntimeError(
+            "compensation reference migration requires interview-prep "
+            "schema v18"
+        )
+
+    conn.execute("SAVEPOINT compensation_references_v19")
+    try:
+        if not _has_interview_prep_reference_schema_v18(conn):
+            raise RuntimeError(
+                "compensation reference migration requires the stable "
+                "interview-prep reference schema"
+            )
+        if _has_compensation_reference_schema_v19(conn):
+            expected_counts = {
+                table: int(
+                    conn.execute(
+                        f'SELECT COUNT(*) FROM "{table}"'
+                    ).fetchone()[0]
+                )
+                for table in _COMPENSATION_REFERENCE_TABLES
+            }
+        else:
+            posted_columns, posted_rows = (
+                _canonical_compensation_rows_v19(
+                    conn,
+                    table="job_posted_compensation_facts",
+                    timestamp_column="parsed_at",
+                )
+            )
+            market_columns, market_rows = (
+                _canonical_compensation_rows_v19(
+                    conn,
+                    table="job_market_compensation_estimates",
+                    timestamp_column="estimated_at",
+                )
+            )
+            for table in (
+                "job_posted_compensation_facts_v19",
+                "job_market_compensation_estimates_v19",
+            ):
+                conn.execute(f'DROP TABLE IF EXISTS "{table}"')
+            _create_compensation_reference_tables_v19(
+                conn,
+                posted_table="job_posted_compensation_facts_v19",
+                market_table="job_market_compensation_estimates_v19",
+            )
+            for table, columns, rows in (
+                (
+                    "job_posted_compensation_facts_v19",
+                    posted_columns,
+                    posted_rows,
+                ),
+                (
+                    "job_market_compensation_estimates_v19",
+                    market_columns,
+                    market_rows,
+                ),
+            ):
+                insert_columns = (
+                    "tenant_id, job_id, "
+                    + ", ".join(
+                        f'"{column}"' for column in columns
+                    )
+                )
+                placeholders = ", ".join(
+                    "?" for _ in range(len(columns) + 2)
+                )
+                conn.executemany(
+                    f'INSERT INTO "{table}" '
+                    f"({insert_columns}) VALUES ({placeholders})",
+                    rows,
+                )
+            conn.execute(
+                'DROP TABLE "job_posted_compensation_facts"'
+            )
+            conn.execute(
+                'DROP TABLE "job_market_compensation_estimates"'
+            )
+            conn.execute(
+                'ALTER TABLE "job_posted_compensation_facts_v19" '
+                'RENAME TO "job_posted_compensation_facts"'
+            )
+            conn.execute(
+                'ALTER TABLE "job_market_compensation_estimates_v19" '
+                'RENAME TO "job_market_compensation_estimates"'
+            )
+            _create_compensation_reference_indexes_v19(conn)
+            expected_counts = {
+                "job_posted_compensation_facts": len(posted_rows),
+                "job_market_compensation_estimates": len(market_rows),
+            }
+        _verify_compensation_references_v19(
+            conn,
+            expected_counts=expected_counts,
+        )
+        conn.execute(
+            f"PRAGMA user_version = "
+            f"{_COMPENSATION_REFERENCE_SCHEMA_VERSION}"
+        )
+        conn.execute("RELEASE SAVEPOINT compensation_references_v19")
+        conn.commit()
+    except BaseException:
+        conn.execute("ROLLBACK TO SAVEPOINT compensation_references_v19")
+        conn.execute("RELEASE SAVEPOINT compensation_references_v19")
+        raise
+
+    return list(_COMPENSATION_REFERENCE_TABLES)
+
+
+def _verify_compensation_references_v19(
+    conn: sqlite3.Connection,
+    *,
+    expected_counts: dict[str, int],
+) -> None:
+    if not _has_compensation_reference_schema_v19(conn):
+        raise RuntimeError(
+            "compensation reference migration did not create the stable "
+            "reference schema"
+        )
+    for table, expected_count in expected_counts.items():
+        observed_count = int(
+            conn.execute(
+                f'SELECT COUNT(*) FROM "{table}"'
+            ).fetchone()[0]
+        )
+        if observed_count != expected_count:
+            raise RuntimeError(
+                "compensation reference migration changed canonical row "
+                f"count for {table}: expected {expected_count}, "
+                f"found {observed_count}"
+            )
+        orphan = conn.execute(
+            f"""
+            SELECT authority.job_id
+            FROM "{table}" AS authority
+            LEFT JOIN jobs
+              ON jobs.tenant_id = authority.tenant_id
+             AND jobs.job_id = authority.job_id
+            WHERE jobs.job_id IS NULL
+            LIMIT 1
+            """
+        ).fetchone()
+        if orphan is not None:
+            raise RuntimeError(
+                "compensation reference migration left an unresolved "
+                f"JobId in {table}"
+            )
+        for row in conn.execute(
+            f'SELECT DISTINCT job_id FROM "{table}"'
+        ).fetchall():
+            _validate_job_uuid(str(row[0]))
+    foreign_key_error = conn.execute(
+        "PRAGMA foreign_key_check"
+    ).fetchone()
+    if foreign_key_error is not None:
+        raise RuntimeError(
+            "compensation reference migration found a foreign-key "
+            "violation"
+        )
+
+
+def _merge_compensation_authority_v19(
+    conn: sqlite3.Connection,
+    *,
+    table: str,
+    timestamp_column: str,
+    tenant_id: str,
+    losing_job_id: str,
+    surviving_job_id: str,
+) -> int:
+    columns = tuple(
+        str(row[1])
+        for row in conn.execute(
+            f'PRAGMA table_info("{table}")'
+        ).fetchall()
+    )
+    job_id_index = columns.index("job_id")
+    timestamp_index = columns.index(timestamp_column)
+    column_sql = ", ".join(f'"{column}"' for column in columns)
+    rows = conn.execute(
+        f"""
+        SELECT {column_sql}
+        FROM "{table}"
+        WHERE tenant_id = ? AND job_id IN (?, ?)
+        """,
+        (tenant_id, losing_job_id, surviving_job_id),
+    ).fetchall()
+    if not rows:
+        return 0
+    selected = max(
+        rows,
+        key=lambda row: (
+            str(row[timestamp_index]),
+            str(row[job_id_index]) == surviving_job_id,
+            str(row[job_id_index]),
+        ),
+    )
+    canonical = list(selected)
+    canonical[job_id_index] = surviving_job_id
+    conn.execute(
+        f"""
+        DELETE FROM "{table}"
+        WHERE tenant_id = ? AND job_id IN (?, ?)
+        """,
+        (tenant_id, losing_job_id, surviving_job_id),
+    )
+    placeholders = ", ".join("?" for _ in columns)
+    conn.execute(
+        f'INSERT INTO "{table}" ({column_sql}) '
+        f"VALUES ({placeholders})",
+        tuple(canonical),
+    )
+    return len(rows)
+
+
+def _reassign_compensation_references_v19(
+    conn: sqlite3.Connection,
+    *,
+    tenant_id: str,
+    losing_job_id: str,
+    surviving_job_id: str,
+) -> None:
+    if losing_job_id == surviving_job_id:
+        return
+    before_counts = {
+        table: int(
+            conn.execute(
+                f'SELECT COUNT(*) FROM "{table}"'
+            ).fetchone()[0]
+        )
+        for table in _COMPENSATION_REFERENCE_TABLES
+    }
+    merged_counts = {
+        table: _merge_compensation_authority_v19(
+            conn,
+            table=table,
+            timestamp_column=_COMPENSATION_TIMESTAMP_COLUMNS[table],
+            tenant_id=tenant_id,
+            losing_job_id=losing_job_id,
+            surviving_job_id=surviving_job_id,
+        )
+        for table in _COMPENSATION_REFERENCE_TABLES
+    }
+    expected_counts = {
+        table: (
+            before_counts[table]
+            - merged_counts[table]
+            + (1 if merged_counts[table] else 0)
+        )
+        for table in _COMPENSATION_REFERENCE_TABLES
+    }
+    _verify_compensation_references_v19(
+        conn,
+        expected_counts=expected_counts,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/workers/automation/src/jobctrl/infrastructure/compensation/sqlite_market_repository.py
+++ b/workers/automation/src/jobctrl/infrastructure/compensation/sqlite_market_repository.py
@@ -32,6 +32,9 @@ from jobctrl.infrastructure.compensation.levels_fyi_public import (
     LevelsFyiPublicTarget,
     load_levels_fyi_public_observations,
 )
+from jobctrl.infrastructure.compensation.sqlite_reference import (
+    SqliteCompensationJobReference,
+)
 from jobctrl.domain.compensation import (
     MarketCompensationEstimate,
     MarketConfidenceFactor,
@@ -236,14 +239,32 @@ class SqliteMarketCompensationRepository:
     def __init__(self, conn: sqlite3.Connection) -> None:
         self._conn = conn
         ensure_market_compensation_tables(conn)
+        self._job_reference = SqliteCompensationJobReference(
+            conn,
+            "job_market_compensation_estimates",
+        )
+        self._posted_job_reference = SqliteCompensationJobReference(
+            conn,
+            "job_posted_compensation_facts",
+        )
 
     def save_estimate(self, estimate: MarketCompensationEstimate) -> None:
         if estimate.estimate_state == "not_requested":
             raise ValueError("not_requested market estimates are read-side markers and must not be persisted")
+        reference = self._job_reference.for_write(
+            estimate.tenant_id,
+            estimate.job_url,
+        )
+        event_job_url = self._job_reference.storage_url(
+            estimate.tenant_id,
+            estimate.job_url,
+        )
+        reference_column = self._job_reference.column
         self._conn.execute(
-            """
+            f"""
             INSERT INTO job_market_compensation_estimates (
-                tenant_id, job_url, estimate_state, currency, period, component,
+                tenant_id, {reference_column}, estimate_state, currency,
+                period, component,
                 minimum_amount, maximum_amount, confidence_interval_minimum_amount,
                 confidence_interval_maximum_amount, confidence_band, confidence_score,
                 source_count, sample_count, aggregate_bucket, geography_scope,
@@ -252,7 +273,7 @@ class SqliteMarketCompensationRepository:
                 source_unavailable_reasons_json, warnings_json, estimator_version, estimated_at,
                 company_name, normalized_company, role_title, normalized_role, company_tier, match_scope
             ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            ON CONFLICT(tenant_id, job_url) DO UPDATE SET
+            ON CONFLICT(tenant_id, {reference_column}) DO UPDATE SET
                 estimate_state                    = excluded.estimate_state,
                 currency                          = excluded.currency,
                 period                            = excluded.period,
@@ -288,7 +309,7 @@ class SqliteMarketCompensationRepository:
             """,
             (
                 estimate.tenant_id,
-                estimate.job_url,
+                reference,
                 estimate.estimate_state,
                 estimate.currency,
                 estimate.period,
@@ -324,12 +345,22 @@ class SqliteMarketCompensationRepository:
             ),
         )
         self._conn.commit()
-        self._record_updated_event(estimate)
+        self._record_updated_event(
+            estimate,
+            job_url=event_job_url,
+        )
 
     def get_estimate(self, tenant_id: str, job_url: str) -> MarketCompensationEstimate | None:
+        reference = self._job_reference.for_read(
+            tenant_id,
+            job_url,
+        )
+        if reference is None:
+            return None
         row = self._conn.execute(
-            """
-            SELECT tenant_id, job_url, estimate_state, currency, period, component,
+            f"""
+            SELECT tenant_id, ? AS job_url, estimate_state, currency,
+                   period, component,
                    minimum_amount, maximum_amount, confidence_interval_minimum_amount,
                    confidence_interval_maximum_amount, confidence_band, confidence_score,
                    source_count, sample_count, aggregate_bucket, geography_scope,
@@ -338,9 +369,9 @@ class SqliteMarketCompensationRepository:
                    source_unavailable_reasons_json, warnings_json, estimator_version, estimated_at,
                    company_name, normalized_company, role_title, normalized_role, company_tier, match_scope
             FROM job_market_compensation_estimates
-            WHERE tenant_id = ? AND job_url = ?
+            WHERE tenant_id = ? AND {self._job_reference.column} = ?
             """,
-            (tenant_id, job_url),
+            (job_url, tenant_id, reference),
         ).fetchone()
         return _row_to_estimate(row) if row is not None else None
 
@@ -409,10 +440,13 @@ class SqliteMarketCompensationRepository:
         job_url: str | None = None,
     ) -> int:
         posted_observations = self._posted_salary_observations(tenant_id=tenant_id, job_url=job_url)
-        sql = "SELECT url, title, site, company, location FROM jobs"
-        params: list[Any] = []
+        sql = (
+            "SELECT url, title, site, company, location "
+            "FROM jobs WHERE tenant_id = ?"
+        )
+        params: list[Any] = [tenant_id]
         if job_url:
-            sql += " WHERE url = ?"
+            sql += " AND url = ?"
             params.append(job_url)
         sql += " ORDER BY url"
         if limit > 0:
@@ -457,13 +491,19 @@ class SqliteMarketCompensationRepository:
         tenant_id: str,
         job_url: str | None,
     ) -> tuple[ReportedCompensationObservation, ...]:
-        sql = """
-            SELECT f.job_url, j.title, j.company, j.site, j.location,
+        reference_column = self._posted_job_reference.column
+        join_sql = (
+            "j.tenant_id = f.tenant_id AND j.job_id = f.job_id"
+            if reference_column == "job_id"
+            else "j.tenant_id = f.tenant_id AND j.url = f.job_url"
+        )
+        sql = f"""
+            SELECT j.url AS job_url, j.title, j.company, j.site, j.location,
                    f.currency, f.period, f.minimum_amount, f.maximum_amount,
                    f.annualized_minimum_amount, f.annualized_maximum_amount,
                    f.warnings_json, f.source_text, f.parsed_at
             FROM job_posted_compensation_facts f
-            JOIN jobs j ON j.url = f.job_url
+            JOIN jobs j ON {join_sql}
             WHERE f.tenant_id = ?
               AND f.parse_state = 'parsed_range'
               AND (
@@ -475,8 +515,14 @@ class SqliteMarketCompensationRepository:
         """
         params: list[Any] = [tenant_id]
         if job_url:
-            sql += " AND f.job_url = ?"
-            params.append(job_url)
+            reference = self._posted_job_reference.for_read(
+                tenant_id,
+                job_url,
+            )
+            if reference is None:
+                return ()
+            sql += f" AND f.{reference_column} = ?"
+            params.append(reference)
         rows = self._conn.execute(sql, params).fetchall()
         observations: list[ReportedCompensationObservation] = []
         for row in rows:
@@ -526,13 +572,20 @@ class SqliteMarketCompensationRepository:
         return tuple(observations)
 
     def _posted_annualized_range(self, tenant_id: str, job_url: str) -> tuple[int | None, int | None]:
+        reference = self._posted_job_reference.for_read(
+            tenant_id,
+            job_url,
+        )
+        if reference is None:
+            return None, None
         row = self._conn.execute(
-            """
+            f"""
             SELECT annualized_minimum_amount, annualized_maximum_amount
             FROM job_posted_compensation_facts
-            WHERE tenant_id = ? AND job_url = ?
+            WHERE tenant_id = ?
+              AND {self._posted_job_reference.column} = ?
             """,
-            (tenant_id, job_url),
+            (tenant_id, reference),
         ).fetchone()
         if row is None:
             return None, None
@@ -540,19 +593,24 @@ class SqliteMarketCompensationRepository:
             _row_value(row, "annualized_maximum_amount")
         )
 
-    def _record_updated_event(self, estimate: MarketCompensationEstimate) -> None:
+    def _record_updated_event(
+        self,
+        estimate: MarketCompensationEstimate,
+        *,
+        job_url: str,
+    ) -> None:
         try:
             from jobctrl.state import record_job_event
 
             record_job_event(
                 self._conn,
-                estimate.job_url,
+                job_url,
                 "enrich",
                 "CompensationFactsUpdated",
                 message="Market compensation estimate updated",
                 occurred_at=estimate.estimated_at,
                 payload={
-                    "jobId": estimate.job_url,
+                    "jobId": job_url,
                     "changedSections": ["market"],
                     "postedRecordStatus": None,
                     "postedParseState": None,

--- a/workers/automation/src/jobctrl/infrastructure/compensation/sqlite_reference.py
+++ b/workers/automation/src/jobctrl/infrastructure/compensation/sqlite_reference.py
@@ -1,0 +1,136 @@
+"""Stable Job identity resolution for SQLite compensation adapters."""
+
+from __future__ import annotations
+
+import sqlite3
+
+from jobctrl.domain.discovery.value_objects import PostingUrl
+from jobctrl.domain.identifiers import JobId, canonical_job_id
+from jobctrl.domain.ports.discovery import ResolvedJobIdentity
+from jobctrl.domain.tenant import TenantId
+from jobctrl.infrastructure.discovery.sqlite_identity_resolver import (
+    SqliteJobIdentityResolver,
+)
+
+
+class SqliteCompensationJobReference:
+    """Resolve URL-shaped compatibility input to one physical table key."""
+
+    def __init__(
+        self,
+        conn: sqlite3.Connection,
+        table_name: str,
+    ) -> None:
+        self._conn = conn
+        self._table_name = table_name
+        self.column = (
+            "job_id"
+            if "job_id"
+            in {
+                str(row[1])
+                for row in conn.execute(
+                    f'PRAGMA table_info("{table_name}")'
+                ).fetchall()
+            }
+            else "job_url"
+        )
+        self._identity_resolver = SqliteJobIdentityResolver(conn)
+
+    def _identity(
+        self,
+        tenant_id: str,
+        raw_reference: str,
+    ) -> ResolvedJobIdentity | None:
+        tenant = TenantId(str(tenant_id))
+        reference = str(raw_reference or "").strip()
+        if not reference:
+            raise ValueError("job reference must be non-empty")
+        identity = self._identity_resolver.resolve_by_posting_url(
+            tenant,
+            PostingUrl(reference),
+        )
+        if identity is not None:
+            return identity
+        direct = self._conn.execute(
+            """
+            SELECT job_id
+            FROM jobs
+            WHERE tenant_id = ? AND url = ?
+            LIMIT 1
+            """,
+            (str(tenant), reference),
+        ).fetchone()
+        if direct is not None and str(direct[0] or "").strip():
+            identity = self._identity_resolver.resolve_by_job_id(
+                tenant,
+                JobId(str(direct[0])),
+            )
+            if identity is not None:
+                return identity
+        try:
+            stable_candidate = canonical_job_id(reference)
+        except ValueError:
+            return None
+        return self._identity_resolver.resolve_by_job_id(
+            tenant,
+            stable_candidate,
+        )
+
+    def for_read(
+        self,
+        tenant_id: str,
+        raw_reference: str,
+    ) -> str | None:
+        identity = self._identity(tenant_id, raw_reference)
+        if identity is None:
+            return None
+        if self.column == "job_id":
+            return str(identity.job_id)
+        exact = self._conn.execute(
+            f"""
+            SELECT 1
+            FROM "{self._table_name}"
+            WHERE tenant_id = ? AND job_url = ?
+            LIMIT 1
+            """,
+            (str(tenant_id), str(raw_reference)),
+        ).fetchone()
+        return (
+            str(raw_reference)
+            if exact is not None
+            else identity.storage_url.value
+        )
+
+    def for_write(
+        self,
+        tenant_id: str,
+        raw_reference: str,
+    ) -> str:
+        identity = self._identity(tenant_id, raw_reference)
+        if identity is None:
+            raise ValueError(
+                "no stable Job identity for compensation reference: "
+                f"{raw_reference}"
+            )
+        return (
+            str(identity.job_id)
+            if self.column == "job_id"
+            else identity.storage_url.value
+        )
+
+    def storage_url(
+        self,
+        tenant_id: str,
+        raw_reference: str,
+    ) -> str:
+        """Return the canonical URL required by legacy event foreign keys."""
+        identity = self._identity(tenant_id, raw_reference)
+        if identity is None:
+            raise ValueError(
+                "no stable Job identity for compensation reference: "
+                f"{raw_reference}"
+            )
+        return identity.storage_url.value
+
+
+__all__ = ["SqliteCompensationJobReference"]

--- a/workers/automation/src/jobctrl/infrastructure/compensation/sqlite_repository.py
+++ b/workers/automation/src/jobctrl/infrastructure/compensation/sqlite_repository.py
@@ -9,6 +9,9 @@ from typing import Any, Callable
 
 from jobctrl.database import ensure_posted_compensation_tables
 from jobctrl.domain.compensation import PostedCompensationFact, parse_posted_compensation
+from jobctrl.infrastructure.compensation.sqlite_reference import (
+    SqliteCompensationJobReference,
+)
 
 COMPENSATION_SOURCE_RE = re.compile(
     r"\b(?:salary|compensation|pay range|base pay|base salary|wage|remuneration|ote)\b|on[- ]target earnings",
@@ -34,6 +37,10 @@ class SqlitePostedCompensationRepository:
     def __init__(self, conn: sqlite3.Connection) -> None:
         self._conn = conn
         ensure_posted_compensation_tables(conn)
+        self._job_reference = SqliteCompensationJobReference(
+            conn,
+            "job_posted_compensation_facts",
+        )
 
     def save_fact(
         self,
@@ -42,16 +49,26 @@ class SqlitePostedCompensationRepository:
         event_idempotency_key: str | None = None,
         event_write_fence: Callable[[], None] | None = None,
     ) -> None:
+        reference = self._job_reference.for_write(
+            fact.tenant_id,
+            fact.job_url,
+        )
+        event_job_url = self._job_reference.storage_url(
+            fact.tenant_id,
+            fact.job_url,
+        )
+        reference_column = self._job_reference.column
         self._conn.execute(
-            """
+            f"""
             INSERT INTO job_posted_compensation_facts (
-                tenant_id, job_url, source_field, source_text, legacy_raw_salary,
+                tenant_id, {reference_column}, source_field, source_text,
+                legacy_raw_salary,
                 parse_state, currency, period, component, minimum_amount,
                 maximum_amount, annualized_minimum_amount, annualized_maximum_amount,
                 annualization_assumption, confidence, warnings_json, parser_version,
                 source_hash, parsed_at
             ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            ON CONFLICT(tenant_id, job_url) DO UPDATE SET
+            ON CONFLICT(tenant_id, {reference_column}) DO UPDATE SET
                 source_field                 = excluded.source_field,
                 source_text                  = excluded.source_text,
                 legacy_raw_salary            = excluded.legacy_raw_salary,
@@ -72,7 +89,7 @@ class SqlitePostedCompensationRepository:
             """,
             (
                 fact.tenant_id,
-                fact.job_url,
+                reference,
                 fact.source_field,
                 fact.source_text,
                 fact.legacy_raw_salary,
@@ -97,21 +114,29 @@ class SqlitePostedCompensationRepository:
             event_write_fence()
         self._record_updated_event(
             fact,
+            job_url=event_job_url,
             idempotency_key=event_idempotency_key,
         )
 
     def get_fact(self, tenant_id: str, job_url: str) -> PostedCompensationFact | None:
+        reference = self._job_reference.for_read(
+            tenant_id,
+            job_url,
+        )
+        if reference is None:
+            return None
         row = self._conn.execute(
-            """
-            SELECT tenant_id, job_url, source_field, source_text, legacy_raw_salary,
+            f"""
+            SELECT tenant_id, ? AS job_url, source_field, source_text,
+                   legacy_raw_salary,
                    parse_state, currency, period, component, minimum_amount,
                    maximum_amount, annualized_minimum_amount, annualized_maximum_amount,
                    annualization_assumption, confidence, warnings_json, parser_version,
                    source_hash, parsed_at
             FROM job_posted_compensation_facts
-            WHERE tenant_id = ? AND job_url = ?
+            WHERE tenant_id = ? AND {self._job_reference.column} = ?
             """,
-            (tenant_id, job_url),
+            (job_url, tenant_id, reference),
         ).fetchone()
         return _row_to_fact(row) if row is not None else None
 
@@ -141,7 +166,15 @@ class SqlitePostedCompensationRepository:
         return fact
 
     def backfill_from_legacy_jobs(self, *, tenant_id: str = "local", parsed_at: str | None = None) -> int:
-        rows = self._conn.execute("SELECT url, salary, full_description, description FROM jobs ORDER BY url").fetchall()
+        rows = self._conn.execute(
+            """
+            SELECT url, salary, full_description, description
+            FROM jobs
+            WHERE tenant_id = ?
+            ORDER BY url
+            """,
+            (tenant_id,),
+        ).fetchall()
         for row in rows:
             source_text, source_field = posted_compensation_source_from_job(row)
             self.parse_and_save_job_salary(
@@ -158,6 +191,7 @@ class SqlitePostedCompensationRepository:
         self,
         fact: PostedCompensationFact,
         *,
+        job_url: str,
         idempotency_key: str | None = None,
     ) -> None:
         try:
@@ -165,13 +199,13 @@ class SqlitePostedCompensationRepository:
 
             record_job_event(
                 self._conn,
-                fact.job_url,
+                job_url,
                 "enrich",
                 "CompensationFactsUpdated",
                 message="Posted compensation fact updated",
                 occurred_at=fact.parsed_at,
                 payload={
-                    "jobId": fact.job_url,
+                    "jobId": job_url,
                     "changedSections": ["posted"],
                     "postedRecordStatus": "recorded",
                     "postedParseState": fact.parse_state,

--- a/workers/automation/tests/test_compensation_identity_reference_migration.py
+++ b/workers/automation/tests/test_compensation_identity_reference_migration.py
@@ -1,0 +1,532 @@
+"""Schema-v19 compensation JobId reference contracts."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import uuid
+from pathlib import Path
+
+import pytest
+
+import jobctrl.database as database_module
+from jobctrl.database import (
+    SCHEMA_VERSION,
+    close_connection,
+    ensure_compensation_references_v19,
+    ensure_market_compensation_tables,
+    ensure_posted_compensation_tables,
+    init_db,
+    reassign_discovery_identity_references,
+)
+from jobctrl.domain.discovery import (
+    Employer,
+    Job,
+    JobMetadata,
+    PostingUrl,
+    SearchStrategy,
+    Source,
+)
+from jobctrl.domain.identifiers import JobId
+from jobctrl.domain.tenant import LOCAL_TENANT
+from jobctrl.infrastructure.compensation import (
+    SqliteMarketCompensationRepository,
+    SqlitePostedCompensationRepository,
+)
+from jobctrl.infrastructure.discovery import SqliteJobRepository
+
+
+PREVIOUS_SCHEMA_VERSION = 18
+
+
+def _discovered_job(posting_url: str, job_id: JobId) -> Job:
+    return Job.discover(
+        tenant_id=LOCAL_TENANT,
+        job_id=job_id,
+        posting_url=PostingUrl(value=posting_url),
+        source=Source(board="example"),
+        employer=Employer(name="Example"),
+        search_strategy=SearchStrategy.JOBSPY,
+        metadata=JobMetadata(title="Platform Engineer"),
+        discovered_at="2026-07-29T10:00:00+00:00",
+    )
+
+
+def _downgrade_compensation_references_to_v18(
+    conn: sqlite3.Connection,
+) -> None:
+    conn.execute("DROP TABLE job_market_compensation_estimates")
+    conn.execute("DROP TABLE job_posted_compensation_facts")
+    conn.execute(f"PRAGMA user_version = {PREVIOUS_SCHEMA_VERSION}")
+    conn.commit()
+    ensure_posted_compensation_tables(conn)
+    ensure_market_compensation_tables(conn)
+
+
+def _insert_posted(
+    conn: sqlite3.Connection,
+    *,
+    reference_column: str,
+    reference: str,
+    marker: str,
+    parsed_at: str,
+    tenant_id: str = "local",
+) -> None:
+    conn.execute(
+        f"""
+        INSERT INTO job_posted_compensation_facts (
+            tenant_id, {reference_column}, parse_state, currency, period,
+            component, minimum_amount, maximum_amount, confidence,
+            parser_version, source_hash, parsed_at
+        ) VALUES (
+            ?, ?, 'parsed_range', 'EUR', 'year', 'base_salary',
+            ?, ?, 'high', ?, ?, ?
+        )
+        """,
+        (
+            tenant_id,
+            reference,
+            80_000 + len(marker),
+            90_000 + len(marker),
+            f"parser:{marker}",
+            f"hash:{marker}",
+            parsed_at,
+        ),
+    )
+
+
+def _insert_market(
+    conn: sqlite3.Connection,
+    *,
+    reference_column: str,
+    reference: str,
+    marker: str,
+    estimated_at: str,
+    tenant_id: str = "local",
+) -> None:
+    conn.execute(
+        f"""
+        INSERT INTO job_market_compensation_estimates (
+            tenant_id, {reference_column}, estimate_state, currency,
+            period, component, minimum_amount, maximum_amount,
+            confidence_band, confidence_score, source_count,
+            estimator_version, estimated_at
+        ) VALUES (
+            ?, ?, 'estimated_range', 'EUR', 'year',
+            'total_compensation', ?, ?, 'medium', 0.75, 2, ?, ?
+        )
+        """,
+        (
+            tenant_id,
+            reference,
+            110_000 + len(marker),
+            140_000 + len(marker),
+            f"company-role-reported-compensation-{marker}",
+            estimated_at,
+        ),
+    )
+
+
+def _columns(
+    conn: sqlite3.Connection,
+    table_name: str,
+) -> set[str]:
+    return {
+        str(row[1])
+        for row in conn.execute(
+            f'PRAGMA table_info("{table_name}")'
+        ).fetchall()
+    }
+
+
+def test_v18_compensation_migrates_alias_winners_and_uuid_urls(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    conn = init_db(db_path)
+    jobs = SqliteJobRepository(conn)
+    stable_job_id = JobId(str(uuid.uuid4()))
+    storage_url = "https://boards.example/jobs/compensation"
+    alias_url = "https://careers.example/jobs/compensation"
+    jobs.save(_discovered_job(storage_url, stable_job_id))
+    jobs.save(_discovered_job(alias_url, stable_job_id))
+
+    uuid_shaped_url = str(uuid.uuid4())
+    uuid_url_owner = JobId(str(uuid.uuid4()))
+    jobs.save(_discovered_job(uuid_shaped_url, uuid_url_owner))
+    jobs.save(
+        _discovered_job(
+            "https://example.com/jobs/id-text-owner",
+            JobId(uuid_shaped_url),
+        )
+    )
+    _downgrade_compensation_references_to_v18(conn)
+    _insert_posted(
+        conn,
+        reference_column="job_url",
+        reference=storage_url,
+        marker="storage-old",
+        parsed_at="2026-07-29T10:00:00+00:00",
+    )
+    _insert_posted(
+        conn,
+        reference_column="job_url",
+        reference=alias_url,
+        marker="alias-new",
+        parsed_at="2026-07-29T10:01:00+00:00",
+    )
+    _insert_posted(
+        conn,
+        reference_column="job_url",
+        reference=uuid_shaped_url,
+        marker="uuid-url",
+        parsed_at="2026-07-29T10:02:00+00:00",
+    )
+    _insert_market(
+        conn,
+        reference_column="job_url",
+        reference=storage_url,
+        marker="storage-new",
+        estimated_at="2026-07-29T10:03:00+00:00",
+    )
+    _insert_market(
+        conn,
+        reference_column="job_url",
+        reference=alias_url,
+        marker="alias-old",
+        estimated_at="2026-07-29T10:02:00+00:00",
+    )
+    _insert_market(
+        conn,
+        reference_column="job_url",
+        reference=uuid_shaped_url,
+        marker="uuid-url",
+        estimated_at="2026-07-29T10:04:00+00:00",
+    )
+    conn.commit()
+    close_connection(db_path)
+
+    reopened = init_db(db_path)
+    assert (
+        reopened.execute("PRAGMA user_version").fetchone()[0]
+        == SCHEMA_VERSION
+        == 19
+    )
+    for table in database_module._COMPENSATION_REFERENCE_TABLES:
+        assert "job_id" in _columns(reopened, table)
+        assert "job_url" not in _columns(reopened, table)
+        assert reopened.execute(
+            f'SELECT COUNT(*) FROM "{table}"'
+        ).fetchone()[0] == 2
+    posted = reopened.execute(
+        """
+        SELECT job_id, parser_version
+        FROM job_posted_compensation_facts
+        ORDER BY parser_version
+        """
+    ).fetchall()
+    assert [tuple(row) for row in posted] == [
+        (str(stable_job_id), "parser:alias-new"),
+        (str(uuid_url_owner), "parser:uuid-url"),
+    ]
+    market = reopened.execute(
+        """
+        SELECT job_id, estimator_version
+        FROM job_market_compensation_estimates
+        ORDER BY estimator_version
+        """
+    ).fetchall()
+    assert [tuple(row) for row in market] == [
+        (
+            str(stable_job_id),
+            "company-role-reported-compensation-storage-new",
+        ),
+        (
+            str(uuid_url_owner),
+            "company-role-reported-compensation-uuid-url",
+        ),
+    ]
+    posted_repo = SqlitePostedCompensationRepository(reopened)
+    alias_fact = posted_repo.get_fact("local", alias_url)
+    assert alias_fact is not None
+    assert alias_fact.job_url == alias_url
+    assert alias_fact.parser_version == "parser:alias-new"
+    uuid_fact = posted_repo.get_fact("local", uuid_shaped_url)
+    assert uuid_fact is not None
+    assert uuid_fact.parser_version == "parser:uuid-url"
+    market_repo = SqliteMarketCompensationRepository(reopened)
+    storage_estimate = market_repo.get_estimate("local", storage_url)
+    assert storage_estimate is not None
+    assert (
+        storage_estimate.estimator_version
+        == "company-role-reported-compensation-storage-new"
+    )
+    assert reopened.execute("PRAGMA foreign_key_check").fetchone() is None
+    close_connection(db_path)
+
+    reopened_again = init_db(db_path)
+    assert reopened_again.execute(
+        "SELECT COUNT(*) FROM job_posted_compensation_facts"
+    ).fetchone()[0] == 2
+    close_connection(db_path)
+
+
+def test_v19_compensation_migration_rolls_back_and_retries(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    conn = init_db(db_path)
+    job_id = JobId(str(uuid.uuid4()))
+    job_url = "https://example.com/jobs/compensation-retry"
+    SqliteJobRepository(conn).save(_discovered_job(job_url, job_id))
+    _downgrade_compensation_references_to_v18(conn)
+    _insert_posted(
+        conn,
+        reference_column="job_url",
+        reference=job_url,
+        marker="retry",
+        parsed_at="2026-07-29T10:00:00+00:00",
+    )
+    _insert_market(
+        conn,
+        reference_column="job_url",
+        reference=job_url,
+        marker="retry",
+        estimated_at="2026-07-29T10:00:00+00:00",
+    )
+    conn.commit()
+    original_verify = (
+        database_module._verify_compensation_references_v19
+    )
+
+    def _fail_verification(
+        _conn: sqlite3.Connection,
+        *,
+        expected_counts: dict[str, int],
+    ) -> None:
+        del expected_counts
+        raise RuntimeError("injected compensation verification failure")
+
+    monkeypatch.setattr(
+        database_module,
+        "_verify_compensation_references_v19",
+        _fail_verification,
+    )
+    with pytest.raises(
+        RuntimeError,
+        match="injected compensation verification failure",
+    ):
+        ensure_compensation_references_v19(conn)
+    assert conn.execute("PRAGMA user_version").fetchone()[0] == 18
+    assert "job_url" in _columns(
+        conn,
+        "job_posted_compensation_facts",
+    )
+    assert conn.execute(
+        "SELECT parser_version FROM job_posted_compensation_facts"
+    ).fetchone()[0] == "parser:retry"
+
+    monkeypatch.setattr(
+        database_module,
+        "_verify_compensation_references_v19",
+        original_verify,
+    )
+    assert ensure_compensation_references_v19(conn) == list(
+        database_module._COMPENSATION_REFERENCE_TABLES
+    )
+    assert conn.execute("PRAGMA user_version").fetchone()[0] == 19
+    assert "job_id" in _columns(
+        conn,
+        "job_posted_compensation_facts",
+    )
+    assert conn.execute("PRAGMA foreign_key_check").fetchone() is None
+    close_connection(db_path)
+
+
+def test_runtime_compensation_merge_preserves_newest_and_tenant(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    conn = init_db(db_path)
+    jobs = SqliteJobRepository(conn)
+    losing_id = JobId(str(uuid.uuid4()))
+    surviving_id = JobId(str(uuid.uuid4()))
+    other_tenant_job_id = JobId(str(uuid.uuid4()))
+    losing_url = "https://example.com/jobs/compensation-losing"
+    surviving_url = "https://example.com/jobs/compensation-surviving"
+    other_tenant_url = "https://tenant-b.example/jobs/compensation"
+    jobs.save(_discovered_job(losing_url, losing_id))
+    jobs.save(_discovered_job(surviving_url, surviving_id))
+    conn.execute(
+        """
+        INSERT INTO jobs (
+            url, tenant_id, job_id, title, company, discovered_at
+        ) VALUES (?, 'tenant-b', ?, 'Platform Engineer', 'Example', ?)
+        """,
+        (
+            other_tenant_url,
+            str(other_tenant_job_id),
+            "2026-07-29T10:00:00+00:00",
+        ),
+    )
+    _insert_posted(
+        conn,
+        reference_column="job_id",
+        reference=str(surviving_id),
+        marker="surviving-old",
+        parsed_at="2026-07-29T10:00:00+00:00",
+    )
+    _insert_posted(
+        conn,
+        reference_column="job_id",
+        reference=str(losing_id),
+        marker="losing-new",
+        parsed_at="2026-07-29T10:01:00+00:00",
+    )
+    _insert_market(
+        conn,
+        reference_column="job_id",
+        reference=str(surviving_id),
+        marker="surviving-new",
+        estimated_at="2026-07-29T10:02:00+00:00",
+    )
+    _insert_market(
+        conn,
+        reference_column="job_id",
+        reference=str(losing_id),
+        marker="losing-old",
+        estimated_at="2026-07-29T10:01:00+00:00",
+    )
+    _insert_posted(
+        conn,
+        reference_column="job_id",
+        reference=str(other_tenant_job_id),
+        marker="other-tenant",
+        parsed_at="2026-07-29T10:03:00+00:00",
+        tenant_id="tenant-b",
+    )
+    _insert_market(
+        conn,
+        reference_column="job_id",
+        reference=str(other_tenant_job_id),
+        marker="other-tenant",
+        estimated_at="2026-07-29T10:03:00+00:00",
+        tenant_id="tenant-b",
+    )
+    conn.commit()
+
+    reassign_discovery_identity_references(
+        conn,
+        losing_job_url=losing_url,
+        surviving_job_url=surviving_url,
+    )
+    conn.execute(
+        "DELETE FROM jobs WHERE tenant_id = 'local' AND url = ?",
+        (losing_url,),
+    )
+
+    assert [
+        tuple(row)
+        for row in conn.execute(
+            """
+            SELECT tenant_id, job_id, parser_version
+            FROM job_posted_compensation_facts
+            ORDER BY tenant_id
+            """
+        ).fetchall()
+    ] == [
+        ("local", str(surviving_id), "parser:losing-new"),
+        (
+            "tenant-b",
+            str(other_tenant_job_id),
+            "parser:other-tenant",
+        ),
+    ]
+    assert [
+        tuple(row)
+        for row in conn.execute(
+            """
+            SELECT tenant_id, job_id, estimator_version
+            FROM job_market_compensation_estimates
+            ORDER BY tenant_id
+            """
+        ).fetchall()
+    ] == [
+        (
+            "local",
+            str(surviving_id),
+            "company-role-reported-compensation-surviving-new",
+        ),
+        (
+            "tenant-b",
+            str(other_tenant_job_id),
+            "company-role-reported-compensation-other-tenant",
+        ),
+    ]
+    posted = SqlitePostedCompensationRepository(conn).get_fact(
+        "local",
+        surviving_url,
+    )
+    assert posted is not None
+    assert posted.parser_version == "parser:losing-new"
+    market = SqliteMarketCompensationRepository(conn).get_estimate(
+        "local",
+        surviving_url,
+    )
+    assert market is not None
+    assert (
+        market.estimator_version
+        == "company-role-reported-compensation-surviving-new"
+    )
+    assert conn.execute("PRAGMA foreign_key_check").fetchone() is None
+    close_connection(db_path)
+
+
+def test_alias_and_job_id_writes_record_events_for_storage_url(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    conn = init_db(db_path)
+    jobs = SqliteJobRepository(conn)
+    stable_job_id = JobId(str(uuid.uuid4()))
+    storage_url = "https://storage.example/jobs/compensation"
+    alias_url = "https://alias.example/jobs/compensation"
+    jobs.save(_discovered_job(storage_url, stable_job_id))
+    jobs.save(_discovered_job(alias_url, stable_job_id))
+    conn.execute("PRAGMA foreign_keys = ON")
+
+    SqlitePostedCompensationRepository(
+        conn
+    ).parse_and_save_job_salary(
+        alias_url,
+        "EUR 100000-120000/year",
+        parsed_at="2026-07-29T10:00:00+00:00",
+    )
+    SqliteMarketCompensationRepository(
+        conn
+    ).estimate_and_save_job(
+        job_url=str(stable_job_id),
+        title="Platform Engineer",
+        company="Example",
+        location="Europe",
+        observations=(),
+        estimated_at="2026-07-29T10:01:00+00:00",
+    )
+
+    events = conn.execute(
+        """
+        SELECT job_url, payload_json
+        FROM job_events
+        WHERE event_type = 'CompensationFactsUpdated'
+        ORDER BY event_id
+        """
+    ).fetchall()
+    assert len(events) == 2
+    assert {str(row["job_url"]) for row in events} == {storage_url}
+    assert {
+        str(json.loads(row["payload_json"])["jobId"])
+        for row in events
+    } == {storage_url}
+    assert conn.execute("PRAGMA foreign_key_check").fetchone() is None
+    close_connection(db_path)

--- a/workers/automation/tests/test_discovery_identity_reference_migration.py
+++ b/workers/automation/tests/test_discovery_identity_reference_migration.py
@@ -220,7 +220,7 @@ def test_v7_discovery_references_migrate_to_stable_job_id_and_reopen(
     init_db(db_path)
     close_connection(db_path)
 
-    assert _user_version(db_path) == SCHEMA_VERSION == 18
+    assert _user_version(db_path) == SCHEMA_VERSION == 19
     assert "job_id" in _columns(db_path, "job_source_observations")
     assert "job_url" not in _columns(db_path, "job_source_observations")
     assert "job_id" in _columns(db_path, "job_canonical_identities")

--- a/workers/automation/tests/test_discovery_search_units.py
+++ b/workers/automation/tests/test_discovery_search_units.py
@@ -723,7 +723,16 @@ def test_compensation_event_rechecks_fence_after_fact_commit(search_db) -> None:
 
     assert (
         search_db.execute(
-            "SELECT COUNT(*) FROM job_posted_compensation_facts WHERE job_url = ?",
+            """
+            SELECT COUNT(*)
+            FROM job_posted_compensation_facts
+            WHERE tenant_id = 'local'
+              AND job_id = (
+                  SELECT job_id
+                  FROM jobs
+                  WHERE tenant_id = 'local' AND url = ?
+              )
+            """,
             (job_url,),
         ).fetchone()[0]
         == 1

--- a/workers/automation/tests/test_employer_analysis_identity_reference_migration.py
+++ b/workers/automation/tests/test_employer_analysis_identity_reference_migration.py
@@ -242,7 +242,7 @@ def test_v15_employer_analysis_migrates_alias_histories_and_uuid_urls(
     assert (
         reopened.execute("PRAGMA user_version").fetchone()[0]
         == SCHEMA_VERSION
-        == 18
+        == 19
     )
     for table in database_module._EMPLOYER_ANALYSIS_REFERENCE_TABLES:
         assert "job_id" in _columns(reopened, table)

--- a/workers/automation/tests/test_enrichment_snapshot_identity_reference_migration.py
+++ b/workers/automation/tests/test_enrichment_snapshot_identity_reference_migration.py
@@ -322,7 +322,7 @@ def test_v10_enrichment_snapshot_references_migrate_and_reopen(
     init_db(db_path)
     close_connection(db_path)
 
-    assert _user_version(db_path) == SCHEMA_VERSION == 18
+    assert _user_version(db_path) == SCHEMA_VERSION == 19
     check = sqlite3.connect(db_path)
     try:
         enrichment_rows = check.execute(

--- a/workers/automation/tests/test_execution_search_identity_reference_migration.py
+++ b/workers/automation/tests/test_execution_search_identity_reference_migration.py
@@ -261,7 +261,7 @@ def test_v8_execution_and_receipts_migrate_to_stable_job_id_and_reopen(
     init_db(db_path)
     close_connection(db_path)
 
-    assert _user_version(db_path) == SCHEMA_VERSION == 18
+    assert _user_version(db_path) == SCHEMA_VERSION == 19
     assert "job_id" in _columns(db_path, "discovery_execution_jobs")
     assert "job_url" not in _columns(db_path, "discovery_execution_jobs")
     assert "job_id" in _columns(db_path, "discovery_search_unit_jobs")

--- a/workers/automation/tests/test_interview_prep_identity_reference_migration.py
+++ b/workers/automation/tests/test_interview_prep_identity_reference_migration.py
@@ -297,7 +297,7 @@ def test_v17_interview_prep_migrates_alias_histories_and_uuid_urls(
     assert (
         reopened.execute("PRAGMA user_version").fetchone()[0]
         == SCHEMA_VERSION
-        == 18
+        == 19
     )
     for table in database_module._INTERVIEW_PREP_REFERENCE_TABLES:
         assert "job_id" in _columns(reopened, table)

--- a/workers/automation/tests/test_jsonrpc_handlers.py
+++ b/workers/automation/tests/test_jsonrpc_handlers.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import sqlite3
 from dataclasses import fields
 from pathlib import Path
 from types import SimpleNamespace
@@ -89,6 +90,18 @@ def _seed_job(db_path: Path, url: str = "https://example.com/job/1") -> None:
         (url, "Test job"),
     )
     conn.commit()
+
+
+def _stable_job_id(
+    conn: sqlite3.Connection,
+    job_url: str,
+) -> str:
+    return str(
+        conn.execute(
+            "SELECT job_id FROM jobs WHERE tenant_id = 'local' AND url = ?",
+            (job_url,),
+        ).fetchone()[0]
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -347,7 +360,12 @@ def test_refresh_compensation_ignores_company_metric_money(tmp_db: Path) -> None
         """
         SELECT parse_state, source_field, minimum_amount, maximum_amount
         FROM job_posted_compensation_facts
-        WHERE job_url = ?
+        WHERE tenant_id = 'local'
+          AND job_id = (
+              SELECT job_id
+              FROM jobs
+              WHERE tenant_id = 'local' AND url = ?
+          )
         """,
         (selected_url,),
     ).fetchone()
@@ -394,7 +412,12 @@ def test_refresh_compensation_does_not_match_ote_inside_words(tmp_db: Path) -> N
         """
         SELECT parse_state, source_field, minimum_amount, maximum_amount
         FROM job_posted_compensation_facts
-        WHERE job_url = ?
+        WHERE tenant_id = 'local'
+          AND job_id = (
+              SELECT job_id
+              FROM jobs
+              WHERE tenant_id = 'local' AND url = ?
+          )
         """,
         (selected_url,),
     ).fetchone()
@@ -531,17 +554,25 @@ def test_refresh_compensation_core_updates_one_job(tmp_db: Path, tmp_path: Path)
         """
         SELECT parse_state, source_field, minimum_amount, maximum_amount
         FROM job_posted_compensation_facts
-        WHERE job_url = ?
+        WHERE tenant_id = 'local' AND job_id = ?
         """,
-        (selected_url,),
+        (_stable_job_id(conn, selected_url),),
     ).fetchone()
     other_posted = conn.execute(
-        "SELECT parse_state FROM job_posted_compensation_facts WHERE job_url = ?",
-        (other_url,),
+        """
+        SELECT parse_state
+        FROM job_posted_compensation_facts
+        WHERE tenant_id = 'local' AND job_id = ?
+        """,
+        (_stable_job_id(conn, other_url),),
     ).fetchone()
     estimate = conn.execute(
-        "SELECT estimate_state, minimum_amount, maximum_amount FROM job_market_compensation_estimates WHERE job_url = ?",
-        (selected_url,),
+        """
+        SELECT estimate_state, minimum_amount, maximum_amount
+        FROM job_market_compensation_estimates
+        WHERE tenant_id = 'local' AND job_id = ?
+        """,
+        (_stable_job_id(conn, selected_url),),
     ).fetchone()
     assert selected_posted["parse_state"] == "parsed_range"
     assert selected_posted["source_field"] == "jobs.full_description"
@@ -603,10 +634,24 @@ def test_refresh_compensation_core_updates_all_jobs(tmp_db: Path, tmp_path: Path
     assert result["estimatesRefreshed"] == 2
 
     posted_rows = conn.execute(
-        "SELECT job_url, parse_state FROM job_posted_compensation_facts ORDER BY job_url",
+        """
+        SELECT jobs.url AS job_url, fact.parse_state
+        FROM job_posted_compensation_facts AS fact
+        JOIN jobs
+          ON jobs.tenant_id = fact.tenant_id
+         AND jobs.job_id = fact.job_id
+        ORDER BY jobs.url
+        """,
     ).fetchall()
     estimate_rows = conn.execute(
-        "SELECT job_url, estimate_state FROM job_market_compensation_estimates ORDER BY job_url",
+        """
+        SELECT jobs.url AS job_url, estimate.estimate_state
+        FROM job_market_compensation_estimates AS estimate
+        JOIN jobs
+          ON jobs.tenant_id = estimate.tenant_id
+         AND jobs.job_id = estimate.job_id
+        ORDER BY jobs.url
+        """,
     ).fetchall()
     assert [row["job_url"] for row in posted_rows] == sorted([first_url, second_url])
     assert [row["parse_state"] for row in posted_rows] == ["parsed_range", "parsed_range"]
@@ -669,9 +714,10 @@ def test_refresh_compensation_without_observations_uses_euro_top_tech_and_update
     estimate = conn.execute(
         """
         SELECT estimate_state, minimum_amount, maximum_amount, component, match_scope, source_snapshot_json
-        FROM job_market_compensation_estimates WHERE job_url = ?
+        FROM job_market_compensation_estimates
+        WHERE tenant_id = 'local' AND job_id = ?
         """,
-        (job_url,),
+        (_stable_job_id(conn, job_url),),
     ).fetchone()
     assert estimate["estimate_state"] == "estimated_range"
     assert estimate["minimum_amount"] == 242_000
@@ -791,9 +837,10 @@ def test_refresh_compensation_loads_all_configured_sources_by_default(
     estimate = conn.execute(
         """
         SELECT minimum_amount, maximum_amount, source_snapshot_json
-        FROM job_market_compensation_estimates WHERE job_url = ?
+        FROM job_market_compensation_estimates
+        WHERE tenant_id = 'local' AND job_id = ?
         """,
-        (job_url,),
+        (_stable_job_id(conn, job_url),),
     ).fetchone()
     assert estimate["minimum_amount"] == 118_000
     assert estimate["maximum_amount"] == 160_000

--- a/workers/automation/tests/test_market_compensation_repository.py
+++ b/workers/automation/tests/test_market_compensation_repository.py
@@ -47,6 +47,18 @@ def _seed_job(
     return url
 
 
+def _stable_job_id(
+    conn: sqlite3.Connection,
+    job_url: str,
+) -> str:
+    return str(
+        conn.execute(
+            "SELECT job_id FROM jobs WHERE tenant_id = 'local' AND url = ?",
+            (job_url,),
+        ).fetchone()[0]
+    )
+
+
 def _levels() -> ReportedCompensationObservation:
     return ReportedCompensationObservation(
         source_id="levels_fyi",
@@ -193,7 +205,14 @@ def test_repository_does_not_persist_not_requested_marker(conn: sqlite3.Connecti
             )
         )
 
-    row = conn.execute("SELECT * FROM job_market_compensation_estimates WHERE job_url = ?", (job_url,)).fetchone()
+    row = conn.execute(
+        """
+        SELECT *
+        FROM job_market_compensation_estimates
+        WHERE tenant_id = 'local' AND job_id = ?
+        """,
+        (_stable_job_id(conn, job_url),),
+    ).fetchone()
     assert row is None
 
 
@@ -215,9 +234,21 @@ def test_backfill_is_idempotent_and_preserves_existing_salary_and_posted_facts(
     assert repo.backfill_from_jobs((_levels(), _glassdoor()), estimated_at="2026-06-19T10:00:00Z") == 1
 
     market_rows = conn.execute(
-        "SELECT * FROM job_market_compensation_estimates WHERE job_url = ?", (job_url,)
+        """
+        SELECT *
+        FROM job_market_compensation_estimates
+        WHERE tenant_id = 'local' AND job_id = ?
+        """,
+        (_stable_job_id(conn, job_url),),
     ).fetchall()
-    posted_rows = conn.execute("SELECT * FROM job_posted_compensation_facts WHERE job_url = ?", (job_url,)).fetchall()
+    posted_rows = conn.execute(
+        """
+        SELECT *
+        FROM job_posted_compensation_facts
+        WHERE tenant_id = 'local' AND job_id = ?
+        """,
+        (_stable_job_id(conn, job_url),),
+    ).fetchall()
     salary = conn.execute("SELECT salary FROM jobs WHERE url = ?", (job_url,)).fetchone()["salary"]
 
     assert len(market_rows) == 1
@@ -804,9 +835,10 @@ def test_persisted_json_contains_safe_reported_source_fields(conn: sqlite3.Conne
     row = conn.execute(
         """
         SELECT source_snapshot_json, factor_reasons_json, insufficient_reasons_json, warnings_json
-        FROM job_market_compensation_estimates WHERE job_url = ?
+        FROM job_market_compensation_estimates
+        WHERE tenant_id = 'local' AND job_id = ?
         """,
-        (job_url,),
+        (_stable_job_id(conn, job_url),),
     ).fetchone()
     serialized = " ".join(str(row[key]).lower() for key in row.keys())
 
@@ -887,8 +919,12 @@ def test_repository_preserves_public_and_licensed_levels_provenance(conn: sqlite
 
     stored = json.loads(
         conn.execute(
-            "SELECT source_snapshot_json FROM job_market_compensation_estimates WHERE job_url = ?",
-            (job_url,),
+            """
+            SELECT source_snapshot_json
+            FROM job_market_compensation_estimates
+            WHERE tenant_id = 'local' AND job_id = ?
+            """,
+            (_stable_job_id(conn, job_url),),
         ).fetchone()["source_snapshot_json"]
     )
     assert [item["source_provenance"] for item in stored] == ["public", "licensed"]
@@ -900,7 +936,7 @@ def test_repository_sanitizes_stale_persisted_source_json_on_read(conn: sqlite3.
     conn.execute(
         """
         INSERT INTO job_market_compensation_estimates (
-            tenant_id, job_url, estimate_state, currency, period, component,
+            tenant_id, job_id, estimate_state, currency, period, component,
             minimum_amount, maximum_amount, confidence_band, confidence_score,
             source_count, sample_count, aggregate_bucket, geography_scope,
             occupation_code, occupation_label, seniority_label, source_snapshot_json,
@@ -911,7 +947,7 @@ def test_repository_sanitizes_stale_persisted_source_json_on_read(conn: sqlite3.
         """,
         (
             "local",
-            job_url,
+            _stable_job_id(conn, job_url),
             "estimated_range",
             "EUR",
             "year",

--- a/workers/automation/tests/test_materials_identity_reference_migration.py
+++ b/workers/automation/tests/test_materials_identity_reference_migration.py
@@ -293,7 +293,7 @@ def test_v14_materials_migrate_alias_histories_and_uuid_shaped_urls(
     close_connection(db_path)
 
     reopened = init_db(db_path)
-    assert reopened.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_VERSION == 18
+    assert reopened.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_VERSION == 19
     for table in database_module._MATERIALS_REFERENCE_TABLES:
         assert "job_id" in _columns(reopened, table)
         assert "job_url" not in _columns(reopened, table)

--- a/workers/automation/tests/test_posted_compensation_repository.py
+++ b/workers/automation/tests/test_posted_compensation_repository.py
@@ -30,6 +30,18 @@ def _seed_job(
     return url
 
 
+def _stable_job_id(
+    conn: sqlite3.Connection,
+    job_url: str,
+) -> str:
+    return str(
+        conn.execute(
+            "SELECT job_id FROM jobs WHERE tenant_id = 'local' AND url = ?",
+            (job_url,),
+        ).fetchone()[0]
+    )
+
+
 def test_schema_is_created_by_init_db(conn: sqlite3.Connection) -> None:
     row = conn.execute(
         "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'job_posted_compensation_facts'"
@@ -91,7 +103,14 @@ def test_backfill_is_idempotent_and_preserves_legacy_salary(conn: sqlite3.Connec
     assert repo.backfill_from_legacy_jobs(parsed_at="2026-06-19T10:00:00Z") == 1
     assert repo.backfill_from_legacy_jobs(parsed_at="2026-06-19T10:00:00Z") == 1
 
-    rows = conn.execute("SELECT * FROM job_posted_compensation_facts WHERE job_url = ?", (job_url,)).fetchall()
+    rows = conn.execute(
+        """
+        SELECT *
+        FROM job_posted_compensation_facts
+        WHERE tenant_id = 'local' AND job_id = ?
+        """,
+        (_stable_job_id(conn, job_url),),
+    ).fetchall()
     salary = conn.execute("SELECT salary FROM jobs WHERE url = ?", (job_url,)).fetchone()["salary"]
     fact = repo.get_fact("local", job_url)
 
@@ -161,8 +180,12 @@ def test_source_text_is_bounded_in_persistence(conn: sqlite3.Connection) -> None
     repo.backfill_from_legacy_jobs()
     fact = repo.get_fact("local", job_url)
     row = conn.execute(
-        "SELECT warnings_json, source_text FROM job_posted_compensation_facts WHERE job_url = ?",
-        (job_url,),
+        """
+        SELECT warnings_json, source_text
+        FROM job_posted_compensation_facts
+        WHERE tenant_id = 'local' AND job_id = ?
+        """,
+        (_stable_job_id(conn, job_url),),
     ).fetchone()
 
     assert fact is not None

--- a/workers/automation/tests/test_preparation_identity_reference_migration.py
+++ b/workers/automation/tests/test_preparation_identity_reference_migration.py
@@ -177,7 +177,7 @@ def test_v9_preparation_references_migrate_to_stable_job_ids_and_reopen(
     init_db(db_path)
     close_connection(db_path)
 
-    assert _user_version(db_path) == SCHEMA_VERSION == 18
+    assert _user_version(db_path) == SCHEMA_VERSION == 19
     check = sqlite3.connect(db_path)
     try:
         rows = check.execute(

--- a/workers/automation/tests/test_repeat_application_prevention.py
+++ b/workers/automation/tests/test_repeat_application_prevention.py
@@ -750,7 +750,7 @@ def test_schema_v5_migrates_additively_without_changing_application_facts(
         (PRIOR,),
     ).fetchall()
 
-    assert int(migrated.execute("PRAGMA user_version").fetchone()[0]) == SCHEMA_VERSION == 18
+    assert int(migrated.execute("PRAGMA user_version").fetchone()[0]) == SCHEMA_VERSION == 19
     assert [tuple(row) for row in after] == [tuple(row) for row in before]
     assert "metadata_json" in {
         str(row[1]) for row in migrated.execute("PRAGMA table_info(job_stage_states)").fetchall()

--- a/workers/automation/tests/test_resume_template_identity_reference_migration.py
+++ b/workers/automation/tests/test_resume_template_identity_reference_migration.py
@@ -254,7 +254,7 @@ def test_v16_template_references_migrate_aliases_and_uuid_urls(
     assert (
         reopened.execute("PRAGMA user_version").fetchone()[0]
         == SCHEMA_VERSION
-        == 18
+        == 19
     )
     for table in database_module._RESUME_TEMPLATE_REFERENCE_TABLES:
         assert "job_id" in _columns(reopened, table)

--- a/workers/automation/tests/test_scoring_identity_reference_migration.py
+++ b/workers/automation/tests/test_scoring_identity_reference_migration.py
@@ -338,7 +338,7 @@ def test_v11_scoring_references_migrate_alias_histories_and_reopen(
     assert (
         int(migrated.execute("PRAGMA user_version").fetchone()[0])
         == SCHEMA_VERSION
-        == 18
+        == 19
     )
     assert _columns(migrated, "job_scores") >= {"tenant_id", "job_id"}
     assert "job_url" not in _columns(migrated, "job_scores")
@@ -404,7 +404,7 @@ def test_v11_scoring_references_migrate_alias_histories_and_reopen(
     assert (
         int(reopened.execute("PRAGMA user_version").fetchone()[0])
         == SCHEMA_VERSION
-        == 18
+        == 19
     )
 
 
@@ -553,7 +553,7 @@ def test_scoring_migration_rolls_back_and_retries_after_verification_failure(
     assert (
         int(retried.execute("PRAGMA user_version").fetchone()[0])
         == SCHEMA_VERSION
-        == 18
+        == 19
     )
     assert [
         tuple(row)

--- a/workers/automation/tests/test_stable_job_identity_migration.py
+++ b/workers/automation/tests/test_stable_job_identity_migration.py
@@ -743,7 +743,7 @@ def test_v6_jobs_gain_stable_uuid_and_posting_url_alias_once(
     init_db(db_path)
     close_connection(db_path)
 
-    assert _user_version(db_path) == SCHEMA_VERSION == 18
+    assert _user_version(db_path) == SCHEMA_VERSION == 19
     first_ids = _identity_rows(db_path)
     assert [row[0] for row in first_ids] == ["local", "local"]
     for _tenant_id, job_id, _url in first_ids:


### PR DESCRIPTION
## Summary

- migrate posted compensation facts and market compensation estimates from URL-shaped ownership to tenant-scoped stable `JobId` references in schema v19
- preserve deterministic newest-record winner selection across posting aliases, runtime identity collisions, UUID-shaped URL ownership, tenant isolation, and transactional rollback/retry
- update Python repositories, projection compatibility, TypeScript readers, and permanent deletion while retaining bounded legacy URL-table support
- record compatibility events against the canonical storage URL even when writes arrive through a posting alias or stable JobId, preserving the pre-Phase-4 `job_events.job_url` foreign key

## Migration guarantees

- rebuild and validate both compensation authorities inside one savepoint before stamping v19
- verify primary keys, composite cascade foreign keys, indexes, UUID validity, orphan absence, canonical row counts, and global `foreign_key_check`
- recognize and validate an already-stable layout during migration replay
- merge live identity collisions using newest timestamps with deterministic survivor tie-breaks
- explicitly purge both tables when permanent deletion runs with SQLite foreign keys disabled

## Validation

- full Python suite: `2705 passed, 2 skipped`
- full API suite: `677 passed`
- focused compensation repository/projection/migration suite: `51 passed`
- focused TypeScript compensation/schema/projection suite: `64 passed`
- TypeScript API check: passed
- Ruff: passed
- `git diff --check`: passed
- independent review: `PASS` — Blocker 0, High 0, Medium 0, Low 0
- independent Tier-3 QA: `PASS` — Blocker 0, High 0, Medium 0, Low 0

## Stack

- base: #544
- canonical product docs and cumulative end-to-end QA remain deferred to the final PR of the approved unreleased stack