### PR TITLE
refactor(discovery): key execution lineage by JobId

### DIFF
--- a/workers/automation/src/jobctrl/discovery/execution_reconciliation.py
+++ b/workers/automation/src/jobctrl/discovery/execution_reconciliation.py
@@ -1130,10 +1130,10 @@ def _persisted_membership_keys(
     temporal_run_id: str,
 ) -> set[str]:
     return {
-        str(row["job_url"])
+        str(row["job_id"])
         for row in conn.execute(
             """
-            SELECT job_url FROM discovery_execution_jobs
+            SELECT job_id FROM discovery_execution_jobs
             WHERE tenant_id = ? AND discover_workflow_id = ? AND discover_run_id = ?
             """,
             (tenant_id, workflow_id, temporal_run_id),

--- a/workers/automation/src/jobctrl/domain/discovery/execution.py
+++ b/workers/automation/src/jobctrl/domain/discovery/execution.py
@@ -12,6 +12,8 @@ import re
 from dataclasses import dataclass
 from typing import Literal
 
+from jobctrl.domain.identifiers import JobId
+
 
 DiscoveryExecutionCohortKind = Literal["observed_this_run", "existing_backlog"]
 DiscoveryExecutionWorkPlanState = Literal["pending", "planned", "not_eligible", "failed"]
@@ -69,7 +71,7 @@ class DiscoveryExecutionJob:
     """One job's immutable membership and decided work plan in an execution."""
 
     execution: DiscoveryExecutionRef
-    job_url: str
+    job_id: JobId
     cohort_kind: DiscoveryExecutionCohortKind
     source_family: str | None
     source_run_id: str | None

--- a/workers/automation/src/jobctrl/infrastructure/discovery/sqlite_execution_repository.py
+++ b/workers/automation/src/jobctrl/infrastructure/discovery/sqlite_execution_repository.py
@@ -6,7 +6,6 @@ import json
 import sqlite3
 from datetime import datetime, timezone
 
-from jobctrl.database import ensure_discovery_execution_tables
 from jobctrl.domain.discovery.execution import (
     DiscoveryExecutionCohortKind,
     DiscoveryExecutionJob,
@@ -18,12 +17,16 @@ from jobctrl.domain.discovery.execution import (
     validate_safe_reason_code,
     validate_work_plan_state,
 )
+from jobctrl.domain.identifiers import JobId, canonical_job_id
 
 
 _SELECT_COLUMNS = """
-    tenant_id, discover_workflow_id, discover_run_id, job_url, cohort_kind,
-    source_family, source_run_id, preparation_workflow_id, work_plan_state,
-    required_steps_json, work_plan_reason, linked_at
+    execution.tenant_id, execution.discover_workflow_id,
+    execution.discover_run_id, execution.job_id, execution.cohort_kind,
+    execution.source_family, execution.source_run_id,
+    execution.preparation_workflow_id, execution.work_plan_state,
+    execution.required_steps_json, execution.work_plan_reason,
+    execution.linked_at
 """
 
 
@@ -32,12 +35,11 @@ class SqliteDiscoveryExecutionRepository:
 
     def __init__(self, conn: sqlite3.Connection) -> None:
         self._conn = conn
-        ensure_discovery_execution_tables(conn)
 
     def link_job(
         self,
         execution: DiscoveryExecutionRef,
-        job_url: str,
+        job_id: JobId,
         *,
         cohort_kind: DiscoveryExecutionCohortKind,
         source_family: str | None = None,
@@ -52,22 +54,25 @@ class SqliteDiscoveryExecutionRepository:
         """
 
         resolved_cohort = validate_cohort_kind(cohort_kind)
-        normalized_job_url = _required_text(job_url, "job_url")
+        normalized_job_id = _required_text(job_id, "job_id")
         normalized_family = _optional_text(source_family)
         normalized_source_run_id = _optional_text(source_run_id)
         if resolved_cohort == "observed_this_run" and normalized_family is None:
             raise ValueError("source_family is required for an observed execution job")
         linked = linked_at or datetime.now(timezone.utc).isoformat()
+        stable_job_id = self._resolve_job_id(execution, normalized_job_id)
 
         with self._conn:
             self._conn.execute(
                 """
                 INSERT INTO discovery_execution_jobs (
-                    tenant_id, discover_workflow_id, discover_run_id, job_url,
+                    tenant_id, discover_workflow_id, discover_run_id, job_id,
                     cohort_kind, source_family, source_run_id, work_plan_state,
                     linked_at
                 ) VALUES (?, ?, ?, ?, ?, ?, ?, 'pending', ?)
-                ON CONFLICT (tenant_id, discover_workflow_id, discover_run_id, job_url)
+                ON CONFLICT (
+                    tenant_id, discover_workflow_id, discover_run_id, job_id
+                )
                 DO UPDATE SET
                     cohort_kind = CASE
                         WHEN excluded.cohort_kind = 'observed_this_run'
@@ -93,7 +98,7 @@ class SqliteDiscoveryExecutionRepository:
                     execution.tenant_id,
                     execution.workflow_id,
                     execution.temporal_run_id,
-                    normalized_job_url,
+                    stable_job_id,
                     resolved_cohort,
                     normalized_family,
                     normalized_source_run_id,
@@ -101,7 +106,7 @@ class SqliteDiscoveryExecutionRepository:
                 ),
             )
 
-        result = self.get(execution, normalized_job_url)
+        result = self.get(execution, stable_job_id)
         if result is None:  # pragma: no cover - defensive database invariant
             raise RuntimeError("discovery execution job link was not persisted")
         return result
@@ -109,7 +114,7 @@ class SqliteDiscoveryExecutionRepository:
     def set_work_plan(
         self,
         execution: DiscoveryExecutionRef,
-        job_url: str,
+        job_id: JobId,
         *,
         state: DiscoveryExecutionWorkPlanState,
         required_steps: list[str] | tuple[str, ...] | None = None,
@@ -144,10 +149,11 @@ class SqliteDiscoveryExecutionRepository:
         if resolved_state in {"pending", "not_eligible"} and normalized_workflow_id is not None:
             raise ValueError(f"{resolved_state} work cannot name a preparation workflow")
 
-        normalized_job_url = _required_text(job_url, "job_url")
-        existing = self.get(execution, normalized_job_url)
+        normalized_job_id = _required_text(job_id, "job_id")
+        stable_job_id = self._resolve_job_id(execution, normalized_job_id)
+        existing = self.get(execution, stable_job_id)
         if existing is None:
-            raise KeyError(f"Job is not linked to discovery execution: {normalized_job_url}")
+            raise KeyError(f"Job is not linked to discovery execution: {stable_job_id}")
 
         desired_steps_json = (
             json.dumps(list(normalized_steps), separators=(",", ":"))
@@ -188,7 +194,7 @@ class SqliteDiscoveryExecutionRepository:
                  WHERE tenant_id = ?
                    AND discover_workflow_id = ?
                    AND discover_run_id = ?
-                   AND job_url = ?
+                   AND job_id = ?
                    AND work_plan_state IN ('pending', 'failed')
                 """,
                 (
@@ -199,11 +205,11 @@ class SqliteDiscoveryExecutionRepository:
                     execution.tenant_id,
                     execution.workflow_id,
                     execution.temporal_run_id,
-                    normalized_job_url,
+                    stable_job_id,
                 ),
             )
             if updated.rowcount != 1:
-                concurrent = self.get(execution, normalized_job_url)
+                concurrent = self.get(execution, stable_job_id)
                 if concurrent is not None and (
                     concurrent.work_plan_state,
                     concurrent.required_steps,
@@ -218,26 +224,34 @@ class SqliteDiscoveryExecutionRepository:
                     return concurrent
                 raise RuntimeError("discovery execution work plan changed concurrently")
 
-        result = self.get(execution, normalized_job_url)
+        result = self.get(execution, stable_job_id)
         if result is None:  # pragma: no cover - defensive database invariant
             raise RuntimeError("discovery execution work plan was not persisted")
         return result
 
-    def get(self, execution: DiscoveryExecutionRef, job_url: str) -> DiscoveryExecutionJob | None:
+    def get(
+        self,
+        execution: DiscoveryExecutionRef,
+        job_id: JobId,
+    ) -> DiscoveryExecutionJob | None:
+        try:
+            stable_job_id = self._resolve_job_id(execution, job_id)
+        except KeyError:
+            return None
         row = self._conn.execute(
             f"""
             SELECT {_SELECT_COLUMNS}
-              FROM discovery_execution_jobs
-             WHERE tenant_id = ?
-               AND discover_workflow_id = ?
-               AND discover_run_id = ?
-               AND job_url = ?
+              FROM discovery_execution_jobs AS execution
+             WHERE execution.tenant_id = ?
+               AND execution.discover_workflow_id = ?
+               AND execution.discover_run_id = ?
+               AND execution.job_id = ?
             """,
             (
                 execution.tenant_id,
                 execution.workflow_id,
                 execution.temporal_run_id,
-                job_url,
+                stable_job_id,
             ),
         ).fetchone()
         return _row_to_execution_job(row) if row is not None else None
@@ -246,15 +260,30 @@ class SqliteDiscoveryExecutionRepository:
         rows = self._conn.execute(
             f"""
             SELECT {_SELECT_COLUMNS}
-              FROM discovery_execution_jobs
-             WHERE tenant_id = ?
-               AND discover_workflow_id = ?
-               AND discover_run_id = ?
-             ORDER BY job_url
+              FROM discovery_execution_jobs AS execution
+             WHERE execution.tenant_id = ?
+               AND execution.discover_workflow_id = ?
+               AND execution.discover_run_id = ?
+             ORDER BY execution.job_id
             """,
             (execution.tenant_id, execution.workflow_id, execution.temporal_run_id),
         ).fetchall()
         return [_row_to_execution_job(row) for row in rows]
+
+    def _resolve_job_id(
+        self,
+        execution: DiscoveryExecutionRef,
+        job_reference: JobId,
+    ) -> JobId:
+        normalized = _required_text(job_reference, "job_id")
+        stable_job_id = canonical_job_id(normalized)
+        row = self._conn.execute(
+            "SELECT 1 FROM jobs WHERE tenant_id = ? AND job_id = ? LIMIT 1",
+            (execution.tenant_id, str(stable_job_id)),
+        ).fetchone()
+        if row is None:
+            raise KeyError(f"No stable Job identity for discovery execution member: {stable_job_id}")
+        return stable_job_id
 
 
 def _row_to_execution_job(row: sqlite3.Row | tuple[object, ...]) -> DiscoveryExecutionJob:
@@ -272,7 +301,7 @@ def _row_to_execution_job(row: sqlite3.Row | tuple[object, ...]) -> DiscoveryExe
             workflow_id=str(row[1]),
             temporal_run_id=str(row[2]),
         ),
-        job_url=str(row[3]),
+        job_id=JobId(str(row[3])),
         cohort_kind=validate_cohort_kind(str(row[4])),
         source_family=_optional_text(row[5]),
         source_run_id=_optional_text(row[6]),

--- a/workers/automation/src/jobctrl/infrastructure/discovery/sqlite_execution_repository.py
+++ b/workers/automation/src/jobctrl/infrastructure/discovery/sqlite_execution_repository.py
@@ -54,13 +54,12 @@ class SqliteDiscoveryExecutionRepository:
         """
 
         resolved_cohort = validate_cohort_kind(cohort_kind)
-        normalized_job_id = _required_text(job_id, "job_id")
         normalized_family = _optional_text(source_family)
         normalized_source_run_id = _optional_text(source_run_id)
         if resolved_cohort == "observed_this_run" and normalized_family is None:
             raise ValueError("source_family is required for an observed execution job")
         linked = linked_at or datetime.now(timezone.utc).isoformat()
-        stable_job_id = self._resolve_job_id(execution, normalized_job_id)
+        stable_job_id = self._resolve_job_id(execution, job_id)
 
         with self._conn:
             self._conn.execute(
@@ -149,8 +148,7 @@ class SqliteDiscoveryExecutionRepository:
         if resolved_state in {"pending", "not_eligible"} and normalized_workflow_id is not None:
             raise ValueError(f"{resolved_state} work cannot name a preparation workflow")
 
-        normalized_job_id = _required_text(job_id, "job_id")
-        stable_job_id = self._resolve_job_id(execution, normalized_job_id)
+        stable_job_id = self._resolve_job_id(execution, job_id)
         existing = self.get(execution, stable_job_id)
         if existing is None:
             raise KeyError(f"Job is not linked to discovery execution: {stable_job_id}")
@@ -275,8 +273,10 @@ class SqliteDiscoveryExecutionRepository:
         execution: DiscoveryExecutionRef,
         job_reference: JobId,
     ) -> JobId:
-        normalized = _required_text(job_reference, "job_id")
-        stable_job_id = canonical_job_id(normalized)
+        serialized = str(job_reference)
+        if serialized != serialized.strip():
+            raise ValueError("JobId must be a canonical UUID")
+        stable_job_id = canonical_job_id(serialized)
         row = self._conn.execute(
             "SELECT 1 FROM jobs WHERE tenant_id = ? AND job_id = ? LIMIT 1",
             (execution.tenant_id, str(stable_job_id)),

--- a/workers/automation/tests/test_discovery_execution_identity.py
+++ b/workers/automation/tests/test_discovery_execution_identity.py
@@ -119,6 +119,31 @@ def test_execution_membership_rejects_url_shaped_and_unknown_identity(
     ).fetchone()[0] == 0
 
 
+@pytest.mark.parametrize(
+    "job_id",
+    [
+        JobId(" 498fe0a9-6615-4b4d-b8fd-6cbb978f6ec6"),
+        JobId("498fe0a9-6615-4b4d-b8fd-6cbb978f6ec6 "),
+    ],
+)
+def test_execution_membership_rejects_whitespace_wrapped_identity(
+    execution_db,
+    job_id: JobId,
+) -> None:
+    repository = SqliteDiscoveryExecutionRepository(execution_db)
+
+    with pytest.raises(ValueError, match="canonical UUID"):
+        repository.link_job(
+            _execution(),
+            job_id,
+            cohort_kind="existing_backlog",
+        )
+
+    assert execution_db.execute(
+        "SELECT COUNT(*) FROM discovery_execution_jobs"
+    ).fetchone()[0] == 0
+
+
 def test_execution_membership_cannot_cross_tenants(execution_db) -> None:
     job_id = JobId("498fe0a9-6615-4b4d-b8fd-6cbb978f6ec6")
     _insert_job(execution_db, job_id, tenant_id="tenant-a")
@@ -134,3 +159,54 @@ def test_execution_membership_cannot_cross_tenants(execution_db) -> None:
     assert execution_db.execute(
         "SELECT COUNT(*) FROM discovery_execution_jobs"
     ).fetchone()[0] == 0
+
+
+def test_work_plan_retry_is_exact_and_memberships_order_by_job_id(
+    execution_db,
+) -> None:
+    first_id = JobId("00000000-0000-4000-8000-000000000001")
+    second_id = JobId("00000000-0000-4000-8000-000000000002")
+    _insert_job(execution_db, second_id)
+    _insert_job(execution_db, first_id)
+    repository = SqliteDiscoveryExecutionRepository(execution_db)
+    execution = _execution()
+    repository.link_job(
+        execution,
+        second_id,
+        cohort_kind="existing_backlog",
+    )
+    repository.link_job(
+        execution,
+        first_id,
+        cohort_kind="existing_backlog",
+    )
+
+    planned = repository.set_work_plan(
+        execution,
+        first_id,
+        state="planned",
+        required_steps=["score", "tailor"],
+        preparation_workflow_id="prep-first",
+    )
+    replay = repository.set_work_plan(
+        execution,
+        first_id,
+        state="planned",
+        required_steps=["score", "tailor"],
+        preparation_workflow_id="prep-first",
+    )
+
+    assert replay == planned
+    assert planned.required_steps == ("score", "tailor")
+    assert [
+        membership.job_id
+        for membership in repository.list_for_execution(execution)
+    ] == [first_id, second_id]
+    with pytest.raises(ValueError, match="immutable"):
+        repository.set_work_plan(
+            execution,
+            first_id,
+            state="planned",
+            required_steps=["score"],
+            preparation_workflow_id="prep-first",
+        )

--- a/workers/automation/tests/test_discovery_execution_identity.py
+++ b/workers/automation/tests/test_discovery_execution_identity.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from jobctrl.database import close_connection, init_db
+from jobctrl.domain.discovery.execution import DiscoveryExecutionRef
+from jobctrl.domain.identifiers import JobId
+from jobctrl.infrastructure.discovery.sqlite_execution_repository import (
+    SqliteDiscoveryExecutionRepository,
+)
+
+
+@pytest.fixture
+def execution_db(tmp_path: Path):
+    db_path = tmp_path / "jobctrl.db"
+    conn = init_db(db_path)
+    try:
+        yield conn
+    finally:
+        close_connection(db_path)
+
+
+def _execution(*, tenant_id: str = "local") -> DiscoveryExecutionRef:
+    return DiscoveryExecutionRef(
+        tenant_id=tenant_id,
+        workflow_id=f"discover-{tenant_id}",
+        temporal_run_id="temporal-run-1",
+    )
+
+
+def _insert_job(
+    conn,
+    job_id: JobId,
+    *,
+    tenant_id: str = "local",
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO jobs (tenant_id, job_id, url, title)
+        VALUES (?, ?, ?, 'Director of Engineering')
+        """,
+        (
+            tenant_id,
+            str(job_id),
+            f"https://example.test/{tenant_id}/jobs/{job_id}",
+        ),
+    )
+    conn.commit()
+
+
+def test_repository_construction_does_not_mutate_exact_v7_schema(
+    execution_db,
+) -> None:
+    schema_version = execution_db.execute("PRAGMA schema_version").fetchone()[0]
+    total_changes = execution_db.total_changes
+
+    SqliteDiscoveryExecutionRepository(execution_db)
+
+    assert execution_db.execute("PRAGMA schema_version").fetchone()[0] == schema_version
+    assert execution_db.total_changes == total_changes
+
+
+def test_execution_membership_is_tenant_scoped_and_keyed_by_job_id(
+    execution_db,
+) -> None:
+    job_id = JobId("498fe0a9-6615-4b4d-b8fd-6cbb978f6ec6")
+    _insert_job(execution_db, job_id)
+    repository = SqliteDiscoveryExecutionRepository(execution_db)
+    execution = _execution()
+
+    linked = repository.link_job(
+        execution,
+        job_id,
+        cohort_kind="observed_this_run",
+        source_family="jobspy",
+        source_run_id="source-run-1",
+        linked_at="2026-07-30T10:00:00+00:00",
+    )
+
+    assert linked.job_id == job_id
+    assert linked.execution == execution
+    assert linked.source_run_id == "source-run-1"
+    row = execution_db.execute(
+        """
+        SELECT tenant_id, job_id
+        FROM discovery_execution_jobs
+        WHERE discover_workflow_id = ?
+          AND discover_run_id = ?
+        """,
+        (execution.workflow_id, execution.temporal_run_id),
+    ).fetchone()
+    assert tuple(row) == ("local", str(job_id))
+
+
+def test_execution_membership_rejects_url_shaped_and_unknown_identity(
+    execution_db,
+) -> None:
+    repository = SqliteDiscoveryExecutionRepository(execution_db)
+    execution = _execution()
+
+    with pytest.raises(ValueError, match="canonical UUID"):
+        repository.link_job(
+            execution,
+            JobId("https://example.test/jobs/not-an-id"),
+            cohort_kind="existing_backlog",
+        )
+
+    with pytest.raises(KeyError, match="No stable Job identity"):
+        repository.link_job(
+            execution,
+            JobId("498fe0a9-6615-4b4d-b8fd-6cbb978f6ec6"),
+            cohort_kind="existing_backlog",
+        )
+
+    assert execution_db.execute(
+        "SELECT COUNT(*) FROM discovery_execution_jobs"
+    ).fetchone()[0] == 0
+
+
+def test_execution_membership_cannot_cross_tenants(execution_db) -> None:
+    job_id = JobId("498fe0a9-6615-4b4d-b8fd-6cbb978f6ec6")
+    _insert_job(execution_db, job_id, tenant_id="tenant-a")
+    repository = SqliteDiscoveryExecutionRepository(execution_db)
+
+    with pytest.raises(KeyError, match="No stable Job identity"):
+        repository.link_job(
+            _execution(tenant_id="tenant-b"),
+            job_id,
+            cohort_kind="existing_backlog",
+        )
+
+    assert execution_db.execute(
+        "SELECT COUNT(*) FROM discovery_execution_jobs"
+    ).fetchone()[0] == 0

--- a/workers/automation/tests/test_discovery_execution_reconciliation.py
+++ b/workers/automation/tests/test_discovery_execution_reconciliation.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import sqlite3
+import uuid
 
 import pytest
 
@@ -40,6 +41,16 @@ from jobctrl.infrastructure.discovery.sqlite_execution_repository import (
 )
 from jobctrl.infrastructure.projections.projection_builder import ProjectionBuilder
 from jobctrl.state import record_job_event
+
+
+def _seed_v7_job(conn: sqlite3.Connection, job_id: str) -> None:
+    conn.execute(
+        """
+        INSERT INTO jobs (tenant_id, job_id, url, title, site, discovered_at)
+        VALUES ('local', ?, ?, 'Recovery fixture', 'fixture', '2026-07-16T08:00:00+00:00')
+        """,
+        (job_id, f"https://fixture.example/jobs/{job_id}"),
+    )
 
 
 def _legacy_records() -> list[dict[str, object]]:
@@ -593,7 +604,10 @@ async def test_decoder_v2_recovers_exact_legacy_fanouts_and_resumes_partial_repl
     assert len(native_step_keys) == 4
     assert legacy_step_keys.isdisjoint(native_step_keys)
 
-    job_urls = [f"https://jobs.example/{index:03d}" for index in range(72)]
+    job_ids = [str(uuid.uuid5(uuid.NAMESPACE_URL, f"jobctrl:recovery:{index:03d}")) for index in range(72)]
+    job_index_by_id = {job_id: index for index, job_id in enumerate(job_ids)}
+    for job_id in job_ids:
+        _seed_v7_job(conn, job_id)
     fanout_job_indexes = (
         range(0),
         range(71),
@@ -614,9 +628,9 @@ async def test_decoder_v2_recovers_exact_legacy_fanouts_and_resumes_partial_repl
                 occurred_at=(f"2026-07-16T09:{pass_index:02d}:10.{position:03d}+00:00"),
                 workflow_id=f"prep-{idempotency_key}",
                 temporal_run_id=f"prep-run-{job_index:03d}",
-                input_summary={"jobUrl": job_urls[job_index]},
+                input_summary={"jobUrl": job_ids[job_index]},
             )
-    for job_index, job_url in enumerate(job_urls):
+    for job_index, job_id in enumerate(job_ids):
         idempotency_key = f"job-{job_index:03d}"
         workflow_id = f"prep-{idempotency_key}"
         temporal_run_id = f"prep-run-{job_index:03d}"
@@ -626,7 +640,7 @@ async def test_decoder_v2_recovers_exact_legacy_fanouts_and_resumes_partial_repl
             workflow_id=workflow_id,
             temporal_run_id=temporal_run_id,
             input_summary={
-                "jobUrl": job_url,
+                "jobUrl": job_id,
                 "steps": ["pdf", "cover", "score", "tailor"],
                 "targetVersion": "1",
                 "idempotencyKey": idempotency_key,
@@ -637,7 +651,7 @@ async def test_decoder_v2_recovers_exact_legacy_fanouts_and_resumes_partial_repl
             occurred_at=f"2026-07-16T10:01:00.{job_index:03d}+00:00",
             workflow_id=workflow_id,
             temporal_run_id=temporal_run_id,
-            input_summary={"jobUrl": job_url},
+            input_summary={"jobUrl": job_id},
         )
 
     for _activity_type, _payload, (step_kind, item_key), detail_code in native_specs:
@@ -667,16 +681,16 @@ async def test_decoder_v2_recovers_exact_legacy_fanouts_and_resumes_partial_repl
     # plans became durable. The four native keys already owned by their normal
     # lifecycle are the only projected step rows at the interruption point.
     repository = SqliteDiscoveryExecutionRepository(conn)
-    for job_index, job_url in enumerate(job_urls[:15]):
+    for job_index, job_id in enumerate(job_ids[:15]):
         repository.link_job(
             execution,
-            job_url,
+            job_id,
             cohort_kind="existing_backlog",
             linked_at="2026-07-16T10:02:00+00:00",
         )
         repository.set_work_plan(
             execution,
-            job_url,
+            job_id,
             state="planned",
             required_steps=("score", "tailor", "cover", "pdf"),
             preparation_workflow_id=f"prep-job-{job_index:03d}",
@@ -684,7 +698,7 @@ async def test_decoder_v2_recovers_exact_legacy_fanouts_and_resumes_partial_repl
         )
 
     all_step_keys = legacy_step_keys | native_step_keys
-    expected_digest = _recovery_key_digest(set(job_urls), all_step_keys)
+    expected_digest = _recovery_key_digest(set(job_ids), all_step_keys)
     _ensure_recovery_manifest_table(conn)
     _write_recovery_manifest(
         conn,
@@ -736,18 +750,18 @@ async def test_decoder_v2_recovers_exact_legacy_fanouts_and_resumes_partial_repl
 
     memberships = conn.execute(
         """
-        SELECT job_url, work_plan_state, required_steps_json,
+        SELECT job_id, work_plan_state, required_steps_json,
                preparation_workflow_id, work_plan_reason
         FROM discovery_execution_jobs
         WHERE tenant_id = ? AND discover_workflow_id = ? AND discover_run_id = ?
         """,
         (execution.tenant_id, execution.workflow_id, execution.temporal_run_id),
     ).fetchall()
-    assert {row["job_url"] for row in memberships} == set(job_urls)
+    assert {row["job_id"] for row in memberships} == set(job_ids)
     assert all(row["work_plan_state"] == "planned" for row in memberships)
     assert all(json.loads(row["required_steps_json"]) == ["score", "tailor", "cover", "pdf"] for row in memberships)
     assert all(
-        row["preparation_workflow_id"] == f"prep-job-{int(str(row['job_url']).rsplit('/', 1)[1]):03d}"
+        row["preparation_workflow_id"] == f"prep-job-{job_index_by_id[str(row['job_id'])]:03d}"
         for row in memberships
     )
     assert all(row["work_plan_reason"] == _LEGACY_WORK_PLAN_REASON_CODE for row in memberships)
@@ -1059,10 +1073,11 @@ async def test_ready_manifest_retries_history_read_without_losing_durable_proof(
         workflow_id="discover-local",
         temporal_run_id="run-history-retry",
     )
+    _seed_v7_job(conn, str(uuid.uuid5(uuid.NAMESPACE_URL, "jobctrl:durable")))
     repository = SqliteDiscoveryExecutionRepository(conn)
     repository.link_job(
         execution,
-        "job:durable",
+        str(uuid.uuid5(uuid.NAMESPACE_URL, "jobctrl:durable")),
         cohort_kind="existing_backlog",
         linked_at="2026-07-16T08:00:00+00:00",
     )
@@ -1079,7 +1094,7 @@ async def test_ready_manifest_retries_history_read_without_losing_durable_proof(
         tenant_id=TenantId(execution.tenant_id),
     ).refresh()
 
-    membership_keys = {"job:durable"}
+    membership_keys = {str(uuid.uuid5(uuid.NAMESPACE_URL, "jobctrl:durable"))}
     step_keys = {("source_planning", "plan")}
     digest = _recovery_key_digest(membership_keys, step_keys)
     _ensure_recovery_manifest_table(conn)
@@ -1261,7 +1276,7 @@ async def test_retried_fanout_recovers_exact_work_without_inventing_queue_time(
         occurred_at="2026-07-16T08:01:01+00:00",
         workflow_id="prep-retried",
         temporal_run_id="prep-run-retried",
-        input_summary={"jobUrl": "job:retried"},
+        input_summary={"jobUrl": str(uuid.uuid5(uuid.NAMESPACE_URL, "jobctrl:retried"))},
     )
     _append_workflow_started(
         conn,
@@ -1269,12 +1284,13 @@ async def test_retried_fanout_recovers_exact_work_without_inventing_queue_time(
         workflow_id="prep-retried",
         temporal_run_id="prep-run-retried",
         input_summary={
-            "jobUrl": "job:retried",
+            "jobUrl": str(uuid.uuid5(uuid.NAMESPACE_URL, "jobctrl:retried")),
             "steps": ["score", "tailor"],
             "targetVersion": "1",
             "idempotencyKey": "retried",
         },
     )
+    _seed_v7_job(conn, str(uuid.uuid5(uuid.NAMESPACE_URL, "jobctrl:retried")))
 
     async def normalized_history(_handle, _converter):
         return records
@@ -1299,7 +1315,8 @@ async def test_retried_fanout_recovers_exact_work_without_inventing_queue_time(
     assert result.jobs_linked == 1
     assert result.work_plans_recovered == 1
     membership = conn.execute(
-        "SELECT * FROM discovery_execution_jobs WHERE job_url = 'job:retried'"
+        "SELECT * FROM discovery_execution_jobs WHERE job_id = ?",
+        (str(uuid.uuid5(uuid.NAMESPACE_URL, "jobctrl:retried")),),
     ).fetchone()
     assert membership["work_plan_state"] == "planned"
     assert membership["preparation_workflow_id"] == "prep-retried"
@@ -1633,7 +1650,7 @@ async def test_terminal_failed_fanout_persists_exact_partial_incomplete_coverage
         occurred_at="2026-07-16T09:00:02+00:00",
         workflow_id="prep-partial",
         temporal_run_id="prep-run-partial",
-        input_summary={"jobUrl": "job:partial"},
+        input_summary={"jobUrl": str(uuid.uuid5(uuid.NAMESPACE_URL, "jobctrl:partial"))},
     )
     _append_workflow_started(
         conn,
@@ -1641,12 +1658,13 @@ async def test_terminal_failed_fanout_persists_exact_partial_incomplete_coverage
         workflow_id="prep-partial",
         temporal_run_id="prep-run-partial",
         input_summary={
-            "jobUrl": "job:partial",
+            "jobUrl": str(uuid.uuid5(uuid.NAMESPACE_URL, "jobctrl:partial")),
             "steps": ["score"],
             "targetVersion": "1",
             "idempotencyKey": "partial",
         },
     )
+    _seed_v7_job(conn, str(uuid.uuid5(uuid.NAMESPACE_URL, "jobctrl:partial")))
 
     async def normalized_history(_handle, _converter):
         return records
@@ -1671,7 +1689,8 @@ async def test_terminal_failed_fanout_persists_exact_partial_incomplete_coverage
     assert result.jobs_linked == 1
     assert result.work_plans_recovered == 1
     membership = conn.execute(
-        "SELECT * FROM discovery_execution_jobs WHERE job_url = 'job:partial'"
+        "SELECT * FROM discovery_execution_jobs WHERE job_id = ?",
+        (str(uuid.uuid5(uuid.NAMESPACE_URL, "jobctrl:partial")),),
     ).fetchone()
     assert membership["work_plan_state"] == "planned"
     assert membership["preparation_workflow_id"] == "prep-partial"
@@ -1698,7 +1717,7 @@ async def test_terminal_failed_fanout_persists_exact_partial_incomplete_coverage
     assert manifest["expected_step_count"] == 1
     assert manifest["persisted_step_count"] == 1
     assert manifest["key_digest"] == _recovery_key_digest(
-        {"job:partial"},
+        {str(uuid.uuid5(uuid.NAMESPACE_URL, "jobctrl:partial"))},
         {("preparation_fanout", "streaming:pass-1")},
     )
 
@@ -1724,9 +1743,10 @@ async def test_reconciliation_repairs_stale_ready_manifest(tmp_path, monkeypatch
         workflow_id="discover-local",
         temporal_run_id="run-stale",
     )
+    _seed_v7_job(conn, str(uuid.uuid5(uuid.NAMESPACE_URL, "jobctrl:new")))
     SqliteDiscoveryExecutionRepository(conn).link_job(
         execution,
-        "job:new",
+        str(uuid.uuid5(uuid.NAMESPACE_URL, "jobctrl:new")),
         cohort_kind="existing_backlog",
         linked_at="2026-07-16T08:00:00+00:00",
     )
@@ -1741,7 +1761,9 @@ async def test_reconciliation_repairs_stale_ready_manifest(tmp_path, monkeypatch
         persisted_memberships=1,
         expected_steps=0,
         persisted_steps=0,
-        key_digest=_recovery_key_digest({"job:old"}, set()),
+        key_digest=_recovery_key_digest(
+            {str(uuid.uuid5(uuid.NAMESPACE_URL, "jobctrl:old"))}, set()
+        ),
     )
 
     async def normalized_history(_handle, _converter):
@@ -1774,7 +1796,7 @@ async def test_reconciliation_repairs_stale_ready_manifest(tmp_path, monkeypatch
     row = conn.execute("SELECT * FROM discovery_execution_recoveries").fetchone()
     assert row["state"] == "ready"
     assert row["expected_membership_count"] == row["persisted_membership_count"] == 1
-    assert row["key_digest"] == _recovery_key_digest({"job:new"}, set())
+    assert row["key_digest"] == _recovery_key_digest({str(uuid.uuid5(uuid.NAMESPACE_URL, "jobctrl:new"))}, set())
 
 
 @pytest.mark.asyncio

--- a/workers/automation/tests/test_worker_heartbeat_loop.py
+++ b/workers/automation/tests/test_worker_heartbeat_loop.py
@@ -79,7 +79,7 @@ def _recovery_connection() -> sqlite3.Connection:
             tenant_id TEXT NOT NULL,
             discover_workflow_id TEXT NOT NULL,
             discover_run_id TEXT NOT NULL,
-            job_url TEXT NOT NULL
+            job_id TEXT NOT NULL
         );
         CREATE TABLE pipeline_step_projections (
             tenant_id TEXT NOT NULL,
@@ -131,7 +131,7 @@ def test_recovery_candidates_keep_open_runs_and_only_latest_incomplete_terminal(
         if table == "discovery_execution_jobs":
             conn.execute(
                 f"INSERT INTO {table} VALUES "
-                "('local', 'discover-open', 'run-open', 'job:open')"
+                "('local', 'discover-open', 'run-open', '11111111-1111-4111-8111-111111111111')"
             )
         else:
             conn.execute(
@@ -179,10 +179,13 @@ def test_recovery_candidates_skip_terminal_incomplete_checkpoint() -> None:
                   '2026-07-16T09:00:00Z', 'run-incomplete')
         """
     )
-    digest = execution_reconciliation._recovery_key_digest({"job:partial"}, set())
+    digest = execution_reconciliation._recovery_key_digest(
+        {"22222222-2222-4222-8222-222222222222"}, set()
+    )
     conn.execute(
         "INSERT INTO discovery_execution_jobs VALUES "
-        "('local', 'discover-incomplete', 'run-incomplete', 'job:partial')"
+        "('local', 'discover-incomplete', 'run-incomplete', "
+        "'22222222-2222-4222-8222-222222222222')"
     )
     conn.execute(
         """
@@ -211,11 +214,14 @@ def test_recovery_candidates_repair_stale_ready_checkpoint() -> None:
     conn.execute(
         """
         INSERT INTO discovery_execution_jobs VALUES (
-            'local', 'discover-stale', 'run-stale', 'job:new'
+            'local', 'discover-stale', 'run-stale',
+            '33333333-3333-4333-8333-333333333333'
         )
         """
     )
-    stale_digest = execution_reconciliation._recovery_key_digest({"job:old"}, set())
+    stale_digest = execution_reconciliation._recovery_key_digest(
+        {"44444444-4444-4444-8444-444444444444"}, set()
+    )
     conn.execute(
         """
         INSERT INTO discovery_execution_recoveries VALUES (
@@ -243,7 +249,8 @@ def test_recovery_candidates_do_not_infer_readiness_from_projection_counts() -> 
     )
     conn.execute(
         "INSERT INTO discovery_execution_jobs VALUES "
-        "('local', 'discover-partial', 'run-partial', 'job:partial')"
+        "('local', 'discover-partial', 'run-partial', "
+        "'22222222-2222-4222-8222-222222222222')"
     )
     conn.execute(
         "INSERT INTO pipeline_step_projections VALUES "


### PR DESCRIPTION
## Summary

- key immutable discovery execution membership by canonical `JobId`
- reject URL-shaped, whitespace-wrapped, unknown, and cross-tenant job references before persistence
- read and deterministically order exact-v7 execution membership through `job_id`
- preserve exact work-plan retries and reject decided-plan mutation
- make repository construction read-only instead of running schema setup at runtime

## Why

Discovery execution lineage must follow the same tenant-scoped stable identity as jobs and search receipts. Posting URLs remain external locators and cannot be accepted as execution member identities.

## Validation

- focused `pytest -q tests/test_discovery_execution_identity.py` — 7 passed
- focused Ruff — passed
- `git diff --check` — passed

## Stack

Base: `feat/job-id-search-unit-receipts` (#575). Workflow callers and reconciliation remain separate review-sized PRs; cumulative Tier 3 QA remains mandatory on the final branch.