### PR TITLE
refactor(discovery): enforce canonical job identity

### DIFF
--- a/apps/api/src/read-model.ts
+++ b/apps/api/src/read-model.ts
@@ -1586,7 +1586,7 @@ function jobEventToAuditEntry(
         actor: "system",
         details: auditDetails(
           ["Reason", humanizeToken(payloadText(payload, "reason"))],
-          ["Candidate", payloadText(payload, "candidateJobId", "candidate_job_id")],
+          ["Candidate", payloadText(payload, "candidatePostingUrl", "candidate_posting_url")],
         ),
       });
     case "DiscoveryFeedbackRecorded":

--- a/apps/api/test/server.test.ts
+++ b/apps/api/test/server.test.ts
@@ -2388,7 +2388,7 @@ describe("local TypeScript API", () => {
         tenantId: "local",
         duplicate_link_id: "dup:policy-1",
         job_id: jobUrl,
-        candidate_job_id: candidateUrl,
+        candidate_posting_url: candidateUrl,
         reason: "content_match_policy_rejected: current_policy_mismatch: location_mismatch",
         rejected_at: "2026-04-29T10:06:00+00:00",
       }),

--- a/apps/web/src/test/fixtures/events.ts
+++ b/apps/web/src/test/fixtures/events.ts
@@ -191,7 +191,7 @@ export const eventByType = {
   DuplicateJobLinkRejected: createDuplicateJobLinkRejected(LOCAL_TENANT, {
     duplicateLinkId: "duplicate-link-rejected-1",
     jobId: JOB_ID,
-    candidateJobId: "job-duplicate-1",
+    candidatePostingUrl: "https://jobs.example/job-duplicate-1",
     reason: "low_confidence",
     rejectedAt: NOW,
   }),

--- a/packages/domain-types/src/events/discovery.ts
+++ b/packages/domain-types/src/events/discovery.ts
@@ -354,13 +354,13 @@ export function createDuplicateJobLinked(
 /**
  * A proposed duplicate link was rejected by Discovery dedupe. Attributed to
  * the surviving `jobId` (the accepted owner the candidate matched) so the
- * rejected link shows in that job's audit history; `candidateJobId` is the
- * distinct posting that was declined.
+ * rejected link shows in that job's audit history; `candidatePostingUrl` is
+ * the distinct posting locator that was declined.
  */
 export interface DuplicateJobLinkRejectedPayload {
   readonly duplicateLinkId: string;
   readonly jobId: string;
-  readonly candidateJobId: string;
+  readonly candidatePostingUrl: string;
   readonly reason: string;
   readonly rejectedAt: string;
 }

--- a/packages/domain-types/test/events.test.ts
+++ b/packages/domain-types/test/events.test.ts
@@ -328,13 +328,13 @@ describe("Discovery events", () => {
     const event = createDuplicateJobLinkRejected(LOCAL_TENANT, {
       duplicateLinkId: "duplicate-link-rejected-1",
       jobId: "owner-1",
-      candidateJobId: "candidate-1",
+      candidatePostingUrl: "https://jobs.example/candidate-1",
       reason: "low_confidence",
       rejectedAt: "2026-05-12T00:00:00Z",
     });
     expect(event.eventType).toBe("DuplicateJobLinkRejected");
     expect(event.payload.jobId).toBe("owner-1");
-    expect(event.payload.candidateJobId).toBe("candidate-1");
+    expect(event.payload.candidatePostingUrl).toBe("https://jobs.example/candidate-1");
   });
 
   it("DiscoveryFeedbackRecorded carries the feedback kind without raw text", () => {
@@ -994,7 +994,7 @@ describe("DOMAIN_EVENT_TYPES enumeration", () => {
       createDuplicateJobLinkRejected(LOCAL_TENANT, {
         duplicateLinkId: "duplicate-link-rejected-1",
         jobId: "j",
-        candidateJobId: "j2",
+        candidatePostingUrl: "https://jobs.example/j2",
         reason: "low_confidence",
         rejectedAt: "t",
       }).eventType,

--- a/workers/automation/src/jobctrl/discovery/jobspy.py
+++ b/workers/automation/src/jobctrl/discovery/jobspy.py
@@ -17,7 +17,7 @@ from typing import Any, Callable
 
 from jobctrl import config
 from jobctrl.database import get_connection, init_db
-from jobctrl.domain.discovery import JobMetadata, PostingUrl, SearchStrategy, Source
+from jobctrl.domain.discovery import Employer, JobMetadata, PostingUrl, SearchStrategy, Source
 from jobctrl.domain.discovery.execution import DiscoveryExecutionRef
 from jobctrl.domain.discovery.search_units import (
     DiscoverySearchSpec,
@@ -236,6 +236,7 @@ def store_jobspy_results(
             source_id=source_id,
             source_native_id=_jobspy_source_native_id(row, url),
             site_label=site_label,
+            company=company,
             title=title,
             salary=salary,
             description=description,
@@ -475,6 +476,7 @@ def _jobspy_posting_from_row(
     source_id: str,
     source_native_id: str,
     site_label: str,
+    company: str | None,
     title: str | None,
     salary: str | None,
     description: str | None,
@@ -483,6 +485,7 @@ def _jobspy_posting_from_row(
     return ScrapedJobPosting(
         posting_url=PostingUrl(value=url),
         source=Source(board=site_label),
+        employer=Employer(name=company) if company else Employer.unknown(),
         metadata=JobMetadata(
             title=title or "",
             salary=salary or "",
@@ -812,7 +815,7 @@ def _find_existing_content_duplicate(
 def _find_stored_content_duplicate_survivor(conn: sqlite3.Connection, *, url: str) -> str | None:
     row = conn.execute(
         """
-        SELECT j.title, j.company, j.site,
+        SELECT j.title, j.company,
                COALESCE(je.full_description, j.full_description, j.description) AS description
         FROM jobs j
         LEFT JOIN job_enrichments je
@@ -824,12 +827,11 @@ def _find_stored_content_duplicate_survivor(conn: sqlite3.Connection, *, url: st
     ).fetchone()
     if row is None:
         return None
-    stored_company = row["company"]
     return _find_content_duplicate_survivor(
         conn,
         url=url,
         title=row["title"],
-        company=stored_company if stored_company else row["site"],
+        company=row["company"],
         description=row["description"],
         include_self=True,
     )
@@ -863,7 +865,7 @@ def _find_content_duplicate_survivor(
         params = (url, *params)
     rows = conn.execute(
         f"""
-        SELECT j.url, j.title, j.company, j.site,
+        SELECT j.url, j.title, j.company,
                j.description AS listing_description,
                COALESCE(je.full_description, j.full_description) AS enriched_description,
                CASE WHEN d.job_id IS NULL THEN 0 ELSE 1 END AS is_deleted
@@ -878,14 +880,13 @@ def _find_content_duplicate_survivor(
         WHERE j.tenant_id = ?
           {self_filter}
           AND jh_normalize_identity(COALESCE(j.title, '')) = ?
-          AND jh_normalize_identity(COALESCE(NULLIF(j.company, ''), j.site, '')) = ?
+          AND jh_normalize_identity(COALESCE(j.company, '')) = ?
         ORDER BY is_deleted ASC, j.discovered_at ASC NULLS LAST, j.url ASC
         """,
         (str(LOCAL_TENANT), *params),
     ).fetchall()
     for existing in rows:
-        stored_company = existing["company"]
-        stored_employer = stored_company if stored_company else existing["site"]
+        stored_employer = existing["company"]
         if not is_genuine_employer_identity(stored_employer):
             continue
         if (

--- a/workers/automation/src/jobctrl/discovery/jobspy.py
+++ b/workers/automation/src/jobctrl/discovery/jobspy.py
@@ -34,6 +34,7 @@ from jobctrl.domain.job_content_identity import (
     job_content_fingerprint,
     normalize_identity_text,
 )
+from jobctrl.domain.identifiers import canonical_job_id
 # Phase 7 (S-27 round-1 review M1): ``parse_proxy`` lives under
 # ``jobctrl.infrastructure.network`` so the Enrichment context's
 # Playwright fetcher can import it without depending on this Discovery

--- a/workers/automation/src/jobctrl/discovery/jobspy.py
+++ b/workers/automation/src/jobctrl/discovery/jobspy.py
@@ -34,8 +34,6 @@ from jobctrl.domain.job_content_identity import (
     job_content_fingerprint,
     normalize_identity_text,
 )
-from jobctrl.domain.identifiers import JobId
-
 # Phase 7 (S-27 round-1 review M1): ``parse_proxy`` lives under
 # ``jobctrl.infrastructure.network`` so the Enrichment context's
 # Playwright fetcher can import it without depending on this Discovery
@@ -690,14 +688,21 @@ def _record_jobspy_source_observation(
     normalized = normalize_observed_url(observed_url)
     source_native_id = normalized or observed_url
     observation_id = "jobspy:" + hashlib.sha256(f"{source_id}:{source_native_id}".encode("utf-8")).hexdigest()[:24]
-    SqliteJobRepository(
+    repository = SqliteJobRepository(
         conn,
         discovery_execution=discovery_execution,
         source_family=("jobspy" if discovery_execution is not None or search_unit_lease is not None else None),
         search_unit_lease=search_unit_lease,
-    ).attach_source_observation(
+    )
+    identity = repository.resolve_by_posting_url(
         LOCAL_TENANT,
-        JobId(job_url),
+        PostingUrl(value=job_url),
+    )
+    if identity is None:
+        raise LookupError(f"JobSpy observation references an unknown posting URL: {job_url!r}")
+    repository.attach_source_observation(
+        LOCAL_TENANT,
+        identity.job_id,
         JobSourceObservation(
             source_observation_id=observation_id,
             source_id=source_id,
@@ -712,14 +717,14 @@ def _record_jobspy_source_observation(
     _apply_write_fence(write_fence)
     record_job_event(
         conn,
-        job_url,
+        identity.job_id,
         "discover",
         "JobSourceObserved",
         message="Job source observed.",
         payload={
             "tenantId": "local",
-            "job_id": job_url,
-            "jobId": job_url,
+            "job_id": str(identity.job_id),
+            "jobId": str(identity.job_id),
             "source_observation_id": observation_id,
             "sourceObservationId": observation_id,
             "source_id": source_id,

--- a/workers/automation/src/jobctrl/discovery/jobspy.py
+++ b/workers/automation/src/jobctrl/discovery/jobspy.py
@@ -16,7 +16,7 @@ from datetime import datetime, timezone
 from typing import Any, Callable
 
 from jobctrl import config
-from jobctrl.database import get_connection, init_db, resurface_deleted_job
+from jobctrl.database import get_connection, init_db
 from jobctrl.domain.discovery import JobMetadata, PostingUrl, SearchStrategy, Source
 from jobctrl.domain.discovery.execution import DiscoveryExecutionRef
 from jobctrl.domain.discovery.search_units import (
@@ -318,7 +318,7 @@ def store_jobspy_results(
                 ),
             )
             _apply_write_fence(write_fence)
-            resurface_deleted_job(conn, duplicate_url, resurfaced_at=now)
+            _restore_job_by_url(conn, duplicate_url, restored_at=now)
             existing += 1
             continue
 
@@ -390,7 +390,7 @@ def store_jobspy_results(
                 ),
             )
             _apply_write_fence(write_fence)
-            resurface_deleted_job(conn, stored_duplicate_url, resurfaced_at=now)
+            _restore_job_by_url(conn, stored_duplicate_url, restored_at=now)
             existing += 1
             continue
 
@@ -461,7 +461,7 @@ def store_jobspy_results(
             new += 1
         elif summary.observed > 0 or summary.duplicates_linked > 0:
             _apply_write_fence(write_fence)
-            resurface_deleted_job(conn, url, resurfaced_at=now)
+            _restore_job_by_url(conn, url, restored_at=now)
             existing += 1
 
     conn.commit()
@@ -574,6 +574,12 @@ def _refresh_existing_jobspy_job(
     idempotency_key: str | None = None,
 ) -> None:
     _apply_write_fence(write_fence)
+    identity = SqliteJobRepository(conn).resolve_by_posting_url(
+        LOCAL_TENANT,
+        PostingUrl(value=job_url),
+    )
+    if identity is None:
+        raise LookupError(f"JobSpy metadata refresh references an unknown posting URL: {job_url!r}")
     cursor = conn.execute(
         """
         UPDATE jobs SET
@@ -590,7 +596,7 @@ def _refresh_existing_jobspy_job(
             full_description = COALESCE(NULLIF(?, ''), full_description),
             application_url = COALESCE(NULLIF(?, ''), application_url),
             detail_scraped_at = COALESCE(?, detail_scraped_at)
-        WHERE url = ?
+        WHERE tenant_id = ? AND job_id = ?
         """,
         (
             title,
@@ -603,7 +609,8 @@ def _refresh_existing_jobspy_job(
             full_description,
             application_url,
             detail_scraped_at,
-            job_url,
+            str(LOCAL_TENANT),
+            str(identity.job_id),
         ),
     )
     if cursor.rowcount:
@@ -611,7 +618,7 @@ def _refresh_existing_jobspy_job(
 
         record_job_event(
             conn,
-            job_url,
+            identity.job_id,
             "discover",
             "JobMetadataUpdated",
             message="Job metadata refreshed from broad-board discovery",
@@ -624,6 +631,19 @@ def _refresh_existing_jobspy_job(
             occurred_at=updated_at,
             idempotency_key=idempotency_key,
         )
+
+
+def _restore_job_by_url(
+    conn: sqlite3.Connection,
+    job_url: str,
+    *,
+    restored_at: str,
+) -> None:
+    repository = SqliteJobRepository(conn)
+    identity = repository.resolve_by_posting_url(LOCAL_TENANT, PostingUrl(value=job_url))
+    if identity is None:
+        raise LookupError(f"JobSpy restore references an unknown posting URL: {job_url!r}")
+    repository.restore(LOCAL_TENANT, identity.job_id, restored_at=restored_at)
 
 
 def _nullable_str(value: object) -> str | None:
@@ -794,10 +814,12 @@ def _find_stored_content_duplicate_survivor(conn: sqlite3.Connection, *, url: st
         SELECT j.title, j.company, j.site,
                COALESCE(je.full_description, j.full_description, j.description) AS description
         FROM jobs j
-        LEFT JOIN job_enrichments je ON je.job_url = j.url
-        WHERE j.url = ?
+        LEFT JOIN job_enrichments je
+          ON je.tenant_id = j.tenant_id
+         AND je.job_id = j.job_id
+        WHERE j.tenant_id = ? AND j.url = ?
         """,
-        (url,),
+        (str(LOCAL_TENANT), url),
     ).fetchone()
     if row is None:
         return None
@@ -830,7 +852,6 @@ def _find_content_duplicate_survivor(
     )
     if incoming_key is None:
         return None
-    _ensure_deleted_jobs_table(conn)
     conn.create_function("jh_normalize_identity", 1, normalize_identity_text, deterministic=True)
     self_filter = "" if include_self else "AND j.url != ?"
     params: tuple[object, ...] = (
@@ -844,19 +865,22 @@ def _find_content_duplicate_survivor(
         SELECT j.url, j.title, j.company, j.site,
                j.description AS listing_description,
                COALESCE(je.full_description, j.full_description) AS enriched_description,
-               CASE WHEN d.job_url IS NULL THEN 0 ELSE 1 END AS is_deleted
+               CASE WHEN d.job_id IS NULL THEN 0 ELSE 1 END AS is_deleted
         FROM jobs j
-        LEFT JOIN job_enrichments je ON je.job_url = j.url
+        LEFT JOIN job_enrichments je
+          ON je.tenant_id = j.tenant_id
+         AND je.job_id = j.job_id
         LEFT JOIN jobctrl_deleted_jobs d
-          ON d.job_url = j.url
+          ON d.tenant_id = j.tenant_id
+         AND d.job_id = j.job_id
          AND (d.restored_at IS NULL OR julianday(d.restored_at) <= julianday(d.deleted_at))
-        WHERE 1 = 1
+        WHERE j.tenant_id = ?
           {self_filter}
           AND jh_normalize_identity(COALESCE(j.title, '')) = ?
           AND jh_normalize_identity(COALESCE(NULLIF(j.company, ''), j.site, '')) = ?
         ORDER BY is_deleted ASC, j.discovered_at ASC NULLS LAST, j.url ASC
         """,
-        params,
+        (str(LOCAL_TENANT), *params),
     ).fetchall()
     for existing in rows:
         stored_company = existing["company"]
@@ -880,20 +904,6 @@ def _find_content_duplicate_survivor(
     return None
 
 
-def _ensure_deleted_jobs_table(conn: sqlite3.Connection) -> None:
-    conn.execute(
-        """
-        CREATE TABLE IF NOT EXISTS jobctrl_deleted_jobs (
-            job_url TEXT PRIMARY KEY,
-            deleted_at TEXT NOT NULL,
-            reason TEXT,
-            restored_at TEXT,
-            FOREIGN KEY(job_url) REFERENCES jobs(url)
-        )
-        """
-    )
-
-
 def _record_content_duplicate_link(
     conn: sqlite3.Connection,
     *,
@@ -913,6 +923,13 @@ def _record_content_duplicate_link(
     _apply_write_fence(write_fence)
     duplicate_link_id = "content:" + link_key[:32]
     normalized_url = normalize_observed_url(duplicate_url)
+    owner = conn.execute(
+        "SELECT job_id FROM jobs WHERE tenant_id = ? AND url = ?",
+        (str(LOCAL_TENANT), surviving_url),
+    ).fetchone()
+    if owner is None:
+        raise LookupError(f"Content duplicate owner is unknown: {surviving_url!r}")
+    owner_job_id = canonical_job_id(str(owner["job_id"] if isinstance(owner, sqlite3.Row) else owner[0]))
     conn.execute(
         """
         INSERT OR IGNORE INTO job_duplicate_links (
@@ -920,19 +937,19 @@ def _record_content_duplicate_link(
             superseded_job_or_observation_id, reason, confidence, linked_at
         ) VALUES ('local', ?, ?, ?, 'content_fingerprint_match', 0.95, ?)
         """,
-        (duplicate_link_id, surviving_url, duplicate_url, observed_at),
+        (duplicate_link_id, str(owner_job_id), duplicate_url, observed_at),
     )
     conn.execute(
         """
         INSERT OR IGNORE INTO job_source_observations (
-            tenant_id, source_observation_id, job_url, source_id,
+            tenant_id, source_observation_id, job_id, source_id,
             source_native_id, observed_url, normalized_observed_url,
             run_id, observed_at
         ) VALUES ('local', ?, ?, ?, ?, ?, ?, 'jobspy', ?)
         """,
         (
             f"content-duplicate:{duplicate_link_id}",
-            surviving_url,
+            str(owner_job_id),
             source,
             duplicate_url,
             duplicate_url,

--- a/workers/automation/src/jobctrl/discovery/smartextract.py
+++ b/workers/automation/src/jobctrl/discovery/smartextract.py
@@ -19,10 +19,8 @@ import sqlite3
 import sys
 import threading
 import time
-import uuid
 from collections.abc import Mapping
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from datetime import datetime, timezone
 from urllib.parse import quote_plus, urljoin
 
 import yaml
@@ -31,21 +29,15 @@ from playwright.sync_api import sync_playwright
 
 from jobctrl import config
 from jobctrl.config import CONFIG_DIR
-from jobctrl.database import get_stats, init_db, resurface_deleted_job
-from jobctrl.domain.discovery.identity import DuplicateJobLink, JobSourceObservation
+from jobctrl.database import get_stats, init_db
 from jobctrl.domain.discovery.execution import DiscoveryExecutionRef
 from jobctrl.domain.discovery.use_cases import (
-    CONTENT_MATCH_CONFIDENCE,
-    CONTENT_SHINGLE_MATCH_CONFIDENCE,
+    DiscoverJobsUseCase,
 )
+from jobctrl.domain.discovery.value_objects import JobMetadata, PostingUrl, SearchStrategy, Source
 from jobctrl.domain.errors import TransientNetworkError
-from jobctrl.domain.identifiers import JobId
-from jobctrl.domain.events import (
-    DuplicateJobLinkedPayload,
-    create_duplicate_job_linked,
-)
 from jobctrl.domain.discovery.source_registry import SMART_EXTRACT_EXPERIMENTAL_POLICY
-from jobctrl.domain.ports.discovery import ContentOwnerMatch
+from jobctrl.domain.ports.discovery import ScrapedJobPosting
 from jobctrl.domain.tenant import LOCAL_TENANT
 from jobctrl.infrastructure.network import (
     PolitenessGateway,
@@ -129,72 +121,6 @@ def load_sites() -> list[dict]:
     return data.get("sites", [])
 
 
-def _merge_smart_extract_content_duplicate(
-    conn: sqlite3.Connection,
-    repository: SqliteJobRepository,
-    publisher: DurableJobEventPublisher,
-    owner_match: ContentOwnerMatch,
-    *,
-    url: str,
-    site: str,
-    observed_at: str,
-    run_id: str,
-) -> None:
-    """Attach a content-matched Smart Extract posting to its existing owner.
-
-    Smart Extract writes rows with direct SQL, so without this check the same
-    posting discovered by another source (ATS or JobSpy) would create a second
-    ``Job`` aggregate and double the scoring/tailoring spend. Mirrors the JobSpy
-    content-dedup merge: record the duplicate link + a source observation against
-    the surviving owner, resurface it if it was soft-deleted, and skip the
-    insert.
-    """
-    owner_url = str(owner_match.job_id)
-    if owner_match.basis == "fingerprint":
-        reason = "content_fingerprint_match"
-        confidence = CONTENT_MATCH_CONFIDENCE
-    else:
-        reason = "content_shingle_match"
-        confidence = CONTENT_SHINGLE_MATCH_CONFIDENCE
-    duplicate_link_id = f"dup:{uuid.uuid4().hex}"
-    repository.record_duplicate_link(
-        LOCAL_TENANT,
-        DuplicateJobLink(
-            duplicate_link_id=duplicate_link_id,
-            surviving_job_id=owner_url,
-            superseded_job_or_observation_id=url,
-            reason=reason,
-            confidence=confidence,
-            linked_at=observed_at,
-        ),
-    )
-    repository.attach_source_observation(
-        LOCAL_TENANT,
-        owner_match.job_id,
-        JobSourceObservation(
-            source_observation_id=f"obs:{uuid.uuid4().hex}",
-            source_id=f"smartextract:{site}",
-            source_native_id=url,
-            observed_url=url,
-            run_id=run_id,
-            observed_at=observed_at,
-        ),
-    )
-    publisher.publish(
-        create_duplicate_job_linked(
-            LOCAL_TENANT,
-            DuplicateJobLinkedPayload(
-                duplicate_link_id=duplicate_link_id,
-                surviving_job_id=owner_url,
-                superseded_job_or_observation_id=url,
-                reason=reason,
-                confidence=confidence,
-            ),
-        )
-    )
-    resurface_deleted_job(conn, owner_url, resurfaced_at=observed_at)
-
-
 def _store_jobs_filtered(
     conn: sqlite3.Connection,
     jobs: list[dict],
@@ -209,7 +135,6 @@ def _store_jobs_filtered(
     discovery_execution: DiscoveryExecutionRef | None = None,
 ) -> tuple[int, int]:
     """Store usable jobs with title, location, and description filtering."""
-    now = datetime.now(timezone.utc).isoformat()
     new = 0
     existing = 0
     filtered = 0
@@ -219,7 +144,10 @@ def _store_jobs_filtered(
         discovery_execution=discovery_execution,
         source_family="smartextract" if discovery_execution is not None else None,
     )
-    publisher = DurableJobEventPublisher(conn, stage="discover")
+    use_case = DiscoverJobsUseCase(
+        repository=repository,
+        publisher=DurableJobEventPublisher(conn, stage="discover"),
+    )
 
     for job in jobs:
         if limit > 0 and new >= limit:
@@ -237,123 +165,37 @@ def _store_jobs_filtered(
         if not description:
             missing_description += 1
             continue
-        content_owner = repository.find_content_owner(
-            LOCAL_TENANT,
-            title=str(job.get("title") or ""),
-            company=str(job.get("company") or ""),
-            description=description,
-        )
-        if content_owner is not None and str(content_owner.job_id) != url:
-            _merge_smart_extract_content_duplicate(
-                conn,
-                repository,
-                publisher,
-                content_owner,
-                url=url,
-                site=site,
-                observed_at=now,
-                run_id=run_id,
-            )
-            existing += 1
-            continue
-        try:
-            conn.execute(
-                "INSERT INTO jobs (url, title, company, salary, description, location, site, strategy, discovered_at) "
-                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
-                (
-                    url,
-                    job.get("title"),
-                    job.get("company"),
-                    job.get("salary"),
-                    description,
-                    job.get("location"),
-                    site,
-                    strategy,
-                    now,
-                ),
-            )
-            new += 1
-        except sqlite3.IntegrityError:
-            company = str(job.get("company") or "").strip()
-            title = str(job.get("title") or "").strip()
-            location = str(job.get("location") or "").strip()
-            salary = str(job.get("salary") or "").strip()
-            update_fields: list[str] = []
-            update_values: list[str] = []
-            metadata_payload: dict[str, object] = {"source": site}
-            if title:
-                update_fields.append("title = CASE WHEN title IS NULL OR title = '' OR title != ? THEN ? ELSE title END")
-                update_values.extend([title, title])
-                metadata_payload["title"] = title
-            if company:
-                update_fields.append("company = CASE WHEN company IS NULL OR company = '' THEN ? ELSE company END")
-                update_values.append(company)
-                metadata_payload["company"] = company
-            if salary:
-                update_fields.append("salary = CASE WHEN salary IS NULL OR salary = '' THEN ? ELSE salary END")
-                update_values.append(salary)
-                metadata_payload["salary"] = True
-            if description:
-                update_fields.append(
-                    f"description = CASE WHEN {_MISSING_DESCRIPTION_SQL} THEN ? ELSE description END"
-                )
-                update_values.append(description)
-                metadata_payload["description"] = True
-            if location:
-                update_fields.append(
-                    "location = CASE WHEN location IS NULL OR location = '' OR location != ? THEN ? ELSE location END"
-                )
-                update_values.extend([location, location])
-                metadata_payload["location"] = location
-            if update_fields:
-                update_predicates: list[str] = []
-                if title:
-                    update_predicates.append("(title IS NULL OR title = '' OR title != ?)")
-                if company:
-                    update_predicates.append("(company IS NULL OR company = '')")
-                if salary:
-                    update_predicates.append("(salary IS NULL OR salary = '')")
-                if description:
-                    update_predicates.append(_MISSING_DESCRIPTION_SQL)
-                if location:
-                    update_predicates.append("(location IS NULL OR location = '' OR location != ?)")
-                predicate_values: list[str] = []
-                if title:
-                    predicate_values.append(title)
-                if location:
-                    predicate_values.append(location)
-                cursor = conn.execute(
-                    f"UPDATE jobs SET {', '.join(update_fields)} WHERE url = ? "
-                    f"AND ({' OR '.join(update_predicates)})",
-                    (*update_values, url, *predicate_values),
-                )
-                if cursor.rowcount:
-                    from jobctrl.state import record_job_event
-
-                    record_job_event(
-                        conn,
-                        url,
-                        "discover",
-                        "JobMetadataUpdated",
-                        message="Job metadata refreshed from SmartExtract",
-                        payload=metadata_payload,
-                        occurred_at=now,
-                    )
-            resurface_deleted_job(conn, url, resurfaced_at=now)
-            existing += 1
-
-        repository.attach_source_observation(
-            LOCAL_TENANT,
-            JobId(url),
-            JobSourceObservation(
-                source_observation_id=f"obs:{uuid.uuid4().hex}",
-                source_id=f"smartextract:{site}",
-                source_native_id=url,
-                observed_url=url,
-                run_id=run_id,
-                observed_at=now,
+        company = str(job.get("company") or "").strip()
+        posting = ScrapedJobPosting(
+            posting_url=PostingUrl(value=url),
+            source=Source(board=company or site),
+            metadata=JobMetadata(
+                title=str(job.get("title") or ""),
+                salary=str(job.get("salary") or ""),
+                description=description,
+                location=str(job.get("location") or ""),
             ),
+            strategy=SearchStrategy.SMART_EXTRACT,
+            source_id=f"smartextract:{site}",
+            source_native_id=url,
+            canonical_url=url,
         )
+        summary = use_case.execute(
+            tenant_id=LOCAL_TENANT,
+            postings=(posting,),
+            run_id=run_id,
+        )
+        new += summary.new_jobs
+        if summary.new_jobs == 0 and (summary.observed > 0 or summary.duplicates_linked > 0):
+            existing += 1
+
+        identity = repository.resolve_by_posting_url(LOCAL_TENANT, posting.posting_url)
+        if identity is not None and company:
+            conn.execute(
+                "UPDATE jobs SET company = COALESCE(NULLIF(company, ''), ?) "
+                "WHERE tenant_id = ? AND job_id = ?",
+                (company, str(LOCAL_TENANT), str(identity.job_id)),
+            )
 
     if filtered:
         log.info("Filtered %d jobs (wrong title/location)", filtered)

--- a/workers/automation/src/jobctrl/discovery/smartextract.py
+++ b/workers/automation/src/jobctrl/discovery/smartextract.py
@@ -34,7 +34,7 @@ from jobctrl.domain.discovery.execution import DiscoveryExecutionRef
 from jobctrl.domain.discovery.use_cases import (
     DiscoverJobsUseCase,
 )
-from jobctrl.domain.discovery.value_objects import JobMetadata, PostingUrl, SearchStrategy, Source
+from jobctrl.domain.discovery.value_objects import Employer, JobMetadata, PostingUrl, SearchStrategy, Source
 from jobctrl.domain.errors import TransientNetworkError
 from jobctrl.domain.discovery.source_registry import SMART_EXTRACT_EXPERIMENTAL_POLICY
 from jobctrl.domain.ports.discovery import ScrapedJobPosting
@@ -166,9 +166,11 @@ def _store_jobs_filtered(
             missing_description += 1
             continue
         company = str(job.get("company") or "").strip()
+        source_board = str(site or "").strip() or "smart-extract"
         posting = ScrapedJobPosting(
             posting_url=PostingUrl(value=url),
-            source=Source(board=company or site),
+            source=Source(board=source_board),
+            employer=Employer(name=company) if company else Employer.unknown(),
             metadata=JobMetadata(
                 title=str(job.get("title") or ""),
                 salary=str(job.get("salary") or ""),

--- a/workers/automation/src/jobctrl/discovery/workday.py
+++ b/workers/automation/src/jobctrl/discovery/workday.py
@@ -25,7 +25,7 @@ from jobctrl.domain.discovery.identity import AtsKind
 from jobctrl.domain.discovery.execution import DiscoveryExecutionRef
 from jobctrl.domain.discovery.source_registry import WORKDAY_API_POLICY
 from jobctrl.domain.discovery.use_cases import DiscoverJobsUseCase
-from jobctrl.domain.discovery.value_objects import JobMetadata, PostingUrl, SearchStrategy, Source
+from jobctrl.domain.discovery.value_objects import Employer, JobMetadata, PostingUrl, SearchStrategy, Source
 from jobctrl.domain.errors import TransientNetworkError
 from jobctrl.domain.events.base import DomainEvent
 from jobctrl.domain.ports.discovery import ScrapedJobPosting
@@ -435,9 +435,11 @@ def _posting_from_job(job: dict, employers: dict) -> ScrapedJobPosting | None:
     description = _usable_description_text(job.get("full_description"))
     if not description:
         return None
+    employer_name = str(job.get("employer_name") or "").strip()
     return ScrapedJobPosting(
         posting_url=PostingUrl(value=url),
-        source=Source(board=str(job.get("employer_name") or "Workday")),
+        source=Source(board="workday"),
+        employer=(Employer(name=employer_name) if employer_name else Employer.unknown()),
         metadata=JobMetadata(
             title=str(job.get("title") or ""),
             salary="",

--- a/workers/automation/src/jobctrl/domain/discovery/use_cases.py
+++ b/workers/automation/src/jobctrl/domain/discovery/use_cases.py
@@ -66,6 +66,7 @@ from jobctrl.domain.identifiers import (
 )
 from jobctrl.domain.job_content_identity import is_genuine_employer_identity
 from jobctrl.domain.ports.discovery import (
+    CanonicalOwnerMatch,
     ContentOwnerMatch,
     JobRepository,
     ScrapedJobPosting,
@@ -289,11 +290,16 @@ class DiscoverJobsUseCase:
         run_id: str,
     ) -> DiscoveryDecision:
         identity = self._resolver(posting)
-        owner_id = self._repository.find_canonical_owner(
+        canonical_owner_match = self._repository.find_canonical_owner(
             tenant_id,
             source_id=posting.source_id,
             source_native_id=identity.source_native_id,
             canonical_url=identity.canonical_url,
+        )
+        owner_id = (
+            canonical_owner_match.job_id
+            if canonical_owner_match is not None
+            else None
         )
         content_match: ContentOwnerMatch | None = None
         if owner_id is None and is_genuine_employer_identity(posting.source.board):
@@ -345,6 +351,7 @@ class DiscoverJobsUseCase:
             posting=posting,
             identity=identity,
             owner_id=owner_id,
+            canonical_owner_match=canonical_owner_match,
             run_id=run_id,
             observation_id=observation_id,
             observed_at=observed_at,
@@ -383,21 +390,9 @@ class DiscoverJobsUseCase:
             result="new_job",
             confidence=identity.confidence,
         ):
-            persisted_job_id = self._repository.save(job)
-            if persisted_job_id != job_id:
-                return self._observe_existing_job(
-                    tenant_id=tenant_id,
-                    posting=posting,
-                    identity=identity,
-                    owner_id=persisted_job_id,
-                    run_id=run_id,
-                    observation_id=observation_id,
-                    observed_at=observed_at,
-                )
-            self._repository.set_canonical_identity(tenant_id, job_id, identity)
-            self._repository.attach_source_observation(
-                tenant_id,
-                job_id,
+            owner_match = self._repository.claim_new_job(
+                job,
+                identity,
                 JobSourceObservation(
                     source_observation_id=observation_id,
                     source_id=posting.source_id,
@@ -407,6 +402,17 @@ class DiscoverJobsUseCase:
                     observed_at=observed_at,
                 ),
             )
+            if owner_match is not None:
+                return self._observe_existing_job(
+                    tenant_id=tenant_id,
+                    posting=posting,
+                    identity=identity,
+                    owner_id=owner_match.job_id,
+                    canonical_owner_match=owner_match,
+                    run_id=run_id,
+                    observation_id=observation_id,
+                    observed_at=observed_at,
+                )
         self._publisher.publish(
             create_job_discovered(
                 tenant_id,
@@ -463,6 +469,7 @@ class DiscoverJobsUseCase:
         posting: ScrapedJobPosting,
         identity: CanonicalJobIdentity,
         owner_id: JobId,
+        canonical_owner_match: CanonicalOwnerMatch | None = None,
         run_id: str,
         observation_id: str,
         observed_at: str,
@@ -643,7 +650,9 @@ class DiscoverJobsUseCase:
                     link_reason = "content_shingle_match"
                     link_confidence = CONTENT_SHINGLE_MATCH_CONFIDENCE
             else:
-                link_reason = "canonical_url_match" if identity.canonical_url else "source_native_id_match"
+                if canonical_owner_match is None:
+                    raise RuntimeError("canonical owner match is required for exact duplicate audit")
+                link_reason = canonical_owner_match.basis
                 link_confidence = identity.confidence
             link = DuplicateJobLink(
                 duplicate_link_id=duplicate_link_id,

--- a/workers/automation/src/jobctrl/domain/discovery/use_cases.py
+++ b/workers/automation/src/jobctrl/domain/discovery/use_cases.py
@@ -59,7 +59,11 @@ from jobctrl.domain.events import (
     create_job_restored,
     create_job_source_observed,
 )
-from jobctrl.domain.identifiers import JobId
+from jobctrl.domain.identifiers import (
+    JobId,
+    canonical_job_id,
+    generate_job_id,
+)
 from jobctrl.domain.job_content_identity import is_genuine_employer_identity
 from jobctrl.domain.ports.discovery import (
     ContentOwnerMatch,
@@ -234,6 +238,7 @@ class DiscoverJobsUseCase:
         run_id_factory: object | None = None,
         clock: object | None = None,
         observation_id_factory: Callable[[], str] | None = None,
+        job_id_factory: Callable[[], JobId] | None = None,
         republish_canonical_identity: bool = False,
     ) -> None:
         self._repository = repository
@@ -243,6 +248,7 @@ class DiscoverJobsUseCase:
         self._run_id_factory = run_id_factory or (lambda: f"run:{uuid.uuid4().hex}")
         self._clock = clock or (lambda: datetime.now(timezone.utc).isoformat())
         self._observation_id_factory = observation_id_factory or (lambda: f"obs:{uuid.uuid4().hex}")
+        self._job_id_factory = job_id_factory or generate_job_id
         self._republish_canonical_identity = republish_canonical_identity
 
     def execute(
@@ -318,8 +324,9 @@ class DiscoverJobsUseCase:
         if owner_id is None:
             acceptance = self._acceptance_policy(posting)
             if not acceptance.accepted:
+                rejected_job_id = canonical_job_id(str(self._job_id_factory()))
                 return self._policy_rejected_decision(
-                    job_id=JobId(identity.canonical_url or posting.posting_url.value),
+                    job_id=rejected_job_id,
                     observation_id=observation_id,
                     confidence=identity.confidence,
                     acceptance=acceptance,
@@ -355,7 +362,10 @@ class DiscoverJobsUseCase:
         observed_at: str,
     ) -> DiscoveryDecision:
         canonical_posting_url = PostingUrl(value=identity.canonical_url)
-        job_id = JobId(canonical_posting_url.value)
+        try:
+            job_id = canonical_job_id(str(self._job_id_factory()))
+        except ValueError as exc:
+            raise ValueError("job_id_factory must return a canonical UUID JobId") from exc
         job = Job.discover(
             tenant_id=tenant_id,
             job_id=job_id,
@@ -373,7 +383,17 @@ class DiscoverJobsUseCase:
             result="new_job",
             confidence=identity.confidence,
         ):
-            self._repository.save(job)
+            persisted_job_id = self._repository.save(job)
+            if persisted_job_id != job_id:
+                return self._observe_existing_job(
+                    tenant_id=tenant_id,
+                    posting=posting,
+                    identity=identity,
+                    owner_id=persisted_job_id,
+                    run_id=run_id,
+                    observation_id=observation_id,
+                    observed_at=observed_at,
+                )
             self._repository.set_canonical_identity(tenant_id, job_id, identity)
             self._repository.attach_source_observation(
                 tenant_id,
@@ -451,7 +471,12 @@ class DiscoverJobsUseCase:
         content_matched = content_match is not None
         observed_url = identity.canonical_url or posting.posting_url.value
         normalized_observed = normalize_observed_url(observed_url)
-        is_distinct_url = normalized_observed != normalize_observed_url(str(owner_id)) and normalized_observed != ""
+        existing = self._repository.load(tenant_id, owner_id)
+        if existing is None:
+            raise LookupError(f"Canonical owner disappeared before observation: {owner_id!r}")
+        is_distinct_url = (
+            normalized_observed != normalize_observed_url(existing.posting_url.value) and normalized_observed != ""
+        )
 
         if not content_matched and identity.confidence < MIN_AUTO_MERGE_CONFIDENCE and is_distinct_url:
             with dedupe_span(
@@ -497,7 +522,6 @@ class DiscoverJobsUseCase:
             result="observed" if acceptance.accepted else "policy_rejected",
             confidence=identity.confidence,
         ):
-            existing = self._repository.load(tenant_id, owner_id)
             if existing is not None:
                 if self._republish_canonical_identity:
                     stored_identity = self._repository.load_canonical_identity(
@@ -729,7 +753,7 @@ class DiscoverJobsUseCase:
                 DuplicateJobLinkRejectedPayload(
                     duplicate_link_id=f"dup:{uuid.uuid4().hex}",
                     job_id=str(owner_id),
-                    candidate_job_id=candidate_url,
+                    candidate_posting_url=candidate_url,
                     reason=reason,
                     rejected_at=rejected_at,
                 ),

--- a/workers/automation/src/jobctrl/domain/discovery/use_cases.py
+++ b/workers/automation/src/jobctrl/domain/discovery/use_cases.py
@@ -42,7 +42,7 @@ from jobctrl.domain.discovery.identity import (
     JobSourceObservation,
     normalize_observed_url,
 )
-from jobctrl.domain.discovery.value_objects import Employer, PostingUrl
+from jobctrl.domain.discovery.value_objects import PostingUrl
 from jobctrl.domain.events import (
     CanonicalJobIdentityResolvedPayload,
     DuplicateJobLinkedPayload,
@@ -302,11 +302,11 @@ class DiscoverJobsUseCase:
             else None
         )
         content_match: ContentOwnerMatch | None = None
-        if owner_id is None and is_genuine_employer_identity(posting.source.board):
+        if owner_id is None and is_genuine_employer_identity(posting.employer.name):
             content_match = self._repository.find_content_owner(
                 tenant_id,
                 title=posting.metadata.title,
-                company=posting.source.board,
+                company=posting.employer.name,
                 description=posting.metadata.description,
             )
             if content_match is not None:
@@ -378,7 +378,7 @@ class DiscoverJobsUseCase:
             job_id=job_id,
             posting_url=canonical_posting_url,
             source=posting.source,
-            employer=Employer.unknown(),
+            employer=posting.employer,
             search_strategy=posting.strategy,
             metadata=posting.metadata,
             discovered_at=observed_at,
@@ -420,7 +420,7 @@ class DiscoverJobsUseCase:
                     job_id=str(job_id),
                     posting_url=canonical_posting_url.value,
                     source=posting.source.board,
-                    employer="Unknown",
+                    employer=posting.employer.name,
                     metadata=posting.metadata.to_dict(),
                     discovered_at=observed_at,
                 ),
@@ -591,6 +591,8 @@ class DiscoverJobsUseCase:
                         acceptance=acceptance,
                     )
                 refreshed = existing.with_metadata(posting.metadata)
+                if refreshed.employer.is_unknown() and not posting.employer.is_unknown():
+                    refreshed = refreshed.with_employer(posting.employer)
                 if refreshed.is_deleted:
                     restored = self._repository.restore(
                         tenant_id,
@@ -599,6 +601,8 @@ class DiscoverJobsUseCase:
                     )
                     if restored is not None:
                         refreshed = restored.with_metadata(posting.metadata)
+                        if refreshed.employer.is_unknown() and not posting.employer.is_unknown():
+                            refreshed = refreshed.with_employer(posting.employer)
                         self._publisher.publish(
                             create_job_restored(
                                 tenant_id,

--- a/workers/automation/src/jobctrl/domain/discovery/use_cases.py
+++ b/workers/automation/src/jobctrl/domain/discovery/use_cases.py
@@ -314,7 +314,7 @@ class DiscoverJobsUseCase:
 
         with canonicalize_span(
             tenant_id=str(tenant_id),
-            job_id=str(owner_id) if owner_id else identity.canonical_url,
+            job_id=str(owner_id) if owner_id else None,
             source_id=posting.source_id,
             canonical_url_present=bool(identity.canonical_url),
             ats_kind=identity.ats_kind.value,

--- a/workers/automation/src/jobctrl/domain/events/discovery.py
+++ b/workers/automation/src/jobctrl/domain/events/discovery.py
@@ -275,13 +275,13 @@ class DuplicateJobLinkRejectedPayload:
     Attributed to the surviving ``job_id`` (the accepted owner the duplicate
     matched) so the rejected link shows in that job's audit history — ``job_id``
     is the standard attribution key both the durable event publisher and the API
-    audit read model key on. ``candidate_job_id`` is the distinct posting that
-    was declined.
+    audit read model key on. ``candidate_posting_url`` is the distinct posting
+    locator that was declined; it is not a Job identity.
     """
 
     duplicate_link_id: str
     job_id: str
-    candidate_job_id: str
+    candidate_posting_url: str
     reason: str
     rejected_at: str
 

--- a/workers/automation/src/jobctrl/domain/ports/discovery.py
+++ b/workers/automation/src/jobctrl/domain/ports/discovery.py
@@ -12,7 +12,7 @@ PR 2 ATS adapters (``WorkdayBoardAdapter``, ``GreenhouseBoardAdapter``,
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Iterable, Protocol
+from typing import Iterable, Literal, Protocol
 
 from jobctrl.domain.discovery.aggregate import Job
 from jobctrl.domain.discovery.identity import (
@@ -73,6 +73,26 @@ class ContentOwnerMatch:
 
     job_id: JobId
     basis: ContentMatchBasis
+
+
+CanonicalOwnerMatchBasis = Literal[
+    "source_native_id_match",
+    "canonical_url_match",
+    "normalized_observation_match",
+]
+
+
+@dataclass(frozen=True)
+class CanonicalOwnerMatch:
+    """An existing Job resolved by an exact discovery identity claim.
+
+    The basis is persisted with duplicate-link audit evidence.  Keeping it at
+    the repository boundary prevents the application layer from guessing which
+    of the exact identity claims won.
+    """
+
+    job_id: JobId
+    basis: CanonicalOwnerMatchBasis
 
 
 @dataclass(frozen=True)
@@ -236,7 +256,7 @@ class JobRepository(JobIdentityResolver, Protocol):
         source_id: str,
         source_native_id: str,
         canonical_url: str,
-    ) -> JobId | None:
+    ) -> CanonicalOwnerMatch | None:
         """Look up the canonical Job that already owns a posting identity.
 
         Resolution order matches the RFC §"Recommended identity checks"
@@ -252,8 +272,23 @@ class JobRepository(JobIdentityResolver, Protocol):
              where one source-native id is missing but the observed URL
              matches an existing observation.
 
-        Returns the surviving ``JobId`` for the first match, or ``None``
-        when the posting is genuinely new.
+        Returns the surviving ``JobId`` and the exact winning claim basis, or
+        ``None`` when the posting is genuinely new.
+        """
+        ...
+
+    def claim_new_job(
+        self,
+        job: Job,
+        identity: CanonicalJobIdentity,
+        observation: JobSourceObservation,
+    ) -> CanonicalOwnerMatch | None:
+        """Atomically create a Job or return the exact owner that won.
+
+        The identity lookup, new Job row, canonical identity, and source
+        observation are one SQLite write transaction.  A competing posting
+        therefore observes the stable owner rather than re-homing evidence to a
+        newly committed candidate Job.
         """
         ...
 
@@ -292,12 +327,14 @@ class JobRepository(JobIdentityResolver, Protocol):
         tenant_id: TenantId,
         job_id: JobId,
         observation: JobSourceObservation,
-    ) -> None:
+    ) -> CanonicalOwnerMatch | None:
         """Persist an observation under an existing canonical Job.
 
         Idempotent on ``(tenant_id, source_id, source_native_id)`` — the
         same source emitting the same posting in a later run REPLACES
-        the previous observation row rather than appending a duplicate.
+        the previous observation row rather than appending a duplicate.  If an
+        exact observation claim belongs to another Job, leaves that evidence in
+        place and returns its stable owner and basis instead of re-homing it.
         """
         ...
 

--- a/workers/automation/src/jobctrl/domain/ports/discovery.py
+++ b/workers/automation/src/jobctrl/domain/ports/discovery.py
@@ -11,7 +11,7 @@ PR 2 ATS adapters (``WorkdayBoardAdapter``, ``GreenhouseBoardAdapter``,
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Iterable, Literal, Protocol
 
 from jobctrl.domain.discovery.aggregate import Job
@@ -23,6 +23,7 @@ from jobctrl.domain.discovery.identity import (
 )
 from jobctrl.domain.discovery.scheduler import DiscoveryRun
 from jobctrl.domain.discovery.value_objects import (
+    Employer,
     JobMetadata,
     PostingUrl,
     SearchStrategy,
@@ -50,6 +51,11 @@ class ScrapedJobPosting:
     URL the source advertises (typically the ATS detail URL), the ATS
     kind detected by the adapter, and the source registry id the
     posting was scraped from.
+
+    ``employer`` is the hiring company reported by the scraper, independent of
+    ``source.board``. Scrapers use ``Employer.unknown()`` only when their payload
+    has no explicit company fact; callers never derive it from a site label or
+    URL.
     """
 
     posting_url: PostingUrl
@@ -60,6 +66,7 @@ class ScrapedJobPosting:
     source_native_id: str
     canonical_url: str
     ats_kind: AtsKind = AtsKind.OTHER
+    employer: Employer = field(default_factory=Employer.unknown)
 
 
 @dataclass(frozen=True)

--- a/workers/automation/src/jobctrl/domain/ports/discovery.py
+++ b/workers/automation/src/jobctrl/domain/ports/discovery.py
@@ -75,6 +75,40 @@ class ContentOwnerMatch:
     basis: ContentMatchBasis
 
 
+@dataclass(frozen=True)
+class ResolvedJobIdentity:
+    """Stable identity and current external locator for one Job.
+
+    ``job_id`` is the canonical aggregate identifier and ``posting_url`` is
+    the mutable current external locator. Runtime callers never receive or
+    infer a second storage identity.
+    """
+
+    tenant_id: TenantId
+    job_id: JobId
+    posting_url: PostingUrl
+
+
+class JobIdentityResolver(Protocol):
+    """Resolve stable Job identities without exposing persistence details."""
+
+    def resolve_by_job_id(
+        self,
+        tenant_id: TenantId,
+        job_id: JobId,
+    ) -> ResolvedJobIdentity | None:
+        """Resolve a canonical aggregate identifier."""
+        ...
+
+    def resolve_by_posting_url(
+        self,
+        tenant_id: TenantId,
+        posting_url: PostingUrl,
+    ) -> ResolvedJobIdentity | None:
+        """Resolve a current or historical posting-URL alias."""
+        ...
+
+
 class JobBoardScraperPort(Protocol):
     """Driven port for external job-board scraping.
 
@@ -111,40 +145,37 @@ class JobBoardScraperPort(Protocol):
         ...
 
 
-class JobRepository(Protocol):
+class JobRepository(JobIdentityResolver, Protocol):
     """Persistence port for the ``Job`` aggregate.
 
-    All methods are tenant-scoped. Local adapters accept ``tenant_id``
-    and ignore the value (single-tenant); hosted adapters use it for row
-    isolation.
+    All methods are tenant-scoped. The local adapter persists and enforces
+    the tenant alongside stable identity even though local mode normally uses
+    one tenant.
 
     Dedup contract:
 
-      * ``save`` enforces the §4.1 invariant — duplicate
-        ``(tenant_id, posting_url)`` is rejected. Callers should
-        ``load_by_url`` first if they want to update an existing job
-        rather than insert a new one.
-      * ``load_by_url`` returns the canonical ``Job`` for a posting URL,
-        regardless of tombstone state, so the URL-resolution flow in
-        enrichment can find the row even after a soft-delete.
+      * ``save`` atomically claims a new posting URL or upserts the Job that
+        already owns the stable id. When a concurrent writer wins the same URL,
+        it returns that winner's stable ``JobId`` so the caller can re-enter
+        the existing-owner flow.
+      * URL locators are resolved through the explicit ``JobIdentityResolver``
+        boundary before calling ``load``.
     """
 
     def load(self, tenant_id: TenantId, job_id: JobId) -> Job | None:
         """Return the Job by aggregate id, or ``None``."""
         ...
 
-    def load_by_url(self, tenant_id: TenantId, posting_url: PostingUrl) -> Job | None:
-        """Return the Job whose ``posting_url`` matches, or ``None``."""
-        ...
-
-    def save(self, job: Job) -> None:
+    def save(self, job: Job) -> JobId:
         """Persist the aggregate.
 
         Inserts on first save; subsequent saves with the same
         ``(tenant_id, job_id)`` perform an upsert that preserves
         ``discovered_at``. The repository is responsible for refusing
         a save whose ``(tenant_id, posting_url)`` collides with a
-        DIFFERENT ``job_id``.
+        DIFFERENT ``job_id``. Returns the persisted stable id, which can differ
+        from ``job.job_id`` only when another concurrent writer won the same
+        posting URL.
         """
         ...
 

--- a/workers/automation/src/jobctrl/infrastructure/discovery/__init__.py
+++ b/workers/automation/src/jobctrl/infrastructure/discovery/__init__.py
@@ -24,6 +24,9 @@ from jobctrl.infrastructure.discovery.ats_adapters import (
 from jobctrl.infrastructure.discovery.sqlite_repository import (
     SqliteJobRepository,
 )
+from jobctrl.infrastructure.discovery.sqlite_identity_resolver import (
+    SqliteJobIdentityResolver,
+)
 from jobctrl.infrastructure.discovery.sqlite_execution_repository import (
     SqliteDiscoveryExecutionRepository,
 )
@@ -62,6 +65,7 @@ __all__ = [
     "SqliteDiscoveryExecutionRepository",
     "SqliteDiscoverySearchUnitCheckpointStore",
     "SqliteDiscoverySearchUnitRepository",
+    "SqliteJobIdentityResolver",
     "SqliteJobRepository",
     "StaleDiscoverySearchUnitLease",
     "WorkdayBoardAdapter",

--- a/workers/automation/src/jobctrl/infrastructure/discovery/ats_adapters.py
+++ b/workers/automation/src/jobctrl/infrastructure/discovery/ats_adapters.py
@@ -35,6 +35,7 @@ from bs4 import BeautifulSoup
 
 from jobctrl.domain.discovery.identity import AtsKind
 from jobctrl.domain.discovery.value_objects import (
+    Employer,
     JobMetadata,
     PostingUrl,
     SearchStrategy,
@@ -49,6 +50,11 @@ from jobctrl.infrastructure.observability.adapter_spans import adapter_fetch_spa
 log = logging.getLogger(__name__)
 
 _NULL_DESCRIPTION_SENTINELS = {"<na>", "nan", "nat", "none", "null"}
+
+
+def _employer_from_optional(value: object) -> Employer:
+    name = str(value or "").strip()
+    return Employer(name=name) if name else Employer.unknown()
 
 
 # ---------------------------------------------------------------------------
@@ -93,7 +99,7 @@ class WorkdayEmployer:
 
     @property
     def board(self) -> str:
-        return self.name
+        return "workday"
 
 
 class WorkdayBoardAdapter:
@@ -221,6 +227,7 @@ class WorkdayBoardAdapter:
         return ScrapedJobPosting(
             posting_url=PostingUrl(value=canonical_url),
             source=Source(board=self._employer.board),
+            employer=_employer_from_optional(self._employer.name),
             metadata=JobMetadata(
                 title=title,
                 salary="",
@@ -336,7 +343,8 @@ class GreenhouseBoardAdapter:
         company = str(raw.get("company_name") or self._company or "").strip()
         return ScrapedJobPosting(
             posting_url=PostingUrl(value=canonical_url),
-            source=Source(board=company or f"greenhouse:{self._board_token}"),
+            source=Source(board="greenhouse"),
+            employer=_employer_from_optional(company),
             metadata=JobMetadata(
                 title=title,
                 salary="",
@@ -440,10 +448,10 @@ class LeverBoardAdapter:
         description = _lever_description(raw)
         if not description:
             return None
-        company = self._company or f"lever:{self._site}"
         return ScrapedJobPosting(
             posting_url=PostingUrl(value=hosted_url),
-            source=Source(board=company),
+            source=Source(board="lever"),
+            employer=_employer_from_optional(self._company),
             metadata=JobMetadata(
                 title=text,
                 salary="",
@@ -545,10 +553,10 @@ class AshbyBoardAdapter:
         description = _ashby_description(raw)
         if not description:
             return None
-        company = self._company or f"ashby:{self._board_name}"
         return ScrapedJobPosting(
             posting_url=PostingUrl(value=job_url),
-            source=Source(board=company),
+            source=Source(board="ashby"),
+            employer=_employer_from_optional(self._company),
             metadata=JobMetadata(
                 title=title,
                 salary="",

--- a/workers/automation/src/jobctrl/infrastructure/discovery/production_wiring.py
+++ b/workers/automation/src/jobctrl/infrastructure/discovery/production_wiring.py
@@ -61,7 +61,7 @@ from jobctrl.domain.enrichment.snapshot_services import (
 from jobctrl.domain.enrichment.snapshot_use_case import CapturePostingSnapshotUseCase
 from jobctrl.domain.enrichment.snapshot_value_objects import QuarantineReason
 from jobctrl.domain.events.base import DomainEvent
-from jobctrl.domain.identifiers import JobId
+from jobctrl.domain.identifiers import JobId, canonical_job_id
 from jobctrl.domain.ports.discovery import ScrapedJobPosting
 from jobctrl.domain.tenant import LOCAL_TENANT, TenantId
 from jobctrl.discovery.target_queries import query_specs_for_source, title_matches_any_query
@@ -207,10 +207,10 @@ class DurableJobEventPublisher:
         if self._write_fence is not None:
             self._write_fence()
         payload = {"tenantId": str(event.tenant_id), **event.payload}
-        job_url = _event_job_url(event)
+        job_id = _event_job_id(event)
         record_job_event(
             self._conn,
-            job_url,
+            job_id,
             self._stage,
             event.event_type,
             message=event.event_type,
@@ -226,7 +226,6 @@ class DurableJobEventPublisher:
 def ensure_worker_discovery_tables(conn: sqlite3.Connection) -> None:
     ensure_source_observation_tables(conn)
     ensure_discovery_control_tables(conn)
-    ensure_enrichment_tables(conn)
     ensure_posting_snapshot_tables(conn)
 
 
@@ -695,11 +694,10 @@ def _promote_ats_source_description_to_enrichment(
     )
     enrichment_repository.save(succeeded)
 
-    job_url = str(job_id)
-    ensure_job_stage_rows(conn, job_url, discovered_at=observed_at)
+    ensure_job_stage_rows(conn, job_id, discovered_at=observed_at)
     stage_row = conn.execute(
-        "SELECT state FROM job_stage_states WHERE job_url = ? AND stage = 'enrich'",
-        (job_url,),
+        "SELECT state FROM job_stage_states WHERE tenant_id = ? AND job_id = ? AND stage = 'enrich'",
+        (str(LOCAL_TENANT), str(job_id)),
     ).fetchone()
     stage_state = str(stage_row["state"] or "") if stage_row is not None else ""
     if stage_state != "succeeded":
@@ -707,7 +705,7 @@ def _promote_ats_source_description_to_enrichment(
             try:
                 set_stage_state(
                     conn,
-                    job_url,
+                    job_id,
                     "enrich",
                     "running",
                     attempt_count=succeeded.attempt_count,
@@ -716,7 +714,7 @@ def _promote_ats_source_description_to_enrichment(
             except ValueError:
                 set_stage_state(
                     conn,
-                    job_url,
+                    job_id,
                     "enrich",
                     "running",
                     attempt_count=succeeded.attempt_count,
@@ -725,7 +723,7 @@ def _promote_ats_source_description_to_enrichment(
                 )
         set_stage_state(
             conn,
-            job_url,
+            job_id,
             "enrich",
             "succeeded",
             attempt_count=succeeded.attempt_count,
@@ -734,7 +732,7 @@ def _promote_ats_source_description_to_enrichment(
         )
         record_job_event(
             conn,
-            job_url,
+            job_id,
             "enrich",
             "StageCompleted",
             message=(f"ATS source description promoted to enrichment: {len(description)} description chars"),
@@ -759,8 +757,6 @@ def retire_invalid_source_jobs(
     """Soft-delete active discovered jobs that fail today's discovery contract."""
 
     ensure_source_observation_tables(conn)
-    ensure_enrichment_tables(conn)
-    _ensure_deleted_jobs_table(conn)
     query_specs_by_family = _query_specs_by_family(search_cfg)
     accept_locs, reject_locs = configured_location_filters(search_cfg)
     locations = tuple(_location_values(search_cfg))
@@ -770,6 +766,7 @@ def retire_invalid_source_jobs(
     rows = conn.execute(
         """
         SELECT
+            j.job_id,
             j.url,
             COALESCE(j.title, '') AS title,
             COALESCE(j.location, '') AS location,
@@ -781,18 +778,18 @@ def retire_invalid_source_jobs(
             COALESCE(MIN(o.source_id), '') AS source_id
         FROM jobs j
         LEFT JOIN job_enrichments e
-          ON e.tenant_id = ? AND e.job_url = j.url
+          ON e.tenant_id = j.tenant_id AND e.job_id = j.job_id
         LEFT JOIN job_canonical_identities c
-          ON c.tenant_id = ? AND c.job_url = j.url
+          ON c.tenant_id = j.tenant_id AND c.job_id = j.job_id
         LEFT JOIN job_source_observations o
-          ON o.tenant_id = ? AND o.job_url = j.url
+          ON o.tenant_id = j.tenant_id AND o.job_id = j.job_id
         LEFT JOIN jobctrl_deleted_jobs d
-          ON d.job_url = j.url
+          ON d.tenant_id = j.tenant_id AND d.job_id = j.job_id
          AND (d.restored_at IS NULL OR julianday(d.restored_at) <= julianday(d.deleted_at))
-        WHERE d.job_url IS NULL
-        GROUP BY j.url
+        WHERE j.tenant_id = ? AND d.job_id IS NULL
+        GROUP BY j.tenant_id, j.job_id
         """,
-        (str(LOCAL_TENANT), str(LOCAL_TENANT), str(LOCAL_TENANT)),
+        (str(LOCAL_TENANT),),
     ).fetchall()
 
     for row in rows:
@@ -820,26 +817,26 @@ def retire_invalid_source_jobs(
             continue
         source_id = str(row["source_id"] or row["ats_kind"] or family)
         reason = f"discovery hygiene rejected {source_id}: {', '.join(reasons)}"
+        job_id = canonical_job_id(str(row["job_id"]))
         job_url = str(row["url"])
         conn.execute(
             """
-            INSERT INTO jobctrl_deleted_jobs (job_url, deleted_at, reason, restored_at)
-            VALUES (?, ?, ?, NULL)
-            ON CONFLICT(job_url) DO UPDATE SET
+            INSERT INTO jobctrl_deleted_jobs (tenant_id, job_id, deleted_at, reason, restored_at)
+            VALUES (?, ?, ?, ?, NULL)
+            ON CONFLICT(tenant_id, job_id) DO UPDATE SET
                 deleted_at = excluded.deleted_at,
                 reason = excluded.reason,
                 restored_at = NULL
             """,
-            (job_url, now, reason),
+            (str(LOCAL_TENANT), str(job_id), now, reason),
         )
         record_job_event(
             conn,
-            job_url,
+            job_id,
             "discover",
             "JobDeleted",
             message=reason,
             payload={
-                "job_id": job_url,
                 "reason": reason,
                 "deleted_at": now,
                 "run_id": run_id,
@@ -985,20 +982,6 @@ def _source_rejection_reasons(
     ):
         reasons.append("location_mismatch")
     return reasons
-
-
-def _ensure_deleted_jobs_table(conn: sqlite3.Connection) -> None:
-    conn.execute(
-        """
-        CREATE TABLE IF NOT EXISTS jobctrl_deleted_jobs (
-            job_url TEXT PRIMARY KEY,
-            deleted_at TEXT NOT NULL,
-            reason TEXT,
-            restored_at TEXT,
-            FOREIGN KEY(job_url) REFERENCES jobs(url)
-        )
-        """
-    )
 
 
 def _scraped_posting_key(posting: ScrapedJobPosting) -> tuple[str, str, str]:
@@ -1149,7 +1132,7 @@ def build_discovery_acceptance_report(
     lead_yield = _scalar_int(
         conn,
         """
-        SELECT COUNT(DISTINCT job_url)
+        SELECT COUNT(DISTINCT job_id)
         FROM job_source_observations
         WHERE tenant_id = ? AND run_id != 'backfill'
         """,
@@ -1176,7 +1159,7 @@ def build_discovery_acceptance_report(
     )
     canonical_jobs = _scalar_int(
         conn,
-        "SELECT COUNT(DISTINCT job_url) FROM job_canonical_identities WHERE tenant_id = ?",
+        "SELECT COUNT(DISTINCT job_id) FROM job_canonical_identities WHERE tenant_id = ?",
         (tenant,),
     )
     canonical_verification_rate = round(canonical_jobs / lead_yield, 4) if lead_yield else 0.0
@@ -1203,14 +1186,15 @@ def build_discovery_acceptance_report(
         """
         SELECT COUNT(*)
         FROM jobs j
-        JOIN job_enrichments e ON e.job_url = j.url AND e.tenant_id = ?
+        JOIN job_enrichments e ON e.tenant_id = j.tenant_id AND e.job_id = j.job_id
         LEFT JOIN discovery_quarantine_entries q
-          ON q.tenant_id = ? AND q.job_id = j.url AND q.status = 'pending'
-        WHERE e.current_status = 'enriched'
+          ON q.tenant_id = j.tenant_id AND q.job_id = j.job_id AND q.status = 'pending'
+        WHERE j.tenant_id = ?
+          AND e.current_status = 'enriched'
           AND j.fit_score IS NULL
           AND q.job_id IS NULL
         """,
-        (tenant, tenant),
+        (tenant,),
     )
     return DiscoveryAcceptanceReport(
         scenario=scenario,
@@ -2228,11 +2212,11 @@ def _looks_protected(url: str) -> bool:
     )
 
 
-def _event_job_url(event: DomainEvent) -> str | None:
-    for key in ("job_id", "jobId", "job_url", "jobUrl", "surviving_job_id"):
+def _event_job_id(event: DomainEvent) -> JobId | None:
+    for key in ("job_id", "jobId", "surviving_job_id"):
         value = event.payload.get(key)
         if value:
-            return str(value)
+            return canonical_job_id(str(value))
     return None
 
 

--- a/workers/automation/src/jobctrl/infrastructure/discovery/production_wiring.py
+++ b/workers/automation/src/jobctrl/infrastructure/discovery/production_wiring.py
@@ -657,12 +657,15 @@ def _promote_ats_source_description_to_enrichment(
         return False
 
     identity = default_canonical_identity(posting)
-    job_id = job_repository.find_canonical_owner(
+    owner_match = job_repository.find_canonical_owner(
         LOCAL_TENANT,
         source_id=posting.source_id,
         source_native_id=identity.source_native_id,
         canonical_url=identity.canonical_url,
-    ) or JobId(identity.canonical_url or posting.posting_url.value)
+    )
+    if owner_match is None:
+        return False
+    job_id = owner_match.job_id
     if job_repository.load(LOCAL_TENANT, job_id) is None:
         return False
 

--- a/workers/automation/src/jobctrl/infrastructure/discovery/production_wiring.py
+++ b/workers/automation/src/jobctrl/infrastructure/discovery/production_wiring.py
@@ -22,7 +22,6 @@ from urllib.parse import urlparse
 
 from jobctrl.database import (
     ensure_discovery_control_tables,
-    ensure_enrichment_tables,
     ensure_posting_snapshot_tables,
     ensure_source_observation_tables,
 )

--- a/workers/automation/src/jobctrl/infrastructure/discovery/production_wiring.py
+++ b/workers/automation/src/jobctrl/infrastructure/discovery/production_wiring.py
@@ -45,6 +45,7 @@ from jobctrl.domain.discovery.use_cases import (
     default_canonical_identity,
 )
 from jobctrl.domain.discovery.value_objects import (
+    Employer,
     JobMetadata,
     PostingUrl,
     SearchStrategy,
@@ -2003,9 +2004,11 @@ def _manual_capture_posting(
     originating_url: str,
 ) -> ScrapedJobPosting:
     title = _extract_title(content) or "User-mediated captured posting"
+    employer_name = _extract_employer(content)
     return ScrapedJobPosting(
         posting_url=PostingUrl(value=url),
         source=Source(board="User-mediated capture"),
+        employer=(Employer(name=employer_name) if employer_name else Employer.unknown()),
         metadata=JobMetadata(
             title=title,
             salary="",
@@ -2253,6 +2256,18 @@ def _extract_title(content: str) -> str:
     match = re.search(r"<title>(.*?)</title>", content, flags=re.IGNORECASE | re.DOTALL)
     if match:
         return re.sub(r"\s+", " ", match.group(1)).strip()
+    return ""
+
+
+def _extract_employer(content: str) -> str:
+    for item in _extract_json_ld(content):
+        organization = item.get("hiringOrganization")
+        if isinstance(organization, dict):
+            name = organization.get("name")
+            if isinstance(name, str) and name.strip():
+                return name.strip()
+        elif isinstance(organization, str) and organization.strip():
+            return organization.strip()
     return ""
 
 

--- a/workers/automation/src/jobctrl/infrastructure/discovery/production_wiring.py
+++ b/workers/automation/src/jobctrl/infrastructure/discovery/production_wiring.py
@@ -400,16 +400,22 @@ def learn_posting_source_from_url(
         confidence=0.82,
     )
     identity_repository = SqliteJobRepository(conn)
+    resolved_job = identity_repository.resolve_by_posting_url(
+        LOCAL_TENANT,
+        PostingUrl(value=job_url),
+    )
+    if resolved_job is None:
+        raise LookupError(f"Source learning references an unknown posting URL: {job_url!r}")
     _apply_optional_write_fence(write_fence)
     identity_repository.set_canonical_identity(
         LOCAL_TENANT,
-        JobId(job_url),
+        resolved_job.job_id,
         identity,
     )
     _apply_optional_write_fence(write_fence)
     _record_canonical_identity_resolved_event(
         conn,
-        job_url=job_url,
+        job_id=resolved_job.job_id,
         identity=identity,
         occurred_at=observed_at,
         idempotency_key=_event_idempotency_key(
@@ -1613,21 +1619,21 @@ def _record_source_registry_updated_event(
 def _record_canonical_identity_resolved_event(
     conn: sqlite3.Connection,
     *,
-    job_url: str,
+    job_id: JobId,
     identity: CanonicalJobIdentity,
     occurred_at: str,
     idempotency_key: str | None = None,
 ) -> None:
     record_job_event(
         conn,
-        job_url,
+        job_id,
         "discover",
         "CanonicalJobIdentityResolved",
         message="Canonical job identity resolved.",
         payload={
             "tenantId": str(LOCAL_TENANT),
-            "job_id": job_url,
-            "jobId": job_url,
+            "job_id": str(job_id),
+            "jobId": str(job_id),
             "canonical_url": identity.canonical_url,
             "canonicalUrl": identity.canonical_url,
             "ats_kind": identity.ats_kind.value,

--- a/workers/automation/src/jobctrl/infrastructure/discovery/sqlite_identity_resolver.py
+++ b/workers/automation/src/jobctrl/infrastructure/discovery/sqlite_identity_resolver.py
@@ -1,0 +1,94 @@
+"""SQLite adapter for stable Job identity resolution."""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import Any
+
+from jobctrl.domain.discovery.value_objects import PostingUrl
+from jobctrl.domain.identifiers import JobId
+from jobctrl.domain.ports.discovery import ResolvedJobIdentity
+from jobctrl.domain.tenant import TenantId
+
+
+_CURRENT_POSTING_URL_SQL = """
+(
+    SELECT locator.locator_value
+    FROM job_locators locator
+    WHERE locator.tenant_id = j.tenant_id
+      AND locator.job_id = j.job_id
+      AND locator.locator_kind = 'posting_url'
+      AND locator.is_current = 1
+      AND locator.retired_at IS NULL
+    LIMIT 1
+)
+"""
+
+
+class SqliteJobIdentityResolver:
+    """Resolve UUID-backed Job identities and their posting-URL aliases."""
+
+    def __init__(self, conn: sqlite3.Connection) -> None:
+        self._conn = conn
+
+    def resolve_by_job_id(
+        self,
+        tenant_id: TenantId,
+        job_id: JobId,
+    ) -> ResolvedJobIdentity | None:
+        row = self._conn.execute(
+            f"""
+            SELECT
+                j.tenant_id,
+                j.job_id,
+                {_CURRENT_POSTING_URL_SQL} AS posting_url
+            FROM jobs j
+            WHERE j.tenant_id = ? AND j.job_id = ?
+            LIMIT 1
+            """,
+            (str(tenant_id), str(job_id)),
+        ).fetchone()
+        return _resolved_identity(row)
+
+    def resolve_by_posting_url(
+        self,
+        tenant_id: TenantId,
+        posting_url: PostingUrl,
+    ) -> ResolvedJobIdentity | None:
+        row = self._conn.execute(
+            f"""
+            SELECT
+                j.tenant_id,
+                j.job_id,
+                {_CURRENT_POSTING_URL_SQL} AS posting_url
+            FROM job_locators a
+            JOIN jobs j
+              ON j.tenant_id = a.tenant_id
+             AND j.job_id = a.job_id
+            WHERE a.tenant_id = ?
+              AND a.locator_kind = 'posting_url'
+              AND a.locator_value = ?
+            LIMIT 1
+            """,
+            (str(tenant_id), posting_url.value),
+        ).fetchone()
+        return _resolved_identity(row)
+
+
+def _resolved_identity(row: Any | None) -> ResolvedJobIdentity | None:
+    if row is None:
+        return None
+    if isinstance(row, sqlite3.Row):
+        tenant_id = row["tenant_id"]
+        job_id = row["job_id"]
+        posting_url = row["posting_url"]
+    else:
+        tenant_id, job_id, posting_url = row
+    return ResolvedJobIdentity(
+        tenant_id=TenantId(str(tenant_id)),
+        job_id=JobId(str(job_id)),
+        posting_url=PostingUrl(value=str(posting_url)),
+    )
+
+
+__all__ = ["SqliteJobIdentityResolver"]

--- a/workers/automation/src/jobctrl/infrastructure/discovery/sqlite_repository.py
+++ b/workers/automation/src/jobctrl/infrastructure/discovery/sqlite_repository.py
@@ -5,7 +5,9 @@ new table is introduced this phase per the migration plan §8 deferred
 scope). The adapter touches only the discovery-owned columns of the
 table:
 
-  ``url``           — ``Job.posting_url`` (still the legacy PRIMARY KEY).
+  ``tenant_id``     — tenant boundary for the aggregate.
+  ``job_id``        — stable, system-generated aggregate identifier.
+  ``url``           — current posting locator, unique but never identity.
   ``title``,
   ``salary``,
   ``description``,
@@ -17,7 +19,7 @@ table:
 Soft-delete state lives in the existing ``jobctrl_deleted_jobs``
 tombstone table (mirror of the API's
 ``apps/api/src/write-model.ts:softDeleteJobs``); the adapter
-reads/writes that table through ``ensure_deleted_jobs_table`` so a
+reads/writes that exact-v7 table directly so a
 worker-side delete and an API-side delete share the same tombstone row
 shape.
 
@@ -53,15 +55,25 @@ from jobctrl.domain.discovery.value_objects import (
     SearchStrategy,
     Source,
 )
-from jobctrl.domain.identifiers import JobId
+from jobctrl.domain.identifiers import (
+    JobId,
+    canonical_job_id,
+)
 from jobctrl.domain.job_content_identity import (
     content_match_basis,
     is_genuine_employer_identity,
     job_content_fingerprint,
     normalize_identity_text,
 )
-from jobctrl.domain.ports.discovery import ContentOwnerMatch
-from jobctrl.domain.tenant import LOCAL_TENANT, TenantId
+from jobctrl.domain.ports.discovery import (
+    ContentOwnerMatch,
+    JobIdentityResolver,
+    ResolvedJobIdentity,
+)
+from jobctrl.domain.tenant import TenantId
+from jobctrl.infrastructure.discovery.sqlite_identity_resolver import (
+    SqliteJobIdentityResolver,
+)
 
 
 class JobUrlConflict(ValueError):
@@ -95,6 +107,7 @@ class SqliteJobRepository:
         discovery_execution: DiscoveryExecutionRef | None = None,
         source_family: str | None = None,
         search_unit_lease: DiscoverySearchUnitLease | None = None,
+        identity_resolver: JobIdentityResolver | None = None,
     ) -> None:
         if search_unit_lease is not None:
             if discovery_execution is None:
@@ -105,9 +118,9 @@ class SqliteJobRepository:
         self._discovery_execution = discovery_execution
         self._source_family = source_family.strip() if source_family else None
         self._search_unit_lease = search_unit_lease
+        self._identity_resolver = identity_resolver or SqliteJobIdentityResolver(conn)
         if discovery_execution is not None and self._source_family is None:
             raise ValueError("source_family is required with discovery_execution")
-        self._ensure_deleted_jobs_table()
         if discovery_execution is not None:
             # Imported lazily to keep the aggregate repository's ordinary path
             # independent from the execution-lineage adapter.
@@ -131,97 +144,32 @@ class SqliteJobRepository:
     # Schema bootstrapping
     # ------------------------------------------------------------------
 
-    def _ensure_deleted_jobs_table(self) -> None:
-        """Mirror of ``apps/api/src/write-model.ts:ensureDeletedJobsTable``.
-
-        Created on demand so the worker-side delete path matches the
-        API-side delete path on row shape.
-        """
-        self._conn.execute(
-            """
-            CREATE TABLE IF NOT EXISTS jobctrl_deleted_jobs (
-                job_url TEXT PRIMARY KEY,
-                deleted_at TEXT NOT NULL,
-                reason TEXT,
-                restored_at TEXT,
-                FOREIGN KEY(job_url) REFERENCES jobs(url)
-            )
-            """
-        )
-        self._conn.commit()
-
     # ------------------------------------------------------------------
     # Read
     # ------------------------------------------------------------------
 
+    def resolve_by_job_id(
+        self,
+        tenant_id: TenantId,
+        job_id: JobId,
+    ) -> ResolvedJobIdentity | None:
+        return self._identity_resolver.resolve_by_job_id(tenant_id, job_id)
+
+    def resolve_by_posting_url(
+        self,
+        tenant_id: TenantId,
+        posting_url: PostingUrl,
+    ) -> ResolvedJobIdentity | None:
+        return self._identity_resolver.resolve_by_posting_url(
+            tenant_id,
+            posting_url,
+        )
+
     def load(self, tenant_id: TenantId, job_id: JobId) -> Job | None:
-        """Return a Job by aggregate id.
-
-        Local mode collapses ``JobId`` and ``PostingUrl`` onto the same
-        ``jobs.url`` column (per migration plan §8: stable ``JobId``
-        narrowing is deferred), so ``load`` and ``load_by_url`` use the
-        same lookup. The cloud cutover swaps in a system-generated UUID
-        column without touching the port.
-        """
-        return self.load_by_url(tenant_id, PostingUrl(value=str(job_id)))
-
-    def load_by_url(self, tenant_id: TenantId, posting_url: PostingUrl) -> Job | None:
-        """Resolve a posting URL to its canonical Job aggregate.
-
-        Per the RFC §"Deduplication Boundary", ``load_by_url`` MUST keep
-        resolving both the canonical ``jobs.url`` and the additional
-        observation URLs during the compatibility window so existing
-        callers and local databases continue to work. Resolution order:
-
-          1. Direct match on ``jobs.url`` (the legacy primary key and
-             the canonical posting URL during the migration).
-          2. Match on a normalised observation URL — when a broad-board
-             callsite passes the URL it scraped from Indeed/LinkedIn,
-             we still want to find the canonical Job that owns it.
-        """
-
-        row = self._conn.execute(
-            """
-            SELECT j.url, j.title, j.salary, j.description, j.location,
-                   j.site, j.strategy, j.discovered_at,
-                   d.deleted_at, d.reason
-            FROM jobs j
-            LEFT JOIN jobctrl_deleted_jobs d
-              ON d.job_url = j.url
-             AND (d.restored_at IS NULL OR julianday(d.restored_at) <= julianday(d.deleted_at))
-            WHERE j.url = ?
-            LIMIT 1
-            """,
-            (posting_url.value,),
-        ).fetchone()
-        if row is not None:
-            return self._row_to_job(row, tenant_id)
-
-        # Fall back to the observation index — this is the
-        # compatibility seam that lets a broad-board URL resolve to
-        # the canonical Job after PR 2's identity migration lands.
-        normalized = normalize_observed_url(posting_url.value)
-        if not normalized:
-            return None
-        row = self._conn.execute(
-            """
-            SELECT j.url, j.title, j.salary, j.description, j.location,
-                   j.site, j.strategy, j.discovered_at,
-                   d.deleted_at, d.reason
-            FROM jobs j
-            JOIN job_source_observations o
-              ON o.job_url = j.url AND o.tenant_id = ?
-            LEFT JOIN jobctrl_deleted_jobs d
-              ON d.job_url = j.url
-             AND (d.restored_at IS NULL OR julianday(d.restored_at) <= julianday(d.deleted_at))
-            WHERE o.normalized_observed_url = ?
-            LIMIT 1
-            """,
-            (str(tenant_id), normalized),
-        ).fetchone()
-        if row is None:
-            return None
-        return self._row_to_job(row, tenant_id)
+        """Return a Job by its canonical stable id."""
+        stable_job_id = canonical_job_id(str(job_id))
+        identity = self.resolve_by_job_id(tenant_id, stable_job_id)
+        return self._load_resolved(identity) if identity is not None else None
 
     def list_recent(
         self,
@@ -232,33 +180,48 @@ class SqliteJobRepository:
     ) -> list[Job]:
         if not include_deleted:
             sql = (
-                "SELECT j.url, j.title, j.salary, j.description, j.location, "
+                "SELECT j.tenant_id, j.job_id, j.url, "
+                "j.title, j.salary, j.description, j.location, "
                 "j.site, j.strategy, j.discovered_at, "
                 "d.deleted_at, d.reason "
                 "FROM jobs j "
                 "LEFT JOIN jobctrl_deleted_jobs d "
-                "  ON d.job_url = j.url "
+                "  ON d.tenant_id = j.tenant_id AND d.job_id = j.job_id "
                 " AND (d.restored_at IS NULL OR julianday(d.restored_at) <= julianday(d.deleted_at)) "
-                "WHERE d.job_url IS NULL "
+                "WHERE j.tenant_id = ? AND d.job_id IS NULL "
                 "ORDER BY j.discovered_at DESC NULLS LAST"
             )
         else:
             sql = (
-                "SELECT j.url, j.title, j.salary, j.description, j.location, "
+                "SELECT j.tenant_id, j.job_id, j.url, "
+                "j.title, j.salary, j.description, j.location, "
                 "j.site, j.strategy, j.discovered_at, "
                 "d.deleted_at, d.reason "
                 "FROM jobs j "
                 "LEFT JOIN jobctrl_deleted_jobs d "
-                "  ON d.job_url = j.url "
+                "  ON d.tenant_id = j.tenant_id AND d.job_id = j.job_id "
                 " AND (d.restored_at IS NULL OR julianday(d.restored_at) <= julianday(d.deleted_at)) "
+                "WHERE j.tenant_id = ? "
                 "ORDER BY j.discovered_at DESC NULLS LAST"
             )
-        params: list[Any] = []
+        params: list[Any] = [str(tenant_id)]
         if limit > 0:
             sql += " LIMIT ?"
             params.append(limit)
         rows = self._conn.execute(sql, params).fetchall()
-        return [self._row_to_job(row, tenant_id) for row in rows]
+        jobs: list[Job] = []
+        for row in rows:
+            row_job_id = JobId(str(row["job_id"])) if isinstance(row, sqlite3.Row) else JobId(str(row[1]))
+            identity = self.resolve_by_job_id(tenant_id, row_job_id)
+            if identity is None:
+                continue
+            jobs.append(
+                self._row_to_job(
+                    row,
+                    posting_url=identity.posting_url,
+                )
+            )
+        return jobs
 
     # ------------------------------------------------------------------
     # Write
@@ -270,69 +233,218 @@ class SqliteJobRepository:
         assert self._search_unit_lease is not None
         self._search_unit_repository.fence_write(self._search_unit_lease)
 
-    def save(self, job: Job) -> None:
-        """Insert / upsert a Job into the wide ``jobs`` table.
+    def save(self, job: Job) -> JobId:
+        """Persist ``job`` and leave no partial write on failure."""
 
-        Enforces the §4.1 dedup invariant in two ways:
+        try:
+            return self._save(job)
+        except BaseException:
+            self._conn.rollback()
+            raise
 
-          * If the URL already exists, the row's ``job_id`` (the URL
-            itself in local mode) MUST match — otherwise the call is
-            illegal.
-          * The upsert preserves ``discovered_at`` for already-known
-            URLs so a re-discovery doesn't reset the discovery
-            timestamp.
+    def _save(self, job: Job) -> JobId:
+        """Atomically insert or upsert a Job and return its stable owner id.
+
+        ``jobs.url`` and the one active ``job_locators`` row always describe
+        the same current posting locator. ``Job.job_id`` is always a canonical
+        UUID; URL locators are resolved only before aggregate construction.
+
+        If another writer wins a first insert for the same posting URL after
+        this call's initial read, the unique constraints arbitrate ownership.
+        The losing call returns the winner's stable id instead of leaking a raw
+        ``sqlite3.IntegrityError``.
         """
-        existing = self._conn.execute(
-            "SELECT url, discovered_at FROM jobs WHERE url = ?",
-            (job.posting_url.value,),
-        ).fetchone()
-        was_new = existing is None
+        supplied_job_id = canonical_job_id(str(job.job_id))
+        stable_owner = self.resolve_by_job_id(job.tenant_id, supplied_job_id)
+        url_owner = self.resolve_by_posting_url(
+            job.tenant_id,
+            job.posting_url,
+        )
+        # Identity discovery is read-only. Fence immediately before the first
+        # possible mutation so parallel search units can both reach the atomic
+        # URL claim and the unique constraint can select one stable owner.
         self._fence_search_unit_write()
 
-        if existing is not None:
-            existing_url = existing["url"] if isinstance(existing, sqlite3.Row) else existing[0]
-            if existing_url != str(job.job_id):
+        if stable_owner is not None:
+            if url_owner is not None and url_owner.job_id != stable_owner.job_id:
                 raise JobUrlConflict(
                     posting_url=job.posting_url,
-                    owner=JobId(str(existing_url)),
-                    attempted=job.job_id,
+                    owner=url_owner.job_id,
+                    attempted=stable_owner.job_id,
                 )
-            existing_discovered_at = existing["discovered_at"] if isinstance(existing, sqlite3.Row) else existing[1]
-            preserved_discovered_at = existing_discovered_at or job.discovered_at
-            self._conn.execute(
-                """
-                UPDATE jobs SET
-                    title = ?,
-                    company = COALESCE(NULLIF(company, ''), ?),
-                    salary = ?,
-                    description = ?,
-                    location = ?,
-                    site = ?,
-                    strategy = ?,
-                    discovered_at = ?
-                WHERE url = ?
-                """,
-                (
-                    job.metadata.title,
-                    None if job.employer.is_unknown() else job.employer.name,
-                    job.metadata.salary,
-                    job.metadata.description,
-                    job.metadata.location,
-                    job.source.board,
-                    job.search_strategy.value,
-                    preserved_discovered_at,
-                    job.posting_url.value,
-                ),
+            persisted_identity = self._set_current_posting_url(
+                stable_owner,
+                job.posting_url,
+            )
+            self._update_existing_job(job, persisted_identity)
+            was_new = False
+        elif url_owner is not None:
+            raise JobUrlConflict(
+                posting_url=job.posting_url,
+                owner=url_owner.job_id,
+                attempted=supplied_job_id,
             )
         else:
+            persisted_identity, was_new = self._insert_or_resolve_winner(
+                job,
+                supplied_job_id,
+            )
+            if not was_new:
+                # No candidate state belongs on a concurrently-created owner.
+                # The application use case re-enters its existing-owner flow.
+                self._conn.commit()
+                return persisted_identity.job_id
+
+        self._sync_tombstone(job, persisted_identity)
+        if self._search_unit_repository is not None:
+            assert self._search_unit_lease is not None
+            self._search_unit_repository.record_accepted_job(
+                self._search_unit_lease,
+                str(persisted_identity.job_id),
+                was_new=was_new,
+                accepted_at=job.discovered_at,
+            )
+        self._conn.commit()
+        return persisted_identity.job_id
+
+    def _set_current_posting_url(
+        self,
+        identity: ResolvedJobIdentity,
+        posting_url: PostingUrl,
+    ) -> ResolvedJobIdentity:
+        """Move the current posting locator while preserving its history."""
+
+        if posting_url == identity.posting_url:
+            return identity
+        changed_at = datetime.now(timezone.utc).isoformat()
+        self._conn.execute(
+            """
+            UPDATE job_locators
+            SET is_current = 0,
+                last_seen_at = ?,
+                retired_at = ?
+            WHERE tenant_id = ?
+              AND locator_kind = 'posting_url'
+              AND job_id = ?
+              AND is_current = 1
+            """,
+            (
+                changed_at,
+                changed_at,
+                str(identity.tenant_id),
+                str(identity.job_id),
+            ),
+        )
+        claimed = self._conn.execute(
+            """
+            INSERT INTO job_locators (
+                tenant_id, job_id, locator_kind, locator_value,
+                is_current, first_seen_at, last_seen_at, retired_at
+            ) VALUES (?, ?, 'posting_url', ?, 1, ?, ?, NULL)
+            ON CONFLICT (tenant_id, locator_kind, locator_value) DO UPDATE SET
+                is_current = 1,
+                last_seen_at = excluded.last_seen_at,
+                retired_at = NULL
+            WHERE job_locators.job_id = excluded.job_id
+            """,
+            (
+                str(identity.tenant_id),
+                str(identity.job_id),
+                posting_url.value,
+                changed_at,
+                changed_at,
+            ),
+        )
+        if claimed.rowcount != 1:
+            owner = self.resolve_by_posting_url(identity.tenant_id, posting_url)
+            if owner is not None:
+                raise JobUrlConflict(
+                    posting_url=posting_url,
+                    owner=owner.job_id,
+                    attempted=identity.job_id,
+                )
+            raise RuntimeError("Posting URL alias claim failed without a resolvable owner")
+        self._conn.execute(
+            """
+            UPDATE jobs
+            SET url = ?
+            WHERE tenant_id = ? AND job_id = ?
+            """,
+            (
+                posting_url.value,
+                str(identity.tenant_id),
+                str(identity.job_id),
+            ),
+        )
+        return ResolvedJobIdentity(
+            tenant_id=identity.tenant_id,
+            job_id=identity.job_id,
+            posting_url=posting_url,
+        )
+
+    def _update_existing_job(
+        self,
+        job: Job,
+        identity: ResolvedJobIdentity,
+    ) -> None:
+        existing = self._conn.execute(
+            """
+            SELECT discovered_at
+            FROM jobs
+            WHERE tenant_id = ? AND job_id = ?
+            LIMIT 1
+            """,
+            (str(identity.tenant_id), str(identity.job_id)),
+        ).fetchone()
+        if existing is None:
+            raise LookupError("Stable Job owner disappeared before repository upsert")
+        existing_discovered_at = existing["discovered_at"] if isinstance(existing, sqlite3.Row) else existing[0]
+        preserved_discovered_at = existing_discovered_at or job.discovered_at
+        self._conn.execute(
+            """
+            UPDATE jobs SET
+                title = ?,
+                company = COALESCE(NULLIF(company, ''), ?),
+                salary = ?,
+                description = ?,
+                location = ?,
+                site = ?,
+                strategy = ?,
+                discovered_at = ?
+            WHERE tenant_id = ? AND job_id = ?
+            """,
+            (
+                job.metadata.title,
+                None if job.employer.is_unknown() else job.employer.name,
+                job.metadata.salary,
+                job.metadata.description,
+                job.metadata.location,
+                job.source.board,
+                job.search_strategy.value,
+                preserved_discovered_at,
+                str(identity.tenant_id),
+                str(identity.job_id),
+            ),
+        )
+
+    def _insert_or_resolve_winner(
+        self,
+        job: Job,
+        candidate_job_id: JobId,
+    ) -> tuple[ResolvedJobIdentity, bool]:
+        """Claim a first URL, returning a concurrent winner when one exists."""
+
+        try:
             self._conn.execute(
                 """
                 INSERT INTO jobs (
-                    url, title, company, salary, description, location,
-                    site, strategy, discovered_at
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    tenant_id, job_id, url, title, company, salary,
+                    description, location, site, strategy, discovered_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
+                    str(job.tenant_id),
+                    str(candidate_job_id),
                     job.posting_url.value,
                     job.metadata.title,
                     None if job.employer.is_unknown() else job.employer.name,
@@ -344,16 +456,69 @@ class SqliteJobRepository:
                     job.discovered_at,
                 ),
             )
-        self._sync_tombstone(job)
-        if self._search_unit_repository is not None:
-            assert self._search_unit_lease is not None
-            self._search_unit_repository.record_accepted_job(
-                self._search_unit_lease,
-                job.posting_url.value,
-                was_new=was_new,
-                accepted_at=job.discovered_at,
+            created_at = datetime.now(timezone.utc).isoformat()
+            self._conn.execute(
+                """
+                INSERT INTO job_locators (
+                    tenant_id, job_id, locator_kind, locator_value,
+                    is_current, first_seen_at, last_seen_at, retired_at
+                ) VALUES (?, ?, 'posting_url', ?, 1, ?, ?, NULL)
+                """,
+                (
+                    str(job.tenant_id),
+                    str(candidate_job_id),
+                    job.posting_url.value,
+                    created_at,
+                    created_at,
+                ),
             )
-        self._conn.commit()
+        except sqlite3.IntegrityError:
+            winner = self.resolve_by_posting_url(
+                job.tenant_id,
+                job.posting_url,
+            )
+            if winner is not None:
+                return winner, False
+
+            stable_winner = self.resolve_by_job_id(
+                job.tenant_id,
+                candidate_job_id,
+            )
+            if stable_winner is not None:
+                url_owner = self.resolve_by_posting_url(
+                    job.tenant_id,
+                    job.posting_url,
+                )
+                if url_owner is not None and url_owner.job_id != candidate_job_id:
+                    raise JobUrlConflict(
+                        posting_url=job.posting_url,
+                        owner=url_owner.job_id,
+                        attempted=candidate_job_id,
+                    )
+                stable_winner = self._set_current_posting_url(
+                    stable_winner,
+                    job.posting_url,
+                )
+                self._update_existing_job(job, stable_winner)
+                return stable_winner, False
+
+            global_owner = self._conn.execute(
+                "SELECT job_id FROM jobs WHERE url = ? LIMIT 1",
+                (job.posting_url.value,),
+            ).fetchone()
+            if global_owner is not None:
+                owner_job_id = global_owner["job_id"] if isinstance(global_owner, sqlite3.Row) else global_owner[0]
+                raise JobUrlConflict(
+                    posting_url=job.posting_url,
+                    owner=JobId(str(owner_job_id)),
+                    attempted=candidate_job_id,
+                )
+            raise
+
+        identity = self.resolve_by_job_id(job.tenant_id, candidate_job_id)
+        if identity is None:
+            raise RuntimeError("Inserted Job is missing its stable identity alias")
+        return identity, True
 
     def soft_delete(
         self,
@@ -366,18 +531,26 @@ class SqliteJobRepository:
         existing = self.load(tenant_id, job_id)
         if existing is None:
             return None
+        identity = self._require_identity(tenant_id, existing.job_id)
         self._fence_search_unit_write()
         deleted = existing.soft_delete(reason=reason, deleted_at=deleted_at)
         self._conn.execute(
             """
-            INSERT INTO jobctrl_deleted_jobs (job_url, deleted_at, reason, restored_at)
-            VALUES (?, ?, ?, NULL)
-            ON CONFLICT(job_url) DO UPDATE SET
+            INSERT INTO jobctrl_deleted_jobs (
+                tenant_id, job_id, deleted_at, reason, restored_at
+            )
+            VALUES (?, ?, ?, ?, NULL)
+            ON CONFLICT(tenant_id, job_id) DO UPDATE SET
                 deleted_at = excluded.deleted_at,
                 reason = excluded.reason,
                 restored_at = NULL
             """,
-            (str(deleted.job_id), deleted.deleted_at, deleted.delete_reason),
+            (
+                str(tenant_id),
+                str(identity.job_id),
+                deleted.deleted_at,
+                deleted.delete_reason,
+            ),
         )
         self._conn.commit()
         return deleted
@@ -392,6 +565,7 @@ class SqliteJobRepository:
         existing = self.load(tenant_id, job_id)
         if existing is None:
             return None
+        identity = self._require_identity(tenant_id, existing.job_id)
         self._fence_search_unit_write()
         restored = existing.restore()
         restore_timestamp = _restore_timestamp(restored_at, deleted_at=existing.deleted_at)
@@ -400,9 +574,9 @@ class SqliteJobRepository:
         # preserved.
         self._conn.execute(
             "UPDATE jobctrl_deleted_jobs SET restored_at = ? "
-            "WHERE job_url = ? "
+            "WHERE tenant_id = ? AND job_id = ? "
             "AND (restored_at IS NULL OR julianday(restored_at) <= julianday(deleted_at))",
-            (restore_timestamp, str(restored.job_id)),
+            (restore_timestamp, str(tenant_id), str(identity.job_id)),
         )
         self._conn.commit()
         return restored
@@ -429,58 +603,67 @@ class SqliteJobRepository:
         if source_id and source_native_id:
             row = self._conn.execute(
                 """
-                SELECT job_url FROM job_source_observations
-                WHERE tenant_id = ? AND source_id = ? AND source_native_id = ?
+                SELECT j.job_id
+                FROM job_source_observations o
+                JOIN jobs j
+                  ON j.tenant_id = o.tenant_id
+                 AND j.job_id = o.job_id
+                WHERE o.tenant_id = ?
+                  AND o.source_id = ?
+                  AND o.source_native_id = ?
                 LIMIT 1
                 """,
                 (str(tenant_id), source_id, source_native_id),
             ).fetchone()
             if row is not None:
-                job_url = row["job_url"] if isinstance(row, sqlite3.Row) else row[0]
-                if job_url:
-                    return JobId(str(job_url))
+                job_id = row["job_id"] if isinstance(row, sqlite3.Row) else row[0]
+                if job_id:
+                    return JobId(str(job_id))
 
         if canonical_url:
-            row = self._conn.execute(
-                """
-                SELECT url FROM jobs
-                WHERE url = ?
-                LIMIT 1
-                """,
-                (canonical_url,),
-            ).fetchone()
-            if row is not None:
-                job_url = row["url"] if isinstance(row, sqlite3.Row) else row[0]
-                if job_url:
-                    return JobId(str(job_url))
+            direct = self._identity_resolver.resolve_by_posting_url(
+                tenant_id,
+                PostingUrl(value=canonical_url),
+            )
+            if direct is not None:
+                return direct.job_id
 
             row = self._conn.execute(
                 """
-                SELECT job_url FROM job_canonical_identities
-                WHERE tenant_id = ? AND canonical_url = ?
+                SELECT j.job_id
+                FROM job_canonical_identities c
+                JOIN jobs j
+                  ON j.tenant_id = c.tenant_id
+                 AND j.job_id = c.job_id
+                WHERE c.tenant_id = ? AND c.canonical_url = ?
                 LIMIT 1
                 """,
                 (str(tenant_id), canonical_url),
             ).fetchone()
             if row is not None:
-                job_url = row["job_url"] if isinstance(row, sqlite3.Row) else row[0]
-                if job_url:
-                    return JobId(str(job_url))
+                job_id = row["job_id"] if isinstance(row, sqlite3.Row) else row[0]
+                if job_id:
+                    return JobId(str(job_id))
 
             normalized = normalize_observed_url(canonical_url)
             if normalized:
                 row = self._conn.execute(
                     """
-                    SELECT job_url FROM job_source_observations
-                    WHERE tenant_id = ? AND normalized_observed_url = ?
+                    SELECT j.job_id
+                    FROM job_source_observations o
+                    JOIN jobs j
+                      ON j.tenant_id = o.tenant_id
+                     AND j.job_id = o.job_id
+                    WHERE o.tenant_id = ?
+                      AND o.normalized_observed_url = ?
                     LIMIT 1
                     """,
                     (str(tenant_id), normalized),
                 ).fetchone()
                 if row is not None:
-                    job_url = row["job_url"] if isinstance(row, sqlite3.Row) else row[0]
-                    if job_url:
-                        return JobId(str(job_url))
+                    job_id = row["job_id"] if isinstance(row, sqlite3.Row) else row[0]
+                    if job_id:
+                        return JobId(str(job_id))
 
         return None
 
@@ -530,21 +713,29 @@ class SqliteJobRepository:
         self._conn.create_function("jh_normalize_identity", 1, normalize_identity_text, deterministic=True)
         rows = self._conn.execute(
             """
-            SELECT j.url, j.title, j.company, j.site,
+            SELECT j.job_id, j.url, j.title, j.company, j.site,
                    j.description AS listing_description,
                    COALESCE(je.full_description, j.full_description)
                        AS enriched_description,
-                   CASE WHEN d.job_url IS NULL THEN 0 ELSE 1 END AS is_deleted
+                   CASE WHEN d.job_id IS NULL THEN 0 ELSE 1 END AS is_deleted
             FROM jobs j
-            LEFT JOIN job_enrichments je ON je.job_url = j.url
+            LEFT JOIN job_enrichments je
+              ON je.tenant_id = j.tenant_id
+             AND je.job_id = j.job_id
             LEFT JOIN jobctrl_deleted_jobs d
-              ON d.job_url = j.url
+              ON d.tenant_id = j.tenant_id
+             AND d.job_id = j.job_id
              AND (d.restored_at IS NULL OR julianday(d.restored_at) <= julianday(d.deleted_at))
-            WHERE jh_normalize_identity(COALESCE(j.title, '')) = ?
+            WHERE j.tenant_id = ?
+              AND jh_normalize_identity(COALESCE(j.title, '')) = ?
               AND jh_normalize_identity(COALESCE(NULLIF(j.company, ''), j.site, '')) = ?
             ORDER BY is_deleted ASC, j.discovered_at ASC NULLS LAST, j.url ASC
             """,
-            (normalize_identity_text(title), normalize_identity_text(company)),
+            (
+                str(tenant_id),
+                normalize_identity_text(title),
+                normalize_identity_text(company),
+            ),
         ).fetchall()
         for existing in rows:
             stored_company = existing["company"]
@@ -562,7 +753,7 @@ class SqliteJobRepository:
                 ),
             )
             if basis is not None:
-                return ContentOwnerMatch(job_id=JobId(str(existing["url"])), basis=basis)
+                return ContentOwnerMatch(job_id=JobId(str(existing["job_id"])), basis=basis)
         return None
 
     def attach_source_observation(
@@ -580,13 +771,15 @@ class SqliteJobRepository:
         also collapses cosmetic URL variants.
         """
 
+        identity = self._require_identity(tenant_id, job_id)
+        stable_job_id = str(identity.job_id)
         self._fence_search_unit_write()
         normalized = normalize_observed_url(observation.observed_url)
         updated = self._conn.execute(
             """
             UPDATE job_source_observations SET
                 source_observation_id = ?,
-                job_url = ?,
+                job_id = ?,
                 observed_url = ?,
                 normalized_observed_url = ?,
                 run_id = ?,
@@ -595,7 +788,7 @@ class SqliteJobRepository:
             """,
             (
                 observation.source_observation_id,
-                str(job_id),
+                stable_job_id,
                 observation.observed_url,
                 normalized,
                 observation.run_id,
@@ -610,7 +803,7 @@ class SqliteJobRepository:
                 """
                 UPDATE job_source_observations SET
                     source_observation_id = ?,
-                    job_url = ?,
+                    job_id = ?,
                     source_id = ?,
                     source_native_id = ?,
                     observed_url = ?,
@@ -620,7 +813,7 @@ class SqliteJobRepository:
                 """,
                 (
                     observation.source_observation_id,
-                    str(job_id),
+                    stable_job_id,
                     observation.source_id,
                     observation.source_native_id,
                     observation.observed_url,
@@ -634,7 +827,7 @@ class SqliteJobRepository:
             self._conn.execute(
                 """
                 INSERT INTO job_source_observations (
-                    tenant_id, source_observation_id, job_url, source_id,
+                    tenant_id, source_observation_id, job_id, source_id,
                     source_native_id, observed_url, normalized_observed_url,
                     run_id, observed_at
                 ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
@@ -642,7 +835,7 @@ class SqliteJobRepository:
                 (
                     str(tenant_id),
                     observation.source_observation_id,
-                    str(job_id),
+                    stable_job_id,
                     observation.source_id,
                     observation.source_native_id,
                     observation.observed_url,
@@ -655,7 +848,7 @@ class SqliteJobRepository:
             assert self._search_unit_lease is not None
             self._search_unit_repository.record_accepted_job(
                 self._search_unit_lease,
-                str(job_id),
+                str(identity.job_id),
                 was_new=False,
                 accepted_at=observation.observed_at,
             )
@@ -669,7 +862,7 @@ class SqliteJobRepository:
             # updated independently in ``job_source_observations`` on retries.
             self._execution_repository.link_job(
                 self._discovery_execution,
-                str(job_id),
+                stable_job_id,
                 cohort_kind="observed_this_run",
                 source_family=self._source_family,
                 source_run_id=observation.run_id,
@@ -685,14 +878,15 @@ class SqliteJobRepository:
     ) -> None:
         """Persist (or replace) the canonical identity decision for a Job."""
 
+        resolved = self._require_identity(tenant_id, job_id)
         self._fence_search_unit_write()
         self._conn.execute(
             """
             INSERT INTO job_canonical_identities (
-                tenant_id, job_url, canonical_url, ats_kind,
+                tenant_id, job_id, canonical_url, ats_kind,
                 source_native_id, confidence, resolved_at
             ) VALUES (?, ?, ?, ?, ?, ?, ?)
-            ON CONFLICT (tenant_id, job_url) DO UPDATE SET
+            ON CONFLICT (tenant_id, job_id) DO UPDATE SET
                 canonical_url = excluded.canonical_url,
                 ats_kind = excluded.ats_kind,
                 source_native_id = excluded.source_native_id,
@@ -701,7 +895,7 @@ class SqliteJobRepository:
             """,
             (
                 str(tenant_id),
-                str(job_id),
+                str(resolved.job_id),
                 identity.canonical_url,
                 identity.ats_kind.value,
                 identity.source_native_id,
@@ -718,6 +912,10 @@ class SqliteJobRepository:
     ) -> None:
         """Persist a confirmed duplicate-link audit record."""
 
+        owner = self._require_identity(
+            tenant_id,
+            JobId(link.surviving_job_id),
+        )
         self._fence_search_unit_write()
         self._conn.execute(
             """
@@ -737,7 +935,7 @@ class SqliteJobRepository:
             (
                 str(tenant_id),
                 link.duplicate_link_id,
-                link.surviving_job_id,
+                str(owner.job_id),
                 link.superseded_job_or_observation_id,
                 link.reason,
                 float(link.confidence),
@@ -764,16 +962,23 @@ class SqliteJobRepository:
         mint a fresh event row (audit noise).
         """
 
+        owner = self._require_identity(tenant_id, owner_job_id)
         self._fence_search_unit_write()
         before = self._conn.total_changes
         self._conn.execute(
             """
             INSERT INTO job_rejected_duplicate_links (
-                tenant_id, owner_job_url, candidate_url, reason, rejected_at
+                tenant_id, owner_job_id, candidate_url, reason, rejected_at
             ) VALUES (?, ?, ?, ?, ?)
-            ON CONFLICT (tenant_id, owner_job_url, candidate_url) DO NOTHING
+            ON CONFLICT (tenant_id, owner_job_id, candidate_url) DO NOTHING
             """,
-            (str(tenant_id), str(owner_job_id), str(candidate_url), reason, rejected_at),
+            (
+                str(tenant_id),
+                str(owner.job_id),
+                str(candidate_url),
+                reason,
+                rejected_at,
+            ),
         )
         self._conn.commit()
         return self._conn.total_changes > before
@@ -785,15 +990,18 @@ class SqliteJobRepository:
     ) -> list[JobSourceObservation]:
         """Read-side helper used by tests and the future Operations projection."""
 
+        identity = self.resolve_by_job_id(tenant_id, job_id)
+        if identity is None:
+            return []
         rows = self._conn.execute(
             """
             SELECT source_observation_id, source_id, source_native_id,
                    observed_url, run_id, observed_at
             FROM job_source_observations
-            WHERE tenant_id = ? AND job_url = ?
+            WHERE tenant_id = ? AND job_id = ?
             ORDER BY observed_at ASC
             """,
-            (str(tenant_id), str(job_id)),
+            (str(tenant_id), str(identity.job_id)),
         ).fetchall()
         return [
             JobSourceObservation(
@@ -814,14 +1022,17 @@ class SqliteJobRepository:
     ) -> CanonicalJobIdentity | None:
         """Read-side helper used by tests and the future Operations projection."""
 
+        identity = self.resolve_by_job_id(tenant_id, job_id)
+        if identity is None:
+            return None
         row = self._conn.execute(
             """
             SELECT canonical_url, ats_kind, source_native_id, confidence
             FROM job_canonical_identities
-            WHERE tenant_id = ? AND job_url = ?
+            WHERE tenant_id = ? AND job_id = ?
             LIMIT 1
             """,
-            (str(tenant_id), str(job_id)),
+            (str(tenant_id), str(identity.job_id)),
         ).fetchone()
         if row is None:
             return None
@@ -836,7 +1047,45 @@ class SqliteJobRepository:
     # Internals
     # ------------------------------------------------------------------
 
-    def _sync_tombstone(self, job: Job) -> None:
+    def _load_resolved(self, identity: ResolvedJobIdentity) -> Job | None:
+        row = self._conn.execute(
+            """
+            SELECT j.tenant_id, j.job_id, j.url,
+                   j.title, j.salary, j.description, j.location,
+                   j.site, j.strategy, j.discovered_at,
+                   d.deleted_at, d.reason
+            FROM jobs j
+            LEFT JOIN jobctrl_deleted_jobs d
+              ON d.tenant_id = j.tenant_id
+             AND d.job_id = j.job_id
+             AND (
+                    d.restored_at IS NULL
+                 OR julianday(d.restored_at) <= julianday(d.deleted_at)
+             )
+            WHERE j.tenant_id = ? AND j.job_id = ?
+            LIMIT 1
+            """,
+            (str(identity.tenant_id), str(identity.job_id)),
+        ).fetchone()
+        if row is None:
+            return None
+        return self._row_to_job(row, posting_url=identity.posting_url)
+
+    def _require_identity(
+        self,
+        tenant_id: TenantId,
+        job_id: JobId,
+    ) -> ResolvedJobIdentity:
+        identity = self._identity_resolver.resolve_by_job_id(tenant_id, job_id)
+        if identity is None:
+            raise LookupError(f"Unknown Job identity for tenant={tenant_id!r} job_id={job_id!r}")
+        return identity
+
+    def _sync_tombstone(
+        self,
+        job: Job,
+        identity: ResolvedJobIdentity,
+    ) -> None:
         """Reflect the aggregate's ``deleted_at`` field in the tombstone table.
 
         Called from ``save``. If the aggregate carries a deleted_at,
@@ -847,29 +1096,39 @@ class SqliteJobRepository:
         if job.deleted_at is not None:
             self._conn.execute(
                 """
-                INSERT INTO jobctrl_deleted_jobs (job_url, deleted_at, reason, restored_at)
-                VALUES (?, ?, ?, NULL)
-                ON CONFLICT(job_url) DO UPDATE SET
+                INSERT INTO jobctrl_deleted_jobs (
+                    tenant_id, job_id, deleted_at, reason, restored_at
+                )
+                VALUES (?, ?, ?, ?, NULL)
+                ON CONFLICT(tenant_id, job_id) DO UPDATE SET
                     deleted_at = excluded.deleted_at,
                     reason = excluded.reason,
                     restored_at = NULL
                 """,
-                (str(job.job_id), job.deleted_at, job.delete_reason),
+                (
+                    str(job.tenant_id),
+                    str(identity.job_id),
+                    job.deleted_at,
+                    job.delete_reason,
+                ),
             )
         else:
-            # Keep legacy active-save behaviour, but timestamp-aware
-            # readers only treat this as restored when the active row
-            # is newer than the tombstone.
             self._conn.execute(
                 "UPDATE jobctrl_deleted_jobs SET restored_at = ? "
-                "WHERE job_url = ? "
+                "WHERE tenant_id = ? AND job_id = ? "
                 "AND (restored_at IS NULL OR julianday(restored_at) <= julianday(deleted_at))",
-                (job.discovered_at, str(job.job_id)),
+                (job.discovered_at, str(job.tenant_id), str(identity.job_id)),
             )
 
     @staticmethod
-    def _row_to_job(row: Any, tenant_id: TenantId | None = None) -> Job:
+    def _row_to_job(
+        row: Any,
+        *,
+        posting_url: PostingUrl | None = None,
+    ) -> Job:
         if isinstance(row, sqlite3.Row):
+            tenant_id = row["tenant_id"]
+            job_id = row["job_id"]
             url = row["url"]
             title = row["title"]
             salary = row["salary"]
@@ -882,6 +1141,8 @@ class SqliteJobRepository:
             delete_reason = row["reason"] if "reason" in row.keys() else None
         else:
             (
+                tenant_id,
+                job_id,
                 url,
                 title,
                 salary,
@@ -901,9 +1162,9 @@ class SqliteJobRepository:
         # invariant holds.
         board = (site or "unknown").strip() or "unknown"
         return Job(
-            tenant_id=tenant_id or LOCAL_TENANT,
-            job_id=JobId(str(url)),
-            posting_url=PostingUrl(value=str(url)),
+            tenant_id=TenantId(str(tenant_id)),
+            job_id=JobId(str(job_id)),
+            posting_url=posting_url or PostingUrl(value=str(url)),
             source=Source(board=board),
             employer=Employer.unknown(),
             search_strategy=strategy,

--- a/workers/automation/src/jobctrl/infrastructure/discovery/sqlite_repository.py
+++ b/workers/automation/src/jobctrl/infrastructure/discovery/sqlite_repository.py
@@ -596,11 +596,14 @@ class SqliteJobRepository:
         the existing owner before any candidate row becomes visible.
         """
 
-        if self._conn.in_transaction:
-            raise RuntimeError("claim_new_job requires an idle SQLite connection")
+        owns_transaction = not self._conn.in_transaction
+        savepoint = "claim_new_job"
+        if owns_transaction:
+            self._conn.execute("BEGIN IMMEDIATE")
+        else:
+            self._conn.execute(f"SAVEPOINT {savepoint}")
 
         try:
-            self._conn.execute("BEGIN IMMEDIATE")
             self._fence_search_unit_write()
             owner_match = self.find_canonical_owner(
                 job.tenant_id,
@@ -609,7 +612,10 @@ class SqliteJobRepository:
                 canonical_url=identity.canonical_url,
             )
             if owner_match is not None:
-                self._conn.commit()
+                if owns_transaction:
+                    self._conn.commit()
+                else:
+                    self._conn.execute(f"RELEASE SAVEPOINT {savepoint}")
                 return owner_match
 
             candidate_job_id = canonical_job_id(str(job.job_id))
@@ -618,7 +624,10 @@ class SqliteJobRepository:
                 candidate_job_id,
             )
             if not was_new:
-                self._conn.commit()
+                if owns_transaction:
+                    self._conn.commit()
+                else:
+                    self._conn.execute(f"RELEASE SAVEPOINT {savepoint}")
                 return CanonicalOwnerMatch(
                     job_id=persisted_identity.job_id,
                     basis="canonical_url_match",
@@ -632,11 +641,22 @@ class SqliteJobRepository:
                 observation,
             )
             if owner_match is not None:
-                self._conn.rollback()
+                if owns_transaction:
+                    self._conn.rollback()
+                else:
+                    self._conn.execute(f"ROLLBACK TO SAVEPOINT {savepoint}")
+                    self._conn.execute(f"RELEASE SAVEPOINT {savepoint}")
                 return owner_match
-            self._conn.commit()
+            if owns_transaction:
+                self._conn.commit()
+            else:
+                self._conn.execute(f"RELEASE SAVEPOINT {savepoint}")
         except BaseException:
-            self._conn.rollback()
+            if owns_transaction:
+                self._conn.rollback()
+            else:
+                self._conn.execute(f"ROLLBACK TO SAVEPOINT {savepoint}")
+                self._conn.execute(f"RELEASE SAVEPOINT {savepoint}")
             raise
 
         self._record_observation_side_effects(

--- a/workers/automation/src/jobctrl/infrastructure/discovery/sqlite_repository.py
+++ b/workers/automation/src/jobctrl/infrastructure/discovery/sqlite_repository.py
@@ -66,6 +66,7 @@ from jobctrl.domain.job_content_identity import (
     normalize_identity_text,
 )
 from jobctrl.domain.ports.discovery import (
+    CanonicalOwnerMatch,
     ContentOwnerMatch,
     JobIdentityResolver,
     ResolvedJobIdentity,
@@ -581,6 +582,71 @@ class SqliteJobRepository:
         self._conn.commit()
         return restored
 
+    def claim_new_job(
+        self,
+        job: Job,
+        identity: CanonicalJobIdentity,
+        observation: JobSourceObservation,
+    ) -> CanonicalOwnerMatch | None:
+        """Atomically create ``job`` with its exact identity evidence.
+
+        A posting URL alone is not enough to establish a Job owner: source-native
+        and normalised-observation claims are also unique.  Serialising the
+        complete claim under ``BEGIN IMMEDIATE`` means a competing intake returns
+        the existing owner before any candidate row becomes visible.
+        """
+
+        if self._conn.in_transaction:
+            raise RuntimeError("claim_new_job requires an idle SQLite connection")
+
+        try:
+            self._conn.execute("BEGIN IMMEDIATE")
+            self._fence_search_unit_write()
+            owner_match = self.find_canonical_owner(
+                job.tenant_id,
+                source_id=observation.source_id,
+                source_native_id=observation.source_native_id,
+                canonical_url=identity.canonical_url,
+            )
+            if owner_match is not None:
+                self._conn.commit()
+                return owner_match
+
+            candidate_job_id = canonical_job_id(str(job.job_id))
+            persisted_identity, was_new = self._insert_or_resolve_winner(
+                job,
+                candidate_job_id,
+            )
+            if not was_new:
+                self._conn.commit()
+                return CanonicalOwnerMatch(
+                    job_id=persisted_identity.job_id,
+                    basis="canonical_url_match",
+                )
+
+            self._sync_tombstone(job, persisted_identity)
+            self._set_canonical_identity(persisted_identity, identity)
+            owner_match = self._attach_source_observation(
+                job.tenant_id,
+                persisted_identity,
+                observation,
+            )
+            if owner_match is not None:
+                self._conn.rollback()
+                return owner_match
+            self._conn.commit()
+        except BaseException:
+            self._conn.rollback()
+            raise
+
+        self._record_observation_side_effects(
+            tenant_id=job.tenant_id,
+            job_id=persisted_identity.job_id,
+            observation=observation,
+            was_new=True,
+        )
+        return None
+
     # ------------------------------------------------------------------
     # PR 2: canonical identity, source observations, duplicate links
     # ------------------------------------------------------------------
@@ -592,7 +658,7 @@ class SqliteJobRepository:
         source_id: str,
         source_native_id: str,
         canonical_url: str,
-    ) -> JobId | None:
+    ) -> CanonicalOwnerMatch | None:
         """Look up the canonical Job for an incoming posting identity.
 
         Resolution order matches the RFC §"Recommended identity checks":
@@ -618,7 +684,10 @@ class SqliteJobRepository:
             if row is not None:
                 job_id = row["job_id"] if isinstance(row, sqlite3.Row) else row[0]
                 if job_id:
-                    return JobId(str(job_id))
+                    return CanonicalOwnerMatch(
+                        job_id=JobId(str(job_id)),
+                        basis="source_native_id_match",
+                    )
 
         if canonical_url:
             direct = self._identity_resolver.resolve_by_posting_url(
@@ -626,7 +695,10 @@ class SqliteJobRepository:
                 PostingUrl(value=canonical_url),
             )
             if direct is not None:
-                return direct.job_id
+                return CanonicalOwnerMatch(
+                    job_id=direct.job_id,
+                    basis="canonical_url_match",
+                )
 
             row = self._conn.execute(
                 """
@@ -643,7 +715,10 @@ class SqliteJobRepository:
             if row is not None:
                 job_id = row["job_id"] if isinstance(row, sqlite3.Row) else row[0]
                 if job_id:
-                    return JobId(str(job_id))
+                    return CanonicalOwnerMatch(
+                        job_id=JobId(str(job_id)),
+                        basis="canonical_url_match",
+                    )
 
             normalized = normalize_observed_url(canonical_url)
             if normalized:
@@ -663,7 +738,10 @@ class SqliteJobRepository:
                 if row is not None:
                     job_id = row["job_id"] if isinstance(row, sqlite3.Row) else row[0]
                     if job_id:
-                        return JobId(str(job_id))
+                        return CanonicalOwnerMatch(
+                            job_id=JobId(str(job_id)),
+                            basis="normalized_observation_match",
+                        )
 
         return None
 
@@ -761,7 +839,7 @@ class SqliteJobRepository:
         tenant_id: TenantId,
         job_id: JobId,
         observation: JobSourceObservation,
-    ) -> None:
+    ) -> CanonicalOwnerMatch | None:
         """Persist or replace an observation row.
 
         Idempotent on ``(tenant_id, source_id, source_native_id)``: if
@@ -772,8 +850,46 @@ class SqliteJobRepository:
         """
 
         identity = self._require_identity(tenant_id, job_id)
+        try:
+            self._fence_search_unit_write()
+            owner_match = self._attach_source_observation(
+                tenant_id,
+                identity,
+                observation,
+            )
+            self._conn.commit()
+        except BaseException:
+            self._conn.rollback()
+            raise
+
+        if owner_match is not None:
+            return owner_match
+        self._record_observation_side_effects(
+            tenant_id=tenant_id,
+            job_id=identity.job_id,
+            observation=observation,
+            was_new=False,
+        )
+        return None
+
+    def _attach_source_observation(
+        self,
+        tenant_id: TenantId,
+        identity: ResolvedJobIdentity,
+        observation: JobSourceObservation,
+    ) -> CanonicalOwnerMatch | None:
+        """Write an observation only when this Job already owns its claims."""
+
+        owner_match = self._find_observation_owner(
+            tenant_id,
+            source_id=observation.source_id,
+            source_native_id=observation.source_native_id,
+            observed_url=observation.observed_url,
+        )
+        if owner_match is not None and owner_match.job_id != identity.job_id:
+            return owner_match
+
         stable_job_id = str(identity.job_id)
-        self._fence_search_unit_write()
         normalized = normalize_observed_url(observation.observed_url)
         updated = self._conn.execute(
             """
@@ -807,6 +923,7 @@ class SqliteJobRepository:
                     source_id = ?,
                     source_native_id = ?,
                     observed_url = ?,
+                    normalized_observed_url = ?,
                     run_id = ?,
                     observed_at = ?
                 WHERE tenant_id = ? AND normalized_observed_url = ?
@@ -817,6 +934,7 @@ class SqliteJobRepository:
                     observation.source_id,
                     observation.source_native_id,
                     observation.observed_url,
+                    normalized,
                     observation.run_id,
                     observation.observed_at,
                     str(tenant_id),
@@ -844,12 +962,22 @@ class SqliteJobRepository:
                     observation.observed_at,
                 ),
             )
+        return None
+
+    def _record_observation_side_effects(
+        self,
+        *,
+        tenant_id: TenantId,
+        job_id: JobId,
+        observation: JobSourceObservation,
+        was_new: bool,
+    ) -> None:
         if self._search_unit_repository is not None:
             assert self._search_unit_lease is not None
             self._search_unit_repository.record_accepted_job(
                 self._search_unit_lease,
-                str(identity.job_id),
-                was_new=False,
+                str(job_id),
+                was_new=was_new,
                 accepted_at=observation.observed_at,
             )
         if self._execution_repository is not None:
@@ -862,13 +990,12 @@ class SqliteJobRepository:
             # updated independently in ``job_source_observations`` on retries.
             self._execution_repository.link_job(
                 self._discovery_execution,
-                stable_job_id,
+                str(job_id),
                 cohort_kind="observed_this_run",
                 source_family=self._source_family,
                 source_run_id=observation.run_id,
                 linked_at=observation.observed_at,
             )
-        self._conn.commit()
 
     def set_canonical_identity(
         self,
@@ -880,6 +1007,14 @@ class SqliteJobRepository:
 
         resolved = self._require_identity(tenant_id, job_id)
         self._fence_search_unit_write()
+        self._set_canonical_identity(resolved, identity)
+        self._conn.commit()
+
+    def _set_canonical_identity(
+        self,
+        resolved: ResolvedJobIdentity,
+        identity: CanonicalJobIdentity,
+    ) -> None:
         self._conn.execute(
             """
             INSERT INTO job_canonical_identities (
@@ -894,7 +1029,7 @@ class SqliteJobRepository:
                 resolved_at = excluded.resolved_at
             """,
             (
-                str(tenant_id),
+                str(resolved.tenant_id),
                 str(resolved.job_id),
                 identity.canonical_url,
                 identity.ats_kind.value,
@@ -903,7 +1038,53 @@ class SqliteJobRepository:
                 datetime.now(timezone.utc).isoformat(),
             ),
         )
-        self._conn.commit()
+
+    def _find_observation_owner(
+        self,
+        tenant_id: TenantId,
+        *,
+        source_id: str,
+        source_native_id: str,
+        observed_url: str,
+    ) -> CanonicalOwnerMatch | None:
+        """Resolve the unique observation claims in the same priority as intake."""
+
+        if source_id and source_native_id:
+            row = self._conn.execute(
+                """
+                SELECT job_id
+                FROM job_source_observations
+                WHERE tenant_id = ? AND source_id = ? AND source_native_id = ?
+                LIMIT 1
+                """,
+                (str(tenant_id), source_id, source_native_id),
+            ).fetchone()
+            if row is not None:
+                job_id = row["job_id"] if isinstance(row, sqlite3.Row) else row[0]
+                return CanonicalOwnerMatch(
+                    job_id=JobId(str(job_id)),
+                    basis="source_native_id_match",
+                )
+
+        normalized = normalize_observed_url(observed_url)
+        if not normalized:
+            return None
+        row = self._conn.execute(
+            """
+            SELECT job_id
+            FROM job_source_observations
+            WHERE tenant_id = ? AND normalized_observed_url = ?
+            LIMIT 1
+            """,
+            (str(tenant_id), normalized),
+        ).fetchone()
+        if row is None:
+            return None
+        job_id = row["job_id"] if isinstance(row, sqlite3.Row) else row[0]
+        return CanonicalOwnerMatch(
+            job_id=JobId(str(job_id)),
+            basis="normalized_observation_match",
+        )
 
     def record_duplicate_link(
         self,

--- a/workers/automation/src/jobctrl/infrastructure/discovery/sqlite_repository.py
+++ b/workers/automation/src/jobctrl/infrastructure/discovery/sqlite_repository.py
@@ -9,12 +9,17 @@ table:
   ``job_id``        — stable, system-generated aggregate identifier.
   ``url``           — current posting locator, unique but never identity.
   ``title``,
+  ``company``        — ``Job.employer.name`` when known.
   ``salary``,
   ``description``,
   ``location``      — ``Job.metadata`` value object fields.
   ``site``          — ``Job.source.board``.
   ``strategy``      — ``Job.search_strategy.value``.
   ``discovered_at`` — ``Job.discovered_at``.
+
+Employer and source are independent canonical facts: ``company`` never falls
+back to ``site`` (or to a URL), and an empty ``company`` hydrates as
+``Employer.unknown()``.
 
 Soft-delete state lives in the existing ``jobctrl_deleted_jobs``
 tombstone table (mirror of the API's
@@ -23,13 +28,6 @@ reads/writes that exact-v7 table directly so a
 worker-side delete and an API-side delete share the same tombstone row
 shape.
 
-The legacy ``Job.employer`` is **not** persisted here this phase: the
-``jobs`` table has no dedicated employer column (the legacy code
-conflates employer with ``site``). The adapter writes ``employer.name``
-into ``site`` only when ``source.board`` is empty — but since the
-``Source.board`` invariant is non-empty, ``site`` always carries the
-board. ``employer`` round-trips on the in-memory aggregate; persisting
-it natively is deferred to the table-narrowing PR called out by §8.
 """
 
 from __future__ import annotations
@@ -182,7 +180,7 @@ class SqliteJobRepository:
         if not include_deleted:
             sql = (
                 "SELECT j.tenant_id, j.job_id, j.url, "
-                "j.title, j.salary, j.description, j.location, "
+                "j.title, j.company, j.salary, j.description, j.location, "
                 "j.site, j.strategy, j.discovered_at, "
                 "d.deleted_at, d.reason "
                 "FROM jobs j "
@@ -195,7 +193,7 @@ class SqliteJobRepository:
         else:
             sql = (
                 "SELECT j.tenant_id, j.job_id, j.url, "
-                "j.title, j.salary, j.description, j.location, "
+                "j.title, j.company, j.salary, j.description, j.location, "
                 "j.site, j.strategy, j.discovered_at, "
                 "d.deleted_at, d.reason "
                 "FROM jobs j "
@@ -781,16 +779,12 @@ class SqliteJobRepository:
         The returned :class:`ContentOwnerMatch` records which of the two paths
         matched so the write boundary logs an honest duplicate-link reason.
 
-        Content merges MUST key on a genuine employer on BOTH sides, otherwise
-        two DISTINCT employers' postings would collapse into one Job (silent
-        data loss). ``jobs.company`` is empty for use-case-created rows, so the
-        stored employer coalesces to ``jobs.site`` (the board, which is the real
-        employer for ATS-owned rows) — but a platform/sentinel board
-        ("User-mediated capture", the "Workday" fallback, a JobSpy board, or the
-        ``Unknown`` sentinel) is shared across employers and must not be treated
-        as an employer key. When either side lacks a genuine employer this falls
-        through to ``None`` (a safe under-merge). Returns ``None`` when the
-        posting cannot be fingerprinted or no existing Job matches.
+        Content merges MUST key on a genuine canonical employer on BOTH sides,
+        otherwise two DISTINCT employers' postings would collapse into one Job
+        (silent data loss). ``jobs.site`` is only the source board and is never an
+        employer fallback. When either side lacks a genuine employer this falls
+        through to ``None`` (a safe under-merge). Returns ``None`` when the posting
+        cannot be fingerprinted or no existing Job matches.
 
         The incoming posting is a raw LISTING, so the match compares it against
         BOTH the stored listing (``jobs.description``) and the stored enriched
@@ -811,7 +805,7 @@ class SqliteJobRepository:
         self._conn.create_function("jh_normalize_identity", 1, normalize_identity_text, deterministic=True)
         rows = self._conn.execute(
             """
-            SELECT j.job_id, j.url, j.title, j.company, j.site,
+            SELECT j.job_id, j.url, j.title, j.company,
                    j.description AS listing_description,
                    COALESCE(je.full_description, j.full_description)
                        AS enriched_description,
@@ -826,7 +820,7 @@ class SqliteJobRepository:
              AND (d.restored_at IS NULL OR julianday(d.restored_at) <= julianday(d.deleted_at))
             WHERE j.tenant_id = ?
               AND jh_normalize_identity(COALESCE(j.title, '')) = ?
-              AND jh_normalize_identity(COALESCE(NULLIF(j.company, ''), j.site, '')) = ?
+              AND jh_normalize_identity(COALESCE(j.company, '')) = ?
             ORDER BY is_deleted ASC, j.discovered_at ASC NULLS LAST, j.url ASC
             """,
             (
@@ -836,8 +830,7 @@ class SqliteJobRepository:
             ),
         ).fetchall()
         for existing in rows:
-            stored_company = existing["company"]
-            stored_employer = stored_company if stored_company else existing["site"]
+            stored_employer = existing["company"]
             if not is_genuine_employer_identity(stored_employer):
                 continue
             basis = content_match_basis(
@@ -1252,7 +1245,7 @@ class SqliteJobRepository:
         row = self._conn.execute(
             """
             SELECT j.tenant_id, j.job_id, j.url,
-                   j.title, j.salary, j.description, j.location,
+                   j.title, j.company, j.salary, j.description, j.location,
                    j.site, j.strategy, j.discovered_at,
                    d.deleted_at, d.reason
             FROM jobs j
@@ -1332,6 +1325,7 @@ class SqliteJobRepository:
             job_id = row["job_id"]
             url = row["url"]
             title = row["title"]
+            company = row["company"]
             salary = row["salary"]
             description = row["description"]
             location = row["location"]
@@ -1346,6 +1340,7 @@ class SqliteJobRepository:
                 job_id,
                 url,
                 title,
+                company,
                 salary,
                 description,
                 location,
@@ -1362,12 +1357,13 @@ class SqliteJobRepository:
         # fall back to the sentinel "unknown" so the value object
         # invariant holds.
         board = (site or "unknown").strip() or "unknown"
+        employer_name = str(company or "").strip()
         return Job(
             tenant_id=TenantId(str(tenant_id)),
             job_id=JobId(str(job_id)),
             posting_url=posting_url or PostingUrl(value=str(url)),
             source=Source(board=board),
-            employer=Employer.unknown(),
+            employer=(Employer(name=employer_name) if employer_name else Employer.unknown()),
             search_strategy=strategy,
             metadata=JobMetadata(
                 title=str(title or ""),

--- a/workers/automation/src/jobctrl/infrastructure/observability/adapter_spans.py
+++ b/workers/automation/src/jobctrl/infrastructure/observability/adapter_spans.py
@@ -63,7 +63,7 @@ def adapter_fetch_span(
 def canonicalize_span(
     *,
     tenant_id: str,
-    job_id: str,
+    job_id: str | None,
     source_id: str,
     canonical_url_present: bool,
     ats_kind: str,
@@ -76,7 +76,8 @@ def canonicalize_span(
     with tracer.start_as_current_span("discovery.canonicalize") as span:
         span.set_attribute("langfuse.observation.type", "span")
         span.set_attribute("tenant.id", tenant_id)
-        span.set_attribute("job.id", job_id)
+        if job_id is not None:
+            span.set_attribute("job.id", job_id)
         span.set_attribute("source.id", source_id)
         span.set_attribute("canonical.url.present", bool(canonical_url_present))
         span.set_attribute("ats.kind", ats_kind)

--- a/workers/automation/tests/test_ats_adapters.py
+++ b/workers/automation/tests/test_ats_adapters.py
@@ -62,7 +62,8 @@ def test_workday_adapter_maps_cxs_payload_to_scraped_posting() -> None:
     posting = postings[0]
     assert posting.metadata.title == "Senior Platform Engineer"
     assert posting.metadata.location == "Remote, United States"
-    assert posting.source.board == "Acme Corp"
+    assert posting.source.board == "workday"
+    assert posting.employer.name == "Acme Corp"
     assert posting.source_id == "workday:acme"
     assert posting.source_native_id == "Senior-Platform-Engineer_JR-123"
     assert posting.canonical_url == (
@@ -164,7 +165,7 @@ def test_greenhouse_adapter_maps_job_board_payload_to_scraped_posting() -> None:
                     "title": "Staff Backend Engineer",
                     "absolute_url": "https://boards.greenhouse.io/acme/jobs/123456",
                     "location": {"name": "Remote"},
-                    "company_name": "Acme Corp",
+                    "company_name": "Acme",
                     "content": "&lt;p&gt;Build backend systems for the platform team.&lt;/p&gt;",
                 }
             ]
@@ -183,7 +184,8 @@ def test_greenhouse_adapter_maps_job_board_payload_to_scraped_posting() -> None:
     assert posting.metadata.title == "Staff Backend Engineer"
     assert posting.metadata.location == "Remote"
     assert posting.metadata.description == "Build backend systems for the platform team."
-    assert posting.source.board == "Acme Corp"
+    assert posting.source.board == "greenhouse"
+    assert posting.employer.name == "Acme"
     assert posting.source_id == "greenhouse:acme"
     assert posting.source_native_id == "123456"
     assert posting.canonical_url == "https://boards.greenhouse.io/acme/jobs/123456"
@@ -245,7 +247,8 @@ def test_lever_adapter_maps_postings_payload_to_scraped_posting() -> None:
     assert posting.metadata.title == "Product Platform Engineer"
     assert posting.metadata.location == "Remote"
     assert posting.metadata.description == "Own the product platform roadmap. Lead cross-functional delivery."
-    assert posting.source.board == "Acme Corp"
+    assert posting.source.board == "lever"
+    assert posting.employer.name == "Acme Corp"
     assert posting.source_id == "lever:acme"
     assert posting.source_native_id == "lever-posting-1"
     assert posting.canonical_url == "https://jobs.lever.co/acme/lever-posting-1"
@@ -306,7 +309,8 @@ def test_ashby_adapter_maps_public_board_payload_to_scraped_posting() -> None:
     assert posting.metadata.title == "Infrastructure Engineer"
     assert posting.metadata.location == "Remote"
     assert posting.metadata.description == "Operate infrastructure systems."
-    assert posting.source.board == "Acme Corp"
+    assert posting.source.board == "ashby"
+    assert posting.employer.name == "Acme Corp"
     assert posting.source_id == "ashby:acme"
     assert posting.source_native_id == "ashby-posting-1"
     assert posting.canonical_url == "https://jobs.ashbyhq.com/acme/ashby-posting-1"

--- a/workers/automation/tests/test_discovery_identity.py
+++ b/workers/automation/tests/test_discovery_identity.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import sqlite3
+import threading
 import uuid
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import pytest
@@ -288,33 +290,257 @@ def test_find_canonical_owner_resolves_native_identity_then_canonical_and_observ
     persisted = repo.load(LOCAL_TENANT, job.job_id)
     assert persisted is not None
 
-    assert (
-        repo.find_canonical_owner(
-            LOCAL_TENANT,
-            source_id="greenhouse:acme",
-            source_native_id="123",
-            canonical_url="",
-        )
-        == persisted.job_id
+    native_match = repo.find_canonical_owner(
+        LOCAL_TENANT,
+        source_id="greenhouse:acme",
+        source_native_id="123",
+        canonical_url="",
     )
-    assert (
-        repo.find_canonical_owner(
-            LOCAL_TENANT,
-            source_id="ashby:acme",
-            source_native_id="different",
-            canonical_url="https://boards.greenhouse.io/acme/jobs/123",
-        )
-        == persisted.job_id
+    assert native_match is not None
+    assert native_match.job_id == persisted.job_id
+    assert native_match.basis == "source_native_id_match"
+
+    canonical_match = repo.find_canonical_owner(
+        LOCAL_TENANT,
+        source_id="ashby:acme",
+        source_native_id="different",
+        canonical_url="https://boards.greenhouse.io/acme/jobs/123",
     )
-    assert (
-        repo.find_canonical_owner(
-            LOCAL_TENANT,
-            source_id="ashby:acme",
-            source_native_id="different",
-            canonical_url="https://boards.greenhouse.io/acme/jobs/123?gh_jid=123",
-        )
-        == persisted.job_id
+    assert canonical_match is not None
+    assert canonical_match.job_id == persisted.job_id
+    assert canonical_match.basis == "canonical_url_match"
+
+    observation_match = repo.find_canonical_owner(
+        LOCAL_TENANT,
+        source_id="ashby:acme",
+        source_native_id="different",
+        canonical_url="https://boards.greenhouse.io/acme/jobs/123?gh_jid=123",
     )
+    assert observation_match is not None
+    assert observation_match.job_id == persisted.job_id
+    assert observation_match.basis == "normalized_observation_match"
+
+
+def _concurrent_discovery_claims(
+    tmp_path: Path,
+    postings: tuple[ScrapedJobPosting, ScrapedJobPosting],
+) -> tuple[list[sqlite3.Row], list[sqlite3.Row], list[list[DomainEvent]]]:
+    """Run two independent intake connections past the initial read together."""
+
+    db_path = tmp_path / "concurrent-discovery.db"
+    initialized = init_db(db_path)
+    initialized.close()
+    barrier = threading.Barrier(2)
+
+    class BarrierRepository(SqliteJobRepository):
+        def __init__(self, connection: sqlite3.Connection) -> None:
+            super().__init__(connection)
+            self._waited = False
+
+        def find_canonical_owner(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+            result = super().find_canonical_owner(*args, **kwargs)
+            if result is None and not self._waited:
+                self._waited = True
+                barrier.wait(timeout=5)
+            return result
+
+    connections = [
+        sqlite3.connect(db_path, timeout=10, check_same_thread=False)
+        for _ in range(2)
+    ]
+    for connection in connections:
+        connection.row_factory = sqlite3.Row
+        connection.execute("PRAGMA foreign_keys = ON")
+        connection.execute("PRAGMA busy_timeout = 10000")
+    repositories = [BarrierRepository(connection) for connection in connections]
+    publishers = [RecordingPublisher(), RecordingPublisher()]
+    job_ids = (
+        JobId("3cce0d51-37a9-4b2d-a73d-7843ff268d28"),
+        JobId("1afb2b31-1b6b-4b09-94d4-0bf5702e88de"),
+    )
+    use_cases = [
+        DiscoverJobsUseCase(
+            repository=repositories[index],
+            publisher=publishers[index],
+            clock=lambda: "2026-05-12T00:00:00Z",
+            job_id_factory=lambda index=index: job_ids[index],
+        )
+        for index in range(2)
+    ]
+
+    try:
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            list(
+                executor.map(
+                    lambda index: use_cases[index].execute(
+                        tenant_id=LOCAL_TENANT,
+                        postings=[postings[index]],
+                        run_id=f"run-{index}",
+                    ),
+                    range(2),
+                )
+            )
+        check = sqlite3.connect(db_path)
+        check.row_factory = sqlite3.Row
+        try:
+            jobs = check.execute("SELECT job_id, url FROM jobs ORDER BY job_id").fetchall()
+            observations = check.execute(
+                """
+                SELECT job_id, source_id, source_native_id, observed_url
+                FROM job_source_observations
+                ORDER BY source_id, source_native_id
+                """
+            ).fetchall()
+        finally:
+            check.close()
+    finally:
+        for connection in connections:
+            connection.close()
+
+    return jobs, observations, [publisher.events for publisher in publishers]
+
+
+def test_concurrent_source_native_claim_preserves_one_owner_and_native_audit(
+    tmp_path: Path,
+) -> None:
+    jobs, observations, event_batches = _concurrent_discovery_claims(
+        tmp_path,
+        (
+            _posting(
+                canonical_url="https://boards.greenhouse.io/acme/jobs/platform-a",
+                source_id="greenhouse:acme",
+                source_native_id="platform-123",
+            ),
+            _posting(
+                canonical_url="https://boards.greenhouse.io/acme/jobs/platform-b",
+                source_id="greenhouse:acme",
+                source_native_id="platform-123",
+            ),
+        ),
+    )
+
+    assert len(jobs) == 1
+    assert len(observations) == 1
+    assert observations[0]["job_id"] == jobs[0]["job_id"]
+    assert observations[0]["source_native_id"] == "platform-123"
+    events = [event for batch in event_batches for event in batch]
+    assert sum(event.event_type == "JobSourceObserved" for event in events) == 2
+    links = [event for event in events if event.event_type == "DuplicateJobLinked"]
+    assert len(links) == 1
+    assert links[0].payload["surviving_job_id"] == jobs[0]["job_id"]
+    assert links[0].payload["reason"] == "source_native_id_match"
+
+
+def test_concurrent_normalized_observation_claim_preserves_one_owner_without_rehoming(
+    tmp_path: Path,
+) -> None:
+    jobs, observations, event_batches = _concurrent_discovery_claims(
+        tmp_path,
+        (
+            _posting(
+                canonical_url="https://boards.greenhouse.io/acme/jobs/platform?utm_source=one",
+                source_id="broad-board:one",
+                source_native_id="platform-one",
+            ),
+            _posting(
+                canonical_url="https://boards.greenhouse.io/acme/jobs/platform?gh_src=two",
+                source_id="broad-board:two",
+                source_native_id="platform-two",
+            ),
+        ),
+    )
+
+    assert len(jobs) == 1
+    assert len(observations) == 1
+    assert observations[0]["job_id"] == jobs[0]["job_id"]
+    events = [event for batch in event_batches for event in batch]
+    assert sum(event.event_type == "JobSourceObserved" for event in events) == 2
+    # These URLs normalise to the owner's current posting URL, so the second
+    # source is a refresh rather than a distinct duplicate-link audit.
+    assert [event for event in events if event.event_type == "DuplicateJobLinked"] == []
+
+
+def test_duplicate_audit_uses_the_exact_canonical_owner_basis(
+    conn: sqlite3.Connection,
+) -> None:
+    repo = SqliteJobRepository(conn)
+    publisher = RecordingPublisher()
+    use_case = DiscoverJobsUseCase(
+        repository=repo,
+        publisher=publisher,
+        clock=lambda: "2026-05-12T00:00:00Z",
+    )
+    primary_url = "https://boards.greenhouse.io/acme/jobs/platform"
+    canonical_alias = "https://careers.acme.example/jobs/platform"
+    observation_alias = "https://jobs.acme.example/openings/platform"
+
+    use_case.execute(
+        tenant_id=LOCAL_TENANT,
+        postings=[
+            _posting(
+                canonical_url=primary_url,
+                source_id="greenhouse:acme",
+                source_native_id="platform-primary",
+            )
+        ],
+        run_id="run-primary",
+    )
+    owner = repo.resolve_by_posting_url(LOCAL_TENANT, PostingUrl(value=primary_url))
+    assert owner is not None
+    repo.set_canonical_identity(
+        LOCAL_TENANT,
+        owner.job_id,
+        CanonicalJobIdentity(
+            canonical_url=canonical_alias,
+            ats_kind=AtsKind.GREENHOUSE,
+            source_native_id="platform-primary",
+            confidence=0.9,
+        ),
+    )
+    use_case.execute(
+        tenant_id=LOCAL_TENANT,
+        postings=[
+            _posting(
+                canonical_url=canonical_alias,
+                source_id="ashby:acme",
+                source_native_id="platform-canonical",
+                ats_kind=AtsKind.ASHBY,
+            )
+        ],
+        run_id="run-canonical",
+    )
+    repo.attach_source_observation(
+        LOCAL_TENANT,
+        owner.job_id,
+        JobSourceObservation(
+            source_observation_id="observation-alias",
+            source_id="broad-board:acme",
+            source_native_id="platform-observation",
+            observed_url=observation_alias,
+            run_id="run-observation-seed",
+            observed_at="2026-05-12T00:00:00Z",
+        ),
+    )
+    use_case.execute(
+        tenant_id=LOCAL_TENANT,
+        postings=[
+            _posting(
+                canonical_url=f"{observation_alias}?utm_source=feed",
+                source_id="lever:acme",
+                source_native_id="platform-normalized",
+                ats_kind=AtsKind.LEVER,
+            )
+        ],
+        run_id="run-observation",
+    )
+
+    reasons = [
+        row["reason"]
+        for row in conn.execute(
+            "SELECT reason FROM job_duplicate_links ORDER BY linked_at, duplicate_link_id"
+        ).fetchall()
+    ]
+    assert set(reasons) == {"canonical_url_match", "normalized_observation_match"}
 
 
 def test_duplicate_links_are_persisted(conn: sqlite3.Connection) -> None:
@@ -536,10 +762,10 @@ def test_discover_jobs_use_case_observes_existing_job_and_links_duplicate(
     assert len(domain_links) == 1
     assert domain_links[0].surviving_job_id == str(owner.job_id)
     assert duplicate.payload["surviving_job_id"] == str(owner.job_id)
-    assert duplicate.payload["reason"] == "canonical_url_match"
+    assert duplicate.payload["reason"] == "source_native_id_match"
     duplicate_row = conn.execute("SELECT reason FROM job_duplicate_links").fetchone()
     assert duplicate_row is not None
-    assert duplicate_row["reason"] == "canonical_url_match"
+    assert duplicate_row["reason"] == "source_native_id_match"
 
 
 def test_discover_jobs_use_case_resurfaces_soft_deleted_existing_job(
@@ -1397,7 +1623,7 @@ def test_discover_jobs_use_case_prefers_native_identity_over_content_match(
     assert summary.duplicates_linked == 1
     assert conn.execute("SELECT COUNT(*) FROM jobs").fetchone()[0] == 1
     link = conn.execute("SELECT reason, confidence FROM job_duplicate_links").fetchone()
-    assert link["reason"] == "canonical_url_match"
+    assert link["reason"] == "source_native_id_match"
     assert link["confidence"] == 0.9
 
 

--- a/workers/automation/tests/test_discovery_identity.py
+++ b/workers/automation/tests/test_discovery_identity.py
@@ -28,7 +28,9 @@ from jobctrl.domain.job_content_identity import is_genuine_employer_identity
 from jobctrl.domain.ports.discovery import ScrapedJobPosting
 from jobctrl.domain.ports.events import EventHandler, Subscription
 from jobctrl.domain.tenant import LOCAL_TENANT, TenantId
+from jobctrl.discovery.jobspy import _record_jobspy_source_observation
 from jobctrl.infrastructure.discovery import SqliteJobRepository
+from jobctrl.infrastructure.discovery import production_wiring
 
 
 @pytest.fixture
@@ -156,6 +158,102 @@ def test_locator_resolution_does_not_treat_observation_urls_as_job_ids(conn: sql
     assert found is None
     canonical = repo.load(LOCAL_TENANT, job.job_id)
     assert canonical is not None
+
+
+def test_jobspy_source_observation_resolves_canonical_job_id_at_url_boundary(
+    conn: sqlite3.Connection,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    job = _job("https://www.linkedin.com/jobs/view/123")
+    SqliteJobRepository(conn).save(job)
+    recorded_events: list[tuple[JobId, str, str, dict[str, object]]] = []
+
+    def record_event(
+        _conn: sqlite3.Connection,
+        job_id: JobId,
+        stage: str,
+        event_type: str,
+        **kwargs: object,
+    ) -> None:
+        payload = kwargs.get("payload")
+        assert isinstance(payload, dict)
+        recorded_events.append((job_id, stage, event_type, payload))
+
+    monkeypatch.setattr("jobctrl.state.record_job_event", record_event)
+
+    _record_jobspy_source_observation(
+        conn,
+        job_url=job.posting_url.value,
+        observed_url="https://www.linkedin.com/jobs/view/123?tracking=feed",
+        source_id="jobspy:linkedin",
+        run_id="jobspy:run-1",
+        observed_at="2026-05-12T01:00:00Z",
+    )
+
+    observation = conn.execute(
+        """
+        SELECT job_id
+        FROM job_source_observations
+        WHERE tenant_id = ? AND source_id = ?
+        """,
+        (
+            str(LOCAL_TENANT),
+            "jobspy:linkedin",
+        ),
+    ).fetchone()
+    assert observation is not None
+    assert observation["job_id"] == str(job.job_id)
+    assert len(recorded_events) == 1
+    assert recorded_events[0][:3] == (
+        job.job_id,
+        "discover",
+        "JobSourceObserved",
+    )
+    assert recorded_events[0][3]["job_id"] == str(job.job_id)
+    assert recorded_events[0][3]["jobId"] == str(job.job_id)
+
+
+def test_source_learning_resolves_canonical_job_id_at_url_boundary(
+    conn: sqlite3.Connection,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    job = _job("https://www.linkedin.com/jobs/view/456")
+    SqliteJobRepository(conn).save(job)
+    resolved_events: list[JobId] = []
+
+    monkeypatch.setattr(production_wiring, "ensure_worker_discovery_tables", lambda _conn: None)
+    monkeypatch.setattr(
+        production_wiring,
+        "_record_canonical_identity_resolved_event",
+        lambda _conn, *, job_id, **_kwargs: resolved_events.append(job_id),
+    )
+    monkeypatch.setattr(
+        production_wiring,
+        "_source_id_from_locator_candidate",
+        lambda _conn, _candidate: "greenhouse:acme",
+    )
+    monkeypatch.setattr(
+        production_wiring,
+        "_promote_locator_candidate",
+        lambda _conn, _candidate, **_kwargs: True,
+    )
+
+    learned = production_wiring.learn_posting_source_from_url(
+        conn,
+        job_url=job.posting_url.value,
+        posting_url="https://boards.greenhouse.io/acme/jobs/456",
+        discovered_via_source_id="jobspy:linkedin",
+        observed_at="2026-05-12T01:00:00Z",
+    )
+
+    stored = conn.execute(
+        "SELECT job_id FROM job_canonical_identities WHERE tenant_id = ?",
+        (str(LOCAL_TENANT),),
+    ).fetchone()
+    assert stored is not None
+    assert stored["job_id"] == str(job.job_id)
+    assert resolved_events == [job.job_id]
+    assert learned.action == "promoted"
 
 
 def _job_id_for_url(repo: SqliteJobRepository, url: str) -> JobId:

--- a/workers/automation/tests/test_discovery_identity.py
+++ b/workers/automation/tests/test_discovery_identity.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 import sqlite3
+import uuid
 from pathlib import Path
 
 import pytest
 
-from jobctrl.database import ensure_source_observation_tables, init_db
+from jobctrl.database import init_db
 from jobctrl.domain.discovery import (
     AtsKind,
     CanonicalJobIdentity,
@@ -24,9 +25,8 @@ from jobctrl.domain.identifiers import JobId
 from jobctrl.domain.job_content_identity import is_genuine_employer_identity
 from jobctrl.domain.ports.discovery import ScrapedJobPosting
 from jobctrl.domain.ports.events import EventHandler, Subscription
-from jobctrl.domain.tenant import LOCAL_TENANT
+from jobctrl.domain.tenant import LOCAL_TENANT, TenantId
 from jobctrl.infrastructure.discovery import SqliteJobRepository
-from jobctrl.infrastructure.compensation import SqlitePostedCompensationRepository
 
 
 @pytest.fixture
@@ -46,10 +46,14 @@ class RecordingPublisher:
         return Subscription(lambda: None)
 
 
+def _job_id(url: str) -> JobId:
+    return JobId(str(uuid.uuid5(uuid.NAMESPACE_URL, url)))
+
+
 def _job(url: str = "https://boards.greenhouse.io/acme/jobs/123") -> Job:
     return Job.discover(
         tenant_id=LOCAL_TENANT,
-        job_id=JobId(url),
+        job_id=_job_id(url),
         posting_url=PostingUrl(value=url),
         source=Source(board="greenhouse"),
         employer=Employer.unknown(),
@@ -95,14 +99,22 @@ def _seed_jobspy_job(
     """Seed a job the way JobSpy persists it: company column set, board in ``site``."""
 
     conn.execute(
-        "INSERT INTO jobs (url, title, company, salary, description, location, site, strategy, discovered_at) "
-        "VALUES (?, ?, ?, '', ?, 'Remote', ?, 'jobspy', ?)",
-        (url, title, company, description, site, discovered_at),
+        "INSERT INTO jobs (tenant_id, job_id, url, title, company, salary, description, location, site, strategy, discovered_at) "
+        "VALUES ('local', ?, ?, ?, ?, '', ?, 'Remote', ?, 'jobspy', ?)",
+        (
+            str(_job_id(url)),
+            url,
+            title,
+            company,
+            description,
+            site,
+            discovered_at,
+        ),
     )
     conn.commit()
     SqliteJobRepository(conn).attach_source_observation(
         LOCAL_TENANT,
-        JobId(url),
+        _job_id(url),
         JobSourceObservation(
             source_observation_id="obs-jobspy-1",
             source_id=source_id,
@@ -118,32 +130,7 @@ def _long_description(marker: str, tokens: int = 90) -> str:
     return " ".join(f"{marker}{index}" for index in range(tokens))
 
 
-def test_source_observation_backfill_seeds_legacy_jobs(conn: sqlite3.Connection) -> None:
-    repo = SqliteJobRepository(conn)
-    repo.save(_job())
-
-    ensure_source_observation_tables(conn)
-
-    row = conn.execute(
-        """
-        SELECT source_observation_id, job_url, source_id, source_native_id,
-               observed_url, normalized_observed_url, run_id, observed_at
-        FROM job_source_observations
-        WHERE job_url = ?
-        """,
-        ("https://boards.greenhouse.io/acme/jobs/123",),
-    ).fetchone()
-    assert row is not None
-    assert row["source_observation_id"] == "backfill:https://boards.greenhouse.io/acme/jobs/123"
-    assert row["source_id"] == "greenhouse"
-    assert row["source_native_id"] == "https://boards.greenhouse.io/acme/jobs/123"
-    assert row["observed_url"] == "https://boards.greenhouse.io/acme/jobs/123"
-    assert row["normalized_observed_url"] == "https://boards.greenhouse.io/acme/jobs/123"
-    assert row["run_id"] == "backfill"
-    assert row["observed_at"] == "2026-05-12T00:00:00Z"
-
-
-def test_load_by_url_resolves_observation_url_to_canonical_job(conn: sqlite3.Connection) -> None:
+def test_locator_resolution_does_not_treat_observation_urls_as_job_ids(conn: sqlite3.Connection) -> None:
     repo = SqliteJobRepository(conn)
     job = _job()
     repo.save(job)
@@ -160,13 +147,19 @@ def test_load_by_url_resolves_observation_url_to_canonical_job(conn: sqlite3.Con
         ),
     )
 
-    found = repo.load_by_url(
+    found = repo.resolve_by_posting_url(
         LOCAL_TENANT,
         PostingUrl(value="https://linkedin.example/jobs/123?utm_campaign=ignored"),
     )
+    assert found is None
+    canonical = repo.load(LOCAL_TENANT, job.job_id)
+    assert canonical is not None
 
-    assert found is not None
-    assert found.job_id == job.job_id
+
+def _job_id_for_url(repo: SqliteJobRepository, url: str) -> JobId:
+    identity = repo.resolve_by_posting_url(LOCAL_TENANT, PostingUrl(value=url))
+    assert identity is not None
+    return identity.job_id
 
 
 def test_attach_source_observation_replaces_repeated_native_identity(
@@ -292,6 +285,8 @@ def test_find_canonical_owner_resolves_native_identity_then_canonical_and_observ
             observed_at="2026-05-12T00:00:00Z",
         ),
     )
+    persisted = repo.load(LOCAL_TENANT, job.job_id)
+    assert persisted is not None
 
     assert (
         repo.find_canonical_owner(
@@ -300,7 +295,7 @@ def test_find_canonical_owner_resolves_native_identity_then_canonical_and_observ
             source_native_id="123",
             canonical_url="",
         )
-        == job.job_id
+        == persisted.job_id
     )
     assert (
         repo.find_canonical_owner(
@@ -309,7 +304,7 @@ def test_find_canonical_owner_resolves_native_identity_then_canonical_and_observ
             source_native_id="different",
             canonical_url="https://boards.greenhouse.io/acme/jobs/123",
         )
-        == job.job_id
+        == persisted.job_id
     )
     assert (
         repo.find_canonical_owner(
@@ -318,20 +313,20 @@ def test_find_canonical_owner_resolves_native_identity_then_canonical_and_observ
             source_native_id="different",
             canonical_url="https://boards.greenhouse.io/acme/jobs/123?gh_jid=123",
         )
-        == job.job_id
+        == persisted.job_id
     )
 
 
 def test_duplicate_links_are_persisted(conn: sqlite3.Connection) -> None:
     repo = SqliteJobRepository(conn)
     job = _job()
-    repo.save(job)
+    stable_job_id = repo.save(job)
 
     repo.record_duplicate_link(
         LOCAL_TENANT,
         DuplicateJobLink(
             duplicate_link_id="dup-1",
-            surviving_job_id=str(job.job_id),
+            surviving_job_id=str(stable_job_id),
             superseded_job_or_observation_id="obs-2",
             reason="canonical_url_match",
             confidence=0.91,
@@ -347,7 +342,7 @@ def test_duplicate_links_are_persisted(conn: sqlite3.Connection) -> None:
         """
     ).fetchone()
     assert row is not None
-    assert row["surviving_job_id"] == str(job.job_id)
+    assert row["surviving_job_id"] == str(stable_job_id)
     assert row["superseded_job_or_observation_id"] == "obs-2"
     assert row["reason"] == "canonical_url_match"
     assert row["confidence"] == 0.91
@@ -360,10 +355,12 @@ def test_discover_jobs_use_case_creates_job_identity_and_first_observation(
     repo = SqliteJobRepository(conn)
     publisher = RecordingPublisher()
     current_time = "2026-05-12T00:00:00Z"
+    stable_job_id = JobId("d7c34823-22ac-42ac-b1a0-64fe00eb1014")
     use_case = DiscoverJobsUseCase(
         repository=repo,
         publisher=publisher,
         clock=lambda: current_time,
+        job_id_factory=lambda: stable_job_id,
     )
 
     summary = use_case.execute(
@@ -372,15 +369,17 @@ def test_discover_jobs_use_case_creates_job_identity_and_first_observation(
         run_id="run-1",
     )
 
-    job_id = JobId("https://boards.greenhouse.io/acme/jobs/123")
     assert summary.total == 1
     assert summary.new_jobs == 1
     assert summary.observed == 0
-    assert repo.load(LOCAL_TENANT, job_id) is not None
-    identity = repo.load_canonical_identity(LOCAL_TENANT, job_id)
+    persisted = repo.load(LOCAL_TENANT, stable_job_id)
+    assert persisted is not None
+    assert uuid.UUID(str(persisted.job_id)).version == 4
+    assert persisted.job_id == stable_job_id
+    identity = repo.load_canonical_identity(LOCAL_TENANT, persisted.job_id)
     assert identity is not None
     assert identity.ats_kind is AtsKind.GREENHOUSE
-    observations = repo.list_observations(LOCAL_TENANT, job_id)
+    observations = repo.list_observations(LOCAL_TENANT, persisted.job_id)
     assert len(observations) == 1
     assert observations[0].source_id == "greenhouse:acme"
     assert [event.event_type for event in publisher.events] == [
@@ -388,11 +387,103 @@ def test_discover_jobs_use_case_creates_job_identity_and_first_observation(
         "CanonicalJobIdentityResolved",
         "JobSourceObserved",
     ]
+    assert {event.payload["job_id"] for event in publisher.events} == {str(stable_job_id)}
     assert publisher.events[-1].payload["run_id"] == "run-1"
+
+
+def test_discover_jobs_use_case_rejects_url_shaped_job_id_factory(
+    conn: sqlite3.Connection,
+) -> None:
+    repo = SqliteJobRepository(conn)
+    publisher = RecordingPublisher()
+    use_case = DiscoverJobsUseCase(
+        repository=repo,
+        publisher=publisher,
+        clock=lambda: "2026-05-12T00:00:00Z",
+        job_id_factory=lambda: JobId("https://boards.greenhouse.io/acme/jobs/123"),
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="job_id_factory must return a canonical UUID JobId",
+    ):
+        use_case.execute(
+            tenant_id=LOCAL_TENANT,
+            postings=[_posting()],
+            run_id="run-invalid-job-id",
+        )
+
+    assert conn.execute("SELECT COUNT(*) FROM jobs").fetchone()[0] == 0
+    assert publisher.events == []
+
+
+def test_discover_jobs_use_case_observes_concurrent_insert_winner(
+    conn: sqlite3.Connection,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = SqliteJobRepository(conn)
+    publisher = RecordingPublisher()
+    winner_job_id = JobId("6cc41ec6-8cb8-45ae-b563-bf3173c62f50")
+    candidate_job_id = JobId("b0216ed3-2b22-48db-a58d-262c31ae1c3d")
+    posting = _posting()
+    winner = Job.discover(
+        tenant_id=LOCAL_TENANT,
+        job_id=winner_job_id,
+        posting_url=posting.posting_url,
+        source=posting.source,
+        employer=Employer.unknown(),
+        search_strategy=posting.strategy,
+        metadata=posting.metadata,
+        discovered_at="2026-05-12T00:00:00Z",
+    )
+    assert repo.save(winner) == winner_job_id
+    repository_save = repo.save
+    first_save = True
+
+    def lose_first_insert(job: Job) -> JobId:
+        nonlocal first_save
+        if first_save:
+            first_save = False
+            return winner_job_id
+        return repository_save(job)
+
+    monkeypatch.setattr(
+        repo,
+        "find_canonical_owner",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        repo,
+        "find_content_owner",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(repo, "save", lose_first_insert)
+    use_case = DiscoverJobsUseCase(
+        repository=repo,
+        publisher=publisher,
+        clock=lambda: "2026-05-12T00:00:01Z",
+        observation_id_factory=lambda: "obs-race-loser",
+        job_id_factory=lambda: candidate_job_id,
+    )
+
+    summary = use_case.execute(
+        tenant_id=LOCAL_TENANT,
+        postings=[posting],
+        run_id="run-race-loser",
+    )
+
+    assert summary.new_jobs == 0
+    assert summary.observed == 1
+    assert conn.execute("SELECT COUNT(*) FROM jobs").fetchone()[0] == 1
+    observations = repo.list_observations(LOCAL_TENANT, winner_job_id)
+    assert [observation.source_observation_id for observation in observations] == ["obs-race-loser"]
+    assert [event.event_type for event in publisher.events] == ["JobSourceObserved"]
+    assert publisher.events[0].payload["job_id"] == str(winner_job_id)
 
 
 def test_discover_jobs_use_case_observes_existing_job_and_links_duplicate(
     conn: sqlite3.Connection,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     repo = SqliteJobRepository(conn)
     publisher = RecordingPublisher()
@@ -403,6 +494,22 @@ def test_discover_jobs_use_case_observes_existing_job_and_links_duplicate(
         clock=lambda: current_time,
     )
     use_case.execute(tenant_id=LOCAL_TENANT, postings=[_posting()], run_id="run-1")
+    owner = repo.resolve_by_posting_url(
+        LOCAL_TENANT,
+        PostingUrl(value="https://boards.greenhouse.io/acme/jobs/123"),
+    )
+    assert owner is not None
+    domain_links: list[DuplicateJobLink] = []
+    record_duplicate_link = repo.record_duplicate_link
+
+    def capture_duplicate_link(
+        tenant_id: TenantId,
+        link: DuplicateJobLink,
+    ) -> None:
+        domain_links.append(link)
+        record_duplicate_link(tenant_id, link)
+
+    monkeypatch.setattr(repo, "record_duplicate_link", capture_duplicate_link)
     publisher.events.clear()
 
     summary = use_case.execute(
@@ -426,7 +533,9 @@ def test_discover_jobs_use_case_observes_existing_job_and_links_duplicate(
         "DuplicateJobLinked",
     ]
     duplicate = publisher.events[-1]
-    assert duplicate.payload["surviving_job_id"] == "https://boards.greenhouse.io/acme/jobs/123"
+    assert len(domain_links) == 1
+    assert domain_links[0].surviving_job_id == str(owner.job_id)
+    assert duplicate.payload["surviving_job_id"] == str(owner.job_id)
     assert duplicate.payload["reason"] == "canonical_url_match"
     duplicate_row = conn.execute("SELECT reason FROM job_duplicate_links").fetchone()
     assert duplicate_row is not None
@@ -445,9 +554,10 @@ def test_discover_jobs_use_case_resurfaces_soft_deleted_existing_job(
         clock=lambda: current_time,
     )
     use_case.execute(tenant_id=LOCAL_TENANT, postings=[_posting()], run_id="run-1")
+    job_id = _job_id_for_url(repo, "https://boards.greenhouse.io/acme/jobs/123")
     repo.soft_delete(
         LOCAL_TENANT,
-        JobId("https://boards.greenhouse.io/acme/jobs/123"),
+        job_id,
         reason="not relevant right now",
         deleted_at="2026-05-13T00:00:00Z",
     )
@@ -471,14 +581,24 @@ def test_discover_jobs_use_case_resurfaces_soft_deleted_existing_job(
     assert summary.total == 1
     assert summary.new_jobs == 0
     assert summary.observed == 1
-    resurfaced = repo.load(LOCAL_TENANT, JobId("https://boards.greenhouse.io/acme/jobs/123"))
+    resurfaced = repo.load(
+        LOCAL_TENANT,
+        job_id,
+    )
     assert resurfaced is not None
     assert resurfaced.is_deleted is False
     assert resurfaced.metadata.title == "Platform Engineering Manager"
     assert resurfaced.metadata.description == "Lead platform engineering teams in Spain."
     assert resurfaced.metadata.location == "Barcelona, Spain"
     tombstone = conn.execute(
-        "SELECT restored_at FROM jobctrl_deleted_jobs WHERE job_url = ?",
+        """
+        SELECT deleted.restored_at
+        FROM jobctrl_deleted_jobs AS deleted
+        JOIN jobs
+          ON jobs.tenant_id = deleted.tenant_id
+         AND jobs.job_id = deleted.job_id
+        WHERE jobs.url = ?
+        """,
         ("https://boards.greenhouse.io/acme/jobs/123",),
     ).fetchone()
     assert tombstone is not None
@@ -526,7 +646,10 @@ def test_discover_jobs_use_case_rejects_new_policy_mismatches_without_creating_j
     assert summary.new_jobs == 0
     assert summary.observed == 0
     assert summary.duplicates_rejected == 0
-    assert repo.load(LOCAL_TENANT, JobId("https://jobs.ashbyhq.com/acai/india")) is None
+    assert repo.resolve_by_posting_url(
+        LOCAL_TENANT,
+        PostingUrl(value="https://jobs.ashbyhq.com/acai/india"),
+    ) is None
     assert publisher.events == []
 
 
@@ -541,6 +664,11 @@ def test_discover_jobs_use_case_soft_deletes_active_job_rejected_by_current_poli
         clock=lambda: "2026-05-12T00:00:00Z",
     )
     use_case.execute(tenant_id=LOCAL_TENANT, postings=[_posting()], run_id="run-1")
+    owner = repo.resolve_by_posting_url(
+        LOCAL_TENANT,
+        PostingUrl(value="https://boards.greenhouse.io/acme/jobs/123"),
+    )
+    assert owner is not None
     publisher.events.clear()
     policy_use_case = DiscoverJobsUseCase(
         repository=repo,
@@ -570,14 +698,14 @@ def test_discover_jobs_use_case_soft_deletes_active_job_rejected_by_current_poli
     assert summary.new_jobs == 0
     assert summary.observed == 0
     assert summary.duplicates_rejected == 0
-    job = repo.load(LOCAL_TENANT, JobId("https://boards.greenhouse.io/acme/jobs/123"))
+    job = repo.load(LOCAL_TENANT, owner.job_id)
     assert job is not None
     assert job.is_deleted is True
     assert "location_mismatch" in (job.delete_reason or "")
     assert job.metadata.title == "Platform Engineer"
     observations = repo.list_observations(
         LOCAL_TENANT,
-        JobId("https://boards.greenhouse.io/acme/jobs/123"),
+        owner.job_id,
     )
     assert [observation.run_id for observation in observations] == ["run-2"]
     assert [event.event_type for event in publisher.events] == [
@@ -596,8 +724,8 @@ def test_discover_jobs_use_case_keeps_policy_rejected_deleted_job_hidden(
         publisher=publisher,
         clock=lambda: "2026-05-12T00:00:00Z",
     )
-    job_id = JobId("https://boards.greenhouse.io/acme/jobs/123")
     use_case.execute(tenant_id=LOCAL_TENANT, postings=[_posting()], run_id="run-1")
+    job_id = _job_id_for_url(repo, "https://boards.greenhouse.io/acme/jobs/123")
     repo.soft_delete(
         LOCAL_TENANT,
         job_id,
@@ -638,8 +766,15 @@ def test_discover_jobs_use_case_keeps_policy_rejected_deleted_job_hidden(
     assert hidden.is_deleted is True
     assert hidden.metadata.title == "Platform Engineer"
     tombstone = conn.execute(
-        "SELECT restored_at FROM jobctrl_deleted_jobs WHERE job_url = ?",
-        (str(job_id),),
+        """
+        SELECT deleted.restored_at
+        FROM jobctrl_deleted_jobs AS deleted
+        JOIN jobs
+          ON jobs.tenant_id = deleted.tenant_id
+         AND jobs.job_id = deleted.job_id
+        WHERE jobs.url = ?
+        """,
+        ("https://boards.greenhouse.io/acme/jobs/123",),
     ).fetchone()
     assert tombstone is not None
     assert tombstone["restored_at"] is None
@@ -689,18 +824,13 @@ def test_discover_jobs_use_case_preserves_existing_salary_when_rediscovery_is_bl
     )
 
     assert summary.observed == 1
-    rediscovered = repo.load(LOCAL_TENANT, JobId("https://boards.greenhouse.io/acme/jobs/123"))
+    rediscovered = repo.load(
+        LOCAL_TENANT,
+        _job_id_for_url(repo, "https://boards.greenhouse.io/acme/jobs/123"),
+    )
     assert rediscovered is not None
     assert rediscovered.metadata.salary == "$180,000"
     assert rediscovered.metadata.description == "Lead engineering teams in Spain."
-
-    compensation_repo = SqlitePostedCompensationRepository(conn)
-    compensation_repo.backfill_from_legacy_jobs(parsed_at="2026-06-19T10:00:00Z")
-    fact = compensation_repo.get_fact(str(LOCAL_TENANT), str(rediscovered.job_id))
-    assert fact is not None
-    assert fact.legacy_raw_salary == "$180,000"
-    assert fact.minimum_amount == 180_000
-
 
 def test_discover_jobs_use_case_rejects_low_confidence_duplicate(
     conn: sqlite3.Connection,
@@ -726,6 +856,11 @@ def test_discover_jobs_use_case_rejects_low_confidence_duplicate(
         clock=lambda: "2026-05-12T00:00:00Z",
     )
     use_case.execute(tenant_id=LOCAL_TENANT, postings=[_posting()], run_id="run-1")
+    owner = repo.resolve_by_posting_url(
+        LOCAL_TENANT,
+        PostingUrl(value="https://boards.greenhouse.io/acme/jobs/123"),
+    )
+    assert owner is not None
     publisher.events.clear()
 
     summary = use_case.execute(
@@ -746,13 +881,16 @@ def test_discover_jobs_use_case_rejects_low_confidence_duplicate(
     assert summary.duplicates_rejected == 1
     assert [event.event_type for event in publisher.events] == ["DuplicateJobLinkRejected"]
     rejected = publisher.events[0]
-    assert rejected.payload["job_id"] == "https://boards.greenhouse.io/acme/jobs/123"
-    assert rejected.payload["candidate_job_id"] == "https://boards.greenhouse.io/acme/jobs/low-confidence"
+    assert rejected.payload["job_id"] == str(owner.job_id)
+    assert (
+        rejected.payload["candidate_posting_url"]
+        == "https://boards.greenhouse.io/acme/jobs/low-confidence"
+    )
     assert rejected.payload["reason"] == "confidence_below_threshold"
     assert (
         repo.list_observations(
             LOCAL_TENANT,
-            JobId("https://boards.greenhouse.io/acme/jobs/123"),
+            _job_id_for_url(repo, "https://boards.greenhouse.io/acme/jobs/123"),
         )[0].run_id
         == "run-1"
     )
@@ -802,15 +940,15 @@ def test_discover_jobs_use_case_collapses_jobspy_job_rediscovered_by_canonical_s
     assert summary.observed == 1
     assert summary.duplicates_linked == 1
     assert conn.execute("SELECT COUNT(*) FROM jobs").fetchone()[0] == 1
-    observations = repo.list_observations(LOCAL_TENANT, JobId(survivor))
+    observations = repo.list_observations(LOCAL_TENANT, _job_id(survivor))
     assert sorted(observation.source_id for observation in observations) == [
         "jobspy:linkedin",
         "workday:acme",
     ]
-    link = conn.execute(
-        "SELECT surviving_job_id, reason, confidence FROM job_duplicate_links"
-    ).fetchone()
-    assert link["surviving_job_id"] == survivor
+    link = conn.execute("SELECT surviving_job_id, reason, confidence FROM job_duplicate_links").fetchone()
+    surviving_job = repo.load(LOCAL_TENANT, _job_id(survivor))
+    assert surviving_job is not None
+    assert link["surviving_job_id"] == str(surviving_job.job_id)
     assert link["reason"] == "content_fingerprint_match"
     assert link["confidence"] == 0.95
     assert [event.event_type for event in publisher.events] == [
@@ -876,17 +1014,16 @@ def test_discover_jobs_use_case_collapses_reworded_cross_source_description(
     assert summary.observed == 1
     assert summary.duplicates_linked == 1
     assert conn.execute("SELECT COUNT(*) FROM jobs").fetchone()[0] == 1
-    assert (
-        repo.load(
-            LOCAL_TENANT,
-            JobId("https://jobs.lever.co/acme/staff-platform-engineer"),
-        ).job_id
-        == JobId(survivor)
+    surviving_job = repo.load(LOCAL_TENANT, _job_id_for_url(repo, survivor))
+    duplicate_lookup = repo.load(
+        LOCAL_TENANT,
+        surviving_job.job_id if surviving_job is not None else _job_id(survivor),
     )
-    link = conn.execute(
-        "SELECT surviving_job_id, reason, confidence FROM job_duplicate_links"
-    ).fetchone()
-    assert link["surviving_job_id"] == survivor
+    assert surviving_job is not None
+    assert duplicate_lookup is not None
+    assert duplicate_lookup.job_id == surviving_job.job_id
+    link = conn.execute("SELECT surviving_job_id, reason, confidence FROM job_duplicate_links").fetchone()
+    assert link["surviving_job_id"] == str(surviving_job.job_id)
     assert link["reason"] == "content_shingle_match"
     assert link["confidence"] == 0.85
 
@@ -934,14 +1071,23 @@ def test_discover_jobs_use_case_matches_fresh_listing_against_enriched_owner(
         ],
         run_id="run-greenhouse",
     )
+    survivor_job_id = conn.execute(
+        "SELECT job_id FROM jobs WHERE tenant_id = 'local' AND url = ?",
+        (survivor,),
+    ).fetchone()[0]
     conn.execute(
         """
         INSERT INTO job_enrichments (
-            job_url, tenant_id, current_status, full_description,
+            job_id, tenant_id, current_status, full_description,
             enriched_at, updated_at
         ) VALUES (?, 'local', 'enriched', ?, ?, ?)
         """,
-        (survivor, enriched, "2026-05-12T01:00:00Z", "2026-05-12T01:00:00Z"),
+        (
+            survivor_job_id,
+            enriched,
+            "2026-05-12T01:00:00Z",
+            "2026-05-12T01:00:00Z",
+        ),
     )
     conn.commit()
     publisher.events.clear()
@@ -969,10 +1115,10 @@ def test_discover_jobs_use_case_matches_fresh_listing_against_enriched_owner(
     assert summary.observed == 1
     assert summary.duplicates_linked == 1
     assert conn.execute("SELECT COUNT(*) FROM jobs").fetchone()[0] == 1
-    link = conn.execute(
-        "SELECT surviving_job_id, reason, confidence FROM job_duplicate_links"
-    ).fetchone()
-    assert link["surviving_job_id"] == survivor
+    surviving_job = repo.load(LOCAL_TENANT, _job_id_for_url(repo, survivor))
+    assert surviving_job is not None
+    link = conn.execute("SELECT surviving_job_id, reason, confidence FROM job_duplicate_links").fetchone()
+    assert link["surviving_job_id"] == str(surviving_job.job_id)
     assert link["reason"] == "content_shingle_match"
     assert link["confidence"] == 0.85
 
@@ -1036,17 +1182,14 @@ def test_discover_jobs_use_case_keeps_accepted_owner_when_content_duplicate_reje
         ),
     )
 
-    created = use_case.execute(
-        tenant_id=LOCAL_TENANT, postings=[accepted], run_id="run-owner"
-    )
+    created = use_case.execute(tenant_id=LOCAL_TENANT, postings=[accepted], run_id="run-owner")
     assert created.new_jobs == 1
-    owner = repo.load(LOCAL_TENANT, JobId(owner_url))
+    owner_id = _job_id_for_url(repo, owner_url)
+    owner = repo.load(LOCAL_TENANT, owner_id)
     assert owner is not None and owner.is_deleted is False
     publisher.events.clear()
 
-    summary = use_case.execute(
-        tenant_id=LOCAL_TENANT, postings=[india_duplicate], run_id="run-duplicate"
-    )
+    summary = use_case.execute(tenant_id=LOCAL_TENANT, postings=[india_duplicate], run_id="run-duplicate")
 
     assert summary.total == 1
     assert summary.new_jobs == 0
@@ -1054,11 +1197,11 @@ def test_discover_jobs_use_case_keeps_accepted_owner_when_content_duplicate_reje
     assert summary.duplicates_linked == 0
     assert summary.duplicates_rejected == 0
 
-    owner = repo.load(LOCAL_TENANT, JobId(owner_url))
+    owner = repo.load(LOCAL_TENANT, owner_id)
     assert owner is not None
     assert owner.is_deleted is False
     assert owner.metadata.location == "Remote - US"
-    assert JobId(owner_url) in [job.job_id for job in repo.list_recent(LOCAL_TENANT)]
+    assert owner.job_id in [job.job_id for job in repo.list_recent(LOCAL_TENANT)]
     assert conn.execute("SELECT COUNT(*) FROM jobs").fetchone()[0] == 1
 
     # The rejected distinct posting is recorded as declined-duplicate audit
@@ -1066,25 +1209,24 @@ def test_discover_jobs_use_case_keeps_accepted_owner_when_content_duplicate_reje
     # NOT attached as an owner observation (which would re-trigger the delete later).
     assert [event.event_type for event in publisher.events] == ["DuplicateJobLinkRejected"]
     rejected = publisher.events[-1]
-    assert rejected.payload["job_id"] == owner_url
-    assert rejected.payload["candidate_job_id"] == "https://jobs.lever.co/acme/staff-platform-engineer-india"
+    assert rejected.payload["job_id"] == str(owner.job_id)
+    assert (
+        rejected.payload["candidate_posting_url"]
+        == "https://jobs.lever.co/acme/staff-platform-engineer-india"
+    )
     assert "location_mismatch" in rejected.payload["reason"]
-    assert [obs.source_id for obs in repo.list_observations(LOCAL_TENANT, JobId(owner_url))] == [
-        "greenhouse:acme"
-    ]
+    assert [obs.source_id for obs in repo.list_observations(LOCAL_TENANT, owner_id)] == ["greenhouse:acme"]
 
     # Re-running the rejected duplicate must be stable: the owner stays active and
     # visible, proving the rejection left no re-observation trail to delete it. The
     # already-recorded (owner, candidate) rejection is idempotent, so no duplicate
     # audit event is appended on the repeat observation.
     publisher.events.clear()
-    resummary = use_case.execute(
-        tenant_id=LOCAL_TENANT, postings=[india_duplicate], run_id="run-duplicate-2"
-    )
+    resummary = use_case.execute(tenant_id=LOCAL_TENANT, postings=[india_duplicate], run_id="run-duplicate-2")
     assert resummary.observed == 0
-    owner = repo.load(LOCAL_TENANT, JobId(owner_url))
+    owner = repo.load(LOCAL_TENANT, owner_id)
     assert owner is not None and owner.is_deleted is False
-    assert JobId(owner_url) in [job.job_id for job in repo.list_recent(LOCAL_TENANT)]
+    assert owner.job_id in [job.job_id for job in repo.list_recent(LOCAL_TENANT)]
     assert "JobDeleted" not in [event.event_type for event in publisher.events]
     assert "DuplicateJobLinkRejected" not in [event.event_type for event in publisher.events]
 

--- a/workers/automation/tests/test_discovery_identity.py
+++ b/workers/automation/tests/test_discovery_identity.py
@@ -7,6 +7,10 @@ from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import pytest
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.trace import set_tracer_provider
 
 from jobctrl.database import init_db
 from jobctrl.domain.discovery import (
@@ -728,6 +732,37 @@ def test_discover_jobs_use_case_creates_job_identity_and_first_observation(
     assert publisher.events[0].payload["employer"] == "Acme"
     assert publisher.events[0].payload["source"] == "greenhouse"
     assert publisher.events[-1].payload["run_id"] == "run-1"
+
+
+def test_discovery_canonicalize_span_omits_new_job_id_and_records_owner_id(
+    conn: sqlite3.Connection,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from opentelemetry import trace as trace_api
+    from opentelemetry.util._once import Once
+
+    monkeypatch.setattr(trace_api, "_TRACER_PROVIDER_SET_ONCE", Once())
+    monkeypatch.setattr(trace_api, "_TRACER_PROVIDER", None)
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    set_tracer_provider(provider)
+
+    job_id = JobId("d7c34823-22ac-42ac-b1a0-64fe00eb1014")
+    use_case = DiscoverJobsUseCase(
+        repository=SqliteJobRepository(conn),
+        publisher=RecordingPublisher(),
+        clock=lambda: "2026-05-12T00:00:00Z",
+        job_id_factory=lambda: job_id,
+    )
+
+    use_case.execute(tenant_id=LOCAL_TENANT, postings=[_posting()], run_id="run-new")
+    use_case.execute(tenant_id=LOCAL_TENANT, postings=[_posting()], run_id="run-owner")
+
+    canonicalize_spans = [span for span in exporter.get_finished_spans() if span.name == "discovery.canonicalize"]
+    assert len(canonicalize_spans) == 2
+    assert "job.id" not in canonicalize_spans[0].attributes
+    assert canonicalize_spans[1].attributes["job.id"] == str(job_id)
 
 
 def test_discover_jobs_use_case_rejects_url_shaped_job_id_factory(

--- a/workers/automation/tests/test_discovery_identity.py
+++ b/workers/automation/tests/test_discovery_identity.py
@@ -74,11 +74,17 @@ def _posting(
     source_id: str = "greenhouse:acme",
     ats_kind: AtsKind = AtsKind.GREENHOUSE,
     board: str = "greenhouse",
+    employer_name: str | None = "Acme",
     metadata: JobMetadata | None = None,
 ) -> ScrapedJobPosting:
     return ScrapedJobPosting(
         posting_url=PostingUrl(value=canonical_url),
         source=Source(board=board),
+        employer=(
+            Employer(name=employer_name)
+            if employer_name is not None
+            else Employer.unknown()
+        ),
         metadata=metadata or JobMetadata(title="Platform Engineer", location="Remote"),
         strategy=SearchStrategy.WORKDAY_API,
         source_id=source_id,
@@ -700,6 +706,13 @@ def test_discover_jobs_use_case_creates_job_identity_and_first_observation(
     assert persisted is not None
     assert uuid.UUID(str(persisted.job_id)).version == 4
     assert persisted.job_id == stable_job_id
+    assert persisted.employer.name == "Acme"
+    assert persisted.source.board == "greenhouse"
+    stored = conn.execute(
+        "SELECT company, site FROM jobs WHERE tenant_id = ? AND job_id = ?",
+        (str(LOCAL_TENANT), str(stable_job_id)),
+    ).fetchone()
+    assert tuple(stored) == ("Acme", "greenhouse")
     identity = repo.load_canonical_identity(LOCAL_TENANT, persisted.job_id)
     assert identity is not None
     assert identity.ats_kind is AtsKind.GREENHOUSE
@@ -712,6 +725,8 @@ def test_discover_jobs_use_case_creates_job_identity_and_first_observation(
         "JobSourceObserved",
     ]
     assert {event.payload["job_id"] for event in publisher.events} == {str(stable_job_id)}
+    assert publisher.events[0].payload["employer"] == "Acme"
+    assert publisher.events[0].payload["source"] == "greenhouse"
     assert publisher.events[-1].payload["run_id"] == "run-1"
 
 
@@ -1755,9 +1770,8 @@ def test_discover_jobs_use_case_does_not_merge_distinct_employers_behind_manual_
     )
     boilerplate = _long_description("boiler", tokens=90)
 
-    # Two DISTINCT employers, both captured with only the shared platform-sentinel
-    # board ("User-mediated capture") and near-identical boilerplate text. The
-    # employer discriminator is absent, so these MUST NOT content-merge.
+    # Two DISTINCT employers share the same platform board and near-identical
+    # boilerplate text. The explicit employer discriminator prevents a merge.
     use_case.execute(
         tenant_id=LOCAL_TENANT,
         postings=[
@@ -1767,6 +1781,7 @@ def test_discover_jobs_use_case_does_not_merge_distinct_employers_behind_manual_
                 source_id="manual_capture:acme",
                 ats_kind=AtsKind.OTHER,
                 board="User-mediated capture",
+                employer_name="Acme",
                 metadata=JobMetadata(
                     title="Head of Engineering",
                     description=boilerplate + " acme alpha beta",
@@ -1786,6 +1801,7 @@ def test_discover_jobs_use_case_does_not_merge_distinct_employers_behind_manual_
                 source_id="manual_capture:globex",
                 ats_kind=AtsKind.OTHER,
                 board="User-mediated capture",
+                employer_name="Globex",
                 metadata=JobMetadata(
                     title="Head of Engineering",
                     description=boilerplate + " globex gamma delta",
@@ -1815,7 +1831,7 @@ def test_discover_jobs_use_case_does_not_merge_distinct_employers_behind_workday
     )
     boilerplate = _long_description("boiler", tokens=90)
 
-    # Employer-less Workday postings fall back to the constant board "Workday".
+    # Distinct employers can share the same Workday source board.
     use_case.execute(
         tenant_id=LOCAL_TENANT,
         postings=[
@@ -1825,6 +1841,7 @@ def test_discover_jobs_use_case_does_not_merge_distinct_employers_behind_workday
                 source_id="workday:one",
                 ats_kind=AtsKind.WORKDAY,
                 board="Workday",
+                employer_name="One Corp",
                 metadata=JobMetadata(
                     title="Head of Data",
                     description=boilerplate + " one alpha beta",
@@ -1844,6 +1861,7 @@ def test_discover_jobs_use_case_does_not_merge_distinct_employers_behind_workday
                 source_id="workday:two",
                 ats_kind=AtsKind.WORKDAY,
                 board="Workday",
+                employer_name="Two Corp",
                 metadata=JobMetadata(
                     title="Head of Data",
                     description=boilerplate + " two gamma delta",

--- a/workers/automation/tests/test_discovery_limits.py
+++ b/workers/automation/tests/test_discovery_limits.py
@@ -10,6 +10,7 @@ from jobctrl.database import close_connection, init_db
 from jobctrl.discovery import jobspy, smartextract, workday
 from jobctrl.domain.discovery import (
     AtsKind,
+    Employer,
     JobMetadata,
     PostingUrl,
     SearchStrategy,
@@ -475,15 +476,8 @@ def test_jobspy_retains_partial_results_and_counts_typed_board_failure(monkeypat
     assert result["errors"] == 1
 
 
-def test_jobspy_dedups_against_ats_first_null_company_owner(tmp_path):
-    """JobSpy's pre-use-case dedup must tolerate an ATS-first owner with NULL company.
-
-    Use-case-created ATS rows leave ``jobs.company`` NULL and carry the employer
-    in ``jobs.site``. JobSpy supplies the employer in its ``company`` column, so a
-    dedup that filters on ``jobs.company`` alone misses the ATS owner and stores a
-    duplicate. The pre-filter must coalesce ``company`` -> ``site`` like the
-    use-case content-owner lookup.
-    """
+def test_jobspy_dedups_against_ats_first_canonical_employer(tmp_path):
+    """JobSpy dedup uses the canonical employer, independently of the source."""
     db_path = tmp_path / "jobs.db"
     conn = init_db(db_path)
     try:
@@ -499,7 +493,8 @@ def test_jobspy_dedups_against_ats_first_null_company_owner(tmp_path):
             postings=[
                 ScrapedJobPosting(
                     posting_url=PostingUrl(value=owner_url),
-                    source=Source(board="Acme"),
+                    source=Source(board="greenhouse"),
+                    employer=Employer(name="Acme"),
                     metadata=JobMetadata(
                         title="Staff Platform Engineer",
                         description=_JOBSPY_DESCRIPTION,
@@ -517,8 +512,8 @@ def test_jobspy_dedups_against_ats_first_null_company_owner(tmp_path):
         stored = conn.execute(
             "SELECT company, site FROM jobs WHERE url = ?", (owner_url,)
         ).fetchone()
-        assert (stored["company"] or "") == ""
-        assert stored["site"] == "Acme"
+        assert stored["company"] == "Acme"
+        assert stored["site"] == "greenhouse"
 
         frame = _jobspy_frame(
             [
@@ -541,15 +536,14 @@ def test_jobspy_dedups_against_ats_first_null_company_owner(tmp_path):
         close_connection(db_path)
 
 
-def test_jobspy_keeps_distinct_roles_at_same_null_company_owner_separate(tmp_path):
-    """Distinct roles must not merge onto a NULL-company ATS owner via JobSpy.
+def test_jobspy_keeps_distinct_roles_at_same_employer_separate(tmp_path):
+    """Distinct roles must not merge onto an ATS owner via JobSpy.
 
-    The company->site coalescing lets JobSpy find an ATS-first owner whose
-    ``jobs.company`` is NULL, but the content match still gates on normalized
-    title AND employer. Two genuinely different roles at the same employer with
+    Content matching gates on normalized title AND canonical employer. Two
+    genuinely different roles at the same employer with
     near-identical (well above 0.83 shingle) descriptions must remain separate
     Jobs -- the title gate short-circuits before the shared description could
-    fingerprint- or shingle-match. Regression guard for the null-company path.
+    fingerprint- or shingle-match.
     """
     db_path = tmp_path / "jobs.db"
     conn = init_db(db_path)
@@ -570,7 +564,8 @@ def test_jobspy_keeps_distinct_roles_at_same_null_company_owner_separate(tmp_pat
             postings=[
                 ScrapedJobPosting(
                     posting_url=PostingUrl(value=owner_url),
-                    source=Source(board="Acme"),
+                    source=Source(board="greenhouse"),
+                    employer=Employer(name="Acme"),
                     metadata=JobMetadata(
                         title="Staff Platform Engineer",
                         description=shared_description,
@@ -588,8 +583,8 @@ def test_jobspy_keeps_distinct_roles_at_same_null_company_owner_separate(tmp_pat
         stored = conn.execute(
             "SELECT company, site FROM jobs WHERE url = ?", (owner_url,)
         ).fetchone()
-        assert (stored["company"] or "") == ""
-        assert stored["site"] == "Acme"
+        assert stored["company"] == "Acme"
+        assert stored["site"] == "greenhouse"
 
         frame = _jobspy_frame(
             [

--- a/workers/automation/tests/test_discovery_limits.py
+++ b/workers/automation/tests/test_discovery_limits.py
@@ -16,6 +16,7 @@ from jobctrl.domain.discovery import (
     Source,
 )
 from jobctrl.domain.discovery.use_cases import DiscoverJobsUseCase
+from jobctrl.domain.identifiers import generate_job_id
 from jobctrl.domain.ports.discovery import ScrapedJobPosting
 from jobctrl.domain.tenant import LOCAL_TENANT
 from jobctrl.infrastructure.compensation import SqlitePostedCompensationRepository
@@ -28,6 +29,15 @@ _JOBSPY_DESCRIPTION = "Lead engineering, platform, security, and delivery teams 
 
 def _jobspy_frame(rows: list[dict]) -> pd.DataFrame:
     return pd.DataFrame([{"description": _JOBSPY_DESCRIPTION, **row} for row in rows])
+
+
+def _stable_job_id(conn, job_url: str) -> str:
+    row = conn.execute(
+        "SELECT job_id FROM jobs WHERE tenant_id = ? AND url = ?",
+        (str(LOCAL_TENANT), job_url),
+    ).fetchone()
+    assert row is not None
+    return str(row["job_id"])
 
 
 def test_jobspy_limit_stops_after_one_new_job(monkeypatch):
@@ -526,7 +536,7 @@ def test_jobspy_dedups_against_ats_first_null_company_owner(tmp_path):
         link = conn.execute(
             "SELECT surviving_job_id FROM job_duplicate_links"
         ).fetchone()
-        assert link["surviving_job_id"] == owner_url
+        assert link["surviving_job_id"] == _stable_job_id(conn, owner_url)
     finally:
         close_connection(db_path)
 
@@ -641,8 +651,8 @@ def test_jobspy_stores_company_and_backfills_existing_job(tmp_path):
         ).fetchone()
         assert row["company"] == "Keyrock"
         event = conn.execute(
-            "SELECT event_type FROM job_events WHERE job_url = ? AND event_type = 'JobMetadataUpdated' LIMIT 1",
-            ("https://www.linkedin.com/jobs/view/1",),
+            "SELECT event_type FROM job_events WHERE job_id = ? AND event_type = 'JobMetadataUpdated' LIMIT 1",
+            (_stable_job_id(conn, "https://www.linkedin.com/jobs/view/1"),),
         ).fetchone()
         assert event["event_type"] == "JobMetadataUpdated"
     finally:
@@ -787,12 +797,16 @@ def test_jobspy_existing_row_refreshes_metadata_before_restore(tmp_path):
     conn = init_db(db_path)
     url = "https://www.linkedin.com/jobs/view/stale"
     try:
+        job_id = str(generate_job_id())
         conn.execute(
             """
-            INSERT INTO jobs (url, title, company, description, location, site, strategy, discovered_at)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            INSERT INTO jobs (
+                tenant_id, job_id, url, title, company, description, location, site, strategy, discovered_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
+                str(LOCAL_TENANT),
+                job_id,
                 url,
                 "Stale Support Role",
                 "",
@@ -803,13 +817,33 @@ def test_jobspy_existing_row_refreshes_metadata_before_restore(tmp_path):
                 "2026-05-20T00:00:00+00:00",
             ),
         )
-        jobspy._ensure_deleted_jobs_table(conn)
         conn.execute(
             """
-            INSERT INTO jobctrl_deleted_jobs (job_url, deleted_at, reason, restored_at)
-            VALUES (?, ?, ?, NULL)
+            INSERT INTO job_locators (
+                tenant_id, job_id, locator_kind, locator_value, is_current,
+                first_seen_at, last_seen_at, retired_at
+            ) VALUES (?, ?, 'posting_url', ?, 1, ?, ?, NULL)
             """,
-            (url, "2026-05-21T00:00:00+00:00", "stale invalid row"),
+            (
+                str(LOCAL_TENANT),
+                job_id,
+                url,
+                "2026-05-20T00:00:00+00:00",
+                "2026-05-20T00:00:00+00:00",
+            ),
+        )
+        conn.execute(
+            """
+            INSERT INTO jobctrl_deleted_jobs (
+                tenant_id, job_id, deleted_at, reason, restored_at
+            ) VALUES (?, ?, ?, ?, NULL)
+            """,
+            (
+                str(LOCAL_TENANT),
+                _stable_job_id(conn, url),
+                "2026-05-21T00:00:00+00:00",
+                "stale invalid row",
+            ),
         )
         conn.commit()
 
@@ -840,8 +874,8 @@ def test_jobspy_existing_row_refreshes_metadata_before_restore(tmp_path):
             "location": "Barcelona, Spain",
         }
         tombstone = conn.execute(
-            "SELECT restored_at FROM jobctrl_deleted_jobs WHERE job_url = ?",
-            (url,),
+            "SELECT restored_at FROM jobctrl_deleted_jobs WHERE tenant_id = ? AND job_id = ?",
+            (str(LOCAL_TENANT), _stable_job_id(conn, url)),
         ).fetchone()
         assert tombstone["restored_at"] is not None
     finally:
@@ -1031,9 +1065,9 @@ def test_jobspy_learns_posting_owner_source_from_direct_ats_url(tmp_path):
             """
             SELECT source_id, observed_url, run_id
             FROM job_source_observations
-            WHERE job_url = ?
+            WHERE job_id = ?
             """,
-            ("https://www.linkedin.com/jobs/view/4416248661",),
+            (_stable_job_id(conn, "https://www.linkedin.com/jobs/view/4416248661"),),
         ).fetchone()
         assert observation["source_id"] == "jobspy:linkedin"
         assert observation["observed_url"] == "https://www.linkedin.com/jobs/view/4416248661"
@@ -1043,9 +1077,9 @@ def test_jobspy_learns_posting_owner_source_from_direct_ats_url(tmp_path):
             """
             SELECT canonical_url, ats_kind, source_native_id, confidence
             FROM job_canonical_identities
-            WHERE job_url = ?
+            WHERE job_id = ?
             """,
-            ("https://www.linkedin.com/jobs/view/4416248661",),
+            (_stable_job_id(conn, "https://www.linkedin.com/jobs/view/4416248661"),),
         ).fetchone()
         assert identity["canonical_url"] == direct_url
         assert identity["ats_kind"] == "greenhouse"
@@ -1105,7 +1139,7 @@ def test_jobspy_persists_posted_compensation_fact_from_bounded_salary_text(tmp_p
 
         fact = SqlitePostedCompensationRepository(conn).get_fact(
             "local",
-            "https://www.linkedin.com/jobs/view/posted-comp",
+            _stable_job_id(conn, "https://www.linkedin.com/jobs/view/posted-comp"),
         )
         assert fact is not None
         assert fact.parse_state == "parsed_range"
@@ -1227,9 +1261,9 @@ def test_jobspy_keeps_learned_workday_sources_in_review_until_runnable(tmp_path)
             """
             SELECT canonical_url, ats_kind, source_native_id
             FROM job_canonical_identities
-            WHERE job_url = ?
+            WHERE job_id = ?
             """,
-            ("https://www.linkedin.com/jobs/view/12",),
+            (_stable_job_id(conn, "https://www.linkedin.com/jobs/view/12"),),
         ).fetchone()
         assert identity["canonical_url"] == direct_url
         assert identity["ats_kind"] == "workday"
@@ -1340,12 +1374,14 @@ def test_jobspy_rejects_same_content_location_variants(tmp_path):
             "SELECT surviving_job_id, superseded_job_or_observation_id, reason "
             "FROM job_duplicate_links"
         ).fetchone()
-        assert link["surviving_job_id"] == "https://www.linkedin.com/jobs/view/4416248661"
+        assert link["surviving_job_id"] == _stable_job_id(
+            conn, "https://www.linkedin.com/jobs/view/4416248661"
+        )
         assert link["superseded_job_or_observation_id"] == "https://www.linkedin.com/jobs/view/4416235850"
         assert link["reason"] == "content_fingerprint_match"
         observation = conn.execute(
-            "SELECT source_id FROM job_source_observations WHERE job_url = ?",
-            ("https://www.linkedin.com/jobs/view/4416248661",),
+            "SELECT source_id FROM job_source_observations WHERE job_id = ?",
+            (_stable_job_id(conn, "https://www.linkedin.com/jobs/view/4416248661"),),
         ).fetchone()
         assert observation["source_id"] == "jobspy:linkedin"
     finally:
@@ -1436,12 +1472,14 @@ def test_jobspy_rejects_cross_board_markdown_description_variants(tmp_path):
         link = conn.execute(
             "SELECT surviving_job_id, superseded_job_or_observation_id, reason FROM job_duplicate_links"
         ).fetchone()
-        assert link["surviving_job_id"] == "https://es.indeed.com/viewjob?jk=6b34cd5504dac130"
+        assert link["surviving_job_id"] == _stable_job_id(
+            conn, "https://es.indeed.com/viewjob?jk=6b34cd5504dac130"
+        )
         assert link["superseded_job_or_observation_id"] == "https://www.linkedin.com/jobs/view/4409381449"
         assert link["reason"] == "content_fingerprint_match"
         observations = conn.execute(
-            "SELECT source_id FROM job_source_observations WHERE job_url = ? ORDER BY source_id",
-            ("https://es.indeed.com/viewjob?jk=6b34cd5504dac130",),
+            "SELECT source_id FROM job_source_observations WHERE job_id = ? ORDER BY source_id",
+            (_stable_job_id(conn, "https://es.indeed.com/viewjob?jk=6b34cd5504dac130"),),
         ).fetchall()
         assert [row["source_id"] for row in observations] == ["jobspy:indeed", "jobspy:linkedin"]
     finally:
@@ -1520,11 +1558,13 @@ def test_jobspy_exact_rediscovery_keeps_deleted_content_duplicate_suppressed(tmp
         conn.execute(
             """
             INSERT INTO jobs (
-                url, title, company, location, site, strategy, discovered_at,
+                tenant_id, job_id, url, title, company, location, site, strategy, discovered_at,
                 description, full_description, detail_scraped_at
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
+                str(LOCAL_TENANT),
+                str(generate_job_id()),
                 duplicate_url,
                 "Director, Product Management (BSS/Platform Services)",
                 "Vonage",
@@ -1539,10 +1579,16 @@ def test_jobspy_exact_rediscovery_keeps_deleted_content_duplicate_suppressed(tmp
         )
         conn.execute(
             """
-            INSERT INTO jobctrl_deleted_jobs (job_url, deleted_at, reason, restored_at)
-            VALUES (?, ?, ?, NULL)
+            INSERT INTO jobctrl_deleted_jobs (
+                tenant_id, job_id, deleted_at, reason, restored_at
+            ) VALUES (?, ?, ?, ?, NULL)
             """,
-            (duplicate_url, "2026-05-21T11:00:00+00:00", "content duplicate"),
+            (
+                str(LOCAL_TENANT),
+                _stable_job_id(conn, duplicate_url),
+                "2026-05-21T11:00:00+00:00",
+                "content duplicate",
+            ),
         )
         conn.commit()
 
@@ -1560,14 +1606,14 @@ def test_jobspy_exact_rediscovery_keeps_deleted_content_duplicate_suppressed(tmp
         assert jobspy.store_jobspy_results(conn, rediscovered, "Product", limit=10) == (0, 1)
 
         tombstone = conn.execute(
-            "SELECT restored_at FROM jobctrl_deleted_jobs WHERE job_url = ?",
-            (duplicate_url,),
+            "SELECT restored_at FROM jobctrl_deleted_jobs WHERE tenant_id = ? AND job_id = ?",
+            (str(LOCAL_TENANT), _stable_job_id(conn, duplicate_url)),
         ).fetchone()
         assert tombstone["restored_at"] is None
         link = conn.execute(
             "SELECT surviving_job_id, superseded_job_or_observation_id, reason FROM job_duplicate_links"
         ).fetchone()
-        assert link["surviving_job_id"] == survivor_url
+        assert link["surviving_job_id"] == _stable_job_id(conn, survivor_url)
         assert link["superseded_job_or_observation_id"] == duplicate_url
         assert link["reason"] == "content_fingerprint_match"
     finally:

--- a/workers/automation/tests/test_discovery_production_wiring.py
+++ b/workers/automation/tests/test_discovery_production_wiring.py
@@ -27,6 +27,7 @@ from jobctrl.domain.discovery.source_registry import (
     SourceState,
     WORKDAY_API_POLICY,
 )
+from jobctrl.domain.identifiers import generate_job_id
 from jobctrl.domain.ports.discovery import ScrapedJobPosting
 from jobctrl.enrichment.detail import _record_posting_snapshot_from_cascade
 from jobctrl.infrastructure.discovery.production_wiring import (
@@ -44,6 +45,77 @@ from jobctrl.infrastructure.discovery.production_wiring import (
 from jobctrl.infrastructure.projections.projection_builder import ProjectionBuilder
 from jobctrl.pipeline import runner
 from jobctrl.state import record_job_event
+
+
+def _insert_v7_job(
+    conn: sqlite3.Connection,
+    *,
+    url: str,
+    title: str,
+    company: str,
+    description: str,
+    location: str,
+    site: str,
+    strategy: str,
+    discovered_at: str,
+) -> str:
+    job_id = str(generate_job_id())
+    conn.execute(
+        """
+        INSERT INTO jobs (
+            tenant_id, job_id, url, title, company, description, location,
+            site, strategy, discovered_at
+        ) VALUES ('local', ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (job_id, url, title, company, description, location, site, strategy, discovered_at),
+    )
+    conn.execute(
+        """
+        INSERT INTO job_locators (
+            tenant_id, job_id, locator_kind, locator_value, is_current,
+            first_seen_at, last_seen_at, retired_at
+        ) VALUES ('local', ?, 'posting_url', ?, 1, ?, ?, NULL)
+        """,
+        (job_id, url, discovered_at, discovered_at),
+    )
+    return job_id
+
+
+def _insert_source_observation(
+    conn: sqlite3.Connection,
+    *,
+    observation_id: str,
+    job_id: str,
+    source_id: str,
+    source_native_id: str,
+    url: str,
+    observed_at: str,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO job_source_observations (
+            tenant_id, source_observation_id, job_id, source_id,
+            source_native_id, observed_url, normalized_observed_url,
+            run_id, observed_at
+        ) VALUES ('local', ?, ?, ?, ?, ?, ?, 'test', ?)
+        """,
+        (observation_id, job_id, source_id, source_native_id, url, url, observed_at),
+    )
+
+
+def _deleted_reasons_by_url(conn: sqlite3.Connection) -> dict[str, str]:
+    return {
+        str(row["url"]): str(row["reason"])
+        for row in conn.execute(
+            """
+            SELECT jobs.url, jobctrl_deleted_jobs.reason
+            FROM jobctrl_deleted_jobs
+            JOIN jobs
+              ON jobs.tenant_id = jobctrl_deleted_jobs.tenant_id
+             AND jobs.job_id = jobctrl_deleted_jobs.job_id
+            """
+        ).fetchall()
+    }
 
 
 @pytest.fixture
@@ -335,25 +407,26 @@ def test_worker_seeds_api_visible_locator_and_manual_queues(
 def test_worker_auto_approves_parseable_sources_from_broad_board_observations(
     conn: sqlite3.Connection,
 ) -> None:
-    conn.execute(
-        """
-        INSERT INTO job_source_observations (
-          tenant_id, source_observation_id, job_url, source_id,
-          source_native_id, observed_url, normalized_observed_url,
-          run_id, observed_at
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-        """,
-        (
-            "local",
-            "obs-1",
-            "https://boards.greenhouse.io/acme/jobs/123",
-            "jobspy:linkedin",
-            "123",
-            "https://boards.greenhouse.io/acme/jobs/123",
-            "https://boards.greenhouse.io/acme/jobs/123",
-            "run-1",
-            "2026-05-12T10:00:00+00:00",
-        ),
+    url = "https://boards.greenhouse.io/acme/jobs/123"
+    job_id = _insert_v7_job(
+        conn,
+        url=url,
+        title="Engineering Manager",
+        company="Acme",
+        description="Lead engineering teams.",
+        location="Barcelona, Spain",
+        site="linkedin",
+        strategy="jobspy",
+        discovered_at="2026-05-12T10:00:00+00:00",
+    )
+    _insert_source_observation(
+        conn,
+        observation_id="obs-1",
+        job_id=job_id,
+        source_id="jobspy:linkedin",
+        source_native_id="123",
+        url=url,
+        observed_at="2026-05-12T10:00:00+00:00",
     )
     conn.commit()
 
@@ -480,22 +553,29 @@ def test_canonical_ats_scheduler_routes_postings_through_discovery_use_case(
     }
     enrichments = conn.execute(
         """
-        SELECT job_url, current_status, full_description, extraction_tier
+        SELECT jobs.url, job_enrichments.current_status,
+               job_enrichments.full_description, job_enrichments.extraction_tier
         FROM job_enrichments
+        JOIN jobs
+          ON jobs.tenant_id = job_enrichments.tenant_id
+         AND jobs.job_id = job_enrichments.job_id
         """
     ).fetchall()
-    assert {row["job_url"] for row in enrichments} == expected_urls
+    assert {row["url"] for row in enrichments} == expected_urls
     assert {row["current_status"] for row in enrichments} == {"enriched"}
     assert {row["extraction_tier"] for row in enrichments} == {"css_selectors"}
     assert all(str(row["full_description"] or "").strip() for row in enrichments)
     stage_rows = conn.execute(
         """
-        SELECT job_url, state
+        SELECT jobs.url, job_stage_states.state
         FROM job_stage_states
-        WHERE stage = 'enrich'
+        JOIN jobs
+          ON jobs.tenant_id = job_stage_states.tenant_id
+         AND jobs.job_id = job_stage_states.job_id
+        WHERE job_stage_states.stage = 'enrich'
         """
     ).fetchall()
-    assert {row["job_url"] for row in stage_rows} == expected_urls
+    assert {row["url"] for row in stage_rows} == expected_urls
     assert {row["state"] for row in stage_rows} == {"succeeded"}
     assert {
         row["url"] for row in get_jobs_by_stage(conn, "pending_score", limit=0)
@@ -607,39 +687,33 @@ def test_discovery_hygiene_retires_existing_invalid_canonical_ats_rows(
         ),
     ]
     for index, (url, title, location, description) in enumerate(rows):
-        conn.execute(
-            """
-            INSERT INTO jobs (url, title, company, description, location, site, strategy, discovered_at)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-            """,
-            (url, title, "Acme", description, location, "Acme", "workday_api", "2026-05-20T00:00:00+00:00"),
+        job_id = _insert_v7_job(
+            conn,
+            url=url,
+            title=title,
+            company="Acme",
+            description=description,
+            location=location,
+            site="Acme",
+            strategy="workday_api",
+            discovered_at="2026-05-20T00:00:00+00:00",
         )
         conn.execute(
             """
             INSERT INTO job_canonical_identities (
-                tenant_id, job_url, canonical_url, ats_kind, source_native_id, confidence, resolved_at
+                tenant_id, job_id, canonical_url, ats_kind, source_native_id, confidence, resolved_at
             ) VALUES (?, ?, ?, ?, ?, ?, ?)
             """,
-            ("local", url, url, "greenhouse", f"gh-{index}", 1.0, "2026-05-20T00:00:00+00:00"),
+            ("local", job_id, url, "greenhouse", f"gh-{index}", 1.0, "2026-05-20T00:00:00+00:00"),
         )
-        conn.execute(
-            """
-            INSERT INTO job_source_observations (
-                tenant_id, source_observation_id, job_url, source_id, source_native_id,
-                observed_url, normalized_observed_url, run_id, observed_at
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-            """,
-            (
-                "local",
-                f"obs-{index}",
-                url,
-                "greenhouse:acme",
-                f"gh-{index}",
-                url,
-                url,
-                "test",
-                "2026-05-20T00:00:00+00:00",
-            ),
+        _insert_source_observation(
+            conn,
+            observation_id=f"obs-{index}",
+            job_id=job_id,
+            source_id="greenhouse:acme",
+            source_native_id=f"gh-{index}",
+            url=url,
+            observed_at="2026-05-20T00:00:00+00:00",
         )
     conn.commit()
 
@@ -650,10 +724,7 @@ def test_discovery_hygiene_retires_existing_invalid_canonical_ats_rows(
     )
 
     assert result["retired_jobs"] == 3
-    deleted = {
-        row["job_url"]: row["reason"]
-        for row in conn.execute("SELECT job_url, reason FROM jobctrl_deleted_jobs").fetchall()
-    }
+    deleted = _deleted_reasons_by_url(conn)
     assert "https://boards.greenhouse.io/acme/jobs/valid" not in deleted
     assert "missing_description" in deleted["https://boards.greenhouse.io/acme/jobs/empty-description"]
     assert "title_mismatch" in deleted["https://boards.greenhouse.io/acme/jobs/sales"]
@@ -686,39 +757,33 @@ def test_discovery_hygiene_retires_ashby_business_travel_portugal_rows(
         ),
     ]
     for url, title, location, description, native_id in rows:
-        conn.execute(
-            """
-            INSERT INTO jobs (url, title, company, description, location, site, strategy, discovered_at)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-            """,
-            (url, title, "Perk", description, location, "jobs.ashbyhq.com", "workday_api", "2026-05-25T21:35:55+00:00"),
+        job_id = _insert_v7_job(
+            conn,
+            url=url,
+            title=title,
+            company="Perk",
+            description=description,
+            location=location,
+            site="jobs.ashbyhq.com",
+            strategy="workday_api",
+            discovered_at="2026-05-25T21:35:55+00:00",
         )
         conn.execute(
             """
             INSERT INTO job_canonical_identities (
-                tenant_id, job_url, canonical_url, ats_kind, source_native_id, confidence, resolved_at
+                tenant_id, job_id, canonical_url, ats_kind, source_native_id, confidence, resolved_at
             ) VALUES (?, ?, ?, ?, ?, ?, ?)
             """,
-            ("local", url, url, "ashby", native_id, 0.9, "2026-05-25T21:35:55+00:00"),
+            ("local", job_id, url, "ashby", native_id, 0.9, "2026-05-25T21:35:55+00:00"),
         )
-        conn.execute(
-            """
-            INSERT INTO job_source_observations (
-                tenant_id, source_observation_id, job_url, source_id, source_native_id,
-                observed_url, normalized_observed_url, run_id, observed_at
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-            """,
-            (
-                "local",
-                f"obs-{native_id}",
-                url,
-                "ashby:perk",
-                native_id,
-                url,
-                url,
-                "test",
-                "2026-05-25T21:35:55+00:00",
-            ),
+        _insert_source_observation(
+            conn,
+            observation_id=f"obs-{native_id}",
+            job_id=job_id,
+            source_id="ashby:perk",
+            source_native_id=native_id,
+            url=url,
+            observed_at="2026-05-25T21:35:55+00:00",
         )
     conn.commit()
 
@@ -742,10 +807,7 @@ def test_discovery_hygiene_retires_ashby_business_travel_portugal_rows(
     )
 
     assert result["retired_jobs"] == 1
-    deleted = {
-        row["job_url"]: row["reason"]
-        for row in conn.execute("SELECT job_url, reason FROM jobctrl_deleted_jobs").fetchall()
-    }
+    deleted = _deleted_reasons_by_url(conn)
     assert good_url not in deleted
     assert "title_mismatch" in deleted[bad_url]
     assert "location_mismatch" in deleted[bad_url]
@@ -778,40 +840,25 @@ def test_discovery_hygiene_retires_invalid_jobspy_rows(
         ),
     ]
     for index, (url, title, location, description, source_id) in enumerate(rows):
-        conn.execute(
-            """
-            INSERT INTO jobs (url, title, company, description, location, site, strategy, discovered_at)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-            """,
-            (
-                url,
-                title,
-                "LinkedInCo",
-                description,
-                location,
-                "linkedin",
-                "jobspy",
-                "2026-05-20T00:00:00+00:00",
-            ),
+        job_id = _insert_v7_job(
+            conn,
+            url=url,
+            title=title,
+            company="LinkedInCo",
+            description=description,
+            location=location,
+            site="linkedin",
+            strategy="jobspy",
+            discovered_at="2026-05-20T00:00:00+00:00",
         )
-        conn.execute(
-            """
-            INSERT INTO job_source_observations (
-                tenant_id, source_observation_id, job_url, source_id, source_native_id,
-                observed_url, normalized_observed_url, run_id, observed_at
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-            """,
-            (
-                "local",
-                f"jobspy-obs-{index}",
-                url,
-                source_id,
-                f"li-{index}",
-                url,
-                url,
-                "test",
-                "2026-05-20T00:00:00+00:00",
-            ),
+        _insert_source_observation(
+            conn,
+            observation_id=f"jobspy-obs-{index}",
+            job_id=job_id,
+            source_id=source_id,
+            source_native_id=f"li-{index}",
+            url=url,
+            observed_at="2026-05-20T00:00:00+00:00",
         )
     conn.commit()
 
@@ -835,10 +882,7 @@ def test_discovery_hygiene_retires_invalid_jobspy_rows(
     )
 
     assert result["retired_jobs"] == 2
-    deleted = {
-        row["job_url"]: row["reason"]
-        for row in conn.execute("SELECT job_url, reason FROM jobctrl_deleted_jobs").fetchall()
-    }
+    deleted = _deleted_reasons_by_url(conn)
     assert "https://www.linkedin.com/jobs/view/valid-head-engineering" not in deleted
     assert "title_mismatch" in deleted["https://www.linkedin.com/jobs/view/head-school-biomedical"]
     assert "location_mismatch" in deleted["https://www.linkedin.com/jobs/view/us-engineering-manager"]
@@ -879,50 +923,39 @@ def test_discovery_hygiene_treats_serialized_null_descriptions_as_missing(
             "Lead engineering teams in Barcelona.",
         ),
     ]
+    job_ids_by_url: dict[str, str] = {}
     for index, (url, title, location, description) in enumerate(rows):
-        conn.execute(
-            """
-            INSERT INTO jobs (url, title, company, description, location, site, strategy, discovered_at)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-            """,
-            (
-                url,
-                title,
-                "LinkedInCo",
-                description,
-                location,
-                "linkedin",
-                "jobspy",
-                "2026-05-20T00:00:00+00:00",
-            ),
+        job_id = _insert_v7_job(
+            conn,
+            url=url,
+            title=title,
+            company="LinkedInCo",
+            description=description,
+            location=location,
+            site="linkedin",
+            strategy="jobspy",
+            discovered_at="2026-05-20T00:00:00+00:00",
         )
-        conn.execute(
-            """
-            INSERT INTO job_source_observations (
-                tenant_id, source_observation_id, job_url, source_id, source_native_id,
-                observed_url, normalized_observed_url, run_id, observed_at
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-            """,
-            (
-                "local",
-                f"jobspy-sentinel-obs-{index}",
-                url,
-                "jobspy:linkedin",
-                f"li-sentinel-{index}",
-                url,
-                url,
-                "test",
-                "2026-05-20T00:00:00+00:00",
-            ),
+        job_ids_by_url[url] = job_id
+        _insert_source_observation(
+            conn,
+            observation_id=f"jobspy-sentinel-obs-{index}",
+            job_id=job_id,
+            source_id="jobspy:linkedin",
+            source_native_id=f"li-sentinel-{index}",
+            url=url,
+            observed_at="2026-05-20T00:00:00+00:00",
         )
     conn.execute(
         """
         INSERT INTO job_enrichments (
-            job_url, tenant_id, current_status, full_description, updated_at
+            job_id, tenant_id, current_status, full_description, updated_at
         ) VALUES (?, ?, ?, ?, ?)
         """,
         (
-            "https://www.linkedin.com/jobs/view/enrichment-sentinel-with-fallback",
+            job_ids_by_url[
+                "https://www.linkedin.com/jobs/view/enrichment-sentinel-with-fallback"
+            ],
             "local",
             "success",
             "<NA>",
@@ -942,10 +975,7 @@ def test_discovery_hygiene_treats_serialized_null_descriptions_as_missing(
     )
 
     assert result["retired_jobs"] == 3
-    deleted = {
-        row["job_url"]: row["reason"]
-        for row in conn.execute("SELECT job_url, reason FROM jobctrl_deleted_jobs").fetchall()
-    }
+    deleted = _deleted_reasons_by_url(conn)
     assert "https://www.linkedin.com/jobs/view/valid-head-engineering" not in deleted
     assert (
         "https://www.linkedin.com/jobs/view/enrichment-sentinel-with-fallback"
@@ -1013,40 +1043,25 @@ def test_discovery_hygiene_applies_to_workday_and_smart_extract_rows(
         ),
     ]
     for index, (url, title, location, description, site, strategy, source_id) in enumerate(rows):
-        conn.execute(
-            """
-            INSERT INTO jobs (url, title, company, description, location, site, strategy, discovered_at)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-            """,
-            (
-                url,
-                title,
-                site,
-                description,
-                location,
-                site,
-                strategy,
-                "2026-05-20T00:00:00+00:00",
-            ),
+        job_id = _insert_v7_job(
+            conn,
+            url=url,
+            title=title,
+            company=site,
+            description=description,
+            location=location,
+            site=site,
+            strategy=strategy,
+            discovered_at="2026-05-20T00:00:00+00:00",
         )
-        conn.execute(
-            """
-            INSERT INTO job_source_observations (
-                tenant_id, source_observation_id, job_url, source_id, source_native_id,
-                observed_url, normalized_observed_url, run_id, observed_at
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-            """,
-            (
-                "local",
-                f"source-family-obs-{index}",
-                url,
-                source_id,
-                f"native-{index}",
-                url,
-                url,
-                "test",
-                "2026-05-20T00:00:00+00:00",
-            ),
+        _insert_source_observation(
+            conn,
+            observation_id=f"source-family-obs-{index}",
+            job_id=job_id,
+            source_id=source_id,
+            source_native_id=f"native-{index}",
+            url=url,
+            observed_at="2026-05-20T00:00:00+00:00",
         )
     conn.commit()
 
@@ -1065,10 +1080,7 @@ def test_discovery_hygiene_applies_to_workday_and_smart_extract_rows(
     )
 
     assert result["retired_jobs"] == 3
-    deleted = {
-        row["job_url"]: row["reason"]
-        for row in conn.execute("SELECT job_url, reason FROM jobctrl_deleted_jobs").fetchall()
-    }
+    deleted = _deleted_reasons_by_url(conn)
     assert "https://acme.wd1.myworkdayjobs.com/jobs/valid-engineering-manager" not in deleted
     assert "https://wellfound.com/jobs/valid-head-engineering" not in deleted
     assert "title_mismatch" in deleted["https://acme.wd1.myworkdayjobs.com/jobs/customer-success"]
@@ -1296,10 +1308,12 @@ def test_enrichment_snapshot_success_uses_observed_source_id(
     )
     row = conn.execute(
         """
-        SELECT jobs.url, jobs.title, jobs.site, job_source_observations.source_id
+        SELECT jobs.job_id, jobs.url, jobs.title, jobs.site,
+               job_source_observations.source_id
         FROM jobs
         JOIN job_source_observations
-            ON job_source_observations.job_url = jobs.url
+          ON job_source_observations.tenant_id = jobs.tenant_id
+         AND job_source_observations.job_id = jobs.job_id
         WHERE job_source_observations.source_id = ?
         LIMIT 1
         """,
@@ -1310,6 +1324,7 @@ def test_enrichment_snapshot_success_uses_observed_source_id(
     _record_posting_snapshot_from_cascade(
         conn,
         url=row["url"],
+        job_id=row["job_id"],
         source_id=row["site"],
         title=row["title"],
         cascade_result={
@@ -1383,7 +1398,7 @@ def test_manual_capture_import_runs_discovery_enrichment_and_snapshot_pipeline(
     assert conn.execute(
         """
         SELECT strategy FROM jobs
-        WHERE url = ?
+        WHERE job_id = ?
         """,
         (outcome.job_id,),
     ).fetchone()["strategy"] == "manual"
@@ -1391,7 +1406,7 @@ def test_manual_capture_import_runs_discovery_enrichment_and_snapshot_pipeline(
         """
         SELECT current_status, extraction_tier
         FROM job_enrichments
-        WHERE job_url = ?
+        WHERE job_id = ?
         """,
         (outcome.job_id,),
     ).fetchone()
@@ -1400,7 +1415,7 @@ def test_manual_capture_import_runs_discovery_enrichment_and_snapshot_pipeline(
         """
         SELECT latest_snapshot_version, latest_active_state
         FROM posting_snapshot_sets
-        WHERE job_url = ?
+        WHERE job_id = ?
         """,
         (outcome.job_id,),
     ).fetchone()
@@ -1518,7 +1533,7 @@ def test_manual_capture_import_cli_routes_api_bridge_through_worker_pipeline(
     assert captured.err == ""
     assert exit_code == 0
     result = json.loads(captured.out)
-    assert result["jobId"] == "https://login.protected.example/jobs/vp-engineering"
+    assert result["jobId"]
     assert result["promotedToJobEnrichment"] is True
     assert result["retryContext"]["manual_capture_provenance"]["source_kind"] == (
         "user_mediated_capture"
@@ -1526,6 +1541,10 @@ def test_manual_capture_import_cli_routes_api_bridge_through_worker_pipeline(
     verify_conn = sqlite3.connect(db_path)
     verify_conn.row_factory = sqlite3.Row
     try:
+        assert result["jobId"] == verify_conn.execute(
+            "SELECT job_id FROM jobs WHERE url = ?",
+            ("https://login.protected.example/jobs/vp-engineering",),
+        ).fetchone()["job_id"]
         assert (
             verify_conn.execute(
                 "SELECT strategy FROM jobs WHERE url = ?",
@@ -1535,8 +1554,8 @@ def test_manual_capture_import_cli_routes_api_bridge_through_worker_pipeline(
         )
         assert (
             verify_conn.execute(
-                "SELECT current_status FROM job_enrichments WHERE job_url = ?",
-                ("https://login.protected.example/jobs/vp-engineering",),
+                "SELECT current_status FROM job_enrichments WHERE job_id = ?",
+                (result["jobId"],),
             ).fetchone()["current_status"]
             == "enriched"
         )

--- a/workers/automation/tests/test_discovery_production_wiring.py
+++ b/workers/automation/tests/test_discovery_production_wiring.py
@@ -32,6 +32,7 @@ from jobctrl.domain.ports.discovery import ScrapedJobPosting
 from jobctrl.enrichment.detail import _record_posting_snapshot_from_cascade
 from jobctrl.infrastructure.discovery.production_wiring import (
     ManualCaptureImport,
+    _manual_capture_posting,
     _posting_acceptance_policy,
     build_discovery_acceptance_report,
     import_manual_capture_item,
@@ -344,6 +345,7 @@ def _manual_capture_html() -> str:
         {{
           "@type": "JobPosting",
           "title": "VP Engineering",
+          "hiringOrganization": {{"name": "Acme"}},
           "description": "{description}",
           "directApply": true,
           "url": "https://login.protected.example/jobs/vp-engineering",
@@ -360,6 +362,19 @@ def _manual_capture_html() -> str:
       <body><main>{description}</main></body>
     </html>
     """
+
+
+def test_manual_capture_mapper_preserves_employer_and_source() -> None:
+    posting = _manual_capture_posting(
+        source_id="manual:protected-board",
+        item_id="manual-item",
+        url="https://login.protected.example/jobs/vp-engineering",
+        content=_manual_capture_html(),
+        originating_url="https://login.protected.example/jobs",
+    )
+
+    assert posting.employer.name == "Acme"
+    assert posting.source.board == "User-mediated capture"
 
 
 def test_worker_seeds_api_visible_locator_and_manual_queues(
@@ -1395,13 +1410,14 @@ def test_manual_capture_import_runs_discovery_enrichment_and_snapshot_pipeline(
 
     assert outcome.promoted_to_job_enrichment is True
     assert outcome.quarantine_reason == "none"
-    assert conn.execute(
+    job_row = conn.execute(
         """
-        SELECT strategy FROM jobs
+        SELECT strategy, company, site FROM jobs
         WHERE job_id = ?
         """,
         (outcome.job_id,),
-    ).fetchone()["strategy"] == "manual"
+    ).fetchone()
+    assert tuple(job_row) == ("manual", "Acme", "User-mediated capture")
     enrichment_row = conn.execute(
         """
         SELECT current_status, extraction_tier

--- a/workers/automation/tests/test_discovery_search_units.py
+++ b/workers/automation/tests/test_discovery_search_units.py
@@ -23,6 +23,7 @@ from jobctrl.domain.identifiers import JobId
 from jobctrl.domain.tenant import LOCAL_TENANT
 from jobctrl.discovery.jobspy import store_jobspy_results
 from jobctrl.infrastructure.compensation import SqlitePostedCompensationRepository
+from jobctrl.infrastructure.discovery.production_wiring import DurableJobEventPublisher
 from jobctrl.infrastructure.discovery.sqlite_repository import SqliteJobRepository
 from jobctrl.infrastructure.discovery.sqlite_search_unit_repository import (
     DiscoverySearchPlanConflict,
@@ -593,20 +594,20 @@ def test_mid_event_supersession_is_fenced_and_retry_repairs_audit_rows(
             "reject_patterns": [],
         },
     }
-    original_set_identity = SqliteJobRepository.set_canonical_identity
+    original_publish = DurableJobEventPublisher.publish
     reclaimed: list = []
 
-    def reclaim_before_identity(self, tenant_id, job_id, identity):
+    def reclaim_before_event(self, event):
         if not reclaimed:
             next_lease = search_units.claim_next(execution, "attempt-2", 2)
             assert next_lease is not None
             reclaimed.append(next_lease)
-        return original_set_identity(self, tenant_id, job_id, identity)
+        return original_publish(self, event)
 
     monkeypatch.setattr(
-        SqliteJobRepository,
-        "set_canonical_identity",
-        reclaim_before_identity,
+        DurableJobEventPublisher,
+        "publish",
+        reclaim_before_event,
     )
 
     with pytest.raises(StaleDiscoverySearchUnitLease):
@@ -632,9 +633,29 @@ def test_mid_event_supersession_is_fenced_and_retry_repairs_audit_rows(
             "SELECT COUNT(*) FROM job_canonical_identities WHERE job_url = ?",
             ("https://example.test/jobs/mid-event",),
         ).fetchone()[0]
-        == 0
+        == 1
     )
     assert reclaimed
+    assert (
+        search_db.execute(
+            """
+            SELECT COUNT(*) FROM job_source_observations
+            WHERE job_id = (SELECT job_id FROM jobs WHERE tenant_id = ? AND url = ?)
+            """,
+            (str(LOCAL_TENANT), "https://example.test/jobs/mid-event"),
+        ).fetchone()[0]
+        == 1
+    )
+    assert (
+        search_db.execute(
+            """
+            SELECT COUNT(*) FROM job_events
+            WHERE job_id = (SELECT job_id FROM jobs WHERE tenant_id = ? AND url = ?)
+            """,
+            (str(LOCAL_TENANT), "https://example.test/jobs/mid-event"),
+        ).fetchone()[0]
+        == 0
+    )
 
     resumed = store_jobspy_results(
         search_db,

--- a/workers/automation/tests/test_job_repository.py
+++ b/workers/automation/tests/test_job_repository.py
@@ -10,21 +10,29 @@ the aggregate's ``deleted_at`` field stays consistent with the
 from __future__ import annotations
 
 import sqlite3
+import threading
+import uuid
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
 
 import pytest
 
-from jobctrl.database import init_db, resurface_deleted_job
+from jobctrl.database import init_db
 from jobctrl.domain.discovery import (
     Employer,
     Job,
     JobMetadata,
+    JobSourceObservation,
     PostingUrl,
     SearchStrategy,
     Source,
 )
 from jobctrl.domain.identifiers import JobId
-from jobctrl.domain.tenant import LOCAL_TENANT
-from jobctrl.infrastructure.discovery import SqliteJobRepository
+from jobctrl.domain.tenant import LOCAL_TENANT, TenantId
+from jobctrl.infrastructure.discovery import (
+    SqliteJobIdentityResolver,
+    SqliteJobRepository,
+)
 from jobctrl.infrastructure.discovery.sqlite_repository import JobUrlConflict
 
 
@@ -34,10 +42,14 @@ def conn(tmp_path) -> sqlite3.Connection:
     return init_db(db_path)
 
 
-def _make_job(url: str = "https://example.com/jobs/1") -> Job:
+def _make_job(
+    url: str = "https://example.com/jobs/1",
+    *,
+    job_id: JobId | None = None,
+) -> Job:
     return Job.discover(
         tenant_id=LOCAL_TENANT,
-        job_id=JobId(url),
+        job_id=job_id or JobId(str(uuid.uuid5(uuid.NAMESPACE_URL, url))),
         posting_url=PostingUrl(value=url),
         source=Source(board="greenhouse"),
         employer=Employer(name="Acme Corp"),
@@ -69,18 +81,197 @@ def test_save_then_load_round_trips(conn: sqlite3.Connection) -> None:
     assert loaded.is_deleted is False
 
 
-def test_load_by_url_finds_jobs(conn: sqlite3.Connection) -> None:
+def test_explicit_locator_resolution_finds_jobs(conn: sqlite3.Connection) -> None:
     repo = SqliteJobRepository(conn)
     job = _make_job()
     repo.save(job)
-    found = repo.load_by_url(LOCAL_TENANT, job.posting_url)
+    identity = repo.resolve_by_posting_url(LOCAL_TENANT, job.posting_url)
+    assert identity is not None
+    found = repo.load(LOCAL_TENANT, identity.job_id)
     assert found is not None
+    assert found.posting_url == job.posting_url
     assert found.job_id == job.job_id
 
 
-def test_load_by_url_returns_none_for_unknown(conn: sqlite3.Connection) -> None:
+def test_save_preserves_supplied_stable_job_id(conn: sqlite3.Connection) -> None:
     repo = SqliteJobRepository(conn)
-    assert repo.load_by_url(LOCAL_TENANT, PostingUrl(value="https://nope/")) is None
+    stable_id = JobId("1d4d7064-21e7-49dc-b53c-90676906af6e")
+    job = _make_job(job_id=stable_id)
+
+    repo.save(job)
+
+    found_by_id = repo.load(LOCAL_TENANT, stable_id)
+    assert found_by_id is not None
+    assert found_by_id.job_id == stable_id
+    assert found_by_id.posting_url == job.posting_url
+    with pytest.raises(ValueError, match="canonical UUID"):
+        repo.load(LOCAL_TENANT, JobId(job.posting_url.value))
+
+
+def test_identity_resolver_keeps_job_id_stable_across_url_aliases(
+    conn: sqlite3.Connection,
+) -> None:
+    repo = SqliteJobRepository(conn)
+    resolver = SqliteJobIdentityResolver(conn)
+    stable_id = JobId("b1bdf251-a7a2-44b9-99fa-cb4097fe6942")
+    original_url = PostingUrl(value="https://example.com/jobs/original")
+    replacement_url = PostingUrl(value="https://example.com/jobs/current")
+    repo.save(_make_job(original_url.value, job_id=stable_id))
+    repo.attach_source_observation(
+        LOCAL_TENANT,
+        stable_id,
+        JobSourceObservation(
+            source_observation_id="obs-original",
+            source_id="greenhouse:acme",
+            source_native_id="original",
+            observed_url=original_url.value,
+            run_id="run-original",
+            observed_at="2026-05-01T00:00:00+00:00",
+        ),
+    )
+
+    returned_id = repo.save(
+        _make_job(
+            replacement_url.value,
+            job_id=stable_id,
+        )
+    )
+
+    by_id = resolver.resolve_by_job_id(LOCAL_TENANT, stable_id)
+    by_original_url = resolver.resolve_by_posting_url(LOCAL_TENANT, original_url)
+    by_replacement_url = resolver.resolve_by_posting_url(
+        LOCAL_TENANT,
+        replacement_url,
+    )
+    storage_row = conn.execute(
+        "SELECT url FROM jobs WHERE tenant_id = ? AND job_id = ?",
+        (str(LOCAL_TENANT), str(stable_id)),
+    ).fetchone()
+    locator_rows = conn.execute(
+        """
+        SELECT locator_value, is_current, retired_at
+        FROM job_locators
+        WHERE tenant_id = ? AND job_id = ?
+        ORDER BY locator_value
+        """,
+        (str(LOCAL_TENANT), str(stable_id)),
+    ).fetchall()
+    observation_row = conn.execute(
+        """
+        SELECT job_id
+        FROM job_source_observations
+        WHERE source_observation_id = 'obs-original'
+        """
+    ).fetchone()
+    assert returned_id == stable_id
+    assert by_id is not None
+    assert by_original_url == by_id
+    assert by_replacement_url == by_id
+    assert by_id.posting_url == replacement_url
+    assert storage_row["url"] == replacement_url.value
+    assert {
+        row["locator_value"]: (row["is_current"], row["retired_at"] is None)
+        for row in locator_rows
+    } == {
+        original_url.value: (0, False),
+        replacement_url.value: (1, True),
+    }
+    assert observation_row["job_id"] == str(stable_id)
+    assert by_original_url is not None
+    loaded_by_original_url = repo.load(LOCAL_TENANT, by_original_url.job_id)
+    assert loaded_by_original_url is not None
+    assert loaded_by_original_url.job_id == stable_id
+    assert loaded_by_original_url.posting_url == replacement_url
+    assert resolver.resolve_by_job_id(TenantId("other"), stable_id) is None
+    assert resolver.resolve_by_posting_url(TenantId("other"), replacement_url) is None
+
+
+def test_concurrent_first_save_returns_one_stable_url_owner(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "concurrent-jobctrl.db"
+    initialized = init_db(db_path)
+    initialized.close()
+    barrier = threading.Barrier(2)
+
+    class BarrierResolver:
+        def __init__(self, connection: sqlite3.Connection) -> None:
+            self._delegate = SqliteJobIdentityResolver(connection)
+            self._waited = False
+
+        def resolve_by_job_id(
+            self,
+            tenant_id: TenantId,
+            job_id: JobId,
+        ):
+            return self._delegate.resolve_by_job_id(tenant_id, job_id)
+
+        def resolve_by_posting_url(
+            self,
+            tenant_id: TenantId,
+            posting_url: PostingUrl,
+        ):
+            resolved = self._delegate.resolve_by_posting_url(
+                tenant_id,
+                posting_url,
+            )
+            if resolved is None and not self._waited:
+                self._waited = True
+                barrier.wait(timeout=5)
+            return resolved
+
+    connections = [
+        sqlite3.connect(
+            db_path,
+            timeout=10,
+            check_same_thread=False,
+        )
+        for _ in range(2)
+    ]
+    for connection in connections:
+        connection.row_factory = sqlite3.Row
+        connection.execute("PRAGMA foreign_keys = ON")
+        connection.execute("PRAGMA busy_timeout = 10000")
+    repositories = [
+        SqliteJobRepository(
+            connection,
+            identity_resolver=BarrierResolver(connection),
+        )
+        for connection in connections
+    ]
+    candidate_ids = [
+        JobId("b1e0e6f4-dafe-4a50-8c2f-55522e5a9ee5"),
+        JobId("ac03f977-cf3b-47a0-b060-51f50ec8de49"),
+    ]
+
+    def save_candidate(index: int) -> JobId:
+        return repositories[index].save(
+            _make_job(
+                "https://example.com/jobs/concurrent",
+                job_id=candidate_ids[index],
+            )
+        )
+
+    try:
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            returned_ids = list(executor.map(save_candidate, range(2)))
+        check = sqlite3.connect(db_path)
+        try:
+            rows = check.execute("SELECT job_id, url FROM jobs").fetchall()
+        finally:
+            check.close()
+    finally:
+        for connection in connections:
+            connection.close()
+
+    assert len(rows) == 1
+    assert returned_ids[0] == returned_ids[1] == JobId(str(rows[0][0]))
+    assert rows[0][1] == "https://example.com/jobs/concurrent"
+
+
+def test_explicit_locator_resolution_returns_none_for_unknown(conn: sqlite3.Connection) -> None:
+    repo = SqliteJobRepository(conn)
+    assert repo.resolve_by_posting_url(LOCAL_TENANT, PostingUrl(value="https://nope/")) is None
 
 
 def test_save_idempotent_preserves_discovered_at(conn: sqlite3.Connection) -> None:
@@ -115,7 +306,7 @@ def test_save_rejects_url_owned_by_different_job(conn: sqlite3.Connection) -> No
     repo.save(_make_job())
     intruder = Job.discover(
         tenant_id=LOCAL_TENANT,
-        job_id=JobId("different-id"),
+        job_id=JobId("18a92504-89e8-4966-a765-ab641919cb6d"),
         posting_url=PostingUrl(value="https://example.com/jobs/1"),
         source=Source(board="linkedin"),
         employer=Employer.unknown(),
@@ -125,13 +316,22 @@ def test_save_rejects_url_owned_by_different_job(conn: sqlite3.Connection) -> No
     )
     with pytest.raises(JobUrlConflict):
         repo.save(intruder)
+    assert conn.in_transaction is False
+    identity = repo.resolve_by_posting_url(
+        LOCAL_TENANT,
+        PostingUrl(value="https://example.com/jobs/1"),
+    )
+    assert identity is not None
+    owner = repo.load(LOCAL_TENANT, identity.job_id)
+    assert owner is not None
+    assert owner.metadata.title == "Senior Engineer"
 
 
 def test_list_recent_orders_by_discovered_at_desc(conn: sqlite3.Connection) -> None:
     repo = SqliteJobRepository(conn)
     older = Job.discover(
         tenant_id=LOCAL_TENANT,
-        job_id=JobId("https://example.com/old"),
+        job_id=JobId("236e953a-4d76-5659-bd18-b8a75f2b46f7"),
         posting_url=PostingUrl(value="https://example.com/old"),
         source=Source(board="greenhouse"),
         employer=Employer.unknown(),
@@ -141,7 +341,7 @@ def test_list_recent_orders_by_discovered_at_desc(conn: sqlite3.Connection) -> N
     )
     newer = Job.discover(
         tenant_id=LOCAL_TENANT,
-        job_id=JobId("https://example.com/new"),
+        job_id=JobId("e0d3c715-6368-592f-88ee-5f0b94ef395c"),
         posting_url=PostingUrl(value="https://example.com/new"),
         source=Source(board="greenhouse"),
         employer=Employer.unknown(),
@@ -164,7 +364,7 @@ def test_list_recent_hides_soft_deleted_by_default(conn: sqlite3.Connection) -> 
     repo.save(_make_job("https://example.com/b"))
     repo.soft_delete(
         LOCAL_TENANT,
-        JobId("https://example.com/a"),
+        _make_job("https://example.com/a").job_id,
         reason="test",
         deleted_at="2026-05-02T00:00:00+00:00",
     )
@@ -192,8 +392,15 @@ def test_soft_delete_writes_tombstone_row(conn: sqlite3.Connection) -> None:
     assert deleted is not None and deleted.is_deleted
 
     row = conn.execute(
-        "SELECT deleted_at, reason, restored_at FROM jobctrl_deleted_jobs WHERE job_url = ?",
-        (str(job.job_id),),
+        """
+        SELECT deleted.deleted_at, deleted.reason, deleted.restored_at
+        FROM jobctrl_deleted_jobs AS deleted
+        JOIN jobs
+          ON jobs.tenant_id = deleted.tenant_id
+         AND jobs.job_id = deleted.job_id
+        WHERE jobs.url = ?
+        """,
+        (job.posting_url.value,),
     ).fetchone()
     assert row is not None
     assert row["deleted_at"] == "2026-05-02T00:00:00+00:00"
@@ -210,7 +417,7 @@ def test_soft_delete_returns_none_for_unknown_job(conn: sqlite3.Connection) -> N
     assert (
         repo.soft_delete(
             LOCAL_TENANT,
-            JobId("https://nope/"),
+            JobId("c726db63-04d4-4de5-a4e8-c1d6ebfe6090"),
             reason=None,
             deleted_at="2026-05-02T00:00:00+00:00",
         )
@@ -239,39 +446,18 @@ def test_restore_clears_tombstone(conn: sqlite3.Connection) -> None:
 
     # Tombstone row carries restored_at (audit history preserved)
     row = conn.execute(
-        "SELECT restored_at FROM jobctrl_deleted_jobs WHERE job_url = ?",
-        (str(job.job_id),),
+        """
+        SELECT deleted.restored_at
+        FROM jobctrl_deleted_jobs AS deleted
+        JOIN jobs
+          ON jobs.tenant_id = deleted.tenant_id
+         AND jobs.job_id = deleted.job_id
+        WHERE jobs.url = ?
+        """,
+        (job.posting_url.value,),
     ).fetchone()
     assert row is not None
     assert row["restored_at"] is not None
-
-
-def test_resurface_deleted_job_clears_tombstone_and_records_event(conn: sqlite3.Connection) -> None:
-    repo = SqliteJobRepository(conn)
-    job = _make_job()
-    repo.save(job)
-    repo.soft_delete(
-        LOCAL_TENANT,
-        job.job_id,
-        reason="not right now",
-        deleted_at="2026-05-02T00:00:00+00:00",
-    )
-
-    resurface_deleted_job(conn, str(job.job_id), resurfaced_at="2026-05-03T00:00:00+00:00")
-
-    row = conn.execute(
-        "SELECT restored_at FROM jobctrl_deleted_jobs WHERE job_url = ?",
-        (str(job.job_id),),
-    ).fetchone()
-    assert row is not None
-    assert row["restored_at"] == "2026-05-03T00:00:00+00:00"
-    event = conn.execute(
-        "SELECT event_type, message FROM job_events WHERE job_url = ? ORDER BY event_id DESC LIMIT 1",
-        (str(job.job_id),),
-    ).fetchone()
-    assert event is not None
-    assert event["event_type"] == "JobRestored"
-    assert event["message"] == "Job resurfaced because discovery observed it again."
 
 
 def test_restore_is_noop_for_undeleted_job(conn: sqlite3.Connection) -> None:

--- a/workers/automation/tests/test_job_repository.py
+++ b/workers/automation/tests/test_job_repository.py
@@ -81,6 +81,28 @@ def test_save_then_load_round_trips(conn: sqlite3.Connection) -> None:
     assert loaded.is_deleted is False
 
 
+def test_reopen_round_trips_employer_separately_from_source(tmp_path: Path) -> None:
+    db_path = tmp_path / "employer-source.db"
+    writer = init_db(db_path)
+    original = _make_job().with_employer(Employer(name="Acme"))
+    SqliteJobRepository(writer).save(original)
+    writer.close()
+
+    reader = init_db(db_path)
+    try:
+        loaded = SqliteJobRepository(reader).load(LOCAL_TENANT, original.job_id)
+        stored = reader.execute(
+            "SELECT company, site FROM jobs WHERE tenant_id = ? AND job_id = ?",
+            (str(LOCAL_TENANT), str(original.job_id)),
+        ).fetchone()
+        assert loaded is not None
+        assert loaded.employer.name == "Acme"
+        assert loaded.source.board == "greenhouse"
+        assert tuple(stored) == ("Acme", "greenhouse")
+    finally:
+        reader.close()
+
+
 def test_explicit_locator_resolution_finds_jobs(conn: sqlite3.Connection) -> None:
     repo = SqliteJobRepository(conn)
     job = _make_job()
@@ -129,6 +151,79 @@ def test_identity_resolver_keeps_job_id_stable_across_url_aliases(
             observed_at="2026-05-01T00:00:00+00:00",
         ),
     )
+    conn.execute(
+        """
+        INSERT INTO job_scores (
+            tenant_id, job_id, version, fit_score, breakdown_json,
+            keywords_json, scored_at
+        ) VALUES (?, ?, 1, 8, '{}', '["python"]', ?)
+        """,
+        (str(LOCAL_TENANT), str(stable_id), "2026-05-01T01:00:00+00:00"),
+    )
+    conn.execute(
+        """
+        INSERT INTO job_stage_states (
+            tenant_id, job_id, stage, state, updated_at
+        ) VALUES (?, ?, 'score', 'succeeded', ?)
+        """,
+        (str(LOCAL_TENANT), str(stable_id), "2026-05-01T01:00:00+00:00"),
+    )
+    conn.execute(
+        """
+        INSERT INTO preparation_work_items (
+            item_id, tenant_id, job_id, kind, target_version,
+            source_event_id, state, idempotency_key, created_at,
+            updated_at, available_at
+        ) VALUES (
+            'prep-alias', ?, ?, 'score', 1,
+            'event-alias', 'completed', 'prep-alias-key', ?, ?, ?
+        )
+        """,
+        (
+            str(LOCAL_TENANT),
+            str(stable_id),
+            "2026-05-01T01:00:00+00:00",
+            "2026-05-01T01:00:00+00:00",
+            "2026-05-01T01:00:00+00:00",
+        ),
+    )
+    conn.execute(
+        """
+        INSERT INTO job_artifacts (
+            tenant_id, job_id, stage, artifact_type, status, path, created_at
+        ) VALUES (?, ?, 'tailor', 'resume_pdf', 'accepted', ?, ?)
+        """,
+        (
+            str(LOCAL_TENANT),
+            str(stable_id),
+            "artifacts/resume-alias.pdf",
+            "2026-05-01T01:00:00+00:00",
+        ),
+    )
+    conn.execute(
+        """
+        INSERT INTO job_events (
+            tenant_id, job_id, identity_version, stage, event_type,
+            occurred_at, payload_json
+        ) VALUES (?, ?, 7, 'score', 'JobScored', ?, '{}')
+        """,
+        (str(LOCAL_TENANT), str(stable_id), "2026-05-01T01:00:00+00:00"),
+    )
+    conn.execute(
+        """
+        INSERT INTO application_outcomes (
+            tenant_id, outcome_id, job_id, kind, source,
+            occurred_at, recorded_at
+        ) VALUES (?, 'outcome-alias', ?, 'interview', 'user', ?, ?)
+        """,
+        (
+            str(LOCAL_TENANT),
+            str(stable_id),
+            "2026-05-01T02:00:00+00:00",
+            "2026-05-01T02:00:00+00:00",
+        ),
+    )
+    conn.commit()
 
     returned_id = repo.save(
         _make_job(
@@ -177,6 +272,37 @@ def test_identity_resolver_keeps_job_id_stable_across_url_aliases(
         replacement_url.value: (1, True),
     }
     assert observation_row["job_id"] == str(stable_id)
+    dependent_rows = conn.execute(
+        """
+        SELECT 'job_scores' AS relation, job_id FROM job_scores
+        WHERE tenant_id = ? AND job_id = ?
+        UNION ALL
+        SELECT 'job_stage_states', job_id FROM job_stage_states
+        WHERE tenant_id = ? AND job_id = ?
+        UNION ALL
+        SELECT 'preparation_work_items', job_id FROM preparation_work_items
+        WHERE tenant_id = ? AND job_id = ?
+        UNION ALL
+        SELECT 'job_artifacts', job_id FROM job_artifacts
+        WHERE tenant_id = ? AND job_id = ?
+        UNION ALL
+        SELECT 'job_events', job_id FROM job_events
+        WHERE tenant_id = ? AND job_id = ?
+        UNION ALL
+        SELECT 'application_outcomes', job_id FROM application_outcomes
+        WHERE tenant_id = ? AND job_id = ?
+        """,
+        (str(LOCAL_TENANT), str(stable_id)) * 6,
+    ).fetchall()
+    assert {row["relation"]: row["job_id"] for row in dependent_rows} == {
+        "job_scores": str(stable_id),
+        "job_stage_states": str(stable_id),
+        "preparation_work_items": str(stable_id),
+        "job_artifacts": str(stable_id),
+        "job_events": str(stable_id),
+        "application_outcomes": str(stable_id),
+    }
+    assert conn.execute("PRAGMA foreign_key_check").fetchall() == []
     assert by_original_url is not None
     loaded_by_original_url = repo.load(LOCAL_TENANT, by_original_url.job_id)
     assert loaded_by_original_url is not None

--- a/workers/automation/tests/test_jobstreaming_resumable_discovery.py
+++ b/workers/automation/tests/test_jobstreaming_resumable_discovery.py
@@ -390,9 +390,13 @@ def test_store_before_ack_replay_resumes_without_duplicate_counts_or_events(
     assert interrupted_unit.checkpoint_revision == 0
     assert interrupted_unit.accepted_jobs == 1
     assert interrupted_unit.new_jobs == 1
-    first_job_event_count = conn.execute(
-        "SELECT COUNT(*) FROM job_events WHERE job_url = ?",
+    first_job_id = conn.execute(
+        "SELECT job_id FROM jobs WHERE url = ?",
         ("https://example.test/director-of-engineering/1",),
+    ).fetchone()["job_id"]
+    first_job_event_count = conn.execute(
+        "SELECT COUNT(*) FROM job_events WHERE job_id = ?",
+        (first_job_id,),
     ).fetchone()[0]
 
     result = jobspy.run_discovery(
@@ -423,8 +427,8 @@ def test_store_before_ack_replay_resumes_without_duplicate_counts_or_events(
     ).fetchone()
     assert event_counts[0] == event_counts[1]
     assert conn.execute(
-        "SELECT COUNT(*) FROM job_events WHERE job_url = ?",
-        ("https://example.test/director-of-engineering/1",),
+        "SELECT COUNT(*) FROM job_events WHERE job_id = ?",
+        (first_job_id,),
     ).fetchone()[0] == first_job_event_count
     assert any(
         snapshot["message"] == "Resuming interrupted JobStreaming search unit"

--- a/workers/automation/tests/test_smartextract_discovery.py
+++ b/workers/automation/tests/test_smartextract_discovery.py
@@ -10,6 +10,7 @@ from jobctrl.discovery import smartextract
 from jobctrl.domain.identifiers import generate_job_id
 from jobctrl.domain.discovery import (
     AtsKind,
+    Employer,
     JobMetadata,
     PostingUrl,
     SearchStrategy,
@@ -121,7 +122,7 @@ def _ats_posting(
     *,
     canonical_url: str,
     description: str,
-    board: str = "Acme",
+    board: str = "greenhouse",
     title: str = "Staff Platform Engineer",
     source_id: str = "greenhouse:acme",
     source_native_id: str = "gh-1",
@@ -130,6 +131,7 @@ def _ats_posting(
     return ScrapedJobPosting(
         posting_url=PostingUrl(value=canonical_url),
         source=Source(board=board),
+        employer=Employer(name="Acme"),
         metadata=JobMetadata(title=title, description=description, location=location),
         strategy=SearchStrategy.WORKDAY_API,
         source_id=source_id,

--- a/workers/automation/tests/test_smartextract_discovery.py
+++ b/workers/automation/tests/test_smartextract_discovery.py
@@ -7,6 +7,7 @@ import pytest
 from jobctrl import config
 from jobctrl.database import close_connection, init_db
 from jobctrl.discovery import smartextract
+from jobctrl.domain.identifiers import generate_job_id
 from jobctrl.domain.discovery import (
     AtsKind,
     JobMetadata,
@@ -19,6 +20,15 @@ from jobctrl.domain.ports.discovery import ScrapedJobPosting
 from jobctrl.domain.tenant import LOCAL_TENANT
 from jobctrl.infrastructure.discovery import SqliteJobRepository
 from jobctrl.infrastructure.discovery.production_wiring import DurableJobEventPublisher
+
+
+def _job_id_by_url(conn, url: str) -> str:
+    row = conn.execute(
+        "SELECT job_id FROM jobs WHERE tenant_id = ? AND url = ?",
+        (str(LOCAL_TENANT), url),
+    ).fetchone()
+    assert row is not None
+    return str(row["job_id"])
 
 
 def test_short_headless_html_never_retries_headful_in_the_bundled_core(
@@ -379,10 +389,12 @@ def test_smart_extract_updates_existing_serialized_null_description(
         conn.execute(
             """
             INSERT INTO jobs (
-                url, title, company, description, location, site, strategy, discovered_at
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                tenant_id, job_id, url, title, company, description, location, site, strategy, discovered_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
+                str(LOCAL_TENANT),
+                str(generate_job_id()),
                 url,
                 "Head of Engineering",
                 "Startup.jobs",
@@ -395,21 +407,25 @@ def test_smart_extract_updates_existing_serialized_null_description(
         )
         conn.execute(
             """
-            CREATE TABLE IF NOT EXISTS jobctrl_deleted_jobs (
-                job_url TEXT PRIMARY KEY,
-                deleted_at TEXT NOT NULL,
-                reason TEXT,
-                restored_at TEXT,
-                FOREIGN KEY(job_url) REFERENCES jobs(url)
+            INSERT INTO job_locators (
+                tenant_id, job_id, locator_kind, locator_value,
+                is_current, first_seen_at, last_seen_at, retired_at
             )
-            """
+            SELECT tenant_id, job_id, 'posting_url', url, 1, discovered_at, discovered_at, NULL
+            FROM jobs WHERE tenant_id = ? AND url = ?
+            """,
+            (str(LOCAL_TENANT), url),
         )
         conn.execute(
             """
-            INSERT INTO jobctrl_deleted_jobs (job_url, deleted_at, reason, restored_at)
-            VALUES (?, ?, ?, NULL)
+            INSERT INTO jobctrl_deleted_jobs (
+                tenant_id, job_id, deleted_at, reason, restored_at
+            )
+            SELECT tenant_id, job_id, ?, ?, NULL
+            FROM jobs
+            WHERE tenant_id = ? AND url = ?
             """,
-            (url, "2026-05-20T00:00:00+00:00", "missing_description"),
+            ("2026-05-20T00:00:00+00:00", "missing_description", str(LOCAL_TENANT), url),
         )
         conn.commit()
 
@@ -434,7 +450,9 @@ def test_smart_extract_updates_existing_serialized_null_description(
             """
             SELECT j.description, d.restored_at
             FROM jobs j
-            JOIN jobctrl_deleted_jobs d ON d.job_url = j.url
+            JOIN jobctrl_deleted_jobs d
+              ON d.tenant_id = j.tenant_id
+             AND d.job_id = j.job_id
             WHERE j.url = ?
             """,
             (url,),
@@ -457,10 +475,12 @@ def test_smart_extract_refreshes_existing_title_location_before_restore(
         conn.execute(
             """
             INSERT INTO jobs (
-                url, title, company, description, location, site, strategy, discovered_at
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                tenant_id, job_id, url, title, company, description, location, site, strategy, discovered_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
+                str(LOCAL_TENANT),
+                str(generate_job_id()),
                 url,
                 "Sales Director, Platform Services",
                 "",
@@ -473,21 +493,25 @@ def test_smart_extract_refreshes_existing_title_location_before_restore(
         )
         conn.execute(
             """
-            CREATE TABLE IF NOT EXISTS jobctrl_deleted_jobs (
-                job_url TEXT PRIMARY KEY,
-                deleted_at TEXT NOT NULL,
-                reason TEXT,
-                restored_at TEXT,
-                FOREIGN KEY(job_url) REFERENCES jobs(url)
+            INSERT INTO job_locators (
+                tenant_id, job_id, locator_kind, locator_value,
+                is_current, first_seen_at, last_seen_at, retired_at
             )
-            """
+            SELECT tenant_id, job_id, 'posting_url', url, 1, discovered_at, discovered_at, NULL
+            FROM jobs WHERE tenant_id = ? AND url = ?
+            """,
+            (str(LOCAL_TENANT), url),
         )
         conn.execute(
             """
-            INSERT INTO jobctrl_deleted_jobs (job_url, deleted_at, reason, restored_at)
-            VALUES (?, ?, ?, NULL)
+            INSERT INTO jobctrl_deleted_jobs (
+                tenant_id, job_id, deleted_at, reason, restored_at
+            )
+            SELECT tenant_id, job_id, ?, ?, NULL
+            FROM jobs
+            WHERE tenant_id = ? AND url = ?
             """,
-            (url, "2026-05-20T00:00:00+00:00", "title/location mismatch"),
+            ("2026-05-20T00:00:00+00:00", "title/location mismatch", str(LOCAL_TENANT), url),
         )
         conn.commit()
 
@@ -513,7 +537,9 @@ def test_smart_extract_refreshes_existing_title_location_before_restore(
             """
             SELECT j.title, j.company, j.description, j.location, d.restored_at
             FROM jobs j
-            JOIN jobctrl_deleted_jobs d ON d.job_url = j.url
+            JOIN jobctrl_deleted_jobs d
+              ON d.tenant_id = j.tenant_id
+             AND d.job_id = j.job_id
             WHERE j.url = ?
             """,
             (url,),
@@ -619,15 +645,16 @@ def test_smart_extract_dedups_against_ats_first_content_owner(
         link = conn.execute(
             "SELECT surviving_job_id, reason, confidence FROM job_duplicate_links"
         ).fetchone()
-        assert link["surviving_job_id"] == owner_url
+        owner_job_id = _job_id_by_url(conn, owner_url)
+        assert link["surviving_job_id"] == owner_job_id
         assert link["reason"] == "content_fingerprint_match"
         assert link["confidence"] == 0.95
         linked_events = conn.execute(
-            "SELECT job_url FROM job_events WHERE event_type = 'DuplicateJobLinked'"
+            "SELECT job_id FROM job_events WHERE event_type = 'DuplicateJobLinked'"
         ).fetchall()
         assert len(linked_events) == 1
-        assert linked_events[0]["job_url"] == owner_url
-        observations = repository.list_observations(LOCAL_TENANT, owner_url)
+        assert linked_events[0]["job_id"] == owner_job_id
+        observations = repository.list_observations(LOCAL_TENANT, owner_job_id)
         assert "smartextract:Acme Careers" in {obs.source_id for obs in observations}
     finally:
         close_connection(db_path)
@@ -687,7 +714,7 @@ def test_ats_dedups_against_smart_extract_first_content_owner(
         link = conn.execute(
             "SELECT surviving_job_id, reason FROM job_duplicate_links"
         ).fetchone()
-        assert link["surviving_job_id"] == smart_url
+        assert link["surviving_job_id"] == _job_id_by_url(conn, smart_url)
         assert link["reason"] == "content_fingerprint_match"
     finally:
         close_connection(db_path)


### PR DESCRIPTION
## Summary

- enforce tenant-scoped canonical `JobId` throughout discovery persistence and events while keeping posting URLs as external locators
- arbitrate normalized observation claims atomically so aliases cannot re-home evidence to another Job
- preserve `Employer` and `Source` as independent facts in JobStreaming, Workday, SmartExtract, ATS, and manual-capture mappings
- hydrate and deduplicate discovery aggregates without reconstructing employer from source or URL metadata
- preserve canonical dependent rows when an accepted URL alias is attached to an existing Job
- omit `job.id` telemetry until discovery has a persisted canonical ID; never publish a posting URL as internal span identity

## Why

Discovery is the first persistence boundary for job identity. It must resolve a posting locator once, retain the source provider independently from the employer, and never pass a posting URL as an internal `JobId`.

## Validation

- discovery identity/repository suite: 46 passed
- ATS and manual-capture mapper suite: 16 passed
- discovery telemetry identity regression: 32 passed
- cumulative Step 3 Python suite: 185 passed
- focused Ruff and `git diff --check`: passed
- independent cumulative review: PASS, 0 Blocker / 0 High
- independent cumulative QA: PASS, 0 Blocker / 0 High

## Stack

Ready-for-review child of #570. Canonical product documentation and the final cumulative Tier 3 release gate remain deferred to the final PR in this unreleased stack.
