### PR TITLE
feat(apply): migrate repeat evidence to stable JobIds

### DIFF
--- a/apps/api/src/db.ts
+++ b/apps/api/src/db.ts
@@ -9,7 +9,7 @@ export type SqliteValue = string | number | bigint | null;
 // writer that stamps ``PRAGMA user_version``; the API only reads it to fail
 // closed on a database written by a newer build. Bump both constants together
 // whenever the schema shape changes.
-export const SUPPORTED_SCHEMA_VERSION = 22;
+export const SUPPORTED_SCHEMA_VERSION = 23;
 
 export class IncompatibleSchemaVersionError extends Error {
   constructor(current: number) {

--- a/apps/api/src/repeat-application.ts
+++ b/apps/api/src/repeat-application.ts
@@ -17,12 +17,15 @@ import {
   hasCompositeJobIdForeignKey,
   jobKeyReferenceColumn,
   jobKeyReferenceJoinToJobs,
+  stableJobIdForUrl,
+  tableColumnSet,
   tableExists,
   type SqliteDatabase,
 } from "./db.js";
 import { InputError } from "./write-model.js";
 
 const DEFAULT_TENANT = "local";
+const REPEAT_APPLICATION_REFERENCE_SCHEMA_VERSION = 23;
 
 interface JobIdentityRow extends Record<string, unknown> {
   url: string;
@@ -78,12 +81,56 @@ interface AuditRow extends Record<string, unknown> {
 }
 
 export function ensureRepeatApplicationTables(db: SqliteDatabase): void {
+  const schemaVersion = db.pragma("user_version", {
+    simple: true,
+  }) as number;
+  const overrideColumns = tableColumnSet(
+    db,
+    "application_repeat_overrides",
+  );
+  const stableOverrideReferences =
+    overrideColumns.has("target_job_id")
+    || (
+      overrideColumns.size === 0
+      && schemaVersion >= REPEAT_APPLICATION_REFERENCE_SCHEMA_VERSION
+    );
+  const auditColumns = tableColumnSet(
+    db,
+    "application_repeat_audit",
+  );
+  const stableAuditReference =
+    auditColumns.has("target_job_id")
+    || (
+      auditColumns.size === 0
+      && schemaVersion >= REPEAT_APPLICATION_REFERENCE_SCHEMA_VERSION
+    );
+  const targetReference = stableOverrideReferences
+    ? "target_job_id"
+    : "target_job_key";
+  const priorReference = stableOverrideReferences
+    ? "prior_job_id"
+    : "prior_job_key";
+  const auditTargetReference = stableAuditReference
+    ? "target_job_id"
+    : "target_job_key";
+  const overrideForeignKeys = stableOverrideReferences
+    ? `,
+      FOREIGN KEY (tenant_id, target_job_id)
+        REFERENCES jobs(tenant_id, job_id) ON DELETE CASCADE,
+      FOREIGN KEY (tenant_id, prior_job_id)
+        REFERENCES jobs(tenant_id, job_id) ON DELETE CASCADE`
+    : "";
+  const auditForeignKey = stableAuditReference
+    ? `,
+      FOREIGN KEY (tenant_id, target_job_id)
+        REFERENCES jobs(tenant_id, job_id) ON DELETE CASCADE`
+    : "";
   db.exec(`
     CREATE TABLE IF NOT EXISTS application_repeat_overrides (
       tenant_id            TEXT NOT NULL DEFAULT 'local',
       override_id          TEXT NOT NULL,
-      target_job_key       TEXT NOT NULL,
-      prior_job_key        TEXT NOT NULL,
+      ${targetReference}    TEXT NOT NULL,
+      ${priorReference}     TEXT NOT NULL,
       relationship         TEXT NOT NULL,
       evidence_fingerprint TEXT NOT NULL,
       evidence_json        TEXT NOT NULL,
@@ -91,9 +138,8 @@ export function ensureRepeatApplicationTables(db: SqliteDatabase): void {
       confirmed_by         TEXT NOT NULL,
       confirmed_at         TEXT NOT NULL,
       PRIMARY KEY (tenant_id, override_id)
+      ${overrideForeignKeys}
     );
-    CREATE INDEX IF NOT EXISTS idx_application_repeat_overrides_target
-      ON application_repeat_overrides(tenant_id, target_job_key, confirmed_at DESC);
 
     CREATE TABLE IF NOT EXISTS application_repeat_override_consumptions (
       tenant_id    TEXT NOT NULL DEFAULT 'local',
@@ -108,7 +154,7 @@ export function ensureRepeatApplicationTables(db: SqliteDatabase): void {
       tenant_id            TEXT NOT NULL DEFAULT 'local',
       audit_id             TEXT NOT NULL,
       audit_key            TEXT NOT NULL,
-      target_job_key       TEXT NOT NULL,
+      ${auditTargetReference} TEXT NOT NULL,
       action               TEXT NOT NULL,
       evidence_fingerprint TEXT NOT NULL,
       evidence_json        TEXT NOT NULL,
@@ -118,10 +164,65 @@ export function ensureRepeatApplicationTables(db: SqliteDatabase): void {
       occurred_at          TEXT NOT NULL,
       PRIMARY KEY (tenant_id, audit_id),
       UNIQUE (tenant_id, audit_key)
+      ${auditForeignKey}
     );
-    CREATE INDEX IF NOT EXISTS idx_application_repeat_audit_target
-      ON application_repeat_audit(tenant_id, target_job_key, occurred_at DESC);
   `);
+  const actualOverrideColumns = tableColumnSet(
+    db,
+    "application_repeat_overrides",
+  );
+  const actualTargetReference = actualOverrideColumns.has("target_job_id")
+    ? "target_job_id"
+    : "target_job_key";
+  const actualPriorReference = actualOverrideColumns.has("prior_job_id")
+    ? "prior_job_id"
+    : "prior_job_key";
+  const actualAuditReference = tableColumnSet(
+    db,
+    "application_repeat_audit",
+  ).has("target_job_id")
+    ? "target_job_id"
+    : "target_job_key";
+  ensureIndex(
+    db,
+    "application_repeat_overrides",
+    "idx_application_repeat_overrides_target",
+    ["tenant_id", actualTargetReference, "confirmed_at"],
+    `CREATE INDEX idx_application_repeat_overrides_target
+       ON application_repeat_overrides(
+         tenant_id, ${actualTargetReference}, confirmed_at DESC
+       )`,
+  );
+  if (actualPriorReference === "prior_job_id") {
+    ensureIndex(
+      db,
+      "application_repeat_overrides",
+      "idx_application_repeat_overrides_prior",
+      ["tenant_id", actualPriorReference, "confirmed_at"],
+      `CREATE INDEX idx_application_repeat_overrides_prior
+         ON application_repeat_overrides(
+           tenant_id, ${actualPriorReference}, confirmed_at DESC
+         )`,
+    );
+  }
+  ensureIndex(
+    db,
+    "application_repeat_audit",
+    "idx_application_repeat_audit_target",
+    ["tenant_id", actualAuditReference, "occurred_at"],
+    `CREATE INDEX idx_application_repeat_audit_target
+       ON application_repeat_audit(
+         tenant_id, ${actualAuditReference}, occurred_at DESC
+       )`,
+  );
+  if (
+    schemaVersion >= REPEAT_APPLICATION_REFERENCE_SCHEMA_VERSION
+    && !hasStableRepeatApplicationSchema(db)
+  ) {
+    throw new Error(
+      "Schema v23 requires stable repeat-application references.",
+    );
+  }
 }
 
 export function evaluateRepeatApplication(
@@ -217,16 +318,29 @@ export function recordRepeatApplicationOverride(
 
     const confirmedAt = new Date().toISOString();
     const overrideId = randomUUID();
+    const stableReferences = hasStableRepeatApplicationSchema(db);
+    const targetReference = stableReferences
+      ? stableRepeatJobId(db, targetJobKey)
+      : targetJobKey;
+    const priorReference = stableReferences
+      ? stableRepeatJobId(db, request.priorJobKey)
+      : request.priorJobKey;
+    const targetColumn = stableReferences
+      ? "target_job_id"
+      : "target_job_key";
+    const priorColumn = stableReferences
+      ? "prior_job_id"
+      : "prior_job_key";
     db.prepare(
       `INSERT INTO application_repeat_overrides (
-         tenant_id, override_id, target_job_key, prior_job_key, relationship,
+         tenant_id, override_id, ${targetColumn}, ${priorColumn}, relationship,
          evidence_fingerprint, evidence_json, reason, confirmed_by, confirmed_at
        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     ).run(
       DEFAULT_TENANT,
       overrideId,
-      targetJobKey,
-      request.priorJobKey,
+      targetReference,
+      priorReference,
       selectedPrior.relationship,
       assessment.evidenceFingerprint,
       JSON.stringify(assessment.matches),
@@ -624,17 +738,41 @@ function matchingOverride(
   targetJobKey: string,
   evidenceFingerprint: string,
 ): RepeatApplicationOverride | null {
+  const stableReferences = hasStableRepeatApplicationSchema(db);
+  const targetReference = stableReferences
+    ? stableRepeatJobId(db, targetJobKey)
+    : targetJobKey;
+  const targetExpression = stableReferences
+    ? "target_jobs.url"
+    : "o.target_job_key";
+  const priorExpression = stableReferences
+    ? "prior_jobs.url"
+    : "o.prior_job_key";
+  const targetColumn = stableReferences
+    ? "target_job_id"
+    : "target_job_key";
+  const identityJoins = stableReferences
+    ? `JOIN jobs target_jobs
+         ON target_jobs.tenant_id = o.tenant_id
+        AND target_jobs.job_id = o.target_job_id
+       JOIN jobs prior_jobs
+         ON prior_jobs.tenant_id = o.tenant_id
+        AND prior_jobs.job_id = o.prior_job_id`
+    : "";
   const row = getRow<OverrideRow>(
     db,
-    `SELECT o.override_id, o.target_job_key, o.prior_job_key,
+    `SELECT o.override_id, ${targetExpression} AS target_job_key,
+            ${priorExpression} AS prior_job_key,
             o.evidence_fingerprint, o.reason, o.confirmed_by, o.confirmed_at,
             c.consumed_at, c.run_id AS consumed_run_id
        FROM application_repeat_overrides o
+       ${identityJoins}
        LEFT JOIN application_repeat_override_consumptions c
          ON c.tenant_id = o.tenant_id AND c.override_id = o.override_id
-      WHERE o.tenant_id = ? AND o.target_job_key = ? AND o.evidence_fingerprint = ?
+      WHERE o.tenant_id = ? AND o.${targetColumn} = ?
+        AND o.evidence_fingerprint = ?
       ORDER BY o.confirmed_at DESC, o.override_id DESC LIMIT 1`,
-    [DEFAULT_TENANT, targetJobKey, evidenceFingerprint],
+    [DEFAULT_TENANT, targetReference, evidenceFingerprint],
   );
   return row
     ? {
@@ -688,16 +826,23 @@ function insertAudit(
     occurredAt: string;
   },
 ): void {
+  const stableReferences = hasStableRepeatApplicationSchema(db);
+  const targetColumn = stableReferences
+    ? "target_job_id"
+    : "target_job_key";
+  const targetReference = stableReferences
+    ? stableRepeatJobId(db, input.targetJobKey)
+    : input.targetJobKey;
   db.prepare(
     `INSERT OR IGNORE INTO application_repeat_audit (
-       tenant_id, audit_id, audit_key, target_job_key, action,
+       tenant_id, audit_id, audit_key, ${targetColumn}, action,
        evidence_fingerprint, evidence_json, override_id, actor, reason, occurred_at
      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   ).run(
     DEFAULT_TENANT,
     randomUUID(),
     input.auditKey,
-    input.targetJobKey,
+    targetReference,
     input.action,
     input.evidenceFingerprint,
     input.evidenceJson,
@@ -709,17 +854,40 @@ function insertAudit(
 }
 
 function auditTrail(db: SqliteDatabase, targetJobKey: string): RepeatApplicationAuditEntry[] {
+  const stableReferences = hasStableRepeatApplicationSchema(db);
+  const targetReference = stableReferences
+    ? stableRepeatJobId(db, targetJobKey)
+    : targetJobKey;
+  const targetExpression = stableReferences
+    ? "target_jobs.url"
+    : "a.target_job_key";
+  const priorExpression = stableReferences
+    ? "prior_jobs.url"
+    : "o.prior_job_key";
+  const targetColumn = stableReferences
+    ? "target_job_id"
+    : "target_job_key";
+  const identityJoins = stableReferences
+    ? `JOIN jobs target_jobs
+         ON target_jobs.tenant_id = a.tenant_id
+        AND target_jobs.job_id = a.target_job_id
+       LEFT JOIN jobs prior_jobs
+         ON prior_jobs.tenant_id = o.tenant_id
+        AND prior_jobs.job_id = o.prior_job_id`
+    : "";
   return allRows<AuditRow>(
     db,
-    `SELECT a.audit_id, a.target_job_key, a.action, a.evidence_fingerprint,
-            a.evidence_json, a.override_id, o.prior_job_key,
+    `SELECT a.audit_id, ${targetExpression} AS target_job_key, a.action,
+            a.evidence_fingerprint, a.evidence_json, a.override_id,
+            ${priorExpression} AS prior_job_key,
             a.actor, a.reason, a.occurred_at
        FROM application_repeat_audit a
        LEFT JOIN application_repeat_overrides o
          ON o.tenant_id = a.tenant_id AND o.override_id = a.override_id
-      WHERE a.tenant_id = ? AND a.target_job_key = ?
+       ${identityJoins}
+      WHERE a.tenant_id = ? AND a.${targetColumn} = ?
       ORDER BY a.occurred_at DESC, a.rowid DESC LIMIT 50`,
-    [DEFAULT_TENANT, targetJobKey],
+    [DEFAULT_TENANT, targetReference],
   ).map((row) => ({
     auditId: row.audit_id,
     targetJobKey: row.target_job_key,
@@ -732,6 +900,195 @@ function auditTrail(db: SqliteDatabase, targetJobKey: string): RepeatApplication
     reason: row.reason,
     occurredAt: row.occurred_at,
   }));
+}
+
+function ensureIndex(
+  db: SqliteDatabase,
+  tableName: string,
+  indexName: string,
+  columns: readonly string[],
+  createSql: string,
+): void {
+  const actual = indexColumns(db, tableName, indexName);
+  if (
+    actual?.length === columns.length
+    && actual.every((column, index) => column === columns[index])
+  ) {
+    return;
+  }
+  db.exec(`DROP INDEX IF EXISTS "${indexName}"`);
+  db.exec(createSql);
+}
+
+function indexColumns(
+  db: SqliteDatabase,
+  tableName: string,
+  indexName: string,
+): string[] | null {
+  const index = allRows<{
+    name: string;
+  }>(
+    db,
+    `PRAGMA index_list("${tableName}")`,
+  ).find((row) => row.name === indexName);
+  if (!index) return null;
+  return allRows<{
+    seqno: number;
+    name: string;
+  }>(
+    db,
+    `PRAGMA index_info("${indexName}")`,
+  )
+    .sort((left, right) => left.seqno - right.seqno)
+    .map((row) => row.name);
+}
+
+function primaryKeyColumns(
+  db: SqliteDatabase,
+  tableName: string,
+): string[] {
+  return allRows<{
+    name: string;
+    pk: number;
+  }>(
+    db,
+    `PRAGMA table_info("${tableName}")`,
+  )
+    .filter((row) => row.pk > 0)
+    .sort((left, right) => left.pk - right.pk)
+    .map((row) => row.name);
+}
+
+function hasUniqueIndexColumns(
+  db: SqliteDatabase,
+  tableName: string,
+  columns: readonly string[],
+): boolean {
+  const indexes = allRows<{
+    name: string;
+    unique: number;
+  }>(
+    db,
+    `PRAGMA index_list("${tableName}")`,
+  );
+  return indexes.some((index) => {
+    if (!index.unique) return false;
+    const actual = indexColumns(db, tableName, index.name);
+    return (
+      actual?.length === columns.length
+      && actual.every((column, position) => column === columns[position])
+    );
+  });
+}
+
+function hasStableRepeatApplicationSchema(
+  db: SqliteDatabase,
+): boolean {
+  const tables = [
+    "application_repeat_overrides",
+    "application_repeat_override_consumptions",
+    "application_repeat_audit",
+  ] as const;
+  if (!tables.every((table) => tableExists(db, table))) return false;
+  const overrides = tableColumnSet(
+    db,
+    "application_repeat_overrides",
+  );
+  const audit = tableColumnSet(db, "application_repeat_audit");
+  const sameColumns = (
+    left: readonly string[],
+    right: readonly string[],
+  ): boolean => (
+    left.length === right.length
+    && left.every((column, index) => column === right[index])
+  );
+  return (
+    overrides.has("target_job_id")
+    && overrides.has("prior_job_id")
+    && !overrides.has("target_job_key")
+    && !overrides.has("prior_job_key")
+    && sameColumns(
+      primaryKeyColumns(db, "application_repeat_overrides"),
+      ["tenant_id", "override_id"],
+    )
+    && hasCompositeJobIdForeignKey(
+      db,
+      "application_repeat_overrides",
+      "target_job_id",
+    )
+    && hasCompositeJobIdForeignKey(
+      db,
+      "application_repeat_overrides",
+      "prior_job_id",
+    )
+    && sameColumns(
+      indexColumns(
+        db,
+        "application_repeat_overrides",
+        "idx_application_repeat_overrides_target",
+      ) ?? [],
+      ["tenant_id", "target_job_id", "confirmed_at"],
+    )
+    && sameColumns(
+      indexColumns(
+        db,
+        "application_repeat_overrides",
+        "idx_application_repeat_overrides_prior",
+      ) ?? [],
+      ["tenant_id", "prior_job_id", "confirmed_at"],
+    )
+    && sameColumns(
+      primaryKeyColumns(
+        db,
+        "application_repeat_override_consumptions",
+      ),
+      ["tenant_id", "override_id"],
+    )
+    && hasUniqueIndexColumns(
+      db,
+      "application_repeat_override_consumptions",
+      ["tenant_id", "run_id"],
+    )
+    && audit.has("target_job_id")
+    && !audit.has("target_job_key")
+    && sameColumns(
+      primaryKeyColumns(db, "application_repeat_audit"),
+      ["tenant_id", "audit_id"],
+    )
+    && hasUniqueIndexColumns(
+      db,
+      "application_repeat_audit",
+      ["tenant_id", "audit_key"],
+    )
+    && hasCompositeJobIdForeignKey(
+      db,
+      "application_repeat_audit",
+      "target_job_id",
+    )
+    && sameColumns(
+      indexColumns(
+        db,
+        "application_repeat_audit",
+        "idx_application_repeat_audit_target",
+      ) ?? [],
+      ["tenant_id", "target_job_id", "occurred_at"],
+    )
+  );
+}
+
+function stableRepeatJobId(
+  db: SqliteDatabase,
+  jobKey: string,
+): string {
+  const jobId = stableJobIdForUrl(
+    db,
+    jobKey,
+    DEFAULT_TENANT,
+  );
+  if (!jobId) {
+    throw new InputError(`No stable Job identity for ${jobKey}.`);
+  }
+  return jobId;
 }
 
 function parseEvidenceSnapshot(value: string): RepeatApplicationMatch[] {

--- a/apps/api/src/write-model.ts
+++ b/apps/api/src/write-model.ts
@@ -852,6 +852,11 @@ function purgeJobRows(db: SqliteDatabase, jobUrl: string): void {
     }
   }
   deleteWhere(db, "job_events", "job_url = ?", [jobUrl]);
+  deleteRepeatApplicationReferences(
+    db,
+    jobId,
+    jobUrl,
+  );
   deleteApplicationFeedbackReferences(
     db,
     jobId,
@@ -1046,6 +1051,179 @@ function deleteApplicationFeedbackReferences(
       ["local", reference],
     );
   }
+}
+
+function deleteRepeatApplicationReferences(
+  db: SqliteDatabase,
+  jobId: string | undefined,
+  jobUrl: string,
+): void {
+  const aliases = repeatApplicationJobAliases(
+    db,
+    jobId,
+    jobUrl,
+  );
+  const overrideIds = new Set<string>();
+  if (tableExists(db, "application_repeat_overrides")) {
+    const columns = tableColumnSet(
+      db,
+      "application_repeat_overrides",
+    );
+    let ownershipPredicate: string;
+    let ownershipParams: SqliteValue[];
+    if (
+      jobId
+      && columns.has("target_job_id")
+      && columns.has("prior_job_id")
+    ) {
+      ownershipPredicate =
+        "target_job_id = ? OR prior_job_id = ?";
+      ownershipParams = [jobId, jobId];
+    } else if (
+      columns.has("target_job_key")
+      && columns.has("prior_job_key")
+    ) {
+      const placeholders = aliases.map(() => "?").join(", ");
+      ownershipPredicate =
+        `target_job_key IN (${placeholders}) `
+        + `OR prior_job_key IN (${placeholders})`;
+      ownershipParams = [...aliases, ...aliases];
+    } else {
+      throw new Error(
+        "application_repeat_overrides has no supported Job identity columns.",
+      );
+    }
+    const aliasPlaceholders = aliases.map(() => "?").join(", ");
+    const predicate =
+      `tenant_id = ? AND ((${ownershipPredicate}) OR `
+      + `${repeatEvidenceReferencePredicate(
+        "application_repeat_overrides",
+        aliasPlaceholders,
+      )})`;
+    const params: SqliteValue[] = [
+      "local",
+      ...ownershipParams,
+      ...aliases,
+    ];
+    for (const row of allRows<{ override_id: string }>(
+      db,
+      `SELECT override_id
+         FROM application_repeat_overrides
+        WHERE ${predicate}`,
+      params,
+    )) {
+      overrideIds.add(row.override_id);
+    }
+  }
+
+  if (tableExists(db, "application_repeat_audit")) {
+    const columns = tableColumnSet(
+      db,
+      "application_repeat_audit",
+    );
+    let targetPredicate: string;
+    let targetParams: SqliteValue[];
+    if (jobId && columns.has("target_job_id")) {
+      targetPredicate = "target_job_id = ?";
+      targetParams = [jobId];
+    } else if (columns.has("target_job_key")) {
+      const placeholders = aliases.map(() => "?").join(", ");
+      targetPredicate = `target_job_key IN (${placeholders})`;
+      targetParams = aliases;
+    } else {
+      throw new Error(
+        "application_repeat_audit has no supported Job identity column.",
+      );
+    }
+    const overrideIdList = [...overrideIds];
+    const overridePredicate = overrideIdList.length
+      ? `OR override_id IN (${overrideIdList.map(() => "?").join(", ")})`
+      : "";
+    const aliasPlaceholders = aliases.map(() => "?").join(", ");
+    db.prepare(
+      `DELETE FROM application_repeat_audit
+        WHERE tenant_id = ?
+          AND (
+            ${targetPredicate}
+            ${overridePredicate}
+            OR ${repeatEvidenceReferencePredicate(
+              "application_repeat_audit",
+              aliasPlaceholders,
+            )}
+          )`,
+    ).run(
+      "local",
+      ...targetParams,
+      ...overrideIdList,
+      ...aliases,
+    );
+  }
+
+  const overrideIdList = [...overrideIds];
+  if (overrideIdList.length) {
+    const placeholders = overrideIdList.map(() => "?").join(", ");
+    deleteWhere(
+      db,
+      "application_repeat_override_consumptions",
+      `tenant_id = ? AND override_id IN (${placeholders})`,
+      ["local", ...overrideIdList],
+    );
+    deleteWhere(
+      db,
+      "application_repeat_overrides",
+      `tenant_id = ? AND override_id IN (${placeholders})`,
+      ["local", ...overrideIdList],
+    );
+  }
+}
+
+function repeatEvidenceReferencePredicate(
+  tableName:
+    | "application_repeat_overrides"
+    | "application_repeat_audit",
+  aliasPlaceholders: string,
+): string {
+  return `EXISTS (
+    SELECT 1
+      FROM json_each(
+        CASE
+          WHEN json_valid(${tableName}.evidence_json)
+          THEN ${tableName}.evidence_json
+          ELSE '[]'
+        END
+      ) AS evidence
+     WHERE json_extract(
+       CASE
+         WHEN evidence.type = 'object'
+         THEN evidence.value
+         ELSE '{}'
+       END,
+       '$.priorApplication.jobKey'
+     ) IN (${aliasPlaceholders})
+  )`;
+}
+
+function repeatApplicationJobAliases(
+  db: SqliteDatabase,
+  jobId: string | undefined,
+  jobUrl: string,
+): string[] {
+  const aliases = new Set([jobUrl]);
+  if (!jobId || !tableExists(db, "job_identity_aliases")) {
+    return [...aliases];
+  }
+  for (const row of allRows<{ alias_value: string }>(
+    db,
+    `SELECT alias_value
+       FROM job_identity_aliases
+      WHERE tenant_id = ?
+        AND job_id = ?
+        AND alias_kind = 'posting_url'`,
+    ["local", jobId],
+  )) {
+    if (row.alias_value) aliases.add(row.alias_value);
+  }
+  return [...aliases];
 }
 
 function deleteJobReferences(

--- a/apps/api/test/repeat-application-v23.test.ts
+++ b/apps/api/test/repeat-application-v23.test.ts
@@ -1,0 +1,499 @@
+import Database from "better-sqlite3";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { hasCompositeJobIdForeignKey, tableColumnSet } from "../src/db.js";
+import {
+  ensureRepeatApplicationTables,
+  evaluateRepeatApplication,
+  recordRepeatApplicationOverride,
+} from "../src/repeat-application.js";
+import { permanentlyDeleteJob } from "../src/write-model.js";
+
+const NOW = "2026-07-30T10:00:00.000Z";
+const UUID_SHAPED_URL = "11111111-1111-4111-8111-111111111111";
+const TARGET_JOB_ID = "22222222-2222-4222-8222-222222222222";
+const PRIOR_JOB_ID = "33333333-3333-4333-8333-333333333333";
+const OTHER_JOB_ID = "44444444-4444-4444-8444-444444444444";
+const DELETE_JOB_ID = "55555555-5555-4555-8555-555555555555";
+const OTHER_PRIOR_JOB_ID = "66666666-6666-4666-8666-666666666666";
+
+let db: Database.Database | undefined;
+
+afterEach(() => {
+  db?.close();
+  db = undefined;
+});
+
+function createDatabase(
+  schemaVersion = 23,
+  foreignKeys = true,
+): Database.Database {
+  const opened = new Database(":memory:");
+  opened.pragma(`foreign_keys = ${foreignKeys ? "ON" : "OFF"}`);
+  opened.exec(`
+    CREATE TABLE jobs (
+      url TEXT PRIMARY KEY,
+      tenant_id TEXT NOT NULL DEFAULT 'local',
+      job_id TEXT NOT NULL,
+      title TEXT,
+      company TEXT,
+      application_url TEXT,
+      applied_at TEXT,
+      apply_status TEXT,
+      discovered_at TEXT,
+      UNIQUE (tenant_id, job_id)
+    );
+    CREATE TABLE job_events (
+      event_id INTEGER PRIMARY KEY AUTOINCREMENT,
+      job_url TEXT,
+      event_type TEXT NOT NULL,
+      occurred_at TEXT NOT NULL
+    );
+    CREATE TABLE job_identity_aliases (
+      tenant_id TEXT NOT NULL,
+      alias_kind TEXT NOT NULL,
+      alias_value TEXT NOT NULL,
+      job_id TEXT NOT NULL,
+      created_at TEXT NOT NULL,
+      retired_at TEXT,
+      PRIMARY KEY (tenant_id, alias_kind, alias_value)
+    );
+    PRAGMA user_version = ${schemaVersion};
+  `);
+  return opened;
+}
+
+function insertJob(input: {
+  url: string;
+  jobId: string;
+  tenantId?: string;
+  title?: string;
+  company?: string;
+}): void {
+  db!
+    .prepare(
+      `INSERT INTO jobs (
+       url, tenant_id, job_id, title, company, application_url, discovered_at
+     ) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    )
+    .run(
+      input.url,
+      input.tenantId ?? "local",
+      input.jobId,
+      input.title ?? "Senior Platform Engineer",
+      input.company ?? "ExampleCo",
+      `${input.url}/apply`,
+      NOW,
+    );
+}
+
+function indexColumns(tableName: string, indexName: string): string[] {
+  const exists = db!
+    .prepare(`PRAGMA index_list("${tableName}")`)
+    .all()
+    .some((row) => (row as { name: string }).name === indexName);
+  if (!exists) return [];
+  return (
+    db!.prepare(`PRAGMA index_info("${indexName}")`).all() as Array<{
+      seqno: number;
+      name: string;
+    }>
+  )
+    .sort((left, right) => left.seqno - right.seqno)
+    .map((row) => row.name);
+}
+
+function hasUniqueIndexColumns(
+  tableName: string,
+  columns: readonly string[],
+): boolean {
+  const indexes = db!
+    .prepare(`PRAGMA index_list("${tableName}")`)
+    .all() as Array<{ name: string; unique: number }>;
+  return indexes.some((index) => {
+    const actual = indexColumns(tableName, index.name);
+    return (
+      Boolean(index.unique) &&
+      actual.length === columns.length &&
+      actual.every((column, position) => column === columns[position])
+    );
+  });
+}
+
+describe("schema-v23 repeat-application references", () => {
+  it.each([
+    [0, "target_job_key", "prior_job_key"],
+    [22, "target_job_key", "prior_job_key"],
+    [23, "target_job_id", "prior_job_id"],
+  ])(
+    "recovers missing tables for schema v%s",
+    (schemaVersion, targetReference, priorReference) => {
+      db = createDatabase(schemaVersion);
+
+      ensureRepeatApplicationTables(db);
+
+      const overrides = tableColumnSet(db, "application_repeat_overrides");
+      const audit = tableColumnSet(db, "application_repeat_audit");
+      expect(overrides.has(targetReference)).toBe(true);
+      expect(overrides.has(priorReference)).toBe(true);
+      expect(audit.has(targetReference)).toBe(true);
+      if (schemaVersion === 23) {
+        expect(
+          hasCompositeJobIdForeignKey(
+            db,
+            "application_repeat_overrides",
+            "target_job_id",
+          ),
+        ).toBe(true);
+        expect(
+          hasCompositeJobIdForeignKey(
+            db,
+            "application_repeat_overrides",
+            "prior_job_id",
+          ),
+        ).toBe(true);
+        expect(
+          hasCompositeJobIdForeignKey(
+            db,
+            "application_repeat_audit",
+            "target_job_id",
+          ),
+        ).toBe(true);
+        expect(
+          indexColumns(
+            "application_repeat_overrides",
+            "idx_application_repeat_overrides_target",
+          ),
+        ).toEqual(["tenant_id", "target_job_id", "confirmed_at"]);
+        expect(
+          indexColumns(
+            "application_repeat_overrides",
+            "idx_application_repeat_overrides_prior",
+          ),
+        ).toEqual(["tenant_id", "prior_job_id", "confirmed_at"]);
+        expect(
+          hasUniqueIndexColumns("application_repeat_override_consumptions", [
+            "tenant_id",
+            "run_id",
+          ]),
+        ).toBe(true);
+        expect(
+          db!
+            .prepare(
+              'PRAGMA foreign_key_list("application_repeat_override_consumptions")',
+            )
+            .all(),
+        ).toEqual([]);
+        expect(
+          (
+            db!
+              .prepare('PRAGMA foreign_key_list("application_repeat_audit")')
+              .all() as Array<{ table: string }>
+          ).map((row) => row.table),
+        ).toEqual(["jobs", "jobs"]);
+      }
+    },
+  );
+
+  it("fails closed when a database is stamped v23 with legacy tables", () => {
+    db = createDatabase(22);
+    ensureRepeatApplicationTables(db);
+    db.pragma("user_version = 23");
+
+    expect(() => ensureRepeatApplicationTables(db!)).toThrow(
+      "Schema v23 requires stable repeat-application references.",
+    );
+  });
+
+  it("stores stable ownership while projecting URL-shaped evidence", () => {
+    db = createDatabase();
+    ensureRepeatApplicationTables(db);
+    const priorUrl = "https://careers.example.test/prior";
+    const collidingOwnerUrl = "https://careers.example.test/uuid-id-owner";
+    insertJob({
+      url: UUID_SHAPED_URL,
+      jobId: TARGET_JOB_ID,
+    });
+    insertJob({
+      url: collidingOwnerUrl,
+      jobId: UUID_SHAPED_URL,
+    });
+    insertJob({
+      url: priorUrl,
+      jobId: PRIOR_JOB_ID,
+    });
+    db.prepare(
+      `INSERT INTO job_events (
+         job_url, event_type, occurred_at
+       ) VALUES (?, 'ApplicationSubmitted', ?)`,
+    ).run(priorUrl, NOW);
+
+    const initial = evaluateRepeatApplication(db, UUID_SHAPED_URL, {
+      evaluatedAt: NOW,
+    });
+    expect(initial.status).toBe("confirmation_required");
+    const response = recordRepeatApplicationOverride(db, UUID_SHAPED_URL, {
+      evidenceFingerprint: initial.evidenceFingerprint!,
+      priorJobKey: priorUrl,
+      reason: "The first application was withdrawn.",
+      confirmedBy: "qa-user",
+    });
+
+    expect(response.assessment).toMatchObject({
+      status: "override_ready",
+      override: {
+        targetJobKey: UUID_SHAPED_URL,
+        priorJobKey: priorUrl,
+      },
+    });
+    expect(
+      db
+        .prepare(
+          `SELECT target_job_id, prior_job_id, evidence_fingerprint,
+                evidence_json
+           FROM application_repeat_overrides`,
+        )
+        .get(),
+    ).toMatchObject({
+      target_job_id: TARGET_JOB_ID,
+      prior_job_id: PRIOR_JOB_ID,
+      evidence_fingerprint: initial.evidenceFingerprint,
+      evidence_json: JSON.stringify(initial.matches),
+    });
+    expect(
+      db
+        .prepare(
+          `SELECT DISTINCT target_job_id
+           FROM application_repeat_audit`,
+        )
+        .all(),
+    ).toEqual([{ target_job_id: TARGET_JOB_ID }]);
+  });
+
+  it("purges the complete repeat graph with foreign keys disabled", () => {
+    db = createDatabase(23, false);
+    ensureRepeatApplicationTables(db);
+    const priorUrl = "https://careers.example.test/prior";
+    const otherUrl = "https://careers.example.test/other";
+    const collidingOwnerUrl = "https://careers.example.test/uuid-id-owner";
+    const postingAlias = "https://legacy.example.test/deleted";
+    insertJob({
+      url: UUID_SHAPED_URL,
+      jobId: DELETE_JOB_ID,
+    });
+    insertJob({
+      url: collidingOwnerUrl,
+      jobId: UUID_SHAPED_URL,
+    });
+    insertJob({
+      url: priorUrl,
+      jobId: PRIOR_JOB_ID,
+    });
+    insertJob({
+      url: otherUrl,
+      jobId: OTHER_JOB_ID,
+    });
+    insertJob({
+      url: "https://blue.example.test/deleted-id-owner",
+      jobId: DELETE_JOB_ID,
+      tenantId: "blue",
+    });
+    insertJob({
+      url: "https://blue.example.test/prior",
+      jobId: OTHER_PRIOR_JOB_ID,
+      tenantId: "blue",
+    });
+    db.prepare(
+      `INSERT INTO job_identity_aliases (
+         tenant_id, alias_kind, alias_value, job_id, created_at
+       ) VALUES ('local', 'posting_url', ?, ?, ?)`,
+    ).run(postingAlias, DELETE_JOB_ID, NOW);
+    const evidenceOnlySnapshot = JSON.stringify([
+      "legacy-scalar-entry",
+      {
+        priorApplication: {
+          jobKey: priorUrl,
+          title: "Selected active role",
+        },
+      },
+      {
+        priorApplication: {
+          jobKey: postingAlias,
+          title: "Deleted private role",
+        },
+      },
+    ]);
+    const overrides = [
+      ["local", "override:target", DELETE_JOB_ID, PRIOR_JOB_ID, "[]"],
+      ["local", "override:prior", OTHER_JOB_ID, DELETE_JOB_ID, "[]"],
+      [
+        "local",
+        "override:evidence",
+        OTHER_JOB_ID,
+        PRIOR_JOB_ID,
+        evidenceOnlySnapshot,
+      ],
+      ["local", "override:collision", UUID_SHAPED_URL, PRIOR_JOB_ID, "[]"],
+      ["local", "override:unrelated", OTHER_JOB_ID, PRIOR_JOB_ID, "[]"],
+      ["blue", "override:blue", DELETE_JOB_ID, OTHER_PRIOR_JOB_ID, "[]"],
+    ] as const;
+    const insertOverride = db.prepare(
+      `INSERT INTO application_repeat_overrides (
+         tenant_id, override_id, target_job_id, prior_job_id,
+         relationship, evidence_fingerprint, evidence_json, reason,
+         confirmed_by, confirmed_at
+       ) VALUES (?, ?, ?, ?, 'canonical_identity', ?, ?, ?, 'qa-user', ?)`,
+    );
+    const insertConsumption = db.prepare(
+      `INSERT INTO application_repeat_override_consumptions (
+         tenant_id, override_id, run_id, consumed_at
+       ) VALUES (?, ?, ?, ?)`,
+    );
+    for (const [
+      tenantId,
+      overrideId,
+      targetJobId,
+      priorJobId,
+      evidenceJson,
+    ] of overrides) {
+      insertOverride.run(
+        tenantId,
+        overrideId,
+        targetJobId,
+        priorJobId,
+        `fingerprint:${overrideId}`,
+        evidenceJson,
+        `reason:${overrideId}`,
+        NOW,
+      );
+      insertConsumption.run(tenantId, overrideId, `run:${overrideId}`, NOW);
+    }
+    const insertAudit = db.prepare(
+      `INSERT INTO application_repeat_audit (
+         tenant_id, audit_id, audit_key, target_job_id, action,
+         evidence_fingerprint, evidence_json, override_id, actor,
+         reason, occurred_at
+       ) VALUES (?, ?, ?, ?, 'override_recorded', ?, ?, ?, 'qa-user', ?, ?)`,
+    );
+    insertAudit.run(
+      "local",
+      "audit:target",
+      "audit-key:target",
+      DELETE_JOB_ID,
+      "fingerprint:target",
+      "[]",
+      "override:target",
+      "target",
+      NOW,
+    );
+    insertAudit.run(
+      "local",
+      "audit:linked",
+      "audit-key:linked",
+      OTHER_JOB_ID,
+      "fingerprint:linked",
+      "[]",
+      "override:prior",
+      "linked",
+      NOW,
+    );
+    insertAudit.run(
+      "local",
+      "audit:evidence",
+      "audit-key:evidence",
+      OTHER_JOB_ID,
+      "fingerprint:evidence",
+      evidenceOnlySnapshot,
+      "override:evidence",
+      "evidence",
+      NOW,
+    );
+    insertAudit.run(
+      "local",
+      "audit:invalid",
+      "audit-key:invalid",
+      OTHER_JOB_ID,
+      "fingerprint:invalid",
+      "{not-json",
+      "override:unrelated",
+      "invalid",
+      NOW,
+    );
+    insertAudit.run(
+      "local",
+      "audit:collision",
+      "audit-key:collision",
+      UUID_SHAPED_URL,
+      "fingerprint:collision",
+      "[]",
+      "override:collision",
+      "collision",
+      NOW,
+    );
+    insertAudit.run(
+      "blue",
+      "audit:blue",
+      "audit-key:blue",
+      DELETE_JOB_ID,
+      "fingerprint:blue",
+      "[]",
+      "override:blue",
+      "blue",
+      NOW,
+    );
+
+    expect(permanentlyDeleteJob(db, UUID_SHAPED_URL)).toMatchObject({
+      ok: true,
+      count: 1,
+      jobKeys: [UUID_SHAPED_URL],
+    });
+
+    expect(
+      db.prepare("SELECT 1 FROM jobs WHERE url = ?").get(UUID_SHAPED_URL),
+    ).toBeUndefined();
+    expect(
+      db
+        .prepare("SELECT job_id FROM jobs WHERE url = ?")
+        .get(collidingOwnerUrl),
+    ).toEqual({ job_id: UUID_SHAPED_URL });
+    expect(
+      db
+        .prepare(
+          `SELECT tenant_id, override_id
+           FROM application_repeat_overrides
+          ORDER BY tenant_id, override_id`,
+        )
+        .all(),
+    ).toEqual([
+      { tenant_id: "blue", override_id: "override:blue" },
+      { tenant_id: "local", override_id: "override:collision" },
+      { tenant_id: "local", override_id: "override:unrelated" },
+    ]);
+    expect(
+      db
+        .prepare(
+          `SELECT tenant_id, override_id
+           FROM application_repeat_override_consumptions
+          ORDER BY tenant_id, override_id`,
+        )
+        .all(),
+    ).toEqual([
+      { tenant_id: "blue", override_id: "override:blue" },
+      { tenant_id: "local", override_id: "override:collision" },
+      { tenant_id: "local", override_id: "override:unrelated" },
+    ]);
+    expect(
+      db
+        .prepare(
+          `SELECT tenant_id, audit_id
+           FROM application_repeat_audit
+          ORDER BY tenant_id, audit_id`,
+        )
+        .all(),
+    ).toEqual([
+      { tenant_id: "blue", audit_id: "audit:blue" },
+      { tenant_id: "local", audit_id: "audit:collision" },
+      { tenant_id: "local", audit_id: "audit:invalid" },
+    ]);
+  });
+});

--- a/apps/api/test/schema-version-guard.test.ts
+++ b/apps/api/test/schema-version-guard.test.ts
@@ -63,7 +63,7 @@ describe("schema version guard at DB open", () => {
   });
 
   it("opens the worker-owned schema-v14 artifact registry", () => {
-    expect(SUPPORTED_SCHEMA_VERSION).toBe(22);
+    expect(SUPPORTED_SCHEMA_VERSION).toBe(23);
     const { dbPath, cleanup } = makeDbWithUserVersion(14);
     try {
       openDatabase(dbPath).close();

--- a/apps/web/e2e/tests/repeat-application.spec.ts
+++ b/apps/web/e2e/tests/repeat-application.spec.ts
@@ -30,10 +30,34 @@ function repeatApplicationTablesExist(db: Database.Database): boolean {
 
 function clearRepeatApplicationState(db: Database.Database): void {
   db.prepare(
-    "DELETE FROM application_repeat_override_consumptions WHERE override_id IN (SELECT override_id FROM application_repeat_overrides WHERE target_job_key = ?)",
+    `DELETE FROM application_repeat_override_consumptions
+      WHERE tenant_id = 'local'
+        AND override_id IN (
+          SELECT override_id
+            FROM application_repeat_overrides
+           WHERE tenant_id = 'local'
+             AND target_job_id = (
+               SELECT job_id FROM jobs
+                WHERE tenant_id = 'local' AND url = ?
+             )
+        )`,
   ).run(TARGET);
-  db.prepare("DELETE FROM application_repeat_audit WHERE target_job_key = ?").run(TARGET);
-  db.prepare("DELETE FROM application_repeat_overrides WHERE target_job_key = ?").run(TARGET);
+  db.prepare(
+    `DELETE FROM application_repeat_audit
+      WHERE tenant_id = 'local'
+        AND target_job_id = (
+          SELECT job_id FROM jobs
+           WHERE tenant_id = 'local' AND url = ?
+        )`,
+  ).run(TARGET);
+  db.prepare(
+    `DELETE FROM application_repeat_overrides
+      WHERE tenant_id = 'local'
+        AND target_job_id = (
+          SELECT job_id FROM jobs
+           WHERE tenant_id = 'local' AND url = ?
+        )`,
+  ).run(TARGET);
 }
 
 function restoreRows(
@@ -94,7 +118,13 @@ test("repeat application block and reasoned override reach only the simulated su
   const originalRepeatOverrides = hasRepeatApplicationTables
     ? (db
         .prepare(
-          "SELECT * FROM application_repeat_overrides WHERE tenant_id = 'local' AND target_job_key = ?",
+          `SELECT *
+             FROM application_repeat_overrides
+            WHERE tenant_id = 'local'
+              AND target_job_id = (
+                SELECT job_id FROM jobs
+                 WHERE tenant_id = 'local' AND url = ?
+              )`,
         )
         .all(TARGET) as Array<Record<string, unknown>>)
     : [];
@@ -103,16 +133,26 @@ test("repeat application block and reasoned override reach only the simulated su
         .prepare(
           `SELECT c.*
              FROM application_repeat_override_consumptions c
-             JOIN application_repeat_overrides o
+            JOIN application_repeat_overrides o
                ON o.tenant_id = c.tenant_id AND o.override_id = c.override_id
-            WHERE o.tenant_id = 'local' AND o.target_job_key = ?`,
+            WHERE o.tenant_id = 'local'
+              AND o.target_job_id = (
+                SELECT job_id FROM jobs
+                 WHERE tenant_id = 'local' AND url = ?
+              )`,
         )
         .all(TARGET) as Array<Record<string, unknown>>)
     : [];
   const originalRepeatAudit = hasRepeatApplicationTables
     ? (db
         .prepare(
-          "SELECT * FROM application_repeat_audit WHERE tenant_id = 'local' AND target_job_key = ?",
+          `SELECT *
+             FROM application_repeat_audit
+            WHERE tenant_id = 'local'
+              AND target_job_id = (
+                SELECT job_id FROM jobs
+                 WHERE tenant_id = 'local' AND url = ?
+              )`,
         )
         .all(TARGET) as Array<Record<string, unknown>>)
     : [];
@@ -294,9 +334,25 @@ print(job["url"])
 
     const override = db
       .prepare(
-        `SELECT override_id, target_job_key, prior_job_key, evidence_fingerprint, reason, confirmed_by, confirmed_at
-           FROM application_repeat_overrides
-          WHERE tenant_id = 'local' AND target_job_key = ?
+        `SELECT overrides.override_id,
+                target_jobs.url AS target_job_key,
+                prior_jobs.url AS prior_job_key,
+                overrides.evidence_fingerprint,
+                overrides.reason,
+                overrides.confirmed_by,
+                overrides.confirmed_at
+           FROM application_repeat_overrides AS overrides
+           JOIN jobs AS target_jobs
+             ON target_jobs.tenant_id = overrides.tenant_id
+            AND target_jobs.job_id = overrides.target_job_id
+           JOIN jobs AS prior_jobs
+             ON prior_jobs.tenant_id = overrides.tenant_id
+            AND prior_jobs.job_id = overrides.prior_job_id
+          WHERE overrides.tenant_id = 'local'
+            AND overrides.target_job_id = (
+              SELECT job_id FROM jobs
+               WHERE tenant_id = 'local' AND url = ?
+            )
           ORDER BY confirmed_at DESC LIMIT 1`,
       )
       .get(TARGET) as Record<string, unknown>;
@@ -311,7 +367,10 @@ print(job["url"])
         `SELECT action, evidence_fingerprint, override_id
            FROM application_repeat_audit
           WHERE tenant_id = 'local'
-            AND target_job_key = ?
+            AND target_job_id = (
+              SELECT job_id FROM jobs
+               WHERE tenant_id = 'local' AND url = ?
+            )
             AND evidence_fingerprint = ?
             AND action IN ('blocked', 'override_recorded', 'override_consumed')
           ORDER BY CASE action

--- a/workers/automation/src/jobctrl/database.py
+++ b/workers/automation/src/jobctrl/database.py
@@ -83,7 +83,10 @@ from jobctrl.config import DB_PATH, DEFAULTS, migrate_legacy_job_tables
 # v22 (application-feedback candidate references): linked email evidence and
 # pending/decided outcome suggestions reference the same tenant-scoped stable
 # Job aggregate while preserving their evidence and decision links.
-SCHEMA_VERSION = 22
+# v23 (repeat-application references): evidence-bound override and audit
+# ownership moves to stable target/prior JobIds without rewriting the immutable
+# URL-shaped evidence snapshot or its fingerprint.
+SCHEMA_VERSION = 23
 
 
 class IncompatibleSchemaVersionError(RuntimeError):
@@ -236,6 +239,7 @@ def _schema_migrations() -> tuple[
         (20, ensure_application_review_references_v20),
         (21, ensure_application_outcome_references_v21),
         (22, ensure_application_feedback_candidate_references_v22),
+        (23, ensure_repeat_application_references_v23),
     )
 
 
@@ -4691,6 +4695,13 @@ def _reassign_discovery_identity_references(
         )
     if _has_application_feedback_candidate_schema_v22(conn):
         _reassign_application_feedback_candidate_references_v22(
+            conn,
+            tenant_id=tenant_id,
+            losing_job_id=losing_job_id,
+            surviving_job_id=surviving_job_id,
+        )
+    if _has_repeat_application_reference_schema_v23(conn):
+        _reassign_repeat_application_references_v23(
             conn,
             tenant_id=tenant_id,
             losing_job_id=losing_job_id,
@@ -13757,6 +13768,624 @@ def _reassign_application_feedback_candidate_references_v22(
             (surviving_job_id, tenant_id, losing_job_id),
         )
     _verify_application_feedback_candidate_references_v22(
+        conn,
+        expected_counts=expected_counts,
+    )
+
+
+_REPEAT_APPLICATION_REFERENCE_SCHEMA_VERSION = 23
+_REPEAT_APPLICATION_REFERENCE_TABLES = (
+    "application_repeat_overrides",
+    "application_repeat_override_consumptions",
+    "application_repeat_audit",
+)
+
+
+def _create_repeat_application_overrides_table_v23(
+    conn: sqlite3.Connection,
+    *,
+    table: str,
+    stable_references: bool,
+) -> None:
+    target_column = (
+        "target_job_id" if stable_references else "target_job_key"
+    )
+    prior_column = (
+        "prior_job_id" if stable_references else "prior_job_key"
+    )
+    foreign_keys = (
+        """,
+            FOREIGN KEY (tenant_id, target_job_id)
+                REFERENCES jobs(tenant_id, job_id) ON DELETE CASCADE,
+            FOREIGN KEY (tenant_id, prior_job_id)
+                REFERENCES jobs(tenant_id, job_id) ON DELETE CASCADE"""
+        if stable_references
+        else ""
+    )
+    conn.execute(
+        f"""
+        CREATE TABLE "{table}" (
+            tenant_id            TEXT NOT NULL DEFAULT 'local',
+            override_id          TEXT NOT NULL,
+            {target_column}      TEXT NOT NULL,
+            {prior_column}       TEXT NOT NULL,
+            relationship         TEXT NOT NULL,
+            evidence_fingerprint TEXT NOT NULL,
+            evidence_json        TEXT NOT NULL,
+            reason               TEXT NOT NULL,
+            confirmed_by         TEXT NOT NULL,
+            confirmed_at         TEXT NOT NULL,
+            PRIMARY KEY (tenant_id, override_id)
+            {foreign_keys}
+        )
+        """
+    )
+
+
+def _create_repeat_application_consumptions_table_v23(
+    conn: sqlite3.Connection,
+    *,
+    table: str,
+) -> None:
+    conn.execute(
+        f"""
+        CREATE TABLE "{table}" (
+            tenant_id   TEXT NOT NULL DEFAULT 'local',
+            override_id TEXT NOT NULL,
+            run_id      TEXT NOT NULL,
+            consumed_at TEXT NOT NULL,
+            PRIMARY KEY (tenant_id, override_id),
+            UNIQUE (tenant_id, run_id)
+        )
+        """
+    )
+
+
+def _create_repeat_application_audit_table_v23(
+    conn: sqlite3.Connection,
+    *,
+    table: str,
+    stable_reference: bool,
+) -> None:
+    target_column = (
+        "target_job_id" if stable_reference else "target_job_key"
+    )
+    foreign_key = (
+        """,
+            FOREIGN KEY (tenant_id, target_job_id)
+                REFERENCES jobs(tenant_id, job_id) ON DELETE CASCADE"""
+        if stable_reference
+        else ""
+    )
+    conn.execute(
+        f"""
+        CREATE TABLE "{table}" (
+            tenant_id            TEXT NOT NULL DEFAULT 'local',
+            audit_id             TEXT NOT NULL,
+            audit_key            TEXT NOT NULL,
+            {target_column}      TEXT NOT NULL,
+            action               TEXT NOT NULL,
+            evidence_fingerprint TEXT NOT NULL,
+            evidence_json        TEXT NOT NULL,
+            override_id          TEXT,
+            actor                TEXT NOT NULL,
+            reason               TEXT,
+            occurred_at          TEXT NOT NULL,
+            PRIMARY KEY (tenant_id, audit_id),
+            UNIQUE (tenant_id, audit_key)
+            {foreign_key}
+        )
+        """
+    )
+
+
+def _create_repeat_application_indexes_v23(
+    conn: sqlite3.Connection,
+    *,
+    target_reference: str,
+    prior_reference: str,
+    audit_reference: str,
+) -> None:
+    indexes = (
+        (
+            "application_repeat_overrides",
+            "idx_application_repeat_overrides_target",
+            ("tenant_id", target_reference, "confirmed_at"),
+            f"""
+            CREATE INDEX idx_application_repeat_overrides_target
+            ON application_repeat_overrides(
+                tenant_id,
+                {target_reference},
+                confirmed_at DESC
+            )
+            """,
+        ),
+        (
+            "application_repeat_overrides",
+            "idx_application_repeat_overrides_prior",
+            ("tenant_id", prior_reference, "confirmed_at"),
+            f"""
+            CREATE INDEX idx_application_repeat_overrides_prior
+            ON application_repeat_overrides(
+                tenant_id,
+                {prior_reference},
+                confirmed_at DESC
+            )
+            """,
+        ),
+        (
+            "application_repeat_audit",
+            "idx_application_repeat_audit_target",
+            ("tenant_id", audit_reference, "occurred_at"),
+            f"""
+            CREATE INDEX idx_application_repeat_audit_target
+            ON application_repeat_audit(
+                tenant_id,
+                {audit_reference},
+                occurred_at DESC
+            )
+            """,
+        ),
+    )
+    for table, name, columns, create_sql in indexes:
+        if _has_index(
+            conn,
+            table,
+            name,
+            columns,
+            unique=False,
+        ):
+            continue
+        conn.execute(f'DROP INDEX IF EXISTS "{name}"')
+        conn.execute(create_sql)
+
+
+def _has_unique_index_columns_v23(
+    conn: sqlite3.Connection,
+    *,
+    table: str,
+    columns: tuple[str, ...],
+) -> bool:
+    for row in conn.execute(
+        f'PRAGMA index_list("{table}")'
+    ).fetchall():
+        if not bool(row[2]):
+            continue
+        name = str(row[1])
+        actual_columns = tuple(
+            str(index_row[2])
+            for index_row in conn.execute(
+                f'PRAGMA index_info("{name}")'
+            ).fetchall()
+        )
+        if actual_columns == columns:
+            return True
+    return False
+
+
+def _has_repeat_application_reference_schema_v23(
+    conn: sqlite3.Connection,
+) -> bool:
+    overrides = "application_repeat_overrides"
+    consumptions = "application_repeat_override_consumptions"
+    audit = "application_repeat_audit"
+    return (
+        "target_job_id" in _table_columns(conn, overrides)
+        and "target_job_key" not in _table_columns(conn, overrides)
+        and "prior_job_id" in _table_columns(conn, overrides)
+        and "prior_job_key" not in _table_columns(conn, overrides)
+        and _primary_key_columns(conn, overrides)
+        == ("tenant_id", "override_id")
+        and _has_composite_job_id_foreign_key(
+            conn,
+            overrides,
+            "target_job_id",
+        )
+        and _has_composite_job_id_foreign_key(
+            conn,
+            overrides,
+            "prior_job_id",
+        )
+        and _has_index(
+            conn,
+            overrides,
+            "idx_application_repeat_overrides_target",
+            ("tenant_id", "target_job_id", "confirmed_at"),
+            unique=False,
+        )
+        and _has_index(
+            conn,
+            overrides,
+            "idx_application_repeat_overrides_prior",
+            ("tenant_id", "prior_job_id", "confirmed_at"),
+            unique=False,
+        )
+        and _primary_key_columns(conn, consumptions)
+        == ("tenant_id", "override_id")
+        and _has_unique_index_columns_v23(
+            conn,
+            table=consumptions,
+            columns=("tenant_id", "run_id"),
+        )
+        and "target_job_id" in _table_columns(conn, audit)
+        and "target_job_key" not in _table_columns(conn, audit)
+        and _primary_key_columns(conn, audit)
+        == ("tenant_id", "audit_id")
+        and _has_unique_index_columns_v23(
+            conn,
+            table=audit,
+            columns=("tenant_id", "audit_key"),
+        )
+        and _has_composite_job_id_foreign_key(
+            conn,
+            audit,
+            "target_job_id",
+        )
+        and _has_index(
+            conn,
+            audit,
+            "idx_application_repeat_audit_target",
+            ("tenant_id", "target_job_id", "occurred_at"),
+            unique=False,
+        )
+    )
+
+
+def _canonical_repeat_application_override_rows_v23(
+    conn: sqlite3.Connection,
+) -> list[tuple[Any, ...]]:
+    target_column = _legacy_or_stable_reference_column(
+        conn,
+        "application_repeat_overrides",
+        stable="target_job_id",
+        legacy="target_job_key",
+    )
+    prior_column = _legacy_or_stable_reference_column(
+        conn,
+        "application_repeat_overrides",
+        stable="prior_job_id",
+        legacy="prior_job_key",
+    )
+    rows = conn.execute(
+        f"""
+        SELECT tenant_id, override_id, {target_column}, {prior_column},
+               relationship, evidence_fingerprint, evidence_json, reason,
+               confirmed_by, confirmed_at
+        FROM application_repeat_overrides
+        ORDER BY tenant_id, override_id
+        """
+    ).fetchall()
+    canonical: list[tuple[Any, ...]] = []
+    for row in rows:
+        tenant_id = str(row[0])
+        target_reference = str(row[2])
+        prior_reference = str(row[3])
+        target_job_id = _resolve_job_reference_value(
+            conn,
+            tenant_id=tenant_id,
+            reference=target_reference,
+            legacy_url=target_column == "target_job_key",
+        )
+        prior_job_id = _resolve_job_reference_value(
+            conn,
+            tenant_id=tenant_id,
+            reference=prior_reference,
+            legacy_url=prior_column == "prior_job_key",
+        )
+        if target_job_id is None:
+            raise RuntimeError(
+                "repeat-application reference migration could not resolve "
+                f"application_repeat_overrides.{target_column}="
+                f"{target_reference!r}"
+            )
+        if prior_job_id is None:
+            raise RuntimeError(
+                "repeat-application reference migration could not resolve "
+                f"application_repeat_overrides.{prior_column}="
+                f"{prior_reference!r}"
+            )
+        _validate_job_uuid(target_job_id)
+        _validate_job_uuid(prior_job_id)
+        canonical.append(
+            (
+                tenant_id,
+                str(row[1]),
+                target_job_id,
+                prior_job_id,
+                *tuple(row[4:]),
+            )
+        )
+    return canonical
+
+
+def _canonical_repeat_application_audit_rows_v23(
+    conn: sqlite3.Connection,
+) -> list[tuple[Any, ...]]:
+    target_column = _legacy_or_stable_reference_column(
+        conn,
+        "application_repeat_audit",
+        stable="target_job_id",
+        legacy="target_job_key",
+    )
+    rows = conn.execute(
+        f"""
+        SELECT tenant_id, audit_id, audit_key, {target_column}, action,
+               evidence_fingerprint, evidence_json, override_id, actor,
+               reason, occurred_at
+        FROM application_repeat_audit
+        ORDER BY tenant_id, audit_id
+        """
+    ).fetchall()
+    canonical: list[tuple[Any, ...]] = []
+    for row in rows:
+        tenant_id = str(row[0])
+        target_reference = str(row[3])
+        target_job_id = _resolve_job_reference_value(
+            conn,
+            tenant_id=tenant_id,
+            reference=target_reference,
+            legacy_url=target_column == "target_job_key",
+        )
+        if target_job_id is None:
+            raise RuntimeError(
+                "repeat-application reference migration could not resolve "
+                f"application_repeat_audit.{target_column}="
+                f"{target_reference!r}"
+            )
+        _validate_job_uuid(target_job_id)
+        canonical.append(
+            (
+                tenant_id,
+                str(row[1]),
+                str(row[2]),
+                target_job_id,
+                *tuple(row[4:]),
+            )
+        )
+    return canonical
+
+
+def ensure_repeat_application_references_v23(
+    conn: sqlite3.Connection | None = None,
+) -> list[str]:
+    """Move repeat-protection ownership to stable target/prior JobIds."""
+    if conn is None:
+        conn = get_connection()
+
+    current = _assert_schema_version_supported(conn)
+    if current >= _REPEAT_APPLICATION_REFERENCE_SCHEMA_VERSION:
+        return []
+    if current != _APPLICATION_FEEDBACK_CANDIDATE_SCHEMA_VERSION:
+        raise RuntimeError(
+            "repeat-application reference migration requires "
+            "application-feedback candidate schema v22"
+        )
+
+    conn.execute("SAVEPOINT repeat_application_references_v23")
+    try:
+        if not _has_application_feedback_candidate_schema_v22(conn):
+            raise RuntimeError(
+                "repeat-application reference migration requires the "
+                "stable application-feedback candidate reference schema"
+            )
+        from jobctrl.domain.apply.repeat_application import (
+            ensure_repeat_application_tables,
+        )
+
+        ensure_repeat_application_tables(conn)
+        expected_counts = {
+            table: int(
+                conn.execute(
+                    f'SELECT COUNT(*) FROM "{table}"'
+                ).fetchone()[0]
+            )
+            for table in _REPEAT_APPLICATION_REFERENCE_TABLES
+        }
+
+        if not {
+            "target_job_id",
+            "prior_job_id",
+        }.issubset(
+            _table_columns(conn, "application_repeat_overrides")
+        ):
+            override_rows = (
+                _canonical_repeat_application_override_rows_v23(conn)
+            )
+            conn.execute(
+                "DROP TABLE IF EXISTS application_repeat_overrides_v23"
+            )
+            _create_repeat_application_overrides_table_v23(
+                conn,
+                table="application_repeat_overrides_v23",
+                stable_references=True,
+            )
+            conn.executemany(
+                """
+                INSERT INTO application_repeat_overrides_v23 (
+                    tenant_id, override_id, target_job_id, prior_job_id,
+                    relationship, evidence_fingerprint, evidence_json,
+                    reason, confirmed_by, confirmed_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                override_rows,
+            )
+            conn.execute('DROP TABLE "application_repeat_overrides"')
+            conn.execute(
+                'ALTER TABLE "application_repeat_overrides_v23" '
+                'RENAME TO "application_repeat_overrides"'
+            )
+
+        if "target_job_id" not in _table_columns(
+            conn,
+            "application_repeat_audit",
+        ):
+            audit_rows = _canonical_repeat_application_audit_rows_v23(
+                conn
+            )
+            conn.execute(
+                "DROP TABLE IF EXISTS application_repeat_audit_v23"
+            )
+            _create_repeat_application_audit_table_v23(
+                conn,
+                table="application_repeat_audit_v23",
+                stable_reference=True,
+            )
+            conn.executemany(
+                """
+                INSERT INTO application_repeat_audit_v23 (
+                    tenant_id, audit_id, audit_key, target_job_id, action,
+                    evidence_fingerprint, evidence_json, override_id, actor,
+                    reason, occurred_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                audit_rows,
+            )
+            conn.execute('DROP TABLE "application_repeat_audit"')
+            conn.execute(
+                'ALTER TABLE "application_repeat_audit_v23" '
+                'RENAME TO "application_repeat_audit"'
+            )
+
+        _create_repeat_application_indexes_v23(
+            conn,
+            target_reference="target_job_id",
+            prior_reference="prior_job_id",
+            audit_reference="target_job_id",
+        )
+        _verify_repeat_application_references_v23(
+            conn,
+            expected_counts=expected_counts,
+        )
+        conn.execute(
+            f"PRAGMA user_version = "
+            f"{_REPEAT_APPLICATION_REFERENCE_SCHEMA_VERSION}"
+        )
+        conn.execute(
+            "RELEASE SAVEPOINT repeat_application_references_v23"
+        )
+        conn.commit()
+    except BaseException:
+        conn.execute(
+            "ROLLBACK TO SAVEPOINT repeat_application_references_v23"
+        )
+        conn.execute(
+            "RELEASE SAVEPOINT repeat_application_references_v23"
+        )
+        raise
+
+    return list(_REPEAT_APPLICATION_REFERENCE_TABLES)
+
+
+def _verify_repeat_application_references_v23(
+    conn: sqlite3.Connection,
+    *,
+    expected_counts: dict[str, int],
+) -> None:
+    if not _has_repeat_application_reference_schema_v23(conn):
+        raise RuntimeError(
+            "repeat-application reference migration did not create the "
+            "stable reference schema"
+        )
+    for table, expected_count in expected_counts.items():
+        observed_count = int(
+            conn.execute(
+                f'SELECT COUNT(*) FROM "{table}"'
+            ).fetchone()[0]
+        )
+        if observed_count != expected_count:
+            raise RuntimeError(
+                "repeat-application reference migration changed "
+                f"{table} history count: expected {expected_count}, "
+                f"found {observed_count}"
+            )
+
+    references = (
+        (
+            "application_repeat_overrides",
+            "target_job_id",
+        ),
+        (
+            "application_repeat_overrides",
+            "prior_job_id",
+        ),
+        (
+            "application_repeat_audit",
+            "target_job_id",
+        ),
+    )
+    for table, column in references:
+        orphan = conn.execute(
+            f"""
+            SELECT source.{column}
+            FROM "{table}" AS source
+            LEFT JOIN jobs
+              ON jobs.tenant_id = source.tenant_id
+             AND jobs.job_id = source.{column}
+            WHERE jobs.job_id IS NULL
+            LIMIT 1
+            """
+        ).fetchone()
+        if orphan is not None:
+            raise RuntimeError(
+                "repeat-application reference migration left an "
+                f"unresolved JobId in {table}.{column}"
+            )
+        for row in conn.execute(
+            f'SELECT DISTINCT {column} FROM "{table}"'
+        ).fetchall():
+            _validate_job_uuid(str(row[0]))
+    foreign_key_error = conn.execute(
+        "PRAGMA foreign_key_check"
+    ).fetchone()
+    if foreign_key_error is not None:
+        raise RuntimeError(
+            "repeat-application reference migration found a foreign-key "
+            "violation"
+        )
+
+
+def _reassign_repeat_application_references_v23(
+    conn: sqlite3.Connection,
+    *,
+    tenant_id: str,
+    losing_job_id: str,
+    surviving_job_id: str,
+) -> None:
+    if losing_job_id == surviving_job_id:
+        return
+    expected_counts = {
+        table: int(
+            conn.execute(
+                f'SELECT COUNT(*) FROM "{table}"'
+            ).fetchone()[0]
+        )
+        for table in _REPEAT_APPLICATION_REFERENCE_TABLES
+    }
+    conn.execute(
+        """
+        UPDATE application_repeat_overrides
+        SET target_job_id = ?
+        WHERE tenant_id = ? AND target_job_id = ?
+        """,
+        (surviving_job_id, tenant_id, losing_job_id),
+    )
+    conn.execute(
+        """
+        UPDATE application_repeat_overrides
+        SET prior_job_id = ?
+        WHERE tenant_id = ? AND prior_job_id = ?
+        """,
+        (surviving_job_id, tenant_id, losing_job_id),
+    )
+    conn.execute(
+        """
+        UPDATE application_repeat_audit
+        SET target_job_id = ?
+        WHERE tenant_id = ? AND target_job_id = ?
+        """,
+        (surviving_job_id, tenant_id, losing_job_id),
+    )
+    _verify_repeat_application_references_v23(
         conn,
         expected_counts=expected_counts,
     )

--- a/workers/automation/src/jobctrl/domain/apply/repeat_application.py
+++ b/workers/automation/src/jobctrl/domain/apply/repeat_application.py
@@ -16,6 +16,7 @@ from datetime import datetime, timezone
 from typing import Any
 
 LOCAL_TENANT = "local"
+REPEAT_APPLICATION_REFERENCE_SCHEMA_VERSION = 23
 
 _RELATIONSHIP_RANK = {
     "canonical_job": 0,
@@ -60,16 +61,42 @@ def ensure_repeat_application_tables(conn) -> list[str]:
         "application_repeat_override_consumptions",
         "application_repeat_audit",
     ]
-    if all(_table_exists(conn, table_name) for table_name in table_names):
-        return table_names
+    schema_version = int(
+        conn.execute("PRAGMA user_version").fetchone()[0]
+    )
+    stable_references = (
+        schema_version >= REPEAT_APPLICATION_REFERENCE_SCHEMA_VERSION
+    )
+    target_column = (
+        "target_job_id" if stable_references else "target_job_key"
+    )
+    prior_column = (
+        "prior_job_id" if stable_references else "prior_job_key"
+    )
+    override_foreign_keys = (
+        """,
+          FOREIGN KEY (tenant_id, target_job_id)
+            REFERENCES jobs(tenant_id, job_id) ON DELETE CASCADE,
+          FOREIGN KEY (tenant_id, prior_job_id)
+            REFERENCES jobs(tenant_id, job_id) ON DELETE CASCADE"""
+        if stable_references
+        else ""
+    )
+    audit_foreign_key = (
+        """,
+          FOREIGN KEY (tenant_id, target_job_id)
+            REFERENCES jobs(tenant_id, job_id) ON DELETE CASCADE"""
+        if stable_references
+        else ""
+    )
     was_in_transaction = conn.in_transaction
     statements = (
-        """
+        f"""
         CREATE TABLE IF NOT EXISTS application_repeat_overrides (
           tenant_id            TEXT NOT NULL DEFAULT 'local',
           override_id          TEXT NOT NULL,
-          target_job_key       TEXT NOT NULL,
-          prior_job_key        TEXT NOT NULL,
+          {target_column}       TEXT NOT NULL,
+          {prior_column}        TEXT NOT NULL,
           relationship         TEXT NOT NULL,
           evidence_fingerprint TEXT NOT NULL,
           evidence_json        TEXT NOT NULL,
@@ -77,11 +104,8 @@ def ensure_repeat_application_tables(conn) -> list[str]:
           confirmed_by         TEXT NOT NULL,
           confirmed_at         TEXT NOT NULL,
           PRIMARY KEY (tenant_id, override_id)
+          {override_foreign_keys}
         )
-        """,
-        """
-        CREATE INDEX IF NOT EXISTS idx_application_repeat_overrides_target
-          ON application_repeat_overrides(tenant_id, target_job_key, confirmed_at DESC)
         """,
         """
         CREATE TABLE IF NOT EXISTS application_repeat_override_consumptions (
@@ -93,12 +117,12 @@ def ensure_repeat_application_tables(conn) -> list[str]:
           UNIQUE (tenant_id, run_id)
         )
         """,
-        """
+        f"""
         CREATE TABLE IF NOT EXISTS application_repeat_audit (
           tenant_id            TEXT NOT NULL DEFAULT 'local',
           audit_id             TEXT NOT NULL,
           audit_key            TEXT NOT NULL,
-          target_job_key       TEXT NOT NULL,
+          {target_column}       TEXT NOT NULL,
           action               TEXT NOT NULL,
           evidence_fingerprint TEXT NOT NULL,
           evidence_json        TEXT NOT NULL,
@@ -108,15 +132,78 @@ def ensure_repeat_application_tables(conn) -> list[str]:
           occurred_at          TEXT NOT NULL,
           PRIMARY KEY (tenant_id, audit_id),
           UNIQUE (tenant_id, audit_key)
+          {audit_foreign_key}
         )
-        """,
-        """
-        CREATE INDEX IF NOT EXISTS idx_application_repeat_audit_target
-          ON application_repeat_audit(tenant_id, target_job_key, occurred_at DESC)
         """,
     )
     for statement in statements:
         conn.execute(statement)
+    override_columns = _table_columns(
+        conn,
+        "application_repeat_overrides",
+    )
+    actual_target_column = (
+        "target_job_id"
+        if "target_job_id" in override_columns
+        else "target_job_key"
+    )
+    actual_prior_column = (
+        "prior_job_id"
+        if "prior_job_id" in override_columns
+        else "prior_job_key"
+    )
+    audit_columns = _table_columns(
+        conn,
+        "application_repeat_audit",
+    )
+    actual_audit_column = (
+        "target_job_id"
+        if "target_job_id" in audit_columns
+        else "target_job_key"
+    )
+    _ensure_index(
+        conn,
+        table="application_repeat_overrides",
+        name="idx_application_repeat_overrides_target",
+        columns=("tenant_id", actual_target_column, "confirmed_at"),
+        sql=f"""
+        CREATE INDEX idx_application_repeat_overrides_target
+        ON application_repeat_overrides(
+          tenant_id, {actual_target_column}, confirmed_at DESC
+        )
+        """,
+    )
+    if actual_prior_column == "prior_job_id":
+        _ensure_index(
+            conn,
+            table="application_repeat_overrides",
+            name="idx_application_repeat_overrides_prior",
+            columns=("tenant_id", actual_prior_column, "confirmed_at"),
+            sql=f"""
+            CREATE INDEX idx_application_repeat_overrides_prior
+            ON application_repeat_overrides(
+              tenant_id, {actual_prior_column}, confirmed_at DESC
+            )
+            """,
+        )
+    _ensure_index(
+        conn,
+        table="application_repeat_audit",
+        name="idx_application_repeat_audit_target",
+        columns=("tenant_id", actual_audit_column, "occurred_at"),
+        sql=f"""
+        CREATE INDEX idx_application_repeat_audit_target
+        ON application_repeat_audit(
+          tenant_id, {actual_audit_column}, occurred_at DESC
+        )
+        """,
+    )
+    if stable_references and not _has_stable_repeat_application_schema(
+        conn
+    ):
+        raise RuntimeError(
+            "schema v23 requires stable repeat-application references"
+        )
     if not was_in_transaction:
         conn.commit()
     return table_names
@@ -572,18 +659,44 @@ def _equivalent_employer_role(target: dict[str, Any], prior: dict[str, Any]) -> 
 
 
 def _matching_override(conn, target_job_key: str, fingerprint: str) -> dict[str, Any] | None:
-    row = conn.execute(
+    stable_references = _has_stable_repeat_application_schema(conn)
+    if stable_references:
+        target_reference = _stable_job_id_for_job_key(
+            conn,
+            target_job_key,
+        )
+        target_expression = "target_jobs.url"
+        prior_expression = "prior_jobs.url"
+        target_column = "target_job_id"
+        identity_joins = """
+          JOIN jobs AS target_jobs
+            ON target_jobs.tenant_id = o.tenant_id
+           AND target_jobs.job_id = o.target_job_id
+          JOIN jobs AS prior_jobs
+            ON prior_jobs.tenant_id = o.tenant_id
+           AND prior_jobs.job_id = o.prior_job_id
         """
-        SELECT o.override_id, o.target_job_key, o.prior_job_key,
+    else:
+        target_reference = target_job_key
+        target_expression = "o.target_job_key"
+        prior_expression = "o.prior_job_key"
+        target_column = "target_job_key"
+        identity_joins = ""
+    row = conn.execute(
+        f"""
+        SELECT o.override_id, {target_expression} AS target_job_key,
+               {prior_expression} AS prior_job_key,
                o.evidence_fingerprint, o.reason, o.confirmed_by, o.confirmed_at,
                c.consumed_at, c.run_id AS consumed_run_id
           FROM application_repeat_overrides o
+          {identity_joins}
           LEFT JOIN application_repeat_override_consumptions c
             ON c.tenant_id = o.tenant_id AND c.override_id = o.override_id
-         WHERE o.tenant_id = ? AND o.target_job_key = ? AND o.evidence_fingerprint = ?
+         WHERE o.tenant_id = ? AND o.{target_column} = ?
+           AND o.evidence_fingerprint = ?
          ORDER BY o.confirmed_at DESC, o.override_id DESC LIMIT 1
         """,
-        (LOCAL_TENANT, target_job_key, fingerprint),
+        (LOCAL_TENANT, target_reference, fingerprint),
     ).fetchone()
     if row is None:
         return None
@@ -613,10 +726,19 @@ def _insert_audit(
     reason: str | None,
     occurred_at: str,
 ) -> None:
+    stable_references = _has_stable_repeat_application_schema(conn)
+    target_column = (
+        "target_job_id" if stable_references else "target_job_key"
+    )
+    target_reference = (
+        _stable_job_id_for_job_key(conn, target_job_key)
+        if stable_references
+        else target_job_key
+    )
     conn.execute(
-        """
+        f"""
         INSERT OR IGNORE INTO application_repeat_audit (
-          tenant_id, audit_id, audit_key, target_job_key, action,
+          tenant_id, audit_id, audit_key, {target_column}, action,
           evidence_fingerprint, evidence_json, override_id, actor, reason, occurred_at
         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """,
@@ -624,7 +746,7 @@ def _insert_audit(
             LOCAL_TENANT,
             str(uuid.uuid4()),
             audit_key,
-            target_job_key,
+            target_reference,
             action,
             evidence_fingerprint,
             evidence_json,
@@ -637,18 +759,43 @@ def _insert_audit(
 
 
 def _audit_trail(conn, target_job_key: str) -> list[dict[str, Any]]:
-    rows = conn.execute(
+    stable_references = _has_stable_repeat_application_schema(conn)
+    if stable_references:
+        target_reference = _stable_job_id_for_job_key(
+            conn,
+            target_job_key,
+        )
+        target_expression = "target_jobs.url"
+        prior_expression = "prior_jobs.url"
+        target_column = "target_job_id"
+        identity_joins = """
+          JOIN jobs AS target_jobs
+            ON target_jobs.tenant_id = a.tenant_id
+           AND target_jobs.job_id = a.target_job_id
+          LEFT JOIN jobs AS prior_jobs
+            ON prior_jobs.tenant_id = o.tenant_id
+           AND prior_jobs.job_id = o.prior_job_id
         """
-        SELECT a.audit_id, a.target_job_key, a.action, a.evidence_fingerprint,
-               a.evidence_json, a.override_id, o.prior_job_key,
+    else:
+        target_reference = target_job_key
+        target_expression = "a.target_job_key"
+        prior_expression = "o.prior_job_key"
+        target_column = "target_job_key"
+        identity_joins = ""
+    rows = conn.execute(
+        f"""
+        SELECT a.audit_id, {target_expression} AS target_job_key, a.action,
+               a.evidence_fingerprint, a.evidence_json, a.override_id,
+               {prior_expression} AS prior_job_key,
                a.actor, a.reason, a.occurred_at
           FROM application_repeat_audit a
           LEFT JOIN application_repeat_overrides o
             ON o.tenant_id = a.tenant_id AND o.override_id = a.override_id
-         WHERE a.tenant_id = ? AND a.target_job_key = ?
+          {identity_joins}
+         WHERE a.tenant_id = ? AND a.{target_column} = ?
          ORDER BY a.occurred_at DESC, a.rowid DESC LIMIT 50
         """,
-        (LOCAL_TENANT, target_job_key),
+        (LOCAL_TENANT, target_reference),
     ).fetchall()
     return [
         {
@@ -692,6 +839,204 @@ def _table_columns(conn, table_name: str) -> set[str]:
             f'PRAGMA table_info("{table_name}")'
         ).fetchall()
     }
+
+
+def _primary_key_columns(conn, table_name: str) -> tuple[str, ...]:
+    keyed = [
+        (int(row[5]), str(row[1]))
+        for row in conn.execute(
+            f'PRAGMA table_info("{table_name}")'
+        ).fetchall()
+        if int(row[5]) > 0
+    ]
+    return tuple(column for _position, column in sorted(keyed))
+
+
+def _index_columns(
+    conn,
+    table_name: str,
+    index_name: str,
+) -> tuple[str, ...] | None:
+    for row in conn.execute(
+        f'PRAGMA index_list("{table_name}")'
+    ).fetchall():
+        if str(row[1]) != index_name:
+            continue
+        return tuple(
+            str(index_row[2])
+            for index_row in conn.execute(
+                f'PRAGMA index_info("{index_name}")'
+            ).fetchall()
+        )
+    return None
+
+
+def _ensure_index(
+    conn,
+    *,
+    table: str,
+    name: str,
+    columns: tuple[str, ...],
+    sql: str,
+) -> None:
+    if _index_columns(conn, table, name) == columns:
+        return
+    conn.execute(f'DROP INDEX IF EXISTS "{name}"')
+    conn.execute(sql)
+
+
+def _has_unique_index_columns(
+    conn,
+    *,
+    table: str,
+    columns: tuple[str, ...],
+) -> bool:
+    for row in conn.execute(
+        f'PRAGMA index_list("{table}")'
+    ).fetchall():
+        if not bool(row[2]):
+            continue
+        name = str(row[1])
+        if _index_columns(conn, table, name) == columns:
+            return True
+    return False
+
+
+def _has_composite_job_reference_fk(
+    conn,
+    table: str,
+    reference_column: str,
+) -> bool:
+    groups: dict[int, set[tuple[str, str]]] = {}
+    cascades: dict[int, bool] = {}
+    for row in conn.execute(
+        f'PRAGMA foreign_key_list("{table}")'
+    ).fetchall():
+        if str(row[2]) != "jobs":
+            continue
+        foreign_key_id = int(row[0])
+        groups.setdefault(foreign_key_id, set()).add(
+            (str(row[3]), str(row[4]))
+        )
+        cascades[foreign_key_id] = str(row[6]).upper() == "CASCADE"
+    expected = {
+        ("tenant_id", "tenant_id"),
+        (reference_column, "job_id"),
+    }
+    return any(
+        columns == expected and cascades.get(foreign_key_id, False)
+        for foreign_key_id, columns in groups.items()
+    )
+
+
+def _has_stable_repeat_application_schema(conn) -> bool:
+    tables = (
+        "application_repeat_overrides",
+        "application_repeat_override_consumptions",
+        "application_repeat_audit",
+    )
+    if not all(_table_exists(conn, table) for table in tables):
+        return False
+    overrides = _table_columns(
+        conn,
+        "application_repeat_overrides",
+    )
+    audit = _table_columns(conn, "application_repeat_audit")
+    return (
+        {"target_job_id", "prior_job_id"}.issubset(overrides)
+        and "target_job_key" not in overrides
+        and "prior_job_key" not in overrides
+        and _primary_key_columns(
+            conn,
+            "application_repeat_overrides",
+        )
+        == ("tenant_id", "override_id")
+        and _has_composite_job_reference_fk(
+            conn,
+            "application_repeat_overrides",
+            "target_job_id",
+        )
+        and _has_composite_job_reference_fk(
+            conn,
+            "application_repeat_overrides",
+            "prior_job_id",
+        )
+        and _index_columns(
+            conn,
+            "application_repeat_overrides",
+            "idx_application_repeat_overrides_target",
+        )
+        == ("tenant_id", "target_job_id", "confirmed_at")
+        and _index_columns(
+            conn,
+            "application_repeat_overrides",
+            "idx_application_repeat_overrides_prior",
+        )
+        == ("tenant_id", "prior_job_id", "confirmed_at")
+        and _primary_key_columns(
+            conn,
+            "application_repeat_override_consumptions",
+        )
+        == ("tenant_id", "override_id")
+        and _has_unique_index_columns(
+            conn,
+            table="application_repeat_override_consumptions",
+            columns=("tenant_id", "run_id"),
+        )
+        and "target_job_id" in audit
+        and "target_job_key" not in audit
+        and _primary_key_columns(
+            conn,
+            "application_repeat_audit",
+        )
+        == ("tenant_id", "audit_id")
+        and _has_unique_index_columns(
+            conn,
+            table="application_repeat_audit",
+            columns=("tenant_id", "audit_key"),
+        )
+        and _has_composite_job_reference_fk(
+            conn,
+            "application_repeat_audit",
+            "target_job_id",
+        )
+        and _index_columns(
+            conn,
+            "application_repeat_audit",
+            "idx_application_repeat_audit_target",
+        )
+        == ("tenant_id", "target_job_id", "occurred_at")
+    )
+
+
+def _stable_job_id_for_job_key(conn, job_key: str) -> str:
+    row = conn.execute(
+        """
+        SELECT job_id
+        FROM jobs
+        WHERE tenant_id = ? AND url = ?
+        LIMIT 1
+        """,
+        (LOCAL_TENANT, job_key),
+    ).fetchone()
+    if row is None and _table_exists(conn, "job_identity_aliases"):
+        row = conn.execute(
+            """
+            SELECT aliases.job_id
+            FROM job_identity_aliases AS aliases
+            JOIN jobs
+              ON jobs.tenant_id = aliases.tenant_id
+             AND jobs.job_id = aliases.job_id
+            WHERE aliases.tenant_id = ?
+              AND aliases.alias_kind = 'posting_url'
+              AND aliases.alias_value = ?
+            LIMIT 1
+            """,
+            (LOCAL_TENANT, job_key),
+        ).fetchone()
+    if row is None:
+        raise ValueError(f"job not found: {job_key}")
+    return str(row[0])
 
 
 def _compact_json(value: Any) -> str:

--- a/workers/automation/tests/test_application_feedback_candidate_identity_reference_migration.py
+++ b/workers/automation/tests/test_application_feedback_candidate_identity_reference_migration.py
@@ -331,7 +331,7 @@ def test_v21_candidates_migrate_every_alias_uuid_url_and_tenant(
     assert (
         reopened.execute("PRAGMA user_version").fetchone()[0]
         == SCHEMA_VERSION
-        == 22
+        == 23
     )
     for table in database_module._APPLICATION_FEEDBACK_CANDIDATE_TABLES:
         assert "job_id" in _columns(reopened, table)

--- a/workers/automation/tests/test_application_outcome_identity_reference_migration.py
+++ b/workers/automation/tests/test_application_outcome_identity_reference_migration.py
@@ -243,7 +243,7 @@ def test_v20_outcomes_migrate_every_alias_uuid_url_and_tenant(
     assert (
         reopened.execute("PRAGMA user_version").fetchone()[0]
         == SCHEMA_VERSION
-        == 22
+        == 23
     )
     assert "job_id" in _columns(reopened, "application_outcomes")
     assert "job_key" not in _columns(reopened, "application_outcomes")

--- a/workers/automation/tests/test_application_review_identity_reference_migration.py
+++ b/workers/automation/tests/test_application_review_identity_reference_migration.py
@@ -204,7 +204,7 @@ def test_v19_review_decisions_migrate_every_alias_and_uuid_url(
     assert (
         reopened.execute("PRAGMA user_version").fetchone()[0]
         == SCHEMA_VERSION
-        == 22
+        == 23
     )
     assert "job_id" in _columns(
         reopened,

--- a/workers/automation/tests/test_compensation_identity_reference_migration.py
+++ b/workers/automation/tests/test_compensation_identity_reference_migration.py
@@ -210,7 +210,7 @@ def test_v18_compensation_migrates_alias_winners_and_uuid_urls(
     assert (
         reopened.execute("PRAGMA user_version").fetchone()[0]
         == SCHEMA_VERSION
-        == 22
+        == 23
     )
     for table in database_module._COMPENSATION_REFERENCE_TABLES:
         assert "job_id" in _columns(reopened, table)

--- a/workers/automation/tests/test_discovery_identity_reference_migration.py
+++ b/workers/automation/tests/test_discovery_identity_reference_migration.py
@@ -220,7 +220,7 @@ def test_v7_discovery_references_migrate_to_stable_job_id_and_reopen(
     init_db(db_path)
     close_connection(db_path)
 
-    assert _user_version(db_path) == SCHEMA_VERSION == 22
+    assert _user_version(db_path) == SCHEMA_VERSION == 23
     assert "job_id" in _columns(db_path, "job_source_observations")
     assert "job_url" not in _columns(db_path, "job_source_observations")
     assert "job_id" in _columns(db_path, "job_canonical_identities")

--- a/workers/automation/tests/test_employer_analysis_identity_reference_migration.py
+++ b/workers/automation/tests/test_employer_analysis_identity_reference_migration.py
@@ -242,7 +242,7 @@ def test_v15_employer_analysis_migrates_alias_histories_and_uuid_urls(
     assert (
         reopened.execute("PRAGMA user_version").fetchone()[0]
         == SCHEMA_VERSION
-        == 22
+        == 23
     )
     for table in database_module._EMPLOYER_ANALYSIS_REFERENCE_TABLES:
         assert "job_id" in _columns(reopened, table)

--- a/workers/automation/tests/test_enrichment_snapshot_identity_reference_migration.py
+++ b/workers/automation/tests/test_enrichment_snapshot_identity_reference_migration.py
@@ -322,7 +322,7 @@ def test_v10_enrichment_snapshot_references_migrate_and_reopen(
     init_db(db_path)
     close_connection(db_path)
 
-    assert _user_version(db_path) == SCHEMA_VERSION == 22
+    assert _user_version(db_path) == SCHEMA_VERSION == 23
     check = sqlite3.connect(db_path)
     try:
         enrichment_rows = check.execute(

--- a/workers/automation/tests/test_execution_search_identity_reference_migration.py
+++ b/workers/automation/tests/test_execution_search_identity_reference_migration.py
@@ -261,7 +261,7 @@ def test_v8_execution_and_receipts_migrate_to_stable_job_id_and_reopen(
     init_db(db_path)
     close_connection(db_path)
 
-    assert _user_version(db_path) == SCHEMA_VERSION == 22
+    assert _user_version(db_path) == SCHEMA_VERSION == 23
     assert "job_id" in _columns(db_path, "discovery_execution_jobs")
     assert "job_url" not in _columns(db_path, "discovery_execution_jobs")
     assert "job_id" in _columns(db_path, "discovery_search_unit_jobs")

--- a/workers/automation/tests/test_interview_prep_identity_reference_migration.py
+++ b/workers/automation/tests/test_interview_prep_identity_reference_migration.py
@@ -323,7 +323,7 @@ def test_v17_interview_prep_migrates_alias_histories_and_uuid_urls(
     assert (
         reopened.execute("PRAGMA user_version").fetchone()[0]
         == SCHEMA_VERSION
-        == 22
+        == 23
     )
     for table in database_module._INTERVIEW_PREP_REFERENCE_TABLES:
         assert "job_id" in _columns(reopened, table)

--- a/workers/automation/tests/test_materials_identity_reference_migration.py
+++ b/workers/automation/tests/test_materials_identity_reference_migration.py
@@ -293,7 +293,7 @@ def test_v14_materials_migrate_alias_histories_and_uuid_shaped_urls(
     close_connection(db_path)
 
     reopened = init_db(db_path)
-    assert reopened.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_VERSION == 22
+    assert reopened.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_VERSION == 23
     for table in database_module._MATERIALS_REFERENCE_TABLES:
         assert "job_id" in _columns(reopened, table)
         assert "job_url" not in _columns(reopened, table)

--- a/workers/automation/tests/test_preparation_identity_reference_migration.py
+++ b/workers/automation/tests/test_preparation_identity_reference_migration.py
@@ -177,7 +177,7 @@ def test_v9_preparation_references_migrate_to_stable_job_ids_and_reopen(
     init_db(db_path)
     close_connection(db_path)
 
-    assert _user_version(db_path) == SCHEMA_VERSION == 22
+    assert _user_version(db_path) == SCHEMA_VERSION == 23
     check = sqlite3.connect(db_path)
     try:
         rows = check.execute(

--- a/workers/automation/tests/test_repeat_application_identity_reference_migration.py
+++ b/workers/automation/tests/test_repeat_application_identity_reference_migration.py
@@ -1,0 +1,788 @@
+"""Schema-v23 repeat-application stable JobId reference contracts."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import jobctrl.database as database_module
+from jobctrl.database import (
+    SCHEMA_VERSION,
+    close_connection,
+    ensure_repeat_application_references_v23,
+    init_db,
+    reassign_discovery_identity_references,
+)
+from jobctrl.domain.apply.repeat_application import (
+    ensure_repeat_application_tables,
+    evaluate_repeat_application,
+)
+from jobctrl.state import record_job_event
+
+
+PREVIOUS_SCHEMA_VERSION = 22
+NOW = "2026-07-30T10:00:00+00:00"
+UUID_SHAPED_URL = "11111111-1111-4111-8111-111111111111"
+TARGET_JOB_ID = "22222222-2222-4222-8222-222222222222"
+COLLIDING_JOB_ID = UUID_SHAPED_URL
+PRIOR_JOB_ID = "33333333-3333-4333-8333-333333333333"
+SURVIVOR_JOB_ID = "44444444-4444-4444-8444-444444444444"
+OTHER_JOB_ID = "55555555-5555-4555-8555-555555555555"
+OTHER_PRIOR_JOB_ID = "66666666-6666-4666-8666-666666666666"
+
+
+def _columns(
+    conn: sqlite3.Connection,
+    table_name: str,
+) -> set[str]:
+    return {
+        str(row[1])
+        for row in conn.execute(
+            f'PRAGMA table_info("{table_name}")'
+        ).fetchall()
+    }
+
+
+def _insert_job(
+    conn: sqlite3.Connection,
+    *,
+    url: str,
+    job_id: str,
+    tenant_id: str = "local",
+    title: str = "Senior Platform Engineer",
+    company: str = "ExampleCo",
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO jobs (
+            url, tenant_id, job_id, title, company, site, description,
+            discovered_at
+        ) VALUES (?, ?, ?, ?, ?, 'test', 'Build reliable systems.', ?)
+        """,
+        (url, tenant_id, job_id, title, company, NOW),
+    )
+
+
+def _downgrade_repeat_tables_to_v22(
+    conn: sqlite3.Connection,
+) -> None:
+    conn.commit()
+    conn.execute("PRAGMA foreign_keys = OFF")
+    conn.executescript(
+        """
+        DROP TABLE application_repeat_audit;
+        DROP TABLE application_repeat_override_consumptions;
+        DROP TABLE application_repeat_overrides;
+        """
+    )
+    database_module._create_repeat_application_overrides_table_v23(
+        conn,
+        table="application_repeat_overrides",
+        stable_references=False,
+    )
+    database_module._create_repeat_application_consumptions_table_v23(
+        conn,
+        table="application_repeat_override_consumptions",
+    )
+    database_module._create_repeat_application_audit_table_v23(
+        conn,
+        table="application_repeat_audit",
+        stable_reference=False,
+    )
+    database_module._create_repeat_application_indexes_v23(
+        conn,
+        target_reference="target_job_key",
+        prior_reference="prior_job_key",
+        audit_reference="target_job_key",
+    )
+    conn.execute(
+        f"PRAGMA user_version = {PREVIOUS_SCHEMA_VERSION}"
+    )
+    conn.commit()
+    conn.execute("PRAGMA foreign_keys = ON")
+
+
+def _insert_legacy_override(
+    conn: sqlite3.Connection,
+    *,
+    tenant_id: str,
+    override_id: str,
+    target_job_key: str,
+    prior_job_key: str,
+    fingerprint: str,
+    evidence_json: str,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO application_repeat_overrides (
+            tenant_id, override_id, target_job_key, prior_job_key,
+            relationship, evidence_fingerprint, evidence_json, reason,
+            confirmed_by, confirmed_at
+        ) VALUES (?, ?, ?, ?, 'canonical_identity', ?, ?, ?, ?, ?)
+        """,
+        (
+            tenant_id,
+            override_id,
+            target_job_key,
+            prior_job_key,
+            fingerprint,
+            evidence_json,
+            f"reason:{override_id}",
+            f"actor:{override_id}",
+            NOW,
+        ),
+    )
+
+
+def _insert_legacy_audit(
+    conn: sqlite3.Connection,
+    *,
+    tenant_id: str,
+    audit_id: str,
+    target_job_key: str,
+    fingerprint: str,
+    evidence_json: str,
+    override_id: str | None,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO application_repeat_audit (
+            tenant_id, audit_id, audit_key, target_job_key, action,
+            evidence_fingerprint, evidence_json, override_id, actor,
+            reason, occurred_at
+        ) VALUES (?, ?, ?, ?, 'override_recorded', ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            tenant_id,
+            audit_id,
+            f"audit-key:{audit_id}",
+            target_job_key,
+            fingerprint,
+            evidence_json,
+            override_id,
+            f"actor:{audit_id}",
+            f"reason:{audit_id}",
+            NOW,
+        ),
+    )
+
+
+def _legacy_snapshot(
+    conn: sqlite3.Connection,
+) -> dict[str, list[tuple[Any, ...]]]:
+    return {
+        table: [
+            tuple(row)
+            for row in conn.execute(
+                f'SELECT * FROM "{table}" ORDER BY tenant_id, rowid'
+            ).fetchall()
+        ]
+        for table in database_module._REPEAT_APPLICATION_REFERENCE_TABLES
+    }
+
+
+def _seed_v22_database(db_path: Path) -> sqlite3.Connection:
+    conn = init_db(db_path)
+    _downgrade_repeat_tables_to_v22(conn)
+    return conn
+
+
+def test_v22_history_migrates_exactly_with_url_first_resolution(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "jobs.db"
+    conn = _seed_v22_database(db_path)
+    prior_url = "https://careers.example.test/prior-current"
+    prior_alias = "https://legacy.example.test/prior"
+    colliding_owner_url = "https://careers.example.test/uuid-id-owner"
+    blue_target_url = "https://blue.example.test/target"
+    blue_prior_url = "https://blue.example.test/prior"
+    _insert_job(
+        conn,
+        url=UUID_SHAPED_URL,
+        job_id=TARGET_JOB_ID,
+    )
+    _insert_job(
+        conn,
+        url=colliding_owner_url,
+        job_id=COLLIDING_JOB_ID,
+    )
+    _insert_job(
+        conn,
+        url=prior_url,
+        job_id=PRIOR_JOB_ID,
+    )
+    _insert_job(
+        conn,
+        url=blue_target_url,
+        job_id=TARGET_JOB_ID,
+        tenant_id="blue",
+    )
+    _insert_job(
+        conn,
+        url=blue_prior_url,
+        job_id=PRIOR_JOB_ID,
+        tenant_id="blue",
+    )
+    conn.execute(
+        """
+        INSERT INTO job_identity_aliases (
+            tenant_id, alias_kind, alias_value, job_id, created_at
+        ) VALUES ('local', 'posting_url', ?, ?, ?)
+        """,
+        (prior_alias, PRIOR_JOB_ID, NOW),
+    )
+    local_evidence = (
+        '[ { "priorApplication": { "jobKey": '
+        f'"{prior_alias}" }}, "private:verbatim" ]'
+    )
+    blue_evidence = (
+        '[{"priorApplication":{"jobKey":'
+        f'"{blue_prior_url}"}}}}]'
+    )
+    _insert_legacy_override(
+        conn,
+        tenant_id="local",
+        override_id="override:local",
+        target_job_key=UUID_SHAPED_URL,
+        prior_job_key=prior_alias,
+        fingerprint="fingerprint:local",
+        evidence_json=local_evidence,
+    )
+    _insert_legacy_override(
+        conn,
+        tenant_id="blue",
+        override_id="override:blue",
+        target_job_key=blue_target_url,
+        prior_job_key=blue_prior_url,
+        fingerprint="fingerprint:blue",
+        evidence_json=blue_evidence,
+    )
+    conn.executemany(
+        """
+        INSERT INTO application_repeat_override_consumptions (
+            tenant_id, override_id, run_id, consumed_at
+        ) VALUES (?, ?, ?, ?)
+        """,
+        (
+            ("local", "override:local", "run:local", NOW),
+            ("blue", "override:blue", "run:blue", NOW),
+            (
+                "local",
+                "override:historical-orphan",
+                "run:historical-orphan",
+                NOW,
+            ),
+        ),
+    )
+    _insert_legacy_audit(
+        conn,
+        tenant_id="local",
+        audit_id="audit:local",
+        target_job_key=UUID_SHAPED_URL,
+        fingerprint="fingerprint:local",
+        evidence_json=local_evidence,
+        override_id="override:local",
+    )
+    _insert_legacy_audit(
+        conn,
+        tenant_id="blue",
+        audit_id="audit:blue",
+        target_job_key=blue_target_url,
+        fingerprint="fingerprint:blue",
+        evidence_json=blue_evidence,
+        override_id="override:blue",
+    )
+    conn.commit()
+    before_consumptions = [
+        tuple(row)
+        for row in conn.execute(
+            """
+            SELECT tenant_id, override_id, run_id, consumed_at
+            FROM application_repeat_override_consumptions
+            ORDER BY tenant_id
+            """
+        ).fetchall()
+    ]
+
+    assert ensure_repeat_application_references_v23(conn) == list(
+        database_module._REPEAT_APPLICATION_REFERENCE_TABLES
+    )
+
+    assert conn.execute("PRAGMA user_version").fetchone()[0] == 23
+    assert database_module._has_repeat_application_reference_schema_v23(
+        conn
+    )
+    assert conn.execute("PRAGMA foreign_key_check").fetchone() is None
+    assert conn.execute(
+        """
+        PRAGMA foreign_key_list(
+            "application_repeat_override_consumptions"
+        )
+        """
+    ).fetchall() == []
+    assert {
+        str(row[2])
+        for row in conn.execute(
+            'PRAGMA foreign_key_list("application_repeat_audit")'
+        ).fetchall()
+    } == {"jobs"}
+    migrated = [
+        tuple(row)
+        for row in conn.execute(
+            """
+            SELECT tenant_id, override_id, target_job_id, prior_job_id,
+                   evidence_fingerprint, evidence_json
+            FROM application_repeat_overrides
+            ORDER BY tenant_id
+            """
+        ).fetchall()
+    ]
+    assert migrated == [
+        (
+            "blue",
+            "override:blue",
+            TARGET_JOB_ID,
+            PRIOR_JOB_ID,
+            "fingerprint:blue",
+            blue_evidence,
+        ),
+        (
+            "local",
+            "override:local",
+            TARGET_JOB_ID,
+            PRIOR_JOB_ID,
+            "fingerprint:local",
+            local_evidence,
+        ),
+    ]
+    assert [
+        tuple(row)
+        for row in conn.execute(
+            """
+            SELECT tenant_id, override_id, run_id, consumed_at
+            FROM application_repeat_override_consumptions
+            ORDER BY tenant_id
+            """
+        ).fetchall()
+    ] == before_consumptions
+    assert [
+        tuple(row)
+        for row in conn.execute(
+            """
+            SELECT tenant_id, audit_id, target_job_id,
+                   evidence_fingerprint, evidence_json, override_id
+            FROM application_repeat_audit
+            ORDER BY tenant_id
+            """
+        ).fetchall()
+    ] == [
+        (
+            "blue",
+            "audit:blue",
+            TARGET_JOB_ID,
+            "fingerprint:blue",
+            blue_evidence,
+            "override:blue",
+        ),
+        (
+            "local",
+            "audit:local",
+            TARGET_JOB_ID,
+            "fingerprint:local",
+            local_evidence,
+            "override:local",
+        ),
+    ]
+    close_connection(db_path)
+    reopened = init_db(db_path)
+    assert reopened.execute("PRAGMA user_version").fetchone()[0] == (
+        SCHEMA_VERSION
+    ) == 23
+    assert database_module._has_repeat_application_reference_schema_v23(
+        reopened
+    )
+
+
+def test_verification_failure_rolls_back_and_retry_succeeds_with_fks_on(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "jobs.db"
+    conn = _seed_v22_database(db_path)
+    target_url = "https://careers.example.test/target"
+    prior_url = "https://careers.example.test/prior"
+    _insert_job(conn, url=target_url, job_id=TARGET_JOB_ID)
+    _insert_job(conn, url=prior_url, job_id=PRIOR_JOB_ID)
+    evidence_json = '[{"private":"exact"}]'
+    _insert_legacy_override(
+        conn,
+        tenant_id="local",
+        override_id="override:retry",
+        target_job_key=target_url,
+        prior_job_key=prior_url,
+        fingerprint="fingerprint:retry",
+        evidence_json=evidence_json,
+    )
+    _insert_legacy_audit(
+        conn,
+        tenant_id="local",
+        audit_id="audit:retry",
+        target_job_key=target_url,
+        fingerprint="fingerprint:retry",
+        evidence_json=evidence_json,
+        override_id="override:retry",
+    )
+    conn.execute(
+        """
+        INSERT INTO application_repeat_override_consumptions
+        VALUES ('local', 'override:retry', 'run:retry', ?)
+        """,
+        (NOW,),
+    )
+    conn.commit()
+    before = _legacy_snapshot(conn)
+    original_verify = (
+        database_module._verify_repeat_application_references_v23
+    )
+
+    def _fail_verification(
+        _conn: sqlite3.Connection,
+        *,
+        expected_counts: dict[str, int],
+    ) -> None:
+        del expected_counts
+        raise RuntimeError("injected repeat verification failure")
+
+    monkeypatch.setattr(
+        database_module,
+        "_verify_repeat_application_references_v23",
+        _fail_verification,
+    )
+    with pytest.raises(
+        RuntimeError,
+        match="injected repeat verification failure",
+    ):
+        ensure_repeat_application_references_v23(conn)
+    assert conn.execute("PRAGMA user_version").fetchone()[0] == 22
+    assert _legacy_snapshot(conn) == before
+    assert "target_job_key" in _columns(
+        conn,
+        "application_repeat_overrides",
+    )
+    assert conn.execute("PRAGMA foreign_keys").fetchone()[0] == 1
+
+    monkeypatch.setattr(
+        database_module,
+        "_verify_repeat_application_references_v23",
+        original_verify,
+    )
+    assert ensure_repeat_application_references_v23(conn)
+    assert conn.execute("PRAGMA user_version").fetchone()[0] == 23
+    assert conn.execute("PRAGMA foreign_key_check").fetchone() is None
+    assert tuple(
+        conn.execute(
+            """
+            SELECT evidence_fingerprint, evidence_json
+            FROM application_repeat_overrides
+            """
+        ).fetchone()
+    ) == ("fingerprint:retry", evidence_json)
+
+
+@pytest.mark.parametrize(
+    ("schema_version", "expected_reference"),
+    ((0, "target_job_key"), (22, "target_job_key"), (23, "target_job_id")),
+)
+def test_missing_table_recovery_is_schema_version_aware(
+    schema_version: int,
+    expected_reference: str,
+) -> None:
+    conn = sqlite3.connect(":memory:")
+    conn.executescript(
+        f"""
+        CREATE TABLE jobs (
+            url TEXT PRIMARY KEY,
+            tenant_id TEXT NOT NULL DEFAULT 'local',
+            job_id TEXT NOT NULL,
+            UNIQUE (tenant_id, job_id)
+        );
+        PRAGMA user_version = {schema_version};
+        """
+    )
+
+    assert ensure_repeat_application_tables(conn) == list(
+        database_module._REPEAT_APPLICATION_REFERENCE_TABLES
+    )
+
+    override_columns = _columns(
+        conn,
+        "application_repeat_overrides",
+    )
+    audit_columns = _columns(conn, "application_repeat_audit")
+    assert expected_reference in override_columns
+    assert expected_reference in audit_columns
+    if schema_version == 23:
+        assert "prior_job_id" in override_columns
+        assert database_module._has_repeat_application_reference_schema_v23(
+            conn
+        )
+    else:
+        assert "prior_job_key" in override_columns
+        assert "target_job_id" not in override_columns
+
+
+def test_runtime_identity_collision_rehomes_refs_without_reauthorizing(
+    tmp_path: Path,
+) -> None:
+    conn = init_db(tmp_path / "jobs.db")
+    losing_url = "https://careers.example.test/losing"
+    survivor_url = "https://careers.example.test/survivor"
+    prior_url = "https://careers.example.test/prior"
+    other_url = "https://careers.example.test/other"
+    _insert_job(conn, url=losing_url, job_id=TARGET_JOB_ID)
+    _insert_job(conn, url=survivor_url, job_id=SURVIVOR_JOB_ID)
+    _insert_job(conn, url=prior_url, job_id=PRIOR_JOB_ID)
+    _insert_job(conn, url=other_url, job_id=OTHER_JOB_ID)
+    _insert_job(
+        conn,
+        url="https://blue.example.test/losing-id-owner",
+        job_id=TARGET_JOB_ID,
+        tenant_id="blue",
+    )
+    _insert_job(
+        conn,
+        url="https://blue.example.test/prior",
+        job_id=OTHER_PRIOR_JOB_ID,
+        tenant_id="blue",
+    )
+    record_job_event(
+        conn,
+        prior_url,
+        "apply",
+        "ApplicationSubmitted",
+        occurred_at=NOW,
+        payload={"run_id": "prior-run"},
+    )
+    assessment = evaluate_repeat_application(conn, losing_url)
+    assert assessment["status"] == "confirmation_required"
+    evidence_json = json.dumps(
+        assessment["matches"],
+        separators=(",", ":"),
+    )
+    fingerprint = str(assessment["evidenceFingerprint"])
+    conn.executemany(
+        """
+        INSERT INTO application_repeat_overrides (
+            tenant_id, override_id, target_job_id, prior_job_id,
+            relationship, evidence_fingerprint, evidence_json, reason,
+            confirmed_by, confirmed_at
+        ) VALUES (?, ?, ?, ?, 'same_employer_equivalent_role', ?, ?, ?, ?, ?)
+        """,
+        (
+            (
+                "local",
+                "override:target",
+                TARGET_JOB_ID,
+                PRIOR_JOB_ID,
+                fingerprint,
+                evidence_json,
+                "old target confirmation",
+                "qa-user",
+                NOW,
+            ),
+            (
+                "local",
+                "override:prior",
+                OTHER_JOB_ID,
+                TARGET_JOB_ID,
+                "fingerprint:prior",
+                '[{"immutable":"prior"}]',
+                "old prior evidence",
+                "qa-user",
+                NOW,
+            ),
+            (
+                "blue",
+                "override:blue",
+                TARGET_JOB_ID,
+                OTHER_PRIOR_JOB_ID,
+                "fingerprint:blue",
+                '[{"immutable":"blue"}]',
+                "tenant isolation",
+                "qa-user",
+                NOW,
+            ),
+        ),
+    )
+    conn.execute(
+        """
+        INSERT INTO application_repeat_audit (
+            tenant_id, audit_id, audit_key, target_job_id, action,
+            evidence_fingerprint, evidence_json, override_id, actor,
+            reason, occurred_at
+        ) VALUES (
+            'local', 'audit:collision', 'audit-key:collision', ?,
+            'override_recorded', ?, ?, 'override:target', 'qa-user',
+            'old target confirmation', ?
+        )
+        """,
+        (TARGET_JOB_ID, fingerprint, evidence_json, NOW),
+    )
+    conn.commit()
+    before_counts = {
+        table: conn.execute(
+            f'SELECT COUNT(*) FROM "{table}"'
+        ).fetchone()[0]
+        for table in database_module._REPEAT_APPLICATION_REFERENCE_TABLES
+    }
+
+    reassign_discovery_identity_references(
+        conn,
+        losing_job_url=losing_url,
+        surviving_job_url=survivor_url,
+    )
+
+    assert {
+        table: conn.execute(
+            f'SELECT COUNT(*) FROM "{table}"'
+        ).fetchone()[0]
+        for table in database_module._REPEAT_APPLICATION_REFERENCE_TABLES
+    } == before_counts
+    rows = {
+        str(row["override_id"]): (
+            str(row["tenant_id"]),
+            str(row["target_job_id"]),
+            str(row["prior_job_id"]),
+            str(row["evidence_fingerprint"]),
+            str(row["evidence_json"]),
+        )
+        for row in conn.execute(
+            """
+            SELECT tenant_id, override_id, target_job_id, prior_job_id,
+                   evidence_fingerprint, evidence_json
+            FROM application_repeat_overrides
+            """
+        ).fetchall()
+    }
+    assert rows["override:target"] == (
+        "local",
+        SURVIVOR_JOB_ID,
+        PRIOR_JOB_ID,
+        fingerprint,
+        evidence_json,
+    )
+    assert rows["override:prior"] == (
+        "local",
+        OTHER_JOB_ID,
+        SURVIVOR_JOB_ID,
+        "fingerprint:prior",
+        '[{"immutable":"prior"}]',
+    )
+    assert rows["override:blue"] == (
+        "blue",
+        TARGET_JOB_ID,
+        OTHER_PRIOR_JOB_ID,
+        "fingerprint:blue",
+        '[{"immutable":"blue"}]',
+    )
+    assert tuple(
+        conn.execute(
+            """
+            SELECT target_job_id, evidence_fingerprint, evidence_json
+            FROM application_repeat_audit
+            WHERE audit_id = 'audit:collision'
+            """
+        ).fetchone()
+    ) == (
+        SURVIVOR_JOB_ID,
+        fingerprint,
+        evidence_json,
+    )
+    reassessed = evaluate_repeat_application(
+        conn,
+        survivor_url,
+        record_audit=False,
+    )
+    assert reassessed["status"] == "confirmation_required"
+    assert reassessed["override"] is None
+    assert reassessed["evidenceFingerprint"] != fingerprint
+
+
+@pytest.mark.parametrize(
+    "unresolved",
+    ("target", "prior", "audit"),
+)
+def test_unresolved_legacy_reference_rolls_back_all_history(
+    tmp_path: Path,
+    unresolved: str,
+) -> None:
+    conn = _seed_v22_database(
+        tmp_path / f"{unresolved}.db"
+    )
+    target_url = "https://careers.example.test/target"
+    prior_url = "https://careers.example.test/prior"
+    missing_url = f"https://missing.example.test/{unresolved}"
+    _insert_job(conn, url=target_url, job_id=TARGET_JOB_ID)
+    _insert_job(conn, url=prior_url, job_id=PRIOR_JOB_ID)
+    evidence_json = '[{"private":"must-survive"}]'
+    _insert_legacy_override(
+        conn,
+        tenant_id="local",
+        override_id=f"override:{unresolved}",
+        target_job_key=(
+            missing_url if unresolved == "target" else target_url
+        ),
+        prior_job_key=(
+            missing_url if unresolved == "prior" else prior_url
+        ),
+        fingerprint=f"fingerprint:{unresolved}",
+        evidence_json=evidence_json,
+    )
+    conn.execute(
+        """
+        INSERT INTO application_repeat_override_consumptions
+        VALUES ('local', ?, ?, ?)
+        """,
+        (
+            f"override:{unresolved}",
+            f"run:{unresolved}",
+            NOW,
+        ),
+    )
+    _insert_legacy_audit(
+        conn,
+        tenant_id="local",
+        audit_id=f"audit:{unresolved}",
+        target_job_key=(
+            missing_url if unresolved == "audit" else target_url
+        ),
+        fingerprint=f"fingerprint:{unresolved}",
+        evidence_json=evidence_json,
+        override_id=f"override:{unresolved}",
+    )
+    conn.commit()
+    before = _legacy_snapshot(conn)
+
+    with pytest.raises(
+        RuntimeError,
+        match="could not resolve",
+    ):
+        ensure_repeat_application_references_v23(conn)
+
+    assert conn.execute("PRAGMA user_version").fetchone()[0] == 22
+    assert _legacy_snapshot(conn) == before
+    assert {
+        str(row[0])
+        for row in conn.execute(
+            """
+            SELECT name
+            FROM sqlite_master
+            WHERE type = 'table' AND name LIKE '%_v23'
+            """
+        ).fetchall()
+    } == set()

--- a/workers/automation/tests/test_repeat_application_prevention.py
+++ b/workers/automation/tests/test_repeat_application_prevention.py
@@ -125,9 +125,21 @@ def _insert_override(
     conn.execute(
         """
         INSERT INTO application_repeat_overrides (
-          tenant_id, override_id, target_job_key, prior_job_key, relationship,
+          tenant_id, override_id, target_job_id, prior_job_id, relationship,
           evidence_fingerprint, evidence_json, reason, confirmed_by, confirmed_at
-        ) VALUES ('local', ?, ?, ?, ?, ?, ?, ?, 'qa-user', ?)
+        ) VALUES (
+          'local',
+          ?,
+          (
+            SELECT job_id FROM jobs
+            WHERE tenant_id = 'local' AND url = ?
+          ),
+          (
+            SELECT job_id FROM jobs
+            WHERE tenant_id = 'local' AND url = ?
+          ),
+          ?, ?, ?, ?, 'qa-user', ?
+        )
         """,
         (
             override_id,
@@ -395,7 +407,16 @@ def test_authoritative_claim_blocks_direct_dispatch_and_repeated_standing_polls(
     )
     assert (
         conn.execute(
-            "SELECT COUNT(*) FROM application_repeat_audit WHERE target_job_key = ? AND action = 'confirmation_required'",
+            """
+            SELECT COUNT(*)
+            FROM application_repeat_audit
+            WHERE tenant_id = 'local'
+              AND target_job_id = (
+                SELECT job_id FROM jobs
+                WHERE tenant_id = 'local' AND url = ?
+              )
+              AND action = 'confirmation_required'
+            """,
             (TARGET,),
         ).fetchone()[0]
         == 1
@@ -441,7 +462,16 @@ def test_non_targeted_claim_skips_protected_high_ranked_job_for_distinct_role(
     )
     assert (
         conn.execute(
-            "SELECT COUNT(*) FROM application_repeat_audit WHERE target_job_key = ? AND action = 'confirmation_required'",
+            """
+            SELECT COUNT(*)
+            FROM application_repeat_audit
+            WHERE tenant_id = 'local'
+              AND target_job_id = (
+                SELECT job_id FROM jobs
+                WHERE tenant_id = 'local' AND url = ?
+              )
+              AND action = 'confirmation_required'
+            """,
             (TARGET,),
         ).fetchone()[0]
         == 1
@@ -469,7 +499,16 @@ def test_protected_queue_audit_survives_lower_candidate_approval_refusal(
 
     assert acquire_job(worker_id=51, approval_required=True) is None
     assert conn.execute(
-        "SELECT COUNT(*) FROM application_repeat_audit WHERE target_job_key = ? AND action = 'confirmation_required'",
+        """
+        SELECT COUNT(*)
+        FROM application_repeat_audit
+        WHERE tenant_id = 'local'
+          AND target_job_id = (
+            SELECT job_id FROM jobs
+            WHERE tenant_id = 'local' AND url = ?
+          )
+          AND action = 'confirmation_required'
+        """,
         (TARGET,),
     ).fetchone()[0] == 1
 
@@ -760,7 +799,7 @@ def test_schema_v5_migrates_additively_without_changing_application_facts(
         (PRIOR,),
     ).fetchall()
 
-    assert int(migrated.execute("PRAGMA user_version").fetchone()[0]) == SCHEMA_VERSION == 22
+    assert int(migrated.execute("PRAGMA user_version").fetchone()[0]) == SCHEMA_VERSION == 23
     assert [tuple(row) for row in after] == [tuple(row) for row in before]
     assert "metadata_json" in {
         str(row[1]) for row in migrated.execute("PRAGMA table_info(job_stage_states)").fetchall()

--- a/workers/automation/tests/test_resume_template_identity_reference_migration.py
+++ b/workers/automation/tests/test_resume_template_identity_reference_migration.py
@@ -254,7 +254,7 @@ def test_v16_template_references_migrate_aliases_and_uuid_urls(
     assert (
         reopened.execute("PRAGMA user_version").fetchone()[0]
         == SCHEMA_VERSION
-        == 22
+        == 23
     )
     for table in database_module._RESUME_TEMPLATE_REFERENCE_TABLES:
         assert "job_id" in _columns(reopened, table)

--- a/workers/automation/tests/test_scoring_identity_reference_migration.py
+++ b/workers/automation/tests/test_scoring_identity_reference_migration.py
@@ -338,7 +338,7 @@ def test_v11_scoring_references_migrate_alias_histories_and_reopen(
     assert (
         int(migrated.execute("PRAGMA user_version").fetchone()[0])
         == SCHEMA_VERSION
-        == 22
+        == 23
     )
     assert _columns(migrated, "job_scores") >= {"tenant_id", "job_id"}
     assert "job_url" not in _columns(migrated, "job_scores")
@@ -404,7 +404,7 @@ def test_v11_scoring_references_migrate_alias_histories_and_reopen(
     assert (
         int(reopened.execute("PRAGMA user_version").fetchone()[0])
         == SCHEMA_VERSION
-        == 22
+        == 23
     )
 
 
@@ -553,7 +553,7 @@ def test_scoring_migration_rolls_back_and_retries_after_verification_failure(
     assert (
         int(retried.execute("PRAGMA user_version").fetchone()[0])
         == SCHEMA_VERSION
-        == 22
+        == 23
     )
     assert [
         tuple(row)

--- a/workers/automation/tests/test_stable_job_identity_migration.py
+++ b/workers/automation/tests/test_stable_job_identity_migration.py
@@ -841,7 +841,7 @@ def test_v6_jobs_gain_stable_uuid_and_posting_url_alias_once(
     init_db(db_path)
     close_connection(db_path)
 
-    assert _user_version(db_path) == SCHEMA_VERSION == 22
+    assert _user_version(db_path) == SCHEMA_VERSION == 23
     first_ids = _identity_rows(db_path)
     assert [row[0] for row in first_ids] == ["local", "local"]
     for _tenant_id, job_id, _url in first_ids:


### PR DESCRIPTION
## Summary

- advance the local schema contract to v23 and migrate repeat-application override target/prior ownership plus audit target ownership from legacy URL-shaped keys to tenant-scoped stable JobIds
- preserve every override, historical consumption (including orphans), audit row, evidence snapshot byte, fingerprint, ID, tenant boundary, and reason/actor field while adding only the required composite cascading Job foreign keys and indexes
- keep API and worker evidence URL-shaped until Phase 4, with URL-first ownership for UUID-shaped posting URLs and collision reassignment limited to normalized ownership fields
- keep old confirmations fail-closed after a URL collision because immutable evidence/fingerprints are not rewritten or silently reauthorized
- explicitly purge target-, prior-, linked-, audit-evidence-, and override-evidence-bound history during permanent deletion when SQLite foreign-key actions are disabled, without crossing tenants or confusing a posting URL with another aggregate's same-text JobId
- add database, API, worker, E2E-fixture, rollback/retry, malformed recovery, collision, multi-match deletion, and schema-version coverage

## Why

#548 moves linked Gmail evidence and outcome suggestions onto stable Job ownership, but the repeat-application guard still persisted mutable URL-shaped ownership around evidence-bound confirmations. This PR migrates that next bounded Apply seam without changing the public evidence contract. The immutable evidence snapshot and fingerprint remain historical proof; stable target/prior ownership can move during an identity collision, while the old fingerprint deliberately does not authorize the survivor.

## Validation

- `pnpm api:check`
- `pnpm --filter @jobctrl/web check`
- `pnpm --filter @jobctrl/api test` — 697 passed
- `PYTHONPATH=src uv run --extra dev python -m pytest -q` — 2,735 passed, 2 skipped
- focused Python repeat/migration suites — 25 passed
- focused earlier identity-migration matrix — 81 passed
- focused API repeat/schema suites — 27 passed
- new v23 API suite — 6 passed after the final evidence-only deletion regression
- focused Ruff checks
- `git diff --check`
- `env -u UV_EXCLUDE_NEWER uv --project workers/automation lock --check`
- independent Tier-3 review — initial evidence-only deletion High found and fixed; rerun PASS, Blocker/High/Medium/Low = 0/0/0/0
- independent Tier-3 QA — rerun PASS, Blocker/High/Medium/Low = 0/0/0/0

## Stack

- base: #548 (`feat/job-id-application-evidence-suggestion-references`)
- this is an intermediate unreleased identity-migration PR; canonical product documentation and cumulative product QA remain intentionally deferred to the final stack PR under the approved stack policy
