### PR TITLE
feat(workflows): declare JobId cutover policy

### DIFF
--- a/workers/automation/src/jobctrl/infrastructure/temporal/registry.py
+++ b/workers/automation/src/jobctrl/infrastructure/temporal/registry.py
@@ -8,6 +8,7 @@ two lists below; no other wiring is required.
 from __future__ import annotations
 
 from collections.abc import Callable
+from dataclasses import dataclass
 from typing import Any
 
 from jobctrl.apply.activities import apply_activity
@@ -65,6 +66,78 @@ WORKFLOWS: list[type] = [
     DurabilityProbeWorkflow,
 ]
 
+
+@dataclass(frozen=True)
+class WorkflowIdentityCutoverPolicy:
+    """How one registered workflow participates in the JobId cutover.
+
+    ``identity_fields`` names serialized URL/identity-bearing fields or the
+    durable job-work relationship that requires the execution to drain. An
+    empty tuple is an explicit declaration that the workflow is unrelated to
+    job identity; it is never an implicit default.
+    """
+
+    workflow_type: str
+    blocks_cutover_when_open: bool
+    identity_fields: tuple[str, ...]
+
+
+WORKFLOW_IDENTITY_CUTOVER_POLICIES: dict[
+    type,
+    WorkflowIdentityCutoverPolicy,
+] = {
+    DiscoverWorkflow: WorkflowIdentityCutoverPolicy(
+        workflow_type="DiscoverWorkflow",
+        blocks_cutover_when_open=True,
+        identity_fields=("durable_discovery_work",),
+    ),
+    JobPipelineWorkflow: WorkflowIdentityCutoverPolicy(
+        workflow_type="JobPipelineWorkflow",
+        blocks_cutover_when_open=True,
+        identity_fields=("job_url", "job_urls"),
+    ),
+    JobPreparationWorkflow: WorkflowIdentityCutoverPolicy(
+        workflow_type="JobPreparationWorkflow",
+        blocks_cutover_when_open=True,
+        identity_fields=("job_url", "idempotency_key"),
+    ),
+    ApplyWorkflow: WorkflowIdentityCutoverPolicy(
+        workflow_type="ApplyWorkflow",
+        blocks_cutover_when_open=True,
+        identity_fields=("job_url", "workflow_id"),
+    ),
+    ManualCaptureImportWorkflow: WorkflowIdentityCutoverPolicy(
+        workflow_type="ManualCaptureImportWorkflow",
+        blocks_cutover_when_open=True,
+        identity_fields=("captured_url", "durable_capture_item"),
+    ),
+    ProfileImportWorkflow: WorkflowIdentityCutoverPolicy(
+        workflow_type="ProfileImportWorkflow",
+        blocks_cutover_when_open=False,
+        identity_fields=(),
+    ),
+    CompensationRefreshWorkflow: WorkflowIdentityCutoverPolicy(
+        workflow_type="CompensationRefreshWorkflow",
+        blocks_cutover_when_open=True,
+        identity_fields=("job_url",),
+    ),
+    InterviewPrepWorkflow: WorkflowIdentityCutoverPolicy(
+        workflow_type="InterviewPrepWorkflow",
+        blocks_cutover_when_open=True,
+        identity_fields=("job_url", "workflow_id"),
+    ),
+    ContactResearchWorkflow: WorkflowIdentityCutoverPolicy(
+        workflow_type="ContactResearchWorkflow",
+        blocks_cutover_when_open=True,
+        identity_fields=("job_url",),
+    ),
+    DurabilityProbeWorkflow: WorkflowIdentityCutoverPolicy(
+        workflow_type="DurabilityProbeWorkflow",
+        blocks_cutover_when_open=False,
+        identity_fields=(),
+    ),
+}
+
 ACTIVITIES: list[Callable[..., Any]] = [
     plan_discovery_sources,
     discovery_source_family_activity,
@@ -90,4 +163,9 @@ ACTIVITIES: list[Callable[..., Any]] = [
     record_workflow_outcome,
 ]
 
-__all__ = ["ACTIVITIES", "WORKFLOWS"]
+__all__ = [
+    "ACTIVITIES",
+    "WORKFLOWS",
+    "WORKFLOW_IDENTITY_CUTOVER_POLICIES",
+    "WorkflowIdentityCutoverPolicy",
+]

--- a/workers/automation/tests/test_temporal_registry.py
+++ b/workers/automation/tests/test_temporal_registry.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
-from jobctrl.infrastructure.temporal.registry import ACTIVITIES, WORKFLOWS
+from jobctrl.infrastructure.temporal.registry import (
+    ACTIVITIES,
+    WORKFLOWS,
+    WORKFLOW_IDENTITY_CUTOVER_POLICIES,
+)
 
 
 def test_registry_exports_non_empty_workflows_and_activities():
@@ -17,6 +21,25 @@ def test_registry_workflows_are_temporal_workflow_definitions():
             f"{workflow_cls.__name__} is in WORKFLOWS but is missing the "
             "@workflow.defn decorator."
         )
+
+
+def test_every_workflow_declares_an_identity_cutover_policy():
+    assert set(WORKFLOW_IDENTITY_CUTOVER_POLICIES) == set(WORKFLOWS)
+    workflow_types = [
+        policy.workflow_type
+        for policy in WORKFLOW_IDENTITY_CUTOVER_POLICIES.values()
+    ]
+    assert len(workflow_types) == len(set(workflow_types))
+    for workflow_cls, policy in WORKFLOW_IDENTITY_CUTOVER_POLICIES.items():
+        definition = getattr(
+            workflow_cls,
+            "__temporal_workflow_definition",
+        )
+        assert policy.workflow_type == definition.name
+        if policy.blocks_cutover_when_open:
+            assert policy.identity_fields
+        else:
+            assert policy.identity_fields == ()
 
 
 def test_registry_activities_are_temporal_activity_definitions():


### PR DESCRIPTION
## Summary

- declare an explicit stable-identity cutover policy for every registered Temporal workflow
- identify URL-bearing serialized fields, deterministic workflow IDs, and durable job-work relationships that require a workflow to drain
- enforce registry parity and Temporal workflow-type name parity in tests

## Why

The event/projection identity cutover needs a complete inventory of workflows that may still carry URL-shaped job identity. Keeping that policy beside the authoritative worker registry makes newly registered workflows fail validation until their cutover behavior is declared.

This is a deliberately small prerequisite PR. It does not calculate quiescence or run a migration. Start fencing, exact-run Temporal verification, and executable cutover orchestration remain in the next stacked phase.

## Validation

- `PYTHONPATH=workers/automation/src /Users/eloibarti/Github/JobHunter/workers/automation/.venv/bin/python -m pytest -q workers/automation/tests/test_temporal_registry.py` — 4 passed
- `/Users/eloibarti/Github/JobHunter/workers/automation/.venv/bin/ruff check workers/automation/src/jobctrl/infrastructure/temporal/registry.py workers/automation/tests/test_temporal_registry.py` — passed
- `git diff --check` — passed
- dependency lock unchanged
- independent Tier 3 groundwork review — Gate: PASS, Blocker 0, High 0, Medium 0, Low 0

## Stack

- Base: `feat/job-id-delete-tombstone-references` (#558)
- This PR is not intended for independent release; cumulative product QA remains required on the executable cutover/final stack branch.