### PR TITLE
feat(identity): define historical event JobId upcast

### DIFF
--- a/apps/api/src/event-identity-upcast.ts
+++ b/apps/api/src/event-identity-upcast.ts
@@ -1,0 +1,248 @@
+import type { SqliteDatabase } from "./db.js";
+
+export const EVENT_IDENTITY_UPCAST_VERSION = 1;
+
+const SINGLE_FIELDS: Record<string, string> = {
+  jobId: "jobId",
+  jobUrl: "jobId",
+  jobKey: "jobId",
+  job_id: "job_id",
+  job_url: "job_id",
+  job_key: "job_id",
+};
+
+const PLURAL_FIELDS: Record<string, string> = {
+  jobIds: "jobIds",
+  jobUrls: "jobIds",
+  jobKeys: "jobIds",
+  job_ids: "job_ids",
+  job_urls: "job_ids",
+  job_keys: "job_ids",
+};
+
+export class EventIdentityUpcastError extends Error {
+  readonly code: string;
+
+  constructor(code: string) {
+    super(code);
+    this.name = "EventIdentityUpcastError";
+    this.code = code;
+  }
+}
+
+export interface UpcastedEventIdentity {
+  version: number;
+  jobId: string | null;
+  referencedJobIds: string[];
+  payload: Record<string, unknown>;
+}
+
+export function upcastEventIdentity(
+  db: SqliteDatabase,
+  input: {
+    tenantId: string;
+    eventJobReference: string | null;
+    payload: unknown;
+  },
+): UpcastedEventIdentity {
+  const tenantId = String(input.tenantId ?? "").trim();
+  if (!tenantId) {
+    throw new EventIdentityUpcastError("event_job_identity_invalid");
+  }
+
+  const referenced = new Set<string>();
+  const columnJobId =
+    input.eventJobReference === null
+      ? null
+      : resolveReference(db, tenantId, input.eventJobReference);
+  if (columnJobId !== null) referenced.add(columnJobId);
+
+  if (!isRecord(input.payload)) {
+    throw new EventIdentityUpcastError("event_job_identity_invalid");
+  }
+  const payload = upcastValue(db, tenantId, input.payload, referenced);
+  if (!isRecord(payload)) {
+    throw new EventIdentityUpcastError("event_job_identity_invalid");
+  }
+
+  const rootJobIds = new Set(
+    ["jobId", "job_id"]
+      .map((key) => payload[key])
+      .filter((value): value is string => typeof value === "string"),
+  );
+  const primaryJobIds = new Set(rootJobIds);
+  if (columnJobId !== null) primaryJobIds.add(columnJobId);
+  if (primaryJobIds.size > 1) {
+    throw new EventIdentityUpcastError("event_job_identity_conflict");
+  }
+
+  let jobId: string | null;
+  if (columnJobId !== null) {
+    jobId = columnJobId;
+  } else if (rootJobIds.size === 1) {
+    jobId = rootJobIds.values().next().value ?? null;
+  } else if (referenced.size === 1) {
+    jobId = referenced.values().next().value ?? null;
+  } else {
+    jobId = null;
+  }
+  return {
+    version: EVENT_IDENTITY_UPCAST_VERSION,
+    jobId,
+    referencedJobIds: [...referenced].sort(),
+    payload,
+  };
+}
+
+function upcastValue(
+  db: SqliteDatabase,
+  tenantId: string,
+  value: unknown,
+  referenced: Set<string>,
+): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => upcastValue(db, tenantId, item, referenced));
+  }
+  if (!isRecord(value)) return value;
+
+  const transformed: Record<string, unknown> = {};
+  for (const [key, rawValue] of Object.entries(value)) {
+    let outputKey = key;
+    let outputValue: unknown;
+    if (hasOwn(SINGLE_FIELDS, key)) {
+      outputKey = SINGLE_FIELDS[key]!;
+      outputValue = upcastSingleReference(db, tenantId, rawValue, referenced);
+    } else if (hasOwn(PLURAL_FIELDS, key)) {
+      outputKey = PLURAL_FIELDS[key]!;
+      outputValue = upcastReferenceCollection(db, tenantId, rawValue, referenced);
+    } else {
+      outputValue = upcastValue(db, tenantId, rawValue, referenced);
+    }
+    if (
+      Object.prototype.hasOwnProperty.call(transformed, outputKey)
+      && !valuesEqual(transformed[outputKey], outputValue)
+    ) {
+      throw new EventIdentityUpcastError("event_job_identity_conflict");
+    }
+    Object.defineProperty(transformed, outputKey, {
+      value: outputValue,
+      enumerable: true,
+      configurable: true,
+      writable: true,
+    });
+  }
+  return transformed;
+}
+
+function upcastSingleReference(
+  db: SqliteDatabase,
+  tenantId: string,
+  value: unknown,
+  referenced: Set<string>,
+): string | null {
+  if (value === null) return null;
+  if (typeof value !== "string") {
+    throw new EventIdentityUpcastError("event_job_identity_invalid");
+  }
+  const jobId = resolveReference(db, tenantId, value);
+  referenced.add(jobId);
+  return jobId;
+}
+
+function upcastReferenceCollection(
+  db: SqliteDatabase,
+  tenantId: string,
+  value: unknown,
+  referenced: Set<string>,
+): Array<string | null> {
+  if (!Array.isArray(value)) {
+    throw new EventIdentityUpcastError("event_job_identity_invalid");
+  }
+  return value.map((item) => upcastSingleReference(db, tenantId, item, referenced));
+}
+
+function resolveReference(
+  db: SqliteDatabase,
+  tenantId: string,
+  reference: string,
+): string {
+  const normalized = String(reference ?? "").trim();
+  if (!normalized) {
+    throw new EventIdentityUpcastError("event_job_identity_invalid");
+  }
+
+  const directUrl = jobIdFromQuery(
+    db,
+    `
+      SELECT job_id
+      FROM jobs
+      WHERE tenant_id = ? AND url = ?
+    `,
+    tenantId,
+    normalized,
+  );
+  const aliasUrl = jobIdFromQuery(
+    db,
+    `
+      SELECT jobs.job_id
+      FROM job_identity_aliases AS aliases
+      JOIN jobs
+        ON jobs.tenant_id = aliases.tenant_id
+       AND jobs.job_id = aliases.job_id
+      WHERE aliases.tenant_id = ?
+        AND aliases.alias_kind = 'posting_url'
+        AND aliases.alias_value = ?
+    `,
+    tenantId,
+    normalized,
+  );
+  if (directUrl !== null && aliasUrl !== null && directUrl !== aliasUrl) {
+    throw new EventIdentityUpcastError("event_job_identity_conflict");
+  }
+  const urlJobId = directUrl ?? aliasUrl;
+  if (urlJobId !== null) return urlJobId;
+
+  const stableJobId = jobIdFromQuery(
+    db,
+    `
+      SELECT job_id
+      FROM jobs
+      WHERE tenant_id = ? AND job_id = ?
+    `,
+    tenantId,
+    normalized,
+  );
+  if (stableJobId === null) {
+    throw new EventIdentityUpcastError("event_job_identity_unresolved");
+  }
+  return stableJobId;
+}
+
+function jobIdFromQuery(
+  db: SqliteDatabase,
+  sql: string,
+  tenantId: string,
+  reference: string,
+): string | null {
+  const row = db.prepare(sql).get(tenantId, reference) as
+    | { job_id?: string | null }
+    | undefined;
+  if (row === undefined) return null;
+  const jobId = String(row.job_id ?? "").trim();
+  if (!jobId) {
+    throw new EventIdentityUpcastError("event_job_identity_invalid");
+  }
+  return jobId;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function valuesEqual(left: unknown, right: unknown): boolean {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+function hasOwn(record: Record<string, string>, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(record, key);
+}

--- a/apps/api/src/event-identity-upcast.ts
+++ b/apps/api/src/event-identity-upcast.ts
@@ -9,6 +9,10 @@ const SINGLE_FIELDS: Record<string, string> = {
   job_id: "job_id",
   job_url: "job_id",
   job_key: "job_id",
+  candidateJobId: "candidateJobId",
+  candidate_job_id: "candidate_job_id",
+  survivingJobId: "survivingJobId",
+  surviving_job_id: "surviving_job_id",
 };
 
 const PLURAL_FIELDS: Record<string, string> = {
@@ -19,6 +23,12 @@ const PLURAL_FIELDS: Record<string, string> = {
   job_urls: "job_ids",
   job_keys: "job_ids",
 };
+const ROOT_PRIMARY_FIELDS = [
+  "jobId",
+  "job_id",
+  "survivingJobId",
+  "surviving_job_id",
+] as const;
 
 export class EventIdentityUpcastError extends Error {
   readonly code: string;
@@ -66,7 +76,7 @@ export function upcastEventIdentity(
   }
 
   const rootJobIds = new Set(
-    ["jobId", "job_id"]
+    ROOT_PRIMARY_FIELDS
       .map((key) => payload[key])
       .filter((value): value is string => typeof value === "string"),
   );
@@ -81,10 +91,12 @@ export function upcastEventIdentity(
     jobId = columnJobId;
   } else if (rootJobIds.size === 1) {
     jobId = rootJobIds.values().next().value ?? null;
-  } else if (referenced.size === 1) {
-    jobId = referenced.values().next().value ?? null;
   } else {
-    jobId = null;
+    const inferableJobIds = inferablePayloadJobIds(payload);
+    jobId =
+      inferableJobIds.size === 1
+        ? inferableJobIds.values().next().value ?? null
+        : null;
   }
   return {
     version: EVENT_IDENTITY_UPCAST_VERSION,
@@ -181,21 +193,23 @@ function resolveReference(
     tenantId,
     normalized,
   );
-  const aliasUrl = jobIdFromQuery(
-    db,
-    `
-      SELECT jobs.job_id
-      FROM job_identity_aliases AS aliases
-      JOIN jobs
-        ON jobs.tenant_id = aliases.tenant_id
-       AND jobs.job_id = aliases.job_id
-      WHERE aliases.tenant_id = ?
-        AND aliases.alias_kind = 'posting_url'
-        AND aliases.alias_value = ?
-    `,
-    tenantId,
-    normalized,
-  );
+  const aliasUrl = aliasTableExists(db)
+    ? jobIdFromQuery(
+        db,
+        `
+          SELECT jobs.job_id
+          FROM job_identity_aliases AS aliases
+          JOIN jobs
+            ON jobs.tenant_id = aliases.tenant_id
+           AND jobs.job_id = aliases.job_id
+          WHERE aliases.tenant_id = ?
+            AND aliases.alias_kind = 'posting_url'
+            AND aliases.alias_value = ?
+        `,
+        tenantId,
+        normalized,
+      )
+    : null;
   if (directUrl !== null && aliasUrl !== null && directUrl !== aliasUrl) {
     throw new EventIdentityUpcastError("event_job_identity_conflict");
   }
@@ -245,4 +259,49 @@ function valuesEqual(left: unknown, right: unknown): boolean {
 
 function hasOwn(record: Record<string, string>, key: string): boolean {
   return Object.prototype.hasOwnProperty.call(record, key);
+}
+
+function aliasTableExists(db: SqliteDatabase): boolean {
+  const row = db
+    .prepare(
+      `
+        SELECT 1
+        FROM sqlite_master
+        WHERE type = 'table' AND name = 'job_identity_aliases'
+        LIMIT 1
+      `,
+    )
+    .get();
+  return row !== undefined;
+}
+
+function inferablePayloadJobIds(value: unknown): Set<string> {
+  const inferred = new Set<string>();
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      for (const jobId of inferablePayloadJobIds(item)) inferred.add(jobId);
+    }
+    return inferred;
+  }
+  if (!isRecord(value)) return inferred;
+
+  for (const [key, item] of Object.entries(value)) {
+    if ((key === "jobId" || key === "job_id") && typeof item === "string") {
+      inferred.add(item);
+    } else if ((key === "jobIds" || key === "job_ids") && Array.isArray(item)) {
+      for (const entry of item) {
+        if (typeof entry === "string") inferred.add(entry);
+      }
+    } else if (
+      ![
+        "candidateJobId",
+        "candidate_job_id",
+        "survivingJobId",
+        "surviving_job_id",
+      ].includes(key)
+    ) {
+      for (const jobId of inferablePayloadJobIds(item)) inferred.add(jobId);
+    }
+  }
+  return inferred;
 }

--- a/apps/api/test/event-identity-upcast.test.ts
+++ b/apps/api/test/event-identity-upcast.test.ts
@@ -107,4 +107,23 @@ describe("historical event identity upcast", () => {
       );
     }
   });
+
+  it("resolves current URLs and stable IDs without an alias table", () => {
+    const db = seededDb();
+    db.exec("DROP TABLE job_identity_aliases");
+
+    const byUrl = upcastEventIdentity(db, {
+      tenantId: "local",
+      eventJobReference: "https://jobs.example/a",
+      payload: {},
+    });
+    const byId = upcastEventIdentity(db, {
+      tenantId: "local",
+      eventJobReference: "22222222-2222-4222-8222-222222222222",
+      payload: {},
+    });
+
+    expect(byUrl.jobId).toBe("11111111-1111-4111-8111-111111111111");
+    expect(byId.jobId).toBe("22222222-2222-4222-8222-222222222222");
+  });
 });

--- a/apps/api/test/event-identity-upcast.test.ts
+++ b/apps/api/test/event-identity-upcast.test.ts
@@ -1,0 +1,110 @@
+import fs from "node:fs";
+import { fileURLToPath } from "node:url";
+import Database from "better-sqlite3";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  EventIdentityUpcastError,
+  upcastEventIdentity,
+} from "../src/event-identity-upcast.js";
+
+const FIXTURE_PATH = fileURLToPath(
+  new URL(
+    "../../../packages/domain-types/test/fixtures/event_identity_upcast_v1.json",
+    import.meta.url,
+  ),
+);
+
+interface FixtureJob {
+  tenantId: string;
+  jobId: string;
+  postingUrl: string;
+  aliases?: string[];
+}
+
+interface FixtureCase {
+  name: string;
+  tenantId: string;
+  eventJobReference: string | null;
+  payload: unknown;
+  expected?: {
+    jobId: string | null;
+    referencedJobIds: string[];
+    payload: Record<string, unknown>;
+  };
+  expectedError?: string;
+}
+
+interface Fixture {
+  version: number;
+  jobs: FixtureJob[];
+  cases: FixtureCase[];
+}
+
+const fixture = JSON.parse(fs.readFileSync(FIXTURE_PATH, "utf8")) as Fixture;
+const databases: Database.Database[] = [];
+
+afterEach(() => {
+  while (databases.length) databases.pop()?.close();
+});
+
+function seededDb(): Database.Database {
+  const db = new Database(":memory:");
+  databases.push(db);
+  db.exec(`
+    CREATE TABLE jobs (
+      tenant_id TEXT NOT NULL,
+      job_id TEXT NOT NULL,
+      url TEXT NOT NULL,
+      PRIMARY KEY (tenant_id, job_id),
+      UNIQUE (tenant_id, url)
+    );
+    CREATE TABLE job_identity_aliases (
+      tenant_id TEXT NOT NULL,
+      alias_kind TEXT NOT NULL,
+      alias_value TEXT NOT NULL,
+      job_id TEXT NOT NULL,
+      PRIMARY KEY (tenant_id, alias_kind, alias_value)
+    );
+  `);
+  const insertJob = db.prepare(
+    "INSERT INTO jobs (tenant_id, job_id, url) VALUES (?, ?, ?)",
+  );
+  const insertAlias = db.prepare(
+    `INSERT INTO job_identity_aliases (
+       tenant_id, alias_kind, alias_value, job_id
+     ) VALUES (?, 'posting_url', ?, ?)`,
+  );
+  for (const job of fixture.jobs) {
+    insertJob.run(job.tenantId, job.jobId, job.postingUrl);
+    for (const alias of job.aliases ?? []) {
+      insertAlias.run(job.tenantId, alias, job.jobId);
+    }
+  }
+  return db;
+}
+
+describe("historical event identity upcast", () => {
+  it.each(fixture.cases)("$name", (testCase) => {
+    const db = seededDb();
+    try {
+      const result = upcastEventIdentity(db, {
+        tenantId: testCase.tenantId,
+        eventJobReference: testCase.eventJobReference,
+        payload: testCase.payload,
+      });
+      expect(testCase.expectedError).toBeUndefined();
+      expect(result).toEqual({
+        version: fixture.version,
+        ...testCase.expected,
+      });
+    } catch (error) {
+      expect(testCase.expectedError).toBeDefined();
+      expect(error).toBeInstanceOf(EventIdentityUpcastError);
+      expect((error as EventIdentityUpcastError).code).toBe(testCase.expectedError);
+      expect(String(error)).not.toContain(
+        testCase.eventJobReference ?? "https://missing.example/job",
+      );
+    }
+  });
+});

--- a/packages/domain-types/test/fixtures/event_identity_upcast_v1.json
+++ b/packages/domain-types/test/fixtures/event_identity_upcast_v1.json
@@ -255,6 +255,52 @@
           }
         }
       }
+    },
+    {
+      "name": "candidate-only domain identity remains related",
+      "tenantId": "local",
+      "eventJobReference": null,
+      "payload": {
+        "candidateJobId": "https://jobs.example/a"
+      },
+      "expected": {
+        "jobId": null,
+        "referencedJobIds": [
+          "11111111-1111-4111-8111-111111111111"
+        ],
+        "payload": {
+          "candidateJobId": "11111111-1111-4111-8111-111111111111"
+        }
+      }
+    },
+    {
+      "name": "surviving domain identity becomes primary",
+      "tenantId": "local",
+      "eventJobReference": null,
+      "payload": {
+        "candidateJobId": "https://jobs.example/a",
+        "surviving_job_id": "https://old.example/c"
+      },
+      "expected": {
+        "jobId": "33333333-3333-4333-8333-333333333333",
+        "referencedJobIds": [
+          "11111111-1111-4111-8111-111111111111",
+          "33333333-3333-4333-8333-333333333333"
+        ],
+        "payload": {
+          "candidateJobId": "11111111-1111-4111-8111-111111111111",
+          "surviving_job_id": "33333333-3333-4333-8333-333333333333"
+        }
+      }
+    },
+    {
+      "name": "event column and surviving identity disagreement fails closed",
+      "tenantId": "local",
+      "eventJobReference": "https://jobs.example/a",
+      "payload": {
+        "survivingJobId": "https://jobs.example/c"
+      },
+      "expectedError": "event_job_identity_conflict"
     }
   ]
 }

--- a/packages/domain-types/test/fixtures/event_identity_upcast_v1.json
+++ b/packages/domain-types/test/fixtures/event_identity_upcast_v1.json
@@ -1,0 +1,260 @@
+{
+  "version": 1,
+  "jobs": [
+    {
+      "tenantId": "local",
+      "jobId": "11111111-1111-4111-8111-111111111111",
+      "postingUrl": "https://jobs.example/a"
+    },
+    {
+      "tenantId": "local",
+      "jobId": "22222222-2222-4222-8222-222222222222",
+      "postingUrl": "11111111-1111-4111-8111-111111111111"
+    },
+    {
+      "tenantId": "local",
+      "jobId": "33333333-3333-4333-8333-333333333333",
+      "postingUrl": "https://jobs.example/c",
+      "aliases": [
+        "https://old.example/c",
+        "https://jobs.example/conflict"
+      ]
+    },
+    {
+      "tenantId": "other",
+      "jobId": "44444444-4444-4444-8444-444444444444",
+      "postingUrl": "https://jobs.example/a"
+    },
+    {
+      "tenantId": "local",
+      "jobId": "55555555-5555-4555-8555-555555555555",
+      "postingUrl": "https://jobs.example/conflict"
+    }
+  ],
+  "cases": [
+    {
+      "name": "legacy column and nested payload fields",
+      "tenantId": "local",
+      "eventJobReference": "https://jobs.example/a",
+      "payload": {
+        "tenantId": "local",
+        "jobUrl": "https://jobs.example/a",
+        "nested": {
+          "job_key": "https://old.example/c"
+        },
+        "jobUrls": [
+          "https://jobs.example/a",
+          "11111111-1111-4111-8111-111111111111"
+        ],
+        "applicationUrl": "https://apply.example/a",
+        "postingUrl": "https://jobs.example/a"
+      },
+      "expected": {
+        "jobId": "11111111-1111-4111-8111-111111111111",
+        "referencedJobIds": [
+          "11111111-1111-4111-8111-111111111111",
+          "22222222-2222-4222-8222-222222222222",
+          "33333333-3333-4333-8333-333333333333"
+        ],
+        "payload": {
+          "tenantId": "local",
+          "jobId": "11111111-1111-4111-8111-111111111111",
+          "nested": {
+            "job_id": "33333333-3333-4333-8333-333333333333"
+          },
+          "jobIds": [
+            "11111111-1111-4111-8111-111111111111",
+            "22222222-2222-4222-8222-222222222222"
+          ],
+          "applicationUrl": "https://apply.example/a",
+          "postingUrl": "https://jobs.example/a"
+        }
+      }
+    },
+    {
+      "name": "stable values and locator fields",
+      "tenantId": "local",
+      "eventJobReference": "22222222-2222-4222-8222-222222222222",
+      "payload": {
+        "jobId": "22222222-2222-4222-8222-222222222222",
+        "job_ids": [
+          "22222222-2222-4222-8222-222222222222",
+          null
+        ],
+        "application_url": "https://apply.example/b",
+        "canonicalUrl": "11111111-1111-4111-8111-111111111111"
+      },
+      "expected": {
+        "jobId": "22222222-2222-4222-8222-222222222222",
+        "referencedJobIds": [
+          "22222222-2222-4222-8222-222222222222"
+        ],
+        "payload": {
+          "jobId": "22222222-2222-4222-8222-222222222222",
+          "job_ids": [
+            "22222222-2222-4222-8222-222222222222",
+            null
+          ],
+          "application_url": "https://apply.example/b",
+          "canonicalUrl": "11111111-1111-4111-8111-111111111111"
+        }
+      }
+    },
+    {
+      "name": "uuid shaped posting URL is resolved URL first",
+      "tenantId": "local",
+      "eventJobReference": "11111111-1111-4111-8111-111111111111",
+      "payload": {
+        "jobKey": "11111111-1111-4111-8111-111111111111"
+      },
+      "expected": {
+        "jobId": "22222222-2222-4222-8222-222222222222",
+        "referencedJobIds": [
+          "22222222-2222-4222-8222-222222222222"
+        ],
+        "payload": {
+          "jobId": "22222222-2222-4222-8222-222222222222"
+        }
+      }
+    },
+    {
+      "name": "nullable optional job identity",
+      "tenantId": "local",
+      "eventJobReference": null,
+      "payload": {
+        "jobId": null,
+        "job_ids": [
+          null
+        ]
+      },
+      "expected": {
+        "jobId": null,
+        "referencedJobIds": [],
+        "payload": {
+          "jobId": null,
+          "job_ids": [
+            null
+          ]
+        }
+      }
+    },
+    {
+      "name": "resolution is tenant scoped",
+      "tenantId": "other",
+      "eventJobReference": "https://jobs.example/a",
+      "payload": {
+        "jobUrl": "https://jobs.example/a"
+      },
+      "expected": {
+        "jobId": "44444444-4444-4444-8444-444444444444",
+        "referencedJobIds": [
+          "44444444-4444-4444-8444-444444444444"
+        ],
+        "payload": {
+          "jobId": "44444444-4444-4444-8444-444444444444"
+        }
+      }
+    },
+    {
+      "name": "direct URL and alias disagreement fails closed",
+      "tenantId": "local",
+      "eventJobReference": "https://jobs.example/conflict",
+      "payload": {},
+      "expectedError": "event_job_identity_conflict"
+    },
+    {
+      "name": "event column and root payload disagreement fails closed",
+      "tenantId": "local",
+      "eventJobReference": "https://jobs.example/a",
+      "payload": {
+        "jobUrl": "https://jobs.example/c"
+      },
+      "expectedError": "event_job_identity_conflict"
+    },
+    {
+      "name": "conflicting payload identity fields fail closed",
+      "tenantId": "local",
+      "eventJobReference": null,
+      "payload": {
+        "jobUrl": "https://jobs.example/a",
+        "jobId": "22222222-2222-4222-8222-222222222222"
+      },
+      "expectedError": "event_job_identity_conflict"
+    },
+    {
+      "name": "unresolved identity fails closed",
+      "tenantId": "local",
+      "eventJobReference": "https://missing.example/job",
+      "payload": {},
+      "expectedError": "event_job_identity_unresolved"
+    },
+    {
+      "name": "malformed identity collection fails closed",
+      "tenantId": "local",
+      "eventJobReference": null,
+      "payload": {
+        "jobUrls": [
+          "https://jobs.example/a",
+          42
+        ]
+      },
+      "expectedError": "event_job_identity_invalid"
+    },
+    {
+      "name": "null root payload fails closed",
+      "tenantId": "local",
+      "eventJobReference": null,
+      "payload": null,
+      "expectedError": "event_job_identity_invalid"
+    },
+    {
+      "name": "array root payload fails closed",
+      "tenantId": "local",
+      "eventJobReference": null,
+      "payload": [
+        [
+          "jobId",
+          null
+        ]
+      ],
+      "expectedError": "event_job_identity_invalid"
+    },
+    {
+      "name": "scalar root payload fails closed",
+      "tenantId": "local",
+      "eventJobReference": null,
+      "payload": "text",
+      "expectedError": "event_job_identity_invalid"
+    },
+    {
+      "name": "prototype named fields remain ordinary payload data",
+      "tenantId": "local",
+      "eventJobReference": null,
+      "payload": {
+        "constructor": {
+          "jobUrl": "https://jobs.example/a"
+        },
+        "toString": "unchanged",
+        "__proto__": {
+          "job_url": "https://jobs.example/c"
+        }
+      },
+      "expected": {
+        "jobId": null,
+        "referencedJobIds": [
+          "11111111-1111-4111-8111-111111111111",
+          "33333333-3333-4333-8333-333333333333"
+        ],
+        "payload": {
+          "constructor": {
+            "jobId": "11111111-1111-4111-8111-111111111111"
+          },
+          "toString": "unchanged",
+          "__proto__": {
+            "job_id": "33333333-3333-4333-8333-333333333333"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/workers/automation/src/jobctrl/infrastructure/events/identity_upcast.py
+++ b/workers/automation/src/jobctrl/infrastructure/events/identity_upcast.py
@@ -21,6 +21,10 @@ _SINGLE_FIELDS = {
     "job_id": "job_id",
     "job_url": "job_id",
     "job_key": "job_id",
+    "candidateJobId": "candidateJobId",
+    "candidate_job_id": "candidate_job_id",
+    "survivingJobId": "survivingJobId",
+    "surviving_job_id": "surviving_job_id",
 }
 _PLURAL_FIELDS = {
     "jobIds": "jobIds",
@@ -30,6 +34,12 @@ _PLURAL_FIELDS = {
     "job_urls": "job_ids",
     "job_keys": "job_ids",
 }
+_ROOT_PRIMARY_FIELDS = (
+    "jobId",
+    "job_id",
+    "survivingJobId",
+    "surviving_job_id",
+)
 
 
 class EventIdentityUpcastError(RuntimeError):
@@ -87,7 +97,7 @@ def upcast_event_identity(
 
     root_job_ids = {
         value
-        for key in ("jobId", "job_id")
+        for key in _ROOT_PRIMARY_FIELDS
         if isinstance((value := transformed.get(key)), str)
     }
     primary_job_ids = set(root_job_ids)
@@ -100,8 +110,8 @@ def upcast_event_identity(
         inferred_job_id = column_job_id
     elif len(root_job_ids) == 1:
         inferred_job_id = next(iter(root_job_ids))
-    elif len(referenced) == 1:
-        inferred_job_id = next(iter(referenced))
+    elif len(inferable_job_ids := _inferable_payload_job_ids(transformed)) == 1:
+        inferred_job_id = next(iter(inferable_job_ids))
     else:
         inferred_job_id = None
     return UpcastedEventIdentity(
@@ -224,19 +234,23 @@ def _resolve_reference(
         """,
         (tenant_id, normalized),
     )
-    alias_url = _job_id_from_query(
-        conn,
-        """
-        SELECT jobs.job_id
-        FROM job_identity_aliases AS aliases
-        JOIN jobs
-          ON jobs.tenant_id = aliases.tenant_id
-         AND jobs.job_id = aliases.job_id
-        WHERE aliases.tenant_id = ?
-          AND aliases.alias_kind = 'posting_url'
-          AND aliases.alias_value = ?
-        """,
-        (tenant_id, normalized),
+    alias_url = (
+        _job_id_from_query(
+            conn,
+            """
+            SELECT jobs.job_id
+            FROM job_identity_aliases AS aliases
+            JOIN jobs
+              ON jobs.tenant_id = aliases.tenant_id
+             AND jobs.job_id = aliases.job_id
+            WHERE aliases.tenant_id = ?
+              AND aliases.alias_kind = 'posting_url'
+              AND aliases.alias_value = ?
+            """,
+            (tenant_id, normalized),
+        )
+        if _table_exists(conn, "job_identity_aliases")
+        else None
     )
     if (
         direct_url is not None
@@ -275,6 +289,44 @@ def _job_id_from_query(
     if not normalized:
         raise EventIdentityUpcastError("event_job_identity_invalid")
     return normalized
+
+
+def _table_exists(conn: sqlite3.Connection, table_name: str) -> bool:
+    row = conn.execute(
+        """
+        SELECT 1
+        FROM sqlite_master
+        WHERE type = 'table' AND name = ?
+        LIMIT 1
+        """,
+        (table_name,),
+    ).fetchone()
+    return row is not None
+
+
+def _inferable_payload_job_ids(value: Any) -> set[str]:
+    if isinstance(value, list):
+        inferred: set[str] = set()
+        for item in value:
+            inferred.update(_inferable_payload_job_ids(item))
+        return inferred
+    if not isinstance(value, dict):
+        return set()
+
+    inferred = set()
+    for key, item in value.items():
+        if key in {"jobId", "job_id"} and isinstance(item, str):
+            inferred.add(item)
+        elif key in {"jobIds", "job_ids"} and isinstance(item, list):
+            inferred.update(entry for entry in item if isinstance(entry, str))
+        elif key not in {
+            "candidateJobId",
+            "candidate_job_id",
+            "survivingJobId",
+            "surviving_job_id",
+        }:
+            inferred.update(_inferable_payload_job_ids(item))
+    return inferred
 
 
 __all__ = [

--- a/workers/automation/src/jobctrl/infrastructure/events/identity_upcast.py
+++ b/workers/automation/src/jobctrl/infrastructure/events/identity_upcast.py
@@ -1,0 +1,285 @@
+"""Versioned legacy-event JobId upcast shared with the TypeScript runtime.
+
+Historical events are immutable. Before a projection consumes a pre-cutover
+event, this adapter resolves job identity fields through the tenant-scoped
+posting-URL alias map and returns a canonical in-memory view. Locator fields
+such as ``postingUrl`` and ``applicationUrl`` remain untouched.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+EVENT_IDENTITY_UPCAST_VERSION = 1
+
+_SINGLE_FIELDS = {
+    "jobId": "jobId",
+    "jobUrl": "jobId",
+    "jobKey": "jobId",
+    "job_id": "job_id",
+    "job_url": "job_id",
+    "job_key": "job_id",
+}
+_PLURAL_FIELDS = {
+    "jobIds": "jobIds",
+    "jobUrls": "jobIds",
+    "jobKeys": "jobIds",
+    "job_ids": "job_ids",
+    "job_urls": "job_ids",
+    "job_keys": "job_ids",
+}
+
+
+class EventIdentityUpcastError(RuntimeError):
+    """Bounded failure that never includes a raw job locator."""
+
+    def __init__(self, code: str) -> None:
+        self.code = code
+        super().__init__(code)
+
+
+@dataclass(frozen=True)
+class UpcastedEventIdentity:
+    version: int
+    job_id: str | None
+    referenced_job_ids: tuple[str, ...]
+    payload: dict[str, Any]
+
+
+def upcast_event_identity(
+    conn: sqlite3.Connection,
+    *,
+    tenant_id: str,
+    event_job_reference: str | None,
+    payload: Mapping[str, Any],
+) -> UpcastedEventIdentity:
+    """Return the canonical identity view for one immutable legacy event."""
+
+    normalized_tenant = str(tenant_id or "").strip()
+    if not normalized_tenant:
+        raise EventIdentityUpcastError("event_job_identity_invalid")
+    if not isinstance(payload, Mapping):
+        raise EventIdentityUpcastError("event_job_identity_invalid")
+
+    referenced: set[str] = set()
+    column_job_id = (
+        _resolve_reference(
+            conn,
+            tenant_id=normalized_tenant,
+            reference=event_job_reference,
+        )
+        if event_job_reference is not None
+        else None
+    )
+    if column_job_id is not None:
+        referenced.add(column_job_id)
+
+    transformed = _upcast_value(
+        conn,
+        tenant_id=normalized_tenant,
+        value=dict(payload),
+        referenced=referenced,
+    )
+    if not isinstance(transformed, dict):
+        raise EventIdentityUpcastError("event_job_identity_invalid")
+
+    root_job_ids = {
+        value
+        for key in ("jobId", "job_id")
+        if isinstance((value := transformed.get(key)), str)
+    }
+    primary_job_ids = set(root_job_ids)
+    if column_job_id is not None:
+        primary_job_ids.add(column_job_id)
+    if len(primary_job_ids) > 1:
+        raise EventIdentityUpcastError("event_job_identity_conflict")
+
+    if column_job_id is not None:
+        inferred_job_id = column_job_id
+    elif len(root_job_ids) == 1:
+        inferred_job_id = next(iter(root_job_ids))
+    elif len(referenced) == 1:
+        inferred_job_id = next(iter(referenced))
+    else:
+        inferred_job_id = None
+    return UpcastedEventIdentity(
+        version=EVENT_IDENTITY_UPCAST_VERSION,
+        job_id=inferred_job_id,
+        referenced_job_ids=tuple(sorted(referenced)),
+        payload=transformed,
+    )
+
+
+def _upcast_value(
+    conn: sqlite3.Connection,
+    *,
+    tenant_id: str,
+    value: Any,
+    referenced: set[str],
+) -> Any:
+    if isinstance(value, list):
+        return [
+            _upcast_value(
+                conn,
+                tenant_id=tenant_id,
+                value=item,
+                referenced=referenced,
+            )
+            for item in value
+        ]
+    if not isinstance(value, dict):
+        return value
+
+    transformed: dict[str, Any] = {}
+    for raw_key, raw_value in value.items():
+        key = str(raw_key)
+        if key in _SINGLE_FIELDS:
+            output_key = _SINGLE_FIELDS[key]
+            output_value = _upcast_single_reference(
+                conn,
+                tenant_id=tenant_id,
+                value=raw_value,
+                referenced=referenced,
+            )
+        elif key in _PLURAL_FIELDS:
+            output_key = _PLURAL_FIELDS[key]
+            output_value = _upcast_reference_collection(
+                conn,
+                tenant_id=tenant_id,
+                value=raw_value,
+                referenced=referenced,
+            )
+        else:
+            output_key = key
+            output_value = _upcast_value(
+                conn,
+                tenant_id=tenant_id,
+                value=raw_value,
+                referenced=referenced,
+            )
+        if output_key in transformed and transformed[output_key] != output_value:
+            raise EventIdentityUpcastError("event_job_identity_conflict")
+        transformed[output_key] = output_value
+    return transformed
+
+
+def _upcast_single_reference(
+    conn: sqlite3.Connection,
+    *,
+    tenant_id: str,
+    value: Any,
+    referenced: set[str],
+) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise EventIdentityUpcastError("event_job_identity_invalid")
+    job_id = _resolve_reference(
+        conn,
+        tenant_id=tenant_id,
+        reference=value,
+    )
+    referenced.add(job_id)
+    return job_id
+
+
+def _upcast_reference_collection(
+    conn: sqlite3.Connection,
+    *,
+    tenant_id: str,
+    value: Any,
+    referenced: set[str],
+) -> list[str | None]:
+    if not isinstance(value, list):
+        raise EventIdentityUpcastError("event_job_identity_invalid")
+    return [
+        _upcast_single_reference(
+            conn,
+            tenant_id=tenant_id,
+            value=item,
+            referenced=referenced,
+        )
+        for item in value
+    ]
+
+
+def _resolve_reference(
+    conn: sqlite3.Connection,
+    *,
+    tenant_id: str,
+    reference: str | None,
+) -> str:
+    normalized = str(reference or "").strip()
+    if not normalized:
+        raise EventIdentityUpcastError("event_job_identity_invalid")
+
+    direct_url = _job_id_from_query(
+        conn,
+        """
+        SELECT job_id
+        FROM jobs
+        WHERE tenant_id = ? AND url = ?
+        """,
+        (tenant_id, normalized),
+    )
+    alias_url = _job_id_from_query(
+        conn,
+        """
+        SELECT jobs.job_id
+        FROM job_identity_aliases AS aliases
+        JOIN jobs
+          ON jobs.tenant_id = aliases.tenant_id
+         AND jobs.job_id = aliases.job_id
+        WHERE aliases.tenant_id = ?
+          AND aliases.alias_kind = 'posting_url'
+          AND aliases.alias_value = ?
+        """,
+        (tenant_id, normalized),
+    )
+    if (
+        direct_url is not None
+        and alias_url is not None
+        and direct_url != alias_url
+    ):
+        raise EventIdentityUpcastError("event_job_identity_conflict")
+    url_job_id = direct_url or alias_url
+    if url_job_id is not None:
+        return url_job_id
+
+    stable_job_id = _job_id_from_query(
+        conn,
+        """
+        SELECT job_id
+        FROM jobs
+        WHERE tenant_id = ? AND job_id = ?
+        """,
+        (tenant_id, normalized),
+    )
+    if stable_job_id is None:
+        raise EventIdentityUpcastError("event_job_identity_unresolved")
+    return stable_job_id
+
+
+def _job_id_from_query(
+    conn: sqlite3.Connection,
+    sql: str,
+    params: tuple[str, str],
+) -> str | None:
+    row = conn.execute(sql, params).fetchone()
+    if row is None:
+        return None
+    value = row["job_id"] if isinstance(row, sqlite3.Row) else row[0]
+    normalized = str(value or "").strip()
+    if not normalized:
+        raise EventIdentityUpcastError("event_job_identity_invalid")
+    return normalized
+
+
+__all__ = [
+    "EVENT_IDENTITY_UPCAST_VERSION",
+    "EventIdentityUpcastError",
+    "UpcastedEventIdentity",
+    "upcast_event_identity",
+]

--- a/workers/automation/tests/test_event_identity_upcast.py
+++ b/workers/automation/tests/test_event_identity_upcast.py
@@ -1,0 +1,97 @@
+"""Cross-runtime contract for the historical event JobId upcast."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from jobctrl.infrastructure.events.identity_upcast import (
+    EventIdentityUpcastError,
+    upcast_event_identity,
+)
+
+_FIXTURE_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "packages/domain-types/test/fixtures/event_identity_upcast_v1.json"
+)
+_FIXTURE: dict[str, Any] = json.loads(_FIXTURE_PATH.read_text())
+
+
+@pytest.fixture
+def seeded_conn() -> sqlite3.Connection:
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.executescript(
+        """
+        CREATE TABLE jobs (
+            tenant_id TEXT NOT NULL,
+            job_id TEXT NOT NULL,
+            url TEXT NOT NULL,
+            PRIMARY KEY (tenant_id, job_id),
+            UNIQUE (tenant_id, url)
+        );
+        CREATE TABLE job_identity_aliases (
+            tenant_id TEXT NOT NULL,
+            alias_kind TEXT NOT NULL,
+            alias_value TEXT NOT NULL,
+            job_id TEXT NOT NULL,
+            PRIMARY KEY (tenant_id, alias_kind, alias_value)
+        );
+        """
+    )
+    for job in _FIXTURE["jobs"]:
+        conn.execute(
+            "INSERT INTO jobs (tenant_id, job_id, url) VALUES (?, ?, ?)",
+            (job["tenantId"], job["jobId"], job["postingUrl"]),
+        )
+        for alias in job.get("aliases", []):
+            conn.execute(
+                """
+                INSERT INTO job_identity_aliases (
+                    tenant_id, alias_kind, alias_value, job_id
+                ) VALUES (?, 'posting_url', ?, ?)
+                """,
+                (job["tenantId"], alias, job["jobId"]),
+            )
+    try:
+        yield conn
+    finally:
+        conn.close()
+
+
+@pytest.mark.parametrize("case", _FIXTURE["cases"], ids=lambda case: case["name"])
+def test_event_identity_upcast_shared_contract(
+    seeded_conn: sqlite3.Connection,
+    case: dict[str, Any],
+) -> None:
+    expected_error = case.get("expectedError")
+    if expected_error:
+        with pytest.raises(EventIdentityUpcastError) as exc_info:
+            upcast_event_identity(
+                seeded_conn,
+                tenant_id=case["tenantId"],
+                event_job_reference=case["eventJobReference"],
+                payload=case["payload"],
+            )
+        assert exc_info.value.code == expected_error
+        assert str(exc_info.value) == expected_error
+        if case["eventJobReference"]:
+            assert case["eventJobReference"] not in str(exc_info.value)
+        return
+
+    result = upcast_event_identity(
+        seeded_conn,
+        tenant_id=case["tenantId"],
+        event_job_reference=case["eventJobReference"],
+        payload=case["payload"],
+    )
+    assert {
+        "jobId": result.job_id,
+        "referencedJobIds": list(result.referenced_job_ids),
+        "payload": result.payload,
+    } == case["expected"]
+    assert result.version == _FIXTURE["version"]

--- a/workers/automation/tests/test_event_identity_upcast.py
+++ b/workers/automation/tests/test_event_identity_upcast.py
@@ -95,3 +95,25 @@ def test_event_identity_upcast_shared_contract(
         "payload": result.payload,
     } == case["expected"]
     assert result.version == _FIXTURE["version"]
+
+
+def test_current_url_and_stable_id_resolve_without_alias_table(
+    seeded_conn: sqlite3.Connection,
+) -> None:
+    seeded_conn.execute("DROP TABLE job_identity_aliases")
+
+    by_url = upcast_event_identity(
+        seeded_conn,
+        tenant_id="local",
+        event_job_reference="https://jobs.example/a",
+        payload={},
+    )
+    by_id = upcast_event_identity(
+        seeded_conn,
+        tenant_id="local",
+        event_job_reference="22222222-2222-4222-8222-222222222222",
+        payload={},
+    )
+
+    assert by_url.job_id == "11111111-1111-4111-8111-111111111111"
+    assert by_id.job_id == "22222222-2222-4222-8222-222222222222"


### PR DESCRIPTION
## Summary

- define one deterministic, tenant-scoped historical event identity upcaster in Python and TypeScript
- resolve pre-v30 event columns and root payload identity aliases URL-first, including UUID-shaped posting URLs
- fail closed on unresolved, malformed, conflicting, or cross-source primary identity
- preserve locator fields, nested related identities, and prototype-named JSON keys
- lock both runtimes to one shared parity fixture

## Why

The v29 to v30 database migration must translate immutable historical event ownership before replacing the event table. This upcaster exists only inside that forward migration. Current runtime readers and writers accept schema v30 and never use it as a compatibility path.

## Validation

- Python shared-fixture and migration tests: 35 passed
- Full API suite including the TypeScript shared fixture: 62 files, 748 tests passed
- API TypeScript check: passed
- Focused Ruff: passed
- Diff check: passed
- Independent review gate: PASS
- Independent QA gate: PASS

## Stack

- Base: #558
- The v29 to v30 event-table migration follows in #567.
- These PRs are review slices of one cumulative local upgrade, not independently deployed application versions.