### PR TITLE
feat(discovery): migrate manual capture links to stable JobIds

### DIFF
--- a/apps/api/src/db.ts
+++ b/apps/api/src/db.ts
@@ -9,7 +9,7 @@ export type SqliteValue = string | number | bigint | null;
 // writer that stamps ``PRAGMA user_version``; the API only reads it to fail
 // closed on a database written by a newer build. Bump both constants together
 // whenever the schema shape changes.
-export const SUPPORTED_SCHEMA_VERSION = 26;
+export const SUPPORTED_SCHEMA_VERSION = 27;
 
 export class IncompatibleSchemaVersionError extends Error {
   constructor(current: number) {

--- a/apps/api/src/discovery-controls.ts
+++ b/apps/api/src/discovery-controls.ts
@@ -67,6 +67,7 @@ import { InputError } from "./write-model.js";
 
 const DEFAULT_TENANT = "local";
 const DISCOVERY_FEEDBACK_REFERENCE_SCHEMA_VERSION = 26;
+const MANUAL_CAPTURE_REFERENCE_SCHEMA_VERSION = 27;
 export const EXTENSION_MANUAL_CAPTURE_SOURCE_ID = "manual_capture:extension";
 const EXTENSION_MANUAL_CAPTURE_REASON: ManualActionReasonValue = "browser_extension_capture";
 const DEFAULT_DISCOVERY_SETTINGS: DiscoverySettings = {
@@ -246,6 +247,8 @@ export function ensureDiscoveryControlTables(db: SqliteDatabase): void {
   );
   const stableFeedbackReferences =
     schemaVersion >= DISCOVERY_FEEDBACK_REFERENCE_SCHEMA_VERSION;
+  const stableManualCaptureReferences =
+    schemaVersion >= MANUAL_CAPTURE_REFERENCE_SCHEMA_VERSION;
   db.exec(`
     CREATE TABLE IF NOT EXISTS discovery_settings (
       tenant_id          TEXT PRIMARY KEY,
@@ -297,26 +300,6 @@ export function ensureDiscoveryControlTables(db: SqliteDatabase): void {
       decided_at       TEXT,
       PRIMARY KEY (tenant_id, job_key)
     );
-    CREATE TABLE IF NOT EXISTS manual_capture_queue (
-      tenant_id                     TEXT NOT NULL DEFAULT 'local',
-      item_id                       TEXT NOT NULL,
-      originating_url               TEXT NOT NULL,
-      source_id                     TEXT,
-      reason                        TEXT NOT NULL,
-      retry_context_json            TEXT NOT NULL DEFAULT '{}',
-      required_at                   TEXT NOT NULL,
-      status                        TEXT NOT NULL DEFAULT 'pending',
-      imported_at                   TEXT,
-      dismissed_at                  TEXT,
-      capture_mode                  TEXT,
-      captured_url                  TEXT,
-      content_sha256                TEXT,
-      content_length                INTEGER,
-      note                          TEXT,
-      future_manual_action_required INTEGER NOT NULL DEFAULT 0,
-      job_key                       TEXT,
-      PRIMARY KEY (tenant_id, item_id)
-    );
     CREATE TABLE IF NOT EXISTS role_match_feedback_suggestions (
       tenant_id       TEXT NOT NULL DEFAULT 'local',
       suggestion_id   TEXT NOT NULL,
@@ -336,6 +319,79 @@ export function ensureDiscoveryControlTables(db: SqliteDatabase): void {
       PRIMARY KEY (tenant_id, suggestion_id)
     );
   `);
+  if (!tableExists(db, "manual_capture_queue")) {
+    const referenceColumn = stableManualCaptureReferences
+      ? "job_id"
+      : "job_key";
+    const foreignKey = stableManualCaptureReferences
+      ? `,
+        FOREIGN KEY (tenant_id, job_id)
+          REFERENCES jobs(tenant_id, job_id) ON DELETE CASCADE`
+      : "";
+    db.exec(`
+      CREATE TABLE manual_capture_queue (
+        tenant_id                     TEXT NOT NULL DEFAULT 'local',
+        item_id                       TEXT NOT NULL,
+        originating_url               TEXT NOT NULL,
+        source_id                     TEXT,
+        reason                        TEXT NOT NULL,
+        retry_context_json            TEXT NOT NULL DEFAULT '{}',
+        required_at                   TEXT NOT NULL,
+        status                        TEXT NOT NULL DEFAULT 'pending',
+        imported_at                   TEXT,
+        dismissed_at                  TEXT,
+        capture_mode                  TEXT,
+        captured_url                  TEXT,
+        content_sha256                TEXT,
+        content_length                INTEGER,
+        note                          TEXT,
+        future_manual_action_required INTEGER NOT NULL DEFAULT 0,
+        ${referenceColumn}            TEXT,
+        PRIMARY KEY (tenant_id, item_id)
+        ${foreignKey}
+      );
+    `);
+  }
+  const manualCaptureColumns = tableColumnSet(
+    db,
+    "manual_capture_queue",
+  );
+  if (
+    stableManualCaptureReferences
+    && (
+      !manualCaptureColumns.has("job_id")
+      || manualCaptureColumns.has("job_key")
+    )
+  ) {
+    throw new Error(
+      "Schema v27 requires stable manual_capture_queue.job_id references.",
+    );
+  }
+  if (stableManualCaptureReferences) {
+    db.exec(`
+      CREATE INDEX IF NOT EXISTS idx_manual_capture_queue_job
+      ON manual_capture_queue(tenant_id, job_id, status);
+    `);
+    if (
+      !hasCompositeJobIdForeignKey(
+        db,
+        "manual_capture_queue",
+      )
+      || tableIndexColumns(
+        db,
+        "manual_capture_queue",
+        "idx_manual_capture_queue_job",
+      ).join(",") !== "tenant_id,job_id,status"
+      || primaryKeyColumns(
+        db,
+        "manual_capture_queue",
+      ).join(",") !== "tenant_id,item_id"
+    ) {
+      throw new Error(
+        "Schema v27 requires the stable manual-capture JobId contract.",
+      );
+    }
+  }
   if (!tableExists(db, "discovery_feedback")) {
     const referenceColumn = stableFeedbackReferences
       ? "job_id"
@@ -1185,13 +1241,17 @@ function dismissedExtensionManualCaptureResponse(
   db: SqliteDatabase,
   itemId: string,
 ): ExtensionCaptureIngestResponse | null {
+  const reference = manualCaptureReferenceProjection(db);
   const row = getRow<ImportedManualCaptureRow>(
     db,
     `SELECT item_id, originating_url, source_id, reason, retry_context_json,
             required_at, status, imported_at, dismissed_at, capture_mode,
-            captured_url, future_manual_action_required, job_key
+            captured_url, future_manual_action_required,
+            ${reference.selectSql}
      FROM manual_capture_queue
-     WHERE tenant_id = ? AND item_id = ? AND status = 'dismissed'`,
+     ${reference.joinSql}
+     WHERE manual_capture_queue.tenant_id = ?
+       AND item_id = ? AND status = 'dismissed'`,
     [DEFAULT_TENANT, itemId],
   );
   if (!row) {
@@ -1211,13 +1271,16 @@ function importedExtensionManualCaptureResponse(
   db: SqliteDatabase,
   itemId: string,
 ): ManualCaptureImportResponse | null {
+  const reference = manualCaptureReferenceProjection(db);
   const row = getRow<ImportedManualCaptureRow>(
     db,
     `SELECT item_id, originating_url, source_id, reason, retry_context_json,
             required_at, status, imported_at, capture_mode, captured_url,
-            future_manual_action_required, job_key
+            future_manual_action_required, ${reference.selectSql}
      FROM manual_capture_queue
-     WHERE tenant_id = ? AND item_id = ? AND status = 'imported'`,
+     ${reference.joinSql}
+     WHERE manual_capture_queue.tenant_id = ?
+       AND item_id = ? AND status = 'imported'`,
     [DEFAULT_TENANT, itemId],
   );
   if (!row?.imported_at) {
@@ -1334,6 +1397,31 @@ function primaryKeyColumns(
     .filter((row) => row.pk > 0)
     .sort((left, right) => left.pk - right.pk)
     .map((row) => row.name);
+}
+
+function manualCaptureReferenceProjection(
+  db: SqliteDatabase,
+): { selectSql: string; joinSql: string } {
+  if (
+    jobKeyReferenceColumn(
+      db,
+      "manual_capture_queue",
+    ) === "job_key"
+  ) {
+    return {
+      selectSql: "manual_capture_queue.job_key AS job_key",
+      joinSql: "",
+    };
+  }
+  return {
+    selectSql: `COALESCE(
+      NULLIF(TRIM(manual_capture_queue.captured_url), ''),
+      jobs.url
+    ) AS job_key`,
+    joinSql: `LEFT JOIN jobs
+      ON jobs.tenant_id = manual_capture_queue.tenant_id
+     AND jobs.job_id = manual_capture_queue.job_id`,
+  };
 }
 
 export function listRoleMatchFeedbackSuggestions(

--- a/apps/api/src/write-model.ts
+++ b/apps/api/src/write-model.ts
@@ -867,6 +867,11 @@ function purgeJobRows(db: SqliteDatabase, jobUrl: string): void {
     jobId,
     jobUrl,
   );
+  deleteManualCaptureReferences(
+    db,
+    jobId,
+    jobUrl,
+  );
   detachOrDeleteOutreachReferences(db, jobId, jobUrl);
   detachOrDeleteContactReferences(db, jobId, jobUrl);
   deleteJobReferences(db, "job_artifacts", jobId, jobUrl);
@@ -1270,6 +1275,27 @@ function deleteDiscoveryFeedbackReferences(
   deleteWhere(
     db,
     "discovery_feedback",
+    `tenant_id = ? AND ${referenceColumn} = ?`,
+    ["local", reference],
+  );
+}
+
+function deleteManualCaptureReferences(
+  db: SqliteDatabase,
+  jobId: string | undefined,
+  jobUrl: string,
+): void {
+  if (!tableExists(db, "manual_capture_queue")) return;
+  const referenceColumn = jobKeyReferenceColumn(
+    db,
+    "manual_capture_queue",
+  );
+  const reference =
+    referenceColumn === "job_id" ? jobId : jobUrl;
+  if (!reference) return;
+  deleteWhere(
+    db,
+    "manual_capture_queue",
     `tenant_id = ? AND ${referenceColumn} = ?`,
     ["local", reference],
   );

--- a/apps/api/test/manual-capture-v27.test.ts
+++ b/apps/api/test/manual-capture-v27.test.ts
@@ -1,0 +1,278 @@
+import Database from "better-sqlite3";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  ensureDiscoveryControlTables,
+  seedExtensionManualCapture,
+} from "../src/discovery-controls.js";
+import { tableColumnSet } from "../src/db.js";
+import { permanentlyDeleteJob } from "../src/write-model.js";
+
+const NOW = "2026-07-30T12:00:00.000Z";
+const JOB_URL = "https://careers.example.test/manual-capture";
+const CANONICAL_JOB_URL = "https://careers.example.test/canonical";
+const JOB_ID = "22222222-2222-4222-8222-222222222222";
+
+let db: Database.Database | undefined;
+let cleanup: (() => void) | undefined;
+
+afterEach(() => {
+  db?.close();
+  db = undefined;
+  cleanup?.();
+  cleanup = undefined;
+});
+
+function createDatabase(
+  schemaVersion = 27,
+  foreignKeys = true,
+): Database.Database {
+  const dir = fs.mkdtempSync(
+    path.join(os.tmpdir(), "jobctrl-manual-capture-v27-"),
+  );
+  cleanup = () => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  };
+  const opened = new Database(path.join(dir, "jobs.db"));
+  opened.pragma(
+    `foreign_keys = ${foreignKeys ? "ON" : "OFF"}`,
+  );
+  opened.exec(`
+    CREATE TABLE jobs (
+      url TEXT PRIMARY KEY,
+      tenant_id TEXT NOT NULL DEFAULT 'local',
+      job_id TEXT NOT NULL,
+      title TEXT,
+      company TEXT,
+      salary TEXT,
+      description TEXT,
+      location TEXT,
+      site TEXT,
+      strategy TEXT,
+      discovered_at TEXT,
+      full_description TEXT,
+      application_url TEXT,
+      detail_scraped_at TEXT,
+      detail_error TEXT,
+      fit_score INTEGER,
+      score_reasoning TEXT,
+      scored_at TEXT,
+      tailored_resume_path TEXT,
+      tailored_at TEXT,
+      tailor_attempts INTEGER DEFAULT 0,
+      cover_letter_path TEXT,
+      cover_letter_at TEXT,
+      cover_attempts INTEGER DEFAULT 0,
+      applied_at TEXT,
+      apply_status TEXT,
+      apply_error TEXT,
+      apply_attempts INTEGER DEFAULT 0,
+      agent_id TEXT,
+      last_attempted_at TEXT,
+      apply_duration_ms INTEGER,
+      apply_task_id TEXT,
+      verification_confidence TEXT,
+      UNIQUE (tenant_id, job_id)
+    );
+    CREATE TABLE job_events (
+      event_id INTEGER PRIMARY KEY AUTOINCREMENT,
+      job_url TEXT,
+      stage TEXT,
+      event_type TEXT NOT NULL DEFAULT '',
+      level TEXT NOT NULL DEFAULT 'info',
+      message TEXT,
+      occurred_at TEXT NOT NULL,
+      payload_json TEXT,
+      entity_kind TEXT,
+      entity_ref TEXT
+    );
+    PRAGMA user_version = ${schemaVersion};
+  `);
+  return opened;
+}
+
+function insertJob(
+  opened: Database.Database,
+  url = JOB_URL,
+): void {
+  opened.prepare(
+    `INSERT INTO jobs (
+       url, tenant_id, job_id, title, company, discovered_at
+     ) VALUES (?, 'local', ?, 'Platform Engineer', 'ExampleCo', ?)`,
+  ).run(url, JOB_ID, NOW);
+}
+
+const extensionCapture = {
+  captureId: "capture-stable-v27",
+  originatingUrl: JOB_URL,
+  captureMode: "current_page" as const,
+  capturedUrl: JOB_URL,
+  contentText: "Visible user-mediated posting text.",
+  futureManualActionRequired: true,
+  captureClient: "browser_extension" as const,
+  extensionVersion: "0.3.0",
+};
+
+describe("schema-v27 manual-capture references", () => {
+  it("recovers the stable nullable reference contract", () => {
+    db = createDatabase();
+    ensureDiscoveryControlTables(db);
+
+    expect(tableColumnSet(db, "manual_capture_queue")).toContain(
+      "job_id",
+    );
+    expect(
+      tableColumnSet(db, "manual_capture_queue"),
+    ).not.toContain("job_key");
+    const actions = new Set(
+      (
+        db
+          .prepare(
+            'PRAGMA foreign_key_list("manual_capture_queue")',
+          )
+          .all() as Array<{ on_delete: string }>
+      ).map((row) => row.on_delete),
+    );
+    expect(actions).toEqual(new Set(["CASCADE"]));
+    expect(
+      (
+        db
+          .prepare(
+            'PRAGMA index_info("idx_manual_capture_queue_job")',
+          )
+          .all() as Array<{ seqno: number; name: string }>
+      )
+        .sort((left, right) => left.seqno - right.seqno)
+        .map((row) => row.name),
+    ).toEqual(["tenant_id", "job_id", "status"]);
+  });
+
+  it("projects imported stable storage back to the captured posting URL", () => {
+    db = createDatabase();
+    insertJob(db, CANONICAL_JOB_URL);
+    const seeded = seedExtensionManualCapture(
+      db,
+      extensionCapture,
+    );
+    expect("ok" in seeded).toBe(false);
+    const itemId = "itemId" in seeded ? seeded.itemId : "";
+    expect(itemId).not.toBe("");
+    const importedAt = "2026-07-30T12:05:00.000Z";
+    db.prepare(
+      `UPDATE manual_capture_queue
+          SET status = 'imported',
+              imported_at = ?,
+              capture_mode = ?,
+              captured_url = ?,
+              content_sha256 = ?,
+              content_length = ?,
+              note = ?,
+              future_manual_action_required = 1,
+              retry_context_json = ?,
+              job_id = ?
+        WHERE tenant_id = 'local' AND item_id = ?`,
+    ).run(
+      importedAt,
+      extensionCapture.captureMode,
+      JOB_URL,
+      "a".repeat(64),
+      extensionCapture.contentText.length,
+      "private: capture note",
+      JSON.stringify({
+        manual_capture_provenance: {
+          source_kind: "user_mediated_capture",
+          originating_url: JOB_URL,
+          source_id: "manual_capture:extension",
+          capture_mode: extensionCapture.captureMode,
+          captured_at: importedAt,
+          future_manual_action_required: true,
+          capture_client: "browser_extension",
+          extension_version: "0.3.0",
+        },
+      }),
+      JOB_ID,
+      itemId,
+    );
+
+    expect(
+      seedExtensionManualCapture(db, extensionCapture),
+    ).toMatchObject({
+      ok: true,
+      itemId,
+      jobKey: JOB_URL,
+      importedAt,
+      provenance: {
+        sourceKind: "user_mediated_capture",
+        originatingUrl: JOB_URL,
+        captureMode: "current_page",
+        futureManualActionRequired: true,
+        captureClient: "browser_extension",
+        extensionVersion: "0.3.0",
+      },
+    });
+    expect(
+      db
+        .prepare(
+          `SELECT job_id, captured_url, note
+             FROM manual_capture_queue
+            WHERE item_id = ?`,
+        )
+        .get(itemId),
+    ).toEqual({
+      job_id: JOB_ID,
+      captured_url: JOB_URL,
+      note: "private: capture note",
+    });
+  });
+
+  it.each([true, false])(
+    "purges an imported capture during permanent deletion with foreign keys %s",
+    (foreignKeys) => {
+      db = createDatabase(27, foreignKeys);
+      insertJob(db);
+      ensureDiscoveryControlTables(db);
+      db.prepare(
+        `INSERT INTO manual_capture_queue (
+           tenant_id, item_id, originating_url, reason,
+           retry_context_json, required_at, status,
+           imported_at, captured_url, note, job_id
+         ) VALUES (
+           'local', 'capture:delete', ?, 'login_required',
+           '{"private":"delete"}', ?, 'imported',
+           ?, ?, 'private deletion note', ?
+         )`,
+      ).run(JOB_URL, NOW, NOW, JOB_URL, JOB_ID);
+
+      expect(permanentlyDeleteJob(db, JOB_URL)).toEqual({
+        ok: true,
+        count: 1,
+        jobKeys: [JOB_URL],
+      });
+      expect(
+        db
+          .prepare(
+            "SELECT COUNT(*) AS count FROM manual_capture_queue",
+          )
+          .get(),
+      ).toEqual({ count: 0 });
+      expect(
+        db
+          .prepare("SELECT COUNT(*) AS count FROM jobs")
+          .get(),
+      ).toEqual({ count: 0 });
+    },
+  );
+
+  it("fails closed when a v27 stamp has a legacy queue", () => {
+    db = createDatabase(26);
+    ensureDiscoveryControlTables(db);
+    db.pragma("user_version = 27");
+
+    expect(() => ensureDiscoveryControlTables(db!)).toThrow(
+      "Schema v27 requires stable manual_capture_queue.job_id references.",
+    );
+  });
+});

--- a/apps/api/test/schema-version-guard.test.ts
+++ b/apps/api/test/schema-version-guard.test.ts
@@ -63,7 +63,7 @@ describe("schema version guard at DB open", () => {
   });
 
   it("opens the worker-owned schema-v14 artifact registry", () => {
-    expect(SUPPORTED_SCHEMA_VERSION).toBe(26);
+    expect(SUPPORTED_SCHEMA_VERSION).toBe(27);
     const { dbPath, cleanup } = makeDbWithUserVersion(14);
     try {
       openDatabase(dbPath).close();

--- a/workers/automation/src/jobctrl/database.py
+++ b/workers/automation/src/jobctrl/database.py
@@ -100,7 +100,10 @@ from jobctrl.config import DB_PATH, DEFAULTS, migrate_legacy_job_tables
 # v26 (discovery-feedback references): user-authored Discovery feedback points
 # at the tenant-scoped stable Job aggregate. The URL-shaped API/event contract
 # remains unchanged, and private free-form notes stay only in canonical storage.
-SCHEMA_VERSION = 26
+# v27 (manual-capture references): imported manual-capture queue rows point at
+# the tenant-scoped stable Job aggregate. Pending captures remain unlinked, and
+# workflow/API results continue to expose the posting URL until Phase 4.
+SCHEMA_VERSION = 27
 
 
 class IncompatibleSchemaVersionError(RuntimeError):
@@ -257,6 +260,7 @@ def _schema_migrations() -> tuple[
         (24, ensure_contact_research_references_v24),
         (25, ensure_outreach_references_v25),
         (26, ensure_discovery_feedback_references_v26),
+        (27, ensure_manual_capture_references_v27),
     )
 
 
@@ -3728,6 +3732,9 @@ def ensure_discovery_control_tables(conn: sqlite3.Connection | None = None) -> l
     stable_feedback_references = (
         current_version >= _DISCOVERY_FEEDBACK_REFERENCE_SCHEMA_VERSION
     )
+    stable_manual_capture_references = (
+        current_version >= _MANUAL_CAPTURE_REFERENCE_SCHEMA_VERSION
+    )
 
     conn.execute(
         """
@@ -3785,30 +3792,31 @@ def ensure_discovery_control_tables(conn: sqlite3.Connection | None = None) -> l
         )
         """
     )
-    conn.execute(
-        """
-        CREATE TABLE IF NOT EXISTS manual_capture_queue (
-            tenant_id                     TEXT NOT NULL DEFAULT 'local',
-            item_id                       TEXT NOT NULL,
-            originating_url               TEXT NOT NULL,
-            source_id                     TEXT,
-            reason                        TEXT NOT NULL,
-            retry_context_json            TEXT NOT NULL DEFAULT '{}',
-            required_at                   TEXT NOT NULL,
-            status                        TEXT NOT NULL DEFAULT 'pending',
-            imported_at                   TEXT,
-            dismissed_at                  TEXT,
-            capture_mode                  TEXT,
-            captured_url                  TEXT,
-            content_sha256                TEXT,
-            content_length                INTEGER,
-            note                          TEXT,
-            future_manual_action_required INTEGER NOT NULL DEFAULT 0,
-            job_key                       TEXT,
-            PRIMARY KEY (tenant_id, item_id)
+    if not _table_columns(conn, "manual_capture_queue"):
+        _create_manual_capture_queue_table_v27(
+            conn,
+            table="manual_capture_queue",
+            stable_reference=stable_manual_capture_references,
         )
-        """
-    )
+    if stable_manual_capture_references:
+        manual_capture_columns = _table_columns(
+            conn,
+            "manual_capture_queue",
+        )
+        if (
+            "job_id" not in manual_capture_columns
+            or "job_key" in manual_capture_columns
+        ):
+            raise RuntimeError(
+                "Schema v27 requires stable manual-capture "
+                "JobId references."
+            )
+        _create_manual_capture_reference_index_v27(conn)
+        if not _has_manual_capture_reference_schema_v27(conn):
+            raise RuntimeError(
+                "Schema v27 requires the stable manual-capture "
+                "JobId contract."
+            )
     if not _table_columns(conn, "discovery_feedback"):
         _create_discovery_feedback_table_v26(
             conn,
@@ -4878,6 +4886,13 @@ def _reassign_discovery_identity_references(
         )
     if _has_discovery_feedback_reference_schema_v26(conn):
         _reassign_discovery_feedback_references_v26(
+            conn,
+            tenant_id=tenant_id,
+            losing_job_id=losing_job_id,
+            surviving_job_id=surviving_job_id,
+        )
+    if _has_manual_capture_reference_schema_v27(conn):
+        _reassign_manual_capture_references_v27(
             conn,
             tenant_id=tenant_id,
             losing_job_id=losing_job_id,
@@ -15535,6 +15550,302 @@ def _reassign_discovery_feedback_references_v26(
         (surviving_job_id, tenant_id, losing_job_id),
     )
     _verify_discovery_feedback_references_v26(
+        conn,
+        expected_count=expected_count,
+    )
+
+
+_MANUAL_CAPTURE_REFERENCE_SCHEMA_VERSION = 27
+_MANUAL_CAPTURE_REFERENCE_TABLES = ("manual_capture_queue",)
+
+
+def _create_manual_capture_queue_table_v27(
+    conn: sqlite3.Connection,
+    *,
+    table: str,
+    stable_reference: bool,
+) -> None:
+    reference_column = "job_id" if stable_reference else "job_key"
+    foreign_key = (
+        """,
+            FOREIGN KEY (tenant_id, job_id)
+                REFERENCES jobs(tenant_id, job_id) ON DELETE CASCADE"""
+        if stable_reference
+        else ""
+    )
+    conn.execute(
+        f"""
+        CREATE TABLE "{table}" (
+            tenant_id                     TEXT NOT NULL DEFAULT 'local',
+            item_id                       TEXT NOT NULL,
+            originating_url               TEXT NOT NULL,
+            source_id                     TEXT,
+            reason                        TEXT NOT NULL,
+            retry_context_json            TEXT NOT NULL DEFAULT '{{}}',
+            required_at                   TEXT NOT NULL,
+            status                        TEXT NOT NULL DEFAULT 'pending',
+            imported_at                   TEXT,
+            dismissed_at                  TEXT,
+            capture_mode                  TEXT,
+            captured_url                  TEXT,
+            content_sha256                TEXT,
+            content_length                INTEGER,
+            note                          TEXT,
+            future_manual_action_required INTEGER NOT NULL DEFAULT 0,
+            {reference_column}            TEXT,
+            PRIMARY KEY (tenant_id, item_id)
+            {foreign_key}
+        )
+        """
+    )
+
+
+def _create_manual_capture_reference_index_v27(
+    conn: sqlite3.Connection,
+) -> None:
+    if _has_index(
+        conn,
+        "manual_capture_queue",
+        "idx_manual_capture_queue_job",
+        ("tenant_id", "job_id", "status"),
+        unique=False,
+    ):
+        return
+    conn.execute(
+        'DROP INDEX IF EXISTS "idx_manual_capture_queue_job"'
+    )
+    conn.execute(
+        """
+        CREATE INDEX idx_manual_capture_queue_job
+        ON manual_capture_queue(tenant_id, job_id, status)
+        """
+    )
+
+
+def _has_manual_capture_reference_schema_v27(
+    conn: sqlite3.Connection,
+) -> bool:
+    table = "manual_capture_queue"
+    return (
+        "job_id" in _table_columns(conn, table)
+        and "job_key" not in _table_columns(conn, table)
+        and _primary_key_columns(conn, table)
+        == ("tenant_id", "item_id")
+        and _has_composite_job_id_foreign_key(
+            conn,
+            table,
+            "job_id",
+        )
+        and _has_index(
+            conn,
+            table,
+            "idx_manual_capture_queue_job",
+            ("tenant_id", "job_id", "status"),
+            unique=False,
+        )
+    )
+
+
+def _canonical_manual_capture_rows_v27(
+    conn: sqlite3.Connection,
+) -> list[tuple[Any, ...]]:
+    reference_column = _legacy_or_stable_reference_column(
+        conn,
+        "manual_capture_queue",
+        stable="job_id",
+        legacy="job_key",
+    )
+    rows = conn.execute(
+        f"""
+        SELECT tenant_id, item_id, originating_url, source_id,
+               reason, retry_context_json, required_at, status,
+               imported_at, dismissed_at, capture_mode, captured_url,
+               content_sha256, content_length, note,
+               future_manual_action_required, {reference_column}
+        FROM manual_capture_queue
+        ORDER BY tenant_id, item_id
+        """
+    ).fetchall()
+    canonical: list[tuple[Any, ...]] = []
+    for row in rows:
+        values = tuple(row)
+        raw_reference = values[16]
+        stable_job_id: str | None = None
+        if raw_reference is not None:
+            stable_job_id = _resolve_job_reference_value(
+                conn,
+                tenant_id=str(values[0]),
+                reference=str(raw_reference),
+                legacy_url=reference_column == "job_key",
+            )
+            if stable_job_id is None:
+                raise RuntimeError(
+                    "manual-capture reference migration could not "
+                    f"resolve manual_capture_queue.{reference_column}="
+                    f"{raw_reference!r} for tenant {values[0]!r}"
+                )
+            _validate_job_uuid(stable_job_id)
+        canonical.append((*values[:16], stable_job_id))
+    return canonical
+
+
+def ensure_manual_capture_references_v27(
+    conn: sqlite3.Connection | None = None,
+) -> list[str]:
+    """Move imported manual-capture links to stable JobIds."""
+    if conn is None:
+        conn = get_connection()
+    current = _assert_schema_version_supported(conn)
+    if current >= _MANUAL_CAPTURE_REFERENCE_SCHEMA_VERSION:
+        return list(_MANUAL_CAPTURE_REFERENCE_TABLES)
+    if current != _DISCOVERY_FEEDBACK_REFERENCE_SCHEMA_VERSION:
+        raise RuntimeError(
+            "manual-capture reference migration requires schema v26; "
+            f"found v{current}"
+        )
+
+    conn.execute("SAVEPOINT manual_capture_references_v27")
+    try:
+        if not _table_columns(conn, "manual_capture_queue"):
+            _create_manual_capture_queue_table_v27(
+                conn,
+                table="manual_capture_queue",
+                stable_reference=False,
+            )
+        expected_count = int(
+            conn.execute(
+                "SELECT COUNT(*) FROM manual_capture_queue"
+            ).fetchone()[0]
+        )
+        capture_rows = _canonical_manual_capture_rows_v27(conn)
+
+        conn.execute("DROP TABLE IF EXISTS manual_capture_queue_v27")
+        _create_manual_capture_queue_table_v27(
+            conn,
+            table="manual_capture_queue_v27",
+            stable_reference=True,
+        )
+        conn.executemany(
+            """
+            INSERT INTO manual_capture_queue_v27 (
+                tenant_id, item_id, originating_url, source_id,
+                reason, retry_context_json, required_at, status,
+                imported_at, dismissed_at, capture_mode, captured_url,
+                content_sha256, content_length, note,
+                future_manual_action_required, job_id
+            ) VALUES (
+                ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+            )
+            """,
+            capture_rows,
+        )
+
+        conn.execute('DROP TABLE "manual_capture_queue"')
+        conn.execute(
+            'ALTER TABLE "manual_capture_queue_v27" '
+            'RENAME TO "manual_capture_queue"'
+        )
+        _create_manual_capture_reference_index_v27(conn)
+        _verify_manual_capture_references_v27(
+            conn,
+            expected_count=expected_count,
+        )
+        conn.execute(
+            f"PRAGMA user_version = "
+            f"{_MANUAL_CAPTURE_REFERENCE_SCHEMA_VERSION}"
+        )
+        conn.execute(
+            "RELEASE SAVEPOINT manual_capture_references_v27"
+        )
+    except BaseException:
+        conn.execute(
+            "ROLLBACK TO SAVEPOINT manual_capture_references_v27"
+        )
+        conn.execute(
+            "RELEASE SAVEPOINT manual_capture_references_v27"
+        )
+        raise
+    return list(_MANUAL_CAPTURE_REFERENCE_TABLES)
+
+
+def _verify_manual_capture_references_v27(
+    conn: sqlite3.Connection,
+    *,
+    expected_count: int,
+) -> None:
+    if not _has_manual_capture_reference_schema_v27(conn):
+        raise RuntimeError(
+            "manual-capture reference migration did not create "
+            "the stable reference schema"
+        )
+    observed_count = int(
+        conn.execute(
+            "SELECT COUNT(*) FROM manual_capture_queue"
+        ).fetchone()[0]
+    )
+    if observed_count != expected_count:
+        raise RuntimeError(
+            "manual-capture reference migration changed row count: "
+            f"expected {expected_count}, found {observed_count}"
+        )
+    orphan = conn.execute(
+        """
+        SELECT capture.job_id
+        FROM manual_capture_queue AS capture
+        LEFT JOIN jobs
+          ON jobs.tenant_id = capture.tenant_id
+         AND jobs.job_id = capture.job_id
+        WHERE capture.job_id IS NOT NULL
+          AND jobs.job_id IS NULL
+        LIMIT 1
+        """
+    ).fetchone()
+    if orphan is not None:
+        raise RuntimeError(
+            "manual-capture reference migration left an "
+            "unresolved JobId"
+        )
+    for row in conn.execute(
+        """
+        SELECT DISTINCT job_id
+        FROM manual_capture_queue
+        WHERE job_id IS NOT NULL
+        """
+    ).fetchall():
+        _validate_job_uuid(str(row[0]))
+    foreign_key_error = conn.execute(
+        "PRAGMA foreign_key_check"
+    ).fetchone()
+    if foreign_key_error is not None:
+        raise RuntimeError(
+            "manual-capture reference migration found a "
+            "foreign-key violation"
+        )
+
+
+def _reassign_manual_capture_references_v27(
+    conn: sqlite3.Connection,
+    *,
+    tenant_id: str,
+    losing_job_id: str,
+    surviving_job_id: str,
+) -> None:
+    if losing_job_id == surviving_job_id:
+        return
+    expected_count = int(
+        conn.execute(
+            "SELECT COUNT(*) FROM manual_capture_queue"
+        ).fetchone()[0]
+    )
+    conn.execute(
+        """
+        UPDATE manual_capture_queue
+        SET job_id = ?
+        WHERE tenant_id = ? AND job_id = ?
+        """,
+        (surviving_job_id, tenant_id, losing_job_id),
+    )
+    _verify_manual_capture_references_v27(
         conn,
         expected_count=expected_count,
     )

--- a/workers/automation/src/jobctrl/discovery/manual_capture_workflow.py
+++ b/workers/automation/src/jobctrl/discovery/manual_capture_workflow.py
@@ -164,14 +164,39 @@ def _capture_row(
     tenant_id: str,
     item_id: str,
 ) -> sqlite3.Row | None:
-    return conn.execute(
+    columns = {
+        str(row[1])
+        for row in conn.execute(
+            'PRAGMA table_info("manual_capture_queue")'
+        ).fetchall()
+    }
+    if "job_id" in columns:
+        reference_select = """
+        COALESCE(
+            NULLIF(TRIM(manual_capture_queue.captured_url), ''),
+            jobs.url
+        ) AS job_key
         """
-        SELECT tenant_id, item_id, originating_url, source_id, status,
+        reference_join = """
+        LEFT JOIN jobs
+          ON jobs.tenant_id = manual_capture_queue.tenant_id
+         AND jobs.job_id = manual_capture_queue.job_id
+        """
+    else:
+        reference_select = (
+            "manual_capture_queue.job_key AS job_key"
+        )
+        reference_join = ""
+    return conn.execute(
+        f"""
+        SELECT manual_capture_queue.tenant_id AS tenant_id,
+               item_id, originating_url, source_id, status,
                imported_at, capture_mode, captured_url, content_sha256,
                content_length, note, future_manual_action_required,
-               retry_context_json, job_key
+               retry_context_json, {reference_select}
         FROM manual_capture_queue
-        WHERE tenant_id = ? AND item_id = ?
+        {reference_join}
+        WHERE manual_capture_queue.tenant_id = ? AND item_id = ?
         LIMIT 1
         """,
         (tenant_id, item_id),

--- a/workers/automation/src/jobctrl/infrastructure/discovery/production_wiring.py
+++ b/workers/automation/src/jobctrl/infrastructure/discovery/production_wiring.py
@@ -21,6 +21,8 @@ from typing import Any, Iterable
 from urllib.parse import urlparse
 
 from jobctrl.database import (
+    _resolve_job_reference_value,
+    _table_columns,
     ensure_discovery_control_tables,
     ensure_enrichment_tables,
     ensure_posting_snapshot_tables,
@@ -1101,8 +1103,15 @@ def import_manual_capture_item(
             notice_text="Manual capture imported but held for review.",
         )
 
+    reference_column, reference_value = (
+        _manual_capture_job_reference(
+            conn,
+            tenant_id=str(tenant_id),
+            job_url=captured_url,
+        )
+    )
     conn.execute(
-        """
+        f"""
         UPDATE manual_capture_queue
          SET status = 'imported',
              imported_at = ?,
@@ -1113,7 +1122,7 @@ def import_manual_capture_item(
              note = ?,
              future_manual_action_required = ?,
              retry_context_json = ?,
-             job_key = ?
+             {reference_column} = ?
          WHERE tenant_id = ? AND item_id = ?
         """,
         (
@@ -1125,7 +1134,7 @@ def import_manual_capture_item(
             capture.note,
             1 if capture.future_manual_action_required else 0,
             json.dumps(retry_context, sort_keys=True),
-            captured_url,
+            reference_value,
             str(tenant_id),
             capture.item_id,
         ),
@@ -1138,6 +1147,35 @@ def import_manual_capture_item(
         promoted_to_job_enrichment=outcome.promoted_to_job_enrichment,
         quarantine_reason=quarantine_reason,
     )
+
+
+def _manual_capture_job_reference(
+    conn: sqlite3.Connection,
+    *,
+    tenant_id: str,
+    job_url: str,
+) -> tuple[str, str]:
+    reference_column = (
+        "job_id"
+        if "job_id" in _table_columns(
+            conn,
+            "manual_capture_queue",
+        )
+        else "job_key"
+    )
+    if reference_column == "job_key":
+        return reference_column, job_url
+    stable_job_id = _resolve_job_reference_value(
+        conn,
+        tenant_id=tenant_id,
+        reference=job_url,
+        legacy_url=True,
+    )
+    if stable_job_id is None:
+        raise RuntimeError(
+            "Manual capture import could not resolve its stable JobId."
+        )
+    return reference_column, stable_job_id
 
 
 def build_discovery_acceptance_report(

--- a/workers/automation/tests/test_application_feedback_candidate_identity_reference_migration.py
+++ b/workers/automation/tests/test_application_feedback_candidate_identity_reference_migration.py
@@ -331,7 +331,7 @@ def test_v21_candidates_migrate_every_alias_uuid_url_and_tenant(
     assert (
         reopened.execute("PRAGMA user_version").fetchone()[0]
         == SCHEMA_VERSION
-        == 26
+        == 27
     )
     for table in database_module._APPLICATION_FEEDBACK_CANDIDATE_TABLES:
         assert "job_id" in _columns(reopened, table)

--- a/workers/automation/tests/test_application_outcome_identity_reference_migration.py
+++ b/workers/automation/tests/test_application_outcome_identity_reference_migration.py
@@ -243,7 +243,7 @@ def test_v20_outcomes_migrate_every_alias_uuid_url_and_tenant(
     assert (
         reopened.execute("PRAGMA user_version").fetchone()[0]
         == SCHEMA_VERSION
-        == 26
+        == 27
     )
     assert "job_id" in _columns(reopened, "application_outcomes")
     assert "job_key" not in _columns(reopened, "application_outcomes")

--- a/workers/automation/tests/test_application_review_identity_reference_migration.py
+++ b/workers/automation/tests/test_application_review_identity_reference_migration.py
@@ -204,7 +204,7 @@ def test_v19_review_decisions_migrate_every_alias_and_uuid_url(
     assert (
         reopened.execute("PRAGMA user_version").fetchone()[0]
         == SCHEMA_VERSION
-        == 26
+        == 27
     )
     assert "job_id" in _columns(
         reopened,

--- a/workers/automation/tests/test_compensation_identity_reference_migration.py
+++ b/workers/automation/tests/test_compensation_identity_reference_migration.py
@@ -210,7 +210,7 @@ def test_v18_compensation_migrates_alias_winners_and_uuid_urls(
     assert (
         reopened.execute("PRAGMA user_version").fetchone()[0]
         == SCHEMA_VERSION
-        == 26
+        == 27
     )
     for table in database_module._COMPENSATION_REFERENCE_TABLES:
         assert "job_id" in _columns(reopened, table)

--- a/workers/automation/tests/test_discovery_feedback_identity_reference_migration.py
+++ b/workers/automation/tests/test_discovery_feedback_identity_reference_migration.py
@@ -10,7 +10,6 @@ import pytest
 
 import jobctrl.database as database_module
 from jobctrl.database import (
-    SCHEMA_VERSION,
     ensure_discovery_control_tables,
     ensure_discovery_feedback_references_v26,
     init_db,
@@ -174,11 +173,7 @@ def test_v25_rows_migrate_exactly_with_url_first_resolution(
         database_module._DISCOVERY_FEEDBACK_REFERENCE_TABLES
     )
 
-    assert (
-        conn.execute("PRAGMA user_version").fetchone()[0]
-        == SCHEMA_VERSION
-        == 26
-    )
+    assert conn.execute("PRAGMA user_version").fetchone()[0] == 26
     assert (
         database_module
         ._has_discovery_feedback_reference_schema_v26(conn)

--- a/workers/automation/tests/test_discovery_identity_reference_migration.py
+++ b/workers/automation/tests/test_discovery_identity_reference_migration.py
@@ -220,7 +220,7 @@ def test_v7_discovery_references_migrate_to_stable_job_id_and_reopen(
     init_db(db_path)
     close_connection(db_path)
 
-    assert _user_version(db_path) == SCHEMA_VERSION == 26
+    assert _user_version(db_path) == SCHEMA_VERSION == 27
     assert "job_id" in _columns(db_path, "job_source_observations")
     assert "job_url" not in _columns(db_path, "job_source_observations")
     assert "job_id" in _columns(db_path, "job_canonical_identities")

--- a/workers/automation/tests/test_employer_analysis_identity_reference_migration.py
+++ b/workers/automation/tests/test_employer_analysis_identity_reference_migration.py
@@ -242,7 +242,7 @@ def test_v15_employer_analysis_migrates_alias_histories_and_uuid_urls(
     assert (
         reopened.execute("PRAGMA user_version").fetchone()[0]
         == SCHEMA_VERSION
-        == 26
+        == 27
     )
     for table in database_module._EMPLOYER_ANALYSIS_REFERENCE_TABLES:
         assert "job_id" in _columns(reopened, table)

--- a/workers/automation/tests/test_enrichment_snapshot_identity_reference_migration.py
+++ b/workers/automation/tests/test_enrichment_snapshot_identity_reference_migration.py
@@ -322,7 +322,7 @@ def test_v10_enrichment_snapshot_references_migrate_and_reopen(
     init_db(db_path)
     close_connection(db_path)
 
-    assert _user_version(db_path) == SCHEMA_VERSION == 26
+    assert _user_version(db_path) == SCHEMA_VERSION == 27
     check = sqlite3.connect(db_path)
     try:
         enrichment_rows = check.execute(

--- a/workers/automation/tests/test_execution_search_identity_reference_migration.py
+++ b/workers/automation/tests/test_execution_search_identity_reference_migration.py
@@ -261,7 +261,7 @@ def test_v8_execution_and_receipts_migrate_to_stable_job_id_and_reopen(
     init_db(db_path)
     close_connection(db_path)
 
-    assert _user_version(db_path) == SCHEMA_VERSION == 26
+    assert _user_version(db_path) == SCHEMA_VERSION == 27
     assert "job_id" in _columns(db_path, "discovery_execution_jobs")
     assert "job_url" not in _columns(db_path, "discovery_execution_jobs")
     assert "job_id" in _columns(db_path, "discovery_search_unit_jobs")

--- a/workers/automation/tests/test_interview_prep_identity_reference_migration.py
+++ b/workers/automation/tests/test_interview_prep_identity_reference_migration.py
@@ -323,7 +323,7 @@ def test_v17_interview_prep_migrates_alias_histories_and_uuid_urls(
     assert (
         reopened.execute("PRAGMA user_version").fetchone()[0]
         == SCHEMA_VERSION
-        == 26
+        == 27
     )
     for table in database_module._INTERVIEW_PREP_REFERENCE_TABLES:
         assert "job_id" in _columns(reopened, table)

--- a/workers/automation/tests/test_manual_capture_identity_reference_migration.py
+++ b/workers/automation/tests/test_manual_capture_identity_reference_migration.py
@@ -1,0 +1,506 @@
+"""Schema-v27 manual-capture stable JobId contracts."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import jobctrl.database as database_module
+from jobctrl.database import (
+    SCHEMA_VERSION,
+    ensure_discovery_control_tables,
+    ensure_manual_capture_references_v27,
+    init_db,
+    reassign_discovery_identity_references,
+)
+
+PREVIOUS_SCHEMA_VERSION = 26
+NOW = "2026-07-30T12:00:00+00:00"
+UUID_SHAPED_URL = "11111111-1111-4111-8111-111111111111"
+TARGET_JOB_ID = "22222222-2222-4222-8222-222222222222"
+COLLIDING_JOB_ID = UUID_SHAPED_URL
+PRIOR_JOB_ID = "33333333-3333-4333-8333-333333333333"
+SURVIVOR_JOB_ID = "44444444-4444-4444-8444-444444444444"
+
+
+def _columns(
+    conn: sqlite3.Connection,
+    table: str,
+) -> set[str]:
+    return {
+        str(row[1])
+        for row in conn.execute(
+            f'PRAGMA table_info("{table}")'
+        ).fetchall()
+    }
+
+
+def _insert_job(
+    conn: sqlite3.Connection,
+    *,
+    url: str,
+    job_id: str,
+    tenant_id: str = "local",
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO jobs (
+            url, tenant_id, job_id, title, company, discovered_at
+        ) VALUES (?, ?, ?, 'Platform Engineer', 'ExampleCo', ?)
+        """,
+        (url, tenant_id, job_id, NOW),
+    )
+
+
+def _downgrade_manual_capture_table_to_v26(
+    conn: sqlite3.Connection,
+) -> None:
+    conn.commit()
+    conn.execute("PRAGMA foreign_keys = OFF")
+    conn.execute("DROP TABLE manual_capture_queue")
+    database_module._create_manual_capture_queue_table_v27(
+        conn,
+        table="manual_capture_queue",
+        stable_reference=False,
+    )
+    conn.execute(
+        f"PRAGMA user_version = {PREVIOUS_SCHEMA_VERSION}"
+    )
+    conn.commit()
+    conn.execute("PRAGMA foreign_keys = ON")
+
+
+def _seed_v26_database(db_path: Path) -> sqlite3.Connection:
+    conn = init_db(db_path)
+    conn.row_factory = sqlite3.Row
+    _downgrade_manual_capture_table_to_v26(conn)
+    return conn
+
+
+def _capture_snapshot(
+    conn: sqlite3.Connection,
+) -> list[tuple[Any, ...]]:
+    return [
+        tuple(row)
+        for row in conn.execute(
+            """
+            SELECT * FROM manual_capture_queue
+            ORDER BY tenant_id, item_id
+            """
+        ).fetchall()
+    ]
+
+
+def _capture_payload_snapshot(
+    conn: sqlite3.Connection,
+) -> list[tuple[Any, ...]]:
+    return [
+        tuple(row)
+        for row in conn.execute(
+            """
+            SELECT tenant_id, item_id, originating_url, source_id,
+                   reason, retry_context_json, required_at, status,
+                   imported_at, dismissed_at, capture_mode,
+                   captured_url, content_sha256, content_length,
+                   note, future_manual_action_required
+            FROM manual_capture_queue
+            ORDER BY tenant_id, item_id
+            """
+        ).fetchall()
+    ]
+
+
+def test_v26_rows_migrate_exactly_with_url_first_resolution(
+    tmp_path: Path,
+) -> None:
+    conn = _seed_v26_database(tmp_path / "jobs.db")
+    colliding_owner_url = (
+        "https://careers.example.test/uuid-id-owner"
+    )
+    prior_url = "https://careers.example.test/prior"
+    prior_alias = "https://legacy.example.test/prior"
+    blue_target_url = "https://blue.example.test/target"
+    _insert_job(
+        conn,
+        url=UUID_SHAPED_URL,
+        job_id=TARGET_JOB_ID,
+    )
+    _insert_job(
+        conn,
+        url=colliding_owner_url,
+        job_id=COLLIDING_JOB_ID,
+    )
+    _insert_job(conn, url=prior_url, job_id=PRIOR_JOB_ID)
+    _insert_job(
+        conn,
+        url=blue_target_url,
+        job_id=TARGET_JOB_ID,
+        tenant_id="blue",
+    )
+    conn.execute(
+        """
+        INSERT INTO job_identity_aliases (
+            tenant_id, alias_kind, alias_value, job_id, created_at
+        ) VALUES ('local', 'posting_url', ?, ?, ?)
+        """,
+        (prior_alias, PRIOR_JOB_ID, NOW),
+    )
+    conn.executemany(
+        """
+        INSERT INTO manual_capture_queue (
+            tenant_id, item_id, originating_url, source_id,
+            reason, retry_context_json, required_at, status,
+            imported_at, dismissed_at, capture_mode, captured_url,
+            content_sha256, content_length, note,
+            future_manual_action_required, job_key
+        ) VALUES (
+            ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+        )
+        """,
+        (
+            (
+                "local",
+                "capture:uuid-url",
+                "https://login.example.test/source",
+                "source:one",
+                "login_required",
+                '{"private":"exact","unicode":"café"}',
+                NOW,
+                "imported",
+                NOW,
+                None,
+                "saved_html",
+                UUID_SHAPED_URL,
+                "a" * 64,
+                1234,
+                "private: multiline\ncapture note",
+                1,
+                UUID_SHAPED_URL,
+            ),
+            (
+                "local",
+                "capture:alias",
+                prior_alias,
+                "source:alias",
+                "browser_extension_capture",
+                '{"source":"browser_extension"}',
+                NOW,
+                "dismissed",
+                NOW,
+                NOW,
+                "current_page",
+                prior_alias,
+                "b" * 64,
+                4321,
+                "private: dismissed note",
+                0,
+                prior_alias,
+            ),
+            (
+                "local",
+                "capture:pending",
+                "https://protected.example.test/pending",
+                None,
+                "captcha",
+                '{"pending":true}',
+                NOW,
+                "pending",
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                0,
+                None,
+            ),
+            (
+                "blue",
+                "capture:blue",
+                blue_target_url,
+                "source:blue",
+                "paywall",
+                '{"tenant":"blue"}',
+                NOW,
+                "imported",
+                NOW,
+                None,
+                "copied_url",
+                blue_target_url,
+                "c" * 64,
+                99,
+                "private: blue note",
+                0,
+                blue_target_url,
+            ),
+        ),
+    )
+    conn.commit()
+    before_payload = _capture_payload_snapshot(conn)
+
+    assert ensure_manual_capture_references_v27(
+        conn
+    ) == list(
+        database_module._MANUAL_CAPTURE_REFERENCE_TABLES
+    )
+
+    assert (
+        conn.execute("PRAGMA user_version").fetchone()[0]
+        == SCHEMA_VERSION
+        == 27
+    )
+    assert (
+        database_module
+        ._has_manual_capture_reference_schema_v27(conn)
+    )
+    assert _capture_payload_snapshot(conn) == before_payload
+    assert [
+        tuple(row)
+        for row in conn.execute(
+            """
+            SELECT tenant_id, item_id, job_id
+            FROM manual_capture_queue
+            ORDER BY tenant_id, item_id
+            """
+        ).fetchall()
+    ] == [
+        ("blue", "capture:blue", TARGET_JOB_ID),
+        ("local", "capture:alias", PRIOR_JOB_ID),
+        ("local", "capture:pending", None),
+        ("local", "capture:uuid-url", TARGET_JOB_ID),
+    ]
+    assert {
+        str(row[6]).upper()
+        for row in conn.execute(
+            'PRAGMA foreign_key_list("manual_capture_queue")'
+        ).fetchall()
+    } == {"CASCADE"}
+    assert conn.execute(
+        "PRAGMA foreign_key_check"
+    ).fetchone() is None
+
+
+def test_unresolved_reference_rolls_back_and_retry_succeeds(
+    tmp_path: Path,
+) -> None:
+    conn = _seed_v26_database(tmp_path / "retry.db")
+    missing_url = "https://careers.example.test/retry"
+    conn.execute(
+        """
+        INSERT INTO manual_capture_queue (
+            tenant_id, item_id, originating_url, reason,
+            retry_context_json, required_at, status,
+            imported_at, captured_url, job_key
+        ) VALUES (
+            'local', 'capture:retry', ?, 'login_required',
+            '{}', ?, 'imported', ?, ?, ?
+        )
+        """,
+        (missing_url, NOW, NOW, missing_url, missing_url),
+    )
+    conn.commit()
+    before = _capture_snapshot(conn)
+
+    with pytest.raises(
+        RuntimeError,
+        match="could not resolve manual_capture_queue.job_key",
+    ):
+        ensure_manual_capture_references_v27(conn)
+
+    assert (
+        conn.execute("PRAGMA user_version").fetchone()[0]
+        == PREVIOUS_SCHEMA_VERSION
+    )
+    assert _capture_snapshot(conn) == before
+    assert "job_key" in _columns(conn, "manual_capture_queue")
+    assert "job_id" not in _columns(conn, "manual_capture_queue")
+    assert conn.execute(
+        """
+        SELECT COUNT(*) FROM sqlite_master
+        WHERE type = 'table' AND name = 'manual_capture_queue_v27'
+        """
+    ).fetchone()[0] == 0
+
+    _insert_job(conn, url=missing_url, job_id=TARGET_JOB_ID)
+    conn.commit()
+    ensure_manual_capture_references_v27(conn)
+    assert conn.execute(
+        "SELECT job_id FROM manual_capture_queue"
+    ).fetchone()[0] == TARGET_JOB_ID
+
+
+def test_verification_failure_rolls_back_and_retry_succeeds(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    conn = _seed_v26_database(tmp_path / "verify.db")
+    job_url = "https://careers.example.test/verify"
+    _insert_job(conn, url=job_url, job_id=TARGET_JOB_ID)
+    conn.execute(
+        """
+        INSERT INTO manual_capture_queue (
+            tenant_id, item_id, originating_url, reason,
+            retry_context_json, required_at, status,
+            imported_at, captured_url, note, job_key
+        ) VALUES (
+            'local', 'capture:verify', ?, 'login_required',
+            '{"private":"verify"}', ?, 'imported',
+            ?, ?, 'private: verification note', ?
+        )
+        """,
+        (job_url, NOW, NOW, job_url, job_url),
+    )
+    conn.commit()
+    before = _capture_snapshot(conn)
+    original_verify = (
+        database_module._verify_manual_capture_references_v27
+    )
+
+    def _fail_verification(
+        _conn: sqlite3.Connection,
+        *,
+        expected_count: int,
+    ) -> None:
+        del expected_count
+        raise RuntimeError(
+            "injected manual-capture verification failure"
+        )
+
+    monkeypatch.setattr(
+        database_module,
+        "_verify_manual_capture_references_v27",
+        _fail_verification,
+    )
+    with pytest.raises(
+        RuntimeError,
+        match="injected manual-capture verification failure",
+    ):
+        ensure_manual_capture_references_v27(conn)
+    assert (
+        conn.execute("PRAGMA user_version").fetchone()[0]
+        == PREVIOUS_SCHEMA_VERSION
+    )
+    assert _capture_snapshot(conn) == before
+    assert "job_key" in _columns(conn, "manual_capture_queue")
+
+    monkeypatch.setattr(
+        database_module,
+        "_verify_manual_capture_references_v27",
+        original_verify,
+    )
+    ensure_manual_capture_references_v27(conn)
+    assert conn.execute(
+        "SELECT job_id FROM manual_capture_queue"
+    ).fetchone()[0] == TARGET_JOB_ID
+
+
+@pytest.mark.parametrize(
+    ("schema_version", "expected_reference"),
+    ((0, "job_key"), (26, "job_key"), (27, "job_id")),
+)
+def test_missing_table_recovery_is_schema_version_aware(
+    schema_version: int,
+    expected_reference: str,
+) -> None:
+    conn = sqlite3.connect(":memory:")
+    conn.executescript(
+        f"""
+        CREATE TABLE jobs (
+            url TEXT PRIMARY KEY,
+            tenant_id TEXT NOT NULL DEFAULT 'local',
+            job_id TEXT NOT NULL,
+            UNIQUE (tenant_id, job_id)
+        );
+        PRAGMA user_version = {schema_version};
+        """
+    )
+
+    ensure_discovery_control_tables(conn)
+
+    assert expected_reference in _columns(
+        conn,
+        "manual_capture_queue",
+    )
+    if schema_version == 27:
+        assert (
+            database_module
+            ._has_manual_capture_reference_schema_v27(conn)
+        )
+
+
+def test_stamped_v27_legacy_table_fails_closed() -> None:
+    conn = sqlite3.connect(":memory:")
+    conn.executescript(
+        """
+        CREATE TABLE jobs (
+            url TEXT PRIMARY KEY,
+            tenant_id TEXT NOT NULL DEFAULT 'local',
+            job_id TEXT NOT NULL,
+            UNIQUE (tenant_id, job_id)
+        );
+        PRAGMA user_version = 26;
+        """
+    )
+    ensure_discovery_control_tables(conn)
+    conn.execute("PRAGMA user_version = 27")
+
+    with pytest.raises(
+        RuntimeError,
+        match="Schema v27 requires stable manual-capture",
+    ):
+        ensure_discovery_control_tables(conn)
+
+
+def test_runtime_collision_rehomes_imported_capture(
+    tmp_path: Path,
+) -> None:
+    conn = init_db(tmp_path / "collision.db")
+    losing_url = "https://careers.example.test/losing"
+    surviving_url = "https://careers.example.test/surviving"
+    _insert_job(conn, url=losing_url, job_id=TARGET_JOB_ID)
+    _insert_job(
+        conn,
+        url=surviving_url,
+        job_id=SURVIVOR_JOB_ID,
+    )
+    conn.execute(
+        """
+        INSERT INTO manual_capture_queue (
+            tenant_id, item_id, originating_url, reason,
+            retry_context_json, required_at, status,
+            imported_at, captured_url, note, job_id
+        ) VALUES (
+            'local', 'capture:collision', ?, 'login_required',
+            '{"private":"collision"}', ?, 'imported',
+            ?, ?, 'private: collision note', ?
+        )
+        """,
+        (losing_url, NOW, NOW, losing_url, TARGET_JOB_ID),
+    )
+    conn.commit()
+
+    reassign_discovery_identity_references(
+        conn,
+        losing_job_url=losing_url,
+        surviving_job_url=surviving_url,
+    )
+
+    row = conn.execute(
+        """
+        SELECT job_id, captured_url, note
+        FROM manual_capture_queue
+        WHERE item_id = 'capture:collision'
+        """
+    ).fetchone()
+    assert tuple(row) == (
+        SURVIVOR_JOB_ID,
+        losing_url,
+        "private: collision note",
+    )
+    assert conn.execute(
+        "PRAGMA foreign_key_check"
+    ).fetchone() is None

--- a/workers/automation/tests/test_manual_capture_workflow.py
+++ b/workers/automation/tests/test_manual_capture_workflow.py
@@ -16,7 +16,12 @@ from temporalio.testing import WorkflowEnvironment
 from temporalio.worker import UnsandboxedWorkflowRunner, Worker
 
 from jobctrl import config
-from jobctrl.database import close_connection, get_connection, init_db
+from jobctrl.database import (
+    close_connection,
+    get_connection,
+    init_db,
+    reassign_discovery_identity_references,
+)
 from jobctrl.discovery.manual_capture_workflow import (
     ManualCaptureImportActivityOutput,
     ManualCaptureImportWorkflow,
@@ -37,6 +42,10 @@ from jobctrl.workflow_specs import build_manual_capture_import_workflow_spec
 
 
 _CAPTURE_URL = "https://example.test/jobs/staff-engineer"
+_CANONICAL_URL = "https://example.test/jobs/staff-engineer-canonical"
+_SURVIVOR_URL = "https://example.test/jobs/staff-engineer-survivor"
+_CANONICAL_JOB_ID = "11111111-1111-4111-8111-111111111111"
+_SURVIVOR_JOB_ID = "22222222-2222-4222-8222-222222222222"
 _CAPTURE_HTML = """
 <html>
   <head>
@@ -198,9 +207,17 @@ def test_activity_reconstructs_exact_result_after_import_commit(tmp_path: Path) 
             (_CAPTURE_URL,),
         ).fetchone()[0]
         row = conn.execute(
-            "SELECT status, content_sha256, imported_at FROM manual_capture_queue "
+            "SELECT status, content_sha256, imported_at, job_id "
+            "FROM manual_capture_queue "
             "WHERE tenant_id = 'local' AND item_id = 'manual-1'"
         ).fetchone()
+        stable_job_id = conn.execute(
+            """
+            SELECT job_id FROM jobs
+            WHERE tenant_id = 'local' AND url = ?
+            """,
+            (_CAPTURE_URL,),
+        ).fetchone()[0]
     finally:
         close_connection(db_path)
 
@@ -209,12 +226,117 @@ def test_activity_reconstructs_exact_result_after_import_commit(tmp_path: Path) 
     assert first.item_id == "manual-1"
     assert first.job_id == _CAPTURE_URL
     assert first.imported_at == row["imported_at"]
+    assert row["job_id"] == stable_job_id
     assert row["status"] == "imported"
     assert row["content_sha256"] == hashlib.sha256(
         _CAPTURE_HTML.encode("utf-8")
     ).hexdigest()
     assert events_after_replay == events_before_replay
     assert snapshot_version_after_replay == snapshot_version_before_replay
+
+
+def test_activity_replays_accepted_alias_as_original_capture_url(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    conn = _seed_pending(db_path)
+    payload = _pending_payload()
+    conn.execute(
+        """
+        INSERT INTO jobs (
+            url, tenant_id, job_id, title, company, discovered_at
+        ) VALUES (?, 'local', ?, 'Staff Engineer', 'ExampleCo', ?)
+        """,
+        (
+            _CANONICAL_URL,
+            _CANONICAL_JOB_ID,
+            "2026-07-10T08:00:00+00:00",
+        ),
+    )
+    conn.execute(
+        """
+        INSERT INTO job_identity_aliases (
+            tenant_id, alias_kind, alias_value, job_id, created_at
+        ) VALUES ('local', 'posting_url', ?, ?, ?)
+        """,
+        (
+            _CAPTURE_URL,
+            _CANONICAL_JOB_ID,
+            "2026-07-10T08:00:00+00:00",
+        ),
+    )
+    conn.commit()
+    try:
+        first = execute_manual_capture_import(payload, conn=conn)
+        replay = execute_manual_capture_import(payload, conn=conn)
+        stored = conn.execute(
+            """
+            SELECT job_id, captured_url
+            FROM manual_capture_queue
+            WHERE tenant_id = 'local' AND item_id = 'manual-1'
+            """
+        ).fetchone()
+    finally:
+        close_connection(db_path)
+
+    assert replay == first
+    assert replay.job_id == _CAPTURE_URL
+    assert tuple(stored) == (_CANONICAL_JOB_ID, _CAPTURE_URL)
+
+
+def test_activity_replays_original_result_after_identity_collision(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    conn = _seed_pending(db_path)
+    payload = _pending_payload()
+    try:
+        first = execute_manual_capture_import(payload, conn=conn)
+        losing_job_id = conn.execute(
+            """
+            SELECT job_id FROM jobs
+            WHERE tenant_id = 'local' AND url = ?
+            """,
+            (_CAPTURE_URL,),
+        ).fetchone()[0]
+        conn.execute(
+            """
+            INSERT INTO jobs (
+                url, tenant_id, job_id, title, company, discovered_at
+            ) VALUES (?, 'local', ?, 'Staff Engineer', 'ExampleCo', ?)
+            """,
+            (
+                _SURVIVOR_URL,
+                _SURVIVOR_JOB_ID,
+                "2026-07-10T08:00:00+00:00",
+            ),
+        )
+        conn.commit()
+        reassign_discovery_identity_references(
+            conn,
+            losing_job_url=_CAPTURE_URL,
+            surviving_job_url=_SURVIVOR_URL,
+        )
+        conn.execute(
+            "DELETE FROM jobs WHERE tenant_id = 'local' AND job_id = ?",
+            (losing_job_id,),
+        )
+        conn.commit()
+
+        replay = execute_manual_capture_import(payload, conn=conn)
+        stored = conn.execute(
+            """
+            SELECT job_id, captured_url
+            FROM manual_capture_queue
+            WHERE tenant_id = 'local' AND item_id = 'manual-1'
+            """
+        ).fetchone()
+    finally:
+        close_connection(db_path)
+
+    assert replay == first
+    assert replay.job_id == _CAPTURE_URL
+    assert tuple(stored) == (_SURVIVOR_JOB_ID, _CAPTURE_URL)
 
 
 @pytest.mark.parametrize(

--- a/workers/automation/tests/test_materials_identity_reference_migration.py
+++ b/workers/automation/tests/test_materials_identity_reference_migration.py
@@ -293,7 +293,7 @@ def test_v14_materials_migrate_alias_histories_and_uuid_shaped_urls(
     close_connection(db_path)
 
     reopened = init_db(db_path)
-    assert reopened.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_VERSION == 26
+    assert reopened.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_VERSION == 27
     for table in database_module._MATERIALS_REFERENCE_TABLES:
         assert "job_id" in _columns(reopened, table)
         assert "job_url" not in _columns(reopened, table)

--- a/workers/automation/tests/test_preparation_identity_reference_migration.py
+++ b/workers/automation/tests/test_preparation_identity_reference_migration.py
@@ -177,7 +177,7 @@ def test_v9_preparation_references_migrate_to_stable_job_ids_and_reopen(
     init_db(db_path)
     close_connection(db_path)
 
-    assert _user_version(db_path) == SCHEMA_VERSION == 26
+    assert _user_version(db_path) == SCHEMA_VERSION == 27
     check = sqlite3.connect(db_path)
     try:
         rows = check.execute(

--- a/workers/automation/tests/test_repeat_application_identity_reference_migration.py
+++ b/workers/automation/tests/test_repeat_application_identity_reference_migration.py
@@ -402,7 +402,7 @@ def test_v22_history_migrates_exactly_with_url_first_resolution(
     reopened = init_db(db_path)
     assert reopened.execute("PRAGMA user_version").fetchone()[0] == (
         SCHEMA_VERSION
-    ) == 26
+    ) == 27
     assert database_module._has_repeat_application_reference_schema_v23(
         reopened
     )

--- a/workers/automation/tests/test_repeat_application_prevention.py
+++ b/workers/automation/tests/test_repeat_application_prevention.py
@@ -799,7 +799,7 @@ def test_schema_v5_migrates_additively_without_changing_application_facts(
         (PRIOR,),
     ).fetchall()
 
-    assert int(migrated.execute("PRAGMA user_version").fetchone()[0]) == SCHEMA_VERSION == 26
+    assert int(migrated.execute("PRAGMA user_version").fetchone()[0]) == SCHEMA_VERSION == 27
     assert [tuple(row) for row in after] == [tuple(row) for row in before]
     assert "metadata_json" in {
         str(row[1]) for row in migrated.execute("PRAGMA table_info(job_stage_states)").fetchall()

--- a/workers/automation/tests/test_resume_template_identity_reference_migration.py
+++ b/workers/automation/tests/test_resume_template_identity_reference_migration.py
@@ -254,7 +254,7 @@ def test_v16_template_references_migrate_aliases_and_uuid_urls(
     assert (
         reopened.execute("PRAGMA user_version").fetchone()[0]
         == SCHEMA_VERSION
-        == 26
+        == 27
     )
     for table in database_module._RESUME_TEMPLATE_REFERENCE_TABLES:
         assert "job_id" in _columns(reopened, table)

--- a/workers/automation/tests/test_scoring_identity_reference_migration.py
+++ b/workers/automation/tests/test_scoring_identity_reference_migration.py
@@ -338,7 +338,7 @@ def test_v11_scoring_references_migrate_alias_histories_and_reopen(
     assert (
         int(migrated.execute("PRAGMA user_version").fetchone()[0])
         == SCHEMA_VERSION
-        == 26
+        == 27
     )
     assert _columns(migrated, "job_scores") >= {"tenant_id", "job_id"}
     assert "job_url" not in _columns(migrated, "job_scores")
@@ -404,7 +404,7 @@ def test_v11_scoring_references_migrate_alias_histories_and_reopen(
     assert (
         int(reopened.execute("PRAGMA user_version").fetchone()[0])
         == SCHEMA_VERSION
-        == 26
+        == 27
     )
 
 
@@ -553,7 +553,7 @@ def test_scoring_migration_rolls_back_and_retries_after_verification_failure(
     assert (
         int(retried.execute("PRAGMA user_version").fetchone()[0])
         == SCHEMA_VERSION
-        == 26
+        == 27
     )
     assert [
         tuple(row)

--- a/workers/automation/tests/test_stable_job_identity_migration.py
+++ b/workers/automation/tests/test_stable_job_identity_migration.py
@@ -841,7 +841,7 @@ def test_v6_jobs_gain_stable_uuid_and_posting_url_alias_once(
     init_db(db_path)
     close_connection(db_path)
 
-    assert _user_version(db_path) == SCHEMA_VERSION == 26
+    assert _user_version(db_path) == SCHEMA_VERSION == 27
     first_ids = _identity_rows(db_path)
     assert [row[0] for row in first_ids] == ["local", "local"]
     for _tenant_id, job_id, _url in first_ids:


### PR DESCRIPTION
## Summary

- migrate nullable `manual_capture_queue.job_key` links to tenant-scoped stable `job_id` references in schema v27 while leaving pending captures unlinked
- preserve the URL-shaped workflow/API contract and every private capture/provenance field; compatibility reads prefer immutable `captured_url` and only fall back to the job's current URL for incomplete historical rows
- resolve UUID-shaped URLs URL-first with alias and tenant isolation, verify exact row preservation, and make migration rollback/retry and stamped-schema failure explicit
- re-home imported captures during identity collisions and preserve permanent-deletion behavior with SQLite foreign keys enabled or disabled
- add regressions for accepted-alias replay and import → collision rehome → original replay, preventing stable identity changes from corrupting an already-committed result

## Stack

- depends on #553
- this PR is intentionally limited to `manual_capture_queue`; `discovery_quarantine_entries` follows as its own reviewable PR because it needs a separate duplicate-row merge policy
- the durable feedback input remains attached to the later auditable learning-ledger phase
- canonical product docs and cumulative product QA are deferred to the final PR in this approved unreleased stack

## Validation

- `pnpm --filter @jobctrl/api test` — 719 passed
- `pnpm --filter @jobctrl/api check` — passed
- `pnpm --filter @jobctrl/web check` — passed
- `PYTHONPATH=src .../.venv/bin/python -m pytest -q` — 2,770 passed, 2 skipped
- focused accepted-alias and post-collision replay regressions — 2 passed (both reproduced `capture_replay_mismatch` before the fix)
- focused API schema-v27 suite — 5 passed
- `.../.venv/bin/ruff check .` — passed
- `uv lock --check --exclude-newer 2026-07-09T19:15:43.240437Z` — passed
- `git diff --check` — passed
- independent Tier 3 review — PASS, no findings after required High replay fix
- independent Tier 3 QA — PASS, no findings after adversarial rehome/replay verification