### PR TITLE
feat(storage): copy canonical v7 candidate rows

### DIFF
--- a/workers/automation/src/jobctrl/infrastructure/migrations/v6_to_v7_copy.py
+++ b/workers/automation/src/jobctrl/infrastructure/migrations/v6_to_v7_copy.py
@@ -1,0 +1,423 @@
+"""Manifest-driven copy of the non-structured v6-to-v7 candidate tables."""
+
+from __future__ import annotations
+
+import sqlite3
+import uuid
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from types import MappingProxyType
+
+from jobctrl.infrastructure.migrations.schema_manifest import (
+    EXACT_V7_MANIFEST,
+    assert_exact_manifest,
+)
+from jobctrl.infrastructure.migrations.v6_to_v7_plan import (
+    ColumnRole,
+    TABLE_PLANS,
+    TableDisposition,
+    classify_column,
+)
+
+
+class CandidateCopyError(RuntimeError):
+    """Raised when a candidate copy would lose or reinterpret durable data."""
+
+
+@dataclass(frozen=True)
+class JobIdMap:
+    """Legacy posting locators mapped to JobIds already written to the candidate."""
+
+    by_locator: Mapping[tuple[str, str], str]
+
+    def resolve(self, *, tenant_id: str, locator: object) -> str | None:
+        if locator is None or not str(locator).strip():
+            return None
+        try:
+            return self.by_locator[(tenant_id, str(locator))]
+        except KeyError as error:
+            raise CandidateCopyError(
+                "candidate copy cannot resolve a legacy job locator for "
+                f"tenant {tenant_id!r}: {locator!r}"
+            ) from error
+
+
+def build_job_id_map(
+    source: sqlite3.Connection,
+    candidate: sqlite3.Connection,
+) -> JobIdMap:
+    """Verify the candidate root rewrite and expose its locator-to-JobId map."""
+    source_columns = _columns(source, "jobs")
+    if "url" not in source_columns:
+        raise CandidateCopyError("candidate copy requires the v6 jobs.url identity")
+    tenant_expression = "tenant_id" if "tenant_id" in source_columns else "'local'"
+    source_locators = {
+        (_tenant_id(tenant), str(locator or "").strip())
+        for tenant, locator in source.execute(
+            f"SELECT {tenant_expression}, url FROM jobs ORDER BY rowid"
+        ).fetchall()
+    }
+    if any(not locator for _, locator in source_locators):
+        raise CandidateCopyError("candidate copy found a source job with no posting URL")
+
+    values: dict[tuple[str, str], str] = {}
+    rows = candidate.execute(
+        "SELECT tenant_id, url, job_id FROM jobs ORDER BY tenant_id, url"
+    ).fetchall()
+    for tenant, locator, job_id in rows:
+        normalized_tenant = _tenant_id(tenant)
+        normalized_locator = str(locator or "").strip()
+        normalized_job_id = str(job_id or "").strip().lower()
+        if not normalized_locator:
+            raise CandidateCopyError("candidate copy found a job with no posting URL")
+        try:
+            if str(uuid.UUID(normalized_job_id)) != normalized_job_id:
+                raise ValueError("not canonical")
+        except ValueError as error:
+            raise CandidateCopyError(
+                "candidate copy found a non-canonical JobId for "
+                f"{normalized_locator!r}"
+            ) from error
+        key = (normalized_tenant, normalized_locator)
+        if key in values and values[key] != normalized_job_id:
+            raise CandidateCopyError(
+                "candidate copy found conflicting JobIds for "
+                f"{normalized_locator!r}"
+            )
+        values[key] = normalized_job_id
+    if set(values) != source_locators:
+        raise CandidateCopyError(
+            "candidate copy requires an exact hydrated canonical jobs table"
+        )
+    return JobIdMap(MappingProxyType(values))
+
+
+def copy_direct_and_scalar_tables(
+    source: sqlite3.Connection,
+    candidate: sqlite3.Connection,
+) -> tuple[str, ...]:
+    """Copy only declared direct/scalar tables into a hydrated exact-v7 candidate.
+
+    The caller owns the root ``jobs`` and ``job_locators`` structured rewrite.
+    Requiring its completed job rows here prevents copied references from being
+    detached from the canonical aggregate.
+    """
+    assert_exact_manifest(candidate, EXACT_V7_MANIFEST)
+    job_ids = build_job_id_map(source, candidate)
+    _validate_source_inventory(source)
+
+    tables = tuple(
+        name
+        for name, plan in TABLE_PLANS.items()
+        if plan.disposition
+        in {
+            TableDisposition.DIRECT_COPY,
+            TableDisposition.SCALAR_JOB_ID_REWRITE,
+        }
+    )
+    ordered_tables = _copy_order(candidate, tables)
+
+    candidate.execute("SAVEPOINT v6_direct_scalar_copy")
+    try:
+        for table in ordered_tables:
+            _copy_table(source, candidate, table, job_ids)
+        violations = candidate.execute("PRAGMA foreign_key_check").fetchall()
+        if violations:
+            raise CandidateCopyError(
+                "candidate copy left a foreign-key violation: "
+                f"{tuple(violations[0])!r}"
+            )
+        candidate.execute("RELEASE SAVEPOINT v6_direct_scalar_copy")
+    except BaseException:
+        candidate.execute("ROLLBACK TO SAVEPOINT v6_direct_scalar_copy")
+        candidate.execute("RELEASE SAVEPOINT v6_direct_scalar_copy")
+        raise
+    return ordered_tables
+
+
+def _validate_source_inventory(source: sqlite3.Connection) -> None:
+    present = _table_names(source)
+    allowed = {name for name, plan in TABLE_PLANS.items() if plan.source_exists}
+    unexpected = sorted(present - allowed)
+    if unexpected:
+        raise CandidateCopyError(
+            f"candidate copy found unclassified source tables: {unexpected!r}"
+        )
+
+    missing = sorted(
+        name
+        for name, plan in TABLE_PLANS.items()
+        if plan.source_required and name not in present
+    )
+    if missing:
+        raise CandidateCopyError(
+            f"candidate copy is missing required source tables: {missing!r}"
+        )
+
+    for name, plan in TABLE_PLANS.items():
+        if (
+            plan.disposition is TableDisposition.RETIRED
+            and name in present
+            and _row_count(source, name)
+        ):
+            raise CandidateCopyError(
+                f"candidate copy found nonempty retired table: {name}"
+            )
+
+
+def _copy_order(
+    candidate: sqlite3.Connection,
+    tables: Iterable[str],
+) -> tuple[str, ...]:
+    pending = set(tables)
+    dependencies = {
+        table: {
+            str(row[2])
+            for row in candidate.execute(
+                f"PRAGMA foreign_key_list({_identifier(table)})"
+            ).fetchall()
+            if str(row[2]) in pending
+        }
+        for table in pending
+    }
+    ordered: list[str] = []
+    while pending:
+        ready = sorted(
+            table for table in pending if not dependencies[table] & pending
+        )
+        if not ready:
+            raise CandidateCopyError(
+                "candidate copy cannot order manifest tables with cyclic foreign keys"
+            )
+        ordered.extend(ready)
+        pending.difference_update(ready)
+    return tuple(ordered)
+
+
+def _copy_table(
+    source: sqlite3.Connection,
+    candidate: sqlite3.Connection,
+    table: str,
+    job_ids: JobIdMap,
+) -> None:
+    plan = TABLE_PLANS[table]
+    if _row_count(candidate, table):
+        raise CandidateCopyError(f"candidate table must be empty: {table}")
+    if table not in _table_names(source):
+        if plan.source_required:
+            raise CandidateCopyError(
+                f"candidate copy is missing required source table: {table}"
+            )
+        return
+    source_columns = _columns(source, table)
+    target_columns = _columns(candidate, table)
+    bindings = _column_bindings(table, plan.disposition, source_columns, target_columns)
+    source_order = tuple(source_columns)
+    target_order = tuple(target_columns)
+    rows = source.execute(
+        f"SELECT {_identifiers(source_order)} FROM {_identifier(table)}"
+    ).fetchall()
+    values = [
+        tuple(
+            _bound_value(
+                table=table,
+                target_column=target_column,
+                binding=binding,
+                source_row=dict(zip(source_order, row, strict=True)),
+                job_ids=job_ids,
+            )
+            for target_column, binding in zip(target_order, bindings, strict=True)
+        )
+        for row in rows
+    ]
+    if values:
+        placeholders = ", ".join("?" for _ in target_order)
+        candidate.executemany(
+            f"INSERT INTO {_identifier(table)} ({_identifiers(target_order)}) "
+            f"VALUES ({placeholders})",
+            values,
+        )
+    if _row_count(candidate, table) != len(rows):
+        raise CandidateCopyError(f"candidate copy changed row count for {table}")
+    if plan.sequence_owned:
+        _copy_sequence_cursor(source, candidate, table)
+
+
+@dataclass(frozen=True)
+class _Binding:
+    source_column: str | None
+    role: ColumnRole
+
+
+def _column_bindings(
+    table: str,
+    disposition: TableDisposition,
+    source_columns: tuple[str, ...],
+    target_columns: tuple[str, ...],
+) -> tuple[_Binding, ...]:
+    source_set = set(source_columns)
+    target_set = set(target_columns)
+    if disposition is TableDisposition.DIRECT_COPY and source_set != target_set:
+        raise CandidateCopyError(f"direct-copy column drift for {table}")
+
+    bindings: list[_Binding] = []
+    consumed: set[str] = set()
+    for target_column in target_columns:
+        target_role = classify_column(table, target_column, "target")
+        if target_role is None:
+            raise CandidateCopyError(
+                f"candidate copy found unclassified target column: {table}.{target_column}"
+            )
+        if target_role is ColumnRole.JOB_ID:
+            source_column = _legacy_identity_column(
+                table, target_column, source_columns
+            )
+        elif target_role is ColumnRole.DERIVED:
+            source_column = "tenant_id" if target_column == "tenant_id" and "tenant_id" in source_set else None
+        elif target_column in source_set:
+            source_column = target_column
+        else:
+            raise CandidateCopyError(
+                f"candidate copy cannot bind {table}.{target_column}"
+            )
+        if source_column is not None:
+            consumed.add(source_column)
+        bindings.append(_Binding(source_column, target_role))
+
+    unconsumed = set(source_columns) - consumed
+    if unconsumed:
+        raise CandidateCopyError(
+            f"candidate copy found unclassified source columns for {table}: "
+            f"{sorted(unconsumed)!r}"
+        )
+    return tuple(bindings)
+
+
+def _legacy_identity_column(
+    table: str,
+    target_column: str,
+    source_columns: tuple[str, ...],
+) -> str:
+    source_roles = {
+        column: classify_column(table, column, "source")
+        for column in source_columns
+    }
+    legacy = {
+        column
+        for column, role in source_roles.items()
+        if role
+        in {
+            ColumnRole.LEGACY_URL_IDENTITY,
+            ColumnRole.UNCHANGED_SCHEMA_URL_IDENTITY,
+        }
+    }
+    stem = target_column.removesuffix("_id")
+    preferred = (
+        f"{stem}_key",
+        f"{stem}_url",
+        target_column,
+    )
+    matches = [column for column in preferred if column in legacy]
+    if len(matches) == 1:
+        return matches[0]
+    if target_column == "job_id" and len(legacy) == 1:
+        return next(iter(legacy))
+    raise CandidateCopyError(
+        "candidate copy cannot bind legacy identity column for "
+        f"{table}.{target_column}"
+    )
+
+
+def _bound_value(
+    *,
+    table: str,
+    target_column: str,
+    binding: _Binding,
+    source_row: Mapping[str, object],
+    job_ids: JobIdMap,
+) -> object:
+    if binding.role is ColumnRole.DERIVED:
+        return _tenant_id(source_row.get("tenant_id"))
+    if binding.source_column is None:
+        raise CandidateCopyError(
+            f"candidate copy has no value source for {table}.{target_column}"
+        )
+    value = source_row[binding.source_column]
+    if binding.role is ColumnRole.JOB_ID:
+        return job_ids.resolve(
+            tenant_id=_tenant_id(source_row.get("tenant_id")), locator=value
+        )
+    return value
+
+
+def _copy_sequence_cursor(
+    source: sqlite3.Connection,
+    candidate: sqlite3.Connection,
+    table: str,
+) -> None:
+    source_row = source.execute(
+        "SELECT seq FROM sqlite_sequence WHERE name = ?", (table,)
+    ).fetchone()
+    candidate_row = candidate.execute(
+        "SELECT seq FROM sqlite_sequence WHERE name = ?", (table,)
+    ).fetchone()
+    if source_row is None:
+        if candidate_row is not None:
+            raise CandidateCopyError(
+                f"candidate copy synthesized a sequence cursor for {table}"
+            )
+        return
+    updated = candidate.execute(
+        "UPDATE sqlite_sequence SET seq = ? WHERE name = ?",
+        (int(source_row[0]), table),
+    )
+    if updated.rowcount == 0:
+        candidate.execute(
+            "INSERT INTO sqlite_sequence(name, seq) VALUES (?, ?)",
+            (table, int(source_row[0])),
+        )
+
+
+def _table_names(conn: sqlite3.Connection) -> set[str]:
+    return {
+        str(row[0])
+        for row in conn.execute(
+            "SELECT name FROM sqlite_master "
+            "WHERE type = 'table' AND name NOT LIKE 'sqlite_%'"
+        ).fetchall()
+    }
+
+
+def _columns(conn: sqlite3.Connection, table: str) -> tuple[str, ...]:
+    if table not in _table_names(conn):
+        raise CandidateCopyError(f"candidate copy is missing table: {table}")
+    return tuple(
+        str(row[1])
+        for row in conn.execute(f"PRAGMA table_info({_identifier(table)})").fetchall()
+    )
+
+
+def _row_count(conn: sqlite3.Connection, table: str) -> int:
+    return int(
+        conn.execute(f"SELECT COUNT(*) FROM {_identifier(table)}").fetchone()[0]
+    )
+
+
+def _tenant_id(value: object) -> str:
+    return str(value or "").strip() or "local"
+
+
+def _identifier(value: str) -> str:
+    return f'"{value.replace(chr(34), chr(34) * 2)}"'
+
+
+def _identifiers(values: Iterable[str]) -> str:
+    return ", ".join(_identifier(value) for value in values)
+
+
+__all__ = [
+    "CandidateCopyError",
+    "JobIdMap",
+    "build_job_id_map",
+    "copy_direct_and_scalar_tables",
+]

--- a/workers/automation/src/jobctrl/infrastructure/migrations/v6_to_v7_copy.py
+++ b/workers/automation/src/jobctrl/infrastructure/migrations/v6_to_v7_copy.py
@@ -18,6 +18,9 @@ from jobctrl.infrastructure.migrations.v6_to_v7_plan import (
     TableDisposition,
     classify_column,
 )
+from jobctrl.infrastructure.migrations.v6_to_v7_preflight import (
+    assert_v6_migration_preflight,
+)
 
 
 class CandidateCopyError(RuntimeError):
@@ -102,6 +105,7 @@ def copy_direct_and_scalar_tables(
     Requiring its completed job rows here prevents copied references from being
     detached from the canonical aggregate.
     """
+    assert_v6_migration_preflight(source)
     assert_exact_manifest(candidate, EXACT_V7_MANIFEST)
     job_ids = build_job_id_map(source, candidate)
     _validate_source_inventory(source)

--- a/workers/automation/src/jobctrl/infrastructure/migrations/v6_to_v7_copy.py
+++ b/workers/automation/src/jobctrl/infrastructure/migrations/v6_to_v7_copy.py
@@ -7,6 +7,7 @@ import uuid
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 from types import MappingProxyType
+from typing import Final
 
 from jobctrl.infrastructure.migrations.schema_manifest import (
     EXACT_V7_MANIFEST,
@@ -20,6 +21,22 @@ from jobctrl.infrastructure.migrations.v6_to_v7_plan import (
 )
 from jobctrl.infrastructure.migrations.v6_to_v7_preflight import (
     assert_v6_migration_preflight,
+)
+
+
+# These six columns were added by the shipped v6 profile runtime without a
+# schema-version bump. The frozen target contains them, while the original v6
+# schema does not. A source with the exact runtime ALTER sequence retains its
+# values; the original shape receives these exact declared defaults.
+_CANDIDATE_PROFILE_V6_DEFAULTS: Final[Mapping[str, object]] = MappingProxyType(
+    {
+        "application_attestation_age_18_plus": None,
+        "application_attestation_background_check_consent": None,
+        "application_attestation_felony_conviction": None,
+        "application_attestation_previously_worked_at_employer": None,
+        "application_attestation_additional_json": "{}",
+        "application_preference_how_heard": "",
+    }
 )
 
 
@@ -262,7 +279,9 @@ def _column_bindings(
     source_set = set(source_columns)
     target_set = set(target_columns)
     if disposition is TableDisposition.DIRECT_COPY and source_set != target_set:
-        raise CandidateCopyError(f"direct-copy column drift for {table}")
+        allowed_source_columns = target_set - set(_CANDIDATE_PROFILE_V6_DEFAULTS)
+        if table != "candidate_profiles" or source_set != allowed_source_columns:
+            raise CandidateCopyError(f"direct-copy column drift for {table}")
 
     bindings: list[_Binding] = []
     consumed: set[str] = set()
@@ -280,6 +299,11 @@ def _column_bindings(
             source_column = "tenant_id" if target_column == "tenant_id" and "tenant_id" in source_set else None
         elif target_column in source_set:
             source_column = target_column
+        elif (
+            table == "candidate_profiles"
+            and target_column in _CANDIDATE_PROFILE_V6_DEFAULTS
+        ):
+            source_column = None
         else:
             raise CandidateCopyError(
                 f"candidate copy cannot bind {table}.{target_column}"
@@ -343,6 +367,11 @@ def _bound_value(
     if binding.role is ColumnRole.DERIVED:
         return _tenant_id(source_row.get("tenant_id"))
     if binding.source_column is None:
+        if (
+            table == "candidate_profiles"
+            and target_column in _CANDIDATE_PROFILE_V6_DEFAULTS
+        ):
+            return _CANDIDATE_PROFILE_V6_DEFAULTS[target_column]
         raise CandidateCopyError(
             f"candidate copy has no value source for {table}.{target_column}"
         )

--- a/workers/automation/tests/test_v6_to_v7_copy.py
+++ b/workers/automation/tests/test_v6_to_v7_copy.py
@@ -1,0 +1,221 @@
+"""Focused contracts for direct/scalar v6-to-v7 candidate copying."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from jobctrl.infrastructure.migrations.schema_v7 import create_exact_v7_schema
+from jobctrl.infrastructure.migrations.v6_to_v7_copy import (
+    CandidateCopyError,
+    copy_direct_and_scalar_tables,
+)
+from tests.v6_migration_fixture import (
+    create_shipped_v6_database,
+    create_supported_upgrade_history_v6_database,
+)
+
+
+def _connections(
+    tmp_path: Path,
+    *,
+    history: bool = False,
+    hydrate_jobs: bool = True,
+) -> tuple[sqlite3.Connection, sqlite3.Connection]:
+    source_path = tmp_path / "source.db"
+    create = (
+        create_supported_upgrade_history_v6_database
+        if history
+        else create_shipped_v6_database
+    )
+    create(source_path)
+    source = sqlite3.connect(source_path)
+    source.execute("PRAGMA foreign_keys = ON")
+
+    candidate = sqlite3.connect(tmp_path / "candidate.db")
+    candidate.execute("PRAGMA foreign_keys = ON")
+    create_exact_v7_schema(candidate)
+    if hydrate_jobs:
+        _hydrate_candidate_jobs(source, candidate)
+    return source, candidate
+
+
+def _hydrate_candidate_jobs(
+    source: sqlite3.Connection,
+    candidate: sqlite3.Connection,
+) -> None:
+    source_columns = tuple(
+        str(row[1]) for row in source.execute("PRAGMA table_info(jobs)")
+    )
+    target_columns = tuple(
+        str(row[1]) for row in candidate.execute("PRAGMA table_info(jobs)")
+    )
+    source_rows = source.execute(
+        f"SELECT {', '.join(source_columns)} FROM jobs ORDER BY rowid"
+    ).fetchall()
+    values = []
+    for index, row in enumerate(source_rows, start=1):
+        source_row = dict(zip(source_columns, row, strict=True))
+        values.append(
+            tuple(
+                (
+                    "local"
+                    if column == "tenant_id"
+                    else f"00000000-0000-4000-8000-{index:012d}"
+                    if column == "job_id"
+                    else source_row[column]
+                )
+                for column in target_columns
+            )
+        )
+    quoted = ", ".join(f'"{column}"' for column in target_columns)
+    candidate.executemany(
+        f"INSERT INTO jobs ({quoted}) "
+        f"VALUES ({', '.join('?' for _ in target_columns)})",
+        values,
+    )
+
+
+def test_manifest_copy_rewrites_job_ids_and_preserves_locator_urls(
+    tmp_path: Path,
+) -> None:
+    source, candidate = _connections(tmp_path)
+    try:
+        job_url = "https://jobs.example/shipped-v6"
+        job_id = str(candidate.execute("SELECT job_id FROM jobs").fetchone()[0])
+        source.execute(
+            """
+            INSERT INTO job_canonical_identities (
+                tenant_id, job_url, canonical_url, ats_kind, source_native_id,
+                confidence, resolved_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "local",
+                job_url,
+                "https://canonical.example/role",
+                "generic",
+                "source-role-1",
+                0.9,
+                "2026-07-30T10:00:00+00:00",
+            ),
+        )
+        source.execute(
+            """
+            INSERT INTO job_enrichments (
+                job_url, tenant_id, current_status, full_description,
+                application_url, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (
+                job_url,
+                "local",
+                "ready",
+                "The full source description.",
+                "https://apply.example/role",
+                "2026-07-30T10:01:00+00:00",
+            ),
+        )
+        source.execute(
+            """
+            INSERT INTO job_artifacts (
+                job_url, stage, artifact_type, path, created_at
+            ) VALUES (?, ?, ?, ?, ?)
+            """,
+            (
+                job_url,
+                "tailor",
+                "resume",
+                "/tmp/resume.pdf",
+                "2026-07-30T10:02:00+00:00",
+            ),
+        )
+        source.execute(
+            """
+            INSERT INTO source_registry_entries (
+                tenant_id, source_id, kind, display_name, policy_id, seed_url,
+                created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "local",
+                "manual",
+                "manual",
+                "Manual source",
+                "allow",
+                "https://source.example/seed",
+                "2026-07-30T10:03:00+00:00",
+                "2026-07-30T10:03:00+00:00",
+            ),
+        )
+
+        copied = copy_direct_and_scalar_tables(source, candidate)
+
+        assert "job_events" not in copied
+        assert candidate.execute("SELECT COUNT(*) FROM job_events").fetchone()[0] == 0
+        assert candidate.execute(
+            "SELECT tenant_id, job_id, canonical_url FROM job_canonical_identities"
+        ).fetchone() == ("local", job_id, "https://canonical.example/role")
+        assert candidate.execute(
+            "SELECT job_id, application_url FROM job_enrichments"
+        ).fetchone() == (job_id, "https://apply.example/role")
+        assert candidate.execute(
+            "SELECT artifact_id, tenant_id, job_id FROM job_artifacts"
+        ).fetchone() == (1, "local", job_id)
+        assert candidate.execute(
+            "SELECT seq FROM sqlite_sequence WHERE name = 'job_artifacts'"
+        ).fetchone() == (1,)
+        assert candidate.execute(
+            "SELECT seed_url FROM source_registry_entries"
+        ).fetchone() == ("https://source.example/seed",)
+        assert candidate.execute("PRAGMA foreign_key_check").fetchall() == []
+    finally:
+        source.close()
+        candidate.close()
+
+
+def test_candidate_copy_rejects_unclassified_source_data_and_rolls_back(
+    tmp_path: Path,
+) -> None:
+    source, candidate = _connections(tmp_path)
+    try:
+        source.execute("ALTER TABLE job_enrichments ADD COLUMN drift TEXT")
+        with pytest.raises(CandidateCopyError, match="unclassified source columns"):
+            copy_direct_and_scalar_tables(source, candidate)
+        assert candidate.execute(
+            "SELECT COUNT(*) FROM job_enrichments"
+        ).fetchone() == (0,)
+
+        source.execute("CREATE TABLE unclassified_data (value TEXT)")
+        with pytest.raises(CandidateCopyError, match="unclassified source tables"):
+            copy_direct_and_scalar_tables(source, candidate)
+    finally:
+        source.close()
+        candidate.close()
+
+
+def test_candidate_copy_rejects_nonempty_retired_upgrade_history_table(
+    tmp_path: Path,
+) -> None:
+    source, candidate = _connections(tmp_path, history=True)
+    try:
+        source.execute(
+            "INSERT INTO discovery_run_projections (run_id) VALUES ('retired-run')"
+        )
+        with pytest.raises(CandidateCopyError, match="nonempty retired table"):
+            copy_direct_and_scalar_tables(source, candidate)
+    finally:
+        source.close()
+        candidate.close()
+
+
+def test_candidate_copy_requires_the_same_persisted_job_ids(tmp_path: Path) -> None:
+    source, candidate = _connections(tmp_path, hydrate_jobs=False)
+    try:
+        with pytest.raises(CandidateCopyError, match="hydrated canonical jobs"):
+            copy_direct_and_scalar_tables(source, candidate)
+    finally:
+        source.close()
+        candidate.close()

--- a/workers/automation/tests/test_v6_to_v7_copy.py
+++ b/workers/automation/tests/test_v6_to_v7_copy.py
@@ -12,6 +12,9 @@ from jobctrl.infrastructure.migrations.v6_to_v7_copy import (
     CandidateCopyError,
     copy_direct_and_scalar_tables,
 )
+from jobctrl.infrastructure.migrations.v6_to_v7_preflight import (
+    V6MigrationPreflightError,
+)
 from tests.v6_migration_fixture import (
     create_shipped_v6_database,
     create_supported_upgrade_history_v6_database,
@@ -182,14 +185,14 @@ def test_candidate_copy_rejects_unclassified_source_data_and_rolls_back(
     source, candidate = _connections(tmp_path)
     try:
         source.execute("ALTER TABLE job_enrichments ADD COLUMN drift TEXT")
-        with pytest.raises(CandidateCopyError, match="unclassified source columns"):
+        with pytest.raises(V6MigrationPreflightError, match="shipped v6"):
             copy_direct_and_scalar_tables(source, candidate)
         assert candidate.execute(
             "SELECT COUNT(*) FROM job_enrichments"
         ).fetchone() == (0,)
 
         source.execute("CREATE TABLE unclassified_data (value TEXT)")
-        with pytest.raises(CandidateCopyError, match="unclassified source tables"):
+        with pytest.raises(V6MigrationPreflightError, match="shipped v6"):
             copy_direct_and_scalar_tables(source, candidate)
     finally:
         source.close()

--- a/workers/automation/tests/test_v6_to_v7_copy.py
+++ b/workers/automation/tests/test_v6_to_v7_copy.py
@@ -17,6 +17,7 @@ from jobctrl.infrastructure.migrations.v6_to_v7_preflight import (
     _V6_AUXILIARY_DDL,
 )
 from tests.v6_migration_fixture import (
+    create_runtime_attestation_v6_database,
     create_shipped_v6_database,
     create_supported_upgrade_history_v6_database,
 )
@@ -220,6 +221,77 @@ def test_candidate_copy_requires_the_same_persisted_job_ids(tmp_path: Path) -> N
     try:
         with pytest.raises(CandidateCopyError, match="hydrated canonical jobs"):
             copy_direct_and_scalar_tables(source, candidate)
+    finally:
+        source.close()
+        candidate.close()
+
+
+def test_candidate_copy_defaults_profile_fields_absent_from_shipped_v6(
+    tmp_path: Path,
+) -> None:
+    source, candidate = _connections(tmp_path)
+    try:
+        source.execute(
+            "INSERT INTO candidate_profiles (updated_at) VALUES (?)",
+            ("2026-07-30T12:00:00+00:00",),
+        )
+
+        copy_direct_and_scalar_tables(source, candidate)
+
+        assert candidate.execute(
+            """
+            SELECT application_attestation_age_18_plus,
+                   application_attestation_background_check_consent,
+                   application_attestation_felony_conviction,
+                   application_attestation_previously_worked_at_employer,
+                   application_attestation_additional_json,
+                   application_preference_how_heard
+            FROM candidate_profiles
+            """
+        ).fetchone() == (None, None, None, None, "{}", "")
+    finally:
+        source.close()
+        candidate.close()
+
+
+def test_candidate_copy_preserves_runtime_profile_attestations(tmp_path: Path) -> None:
+    source_path = tmp_path / "runtime-attestations-v6.db"
+    create_runtime_attestation_v6_database(source_path)
+    source = sqlite3.connect(source_path)
+    source.execute("PRAGMA foreign_keys = ON")
+    candidate = sqlite3.connect(tmp_path / "candidate.db")
+    candidate.execute("PRAGMA foreign_keys = ON")
+    create_exact_v7_schema(candidate)
+    _hydrate_candidate_jobs(source, candidate)
+    try:
+        source.execute(
+            """
+            INSERT INTO candidate_profiles (
+                application_attestation_age_18_plus,
+                application_attestation_background_check_consent,
+                application_attestation_felony_conviction,
+                application_attestation_previously_worked_at_employer,
+                application_attestation_additional_json,
+                application_preference_how_heard,
+                updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (1, 1, 0, 0, '{"export_control":"accepted"}', "referral", "2026-07-30T12:00:00+00:00"),
+        )
+
+        copy_direct_and_scalar_tables(source, candidate)
+
+        assert candidate.execute(
+            """
+            SELECT application_attestation_age_18_plus,
+                   application_attestation_background_check_consent,
+                   application_attestation_felony_conviction,
+                   application_attestation_previously_worked_at_employer,
+                   application_attestation_additional_json,
+                   application_preference_how_heard
+            FROM candidate_profiles
+            """
+        ).fetchone() == (1, 1, 0, 0, '{"export_control":"accepted"}', "referral")
     finally:
         source.close()
         candidate.close()

--- a/workers/automation/tests/test_v6_to_v7_copy.py
+++ b/workers/automation/tests/test_v6_to_v7_copy.py
@@ -14,6 +14,7 @@ from jobctrl.infrastructure.migrations.v6_to_v7_copy import (
 )
 from jobctrl.infrastructure.migrations.v6_to_v7_preflight import (
     V6MigrationPreflightError,
+    _V6_AUXILIARY_DDL,
 )
 from tests.v6_migration_fixture import (
     create_shipped_v6_database,
@@ -219,6 +220,98 @@ def test_candidate_copy_requires_the_same_persisted_job_ids(tmp_path: Path) -> N
     try:
         with pytest.raises(CandidateCopyError, match="hydrated canonical jobs"):
             copy_direct_and_scalar_tables(source, candidate)
+    finally:
+        source.close()
+        candidate.close()
+
+
+@pytest.mark.parametrize("populated", [False, True])
+def test_candidate_copy_derives_local_tenant_for_optional_lifecycle_tables(
+    tmp_path: Path,
+    populated: bool,
+) -> None:
+    source, candidate = _connections(tmp_path)
+    try:
+        lifecycle_ddl = tuple(
+            ddl
+            for ddl in _V6_AUXILIARY_DDL
+            if "jobctrl_deleted_jobs" in ddl or "jobctrl_hidden_jobs" in ddl
+        )
+        assert len(lifecycle_ddl) == 2
+        for ddl in lifecycle_ddl:
+            source.execute(ddl)
+
+        job_url = str(source.execute("SELECT url FROM jobs").fetchone()[0])
+        job_id = str(candidate.execute("SELECT job_id FROM jobs").fetchone()[0])
+        if populated:
+            source.execute(
+                """
+                INSERT INTO jobctrl_deleted_jobs (
+                    job_url, deleted_at, reason, restored_at
+                ) VALUES (?, ?, ?, ?)
+                """,
+                (
+                    job_url,
+                    "2026-07-30T11:00:00+00:00",
+                    "duplicate",
+                    None,
+                ),
+            )
+            source.execute(
+                """
+                INSERT INTO jobctrl_hidden_jobs (
+                    job_url, hidden_at, reason, unhidden_at
+                ) VALUES (?, ?, ?, ?)
+                """,
+                (
+                    job_url,
+                    "2026-07-30T11:01:00+00:00",
+                    "not relevant",
+                    None,
+                ),
+            )
+
+        copy_direct_and_scalar_tables(source, candidate)
+
+        expected_deleted = (
+            [
+                (
+                    "local",
+                    job_id,
+                    "2026-07-30T11:00:00+00:00",
+                    "duplicate",
+                    None,
+                )
+            ]
+            if populated
+            else []
+        )
+        expected_hidden = (
+            [
+                (
+                    "local",
+                    job_id,
+                    "2026-07-30T11:01:00+00:00",
+                    "not relevant",
+                    None,
+                )
+            ]
+            if populated
+            else []
+        )
+        assert candidate.execute(
+            """
+            SELECT tenant_id, job_id, deleted_at, reason, restored_at
+            FROM jobctrl_deleted_jobs
+            """
+        ).fetchall() == expected_deleted
+        assert candidate.execute(
+            """
+            SELECT tenant_id, job_id, hidden_at, reason, unhidden_at
+            FROM jobctrl_hidden_jobs
+            """
+        ).fetchall() == expected_hidden
+        assert candidate.execute("PRAGMA foreign_key_check").fetchall() == []
     finally:
         source.close()
         candidate.close()


### PR DESCRIPTION
## Summary

- copy declared direct and scalar-rewrite table families from untouched v6 into an exact-v7 candidate
- enforce the exact-v6 preflight before any candidate copy writes
- resolve legacy URL identities through JobIds already written by the candidate root rewrite
- preserve supported runtime profile attestations and referral preference values, while applying exact declared defaults for fields absent from the original shipped-v6 schema
- derive local tenancy for legacy deleted/hidden lifecycle rows and preserve empty or populated optional tables
- preserve locator URLs and sequence cursors without mutating the source database
- exclude structured workflow/evidence projections from direct copy
- reject schema drift, unresolved identities, nonempty retired data, pre-populated target tables, and foreign-key violations with savepoint rollback

## Why

The local upgrade must leave v6 untouched until a fully verified candidate exists. This slice establishes the reusable copy engine without in-place table transforms, runtime compatibility, or atomic-swap orchestration.

## Validation

- cumulative focused preflight/plan/copy/candidate/execute regression suite on the rebased top — 47 passed
- focused Ruff — passed
- `git diff --check` — passed

## Stack

Base: `feat/job-id-v7-migration-registry` (#577). Root `jobs`/locator copying is isolated in #579. Structured event/projection transforms, final verifier, atomic swap, and launcher integration remain separate follow-up PRs.
