### PR TITLE
feat(discovery): migrate quarantine links to stable JobIds

### DIFF
--- a/apps/api/src/db.ts
+++ b/apps/api/src/db.ts
@@ -9,7 +9,7 @@ export type SqliteValue = string | number | bigint | null;
 // writer that stamps ``PRAGMA user_version``; the API only reads it to fail
 // closed on a database written by a newer build. Bump both constants together
 // whenever the schema shape changes.
-export const SUPPORTED_SCHEMA_VERSION = 27;
+export const SUPPORTED_SCHEMA_VERSION = 28;
 
 export class IncompatibleSchemaVersionError extends Error {
   constructor(current: number) {

--- a/apps/api/src/discovery-controls.ts
+++ b/apps/api/src/discovery-controls.ts
@@ -68,6 +68,7 @@ import { InputError } from "./write-model.js";
 const DEFAULT_TENANT = "local";
 const DISCOVERY_FEEDBACK_REFERENCE_SCHEMA_VERSION = 26;
 const MANUAL_CAPTURE_REFERENCE_SCHEMA_VERSION = 27;
+const QUARANTINE_REFERENCE_SCHEMA_VERSION = 28;
 export const EXTENSION_MANUAL_CAPTURE_SOURCE_ID = "manual_capture:extension";
 const EXTENSION_MANUAL_CAPTURE_REASON: ManualActionReasonValue = "browser_extension_capture";
 const DEFAULT_DISCOVERY_SETTINGS: DiscoverySettings = {
@@ -174,6 +175,7 @@ interface PreviewObservationRow extends Record<string, unknown> {
 interface QuarantineEntryRow extends Record<string, unknown> {
   job_id: string;
   job_key: string;
+  canonical_job_url: string;
   title: string;
   company: string;
   source_id: string;
@@ -249,6 +251,8 @@ export function ensureDiscoveryControlTables(db: SqliteDatabase): void {
     schemaVersion >= DISCOVERY_FEEDBACK_REFERENCE_SCHEMA_VERSION;
   const stableManualCaptureReferences =
     schemaVersion >= MANUAL_CAPTURE_REFERENCE_SCHEMA_VERSION;
+  const stableQuarantineReferences =
+    schemaVersion >= QUARANTINE_REFERENCE_SCHEMA_VERSION;
   db.exec(`
     CREATE TABLE IF NOT EXISTS discovery_settings (
       tenant_id          TEXT PRIMARY KEY,
@@ -282,24 +286,6 @@ export function ensureDiscoveryControlTables(db: SqliteDatabase): void {
       discovered_at            TEXT NOT NULL,
       PRIMARY KEY (tenant_id, candidate_id)
     );
-    CREATE TABLE IF NOT EXISTS discovery_quarantine_entries (
-      tenant_id        TEXT NOT NULL DEFAULT 'local',
-      job_id           TEXT NOT NULL,
-      job_key          TEXT NOT NULL,
-      title            TEXT NOT NULL DEFAULT '',
-      company          TEXT NOT NULL DEFAULT '',
-      source_id        TEXT NOT NULL,
-      posting_url      TEXT,
-      reason           TEXT NOT NULL,
-      confidence       REAL,
-      snapshot_version INTEGER,
-      captured_at      TEXT,
-      notice_text      TEXT,
-      status           TEXT NOT NULL DEFAULT 'pending',
-      decision_reason  TEXT,
-      decided_at       TEXT,
-      PRIMARY KEY (tenant_id, job_key)
-    );
     CREATE TABLE IF NOT EXISTS role_match_feedback_suggestions (
       tenant_id       TEXT NOT NULL DEFAULT 'local',
       suggestion_id   TEXT NOT NULL,
@@ -319,6 +305,84 @@ export function ensureDiscoveryControlTables(db: SqliteDatabase): void {
       PRIMARY KEY (tenant_id, suggestion_id)
     );
   `);
+  if (!tableExists(db, "discovery_quarantine_entries")) {
+    const identityColumns = stableQuarantineReferences
+      ? "job_id TEXT NOT NULL"
+      : `job_id TEXT NOT NULL,
+        job_key TEXT NOT NULL`;
+    const primaryKey = stableQuarantineReferences
+      ? "PRIMARY KEY (tenant_id, job_id)"
+      : "PRIMARY KEY (tenant_id, job_key)";
+    const foreignKey = stableQuarantineReferences
+      ? `,
+        FOREIGN KEY (tenant_id, job_id)
+          REFERENCES jobs(tenant_id, job_id) ON DELETE CASCADE`
+      : "";
+    db.exec(`
+      CREATE TABLE discovery_quarantine_entries (
+        tenant_id        TEXT NOT NULL DEFAULT 'local',
+        ${identityColumns},
+        title            TEXT NOT NULL DEFAULT '',
+        company          TEXT NOT NULL DEFAULT '',
+        source_id        TEXT NOT NULL,
+        posting_url      TEXT,
+        reason           TEXT NOT NULL,
+        confidence       REAL,
+        snapshot_version INTEGER,
+        captured_at      TEXT,
+        notice_text      TEXT,
+        status           TEXT NOT NULL DEFAULT 'pending',
+        decision_reason  TEXT,
+        decided_at       TEXT,
+        ${primaryKey}
+        ${foreignKey}
+      );
+    `);
+  }
+  const quarantineColumns = tableColumnSet(
+    db,
+    "discovery_quarantine_entries",
+  );
+  if (
+    stableQuarantineReferences
+    && (
+      !quarantineColumns.has("job_id")
+      || quarantineColumns.has("job_key")
+    )
+  ) {
+    throw new Error(
+      "Schema v28 requires stable Discovery quarantine JobId references.",
+    );
+  }
+  if (stableQuarantineReferences) {
+    db.exec(`
+      CREATE INDEX IF NOT EXISTS idx_discovery_quarantine_status
+      ON discovery_quarantine_entries(
+        tenant_id,
+        status,
+        captured_at
+      );
+    `);
+    if (
+      !hasCompositeJobIdForeignKey(
+        db,
+        "discovery_quarantine_entries",
+      )
+      || tableIndexColumns(
+        db,
+        "discovery_quarantine_entries",
+        "idx_discovery_quarantine_status",
+      ).join(",") !== "tenant_id,status,captured_at"
+      || primaryKeyColumns(
+        db,
+        "discovery_quarantine_entries",
+      ).join(",") !== "tenant_id,job_id"
+    ) {
+      throw new Error(
+        "Schema v28 requires the stable Discovery quarantine JobId contract.",
+      );
+    }
+  }
   if (!tableExists(db, "manual_capture_queue")) {
     const referenceColumn = stableManualCaptureReferences
       ? "job_id"
@@ -1062,13 +1126,22 @@ export function rejectSourceLocatorCandidate(
 
 export function listQuarantine(db: SqliteDatabase): QuarantineListResponse {
   ensureDiscoveryControlTables(db);
+  const reference = quarantineReferenceProjection(db);
   const rows = allRows<QuarantineEntryRow>(
     db,
-    `SELECT job_id, job_key, title, company, source_id, posting_url, reason,
-            confidence, snapshot_version, captured_at, notice_text
-     FROM discovery_quarantine_entries
-     WHERE tenant_id = ? AND status = 'pending'
-     ORDER BY captured_at DESC, job_key ASC`,
+    `SELECT ${reference.urlSql} AS job_id,
+            ${reference.urlSql} AS job_key,
+            ${reference.eventUrlSql} AS canonical_job_url,
+            quarantine.title, quarantine.company,
+            quarantine.source_id, quarantine.posting_url,
+            quarantine.reason, quarantine.confidence,
+            quarantine.snapshot_version, quarantine.captured_at,
+            quarantine.notice_text
+     FROM discovery_quarantine_entries AS quarantine
+     ${reference.joinSql}
+     WHERE quarantine.tenant_id = ?
+       AND quarantine.status = 'pending'
+     ORDER BY quarantine.captured_at DESC, job_key ASC`,
     [DEFAULT_TENANT],
   );
   return {
@@ -1096,34 +1169,64 @@ export function decideQuarantineEntry(
 ): QuarantineDecisionResponse {
   ensureDiscoveryControlTables(db);
   const now = new Date().toISOString();
+  const reference = quarantineReferenceProjection(db);
+  let storedReference: string;
+  try {
+    storedReference = quarantineReferenceForUrl(
+      db,
+      jobKey,
+    );
+  } catch {
+    throw new InputError(
+      `No stable Job identity for ${jobKey}.`,
+    );
+  }
   const row = getRow<QuarantineEntryRow>(
     db,
-    `SELECT job_id, job_key, title, company, source_id, posting_url, reason,
-            confidence, snapshot_version, captured_at, notice_text
-     FROM discovery_quarantine_entries
-     WHERE tenant_id = ? AND job_key = ? AND status = 'pending'`,
-    [DEFAULT_TENANT, jobKey],
+    `SELECT ${reference.urlSql} AS job_id,
+            ${reference.urlSql} AS job_key,
+            ${reference.eventUrlSql} AS canonical_job_url,
+            quarantine.title, quarantine.company,
+            quarantine.source_id, quarantine.posting_url,
+            quarantine.reason, quarantine.confidence,
+            quarantine.snapshot_version, quarantine.captured_at,
+            quarantine.notice_text
+     FROM discovery_quarantine_entries AS quarantine
+     ${reference.joinSql}
+     WHERE quarantine.tenant_id = ?
+       AND quarantine.${reference.column} = ?
+       AND quarantine.status = 'pending'`,
+    [DEFAULT_TENANT, storedReference],
   );
   if (!row) {
     throw new InputError(`Quarantine entry ${jobKey} was not found.`);
   }
-  db.prepare(
-    `UPDATE discovery_quarantine_entries
-     SET status = ?, decision_reason = ?, decided_at = ?
-     WHERE tenant_id = ? AND job_key = ?`,
-  ).run(decision.decision, decision.reason ?? null, now, DEFAULT_TENANT, jobKey);
-  recordEvent(db, {
-    eventType: "DiscoveryFeedbackRecorded",
-    jobUrl: row.job_id || row.job_key,
-    message: "Discovery quarantine decision recorded.",
-    payload: {
-      feedbackId: `feedback-${crypto.randomUUID()}`,
-      jobId: row.job_id || row.job_key,
-      sourceId: row.source_id,
-      kind: decision.decision === "approve" ? "useful" : "irrelevant",
-      recordedAt: now,
-    },
+  const persistDecision = db.transaction(() => {
+    db.prepare(
+      `UPDATE discovery_quarantine_entries
+       SET status = ?, decision_reason = ?, decided_at = ?
+       WHERE tenant_id = ? AND ${reference.column} = ?`,
+    ).run(
+      decision.decision,
+      decision.reason ?? null,
+      now,
+      DEFAULT_TENANT,
+      storedReference,
+    );
+    recordEvent(db, {
+      eventType: "DiscoveryFeedbackRecorded",
+      jobUrl: row.canonical_job_url,
+      message: "Discovery quarantine decision recorded.",
+      payload: {
+        feedbackId: `feedback-${crypto.randomUUID()}`,
+        jobId: row.job_key,
+        sourceId: row.source_id,
+        kind: decision.decision === "approve" ? "useful" : "irrelevant",
+        recordedAt: now,
+      },
+    });
   });
+  persistDecision();
   return { ok: true, jobKey, decision: decision.decision, recordedAt: now };
 }
 
@@ -1397,6 +1500,74 @@ function primaryKeyColumns(
     .filter((row) => row.pk > 0)
     .sort((left, right) => left.pk - right.pk)
     .map((row) => row.name);
+}
+
+function quarantineReferenceProjection(
+  db: SqliteDatabase,
+): {
+  column: "job_id" | "job_key";
+  urlSql: string;
+  eventUrlSql: string;
+  joinSql: string;
+} {
+  const columns = tableColumnSet(
+    db,
+    "discovery_quarantine_entries",
+  );
+  if (columns.has("job_key")) {
+    return {
+      column: "job_key",
+      urlSql: "quarantine.job_key",
+      eventUrlSql: "quarantine.job_key",
+      joinSql: "",
+    };
+  }
+  return {
+    column: "job_id",
+    urlSql: `COALESCE(
+      NULLIF(TRIM(quarantine.posting_url), ''),
+      jobs.url
+    )`,
+    eventUrlSql: "jobs.url",
+    joinSql: `JOIN jobs
+      ON jobs.tenant_id = quarantine.tenant_id
+     AND jobs.job_id = quarantine.job_id`,
+  };
+}
+
+function quarantineReferenceForUrl(
+  db: SqliteDatabase,
+  jobUrl: string,
+): string {
+  const projection = quarantineReferenceProjection(db);
+  if (projection.column === "job_key") {
+    return jobUrl;
+  }
+  const exactPendingRows = db
+    .prepare(
+      `SELECT job_id
+       FROM discovery_quarantine_entries
+       WHERE tenant_id = ?
+         AND status = 'pending'
+         AND NULLIF(TRIM(posting_url), '') = ?
+       ORDER BY job_id
+       LIMIT 2`,
+    )
+    .all(DEFAULT_TENANT, jobUrl) as Array<{ job_id: string }>;
+  if (exactPendingRows.length === 1) {
+    return exactPendingRows[0]!.job_id;
+  }
+  if (exactPendingRows.length > 1) {
+    throw new Error(
+      `Ambiguous Discovery quarantine identity for ${jobUrl}.`,
+    );
+  }
+  return jobKeyReferenceForUrl(
+    db,
+    "discovery_quarantine_entries",
+    jobUrl,
+    DEFAULT_TENANT,
+  );
 }
 
 function manualCaptureReferenceProjection(

--- a/apps/api/src/write-model.ts
+++ b/apps/api/src/write-model.ts
@@ -922,11 +922,7 @@ function purgeJobRows(db: SqliteDatabase, jobUrl: string): void {
   deleteWhere(db, "artifact_list_projections", "job_id = ?", [jobUrl]);
   deleteWhere(db, "job_detail_projections", "job_id = ?", [jobUrl]);
   deleteWhere(db, "job_list_projections", "job_id = ?", [jobUrl]);
-  deleteWhere(db, "discovery_quarantine_entries", "job_id = ? OR job_key = ? OR posting_url = ?", [
-    jobUrl,
-    jobUrl,
-    jobUrl,
-  ]);
+  deleteQuarantineReferences(db, jobId, jobUrl);
   deleteWhere(db, "jobs", "url = ?", [jobUrl]);
 }
 
@@ -1298,6 +1294,36 @@ function deleteManualCaptureReferences(
     "manual_capture_queue",
     `tenant_id = ? AND ${referenceColumn} = ?`,
     ["local", reference],
+  );
+}
+
+function deleteQuarantineReferences(
+  db: SqliteDatabase,
+  jobId: string | undefined,
+  jobUrl: string,
+): void {
+  if (!tableExists(db, "discovery_quarantine_entries")) {
+    return;
+  }
+  const columns = tableColumnSet(
+    db,
+    "discovery_quarantine_entries",
+  );
+  if (columns.has("job_key")) {
+    deleteWhere(
+      db,
+      "discovery_quarantine_entries",
+      "job_id = ? OR job_key = ? OR posting_url = ?",
+      [jobUrl, jobUrl, jobUrl],
+    );
+    return;
+  }
+  if (!jobId) return;
+  deleteWhere(
+    db,
+    "discovery_quarantine_entries",
+    "tenant_id = ? AND job_id = ?",
+    ["local", jobId],
   );
 }
 

--- a/apps/api/test/quarantine-v28.test.ts
+++ b/apps/api/test/quarantine-v28.test.ts
@@ -1,0 +1,426 @@
+import Database from "better-sqlite3";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  decideQuarantineEntry,
+  ensureDiscoveryControlTables,
+  listQuarantine,
+} from "../src/discovery-controls.js";
+import { tableColumnSet } from "../src/db.js";
+import { permanentlyDeleteJob } from "../src/write-model.js";
+
+const NOW = "2026-07-30T12:00:00.000Z";
+const CANONICAL_URL =
+  "https://careers.example.test/quarantine-canonical";
+const POSTING_URL =
+  "https://legacy.example.test/quarantine-posting";
+const JOB_ID = "22222222-2222-4222-8222-222222222222";
+const LOSING_JOB_ID = "33333333-3333-4333-8333-333333333333";
+const LOSING_URL =
+  "https://careers.example.test/quarantine-collision";
+
+let db: Database.Database | undefined;
+let cleanup: (() => void) | undefined;
+
+afterEach(() => {
+  db?.close();
+  db = undefined;
+  cleanup?.();
+  cleanup = undefined;
+});
+
+function createDatabase(
+  schemaVersion = 28,
+  foreignKeys = true,
+): Database.Database {
+  const dir = fs.mkdtempSync(
+    path.join(os.tmpdir(), "jobctrl-quarantine-v28-"),
+  );
+  cleanup = () => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  };
+  const opened = new Database(path.join(dir, "jobs.db"));
+  opened.pragma(
+    `foreign_keys = ${foreignKeys ? "ON" : "OFF"}`,
+  );
+  opened.exec(`
+    CREATE TABLE jobs (
+      url TEXT PRIMARY KEY,
+      tenant_id TEXT NOT NULL DEFAULT 'local',
+      job_id TEXT NOT NULL,
+      title TEXT,
+      company TEXT,
+      salary TEXT,
+      description TEXT,
+      location TEXT,
+      site TEXT,
+      strategy TEXT,
+      discovered_at TEXT,
+      full_description TEXT,
+      application_url TEXT,
+      detail_scraped_at TEXT,
+      detail_error TEXT,
+      fit_score INTEGER,
+      score_reasoning TEXT,
+      scored_at TEXT,
+      tailored_resume_path TEXT,
+      tailored_at TEXT,
+      tailor_attempts INTEGER DEFAULT 0,
+      cover_letter_path TEXT,
+      cover_letter_at TEXT,
+      cover_attempts INTEGER DEFAULT 0,
+      applied_at TEXT,
+      apply_status TEXT,
+      apply_error TEXT,
+      apply_attempts INTEGER DEFAULT 0,
+      agent_id TEXT,
+      last_attempted_at TEXT,
+      apply_duration_ms INTEGER,
+      apply_task_id TEXT,
+      verification_confidence TEXT,
+      UNIQUE (tenant_id, job_id)
+    );
+    CREATE TABLE job_identity_aliases (
+      tenant_id TEXT NOT NULL,
+      alias_kind TEXT NOT NULL,
+      alias_value TEXT NOT NULL,
+      job_id TEXT NOT NULL,
+      created_at TEXT NOT NULL,
+      PRIMARY KEY (tenant_id, alias_kind, alias_value)
+    );
+    CREATE TABLE job_events (
+      event_id INTEGER PRIMARY KEY AUTOINCREMENT,
+      job_url TEXT,
+      stage TEXT,
+      event_type TEXT NOT NULL DEFAULT '',
+      level TEXT NOT NULL DEFAULT 'info',
+      message TEXT,
+      occurred_at TEXT NOT NULL,
+      payload_json TEXT,
+      entity_kind TEXT,
+      entity_ref TEXT,
+      FOREIGN KEY (job_url) REFERENCES jobs(url) ON DELETE CASCADE
+    );
+    PRAGMA user_version = ${schemaVersion};
+  `);
+  return opened;
+}
+
+function insertJob(opened: Database.Database): void {
+  opened.prepare(
+    `INSERT INTO jobs (
+       url, tenant_id, job_id, title, company, discovered_at
+     ) VALUES (?, 'local', ?, 'Platform Engineer', 'ExampleCo', ?)`,
+  ).run(CANONICAL_URL, JOB_ID, NOW);
+  opened.prepare(
+    `INSERT INTO job_identity_aliases (
+       tenant_id, alias_kind, alias_value, job_id, created_at
+     ) VALUES ('local', 'posting_url', ?, ?, ?)`,
+  ).run(POSTING_URL, JOB_ID, NOW);
+}
+
+function insertQuarantine(opened: Database.Database): void {
+  opened.prepare(
+    `INSERT INTO discovery_quarantine_entries (
+       tenant_id, job_id, title, company, source_id,
+       posting_url, reason, confidence, snapshot_version,
+       captured_at, notice_text, status
+     ) VALUES (
+       'local', ?, 'Platform Engineer', 'ExampleCo',
+       'source:alias', ?, 'unknown_active_state', 0.4, 3,
+       ?, 'Private review context stays canonical.', 'pending'
+     )`,
+  ).run(JOB_ID, POSTING_URL, NOW);
+}
+
+describe("schema-v28 Discovery quarantine references", () => {
+  it("recovers the stable current-authority contract", () => {
+    db = createDatabase();
+    ensureDiscoveryControlTables(db);
+
+    expect(
+      tableColumnSet(db, "discovery_quarantine_entries"),
+    ).toContain("job_id");
+    expect(
+      tableColumnSet(db, "discovery_quarantine_entries"),
+    ).not.toContain("job_key");
+    const actions = new Set(
+      (
+        db
+          .prepare(
+            'PRAGMA foreign_key_list("discovery_quarantine_entries")',
+          )
+          .all() as Array<{ on_delete: string }>
+      ).map((row) => row.on_delete),
+    );
+    expect(actions).toEqual(new Set(["CASCADE"]));
+    expect(
+      (
+        db
+          .prepare(
+            'PRAGMA index_info("idx_discovery_quarantine_status")',
+          )
+          .all() as Array<{ seqno: number; name: string }>
+      )
+        .sort((left, right) => left.seqno - right.seqno)
+        .map((row) => row.name),
+    ).toEqual(["tenant_id", "status", "captured_at"]);
+  });
+
+  it("lists and decides by the preserved posting URL", () => {
+    db = createDatabase();
+    insertJob(db);
+    ensureDiscoveryControlTables(db);
+    insertQuarantine(db);
+
+    expect(listQuarantine(db)).toEqual({
+      ok: true,
+      entries: [
+        {
+          jobId: POSTING_URL,
+          jobKey: POSTING_URL,
+          title: "Platform Engineer",
+          company: "ExampleCo",
+          sourceId: "source:alias",
+          postingUrl: POSTING_URL,
+          reason: "unknown_active_state",
+          confidence: 0.4,
+          snapshotVersion: 3,
+          capturedAt: NOW,
+          noticeText: "Private review context stays canonical.",
+        },
+      ],
+    });
+
+    expect(
+      decideQuarantineEntry(db, POSTING_URL, {
+        decision: "approve",
+        reason: "Reviewed",
+      }),
+    ).toMatchObject({
+      ok: true,
+      jobKey: POSTING_URL,
+      decision: "approve",
+    });
+    expect(
+      db
+        .prepare(
+          `SELECT job_id, posting_url, status,
+                  decision_reason, decided_at
+             FROM discovery_quarantine_entries`,
+        )
+        .get(),
+    ).toMatchObject({
+      job_id: JOB_ID,
+      posting_url: POSTING_URL,
+      status: "approve",
+      decision_reason: "Reviewed",
+    });
+    const event = db
+      .prepare(
+        `SELECT job_url, payload_json
+           FROM job_events
+          WHERE event_type = 'DiscoveryFeedbackRecorded'`,
+      )
+      .get() as {
+        job_url: string;
+        payload_json: string;
+      };
+    expect(event.job_url).toBe(CANONICAL_URL);
+    expect(JSON.parse(event.payload_json)).toMatchObject({
+      jobId: POSTING_URL,
+      sourceId: "source:alias",
+      kind: "useful",
+    });
+    expect(event.payload_json).not.toContain(JOB_ID);
+    expect(event.payload_json).not.toContain(
+      "Private review context",
+    );
+  });
+
+  it("decides a collision-rehomed row by the exact listed URL", () => {
+    db = createDatabase();
+    insertJob(db);
+    db.prepare(
+      `INSERT INTO jobs (
+         url, tenant_id, job_id, title, company, discovered_at
+       ) VALUES (?, 'local', ?, 'Duplicate Engineer', 'ExampleCo', ?)`,
+    ).run(LOSING_URL, LOSING_JOB_ID, NOW);
+    db.prepare(
+      `INSERT INTO job_identity_aliases (
+         tenant_id, alias_kind, alias_value, job_id, created_at
+       ) VALUES ('local', 'posting_url', ?, ?, ?)`,
+    ).run(LOSING_URL, LOSING_JOB_ID, NOW);
+    ensureDiscoveryControlTables(db);
+    db.prepare(
+      `INSERT INTO discovery_quarantine_entries (
+         tenant_id, job_id, title, company, source_id,
+         posting_url, reason, confidence, snapshot_version,
+         captured_at, notice_text, status
+       ) VALUES (
+         'local', ?, 'Duplicate Engineer', 'ExampleCo',
+         'source:collision', ?, 'unknown_active_state', 0.3, 2,
+         ?, 'Collision review context.', 'pending'
+       )`,
+    ).run(LOSING_JOB_ID, LOSING_URL, NOW);
+
+    db.prepare(
+      `UPDATE discovery_quarantine_entries
+       SET job_id = ?
+       WHERE tenant_id = 'local' AND job_id = ?`,
+    ).run(JOB_ID, LOSING_JOB_ID);
+    db.prepare(
+      `DELETE FROM job_identity_aliases
+       WHERE tenant_id = 'local' AND job_id = ?`,
+    ).run(LOSING_JOB_ID);
+    db.prepare(
+      `DELETE FROM jobs
+       WHERE tenant_id = 'local' AND job_id = ?`,
+    ).run(LOSING_JOB_ID);
+
+    const listed = listQuarantine(db);
+    expect(listed.entries).toHaveLength(1);
+    expect(listed.entries[0]).toMatchObject({
+      jobId: LOSING_URL,
+      jobKey: LOSING_URL,
+      postingUrl: LOSING_URL,
+    });
+    expect(
+      db
+        .prepare(
+          `SELECT COUNT(*) AS count
+           FROM job_identity_aliases
+           WHERE tenant_id = 'local' AND alias_value = ?`,
+        )
+        .get(LOSING_URL),
+    ).toEqual({ count: 0 });
+
+    expect(
+      decideQuarantineEntry(db, listed.entries[0]!.jobKey, {
+        decision: "approve",
+        reason: "Reviewed after collision",
+      }),
+    ).toMatchObject({
+      ok: true,
+      jobKey: LOSING_URL,
+      decision: "approve",
+    });
+    expect(
+      db
+        .prepare(
+          `SELECT job_id, status, decision_reason
+           FROM discovery_quarantine_entries`,
+        )
+        .get(),
+    ).toEqual({
+      job_id: JOB_ID,
+      status: "approve",
+      decision_reason: "Reviewed after collision",
+    });
+    const event = db
+      .prepare(
+        `SELECT job_url, payload_json
+         FROM job_events
+         WHERE event_type = 'DiscoveryFeedbackRecorded'`,
+      )
+      .get() as {
+        job_url: string;
+        payload_json: string;
+      };
+    expect(event.job_url).toBe(CANONICAL_URL);
+    expect(JSON.parse(event.payload_json)).toMatchObject({
+      jobId: LOSING_URL,
+      sourceId: "source:collision",
+      kind: "useful",
+    });
+    expect(event.payload_json).not.toContain(JOB_ID);
+    expect(event.payload_json).not.toContain(
+      "Collision review context",
+    );
+  });
+
+  it("rolls back the decision when audit-event persistence fails", () => {
+    db = createDatabase();
+    insertJob(db);
+    ensureDiscoveryControlTables(db);
+    insertQuarantine(db);
+    db.exec(`
+      CREATE TRIGGER reject_quarantine_feedback_event
+      BEFORE INSERT ON job_events
+      WHEN NEW.event_type = 'DiscoveryFeedbackRecorded'
+      BEGIN
+        SELECT RAISE(ABORT, 'injected event failure');
+      END;
+    `);
+
+    expect(() =>
+      decideQuarantineEntry(db!, POSTING_URL, {
+        decision: "approve",
+        reason: "Must roll back",
+      }),
+    ).toThrow("injected event failure");
+    expect(
+      db
+        .prepare(
+          `SELECT status, decision_reason, decided_at
+           FROM discovery_quarantine_entries`,
+        )
+        .get(),
+    ).toEqual({
+      status: "pending",
+      decision_reason: null,
+      decided_at: null,
+    });
+    expect(
+      db
+        .prepare(
+          `SELECT COUNT(*) AS count
+           FROM job_events
+           WHERE event_type = 'DiscoveryFeedbackRecorded'`,
+        )
+        .get(),
+    ).toEqual({ count: 0 });
+  });
+
+  it.each([true, false])(
+    "purges quarantine during permanent deletion with foreign keys %s",
+    (foreignKeys) => {
+      db = createDatabase(28, foreignKeys);
+      insertJob(db);
+      ensureDiscoveryControlTables(db);
+      insertQuarantine(db);
+
+      expect(
+        permanentlyDeleteJob(db, CANONICAL_URL),
+      ).toEqual({
+        ok: true,
+        count: 1,
+        jobKeys: [CANONICAL_URL],
+      });
+      expect(
+        db
+          .prepare(
+            `SELECT COUNT(*) AS count
+               FROM discovery_quarantine_entries`,
+          )
+          .get(),
+      ).toEqual({ count: 0 });
+      expect(
+        db.prepare("SELECT COUNT(*) AS count FROM jobs").get(),
+      ).toEqual({ count: 0 });
+    },
+  );
+
+  it("fails closed when a v28 stamp has a legacy table", () => {
+    db = createDatabase(27);
+    ensureDiscoveryControlTables(db);
+    db.pragma("user_version = 28");
+
+    expect(() => ensureDiscoveryControlTables(db!)).toThrow(
+      "Schema v28 requires stable Discovery quarantine JobId references.",
+    );
+  });
+});

--- a/apps/api/test/schema-version-guard.test.ts
+++ b/apps/api/test/schema-version-guard.test.ts
@@ -63,7 +63,7 @@ describe("schema version guard at DB open", () => {
   });
 
   it("opens the worker-owned schema-v14 artifact registry", () => {
-    expect(SUPPORTED_SCHEMA_VERSION).toBe(27);
+    expect(SUPPORTED_SCHEMA_VERSION).toBe(28);
     const { dbPath, cleanup } = makeDbWithUserVersion(14);
     try {
       openDatabase(dbPath).close();

--- a/workers/automation/src/jobctrl/database.py
+++ b/workers/automation/src/jobctrl/database.py
@@ -103,7 +103,10 @@ from jobctrl.config import DB_PATH, DEFAULTS, migrate_legacy_job_tables
 # v27 (manual-capture references): imported manual-capture queue rows point at
 # the tenant-scoped stable Job aggregate. Pending captures remain unlinked, and
 # workflow/API results continue to expose the posting URL until Phase 4.
-SCHEMA_VERSION = 27
+# v28 (quarantine references): the current Discovery quarantine authority is
+# keyed by the tenant-scoped stable Job aggregate. URL-era duplicates collapse
+# deterministically while their snapshots and events retain historical facts.
+SCHEMA_VERSION = 28
 
 
 class IncompatibleSchemaVersionError(RuntimeError):
@@ -261,6 +264,7 @@ def _schema_migrations() -> tuple[
         (25, ensure_outreach_references_v25),
         (26, ensure_discovery_feedback_references_v26),
         (27, ensure_manual_capture_references_v27),
+        (28, ensure_quarantine_references_v28),
     )
 
 
@@ -3735,6 +3739,9 @@ def ensure_discovery_control_tables(conn: sqlite3.Connection | None = None) -> l
     stable_manual_capture_references = (
         current_version >= _MANUAL_CAPTURE_REFERENCE_SCHEMA_VERSION
     )
+    stable_quarantine_references = (
+        current_version >= _QUARANTINE_REFERENCE_SCHEMA_VERSION
+    )
 
     conn.execute(
         """
@@ -3770,28 +3777,31 @@ def ensure_discovery_control_tables(conn: sqlite3.Connection | None = None) -> l
         )
         """
     )
-    conn.execute(
-        """
-        CREATE TABLE IF NOT EXISTS discovery_quarantine_entries (
-            tenant_id        TEXT NOT NULL DEFAULT 'local',
-            job_id           TEXT NOT NULL,
-            job_key          TEXT NOT NULL,
-            title            TEXT NOT NULL DEFAULT '',
-            company          TEXT NOT NULL DEFAULT '',
-            source_id        TEXT NOT NULL,
-            posting_url      TEXT,
-            reason           TEXT NOT NULL,
-            confidence       REAL,
-            snapshot_version INTEGER,
-            captured_at      TEXT,
-            notice_text      TEXT,
-            status           TEXT NOT NULL DEFAULT 'pending',
-            decision_reason  TEXT,
-            decided_at       TEXT,
-            PRIMARY KEY (tenant_id, job_key)
+    if not _table_columns(conn, "discovery_quarantine_entries"):
+        _create_quarantine_table_v28(
+            conn,
+            table="discovery_quarantine_entries",
+            stable_reference=stable_quarantine_references,
         )
-        """
-    )
+    if stable_quarantine_references:
+        quarantine_columns = _table_columns(
+            conn,
+            "discovery_quarantine_entries",
+        )
+        if (
+            "job_id" not in quarantine_columns
+            or "job_key" in quarantine_columns
+        ):
+            raise RuntimeError(
+                "Schema v28 requires stable Discovery quarantine "
+                "JobId references."
+            )
+        _create_quarantine_reference_index_v28(conn)
+        if not _has_quarantine_reference_schema_v28(conn):
+            raise RuntimeError(
+                "Schema v28 requires the stable Discovery quarantine "
+                "JobId contract."
+            )
     if not _table_columns(conn, "manual_capture_queue"):
         _create_manual_capture_queue_table_v27(
             conn,
@@ -4893,6 +4903,13 @@ def _reassign_discovery_identity_references(
         )
     if _has_manual_capture_reference_schema_v27(conn):
         _reassign_manual_capture_references_v27(
+            conn,
+            tenant_id=tenant_id,
+            losing_job_id=losing_job_id,
+            surviving_job_id=surviving_job_id,
+        )
+    if _has_quarantine_reference_schema_v28(conn):
+        _reassign_quarantine_references_v28(
             conn,
             tenant_id=tenant_id,
             losing_job_id=losing_job_id,
@@ -15846,6 +15863,559 @@ def _reassign_manual_capture_references_v27(
         (surviving_job_id, tenant_id, losing_job_id),
     )
     _verify_manual_capture_references_v27(
+        conn,
+        expected_count=expected_count,
+    )
+
+
+_QUARANTINE_REFERENCE_SCHEMA_VERSION = 28
+_QUARANTINE_REFERENCE_TABLES = ("discovery_quarantine_entries",)
+_QUARANTINE_PAYLOAD_FIELDS_V28 = (
+    "title",
+    "company",
+    "source_id",
+    "posting_url",
+    "reason",
+    "confidence",
+    "snapshot_version",
+    "captured_at",
+    "notice_text",
+    "status",
+    "decision_reason",
+    "decided_at",
+)
+
+
+def _create_quarantine_table_v28(
+    conn: sqlite3.Connection,
+    *,
+    table: str,
+    stable_reference: bool,
+) -> None:
+    identity_columns = (
+        "job_id TEXT NOT NULL"
+        if stable_reference
+        else "job_id TEXT NOT NULL,\n            job_key TEXT NOT NULL"
+    )
+    primary_key = (
+        "PRIMARY KEY (tenant_id, job_id)"
+        if stable_reference
+        else "PRIMARY KEY (tenant_id, job_key)"
+    )
+    foreign_key = (
+        """,
+            FOREIGN KEY (tenant_id, job_id)
+                REFERENCES jobs(tenant_id, job_id) ON DELETE CASCADE"""
+        if stable_reference
+        else ""
+    )
+    conn.execute(
+        f"""
+        CREATE TABLE "{table}" (
+            tenant_id        TEXT NOT NULL DEFAULT 'local',
+            {identity_columns},
+            title            TEXT NOT NULL DEFAULT '',
+            company          TEXT NOT NULL DEFAULT '',
+            source_id        TEXT NOT NULL,
+            posting_url      TEXT,
+            reason           TEXT NOT NULL,
+            confidence       REAL,
+            snapshot_version INTEGER,
+            captured_at      TEXT,
+            notice_text      TEXT,
+            status           TEXT NOT NULL DEFAULT 'pending',
+            decision_reason  TEXT,
+            decided_at       TEXT,
+            {primary_key}
+            {foreign_key}
+        )
+        """
+    )
+
+
+def _create_quarantine_reference_index_v28(
+    conn: sqlite3.Connection,
+) -> None:
+    if _has_index(
+        conn,
+        "discovery_quarantine_entries",
+        "idx_discovery_quarantine_status",
+        ("tenant_id", "status", "captured_at"),
+        unique=False,
+    ):
+        return
+    conn.execute(
+        'DROP INDEX IF EXISTS "idx_discovery_quarantine_status"'
+    )
+    conn.execute(
+        """
+        CREATE INDEX idx_discovery_quarantine_status
+        ON discovery_quarantine_entries(
+            tenant_id,
+            status,
+            captured_at
+        )
+        """
+    )
+
+
+def _has_quarantine_reference_schema_v28(
+    conn: sqlite3.Connection,
+) -> bool:
+    table = "discovery_quarantine_entries"
+    return (
+        "job_id" in _table_columns(conn, table)
+        and "job_key" not in _table_columns(conn, table)
+        and _primary_key_columns(conn, table)
+        == ("tenant_id", "job_id")
+        and _has_composite_job_id_foreign_key(
+            conn,
+            table,
+            "job_id",
+        )
+        and _has_index(
+            conn,
+            table,
+            "idx_discovery_quarantine_status",
+            ("tenant_id", "status", "captured_at"),
+            unique=False,
+        )
+    )
+
+
+def _quarantine_timestamp_rank_v28(
+    value: Any,
+) -> tuple[float, str]:
+    raw = str(value or "")
+    if not raw:
+        return (float("-inf"), "")
+    try:
+        parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        timestamp = parsed.astimezone(timezone.utc).timestamp()
+    except ValueError:
+        return (float("-inf"), raw)
+    return (timestamp, raw)
+
+
+def _quarantine_candidate_v28(
+    *,
+    tenant_id: Any,
+    stable_job_id: str,
+    payload: tuple[Any, ...],
+    tie_breaker: str,
+) -> dict[str, Any]:
+    candidate = {
+        name: value
+        for name, value in zip(
+            _QUARANTINE_PAYLOAD_FIELDS_V28,
+            payload,
+            strict=True,
+        )
+    }
+    candidate["tenant_id"] = tenant_id
+    candidate["job_id"] = stable_job_id
+    candidate["_tie_breaker"] = tie_breaker
+    return candidate
+
+
+def _quarantine_evidence_rank_v28(
+    candidate: dict[str, Any],
+) -> tuple[tuple[float, str], int, str]:
+    snapshot_version = candidate.get("snapshot_version")
+    return (
+        _quarantine_timestamp_rank_v28(
+            candidate.get("captured_at"),
+        ),
+        int(snapshot_version)
+        if isinstance(snapshot_version, int)
+        else -1,
+        str(candidate["_tie_breaker"]),
+    )
+
+
+def _quarantine_decision_rank_v28(
+    candidate: dict[str, Any],
+) -> tuple[tuple[float, str], str]:
+    return (
+        _quarantine_timestamp_rank_v28(
+            candidate.get("decided_at"),
+        ),
+        str(candidate["_tie_breaker"]),
+    )
+
+
+def _merge_quarantine_candidates_v28(
+    candidates: list[dict[str, Any]],
+) -> tuple[Any, ...]:
+    if not candidates:
+        raise RuntimeError(
+            "Discovery quarantine merge requires at least one row"
+        )
+    winner = max(candidates, key=_quarantine_evidence_rank_v28)
+    decision_candidates = [
+        candidate
+        for candidate in candidates
+        if candidate.get("decided_at") is not None
+        or candidate.get("decision_reason") is not None
+    ]
+    decision_reason = winner.get("decision_reason")
+    decided_at = winner.get("decided_at")
+    if decision_candidates and (
+        str(winner.get("status")) == "pending"
+        or (
+            decision_reason is None
+            and decided_at is None
+        )
+    ):
+        latest_decision = max(
+            decision_candidates,
+            key=_quarantine_decision_rank_v28,
+        )
+        decision_reason = latest_decision.get("decision_reason")
+        decided_at = latest_decision.get("decided_at")
+    return (
+        winner["tenant_id"],
+        winner["job_id"],
+        winner["title"],
+        winner["company"],
+        winner["source_id"],
+        winner["posting_url"],
+        winner["reason"],
+        winner["confidence"],
+        winner["snapshot_version"],
+        winner["captured_at"],
+        winner["notice_text"],
+        winner["status"],
+        decision_reason,
+        decided_at,
+    )
+
+
+def _canonical_quarantine_rows_v28(
+    conn: sqlite3.Connection,
+) -> list[tuple[Any, ...]]:
+    legacy = "job_key" in _table_columns(
+        conn,
+        "discovery_quarantine_entries",
+    )
+    identity_columns = (
+        "job_id, job_key"
+        if legacy
+        else "job_id"
+    )
+    rows = conn.execute(
+        f"""
+        SELECT tenant_id, {identity_columns},
+               title, company, source_id, posting_url, reason,
+               confidence, snapshot_version, captured_at,
+               notice_text, status, decision_reason, decided_at
+        FROM discovery_quarantine_entries
+        ORDER BY tenant_id, job_id
+        """
+    ).fetchall()
+    grouped: dict[tuple[str, str], list[dict[str, Any]]] = {}
+    for row in rows:
+        values = tuple(row)
+        tenant_id = str(values[0])
+        raw_job_id = str(values[1])
+        if legacy:
+            raw_job_key = str(values[2])
+            resolved_job_id = _resolve_job_reference_value(
+                conn,
+                tenant_id=tenant_id,
+                reference=raw_job_id,
+                legacy_url=True,
+            )
+            resolved_job_key = _resolve_job_reference_value(
+                conn,
+                tenant_id=tenant_id,
+                reference=raw_job_key,
+                legacy_url=True,
+            )
+            if (
+                resolved_job_id is None
+                or resolved_job_key is None
+            ):
+                raise RuntimeError(
+                    "Discovery quarantine reference migration could "
+                    "not resolve both URL-era identity columns for "
+                    f"tenant {tenant_id!r}: job_id={raw_job_id!r}, "
+                    f"job_key={raw_job_key!r}"
+                )
+            if resolved_job_id != resolved_job_key:
+                raise RuntimeError(
+                    "Discovery quarantine reference migration found "
+                    "conflicting URL-era identity columns for tenant "
+                    f"{tenant_id!r}: job_id={raw_job_id!r}, "
+                    f"job_key={raw_job_key!r}"
+                )
+            stable_job_id = resolved_job_id
+            payload = values[3:]
+            tie_breaker = raw_job_key
+        else:
+            stable_job_id = _resolve_job_reference_value(
+                conn,
+                tenant_id=tenant_id,
+                reference=raw_job_id,
+                legacy_url=False,
+            )
+            if stable_job_id is None:
+                raise RuntimeError(
+                    "Discovery quarantine reference migration could "
+                    "not resolve discovery_quarantine_entries.job_id="
+                    f"{raw_job_id!r} for tenant {tenant_id!r}"
+                )
+            payload = values[2:]
+            tie_breaker = raw_job_id
+        _validate_job_uuid(stable_job_id)
+        grouped.setdefault(
+            (tenant_id, stable_job_id),
+            [],
+        ).append(
+            _quarantine_candidate_v28(
+                tenant_id=tenant_id,
+                stable_job_id=stable_job_id,
+                payload=payload,
+                tie_breaker=tie_breaker,
+            )
+        )
+    return [
+        _merge_quarantine_candidates_v28(candidates)
+        for _identity, candidates in sorted(grouped.items())
+    ]
+
+
+def _insert_quarantine_rows_v28(
+    conn: sqlite3.Connection,
+    *,
+    table: str,
+    rows: list[tuple[Any, ...]],
+) -> None:
+    conn.executemany(
+        f"""
+        INSERT INTO "{table}" (
+            tenant_id, job_id, title, company, source_id,
+            posting_url, reason, confidence, snapshot_version,
+            captured_at, notice_text, status, decision_reason,
+            decided_at
+        ) VALUES (
+            ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+        )
+        """,
+        rows,
+    )
+
+
+def ensure_quarantine_references_v28(
+    conn: sqlite3.Connection | None = None,
+) -> list[str]:
+    """Move the current Discovery quarantine authority to stable JobIds."""
+    if conn is None:
+        conn = get_connection()
+    current = _assert_schema_version_supported(conn)
+    if current >= _QUARANTINE_REFERENCE_SCHEMA_VERSION:
+        return list(_QUARANTINE_REFERENCE_TABLES)
+    if current != _MANUAL_CAPTURE_REFERENCE_SCHEMA_VERSION:
+        raise RuntimeError(
+            "Discovery quarantine reference migration requires "
+            f"schema v27; found v{current}"
+        )
+
+    conn.execute("SAVEPOINT quarantine_references_v28")
+    try:
+        if not _table_columns(
+            conn,
+            "discovery_quarantine_entries",
+        ):
+            _create_quarantine_table_v28(
+                conn,
+                table="discovery_quarantine_entries",
+                stable_reference=False,
+            )
+        source_count = int(
+            conn.execute(
+                "SELECT COUNT(*) FROM "
+                "discovery_quarantine_entries"
+            ).fetchone()[0]
+        )
+        quarantine_rows = _canonical_quarantine_rows_v28(conn)
+        expected_count = len(quarantine_rows)
+        if expected_count > source_count:
+            raise RuntimeError(
+                "Discovery quarantine reference migration created "
+                "unexpected authority rows"
+            )
+
+        conn.execute(
+            "DROP TABLE IF EXISTS "
+            "discovery_quarantine_entries_v28"
+        )
+        _create_quarantine_table_v28(
+            conn,
+            table="discovery_quarantine_entries_v28",
+            stable_reference=True,
+        )
+        _insert_quarantine_rows_v28(
+            conn,
+            table="discovery_quarantine_entries_v28",
+            rows=quarantine_rows,
+        )
+
+        conn.execute(
+            'DROP TABLE "discovery_quarantine_entries"'
+        )
+        conn.execute(
+            'ALTER TABLE "discovery_quarantine_entries_v28" '
+            'RENAME TO "discovery_quarantine_entries"'
+        )
+        _create_quarantine_reference_index_v28(conn)
+        _verify_quarantine_references_v28(
+            conn,
+            expected_count=expected_count,
+        )
+        conn.execute(
+            f"PRAGMA user_version = "
+            f"{_QUARANTINE_REFERENCE_SCHEMA_VERSION}"
+        )
+        conn.execute(
+            "RELEASE SAVEPOINT quarantine_references_v28"
+        )
+    except BaseException:
+        conn.execute(
+            "ROLLBACK TO SAVEPOINT quarantine_references_v28"
+        )
+        conn.execute(
+            "RELEASE SAVEPOINT quarantine_references_v28"
+        )
+        raise
+    return list(_QUARANTINE_REFERENCE_TABLES)
+
+
+def _verify_quarantine_references_v28(
+    conn: sqlite3.Connection,
+    *,
+    expected_count: int,
+) -> None:
+    if not _has_quarantine_reference_schema_v28(conn):
+        raise RuntimeError(
+            "Discovery quarantine reference migration did not "
+            "create the stable reference schema"
+        )
+    observed_count = int(
+        conn.execute(
+            "SELECT COUNT(*) FROM discovery_quarantine_entries"
+        ).fetchone()[0]
+    )
+    if observed_count != expected_count:
+        raise RuntimeError(
+            "Discovery quarantine reference migration changed "
+            f"authority count: expected {expected_count}, "
+            f"found {observed_count}"
+        )
+    orphan = conn.execute(
+        """
+        SELECT quarantine.job_id
+        FROM discovery_quarantine_entries AS quarantine
+        LEFT JOIN jobs
+          ON jobs.tenant_id = quarantine.tenant_id
+         AND jobs.job_id = quarantine.job_id
+        WHERE jobs.job_id IS NULL
+        LIMIT 1
+        """
+    ).fetchone()
+    if orphan is not None:
+        raise RuntimeError(
+            "Discovery quarantine reference migration left an "
+            "unresolved JobId"
+        )
+    for row in conn.execute(
+        "SELECT DISTINCT job_id "
+        "FROM discovery_quarantine_entries"
+    ).fetchall():
+        _validate_job_uuid(str(row[0]))
+    foreign_key_error = conn.execute(
+        "PRAGMA foreign_key_check"
+    ).fetchone()
+    if foreign_key_error is not None:
+        raise RuntimeError(
+            "Discovery quarantine reference migration found a "
+            "foreign-key violation"
+        )
+
+
+def _reassign_quarantine_references_v28(
+    conn: sqlite3.Connection,
+    *,
+    tenant_id: str,
+    losing_job_id: str,
+    surviving_job_id: str,
+) -> None:
+    if losing_job_id == surviving_job_id:
+        return
+    expected_count = int(
+        conn.execute(
+            "SELECT COUNT(*) FROM discovery_quarantine_entries"
+        ).fetchone()[0]
+    )
+    rows = conn.execute(
+        """
+        SELECT tenant_id, job_id, title, company, source_id,
+               posting_url, reason, confidence, snapshot_version,
+               captured_at, notice_text, status, decision_reason,
+               decided_at
+        FROM discovery_quarantine_entries
+        WHERE tenant_id = ? AND job_id IN (?, ?)
+        ORDER BY job_id
+        """,
+        (tenant_id, losing_job_id, surviving_job_id),
+    ).fetchall()
+    losing_present = any(str(row[1]) == losing_job_id for row in rows)
+    if not losing_present:
+        return
+    surviving_present = any(
+        str(row[1]) == surviving_job_id
+        for row in rows
+    )
+    if not surviving_present:
+        conn.execute(
+            """
+            UPDATE discovery_quarantine_entries
+            SET job_id = ?
+            WHERE tenant_id = ? AND job_id = ?
+            """,
+            (surviving_job_id, tenant_id, losing_job_id),
+        )
+    else:
+        candidates = [
+            _quarantine_candidate_v28(
+                tenant_id=row[0],
+                stable_job_id=surviving_job_id,
+                payload=tuple(row)[2:],
+                tie_breaker=(
+                    "1:surviving"
+                    if str(row[1]) == surviving_job_id
+                    else "0:losing"
+                ),
+            )
+            for row in rows
+        ]
+        merged = _merge_quarantine_candidates_v28(candidates)
+        conn.execute(
+            """
+            DELETE FROM discovery_quarantine_entries
+            WHERE tenant_id = ? AND job_id IN (?, ?)
+            """,
+            (tenant_id, losing_job_id, surviving_job_id),
+        )
+        _insert_quarantine_rows_v28(
+            conn,
+            table="discovery_quarantine_entries",
+            rows=[merged],
+        )
+        expected_count -= 1
+    _verify_quarantine_references_v28(
         conn,
         expected_count=expected_count,
     )

--- a/workers/automation/src/jobctrl/enrichment/detail.py
+++ b/workers/automation/src/jobctrl/enrichment/detail.py
@@ -1661,14 +1661,45 @@ def _record_posting_snapshot_from_cascade(
             )
         if quarantine_reason is not QuarantineReason.NONE:
             ensure_discovery_control_tables(conn)
+            legacy_quarantine_reference = (
+                "job_key"
+                in db_module._table_columns(
+                    conn,
+                    "discovery_quarantine_entries",
+                )
+            )
+            if legacy_quarantine_reference:
+                identity_columns = "job_id, job_key"
+                identity_placeholders = "?, ?"
+                identity_values = (url, url)
+                conflict_column = "job_key"
+            else:
+                stable_job_id = db_module._resolve_job_reference_value(
+                    conn,
+                    tenant_id=str(LOCAL_TENANT),
+                    reference=url,
+                    legacy_url=True,
+                )
+                if stable_job_id is None:
+                    raise RuntimeError(
+                        "Enrichment quarantine write could not "
+                        "resolve its stable JobId."
+                    )
+                identity_columns = "job_id"
+                identity_placeholders = "?"
+                identity_values = (stable_job_id,)
+                conflict_column = "job_id"
             conn.execute(
-                """
+                f"""
                 INSERT INTO discovery_quarantine_entries (
-                    tenant_id, job_id, job_key, title, company, source_id,
+                    tenant_id, {identity_columns}, title, company, source_id,
                     posting_url, reason, confidence, snapshot_version,
                     captured_at, notice_text, status
-                ) VALUES (?, ?, ?, ?, '', ?, ?, ?, ?, ?, ?, ?, 'pending')
-                ON CONFLICT(tenant_id, job_key) DO UPDATE SET
+                ) VALUES (
+                    ?, {identity_placeholders}, ?, '', ?, ?, ?, ?, ?, ?, ?,
+                    'pending'
+                )
+                ON CONFLICT(tenant_id, {conflict_column}) DO UPDATE SET
                     title = excluded.title,
                     source_id = excluded.source_id,
                     posting_url = excluded.posting_url,
@@ -1681,8 +1712,7 @@ def _record_posting_snapshot_from_cascade(
                 """,
                 (
                     str(LOCAL_TENANT),
-                    url,
-                    url,
+                    *identity_values,
                     title,
                     resolved_source_id,
                     url,

--- a/workers/automation/src/jobctrl/infrastructure/discovery/production_wiring.py
+++ b/workers/automation/src/jobctrl/infrastructure/discovery/production_wiring.py
@@ -1092,7 +1092,7 @@ def import_manual_capture_item(
     if outcome.ok and quarantine_reason and quarantine_reason != QuarantineReason.NONE.value:
         _upsert_quarantine_entry(
             conn,
-            job_id=captured_url,
+            job_url=captured_url,
             source_id=str(source_id),
             reason=quarantine_reason,
             confidence=None,
@@ -1239,16 +1239,26 @@ def build_discovery_acceptance_report(
         "SELECT COUNT(*) FROM source_quality_stats WHERE tenant_id = ?",
         (tenant,),
     )
+    quarantine_job_reference = (
+        "j.url"
+        if "job_key" in _table_columns(
+            conn,
+            "discovery_quarantine_entries",
+        )
+        else "j.job_id"
+    )
     scoring_handoff_count = _scalar_int(
         conn,
-        """
+        f"""
         SELECT COUNT(*)
         FROM jobs j
         JOIN job_enrichments e
           ON e.tenant_id = j.tenant_id
          AND e.job_id = j.job_id
         LEFT JOIN discovery_quarantine_entries q
-          ON q.tenant_id = ? AND q.job_id = j.url AND q.status = 'pending'
+          ON q.tenant_id = ?
+         AND q.job_id = {quarantine_job_reference}
+         AND q.status = 'pending'
         WHERE j.tenant_id = ?
           AND e.current_status = 'enriched'
           AND j.fit_score IS NULL
@@ -2132,7 +2142,7 @@ def manual_capture_content(capture: ManualCaptureImport) -> str:
 def _upsert_quarantine_entry(
     conn: sqlite3.Connection,
     *,
-    job_id: str,
+    job_url: str,
     source_id: str,
     reason: str,
     confidence: float | None,
@@ -2142,14 +2152,43 @@ def _upsert_quarantine_entry(
     posting_url: str,
     notice_text: str,
 ) -> None:
+    legacy_reference = "job_key" in _table_columns(
+        conn,
+        "discovery_quarantine_entries",
+    )
+    if legacy_reference:
+        identity_columns = "job_id, job_key"
+        identity_placeholders = "?, ?"
+        identity_values = (job_url, job_url)
+        conflict_column = "job_key"
+    else:
+        stable_job_id = _resolve_job_reference_value(
+            conn,
+            tenant_id=str(LOCAL_TENANT),
+            reference=job_url,
+            legacy_url=True,
+        )
+        if stable_job_id is None:
+            raise RuntimeError(
+                "Discovery quarantine write could not resolve its "
+                "stable JobId."
+            )
+        identity_columns = "job_id"
+        identity_placeholders = "?"
+        identity_values = (stable_job_id,)
+        conflict_column = "job_id"
     conn.execute(
-        """
+        f"""
         INSERT INTO discovery_quarantine_entries (
-            tenant_id, job_id, job_key, title, company, source_id, posting_url,
+            tenant_id, {identity_columns}, title, company,
+            source_id, posting_url,
             reason, confidence, snapshot_version, captured_at, notice_text,
             status
-        ) VALUES (?, ?, ?, ?, '', ?, ?, ?, ?, ?, ?, ?, 'pending')
-        ON CONFLICT(tenant_id, job_key) DO UPDATE SET
+        ) VALUES (
+            ?, {identity_placeholders}, ?, '', ?, ?, ?, ?, ?, ?, ?,
+            'pending'
+        )
+        ON CONFLICT(tenant_id, {conflict_column}) DO UPDATE SET
             title = excluded.title,
             source_id = excluded.source_id,
             posting_url = excluded.posting_url,
@@ -2162,8 +2201,7 @@ def _upsert_quarantine_entry(
         """,
         (
             str(LOCAL_TENANT),
-            job_id,
-            job_id,
+            *identity_values,
             title,
             source_id,
             posting_url,

--- a/workers/automation/tests/test_application_feedback_candidate_identity_reference_migration.py
+++ b/workers/automation/tests/test_application_feedback_candidate_identity_reference_migration.py
@@ -331,7 +331,7 @@ def test_v21_candidates_migrate_every_alias_uuid_url_and_tenant(
     assert (
         reopened.execute("PRAGMA user_version").fetchone()[0]
         == SCHEMA_VERSION
-        == 27
+        == 28
     )
     for table in database_module._APPLICATION_FEEDBACK_CANDIDATE_TABLES:
         assert "job_id" in _columns(reopened, table)

--- a/workers/automation/tests/test_application_outcome_identity_reference_migration.py
+++ b/workers/automation/tests/test_application_outcome_identity_reference_migration.py
@@ -243,7 +243,7 @@ def test_v20_outcomes_migrate_every_alias_uuid_url_and_tenant(
     assert (
         reopened.execute("PRAGMA user_version").fetchone()[0]
         == SCHEMA_VERSION
-        == 27
+        == 28
     )
     assert "job_id" in _columns(reopened, "application_outcomes")
     assert "job_key" not in _columns(reopened, "application_outcomes")

--- a/workers/automation/tests/test_application_review_identity_reference_migration.py
+++ b/workers/automation/tests/test_application_review_identity_reference_migration.py
@@ -204,7 +204,7 @@ def test_v19_review_decisions_migrate_every_alias_and_uuid_url(
     assert (
         reopened.execute("PRAGMA user_version").fetchone()[0]
         == SCHEMA_VERSION
-        == 27
+        == 28
     )
     assert "job_id" in _columns(
         reopened,

--- a/workers/automation/tests/test_compensation_identity_reference_migration.py
+++ b/workers/automation/tests/test_compensation_identity_reference_migration.py
@@ -210,7 +210,7 @@ def test_v18_compensation_migrates_alias_winners_and_uuid_urls(
     assert (
         reopened.execute("PRAGMA user_version").fetchone()[0]
         == SCHEMA_VERSION
-        == 27
+        == 28
     )
     for table in database_module._COMPENSATION_REFERENCE_TABLES:
         assert "job_id" in _columns(reopened, table)

--- a/workers/automation/tests/test_discovery_identity_reference_migration.py
+++ b/workers/automation/tests/test_discovery_identity_reference_migration.py
@@ -220,7 +220,7 @@ def test_v7_discovery_references_migrate_to_stable_job_id_and_reopen(
     init_db(db_path)
     close_connection(db_path)
 
-    assert _user_version(db_path) == SCHEMA_VERSION == 27
+    assert _user_version(db_path) == SCHEMA_VERSION == 28
     assert "job_id" in _columns(db_path, "job_source_observations")
     assert "job_url" not in _columns(db_path, "job_source_observations")
     assert "job_id" in _columns(db_path, "job_canonical_identities")

--- a/workers/automation/tests/test_discovery_production_wiring.py
+++ b/workers/automation/tests/test_discovery_production_wiring.py
@@ -33,6 +33,7 @@ from jobctrl.enrichment.detail import _record_posting_snapshot_from_cascade
 from jobctrl.infrastructure.discovery.production_wiring import (
     ManualCaptureImport,
     _posting_acceptance_policy,
+    _upsert_quarantine_entry,
     build_discovery_acceptance_report,
     import_manual_capture_item,
     retire_invalid_canonical_ats_jobs,
@@ -1125,11 +1126,70 @@ def test_acceptance_report_scoring_handoff_is_tenant_scoped(
         """,
         (shared_job_id,),
     )
+    conn.execute(
+        """
+        INSERT INTO discovery_quarantine_entries (
+            tenant_id, job_id, title, company, source_id,
+            posting_url, reason, confidence, snapshot_version,
+            captured_at, notice_text, status
+        ) VALUES (
+            'other-tenant', ?, 'Foreign quarantine', 'ExampleCo',
+            'source:foreign', 'https://example.com/jobs/foreign-handoff',
+            'unknown_active_state', 0.4, 1,
+            '2026-07-29T10:02:00+00:00', NULL, 'pending'
+        )
+        """,
+        (shared_job_id,),
+    )
     conn.commit()
 
     report = build_discovery_acceptance_report(conn)
 
     assert report.scoring_handoff_count == 1
+
+
+def test_quarantine_upsert_stores_stable_job_identity(
+    conn: sqlite3.Connection,
+) -> None:
+    job_url = "https://example.com/jobs/quarantine-write"
+    stable_job_id = str(uuid.uuid4())
+    conn.execute(
+        """
+        INSERT INTO jobs (
+            url, tenant_id, job_id, title, discovered_at
+        ) VALUES (?, 'local', ?, 'Engineering Manager', ?)
+        """,
+        (
+            job_url,
+            stable_job_id,
+            "2026-07-29T10:00:00+00:00",
+        ),
+    )
+    _upsert_quarantine_entry(
+        conn,
+        job_url=job_url,
+        source_id="source:stable",
+        reason="unknown_active_state",
+        confidence=0.4,
+        snapshot_version=2,
+        captured_at="2026-07-29T10:02:00+00:00",
+        title="Engineering Manager",
+        posting_url=job_url,
+        notice_text="Review current evidence.",
+    )
+
+    row = conn.execute(
+        """
+        SELECT job_id, posting_url, source_id, status
+        FROM discovery_quarantine_entries
+        """
+    ).fetchone()
+    assert tuple(row) == (
+        stable_job_id,
+        job_url,
+        "source:stable",
+        "pending",
+    )
 
 
 def test_discovery_hygiene_applies_to_workday_and_smart_extract_rows(

--- a/workers/automation/tests/test_employer_analysis_identity_reference_migration.py
+++ b/workers/automation/tests/test_employer_analysis_identity_reference_migration.py
@@ -242,7 +242,7 @@ def test_v15_employer_analysis_migrates_alias_histories_and_uuid_urls(
     assert (
         reopened.execute("PRAGMA user_version").fetchone()[0]
         == SCHEMA_VERSION
-        == 27
+        == 28
     )
     for table in database_module._EMPLOYER_ANALYSIS_REFERENCE_TABLES:
         assert "job_id" in _columns(reopened, table)

--- a/workers/automation/tests/test_enrichment_quarantine_gating.py
+++ b/workers/automation/tests/test_enrichment_quarantine_gating.py
@@ -375,6 +375,23 @@ def test_snapshot_captured_event_records_confidence_and_quarantine(
     assert payload["confidence"] == "low"
     assert payload["quarantine_reason"] == "low_confidence_extraction"
     assert payload["quarantined"] is True
+    quarantine = conn.execute(
+        """
+        SELECT quarantine.job_id AS quarantine_job_id,
+               quarantine.posting_url,
+               jobs.job_id AS stable_job_id
+        FROM discovery_quarantine_entries AS quarantine
+        JOIN jobs
+          ON jobs.tenant_id = quarantine.tenant_id
+         AND jobs.job_id = quarantine.job_id
+        WHERE jobs.url = ?
+        """,
+        (url,),
+    ).fetchone()
+    assert quarantine is not None
+    assert quarantine["quarantine_job_id"] == quarantine["stable_job_id"]
+    assert quarantine["posting_url"] == url
+    assert quarantine["quarantine_job_id"] != url
 
 
 def test_no_snapshot_backlog_job_is_never_gated_from_any_selector(

--- a/workers/automation/tests/test_enrichment_snapshot_identity_reference_migration.py
+++ b/workers/automation/tests/test_enrichment_snapshot_identity_reference_migration.py
@@ -322,7 +322,7 @@ def test_v10_enrichment_snapshot_references_migrate_and_reopen(
     init_db(db_path)
     close_connection(db_path)
 
-    assert _user_version(db_path) == SCHEMA_VERSION == 27
+    assert _user_version(db_path) == SCHEMA_VERSION == 28
     check = sqlite3.connect(db_path)
     try:
         enrichment_rows = check.execute(

--- a/workers/automation/tests/test_execution_search_identity_reference_migration.py
+++ b/workers/automation/tests/test_execution_search_identity_reference_migration.py
@@ -261,7 +261,7 @@ def test_v8_execution_and_receipts_migrate_to_stable_job_id_and_reopen(
     init_db(db_path)
     close_connection(db_path)
 
-    assert _user_version(db_path) == SCHEMA_VERSION == 27
+    assert _user_version(db_path) == SCHEMA_VERSION == 28
     assert "job_id" in _columns(db_path, "discovery_execution_jobs")
     assert "job_url" not in _columns(db_path, "discovery_execution_jobs")
     assert "job_id" in _columns(db_path, "discovery_search_unit_jobs")

--- a/workers/automation/tests/test_interview_prep_identity_reference_migration.py
+++ b/workers/automation/tests/test_interview_prep_identity_reference_migration.py
@@ -323,7 +323,7 @@ def test_v17_interview_prep_migrates_alias_histories_and_uuid_urls(
     assert (
         reopened.execute("PRAGMA user_version").fetchone()[0]
         == SCHEMA_VERSION
-        == 27
+        == 28
     )
     for table in database_module._INTERVIEW_PREP_REFERENCE_TABLES:
         assert "job_id" in _columns(reopened, table)

--- a/workers/automation/tests/test_manual_capture_identity_reference_migration.py
+++ b/workers/automation/tests/test_manual_capture_identity_reference_migration.py
@@ -10,7 +10,6 @@ import pytest
 
 import jobctrl.database as database_module
 from jobctrl.database import (
-    SCHEMA_VERSION,
     ensure_discovery_control_tables,
     ensure_manual_capture_references_v27,
     init_db,
@@ -248,11 +247,7 @@ def test_v26_rows_migrate_exactly_with_url_first_resolution(
         database_module._MANUAL_CAPTURE_REFERENCE_TABLES
     )
 
-    assert (
-        conn.execute("PRAGMA user_version").fetchone()[0]
-        == SCHEMA_VERSION
-        == 27
-    )
+    assert conn.execute("PRAGMA user_version").fetchone()[0] == 27
     assert (
         database_module
         ._has_manual_capture_reference_schema_v27(conn)

--- a/workers/automation/tests/test_materials_identity_reference_migration.py
+++ b/workers/automation/tests/test_materials_identity_reference_migration.py
@@ -293,7 +293,7 @@ def test_v14_materials_migrate_alias_histories_and_uuid_shaped_urls(
     close_connection(db_path)
 
     reopened = init_db(db_path)
-    assert reopened.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_VERSION == 27
+    assert reopened.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_VERSION == 28
     for table in database_module._MATERIALS_REFERENCE_TABLES:
         assert "job_id" in _columns(reopened, table)
         assert "job_url" not in _columns(reopened, table)

--- a/workers/automation/tests/test_preparation_identity_reference_migration.py
+++ b/workers/automation/tests/test_preparation_identity_reference_migration.py
@@ -177,7 +177,7 @@ def test_v9_preparation_references_migrate_to_stable_job_ids_and_reopen(
     init_db(db_path)
     close_connection(db_path)
 
-    assert _user_version(db_path) == SCHEMA_VERSION == 27
+    assert _user_version(db_path) == SCHEMA_VERSION == 28
     check = sqlite3.connect(db_path)
     try:
         rows = check.execute(

--- a/workers/automation/tests/test_quarantine_identity_reference_migration.py
+++ b/workers/automation/tests/test_quarantine_identity_reference_migration.py
@@ -1,0 +1,678 @@
+"""Schema-v28 Discovery quarantine stable JobId contracts."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import jobctrl.database as database_module
+from jobctrl.database import (
+    SCHEMA_VERSION,
+    ensure_discovery_control_tables,
+    ensure_quarantine_references_v28,
+    init_db,
+    reassign_discovery_identity_references,
+)
+
+PREVIOUS_SCHEMA_VERSION = 27
+NOW = "2026-07-30T12:00:00+00:00"
+UUID_SHAPED_URL = "11111111-1111-4111-8111-111111111111"
+TARGET_JOB_ID = "22222222-2222-4222-8222-222222222222"
+COLLIDING_JOB_ID = UUID_SHAPED_URL
+PRIOR_JOB_ID = "33333333-3333-4333-8333-333333333333"
+MERGED_JOB_ID = "44444444-4444-4444-8444-444444444444"
+SURVIVOR_JOB_ID = "55555555-5555-4555-8555-555555555555"
+
+
+def _columns(
+    conn: sqlite3.Connection,
+    table: str,
+) -> set[str]:
+    return {
+        str(row[1])
+        for row in conn.execute(
+            f'PRAGMA table_info("{table}")'
+        ).fetchall()
+    }
+
+
+def _insert_job(
+    conn: sqlite3.Connection,
+    *,
+    url: str,
+    job_id: str,
+    tenant_id: str = "local",
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO jobs (
+            url, tenant_id, job_id, title, company, discovered_at
+        ) VALUES (?, ?, ?, 'Platform Engineer', 'ExampleCo', ?)
+        """,
+        (url, tenant_id, job_id, NOW),
+    )
+
+
+def _downgrade_quarantine_table_to_v27(
+    conn: sqlite3.Connection,
+) -> None:
+    conn.commit()
+    conn.execute("PRAGMA foreign_keys = OFF")
+    conn.execute("DROP TABLE discovery_quarantine_entries")
+    database_module._create_quarantine_table_v28(
+        conn,
+        table="discovery_quarantine_entries",
+        stable_reference=False,
+    )
+    conn.execute(
+        f"PRAGMA user_version = {PREVIOUS_SCHEMA_VERSION}"
+    )
+    conn.commit()
+    conn.execute("PRAGMA foreign_keys = ON")
+
+
+def _seed_v27_database(db_path: Path) -> sqlite3.Connection:
+    conn = init_db(db_path)
+    conn.row_factory = sqlite3.Row
+    _downgrade_quarantine_table_to_v27(conn)
+    return conn
+
+
+def _quarantine_snapshot(
+    conn: sqlite3.Connection,
+) -> list[tuple[Any, ...]]:
+    return [
+        tuple(row)
+        for row in conn.execute(
+            """
+            SELECT * FROM discovery_quarantine_entries
+            ORDER BY tenant_id, job_key
+            """
+        ).fetchall()
+    ]
+
+
+def _insert_legacy_quarantine(
+    conn: sqlite3.Connection,
+    *,
+    tenant_id: str,
+    job_url: str,
+    title: str,
+    source_id: str,
+    posting_url: str,
+    reason: str,
+    confidence: float,
+    snapshot_version: int,
+    captured_at: str,
+    notice_text: str,
+    status: str,
+    decision_reason: str | None = None,
+    decided_at: str | None = None,
+    job_id_url: str | None = None,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO discovery_quarantine_entries (
+            tenant_id, job_id, job_key, title, company, source_id,
+            posting_url, reason, confidence, snapshot_version,
+            captured_at, notice_text, status, decision_reason,
+            decided_at
+        ) VALUES (
+            ?, ?, ?, ?, 'ExampleCo', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+        )
+        """,
+        (
+            tenant_id,
+            job_id_url or job_url,
+            job_url,
+            title,
+            source_id,
+            posting_url,
+            reason,
+            confidence,
+            snapshot_version,
+            captured_at,
+            notice_text,
+            status,
+            decision_reason,
+            decided_at,
+        ),
+    )
+
+
+def test_v27_rows_migrate_and_duplicate_authorities_merge(
+    tmp_path: Path,
+) -> None:
+    conn = _seed_v27_database(tmp_path / "jobs.db")
+    colliding_owner_url = (
+        "https://careers.example.test/uuid-id-owner"
+    )
+    prior_url = "https://careers.example.test/prior"
+    prior_alias = "https://legacy.example.test/prior"
+    merged_url = "https://careers.example.test/merged"
+    merged_alias = "https://legacy.example.test/merged"
+    blue_url = "https://blue.example.test/target"
+    _insert_job(
+        conn,
+        url=UUID_SHAPED_URL,
+        job_id=TARGET_JOB_ID,
+    )
+    _insert_job(
+        conn,
+        url=colliding_owner_url,
+        job_id=COLLIDING_JOB_ID,
+    )
+    _insert_job(conn, url=prior_url, job_id=PRIOR_JOB_ID)
+    _insert_job(conn, url=merged_url, job_id=MERGED_JOB_ID)
+    _insert_job(
+        conn,
+        url=blue_url,
+        job_id=TARGET_JOB_ID,
+        tenant_id="blue",
+    )
+    conn.executemany(
+        """
+        INSERT INTO job_identity_aliases (
+            tenant_id, alias_kind, alias_value, job_id, created_at
+        ) VALUES ('local', 'posting_url', ?, ?, ?)
+        """,
+        (
+            (prior_alias, PRIOR_JOB_ID, NOW),
+            (merged_alias, MERGED_JOB_ID, NOW),
+        ),
+    )
+    _insert_legacy_quarantine(
+        conn,
+        tenant_id="local",
+        job_url=UUID_SHAPED_URL,
+        title="UUID URL",
+        source_id="source:uuid",
+        posting_url=UUID_SHAPED_URL,
+        reason="unknown_active_state",
+        confidence=0.4,
+        snapshot_version=1,
+        captured_at="2026-07-30T09:00:00+00:00",
+        notice_text="UUID-shaped URL evidence",
+        status="pending",
+    )
+    _insert_legacy_quarantine(
+        conn,
+        tenant_id="local",
+        job_url=prior_alias,
+        title="Alias URL",
+        source_id="source:alias",
+        posting_url=prior_alias,
+        reason="user_review_requested",
+        confidence=0.6,
+        snapshot_version=2,
+        captured_at="2026-07-30T09:30:00+00:00",
+        notice_text="Alias evidence",
+        status="approve",
+        decision_reason="Reviewed alias",
+        decided_at="2026-07-30T09:45:00+00:00",
+    )
+    _insert_legacy_quarantine(
+        conn,
+        tenant_id="blue",
+        job_url=blue_url,
+        title="Blue tenant",
+        source_id="source:blue",
+        posting_url=blue_url,
+        reason="broad_board_only",
+        confidence=0.5,
+        snapshot_version=1,
+        captured_at="2026-07-30T10:00:00+00:00",
+        notice_text="Blue evidence",
+        status="pending",
+    )
+    _insert_legacy_quarantine(
+        conn,
+        tenant_id="local",
+        job_url=merged_url,
+        title="Older reviewed capture",
+        source_id="source:older",
+        posting_url=merged_url,
+        reason="low_confidence_extraction",
+        confidence=0.3,
+        snapshot_version=3,
+        captured_at="2026-07-30T10:00:00+00:00",
+        notice_text="Older review evidence",
+        status="reject",
+        decision_reason="Rejected older capture",
+        decided_at="2026-07-30T10:30:00+00:00",
+    )
+    _insert_legacy_quarantine(
+        conn,
+        tenant_id="local",
+        job_url=merged_alias,
+        title="Newest pending capture",
+        source_id="source:newest",
+        posting_url=merged_alias,
+        reason="policy_overridden",
+        confidence=0.8,
+        snapshot_version=4,
+        captured_at="2026-07-30T11:00:00+00:00",
+        notice_text="Newest pending evidence",
+        status="pending",
+    )
+    conn.commit()
+
+    assert ensure_quarantine_references_v28(
+        conn
+    ) == list(database_module._QUARANTINE_REFERENCE_TABLES)
+
+    assert (
+        conn.execute("PRAGMA user_version").fetchone()[0]
+        == SCHEMA_VERSION
+        == 28
+    )
+    assert database_module._has_quarantine_reference_schema_v28(
+        conn
+    )
+    assert [
+        tuple(row)
+        for row in conn.execute(
+            """
+            SELECT tenant_id, job_id, title, source_id, posting_url,
+                   reason, confidence, snapshot_version, captured_at,
+                   notice_text, status, decision_reason, decided_at
+            FROM discovery_quarantine_entries
+            ORDER BY tenant_id, job_id
+            """
+        ).fetchall()
+    ] == [
+        (
+            "blue",
+            TARGET_JOB_ID,
+            "Blue tenant",
+            "source:blue",
+            blue_url,
+            "broad_board_only",
+            0.5,
+            1,
+            "2026-07-30T10:00:00+00:00",
+            "Blue evidence",
+            "pending",
+            None,
+            None,
+        ),
+        (
+            "local",
+            TARGET_JOB_ID,
+            "UUID URL",
+            "source:uuid",
+            UUID_SHAPED_URL,
+            "unknown_active_state",
+            0.4,
+            1,
+            "2026-07-30T09:00:00+00:00",
+            "UUID-shaped URL evidence",
+            "pending",
+            None,
+            None,
+        ),
+        (
+            "local",
+            PRIOR_JOB_ID,
+            "Alias URL",
+            "source:alias",
+            prior_alias,
+            "user_review_requested",
+            0.6,
+            2,
+            "2026-07-30T09:30:00+00:00",
+            "Alias evidence",
+            "approve",
+            "Reviewed alias",
+            "2026-07-30T09:45:00+00:00",
+        ),
+        (
+            "local",
+            MERGED_JOB_ID,
+            "Newest pending capture",
+            "source:newest",
+            merged_alias,
+            "policy_overridden",
+            0.8,
+            4,
+            "2026-07-30T11:00:00+00:00",
+            "Newest pending evidence",
+            "pending",
+            "Rejected older capture",
+            "2026-07-30T10:30:00+00:00",
+        ),
+    ]
+    assert {
+        str(row[6]).upper()
+        for row in conn.execute(
+            'PRAGMA foreign_key_list("discovery_quarantine_entries")'
+        ).fetchall()
+    } == {"CASCADE"}
+    assert conn.execute(
+        "PRAGMA foreign_key_check"
+    ).fetchone() is None
+
+
+def test_unresolved_reference_rolls_back_and_retry_succeeds(
+    tmp_path: Path,
+) -> None:
+    conn = _seed_v27_database(tmp_path / "retry.db")
+    missing_url = "https://careers.example.test/retry"
+    _insert_legacy_quarantine(
+        conn,
+        tenant_id="local",
+        job_url=missing_url,
+        title="Retry",
+        source_id="source:retry",
+        posting_url=missing_url,
+        reason="unknown_active_state",
+        confidence=0.2,
+        snapshot_version=1,
+        captured_at=NOW,
+        notice_text="Retry evidence",
+        status="pending",
+    )
+    conn.commit()
+    before = _quarantine_snapshot(conn)
+
+    with pytest.raises(
+        RuntimeError,
+        match="could not resolve both URL-era identity columns",
+    ):
+        ensure_quarantine_references_v28(conn)
+
+    assert (
+        conn.execute("PRAGMA user_version").fetchone()[0]
+        == PREVIOUS_SCHEMA_VERSION
+    )
+    assert _quarantine_snapshot(conn) == before
+    assert "job_key" in _columns(
+        conn,
+        "discovery_quarantine_entries",
+    )
+    assert conn.execute(
+        """
+        SELECT COUNT(*) FROM sqlite_master
+        WHERE type = 'table'
+          AND name = 'discovery_quarantine_entries_v28'
+        """
+    ).fetchone()[0] == 0
+
+    _insert_job(conn, url=missing_url, job_id=TARGET_JOB_ID)
+    conn.commit()
+    ensure_quarantine_references_v28(conn)
+    assert conn.execute(
+        "SELECT job_id FROM discovery_quarantine_entries"
+    ).fetchone()[0] == TARGET_JOB_ID
+
+
+def test_conflicting_legacy_identity_columns_fail_closed(
+    tmp_path: Path,
+) -> None:
+    conn = _seed_v27_database(tmp_path / "conflict.db")
+    first_url = "https://careers.example.test/first"
+    second_url = "https://careers.example.test/second"
+    _insert_job(conn, url=first_url, job_id=TARGET_JOB_ID)
+    _insert_job(conn, url=second_url, job_id=PRIOR_JOB_ID)
+    _insert_legacy_quarantine(
+        conn,
+        tenant_id="local",
+        job_url=second_url,
+        job_id_url=first_url,
+        title="Conflicting identity",
+        source_id="source:conflict",
+        posting_url=second_url,
+        reason="unknown_active_state",
+        confidence=0.1,
+        snapshot_version=1,
+        captured_at=NOW,
+        notice_text="Conflict",
+        status="pending",
+    )
+    conn.commit()
+    before = _quarantine_snapshot(conn)
+
+    with pytest.raises(
+        RuntimeError,
+        match="conflicting URL-era identity columns",
+    ):
+        ensure_quarantine_references_v28(conn)
+
+    assert _quarantine_snapshot(conn) == before
+    assert (
+        conn.execute("PRAGMA user_version").fetchone()[0]
+        == PREVIOUS_SCHEMA_VERSION
+    )
+
+
+def test_verification_failure_rolls_back_and_retry_succeeds(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    conn = _seed_v27_database(tmp_path / "verify.db")
+    job_url = "https://careers.example.test/verify"
+    _insert_job(conn, url=job_url, job_id=TARGET_JOB_ID)
+    _insert_legacy_quarantine(
+        conn,
+        tenant_id="local",
+        job_url=job_url,
+        title="Verify",
+        source_id="source:verify",
+        posting_url=job_url,
+        reason="unknown_active_state",
+        confidence=0.4,
+        snapshot_version=1,
+        captured_at=NOW,
+        notice_text="Verification evidence",
+        status="pending",
+    )
+    conn.commit()
+    before = _quarantine_snapshot(conn)
+    original_verify = (
+        database_module._verify_quarantine_references_v28
+    )
+
+    def _fail_verification(
+        _conn: sqlite3.Connection,
+        *,
+        expected_count: int,
+    ) -> None:
+        del expected_count
+        raise RuntimeError(
+            "injected quarantine verification failure"
+        )
+
+    monkeypatch.setattr(
+        database_module,
+        "_verify_quarantine_references_v28",
+        _fail_verification,
+    )
+    with pytest.raises(
+        RuntimeError,
+        match="injected quarantine verification failure",
+    ):
+        ensure_quarantine_references_v28(conn)
+    assert _quarantine_snapshot(conn) == before
+    assert (
+        conn.execute("PRAGMA user_version").fetchone()[0]
+        == PREVIOUS_SCHEMA_VERSION
+    )
+
+    monkeypatch.setattr(
+        database_module,
+        "_verify_quarantine_references_v28",
+        original_verify,
+    )
+    ensure_quarantine_references_v28(conn)
+    assert conn.execute(
+        "SELECT job_id FROM discovery_quarantine_entries"
+    ).fetchone()[0] == TARGET_JOB_ID
+
+
+@pytest.mark.parametrize(
+    ("schema_version", "stable"),
+    ((0, False), (27, False), (28, True)),
+)
+def test_missing_table_recovery_is_schema_version_aware(
+    schema_version: int,
+    stable: bool,
+) -> None:
+    conn = sqlite3.connect(":memory:")
+    conn.executescript(
+        f"""
+        CREATE TABLE jobs (
+            url TEXT PRIMARY KEY,
+            tenant_id TEXT NOT NULL DEFAULT 'local',
+            job_id TEXT NOT NULL,
+            UNIQUE (tenant_id, job_id)
+        );
+        PRAGMA user_version = {schema_version};
+        """
+    )
+
+    ensure_discovery_control_tables(conn)
+
+    columns = _columns(
+        conn,
+        "discovery_quarantine_entries",
+    )
+    assert ("job_key" not in columns) is stable
+    if stable:
+        assert database_module._has_quarantine_reference_schema_v28(
+            conn
+        )
+
+
+def test_stamped_v28_legacy_table_fails_closed() -> None:
+    conn = sqlite3.connect(":memory:")
+    conn.executescript(
+        """
+        CREATE TABLE jobs (
+            url TEXT PRIMARY KEY,
+            tenant_id TEXT NOT NULL DEFAULT 'local',
+            job_id TEXT NOT NULL,
+            UNIQUE (tenant_id, job_id)
+        );
+        PRAGMA user_version = 27;
+        """
+    )
+    ensure_discovery_control_tables(conn)
+    conn.execute("PRAGMA user_version = 28")
+
+    with pytest.raises(
+        RuntimeError,
+        match="Schema v28 requires stable Discovery quarantine",
+    ):
+        ensure_discovery_control_tables(conn)
+
+
+def test_runtime_collision_merges_current_projection(
+    tmp_path: Path,
+) -> None:
+    conn = init_db(tmp_path / "collision.db")
+    losing_url = "https://careers.example.test/losing"
+    surviving_url = "https://careers.example.test/surviving"
+    _insert_job(conn, url=losing_url, job_id=TARGET_JOB_ID)
+    _insert_job(
+        conn,
+        url=surviving_url,
+        job_id=SURVIVOR_JOB_ID,
+    )
+    conn.executemany(
+        """
+        INSERT INTO discovery_quarantine_entries (
+            tenant_id, job_id, title, company, source_id,
+            posting_url, reason, confidence, snapshot_version,
+            captured_at, notice_text, status, decision_reason,
+            decided_at
+        ) VALUES (
+            'local', ?, ?, 'ExampleCo', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+        )
+        """,
+        (
+            (
+                TARGET_JOB_ID,
+                "Newest losing capture",
+                "source:losing",
+                losing_url,
+                "policy_overridden",
+                0.8,
+                4,
+                "2026-07-30T11:00:00+00:00",
+                "Newest evidence",
+                "pending",
+                None,
+                None,
+            ),
+            (
+                SURVIVOR_JOB_ID,
+                "Older survivor capture",
+                "source:surviving",
+                surviving_url,
+                "low_confidence_extraction",
+                0.3,
+                3,
+                "2026-07-30T10:00:00+00:00",
+                "Older evidence",
+                "reject",
+                "Reviewed survivor",
+                "2026-07-30T10:30:00+00:00",
+            ),
+        ),
+    )
+    conn.commit()
+
+    reassign_discovery_identity_references(
+        conn,
+        losing_job_url=losing_url,
+        surviving_job_url=surviving_url,
+    )
+    conn.execute(
+        """
+        DELETE FROM jobs
+        WHERE tenant_id = 'local' AND job_id = ?
+        """,
+        (TARGET_JOB_ID,),
+    )
+
+    assert [
+        tuple(row)
+        for row in conn.execute(
+            """
+            SELECT job_id, title, source_id, posting_url, reason,
+                   confidence, snapshot_version, captured_at,
+                   notice_text, status, decision_reason, decided_at
+            FROM discovery_quarantine_entries
+            """
+        ).fetchall()
+    ] == [
+        (
+            SURVIVOR_JOB_ID,
+            "Newest losing capture",
+            "source:losing",
+            losing_url,
+            "policy_overridden",
+            0.8,
+            4,
+            "2026-07-30T11:00:00+00:00",
+            "Newest evidence",
+            "pending",
+            "Reviewed survivor",
+            "2026-07-30T10:30:00+00:00",
+        )
+    ]
+    assert (
+        database_module._resolve_job_reference_value(
+            conn,
+            tenant_id="local",
+            reference=losing_url,
+            legacy_url=True,
+        )
+        is None
+    )
+    assert conn.execute(
+        "PRAGMA foreign_key_check"
+    ).fetchone() is None

--- a/workers/automation/tests/test_repeat_application_identity_reference_migration.py
+++ b/workers/automation/tests/test_repeat_application_identity_reference_migration.py
@@ -402,7 +402,7 @@ def test_v22_history_migrates_exactly_with_url_first_resolution(
     reopened = init_db(db_path)
     assert reopened.execute("PRAGMA user_version").fetchone()[0] == (
         SCHEMA_VERSION
-    ) == 27
+    ) == 28
     assert database_module._has_repeat_application_reference_schema_v23(
         reopened
     )

--- a/workers/automation/tests/test_repeat_application_prevention.py
+++ b/workers/automation/tests/test_repeat_application_prevention.py
@@ -799,7 +799,7 @@ def test_schema_v5_migrates_additively_without_changing_application_facts(
         (PRIOR,),
     ).fetchall()
 
-    assert int(migrated.execute("PRAGMA user_version").fetchone()[0]) == SCHEMA_VERSION == 27
+    assert int(migrated.execute("PRAGMA user_version").fetchone()[0]) == SCHEMA_VERSION == 28
     assert [tuple(row) for row in after] == [tuple(row) for row in before]
     assert "metadata_json" in {
         str(row[1]) for row in migrated.execute("PRAGMA table_info(job_stage_states)").fetchall()

--- a/workers/automation/tests/test_resume_template_identity_reference_migration.py
+++ b/workers/automation/tests/test_resume_template_identity_reference_migration.py
@@ -254,7 +254,7 @@ def test_v16_template_references_migrate_aliases_and_uuid_urls(
     assert (
         reopened.execute("PRAGMA user_version").fetchone()[0]
         == SCHEMA_VERSION
-        == 27
+        == 28
     )
     for table in database_module._RESUME_TEMPLATE_REFERENCE_TABLES:
         assert "job_id" in _columns(reopened, table)

--- a/workers/automation/tests/test_scoring_identity_reference_migration.py
+++ b/workers/automation/tests/test_scoring_identity_reference_migration.py
@@ -338,7 +338,7 @@ def test_v11_scoring_references_migrate_alias_histories_and_reopen(
     assert (
         int(migrated.execute("PRAGMA user_version").fetchone()[0])
         == SCHEMA_VERSION
-        == 27
+        == 28
     )
     assert _columns(migrated, "job_scores") >= {"tenant_id", "job_id"}
     assert "job_url" not in _columns(migrated, "job_scores")
@@ -404,7 +404,7 @@ def test_v11_scoring_references_migrate_alias_histories_and_reopen(
     assert (
         int(reopened.execute("PRAGMA user_version").fetchone()[0])
         == SCHEMA_VERSION
-        == 27
+        == 28
     )
 
 
@@ -553,7 +553,7 @@ def test_scoring_migration_rolls_back_and_retries_after_verification_failure(
     assert (
         int(retried.execute("PRAGMA user_version").fetchone()[0])
         == SCHEMA_VERSION
-        == 27
+        == 28
     )
     assert [
         tuple(row)

--- a/workers/automation/tests/test_stable_job_identity_migration.py
+++ b/workers/automation/tests/test_stable_job_identity_migration.py
@@ -841,7 +841,7 @@ def test_v6_jobs_gain_stable_uuid_and_posting_url_alias_once(
     init_db(db_path)
     close_connection(db_path)
 
-    assert _user_version(db_path) == SCHEMA_VERSION == 27
+    assert _user_version(db_path) == SCHEMA_VERSION == 28
     first_ids = _identity_rows(db_path)
     assert [row[0] for row in first_ids] == ["local", "local"]
     for _tenant_id, job_id, _url in first_ids:


### PR DESCRIPTION
## Summary

- add schema v28 and migrate the current Discovery quarantine authority from URL-shaped `job_id`/`job_key` fields to tenant-scoped stable `JobId`
- resolve URL-era identities URL-first, fail closed on conflicts or unresolved rows, and collapse duplicate current projections deterministically while preserving the latest prior decision metadata for a new pending capture
- update worker/enrichment writers, acceptance reporting, API list/decision compatibility, collision rehome, and permanent deletion for the stable reference
- keep pre-Phase4 DTO/event payloads URL-shaped while storing audit events against the surviving FK-valid canonical URL
- make quarantine decisions and their audit events atomic, including the collision path where the preserved posting URL is no longer an active alias

Stacked on #556. Tombstones and remaining lifecycle references follow in separate reviewable PRs. Canonical product docs and cumulative product QA remain deferred to the final unreleased stack PR.

## Why

`discovery_quarantine_entries` was still a URL-keyed current authority. That allowed one logical job to acquire multiple quarantine rows and made identity-collision cleanup unsafe. This migration gives each tenant/JobId one current quarantine projection without rewriting snapshot or event history.

## Validation

- `corepack pnpm --filter @jobctrl/api test` — 60 files, 726 tests passed
- `corepack pnpm --filter @jobctrl/api check` — passed
- focused API quarantine/discovery/schema tests — 33 passed
- full Python suite — 2780 passed, 2 skipped (before the final API-only atomicity repair)
- focused Python quarantine migration and runtime paths — 22 passed after collision regression updates
- full and focused Ruff checks — passed
- `uv lock --check --exclude-newer 2026-07-09T19:15:43.240437Z` — passed
- `git diff --check` — passed
- independent Tier 3 reviewer gate — PASS, 0 findings
- independent Tier 3 QA gate — PASS, including real `resolve_all_urls` collision → list → decision and injected event-failure rollback

## Risk controls

- migration uses a savepoint and stamps v28 only after schema, count, UUID, foreign-key, and orphan verification
- UUID-shaped posting URLs resolve as URLs before any stable-ID interpretation
- ambiguous preserved posting URLs fail closed
- private quarantine notice text is not copied into the event payload
- foreign-key-on and foreign-key-off permanent deletion are covered
