### PR TITLE
docs: publish auditable automation guides

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -44,6 +44,11 @@ const HOME_STRUCTURED_DATA = JSON.stringify({
       applicationSubCategory: "Job search automation",
       operatingSystem: "macOS 15 or later on Apple silicon",
       isAccessibleForFree: true,
+      offers: {
+        "@type": "Offer",
+        price: "0",
+        priceCurrency: "USD",
+      },
       license: "https://www.gnu.org/licenses/agpl-3.0.html",
       sameAs: [REPO_URL],
       publisher: { "@id": ORGANIZATION_ID },
@@ -133,6 +138,18 @@ const SIDEBAR: DefaultTheme.SidebarItem[] = [
       {
         text: "Resume Tailoring Without Fabrication",
         link: "/guides/resume-tailoring-without-fabrication",
+      },
+      {
+        text: "Evidence-based Job Fit Scoring",
+        link: "/guides/evidence-based-job-fit-scoring",
+      },
+      {
+        text: "At-most-once Job Application Submission",
+        link: "/guides/at-most-once-job-application-submission",
+      },
+      {
+        text: "Temporal Workflows In A Desktop App",
+        link: "/guides/temporal-workflows-desktop-app",
       },
     ],
   },

--- a/docs/README.md
+++ b/docs/README.md
@@ -43,6 +43,15 @@ has one defining page; other pages summarize it briefly and link to that owner.
 - [`guides/resume-tailoring-without-fabrication.md`](guides/resume-tailoring-without-fabrication.md):
   source authority, candidate selection, rendered validation, and accepted
   artifact history.
+- [`guides/evidence-based-job-fit-scoring.md`](guides/evidence-based-job-fit-scoring.md):
+  applicant-side requirement evidence, deterministic score resolution,
+  confidence, eligibility, and corrections.
+- [`guides/at-most-once-job-application-submission.md`](guides/at-most-once-job-application-submission.md):
+  binding approval, durable submit intent, ambiguity, and manual browser
+  submission.
+- [`guides/temporal-workflows-desktop-app.md`](guides/temporal-workflows-desktop-app.md):
+  durable local orchestration, workflow identity, retries, projections, and
+  recovery.
 
 ### The Job-Search Lifecycle
 

--- a/docs/architecture/runtime.md
+++ b/docs/architecture/runtime.md
@@ -4,6 +4,9 @@ JobCtrl runs as four long-lived local processes, plus a `jobctrl rpc`
 subprocess the TypeScript API spawns on demand. This page walks each runtime
 boundary — what it owns, what it must never do, and how the pieces talk.
 
+For a focused explanation of the workflow-engine choice, read
+[Temporal Workflows In A Desktop App](../guides/temporal-workflows-desktop-app.md).
+
 **Read this if** you need to know which process is responsible for a behavior,
 or where a change belongs.
 

--- a/docs/guides/at-most-once-job-application-submission.md
+++ b/docs/guides/at-most-once-job-application-submission.md
@@ -1,0 +1,148 @@
+---
+description: "Understand at-most-once job application submission, durable submit intent, approval binding, retry ambiguity, and JobCtrl's manual browser boundary."
+---
+
+# At-most-once Job Application Submission
+
+At-most-once submission means automation must never create a second
+employer-facing attempt merely because the first attempt returned an ambiguous
+result. JobCtrl combines durable submit intent with binding approval, repeat
+protection, and human verification—and keeps final browser submission manual.
+
+## Why Ordinary Retries Are Dangerous
+
+Retries are useful for read-only work. If a source times out while fetching a
+posting, trying again can be safe. A submission is different: the employer may
+have received the application even when the local process did not receive a
+confirmation.
+
+Consider a crash immediately after an email provider accepts a message:
+
+```mermaid
+flowchart LR
+    accTitle: At-most-once submission after an ambiguous result
+    accDescr: JobCtrl verifies the reviewed claim, records durable submit intent, performs one exact approved send, and either stores confirmation or stops for human verification. It never automatically sends again after intent.
+
+    CLAIM["Verify claim<br/>approval + repeat risk"]
+    INTENT[["Persist submit intent"]]
+    SEND["One exact<br/>approved send"]
+    DONE[["Persist confirmation"]]
+    VERIFY["Needs verification<br/>no automatic retry"]
+
+    CLAIM -->|eligible| INTENT
+    INTENT -->|one attempt| SEND
+    SEND -->|confirmed| DONE
+    SEND -.->|timeout or crash| VERIFY
+```
+
+Solid arrows show the confirmed path. The dashed arrow is an ambiguous outcome:
+the system preserves uncertainty instead of converting it into permission to
+try again.
+
+## At-most-once Is Not Exactly-once
+
+“Exactly once” would promise both that the application happens and that it
+happens only once. A distributed system cannot always prove both after a crash
+or network partition unless the remote destination provides a compatible
+idempotency contract.
+
+At-most-once chooses the safer failure mode:
+
+- before durable submit intent, a failed claim can remain eligible for a later
+  reviewed attempt;
+- after intent, JobCtrl will not automatically repeat the employer-facing
+  action;
+- when confirmation is missing, the run stops in `needs_verification`;
+- the user checks the destination or provider history and records the real
+  outcome.
+
+The result may require manual recovery, but it avoids turning uncertainty into
+a duplicate application.
+
+## Approval Is Bound At The Mutation Boundary
+
+With approval required—the default—the latest Apply Review decision must bind
+the current job, profile version, application URL, material generation, and
+qualifying rehearsal evidence. Email applications additionally bind the exact
+recipient and attachment.
+
+The worker checks that binding while atomically claiming work in SQLite. It is
+not only a disabled button in the web app, so a stale page, direct API call,
+standing loop, or concurrent worker cannot bypass the claim-time decision.
+
+Turning the general approval wait off does not create generic submission
+authority. Browser final submit remains manual, the Gmail sender still requires
+its exact send scope, and repeat-application protection still runs.
+
+## Repeat Protection Answers A Different Question
+
+At-most-once protects one submission attempt from retry duplication. Repeat
+protection asks whether the candidate already has a confirmed application to
+the same opening.
+
+Before each live claim, JobCtrl combines canonical job identity with confirmed
+application facts. The same opening is blocked. A conservative match for the
+same employer and an equivalent role requires explicit reasoned confirmation
+bound to the current evidence. A one-use override is consumed in the same
+atomic claim transaction.
+
+Pending Gmail suggestions, notes, dry runs, failed pre-submit work, and submit
+intent without confirmation do not become application history. Keeping these
+gates separate prevents a similarity guess from creating a fact while still
+blocking a known duplicate.
+
+See
+[Apply → Repeat-Application Protection](../user/apply.md#repeat-application-protection)
+for the current evidence and override states.
+
+## Browser And Email Have Different Submission Boundaries
+
+JobCtrl does not give a page-reading model final browser-submit authority. A
+browser-form claim stops before the model-driven session begins, and the user
+completes the final employer action manually. The browser extension can capture
+and autofill whitelisted fields, but it has no submit capability.
+
+The owned Gmail path is different because JobCtrl controls the mutation
+adapter. It can compare the exact recipient and attachment with the approval,
+persist submit intent immediately before the send, restrict the live activity
+to one attempt, and preserve the provider result.
+
+These are not interchangeable promises. “At-most-once” does not mean a model
+may click any web submit button once.
+
+## Dry Runs Exercise The Boundary Without Submitting
+
+A dry run grants one exact read-only navigation to the reviewed application
+URL. Browser-level interception blocks form submission, mutating requests,
+navigation replay, URL changes, redirects, and other write-bearing channels.
+The agent also lacks generic typing, artifact upload, saved credentials, and
+verification-code tools.
+
+The receipt records which bounded inspection occurred. A model saying
+`RESULT:DRY_RUN` is not by itself proof of complete rehearsal, and
+`RESULT:APPLIED` is never accepted as authoritative submission evidence.
+
+Dry runs help you inspect an application path. They do not consume a live
+application fact or grant a later submit.
+
+## What To Do When Verification Is Required
+
+If a run reaches durable submit intent but lacks trustworthy confirmation:
+
+1. do not start another live application;
+2. inspect the sent-mail or employer-side history outside the model;
+3. record the actual outcome in JobCtrl;
+4. retry only if the evidence establishes that no employer-facing action
+   occurred and the current controls allow a new claim.
+
+This is intentionally less convenient than blind retry. The audit trail keeps
+the original intent and ambiguity so recovery does not rewrite what happened.
+
+For the full user workflow, read [Apply](../user/apply.md). For enforcement
+details, read [Security](../user/security.md#approval-and-control-gates).
+
+Related reading:
+
+- [Open-source Job Application Tracker](open-source-job-application-tracker.md)
+- [Local-first Job Search Automation](local-first-job-search-automation.md)
+- [JobCtrl Guides](index.md)

--- a/docs/guides/evidence-based-job-fit-scoring.md
+++ b/docs/guides/evidence-based-job-fit-scoring.md
@@ -1,0 +1,141 @@
+---
+description: "Learn how evidence-based job fit scoring connects employer requirements to versioned candidate facts, deterministic policy, confidence, and corrections."
+---
+
+# Evidence-based Job Fit Scoring
+
+Evidence-based job fit scoring should answer two questions together: “How
+strong is this opportunity for me?” and “What facts support that conclusion?”
+JobCtrl keeps the score, requirement assessments, profile evidence, confidence,
+blockers, and policy version in one reviewable decision record.
+
+## A Score Is A Triage Tool, Not A Verdict
+
+JobCtrl scores jobs for the person conducting the search. It is not an
+employer-side candidate-ranking system, and it should not be used to decide who
+gets hired.
+
+The 1–10 score helps a job seeker sort a large set of openings and decide where
+to spend attention. It does not prove that an employer will interview you. A
+strong result can still contain a hard blocker, uncertain evidence, or a
+requirement you interpret differently. A weak result can reflect an incomplete
+Candidate Profile rather than a poor real-world fit.
+
+That is why the Job Detail workspace presents the evidence and correction
+history beside the score instead of treating the number as self-explanatory.
+
+## Start With Two Separate Sources Of Truth
+
+The scoring boundary deliberately separates employer claims from candidate
+claims:
+
+- the captured posting and accepted employer analysis own requirements,
+  priorities, and evidence about the role;
+- the versioned Candidate Profile owns experience, skills, achievements,
+  preferences, and evidence about the job seeker.
+
+The scorer may classify how those sources relate. It may not turn wording from
+the posting into a new fact about the candidate. An evidence link for a match
+must point back to profile data; if that reference cannot be resolved, JobCtrl
+labels it unavailable rather than displaying it as proof.
+
+Read [Candidate Profile](../user/candidate-profile.md) for candidate evidence
+ownership and [Discovery](../user/discovery.md) for the canonical employer
+analysis.
+
+## Score Requirements Before Resolving The Number
+
+When an accepted employer analysis contains explicit requirements, JobCtrl asks
+the scorer for a structured assessment of each one. A row records the
+requirement identity, importance, posting evidence, fit classification, and
+supporting Candidate Profile evidence.
+
+The useful unit is the row:
+
+| Requirement result | Meaning for review |
+| --- | --- |
+| Direct or strong match | Profile evidence substantially supports the requirement |
+| Transferable evidence | The profile supports adjacent experience, but not the exact claim |
+| Missing | The current profile does not contain supporting evidence |
+| Blocked | A hard requirement is not met and constrains eligibility |
+| Not assessed | The decision record does not contain a usable classification |
+
+Versioned deterministic code then turns those rows into the saved score. More
+important requirements contribute more, matched evidence receives more credit
+than transferable evidence, and blocked requirements constrain the final
+result. The current weights, rounding rules, compatibility path, and worked
+example live in the canonical
+[Scoring guide](../user/scoring-and-employer-analysis.md#how-the-score-is-calculated).
+
+This division matters: a model classifies structured evidence, while a named
+policy resolves the number. The persisted score is not a free-form model
+opinion.
+
+## Score, Confidence, And Eligibility Are Different
+
+Collapsing every concern into one number makes a score look simpler than it is.
+JobCtrl keeps three concepts distinct:
+
+- **Fit score** summarizes the policy-resolved relationship between the role
+  requirements and current profile evidence.
+- **Confidence** tells you how much scrutiny the evidence needs. It is a review
+  signal, not a hidden points multiplier.
+- **Eligibility** decides whether downstream work such as automatic material
+  generation may proceed. Hard blockers and the live minimum-fit threshold can
+  affect eligibility without rewriting the saved score.
+
+Changing the minimum-fit threshold therefore does not recalculate old scores.
+It changes which existing decisions are eligible for later stages. Likewise, a
+low-confidence score is not automatically low fit, and a high-confidence score
+is not an application guarantee.
+
+## Corrections Create History
+
+If the evidence is wrong or your judgment differs, JobCtrl offers two separate
+actions:
+
+1. **Correct the score** to record your reviewed decision and rationale. This
+   creates a new version and a calibration anchor.
+2. **Re-score the job** to run the current policy against the current canonical
+   inputs. This creates a new model-derived version.
+
+Neither action silently edits the old record. A later policy can mark older
+scores stale, but adopting it remains deliberate. The history lets you see
+whether a change came from profile evidence, employer analysis, a policy
+version, model execution, or human judgment.
+
+The Evidence Map provides the reverse view: start from a profile achievement or
+skill and inspect where scoring and generated materials used it.
+
+## What The Audit Trail Can And Cannot Prove
+
+The current requirement-led resolver is deterministic over the structured
+response it accepts. The parser validates shapes and requires evidence
+identifiers for matched rows, but it does not yet prove that every returned
+identifier exists in the saved profile or reconcile every returned requirement
+field against the accepted analysis before resolving the score.
+
+That limit is visible in the product contract. An unresolved reference is
+shown as unavailable, and its storage key remains under technical details. You
+should not treat it as supporting evidence merely because the numeric score was
+saved.
+
+Evidence-based scoring improves auditability; it does not eliminate model
+error, incomplete profiles, ambiguous postings, or human disagreement. Inspect
+high-value jobs and correct the record when the evidence is weak.
+
+## Review Fit In JobCtrl
+
+Use the [synthetic live demo](https://demo.jobctrl.dev) to open a Job Detail
+workspace and inspect requirement rows without connecting a provider. In a
+local installation, start with a reviewed Candidate Profile and a bounded
+Discover run, then filter the Jobs workspace by score or fit band.
+
+For exact behavior, read [Scoring](../user/scoring-and-employer-analysis.md)
+and the deeper [Scoring Policy](../architecture/scoring.md).
+
+Related reading:
+
+- [Resume Tailoring Without Fabrication](resume-tailoring-without-fabrication.md)
+- [Open-source Job Application Tracker](open-source-job-application-tracker.md)
+- [JobCtrl Guides](index.md)

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -20,6 +20,18 @@ product or architecture page for exact behavior and current limits.
   explains why a job description is context rather than candidate evidence,
   and how JobCtrl validates the resume it actually renders.
 
+## For Inspectable Automation
+
+- [Evidence-based Job Fit Scoring](evidence-based-job-fit-scoring.md) separates
+  fit, confidence, and eligibility and shows how requirement evidence becomes a
+  versioned decision.
+- [At-most-once Job Application Submission](at-most-once-job-application-submission.md)
+  explains why ambiguous employer-facing work stops for verification instead
+  of retrying blindly.
+- [Temporal Workflows In A Desktop App](temporal-workflows-desktop-app.md)
+  explains how local workflow history makes long-running work recoverable,
+  cancelable, and visible.
+
 ## See It Before Installing
 
 Explore the [synthetic live demo](https://demo.jobctrl.dev), take the

--- a/docs/guides/temporal-workflows-desktop-app.md
+++ b/docs/guides/temporal-workflows-desktop-app.md
@@ -1,0 +1,166 @@
+---
+description: "Learn why JobCtrl runs Temporal workflows inside a local desktop product for recovery, retries, visibility, cancellation, and bounded automation."
+---
+
+# Temporal Workflows In A Desktop App
+
+Temporal is usually discussed as server infrastructure. JobCtrl runs Temporal
+locally because a desktop job-search workflow still needs durable execution:
+the laptop can sleep, providers can fail, workers can restart, and
+employer-facing actions cannot be retried casually.
+
+## A Desktop Workflow Is Still Distributed
+
+JobCtrl presents one local web application, but several processes collaborate:
+
+- the web app renders product state and sends structured actions;
+- the local TypeScript API validates requests and serves read models;
+- a JSON-RPC bridge starts Python-owned work;
+- the Python worker executes workflow activities;
+- Temporal records workflow history, timers, retries, and cancellation;
+- SQLite and registered local files hold domain facts and artifacts.
+
+These processes can fail independently even though they share one computer.
+Treating a long operation as one browser request would tie its lifetime to a
+tab, an API connection, or an in-memory process. Temporal gives the operation a
+separate durable identity.
+
+The full process boundary is documented in
+[Runtime & Processes](../architecture/runtime.md).
+
+## Workflows Coordinate; Activities Perform Side Effects
+
+Temporal workflow code decides sequence, retries, and branching from recorded
+history. Activities perform non-deterministic work such as SQLite access,
+network requests, model calls, browser operations, rendering, and event
+persistence.
+
+That separation lets Temporal replay orchestration without repeating arbitrary
+in-workflow I/O. JobCtrl’s long-running entry points all start workflows rather
+than falling back to a hidden in-process runner.
+
+Representative workflow shapes include:
+
+| Workflow responsibility | Durable behavior |
+| --- | --- |
+| Discover | Coordinates source families, resumable search units, enrichment, and per-job preparation |
+| Job preparation | Runs the required score, tailor, cover, and PDF subset in canonical order for one job |
+| Apply | Uses job-scoped identity and sink-specific retry rules for guarded application work |
+| Profile import and compensation refresh | Moves heavy operations off the long-lived request thread |
+| Durability probe | Uses an inert durable timer to prove recovery without network, model, browser, or Apply work |
+
+The exact catalog and code pointers live in
+[Temporal Workflows](../architecture/pipeline/index.md).
+
+## Stable Identity Prevents Accidental Parallel Work
+
+Some actions should have one active execution for a given target. JobCtrl uses
+deterministic workflow identifiers where duplication would be unsafe. Starting
+the same identity while it is running returns the existing execution instead of
+creating a second one.
+
+The Temporal run ID still matters because a deterministic workflow ID can be
+used again after a prior execution closes. JobCtrl records both. Read-model
+reconciliation pins its lookup to the exact run so an old failure is not
+confused with a later execution using the same logical identity.
+
+Other orchestration uses a fresh run identity when independence is correct.
+Identity is therefore a domain decision, not a global “deduplicate everything”
+switch.
+
+## Retries Follow The Side Effect
+
+A transient source fetch and a live submission do not share one retry policy.
+JobCtrl classifies errors and bounds activity attempts according to the
+operation:
+
+- retryable provider or network failures can retry within a named activity
+  policy;
+- permanent validation and budget errors fail fast;
+- per-stage score and model retries are bounded;
+- idempotent preparation steps report `already_done` when replay finds
+  completed work;
+- live employer-facing intent is not blindly retried after ambiguity.
+
+The workflow provides the recovery mechanism, while the domain decides whether
+repetition is safe. That is why durable orchestration improves safety only when
+activity boundaries and idempotency rules are explicit.
+
+Read
+[Activities, Retries & Cancellation](../architecture/pipeline/envelope.md) for
+the current policies and
+[At-most-once Job Application Submission](at-most-once-job-application-submission.md)
+for the high-risk example.
+
+## Workflow History Becomes Product Visibility
+
+Temporal’s own history is an execution authority, but raw workflow events are
+not a friendly product interface. JobCtrl records bounded `Workflow*` and
+`PipelineStep*` domain events and folds them into local read-model projections.
+The Runs and Pipelines workspaces then combine durable lineage with fresh
+worker and task-queue telemetry.
+
+This supports questions a desktop user actually asks:
+
+- Is this run still active, draining admitted work, complete, failed, or
+  canceled?
+- Which jobs and steps belong to this exact Discover execution?
+- Did a worker restart leave work running?
+- Is an estimate based on fresh capacity or stale telemetry?
+- Can I safely start a replacement run?
+
+The UI does not infer completion from a finished source crawl when downstream
+preparation remains. It also does not call a failed workflow proof that the
+runtime is idle.
+
+## Reconciliation Repairs Gaps Without Inventing History
+
+Each workflow records a start marker and a terminal outcome through activities.
+The starter also writes an open row immediately after Temporal accepts a start,
+covering executions that close before their first activity.
+
+A heartbeat reconciler compares projected runs with the exact recorded Temporal
+run. If history is temporarily unavailable, JobCtrl records a provisional
+not-found state and keeps checking. If the authoritative run returns, a
+compensating event reopens it or applies its real outcome; the false terminal
+remains in the audit stream.
+
+For older Discover runs, bounded history reconstruction can rebuild exact
+membership and step keys. During that recovery, the UI labels the state and
+withholds unsupported selected-run counts and estimates instead of displaying
+partial data as truth.
+
+The detailed projection and recovery contract is in
+[Operations & Events](../architecture/pipeline/operations.md).
+
+## Local Scheduling Remains Explicit
+
+Temporal also supplies a local recurring schedule for discovery. It is disabled
+by default. When enabled, worker startup reconciles one cron schedule with
+skip-overlap behavior, so a slow execution does not overlap the next tick.
+
+This is not a hosted background service: the local Temporal server and JobCtrl
+worker must be running. The standing Apply loop is likewise an explicit local
+setting, appears as a normal workflow run, and remains subject to Apply safety
+and spend controls.
+
+## The Tradeoff
+
+Running a workflow engine locally adds processes, a history store, task queues,
+and operational concepts to a desktop product. A small synchronous utility
+would not need that machinery.
+
+JobCtrl accepts the overhead because its core workflow is long-running,
+multi-stage, provider-dependent, and partly employer-facing. Durable history,
+classified retries, cancellation, recovery, and visible ownership are product
+features rather than backend implementation details.
+
+Use the [Product Tour](../user/product-tour.md#runs) to see run history, or
+follow [Getting Started](../user/getting-started.md) to start the bundled local
+runtime.
+
+Related reading:
+
+- [Local-first Job Search Automation](local-first-job-search-automation.md)
+- [At-most-once Job Application Submission](at-most-once-job-application-submission.md)
+- [JobCtrl Guides](index.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -57,3 +57,18 @@ features:
     link: /user/product-tour#runs
     linkText: See run history
 ---
+
+## Practical JobCtrl Guides
+
+- [Local-first job search automation](/guides/local-first-job-search-automation)
+  — what stays local, what uses the network, and why durable workflows matter.
+- [Open-source job application tracking](/guides/open-source-job-application-tracker)
+  — connect jobs, evidence, materials, applications, and outcomes.
+- [Resume tailoring without fabrication](/guides/resume-tailoring-without-fabrication)
+  — keep the posting as context and the Candidate Profile as evidence.
+- [Evidence-based job fit scoring](/guides/evidence-based-job-fit-scoring)
+  — inspect requirement fit, confidence, eligibility, and corrections.
+- [At-most-once application submission](/guides/at-most-once-job-application-submission)
+  — stop ambiguous employer-facing work from becoming a blind retry.
+- [Temporal workflows in a desktop app](/guides/temporal-workflows-desktop-app)
+  — make long-running local automation recoverable and visible.

--- a/docs/user/apply.md
+++ b/docs/user/apply.md
@@ -15,6 +15,9 @@ Gmail for bounded verification or an explicitly approved email application.
 The practical review sequence is in [Daily Workflow](normal-flows.md); the
 enforcement model is in [Security](security.md#approval-and-control-gates).
 
+For the retry and ambiguity model behind employer-facing work, read
+[At-most-once Job Application Submission](../guides/at-most-once-job-application-submission.md).
+
 ::: info Command spelling
 Command blocks on this page use the canonical installed spelling,
 `jobctrl <command>`. Contributors running from source can use the

--- a/docs/user/data-and-safety.md
+++ b/docs/user/data-and-safety.md
@@ -17,6 +17,8 @@ controls that enforce risky actions, read [Security](security.md). Feature
 settings live in [Discovery](discovery.md) and [Apply](apply.md); shared
 providers, precedence, and spend controls live in
 [Configuration](configuration.md).
+For a plain-language overview, read
+[Local-first Job Search Automation](../guides/local-first-job-search-automation.md).
 
 ## Privacy Quick Answer
 

--- a/docs/user/materials-and-tailoring.md
+++ b/docs/user/materials-and-tailoring.md
@@ -8,6 +8,8 @@ Materials are the job-specific resumes, cover letters, PDFs, and related review
 records JobCtrl creates from canonical profile evidence and the target posting.
 Tailoring is the versioned, gated process that selects and renders those claims
 without turning the job description into evidence about you.
+For a plain-language walkthrough of that boundary, read
+[Resume Tailoring Without Fabrication](../guides/resume-tailoring-without-fabrication.md).
 
 ## How JobCtrl Chooses A Resume
 

--- a/docs/user/normal-flows.md
+++ b/docs/user/normal-flows.md
@@ -14,6 +14,9 @@ review → Apply. The web app is the main way you work; the command line stays
 available for maintenance and diagnostics. For a screen-by-screen walkthrough of
 each page below, see the [Product Tour](product-tour.md).
 
+For a lifecycle-level view of the records these steps create, read
+[Open-source Job Application Tracker](../guides/open-source-job-application-tracker.md).
+
 ::: info Command spelling
 This guide uses the canonical installed spelling, `jobctrl <command>`. The
 same native executable owns `jobctrl start`, `stop`, and `status`, regardless

--- a/docs/user/scoring-and-employer-analysis.md
+++ b/docs/user/scoring-and-employer-analysis.md
@@ -9,6 +9,8 @@ a versioned Candidate Profile. It produces an applicant-side fit score,
 confidence, blockers, gaps, and requirement-level evidence for your own triage.
 Discovery owns how the employer analysis is generated and which perspectives
 participate; this page owns how that accepted input becomes a fit decision.
+For a shorter conceptual introduction, read
+[Evidence-based Job Fit Scoring](../guides/evidence-based-job-fit-scoring.md).
 
 ## How The Score Is Calculated
 

--- a/scripts/check-docs-site-runtime.mjs
+++ b/scripts/check-docs-site-runtime.mjs
@@ -46,6 +46,21 @@ const PAGES = [
     visualSelector: null,
     images: false,
   },
+  {
+    path: "/guides/evidence-based-job-fit-scoring",
+    visualSelector: null,
+    images: false,
+  },
+  {
+    path: "/guides/at-most-once-job-application-submission",
+    visualSelector: ".mermaid svg",
+    images: false,
+  },
+  {
+    path: "/guides/temporal-workflows-desktop-app",
+    visualSelector: null,
+    images: false,
+  },
   { path: "/architecture/", visualSelector: ".system-topology", images: false },
   { path: "/developer/", visualSelector: null, images: false },
   {
@@ -117,6 +132,9 @@ const SOCIAL_METADATA_ROUTES = new Set([
   "/guides/local-first-job-search-automation",
   "/guides/open-source-job-application-tracker",
   "/guides/resume-tailoring-without-fabrication",
+  "/guides/evidence-based-job-fit-scoring",
+  "/guides/at-most-once-job-application-submission",
+  "/guides/temporal-workflows-desktop-app",
   "/architecture/",
   "/developer/",
   "/user/apply",
@@ -448,7 +466,10 @@ async function assertHomepageSearchIdentity(page) {
     website?.alternateName !== "jobctrl.dev" ||
     website?.url !== "https://jobctrl.dev/" ||
     software?.name !== "JobCtrl" ||
-    software?.applicationSubCategory !== "Job search automation"
+    software?.applicationSubCategory !== "Job search automation" ||
+    software?.offers?.["@type"] !== "Offer" ||
+    software?.offers?.price !== "0" ||
+    software?.offers?.priceCurrency !== "USD"
   ) {
     fail(`/: homepage search identity is incomplete (${JSON.stringify(identity)})`);
   } else {

--- a/scripts/docs-launch-copy.test.mjs
+++ b/scripts/docs-launch-copy.test.mjs
@@ -109,6 +109,7 @@ test("public docs emit crawl and social-discovery metadata", async () => {
   assert.match(config, /"@type": "WebSite"/);
   assert.match(config, /alternateName: "jobctrl\.dev"/);
   assert.match(config, /"@type": "SoftwareApplication"/);
+  assert.match(config, /offers:\s*\{\s*"@type": "Offer",\s*price: "0",/);
   assert.match(config, /id: "jobctrl-structured-data"/);
   assert.match(homepage, /title: "JobCtrl — Local-first job search automation"/);
   assert.match(homepage, /titleTemplate: false/);
@@ -143,6 +144,18 @@ test("priority public pages have distinct search descriptions", async () => {
     [
       "docs/guides/resume-tailoring-without-fabrication.md",
       "Understand how JobCtrl tailors a resume",
+    ],
+    [
+      "docs/guides/evidence-based-job-fit-scoring.md",
+      "Learn how evidence-based job fit scoring",
+    ],
+    [
+      "docs/guides/at-most-once-job-application-submission.md",
+      "Understand at-most-once job application submission",
+    ],
+    [
+      "docs/guides/temporal-workflows-desktop-app.md",
+      "Learn why JobCtrl runs Temporal workflows",
     ],
   ]);
   const observed = new Set();
@@ -186,6 +199,32 @@ test("search-intent guides are substantive and route readers to canonical owners
         "../user/materials-and-tailoring.md",
       ],
     },
+    {
+      path: "docs/guides/evidence-based-job-fit-scoring.md",
+      heading: "# Evidence-based Job Fit Scoring",
+      owners: [
+        "../user/scoring-and-employer-analysis.md",
+        "../architecture/scoring.md",
+        "../user/candidate-profile.md",
+      ],
+    },
+    {
+      path: "docs/guides/at-most-once-job-application-submission.md",
+      heading: "# At-most-once Job Application Submission",
+      owners: [
+        "../user/apply.md",
+        "../user/security.md",
+      ],
+    },
+    {
+      path: "docs/guides/temporal-workflows-desktop-app.md",
+      heading: "# Temporal Workflows In A Desktop App",
+      owners: [
+        "../architecture/runtime.md",
+        "../architecture/pipeline/index.md",
+        "../architecture/pipeline/operations.md",
+      ],
+    },
   ];
 
   for (const contract of guideContracts) {
@@ -201,6 +240,32 @@ test("search-intent guides are substantive and route readers to canonical owners
         document.includes(`](${owner}`),
         `${contract.path} must link to ${owner}`,
       );
+    }
+  }
+});
+
+test("homepage and canonical owners cross-link the public guides", async () => {
+  const links = new Map([
+    ["docs/index.md", [
+      "/guides/local-first-job-search-automation",
+      "/guides/open-source-job-application-tracker",
+      "/guides/resume-tailoring-without-fabrication",
+      "/guides/evidence-based-job-fit-scoring",
+      "/guides/at-most-once-job-application-submission",
+      "/guides/temporal-workflows-desktop-app",
+    ]],
+    ["docs/user/data-and-safety.md", ["../guides/local-first-job-search-automation.md"]],
+    ["docs/user/normal-flows.md", ["../guides/open-source-job-application-tracker.md"]],
+    ["docs/user/materials-and-tailoring.md", ["../guides/resume-tailoring-without-fabrication.md"]],
+    ["docs/user/scoring-and-employer-analysis.md", ["../guides/evidence-based-job-fit-scoring.md"]],
+    ["docs/user/apply.md", ["../guides/at-most-once-job-application-submission.md"]],
+    ["docs/architecture/runtime.md", ["../guides/temporal-workflows-desktop-app.md"]],
+  ]);
+
+  for (const [path, expectedLinks] of links) {
+    const document = await read(path);
+    for (const link of expectedLinks) {
+      assert.ok(document.includes(`](${link})`), `${path} must link to ${link}`);
     }
   }
 });


### PR DESCRIPTION
## What changed

- publish guides for evidence-based job fit scoring, at-most-once application submission, and Temporal workflows in a desktop app
- cross-link all six guides from the homepage and their canonical product or architecture owners
- complete the guide hub, sidebar, documentation map, metadata coverage, sitemap coverage, and browser traversal
- add an accurate zero-price Offer to SoftwareApplication structured data for Google rich-result eligibility

## Why

The final stack layer makes JobCtrl’s strongest implementation choices discoverable through practical, technically grounded pages while preserving the canonical behavior contracts.

## Stack

- depends on #554, which depends on #552
- base branch: `agent/seo-guides-user`

## Validation

- `node --test scripts/docs-launch-copy.test.mjs` (11/11)
- `corepack pnpm docs:build` (9,649 links across 359 emitted files)
- `corepack pnpm docs:check:runtime`
- `git diff --check`
- independent review: PASS (0 Blocker, 0 High)
- independent QA: PASS (0 Blocker, 0 High)