### PR TITLE
feat(workflows): add cutover recovery proof contract

### DIFF
--- a/workers/automation/src/jobctrl/infrastructure/temporal/identity_cutover_proof.py
+++ b/workers/automation/src/jobctrl/infrastructure/temporal/identity_cutover_proof.py
@@ -1,0 +1,223 @@
+"""Durable proof contract for the stable-identity cutover inventory.
+
+The exact-run preflight cannot infer that a local inventory is complete merely
+because a projection or dispatch table is empty. A preceding recovery step must
+backfill every pre-fence Temporal execution into the dispatch registry, stop the
+supported JobCtrl worker processes, and seal the resulting registry and worker
+inventories for the current fence epoch.
+
+This module validates that seal. It deliberately does not create one: proof
+creation belongs to the later recovery/handoff step that can inspect Temporal
+and verify process shutdown.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import sqlite3
+from dataclasses import dataclass
+from typing import Any
+
+CONTROL_KEY = "stable-job-id-cutover"
+INVENTORY_PROOF_VERSION = 1
+INVENTORY_PROOF_TABLE = "workflow_identity_cutover_inventory_proof"
+WORKER_HEARTBEAT_TABLE = "worker_runtime_heartbeats"
+
+
+@dataclass(frozen=True)
+class InventoryFingerprint:
+    digest: str
+    entry_count: int
+
+
+@dataclass(frozen=True)
+class InventoryProofObservation:
+    state: str
+    detail: str | None = None
+
+    @property
+    def valid(self) -> bool:
+        return self.state == "valid"
+
+
+def validate_identity_cutover_inventory_proof(
+    conn: sqlite3.Connection,
+    *,
+    fence_blocked_at: str | None,
+) -> InventoryProofObservation:
+    """Validate the recovery seal and current worker-process quiescence."""
+
+    if not fence_blocked_at:
+        return InventoryProofObservation("missing_fence_epoch")
+    tables = _table_names(conn)
+    if INVENTORY_PROOF_TABLE not in tables:
+        return InventoryProofObservation("proof_table_missing")
+    row = conn.execute(
+        f"""
+        SELECT proof_version, fence_blocked_at,
+               registry_inventory_digest, registry_entry_count,
+               worker_inventory_digest, worker_entry_count,
+               worker_quiescent_at
+        FROM {INVENTORY_PROOF_TABLE}
+        WHERE control_key = ?
+        """,
+        (CONTROL_KEY,),
+    ).fetchone()
+    if row is None:
+        return InventoryProofObservation("proof_missing")
+
+    proof_version = _integer(row[0])
+    if proof_version != INVENTORY_PROOF_VERSION:
+        return InventoryProofObservation(
+            "proof_version_unsupported",
+            str(proof_version),
+        )
+    if str(row[1] or "") != fence_blocked_at:
+        return InventoryProofObservation("proof_fence_epoch_mismatch")
+    if not str(row[6] or "").strip():
+        return InventoryProofObservation("worker_quiescence_unproven")
+
+    registry = registry_inventory_fingerprint(conn)
+    if str(row[2] or "") != registry.digest or _integer(row[3]) != registry.entry_count:
+        return InventoryProofObservation("registry_inventory_changed")
+
+    worker = worker_inventory_fingerprint(conn)
+    if str(row[4] or "") != worker.digest or _integer(row[5]) != worker.entry_count:
+        return InventoryProofObservation("worker_inventory_changed")
+
+    live_worker = _live_local_worker(conn)
+    if live_worker is not None:
+        return InventoryProofObservation("worker_process_live", live_worker)
+    return InventoryProofObservation("valid")
+
+
+def registry_inventory_fingerprint(
+    conn: sqlite3.Connection,
+) -> InventoryFingerprint:
+    """Hash the complete dispatch registry in stable row order."""
+
+    rows = conn.execute(
+        """
+        SELECT launch_id, workflow_id, temporal_run_id,
+               workflow_type, state, created_at, updated_at
+        FROM workflow_dispatch_registry
+        ORDER BY launch_id
+        """
+    ).fetchall()
+    return _fingerprint(rows)
+
+
+def worker_inventory_fingerprint(
+    conn: sqlite3.Connection,
+) -> InventoryFingerprint:
+    """Hash worker identities and their last exact activity observations."""
+
+    if WORKER_HEARTBEAT_TABLE not in _table_names(conn):
+        return _fingerprint(())
+    columns = {str(row[1]) for row in conn.execute(f"PRAGMA table_info({WORKER_HEARTBEAT_TABLE})").fetchall()}
+    selected = (
+        "worker_id",
+        "component",
+        "pid",
+        "hostname",
+        "app_dir",
+        "db_path",
+        "task_queue",
+        "started_at",
+        "last_seen_at",
+        "active_activity_count",
+        "heartbeat_schema_version",
+    )
+    expressions = [column if column in columns else f"NULL AS {column}" for column in selected]
+    rows = conn.execute(
+        f"""
+        SELECT {", ".join(expressions)}
+        FROM {WORKER_HEARTBEAT_TABLE}
+        ORDER BY worker_id
+        """
+    ).fetchall()
+    return _fingerprint(rows)
+
+
+def _live_local_worker(conn: sqlite3.Connection) -> str | None:
+    if WORKER_HEARTBEAT_TABLE not in _table_names(conn):
+        return None
+    columns = {str(row[1]) for row in conn.execute(f"PRAGMA table_info({WORKER_HEARTBEAT_TABLE})").fetchall()}
+    required = {"worker_id", "component", "pid", "hostname"}
+    if not required.issubset(columns):
+        return "heartbeat_schema_incomplete"
+    rows = conn.execute(
+        f"""
+        SELECT worker_id, pid, hostname
+        FROM {WORKER_HEARTBEAT_TABLE}
+        WHERE component = 'temporal-worker'
+        ORDER BY worker_id
+        """
+    ).fetchall()
+    for worker_id, raw_pid, _hostname in rows:
+        # Hostname is descriptive provenance, not a liveness authority. It can
+        # drift while a worker process remains alive, and a restored heartbeat
+        # can reuse a local PID. Both cases must block until recovery explicitly
+        # retires the stale worker identity.
+        pid = _integer(raw_pid)
+        if pid > 0 and _pid_is_alive(pid):
+            return str(worker_id or pid)
+    return None
+
+
+def _pid_is_alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def _fingerprint(rows: Any) -> InventoryFingerprint:
+    normalized = [[value for value in tuple(row)] for row in rows]
+    payload = json.dumps(
+        normalized,
+        sort_keys=False,
+        separators=(",", ":"),
+        ensure_ascii=True,
+    ).encode("utf-8")
+    return InventoryFingerprint(
+        digest=hashlib.sha256(payload).hexdigest(),
+        entry_count=len(normalized),
+    )
+
+
+def _integer(value: Any) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return -1
+
+
+def _table_names(conn: sqlite3.Connection) -> set[str]:
+    return {
+        str(row[0])
+        for row in conn.execute(
+            """
+            SELECT name
+            FROM sqlite_master
+            WHERE type = 'table'
+            """
+        ).fetchall()
+    }
+
+
+__all__ = [
+    "CONTROL_KEY",
+    "INVENTORY_PROOF_TABLE",
+    "INVENTORY_PROOF_VERSION",
+    "InventoryFingerprint",
+    "InventoryProofObservation",
+    "registry_inventory_fingerprint",
+    "validate_identity_cutover_inventory_proof",
+    "worker_inventory_fingerprint",
+]

--- a/workers/automation/src/jobctrl/infrastructure/temporal/workflow_dispatch_control.py
+++ b/workers/automation/src/jobctrl/infrastructure/temporal/workflow_dispatch_control.py
@@ -70,7 +70,7 @@ class WorkflowDispatchReservation:
 
 def ensure_workflow_dispatch_control_tables(
     conn: sqlite3.Connection,
-) -> tuple[str, str]:
+) -> tuple[str, str, str]:
     """Create the operational gate and durable launch inventory."""
 
     conn.executescript(
@@ -97,9 +97,25 @@ def ensure_workflow_dispatch_control_tables(
 
         CREATE INDEX IF NOT EXISTS idx_workflow_dispatch_registry_state
         ON workflow_dispatch_registry(state, workflow_type, created_at);
+
+        CREATE TABLE IF NOT EXISTS workflow_identity_cutover_inventory_proof (
+            control_key                TEXT PRIMARY KEY,
+            proof_version              INTEGER NOT NULL,
+            fence_blocked_at            TEXT NOT NULL,
+            registry_inventory_digest  TEXT NOT NULL,
+            registry_entry_count       INTEGER NOT NULL,
+            worker_inventory_digest    TEXT NOT NULL,
+            worker_entry_count         INTEGER NOT NULL,
+            worker_quiescent_at         TEXT NOT NULL,
+            created_at                  TEXT NOT NULL
+        );
         """
     )
-    return ("workflow_dispatch_control", "workflow_dispatch_registry")
+    return (
+        "workflow_dispatch_control",
+        "workflow_dispatch_registry",
+        "workflow_identity_cutover_inventory_proof",
+    )
 
 
 @asynccontextmanager
@@ -299,6 +315,16 @@ def _write_workflow_dispatch_gate(
     try:
         ensure_workflow_dispatch_control_tables(conn)
         with conn:
+            # A proof is bound to one exact fence epoch. Re-activating or
+            # releasing the fence invalidates it before any later preflight can
+            # mistake stale recovery evidence for the current handoff.
+            conn.execute(
+                """
+                DELETE FROM workflow_identity_cutover_inventory_proof
+                WHERE control_key = ?
+                """,
+                (_CONTROL_KEY,),
+            )
             if blocked:
                 conn.execute(
                     """

--- a/workers/automation/tests/test_identity_cutover_proof.py
+++ b/workers/automation/tests/test_identity_cutover_proof.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+import os
+import socket
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from jobctrl.database import close_connection, init_db
+from jobctrl.infrastructure.temporal.identity_cutover_proof import (
+    CONTROL_KEY,
+    INVENTORY_PROOF_VERSION,
+    registry_inventory_fingerprint,
+    validate_identity_cutover_inventory_proof,
+    worker_inventory_fingerprint,
+)
+from jobctrl.infrastructure.temporal.workflow_dispatch_control import (
+    set_workflow_dispatches_blocked,
+)
+
+
+@pytest.fixture
+def db_path(tmp_path: Path) -> Path:
+    path = tmp_path / "jobctrl.db"
+    conn = init_db(path)
+    conn.commit()
+    close_connection(path)
+    return path
+
+
+def _fence_epoch(db_path: Path) -> str:
+    with sqlite3.connect(db_path) as conn:
+        return str(
+            conn.execute(
+                """
+                SELECT blocked_at
+                FROM workflow_dispatch_control
+                WHERE control_key = ?
+                """,
+                (CONTROL_KEY,),
+            ).fetchone()[0]
+        )
+
+
+def _seal(db_path: Path) -> None:
+    with sqlite3.connect(db_path) as conn:
+        registry = registry_inventory_fingerprint(conn)
+        workers = worker_inventory_fingerprint(conn)
+        fence_blocked_at = str(
+            conn.execute(
+                """
+                SELECT blocked_at
+                FROM workflow_dispatch_control
+                WHERE control_key = ?
+                """,
+                (CONTROL_KEY,),
+            ).fetchone()[0]
+        )
+        conn.execute(
+            """
+            INSERT INTO workflow_identity_cutover_inventory_proof (
+                control_key, proof_version, fence_blocked_at,
+                registry_inventory_digest, registry_entry_count,
+                worker_inventory_digest, worker_entry_count,
+                worker_quiescent_at, created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                CONTROL_KEY,
+                INVENTORY_PROOF_VERSION,
+                fence_blocked_at,
+                registry.digest,
+                registry.entry_count,
+                workers.digest,
+                workers.entry_count,
+                "2026-07-30T00:00:01+00:00",
+                "2026-07-30T00:00:01+00:00",
+            ),
+        )
+
+
+def _block(db_path: Path) -> None:
+    set_workflow_dispatches_blocked(
+        blocked=True,
+        reason="identity-cutover",
+        db_path=db_path,
+    )
+
+
+def test_inventory_proof_is_missing_until_recovery_seals_current_fence(
+    db_path: Path,
+) -> None:
+    _block(db_path)
+
+    with sqlite3.connect(db_path) as conn:
+        result = validate_identity_cutover_inventory_proof(
+            conn,
+            fence_blocked_at=_fence_epoch(db_path),
+        )
+
+    assert result.state == "proof_missing"
+
+
+def test_inventory_proof_validates_exact_registry_and_worker_inventories(
+    db_path: Path,
+) -> None:
+    _block(db_path)
+    _seal(db_path)
+
+    with sqlite3.connect(db_path) as conn:
+        result = validate_identity_cutover_inventory_proof(
+            conn,
+            fence_blocked_at=_fence_epoch(db_path),
+        )
+
+    assert result.valid is True
+
+
+def test_inventory_proof_fails_after_registry_membership_changes(
+    db_path: Path,
+) -> None:
+    _block(db_path)
+    _seal(db_path)
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            INSERT INTO workflow_dispatch_registry (
+                launch_id, workflow_id, temporal_run_id,
+                workflow_type, state, created_at, updated_at
+            ) VALUES (
+                'late-launch', 'late-workflow', NULL,
+                'JobPipelineWorkflow', 'uncertain', ?, ?
+            )
+            """,
+            (
+                "2026-07-30T00:00:02+00:00",
+                "2026-07-30T00:00:02+00:00",
+            ),
+        )
+
+    with sqlite3.connect(db_path) as conn:
+        result = validate_identity_cutover_inventory_proof(
+            conn,
+            fence_blocked_at=_fence_epoch(db_path),
+        )
+
+    assert result.state == "registry_inventory_changed"
+
+
+def test_reactivating_fence_invalidates_prior_inventory_proof(
+    db_path: Path,
+) -> None:
+    _block(db_path)
+    _seal(db_path)
+
+    _block(db_path)
+
+    with sqlite3.connect(db_path) as conn:
+        proof_count = conn.execute(
+            """
+            SELECT COUNT(*)
+            FROM workflow_identity_cutover_inventory_proof
+            """
+        ).fetchone()[0]
+
+    assert proof_count == 0
+
+
+@pytest.mark.parametrize(
+    "recorded_hostname",
+    [
+        socket.gethostname(),
+        "hostname-before-local-drift",
+    ],
+)
+def test_inventory_proof_cannot_certify_a_live_worker_pid(
+    db_path: Path,
+    recorded_hostname: str,
+) -> None:
+    _block(db_path)
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            CREATE TABLE worker_runtime_heartbeats (
+                worker_id TEXT PRIMARY KEY,
+                component TEXT NOT NULL,
+                pid INTEGER NOT NULL,
+                hostname TEXT NOT NULL
+            )
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO worker_runtime_heartbeats (
+                worker_id, component, pid, hostname
+            ) VALUES (?, 'temporal-worker', ?, ?)
+            """,
+            ("live-worker", os.getpid(), recorded_hostname),
+        )
+    _seal(db_path)
+
+    with sqlite3.connect(db_path) as conn:
+        result = validate_identity_cutover_inventory_proof(
+            conn,
+            fence_blocked_at=_fence_epoch(db_path),
+        )
+
+    assert result.state == "worker_process_live"
+    assert result.detail == "live-worker"


### PR DESCRIPTION
## What changed

- add a durable, fence-epoch-bound inventory proof for the stable JobId cutover
- fingerprint the complete dispatch registry and worker heartbeat inventory
- fail closed when proof metadata, inventory digests, worker schema, or recorded worker PID liveness cannot establish quiescence
- invalidate any prior proof atomically whenever the dispatch fence is activated again or released

## Why

The exact-run cutover preflight must not interpret an empty rebuildable projection as proof that pre-upgrade Temporal executions do not exist. This slice defines the durable recovery/handoff contract that a later recovery step must seal before migration readiness can be evaluated.

This is stacked on #561 and intentionally contains only the proof contract. The executable Temporal inventory and migration preflight follow in the next stack slice.

## Validation

- `PYTHONPATH=workers/automation/src /Users/eloibarti/Github/JobHunter/workers/automation/.venv/bin/python -m pytest workers/automation/tests/test_identity_cutover_proof.py workers/automation/tests/test_workflow_dispatch_control.py -q` — 11 passed
- targeted Ruff checks — passed
- `git diff --cached --check` — passed
- independent Tier 3 groundwork review — PASS, no findings

Product-path QA is deferred to the first stack phase that exposes the executable recovery/preflight path.