### PR TITLE
feat(apply): migrate reviewed outcomes to stable JobIds

### DIFF
--- a/apps/api/src/application-feedback.ts
+++ b/apps/api/src/application-feedback.ts
@@ -48,6 +48,10 @@ import {
   allRows,
   getRow,
   hasCompositeJobIdForeignKey,
+  jobKeyReferenceColumn,
+  jobKeyReferenceForUrl,
+  jobKeyReferenceJoinToJobs,
+  jobKeyReferencePredicateForUrl,
   jobReferenceColumn,
   jobReferenceJoinToJobs,
   jobReferencePredicateForUrl,
@@ -67,6 +71,7 @@ import { InputError, resolveJobUrl } from "./write-model.js";
 const DEFAULT_TENANT = "local";
 const DEFAULT_PROFILE_ID = "default";
 const APPLICATION_REVIEW_REFERENCE_SCHEMA_VERSION = 20;
+const APPLICATION_OUTCOME_REFERENCE_SCHEMA_VERSION = 21;
 const CLOSED_ACTIVE_STATES = ["closed", "expired", "removed", "location_incompatible"];
 const POSITION_PREVIEW_CHAR_LIMIT = 6000;
 const MATERIAL_PREVIEW_CHAR_LIMIT = 4000;
@@ -190,6 +195,16 @@ export function ensureApplicationFeedbackTables(db: SqliteDatabase): void {
       FOREIGN KEY (tenant_id, job_id)
         REFERENCES jobs(tenant_id, job_id) ON DELETE CASCADE`
     : "";
+  const stableOutcomeSchema =
+    schemaVersion >= APPLICATION_OUTCOME_REFERENCE_SCHEMA_VERSION;
+  const createdOutcomeReference = stableOutcomeSchema
+    ? "job_id"
+    : "job_key";
+  const outcomeForeignKey = stableOutcomeSchema
+    ? `,
+      FOREIGN KEY (tenant_id, job_id)
+        REFERENCES jobs(tenant_id, job_id) ON DELETE CASCADE`
+    : "";
   db.exec(`
     CREATE TABLE IF NOT EXISTS application_review_decisions (
       tenant_id    TEXT NOT NULL DEFAULT 'local',
@@ -212,7 +227,7 @@ export function ensureApplicationFeedbackTables(db: SqliteDatabase): void {
     CREATE TABLE IF NOT EXISTS application_outcomes (
       tenant_id     TEXT NOT NULL DEFAULT 'local',
       outcome_id    TEXT NOT NULL,
-      job_key       TEXT NOT NULL,
+      ${createdOutcomeReference} TEXT NOT NULL,
       kind          TEXT NOT NULL,
       source        TEXT NOT NULL,
       note          TEXT,
@@ -221,10 +236,10 @@ export function ensureApplicationFeedbackTables(db: SqliteDatabase): void {
       suggestion_id TEXT,
       evidence_id   TEXT,
       created_by    TEXT NOT NULL DEFAULT 'user',
+      interview_prep_generation INTEGER,
       PRIMARY KEY (tenant_id, outcome_id)
+      ${outcomeForeignKey}
     );
-    CREATE INDEX IF NOT EXISTS idx_application_outcomes_job
-      ON application_outcomes(tenant_id, job_key, occurred_at DESC, recorded_at DESC);
 
     CREATE TABLE IF NOT EXISTS application_email_evidence (
       tenant_id            TEXT NOT NULL DEFAULT 'local',
@@ -282,6 +297,19 @@ export function ensureApplicationFeedbackTables(db: SqliteDatabase): void {
       );
   `);
   ensureApplicationOutcomeColumns(db);
+  const outcomeReference = jobKeyReferenceColumn(
+    db,
+    "application_outcomes",
+  );
+  db.exec(`
+    CREATE INDEX IF NOT EXISTS idx_application_outcomes_job
+      ON application_outcomes(
+        tenant_id,
+        ${outcomeReference},
+        occurred_at DESC,
+        recorded_at DESC
+      );
+  `);
   ensureRepeatApplicationTables(db);
 }
 
@@ -835,13 +863,19 @@ function insertOutcome(
 
   db.prepare(
     `INSERT INTO application_outcomes (
-       tenant_id, outcome_id, job_key, kind, source, note, occurred_at,
+       tenant_id, outcome_id, ${jobKeyReferenceColumn(db, "application_outcomes")},
+       kind, source, note, occurred_at,
        recorded_at, suggestion_id, evidence_id, interview_prep_generation, created_by
      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   ).run(
     DEFAULT_TENANT,
     outcome.outcomeId,
-    outcome.jobKey,
+    jobKeyReferenceForUrl(
+      db,
+      "application_outcomes",
+      outcome.jobKey,
+      DEFAULT_TENANT,
+    ),
     outcome.kind,
     outcome.source,
     outcome.note,
@@ -876,26 +910,74 @@ function insertOutcome(
 }
 
 function readOutcomes(db: SqliteDatabase, jobKey?: string): ApplicationOutcome[] {
-  const where = jobKey ? "WHERE tenant_id = ? AND job_key = ?" : "WHERE tenant_id = ?";
-  const params = jobKey ? [DEFAULT_TENANT, jobKey] : [DEFAULT_TENANT];
+  const stableReferences =
+    jobKeyReferenceColumn(db, "application_outcomes") === "job_id";
+  const reference = jobKey
+    ? jobKeyReferencePredicateForUrl(
+        db,
+        "application_outcomes",
+        jobKey,
+        DEFAULT_TENANT,
+        "outcomes",
+      )
+    : null;
+  const where = reference
+    ? `WHERE ${reference.sql}`
+    : "WHERE outcomes.tenant_id = ?";
+  const params = reference?.params ?? [DEFAULT_TENANT];
+  const identityJoin = stableReferences
+    ? `JOIN jobs
+         ON ${jobKeyReferenceJoinToJobs(
+           db,
+           "application_outcomes",
+           "outcomes",
+           "jobs",
+         )}`
+    : "";
+  const jobKeySelect = stableReferences
+    ? "jobs.url"
+    : "outcomes.job_key";
   return allRows<OutcomeRow>(
     db,
-    `SELECT outcome_id, job_key, kind, source, note, occurred_at,
-            recorded_at, suggestion_id, evidence_id, interview_prep_generation
-     FROM application_outcomes
+    `SELECT outcomes.outcome_id, ${jobKeySelect} AS job_key,
+            outcomes.kind, outcomes.source, outcomes.note,
+            outcomes.occurred_at, outcomes.recorded_at,
+            outcomes.suggestion_id, outcomes.evidence_id,
+            outcomes.interview_prep_generation
+     FROM application_outcomes AS outcomes
+     ${identityJoin}
      ${where}
-     ORDER BY occurred_at DESC, recorded_at DESC, outcome_id DESC`,
+     ORDER BY outcomes.occurred_at DESC, outcomes.recorded_at DESC,
+              outcomes.outcome_id DESC`,
     params,
   ).map(outcomeFromRow);
 }
 
 function readOutcome(db: SqliteDatabase, outcomeId: string): ApplicationOutcome | null {
+  const stableReferences =
+    jobKeyReferenceColumn(db, "application_outcomes") === "job_id";
+  const identityJoin = stableReferences
+    ? `JOIN jobs
+         ON ${jobKeyReferenceJoinToJobs(
+           db,
+           "application_outcomes",
+           "outcomes",
+           "jobs",
+         )}`
+    : "";
+  const jobKeySelect = stableReferences
+    ? "jobs.url"
+    : "outcomes.job_key";
   const row = getRow<OutcomeRow>(
     db,
-    `SELECT outcome_id, job_key, kind, source, note, occurred_at,
-            recorded_at, suggestion_id, evidence_id, interview_prep_generation
-     FROM application_outcomes
-     WHERE tenant_id = ? AND outcome_id = ?`,
+    `SELECT outcomes.outcome_id, ${jobKeySelect} AS job_key,
+            outcomes.kind, outcomes.source, outcomes.note,
+            outcomes.occurred_at, outcomes.recorded_at,
+            outcomes.suggestion_id, outcomes.evidence_id,
+            outcomes.interview_prep_generation
+     FROM application_outcomes AS outcomes
+     ${identityJoin}
+     WHERE outcomes.tenant_id = ? AND outcomes.outcome_id = ?`,
     [DEFAULT_TENANT, outcomeId],
   );
   return row ? outcomeFromRow(row) : null;

--- a/apps/api/src/db.ts
+++ b/apps/api/src/db.ts
@@ -9,7 +9,7 @@ export type SqliteValue = string | number | bigint | null;
 // writer that stamps ``PRAGMA user_version``; the API only reads it to fail
 // closed on a database written by a newer build. Bump both constants together
 // whenever the schema shape changes.
-export const SUPPORTED_SCHEMA_VERSION = 20;
+export const SUPPORTED_SCHEMA_VERSION = 21;
 
 export class IncompatibleSchemaVersionError extends Error {
   constructor(current: number) {
@@ -71,6 +71,7 @@ export function tableExists(db: SqliteDatabase, tableName: string): boolean {
 }
 
 export type JobReferenceColumn = "job_id" | "job_url";
+export type JobKeyReferenceColumn = "job_id" | "job_key";
 
 export function tableColumnSet(db: SqliteDatabase, tableName: string): Set<string> {
   if (!tableExists(db, tableName)) return new Set();
@@ -167,6 +168,62 @@ export function jobReferenceJoinToJobs(
   return jobReferenceColumn(db, tableName) === "job_id"
     ? `${sourceAlias}.tenant_id = ${jobsAlias}.tenant_id AND ${sourceAlias}.job_id = ${jobsAlias}.job_id`
     : `${sourceAlias}.job_url = ${jobsAlias}.url`;
+}
+
+export function jobKeyReferenceColumn(
+  db: SqliteDatabase,
+  tableName: string,
+): JobKeyReferenceColumn {
+  const columns = tableColumnSet(db, tableName);
+  if (columns.has("job_id")) return "job_id";
+  if (columns.has("job_key")) return "job_key";
+  throw new Error(`${tableName} has no Job identity column.`);
+}
+
+export function jobKeyReferenceForUrl(
+  db: SqliteDatabase,
+  tableName: string,
+  jobUrl: string,
+  tenantId = "local",
+): string {
+  if (jobKeyReferenceColumn(db, tableName) === "job_key") return jobUrl;
+  const jobId = stableJobIdForUrl(db, jobUrl, tenantId);
+  if (!jobId) {
+    throw new Error(`No stable Job identity for ${jobUrl}.`);
+  }
+  return jobId;
+}
+
+export function jobKeyReferencePredicateForUrl(
+  db: SqliteDatabase,
+  tableName: string,
+  jobUrl: string,
+  tenantId = "local",
+  alias = "",
+): { sql: string; params: SqliteValue[] } {
+  const prefix = alias ? `${alias}.` : "";
+  const referenceColumn = jobKeyReferenceColumn(db, tableName);
+  const reference = jobKeyReferenceForUrl(
+    db,
+    tableName,
+    jobUrl,
+    tenantId,
+  );
+  return {
+    sql: `${prefix}tenant_id = ? AND ${prefix}${referenceColumn} = ?`,
+    params: [tenantId, reference],
+  };
+}
+
+export function jobKeyReferenceJoinToJobs(
+  db: SqliteDatabase,
+  tableName: string,
+  sourceAlias: string,
+  jobsAlias: string,
+): string {
+  return jobKeyReferenceColumn(db, tableName) === "job_id"
+    ? `${sourceAlias}.tenant_id = ${jobsAlias}.tenant_id AND ${sourceAlias}.job_id = ${jobsAlias}.job_id`
+    : `${sourceAlias}.tenant_id = ${jobsAlias}.tenant_id AND ${sourceAlias}.job_key = ${jobsAlias}.url`;
 }
 
 export function hasCompositeJobIdForeignKey(

--- a/apps/api/src/outreach.ts
+++ b/apps/api/src/outreach.ts
@@ -35,7 +35,14 @@ import {
   OUTREACH_DRAFT_STATUSES,
   OUTREACH_SEND_CHANNELS,
 } from "./contracts.js";
-import { allRows, getRow, tableExists, type SqliteDatabase, type SqliteValue } from "./db.js";
+import {
+  allRows,
+  getRow,
+  jobKeyReferencePredicateForUrl,
+  tableExists,
+  type SqliteDatabase,
+  type SqliteValue,
+} from "./db.js";
 import { refreshOutreachProjections, refreshProjections } from "./projections.js";
 
 // Conservative follow-up cadence (plan §16 res. 5), mirrored from the Python
@@ -525,14 +532,20 @@ function latestApplicationSubmittedAt(db: SqliteDatabase, thread: ThreadRow): st
     return "";
   }
   if (tableExists(db, "application_outcomes")) {
+    const reference = jobKeyReferencePredicateForUrl(
+      db,
+      "application_outcomes",
+      jobUrl,
+      TENANT_ID,
+    );
     const outcome = getRow<{ occurred_at: string | null }>(
       db,
       `SELECT occurred_at
        FROM application_outcomes
-       WHERE tenant_id = ? AND job_key = ? AND kind = 'applied_confirmation'
+       WHERE ${reference.sql} AND kind = 'applied_confirmation'
        ORDER BY occurred_at DESC, recorded_at DESC
        LIMIT 1`,
-      [TENANT_ID, jobUrl],
+      reference.params,
     );
     if (outcome?.occurred_at) {
       return outcome.occurred_at;

--- a/apps/api/src/projections.ts
+++ b/apps/api/src/projections.ts
@@ -25,6 +25,9 @@ import {
   allRows,
   getRow,
   hasCompositeJobIdForeignKey,
+  jobKeyReferenceColumn,
+  jobKeyReferenceJoinToJobs,
+  jobKeyReferencePredicateForUrl,
   jobReferenceColumn,
   jobReferenceForUrl,
   jobReferenceJoinToJobs,
@@ -4240,9 +4243,26 @@ function hasAnyKind(outcomes: readonly OutcomeFact[], target: Set<string>): bool
 function loadOutcomesByJob(db: SqliteDatabase, tenantId: string): Map<string, OutcomeFact[]> {
   const result = new Map<string, OutcomeFact[]>();
   if (!tableExists(db, "application_outcomes")) return result;
+  const stableReferences =
+    jobKeyReferenceColumn(db, "application_outcomes") === "job_id";
+  const jobKeySelect = stableReferences
+    ? "jobs.url"
+    : "outcomes.job_key";
+  const identityJoin = stableReferences
+    ? `JOIN jobs
+         ON ${jobKeyReferenceJoinToJobs(
+           db,
+           "application_outcomes",
+           "outcomes",
+           "jobs",
+         )}`
+    : "";
   const rows = allRows<{ job_key: string; kind: string; occurred_at: string | null }>(
     db,
-    "SELECT job_key, kind, occurred_at FROM application_outcomes WHERE tenant_id = ?",
+    `SELECT ${jobKeySelect} AS job_key, outcomes.kind, outcomes.occurred_at
+       FROM application_outcomes AS outcomes
+       ${identityJoin}
+      WHERE outcomes.tenant_id = ?`,
     [tenantId],
   );
   for (const row of rows) {
@@ -5811,10 +5831,18 @@ function hasApplicationOutcomeKind(
   kind: string,
 ): boolean {
   if (!tableExists(db, "application_outcomes")) return false;
+  const reference = jobKeyReferencePredicateForUrl(
+    db,
+    "application_outcomes",
+    jobUrl,
+    tenantId,
+  );
   const row = getRow<{ c: number }>(
     db,
-    "SELECT COUNT(*) AS c FROM application_outcomes WHERE tenant_id = ? AND job_key = ? AND kind = ?",
-    [tenantId, jobUrl, kind],
+    `SELECT COUNT(*) AS c
+       FROM application_outcomes
+      WHERE ${reference.sql} AND kind = ?`,
+    [...reference.params, kind],
   );
   return Number(row?.c ?? 0) > 0;
 }

--- a/apps/api/src/read-model.ts
+++ b/apps/api/src/read-model.ts
@@ -76,6 +76,8 @@ import {
   allRows,
   getRow,
   hasCompositeJobIdForeignKey,
+  jobKeyReferenceColumn,
+  jobKeyReferencePredicateForUrl,
   jobReferenceColumn,
   tableColumnSet,
   tableExists,
@@ -797,6 +799,10 @@ const FOLLOW_UP_STOP_OUTCOMES = new Set([
 function countFollowUpsDue(db: SqliteDatabase, now: Date): number {
   if (!tableExists(db, "application_outcomes")) return 0;
   const cutoff = new Date(now.getTime() - DIGEST_FOLLOW_UP_THRESHOLD_DAYS * 24 * 60 * 60 * 1000).toISOString();
+  const outcomeReference = jobKeyReferenceColumn(
+    db,
+    "application_outcomes",
+  );
   const rows = allRows<{
     job_key: string;
     kind: string;
@@ -804,10 +810,10 @@ function countFollowUpsDue(db: SqliteDatabase, now: Date): number {
     recorded_at: string | null;
   }>(
     db,
-    `SELECT job_key, kind, occurred_at, recorded_at
+    `SELECT ${outcomeReference} AS job_key, kind, occurred_at, recorded_at
        FROM application_outcomes
       WHERE tenant_id = ?
-      ORDER BY job_key ASC, occurred_at ASC, recorded_at ASC`,
+      ORDER BY ${outcomeReference} ASC, occurred_at ASC, recorded_at ASC`,
     [DEFAULT_TENANT],
   );
   const byJob = new Map<string, { appliedAt: string | null; lastActivityAt: string | null; stopped: boolean }>();
@@ -1552,13 +1558,19 @@ function appendApplicationOutcomeAuditEntries(
   seenReferences: Set<string>,
 ): void {
   if (!tableExists(db, "application_outcomes")) return;
+  const reference = jobKeyReferencePredicateForUrl(
+    db,
+    "application_outcomes",
+    jobId,
+    DEFAULT_TENANT,
+  );
   const rows = allRows<ApplicationOutcomeAuditRow>(
     db,
     `SELECT outcome_id, kind, source, note, occurred_at, recorded_at, suggestion_id, evidence_id
        FROM application_outcomes
-      WHERE tenant_id = ? AND job_key = ?
+      WHERE ${reference.sql}
       ORDER BY occurred_at ASC, recorded_at ASC, outcome_id ASC`,
-    [DEFAULT_TENANT, jobId],
+    reference.params,
   );
   for (const row of rows) {
     if (seenReferences.has(`outcome:${row.outcome_id}`)) continue;

--- a/apps/api/src/repeat-application.ts
+++ b/apps/api/src/repeat-application.ts
@@ -15,6 +15,8 @@ import {
   allRows,
   getRow,
   hasCompositeJobIdForeignKey,
+  jobKeyReferenceColumn,
+  jobKeyReferenceJoinToJobs,
   tableExists,
   type SqliteDatabase,
 } from "./db.js";
@@ -355,16 +357,32 @@ function confirmedApplicationFacts(db: SqliteDatabase): ConfirmedFactRow[] {
     );
   }
   if (tableExists(db, "application_outcomes")) {
+    const stableOutcomeReferences =
+      jobKeyReferenceColumn(db, "application_outcomes") === "job_id";
+    const outcomeJobKey = stableOutcomeReferences
+      ? "jobs.url"
+      : "outcomes.job_key";
+    const outcomeIdentityJoin = stableOutcomeReferences
+      ? `JOIN jobs
+           ON ${jobKeyReferenceJoinToJobs(
+             db,
+             "application_outcomes",
+             "outcomes",
+             "jobs",
+           )}`
+      : "";
     facts.push(
       ...allRows<ConfirmedFactRow>(
         db,
-        `SELECT job_key,
+        `SELECT ${outcomeJobKey} AS job_key,
                 'applied_confirmation' AS fact_kind,
-                'outcome:' || outcome_id AS fact_id,
-                occurred_at AS confirmed_at,
+                'outcome:' || outcomes.outcome_id AS fact_id,
+                outcomes.occurred_at AS confirmed_at,
                 20 AS priority
-           FROM application_outcomes
-          WHERE tenant_id = ? AND kind = 'applied_confirmation'`,
+           FROM application_outcomes AS outcomes
+           ${outcomeIdentityJoin}
+          WHERE outcomes.tenant_id = ?
+            AND outcomes.kind = 'applied_confirmation'`,
         [DEFAULT_TENANT],
       ),
     );

--- a/apps/api/src/write-model.ts
+++ b/apps/api/src/write-model.ts
@@ -26,6 +26,7 @@ import {
   allRows,
   getRow,
   hasCompositeJobIdForeignKey,
+  jobKeyReferenceColumn,
   jobReferenceColumn,
   jobReferenceForUrl,
   jobReferencePredicateForUrl,
@@ -851,7 +852,7 @@ function purgeJobRows(db: SqliteDatabase, jobUrl: string): void {
     }
   }
   deleteWhere(db, "job_events", "job_url = ?", [jobUrl]);
-  deleteApplicationReviewDecisionReferences(
+  deleteApplicationFeedbackReferences(
     db,
     jobId,
     jobUrl,
@@ -1023,32 +1024,26 @@ function deleteScoringJobReferences(
   }
 }
 
-function deleteApplicationReviewDecisionReferences(
+function deleteApplicationFeedbackReferences(
   db: SqliteDatabase,
   jobId: string | undefined,
   jobUrl: string,
 ): void {
-  if (!tableExists(db, "application_review_decisions")) return;
-  const stableReferences = tableColumnSet(
-    db,
+  for (const tableName of [
     "application_review_decisions",
-  ).has("job_id");
-  if (stableReferences) {
-    if (!jobId) return;
+    "application_outcomes",
+  ]) {
+    if (!tableExists(db, tableName)) continue;
+    const referenceColumn = jobKeyReferenceColumn(db, tableName);
+    const reference = referenceColumn === "job_id" ? jobId : jobUrl;
+    if (!reference) continue;
     deleteWhere(
       db,
-      "application_review_decisions",
-      "tenant_id = ? AND job_id = ?",
-      ["local", jobId],
+      tableName,
+      `tenant_id = ? AND ${referenceColumn} = ?`,
+      ["local", reference],
     );
-    return;
   }
-  deleteWhere(
-    db,
-    "application_review_decisions",
-    "tenant_id = ? AND job_key = ?",
-    ["local", jobUrl],
-  );
 }
 
 function deleteJobReferences(

--- a/apps/api/test/application-outcomes-v21.test.ts
+++ b/apps/api/test/application-outcomes-v21.test.ts
@@ -1,0 +1,196 @@
+import Database from "better-sqlite3";
+import { describe, expect, it } from "vitest";
+
+import {
+  ensureApplicationFeedbackTables,
+  listJobApplicationOutcomes,
+  recordManualApplicationOutcome,
+} from "../src/application-feedback.js";
+import { permanentlyDeleteJob } from "../src/write-model.js";
+
+const UUID_SHAPED_URL = "11111111-1111-4111-8111-111111111111";
+const URL_OWNER_JOB_ID = "22222222-2222-4222-8222-222222222222";
+const ID_TEXT_OWNER_URL = "https://example.com/jobs/id-text-owner";
+const OTHER_TENANT_URL = "https://example.com/jobs/other-tenant-outcome";
+
+function createSchema(db: Database.Database): void {
+  db.pragma("foreign_keys = OFF");
+  expect(db.pragma("foreign_keys", { simple: true })).toBe(0);
+  db.pragma("user_version = 21");
+  db.exec(`
+    CREATE TABLE jobs (
+      url TEXT PRIMARY KEY,
+      tenant_id TEXT NOT NULL DEFAULT 'local',
+      job_id TEXT NOT NULL,
+      title TEXT,
+      application_url TEXT,
+      tailored_resume_path TEXT,
+      cover_letter_path TEXT,
+      UNIQUE (tenant_id, job_id)
+    );
+  `);
+}
+
+function seedCollisionGraph(db: Database.Database): void {
+  const insert = db.prepare(
+    `INSERT INTO jobs (
+       url, tenant_id, job_id, title, application_url
+     ) VALUES (?, ?, ?, 'Platform Engineer', NULL)`,
+  );
+  insert.run(UUID_SHAPED_URL, "local", URL_OWNER_JOB_ID);
+  insert.run(ID_TEXT_OWNER_URL, "local", UUID_SHAPED_URL);
+  insert.run(OTHER_TENANT_URL, "tenant-b", URL_OWNER_JOB_ID);
+}
+
+function seedOutcome(
+  db: Database.Database,
+  input: {
+    tenantId: string;
+    outcomeId: string;
+    jobId: string;
+  },
+): void {
+  db.prepare(
+    `INSERT INTO application_outcomes (
+       tenant_id, outcome_id, job_id, kind, source, occurred_at,
+       recorded_at, created_by
+     ) VALUES (?, ?, ?, 'interview', 'manual', ?, ?, 'user')`,
+  ).run(
+    input.tenantId,
+    input.outcomeId,
+    input.jobId,
+    "2026-07-30T10:00:00.000Z",
+    "2026-07-30T10:00:00.000Z",
+  );
+}
+
+describe("schema-v21 reviewed application-outcome API compatibility", () => {
+  it("stores a UUID-shaped posting URL under its URL owner's JobId", () => {
+    const db = new Database(":memory:");
+    createSchema(db);
+    seedCollisionGraph(db);
+    ensureApplicationFeedbackTables(db);
+
+    const result = recordManualApplicationOutcome(
+      db,
+      UUID_SHAPED_URL,
+      {
+        kind: "interview",
+        occurredAt: "2026-07-30T10:00:00.000Z",
+        note: "Recruiter screen booked.",
+      },
+    );
+
+    expect(result.outcome).toMatchObject({
+      jobKey: UUID_SHAPED_URL,
+      kind: "interview",
+    });
+    expect(
+      db.prepare(
+        `SELECT tenant_id, job_id, kind
+           FROM application_outcomes`,
+      ).get(),
+    ).toEqual({
+      tenant_id: "local",
+      job_id: URL_OWNER_JOB_ID,
+      kind: "interview",
+    });
+    expect(
+      listJobApplicationOutcomes(db, UUID_SHAPED_URL),
+    ).toMatchObject({
+      ok: true,
+      jobKey: UUID_SHAPED_URL,
+      outcomes: [
+        expect.objectContaining({
+          jobKey: UUID_SHAPED_URL,
+          kind: "interview",
+        }),
+      ],
+    });
+    db.close();
+  });
+
+  it("deletes only the URL owner's outcome history with cascades off", () => {
+    const db = new Database(":memory:");
+    createSchema(db);
+    seedCollisionGraph(db);
+    ensureApplicationFeedbackTables(db);
+    seedOutcome(db, {
+      tenantId: "local",
+      outcomeId: "url-owner",
+      jobId: URL_OWNER_JOB_ID,
+    });
+    seedOutcome(db, {
+      tenantId: "local",
+      outcomeId: "id-owner",
+      jobId: UUID_SHAPED_URL,
+    });
+    seedOutcome(db, {
+      tenantId: "tenant-b",
+      outcomeId: "other-tenant",
+      jobId: URL_OWNER_JOB_ID,
+    });
+
+    expect(permanentlyDeleteJob(db, UUID_SHAPED_URL)).toEqual({
+      ok: true,
+      count: 1,
+      jobKeys: [UUID_SHAPED_URL],
+    });
+    expect(
+      db.prepare(
+        `SELECT tenant_id, outcome_id, job_id
+           FROM application_outcomes
+          ORDER BY tenant_id, outcome_id`,
+      ).all(),
+    ).toEqual([
+      {
+        tenant_id: "local",
+        outcome_id: "id-owner",
+        job_id: UUID_SHAPED_URL,
+      },
+      {
+        tenant_id: "tenant-b",
+        outcome_id: "other-tenant",
+        job_id: URL_OWNER_JOB_ID,
+      },
+    ]);
+    expect(
+      db.prepare("SELECT url FROM jobs ORDER BY url").all(),
+    ).toEqual([
+      { url: ID_TEXT_OWNER_URL },
+      { url: OTHER_TENANT_URL },
+    ]);
+    expect(db.pragma("foreign_key_check")).toEqual([]);
+    db.close();
+  });
+
+  it.each([
+    [0, "job_key"],
+    [20, "job_key"],
+    [21, "job_id"],
+  ])(
+    "creates the version-aware outcome reference at schema %i",
+    (schemaVersion, expectedReference) => {
+      const db = new Database(":memory:");
+      db.pragma(`user_version = ${schemaVersion}`);
+      db.exec(`
+        CREATE TABLE jobs (
+          url TEXT PRIMARY KEY,
+          tenant_id TEXT NOT NULL DEFAULT 'local',
+          job_id TEXT NOT NULL,
+          UNIQUE (tenant_id, job_id)
+        );
+      `);
+      ensureApplicationFeedbackTables(db);
+      const columns = new Set(
+        (db.prepare("PRAGMA table_info(application_outcomes)").all() as Array<{ name: string }>)
+          .map((row) => row.name),
+      );
+      expect(columns.has(expectedReference)).toBe(true);
+      expect(
+        columns.has(expectedReference === "job_id" ? "job_key" : "job_id"),
+      ).toBe(false);
+      db.close();
+    },
+  );
+});

--- a/apps/api/test/schema-version-guard.test.ts
+++ b/apps/api/test/schema-version-guard.test.ts
@@ -63,7 +63,7 @@ describe("schema version guard at DB open", () => {
   });
 
   it("opens the worker-owned schema-v14 artifact registry", () => {
-    expect(SUPPORTED_SCHEMA_VERSION).toBe(20);
+    expect(SUPPORTED_SCHEMA_VERSION).toBe(21);
     const { dbPath, cleanup } = makeDbWithUserVersion(14);
     try {
       openDatabase(dbPath).close();

--- a/workers/automation/src/jobctrl/database.py
+++ b/workers/automation/src/jobctrl/database.py
@@ -77,7 +77,10 @@ from jobctrl.config import DB_PATH, DEFAULTS, migrate_legacy_job_tables
 # v20 (application-review references): every append-only Apply Review decision
 # references the tenant-scoped stable Job aggregate. URL aliases, including
 # UUID-shaped posting URLs, are resolved URL-first without collapsing history.
-SCHEMA_VERSION = 20
+# v21 (application-outcome references): every reviewed application outcome
+# references the tenant-scoped stable Job aggregate. Append-only history and
+# immutable links to Interview Preparation generations remain exact.
+SCHEMA_VERSION = 21
 
 
 class IncompatibleSchemaVersionError(RuntimeError):
@@ -228,6 +231,7 @@ def _schema_migrations() -> tuple[
         (18, ensure_interview_prep_references_v18),
         (19, ensure_compensation_references_v19),
         (20, ensure_application_review_references_v20),
+        (21, ensure_application_outcome_references_v21),
     )
 
 
@@ -397,6 +401,10 @@ def init_db(db_path: Path | str | None = None) -> sqlite3.Connection:
             decided_at DESC
         )
     """ % application_review_reference)
+    _ensure_application_outcome_table_for_version(
+        conn,
+        current_version=current_version,
+    )
     ensure_profile_tables(conn)
     ensure_score_tables(conn)
     ensure_tailoring_policy_tables(conn)
@@ -4661,6 +4669,13 @@ def _reassign_discovery_identity_references(
         )
     if _has_application_review_reference_schema_v20(conn):
         _reassign_application_review_references_v20(
+            conn,
+            tenant_id=tenant_id,
+            losing_job_id=losing_job_id,
+            surviving_job_id=surviving_job_id,
+        )
+    if _has_application_outcome_reference_schema_v21(conn):
+        _reassign_application_outcome_references_v21(
             conn,
             tenant_id=tenant_id,
             losing_job_id=losing_job_id,
@@ -11500,24 +11515,30 @@ def _remap_application_outcome_interview_prep_generations_v18(
 ) -> None:
     """Preserve immutable outcome-to-preparation links during renumbering.
 
-    Application outcomes remain URL-keyed until their own identity-reference
-    migration. Only the linked preparation generation is rewritten here, using
-    the exact source URL/JobId that owned the generation before histories were
-    merged.
+    The outcome reference may be the legacy URL-shaped ``job_key`` or the
+    stable ``job_id`` introduced in schema v21. Only the linked preparation
+    generation is rewritten, using the exact source reference that owned the
+    generation before histories were merged.
     """
     columns = _table_columns(conn, "application_outcomes")
+    reference_column = (
+        "job_id"
+        if "job_id" in columns
+        else "job_key"
+        if "job_key" in columns
+        else None
+    )
     required = {
         "tenant_id",
         "outcome_id",
-        "job_key",
         "interview_prep_generation",
     }
-    if not required.issubset(columns):
+    if reference_column is None or not required.issubset(columns):
         return
 
     rows = conn.execute(
-        """
-        SELECT tenant_id, outcome_id, job_key,
+        f"""
+        SELECT tenant_id, outcome_id, {reference_column},
                interview_prep_generation
         FROM application_outcomes
         WHERE interview_prep_generation IS NOT NULL
@@ -11535,12 +11556,12 @@ def _remap_application_outcome_interview_prep_generations_v18(
         if new_generation is None:
             continue
         updated = conn.execute(
-            """
+            f"""
             UPDATE application_outcomes
             SET interview_prep_generation = ?
             WHERE tenant_id = ?
               AND outcome_id = ?
-              AND job_key = ?
+              AND {reference_column} = ?
               AND interview_prep_generation = ?
             """,
             (
@@ -11923,19 +11944,23 @@ def _reassign_interview_prep_references_v18(
     _remap_application_outcome_interview_prep_generations_v18(
         conn,
         generation_map={
-            (
-                tenant_id,
-                (
-                    losing_job_url
-                    if old_job_id == losing_job_id
-                    else surviving_job_url
-                ),
-                old_generation,
-            ): new_generation
+            key: new_generation
             for (
                 old_job_id,
                 old_generation,
             ), new_generation in generation_map.items()
+            for key in (
+                (tenant_id, old_job_id, old_generation),
+                (
+                    tenant_id,
+                    (
+                        losing_job_url
+                        if old_job_id == losing_job_id
+                        else surviving_job_url
+                    ),
+                    old_generation,
+                ),
+            )
         },
     )
     _verify_interview_prep_references_v18(
@@ -12752,6 +12777,367 @@ def _reassign_application_review_references_v20(
         (surviving_job_id, tenant_id, losing_job_id),
     )
     _verify_application_review_references_v20(
+        conn,
+        expected_count=expected_count,
+    )
+
+
+_APPLICATION_OUTCOME_REFERENCE_SCHEMA_VERSION = 21
+_APPLICATION_OUTCOME_REFERENCE_TABLE = "application_outcomes"
+
+
+def _create_application_outcome_table_v21(
+    conn: sqlite3.Connection,
+    *,
+    table: str,
+    stable_reference: bool,
+) -> None:
+    reference_column = "job_id" if stable_reference else "job_key"
+    foreign_key = (
+        """,
+            FOREIGN KEY (tenant_id, job_id)
+                REFERENCES jobs(tenant_id, job_id) ON DELETE CASCADE"""
+        if stable_reference
+        else ""
+    )
+    conn.execute(
+        f"""
+        CREATE TABLE "{table}" (
+            tenant_id                TEXT NOT NULL DEFAULT 'local',
+            outcome_id               TEXT NOT NULL,
+            {reference_column}       TEXT NOT NULL,
+            kind                     TEXT NOT NULL,
+            source                   TEXT NOT NULL,
+            note                     TEXT,
+            occurred_at              TEXT NOT NULL,
+            recorded_at              TEXT NOT NULL,
+            suggestion_id            TEXT,
+            evidence_id              TEXT,
+            created_by               TEXT NOT NULL DEFAULT 'user',
+            interview_prep_generation INTEGER,
+            PRIMARY KEY (tenant_id, outcome_id)
+            {foreign_key}
+        )
+        """
+    )
+
+
+def _create_application_outcome_reference_index_v21(
+    conn: sqlite3.Connection,
+    *,
+    reference_column: str,
+) -> None:
+    expected_columns = (
+        "tenant_id",
+        reference_column,
+        "occurred_at",
+        "recorded_at",
+    )
+    if not _has_index(
+        conn,
+        _APPLICATION_OUTCOME_REFERENCE_TABLE,
+        "idx_application_outcomes_job",
+        expected_columns,
+        unique=False,
+    ):
+        conn.execute("DROP INDEX IF EXISTS idx_application_outcomes_job")
+        conn.execute(
+            f"""
+            CREATE INDEX idx_application_outcomes_job
+            ON application_outcomes(
+                tenant_id,
+                {reference_column},
+                occurred_at DESC,
+                recorded_at DESC
+            )
+            """
+        )
+
+
+def _ensure_application_outcome_table_for_version(
+    conn: sqlite3.Connection,
+    *,
+    current_version: int,
+) -> None:
+    """Recover a missing outcome table without skipping ordered migration."""
+    table = _APPLICATION_OUTCOME_REFERENCE_TABLE
+    columns = _table_columns(conn, table)
+    if not columns:
+        _create_application_outcome_table_v21(
+            conn,
+            table=table,
+            stable_reference=(
+                current_version
+                >= _APPLICATION_OUTCOME_REFERENCE_SCHEMA_VERSION
+            ),
+        )
+        columns = _table_columns(conn, table)
+    for column, definition in (
+        ("note", "TEXT"),
+        ("suggestion_id", "TEXT"),
+        ("evidence_id", "TEXT"),
+        ("created_by", "TEXT NOT NULL DEFAULT 'user'"),
+        ("interview_prep_generation", "INTEGER"),
+    ):
+        if column in columns:
+            continue
+        conn.execute(
+            "ALTER TABLE application_outcomes "
+            f"ADD COLUMN {column} {definition}"
+        )
+        columns.add(column)
+    reference_column = (
+        "job_id"
+        if "job_id" in columns
+        else "job_key"
+        if "job_key" in columns
+        else None
+    )
+    if reference_column is None:
+        raise RuntimeError(
+            "application_outcomes has no Job identity column"
+        )
+    _create_application_outcome_reference_index_v21(
+        conn,
+        reference_column=reference_column,
+    )
+    if (
+        current_version >= _APPLICATION_OUTCOME_REFERENCE_SCHEMA_VERSION
+        and not _has_application_outcome_reference_schema_v21(conn)
+    ):
+        raise RuntimeError(
+            "schema v21 requires stable application-outcome references"
+        )
+
+
+def _has_application_outcome_reference_schema_v21(
+    conn: sqlite3.Connection,
+) -> bool:
+    table = _APPLICATION_OUTCOME_REFERENCE_TABLE
+    return (
+        "job_id" in _table_columns(conn, table)
+        and "job_key" not in _table_columns(conn, table)
+        and _primary_key_columns(conn, table)
+        == ("tenant_id", "outcome_id")
+        and _has_composite_job_id_foreign_key(
+            conn,
+            table,
+            "job_id",
+        )
+        and _has_index(
+            conn,
+            table,
+            "idx_application_outcomes_job",
+            (
+                "tenant_id",
+                "job_id",
+                "occurred_at",
+                "recorded_at",
+            ),
+            unique=False,
+        )
+    )
+
+
+def _canonical_application_outcome_rows_v21(
+    conn: sqlite3.Connection,
+) -> list[tuple[Any, ...]]:
+    rows = conn.execute(
+        """
+        SELECT tenant_id, outcome_id, job_key, kind, source, note,
+               occurred_at, recorded_at, suggestion_id, evidence_id,
+               created_by, interview_prep_generation
+        FROM application_outcomes
+        ORDER BY tenant_id, outcome_id
+        """
+    ).fetchall()
+    canonical: list[tuple[Any, ...]] = []
+    for row in rows:
+        tenant_id = str(row[0])
+        legacy_job_key = str(row[2])
+        stable_job_id = _resolve_job_reference_value(
+            conn,
+            tenant_id=tenant_id,
+            reference=legacy_job_key,
+            legacy_url=True,
+        )
+        if stable_job_id is None:
+            raise RuntimeError(
+                "application-outcome reference migration could not resolve "
+                f"application_outcomes.job_key={legacy_job_key!r}"
+            )
+        _validate_job_uuid(stable_job_id)
+        canonical.append(
+            (
+                tenant_id,
+                str(row[1]),
+                stable_job_id,
+                *tuple(row[3:]),
+            )
+        )
+    return canonical
+
+
+def ensure_application_outcome_references_v21(
+    conn: sqlite3.Connection | None = None,
+) -> list[str]:
+    """Move reviewed application outcomes to stable JobId references."""
+    if conn is None:
+        conn = get_connection()
+
+    current = _assert_schema_version_supported(conn)
+    if current >= _APPLICATION_OUTCOME_REFERENCE_SCHEMA_VERSION:
+        return []
+    if current != _APPLICATION_REVIEW_REFERENCE_SCHEMA_VERSION:
+        raise RuntimeError(
+            "application-outcome reference migration requires "
+            "application-review schema v20"
+        )
+
+    conn.execute("SAVEPOINT application_outcome_references_v21")
+    try:
+        if not _has_application_review_reference_schema_v20(conn):
+            raise RuntimeError(
+                "application-outcome reference migration requires the "
+                "stable application-review reference schema"
+            )
+        _ensure_application_outcome_table_for_version(
+            conn,
+            current_version=current,
+        )
+        if _has_application_outcome_reference_schema_v21(conn):
+            expected_count = int(
+                conn.execute(
+                    "SELECT COUNT(*) FROM application_outcomes"
+                ).fetchone()[0]
+            )
+        else:
+            rows = _canonical_application_outcome_rows_v21(conn)
+            conn.execute(
+                "DROP TABLE IF EXISTS application_outcomes_v21"
+            )
+            _create_application_outcome_table_v21(
+                conn,
+                table="application_outcomes_v21",
+                stable_reference=True,
+            )
+            conn.executemany(
+                """
+                INSERT INTO application_outcomes_v21 (
+                    tenant_id, outcome_id, job_id, kind, source, note,
+                    occurred_at, recorded_at, suggestion_id, evidence_id,
+                    created_by, interview_prep_generation
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                rows,
+            )
+            conn.execute('DROP TABLE "application_outcomes"')
+            conn.execute(
+                'ALTER TABLE "application_outcomes_v21" '
+                'RENAME TO "application_outcomes"'
+            )
+            _create_application_outcome_reference_index_v21(
+                conn,
+                reference_column="job_id",
+            )
+            expected_count = len(rows)
+        _verify_application_outcome_references_v21(
+            conn,
+            expected_count=expected_count,
+        )
+        conn.execute(
+            f"PRAGMA user_version = "
+            f"{_APPLICATION_OUTCOME_REFERENCE_SCHEMA_VERSION}"
+        )
+        conn.execute(
+            "RELEASE SAVEPOINT application_outcome_references_v21"
+        )
+        conn.commit()
+    except BaseException:
+        conn.execute(
+            "ROLLBACK TO SAVEPOINT application_outcome_references_v21"
+        )
+        conn.execute(
+            "RELEASE SAVEPOINT application_outcome_references_v21"
+        )
+        raise
+
+    return [_APPLICATION_OUTCOME_REFERENCE_TABLE]
+
+
+def _verify_application_outcome_references_v21(
+    conn: sqlite3.Connection,
+    *,
+    expected_count: int,
+) -> None:
+    if not _has_application_outcome_reference_schema_v21(conn):
+        raise RuntimeError(
+            "application-outcome reference migration did not create the "
+            "stable reference schema"
+        )
+    observed_count = int(
+        conn.execute(
+            "SELECT COUNT(*) FROM application_outcomes"
+        ).fetchone()[0]
+    )
+    if observed_count != expected_count:
+        raise RuntimeError(
+            "application-outcome reference migration changed append-only "
+            f"history count: expected {expected_count}, "
+            f"found {observed_count}"
+        )
+    orphan = conn.execute(
+        """
+        SELECT outcomes.job_id
+        FROM application_outcomes AS outcomes
+        LEFT JOIN jobs
+          ON jobs.tenant_id = outcomes.tenant_id
+         AND jobs.job_id = outcomes.job_id
+        WHERE jobs.job_id IS NULL
+        LIMIT 1
+        """
+    ).fetchone()
+    if orphan is not None:
+        raise RuntimeError(
+            "application-outcome reference migration left an unresolved JobId"
+        )
+    for row in conn.execute(
+        "SELECT DISTINCT job_id FROM application_outcomes"
+    ).fetchall():
+        _validate_job_uuid(str(row[0]))
+    foreign_key_error = conn.execute(
+        "PRAGMA foreign_key_check"
+    ).fetchone()
+    if foreign_key_error is not None:
+        raise RuntimeError(
+            "application-outcome reference migration found a foreign-key "
+            "violation"
+        )
+
+
+def _reassign_application_outcome_references_v21(
+    conn: sqlite3.Connection,
+    *,
+    tenant_id: str,
+    losing_job_id: str,
+    surviving_job_id: str,
+) -> None:
+    if losing_job_id == surviving_job_id:
+        return
+    expected_count = int(
+        conn.execute(
+            "SELECT COUNT(*) FROM application_outcomes"
+        ).fetchone()[0]
+    )
+    conn.execute(
+        """
+        UPDATE application_outcomes
+        SET job_id = ?
+        WHERE tenant_id = ? AND job_id = ?
+        """,
+        (surviving_job_id, tenant_id, losing_job_id),
+    )
+    _verify_application_outcome_references_v21(
         conn,
         expected_count=expected_count,
     )

--- a/workers/automation/src/jobctrl/digest.py
+++ b/workers/automation/src/jobctrl/digest.py
@@ -773,12 +773,18 @@ def _count_follow_ups_due(conn: sqlite3.Connection, *, now: datetime) -> int:
     if not _table_exists(conn, "application_outcomes"):
         return 0
     cutoff = _format_utc_timestamp(now - timedelta(days=FOLLOW_UP_THRESHOLD_DAYS))
+    outcome_reference = (
+        "job_id"
+        if "job_id" in _table_columns(conn, "application_outcomes")
+        else "job_key"
+    )
     rows = conn.execute(
-        """
-        SELECT job_key, kind, occurred_at, recorded_at
+        f"""
+        SELECT {outcome_reference} AS job_key,
+               kind, occurred_at, recorded_at
         FROM application_outcomes
         WHERE tenant_id = ?
-        ORDER BY job_key ASC, occurred_at ASC, recorded_at ASC
+        ORDER BY {outcome_reference} ASC, occurred_at ASC, recorded_at ASC
         """,
         (TENANT_ID,),
     ).fetchall()

--- a/workers/automation/src/jobctrl/domain/apply/repeat_application.py
+++ b/workers/automation/src/jobctrl/domain/apply/repeat_application.py
@@ -356,13 +356,31 @@ def _confirmed_application_facts(conn) -> list[dict[str, Any]]:
         ).fetchall():
             facts.append(dict(row))
     if _table_exists(conn, "application_outcomes"):
-        for row in conn.execute(
+        stable_outcome_references = (
+            "job_id" in _table_columns(conn, "application_outcomes")
+        )
+        outcome_job_key = (
+            "jobs.url" if stable_outcome_references else "outcomes.job_key"
+        )
+        outcome_identity_join = (
             """
-            SELECT job_key, 'applied_confirmation' AS fact_kind,
-                   'outcome:' || outcome_id AS fact_id,
-                   occurred_at AS confirmed_at, 20 AS priority
-              FROM application_outcomes
-             WHERE tenant_id = ? AND kind = 'applied_confirmation'
+            JOIN jobs
+              ON jobs.tenant_id = outcomes.tenant_id
+             AND jobs.job_id = outcomes.job_id
+            """
+            if stable_outcome_references
+            else ""
+        )
+        for row in conn.execute(
+            f"""
+            SELECT {outcome_job_key} AS job_key,
+                   'applied_confirmation' AS fact_kind,
+                   'outcome:' || outcomes.outcome_id AS fact_id,
+                   outcomes.occurred_at AS confirmed_at, 20 AS priority
+              FROM application_outcomes AS outcomes
+              {outcome_identity_join}
+             WHERE outcomes.tenant_id = ?
+               AND outcomes.kind = 'applied_confirmation'
             """,
             (LOCAL_TENANT,),
         ).fetchall():
@@ -665,6 +683,15 @@ def _table_exists(conn, table_name: str) -> bool:
         ).fetchone()
         is not None
     )
+
+
+def _table_columns(conn, table_name: str) -> set[str]:
+    return {
+        str(row[1])
+        for row in conn.execute(
+            f'PRAGMA table_info("{table_name}")'
+        ).fetchall()
+    }
 
 
 def _compact_json(value: Any) -> str:

--- a/workers/automation/src/jobctrl/infrastructure/gmail/feedback.py
+++ b/workers/automation/src/jobctrl/infrastructure/gmail/feedback.py
@@ -27,6 +27,7 @@ MAX_LIMIT = 100
 MAX_RESULTS_PER_ANCHOR = 20
 MAX_WINDOW_DAYS = 180
 APPLICATION_REVIEW_REFERENCE_SCHEMA_VERSION = 20
+APPLICATION_OUTCOME_REFERENCE_SCHEMA_VERSION = 21
 
 _EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
 _TOKEN_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._+-]{1,64}")
@@ -264,6 +265,19 @@ def ensure_application_feedback_tables(conn: sqlite3.Connection) -> None:
         if stable_review_schema
         else ""
     )
+    stable_outcome_schema = (
+        schema_version >= APPLICATION_OUTCOME_REFERENCE_SCHEMA_VERSION
+    )
+    created_outcome_reference = (
+        "job_id" if stable_outcome_schema else "job_key"
+    )
+    outcome_foreign_key = (
+        """,
+          FOREIGN KEY (tenant_id, job_id)
+            REFERENCES jobs(tenant_id, job_id) ON DELETE CASCADE"""
+        if stable_outcome_schema
+        else ""
+    )
     conn.executescript(
         f"""
         CREATE TABLE IF NOT EXISTS application_review_decisions (
@@ -287,7 +301,7 @@ def ensure_application_feedback_tables(conn: sqlite3.Connection) -> None:
         CREATE TABLE IF NOT EXISTS application_outcomes (
           tenant_id     TEXT NOT NULL DEFAULT 'local',
           outcome_id    TEXT NOT NULL,
-          job_key       TEXT NOT NULL,
+          {created_outcome_reference} TEXT NOT NULL,
           kind          TEXT NOT NULL,
           source        TEXT NOT NULL,
           note          TEXT,
@@ -296,10 +310,10 @@ def ensure_application_feedback_tables(conn: sqlite3.Connection) -> None:
           suggestion_id TEXT,
           evidence_id   TEXT,
           created_by    TEXT NOT NULL DEFAULT 'user',
+          interview_prep_generation INTEGER,
           PRIMARY KEY (tenant_id, outcome_id)
+          {outcome_foreign_key}
         );
-        CREATE INDEX IF NOT EXISTS idx_application_outcomes_job
-          ON application_outcomes(tenant_id, job_key, occurred_at DESC, recorded_at DESC);
 
         CREATE TABLE IF NOT EXISTS application_email_evidence (
           tenant_id            TEXT NOT NULL DEFAULT 'local',
@@ -374,6 +388,28 @@ def ensure_application_feedback_tables(conn: sqlite3.Connection) -> None:
         )
         """
         % review_reference
+    )
+    _ensure_columns(
+        conn,
+        "application_outcomes",
+        {"interview_prep_generation": "INTEGER"},
+    )
+    outcome_reference = (
+        "job_id"
+        if "job_id" in _columns(conn, "application_outcomes")
+        else "job_key"
+    )
+    conn.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_application_outcomes_job
+        ON application_outcomes(
+            tenant_id,
+            %s,
+            occurred_at DESC,
+            recorded_at DESC
+        )
+        """
+        % outcome_reference
     )
 
 
@@ -678,12 +714,20 @@ def _outcome_anchors(conn: sqlite3.Connection) -> list[ApplicationAnchor]:
     title_expr = _column_expr(columns, "title", prefix="j")
     company_expr = _first_column_expr(columns, ["company", "site", "employer"], prefix="j")
     application_url_expr = _column_expr(columns, "application_url", prefix="j")
+    outcome_columns = _columns(conn, "application_outcomes")
+    stable_references = "job_id" in outcome_columns
+    outcome_job_key = "j.url" if stable_references else "o.job_key"
+    identity_join = (
+        "j.tenant_id = o.tenant_id AND j.job_id = o.job_id"
+        if stable_references
+        else "j.url = o.job_key"
+    )
     rows = conn.execute(
         f"""
-        SELECT o.job_key AS job_key, {title_expr} AS title, {company_expr} AS company,
+        SELECT {outcome_job_key} AS job_key, {title_expr} AS title, {company_expr} AS company,
                {application_url_expr} AS application_url, o.occurred_at AS anchor_at
         FROM application_outcomes o
-        LEFT JOIN jobs j ON j.url = o.job_key
+        LEFT JOIN jobs j ON {identity_join}
         WHERE o.tenant_id = ?
           AND o.kind IN (
             'applied_confirmation', 'recruiter_reply', 'interview',

--- a/workers/automation/src/jobctrl/infrastructure/projections/projection_builder.py
+++ b/workers/automation/src/jobctrl/infrastructure/projections/projection_builder.py
@@ -2746,15 +2746,23 @@ class ProjectionBuilder:
 
     def _has_application_outcome_kind(self, job_url: str, kind: str) -> bool:
         try:
+            reference_sql, reference_params = (
+                _job_key_reference_predicate_for_url(
+                    self._conn,
+                    "application_outcomes",
+                    job_url,
+                    tenant_id=str(self._tenant_id),
+                )
+            )
             row = self._conn.execute(
-                """
+                f"""
                 SELECT COUNT(*) AS c
                 FROM application_outcomes
-                WHERE tenant_id = ? AND job_key = ? AND kind = ?
+                WHERE {reference_sql} AND kind = ?
                 """,
-                (str(self._tenant_id), job_url, kind),
+                (*reference_params, kind),
             ).fetchone()
-        except sqlite3.OperationalError:
+        except (sqlite3.OperationalError, ValueError):
             return False
         return int(_row_nullable_int(row, "c") or 0) > 0
 
@@ -3395,8 +3403,32 @@ class ProjectionBuilder:
 
     def _load_outcomes_by_job(self) -> dict[str, tuple[dict[str, str | None], ...]]:
         try:
+            stable_references = _has_column(
+                self._conn,
+                "application_outcomes",
+                "job_id",
+            )
+            job_key_select = (
+                "jobs.url" if stable_references else "outcomes.job_key"
+            )
+            identity_join = (
+                """
+                JOIN jobs
+                  ON jobs.tenant_id = outcomes.tenant_id
+                 AND jobs.job_id = outcomes.job_id
+                """
+                if stable_references
+                else ""
+            )
             rows = self._conn.execute(
-                "SELECT job_key, kind, occurred_at FROM application_outcomes WHERE tenant_id = ?",
+                f"""
+                SELECT {job_key_select} AS job_key,
+                       outcomes.kind,
+                       outcomes.occurred_at
+                FROM application_outcomes AS outcomes
+                {identity_join}
+                WHERE outcomes.tenant_id = ?
+                """,
                 (str(self._tenant_id),),
             ).fetchall()
         except sqlite3.OperationalError:
@@ -4248,6 +4280,47 @@ def _job_reference_predicate_for_url(
     prefix = f"{alias}." if alias else ""
     if not _has_column(conn, table_name, "job_id"):
         return f"{prefix}job_url = ?", (job_url,)
+    row = conn.execute(
+        """
+        SELECT j.tenant_id, j.job_id
+        FROM jobs j
+        WHERE j.tenant_id = ? AND j.url = ?
+        UNION ALL
+        SELECT alias.tenant_id, alias.job_id
+        FROM job_identity_aliases alias
+        JOIN jobs j
+          ON j.tenant_id = alias.tenant_id
+         AND j.job_id = alias.job_id
+        WHERE alias.tenant_id = ?
+          AND alias.alias_kind = 'posting_url'
+          AND alias.alias_value = ?
+        LIMIT 1
+        """,
+        (tenant_id, job_url, tenant_id, job_url),
+    ).fetchone()
+    if row is None:
+        raise ValueError(f"no stable Job identity for posting URL: {job_url}")
+    return f"{prefix}tenant_id = ? AND {prefix}job_id = ?", (
+        str(row[0]),
+        str(row[1]),
+    )
+
+
+def _job_key_reference_predicate_for_url(
+    conn: sqlite3.Connection,
+    table_name: str,
+    job_url: str,
+    *,
+    tenant_id: str,
+    alias: str = "",
+) -> tuple[str, tuple[str, ...]]:
+    """Resolve a URL for tables whose legacy reference is ``job_key``."""
+    prefix = f"{alias}." if alias else ""
+    if not _has_column(conn, table_name, "job_id"):
+        return (
+            f"{prefix}tenant_id = ? AND {prefix}job_key = ?",
+            (tenant_id, job_url),
+        )
     row = conn.execute(
         """
         SELECT j.tenant_id, j.job_id

--- a/workers/automation/tests/test_application_outcome_identity_reference_migration.py
+++ b/workers/automation/tests/test_application_outcome_identity_reference_migration.py
@@ -1,0 +1,616 @@
+"""Schema-v21 reviewed application-outcome JobId reference contracts."""
+
+from __future__ import annotations
+
+import sqlite3
+import uuid
+from pathlib import Path
+
+import pytest
+
+import jobctrl.database as database_module
+from jobctrl.database import (
+    SCHEMA_VERSION,
+    close_connection,
+    ensure_application_outcome_references_v21,
+    init_db,
+    reassign_discovery_identity_references,
+)
+from jobctrl.domain.discovery import (
+    Employer,
+    Job,
+    JobMetadata,
+    PostingUrl,
+    SearchStrategy,
+    Source,
+)
+from jobctrl.domain.identifiers import JobId
+from jobctrl.domain.tenant import LOCAL_TENANT
+from jobctrl.infrastructure.discovery import SqliteJobRepository
+
+
+PREVIOUS_SCHEMA_VERSION = 20
+
+
+def _discovered_job(posting_url: str, job_id: JobId) -> Job:
+    return Job.discover(
+        tenant_id=LOCAL_TENANT,
+        job_id=job_id,
+        posting_url=PostingUrl(value=posting_url),
+        source=Source(board="example"),
+        employer=Employer(name="Example"),
+        search_strategy=SearchStrategy.JOBSPY,
+        metadata=JobMetadata(title="Platform Engineer"),
+        discovered_at="2026-07-30T10:00:00+00:00",
+    )
+
+
+def _downgrade_application_outcomes_to_v20(
+    conn: sqlite3.Connection,
+) -> None:
+    conn.execute("DROP TABLE application_outcomes")
+    conn.executescript(
+        """
+        CREATE TABLE application_outcomes (
+            tenant_id                 TEXT NOT NULL DEFAULT 'local',
+            outcome_id                TEXT NOT NULL,
+            job_key                   TEXT NOT NULL,
+            kind                      TEXT NOT NULL,
+            source                    TEXT NOT NULL,
+            note                      TEXT,
+            occurred_at               TEXT NOT NULL,
+            recorded_at               TEXT NOT NULL,
+            suggestion_id             TEXT,
+            evidence_id               TEXT,
+            created_by                TEXT NOT NULL DEFAULT 'user',
+            interview_prep_generation INTEGER,
+            PRIMARY KEY (tenant_id, outcome_id)
+        );
+        CREATE INDEX idx_application_outcomes_job
+        ON application_outcomes(
+            tenant_id,
+            job_key,
+            occurred_at DESC,
+            recorded_at DESC
+        );
+        """
+    )
+    conn.execute(f"PRAGMA user_version = {PREVIOUS_SCHEMA_VERSION}")
+    conn.commit()
+
+
+def _insert_outcome(
+    conn: sqlite3.Connection,
+    *,
+    tenant_id: str,
+    outcome_id: str,
+    reference_column: str,
+    reference: str,
+    kind: str,
+    occurred_at: str,
+    generation: int | None = None,
+) -> None:
+    conn.execute(
+        f"""
+        INSERT INTO application_outcomes (
+            tenant_id, outcome_id, {reference_column}, kind, source, note,
+            occurred_at, recorded_at, suggestion_id, evidence_id,
+            created_by, interview_prep_generation
+        ) VALUES (?, ?, ?, ?, 'manual', ?, ?, ?, ?, ?, 'user', ?)
+        """,
+        (
+            tenant_id,
+            outcome_id,
+            reference,
+            kind,
+            f"note:{outcome_id}",
+            occurred_at,
+            occurred_at,
+            f"suggestion:{outcome_id}",
+            f"evidence:{outcome_id}",
+            generation,
+        ),
+    )
+
+
+def _columns(
+    conn: sqlite3.Connection,
+    table_name: str,
+) -> set[str]:
+    return {
+        str(row[1])
+        for row in conn.execute(
+            f'PRAGMA table_info("{table_name}")'
+        ).fetchall()
+    }
+
+
+def _insert_stable_prep(
+    conn: sqlite3.Connection,
+    *,
+    tenant_id: str,
+    job_id: JobId,
+    generation: int,
+    marker: str,
+    generated_at: str,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO job_interview_prep (
+            tenant_id, job_id, generation, status, model,
+            generated_at, gate_status, fabrication_findings_json,
+            grounding_findings_json, judge_verdict, warnings_json,
+            failure_reason, origin_run_id
+        ) VALUES (
+            ?, ?, ?, 'accepted', 'test-model', ?, 'passed', '[]', '[]',
+            'pass:1.00', '[]', '', ?
+        )
+        """,
+        (
+            tenant_id,
+            str(job_id),
+            generation,
+            generated_at,
+            f"run:{marker}",
+        ),
+    )
+
+
+def test_v20_outcomes_migrate_every_alias_uuid_url_and_tenant(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    conn = init_db(db_path)
+    jobs = SqliteJobRepository(conn)
+    stable_job_id = JobId(str(uuid.uuid4()))
+    storage_url = "https://boards.example/jobs/outcome"
+    alias_url = "https://careers.example/jobs/outcome"
+    jobs.save(_discovered_job(storage_url, stable_job_id))
+    jobs.save(_discovered_job(alias_url, stable_job_id))
+
+    uuid_shaped_url = str(uuid.uuid4())
+    uuid_url_owner = JobId(str(uuid.uuid4()))
+    jobs.save(_discovered_job(uuid_shaped_url, uuid_url_owner))
+    jobs.save(
+        _discovered_job(
+            "https://example.com/jobs/id-text-owner",
+            JobId(uuid_shaped_url),
+        )
+    )
+    other_tenant_url = "https://tenant-b.example/jobs/outcome"
+    conn.execute(
+        """
+        INSERT INTO jobs (
+            url, tenant_id, job_id, title, company, discovered_at
+        ) VALUES (?, 'tenant-b', ?, 'Platform Engineer', 'Example', ?)
+        """,
+        (
+            other_tenant_url,
+            str(stable_job_id),
+            "2026-07-30T10:00:00+00:00",
+        ),
+    )
+
+    _downgrade_application_outcomes_to_v20(conn)
+    for tenant_id, outcome_id, job_key, kind, occurred_at, generation in (
+        (
+            "local",
+            "storage-outcome",
+            storage_url,
+            "applied_confirmation",
+            "2026-07-30T10:00:00+00:00",
+            1,
+        ),
+        (
+            "local",
+            "alias-outcome",
+            alias_url,
+            "interview",
+            "2026-07-30T10:01:00+00:00",
+            2,
+        ),
+        (
+            "local",
+            "shared-outcome",
+            uuid_shaped_url,
+            "offer",
+            "2026-07-30T10:02:00+00:00",
+            None,
+        ),
+        (
+            "tenant-b",
+            "shared-outcome",
+            other_tenant_url,
+            "rejection",
+            "2026-07-30T10:03:00+00:00",
+            None,
+        ),
+    ):
+        _insert_outcome(
+            conn,
+            tenant_id=tenant_id,
+            outcome_id=outcome_id,
+            reference_column="job_key",
+            reference=job_key,
+            kind=kind,
+            occurred_at=occurred_at,
+            generation=generation,
+        )
+    conn.commit()
+    close_connection(db_path)
+
+    reopened = init_db(db_path)
+    assert (
+        reopened.execute("PRAGMA user_version").fetchone()[0]
+        == SCHEMA_VERSION
+        == 21
+    )
+    assert "job_id" in _columns(reopened, "application_outcomes")
+    assert "job_key" not in _columns(reopened, "application_outcomes")
+    assert [
+        tuple(row)
+        for row in reopened.execute(
+            """
+            SELECT tenant_id, outcome_id, job_id, kind, suggestion_id,
+                   evidence_id, interview_prep_generation
+            FROM application_outcomes
+            ORDER BY tenant_id, outcome_id
+            """
+        ).fetchall()
+    ] == [
+        (
+            "local",
+            "alias-outcome",
+            str(stable_job_id),
+            "interview",
+            "suggestion:alias-outcome",
+            "evidence:alias-outcome",
+            2,
+        ),
+        (
+            "local",
+            "shared-outcome",
+            str(uuid_url_owner),
+            "offer",
+            "suggestion:shared-outcome",
+            "evidence:shared-outcome",
+            None,
+        ),
+        (
+            "local",
+            "storage-outcome",
+            str(stable_job_id),
+            "applied_confirmation",
+            "suggestion:storage-outcome",
+            "evidence:storage-outcome",
+            1,
+        ),
+        (
+            "tenant-b",
+            "shared-outcome",
+            str(stable_job_id),
+            "rejection",
+            "suggestion:shared-outcome",
+            "evidence:shared-outcome",
+            None,
+        ),
+    ]
+    assert reopened.execute(
+        "PRAGMA foreign_key_check"
+    ).fetchone() is None
+    close_connection(db_path)
+
+    reopened_again = init_db(db_path)
+    assert reopened_again.execute(
+        "SELECT COUNT(*) FROM application_outcomes"
+    ).fetchone()[0] == 4
+    close_connection(db_path)
+
+
+def test_v21_outcome_migration_rolls_back_and_retries(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    conn = init_db(db_path)
+    job_id = JobId(str(uuid.uuid4()))
+    job_url = "https://example.com/jobs/outcome-retry"
+    SqliteJobRepository(conn).save(_discovered_job(job_url, job_id))
+    _downgrade_application_outcomes_to_v20(conn)
+    _insert_outcome(
+        conn,
+        tenant_id="local",
+        outcome_id="retry-outcome",
+        reference_column="job_key",
+        reference=job_url,
+        kind="interview",
+        occurred_at="2026-07-30T10:00:00+00:00",
+    )
+    conn.commit()
+    conn.execute("PRAGMA foreign_keys = ON")
+    original_verify = (
+        database_module._verify_application_outcome_references_v21
+    )
+
+    def _fail_verification(
+        _conn: sqlite3.Connection,
+        *,
+        expected_count: int,
+    ) -> None:
+        del expected_count
+        raise RuntimeError("injected outcome verification failure")
+
+    monkeypatch.setattr(
+        database_module,
+        "_verify_application_outcome_references_v21",
+        _fail_verification,
+    )
+    with pytest.raises(
+        RuntimeError,
+        match="injected outcome verification failure",
+    ):
+        ensure_application_outcome_references_v21(conn)
+    assert conn.execute("PRAGMA user_version").fetchone()[0] == 20
+    assert "job_key" in _columns(conn, "application_outcomes")
+    assert conn.execute(
+        "SELECT kind FROM application_outcomes"
+    ).fetchone()[0] == "interview"
+
+    monkeypatch.setattr(
+        database_module,
+        "_verify_application_outcome_references_v21",
+        original_verify,
+    )
+    assert ensure_application_outcome_references_v21(conn) == [
+        "application_outcomes"
+    ]
+    assert conn.execute("PRAGMA user_version").fetchone()[0] == 21
+    assert "job_id" in _columns(conn, "application_outcomes")
+    assert conn.execute("PRAGMA foreign_key_check").fetchone() is None
+    close_connection(db_path)
+
+
+@pytest.mark.parametrize(
+    ("schema_version", "expected_reference"),
+    ((0, "job_key"), (20, "job_key"), (21, "job_id")),
+)
+def test_missing_outcome_table_recovery_is_version_aware(
+    schema_version: int,
+    expected_reference: str,
+) -> None:
+    conn = sqlite3.connect(":memory:")
+    conn.executescript(
+        f"""
+        CREATE TABLE jobs (
+            url TEXT PRIMARY KEY,
+            tenant_id TEXT NOT NULL DEFAULT 'local',
+            job_id TEXT NOT NULL,
+            UNIQUE (tenant_id, job_id)
+        );
+        PRAGMA user_version = {schema_version};
+        """
+    )
+    database_module._ensure_application_outcome_table_for_version(
+        conn,
+        current_version=schema_version,
+    )
+    columns = _columns(conn, "application_outcomes")
+    assert expected_reference in columns
+    assert (
+        {"job_id", "job_key"} - {expected_reference}
+    ).isdisjoint(columns)
+    if schema_version == 21:
+        assert (
+            database_module
+            ._has_application_outcome_reference_schema_v21(conn)
+        )
+    conn.close()
+
+
+def test_gmail_v21_recovers_missing_outcome_table_with_fk_and_index() -> None:
+    from jobctrl.infrastructure.gmail.feedback import (
+        ensure_application_feedback_tables,
+    )
+
+    conn = sqlite3.connect(":memory:")
+    conn.executescript(
+        """
+        CREATE TABLE jobs (
+            url TEXT PRIMARY KEY,
+            tenant_id TEXT NOT NULL DEFAULT 'local',
+            job_id TEXT NOT NULL,
+            UNIQUE (tenant_id, job_id)
+        );
+        PRAGMA user_version = 21;
+        """
+    )
+
+    ensure_application_feedback_tables(conn)
+
+    columns = _columns(conn, "application_outcomes")
+    assert "job_id" in columns
+    assert "job_key" not in columns
+    assert database_module._has_composite_job_id_foreign_key(
+        conn,
+        "application_outcomes",
+        "job_id",
+    )
+    assert [
+        str(row[2])
+        for row in conn.execute(
+            "PRAGMA index_info(idx_application_outcomes_job)"
+        ).fetchall()
+    ] == [
+        "tenant_id",
+        "job_id",
+        "occurred_at",
+        "recorded_at",
+    ]
+    assert database_module._has_application_outcome_reference_schema_v21(
+        conn
+    )
+    conn.close()
+
+
+def test_runtime_outcome_merge_preserves_history_generation_and_tenant(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    conn = init_db(db_path)
+    jobs = SqliteJobRepository(conn)
+    losing_id = JobId(str(uuid.uuid4()))
+    surviving_id = JobId(str(uuid.uuid4()))
+    other_tenant_id = JobId(str(uuid.uuid4()))
+    losing_url = "https://example.com/jobs/outcome-losing"
+    surviving_url = "https://example.com/jobs/outcome-surviving"
+    other_tenant_url = "https://tenant-b.example/jobs/outcome"
+    jobs.save(_discovered_job(losing_url, losing_id))
+    jobs.save(_discovered_job(surviving_url, surviving_id))
+    conn.execute(
+        """
+        INSERT INTO jobs (
+            url, tenant_id, job_id, title, company, discovered_at
+        ) VALUES (?, 'tenant-b', ?, 'Platform Engineer', 'Example', ?)
+        """,
+        (
+            other_tenant_url,
+            str(other_tenant_id),
+            "2026-07-30T10:00:00+00:00",
+        ),
+    )
+    _insert_stable_prep(
+        conn,
+        tenant_id="local",
+        job_id=losing_id,
+        generation=1,
+        marker="losing",
+        generated_at="2026-07-30T10:00:00+00:00",
+    )
+    _insert_stable_prep(
+        conn,
+        tenant_id="local",
+        job_id=surviving_id,
+        generation=1,
+        marker="surviving",
+        generated_at="2026-07-30T10:01:00+00:00",
+    )
+    _insert_stable_prep(
+        conn,
+        tenant_id="tenant-b",
+        job_id=other_tenant_id,
+        generation=1,
+        marker="tenant-b",
+        generated_at="2026-07-30T10:02:00+00:00",
+    )
+    _insert_outcome(
+        conn,
+        tenant_id="local",
+        outcome_id="losing-outcome",
+        reference_column="job_id",
+        reference=str(losing_id),
+        kind="interview",
+        occurred_at="2026-07-30T11:00:00+00:00",
+        generation=1,
+    )
+    _insert_outcome(
+        conn,
+        tenant_id="local",
+        outcome_id="surviving-outcome",
+        reference_column="job_id",
+        reference=str(surviving_id),
+        kind="offer",
+        occurred_at="2026-07-30T11:01:00+00:00",
+        generation=1,
+    )
+    _insert_outcome(
+        conn,
+        tenant_id="tenant-b",
+        outcome_id="tenant-b-outcome",
+        reference_column="job_id",
+        reference=str(other_tenant_id),
+        kind="rejection",
+        occurred_at="2026-07-30T11:02:00+00:00",
+        generation=1,
+    )
+    conn.commit()
+    conn.execute("PRAGMA foreign_keys = ON")
+
+    reassign_discovery_identity_references(
+        conn,
+        losing_job_url=losing_url,
+        surviving_job_url=surviving_url,
+    )
+    conn.execute(
+        "DELETE FROM jobs WHERE tenant_id = 'local' AND url = ?",
+        (losing_url,),
+    )
+
+    assert [
+        tuple(row)
+        for row in conn.execute(
+            """
+            SELECT tenant_id, outcome_id, job_id,
+                   interview_prep_generation
+            FROM application_outcomes
+            ORDER BY tenant_id, outcome_id
+            """
+        ).fetchall()
+    ] == [
+        ("local", "losing-outcome", str(surviving_id), 1),
+        ("local", "surviving-outcome", str(surviving_id), 2),
+        ("tenant-b", "tenant-b-outcome", str(other_tenant_id), 1),
+    ]
+    assert [
+        tuple(row)
+        for row in conn.execute(
+            """
+            SELECT outcomes.outcome_id, prep.origin_run_id
+            FROM application_outcomes AS outcomes
+            JOIN job_interview_prep AS prep
+              ON prep.tenant_id = outcomes.tenant_id
+             AND prep.job_id = outcomes.job_id
+             AND prep.generation =
+                 outcomes.interview_prep_generation
+            WHERE outcomes.tenant_id = 'local'
+            ORDER BY outcomes.outcome_id
+            """
+        ).fetchall()
+    ] == [
+        ("losing-outcome", "run:losing"),
+        ("surviving-outcome", "run:surviving"),
+    ]
+    assert conn.execute(
+        "SELECT COUNT(*) FROM application_outcomes"
+    ).fetchone()[0] == 3
+    assert conn.execute("PRAGMA foreign_key_check").fetchone() is None
+    close_connection(db_path)
+
+
+def test_gmail_anchor_projects_url_from_stable_outcome_reference(
+    tmp_path: Path,
+) -> None:
+    from jobctrl.infrastructure.gmail.feedback import _outcome_anchors
+
+    db_path = tmp_path / "jobctrl.db"
+    conn = init_db(db_path)
+    job_id = JobId(str(uuid.uuid4()))
+    job_url = "https://example.com/jobs/stable-outcome-anchor"
+    SqliteJobRepository(conn).save(_discovered_job(job_url, job_id))
+    _insert_outcome(
+        conn,
+        tenant_id="local",
+        outcome_id="anchor-outcome",
+        reference_column="job_id",
+        reference=str(job_id),
+        kind="interview",
+        occurred_at="2026-07-30T11:00:00+00:00",
+    )
+    conn.commit()
+
+    anchors = _outcome_anchors(conn)
+
+    assert len(anchors) == 1
+    assert anchors[0].job_key == job_url
+    assert anchors[0].title == "Platform Engineer"
+    assert anchors[0].company == "Example"
+    close_connection(db_path)

--- a/workers/automation/tests/test_application_review_identity_reference_migration.py
+++ b/workers/automation/tests/test_application_review_identity_reference_migration.py
@@ -204,7 +204,7 @@ def test_v19_review_decisions_migrate_every_alias_and_uuid_url(
     assert (
         reopened.execute("PRAGMA user_version").fetchone()[0]
         == SCHEMA_VERSION
-        == 20
+        == 21
     )
     assert "job_id" in _columns(
         reopened,

--- a/workers/automation/tests/test_audit_projection_parity.py
+++ b/workers/automation/tests/test_audit_projection_parity.py
@@ -499,11 +499,23 @@ def _seed_conversion_rows(conn: sqlite3.Connection, fixture: dict[str, Any]) -> 
             )
     for outcome in rows["applicationOutcomes"]:
         conn.execute(
-            """
-            INSERT INTO application_outcomes (
-                tenant_id, outcome_id, job_key, kind, source, occurred_at, recorded_at
-            ) VALUES ('local', ?, ?, ?, 'manual', ?, ?)
-            """,
+                """
+                INSERT INTO application_outcomes (
+                    tenant_id, outcome_id, job_id, kind, source,
+                    occurred_at, recorded_at
+                ) VALUES (
+                    'local',
+                    ?,
+                    (
+                        SELECT job_id FROM jobs
+                        WHERE tenant_id = 'local' AND url = ?
+                    ),
+                    ?,
+                    'manual',
+                    ?,
+                    ?
+                )
+                """,
             (
                 outcome["outcomeId"],
                 outcome["jobKey"],

--- a/workers/automation/tests/test_compensation_identity_reference_migration.py
+++ b/workers/automation/tests/test_compensation_identity_reference_migration.py
@@ -210,7 +210,7 @@ def test_v18_compensation_migrates_alias_winners_and_uuid_urls(
     assert (
         reopened.execute("PRAGMA user_version").fetchone()[0]
         == SCHEMA_VERSION
-        == 20
+        == 21
     )
     for table in database_module._COMPENSATION_REFERENCE_TABLES:
         assert "job_id" in _columns(reopened, table)

--- a/workers/automation/tests/test_dashboard_projection.py
+++ b/workers/automation/tests/test_dashboard_projection.py
@@ -497,8 +497,19 @@ def _record_outcome(
     conn.execute(
         """
         INSERT INTO application_outcomes (
-            tenant_id, outcome_id, job_key, kind, source, occurred_at, recorded_at
-        ) VALUES ('local', ?, ?, ?, 'manual', ?, ?)
+            tenant_id, outcome_id, job_id, kind, source, occurred_at, recorded_at
+        ) VALUES (
+            'local',
+            ?,
+            (
+                SELECT job_id FROM jobs
+                WHERE tenant_id = 'local' AND url = ?
+            ),
+            ?,
+            'manual',
+            ?,
+            ?
+        )
         """,
         (f"outcome-{url}-{kind}", url, kind, at, at),
     )

--- a/workers/automation/tests/test_discovery_identity_reference_migration.py
+++ b/workers/automation/tests/test_discovery_identity_reference_migration.py
@@ -220,7 +220,7 @@ def test_v7_discovery_references_migrate_to_stable_job_id_and_reopen(
     init_db(db_path)
     close_connection(db_path)
 
-    assert _user_version(db_path) == SCHEMA_VERSION == 20
+    assert _user_version(db_path) == SCHEMA_VERSION == 21
     assert "job_id" in _columns(db_path, "job_source_observations")
     assert "job_url" not in _columns(db_path, "job_source_observations")
     assert "job_id" in _columns(db_path, "job_canonical_identities")

--- a/workers/automation/tests/test_employer_analysis_identity_reference_migration.py
+++ b/workers/automation/tests/test_employer_analysis_identity_reference_migration.py
@@ -242,7 +242,7 @@ def test_v15_employer_analysis_migrates_alias_histories_and_uuid_urls(
     assert (
         reopened.execute("PRAGMA user_version").fetchone()[0]
         == SCHEMA_VERSION
-        == 20
+        == 21
     )
     for table in database_module._EMPLOYER_ANALYSIS_REFERENCE_TABLES:
         assert "job_id" in _columns(reopened, table)

--- a/workers/automation/tests/test_enrichment_snapshot_identity_reference_migration.py
+++ b/workers/automation/tests/test_enrichment_snapshot_identity_reference_migration.py
@@ -322,7 +322,7 @@ def test_v10_enrichment_snapshot_references_migrate_and_reopen(
     init_db(db_path)
     close_connection(db_path)
 
-    assert _user_version(db_path) == SCHEMA_VERSION == 20
+    assert _user_version(db_path) == SCHEMA_VERSION == 21
     check = sqlite3.connect(db_path)
     try:
         enrichment_rows = check.execute(

--- a/workers/automation/tests/test_execution_search_identity_reference_migration.py
+++ b/workers/automation/tests/test_execution_search_identity_reference_migration.py
@@ -261,7 +261,7 @@ def test_v8_execution_and_receipts_migrate_to_stable_job_id_and_reopen(
     init_db(db_path)
     close_connection(db_path)
 
-    assert _user_version(db_path) == SCHEMA_VERSION == 20
+    assert _user_version(db_path) == SCHEMA_VERSION == 21
     assert "job_id" in _columns(db_path, "discovery_execution_jobs")
     assert "job_url" not in _columns(db_path, "discovery_execution_jobs")
     assert "job_id" in _columns(db_path, "discovery_search_unit_jobs")

--- a/workers/automation/tests/test_interview_prep_identity_reference_migration.py
+++ b/workers/automation/tests/test_interview_prep_identity_reference_migration.py
@@ -49,6 +49,7 @@ def _discovered_job(posting_url: str, job_id: JobId) -> Job:
 def _downgrade_interview_prep_references_to_v17(
     conn: sqlite3.Connection,
 ) -> None:
+    conn.execute("DROP TABLE application_outcomes")
     conn.execute("DROP TABLE job_interview_prep_items")
     conn.execute("DROP TABLE job_interview_prep")
     conn.executescript(
@@ -108,6 +109,17 @@ def _downgrade_interview_prep_references_to_v17(
             ON job_interview_prep_items(
                 tenant_id, kind, position
             );
+        CREATE TABLE application_outcomes (
+            tenant_id                 TEXT NOT NULL DEFAULT 'local',
+            outcome_id                TEXT NOT NULL,
+            job_key                   TEXT NOT NULL,
+            kind                      TEXT NOT NULL,
+            source                    TEXT NOT NULL,
+            occurred_at               TEXT NOT NULL,
+            recorded_at               TEXT NOT NULL,
+            interview_prep_generation INTEGER,
+            PRIMARY KEY (tenant_id, outcome_id)
+        );
         """
     )
     conn.execute(f"PRAGMA user_version = {PREVIOUS_SCHEMA_VERSION}")
@@ -188,17 +200,31 @@ def _insert_outcome_link(
         )
         """
     )
+    columns = _columns(conn, "application_outcomes")
+    reference_column = "job_id" if "job_id" in columns else "job_key"
+    reference = job_key
+    if reference_column == "job_id":
+        row = conn.execute(
+            """
+            SELECT job_id
+            FROM jobs
+            WHERE tenant_id = ? AND url = ?
+            """,
+            (tenant_id, job_key),
+        ).fetchone()
+        assert row is not None
+        reference = str(row[0])
     conn.execute(
-        """
+        f"""
         INSERT INTO application_outcomes (
-            tenant_id, outcome_id, job_key, kind, source, occurred_at,
+            tenant_id, outcome_id, {reference_column}, kind, source, occurred_at,
             recorded_at, interview_prep_generation
         ) VALUES (?, ?, ?, 'interview', 'manual', ?, ?, ?)
         """,
         (
             tenant_id,
             outcome_id,
-            job_key,
+            reference,
             "2026-07-29T11:00:00+00:00",
             "2026-07-29T11:00:00+00:00",
             generation,
@@ -297,7 +323,7 @@ def test_v17_interview_prep_migrates_alias_histories_and_uuid_urls(
     assert (
         reopened.execute("PRAGMA user_version").fetchone()[0]
         == SCHEMA_VERSION
-        == 20
+        == 21
     )
     for table in database_module._INTERVIEW_PREP_REFERENCE_TABLES:
         assert "job_id" in _columns(reopened, table)
@@ -347,15 +373,15 @@ def test_v17_interview_prep_migrates_alias_histories_and_uuid_urls(
         tuple(row)
         for row in reopened.execute(
             """
-            SELECT outcome_id, job_key, interview_prep_generation
+            SELECT outcome_id, job_id, interview_prep_generation
             FROM application_outcomes
             ORDER BY outcome_id
             """
         ).fetchall()
     ] == [
-        ("outcome-current", current_url, 2),
-        ("outcome-original", original_url, 1),
-        ("outcome-uuid-url", uuid_shaped_url, 1),
+        ("outcome-current", str(stable_job_id), 2),
+        ("outcome-original", str(stable_job_id), 1),
+        ("outcome-uuid-url", str(uuid_url_owner), 1),
     ]
     repository = SqliteInterviewPrepRepository(reopened)
     latest = repository.load_latest(
@@ -646,19 +672,19 @@ def test_runtime_interview_prep_merge_preserves_histories_and_tenant(
         tuple(row)
         for row in conn.execute(
             """
-            SELECT tenant_id, outcome_id, job_key,
+            SELECT tenant_id, outcome_id, job_id,
                    interview_prep_generation
             FROM application_outcomes
             ORDER BY tenant_id, outcome_id
             """
         ).fetchall()
     ] == [
-        ("local", "outcome-losing", surviving_url, 1),
-        ("local", "outcome-surviving", surviving_url, 2),
+        ("local", "outcome-losing", str(surviving_id), 1),
+        ("local", "outcome-surviving", str(surviving_id), 2),
         (
             "tenant-b",
             "outcome-other-tenant",
-            "https://tenant-b.example/jobs/stable",
+            str(other_tenant_job_id),
             1,
         ),
     ]
@@ -678,13 +704,9 @@ def test_runtime_interview_prep_merge_preserves_histories_and_tenant(
             """
             SELECT outcome.outcome_id, prep.origin_run_id
             FROM application_outcomes AS outcome
-            JOIN job_identity_aliases AS alias
-              ON alias.tenant_id = outcome.tenant_id
-             AND alias.alias_kind = 'posting_url'
-             AND alias.alias_value = outcome.job_key
             JOIN job_interview_prep AS prep
               ON prep.tenant_id = outcome.tenant_id
-             AND prep.job_id = alias.job_id
+             AND prep.job_id = outcome.job_id
              AND prep.generation =
                  outcome.interview_prep_generation
             WHERE outcome.tenant_id = 'local'
@@ -776,22 +798,19 @@ def test_real_url_collision_keeps_outcome_link_reachable(
     }
     outcome = conn.execute(
         """
-        SELECT job_key, interview_prep_generation
+        SELECT job_id, interview_prep_generation
         FROM application_outcomes
         WHERE outcome_id = 'outcome-losing-url'
         """
     ).fetchone()
-    assert tuple(outcome) == (canonical_url, 1)
+    assert tuple(outcome) == (job_ids[canonical_url], 1)
     linked = conn.execute(
         """
         SELECT prep.origin_run_id
         FROM application_outcomes AS outcome
-        JOIN jobs
-          ON jobs.tenant_id = outcome.tenant_id
-         AND jobs.url = outcome.job_key
         JOIN job_interview_prep AS prep
-          ON prep.tenant_id = jobs.tenant_id
-         AND prep.job_id = jobs.job_id
+          ON prep.tenant_id = outcome.tenant_id
+         AND prep.job_id = outcome.job_id
          AND prep.generation = outcome.interview_prep_generation
         WHERE outcome.outcome_id = 'outcome-losing-url'
         """

--- a/workers/automation/tests/test_materials_identity_reference_migration.py
+++ b/workers/automation/tests/test_materials_identity_reference_migration.py
@@ -293,7 +293,7 @@ def test_v14_materials_migrate_alias_histories_and_uuid_shaped_urls(
     close_connection(db_path)
 
     reopened = init_db(db_path)
-    assert reopened.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_VERSION == 20
+    assert reopened.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_VERSION == 21
     for table in database_module._MATERIALS_REFERENCE_TABLES:
         assert "job_id" in _columns(reopened, table)
         assert "job_url" not in _columns(reopened, table)

--- a/workers/automation/tests/test_preparation_identity_reference_migration.py
+++ b/workers/automation/tests/test_preparation_identity_reference_migration.py
@@ -177,7 +177,7 @@ def test_v9_preparation_references_migrate_to_stable_job_ids_and_reopen(
     init_db(db_path)
     close_connection(db_path)
 
-    assert _user_version(db_path) == SCHEMA_VERSION == 20
+    assert _user_version(db_path) == SCHEMA_VERSION == 21
     check = sqlite3.connect(db_path)
     try:
         rows = check.execute(

--- a/workers/automation/tests/test_repeat_application_prevention.py
+++ b/workers/automation/tests/test_repeat_application_prevention.py
@@ -758,7 +758,7 @@ def test_schema_v5_migrates_additively_without_changing_application_facts(
         (PRIOR,),
     ).fetchall()
 
-    assert int(migrated.execute("PRAGMA user_version").fetchone()[0]) == SCHEMA_VERSION == 20
+    assert int(migrated.execute("PRAGMA user_version").fetchone()[0]) == SCHEMA_VERSION == 21
     assert [tuple(row) for row in after] == [tuple(row) for row in before]
     assert "metadata_json" in {
         str(row[1]) for row in migrated.execute("PRAGMA table_info(job_stage_states)").fetchall()

--- a/workers/automation/tests/test_resume_template_identity_reference_migration.py
+++ b/workers/automation/tests/test_resume_template_identity_reference_migration.py
@@ -254,7 +254,7 @@ def test_v16_template_references_migrate_aliases_and_uuid_urls(
     assert (
         reopened.execute("PRAGMA user_version").fetchone()[0]
         == SCHEMA_VERSION
-        == 20
+        == 21
     )
     for table in database_module._RESUME_TEMPLATE_REFERENCE_TABLES:
         assert "job_id" in _columns(reopened, table)

--- a/workers/automation/tests/test_scoring_identity_reference_migration.py
+++ b/workers/automation/tests/test_scoring_identity_reference_migration.py
@@ -338,7 +338,7 @@ def test_v11_scoring_references_migrate_alias_histories_and_reopen(
     assert (
         int(migrated.execute("PRAGMA user_version").fetchone()[0])
         == SCHEMA_VERSION
-        == 20
+        == 21
     )
     assert _columns(migrated, "job_scores") >= {"tenant_id", "job_id"}
     assert "job_url" not in _columns(migrated, "job_scores")
@@ -404,7 +404,7 @@ def test_v11_scoring_references_migrate_alias_histories_and_reopen(
     assert (
         int(reopened.execute("PRAGMA user_version").fetchone()[0])
         == SCHEMA_VERSION
-        == 20
+        == 21
     )
 
 
@@ -553,7 +553,7 @@ def test_scoring_migration_rolls_back_and_retries_after_verification_failure(
     assert (
         int(retried.execute("PRAGMA user_version").fetchone()[0])
         == SCHEMA_VERSION
-        == 20
+        == 21
     )
     assert [
         tuple(row)

--- a/workers/automation/tests/test_stable_job_identity_migration.py
+++ b/workers/automation/tests/test_stable_job_identity_migration.py
@@ -196,7 +196,7 @@ def _create_representative_v6_pair(
     conn.execute(
         """
         INSERT INTO application_outcomes (
-            tenant_id, outcome_id, job_key, kind, source, note,
+            tenant_id, outcome_id, job_id, kind, source, note,
             occurred_at, recorded_at, created_by
         ) VALUES (
             'local', 'outcome-fixture', ?, 'interview', 'user',
@@ -204,7 +204,7 @@ def _create_representative_v6_pair(
         )
         """,
         (
-            job_url,
+            job_id,
             "2026-07-02T10:00:00+00:00",
             "2026-07-02T10:01:00+00:00",
         ),
@@ -313,6 +313,58 @@ def _create_representative_v6_pair(
              AND jobs.job_id = execution.job_id
             """
         ).fetchall()
+        outcome_rows = raw.execute(
+            """
+            SELECT
+                outcomes.tenant_id,
+                outcomes.outcome_id,
+                jobs.url,
+                outcomes.kind,
+                outcomes.source,
+                outcomes.note,
+                outcomes.occurred_at,
+                outcomes.recorded_at,
+                outcomes.suggestion_id,
+                outcomes.evidence_id,
+                outcomes.created_by,
+                outcomes.interview_prep_generation
+            FROM application_outcomes AS outcomes
+            JOIN jobs
+              ON jobs.tenant_id = outcomes.tenant_id
+             AND jobs.job_id = outcomes.job_id
+            ORDER BY outcomes.tenant_id, outcomes.outcome_id
+            """
+        ).fetchall()
+        raw.execute("DROP TABLE application_outcomes")
+        raw.executescript(
+            """
+            CREATE TABLE application_outcomes (
+                tenant_id                 TEXT NOT NULL DEFAULT 'local',
+                outcome_id                TEXT NOT NULL,
+                job_key                   TEXT NOT NULL,
+                kind                      TEXT NOT NULL,
+                source                    TEXT NOT NULL,
+                note                      TEXT,
+                occurred_at               TEXT NOT NULL,
+                recorded_at               TEXT NOT NULL,
+                suggestion_id             TEXT,
+                evidence_id               TEXT,
+                created_by                TEXT NOT NULL DEFAULT 'user',
+                interview_prep_generation INTEGER,
+                PRIMARY KEY (tenant_id, outcome_id)
+            );
+            """
+        )
+        raw.executemany(
+            """
+            INSERT INTO application_outcomes (
+                tenant_id, outcome_id, job_key, kind, source, note,
+                occurred_at, recorded_at, suggestion_id, evidence_id,
+                created_by, interview_prep_generation
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            outcome_rows,
+        )
         raw.execute("DROP TABLE discovery_execution_jobs")
         raw.execute("DROP TABLE discovery_search_unit_jobs")
         raw.executescript(
@@ -703,6 +755,52 @@ def _reference_snapshot(db_path: Path) -> dict[str, list[tuple[object, ...]]]:
                     """
                 ).fetchall()
             ]
+        outcome_columns = {
+            str(row[1])
+            for row in conn.execute(
+                "PRAGMA table_info(application_outcomes)"
+            ).fetchall()
+        }
+        if "job_id" in outcome_columns:
+            snapshot["application_outcomes"] = [
+                tuple(row)
+                for row in conn.execute(
+                    """
+                    SELECT
+                        outcomes.tenant_id,
+                        outcomes.outcome_id,
+                        jobs.url,
+                        outcomes.kind,
+                        outcomes.source,
+                        outcomes.note,
+                        outcomes.occurred_at,
+                        outcomes.recorded_at,
+                        outcomes.suggestion_id,
+                        outcomes.evidence_id,
+                        outcomes.created_by,
+                        outcomes.interview_prep_generation
+                    FROM application_outcomes AS outcomes
+                    JOIN jobs
+                      ON jobs.tenant_id = outcomes.tenant_id
+                     AND jobs.job_id = outcomes.job_id
+                    ORDER BY outcomes.tenant_id, outcomes.outcome_id
+                    """
+                ).fetchall()
+            ]
+        else:
+            snapshot["application_outcomes"] = [
+                tuple(row)
+                for row in conn.execute(
+                    """
+                    SELECT
+                        tenant_id, outcome_id, job_key, kind, source, note,
+                        occurred_at, recorded_at, suggestion_id, evidence_id,
+                        created_by, interview_prep_generation
+                    FROM application_outcomes
+                    ORDER BY tenant_id, outcome_id
+                    """
+                ).fetchall()
+            ]
         snapshot["jobs"] = [
             tuple(row)
             for row in conn.execute(
@@ -743,7 +841,7 @@ def test_v6_jobs_gain_stable_uuid_and_posting_url_alias_once(
     init_db(db_path)
     close_connection(db_path)
 
-    assert _user_version(db_path) == SCHEMA_VERSION == 20
+    assert _user_version(db_path) == SCHEMA_VERSION == 21
     first_ids = _identity_rows(db_path)
     assert [row[0] for row in first_ids] == ["local", "local"]
     for _tenant_id, job_id, _url in first_ids:


### PR DESCRIPTION
## Summary

- advance the worker-owned SQLite schema from v20 to v21 and migrate every reviewed `application_outcomes` row from URL-shaped `job_key` storage to tenant-scoped stable `job_id`
- preserve append-only outcome history, same outcome IDs across tenants, evidence/suggestion links, audit fields, and immutable Interview Preparation generation references
- resolve legacy references URL-first, including UUID-shaped posting URLs, with transactional rollback/retry and version-aware missing-table recovery
- adapt API and Python readers/writers, digest counts, projections, repeat-application prevention, outreach, and Gmail anchors while keeping the public contract URL-shaped until the later Phase 4 cutover
- rehome all outcomes during runtime identity collisions, preserve preparation-generation renumbering, and explicitly purge stable outcome references when SQLite foreign-key cascades are disabled

## Stack context

- stacked on #546 (`feat/job-id-application-evidence-references`)
- this PR migrates reviewed user-authoritative outcomes only
- the next PR will migrate linked Gmail evidence and pending outcome suggestions together
- canonical product documentation and cumulative stack QA remain intentionally deferred to the final unreleased-stack PR under the repository workflow

## Validation

- `pnpm api:check` — passed
- `pnpm api:test` — 53 files, 685 tests passed
- full Python suite — 2,716 passed, 2 skipped; final Gmail/v21 delta then passed its focused 21-test matrix
- focused outcome/review/interview-prep migration matrix — passed
- focused projection, digest, audit, repeat-application, and legacy compatibility matrix — passed
- Ruff on all touched Python surfaces — passed
- `git diff --check` — passed
- independent Tier 3 reviewer — PASS, Blocker 0 / High 0 / Medium 0 / Low 0
- independent Tier 3 QA — PASS, Blocker 0 / High 0 / Medium 0 / Low 0

## Safety notes

- validation used disposable SQLite databases; no live user data was read or modified
- no submission, browser-application, profile, resume, PDF, or credential paths were exercised