### PR TITLE
feat(workflows): retain cutover lifecycle lease

### DIFF
--- a/workers/automation/src/jobctrl/cli.py
+++ b/workers/automation/src/jobctrl/cli.py
@@ -10,7 +10,7 @@ import sqlite3
 import time
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Awaitable, Callable, Optional
 
 import httpx
 import typer
@@ -2263,13 +2263,6 @@ def worker(
     ),
 ) -> None:
     """Run the long-lived JobCtrl Temporal worker."""
-    _bootstrap()
-
-    # Verify the browser this worker needs is installed before we connect to
-    # Temporal and start accepting activities — a missing binary must surface
-    # here, not two hours into a Discover run.
-    _preflight_browsers_or_exit()
-
     from jobctrl.infrastructure.temporal import (
         JOBCTRL_TASK_QUEUE,
         build_worker,
@@ -2285,6 +2278,13 @@ def worker(
         write_worker_heartbeat,
     )
     queue = task_queue or JOBCTRL_TASK_QUEUE
+
+    def _prepare() -> None:
+        _bootstrap()
+        # Verify the browser this worker needs is installed before we connect
+        # to Temporal and start accepting activities — a missing binary must
+        # surface here, not two hours into a Discover run.
+        _preflight_browsers_or_exit()
 
     async def _run() -> None:
         client = await get_temporal_client()
@@ -2360,11 +2360,43 @@ def worker(
     from jobctrl.infrastructure.observability import shutdown_otel
 
     try:
-        asyncio.run(_run())
+        asyncio.run(
+            _run_worker_with_dispatch_lease(
+                _run,
+                db_path=current_runtime_identity().db_path,
+                prepare_worker=_prepare,
+            )
+        )
     finally:
         # Flush any in-flight spans so the BatchSpanProcessor doesn't drop
         # them on Ctrl-C.
         shutdown_otel()
+
+
+async def _run_worker_with_dispatch_lease(
+    run_worker: Callable[[], Awaitable[None]],
+    *,
+    db_path: Path | str,
+    prepare_worker: Callable[[], None] | None = None,
+) -> None:
+    """Hold the shared process fence for the complete worker lifetime."""
+
+    from jobctrl.infrastructure.temporal.workflow_dispatch_control import (
+        WorkflowDispatchFencedError,
+        workflow_dispatch_read_lock,
+        workflow_dispatches_blocked,
+    )
+
+    async with workflow_dispatch_read_lock(
+        db_path=db_path,
+    ):
+        if workflow_dispatches_blocked(db_path):
+            raise WorkflowDispatchFencedError(
+                "worker startup is blocked for the stable JobId cutover"
+            )
+        if prepare_worker is not None:
+            prepare_worker()
+        await run_worker()
 
 
 async def _worker_heartbeat_loop(

--- a/workers/automation/src/jobctrl/infrastructure/temporal/identity_cutover_proof.py
+++ b/workers/automation/src/jobctrl/infrastructure/temporal/identity_cutover_proof.py
@@ -33,9 +33,22 @@ class InventoryFingerprint:
 
 
 @dataclass(frozen=True)
+class InventoryProofIdentity:
+    """Stable proof generation and exact Temporal authority binding."""
+
+    proof_id: str
+    fence_blocked_at: str
+    temporal_namespace: str
+    temporal_namespace_id: str
+    authority_workflow_id: str
+    authority_run_id: str
+
+
+@dataclass(frozen=True)
 class InventoryProofObservation:
     state: str
     detail: str | None = None
+    identity: InventoryProofIdentity | None = None
 
     @property
     def valid(self) -> bool:
@@ -56,10 +69,12 @@ def validate_identity_cutover_inventory_proof(
         return InventoryProofObservation("proof_table_missing")
     row = conn.execute(
         f"""
-        SELECT proof_version, fence_blocked_at,
+        SELECT proof_version, proof_id, fence_blocked_at,
                registry_inventory_digest, registry_entry_count,
                worker_inventory_digest, worker_entry_count,
-               worker_quiescent_at
+               worker_quiescent_at, temporal_namespace,
+               temporal_namespace_id, authority_workflow_id,
+               authority_run_id
         FROM {INVENTORY_PROOF_TABLE}
         WHERE control_key = ?
         """,
@@ -74,23 +89,50 @@ def validate_identity_cutover_inventory_proof(
             "proof_version_unsupported",
             str(proof_version),
         )
-    if str(row[1] or "") != fence_blocked_at:
+    proof_id = str(row[1] or "").strip()
+    if not proof_id:
+        return InventoryProofObservation("proof_identity_missing")
+    if str(row[2] or "") != fence_blocked_at:
         return InventoryProofObservation("proof_fence_epoch_mismatch")
-    if not str(row[6] or "").strip():
+    if not str(row[7] or "").strip():
         return InventoryProofObservation("worker_quiescence_unproven")
 
+    temporal_namespace = str(row[8] or "").strip()
+    temporal_namespace_id = str(row[9] or "").strip()
+    authority_workflow_id = str(row[10] or "").strip()
+    authority_run_id = str(row[11] or "").strip()
+    if not all(
+        (
+            temporal_namespace,
+            temporal_namespace_id,
+            authority_workflow_id,
+            authority_run_id,
+        )
+    ):
+        return InventoryProofObservation("temporal_authority_unproven")
+
     registry = registry_inventory_fingerprint(conn)
-    if str(row[2] or "") != registry.digest or _integer(row[3]) != registry.entry_count:
+    if str(row[3] or "") != registry.digest or _integer(row[4]) != registry.entry_count:
         return InventoryProofObservation("registry_inventory_changed")
 
     worker = worker_inventory_fingerprint(conn)
-    if str(row[4] or "") != worker.digest or _integer(row[5]) != worker.entry_count:
+    if str(row[5] or "") != worker.digest or _integer(row[6]) != worker.entry_count:
         return InventoryProofObservation("worker_inventory_changed")
 
     live_worker = _live_local_worker(conn)
     if live_worker is not None:
         return InventoryProofObservation("worker_process_live", live_worker)
-    return InventoryProofObservation("valid")
+    return InventoryProofObservation(
+        "valid",
+        identity=InventoryProofIdentity(
+            proof_id=proof_id,
+            fence_blocked_at=fence_blocked_at,
+            temporal_namespace=temporal_namespace,
+            temporal_namespace_id=temporal_namespace_id,
+            authority_workflow_id=authority_workflow_id,
+            authority_run_id=authority_run_id,
+        ),
+    )
 
 
 def registry_inventory_fingerprint(
@@ -216,6 +258,7 @@ __all__ = [
     "INVENTORY_PROOF_TABLE",
     "INVENTORY_PROOF_VERSION",
     "InventoryFingerprint",
+    "InventoryProofIdentity",
     "InventoryProofObservation",
     "registry_inventory_fingerprint",
     "validate_identity_cutover_inventory_proof",

--- a/workers/automation/src/jobctrl/infrastructure/temporal/workflow_dispatch_control.py
+++ b/workers/automation/src/jobctrl/infrastructure/temporal/workflow_dispatch_control.py
@@ -5,8 +5,9 @@ contacting Temporal. A shared filesystem lock covers that reservation and the
 remote start call. Cutover orchestration takes the corresponding exclusive
 lock before blocking starts, so it cannot race an in-flight dispatch.
 
-Temporal-owned schedules do not pass through this boundary; cutover
-orchestration must pause them separately before it blocks direct dispatch.
+Temporal-owned schedules do not pass through direct reservations; cutover
+activation blocks direct dispatch and pauses those schedules while holding the
+same exclusive fence.
 The durable launch inventory deliberately treats client errors as uncertain: Temporal
 may have accepted a start even when the response was lost. A later preflight
 must reconcile every reserved, uncertain, or dispatched launch with an exact
@@ -48,6 +49,10 @@ class UnregisteredWorkflowDispatchError(RuntimeError):
     """Raised when a workflow has no explicit identity-cutover policy."""
 
 
+class IdentityCutoverLeaseError(RuntimeError):
+    """Raised when cutover work does not own the exclusive process fence."""
+
+
 @dataclass
 class WorkflowDispatchReservation:
     launch_id: str
@@ -66,6 +71,29 @@ class WorkflowDispatchReservation:
         )
         self.temporal_run_id = str(run_id) if run_id else None
         self.dispatch_confirmed = True
+
+
+@dataclass
+class IdentityCutoverLease:
+    """Exclusive process fence retained through preflight and migration."""
+
+    db_path: Path
+    lease_id: str
+    _active: bool = True
+
+    def assert_active(
+        self,
+        *,
+        db_path: Path | str,
+    ) -> None:
+        if not self._active:
+            raise IdentityCutoverLeaseError(
+                "identity cutover lease is no longer active"
+            )
+        if self.db_path.resolve() != Path(db_path).resolve():
+            raise IdentityCutoverLeaseError(
+                "identity cutover lease belongs to a different database"
+            )
 
 
 def ensure_workflow_dispatch_control_tables(
@@ -101,21 +129,53 @@ def ensure_workflow_dispatch_control_tables(
         CREATE TABLE IF NOT EXISTS workflow_identity_cutover_inventory_proof (
             control_key                TEXT PRIMARY KEY,
             proof_version              INTEGER NOT NULL,
+            proof_id                   TEXT NOT NULL,
             fence_blocked_at            TEXT NOT NULL,
             registry_inventory_digest  TEXT NOT NULL,
             registry_entry_count       INTEGER NOT NULL,
             worker_inventory_digest    TEXT NOT NULL,
             worker_entry_count         INTEGER NOT NULL,
             worker_quiescent_at         TEXT NOT NULL,
+            temporal_namespace          TEXT NOT NULL,
+            temporal_namespace_id       TEXT NOT NULL,
+            authority_workflow_id       TEXT NOT NULL,
+            authority_run_id            TEXT NOT NULL,
             created_at                  TEXT NOT NULL
         );
         """
     )
+    _ensure_identity_cutover_proof_columns(conn)
     return (
         "workflow_dispatch_control",
         "workflow_dispatch_registry",
         "workflow_identity_cutover_inventory_proof",
     )
+
+
+def _ensure_identity_cutover_proof_columns(
+    conn: sqlite3.Connection,
+) -> None:
+    columns = {
+        str(row[1])
+        for row in conn.execute(
+            """
+            PRAGMA table_info(workflow_identity_cutover_inventory_proof)
+            """
+        ).fetchall()
+    }
+    additions = {
+        "proof_id": "TEXT NOT NULL DEFAULT ''",
+        "temporal_namespace": "TEXT NOT NULL DEFAULT ''",
+        "temporal_namespace_id": "TEXT NOT NULL DEFAULT ''",
+        "authority_workflow_id": "TEXT NOT NULL DEFAULT ''",
+        "authority_run_id": "TEXT NOT NULL DEFAULT ''",
+    }
+    for column, declaration in additions.items():
+        if column not in columns:
+            conn.execute(
+                "ALTER TABLE workflow_identity_cutover_inventory_proof "
+                f"ADD COLUMN {column} {declaration}"
+            )
 
 
 @asynccontextmanager
@@ -133,6 +193,38 @@ async def workflow_dispatch_read_lock(
     try:
         yield resolved_path
     finally:
+        _release_lock(lock_fd)
+
+
+@asynccontextmanager
+async def identity_cutover_exclusive_lease(
+    *,
+    db_path: Path | str | None = None,
+) -> AsyncIterator[IdentityCutoverLease]:
+    """Own the process fence continuously through preflight and migration.
+
+    Direct dispatches and supported worker processes hold the shared side.
+    Acquiring this lease therefore proves those processes have drained and
+    prevents their restart until the migration transaction is complete.
+    """
+
+    resolved_path = _resolve_db_path(db_path)
+    lock_fd = await _acquire_lock_async(
+        _lock_path(resolved_path),
+        fcntl.LOCK_EX,
+    )
+    lease = IdentityCutoverLease(
+        db_path=resolved_path,
+        lease_id=uuid.uuid4().hex,
+    )
+    try:
+        if not workflow_dispatches_blocked(resolved_path):
+            raise IdentityCutoverLeaseError(
+                "workflow dispatches must be blocked before cutover lease acquisition"
+            )
+        yield lease
+    finally:
+        lease._active = False
         _release_lock(lock_fd)
 
 
@@ -464,11 +556,14 @@ def _utc_now() -> str:
 
 
 __all__ = [
+    "IdentityCutoverLease",
+    "IdentityCutoverLeaseError",
     "UnregisteredWorkflowDispatchError",
     "WorkflowDispatchReservation",
     "WorkflowDispatchFencedError",
     "activate_workflow_dispatch_fence",
     "ensure_workflow_dispatch_control_tables",
+    "identity_cutover_exclusive_lease",
     "reserve_workflow_dispatch",
     "set_workflow_dispatches_blocked",
     "workflow_dispatch_read_lock",

--- a/workers/automation/tests/test_identity_cutover_proof.py
+++ b/workers/automation/tests/test_identity_cutover_proof.py
@@ -11,11 +11,13 @@ from jobctrl.database import close_connection, init_db
 from jobctrl.infrastructure.temporal.identity_cutover_proof import (
     CONTROL_KEY,
     INVENTORY_PROOF_VERSION,
+    InventoryProofIdentity,
     registry_inventory_fingerprint,
     validate_identity_cutover_inventory_proof,
     worker_inventory_fingerprint,
 )
 from jobctrl.infrastructure.temporal.workflow_dispatch_control import (
+    ensure_workflow_dispatch_control_tables,
     set_workflow_dispatches_blocked,
 )
 
@@ -43,7 +45,15 @@ def _fence_epoch(db_path: Path) -> str:
         )
 
 
-def _seal(db_path: Path) -> None:
+def _seal(
+    db_path: Path,
+    *,
+    proof_id: str = "proof-one",
+    temporal_namespace: str = "default",
+    temporal_namespace_id: str = "namespace-id-one",
+    authority_workflow_id: str = "cutover-authority-marker",
+    authority_run_id: str = "marker-run-one",
+) -> None:
     with sqlite3.connect(db_path) as conn:
         registry = registry_inventory_fingerprint(conn)
         workers = worker_inventory_fingerprint(conn)
@@ -60,21 +70,28 @@ def _seal(db_path: Path) -> None:
         conn.execute(
             """
             INSERT INTO workflow_identity_cutover_inventory_proof (
-                control_key, proof_version, fence_blocked_at,
+                control_key, proof_version, proof_id, fence_blocked_at,
                 registry_inventory_digest, registry_entry_count,
                 worker_inventory_digest, worker_entry_count,
-                worker_quiescent_at, created_at
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                worker_quiescent_at, temporal_namespace,
+                temporal_namespace_id, authority_workflow_id,
+                authority_run_id, created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 CONTROL_KEY,
                 INVENTORY_PROOF_VERSION,
+                proof_id,
                 fence_blocked_at,
                 registry.digest,
                 registry.entry_count,
                 workers.digest,
                 workers.entry_count,
                 "2026-07-30T00:00:01+00:00",
+                temporal_namespace,
+                temporal_namespace_id,
+                authority_workflow_id,
+                authority_run_id,
                 "2026-07-30T00:00:01+00:00",
             ),
         )
@@ -115,6 +132,87 @@ def test_inventory_proof_validates_exact_registry_and_worker_inventories(
         )
 
     assert result.valid is True
+    assert result.identity == InventoryProofIdentity(
+        proof_id="proof-one",
+        fence_blocked_at=_fence_epoch(db_path),
+        temporal_namespace="default",
+        temporal_namespace_id="namespace-id-one",
+        authority_workflow_id="cutover-authority-marker",
+        authority_run_id="marker-run-one",
+    )
+
+
+@pytest.mark.parametrize(
+    ("field", "expected_state"),
+    [
+        ("proof_id", "proof_identity_missing"),
+        ("temporal_namespace", "temporal_authority_unproven"),
+        ("temporal_namespace_id", "temporal_authority_unproven"),
+        ("authority_workflow_id", "temporal_authority_unproven"),
+        ("authority_run_id", "temporal_authority_unproven"),
+    ],
+)
+def test_inventory_proof_requires_generation_and_temporal_authority(
+    db_path: Path,
+    field: str,
+    expected_state: str,
+) -> None:
+    _block(db_path)
+    values = {
+        "proof_id": "proof-one",
+        "temporal_namespace": "default",
+        "temporal_namespace_id": "namespace-id-one",
+        "authority_workflow_id": "cutover-authority-marker",
+        "authority_run_id": "marker-run-one",
+    }
+    values[field] = ""
+    _seal(db_path, **values)
+
+    with sqlite3.connect(db_path) as conn:
+        result = validate_identity_cutover_inventory_proof(
+            conn,
+            fence_blocked_at=_fence_epoch(db_path),
+        )
+
+    assert result.state == expected_state
+    assert result.identity is None
+
+
+def test_control_table_upgrade_adds_fail_closed_proof_authority_columns(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "legacy-proof.db"
+    with sqlite3.connect(path) as conn:
+        conn.execute(
+            """
+            CREATE TABLE workflow_identity_cutover_inventory_proof (
+                control_key                TEXT PRIMARY KEY,
+                proof_version              INTEGER NOT NULL,
+                fence_blocked_at            TEXT NOT NULL,
+                registry_inventory_digest  TEXT NOT NULL,
+                registry_entry_count       INTEGER NOT NULL,
+                worker_inventory_digest    TEXT NOT NULL,
+                worker_entry_count         INTEGER NOT NULL,
+                worker_quiescent_at         TEXT NOT NULL,
+                created_at                  TEXT NOT NULL
+            )
+            """
+        )
+        ensure_workflow_dispatch_control_tables(conn)
+        columns = {
+            str(row[1]): str(row[4] or "")
+            for row in conn.execute(
+                """
+                PRAGMA table_info(workflow_identity_cutover_inventory_proof)
+                """
+            )
+        }
+
+    assert columns["proof_id"] == "''"
+    assert columns["temporal_namespace"] == "''"
+    assert columns["temporal_namespace_id"] == "''"
+    assert columns["authority_workflow_id"] == "''"
+    assert columns["authority_run_id"] == "''"
 
 
 def test_inventory_proof_fails_after_registry_membership_changes(

--- a/workers/automation/tests/test_worker_dispatch_lease.py
+++ b/workers/automation/tests/test_worker_dispatch_lease.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from jobctrl import cli, config
+from jobctrl.cli import _run_worker_with_dispatch_lease
+from jobctrl.database import close_connection, init_db
+from jobctrl.infrastructure.temporal.workflow_dispatch_control import (
+    WorkflowDispatchFencedError,
+    set_workflow_dispatches_blocked,
+)
+
+
+@pytest.fixture
+def db_path(tmp_path: Path) -> Path:
+    path = tmp_path / "jobctrl.db"
+    conn = init_db(path)
+    conn.commit()
+    close_connection(path)
+    return path
+
+
+@pytest.mark.asyncio
+async def test_worker_runtime_refuses_blocked_cutover_gate(
+    db_path: Path,
+) -> None:
+    set_workflow_dispatches_blocked(
+        blocked=True,
+        reason="identity-cutover",
+        db_path=db_path,
+    )
+    prepared = False
+    entered = False
+
+    def _prepare() -> None:
+        nonlocal prepared
+        prepared = True
+
+    async def _run() -> None:
+        nonlocal entered
+        entered = True
+
+    with pytest.raises(
+        WorkflowDispatchFencedError,
+        match="worker startup is blocked",
+    ):
+        await _run_worker_with_dispatch_lease(
+            _run,
+            db_path=str(db_path),
+            prepare_worker=_prepare,
+        )
+
+    assert prepared is False
+    assert entered is False
+
+
+def test_worker_command_checks_fence_before_bootstrap(
+    db_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    set_workflow_dispatches_blocked(
+        blocked=True,
+        reason="identity-cutover",
+        db_path=db_path,
+    )
+    bootstrapped = False
+    browser_checked = False
+
+    def _bootstrap() -> None:
+        nonlocal bootstrapped
+        bootstrapped = True
+
+    def _browser_preflight() -> None:
+        nonlocal browser_checked
+        browser_checked = True
+
+    monkeypatch.setattr(config, "DB_PATH", db_path)
+    monkeypatch.setattr(config, "APP_DIR", db_path.parent)
+    monkeypatch.setattr(cli, "_bootstrap", _bootstrap)
+    monkeypatch.setattr(
+        cli,
+        "_preflight_browsers_or_exit",
+        _browser_preflight,
+    )
+    monkeypatch.setattr(
+        "jobctrl.infrastructure.observability.shutdown_otel",
+        lambda: None,
+    )
+
+    with pytest.raises(
+        WorkflowDispatchFencedError,
+        match="worker startup is blocked",
+    ):
+        cli.worker(task_queue=None)
+
+    assert bootstrapped is False
+    assert browser_checked is False
+
+
+@pytest.mark.asyncio
+async def test_worker_runtime_holds_shared_fence_until_shutdown(
+    db_path: Path,
+) -> None:
+    entered = asyncio.Event()
+    release = asyncio.Event()
+
+    async def _run() -> None:
+        entered.set()
+        await release.wait()
+
+    worker_task = asyncio.create_task(
+        _run_worker_with_dispatch_lease(
+            _run,
+            db_path=str(db_path),
+        )
+    )
+    await entered.wait()
+    fence_task = asyncio.create_task(
+        asyncio.to_thread(
+            set_workflow_dispatches_blocked,
+            blocked=True,
+            reason="identity-cutover",
+            db_path=db_path,
+        )
+    )
+    await asyncio.sleep(0.1)
+    assert fence_task.done() is False
+
+    release.set()
+    await worker_task
+    assert await fence_task is True

--- a/workers/automation/tests/test_workflow_dispatch_control.py
+++ b/workers/automation/tests/test_workflow_dispatch_control.py
@@ -9,10 +9,13 @@ import pytest
 
 from jobctrl.database import close_connection, init_db
 from jobctrl.infrastructure.temporal.workflow_dispatch_control import (
+    IdentityCutoverLeaseError,
     UnregisteredWorkflowDispatchError,
     WorkflowDispatchFencedError,
+    identity_cutover_exclusive_lease,
     reserve_workflow_dispatch,
     set_workflow_dispatches_blocked,
+    workflow_dispatch_read_lock,
     workflow_dispatches_blocked,
 )
 from jobctrl.pipeline.workflow import JobPipelineWorkflow
@@ -167,6 +170,54 @@ async def test_exclusive_gate_waits_for_inflight_reserved_start(
     await dispatch_task
     assert await fence_task is True
     assert workflow_dispatches_blocked(db_path) is True
+
+
+@pytest.mark.asyncio
+async def test_cutover_lease_requires_blocked_dispatch_gate(
+    db_path: Path,
+) -> None:
+    with pytest.raises(
+        IdentityCutoverLeaseError,
+        match="must be blocked",
+    ):
+        async with identity_cutover_exclusive_lease(
+            db_path=db_path,
+        ):
+            pytest.fail("an open dispatch gate must not yield a cutover lease")
+
+
+@pytest.mark.asyncio
+async def test_cutover_lease_excludes_worker_runtime_for_full_lifetime(
+    db_path: Path,
+) -> None:
+    set_workflow_dispatches_blocked(
+        blocked=True,
+        reason="identity-cutover",
+        db_path=db_path,
+    )
+    runtime_entered = asyncio.Event()
+
+    async def _enter_runtime() -> None:
+        async with workflow_dispatch_read_lock(
+            db_path=db_path,
+        ):
+            runtime_entered.set()
+
+    async with identity_cutover_exclusive_lease(
+        db_path=db_path,
+    ) as lease:
+        lease.assert_active(db_path=db_path)
+        runtime_task = asyncio.create_task(_enter_runtime())
+        await asyncio.sleep(0.1)
+        assert runtime_entered.is_set() is False
+
+    with pytest.raises(
+        IdentityCutoverLeaseError,
+        match="no longer active",
+    ):
+        lease.assert_active(db_path=db_path)
+    await runtime_task
+    assert runtime_entered.is_set() is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What changed

- hold the shared dispatch fence before worker bootstrap and for the worker's full lifetime
- add an exclusive cutover lease that must remain active through preflight and migration
- bind recovery proofs to a stable proof generation and exact Temporal namespace/history marker identity
- upgrade earlier proof tables additively while treating unbound legacy rows as invalid

## Why

The stable JobId cutover must exclude worker restarts and database bootstrap writes from validation through migration. Recovery evidence also needs a stable identity that the next exact-run preflight can compare and validate against the paired Temporal history store.

This is a small stacked prerequisite for the exact quiescence preflight. It does not claim to perform the Temporal RPC validation itself.

## Validation

- `ruff check` on the touched Python surfaces
- focused lifecycle/proof/worker tests: 30 passed
- full Python suite: 2,833 passed, 2 skipped
- independent review: PASS
- lifecycle/concurrency QA, including subprocess lock contention and blocked command bootstrap: PASS
- `git diff --cached --check`