### PR TITLE
docs: add practical job search guides

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -99,7 +99,7 @@ function canonicalUrlForPage(docPath: string): string {
   return new URL(route.startsWith("/") ? route : `/${route}`, DOCS_SITE_URL).toString();
 }
 
-// One guide, one navigation tree. The first two groups answer the questions a
+// One documentation tree. The first groups answer the questions a
 // new reader asks; contributor, architecture, and reference depth stays
 // available everywhere through collapsed groups. Every route appears once so
 // active-link state and previous/next navigation remain unambiguous.
@@ -115,6 +115,25 @@ const SIDEBAR: DefaultTheme.SidebarItem[] = [
       { text: "Product Tour", link: "/user/product-tour" },
       { text: "Getting Started", link: "/user/getting-started" },
       { text: "Daily Workflow", link: "/user/normal-flows" },
+    ],
+  },
+  {
+    text: "Guides",
+    collapsed: false,
+    items: [
+      { text: "JobCtrl Guides", link: "/guides/" },
+      {
+        text: "Local-first Job Search Automation",
+        link: "/guides/local-first-job-search-automation",
+      },
+      {
+        text: "Open-source Job Application Tracker",
+        link: "/guides/open-source-job-application-tracker",
+      },
+      {
+        text: "Resume Tailoring Without Fabrication",
+        link: "/guides/resume-tailoring-without-fabrication",
+      },
     ],
   },
   {

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,6 +31,19 @@ has one defining page; other pages summarize it briefly and link to that owner.
 - [`user/normal-flows.md`](user/normal-flows.md): the complete supervised daily
   workflow and the web/CLI surfaces for each step.
 
+### Guides
+
+- [`guides/index.md`](guides/index.md): practical guide hub and reading paths.
+- [`guides/local-first-job-search-automation.md`](guides/local-first-job-search-automation.md):
+  local storage, deliberate network boundaries, durable workflows, and user
+  control.
+- [`guides/open-source-job-application-tracker.md`](guides/open-source-job-application-tracker.md):
+  application records, evidence, canonical identity, outcomes, and open-source
+  inspectability.
+- [`guides/resume-tailoring-without-fabrication.md`](guides/resume-tailoring-without-fabrication.md):
+  source authority, candidate selection, rendered validation, and accepted
+  artifact history.
+
 ### The Job-Search Lifecycle
 
 - [`user/candidate-profile.md`](user/candidate-profile.md): canonical candidate

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -1,0 +1,29 @@
+---
+description: "Read practical JobCtrl guides about local-first job search automation, open-source application tracking, and truthful resume tailoring."
+---
+
+# JobCtrl Guides
+
+These guides explain the product choices behind JobCtrl in plain language.
+Each guide gives you the practical answer first, then links to the canonical
+product or architecture page for exact behavior and current limits.
+
+## For A More Private Job Search
+
+- [Local-first Job Search Automation](local-first-job-search-automation.md)
+  explains what stays on your computer, what still uses the network, and how
+  JobCtrl keeps long-running work visible and recoverable.
+- [Open-source Job Application Tracker](open-source-job-application-tracker.md)
+  shows how discovery, evidence, materials, applications, and outcomes become
+  one inspectable local record instead of disconnected spreadsheet rows.
+- [Resume Tailoring Without Fabrication](resume-tailoring-without-fabrication.md)
+  explains why a job description is context rather than candidate evidence,
+  and how JobCtrl validates the resume it actually renders.
+
+## See It Before Installing
+
+Explore the [synthetic live demo](https://demo.jobctrl.dev), take the
+[Product Tour](../user/product-tour.md), or follow
+[Getting Started](../user/getting-started.md) to install JobCtrl on an
+Apple-silicon Mac. The demo cannot contact employers, providers, Gmail, job
+boards, or your local JobCtrl app.

--- a/docs/guides/local-first-job-search-automation.md
+++ b/docs/guides/local-first-job-search-automation.md
@@ -1,0 +1,120 @@
+---
+description: "Learn how local-first job search automation keeps your profile, jobs, resumes, and workflow history on your computer while preserving useful integrations."
+---
+
+# Local-first Job Search Automation
+
+Local-first job search automation means the application, working database, and
+generated files live on your computer, while network access is limited to the
+features you choose to run. JobCtrl uses that model so a job search can be
+automated without making a vendor-hosted account the owner of your career data.
+
+## What “Local-first” Means In JobCtrl
+
+JobCtrl runs as a small local system: a web app, a local TypeScript API, a
+Python worker, Temporal (the workflow engine), SQLite, and a directory of
+generated artifacts. The normal workspace is under `~/.jobctrl/`. There is no
+JobCtrl account and no hosted JobCtrl backend required to use the product.
+
+That gives the local installation several concrete responsibilities:
+
+| Responsibility | Local source of truth |
+| --- | --- |
+| Candidate facts, preferences, and application answers | Versioned Candidate Profile rows in SQLite |
+| Discovered jobs, source observations, scores, and outcomes | The local `jobctrl.db` database |
+| Tailored resumes, cover letters, and previews | Registered files in the local JobCtrl workspace |
+| Workflow progress, retries, and cancellation | The local Temporal runtime plus durable JobCtrl projections |
+| Non-secret product settings | SQLite or `config.json`, according to the owning setting |
+| Provider credentials | The documented environment, CLI, or OS-backed secret boundary—not browser-readable settings |
+
+The exact inventory, retention rules, and credential boundaries live in
+[Data, Privacy & Safety](../user/data-and-safety.md) and
+[Configuration](../user/configuration.md).
+
+## Local-first Does Not Mean Offline
+
+A useful job-search tool still needs to communicate with the outside world.
+Discovery fetches job sources. Enrichment may open a managed browser. Scoring
+or writing features call a model provider you configured. A live application
+contacts an employer only through the guarded Apply paths you invoke.
+
+The important distinction is control and ownership:
+
+- you start a run, or explicitly enable a local schedule;
+- the selected feature makes the network requests it needs;
+- accepted jobs, evidence, materials, and workflow state return to local
+  storage;
+- optional product telemetry is disabled unless you configure it;
+- documentation-site analytics have their own consent choice and are not part
+  of the installed product.
+
+So “local-first” is not a promise that every operation happens without a
+network. It is a promise that the product does not require a hosted JobCtrl
+data plane to own and operate your job search.
+
+## Why Automation Needs Durable Local Workflows
+
+Job discovery and preparation are not one request. One run may search several
+sources, capture postings, enrich descriptions, analyze requirements, score
+fit, create materials, render files, and wait for review. A laptop can sleep,
+a provider can fail, or a worker can restart while that sequence is running.
+
+JobCtrl routes long-running work through Temporal instead of hiding it in a
+browser tab or an in-process loop. Stable workflow identities, bounded retries,
+cancellation, and persisted stage events let the Runs and Pipelines surfaces
+show what happened. Broad-board discovery checkpoints each search unit, so an
+interrupted execution can resume unfinished work without pretending the entire
+run never started.
+
+This does not make every failure disappear. It makes failure a state you can
+inspect rather than an invisible partial side effect. The exact runtime,
+recovery, and concurrency contracts are documented in
+[Runtime & Processes](../architecture/runtime.md) and
+[Temporal Workflows](../architecture/pipeline/index.md).
+
+## The Human Still Owns Risky Decisions
+
+Local execution is only one part of responsible automation. JobCtrl also keeps
+high-impact actions behind explicit boundaries:
+
+- scores link back to requirement and profile evidence so you can challenge
+  them;
+- generated candidate claims must come from the Candidate Profile, not from a
+  job description;
+- a failed re-tailor does not erase the last accepted resume;
+- dry runs cannot submit;
+- model-driven browser work stops before final browser submission, which
+  remains manual;
+- the separate Gmail sender rechecks the exact approved recipient and
+  attachment and records submit intent before sending;
+- ambiguous submit outcomes stop for verification instead of retrying blindly.
+
+Read [Apply](../user/apply.md) for the current browser and email boundaries and
+[Security](../user/security.md) for the enforcement points.
+
+## Who This Model Fits
+
+Local-first automation is a good fit when you want a capable workflow but also
+want to inspect storage, source code, model decisions, and submission history.
+It is especially useful if your profile and application archive should remain
+portable rather than trapped in a hosted account.
+
+It also has tradeoffs. Your machine runs the services. You choose and pay for
+any external model providers you enable. You are responsible for backups, local
+access, and reviewing employer-facing work. A hosted service may require less
+local operation; JobCtrl deliberately chooses user control over that
+convenience.
+
+## Try The Workflow
+
+The [live demo](https://demo.jobctrl.dev) uses synthetic data and cannot contact
+external services. To run the real local product, follow
+[Getting Started](../user/getting-started.md). Then use the
+[Daily Workflow](../user/normal-flows.md) to move from a versioned profile
+through discovery, evidence review, truthful materials, and supervised Apply.
+
+Related reading:
+
+- [Open-source Job Application Tracker](open-source-job-application-tracker.md)
+- [Resume Tailoring Without Fabrication](resume-tailoring-without-fabrication.md)
+- [JobCtrl Guides](index.md)

--- a/docs/guides/open-source-job-application-tracker.md
+++ b/docs/guides/open-source-job-application-tracker.md
@@ -1,0 +1,129 @@
+---
+description: "See how an open-source job application tracker can connect job discovery, evidence, tailored materials, approvals, and outcomes in one local audit trail."
+---
+
+# Open-source Job Application Tracker
+
+An open-source job application tracker should do more than store a company,
+role, URL, and status. JobCtrl connects each application record to the posting
+snapshot, fit evidence, reviewed materials, workflow history, submission
+boundary, and confirmed outcome that produced it.
+
+## From Status List To Evidence Trail
+
+A spreadsheet is effective when the main question is “Where did I apply?” It
+becomes harder to maintain when you also need to answer:
+
+- Which source produced this job, and is another URL the same opening?
+- Which requirements did my profile actually support?
+- Which resume generation did I review for this application?
+- Did a run fail before submission, reach submit intent, or receive
+  confirmation?
+- Did an outcome come from me, a reviewed Gmail suggestion, or an inference?
+- Can interrupted automation resume without duplicating employer-facing work?
+
+JobCtrl treats those questions as linked records instead of free-form notes.
+The Jobs, Job Detail, Evidence Map, Artifacts, Apply Review, Runs, and Outcomes
+surfaces are different views over the same local workflow.
+
+## What The Tracker Records
+
+The record grows as the job moves through the lifecycle:
+
+| Stage | Inspectable record |
+| --- | --- |
+| Discover | Source, source-native identity, captured URL, canonical identity evidence, and run membership |
+| Enrich | Posting snapshot, extracted fields, content provenance, and quality state |
+| Score | Versioned fit score, confidence, blockers, requirement rows, and Candidate Profile evidence links |
+| Tailor | Plan, policy, candidate attempts, accepted generation, rendered files, validation, and provenance |
+| Review | Human edits, comments, replacement render, defer/decline/approval decision, and approval binding |
+| Apply | Dry-run receipt, submit intent, guarded transport result, confirmation evidence, or verification state |
+| Outcome | Confirmed application facts, reviewed suggestions, timeline entries, and bounded analytics |
+
+Not every job must pass through every stage. A manually captured lead can still
+be useful, a weak fit can stop before materials, and a browser application may
+end with manual final submission. The tracker preserves the state that actually
+exists rather than inventing a clean funnel.
+
+The precise lifecycle and owning UI surfaces are in
+[Daily Workflow](../user/normal-flows.md).
+
+## Open Source Changes What You Can Verify
+
+JobCtrl is licensed under
+[AGPL-3.0-only](https://github.com/ebarti/JobCtrl/blob/main/LICENSE), and its
+source, tests, architecture decisions, and issue history are public. That means
+you can inspect how a score is calculated, where an approval is checked, which
+process can read a credential, and how a workflow handles retries.
+
+Open source is not proof that every result is correct. It makes the mechanism
+reviewable and changeable. JobCtrl complements that with product-level audit
+surfaces so ordinary review does not require reading source code. For example,
+a requirement-fit row exposes its evidence, and an accepted resume generation
+keeps its provenance and validation record.
+
+Contributors can start with the
+[repository and ownership map](../developer/repository-and-ownership-map.md).
+Job seekers can stay in the product and use the
+[Product Tour](../user/product-tour.md).
+
+## Canonical Identity Prevents A Common Tracking Error
+
+The same opening may appear on a company site, a job board, and an applicant
+tracking system. Treating each URL as a new row creates duplicate preparation
+and can create repeat-application risk.
+
+JobCtrl preserves source observations and reviewed duplicate relationships
+around one canonical job identity. Before a live Apply claim, it combines that
+identity with confirmed application facts. The same canonical opening is
+blocked by default; a conservative same-employer, equivalent-role relationship
+requires an explicit reasoned confirmation bound to the current evidence.
+
+Similarity alone does not rewrite history. Pending email suggestions, notes,
+dry runs, failed pre-submit attempts, and submit intent alone are not treated as
+confirmed applications. The detailed decision states and override lifecycle
+are owned by
+[Apply → Repeat-Application Protection](../user/apply.md#repeat-application-protection).
+
+## Outcomes Stay Factual
+
+A useful tracker should help you learn from outcomes without silently turning
+an email guess into a fact. JobCtrl separates confirmed events, reviewed Gmail
+suggestions, free-form notes, and analytics projections.
+
+The timeline can show applications, replies, interviews, offers, rejections,
+withdrawals, and manual corrections, but each source keeps its identity.
+Outcome analytics remain read-only and sample-gated so a small number of
+applications does not become a confident recommendation. See
+[Outcomes & Feedback](../user/outcomes-and-feedback.md) for the current
+confirmation and projection boundaries.
+
+## Application Tracking Without Autonomous Submission
+
+Tracking and submission are intentionally separate authorities. You can
+discover, score, tailor, and review a job without granting a model permission
+to submit it.
+
+JobCtrl supports inspection-only browser rehearsals, manual final browser
+submission, and a separate exact-approved Gmail sender. Approval binds to the
+current job, profile, URL, materials, and qualifying evidence. At-most-once
+submit intent protects retries, while an ambiguous post-intent result becomes
+`needs_verification` instead of an automatic second attempt.
+
+This lets the tracker record automation without letting the record itself grant
+submission authority. Read [Apply](../user/apply.md) before enabling any
+employer-facing capability.
+
+## Use JobCtrl As Your Local Tracker
+
+Explore the complete interface with synthetic data in the
+[live demo](https://demo.jobctrl.dev). For a real workspace, install the local
+product through [Getting Started](../user/getting-started.md), build your
+[Candidate Profile](../user/candidate-profile.md), and start with a bounded
+Discover run.
+
+Related reading:
+
+- [Local-first Job Search Automation](local-first-job-search-automation.md)
+- [Resume Tailoring Without Fabrication](resume-tailoring-without-fabrication.md)
+- [JobCtrl Guides](index.md)

--- a/docs/guides/resume-tailoring-without-fabrication.md
+++ b/docs/guides/resume-tailoring-without-fabrication.md
@@ -1,0 +1,141 @@
+---
+description: "Understand how JobCtrl tailors a resume from canonical profile evidence, validates rendered claims, rejects fabrication, and preserves an inspectable audit trail."
+---
+
+# Resume Tailoring Without Fabrication
+
+Truthful resume tailoring changes emphasis and structure without changing the
+facts. JobCtrl treats the job posting as target context and the Candidate
+Profile as the only authority for claims about you.
+
+## The Job Description Is Not Candidate Evidence
+
+A posting can tell a tailoring system what the employer values. It cannot prove
+that you have a skill, held a title, delivered a result, or achieved a metric.
+Copying requirements into a resume may improve keyword overlap while making the
+document less trustworthy.
+
+JobCtrl keeps four inputs separate:
+
+| Input | What it is allowed to do |
+| --- | --- |
+| Candidate Profile snapshot | Prove experience, skills, dates, employers, titles, metrics, and other candidate facts |
+| Posting and accepted employer analysis | Describe the target role, requirements, priorities, and employer wording |
+| Requirement-fit record | Connect a requirement to direct, strong, transferable, missing, or blocked profile evidence |
+| Tailoring policy and preferences | Control selection, structure, style, models, templates, and validation thresholds |
+
+The generated resume is a new presentation of profile evidence. Neither the
+posting nor a model response becomes a new candidate fact.
+
+## Tailoring Is A Candidate-selection Pipeline
+
+JobCtrl does not save the first block of prose returned by one prompt. The
+current workflow:
+
+1. builds one deterministic plan from the accepted posting, profile snapshot,
+   requirement fit, user permissions, pinned evidence, and writing style;
+2. asks each ready generator for structured content under the same plan;
+3. resolves referenced experience and skill identifiers against known profile
+   data;
+4. assembles and renders each candidate;
+5. checks the actual rendered text for grounding, structure, prohibited claims,
+   metrics, seniority, and requirement coverage;
+6. sends repairable failures through a bounded revision attempt;
+7. requires enabled judge and adversarial gates to approve the candidate;
+8. selects the best clean candidate and runs the fabrication gate again after
+   any optional voice refinement;
+9. persists the accepted generation, files, provenance, coverage, and audit
+   data together.
+
+This sequence matters because structured JSON can be valid while the assembled
+resume is not. Validation therefore follows the content through rendering
+instead of stopping at the model boundary.
+
+For the exact modes, thresholds, retry behavior, and failure codes, use the
+canonical [Tailoring Contract](../architecture/tailoring.md).
+
+## What The Fabrication Gates Check
+
+There is no single “truth score.” Different checks protect different failure
+modes:
+
+- **Reference validation** rejects unknown experience or skill-category
+  identifiers.
+- **Grounding checks** compare candidate claims with the canonical profile
+  evidence they cite.
+- **Deterministic text checks** inspect preserved employers, education,
+  sections, unsupported metrics, seniority changes, and prohibited claims.
+- **Rendered coverage checks** count a keyword only when it appears in the
+  actual grounded resume text.
+- **A structured judge** must pass the configured quality threshold and report
+  no unsupported claims, fabrications, or missing required evidence.
+- **Adversarial personas** challenge high-fit candidates from several review
+  perspectives and produce blockers, warnings, and repair instructions.
+- **A final fabrication pass** runs after optional style refinement so improved
+  voice cannot quietly weaken grounding.
+
+Models still make mistakes, and deterministic checks have defined limits.
+JobCtrl exposes the evidence and gate outputs because a human reviewer remains
+the final authority.
+
+## Missing Evidence Stays Missing
+
+Suppose a posting requires Kubernetes production operations but the Candidate
+Profile contains only local Docker development. A truthful tailoring system can
+surface transferable container experience, leave Kubernetes as a gap, or
+decide the job is not eligible for automatic materials. It cannot rewrite
+Docker work as Kubernetes ownership.
+
+The same rule applies to metrics and seniority. A number in a posting is an
+employer requirement, not your accomplishment. A senior title in the target
+role does not upgrade a prior title. If important experience is missing from
+the Candidate Profile, correct the profile from your real evidence and create a
+new version before generating again.
+
+See [Candidate Profile](../user/candidate-profile.md) for evidence ownership and
+[Scoring](../user/scoring-and-employer-analysis.md) for the distinction between
+direct, strong, transferable, missing, and blocked requirement fit.
+
+## Inspect The Accepted Resume, Not Just The Prompt
+
+The Artifacts workspace preserves more than a PDF. Its inspector can expose the
+tailoring plan, policy version, candidate attempts, validation, provenance,
+requirement and keyword coverage, judge result, adversarial review, voice
+measures, template, risk metadata, and same-job generations.
+
+Warnings are tied to their lifecycle. A warning may have caused a repair, been
+accepted as residual on the selected candidate, or appeared after acceptance
+without influencing the artifact. Missing audit data is reported as unrecorded
+rather than converted into a reassuring zero.
+
+Apply Review then loads the accepted HTML into an editor. Human edits,
+comments, validation, replacement rendering, and the final PDF remain attached
+to the material generation being reviewed. Generating, choosing a template,
+editing, and approving a submission are separate decisions.
+
+The current user-facing controls and artifact lifecycle are documented in
+[Materials & Tailoring](../user/materials-and-tailoring.md).
+
+## Failed Re-tailoring Does Not Destroy Good Work
+
+A retry is an audit event, not permission to hide the current accepted resume.
+If a new candidate fails grounding, judge review, rendering, or persistence,
+JobCtrl keeps the last accepted generation available for review. A successful
+replacement supersedes it while preserving history.
+
+That preservation rule makes comparison possible and prevents a model or
+provider failure from erasing the document you already approved.
+
+## Try Truthful Tailoring
+
+Use the [synthetic live demo](https://demo.jobctrl.dev) to inspect requirement
+evidence and generated materials without connecting a provider. To tailor your
+own profile, follow [Getting Started](../user/getting-started.md), create and
+review a versioned Candidate Profile, then run a bounded Discover workflow.
+Always read the rendered resume and its evidence before using it.
+
+Related reading:
+
+- [Local-first Job Search Automation](local-first-job-search-automation.md)
+- [Open-source Job Application Tracker](open-source-job-application-tracker.md)
+- [JobCtrl Guides](index.md)

--- a/scripts/check-docs-site-runtime.mjs
+++ b/scripts/check-docs-site-runtime.mjs
@@ -30,6 +30,22 @@ const { chromium } = require("@playwright/test");
 
 const PAGES = [
   { path: "/", visualSelector: null, images: false },
+  { path: "/guides/", visualSelector: null, images: false },
+  {
+    path: "/guides/local-first-job-search-automation",
+    visualSelector: null,
+    images: false,
+  },
+  {
+    path: "/guides/open-source-job-application-tracker",
+    visualSelector: null,
+    images: false,
+  },
+  {
+    path: "/guides/resume-tailoring-without-fabrication",
+    visualSelector: null,
+    images: false,
+  },
   { path: "/architecture/", visualSelector: ".system-topology", images: false },
   { path: "/developer/", visualSelector: null, images: false },
   {
@@ -97,6 +113,10 @@ const PAGES = [
 const SOCIAL_METADATA_ROUTES = new Set([
   "/",
   "/comparison",
+  "/guides/",
+  "/guides/local-first-job-search-automation",
+  "/guides/open-source-job-application-tracker",
+  "/guides/resume-tailoring-without-fabrication",
   "/architecture/",
   "/developer/",
   "/user/apply",

--- a/scripts/docs-launch-copy.test.mjs
+++ b/scripts/docs-launch-copy.test.mjs
@@ -131,6 +131,19 @@ test("priority public pages have distinct search descriptions", async () => {
     ["docs/user/apply.md", "Review JobCtrl's supervised application controls"],
     ["docs/architecture/index.md", "Explore JobCtrl's local-first architecture"],
     ["docs/developer/README.md", "Start contributing to JobCtrl"],
+    ["docs/guides/index.md", "Read practical JobCtrl guides"],
+    [
+      "docs/guides/local-first-job-search-automation.md",
+      "Learn how local-first job search automation",
+    ],
+    [
+      "docs/guides/open-source-job-application-tracker.md",
+      "See how an open-source job application tracker",
+    ],
+    [
+      "docs/guides/resume-tailoring-without-fabrication.md",
+      "Understand how JobCtrl tailors a resume",
+    ],
   ]);
   const observed = new Set();
 
@@ -141,6 +154,54 @@ test("priority public pages have distinct search descriptions", async () => {
     assert.match(description, new RegExp(`^${expectedPrefix.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`));
     assert.ok(!observed.has(description), `${path} must not reuse another priority description`);
     observed.add(description);
+  }
+});
+
+test("search-intent guides are substantive and route readers to canonical owners", async () => {
+  const guideContracts = [
+    {
+      path: "docs/guides/local-first-job-search-automation.md",
+      heading: "# Local-first Job Search Automation",
+      owners: [
+        "../user/data-and-safety.md",
+        "../architecture/runtime.md",
+        "../user/apply.md",
+      ],
+    },
+    {
+      path: "docs/guides/open-source-job-application-tracker.md",
+      heading: "# Open-source Job Application Tracker",
+      owners: [
+        "../user/normal-flows.md",
+        "../user/outcomes-and-feedback.md",
+        "../user/apply.md",
+      ],
+    },
+    {
+      path: "docs/guides/resume-tailoring-without-fabrication.md",
+      heading: "# Resume Tailoring Without Fabrication",
+      owners: [
+        "../architecture/tailoring.md",
+        "../user/candidate-profile.md",
+        "../user/materials-and-tailoring.md",
+      ],
+    },
+  ];
+
+  for (const contract of guideContracts) {
+    const document = await read(contract.path);
+    assert.match(document, new RegExp(`^${contract.heading}$`, "m"));
+    assert.ok(document.length >= 5_000, `${contract.path} must remain substantive`);
+    assert.ok(
+      (document.match(/^## /gm) ?? []).length >= 5,
+      `${contract.path} must retain a useful reader journey`,
+    );
+    for (const owner of contract.owners) {
+      assert.ok(
+        document.includes(`](${owner}`),
+        `${contract.path} must link to ${owner}`,
+      );
+    }
   }
 });
 


### PR DESCRIPTION
## What changed

- add a public guide hub
- publish substantive guides for local-first job search automation, open-source application tracking, and resume tailoring without fabrication
- connect each guide to its canonical product and architecture owners
- add the routes to navigation, metadata regression coverage, browser traversal, and the generated sitemap

## Why

These pages answer concrete search questions with implementation-backed guidance while keeping mutable product contracts in their existing canonical documentation.

## Stack

- depends on #552
- base branch: `agent/seo-identity`

## Validation

- `node --test scripts/docs-launch-copy.test.mjs`
- `corepack pnpm docs:build`
- `corepack pnpm docs:check:runtime`
- `git diff --check`
- independent review: PASS (0 Blocker, 0 High)