### PR TITLE
feat(workflows): fence JobId cutover schedules

### DIFF
--- a/workers/automation/src/jobctrl/cli.py
+++ b/workers/automation/src/jobctrl/cli.py
@@ -2116,44 +2116,108 @@ async def _reconcile_discovery_schedule(client: Any, task_queue: str) -> None:
         ScheduleOverlapPolicy,
         SchedulePolicy,
         ScheduleSpec,
+        ScheduleState,
         ScheduleUpdate,
     )
+    from temporalio.service import RPCError, RPCStatusCode
 
     from jobctrl.config import load_discovery_schedule_settings
     from jobctrl.discovery.workflow import (
         DiscoverWorkflow,
         DiscoverWorkflowInput,
-        discover_workflow_id,
     )
     from jobctrl.domain.tenant import LOCAL_TENANT
+    from jobctrl.infrastructure.runtime_identity import (
+        current_runtime_identity,
+    )
+    from jobctrl.infrastructure.temporal.schedule_cutover import (
+        identity_bearing_schedule_policies,
+    )
+    from jobctrl.infrastructure.temporal.workflow_dispatch_control import (
+        workflow_dispatch_read_lock,
+        workflow_dispatches_blocked,
+    )
 
     enabled, cron = load_discovery_schedule_settings()
-    schedule_id = f"jobctrl-discovery-{LOCAL_TENANT}"
-    handle = client.get_schedule_handle(schedule_id)
-    if not enabled:
-        try:
-            await handle.delete()
-        except Exception:
-            log.debug("Discovery schedule %s absent or already deleted", schedule_id, exc_info=True)
-        return
+    policy = identity_bearing_schedule_policies(
+        str(LOCAL_TENANT)
+    )[0]
+    schedule_id = policy.schedule_id
+    async with workflow_dispatch_read_lock(
+        db_path=current_runtime_identity().db_path,
+    ):
+        cutover_blocked = workflow_dispatches_blocked(
+            current_runtime_identity().db_path
+        )
+        handle = client.get_schedule_handle(schedule_id)
+        if not enabled:
+            try:
+                await handle.delete()
+            except RPCError as exc:
+                if exc.status == RPCStatusCode.NOT_FOUND:
+                    return
+                if cutover_blocked:
+                    raise RuntimeError(
+                        "could not prove the identity-bearing Discovery "
+                        "schedule is absent during JobId cutover"
+                    ) from exc
+                log.debug(
+                    "Discovery schedule %s delete failed",
+                    schedule_id,
+                    exc_info=True,
+                )
+            except Exception as exc:
+                if cutover_blocked:
+                    raise RuntimeError(
+                        "could not prove the identity-bearing Discovery "
+                        "schedule is absent during JobId cutover"
+                    ) from exc
+                log.debug(
+                    "Discovery schedule %s absent or already deleted",
+                    schedule_id,
+                    exc_info=True,
+                )
+            return
 
-    schedule = Schedule(
-        action=ScheduleActionStartWorkflow(
-            DiscoverWorkflow.run,
-            DiscoverWorkflowInput(tenant_id=str(LOCAL_TENANT)),
-            id=discover_workflow_id(str(LOCAL_TENANT)),
-            task_queue=task_queue,
-        ),
-        spec=ScheduleSpec(cron_expressions=[cron]),
-        policy=SchedulePolicy(overlap=ScheduleOverlapPolicy.SKIP),
-    )
-    try:
-        await client.create_schedule(schedule_id, schedule)
-    except Exception:
+        schedule = Schedule(
+            action=ScheduleActionStartWorkflow(
+                DiscoverWorkflow.run,
+                DiscoverWorkflowInput(tenant_id=str(LOCAL_TENANT)),
+                id=policy.workflow_id,
+                task_queue=task_queue,
+            ),
+            spec=ScheduleSpec(cron_expressions=[cron]),
+            policy=SchedulePolicy(
+                overlap=ScheduleOverlapPolicy.SKIP
+            ),
+            state=ScheduleState(
+                paused=cutover_blocked,
+                note=(
+                    "Paused for the stable JobId cutover."
+                    if cutover_blocked
+                    else None
+                ),
+            ),
+        )
         try:
-            await handle.update(lambda _input: ScheduleUpdate(schedule))
+            await client.create_schedule(schedule_id, schedule)
         except Exception:
-            log.warning("Discovery schedule %s reconcile failed", schedule_id, exc_info=True)
+            try:
+                await handle.update(
+                    lambda _input: ScheduleUpdate(schedule)
+                )
+            except Exception as update_exc:
+                if cutover_blocked:
+                    raise RuntimeError(
+                        "could not reconcile the identity-bearing "
+                        "Discovery schedule in a paused state during "
+                        "JobId cutover"
+                    ) from update_exc
+                log.warning(
+                    "Discovery schedule %s reconcile failed",
+                    schedule_id,
+                    exc_info=True,
+                )
 
 
 # Truthy spellings accepted by the browser-preflight escape hatch, matching the

--- a/workers/automation/src/jobctrl/infrastructure/temporal/schedule_cutover.py
+++ b/workers/automation/src/jobctrl/infrastructure/temporal/schedule_cutover.py
@@ -1,0 +1,97 @@
+"""Temporal-owned schedule controls for the stable JobId cutover."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from temporalio.service import RPCError, RPCStatusCode
+
+from jobctrl.discovery.workflow import discover_workflow_id
+from jobctrl.domain.tenant import LOCAL_TENANT
+from jobctrl.infrastructure.temporal.workflow_dispatch_control import (
+    activate_workflow_dispatch_fence,
+)
+
+_CUTOVER_PAUSE_NOTE = "Paused for the stable JobId cutover."
+
+
+@dataclass(frozen=True)
+class ScheduledWorkflowIdentityPolicy:
+    schedule_id: str
+    workflow_type: str
+    workflow_id: str
+
+
+@dataclass(frozen=True)
+class IdentityCutoverFenceReceipt:
+    dispatches_blocked: bool
+    paused_schedule_ids: tuple[str, ...]
+
+
+def identity_bearing_schedule_policies(
+    tenant_id: str = str(LOCAL_TENANT),
+) -> tuple[ScheduledWorkflowIdentityPolicy, ...]:
+    """Return every Temporal-owned schedule that can start job identity work."""
+
+    return (
+        ScheduledWorkflowIdentityPolicy(
+            schedule_id=f"jobctrl-discovery-{tenant_id}",
+            workflow_type="DiscoverWorkflow",
+            workflow_id=discover_workflow_id(tenant_id),
+        ),
+    )
+
+
+async def pause_identity_bearing_schedules(
+    client: Any,
+    *,
+    tenant_id: str = str(LOCAL_TENANT),
+) -> tuple[str, ...]:
+    """Pause every configured identity-bearing schedule, failing closed."""
+
+    paused: list[str] = []
+    for policy in identity_bearing_schedule_policies(tenant_id):
+        handle = client.get_schedule_handle(policy.schedule_id)
+        try:
+            await handle.pause(note=_CUTOVER_PAUSE_NOTE)
+        except RPCError as exc:
+            if exc.status == RPCStatusCode.NOT_FOUND:
+                continue
+            raise
+        paused.append(policy.schedule_id)
+    return tuple(paused)
+
+
+async def activate_identity_cutover_fence(
+    client: Any,
+    *,
+    db_path: str,
+    tenant_id: str = str(LOCAL_TENANT),
+) -> IdentityCutoverFenceReceipt:
+    """Atomically block direct dispatch and pause Temporal-owned schedules."""
+
+    async def _pause() -> tuple[str, ...]:
+        return await pause_identity_bearing_schedules(
+            client,
+            tenant_id=tenant_id,
+        )
+
+    paused = await activate_workflow_dispatch_fence(
+        reason="stable-job-id-cutover",
+        after_blocked=_pause,
+        db_path=db_path,
+    )
+    return IdentityCutoverFenceReceipt(
+        dispatches_blocked=True,
+        paused_schedule_ids=paused,
+    )
+
+
+__all__ = [
+    "IdentityCutoverFenceReceipt",
+    "ScheduledWorkflowIdentityPolicy",
+    "activate_identity_cutover_fence",
+    "identity_bearing_schedule_policies",
+    "pause_identity_bearing_schedules",
+]

--- a/workers/automation/src/jobctrl/infrastructure/temporal/workflow_dispatch_control.py
+++ b/workers/automation/src/jobctrl/infrastructure/temporal/workflow_dispatch_control.py
@@ -24,12 +24,20 @@ from contextlib import asynccontextmanager, contextmanager
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, AsyncIterator, Iterator
+from typing import (
+    Any,
+    AsyncIterator,
+    Awaitable,
+    Callable,
+    Iterator,
+    TypeVar,
+)
 
 from jobctrl import config
 
 _CONTROL_KEY = "stable-job-id-cutover"
 _LOCK_SUFFIX = ".workflow-dispatch.lock"
+_FenceResult = TypeVar("_FenceResult")
 
 
 class WorkflowDispatchFencedError(RuntimeError):
@@ -95,6 +103,24 @@ def ensure_workflow_dispatch_control_tables(
 
 
 @asynccontextmanager
+async def workflow_dispatch_read_lock(
+    *,
+    db_path: Path | str | None = None,
+) -> AsyncIterator[Path]:
+    """Hold the shared side of the cutover fence for dispatch-adjacent work."""
+
+    resolved_path = _resolve_db_path(db_path)
+    lock_fd = await _acquire_lock_async(
+        _lock_path(resolved_path),
+        fcntl.LOCK_SH,
+    )
+    try:
+        yield resolved_path
+    finally:
+        _release_lock(lock_fd)
+
+
+@asynccontextmanager
 async def reserve_workflow_dispatch(
     *,
     workflow: type,
@@ -116,13 +142,10 @@ async def reserve_workflow_dispatch(
     resolved_id = str(workflow_id or "").strip()
     if not resolved_id:
         raise ValueError("workflow_id must be non-empty")
-    resolved_path = _resolve_db_path(db_path)
-    lock_fd = await _acquire_lock_async(
-        _lock_path(resolved_path),
-        fcntl.LOCK_SH,
-    )
     reservation: WorkflowDispatchReservation | None = None
-    try:
+    async with workflow_dispatch_read_lock(
+        db_path=db_path,
+    ) as resolved_path:
         reservation = _create_reservation(
             resolved_path,
             workflow_id=resolved_id,
@@ -147,8 +170,6 @@ async def reserve_workflow_dispatch(
                     else "uncertain"
                 ),
             )
-    finally:
-        _release_lock(lock_fd)
 
 
 def set_workflow_dispatches_blocked(
@@ -161,37 +182,41 @@ def set_workflow_dispatches_blocked(
 
     resolved_path = _resolve_db_path(db_path)
     with _locked(_lock_path(resolved_path), fcntl.LOCK_EX):
-        conn = _open_control_connection(resolved_path)
-        try:
-            ensure_workflow_dispatch_control_tables(conn)
-            with conn:
-                if blocked:
-                    conn.execute(
-                        """
-                        INSERT INTO workflow_dispatch_control (
-                            control_key, reason, blocked_at
-                        ) VALUES (?, ?, ?)
-                        ON CONFLICT(control_key) DO UPDATE SET
-                            reason = excluded.reason,
-                            blocked_at = excluded.blocked_at
-                        """,
-                        (
-                            _CONTROL_KEY,
-                            str(reason or ""),
-                            _utc_now(),
-                        ),
-                    )
-                else:
-                    conn.execute(
-                        """
-                        DELETE FROM workflow_dispatch_control
-                        WHERE control_key = ?
-                        """,
-                        (_CONTROL_KEY,),
-                    )
-                return blocked
-        finally:
-            conn.close()
+        _write_workflow_dispatch_gate(
+            resolved_path,
+            blocked=blocked,
+            reason=reason,
+        )
+    return blocked
+
+
+async def activate_workflow_dispatch_fence(
+    *,
+    reason: str,
+    after_blocked: Callable[[], Awaitable[_FenceResult]],
+    db_path: Path | str | None = None,
+) -> _FenceResult:
+    """Block direct dispatch and run schedule fencing under one write lock.
+
+    The durable gate is intentionally left blocked when ``after_blocked``
+    raises. That fail-closed state prevents direct dispatch while an operator
+    retries or abandons the schedule pause.
+    """
+
+    resolved_path = _resolve_db_path(db_path)
+    lock_fd = await _acquire_lock_async(
+        _lock_path(resolved_path),
+        fcntl.LOCK_EX,
+    )
+    try:
+        _write_workflow_dispatch_gate(
+            resolved_path,
+            blocked=True,
+            reason=reason,
+        )
+        return await after_blocked()
+    finally:
+        _release_lock(lock_fd)
 
 
 def workflow_dispatches_blocked(
@@ -262,6 +287,44 @@ def _create_reservation(
         workflow_id=workflow_id,
         workflow_type=workflow_type,
     )
+
+
+def _write_workflow_dispatch_gate(
+    db_path: Path,
+    *,
+    blocked: bool,
+    reason: str,
+) -> None:
+    conn = _open_control_connection(db_path)
+    try:
+        ensure_workflow_dispatch_control_tables(conn)
+        with conn:
+            if blocked:
+                conn.execute(
+                    """
+                    INSERT INTO workflow_dispatch_control (
+                        control_key, reason, blocked_at
+                    ) VALUES (?, ?, ?)
+                    ON CONFLICT(control_key) DO UPDATE SET
+                        reason = excluded.reason,
+                        blocked_at = excluded.blocked_at
+                    """,
+                    (
+                        _CONTROL_KEY,
+                        str(reason or ""),
+                        _utc_now(),
+                    ),
+                )
+            else:
+                conn.execute(
+                    """
+                    DELETE FROM workflow_dispatch_control
+                    WHERE control_key = ?
+                    """,
+                    (_CONTROL_KEY,),
+                )
+    finally:
+        conn.close()
 
 
 def _finish_reservation(
@@ -378,8 +441,10 @@ __all__ = [
     "UnregisteredWorkflowDispatchError",
     "WorkflowDispatchReservation",
     "WorkflowDispatchFencedError",
+    "activate_workflow_dispatch_fence",
     "ensure_workflow_dispatch_control_tables",
     "reserve_workflow_dispatch",
     "set_workflow_dispatches_blocked",
+    "workflow_dispatch_read_lock",
     "workflow_dispatches_blocked",
 ]

--- a/workers/automation/tests/test_schedule_cutover.py
+++ b/workers/automation/tests/test_schedule_cutover.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+from temporalio.service import RPCError, RPCStatusCode
+
+from jobctrl.infrastructure.temporal.schedule_cutover import (
+    activate_identity_cutover_fence,
+    identity_bearing_schedule_policies,
+    pause_identity_bearing_schedules,
+)
+from jobctrl.infrastructure.temporal.workflow_dispatch_control import (
+    workflow_dispatches_blocked,
+)
+
+
+@dataclass
+class _ScheduleHandle:
+    outcome: Exception | None = None
+    pause_notes: list[str | None] | None = None
+
+    async def pause(self, *, note: str | None = None) -> None:
+        if self.outcome is not None:
+            raise self.outcome
+        if self.pause_notes is None:
+            self.pause_notes = []
+        self.pause_notes.append(note)
+
+
+class _ScheduleClient:
+    def __init__(self, handle: _ScheduleHandle) -> None:
+        self.handle = handle
+        self.schedule_ids: list[str] = []
+
+    def get_schedule_handle(
+        self,
+        schedule_id: str,
+    ) -> _ScheduleHandle:
+        self.schedule_ids.append(schedule_id)
+        return self.handle
+
+
+def test_identity_bearing_schedule_policy_names_exact_discovery_execution() -> None:
+    policies = identity_bearing_schedule_policies("tenant-a")
+    assert len(policies) == 1
+    policy = policies[0]
+    assert policy.schedule_id == "jobctrl-discovery-tenant-a"
+    assert policy.workflow_type == "DiscoverWorkflow"
+    assert policy.workflow_id == "discover-tenant-a"
+
+
+@pytest.mark.asyncio
+async def test_pause_identity_bearing_schedules_returns_only_confirmed_pauses() -> None:
+    handle = _ScheduleHandle()
+    client = _ScheduleClient(handle)
+
+    paused = await pause_identity_bearing_schedules(
+        client,
+        tenant_id="tenant-a",
+    )
+
+    assert paused == ("jobctrl-discovery-tenant-a",)
+    assert client.schedule_ids == ["jobctrl-discovery-tenant-a"]
+    assert handle.pause_notes == [
+        "Paused for the stable JobId cutover."
+    ]
+
+
+@pytest.mark.asyncio
+async def test_pause_identity_bearing_schedules_treats_absence_as_safe() -> None:
+    handle = _ScheduleHandle(
+        outcome=RPCError(
+            "not found",
+            RPCStatusCode.NOT_FOUND,
+            b"",
+        )
+    )
+
+    paused = await pause_identity_bearing_schedules(
+        _ScheduleClient(handle),
+    )
+
+    assert paused == ()
+
+
+@pytest.mark.asyncio
+async def test_pause_identity_bearing_schedules_propagates_unknown_failure() -> None:
+    handle = _ScheduleHandle(
+        outcome=RPCError(
+            "unavailable",
+            RPCStatusCode.UNAVAILABLE,
+            b"",
+        )
+    )
+
+    with pytest.raises(RPCError):
+        await pause_identity_bearing_schedules(
+            _ScheduleClient(handle),
+        )
+
+
+@pytest.mark.asyncio
+async def test_activation_leaves_dispatch_blocked_when_schedule_pause_fails(
+    tmp_path,
+) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    handle = _ScheduleHandle(
+        outcome=RPCError(
+            "unavailable",
+            RPCStatusCode.UNAVAILABLE,
+            b"",
+        )
+    )
+
+    with pytest.raises(RPCError):
+        await activate_identity_cutover_fence(
+            _ScheduleClient(handle),
+            db_path=str(db_path),
+        )
+
+    assert workflow_dispatches_blocked(db_path) is True

--- a/workers/automation/tests/test_workflow_discovery.py
+++ b/workers/automation/tests/test_workflow_discovery.py
@@ -13,9 +13,11 @@ import pytest
 from temporalio import activity
 from temporalio.client import ScheduleOverlapPolicy, WorkflowFailureError
 from temporalio.exceptions import ActivityError, ApplicationError, CancelledError
+from temporalio.service import RPCError, RPCStatusCode
 from temporalio.testing import WorkflowEnvironment
 from temporalio.worker import UnsandboxedWorkflowRunner, Worker
 
+from jobctrl import config
 from jobctrl.cli import _reconcile_discovery_schedule
 from jobctrl.config import DEFAULT_DISCOVERY_SEARCH_CONFIG, load_discovery_schedule_settings
 from jobctrl.domain.discovery.scheduler import DiscoveryRunProgress
@@ -38,6 +40,12 @@ from jobctrl.discovery.workflow import (
     _activity_error_was_cancelled,
 )
 from jobctrl.infrastructure.temporal.finalize import WorkflowOutcomeInput, WorkflowStartedInput
+from jobctrl.infrastructure.temporal.schedule_cutover import (
+    activate_identity_cutover_fence,
+)
+from jobctrl.infrastructure.temporal.workflow_dispatch_control import (
+    set_workflow_dispatches_blocked,
+)
 from jobctrl.llm import SpendBudgetStatus
 from jobctrl.pipeline import runner
 
@@ -1083,16 +1091,40 @@ def test_discovery_schedule_defaults_disabled() -> None:
 
 
 class _FakeScheduleHandle:
-    def __init__(self, *, update_raises: bool = False) -> None:
+    def __init__(
+        self,
+        *,
+        delete_outcome: Exception | None = None,
+        delete_raises: bool = False,
+        update_entered: asyncio.Event | None = None,
+        update_release: asyncio.Event | None = None,
+        update_raises: bool = False,
+    ) -> None:
         self.deleted = 0
+        self.delete_outcome = delete_outcome
+        self.delete_raises = delete_raises
+        self.pause_notes: list[str | None] = []
         self.updated = 0
+        self.update_entered = update_entered
+        self.update_release = update_release
         self.update_result = None
         self.update_raises = update_raises
 
     async def delete(self) -> None:
+        if self.delete_outcome is not None:
+            raise self.delete_outcome
+        if self.delete_raises:
+            raise RuntimeError("delete failed")
         self.deleted += 1
 
+    async def pause(self, *, note: str | None = None) -> None:
+        self.pause_notes.append(note)
+
     async def update(self, updater) -> None:
+        if self.update_entered is not None:
+            self.update_entered.set()
+        if self.update_release is not None:
+            await self.update_release.wait()
         if self.update_raises:
             raise RuntimeError("bad persisted schedule")
         self.updated += 1
@@ -1100,8 +1132,23 @@ class _FakeScheduleHandle:
 
 
 class _FakeScheduleClient:
-    def __init__(self, *, create_raises: bool = False, update_raises: bool = False) -> None:
-        self.handle = _FakeScheduleHandle(update_raises=update_raises)
+    def __init__(
+        self,
+        *,
+        create_raises: bool = False,
+        delete_outcome: Exception | None = None,
+        delete_raises: bool = False,
+        update_entered: asyncio.Event | None = None,
+        update_release: asyncio.Event | None = None,
+        update_raises: bool = False,
+    ) -> None:
+        self.handle = _FakeScheduleHandle(
+            delete_outcome=delete_outcome,
+            delete_raises=delete_raises,
+            update_entered=update_entered,
+            update_release=update_release,
+            update_raises=update_raises,
+        )
         self.create_raises = create_raises
         self.created: list[tuple[str, Any]] = []
 
@@ -1146,6 +1193,7 @@ async def test_discovery_schedule_reconcile_creates_skip_overlap_schedule(
     assert schedule.policy.overlap is ScheduleOverlapPolicy.SKIP
     assert schedule.action.id == "discover-local"
     assert schedule.action.task_queue == "jobctrl-test"
+    assert schedule.state.paused is False
 
 
 @pytest.mark.asyncio
@@ -1163,6 +1211,7 @@ async def test_discovery_schedule_reconcile_updates_existing_schedule(
     assert client.handle.updated == 1
     assert client.handle.update_result.schedule.spec.cron_expressions == ["30 6 * * *"]
     assert client.handle.update_result.schedule.policy.overlap is ScheduleOverlapPolicy.SKIP
+    assert client.handle.update_result.schedule.state.paused is False
 
 
 @pytest.mark.asyncio
@@ -1178,3 +1227,190 @@ async def test_discovery_schedule_reconcile_failure_does_not_block_worker_boot(
     await _reconcile_discovery_schedule(client, "jobctrl-test")
 
     assert client.handle.updated == 0
+
+
+@pytest.mark.asyncio
+async def test_discovery_schedule_reconcile_creates_paused_while_cutover_is_blocked(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    monkeypatch.setattr(config, "DB_PATH", db_path)
+    monkeypatch.setattr(
+        "jobctrl.config.load_discovery_schedule_settings",
+        lambda: (True, "15 9 * * *"),
+    )
+    set_workflow_dispatches_blocked(
+        blocked=True,
+        reason="identity-cutover",
+        db_path=db_path,
+    )
+    client = _FakeScheduleClient()
+
+    await _reconcile_discovery_schedule(client, "jobctrl-test")
+
+    [(_schedule_id, schedule)] = client.created
+    assert schedule.state.paused is True
+    assert schedule.state.note == "Paused for the stable JobId cutover."
+
+
+@pytest.mark.asyncio
+async def test_discovery_schedule_reconcile_updates_existing_to_paused_during_cutover(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    monkeypatch.setattr(config, "DB_PATH", db_path)
+    monkeypatch.setattr(
+        "jobctrl.config.load_discovery_schedule_settings",
+        lambda: (True, "30 6 * * *"),
+    )
+    set_workflow_dispatches_blocked(
+        blocked=True,
+        reason="identity-cutover",
+        db_path=db_path,
+    )
+    client = _FakeScheduleClient(create_raises=True)
+
+    await _reconcile_discovery_schedule(client, "jobctrl-test")
+
+    assert client.handle.updated == 1
+    assert client.handle.update_result.schedule.state.paused is True
+
+
+@pytest.mark.asyncio
+async def test_discovery_schedule_reconcile_fails_closed_when_pause_cannot_be_proven(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    monkeypatch.setattr(config, "DB_PATH", db_path)
+    monkeypatch.setattr(
+        "jobctrl.config.load_discovery_schedule_settings",
+        lambda: (True, "30 6 * * *"),
+    )
+    set_workflow_dispatches_blocked(
+        blocked=True,
+        reason="identity-cutover",
+        db_path=db_path,
+    )
+    client = _FakeScheduleClient(
+        create_raises=True,
+        update_raises=True,
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match="paused state during JobId cutover",
+    ):
+        await _reconcile_discovery_schedule(
+            client,
+            "jobctrl-test",
+        )
+
+
+@pytest.mark.asyncio
+async def test_disabled_discovery_schedule_fails_closed_when_delete_is_uncertain(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    monkeypatch.setattr(config, "DB_PATH", db_path)
+    monkeypatch.setattr(
+        "jobctrl.config.load_discovery_schedule_settings",
+        lambda: (False, "0 7 * * *"),
+    )
+    set_workflow_dispatches_blocked(
+        blocked=True,
+        reason="identity-cutover",
+        db_path=db_path,
+    )
+    client = _FakeScheduleClient(delete_raises=True)
+
+    with pytest.raises(
+        RuntimeError,
+        match="schedule is absent during JobId cutover",
+    ):
+        await _reconcile_discovery_schedule(
+            client,
+            "jobctrl-test",
+        )
+
+
+@pytest.mark.asyncio
+async def test_disabled_absent_schedule_is_safe_during_cutover(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    monkeypatch.setattr(config, "DB_PATH", db_path)
+    monkeypatch.setattr(
+        "jobctrl.config.load_discovery_schedule_settings",
+        lambda: (False, "0 7 * * *"),
+    )
+    set_workflow_dispatches_blocked(
+        blocked=True,
+        reason="identity-cutover",
+        db_path=db_path,
+    )
+    client = _FakeScheduleClient(
+        delete_outcome=RPCError(
+            "not found",
+            RPCStatusCode.NOT_FOUND,
+            b"",
+        )
+    )
+
+    await _reconcile_discovery_schedule(
+        client,
+        "jobctrl-test",
+    )
+
+    assert client.handle.deleted == 0
+
+
+@pytest.mark.asyncio
+async def test_cutover_gate_waits_for_inflight_schedule_reconciliation(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    monkeypatch.setattr(config, "DB_PATH", db_path)
+    monkeypatch.setattr(
+        "jobctrl.config.load_discovery_schedule_settings",
+        lambda: (True, "30 6 * * *"),
+    )
+    update_entered = asyncio.Event()
+    update_release = asyncio.Event()
+    client = _FakeScheduleClient(
+        create_raises=True,
+        update_entered=update_entered,
+        update_release=update_release,
+    )
+
+    reconcile_task = asyncio.create_task(
+        _reconcile_discovery_schedule(
+            client,
+            "jobctrl-test",
+        )
+    )
+    await update_entered.wait()
+    fence_task = asyncio.create_task(
+        activate_identity_cutover_fence(
+            client,
+            db_path=db_path,
+        )
+    )
+    await asyncio.sleep(0.1)
+    assert fence_task.done() is False
+
+    update_release.set()
+    await reconcile_task
+    receipt = await fence_task
+    assert receipt.dispatches_blocked is True
+    assert receipt.paused_schedule_ids == (
+        "jobctrl-discovery-local",
+    )
+    assert client.handle.pause_notes == [
+        "Paused for the stable JobId cutover."
+    ]


### PR DESCRIPTION
## Summary

- declare the Temporal-owned Discovery schedule as an identity-bearing workflow source
- atomically activate the durable direct-dispatch gate and pause identity-bearing schedules under one exclusive cutover fence
- make worker schedule reconciliation share that fence and preserve a paused state while cutover is active
- treat Temporal `NOT_FOUND` as authoritative schedule absence while failing closed on unknown schedule errors
- keep the dispatch gate blocked when schedule pausing cannot be confirmed

## Why

Direct workflow starts were fenced in the parent PR, but Temporal schedules could still launch identity-bearing work. The cutover needs a single activation boundary that prevents a concurrent worker reconciliation from re-enabling a schedule after it has been paused.

## Validation

- `PYTHONPATH=workers/automation/src /Users/eloibarti/Github/JobHunter/workers/automation/.venv/bin/python -m pytest -q workers/automation/tests` — 2816 passed, 2 skipped
- focused schedule and discovery tests — 41 passed
- Ruff on all touched Python files — passed
- `git diff --check` — passed
- canonical `workers/automation/uv.lock` unchanged
- independent review gate — PASS, 0 findings
- independent QA gate — PASS, 0 findings

## Stack

- Base: #560
- This PR fences scheduled workflow creation; exact-run quiescence proof and migration execution remain separate follow-up slices.