### PR TITLE
feat(workflows): verify exact cutover quiescence

### DIFF
--- a/workers/automation/src/jobctrl/infrastructure/temporal/identity_cutover_preflight.py
+++ b/workers/automation/src/jobctrl/infrastructure/temporal/identity_cutover_preflight.py
@@ -1,0 +1,1342 @@
+"""Authoritative exact-run quiescence checks for the stable JobId cutover.
+
+A fence-epoch recovery proof plus independent SQLite authorities provide a
+closed inventory of exact workflow identifiers. They never decide whether an
+execution is open. Every candidate is checked through
+``DescribeWorkflowExecution``; Temporal visibility/list APIs are intentionally
+outside this module because their absence result is eventually consistent and
+cannot certify quiescence.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from dataclasses import dataclass
+from datetime import timedelta
+from pathlib import Path
+from typing import Any, Literal
+
+from temporalio.api.workflowservice.v1 import DescribeNamespaceRequest
+from temporalio.client import WorkflowExecutionStatus
+from temporalio.service import RPCError, RPCStatusCode
+
+from jobctrl.domain.tenant import LOCAL_TENANT
+from jobctrl.infrastructure.temporal.identity_cutover_proof import (
+    INVENTORY_PROOF_TABLE,
+    InventoryProofIdentity,
+    validate_identity_cutover_inventory_proof,
+)
+from jobctrl.infrastructure.temporal.registry import (
+    WORKFLOW_IDENTITY_CUTOVER_POLICIES,
+    WorkflowIdentityCutoverPolicy,
+)
+from jobctrl.infrastructure.temporal.schedule_cutover import (
+    identity_bearing_schedule_policies,
+)
+from jobctrl.infrastructure.temporal.workflow_dispatch_control import (
+    IdentityCutoverLease,
+)
+
+ExecutionState = Literal[
+    "open",
+    "closed",
+    "not_found",
+    "unavailable",
+    "unknown",
+]
+ScheduleState = Literal[
+    "paused",
+    "not_found",
+    "unpaused",
+    "unavailable",
+    "unknown",
+]
+
+_CONTROL_KEY = "stable-job-id-cutover"
+_OPEN_TEMPORAL_STATES = {
+    WorkflowExecutionStatus.RUNNING,
+}
+_CLOSED_TEMPORAL_STATES = {
+    WorkflowExecutionStatus.COMPLETED,
+    WorkflowExecutionStatus.FAILED,
+    WorkflowExecutionStatus.CANCELED,
+    WorkflowExecutionStatus.TERMINATED,
+    WorkflowExecutionStatus.TIMED_OUT,
+    # Every exact-run candidate also contributes a current/latest handle for
+    # the same Workflow ID. The continued execution is therefore checked
+    # separately; the predecessor run itself is terminal.
+    WorkflowExecutionStatus.CONTINUED_AS_NEW,
+}
+_INVENTORY_TABLES = {
+    "workflow_dispatch_control",
+    "workflow_dispatch_registry",
+    INVENTORY_PROOF_TABLE,
+    "workflow_run_projections",
+    "job_events",
+    "jobs",
+    "manual_capture_queue",
+    "contact_research_tasks",
+    "discovery_execution_jobs",
+    "discovery_search_units",
+    "pipeline_step_projections",
+    "preparation_work_items",
+}
+
+
+@dataclass(frozen=True)
+class WorkflowExecutionCandidate:
+    workflow_type: str
+    workflow_id: str
+    temporal_run_id: str | None
+    sources: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class WorkflowExecutionObservation:
+    candidate: WorkflowExecutionCandidate
+    state: ExecutionState
+    temporal_status: str | None = None
+
+
+@dataclass(frozen=True)
+class ScheduleFenceObservation:
+    schedule_id: str
+    workflow_type: str
+    state: ScheduleState
+
+
+@dataclass(frozen=True)
+class DurableOwnerObservation:
+    source: str
+    state: str
+    count: int
+
+
+@dataclass(frozen=True)
+class IdentityCutoverBlocker:
+    code: str
+    source: str
+    workflow_type: str | None = None
+    workflow_id: str | None = None
+    temporal_run_id: str | None = None
+    detail: str | None = None
+
+
+@dataclass(frozen=True)
+class IdentityCutoverPreflightResult:
+    ready: bool
+    dispatch_gate_blocked: bool
+    candidates: tuple[WorkflowExecutionCandidate, ...]
+    executions: tuple[WorkflowExecutionObservation, ...]
+    schedules: tuple[ScheduleFenceObservation, ...]
+    durable_owners: tuple[DurableOwnerObservation, ...]
+    blockers: tuple[IdentityCutoverBlocker, ...]
+
+
+@dataclass
+class _CandidateAccumulator:
+    workflow_type: str
+    workflow_id: str
+    temporal_run_id: str | None
+    sources: set[str]
+
+
+@dataclass(frozen=True)
+class _LocalIdentityInventory:
+    dispatch_gate_blocked: bool
+    fence_blocked_at: str | None
+    proof_identity: InventoryProofIdentity | None
+    candidates: tuple[WorkflowExecutionCandidate, ...]
+    durable_owners: tuple[DurableOwnerObservation, ...]
+    blockers: tuple[IdentityCutoverBlocker, ...]
+
+
+async def run_identity_cutover_preflight(
+    temporal_client: Any,
+    *,
+    db_path: Path | str,
+    cutover_lease: IdentityCutoverLease,
+    tenant_id: str = str(LOCAL_TENANT),
+) -> IdentityCutoverPreflightResult:
+    """Return readiness while the caller retains the exclusive cutover lease."""
+
+    path = Path(db_path)
+    cutover_lease.assert_active(db_path=path)
+    try:
+        initial = _read_local_inventory(path, tenant_id=tenant_id)
+    except sqlite3.Error:
+        return _result(
+            gate_blocked=False,
+            candidates=(),
+            durable_owners=(),
+            blockers=[
+                IdentityCutoverBlocker(
+                    code="inventory_unreadable",
+                    source="sqlite",
+                )
+            ],
+        )
+
+    blockers = list(initial.blockers)
+    if not initial.dispatch_gate_blocked:
+        blockers.append(
+            IdentityCutoverBlocker(
+                code="dispatch_gate_open",
+                source="workflow_dispatch_control",
+            )
+        )
+
+    # Do not spend remote calls or imply a meaningful Temporal snapshot while
+    # local membership can still grow or its inventory contract is incomplete.
+    if not initial.dispatch_gate_blocked or _has_inventory_blocker(blockers):
+        return _result(
+            gate_blocked=initial.dispatch_gate_blocked,
+            candidates=initial.candidates,
+            durable_owners=initial.durable_owners,
+            blockers=blockers,
+        )
+
+    if initial.proof_identity is None:
+        blockers.append(
+            IdentityCutoverBlocker(
+                code="pre_fence_inventory_unproven",
+                source=INVENTORY_PROOF_TABLE,
+                detail="proof_identity_missing",
+            )
+        )
+        return _result(
+            gate_blocked=initial.dispatch_gate_blocked,
+            candidates=initial.candidates,
+            durable_owners=initial.durable_owners,
+            blockers=blockers,
+        )
+
+    blockers.extend(
+        await _validate_temporal_authority(
+            temporal_client,
+            proof_identity=initial.proof_identity,
+        )
+    )
+    if blockers:
+        return _result(
+            gate_blocked=initial.dispatch_gate_blocked,
+            candidates=initial.candidates,
+            durable_owners=initial.durable_owners,
+            blockers=blockers,
+        )
+
+    schedule_observations, schedule_blockers = await _observe_schedule_fences(
+        temporal_client,
+        tenant_id=tenant_id,
+    )
+    blockers.extend(schedule_blockers)
+
+    execution_observations: list[WorkflowExecutionObservation] = []
+    for candidate in initial.candidates:
+        observation, blocker = await _observe_exact_execution(
+            temporal_client,
+            candidate,
+        )
+        execution_observations.append(observation)
+        if blocker is not None:
+            blockers.append(blocker)
+
+    for owner in initial.durable_owners:
+        blockers.append(
+            IdentityCutoverBlocker(
+                code="durable_owner_nonterminal",
+                source=owner.source,
+                detail=f"{owner.state}:{owner.count}",
+            )
+        )
+
+    # An execution that was open when the local snapshot was read can finish
+    # and commit new durable work before its describe call returns CLOSED.
+    # Require a second identical local inventory, then repeat exact describes.
+    # This turns that TOCTOU window into a retryable blocker instead of a false
+    # quiescence result.
+    if blockers:
+        return _result(
+            gate_blocked=initial.dispatch_gate_blocked,
+            candidates=initial.candidates,
+            executions=execution_observations,
+            schedules=schedule_observations,
+            durable_owners=initial.durable_owners,
+            blockers=blockers,
+        )
+
+    try:
+        final = _read_local_inventory(path, tenant_id=tenant_id)
+    except sqlite3.Error:
+        final = _unreadable_local_inventory()
+
+    blockers.extend(final.blockers)
+    if not final.dispatch_gate_blocked:
+        blockers.append(
+            IdentityCutoverBlocker(
+                code="dispatch_gate_open",
+                source="workflow_dispatch_control",
+            )
+        )
+    if final.fence_blocked_at != initial.fence_blocked_at or final.proof_identity != initial.proof_identity:
+        blockers.append(
+            IdentityCutoverBlocker(
+                code="cutover_proof_changed",
+                source=INVENTORY_PROOF_TABLE,
+            )
+        )
+    if final.candidates != initial.candidates or final.durable_owners != initial.durable_owners:
+        blockers.append(
+            IdentityCutoverBlocker(
+                code="local_inventory_changed",
+                source="sqlite",
+            )
+        )
+    for owner in final.durable_owners:
+        blockers.append(
+            IdentityCutoverBlocker(
+                code="durable_owner_nonterminal",
+                source=owner.source,
+                detail=f"{owner.state}:{owner.count}",
+            )
+        )
+    if blockers:
+        return _result(
+            gate_blocked=final.dispatch_gate_blocked,
+            candidates=final.candidates,
+            schedules=schedule_observations,
+            durable_owners=final.durable_owners,
+            blockers=blockers,
+        )
+
+    final_schedule_observations, final_schedule_blockers = await _observe_schedule_fences(
+        temporal_client,
+        tenant_id=tenant_id,
+    )
+    blockers.extend(final_schedule_blockers)
+    final_execution_observations: list[WorkflowExecutionObservation] = []
+    for candidate in final.candidates:
+        observation, blocker = await _observe_exact_execution(
+            temporal_client,
+            candidate,
+        )
+        final_execution_observations.append(observation)
+        if blocker is not None:
+            blockers.append(blocker)
+
+    # The process handoff proof prevents supported workers from writing after
+    # this boundary. Still take one final SQLite snapshot after the last remote
+    # describe pass so a restarted worker, changed proof, or late activity
+    # commit is observed rather than converted into a false-ready result.
+    try:
+        sealed = _read_local_inventory(path, tenant_id=tenant_id)
+    except sqlite3.Error:
+        sealed = _unreadable_local_inventory()
+    blockers.extend(sealed.blockers)
+    if not sealed.dispatch_gate_blocked:
+        blockers.append(
+            IdentityCutoverBlocker(
+                code="dispatch_gate_open",
+                source="workflow_dispatch_control",
+            )
+        )
+    if sealed.fence_blocked_at != final.fence_blocked_at or sealed.proof_identity != final.proof_identity:
+        blockers.append(
+            IdentityCutoverBlocker(
+                code="cutover_proof_changed",
+                source=INVENTORY_PROOF_TABLE,
+            )
+        )
+    if sealed.candidates != final.candidates or sealed.durable_owners != final.durable_owners:
+        blockers.append(
+            IdentityCutoverBlocker(
+                code="local_inventory_changed",
+                source="sqlite",
+            )
+        )
+    for owner in sealed.durable_owners:
+        blockers.append(
+            IdentityCutoverBlocker(
+                code="durable_owner_nonterminal",
+                source=owner.source,
+                detail=f"{owner.state}:{owner.count}",
+            )
+        )
+
+    cutover_lease.assert_active(db_path=path)
+    return _result(
+        gate_blocked=sealed.dispatch_gate_blocked,
+        candidates=sealed.candidates,
+        executions=final_execution_observations,
+        schedules=final_schedule_observations,
+        durable_owners=sealed.durable_owners,
+        blockers=blockers,
+    )
+
+
+def _read_local_inventory(
+    path: Path,
+    *,
+    tenant_id: str,
+) -> _LocalIdentityInventory:
+    conn = sqlite3.connect(path)
+    conn.row_factory = sqlite3.Row
+    try:
+        return _load_local_inventory(
+            conn,
+            tenant_id=tenant_id,
+        )
+    finally:
+        conn.close()
+
+
+def _load_local_inventory(
+    conn: sqlite3.Connection,
+    *,
+    tenant_id: str,
+) -> _LocalIdentityInventory:
+    policies = _policies_by_type()
+    blockers: list[IdentityCutoverBlocker] = []
+    tables = _table_names(conn)
+    for table in sorted(_INVENTORY_TABLES - tables):
+        blockers.append(
+            IdentityCutoverBlocker(
+                code="inventory_table_missing",
+                source=table,
+            )
+        )
+
+    gate_blocked = False
+    fence_blocked_at: str | None = None
+    if "workflow_dispatch_control" in tables:
+        row = conn.execute(
+            """
+            SELECT blocked_at
+            FROM workflow_dispatch_control
+            WHERE control_key = ?
+            """,
+            (_CONTROL_KEY,),
+        ).fetchone()
+        gate_blocked = row is not None
+        if row is not None:
+            fence_blocked_at = _optional_text(row[0])
+
+    proof_identity: InventoryProofIdentity | None = None
+    if gate_blocked:
+        proof = validate_identity_cutover_inventory_proof(
+            conn,
+            fence_blocked_at=fence_blocked_at,
+        )
+        if not proof.valid:
+            blockers.append(
+                IdentityCutoverBlocker(
+                    code="pre_fence_inventory_unproven",
+                    source=INVENTORY_PROOF_TABLE,
+                    detail=(proof.state if proof.detail is None else f"{proof.state}:{proof.detail}"),
+                )
+            )
+        else:
+            proof_identity = proof.identity
+
+    candidates: dict[
+        tuple[str, str, str | None],
+        _CandidateAccumulator,
+    ] = {}
+
+    if "workflow_dispatch_registry" in tables:
+        rows = conn.execute(
+            """
+            SELECT workflow_type, workflow_id, temporal_run_id
+            FROM workflow_dispatch_registry
+            ORDER BY created_at, launch_id
+            """
+        ).fetchall()
+        for row in rows:
+            _add_registered_candidate(
+                candidates,
+                blockers,
+                policies,
+                workflow_type=str(row["workflow_type"] or ""),
+                workflow_id=str(row["workflow_id"] or ""),
+                temporal_run_id=_optional_text(row["temporal_run_id"]),
+                source="dispatch_registry",
+            )
+
+    if "job_events" in tables:
+        rows = conn.execute(
+            """
+            SELECT event_id, payload_json
+            FROM job_events
+            WHERE event_type = 'WorkflowStarted'
+            ORDER BY event_id
+            """
+        ).fetchall()
+        for row in rows:
+            try:
+                payload = json.loads(str(row["payload_json"] or ""))
+            except (TypeError, ValueError):
+                payload = None
+            if not isinstance(payload, dict):
+                blockers.append(_invalid_workflow_start_event(row["event_id"]))
+                continue
+            raw_tenant = payload.get(
+                "tenantId",
+                payload.get("tenant_id"),
+            )
+            raw_workflow_type = payload.get(
+                "workflowType",
+                payload.get("workflow_type"),
+            )
+            raw_workflow_id = payload.get(
+                "workflowId",
+                payload.get("workflow_id"),
+            )
+            raw_temporal_run_id = payload.get(
+                "temporalRunId",
+                payload.get("temporal_run_id"),
+            )
+            if (
+                not isinstance(raw_tenant, str)
+                or not raw_tenant.strip()
+                or not isinstance(raw_workflow_type, str)
+                or not raw_workflow_type.strip()
+                or not isinstance(raw_workflow_id, str)
+                or not raw_workflow_id.strip()
+                or (raw_temporal_run_id is not None and not isinstance(raw_temporal_run_id, str))
+            ):
+                blockers.append(_invalid_workflow_start_event(row["event_id"]))
+                continue
+            event_tenant = raw_tenant.strip()
+            if event_tenant != tenant_id:
+                continue
+            _add_registered_candidate(
+                candidates,
+                blockers,
+                policies,
+                workflow_type=raw_workflow_type.strip(),
+                workflow_id=raw_workflow_id.strip(),
+                temporal_run_id=_optional_text(raw_temporal_run_id),
+                source="workflow_start_event",
+            )
+
+    if "workflow_run_projections" in tables:
+        rows = conn.execute(
+            """
+            SELECT workflow_type, workflow_id, temporal_run_id
+            FROM workflow_run_projections
+            WHERE tenant_id = ?
+            ORDER BY COALESCE(started_at, finished_at), workflow_id
+            """,
+            (tenant_id,),
+        ).fetchall()
+        for row in rows:
+            _add_registered_candidate(
+                candidates,
+                blockers,
+                policies,
+                workflow_type=str(row["workflow_type"] or ""),
+                workflow_id=str(row["workflow_id"] or ""),
+                temporal_run_id=_optional_text(row["temporal_run_id"]),
+                source="workflow_run_projection",
+            )
+
+    for schedule in identity_bearing_schedule_policies(tenant_id):
+        _add_registered_candidate(
+            candidates,
+            blockers,
+            policies,
+            workflow_type=schedule.workflow_type,
+            workflow_id=schedule.workflow_id,
+            temporal_run_id=None,
+            source="identity_schedule",
+        )
+
+    if "jobs" in tables:
+        from jobctrl.workflow_specs import (
+            apply_workflow_id,
+            interview_prep_workflow_id,
+        )
+
+        rows = conn.execute(
+            """
+            SELECT job_id, url
+            FROM jobs
+            WHERE tenant_id = ?
+            ORDER BY job_id, url
+            """,
+            (tenant_id,),
+        ).fetchall()
+        for row in rows:
+            job_id = _optional_text(row["job_id"])
+            posting_url = _optional_text(row["url"])
+            if job_id is None or posting_url is None:
+                blockers.append(
+                    IdentityCutoverBlocker(
+                        code="job_identity_incomplete",
+                        source="job_identity_derived",
+                        detail=("missing_job_id" if job_id is None else "missing_posting_url"),
+                    )
+                )
+            for job_key in {value for value in (job_id, posting_url) if value is not None}:
+                _add_registered_candidate(
+                    candidates,
+                    blockers,
+                    policies,
+                    workflow_type="ApplyWorkflow",
+                    workflow_id=apply_workflow_id(tenant_id, job_key),
+                    temporal_run_id=None,
+                    source="job_identity_derived",
+                )
+                _add_registered_candidate(
+                    candidates,
+                    blockers,
+                    policies,
+                    workflow_type="InterviewPrepWorkflow",
+                    workflow_id=interview_prep_workflow_id(
+                        tenant_id,
+                        job_key,
+                    ),
+                    temporal_run_id=None,
+                    source="job_identity_derived",
+                )
+
+    from jobctrl.apply.auto_apply import auto_apply_workflow_id
+
+    _add_registered_candidate(
+        candidates,
+        blockers,
+        policies,
+        workflow_type="ApplyWorkflow",
+        workflow_id=auto_apply_workflow_id(tenant_id),
+        temporal_run_id=None,
+        source="auto_apply_loop",
+    )
+
+    if "manual_capture_queue" in tables:
+        from jobctrl.discovery.manual_capture_workflow import (
+            manual_capture_import_workflow_id,
+        )
+
+        rows = conn.execute(
+            """
+            SELECT item_id
+            FROM manual_capture_queue
+            WHERE tenant_id = ?
+            ORDER BY item_id
+            """,
+            (tenant_id,),
+        ).fetchall()
+        for row in rows:
+            item_id = _optional_text(row["item_id"])
+            _add_registered_candidate(
+                candidates,
+                blockers,
+                policies,
+                workflow_type="ManualCaptureImportWorkflow",
+                workflow_id=(
+                    manual_capture_import_workflow_id(
+                        tenant_id,
+                        item_id,
+                    )
+                    if item_id is not None
+                    else ""
+                ),
+                temporal_run_id=None,
+                source="manual_capture_queue",
+            )
+
+    if "contact_research_tasks" in tables:
+        from jobctrl.contact.workflow import (
+            contact_research_workflow_id,
+        )
+
+        rows = conn.execute(
+            """
+            SELECT task_id
+            FROM contact_research_tasks
+            WHERE tenant_id = ?
+            ORDER BY task_id
+            """,
+            (tenant_id,),
+        ).fetchall()
+        for row in rows:
+            task_id = _optional_text(row["task_id"])
+            _add_registered_candidate(
+                candidates,
+                blockers,
+                policies,
+                workflow_type="ContactResearchWorkflow",
+                workflow_id=(contact_research_workflow_id(task_id) if task_id is not None else ""),
+                temporal_run_id=None,
+                source="contact_research_task",
+            )
+
+    if "discovery_execution_jobs" in tables:
+        pending_count = int(
+            conn.execute(
+                """
+                SELECT COUNT(*)
+                FROM discovery_execution_jobs
+                WHERE tenant_id = ?
+                  AND work_plan_state = 'pending'
+                """,
+                (tenant_id,),
+            ).fetchone()[0]
+        )
+        rows = conn.execute(
+            """
+            SELECT DISTINCT discover_workflow_id, discover_run_id,
+                            preparation_workflow_id, work_plan_state
+            FROM discovery_execution_jobs
+            WHERE tenant_id = ?
+              AND work_plan_state IN ('pending', 'planned')
+            ORDER BY discover_workflow_id, discover_run_id,
+                     preparation_workflow_id
+            """,
+            (tenant_id,),
+        ).fetchall()
+        for row in rows:
+            _add_registered_candidate(
+                candidates,
+                blockers,
+                policies,
+                workflow_type="DiscoverWorkflow",
+                workflow_id=str(row["discover_workflow_id"] or ""),
+                temporal_run_id=_optional_text(row["discover_run_id"]),
+                source="discovery_execution",
+            )
+            preparation_workflow_id = _optional_text(row["preparation_workflow_id"])
+            if preparation_workflow_id is not None:
+                _add_registered_candidate(
+                    candidates,
+                    blockers,
+                    policies,
+                    workflow_type="JobPreparationWorkflow",
+                    workflow_id=preparation_workflow_id,
+                    temporal_run_id=None,
+                    source="discovery_preparation_plan",
+                )
+        if pending_count:
+            durable_owners = [
+                DurableOwnerObservation(
+                    source="discovery_execution_jobs",
+                    state="pending",
+                    count=pending_count,
+                )
+            ]
+        else:
+            durable_owners = []
+    else:
+        durable_owners = []
+
+    if "discovery_search_units" in tables:
+        rows = conn.execute(
+            """
+            SELECT discover_workflow_id, discover_run_id, state, COUNT(*) AS n
+            FROM discovery_search_units
+            WHERE tenant_id = ?
+              AND state IN ('pending', 'running')
+            GROUP BY discover_workflow_id, discover_run_id, state
+            ORDER BY discover_workflow_id, discover_run_id, state
+            """,
+            (tenant_id,),
+        ).fetchall()
+        for row in rows:
+            _add_registered_candidate(
+                candidates,
+                blockers,
+                policies,
+                workflow_type="DiscoverWorkflow",
+                workflow_id=str(row["discover_workflow_id"] or ""),
+                temporal_run_id=_optional_text(row["discover_run_id"]),
+                source="discovery_search_unit",
+            )
+            durable_owners.append(
+                DurableOwnerObservation(
+                    source="discovery_search_units",
+                    state=str(row["state"]),
+                    count=int(row["n"]),
+                )
+            )
+
+    if "pipeline_step_projections" in tables:
+        rows = conn.execute(
+            """
+            SELECT discover_workflow_id, discover_run_id, state, COUNT(*) AS n
+            FROM pipeline_step_projections
+            WHERE tenant_id = ?
+              AND state IN ('queued', 'running')
+            GROUP BY discover_workflow_id, discover_run_id, state
+            ORDER BY discover_workflow_id, discover_run_id, state
+            """,
+            (tenant_id,),
+        ).fetchall()
+        for row in rows:
+            _add_registered_candidate(
+                candidates,
+                blockers,
+                policies,
+                workflow_type="DiscoverWorkflow",
+                workflow_id=str(row["discover_workflow_id"] or ""),
+                temporal_run_id=_optional_text(row["discover_run_id"]),
+                source="pipeline_step_projection",
+            )
+            durable_owners.append(
+                DurableOwnerObservation(
+                    source="pipeline_step_projections",
+                    state=str(row["state"]),
+                    count=int(row["n"]),
+                )
+            )
+
+    if "preparation_work_items" in tables:
+        rows = conn.execute(
+            """
+            SELECT idempotency_key, state
+            FROM preparation_work_items
+            WHERE tenant_id = ?
+              AND state IN ('queued', 'running')
+            ORDER BY idempotency_key
+            """,
+            (tenant_id,),
+        ).fetchall()
+        counts: dict[str, int] = {}
+        for row in rows:
+            state = str(row["state"])
+            counts[state] = counts.get(state, 0) + 1
+            idempotency_key = str(row["idempotency_key"] or "").strip()
+            _add_registered_candidate(
+                candidates,
+                blockers,
+                policies,
+                workflow_type="JobPreparationWorkflow",
+                workflow_id=(f"prep-{idempotency_key}" if idempotency_key else ""),
+                temporal_run_id=None,
+                source="preparation_work_item",
+            )
+        durable_owners.extend(
+            DurableOwnerObservation(
+                source="preparation_work_items",
+                state=state,
+                count=count,
+            )
+            for state, count in sorted(counts.items())
+        )
+
+    # Child workflows are started by Temporal from inside JobPipelineWorkflow,
+    # so they never cross the application dispatch boundary. Their deterministic
+    # IDs remain derivable from every canonical parent candidate.
+    pipeline_workflow_ids = {
+        candidate.workflow_id for candidate in candidates.values() if candidate.workflow_type == "JobPipelineWorkflow"
+    }
+    for pipeline_workflow_id in sorted(pipeline_workflow_ids):
+        _add_registered_candidate(
+            candidates,
+            blockers,
+            policies,
+            workflow_type="DiscoverWorkflow",
+            workflow_id=f"{pipeline_workflow_id}-discover",
+            temporal_run_id=None,
+            source="pipeline_child",
+        )
+        _add_registered_candidate(
+            candidates,
+            blockers,
+            policies,
+            workflow_type="ApplyWorkflow",
+            workflow_id=f"{pipeline_workflow_id}-apply",
+            temporal_run_id=None,
+            source="pipeline_child",
+        )
+
+    frozen_candidates = tuple(
+        WorkflowExecutionCandidate(
+            workflow_type=item.workflow_type,
+            workflow_id=item.workflow_id,
+            temporal_run_id=item.temporal_run_id,
+            sources=tuple(sorted(item.sources)),
+        )
+        for item in sorted(
+            candidates.values(),
+            key=lambda candidate: (
+                candidate.workflow_type,
+                candidate.workflow_id,
+                candidate.temporal_run_id or "",
+            ),
+        )
+    )
+    identity_types: dict[tuple[str, str | None], set[str]] = {}
+    for candidate in frozen_candidates:
+        identity = (
+            candidate.workflow_id,
+            candidate.temporal_run_id,
+        )
+        identity_types.setdefault(identity, set()).add(candidate.workflow_type)
+    for (workflow_id, temporal_run_id), workflow_types in sorted(
+        identity_types.items(),
+        key=lambda item: (item[0][0], item[0][1] or ""),
+    ):
+        if len(workflow_types) <= 1:
+            continue
+        blockers.append(
+            IdentityCutoverBlocker(
+                code="workflow_identity_type_conflict",
+                source="sqlite",
+                workflow_id=workflow_id,
+                temporal_run_id=temporal_run_id,
+                detail=",".join(sorted(workflow_types)),
+            )
+        )
+    return _LocalIdentityInventory(
+        dispatch_gate_blocked=gate_blocked,
+        fence_blocked_at=fence_blocked_at,
+        proof_identity=proof_identity,
+        candidates=frozen_candidates,
+        durable_owners=tuple(durable_owners),
+        blockers=tuple(blockers),
+    )
+
+
+def _unreadable_local_inventory() -> _LocalIdentityInventory:
+    return _LocalIdentityInventory(
+        dispatch_gate_blocked=False,
+        fence_blocked_at=None,
+        proof_identity=None,
+        candidates=(),
+        durable_owners=(),
+        blockers=(
+            IdentityCutoverBlocker(
+                code="inventory_unreadable",
+                source="sqlite",
+            ),
+        ),
+    )
+
+
+def _add_registered_candidate(
+    candidates: dict[
+        tuple[str, str, str | None],
+        _CandidateAccumulator,
+    ],
+    blockers: list[IdentityCutoverBlocker],
+    policies: dict[str, WorkflowIdentityCutoverPolicy],
+    *,
+    workflow_type: str,
+    workflow_id: str,
+    temporal_run_id: str | None,
+    source: str,
+) -> None:
+    policy = policies.get(workflow_type)
+    if policy is None:
+        blockers.append(
+            IdentityCutoverBlocker(
+                code="workflow_type_unregistered",
+                source=source,
+                workflow_type=workflow_type or None,
+                workflow_id=workflow_id or None,
+                temporal_run_id=temporal_run_id,
+            )
+        )
+        return
+    if not policy.blocks_cutover_when_open:
+        return
+    if source not in policy.inventory_sources:
+        blockers.append(
+            IdentityCutoverBlocker(
+                code="inventory_source_undeclared",
+                source=source,
+                workflow_type=workflow_type,
+                workflow_id=workflow_id or None,
+                temporal_run_id=temporal_run_id,
+            )
+        )
+        return
+    if not workflow_id.strip():
+        blockers.append(
+            IdentityCutoverBlocker(
+                code="workflow_id_missing",
+                source=source,
+                workflow_type=workflow_type,
+                temporal_run_id=temporal_run_id,
+            )
+        )
+        return
+    _merge_candidate(
+        candidates,
+        workflow_type=workflow_type,
+        workflow_id=workflow_id,
+        temporal_run_id=temporal_run_id,
+        source=source,
+    )
+    # A pinned predecessor can be terminal because it continued as new while
+    # the current chain is still live. Always inspect the latest execution too.
+    if temporal_run_id is not None:
+        _merge_candidate(
+            candidates,
+            workflow_type=workflow_type,
+            workflow_id=workflow_id,
+            temporal_run_id=None,
+            source=source,
+        )
+
+
+def _merge_candidate(
+    candidates: dict[
+        tuple[str, str, str | None],
+        _CandidateAccumulator,
+    ],
+    *,
+    workflow_type: str,
+    workflow_id: str,
+    temporal_run_id: str | None,
+    source: str,
+) -> None:
+    key = (workflow_type, workflow_id, temporal_run_id)
+    existing = candidates.get(key)
+    if existing is None:
+        candidates[key] = _CandidateAccumulator(
+            workflow_type=workflow_type,
+            workflow_id=workflow_id,
+            temporal_run_id=temporal_run_id,
+            sources={source},
+        )
+        return
+    existing.sources.add(source)
+
+
+async def _validate_temporal_authority(
+    temporal_client: Any,
+    *,
+    proof_identity: InventoryProofIdentity,
+) -> list[IdentityCutoverBlocker]:
+    """Bind exact absence checks to the recovery proof's history authority."""
+
+    namespace = _optional_text(getattr(temporal_client, "namespace", None))
+    if namespace != proof_identity.temporal_namespace:
+        return [
+            IdentityCutoverBlocker(
+                code="temporal_namespace_mismatch",
+                source="temporal_authority",
+            )
+        ]
+
+    try:
+        response = await temporal_client.workflow_service.describe_namespace(
+            DescribeNamespaceRequest(namespace=namespace),
+            retry=False,
+            timeout=timedelta(seconds=3),
+        )
+    except Exception:
+        return [
+            IdentityCutoverBlocker(
+                code="temporal_namespace_describe_unavailable",
+                source="temporal_authority",
+            )
+        ]
+
+    namespace_info = getattr(response, "namespace_info", None)
+    namespace_id = _optional_text(getattr(namespace_info, "id", None))
+    if namespace_id != proof_identity.temporal_namespace_id:
+        return [
+            IdentityCutoverBlocker(
+                code="temporal_namespace_id_mismatch",
+                source="temporal_authority",
+            )
+        ]
+
+    marker = WorkflowExecutionCandidate(
+        workflow_type="DurabilityProbeWorkflow",
+        workflow_id=proof_identity.authority_workflow_id,
+        temporal_run_id=proof_identity.authority_run_id,
+        sources=("temporal_authority",),
+    )
+    observation, _blocker = await _observe_exact_execution(
+        temporal_client,
+        marker,
+        not_found_is_safe=False,
+    )
+    if observation.state == "closed":
+        return []
+    if observation.state == "open":
+        code = "temporal_authority_marker_open"
+    elif observation.state == "unknown":
+        code = "temporal_authority_marker_status_unknown"
+    else:
+        code = "temporal_authority_marker_unavailable"
+    return [
+        IdentityCutoverBlocker(
+            code=code,
+            source="temporal_authority",
+            workflow_type=marker.workflow_type,
+            workflow_id=marker.workflow_id,
+            temporal_run_id=marker.temporal_run_id,
+        )
+    ]
+
+
+async def _observe_schedule_fences(
+    temporal_client: Any,
+    *,
+    tenant_id: str,
+) -> tuple[
+    list[ScheduleFenceObservation],
+    list[IdentityCutoverBlocker],
+]:
+    observations: list[ScheduleFenceObservation] = []
+    blockers: list[IdentityCutoverBlocker] = []
+    for policy in identity_bearing_schedule_policies(tenant_id):
+        try:
+            description = await temporal_client.get_schedule_handle(policy.schedule_id).describe()
+        except RPCError as exc:
+            if exc.status == RPCStatusCode.NOT_FOUND:
+                observations.append(
+                    ScheduleFenceObservation(
+                        schedule_id=policy.schedule_id,
+                        workflow_type=policy.workflow_type,
+                        state="not_found",
+                    )
+                )
+                continue
+            observations.append(
+                ScheduleFenceObservation(
+                    schedule_id=policy.schedule_id,
+                    workflow_type=policy.workflow_type,
+                    state="unavailable",
+                )
+            )
+            blockers.append(
+                IdentityCutoverBlocker(
+                    code="schedule_describe_unavailable",
+                    source="identity_schedule",
+                    workflow_type=policy.workflow_type,
+                    workflow_id=policy.workflow_id,
+                )
+            )
+            continue
+        except Exception:
+            observations.append(
+                ScheduleFenceObservation(
+                    schedule_id=policy.schedule_id,
+                    workflow_type=policy.workflow_type,
+                    state="unavailable",
+                )
+            )
+            blockers.append(
+                IdentityCutoverBlocker(
+                    code="schedule_describe_unavailable",
+                    source="identity_schedule",
+                    workflow_type=policy.workflow_type,
+                    workflow_id=policy.workflow_id,
+                )
+            )
+            continue
+
+        schedule = getattr(description, "schedule", None)
+        state = getattr(schedule, "state", None)
+        paused = getattr(state, "paused", None)
+        if paused is True:
+            observation_state: ScheduleState = "paused"
+        elif paused is False:
+            observation_state = "unpaused"
+            blockers.append(
+                IdentityCutoverBlocker(
+                    code="identity_schedule_unpaused",
+                    source="identity_schedule",
+                    workflow_type=policy.workflow_type,
+                    workflow_id=policy.workflow_id,
+                )
+            )
+        else:
+            observation_state = "unknown"
+            blockers.append(
+                IdentityCutoverBlocker(
+                    code="schedule_state_unknown",
+                    source="identity_schedule",
+                    workflow_type=policy.workflow_type,
+                    workflow_id=policy.workflow_id,
+                )
+            )
+        observations.append(
+            ScheduleFenceObservation(
+                schedule_id=policy.schedule_id,
+                workflow_type=policy.workflow_type,
+                state=observation_state,
+            )
+        )
+    return observations, blockers
+
+
+async def _observe_exact_execution(
+    temporal_client: Any,
+    candidate: WorkflowExecutionCandidate,
+    *,
+    not_found_is_safe: bool = True,
+) -> tuple[
+    WorkflowExecutionObservation,
+    IdentityCutoverBlocker | None,
+]:
+    try:
+        handle = temporal_client.get_workflow_handle(
+            candidate.workflow_id,
+            **({"run_id": candidate.temporal_run_id} if candidate.temporal_run_id is not None else {}),
+        )
+        description = await handle.describe()
+    except RPCError as exc:
+        if exc.status == RPCStatusCode.NOT_FOUND and not_found_is_safe:
+            return (
+                WorkflowExecutionObservation(
+                    candidate=candidate,
+                    state="not_found",
+                ),
+                None,
+            )
+        return _unavailable_execution(candidate)
+    except Exception:
+        return _unavailable_execution(candidate)
+
+    status = getattr(description, "status", None)
+    status_name = getattr(status, "name", str(status) if status is not None else None)
+    if status in _OPEN_TEMPORAL_STATES:
+        return (
+            WorkflowExecutionObservation(
+                candidate=candidate,
+                state="open",
+                temporal_status=status_name,
+            ),
+            IdentityCutoverBlocker(
+                code="workflow_execution_open",
+                source="temporal_describe",
+                workflow_type=candidate.workflow_type,
+                workflow_id=candidate.workflow_id,
+                temporal_run_id=candidate.temporal_run_id,
+                detail=status_name,
+            ),
+        )
+    if status in _CLOSED_TEMPORAL_STATES:
+        return (
+            WorkflowExecutionObservation(
+                candidate=candidate,
+                state="closed",
+                temporal_status=status_name,
+            ),
+            None,
+        )
+    return (
+        WorkflowExecutionObservation(
+            candidate=candidate,
+            state="unknown",
+            temporal_status=status_name,
+        ),
+        IdentityCutoverBlocker(
+            code="workflow_execution_status_unknown",
+            source="temporal_describe",
+            workflow_type=candidate.workflow_type,
+            workflow_id=candidate.workflow_id,
+            temporal_run_id=candidate.temporal_run_id,
+            detail=status_name,
+        ),
+    )
+
+
+def _unavailable_execution(
+    candidate: WorkflowExecutionCandidate,
+) -> tuple[
+    WorkflowExecutionObservation,
+    IdentityCutoverBlocker,
+]:
+    return (
+        WorkflowExecutionObservation(
+            candidate=candidate,
+            state="unavailable",
+        ),
+        IdentityCutoverBlocker(
+            code="workflow_describe_unavailable",
+            source="temporal_describe",
+            workflow_type=candidate.workflow_type,
+            workflow_id=candidate.workflow_id,
+            temporal_run_id=candidate.temporal_run_id,
+        ),
+    )
+
+
+def _policies_by_type() -> dict[str, WorkflowIdentityCutoverPolicy]:
+    return {policy.workflow_type: policy for policy in WORKFLOW_IDENTITY_CUTOVER_POLICIES.values()}
+
+
+def _table_names(conn: sqlite3.Connection) -> set[str]:
+    return {
+        str(row[0])
+        for row in conn.execute(
+            """
+            SELECT name
+            FROM sqlite_master
+            WHERE type = 'table'
+            """
+        ).fetchall()
+    }
+
+
+def _optional_text(value: Any) -> str | None:
+    normalized = str(value or "").strip()
+    return normalized or None
+
+
+def _invalid_workflow_start_event(
+    event_id: Any,
+) -> IdentityCutoverBlocker:
+    return IdentityCutoverBlocker(
+        code="workflow_start_event_invalid",
+        source="workflow_start_event",
+        detail=f"event:{event_id}",
+    )
+
+
+def _has_inventory_blocker(
+    blockers: list[IdentityCutoverBlocker],
+) -> bool:
+    return any(
+        blocker.code
+        in {
+            "inventory_table_missing",
+            "inventory_source_undeclared",
+            "job_identity_incomplete",
+            "pre_fence_inventory_unproven",
+            "workflow_start_event_invalid",
+            "workflow_id_missing",
+            "workflow_identity_type_conflict",
+            "workflow_type_unregistered",
+        }
+        for blocker in blockers
+    )
+
+
+def _result(
+    *,
+    gate_blocked: bool,
+    candidates: tuple[WorkflowExecutionCandidate, ...],
+    durable_owners: tuple[DurableOwnerObservation, ...],
+    blockers: list[IdentityCutoverBlocker],
+    executions: list[WorkflowExecutionObservation] | None = None,
+    schedules: list[ScheduleFenceObservation] | None = None,
+) -> IdentityCutoverPreflightResult:
+    return IdentityCutoverPreflightResult(
+        ready=not blockers,
+        dispatch_gate_blocked=gate_blocked,
+        candidates=candidates,
+        executions=tuple(executions or ()),
+        schedules=tuple(schedules or ()),
+        durable_owners=durable_owners,
+        blockers=tuple(blockers),
+    )
+
+
+__all__ = [
+    "DurableOwnerObservation",
+    "IdentityCutoverBlocker",
+    "IdentityCutoverPreflightResult",
+    "ScheduleFenceObservation",
+    "WorkflowExecutionCandidate",
+    "WorkflowExecutionObservation",
+    "run_identity_cutover_preflight",
+]

--- a/workers/automation/tests/test_identity_cutover_preflight.py
+++ b/workers/automation/tests/test_identity_cutover_preflight.py
@@ -1,0 +1,1319 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from temporalio.client import WorkflowExecutionStatus
+from temporalio.service import RPCError, RPCStatusCode
+
+from jobctrl.database import close_connection, init_db
+from jobctrl.discovery.manual_capture_workflow import (
+    manual_capture_import_workflow_id,
+)
+from jobctrl.infrastructure.temporal.identity_cutover_preflight import (
+    IdentityCutoverPreflightResult,
+    run_identity_cutover_preflight,
+)
+from jobctrl.infrastructure.temporal.identity_cutover_proof import (
+    CONTROL_KEY,
+    INVENTORY_PROOF_VERSION,
+    registry_inventory_fingerprint,
+    worker_inventory_fingerprint,
+)
+from jobctrl.infrastructure.temporal.workflow_dispatch_control import (
+    IdentityCutoverLease,
+    IdentityCutoverLeaseError,
+    identity_cutover_exclusive_lease,
+    set_workflow_dispatches_blocked,
+    workflow_dispatch_read_lock,
+)
+from jobctrl.workflow_specs import (
+    apply_workflow_id,
+    interview_prep_workflow_id,
+)
+
+
+@dataclass(frozen=True)
+class _WorkflowDescription:
+    status: WorkflowExecutionStatus
+
+
+class _WorkflowHandle:
+    def __init__(self, outcome: object) -> None:
+        self.outcome = outcome
+
+    async def describe(self) -> object:
+        if isinstance(self.outcome, BaseException):
+            raise self.outcome
+        if callable(self.outcome):
+            return self.outcome()
+        return self.outcome
+
+
+class _ScheduleHandle:
+    def __init__(self, outcome: object) -> None:
+        self.outcome = outcome
+
+    async def describe(self) -> object:
+        if isinstance(self.outcome, BaseException):
+            raise self.outcome
+        return self.outcome
+
+
+class _WorkflowService:
+    def __init__(
+        self,
+        *,
+        namespace_id: str,
+        outcome: object | None = None,
+    ) -> None:
+        self.namespace_id = namespace_id
+        self.outcome = outcome
+        self.requests: list[object] = []
+
+    async def describe_namespace(
+        self,
+        request: object,
+        *,
+        retry: bool,
+        timeout: object,
+    ) -> object:
+        self.requests.append(request)
+        if isinstance(self.outcome, BaseException):
+            raise self.outcome
+        if self.outcome is not None:
+            return self.outcome
+        return SimpleNamespace(
+            namespace_info=SimpleNamespace(id=self.namespace_id),
+        )
+
+
+_PROOF_ID = "proof-one"
+_TEMPORAL_NAMESPACE = "default"
+_TEMPORAL_NAMESPACE_ID = "namespace-id-one"
+_AUTHORITY_WORKFLOW_ID = "cutover-authority-marker"
+_AUTHORITY_RUN_ID = "marker-run-one"
+
+
+class _TemporalClient:
+    def __init__(
+        self,
+        *,
+        workflows: dict[tuple[str, str | None], object] | None = None,
+        schedule: object | None = None,
+        namespace: str = _TEMPORAL_NAMESPACE,
+        namespace_id: str = _TEMPORAL_NAMESPACE_ID,
+        namespace_outcome: object | None = None,
+        authority_outcome: object = _WorkflowDescription(WorkflowExecutionStatus.COMPLETED),
+    ) -> None:
+        self.workflows = workflows or {}
+        self.namespace = namespace
+        self.workflow_service = _WorkflowService(
+            namespace_id=namespace_id,
+            outcome=namespace_outcome,
+        )
+        self.authority_outcome = authority_outcome
+        self.schedule = (
+            schedule
+            if schedule is not None
+            else SimpleNamespace(schedule=SimpleNamespace(state=SimpleNamespace(paused=True)))
+        )
+        self.workflow_describes: list[tuple[str, str | None]] = []
+        self.schedule_describes: list[str] = []
+
+    def get_workflow_handle(
+        self,
+        workflow_id: str,
+        *,
+        run_id: str | None = None,
+    ) -> _WorkflowHandle:
+        self.workflow_describes.append((workflow_id, run_id))
+        if workflow_id == _AUTHORITY_WORKFLOW_ID and run_id == _AUTHORITY_RUN_ID:
+            outcome = self.authority_outcome
+        else:
+            outcome = self.workflows.get(
+                (workflow_id, run_id),
+                RPCError(
+                    "not found",
+                    RPCStatusCode.NOT_FOUND,
+                    b"",
+                ),
+            )
+        return _WorkflowHandle(outcome)
+
+    def get_schedule_handle(self, schedule_id: str) -> _ScheduleHandle:
+        self.schedule_describes.append(schedule_id)
+        return _ScheduleHandle(self.schedule)
+
+
+@pytest.fixture
+def db_path(tmp_path: Path) -> Path:
+    path = tmp_path / "jobctrl.db"
+    conn = init_db(path)
+    conn.commit()
+    close_connection(path)
+    return path
+
+
+def _block_dispatches(db_path: Path) -> None:
+    set_workflow_dispatches_blocked(
+        blocked=True,
+        reason="identity-cutover",
+        db_path=db_path,
+    )
+    _seal_inventory(db_path)
+
+
+def _seal_inventory(
+    db_path: Path,
+    *,
+    proof_id: str = _PROOF_ID,
+) -> None:
+    with sqlite3.connect(db_path) as conn:
+        fence_blocked_at = conn.execute(
+            """
+            SELECT blocked_at
+            FROM workflow_dispatch_control
+            WHERE control_key = ?
+            """,
+            (CONTROL_KEY,),
+        ).fetchone()[0]
+        registry = registry_inventory_fingerprint(conn)
+        workers = worker_inventory_fingerprint(conn)
+        conn.execute(
+            """
+            INSERT INTO workflow_identity_cutover_inventory_proof (
+                control_key, proof_version, proof_id, fence_blocked_at,
+                registry_inventory_digest, registry_entry_count,
+                worker_inventory_digest, worker_entry_count,
+                worker_quiescent_at, temporal_namespace,
+                temporal_namespace_id, authority_workflow_id,
+                authority_run_id, created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(control_key) DO UPDATE SET
+                proof_version = excluded.proof_version,
+                proof_id = excluded.proof_id,
+                fence_blocked_at = excluded.fence_blocked_at,
+                registry_inventory_digest =
+                    excluded.registry_inventory_digest,
+                registry_entry_count = excluded.registry_entry_count,
+                worker_inventory_digest = excluded.worker_inventory_digest,
+                worker_entry_count = excluded.worker_entry_count,
+                worker_quiescent_at = excluded.worker_quiescent_at,
+                temporal_namespace = excluded.temporal_namespace,
+                temporal_namespace_id = excluded.temporal_namespace_id,
+                authority_workflow_id = excluded.authority_workflow_id,
+                authority_run_id = excluded.authority_run_id,
+                created_at = excluded.created_at
+            """,
+            (
+                CONTROL_KEY,
+                INVENTORY_PROOF_VERSION,
+                proof_id,
+                str(fence_blocked_at),
+                registry.digest,
+                registry.entry_count,
+                workers.digest,
+                workers.entry_count,
+                "2026-07-30T00:00:01+00:00",
+                _TEMPORAL_NAMESPACE,
+                _TEMPORAL_NAMESPACE_ID,
+                _AUTHORITY_WORKFLOW_ID,
+                _AUTHORITY_RUN_ID,
+                "2026-07-30T00:00:01+00:00",
+            ),
+        )
+
+
+async def _run_preflight(
+    temporal_client: _TemporalClient,
+    *,
+    db_path: Path,
+) -> IdentityCutoverPreflightResult:
+    async with identity_cutover_exclusive_lease(
+        db_path=db_path,
+    ) as lease:
+        return await run_identity_cutover_preflight(
+            temporal_client,
+            db_path=db_path,
+            cutover_lease=lease,
+        )
+
+
+def _insert_dispatch(
+    db_path: Path,
+    *,
+    workflow_type: str,
+    workflow_id: str,
+    run_id: str | None,
+) -> None:
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            INSERT INTO workflow_dispatch_registry (
+                launch_id, workflow_id, temporal_run_id,
+                workflow_type, state, created_at, updated_at
+            ) VALUES (?, ?, ?, ?, 'dispatched', ?, ?)
+            """,
+            (
+                f"launch-{workflow_id}",
+                workflow_id,
+                run_id,
+                workflow_type,
+                "2026-07-30T00:00:00+00:00",
+                "2026-07-30T00:00:00+00:00",
+            ),
+        )
+    _seal_inventory(db_path)
+
+
+def _ensure_job(db_path: Path) -> str:
+    job_id = "00000000-0000-4000-8000-000000000001"
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            INSERT OR IGNORE INTO jobs (
+                tenant_id, job_id, url, discovered_at
+            ) VALUES ('local', ?, ?, ?)
+            """,
+            (
+                job_id,
+                "https://example.test/jobs/one",
+                "2026-07-30T00:00:00+00:00",
+            ),
+        )
+    return job_id
+
+
+@pytest.mark.asyncio
+async def test_preflight_requires_active_exclusive_cutover_lease(
+    db_path: Path,
+) -> None:
+    client = _TemporalClient()
+    released_lease = IdentityCutoverLease(
+        db_path=db_path,
+        lease_id="released",
+        _active=False,
+    )
+
+    with pytest.raises(
+        IdentityCutoverLeaseError,
+        match="no longer active",
+    ):
+        await run_identity_cutover_preflight(
+            client,
+            db_path=db_path,
+            cutover_lease=released_lease,
+        )
+    assert client.schedule_describes == []
+    assert client.workflow_describes == []
+
+
+@pytest.mark.asyncio
+async def test_preflight_refuses_unproven_pre_fence_upgrade_inventory(
+    db_path: Path,
+) -> None:
+    # This is the supported-upgrade crash window: predecessor Temporal may
+    # contain an accepted random-ID execution while neither the dispatch
+    # registry nor the best-effort projection/event contains it. Activating the
+    # gate alone must never turn local absence into readiness.
+    set_workflow_dispatches_blocked(
+        blocked=True,
+        reason="identity-cutover",
+        db_path=db_path,
+    )
+    client = _TemporalClient()
+
+    result = await _run_preflight(
+        client,
+        db_path=db_path,
+    )
+
+    assert result.ready is False
+    assert any(
+        blocker.code == "pre_fence_inventory_unproven" and blocker.detail == "proof_missing"
+        for blocker in result.blockers
+    )
+    assert client.schedule_describes == []
+    assert client.workflow_describes == []
+
+
+@pytest.mark.asyncio
+async def test_preflight_is_ready_after_paused_schedule_and_exact_absence(
+    db_path: Path,
+) -> None:
+    _block_dispatches(db_path)
+    client = _TemporalClient()
+
+    result = await _run_preflight(
+        client,
+        db_path=db_path,
+    )
+
+    assert result.ready is True
+    assert result.blockers == ()
+    assert result.schedules[0].state == "paused"
+    assert client.schedule_describes == [
+        "jobctrl-discovery-local",
+        "jobctrl-discovery-local",
+    ]
+    assert client.workflow_describes == [
+        (_AUTHORITY_WORKFLOW_ID, _AUTHORITY_RUN_ID),
+        ("apply-auto-local", None),
+        ("discover-local", None),
+        ("apply-auto-local", None),
+        ("discover-local", None),
+    ]
+    assert all(observation.state == "not_found" for observation in result.executions)
+
+
+@pytest.mark.asyncio
+async def test_ready_result_is_returned_while_exclusive_lease_remains_held(
+    db_path: Path,
+) -> None:
+    _block_dispatches(db_path)
+    client = _TemporalClient()
+    worker_entered = asyncio.Event()
+
+    async def _enter_worker_runtime() -> None:
+        async with workflow_dispatch_read_lock(
+            db_path=db_path,
+        ):
+            worker_entered.set()
+
+    async with identity_cutover_exclusive_lease(
+        db_path=db_path,
+    ) as lease:
+        result = await run_identity_cutover_preflight(
+            client,
+            db_path=db_path,
+            cutover_lease=lease,
+        )
+        worker_task = asyncio.create_task(_enter_worker_runtime())
+        await asyncio.sleep(0.1)
+        assert result.ready is True
+        assert worker_entered.is_set() is False
+
+    await worker_task
+    assert worker_entered.is_set() is True
+
+
+@pytest.mark.asyncio
+async def test_preflight_rejects_wrong_temporal_namespace_before_absence_checks(
+    db_path: Path,
+) -> None:
+    _block_dispatches(db_path)
+    client = _TemporalClient(namespace="wrong-namespace")
+
+    result = await _run_preflight(
+        client,
+        db_path=db_path,
+    )
+
+    assert result.ready is False
+    assert [blocker.code for blocker in result.blockers] == ["temporal_namespace_mismatch"]
+    assert client.workflow_service.requests == []
+    assert client.schedule_describes == []
+    assert client.workflow_describes == []
+
+
+@pytest.mark.asyncio
+async def test_preflight_rejects_wrong_temporal_history_store(
+    db_path: Path,
+) -> None:
+    _block_dispatches(db_path)
+    client = _TemporalClient(namespace_id="wrong-namespace-id")
+
+    result = await _run_preflight(
+        client,
+        db_path=db_path,
+    )
+
+    assert result.ready is False
+    assert [blocker.code for blocker in result.blockers] == ["temporal_namespace_id_mismatch"]
+    assert len(client.workflow_service.requests) == 1
+    assert client.schedule_describes == []
+    assert client.workflow_describes == []
+
+
+@pytest.mark.asyncio
+async def test_preflight_fails_closed_when_namespace_authority_is_unavailable(
+    db_path: Path,
+) -> None:
+    _block_dispatches(db_path)
+    client = _TemporalClient(
+        namespace_outcome=RuntimeError(
+            "sensitive-temporal-endpoint",
+        )
+    )
+
+    result = await _run_preflight(
+        client,
+        db_path=db_path,
+    )
+
+    assert [blocker.code for blocker in result.blockers] == ["temporal_namespace_describe_unavailable"]
+    assert client.schedule_describes == []
+    assert client.workflow_describes == []
+    assert "sensitive-temporal-endpoint" not in repr(result)
+
+
+@pytest.mark.asyncio
+async def test_preflight_requires_exact_authority_marker_execution(
+    db_path: Path,
+) -> None:
+    _block_dispatches(db_path)
+    client = _TemporalClient(
+        authority_outcome=RPCError(
+            "not found in wrong history store",
+            RPCStatusCode.NOT_FOUND,
+            b"sensitive-history-target",
+        )
+    )
+
+    result = await _run_preflight(
+        client,
+        db_path=db_path,
+    )
+
+    assert result.ready is False
+    assert [blocker.code for blocker in result.blockers] == ["temporal_authority_marker_unavailable"]
+    assert client.schedule_describes == []
+    assert client.workflow_describes == [(_AUTHORITY_WORKFLOW_ID, _AUTHORITY_RUN_ID)]
+    assert "sensitive-history-target" not in repr(result)
+
+
+@pytest.mark.asyncio
+async def test_preflight_requires_closed_authority_marker(
+    db_path: Path,
+) -> None:
+    _block_dispatches(db_path)
+    client = _TemporalClient(authority_outcome=_WorkflowDescription(WorkflowExecutionStatus.RUNNING))
+
+    result = await _run_preflight(
+        client,
+        db_path=db_path,
+    )
+
+    assert [blocker.code for blocker in result.blockers] == ["temporal_authority_marker_open"]
+    assert client.schedule_describes == []
+    assert client.workflow_describes == [(_AUTHORITY_WORKFLOW_ID, _AUTHORITY_RUN_ID)]
+
+
+@pytest.mark.asyncio
+async def test_preflight_describes_recorded_run_and_latest_execution(
+    db_path: Path,
+) -> None:
+    _block_dispatches(db_path)
+    _insert_dispatch(
+        db_path,
+        workflow_type="ApplyWorkflow",
+        workflow_id="apply-local-job-one",
+        run_id="run-one",
+    )
+    client = _TemporalClient(
+        workflows={
+            (
+                "apply-local-job-one",
+                "run-one",
+            ): _WorkflowDescription(WorkflowExecutionStatus.COMPLETED),
+            (
+                "apply-local-job-one",
+                None,
+            ): _WorkflowDescription(WorkflowExecutionStatus.RUNNING),
+        }
+    )
+
+    result = await _run_preflight(
+        client,
+        db_path=db_path,
+    )
+
+    assert result.ready is False
+    assert {
+        (observation.candidate.workflow_id, observation.candidate.temporal_run_id)
+        for observation in result.executions
+        if observation.candidate.workflow_id == "apply-local-job-one"
+    } == {
+        ("apply-local-job-one", "run-one"),
+        ("apply-local-job-one", None),
+    }
+    assert any(
+        blocker.code == "workflow_execution_open" and blocker.temporal_run_id is None for blocker in result.blockers
+    )
+
+
+@pytest.mark.asyncio
+async def test_preflight_follows_continued_run_through_latest_execution(
+    db_path: Path,
+) -> None:
+    _block_dispatches(db_path)
+    _insert_dispatch(
+        db_path,
+        workflow_type="ApplyWorkflow",
+        workflow_id="apply-local-continued",
+        run_id="run-before-continue",
+    )
+    client = _TemporalClient(
+        workflows={
+            (
+                "apply-local-continued",
+                "run-before-continue",
+            ): _WorkflowDescription(WorkflowExecutionStatus.CONTINUED_AS_NEW),
+            (
+                "apply-local-continued",
+                None,
+            ): _WorkflowDescription(WorkflowExecutionStatus.COMPLETED),
+        }
+    )
+
+    result = await _run_preflight(
+        client,
+        db_path=db_path,
+    )
+
+    assert result.ready is True
+    assert {
+        (
+            observation.candidate.temporal_run_id,
+            observation.state,
+            observation.temporal_status,
+        )
+        for observation in result.executions
+        if observation.candidate.workflow_id == "apply-local-continued"
+    } == {
+        (None, "closed", "COMPLETED"),
+        (
+            "run-before-continue",
+            "closed",
+            "CONTINUED_AS_NEW",
+        ),
+    }
+
+
+@pytest.mark.asyncio
+async def test_preflight_fails_closed_when_exact_describe_is_unavailable(
+    db_path: Path,
+) -> None:
+    _block_dispatches(db_path)
+    _insert_dispatch(
+        db_path,
+        workflow_type="ContactResearchWorkflow",
+        workflow_id="contact-research-task-one",
+        run_id="run-contact",
+    )
+    client = _TemporalClient(
+        workflows={
+            (
+                "contact-research-task-one",
+                "run-contact",
+            ): RPCError(
+                "unavailable",
+                RPCStatusCode.UNAVAILABLE,
+                b"",
+            ),
+        }
+    )
+
+    result = await _run_preflight(
+        client,
+        db_path=db_path,
+    )
+
+    assert result.ready is False
+    assert any(
+        blocker.code == "workflow_describe_unavailable" and blocker.temporal_run_id == "run-contact"
+        for blocker in result.blockers
+    )
+
+
+@pytest.mark.asyncio
+async def test_preflight_refuses_unknown_open_projection_workflow_type(
+    db_path: Path,
+) -> None:
+    _block_dispatches(db_path)
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            INSERT INTO workflow_run_projections (
+                workflow_id, tenant_id, workflow_type, status,
+                input_summary_json, retryable, events_json
+            ) VALUES (?, 'local', ?, 'in_progress', '{}', 0, '[]')
+            """,
+            ("legacy-unknown", "RemovedLegacyWorkflow"),
+        )
+    client = _TemporalClient()
+
+    result = await _run_preflight(
+        client,
+        db_path=db_path,
+    )
+
+    assert result.ready is False
+    assert any(
+        blocker.code == "workflow_type_unregistered" and blocker.workflow_type == "RemovedLegacyWorkflow"
+        for blocker in result.blockers
+    )
+    assert client.workflow_describes == []
+
+
+@pytest.mark.asyncio
+async def test_preflight_reads_canonical_workflow_started_event_when_projection_is_missing(
+    db_path: Path,
+) -> None:
+    _block_dispatches(db_path)
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            INSERT INTO job_events (
+                event_type, occurred_at, payload_json
+            ) VALUES ('WorkflowStarted', ?, ?)
+            """,
+            (
+                "2026-07-30T00:00:00+00:00",
+                json.dumps(
+                    {
+                        "tenantId": "local",
+                        "workflowId": "run-from-canonical-event",
+                        "workflowType": "JobPipelineWorkflow",
+                        "temporalRunId": "event-run-id",
+                    }
+                ),
+            ),
+        )
+    client = _TemporalClient(
+        workflows={
+            (
+                "run-from-canonical-event",
+                "event-run-id",
+            ): _WorkflowDescription(WorkflowExecutionStatus.RUNNING),
+        }
+    )
+
+    result = await _run_preflight(
+        client,
+        db_path=db_path,
+    )
+
+    assert result.ready is False
+    event_candidate = next(
+        candidate
+        for candidate in result.candidates
+        if candidate.workflow_id == "run-from-canonical-event" and candidate.temporal_run_id == "event-run-id"
+    )
+    assert "workflow_start_event" in event_candidate.sources
+    assert any(
+        blocker.code == "workflow_execution_open" and blocker.workflow_id == "run-from-canonical-event"
+        for blocker in result.blockers
+    )
+
+
+@pytest.mark.asyncio
+async def test_preflight_refuses_workflow_started_event_without_tenant(
+    db_path: Path,
+) -> None:
+    _block_dispatches(db_path)
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            INSERT INTO job_events (
+                event_type, occurred_at, payload_json
+            ) VALUES ('WorkflowStarted', ?, ?)
+            """,
+            (
+                "2026-07-30T00:00:00+00:00",
+                json.dumps(
+                    {
+                        "workflowId": "run-without-tenant",
+                        "workflowType": "ApplyWorkflow",
+                        "temporalRunId": "run-id-without-tenant",
+                    }
+                ),
+            ),
+        )
+    client = _TemporalClient()
+
+    result = await _run_preflight(
+        client,
+        db_path=db_path,
+    )
+
+    assert result.ready is False
+    assert any(
+        blocker.code == "workflow_start_event_invalid" and blocker.detail == "event:1" for blocker in result.blockers
+    )
+    assert client.schedule_describes == []
+    assert client.workflow_describes == []
+
+
+@pytest.mark.asyncio
+async def test_preflight_derives_deterministic_domain_execution_ids(
+    db_path: Path,
+) -> None:
+    _block_dispatches(db_path)
+    job_id = _ensure_job(db_path)
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            INSERT INTO manual_capture_queue (
+                tenant_id, item_id, originating_url, reason,
+                required_at, status
+            ) VALUES (
+                'local', 'capture-one', 'https://example.test/jobs/one',
+                'manual', ?, 'pending'
+            )
+            """,
+            ("2026-07-30T00:00:00+00:00",),
+        )
+        conn.execute(
+            """
+            INSERT INTO contact_research_tasks (
+                tenant_id, task_id, employer, job_id,
+                status, updated_at
+            ) VALUES (
+                'local', 'research-one', 'Example', ?,
+                'queued', ?
+            )
+            """,
+            (
+                job_id,
+                "2026-07-30T00:00:00+00:00",
+            ),
+        )
+    client = _TemporalClient()
+
+    result = await _run_preflight(
+        client,
+        db_path=db_path,
+    )
+
+    assert result.ready is True
+    by_id = {candidate.workflow_id: candidate for candidate in result.candidates}
+    posting_url = "https://example.test/jobs/one"
+    expected_sources = {
+        apply_workflow_id("local", job_id): "job_identity_derived",
+        apply_workflow_id("local", posting_url): "job_identity_derived",
+        interview_prep_workflow_id(
+            "local",
+            job_id,
+        ): "job_identity_derived",
+        interview_prep_workflow_id(
+            "local",
+            posting_url,
+        ): "job_identity_derived",
+        manual_capture_import_workflow_id(
+            "local",
+            "capture-one",
+        ): "manual_capture_queue",
+        "contact-research-research-one": "contact_research_task",
+        "apply-auto-local": "auto_apply_loop",
+    }
+    for workflow_id, source in expected_sources.items():
+        assert source in by_id[workflow_id].sources
+
+
+@pytest.mark.asyncio
+async def test_preflight_derives_temporal_owned_pipeline_child_ids(
+    db_path: Path,
+) -> None:
+    _block_dispatches(db_path)
+    _insert_dispatch(
+        db_path,
+        workflow_type="JobPipelineWorkflow",
+        workflow_id="pipeline-parent",
+        run_id="pipeline-parent-run",
+    )
+    client = _TemporalClient(
+        workflows={
+            (
+                "pipeline-parent",
+                "pipeline-parent-run",
+            ): _WorkflowDescription(WorkflowExecutionStatus.COMPLETED),
+            (
+                "pipeline-parent",
+                None,
+            ): _WorkflowDescription(WorkflowExecutionStatus.COMPLETED),
+            (
+                "pipeline-parent-apply",
+                None,
+            ): _WorkflowDescription(WorkflowExecutionStatus.RUNNING),
+        }
+    )
+
+    result = await _run_preflight(
+        client,
+        db_path=db_path,
+    )
+
+    assert result.ready is False
+    apply_child = next(candidate for candidate in result.candidates if candidate.workflow_id == "pipeline-parent-apply")
+    discover_child = next(
+        candidate for candidate in result.candidates if candidate.workflow_id == "pipeline-parent-discover"
+    )
+    assert apply_child.sources == ("pipeline_child",)
+    assert discover_child.sources == ("pipeline_child",)
+    assert any(
+        blocker.code == "workflow_execution_open" and blocker.workflow_id == "pipeline-parent-apply"
+        for blocker in result.blockers
+    )
+
+
+@pytest.mark.asyncio
+async def test_preflight_ignores_registered_non_identity_workflow(
+    db_path: Path,
+) -> None:
+    _block_dispatches(db_path)
+    _insert_dispatch(
+        db_path,
+        workflow_type="ProfileImportWorkflow",
+        workflow_id="profile-import-one",
+        run_id="profile-run-one",
+    )
+    client = _TemporalClient()
+
+    result = await _run_preflight(
+        client,
+        db_path=db_path,
+    )
+
+    assert result.ready is True
+    assert all(candidate.workflow_id != "profile-import-one" for candidate in result.candidates)
+    assert all(workflow_id != "profile-import-one" for workflow_id, _run_id in client.workflow_describes)
+
+
+@pytest.mark.asyncio
+async def test_preflight_refuses_one_execution_claimed_by_two_workflow_types(
+    db_path: Path,
+) -> None:
+    _block_dispatches(db_path)
+    _insert_dispatch(
+        db_path,
+        workflow_type="ApplyWorkflow",
+        workflow_id="shared-identity",
+        run_id=None,
+    )
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            INSERT INTO workflow_run_projections (
+                workflow_id, tenant_id, workflow_type, status,
+                input_summary_json, retryable, events_json
+            ) VALUES (?, 'local', ?, 'in_progress', '{}', 0, '[]')
+            """,
+            ("shared-identity", "ContactResearchWorkflow"),
+        )
+    client = _TemporalClient()
+
+    result = await _run_preflight(
+        client,
+        db_path=db_path,
+    )
+
+    assert result.ready is False
+    assert any(
+        blocker.code == "workflow_identity_type_conflict" and blocker.workflow_id == "shared-identity"
+        for blocker in result.blockers
+    )
+    assert client.workflow_describes == []
+
+
+@pytest.mark.asyncio
+async def test_preflight_requires_complete_local_inventory_schema(
+    db_path: Path,
+) -> None:
+    _block_dispatches(db_path)
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("DROP TABLE pipeline_step_projections")
+    client = _TemporalClient()
+
+    result = await _run_preflight(
+        client,
+        db_path=db_path,
+    )
+
+    assert result.ready is False
+    assert any(
+        blocker.code == "inventory_table_missing" and blocker.source == "pipeline_step_projections"
+        for blocker in result.blockers
+    )
+    assert client.workflow_describes == []
+
+
+@pytest.mark.asyncio
+async def test_preflight_blocks_nonterminal_search_unit_after_temporal_close(
+    db_path: Path,
+) -> None:
+    _block_dispatches(db_path)
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            INSERT INTO discovery_search_units (
+                tenant_id, discover_workflow_id, discover_run_id,
+                unit_id, ordinal, request_json, request_fingerprint,
+                state, created_at, updated_at
+            ) VALUES (
+                'local', 'discover-local', 'discover-run-one',
+                'unit-one', 0, '{}', 'fingerprint',
+                'running', ?, ?
+            )
+            """,
+            (
+                "2026-07-30T00:00:00+00:00",
+                "2026-07-30T00:00:00+00:00",
+            ),
+        )
+    client = _TemporalClient(
+        workflows={
+            (
+                "discover-local",
+                "discover-run-one",
+            ): _WorkflowDescription(WorkflowExecutionStatus.COMPLETED),
+            (
+                "discover-local",
+                None,
+            ): _WorkflowDescription(WorkflowExecutionStatus.COMPLETED),
+        }
+    )
+
+    result = await _run_preflight(
+        client,
+        db_path=db_path,
+    )
+
+    assert result.ready is False
+    assert any(
+        owner.source == "discovery_search_units" and owner.state == "running" and owner.count == 1
+        for owner in result.durable_owners
+    )
+    assert any(
+        blocker.code == "durable_owner_nonterminal" and blocker.source == "discovery_search_units"
+        for blocker in result.blockers
+    )
+
+
+@pytest.mark.asyncio
+async def test_preflight_rechecks_exact_execution_after_stable_inventory(
+    db_path: Path,
+) -> None:
+    _block_dispatches(db_path)
+    observations = iter(
+        (
+            _WorkflowDescription(WorkflowExecutionStatus.COMPLETED),
+            _WorkflowDescription(WorkflowExecutionStatus.RUNNING),
+        )
+    )
+    client = _TemporalClient(
+        workflows={
+            ("discover-local", None): lambda: next(observations),
+        }
+    )
+
+    result = await _run_preflight(
+        client,
+        db_path=db_path,
+    )
+
+    assert result.ready is False
+    discover = next(
+        observation for observation in result.executions if observation.candidate.workflow_id == "discover-local"
+    )
+    assert discover.state == "open"
+    assert any(blocker.code == "workflow_execution_open" for blocker in result.blockers)
+    assert client.workflow_describes == [
+        (_AUTHORITY_WORKFLOW_ID, _AUTHORITY_RUN_ID),
+        ("apply-auto-local", None),
+        ("discover-local", None),
+        ("apply-auto-local", None),
+        ("discover-local", None),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_preflight_blocks_queued_preparation_owner_even_when_run_absent(
+    db_path: Path,
+) -> None:
+    _block_dispatches(db_path)
+    resolved_job_id = _ensure_job(db_path)
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            INSERT INTO preparation_work_items (
+                item_id, tenant_id, job_id, kind, target_version,
+                source_event_id, state, idempotency_key, attempts,
+                last_error, created_at, updated_at, available_at
+            ) VALUES (
+                'item-one', 'local', ?, 'score_job', 1,
+                '', 'queued', 'preparation:legacy-key', 0,
+                '', ?, ?, ?
+            )
+            """,
+            (
+                resolved_job_id,
+                "2026-07-30T00:00:00+00:00",
+                "2026-07-30T00:00:00+00:00",
+                "2026-07-30T00:00:00+00:00",
+            ),
+        )
+    client = _TemporalClient()
+
+    result = await _run_preflight(
+        client,
+        db_path=db_path,
+    )
+
+    assert result.ready is False
+    assert (
+        "prep-preparation:legacy-key",
+        None,
+    ) in client.workflow_describes
+    assert any(
+        blocker.code == "durable_owner_nonterminal" and blocker.source == "preparation_work_items"
+        for blocker in result.blockers
+    )
+
+
+@pytest.mark.asyncio
+async def test_preflight_blocks_pending_discovery_work_plan(
+    db_path: Path,
+) -> None:
+    _block_dispatches(db_path)
+    job_id = _ensure_job(db_path)
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            INSERT INTO discovery_execution_jobs (
+                tenant_id, discover_workflow_id, discover_run_id,
+                job_id, cohort_kind, work_plan_state, linked_at
+            ) VALUES (
+                'local', 'discover-local', 'discover-pending-run',
+                ?, 'existing_backlog', 'pending', ?
+            )
+            """,
+            (
+                job_id,
+                "2026-07-30T00:00:00+00:00",
+            ),
+        )
+    client = _TemporalClient()
+
+    result = await _run_preflight(
+        client,
+        db_path=db_path,
+    )
+
+    assert result.ready is False
+    assert any(
+        owner.source == "discovery_execution_jobs" and owner.state == "pending" and owner.count == 1
+        for owner in result.durable_owners
+    )
+    assert any(
+        blocker.code == "durable_owner_nonterminal" and blocker.source == "discovery_execution_jobs"
+        for blocker in result.blockers
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("state", ["queued", "running"])
+async def test_preflight_blocks_nonterminal_pipeline_step(
+    db_path: Path,
+    state: str,
+) -> None:
+    _block_dispatches(db_path)
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            INSERT INTO pipeline_step_projections (
+                tenant_id, discover_workflow_id, discover_run_id,
+                step_kind, item_key, state, attempt,
+                last_event_id, last_updated_at
+            ) VALUES (
+                'local', 'discover-local', 'discover-step-run',
+                'source_family', ?, ?, 1, 1, ?
+            )
+            """,
+            (
+                f"step-{state}",
+                state,
+                "2026-07-30T00:00:00+00:00",
+            ),
+        )
+    client = _TemporalClient()
+
+    result = await _run_preflight(
+        client,
+        db_path=db_path,
+    )
+
+    assert result.ready is False
+    assert any(
+        owner.source == "pipeline_step_projections" and owner.state == state and owner.count == 1
+        for owner in result.durable_owners
+    )
+    assert any(
+        blocker.code == "durable_owner_nonterminal" and blocker.source == "pipeline_step_projections"
+        for blocker in result.blockers
+    )
+
+
+@pytest.mark.asyncio
+async def test_preflight_refuses_unpaused_identity_schedule(
+    db_path: Path,
+) -> None:
+    _block_dispatches(db_path)
+    client = _TemporalClient(schedule=SimpleNamespace(schedule=SimpleNamespace(state=SimpleNamespace(paused=False))))
+
+    result = await _run_preflight(
+        client,
+        db_path=db_path,
+    )
+
+    assert result.ready is False
+    assert result.schedules[0].state == "unpaused"
+    assert any(blocker.code == "identity_schedule_unpaused" for blocker in result.blockers)
+
+
+@pytest.mark.asyncio
+async def test_preflight_refuses_local_work_added_during_exact_describe(
+    db_path: Path,
+) -> None:
+    _block_dispatches(db_path)
+
+    def _close_after_persisting_work() -> _WorkflowDescription:
+        with sqlite3.connect(db_path) as conn:
+            conn.execute(
+                """
+                INSERT INTO discovery_search_units (
+                    tenant_id, discover_workflow_id, discover_run_id,
+                    unit_id, ordinal, request_json, request_fingerprint,
+                    state, created_at, updated_at
+                ) VALUES (
+                    'local', 'discover-local', 'late-run',
+                    'late-unit', 0, '{}', 'fingerprint',
+                    'pending', ?, ?
+                )
+                """,
+                (
+                    "2026-07-30T00:00:00+00:00",
+                    "2026-07-30T00:00:00+00:00",
+                ),
+            )
+        return _WorkflowDescription(WorkflowExecutionStatus.COMPLETED)
+
+    client = _TemporalClient(
+        workflows={
+            ("discover-local", None): _close_after_persisting_work,
+        }
+    )
+
+    result = await _run_preflight(
+        client,
+        db_path=db_path,
+    )
+
+    assert result.ready is False
+    assert any(blocker.code == "local_inventory_changed" for blocker in result.blockers)
+    assert any(
+        blocker.code == "durable_owner_nonterminal" and blocker.source == "discovery_search_units"
+        for blocker in result.blockers
+    )
+
+
+@pytest.mark.asyncio
+async def test_preflight_refuses_local_work_added_during_second_describe(
+    db_path: Path,
+) -> None:
+    _block_dispatches(db_path)
+    describe_count = 0
+
+    def _persist_work_during_second_describe() -> _WorkflowDescription:
+        nonlocal describe_count
+        describe_count += 1
+        if describe_count == 2:
+            with sqlite3.connect(db_path) as conn:
+                conn.execute(
+                    """
+                    INSERT INTO discovery_search_units (
+                        tenant_id, discover_workflow_id, discover_run_id,
+                        unit_id, ordinal, request_json, request_fingerprint,
+                        state, created_at, updated_at
+                    ) VALUES (
+                        'local', 'discover-local', 'late-second-run',
+                        'late-second-unit', 0, '{}', 'fingerprint-second',
+                        'pending', ?, ?
+                    )
+                    """,
+                    (
+                        "2026-07-30T00:00:00+00:00",
+                        "2026-07-30T00:00:00+00:00",
+                    ),
+                )
+        return _WorkflowDescription(WorkflowExecutionStatus.COMPLETED)
+
+    client = _TemporalClient(
+        workflows={
+            ("discover-local", None): _persist_work_during_second_describe,
+        }
+    )
+
+    result = await _run_preflight(
+        client,
+        db_path=db_path,
+    )
+
+    assert result.ready is False
+    assert describe_count == 2
+    assert any(blocker.code == "local_inventory_changed" for blocker in result.blockers)
+    assert any(
+        blocker.code == "durable_owner_nonterminal" and blocker.source == "discovery_search_units"
+        for blocker in result.blockers
+    )
+
+
+@pytest.mark.asyncio
+async def test_preflight_refuses_replaced_fence_and_proof_generation(
+    db_path: Path,
+) -> None:
+    _block_dispatches(db_path)
+    describe_count = 0
+
+    def _replace_proof_during_second_describe() -> _WorkflowDescription:
+        nonlocal describe_count
+        describe_count += 1
+        if describe_count == 2:
+            with sqlite3.connect(db_path) as conn:
+                conn.execute(
+                    """
+                    UPDATE workflow_dispatch_control
+                    SET blocked_at = ?
+                    WHERE control_key = ?
+                    """,
+                    (
+                        "2026-07-30T00:00:02+00:00",
+                        CONTROL_KEY,
+                    ),
+                )
+            _seal_inventory(
+                db_path,
+                proof_id="proof-two",
+            )
+        return _WorkflowDescription(WorkflowExecutionStatus.COMPLETED)
+
+    client = _TemporalClient(
+        workflows={
+            ("discover-local", None): _replace_proof_during_second_describe,
+        }
+    )
+
+    result = await _run_preflight(
+        client,
+        db_path=db_path,
+    )
+
+    assert result.ready is False
+    assert describe_count == 2
+    assert any(blocker.code == "cutover_proof_changed" for blocker in result.blockers)


### PR DESCRIPTION
## What changed

- collect a closed inventory of identity-bearing Temporal executions from the declared SQLite authorities
- describe both pinned runs and the latest execution for each workflow ID, including continued-as-new chains
- verify identity-bearing schedule state and all durable nonterminal owners
- bind every absence decision to the recovery proof's namespace name, server namespace ID, and exact closed authority-marker execution
- compare fence epoch, proof generation, candidates, and durable owners across repeated local snapshots and exact describe passes
- require the caller to retain the exclusive cutover lifecycle lease through preflight and the later migration transaction

## Why

The stable JobId migration cannot safely rebuild identity-bearing records while an execution may still be open, a worker can restart, a local owner can commit late work, or Temporal absence is being queried against the wrong history store. This preflight returns ready only when those authorities agree under one retained lease.

Visibility/list/search APIs are intentionally not used because their absence results are eventually consistent.

## Validation

- focused exact-preflight tests: 30 passed
- focused prerequisite and adversarial QA matrix: 61 passed
- full Python suite: 2,863 passed, 2 skipped
- Ruff, Python compilation, and diff-check: passed
- independent review: PASS
- adversarial QA: PASS

The remaining residual is operational: exact SDK behavior was tested with service-shaped doubles rather than a live restored/replaced Temporal namespace. A live operator workflow is added in the subsequent cutover-runner phase.