### PR TITLE
feat(outreach): migrate job links to stable JobIds

### DIFF
--- a/apps/api/src/db.ts
+++ b/apps/api/src/db.ts
@@ -9,7 +9,7 @@ export type SqliteValue = string | number | bigint | null;
 // writer that stamps ``PRAGMA user_version``; the API only reads it to fail
 // closed on a database written by a newer build. Bump both constants together
 // whenever the schema shape changes.
-export const SUPPORTED_SCHEMA_VERSION = 24;
+export const SUPPORTED_SCHEMA_VERSION = 25;
 
 export class IncompatibleSchemaVersionError extends Error {
   constructor(current: number) {

--- a/apps/api/src/outreach.ts
+++ b/apps/api/src/outreach.ts
@@ -38,7 +38,12 @@ import {
 import {
   allRows,
   getRow,
+  hasCompositeJobIdForeignKeyAction,
   jobKeyReferencePredicateForUrl,
+  jobReferenceColumn,
+  jobReferenceForUrl,
+  tableColumnSet,
+  tableIndexColumns,
   tableExists,
   type SqliteDatabase,
   type SqliteValue,
@@ -59,18 +64,28 @@ export class OutreachInputError extends Error {}
 export class OutreachDraftGatesNotPassedError extends Error {}
 
 export function ensureOutreachTables(db: SqliteDatabase): void {
+  const schemaVersion = Number(
+    db.pragma("user_version", { simple: true }),
+  );
+  const stableReferences = schemaVersion >= 25;
+  const referenceColumn = stableReferences ? "job_id" : "job_url";
+  const foreignKey = stableReferences
+    ? `, FOREIGN KEY (tenant_id, job_id)
+         REFERENCES jobs(tenant_id, job_id) ON DELETE RESTRICT`
+    : "";
   db.exec(`
     CREATE TABLE IF NOT EXISTS outreach_threads (
       tenant_id        TEXT NOT NULL DEFAULT 'local',
       thread_id        TEXT NOT NULL,
       contact_id       TEXT NOT NULL,
-      job_url          TEXT,
+      ${referenceColumn} TEXT,
       created_at       TEXT NOT NULL,
       updated_at       TEXT NOT NULL,
       follow_up_due_at TEXT,
       follow_up_basis  TEXT,
       follow_up_state  TEXT NOT NULL DEFAULT 'none',
       PRIMARY KEY (tenant_id, thread_id)
+      ${foreignKey}
     );
     CREATE TABLE IF NOT EXISTS outreach_drafts (
       tenant_id         TEXT NOT NULL DEFAULT 'local',
@@ -98,13 +113,44 @@ export function ensureOutreachTables(db: SqliteDatabase): void {
       logged_at        TEXT NOT NULL,
       PRIMARY KEY (tenant_id, send_log_id)
     );
-    CREATE INDEX IF NOT EXISTS idx_outreach_threads_contact
-      ON outreach_threads(tenant_id, contact_id);
     CREATE INDEX IF NOT EXISTS idx_outreach_drafts_thread
       ON outreach_drafts(tenant_id, thread_id, generation DESC);
     CREATE INDEX IF NOT EXISTS idx_outreach_send_logs_thread
       ON outreach_send_logs(tenant_id, thread_id);
   `);
+  const columns = tableColumnSet(db, "outreach_threads");
+  if (
+    stableReferences
+    && (!columns.has("job_id") || columns.has("job_url"))
+  ) {
+    throw new Error(
+      "Schema v25 requires stable outreach_threads.job_id references.",
+    );
+  }
+  db.exec(
+    `CREATE INDEX IF NOT EXISTS idx_outreach_threads_contact
+       ON outreach_threads(tenant_id, contact_id, ${referenceColumn})`,
+  );
+  if (
+    stableReferences
+    && (
+      !hasCompositeJobIdForeignKeyAction(
+        db,
+        "outreach_threads",
+        "job_id",
+        "RESTRICT",
+      )
+      || tableIndexColumns(
+        db,
+        "outreach_threads",
+        "idx_outreach_threads_contact",
+      ).join(",") !== "tenant_id,contact_id,job_id"
+    )
+  ) {
+    throw new Error(
+      "Schema v25 requires the restrictive outreach-thread JobId contract.",
+    );
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -597,9 +643,30 @@ type SendLogRow = {
   logged_at: string | null;
 };
 
-const THREAD_COLUMNS =
-  "thread_id, contact_id, job_url, created_at, updated_at, " +
-  "follow_up_due_at, follow_up_basis, follow_up_state";
+function threadColumns(db: SqliteDatabase): string {
+  const stableReferences =
+    jobReferenceColumn(db, "outreach_threads") === "job_id";
+  return [
+    "outreach_threads.thread_id",
+    "outreach_threads.contact_id",
+    stableReferences
+      ? "jobs.url AS job_url"
+      : "outreach_threads.job_url AS job_url",
+    "outreach_threads.created_at",
+    "outreach_threads.updated_at",
+    "outreach_threads.follow_up_due_at",
+    "outreach_threads.follow_up_basis",
+    "outreach_threads.follow_up_state",
+  ].join(", ");
+}
+
+function threadJobJoin(db: SqliteDatabase): string {
+  return jobReferenceColumn(db, "outreach_threads") === "job_id"
+    ? `LEFT JOIN jobs
+         ON jobs.tenant_id = outreach_threads.tenant_id
+        AND jobs.job_id = outreach_threads.job_id`
+    : "";
+}
 
 type DraftRow = {
   draft_id: string;
@@ -628,7 +695,11 @@ function loadThreadRow(db: SqliteDatabase, threadId: string): ThreadRow | null {
   return (
     getRow<ThreadRow>(
       db,
-      `SELECT ${THREAD_COLUMNS} FROM outreach_threads WHERE tenant_id = ? AND thread_id = ?`,
+      `SELECT ${threadColumns(db)}
+         FROM outreach_threads
+         ${threadJobJoin(db)}
+        WHERE outreach_threads.tenant_id = ?
+          AND outreach_threads.thread_id = ?`,
       [TENANT_ID, threadId],
     ) ?? null
   );
@@ -640,19 +711,46 @@ function loadThreadForContact(
   jobId: string | null,
 ): ThreadRow | null {
   const job = (jobId ?? "").trim();
+  const referenceColumn = jobReferenceColumn(
+    db,
+    "outreach_threads",
+  );
   if (job) {
+    let physicalReference: string;
+    try {
+      physicalReference = jobReferenceForUrl(
+        db,
+        "outreach_threads",
+        job,
+        TENANT_ID,
+      );
+    } catch {
+      throw new OutreachInputError(
+        `No stable Job identity exists for ${job}.`,
+      );
+    }
     return (
       getRow<ThreadRow>(
         db,
-        `SELECT ${THREAD_COLUMNS} FROM outreach_threads WHERE tenant_id = ? AND contact_id = ? AND job_url = ?`,
-        [TENANT_ID, contactId, job],
+        `SELECT ${threadColumns(db)}
+           FROM outreach_threads
+           ${threadJobJoin(db)}
+          WHERE outreach_threads.tenant_id = ?
+            AND outreach_threads.contact_id = ?
+            AND outreach_threads.${referenceColumn} = ?`,
+        [TENANT_ID, contactId, physicalReference],
       ) ?? null
     );
   }
   return (
     getRow<ThreadRow>(
       db,
-      `SELECT ${THREAD_COLUMNS} FROM outreach_threads WHERE tenant_id = ? AND contact_id = ? AND job_url IS NULL`,
+      `SELECT ${threadColumns(db)}
+         FROM outreach_threads
+         ${threadJobJoin(db)}
+        WHERE outreach_threads.tenant_id = ?
+          AND outreach_threads.contact_id = ?
+          AND outreach_threads.${referenceColumn} IS NULL`,
       [TENANT_ID, contactId],
     ) ?? null
   );

--- a/apps/api/src/projections.ts
+++ b/apps/api/src/projections.ts
@@ -5082,6 +5082,8 @@ function rebuildOutreachProjections(db: SqliteDatabase, tenantId: string): void 
   if (!tableExists(db, "outreach_threads") || !tableExists(db, "outreach_drafts")) {
     return;
   }
+  const stableReferences =
+    jobReferenceColumn(db, "outreach_threads") === "job_id";
   const threads = allRows<{
     thread_id: string;
     contact_id: string;
@@ -5090,9 +5092,16 @@ function rebuildOutreachProjections(db: SqliteDatabase, tenantId: string): void 
     updated_at: string | null;
   }>(
     db,
-    `SELECT thread_id, contact_id, job_url, created_at, updated_at
-     FROM outreach_threads
-     WHERE tenant_id = ?`,
+    `SELECT outreach.thread_id, outreach.contact_id,
+            ${stableReferences ? "jobs.url" : "outreach.job_url"} AS job_url,
+            outreach.created_at, outreach.updated_at
+       FROM outreach_threads AS outreach
+       ${stableReferences
+         ? `LEFT JOIN jobs
+              ON jobs.tenant_id = outreach.tenant_id
+             AND jobs.job_id = outreach.job_id`
+         : ""}
+      WHERE outreach.tenant_id = ?`,
     [tenantId],
   );
   const liveIds = new Set<string>();
@@ -5202,6 +5211,8 @@ function rebuildDueFollowUpProjections(db: SqliteDatabase, tenantId: string): vo
   if (!tableExists(db, "outreach_threads")) {
     return;
   }
+  const stableReferences =
+    jobReferenceColumn(db, "outreach_threads") === "job_id";
   const threads = allRows<{
     thread_id: string;
     contact_id: string;
@@ -5213,10 +5224,19 @@ function rebuildDueFollowUpProjections(db: SqliteDatabase, tenantId: string): vo
     updated_at: string | null;
   }>(
     db,
-    `SELECT thread_id, contact_id, job_url, follow_up_due_at, follow_up_basis,
-            follow_up_state, created_at, updated_at
-     FROM outreach_threads
-     WHERE tenant_id = ? AND follow_up_state = 'scheduled'`,
+    `SELECT outreach.thread_id, outreach.contact_id,
+            ${stableReferences ? "jobs.url" : "outreach.job_url"} AS job_url,
+            outreach.follow_up_due_at, outreach.follow_up_basis,
+            outreach.follow_up_state, outreach.created_at,
+            outreach.updated_at
+       FROM outreach_threads AS outreach
+       ${stableReferences
+         ? `LEFT JOIN jobs
+              ON jobs.tenant_id = outreach.tenant_id
+             AND jobs.job_id = outreach.job_id`
+         : ""}
+      WHERE outreach.tenant_id = ?
+        AND outreach.follow_up_state = 'scheduled'`,
     [tenantId],
   );
   const liveIds = new Set<string>();

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -2720,14 +2720,26 @@ export function buildApp(options: BuildAppOptions): FastifyInstance {
     async (request, reply) =>
       withDb(reply, options.dbPath, (db) => {
         const query = OutreachThreadQuerySchema.parse(request.query);
-        return {
-          ok: true,
-          thread: getOutreachThreadForContact(
-            db,
-            decodeRouteParam(request.params.contactId),
-            query.jobId ?? null,
-          ),
-        };
+        try {
+          return {
+            ok: true,
+            thread: getOutreachThreadForContact(
+              db,
+              decodeRouteParam(request.params.contactId),
+              query.jobId ?? null,
+            ),
+          };
+        } catch (error) {
+          if (error instanceof OutreachInputError) {
+            void reply.code(400);
+            return {
+              ok: false,
+              error: "invalid_outreach_job",
+              message: error.message,
+            };
+          }
+          throw error;
+        }
       }),
   );
 
@@ -2745,7 +2757,22 @@ export function buildApp(options: BuildAppOptions): FastifyInstance {
       const contactId = decodeRouteParam(request.params.contactId);
       const jobId = body.jobId ?? null;
       return withWritableDb(reply, options.dbPath, async (db) => {
-        const threadId = findOutreachThreadIdForContact(db, contactId, jobId) ?? randomUUID();
+        let threadId: string;
+        try {
+          threadId =
+            findOutreachThreadIdForContact(db, contactId, jobId)
+            ?? randomUUID();
+        } catch (error) {
+          if (error instanceof OutreachInputError) {
+            void reply.code(400);
+            return {
+              ok: false,
+              error: "invalid_outreach_job",
+              message: error.message,
+            };
+          }
+          throw error;
+        }
         await outreachDraftGenerator(
           {
             threadId,

--- a/apps/api/src/write-model.ts
+++ b/apps/api/src/write-model.ts
@@ -862,6 +862,7 @@ function purgeJobRows(db: SqliteDatabase, jobUrl: string): void {
     jobId,
     jobUrl,
   );
+  detachOrDeleteOutreachReferences(db, jobId, jobUrl);
   detachOrDeleteContactReferences(db, jobId, jobUrl);
   deleteJobReferences(db, "job_artifacts", jobId, jobUrl);
   deleteScoringJobReferences(db, jobId, jobUrl);
@@ -918,6 +919,108 @@ function purgeJobRows(db: SqliteDatabase, jobUrl: string): void {
   ]);
   deleteWhere(db, "discovery_feedback", "job_key = ?", [jobUrl]);
   deleteWhere(db, "jobs", "url = ?", [jobUrl]);
+}
+
+function detachOrDeleteOutreachReferences(
+  db: SqliteDatabase,
+  jobId: string | undefined,
+  jobUrl: string,
+): void {
+  if (!tableExists(db, "outreach_threads")) return;
+  const referenceColumn = jobReferenceColumn(
+    db,
+    "outreach_threads",
+  );
+  const reference =
+    referenceColumn === "job_id" ? jobId : jobUrl;
+  if (!reference) return;
+
+  // A Contact with no employer is owned only by the deleted Job and is purged
+  // by the contact cleanup below. Remove its complete outreach aggregate first
+  // so drafts and user-attested send logs cannot become orphaned. Employer-
+  // scoped contacts survive; their outreach history is retained and detached
+  // from the deleted application.
+  const jobOnlyContactIds: string[] = [];
+  if (tableExists(db, "contacts")) {
+    const contactReferenceColumn = jobReferenceColumn(
+      db,
+      "contacts",
+    );
+    const contactReference =
+      contactReferenceColumn === "job_id" ? jobId : jobUrl;
+    if (contactReference) {
+      for (const row of allRows<{ contact_id: string }>(
+        db,
+        `SELECT contact_id
+           FROM contacts
+          WHERE tenant_id = 'local'
+            AND ${contactReferenceColumn} = ?
+            AND NULLIF(TRIM(COALESCE(employer, '')), '') IS NULL`,
+        [contactReference],
+      )) {
+        jobOnlyContactIds.push(row.contact_id);
+      }
+    }
+  }
+  if (jobOnlyContactIds.length) {
+    const contactPlaceholders = jobOnlyContactIds
+      .map(() => "?")
+      .join(", ");
+    const threadIds = allRows<{ thread_id: string }>(
+      db,
+      `SELECT thread_id
+         FROM outreach_threads
+        WHERE tenant_id = 'local'
+          AND contact_id IN (${contactPlaceholders})`,
+      jobOnlyContactIds,
+    ).map((row) => row.thread_id);
+    if (threadIds.length) {
+      const threadPlaceholders = threadIds
+        .map(() => "?")
+        .join(", ");
+      deleteWhere(
+        db,
+        "outreach_send_logs",
+        `tenant_id = 'local'
+         AND thread_id IN (${threadPlaceholders})`,
+        threadIds,
+      );
+      deleteWhere(
+        db,
+        "outreach_drafts",
+        `tenant_id = 'local'
+         AND thread_id IN (${threadPlaceholders})`,
+        threadIds,
+      );
+      deleteWhere(
+        db,
+        "outreach_threads",
+        `tenant_id = 'local'
+         AND thread_id IN (${threadPlaceholders})`,
+        threadIds,
+      );
+    }
+  }
+  db.prepare(
+    `UPDATE outreach_threads
+        SET ${referenceColumn} = NULL
+      WHERE tenant_id = 'local'
+        AND ${referenceColumn} = ?`,
+  ).run(reference);
+  // These read models remain URL-shaped until Phase 4. Clear the tenant slice
+  // so the next normal refresh rebuilds detached rows and omits purged ones.
+  deleteWhere(
+    db,
+    "outreach_thread_projections",
+    "tenant_id = 'local'",
+    [],
+  );
+  deleteWhere(
+    db,
+    "due_follow_up_projections",
+    "tenant_id = 'local'",
+    [],
+  );
 }
 
 function detachOrDeleteContactReferences(

--- a/apps/api/test/outreach-v25.test.ts
+++ b/apps/api/test/outreach-v25.test.ts
@@ -1,0 +1,335 @@
+import Database from "better-sqlite3";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { ensureContactResearchTables } from "../src/contact-research.js";
+import {
+  ensureOutreachTables,
+  findOutreachThreadIdForContact,
+  getOutreachThreadForContact,
+  OutreachInputError,
+} from "../src/outreach.js";
+import {
+  jobReferenceColumn,
+  tableColumnSet,
+} from "../src/db.js";
+import { refreshProjections } from "../src/projections.js";
+import { permanentlyDeleteJob } from "../src/write-model.js";
+
+const NOW = "2026-07-30T12:00:00.000Z";
+const UUID_SHAPED_URL = "11111111-1111-4111-8111-111111111111";
+const TARGET_JOB_ID = "22222222-2222-4222-8222-222222222222";
+const OTHER_JOB_ID = "33333333-3333-4333-8333-333333333333";
+
+let db: Database.Database | undefined;
+
+afterEach(() => {
+  db?.close();
+  db = undefined;
+});
+
+function createDatabase(
+  foreignKeys = true,
+  schemaVersion = 25,
+): Database.Database {
+  const opened = new Database(":memory:");
+  opened.pragma(`foreign_keys = ${foreignKeys ? "ON" : "OFF"}`);
+  opened.exec(`
+    CREATE TABLE jobs (
+      url TEXT PRIMARY KEY,
+      tenant_id TEXT NOT NULL DEFAULT 'local',
+      job_id TEXT NOT NULL,
+      title TEXT,
+      company TEXT,
+      salary TEXT,
+      description TEXT,
+      location TEXT,
+      site TEXT,
+      strategy TEXT,
+      discovered_at TEXT,
+      full_description TEXT,
+      application_url TEXT,
+      detail_scraped_at TEXT,
+      detail_error TEXT,
+      fit_score INTEGER,
+      score_reasoning TEXT,
+      scored_at TEXT,
+      tailored_resume_path TEXT,
+      tailored_at TEXT,
+      tailor_attempts INTEGER DEFAULT 0,
+      cover_letter_path TEXT,
+      cover_letter_at TEXT,
+      cover_attempts INTEGER DEFAULT 0,
+      applied_at TEXT,
+      apply_status TEXT,
+      apply_error TEXT,
+      apply_attempts INTEGER DEFAULT 0,
+      agent_id TEXT,
+      last_attempted_at TEXT,
+      apply_duration_ms INTEGER,
+      apply_task_id TEXT,
+      verification_confidence TEXT,
+      UNIQUE (tenant_id, job_id)
+    );
+    CREATE TABLE job_identity_aliases (
+      tenant_id TEXT NOT NULL,
+      alias_kind TEXT NOT NULL,
+      alias_value TEXT NOT NULL,
+      job_id TEXT NOT NULL,
+      created_at TEXT NOT NULL,
+      retired_at TEXT,
+      PRIMARY KEY (tenant_id, alias_kind, alias_value)
+    );
+    CREATE TABLE job_events (
+      event_id INTEGER PRIMARY KEY AUTOINCREMENT,
+      job_url TEXT,
+      stage TEXT,
+      event_type TEXT NOT NULL,
+      level TEXT NOT NULL DEFAULT 'info',
+      message TEXT,
+      occurred_at TEXT NOT NULL,
+      payload_json TEXT,
+      entity_kind TEXT,
+      entity_ref TEXT
+    );
+    PRAGMA user_version = ${schemaVersion};
+  `);
+  ensureContactResearchTables(opened);
+  ensureOutreachTables(opened);
+  return opened;
+}
+
+function insertJob(
+  url: string,
+  jobId: string,
+  company = "ExampleCo",
+): void {
+  db!.prepare(
+    `INSERT INTO jobs (
+       url, tenant_id, job_id, title, company, discovered_at
+     ) VALUES (?, 'local', ?, 'Platform Engineer', ?, ?)`,
+  ).run(url, jobId, company, NOW);
+}
+
+function indexColumns(table: string, name: string): string[] {
+  return (
+    db!.prepare(`PRAGMA index_info("${name}")`).all() as Array<{
+      seqno: number;
+      name: string;
+    }>
+  )
+    .sort((left, right) => left.seqno - right.seqno)
+    .map((row) => row.name);
+}
+
+describe("schema-v25 OutreachThread references", () => {
+  it("recovers a stable nullable reference table with a restrictive FK", () => {
+    db = createDatabase();
+
+    expect(tableColumnSet(db, "outreach_threads")).toContain("job_id");
+    expect(tableColumnSet(db, "outreach_threads")).not.toContain(
+      "job_url",
+    );
+    expect(
+      indexColumns(
+        "outreach_threads",
+        "idx_outreach_threads_contact",
+      ),
+    ).toEqual(["tenant_id", "contact_id", "job_id"]);
+    const actions = new Set(
+      (
+        db
+          .prepare('PRAGMA foreign_key_list("outreach_threads")')
+          .all() as Array<{ on_delete: string }>
+      ).map((row) => row.on_delete),
+    );
+    expect(actions).toEqual(new Set(["RESTRICT"]));
+  });
+
+  it("fails closed when a v25 stamp has a legacy outreach table", () => {
+    db = createDatabase(true, 24);
+    db.pragma("user_version = 25");
+
+    expect(() => ensureOutreachTables(db!)).toThrow(
+      "Schema v25 requires stable outreach_threads.job_id references.",
+    );
+  });
+
+  it("resolves UUID-shaped URL inputs URL-first and projects URLs", () => {
+    db = createDatabase();
+    insertJob(UUID_SHAPED_URL, TARGET_JOB_ID);
+    insertJob(
+      "https://careers.example.test/uuid-id-owner",
+      UUID_SHAPED_URL,
+    );
+    db.prepare(
+      `INSERT INTO outreach_threads (
+         tenant_id, thread_id, contact_id, job_id,
+         created_at, updated_at
+       ) VALUES ('local', 'thread:uuid-url', 'contact:one', ?, ?, ?)`,
+    ).run(TARGET_JOB_ID, NOW, NOW);
+    db.prepare(
+      `INSERT INTO outreach_drafts (
+         tenant_id, draft_id, thread_id, generation, kind,
+         status, gate_results_json, created_at
+       ) VALUES (
+         'local', 'draft:one', 'thread:uuid-url', 1,
+         'intro_request', 'candidate', '{"passed":true}', ?
+       )`,
+    ).run(NOW);
+
+    expect(
+      findOutreachThreadIdForContact(
+        db,
+        "contact:one",
+        UUID_SHAPED_URL,
+      ),
+    ).toBe("thread:uuid-url");
+    const detail = getOutreachThreadForContact(
+      db,
+      "contact:one",
+      UUID_SHAPED_URL,
+    );
+    expect(detail?.jobId).toBe(UUID_SHAPED_URL);
+    expect(
+      db
+        .prepare(
+          "SELECT job_id FROM outreach_thread_projections",
+        )
+        .get(),
+    ).toEqual({ job_id: UUID_SHAPED_URL });
+  });
+
+  it("fails closed when a linked URL has no stable Job identity", () => {
+    db = createDatabase();
+
+    expect(() =>
+      findOutreachThreadIdForContact(
+        db!,
+        "contact:missing",
+        "https://missing.example.test/job",
+      ),
+    ).toThrow(OutreachInputError);
+  });
+
+  function assertPermanentDeletionBehavior(
+    foreignKeys: boolean,
+  ): void {
+    db = createDatabase(foreignKeys);
+    const targetUrl = "https://careers.example.test/delete";
+    const otherUrl = "https://careers.example.test/keep";
+    insertJob(targetUrl, TARGET_JOB_ID);
+    insertJob(otherUrl, OTHER_JOB_ID, "OtherCo");
+    expect(jobReferenceColumn(db, "outreach_threads")).toBe("job_id");
+
+    db.exec(`
+      INSERT INTO contacts (
+        tenant_id, contact_id, employer, job_id, role,
+        created_at, updated_at
+      ) VALUES
+        ('local', 'contact:employer', 'ExampleCo', '${TARGET_JOB_ID}', 'other', '${NOW}', '${NOW}'),
+        ('local', 'contact:job-only', NULL, '${TARGET_JOB_ID}', 'other', '${NOW}', '${NOW}'),
+        ('local', 'contact:other', 'OtherCo', '${OTHER_JOB_ID}', 'other', '${NOW}', '${NOW}');
+      INSERT INTO outreach_threads (
+        tenant_id, thread_id, contact_id, job_id,
+        created_at, updated_at, follow_up_due_at,
+        follow_up_basis, follow_up_state
+      ) VALUES
+        ('local', 'thread:employer', 'contact:employer', '${TARGET_JOB_ID}', '${NOW}', '${NOW}', '${NOW}', 'application_submitted', 'scheduled'),
+        ('local', 'thread:job-only', 'contact:job-only', '${TARGET_JOB_ID}', '${NOW}', '${NOW}', NULL, NULL, 'none'),
+        ('local', 'thread:other', 'contact:other', '${OTHER_JOB_ID}', '${NOW}', '${NOW}', NULL, NULL, 'none');
+      INSERT INTO outreach_drafts (
+        tenant_id, draft_id, thread_id, generation, kind,
+        status, gate_results_json, created_at
+      ) VALUES
+        ('local', 'draft:employer', 'thread:employer', 1, 'intro_request', 'approved', '{"passed":true}', '${NOW}'),
+        ('local', 'draft:job-only', 'thread:job-only', 1, 'intro_request', 'approved', '{"passed":true}', '${NOW}'),
+        ('local', 'draft:other', 'thread:other', 1, 'intro_request', 'approved', '{"passed":true}', '${NOW}');
+      INSERT INTO outreach_send_logs (
+        tenant_id, send_log_id, thread_id, draft_id,
+        channel, sent_at, logged_at
+      ) VALUES
+        ('local', 'send:employer', 'thread:employer', 'draft:employer', 'other', '${NOW}', '${NOW}'),
+        ('local', 'send:job-only', 'thread:job-only', 'draft:job-only', 'other', '${NOW}', '${NOW}'),
+        ('local', 'send:other', 'thread:other', 'draft:other', 'other', '${NOW}', '${NOW}');
+    `);
+    refreshProjections(db);
+
+    expect(permanentlyDeleteJob(db, targetUrl)).toEqual({
+      ok: true,
+      count: 1,
+      jobKeys: [targetUrl],
+    });
+
+    expect(
+      db
+        .prepare(
+          "SELECT thread_id, job_id FROM outreach_threads ORDER BY thread_id",
+        )
+        .all(),
+    ).toEqual([
+      { thread_id: "thread:employer", job_id: null },
+      { thread_id: "thread:other", job_id: OTHER_JOB_ID },
+    ]);
+    expect(
+      db
+        .prepare(
+          "SELECT draft_id FROM outreach_drafts ORDER BY draft_id",
+        )
+        .all(),
+    ).toEqual([
+      { draft_id: "draft:employer" },
+      { draft_id: "draft:other" },
+    ]);
+    expect(
+      db
+        .prepare(
+          "SELECT send_log_id FROM outreach_send_logs ORDER BY send_log_id",
+        )
+        .all(),
+    ).toEqual([
+      { send_log_id: "send:employer" },
+      { send_log_id: "send:other" },
+    ]);
+    expect(
+      db
+        .prepare(
+          "SELECT contact_id, job_id FROM contacts ORDER BY contact_id",
+        )
+        .all(),
+    ).toEqual([
+      { contact_id: "contact:employer", job_id: null },
+      { contact_id: "contact:other", job_id: OTHER_JOB_ID },
+    ]);
+    expect(
+      db.prepare("SELECT COUNT(*) AS c FROM jobs WHERE url = ?").get(
+        targetUrl,
+      ),
+    ).toEqual({ c: 0 });
+
+    refreshProjections(db);
+    expect(
+      db
+        .prepare(
+          "SELECT thread_id, job_id FROM outreach_thread_projections ORDER BY thread_id",
+        )
+        .all(),
+    ).toEqual([
+      { thread_id: "thread:employer", job_id: null },
+      { thread_id: "thread:other", job_id: otherUrl },
+    ]);
+    expect(
+      db
+        .prepare(
+          "SELECT thread_id, job_id FROM due_follow_up_projections ORDER BY thread_id",
+        )
+        .all(),
+    ).toEqual([
+      { thread_id: "thread:employer", job_id: null },
+    ]);
+  }
+
+  it.each([true, false])(
+    "detaches preserved history and purges job-only outreach (foreign keys: %s)",
+    assertPermanentDeletionBehavior,
+  );
+});

--- a/apps/api/test/qa-seed.ts
+++ b/apps/api/test/qa-seed.ts
@@ -1947,6 +1947,10 @@ function seedDiscoverySources(db: Database.Database): void {
 
 function seedOutreachThread(db: Database.Database): void {
   ensureOutreachTables(db);
+  const outreachReference = jobReferenceColumn(
+    db,
+    "outreach_threads",
+  );
   const threadId = "qa-outreach-hiring-manager";
   const approvedDraftId = "qa-outreach-approved-intro";
   const gateResults = JSON.stringify({
@@ -1987,7 +1991,8 @@ function seedOutreachThread(db: Database.Database): void {
 
   db.prepare(
     `INSERT INTO outreach_threads (
-      tenant_id, thread_id, contact_id, job_url, created_at, updated_at,
+      tenant_id, thread_id, contact_id, ${outreachReference},
+      created_at, updated_at,
       follow_up_due_at, follow_up_basis, follow_up_state
     ) VALUES ('local', ?, 'qa-contact-hiring-manager', NULL, ?, ?, ?, 'manual', 'scheduled')`,
   ).run(

--- a/apps/api/test/schema-version-guard.test.ts
+++ b/apps/api/test/schema-version-guard.test.ts
@@ -63,7 +63,7 @@ describe("schema version guard at DB open", () => {
   });
 
   it("opens the worker-owned schema-v14 artifact registry", () => {
-    expect(SUPPORTED_SCHEMA_VERSION).toBe(24);
+    expect(SUPPORTED_SCHEMA_VERSION).toBe(25);
     const { dbPath, cleanup } = makeDbWithUserVersion(14);
     try {
       openDatabase(dbPath).close();

--- a/apps/web/e2e/tests/outreach.spec.ts
+++ b/apps/web/e2e/tests/outreach.spec.ts
@@ -85,10 +85,18 @@ function ensureOutreachSeedTables(db: Database.Database): void {
     db.pragma("user_version", { simple: true }),
   );
   const stableContactReferences = schemaVersion >= 24;
+  const stableOutreachReferences = schemaVersion >= 25;
   const contactReference = stableContactReferences
     ? "job_id"
     : "job_url";
   const contactForeignKey = stableContactReferences
+    ? `, FOREIGN KEY (tenant_id, job_id)
+         REFERENCES jobs(tenant_id, job_id) ON DELETE RESTRICT`
+    : "";
+  const outreachReference = stableOutreachReferences
+    ? "job_id"
+    : "job_url";
+  const outreachForeignKey = stableOutreachReferences
     ? `, FOREIGN KEY (tenant_id, job_id)
          REFERENCES jobs(tenant_id, job_id) ON DELETE RESTRICT`
     : "";
@@ -155,13 +163,14 @@ function ensureOutreachSeedTables(db: Database.Database): void {
       tenant_id        TEXT NOT NULL DEFAULT 'local',
       thread_id        TEXT NOT NULL,
       contact_id       TEXT NOT NULL,
-      job_url          TEXT,
+      ${outreachReference} TEXT,
       created_at       TEXT NOT NULL,
       updated_at       TEXT NOT NULL,
       follow_up_due_at TEXT,
       follow_up_basis  TEXT,
       follow_up_state  TEXT NOT NULL DEFAULT 'none',
       PRIMARY KEY (tenant_id, thread_id)
+      ${outreachForeignKey}
     );
     CREATE TABLE IF NOT EXISTS outreach_drafts (
       tenant_id         TEXT NOT NULL DEFAULT 'local',
@@ -394,9 +403,20 @@ function seedOutreachPlanner(dbPath: string): void {
       NOW,
     );
 
+    const outreachReference = referenceColumn(
+      db,
+      "outreach_threads",
+      "job_url",
+    );
+    const outreachJobReference = referenceForJobUrl(
+      db,
+      outreachReference,
+      JOB_URL,
+    );
     const insertThread = db.prepare(
       `INSERT INTO outreach_threads (
-         tenant_id, thread_id, contact_id, job_url, created_at, updated_at,
+         tenant_id, thread_id, contact_id, ${outreachReference},
+         created_at, updated_at,
          follow_up_due_at, follow_up_basis, follow_up_state
        ) VALUES ('local', ?, ?, ?, ?, ?, ?, ?, ?)`,
     );
@@ -413,7 +433,7 @@ function seedOutreachPlanner(dbPath: string): void {
     insertThread.run(
       DUE_THREAD_ID,
       CONTACT_ID,
-      JOB_URL,
+      outreachJobReference,
       NOW,
       NOW,
       PAST_DUE_AT,
@@ -423,7 +443,7 @@ function seedOutreachPlanner(dbPath: string): void {
     insertThread.run(
       FUTURE_THREAD_ID,
       CONTACT_ID,
-      JOB_URL,
+      outreachJobReference,
       NOW,
       NOW,
       FUTURE_DUE_AT,

--- a/workers/automation/src/jobctrl/database.py
+++ b/workers/automation/src/jobctrl/database.py
@@ -91,7 +91,13 @@ from jobctrl.config import DB_PATH, DEFAULTS, migrate_legacy_job_tables
 # facts, research candidates, and the URL-shaped public/read-model boundary stay
 # unchanged. Job deletion is restricted so the explicit permanent-delete path
 # can detach employer-linked records instead of silently erasing them.
-SCHEMA_VERSION = 24
+# v25 (outreach references): optional application links on OutreachThread move
+# to tenant-scoped stable JobIds. Draft and user-attested send histories remain
+# keyed by the thread aggregate, while URL-shaped public/read-model values are
+# resolved at the adapter boundary. Job deletion is restricted so the explicit
+# permanent-delete path can detach preserved outreach history or purge threads
+# whose job-only Contact is removed.
+SCHEMA_VERSION = 25
 
 
 class IncompatibleSchemaVersionError(RuntimeError):
@@ -246,6 +252,7 @@ def _schema_migrations() -> tuple[
         (22, ensure_application_feedback_candidate_references_v22),
         (23, ensure_repeat_application_references_v23),
         (24, ensure_contact_research_references_v24),
+        (25, ensure_outreach_references_v25),
     )
 
 
@@ -538,6 +545,39 @@ def _create_contact_research_tasks_table_v24(
     )
 
 
+def _create_outreach_threads_table_v25(
+    conn: sqlite3.Connection,
+    *,
+    table: str,
+    stable_reference: bool,
+) -> None:
+    reference_column = "job_id" if stable_reference else "job_url"
+    foreign_key = (
+        """,
+            FOREIGN KEY (tenant_id, job_id)
+                REFERENCES jobs(tenant_id, job_id) ON DELETE RESTRICT"""
+        if stable_reference
+        else ""
+    )
+    conn.execute(
+        f"""
+        CREATE TABLE "{table}" (
+            tenant_id           TEXT NOT NULL DEFAULT 'local',
+            thread_id           TEXT NOT NULL,
+            contact_id          TEXT NOT NULL,
+            {reference_column}  TEXT,
+            created_at          TEXT NOT NULL,
+            updated_at          TEXT NOT NULL,
+            follow_up_due_at    TEXT,
+            follow_up_basis     TEXT,
+            follow_up_state     TEXT NOT NULL DEFAULT 'none',
+            PRIMARY KEY (tenant_id, thread_id)
+            {foreign_key}
+        )
+        """
+    )
+
+
 def ensure_contact_tables(conn: sqlite3.Connection | None = None) -> list[str]:
     """Create the Contact & Outreach (ninth bounded context) canonical tables.
 
@@ -559,6 +599,9 @@ def ensure_contact_tables(conn: sqlite3.Connection | None = None) -> list[str]:
     current_version = _assert_schema_version_supported(conn)
     stable_contact_references = (
         current_version >= _CONTACT_RESEARCH_REFERENCE_SCHEMA_VERSION
+    )
+    stable_outreach_references = (
+        current_version >= _OUTREACH_REFERENCE_SCHEMA_VERSION
     )
     if not _table_columns(conn, "contacts"):
         _create_contacts_table_v24(
@@ -606,20 +649,12 @@ def ensure_contact_tables(conn: sqlite3.Connection | None = None) -> list[str]:
             PRIMARY KEY (tenant_id, candidate_id)
         )
     """)
-    conn.execute("""
-        CREATE TABLE IF NOT EXISTS outreach_threads (
-            tenant_id           TEXT NOT NULL DEFAULT 'local',
-            thread_id           TEXT NOT NULL,
-            contact_id          TEXT NOT NULL,
-            job_url             TEXT,
-            created_at          TEXT NOT NULL,
-            updated_at          TEXT NOT NULL,
-            follow_up_due_at    TEXT,
-            follow_up_basis     TEXT,
-            follow_up_state     TEXT NOT NULL DEFAULT 'none',
-            PRIMARY KEY (tenant_id, thread_id)
+    if not _table_columns(conn, "outreach_threads"):
+        _create_outreach_threads_table_v25(
+            conn,
+            table="outreach_threads",
+            stable_reference=stable_outreach_references,
         )
-    """)
     conn.execute("""
         CREATE TABLE IF NOT EXISTS outreach_drafts (
             tenant_id           TEXT NOT NULL DEFAULT 'local',
@@ -695,10 +730,24 @@ def ensure_contact_tables(conn: sqlite3.Connection | None = None) -> list[str]:
         CREATE INDEX IF NOT EXISTS idx_contact_candidates_task
         ON contact_candidates(tenant_id, task_id, status)
     """)
-    conn.execute("""
-        CREATE INDEX IF NOT EXISTS idx_outreach_threads_contact
-        ON outreach_threads(tenant_id, contact_id)
-    """)
+    if stable_outreach_references:
+        if (
+            "job_id" not in _table_columns(conn, "outreach_threads")
+            or "job_url" in _table_columns(conn, "outreach_threads")
+        ):
+            raise RuntimeError(
+                "Schema v25 requires stable outreach-thread JobId references."
+            )
+        _create_outreach_reference_indexes_v25(conn)
+        if not _has_outreach_reference_schema_v25(conn):
+            raise RuntimeError(
+                "Schema v25 requires stable outreach-thread JobId references."
+            )
+    else:
+        conn.execute("""
+            CREATE INDEX IF NOT EXISTS idx_outreach_threads_contact
+            ON outreach_threads(tenant_id, contact_id)
+        """)
     conn.execute("""
         CREATE INDEX IF NOT EXISTS idx_outreach_drafts_thread
         ON outreach_drafts(tenant_id, thread_id, generation DESC)
@@ -4792,6 +4841,15 @@ def _reassign_discovery_identity_references(
         )
     if _has_contact_research_reference_schema_v24(conn):
         _reassign_contact_research_references_v24(
+            conn,
+            tenant_id=tenant_id,
+            losing_job_id=losing_job_id,
+            surviving_job_id=surviving_job_id,
+            losing_job_url=losing_job_url,
+            surviving_job_url=surviving_job_url,
+        )
+    if _has_outreach_reference_schema_v25(conn):
+        _reassign_outreach_references_v25(
             conn,
             tenant_id=tenant_id,
             losing_job_id=losing_job_id,
@@ -14896,6 +14954,281 @@ def _reassign_contact_research_references_v24(
             (surviving_job_url, tenant_id, losing_job_url),
         )
     _verify_contact_research_references_v24(
+        conn,
+        expected_counts=expected_counts,
+    )
+
+
+_OUTREACH_REFERENCE_SCHEMA_VERSION = 25
+_OUTREACH_REFERENCE_TABLES = ("outreach_threads",)
+_OUTREACH_HISTORY_TABLES = (
+    "outreach_threads",
+    "outreach_drafts",
+    "outreach_send_logs",
+)
+
+
+def _has_outreach_reference_schema_v25(
+    conn: sqlite3.Connection,
+) -> bool:
+    table = "outreach_threads"
+    return (
+        "job_id" in _table_columns(conn, table)
+        and "job_url" not in _table_columns(conn, table)
+        and _primary_key_columns(conn, table)
+        == ("tenant_id", "thread_id")
+        and _has_composite_job_id_foreign_key_action(
+            conn,
+            table=table,
+            reference_column="job_id",
+            on_delete="RESTRICT",
+        )
+        and _has_index(
+            conn,
+            table,
+            "idx_outreach_threads_contact",
+            ("tenant_id", "contact_id", "job_id"),
+            unique=False,
+        )
+    )
+
+
+def _canonical_outreach_thread_rows_v25(
+    conn: sqlite3.Connection,
+) -> list[tuple[Any, ...]]:
+    reference_column = _legacy_or_stable_reference_column(
+        conn,
+        "outreach_threads",
+        stable="job_id",
+        legacy="job_url",
+    )
+    rows = conn.execute(
+        f"""
+        SELECT tenant_id, thread_id, contact_id, {reference_column},
+               created_at, updated_at, follow_up_due_at,
+               follow_up_basis, follow_up_state
+        FROM outreach_threads
+        ORDER BY tenant_id, thread_id
+        """
+    ).fetchall()
+    canonical: list[tuple[Any, ...]] = []
+    for row in rows:
+        values = tuple(row)
+        raw_reference = values[3]
+        stable_job_id: str | None = None
+        if raw_reference is not None:
+            stable_job_id = _resolve_job_reference_value(
+                conn,
+                tenant_id=str(values[0]),
+                reference=str(raw_reference),
+                legacy_url=reference_column == "job_url",
+            )
+            if stable_job_id is None:
+                raise RuntimeError(
+                    "outreach reference migration could not resolve "
+                    f"outreach_threads.{reference_column}="
+                    f"{raw_reference!r} for tenant {values[0]!r}"
+                )
+            _validate_job_uuid(stable_job_id)
+        canonical.append(
+            (
+                values[0],
+                values[1],
+                values[2],
+                stable_job_id,
+                *values[4:],
+            )
+        )
+    return canonical
+
+
+def _create_outreach_reference_indexes_v25(
+    conn: sqlite3.Connection,
+) -> None:
+    if _has_index(
+        conn,
+        "outreach_threads",
+        "idx_outreach_threads_contact",
+        ("tenant_id", "contact_id", "job_id"),
+        unique=False,
+    ):
+        return
+    conn.execute(
+        'DROP INDEX IF EXISTS "idx_outreach_threads_contact"'
+    )
+    conn.execute(
+        """
+        CREATE INDEX idx_outreach_threads_contact
+        ON outreach_threads(tenant_id, contact_id, job_id)
+        """
+    )
+
+
+def ensure_outreach_references_v25(
+    conn: sqlite3.Connection | None = None,
+) -> list[str]:
+    """Move optional OutreachThread application links to stable JobIds."""
+    if conn is None:
+        conn = get_connection()
+    current = _assert_schema_version_supported(conn)
+    if current >= _OUTREACH_REFERENCE_SCHEMA_VERSION:
+        return list(_OUTREACH_REFERENCE_TABLES)
+    if current != _CONTACT_RESEARCH_REFERENCE_SCHEMA_VERSION:
+        raise RuntimeError(
+            "outreach reference migration requires schema v24; "
+            f"found v{current}"
+        )
+
+    expected_counts = {
+        table: int(
+            conn.execute(
+                f'SELECT COUNT(*) FROM "{table}"'
+            ).fetchone()[0]
+        )
+        for table in _OUTREACH_HISTORY_TABLES
+    }
+    conn.execute("SAVEPOINT outreach_references_v25")
+    try:
+        thread_rows = _canonical_outreach_thread_rows_v25(conn)
+
+        conn.execute("DROP TABLE IF EXISTS outreach_threads_v25")
+        _create_outreach_threads_table_v25(
+            conn,
+            table="outreach_threads_v25",
+            stable_reference=True,
+        )
+        conn.executemany(
+            """
+            INSERT INTO outreach_threads_v25 (
+                tenant_id, thread_id, contact_id, job_id,
+                created_at, updated_at, follow_up_due_at,
+                follow_up_basis, follow_up_state
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            thread_rows,
+        )
+
+        conn.execute('DROP TABLE "outreach_threads"')
+        conn.execute(
+            'ALTER TABLE "outreach_threads_v25" '
+            'RENAME TO "outreach_threads"'
+        )
+        _create_outreach_reference_indexes_v25(conn)
+        _verify_outreach_references_v25(
+            conn,
+            expected_counts=expected_counts,
+        )
+        conn.execute(
+            f"PRAGMA user_version = "
+            f"{_OUTREACH_REFERENCE_SCHEMA_VERSION}"
+        )
+        conn.execute("RELEASE SAVEPOINT outreach_references_v25")
+    except BaseException:
+        conn.execute(
+            "ROLLBACK TO SAVEPOINT outreach_references_v25"
+        )
+        conn.execute(
+            "RELEASE SAVEPOINT outreach_references_v25"
+        )
+        raise
+    return list(_OUTREACH_REFERENCE_TABLES)
+
+
+def _verify_outreach_references_v25(
+    conn: sqlite3.Connection,
+    *,
+    expected_counts: dict[str, int],
+) -> None:
+    if not _has_outreach_reference_schema_v25(conn):
+        raise RuntimeError(
+            "outreach reference migration did not create the stable "
+            "reference schema"
+        )
+    for table, expected_count in expected_counts.items():
+        observed_count = int(
+            conn.execute(
+                f'SELECT COUNT(*) FROM "{table}"'
+            ).fetchone()[0]
+        )
+        if observed_count != expected_count:
+            raise RuntimeError(
+                "outreach reference migration changed "
+                f"{table} row count: expected {expected_count}, "
+                f"found {observed_count}"
+            )
+    orphan = conn.execute(
+        """
+        SELECT source.job_id
+        FROM outreach_threads AS source
+        LEFT JOIN jobs
+          ON jobs.tenant_id = source.tenant_id
+         AND jobs.job_id = source.job_id
+        WHERE source.job_id IS NOT NULL
+          AND jobs.job_id IS NULL
+        LIMIT 1
+        """
+    ).fetchone()
+    if orphan is not None:
+        raise RuntimeError(
+            "outreach reference migration left an unresolved "
+            "JobId in outreach_threads.job_id"
+        )
+    for row in conn.execute(
+        "SELECT DISTINCT job_id FROM outreach_threads "
+        "WHERE job_id IS NOT NULL"
+    ).fetchall():
+        _validate_job_uuid(str(row[0]))
+    foreign_key_error = conn.execute(
+        "PRAGMA foreign_key_check"
+    ).fetchone()
+    if foreign_key_error is not None:
+        raise RuntimeError(
+            "outreach reference migration found a foreign-key violation"
+        )
+
+
+def _reassign_outreach_references_v25(
+    conn: sqlite3.Connection,
+    *,
+    tenant_id: str,
+    losing_job_id: str,
+    surviving_job_id: str,
+    losing_job_url: str,
+    surviving_job_url: str,
+) -> None:
+    if losing_job_id == surviving_job_id:
+        return
+    expected_counts = {
+        table: int(
+            conn.execute(
+                f'SELECT COUNT(*) FROM "{table}"'
+            ).fetchone()[0]
+        )
+        for table in _OUTREACH_HISTORY_TABLES
+    }
+    conn.execute(
+        """
+        UPDATE outreach_threads
+        SET job_id = ?
+        WHERE tenant_id = ? AND job_id = ?
+        """,
+        (surviving_job_id, tenant_id, losing_job_id),
+    )
+    for projection in (
+        "outreach_thread_projections",
+        "due_follow_up_projections",
+    ):
+        if not _table_columns(conn, projection):
+            continue
+        conn.execute(
+            f"""
+            UPDATE "{projection}"
+            SET job_id = ?
+            WHERE tenant_id = ? AND job_id = ?
+            """,
+            (surviving_job_url, tenant_id, losing_job_url),
+        )
+    _verify_outreach_references_v25(
         conn,
         expected_counts=expected_counts,
     )

--- a/workers/automation/src/jobctrl/infrastructure/contact/job_reference.py
+++ b/workers/automation/src/jobctrl/infrastructure/contact/job_reference.py
@@ -1,9 +1,10 @@
-"""Compatibility boundary for Contact-owned optional Job links.
+"""Compatibility boundary for Contact and Outreach optional Job links.
 
-Schema v24 stores tenant-scoped stable ``JobId`` values while the Contact
-domain and public DTOs remain URL-shaped until the Phase-4 cutover. Resolution
-is deliberately URL-first so a UUID-shaped posting URL cannot bind to an
-unrelated row whose stable id happens to contain the same text.
+Schemas v24-v25 store tenant-scoped stable ``JobId`` values while the Contact,
+ContactResearch, and Outreach domains and public DTOs remain URL-shaped until
+the Phase-4 cutover. Resolution is deliberately URL-first so a UUID-shaped
+posting URL cannot bind to an unrelated row whose stable id happens to contain
+the same text.
 """
 
 from __future__ import annotations

--- a/workers/automation/src/jobctrl/infrastructure/contact/outreach_repository.py
+++ b/workers/automation/src/jobctrl/infrastructure/contact/outreach_repository.py
@@ -45,6 +45,11 @@ from jobctrl.domain.contact.outreach_gates import (
 from jobctrl.domain.materials.value_objects import ArtifactStatus
 from jobctrl.domain.ports.events import EventPublisher
 from jobctrl.domain.tenant import TenantId
+from jobctrl.infrastructure.contact.job_reference import (
+    contact_job_reference_column,
+    physical_contact_job_reference,
+    public_contact_job_reference,
+)
 from jobctrl.state import record_job_event
 
 logger = logging.getLogger(__name__)
@@ -57,6 +62,10 @@ class SqliteOutreachThreadRepository:
         self._conn = conn
         self._publisher = publisher
         ensure_contact_tables(self._conn)
+        self._reference_column = contact_job_reference_column(
+            self._conn,
+            "outreach_threads",
+        )
 
     # ------------------------------------------------------------------ load
 
@@ -73,19 +82,27 @@ class SqliteOutreachThreadRepository:
         self, tenant_id: TenantId, contact_id: str, job_id: str | None = None
     ) -> OutreachThread | None:
         if job_id:
+            reference = physical_contact_job_reference(
+                self._conn,
+                table="outreach_threads",
+                tenant_id=tenant_id,
+                public_reference=job_id,
+            )
             row = self._conn.execute(
-                """
+                f"""
                 SELECT * FROM outreach_threads
-                WHERE tenant_id = ? AND contact_id = ? AND job_url = ?
+                WHERE tenant_id = ? AND contact_id = ?
+                  AND {self._reference_column} = ?
                 ORDER BY updated_at DESC LIMIT 1
                 """,
-                (str(tenant_id), str(contact_id), str(job_id)),
+                (str(tenant_id), str(contact_id), str(reference)),
             ).fetchone()
         else:
             row = self._conn.execute(
-                """
+                f"""
                 SELECT * FROM outreach_threads
-                WHERE tenant_id = ? AND contact_id = ? AND job_url IS NULL
+                WHERE tenant_id = ? AND contact_id = ?
+                  AND {self._reference_column} IS NULL
                 ORDER BY updated_at DESC LIMIT 1
                 """,
                 (str(tenant_id), str(contact_id)),
@@ -107,11 +124,17 @@ class SqliteOutreachThreadRepository:
 
     def _row_to_thread(self, tenant_id: TenantId, row: sqlite3.Row) -> OutreachThread:
         thread_id = str(row["thread_id"])
+        physical_reference = row[self._reference_column]
         return OutreachThread(
             tenant_id=tenant_id,
             thread_id=thread_id,
             contact_id=str(row["contact_id"]),
-            job_id=row["job_url"],
+            job_id=public_contact_job_reference(
+                self._conn,
+                table="outreach_threads",
+                tenant_id=tenant_id,
+                physical_reference=physical_reference,
+            ),
             drafts=self._load_drafts(tenant_id, thread_id),
             created_at=str(row["created_at"] or ""),
             updated_at=str(row["updated_at"] or ""),
@@ -195,16 +218,24 @@ class SqliteOutreachThreadRepository:
     def _persist_canonical(self, tenant_id: TenantId, thread: OutreachThread) -> None:
         tenant = str(tenant_id)
         thread_id = str(thread.thread_id)
+        job_reference = physical_contact_job_reference(
+            self._conn,
+            table="outreach_threads",
+            tenant_id=tenant_id,
+            public_reference=thread.job_id,
+        )
         with self._conn:
             self._conn.execute(
-                """
+                f"""
                 INSERT INTO outreach_threads (
-                    tenant_id, thread_id, contact_id, job_url, created_at, updated_at,
+                    tenant_id, thread_id, contact_id, {self._reference_column},
+                    created_at, updated_at,
                     follow_up_due_at, follow_up_basis, follow_up_state
                 ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
                 ON CONFLICT(tenant_id, thread_id) DO UPDATE SET
                     contact_id       = excluded.contact_id,
-                    job_url          = excluded.job_url,
+                    {self._reference_column} =
+                        excluded.{self._reference_column},
                     updated_at       = excluded.updated_at,
                     follow_up_due_at = excluded.follow_up_due_at,
                     follow_up_basis  = excluded.follow_up_basis,
@@ -214,7 +245,7 @@ class SqliteOutreachThreadRepository:
                     tenant,
                     thread_id,
                     thread.contact_id,
-                    thread.job_id,
+                    job_reference,
                     thread.created_at,
                     thread.updated_at,
                     thread.follow_up.due_at,

--- a/workers/automation/src/jobctrl/infrastructure/projections/projection_builder.py
+++ b/workers/automation/src/jobctrl/infrastructure/projections/projection_builder.py
@@ -1248,10 +1248,15 @@ class ProjectionBuilder:
         dropped so the rebuild stays a faithful mirror of canonical state.
         """
         tenant = str(self._tenant_id)
+        reference_column = contact_job_reference_column(
+            self._conn,
+            "outreach_threads",
+        )
         try:
             thread_rows = self._conn.execute(
-                """
-                SELECT thread_id, contact_id, job_url, created_at, updated_at
+                f"""
+                SELECT thread_id, contact_id, {reference_column},
+                       created_at, updated_at
                 FROM outreach_threads
                 WHERE tenant_id = ?
                 """,
@@ -1303,7 +1308,12 @@ class ProjectionBuilder:
                     tenant_id=self._tenant_id,
                     thread_id=thread_id,
                     contact_id=str(row[1]),
-                    job_id=row[2],
+                    job_id=public_contact_job_reference(
+                        self._conn,
+                        table="outreach_threads",
+                        tenant_id=self._tenant_id,
+                        physical_reference=row[2],
+                    ),
                     draft_count=len(draft_rows),
                     latest_generation=latest_generation,
                     has_approved_draft=has_approved,
@@ -1333,10 +1343,15 @@ class ProjectionBuilder:
         the currently-scheduled follow-ups. Carries safe references only.
         """
         tenant = str(self._tenant_id)
+        reference_column = contact_job_reference_column(
+            self._conn,
+            "outreach_threads",
+        )
         try:
             rows = self._conn.execute(
-                """
-                SELECT thread_id, contact_id, job_url, follow_up_due_at,
+                f"""
+                SELECT thread_id, contact_id, {reference_column},
+                       follow_up_due_at,
                        follow_up_basis, follow_up_state, created_at, updated_at
                 FROM outreach_threads
                 WHERE tenant_id = ? AND follow_up_state = 'scheduled'
@@ -1354,7 +1369,12 @@ class ProjectionBuilder:
                     tenant_id=self._tenant_id,
                     thread_id=thread_id,
                     contact_id=str(row[1]),
-                    job_id=row[2],
+                    job_id=public_contact_job_reference(
+                        self._conn,
+                        table="outreach_threads",
+                        tenant_id=self._tenant_id,
+                        physical_reference=row[2],
+                    ),
                     due_at=row[3],
                     basis=str(row[4] or ""),
                     state=str(row[5] or "scheduled"),

--- a/workers/automation/tests/test_application_feedback_candidate_identity_reference_migration.py
+++ b/workers/automation/tests/test_application_feedback_candidate_identity_reference_migration.py
@@ -331,7 +331,7 @@ def test_v21_candidates_migrate_every_alias_uuid_url_and_tenant(
     assert (
         reopened.execute("PRAGMA user_version").fetchone()[0]
         == SCHEMA_VERSION
-        == 24
+        == 25
     )
     for table in database_module._APPLICATION_FEEDBACK_CANDIDATE_TABLES:
         assert "job_id" in _columns(reopened, table)

--- a/workers/automation/tests/test_application_outcome_identity_reference_migration.py
+++ b/workers/automation/tests/test_application_outcome_identity_reference_migration.py
@@ -243,7 +243,7 @@ def test_v20_outcomes_migrate_every_alias_uuid_url_and_tenant(
     assert (
         reopened.execute("PRAGMA user_version").fetchone()[0]
         == SCHEMA_VERSION
-        == 24
+        == 25
     )
     assert "job_id" in _columns(reopened, "application_outcomes")
     assert "job_key" not in _columns(reopened, "application_outcomes")

--- a/workers/automation/tests/test_application_review_identity_reference_migration.py
+++ b/workers/automation/tests/test_application_review_identity_reference_migration.py
@@ -204,7 +204,7 @@ def test_v19_review_decisions_migrate_every_alias_and_uuid_url(
     assert (
         reopened.execute("PRAGMA user_version").fetchone()[0]
         == SCHEMA_VERSION
-        == 24
+        == 25
     )
     assert "job_id" in _columns(
         reopened,

--- a/workers/automation/tests/test_compensation_identity_reference_migration.py
+++ b/workers/automation/tests/test_compensation_identity_reference_migration.py
@@ -210,7 +210,7 @@ def test_v18_compensation_migrates_alias_winners_and_uuid_urls(
     assert (
         reopened.execute("PRAGMA user_version").fetchone()[0]
         == SCHEMA_VERSION
-        == 24
+        == 25
     )
     for table in database_module._COMPENSATION_REFERENCE_TABLES:
         assert "job_id" in _columns(reopened, table)

--- a/workers/automation/tests/test_contact_research_identity_reference_migration.py
+++ b/workers/automation/tests/test_contact_research_identity_reference_migration.py
@@ -10,7 +10,6 @@ import pytest
 
 import jobctrl.database as database_module
 from jobctrl.database import (
-    SCHEMA_VERSION,
     ensure_contact_research_references_v24,
     ensure_contact_tables,
     init_db,
@@ -273,11 +272,7 @@ def test_v23_rows_migrate_exactly_with_url_first_resolution(
         database_module._CONTACT_RESEARCH_REFERENCE_TABLES
     )
 
-    assert (
-        conn.execute("PRAGMA user_version").fetchone()[0]
-        == SCHEMA_VERSION
-        == 24
-    )
+    assert conn.execute("PRAGMA user_version").fetchone()[0] == 24
     assert (
         database_module._has_contact_research_reference_schema_v24(
             conn

--- a/workers/automation/tests/test_discovery_identity_reference_migration.py
+++ b/workers/automation/tests/test_discovery_identity_reference_migration.py
@@ -220,7 +220,7 @@ def test_v7_discovery_references_migrate_to_stable_job_id_and_reopen(
     init_db(db_path)
     close_connection(db_path)
 
-    assert _user_version(db_path) == SCHEMA_VERSION == 24
+    assert _user_version(db_path) == SCHEMA_VERSION == 25
     assert "job_id" in _columns(db_path, "job_source_observations")
     assert "job_url" not in _columns(db_path, "job_source_observations")
     assert "job_id" in _columns(db_path, "job_canonical_identities")

--- a/workers/automation/tests/test_due_follow_up_projection_parity.py
+++ b/workers/automation/tests/test_due_follow_up_projection_parity.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import json
 import sqlite3
+import uuid
 from pathlib import Path
 from typing import Any
 
@@ -34,10 +35,27 @@ _FIXTURE = (
 def _seed_canonical(conn: sqlite3.Connection, fixture: dict[str, Any]) -> None:
     tenant = fixture["tenantId"]
     for thread in fixture["threads"]:
+        job_url = thread["jobUrl"]
+        job_id = (
+            str(uuid.uuid5(uuid.NAMESPACE_URL, job_url))
+            if job_url
+            else None
+        )
+        if job_url:
+            conn.execute(
+                """
+                INSERT OR IGNORE INTO jobs (
+                    url, tenant_id, job_id, title, company,
+                    discovered_at
+                ) VALUES (?, ?, ?, 'Platform Engineer', 'ExampleCo', ?)
+                """,
+                (job_url, tenant, job_id, thread["createdAt"]),
+            )
         conn.execute(
             """
             INSERT INTO outreach_threads (
-                tenant_id, thread_id, contact_id, job_url, created_at, updated_at,
+                tenant_id, thread_id, contact_id, job_id,
+                created_at, updated_at,
                 follow_up_due_at, follow_up_basis, follow_up_state
             ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
@@ -45,7 +63,7 @@ def _seed_canonical(conn: sqlite3.Connection, fixture: dict[str, Any]) -> None:
                 tenant,
                 thread["threadId"],
                 thread["contactId"],
-                thread["jobUrl"],
+                job_id,
                 thread["createdAt"],
                 thread["updatedAt"],
                 thread["followUpDueAt"],

--- a/workers/automation/tests/test_employer_analysis_identity_reference_migration.py
+++ b/workers/automation/tests/test_employer_analysis_identity_reference_migration.py
@@ -242,7 +242,7 @@ def test_v15_employer_analysis_migrates_alias_histories_and_uuid_urls(
     assert (
         reopened.execute("PRAGMA user_version").fetchone()[0]
         == SCHEMA_VERSION
-        == 24
+        == 25
     )
     for table in database_module._EMPLOYER_ANALYSIS_REFERENCE_TABLES:
         assert "job_id" in _columns(reopened, table)

--- a/workers/automation/tests/test_enrichment_snapshot_identity_reference_migration.py
+++ b/workers/automation/tests/test_enrichment_snapshot_identity_reference_migration.py
@@ -322,7 +322,7 @@ def test_v10_enrichment_snapshot_references_migrate_and_reopen(
     init_db(db_path)
     close_connection(db_path)
 
-    assert _user_version(db_path) == SCHEMA_VERSION == 24
+    assert _user_version(db_path) == SCHEMA_VERSION == 25
     check = sqlite3.connect(db_path)
     try:
         enrichment_rows = check.execute(

--- a/workers/automation/tests/test_execution_search_identity_reference_migration.py
+++ b/workers/automation/tests/test_execution_search_identity_reference_migration.py
@@ -261,7 +261,7 @@ def test_v8_execution_and_receipts_migrate_to_stable_job_id_and_reopen(
     init_db(db_path)
     close_connection(db_path)
 
-    assert _user_version(db_path) == SCHEMA_VERSION == 24
+    assert _user_version(db_path) == SCHEMA_VERSION == 25
     assert "job_id" in _columns(db_path, "discovery_execution_jobs")
     assert "job_url" not in _columns(db_path, "discovery_execution_jobs")
     assert "job_id" in _columns(db_path, "discovery_search_unit_jobs")

--- a/workers/automation/tests/test_interview_prep_identity_reference_migration.py
+++ b/workers/automation/tests/test_interview_prep_identity_reference_migration.py
@@ -323,7 +323,7 @@ def test_v17_interview_prep_migrates_alias_histories_and_uuid_urls(
     assert (
         reopened.execute("PRAGMA user_version").fetchone()[0]
         == SCHEMA_VERSION
-        == 24
+        == 25
     )
     for table in database_module._INTERVIEW_PREP_REFERENCE_TABLES:
         assert "job_id" in _columns(reopened, table)

--- a/workers/automation/tests/test_materials_identity_reference_migration.py
+++ b/workers/automation/tests/test_materials_identity_reference_migration.py
@@ -293,7 +293,7 @@ def test_v14_materials_migrate_alias_histories_and_uuid_shaped_urls(
     close_connection(db_path)
 
     reopened = init_db(db_path)
-    assert reopened.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_VERSION == 24
+    assert reopened.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_VERSION == 25
     for table in database_module._MATERIALS_REFERENCE_TABLES:
         assert "job_id" in _columns(reopened, table)
         assert "job_url" not in _columns(reopened, table)

--- a/workers/automation/tests/test_outreach_follow_up_derivation.py
+++ b/workers/automation/tests/test_outreach_follow_up_derivation.py
@@ -117,6 +117,19 @@ def test_recurring_reminder_can_be_enabled_but_never_sends() -> None:
 def _repo() -> tuple[SqliteOutreachThreadRepository, sqlite3.Connection]:
     conn = init_db(Path(tempfile.mkdtemp()) / "jobctrl.db")
     conn.row_factory = sqlite3.Row
+    conn.execute(
+        """
+        INSERT INTO jobs (
+            url, tenant_id, job_id, title, company, discovered_at
+        ) VALUES (
+            'https://job/1', 'local',
+            '11111111-1111-4111-8111-111111111111',
+            'Platform Engineer', 'ExampleCo', ?
+        )
+        """,
+        (_SUBMITTED,),
+    )
+    conn.commit()
     return SqliteOutreachThreadRepository(conn, publisher=InProcessEventBus()), conn
 
 

--- a/workers/automation/tests/test_outreach_identity_reference_migration.py
+++ b/workers/automation/tests/test_outreach_identity_reference_migration.py
@@ -1,0 +1,576 @@
+"""Schema-v25 OutreachThread stable JobId contracts."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import jobctrl.database as database_module
+from jobctrl.database import (
+    SCHEMA_VERSION,
+    ensure_contact_tables,
+    ensure_outreach_references_v25,
+    init_db,
+    reassign_discovery_identity_references,
+)
+from jobctrl.domain.contact.outreach import OutreachThread
+from jobctrl.domain.tenant import LOCAL_TENANT
+from jobctrl.infrastructure.contact.outreach_repository import (
+    SqliteOutreachThreadRepository,
+)
+from jobctrl.infrastructure.events.in_process_bus import InProcessEventBus
+
+PREVIOUS_SCHEMA_VERSION = 24
+NOW = "2026-07-30T12:00:00+00:00"
+UUID_SHAPED_URL = "11111111-1111-4111-8111-111111111111"
+TARGET_JOB_ID = "22222222-2222-4222-8222-222222222222"
+COLLIDING_JOB_ID = UUID_SHAPED_URL
+PRIOR_JOB_ID = "33333333-3333-4333-8333-333333333333"
+SURVIVOR_JOB_ID = "44444444-4444-4444-8444-444444444444"
+
+
+def _columns(
+    conn: sqlite3.Connection,
+    table: str,
+) -> set[str]:
+    return {
+        str(row[1])
+        for row in conn.execute(
+            f'PRAGMA table_info("{table}")'
+        ).fetchall()
+    }
+
+
+def _insert_job(
+    conn: sqlite3.Connection,
+    *,
+    url: str,
+    job_id: str,
+    tenant_id: str = "local",
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO jobs (
+            url, tenant_id, job_id, title, company, discovered_at
+        ) VALUES (?, ?, ?, 'Platform Engineer', 'ExampleCo', ?)
+        """,
+        (url, tenant_id, job_id, NOW),
+    )
+
+
+def _downgrade_outreach_table_to_v24(
+    conn: sqlite3.Connection,
+) -> None:
+    conn.commit()
+    conn.execute("PRAGMA foreign_keys = OFF")
+    conn.execute("DROP TABLE outreach_threads")
+    database_module._create_outreach_threads_table_v25(
+        conn,
+        table="outreach_threads",
+        stable_reference=False,
+    )
+    conn.execute(
+        """
+        CREATE INDEX idx_outreach_threads_contact
+        ON outreach_threads(tenant_id, contact_id)
+        """
+    )
+    conn.execute(
+        f"PRAGMA user_version = {PREVIOUS_SCHEMA_VERSION}"
+    )
+    conn.commit()
+    conn.execute("PRAGMA foreign_keys = ON")
+
+
+def _seed_v24_database(db_path: Path) -> sqlite3.Connection:
+    conn = init_db(db_path)
+    conn.row_factory = sqlite3.Row
+    _downgrade_outreach_table_to_v24(conn)
+    return conn
+
+
+def _history_snapshot(
+    conn: sqlite3.Connection,
+) -> dict[str, list[tuple[Any, ...]]]:
+    return {
+        table: [
+            tuple(row)
+            for row in conn.execute(
+                f'SELECT * FROM "{table}" ORDER BY tenant_id, rowid'
+            ).fetchall()
+        ]
+        for table in database_module._OUTREACH_HISTORY_TABLES
+    }
+
+
+def test_v24_rows_migrate_exactly_with_url_first_resolution(
+    tmp_path: Path,
+) -> None:
+    conn = _seed_v24_database(tmp_path / "jobs.db")
+    colliding_owner_url = (
+        "https://careers.example.test/uuid-id-owner"
+    )
+    prior_url = "https://careers.example.test/prior"
+    prior_alias = "https://legacy.example.test/prior"
+    blue_target_url = "https://blue.example.test/target"
+    _insert_job(
+        conn,
+        url=UUID_SHAPED_URL,
+        job_id=TARGET_JOB_ID,
+    )
+    _insert_job(
+        conn,
+        url=colliding_owner_url,
+        job_id=COLLIDING_JOB_ID,
+    )
+    _insert_job(conn, url=prior_url, job_id=PRIOR_JOB_ID)
+    _insert_job(
+        conn,
+        url=blue_target_url,
+        job_id=TARGET_JOB_ID,
+        tenant_id="blue",
+    )
+    conn.execute(
+        """
+        INSERT INTO job_identity_aliases (
+            tenant_id, alias_kind, alias_value, job_id, created_at
+        ) VALUES ('local', 'posting_url', ?, ?, ?)
+        """,
+        (prior_alias, PRIOR_JOB_ID, NOW),
+    )
+    conn.executemany(
+        """
+        INSERT INTO outreach_threads (
+            tenant_id, thread_id, contact_id, job_url,
+            created_at, updated_at, follow_up_due_at,
+            follow_up_basis, follow_up_state
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            (
+                "local",
+                "thread:uuid-url",
+                "contact:uuid-url",
+                UUID_SHAPED_URL,
+                NOW,
+                NOW,
+                NOW,
+                "application_submitted",
+                "scheduled",
+            ),
+            (
+                "local",
+                "thread:alias",
+                "contact:alias",
+                prior_alias,
+                NOW,
+                NOW,
+                None,
+                None,
+                "none",
+            ),
+            (
+                "local",
+                "thread:contact-only",
+                "contact:only",
+                None,
+                NOW,
+                NOW,
+                None,
+                None,
+                "none",
+            ),
+            (
+                "blue",
+                "thread:blue",
+                "contact:blue",
+                blue_target_url,
+                NOW,
+                NOW,
+                None,
+                None,
+                "none",
+            ),
+        ),
+    )
+    conn.execute(
+        """
+        INSERT INTO outreach_drafts (
+            tenant_id, draft_id, thread_id, generation, kind,
+            status, body_text, gate_results_json, provenance_json,
+            created_at
+        ) VALUES (
+            'local', 'draft:exact', 'thread:uuid-url', 1,
+            'intro_request', 'approved', 'private:exact',
+            '{"passed":true}', '[{"source":"private:exact"}]', ?
+        )
+        """,
+        (NOW,),
+    )
+    conn.execute(
+        """
+        INSERT INTO outreach_send_logs (
+            tenant_id, send_log_id, thread_id, draft_id,
+            channel, sent_at, logged_at
+        ) VALUES (
+            'local', 'send:exact', 'thread:uuid-url',
+            'draft:exact', 'other', ?, ?
+        )
+        """,
+        (NOW, NOW),
+    )
+    conn.commit()
+    before_drafts = [
+        tuple(row)
+        for row in conn.execute(
+            "SELECT * FROM outreach_drafts ORDER BY rowid"
+        ).fetchall()
+    ]
+    before_send_logs = [
+        tuple(row)
+        for row in conn.execute(
+            "SELECT * FROM outreach_send_logs ORDER BY rowid"
+        ).fetchall()
+    ]
+
+    assert ensure_outreach_references_v25(conn) == list(
+        database_module._OUTREACH_REFERENCE_TABLES
+    )
+
+    assert (
+        conn.execute("PRAGMA user_version").fetchone()[0]
+        == SCHEMA_VERSION
+        == 25
+    )
+    assert database_module._has_outreach_reference_schema_v25(
+        conn
+    )
+    assert [
+        tuple(row)
+        for row in conn.execute(
+            """
+            SELECT tenant_id, thread_id, job_id
+            FROM outreach_threads
+            ORDER BY tenant_id, thread_id
+            """
+        ).fetchall()
+    ] == [
+        ("blue", "thread:blue", TARGET_JOB_ID),
+        ("local", "thread:alias", PRIOR_JOB_ID),
+        ("local", "thread:contact-only", None),
+        ("local", "thread:uuid-url", TARGET_JOB_ID),
+    ]
+    assert [
+        tuple(row)
+        for row in conn.execute(
+            "SELECT * FROM outreach_drafts ORDER BY rowid"
+        ).fetchall()
+    ] == before_drafts
+    assert [
+        tuple(row)
+        for row in conn.execute(
+            "SELECT * FROM outreach_send_logs ORDER BY rowid"
+        ).fetchall()
+    ] == before_send_logs
+    assert {
+        str(row[6]).upper()
+        for row in conn.execute(
+            'PRAGMA foreign_key_list("outreach_threads")'
+        ).fetchall()
+    } == {"RESTRICT"}
+    assert conn.execute("PRAGMA foreign_key_check").fetchone() is None
+
+
+def test_verification_failure_rolls_back_and_retry_succeeds(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    conn = _seed_v24_database(tmp_path / "retry.db")
+    job_url = "https://careers.example.test/retry"
+    _insert_job(conn, url=job_url, job_id=TARGET_JOB_ID)
+    conn.execute(
+        """
+        INSERT INTO outreach_threads (
+            tenant_id, thread_id, contact_id, job_url,
+            created_at, updated_at
+        ) VALUES (
+            'local', 'thread:retry', 'contact:retry', ?, ?, ?
+        )
+        """,
+        (job_url, NOW, NOW),
+    )
+    conn.execute(
+        """
+        INSERT INTO outreach_drafts (
+            tenant_id, draft_id, thread_id, generation, kind,
+            status, created_at
+        ) VALUES (
+            'local', 'draft:retry', 'thread:retry', 1,
+            'intro_request', 'candidate', ?
+        )
+        """,
+        (NOW,),
+    )
+    conn.commit()
+    before = _history_snapshot(conn)
+    original_verify = database_module._verify_outreach_references_v25
+
+    def _fail_verification(
+        _conn: sqlite3.Connection,
+        *,
+        expected_counts: dict[str, int],
+    ) -> None:
+        del expected_counts
+        raise RuntimeError("injected outreach verification failure")
+
+    monkeypatch.setattr(
+        database_module,
+        "_verify_outreach_references_v25",
+        _fail_verification,
+    )
+    with pytest.raises(
+        RuntimeError,
+        match="injected outreach verification failure",
+    ):
+        ensure_outreach_references_v25(conn)
+    assert conn.execute("PRAGMA user_version").fetchone()[0] == 24
+    assert _history_snapshot(conn) == before
+    assert "job_url" in _columns(conn, "outreach_threads")
+    assert {
+        str(row[0])
+        for row in conn.execute(
+            """
+            SELECT name FROM sqlite_master
+            WHERE type = 'table' AND name LIKE '%_v25'
+            """
+        ).fetchall()
+    } == set()
+    assert conn.execute("PRAGMA foreign_keys").fetchone()[0] == 1
+
+    monkeypatch.setattr(
+        database_module,
+        "_verify_outreach_references_v25",
+        original_verify,
+    )
+    ensure_outreach_references_v25(conn)
+    assert conn.execute("PRAGMA user_version").fetchone()[0] == 25
+    assert conn.execute(
+        "SELECT job_id FROM outreach_threads"
+    ).fetchone()[0] == TARGET_JOB_ID
+
+
+@pytest.mark.parametrize(
+    ("schema_version", "expected_reference"),
+    ((0, "job_url"), (24, "job_url"), (25, "job_id")),
+)
+def test_missing_table_recovery_is_schema_version_aware(
+    schema_version: int,
+    expected_reference: str,
+) -> None:
+    conn = sqlite3.connect(":memory:")
+    conn.executescript(
+        f"""
+        CREATE TABLE jobs (
+            url TEXT PRIMARY KEY,
+            tenant_id TEXT NOT NULL DEFAULT 'local',
+            job_id TEXT NOT NULL,
+            UNIQUE (tenant_id, job_id)
+        );
+        PRAGMA user_version = {schema_version};
+        """
+    )
+
+    ensure_contact_tables(conn)
+
+    assert expected_reference in _columns(
+        conn,
+        "outreach_threads",
+    )
+    if schema_version == 25:
+        assert database_module._has_outreach_reference_schema_v25(
+            conn
+        )
+
+
+def test_stamped_v25_legacy_table_fails_closed() -> None:
+    conn = sqlite3.connect(":memory:")
+    conn.executescript(
+        """
+        CREATE TABLE jobs (
+            url TEXT PRIMARY KEY,
+            tenant_id TEXT NOT NULL DEFAULT 'local',
+            job_id TEXT NOT NULL,
+            UNIQUE (tenant_id, job_id)
+        );
+        PRAGMA user_version = 24;
+        """
+    )
+    ensure_contact_tables(conn)
+    conn.execute("PRAGMA user_version = 25")
+
+    with pytest.raises(
+        RuntimeError,
+        match="Schema v25 requires stable outreach",
+    ):
+        ensure_contact_tables(conn)
+
+
+def test_runtime_collision_rehomes_authority_and_url_projections(
+    tmp_path: Path,
+) -> None:
+    conn = init_db(tmp_path / "collision.db")
+    conn.row_factory = sqlite3.Row
+    losing_url = "https://careers.example.test/losing"
+    surviving_url = "https://careers.example.test/surviving"
+    _insert_job(conn, url=losing_url, job_id=TARGET_JOB_ID)
+    _insert_job(
+        conn,
+        url=surviving_url,
+        job_id=SURVIVOR_JOB_ID,
+    )
+    conn.execute(
+        """
+        INSERT INTO outreach_threads (
+            tenant_id, thread_id, contact_id, job_id,
+            created_at, updated_at, follow_up_due_at,
+            follow_up_basis, follow_up_state
+        ) VALUES (
+            'local', 'thread:collision', 'contact:collision', ?,
+            ?, ?, ?, 'application_submitted', 'scheduled'
+        )
+        """,
+        (TARGET_JOB_ID, NOW, NOW, NOW),
+    )
+    conn.execute(
+        """
+        INSERT INTO outreach_drafts (
+            tenant_id, draft_id, thread_id, generation, kind,
+            status, created_at
+        ) VALUES (
+            'local', 'draft:collision', 'thread:collision', 1,
+            'intro_request', 'candidate', ?
+        )
+        """,
+        (NOW,),
+    )
+    conn.execute(
+        """
+        INSERT INTO outreach_thread_projections (
+            tenant_id, thread_id, contact_id, job_id, draft_count,
+            latest_generation, has_approved_draft, drafts_json,
+            created_at, updated_at, last_updated_at
+        ) VALUES (
+            'local', 'thread:collision', 'contact:collision', ?, 1,
+            1, 0, '[]', ?, ?, ?
+        )
+        """,
+        (losing_url, NOW, NOW, NOW),
+    )
+    conn.execute(
+        """
+        INSERT INTO due_follow_up_projections (
+            tenant_id, thread_id, contact_id, job_id, due_at,
+            basis, state, created_at, updated_at, last_updated_at
+        ) VALUES (
+            'local', 'thread:collision', 'contact:collision', ?, ?,
+            'application_submitted', 'scheduled', ?, ?, ?
+        )
+        """,
+        (losing_url, NOW, NOW, NOW, NOW),
+    )
+    conn.commit()
+
+    reassign_discovery_identity_references(
+        conn,
+        losing_job_url=losing_url,
+        surviving_job_url=surviving_url,
+    )
+
+    assert conn.execute(
+        "SELECT job_id FROM outreach_threads"
+    ).fetchone()[0] == SURVIVOR_JOB_ID
+    assert conn.execute(
+        "SELECT job_id FROM outreach_thread_projections"
+    ).fetchone()[0] == surviving_url
+    assert conn.execute(
+        "SELECT job_id FROM due_follow_up_projections"
+    ).fetchone()[0] == surviving_url
+    assert conn.execute(
+        "SELECT COUNT(*) FROM outreach_drafts"
+    ).fetchone()[0] == 1
+    assert conn.execute("PRAGMA foreign_key_check").fetchone() is None
+
+
+def test_runtime_repository_resolves_uuid_shaped_url_before_job_id(
+    tmp_path: Path,
+) -> None:
+    conn = init_db(tmp_path / "repository.db")
+    conn.row_factory = sqlite3.Row
+    _insert_job(
+        conn,
+        url=UUID_SHAPED_URL,
+        job_id=TARGET_JOB_ID,
+    )
+    _insert_job(
+        conn,
+        url="https://careers.example.test/uuid-id-owner",
+        job_id=COLLIDING_JOB_ID,
+    )
+    conn.commit()
+    repository = SqliteOutreachThreadRepository(
+        conn,
+        publisher=InProcessEventBus(),
+    )
+
+    repository.save(
+        LOCAL_TENANT,
+        OutreachThread(
+            tenant_id=LOCAL_TENANT,
+            thread_id="thread:runtime",
+            contact_id="contact:runtime",
+            job_id=UUID_SHAPED_URL,
+            created_at=NOW,
+            updated_at=NOW,
+        ),
+    )
+
+    assert conn.execute(
+        """
+        SELECT job_id FROM outreach_threads
+        WHERE thread_id = 'thread:runtime'
+        """
+    ).fetchone()[0] == TARGET_JOB_ID
+    loaded = repository.load(LOCAL_TENANT, "thread:runtime")
+    assert loaded is not None
+    assert loaded.job_id == UUID_SHAPED_URL
+
+
+def test_direct_job_delete_is_restricted_until_thread_is_detached(
+    tmp_path: Path,
+) -> None:
+    conn = init_db(tmp_path / "restrict.db")
+    conn.execute("PRAGMA foreign_keys = ON")
+    job_url = "https://careers.example.test/restrict"
+    _insert_job(conn, url=job_url, job_id=TARGET_JOB_ID)
+    conn.execute(
+        """
+        INSERT INTO outreach_threads (
+            tenant_id, thread_id, contact_id, job_id,
+            created_at, updated_at
+        ) VALUES (
+            'local', 'thread:restrict', 'contact:restrict', ?, ?, ?
+        )
+        """,
+        (TARGET_JOB_ID, NOW, NOW),
+    )
+    conn.commit()
+
+    with pytest.raises(sqlite3.IntegrityError):
+        conn.execute("DELETE FROM jobs WHERE url = ?", (job_url,))
+
+    assert conn.execute(
+        "SELECT COUNT(*) FROM outreach_threads"
+    ).fetchone()[0] == 1

--- a/workers/automation/tests/test_outreach_no_auto_send.py
+++ b/workers/automation/tests/test_outreach_no_auto_send.py
@@ -61,6 +61,19 @@ _PASS_GATES = DraftGateResults(
 def _repo() -> tuple[SqliteOutreachThreadRepository, sqlite3.Connection]:
     conn = init_db(Path(tempfile.mkdtemp()) / "jobctrl.db")
     conn.row_factory = sqlite3.Row
+    conn.execute(
+        """
+        INSERT INTO jobs (
+            url, tenant_id, job_id, title, company, discovered_at
+        ) VALUES (
+            'https://job/1', 'local',
+            '11111111-1111-4111-8111-111111111111',
+            'Platform Engineer', 'ExampleCo',
+            '2026-07-06T00:00:00Z'
+        )
+        """
+    )
+    conn.commit()
     return SqliteOutreachThreadRepository(conn, publisher=InProcessEventBus()), conn
 
 

--- a/workers/automation/tests/test_outreach_projection_parity.py
+++ b/workers/automation/tests/test_outreach_projection_parity.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import json
 import sqlite3
+import uuid
 from pathlib import Path
 from typing import Any
 
@@ -32,17 +33,34 @@ _FIXTURE = (
 def _seed_canonical(conn: sqlite3.Connection, fixture: dict[str, Any]) -> None:
     tenant = fixture["tenantId"]
     for thread in fixture["threads"]:
+        job_url = thread["jobUrl"]
+        job_id = (
+            str(uuid.uuid5(uuid.NAMESPACE_URL, job_url))
+            if job_url
+            else None
+        )
+        if job_url:
+            conn.execute(
+                """
+                INSERT OR IGNORE INTO jobs (
+                    url, tenant_id, job_id, title, company,
+                    discovered_at
+                ) VALUES (?, ?, ?, 'Platform Engineer', 'ExampleCo', ?)
+                """,
+                (job_url, tenant, job_id, thread["createdAt"]),
+            )
         conn.execute(
             """
             INSERT INTO outreach_threads (
-                tenant_id, thread_id, contact_id, job_url, created_at, updated_at
+                tenant_id, thread_id, contact_id, job_id,
+                created_at, updated_at
             ) VALUES (?, ?, ?, ?, ?, ?)
             """,
             (
                 tenant,
                 thread["threadId"],
                 thread["contactId"],
-                thread["jobUrl"],
+                job_id,
                 thread["createdAt"],
                 thread["updatedAt"],
             ),

--- a/workers/automation/tests/test_preparation_identity_reference_migration.py
+++ b/workers/automation/tests/test_preparation_identity_reference_migration.py
@@ -177,7 +177,7 @@ def test_v9_preparation_references_migrate_to_stable_job_ids_and_reopen(
     init_db(db_path)
     close_connection(db_path)
 
-    assert _user_version(db_path) == SCHEMA_VERSION == 24
+    assert _user_version(db_path) == SCHEMA_VERSION == 25
     check = sqlite3.connect(db_path)
     try:
         rows = check.execute(

--- a/workers/automation/tests/test_repeat_application_identity_reference_migration.py
+++ b/workers/automation/tests/test_repeat_application_identity_reference_migration.py
@@ -402,7 +402,7 @@ def test_v22_history_migrates_exactly_with_url_first_resolution(
     reopened = init_db(db_path)
     assert reopened.execute("PRAGMA user_version").fetchone()[0] == (
         SCHEMA_VERSION
-    ) == 24
+    ) == 25
     assert database_module._has_repeat_application_reference_schema_v23(
         reopened
     )

--- a/workers/automation/tests/test_repeat_application_prevention.py
+++ b/workers/automation/tests/test_repeat_application_prevention.py
@@ -799,7 +799,7 @@ def test_schema_v5_migrates_additively_without_changing_application_facts(
         (PRIOR,),
     ).fetchall()
 
-    assert int(migrated.execute("PRAGMA user_version").fetchone()[0]) == SCHEMA_VERSION == 24
+    assert int(migrated.execute("PRAGMA user_version").fetchone()[0]) == SCHEMA_VERSION == 25
     assert [tuple(row) for row in after] == [tuple(row) for row in before]
     assert "metadata_json" in {
         str(row[1]) for row in migrated.execute("PRAGMA table_info(job_stage_states)").fetchall()

--- a/workers/automation/tests/test_resume_template_identity_reference_migration.py
+++ b/workers/automation/tests/test_resume_template_identity_reference_migration.py
@@ -254,7 +254,7 @@ def test_v16_template_references_migrate_aliases_and_uuid_urls(
     assert (
         reopened.execute("PRAGMA user_version").fetchone()[0]
         == SCHEMA_VERSION
-        == 24
+        == 25
     )
     for table in database_module._RESUME_TEMPLATE_REFERENCE_TABLES:
         assert "job_id" in _columns(reopened, table)

--- a/workers/automation/tests/test_scoring_identity_reference_migration.py
+++ b/workers/automation/tests/test_scoring_identity_reference_migration.py
@@ -338,7 +338,7 @@ def test_v11_scoring_references_migrate_alias_histories_and_reopen(
     assert (
         int(migrated.execute("PRAGMA user_version").fetchone()[0])
         == SCHEMA_VERSION
-        == 24
+        == 25
     )
     assert _columns(migrated, "job_scores") >= {"tenant_id", "job_id"}
     assert "job_url" not in _columns(migrated, "job_scores")
@@ -404,7 +404,7 @@ def test_v11_scoring_references_migrate_alias_histories_and_reopen(
     assert (
         int(reopened.execute("PRAGMA user_version").fetchone()[0])
         == SCHEMA_VERSION
-        == 24
+        == 25
     )
 
 
@@ -553,7 +553,7 @@ def test_scoring_migration_rolls_back_and_retries_after_verification_failure(
     assert (
         int(retried.execute("PRAGMA user_version").fetchone()[0])
         == SCHEMA_VERSION
-        == 24
+        == 25
     )
     assert [
         tuple(row)

--- a/workers/automation/tests/test_stable_job_identity_migration.py
+++ b/workers/automation/tests/test_stable_job_identity_migration.py
@@ -841,7 +841,7 @@ def test_v6_jobs_gain_stable_uuid_and_posting_url_alias_once(
     init_db(db_path)
     close_connection(db_path)
 
-    assert _user_version(db_path) == SCHEMA_VERSION == 24
+    assert _user_version(db_path) == SCHEMA_VERSION == 25
     first_ids = _identity_rows(db_path)
     assert [row[0] for row in first_ids] == ["local", "local"]
     for _tenant_id, job_id, _url in first_ids:


### PR DESCRIPTION
## Summary

- migrate `outreach_threads` from URL-shaped application links to nullable tenant-scoped stable `job_id` references in schema v25
- keep outreach DTOs, events, thread reads, and outreach/due-follow-up projections URL-compatible until the Phase 4 cutover
- resolve UUID-shaped URLs URL-first, retain alias and tenant isolation, and reject unknown linked jobs before draft generation
- preserve drafts, approved history, and user-attested send logs during migration and collision rehoming
- make permanent deletion explicit: detach employer-scoped outreach history and purge complete outreach aggregates owned by job-only contacts, with foreign keys both enabled and disabled
- preserve the no-auto-send and sensitive-data projection boundaries

## Stack

- depends on #550
- this PR is intentionally limited to outreach references; feedback/tombstones and remaining authorities follow separately
- canonical product docs and cumulative product QA are deferred to the final PR in this approved unreleased stack

## Validation

- `corepack pnpm api:test` — 709 passed
- `corepack pnpm api:check` — passed
- `corepack pnpm web:check` — passed
- `PYTHONPATH=src .../.venv/bin/python -m pytest -q` — 2,752 passed, 2 skipped
- focused identity matrix — 114 passed
- focused Python outreach suite — 57 passed
- focused API outreach suite — 24 passed before final FK-on/off expansion; final v25 suite 6 passed
- `.../.venv/bin/ruff check src tests` — passed
- `env -u UV_EXCLUDE_NEWER uv --project workers/automation lock --check` — passed
- `git diff --check` — passed
- independent Tier 3 review — PASS, no findings
- independent Tier 3 QA — PASS, no findings
