### PR TITLE
feat(feedback): migrate candidate references to stable JobIds

### DIFF
--- a/apps/api/src/application-feedback.ts
+++ b/apps/api/src/application-feedback.ts
@@ -72,6 +72,7 @@ const DEFAULT_TENANT = "local";
 const DEFAULT_PROFILE_ID = "default";
 const APPLICATION_REVIEW_REFERENCE_SCHEMA_VERSION = 20;
 const APPLICATION_OUTCOME_REFERENCE_SCHEMA_VERSION = 21;
+const APPLICATION_FEEDBACK_CANDIDATE_REFERENCE_SCHEMA_VERSION = 22;
 const CLOSED_ACTIVE_STATES = ["closed", "expired", "removed", "location_incompatible"];
 const POSITION_PREVIEW_CHAR_LIMIT = 6000;
 const MATERIAL_PREVIEW_CHAR_LIMIT = 4000;
@@ -205,6 +206,17 @@ export function ensureApplicationFeedbackTables(db: SqliteDatabase): void {
       FOREIGN KEY (tenant_id, job_id)
         REFERENCES jobs(tenant_id, job_id) ON DELETE CASCADE`
     : "";
+  const stableCandidateSchema =
+    schemaVersion >=
+    APPLICATION_FEEDBACK_CANDIDATE_REFERENCE_SCHEMA_VERSION;
+  const createdCandidateReference = stableCandidateSchema
+    ? "job_id"
+    : "job_key";
+  const candidateForeignKey = stableCandidateSchema
+    ? `,
+      FOREIGN KEY (tenant_id, job_id)
+        REFERENCES jobs(tenant_id, job_id) ON DELETE CASCADE`
+    : "";
   db.exec(`
     CREATE TABLE IF NOT EXISTS application_review_decisions (
       tenant_id    TEXT NOT NULL DEFAULT 'local',
@@ -244,7 +256,7 @@ export function ensureApplicationFeedbackTables(db: SqliteDatabase): void {
     CREATE TABLE IF NOT EXISTS application_email_evidence (
       tenant_id            TEXT NOT NULL DEFAULT 'local',
       evidence_id          TEXT NOT NULL,
-      job_key              TEXT NOT NULL,
+      ${createdCandidateReference} TEXT NOT NULL,
       provider             TEXT NOT NULL DEFAULT 'gmail',
       provider_message_id  TEXT NOT NULL,
       provider_thread_id   TEXT,
@@ -261,14 +273,13 @@ export function ensureApplicationFeedbackTables(db: SqliteDatabase): void {
       body_stored_at       TEXT,
       PRIMARY KEY (tenant_id, evidence_id),
       UNIQUE (tenant_id, provider, provider_message_id)
+      ${candidateForeignKey}
     );
-    CREATE INDEX IF NOT EXISTS idx_application_email_evidence_job
-      ON application_email_evidence(tenant_id, job_key, received_at DESC);
 
     CREATE TABLE IF NOT EXISTS application_outcome_suggestions (
       tenant_id          TEXT NOT NULL DEFAULT 'local',
       suggestion_id      TEXT NOT NULL,
-      job_key            TEXT NOT NULL,
+      ${createdCandidateReference} TEXT NOT NULL,
       evidence_id        TEXT,
       suggested_kind     TEXT NOT NULL,
       confidence         REAL NOT NULL DEFAULT 0,
@@ -280,9 +291,8 @@ export function ensureApplicationFeedbackTables(db: SqliteDatabase): void {
       decision_reason    TEXT,
       decided_outcome_id TEXT,
       PRIMARY KEY (tenant_id, suggestion_id)
+      ${candidateForeignKey}
     );
-    CREATE INDEX IF NOT EXISTS idx_application_outcome_suggestions_job
-      ON application_outcome_suggestions(tenant_id, job_key, status, created_at DESC);
     CREATE INDEX IF NOT EXISTS idx_application_outcome_suggestions_status
       ON application_outcome_suggestions(tenant_id, status, created_at DESC);
   `);
@@ -308,6 +318,29 @@ export function ensureApplicationFeedbackTables(db: SqliteDatabase): void {
         ${outcomeReference},
         occurred_at DESC,
         recorded_at DESC
+      );
+  `);
+  const evidenceReference = jobKeyReferenceColumn(
+    db,
+    "application_email_evidence",
+  );
+  const suggestionReference = jobKeyReferenceColumn(
+    db,
+    "application_outcome_suggestions",
+  );
+  db.exec(`
+    CREATE INDEX IF NOT EXISTS idx_application_email_evidence_job
+      ON application_email_evidence(
+        tenant_id,
+        ${evidenceReference},
+        received_at DESC
+      );
+    CREATE INDEX IF NOT EXISTS idx_application_outcome_suggestions_job
+      ON application_outcome_suggestions(
+        tenant_id,
+        ${suggestionReference},
+        status,
+        created_at DESC
       );
   `);
   ensureRepeatApplicationTables(db);
@@ -1018,28 +1051,83 @@ function resolveInterviewPrepGeneration(
 }
 
 function readSuggestions(db: SqliteDatabase, jobKey?: string): OutcomeSuggestion[] {
-  const where = jobKey ? "WHERE tenant_id = ? AND job_key = ?" : "WHERE tenant_id = ?";
-  const params = jobKey ? [DEFAULT_TENANT, jobKey] : [DEFAULT_TENANT];
+  const stableReferences =
+    jobKeyReferenceColumn(
+      db,
+      "application_outcome_suggestions",
+    ) === "job_id";
+  const reference = jobKey
+    ? jobKeyReferencePredicateForUrl(
+        db,
+        "application_outcome_suggestions",
+        jobKey,
+        DEFAULT_TENANT,
+        "suggestions",
+      )
+    : null;
+  const where = reference
+    ? `WHERE ${reference.sql}`
+    : "WHERE suggestions.tenant_id = ?";
+  const params = reference?.params ?? [DEFAULT_TENANT];
+  const identityJoin = stableReferences
+    ? `JOIN jobs
+         ON ${jobKeyReferenceJoinToJobs(
+           db,
+           "application_outcome_suggestions",
+           "suggestions",
+           "jobs",
+         )}`
+    : "";
+  const jobKeySelect = stableReferences
+    ? "jobs.url"
+    : "suggestions.job_key";
   return allRows<SuggestionRow>(
     db,
-    `SELECT suggestion_id, job_key, evidence_id, suggested_kind, confidence,
-            rationale, status, created_at, decided_at, decision_reason,
-            decided_outcome_id
-     FROM application_outcome_suggestions
+    `SELECT suggestions.suggestion_id, ${jobKeySelect} AS job_key,
+            suggestions.evidence_id, suggestions.suggested_kind,
+            suggestions.confidence, suggestions.rationale,
+            suggestions.status, suggestions.created_at,
+            suggestions.decided_at, suggestions.decision_reason,
+            suggestions.decided_outcome_id
+     FROM application_outcome_suggestions AS suggestions
+     ${identityJoin}
      ${where}
-     ORDER BY created_at DESC, suggestion_id DESC`,
+     ORDER BY suggestions.created_at DESC,
+              suggestions.suggestion_id DESC`,
     params,
   ).map(suggestionFromRow);
 }
 
 function getSuggestionRow(db: SqliteDatabase, suggestionId: string): SuggestionRow | undefined {
+  const stableReferences =
+    jobKeyReferenceColumn(
+      db,
+      "application_outcome_suggestions",
+    ) === "job_id";
+  const identityJoin = stableReferences
+    ? `JOIN jobs
+         ON ${jobKeyReferenceJoinToJobs(
+           db,
+           "application_outcome_suggestions",
+           "suggestions",
+           "jobs",
+         )}`
+    : "";
+  const jobKeySelect = stableReferences
+    ? "jobs.url"
+    : "suggestions.job_key";
   return getRow<SuggestionRow>(
     db,
-    `SELECT suggestion_id, job_key, evidence_id, suggested_kind, confidence,
-            rationale, status, created_at, decided_at, decision_reason,
-            decided_outcome_id
-     FROM application_outcome_suggestions
-     WHERE tenant_id = ? AND suggestion_id = ?`,
+    `SELECT suggestions.suggestion_id, ${jobKeySelect} AS job_key,
+            suggestions.evidence_id, suggestions.suggested_kind,
+            suggestions.confidence, suggestions.rationale,
+            suggestions.status, suggestions.created_at,
+            suggestions.decided_at, suggestions.decision_reason,
+            suggestions.decided_outcome_id
+     FROM application_outcome_suggestions AS suggestions
+     ${identityJoin}
+     WHERE suggestions.tenant_id = ?
+       AND suggestions.suggestion_id = ?`,
     [DEFAULT_TENANT, suggestionId],
   );
 }

--- a/apps/api/src/db.ts
+++ b/apps/api/src/db.ts
@@ -9,7 +9,7 @@ export type SqliteValue = string | number | bigint | null;
 // writer that stamps ``PRAGMA user_version``; the API only reads it to fail
 // closed on a database written by a newer build. Bump both constants together
 // whenever the schema shape changes.
-export const SUPPORTED_SCHEMA_VERSION = 21;
+export const SUPPORTED_SCHEMA_VERSION = 22;
 
 export class IncompatibleSchemaVersionError extends Error {
   constructor(current: number) {

--- a/apps/api/src/read-model.ts
+++ b/apps/api/src/read-model.ts
@@ -1602,14 +1602,20 @@ function appendOutcomeSuggestionAuditEntries(
   seenReferences: Set<string>,
 ): void {
   if (!tableExists(db, "application_outcome_suggestions")) return;
+  const reference = jobKeyReferencePredicateForUrl(
+    db,
+    "application_outcome_suggestions",
+    jobId,
+    DEFAULT_TENANT,
+  );
   const rows = allRows<OutcomeSuggestionAuditRow>(
     db,
     `SELECT suggestion_id, suggested_kind, confidence, status, created_at, decided_at,
             decision, decision_reason, decided_outcome_id
        FROM application_outcome_suggestions
-      WHERE tenant_id = ? AND job_key = ?
+      WHERE ${reference.sql}
       ORDER BY created_at ASC, suggestion_id ASC`,
-    [DEFAULT_TENANT, jobId],
+    reference.params,
   );
   for (const row of rows) {
     if (seenReferences.has(`suggestion:${row.suggestion_id}`)) continue;

--- a/apps/api/src/write-model.ts
+++ b/apps/api/src/write-model.ts
@@ -1032,6 +1032,8 @@ function deleteApplicationFeedbackReferences(
   for (const tableName of [
     "application_review_decisions",
     "application_outcomes",
+    "application_outcome_suggestions",
+    "application_email_evidence",
   ]) {
     if (!tableExists(db, tableName)) continue;
     const referenceColumn = jobKeyReferenceColumn(db, tableName);

--- a/apps/api/test/application-feedback-candidates-v22.test.ts
+++ b/apps/api/test/application-feedback-candidates-v22.test.ts
@@ -1,0 +1,353 @@
+import Database from "better-sqlite3";
+import { describe, expect, it } from "vitest";
+
+import {
+  decideOutcomeSuggestion,
+  ensureApplicationFeedbackTables,
+  listJobApplicationOutcomes,
+} from "../src/application-feedback.js";
+import { permanentlyDeleteJob } from "../src/write-model.js";
+
+const UUID_SHAPED_URL = "11111111-1111-4111-8111-111111111111";
+const URL_OWNER_JOB_ID = "22222222-2222-4222-8222-222222222222";
+const ID_TEXT_OWNER_URL = "https://example.com/jobs/id-text-owner";
+const OTHER_TENANT_URL = "https://example.com/jobs/other-tenant-candidate";
+const NOW = "2026-07-30T10:00:00.000Z";
+
+function createSchema(db: Database.Database): void {
+  db.pragma("foreign_keys = OFF");
+  expect(db.pragma("foreign_keys", { simple: true })).toBe(0);
+  db.pragma("user_version = 22");
+  db.exec(`
+    CREATE TABLE jobs (
+      url TEXT PRIMARY KEY,
+      tenant_id TEXT NOT NULL DEFAULT 'local',
+      job_id TEXT NOT NULL,
+      title TEXT,
+      application_url TEXT,
+      tailored_resume_path TEXT,
+      cover_letter_path TEXT,
+      UNIQUE (tenant_id, job_id)
+    );
+  `);
+}
+
+function seedCollisionGraph(db: Database.Database): void {
+  const insert = db.prepare(
+    `INSERT INTO jobs (
+       url, tenant_id, job_id, title, application_url
+     ) VALUES (?, ?, ?, 'Platform Engineer', NULL)`,
+  );
+  insert.run(UUID_SHAPED_URL, "local", URL_OWNER_JOB_ID);
+  insert.run(ID_TEXT_OWNER_URL, "local", UUID_SHAPED_URL);
+  insert.run(OTHER_TENANT_URL, "tenant-b", URL_OWNER_JOB_ID);
+}
+
+function seedCandidatePair(
+  db: Database.Database,
+  input: {
+    tenantId: string;
+    marker: string;
+    jobId: string;
+    evidenceId?: string;
+    suggestionId?: string;
+    providerMessageId?: string;
+  },
+): void {
+  const evidenceId = input.evidenceId ?? `evidence:${input.marker}`;
+  db.prepare(
+    `INSERT INTO application_email_evidence (
+       tenant_id, evidence_id, job_id, provider, provider_message_id,
+       provider_thread_id, from_address, to_addresses_json, subject,
+       snippet, received_at, linked_at, link_confidence,
+       link_signals_json, body_text, body_sha256, body_stored_at
+     ) VALUES (?, ?, ?, 'gmail', ?, ?, ?, '[]', ?, ?, ?, ?, 0.91,
+               '["recipient"]', ?, ?, ?)`,
+  ).run(
+    input.tenantId,
+    evidenceId,
+    input.jobId,
+    input.providerMessageId ?? `message:${input.marker}`,
+    `thread:${input.marker}`,
+    `from:${input.marker}@example.com`,
+    `subject:${input.marker}`,
+    `snippet:${input.marker}`,
+    NOW,
+    NOW,
+    `private-body:${input.marker}`,
+    `sha256:${input.marker}`,
+    NOW,
+  );
+  db.prepare(
+    `INSERT INTO application_outcome_suggestions (
+       tenant_id, suggestion_id, job_id, evidence_id, suggested_kind,
+       confidence, rationale, status, created_at
+     ) VALUES (?, ?, ?, ?, 'interview', 0.87, ?, 'pending', ?)`,
+  ).run(
+    input.tenantId,
+    input.suggestionId ?? `suggestion:${input.marker}`,
+    input.jobId,
+    evidenceId,
+    `rationale:${input.marker}`,
+    NOW,
+  );
+}
+
+function columns(
+  db: Database.Database,
+  table: string,
+): Set<string> {
+  return new Set(
+    (
+      db.prepare(`PRAGMA table_info("${table}")`).all() as Array<{
+        name: string;
+      }>
+    ).map((row) => row.name),
+  );
+}
+
+function indexColumns(
+  db: Database.Database,
+  index: string,
+): string[] {
+  return (
+    db.prepare(`PRAGMA index_info("${index}")`).all() as Array<{
+      name: string;
+    }>
+  ).map((row) => row.name);
+}
+
+function hasCompositeJobIdForeignKey(
+  db: Database.Database,
+  table: string,
+): boolean {
+  const rows = db
+    .prepare(`PRAGMA foreign_key_list("${table}")`)
+    .all() as Array<{
+      id: number;
+      table: string;
+      from: string;
+      to: string;
+      on_delete: string;
+    }>;
+  const grouped = new Map<number, Set<string>>();
+  const cascades = new Map<number, boolean>();
+  for (const row of rows) {
+    if (row.table !== "jobs") continue;
+    const references = grouped.get(row.id) ?? new Set<string>();
+    references.add(`${row.from}:${row.to}`);
+    grouped.set(row.id, references);
+    cascades.set(row.id, row.on_delete.toUpperCase() === "CASCADE");
+  }
+  return [...grouped.entries()].some(
+    ([id, references]) =>
+      cascades.get(id) === true &&
+      references.size === 2 &&
+      references.has("tenant_id:tenant_id") &&
+      references.has("job_id:job_id"),
+  );
+}
+
+describe("schema-v22 application-feedback candidate compatibility", () => {
+  it("projects a UUID-shaped URL while storing its URL owner's JobId", () => {
+    const db = new Database(":memory:");
+    createSchema(db);
+    seedCollisionGraph(db);
+    ensureApplicationFeedbackTables(db);
+    seedCandidatePair(db, {
+      tenantId: "local",
+      marker: "url-owner",
+      jobId: URL_OWNER_JOB_ID,
+      suggestionId: "suggestion-url-owner",
+    });
+
+    expect(
+      listJobApplicationOutcomes(db, UUID_SHAPED_URL),
+    ).toMatchObject({
+      ok: true,
+      jobKey: UUID_SHAPED_URL,
+      suggestions: [
+        {
+          suggestionId: "suggestion-url-owner",
+          jobKey: UUID_SHAPED_URL,
+          evidenceId: "evidence:url-owner",
+          suggestedKind: "interview",
+          status: "pending",
+        },
+      ],
+    });
+
+    const decided = decideOutcomeSuggestion(
+      db,
+      "suggestion-url-owner",
+      { decision: "accept" },
+    );
+    expect(decided.suggestion).toMatchObject({
+      jobKey: UUID_SHAPED_URL,
+      status: "accepted",
+    });
+    expect(decided.outcome).toMatchObject({
+      jobKey: UUID_SHAPED_URL,
+      kind: "interview",
+      source: "email_suggestion",
+    });
+    expect(
+      db.prepare(
+        `SELECT job_id, status, decided_outcome_id
+           FROM application_outcome_suggestions`,
+      ).get(),
+    ).toMatchObject({
+      job_id: URL_OWNER_JOB_ID,
+      status: "accepted",
+    });
+    expect(
+      db.prepare("SELECT job_id FROM application_outcomes").get(),
+    ).toEqual({ job_id: URL_OWNER_JOB_ID });
+    db.close();
+  });
+
+  it("deletes only the URL owner's evidence graph with cascades off", () => {
+    const db = new Database(":memory:");
+    createSchema(db);
+    seedCollisionGraph(db);
+    ensureApplicationFeedbackTables(db);
+    seedCandidatePair(db, {
+      tenantId: "local",
+      marker: "url-owner",
+      jobId: URL_OWNER_JOB_ID,
+    });
+    seedCandidatePair(db, {
+      tenantId: "local",
+      marker: "id-owner",
+      jobId: UUID_SHAPED_URL,
+    });
+    seedCandidatePair(db, {
+      tenantId: "tenant-b",
+      marker: "tenant-b",
+      jobId: URL_OWNER_JOB_ID,
+      evidenceId: "evidence:url-owner",
+      suggestionId: "suggestion:url-owner",
+      providerMessageId: "message:url-owner",
+    });
+
+    expect(permanentlyDeleteJob(db, UUID_SHAPED_URL)).toEqual({
+      ok: true,
+      count: 1,
+      jobKeys: [UUID_SHAPED_URL],
+    });
+    expect(
+      db.prepare(
+        `SELECT tenant_id, evidence_id, job_id
+           FROM application_email_evidence
+          ORDER BY tenant_id, evidence_id`,
+      ).all(),
+    ).toEqual([
+      {
+        tenant_id: "local",
+        evidence_id: "evidence:id-owner",
+        job_id: UUID_SHAPED_URL,
+      },
+      {
+        tenant_id: "tenant-b",
+        evidence_id: "evidence:url-owner",
+        job_id: URL_OWNER_JOB_ID,
+      },
+    ]);
+    expect(
+      db.prepare(
+        `SELECT tenant_id, suggestion_id, job_id, evidence_id
+           FROM application_outcome_suggestions
+          ORDER BY tenant_id, suggestion_id`,
+      ).all(),
+    ).toEqual([
+      {
+        tenant_id: "local",
+        suggestion_id: "suggestion:id-owner",
+        job_id: UUID_SHAPED_URL,
+        evidence_id: "evidence:id-owner",
+      },
+      {
+        tenant_id: "tenant-b",
+        suggestion_id: "suggestion:url-owner",
+        job_id: URL_OWNER_JOB_ID,
+        evidence_id: "evidence:url-owner",
+      },
+    ]);
+    expect(
+      db.prepare("SELECT url FROM jobs ORDER BY url").all(),
+    ).toEqual([
+      { url: ID_TEXT_OWNER_URL },
+      { url: OTHER_TENANT_URL },
+    ]);
+    expect(db.pragma("foreign_key_check")).toEqual([]);
+    db.close();
+  });
+
+  it.each([
+    [0, "job_key"],
+    [21, "job_key"],
+    [22, "job_id"],
+  ])(
+    "recovers candidate tables with the schema-%i reference",
+    (schemaVersion, expectedReference) => {
+      const db = new Database(":memory:");
+      db.pragma(`user_version = ${schemaVersion}`);
+      db.exec(`
+        CREATE TABLE jobs (
+          url TEXT PRIMARY KEY,
+          tenant_id TEXT NOT NULL DEFAULT 'local',
+          job_id TEXT NOT NULL,
+          UNIQUE (tenant_id, job_id)
+        );
+      `);
+      ensureApplicationFeedbackTables(db);
+
+      for (const table of [
+        "application_email_evidence",
+        "application_outcome_suggestions",
+      ]) {
+        expect(columns(db, table).has(expectedReference)).toBe(true);
+        expect(
+          columns(db, table).has(
+            expectedReference === "job_id" ? "job_key" : "job_id",
+          ),
+        ).toBe(false);
+        expect(
+          hasCompositeJobIdForeignKey(db, table),
+        ).toBe(schemaVersion === 22);
+      }
+      expect(
+        indexColumns(db, "idx_application_email_evidence_job"),
+      ).toEqual([
+        "tenant_id",
+        expectedReference,
+        "received_at",
+      ]);
+      expect(
+        indexColumns(
+          db,
+          "idx_application_outcome_suggestions_job",
+        ),
+      ).toEqual([
+        "tenant_id",
+        expectedReference,
+        "status",
+        "created_at",
+      ]);
+      const uniqueIndexes = db
+        .prepare(
+          'PRAGMA index_list("application_email_evidence")',
+        )
+        .all() as Array<{ name: string; unique: number }>;
+      expect(
+        uniqueIndexes.some(
+          (index) =>
+            index.unique === 1 &&
+            indexColumns(db, index.name).join(",") ===
+              "tenant_id,provider,provider_message_id",
+        ),
+      ).toBe(true);
+      db.close();
+    },
+  );
+});

--- a/apps/api/test/application-outcomes-v21.test.ts
+++ b/apps/api/test/application-outcomes-v21.test.ts
@@ -168,6 +168,7 @@ describe("schema-v21 reviewed application-outcome API compatibility", () => {
     [0, "job_key"],
     [20, "job_key"],
     [21, "job_id"],
+    [22, "job_id"],
   ])(
     "creates the version-aware outcome reference at schema %i",
     (schemaVersion, expectedReference) => {

--- a/apps/api/test/schema-version-guard.test.ts
+++ b/apps/api/test/schema-version-guard.test.ts
@@ -63,7 +63,7 @@ describe("schema version guard at DB open", () => {
   });
 
   it("opens the worker-owned schema-v14 artifact registry", () => {
-    expect(SUPPORTED_SCHEMA_VERSION).toBe(21);
+    expect(SUPPORTED_SCHEMA_VERSION).toBe(22);
     const { dbPath, cleanup } = makeDbWithUserVersion(14);
     try {
       openDatabase(dbPath).close();

--- a/workers/automation/src/jobctrl/database.py
+++ b/workers/automation/src/jobctrl/database.py
@@ -80,7 +80,10 @@ from jobctrl.config import DB_PATH, DEFAULTS, migrate_legacy_job_tables
 # v21 (application-outcome references): every reviewed application outcome
 # references the tenant-scoped stable Job aggregate. Append-only history and
 # immutable links to Interview Preparation generations remain exact.
-SCHEMA_VERSION = 21
+# v22 (application-feedback candidate references): linked email evidence and
+# pending/decided outcome suggestions reference the same tenant-scoped stable
+# Job aggregate while preserving their evidence and decision links.
+SCHEMA_VERSION = 22
 
 
 class IncompatibleSchemaVersionError(RuntimeError):
@@ -232,6 +235,7 @@ def _schema_migrations() -> tuple[
         (19, ensure_compensation_references_v19),
         (20, ensure_application_review_references_v20),
         (21, ensure_application_outcome_references_v21),
+        (22, ensure_application_feedback_candidate_references_v22),
     )
 
 
@@ -402,6 +406,10 @@ def init_db(db_path: Path | str | None = None) -> sqlite3.Connection:
         )
     """ % application_review_reference)
     _ensure_application_outcome_table_for_version(
+        conn,
+        current_version=current_version,
+    )
+    _ensure_application_feedback_candidate_tables_for_version(
         conn,
         current_version=current_version,
     )
@@ -4676,6 +4684,13 @@ def _reassign_discovery_identity_references(
         )
     if _has_application_outcome_reference_schema_v21(conn):
         _reassign_application_outcome_references_v21(
+            conn,
+            tenant_id=tenant_id,
+            losing_job_id=losing_job_id,
+            surviving_job_id=surviving_job_id,
+        )
+    if _has_application_feedback_candidate_schema_v22(conn):
+        _reassign_application_feedback_candidate_references_v22(
             conn,
             tenant_id=tenant_id,
             losing_job_id=losing_job_id,
@@ -13140,6 +13155,610 @@ def _reassign_application_outcome_references_v21(
     _verify_application_outcome_references_v21(
         conn,
         expected_count=expected_count,
+    )
+
+
+_APPLICATION_FEEDBACK_CANDIDATE_SCHEMA_VERSION = 22
+_APPLICATION_FEEDBACK_CANDIDATE_TABLES = (
+    "application_email_evidence",
+    "application_outcome_suggestions",
+)
+
+
+def _create_application_email_evidence_table_v22(
+    conn: sqlite3.Connection,
+    *,
+    table: str,
+    stable_reference: bool,
+) -> None:
+    reference_column = "job_id" if stable_reference else "job_key"
+    foreign_key = (
+        """,
+            FOREIGN KEY (tenant_id, job_id)
+                REFERENCES jobs(tenant_id, job_id) ON DELETE CASCADE"""
+        if stable_reference
+        else ""
+    )
+    conn.execute(
+        f"""
+        CREATE TABLE "{table}" (
+            tenant_id            TEXT NOT NULL DEFAULT 'local',
+            evidence_id          TEXT NOT NULL,
+            {reference_column}   TEXT NOT NULL,
+            provider             TEXT NOT NULL DEFAULT 'gmail',
+            provider_message_id  TEXT NOT NULL,
+            provider_thread_id   TEXT,
+            from_address         TEXT,
+            to_addresses_json    TEXT NOT NULL DEFAULT '[]',
+            subject              TEXT,
+            snippet              TEXT,
+            received_at          TEXT,
+            linked_at            TEXT NOT NULL,
+            link_confidence      REAL NOT NULL DEFAULT 0,
+            link_signals_json    TEXT NOT NULL DEFAULT '[]',
+            body_text            TEXT,
+            body_sha256          TEXT,
+            body_stored_at       TEXT,
+            PRIMARY KEY (tenant_id, evidence_id),
+            UNIQUE (tenant_id, provider, provider_message_id)
+            {foreign_key}
+        )
+        """
+    )
+
+
+def _create_application_outcome_suggestion_table_v22(
+    conn: sqlite3.Connection,
+    *,
+    table: str,
+    stable_reference: bool,
+) -> None:
+    reference_column = "job_id" if stable_reference else "job_key"
+    foreign_key = (
+        """,
+            FOREIGN KEY (tenant_id, job_id)
+                REFERENCES jobs(tenant_id, job_id) ON DELETE CASCADE"""
+        if stable_reference
+        else ""
+    )
+    conn.execute(
+        f"""
+        CREATE TABLE "{table}" (
+            tenant_id          TEXT NOT NULL DEFAULT 'local',
+            suggestion_id      TEXT NOT NULL,
+            {reference_column} TEXT NOT NULL,
+            evidence_id        TEXT,
+            suggested_kind     TEXT NOT NULL,
+            confidence         REAL NOT NULL DEFAULT 0,
+            rationale          TEXT NOT NULL DEFAULT '',
+            status             TEXT NOT NULL DEFAULT 'pending',
+            created_at         TEXT NOT NULL,
+            decided_at         TEXT,
+            decision           TEXT,
+            decision_reason    TEXT,
+            decided_outcome_id TEXT,
+            PRIMARY KEY (tenant_id, suggestion_id)
+            {foreign_key}
+        )
+        """
+    )
+
+
+def _create_application_feedback_candidate_indexes_v22(
+    conn: sqlite3.Connection,
+    *,
+    evidence_reference: str,
+    suggestion_reference: str,
+) -> None:
+    indexes = (
+        (
+            "application_email_evidence",
+            "idx_application_email_evidence_job",
+            ("tenant_id", evidence_reference, "received_at"),
+            f"""
+            CREATE INDEX idx_application_email_evidence_job
+            ON application_email_evidence(
+                tenant_id,
+                {evidence_reference},
+                received_at DESC
+            )
+            """,
+        ),
+        (
+            "application_outcome_suggestions",
+            "idx_application_outcome_suggestions_job",
+            (
+                "tenant_id",
+                suggestion_reference,
+                "status",
+                "created_at",
+            ),
+            f"""
+            CREATE INDEX idx_application_outcome_suggestions_job
+            ON application_outcome_suggestions(
+                tenant_id,
+                {suggestion_reference},
+                status,
+                created_at DESC
+            )
+            """,
+        ),
+        (
+            "application_outcome_suggestions",
+            "idx_application_outcome_suggestions_status",
+            ("tenant_id", "status", "created_at"),
+            """
+            CREATE INDEX idx_application_outcome_suggestions_status
+            ON application_outcome_suggestions(
+                tenant_id,
+                status,
+                created_at DESC
+            )
+            """,
+        ),
+    )
+    for table, name, columns, create_sql in indexes:
+        if _has_index(
+            conn,
+            table,
+            name,
+            columns,
+            unique=False,
+        ):
+            continue
+        conn.execute(f'DROP INDEX IF EXISTS "{name}"')
+        conn.execute(create_sql)
+
+
+def _ensure_application_feedback_candidate_tables_for_version(
+    conn: sqlite3.Connection,
+    *,
+    current_version: int,
+) -> None:
+    """Recover missing candidate tables without skipping ordered migration."""
+    stable_reference = (
+        current_version
+        >= _APPLICATION_FEEDBACK_CANDIDATE_SCHEMA_VERSION
+    )
+    if not _table_columns(conn, "application_email_evidence"):
+        _create_application_email_evidence_table_v22(
+            conn,
+            table="application_email_evidence",
+            stable_reference=stable_reference,
+        )
+    if not _table_columns(conn, "application_outcome_suggestions"):
+        _create_application_outcome_suggestion_table_v22(
+            conn,
+            table="application_outcome_suggestions",
+            stable_reference=stable_reference,
+        )
+    evidence_columns = _table_columns(
+        conn,
+        "application_email_evidence",
+    )
+    suggestion_columns = _table_columns(
+        conn,
+        "application_outcome_suggestions",
+    )
+    evidence_reference = (
+        "job_id"
+        if "job_id" in evidence_columns
+        else "job_key"
+        if "job_key" in evidence_columns
+        else None
+    )
+    suggestion_reference = (
+        "job_id"
+        if "job_id" in suggestion_columns
+        else "job_key"
+        if "job_key" in suggestion_columns
+        else None
+    )
+    if evidence_reference is None or suggestion_reference is None:
+        raise RuntimeError(
+            "application feedback candidate table has no Job identity column"
+        )
+    _create_application_feedback_candidate_indexes_v22(
+        conn,
+        evidence_reference=evidence_reference,
+        suggestion_reference=suggestion_reference,
+    )
+    if (
+        current_version
+        >= _APPLICATION_FEEDBACK_CANDIDATE_SCHEMA_VERSION
+        and not _has_application_feedback_candidate_schema_v22(conn)
+    ):
+        raise RuntimeError(
+            "schema v22 requires stable application-feedback candidate "
+            "references"
+        )
+
+
+def _has_unique_index_columns_v22(
+    conn: sqlite3.Connection,
+    *,
+    table: str,
+    columns: tuple[str, ...],
+) -> bool:
+    for row in conn.execute(
+        f'PRAGMA index_list("{table}")'
+    ).fetchall():
+        if not bool(row[2]):
+            continue
+        name = str(row[1])
+        actual_columns = tuple(
+            str(index_row[2])
+            for index_row in conn.execute(
+                f'PRAGMA index_info("{name}")'
+            ).fetchall()
+        )
+        if actual_columns == columns:
+            return True
+    return False
+
+
+def _has_application_feedback_candidate_schema_v22(
+    conn: sqlite3.Connection,
+) -> bool:
+    evidence = "application_email_evidence"
+    suggestions = "application_outcome_suggestions"
+    return (
+        "job_id" in _table_columns(conn, evidence)
+        and "job_key" not in _table_columns(conn, evidence)
+        and _primary_key_columns(conn, evidence)
+        == ("tenant_id", "evidence_id")
+        and _has_composite_job_id_foreign_key(
+            conn,
+            evidence,
+            "job_id",
+        )
+        and _has_unique_index_columns_v22(
+            conn,
+            table=evidence,
+            columns=("tenant_id", "provider", "provider_message_id"),
+        )
+        and _has_index(
+            conn,
+            evidence,
+            "idx_application_email_evidence_job",
+            ("tenant_id", "job_id", "received_at"),
+            unique=False,
+        )
+        and "job_id" in _table_columns(conn, suggestions)
+        and "job_key" not in _table_columns(conn, suggestions)
+        and _primary_key_columns(conn, suggestions)
+        == ("tenant_id", "suggestion_id")
+        and _has_composite_job_id_foreign_key(
+            conn,
+            suggestions,
+            "job_id",
+        )
+        and _has_index(
+            conn,
+            suggestions,
+            "idx_application_outcome_suggestions_job",
+            ("tenant_id", "job_id", "status", "created_at"),
+            unique=False,
+        )
+        and _has_index(
+            conn,
+            suggestions,
+            "idx_application_outcome_suggestions_status",
+            ("tenant_id", "status", "created_at"),
+            unique=False,
+        )
+    )
+
+
+def _canonical_application_email_evidence_rows_v22(
+    conn: sqlite3.Connection,
+) -> list[tuple[Any, ...]]:
+    rows = conn.execute(
+        """
+        SELECT tenant_id, evidence_id, job_key, provider,
+               provider_message_id, provider_thread_id, from_address,
+               to_addresses_json, subject, snippet, received_at, linked_at,
+               link_confidence, link_signals_json, body_text, body_sha256,
+               body_stored_at
+        FROM application_email_evidence
+        ORDER BY tenant_id, evidence_id
+        """
+    ).fetchall()
+    canonical: list[tuple[Any, ...]] = []
+    for row in rows:
+        tenant_id = str(row[0])
+        legacy_job_key = str(row[2])
+        stable_job_id = _resolve_job_reference_value(
+            conn,
+            tenant_id=tenant_id,
+            reference=legacy_job_key,
+            legacy_url=True,
+        )
+        if stable_job_id is None:
+            raise RuntimeError(
+                "application-feedback candidate migration could not resolve "
+                f"application_email_evidence.job_key={legacy_job_key!r}"
+            )
+        _validate_job_uuid(stable_job_id)
+        canonical.append(
+            (
+                tenant_id,
+                str(row[1]),
+                stable_job_id,
+                *tuple(row[3:]),
+            )
+        )
+    return canonical
+
+
+def _canonical_application_outcome_suggestion_rows_v22(
+    conn: sqlite3.Connection,
+) -> list[tuple[Any, ...]]:
+    rows = conn.execute(
+        """
+        SELECT tenant_id, suggestion_id, job_key, evidence_id,
+               suggested_kind, confidence, rationale, status, created_at,
+               decided_at, decision, decision_reason, decided_outcome_id
+        FROM application_outcome_suggestions
+        ORDER BY tenant_id, suggestion_id
+        """
+    ).fetchall()
+    canonical: list[tuple[Any, ...]] = []
+    for row in rows:
+        tenant_id = str(row[0])
+        legacy_job_key = str(row[2])
+        stable_job_id = _resolve_job_reference_value(
+            conn,
+            tenant_id=tenant_id,
+            reference=legacy_job_key,
+            legacy_url=True,
+        )
+        if stable_job_id is None:
+            raise RuntimeError(
+                "application-feedback candidate migration could not resolve "
+                "application_outcome_suggestions."
+                f"job_key={legacy_job_key!r}"
+            )
+        _validate_job_uuid(stable_job_id)
+        canonical.append(
+            (
+                tenant_id,
+                str(row[1]),
+                stable_job_id,
+                *tuple(row[3:]),
+            )
+        )
+    return canonical
+
+
+def ensure_application_feedback_candidate_references_v22(
+    conn: sqlite3.Connection | None = None,
+) -> list[str]:
+    """Move linked evidence and suggestions to stable JobId references."""
+    if conn is None:
+        conn = get_connection()
+
+    current = _assert_schema_version_supported(conn)
+    if current >= _APPLICATION_FEEDBACK_CANDIDATE_SCHEMA_VERSION:
+        return []
+    if current != _APPLICATION_OUTCOME_REFERENCE_SCHEMA_VERSION:
+        raise RuntimeError(
+            "application-feedback candidate migration requires "
+            "application-outcome schema v21"
+        )
+
+    conn.execute(
+        "SAVEPOINT application_feedback_candidate_references_v22"
+    )
+    try:
+        if not _has_application_outcome_reference_schema_v21(conn):
+            raise RuntimeError(
+                "application-feedback candidate migration requires the "
+                "stable application-outcome reference schema"
+            )
+        _ensure_application_feedback_candidate_tables_for_version(
+            conn,
+            current_version=current,
+        )
+        expected_counts: dict[str, int] = {}
+        if "job_id" not in _table_columns(
+            conn,
+            "application_email_evidence",
+        ):
+            evidence_rows = (
+                _canonical_application_email_evidence_rows_v22(conn)
+            )
+            conn.execute(
+                "DROP TABLE IF EXISTS application_email_evidence_v22"
+            )
+            _create_application_email_evidence_table_v22(
+                conn,
+                table="application_email_evidence_v22",
+                stable_reference=True,
+            )
+            conn.executemany(
+                """
+                INSERT INTO application_email_evidence_v22 (
+                    tenant_id, evidence_id, job_id, provider,
+                    provider_message_id, provider_thread_id, from_address,
+                    to_addresses_json, subject, snippet, received_at,
+                    linked_at, link_confidence, link_signals_json, body_text,
+                    body_sha256, body_stored_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                evidence_rows,
+            )
+            conn.execute('DROP TABLE "application_email_evidence"')
+            conn.execute(
+                'ALTER TABLE "application_email_evidence_v22" '
+                'RENAME TO "application_email_evidence"'
+            )
+            expected_counts["application_email_evidence"] = len(
+                evidence_rows
+            )
+        else:
+            expected_counts["application_email_evidence"] = int(
+                conn.execute(
+                    "SELECT COUNT(*) FROM application_email_evidence"
+                ).fetchone()[0]
+            )
+        if "job_id" not in _table_columns(
+            conn,
+            "application_outcome_suggestions",
+        ):
+            suggestion_rows = (
+                _canonical_application_outcome_suggestion_rows_v22(conn)
+            )
+            conn.execute(
+                "DROP TABLE IF EXISTS "
+                "application_outcome_suggestions_v22"
+            )
+            _create_application_outcome_suggestion_table_v22(
+                conn,
+                table="application_outcome_suggestions_v22",
+                stable_reference=True,
+            )
+            conn.executemany(
+                """
+                INSERT INTO application_outcome_suggestions_v22 (
+                    tenant_id, suggestion_id, job_id, evidence_id,
+                    suggested_kind, confidence, rationale, status,
+                    created_at, decided_at, decision, decision_reason,
+                    decided_outcome_id
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                suggestion_rows,
+            )
+            conn.execute(
+                'DROP TABLE "application_outcome_suggestions"'
+            )
+            conn.execute(
+                'ALTER TABLE "application_outcome_suggestions_v22" '
+                'RENAME TO "application_outcome_suggestions"'
+            )
+            expected_counts["application_outcome_suggestions"] = len(
+                suggestion_rows
+            )
+        else:
+            expected_counts["application_outcome_suggestions"] = int(
+                conn.execute(
+                    "SELECT COUNT(*) "
+                    "FROM application_outcome_suggestions"
+                ).fetchone()[0]
+            )
+        _create_application_feedback_candidate_indexes_v22(
+            conn,
+            evidence_reference="job_id",
+            suggestion_reference="job_id",
+        )
+        _verify_application_feedback_candidate_references_v22(
+            conn,
+            expected_counts=expected_counts,
+        )
+        conn.execute(
+            f"PRAGMA user_version = "
+            f"{_APPLICATION_FEEDBACK_CANDIDATE_SCHEMA_VERSION}"
+        )
+        conn.execute(
+            "RELEASE SAVEPOINT "
+            "application_feedback_candidate_references_v22"
+        )
+        conn.commit()
+    except BaseException:
+        conn.execute(
+            "ROLLBACK TO SAVEPOINT "
+            "application_feedback_candidate_references_v22"
+        )
+        conn.execute(
+            "RELEASE SAVEPOINT "
+            "application_feedback_candidate_references_v22"
+        )
+        raise
+
+    return list(_APPLICATION_FEEDBACK_CANDIDATE_TABLES)
+
+
+def _verify_application_feedback_candidate_references_v22(
+    conn: sqlite3.Connection,
+    *,
+    expected_counts: dict[str, int],
+) -> None:
+    if not _has_application_feedback_candidate_schema_v22(conn):
+        raise RuntimeError(
+            "application-feedback candidate migration did not create the "
+            "stable reference schema"
+        )
+    for table, expected_count in expected_counts.items():
+        observed_count = int(
+            conn.execute(
+                f'SELECT COUNT(*) FROM "{table}"'
+            ).fetchone()[0]
+        )
+        if observed_count != expected_count:
+            raise RuntimeError(
+                "application-feedback candidate migration changed "
+                f"{table} history count: expected {expected_count}, "
+                f"found {observed_count}"
+            )
+        orphan = conn.execute(
+            f"""
+            SELECT candidates.job_id
+            FROM "{table}" AS candidates
+            LEFT JOIN jobs
+              ON jobs.tenant_id = candidates.tenant_id
+             AND jobs.job_id = candidates.job_id
+            WHERE jobs.job_id IS NULL
+            LIMIT 1
+            """
+        ).fetchone()
+        if orphan is not None:
+            raise RuntimeError(
+                "application-feedback candidate migration left an "
+                f"unresolved JobId in {table}"
+            )
+        for row in conn.execute(
+            f'SELECT DISTINCT job_id FROM "{table}"'
+        ).fetchall():
+            _validate_job_uuid(str(row[0]))
+    foreign_key_error = conn.execute(
+        "PRAGMA foreign_key_check"
+    ).fetchone()
+    if foreign_key_error is not None:
+        raise RuntimeError(
+            "application-feedback candidate migration found a foreign-key "
+            "violation"
+        )
+
+
+def _reassign_application_feedback_candidate_references_v22(
+    conn: sqlite3.Connection,
+    *,
+    tenant_id: str,
+    losing_job_id: str,
+    surviving_job_id: str,
+) -> None:
+    if losing_job_id == surviving_job_id:
+        return
+    expected_counts = {
+        table: int(
+            conn.execute(
+                f'SELECT COUNT(*) FROM "{table}"'
+            ).fetchone()[0]
+        )
+        for table in _APPLICATION_FEEDBACK_CANDIDATE_TABLES
+    }
+    for table in _APPLICATION_FEEDBACK_CANDIDATE_TABLES:
+        conn.execute(
+            f"""
+            UPDATE "{table}"
+            SET job_id = ?
+            WHERE tenant_id = ? AND job_id = ?
+            """,
+            (surviving_job_id, tenant_id, losing_job_id),
+        )
+    _verify_application_feedback_candidate_references_v22(
+        conn,
+        expected_counts=expected_counts,
     )
 
 

--- a/workers/automation/src/jobctrl/infrastructure/gmail/feedback.py
+++ b/workers/automation/src/jobctrl/infrastructure/gmail/feedback.py
@@ -28,6 +28,7 @@ MAX_RESULTS_PER_ANCHOR = 20
 MAX_WINDOW_DAYS = 180
 APPLICATION_REVIEW_REFERENCE_SCHEMA_VERSION = 20
 APPLICATION_OUTCOME_REFERENCE_SCHEMA_VERSION = 21
+APPLICATION_FEEDBACK_CANDIDATE_REFERENCE_SCHEMA_VERSION = 22
 
 _EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
 _TOKEN_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._+-]{1,64}")
@@ -278,6 +279,20 @@ def ensure_application_feedback_tables(conn: sqlite3.Connection) -> None:
         if stable_outcome_schema
         else ""
     )
+    stable_candidate_schema = (
+        schema_version
+        >= APPLICATION_FEEDBACK_CANDIDATE_REFERENCE_SCHEMA_VERSION
+    )
+    created_candidate_reference = (
+        "job_id" if stable_candidate_schema else "job_key"
+    )
+    candidate_foreign_key = (
+        """,
+          FOREIGN KEY (tenant_id, job_id)
+            REFERENCES jobs(tenant_id, job_id) ON DELETE CASCADE"""
+        if stable_candidate_schema
+        else ""
+    )
     conn.executescript(
         f"""
         CREATE TABLE IF NOT EXISTS application_review_decisions (
@@ -318,7 +333,7 @@ def ensure_application_feedback_tables(conn: sqlite3.Connection) -> None:
         CREATE TABLE IF NOT EXISTS application_email_evidence (
           tenant_id            TEXT NOT NULL DEFAULT 'local',
           evidence_id          TEXT NOT NULL,
-          job_key              TEXT NOT NULL,
+          {created_candidate_reference} TEXT NOT NULL,
           provider             TEXT NOT NULL DEFAULT 'gmail',
           provider_message_id  TEXT NOT NULL,
           provider_thread_id   TEXT,
@@ -335,14 +350,13 @@ def ensure_application_feedback_tables(conn: sqlite3.Connection) -> None:
           body_stored_at       TEXT,
           PRIMARY KEY (tenant_id, evidence_id),
           UNIQUE (tenant_id, provider, provider_message_id)
+          {candidate_foreign_key}
         );
-        CREATE INDEX IF NOT EXISTS idx_application_email_evidence_job
-          ON application_email_evidence(tenant_id, job_key, received_at DESC);
 
         CREATE TABLE IF NOT EXISTS application_outcome_suggestions (
           tenant_id          TEXT NOT NULL DEFAULT 'local',
           suggestion_id      TEXT NOT NULL,
-          job_key            TEXT NOT NULL,
+          {created_candidate_reference} TEXT NOT NULL,
           evidence_id        TEXT,
           suggested_kind     TEXT NOT NULL,
           confidence         REAL NOT NULL DEFAULT 0,
@@ -354,9 +368,8 @@ def ensure_application_feedback_tables(conn: sqlite3.Connection) -> None:
           decision_reason    TEXT,
           decided_outcome_id TEXT,
           PRIMARY KEY (tenant_id, suggestion_id)
+          {candidate_foreign_key}
         );
-        CREATE INDEX IF NOT EXISTS idx_application_outcome_suggestions_job
-          ON application_outcome_suggestions(tenant_id, job_key, status, created_at DESC);
         CREATE INDEX IF NOT EXISTS idx_application_outcome_suggestions_status
           ON application_outcome_suggestions(tenant_id, status, created_at DESC);
         """
@@ -410,6 +423,42 @@ def ensure_application_feedback_tables(conn: sqlite3.Connection) -> None:
         )
         """
         % outcome_reference
+    )
+    evidence_reference = (
+        "job_id"
+        if "job_id" in _columns(conn, "application_email_evidence")
+        else "job_key"
+    )
+    suggestion_reference = (
+        "job_id"
+        if "job_id" in _columns(
+            conn,
+            "application_outcome_suggestions",
+        )
+        else "job_key"
+    )
+    conn.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_application_email_evidence_job
+        ON application_email_evidence(
+            tenant_id,
+            %s,
+            received_at DESC
+        )
+        """
+        % evidence_reference
+    )
+    conn.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_application_outcome_suggestions_job
+        ON application_outcome_suggestions(
+            tenant_id,
+            %s,
+            status,
+            created_at DESC
+        )
+        """
+        % suggestion_reference
     )
 
 
@@ -503,11 +552,17 @@ def _store_linked_message(
     to_addresses = _email_addresses(_text(full_message.get("to") or metadata.get("to")))
     thread_id = _nullable_text(full_message.get("threadId") or metadata.get("threadId"))
     linked_at_text = _iso(linked_at)
+    reference_column, job_reference = _job_key_reference_for_url(
+        conn,
+        "application_email_evidence",
+        anchor.job_key,
+    )
 
     conn.execute(
-        """
+        f"""
         INSERT INTO application_email_evidence (
-            tenant_id, evidence_id, job_key, provider, provider_message_id,
+            tenant_id, evidence_id, {reference_column}, provider,
+            provider_message_id,
             provider_thread_id, from_address, to_addresses_json, subject, snippet,
             received_at, linked_at, link_confidence, link_signals_json,
             body_text, body_sha256, body_stored_at
@@ -516,7 +571,7 @@ def _store_linked_message(
         (
             TENANT_ID,
             evidence_id,
-            anchor.job_key,
+            job_reference,
             PROVIDER,
             message_id,
             thread_id,
@@ -554,17 +609,23 @@ def _store_suggestion(
         "gmail-suggestion",
         f"{anchor.job_key}|{provider_message_id}|{classification.kind}",
     )
+    reference_column, job_reference = _job_key_reference_for_url(
+        conn,
+        "application_outcome_suggestions",
+        anchor.job_key,
+    )
     cursor = conn.execute(
-        """
+        f"""
         INSERT OR IGNORE INTO application_outcome_suggestions (
-            tenant_id, suggestion_id, job_key, evidence_id, suggested_kind,
+            tenant_id, suggestion_id, {reference_column}, evidence_id,
+            suggested_kind,
             confidence, rationale, status, created_at
         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
         """,
         (
             TENANT_ID,
             suggestion_id,
-            anchor.job_key,
+            job_reference,
             evidence_id,
             classification.kind,
             classification.confidence,
@@ -854,6 +915,62 @@ def _utc_now() -> datetime:
 def _stable_id(prefix: str, value: str) -> str:
     digest = hashlib.sha256(value.encode("utf-8")).hexdigest()[:24]
     return f"{prefix}-{digest}"
+
+
+def _job_key_reference_for_url(
+    conn: sqlite3.Connection,
+    table_name: str,
+    job_url: str,
+) -> tuple[str, str]:
+    """Return the table's reference column and URL-owned stored value."""
+
+    columns = _columns(conn, table_name)
+    if "job_key" in columns:
+        return "job_key", job_url
+    if "job_id" not in columns:
+        raise GmailFeedbackError(
+            f"{table_name} has no Job identity column."
+        )
+
+    job_columns = _columns(conn, "jobs")
+    if not {"tenant_id", "job_id", "url"}.issubset(job_columns):
+        raise GmailFeedbackError(
+            "Stable Gmail feedback storage requires tenant-scoped Job "
+            "identities."
+        )
+    direct = conn.execute(
+        """
+        SELECT job_id
+        FROM jobs
+        WHERE tenant_id = ? AND url = ?
+        LIMIT 1
+        """,
+        (TENANT_ID, job_url),
+    ).fetchone()
+    if direct is not None and _text(direct["job_id"]):
+        return "job_id", _text(direct["job_id"])
+
+    if _table_exists(conn, "job_identity_aliases"):
+        alias = conn.execute(
+            """
+            SELECT aliases.job_id
+            FROM job_identity_aliases AS aliases
+            JOIN jobs
+              ON jobs.tenant_id = aliases.tenant_id
+             AND jobs.job_id = aliases.job_id
+            WHERE aliases.tenant_id = ?
+              AND aliases.alias_kind = 'posting_url'
+              AND aliases.alias_value = ?
+            LIMIT 1
+            """,
+            (TENANT_ID, job_url),
+        ).fetchone()
+        if alias is not None and _text(alias["job_id"]):
+            return "job_id", _text(alias["job_id"])
+
+    raise GmailFeedbackError(
+        f"No stable Job identity for {job_url}."
+    )
 
 
 def _bounded_int(value: int, *, minimum: int, maximum: int, default: int) -> int:

--- a/workers/automation/tests/test_application_feedback_candidate_identity_reference_migration.py
+++ b/workers/automation/tests/test_application_feedback_candidate_identity_reference_migration.py
@@ -1,0 +1,787 @@
+"""Schema-v22 application-feedback candidate JobId reference contracts."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import uuid
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import jobctrl.database as database_module
+from jobctrl.database import (
+    SCHEMA_VERSION,
+    close_connection,
+    ensure_application_feedback_candidate_references_v22,
+    init_db,
+    reassign_discovery_identity_references,
+)
+from jobctrl.domain.discovery import (
+    Employer,
+    Job,
+    JobMetadata,
+    PostingUrl,
+    SearchStrategy,
+    Source,
+)
+from jobctrl.domain.identifiers import JobId
+from jobctrl.domain.tenant import LOCAL_TENANT
+from jobctrl.infrastructure.discovery import SqliteJobRepository
+from jobctrl.infrastructure.gmail.feedback import (
+    ensure_application_feedback_tables,
+    scan_gmail_feedback,
+)
+
+
+PREVIOUS_SCHEMA_VERSION = 21
+
+
+def _discovered_job(posting_url: str, job_id: JobId) -> Job:
+    return Job.discover(
+        tenant_id=LOCAL_TENANT,
+        job_id=job_id,
+        posting_url=PostingUrl(value=posting_url),
+        source=Source(board="example"),
+        employer=Employer(name="ExampleCo"),
+        search_strategy=SearchStrategy.JOBSPY,
+        metadata=JobMetadata(title="Platform Engineer"),
+        discovered_at="2026-07-30T10:00:00+00:00",
+    )
+
+
+def _columns(
+    conn: sqlite3.Connection,
+    table_name: str,
+) -> set[str]:
+    return {
+        str(row[1])
+        for row in conn.execute(
+            f'PRAGMA table_info("{table_name}")'
+        ).fetchall()
+    }
+
+
+def _downgrade_candidates_to_v21(conn: sqlite3.Connection) -> None:
+    conn.executescript(
+        """
+        DROP TABLE application_outcome_suggestions;
+        DROP TABLE application_email_evidence;
+        CREATE TABLE application_email_evidence (
+            tenant_id            TEXT NOT NULL DEFAULT 'local',
+            evidence_id          TEXT NOT NULL,
+            job_key              TEXT NOT NULL,
+            provider             TEXT NOT NULL DEFAULT 'gmail',
+            provider_message_id  TEXT NOT NULL,
+            provider_thread_id   TEXT,
+            from_address         TEXT,
+            to_addresses_json    TEXT NOT NULL DEFAULT '[]',
+            subject              TEXT,
+            snippet              TEXT,
+            received_at          TEXT,
+            linked_at            TEXT NOT NULL,
+            link_confidence      REAL NOT NULL DEFAULT 0,
+            link_signals_json    TEXT NOT NULL DEFAULT '[]',
+            body_text            TEXT,
+            body_sha256          TEXT,
+            body_stored_at       TEXT,
+            PRIMARY KEY (tenant_id, evidence_id),
+            UNIQUE (tenant_id, provider, provider_message_id)
+        );
+        CREATE INDEX idx_application_email_evidence_job
+        ON application_email_evidence(
+            tenant_id, job_key, received_at DESC
+        );
+        CREATE TABLE application_outcome_suggestions (
+            tenant_id          TEXT NOT NULL DEFAULT 'local',
+            suggestion_id      TEXT NOT NULL,
+            job_key            TEXT NOT NULL,
+            evidence_id        TEXT,
+            suggested_kind     TEXT NOT NULL,
+            confidence         REAL NOT NULL DEFAULT 0,
+            rationale          TEXT NOT NULL DEFAULT '',
+            status             TEXT NOT NULL DEFAULT 'pending',
+            created_at         TEXT NOT NULL,
+            decided_at         TEXT,
+            decision           TEXT,
+            decision_reason    TEXT,
+            decided_outcome_id TEXT,
+            PRIMARY KEY (tenant_id, suggestion_id)
+        );
+        CREATE INDEX idx_application_outcome_suggestions_job
+        ON application_outcome_suggestions(
+            tenant_id, job_key, status, created_at DESC
+        );
+        CREATE INDEX idx_application_outcome_suggestions_status
+        ON application_outcome_suggestions(
+            tenant_id, status, created_at DESC
+        );
+        PRAGMA user_version = 21;
+        """
+    )
+    conn.commit()
+
+
+def _insert_candidate_pair(
+    conn: sqlite3.Connection,
+    *,
+    tenant_id: str,
+    reference_column: str,
+    reference: str,
+    marker: str,
+    evidence_id: str | None = None,
+    suggestion_id: str | None = None,
+    provider_message_id: str | None = None,
+) -> None:
+    evidence = evidence_id or f"evidence:{marker}"
+    suggestion = suggestion_id or f"suggestion:{marker}"
+    message = provider_message_id or f"message:{marker}"
+    conn.execute(
+        f"""
+        INSERT INTO application_email_evidence (
+            tenant_id, evidence_id, {reference_column}, provider,
+            provider_message_id, provider_thread_id, from_address,
+            to_addresses_json, subject, snippet, received_at, linked_at,
+            link_confidence, link_signals_json, body_text, body_sha256,
+            body_stored_at
+        ) VALUES (
+            ?, ?, ?, 'gmail', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+        )
+        """,
+        (
+            tenant_id,
+            evidence,
+            reference,
+            message,
+            f"thread:{marker}",
+            f"from:{marker}@example.com",
+            json.dumps([f"to:{marker}@example.com"]),
+            f"subject:{marker}",
+            f"snippet:{marker}",
+            f"2026-07-30T10:0{len(marker) % 9}:00+00:00",
+            "2026-07-30T11:00:00+00:00",
+            0.91,
+            json.dumps(["recipient", f"signal:{marker}"]),
+            f"private-body:{marker}",
+            f"sha256:{marker}",
+            "2026-07-30T11:00:00+00:00",
+        ),
+    )
+    conn.execute(
+        f"""
+        INSERT INTO application_outcome_suggestions (
+            tenant_id, suggestion_id, {reference_column}, evidence_id,
+            suggested_kind, confidence, rationale, status, created_at,
+            decided_at, decision, decision_reason, decided_outcome_id
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            tenant_id,
+            suggestion,
+            reference,
+            evidence,
+            "interview",
+            0.87,
+            f"rationale:{marker}",
+            "accepted",
+            "2026-07-30T11:01:00+00:00",
+            "2026-07-30T11:02:00+00:00",
+            "accept",
+            f"reason:{marker}",
+            f"outcome:{marker}",
+        ),
+    )
+
+
+def _rows_without_reference(
+    conn: sqlite3.Connection,
+    *,
+    table: str,
+    reference: str,
+) -> dict[tuple[str, str], tuple[Any, ...]]:
+    id_column = (
+        "evidence_id"
+        if table == "application_email_evidence"
+        else "suggestion_id"
+    )
+    columns = [
+        str(row[1])
+        for row in conn.execute(
+            f'PRAGMA table_info("{table}")'
+        ).fetchall()
+        if str(row[1]) != reference
+    ]
+    selected = ", ".join(f'"{column}"' for column in columns)
+    return {
+        (str(row[0]), str(row[1])): tuple(row)
+        for row in conn.execute(
+            f"""
+            SELECT tenant_id, {id_column}, {selected}
+            FROM "{table}"
+            ORDER BY tenant_id, {id_column}
+            """
+        ).fetchall()
+    }
+
+
+def test_v21_candidates_migrate_every_alias_uuid_url_and_tenant(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    conn = init_db(db_path)
+    jobs = SqliteJobRepository(conn)
+    owner_id = JobId(str(uuid.uuid4()))
+    storage_url = "https://boards.example/jobs/evidence"
+    alias_url = "https://careers.example/jobs/evidence"
+    jobs.save(_discovered_job(storage_url, owner_id))
+    jobs.save(_discovered_job(alias_url, owner_id))
+
+    uuid_shaped_url = str(uuid.uuid4())
+    uuid_url_owner = JobId(str(uuid.uuid4()))
+    jobs.save(_discovered_job(uuid_shaped_url, uuid_url_owner))
+    jobs.save(
+        _discovered_job(
+            "https://example.com/jobs/id-text-owner",
+            JobId(uuid_shaped_url),
+        )
+    )
+    other_tenant_url = "https://tenant-b.example/jobs/evidence"
+    conn.execute(
+        """
+        INSERT INTO jobs (
+            url, tenant_id, job_id, title, company, discovered_at
+        ) VALUES (?, 'tenant-b', ?, 'Platform Engineer', 'ExampleCo', ?)
+        """,
+        (
+            other_tenant_url,
+            str(owner_id),
+            "2026-07-30T10:00:00+00:00",
+        ),
+    )
+
+    _downgrade_candidates_to_v21(conn)
+    fixtures = (
+        (
+            "local",
+            storage_url,
+            "storage",
+            "storage-evidence",
+            "storage-suggestion",
+            "storage-message",
+        ),
+        (
+            "local",
+            alias_url,
+            "alias",
+            "alias-evidence",
+            "alias-suggestion",
+            "alias-message",
+        ),
+        (
+            "local",
+            uuid_shaped_url,
+            "uuid-url",
+            "shared-evidence",
+            "shared-suggestion",
+            "shared-message",
+        ),
+        (
+            "tenant-b",
+            other_tenant_url,
+            "tenant-b",
+            "shared-evidence",
+            "shared-suggestion",
+            "shared-message",
+        ),
+    )
+    for (
+        tenant_id,
+        job_key,
+        marker,
+        evidence_id,
+        suggestion_id,
+        provider_message_id,
+    ) in fixtures:
+        _insert_candidate_pair(
+            conn,
+            tenant_id=tenant_id,
+            reference_column="job_key",
+            reference=job_key,
+            marker=marker,
+            evidence_id=evidence_id,
+            suggestion_id=suggestion_id,
+            provider_message_id=provider_message_id,
+        )
+    conn.commit()
+    before_evidence = _rows_without_reference(
+        conn,
+        table="application_email_evidence",
+        reference="job_key",
+    )
+    before_suggestions = _rows_without_reference(
+        conn,
+        table="application_outcome_suggestions",
+        reference="job_key",
+    )
+    close_connection(db_path)
+
+    reopened = init_db(db_path)
+    assert (
+        reopened.execute("PRAGMA user_version").fetchone()[0]
+        == SCHEMA_VERSION
+        == 22
+    )
+    for table in database_module._APPLICATION_FEEDBACK_CANDIDATE_TABLES:
+        assert "job_id" in _columns(reopened, table)
+        assert "job_key" not in _columns(reopened, table)
+    assert _rows_without_reference(
+        reopened,
+        table="application_email_evidence",
+        reference="job_id",
+    ) == before_evidence
+    assert _rows_without_reference(
+        reopened,
+        table="application_outcome_suggestions",
+        reference="job_id",
+    ) == before_suggestions
+
+    expected_job_ids = {
+        ("local", "storage-evidence"): str(owner_id),
+        ("local", "alias-evidence"): str(owner_id),
+        ("local", "shared-evidence"): str(uuid_url_owner),
+        ("tenant-b", "shared-evidence"): str(owner_id),
+    }
+    assert {
+        (str(row[0]), str(row[1])): str(row[2])
+        for row in reopened.execute(
+            """
+            SELECT tenant_id, evidence_id, job_id
+            FROM application_email_evidence
+            """
+        ).fetchall()
+    } == expected_job_ids
+    assert database_module._has_application_feedback_candidate_schema_v22(
+        reopened
+    )
+    assert reopened.execute("PRAGMA foreign_key_check").fetchone() is None
+    with pytest.raises(sqlite3.IntegrityError):
+        reopened.execute(
+            """
+            INSERT INTO application_email_evidence (
+                tenant_id, evidence_id, job_id, provider,
+                provider_message_id, linked_at
+            ) VALUES ('local', 'duplicate-provider-message', ?, 'gmail',
+                      'shared-message', '2026-07-30T12:00:00+00:00')
+            """,
+            (str(owner_id),),
+        )
+    reopened.rollback()
+    close_connection(db_path)
+
+    reopened_again = init_db(db_path)
+    assert reopened_again.execute(
+        "SELECT COUNT(*) FROM application_email_evidence"
+    ).fetchone()[0] == 4
+    assert reopened_again.execute(
+        "SELECT COUNT(*) FROM application_outcome_suggestions"
+    ).fetchone()[0] == 4
+    close_connection(db_path)
+
+
+def test_v22_candidate_migration_rolls_back_and_retries_with_fks_on(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    conn = init_db(db_path)
+    job_id = JobId(str(uuid.uuid4()))
+    job_url = "https://example.com/jobs/candidate-retry"
+    SqliteJobRepository(conn).save(_discovered_job(job_url, job_id))
+    _downgrade_candidates_to_v21(conn)
+    _insert_candidate_pair(
+        conn,
+        tenant_id="local",
+        reference_column="job_key",
+        reference=job_url,
+        marker="retry",
+    )
+    conn.commit()
+    conn.execute("PRAGMA foreign_keys = ON")
+    original_verify = (
+        database_module
+        ._verify_application_feedback_candidate_references_v22
+    )
+
+    def _fail_verification(
+        _conn: sqlite3.Connection,
+        *,
+        expected_counts: dict[str, int],
+    ) -> None:
+        del expected_counts
+        raise RuntimeError("injected candidate verification failure")
+
+    monkeypatch.setattr(
+        database_module,
+        "_verify_application_feedback_candidate_references_v22",
+        _fail_verification,
+    )
+    with pytest.raises(
+        RuntimeError,
+        match="injected candidate verification failure",
+    ):
+        ensure_application_feedback_candidate_references_v22(conn)
+    assert conn.execute("PRAGMA user_version").fetchone()[0] == 21
+    assert "job_key" in _columns(
+        conn,
+        "application_email_evidence",
+    )
+    assert "job_key" in _columns(
+        conn,
+        "application_outcome_suggestions",
+    )
+    assert conn.execute(
+        "SELECT body_text FROM application_email_evidence"
+    ).fetchone()[0] == "private-body:retry"
+
+    monkeypatch.setattr(
+        database_module,
+        "_verify_application_feedback_candidate_references_v22",
+        original_verify,
+    )
+    assert ensure_application_feedback_candidate_references_v22(conn) == [
+        "application_email_evidence",
+        "application_outcome_suggestions",
+    ]
+    assert conn.execute("PRAGMA user_version").fetchone()[0] == 22
+    assert conn.execute("PRAGMA foreign_key_check").fetchone() is None
+    close_connection(db_path)
+
+
+@pytest.mark.parametrize(
+    ("schema_version", "expected_reference"),
+    ((0, "job_key"), (21, "job_key"), (22, "job_id")),
+)
+def test_missing_candidate_table_recovery_is_version_aware(
+    schema_version: int,
+    expected_reference: str,
+) -> None:
+    for ensure_tables in (
+        lambda conn: database_module
+        ._ensure_application_feedback_candidate_tables_for_version(
+            conn,
+            current_version=schema_version,
+        ),
+        ensure_application_feedback_tables,
+    ):
+        conn = sqlite3.connect(":memory:")
+        conn.executescript(
+            f"""
+            CREATE TABLE jobs (
+                url TEXT PRIMARY KEY,
+                tenant_id TEXT NOT NULL DEFAULT 'local',
+                job_id TEXT NOT NULL,
+                UNIQUE (tenant_id, job_id)
+            );
+            PRAGMA user_version = {schema_version};
+            """
+        )
+        ensure_tables(conn)
+        for table in database_module._APPLICATION_FEEDBACK_CANDIDATE_TABLES:
+            columns = _columns(conn, table)
+            assert expected_reference in columns
+            assert (
+                {"job_id", "job_key"} - {expected_reference}
+            ).isdisjoint(columns)
+            if schema_version == 22:
+                assert database_module._has_composite_job_id_foreign_key(
+                    conn,
+                    table,
+                    "job_id",
+                )
+        evidence_index = [
+            str(row[2])
+            for row in conn.execute(
+                "PRAGMA index_info(idx_application_email_evidence_job)"
+            ).fetchall()
+        ]
+        suggestion_index = [
+            str(row[2])
+            for row in conn.execute(
+                "PRAGMA index_info("
+                "idx_application_outcome_suggestions_job)"
+            ).fetchall()
+        ]
+        assert evidence_index == [
+            "tenant_id",
+            expected_reference,
+            "received_at",
+        ]
+        assert suggestion_index == [
+            "tenant_id",
+            expected_reference,
+            "status",
+            "created_at",
+        ]
+        conn.close()
+
+
+def test_runtime_candidate_merge_preserves_links_counts_and_tenant(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    conn = init_db(db_path)
+    jobs = SqliteJobRepository(conn)
+    losing_id = JobId(str(uuid.uuid4()))
+    surviving_id = JobId(str(uuid.uuid4()))
+    other_tenant_id = JobId(str(uuid.uuid4()))
+    losing_url = "https://example.com/jobs/candidate-losing"
+    surviving_url = "https://example.com/jobs/candidate-surviving"
+    other_url = "https://tenant-b.example/jobs/candidate"
+    jobs.save(_discovered_job(losing_url, losing_id))
+    jobs.save(_discovered_job(surviving_url, surviving_id))
+    conn.execute(
+        """
+        INSERT INTO jobs (
+            url, tenant_id, job_id, title, company, discovered_at
+        ) VALUES (?, 'tenant-b', ?, 'Platform Engineer', 'ExampleCo', ?)
+        """,
+        (
+            other_url,
+            str(other_tenant_id),
+            "2026-07-30T10:00:00+00:00",
+        ),
+    )
+    _insert_candidate_pair(
+        conn,
+        tenant_id="local",
+        reference_column="job_id",
+        reference=str(losing_id),
+        marker="losing",
+    )
+    _insert_candidate_pair(
+        conn,
+        tenant_id="local",
+        reference_column="job_id",
+        reference=str(surviving_id),
+        marker="surviving",
+    )
+    _insert_candidate_pair(
+        conn,
+        tenant_id="tenant-b",
+        reference_column="job_id",
+        reference=str(other_tenant_id),
+        marker="tenant-b",
+    )
+    conn.commit()
+    conn.execute("PRAGMA foreign_keys = ON")
+
+    reassign_discovery_identity_references(
+        conn,
+        losing_job_url=losing_url,
+        surviving_job_url=surviving_url,
+    )
+    conn.execute(
+        "DELETE FROM jobs WHERE tenant_id = 'local' AND url = ?",
+        (losing_url,),
+    )
+
+    assert [
+        tuple(row)
+        for row in conn.execute(
+            """
+            SELECT tenant_id, evidence_id, job_id
+            FROM application_email_evidence
+            ORDER BY tenant_id, evidence_id
+            """
+        ).fetchall()
+    ] == [
+        ("local", "evidence:losing", str(surviving_id)),
+        ("local", "evidence:surviving", str(surviving_id)),
+        ("tenant-b", "evidence:tenant-b", str(other_tenant_id)),
+    ]
+    assert [
+        tuple(row)
+        for row in conn.execute(
+            """
+            SELECT tenant_id, suggestion_id, job_id, evidence_id,
+                   decided_outcome_id
+            FROM application_outcome_suggestions
+            ORDER BY tenant_id, suggestion_id
+            """
+        ).fetchall()
+    ] == [
+        (
+            "local",
+            "suggestion:losing",
+            str(surviving_id),
+            "evidence:losing",
+            "outcome:losing",
+        ),
+        (
+            "local",
+            "suggestion:surviving",
+            str(surviving_id),
+            "evidence:surviving",
+            "outcome:surviving",
+        ),
+        (
+            "tenant-b",
+            "suggestion:tenant-b",
+            str(other_tenant_id),
+            "evidence:tenant-b",
+            "outcome:tenant-b",
+        ),
+    ]
+    assert conn.execute("PRAGMA foreign_key_check").fetchone() is None
+    close_connection(db_path)
+
+
+def test_unresolved_candidate_url_rolls_back_both_tables(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    conn = init_db(db_path)
+    job_id = JobId(str(uuid.uuid4()))
+    job_url = "https://example.com/jobs/resolved-candidate"
+    SqliteJobRepository(conn).save(_discovered_job(job_url, job_id))
+    _downgrade_candidates_to_v21(conn)
+    _insert_candidate_pair(
+        conn,
+        tenant_id="local",
+        reference_column="job_key",
+        reference=job_url,
+        marker="resolved",
+    )
+    conn.execute(
+        """
+        UPDATE application_outcome_suggestions
+        SET job_key = 'https://example.com/jobs/unresolved'
+        """
+    )
+    conn.commit()
+
+    with pytest.raises(
+        RuntimeError,
+        match="application_outcome_suggestions.job_key",
+    ):
+        ensure_application_feedback_candidate_references_v22(conn)
+
+    assert conn.execute("PRAGMA user_version").fetchone()[0] == 21
+    assert "job_key" in _columns(
+        conn,
+        "application_email_evidence",
+    )
+    assert "job_key" in _columns(
+        conn,
+        "application_outcome_suggestions",
+    )
+    assert conn.execute(
+        "SELECT body_text FROM application_email_evidence"
+    ).fetchone()[0] == "private-body:resolved"
+    close_connection(db_path)
+
+
+class _FakeGmailClient:
+    def search_feedback_emails(
+        self,
+        *,
+        query: str,
+        to_email: str,
+        after: datetime,
+        before: datetime,
+        max_results: int,
+    ) -> list[dict[str, Any]]:
+        del query, to_email, after, before, max_results
+        return [
+            {
+                "id": "stable-message",
+                "threadId": "stable-thread",
+                "subject": (
+                    "ExampleCo application received for Platform Engineer"
+                ),
+                "from": "recruiting@example.com",
+                "to": "candidate@example.com",
+                "date": "Thu, 30 Jul 2026 11:00:00 +0000",
+                "snippet": "Thank you for applying.",
+            }
+        ]
+
+    def read_email(self, *, message_id: str) -> dict[str, Any]:
+        assert message_id == "stable-message"
+        return {
+            "id": message_id,
+            "threadId": "stable-thread",
+            "subject": (
+                "ExampleCo application received for Platform Engineer"
+            ),
+            "from": "recruiting@example.com",
+            "to": "candidate@example.com",
+            "date": "Thu, 30 Jul 2026 11:00:00 +0000",
+            "snippet": "Thank you for applying.",
+            "body_text": "private candidate email body",
+        }
+
+
+def test_gmail_v22_stores_url_owner_but_projects_url_and_safe_event(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    conn = init_db(db_path)
+    uuid_shaped_url = str(uuid.uuid4())
+    url_owner_id = JobId(str(uuid.uuid4()))
+    SqliteJobRepository(conn).save(
+        _discovered_job(uuid_shaped_url, url_owner_id)
+    )
+    SqliteJobRepository(conn).save(
+        _discovered_job(
+            "https://example.com/jobs/id-text-owner",
+            JobId(uuid_shaped_url),
+        )
+    )
+    conn.execute(
+        "UPDATE jobs SET applied_at = ? WHERE url = ?",
+        ("2026-07-30T10:00:00+00:00", uuid_shaped_url),
+    )
+    conn.commit()
+    close_connection(db_path)
+
+    summary = scan_gmail_feedback(
+        db_path=db_path,
+        client=_FakeGmailClient(),
+        recipient_email="candidate@example.com",
+        limit=1,
+        max_results_per_anchor=1,
+        window_days=7,
+    )
+
+    assert summary["linkedEvidenceCount"] == 1
+    assert summary["suggestionsCreatedCount"] == 1
+    assert summary["evidence"][0]["jobKey"] == uuid_shaped_url
+    assert summary["suggestions"][0]["jobKey"] == uuid_shaped_url
+    check = sqlite3.connect(db_path)
+    check.row_factory = sqlite3.Row
+    assert check.execute(
+        "SELECT job_id FROM application_email_evidence"
+    ).fetchone()["job_id"] == str(url_owner_id)
+    assert check.execute(
+        "SELECT job_id FROM application_outcome_suggestions"
+    ).fetchone()["job_id"] == str(url_owner_id)
+    event_row = check.execute(
+        """
+        SELECT job_url, payload_json
+        FROM job_events
+        WHERE event_type = 'ApplicationEmailFeedbackIngested'
+        ORDER BY event_id DESC
+        LIMIT 1
+        """
+    ).fetchone()
+    assert event_row["job_url"] == uuid_shaped_url
+    payload = json.loads(str(event_row["payload_json"]))
+    assert payload["jobKey"] == uuid_shaped_url
+    assert "body" not in payload
+    assert "private candidate email body" not in str(
+        event_row["payload_json"]
+    )
+    check.close()

--- a/workers/automation/tests/test_application_outcome_identity_reference_migration.py
+++ b/workers/automation/tests/test_application_outcome_identity_reference_migration.py
@@ -243,7 +243,7 @@ def test_v20_outcomes_migrate_every_alias_uuid_url_and_tenant(
     assert (
         reopened.execute("PRAGMA user_version").fetchone()[0]
         == SCHEMA_VERSION
-        == 21
+        == 22
     )
     assert "job_id" in _columns(reopened, "application_outcomes")
     assert "job_key" not in _columns(reopened, "application_outcomes")
@@ -372,7 +372,12 @@ def test_v21_outcome_migration_rolls_back_and_retries(
 
 @pytest.mark.parametrize(
     ("schema_version", "expected_reference"),
-    ((0, "job_key"), (20, "job_key"), (21, "job_id")),
+    (
+        (0, "job_key"),
+        (20, "job_key"),
+        (21, "job_id"),
+        (22, "job_id"),
+    ),
 )
 def test_missing_outcome_table_recovery_is_version_aware(
     schema_version: int,
@@ -399,7 +404,7 @@ def test_missing_outcome_table_recovery_is_version_aware(
     assert (
         {"job_id", "job_key"} - {expected_reference}
     ).isdisjoint(columns)
-    if schema_version == 21:
+    if schema_version >= 21:
         assert (
             database_module
             ._has_application_outcome_reference_schema_v21(conn)

--- a/workers/automation/tests/test_application_review_identity_reference_migration.py
+++ b/workers/automation/tests/test_application_review_identity_reference_migration.py
@@ -204,7 +204,7 @@ def test_v19_review_decisions_migrate_every_alias_and_uuid_url(
     assert (
         reopened.execute("PRAGMA user_version").fetchone()[0]
         == SCHEMA_VERSION
-        == 21
+        == 22
     )
     assert "job_id" in _columns(
         reopened,

--- a/workers/automation/tests/test_audit_projection_parity.py
+++ b/workers/automation/tests/test_audit_projection_parity.py
@@ -528,9 +528,23 @@ def _seed_conversion_rows(conn: sqlite3.Connection, fixture: dict[str, Any]) -> 
         conn.execute(
             """
             INSERT INTO application_outcome_suggestions (
-                tenant_id, suggestion_id, job_key, suggested_kind, confidence, rationale,
+                tenant_id, suggestion_id, job_id, suggested_kind, confidence, rationale,
                 status, created_at, decided_at, decision
-            ) VALUES ('local', ?, ?, 'recruiter_reply', 0.9, '', ?, ?, ?, ?)
+            ) VALUES (
+                'local',
+                ?,
+                (
+                    SELECT job_id FROM jobs
+                    WHERE tenant_id = 'local' AND url = ?
+                ),
+                'recruiter_reply',
+                0.9,
+                '',
+                ?,
+                ?,
+                ?,
+                ?
+            )
             """,
             (
                 suggestion["suggestionId"],

--- a/workers/automation/tests/test_compensation_identity_reference_migration.py
+++ b/workers/automation/tests/test_compensation_identity_reference_migration.py
@@ -210,7 +210,7 @@ def test_v18_compensation_migrates_alias_winners_and_uuid_urls(
     assert (
         reopened.execute("PRAGMA user_version").fetchone()[0]
         == SCHEMA_VERSION
-        == 21
+        == 22
     )
     for table in database_module._COMPENSATION_REFERENCE_TABLES:
         assert "job_id" in _columns(reopened, table)

--- a/workers/automation/tests/test_dashboard_projection.py
+++ b/workers/automation/tests/test_dashboard_projection.py
@@ -601,13 +601,28 @@ def _record_suggestion(conn: sqlite3.Connection, index: int, status: str) -> Non
     conn.execute(
         """
         INSERT INTO application_outcome_suggestions (
-            tenant_id, suggestion_id, job_key, suggested_kind, confidence, rationale,
+            tenant_id, suggestion_id, job_id, suggested_kind, confidence, rationale,
             status, created_at, decided_at, decision
-        ) VALUES ('local', ?, ?, 'recruiter_reply', 0.9, '', ?, ?, ?, ?)
+        ) VALUES (
+            'local',
+            ?,
+            (
+                SELECT job_id FROM jobs
+                WHERE tenant_id = 'local'
+                ORDER BY url
+                LIMIT 1
+            ),
+            'recruiter_reply',
+            0.9,
+            '',
+            ?,
+            ?,
+            ?,
+            ?
+        )
         """,
         (
             f"suggestion-{index}",
-            f"https://example.com/suggestion-{index}",
             status,
             utc_now(),
             utc_now(),

--- a/workers/automation/tests/test_discovery_identity_reference_migration.py
+++ b/workers/automation/tests/test_discovery_identity_reference_migration.py
@@ -220,7 +220,7 @@ def test_v7_discovery_references_migrate_to_stable_job_id_and_reopen(
     init_db(db_path)
     close_connection(db_path)
 
-    assert _user_version(db_path) == SCHEMA_VERSION == 21
+    assert _user_version(db_path) == SCHEMA_VERSION == 22
     assert "job_id" in _columns(db_path, "job_source_observations")
     assert "job_url" not in _columns(db_path, "job_source_observations")
     assert "job_id" in _columns(db_path, "job_canonical_identities")

--- a/workers/automation/tests/test_employer_analysis_identity_reference_migration.py
+++ b/workers/automation/tests/test_employer_analysis_identity_reference_migration.py
@@ -242,7 +242,7 @@ def test_v15_employer_analysis_migrates_alias_histories_and_uuid_urls(
     assert (
         reopened.execute("PRAGMA user_version").fetchone()[0]
         == SCHEMA_VERSION
-        == 21
+        == 22
     )
     for table in database_module._EMPLOYER_ANALYSIS_REFERENCE_TABLES:
         assert "job_id" in _columns(reopened, table)

--- a/workers/automation/tests/test_enrichment_snapshot_identity_reference_migration.py
+++ b/workers/automation/tests/test_enrichment_snapshot_identity_reference_migration.py
@@ -322,7 +322,7 @@ def test_v10_enrichment_snapshot_references_migrate_and_reopen(
     init_db(db_path)
     close_connection(db_path)
 
-    assert _user_version(db_path) == SCHEMA_VERSION == 21
+    assert _user_version(db_path) == SCHEMA_VERSION == 22
     check = sqlite3.connect(db_path)
     try:
         enrichment_rows = check.execute(

--- a/workers/automation/tests/test_execution_search_identity_reference_migration.py
+++ b/workers/automation/tests/test_execution_search_identity_reference_migration.py
@@ -261,7 +261,7 @@ def test_v8_execution_and_receipts_migrate_to_stable_job_id_and_reopen(
     init_db(db_path)
     close_connection(db_path)
 
-    assert _user_version(db_path) == SCHEMA_VERSION == 21
+    assert _user_version(db_path) == SCHEMA_VERSION == 22
     assert "job_id" in _columns(db_path, "discovery_execution_jobs")
     assert "job_url" not in _columns(db_path, "discovery_execution_jobs")
     assert "job_id" in _columns(db_path, "discovery_search_unit_jobs")

--- a/workers/automation/tests/test_interview_prep_identity_reference_migration.py
+++ b/workers/automation/tests/test_interview_prep_identity_reference_migration.py
@@ -323,7 +323,7 @@ def test_v17_interview_prep_migrates_alias_histories_and_uuid_urls(
     assert (
         reopened.execute("PRAGMA user_version").fetchone()[0]
         == SCHEMA_VERSION
-        == 21
+        == 22
     )
     for table in database_module._INTERVIEW_PREP_REFERENCE_TABLES:
         assert "job_id" in _columns(reopened, table)

--- a/workers/automation/tests/test_materials_identity_reference_migration.py
+++ b/workers/automation/tests/test_materials_identity_reference_migration.py
@@ -293,7 +293,7 @@ def test_v14_materials_migrate_alias_histories_and_uuid_shaped_urls(
     close_connection(db_path)
 
     reopened = init_db(db_path)
-    assert reopened.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_VERSION == 21
+    assert reopened.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_VERSION == 22
     for table in database_module._MATERIALS_REFERENCE_TABLES:
         assert "job_id" in _columns(reopened, table)
         assert "job_url" not in _columns(reopened, table)

--- a/workers/automation/tests/test_preparation_identity_reference_migration.py
+++ b/workers/automation/tests/test_preparation_identity_reference_migration.py
@@ -177,7 +177,7 @@ def test_v9_preparation_references_migrate_to_stable_job_ids_and_reopen(
     init_db(db_path)
     close_connection(db_path)
 
-    assert _user_version(db_path) == SCHEMA_VERSION == 21
+    assert _user_version(db_path) == SCHEMA_VERSION == 22
     check = sqlite3.connect(db_path)
     try:
         rows = check.execute(

--- a/workers/automation/tests/test_repeat_application_prevention.py
+++ b/workers/automation/tests/test_repeat_application_prevention.py
@@ -317,17 +317,19 @@ def test_unconfirmed_sources_do_not_establish_application_history(tmp_path: Path
         )
     conn.execute(
         """
-        CREATE TABLE IF NOT EXISTS application_outcome_suggestions (
-          tenant_id TEXT NOT NULL, suggestion_id TEXT NOT NULL, job_key TEXT NOT NULL,
-          suggested_kind TEXT NOT NULL, status TEXT NOT NULL, created_at TEXT NOT NULL
-        )
-        """
-    )
-    conn.execute(
-        """
         INSERT INTO application_outcome_suggestions
-          (tenant_id, suggestion_id, job_key, suggested_kind, status, created_at)
-        VALUES ('local', 'pending-suggestion', ?, 'applied_confirmation', 'pending', ?)
+          (tenant_id, suggestion_id, job_id, suggested_kind, status, created_at)
+        VALUES (
+          'local',
+          'pending-suggestion',
+          (
+            SELECT job_id FROM jobs
+            WHERE tenant_id = 'local' AND url = ?
+          ),
+          'applied_confirmation',
+          'pending',
+          ?
+        )
         """,
         (PRIOR, NOW),
     )
@@ -758,7 +760,7 @@ def test_schema_v5_migrates_additively_without_changing_application_facts(
         (PRIOR,),
     ).fetchall()
 
-    assert int(migrated.execute("PRAGMA user_version").fetchone()[0]) == SCHEMA_VERSION == 21
+    assert int(migrated.execute("PRAGMA user_version").fetchone()[0]) == SCHEMA_VERSION == 22
     assert [tuple(row) for row in after] == [tuple(row) for row in before]
     assert "metadata_json" in {
         str(row[1]) for row in migrated.execute("PRAGMA table_info(job_stage_states)").fetchall()

--- a/workers/automation/tests/test_resume_template_identity_reference_migration.py
+++ b/workers/automation/tests/test_resume_template_identity_reference_migration.py
@@ -254,7 +254,7 @@ def test_v16_template_references_migrate_aliases_and_uuid_urls(
     assert (
         reopened.execute("PRAGMA user_version").fetchone()[0]
         == SCHEMA_VERSION
-        == 21
+        == 22
     )
     for table in database_module._RESUME_TEMPLATE_REFERENCE_TABLES:
         assert "job_id" in _columns(reopened, table)

--- a/workers/automation/tests/test_scoring_identity_reference_migration.py
+++ b/workers/automation/tests/test_scoring_identity_reference_migration.py
@@ -338,7 +338,7 @@ def test_v11_scoring_references_migrate_alias_histories_and_reopen(
     assert (
         int(migrated.execute("PRAGMA user_version").fetchone()[0])
         == SCHEMA_VERSION
-        == 21
+        == 22
     )
     assert _columns(migrated, "job_scores") >= {"tenant_id", "job_id"}
     assert "job_url" not in _columns(migrated, "job_scores")
@@ -404,7 +404,7 @@ def test_v11_scoring_references_migrate_alias_histories_and_reopen(
     assert (
         int(reopened.execute("PRAGMA user_version").fetchone()[0])
         == SCHEMA_VERSION
-        == 21
+        == 22
     )
 
 
@@ -553,7 +553,7 @@ def test_scoring_migration_rolls_back_and_retries_after_verification_failure(
     assert (
         int(retried.execute("PRAGMA user_version").fetchone()[0])
         == SCHEMA_VERSION
-        == 21
+        == 22
     )
     assert [
         tuple(row)

--- a/workers/automation/tests/test_stable_job_identity_migration.py
+++ b/workers/automation/tests/test_stable_job_identity_migration.py
@@ -841,7 +841,7 @@ def test_v6_jobs_gain_stable_uuid_and_posting_url_alias_once(
     init_db(db_path)
     close_connection(db_path)
 
-    assert _user_version(db_path) == SCHEMA_VERSION == 21
+    assert _user_version(db_path) == SCHEMA_VERSION == 22
     first_ids = _identity_rows(db_path)
     assert [row[0] for row in first_ids] == ["local", "local"]
     for _tenant_id, job_id, _url in first_ids:


### PR DESCRIPTION
## Summary

- advance the local schema contract to v22 and migrate linked Gmail evidence plus pending/decided outcome suggestions from legacy URL-shaped `job_key` references to tenant-scoped stable `job_id` references
- preserve every evidence and suggestion field, ID, cross-link, decision state, provider-message uniqueness, and tenant boundary while adding the required composite cascading Job foreign keys and indexes
- keep the public API, Gmail summaries, and audit events URL-shaped until Phase 4, including URL-first ownership when a posting URL is itself UUID-shaped
- explicitly purge both candidate tables during permanent deletion when SQLite foreign-key actions are disabled
- add database, Gmail, API, rollback/retry, collision, deletion, privacy, and version-aware recovery coverage

## Why

Reviewed outcomes became JobId-owned in #547, but their machine-generated candidate graph still used mutable URL-shaped keys. This PR moves that next bounded seam together so an evidence row and its suggestion cannot drift to a different aggregate during URL aliasing or collision merges. Reviewed outcomes remain the user-authoritative layer from #547; this PR does not change their meaning or add cross-table foreign keys for `evidence_id` or `decided_outcome_id`.

## Validation

- `pnpm api:check`
- `pnpm --filter @jobctrl/api test` — 691 passed
- `PYTHONPATH=src .../.venv/bin/python -m pytest -q` — 2,725 passed, 2 skipped before the final recovery-case-only test addition
- focused final Python recovery suite — 9 passed
- new v22 Python migration suite — 8 passed
- new v22 API suite — 5 passed
- focused identity/regression matrix — 111 passed
- focused Ruff checks
- `git diff --check`
- independent Tier-3 review — PASS, Blocker/High/Medium/Low = 0/0/0/0
- independent Tier-3 QA — PASS, Blocker/High/Medium/Low = 0/0/0/0

## Stack

- base: #547 (`feat/job-id-application-outcome-references`)
- this is an intermediate unreleased identity-migration PR; canonical product documentation and cumulative product QA remain intentionally deferred to the final stack PR under the approved stack policy
