### PR TITLE
feat(contacts): migrate job links to stable JobIds

### DIFF
--- a/apps/api/src/contact-research.ts
+++ b/apps/api/src/contact-research.ts
@@ -32,7 +32,18 @@ import type {
 } from "./contracts.js";
 import { CONTACT_ROLES } from "@jobctrl/domain-types";
 import { ensureContactTables, getContactDetail } from "./contacts.js";
-import { allRows, getRow, tableExists, type SqliteDatabase, type SqliteValue } from "./db.js";
+import {
+  allRows,
+  getRow,
+  hasCompositeJobIdForeignKeyAction,
+  jobReferenceColumn,
+  jobReferenceForUrl,
+  tableColumnSet,
+  tableIndexColumns,
+  tableExists,
+  type SqliteDatabase,
+  type SqliteValue,
+} from "./db.js";
 import { refreshContactResearchProjections, refreshProjections } from "./projections.js";
 
 const TENANT_ID = "local";
@@ -42,12 +53,19 @@ export class ContactResearchInputError extends Error {}
 
 export function ensureContactResearchTables(db: SqliteDatabase): void {
   ensureContactTables(db);
+  const schemaVersion = Number(db.pragma("user_version", { simple: true }));
+  const stableReferences = schemaVersion >= 24;
+  const referenceColumn = stableReferences ? "job_id" : "job_url";
+  const foreignKey = stableReferences
+    ? `, FOREIGN KEY (tenant_id, job_id)
+         REFERENCES jobs(tenant_id, job_id) ON DELETE RESTRICT`
+    : "";
   db.exec(`
     CREATE TABLE IF NOT EXISTS contact_research_tasks (
       tenant_id            TEXT NOT NULL DEFAULT 'local',
       task_id              TEXT NOT NULL,
       employer             TEXT,
-      job_url              TEXT,
+      ${referenceColumn}    TEXT,
       status               TEXT NOT NULL DEFAULT 'queued',
       source_attempts_json TEXT NOT NULL DEFAULT '[]',
       started_at           TEXT,
@@ -57,6 +75,7 @@ export function ensureContactResearchTables(db: SqliteDatabase): void {
       failed_at            TEXT,
       error_class          TEXT,
       PRIMARY KEY (tenant_id, task_id)
+      ${foreignKey}
     );
     CREATE TABLE IF NOT EXISTS contact_candidates (
       tenant_id            TEXT NOT NULL DEFAULT 'local',
@@ -77,6 +96,39 @@ export function ensureContactResearchTables(db: SqliteDatabase): void {
     CREATE INDEX IF NOT EXISTS idx_contact_candidates_task
       ON contact_candidates(tenant_id, task_id, status);
   `);
+  const columns = tableColumnSet(db, "contact_research_tasks");
+  if (
+    stableReferences
+    && (!columns.has("job_id") || columns.has("job_url"))
+  ) {
+    throw new Error(
+      "Schema v24 requires stable contact_research_tasks.job_id references.",
+    );
+  }
+  db.exec(
+    `CREATE INDEX IF NOT EXISTS idx_contact_research_tasks_lookup
+       ON contact_research_tasks(tenant_id, employer, ${referenceColumn})`,
+  );
+  if (
+    stableReferences
+    && (
+      !hasCompositeJobIdForeignKeyAction(
+        db,
+        "contact_research_tasks",
+        "job_id",
+        "RESTRICT",
+      )
+      || tableIndexColumns(
+        db,
+        "contact_research_tasks",
+        "idx_contact_research_tasks_lookup",
+      ).join(",") !== "tenant_id,employer,job_id"
+    )
+  ) {
+    throw new Error(
+      "Schema v24 requires the restrictive contact-research JobId contract.",
+    );
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -156,12 +208,27 @@ export function createQueuedResearchTask(
 ): ContactResearchTaskSummary {
   ensureContactResearchTables(db);
   const now = new Date().toISOString();
+  const referenceColumn = jobReferenceColumn(
+    db,
+    "contact_research_tasks",
+  );
+  const referenceValue = physicalResearchJobReference(
+    db,
+    input.jobId,
+  );
   db.prepare(
     `INSERT INTO contact_research_tasks (
-       tenant_id, task_id, employer, job_url, status, source_attempts_json, started_at, updated_at
+       tenant_id, task_id, employer, ${referenceColumn}, status, source_attempts_json, started_at, updated_at
      ) VALUES (?, ?, ?, ?, 'queued', '[]', ?, ?)
      ON CONFLICT(tenant_id, task_id) DO NOTHING`,
-  ).run(TENANT_ID, input.taskId, input.employer, input.jobId, now, now);
+  ).run(
+    TENANT_ID,
+    input.taskId,
+    input.employer,
+    referenceValue,
+    now,
+    now,
+  );
   recordEvent(db, {
     jobUrl: input.jobId,
     eventType: "ContactResearchTaskStarted",
@@ -231,10 +298,23 @@ export function confirmContactCandidate(
   const jobId = task.job_url ?? null;
 
   const transaction = db.transaction(() => {
+    const contactReferenceColumn = jobReferenceColumn(db, "contacts");
+    const contactReferenceValue =
+      jobId === null
+        ? null
+        : jobReferenceForUrl(db, "contacts", jobId, TENANT_ID);
     db.prepare(
-      `INSERT INTO contacts (tenant_id, contact_id, employer, job_url, role, created_at, updated_at, deleted_at)
+      `INSERT INTO contacts (tenant_id, contact_id, employer, ${contactReferenceColumn}, role, created_at, updated_at, deleted_at)
        VALUES (?, ?, ?, ?, ?, ?, ?, NULL)`,
-    ).run(TENANT_ID, contactId, employer, jobId, contactRole, now, now);
+    ).run(
+      TENANT_ID,
+      contactId,
+      employer,
+      contactReferenceValue,
+      contactRole,
+      now,
+      now,
+    );
     const insertAttr = db.prepare(
       `INSERT INTO contact_attributes (
          tenant_id, attribute_id, contact_id, attribute_kind, value_json,
@@ -369,13 +449,59 @@ type CandidateRow = {
 };
 
 function loadTaskRow(db: SqliteDatabase, taskId: string): TaskRow | null {
+  const referenceColumn = jobReferenceColumn(
+    db,
+    "contact_research_tasks",
+  );
+  const stableReferences = referenceColumn === "job_id";
   return (
     getRow<TaskRow>(
       db,
-      "SELECT * FROM contact_research_tasks WHERE tenant_id = ? AND task_id = ?",
+      `SELECT contact_research_tasks.task_id,
+              contact_research_tasks.employer,
+              ${stableReferences
+                ? "jobs.url"
+                : "contact_research_tasks.job_url"} AS job_url,
+              contact_research_tasks.status,
+              contact_research_tasks.source_attempts_json,
+              contact_research_tasks.started_at,
+              contact_research_tasks.updated_at,
+              contact_research_tasks.needs_review_at,
+              contact_research_tasks.completed_at,
+              contact_research_tasks.failed_at,
+              contact_research_tasks.error_class
+         FROM contact_research_tasks
+         ${stableReferences
+           ? `LEFT JOIN jobs
+                ON jobs.tenant_id = contact_research_tasks.tenant_id
+               AND jobs.job_id = contact_research_tasks.job_id`
+           : ""}
+        WHERE contact_research_tasks.tenant_id = ?
+          AND contact_research_tasks.task_id = ?`,
       [TENANT_ID, taskId],
     ) ?? null
   );
+}
+
+function physicalResearchJobReference(
+  db: SqliteDatabase,
+  jobUrl: string | null,
+): string | null {
+  if (jobUrl === null) {
+    return null;
+  }
+  try {
+    return jobReferenceForUrl(
+      db,
+      "contact_research_tasks",
+      jobUrl,
+      TENANT_ID,
+    );
+  } catch {
+    throw new ContactResearchInputError(
+      `No stable Job identity exists for ${jobUrl}.`,
+    );
+  }
 }
 
 function loadCandidates(db: SqliteDatabase, taskId: string): ContactCandidateDto[] {

--- a/apps/api/src/contacts.ts
+++ b/apps/api/src/contacts.ts
@@ -33,7 +33,18 @@ import type {
   ContactUpdateRequest,
 } from "./contracts.js";
 import { CONTACT_ROLES } from "@jobctrl/domain-types";
-import { allRows, getRow, tableExists, type SqliteDatabase, type SqliteValue } from "./db.js";
+import {
+  allRows,
+  getRow,
+  hasCompositeJobIdForeignKeyAction,
+  jobReferenceColumn,
+  jobReferenceForUrl,
+  tableColumnSet,
+  tableIndexColumns,
+  tableExists,
+  type SqliteDatabase,
+  type SqliteValue,
+} from "./db.js";
 import { refreshProjections } from "./projections.js";
 
 const TENANT_ID = "local";
@@ -57,17 +68,25 @@ interface AttributeSeed {
 }
 
 export function ensureContactTables(db: SqliteDatabase): void {
+  const schemaVersion = Number(db.pragma("user_version", { simple: true }));
+  const stableReferences = schemaVersion >= 24;
+  const referenceColumn = stableReferences ? "job_id" : "job_url";
+  const foreignKey = stableReferences
+    ? `, FOREIGN KEY (tenant_id, job_id)
+         REFERENCES jobs(tenant_id, job_id) ON DELETE RESTRICT`
+    : "";
   db.exec(`
     CREATE TABLE IF NOT EXISTS contacts (
       tenant_id   TEXT NOT NULL DEFAULT 'local',
       contact_id  TEXT NOT NULL,
       employer    TEXT,
-      job_url     TEXT,
+      ${referenceColumn} TEXT,
       role        TEXT NOT NULL DEFAULT 'other',
       created_at  TEXT NOT NULL,
       updated_at  TEXT NOT NULL,
       deleted_at  TEXT,
       PRIMARY KEY (tenant_id, contact_id)
+      ${foreignKey}
     );
     CREATE TABLE IF NOT EXISTS contact_attributes (
       tenant_id      TEXT NOT NULL DEFAULT 'local',
@@ -83,10 +102,42 @@ export function ensureContactTables(db: SqliteDatabase): void {
       recorded_at    TEXT NOT NULL,
       PRIMARY KEY (tenant_id, attribute_id)
     );
-    CREATE INDEX IF NOT EXISTS idx_contacts_lookup ON contacts(tenant_id, employer, job_url);
     CREATE INDEX IF NOT EXISTS idx_contact_attributes_contact
       ON contact_attributes(tenant_id, contact_id);
   `);
+  const columns = tableColumnSet(db, "contacts");
+  if (
+    stableReferences
+    && (!columns.has("job_id") || columns.has("job_url"))
+  ) {
+    throw new Error(
+      "Schema v24 requires stable contacts.job_id references.",
+    );
+  }
+  db.exec(
+    `CREATE INDEX IF NOT EXISTS idx_contacts_lookup
+       ON contacts(tenant_id, employer, ${referenceColumn})`,
+  );
+  if (
+    stableReferences
+    && (
+      !hasCompositeJobIdForeignKeyAction(
+        db,
+        "contacts",
+        "job_id",
+        "RESTRICT",
+      )
+      || tableIndexColumns(
+        db,
+        "contacts",
+        "idx_contacts_lookup",
+      ).join(",") !== "tenant_id,employer,job_id"
+    )
+  ) {
+    throw new Error(
+      "Schema v24 requires the restrictive contacts JobId contract.",
+    );
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -203,11 +254,7 @@ export function updateContact(
   request: ContactUpdateRequest,
 ): ContactDetail {
   ensureContactTables(db);
-  const existing = getRow<ContactRow>(
-    db,
-    "SELECT * FROM contacts WHERE tenant_id = ? AND contact_id = ? AND deleted_at IS NULL",
-    [TENANT_ID, contactId],
-  );
+  const existing = loadContactRow(db, contactId);
   if (!existing) {
     throw new ContactNotFoundError(`Contact ${contactId} not found`);
   }
@@ -234,10 +281,12 @@ export function updateContact(
   const nextAttributes =
     request.attributes !== undefined ? seedAttributes(request.attributes) : null;
   const transaction = db.transaction(() => {
+    const referenceColumn = jobReferenceColumn(db, "contacts");
+    const referenceValue = physicalJobReference(db, "contacts", jobId);
     db.prepare(
-      `UPDATE contacts SET employer = ?, job_url = ?, role = ?, updated_at = ?
+      `UPDATE contacts SET employer = ?, ${referenceColumn} = ?, role = ?, updated_at = ?
        WHERE tenant_id = ? AND contact_id = ?`,
-    ).run(employer, jobId, role, now, TENANT_ID, contactId);
+    ).run(employer, referenceValue, role, now, TENANT_ID, contactId);
     if (nextAttributes !== null) {
       db.prepare("DELETE FROM contact_attributes WHERE tenant_id = ? AND contact_id = ?").run(
         TENANT_ID,
@@ -493,10 +542,67 @@ function insertContactRow(
     updatedAt: string;
   },
 ): void {
+  const referenceColumn = jobReferenceColumn(db, "contacts");
+  const referenceValue = physicalJobReference(
+    db,
+    "contacts",
+    input.jobId,
+  );
   db.prepare(
-    `INSERT INTO contacts (tenant_id, contact_id, employer, job_url, role, created_at, updated_at, deleted_at)
+    `INSERT INTO contacts (tenant_id, contact_id, employer, ${referenceColumn}, role, created_at, updated_at, deleted_at)
      VALUES (?, ?, ?, ?, ?, ?, ?, NULL)`,
-  ).run(TENANT_ID, input.contactId, input.employer, input.jobId, input.role, input.createdAt, input.updatedAt);
+  ).run(
+    TENANT_ID,
+    input.contactId,
+    input.employer,
+    referenceValue,
+    input.role,
+    input.createdAt,
+    input.updatedAt,
+  );
+}
+
+function physicalJobReference(
+  db: SqliteDatabase,
+  tableName: "contacts",
+  jobUrl: string | null,
+): string | null {
+  if (jobUrl === null) {
+    return null;
+  }
+  try {
+    return jobReferenceForUrl(db, tableName, jobUrl, TENANT_ID);
+  } catch {
+    throw new ContactInputError(
+      `No stable Job identity exists for ${jobUrl}.`,
+    );
+  }
+}
+
+function loadContactRow(
+  db: SqliteDatabase,
+  contactId: string,
+): ContactRow | null {
+  const referenceColumn = jobReferenceColumn(db, "contacts");
+  const stableReferences = referenceColumn === "job_id";
+  return (
+    getRow<ContactRow>(
+      db,
+      `SELECT contacts.contact_id, contacts.employer,
+              ${stableReferences ? "jobs.url" : "contacts.job_url"} AS job_url,
+              contacts.role, contacts.created_at, contacts.updated_at
+         FROM contacts
+         ${stableReferences
+           ? `LEFT JOIN jobs
+                ON jobs.tenant_id = contacts.tenant_id
+               AND jobs.job_id = contacts.job_id`
+           : ""}
+        WHERE contacts.tenant_id = ?
+          AND contacts.contact_id = ?
+          AND contacts.deleted_at IS NULL`,
+      [TENANT_ID, contactId],
+    ) ?? null
+  );
 }
 
 interface AttributeRowSeed {

--- a/apps/api/src/db.ts
+++ b/apps/api/src/db.ts
@@ -9,7 +9,7 @@ export type SqliteValue = string | number | bigint | null;
 // writer that stamps ``PRAGMA user_version``; the API only reads it to fail
 // closed on a database written by a newer build. Bump both constants together
 // whenever the schema shape changes.
-export const SUPPORTED_SCHEMA_VERSION = 23;
+export const SUPPORTED_SCHEMA_VERSION = 24;
 
 export class IncompatibleSchemaVersionError extends Error {
   constructor(current: number) {
@@ -79,6 +79,27 @@ export function tableColumnSet(db: SqliteDatabase, tableName: string): Set<strin
     (db.prepare(`PRAGMA table_info(${quoteIdentifier(tableName)})`).all() as Array<{ name: string }>)
       .map((row) => row.name),
   );
+}
+
+export function tableIndexColumns(
+  db: SqliteDatabase,
+  tableName: string,
+  indexName: string,
+): string[] {
+  if (!tableExists(db, tableName)) return [];
+  const exists = (
+    db
+      .prepare(`PRAGMA index_list(${quoteIdentifier(tableName)})`)
+      .all() as Array<{ name: string }>
+  ).some((row) => row.name === indexName);
+  if (!exists) return [];
+  return (
+    db
+      .prepare(`PRAGMA index_info(${quoteIdentifier(indexName)})`)
+      .all() as Array<{ seqno: number; name: string }>
+  )
+    .sort((left, right) => left.seqno - right.seqno)
+    .map((row) => row.name);
 }
 
 export function jobReferenceColumn(
@@ -231,6 +252,20 @@ export function hasCompositeJobIdForeignKey(
   tableName: string,
   referenceColumn = "job_id",
 ): boolean {
+  return hasCompositeJobIdForeignKeyAction(
+    db,
+    tableName,
+    referenceColumn,
+    "CASCADE",
+  );
+}
+
+export function hasCompositeJobIdForeignKeyAction(
+  db: SqliteDatabase,
+  tableName: string,
+  referenceColumn: string,
+  onDelete: string,
+): boolean {
   if (!tableExists(db, tableName)) return false;
   const rows = db
     .prepare(`PRAGMA foreign_key_list(${quoteIdentifier(tableName)})`)
@@ -242,20 +277,20 @@ export function hasCompositeJobIdForeignKey(
       on_delete: string;
     }>;
   const groups = new Map<number, Set<string>>();
-  const cascades = new Map<number, boolean>();
+  const actions = new Map<number, string>();
   for (const row of rows) {
     if (row.table !== "jobs") continue;
     const columns = groups.get(row.id) ?? new Set<string>();
     columns.add(`${row.from}:${row.to}`);
     groups.set(row.id, columns);
-    cascades.set(row.id, row.on_delete.toUpperCase() === "CASCADE");
+    actions.set(row.id, row.on_delete.toUpperCase());
   }
   const expected = new Set([
     "tenant_id:tenant_id",
     `${referenceColumn}:job_id`,
   ]);
   return [...groups.entries()].some(([id, columns]) => (
-    cascades.get(id) === true
+    actions.get(id) === onDelete.toUpperCase()
     && columns.size === expected.size
     && [...expected].every((column) => columns.has(column))
   ));

--- a/apps/api/src/projections.ts
+++ b/apps/api/src/projections.ts
@@ -4735,6 +4735,8 @@ function rebuildContactProjections(db: SqliteDatabase, tenantId: string): void {
   if (!tableExists(db, "contacts") || !tableExists(db, "contact_attributes")) {
     return;
   }
+  const contactReference = jobReferenceColumn(db, "contacts");
+  const stableContactReferences = contactReference === "job_id";
   const contacts = allRows<{
     contact_id: string;
     employer: string | null;
@@ -4744,9 +4746,15 @@ function rebuildContactProjections(db: SqliteDatabase, tenantId: string): void {
     updated_at: string | null;
   }>(
     db,
-    `SELECT contact_id, employer, job_url, role, created_at, updated_at
+    `SELECT contacts.contact_id, contacts.employer,
+            ${stableContactReferences ? "jobs.url" : "contacts.job_url"} AS job_url,
+            contacts.role, contacts.created_at, contacts.updated_at
      FROM contacts
-     WHERE tenant_id = ? AND deleted_at IS NULL`,
+     ${stableContactReferences
+       ? `LEFT JOIN jobs
+            ON ${jobReferenceJoinToJobs(db, "contacts", "contacts", "jobs")}`
+       : ""}
+     WHERE contacts.tenant_id = ? AND contacts.deleted_at IS NULL`,
     [tenantId],
   );
   const liveIds = new Set<string>();
@@ -4874,6 +4882,11 @@ function rebuildContactResearchProjections(db: SqliteDatabase, tenantId: string)
   if (!tableExists(db, "contact_research_tasks") || !tableExists(db, "contact_candidates")) {
     return;
   }
+  const researchReference = jobReferenceColumn(
+    db,
+    "contact_research_tasks",
+  );
+  const stableResearchReferences = researchReference === "job_id";
   const tasks = allRows<{
     task_id: string;
     employer: string | null;
@@ -4888,10 +4901,30 @@ function rebuildContactResearchProjections(db: SqliteDatabase, tenantId: string)
     error_class: string | null;
   }>(
     db,
-    `SELECT task_id, employer, job_url, status, source_attempts_json,
-            started_at, updated_at, needs_review_at, completed_at, failed_at, error_class
+    `SELECT contact_research_tasks.task_id,
+            contact_research_tasks.employer,
+            ${stableResearchReferences
+              ? "jobs.url"
+              : "contact_research_tasks.job_url"} AS job_url,
+            contact_research_tasks.status,
+            contact_research_tasks.source_attempts_json,
+            contact_research_tasks.started_at,
+            contact_research_tasks.updated_at,
+            contact_research_tasks.needs_review_at,
+            contact_research_tasks.completed_at,
+            contact_research_tasks.failed_at,
+            contact_research_tasks.error_class
      FROM contact_research_tasks
-     WHERE tenant_id = ?`,
+     ${stableResearchReferences
+       ? `LEFT JOIN jobs
+            ON ${jobReferenceJoinToJobs(
+              db,
+              "contact_research_tasks",
+              "contact_research_tasks",
+              "jobs",
+            )}`
+       : ""}
+     WHERE contact_research_tasks.tenant_id = ?`,
     [tenantId],
   );
   const liveIds = new Set<string>();

--- a/apps/api/src/write-model.ts
+++ b/apps/api/src/write-model.ts
@@ -862,6 +862,7 @@ function purgeJobRows(db: SqliteDatabase, jobUrl: string): void {
     jobId,
     jobUrl,
   );
+  detachOrDeleteContactReferences(db, jobId, jobUrl);
   deleteJobReferences(db, "job_artifacts", jobId, jobUrl);
   deleteScoringJobReferences(db, jobId, jobUrl);
   for (const tableName of [
@@ -917,6 +918,99 @@ function purgeJobRows(db: SqliteDatabase, jobUrl: string): void {
   ]);
   deleteWhere(db, "discovery_feedback", "job_key = ?", [jobUrl]);
   deleteWhere(db, "jobs", "url = ?", [jobUrl]);
+}
+
+function detachOrDeleteContactReferences(
+  db: SqliteDatabase,
+  jobId: string | undefined,
+  jobUrl: string,
+): void {
+  if (tableExists(db, "contacts")) {
+    const referenceColumn = jobReferenceColumn(db, "contacts");
+    const reference =
+      referenceColumn === "job_id" ? jobId : jobUrl;
+    if (reference) {
+      deleteWhere(
+        db,
+        "contact_attributes",
+        `tenant_id = 'local'
+         AND contact_id IN (
+           SELECT contact_id
+             FROM contacts
+            WHERE tenant_id = 'local'
+              AND ${referenceColumn} = ?
+              AND NULLIF(TRIM(COALESCE(employer, '')), '') IS NULL
+         )`,
+        [reference],
+      );
+      deleteWhere(
+        db,
+        "contacts",
+        `tenant_id = 'local'
+         AND ${referenceColumn} = ?
+         AND NULLIF(TRIM(COALESCE(employer, '')), '') IS NULL`,
+        [reference],
+      );
+      db.prepare(
+        `UPDATE contacts
+            SET ${referenceColumn} = NULL
+          WHERE tenant_id = 'local'
+            AND ${referenceColumn} = ?`,
+      ).run(reference);
+    }
+  }
+  if (tableExists(db, "contact_research_tasks")) {
+    const referenceColumn = jobReferenceColumn(
+      db,
+      "contact_research_tasks",
+    );
+    const reference =
+      referenceColumn === "job_id" ? jobId : jobUrl;
+    if (reference) {
+      deleteWhere(
+        db,
+        "contact_candidates",
+        `tenant_id = 'local'
+         AND task_id IN (
+           SELECT task_id
+             FROM contact_research_tasks
+            WHERE tenant_id = 'local'
+              AND ${referenceColumn} = ?
+              AND NULLIF(TRIM(COALESCE(employer, '')), '') IS NULL
+         )`,
+        [reference],
+      );
+      deleteWhere(
+        db,
+        "contact_research_tasks",
+        `tenant_id = 'local'
+         AND ${referenceColumn} = ?
+         AND NULLIF(TRIM(COALESCE(employer, '')), '') IS NULL`,
+        [reference],
+      );
+      db.prepare(
+        `UPDATE contact_research_tasks
+            SET ${referenceColumn} = NULL
+          WHERE tenant_id = 'local'
+            AND ${referenceColumn} = ?`,
+      ).run(reference);
+    }
+  }
+  // These projections remain URL-shaped until Phase 4. Clearing the small
+  // local read models makes the next normal refresh rebuild detached rows and
+  // omit purged ones without leaving the deleted posting URL visible.
+  deleteWhere(
+    db,
+    "contact_projections",
+    "tenant_id = 'local'",
+    [],
+  );
+  deleteWhere(
+    db,
+    "contact_research_task_projections",
+    "tenant_id = 'local'",
+    [],
+  );
 }
 
 function deleteEnrichmentJobReferences(

--- a/apps/api/test/contact-research-v24.test.ts
+++ b/apps/api/test/contact-research-v24.test.ts
@@ -1,0 +1,409 @@
+import Database from "better-sqlite3";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  createContact,
+  ensureContactTables,
+  updateContact,
+} from "../src/contacts.js";
+import {
+  confirmContactCandidate,
+  createQueuedResearchTask,
+  ensureContactResearchTables,
+} from "../src/contact-research.js";
+import {
+  jobReferenceColumn,
+  tableColumnSet,
+} from "../src/db.js";
+import { refreshProjections } from "../src/projections.js";
+import { permanentlyDeleteJob } from "../src/write-model.js";
+
+const NOW = "2026-07-30T12:00:00.000Z";
+const UUID_SHAPED_URL = "11111111-1111-4111-8111-111111111111";
+const TARGET_JOB_ID = "22222222-2222-4222-8222-222222222222";
+const OTHER_JOB_ID = "33333333-3333-4333-8333-333333333333";
+
+let db: Database.Database | undefined;
+
+afterEach(() => {
+  db?.close();
+  db = undefined;
+});
+
+function createDatabase(
+  foreignKeys = true,
+  schemaVersion = 24,
+): Database.Database {
+  const opened = new Database(":memory:");
+  opened.pragma(`foreign_keys = ${foreignKeys ? "ON" : "OFF"}`);
+  opened.exec(`
+    CREATE TABLE jobs (
+      url TEXT PRIMARY KEY,
+      tenant_id TEXT NOT NULL DEFAULT 'local',
+      job_id TEXT NOT NULL,
+      title TEXT,
+      company TEXT,
+      salary TEXT,
+      description TEXT,
+      location TEXT,
+      site TEXT,
+      strategy TEXT,
+      discovered_at TEXT,
+      full_description TEXT,
+      application_url TEXT,
+      detail_scraped_at TEXT,
+      detail_error TEXT,
+      fit_score INTEGER,
+      score_reasoning TEXT,
+      scored_at TEXT,
+      tailored_resume_path TEXT,
+      tailored_at TEXT,
+      tailor_attempts INTEGER DEFAULT 0,
+      cover_letter_path TEXT,
+      cover_letter_at TEXT,
+      cover_attempts INTEGER DEFAULT 0,
+      applied_at TEXT,
+      apply_status TEXT,
+      apply_error TEXT,
+      apply_attempts INTEGER DEFAULT 0,
+      agent_id TEXT,
+      last_attempted_at TEXT,
+      apply_duration_ms INTEGER,
+      apply_task_id TEXT,
+      verification_confidence TEXT,
+      UNIQUE (tenant_id, job_id)
+    );
+    CREATE TABLE job_identity_aliases (
+      tenant_id TEXT NOT NULL,
+      alias_kind TEXT NOT NULL,
+      alias_value TEXT NOT NULL,
+      job_id TEXT NOT NULL,
+      created_at TEXT NOT NULL,
+      retired_at TEXT,
+      PRIMARY KEY (tenant_id, alias_kind, alias_value)
+    );
+    CREATE TABLE job_events (
+      event_id INTEGER PRIMARY KEY AUTOINCREMENT,
+      job_url TEXT,
+      stage TEXT,
+      event_type TEXT NOT NULL,
+      level TEXT NOT NULL DEFAULT 'info',
+      message TEXT,
+      occurred_at TEXT NOT NULL,
+      payload_json TEXT,
+      entity_kind TEXT,
+      entity_ref TEXT
+    );
+    PRAGMA user_version = ${schemaVersion};
+  `);
+  ensureContactResearchTables(opened);
+  return opened;
+}
+
+function insertJob(
+  url: string,
+  jobId: string,
+  company = "ExampleCo",
+): void {
+  db!.prepare(
+    `INSERT INTO jobs (
+       url, tenant_id, job_id, title, company, discovered_at
+     ) VALUES (?, 'local', ?, 'Platform Engineer', ?, ?)`,
+  ).run(url, jobId, company, NOW);
+}
+
+function indexColumns(table: string, name: string): string[] {
+  return (
+    db!.prepare(`PRAGMA index_info("${name}")`).all() as Array<{
+      seqno: number;
+      name: string;
+    }>
+  )
+    .sort((left, right) => left.seqno - right.seqno)
+    .map((row) => row.name);
+}
+
+describe("schema-v24 Contact and contact-research references", () => {
+  it("recovers stable nullable reference tables with restrictive FKs", () => {
+    db = createDatabase();
+
+    expect(tableColumnSet(db, "contacts")).toContain("job_id");
+    expect(tableColumnSet(db, "contacts")).not.toContain("job_url");
+    expect(tableColumnSet(db, "contact_research_tasks")).toContain(
+      "job_id",
+    );
+    expect(
+      tableColumnSet(db, "contact_research_tasks"),
+    ).not.toContain("job_url");
+    expect(indexColumns("contacts", "idx_contacts_lookup")).toEqual([
+      "tenant_id",
+      "employer",
+      "job_id",
+    ]);
+    expect(
+      indexColumns(
+        "contact_research_tasks",
+        "idx_contact_research_tasks_lookup",
+      ),
+    ).toEqual(["tenant_id", "employer", "job_id"]);
+    for (const table of ["contacts", "contact_research_tasks"]) {
+      const actions = new Set(
+        (
+          db
+            .prepare(`PRAGMA foreign_key_list("${table}")`)
+            .all() as Array<{ on_delete: string }>
+        ).map((row) => row.on_delete),
+      );
+      expect(actions).toEqual(new Set(["RESTRICT"]));
+    }
+  });
+
+  it("fails closed when a v24 stamp has legacy contact tables", () => {
+    db = createDatabase(true, 23);
+    db.pragma("user_version = 24");
+
+    expect(() => ensureContactTables(db!)).toThrow(
+      "Schema v24 requires stable contacts.job_id references.",
+    );
+  });
+
+  it("stores UUID-shaped URL inputs URL-first while projecting URLs", () => {
+    db = createDatabase();
+    insertJob(UUID_SHAPED_URL, TARGET_JOB_ID);
+    insertJob(
+      "https://careers.example.test/uuid-id-owner",
+      UUID_SHAPED_URL,
+    );
+
+    const contact = createContact(db, {
+      employer: "ExampleCo",
+      jobId: UUID_SHAPED_URL,
+      role: "recruiter",
+      attributes: [{ kind: "name", value: "Private Person" }],
+    });
+    const task = createQueuedResearchTask(db, {
+      taskId: "task:uuid-url",
+      employer: "ExampleCo",
+      jobId: UUID_SHAPED_URL,
+    });
+
+    expect(contact.jobId).toBe(UUID_SHAPED_URL);
+    expect(task.jobId).toBe(UUID_SHAPED_URL);
+    expect(
+      db
+        .prepare("SELECT job_id FROM contacts")
+        .get(),
+    ).toEqual({ job_id: TARGET_JOB_ID });
+    expect(
+      db
+        .prepare("SELECT job_id FROM contact_research_tasks")
+        .get(),
+    ).toEqual({ job_id: TARGET_JOB_ID });
+    const payloads = (
+      db
+        .prepare(
+          "SELECT payload_json FROM job_events ORDER BY event_id",
+        )
+        .all() as Array<{ payload_json: string }>
+    ).map((row) => JSON.parse(row.payload_json) as {
+      jobId?: string;
+    });
+    expect(
+      payloads.filter((payload) => payload.jobId).map(
+        (payload) => payload.jobId,
+      ),
+    ).toEqual([UUID_SHAPED_URL, UUID_SHAPED_URL]);
+
+    const updated = updateContact(db, contact.contactId, {
+      jobId: "https://careers.example.test/uuid-id-owner",
+    });
+    expect(updated.jobId).toBe(
+      "https://careers.example.test/uuid-id-owner",
+    );
+    expect(
+      db
+        .prepare("SELECT job_id FROM contacts")
+        .get(),
+    ).toEqual({ job_id: UUID_SHAPED_URL });
+  });
+
+  it("promotes a research candidate into a stable linked Contact", () => {
+    db = createDatabase();
+    const jobUrl = "https://careers.example.test/research";
+    insertJob(jobUrl, TARGET_JOB_ID);
+    createQueuedResearchTask(db, {
+      taskId: "task:confirm",
+      employer: "ExampleCo",
+      jobId: jobUrl,
+    });
+    db.prepare(
+      `INSERT INTO contact_candidates (
+         tenant_id, candidate_id, task_id, role, attributes_json,
+         source_kind, source_ref, capture_method, confidence,
+         status, proposed_at
+       ) VALUES (
+         'local', 'candidate:confirm', 'task:confirm', 'recruiter', ?,
+         'public_web_page', 'https://example.test/team',
+         'llm_assisted', 0.8, 'needs_review', ?
+       )`,
+    ).run(
+      JSON.stringify([
+        {
+          attributeId: "attribute:confirm",
+          kind: "name",
+          value: "Private Person",
+          provenance: {
+            sourceKind: "public_web_page",
+            sourceRef: "https://example.test/team",
+            captureMethod: "llm_assisted",
+            capturedAt: NOW,
+            confidence: 0.8,
+            userConfirmed: false,
+          },
+        },
+      ]),
+      NOW,
+    );
+
+    const confirmed = confirmContactCandidate(
+      db,
+      "task:confirm",
+      "candidate:confirm",
+    );
+
+    expect(confirmed.contact.jobId).toBe(jobUrl);
+    expect(
+      db
+        .prepare(
+          "SELECT job_id FROM contacts WHERE contact_id = ?",
+        )
+        .get(confirmed.contact.contactId),
+    ).toEqual({ job_id: TARGET_JOB_ID });
+    expect(confirmed.task.status).toBe("completed");
+  });
+
+  it("fails closed when a linked URL has no stable Job identity", () => {
+    db = createDatabase();
+
+    expect(() =>
+      createContact(db!, {
+        employer: "ExampleCo",
+        jobId: "https://missing.example.test/job",
+        role: "other",
+        attributes: [],
+      }),
+    ).toThrow("No stable Job identity exists");
+    expect(() =>
+      createQueuedResearchTask(db!, {
+        taskId: "task:missing",
+        employer: "ExampleCo",
+        jobId: "https://missing.example.test/job",
+      }),
+    ).toThrow("No stable Job identity exists");
+  });
+
+  it("detaches employer records and purges job-only records with FKs off", () => {
+    db = createDatabase(false);
+    const targetUrl = "https://careers.example.test/delete";
+    const otherUrl = "https://careers.example.test/keep";
+    insertJob(targetUrl, TARGET_JOB_ID);
+    insertJob(otherUrl, OTHER_JOB_ID, "OtherCo");
+    expect(jobReferenceColumn(db, "contacts")).toBe("job_id");
+
+    db.exec(`
+      INSERT INTO contacts (
+        tenant_id, contact_id, employer, job_id, role,
+        created_at, updated_at
+      ) VALUES
+        ('local', 'contact:employer', 'ExampleCo', '${TARGET_JOB_ID}', 'other', '${NOW}', '${NOW}'),
+        ('local', 'contact:job-only', NULL, '${TARGET_JOB_ID}', 'other', '${NOW}', '${NOW}'),
+        ('local', 'contact:other', 'OtherCo', '${OTHER_JOB_ID}', 'other', '${NOW}', '${NOW}');
+      INSERT INTO contact_attributes (
+        tenant_id, attribute_id, contact_id, attribute_kind,
+        value_json, source_kind, source_ref, capture_method,
+        confidence, user_confirmed, recorded_at
+      ) VALUES
+        ('local', 'attribute:employer', 'contact:employer', 'name', '"Employer Person"', 'user_entered', 'user_entered', 'manual', 1, 1, '${NOW}'),
+        ('local', 'attribute:job-only', 'contact:job-only', 'name', '"Job Person"', 'user_entered', 'user_entered', 'manual', 1, 1, '${NOW}'),
+        ('local', 'attribute:other', 'contact:other', 'name', '"Other Person"', 'user_entered', 'user_entered', 'manual', 1, 1, '${NOW}');
+      INSERT INTO contact_research_tasks (
+        tenant_id, task_id, employer, job_id, status, updated_at
+      ) VALUES
+        ('local', 'task:employer', 'ExampleCo', '${TARGET_JOB_ID}', 'queued', '${NOW}'),
+        ('local', 'task:job-only', NULL, '${TARGET_JOB_ID}', 'queued', '${NOW}'),
+        ('local', 'task:other', 'OtherCo', '${OTHER_JOB_ID}', 'queued', '${NOW}');
+      INSERT INTO contact_candidates (
+        tenant_id, candidate_id, task_id, role, attributes_json,
+        source_kind, source_ref, capture_method, confidence,
+        status, proposed_at
+      ) VALUES
+        ('local', 'candidate:employer', 'task:employer', 'other', '[]', 'user_entered', 'user_entered', 'manual', 1, 'needs_review', '${NOW}'),
+        ('local', 'candidate:job-only', 'task:job-only', 'other', '[]', 'user_entered', 'user_entered', 'manual', 1, 'needs_review', '${NOW}'),
+        ('local', 'candidate:other', 'task:other', 'other', '[]', 'user_entered', 'user_entered', 'manual', 1, 'needs_review', '${NOW}');
+    `);
+    refreshProjections(db);
+
+    expect(permanentlyDeleteJob(db, targetUrl)).toEqual({
+      ok: true,
+      count: 1,
+      jobKeys: [targetUrl],
+    });
+
+    expect(
+      db
+        .prepare(
+          "SELECT contact_id, job_id FROM contacts ORDER BY contact_id",
+        )
+        .all(),
+    ).toEqual([
+      { contact_id: "contact:employer", job_id: null },
+      { contact_id: "contact:other", job_id: OTHER_JOB_ID },
+    ]);
+    expect(
+      db
+        .prepare(
+          "SELECT attribute_id FROM contact_attributes ORDER BY attribute_id",
+        )
+        .all(),
+    ).toEqual([
+      { attribute_id: "attribute:employer" },
+      { attribute_id: "attribute:other" },
+    ]);
+    expect(
+      db
+        .prepare(
+          "SELECT task_id, job_id FROM contact_research_tasks ORDER BY task_id",
+        )
+        .all(),
+    ).toEqual([
+      { task_id: "task:employer", job_id: null },
+      { task_id: "task:other", job_id: OTHER_JOB_ID },
+    ]);
+    expect(
+      db
+        .prepare(
+          "SELECT candidate_id FROM contact_candidates ORDER BY candidate_id",
+        )
+        .all(),
+    ).toEqual([
+      { candidate_id: "candidate:employer" },
+      { candidate_id: "candidate:other" },
+    ]);
+    expect(
+      db.prepare("SELECT COUNT(*) AS c FROM jobs WHERE url = ?").get(
+        targetUrl,
+      ),
+    ).toEqual({ c: 0 });
+
+    refreshProjections(db);
+    const projected = db
+      .prepare(
+        "SELECT contact_id, job_id FROM contact_projections ORDER BY contact_id",
+      )
+      .all();
+    expect(projected).toEqual([
+      { contact_id: "contact:employer", job_id: null },
+      { contact_id: "contact:other", job_id: otherUrl },
+    ]);
+  });
+});

--- a/apps/api/test/qa-seed.ts
+++ b/apps/api/test/qa-seed.ts
@@ -6,6 +6,10 @@ import { pathToFileURL } from "node:url";
 import Database from "better-sqlite3";
 
 import { ensureApplicationFeedbackTables } from "../src/application-feedback.js";
+import {
+  jobReferenceColumn,
+  jobReferenceForUrl,
+} from "../src/db.js";
 import { ensureDiscoveryControlTables } from "../src/discovery-controls.js";
 import { ensureOutreachTables } from "../src/outreach.js";
 import { writeProfileConfig } from "../src/profile-store.js";
@@ -1606,15 +1610,21 @@ function seedResumeReviewDraft(db: Database.Database): void {
 }
 
 function seedContacts(db: Database.Database): void {
+  const referenceColumn = jobReferenceColumn(db, "contacts");
+  const jobReference = jobReferenceForUrl(
+    db,
+    "contacts",
+    QA_PLATFORM_JOB_URL,
+  );
   const insertContact = db.prepare(
     `INSERT INTO contacts (
-      tenant_id, contact_id, employer, job_url, role, created_at, updated_at
+      tenant_id, contact_id, employer, ${referenceColumn}, role, created_at, updated_at
     ) VALUES ('local', ?, ?, ?, ?, ?, ?)`,
   );
   insertContact.run(
     "qa-contact-hiring-manager",
     "GitLab",
-    QA_PLATFORM_JOB_URL,
+    jobReference,
     "hiring_manager",
     QA_NOW,
     QA_NOW,
@@ -1622,7 +1632,7 @@ function seedContacts(db: Database.Database): void {
   insertContact.run(
     "qa-contact-recruiter",
     "GitLab",
-    QA_PLATFORM_JOB_URL,
+    jobReference,
     "recruiter",
     QA_NOW,
     QA_NOW,

--- a/apps/api/test/schema-version-guard.test.ts
+++ b/apps/api/test/schema-version-guard.test.ts
@@ -63,7 +63,7 @@ describe("schema version guard at DB open", () => {
   });
 
   it("opens the worker-owned schema-v14 artifact registry", () => {
-    expect(SUPPORTED_SCHEMA_VERSION).toBe(23);
+    expect(SUPPORTED_SCHEMA_VERSION).toBe(24);
     const { dbPath, cleanup } = makeDbWithUserVersion(14);
     try {
       openDatabase(dbPath).close();

--- a/apps/web/e2e/tests/outreach.spec.ts
+++ b/apps/web/e2e/tests/outreach.spec.ts
@@ -30,6 +30,40 @@ function tableExists(db: Database.Database, table: string): boolean {
   return Boolean(row);
 }
 
+function referenceColumn(
+  db: Database.Database,
+  table: string,
+  legacyColumn: "job_url" | "job_key",
+): "job_id" | "job_url" | "job_key" {
+  const columns = new Set(
+    (
+      db.prepare(`PRAGMA table_info(${table})`).all() as Array<{
+        name: string;
+      }>
+    ).map((row) => row.name),
+  );
+  return columns.has("job_id") ? "job_id" : legacyColumn;
+}
+
+function referenceForJobUrl(
+  db: Database.Database,
+  column: "job_id" | "job_url" | "job_key",
+  jobUrl: string,
+): string {
+  if (column !== "job_id") {
+    return jobUrl;
+  }
+  const row = db
+    .prepare(
+      "SELECT job_id FROM jobs WHERE tenant_id = 'local' AND url = ?",
+    )
+    .get(jobUrl) as { job_id?: string } | undefined;
+  if (!row?.job_id) {
+    throw new Error(`Missing stable Job identity for ${jobUrl}`);
+  }
+  return row.job_id;
+}
+
 function ensureColumn(
   db: Database.Database,
   table: string,
@@ -47,17 +81,29 @@ function ensureColumn(
 }
 
 function ensureOutreachSeedTables(db: Database.Database): void {
+  const schemaVersion = Number(
+    db.pragma("user_version", { simple: true }),
+  );
+  const stableContactReferences = schemaVersion >= 24;
+  const contactReference = stableContactReferences
+    ? "job_id"
+    : "job_url";
+  const contactForeignKey = stableContactReferences
+    ? `, FOREIGN KEY (tenant_id, job_id)
+         REFERENCES jobs(tenant_id, job_id) ON DELETE RESTRICT`
+    : "";
   db.exec(`
     CREATE TABLE IF NOT EXISTS contacts (
       tenant_id   TEXT NOT NULL DEFAULT 'local',
       contact_id  TEXT NOT NULL,
       employer    TEXT,
-      job_url     TEXT,
+      ${contactReference} TEXT,
       role        TEXT NOT NULL DEFAULT 'other',
       created_at  TEXT NOT NULL,
       updated_at  TEXT NOT NULL,
       deleted_at  TEXT,
       PRIMARY KEY (tenant_id, contact_id)
+      ${contactForeignKey}
     );
     CREATE TABLE IF NOT EXISTS contact_attributes (
       tenant_id      TEXT NOT NULL DEFAULT 'local',
@@ -77,7 +123,7 @@ function ensureOutreachSeedTables(db: Database.Database): void {
       tenant_id            TEXT NOT NULL DEFAULT 'local',
       task_id              TEXT NOT NULL,
       employer             TEXT,
-      job_url              TEXT,
+      ${contactReference}  TEXT,
       status               TEXT NOT NULL DEFAULT 'queued',
       source_attempts_json TEXT NOT NULL DEFAULT '[]',
       started_at           TEXT,
@@ -87,6 +133,7 @@ function ensureOutreachSeedTables(db: Database.Database): void {
       failed_at            TEXT,
       error_class          TEXT,
       PRIMARY KEY (tenant_id, task_id)
+      ${contactForeignKey}
     );
     CREATE TABLE IF NOT EXISTS contact_candidates (
       tenant_id            TEXT NOT NULL DEFAULT 'local',
@@ -225,12 +272,32 @@ function seedOutreachPlanner(dbPath: string): void {
   try {
     ensureOutreachSeedTables(db);
     resetOutreachSeed(db);
+    const contactReference = referenceColumn(
+      db,
+      "contacts",
+      "job_url",
+    );
+    const researchReference = referenceColumn(
+      db,
+      "contact_research_tasks",
+      "job_url",
+    );
+    const contactJobReference = referenceForJobUrl(
+      db,
+      contactReference,
+      JOB_URL,
+    );
+    const researchJobReference = referenceForJobUrl(
+      db,
+      researchReference,
+      JOB_URL,
+    );
 
     db.prepare(
       `INSERT INTO contacts (
-         tenant_id, contact_id, employer, job_url, role, created_at, updated_at, deleted_at
+         tenant_id, contact_id, employer, ${contactReference}, role, created_at, updated_at, deleted_at
        ) VALUES ('local', ?, 'GitLab', ?, 'recruiter', ?, ?, NULL)`,
-    ).run(CONTACT_ID, JOB_URL, NOW, NOW);
+    ).run(CONTACT_ID, contactJobReference, NOW, NOW);
     const insertAttribute = db.prepare(
       `INSERT INTO contact_attributes (
          tenant_id, attribute_id, contact_id, attribute_kind, value_json,
@@ -261,12 +328,12 @@ function seedOutreachPlanner(dbPath: string): void {
 
     db.prepare(
       `INSERT INTO contact_research_tasks (
-         tenant_id, task_id, employer, job_url, status, source_attempts_json,
+         tenant_id, task_id, employer, ${researchReference}, status, source_attempts_json,
          started_at, updated_at, needs_review_at, completed_at, failed_at, error_class
        ) VALUES ('local', ?, 'GitLab', ?, 'needs_review', ?, ?, ?, ?, NULL, NULL, NULL)`,
     ).run(
       TASK_ID,
-      JOB_URL,
+      researchJobReference,
       JSON.stringify([
         {
           sourceKind: "public_web_page",
@@ -453,13 +520,23 @@ function seedOutreachPlanner(dbPath: string): void {
          tenant_id, send_log_id, thread_id, draft_id, channel, sent_at, logged_at
        ) VALUES ('local', 'send-log-e2e-existing', ?, 'draft-e2e-approved', 'email', '2026-07-05', ?)`,
     ).run(CONTACT_THREAD_ID, NOW);
+    const outcomeReference = referenceColumn(
+      db,
+      "application_outcomes",
+      "job_key",
+    );
+    const outcomeJobReference = referenceForJobUrl(
+      db,
+      outcomeReference,
+      JOB_URL,
+    );
     db.prepare(
       `INSERT INTO application_outcomes (
-         tenant_id, outcome_id, job_key, kind, source, note, occurred_at, recorded_at,
+         tenant_id, outcome_id, ${outcomeReference}, kind, source, note, occurred_at, recorded_at,
          suggestion_id, evidence_id, interview_prep_generation, created_by
        ) VALUES ('local', 'outcome-e2e-outreach', ?, 'applied_confirmation', 'e2e_seed',
          NULL, '2026-07-01T12:00:00.000Z', ?, NULL, NULL, NULL, 'e2e')`,
-    ).run(JOB_URL, NOW);
+    ).run(outcomeJobReference, NOW);
 
     // This fixture writes canonical rows directly. Clear the derived read
     // models so the next public API read rematerializes every outreach surface

--- a/workers/automation/src/jobctrl/database.py
+++ b/workers/automation/src/jobctrl/database.py
@@ -86,7 +86,12 @@ from jobctrl.config import DB_PATH, DEFAULTS, migrate_legacy_job_tables
 # v23 (repeat-application references): evidence-bound override and audit
 # ownership moves to stable target/prior JobIds without rewriting the immutable
 # URL-shaped evidence snapshot or its fingerprint.
-SCHEMA_VERSION = 23
+# v24 (contact and contact-research references): optional application links on
+# Contact and ContactResearchTask move to tenant-scoped stable JobIds. Contact
+# facts, research candidates, and the URL-shaped public/read-model boundary stay
+# unchanged. Job deletion is restricted so the explicit permanent-delete path
+# can detach employer-linked records instead of silently erasing them.
+SCHEMA_VERSION = 24
 
 
 class IncompatibleSchemaVersionError(RuntimeError):
@@ -240,6 +245,7 @@ def _schema_migrations() -> tuple[
         (21, ensure_application_outcome_references_v21),
         (22, ensure_application_feedback_candidate_references_v22),
         (23, ensure_repeat_application_references_v23),
+        (24, ensure_contact_research_references_v24),
     )
 
 
@@ -464,6 +470,74 @@ def ensure_projection_tables_in_db(conn: sqlite3.Connection | None = None) -> li
     return ensure_projection_tables(conn)
 
 
+def _create_contacts_table_v24(
+    conn: sqlite3.Connection,
+    *,
+    table: str,
+    stable_reference: bool,
+) -> None:
+    reference_column = "job_id" if stable_reference else "job_url"
+    foreign_key = (
+        """,
+            FOREIGN KEY (tenant_id, job_id)
+                REFERENCES jobs(tenant_id, job_id) ON DELETE RESTRICT"""
+        if stable_reference
+        else ""
+    )
+    conn.execute(
+        f"""
+        CREATE TABLE "{table}" (
+            tenant_id           TEXT NOT NULL DEFAULT 'local',
+            contact_id          TEXT NOT NULL,
+            employer            TEXT,
+            {reference_column}  TEXT,
+            role                TEXT NOT NULL DEFAULT 'other',
+            created_at          TEXT NOT NULL,
+            updated_at          TEXT NOT NULL,
+            deleted_at          TEXT,
+            PRIMARY KEY (tenant_id, contact_id)
+            {foreign_key}
+        )
+        """
+    )
+
+
+def _create_contact_research_tasks_table_v24(
+    conn: sqlite3.Connection,
+    *,
+    table: str,
+    stable_reference: bool,
+) -> None:
+    reference_column = "job_id" if stable_reference else "job_url"
+    foreign_key = (
+        """,
+            FOREIGN KEY (tenant_id, job_id)
+                REFERENCES jobs(tenant_id, job_id) ON DELETE RESTRICT"""
+        if stable_reference
+        else ""
+    )
+    conn.execute(
+        f"""
+        CREATE TABLE "{table}" (
+            tenant_id            TEXT NOT NULL DEFAULT 'local',
+            task_id              TEXT NOT NULL,
+            employer             TEXT,
+            {reference_column}   TEXT,
+            status               TEXT NOT NULL DEFAULT 'queued',
+            source_attempts_json TEXT NOT NULL DEFAULT '[]',
+            started_at           TEXT,
+            updated_at           TEXT NOT NULL,
+            needs_review_at      TEXT,
+            completed_at         TEXT,
+            failed_at            TEXT,
+            error_class          TEXT,
+            PRIMARY KEY (tenant_id, task_id)
+            {foreign_key}
+        )
+        """
+    )
+
+
 def ensure_contact_tables(conn: sqlite3.Connection | None = None) -> list[str]:
     """Create the Contact & Outreach (ninth bounded context) canonical tables.
 
@@ -482,19 +556,16 @@ def ensure_contact_tables(conn: sqlite3.Connection | None = None) -> list[str]:
     if conn is None:
         conn = get_connection()
 
-    conn.execute("""
-        CREATE TABLE IF NOT EXISTS contacts (
-            tenant_id           TEXT NOT NULL DEFAULT 'local',
-            contact_id          TEXT NOT NULL,
-            employer            TEXT,
-            job_url             TEXT,
-            role                TEXT NOT NULL DEFAULT 'other',
-            created_at          TEXT NOT NULL,
-            updated_at          TEXT NOT NULL,
-            deleted_at          TEXT,
-            PRIMARY KEY (tenant_id, contact_id)
+    current_version = _assert_schema_version_supported(conn)
+    stable_contact_references = (
+        current_version >= _CONTACT_RESEARCH_REFERENCE_SCHEMA_VERSION
+    )
+    if not _table_columns(conn, "contacts"):
+        _create_contacts_table_v24(
+            conn,
+            table="contacts",
+            stable_reference=stable_contact_references,
         )
-    """)
     conn.execute("""
         CREATE TABLE IF NOT EXISTS contact_attributes (
             tenant_id           TEXT NOT NULL DEFAULT 'local',
@@ -511,23 +582,12 @@ def ensure_contact_tables(conn: sqlite3.Connection | None = None) -> list[str]:
             PRIMARY KEY (tenant_id, attribute_id)
         )
     """)
-    conn.execute("""
-        CREATE TABLE IF NOT EXISTS contact_research_tasks (
-            tenant_id           TEXT NOT NULL DEFAULT 'local',
-            task_id             TEXT NOT NULL,
-            employer            TEXT,
-            job_url             TEXT,
-            status              TEXT NOT NULL DEFAULT 'queued',
-            source_attempts_json TEXT NOT NULL DEFAULT '[]',
-            started_at          TEXT,
-            updated_at          TEXT NOT NULL,
-            needs_review_at     TEXT,
-            completed_at        TEXT,
-            failed_at           TEXT,
-            error_class         TEXT,
-            PRIMARY KEY (tenant_id, task_id)
+    if not _table_columns(conn, "contact_research_tasks"):
+        _create_contact_research_tasks_table_v24(
+            conn,
+            table="contact_research_tasks",
+            stable_reference=stable_contact_references,
         )
-    """)
     conn.execute("""
         CREATE TABLE IF NOT EXISTS contact_candidates (
             tenant_id           TEXT NOT NULL DEFAULT 'local',
@@ -590,10 +650,25 @@ def ensure_contact_tables(conn: sqlite3.Connection | None = None) -> list[str]:
             PRIMARY KEY (tenant_id, send_log_id)
         )
     """)
-    conn.execute("""
-        CREATE INDEX IF NOT EXISTS idx_contacts_lookup
-        ON contacts(tenant_id, employer, job_url)
-    """)
+    if stable_contact_references:
+        if (
+            "job_id" not in _table_columns(conn, "contacts")
+            or "job_url" in _table_columns(conn, "contacts")
+            or "job_id"
+            not in _table_columns(conn, "contact_research_tasks")
+            or "job_url"
+            in _table_columns(conn, "contact_research_tasks")
+        ):
+            raise RuntimeError(
+                "Schema v24 requires stable contact and "
+                "contact-research JobId references."
+            )
+        _create_contact_reference_indexes_v24(conn)
+    else:
+        conn.execute("""
+            CREATE INDEX IF NOT EXISTS idx_contacts_lookup
+            ON contacts(tenant_id, employer, job_url)
+        """)
     conn.execute("""
         CREATE INDEX IF NOT EXISTS idx_contact_attributes_contact
         ON contact_attributes(tenant_id, contact_id)
@@ -607,6 +682,14 @@ def ensure_contact_tables(conn: sqlite3.Connection | None = None) -> list[str]:
     if "source_attempts_json" not in research_columns:
         conn.execute(
             "ALTER TABLE contact_research_tasks ADD COLUMN source_attempts_json TEXT NOT NULL DEFAULT '[]'"
+        )
+    if (
+        stable_contact_references
+        and not _has_contact_research_reference_schema_v24(conn)
+    ):
+        raise RuntimeError(
+            "Schema v24 requires stable contact and "
+            "contact-research JobId references."
         )
     conn.execute("""
         CREATE INDEX IF NOT EXISTS idx_contact_candidates_task
@@ -4706,6 +4789,15 @@ def _reassign_discovery_identity_references(
             tenant_id=tenant_id,
             losing_job_id=losing_job_id,
             surviving_job_id=surviving_job_id,
+        )
+    if _has_contact_research_reference_schema_v24(conn):
+        _reassign_contact_research_references_v24(
+            conn,
+            tenant_id=tenant_id,
+            losing_job_id=losing_job_id,
+            surviving_job_id=surviving_job_id,
+            losing_job_url=losing_job_url,
+            surviving_job_url=surviving_job_url,
         )
     if _has_scoring_reference_schema_v12(conn):
         _reassign_scoring_references_v12(
@@ -14386,6 +14478,424 @@ def _reassign_repeat_application_references_v23(
         (surviving_job_id, tenant_id, losing_job_id),
     )
     _verify_repeat_application_references_v23(
+        conn,
+        expected_counts=expected_counts,
+    )
+
+
+_CONTACT_RESEARCH_REFERENCE_SCHEMA_VERSION = 24
+_CONTACT_RESEARCH_REFERENCE_TABLES = (
+    "contacts",
+    "contact_research_tasks",
+)
+_CONTACT_RESEARCH_HISTORY_TABLES = (
+    "contacts",
+    "contact_attributes",
+    "contact_research_tasks",
+    "contact_candidates",
+)
+
+
+def _has_composite_job_id_foreign_key_action(
+    conn: sqlite3.Connection,
+    *,
+    table: str,
+    reference_column: str,
+    on_delete: str,
+) -> bool:
+    groups: dict[int, set[tuple[str, str]]] = {}
+    actions: dict[int, str] = {}
+    for row in conn.execute(
+        f'PRAGMA foreign_key_list("{table}")'
+    ).fetchall():
+        if str(row[2]) != "jobs":
+            continue
+        foreign_key_id = int(row[0])
+        groups.setdefault(foreign_key_id, set()).add(
+            (str(row[3]), str(row[4]))
+        )
+        actions[foreign_key_id] = str(row[6]).upper()
+    expected = {
+        ("tenant_id", "tenant_id"),
+        (reference_column, "job_id"),
+    }
+    return any(
+        columns == expected
+        and actions.get(foreign_key_id) == on_delete.upper()
+        for foreign_key_id, columns in groups.items()
+    )
+
+
+def _has_contact_research_reference_schema_v24(
+    conn: sqlite3.Connection,
+) -> bool:
+    contacts = "contacts"
+    research = "contact_research_tasks"
+    return (
+        "job_id" in _table_columns(conn, contacts)
+        and "job_url" not in _table_columns(conn, contacts)
+        and _primary_key_columns(conn, contacts)
+        == ("tenant_id", "contact_id")
+        and _has_composite_job_id_foreign_key_action(
+            conn,
+            table=contacts,
+            reference_column="job_id",
+            on_delete="RESTRICT",
+        )
+        and _has_index(
+            conn,
+            contacts,
+            "idx_contacts_lookup",
+            ("tenant_id", "employer", "job_id"),
+            unique=False,
+        )
+        and "job_id" in _table_columns(conn, research)
+        and "job_url" not in _table_columns(conn, research)
+        and _primary_key_columns(conn, research)
+        == ("tenant_id", "task_id")
+        and _has_composite_job_id_foreign_key_action(
+            conn,
+            table=research,
+            reference_column="job_id",
+            on_delete="RESTRICT",
+        )
+        and _has_index(
+            conn,
+            research,
+            "idx_contact_research_tasks_lookup",
+            ("tenant_id", "employer", "job_id"),
+            unique=False,
+        )
+    )
+
+
+def _canonical_contact_rows_v24(
+    conn: sqlite3.Connection,
+) -> list[tuple[Any, ...]]:
+    reference_column = _legacy_or_stable_reference_column(
+        conn,
+        "contacts",
+        stable="job_id",
+        legacy="job_url",
+    )
+    rows = conn.execute(
+        f"""
+        SELECT tenant_id, contact_id, employer, {reference_column},
+               role, created_at, updated_at, deleted_at
+        FROM contacts
+        ORDER BY tenant_id, contact_id
+        """
+    ).fetchall()
+    canonical: list[tuple[Any, ...]] = []
+    for row in rows:
+        values = tuple(row)
+        raw_reference = values[3]
+        stable_job_id: str | None = None
+        if raw_reference is not None:
+            stable_job_id = _resolve_job_reference_value(
+                conn,
+                tenant_id=str(values[0]),
+                reference=str(raw_reference),
+                legacy_url=reference_column == "job_url",
+            )
+            if stable_job_id is None:
+                raise RuntimeError(
+                    "contact reference migration could not resolve "
+                    f"contacts.{reference_column}={raw_reference!r} "
+                    f"for tenant {values[0]!r}"
+                )
+            _validate_job_uuid(stable_job_id)
+        canonical.append(
+            (
+                values[0],
+                values[1],
+                values[2],
+                stable_job_id,
+                values[4],
+                values[5],
+                values[6],
+                values[7],
+            )
+        )
+    return canonical
+
+
+def _canonical_contact_research_rows_v24(
+    conn: sqlite3.Connection,
+) -> list[tuple[Any, ...]]:
+    reference_column = _legacy_or_stable_reference_column(
+        conn,
+        "contact_research_tasks",
+        stable="job_id",
+        legacy="job_url",
+    )
+    rows = conn.execute(
+        f"""
+        SELECT tenant_id, task_id, employer, {reference_column}, status,
+               source_attempts_json, started_at, updated_at,
+               needs_review_at, completed_at, failed_at, error_class
+        FROM contact_research_tasks
+        ORDER BY tenant_id, task_id
+        """
+    ).fetchall()
+    canonical: list[tuple[Any, ...]] = []
+    for row in rows:
+        values = tuple(row)
+        raw_reference = values[3]
+        stable_job_id: str | None = None
+        if raw_reference is not None:
+            stable_job_id = _resolve_job_reference_value(
+                conn,
+                tenant_id=str(values[0]),
+                reference=str(raw_reference),
+                legacy_url=reference_column == "job_url",
+            )
+            if stable_job_id is None:
+                raise RuntimeError(
+                    "contact-research reference migration could not resolve "
+                    "contact_research_tasks."
+                    f"{reference_column}={raw_reference!r} "
+                    f"for tenant {values[0]!r}"
+                )
+            _validate_job_uuid(stable_job_id)
+        canonical.append(
+            (
+                values[0],
+                values[1],
+                values[2],
+                stable_job_id,
+                *values[4:],
+            )
+        )
+    return canonical
+
+
+def _create_contact_reference_indexes_v24(
+    conn: sqlite3.Connection,
+) -> None:
+    indexes = (
+        (
+            "contacts",
+            "idx_contacts_lookup",
+            ("tenant_id", "employer", "job_id"),
+            """
+            CREATE INDEX idx_contacts_lookup
+            ON contacts(tenant_id, employer, job_id)
+            """,
+        ),
+        (
+            "contact_research_tasks",
+            "idx_contact_research_tasks_lookup",
+            ("tenant_id", "employer", "job_id"),
+            """
+            CREATE INDEX idx_contact_research_tasks_lookup
+            ON contact_research_tasks(tenant_id, employer, job_id)
+            """,
+        ),
+    )
+    for table, name, columns, create_sql in indexes:
+        if _has_index(
+            conn,
+            table,
+            name,
+            columns,
+            unique=False,
+        ):
+            continue
+        conn.execute(f'DROP INDEX IF EXISTS "{name}"')
+        conn.execute(create_sql)
+
+
+def ensure_contact_research_references_v24(
+    conn: sqlite3.Connection | None = None,
+) -> list[str]:
+    """Move optional Contact and research-task links to stable JobIds."""
+    if conn is None:
+        conn = get_connection()
+    current = _assert_schema_version_supported(conn)
+    if current >= _CONTACT_RESEARCH_REFERENCE_SCHEMA_VERSION:
+        return list(_CONTACT_RESEARCH_REFERENCE_TABLES)
+    if current != _REPEAT_APPLICATION_REFERENCE_SCHEMA_VERSION:
+        raise RuntimeError(
+            "contact reference migration requires schema v23; "
+            f"found v{current}"
+        )
+
+    expected_counts = {
+        table: int(
+            conn.execute(
+                f'SELECT COUNT(*) FROM "{table}"'
+            ).fetchone()[0]
+        )
+        for table in _CONTACT_RESEARCH_HISTORY_TABLES
+    }
+    conn.execute("SAVEPOINT contact_research_references_v24")
+    try:
+        contact_rows = _canonical_contact_rows_v24(conn)
+        research_rows = _canonical_contact_research_rows_v24(conn)
+
+        conn.execute("DROP TABLE IF EXISTS contacts_v24")
+        _create_contacts_table_v24(
+            conn,
+            table="contacts_v24",
+            stable_reference=True,
+        )
+        conn.executemany(
+            """
+            INSERT INTO contacts_v24 (
+                tenant_id, contact_id, employer, job_id, role,
+                created_at, updated_at, deleted_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            contact_rows,
+        )
+
+        conn.execute(
+            "DROP TABLE IF EXISTS contact_research_tasks_v24"
+        )
+        _create_contact_research_tasks_table_v24(
+            conn,
+            table="contact_research_tasks_v24",
+            stable_reference=True,
+        )
+        conn.executemany(
+            """
+            INSERT INTO contact_research_tasks_v24 (
+                tenant_id, task_id, employer, job_id, status,
+                source_attempts_json, started_at, updated_at,
+                needs_review_at, completed_at, failed_at, error_class
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            research_rows,
+        )
+
+        conn.execute('DROP TABLE "contacts"')
+        conn.execute(
+            'ALTER TABLE "contacts_v24" RENAME TO "contacts"'
+        )
+        conn.execute('DROP TABLE "contact_research_tasks"')
+        conn.execute(
+            'ALTER TABLE "contact_research_tasks_v24" '
+            'RENAME TO "contact_research_tasks"'
+        )
+        _create_contact_reference_indexes_v24(conn)
+        _verify_contact_research_references_v24(
+            conn,
+            expected_counts=expected_counts,
+        )
+        conn.execute(
+            f"PRAGMA user_version = "
+            f"{_CONTACT_RESEARCH_REFERENCE_SCHEMA_VERSION}"
+        )
+        conn.execute("RELEASE SAVEPOINT contact_research_references_v24")
+    except BaseException:
+        conn.execute(
+            "ROLLBACK TO SAVEPOINT contact_research_references_v24"
+        )
+        conn.execute(
+            "RELEASE SAVEPOINT contact_research_references_v24"
+        )
+        raise
+    return list(_CONTACT_RESEARCH_REFERENCE_TABLES)
+
+
+def _verify_contact_research_references_v24(
+    conn: sqlite3.Connection,
+    *,
+    expected_counts: dict[str, int],
+) -> None:
+    if not _has_contact_research_reference_schema_v24(conn):
+        raise RuntimeError(
+            "contact reference migration did not create the stable "
+            "reference schema"
+        )
+    for table, expected_count in expected_counts.items():
+        observed_count = int(
+            conn.execute(
+                f'SELECT COUNT(*) FROM "{table}"'
+            ).fetchone()[0]
+        )
+        if observed_count != expected_count:
+            raise RuntimeError(
+                "contact reference migration changed "
+                f"{table} row count: expected {expected_count}, "
+                f"found {observed_count}"
+            )
+    for table in _CONTACT_RESEARCH_REFERENCE_TABLES:
+        orphan = conn.execute(
+            f"""
+            SELECT source.job_id
+            FROM "{table}" AS source
+            LEFT JOIN jobs
+              ON jobs.tenant_id = source.tenant_id
+             AND jobs.job_id = source.job_id
+            WHERE source.job_id IS NOT NULL
+              AND jobs.job_id IS NULL
+            LIMIT 1
+            """
+        ).fetchone()
+        if orphan is not None:
+            raise RuntimeError(
+                "contact reference migration left an unresolved "
+                f"JobId in {table}.job_id"
+            )
+        for row in conn.execute(
+            f'SELECT DISTINCT job_id FROM "{table}" '
+            "WHERE job_id IS NOT NULL"
+        ).fetchall():
+            _validate_job_uuid(str(row[0]))
+    foreign_key_error = conn.execute(
+        "PRAGMA foreign_key_check"
+    ).fetchone()
+    if foreign_key_error is not None:
+        raise RuntimeError(
+            "contact reference migration found a foreign-key violation"
+        )
+
+
+def _reassign_contact_research_references_v24(
+    conn: sqlite3.Connection,
+    *,
+    tenant_id: str,
+    losing_job_id: str,
+    surviving_job_id: str,
+    losing_job_url: str,
+    surviving_job_url: str,
+) -> None:
+    if losing_job_id == surviving_job_id:
+        return
+    expected_counts = {
+        table: int(
+            conn.execute(
+                f'SELECT COUNT(*) FROM "{table}"'
+            ).fetchone()[0]
+        )
+        for table in _CONTACT_RESEARCH_HISTORY_TABLES
+    }
+    for table in _CONTACT_RESEARCH_REFERENCE_TABLES:
+        conn.execute(
+            f"""
+            UPDATE "{table}"
+            SET job_id = ?
+            WHERE tenant_id = ? AND job_id = ?
+            """,
+            (surviving_job_id, tenant_id, losing_job_id),
+        )
+    for projection in (
+        "contact_projections",
+        "contact_research_task_projections",
+    ):
+        if not _table_columns(conn, projection):
+            continue
+        conn.execute(
+            f"""
+            UPDATE "{projection}"
+            SET job_id = ?
+            WHERE tenant_id = ? AND job_id = ?
+            """,
+            (surviving_job_url, tenant_id, losing_job_url),
+        )
+    _verify_contact_research_references_v24(
         conn,
         expected_counts=expected_counts,
     )

--- a/workers/automation/src/jobctrl/infrastructure/contact/job_reference.py
+++ b/workers/automation/src/jobctrl/infrastructure/contact/job_reference.py
@@ -1,0 +1,114 @@
+"""Compatibility boundary for Contact-owned optional Job links.
+
+Schema v24 stores tenant-scoped stable ``JobId`` values while the Contact
+domain and public DTOs remain URL-shaped until the Phase-4 cutover. Resolution
+is deliberately URL-first so a UUID-shaped posting URL cannot bind to an
+unrelated row whose stable id happens to contain the same text.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+from jobctrl.domain.tenant import TenantId
+
+
+def contact_job_reference_column(
+    conn: sqlite3.Connection,
+    table: str,
+) -> str:
+    columns = {
+        str(row[1])
+        for row in conn.execute(
+            f'PRAGMA table_info("{table}")'
+        ).fetchall()
+    }
+    if "job_id" in columns:
+        return "job_id"
+    if "job_url" in columns:
+        return "job_url"
+    raise RuntimeError(f"{table} has no Job identity column")
+
+
+def physical_contact_job_reference(
+    conn: sqlite3.Connection,
+    *,
+    table: str,
+    tenant_id: TenantId,
+    public_reference: str | None,
+) -> str | None:
+    if public_reference is None:
+        return None
+    raw_reference = str(public_reference).strip()
+    if not raw_reference:
+        raise ValueError("job link must be non-empty")
+    if contact_job_reference_column(conn, table) == "job_url":
+        return raw_reference
+
+    tenant = str(tenant_id)
+    lookups = (
+        """
+        SELECT job_id
+        FROM jobs
+        WHERE tenant_id = ? AND url = ?
+        LIMIT 1
+        """,
+        """
+        SELECT aliases.job_id
+        FROM job_identity_aliases aliases
+        JOIN jobs
+          ON jobs.tenant_id = aliases.tenant_id
+         AND jobs.job_id = aliases.job_id
+        WHERE aliases.tenant_id = ?
+          AND aliases.alias_kind = 'posting_url'
+          AND aliases.alias_value = ?
+        LIMIT 1
+        """,
+        """
+        SELECT job_id
+        FROM jobs
+        WHERE tenant_id = ? AND job_id = ?
+        LIMIT 1
+        """,
+    )
+    for sql in lookups:
+        row = conn.execute(sql, (tenant, raw_reference)).fetchone()
+        if row is not None and str(row[0] or "").strip():
+            return str(row[0])
+    raise KeyError(
+        f"No stable Job identity for contact link: {raw_reference}"
+    )
+
+
+def public_contact_job_reference(
+    conn: sqlite3.Connection,
+    *,
+    table: str,
+    tenant_id: TenantId,
+    physical_reference: str | None,
+) -> str | None:
+    if physical_reference is None:
+        return None
+    if contact_job_reference_column(conn, table) == "job_url":
+        return str(physical_reference)
+    row = conn.execute(
+        """
+        SELECT url
+        FROM jobs
+        WHERE tenant_id = ? AND job_id = ?
+        LIMIT 1
+        """,
+        (str(tenant_id), str(physical_reference)),
+    ).fetchone()
+    if row is None:
+        raise RuntimeError(
+            f"{table} contains an unresolved JobId: {physical_reference}"
+        )
+    return str(row[0])
+
+
+__all__ = [
+    "contact_job_reference_column",
+    "physical_contact_job_reference",
+    "public_contact_job_reference",
+]

--- a/workers/automation/src/jobctrl/infrastructure/contact/research_repository.py
+++ b/workers/automation/src/jobctrl/infrastructure/contact/research_repository.py
@@ -35,6 +35,11 @@ from jobctrl.domain.contact.value_objects import (
 )
 from jobctrl.domain.ports.events import EventPublisher
 from jobctrl.domain.tenant import TenantId
+from jobctrl.infrastructure.contact.job_reference import (
+    contact_job_reference_column,
+    physical_contact_job_reference,
+    public_contact_job_reference,
+)
 from jobctrl.state import record_job_event
 
 logger = logging.getLogger(__name__)
@@ -47,6 +52,10 @@ class SqliteContactResearchTaskRepository:
         self._conn = conn
         self._publisher = publisher
         ensure_contact_tables(self._conn)
+        self._reference_column = contact_job_reference_column(
+            self._conn,
+            "contact_research_tasks",
+        )
 
     # ------------------------------------------------------------------ load
 
@@ -71,10 +80,19 @@ class SqliteContactResearchTaskRepository:
         return [self._row_to_task(tenant_id, row) for row in rows]
 
     def _row_to_task(self, tenant_id: TenantId, row: sqlite3.Row) -> ContactResearchTask:
+        physical_reference = row[self._reference_column]
         return ContactResearchTask(
             tenant_id=tenant_id,
             task_id=str(row["task_id"]),
-            link=ContactLink(employer=row["employer"], job_id=row["job_url"]),
+            link=ContactLink(
+                employer=row["employer"],
+                job_id=public_contact_job_reference(
+                    self._conn,
+                    table="contact_research_tasks",
+                    tenant_id=tenant_id,
+                    physical_reference=physical_reference,
+                ),
+            ),
             status=_status(row["status"]),
             candidates=self._load_candidates(tenant_id, str(row["task_id"])),
             source_attempts=_decode_attempts(row["source_attempts_json"]),
@@ -143,16 +161,22 @@ class SqliteContactResearchTaskRepository:
     def _persist_canonical(self, tenant_id: TenantId, task: ContactResearchTask) -> None:
         tenant = str(tenant_id)
         task_id = str(task.task_id)
+        job_reference = physical_contact_job_reference(
+            self._conn,
+            table="contact_research_tasks",
+            tenant_id=tenant_id,
+            public_reference=task.link.job_id,
+        )
         with self._conn:
             self._conn.execute(
-                """
+                f"""
                 INSERT INTO contact_research_tasks (
-                    tenant_id, task_id, employer, job_url, status, source_attempts_json,
+                    tenant_id, task_id, employer, {self._reference_column}, status, source_attempts_json,
                     started_at, updated_at, needs_review_at, completed_at, failed_at, error_class
                 ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 ON CONFLICT(tenant_id, task_id) DO UPDATE SET
                     employer             = excluded.employer,
-                    job_url              = excluded.job_url,
+                    {self._reference_column} = excluded.{self._reference_column},
                     status               = excluded.status,
                     source_attempts_json = excluded.source_attempts_json,
                     started_at           = excluded.started_at,
@@ -166,7 +190,7 @@ class SqliteContactResearchTaskRepository:
                     tenant,
                     task_id,
                     task.link.employer,
-                    task.link.job_id,
+                    job_reference,
                     task.status.value,
                     _encode_attempts(task.source_attempts),
                     task.started_at,

--- a/workers/automation/src/jobctrl/infrastructure/contact/sqlite_repository.py
+++ b/workers/automation/src/jobctrl/infrastructure/contact/sqlite_repository.py
@@ -32,6 +32,11 @@ from jobctrl.domain.contact.value_objects import (
 from jobctrl.domain.identifiers import ContactId
 from jobctrl.domain.ports.events import EventPublisher
 from jobctrl.domain.tenant import TenantId
+from jobctrl.infrastructure.contact.job_reference import (
+    contact_job_reference_column,
+    physical_contact_job_reference,
+    public_contact_job_reference,
+)
 from jobctrl.state import record_job_event, utc_now
 
 logger = logging.getLogger(__name__)
@@ -44,6 +49,10 @@ class SqliteContactRepository:
         self._conn = conn
         self._publisher = publisher
         ensure_contact_tables(self._conn)
+        self._reference_column = contact_job_reference_column(
+            self._conn,
+            "contacts",
+        )
 
     # ------------------------------------------------------------------
     # Load
@@ -62,7 +71,17 @@ class SqliteContactRepository:
         return self._list(tenant_id, "", ())
 
     def list_for_job(self, tenant_id: TenantId, job_id: str) -> list[Contact]:
-        return self._list(tenant_id, "AND job_url = ?", (job_id,))
+        reference = physical_contact_job_reference(
+            self._conn,
+            table="contacts",
+            tenant_id=tenant_id,
+            public_reference=job_id,
+        )
+        return self._list(
+            tenant_id,
+            f"AND {self._reference_column} = ?",
+            (str(reference),),
+        )
 
     def list_for_employer(self, tenant_id: TenantId, employer: str) -> list[Contact]:
         return self._list(tenant_id, "AND employer = ?", (employer,))
@@ -81,10 +100,19 @@ class SqliteContactRepository:
         return [self._row_to_contact(tenant_id, row) for row in rows]
 
     def _row_to_contact(self, tenant_id: TenantId, row: sqlite3.Row) -> Contact:
+        physical_reference = row[self._reference_column]
         return Contact(
             tenant_id=tenant_id,
             contact_id=ContactId(str(row["contact_id"])),
-            link=ContactLink(employer=row["employer"], job_id=row["job_url"]),
+            link=ContactLink(
+                employer=row["employer"],
+                job_id=public_contact_job_reference(
+                    self._conn,
+                    table="contacts",
+                    tenant_id=tenant_id,
+                    physical_reference=physical_reference,
+                ),
+            ),
             role=_role(row["role"]),
             attributes=self._load_attributes(tenant_id, str(row["contact_id"])),
             created_at=str(row["created_at"] or ""),
@@ -139,16 +167,22 @@ class SqliteContactRepository:
     def _persist_canonical(self, tenant_id: TenantId, contact: Contact) -> None:
         tenant = str(tenant_id)
         contact_id = str(contact.contact_id)
+        job_reference = physical_contact_job_reference(
+            self._conn,
+            table="contacts",
+            tenant_id=tenant_id,
+            public_reference=contact.link.job_id,
+        )
         with self._conn:
             self._conn.execute(
-                """
+                f"""
                 INSERT INTO contacts (
-                    tenant_id, contact_id, employer, job_url, role,
+                    tenant_id, contact_id, employer, {self._reference_column}, role,
                     created_at, updated_at, deleted_at
                 ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
                 ON CONFLICT(tenant_id, contact_id) DO UPDATE SET
                     employer = excluded.employer,
-                    job_url = excluded.job_url,
+                    {self._reference_column} = excluded.{self._reference_column},
                     role = excluded.role,
                     updated_at = excluded.updated_at,
                     deleted_at = excluded.deleted_at
@@ -157,7 +191,7 @@ class SqliteContactRepository:
                     tenant,
                     contact_id,
                     contact.link.employer,
-                    contact.link.job_id,
+                    job_reference,
                     contact.role.value,
                     contact.created_at,
                     contact.updated_at,

--- a/workers/automation/src/jobctrl/infrastructure/projections/projection_builder.py
+++ b/workers/automation/src/jobctrl/infrastructure/projections/projection_builder.py
@@ -64,6 +64,10 @@ from jobctrl.domain.operations.projections import (
 )
 from jobctrl.domain.ports.events import EventPublisher, Subscription
 from jobctrl.domain.tenant import LOCAL_TENANT, TenantId
+from jobctrl.infrastructure.contact.job_reference import (
+    contact_job_reference_column,
+    public_contact_job_reference,
+)
 from jobctrl.infrastructure.events.watermark import SqliteEventWatermarkRepository
 from jobctrl.infrastructure.projections.location_normalization import (
     normalize_job_location,
@@ -1030,9 +1034,14 @@ class ProjectionBuilder:
         """
         tenant = str(self._tenant_id)
         try:
+            reference_column = contact_job_reference_column(
+                self._conn,
+                "contacts",
+            )
             contact_rows = self._conn.execute(
-                """
-                SELECT contact_id, employer, job_url, role, created_at, updated_at
+                f"""
+                SELECT contact_id, employer, {reference_column}, role,
+                       created_at, updated_at
                 FROM contacts
                 WHERE tenant_id = ? AND deleted_at IS NULL
                 """,
@@ -1081,7 +1090,12 @@ class ProjectionBuilder:
                     tenant_id=self._tenant_id,
                     contact_id=contact_id,
                     employer=row[1],
-                    job_id=row[2],
+                    job_id=public_contact_job_reference(
+                        self._conn,
+                        table="contacts",
+                        tenant_id=self._tenant_id,
+                        physical_reference=row[2],
+                    ),
                     role=str(row[3] or "other"),
                     attribute_count=len(attribute_rows),
                     confirmed_count=confirmed,
@@ -1121,9 +1135,14 @@ class ProjectionBuilder:
         """
         tenant = str(self._tenant_id)
         try:
+            reference_column = contact_job_reference_column(
+                self._conn,
+                "contact_research_tasks",
+            )
             task_rows = self._conn.execute(
-                """
-                SELECT task_id, employer, job_url, status, source_attempts_json,
+                f"""
+                SELECT task_id, employer, {reference_column}, status,
+                       source_attempts_json,
                        started_at, updated_at, needs_review_at, completed_at,
                        failed_at, error_class
                 FROM contact_research_tasks
@@ -1177,7 +1196,12 @@ class ProjectionBuilder:
                     tenant_id=self._tenant_id,
                     task_id=task_id,
                     employer=row[1],
-                    job_id=row[2],
+                    job_id=public_contact_job_reference(
+                        self._conn,
+                        table="contact_research_tasks",
+                        tenant_id=self._tenant_id,
+                        physical_reference=row[2],
+                    ),
                     status=str(row[3] or "queued"),
                     candidate_count=len(candidate_rows),
                     needs_review_count=needs_review,

--- a/workers/automation/tests/test_application_feedback_candidate_identity_reference_migration.py
+++ b/workers/automation/tests/test_application_feedback_candidate_identity_reference_migration.py
@@ -331,7 +331,7 @@ def test_v21_candidates_migrate_every_alias_uuid_url_and_tenant(
     assert (
         reopened.execute("PRAGMA user_version").fetchone()[0]
         == SCHEMA_VERSION
-        == 23
+        == 24
     )
     for table in database_module._APPLICATION_FEEDBACK_CANDIDATE_TABLES:
         assert "job_id" in _columns(reopened, table)

--- a/workers/automation/tests/test_application_outcome_identity_reference_migration.py
+++ b/workers/automation/tests/test_application_outcome_identity_reference_migration.py
@@ -243,7 +243,7 @@ def test_v20_outcomes_migrate_every_alias_uuid_url_and_tenant(
     assert (
         reopened.execute("PRAGMA user_version").fetchone()[0]
         == SCHEMA_VERSION
-        == 23
+        == 24
     )
     assert "job_id" in _columns(reopened, "application_outcomes")
     assert "job_key" not in _columns(reopened, "application_outcomes")

--- a/workers/automation/tests/test_application_review_identity_reference_migration.py
+++ b/workers/automation/tests/test_application_review_identity_reference_migration.py
@@ -204,7 +204,7 @@ def test_v19_review_decisions_migrate_every_alias_and_uuid_url(
     assert (
         reopened.execute("PRAGMA user_version").fetchone()[0]
         == SCHEMA_VERSION
-        == 23
+        == 24
     )
     assert "job_id" in _columns(
         reopened,

--- a/workers/automation/tests/test_compensation_identity_reference_migration.py
+++ b/workers/automation/tests/test_compensation_identity_reference_migration.py
@@ -210,7 +210,7 @@ def test_v18_compensation_migrates_alias_winners_and_uuid_urls(
     assert (
         reopened.execute("PRAGMA user_version").fetchone()[0]
         == SCHEMA_VERSION
-        == 23
+        == 24
     )
     for table in database_module._COMPENSATION_REFERENCE_TABLES:
         assert "job_id" in _columns(reopened, table)

--- a/workers/automation/tests/test_contact_projection_parity.py
+++ b/workers/automation/tests/test_contact_projection_parity.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import json
 import sqlite3
+import uuid
 from pathlib import Path
 from typing import Any
 
@@ -32,11 +33,25 @@ _FIXTURE = (
 
 def _seed_canonical(conn: sqlite3.Connection, fixture: dict[str, Any]) -> None:
     tenant = fixture["tenantId"]
+    job_ids = {
+        str(contact["jobUrl"]): str(
+            uuid.uuid5(uuid.NAMESPACE_URL, str(contact["jobUrl"]))
+        )
+        for contact in fixture["contacts"]
+        if contact["jobUrl"] is not None
+    }
+    conn.executemany(
+        "INSERT INTO jobs (url, tenant_id, job_id) VALUES (?, ?, ?)",
+        (
+            (job_url, tenant, job_id)
+            for job_url, job_id in job_ids.items()
+        ),
+    )
     for contact in fixture["contacts"]:
         conn.execute(
             """
             INSERT INTO contacts (
-                tenant_id, contact_id, employer, job_url, role,
+                tenant_id, contact_id, employer, job_id, role,
                 created_at, updated_at, deleted_at
             ) VALUES (?, ?, ?, ?, ?, ?, ?, NULL)
             """,
@@ -44,7 +59,7 @@ def _seed_canonical(conn: sqlite3.Connection, fixture: dict[str, Any]) -> None:
                 tenant,
                 contact["contactId"],
                 contact["employer"],
-                contact["jobUrl"],
+                job_ids.get(contact["jobUrl"]),
                 contact["role"],
                 contact["createdAt"],
                 contact["updatedAt"],

--- a/workers/automation/tests/test_contact_repository.py
+++ b/workers/automation/tests/test_contact_repository.py
@@ -37,6 +37,23 @@ _SECRET_EMAIL = "jane@acme.example"
 def _setup(tmp_path: Path) -> tuple[SqliteContactRepository, sqlite3.Connection]:
     conn = init_db(tmp_path / "jobctrl.db")
     conn.row_factory = sqlite3.Row
+    conn.executemany(
+        """
+        INSERT INTO jobs (url, tenant_id, job_id)
+        VALUES (?, 'local', ?)
+        """,
+        (
+            (
+                "https://job/1",
+                "11111111-1111-4111-8111-111111111111",
+            ),
+            (
+                "https://job/2",
+                "22222222-2222-4222-8222-222222222222",
+            ),
+        ),
+    )
+    conn.commit()
     bus = InProcessEventBus()
     ProjectionBuilder(conn_factory=lambda: conn, tenant_id=LOCAL_TENANT).subscribe_to(bus)
     return SqliteContactRepository(conn, publisher=bus), conn

--- a/workers/automation/tests/test_contact_research_identity_reference_migration.py
+++ b/workers/automation/tests/test_contact_research_identity_reference_migration.py
@@ -1,0 +1,584 @@
+"""Schema-v24 Contact and contact-research stable JobId contracts."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import jobctrl.database as database_module
+from jobctrl.database import (
+    SCHEMA_VERSION,
+    ensure_contact_research_references_v24,
+    ensure_contact_tables,
+    init_db,
+    reassign_discovery_identity_references,
+)
+
+PREVIOUS_SCHEMA_VERSION = 23
+NOW = "2026-07-30T12:00:00+00:00"
+UUID_SHAPED_URL = "11111111-1111-4111-8111-111111111111"
+TARGET_JOB_ID = "22222222-2222-4222-8222-222222222222"
+COLLIDING_JOB_ID = UUID_SHAPED_URL
+PRIOR_JOB_ID = "33333333-3333-4333-8333-333333333333"
+SURVIVOR_JOB_ID = "44444444-4444-4444-8444-444444444444"
+
+
+def _columns(
+    conn: sqlite3.Connection,
+    table: str,
+) -> set[str]:
+    return {
+        str(row[1])
+        for row in conn.execute(
+            f'PRAGMA table_info("{table}")'
+        ).fetchall()
+    }
+
+
+def _insert_job(
+    conn: sqlite3.Connection,
+    *,
+    url: str,
+    job_id: str,
+    tenant_id: str = "local",
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO jobs (
+            url, tenant_id, job_id, title, company, discovered_at
+        ) VALUES (?, ?, ?, 'Platform Engineer', 'ExampleCo', ?)
+        """,
+        (url, tenant_id, job_id, NOW),
+    )
+
+
+def _downgrade_contact_tables_to_v23(
+    conn: sqlite3.Connection,
+) -> None:
+    conn.commit()
+    conn.execute("PRAGMA foreign_keys = OFF")
+    conn.executescript(
+        """
+        DROP TABLE contacts;
+        DROP TABLE contact_research_tasks;
+        """
+    )
+    database_module._create_contacts_table_v24(
+        conn,
+        table="contacts",
+        stable_reference=False,
+    )
+    database_module._create_contact_research_tasks_table_v24(
+        conn,
+        table="contact_research_tasks",
+        stable_reference=False,
+    )
+    conn.executescript(
+        """
+        CREATE INDEX idx_contacts_lookup
+        ON contacts(tenant_id, employer, job_url);
+        CREATE INDEX idx_contact_research_tasks_lookup
+        ON contact_research_tasks(tenant_id, employer, job_url);
+        """
+    )
+    conn.execute(
+        f"PRAGMA user_version = {PREVIOUS_SCHEMA_VERSION}"
+    )
+    conn.commit()
+    conn.execute("PRAGMA foreign_keys = ON")
+
+
+def _seed_v23_database(db_path: Path) -> sqlite3.Connection:
+    conn = init_db(db_path)
+    conn.row_factory = sqlite3.Row
+    _downgrade_contact_tables_to_v23(conn)
+    return conn
+
+
+def _history_snapshot(
+    conn: sqlite3.Connection,
+) -> dict[str, list[tuple[Any, ...]]]:
+    return {
+        table: [
+            tuple(row)
+            for row in conn.execute(
+                f'SELECT * FROM "{table}" ORDER BY tenant_id, rowid'
+            ).fetchall()
+        ]
+        for table in database_module._CONTACT_RESEARCH_HISTORY_TABLES
+    }
+
+
+def test_v23_rows_migrate_exactly_with_url_first_resolution(
+    tmp_path: Path,
+) -> None:
+    conn = _seed_v23_database(tmp_path / "jobs.db")
+    colliding_owner_url = (
+        "https://careers.example.test/uuid-id-owner"
+    )
+    prior_url = "https://careers.example.test/prior"
+    prior_alias = "https://legacy.example.test/prior"
+    blue_target_url = "https://blue.example.test/target"
+    _insert_job(
+        conn,
+        url=UUID_SHAPED_URL,
+        job_id=TARGET_JOB_ID,
+    )
+    _insert_job(
+        conn,
+        url=colliding_owner_url,
+        job_id=COLLIDING_JOB_ID,
+    )
+    _insert_job(conn, url=prior_url, job_id=PRIOR_JOB_ID)
+    _insert_job(
+        conn,
+        url=blue_target_url,
+        job_id=TARGET_JOB_ID,
+        tenant_id="blue",
+    )
+    conn.execute(
+        """
+        INSERT INTO job_identity_aliases (
+            tenant_id, alias_kind, alias_value, job_id, created_at
+        ) VALUES ('local', 'posting_url', ?, ?, ?)
+        """,
+        (prior_alias, PRIOR_JOB_ID, NOW),
+    )
+    conn.executemany(
+        """
+        INSERT INTO contacts (
+            tenant_id, contact_id, employer, job_url, role,
+            created_at, updated_at, deleted_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            (
+                "local",
+                "contact:uuid-url",
+                "ExampleCo",
+                UUID_SHAPED_URL,
+                "recruiter",
+                NOW,
+                NOW,
+                None,
+            ),
+            (
+                "local",
+                "contact:employer-only",
+                "ExampleCo",
+                None,
+                "hiring_manager",
+                NOW,
+                NOW,
+                None,
+            ),
+            (
+                "blue",
+                "contact:blue",
+                "BlueCo",
+                blue_target_url,
+                "other",
+                NOW,
+                NOW,
+                None,
+            ),
+        ),
+    )
+    conn.execute(
+        """
+        INSERT INTO contact_attributes (
+            tenant_id, attribute_id, contact_id, attribute_kind,
+            value_json, source_kind, source_ref, capture_method,
+            confidence, user_confirmed, recorded_at
+        ) VALUES (
+            'local', 'attribute:exact', 'contact:uuid-url', 'note',
+            '"private:exact"', 'user_entered', 'user_entered',
+            'manual', 1, 1, ?
+        )
+        """,
+        (NOW,),
+    )
+    conn.executemany(
+        """
+        INSERT INTO contact_research_tasks (
+            tenant_id, task_id, employer, job_url, status,
+            source_attempts_json, started_at, updated_at,
+            needs_review_at, completed_at, failed_at, error_class
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            (
+                "local",
+                "task:alias",
+                "ExampleCo",
+                prior_alias,
+                "needs_review",
+                '[{"sourceRef":"private:exact"}]',
+                NOW,
+                NOW,
+                NOW,
+                None,
+                None,
+                None,
+            ),
+            (
+                "local",
+                "task:employer-only",
+                "ExampleCo",
+                None,
+                "queued",
+                "[]",
+                None,
+                NOW,
+                None,
+                None,
+                None,
+                None,
+            ),
+        ),
+    )
+    conn.execute(
+        """
+        INSERT INTO contact_candidates (
+            tenant_id, candidate_id, task_id, role, attributes_json,
+            source_kind, source_ref, capture_method, confidence,
+            status, proposed_at
+        ) VALUES (
+            'local', 'candidate:exact', 'task:alias', 'recruiter',
+            '[{"value":"private:exact"}]', 'public_web_page',
+            'https://example.test/team', 'llm_assisted', 0.8,
+            'needs_review', ?
+        )
+        """,
+        (NOW,),
+    )
+    conn.commit()
+    before_attributes = [
+        tuple(row)
+        for row in conn.execute(
+            "SELECT * FROM contact_attributes ORDER BY rowid"
+        ).fetchall()
+    ]
+    before_candidates = [
+        tuple(row)
+        for row in conn.execute(
+            "SELECT * FROM contact_candidates ORDER BY rowid"
+        ).fetchall()
+    ]
+
+    assert ensure_contact_research_references_v24(conn) == list(
+        database_module._CONTACT_RESEARCH_REFERENCE_TABLES
+    )
+
+    assert (
+        conn.execute("PRAGMA user_version").fetchone()[0]
+        == SCHEMA_VERSION
+        == 24
+    )
+    assert (
+        database_module._has_contact_research_reference_schema_v24(
+            conn
+        )
+    )
+    assert [
+        tuple(row)
+        for row in conn.execute(
+            """
+            SELECT tenant_id, contact_id, job_id
+            FROM contacts
+            ORDER BY tenant_id, contact_id
+            """
+        ).fetchall()
+    ] == [
+        ("blue", "contact:blue", TARGET_JOB_ID),
+        ("local", "contact:employer-only", None),
+        ("local", "contact:uuid-url", TARGET_JOB_ID),
+    ]
+    assert [
+        tuple(row)
+        for row in conn.execute(
+            """
+            SELECT task_id, job_id
+            FROM contact_research_tasks
+            ORDER BY task_id
+            """
+        ).fetchall()
+    ] == [
+        ("task:alias", PRIOR_JOB_ID),
+        ("task:employer-only", None),
+    ]
+    assert [
+        tuple(row)
+        for row in conn.execute(
+            "SELECT * FROM contact_attributes ORDER BY rowid"
+        ).fetchall()
+    ] == before_attributes
+    assert [
+        tuple(row)
+        for row in conn.execute(
+            "SELECT * FROM contact_candidates ORDER BY rowid"
+        ).fetchall()
+    ] == before_candidates
+    for table in database_module._CONTACT_RESEARCH_REFERENCE_TABLES:
+        actions = {
+            str(row[6]).upper()
+            for row in conn.execute(
+                f'PRAGMA foreign_key_list("{table}")'
+            ).fetchall()
+        }
+        assert actions == {"RESTRICT"}
+    assert conn.execute("PRAGMA foreign_key_check").fetchone() is None
+
+
+def test_verification_failure_rolls_back_and_retry_succeeds(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    conn = _seed_v23_database(tmp_path / "retry.db")
+    job_url = "https://careers.example.test/retry"
+    _insert_job(conn, url=job_url, job_id=TARGET_JOB_ID)
+    conn.execute(
+        """
+        INSERT INTO contacts (
+            tenant_id, contact_id, employer, job_url, role,
+            created_at, updated_at
+        ) VALUES ('local', 'contact:retry', 'ExampleCo', ?,
+                  'other', ?, ?)
+        """,
+        (job_url, NOW, NOW),
+    )
+    conn.execute(
+        """
+        INSERT INTO contact_research_tasks (
+            tenant_id, task_id, employer, job_url, status, updated_at
+        ) VALUES (
+            'local', 'task:retry', 'ExampleCo', ?, 'queued', ?
+        )
+        """,
+        (job_url, NOW),
+    )
+    conn.commit()
+    before = _history_snapshot(conn)
+    original_verify = (
+        database_module._verify_contact_research_references_v24
+    )
+
+    def _fail_verification(
+        _conn: sqlite3.Connection,
+        *,
+        expected_counts: dict[str, int],
+    ) -> None:
+        del expected_counts
+        raise RuntimeError("injected contact verification failure")
+
+    monkeypatch.setattr(
+        database_module,
+        "_verify_contact_research_references_v24",
+        _fail_verification,
+    )
+    with pytest.raises(
+        RuntimeError,
+        match="injected contact verification failure",
+    ):
+        ensure_contact_research_references_v24(conn)
+    assert conn.execute("PRAGMA user_version").fetchone()[0] == 23
+    assert _history_snapshot(conn) == before
+    assert "job_url" in _columns(conn, "contacts")
+    assert "job_url" in _columns(conn, "contact_research_tasks")
+    assert {
+        str(row[0])
+        for row in conn.execute(
+            """
+            SELECT name FROM sqlite_master
+            WHERE type = 'table' AND name LIKE '%_v24'
+            """
+        ).fetchall()
+    } == set()
+    assert conn.execute("PRAGMA foreign_keys").fetchone()[0] == 1
+
+    monkeypatch.setattr(
+        database_module,
+        "_verify_contact_research_references_v24",
+        original_verify,
+    )
+    ensure_contact_research_references_v24(conn)
+    assert conn.execute("PRAGMA user_version").fetchone()[0] == 24
+    assert conn.execute(
+        "SELECT job_id FROM contacts"
+    ).fetchone()[0] == TARGET_JOB_ID
+
+
+@pytest.mark.parametrize(
+    ("schema_version", "expected_reference"),
+    ((0, "job_url"), (23, "job_url"), (24, "job_id")),
+)
+def test_missing_table_recovery_is_schema_version_aware(
+    schema_version: int,
+    expected_reference: str,
+) -> None:
+    conn = sqlite3.connect(":memory:")
+    conn.executescript(
+        f"""
+        CREATE TABLE jobs (
+            url TEXT PRIMARY KEY,
+            tenant_id TEXT NOT NULL DEFAULT 'local',
+            job_id TEXT NOT NULL,
+            UNIQUE (tenant_id, job_id)
+        );
+        PRAGMA user_version = {schema_version};
+        """
+    )
+
+    ensure_contact_tables(conn)
+
+    assert expected_reference in _columns(conn, "contacts")
+    assert expected_reference in _columns(
+        conn,
+        "contact_research_tasks",
+    )
+    if schema_version == 24:
+        assert (
+            database_module._has_contact_research_reference_schema_v24(
+                conn
+            )
+        )
+
+
+def test_stamped_v24_legacy_tables_fail_closed() -> None:
+    conn = sqlite3.connect(":memory:")
+    conn.executescript(
+        """
+        CREATE TABLE jobs (
+            url TEXT PRIMARY KEY,
+            tenant_id TEXT NOT NULL DEFAULT 'local',
+            job_id TEXT NOT NULL,
+            UNIQUE (tenant_id, job_id)
+        );
+        PRAGMA user_version = 23;
+        """
+    )
+    ensure_contact_tables(conn)
+    conn.execute("PRAGMA user_version = 24")
+
+    with pytest.raises(
+        RuntimeError,
+        match="Schema v24 requires stable contact",
+    ):
+        ensure_contact_tables(conn)
+
+
+def test_runtime_collision_rehomes_authorities_and_url_projections(
+    tmp_path: Path,
+) -> None:
+    conn = init_db(tmp_path / "collision.db")
+    conn.row_factory = sqlite3.Row
+    losing_url = "https://careers.example.test/losing"
+    surviving_url = "https://careers.example.test/surviving"
+    _insert_job(conn, url=losing_url, job_id=TARGET_JOB_ID)
+    _insert_job(
+        conn,
+        url=surviving_url,
+        job_id=SURVIVOR_JOB_ID,
+    )
+    conn.execute(
+        """
+        INSERT INTO contacts (
+            tenant_id, contact_id, employer, job_id, role,
+            created_at, updated_at
+        ) VALUES (
+            'local', 'contact:collision', 'ExampleCo', ?,
+            'other', ?, ?
+        )
+        """,
+        (TARGET_JOB_ID, NOW, NOW),
+    )
+    conn.execute(
+        """
+        INSERT INTO contact_research_tasks (
+            tenant_id, task_id, employer, job_id, status, updated_at
+        ) VALUES (
+            'local', 'task:collision', 'ExampleCo', ?, 'queued', ?
+        )
+        """,
+        (TARGET_JOB_ID, NOW),
+    )
+    conn.execute(
+        """
+        INSERT INTO contact_projections (
+            tenant_id, contact_id, employer, job_id, role,
+            attribute_count, confirmed_count, source_kinds_json,
+            provenance_json, updated_at, last_updated_at
+        ) VALUES (
+            'local', 'contact:collision', 'ExampleCo', ?, 'other',
+            0, 0, '[]', '[]', ?, ?
+        )
+        """,
+        (losing_url, NOW, NOW),
+    )
+    conn.execute(
+        """
+        INSERT INTO contact_research_task_projections (
+            tenant_id, task_id, employer, job_id, status,
+            candidate_count, needs_review_count, confirmed_count,
+            source_attempts_json, candidates_json, updated_at,
+            last_updated_at
+        ) VALUES (
+            'local', 'task:collision', 'ExampleCo', ?, 'queued',
+            0, 0, 0, '[]', '[]', ?, ?
+        )
+        """,
+        (losing_url, NOW, NOW),
+    )
+    conn.commit()
+
+    reassign_discovery_identity_references(
+        conn,
+        losing_job_url=losing_url,
+        surviving_job_url=surviving_url,
+    )
+
+    assert conn.execute(
+        "SELECT job_id FROM contacts"
+    ).fetchone()[0] == SURVIVOR_JOB_ID
+    assert conn.execute(
+        "SELECT job_id FROM contact_research_tasks"
+    ).fetchone()[0] == SURVIVOR_JOB_ID
+    assert conn.execute(
+        "SELECT job_id FROM contact_projections"
+    ).fetchone()[0] == surviving_url
+    assert conn.execute(
+        "SELECT job_id FROM contact_research_task_projections"
+    ).fetchone()[0] == surviving_url
+    assert conn.execute("PRAGMA foreign_key_check").fetchone() is None
+
+
+def test_direct_job_delete_is_restricted_until_links_are_detached(
+    tmp_path: Path,
+) -> None:
+    conn = init_db(tmp_path / "restrict.db")
+    conn.execute("PRAGMA foreign_keys = ON")
+    job_url = "https://careers.example.test/restrict"
+    _insert_job(conn, url=job_url, job_id=TARGET_JOB_ID)
+    conn.execute(
+        """
+        INSERT INTO contacts (
+            tenant_id, contact_id, employer, job_id, role,
+            created_at, updated_at
+        ) VALUES (
+            'local', 'contact:restrict', 'ExampleCo', ?,
+            'other', ?, ?
+        )
+        """,
+        (TARGET_JOB_ID, NOW, NOW),
+    )
+    conn.commit()
+
+    with pytest.raises(sqlite3.IntegrityError):
+        conn.execute("DELETE FROM jobs WHERE url = ?", (job_url,))
+
+    assert conn.execute(
+        "SELECT COUNT(*) FROM contacts"
+    ).fetchone()[0] == 1

--- a/workers/automation/tests/test_contact_research_projection_parity.py
+++ b/workers/automation/tests/test_contact_research_projection_parity.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import json
 import sqlite3
+import uuid
 from pathlib import Path
 from typing import Any
 
@@ -30,11 +31,25 @@ _FIXTURE = (
 
 def _seed_canonical(conn: sqlite3.Connection, fixture: dict[str, Any]) -> None:
     tenant = fixture["tenantId"]
+    job_ids = {
+        str(task["jobUrl"]): str(
+            uuid.uuid5(uuid.NAMESPACE_URL, str(task["jobUrl"]))
+        )
+        for task in fixture["tasks"]
+        if task["jobUrl"] is not None
+    }
+    conn.executemany(
+        "INSERT INTO jobs (url, tenant_id, job_id) VALUES (?, ?, ?)",
+        (
+            (job_url, tenant, job_id)
+            for job_url, job_id in job_ids.items()
+        ),
+    )
     for task in fixture["tasks"]:
         conn.execute(
             """
             INSERT INTO contact_research_tasks (
-                tenant_id, task_id, employer, job_url, status, source_attempts_json,
+                tenant_id, task_id, employer, job_id, status, source_attempts_json,
                 started_at, updated_at, needs_review_at, completed_at, failed_at, error_class
             ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
@@ -42,7 +57,7 @@ def _seed_canonical(conn: sqlite3.Connection, fixture: dict[str, Any]) -> None:
                 tenant,
                 task["taskId"],
                 task["employer"],
-                task["jobUrl"],
+                job_ids.get(task["jobUrl"]),
                 task["status"],
                 json.dumps(task["sourceAttempts"]),
                 task["startedAt"],

--- a/workers/automation/tests/test_contact_research_workflow.py
+++ b/workers/automation/tests/test_contact_research_workflow.py
@@ -96,6 +96,17 @@ def _setup(tmp_path: Path):
 
     conn = init_db(tmp_path / "jobctrl.db")
     conn.row_factory = sqlite3.Row
+    conn.execute(
+        """
+        INSERT INTO jobs (url, tenant_id, job_id)
+        VALUES (
+            'https://job/1',
+            'local',
+            '11111111-1111-4111-8111-111111111111'
+        )
+        """
+    )
+    conn.commit()
     bus = InProcessEventBus()
     ProjectionBuilder(conn_factory=lambda: conn, tenant_id=LOCAL_TENANT).subscribe_to(bus)
     research_repo = SqliteContactResearchTaskRepository(conn, publisher=bus)

--- a/workers/automation/tests/test_discovery_identity_reference_migration.py
+++ b/workers/automation/tests/test_discovery_identity_reference_migration.py
@@ -220,7 +220,7 @@ def test_v7_discovery_references_migrate_to_stable_job_id_and_reopen(
     init_db(db_path)
     close_connection(db_path)
 
-    assert _user_version(db_path) == SCHEMA_VERSION == 23
+    assert _user_version(db_path) == SCHEMA_VERSION == 24
     assert "job_id" in _columns(db_path, "job_source_observations")
     assert "job_url" not in _columns(db_path, "job_source_observations")
     assert "job_id" in _columns(db_path, "job_canonical_identities")

--- a/workers/automation/tests/test_employer_analysis_identity_reference_migration.py
+++ b/workers/automation/tests/test_employer_analysis_identity_reference_migration.py
@@ -242,7 +242,7 @@ def test_v15_employer_analysis_migrates_alias_histories_and_uuid_urls(
     assert (
         reopened.execute("PRAGMA user_version").fetchone()[0]
         == SCHEMA_VERSION
-        == 23
+        == 24
     )
     for table in database_module._EMPLOYER_ANALYSIS_REFERENCE_TABLES:
         assert "job_id" in _columns(reopened, table)

--- a/workers/automation/tests/test_enrichment_snapshot_identity_reference_migration.py
+++ b/workers/automation/tests/test_enrichment_snapshot_identity_reference_migration.py
@@ -322,7 +322,7 @@ def test_v10_enrichment_snapshot_references_migrate_and_reopen(
     init_db(db_path)
     close_connection(db_path)
 
-    assert _user_version(db_path) == SCHEMA_VERSION == 23
+    assert _user_version(db_path) == SCHEMA_VERSION == 24
     check = sqlite3.connect(db_path)
     try:
         enrichment_rows = check.execute(

--- a/workers/automation/tests/test_execution_search_identity_reference_migration.py
+++ b/workers/automation/tests/test_execution_search_identity_reference_migration.py
@@ -261,7 +261,7 @@ def test_v8_execution_and_receipts_migrate_to_stable_job_id_and_reopen(
     init_db(db_path)
     close_connection(db_path)
 
-    assert _user_version(db_path) == SCHEMA_VERSION == 23
+    assert _user_version(db_path) == SCHEMA_VERSION == 24
     assert "job_id" in _columns(db_path, "discovery_execution_jobs")
     assert "job_url" not in _columns(db_path, "discovery_execution_jobs")
     assert "job_id" in _columns(db_path, "discovery_search_unit_jobs")

--- a/workers/automation/tests/test_interview_prep_identity_reference_migration.py
+++ b/workers/automation/tests/test_interview_prep_identity_reference_migration.py
@@ -323,7 +323,7 @@ def test_v17_interview_prep_migrates_alias_histories_and_uuid_urls(
     assert (
         reopened.execute("PRAGMA user_version").fetchone()[0]
         == SCHEMA_VERSION
-        == 23
+        == 24
     )
     for table in database_module._INTERVIEW_PREP_REFERENCE_TABLES:
         assert "job_id" in _columns(reopened, table)

--- a/workers/automation/tests/test_materials_identity_reference_migration.py
+++ b/workers/automation/tests/test_materials_identity_reference_migration.py
@@ -293,7 +293,7 @@ def test_v14_materials_migrate_alias_histories_and_uuid_shaped_urls(
     close_connection(db_path)
 
     reopened = init_db(db_path)
-    assert reopened.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_VERSION == 23
+    assert reopened.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_VERSION == 24
     for table in database_module._MATERIALS_REFERENCE_TABLES:
         assert "job_id" in _columns(reopened, table)
         assert "job_url" not in _columns(reopened, table)

--- a/workers/automation/tests/test_outreach_draft_gates.py
+++ b/workers/automation/tests/test_outreach_draft_gates.py
@@ -146,6 +146,17 @@ def _counter():
 def _setup(tmp_path: Path):
     conn = init_db(tmp_path / "jobctrl.db")
     conn.row_factory = sqlite3.Row
+    conn.execute(
+        """
+        INSERT INTO jobs (url, tenant_id, job_id)
+        VALUES (
+            'https://job/1',
+            'local',
+            '11111111-1111-4111-8111-111111111111'
+        )
+        """
+    )
+    conn.commit()
     bus = InProcessEventBus()
     contact_repo = SqliteContactRepository(conn, publisher=bus)
     thread_repo = SqliteOutreachThreadRepository(conn, publisher=bus)

--- a/workers/automation/tests/test_preparation_identity_reference_migration.py
+++ b/workers/automation/tests/test_preparation_identity_reference_migration.py
@@ -177,7 +177,7 @@ def test_v9_preparation_references_migrate_to_stable_job_ids_and_reopen(
     init_db(db_path)
     close_connection(db_path)
 
-    assert _user_version(db_path) == SCHEMA_VERSION == 23
+    assert _user_version(db_path) == SCHEMA_VERSION == 24
     check = sqlite3.connect(db_path)
     try:
         rows = check.execute(

--- a/workers/automation/tests/test_repeat_application_identity_reference_migration.py
+++ b/workers/automation/tests/test_repeat_application_identity_reference_migration.py
@@ -402,7 +402,7 @@ def test_v22_history_migrates_exactly_with_url_first_resolution(
     reopened = init_db(db_path)
     assert reopened.execute("PRAGMA user_version").fetchone()[0] == (
         SCHEMA_VERSION
-    ) == 23
+    ) == 24
     assert database_module._has_repeat_application_reference_schema_v23(
         reopened
     )

--- a/workers/automation/tests/test_repeat_application_prevention.py
+++ b/workers/automation/tests/test_repeat_application_prevention.py
@@ -799,7 +799,7 @@ def test_schema_v5_migrates_additively_without_changing_application_facts(
         (PRIOR,),
     ).fetchall()
 
-    assert int(migrated.execute("PRAGMA user_version").fetchone()[0]) == SCHEMA_VERSION == 23
+    assert int(migrated.execute("PRAGMA user_version").fetchone()[0]) == SCHEMA_VERSION == 24
     assert [tuple(row) for row in after] == [tuple(row) for row in before]
     assert "metadata_json" in {
         str(row[1]) for row in migrated.execute("PRAGMA table_info(job_stage_states)").fetchall()

--- a/workers/automation/tests/test_resume_template_identity_reference_migration.py
+++ b/workers/automation/tests/test_resume_template_identity_reference_migration.py
@@ -254,7 +254,7 @@ def test_v16_template_references_migrate_aliases_and_uuid_urls(
     assert (
         reopened.execute("PRAGMA user_version").fetchone()[0]
         == SCHEMA_VERSION
-        == 23
+        == 24
     )
     for table in database_module._RESUME_TEMPLATE_REFERENCE_TABLES:
         assert "job_id" in _columns(reopened, table)

--- a/workers/automation/tests/test_scoring_identity_reference_migration.py
+++ b/workers/automation/tests/test_scoring_identity_reference_migration.py
@@ -338,7 +338,7 @@ def test_v11_scoring_references_migrate_alias_histories_and_reopen(
     assert (
         int(migrated.execute("PRAGMA user_version").fetchone()[0])
         == SCHEMA_VERSION
-        == 23
+        == 24
     )
     assert _columns(migrated, "job_scores") >= {"tenant_id", "job_id"}
     assert "job_url" not in _columns(migrated, "job_scores")
@@ -404,7 +404,7 @@ def test_v11_scoring_references_migrate_alias_histories_and_reopen(
     assert (
         int(reopened.execute("PRAGMA user_version").fetchone()[0])
         == SCHEMA_VERSION
-        == 23
+        == 24
     )
 
 
@@ -553,7 +553,7 @@ def test_scoring_migration_rolls_back_and_retries_after_verification_failure(
     assert (
         int(retried.execute("PRAGMA user_version").fetchone()[0])
         == SCHEMA_VERSION
-        == 23
+        == 24
     )
     assert [
         tuple(row)

--- a/workers/automation/tests/test_stable_job_identity_migration.py
+++ b/workers/automation/tests/test_stable_job_identity_migration.py
@@ -841,7 +841,7 @@ def test_v6_jobs_gain_stable_uuid_and_posting_url_alias_once(
     init_db(db_path)
     close_connection(db_path)
 
-    assert _user_version(db_path) == SCHEMA_VERSION == 23
+    assert _user_version(db_path) == SCHEMA_VERSION == 24
     first_ids = _identity_rows(db_path)
     assert [row[0] for row in first_ids] == ["local", "local"]
     for _tenant_id, job_id, _url in first_ids:


### PR DESCRIPTION
## Summary

- migrate `contacts` and `contact_research_tasks` from URL-shaped job references to nullable tenant-scoped stable `job_id` references in schema v24
- preserve URL-shaped public DTOs, events, and projections by resolving stable identities at adapter boundaries
- handle UUID-shaped URLs URL-first, preserve tenant isolation, and fail closed for unknown linked jobs
- make permanent deletion explicit: detach employer-scoped history and purge job-only contact/research records plus dependents
- add migration rollback/retry, schema recovery/fail-close, collision-rehome, deletion, projection, and runtime adapter coverage

## Stack

- depends on #549
- this PR is intentionally limited to contacts and contact research; outreach references follow in the next stacked PR
- canonical product docs and cumulative product QA are deferred to the final PR in this approved unreleased stack

## Validation

- `corepack pnpm api:test` — 703 passed
- `corepack pnpm api:check` — passed
- `corepack pnpm web:check` — passed
- `PYTHONPATH=src .../.venv/bin/python -m pytest -q` — 2,743 passed, 2 skipped
- `.../.venv/bin/ruff check src tests` — passed
- `env -u UV_EXCLUDE_NEWER uv --project workers/automation lock --check` — passed
- `git diff --check` — passed
- independent Tier 3 review — PASS, no findings
- independent Tier 3 QA — PASS, 42 focused Python + 72 focused API tests, no findings
