### PR TITLE
feat(apply): migrate review decisions to stable JobIds

### DIFF
--- a/apps/api/src/application-feedback.ts
+++ b/apps/api/src/application-feedback.ts
@@ -51,6 +51,7 @@ import {
   jobReferenceColumn,
   jobReferenceJoinToJobs,
   jobReferencePredicateForUrl,
+  stableJobIdForUrl,
   tableExists,
   type SqliteDatabase,
   type SqliteValue,
@@ -65,6 +66,7 @@ import { InputError, resolveJobUrl } from "./write-model.js";
 
 const DEFAULT_TENANT = "local";
 const DEFAULT_PROFILE_ID = "default";
+const APPLICATION_REVIEW_REFERENCE_SCHEMA_VERSION = 20;
 const CLOSED_ACTIVE_STATES = ["closed", "expired", "removed", "location_incompatible"];
 const POSITION_PREVIEW_CHAR_LIMIT = 6000;
 const MATERIAL_PREVIEW_CHAR_LIMIT = 4000;
@@ -151,12 +153,48 @@ interface SuggestionRow extends Record<string, unknown> {
   decided_outcome_id: string | null;
 }
 
+type ApplicationReviewReferenceColumn = "job_id" | "job_key";
+
+function applicationReviewReferenceColumn(
+  db: SqliteDatabase,
+): ApplicationReviewReferenceColumn {
+  const columns = tableColumnSet(db, "application_review_decisions");
+  return columns.has("job_id") ? "job_id" : "job_key";
+}
+
+function applicationReviewReferenceForUrl(
+  db: SqliteDatabase,
+  jobUrl: string,
+): string {
+  if (applicationReviewReferenceColumn(db) === "job_key") {
+    return jobUrl;
+  }
+  const jobId = stableJobIdForUrl(db, jobUrl, DEFAULT_TENANT);
+  if (!jobId) {
+    throw new InputError(`No stable Job identity for ${jobUrl}.`);
+  }
+  return jobId;
+}
+
 export function ensureApplicationFeedbackTables(db: SqliteDatabase): void {
+  const schemaVersion = db.pragma("user_version", {
+    simple: true,
+  }) as number;
+  const stableReviewSchema =
+    schemaVersion >= APPLICATION_REVIEW_REFERENCE_SCHEMA_VERSION;
+  const createdReviewReference = stableReviewSchema
+    ? "job_id"
+    : "job_key";
+  const reviewForeignKey = stableReviewSchema
+    ? `,
+      FOREIGN KEY (tenant_id, job_id)
+        REFERENCES jobs(tenant_id, job_id) ON DELETE CASCADE`
+    : "";
   db.exec(`
     CREATE TABLE IF NOT EXISTS application_review_decisions (
       tenant_id    TEXT NOT NULL DEFAULT 'local',
       decision_id  TEXT NOT NULL,
-      job_key      TEXT NOT NULL,
+      ${createdReviewReference} TEXT NOT NULL,
       decision     TEXT NOT NULL,
       reason       TEXT,
       decided_by   TEXT NOT NULL DEFAULT 'user',
@@ -168,9 +206,8 @@ export function ensureApplicationFeedbackTables(db: SqliteDatabase): void {
       email_recipient TEXT,
       email_attachment_artifact_id TEXT,
       PRIMARY KEY (tenant_id, decision_id)
+      ${reviewForeignKey}
     );
-    CREATE INDEX IF NOT EXISTS idx_application_review_decisions_job
-      ON application_review_decisions(tenant_id, job_key, decided_at DESC);
 
     CREATE TABLE IF NOT EXISTS application_outcomes (
       tenant_id     TEXT NOT NULL DEFAULT 'local',
@@ -235,6 +272,15 @@ export function ensureApplicationFeedbackTables(db: SqliteDatabase): void {
       ON application_outcome_suggestions(tenant_id, status, created_at DESC);
   `);
   ensureApplicationReviewDecisionColumns(db);
+  const reviewReference = applicationReviewReferenceColumn(db);
+  db.exec(`
+    CREATE INDEX IF NOT EXISTS idx_application_review_decisions_job
+      ON application_review_decisions(
+        tenant_id,
+        ${reviewReference},
+        decided_at DESC
+      );
+  `);
   ensureApplicationOutcomeColumns(db);
   ensureRepeatApplicationTables(db);
 }
@@ -341,6 +387,16 @@ export function listApplyReviewQueue(db: SqliteDatabase): ApplyReviewQueueRespon
     db,
     "job_stage_states",
   ) === "job_id";
+  const reviewReference = applicationReviewReferenceColumn(db);
+  const stableReviewReferences = reviewReference === "job_id";
+  const reviewJobKeySelect = stableReviewReferences
+    ? "review_jobs.url"
+    : "review_decisions.job_key";
+  const reviewJobsJoin = stableReviewReferences
+    ? `JOIN jobs review_jobs
+         ON review_jobs.tenant_id = review_decisions.tenant_id
+        AND review_jobs.job_id = review_decisions.job_id`
+    : "";
   const rows = allRows<ReviewQueueRow>(
     db,
     `
@@ -349,15 +405,25 @@ export function listApplyReviewQueue(db: SqliteDatabase): ApplyReviewQueueRespon
              materials_generation, profile_version, application_url,
              partial_override_run_id, email_recipient, email_attachment_artifact_id
       FROM (
-        SELECT decision_id, job_key, decision, decided_at,
-               materials_generation, profile_version, application_url,
-               partial_override_run_id, email_recipient, email_attachment_artifact_id,
+        SELECT review_decisions.decision_id,
+               ${reviewJobKeySelect} AS job_key,
+               review_decisions.decision,
+               review_decisions.decided_at,
+               review_decisions.materials_generation,
+               review_decisions.profile_version,
+               review_decisions.application_url,
+               review_decisions.partial_override_run_id,
+               review_decisions.email_recipient,
+               review_decisions.email_attachment_artifact_id,
                ROW_NUMBER() OVER (
-                 PARTITION BY tenant_id, job_key
-                 ORDER BY decided_at DESC, decision_id DESC
+                 PARTITION BY review_decisions.tenant_id,
+                              review_decisions.${reviewReference}
+                 ORDER BY review_decisions.decided_at DESC,
+                          review_decisions.decision_id DESC
                ) AS row_num
-        FROM application_review_decisions
-        WHERE tenant_id = ?
+        FROM application_review_decisions review_decisions
+        ${reviewJobsJoin}
+        WHERE review_decisions.tenant_id = ?
       )
       WHERE row_num = 1
     ),
@@ -549,17 +615,22 @@ export function recordApplyReviewDecision(
     emailRecipient: emailCandidate?.recipient ?? null,
     emailAttachmentArtifactId: emailCandidate?.attachmentArtifactId ?? null,
   };
+  const reviewReference = applicationReviewReferenceColumn(db);
+  const storedJobReference = applicationReviewReferenceForUrl(
+    db,
+    jobUrl,
+  );
 
   db.prepare(
     `INSERT INTO application_review_decisions (
-       tenant_id, decision_id, job_key, decision, reason, decided_by, decided_at,
+       tenant_id, decision_id, ${reviewReference}, decision, reason, decided_by, decided_at,
        materials_generation, profile_version, application_url, partial_override_run_id,
        email_recipient, email_attachment_artifact_id
      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   ).run(
     DEFAULT_TENANT,
     decision.decisionId,
-    decision.jobKey,
+    storedJobReference,
     decision.decision,
     decision.reason,
     decision.decidedBy,

--- a/apps/api/src/db.ts
+++ b/apps/api/src/db.ts
@@ -9,7 +9,7 @@ export type SqliteValue = string | number | bigint | null;
 // writer that stamps ``PRAGMA user_version``; the API only reads it to fail
 // closed on a database written by a newer build. Bump both constants together
 // whenever the schema shape changes.
-export const SUPPORTED_SCHEMA_VERSION = 19;
+export const SUPPORTED_SCHEMA_VERSION = 20;
 
 export class IncompatibleSchemaVersionError extends Error {
   constructor(current: number) {

--- a/apps/api/src/read-model.ts
+++ b/apps/api/src/read-model.ts
@@ -1503,12 +1503,26 @@ function appendReviewDecisionAuditEntries(
   seenReferences: Set<string>,
 ): void {
   if (!tableExists(db, "application_review_decisions")) return;
+  const stableReferences = tableColumnSet(
+    db,
+    "application_review_decisions",
+  ).has("job_id");
+  const jobJoin = stableReferences
+    ? `JOIN jobs review_jobs
+         ON review_jobs.tenant_id = decisions.tenant_id
+        AND review_jobs.job_id = decisions.job_id`
+    : "";
+  const jobPredicate = stableReferences
+    ? "review_jobs.url = ?"
+    : "decisions.job_key = ?";
   const rows = allRows<ApplicationReviewDecisionAuditRow>(
     db,
     `SELECT decision_id, decision, reason, decided_by, decided_at
-       FROM application_review_decisions
-      WHERE tenant_id = ? AND job_key = ?
-      ORDER BY decided_at ASC, decision_id ASC`,
+       FROM application_review_decisions decisions
+       ${jobJoin}
+      WHERE decisions.tenant_id = ?
+        AND ${jobPredicate}
+      ORDER BY decisions.decided_at ASC, decisions.decision_id ASC`,
     [DEFAULT_TENANT, jobId],
   );
   for (const row of rows) {

--- a/apps/api/src/write-model.ts
+++ b/apps/api/src/write-model.ts
@@ -29,6 +29,7 @@ import {
   jobReferenceColumn,
   jobReferenceForUrl,
   jobReferencePredicateForUrl,
+  tableColumnSet,
   tableExists,
   type SqliteDatabase,
   type SqliteValue,
@@ -850,6 +851,11 @@ function purgeJobRows(db: SqliteDatabase, jobUrl: string): void {
     }
   }
   deleteWhere(db, "job_events", "job_url = ?", [jobUrl]);
+  deleteApplicationReviewDecisionReferences(
+    db,
+    jobId,
+    jobUrl,
+  );
   deleteJobReferences(db, "job_artifacts", jobId, jobUrl);
   deleteScoringJobReferences(db, jobId, jobUrl);
   for (const tableName of [
@@ -1015,6 +1021,34 @@ function deleteScoringJobReferences(
     if (!reference) continue;
     deleteWhere(db, tableName, `${referenceColumn} = ?`, [reference]);
   }
+}
+
+function deleteApplicationReviewDecisionReferences(
+  db: SqliteDatabase,
+  jobId: string | undefined,
+  jobUrl: string,
+): void {
+  if (!tableExists(db, "application_review_decisions")) return;
+  const stableReferences = tableColumnSet(
+    db,
+    "application_review_decisions",
+  ).has("job_id");
+  if (stableReferences) {
+    if (!jobId) return;
+    deleteWhere(
+      db,
+      "application_review_decisions",
+      "tenant_id = ? AND job_id = ?",
+      ["local", jobId],
+    );
+    return;
+  }
+  deleteWhere(
+    db,
+    "application_review_decisions",
+    "tenant_id = ? AND job_key = ?",
+    ["local", jobUrl],
+  );
 }
 
 function deleteJobReferences(

--- a/apps/api/test/application-feedback.test.ts
+++ b/apps/api/test/application-feedback.test.ts
@@ -8,6 +8,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   ensureApplicationFeedbackTables,
   listApplyReviewQueue,
+  recordApplyReviewDecision,
 } from "../src/application-feedback.js";
 import type { ApplyReviewQueueResponse } from "../src/contracts.js";
 import { GmailFeedbackScanError, type GmailFeedbackScanner } from "../src/gmail-feedback-worker.js";
@@ -44,6 +45,78 @@ afterEach(() => {
 });
 
 describe("application feedback API", () => {
+  it("reads stable JobId review decisions through URL-shaped projections", () => {
+    const db = new Database(options.dbPath);
+    ensureApplicationFeedbackTables(db);
+    db.exec(`
+      ALTER TABLE jobs
+        ADD COLUMN tenant_id TEXT NOT NULL DEFAULT 'local';
+      ALTER TABLE jobs
+        ADD COLUMN job_id TEXT;
+      UPDATE jobs
+      SET job_id = CASE url
+        WHEN '${READY_JOB}' THEN '11111111-1111-4111-8111-111111111111'
+        WHEN '${DRY_RUN_JOB}' THEN '22222222-2222-4222-8222-222222222222'
+        WHEN '${APPLIED_JOB}' THEN '33333333-3333-4333-8333-333333333333'
+        ELSE printf(
+          '44444444-4444-4444-8444-%012d',
+          rowid
+        )
+      END;
+      CREATE UNIQUE INDEX idx_jobs_tenant_job_id
+        ON jobs(tenant_id, job_id);
+      DROP TABLE application_review_decisions;
+      CREATE TABLE application_review_decisions (
+        tenant_id                    TEXT NOT NULL DEFAULT 'local',
+        decision_id                  TEXT NOT NULL,
+        job_id                       TEXT NOT NULL,
+        decision                     TEXT NOT NULL,
+        reason                       TEXT,
+        decided_by                   TEXT DEFAULT 'user',
+        decided_at                   TEXT NOT NULL,
+        materials_generation         INTEGER,
+        profile_version              INTEGER,
+        application_url              TEXT,
+        partial_override_run_id      TEXT,
+        email_recipient              TEXT,
+        email_attachment_artifact_id TEXT,
+        PRIMARY KEY (tenant_id, decision_id),
+        FOREIGN KEY (tenant_id, job_id)
+          REFERENCES jobs(tenant_id, job_id) ON DELETE CASCADE
+      );
+      CREATE INDEX idx_application_review_decisions_job
+        ON application_review_decisions(
+          tenant_id,
+          job_id,
+          decided_at DESC
+        );
+    `);
+
+    expect(
+      recordApplyReviewDecision(
+        db,
+        READY_JOB,
+        {
+          decision: "approve_dry_run",
+          reason: "Validate safely first.",
+          decidedBy: "user",
+        },
+      ).decision,
+    ).toMatchObject({
+      jobKey: READY_JOB,
+      decision: "approve_dry_run",
+    });
+    expect(
+      queueItem(listApplyReviewQueue(db), READY_JOB),
+    ).toMatchObject({
+      review: {
+        state: "approved_dry_run",
+        decision: "approve_dry_run",
+      },
+    });
+    db.close();
+  });
+
   it("lists only apply-review eligible jobs with readiness and latest run context", async () => {
     const app = buildApp(options);
 

--- a/apps/api/test/application-review-v20.test.ts
+++ b/apps/api/test/application-review-v20.test.ts
@@ -1,0 +1,176 @@
+import Database from "better-sqlite3";
+import { describe, expect, it } from "vitest";
+
+import {
+  ensureApplicationFeedbackTables,
+  recordApplyReviewDecision,
+} from "../src/application-feedback.js";
+import { permanentlyDeleteJob } from "../src/write-model.js";
+
+const UUID_SHAPED_URL = "11111111-1111-4111-8111-111111111111";
+const URL_OWNER_JOB_ID = "22222222-2222-4222-8222-222222222222";
+const ID_TEXT_OWNER_URL = "https://example.com/jobs/id-text-owner";
+const OTHER_TENANT_URL = "https://example.com/jobs/other-tenant-review";
+
+function createSchema(db: Database.Database): void {
+  db.pragma("foreign_keys = OFF");
+  expect(db.pragma("foreign_keys", { simple: true })).toBe(0);
+  db.pragma("user_version = 20");
+  db.exec(`
+    CREATE TABLE jobs (
+      url TEXT PRIMARY KEY,
+      tenant_id TEXT NOT NULL DEFAULT 'local',
+      job_id TEXT NOT NULL,
+      title TEXT,
+      application_url TEXT,
+      tailored_resume_path TEXT,
+      cover_letter_path TEXT,
+      UNIQUE (tenant_id, job_id)
+    );
+    CREATE TABLE application_review_decisions (
+      tenant_id                    TEXT NOT NULL DEFAULT 'local',
+      decision_id                  TEXT NOT NULL,
+      job_id                       TEXT NOT NULL,
+      decision                     TEXT NOT NULL,
+      reason                       TEXT,
+      decided_by                   TEXT DEFAULT 'user',
+      decided_at                   TEXT NOT NULL,
+      materials_generation         INTEGER,
+      profile_version              INTEGER,
+      application_url              TEXT,
+      partial_override_run_id      TEXT,
+      email_recipient              TEXT,
+      email_attachment_artifact_id TEXT,
+      PRIMARY KEY (tenant_id, decision_id),
+      FOREIGN KEY (tenant_id, job_id)
+        REFERENCES jobs(tenant_id, job_id) ON DELETE CASCADE
+    );
+    CREATE INDEX idx_application_review_decisions_job
+      ON application_review_decisions(
+        tenant_id,
+        job_id,
+        decided_at DESC
+      );
+  `);
+}
+
+function seedCollisionGraph(db: Database.Database): void {
+  const insert = db.prepare(
+    `INSERT INTO jobs (
+       url, tenant_id, job_id, title, application_url
+     ) VALUES (?, ?, ?, 'Platform Engineer', NULL)`,
+  );
+  insert.run(UUID_SHAPED_URL, "local", URL_OWNER_JOB_ID);
+  insert.run(ID_TEXT_OWNER_URL, "local", UUID_SHAPED_URL);
+  insert.run(OTHER_TENANT_URL, "tenant-b", URL_OWNER_JOB_ID);
+}
+
+function seedDecision(
+  db: Database.Database,
+  input: {
+    tenantId: string;
+    decisionId: string;
+    jobId: string;
+  },
+): void {
+  db.prepare(
+    `INSERT INTO application_review_decisions (
+       tenant_id, decision_id, job_id, decision, reason, decided_by,
+       decided_at
+     ) VALUES (?, ?, ?, 'defer', NULL, 'user', ?)`,
+  ).run(
+    input.tenantId,
+    input.decisionId,
+    input.jobId,
+    "2026-07-30T10:00:00.000Z",
+  );
+}
+
+describe("schema-v20 Apply Review API compatibility", () => {
+  it("writes a UUID-shaped posting URL under its URL owner's JobId", () => {
+    const db = new Database(":memory:");
+    createSchema(db);
+    seedCollisionGraph(db);
+    db.exec("DROP TABLE application_review_decisions");
+    ensureApplicationFeedbackTables(db);
+
+    const result = recordApplyReviewDecision(
+      db,
+      UUID_SHAPED_URL,
+      {
+        decision: "defer",
+        reason: "Review later.",
+        decidedBy: "user",
+      },
+    );
+
+    expect(result.decision).toMatchObject({
+      jobKey: UUID_SHAPED_URL,
+      decision: "defer",
+    });
+    expect(
+      db.prepare(
+        `SELECT tenant_id, job_id, decision
+           FROM application_review_decisions`,
+      ).get(),
+    ).toEqual({
+      tenant_id: "local",
+      job_id: URL_OWNER_JOB_ID,
+      decision: "defer",
+    });
+    db.close();
+  });
+
+  it("deletes only the URL owner's review history with cascades off", () => {
+    const db = new Database(":memory:");
+    createSchema(db);
+    seedCollisionGraph(db);
+    seedDecision(db, {
+      tenantId: "local",
+      decisionId: "url-owner",
+      jobId: URL_OWNER_JOB_ID,
+    });
+    seedDecision(db, {
+      tenantId: "local",
+      decisionId: "id-owner",
+      jobId: UUID_SHAPED_URL,
+    });
+    seedDecision(db, {
+      tenantId: "tenant-b",
+      decisionId: "other-tenant",
+      jobId: URL_OWNER_JOB_ID,
+    });
+
+    expect(permanentlyDeleteJob(db, UUID_SHAPED_URL)).toEqual({
+      ok: true,
+      count: 1,
+      jobKeys: [UUID_SHAPED_URL],
+    });
+    expect(
+      db.prepare(
+        `SELECT tenant_id, decision_id, job_id
+           FROM application_review_decisions
+          ORDER BY tenant_id, decision_id`,
+      ).all(),
+    ).toEqual([
+      {
+        tenant_id: "local",
+        decision_id: "id-owner",
+        job_id: UUID_SHAPED_URL,
+      },
+      {
+        tenant_id: "tenant-b",
+        decision_id: "other-tenant",
+        job_id: URL_OWNER_JOB_ID,
+      },
+    ]);
+    expect(
+      db.prepare("SELECT url FROM jobs ORDER BY url").all(),
+    ).toEqual([
+      { url: ID_TEXT_OWNER_URL },
+      { url: OTHER_TENANT_URL },
+    ]);
+    expect(db.pragma("foreign_key_check")).toEqual([]);
+    db.close();
+  });
+});

--- a/apps/api/test/schema-version-guard.test.ts
+++ b/apps/api/test/schema-version-guard.test.ts
@@ -63,7 +63,7 @@ describe("schema version guard at DB open", () => {
   });
 
   it("opens the worker-owned schema-v14 artifact registry", () => {
-    expect(SUPPORTED_SCHEMA_VERSION).toBe(19);
+    expect(SUPPORTED_SCHEMA_VERSION).toBe(20);
     const { dbPath, cleanup } = makeDbWithUserVersion(14);
     try {
       openDatabase(dbPath).close();

--- a/workers/automation/src/jobctrl/apply/launcher.py
+++ b/workers/automation/src/jobctrl/apply/launcher.py
@@ -79,6 +79,8 @@ from jobctrl.database import (
     _SCORE_DOWNSTREAM_STATE_JOIN,
     _SCORE_CURRENT_FOR_DOWNSTREAM,
     _SCORE_ELIGIBLE_FOR_DOWNSTREAM,
+    _resolve_job_reference_value,
+    _table_columns,
     _order_rows_by_feedback,
     ensure_application_review_decision_columns,
     get_connection,
@@ -171,16 +173,32 @@ def _attempt_count_for(conn, url: str) -> int:
 
 def _latest_apply_review_decision(conn, *, tenant_id: str, job_key: str) -> dict[str, Any] | None:
     ensure_application_review_decision_columns(conn)
+    stable_references = (
+        "job_id"
+        in _table_columns(conn, "application_review_decisions")
+    )
+    reference_column = "job_id" if stable_references else "job_key"
+    reference = job_key
+    if stable_references:
+        resolved = _resolve_job_reference_value(
+            conn,
+            tenant_id=tenant_id,
+            reference=job_key,
+            legacy_url=True,
+        )
+        if resolved is None:
+            return None
+        reference = resolved
     row = conn.execute(
-        """
+        f"""
         SELECT decision, materials_generation, profile_version, application_url,
                partial_override_run_id, email_recipient, email_attachment_artifact_id
         FROM application_review_decisions
-        WHERE tenant_id = ? AND job_key = ?
+        WHERE tenant_id = ? AND {reference_column} = ?
         ORDER BY decided_at DESC, decision_id DESC
         LIMIT 1
         """,
-        (tenant_id, job_key),
+        (tenant_id, reference),
     ).fetchone()
     if row is None:
         return None

--- a/workers/automation/src/jobctrl/database.py
+++ b/workers/automation/src/jobctrl/database.py
@@ -74,7 +74,10 @@ from jobctrl.config import DB_PATH, DEFAULTS, migrate_legacy_job_tables
 # v19 (compensation references): canonical posted compensation facts and market
 # estimates reference the stable Job aggregate. Alias collisions keep the
 # newest recorded fact/estimate with a deterministic survivor tie-break.
-SCHEMA_VERSION = 19
+# v20 (application-review references): every append-only Apply Review decision
+# references the tenant-scoped stable Job aggregate. URL aliases, including
+# UUID-shaped posting URLs, are resolved URL-first without collapsing history.
+SCHEMA_VERSION = 20
 
 
 class IncompatibleSchemaVersionError(RuntimeError):
@@ -224,6 +227,7 @@ def _schema_migrations() -> tuple[
         (17, ensure_resume_template_references_v17),
         (18, ensure_interview_prep_references_v18),
         (19, ensure_compensation_references_v19),
+        (20, ensure_application_review_references_v20),
     )
 
 
@@ -351,28 +355,48 @@ def init_db(db_path: Path | str | None = None) -> sqlite3.Connection:
     ensure_posted_compensation_tables(conn)
     ensure_market_compensation_tables(conn)
     ensure_state_tables(conn)
-    conn.execute("""
-        CREATE TABLE IF NOT EXISTS application_review_decisions (
-            tenant_id           TEXT NOT NULL DEFAULT 'local',
-            decision_id         TEXT PRIMARY KEY,
-            job_key             TEXT NOT NULL,
-            decision            TEXT NOT NULL,
-            reason              TEXT,
-            decided_by          TEXT,
-            decided_at          TEXT NOT NULL,
-            materials_generation INTEGER,
-            profile_version     INTEGER,
-            application_url     TEXT,
-            partial_override_run_id TEXT,
-            email_recipient TEXT,
-            email_attachment_artifact_id TEXT
-        )
-    """)
+    if current_version >= _APPLICATION_REVIEW_REFERENCE_SCHEMA_VERSION:
+        if not _table_columns(conn, "application_review_decisions"):
+            _create_application_review_reference_table_v20(
+                conn,
+                table="application_review_decisions",
+            )
+    else:
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS application_review_decisions (
+                tenant_id           TEXT NOT NULL DEFAULT 'local',
+                decision_id         TEXT PRIMARY KEY,
+                job_key             TEXT NOT NULL,
+                decision            TEXT NOT NULL,
+                reason              TEXT,
+                decided_by          TEXT,
+                decided_at          TEXT NOT NULL,
+                materials_generation INTEGER,
+                profile_version     INTEGER,
+                application_url     TEXT,
+                partial_override_run_id TEXT,
+                email_recipient TEXT,
+                email_attachment_artifact_id TEXT
+            )
+        """)
     ensure_application_review_decision_columns(conn)
+    application_review_columns = _table_columns(
+        conn,
+        "application_review_decisions",
+    )
+    application_review_reference = (
+        "job_id"
+        if "job_id" in application_review_columns
+        else "job_key"
+    )
     conn.execute("""
         CREATE INDEX IF NOT EXISTS idx_application_review_decisions_job
-        ON application_review_decisions(tenant_id, job_key, decided_at DESC)
-    """)
+        ON application_review_decisions(
+            tenant_id,
+            %s,
+            decided_at DESC
+        )
+    """ % application_review_reference)
     ensure_profile_tables(conn)
     ensure_score_tables(conn)
     ensure_tailoring_policy_tables(conn)
@@ -4630,6 +4654,13 @@ def _reassign_discovery_identity_references(
         )
     if _has_compensation_reference_schema_v19(conn):
         _reassign_compensation_references_v19(
+            conn,
+            tenant_id=tenant_id,
+            losing_job_id=losing_job_id,
+            surviving_job_id=surviving_job_id,
+        )
+    if _has_application_review_reference_schema_v20(conn):
+        _reassign_application_review_references_v20(
             conn,
             tenant_id=tenant_id,
             losing_job_id=losing_job_id,
@@ -12452,6 +12483,277 @@ def _reassign_compensation_references_v19(
     _verify_compensation_references_v19(
         conn,
         expected_counts=expected_counts,
+    )
+
+
+_APPLICATION_REVIEW_REFERENCE_SCHEMA_VERSION = 20
+_APPLICATION_REVIEW_REFERENCE_TABLE = "application_review_decisions"
+
+
+def _create_application_review_reference_table_v20(
+    conn: sqlite3.Connection,
+    *,
+    table: str,
+) -> None:
+    conn.execute(
+        f"""
+        CREATE TABLE "{table}" (
+            tenant_id                   TEXT NOT NULL DEFAULT 'local',
+            decision_id                 TEXT NOT NULL,
+            job_id                      TEXT NOT NULL,
+            decision                    TEXT NOT NULL,
+            reason                      TEXT,
+            decided_by                  TEXT DEFAULT 'user',
+            decided_at                  TEXT NOT NULL,
+            materials_generation        INTEGER,
+            profile_version             INTEGER,
+            application_url             TEXT,
+            partial_override_run_id     TEXT,
+            email_recipient             TEXT,
+            email_attachment_artifact_id TEXT,
+            PRIMARY KEY (tenant_id, decision_id),
+            FOREIGN KEY (tenant_id, job_id)
+                REFERENCES jobs(tenant_id, job_id) ON DELETE CASCADE
+        )
+        """
+    )
+
+
+def _create_application_review_reference_index_v20(
+    conn: sqlite3.Connection,
+) -> None:
+    conn.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_application_review_decisions_job
+        ON application_review_decisions(
+            tenant_id,
+            job_id,
+            decided_at DESC
+        )
+        """
+    )
+
+
+def _has_application_review_reference_schema_v20(
+    conn: sqlite3.Connection,
+) -> bool:
+    table = _APPLICATION_REVIEW_REFERENCE_TABLE
+    return (
+        "job_id" in _table_columns(conn, table)
+        and "job_key" not in _table_columns(conn, table)
+        and _primary_key_columns(conn, table)
+        == ("tenant_id", "decision_id")
+        and _has_composite_job_id_foreign_key(
+            conn,
+            table,
+            "job_id",
+        )
+        and _has_index(
+            conn,
+            table,
+            "idx_application_review_decisions_job",
+            ("tenant_id", "job_id", "decided_at"),
+            unique=False,
+        )
+    )
+
+
+def _canonical_application_review_rows_v20(
+    conn: sqlite3.Connection,
+) -> tuple[tuple[str, ...], list[tuple[Any, ...]]]:
+    table = _APPLICATION_REVIEW_REFERENCE_TABLE
+    columns = tuple(
+        str(row[1])
+        for row in conn.execute(
+            f'PRAGMA table_info("{table}")'
+        ).fetchall()
+        if str(row[1]) not in {"tenant_id", "job_key"}
+    )
+    select_columns = ", ".join(f'"{column}"' for column in columns)
+    rows = conn.execute(
+        f"""
+        SELECT tenant_id, job_key, {select_columns}
+        FROM "{table}"
+        ORDER BY tenant_id, decision_id
+        """
+    ).fetchall()
+    canonical: list[tuple[Any, ...]] = []
+    for row in rows:
+        tenant_id = str(row[0])
+        legacy_job_key = str(row[1])
+        stable_job_id = _resolve_job_reference_value(
+            conn,
+            tenant_id=tenant_id,
+            reference=legacy_job_key,
+            legacy_url=True,
+        )
+        if stable_job_id is None:
+            raise RuntimeError(
+                "application-review reference migration could not resolve "
+                f"application_review_decisions.job_key={legacy_job_key!r}"
+            )
+        _validate_job_uuid(stable_job_id)
+        canonical.append((tenant_id, stable_job_id, *tuple(row[2:])))
+    return columns, canonical
+
+
+def ensure_application_review_references_v20(
+    conn: sqlite3.Connection | None = None,
+) -> list[str]:
+    """Move append-only Apply Review decisions to stable JobIds."""
+    if conn is None:
+        conn = get_connection()
+
+    current = _assert_schema_version_supported(conn)
+    if current >= _APPLICATION_REVIEW_REFERENCE_SCHEMA_VERSION:
+        return []
+    if current != _COMPENSATION_REFERENCE_SCHEMA_VERSION:
+        raise RuntimeError(
+            "application-review reference migration requires compensation "
+            "schema v19"
+        )
+
+    conn.execute("SAVEPOINT application_review_references_v20")
+    try:
+        if not _has_compensation_reference_schema_v19(conn):
+            raise RuntimeError(
+                "application-review reference migration requires the stable "
+                "compensation reference schema"
+            )
+        if _has_application_review_reference_schema_v20(conn):
+            expected_count = int(
+                conn.execute(
+                    "SELECT COUNT(*) "
+                    "FROM application_review_decisions"
+                ).fetchone()[0]
+            )
+        else:
+            columns, rows = _canonical_application_review_rows_v20(conn)
+            conn.execute(
+                "DROP TABLE IF EXISTS application_review_decisions_v20"
+            )
+            _create_application_review_reference_table_v20(
+                conn,
+                table="application_review_decisions_v20",
+            )
+            insert_columns = (
+                "tenant_id, job_id, "
+                + ", ".join(f'"{column}"' for column in columns)
+            )
+            placeholders = ", ".join(
+                "?" for _ in range(len(columns) + 2)
+            )
+            conn.executemany(
+                "INSERT INTO application_review_decisions_v20 "
+                f"({insert_columns}) VALUES ({placeholders})",
+                rows,
+            )
+            conn.execute('DROP TABLE "application_review_decisions"')
+            conn.execute(
+                'ALTER TABLE "application_review_decisions_v20" '
+                'RENAME TO "application_review_decisions"'
+            )
+            _create_application_review_reference_index_v20(conn)
+            expected_count = len(rows)
+        _verify_application_review_references_v20(
+            conn,
+            expected_count=expected_count,
+        )
+        conn.execute(
+            f"PRAGMA user_version = "
+            f"{_APPLICATION_REVIEW_REFERENCE_SCHEMA_VERSION}"
+        )
+        conn.execute(
+            "RELEASE SAVEPOINT application_review_references_v20"
+        )
+        conn.commit()
+    except BaseException:
+        conn.execute(
+            "ROLLBACK TO SAVEPOINT application_review_references_v20"
+        )
+        conn.execute(
+            "RELEASE SAVEPOINT application_review_references_v20"
+        )
+        raise
+
+    return [_APPLICATION_REVIEW_REFERENCE_TABLE]
+
+
+def _verify_application_review_references_v20(
+    conn: sqlite3.Connection,
+    *,
+    expected_count: int,
+) -> None:
+    if not _has_application_review_reference_schema_v20(conn):
+        raise RuntimeError(
+            "application-review reference migration did not create the "
+            "stable reference schema"
+        )
+    observed_count = int(
+        conn.execute(
+            "SELECT COUNT(*) FROM application_review_decisions"
+        ).fetchone()[0]
+    )
+    if observed_count != expected_count:
+        raise RuntimeError(
+            "application-review reference migration changed append-only "
+            f"history count: expected {expected_count}, "
+            f"found {observed_count}"
+        )
+    orphan = conn.execute(
+        """
+        SELECT decisions.job_id
+        FROM application_review_decisions AS decisions
+        LEFT JOIN jobs
+          ON jobs.tenant_id = decisions.tenant_id
+         AND jobs.job_id = decisions.job_id
+        WHERE jobs.job_id IS NULL
+        LIMIT 1
+        """
+    ).fetchone()
+    if orphan is not None:
+        raise RuntimeError(
+            "application-review reference migration left an unresolved JobId"
+        )
+    for row in conn.execute(
+        "SELECT DISTINCT job_id FROM application_review_decisions"
+    ).fetchall():
+        _validate_job_uuid(str(row[0]))
+    foreign_key_error = conn.execute(
+        "PRAGMA foreign_key_check"
+    ).fetchone()
+    if foreign_key_error is not None:
+        raise RuntimeError(
+            "application-review reference migration found a foreign-key "
+            "violation"
+        )
+
+
+def _reassign_application_review_references_v20(
+    conn: sqlite3.Connection,
+    *,
+    tenant_id: str,
+    losing_job_id: str,
+    surviving_job_id: str,
+) -> None:
+    if losing_job_id == surviving_job_id:
+        return
+    expected_count = int(
+        conn.execute(
+            "SELECT COUNT(*) FROM application_review_decisions"
+        ).fetchone()[0]
+    )
+    conn.execute(
+        """
+        UPDATE application_review_decisions
+        SET job_id = ?
+        WHERE tenant_id = ? AND job_id = ?
+        """,
+        (surviving_job_id, tenant_id, losing_job_id),
+    )
+    _verify_application_review_references_v20(
+        conn,
+        expected_count=expected_count,
     )
 
 

--- a/workers/automation/src/jobctrl/digest.py
+++ b/workers/automation/src/jobctrl/digest.py
@@ -593,6 +593,35 @@ def _latest_decision_cte(conn: sqlite3.Connection) -> tuple[str, list[Any]]:
             """,
             [],
         )
+    stable_references = (
+        "job_id"
+        in _table_columns(conn, "application_review_decisions")
+    )
+    if stable_references:
+        return (
+            """
+            WITH latest_digest_decision AS (
+                SELECT job_key, decision
+                FROM (
+                    SELECT jobs.url AS job_key,
+                           decisions.decision,
+                           ROW_NUMBER() OVER (
+                               PARTITION BY decisions.tenant_id,
+                                            decisions.job_id
+                               ORDER BY decisions.decided_at DESC,
+                                        decisions.decision_id DESC
+                           ) AS row_num
+                    FROM application_review_decisions decisions
+                    JOIN jobs
+                      ON jobs.tenant_id = decisions.tenant_id
+                     AND jobs.job_id = decisions.job_id
+                    WHERE decisions.tenant_id = ?
+                )
+                WHERE row_num = 1
+            )
+            """,
+            [TENANT_ID],
+        )
     return (
         """
         WITH latest_digest_decision AS (

--- a/workers/automation/src/jobctrl/infrastructure/gmail/feedback.py
+++ b/workers/automation/src/jobctrl/infrastructure/gmail/feedback.py
@@ -26,6 +26,7 @@ DEFAULT_WINDOW_DAYS = 45
 MAX_LIMIT = 100
 MAX_RESULTS_PER_ANCHOR = 20
 MAX_WINDOW_DAYS = 180
+APPLICATION_REVIEW_REFERENCE_SCHEMA_VERSION = 20
 
 _EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
 _TOKEN_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._+-]{1,64}")
@@ -247,12 +248,28 @@ def scan_gmail_feedback(
 def ensure_application_feedback_tables(conn: sqlite3.Connection) -> None:
     """Create the feedback tables with the TypeScript API's table shape."""
 
+    schema_version = int(
+        conn.execute("PRAGMA user_version").fetchone()[0]
+    )
+    stable_review_schema = (
+        schema_version >= APPLICATION_REVIEW_REFERENCE_SCHEMA_VERSION
+    )
+    created_review_reference = (
+        "job_id" if stable_review_schema else "job_key"
+    )
+    review_foreign_key = (
+        """,
+          FOREIGN KEY (tenant_id, job_id)
+            REFERENCES jobs(tenant_id, job_id) ON DELETE CASCADE"""
+        if stable_review_schema
+        else ""
+    )
     conn.executescript(
-        """
+        f"""
         CREATE TABLE IF NOT EXISTS application_review_decisions (
           tenant_id    TEXT NOT NULL DEFAULT 'local',
           decision_id  TEXT NOT NULL,
-          job_key      TEXT NOT NULL,
+          {created_review_reference} TEXT NOT NULL,
           decision     TEXT NOT NULL,
           reason       TEXT,
           decided_by   TEXT NOT NULL DEFAULT 'user',
@@ -264,9 +281,8 @@ def ensure_application_feedback_tables(conn: sqlite3.Connection) -> None:
           email_recipient TEXT,
           email_attachment_artifact_id TEXT,
           PRIMARY KEY (tenant_id, decision_id)
+          {review_foreign_key}
         );
-        CREATE INDEX IF NOT EXISTS idx_application_review_decisions_job
-          ON application_review_decisions(tenant_id, job_key, decided_at DESC);
 
         CREATE TABLE IF NOT EXISTS application_outcomes (
           tenant_id     TEXT NOT NULL DEFAULT 'local',
@@ -342,6 +358,22 @@ def ensure_application_feedback_tables(conn: sqlite3.Connection) -> None:
             "email_recipient": "TEXT",
             "email_attachment_artifact_id": "TEXT",
         },
+    )
+    review_reference = (
+        "job_id"
+        if "job_id" in _columns(conn, "application_review_decisions")
+        else "job_key"
+    )
+    conn.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_application_review_decisions_job
+        ON application_review_decisions(
+            tenant_id,
+            %s,
+            decided_at DESC
+        )
+        """
+        % review_reference
     )
 
 

--- a/workers/automation/tests/test_application_review_identity_reference_migration.py
+++ b/workers/automation/tests/test_application_review_identity_reference_migration.py
@@ -1,0 +1,464 @@
+"""Schema-v20 Apply Review JobId reference contracts."""
+
+from __future__ import annotations
+
+import sqlite3
+import uuid
+from pathlib import Path
+
+import pytest
+
+import jobctrl.database as database_module
+from jobctrl.database import (
+    SCHEMA_VERSION,
+    close_connection,
+    ensure_application_review_references_v20,
+    init_db,
+    reassign_discovery_identity_references,
+)
+from jobctrl.domain.discovery import (
+    Employer,
+    Job,
+    JobMetadata,
+    PostingUrl,
+    SearchStrategy,
+    Source,
+)
+from jobctrl.domain.identifiers import JobId
+from jobctrl.domain.tenant import LOCAL_TENANT
+from jobctrl.infrastructure.discovery import SqliteJobRepository
+
+
+PREVIOUS_SCHEMA_VERSION = 19
+
+
+def _discovered_job(posting_url: str, job_id: JobId) -> Job:
+    return Job.discover(
+        tenant_id=LOCAL_TENANT,
+        job_id=job_id,
+        posting_url=PostingUrl(value=posting_url),
+        source=Source(board="example"),
+        employer=Employer(name="Example"),
+        search_strategy=SearchStrategy.JOBSPY,
+        metadata=JobMetadata(title="Platform Engineer"),
+        discovered_at="2026-07-30T10:00:00+00:00",
+    )
+
+
+def _downgrade_application_review_references_to_v19(
+    conn: sqlite3.Connection,
+) -> None:
+    conn.execute("DROP TABLE application_review_decisions")
+    conn.executescript(
+        """
+        CREATE TABLE application_review_decisions (
+            tenant_id                    TEXT NOT NULL DEFAULT 'local',
+            decision_id                  TEXT NOT NULL,
+            job_key                      TEXT NOT NULL,
+            decision                     TEXT NOT NULL,
+            reason                       TEXT,
+            decided_by                   TEXT DEFAULT 'user',
+            decided_at                   TEXT NOT NULL,
+            materials_generation         INTEGER,
+            profile_version              INTEGER,
+            application_url              TEXT,
+            partial_override_run_id      TEXT,
+            email_recipient              TEXT,
+            email_attachment_artifact_id TEXT,
+            PRIMARY KEY (tenant_id, decision_id)
+        );
+        CREATE INDEX idx_application_review_decisions_job
+        ON application_review_decisions(
+            tenant_id,
+            job_key,
+            decided_at DESC
+        );
+        """
+    )
+    conn.execute(f"PRAGMA user_version = {PREVIOUS_SCHEMA_VERSION}")
+    conn.commit()
+
+
+def _insert_decision(
+    conn: sqlite3.Connection,
+    *,
+    tenant_id: str,
+    decision_id: str,
+    reference_column: str,
+    reference: str,
+    decision: str,
+    decided_at: str,
+) -> None:
+    conn.execute(
+        f"""
+        INSERT INTO application_review_decisions (
+            tenant_id,
+            decision_id,
+            {reference_column},
+            decision,
+            reason,
+            decided_by,
+            decided_at
+        ) VALUES (?, ?, ?, ?, ?, 'user', ?)
+        """,
+        (
+            tenant_id,
+            decision_id,
+            reference,
+            decision,
+            f"reason:{decision_id}",
+            decided_at,
+        ),
+    )
+
+
+def _columns(
+    conn: sqlite3.Connection,
+    table_name: str,
+) -> set[str]:
+    return {
+        str(row[1])
+        for row in conn.execute(
+            f'PRAGMA table_info("{table_name}")'
+        ).fetchall()
+    }
+
+
+def test_v19_review_decisions_migrate_every_alias_and_uuid_url(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    conn = init_db(db_path)
+    jobs = SqliteJobRepository(conn)
+    stable_job_id = JobId(str(uuid.uuid4()))
+    storage_url = "https://boards.example/jobs/review"
+    alias_url = "https://careers.example/jobs/review"
+    jobs.save(_discovered_job(storage_url, stable_job_id))
+    jobs.save(_discovered_job(alias_url, stable_job_id))
+
+    uuid_shaped_url = str(uuid.uuid4())
+    uuid_url_owner = JobId(str(uuid.uuid4()))
+    jobs.save(_discovered_job(uuid_shaped_url, uuid_url_owner))
+    jobs.save(
+        _discovered_job(
+            "https://example.com/jobs/id-text-owner",
+            JobId(uuid_shaped_url),
+        )
+    )
+    other_tenant_job_id = str(stable_job_id)
+    other_tenant_url = "https://tenant-b.example/jobs/review"
+    conn.execute(
+        """
+        INSERT INTO jobs (
+            url, tenant_id, job_id, title, company, discovered_at
+        ) VALUES (?, 'tenant-b', ?, 'Platform Engineer', 'Example', ?)
+        """,
+        (
+            other_tenant_url,
+            other_tenant_job_id,
+            "2026-07-30T10:00:00+00:00",
+        ),
+    )
+
+    _downgrade_application_review_references_to_v19(conn)
+    _insert_decision(
+        conn,
+        tenant_id="local",
+        decision_id="storage-decision",
+        reference_column="job_key",
+        reference=storage_url,
+        decision="approve_dry_run",
+        decided_at="2026-07-30T10:00:00+00:00",
+    )
+    _insert_decision(
+        conn,
+        tenant_id="local",
+        decision_id="alias-decision",
+        reference_column="job_key",
+        reference=alias_url,
+        decision="defer",
+        decided_at="2026-07-30T10:01:00+00:00",
+    )
+    _insert_decision(
+        conn,
+        tenant_id="local",
+        decision_id="shared-decision",
+        reference_column="job_key",
+        reference=uuid_shaped_url,
+        decision="decline",
+        decided_at="2026-07-30T10:02:00+00:00",
+    )
+    _insert_decision(
+        conn,
+        tenant_id="tenant-b",
+        decision_id="shared-decision",
+        reference_column="job_key",
+        reference=other_tenant_url,
+        decision="approve_submit",
+        decided_at="2026-07-30T10:03:00+00:00",
+    )
+    conn.commit()
+    close_connection(db_path)
+
+    reopened = init_db(db_path)
+    assert (
+        reopened.execute("PRAGMA user_version").fetchone()[0]
+        == SCHEMA_VERSION
+        == 20
+    )
+    assert "job_id" in _columns(
+        reopened,
+        "application_review_decisions",
+    )
+    assert "job_key" not in _columns(
+        reopened,
+        "application_review_decisions",
+    )
+    assert [
+        tuple(row)
+        for row in reopened.execute(
+            """
+            SELECT tenant_id, decision_id, job_id, decision
+            FROM application_review_decisions
+            ORDER BY tenant_id, decision_id
+            """
+        ).fetchall()
+    ] == [
+        (
+            "local",
+            "alias-decision",
+            str(stable_job_id),
+            "defer",
+        ),
+        (
+            "local",
+            "shared-decision",
+            str(uuid_url_owner),
+            "decline",
+        ),
+        (
+            "local",
+            "storage-decision",
+            str(stable_job_id),
+            "approve_dry_run",
+        ),
+        (
+            "tenant-b",
+            "shared-decision",
+            other_tenant_job_id,
+            "approve_submit",
+        ),
+    ]
+    assert reopened.execute(
+        "PRAGMA foreign_key_check"
+    ).fetchone() is None
+    close_connection(db_path)
+
+    reopened_again = init_db(db_path)
+    assert reopened_again.execute(
+        "SELECT COUNT(*) FROM application_review_decisions"
+    ).fetchone()[0] == 4
+    close_connection(db_path)
+
+
+def test_v20_review_decision_migration_rolls_back_and_retries(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    conn = init_db(db_path)
+    job_id = JobId(str(uuid.uuid4()))
+    job_url = "https://example.com/jobs/review-retry"
+    SqliteJobRepository(conn).save(_discovered_job(job_url, job_id))
+    _downgrade_application_review_references_to_v19(conn)
+    _insert_decision(
+        conn,
+        tenant_id="local",
+        decision_id="retry-decision",
+        reference_column="job_key",
+        reference=job_url,
+        decision="defer",
+        decided_at="2026-07-30T10:00:00+00:00",
+    )
+    conn.commit()
+    conn.execute("PRAGMA foreign_keys = ON")
+    original_verify = (
+        database_module._verify_application_review_references_v20
+    )
+
+    def _fail_verification(
+        _conn: sqlite3.Connection,
+        *,
+        expected_count: int,
+    ) -> None:
+        del expected_count
+        raise RuntimeError("injected review verification failure")
+
+    monkeypatch.setattr(
+        database_module,
+        "_verify_application_review_references_v20",
+        _fail_verification,
+    )
+    with pytest.raises(
+        RuntimeError,
+        match="injected review verification failure",
+    ):
+        ensure_application_review_references_v20(conn)
+    assert conn.execute("PRAGMA user_version").fetchone()[0] == 19
+    assert "job_key" in _columns(
+        conn,
+        "application_review_decisions",
+    )
+    assert conn.execute(
+        "SELECT decision FROM application_review_decisions"
+    ).fetchone()[0] == "defer"
+
+    monkeypatch.setattr(
+        database_module,
+        "_verify_application_review_references_v20",
+        original_verify,
+    )
+    assert ensure_application_review_references_v20(conn) == [
+        "application_review_decisions"
+    ]
+    assert conn.execute("PRAGMA user_version").fetchone()[0] == 20
+    assert "job_id" in _columns(
+        conn,
+        "application_review_decisions",
+    )
+    assert conn.execute(
+        "PRAGMA foreign_key_check"
+    ).fetchone() is None
+    close_connection(db_path)
+
+
+def test_v20_init_restores_a_missing_review_authority_as_stable(
+    tmp_path: Path,
+) -> None:
+    from jobctrl.infrastructure.gmail.feedback import (
+        ensure_application_feedback_tables,
+    )
+
+    db_path = tmp_path / "jobctrl.db"
+    conn = init_db(db_path)
+    conn.execute("DROP TABLE application_review_decisions")
+    conn.commit()
+    ensure_application_feedback_tables(conn)
+    assert database_module._has_application_review_reference_schema_v20(
+        conn
+    )
+    conn.execute("DROP TABLE application_review_decisions")
+    conn.commit()
+    close_connection(db_path)
+
+    reopened = init_db(db_path)
+    assert "job_id" in _columns(
+        reopened,
+        "application_review_decisions",
+    )
+    assert "job_key" not in _columns(
+        reopened,
+        "application_review_decisions",
+    )
+    assert database_module._has_application_review_reference_schema_v20(
+        reopened
+    )
+    close_connection(db_path)
+
+
+def test_runtime_review_merge_preserves_append_only_history_and_tenant(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    conn = init_db(db_path)
+    jobs = SqliteJobRepository(conn)
+    losing_id = JobId(str(uuid.uuid4()))
+    surviving_id = JobId(str(uuid.uuid4()))
+    losing_url = "https://example.com/jobs/review-losing"
+    surviving_url = "https://example.com/jobs/review-surviving"
+    jobs.save(_discovered_job(losing_url, losing_id))
+    jobs.save(_discovered_job(surviving_url, surviving_id))
+    other_tenant_job_id = str(surviving_id)
+    other_tenant_url = "https://tenant-b.example/jobs/review"
+    conn.execute(
+        """
+        INSERT INTO jobs (
+            url, tenant_id, job_id, title, company, discovered_at
+        ) VALUES (?, 'tenant-b', ?, 'Platform Engineer', 'Example', ?)
+        """,
+        (
+            other_tenant_url,
+            other_tenant_job_id,
+            "2026-07-30T10:00:00+00:00",
+        ),
+    )
+    for decision_id, reference, decision, decided_at in (
+        (
+            "losing-1",
+            str(losing_id),
+            "approve_dry_run",
+            "2026-07-30T10:00:00+00:00",
+        ),
+        (
+            "losing-2",
+            str(losing_id),
+            "defer",
+            "2026-07-30T10:01:00+00:00",
+        ),
+        (
+            "surviving-1",
+            str(surviving_id),
+            "decline",
+            "2026-07-30T10:02:00+00:00",
+        ),
+    ):
+        _insert_decision(
+            conn,
+            tenant_id="local",
+            decision_id=decision_id,
+            reference_column="job_id",
+            reference=reference,
+            decision=decision,
+            decided_at=decided_at,
+        )
+    _insert_decision(
+        conn,
+        tenant_id="tenant-b",
+        decision_id="tenant-b-1",
+        reference_column="job_id",
+        reference=other_tenant_job_id,
+        decision="approve_submit",
+        decided_at="2026-07-30T10:04:00+00:00",
+    )
+    conn.commit()
+    conn.execute("PRAGMA foreign_keys = ON")
+
+    reassign_discovery_identity_references(
+        conn,
+        losing_job_url=losing_url,
+        surviving_job_url=surviving_url,
+    )
+    conn.execute(
+        "DELETE FROM jobs WHERE tenant_id = 'local' AND url = ?",
+        (losing_url,),
+    )
+
+    assert [
+        tuple(row)
+        for row in conn.execute(
+            """
+            SELECT tenant_id, decision_id, job_id
+            FROM application_review_decisions
+            ORDER BY tenant_id, decision_id
+            """
+        ).fetchall()
+    ] == [
+        ("local", "losing-1", str(surviving_id)),
+        ("local", "losing-2", str(surviving_id)),
+        ("local", "surviving-1", str(surviving_id)),
+        ("tenant-b", "tenant-b-1", other_tenant_job_id),
+    ]
+    assert conn.execute(
+        "PRAGMA foreign_key_check"
+    ).fetchone() is None
+    close_connection(db_path)

--- a/workers/automation/tests/test_apply_regressions.py
+++ b/workers/automation/tests/test_apply_regressions.py
@@ -170,16 +170,37 @@ def _insert_review_decision(
     application_url: str | None = None,
     partial_override_run_id: str | None = None,
 ) -> None:
+    review_columns = {
+        str(row[1])
+        for row in conn.execute(
+            "PRAGMA table_info(application_review_decisions)"
+        ).fetchall()
+    }
+    reference_column = (
+        "job_id" if "job_id" in review_columns else "job_key"
+    )
+    reference = job_key
+    if reference_column == "job_id":
+        row = conn.execute(
+            """
+            SELECT job_id
+            FROM jobs
+            WHERE tenant_id = 'local' AND url = ?
+            """,
+            (job_key,),
+        ).fetchone()
+        assert row is not None
+        reference = str(row[0])
     conn.execute(
-        """
+        f"""
         INSERT INTO application_review_decisions (
-            tenant_id, decision_id, job_key, decision, reason, decided_by, decided_at,
+            tenant_id, decision_id, {reference_column}, decision, reason, decided_by, decided_at,
             materials_generation, profile_version, application_url, partial_override_run_id
         ) VALUES ('local', ?, ?, ?, 'test', 'pytest', ?, ?, ?, ?, ?)
         """,
         (
             decision_id or f"decision-{decision}-{decided_at}",
-            job_key,
+            reference,
             decision,
             decided_at,
             materials_generation,

--- a/workers/automation/tests/test_compensation_identity_reference_migration.py
+++ b/workers/automation/tests/test_compensation_identity_reference_migration.py
@@ -210,7 +210,7 @@ def test_v18_compensation_migrates_alias_winners_and_uuid_urls(
     assert (
         reopened.execute("PRAGMA user_version").fetchone()[0]
         == SCHEMA_VERSION
-        == 19
+        == 20
     )
     for table in database_module._COMPENSATION_REFERENCE_TABLES:
         assert "job_id" in _columns(reopened, table)

--- a/workers/automation/tests/test_discovery_identity_reference_migration.py
+++ b/workers/automation/tests/test_discovery_identity_reference_migration.py
@@ -220,7 +220,7 @@ def test_v7_discovery_references_migrate_to_stable_job_id_and_reopen(
     init_db(db_path)
     close_connection(db_path)
 
-    assert _user_version(db_path) == SCHEMA_VERSION == 19
+    assert _user_version(db_path) == SCHEMA_VERSION == 20
     assert "job_id" in _columns(db_path, "job_source_observations")
     assert "job_url" not in _columns(db_path, "job_source_observations")
     assert "job_id" in _columns(db_path, "job_canonical_identities")

--- a/workers/automation/tests/test_employer_analysis_identity_reference_migration.py
+++ b/workers/automation/tests/test_employer_analysis_identity_reference_migration.py
@@ -242,7 +242,7 @@ def test_v15_employer_analysis_migrates_alias_histories_and_uuid_urls(
     assert (
         reopened.execute("PRAGMA user_version").fetchone()[0]
         == SCHEMA_VERSION
-        == 19
+        == 20
     )
     for table in database_module._EMPLOYER_ANALYSIS_REFERENCE_TABLES:
         assert "job_id" in _columns(reopened, table)

--- a/workers/automation/tests/test_enrichment_snapshot_identity_reference_migration.py
+++ b/workers/automation/tests/test_enrichment_snapshot_identity_reference_migration.py
@@ -322,7 +322,7 @@ def test_v10_enrichment_snapshot_references_migrate_and_reopen(
     init_db(db_path)
     close_connection(db_path)
 
-    assert _user_version(db_path) == SCHEMA_VERSION == 19
+    assert _user_version(db_path) == SCHEMA_VERSION == 20
     check = sqlite3.connect(db_path)
     try:
         enrichment_rows = check.execute(

--- a/workers/automation/tests/test_execution_search_identity_reference_migration.py
+++ b/workers/automation/tests/test_execution_search_identity_reference_migration.py
@@ -261,7 +261,7 @@ def test_v8_execution_and_receipts_migrate_to_stable_job_id_and_reopen(
     init_db(db_path)
     close_connection(db_path)
 
-    assert _user_version(db_path) == SCHEMA_VERSION == 19
+    assert _user_version(db_path) == SCHEMA_VERSION == 20
     assert "job_id" in _columns(db_path, "discovery_execution_jobs")
     assert "job_url" not in _columns(db_path, "discovery_execution_jobs")
     assert "job_id" in _columns(db_path, "discovery_search_unit_jobs")

--- a/workers/automation/tests/test_interview_prep_identity_reference_migration.py
+++ b/workers/automation/tests/test_interview_prep_identity_reference_migration.py
@@ -297,7 +297,7 @@ def test_v17_interview_prep_migrates_alias_histories_and_uuid_urls(
     assert (
         reopened.execute("PRAGMA user_version").fetchone()[0]
         == SCHEMA_VERSION
-        == 19
+        == 20
     )
     for table in database_module._INTERVIEW_PREP_REFERENCE_TABLES:
         assert "job_id" in _columns(reopened, table)

--- a/workers/automation/tests/test_materials_identity_reference_migration.py
+++ b/workers/automation/tests/test_materials_identity_reference_migration.py
@@ -293,7 +293,7 @@ def test_v14_materials_migrate_alias_histories_and_uuid_shaped_urls(
     close_connection(db_path)
 
     reopened = init_db(db_path)
-    assert reopened.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_VERSION == 19
+    assert reopened.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_VERSION == 20
     for table in database_module._MATERIALS_REFERENCE_TABLES:
         assert "job_id" in _columns(reopened, table)
         assert "job_url" not in _columns(reopened, table)

--- a/workers/automation/tests/test_preparation_identity_reference_migration.py
+++ b/workers/automation/tests/test_preparation_identity_reference_migration.py
@@ -177,7 +177,7 @@ def test_v9_preparation_references_migrate_to_stable_job_ids_and_reopen(
     init_db(db_path)
     close_connection(db_path)
 
-    assert _user_version(db_path) == SCHEMA_VERSION == 19
+    assert _user_version(db_path) == SCHEMA_VERSION == 20
     check = sqlite3.connect(db_path)
     try:
         rows = check.execute(

--- a/workers/automation/tests/test_repeat_application_prevention.py
+++ b/workers/automation/tests/test_repeat_application_prevention.py
@@ -705,15 +705,23 @@ def test_stale_apply_approval_does_not_consume_repeat_override(
     db_path = tmp_path / "jobs.db"
     conn = _seed_equivalent_repeat(db_path)
     _insert_override(conn, evaluate_repeat_application(conn, TARGET))
+    target_job_id = conn.execute(
+        """
+        SELECT job_id
+        FROM jobs
+        WHERE tenant_id = 'local' AND url = ?
+        """,
+        (TARGET,),
+    ).fetchone()[0]
     conn.execute(
         """
         INSERT INTO application_review_decisions (
-          tenant_id, decision_id, job_key, decision, reason, decided_by, decided_at,
+          tenant_id, decision_id, job_id, decision, reason, decided_by, decided_at,
           materials_generation, profile_version, application_url
         ) VALUES ('local', 'stale-approval', ?, 'approve_submit', 'test', 'qa', ?,
                   0, 1, ?)
         """,
-        (TARGET, NOW, f"{TARGET}/apply"),
+        (target_job_id, NOW, f"{TARGET}/apply"),
     )
     conn.commit()
     monkeypatch.setattr("jobctrl.apply.launcher.get_connection", lambda: get_connection(db_path))
@@ -750,7 +758,7 @@ def test_schema_v5_migrates_additively_without_changing_application_facts(
         (PRIOR,),
     ).fetchall()
 
-    assert int(migrated.execute("PRAGMA user_version").fetchone()[0]) == SCHEMA_VERSION == 19
+    assert int(migrated.execute("PRAGMA user_version").fetchone()[0]) == SCHEMA_VERSION == 20
     assert [tuple(row) for row in after] == [tuple(row) for row in before]
     assert "metadata_json" in {
         str(row[1]) for row in migrated.execute("PRAGMA table_info(job_stage_states)").fetchall()

--- a/workers/automation/tests/test_resume_template_identity_reference_migration.py
+++ b/workers/automation/tests/test_resume_template_identity_reference_migration.py
@@ -254,7 +254,7 @@ def test_v16_template_references_migrate_aliases_and_uuid_urls(
     assert (
         reopened.execute("PRAGMA user_version").fetchone()[0]
         == SCHEMA_VERSION
-        == 19
+        == 20
     )
     for table in database_module._RESUME_TEMPLATE_REFERENCE_TABLES:
         assert "job_id" in _columns(reopened, table)

--- a/workers/automation/tests/test_scoring_identity_reference_migration.py
+++ b/workers/automation/tests/test_scoring_identity_reference_migration.py
@@ -338,7 +338,7 @@ def test_v11_scoring_references_migrate_alias_histories_and_reopen(
     assert (
         int(migrated.execute("PRAGMA user_version").fetchone()[0])
         == SCHEMA_VERSION
-        == 19
+        == 20
     )
     assert _columns(migrated, "job_scores") >= {"tenant_id", "job_id"}
     assert "job_url" not in _columns(migrated, "job_scores")
@@ -404,7 +404,7 @@ def test_v11_scoring_references_migrate_alias_histories_and_reopen(
     assert (
         int(reopened.execute("PRAGMA user_version").fetchone()[0])
         == SCHEMA_VERSION
-        == 19
+        == 20
     )
 
 
@@ -553,7 +553,7 @@ def test_scoring_migration_rolls_back_and_retries_after_verification_failure(
     assert (
         int(retried.execute("PRAGMA user_version").fetchone()[0])
         == SCHEMA_VERSION
-        == 19
+        == 20
     )
     assert [
         tuple(row)

--- a/workers/automation/tests/test_stable_job_identity_migration.py
+++ b/workers/automation/tests/test_stable_job_identity_migration.py
@@ -743,7 +743,7 @@ def test_v6_jobs_gain_stable_uuid_and_posting_url_alias_once(
     init_db(db_path)
     close_connection(db_path)
 
-    assert _user_version(db_path) == SCHEMA_VERSION == 19
+    assert _user_version(db_path) == SCHEMA_VERSION == 20
     first_ids = _identity_rows(db_path)
     assert [row[0] for row in first_ids] == ["local", "local"]
     for _tenant_id, job_id, _url in first_ids:


### PR DESCRIPTION
## Summary

- add schema v20, migrating every append-only Apply Review decision from mutable `job_key` URLs to tenant-scoped stable `job_id` references
- preserve URL-shaped API and worker compatibility through explicit boundary translation in review writes, queue/audit/digest reads, approval lookup, Gmail setup, and permanent deletion
- preserve every decision during alias migration and runtime identity collisions, including UUID-shaped posting URLs and same-JobId values in different tenants
- recover a missing review authority with the correct schema for its database version: v0/v19 remain legacy for ordered migration, while v20 recreates the composite-FK JobId schema

## Why

Review decisions are durable user evidence. Keeping their owner URL-shaped would make approvals drift or disappear when the same job is rediscovered under another posting URL. This slice moves that one authority to the stable Job aggregate without cutting over the public URL-shaped contract yet.

## Stack

- stacked on #545 (`feat/job-id-compensation-references`)
- intentionally limited to Apply Review decisions; outcomes/email suggestions and repeat-application evidence follow as separate reviewable PRs
- canonical product docs and cumulative product QA remain deferred to the final approved stack PR

## Validation

- `PYTHONPATH=src /Users/eloibarti/Github/JobHunter/workers/automation/.venv/bin/python -m pytest -q` — 2709 passed, 2 skipped
- `pnpm --dir apps/api test` — 680 passed
- `pnpm --dir apps/api check` — passed
- focused migration, rollback/retry, collision, worker/digest/Gmail, stable API, and FK-off deletion suites — passed
- Ruff on all touched Python surfaces — passed
- `git diff --check` — passed
- independent Tier 3 reviewer gate — PASS, Blocker/High/Medium/Low = 0/0/0/0
- independent Tier 3 QA gate — PASS, Blocker/High/Medium/Low = 0/0/0/0
