### PR TITLE
feat(discovery): migrate delete tombstones to stable JobIds

### DIFF
--- a/apps/api/src/db.ts
+++ b/apps/api/src/db.ts
@@ -9,7 +9,7 @@ export type SqliteValue = string | number | bigint | null;
 // writer that stamps ``PRAGMA user_version``; the API only reads it to fail
 // closed on a database written by a newer build. Bump both constants together
 // whenever the schema shape changes.
-export const SUPPORTED_SCHEMA_VERSION = 28;
+export const SUPPORTED_SCHEMA_VERSION = 29;
 
 export class IncompatibleSchemaVersionError extends Error {
   constructor(current: number) {
@@ -191,6 +191,112 @@ export function jobReferenceJoinToJobs(
     : `${sourceAlias}.job_url = ${jobsAlias}.url`;
 }
 
+function hasPostingUrlAliasSchema(db: SqliteDatabase): boolean {
+  const columns = tableColumnSet(db, "job_identity_aliases");
+  const jobColumns = tableColumnSet(db, "jobs");
+  return (
+    ["tenant_id", "alias_kind", "alias_value", "job_id"].every(
+      (column) => columns.has(column),
+    )
+    && ["tenant_id", "job_id", "url"].every(
+      (column) => jobColumns.has(column),
+    )
+  );
+}
+
+export function stableJobIdForUrlSqlExpression(
+  db: SqliteDatabase,
+  tenantExpression: string,
+  jobUrlExpression: string,
+): string {
+  const jobColumns = tableColumnSet(db, "jobs");
+  if (!jobColumns.has("job_id") || !jobColumns.has("url")) {
+    return "NULL";
+  }
+  const tenantPredicate = jobColumns.has("tenant_id")
+    ? `lifecycle_job.tenant_id = ${tenantExpression} AND `
+    : "";
+  const directUrl = `(SELECT lifecycle_job.job_id
+        FROM jobs AS lifecycle_job
+        WHERE ${tenantPredicate}lifecycle_job.url = ${jobUrlExpression}
+        LIMIT 1
+      )`;
+  if (!hasPostingUrlAliasSchema(db)) {
+    return directUrl;
+  }
+  const postingUrlAlias = `(SELECT lifecycle_alias.job_id
+        FROM job_identity_aliases AS lifecycle_alias
+        JOIN jobs AS lifecycle_alias_job
+          ON lifecycle_alias_job.tenant_id = lifecycle_alias.tenant_id
+         AND lifecycle_alias_job.job_id = lifecycle_alias.job_id
+        WHERE lifecycle_alias.tenant_id = ${tenantExpression}
+          AND lifecycle_alias.alias_kind = 'posting_url'
+          AND lifecycle_alias.alias_value = ${jobUrlExpression}
+        LIMIT 1
+      )`;
+  // URL-shaped legacy values must resolve as URLs before any other identity
+  // interpretation. This also makes a current URL win if an old posting alias
+  // happens to contain the same UUID-shaped text.
+  return `COALESCE(${directUrl}, ${postingUrlAlias})`;
+}
+
+export function canonicalJobUrlForUrlSqlExpression(
+  db: SqliteDatabase,
+  tenantExpression: string,
+  jobUrlExpression: string,
+): string {
+  const jobColumns = tableColumnSet(db, "jobs");
+  if (!jobColumns.has("url")) {
+    return jobUrlExpression;
+  }
+  const tenantPredicate = jobColumns.has("tenant_id")
+    ? `lifecycle_job.tenant_id = ${tenantExpression} AND `
+    : "";
+  const directUrl = `(SELECT lifecycle_job.url
+        FROM jobs AS lifecycle_job
+        WHERE ${tenantPredicate}lifecycle_job.url = ${jobUrlExpression}
+        LIMIT 1
+      )`;
+  if (!hasPostingUrlAliasSchema(db)) {
+    return `COALESCE(${directUrl}, ${jobUrlExpression})`;
+  }
+  const postingUrlAlias = `(SELECT lifecycle_alias_job.url
+        FROM job_identity_aliases AS lifecycle_alias
+        JOIN jobs AS lifecycle_alias_job
+          ON lifecycle_alias_job.tenant_id = lifecycle_alias.tenant_id
+         AND lifecycle_alias_job.job_id = lifecycle_alias.job_id
+        WHERE lifecycle_alias.tenant_id = ${tenantExpression}
+          AND lifecycle_alias.alias_kind = 'posting_url'
+          AND lifecycle_alias.alias_value = ${jobUrlExpression}
+        LIMIT 1
+      )`;
+  return `COALESCE(${directUrl}, ${postingUrlAlias}, ${jobUrlExpression})`;
+}
+
+export function jobReferenceJoinToUrl(
+  db: SqliteDatabase,
+  tableName: string,
+  sourceAlias: string,
+  tenantExpression: string,
+  jobUrlExpression: string,
+): string {
+  return jobReferenceColumn(db, tableName) === "job_id"
+    ? `${sourceAlias}.tenant_id = ${tenantExpression} AND ${sourceAlias}.job_id = ${stableJobIdForUrlSqlExpression(
+        db,
+        tenantExpression,
+        jobUrlExpression,
+      )}`
+    : `${sourceAlias}.job_url = ${jobUrlExpression}`;
+}
+
+export function jobReferenceMissingSql(
+  db: SqliteDatabase,
+  tableName: string,
+  sourceAlias: string,
+): string {
+  return `${sourceAlias}.${jobReferenceColumn(db, tableName)} IS NULL`;
+}
+
 export function jobKeyReferenceColumn(
   db: SqliteDatabase,
   tableName: string,
@@ -341,6 +447,9 @@ const jobLifecycleTableSpecs: JobLifecycleTableSpec[] = [
 export function migrateLegacyJobTables(db: SqliteDatabase): string[] {
   return db.transaction(() => {
     const migrated = new Set<string>();
+    const schemaVersion = Number(
+      db.pragma("user_version", { simple: true }),
+    );
     for (const spec of jobLifecycleTableSpecs) {
       const suffix = spec.suffix;
       const currentTable = spec.currentTable;
@@ -349,6 +458,58 @@ export function migrateLegacyJobTables(db: SqliteDatabase): string[] {
         .filter((legacyTable) => tableExists(db, legacyTable));
       const currentExists = tableExists(db, currentTable);
       if (existingLegacyTables.length === 0 && !currentExists) continue;
+      if (
+        suffix === "deleted_jobs"
+        && currentExists
+        && schemaVersion < 29
+      ) {
+        const currentColumns = new Set(
+          tableColumns(db, currentTable),
+        );
+        const stableCurrent = (
+          currentColumns.has("tenant_id")
+          && currentColumns.has("job_id")
+          && !currentColumns.has("job_url")
+        );
+        if (stableCurrent) {
+          if (existingLegacyTables.length > 0) {
+            throw new Error(
+              "Cannot merge URL-era branded soft-delete "
+                + "tables into stable JobId tombstones.",
+            );
+          }
+          continue;
+        }
+      }
+      if (
+        suffix === "deleted_jobs"
+        && schemaVersion >= 29
+      ) {
+        if (existingLegacyTables.length > 0) {
+          throw new Error(
+            "Schema v29 cannot merge URL-era branded soft-delete "
+              + "tables after the stable JobId cutover.",
+          );
+        }
+        const columns = new Set(tableColumns(db, currentTable));
+        if (
+          !columns.has("tenant_id")
+          || !columns.has("job_id")
+          || columns.has("job_url")
+          || primaryKeyColumns(db, currentTable).join(",")
+            !== "tenant_id,job_id"
+          || !hasCompositeJobIdForeignKey(
+            db,
+            currentTable,
+          )
+        ) {
+          throw new Error(
+            "Schema v29 requires stable soft-delete "
+              + "tombstone JobId references.",
+          );
+        }
+        continue;
+      }
 
       for (const legacyTable of existingLegacyTables) {
         const legacyColumns = tableColumns(db, legacyTable);
@@ -416,6 +577,22 @@ function assertNoLifecycleMigrationConflicts(db: SqliteDatabase, currentTable: s
 
 function tableColumns(db: SqliteDatabase, tableName: string): string[] {
   return db.prepare(`PRAGMA table_info(${quoteIdentifier(tableName)})`).all().map((row) => String((row as { name: unknown }).name));
+}
+
+function primaryKeyColumns(
+  db: SqliteDatabase,
+  tableName: string,
+): string[] {
+  return (
+    db
+      .prepare(
+        `PRAGMA table_info(${quoteIdentifier(tableName)})`,
+      )
+      .all() as Array<{ name: string; pk: number }>
+  )
+    .filter((row) => row.pk > 0)
+    .sort((left, right) => left.pk - right.pk)
+    .map((row) => row.name);
 }
 
 function quoteIdentifier(identifier: string): string {

--- a/apps/api/src/projections.ts
+++ b/apps/api/src/projections.ts
@@ -31,6 +31,8 @@ import {
   jobReferenceColumn,
   jobReferenceForUrl,
   jobReferenceJoinToJobs,
+  jobReferenceJoinToUrl,
+  jobReferenceMissingSql,
   jobReferencePredicateForUrl,
   tableColumnSet,
   tableExists,
@@ -2659,7 +2661,11 @@ function attachResumeUsages(
           AND provenance_jobs.job_id = provenance.job_id`
     : "";
   const jobMetadata = jobMetadataJoinSql(db, jobUrlExpression);
-  const lifecycle = jobLifecycleExclusionSql(db, jobUrlExpression);
+  const lifecycle = jobLifecycleExclusionSql(
+    db,
+    jobUrlExpression,
+    "provenance.tenant_id",
+  );
   const latestIdentityMatch = stableReferences
     ? "latest.job_id = provenance.job_id"
     : "latest.job_url = provenance.job_url";
@@ -2732,7 +2738,11 @@ function attachRequirementUsagesAndGaps(
         AND score_jobs.job_id = items.job_id`
     : "";
   const jobMetadata = jobMetadataJoinSql(db, jobUrlExpression);
-  const lifecycle = jobLifecycleExclusionSql(db, jobUrlExpression);
+  const lifecycle = jobLifecycleExclusionSql(
+    db,
+    jobUrlExpression,
+    "items.tenant_id",
+  );
   const rows = allRows<RequirementFitItemRow & {
     job_url: string;
     score_version: number;
@@ -2821,7 +2831,11 @@ function attachSkillCoverageUsagesAndGaps(
   gaps: Map<string, EvidenceGapPayload>,
 ): void {
   if (!tableExists(db, "artifact_list_projections")) return;
-  const lifecycle = jobLifecycleExclusionSql(db, "alp.job_id");
+  const lifecycle = jobLifecycleExclusionSql(
+    db,
+    "alp.job_id",
+    "alp.tenant_id",
+  );
   const rows = allRows<{
     job_id: string;
     job_title: string;
@@ -3225,25 +3239,52 @@ function loadLatestApplyRun(db: SqliteDatabase, jobUrl: string): ApplyLatest {
 
 function loadDeletedAt(db: SqliteDatabase, jobUrl: string): string | null {
   if (!tableExists(db, "jobctrl_deleted_jobs")) return null;
+  const reference = jobReferencePredicateForUrl(
+    db,
+    "jobctrl_deleted_jobs",
+    jobUrl,
+  );
   const row = getRow<{ deleted_at: string | null }>(
     db,
-    "SELECT deleted_at FROM jobctrl_deleted_jobs WHERE job_url = ? AND (restored_at IS NULL OR julianday(restored_at) <= julianday(deleted_at))",
-    [jobUrl],
+    `SELECT deleted_at
+     FROM jobctrl_deleted_jobs
+     WHERE ${reference.sql}
+       AND (
+         restored_at IS NULL
+         OR julianday(restored_at) <= julianday(deleted_at)
+       )`,
+    reference.params,
   );
   return row ? nullableString(row.deleted_at) : null;
 }
 
 function staleDeletedProjectionJobs(db: SqliteDatabase, tenantId: string): string[] {
   if (!tableExists(db, "jobctrl_deleted_jobs")) return [];
+  const deletedJoin = jobReferenceJoinToUrl(
+    db,
+    "jobctrl_deleted_jobs",
+    "d",
+    "p.tenant_id",
+    "p.job_id",
+  );
   const rows = allRows<{ job_id: string }>(
     db,
     `SELECT p.job_id
      FROM job_list_projections p
      JOIN jobctrl_deleted_jobs d
-       ON d.job_url = p.job_id
+       ON ${deletedJoin}
      WHERE p.tenant_id = ?
-       AND (d.restored_at IS NULL OR julianday(d.restored_at) <= julianday(d.deleted_at))
-       AND (p.deleted_at IS NULL OR p.deleted_at != d.deleted_at)`,
+       AND (
+         (
+           (d.restored_at IS NULL OR julianday(d.restored_at) <= julianday(d.deleted_at))
+           AND (p.deleted_at IS NULL OR p.deleted_at != d.deleted_at)
+         )
+         OR (
+           d.restored_at IS NOT NULL
+           AND julianday(d.restored_at) > julianday(d.deleted_at)
+           AND p.deleted_at IS NOT NULL
+         )
+       )`,
     [tenantId],
   );
   return rows.map((row) => row.job_id).filter(Boolean);
@@ -4533,7 +4574,16 @@ function rebuildDashboardProjection(db: SqliteDatabase, tenantId: string): void 
       const hasHidden = tableExists(db, "jobctrl_hidden_jobs");
       const hasSnapshots = tableExists(db, "posting_snapshot_sets");
       const deletedJoin = hasDeleted
-        ? " LEFT JOIN jobctrl_deleted_jobs d ON d.job_url = arp.job_id AND (d.restored_at IS NULL OR julianday(d.restored_at) <= julianday(d.deleted_at))"
+        ? ` LEFT JOIN jobctrl_deleted_jobs d ON ${jobReferenceJoinToUrl(
+            db,
+            "jobctrl_deleted_jobs",
+            "d",
+            "arp.tenant_id",
+            "arp.job_id",
+          )} AND (
+            d.restored_at IS NULL
+            OR julianday(d.restored_at) <= julianday(d.deleted_at)
+          )`
         : "";
       const hiddenJoin = hasHidden
         ? " LEFT JOIN jobctrl_hidden_jobs h ON h.job_url = arp.job_id AND h.unhidden_at IS NULL"
@@ -4544,7 +4594,13 @@ function rebuildDashboardProjection(db: SqliteDatabase, tenantId: string): void 
           : " LEFT JOIN posting_snapshot_sets pss ON pss.tenant_id = arp.tenant_id AND pss.job_url = arp.job_id"
         : "";
       const lifecycleWhere = [
-        hasDeleted ? "d.job_url IS NULL" : "",
+        hasDeleted
+          ? jobReferenceMissingSql(
+              db,
+              "jobctrl_deleted_jobs",
+              "d",
+            )
+          : "",
         hasHidden ? "h.job_url IS NULL" : "",
         hasSnapshots
           ? `(pss.latest_active_state IS NULL OR pss.latest_active_state NOT IN (${CLOSED_ACTIVE_STATES.map((state) => `'${state}'`).join(", ")}))`
@@ -5668,14 +5724,30 @@ function jobMetadataJoinSql(
 function jobLifecycleExclusionSql(
   db: SqliteDatabase,
   jobUrlExpression: string,
+  tenantExpression: string,
 ): { joinSql: string; whereSql: string } {
   const joins: string[] = [];
   const wheres: string[] = [];
   if (tableExists(db, "jobctrl_deleted_jobs")) {
     joins.push(
-      `LEFT JOIN jobctrl_deleted_jobs d ON d.job_url = ${jobUrlExpression} AND (d.restored_at IS NULL OR julianday(d.restored_at) <= julianday(d.deleted_at))`,
+      `LEFT JOIN jobctrl_deleted_jobs d ON ${jobReferenceJoinToUrl(
+        db,
+        "jobctrl_deleted_jobs",
+        "d",
+        tenantExpression,
+        jobUrlExpression,
+      )} AND (
+        d.restored_at IS NULL
+        OR julianday(d.restored_at) <= julianday(d.deleted_at)
+      )`,
     );
-    wheres.push("d.job_url IS NULL");
+    wheres.push(
+      jobReferenceMissingSql(
+        db,
+        "jobctrl_deleted_jobs",
+        "d",
+      ),
+    );
   }
   if (tableExists(db, "jobctrl_hidden_jobs")) {
     joins.push(

--- a/apps/api/src/read-model.ts
+++ b/apps/api/src/read-model.ts
@@ -74,11 +74,14 @@ import { buildApplyAudit, type ApplyAuditLatestRun } from "./apply-audit.js";
 import { evaluateRepeatApplication } from "./repeat-application.js";
 import {
   allRows,
+  canonicalJobUrlForUrlSqlExpression,
   getRow,
   hasCompositeJobIdForeignKey,
   jobKeyReferenceColumn,
   jobKeyReferencePredicateForUrl,
   jobReferenceColumn,
+  jobReferenceJoinToUrl,
+  jobReferenceMissingSql,
   tableColumnSet,
   tableExists,
   type SqliteDatabase,
@@ -444,24 +447,30 @@ function dashboardWorkSummary(db: SqliteDatabase): DashboardSummary["work"] {
   const stageJoin = hasStageState
     ? jobReferenceColumn(db, "job_stage_states") === "job_id"
       ? `LEFT JOIN jobs AS stage_jobs
-           ON stage_jobs.tenant_id = job_list_projections.tenant_id
-          AND stage_jobs.url = job_list_projections.job_id
+           ON stage_jobs.tenant_id = work.tenant_id
+          AND stage_jobs.url = work.job_id
          LEFT JOIN job_stage_states AS stage_state
            ON stage_state.tenant_id = stage_jobs.tenant_id
           AND stage_state.job_id = stage_jobs.job_id
-          AND stage_state.stage = job_list_projections.current_substage`
+          AND stage_state.stage = work.current_substage`
       : `LEFT JOIN job_stage_states AS stage_state
-           ON stage_state.job_url = job_list_projections.job_id
-          AND stage_state.stage = job_list_projections.current_substage`
+           ON stage_state.job_url = work.job_id
+          AND stage_state.stage = work.current_substage`
     : "";
   const rows = allRows<DashboardWorkRow>(
     db,
-    `SELECT job_id, title, employer, current_stage, current_substage, current_state,
+    `SELECT work.job_id, work.title, work.employer, work.current_stage,
+            work.current_substage, work.current_state,
             ${stageColumns}
-       FROM job_list_projections
+       FROM (
+         SELECT tenant_id, job_id, title, employer, current_stage,
+                current_substage, current_state
+           FROM job_list_projections
+           ${activeFilter.where}
+            AND current_state IN ('queued', 'running')
+       ) AS work
        ${stageJoin}
-       ${activeFilter.where}
-        AND current_state IN ('queued', 'running')`,
+       `,
     activeFilter.params,
   );
 
@@ -2507,12 +2516,27 @@ export function listArtifacts(db: SqliteDatabase, query: ArtifactListQuery): Pag
   refreshProjections(db, DEFAULT_TENANT);
   const normalizedQuery = query.q.toLowerCase();
   const deletedJoin = tableExists(db, "jobctrl_deleted_jobs")
-    ? " LEFT JOIN jobctrl_deleted_jobs d ON d.job_url = ap.job_id AND (d.restored_at IS NULL OR julianday(d.restored_at) <= julianday(d.deleted_at))"
+    ? ` LEFT JOIN jobctrl_deleted_jobs d ON ${jobReferenceJoinToUrl(
+        db,
+        "jobctrl_deleted_jobs",
+        "d",
+        "ap.tenant_id",
+        "ap.job_id",
+      )} AND (
+        d.restored_at IS NULL
+        OR julianday(d.restored_at) <= julianday(d.deleted_at)
+      )`
     : "";
   const hiddenJoin = tableExists(db, "jobctrl_hidden_jobs")
     ? " LEFT JOIN jobctrl_hidden_jobs h ON h.job_url = ap.job_id AND h.unhidden_at IS NULL"
     : "";
-  const deletedWhere = tableExists(db, "jobctrl_deleted_jobs") ? " AND d.job_url IS NULL" : "";
+  const deletedWhere = tableExists(db, "jobctrl_deleted_jobs")
+    ? ` AND ${jobReferenceMissingSql(
+        db,
+        "jobctrl_deleted_jobs",
+        "d",
+      )}`
+    : "";
   const hiddenWhere = tableExists(db, "jobctrl_hidden_jobs") ? " AND h.job_url IS NULL" : "";
   const rows = allRows<ArtifactProjectionRow>(
     db,
@@ -5696,14 +5720,33 @@ function listActivityFromEvents(
   const eventTypeSelect = eventColumns.has("event_type") ? "e.event_type" : "'Event' AS event_type";
   const eventTypePredicate = eventColumns.has("event_type") ? "COALESCE(e.event_type, '')" : "'Event'";
   const hideDeletedJoin = tableExists(db, "jobctrl_deleted_jobs")
-    ? " LEFT JOIN jobctrl_deleted_jobs d ON d.job_url = e.job_url AND (d.restored_at IS NULL OR julianday(d.restored_at) <= julianday(d.deleted_at))"
+    ? ` LEFT JOIN jobctrl_deleted_jobs d ON ${jobReferenceJoinToUrl(
+        db,
+        "jobctrl_deleted_jobs",
+        "d",
+        `'${DEFAULT_TENANT}'`,
+        "e.job_url",
+      )} AND (
+        d.restored_at IS NULL
+        OR julianday(d.restored_at) <= julianday(d.deleted_at)
+      )`
     : "";
   const hideHiddenJoin = tableExists(db, "jobctrl_hidden_jobs")
-    ? " LEFT JOIN jobctrl_hidden_jobs h ON h.job_url = e.job_url AND h.unhidden_at IS NULL"
+    ? ` LEFT JOIN jobctrl_hidden_jobs h ON h.job_url = ${canonicalJobUrlForUrlSqlExpression(
+        db,
+        `'${DEFAULT_TENANT}'`,
+        "e.job_url",
+      )} AND h.unhidden_at IS NULL`
     : "";
   const activityClauses = [
     "(e.job_url IS NULL OR e.job_url = '' OR jp.job_id IS NOT NULL)",
-    tableExists(db, "jobctrl_deleted_jobs") ? "d.job_url IS NULL" : "",
+    tableExists(db, "jobctrl_deleted_jobs")
+      ? jobReferenceMissingSql(
+          db,
+          "jobctrl_deleted_jobs",
+          "d",
+        )
+      : "",
     tableExists(db, "jobctrl_hidden_jobs") ? "h.job_url IS NULL" : "",
   ].filter(Boolean);
   const params: SqliteValue[] = [DEFAULT_TENANT];
@@ -5738,7 +5781,12 @@ function listActivityFromEvents(
   const activityWhere = `WHERE ${activityClauses.join(" AND ")}`;
   const fromSql = `
     FROM job_events e
-    LEFT JOIN job_list_projections jp ON jp.tenant_id = ? AND jp.job_id = e.job_url
+    LEFT JOIN job_list_projections jp ON jp.tenant_id = ?
+      AND jp.job_id = ${canonicalJobUrlForUrlSqlExpression(
+        db,
+        `'${DEFAULT_TENANT}'`,
+        "e.job_url",
+      )}
     ${hideDeletedJoin}
     ${hideHiddenJoin}
     ${activityWhere}`;
@@ -5783,15 +5831,34 @@ function getActivityEventFromEvents(db: SqliteDatabase, eventId: string): Activi
   const eventColumns = columnNames(db, "job_events");
   const eventTypeSelect = eventColumns.has("event_type") ? "e.event_type" : "'Event' AS event_type";
   const hideDeletedJoin = tableExists(db, "jobctrl_deleted_jobs")
-    ? " LEFT JOIN jobctrl_deleted_jobs d ON d.job_url = e.job_url AND (d.restored_at IS NULL OR julianday(d.restored_at) <= julianday(d.deleted_at))"
+    ? ` LEFT JOIN jobctrl_deleted_jobs d ON ${jobReferenceJoinToUrl(
+        db,
+        "jobctrl_deleted_jobs",
+        "d",
+        `'${DEFAULT_TENANT}'`,
+        "e.job_url",
+      )} AND (
+        d.restored_at IS NULL
+        OR julianday(d.restored_at) <= julianday(d.deleted_at)
+      )`
     : "";
   const hideHiddenJoin = tableExists(db, "jobctrl_hidden_jobs")
-    ? " LEFT JOIN jobctrl_hidden_jobs h ON h.job_url = e.job_url AND h.unhidden_at IS NULL"
+    ? ` LEFT JOIN jobctrl_hidden_jobs h ON h.job_url = ${canonicalJobUrlForUrlSqlExpression(
+        db,
+        `'${DEFAULT_TENANT}'`,
+        "e.job_url",
+      )} AND h.unhidden_at IS NULL`
     : "";
   const activityClauses = [
     "e.event_id = ?",
     "(e.job_url IS NULL OR e.job_url = '' OR jp.job_id IS NOT NULL)",
-    tableExists(db, "jobctrl_deleted_jobs") ? "d.job_url IS NULL" : "",
+    tableExists(db, "jobctrl_deleted_jobs")
+      ? jobReferenceMissingSql(
+          db,
+          "jobctrl_deleted_jobs",
+          "d",
+        )
+      : "",
     tableExists(db, "jobctrl_hidden_jobs") ? "h.job_url IS NULL" : "",
   ].filter(Boolean);
   const row = getRow<Record<string, unknown>>(
@@ -5807,7 +5874,12 @@ function getActivityEventFromEvents(db: SqliteDatabase, eventId: string): Activi
        jp.title    AS title,
        jp.employer AS employer
      FROM job_events e
-     LEFT JOIN job_list_projections jp ON jp.tenant_id = ? AND jp.job_id = e.job_url
+     LEFT JOIN job_list_projections jp ON jp.tenant_id = ?
+       AND jp.job_id = ${canonicalJobUrlForUrlSqlExpression(
+         db,
+         `'${DEFAULT_TENANT}'`,
+         "e.job_url",
+       )}
      ${hideDeletedJoin}
      ${hideHiddenJoin}
      WHERE ${activityClauses.join(" AND ")}
@@ -6100,7 +6172,16 @@ export function listWorkflowRuns(
   // rows have a NULL apply_job_id and pass through untouched.
   const deletedJoin =
     hasApply && tableExists(db, "jobctrl_deleted_jobs")
-      ? " LEFT JOIN jobctrl_deleted_jobs d ON d.job_url = arp.job_id AND (d.restored_at IS NULL OR julianday(d.restored_at) <= julianday(d.deleted_at))"
+      ? ` LEFT JOIN jobctrl_deleted_jobs d ON ${jobReferenceJoinToUrl(
+          db,
+          "jobctrl_deleted_jobs",
+          "d",
+          "arp.tenant_id",
+          "arp.job_id",
+        )} AND (
+          d.restored_at IS NULL
+          OR julianday(d.restored_at) <= julianday(d.deleted_at)
+        )`
       : "";
   const hiddenJoin =
     hasApply && tableExists(db, "jobctrl_hidden_jobs")
@@ -6109,7 +6190,13 @@ export function listWorkflowRuns(
   const where: string[] = ["wrp.tenant_id = ?"];
   const params: SqliteValue[] = [DEFAULT_TENANT];
   if (deletedJoin) {
-    where.push("d.job_url IS NULL");
+    where.push(
+      jobReferenceMissingSql(
+        db,
+        "jobctrl_deleted_jobs",
+        "d",
+      ),
+    );
   }
   if (hiddenJoin) {
     where.push("h.job_url IS NULL");
@@ -6317,12 +6404,27 @@ function recentApplyRuns(db: SqliteDatabase): DashboardSummary["applyRuns"] {
   // L3 (round-1 review): caller (``buildDashboardSummary``) already
   // refreshed projections; do not double-refresh here.
   const deletedJoin = tableExists(db, "jobctrl_deleted_jobs")
-    ? " LEFT JOIN jobctrl_deleted_jobs d ON d.job_url = arp.job_id AND (d.restored_at IS NULL OR julianday(d.restored_at) <= julianday(d.deleted_at))"
+    ? ` LEFT JOIN jobctrl_deleted_jobs d ON ${jobReferenceJoinToUrl(
+        db,
+        "jobctrl_deleted_jobs",
+        "d",
+        "arp.tenant_id",
+        "arp.job_id",
+      )} AND (
+        d.restored_at IS NULL
+        OR julianday(d.restored_at) <= julianday(d.deleted_at)
+      )`
     : "";
   const hiddenJoin = tableExists(db, "jobctrl_hidden_jobs")
     ? " LEFT JOIN jobctrl_hidden_jobs h ON h.job_url = arp.job_id AND h.unhidden_at IS NULL"
     : "";
-  const deletedWhere = tableExists(db, "jobctrl_deleted_jobs") ? " AND d.job_url IS NULL" : "";
+  const deletedWhere = tableExists(db, "jobctrl_deleted_jobs")
+    ? ` AND ${jobReferenceMissingSql(
+        db,
+        "jobctrl_deleted_jobs",
+        "d",
+      )}`
+    : "";
   const hiddenWhere = tableExists(db, "jobctrl_hidden_jobs") ? " AND h.job_url IS NULL" : "";
   const rows = allRows<ApplyRunProjectionRow>(
     db,

--- a/apps/api/src/write-model.ts
+++ b/apps/api/src/write-model.ts
@@ -30,6 +30,7 @@ import {
   jobReferenceColumn,
   jobReferenceForUrl,
   jobReferencePredicateForUrl,
+  stableJobIdForUrl,
   tableColumnSet,
   tableExists,
   type SqliteDatabase,
@@ -133,11 +134,50 @@ export function resolveJobUrl(db: SqliteDatabase, jobKey: string): string | null
   if (!tableExists(db, "jobs")) {
     return null;
   }
-  const row = getRow<{ url?: string }>(db, "SELECT url FROM jobs WHERE url = ? OR application_url = ? LIMIT 1", [
-    jobKey,
-    jobKey,
-  ]);
-  return row?.url ?? null;
+  const jobColumns = tableColumnSet(db, "jobs");
+  const tenantScoped = jobColumns.has("tenant_id");
+  const row = getRow<{ url?: string }>(
+    db,
+    `SELECT url
+       FROM jobs
+      WHERE ${tenantScoped ? "tenant_id = 'local' AND " : ""}
+            (url = ? OR application_url = ?)
+      LIMIT 1`,
+    [jobKey, jobKey],
+  );
+  if (row?.url) {
+    return row.url;
+  }
+  if (
+    !tenantScoped
+    || !jobColumns.has("job_id")
+  ) {
+    return null;
+  }
+  // A legacy posting URL can itself be UUID-shaped. Resolve current URLs and
+  // posting aliases before interpreting the token as another aggregate's
+  // stable JobId; destructive lifecycle mutations must retain URL semantics.
+  const stableJobId = stableJobIdForUrl(db, jobKey, "local") ?? getRow<{ job_id?: string }>(
+    db,
+    `SELECT job_id
+       FROM jobs
+      WHERE tenant_id = 'local'
+        AND job_id = ?
+      LIMIT 1`,
+    [jobKey],
+  )?.job_id;
+  if (!stableJobId) {
+    return null;
+  }
+  return getRow<{ url?: string }>(
+    db,
+    `SELECT url
+       FROM jobs
+      WHERE tenant_id = 'local'
+        AND job_id = ?
+      LIMIT 1`,
+    [stableJobId],
+  )?.url ?? null;
 }
 
 export function resetJobStage(
@@ -541,17 +581,46 @@ export function softDeleteJobs(db: SqliteDatabase, request: BulkJobMutationReque
   ensureDeletedJobsTable(db);
   const deletedAt = new Date().toISOString();
   const jobKeys = mutableJobKeys(db, request);
+  const referenceColumn = jobReferenceColumn(
+    db,
+    "jobctrl_deleted_jobs",
+  );
+  const stableReference = referenceColumn === "job_id";
+  const identityColumns = stableReference
+    ? "tenant_id, job_id"
+    : "job_url";
+  const identityPlaceholders = stableReference
+    ? "?, ?"
+    : "?";
+  const conflictTarget = stableReference
+    ? "tenant_id, job_id"
+    : "job_url";
   const statement = db.prepare(`
-    INSERT INTO jobctrl_deleted_jobs (job_url, deleted_at, reason, restored_at)
-    VALUES (?, ?, ?, NULL)
-    ON CONFLICT(job_url) DO UPDATE SET
+    INSERT INTO jobctrl_deleted_jobs (
+      ${identityColumns}, deleted_at, reason, restored_at
+    )
+    VALUES (${identityPlaceholders}, ?, ?, NULL)
+    ON CONFLICT(${conflictTarget}) DO UPDATE SET
       deleted_at = excluded.deleted_at,
       reason = excluded.reason,
       restored_at = NULL
   `);
   const transaction = db.transaction((keys: string[]) => {
     for (const jobUrl of keys) {
-      statement.run(jobUrl, deletedAt, request.reason ?? null);
+      const reference = stableReference
+        ? jobReferenceForUrl(
+            db,
+            "jobctrl_deleted_jobs",
+            jobUrl,
+          )
+        : jobUrl;
+      statement.run(
+        ...(stableReference
+          ? ["local", reference]
+          : [reference]),
+        deletedAt,
+        request.reason ?? null,
+      );
       recordActionEvent(db, {
         jobUrl,
         stage: currentMutableStage(db, jobUrl),
@@ -574,12 +643,37 @@ export function restoreJobs(db: SqliteDatabase, request: BulkJobMutationRequest)
   ensureDeletedJobsTable(db);
   const restoredAt = new Date().toISOString();
   const jobKeys = mutableJobKeys(db, request);
+  const referenceColumn = jobReferenceColumn(
+    db,
+    "jobctrl_deleted_jobs",
+  );
+  const stableReference = referenceColumn === "job_id";
   const statement = db.prepare(
-    "UPDATE jobctrl_deleted_jobs SET restored_at = ? WHERE job_url = ? AND (restored_at IS NULL OR julianday(restored_at) <= julianday(deleted_at))",
+    `UPDATE jobctrl_deleted_jobs
+     SET restored_at = ?
+     WHERE ${stableReference
+       ? "tenant_id = ? AND job_id = ?"
+       : "job_url = ?"}
+       AND (
+         restored_at IS NULL
+         OR julianday(restored_at) <= julianday(deleted_at)
+       )`,
   );
   const transaction = db.transaction((keys: string[]) => {
     for (const jobUrl of keys) {
-      statement.run(restoredAt, jobUrl);
+      const reference = stableReference
+        ? jobReferenceForUrl(
+            db,
+            "jobctrl_deleted_jobs",
+            jobUrl,
+          )
+        : jobUrl;
+      statement.run(
+        restoredAt,
+        ...(stableReference
+          ? ["local", reference]
+          : [reference]),
+      );
       recordActionEvent(db, {
         jobUrl,
         stage: currentMutableStage(db, jobUrl),
@@ -791,15 +885,56 @@ function resetEnrichmentAggregate(db: SqliteDatabase, jobUrl: string): void {
 }
 
 function ensureDeletedJobsTable(db: SqliteDatabase): void {
-  db.prepare(
-    `CREATE TABLE IF NOT EXISTS jobctrl_deleted_jobs (
-      job_url TEXT PRIMARY KEY,
-      deleted_at TEXT NOT NULL,
-      reason TEXT,
-      restored_at TEXT,
-      FOREIGN KEY(job_url) REFERENCES jobs(url)
-    )`,
-  ).run();
+  const schemaVersion = Number(
+    db.pragma("user_version", { simple: true }),
+  );
+  const stableReference = schemaVersion >= 29;
+  if (!tableExists(db, "jobctrl_deleted_jobs")) {
+    db.prepare(
+      stableReference
+        ? `CREATE TABLE jobctrl_deleted_jobs (
+            tenant_id TEXT NOT NULL DEFAULT 'local',
+            job_id TEXT NOT NULL,
+            deleted_at TEXT NOT NULL,
+            reason TEXT,
+            restored_at TEXT,
+            PRIMARY KEY (tenant_id, job_id),
+            FOREIGN KEY (tenant_id, job_id)
+              REFERENCES jobs(tenant_id, job_id) ON DELETE CASCADE
+          )`
+        : `CREATE TABLE jobctrl_deleted_jobs (
+            job_url TEXT PRIMARY KEY,
+            deleted_at TEXT NOT NULL,
+            reason TEXT,
+            restored_at TEXT,
+            FOREIGN KEY(job_url) REFERENCES jobs(url)
+          )`,
+    ).run();
+  }
+  if (
+    stableReference
+    && (
+      jobReferenceColumn(db, "jobctrl_deleted_jobs")
+        !== "job_id"
+      || tableColumnSet(
+        db,
+        "jobctrl_deleted_jobs",
+      ).has("job_url")
+      || !hasCompositeJobIdForeignKey(
+        db,
+        "jobctrl_deleted_jobs",
+      )
+      || tablePrimaryKeyColumns(
+        db,
+        "jobctrl_deleted_jobs",
+      ).join(",") !== "tenant_id,job_id"
+    )
+  ) {
+    throw new Error(
+      "Schema v29 requires stable soft-delete "
+        + "tombstone JobId references.",
+    );
+  }
 }
 
 function ensureHiddenJobsTable(db: SqliteDatabase): void {
@@ -836,7 +971,27 @@ function purgeJobRows(db: SqliteDatabase, jobUrl: string): void {
     [jobUrl],
   );
   const jobId = identity?.job_id;
-  deleteWhere(db, "jobctrl_deleted_jobs", "job_url = ?", [jobUrl]);
+  if (tableExists(db, "jobctrl_deleted_jobs")) {
+    const deletedReference = jobReferenceColumn(
+      db,
+      "jobctrl_deleted_jobs",
+    );
+    if (deletedReference === "job_id" && jobId) {
+      deleteWhere(
+        db,
+        "jobctrl_deleted_jobs",
+        "tenant_id = ? AND job_id = ?",
+        ["local", jobId],
+      );
+    } else if (deletedReference === "job_url") {
+      deleteWhere(
+        db,
+        "jobctrl_deleted_jobs",
+        "job_url = ?",
+        [jobUrl],
+      );
+    }
+  }
   deleteWhere(db, "jobctrl_hidden_jobs", "job_url = ?", [jobUrl]);
   if (tableExists(db, "job_stage_states")) {
     const stageReference = jobReferenceColumn(db, "job_stage_states");
@@ -1210,6 +1365,22 @@ function deleteWhere(db: SqliteDatabase, tableName: string, whereSql: string, pa
     return;
   }
   db.prepare(`DELETE FROM ${tableName} WHERE ${whereSql}`).run(...params);
+}
+
+function tablePrimaryKeyColumns(
+  db: SqliteDatabase,
+  tableName: string,
+): string[] {
+  return (
+    db
+      .prepare(
+        `PRAGMA table_info("${tableName.replaceAll('"', '""')}")`,
+      )
+      .all() as Array<{ name: string; pk: number }>
+  )
+    .filter((row) => row.pk > 0)
+    .sort((left, right) => left.pk - right.pk)
+    .map((row) => row.name);
 }
 
 function deleteScoringJobReferences(

--- a/apps/api/test/deleted-jobs-v29.test.ts
+++ b/apps/api/test/deleted-jobs-v29.test.ts
@@ -1,0 +1,167 @@
+import Database from "better-sqlite3";
+import { describe, expect, it } from "vitest";
+
+import {
+  permanentlyDeleteJob,
+  restoreJob,
+  softDeleteJob,
+} from "../src/write-model.js";
+
+const JOB_URL = "https://example.test/jobs/platform";
+const JOB_ID = "22222222-2222-4222-8222-222222222222";
+
+function createV29Database(
+  foreignKeys: "ON" | "OFF",
+): Database.Database {
+  const db = new Database(":memory:");
+  db.exec(`
+    CREATE TABLE jobs (
+      url TEXT PRIMARY KEY,
+      tenant_id TEXT NOT NULL DEFAULT 'local',
+      job_id TEXT NOT NULL,
+      application_url TEXT,
+      UNIQUE (tenant_id, job_id)
+    );
+    INSERT INTO jobs (
+      url, tenant_id, job_id, application_url
+    ) VALUES (
+      '${JOB_URL}', 'local', '${JOB_ID}', '${JOB_URL}'
+    );
+    PRAGMA user_version = 29;
+    PRAGMA foreign_keys = ${foreignKeys};
+  `);
+  return db;
+}
+
+describe("schema-v29 soft-delete tombstones", () => {
+  it.each(["ON", "OFF"] as const)(
+    "permanent delete explicitly purges the stable tombstone with foreign keys %s",
+    (foreignKeys) => {
+      const db = createV29Database(foreignKeys);
+
+      expect(
+        softDeleteJob(db, JOB_URL, {
+          reason: "not relevant",
+        }),
+      ).toMatchObject({
+        ok: true,
+        count: 1,
+        jobKeys: [JOB_URL],
+      });
+      expect(
+        db.prepare(
+          `SELECT tenant_id, job_id, reason
+           FROM jobctrl_deleted_jobs`,
+        ).get(),
+      ).toMatchObject({
+        tenant_id: "local",
+        job_id: JOB_ID,
+        reason: "not relevant",
+      });
+
+      expect(
+        permanentlyDeleteJob(db, JOB_URL),
+      ).toMatchObject({
+        ok: true,
+        count: 1,
+        jobKeys: [JOB_URL],
+      });
+      expect(
+        db.prepare(
+          "SELECT COUNT(*) AS count FROM jobctrl_deleted_jobs",
+        ).get(),
+      ).toMatchObject({ count: 0 });
+      expect(
+        db.prepare(
+          "SELECT COUNT(*) AS count FROM jobs",
+        ).get(),
+      ).toMatchObject({ count: 0 });
+
+      db.close();
+    },
+  );
+
+  it("fails closed instead of writing into a URL-era table stamped as v29", () => {
+    const db = createV29Database("ON");
+    db.exec(`
+      CREATE TABLE jobctrl_deleted_jobs (
+        job_url TEXT PRIMARY KEY,
+        deleted_at TEXT NOT NULL,
+        reason TEXT,
+        restored_at TEXT
+      );
+    `);
+
+    expect(() => softDeleteJob(db, JOB_URL)).toThrow(
+      /requires stable soft-delete tombstone JobId references/,
+    );
+    expect(
+      db.prepare(
+        "SELECT COUNT(*) AS count FROM jobctrl_deleted_jobs",
+      ).get(),
+    ).toMatchObject({ count: 0 });
+
+    db.close();
+  });
+
+  it("keeps URL semantics when a UUID-shaped posting alias equals another JobId", () => {
+    const collidingAlias = "33333333-3333-4333-8333-333333333333";
+    const otherUrl = "https://example.test/jobs/other";
+    const db = createV29Database("ON");
+    db.exec(`
+      CREATE TABLE job_identity_aliases (
+        tenant_id TEXT NOT NULL,
+        alias_kind TEXT NOT NULL,
+        alias_value TEXT NOT NULL,
+        job_id TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        PRIMARY KEY (tenant_id, alias_kind, alias_value),
+        FOREIGN KEY (tenant_id, job_id)
+          REFERENCES jobs(tenant_id, job_id) ON DELETE CASCADE
+      );
+    `);
+    db.prepare(
+      `INSERT INTO jobs (url, tenant_id, job_id, application_url)
+       VALUES (?, 'local', ?, ?)`,
+    ).run(otherUrl, collidingAlias, otherUrl);
+    db.prepare(
+      `INSERT INTO job_identity_aliases (
+         tenant_id, alias_kind, alias_value, job_id, created_at
+       ) VALUES ('local', 'posting_url', ?, ?, ?)`,
+    ).run(
+      collidingAlias,
+      JOB_ID,
+      "2026-07-30T10:00:00+00:00",
+    );
+
+    expect(softDeleteJob(db, collidingAlias)).toMatchObject({
+      ok: true,
+      count: 1,
+      jobKeys: [JOB_URL],
+    });
+    expect(
+      db.prepare(
+        "SELECT job_id FROM jobctrl_deleted_jobs",
+      ).get(),
+    ).toMatchObject({ job_id: JOB_ID });
+
+    expect(restoreJob(db, collidingAlias)).toMatchObject({
+      ok: true,
+      count: 1,
+      jobKeys: [JOB_URL],
+    });
+    expect(softDeleteJob(db, collidingAlias).count).toBe(1);
+    expect(permanentlyDeleteJob(db, collidingAlias)).toMatchObject({
+      ok: true,
+      count: 1,
+      jobKeys: [JOB_URL],
+    });
+    expect(
+      db.prepare(
+        "SELECT url FROM jobs WHERE tenant_id = 'local' AND job_id = ?",
+      ).get(collidingAlias),
+    ).toMatchObject({ url: otherUrl });
+
+    db.close();
+  });
+});

--- a/apps/api/test/schema-version-guard.test.ts
+++ b/apps/api/test/schema-version-guard.test.ts
@@ -13,6 +13,8 @@ import {
   tableExists,
 } from "../src/db.js";
 
+const LEGACY_TOMBSTONE_SCHEMA_VERSION = 28;
+
 function makeDbWithUserVersion(userVersion: number): { dbPath: string; cleanup: () => void } {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "jobctrl-api-schema-version-"));
   const dbPath = path.join(dir, "jobs.db");
@@ -63,7 +65,7 @@ describe("schema version guard at DB open", () => {
   });
 
   it("opens the worker-owned schema-v14 artifact registry", () => {
-    expect(SUPPORTED_SCHEMA_VERSION).toBe(28);
+    expect(SUPPORTED_SCHEMA_VERSION).toBe(29);
     const { dbPath, cleanup } = makeDbWithUserVersion(14);
     try {
       openDatabase(dbPath).close();
@@ -89,7 +91,7 @@ describe("schema version guard at DB open", () => {
 
 describe("legacy tombstone table migration", () => {
   it.each(legacyTokens())("renames old %s deleted and hidden tables on writable open", (token) => {
-    const { dbPath, cleanup } = makeDbWithUserVersion(SUPPORTED_SCHEMA_VERSION);
+    const { dbPath, cleanup } = makeDbWithUserVersion(LEGACY_TOMBSTONE_SCHEMA_VERSION);
     try {
       const seed = new Database(dbPath);
       seed.exec(`
@@ -168,7 +170,7 @@ describe("legacy tombstone table migration", () => {
   });
 
   it("normalizes tables left behind by an earlier rename-only migration", () => {
-    const { dbPath, cleanup } = makeDbWithUserVersion(SUPPORTED_SCHEMA_VERSION);
+    const { dbPath, cleanup } = makeDbWithUserVersion(LEGACY_TOMBSTONE_SCHEMA_VERSION);
     try {
       const seed = new Database(dbPath);
       seed.exec(`
@@ -196,6 +198,142 @@ describe("legacy tombstone table migration", () => {
       expect(tableColumns(seed, "jobctrl_deleted_jobs")).toEqual(expect.arrayContaining(["restored_at"]));
       expect(tableColumns(seed, "jobctrl_hidden_jobs")).toEqual(expect.arrayContaining(["unhidden_at"]));
       seed.close();
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("accepts the worker-owned stable tombstone schema at v29", () => {
+    const { dbPath, cleanup } = makeDbWithUserVersion(SUPPORTED_SCHEMA_VERSION);
+    try {
+      const seed = new Database(dbPath);
+      seed.pragma("foreign_keys = ON");
+      seed.exec(`
+        CREATE TABLE jobs (
+          url TEXT PRIMARY KEY,
+          tenant_id TEXT NOT NULL,
+          job_id TEXT NOT NULL,
+          UNIQUE (tenant_id, job_id)
+        );
+        CREATE TABLE jobctrl_deleted_jobs (
+          tenant_id TEXT NOT NULL DEFAULT 'local',
+          job_id TEXT NOT NULL,
+          deleted_at TEXT NOT NULL,
+          reason TEXT,
+          restored_at TEXT,
+          PRIMARY KEY (tenant_id, job_id),
+          FOREIGN KEY (tenant_id, job_id)
+            REFERENCES jobs(tenant_id, job_id) ON DELETE CASCADE
+        );
+        CREATE TABLE jobctrl_hidden_jobs (
+          job_url TEXT PRIMARY KEY,
+          hidden_at TEXT NOT NULL,
+          reason TEXT
+        );
+      `);
+      seed.close();
+
+      const db = openDatabase(dbPath);
+      try {
+        expect(tableColumns(db, "jobctrl_deleted_jobs")).toEqual([
+          "tenant_id",
+          "job_id",
+          "deleted_at",
+          "reason",
+          "restored_at",
+        ]);
+        expect(tableColumns(db, "jobctrl_hidden_jobs")).toEqual(
+          expect.arrayContaining(["job_url", "hidden_at", "reason", "unhidden_at"]),
+        );
+      } finally {
+        db.close();
+      }
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("preserves an already-stable tombstone table during an earlier migration replay", () => {
+    const { dbPath, cleanup } = makeDbWithUserVersion(LEGACY_TOMBSTONE_SCHEMA_VERSION);
+    try {
+      const seed = new Database(dbPath);
+      seed.exec(`
+        CREATE TABLE jobctrl_deleted_jobs (
+          tenant_id TEXT NOT NULL DEFAULT 'local',
+          job_id TEXT NOT NULL,
+          deleted_at TEXT NOT NULL,
+          reason TEXT,
+          restored_at TEXT,
+          PRIMARY KEY (tenant_id, job_id)
+        );
+      `);
+
+      expect(migrateLegacyJobTables(seed)).toEqual([]);
+      expect(tableColumns(seed, "jobctrl_deleted_jobs")).not.toContain(
+        "job_url",
+      );
+      seed.close();
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("refuses mixed stable and branded URL-era tombstone authorities", () => {
+    const { dbPath, cleanup } = makeDbWithUserVersion(LEGACY_TOMBSTONE_SCHEMA_VERSION);
+    try {
+      const token = "job" + "ctl";
+      const seed = new Database(dbPath);
+      seed.exec(`
+        CREATE TABLE jobctrl_deleted_jobs (
+          tenant_id TEXT NOT NULL DEFAULT 'local',
+          job_id TEXT NOT NULL,
+          deleted_at TEXT NOT NULL,
+          reason TEXT,
+          restored_at TEXT,
+          PRIMARY KEY (tenant_id, job_id)
+        );
+        CREATE TABLE ${token}_deleted_jobs (
+          job_url TEXT PRIMARY KEY,
+          deleted_at TEXT NOT NULL,
+          reason TEXT,
+          restored_at TEXT
+        );
+      `);
+
+      expect(() => migrateLegacyJobTables(seed)).toThrow(
+        /Cannot merge URL-era branded soft-delete tables into stable JobId tombstones/,
+      );
+      expect(tableExists(seed, "jobctrl_deleted_jobs")).toBe(true);
+      expect(tableExists(seed, `${token}_deleted_jobs`)).toBe(true);
+      seed.close();
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("refuses a URL-era tombstone table stamped as v29", () => {
+    const { dbPath, cleanup } = makeDbWithUserVersion(SUPPORTED_SCHEMA_VERSION);
+    try {
+      const seed = new Database(dbPath);
+      seed.exec(`
+        CREATE TABLE jobctrl_deleted_jobs (
+          job_url TEXT PRIMARY KEY,
+          deleted_at TEXT NOT NULL,
+          reason TEXT,
+          restored_at TEXT
+        );
+      `);
+      seed.close();
+
+      expect(() => openDatabase(dbPath)).toThrow(
+        /requires stable soft-delete tombstone JobId references/,
+      );
+      const probe = new Database(dbPath, { readonly: true });
+      try {
+        expect(tableColumns(probe, "jobctrl_deleted_jobs")).toContain("job_url");
+      } finally {
+        probe.close();
+      }
     } finally {
       cleanup();
     }

--- a/apps/api/test/server.test.ts
+++ b/apps/api/test/server.test.ts
@@ -2574,6 +2574,395 @@ describe("local TypeScript API", () => {
     await app.close();
   });
 
+  it("uses stable v29 tombstones for alias delete, restore, reads, events, and purge", async () => {
+    const readyUrl = "https://example.com/jobs/ready";
+    const aliasUrl = "https://legacy.example.com/jobs/ready";
+    const readyJobId = "11111111-1111-4111-8111-111111111111";
+    const setup = new Database(options.dbPath);
+    setup.prepare(
+      "UPDATE jobs SET job_id = ? WHERE tenant_id = 'local' AND url = ?",
+    ).run(readyJobId, readyUrl);
+    setup.exec(`
+      CREATE UNIQUE INDEX idx_jobs_tenant_job_id
+      ON jobs(tenant_id, job_id);
+      CREATE TABLE job_identity_aliases (
+        tenant_id TEXT NOT NULL,
+        alias_kind TEXT NOT NULL,
+        alias_value TEXT NOT NULL,
+        job_id TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        PRIMARY KEY (tenant_id, alias_kind, alias_value),
+        FOREIGN KEY (tenant_id, job_id)
+          REFERENCES jobs(tenant_id, job_id) ON DELETE CASCADE
+      );
+      ALTER TABLE job_stage_states RENAME TO job_stage_states_url_v29_test;
+      CREATE TABLE job_stage_states (
+        tenant_id TEXT NOT NULL DEFAULT 'local',
+        job_id TEXT NOT NULL,
+        stage TEXT NOT NULL,
+        state TEXT NOT NULL DEFAULT 'pending',
+        attempt_count INTEGER DEFAULT 0,
+        max_attempts INTEGER,
+        started_at TEXT,
+        updated_at TEXT NOT NULL,
+        finished_at TEXT,
+        duration_ms INTEGER,
+        error_code TEXT,
+        error_message TEXT,
+        retryable INTEGER DEFAULT 1,
+        blocked_by_json TEXT,
+        next_action TEXT,
+        metadata_json TEXT,
+        version INTEGER NOT NULL DEFAULT 0,
+        PRIMARY KEY (tenant_id, job_id, stage),
+        FOREIGN KEY (tenant_id, job_id)
+          REFERENCES jobs(tenant_id, job_id) ON DELETE CASCADE
+      );
+      INSERT INTO job_stage_states (
+        tenant_id, job_id, stage, state, attempt_count, max_attempts,
+        started_at, updated_at, finished_at, duration_ms, error_code,
+        error_message, retryable, blocked_by_json, next_action,
+        metadata_json, version
+      )
+      SELECT jobs.tenant_id, jobs.job_id, legacy.stage, legacy.state,
+             legacy.attempt_count, legacy.max_attempts, legacy.started_at,
+             legacy.updated_at, legacy.finished_at, legacy.duration_ms,
+             legacy.error_code, legacy.error_message, legacy.retryable,
+             legacy.blocked_by_json, legacy.next_action, NULL, 0
+      FROM job_stage_states_url_v29_test legacy
+      JOIN jobs ON jobs.url = legacy.job_url;
+      DROP TABLE job_stage_states_url_v29_test;
+      PRAGMA user_version = 29;
+    `);
+    setup.prepare(
+      `INSERT INTO job_identity_aliases (
+         tenant_id, alias_kind, alias_value, job_id, created_at
+       ) VALUES ('local', 'posting_url', ?, ?, ?)`,
+    ).run(
+      aliasUrl,
+      readyJobId,
+      "2026-07-30T10:00:00+00:00",
+    );
+    setup.close();
+    const app = buildApp(options);
+
+    const workerSchemaDashboard = await app.inject({
+      method: "GET",
+      url: "/v1/dashboard/summary",
+    });
+    expect(
+      workerSchemaDashboard.statusCode,
+      workerSchemaDashboard.body,
+    ).toBe(200);
+
+    const historical = new Database(options.dbPath);
+    historical.prepare(
+      `UPDATE apply_run_projections
+       SET job_id = ?
+       WHERE run_id = 'run-1'`,
+    ).run(aliasUrl);
+    historical.prepare(
+      `INSERT INTO job_events (
+         job_url, stage, event_type, level, message, occurred_at
+       ) VALUES (?, 'apply', 'AliasHistorical', 'info', ?, ?)`,
+    ).run(
+      aliasUrl,
+      "Historical alias event",
+      "2026-07-30T10:01:00+00:00",
+    );
+    historical.close();
+
+    const visibleWorkflow = await app.inject({
+      method: "GET",
+      url: "/v1/workflow-runs",
+    });
+    expect(
+      visibleWorkflow.json().items.map(
+        (run: { runId: string }) => run.runId,
+      ),
+    ).toContain("run-1");
+    const visibleActivity = await app.inject({
+      method: "GET",
+      url: "/v1/debug/activity?eventType=AliasHistorical",
+    });
+    expect(
+      visibleActivity.json().items.map(
+        (event: { eventType: string }) => event.eventType,
+      ),
+    ).toContain("AliasHistorical");
+
+    const deletedByAlias = await app.inject({
+      method: "DELETE",
+      url: `/v1/jobs/${encodeURIComponent(aliasUrl)}`,
+      payload: { reason: "not relevant" },
+    });
+    expect(
+      deletedByAlias.statusCode,
+      deletedByAlias.body,
+    ).toBe(200);
+    expect(deletedByAlias.json()).toMatchObject({
+      ok: true,
+      count: 1,
+      jobKeys: [readyUrl],
+    });
+
+    const deletedProbe = new Database(options.dbPath);
+    const deletedColumns = deletedProbe
+      .prepare("PRAGMA table_info(jobctrl_deleted_jobs)")
+      .all()
+      .map((row) => String((row as { name: unknown }).name));
+    expect(deletedColumns).toEqual([
+      "tenant_id",
+      "job_id",
+      "deleted_at",
+      "reason",
+      "restored_at",
+    ]);
+    expect(
+      deletedProbe.prepare(
+        `SELECT tenant_id, job_id, reason, restored_at
+         FROM jobctrl_deleted_jobs`,
+      ).get(),
+    ).toMatchObject({
+      tenant_id: "local",
+      job_id: readyJobId,
+      reason: "not relevant",
+      restored_at: null,
+    });
+    expect(
+      deletedProbe.prepare(
+        `SELECT job_url
+         FROM job_events
+         WHERE event_type = 'JobDeleted'
+         ORDER BY event_id DESC
+         LIMIT 1`,
+      ).get(),
+    ).toMatchObject({ job_url: readyUrl });
+    deletedProbe.close();
+
+    const active = await app.inject({
+      method: "GET",
+      url: "/v1/jobs?deleted=active",
+    });
+    expect(active.statusCode, active.body).toBe(200);
+    expect(
+      active.json().items.map(
+        (job: { jobKey: string }) => job.jobKey,
+      ),
+    ).not.toContain(readyUrl);
+    const deleted = await app.inject({
+      method: "GET",
+      url: "/v1/jobs?deleted=deleted",
+    });
+    expect(deleted.statusCode, deleted.body).toBe(200);
+    expect(
+      deleted.json().items.map(
+        (job: { jobKey: string }) => job.jobKey,
+      ),
+    ).toContain(readyUrl);
+    const deletedWorkflow = await app.inject({
+      method: "GET",
+      url: "/v1/workflow-runs",
+    });
+    expect(
+      deletedWorkflow.json().items.map(
+        (run: { runId: string }) => run.runId,
+      ),
+    ).not.toContain("run-1");
+    const deletedActivity = await app.inject({
+      method: "GET",
+      url: "/v1/debug/activity?eventType=AliasHistorical",
+    });
+    expect(deletedActivity.json().items).toEqual([]);
+    const deletedDashboard = await app.inject({
+      method: "GET",
+      url: "/v1/dashboard/summary",
+    });
+    expect(deletedDashboard.json().totals.dryRuns).toBe(0);
+    expect(
+      deletedDashboard.json().applyRuns.map(
+        (run: { runId: string }) => run.runId,
+      ),
+    ).not.toContain("run-1");
+
+    const restoredByAlias = await app.inject({
+      method: "POST",
+      url: `/v1/jobs/${encodeURIComponent(aliasUrl)}/restore`,
+    });
+    expect(
+      restoredByAlias.statusCode,
+      restoredByAlias.body,
+    ).toBe(200);
+    expect(restoredByAlias.json()).toMatchObject({
+      ok: true,
+      count: 1,
+      jobKeys: [readyUrl],
+    });
+    const restored = await app.inject({
+      method: "GET",
+      url: "/v1/jobs?deleted=active",
+    });
+    expect(
+      restored.json().items.map(
+        (job: { jobKey: string }) => job.jobKey,
+      ),
+    ).toContain(readyUrl);
+    const restoredWorkflow = await app.inject({
+      method: "GET",
+      url: "/v1/workflow-runs",
+    });
+    expect(
+      restoredWorkflow.json().items.map(
+        (run: { runId: string }) => run.runId,
+      ),
+    ).toContain("run-1");
+    const restoredActivity = await app.inject({
+      method: "GET",
+      url: "/v1/debug/activity?eventType=AliasHistorical",
+    });
+    expect(
+      restoredActivity.json().items.map(
+        (event: { eventType: string }) => event.eventType,
+      ),
+    ).toContain("AliasHistorical");
+    const restoredDashboard = await app.inject({
+      method: "GET",
+      url: "/v1/dashboard/summary",
+    });
+    expect(restoredDashboard.json().totals.dryRuns).toBe(1);
+    expect(
+      restoredDashboard.json().applyRuns.map(
+        (run: { runId: string }) => run.runId,
+      ),
+    ).toContain("run-1");
+
+    const deletedByCanonical = await app.inject({
+      method: "DELETE",
+      url: `/v1/jobs/${encodeURIComponent(readyUrl)}`,
+    });
+    expect(
+      deletedByCanonical.statusCode,
+      deletedByCanonical.body,
+    ).toBe(200);
+    const permanent = await app.inject({
+      method: "DELETE",
+      url: `/v1/jobs/${encodeURIComponent(readyUrl)}/permanent`,
+    });
+    expect(permanent.statusCode, permanent.body).toBe(200);
+
+    const purged = new Database(options.dbPath);
+    expect(
+      purged.prepare(
+        `SELECT COUNT(*) AS count
+         FROM jobctrl_deleted_jobs
+         WHERE tenant_id = 'local' AND job_id = ?`,
+      ).get(readyJobId),
+    ).toMatchObject({ count: 0 });
+    expect(
+      purged.prepare(
+        "SELECT COUNT(*) AS count FROM jobs WHERE url = ?",
+      ).get(readyUrl),
+    ).toMatchObject({ count: 0 });
+    purged.close();
+
+    await app.close();
+  });
+
+  it("reconciles a restored stable tombstone without a lifecycle event", async () => {
+    const readyUrl = "https://example.com/jobs/ready";
+    const aliasUrl = "https://legacy.example.com/jobs/restored-ready";
+    const readyJobId = "44444444-4444-4444-8444-444444444444";
+    const setup = new Database(options.dbPath);
+    setup.prepare(
+      "UPDATE jobs SET job_id = ? WHERE tenant_id = 'local' AND url = ?",
+    ).run(readyJobId, readyUrl);
+    setup.exec(`
+      CREATE UNIQUE INDEX idx_jobs_tenant_job_id
+      ON jobs(tenant_id, job_id);
+      CREATE TABLE job_identity_aliases (
+        tenant_id TEXT NOT NULL,
+        alias_kind TEXT NOT NULL,
+        alias_value TEXT NOT NULL,
+        job_id TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        PRIMARY KEY (tenant_id, alias_kind, alias_value),
+        FOREIGN KEY (tenant_id, job_id)
+          REFERENCES jobs(tenant_id, job_id) ON DELETE CASCADE
+      );
+      CREATE TABLE jobctrl_deleted_jobs (
+        tenant_id TEXT NOT NULL DEFAULT 'local',
+        job_id TEXT NOT NULL,
+        deleted_at TEXT NOT NULL,
+        reason TEXT,
+        restored_at TEXT,
+        PRIMARY KEY (tenant_id, job_id),
+        FOREIGN KEY (tenant_id, job_id)
+          REFERENCES jobs(tenant_id, job_id) ON DELETE CASCADE
+      );
+      PRAGMA user_version = 29;
+    `);
+    setup.prepare(
+      `INSERT INTO job_identity_aliases (
+         tenant_id, alias_kind, alias_value, job_id, created_at
+       ) VALUES ('local', 'posting_url', ?, ?, ?)`,
+    ).run(
+      aliasUrl,
+      readyJobId,
+      "2026-07-30T10:00:00+00:00",
+    );
+    setup.close();
+    const app = buildApp(options);
+
+    const initial = await app.inject({
+      method: "GET",
+      url: "/v1/jobs?deleted=active",
+    });
+    expect(initial.statusCode, initial.body).toBe(200);
+
+    const stale = new Database(options.dbPath);
+    stale.prepare(
+      `INSERT INTO jobctrl_deleted_jobs (
+         tenant_id, job_id, deleted_at, reason, restored_at
+       ) VALUES ('local', ?, ?, 'migrated alias merge', ?)`,
+    ).run(
+      readyJobId,
+      "2026-07-30T11:00:00+00:00",
+      "2026-07-30T12:00:00+00:00",
+    );
+    stale.prepare(
+      `UPDATE job_list_projections
+       SET job_id = ?, deleted_at = ?
+       WHERE tenant_id = 'local' AND job_id = ?`,
+    ).run(
+      aliasUrl,
+      "2026-07-30T11:00:00+00:00",
+      readyUrl,
+    );
+    stale.close();
+
+    const reconciled = await app.inject({
+      method: "GET",
+      url: "/v1/jobs?deleted=active",
+    });
+    expect(reconciled.statusCode, reconciled.body).toBe(200);
+    expect(
+      reconciled.json().items.map(
+        (job: { jobKey: string }) => job.jobKey,
+      ),
+    ).toContain(readyUrl);
+    const projection = new Database(options.dbPath);
+    expect(
+      projection.prepare(
+        `SELECT deleted_at
+         FROM job_list_projections
+         WHERE tenant_id = 'local' AND job_id = ?`,
+      ).get(readyUrl),
+    ).toMatchObject({ deleted_at: null });
+    projection.close();
+
+    await app.close();
+  });
+
   it("treats stale restores before later deletes as deleted", async () => {
     const db = new Database(options.dbPath);
     db.exec(`

--- a/workers/automation/src/jobctrl/config.py
+++ b/workers/automation/src/jobctrl/config.py
@@ -213,6 +213,9 @@ def migrate_legacy_job_tables(conn: sqlite3.Connection) -> list[str]:
     lifecycle columns used by the read model.
     """
     renamed: list[str] = []
+    schema_version = int(
+        conn.execute("PRAGMA user_version").fetchone()[0]
+    )
     with conn:
         for suffix, spec in _JOB_LIFECYCLE_TABLES.items():
             legacy_tables = [f"{token}_{suffix}" for token in _LEGACY_TOKENS]
@@ -220,6 +223,48 @@ def migrate_legacy_job_tables(conn: sqlite3.Connection) -> list[str]:
             existing_legacy_tables = [table for table in legacy_tables if _table_exists(conn, table)]
             current_exists = _table_exists(conn, current)
             if not existing_legacy_tables and not current_exists:
+                continue
+            if (
+                suffix == "deleted_jobs"
+                and current_exists
+                and schema_version < 29
+            ):
+                current_columns = set(
+                    _table_columns(conn, current)
+                )
+                stable_current = (
+                    {"tenant_id", "job_id"}.issubset(
+                        current_columns
+                    )
+                    and "job_url" not in current_columns
+                )
+                if stable_current:
+                    if existing_legacy_tables:
+                        raise WorkspaceMigrationError(
+                            "cannot merge URL-era branded soft-delete "
+                            "tables into stable JobId tombstones"
+                        )
+                    # Migration regression fixtures may temporarily roll
+                    # user_version back while retaining an already-migrated
+                    # lifecycle table. Preserve that forward-compatible
+                    # authority; the normal schema runner will validate it
+                    # again when it reaches v29.
+                    continue
+            if suffix == "deleted_jobs" and schema_version >= 29:
+                if existing_legacy_tables:
+                    raise WorkspaceMigrationError(
+                        "schema v29 cannot merge URL-era branded "
+                        "soft-delete tables after the stable JobId cutover"
+                    )
+                columns = set(_table_columns(conn, current))
+                if (
+                    not {"tenant_id", "job_id"}.issubset(columns)
+                    or "job_url" in columns
+                ):
+                    raise WorkspaceMigrationError(
+                        "schema v29 requires stable soft-delete "
+                        "tombstone JobId references"
+                    )
                 continue
 
             for legacy in existing_legacy_tables:

--- a/workers/automation/src/jobctrl/database.py
+++ b/workers/automation/src/jobctrl/database.py
@@ -106,7 +106,10 @@ from jobctrl.config import DB_PATH, DEFAULTS, migrate_legacy_job_tables
 # v28 (quarantine references): the current Discovery quarantine authority is
 # keyed by the tenant-scoped stable Job aggregate. URL-era duplicates collapse
 # deterministically while their snapshots and events retain historical facts.
-SCHEMA_VERSION = 28
+# v29 (delete tombstones): soft-delete lifecycle state is keyed by the
+# tenant-scoped stable Job aggregate. URL-era alias tombstones collapse into
+# one current lifecycle projection without changing delete/restore history.
+SCHEMA_VERSION = 29
 
 
 class IncompatibleSchemaVersionError(RuntimeError):
@@ -265,6 +268,7 @@ def _schema_migrations() -> tuple[
         (26, ensure_discovery_feedback_references_v26),
         (27, ensure_manual_capture_references_v27),
         (28, ensure_quarantine_references_v28),
+        (29, ensure_deleted_job_references_v29),
     )
 
 
@@ -467,6 +471,7 @@ def init_db(db_path: Path | str | None = None) -> sqlite3.Connection:
     ensure_projection_tables_in_db(conn)
     drop_legacy_apply_runs_tables(conn)
     _run_schema_migrations(conn)
+    ensure_deleted_jobs_table(conn)
 
     return conn
 
@@ -4910,6 +4915,13 @@ def _reassign_discovery_identity_references(
         )
     if _has_quarantine_reference_schema_v28(conn):
         _reassign_quarantine_references_v28(
+            conn,
+            tenant_id=tenant_id,
+            losing_job_id=losing_job_id,
+            surviving_job_id=surviving_job_id,
+        )
+    if _has_deleted_job_reference_schema_v29(conn):
+        _reassign_deleted_job_references_v29(
             conn,
             tenant_id=tenant_id,
             losing_job_id=losing_job_id,
@@ -16421,6 +16433,590 @@ def _reassign_quarantine_references_v28(
     )
 
 
+_DELETED_JOB_REFERENCE_SCHEMA_VERSION = 29
+_DELETED_JOB_REFERENCE_TABLES = ("jobctrl_deleted_jobs",)
+_DELETED_JOB_PAYLOAD_FIELDS_V29 = (
+    "deleted_at",
+    "reason",
+    "restored_at",
+)
+
+
+def _create_deleted_jobs_table_v29(
+    conn: sqlite3.Connection,
+    *,
+    table: str,
+    stable_reference: bool,
+) -> None:
+    if stable_reference:
+        conn.execute(
+            f"""
+            CREATE TABLE "{table}" (
+                tenant_id   TEXT NOT NULL DEFAULT 'local',
+                job_id      TEXT NOT NULL,
+                deleted_at  TEXT NOT NULL,
+                reason      TEXT,
+                restored_at TEXT,
+                PRIMARY KEY (tenant_id, job_id),
+                FOREIGN KEY (tenant_id, job_id)
+                    REFERENCES jobs(tenant_id, job_id) ON DELETE CASCADE
+            )
+            """
+        )
+        return
+    conn.execute(
+        f"""
+        CREATE TABLE "{table}" (
+            job_url     TEXT PRIMARY KEY,
+            deleted_at  TEXT NOT NULL,
+            reason      TEXT,
+            restored_at TEXT,
+            FOREIGN KEY (job_url) REFERENCES jobs(url)
+        )
+        """
+    )
+
+
+def deleted_jobs_reference_column(
+    conn: sqlite3.Connection,
+) -> str:
+    columns = _table_columns(conn, "jobctrl_deleted_jobs")
+    if "job_id" in columns:
+        return "job_id"
+    if "job_url" in columns:
+        return "job_url"
+    raise RuntimeError(
+        "jobctrl_deleted_jobs has no Job identity column"
+    )
+
+
+def deleted_jobs_join_to_jobs(
+    conn: sqlite3.Connection,
+    *,
+    deleted_alias: str,
+    jobs_alias: str,
+) -> str:
+    if (
+        deleted_jobs_reference_column(conn)
+        == "job_id"
+    ):
+        return (
+            f"{deleted_alias}.tenant_id = {jobs_alias}.tenant_id "
+            f"AND {deleted_alias}.job_id = {jobs_alias}.job_id"
+        )
+    return f"{deleted_alias}.job_url = {jobs_alias}.url"
+
+
+def deleted_jobs_join_to_url(
+    conn: sqlite3.Connection,
+    *,
+    deleted_alias: str,
+    tenant_expression: str,
+    job_url_expression: str,
+) -> str:
+    if deleted_jobs_reference_column(conn) == "job_url":
+        return f"{deleted_alias}.job_url = {job_url_expression}"
+
+    direct_url = (
+        "(SELECT lifecycle_job.job_id "
+        "FROM jobs AS lifecycle_job "
+        f"WHERE lifecycle_job.tenant_id = {tenant_expression} "
+        f"AND lifecycle_job.url = {job_url_expression} LIMIT 1)"
+    )
+    alias_columns = _table_columns(conn, "job_identity_aliases")
+    if not {
+        "tenant_id",
+        "alias_kind",
+        "alias_value",
+        "job_id",
+    }.issubset(alias_columns):
+        resolved_job_id = direct_url
+    else:
+        posting_url_alias = (
+            "(SELECT lifecycle_alias.job_id "
+            "FROM job_identity_aliases AS lifecycle_alias "
+            "JOIN jobs AS lifecycle_alias_job "
+            "ON lifecycle_alias_job.tenant_id = lifecycle_alias.tenant_id "
+            "AND lifecycle_alias_job.job_id = lifecycle_alias.job_id "
+            f"WHERE lifecycle_alias.tenant_id = {tenant_expression} "
+            "AND lifecycle_alias.alias_kind = 'posting_url' "
+            f"AND lifecycle_alias.alias_value = {job_url_expression} LIMIT 1)"
+        )
+        # Legacy URL-shaped references stay URL-first. In particular, a
+        # current URL wins over a same-text old alias.
+        resolved_job_id = (
+            f"COALESCE({direct_url}, {posting_url_alias})"
+        )
+    return (
+        f"{deleted_alias}.tenant_id = {tenant_expression} "
+        f"AND {deleted_alias}.job_id = {resolved_job_id}"
+    )
+
+
+def deleted_jobs_missing_reference_sql(
+    conn: sqlite3.Connection,
+    *,
+    deleted_alias: str,
+) -> str:
+    return (
+        f"{deleted_alias}."
+        f"{deleted_jobs_reference_column(conn)} IS NULL"
+    )
+
+
+def deleted_jobs_reference_values(
+    conn: sqlite3.Connection,
+    *,
+    tenant_id: str,
+    job_id: str,
+    job_url: str,
+) -> tuple[str, str, tuple[str, ...], str]:
+    if (
+        deleted_jobs_reference_column(conn)
+        == "job_id"
+    ):
+        return (
+            "tenant_id, job_id",
+            "?, ?",
+            (tenant_id, job_id),
+            "tenant_id, job_id",
+        )
+    return ("job_url", "?", (job_url,), "job_url")
+
+
+def deleted_jobs_reference_predicate(
+    conn: sqlite3.Connection,
+    *,
+    tenant_id: str,
+    job_id: str,
+    job_url: str,
+    deleted_alias: str = "",
+) -> tuple[str, tuple[str, ...]]:
+    prefix = f"{deleted_alias}." if deleted_alias else ""
+    if (
+        deleted_jobs_reference_column(conn)
+        == "job_id"
+    ):
+        return (
+            f"{prefix}tenant_id = ? "
+            f"AND {prefix}job_id = ?",
+            (tenant_id, job_id),
+        )
+    return (f"{prefix}job_url = ?", (job_url,))
+
+
+def _has_deleted_job_reference_schema_v29(
+    conn: sqlite3.Connection,
+) -> bool:
+    table = "jobctrl_deleted_jobs"
+    return (
+        "tenant_id" in _table_columns(conn, table)
+        and "job_id" in _table_columns(conn, table)
+        and "job_url" not in _table_columns(conn, table)
+        and _primary_key_columns(conn, table)
+        == ("tenant_id", "job_id")
+        and _has_composite_job_id_foreign_key(
+            conn,
+            table,
+            "job_id",
+        )
+    )
+
+
+def ensure_deleted_jobs_table(
+    conn: sqlite3.Connection,
+) -> list[str]:
+    current = _assert_schema_version_supported(conn)
+    stable_reference = (
+        current >= _DELETED_JOB_REFERENCE_SCHEMA_VERSION
+    )
+    if not _table_columns(conn, "jobctrl_deleted_jobs"):
+        _create_deleted_jobs_table_v29(
+            conn,
+            table="jobctrl_deleted_jobs",
+            stable_reference=stable_reference,
+        )
+    if stable_reference:
+        if not _has_deleted_job_reference_schema_v29(conn):
+            raise RuntimeError(
+                "Schema v29 requires stable soft-delete "
+                "tombstone JobId references."
+            )
+    elif (
+        deleted_jobs_reference_column(conn) != "job_url"
+    ):
+        raise RuntimeError(
+            "Pre-v29 soft-delete tombstones require URL references."
+        )
+    return list(_DELETED_JOB_REFERENCE_TABLES)
+
+
+def _deleted_job_candidate_v29(
+    *,
+    tenant_id: str,
+    stable_job_id: str,
+    payload: tuple[Any, ...],
+    tie_breaker: str,
+) -> dict[str, Any]:
+    candidate = {
+        name: value
+        for name, value in zip(
+            _DELETED_JOB_PAYLOAD_FIELDS_V29,
+            payload,
+            strict=True,
+        )
+    }
+    candidate["tenant_id"] = tenant_id
+    candidate["job_id"] = stable_job_id
+    candidate["_tie_breaker"] = tie_breaker
+    return candidate
+
+
+def _deleted_job_timestamp_rank_v29(
+    candidate: dict[str, Any],
+    field: str,
+) -> tuple[tuple[float, str], str]:
+    return (
+        _quarantine_timestamp_rank_v28(
+            candidate.get(field),
+        ),
+        str(candidate["_tie_breaker"]),
+    )
+
+
+def _merge_deleted_job_candidates_v29(
+    candidates: list[dict[str, Any]],
+) -> tuple[Any, ...]:
+    if not candidates:
+        raise RuntimeError(
+            "Soft-delete tombstone merge requires at least one row"
+        )
+    latest_delete = max(
+        candidates,
+        key=lambda candidate: (
+            _deleted_job_timestamp_rank_v29(
+                candidate,
+                "deleted_at",
+            )
+        ),
+    )
+    restore_candidates = [
+        candidate
+        for candidate in candidates
+        if candidate.get("restored_at") is not None
+    ]
+    restored_at = None
+    if restore_candidates:
+        latest_restore = max(
+            restore_candidates,
+            key=lambda candidate: (
+                _deleted_job_timestamp_rank_v29(
+                    candidate,
+                    "restored_at",
+                )
+            ),
+        )
+        restored_at = latest_restore.get("restored_at")
+    return (
+        latest_delete["tenant_id"],
+        latest_delete["job_id"],
+        latest_delete["deleted_at"],
+        latest_delete["reason"],
+        restored_at,
+    )
+
+
+def _canonical_deleted_job_rows_v29(
+    conn: sqlite3.Connection,
+) -> list[tuple[Any, ...]]:
+    legacy = (
+        deleted_jobs_reference_column(conn)
+        == "job_url"
+    )
+    rows = conn.execute(
+        (
+            """
+            SELECT job_url, deleted_at, reason, restored_at
+            FROM jobctrl_deleted_jobs
+            ORDER BY job_url
+            """
+            if legacy
+            else """
+            SELECT tenant_id, job_id, deleted_at, reason, restored_at
+            FROM jobctrl_deleted_jobs
+            ORDER BY tenant_id, job_id
+            """
+        )
+    ).fetchall()
+    grouped: dict[
+        tuple[str, str],
+        list[dict[str, Any]],
+    ] = {}
+    for row in rows:
+        values = tuple(row)
+        if legacy:
+            tenant_id = "local"
+            raw_reference = str(values[0])
+            stable_job_id = _resolve_job_reference_value(
+                conn,
+                tenant_id=tenant_id,
+                reference=raw_reference,
+                legacy_url=True,
+            )
+            payload = values[1:]
+        else:
+            tenant_id = str(values[0])
+            raw_reference = str(values[1])
+            stable_job_id = _resolve_job_reference_value(
+                conn,
+                tenant_id=tenant_id,
+                reference=raw_reference,
+                legacy_url=False,
+            )
+            payload = values[2:]
+        if stable_job_id is None:
+            raise RuntimeError(
+                "Soft-delete tombstone reference migration could "
+                f"not resolve {raw_reference!r} for tenant "
+                f"{tenant_id!r}"
+            )
+        _validate_job_uuid(stable_job_id)
+        grouped.setdefault(
+            (tenant_id, stable_job_id),
+            [],
+        ).append(
+            _deleted_job_candidate_v29(
+                tenant_id=tenant_id,
+                stable_job_id=stable_job_id,
+                payload=payload,
+                tie_breaker=raw_reference,
+            )
+        )
+    return [
+        _merge_deleted_job_candidates_v29(candidates)
+        for _identity, candidates in sorted(grouped.items())
+    ]
+
+
+def _insert_deleted_job_rows_v29(
+    conn: sqlite3.Connection,
+    *,
+    table: str,
+    rows: list[tuple[Any, ...]],
+) -> None:
+    conn.executemany(
+        f"""
+        INSERT INTO "{table}" (
+            tenant_id, job_id, deleted_at, reason, restored_at
+        ) VALUES (?, ?, ?, ?, ?)
+        """,
+        rows,
+    )
+
+
+def ensure_deleted_job_references_v29(
+    conn: sqlite3.Connection | None = None,
+) -> list[str]:
+    """Move soft-delete lifecycle authority to stable JobIds."""
+    if conn is None:
+        conn = get_connection()
+    current = _assert_schema_version_supported(conn)
+    if current >= _DELETED_JOB_REFERENCE_SCHEMA_VERSION:
+        return list(_DELETED_JOB_REFERENCE_TABLES)
+    if current != _QUARANTINE_REFERENCE_SCHEMA_VERSION:
+        raise RuntimeError(
+            "Soft-delete tombstone reference migration requires "
+            f"schema v28; found v{current}"
+        )
+
+    conn.execute("SAVEPOINT deleted_job_references_v29")
+    try:
+        if not _table_columns(conn, "jobctrl_deleted_jobs"):
+            _create_deleted_jobs_table_v29(
+                conn,
+                table="jobctrl_deleted_jobs",
+                stable_reference=False,
+            )
+        source_count = int(
+            conn.execute(
+                "SELECT COUNT(*) FROM jobctrl_deleted_jobs"
+            ).fetchone()[0]
+        )
+        canonical_rows = _canonical_deleted_job_rows_v29(conn)
+        expected_count = len(canonical_rows)
+        if expected_count > source_count:
+            raise RuntimeError(
+                "Soft-delete tombstone migration created "
+                "unexpected authority rows"
+            )
+
+        conn.execute(
+            "DROP TABLE IF EXISTS jobctrl_deleted_jobs_v29"
+        )
+        _create_deleted_jobs_table_v29(
+            conn,
+            table="jobctrl_deleted_jobs_v29",
+            stable_reference=True,
+        )
+        _insert_deleted_job_rows_v29(
+            conn,
+            table="jobctrl_deleted_jobs_v29",
+            rows=canonical_rows,
+        )
+        conn.execute('DROP TABLE "jobctrl_deleted_jobs"')
+        conn.execute(
+            'ALTER TABLE "jobctrl_deleted_jobs_v29" '
+            'RENAME TO "jobctrl_deleted_jobs"'
+        )
+        _verify_deleted_job_references_v29(
+            conn,
+            expected_count=expected_count,
+        )
+        conn.execute(
+            f"PRAGMA user_version = "
+            f"{_DELETED_JOB_REFERENCE_SCHEMA_VERSION}"
+        )
+        conn.execute(
+            "RELEASE SAVEPOINT deleted_job_references_v29"
+        )
+    except BaseException:
+        conn.execute(
+            "ROLLBACK TO SAVEPOINT deleted_job_references_v29"
+        )
+        conn.execute(
+            "RELEASE SAVEPOINT deleted_job_references_v29"
+        )
+        raise
+    return list(_DELETED_JOB_REFERENCE_TABLES)
+
+
+def _verify_deleted_job_references_v29(
+    conn: sqlite3.Connection,
+    *,
+    expected_count: int,
+) -> None:
+    if not _has_deleted_job_reference_schema_v29(conn):
+        raise RuntimeError(
+            "Soft-delete tombstone reference migration did not "
+            "create the stable reference schema"
+        )
+    observed_count = int(
+        conn.execute(
+            "SELECT COUNT(*) FROM jobctrl_deleted_jobs"
+        ).fetchone()[0]
+    )
+    if observed_count != expected_count:
+        raise RuntimeError(
+            "Soft-delete tombstone reference migration changed "
+            f"authority count: expected {expected_count}, "
+            f"found {observed_count}"
+        )
+    orphan = conn.execute(
+        """
+        SELECT deleted.job_id
+        FROM jobctrl_deleted_jobs AS deleted
+        LEFT JOIN jobs
+          ON jobs.tenant_id = deleted.tenant_id
+         AND jobs.job_id = deleted.job_id
+        WHERE jobs.job_id IS NULL
+        LIMIT 1
+        """
+    ).fetchone()
+    if orphan is not None:
+        raise RuntimeError(
+            "Soft-delete tombstone reference migration left an "
+            "unresolved JobId"
+        )
+    for row in conn.execute(
+        "SELECT DISTINCT job_id FROM jobctrl_deleted_jobs"
+    ).fetchall():
+        _validate_job_uuid(str(row[0]))
+    foreign_key_error = conn.execute(
+        "PRAGMA foreign_key_check"
+    ).fetchone()
+    if foreign_key_error is not None:
+        raise RuntimeError(
+            "Soft-delete tombstone reference migration found a "
+            "foreign-key violation"
+        )
+
+
+def _reassign_deleted_job_references_v29(
+    conn: sqlite3.Connection,
+    *,
+    tenant_id: str,
+    losing_job_id: str,
+    surviving_job_id: str,
+) -> None:
+    if losing_job_id == surviving_job_id:
+        return
+    expected_count = int(
+        conn.execute(
+            "SELECT COUNT(*) FROM jobctrl_deleted_jobs"
+        ).fetchone()[0]
+    )
+    rows = conn.execute(
+        """
+        SELECT tenant_id, job_id, deleted_at, reason, restored_at
+        FROM jobctrl_deleted_jobs
+        WHERE tenant_id = ? AND job_id IN (?, ?)
+        ORDER BY job_id
+        """,
+        (tenant_id, losing_job_id, surviving_job_id),
+    ).fetchall()
+    losing_present = any(
+        str(row[1]) == losing_job_id
+        for row in rows
+    )
+    if not losing_present:
+        return
+    surviving_present = any(
+        str(row[1]) == surviving_job_id
+        for row in rows
+    )
+    if not surviving_present:
+        conn.execute(
+            """
+            UPDATE jobctrl_deleted_jobs
+            SET job_id = ?
+            WHERE tenant_id = ? AND job_id = ?
+            """,
+            (surviving_job_id, tenant_id, losing_job_id),
+        )
+    else:
+        candidates = [
+            _deleted_job_candidate_v29(
+                tenant_id=str(row[0]),
+                stable_job_id=surviving_job_id,
+                payload=tuple(row)[2:],
+                tie_breaker=(
+                    "1:surviving"
+                    if str(row[1]) == surviving_job_id
+                    else "0:losing"
+                ),
+            )
+            for row in rows
+        ]
+        merged = _merge_deleted_job_candidates_v29(candidates)
+        conn.execute(
+            """
+            DELETE FROM jobctrl_deleted_jobs
+            WHERE tenant_id = ? AND job_id IN (?, ?)
+            """,
+            (tenant_id, losing_job_id, surviving_job_id),
+        )
+        _insert_deleted_job_rows_v29(
+            conn,
+            table="jobctrl_deleted_jobs",
+            rows=[merged],
+        )
+        expected_count -= 1
+    _verify_deleted_job_references_v29(
+        conn,
+        expected_count=expected_count,
+    )
+
+
 # ---------------------------------------------------------------------------
 # job_enrichments read fragments — used by every selector / stat that
 # previously read bare ``jobs.full_description`` / ``jobs.application_url``
@@ -17067,25 +17663,33 @@ def resurface_deleted_job(conn: sqlite3.Connection, job_url: str, *, resurfaced_
     Hidden jobs are tracked in a separate table and are intentionally not
     touched here, so a hidden job remains suppressed across discoveries.
     """
-    conn.execute(
-        """
-        CREATE TABLE IF NOT EXISTS jobctrl_deleted_jobs (
-            job_url TEXT PRIMARY KEY,
-            deleted_at TEXT NOT NULL,
-            reason TEXT,
-            restored_at TEXT,
-            FOREIGN KEY(job_url) REFERENCES jobs(url)
+    ensure_deleted_jobs_table(conn)
+    job_id = _resolve_job_reference_value(
+        conn,
+        tenant_id="local",
+        reference=job_url,
+        legacy_url=True,
+    )
+    if job_id is None:
+        raise RuntimeError(
+            "Cannot resurface an unresolved Job identity."
         )
-        """
+    reference_sql, reference_params = (
+        deleted_jobs_reference_predicate(
+            conn,
+            tenant_id="local",
+            job_id=job_id,
+            job_url=job_url,
+        )
     )
     cursor = conn.execute(
-        """
+        f"""
         UPDATE jobctrl_deleted_jobs
         SET restored_at = ?
-        WHERE job_url = ?
+        WHERE {reference_sql}
           AND (restored_at IS NULL OR julianday(restored_at) <= julianday(deleted_at))
         """,
-        (resurfaced_at, job_url),
+        (resurfaced_at, *reference_params),
     )
     if cursor.rowcount:
         from jobctrl.state import record_job_event

--- a/workers/automation/src/jobctrl/discovery/jobspy.py
+++ b/workers/automation/src/jobctrl/discovery/jobspy.py
@@ -16,7 +16,14 @@ from datetime import datetime, timezone
 from typing import Any, Callable
 
 from jobctrl import config
-from jobctrl.database import get_connection, init_db, resurface_deleted_job
+from jobctrl.database import (
+    deleted_jobs_join_to_jobs,
+    deleted_jobs_missing_reference_sql,
+    ensure_deleted_jobs_table,
+    get_connection,
+    init_db,
+    resurface_deleted_job,
+)
 from jobctrl.domain.discovery import JobMetadata, PostingUrl, SearchStrategy, Source
 from jobctrl.domain.discovery.execution import DiscoveryExecutionRef
 from jobctrl.domain.discovery.search_units import (
@@ -828,6 +835,15 @@ def _find_content_duplicate_survivor(
     if incoming_key is None:
         return None
     _ensure_deleted_jobs_table(conn)
+    deleted_join = deleted_jobs_join_to_jobs(
+        conn,
+        deleted_alias="d",
+        jobs_alias="j",
+    )
+    deleted_missing = deleted_jobs_missing_reference_sql(
+        conn,
+        deleted_alias="d",
+    )
     conn.create_function("jh_normalize_identity", 1, normalize_identity_text, deterministic=True)
     self_filter = "" if include_self else "AND j.url != ?"
     params: tuple[object, ...] = (
@@ -841,13 +857,13 @@ def _find_content_duplicate_survivor(
         SELECT j.url, j.title, j.company, j.site,
                j.description AS listing_description,
                COALESCE(je.full_description, j.full_description) AS enriched_description,
-               CASE WHEN d.job_url IS NULL THEN 0 ELSE 1 END AS is_deleted
+               CASE WHEN {deleted_missing} THEN 0 ELSE 1 END AS is_deleted
         FROM jobs j
         LEFT JOIN job_enrichments je
           ON je.tenant_id = j.tenant_id
          AND je.job_id = j.job_id
         LEFT JOIN jobctrl_deleted_jobs d
-          ON d.job_url = j.url
+          ON {deleted_join}
          AND (d.restored_at IS NULL OR julianday(d.restored_at) <= julianday(d.deleted_at))
         WHERE 1 = 1
           {self_filter}
@@ -880,17 +896,7 @@ def _find_content_duplicate_survivor(
 
 
 def _ensure_deleted_jobs_table(conn: sqlite3.Connection) -> None:
-    conn.execute(
-        """
-        CREATE TABLE IF NOT EXISTS jobctrl_deleted_jobs (
-            job_url TEXT PRIMARY KEY,
-            deleted_at TEXT NOT NULL,
-            reason TEXT,
-            restored_at TEXT,
-            FOREIGN KEY(job_url) REFERENCES jobs(url)
-        )
-        """
-    )
+    ensure_deleted_jobs_table(conn)
 
 
 def _record_content_duplicate_link(

--- a/workers/automation/src/jobctrl/infrastructure/discovery/production_wiring.py
+++ b/workers/automation/src/jobctrl/infrastructure/discovery/production_wiring.py
@@ -23,6 +23,10 @@ from urllib.parse import urlparse
 from jobctrl.database import (
     _resolve_job_reference_value,
     _table_columns,
+    deleted_jobs_join_to_jobs,
+    deleted_jobs_missing_reference_sql,
+    deleted_jobs_reference_values,
+    ensure_deleted_jobs_table,
     ensure_discovery_control_tables,
     ensure_enrichment_tables,
     ensure_posting_snapshot_tables,
@@ -766,6 +770,15 @@ def retire_invalid_source_jobs(
     ensure_source_observation_tables(conn)
     ensure_enrichment_tables(conn)
     _ensure_deleted_jobs_table(conn)
+    deleted_join = deleted_jobs_join_to_jobs(
+        conn,
+        deleted_alias="d",
+        jobs_alias="j",
+    )
+    deleted_missing = deleted_jobs_missing_reference_sql(
+        conn,
+        deleted_alias="d",
+    )
     query_specs_by_family = _query_specs_by_family(search_cfg)
     accept_locs, reject_locs = configured_location_filters(search_cfg)
     locations = tuple(_location_values(search_cfg))
@@ -773,9 +786,10 @@ def retire_invalid_source_jobs(
     retired: list[dict[str, str]] = []
 
     rows = conn.execute(
-        """
+        f"""
         SELECT
             j.url,
+            j.job_id,
             COALESCE(j.title, '') AS title,
             COALESCE(j.location, '') AS location,
             COALESCE(e.full_description, '') AS enrichment_description,
@@ -792,9 +806,9 @@ def retire_invalid_source_jobs(
         LEFT JOIN job_source_observations o
           ON o.tenant_id = j.tenant_id AND o.job_id = j.job_id
         LEFT JOIN jobctrl_deleted_jobs d
-          ON d.job_url = j.url
+          ON {deleted_join}
          AND (d.restored_at IS NULL OR julianday(d.restored_at) <= julianday(d.deleted_at))
-        WHERE j.tenant_id = ? AND d.job_url IS NULL
+        WHERE j.tenant_id = ? AND {deleted_missing}
         GROUP BY j.url
         """,
         (str(LOCAL_TENANT),),
@@ -826,16 +840,29 @@ def retire_invalid_source_jobs(
         source_id = str(row["source_id"] or row["ats_kind"] or family)
         reason = f"discovery hygiene rejected {source_id}: {', '.join(reasons)}"
         job_url = str(row["url"])
+        (
+            identity_columns,
+            identity_placeholders,
+            identity_values,
+            conflict_target,
+        ) = deleted_jobs_reference_values(
+            conn,
+            tenant_id=str(LOCAL_TENANT),
+            job_id=str(row["job_id"]),
+            job_url=job_url,
+        )
         conn.execute(
-            """
-            INSERT INTO jobctrl_deleted_jobs (job_url, deleted_at, reason, restored_at)
-            VALUES (?, ?, ?, NULL)
-            ON CONFLICT(job_url) DO UPDATE SET
+            f"""
+            INSERT INTO jobctrl_deleted_jobs (
+                {identity_columns}, deleted_at, reason, restored_at
+            )
+            VALUES ({identity_placeholders}, ?, ?, NULL)
+            ON CONFLICT({conflict_target}) DO UPDATE SET
                 deleted_at = excluded.deleted_at,
                 reason = excluded.reason,
                 restored_at = NULL
             """,
-            (job_url, now, reason),
+            (*identity_values, now, reason),
         )
         record_job_event(
             conn,
@@ -993,17 +1020,7 @@ def _source_rejection_reasons(
 
 
 def _ensure_deleted_jobs_table(conn: sqlite3.Connection) -> None:
-    conn.execute(
-        """
-        CREATE TABLE IF NOT EXISTS jobctrl_deleted_jobs (
-            job_url TEXT PRIMARY KEY,
-            deleted_at TEXT NOT NULL,
-            reason TEXT,
-            restored_at TEXT,
-            FOREIGN KEY(job_url) REFERENCES jobs(url)
-        )
-        """
-    )
+    ensure_deleted_jobs_table(conn)
 
 
 def _scraped_posting_key(posting: ScrapedJobPosting) -> tuple[str, str, str]:

--- a/workers/automation/src/jobctrl/infrastructure/discovery/sqlite_repository.py
+++ b/workers/automation/src/jobctrl/infrastructure/discovery/sqlite_repository.py
@@ -38,6 +38,13 @@ import sqlite3
 from datetime import datetime, timezone
 from typing import Any
 
+from jobctrl.database import (
+    deleted_jobs_join_to_jobs,
+    deleted_jobs_missing_reference_sql,
+    deleted_jobs_reference_predicate,
+    deleted_jobs_reference_values,
+    ensure_deleted_jobs_table as ensure_deleted_jobs_schema,
+)
 from jobctrl.domain.discovery.aggregate import Job
 from jobctrl.domain.discovery.execution import DiscoveryExecutionRef
 from jobctrl.domain.discovery.search_units import DiscoverySearchUnitLease
@@ -152,17 +159,7 @@ class SqliteJobRepository:
         Created on demand so the worker-side delete path matches the
         API-side delete path on row shape.
         """
-        self._conn.execute(
-            """
-            CREATE TABLE IF NOT EXISTS jobctrl_deleted_jobs (
-                job_url TEXT PRIMARY KEY,
-                deleted_at TEXT NOT NULL,
-                reason TEXT,
-                restored_at TEXT,
-                FOREIGN KEY(job_url) REFERENCES jobs(url)
-            )
-            """
-        )
+        ensure_deleted_jobs_schema(self._conn)
         self._conn.commit()
 
     # ------------------------------------------------------------------
@@ -253,6 +250,15 @@ class SqliteJobRepository:
         limit: int = 100,
         include_deleted: bool = False,
     ) -> list[Job]:
+        deleted_join = deleted_jobs_join_to_jobs(
+            self._conn,
+            deleted_alias="d",
+            jobs_alias="j",
+        )
+        deleted_missing = deleted_jobs_missing_reference_sql(
+            self._conn,
+            deleted_alias="d",
+        )
         if not include_deleted:
             sql = (
                 "SELECT j.tenant_id, j.job_id, j.url, "
@@ -261,9 +267,9 @@ class SqliteJobRepository:
                 "d.deleted_at, d.reason "
                 "FROM jobs j "
                 "LEFT JOIN jobctrl_deleted_jobs d "
-                "  ON d.job_url = j.url "
+                f"  ON {deleted_join} "
                 " AND (d.restored_at IS NULL OR julianday(d.restored_at) <= julianday(d.deleted_at)) "
-                "WHERE j.tenant_id = ? AND d.job_url IS NULL "
+                f"WHERE j.tenant_id = ? AND {deleted_missing} "
                 "ORDER BY j.discovered_at DESC NULLS LAST"
             )
         else:
@@ -274,7 +280,7 @@ class SqliteJobRepository:
                 "d.deleted_at, d.reason "
                 "FROM jobs j "
                 "LEFT JOIN jobctrl_deleted_jobs d "
-                "  ON d.job_url = j.url "
+                f"  ON {deleted_join} "
                 " AND (d.restored_at IS NULL OR julianday(d.restored_at) <= julianday(d.deleted_at)) "
                 "WHERE j.tenant_id = ? "
                 "ORDER BY j.discovered_at DESC NULLS LAST"
@@ -597,17 +603,30 @@ class SqliteJobRepository:
         identity = self._require_identity(tenant_id, existing.job_id)
         self._fence_search_unit_write()
         deleted = existing.soft_delete(reason=reason, deleted_at=deleted_at)
+        (
+            identity_columns,
+            identity_placeholders,
+            identity_values,
+            conflict_target,
+        ) = deleted_jobs_reference_values(
+            self._conn,
+            tenant_id=str(tenant_id),
+            job_id=str(identity.job_id),
+            job_url=identity.storage_url.value,
+        )
         self._conn.execute(
-            """
-            INSERT INTO jobctrl_deleted_jobs (job_url, deleted_at, reason, restored_at)
-            VALUES (?, ?, ?, NULL)
-            ON CONFLICT(job_url) DO UPDATE SET
+            f"""
+            INSERT INTO jobctrl_deleted_jobs (
+                {identity_columns}, deleted_at, reason, restored_at
+            )
+            VALUES ({identity_placeholders}, ?, ?, NULL)
+            ON CONFLICT({conflict_target}) DO UPDATE SET
                 deleted_at = excluded.deleted_at,
                 reason = excluded.reason,
                 restored_at = NULL
             """,
             (
-                identity.storage_url.value,
+                *identity_values,
                 deleted.deleted_at,
                 deleted.delete_reason,
             ),
@@ -629,14 +648,22 @@ class SqliteJobRepository:
         self._fence_search_unit_write()
         restored = existing.restore()
         restore_timestamp = _restore_timestamp(restored_at, deleted_at=existing.deleted_at)
+        reference_sql, reference_params = (
+            deleted_jobs_reference_predicate(
+                self._conn,
+                tenant_id=str(tenant_id),
+                job_id=str(identity.job_id),
+                job_url=identity.storage_url.value,
+            )
+        )
         # Mirror the API's restore semantics — set restored_at rather
         # than deleting the tombstone row so audit history is
         # preserved.
         self._conn.execute(
             "UPDATE jobctrl_deleted_jobs SET restored_at = ? "
-            "WHERE job_url = ? "
+            f"WHERE {reference_sql} "
             "AND (restored_at IS NULL OR julianday(restored_at) <= julianday(deleted_at))",
-            (restore_timestamp, identity.storage_url.value),
+            (restore_timestamp, *reference_params),
         )
         self._conn.commit()
         return restored
@@ -771,19 +798,28 @@ class SqliteJobRepository:
         if incoming_key is None:
             return None
         self._conn.create_function("jh_normalize_identity", 1, normalize_identity_text, deterministic=True)
+        deleted_join = deleted_jobs_join_to_jobs(
+            self._conn,
+            deleted_alias="d",
+            jobs_alias="j",
+        )
+        deleted_missing = deleted_jobs_missing_reference_sql(
+            self._conn,
+            deleted_alias="d",
+        )
         rows = self._conn.execute(
-            """
+            f"""
             SELECT j.job_id, j.url, j.title, j.company, j.site,
                    j.description AS listing_description,
                    COALESCE(je.full_description, j.full_description)
                        AS enriched_description,
-                   CASE WHEN d.job_url IS NULL THEN 0 ELSE 1 END AS is_deleted
+                   CASE WHEN {deleted_missing} THEN 0 ELSE 1 END AS is_deleted
             FROM jobs j
             LEFT JOIN job_enrichments je
               ON je.tenant_id = j.tenant_id
              AND je.job_id = j.job_id
             LEFT JOIN jobctrl_deleted_jobs d
-              ON d.job_url = j.url
+              ON {deleted_join}
              AND (d.restored_at IS NULL OR julianday(d.restored_at) <= julianday(d.deleted_at))
             WHERE j.tenant_id = ?
               AND jh_normalize_identity(COALESCE(j.title, '')) = ?
@@ -1108,15 +1144,20 @@ class SqliteJobRepository:
     # ------------------------------------------------------------------
 
     def _load_resolved(self, identity: ResolvedJobIdentity) -> Job | None:
+        deleted_join = deleted_jobs_join_to_jobs(
+            self._conn,
+            deleted_alias="d",
+            jobs_alias="j",
+        )
         row = self._conn.execute(
-            """
+            f"""
             SELECT j.tenant_id, j.job_id, j.url,
                    j.title, j.salary, j.description, j.location,
                    j.site, j.strategy, j.discovered_at,
                    d.deleted_at, d.reason
             FROM jobs j
             LEFT JOIN jobctrl_deleted_jobs d
-              ON d.job_url = j.url
+              ON {deleted_join}
              AND (
                     d.restored_at IS NULL
                  OR julianday(d.restored_at) <= julianday(d.deleted_at)
@@ -1167,31 +1208,52 @@ class SqliteJobRepository:
         the URL. This keeps the two sources of truth consistent on
         every save.
         """
+        (
+            identity_columns,
+            identity_placeholders,
+            identity_values,
+            conflict_target,
+        ) = deleted_jobs_reference_values(
+            self._conn,
+            tenant_id=str(job.tenant_id),
+            job_id=str(identity.job_id),
+            job_url=identity.storage_url.value,
+        )
         if job.deleted_at is not None:
             self._conn.execute(
-                """
-                INSERT INTO jobctrl_deleted_jobs (job_url, deleted_at, reason, restored_at)
-                VALUES (?, ?, ?, NULL)
-                ON CONFLICT(job_url) DO UPDATE SET
+                f"""
+                INSERT INTO jobctrl_deleted_jobs (
+                    {identity_columns}, deleted_at, reason, restored_at
+                )
+                VALUES ({identity_placeholders}, ?, ?, NULL)
+                ON CONFLICT({conflict_target}) DO UPDATE SET
                     deleted_at = excluded.deleted_at,
                     reason = excluded.reason,
                     restored_at = NULL
                 """,
                 (
-                    identity.storage_url.value,
+                    *identity_values,
                     job.deleted_at,
                     job.delete_reason,
                 ),
             )
         else:
+            reference_sql, reference_params = (
+                deleted_jobs_reference_predicate(
+                    self._conn,
+                    tenant_id=str(job.tenant_id),
+                    job_id=str(identity.job_id),
+                    job_url=identity.storage_url.value,
+                )
+            )
             # Keep legacy active-save behaviour, but timestamp-aware
             # readers only treat this as restored when the active row
             # is newer than the tombstone.
             self._conn.execute(
                 "UPDATE jobctrl_deleted_jobs SET restored_at = ? "
-                "WHERE job_url = ? "
+                f"WHERE {reference_sql} "
                 "AND (restored_at IS NULL OR julianday(restored_at) <= julianday(deleted_at))",
-                (job.discovered_at, identity.storage_url.value),
+                (job.discovered_at, *reference_params),
             )
 
     @staticmethod

--- a/workers/automation/src/jobctrl/infrastructure/projections/projection_builder.py
+++ b/workers/automation/src/jobctrl/infrastructure/projections/projection_builder.py
@@ -45,6 +45,12 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any, Callable
 
+from jobctrl.database import (
+    deleted_jobs_join_to_jobs,
+    deleted_jobs_join_to_url,
+    deleted_jobs_missing_reference_sql,
+    deleted_jobs_reference_column,
+)
 from jobctrl.domain.discovery.value_objects import PostingUrl
 from jobctrl.domain.events.base import DomainEvent
 from jobctrl.domain.identifiers import JobId
@@ -1822,7 +1828,11 @@ class ProjectionBuilder:
         if not _table_exists(self._conn, "job_bullet_provenance"):
             return
         job_metadata = _job_metadata_join_sql(self._conn, "identity.url")
-        lifecycle = _job_lifecycle_exclusion_sql(self._conn, "identity.url")
+        lifecycle = _job_lifecycle_exclusion_sql(
+            self._conn,
+            "identity.url",
+            tenant_expression="identity.tenant_id",
+        )
         rows = self._conn.execute(
             f"""
             SELECT identity.url AS job_url, provenance.artifact_id,
@@ -1893,6 +1903,7 @@ class ProjectionBuilder:
         lifecycle = _job_lifecycle_exclusion_sql(
             self._conn,
             "score_jobs.url",
+            tenant_expression="score_jobs.tenant_id",
         )
         rows = self._conn.execute(
             f"""
@@ -1981,7 +1992,11 @@ class ProjectionBuilder:
     ) -> None:
         if not _table_exists(self._conn, "artifact_list_projections"):
             return
-        lifecycle = _job_lifecycle_exclusion_sql(self._conn, "alp.job_id")
+        lifecycle = _job_lifecycle_exclusion_sql(
+            self._conn,
+            "alp.job_id",
+            tenant_expression="alp.tenant_id",
+        )
         rows = self._conn.execute(
             f"""
             SELECT alp.job_id, alp.job_title, alp.job_employer, alp.artifact_id, alp.generation,
@@ -2812,13 +2827,25 @@ class ProjectionBuilder:
 
     def _load_deleted_at(self, job_url: str) -> str | None:
         try:
+            deleted_join = deleted_jobs_join_to_jobs(
+                self._conn,
+                deleted_alias="deleted",
+                jobs_alias="jobs",
+            )
             row = self._conn.execute(
-                """
-                SELECT deleted_at FROM jobctrl_deleted_jobs
-                WHERE job_url = ?
-                  AND (restored_at IS NULL OR julianday(restored_at) <= julianday(deleted_at))
+                f"""
+                SELECT deleted.deleted_at
+                FROM jobs
+                JOIN jobctrl_deleted_jobs AS deleted
+                  ON {deleted_join}
+                 AND (
+                      deleted.restored_at IS NULL
+                      OR julianday(deleted.restored_at)
+                         <= julianday(deleted.deleted_at)
+                 )
+                WHERE jobs.tenant_id = ? AND jobs.url = ?
                 """,
-                (job_url,),
+                (str(self._tenant_id), job_url),
             ).fetchone()
         except sqlite3.OperationalError:
             return None
@@ -2828,25 +2855,69 @@ class ProjectionBuilder:
 
     def _stale_deleted_projection_jobs(self) -> set[str]:
         try:
+            deleted_join = deleted_jobs_join_to_url(
+                self._conn,
+                deleted_alias="d",
+                tenant_expression="p.tenant_id",
+                job_url_expression="p.job_id",
+            )
+            stable_reference = (
+                deleted_jobs_reference_column(self._conn)
+                == "job_id"
+            )
+            canonical_select = (
+                "canonical_deleted_job.url AS canonical_job_url"
+                if stable_reference
+                else "p.job_id AS canonical_job_url"
+            )
+            canonical_join = (
+                "JOIN jobs canonical_deleted_job "
+                "ON canonical_deleted_job.tenant_id = d.tenant_id "
+                "AND canonical_deleted_job.job_id = d.job_id"
+                if stable_reference
+                else ""
+            )
             rows = self._conn.execute(
-                """
-                SELECT p.job_id
+                f"""
+                SELECT p.job_id, {canonical_select}
                 FROM job_list_projections p
                 JOIN jobctrl_deleted_jobs d
-                  ON d.job_url = p.job_id
+                  ON {deleted_join}
+                {canonical_join}
                 WHERE p.tenant_id = ?
-                  AND (d.restored_at IS NULL OR julianday(d.restored_at) <= julianday(d.deleted_at))
-                  AND (p.deleted_at IS NULL OR p.deleted_at != d.deleted_at)
+                  AND (
+                    (
+                      (d.restored_at IS NULL OR julianday(d.restored_at) <= julianday(d.deleted_at))
+                      AND (p.deleted_at IS NULL OR p.deleted_at != d.deleted_at)
+                    )
+                    OR (
+                      d.restored_at IS NOT NULL
+                      AND julianday(d.restored_at) > julianday(d.deleted_at)
+                      AND p.deleted_at IS NOT NULL
+                    )
+                  )
                 """,
                 (str(self._tenant_id),),
             ).fetchall()
         except sqlite3.OperationalError:
             return set()
-        return {
-            str(row["job_id"] if not isinstance(row, tuple) else row[0])
-            for row in rows
-            if (row["job_id"] if not isinstance(row, tuple) else row[0])
-        }
+        dirty_jobs: set[str] = set()
+        for row in rows:
+            projection_job = (
+                row["job_id"]
+                if not isinstance(row, tuple)
+                else row[0]
+            )
+            canonical_job = (
+                row["canonical_job_url"]
+                if not isinstance(row, tuple)
+                else row[1]
+            )
+            if projection_job:
+                dirty_jobs.add(str(projection_job))
+            if canonical_job:
+                dirty_jobs.add(str(canonical_job))
+        return dirty_jobs
 
     def _stale_stage_projection_jobs(self) -> set[str]:
         try:
@@ -3184,17 +3255,27 @@ class ProjectionBuilder:
                        AND pss.job_url = arp.job_id
                 """
             )
+            deleted_join = deleted_jobs_join_to_url(
+                self._conn,
+                deleted_alias="d",
+                tenant_expression="arp.tenant_id",
+                job_url_expression="arp.job_id",
+            )
+            deleted_missing = deleted_jobs_missing_reference_sql(
+                self._conn,
+                deleted_alias="d",
+            )
             dry_runs = int(
                 self._conn.execute(
                     f"""
                     SELECT COUNT(*)
                     FROM apply_run_projections arp
                     LEFT JOIN jobctrl_deleted_jobs d
-                        ON d.job_url = arp.job_id
+                        ON {deleted_join}
                        AND (d.restored_at IS NULL OR julianday(d.restored_at) <= julianday(d.deleted_at))
                     {snapshot_join}
                     WHERE arp.dry_run = 1
-                      AND d.job_url IS NULL
+                      AND {deleted_missing}
                       AND (
                         pss.latest_active_state IS NULL
                         OR pss.latest_active_state NOT IN (
@@ -4422,7 +4503,10 @@ def _job_metadata_join_sql(conn: sqlite3.Connection, job_url_expression: str) ->
 
 
 def _job_lifecycle_exclusion_sql(
-    conn: sqlite3.Connection, job_url_expression: str
+    conn: sqlite3.Connection,
+    job_url_expression: str,
+    *,
+    tenant_expression: str,
 ) -> dict[str, str]:
     """Anti-join fragments excluding soft-deleted and hidden jobs from a
     tenant-wide read, mirroring the TS ``jobLifecycleExclusionSql``. Guarded by
@@ -4432,12 +4516,24 @@ def _job_lifecycle_exclusion_sql(
     joins: list[str] = []
     wheres: list[str] = []
     if _table_exists(conn, "jobctrl_deleted_jobs"):
+        deleted_join = deleted_jobs_join_to_url(
+            conn,
+            deleted_alias="d",
+            tenant_expression=tenant_expression,
+            job_url_expression=job_url_expression,
+        )
         joins.append(
             "LEFT JOIN jobctrl_deleted_jobs d "
-            f"ON d.job_url = {job_url_expression} "
-            "AND (d.restored_at IS NULL OR julianday(d.restored_at) <= julianday(d.deleted_at))"
+            f"ON {deleted_join} "
+            "AND (d.restored_at IS NULL OR "
+            "julianday(d.restored_at) <= julianday(d.deleted_at))"
         )
-        wheres.append("d.job_url IS NULL")
+        wheres.append(
+            deleted_jobs_missing_reference_sql(
+                conn,
+                deleted_alias="d",
+            )
+        )
     if _table_exists(conn, "jobctrl_hidden_jobs"):
         joins.append(
             "LEFT JOIN jobctrl_hidden_jobs h "

--- a/workers/automation/src/jobctrl/pipeline/current_policy_selectors.py
+++ b/workers/automation/src/jobctrl/pipeline/current_policy_selectors.py
@@ -6,6 +6,7 @@ import sqlite3
 from typing import Any
 
 from jobctrl.database import (
+    deleted_jobs_reference_column,
     effective_tailoring_min_score,
     ensure_scoring_policy_tables,
     ensure_tailoring_policy_tables,
@@ -230,10 +231,19 @@ def _active_job_filter(
 ) -> str:
     clauses: list[str] = []
     if _table_exists(conn, "jobctrl_deleted_jobs"):
+        deleted_reference = (
+            (
+                f"d.tenant_id = {tenant_expr} "
+                f"AND d.job_id = {job_id_expr}"
+            )
+            if deleted_jobs_reference_column(conn)
+            == "job_id"
+            else f"d.job_url = {job_url_expr}"
+        )
         clauses.append(
             "NOT EXISTS ("
             "SELECT 1 FROM jobctrl_deleted_jobs d "
-            f"WHERE d.job_url = {job_url_expr} "
+            f"WHERE {deleted_reference} "
             "AND (d.restored_at IS NULL OR julianday(d.restored_at) <= julianday(d.deleted_at))"
             ")"
         )

--- a/workers/automation/src/jobctrl/pipeline/preparation.py
+++ b/workers/automation/src/jobctrl/pipeline/preparation.py
@@ -608,17 +608,24 @@ def _unselected_work_plan_outcome(
 ) -> tuple[DiscoveryExecutionWorkPlanState, str]:
     is_deleted = "0"
     if _table_exists(conn, "jobctrl_deleted_jobs"):
+        deleted_reference = (
+            "deleted.tenant_id = jobs.tenant_id "
+            "AND deleted.job_id = jobs.job_id"
+            if db_module.deleted_jobs_reference_column(conn)
+            == "job_id"
+            else "deleted.job_url = jobs.url"
+        )
         is_deleted = """
             CASE WHEN EXISTS (
                 SELECT 1
                   FROM jobctrl_deleted_jobs deleted
-                 WHERE deleted.job_url = jobs.url
+                 WHERE %s
                    AND (
                        deleted.restored_at IS NULL
                        OR julianday(deleted.restored_at) <= julianday(deleted.deleted_at)
                    )
             ) THEN 1 ELSE 0 END
-        """
+        """ % deleted_reference
     row = conn.execute(
         f"""
         SELECT {db_module._EFFECTIVE_FIT_SCORE} AS effective_score,

--- a/workers/automation/src/jobctrl/scoring/scorer.py
+++ b/workers/automation/src/jobctrl/scoring/scorer.py
@@ -26,7 +26,13 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Any, Mapping, Protocol
 
 from jobctrl.config import RESUME_PATH
-from jobctrl.database import get_connection, get_jobs_by_stage, load_job_with_enrichment
+from jobctrl.database import (
+    deleted_jobs_join_to_jobs,
+    deleted_jobs_missing_reference_sql,
+    get_connection,
+    get_jobs_by_stage,
+    load_job_with_enrichment,
+)
 from jobctrl.domain.identifiers import JobId
 from jobctrl.domain.job_content_identity import (
     job_content_fingerprint,
@@ -1013,16 +1019,33 @@ def _preferred_direct_score_for_repost(
 
     if not _is_reference_repost_candidate(conn, job, tenant_id=tenant_id):
         return None
+    deleted_join_sql = (
+        deleted_jobs_join_to_jobs(
+            conn,
+            deleted_alias="d",
+            jobs_alias="j",
+        )
+        if _table_exists(conn, "jobctrl_deleted_jobs")
+        else ""
+    )
     deleted_join = (
-        """
+        f"""
         LEFT JOIN jobctrl_deleted_jobs d
-          ON d.job_url = j.url
+          ON {deleted_join_sql}
          AND (d.restored_at IS NULL OR julianday(d.restored_at) <= julianday(d.deleted_at))
         """
         if _table_exists(conn, "jobctrl_deleted_jobs")
         else ""
     )
-    deleted_filter = "AND d.job_url IS NULL" if deleted_join else ""
+    deleted_filter = (
+        "AND "
+        + deleted_jobs_missing_reference_sql(
+            conn,
+            deleted_alias="d",
+        )
+        if deleted_join
+        else ""
+    )
     rows = conn.execute(
         f"""
         SELECT j.url, j.job_id, j.title, j.location,

--- a/workers/automation/tests/test_application_feedback_candidate_identity_reference_migration.py
+++ b/workers/automation/tests/test_application_feedback_candidate_identity_reference_migration.py
@@ -331,7 +331,7 @@ def test_v21_candidates_migrate_every_alias_uuid_url_and_tenant(
     assert (
         reopened.execute("PRAGMA user_version").fetchone()[0]
         == SCHEMA_VERSION
-        == 28
+        == 29
     )
     for table in database_module._APPLICATION_FEEDBACK_CANDIDATE_TABLES:
         assert "job_id" in _columns(reopened, table)

--- a/workers/automation/tests/test_application_outcome_identity_reference_migration.py
+++ b/workers/automation/tests/test_application_outcome_identity_reference_migration.py
@@ -243,7 +243,7 @@ def test_v20_outcomes_migrate_every_alias_uuid_url_and_tenant(
     assert (
         reopened.execute("PRAGMA user_version").fetchone()[0]
         == SCHEMA_VERSION
-        == 28
+        == 29
     )
     assert "job_id" in _columns(reopened, "application_outcomes")
     assert "job_key" not in _columns(reopened, "application_outcomes")

--- a/workers/automation/tests/test_application_review_identity_reference_migration.py
+++ b/workers/automation/tests/test_application_review_identity_reference_migration.py
@@ -204,7 +204,7 @@ def test_v19_review_decisions_migrate_every_alias_and_uuid_url(
     assert (
         reopened.execute("PRAGMA user_version").fetchone()[0]
         == SCHEMA_VERSION
-        == 28
+        == 29
     )
     assert "job_id" in _columns(
         reopened,

--- a/workers/automation/tests/test_apply_regressions.py
+++ b/workers/automation/tests/test_apply_regressions.py
@@ -1851,21 +1851,6 @@ def test_dashboard_dry_runs_excludes_soft_deleted_jobs(tmp_path):
     db_path = Path(tmp_path) / "jobs.db"
     conn = init_db(db_path)
 
-    # ``jobctrl_deleted_jobs`` is created on demand by the discovery
-    # repository.  Create it here so the test seeds a tombstone.
-    conn.execute(
-        """
-        CREATE TABLE IF NOT EXISTS jobctrl_deleted_jobs (
-            job_url TEXT PRIMARY KEY,
-            deleted_at TEXT NOT NULL,
-            reason TEXT,
-            restored_at TEXT,
-            FOREIGN KEY(job_url) REFERENCES jobs(url)
-        )
-        """
-    )
-    conn.commit()
-
     try:
         # Two jobs, both with a dry-run apply lifecycle.
         for url in (
@@ -1905,9 +1890,18 @@ def test_dashboard_dry_runs_excludes_soft_deleted_jobs(tmp_path):
 
         # Soft-delete the second job.
         conn.execute(
-            "INSERT INTO jobctrl_deleted_jobs (job_url, deleted_at) "
-            "VALUES (?, ?)",
-            ("https://example.com/job-deleted", "2026-05-04T13:05:00+00:00"),
+            """
+            INSERT INTO jobctrl_deleted_jobs (
+                tenant_id, job_id, deleted_at
+            )
+            SELECT tenant_id, job_id, ?
+            FROM jobs
+            WHERE url = ?
+            """,
+            (
+                "2026-05-04T13:05:00+00:00",
+                "https://example.com/job-deleted",
+            ),
         )
         conn.commit()
         ProjectionBuilder(conn_factory=lambda: conn).refresh()

--- a/workers/automation/tests/test_compensation_identity_reference_migration.py
+++ b/workers/automation/tests/test_compensation_identity_reference_migration.py
@@ -210,7 +210,7 @@ def test_v18_compensation_migrates_alias_winners_and_uuid_urls(
     assert (
         reopened.execute("PRAGMA user_version").fetchone()[0]
         == SCHEMA_VERSION
-        == 28
+        == 29
     )
     for table in database_module._COMPENSATION_REFERENCE_TABLES:
         assert "job_id" in _columns(reopened, table)

--- a/workers/automation/tests/test_deleted_job_identity_reference_migration.py
+++ b/workers/automation/tests/test_deleted_job_identity_reference_migration.py
@@ -1,0 +1,557 @@
+"""Schema-v29 soft-delete tombstone stable JobId contracts."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import jobctrl.database as database_module
+from jobctrl.database import (
+    ensure_deleted_job_references_v29,
+    ensure_deleted_jobs_table,
+    init_db,
+    reassign_discovery_identity_references,
+)
+from jobctrl.domain.identifiers import JobId
+from jobctrl.domain.tenant import LOCAL_TENANT
+from jobctrl.infrastructure.discovery import SqliteJobRepository
+
+PREVIOUS_SCHEMA_VERSION = 28
+NOW = "2026-07-30T12:00:00+00:00"
+UUID_SHAPED_URL = "11111111-1111-4111-8111-111111111111"
+TARGET_JOB_ID = "22222222-2222-4222-8222-222222222222"
+COLLIDING_JOB_ID = UUID_SHAPED_URL
+ALIAS_JOB_ID = "33333333-3333-4333-8333-333333333333"
+LOSING_JOB_ID = "44444444-4444-4444-8444-444444444444"
+SURVIVING_JOB_ID = "55555555-5555-4555-8555-555555555555"
+SHARED_JOB_ID = "66666666-6666-4666-8666-666666666666"
+
+
+def _columns(
+    conn: sqlite3.Connection,
+    table: str,
+) -> set[str]:
+    return {
+        str(row[1])
+        for row in conn.execute(
+            f'PRAGMA table_info("{table}")'
+        ).fetchall()
+    }
+
+
+def _insert_job(
+    conn: sqlite3.Connection,
+    *,
+    url: str,
+    job_id: str,
+    tenant_id: str = "local",
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO jobs (
+            url, tenant_id, job_id, title, company, discovered_at
+        ) VALUES (?, ?, ?, 'Platform Engineer', 'ExampleCo', ?)
+        """,
+        (url, tenant_id, job_id, NOW),
+    )
+
+
+def _downgrade_deleted_jobs_table_to_v28(
+    conn: sqlite3.Connection,
+) -> None:
+    conn.commit()
+    conn.execute("PRAGMA foreign_keys = OFF")
+    conn.execute("DROP TABLE jobctrl_deleted_jobs")
+    database_module._create_deleted_jobs_table_v29(
+        conn,
+        table="jobctrl_deleted_jobs",
+        stable_reference=False,
+    )
+    conn.execute(
+        f"PRAGMA user_version = {PREVIOUS_SCHEMA_VERSION}"
+    )
+    conn.commit()
+    conn.execute("PRAGMA foreign_keys = ON")
+
+
+def _seed_v28_database(db_path: Path) -> sqlite3.Connection:
+    conn = init_db(db_path)
+    conn.row_factory = sqlite3.Row
+    _downgrade_deleted_jobs_table_to_v28(conn)
+    return conn
+
+
+def _tombstone_snapshot(
+    conn: sqlite3.Connection,
+) -> list[tuple[Any, ...]]:
+    return [
+        tuple(row)
+        for row in conn.execute(
+            """
+            SELECT *
+            FROM jobctrl_deleted_jobs
+            ORDER BY job_url
+            """
+        ).fetchall()
+    ]
+
+
+def test_v28_rows_migrate_url_first_and_alias_lifecycle_merges(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "jobs.db"
+    conn = _seed_v28_database(db_path)
+    colliding_owner_url = (
+        "https://careers.example.test/uuid-id-owner"
+    )
+    canonical_url = "https://careers.example.test/alias-owner"
+    alias_url = "https://legacy.example.test/alias-owner"
+    _insert_job(
+        conn,
+        url=UUID_SHAPED_URL,
+        job_id=TARGET_JOB_ID,
+    )
+    _insert_job(
+        conn,
+        url=colliding_owner_url,
+        job_id=COLLIDING_JOB_ID,
+    )
+    _insert_job(
+        conn,
+        url=canonical_url,
+        job_id=ALIAS_JOB_ID,
+    )
+    conn.execute(
+        """
+        INSERT INTO job_identity_aliases (
+            tenant_id, alias_kind, alias_value, job_id, created_at
+        ) VALUES ('local', 'posting_url', ?, ?, ?)
+        """,
+        (alias_url, ALIAS_JOB_ID, NOW),
+    )
+    conn.commit()
+    conn.execute("PRAGMA foreign_keys = OFF")
+    conn.executemany(
+        """
+        INSERT INTO jobctrl_deleted_jobs (
+            job_url, deleted_at, reason, restored_at
+        ) VALUES (?, ?, ?, ?)
+        """,
+        (
+            (
+                UUID_SHAPED_URL,
+                "2026-07-30T09:00:00+00:00",
+                "uuid-shaped URL",
+                None,
+            ),
+            (
+                alias_url,
+                "2026-07-30T10:00:00+00:00",
+                "older alias delete",
+                "2026-07-30T13:00:00+00:00",
+            ),
+            (
+                canonical_url,
+                "2026-07-30T12:00:00+00:00",
+                "latest canonical delete",
+                "2026-07-30T11:00:00+00:00",
+            ),
+        ),
+    )
+    conn.commit()
+    conn.execute("PRAGMA foreign_keys = ON")
+
+    ensure_deleted_job_references_v29(conn)
+
+    assert (
+        conn.execute("PRAGMA user_version").fetchone()[0]
+        == 29
+    )
+    assert _columns(conn, "jobctrl_deleted_jobs") == {
+        "tenant_id",
+        "job_id",
+        "deleted_at",
+        "reason",
+        "restored_at",
+    }
+    rows = [
+        tuple(row)
+        for row in conn.execute(
+            """
+            SELECT tenant_id, job_id, deleted_at, reason, restored_at
+            FROM jobctrl_deleted_jobs
+            ORDER BY job_id
+            """
+        ).fetchall()
+    ]
+    assert rows == [
+        (
+            "local",
+            TARGET_JOB_ID,
+            "2026-07-30T09:00:00+00:00",
+            "uuid-shaped URL",
+            None,
+        ),
+        (
+            "local",
+            ALIAS_JOB_ID,
+            "2026-07-30T12:00:00+00:00",
+            "latest canonical delete",
+            "2026-07-30T13:00:00+00:00",
+        ),
+    ]
+    repository = SqliteJobRepository(conn)
+    uuid_url_job = repository.load(
+        LOCAL_TENANT,
+        JobId(TARGET_JOB_ID),
+    )
+    alias_job = repository.load(
+        LOCAL_TENANT,
+        JobId(ALIAS_JOB_ID),
+    )
+    assert uuid_url_job is not None
+    assert uuid_url_job.is_deleted is True
+    assert alias_job is not None
+    assert alias_job.is_deleted is False
+
+    conn.commit()
+    conn.close()
+    reopened = init_db(db_path)
+    assert database_module._has_deleted_job_reference_schema_v29(
+        reopened
+    )
+
+
+def test_unresolved_reference_rolls_back_then_retries(
+    tmp_path: Path,
+) -> None:
+    conn = _seed_v28_database(tmp_path / "jobs.db")
+    unresolved_url = "https://careers.example.test/missing"
+    conn.commit()
+    conn.execute("PRAGMA foreign_keys = OFF")
+    conn.execute(
+        """
+        INSERT INTO jobctrl_deleted_jobs (
+            job_url, deleted_at, reason, restored_at
+        ) VALUES (?, ?, ?, NULL)
+        """,
+        (
+            unresolved_url,
+            "2026-07-30T10:00:00+00:00",
+            "unresolved",
+        ),
+    )
+    conn.commit()
+    conn.execute("PRAGMA foreign_keys = ON")
+    before = _tombstone_snapshot(conn)
+
+    with pytest.raises(
+        RuntimeError,
+        match="could not resolve",
+    ):
+        ensure_deleted_job_references_v29(conn)
+
+    assert _tombstone_snapshot(conn) == before
+    assert "job_url" in _columns(
+        conn,
+        "jobctrl_deleted_jobs",
+    )
+    assert (
+        conn.execute("PRAGMA user_version").fetchone()[0]
+        == PREVIOUS_SCHEMA_VERSION
+    )
+    assert conn.execute(
+        """
+        SELECT 1
+        FROM sqlite_master
+        WHERE type = 'table'
+          AND name = 'jobctrl_deleted_jobs_v29'
+        """
+    ).fetchone() is None
+
+    _insert_job(
+        conn,
+        url=unresolved_url,
+        job_id=TARGET_JOB_ID,
+    )
+    ensure_deleted_job_references_v29(conn)
+    assert conn.execute(
+        """
+        SELECT job_id
+        FROM jobctrl_deleted_jobs
+        """
+    ).fetchone()[0] == TARGET_JOB_ID
+
+
+def test_verification_failure_rolls_back_then_retries(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    conn = _seed_v28_database(tmp_path / "jobs.db")
+    url = "https://careers.example.test/verification"
+    _insert_job(conn, url=url, job_id=TARGET_JOB_ID)
+    conn.execute(
+        """
+        INSERT INTO jobctrl_deleted_jobs (
+            job_url, deleted_at, reason, restored_at
+        ) VALUES (?, ?, ?, NULL)
+        """,
+        (
+            url,
+            "2026-07-30T10:00:00+00:00",
+            "verification",
+        ),
+    )
+    conn.commit()
+    before = _tombstone_snapshot(conn)
+    original_verify = (
+        database_module._verify_deleted_job_references_v29
+    )
+
+    def fail_verification(
+        _conn: sqlite3.Connection,
+        *,
+        expected_count: int,
+    ) -> None:
+        del expected_count
+        raise RuntimeError("injected verification failure")
+
+    monkeypatch.setattr(
+        database_module,
+        "_verify_deleted_job_references_v29",
+        fail_verification,
+    )
+    with pytest.raises(
+        RuntimeError,
+        match="injected verification failure",
+    ):
+        ensure_deleted_job_references_v29(conn)
+
+    assert _tombstone_snapshot(conn) == before
+    assert "job_url" in _columns(
+        conn,
+        "jobctrl_deleted_jobs",
+    )
+    assert (
+        conn.execute("PRAGMA user_version").fetchone()[0]
+        == PREVIOUS_SCHEMA_VERSION
+    )
+
+    monkeypatch.setattr(
+        database_module,
+        "_verify_deleted_job_references_v29",
+        original_verify,
+    )
+    ensure_deleted_job_references_v29(conn)
+    assert database_module._has_deleted_job_reference_schema_v29(
+        conn
+    )
+
+
+def test_missing_table_recovery_matches_schema_version(
+    tmp_path: Path,
+) -> None:
+    legacy = sqlite3.connect(":memory:")
+    legacy.execute(
+        "CREATE TABLE jobs (url TEXT PRIMARY KEY)"
+    )
+    ensure_deleted_jobs_table(legacy)
+    assert "job_url" in _columns(
+        legacy,
+        "jobctrl_deleted_jobs",
+    )
+
+    v28 = _seed_v28_database(tmp_path / "v28.db")
+    v28.execute("DROP TABLE jobctrl_deleted_jobs")
+    ensure_deleted_job_references_v29(v28)
+    assert database_module._has_deleted_job_reference_schema_v29(
+        v28
+    )
+
+    v29 = init_db(tmp_path / "v29.db")
+    v29.execute("DROP TABLE jobctrl_deleted_jobs")
+    ensure_deleted_jobs_table(v29)
+    assert database_module._has_deleted_job_reference_schema_v29(
+        v29
+    )
+
+
+def test_stamped_v29_legacy_table_fails_closed(
+    tmp_path: Path,
+) -> None:
+    conn = init_db(tmp_path / "jobs.db")
+    _downgrade_deleted_jobs_table_to_v28(conn)
+    conn.execute("PRAGMA user_version = 29")
+
+    with pytest.raises(
+        RuntimeError,
+        match="requires stable soft-delete tombstone",
+    ):
+        ensure_deleted_jobs_table(conn)
+
+    assert "job_url" in _columns(
+        conn,
+        "jobctrl_deleted_jobs",
+    )
+
+
+def test_collision_rehome_merges_lifecycle_before_job_delete(
+    tmp_path: Path,
+) -> None:
+    conn = init_db(tmp_path / "jobs.db")
+    losing_url = "https://careers.example.test/losing"
+    surviving_url = "https://careers.example.test/surviving"
+    _insert_job(
+        conn,
+        url=losing_url,
+        job_id=LOSING_JOB_ID,
+    )
+    _insert_job(
+        conn,
+        url=surviving_url,
+        job_id=SURVIVING_JOB_ID,
+    )
+    conn.executemany(
+        """
+        INSERT INTO jobctrl_deleted_jobs (
+            tenant_id, job_id, deleted_at, reason, restored_at
+        ) VALUES ('local', ?, ?, ?, ?)
+        """,
+        (
+            (
+                LOSING_JOB_ID,
+                "2026-07-30T14:00:00+00:00",
+                "latest losing delete",
+                "2026-07-30T11:00:00+00:00",
+            ),
+            (
+                SURVIVING_JOB_ID,
+                "2026-07-30T10:00:00+00:00",
+                "older surviving delete",
+                "2026-07-30T15:00:00+00:00",
+            ),
+        ),
+    )
+
+    reassign_discovery_identity_references(
+        conn,
+        losing_job_url=losing_url,
+        surviving_job_url=surviving_url,
+    )
+
+    row = conn.execute(
+        """
+        SELECT tenant_id, job_id, deleted_at, reason, restored_at
+        FROM jobctrl_deleted_jobs
+        """
+    ).fetchone()
+    assert tuple(row) == (
+        "local",
+        SURVIVING_JOB_ID,
+        "2026-07-30T14:00:00+00:00",
+        "latest losing delete",
+        "2026-07-30T15:00:00+00:00",
+    )
+    conn.execute(
+        "DELETE FROM jobs WHERE url = ?",
+        (losing_url,),
+    )
+    assert conn.execute(
+        """
+        SELECT job_id
+        FROM jobctrl_deleted_jobs
+        """
+    ).fetchone()[0] == SURVIVING_JOB_ID
+
+
+def test_runtime_restore_is_tenant_scoped(
+    tmp_path: Path,
+) -> None:
+    conn = init_db(tmp_path / "jobs.db")
+    _insert_job(
+        conn,
+        tenant_id="local",
+        url="https://local.example.test/shared",
+        job_id=SHARED_JOB_ID,
+    )
+    _insert_job(
+        conn,
+        tenant_id="blue",
+        url="https://blue.example.test/shared",
+        job_id=SHARED_JOB_ID,
+    )
+    conn.executemany(
+        """
+        INSERT INTO jobctrl_deleted_jobs (
+            tenant_id, job_id, deleted_at, reason, restored_at
+        ) VALUES (?, ?, ?, 'tenant isolation', NULL)
+        """,
+        (
+            (
+                "local",
+                SHARED_JOB_ID,
+                "2026-07-30T10:00:00+00:00",
+            ),
+            (
+                "blue",
+                SHARED_JOB_ID,
+                "2026-07-30T10:00:00+00:00",
+            ),
+        ),
+    )
+    repository = SqliteJobRepository(conn)
+
+    restored = repository.restore(
+        LOCAL_TENANT,
+        JobId(SHARED_JOB_ID),
+        restored_at="2026-07-30T11:00:00+00:00",
+    )
+
+    assert restored is not None
+    rows = [
+        tuple(row)
+        for row in conn.execute(
+            """
+            SELECT tenant_id, restored_at
+            FROM jobctrl_deleted_jobs
+            ORDER BY tenant_id
+            """
+        ).fetchall()
+    ]
+    assert rows == [
+        ("blue", None),
+        ("local", "2026-07-30T11:00:00+00:00"),
+    ]
+
+
+def test_stable_tombstone_cascades_with_job_delete(
+    tmp_path: Path,
+) -> None:
+    conn = init_db(tmp_path / "jobs.db")
+    conn.commit()
+    conn.execute("PRAGMA foreign_keys = ON")
+    url = "https://careers.example.test/cascade"
+    _insert_job(conn, url=url, job_id=TARGET_JOB_ID)
+    conn.execute(
+        """
+        INSERT INTO jobctrl_deleted_jobs (
+            tenant_id, job_id, deleted_at, reason, restored_at
+        ) VALUES (
+            'local', ?, '2026-07-30T10:00:00+00:00',
+            'cascade', NULL
+        )
+        """,
+        (TARGET_JOB_ID,),
+    )
+
+    conn.execute(
+        "DELETE FROM jobs WHERE url = ?",
+        (url,),
+    )
+
+    assert conn.execute(
+        "SELECT COUNT(*) FROM jobctrl_deleted_jobs"
+    ).fetchone()[0] == 0

--- a/workers/automation/tests/test_discovery_execution_lineage.py
+++ b/workers/automation/tests/test_discovery_execution_lineage.py
@@ -430,17 +430,14 @@ def test_terminal_fanout_honors_deleted_job_tombstone_when_table_exists(
     job_url = _insert_job(conn, "deleted")
     conn.execute(
         """
-        CREATE TABLE jobctrl_deleted_jobs (
-            job_url TEXT PRIMARY KEY,
-            deleted_at TEXT NOT NULL,
-            reason TEXT,
-            restored_at TEXT
+        INSERT INTO jobctrl_deleted_jobs (
+            tenant_id, job_id, deleted_at
         )
-        """
-    )
-    conn.execute(
-        "INSERT INTO jobctrl_deleted_jobs (job_url, deleted_at) VALUES (?, ?)",
-        (job_url, "2026-07-14T09:00:00+00:00"),
+        SELECT tenant_id, job_id, ?
+        FROM jobs
+        WHERE url = ?
+        """,
+        ("2026-07-14T09:00:00+00:00", job_url),
     )
     conn.commit()
     repository.link_job(

--- a/workers/automation/tests/test_discovery_identity.py
+++ b/workers/automation/tests/test_discovery_identity.py
@@ -600,7 +600,14 @@ def test_discover_jobs_use_case_resurfaces_soft_deleted_existing_job(
     assert resurfaced.metadata.description == "Lead platform engineering teams in Spain."
     assert resurfaced.metadata.location == "Barcelona, Spain"
     tombstone = conn.execute(
-        "SELECT restored_at FROM jobctrl_deleted_jobs WHERE job_url = ?",
+        """
+        SELECT deleted.restored_at
+        FROM jobctrl_deleted_jobs AS deleted
+        JOIN jobs
+          ON jobs.tenant_id = deleted.tenant_id
+         AND jobs.job_id = deleted.job_id
+        WHERE jobs.url = ?
+        """,
         ("https://boards.greenhouse.io/acme/jobs/123",),
     ).fetchone()
     assert tombstone is not None
@@ -760,8 +767,15 @@ def test_discover_jobs_use_case_keeps_policy_rejected_deleted_job_hidden(
     assert hidden.is_deleted is True
     assert hidden.metadata.title == "Platform Engineer"
     tombstone = conn.execute(
-        "SELECT restored_at FROM jobctrl_deleted_jobs WHERE job_url = ?",
-        (str(job_id),),
+        """
+        SELECT deleted.restored_at
+        FROM jobctrl_deleted_jobs AS deleted
+        JOIN jobs
+          ON jobs.tenant_id = deleted.tenant_id
+         AND jobs.job_id = deleted.job_id
+        WHERE jobs.url = ?
+        """,
+        ("https://boards.greenhouse.io/acme/jobs/123",),
     ).fetchone()
     assert tombstone is not None
     assert tombstone["restored_at"] is None

--- a/workers/automation/tests/test_discovery_identity_reference_migration.py
+++ b/workers/automation/tests/test_discovery_identity_reference_migration.py
@@ -220,7 +220,7 @@ def test_v7_discovery_references_migrate_to_stable_job_id_and_reopen(
     init_db(db_path)
     close_connection(db_path)
 
-    assert _user_version(db_path) == SCHEMA_VERSION == 28
+    assert _user_version(db_path) == SCHEMA_VERSION == 29
     assert "job_id" in _columns(db_path, "job_source_observations")
     assert "job_url" not in _columns(db_path, "job_source_observations")
     assert "job_id" in _columns(db_path, "job_canonical_identities")

--- a/workers/automation/tests/test_discovery_limits.py
+++ b/workers/automation/tests/test_discovery_limits.py
@@ -815,10 +815,18 @@ def test_jobspy_existing_row_refreshes_metadata_before_restore(tmp_path):
         jobspy._ensure_deleted_jobs_table(conn)
         conn.execute(
             """
-            INSERT INTO jobctrl_deleted_jobs (job_url, deleted_at, reason, restored_at)
-            VALUES (?, ?, ?, NULL)
+            INSERT INTO jobctrl_deleted_jobs (
+                tenant_id, job_id, deleted_at, reason, restored_at
+            )
+            SELECT tenant_id, job_id, ?, ?, NULL
+            FROM jobs
+            WHERE url = ?
             """,
-            (url, "2026-05-21T00:00:00+00:00", "stale invalid row"),
+            (
+                "2026-05-21T00:00:00+00:00",
+                "stale invalid row",
+                url,
+            ),
         )
         conn.commit()
 
@@ -849,7 +857,14 @@ def test_jobspy_existing_row_refreshes_metadata_before_restore(tmp_path):
             "location": "Barcelona, Spain",
         }
         tombstone = conn.execute(
-            "SELECT restored_at FROM jobctrl_deleted_jobs WHERE job_url = ?",
+            """
+            SELECT deleted.restored_at
+            FROM jobctrl_deleted_jobs AS deleted
+            JOIN jobs
+              ON jobs.tenant_id = deleted.tenant_id
+             AND jobs.job_id = deleted.job_id
+            WHERE jobs.url = ?
+            """,
             (url,),
         ).fetchone()
         assert tombstone["restored_at"] is not None
@@ -1563,10 +1578,18 @@ def test_jobspy_exact_rediscovery_keeps_deleted_content_duplicate_suppressed(tmp
         )
         conn.execute(
             """
-            INSERT INTO jobctrl_deleted_jobs (job_url, deleted_at, reason, restored_at)
-            VALUES (?, ?, ?, NULL)
+            INSERT INTO jobctrl_deleted_jobs (
+                tenant_id, job_id, deleted_at, reason, restored_at
+            )
+            SELECT tenant_id, job_id, ?, ?, NULL
+            FROM jobs
+            WHERE url = ?
             """,
-            (duplicate_url, "2026-05-21T11:00:00+00:00", "content duplicate"),
+            (
+                "2026-05-21T11:00:00+00:00",
+                "content duplicate",
+                duplicate_url,
+            ),
         )
         conn.commit()
 
@@ -1584,7 +1607,14 @@ def test_jobspy_exact_rediscovery_keeps_deleted_content_duplicate_suppressed(tmp
         assert jobspy.store_jobspy_results(conn, rediscovered, "Product", limit=10) == (0, 1)
 
         tombstone = conn.execute(
-            "SELECT restored_at FROM jobctrl_deleted_jobs WHERE job_url = ?",
+            """
+            SELECT deleted.restored_at
+            FROM jobctrl_deleted_jobs AS deleted
+            JOIN jobs
+              ON jobs.tenant_id = deleted.tenant_id
+             AND jobs.job_id = deleted.job_id
+            WHERE jobs.url = ?
+            """,
             (duplicate_url,),
         ).fetchone()
         assert tombstone["restored_at"] is None

--- a/workers/automation/tests/test_discovery_production_wiring.py
+++ b/workers/automation/tests/test_discovery_production_wiring.py
@@ -686,7 +686,15 @@ def test_discovery_hygiene_retires_existing_invalid_canonical_ats_rows(
     assert result["retired_jobs"] == 3
     deleted = {
         row["job_url"]: row["reason"]
-        for row in conn.execute("SELECT job_url, reason FROM jobctrl_deleted_jobs").fetchall()
+        for row in conn.execute(
+            """
+            SELECT jobs.url AS job_url, deleted.reason
+            FROM jobctrl_deleted_jobs AS deleted
+            JOIN jobs
+              ON jobs.tenant_id = deleted.tenant_id
+             AND jobs.job_id = deleted.job_id
+            """
+        ).fetchall()
     }
     assert "https://boards.greenhouse.io/acme/jobs/valid" not in deleted
     assert "missing_description" in deleted["https://boards.greenhouse.io/acme/jobs/empty-description"]
@@ -786,7 +794,15 @@ def test_discovery_hygiene_retires_ashby_business_travel_portugal_rows(
     assert result["retired_jobs"] == 1
     deleted = {
         row["job_url"]: row["reason"]
-        for row in conn.execute("SELECT job_url, reason FROM jobctrl_deleted_jobs").fetchall()
+        for row in conn.execute(
+            """
+            SELECT jobs.url AS job_url, deleted.reason
+            FROM jobctrl_deleted_jobs AS deleted
+            JOIN jobs
+              ON jobs.tenant_id = deleted.tenant_id
+             AND jobs.job_id = deleted.job_id
+            """
+        ).fetchall()
     }
     assert good_url not in deleted
     assert "title_mismatch" in deleted[bad_url]
@@ -879,7 +895,15 @@ def test_discovery_hygiene_retires_invalid_jobspy_rows(
     assert result["retired_jobs"] == 2
     deleted = {
         row["job_url"]: row["reason"]
-        for row in conn.execute("SELECT job_url, reason FROM jobctrl_deleted_jobs").fetchall()
+        for row in conn.execute(
+            """
+            SELECT jobs.url AS job_url, deleted.reason
+            FROM jobctrl_deleted_jobs AS deleted
+            JOIN jobs
+              ON jobs.tenant_id = deleted.tenant_id
+             AND jobs.job_id = deleted.job_id
+            """
+        ).fetchall()
     }
     assert "https://www.linkedin.com/jobs/view/valid-head-engineering" not in deleted
     assert "title_mismatch" in deleted["https://www.linkedin.com/jobs/view/head-school-biomedical"]
@@ -989,7 +1013,15 @@ def test_discovery_hygiene_treats_serialized_null_descriptions_as_missing(
     assert result["retired_jobs"] == 3
     deleted = {
         row["job_url"]: row["reason"]
-        for row in conn.execute("SELECT job_url, reason FROM jobctrl_deleted_jobs").fetchall()
+        for row in conn.execute(
+            """
+            SELECT jobs.url AS job_url, deleted.reason
+            FROM jobctrl_deleted_jobs AS deleted
+            JOIN jobs
+              ON jobs.tenant_id = deleted.tenant_id
+             AND jobs.job_id = deleted.job_id
+            """
+        ).fetchall()
     }
     assert "https://www.linkedin.com/jobs/view/valid-head-engineering" not in deleted
     assert (
@@ -1297,7 +1329,15 @@ def test_discovery_hygiene_applies_to_workday_and_smart_extract_rows(
     assert result["retired_jobs"] == 3
     deleted = {
         row["job_url"]: row["reason"]
-        for row in conn.execute("SELECT job_url, reason FROM jobctrl_deleted_jobs").fetchall()
+        for row in conn.execute(
+            """
+            SELECT jobs.url AS job_url, deleted.reason
+            FROM jobctrl_deleted_jobs AS deleted
+            JOIN jobs
+              ON jobs.tenant_id = deleted.tenant_id
+             AND jobs.job_id = deleted.job_id
+            """
+        ).fetchall()
     }
     assert "https://acme.wd1.myworkdayjobs.com/jobs/valid-engineering-manager" not in deleted
     assert "https://wellfound.com/jobs/valid-head-engineering" not in deleted

--- a/workers/automation/tests/test_employer_analysis_identity_reference_migration.py
+++ b/workers/automation/tests/test_employer_analysis_identity_reference_migration.py
@@ -242,7 +242,7 @@ def test_v15_employer_analysis_migrates_alias_histories_and_uuid_urls(
     assert (
         reopened.execute("PRAGMA user_version").fetchone()[0]
         == SCHEMA_VERSION
-        == 28
+        == 29
     )
     for table in database_module._EMPLOYER_ANALYSIS_REFERENCE_TABLES:
         assert "job_id" in _columns(reopened, table)

--- a/workers/automation/tests/test_enrichment_snapshot_identity_reference_migration.py
+++ b/workers/automation/tests/test_enrichment_snapshot_identity_reference_migration.py
@@ -322,7 +322,7 @@ def test_v10_enrichment_snapshot_references_migrate_and_reopen(
     init_db(db_path)
     close_connection(db_path)
 
-    assert _user_version(db_path) == SCHEMA_VERSION == 28
+    assert _user_version(db_path) == SCHEMA_VERSION == 29
     check = sqlite3.connect(db_path)
     try:
         enrichment_rows = check.execute(

--- a/workers/automation/tests/test_execution_search_identity_reference_migration.py
+++ b/workers/automation/tests/test_execution_search_identity_reference_migration.py
@@ -261,7 +261,7 @@ def test_v8_execution_and_receipts_migrate_to_stable_job_id_and_reopen(
     init_db(db_path)
     close_connection(db_path)
 
-    assert _user_version(db_path) == SCHEMA_VERSION == 28
+    assert _user_version(db_path) == SCHEMA_VERSION == 29
     assert "job_id" in _columns(db_path, "discovery_execution_jobs")
     assert "job_url" not in _columns(db_path, "discovery_execution_jobs")
     assert "job_id" in _columns(db_path, "discovery_search_unit_jobs")

--- a/workers/automation/tests/test_interview_prep_identity_reference_migration.py
+++ b/workers/automation/tests/test_interview_prep_identity_reference_migration.py
@@ -323,7 +323,7 @@ def test_v17_interview_prep_migrates_alias_histories_and_uuid_urls(
     assert (
         reopened.execute("PRAGMA user_version").fetchone()[0]
         == SCHEMA_VERSION
-        == 28
+        == 29
     )
     for table in database_module._INTERVIEW_PREP_REFERENCE_TABLES:
         assert "job_id" in _columns(reopened, table)

--- a/workers/automation/tests/test_job_list_projection.py
+++ b/workers/automation/tests/test_job_list_projection.py
@@ -474,21 +474,17 @@ def test_apply_run_succeeded_marks_applied(conn: sqlite3.Connection) -> None:
 def test_soft_deleted_job_carries_deleted_at(conn: sqlite3.Connection) -> None:
     url = "https://example.com/jobs/5"
     _seed_job(conn, url)
-    conn.execute(
-        """
-        CREATE TABLE IF NOT EXISTS jobctrl_deleted_jobs (
-            job_url     TEXT PRIMARY KEY,
-            deleted_at  TEXT NOT NULL,
-            reason      TEXT,
-            restored_at TEXT
-        )
-        """
-    )
     deleted_at = "2026-05-04T14:00:00+00:00"
     conn.execute(
-        "INSERT INTO jobctrl_deleted_jobs (job_url, deleted_at, reason, restored_at) "
-        "VALUES (?, ?, ?, NULL)",
-        (url, deleted_at, "test"),
+        """
+        INSERT INTO jobctrl_deleted_jobs (
+            tenant_id, job_id, deleted_at, reason, restored_at
+        )
+        SELECT tenant_id, job_id, ?, ?, NULL
+        FROM jobs
+        WHERE url = ?
+        """,
+        (deleted_at, "test", url),
     )
     record_job_event(conn, url, "discover", "JobDeleted")
     conn.commit()
@@ -504,21 +500,22 @@ def test_soft_deleted_job_carries_deleted_at(conn: sqlite3.Connection) -> None:
 def test_stale_restore_before_delete_still_carries_deleted_at(conn: sqlite3.Connection) -> None:
     url = "https://example.com/jobs/stale-restore"
     _seed_job(conn, url)
-    conn.execute(
-        """
-        CREATE TABLE IF NOT EXISTS jobctrl_deleted_jobs (
-            job_url     TEXT PRIMARY KEY,
-            deleted_at  TEXT NOT NULL,
-            reason      TEXT,
-            restored_at TEXT
-        )
-        """
-    )
     deleted_at = "2026-05-25T23:10:33.870522+00:00"
     conn.execute(
-        "INSERT INTO jobctrl_deleted_jobs (job_url, deleted_at, reason, restored_at) "
-        "VALUES (?, ?, ?, ?)",
-        (url, deleted_at, "discovery hygiene rejected source", "2026-05-25T21:35:55.879345+00:00"),
+        """
+        INSERT INTO jobctrl_deleted_jobs (
+            tenant_id, job_id, deleted_at, reason, restored_at
+        )
+        SELECT tenant_id, job_id, ?, ?, ?
+        FROM jobs
+        WHERE url = ?
+        """,
+        (
+            deleted_at,
+            "discovery hygiene rejected source",
+            "2026-05-25T21:35:55.879345+00:00",
+            url,
+        ),
     )
     record_job_event(conn, url, "discover", "JobDeleted")
     conn.commit()

--- a/workers/automation/tests/test_job_repository.py
+++ b/workers/automation/tests/test_job_repository.py
@@ -390,8 +390,15 @@ def test_soft_delete_writes_tombstone_row(conn: sqlite3.Connection) -> None:
     assert deleted is not None and deleted.is_deleted
 
     row = conn.execute(
-        "SELECT deleted_at, reason, restored_at FROM jobctrl_deleted_jobs WHERE job_url = ?",
-        (str(job.job_id),),
+        """
+        SELECT deleted.deleted_at, deleted.reason, deleted.restored_at
+        FROM jobctrl_deleted_jobs AS deleted
+        JOIN jobs
+          ON jobs.tenant_id = deleted.tenant_id
+         AND jobs.job_id = deleted.job_id
+        WHERE jobs.url = ?
+        """,
+        (job.posting_url.value,),
     ).fetchone()
     assert row is not None
     assert row["deleted_at"] == "2026-05-02T00:00:00+00:00"
@@ -437,8 +444,15 @@ def test_restore_clears_tombstone(conn: sqlite3.Connection) -> None:
 
     # Tombstone row carries restored_at (audit history preserved)
     row = conn.execute(
-        "SELECT restored_at FROM jobctrl_deleted_jobs WHERE job_url = ?",
-        (str(job.job_id),),
+        """
+        SELECT deleted.restored_at
+        FROM jobctrl_deleted_jobs AS deleted
+        JOIN jobs
+          ON jobs.tenant_id = deleted.tenant_id
+         AND jobs.job_id = deleted.job_id
+        WHERE jobs.url = ?
+        """,
+        (job.posting_url.value,),
     ).fetchone()
     assert row is not None
     assert row["restored_at"] is not None
@@ -458,8 +472,15 @@ def test_resurface_deleted_job_clears_tombstone_and_records_event(conn: sqlite3.
     resurface_deleted_job(conn, str(job.job_id), resurfaced_at="2026-05-03T00:00:00+00:00")
 
     row = conn.execute(
-        "SELECT restored_at FROM jobctrl_deleted_jobs WHERE job_url = ?",
-        (str(job.job_id),),
+        """
+        SELECT deleted.restored_at
+        FROM jobctrl_deleted_jobs AS deleted
+        JOIN jobs
+          ON jobs.tenant_id = deleted.tenant_id
+         AND jobs.job_id = deleted.job_id
+        WHERE jobs.url = ?
+        """,
+        (job.posting_url.value,),
     ).fetchone()
     assert row is not None
     assert row["restored_at"] == "2026-05-03T00:00:00+00:00"

--- a/workers/automation/tests/test_materials_identity_reference_migration.py
+++ b/workers/automation/tests/test_materials_identity_reference_migration.py
@@ -293,7 +293,7 @@ def test_v14_materials_migrate_alias_histories_and_uuid_shaped_urls(
     close_connection(db_path)
 
     reopened = init_db(db_path)
-    assert reopened.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_VERSION == 28
+    assert reopened.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_VERSION == 29
     for table in database_module._MATERIALS_REFERENCE_TABLES:
         assert "job_id" in _columns(reopened, table)
         assert "job_url" not in _columns(reopened, table)

--- a/workers/automation/tests/test_preparation_identity_reference_migration.py
+++ b/workers/automation/tests/test_preparation_identity_reference_migration.py
@@ -177,7 +177,7 @@ def test_v9_preparation_references_migrate_to_stable_job_ids_and_reopen(
     init_db(db_path)
     close_connection(db_path)
 
-    assert _user_version(db_path) == SCHEMA_VERSION == 28
+    assert _user_version(db_path) == SCHEMA_VERSION == 29
     check = sqlite3.connect(db_path)
     try:
         rows = check.execute(

--- a/workers/automation/tests/test_projection_builder.py
+++ b/workers/automation/tests/test_projection_builder.py
@@ -18,6 +18,7 @@ from jobctrl.infrastructure.events.watermark import SqliteEventWatermarkReposito
 from jobctrl.infrastructure.projections.projection_builder import (
     PROJECTION_NAME,
     ProjectionBuilder,
+    _job_lifecycle_exclusion_sql,
 )
 from jobctrl.state import record_job_event, utc_now
 
@@ -49,6 +50,153 @@ def _stable_job_id(conn: sqlite3.Connection, url: str) -> str:
     ).fetchone()
     assert row is not None
     return str(row[0])
+
+
+def test_lifecycle_exclusion_resolves_historical_posting_alias(
+    conn: sqlite3.Connection,
+) -> None:
+    canonical_url = "https://example.com/jobs/current"
+    historical_alias = "https://legacy.example.com/jobs/current"
+    _seed_job(conn, canonical_url)
+    job_id = _stable_job_id(conn, canonical_url)
+    conn.execute(
+        """
+        INSERT INTO job_identity_aliases (
+            tenant_id, alias_kind, alias_value, job_id, created_at
+        ) VALUES ('local', 'posting_url', ?, ?, ?)
+        """,
+        (
+            historical_alias,
+            job_id,
+            "2026-07-30T10:00:00+00:00",
+        ),
+    )
+    conn.execute(
+        """
+        INSERT INTO jobctrl_deleted_jobs (
+            tenant_id, job_id, deleted_at, reason, restored_at
+        ) VALUES ('local', ?, ?, 'user delete', NULL)
+        """,
+        (job_id, "2026-07-30T11:00:00+00:00"),
+    )
+    conn.execute(
+        """
+        CREATE TEMP TABLE historical_url_consumers (
+            tenant_id TEXT NOT NULL,
+            job_url TEXT NOT NULL
+        )
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO historical_url_consumers (tenant_id, job_url)
+        VALUES ('local', ?)
+        """,
+        (historical_alias,),
+    )
+    lifecycle = _job_lifecycle_exclusion_sql(
+        conn,
+        "consumer.job_url",
+        tenant_expression="consumer.tenant_id",
+    )
+    rows = conn.execute(
+        f"""
+        SELECT consumer.job_url
+        FROM historical_url_consumers consumer
+        {lifecycle["join_sql"]}
+        WHERE 1 = 1{lifecycle["where_sql"]}
+        """
+    ).fetchall()
+    assert rows == []
+
+    conn.execute(
+        """
+        UPDATE jobctrl_deleted_jobs
+        SET restored_at = ?
+        WHERE tenant_id = 'local' AND job_id = ?
+        """,
+        ("2026-07-30T12:00:00+00:00", job_id),
+    )
+    rows = conn.execute(
+        f"""
+        SELECT consumer.job_url
+        FROM historical_url_consumers consumer
+        {lifecycle["join_sql"]}
+        WHERE 1 = 1{lifecycle["where_sql"]}
+        """
+    ).fetchall()
+    assert [str(row[0]) for row in rows] == [historical_alias]
+
+
+def test_refresh_reconciles_restored_alias_projection_without_event(
+    conn: sqlite3.Connection,
+) -> None:
+    canonical_url = "https://example.com/jobs/restored-current"
+    historical_alias = "https://legacy.example.com/jobs/restored-current"
+    _seed_job(conn, canonical_url)
+    record_job_event(
+        conn,
+        canonical_url,
+        "discover",
+        "JobDiscovered",
+    )
+    conn.commit()
+    builder = ProjectionBuilder(conn_factory=lambda: conn)
+    builder.refresh()
+
+    job_id = _stable_job_id(conn, canonical_url)
+    conn.execute(
+        """
+        INSERT INTO job_identity_aliases (
+            tenant_id, alias_kind, alias_value, job_id, created_at
+        ) VALUES ('local', 'posting_url', ?, ?, ?)
+        """,
+        (
+            historical_alias,
+            job_id,
+            "2026-07-30T10:00:00+00:00",
+        ),
+    )
+    conn.execute(
+        """
+        INSERT INTO jobctrl_deleted_jobs (
+            tenant_id, job_id, deleted_at, reason, restored_at
+        ) VALUES ('local', ?, ?, 'migrated alias merge', ?)
+        """,
+        (
+            job_id,
+            "2026-07-30T11:00:00+00:00",
+            "2026-07-30T12:00:00+00:00",
+        ),
+    )
+    conn.execute(
+        """
+        UPDATE job_list_projections
+        SET job_id = ?, deleted_at = ?
+        WHERE tenant_id = 'local' AND job_id = ?
+        """,
+        (
+            historical_alias,
+            "2026-07-30T11:00:00+00:00",
+            canonical_url,
+        ),
+    )
+    conn.commit()
+
+    builder.refresh()
+
+    rows = conn.execute(
+        """
+        SELECT job_id, deleted_at
+        FROM job_list_projections
+        WHERE tenant_id = 'local'
+        ORDER BY job_id
+        """
+    ).fetchall()
+    assert [
+        (str(row["job_id"]), row["deleted_at"])
+        for row in rows
+    ] == [(canonical_url, None)]
 
 
 def test_initial_watermark_is_zero(conn: sqlite3.Connection) -> None:
@@ -341,19 +489,8 @@ def test_evidence_map_excludes_soft_deleted_and_hidden_jobs(
         """
     )
 
-    # jobctrl_deleted_jobs / jobctrl_hidden_jobs are owned by the TS
-    # write-model; create them here so the Python builder's _table_exists-guarded
-    # exclusion joins engage.
-    conn.execute(
-        """
-        CREATE TABLE IF NOT EXISTS jobctrl_deleted_jobs (
-            job_url TEXT PRIMARY KEY,
-            deleted_at TEXT NOT NULL,
-            reason TEXT,
-            restored_at TEXT
-        )
-        """
-    )
+    # jobctrl_hidden_jobs is still owned by the TS write-model. The
+    # worker-owned v29 schema already includes stable soft-delete tombstones.
     conn.execute(
         """
         CREATE TABLE IF NOT EXISTS jobctrl_hidden_jobs (
@@ -499,8 +636,15 @@ def test_evidence_map_excludes_soft_deleted_and_hidden_jobs(
     )
 
     conn.execute(
-        "INSERT INTO jobctrl_deleted_jobs (job_url, deleted_at, reason, restored_at) "
-        "VALUES (?, '2026-07-05T13:00:00Z', 'user delete', NULL)",
+        """
+        INSERT INTO jobctrl_deleted_jobs (
+            tenant_id, job_id, deleted_at, reason, restored_at
+        )
+        SELECT tenant_id, job_id,
+               '2026-07-05T13:00:00Z', 'user delete', NULL
+        FROM jobs
+        WHERE url = ?
+        """,
         (deleted_url,),
     )
     conn.execute(

--- a/workers/automation/tests/test_quarantine_identity_reference_migration.py
+++ b/workers/automation/tests/test_quarantine_identity_reference_migration.py
@@ -10,7 +10,6 @@ import pytest
 
 import jobctrl.database as database_module
 from jobctrl.database import (
-    SCHEMA_VERSION,
     ensure_discovery_control_tables,
     ensure_quarantine_references_v28,
     init_db,
@@ -266,7 +265,6 @@ def test_v27_rows_migrate_and_duplicate_authorities_merge(
 
     assert (
         conn.execute("PRAGMA user_version").fetchone()[0]
-        == SCHEMA_VERSION
         == 28
     )
     assert database_module._has_quarantine_reference_schema_v28(

--- a/workers/automation/tests/test_repeat_application_identity_reference_migration.py
+++ b/workers/automation/tests/test_repeat_application_identity_reference_migration.py
@@ -402,7 +402,7 @@ def test_v22_history_migrates_exactly_with_url_first_resolution(
     reopened = init_db(db_path)
     assert reopened.execute("PRAGMA user_version").fetchone()[0] == (
         SCHEMA_VERSION
-    ) == 28
+    ) == 29
     assert database_module._has_repeat_application_reference_schema_v23(
         reopened
     )

--- a/workers/automation/tests/test_repeat_application_prevention.py
+++ b/workers/automation/tests/test_repeat_application_prevention.py
@@ -799,7 +799,7 @@ def test_schema_v5_migrates_additively_without_changing_application_facts(
         (PRIOR,),
     ).fetchall()
 
-    assert int(migrated.execute("PRAGMA user_version").fetchone()[0]) == SCHEMA_VERSION == 28
+    assert int(migrated.execute("PRAGMA user_version").fetchone()[0]) == SCHEMA_VERSION == 29
     assert [tuple(row) for row in after] == [tuple(row) for row in before]
     assert "metadata_json" in {
         str(row[1]) for row in migrated.execute("PRAGMA table_info(job_stage_states)").fetchall()

--- a/workers/automation/tests/test_resume_template_identity_reference_migration.py
+++ b/workers/automation/tests/test_resume_template_identity_reference_migration.py
@@ -254,7 +254,7 @@ def test_v16_template_references_migrate_aliases_and_uuid_urls(
     assert (
         reopened.execute("PRAGMA user_version").fetchone()[0]
         == SCHEMA_VERSION
-        == 28
+        == 29
     )
     for table in database_module._RESUME_TEMPLATE_REFERENCE_TABLES:
         assert "job_id" in _columns(reopened, table)

--- a/workers/automation/tests/test_scoring_identity_reference_migration.py
+++ b/workers/automation/tests/test_scoring_identity_reference_migration.py
@@ -338,7 +338,7 @@ def test_v11_scoring_references_migrate_alias_histories_and_reopen(
     assert (
         int(migrated.execute("PRAGMA user_version").fetchone()[0])
         == SCHEMA_VERSION
-        == 28
+        == 29
     )
     assert _columns(migrated, "job_scores") >= {"tenant_id", "job_id"}
     assert "job_url" not in _columns(migrated, "job_scores")
@@ -404,7 +404,7 @@ def test_v11_scoring_references_migrate_alias_histories_and_reopen(
     assert (
         int(reopened.execute("PRAGMA user_version").fetchone()[0])
         == SCHEMA_VERSION
-        == 28
+        == 29
     )
 
 
@@ -553,7 +553,7 @@ def test_scoring_migration_rolls_back_and_retries_after_verification_failure(
     assert (
         int(retried.execute("PRAGMA user_version").fetchone()[0])
         == SCHEMA_VERSION
-        == 28
+        == 29
     )
     assert [
         tuple(row)

--- a/workers/automation/tests/test_smartextract_discovery.py
+++ b/workers/automation/tests/test_smartextract_discovery.py
@@ -414,21 +414,18 @@ def test_smart_extract_updates_existing_serialized_null_description(
         )
         conn.execute(
             """
-            CREATE TABLE IF NOT EXISTS jobctrl_deleted_jobs (
-                job_url TEXT PRIMARY KEY,
-                deleted_at TEXT NOT NULL,
-                reason TEXT,
-                restored_at TEXT,
-                FOREIGN KEY(job_url) REFERENCES jobs(url)
+            INSERT INTO jobctrl_deleted_jobs (
+                tenant_id, job_id, deleted_at, reason, restored_at
             )
-            """
-        )
-        conn.execute(
-            """
-            INSERT INTO jobctrl_deleted_jobs (job_url, deleted_at, reason, restored_at)
-            VALUES (?, ?, ?, NULL)
+            SELECT tenant_id, job_id, ?, ?, NULL
+            FROM jobs
+            WHERE url = ?
             """,
-            (url, "2026-05-20T00:00:00+00:00", "missing_description"),
+            (
+                "2026-05-20T00:00:00+00:00",
+                "missing_description",
+                url,
+            ),
         )
         conn.commit()
 
@@ -453,7 +450,9 @@ def test_smart_extract_updates_existing_serialized_null_description(
             """
             SELECT j.description, d.restored_at
             FROM jobs j
-            JOIN jobctrl_deleted_jobs d ON d.job_url = j.url
+            JOIN jobctrl_deleted_jobs d
+              ON d.tenant_id = j.tenant_id
+             AND d.job_id = j.job_id
             WHERE j.url = ?
             """,
             (url,),
@@ -539,7 +538,15 @@ def test_smart_extract_current_alias_refreshes_and_restores_storage_owner(
             (str(stable_job_id),),
         ).fetchone()
         assert physical["url"] == storage_url
-        tombstones = conn.execute("SELECT job_url, restored_at FROM jobctrl_deleted_jobs").fetchall()
+        tombstones = conn.execute(
+            """
+            SELECT jobs.url AS job_url, deleted.restored_at
+            FROM jobctrl_deleted_jobs AS deleted
+            JOIN jobs
+              ON jobs.tenant_id = deleted.tenant_id
+             AND jobs.job_id = deleted.job_id
+            """
+        ).fetchall()
         assert [(row["job_url"], row["restored_at"] is not None) for row in tombstones] == [(storage_url, True)]
         event_urls = {
             row["job_url"]
@@ -595,21 +602,18 @@ def test_smart_extract_refreshes_existing_title_location_before_restore(
         )
         conn.execute(
             """
-            CREATE TABLE IF NOT EXISTS jobctrl_deleted_jobs (
-                job_url TEXT PRIMARY KEY,
-                deleted_at TEXT NOT NULL,
-                reason TEXT,
-                restored_at TEXT,
-                FOREIGN KEY(job_url) REFERENCES jobs(url)
+            INSERT INTO jobctrl_deleted_jobs (
+                tenant_id, job_id, deleted_at, reason, restored_at
             )
-            """
-        )
-        conn.execute(
-            """
-            INSERT INTO jobctrl_deleted_jobs (job_url, deleted_at, reason, restored_at)
-            VALUES (?, ?, ?, NULL)
+            SELECT tenant_id, job_id, ?, ?, NULL
+            FROM jobs
+            WHERE url = ?
             """,
-            (url, "2026-05-20T00:00:00+00:00", "title/location mismatch"),
+            (
+                "2026-05-20T00:00:00+00:00",
+                "title/location mismatch",
+                url,
+            ),
         )
         conn.commit()
 
@@ -635,7 +639,9 @@ def test_smart_extract_refreshes_existing_title_location_before_restore(
             """
             SELECT j.title, j.company, j.description, j.location, d.restored_at
             FROM jobs j
-            JOIN jobctrl_deleted_jobs d ON d.job_url = j.url
+            JOIN jobctrl_deleted_jobs d
+              ON d.tenant_id = j.tenant_id
+             AND d.job_id = j.job_id
             WHERE j.url = ?
             """,
             (url,),

--- a/workers/automation/tests/test_stable_job_identity_migration.py
+++ b/workers/automation/tests/test_stable_job_identity_migration.py
@@ -841,7 +841,7 @@ def test_v6_jobs_gain_stable_uuid_and_posting_url_alias_once(
     init_db(db_path)
     close_connection(db_path)
 
-    assert _user_version(db_path) == SCHEMA_VERSION == 28
+    assert _user_version(db_path) == SCHEMA_VERSION == 29
     first_ids = _identity_rows(db_path)
     assert [row[0] for row in first_ids] == ["local", "local"]
     for _tenant_id, job_id, _url in first_ids:

--- a/workers/automation/tests/test_workspace_migration.py
+++ b/workers/automation/tests/test_workspace_migration.py
@@ -196,6 +196,159 @@ def test_legacy_table_migration_normalizes_previously_renamed_tables(tmp_path) -
     )
 
 
+@pytest.mark.parametrize("schema_version", (28, 29))
+def test_workspace_migration_preserves_stable_deleted_table(
+    tmp_path,
+    schema_version: int,
+) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.executescript(
+            """
+            CREATE TABLE jobs (
+                url TEXT PRIMARY KEY,
+                tenant_id TEXT NOT NULL,
+                job_id TEXT NOT NULL,
+                UNIQUE (tenant_id, job_id)
+            );
+            CREATE TABLE jobctrl_deleted_jobs (
+                tenant_id TEXT NOT NULL,
+                job_id TEXT NOT NULL,
+                deleted_at TEXT NOT NULL,
+                reason TEXT,
+                restored_at TEXT,
+                PRIMARY KEY (tenant_id, job_id),
+                FOREIGN KEY (tenant_id, job_id)
+                    REFERENCES jobs(tenant_id, job_id)
+                    ON DELETE CASCADE
+            );
+            """
+        )
+        conn.execute(
+            f"PRAGMA user_version = {schema_version}"
+        )
+
+        assert config.migrate_legacy_job_tables(conn) == []
+        assert _table_columns(
+            db_path,
+            "jobctrl_deleted_jobs",
+        ) == {
+            "tenant_id",
+            "job_id",
+            "deleted_at",
+            "reason",
+            "restored_at",
+        }
+    finally:
+        conn.close()
+
+
+def test_pre_v29_workspace_migration_refuses_mixed_deleted_authorities(
+    tmp_path,
+) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    token = _immediate_legacy_token()
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.executescript(
+            f"""
+            CREATE TABLE jobctrl_deleted_jobs (
+                tenant_id TEXT NOT NULL,
+                job_id TEXT NOT NULL,
+                deleted_at TEXT NOT NULL,
+                reason TEXT,
+                restored_at TEXT,
+                PRIMARY KEY (tenant_id, job_id)
+            );
+            CREATE TABLE {token}_deleted_jobs (
+                job_url TEXT PRIMARY KEY,
+                deleted_at TEXT NOT NULL,
+                reason TEXT,
+                restored_at TEXT
+            );
+            PRAGMA user_version = 28;
+            """
+        )
+
+        with pytest.raises(
+            WorkspaceMigrationError,
+            match="cannot merge URL-era branded soft-delete",
+        ):
+            config.migrate_legacy_job_tables(conn)
+
+        assert {
+            "jobctrl_deleted_jobs",
+            f"{token}_deleted_jobs",
+        }.issubset(_table_names(db_path))
+    finally:
+        conn.close()
+
+
+def test_schema_v29_workspace_migration_refuses_url_era_deleted_table(
+    tmp_path,
+) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.executescript(
+            """
+            CREATE TABLE jobctrl_deleted_jobs (
+                job_url TEXT PRIMARY KEY,
+                deleted_at TEXT NOT NULL,
+                reason TEXT,
+                restored_at TEXT
+            );
+            PRAGMA user_version = 29;
+            """
+        )
+
+        with pytest.raises(
+            WorkspaceMigrationError,
+            match="requires stable soft-delete tombstone",
+        ):
+            config.migrate_legacy_job_tables(conn)
+
+        assert "job_url" in _table_columns(
+            db_path,
+            "jobctrl_deleted_jobs",
+        )
+    finally:
+        conn.close()
+
+
+def test_schema_v29_workspace_migration_refuses_branded_deleted_table(
+    tmp_path,
+) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    token = _immediate_legacy_token()
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.executescript(
+            f"""
+            CREATE TABLE {token}_deleted_jobs (
+                job_url TEXT PRIMARY KEY,
+                deleted_at TEXT NOT NULL,
+                reason TEXT,
+                restored_at TEXT
+            );
+            PRAGMA user_version = 29;
+            """
+        )
+
+        with pytest.raises(
+            WorkspaceMigrationError,
+            match="cannot merge URL-era branded soft-delete",
+        ):
+            config.migrate_legacy_job_tables(conn)
+
+        assert f"{token}_deleted_jobs" in _table_names(
+            db_path
+        )
+    finally:
+        conn.close()
+
+
 def test_default_workspace_resolution_does_not_inspect_legacy_db_conflicts(
     tmp_path,
     monkeypatch,


### PR DESCRIPTION
## Summary

- migrate soft-delete tombstones to tenant-scoped stable JobIds in schema v29, with deterministic alias collapse, collision rehoming, rollback-safe verification, and cascade cleanup
- preserve URL-shaped compatibility at API and projection boundaries using URL-first posting-alias resolution, including UUID-shaped collision safety for destructive mutations
- reconcile active and restored tombstones across Python and TypeScript projections, including historical alias activity/workflow rows and worker-owned dashboard schemas

## Stack

- stacked on #557 (`feat/job-id-quarantine-references`)
- canonical product documentation and cumulative stack QA remain deferred to the final approved stack PR

## Validation

- API typecheck: passed
- Web typecheck: passed
- API tests: 61 files, 736 tests passed
- Python tests: 2795 passed, 2 skipped
- Changed Python test files: 312 passed
- Independent review gate: PASS (0 Blocker, 0 High, 0 Medium)
- Independent QA gate: PASS (0 Blocker, 0 High, 0 Medium, 0 Low)
- `git diff --check`: passed
