### PR TITLE
feat(identity): enforce canonical JobId values

### DIFF
--- a/workers/automation/src/jobctrl/domain/identifiers.py
+++ b/workers/automation/src/jobctrl/domain/identifiers.py
@@ -12,6 +12,19 @@ from typing import NewType
 JobId = NewType("JobId", str)
 
 
+def canonical_job_id(value: str) -> JobId:
+    """Return a JobId only when *value* is a canonical UUID serialization."""
+    try:
+        parsed = uuid.UUID(value)
+    except (AttributeError, TypeError, ValueError) as exc:
+        raise ValueError("JobId must be a canonical UUID") from exc
+
+    if str(parsed) != value:
+        raise ValueError("JobId must be a canonical UUID")
+
+    return JobId(value)
+
+
 def generate_job_id() -> JobId:
     """Generate a new random JobId using uuid4."""
     return JobId(str(uuid.uuid4()))

--- a/workers/automation/tests/test_domain_types.py
+++ b/workers/automation/tests/test_domain_types.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from jobctrl.domain.tenant import TenantId, LOCAL_TENANT
-from jobctrl.domain.identifiers import JobId, generate_job_id
+from jobctrl.domain.identifiers import JobId, canonical_job_id, generate_job_id
 from jobctrl.domain.pipeline_types import (
     Stage,
     STAGES,
@@ -62,6 +62,28 @@ class TestJobId:
         jid = generate_job_id()
         assert isinstance(jid, str)
         assert len(jid) == 36  # UUID format
+
+    def test_canonical_job_id_accepts_canonical_lowercase_uuid(self) -> None:
+        value = "123e4567-e89b-12d3-a456-426614174000"
+
+        assert canonical_job_id(value) == JobId(value)
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "https://example.com/jobs/123",
+            "job-123",
+            "123E4567-E89B-12D3-A456-426614174000",
+            "123e4567e89b12d3a456426614174000",
+            "{123e4567-e89b-12d3-a456-426614174000}",
+            "urn:uuid:123e4567-e89b-12d3-a456-426614174000",
+            "",
+            "not-a-uuid",
+        ],
+    )
+    def test_canonical_job_id_rejects_noncanonical_values(self, value: str) -> None:
+        with pytest.raises(ValueError, match="canonical UUID"):
+            canonical_job_id(value)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Stack

- Parent: #526 — corrected single-version roadmap and migration contract
- This PR: canonical JobId value boundary
- Next: exact v6-to-v7 migration and transition rollback wiring

## What changed

- add one canonical JobId parser for the Python domain boundary
- accept only the exact lowercase hyphenated UUID serialization
- reject URLs, aliases, uppercase and compact UUID spellings, empty strings, and malformed values
- retain UUIDv4 generation for newly created jobs

## Why

Stable identity must have a strict value boundary before storage and runtime adapters are cut over. URL-shaped values must not be accepted merely because JobId is represented as a string.

## Validation

- `pytest -q workers/automation/tests/test_domain_types.py` — 37 passed
- Ruff on the two touched files — passed
- `git diff --check` — passed

This is a review slice of one cumulative local upgrade and is not released independently.
