### PR TITLE
feat(storage): migrate event history to JobId

### DIFF
--- a/workers/automation/src/jobctrl/infrastructure/migrations/identity_upcast.py
+++ b/workers/automation/src/jobctrl/infrastructure/migrations/identity_upcast.py
@@ -1,0 +1,308 @@
+"""Migration-only root-event JobId upcast for the v6-to-v7 cutover.
+
+Historical event payloads are audit data.  Only root-level identity fields are
+rewritten; values nested under unrelated payload keys remain opaque and are
+preserved exactly when the event row is reconstructed.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+EVENT_IDENTITY_UPCAST_VERSION = 1
+
+_SINGLE_FIELDS = {
+    "jobId": "jobId",
+    "jobUrl": "jobId",
+    "jobKey": "jobId",
+    "job_id": "job_id",
+    "job_url": "job_id",
+    "job_key": "job_id",
+    "candidateJobId": "candidateJobId",
+    "candidate_job_id": "candidate_job_id",
+    "survivingJobId": "survivingJobId",
+    "surviving_job_id": "surviving_job_id",
+}
+_PLURAL_FIELDS = {
+    "jobIds": "jobIds",
+    "jobUrls": "jobIds",
+    "jobKeys": "jobIds",
+    "job_ids": "job_ids",
+    "job_urls": "job_ids",
+    "job_keys": "job_ids",
+}
+_ROOT_PRIMARY_FIELDS = (
+    "jobId",
+    "job_id",
+    "survivingJobId",
+    "surviving_job_id",
+)
+_NON_JOB_SCOPE_REFERENCES = frozenset({"pipeline"})
+
+
+class EventIdentityUpcastError(RuntimeError):
+    """Bounded failure that never includes a raw job locator."""
+
+    def __init__(self, code: str) -> None:
+        self.code = code
+        super().__init__(code)
+
+
+@dataclass(frozen=True)
+class UpcastedEventIdentity:
+    version: int
+    job_id: str | None
+    referenced_job_ids: tuple[str, ...]
+    payload: dict[str, Any]
+
+
+def upcast_v6_event_identity(
+    conn: sqlite3.Connection,
+    *,
+    tenant_id: str,
+    event_type: str | None = None,
+    event_job_reference: str | None,
+    payload: Mapping[str, Any],
+) -> UpcastedEventIdentity:
+    """Return the v7 identity view of one immutable v6 event row."""
+    normalized_tenant = str(tenant_id or "").strip()
+    if not normalized_tenant or not isinstance(payload, Mapping):
+        raise EventIdentityUpcastError("event_job_identity_invalid")
+
+    referenced: set[str] = set()
+    column_job_id = (
+        _resolve_reference(
+            conn,
+            tenant_id=normalized_tenant,
+            reference=event_job_reference,
+        )
+        if event_job_reference is not None
+        else None
+    )
+    if column_job_id is not None:
+        referenced.add(column_job_id)
+
+    transformed = _upcast_root_payload(
+        conn,
+        tenant_id=normalized_tenant,
+        payload=_normalize_root_payload(event_type, payload),
+        referenced=referenced,
+    )
+    root_job_ids = {
+        value
+        for key in _ROOT_PRIMARY_FIELDS
+        if isinstance((value := transformed.get(key)), str)
+        and value not in _NON_JOB_SCOPE_REFERENCES
+    }
+    primary_job_ids = set(root_job_ids)
+    if column_job_id is not None:
+        primary_job_ids.add(column_job_id)
+    if len(primary_job_ids) > 1:
+        raise EventIdentityUpcastError("event_job_identity_conflict")
+
+    if column_job_id is not None:
+        inferred_job_id = column_job_id
+    elif len(root_job_ids) == 1:
+        inferred_job_id = next(iter(root_job_ids))
+    elif len(inferable_job_ids := _root_payload_job_ids(transformed)) == 1:
+        inferred_job_id = next(iter(inferable_job_ids))
+    else:
+        inferred_job_id = None
+    return UpcastedEventIdentity(
+        version=EVENT_IDENTITY_UPCAST_VERSION,
+        job_id=inferred_job_id,
+        referenced_job_ids=tuple(sorted(referenced)),
+        payload=transformed,
+    )
+
+
+def _normalize_root_payload(
+    event_type: str | None,
+    payload: Mapping[str, Any],
+) -> dict[str, Any]:
+    normalized = dict(payload)
+    if event_type != "DuplicateJobLinkRejected":
+        return normalized
+    _rename_root_posting_locator(
+        normalized,
+        historical_key="candidateJobId",
+        current_key="candidatePostingUrl",
+    )
+    _rename_root_posting_locator(
+        normalized,
+        historical_key="candidate_job_id",
+        current_key="candidate_posting_url",
+    )
+    return normalized
+
+
+def _rename_root_posting_locator(
+    payload: dict[str, Any],
+    *,
+    historical_key: str,
+    current_key: str,
+) -> None:
+    if historical_key not in payload:
+        return
+    historical_value = payload[historical_key]
+    if current_key in payload and payload[current_key] != historical_value:
+        raise EventIdentityUpcastError("event_job_identity_conflict")
+    payload[current_key] = historical_value
+    del payload[historical_key]
+
+
+def _upcast_root_payload(
+    conn: sqlite3.Connection,
+    *,
+    tenant_id: str,
+    payload: Mapping[str, Any],
+    referenced: set[str],
+) -> dict[str, Any]:
+    transformed: dict[str, Any] = {}
+    for raw_key, raw_value in payload.items():
+        key = str(raw_key)
+        if key in _SINGLE_FIELDS:
+            output_key = _SINGLE_FIELDS[key]
+            output_value = _upcast_single_reference(
+                conn,
+                tenant_id=tenant_id,
+                value=raw_value,
+                referenced=referenced,
+            )
+        elif key in _PLURAL_FIELDS:
+            output_key = _PLURAL_FIELDS[key]
+            output_value = _upcast_reference_collection(
+                conn,
+                tenant_id=tenant_id,
+                value=raw_value,
+                referenced=referenced,
+            )
+        else:
+            output_key = key
+            output_value = raw_value
+        if output_key in transformed and transformed[output_key] != output_value:
+            raise EventIdentityUpcastError("event_job_identity_conflict")
+        transformed[output_key] = output_value
+    return transformed
+
+
+def _upcast_single_reference(
+    conn: sqlite3.Connection,
+    *,
+    tenant_id: str,
+    value: Any,
+    referenced: set[str],
+) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise EventIdentityUpcastError("event_job_identity_invalid")
+    if value.strip() in _NON_JOB_SCOPE_REFERENCES:
+        return value.strip()
+    job_id = _resolve_reference(conn, tenant_id=tenant_id, reference=value)
+    referenced.add(job_id)
+    return job_id
+
+
+def _upcast_reference_collection(
+    conn: sqlite3.Connection,
+    *,
+    tenant_id: str,
+    value: Any,
+    referenced: set[str],
+) -> list[str | None]:
+    if not isinstance(value, list):
+        raise EventIdentityUpcastError("event_job_identity_invalid")
+    return [
+        _upcast_single_reference(
+            conn,
+            tenant_id=tenant_id,
+            value=item,
+            referenced=referenced,
+        )
+        for item in value
+    ]
+
+
+def _resolve_reference(
+    conn: sqlite3.Connection,
+    *,
+    tenant_id: str,
+    reference: str | None,
+) -> str:
+    normalized = str(reference or "").strip()
+    if not normalized:
+        raise EventIdentityUpcastError("event_job_identity_invalid")
+
+    direct_url = _job_id_from_query(
+        conn,
+        "SELECT job_id FROM jobs WHERE tenant_id = ? AND url = ?",
+        (tenant_id, normalized),
+    )
+    alias_url = _job_id_from_query(
+        conn,
+        """
+        SELECT jobs.job_id
+        FROM job_identity_aliases AS aliases
+        JOIN jobs
+          ON jobs.tenant_id = aliases.tenant_id
+         AND jobs.job_id = aliases.job_id
+        WHERE aliases.tenant_id = ?
+          AND aliases.alias_kind = 'posting_url'
+          AND aliases.alias_value = ?
+        """,
+        (tenant_id, normalized),
+    )
+    if direct_url is not None and alias_url is not None and direct_url != alias_url:
+        raise EventIdentityUpcastError("event_job_identity_conflict")
+    if direct_url is not None or alias_url is not None:
+        return direct_url or alias_url  # type: ignore[return-value]
+
+    stable_job_id = _job_id_from_query(
+        conn,
+        "SELECT job_id FROM jobs WHERE tenant_id = ? AND job_id = ?",
+        (tenant_id, normalized),
+    )
+    if stable_job_id is None:
+        raise EventIdentityUpcastError("event_job_identity_unresolved")
+    return stable_job_id
+
+
+def _job_id_from_query(
+    conn: sqlite3.Connection,
+    sql: str,
+    params: tuple[str, str],
+) -> str | None:
+    row = conn.execute(sql, params).fetchone()
+    if row is None:
+        return None
+    value = row["job_id"] if isinstance(row, sqlite3.Row) else row[0]
+    normalized = str(value or "").strip()
+    if not normalized:
+        raise EventIdentityUpcastError("event_job_identity_invalid")
+    return normalized
+
+
+def _root_payload_job_ids(payload: Mapping[str, Any]) -> set[str]:
+    inferred: set[str] = set()
+    for key, value in payload.items():
+        if key in {"jobId", "job_id"} and isinstance(value, str):
+            if value not in _NON_JOB_SCOPE_REFERENCES:
+                inferred.add(value)
+        elif key in {"jobIds", "job_ids"} and isinstance(value, list):
+            inferred.update(
+                item
+                for item in value
+                if isinstance(item, str) and item not in _NON_JOB_SCOPE_REFERENCES
+            )
+    return inferred
+
+
+__all__ = [
+    "EVENT_IDENTITY_UPCAST_VERSION",
+    "EventIdentityUpcastError",
+    "UpcastedEventIdentity",
+    "upcast_v6_event_identity",
+]

--- a/workers/automation/src/jobctrl/infrastructure/migrations/v6_to_v7_events.py
+++ b/workers/automation/src/jobctrl/infrastructure/migrations/v6_to_v7_events.py
@@ -1,0 +1,309 @@
+"""Explicit v6-to-v7 reconstruction of append-only job event identity."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from typing import Any
+
+from jobctrl.infrastructure.migrations.identity_upcast import (
+    EVENT_IDENTITY_UPCAST_VERSION,
+    upcast_v6_event_identity,
+)
+from jobctrl.infrastructure.migrations.v6_to_v7_support import (
+    has_tenant_job_foreign_key,
+    table_columns,
+)
+
+_EVENT_TABLES = ("job_events",)
+_EVENT_COLUMNS = (
+    "event_id",
+    "tenant_id",
+    "job_id",
+    "identity_version",
+    "stage",
+    "event_type",
+    "level",
+    "message",
+    "occurred_at",
+    "payload_json",
+    "entity_kind",
+    "entity_ref",
+    "idempotency_key",
+)
+
+
+def transform_v6_job_events(conn: sqlite3.Connection) -> list[str]:
+    """Replace v6 URL-keyed events with v7 tenant-scoped JobId events."""
+    if "job_url" not in table_columns(conn, "job_events"):
+        raise RuntimeError(
+            "the v7 cutover event identity requires the legacy job_url column"
+        )
+
+    conn.execute("SAVEPOINT v6_job_events")
+    try:
+        canonical_rows, expected_event_ids, sequence_high_water = canonical_v6_event_rows(
+            conn
+        )
+        conn.execute('DROP TABLE IF EXISTS "job_events_rebuilt"')
+        create_v7_job_events_table(conn, table="job_events_rebuilt")
+        conn.executemany(
+            """
+            INSERT INTO job_events_rebuilt (
+                event_id,
+                tenant_id,
+                job_id,
+                identity_version,
+                stage,
+                event_type,
+                level,
+                message,
+                occurred_at,
+                payload_json,
+                entity_kind,
+                entity_ref,
+                idempotency_key
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            canonical_rows,
+        )
+        conn.execute('DROP TABLE "job_events"')
+        conn.execute('ALTER TABLE "job_events_rebuilt" RENAME TO "job_events"')
+        restore_job_event_sequence(
+            conn,
+            sequence_high_water=sequence_high_water,
+        )
+        create_v7_job_event_indexes(conn)
+        verify_v7_job_events(
+            conn,
+            expected_event_ids=expected_event_ids,
+            expected_sequence_high_water=sequence_high_water,
+        )
+        conn.execute("RELEASE SAVEPOINT v6_job_events")
+    except BaseException:
+        conn.execute("ROLLBACK TO SAVEPOINT v6_job_events")
+        conn.execute("RELEASE SAVEPOINT v6_job_events")
+        raise
+    return list(_EVENT_TABLES)
+
+
+def create_v7_job_events_table(conn: sqlite3.Connection, *, table: str) -> None:
+    """Create the final event schema using a temporary rebuild table name."""
+    conn.execute(
+        f"""
+        CREATE TABLE "{table}" (
+            event_id         INTEGER PRIMARY KEY AUTOINCREMENT,
+            tenant_id        TEXT NOT NULL,
+            job_id           TEXT,
+            identity_version INTEGER NOT NULL,
+            stage            TEXT,
+            event_type       TEXT NOT NULL,
+            level            TEXT NOT NULL DEFAULT 'info',
+            message          TEXT,
+            occurred_at      TEXT NOT NULL,
+            payload_json     TEXT,
+            entity_kind      TEXT,
+            entity_ref       TEXT,
+            idempotency_key  TEXT,
+            FOREIGN KEY (tenant_id, job_id)
+                REFERENCES jobs(tenant_id, job_id) ON DELETE CASCADE
+        )
+        """
+    )
+
+
+def create_v7_job_event_indexes(conn: sqlite3.Connection) -> None:
+    """Install the target event read and idempotency indexes."""
+    conn.execute(
+        """
+        CREATE UNIQUE INDEX idx_job_events_idempotency_key
+        ON job_events(idempotency_key)
+        WHERE idempotency_key IS NOT NULL
+        """
+    )
+    conn.execute(
+        """
+        CREATE INDEX idx_job_events_job_time
+        ON job_events(tenant_id, job_id, occurred_at DESC, event_id DESC)
+        """
+    )
+    conn.execute(
+        "CREATE INDEX idx_job_events_tenant_eid ON job_events(tenant_id, event_id)"
+    )
+    conn.execute(
+        """
+        CREATE INDEX idx_job_events_stage_time
+        ON job_events(tenant_id, stage, occurred_at DESC, event_id DESC)
+        """
+    )
+    conn.execute(
+        """
+        CREATE INDEX idx_job_events_entity
+        ON job_events(tenant_id, entity_kind, entity_ref, occurred_at DESC, event_id DESC)
+        """
+    )
+
+
+def canonical_v6_event_rows(
+    conn: sqlite3.Connection,
+) -> tuple[list[tuple[Any, ...]], tuple[int, ...], int]:
+    """Upcast v6 event identity while preserving event IDs and payload content."""
+    rows = conn.execute(
+        """
+        SELECT
+            event_id,
+            job_url,
+            stage,
+            event_type,
+            level,
+            message,
+            occurred_at,
+            payload_json,
+            entity_kind,
+            entity_ref,
+            idempotency_key
+        FROM job_events
+        ORDER BY event_id
+        """
+    ).fetchall()
+    sequence_row = conn.execute(
+        "SELECT seq FROM sqlite_sequence WHERE name = 'job_events'"
+    ).fetchone()
+    canonical: list[tuple[Any, ...]] = []
+    event_ids: list[int] = []
+    for row in rows:
+        event_id = int(row[0])
+        raw_payload = row[7]
+        upcasted = upcast_v6_event_identity(
+            conn,
+            tenant_id="local",
+            event_type=str(row[3]),
+            event_job_reference=str(row[1]) if row[1] is not None else None,
+            payload=parse_v6_event_payload(raw_payload),
+        )
+        canonical.append(
+            (
+                event_id,
+                "local",
+                upcasted.job_id,
+                upcasted.version,
+                row[2],
+                row[3],
+                row[4],
+                row[5],
+                row[6],
+                (
+                    json.dumps(
+                        upcasted.payload,
+                        separators=(",", ":"),
+                        sort_keys=True,
+                    )
+                    if raw_payload is not None
+                    else None
+                ),
+                row[8],
+                (
+                    upcasted.job_id
+                    if row[8] == "job" and upcasted.job_id is not None
+                    else row[9]
+                ),
+                row[10],
+            )
+        )
+        event_ids.append(event_id)
+    max_event_id = max(event_ids, default=0)
+    sequence_high_water = max(
+        int(sequence_row[0]) if sequence_row is not None else 0,
+        max_event_id,
+    )
+    return canonical, tuple(event_ids), sequence_high_water
+
+
+def parse_v6_event_payload(raw_payload: Any) -> dict[str, Any]:
+    """Decode the object payload required by the historical v6 event log."""
+    if raw_payload is None:
+        return {}
+    try:
+        parsed = json.loads(str(raw_payload))
+    except (TypeError, ValueError) as exc:
+        raise RuntimeError("Event identity migration found invalid payload JSON") from exc
+    if not isinstance(parsed, dict):
+        raise RuntimeError("Event identity migration requires object payload JSON")
+    return parsed
+
+
+def restore_job_event_sequence(
+    conn: sqlite3.Connection,
+    *,
+    sequence_high_water: int,
+) -> None:
+    """Restore the append-only event ID high-water after table replacement."""
+    conn.execute(
+        "DELETE FROM sqlite_sequence WHERE name IN ('job_events', 'job_events_rebuilt')"
+    )
+    conn.execute(
+        "INSERT INTO sqlite_sequence (name, seq) VALUES ('job_events', ?)",
+        (sequence_high_water,),
+    )
+
+
+def verify_v7_job_events(
+    conn: sqlite3.Connection,
+    *,
+    expected_event_ids: tuple[int, ...],
+    expected_sequence_high_water: int,
+) -> None:
+    """Verify v7 event identity, ordered history, and sequence continuity."""
+    columns = table_columns(conn, "job_events")
+    if columns != set(_EVENT_COLUMNS) or len(columns) != len(_EVENT_COLUMNS):
+        raise RuntimeError("Event identity migration did not create the v7 schema")
+    if not has_tenant_job_foreign_key(conn, "job_events", "job_id"):
+        raise RuntimeError("Event identity migration did not create the v7 schema")
+    observed_event_ids = tuple(
+        int(row[0])
+        for row in conn.execute(
+            "SELECT event_id FROM job_events ORDER BY event_id"
+        ).fetchall()
+    )
+    if observed_event_ids != expected_event_ids:
+        raise RuntimeError("Event identity migration changed event ordering or identity")
+    sequence_row = conn.execute(
+        "SELECT seq FROM sqlite_sequence WHERE name = 'job_events'"
+    ).fetchone()
+    if (
+        sequence_row is None
+        or int(sequence_row[0]) != expected_sequence_high_water
+    ):
+        raise RuntimeError("Event identity migration changed the event ID high-water")
+    invalid_identity_version = conn.execute(
+        "SELECT event_id FROM job_events WHERE identity_version != ? LIMIT 1",
+        (EVENT_IDENTITY_UPCAST_VERSION,),
+    ).fetchone()
+    if invalid_identity_version is not None:
+        raise RuntimeError("Event identity migration left an invalid identity version")
+    orphan = conn.execute(
+        """
+        SELECT events.event_id
+        FROM job_events AS events
+        LEFT JOIN jobs
+          ON jobs.tenant_id = events.tenant_id
+         AND jobs.job_id = events.job_id
+        WHERE events.job_id IS NOT NULL
+          AND jobs.job_id IS NULL
+        LIMIT 1
+        """
+    ).fetchone()
+    if orphan is not None:
+        raise RuntimeError("Event identity migration left an unresolved JobId")
+    foreign_key_error = conn.execute("PRAGMA foreign_key_check").fetchone()
+    if foreign_key_error is not None:
+        raise RuntimeError("Event identity migration found a foreign-key violation")
+
+
+__all__ = [
+    "canonical_v6_event_rows",
+    "parse_v6_event_payload",
+    "restore_job_event_sequence",
+    "transform_v6_job_events",
+    "verify_v7_job_events",
+]

--- a/workers/automation/src/jobctrl/infrastructure/migrations/v6_to_v7_events.py
+++ b/workers/automation/src/jobctrl/infrastructure/migrations/v6_to_v7_events.py
@@ -124,22 +124,41 @@ def create_v7_job_event_indexes(conn: sqlite3.Connection) -> None:
     conn.execute(
         """
         CREATE INDEX idx_job_events_job_time
-        ON job_events(tenant_id, job_id, occurred_at DESC, event_id DESC)
+        ON job_events(
+            tenant_id,
+            job_id,
+            occurred_at DESC,
+            event_id DESC
+        )
         """
-    )
-    conn.execute(
-        "CREATE INDEX idx_job_events_tenant_eid ON job_events(tenant_id, event_id)"
     )
     conn.execute(
         """
         CREATE INDEX idx_job_events_stage_time
-        ON job_events(tenant_id, stage, occurred_at DESC, event_id DESC)
+        ON job_events(
+            tenant_id,
+            stage,
+            occurred_at DESC,
+            event_id DESC
+        )
         """
     )
     conn.execute(
         """
         CREATE INDEX idx_job_events_entity
-        ON job_events(tenant_id, entity_kind, entity_ref, occurred_at DESC, event_id DESC)
+        ON job_events(
+            tenant_id,
+            entity_kind,
+            entity_ref,
+            occurred_at DESC,
+            event_id DESC
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE INDEX idx_job_events_tenant_eid
+        ON job_events(tenant_id, event_id)
         """
     )
 

--- a/workers/automation/tests/test_v6_to_v7_events.py
+++ b/workers/automation/tests/test_v6_to_v7_events.py
@@ -1,0 +1,264 @@
+"""Focused v6-to-v7 historical event identity migration tests."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from jobctrl.infrastructure.migrations import v6_to_v7_events as events
+from jobctrl.infrastructure.migrations.v6_to_v7_identity import transform_v6_root_identity
+from tests.v6_migration_fixture import create_shipped_v6_database
+
+
+def _insert_v6_event(
+    conn: sqlite3.Connection,
+    *,
+    payload: dict[str, object],
+    event_id: int = 7,
+    event_type: str = "StageCompleted",
+    job_url: str = "https://jobs.example/shipped-v6",
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO job_events (
+            event_id, job_url, stage, event_type, level, message, occurred_at,
+            payload_json, entity_kind, entity_ref, idempotency_key
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            event_id,
+            job_url,
+            "discover",
+            event_type,
+            "info",
+            "fixture",
+            "2026-07-30T10:00:00+00:00",
+            json.dumps(payload, separators=(",", ":")),
+            "job",
+            job_url,
+            f"fixture-event-{event_id}",
+        ),
+    )
+    conn.execute("UPDATE sqlite_sequence SET seq = 41 WHERE name = 'job_events'")
+
+
+def test_event_root_identity_is_upcast_without_mutating_nested_payloads(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    create_shipped_v6_database(db_path)
+    conn = sqlite3.connect(db_path)
+    try:
+        transform_v6_root_identity(conn)
+        expected_job_id = str(conn.execute("SELECT job_id FROM jobs").fetchone()[0])
+        nested_untrusted_payload = {
+            "userContext": "Attack vectors:\nPrompt injection",
+            "jobUrl": "https://jobs.example/shipped-v6",
+            "items": [{"job_url": "https://jobs.example/shipped-v6"}],
+        }
+        _insert_v6_event(
+            conn,
+            payload={
+                "jobUrl": "https://jobs.example/shipped-v6",
+                "untrusted": nested_untrusted_payload,
+            },
+        )
+
+        events.transform_v6_job_events(conn)
+
+        row = conn.execute(
+            "SELECT event_id, job_id, entity_ref, payload_json FROM job_events"
+        ).fetchone()
+        payload = json.loads(str(row[3]))
+        assert row[:3] == (7, expected_job_id, expected_job_id)
+        assert payload["jobId"] == expected_job_id
+        assert "jobUrl" not in payload
+        assert payload["untrusted"] == nested_untrusted_payload
+        assert conn.execute(
+            "SELECT seq FROM sqlite_sequence WHERE name = 'job_events'"
+        ).fetchone()[0] == 41
+    finally:
+        conn.close()
+
+
+def test_event_root_plural_variants_are_upcast_to_job_ids(tmp_path: Path) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    create_shipped_v6_database(db_path)
+    conn = sqlite3.connect(db_path)
+    try:
+        transform_v6_root_identity(conn)
+        expected_job_id = str(conn.execute("SELECT job_id FROM jobs").fetchone()[0])
+        _insert_v6_event(
+            conn,
+            payload={
+                "jobUrls": ["https://jobs.example/shipped-v6"],
+                "job_keys": [expected_job_id],
+            },
+        )
+
+        events.transform_v6_job_events(conn)
+
+        row = conn.execute(
+            "SELECT job_id, entity_ref, payload_json FROM job_events"
+        ).fetchone()
+        assert row[:2] == (expected_job_id, expected_job_id)
+        assert json.loads(str(row[2])) == {
+            "jobIds": [expected_job_id],
+            "job_ids": [expected_job_id],
+        }
+    finally:
+        conn.close()
+
+
+def test_duplicate_link_event_preserves_historical_candidate_locator(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    create_shipped_v6_database(db_path)
+    conn = sqlite3.connect(db_path)
+    try:
+        transform_v6_root_identity(conn)
+        expected_job_id = str(conn.execute("SELECT job_id FROM jobs").fetchone()[0])
+        historical_url = "https://jobs.example/historical-v6"
+        conn.execute(
+            """
+            INSERT INTO job_identity_aliases (
+                tenant_id, alias_kind, alias_value, job_id, created_at, retired_at
+            ) VALUES ('local', 'posting_url', ?, ?, ?, ?)
+            """,
+            (
+                historical_url,
+                expected_job_id,
+                "2026-07-01T00:00:00+00:00",
+                "2026-07-15T00:00:00+00:00",
+            ),
+        )
+        _insert_v6_event(
+            conn,
+            event_type="DuplicateJobLinkRejected",
+            payload={
+                "candidateJobId": historical_url,
+                "survivingJobId": historical_url,
+                "details": {"candidateJobId": historical_url},
+            },
+        )
+
+        events.transform_v6_job_events(conn)
+
+        payload = json.loads(
+            str(conn.execute("SELECT payload_json FROM job_events").fetchone()[0])
+        )
+        assert payload == {
+            "candidatePostingUrl": historical_url,
+            "survivingJobId": expected_job_id,
+            "details": {"candidateJobId": historical_url},
+        }
+    finally:
+        conn.close()
+
+
+@pytest.mark.parametrize(
+    "payload_kind",
+    ("unresolved", "conflict"),
+)
+def test_invalid_event_root_reference_rolls_back_without_data_loss(
+    tmp_path: Path,
+    payload_kind: str,
+) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    create_shipped_v6_database(db_path)
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute(
+            """
+            INSERT INTO jobs (url, title, discovered_at) VALUES (?, ?, ?)
+            """,
+            (
+                "https://jobs.example/conflicting-v6",
+                "Conflicting V6 fixture",
+                "2026-07-30T09:01:00+00:00",
+            ),
+        )
+        transform_v6_root_identity(conn)
+        conflicting_job_id = str(
+            conn.execute(
+                "SELECT job_id FROM jobs WHERE url = ?",
+                ("https://jobs.example/conflicting-v6",),
+            ).fetchone()[0]
+        )
+        _insert_v6_event(
+            conn,
+            payload=(
+                {"jobUrl": "https://jobs.example/unresolved-v6"}
+                if payload_kind == "unresolved"
+                else {"jobId": conflicting_job_id}
+            ),
+        )
+        before_schema = tuple(
+            conn.execute(
+                "SELECT type, name, tbl_name, sql FROM sqlite_master ORDER BY type, name"
+            ).fetchall()
+        )
+        before_rows = tuple(conn.execute("SELECT * FROM job_events").fetchall())
+        before_sequence = conn.execute(
+            "SELECT seq FROM sqlite_sequence WHERE name = 'job_events'"
+        ).fetchone()
+
+        with pytest.raises(RuntimeError, match="event_job_identity"):
+            events.transform_v6_job_events(conn)
+
+        assert tuple(
+            conn.execute(
+                "SELECT type, name, tbl_name, sql FROM sqlite_master ORDER BY type, name"
+            ).fetchall()
+        ) == before_schema
+        assert tuple(conn.execute("SELECT * FROM job_events").fetchall()) == before_rows
+        assert conn.execute(
+            "SELECT seq FROM sqlite_sequence WHERE name = 'job_events'"
+        ).fetchone() == before_sequence
+    finally:
+        conn.close()
+
+
+def test_event_identity_rebuild_rolls_back_when_verification_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    create_shipped_v6_database(db_path)
+    conn = sqlite3.connect(db_path)
+    try:
+        transform_v6_root_identity(conn)
+        _insert_v6_event(conn, payload={"jobUrl": "https://jobs.example/shipped-v6"})
+        before_schema = tuple(
+            conn.execute(
+                "SELECT type, name, tbl_name, sql FROM sqlite_master ORDER BY type, name"
+            ).fetchall()
+        )
+        before_rows = tuple(conn.execute("SELECT * FROM job_events").fetchall())
+        before_sequence = conn.execute(
+            "SELECT seq FROM sqlite_sequence WHERE name = 'job_events'"
+        ).fetchone()
+        monkeypatch.setattr(
+            events,
+            "create_v7_job_event_indexes",
+            lambda _conn: (_ for _ in ()).throw(RuntimeError("fault")),
+        )
+
+        with pytest.raises(RuntimeError, match="fault"):
+            events.transform_v6_job_events(conn)
+
+        assert tuple(
+            conn.execute(
+                "SELECT type, name, tbl_name, sql FROM sqlite_master ORDER BY type, name"
+            ).fetchall()
+        ) == before_schema
+        assert tuple(conn.execute("SELECT * FROM job_events").fetchall()) == before_rows
+        assert conn.execute(
+            "SELECT seq FROM sqlite_sequence WHERE name = 'job_events'"
+        ).fetchone() == before_sequence
+    finally:
+        conn.close()

--- a/workers/automation/tests/test_v6_to_v7_events.py
+++ b/workers/automation/tests/test_v6_to_v7_events.py
@@ -9,6 +9,8 @@ from pathlib import Path
 import pytest
 
 from jobctrl.infrastructure.migrations import v6_to_v7_events as events
+from jobctrl.infrastructure.migrations.schema_manifest import schema_dump
+from jobctrl.infrastructure.migrations.schema_v7 import create_exact_v7_schema
 from jobctrl.infrastructure.migrations.v6_to_v7_identity import transform_v6_root_identity
 from tests.v6_migration_fixture import create_shipped_v6_database
 
@@ -220,6 +222,26 @@ def test_invalid_event_root_reference_rolls_back_without_data_loss(
             "SELECT seq FROM sqlite_sequence WHERE name = 'job_events'"
         ).fetchone() == before_sequence
     finally:
+        conn.close()
+
+
+def test_event_rebuild_matches_the_exact_v7_schema_objects(tmp_path: Path) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    create_shipped_v6_database(db_path)
+    conn = sqlite3.connect(db_path)
+    canonical = sqlite3.connect(":memory:")
+    try:
+        transform_v6_root_identity(conn)
+        events.transform_v6_job_events(conn)
+        create_exact_v7_schema(canonical)
+
+        assert tuple(
+            row for row in schema_dump(conn) if row[2] == "job_events"
+        ) == tuple(
+            row for row in schema_dump(canonical) if row[2] == "job_events"
+        )
+    finally:
+        canonical.close()
         conn.close()
 
 


### PR DESCRIPTION
> Superseded by the source-immutable exact-v7 candidate migration stack beginning at #577. This PR rebuilt the event table inside the admitted v6 database and therefore belongs to the discarded in-place design.

## Status

Closed without merge. Event-history rewriting will be reintroduced as a candidate-only structured-copy slice; no descendant READY PR depends on this branch.