### PR TITLE
feat(workflows): declare cutover inventory sources

### DIFF
--- a/workers/automation/src/jobctrl/infrastructure/temporal/registry.py
+++ b/workers/automation/src/jobctrl/infrastructure/temporal/registry.py
@@ -75,11 +75,18 @@ class WorkflowIdentityCutoverPolicy:
     durable job-work relationship that requires the execution to drain. An
     empty tuple is an explicit declaration that the workflow is unrelated to
     job identity; it is never an implicit default.
+
+    ``inventory_sources`` declares every local authority that can identify an
+    exact execution for cutover preflight. A blocking workflow must always
+    participate in the dispatch registry, canonical workflow-event, and
+    workflow-run projection inventories; workflow-specific schedules,
+    deterministic identities, or durable ownership add sources explicitly.
     """
 
     workflow_type: str
     blocks_cutover_when_open: bool
     identity_fields: tuple[str, ...]
+    inventory_sources: tuple[str, ...]
 
 
 WORKFLOW_IDENTITY_CUTOVER_POLICIES: dict[
@@ -90,51 +97,106 @@ WORKFLOW_IDENTITY_CUTOVER_POLICIES: dict[
         workflow_type="DiscoverWorkflow",
         blocks_cutover_when_open=True,
         identity_fields=("durable_discovery_work",),
+        inventory_sources=(
+            "dispatch_registry",
+            "workflow_start_event",
+            "workflow_run_projection",
+            "identity_schedule",
+            "pipeline_child",
+            "discovery_execution",
+            "discovery_search_unit",
+            "pipeline_step_projection",
+        ),
     ),
     JobPipelineWorkflow: WorkflowIdentityCutoverPolicy(
         workflow_type="JobPipelineWorkflow",
         blocks_cutover_when_open=True,
         identity_fields=("job_url", "job_urls"),
+        inventory_sources=(
+            "dispatch_registry",
+            "workflow_start_event",
+            "workflow_run_projection",
+        ),
     ),
     JobPreparationWorkflow: WorkflowIdentityCutoverPolicy(
         workflow_type="JobPreparationWorkflow",
         blocks_cutover_when_open=True,
         identity_fields=("job_url", "idempotency_key"),
+        inventory_sources=(
+            "dispatch_registry",
+            "workflow_start_event",
+            "workflow_run_projection",
+            "discovery_preparation_plan",
+            "preparation_work_item",
+        ),
     ),
     ApplyWorkflow: WorkflowIdentityCutoverPolicy(
         workflow_type="ApplyWorkflow",
         blocks_cutover_when_open=True,
         identity_fields=("job_url", "workflow_id"),
+        inventory_sources=(
+            "dispatch_registry",
+            "workflow_start_event",
+            "workflow_run_projection",
+            "pipeline_child",
+            "job_identity_derived",
+            "auto_apply_loop",
+        ),
     ),
     ManualCaptureImportWorkflow: WorkflowIdentityCutoverPolicy(
         workflow_type="ManualCaptureImportWorkflow",
         blocks_cutover_when_open=True,
         identity_fields=("captured_url", "durable_capture_item"),
+        inventory_sources=(
+            "dispatch_registry",
+            "workflow_start_event",
+            "workflow_run_projection",
+            "manual_capture_queue",
+        ),
     ),
     ProfileImportWorkflow: WorkflowIdentityCutoverPolicy(
         workflow_type="ProfileImportWorkflow",
         blocks_cutover_when_open=False,
         identity_fields=(),
+        inventory_sources=(),
     ),
     CompensationRefreshWorkflow: WorkflowIdentityCutoverPolicy(
         workflow_type="CompensationRefreshWorkflow",
         blocks_cutover_when_open=True,
         identity_fields=("job_url",),
+        inventory_sources=(
+            "dispatch_registry",
+            "workflow_start_event",
+            "workflow_run_projection",
+        ),
     ),
     InterviewPrepWorkflow: WorkflowIdentityCutoverPolicy(
         workflow_type="InterviewPrepWorkflow",
         blocks_cutover_when_open=True,
         identity_fields=("job_url", "workflow_id"),
+        inventory_sources=(
+            "dispatch_registry",
+            "workflow_start_event",
+            "workflow_run_projection",
+            "job_identity_derived",
+        ),
     ),
     ContactResearchWorkflow: WorkflowIdentityCutoverPolicy(
         workflow_type="ContactResearchWorkflow",
         blocks_cutover_when_open=True,
         identity_fields=("job_url",),
+        inventory_sources=(
+            "dispatch_registry",
+            "workflow_start_event",
+            "workflow_run_projection",
+            "contact_research_task",
+        ),
     ),
     DurabilityProbeWorkflow: WorkflowIdentityCutoverPolicy(
         workflow_type="DurabilityProbeWorkflow",
         blocks_cutover_when_open=False,
         identity_fields=(),
+        inventory_sources=(),
     ),
 }
 

--- a/workers/automation/tests/test_temporal_registry.py
+++ b/workers/automation/tests/test_temporal_registry.py
@@ -38,8 +38,12 @@ def test_every_workflow_declares_an_identity_cutover_policy():
         assert policy.workflow_type == definition.name
         if policy.blocks_cutover_when_open:
             assert policy.identity_fields
+            assert "dispatch_registry" in policy.inventory_sources
+            assert "workflow_start_event" in policy.inventory_sources
+            assert "workflow_run_projection" in policy.inventory_sources
         else:
             assert policy.identity_fields == ()
+            assert policy.inventory_sources == ()
 
 
 def test_registry_activities_are_temporal_activity_definitions():


### PR DESCRIPTION
## What changed

- require every Temporal workflow policy to declare its local stable-identity inventory sources
- require identity-blocking workflows to include the dispatch registry, canonical `WorkflowStarted` events, and workflow-run projections
- declare schedule, child-workflow, deterministic-ID, and durable-owner sources where each workflow needs them
- make non-identity workflows explicitly declare an empty inventory contract

## Why

The exact JobId cutover preflight needs a closed, reviewable inventory contract before it can collect candidates. Keeping that declaration separate makes source completeness auditable without mixing it with the larger SQLite and Temporal preflight implementation.

This is declarative groundwork; executable collection and exact Temporal verification are in the next stacked PR.

## Validation

- `pytest -q workers/automation/tests/test_temporal_registry.py` — 4 passed
- focused Ruff — passed
- `git diff --cached --check` — passed
- independent review — PASS