### PR TITLE
feat(storage): migrate operational metrics to JobId

### DIFF
--- a/workers/automation/src/jobctrl/infrastructure/migrations/v6_to_v7_operational_metrics.py
+++ b/workers/automation/src/jobctrl/infrastructure/migrations/v6_to_v7_operational_metrics.py
@@ -1,0 +1,187 @@
+"""Explicit v6-to-v7 transform for operational-metric Job references."""
+
+from __future__ import annotations
+
+import sqlite3
+
+from jobctrl.infrastructure.migrations.v6_to_v7_support import table_columns, table_exists
+
+
+def migrate_v6_operational_attempt_metrics(conn: sqlite3.Connection) -> list[str]:
+    """Replace optional v6 metric URLs with canonical JobId references."""
+    if not table_exists(conn, "operational_attempt_metrics"):
+        return []
+    columns = table_columns(conn, "operational_attempt_metrics")
+    if "job_url" not in columns:
+        raise RuntimeError("v6 operational metrics is missing job_url")
+    expected_count = int(
+        conn.execute("SELECT COUNT(*) FROM operational_attempt_metrics").fetchone()[0]
+    )
+    sequence_row = conn.execute(
+        "SELECT seq FROM sqlite_sequence WHERE name = 'operational_attempt_metrics'"
+    ).fetchone()
+    max_metric_row = conn.execute(
+        "SELECT COALESCE(MAX(metric_id), 0) FROM operational_attempt_metrics"
+    ).fetchone()
+    sequence_high_water = max(
+        int(sequence_row[0]) if sequence_row is not None else 0,
+        int(max_metric_row[0]),
+    )
+    unresolved = conn.execute(
+        """
+        SELECT metrics.metric_id
+        FROM operational_attempt_metrics AS metrics
+        LEFT JOIN jobs AS current_job
+          ON current_job.tenant_id = metrics.tenant_id
+         AND current_job.url = metrics.job_url
+        LEFT JOIN job_identity_aliases AS locators
+          ON locators.tenant_id = metrics.tenant_id
+         AND locators.alias_kind = 'posting_url'
+         AND locators.alias_value = metrics.job_url
+        WHERE metrics.job_url IS NOT NULL
+          AND current_job.job_id IS NULL
+          AND locators.job_id IS NULL
+        LIMIT 1
+        """
+    ).fetchone()
+    if unresolved is not None:
+        raise RuntimeError("operational metrics contains an unresolved job locator")
+
+    conn.execute("SAVEPOINT v6_operational_metrics")
+    try:
+        conn.execute('DROP TABLE IF EXISTS "operational_attempt_metrics_rebuilt"')
+        conn.execute(
+            """
+            CREATE TABLE operational_attempt_metrics_rebuilt (
+            metric_id               INTEGER PRIMARY KEY AUTOINCREMENT,
+            tenant_id               TEXT NOT NULL DEFAULT 'local',
+            occurred_at             TEXT NOT NULL,
+            stage                   TEXT NOT NULL,
+            source_id               TEXT,
+            source_kind             TEXT,
+            source_priority         TEXT,
+            source_role             TEXT,
+            adapter                 TEXT,
+            attempt_kind            TEXT NOT NULL,
+            outcome                 TEXT NOT NULL,
+            failure_category        TEXT,
+            is_operational_failure  INTEGER NOT NULL DEFAULT 0,
+            is_scrape_failure       INTEGER NOT NULL DEFAULT 0,
+            is_retryable            INTEGER NOT NULL DEFAULT 1,
+            run_id                  TEXT,
+            job_id                  TEXT,
+            duration_ms             INTEGER,
+            total_count             INTEGER,
+            new_count               INTEGER,
+            existing_count          INTEGER,
+            observed_count          INTEGER,
+            duplicate_count         INTEGER,
+            error_class             TEXT,
+            error_message           TEXT,
+            metadata_json           TEXT NOT NULL DEFAULT '{}',
+            FOREIGN KEY (tenant_id, job_id)
+                REFERENCES jobs(tenant_id, job_id) ON DELETE RESTRICT
+        )
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO operational_attempt_metrics_rebuilt (
+            metric_id, tenant_id, occurred_at, stage, source_id, source_kind,
+            source_priority, source_role, adapter, attempt_kind, outcome,
+            failure_category, is_operational_failure, is_scrape_failure,
+            is_retryable, run_id, job_id, duration_ms, total_count, new_count,
+            existing_count, observed_count, duplicate_count, error_class,
+            error_message, metadata_json
+        )
+        SELECT
+            metrics.metric_id, metrics.tenant_id, metrics.occurred_at,
+            metrics.stage, metrics.source_id, metrics.source_kind,
+            metrics.source_priority, metrics.source_role, metrics.adapter,
+            metrics.attempt_kind, metrics.outcome, metrics.failure_category,
+            metrics.is_operational_failure, metrics.is_scrape_failure,
+            metrics.is_retryable, metrics.run_id,
+            COALESCE(current_job.job_id, historical_job.job_id),
+            metrics.duration_ms, metrics.total_count, metrics.new_count,
+            metrics.existing_count, metrics.observed_count,
+            metrics.duplicate_count, metrics.error_class,
+            metrics.error_message, metrics.metadata_json
+        FROM operational_attempt_metrics AS metrics
+        LEFT JOIN jobs AS current_job
+          ON current_job.tenant_id = metrics.tenant_id
+         AND current_job.url = metrics.job_url
+        LEFT JOIN job_identity_aliases AS locators
+          ON locators.tenant_id = metrics.tenant_id
+         AND locators.alias_kind = 'posting_url'
+         AND locators.alias_value = metrics.job_url
+        LEFT JOIN jobs AS historical_job
+          ON historical_job.tenant_id = locators.tenant_id
+         AND historical_job.job_id = locators.job_id
+            """
+        )
+        conn.execute('DROP TABLE "operational_attempt_metrics"')
+        conn.execute(
+            'ALTER TABLE "operational_attempt_metrics_rebuilt" '
+            'RENAME TO "operational_attempt_metrics"'
+        )
+        conn.execute(
+            "CREATE INDEX idx_operational_attempt_metrics_stage_time "
+            "ON operational_attempt_metrics"
+            "(tenant_id, stage, occurred_at DESC, metric_id DESC)"
+        )
+        conn.execute(
+            "CREATE INDEX idx_operational_attempt_metrics_source_time "
+            "ON operational_attempt_metrics"
+            "(tenant_id, source_id, occurred_at DESC, metric_id DESC)"
+        )
+        conn.execute(
+            "DELETE FROM sqlite_sequence WHERE name = 'operational_attempt_metrics'"
+        )
+        if sequence_high_water:
+            conn.execute(
+                "INSERT INTO sqlite_sequence(name, seq) "
+                "VALUES ('operational_attempt_metrics', ?)",
+                (sequence_high_water,),
+            )
+        verify_v7_operational_attempt_metrics(
+            conn,
+            expected_count=expected_count,
+            expected_sequence_high_water=sequence_high_water,
+        )
+        conn.execute("RELEASE SAVEPOINT v6_operational_metrics")
+    except BaseException:
+        conn.execute("ROLLBACK TO SAVEPOINT v6_operational_metrics")
+        conn.execute("RELEASE SAVEPOINT v6_operational_metrics")
+        raise
+    return ["operational_attempt_metrics"]
+
+
+def verify_v7_operational_attempt_metrics(
+    conn: sqlite3.Connection,
+    *,
+    expected_count: int,
+    expected_sequence_high_water: int,
+) -> None:
+    """Verify the exact metric identity transform and sequence continuity."""
+    columns = table_columns(conn, "operational_attempt_metrics")
+    if "job_id" not in columns or "job_url" in columns:
+        raise RuntimeError("operational metrics migration did not create v7 identity")
+    observed_count = int(
+        conn.execute("SELECT COUNT(*) FROM operational_attempt_metrics").fetchone()[0]
+    )
+    if observed_count != expected_count:
+        raise RuntimeError("operational metrics migration changed the row count")
+    sequence_row = conn.execute(
+        "SELECT seq FROM sqlite_sequence WHERE name = 'operational_attempt_metrics'"
+    ).fetchone()
+    observed_high_water = int(sequence_row[0]) if sequence_row is not None else 0
+    if observed_high_water != expected_sequence_high_water:
+        raise RuntimeError("operational metrics migration changed the ID high-water")
+    if conn.execute("PRAGMA foreign_key_check").fetchone() is not None:
+        raise RuntimeError("operational metrics migration found a foreign-key violation")
+
+
+__all__ = [
+    "migrate_v6_operational_attempt_metrics",
+    "verify_v7_operational_attempt_metrics",
+]

--- a/workers/automation/tests/test_v6_to_v7_operational_metrics.py
+++ b/workers/automation/tests/test_v6_to_v7_operational_metrics.py
@@ -1,0 +1,111 @@
+"""Focused v6-to-v7 operational metric reference migration tests."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from jobctrl.infrastructure.migrations import (
+    v6_to_v7_operational_metrics as metrics,
+)
+from jobctrl.infrastructure.migrations.v6_to_v7_identity import transform_v6_root_identity
+from jobctrl.infrastructure.migrations.v6_to_v7_operational_metrics import (
+    migrate_v6_operational_attempt_metrics,
+)
+from tests.v6_migration_fixture import create_shipped_v6_database
+
+
+def test_operational_metrics_keep_their_job_association_as_job_id(tmp_path: Path) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    create_shipped_v6_database(db_path)
+    conn = sqlite3.connect(db_path)
+    try:
+        job_url = "https://jobs.example/shipped-v6"
+        conn.execute(
+            """
+            INSERT INTO operational_attempt_metrics (
+                occurred_at, stage, attempt_kind, outcome, job_url
+            ) VALUES (?, ?, ?, ?, ?)
+            """,
+            ("2026-07-30T10:00:00+00:00", "discover", "crawl", "success", job_url),
+        )
+        transform_v6_root_identity(conn)
+        expected_job_id = str(conn.execute("SELECT job_id FROM jobs").fetchone()[0])
+
+        migrate_v6_operational_attempt_metrics(conn)
+
+        assert conn.execute(
+            "SELECT job_id FROM operational_attempt_metrics"
+        ).fetchone()[0] == expected_job_id
+        assert "job_url" not in {
+            str(row[1])
+            for row in conn.execute("PRAGMA table_info(operational_attempt_metrics)")
+        }
+    finally:
+        conn.close()
+
+
+def test_operational_metrics_reject_an_unresolved_job_locator(tmp_path: Path) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    create_shipped_v6_database(db_path)
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute(
+            """
+            INSERT INTO operational_attempt_metrics (
+                occurred_at, stage, attempt_kind, outcome, job_url
+            ) VALUES (?, ?, ?, ?, ?)
+            """,
+            (
+                "2026-07-30T10:00:00+00:00",
+                "discover",
+                "crawl",
+                "success",
+                "https://jobs.example/unresolved",
+            ),
+        )
+        transform_v6_root_identity(conn)
+
+        with pytest.raises(RuntimeError, match="unresolved job locator"):
+            migrate_v6_operational_attempt_metrics(conn)
+
+        assert "job_url" in {
+            str(row[1])
+            for row in conn.execute("PRAGMA table_info(operational_attempt_metrics)")
+        }
+    finally:
+        conn.close()
+
+
+def test_operational_metrics_rebuild_rolls_back_on_verification_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    create_shipped_v6_database(db_path)
+    conn = sqlite3.connect(db_path)
+    try:
+        transform_v6_root_identity(conn)
+        before_schema = tuple(
+            conn.execute(
+                "SELECT type, name, tbl_name, sql FROM sqlite_master ORDER BY type, name"
+            ).fetchall()
+        )
+        monkeypatch.setattr(
+            metrics,
+            "verify_v7_operational_attempt_metrics",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("fault")),
+        )
+
+        with pytest.raises(RuntimeError, match="fault"):
+            migrate_v6_operational_attempt_metrics(conn)
+
+        assert tuple(
+            conn.execute(
+                "SELECT type, name, tbl_name, sql FROM sqlite_master ORDER BY type, name"
+            ).fetchall()
+        ) == before_schema
+    finally:
+        conn.close()


### PR DESCRIPTION
> Superseded by the source-immutable exact-v7 candidate migration stack beginning at #577. This PR rebuilt operational metrics inside the admitted v6 database and therefore belongs to the discarded in-place design.

## Status

Closed without merge. Metrics are covered by the candidate direct/scalar copier in #578; no descendant READY PR depends on this branch.