### PR TITLE
feat(discovery): migrate feedback links to stable JobIds

### DIFF
--- a/apps/api/src/db.ts
+++ b/apps/api/src/db.ts
@@ -9,7 +9,7 @@ export type SqliteValue = string | number | bigint | null;
 // writer that stamps ``PRAGMA user_version``; the API only reads it to fail
 // closed on a database written by a newer build. Bump both constants together
 // whenever the schema shape changes.
-export const SUPPORTED_SCHEMA_VERSION = 25;
+export const SUPPORTED_SCHEMA_VERSION = 26;
 
 export class IncompatibleSchemaVersionError extends Error {
   constructor(current: number) {

--- a/apps/api/src/discovery-controls.ts
+++ b/apps/api/src/discovery-controls.ts
@@ -50,7 +50,12 @@ import {
 import {
   allRows,
   getRow,
+  hasCompositeJobIdForeignKey,
+  jobKeyReferenceColumn,
+  jobKeyReferenceForUrl,
   jobReferenceColumn,
+  tableColumnSet,
+  tableIndexColumns,
   tableExists,
   type SqliteDatabase,
   type SqliteValue,
@@ -61,6 +66,7 @@ import { refreshProjections } from "./projections.js";
 import { InputError } from "./write-model.js";
 
 const DEFAULT_TENANT = "local";
+const DISCOVERY_FEEDBACK_REFERENCE_SCHEMA_VERSION = 26;
 export const EXTENSION_MANUAL_CAPTURE_SOURCE_ID = "manual_capture:extension";
 const EXTENSION_MANUAL_CAPTURE_REASON: ManualActionReasonValue = "browser_extension_capture";
 const DEFAULT_DISCOVERY_SETTINGS: DiscoverySettings = {
@@ -235,6 +241,11 @@ interface CandidateProfileTargetRow extends Record<string, unknown> {
 type CandidateProfileTargetColumn = "experience_target_locations" | "personal_city" | "personal_country";
 
 export function ensureDiscoveryControlTables(db: SqliteDatabase): void {
+  const schemaVersion = Number(
+    db.pragma("user_version", { simple: true }),
+  );
+  const stableFeedbackReferences =
+    schemaVersion >= DISCOVERY_FEEDBACK_REFERENCE_SCHEMA_VERSION;
   db.exec(`
     CREATE TABLE IF NOT EXISTS discovery_settings (
       tenant_id          TEXT PRIMARY KEY,
@@ -306,16 +317,6 @@ export function ensureDiscoveryControlTables(db: SqliteDatabase): void {
       job_key                       TEXT,
       PRIMARY KEY (tenant_id, item_id)
     );
-    CREATE TABLE IF NOT EXISTS discovery_feedback (
-      tenant_id   TEXT NOT NULL DEFAULT 'local',
-      feedback_id TEXT NOT NULL,
-      job_key     TEXT NOT NULL,
-      source_id   TEXT,
-      kind        TEXT NOT NULL,
-      note        TEXT,
-      recorded_at TEXT NOT NULL,
-      PRIMARY KEY (tenant_id, feedback_id)
-    );
     CREATE TABLE IF NOT EXISTS role_match_feedback_suggestions (
       tenant_id       TEXT NOT NULL DEFAULT 'local',
       suggestion_id   TEXT NOT NULL,
@@ -335,6 +336,69 @@ export function ensureDiscoveryControlTables(db: SqliteDatabase): void {
       PRIMARY KEY (tenant_id, suggestion_id)
     );
   `);
+  if (!tableExists(db, "discovery_feedback")) {
+    const referenceColumn = stableFeedbackReferences
+      ? "job_id"
+      : "job_key";
+    const foreignKey = stableFeedbackReferences
+      ? `,
+        FOREIGN KEY (tenant_id, job_id)
+          REFERENCES jobs(tenant_id, job_id) ON DELETE CASCADE`
+      : "";
+    db.exec(`
+      CREATE TABLE discovery_feedback (
+        tenant_id          TEXT NOT NULL DEFAULT 'local',
+        feedback_id        TEXT NOT NULL,
+        ${referenceColumn} TEXT NOT NULL,
+        source_id          TEXT,
+        kind               TEXT NOT NULL,
+        note               TEXT,
+        recorded_at        TEXT NOT NULL,
+        PRIMARY KEY (tenant_id, feedback_id)
+        ${foreignKey}
+      );
+    `);
+  }
+  const feedbackColumns = tableColumnSet(
+    db,
+    "discovery_feedback",
+  );
+  if (
+    stableFeedbackReferences
+    && (
+      !feedbackColumns.has("job_id")
+      || feedbackColumns.has("job_key")
+    )
+  ) {
+    throw new Error(
+      "Schema v26 requires stable discovery_feedback.job_id references.",
+    );
+  }
+  if (stableFeedbackReferences) {
+    db.exec(`
+      CREATE INDEX IF NOT EXISTS idx_discovery_feedback_job
+      ON discovery_feedback(tenant_id, job_id, recorded_at);
+    `);
+    if (
+      !hasCompositeJobIdForeignKey(
+        db,
+        "discovery_feedback",
+      )
+      || tableIndexColumns(
+        db,
+        "discovery_feedback",
+        "idx_discovery_feedback_job",
+      ).join(",") !== "tenant_id,job_id,recorded_at"
+      || primaryKeyColumns(
+        db,
+        "discovery_feedback",
+      ).join(",") !== "tenant_id,feedback_id"
+    ) {
+      throw new Error(
+        "Schema v26 requires the stable discovery-feedback JobId contract.",
+      );
+    }
+  }
 }
 
 export function readDiscoverySettings(
@@ -1205,14 +1269,32 @@ export function recordDiscoveryFeedback(
   ensureDiscoveryControlTables(db);
   const now = new Date().toISOString();
   const feedbackId = `feedback-${crypto.randomUUID()}`;
+  const referenceColumn = jobKeyReferenceColumn(
+    db,
+    "discovery_feedback",
+  );
+  let reference: string;
+  try {
+    reference = jobKeyReferenceForUrl(
+      db,
+      "discovery_feedback",
+      input.jobKey,
+      DEFAULT_TENANT,
+    );
+  } catch {
+    throw new InputError(
+      `No stable Job identity for ${input.jobKey}.`,
+    );
+  }
   db.prepare(
     `INSERT INTO discovery_feedback (
-       tenant_id, feedback_id, job_key, source_id, kind, note, recorded_at
+       tenant_id, feedback_id, ${referenceColumn},
+       source_id, kind, note, recorded_at
      ) VALUES (?, ?, ?, ?, ?, ?, ?)`,
   ).run(
     DEFAULT_TENANT,
     feedbackId,
-    input.jobKey,
+    reference,
     input.sourceId ?? null,
     input.kind,
     input.note ?? null,
@@ -1238,6 +1320,20 @@ export function recordDiscoveryFeedback(
     kind: input.kind,
     recordedAt: now,
   };
+}
+
+function primaryKeyColumns(
+  db: SqliteDatabase,
+  tableName: string,
+): string[] {
+  return (
+    db
+      .prepare(`PRAGMA table_info("${tableName.replaceAll('"', '""')}")`)
+      .all() as Array<{ name: string; pk: number }>
+  )
+    .filter((row) => row.pk > 0)
+    .sort((left, right) => left.pk - right.pk)
+    .map((row) => row.name);
 }
 
 export function listRoleMatchFeedbackSuggestions(

--- a/apps/api/src/write-model.ts
+++ b/apps/api/src/write-model.ts
@@ -862,6 +862,11 @@ function purgeJobRows(db: SqliteDatabase, jobUrl: string): void {
     jobId,
     jobUrl,
   );
+  deleteDiscoveryFeedbackReferences(
+    db,
+    jobId,
+    jobUrl,
+  );
   detachOrDeleteOutreachReferences(db, jobId, jobUrl);
   detachOrDeleteContactReferences(db, jobId, jobUrl);
   deleteJobReferences(db, "job_artifacts", jobId, jobUrl);
@@ -917,7 +922,6 @@ function purgeJobRows(db: SqliteDatabase, jobUrl: string): void {
     jobUrl,
     jobUrl,
   ]);
-  deleteWhere(db, "discovery_feedback", "job_key = ?", [jobUrl]);
   deleteWhere(db, "jobs", "url = ?", [jobUrl]);
 }
 
@@ -1248,6 +1252,27 @@ function deleteApplicationFeedbackReferences(
       ["local", reference],
     );
   }
+}
+
+function deleteDiscoveryFeedbackReferences(
+  db: SqliteDatabase,
+  jobId: string | undefined,
+  jobUrl: string,
+): void {
+  if (!tableExists(db, "discovery_feedback")) return;
+  const referenceColumn = jobKeyReferenceColumn(
+    db,
+    "discovery_feedback",
+  );
+  const reference =
+    referenceColumn === "job_id" ? jobId : jobUrl;
+  if (!reference) return;
+  deleteWhere(
+    db,
+    "discovery_feedback",
+    `tenant_id = ? AND ${referenceColumn} = ?`,
+    ["local", reference],
+  );
 }
 
 function deleteRepeatApplicationReferences(

--- a/apps/api/test/discovery-feedback-v26.test.ts
+++ b/apps/api/test/discovery-feedback-v26.test.ts
@@ -1,0 +1,298 @@
+import Database from "better-sqlite3";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  ensureDiscoveryControlTables,
+} from "../src/discovery-controls.js";
+import { buildApp } from "../src/server.js";
+import { permanentlyDeleteJob } from "../src/write-model.js";
+
+const NOW = "2026-07-30T12:00:00.000Z";
+const UUID_SHAPED_URL =
+  "11111111-1111-4111-8111-111111111111";
+const TARGET_JOB_ID =
+  "22222222-2222-4222-8222-222222222222";
+
+let db: Database.Database | undefined;
+let cleanup: (() => void) | undefined;
+
+afterEach(() => {
+  db?.close();
+  db = undefined;
+  cleanup?.();
+  cleanup = undefined;
+});
+
+function createDatabase(
+  schemaVersion = 26,
+  foreignKeys = true,
+): {
+  db: Database.Database;
+  dbPath: string;
+  dir: string;
+} {
+  const dir = fs.mkdtempSync(
+    path.join(os.tmpdir(), "jobctrl-discovery-feedback-v26-"),
+  );
+  const dbPath = path.join(dir, "jobs.db");
+  const opened = new Database(dbPath);
+  opened.pragma(
+    `foreign_keys = ${foreignKeys ? "ON" : "OFF"}`,
+  );
+  opened.exec(`
+    CREATE TABLE jobs (
+      url TEXT PRIMARY KEY,
+      tenant_id TEXT NOT NULL DEFAULT 'local',
+      job_id TEXT NOT NULL,
+      title TEXT,
+      company TEXT,
+      salary TEXT,
+      description TEXT,
+      location TEXT,
+      site TEXT,
+      strategy TEXT,
+      discovered_at TEXT,
+      full_description TEXT,
+      application_url TEXT,
+      detail_scraped_at TEXT,
+      detail_error TEXT,
+      fit_score INTEGER,
+      score_reasoning TEXT,
+      scored_at TEXT,
+      tailored_resume_path TEXT,
+      tailored_at TEXT,
+      tailor_attempts INTEGER DEFAULT 0,
+      cover_letter_path TEXT,
+      cover_letter_at TEXT,
+      cover_attempts INTEGER DEFAULT 0,
+      applied_at TEXT,
+      apply_status TEXT,
+      apply_error TEXT,
+      apply_attempts INTEGER DEFAULT 0,
+      agent_id TEXT,
+      last_attempted_at TEXT,
+      apply_duration_ms INTEGER,
+      apply_task_id TEXT,
+      verification_confidence TEXT,
+      UNIQUE (tenant_id, job_id)
+    );
+    CREATE TABLE job_identity_aliases (
+      tenant_id TEXT NOT NULL,
+      alias_kind TEXT NOT NULL,
+      alias_value TEXT NOT NULL,
+      job_id TEXT NOT NULL,
+      created_at TEXT NOT NULL,
+      retired_at TEXT,
+      PRIMARY KEY (tenant_id, alias_kind, alias_value)
+    );
+    CREATE TABLE job_events (
+      event_id INTEGER PRIMARY KEY AUTOINCREMENT,
+      job_url TEXT,
+      stage TEXT,
+      event_type TEXT NOT NULL DEFAULT '',
+      level TEXT NOT NULL DEFAULT 'info',
+      message TEXT,
+      occurred_at TEXT NOT NULL,
+      payload_json TEXT,
+      entity_kind TEXT,
+      entity_ref TEXT
+    );
+    PRAGMA user_version = ${schemaVersion};
+  `);
+  cleanup = () => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  };
+  return { db: opened, dbPath, dir };
+}
+
+function insertJob(
+  opened: Database.Database,
+  url: string,
+  jobId: string,
+): void {
+  opened.prepare(
+    `INSERT INTO jobs (
+       url, tenant_id, job_id, title, company, discovered_at
+     ) VALUES (?, 'local', ?, 'Platform Engineer', 'ExampleCo', ?)`,
+  ).run(url, jobId, NOW);
+}
+
+describe("schema-v26 Discovery feedback references", () => {
+  it("stores a URL-first stable JobId while preserving the URL event boundary", async () => {
+    const created = createDatabase();
+    db = created.db;
+    insertJob(db, UUID_SHAPED_URL, TARGET_JOB_ID);
+    insertJob(
+      db,
+      "https://careers.example.test/uuid-id-owner",
+      UUID_SHAPED_URL,
+    );
+    db.close();
+    db = undefined;
+
+    const app = buildApp({
+      dbPath: created.dbPath,
+      configPath: path.join(created.dir, "config.json"),
+    });
+    try {
+      const response = await app.inject({
+        method: "POST",
+        url: "/v1/discovery/feedback",
+        payload: {
+          jobKey: UUID_SHAPED_URL,
+          sourceId: "source:one",
+          kind: "bad_source",
+          note: "private reviewer note",
+        },
+      });
+      expect(response.statusCode, response.body).toBe(200);
+      expect(response.json()).toMatchObject({
+        ok: true,
+        jobKey: UUID_SHAPED_URL,
+        sourceId: "source:one",
+        kind: "bad_source",
+      });
+
+      db = new Database(created.dbPath);
+      const stored = db
+        .prepare(
+          `SELECT job_id, note
+             FROM discovery_feedback`,
+        )
+        .get() as {
+        job_id: string;
+        note: string;
+      };
+      expect(stored).toEqual({
+        job_id: TARGET_JOB_ID,
+        note: "private reviewer note",
+      });
+      const event = db
+        .prepare(
+          `SELECT job_url, payload_json
+             FROM job_events
+            WHERE event_type = 'DiscoveryFeedbackRecorded'`,
+        )
+        .get() as {
+        job_url: string;
+        payload_json: string;
+      };
+      expect(event.job_url).toBe(UUID_SHAPED_URL);
+      expect(JSON.parse(event.payload_json)).toMatchObject({
+        jobId: UUID_SHAPED_URL,
+        sourceId: "source:one",
+        kind: "bad_source",
+      });
+      expect(event.payload_json).not.toContain(
+        "private reviewer note",
+      );
+    } finally {
+      await app.close();
+    }
+  });
+
+  it("rejects an unknown canonical link before writing feedback or an event", async () => {
+    const created = createDatabase();
+    db = created.db;
+    db.close();
+    db = undefined;
+    const app = buildApp({
+      dbPath: created.dbPath,
+      configPath: path.join(created.dir, "config.json"),
+    });
+    try {
+      const missingUrl =
+        "https://careers.example.test/missing";
+      const response = await app.inject({
+        method: "POST",
+        url: "/v1/discovery/feedback",
+        payload: {
+          jobKey: missingUrl,
+          kind: "irrelevant",
+          note: "private rejected note",
+        },
+      });
+      expect(response.statusCode, response.body).toBe(404);
+      expect(response.json()).toMatchObject({
+        ok: false,
+        error: "not_found",
+        message: `No stable Job identity for ${missingUrl}.`,
+      });
+
+      db = new Database(created.dbPath);
+      expect(
+        db
+          .prepare(
+            "SELECT COUNT(*) AS count FROM discovery_feedback",
+          )
+          .get(),
+      ).toEqual({ count: 0 });
+      expect(
+        db
+          .prepare(
+            `SELECT COUNT(*) AS count
+               FROM job_events
+              WHERE event_type = 'DiscoveryFeedbackRecorded'`,
+          )
+          .get(),
+      ).toEqual({ count: 0 });
+    } finally {
+      await app.close();
+    }
+  });
+
+  it.each([true, false])(
+    "purges canonical feedback during permanent deletion with foreign keys %s",
+    (foreignKeys) => {
+      const created = createDatabase(26, foreignKeys);
+      db = created.db;
+      const targetUrl =
+        "https://careers.example.test/delete";
+      insertJob(db, targetUrl, TARGET_JOB_ID);
+      ensureDiscoveryControlTables(db);
+      db.prepare(
+        `INSERT INTO discovery_feedback (
+           tenant_id, feedback_id, job_id, source_id,
+           kind, note, recorded_at
+         ) VALUES (
+           'local', 'feedback:delete', ?, 'source:delete',
+           'bad_source', 'private deletion note', ?
+         )`,
+      ).run(TARGET_JOB_ID, NOW);
+
+      expect(permanentlyDeleteJob(db, targetUrl)).toEqual({
+        ok: true,
+        count: 1,
+        jobKeys: [targetUrl],
+      });
+      expect(
+        db
+          .prepare(
+            "SELECT COUNT(*) AS count FROM discovery_feedback",
+          )
+          .get(),
+      ).toEqual({ count: 0 });
+      expect(
+        db
+          .prepare(
+            "SELECT COUNT(*) AS count FROM jobs",
+          )
+          .get(),
+      ).toEqual({ count: 0 });
+    },
+  );
+
+  it("fails closed when a v26 stamp has a legacy feedback table", () => {
+    const created = createDatabase(25);
+    db = created.db;
+    ensureDiscoveryControlTables(db);
+    db.pragma("user_version = 26");
+
+    expect(() => ensureDiscoveryControlTables(db!)).toThrow(
+      "Schema v26 requires stable discovery_feedback.job_id references.",
+    );
+  });
+});

--- a/apps/api/test/schema-version-guard.test.ts
+++ b/apps/api/test/schema-version-guard.test.ts
@@ -63,7 +63,7 @@ describe("schema version guard at DB open", () => {
   });
 
   it("opens the worker-owned schema-v14 artifact registry", () => {
-    expect(SUPPORTED_SCHEMA_VERSION).toBe(25);
+    expect(SUPPORTED_SCHEMA_VERSION).toBe(26);
     const { dbPath, cleanup } = makeDbWithUserVersion(14);
     try {
       openDatabase(dbPath).close();

--- a/workers/automation/src/jobctrl/database.py
+++ b/workers/automation/src/jobctrl/database.py
@@ -97,7 +97,10 @@ from jobctrl.config import DB_PATH, DEFAULTS, migrate_legacy_job_tables
 # resolved at the adapter boundary. Job deletion is restricted so the explicit
 # permanent-delete path can detach preserved outreach history or purge threads
 # whose job-only Contact is removed.
-SCHEMA_VERSION = 25
+# v26 (discovery-feedback references): user-authored Discovery feedback points
+# at the tenant-scoped stable Job aggregate. The URL-shaped API/event contract
+# remains unchanged, and private free-form notes stay only in canonical storage.
+SCHEMA_VERSION = 26
 
 
 class IncompatibleSchemaVersionError(RuntimeError):
@@ -253,6 +256,7 @@ def _schema_migrations() -> tuple[
         (23, ensure_repeat_application_references_v23),
         (24, ensure_contact_research_references_v24),
         (25, ensure_outreach_references_v25),
+        (26, ensure_discovery_feedback_references_v26),
     )
 
 
@@ -3720,6 +3724,10 @@ def ensure_discovery_control_tables(conn: sqlite3.Connection | None = None) -> l
     """
     if conn is None:
         conn = get_connection()
+    current_version = _assert_schema_version_supported(conn)
+    stable_feedback_references = (
+        current_version >= _DISCOVERY_FEEDBACK_REFERENCE_SCHEMA_VERSION
+    )
 
     conn.execute(
         """
@@ -3801,20 +3809,31 @@ def ensure_discovery_control_tables(conn: sqlite3.Connection | None = None) -> l
         )
         """
     )
-    conn.execute(
-        """
-        CREATE TABLE IF NOT EXISTS discovery_feedback (
-            tenant_id   TEXT NOT NULL DEFAULT 'local',
-            feedback_id TEXT NOT NULL,
-            job_key     TEXT NOT NULL,
-            source_id   TEXT,
-            kind        TEXT NOT NULL,
-            note        TEXT,
-            recorded_at TEXT NOT NULL,
-            PRIMARY KEY (tenant_id, feedback_id)
+    if not _table_columns(conn, "discovery_feedback"):
+        _create_discovery_feedback_table_v26(
+            conn,
+            table="discovery_feedback",
+            stable_reference=stable_feedback_references,
         )
-        """
-    )
+    if stable_feedback_references:
+        feedback_columns = _table_columns(
+            conn,
+            "discovery_feedback",
+        )
+        if (
+            "job_id" not in feedback_columns
+            or "job_key" in feedback_columns
+        ):
+            raise RuntimeError(
+                "Schema v26 requires stable discovery-feedback "
+                "JobId references."
+            )
+        _create_discovery_feedback_reference_index_v26(conn)
+        if not _has_discovery_feedback_reference_schema_v26(conn):
+            raise RuntimeError(
+                "Schema v26 requires the stable discovery-feedback "
+                "JobId contract."
+            )
     conn.commit()
     return [
         "source_registry_entries",
@@ -4856,6 +4875,13 @@ def _reassign_discovery_identity_references(
             surviving_job_id=surviving_job_id,
             losing_job_url=losing_job_url,
             surviving_job_url=surviving_job_url,
+        )
+    if _has_discovery_feedback_reference_schema_v26(conn):
+        _reassign_discovery_feedback_references_v26(
+            conn,
+            tenant_id=tenant_id,
+            losing_job_id=losing_job_id,
+            surviving_job_id=surviving_job_id,
         )
     if _has_scoring_reference_schema_v12(conn):
         _reassign_scoring_references_v12(
@@ -15231,6 +15257,286 @@ def _reassign_outreach_references_v25(
     _verify_outreach_references_v25(
         conn,
         expected_counts=expected_counts,
+    )
+
+
+_DISCOVERY_FEEDBACK_REFERENCE_SCHEMA_VERSION = 26
+_DISCOVERY_FEEDBACK_REFERENCE_TABLES = ("discovery_feedback",)
+
+
+def _create_discovery_feedback_table_v26(
+    conn: sqlite3.Connection,
+    *,
+    table: str,
+    stable_reference: bool,
+) -> None:
+    reference_column = "job_id" if stable_reference else "job_key"
+    foreign_key = (
+        """,
+            FOREIGN KEY (tenant_id, job_id)
+                REFERENCES jobs(tenant_id, job_id) ON DELETE CASCADE"""
+        if stable_reference
+        else ""
+    )
+    conn.execute(
+        f"""
+        CREATE TABLE "{table}" (
+            tenant_id         TEXT NOT NULL DEFAULT 'local',
+            feedback_id       TEXT NOT NULL,
+            {reference_column} TEXT NOT NULL,
+            source_id         TEXT,
+            kind              TEXT NOT NULL,
+            note              TEXT,
+            recorded_at       TEXT NOT NULL,
+            PRIMARY KEY (tenant_id, feedback_id)
+            {foreign_key}
+        )
+        """
+    )
+
+
+def _create_discovery_feedback_reference_index_v26(
+    conn: sqlite3.Connection,
+) -> None:
+    if _has_index(
+        conn,
+        "discovery_feedback",
+        "idx_discovery_feedback_job",
+        ("tenant_id", "job_id", "recorded_at"),
+        unique=False,
+    ):
+        return
+    conn.execute(
+        'DROP INDEX IF EXISTS "idx_discovery_feedback_job"'
+    )
+    conn.execute(
+        """
+        CREATE INDEX idx_discovery_feedback_job
+        ON discovery_feedback(tenant_id, job_id, recorded_at)
+        """
+    )
+
+
+def _has_discovery_feedback_reference_schema_v26(
+    conn: sqlite3.Connection,
+) -> bool:
+    table = "discovery_feedback"
+    return (
+        "job_id" in _table_columns(conn, table)
+        and "job_key" not in _table_columns(conn, table)
+        and _primary_key_columns(conn, table)
+        == ("tenant_id", "feedback_id")
+        and _has_composite_job_id_foreign_key(
+            conn,
+            table,
+            "job_id",
+        )
+        and _has_index(
+            conn,
+            table,
+            "idx_discovery_feedback_job",
+            ("tenant_id", "job_id", "recorded_at"),
+            unique=False,
+        )
+    )
+
+
+def _canonical_discovery_feedback_rows_v26(
+    conn: sqlite3.Connection,
+) -> list[tuple[Any, ...]]:
+    reference_column = _legacy_or_stable_reference_column(
+        conn,
+        "discovery_feedback",
+        stable="job_id",
+        legacy="job_key",
+    )
+    rows = conn.execute(
+        f"""
+        SELECT tenant_id, feedback_id, {reference_column},
+               source_id, kind, note, recorded_at
+        FROM discovery_feedback
+        ORDER BY tenant_id, feedback_id
+        """
+    ).fetchall()
+    canonical: list[tuple[Any, ...]] = []
+    for row in rows:
+        values = tuple(row)
+        stable_job_id = _resolve_job_reference_value(
+            conn,
+            tenant_id=str(values[0]),
+            reference=str(values[2]),
+            legacy_url=reference_column == "job_key",
+        )
+        if stable_job_id is None:
+            raise RuntimeError(
+                "discovery-feedback reference migration could not "
+                f"resolve discovery_feedback.{reference_column}="
+                f"{values[2]!r} for tenant {values[0]!r}"
+            )
+        _validate_job_uuid(stable_job_id)
+        canonical.append(
+            (
+                values[0],
+                values[1],
+                stable_job_id,
+                *values[3:],
+            )
+        )
+    return canonical
+
+
+def ensure_discovery_feedback_references_v26(
+    conn: sqlite3.Connection | None = None,
+) -> list[str]:
+    """Move user-authored Discovery feedback links to stable JobIds."""
+    if conn is None:
+        conn = get_connection()
+    current = _assert_schema_version_supported(conn)
+    if current >= _DISCOVERY_FEEDBACK_REFERENCE_SCHEMA_VERSION:
+        return list(_DISCOVERY_FEEDBACK_REFERENCE_TABLES)
+    if current != _OUTREACH_REFERENCE_SCHEMA_VERSION:
+        raise RuntimeError(
+            "discovery-feedback reference migration requires schema v25; "
+            f"found v{current}"
+        )
+
+    conn.execute("SAVEPOINT discovery_feedback_references_v26")
+    try:
+        if not _table_columns(conn, "discovery_feedback"):
+            _create_discovery_feedback_table_v26(
+                conn,
+                table="discovery_feedback",
+                stable_reference=False,
+            )
+        expected_count = int(
+            conn.execute(
+                "SELECT COUNT(*) FROM discovery_feedback"
+            ).fetchone()[0]
+        )
+        feedback_rows = _canonical_discovery_feedback_rows_v26(
+            conn
+        )
+
+        conn.execute("DROP TABLE IF EXISTS discovery_feedback_v26")
+        _create_discovery_feedback_table_v26(
+            conn,
+            table="discovery_feedback_v26",
+            stable_reference=True,
+        )
+        conn.executemany(
+            """
+            INSERT INTO discovery_feedback_v26 (
+                tenant_id, feedback_id, job_id, source_id,
+                kind, note, recorded_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            feedback_rows,
+        )
+
+        conn.execute('DROP TABLE "discovery_feedback"')
+        conn.execute(
+            'ALTER TABLE "discovery_feedback_v26" '
+            'RENAME TO "discovery_feedback"'
+        )
+        _create_discovery_feedback_reference_index_v26(conn)
+        _verify_discovery_feedback_references_v26(
+            conn,
+            expected_count=expected_count,
+        )
+        conn.execute(
+            f"PRAGMA user_version = "
+            f"{_DISCOVERY_FEEDBACK_REFERENCE_SCHEMA_VERSION}"
+        )
+        conn.execute(
+            "RELEASE SAVEPOINT discovery_feedback_references_v26"
+        )
+    except BaseException:
+        conn.execute(
+            "ROLLBACK TO SAVEPOINT "
+            "discovery_feedback_references_v26"
+        )
+        conn.execute(
+            "RELEASE SAVEPOINT discovery_feedback_references_v26"
+        )
+        raise
+    return list(_DISCOVERY_FEEDBACK_REFERENCE_TABLES)
+
+
+def _verify_discovery_feedback_references_v26(
+    conn: sqlite3.Connection,
+    *,
+    expected_count: int,
+) -> None:
+    if not _has_discovery_feedback_reference_schema_v26(conn):
+        raise RuntimeError(
+            "discovery-feedback reference migration did not create "
+            "the stable reference schema"
+        )
+    observed_count = int(
+        conn.execute(
+            "SELECT COUNT(*) FROM discovery_feedback"
+        ).fetchone()[0]
+    )
+    if observed_count != expected_count:
+        raise RuntimeError(
+            "discovery-feedback reference migration changed row count: "
+            f"expected {expected_count}, found {observed_count}"
+        )
+    orphan = conn.execute(
+        """
+        SELECT feedback.job_id
+        FROM discovery_feedback AS feedback
+        LEFT JOIN jobs
+          ON jobs.tenant_id = feedback.tenant_id
+         AND jobs.job_id = feedback.job_id
+        WHERE jobs.job_id IS NULL
+        LIMIT 1
+        """
+    ).fetchone()
+    if orphan is not None:
+        raise RuntimeError(
+            "discovery-feedback reference migration left an "
+            "unresolved JobId"
+        )
+    for row in conn.execute(
+        "SELECT DISTINCT job_id FROM discovery_feedback"
+    ).fetchall():
+        _validate_job_uuid(str(row[0]))
+    foreign_key_error = conn.execute(
+        "PRAGMA foreign_key_check"
+    ).fetchone()
+    if foreign_key_error is not None:
+        raise RuntimeError(
+            "discovery-feedback reference migration found a "
+            "foreign-key violation"
+        )
+
+
+def _reassign_discovery_feedback_references_v26(
+    conn: sqlite3.Connection,
+    *,
+    tenant_id: str,
+    losing_job_id: str,
+    surviving_job_id: str,
+) -> None:
+    if losing_job_id == surviving_job_id:
+        return
+    expected_count = int(
+        conn.execute(
+            "SELECT COUNT(*) FROM discovery_feedback"
+        ).fetchone()[0]
+    )
+    conn.execute(
+        """
+        UPDATE discovery_feedback
+        SET job_id = ?
+        WHERE tenant_id = ? AND job_id = ?
+        """,
+        (surviving_job_id, tenant_id, losing_job_id),
+    )
+    _verify_discovery_feedback_references_v26(
+        conn,
+        expected_count=expected_count,
     )
 
 

--- a/workers/automation/tests/test_application_feedback_candidate_identity_reference_migration.py
+++ b/workers/automation/tests/test_application_feedback_candidate_identity_reference_migration.py
@@ -331,7 +331,7 @@ def test_v21_candidates_migrate_every_alias_uuid_url_and_tenant(
     assert (
         reopened.execute("PRAGMA user_version").fetchone()[0]
         == SCHEMA_VERSION
-        == 25
+        == 26
     )
     for table in database_module._APPLICATION_FEEDBACK_CANDIDATE_TABLES:
         assert "job_id" in _columns(reopened, table)

--- a/workers/automation/tests/test_application_outcome_identity_reference_migration.py
+++ b/workers/automation/tests/test_application_outcome_identity_reference_migration.py
@@ -243,7 +243,7 @@ def test_v20_outcomes_migrate_every_alias_uuid_url_and_tenant(
     assert (
         reopened.execute("PRAGMA user_version").fetchone()[0]
         == SCHEMA_VERSION
-        == 25
+        == 26
     )
     assert "job_id" in _columns(reopened, "application_outcomes")
     assert "job_key" not in _columns(reopened, "application_outcomes")

--- a/workers/automation/tests/test_application_review_identity_reference_migration.py
+++ b/workers/automation/tests/test_application_review_identity_reference_migration.py
@@ -204,7 +204,7 @@ def test_v19_review_decisions_migrate_every_alias_and_uuid_url(
     assert (
         reopened.execute("PRAGMA user_version").fetchone()[0]
         == SCHEMA_VERSION
-        == 25
+        == 26
     )
     assert "job_id" in _columns(
         reopened,

--- a/workers/automation/tests/test_compensation_identity_reference_migration.py
+++ b/workers/automation/tests/test_compensation_identity_reference_migration.py
@@ -210,7 +210,7 @@ def test_v18_compensation_migrates_alias_winners_and_uuid_urls(
     assert (
         reopened.execute("PRAGMA user_version").fetchone()[0]
         == SCHEMA_VERSION
-        == 25
+        == 26
     )
     for table in database_module._COMPENSATION_REFERENCE_TABLES:
         assert "job_id" in _columns(reopened, table)

--- a/workers/automation/tests/test_discovery_feedback_identity_reference_migration.py
+++ b/workers/automation/tests/test_discovery_feedback_identity_reference_migration.py
@@ -1,0 +1,449 @@
+"""Schema-v26 Discovery feedback stable JobId contracts."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import jobctrl.database as database_module
+from jobctrl.database import (
+    SCHEMA_VERSION,
+    ensure_discovery_control_tables,
+    ensure_discovery_feedback_references_v26,
+    init_db,
+    reassign_discovery_identity_references,
+)
+
+PREVIOUS_SCHEMA_VERSION = 25
+NOW = "2026-07-30T12:00:00+00:00"
+UUID_SHAPED_URL = "11111111-1111-4111-8111-111111111111"
+TARGET_JOB_ID = "22222222-2222-4222-8222-222222222222"
+COLLIDING_JOB_ID = UUID_SHAPED_URL
+PRIOR_JOB_ID = "33333333-3333-4333-8333-333333333333"
+SURVIVOR_JOB_ID = "44444444-4444-4444-8444-444444444444"
+
+
+def _columns(
+    conn: sqlite3.Connection,
+    table: str,
+) -> set[str]:
+    return {
+        str(row[1])
+        for row in conn.execute(
+            f'PRAGMA table_info("{table}")'
+        ).fetchall()
+    }
+
+
+def _insert_job(
+    conn: sqlite3.Connection,
+    *,
+    url: str,
+    job_id: str,
+    tenant_id: str = "local",
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO jobs (
+            url, tenant_id, job_id, title, company, discovered_at
+        ) VALUES (?, ?, ?, 'Platform Engineer', 'ExampleCo', ?)
+        """,
+        (url, tenant_id, job_id, NOW),
+    )
+
+
+def _downgrade_discovery_feedback_table_to_v25(
+    conn: sqlite3.Connection,
+) -> None:
+    conn.commit()
+    conn.execute("PRAGMA foreign_keys = OFF")
+    conn.execute("DROP TABLE discovery_feedback")
+    database_module._create_discovery_feedback_table_v26(
+        conn,
+        table="discovery_feedback",
+        stable_reference=False,
+    )
+    conn.execute(
+        f"PRAGMA user_version = {PREVIOUS_SCHEMA_VERSION}"
+    )
+    conn.commit()
+    conn.execute("PRAGMA foreign_keys = ON")
+
+
+def _seed_v25_database(db_path: Path) -> sqlite3.Connection:
+    conn = init_db(db_path)
+    conn.row_factory = sqlite3.Row
+    _downgrade_discovery_feedback_table_to_v25(conn)
+    return conn
+
+
+def _feedback_snapshot(
+    conn: sqlite3.Connection,
+) -> list[tuple[Any, ...]]:
+    return [
+        tuple(row)
+        for row in conn.execute(
+            """
+            SELECT * FROM discovery_feedback
+            ORDER BY tenant_id, feedback_id
+            """
+        ).fetchall()
+    ]
+
+
+def test_v25_rows_migrate_exactly_with_url_first_resolution(
+    tmp_path: Path,
+) -> None:
+    conn = _seed_v25_database(tmp_path / "jobs.db")
+    colliding_owner_url = (
+        "https://careers.example.test/uuid-id-owner"
+    )
+    prior_url = "https://careers.example.test/prior"
+    prior_alias = "https://legacy.example.test/prior"
+    blue_target_url = "https://blue.example.test/target"
+    _insert_job(
+        conn,
+        url=UUID_SHAPED_URL,
+        job_id=TARGET_JOB_ID,
+    )
+    _insert_job(
+        conn,
+        url=colliding_owner_url,
+        job_id=COLLIDING_JOB_ID,
+    )
+    _insert_job(conn, url=prior_url, job_id=PRIOR_JOB_ID)
+    _insert_job(
+        conn,
+        url=blue_target_url,
+        job_id=TARGET_JOB_ID,
+        tenant_id="blue",
+    )
+    conn.execute(
+        """
+        INSERT INTO job_identity_aliases (
+            tenant_id, alias_kind, alias_value, job_id, created_at
+        ) VALUES ('local', 'posting_url', ?, ?, ?)
+        """,
+        (prior_alias, PRIOR_JOB_ID, NOW),
+    )
+    conn.executemany(
+        """
+        INSERT INTO discovery_feedback (
+            tenant_id, feedback_id, job_key, source_id,
+            kind, note, recorded_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            (
+                "local",
+                "feedback:uuid-url",
+                UUID_SHAPED_URL,
+                "source:one",
+                "bad_source",
+                "private: uuid-shaped URL note",
+                NOW,
+            ),
+            (
+                "local",
+                "feedback:alias",
+                prior_alias,
+                None,
+                "irrelevant",
+                "private: alias note",
+                NOW,
+            ),
+            (
+                "blue",
+                "feedback:blue",
+                blue_target_url,
+                "source:blue",
+                "useful",
+                "private: tenant-isolated note",
+                NOW,
+            ),
+        ),
+    )
+    conn.commit()
+
+    assert ensure_discovery_feedback_references_v26(
+        conn
+    ) == list(
+        database_module._DISCOVERY_FEEDBACK_REFERENCE_TABLES
+    )
+
+    assert (
+        conn.execute("PRAGMA user_version").fetchone()[0]
+        == SCHEMA_VERSION
+        == 26
+    )
+    assert (
+        database_module
+        ._has_discovery_feedback_reference_schema_v26(conn)
+    )
+    assert [
+        tuple(row)
+        for row in conn.execute(
+            """
+            SELECT tenant_id, feedback_id, job_id, source_id,
+                   kind, note, recorded_at
+            FROM discovery_feedback
+            ORDER BY tenant_id, feedback_id
+            """
+        ).fetchall()
+    ] == [
+        (
+            "blue",
+            "feedback:blue",
+            TARGET_JOB_ID,
+            "source:blue",
+            "useful",
+            "private: tenant-isolated note",
+            NOW,
+        ),
+        (
+            "local",
+            "feedback:alias",
+            PRIOR_JOB_ID,
+            None,
+            "irrelevant",
+            "private: alias note",
+            NOW,
+        ),
+        (
+            "local",
+            "feedback:uuid-url",
+            TARGET_JOB_ID,
+            "source:one",
+            "bad_source",
+            "private: uuid-shaped URL note",
+            NOW,
+        ),
+    ]
+    assert {
+        str(row[6]).upper()
+        for row in conn.execute(
+            'PRAGMA foreign_key_list("discovery_feedback")'
+        ).fetchall()
+    } == {"CASCADE"}
+    assert conn.execute(
+        "PRAGMA foreign_key_check"
+    ).fetchone() is None
+
+
+def test_unresolved_reference_rolls_back_and_retry_succeeds(
+    tmp_path: Path,
+) -> None:
+    conn = _seed_v25_database(tmp_path / "retry.db")
+    missing_url = "https://careers.example.test/retry"
+    conn.execute(
+        """
+        INSERT INTO discovery_feedback (
+            tenant_id, feedback_id, job_key, source_id,
+            kind, note, recorded_at
+        ) VALUES (
+            'local', 'feedback:retry', ?, 'source:retry',
+            'bad_source', 'private: retry note', ?
+        )
+        """,
+        (missing_url, NOW),
+    )
+    conn.commit()
+    before = _feedback_snapshot(conn)
+
+    with pytest.raises(
+        RuntimeError,
+        match="could not resolve discovery_feedback.job_key",
+    ):
+        ensure_discovery_feedback_references_v26(conn)
+
+    assert (
+        conn.execute("PRAGMA user_version").fetchone()[0]
+        == PREVIOUS_SCHEMA_VERSION
+    )
+    assert _feedback_snapshot(conn) == before
+    assert "job_key" in _columns(conn, "discovery_feedback")
+    assert "job_id" not in _columns(conn, "discovery_feedback")
+    assert conn.execute(
+        """
+        SELECT COUNT(*) FROM sqlite_master
+        WHERE type = 'table' AND name = 'discovery_feedback_v26'
+        """
+    ).fetchone()[0] == 0
+
+    _insert_job(conn, url=missing_url, job_id=TARGET_JOB_ID)
+    conn.commit()
+    ensure_discovery_feedback_references_v26(conn)
+    assert conn.execute(
+        "SELECT job_id FROM discovery_feedback"
+    ).fetchone()[0] == TARGET_JOB_ID
+
+
+def test_verification_failure_rolls_back_and_retry_succeeds(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    conn = _seed_v25_database(tmp_path / "verify.db")
+    job_url = "https://careers.example.test/verify"
+    _insert_job(conn, url=job_url, job_id=TARGET_JOB_ID)
+    conn.execute(
+        """
+        INSERT INTO discovery_feedback (
+            tenant_id, feedback_id, job_key, kind, note, recorded_at
+        ) VALUES (
+            'local', 'feedback:verify', ?, 'useful',
+            'private: verification note', ?
+        )
+        """,
+        (job_url, NOW),
+    )
+    conn.commit()
+    before = _feedback_snapshot(conn)
+    original_verify = (
+        database_module
+        ._verify_discovery_feedback_references_v26
+    )
+
+    def _fail_verification(
+        _conn: sqlite3.Connection,
+        *,
+        expected_count: int,
+    ) -> None:
+        del expected_count
+        raise RuntimeError(
+            "injected discovery-feedback verification failure"
+        )
+
+    monkeypatch.setattr(
+        database_module,
+        "_verify_discovery_feedback_references_v26",
+        _fail_verification,
+    )
+    with pytest.raises(
+        RuntimeError,
+        match="injected discovery-feedback verification failure",
+    ):
+        ensure_discovery_feedback_references_v26(conn)
+    assert (
+        conn.execute("PRAGMA user_version").fetchone()[0]
+        == PREVIOUS_SCHEMA_VERSION
+    )
+    assert _feedback_snapshot(conn) == before
+    assert "job_key" in _columns(conn, "discovery_feedback")
+
+    monkeypatch.setattr(
+        database_module,
+        "_verify_discovery_feedback_references_v26",
+        original_verify,
+    )
+    ensure_discovery_feedback_references_v26(conn)
+    assert conn.execute(
+        "SELECT job_id FROM discovery_feedback"
+    ).fetchone()[0] == TARGET_JOB_ID
+
+
+@pytest.mark.parametrize(
+    ("schema_version", "expected_reference"),
+    ((0, "job_key"), (25, "job_key"), (26, "job_id")),
+)
+def test_missing_table_recovery_is_schema_version_aware(
+    schema_version: int,
+    expected_reference: str,
+) -> None:
+    conn = sqlite3.connect(":memory:")
+    conn.executescript(
+        f"""
+        CREATE TABLE jobs (
+            url TEXT PRIMARY KEY,
+            tenant_id TEXT NOT NULL DEFAULT 'local',
+            job_id TEXT NOT NULL,
+            UNIQUE (tenant_id, job_id)
+        );
+        PRAGMA user_version = {schema_version};
+        """
+    )
+
+    ensure_discovery_control_tables(conn)
+
+    assert expected_reference in _columns(
+        conn,
+        "discovery_feedback",
+    )
+    if schema_version == 26:
+        assert (
+            database_module
+            ._has_discovery_feedback_reference_schema_v26(conn)
+        )
+
+
+def test_stamped_v26_legacy_table_fails_closed() -> None:
+    conn = sqlite3.connect(":memory:")
+    conn.executescript(
+        """
+        CREATE TABLE jobs (
+            url TEXT PRIMARY KEY,
+            tenant_id TEXT NOT NULL DEFAULT 'local',
+            job_id TEXT NOT NULL,
+            UNIQUE (tenant_id, job_id)
+        );
+        PRAGMA user_version = 25;
+        """
+    )
+    ensure_discovery_control_tables(conn)
+    conn.execute("PRAGMA user_version = 26")
+
+    with pytest.raises(
+        RuntimeError,
+        match="Schema v26 requires stable discovery-feedback",
+    ):
+        ensure_discovery_control_tables(conn)
+
+
+def test_runtime_collision_rehomes_feedback_without_exposing_note(
+    tmp_path: Path,
+) -> None:
+    conn = init_db(tmp_path / "collision.db")
+    losing_url = "https://careers.example.test/losing"
+    surviving_url = "https://careers.example.test/surviving"
+    _insert_job(conn, url=losing_url, job_id=TARGET_JOB_ID)
+    _insert_job(
+        conn,
+        url=surviving_url,
+        job_id=SURVIVOR_JOB_ID,
+    )
+    conn.execute(
+        """
+        INSERT INTO discovery_feedback (
+            tenant_id, feedback_id, job_id, source_id,
+            kind, note, recorded_at
+        ) VALUES (
+            'local', 'feedback:collision', ?, 'source:collision',
+            'bad_source', 'private: collision note', ?
+        )
+        """,
+        (TARGET_JOB_ID, NOW),
+    )
+    conn.commit()
+
+    reassign_discovery_identity_references(
+        conn,
+        losing_job_url=losing_url,
+        surviving_job_url=surviving_url,
+    )
+
+    row = conn.execute(
+        """
+        SELECT job_id, note
+        FROM discovery_feedback
+        WHERE feedback_id = 'feedback:collision'
+        """
+    ).fetchone()
+    assert tuple(row) == (
+        SURVIVOR_JOB_ID,
+        "private: collision note",
+    )
+    assert conn.execute(
+        "PRAGMA foreign_key_check"
+    ).fetchone() is None

--- a/workers/automation/tests/test_discovery_identity_reference_migration.py
+++ b/workers/automation/tests/test_discovery_identity_reference_migration.py
@@ -220,7 +220,7 @@ def test_v7_discovery_references_migrate_to_stable_job_id_and_reopen(
     init_db(db_path)
     close_connection(db_path)
 
-    assert _user_version(db_path) == SCHEMA_VERSION == 25
+    assert _user_version(db_path) == SCHEMA_VERSION == 26
     assert "job_id" in _columns(db_path, "job_source_observations")
     assert "job_url" not in _columns(db_path, "job_source_observations")
     assert "job_id" in _columns(db_path, "job_canonical_identities")

--- a/workers/automation/tests/test_employer_analysis_identity_reference_migration.py
+++ b/workers/automation/tests/test_employer_analysis_identity_reference_migration.py
@@ -242,7 +242,7 @@ def test_v15_employer_analysis_migrates_alias_histories_and_uuid_urls(
     assert (
         reopened.execute("PRAGMA user_version").fetchone()[0]
         == SCHEMA_VERSION
-        == 25
+        == 26
     )
     for table in database_module._EMPLOYER_ANALYSIS_REFERENCE_TABLES:
         assert "job_id" in _columns(reopened, table)

--- a/workers/automation/tests/test_enrichment_snapshot_identity_reference_migration.py
+++ b/workers/automation/tests/test_enrichment_snapshot_identity_reference_migration.py
@@ -322,7 +322,7 @@ def test_v10_enrichment_snapshot_references_migrate_and_reopen(
     init_db(db_path)
     close_connection(db_path)
 
-    assert _user_version(db_path) == SCHEMA_VERSION == 25
+    assert _user_version(db_path) == SCHEMA_VERSION == 26
     check = sqlite3.connect(db_path)
     try:
         enrichment_rows = check.execute(

--- a/workers/automation/tests/test_execution_search_identity_reference_migration.py
+++ b/workers/automation/tests/test_execution_search_identity_reference_migration.py
@@ -261,7 +261,7 @@ def test_v8_execution_and_receipts_migrate_to_stable_job_id_and_reopen(
     init_db(db_path)
     close_connection(db_path)
 
-    assert _user_version(db_path) == SCHEMA_VERSION == 25
+    assert _user_version(db_path) == SCHEMA_VERSION == 26
     assert "job_id" in _columns(db_path, "discovery_execution_jobs")
     assert "job_url" not in _columns(db_path, "discovery_execution_jobs")
     assert "job_id" in _columns(db_path, "discovery_search_unit_jobs")

--- a/workers/automation/tests/test_interview_prep_identity_reference_migration.py
+++ b/workers/automation/tests/test_interview_prep_identity_reference_migration.py
@@ -323,7 +323,7 @@ def test_v17_interview_prep_migrates_alias_histories_and_uuid_urls(
     assert (
         reopened.execute("PRAGMA user_version").fetchone()[0]
         == SCHEMA_VERSION
-        == 25
+        == 26
     )
     for table in database_module._INTERVIEW_PREP_REFERENCE_TABLES:
         assert "job_id" in _columns(reopened, table)

--- a/workers/automation/tests/test_materials_identity_reference_migration.py
+++ b/workers/automation/tests/test_materials_identity_reference_migration.py
@@ -293,7 +293,7 @@ def test_v14_materials_migrate_alias_histories_and_uuid_shaped_urls(
     close_connection(db_path)
 
     reopened = init_db(db_path)
-    assert reopened.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_VERSION == 25
+    assert reopened.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_VERSION == 26
     for table in database_module._MATERIALS_REFERENCE_TABLES:
         assert "job_id" in _columns(reopened, table)
         assert "job_url" not in _columns(reopened, table)

--- a/workers/automation/tests/test_outreach_identity_reference_migration.py
+++ b/workers/automation/tests/test_outreach_identity_reference_migration.py
@@ -10,7 +10,6 @@ import pytest
 
 import jobctrl.database as database_module
 from jobctrl.database import (
-    SCHEMA_VERSION,
     ensure_contact_tables,
     ensure_outreach_references_v25,
     init_db,
@@ -240,11 +239,7 @@ def test_v24_rows_migrate_exactly_with_url_first_resolution(
         database_module._OUTREACH_REFERENCE_TABLES
     )
 
-    assert (
-        conn.execute("PRAGMA user_version").fetchone()[0]
-        == SCHEMA_VERSION
-        == 25
-    )
+    assert conn.execute("PRAGMA user_version").fetchone()[0] == 25
     assert database_module._has_outreach_reference_schema_v25(
         conn
     )

--- a/workers/automation/tests/test_preparation_identity_reference_migration.py
+++ b/workers/automation/tests/test_preparation_identity_reference_migration.py
@@ -177,7 +177,7 @@ def test_v9_preparation_references_migrate_to_stable_job_ids_and_reopen(
     init_db(db_path)
     close_connection(db_path)
 
-    assert _user_version(db_path) == SCHEMA_VERSION == 25
+    assert _user_version(db_path) == SCHEMA_VERSION == 26
     check = sqlite3.connect(db_path)
     try:
         rows = check.execute(

--- a/workers/automation/tests/test_repeat_application_identity_reference_migration.py
+++ b/workers/automation/tests/test_repeat_application_identity_reference_migration.py
@@ -402,7 +402,7 @@ def test_v22_history_migrates_exactly_with_url_first_resolution(
     reopened = init_db(db_path)
     assert reopened.execute("PRAGMA user_version").fetchone()[0] == (
         SCHEMA_VERSION
-    ) == 25
+    ) == 26
     assert database_module._has_repeat_application_reference_schema_v23(
         reopened
     )

--- a/workers/automation/tests/test_repeat_application_prevention.py
+++ b/workers/automation/tests/test_repeat_application_prevention.py
@@ -799,7 +799,7 @@ def test_schema_v5_migrates_additively_without_changing_application_facts(
         (PRIOR,),
     ).fetchall()
 
-    assert int(migrated.execute("PRAGMA user_version").fetchone()[0]) == SCHEMA_VERSION == 25
+    assert int(migrated.execute("PRAGMA user_version").fetchone()[0]) == SCHEMA_VERSION == 26
     assert [tuple(row) for row in after] == [tuple(row) for row in before]
     assert "metadata_json" in {
         str(row[1]) for row in migrated.execute("PRAGMA table_info(job_stage_states)").fetchall()

--- a/workers/automation/tests/test_resume_template_identity_reference_migration.py
+++ b/workers/automation/tests/test_resume_template_identity_reference_migration.py
@@ -254,7 +254,7 @@ def test_v16_template_references_migrate_aliases_and_uuid_urls(
     assert (
         reopened.execute("PRAGMA user_version").fetchone()[0]
         == SCHEMA_VERSION
-        == 25
+        == 26
     )
     for table in database_module._RESUME_TEMPLATE_REFERENCE_TABLES:
         assert "job_id" in _columns(reopened, table)

--- a/workers/automation/tests/test_scoring_identity_reference_migration.py
+++ b/workers/automation/tests/test_scoring_identity_reference_migration.py
@@ -338,7 +338,7 @@ def test_v11_scoring_references_migrate_alias_histories_and_reopen(
     assert (
         int(migrated.execute("PRAGMA user_version").fetchone()[0])
         == SCHEMA_VERSION
-        == 25
+        == 26
     )
     assert _columns(migrated, "job_scores") >= {"tenant_id", "job_id"}
     assert "job_url" not in _columns(migrated, "job_scores")
@@ -404,7 +404,7 @@ def test_v11_scoring_references_migrate_alias_histories_and_reopen(
     assert (
         int(reopened.execute("PRAGMA user_version").fetchone()[0])
         == SCHEMA_VERSION
-        == 25
+        == 26
     )
 
 
@@ -553,7 +553,7 @@ def test_scoring_migration_rolls_back_and_retries_after_verification_failure(
     assert (
         int(retried.execute("PRAGMA user_version").fetchone()[0])
         == SCHEMA_VERSION
-        == 25
+        == 26
     )
     assert [
         tuple(row)

--- a/workers/automation/tests/test_stable_job_identity_migration.py
+++ b/workers/automation/tests/test_stable_job_identity_migration.py
@@ -841,7 +841,7 @@ def test_v6_jobs_gain_stable_uuid_and_posting_url_alias_once(
     init_db(db_path)
     close_connection(db_path)
 
-    assert _user_version(db_path) == SCHEMA_VERSION == 25
+    assert _user_version(db_path) == SCHEMA_VERSION == 26
     first_ids = _identity_rows(db_path)
     assert [row[0] for row in first_ids] == ["local", "local"]
     for _tenant_id, job_id, _url in first_ids:


### PR DESCRIPTION
## Summary

- migrate `discovery_feedback.job_key` to tenant-scoped stable `job_id` references in schema v26
- preserve URL-shaped API responses and `DiscoveryFeedbackRecorded` events until the Phase 4 cutover while keeping private free-form notes out of events
- resolve UUID-shaped URLs URL-first, retain alias and tenant isolation, and reject unknown links before any feedback or event write
- make the migration exact, retryable, and fail-closed with count/orphan/UUID/FK verification and schema-aware recovery
- re-home canonical feedback during identity collisions and preserve permanent-deletion behavior with foreign keys enabled or disabled

## Stack

- depends on #551
- this PR is intentionally limited to `discovery_feedback`; quarantine/manual-capture references and lifecycle tombstones follow as separate reviewable PRs
- the feedback table is the first durable input attached to the later auditable learning-ledger phase
- canonical product docs and cumulative product QA are deferred to the final PR in this approved unreleased stack

## Validation

- `pnpm api:test` — 714 passed
- `pnpm --filter @jobctrl/api check` — passed
- `pnpm web:check` — passed
- `PYTHONPATH=src .../.venv/bin/python -m pytest -q` — 2,760 passed, 2 skipped
- focused API discovery-feedback/schema suite — 31 passed
- focused Python v26/outreach migration suite — 17 passed
- `.../.venv/bin/ruff check src tests` — passed
- `env -u UV_EXCLUDE_NEWER uv --project workers/automation lock --check` — passed
- `git diff --check` — passed
- independent Tier 3 review — PASS, no findings
- independent Tier 3 QA — PASS, no findings