### PR TITLE
refactor(discovery): key search receipts by JobId

### DIFF
--- a/workers/automation/src/jobctrl/infrastructure/discovery/sqlite_repository.py
+++ b/workers/automation/src/jobctrl/infrastructure/discovery/sqlite_repository.py
@@ -299,7 +299,7 @@ class SqliteJobRepository:
             assert self._search_unit_lease is not None
             self._search_unit_repository.record_accepted_job(
                 self._search_unit_lease,
-                str(persisted_identity.job_id),
+                persisted_identity.job_id,
                 was_new=was_new,
                 accepted_at=job.discovered_at,
             )
@@ -989,7 +989,7 @@ class SqliteJobRepository:
             assert self._search_unit_lease is not None
             self._search_unit_repository.record_accepted_job(
                 self._search_unit_lease,
-                str(job_id),
+                job_id,
                 was_new=was_new,
                 accepted_at=observation.observed_at,
             )

--- a/workers/automation/src/jobctrl/infrastructure/discovery/sqlite_search_unit_repository.py
+++ b/workers/automation/src/jobctrl/infrastructure/discovery/sqlite_search_unit_repository.py
@@ -15,7 +15,6 @@ from jobstreaming import (
     SearchCheckpoint,
 )
 
-from jobctrl.database import ensure_discovery_search_unit_tables
 from jobctrl.domain.discovery.execution import DiscoveryExecutionRef
 from jobctrl.domain.discovery.search_units import (
     DiscoverySearchSpec,
@@ -25,6 +24,7 @@ from jobctrl.domain.discovery.search_units import (
     validate_search_unit_state,
     validate_unit_id,
 )
+from jobctrl.domain.identifiers import JobId, canonical_job_id
 
 
 _SAFE_ERROR_IDENTIFIER = re.compile(r"^[A-Za-z0-9_.:-]{1,128}$")
@@ -37,7 +37,7 @@ _SELECT_UNIT = """
            u.last_error_retryable, u.reset_checkpoint,
            u.reset_checkpoint_after_revision,
            u.created_at, u.updated_at, u.completed_at,
-           COUNT(j.job_url) AS accepted_jobs,
+           COUNT(j.job_id) AS accepted_jobs,
            COALESCE(SUM(j.was_new), 0) AS new_jobs
       FROM discovery_search_units u
       LEFT JOIN discovery_search_unit_jobs j
@@ -71,7 +71,6 @@ class SqliteDiscoverySearchUnitRepository:
 
     def __init__(self, conn: sqlite3.Connection) -> None:
         self._conn = conn
-        ensure_discovery_search_unit_tables(conn)
 
     def plan_units(
         self,
@@ -409,34 +408,32 @@ class SqliteDiscoverySearchUnitRepository:
     def record_accepted_job(
         self,
         lease: DiscoverySearchUnitLease,
-        job_url: str,
+        job_id: JobId,
         *,
         was_new: bool,
         accepted_at: str | None = None,
     ) -> None:
         """Record an idempotent accepted-job receipt under the current fence."""
 
-        normalized_url = job_url.strip()
-        if not normalized_url:
-            raise ValueError("job_url must be non-empty")
+        stable_job_id = str(canonical_job_id(str(job_id)))
         with self._conn:
             self.fence_write(lease)
             self._conn.execute(
                 """
                 INSERT INTO discovery_search_unit_jobs (
                     tenant_id, discover_workflow_id, discover_run_id,
-                    unit_id, job_url, was_new, accepted_at
+                    unit_id, job_id, was_new, accepted_at
                 ) VALUES (?, ?, ?, ?, ?, ?, ?)
                 ON CONFLICT (
                     tenant_id, discover_workflow_id, discover_run_id,
-                    unit_id, job_url
+                    unit_id, job_id
                 ) DO UPDATE SET
                     was_new = MAX(discovery_search_unit_jobs.was_new, excluded.was_new)
                 """,
                 (
                     *_execution_params(lease.execution),
                     lease.unit_id,
-                    normalized_url,
+                    stable_job_id,
                     int(was_new),
                     accepted_at or _utc_now(),
                 ),

--- a/workers/automation/tests/test_discovery_search_unit_identity.py
+++ b/workers/automation/tests/test_discovery_search_unit_identity.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from jobctrl.database import close_connection, init_db
+from jobctrl.domain.discovery.execution import DiscoveryExecutionRef
+from jobctrl.domain.discovery.search_units import DiscoverySearchSpec
+from jobctrl.domain.identifiers import JobId
+from jobctrl.infrastructure.discovery.sqlite_search_unit_repository import (
+    SqliteDiscoverySearchUnitRepository,
+)
+
+
+def _execution() -> DiscoveryExecutionRef:
+    return DiscoveryExecutionRef(
+        tenant_id="local",
+        workflow_id="discover-local",
+        temporal_run_id="temporal-run-1",
+    )
+
+
+def _spec() -> DiscoverySearchSpec:
+    return DiscoverySearchSpec(
+        query="Director of Engineering",
+        provider_location="Barcelona, Spain",
+        target_location="Barcelona, Spain",
+        sites=("indeed",),
+        results_per_site=25,
+        hours_old=72,
+        remote_only=True,
+        country_indeed="spain",
+        linkedin_fetch_description=True,
+        match_mode="recall",
+        target_track="engineering_leadership",
+        seniority_floor="director",
+        accept_locations=("Barcelona, Spain", "Europe"),
+        reject_locations=("United States",),
+        local_accept_locations=("Barcelona, Spain",),
+    )
+
+
+@pytest.fixture
+def search_db(tmp_path: Path):
+    db_path = tmp_path / "jobctrl.db"
+    conn = init_db(db_path)
+    try:
+        yield conn
+    finally:
+        close_connection(db_path)
+
+
+def test_repository_construction_does_not_mutate_exact_v7_schema(search_db) -> None:
+    schema_version = search_db.execute("PRAGMA schema_version").fetchone()[0]
+    total_changes = search_db.total_changes
+
+    SqliteDiscoverySearchUnitRepository(search_db)
+
+    assert search_db.execute("PRAGMA schema_version").fetchone()[0] == schema_version
+    assert search_db.total_changes == total_changes
+
+
+def test_accepted_receipts_use_canonical_job_id(search_db) -> None:
+    job_id = JobId("498fe0a9-6615-4b4d-b8fd-6cbb978f6ec6")
+    posting_url = "https://example.test/jobs/accepted"
+    search_db.execute(
+        """
+        INSERT INTO jobs (
+            tenant_id, job_id, url, title, salary, description, location, site, strategy
+        ) VALUES ('local', ?, ?, 'Director of Engineering', '', '', '', 'indeed', 'jobspy')
+        """,
+        (str(job_id), posting_url),
+    )
+    search_db.commit()
+    repository = SqliteDiscoverySearchUnitRepository(search_db)
+    execution = _execution()
+    repository.plan_units(execution, [_spec()])
+    lease = repository.claim_next(execution, "attempt-1", 1)
+    assert lease is not None
+
+    repository.record_accepted_job(
+        lease,
+        job_id,
+        was_new=True,
+        accepted_at="2026-07-30T10:00:00+00:00",
+    )
+    repository.record_accepted_job(
+        lease,
+        job_id,
+        was_new=False,
+        accepted_at="2026-07-30T10:01:00+00:00",
+    )
+
+    unit = repository.get_unit(execution, lease.unit_id)
+    assert unit is not None
+    assert unit.accepted_jobs == 1
+    assert unit.new_jobs == 1
+    receipt = search_db.execute(
+        "SELECT job_id, was_new FROM discovery_search_unit_jobs"
+    ).fetchone()
+    assert tuple(receipt) == (str(job_id), 1)
+
+
+def test_accepted_receipts_reject_url_shaped_identity(search_db) -> None:
+    repository = SqliteDiscoverySearchUnitRepository(search_db)
+    execution = _execution()
+    repository.plan_units(execution, [_spec()])
+    lease = repository.claim_next(execution, "attempt-1", 1)
+    assert lease is not None
+
+    with pytest.raises(ValueError, match="canonical UUID"):
+        repository.record_accepted_job(
+            lease,
+            JobId("https://example.test/jobs/not-an-id"),
+            was_new=True,
+        )
+
+    assert search_db.execute(
+        "SELECT COUNT(*) FROM discovery_search_unit_jobs"
+    ).fetchone()[0] == 0


### PR DESCRIPTION
## Summary

- key discovery search-unit acceptance receipts by canonical `JobId`
- validate canonical UUID serialization before writing a receipt
- count accepted jobs from exact-v7 `job_id` columns
- keep repository construction read-only instead of running schema setup at runtime

## Why

Search-unit persistence is part of the exact-v7 runtime cutover. It must use the same stable job identity as the discovery aggregate and must not mutate or infer schema shape when the runtime opens an already-migrated database.

## Validation

- staged-snapshot `pytest -q tests/test_discovery_search_unit_identity.py` — 3 passed
- staged-snapshot Ruff on all changed Python files — passed
- `git diff --cached --check` — passed

## Stack

Base: `feat/job-id-python-discovery` (#574). Broader JobSpy, compensation, and execution-lineage integration tests are intentionally left to their own follow-up slices; cumulative Tier 3 QA remains mandatory on the final branch.