### PR TITLE
fix(docs): distinguish JobCtrl in search metadata

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -1,12 +1,66 @@
 import { posix } from "node:path";
-import { defineConfig, type DefaultTheme } from "vitepress";
+import { defineConfig, type DefaultTheme, type HeadConfig } from "vitepress";
 import { withMermaid } from "vitepress-plugin-mermaid";
 
 const REPO_URL = "https://github.com/ebarti/JobCtrl";
 const DOCS_SITE_URL = "https://jobctrl.dev";
+const SITE_NAME = "JobCtrl";
+const SITE_DESCRIPTION =
+  "Run your job search without surrendering your data: local discovery, evidence-backed scoring, truthful tailoring, and supervised apply.";
 const SOCIAL_IMAGE_URL = `${DOCS_SITE_URL}/assets/brand/social-preview.png`;
 const SOCIAL_IMAGE_ALT =
   "JobCtrl: run your job search, keep your data, and inspect key AI-assisted decisions.";
+const ORGANIZATION_ID = `${DOCS_SITE_URL}/#organization`;
+const WEBSITE_ID = `${DOCS_SITE_URL}/#website`;
+const SOFTWARE_ID = `${DOCS_SITE_URL}/#software`;
+const HOME_STRUCTURED_DATA = JSON.stringify({
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "Organization",
+      "@id": ORGANIZATION_ID,
+      name: SITE_NAME,
+      url: `${DOCS_SITE_URL}/`,
+      logo: `${DOCS_SITE_URL}/assets/brand/app-icon.png`,
+      sameAs: [REPO_URL],
+    },
+    {
+      "@type": "WebSite",
+      "@id": WEBSITE_ID,
+      url: `${DOCS_SITE_URL}/`,
+      name: SITE_NAME,
+      alternateName: "jobctrl.dev",
+      description: SITE_DESCRIPTION,
+      inLanguage: "en",
+      publisher: { "@id": ORGANIZATION_ID },
+    },
+    {
+      "@type": "SoftwareApplication",
+      "@id": SOFTWARE_ID,
+      name: SITE_NAME,
+      url: `${DOCS_SITE_URL}/`,
+      description: SITE_DESCRIPTION,
+      applicationCategory: "BusinessApplication",
+      applicationSubCategory: "Job search automation",
+      operatingSystem: "macOS 15 or later on Apple silicon",
+      isAccessibleForFree: true,
+      license: "https://www.gnu.org/licenses/agpl-3.0.html",
+      sameAs: [REPO_URL],
+      publisher: { "@id": ORGANIZATION_ID },
+    },
+  ],
+});
+
+function structuredDataHeadForPage(relativePath: string): HeadConfig[] {
+  if (relativePath !== "index.md") return [];
+  return [
+    [
+      "script",
+      { type: "application/ld+json", id: "jobctrl-structured-data" },
+      HOME_STRUCTURED_DATA,
+    ],
+  ];
+}
 
 // Docs that stay in the repository but are not published on the site.
 // docs/README.md is the repo-facing documentation map (GitHub renders it when
@@ -240,9 +294,8 @@ function rewriteEscapingLink(href: string, pageRelativePath: string): string | n
 
 export default withMermaid(
   defineConfig({
-    title: "JobCtrl",
-    description:
-      "Run your job search without surrendering your data: local discovery, evidence-backed scoring, truthful tailoring, and supervised apply.",
+    title: SITE_NAME,
+    description: SITE_DESCRIPTION,
     sitemap: {
       hostname: DOCS_SITE_URL,
     },
@@ -257,6 +310,7 @@ export default withMermaid(
       return [
         ["link", { rel: "canonical", href: canonicalUrl }],
         ["meta", { property: "og:type", content: "website" }],
+        ["meta", { property: "og:site_name", content: SITE_NAME }],
         ["meta", { property: "og:url", content: canonicalUrl }],
         ["meta", { property: "og:title", content: title }],
         ["meta", { property: "og:description", content: description }],
@@ -269,6 +323,7 @@ export default withMermaid(
         ["meta", { name: "twitter:description", content: description }],
         ["meta", { name: "twitter:image", content: SOCIAL_IMAGE_URL }],
         ["meta", { name: "twitter:image:alt", content: SOCIAL_IMAGE_ALT }],
+        ...structuredDataHeadForPage(pageData.relativePath),
       ];
     },
     srcExclude: [

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -1,6 +1,7 @@
 ---
 pageClass: jh-visual-doc
 aside: false
+description: "Explore JobCtrl's local-first architecture across the web app, TypeScript API, Python worker, Temporal workflows, SQLite, and external providers."
 ---
 
 # System Overview

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -1,5 +1,6 @@
 ---
 pageClass: jh-visual-doc jh-comparison-page
+description: "Compare JobCtrl's local-first, auditable workflow with Career-Ops and AI Job Search across discovery, tailoring, safety, and operations."
 ---
 
 # How JobCtrl Compares

--- a/docs/developer/README.md
+++ b/docs/developer/README.md
@@ -1,3 +1,7 @@
+---
+description: "Start contributing to JobCtrl by locating the owning source boundary, architecture contract, validation commands, and security requirements."
+---
+
 # Contributor Start
 
 This is the shortest path from a fresh checkout to the document that owns the

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,8 @@
 ---
 layout: home
+title: "JobCtrl — Local-first job search automation"
+titleTemplate: false
+description: "JobCtrl is a local-first job search application for private discovery, evidence-based fit scoring, truthful resume tailoring, and supervised applications."
 
 hero:
   name: JobCtrl

--- a/docs/user/apply.md
+++ b/docs/user/apply.md
@@ -1,3 +1,7 @@
+---
+description: "Review JobCtrl's supervised application controls: profile-bound answers, dry runs, explicit approval, browser safeguards, Gmail, and at-most-once sending."
+---
+
 <script setup lang="ts">
 import ApplySafetyFlow from "../.vitepress/theme/ApplySafetyFlow.vue";
 </script>

--- a/docs/user/data-and-safety.md
+++ b/docs/user/data-and-safety.md
@@ -1,3 +1,7 @@
+---
+description: "Understand where JobCtrl stores profiles, jobs, resumes, browser state, and telemetry, and when a user-triggered feature contacts an external service."
+---
+
 <script setup lang="ts">
 import DataBoundaryMap from "../.vitepress/theme/DataBoundaryMap.vue";
 </script>

--- a/docs/user/getting-started.md
+++ b/docs/user/getting-started.md
@@ -1,3 +1,7 @@
+---
+description: "Install JobCtrl on Apple-silicon macOS, explore the live demo, configure providers, and run your first private, supervised job-search workflow."
+---
+
 # Getting Started
 
 JobCtrl is a local application: the app, database, settings, and generated

--- a/docs/user/materials-and-tailoring.md
+++ b/docs/user/materials-and-tailoring.md
@@ -1,3 +1,7 @@
+---
+description: "Learn how JobCtrl creates truthful, job-specific resumes and cover letters with provenance, fabrication gates, validation, repair, and human approval."
+---
+
 # Materials & Tailoring
 
 Materials are the job-specific resumes, cover letters, PDFs, and related review

--- a/docs/user/normal-flows.md
+++ b/docs/user/normal-flows.md
@@ -1,5 +1,6 @@
 ---
 pageClass: jh-visual-doc jh-daily-workflow-page jh-outline-page
+description: "Follow JobCtrl from profile-driven discovery and evidence review through truthful materials, dry runs, approval, and recorded outcomes."
 ---
 
 <script setup lang="ts">

--- a/docs/user/product-tour.md
+++ b/docs/user/product-tour.md
@@ -1,5 +1,6 @@
 ---
 pageClass: jh-visual-doc jh-product-tour-page jh-outline-page
+description: "Tour JobCtrl's local-first workspace with synthetic screenshots of discovery, scoring, tailoring, review, applications, and durable runs."
 ---
 
 # Product Tour

--- a/docs/user/scoring-and-employer-analysis.md
+++ b/docs/user/scoring-and-employer-analysis.md
@@ -1,3 +1,7 @@
+---
+description: "See how JobCtrl scores job fit from versioned profile evidence, requirement-level assessments, blockers, confidence, and correction history."
+---
+
 # Scoring
 
 Scoring compares Discovery's canonical, evidence-linked employer analysis with

--- a/scripts/check-docs-site-runtime.mjs
+++ b/scripts/check-docs-site-runtime.mjs
@@ -47,6 +47,7 @@ const PAGES = [
     visualSelector: ".jh-daily-journey",
     images: true,
   },
+  { path: "/user/getting-started", visualSelector: null, images: false },
   { path: "/user/product-tour", visualSelector: null, images: true },
   {
     path: "/user/data-and-safety",
@@ -95,9 +96,16 @@ const PAGES = [
 
 const SOCIAL_METADATA_ROUTES = new Set([
   "/",
+  "/comparison",
   "/architecture/",
   "/developer/",
   "/user/apply",
+  "/user/data-and-safety",
+  "/user/getting-started",
+  "/user/materials-and-tailoring",
+  "/user/normal-flows",
+  "/user/product-tour",
+  "/user/scoring-and-employer-analysis",
 ]);
 const SOCIAL_IMAGE_URL = "https://jobctrl.dev/assets/brand/social-preview.png";
 const SOCIAL_IMAGE_ALT =
@@ -107,6 +115,7 @@ const DOCS_GOOGLE_TAG_MEASUREMENT_ID = "G-KB495KG6MS";
 const DOCS_GOOGLE_TAG_SCRIPT_ID = "jobctrl-docs-google-analytics";
 const DOCS_ANALYTICS_CONSENT_STORAGE_KEY =
   "jobctrl-docs-analytics-consent-v1";
+const observedSocialDescriptions = new Map();
 
 const LIFECYCLE_EXPLANATION_CONTRACTS = [
   {
@@ -344,6 +353,7 @@ async function assertSocialMetadata(page, route) {
       description: values('meta[name="description"]')[0],
       canonical: values('link[rel="canonical"]', "href"),
       ogType: values('meta[property="og:type"]'),
+      ogSiteName: values('meta[property="og:site_name"]'),
       ogUrl: values('meta[property="og:url"]'),
       ogTitle: values('meta[property="og:title"]'),
       ogDescription: values('meta[property="og:description"]'),
@@ -362,6 +372,7 @@ async function assertSocialMetadata(page, route) {
   const expected = {
     canonical: [expectedCanonical],
     ogType: ["website"],
+    ogSiteName: ["JobCtrl"],
     ogUrl: [expectedCanonical],
     ogTitle: [metadata.title],
     ogDescription: [metadata.description],
@@ -380,8 +391,48 @@ async function assertSocialMetadata(page, route) {
     .map(([key]) => key);
   if (!metadata.title || !metadata.description || mismatches.length > 0) {
     fail(`${route}: canonical or social metadata is missing, duplicated, or conflicting (${mismatches.join(", ")})`);
+  } else if (observedSocialDescriptions.has(metadata.description)) {
+    fail(
+      `${route}: search description duplicates ${observedSocialDescriptions.get(metadata.description)}`,
+    );
   } else {
+    observedSocialDescriptions.set(metadata.description, route);
     console.log(`ok    ${route} canonical and social metadata`);
+  }
+}
+
+async function assertHomepageSearchIdentity(page) {
+  const identity = await page.evaluate(() => {
+    const element = document.querySelector(
+      'script#jobctrl-structured-data[type="application/ld+json"]',
+    );
+    return {
+      title: document.title,
+      data: element ? JSON.parse(element.textContent ?? "{}") : null,
+    };
+  });
+  const graph = Array.isArray(identity.data?.["@graph"])
+    ? identity.data["@graph"]
+    : [];
+  const organization = graph.find((node) => node?.["@type"] === "Organization");
+  const website = graph.find((node) => node?.["@type"] === "WebSite");
+  const software = graph.find(
+    (node) => node?.["@type"] === "SoftwareApplication",
+  );
+  if (
+    identity.title !== "JobCtrl — Local-first job search automation" ||
+    organization?.name !== "JobCtrl" ||
+    organization?.url !== "https://jobctrl.dev/" ||
+    !organization?.sameAs?.includes("https://github.com/ebarti/JobCtrl") ||
+    website?.name !== "JobCtrl" ||
+    website?.alternateName !== "jobctrl.dev" ||
+    website?.url !== "https://jobctrl.dev/" ||
+    software?.name !== "JobCtrl" ||
+    software?.applicationSubCategory !== "Job search automation"
+  ) {
+    fail(`/: homepage search identity is incomplete (${JSON.stringify(identity)})`);
+  } else {
+    console.log("ok    / homepage search identity");
   }
 }
 
@@ -1043,6 +1094,9 @@ try {
 
     if (SOCIAL_METADATA_ROUTES.has(spec.path)) {
       await assertSocialMetadata(page, spec.path);
+    }
+    if (spec.path === "/") {
+      await assertHomepageSearchIdentity(page);
     }
 
     if (spec.visualSelector) {

--- a/scripts/docs-launch-copy.test.mjs
+++ b/scripts/docs-launch-copy.test.mjs
@@ -97,16 +97,51 @@ test("homepage describes supervised browser and email submission", async () => {
 
 test("public docs emit crawl and social-discovery metadata", async () => {
   const config = await read("docs/.vitepress/config.ts");
+  const homepage = await read("docs/index.md");
   const robots = await read("docs/public/robots.txt");
 
   assert.match(config, /SOCIAL_IMAGE_URL = `\$\{DOCS_SITE_URL\}\/assets\/brand\/social-preview\.png`/);
   assert.match(config, /sitemap:\s*\{\s*hostname: DOCS_SITE_URL,/);
+  assert.match(config, /\["meta", \{ property: "og:site_name", content: SITE_NAME \}\]/);
   assert.match(config, /\["meta", \{ property: "og:image:width", content: "1200" \}\]/);
   assert.match(config, /\["meta", \{ property: "og:image:height", content: "630" \}\]/);
+  assert.match(config, /"@type": "Organization"/);
+  assert.match(config, /"@type": "WebSite"/);
+  assert.match(config, /alternateName: "jobctrl\.dev"/);
+  assert.match(config, /"@type": "SoftwareApplication"/);
+  assert.match(config, /id: "jobctrl-structured-data"/);
+  assert.match(homepage, /title: "JobCtrl — Local-first job search automation"/);
+  assert.match(homepage, /titleTemplate: false/);
   assert.equal(
     robots,
     "User-agent: *\nAllow: /\n\nSitemap: https://jobctrl.dev/sitemap.xml\n",
   );
+});
+
+test("priority public pages have distinct search descriptions", async () => {
+  const descriptions = new Map([
+    ["docs/index.md", "JobCtrl is a local-first job search application"],
+    ["docs/comparison.md", "Compare JobCtrl's local-first, auditable workflow"],
+    ["docs/user/product-tour.md", "Tour JobCtrl's local-first workspace"],
+    ["docs/user/getting-started.md", "Install JobCtrl on Apple-silicon macOS"],
+    ["docs/user/normal-flows.md", "Follow JobCtrl from profile-driven discovery"],
+    ["docs/user/data-and-safety.md", "Understand where JobCtrl stores profiles"],
+    ["docs/user/scoring-and-employer-analysis.md", "See how JobCtrl scores job fit"],
+    ["docs/user/materials-and-tailoring.md", "Learn how JobCtrl creates truthful"],
+    ["docs/user/apply.md", "Review JobCtrl's supervised application controls"],
+    ["docs/architecture/index.md", "Explore JobCtrl's local-first architecture"],
+    ["docs/developer/README.md", "Start contributing to JobCtrl"],
+  ]);
+  const observed = new Set();
+
+  for (const [path, expectedPrefix] of descriptions) {
+    const document = await read(path);
+    const description = document.match(/^description: "([^"]+)"$/m)?.[1];
+    assert.ok(description, `${path} must declare a page-specific description`);
+    assert.match(description, new RegExp(`^${expectedPrefix.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`));
+    assert.ok(!observed.has(description), `${path} must not reuse another priority description`);
+    observed.add(description);
+  }
 });
 
 test("comparison cites the current pinned AI Job Search discovery source", async () => {


### PR DESCRIPTION
## What changed

- give the homepage a descriptive, brand-qualified search title
- add distinct descriptions to priority public pages
- emit `og:site_name` and homepage Organization, WebSite, and SoftwareApplication structured data
- extend static and browser-runtime regression coverage for search metadata

## Why

The bare `JobCtrl` title does not distinguish jobctrl.dev from older similarly named products. These changes give search engines clearer product, site, and page-level identity signals without changing product behavior.

## Validation

- `node --test scripts/docs-launch-copy.test.mjs`
- `corepack pnpm docs:build`
- `corepack pnpm docs:check:runtime`
- `git diff --check`
- independent review: PASS (0 Blocker, 0 High)