### PR TITLE
feat(workflows): fence JobId cutover dispatch

### DIFF
--- a/workers/automation/src/jobctrl/apply/auto_apply.py
+++ b/workers/automation/src/jobctrl/apply/auto_apply.py
@@ -15,12 +15,21 @@ from temporalio.service import RPCError, RPCStatusCode
 from jobctrl.apply.workflow import ApplyWorkflow, ApplyWorkflowInput
 from jobctrl.browser_capabilities import browser_capability_status
 from jobctrl.domain.tenant import LOCAL_TENANT
+from jobctrl.infrastructure.runtime_identity import (
+    assert_expected_runtime,
+    current_runtime_identity,
+)
 from jobctrl.infrastructure.scoring.criteria_provider import (
     read_apply_approval_required,
     read_apply_concurrency,
     read_auto_apply_enabled,
     read_daily_budget_usd,
     read_min_fit_score,
+)
+from jobctrl.infrastructure.temporal.workflow_dispatch_control import (
+    WorkflowDispatchFencedError,
+    reserve_workflow_dispatch,
+    workflow_dispatches_blocked,
 )
 
 AUTO_APPLY_WORKFLOW_PREFIX = "apply-auto"
@@ -70,8 +79,16 @@ async def reconcile_auto_apply_loop(
     expected_db_path: str | None = None,
 ) -> AutoApplyReconcileResult:
     """Ensure the deterministic continuous apply workflow matches settings."""
+    assert_expected_runtime(expected_db_path=expected_db_path)
+    runtime_db_path = current_runtime_identity().db_path
     settings = read_auto_apply_loop_settings(settings_path)
     workflow_id = auto_apply_workflow_id(tenant_id)
+    if settings.enabled and workflow_dispatches_blocked(
+        runtime_db_path
+    ):
+        raise WorkflowDispatchFencedError(
+            "workflow dispatches are blocked for the stable JobId cutover"
+        )
     running = await _is_workflow_running(client, workflow_id)
     if settings.enabled:
         capability = browser_capability_status("auto-apply-browser")
@@ -104,14 +121,20 @@ async def reconcile_auto_apply_loop(
             continuous=True,
             auto_apply_loop=True,
         )
-        await client.start_workflow(
-            ApplyWorkflow.run,
-            payload,
-            id=workflow_id,
-            task_queue=task_queue,
-            id_conflict_policy=WorkflowIDConflictPolicy.USE_EXISTING,
-            id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE,
-        )
+        async with reserve_workflow_dispatch(
+            workflow=ApplyWorkflow,
+            workflow_id=workflow_id,
+            db_path=runtime_db_path,
+        ) as reservation:
+            handle = await client.start_workflow(
+                ApplyWorkflow.run,
+                payload,
+                id=workflow_id,
+                task_queue=task_queue,
+                id_conflict_policy=WorkflowIDConflictPolicy.USE_EXISTING,
+                id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE,
+            )
+            reservation.mark_dispatched(handle)
         return AutoApplyReconcileResult(workflow_id, "started", True)
 
     if running:

--- a/workers/automation/src/jobctrl/database.py
+++ b/workers/automation/src/jobctrl/database.py
@@ -471,6 +471,11 @@ def init_db(db_path: Path | str | None = None) -> sqlite3.Connection:
     ensure_projection_tables_in_db(conn)
     drop_legacy_apply_runs_tables(conn)
     _run_schema_migrations(conn)
+    from jobctrl.infrastructure.temporal.workflow_dispatch_control import (
+        ensure_workflow_dispatch_control_tables,
+    )
+
+    ensure_workflow_dispatch_control_tables(conn)
     ensure_deleted_jobs_table(conn)
 
     return conn

--- a/workers/automation/src/jobctrl/infrastructure/rpc/workflow_starter.py
+++ b/workers/automation/src/jobctrl/infrastructure/rpc/workflow_starter.py
@@ -31,8 +31,15 @@ from temporalio.client import WorkflowHandle
 from temporalio.common import WorkflowIDConflictPolicy, WorkflowIDReusePolicy
 
 from jobctrl.domain.rpc.messages import WorkflowStartSpec
+from jobctrl.infrastructure.runtime_identity import (
+    assert_expected_runtime,
+    current_runtime_identity,
+)
 from jobctrl.infrastructure.temporal.client import get_temporal_client
 from jobctrl.infrastructure.temporal.task_queues import JOBCTRL_TASK_QUEUE
+from jobctrl.infrastructure.temporal.workflow_dispatch_control import (
+    reserve_workflow_dispatch,
+)
 
 log = logging.getLogger(__name__)
 
@@ -47,7 +54,6 @@ WorkflowCanceler = Callable[[str], Coroutine[Any, Any, None]]
 
 
 async def default_workflow_starter(spec: WorkflowStartSpec) -> WorkflowHandle:
-    client = await get_temporal_client()
     workflow_id = spec.workflow_id or f"run-{uuid4().hex}"
     # USE_EXISTING makes a double-start of a deterministic id (e.g.
     # ``apply-{jobKey}``) return the already-running handle instead of a
@@ -56,15 +62,26 @@ async def default_workflow_starter(spec: WorkflowStartSpec) -> WorkflowHandle:
     # trigger, so they are safe as global defaults.
     id_conflict_policy = spec.id_conflict_policy or WorkflowIDConflictPolicy.USE_EXISTING
     id_reuse_policy = spec.id_reuse_policy or WorkflowIDReusePolicy.ALLOW_DUPLICATE
-    handle = await client.start_workflow(
-        spec.workflow,
-        *spec.args,
-        id=workflow_id,
-        task_queue=JOBCTRL_TASK_QUEUE,
-        retry_policy=spec.retry_policy,
-        id_conflict_policy=id_conflict_policy,
-        id_reuse_policy=id_reuse_policy,
-    )
+    payload = spec.args[0] if spec.args else None
+    expected_db_path = getattr(payload, "expected_db_path", None)
+    assert_expected_runtime(expected_db_path=expected_db_path)
+    runtime_db_path = current_runtime_identity().db_path
+    async with reserve_workflow_dispatch(
+        workflow=spec.workflow,
+        workflow_id=workflow_id,
+        db_path=runtime_db_path,
+    ) as reservation:
+        client = await get_temporal_client()
+        handle = await client.start_workflow(
+            spec.workflow,
+            *spec.args,
+            id=workflow_id,
+            task_queue=JOBCTRL_TASK_QUEUE,
+            retry_policy=spec.retry_policy,
+            id_conflict_policy=id_conflict_policy,
+            id_reuse_policy=id_reuse_policy,
+        )
+        reservation.mark_dispatched(handle)
     _record_dispatch_started(spec, workflow_id, handle)
     return handle
 

--- a/workers/automation/src/jobctrl/infrastructure/temporal/workflow_dispatch_control.py
+++ b/workers/automation/src/jobctrl/infrastructure/temporal/workflow_dispatch_control.py
@@ -1,0 +1,385 @@
+"""Durable application-dispatch control for the stable JobId cutover.
+
+Every direct application-owned Temporal start reserves a local launch record before
+contacting Temporal. A shared filesystem lock covers that reservation and the
+remote start call. Cutover orchestration takes the corresponding exclusive
+lock before blocking starts, so it cannot race an in-flight dispatch.
+
+Temporal-owned schedules do not pass through this boundary; cutover
+orchestration must pause them separately before it blocks direct dispatch.
+The durable launch inventory deliberately treats client errors as uncertain: Temporal
+may have accepted a start even when the response was lost. A later preflight
+must reconcile every reserved, uncertain, or dispatched launch with an exact
+``DescribeWorkflowExecution`` call before declaring quiescence.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import fcntl
+import os
+import sqlite3
+import uuid
+from contextlib import asynccontextmanager, contextmanager
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, AsyncIterator, Iterator
+
+from jobctrl import config
+
+_CONTROL_KEY = "stable-job-id-cutover"
+_LOCK_SUFFIX = ".workflow-dispatch.lock"
+
+
+class WorkflowDispatchFencedError(RuntimeError):
+    """Raised before dispatch while the identity cutover owns the start gate."""
+
+
+class UnregisteredWorkflowDispatchError(RuntimeError):
+    """Raised when a workflow has no explicit identity-cutover policy."""
+
+
+@dataclass
+class WorkflowDispatchReservation:
+    launch_id: str
+    workflow_id: str
+    workflow_type: str
+    temporal_run_id: str | None = None
+    dispatch_confirmed: bool = False
+
+    def mark_dispatched(self, handle: Any) -> None:
+        """Record the exact run ID returned by Temporal when it is available."""
+
+        run_id = (
+            getattr(handle, "first_execution_run_id", None)
+            or getattr(handle, "result_run_id", None)
+            or getattr(handle, "run_id", None)
+        )
+        self.temporal_run_id = str(run_id) if run_id else None
+        self.dispatch_confirmed = True
+
+
+def ensure_workflow_dispatch_control_tables(
+    conn: sqlite3.Connection,
+) -> tuple[str, str]:
+    """Create the operational gate and durable launch inventory."""
+
+    conn.executescript(
+        """
+        CREATE TABLE IF NOT EXISTS workflow_dispatch_control (
+            control_key TEXT PRIMARY KEY,
+            reason      TEXT NOT NULL,
+            blocked_at  TEXT NOT NULL
+        );
+
+        CREATE TABLE IF NOT EXISTS workflow_dispatch_registry (
+            launch_id       TEXT PRIMARY KEY,
+            workflow_id     TEXT NOT NULL,
+            temporal_run_id TEXT,
+            workflow_type   TEXT NOT NULL,
+            state           TEXT NOT NULL
+                CHECK (state IN ('reserved', 'dispatched', 'uncertain')),
+            created_at      TEXT NOT NULL,
+            updated_at      TEXT NOT NULL
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_workflow_dispatch_registry_execution
+        ON workflow_dispatch_registry(workflow_id, temporal_run_id, created_at);
+
+        CREATE INDEX IF NOT EXISTS idx_workflow_dispatch_registry_state
+        ON workflow_dispatch_registry(state, workflow_type, created_at);
+        """
+    )
+    return ("workflow_dispatch_control", "workflow_dispatch_registry")
+
+
+@asynccontextmanager
+async def reserve_workflow_dispatch(
+    *,
+    workflow: type,
+    workflow_id: str,
+    db_path: Path | str | None = None,
+) -> AsyncIterator[WorkflowDispatchReservation]:
+    """Reserve and audit one start while sharing the cutover dispatch lock."""
+
+    from jobctrl.infrastructure.temporal.registry import (
+        WORKFLOW_IDENTITY_CUTOVER_POLICIES,
+    )
+
+    policy = WORKFLOW_IDENTITY_CUTOVER_POLICIES.get(workflow)
+    if policy is None:
+        raise UnregisteredWorkflowDispatchError(
+            f"{getattr(workflow, '__name__', workflow)!s} is not declared "
+            "in the Temporal identity-cutover registry"
+        )
+    resolved_id = str(workflow_id or "").strip()
+    if not resolved_id:
+        raise ValueError("workflow_id must be non-empty")
+    resolved_path = _resolve_db_path(db_path)
+    lock_fd = await _acquire_lock_async(
+        _lock_path(resolved_path),
+        fcntl.LOCK_SH,
+    )
+    reservation: WorkflowDispatchReservation | None = None
+    try:
+        reservation = _create_reservation(
+            resolved_path,
+            workflow_id=resolved_id,
+            workflow_type=policy.workflow_type,
+        )
+        try:
+            yield reservation
+        except BaseException:
+            _finish_reservation(
+                resolved_path,
+                reservation,
+                state="uncertain",
+            )
+            raise
+        else:
+            _finish_reservation(
+                resolved_path,
+                reservation,
+                state=(
+                    "dispatched"
+                    if reservation.dispatch_confirmed
+                    else "uncertain"
+                ),
+            )
+    finally:
+        _release_lock(lock_fd)
+
+
+def set_workflow_dispatches_blocked(
+    *,
+    blocked: bool,
+    reason: str,
+    db_path: Path | str | None = None,
+) -> bool:
+    """Atomically change the durable gate after all in-flight starts drain."""
+
+    resolved_path = _resolve_db_path(db_path)
+    with _locked(_lock_path(resolved_path), fcntl.LOCK_EX):
+        conn = _open_control_connection(resolved_path)
+        try:
+            ensure_workflow_dispatch_control_tables(conn)
+            with conn:
+                if blocked:
+                    conn.execute(
+                        """
+                        INSERT INTO workflow_dispatch_control (
+                            control_key, reason, blocked_at
+                        ) VALUES (?, ?, ?)
+                        ON CONFLICT(control_key) DO UPDATE SET
+                            reason = excluded.reason,
+                            blocked_at = excluded.blocked_at
+                        """,
+                        (
+                            _CONTROL_KEY,
+                            str(reason or ""),
+                            _utc_now(),
+                        ),
+                    )
+                else:
+                    conn.execute(
+                        """
+                        DELETE FROM workflow_dispatch_control
+                        WHERE control_key = ?
+                        """,
+                        (_CONTROL_KEY,),
+                    )
+                return blocked
+        finally:
+            conn.close()
+
+
+def workflow_dispatches_blocked(
+    db_path: Path | str | None = None,
+) -> bool:
+    """Return the current durable gate state."""
+
+    resolved_path = _resolve_db_path(db_path)
+    conn = _open_control_connection(resolved_path)
+    try:
+        ensure_workflow_dispatch_control_tables(conn)
+        row = conn.execute(
+            """
+            SELECT 1
+            FROM workflow_dispatch_control
+            WHERE control_key = ?
+            """,
+            (_CONTROL_KEY,),
+        ).fetchone()
+        return row is not None
+    finally:
+        conn.close()
+
+
+def _create_reservation(
+    db_path: Path,
+    *,
+    workflow_id: str,
+    workflow_type: str,
+) -> WorkflowDispatchReservation:
+    conn = _open_control_connection(db_path)
+    launch_id = uuid.uuid4().hex
+    now = _utc_now()
+    try:
+        ensure_workflow_dispatch_control_tables(conn)
+        with conn:
+            row = conn.execute(
+                """
+                SELECT 1
+                FROM workflow_dispatch_control
+                WHERE control_key = ?
+                """,
+                (_CONTROL_KEY,),
+            ).fetchone()
+            if row is not None:
+                raise WorkflowDispatchFencedError(
+                    "workflow dispatches are blocked for the stable JobId cutover"
+                )
+            conn.execute(
+                """
+                INSERT INTO workflow_dispatch_registry (
+                    launch_id, workflow_id, temporal_run_id,
+                    workflow_type, state, created_at, updated_at
+                ) VALUES (?, ?, NULL, ?, 'reserved', ?, ?)
+                """,
+                (
+                    launch_id,
+                    workflow_id,
+                    workflow_type,
+                    now,
+                    now,
+                ),
+            )
+    finally:
+        conn.close()
+    return WorkflowDispatchReservation(
+        launch_id=launch_id,
+        workflow_id=workflow_id,
+        workflow_type=workflow_type,
+    )
+
+
+def _finish_reservation(
+    db_path: Path,
+    reservation: WorkflowDispatchReservation,
+    *,
+    state: str,
+) -> None:
+    conn = _open_control_connection(db_path)
+    try:
+        with conn:
+            updated = conn.execute(
+                """
+                UPDATE workflow_dispatch_registry
+                SET temporal_run_id = ?,
+                    state = ?,
+                    updated_at = ?
+                WHERE launch_id = ?
+                  AND state = 'reserved'
+                """,
+                (
+                    reservation.temporal_run_id,
+                    state,
+                    _utc_now(),
+                    reservation.launch_id,
+                ),
+            )
+            if updated.rowcount != 1:
+                raise RuntimeError(
+                    "workflow launch reservation changed unexpectedly"
+                )
+    finally:
+        conn.close()
+
+
+def _open_control_connection(
+    db_path: Path,
+) -> sqlite3.Connection:
+    conn = sqlite3.connect(db_path, timeout=30)
+    conn.execute("PRAGMA busy_timeout=10000")
+    return conn
+
+
+def _resolve_db_path(
+    db_path: Path | str | None,
+) -> Path:
+    return Path(db_path if db_path is not None else config.DB_PATH)
+
+
+def _lock_path(db_path: Path) -> Path:
+    return db_path.with_name(f".{db_path.name}{_LOCK_SUFFIX}")
+
+
+def _acquire_lock(path: Path, operation: int) -> int:
+    fd = _open_lock_file(path)
+    try:
+        fcntl.flock(fd, operation)
+    except BaseException:
+        os.close(fd)
+        raise
+    return fd
+
+
+async def _acquire_lock_async(
+    path: Path,
+    operation: int,
+) -> int:
+    fd = _open_lock_file(path)
+    try:
+        while True:
+            try:
+                fcntl.flock(
+                    fd,
+                    operation | fcntl.LOCK_NB,
+                )
+                return fd
+            except BlockingIOError:
+                await asyncio.sleep(0.05)
+    except BaseException:
+        os.close(fd)
+        raise
+
+
+def _open_lock_file(path: Path) -> int:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    flags = os.O_CREAT | os.O_RDWR | getattr(os, "O_CLOEXEC", 0)
+    return os.open(path, flags, 0o600)
+
+
+def _release_lock(fd: int) -> None:
+    try:
+        fcntl.flock(fd, fcntl.LOCK_UN)
+    finally:
+        os.close(fd)
+
+
+@contextmanager
+def _locked(
+    path: Path,
+    operation: int,
+) -> Iterator[None]:
+    fd = _acquire_lock(path, operation)
+    try:
+        yield
+    finally:
+        _release_lock(fd)
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+__all__ = [
+    "UnregisteredWorkflowDispatchError",
+    "WorkflowDispatchReservation",
+    "WorkflowDispatchFencedError",
+    "ensure_workflow_dispatch_control_tables",
+    "reserve_workflow_dispatch",
+    "set_workflow_dispatches_blocked",
+    "workflow_dispatches_blocked",
+]

--- a/workers/automation/tests/test_auto_apply_reconciler.py
+++ b/workers/automation/tests/test_auto_apply_reconciler.py
@@ -16,6 +16,10 @@ from jobctrl.apply import auto_apply
 from jobctrl.apply.auto_apply import auto_apply_workflow_id, reconcile_auto_apply_loop
 from jobctrl.apply.workflow import ApplyWorkflow, ApplyWorkflowInput
 from jobctrl.browser_capabilities import BrowserCapabilityStatus
+from jobctrl.infrastructure.temporal.workflow_dispatch_control import (
+    WorkflowDispatchFencedError,
+    set_workflow_dispatches_blocked,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -52,8 +56,10 @@ class _FakeClient:
     def __init__(self) -> None:
         self.handles: dict[str, _FakeHandle] = {}
         self.starts: list[dict[str, Any]] = []
+        self.describes: list[str] = []
 
     def get_workflow_handle(self, workflow_id: str) -> _FakeHandle:
+        self.describes.append(workflow_id)
         return self.handles.get(
             workflow_id,
             _FakeHandle(RPCError("not found", RPCStatusCode.NOT_FOUND, b"")),
@@ -130,15 +136,15 @@ async def test_auto_apply_on_starts_exactly_one_standing_loop(tmp_path, monkeypa
         client,
         task_queue="jobctrl-test",
         settings_path=settings_path,
-        expected_app_dir="/tmp/jobctrl",
-        expected_db_path="/tmp/jobctrl/jobctrl.db",
+        expected_app_dir=str(tmp_path),
+        expected_db_path=str(tmp_path / "jobctrl.db"),
     )
     second = await reconcile_auto_apply_loop(
         client,
         task_queue="jobctrl-test",
         settings_path=settings_path,
-        expected_app_dir="/tmp/jobctrl",
-        expected_db_path="/tmp/jobctrl/jobctrl.db",
+        expected_app_dir=str(tmp_path),
+        expected_db_path=str(tmp_path / "jobctrl.db"),
     )
 
     assert first.action == "started"
@@ -154,11 +160,46 @@ async def test_auto_apply_on_starts_exactly_one_standing_loop(tmp_path, monkeypa
     assert payload.min_score == 9
     assert payload.workers == 3
     assert payload.approval_required is True
-    assert payload.expected_app_dir == "/tmp/jobctrl"
-    assert payload.expected_db_path == "/tmp/jobctrl/jobctrl.db"
+    assert payload.expected_app_dir == str(tmp_path)
+    assert payload.expected_db_path == str(tmp_path / "jobctrl.db")
     assert start["kwargs"]["id"] == auto_apply_workflow_id("local")
     assert start["kwargs"]["id_conflict_policy"] is WorkflowIDConflictPolicy.USE_EXISTING
     assert start["kwargs"]["id_reuse_policy"] is WorkflowIDReusePolicy.ALLOW_DUPLICATE
+
+
+@pytest.mark.asyncio
+async def test_auto_apply_never_starts_while_dispatch_is_fenced(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settings_path = tmp_path / "config.json"
+    db_path = tmp_path / "jobctrl.db"
+    _write_config_settings(settings_path)
+    _write_discovery_automation_settings(
+        monkeypatch,
+        tmp_path,
+        auto_apply=True,
+    )
+    set_workflow_dispatches_blocked(
+        blocked=True,
+        reason="identity-cutover",
+        db_path=db_path,
+    )
+    client = _FakeClient()
+
+    with pytest.raises(
+        WorkflowDispatchFencedError,
+        match="stable JobId cutover",
+    ):
+        await reconcile_auto_apply_loop(
+            client,
+            task_queue="jobctrl-test",
+            settings_path=settings_path,
+            expected_db_path=str(db_path),
+        )
+
+    assert client.starts == []
+    assert client.describes == []
 
 
 @pytest.mark.asyncio

--- a/workers/automation/tests/test_workflow_dispatch_control.py
+++ b/workers/automation/tests/test_workflow_dispatch_control.py
@@ -1,0 +1,194 @@
+from __future__ import annotations
+
+import asyncio
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from jobctrl.database import close_connection, init_db
+from jobctrl.infrastructure.temporal.workflow_dispatch_control import (
+    UnregisteredWorkflowDispatchError,
+    WorkflowDispatchFencedError,
+    reserve_workflow_dispatch,
+    set_workflow_dispatches_blocked,
+    workflow_dispatches_blocked,
+)
+from jobctrl.pipeline.workflow import JobPipelineWorkflow
+
+
+@dataclass(frozen=True)
+class _Handle:
+    run_id: str
+
+
+@pytest.fixture
+def db_path(tmp_path: Path) -> Path:
+    path = tmp_path / "jobctrl.db"
+    conn = init_db(path)
+    conn.commit()
+    close_connection(path)
+    return path
+
+
+@pytest.mark.asyncio
+async def test_registered_start_is_reserved_before_dispatch(
+    db_path: Path,
+) -> None:
+    async with reserve_workflow_dispatch(
+        workflow=JobPipelineWorkflow,
+        workflow_id="run-one",
+        db_path=db_path,
+    ) as reservation:
+        with sqlite3.connect(db_path) as conn:
+            row = conn.execute(
+                """
+                SELECT workflow_id, temporal_run_id,
+                       workflow_type, state
+                FROM workflow_dispatch_registry
+                WHERE launch_id = ?
+                """,
+                (reservation.launch_id,),
+            ).fetchone()
+        assert row == (
+            "run-one",
+            None,
+            "JobPipelineWorkflow",
+            "reserved",
+        )
+        reservation.mark_dispatched(_Handle("temporal-one"))
+
+    with sqlite3.connect(db_path) as conn:
+        row = conn.execute(
+            """
+            SELECT temporal_run_id, state
+            FROM workflow_dispatch_registry
+            WHERE launch_id = ?
+            """,
+            (reservation.launch_id,),
+        ).fetchone()
+    assert row == ("temporal-one", "dispatched")
+
+
+@pytest.mark.asyncio
+async def test_failed_start_remains_uncertain_for_exact_reconciliation(
+    db_path: Path,
+) -> None:
+    with pytest.raises(TimeoutError, match="response lost"):
+        async with reserve_workflow_dispatch(
+            workflow=JobPipelineWorkflow,
+            workflow_id="run-uncertain",
+            db_path=db_path,
+        ) as reservation:
+            raise TimeoutError("response lost")
+
+    with sqlite3.connect(db_path) as conn:
+        row = conn.execute(
+            """
+            SELECT temporal_run_id, state
+            FROM workflow_dispatch_registry
+            WHERE launch_id = ?
+            """,
+            (reservation.launch_id,),
+        ).fetchone()
+    assert row == (None, "uncertain")
+
+
+@pytest.mark.asyncio
+async def test_blocked_gate_refuses_dispatch_without_a_launch_row(
+    db_path: Path,
+) -> None:
+    assert set_workflow_dispatches_blocked(
+        blocked=True,
+        reason="identity-cutover",
+        db_path=db_path,
+    )
+    assert workflow_dispatches_blocked(db_path)
+
+    with pytest.raises(
+        WorkflowDispatchFencedError,
+        match="stable JobId cutover",
+    ):
+        async with reserve_workflow_dispatch(
+            workflow=JobPipelineWorkflow,
+            workflow_id="run-blocked",
+            db_path=db_path,
+        ):
+            pytest.fail("a fenced start must not reach dispatch")
+
+    with sqlite3.connect(db_path) as conn:
+        count = conn.execute(
+            "SELECT COUNT(*) FROM workflow_dispatch_registry"
+        ).fetchone()[0]
+    assert count == 0
+    assert (
+        set_workflow_dispatches_blocked(
+            blocked=False,
+            reason="test cleanup",
+            db_path=db_path,
+        )
+        is False
+    )
+    assert workflow_dispatches_blocked(db_path) is False
+
+
+@pytest.mark.asyncio
+async def test_exclusive_gate_waits_for_inflight_reserved_start(
+    db_path: Path,
+) -> None:
+    dispatch_entered = asyncio.Event()
+    release_dispatch = asyncio.Event()
+
+    async def _dispatch() -> None:
+        async with reserve_workflow_dispatch(
+            workflow=JobPipelineWorkflow,
+            workflow_id="run-inflight",
+            db_path=db_path,
+        ) as reservation:
+            dispatch_entered.set()
+            await release_dispatch.wait()
+            reservation.mark_dispatched(_Handle("temporal-inflight"))
+
+    dispatch_task = asyncio.create_task(_dispatch())
+    await dispatch_entered.wait()
+    fence_task = asyncio.create_task(
+        asyncio.to_thread(
+            set_workflow_dispatches_blocked,
+            blocked=True,
+            reason="identity-cutover",
+            db_path=db_path,
+        )
+    )
+    await asyncio.sleep(0.1)
+    assert fence_task.done() is False
+
+    release_dispatch.set()
+    await dispatch_task
+    assert await fence_task is True
+    assert workflow_dispatches_blocked(db_path) is True
+
+
+@pytest.mark.asyncio
+async def test_unregistered_workflow_fails_before_creating_lock_or_row(
+    db_path: Path,
+) -> None:
+    class UndeclaredWorkflow:
+        pass
+
+    with pytest.raises(
+        UnregisteredWorkflowDispatchError,
+        match="not declared",
+    ):
+        async with reserve_workflow_dispatch(
+            workflow=UndeclaredWorkflow,
+            workflow_id="undeclared",
+            db_path=db_path,
+        ):
+            pytest.fail("an undeclared workflow must not reach dispatch")
+
+    with sqlite3.connect(db_path) as conn:
+        count = conn.execute(
+            "SELECT COUNT(*) FROM workflow_dispatch_registry"
+        ).fetchone()[0]
+    assert count == 0

--- a/workers/automation/tests/test_workflow_starter_cache.py
+++ b/workers/automation/tests/test_workflow_starter_cache.py
@@ -15,6 +15,7 @@ succeeds.
 from __future__ import annotations
 
 import asyncio
+import sqlite3
 import uuid
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -22,15 +23,17 @@ import pytest
 from temporalio.client import WorkflowExecutionStatus
 from temporalio.service import RPCError, RPCStatusCode
 
+from jobctrl import config
 from jobctrl.cli import _reconcile_workflow_runs
 from jobctrl.database import get_connection
 from jobctrl.domain.rpc.messages import WorkflowStartSpec
 from jobctrl.infrastructure.rpc import workflow_starter as ws
+from jobctrl.infrastructure.runtime_identity import RuntimeIdentityMismatch
+from jobctrl.infrastructure.temporal.workflow_dispatch_control import (
+    WorkflowDispatchFencedError,
+    set_workflow_dispatches_blocked,
+)
 from jobctrl.pipeline.workflow import JobPipelineWorkflow, JobPipelineWorkflowInput
-
-
-class _FakeWorkflow:
-    pass
 
 
 class _FakeDescribe:
@@ -76,7 +79,7 @@ def test_starter_connects_per_call() -> None:
     with patch.object(
         ws, "get_temporal_client", AsyncMock(return_value=fake_client)
     ) as connect_mock:
-        spec = WorkflowStartSpec(workflow=_FakeWorkflow, args=())
+        spec = _registered_spec()
 
         async def _drive() -> None:
             await ws.default_workflow_starter(spec)
@@ -123,13 +126,133 @@ def test_starter_survives_cross_loop_invocation() -> None:
     with patch.object(
         ws, "get_temporal_client", AsyncMock(return_value=fake_client)
     ):
-        spec = WorkflowStartSpec(workflow=_FakeWorkflow, args=())
+        spec = _registered_spec()
 
         # Each asyncio.run owns its own loop — exactly the JSON-RPC dispatch path.
         asyncio.run(ws.default_workflow_starter(spec))
         asyncio.run(ws.default_workflow_starter(spec))
 
     assert fake_client.start_workflow.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_starter_never_contacts_temporal_while_dispatch_is_fenced(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    monkeypatch.setattr(config, "DB_PATH", db_path)
+    set_workflow_dispatches_blocked(
+        blocked=True,
+        reason="identity-cutover",
+        db_path=db_path,
+    )
+    fake_client = MagicMock()
+    fake_client.start_workflow = AsyncMock()
+    spec = WorkflowStartSpec(
+        workflow=JobPipelineWorkflow,
+        args=(
+            JobPipelineWorkflowInput(
+                tenant_id="local",
+                stages=["score"],
+                expected_db_path=str(db_path),
+            ),
+        ),
+    )
+
+    with (
+        patch.object(
+            ws,
+            "get_temporal_client",
+            AsyncMock(return_value=fake_client),
+        ) as connect_mock,
+        pytest.raises(
+            WorkflowDispatchFencedError,
+            match="stable JobId cutover",
+        ),
+    ):
+        await ws.default_workflow_starter(spec)
+
+    connect_mock.assert_not_awaited()
+    fake_client.start_workflow.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_starter_rejects_an_alternate_expected_db_before_temporal_contact(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    canonical_db_path = tmp_path / "canonical.db"
+    alternate_db_path = tmp_path / "alternate.db"
+    monkeypatch.setattr(config, "DB_PATH", canonical_db_path)
+    fake_client = MagicMock()
+    fake_client.start_workflow = AsyncMock()
+    spec = WorkflowStartSpec(
+        workflow=JobPipelineWorkflow,
+        args=(
+            JobPipelineWorkflowInput(
+                tenant_id="local",
+                stages=["score"],
+                expected_db_path=str(alternate_db_path),
+            ),
+        ),
+    )
+
+    with (
+        patch.object(
+            ws,
+            "get_temporal_client",
+            AsyncMock(return_value=fake_client),
+        ) as connect_mock,
+        pytest.raises(
+            RuntimeIdentityMismatch,
+            match="Worker runtime mismatch",
+        ),
+    ):
+        await ws.default_workflow_starter(spec)
+
+    connect_mock.assert_not_awaited()
+    fake_client.start_workflow.assert_not_awaited()
+    assert alternate_db_path.exists() is False
+
+
+@pytest.mark.asyncio
+async def test_starter_connector_failure_keeps_an_uncertain_reservation(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    monkeypatch.setattr(config, "DB_PATH", db_path)
+    spec = WorkflowStartSpec(
+        workflow=JobPipelineWorkflow,
+        args=(
+            JobPipelineWorkflowInput(
+                tenant_id="local",
+                stages=["score"],
+                expected_db_path=str(db_path),
+            ),
+        ),
+        workflow_id="run-connect-timeout",
+    )
+
+    with (
+        patch.object(
+            ws,
+            "get_temporal_client",
+            AsyncMock(side_effect=TimeoutError("connector timeout")),
+        ),
+        pytest.raises(TimeoutError, match="connector timeout"),
+    ):
+        await ws.default_workflow_starter(spec)
+
+    with sqlite3.connect(db_path) as conn:
+        row = conn.execute(
+            """
+            SELECT workflow_id, temporal_run_id, state
+            FROM workflow_dispatch_registry
+            """
+        ).fetchone()
+    assert row == ("run-connect-timeout", None, "uncertain")
 
 
 @pytest.mark.asyncio
@@ -170,3 +293,15 @@ async def test_dispatch_started_row_is_visible_and_reconciler_terminalizes_not_f
     assert terminalized >= 1
     assert row["status"] == "terminated"
     assert row["error_code"] == "reconciled_not_found"
+
+
+def _registered_spec() -> WorkflowStartSpec:
+    return WorkflowStartSpec(
+        workflow=JobPipelineWorkflow,
+        args=(
+            JobPipelineWorkflowInput(
+                tenant_id="local",
+                stages=["score"],
+            ),
+        ),
+    )


### PR DESCRIPTION
## Summary

- reserve every direct application-owned Temporal dispatch in durable SQLite before connecting to Temporal
- serialize dispatch with a shared filesystem lock and cutover blocking with the matching exclusive lock
- retain connector/start failures as `uncertain` because Temporal may have accepted a request whose response was lost
- anchor the fence to the authoritative runtime database and reject mismatched expected DB paths before any Temporal call
- cover the default RPC/preparation starter and the separate auto-apply reconciler

## Why

The JobId event/projection cutover cannot race a legacy URL-bearing workflow start. This layer closes the direct-dispatch race and creates the exact workflow/run inventory that the next quiescence layer will reconcile with strongly consistent Temporal descriptions.

Temporal-owned schedules do not pass through direct dispatch. Pausing and verifying those schedules is deliberately isolated to the next stacked PR; this PR does not claim that all Temporal starts are fenced yet.

## Safety properties

- a durable `reserved` row exists before Temporal connection/start
- a lost connector or start response becomes `uncertain`, never silently safe
- an exclusive cutover gate waits for in-flight shared dispatches
- once blocked, RPC/preparation and enabled auto-apply paths make zero connector, describe, or start calls
- a payload cannot select an alternate fence database
- undeclared workflows fail closed against the registry policy

## Validation

- full worker suite: 2,805 passed, 2 skipped
- focused dispatch/auto-apply/starter regressions: 17 passed
- Ruff on all touched Python files: passed
- `git diff --check`: passed
- dependency lock unchanged
- independent reviewer: Gate PASS; Blocker 0, High 0, Medium 0, Low 0
- independent QA: Gate PASS; Blocker 0, High 0, Medium 0, Low 0

## Stack

- Base: `feat/job-id-cutover-workflow-policy` (#559)
- This active-path safety layer is fully verified on its own head.
- Next: pause Temporal-owned schedules and reconcile every durable dispatch with exact execution descriptions before quiescence can return ready.