### PR TITLE
feat(identity): migrate durable event ownership

### DIFF
--- a/apps/api/src/event-identity-upcast.ts
+++ b/apps/api/src/event-identity-upcast.ts
@@ -29,6 +29,7 @@ const ROOT_PRIMARY_FIELDS = [
   "survivingJobId",
   "surviving_job_id",
 ] as const;
+const NON_JOB_SCOPE_REFERENCES = new Set(["pipeline"]);
 
 export class EventIdentityUpcastError extends Error {
   readonly code: string;
@@ -78,7 +79,10 @@ export function upcastEventIdentity(
   const rootJobIds = new Set(
     ROOT_PRIMARY_FIELDS
       .map((key) => payload[key])
-      .filter((value): value is string => typeof value === "string"),
+      .filter(
+        (value): value is string =>
+          typeof value === "string" && !NON_JOB_SCOPE_REFERENCES.has(value),
+      ),
   );
   const primaryJobIds = new Set(rootJobIds);
   if (columnJobId !== null) primaryJobIds.add(columnJobId);
@@ -155,6 +159,10 @@ function upcastSingleReference(
   if (value === null) return null;
   if (typeof value !== "string") {
     throw new EventIdentityUpcastError("event_job_identity_invalid");
+  }
+  const normalized = value.trim();
+  if (NON_JOB_SCOPE_REFERENCES.has(normalized)) {
+    return normalized;
   }
   const jobId = resolveReference(db, tenantId, value);
   referenced.add(jobId);
@@ -286,11 +294,17 @@ function inferablePayloadJobIds(value: unknown): Set<string> {
   if (!isRecord(value)) return inferred;
 
   for (const [key, item] of Object.entries(value)) {
-    if ((key === "jobId" || key === "job_id") && typeof item === "string") {
+    if (
+      (key === "jobId" || key === "job_id")
+      && typeof item === "string"
+      && !NON_JOB_SCOPE_REFERENCES.has(item)
+    ) {
       inferred.add(item);
     } else if ((key === "jobIds" || key === "job_ids") && Array.isArray(item)) {
       for (const entry of item) {
-        if (typeof entry === "string") inferred.add(entry);
+        if (typeof entry === "string" && !NON_JOB_SCOPE_REFERENCES.has(entry)) {
+          inferred.add(entry);
+        }
       }
     } else if (
       ![

--- a/packages/domain-types/test/fixtures/event_identity_upcast_v1.json
+++ b/packages/domain-types/test/fixtures/event_identity_upcast_v1.json
@@ -139,6 +139,23 @@
       }
     },
     {
+      "name": "pipeline scope is not a job identity",
+      "tenantId": "local",
+      "eventJobReference": null,
+      "payload": {
+        "jobId": "pipeline",
+        "workflowId": "pipeline-score-1"
+      },
+      "expected": {
+        "jobId": null,
+        "referencedJobIds": [],
+        "payload": {
+          "jobId": "pipeline",
+          "workflowId": "pipeline-score-1"
+        }
+      }
+    },
+    {
       "name": "resolution is tenant scoped",
       "tenantId": "other",
       "eventJobReference": "https://jobs.example/a",

--- a/workers/automation/src/jobctrl/database.py
+++ b/workers/automation/src/jobctrl/database.py
@@ -109,6 +109,9 @@ from jobctrl.config import DB_PATH, DEFAULTS, migrate_legacy_job_tables
 # v29 (delete tombstones): soft-delete lifecycle state is keyed by the
 # tenant-scoped stable Job aggregate. URL-era alias tombstones collapse into
 # one current lifecycle projection without changing delete/restore history.
+# v30 (event identity): the append-only event log records tenant ownership and
+# stable JobId references directly. The forward-only local upgrade preserves
+# event ordering and payload facts while removing URL-shaped storage identity.
 SCHEMA_VERSION = 29
 
 
@@ -16939,6 +16942,349 @@ def _verify_deleted_job_references_v29(
             "Soft-delete tombstone reference migration found a "
             "foreign-key violation"
         )
+
+
+_EVENT_IDENTITY_SCHEMA_VERSION = 30
+_EVENT_IDENTITY_TABLES = ("job_events",)
+_EVENT_IDENTITY_COLUMNS_V30 = (
+    "event_id",
+    "tenant_id",
+    "job_id",
+    "identity_version",
+    "stage",
+    "event_type",
+    "level",
+    "message",
+    "occurred_at",
+    "payload_json",
+    "entity_kind",
+    "entity_ref",
+    "idempotency_key",
+)
+
+
+def _create_job_events_table_v30(
+    conn: sqlite3.Connection,
+    *,
+    table: str,
+) -> None:
+    conn.execute(
+        f"""
+        CREATE TABLE "{table}" (
+            event_id         INTEGER PRIMARY KEY AUTOINCREMENT,
+            tenant_id        TEXT NOT NULL,
+            job_id           TEXT,
+            identity_version INTEGER NOT NULL,
+            stage            TEXT,
+            event_type       TEXT NOT NULL,
+            level            TEXT NOT NULL DEFAULT 'info',
+            message          TEXT,
+            occurred_at      TEXT NOT NULL,
+            payload_json     TEXT,
+            entity_kind      TEXT,
+            entity_ref       TEXT,
+            idempotency_key  TEXT,
+            FOREIGN KEY (tenant_id, job_id)
+                REFERENCES jobs(tenant_id, job_id) ON DELETE CASCADE
+        )
+        """
+    )
+
+
+def _create_job_event_indexes_v30(
+    conn: sqlite3.Connection,
+) -> None:
+    conn.execute(
+        """
+        CREATE UNIQUE INDEX idx_job_events_idempotency_key
+        ON job_events(idempotency_key)
+        WHERE idempotency_key IS NOT NULL
+        """
+    )
+    conn.execute(
+        """
+        CREATE INDEX idx_job_events_job_time
+        ON job_events(
+            tenant_id,
+            job_id,
+            occurred_at DESC,
+            event_id DESC
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE INDEX idx_job_events_tenant_eid
+        ON job_events(tenant_id, event_id)
+        """
+    )
+    conn.execute(
+        """
+        CREATE INDEX idx_job_events_stage_time
+        ON job_events(
+            tenant_id,
+            stage,
+            occurred_at DESC,
+            event_id DESC
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE INDEX idx_job_events_entity
+        ON job_events(
+            tenant_id,
+            entity_kind,
+            entity_ref,
+            occurred_at DESC,
+            event_id DESC
+        )
+        """
+    )
+
+
+def _has_event_identity_schema_v30(
+    conn: sqlite3.Connection,
+) -> bool:
+    columns = _table_columns(conn, "job_events")
+    if (
+        columns != set(_EVENT_IDENTITY_COLUMNS_V30)
+        or len(columns) != len(_EVENT_IDENTITY_COLUMNS_V30)
+    ):
+        return False
+    return _has_composite_job_id_foreign_key(
+        conn,
+        "job_events",
+        "job_id",
+    )
+
+
+def _legacy_event_payload_v30(
+    raw_payload: Any,
+) -> dict[str, Any]:
+    if raw_payload is None:
+        return {}
+    try:
+        parsed = json.loads(str(raw_payload))
+    except (TypeError, ValueError) as exc:
+        raise RuntimeError(
+            "Event identity migration found invalid payload JSON"
+        ) from exc
+    if not isinstance(parsed, dict):
+        raise RuntimeError(
+            "Event identity migration requires object payload JSON"
+        )
+    return parsed
+
+
+def _canonical_job_event_rows_v30(
+    conn: sqlite3.Connection,
+) -> tuple[list[tuple[Any, ...]], tuple[int, ...]]:
+    from jobctrl.infrastructure.events.identity_upcast import (
+        upcast_event_identity,
+    )
+
+    rows = conn.execute(
+        """
+        SELECT
+            event_id,
+            job_url,
+            stage,
+            event_type,
+            level,
+            message,
+            occurred_at,
+            payload_json,
+            entity_kind,
+            entity_ref,
+            idempotency_key
+        FROM job_events
+        ORDER BY event_id
+        """
+    ).fetchall()
+    canonical: list[tuple[Any, ...]] = []
+    event_ids: list[int] = []
+    for row in rows:
+        event_id = int(row[0])
+        raw_payload = row[7]
+        upcasted = upcast_event_identity(
+            conn,
+            tenant_id="local",
+            event_job_reference=(
+                str(row[1])
+                if row[1] is not None
+                else None
+            ),
+            payload=_legacy_event_payload_v30(raw_payload),
+        )
+        canonical.append(
+            (
+                event_id,
+                "local",
+                upcasted.job_id,
+                upcasted.version,
+                row[2],
+                row[3],
+                row[4],
+                row[5],
+                row[6],
+                (
+                    json.dumps(
+                        upcasted.payload,
+                        separators=(",", ":"),
+                        sort_keys=True,
+                    )
+                    if raw_payload is not None
+                    else None
+                ),
+                row[8],
+                row[9],
+                row[10],
+            )
+        )
+        event_ids.append(event_id)
+    return canonical, tuple(event_ids)
+
+
+def _verify_job_event_identity_v30(
+    conn: sqlite3.Connection,
+    *,
+    expected_event_ids: tuple[int, ...],
+) -> None:
+    if not _has_event_identity_schema_v30(conn):
+        raise RuntimeError(
+            "Event identity migration did not create the v30 schema"
+        )
+    observed_event_ids = tuple(
+        int(row[0])
+        for row in conn.execute(
+            "SELECT event_id FROM job_events ORDER BY event_id"
+        ).fetchall()
+    )
+    if observed_event_ids != expected_event_ids:
+        raise RuntimeError(
+            "Event identity migration changed event ordering or identity"
+        )
+    invalid_identity_version = conn.execute(
+        """
+        SELECT event_id
+        FROM job_events
+        WHERE identity_version != ?
+        LIMIT 1
+        """,
+        (1,),
+    ).fetchone()
+    if invalid_identity_version is not None:
+        raise RuntimeError(
+            "Event identity migration left an invalid identity version"
+        )
+    orphan = conn.execute(
+        """
+        SELECT events.event_id
+        FROM job_events AS events
+        LEFT JOIN jobs
+          ON jobs.tenant_id = events.tenant_id
+         AND jobs.job_id = events.job_id
+        WHERE events.job_id IS NOT NULL
+          AND jobs.job_id IS NULL
+        LIMIT 1
+        """
+    ).fetchone()
+    if orphan is not None:
+        raise RuntimeError(
+            "Event identity migration left an unresolved JobId"
+        )
+    foreign_key_error = conn.execute(
+        "PRAGMA foreign_key_check"
+    ).fetchone()
+    if foreign_key_error is not None:
+        raise RuntimeError(
+            "Event identity migration found a foreign-key violation"
+        )
+
+
+def ensure_job_event_identity_v30(
+    conn: sqlite3.Connection | None = None,
+) -> list[str]:
+    """Move the local append-only event log to tenant-scoped stable JobIds.
+
+    JobCtrl upgrades one local database in place. The application is stopped,
+    a backup is taken by the upgrade runner, and this single transaction
+    replaces the v29 table. There is no dual-write or mixed-version mode.
+    """
+    if conn is None:
+        conn = get_connection()
+    current = _assert_schema_version_supported(
+        conn,
+        supported_version=_EVENT_IDENTITY_SCHEMA_VERSION,
+    )
+    if current >= _EVENT_IDENTITY_SCHEMA_VERSION:
+        if not _has_event_identity_schema_v30(conn):
+            raise RuntimeError(
+                "Schema v30 requires tenant-scoped stable event identity"
+            )
+        return list(_EVENT_IDENTITY_TABLES)
+    if current != _DELETED_JOB_REFERENCE_SCHEMA_VERSION:
+        raise RuntimeError(
+            "Event identity migration requires schema v29; "
+            f"found v{current}"
+        )
+    if "job_url" not in _table_columns(conn, "job_events"):
+        raise RuntimeError(
+            "Schema v29 event identity requires the legacy job_url column"
+        )
+
+    conn.execute("SAVEPOINT job_event_identity_v30")
+    try:
+        canonical_rows, expected_event_ids = _canonical_job_event_rows_v30(
+            conn
+        )
+        conn.execute("DROP TABLE IF EXISTS job_events_v30")
+        _create_job_events_table_v30(
+            conn,
+            table="job_events_v30",
+        )
+        conn.executemany(
+            """
+            INSERT INTO job_events_v30 (
+                event_id,
+                tenant_id,
+                job_id,
+                identity_version,
+                stage,
+                event_type,
+                level,
+                message,
+                occurred_at,
+                payload_json,
+                entity_kind,
+                entity_ref,
+                idempotency_key
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            canonical_rows,
+        )
+        conn.execute('DROP TABLE "job_events"')
+        conn.execute(
+            'ALTER TABLE "job_events_v30" RENAME TO "job_events"'
+        )
+        _create_job_event_indexes_v30(conn)
+        _verify_job_event_identity_v30(
+            conn,
+            expected_event_ids=expected_event_ids,
+        )
+        conn.execute(
+            f"PRAGMA user_version = "
+            f"{_EVENT_IDENTITY_SCHEMA_VERSION}"
+        )
+        conn.execute("RELEASE SAVEPOINT job_event_identity_v30")
+    except BaseException:
+        conn.execute(
+            "ROLLBACK TO SAVEPOINT job_event_identity_v30"
+        )
+        conn.execute("RELEASE SAVEPOINT job_event_identity_v30")
+        raise
+    return list(_EVENT_IDENTITY_TABLES)
 
 
 def _reassign_deleted_job_references_v29(

--- a/workers/automation/src/jobctrl/database.py
+++ b/workers/automation/src/jobctrl/database.py
@@ -17079,7 +17079,7 @@ def _legacy_event_payload_v30(
 
 def _canonical_job_event_rows_v30(
     conn: sqlite3.Connection,
-) -> tuple[list[tuple[Any, ...]], tuple[int, ...]]:
+) -> tuple[list[tuple[Any, ...]], tuple[int, ...], int]:
     from jobctrl.infrastructure.events.identity_upcast import (
         upcast_event_identity,
     )
@@ -17102,6 +17102,13 @@ def _canonical_job_event_rows_v30(
         ORDER BY event_id
         """
     ).fetchall()
+    sequence_row = conn.execute(
+        """
+        SELECT seq
+        FROM sqlite_sequence
+        WHERE name = 'job_events'
+        """
+    ).fetchone()
     canonical: list[tuple[Any, ...]] = []
     event_ids: list[int] = []
     for row in rows:
@@ -17143,13 +17150,39 @@ def _canonical_job_event_rows_v30(
             )
         )
         event_ids.append(event_id)
-    return canonical, tuple(event_ids)
+    max_event_id = max(event_ids, default=0)
+    sequence_high_water = max(
+        int(sequence_row[0]) if sequence_row is not None else 0,
+        max_event_id,
+    )
+    return canonical, tuple(event_ids), sequence_high_water
+
+
+def _restore_job_event_sequence_v30(
+    conn: sqlite3.Connection,
+    *,
+    sequence_high_water: int,
+) -> None:
+    conn.execute(
+        """
+        DELETE FROM sqlite_sequence
+        WHERE name IN ('job_events', 'job_events_v30')
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO sqlite_sequence (name, seq)
+        VALUES ('job_events', ?)
+        """,
+        (sequence_high_water,),
+    )
 
 
 def _verify_job_event_identity_v30(
     conn: sqlite3.Connection,
     *,
     expected_event_ids: tuple[int, ...],
+    expected_sequence_high_water: int,
 ) -> None:
     if not _has_event_identity_schema_v30(conn):
         raise RuntimeError(
@@ -17164,6 +17197,20 @@ def _verify_job_event_identity_v30(
     if observed_event_ids != expected_event_ids:
         raise RuntimeError(
             "Event identity migration changed event ordering or identity"
+        )
+    sequence_row = conn.execute(
+        """
+        SELECT seq
+        FROM sqlite_sequence
+        WHERE name = 'job_events'
+        """
+    ).fetchone()
+    if (
+        sequence_row is None
+        or int(sequence_row[0]) != expected_sequence_high_water
+    ):
+        raise RuntimeError(
+            "Event identity migration changed the event ID high-water"
         )
     invalid_identity_version = conn.execute(
         """
@@ -17236,9 +17283,11 @@ def ensure_job_event_identity_v30(
 
     conn.execute("SAVEPOINT job_event_identity_v30")
     try:
-        canonical_rows, expected_event_ids = _canonical_job_event_rows_v30(
-            conn
-        )
+        (
+            canonical_rows,
+            expected_event_ids,
+            sequence_high_water,
+        ) = _canonical_job_event_rows_v30(conn)
         conn.execute("DROP TABLE IF EXISTS job_events_v30")
         _create_job_events_table_v30(
             conn,
@@ -17268,10 +17317,15 @@ def ensure_job_event_identity_v30(
         conn.execute(
             'ALTER TABLE "job_events_v30" RENAME TO "job_events"'
         )
+        _restore_job_event_sequence_v30(
+            conn,
+            sequence_high_water=sequence_high_water,
+        )
         _create_job_event_indexes_v30(conn)
         _verify_job_event_identity_v30(
             conn,
             expected_event_ids=expected_event_ids,
+            expected_sequence_high_water=sequence_high_water,
         )
         conn.execute(
             f"PRAGMA user_version = "

--- a/workers/automation/src/jobctrl/infrastructure/events/identity_upcast.py
+++ b/workers/automation/src/jobctrl/infrastructure/events/identity_upcast.py
@@ -40,6 +40,7 @@ _ROOT_PRIMARY_FIELDS = (
     "survivingJobId",
     "surviving_job_id",
 )
+_NON_JOB_SCOPE_REFERENCES = frozenset({"pipeline"})
 
 
 class EventIdentityUpcastError(RuntimeError):
@@ -99,6 +100,7 @@ def upcast_event_identity(
         value
         for key in _ROOT_PRIMARY_FIELDS
         if isinstance((value := transformed.get(key)), str)
+        and value not in _NON_JOB_SCOPE_REFERENCES
     }
     primary_job_ids = set(root_job_ids)
     if column_job_id is not None:
@@ -186,6 +188,9 @@ def _upcast_single_reference(
         return None
     if not isinstance(value, str):
         raise EventIdentityUpcastError("event_job_identity_invalid")
+    normalized = value.strip()
+    if normalized in _NON_JOB_SCOPE_REFERENCES:
+        return normalized
     job_id = _resolve_reference(
         conn,
         tenant_id=tenant_id,
@@ -315,10 +320,19 @@ def _inferable_payload_job_ids(value: Any) -> set[str]:
 
     inferred = set()
     for key, item in value.items():
-        if key in {"jobId", "job_id"} and isinstance(item, str):
+        if (
+            key in {"jobId", "job_id"}
+            and isinstance(item, str)
+            and item not in _NON_JOB_SCOPE_REFERENCES
+        ):
             inferred.add(item)
         elif key in {"jobIds", "job_ids"} and isinstance(item, list):
-            inferred.update(entry for entry in item if isinstance(entry, str))
+            inferred.update(
+                entry
+                for entry in item
+                if isinstance(entry, str)
+                and entry not in _NON_JOB_SCOPE_REFERENCES
+            )
         elif key not in {
             "candidateJobId",
             "candidate_job_id",

--- a/workers/automation/tests/test_job_event_identity_migration.py
+++ b/workers/automation/tests/test_job_event_identity_migration.py
@@ -121,8 +121,44 @@ def v29_database(tmp_path: Path) -> tuple[Path, sqlite3.Connection]:
             ),
         ),
     )
+    conn.execute(
+        """
+        INSERT INTO job_events (
+            event_id,
+            job_url,
+            stage,
+            event_type,
+            level,
+            occurred_at,
+            payload_json
+        ) VALUES (
+            100,
+            NULL,
+            'workflow',
+            'WorkflowCompleted',
+            'info',
+            '2026-07-30T09:13:00+00:00',
+            '{}'
+        )
+        """
+    )
+    conn.execute("DELETE FROM job_events WHERE event_id = 100")
+    conn.execute(
+        """
+        INSERT INTO event_watermarks (
+            projection_name, last_event_id, updated_at
+        ) VALUES (
+            'operations_projections',
+            100,
+            '2026-07-30T09:14:00+00:00'
+        )
+        """
+    )
     conn.commit()
     assert conn.execute("PRAGMA user_version").fetchone()[0] == 29
+    assert conn.execute(
+        "SELECT seq FROM sqlite_sequence WHERE name = 'job_events'"
+    ).fetchone()[0] == 100
     try:
         yield db_path, conn
     finally:
@@ -204,6 +240,42 @@ def test_v30_migrates_event_identity_without_changing_history(
         "idx_job_events_entity",
     }.issubset(indexes)
     assert conn.execute("PRAGMA foreign_key_check").fetchall() == []
+    assert conn.execute(
+        "SELECT seq FROM sqlite_sequence WHERE name = 'job_events'"
+    ).fetchone()[0] == 100
+    next_event_id = conn.execute(
+        """
+        INSERT INTO job_events (
+            tenant_id,
+            job_id,
+            identity_version,
+            stage,
+            event_type,
+            level,
+            occurred_at,
+            payload_json
+        ) VALUES (
+            'local',
+            NULL,
+            1,
+            'workflow',
+            'WorkflowStarted',
+            'info',
+            '2026-07-30T09:15:00+00:00',
+            '{}'
+        )
+        RETURNING event_id
+        """
+    ).fetchone()[0]
+    assert next_event_id == 101
+    assert conn.execute(
+        """
+        SELECT last_event_id
+        FROM event_watermarks
+        WHERE projection_name = 'operations_projections'
+        """
+    ).fetchone()[0] == 100
+    conn.commit()
 
     # Forward recovery is idempotent and the migrated file reopens exactly.
     assert ensure_job_event_identity_v30(conn) == ["job_events"]
@@ -213,7 +285,7 @@ def test_v30_migrates_event_identity_without_changing_history(
         assert reopened.execute("PRAGMA user_version").fetchone()[0] == 30
         assert reopened.execute(
             "SELECT event_id FROM job_events ORDER BY event_id"
-        ).fetchall() == [(7,), (11,), (15,)]
+        ).fetchall() == [(7,), (11,), (15,), (101,)]
     finally:
         reopened.close()
 

--- a/workers/automation/tests/test_job_event_identity_migration.py
+++ b/workers/automation/tests/test_job_event_identity_migration.py
@@ -1,0 +1,300 @@
+"""Forward-only v29 -> v30 event identity migration coverage."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from jobctrl.database import (
+    backup_database,
+    close_connection,
+    ensure_job_event_identity_v30,
+    init_db,
+)
+from jobctrl.infrastructure.events.identity_upcast import (
+    EventIdentityUpcastError,
+)
+
+JOB_ID = "11111111-1111-4111-8111-111111111111"
+POSTING_URL = "https://jobs.example/current"
+OLD_POSTING_URL = "https://jobs.example/old"
+
+
+@pytest.fixture
+def v29_database(tmp_path: Path) -> tuple[Path, sqlite3.Connection]:
+    db_path = tmp_path / "jobctrl.db"
+    conn = init_db(db_path)
+    conn.execute(
+        """
+        INSERT INTO jobs (
+            url, tenant_id, job_id, title, company, discovered_at
+        ) VALUES (?, 'local', ?, 'Engineer', 'Example', ?)
+        """,
+        (POSTING_URL, JOB_ID, "2026-07-30T08:00:00+00:00"),
+    )
+    conn.execute(
+        """
+        INSERT INTO job_identity_aliases (
+            tenant_id,
+            alias_kind,
+            alias_value,
+            job_id,
+            created_at,
+            retired_at
+        ) VALUES ('local', 'posting_url', ?, ?, ?, ?)
+        """,
+        (
+            OLD_POSTING_URL,
+            JOB_ID,
+            "2026-07-30T08:00:00+00:00",
+            "2026-07-30T09:00:00+00:00",
+        ),
+    )
+    conn.executemany(
+        """
+        INSERT INTO job_events (
+            event_id,
+            job_url,
+            stage,
+            event_type,
+            level,
+            message,
+            occurred_at,
+            payload_json,
+            entity_kind,
+            entity_ref,
+            idempotency_key
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            (
+                7,
+                OLD_POSTING_URL,
+                "score",
+                "JobScored",
+                "info",
+                "Scored.",
+                "2026-07-30T09:10:00+00:00",
+                json.dumps(
+                    {
+                        "jobUrl": OLD_POSTING_URL,
+                        "score": 8,
+                    }
+                ),
+                "job",
+                OLD_POSTING_URL,
+                "score-once",
+            ),
+            (
+                11,
+                None,
+                "workflow",
+                "WorkflowStarted",
+                "info",
+                "Started.",
+                "2026-07-30T09:11:00+00:00",
+                json.dumps(
+                    {
+                        "jobId": "pipeline",
+                        "workflowId": "pipeline-score-1",
+                    }
+                ),
+                "workflow",
+                "pipeline-score-1",
+                None,
+            ),
+            (
+                15,
+                None,
+                None,
+                "DigestReviewed",
+                "info",
+                "Reviewed.",
+                "2026-07-30T09:12:00+00:00",
+                None,
+                "digest",
+                "daily",
+                None,
+            ),
+        ),
+    )
+    conn.commit()
+    assert conn.execute("PRAGMA user_version").fetchone()[0] == 29
+    try:
+        yield db_path, conn
+    finally:
+        close_connection(db_path)
+
+
+def test_v30_migrates_event_identity_without_changing_history(
+    v29_database: tuple[Path, sqlite3.Connection],
+) -> None:
+    db_path, conn = v29_database
+
+    assert ensure_job_event_identity_v30(conn) == ["job_events"]
+    conn.commit()
+
+    assert conn.execute("PRAGMA user_version").fetchone()[0] == 30
+    columns = {
+        str(row[1])
+        for row in conn.execute("PRAGMA table_info(job_events)").fetchall()
+    }
+    assert columns == {
+        "event_id",
+        "tenant_id",
+        "job_id",
+        "identity_version",
+        "stage",
+        "event_type",
+        "level",
+        "message",
+        "occurred_at",
+        "payload_json",
+        "entity_kind",
+        "entity_ref",
+        "idempotency_key",
+    }
+    assert "job_url" not in columns
+
+    rows = conn.execute(
+        """
+        SELECT
+            event_id,
+            tenant_id,
+            job_id,
+            identity_version,
+            payload_json,
+            entity_kind,
+            entity_ref,
+            idempotency_key
+        FROM job_events
+        ORDER BY event_id
+        """
+    ).fetchall()
+    assert [int(row[0]) for row in rows] == [7, 11, 15]
+    assert tuple(rows[0][1:4]) == ("local", JOB_ID, 1)
+    assert json.loads(str(rows[0][4])) == {
+        "jobId": JOB_ID,
+        "score": 8,
+    }
+    assert tuple(rows[0][5:8]) == (
+        "job",
+        OLD_POSTING_URL,
+        "score-once",
+    )
+    assert tuple(rows[1][1:4]) == ("local", None, 1)
+    assert json.loads(str(rows[1][4])) == {
+        "jobId": "pipeline",
+        "workflowId": "pipeline-score-1",
+    }
+    assert tuple(rows[2][1:5]) == ("local", None, 1, None)
+
+    indexes = {
+        str(row[1])
+        for row in conn.execute("PRAGMA index_list(job_events)").fetchall()
+    }
+    assert {
+        "idx_job_events_idempotency_key",
+        "idx_job_events_job_time",
+        "idx_job_events_tenant_eid",
+        "idx_job_events_stage_time",
+        "idx_job_events_entity",
+    }.issubset(indexes)
+    assert conn.execute("PRAGMA foreign_key_check").fetchall() == []
+
+    # Forward recovery is idempotent and the migrated file reopens exactly.
+    assert ensure_job_event_identity_v30(conn) == ["job_events"]
+    close_connection(db_path)
+    reopened = sqlite3.connect(db_path)
+    try:
+        assert reopened.execute("PRAGMA user_version").fetchone()[0] == 30
+        assert reopened.execute(
+            "SELECT event_id FROM job_events ORDER BY event_id"
+        ).fetchall() == [(7,), (11,), (15,)]
+    finally:
+        reopened.close()
+
+
+def test_v30_failure_rolls_back_table_and_version(
+    v29_database: tuple[Path, sqlite3.Connection],
+) -> None:
+    _db_path, conn = v29_database
+    conn.execute(
+        """
+        INSERT INTO job_events (
+            event_id,
+            job_url,
+            stage,
+            event_type,
+            level,
+            occurred_at,
+            payload_json
+        ) VALUES (?, ?, 'score', 'JobScored', 'info', ?, ?)
+        """,
+        (
+            20,
+            "https://jobs.example/unresolved",
+            "2026-07-30T09:20:00+00:00",
+            "{}",
+        ),
+    )
+    conn.commit()
+
+    with pytest.raises(EventIdentityUpcastError) as exc_info:
+        ensure_job_event_identity_v30(conn)
+
+    assert exc_info.value.code == "event_job_identity_unresolved"
+    assert conn.execute("PRAGMA user_version").fetchone()[0] == 29
+    assert "job_url" in {
+        str(row[1])
+        for row in conn.execute("PRAGMA table_info(job_events)").fetchall()
+    }
+    assert [
+        int(row[0])
+        for row in conn.execute(
+            "SELECT event_id FROM job_events ORDER BY event_id"
+        ).fetchall()
+    ] == [7, 11, 15, 20]
+    assert conn.execute(
+        """
+        SELECT name
+        FROM sqlite_master
+        WHERE type = 'table' AND name = 'job_events_v30'
+        """
+    ).fetchone() is None
+
+
+def test_pre_upgrade_backup_reopens_with_v29_schema(
+    v29_database: tuple[Path, sqlite3.Connection],
+    tmp_path: Path,
+) -> None:
+    db_path, conn = v29_database
+    snapshot = backup_database(
+        tmp_path / "pre-v30.db",
+        db_path=db_path,
+    )
+
+    ensure_job_event_identity_v30(conn)
+    conn.commit()
+    assert conn.execute("PRAGMA user_version").fetchone()[0] == 30
+
+    restored = init_db(snapshot)
+    try:
+        assert restored.execute("PRAGMA user_version").fetchone()[0] == 29
+        assert "job_url" in {
+            str(row[1])
+            for row in restored.execute(
+                "PRAGMA table_info(job_events)"
+            ).fetchall()
+        }
+        assert [
+            int(row[0])
+            for row in restored.execute(
+                "SELECT event_id FROM job_events ORDER BY event_id"
+            ).fetchall()
+        ] == [7, 11, 15]
+    finally:
+        close_connection(snapshot)


### PR DESCRIPTION
## Summary

- add the forward-only v29 to v30 `job_events` table replacement for the local JobCtrl database
- resolve historical URL-shaped event identity through the migration-only Python/TypeScript upcast contract
- persist tenant ownership, stable `job_id`, and the upcast version directly in the durable event log
- preserve exact event IDs, ordering, idempotency keys, entity references, payload facts, indexes, foreign keys, and the pre-upgrade AUTOINCREMENT high-water
- prove failed migrations leave the v29 table and version untouched and that the pre-upgrade backup reopens through the prior schema

## Why

The legacy event table used posting URLs as durable job identity. The one-time local upgrade must replace that shape before the new runtime starts. No old and new runtime coexistence is supported: the old process is stopped, the databases are backed up, the migration runs once, and only schema v30 is accepted afterward.

## Validation

- Python event-upcast, event-migration, and backup tests: 35 passed
- Full API suite including the TypeScript upcast parity fixture: 62 files, 748 tests passed
- API TypeScript check: passed
- Focused Ruff: passed
- `git diff --check`: passed

## Stack

- Base: #566
- Runtime event writers and readers are activated in the next small stacked slices.
- These PRs are review slices of one cumulative local upgrade, not independently deployed application versions.