### PR TITLE
feat(storage): copy v6 events into candidate

### DIFF
--- a/workers/automation/src/jobctrl/infrastructure/migrations/identity_upcast.py
+++ b/workers/automation/src/jobctrl/infrastructure/migrations/identity_upcast.py
@@ -1,0 +1,248 @@
+"""Migration-only upcast for root-level v6 event identity payload fields."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any
+
+from jobctrl.infrastructure.migrations.v6_to_v7_copy import (
+    CandidateCopyError,
+    JobIdMap,
+)
+
+EVENT_IDENTITY_VERSION = 1
+
+_SINGULAR_FIELDS = {
+    "jobUrl": "jobId",
+    "jobKey": "jobId",
+    "jobId": "jobId",
+    "job_url": "job_id",
+    "job_key": "job_id",
+    "job_id": "job_id",
+    "survivingJobUrl": "survivingJobId",
+    "survivingJobKey": "survivingJobId",
+    "survivingJobId": "survivingJobId",
+    "surviving_job_url": "surviving_job_id",
+    "surviving_job_key": "surviving_job_id",
+    "surviving_job_id": "surviving_job_id",
+}
+_PLURAL_FIELDS = {
+    "jobUrls": "jobIds",
+    "jobKeys": "jobIds",
+    "jobIds": "jobIds",
+    "job_urls": "job_ids",
+    "job_keys": "job_ids",
+    "job_ids": "job_ids",
+    "survivingJobUrls": "survivingJobIds",
+    "survivingJobKeys": "survivingJobIds",
+    "survivingJobIds": "survivingJobIds",
+    "surviving_job_urls": "surviving_job_ids",
+    "surviving_job_keys": "surviving_job_ids",
+    "surviving_job_ids": "surviving_job_ids",
+}
+_PRIMARY_FIELDS = frozenset(
+    {
+        "jobId",
+        "job_id",
+        "survivingJobId",
+        "surviving_job_id",
+    }
+)
+
+
+class EventIdentityUpcastError(RuntimeError):
+    """Raised when immutable event identity cannot be upcast safely."""
+
+
+@dataclass(frozen=True)
+class UpcastedEventIdentity:
+    """Stable identity values for one copied v6 event row."""
+
+    job_id: str | None
+    payload_json: str | None
+    entity_ref: object
+
+
+def upcast_v6_event_identity(
+    *,
+    job_ids: JobIdMap,
+    event_type: object,
+    event_job_locator: object,
+    payload_json: object,
+    entity_kind: object,
+    entity_ref: object,
+) -> UpcastedEventIdentity:
+    """Rewrite only root event identity fields using the copied-job authority."""
+    column_job_id = _resolve_optional(job_ids, event_job_locator)
+    rewritten_payload, payload_primary, payload_references = _upcast_payload(
+        job_ids=job_ids,
+        event_type=event_type,
+        payload_json=payload_json,
+    )
+    entity_job_id = (
+        _resolve_optional(job_ids, entity_ref)
+        if entity_kind == "job" and entity_ref is not None
+        else None
+    )
+    primary = {
+        value
+        for value in (*payload_primary, column_job_id, entity_job_id)
+        if value is not None
+    }
+    if len(primary) > 1:
+        raise EventIdentityUpcastError("event_job_identity_conflict")
+
+    if primary:
+        job_id = next(iter(primary))
+    elif len(payload_references) == 1:
+        job_id = next(iter(payload_references))
+    else:
+        job_id = None
+
+    if entity_kind == "job":
+        if job_id is None:
+            raise EventIdentityUpcastError("event_job_identity_unresolved")
+        rewritten_entity_ref = job_id if entity_ref is not None else None
+    else:
+        rewritten_entity_ref = entity_ref
+
+    return UpcastedEventIdentity(
+        job_id=job_id,
+        payload_json=rewritten_payload,
+        entity_ref=rewritten_entity_ref,
+    )
+
+
+def _upcast_payload(
+    *,
+    job_ids: JobIdMap,
+    event_type: object,
+    payload_json: object,
+) -> tuple[str | None, tuple[str, ...], frozenset[str]]:
+    if payload_json is None:
+        return None, (), frozenset()
+    try:
+        decoded = json.loads(str(payload_json))
+    except (TypeError, ValueError) as error:
+        raise EventIdentityUpcastError("event_payload_invalid") from error
+    if not isinstance(decoded, dict):
+        # Non-object payloads have no root keys and are audit data unchanged.
+        return str(payload_json), (), frozenset()
+
+    normalized = _normalize_duplicate_link_payload(event_type, decoded)
+    transformed: dict[str, Any] = {}
+    primary: set[str] = set()
+    references: set[str] = set()
+    for key, value in normalized.items():
+        output_key = _SINGULAR_FIELDS.get(key)
+        if output_key is not None:
+            output_value, resolved = _upcast_singular(job_ids, value)
+        else:
+            output_key = _PLURAL_FIELDS.get(key)
+            if output_key is not None:
+                output_value, resolved = _upcast_plural(job_ids, value)
+            else:
+                output_key = key
+                output_value = value
+                resolved = ()
+        if output_key in transformed and transformed[output_key] != output_value:
+            raise EventIdentityUpcastError("event_job_identity_conflict")
+        transformed[output_key] = output_value
+        references.update(resolved)
+        if output_key in _PRIMARY_FIELDS:
+            primary.update(resolved)
+
+    return (
+        json.dumps(transformed, separators=(",", ":"), sort_keys=True),
+        tuple(sorted(primary)),
+        frozenset(references),
+    )
+
+
+def _normalize_duplicate_link_payload(
+    event_type: object,
+    payload: dict[str, Any],
+) -> dict[str, Any]:
+    normalized = dict(payload)
+    if event_type != "DuplicateJobLinkRejected":
+        return normalized
+    _rename_historical_candidate_locator(
+        normalized,
+        historical_key="candidateJobId",
+        locator_key="candidatePostingUrl",
+    )
+    _rename_historical_candidate_locator(
+        normalized,
+        historical_key="candidate_job_id",
+        locator_key="candidate_posting_url",
+    )
+    return normalized
+
+
+def _rename_historical_candidate_locator(
+    payload: dict[str, Any],
+    *,
+    historical_key: str,
+    locator_key: str,
+) -> None:
+    if historical_key not in payload:
+        return
+    historical_value = payload[historical_key]
+    if locator_key in payload and payload[locator_key] != historical_value:
+        raise EventIdentityUpcastError("event_job_identity_conflict")
+    payload[locator_key] = historical_value
+    del payload[historical_key]
+
+
+def _upcast_singular(
+    job_ids: JobIdMap,
+    value: object,
+) -> tuple[str | None, tuple[str, ...]]:
+    if value is None:
+        return None, ()
+    if not isinstance(value, str):
+        raise EventIdentityUpcastError("event_job_identity_invalid")
+    resolved = _resolve_required(job_ids, value)
+    return resolved, (resolved,)
+
+
+def _upcast_plural(
+    job_ids: JobIdMap,
+    value: object,
+) -> tuple[list[str | None], tuple[str, ...]]:
+    if not isinstance(value, list):
+        raise EventIdentityUpcastError("event_job_identity_invalid")
+    rewritten: list[str | None] = []
+    references: list[str] = []
+    for item in value:
+        result, resolved = _upcast_singular(job_ids, item)
+        rewritten.append(result)
+        references.extend(resolved)
+    return rewritten, tuple(references)
+
+
+def _resolve_optional(job_ids: JobIdMap, value: object) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value.strip():
+        raise EventIdentityUpcastError("event_job_identity_invalid")
+    return _resolve_required(job_ids, value)
+
+
+def _resolve_required(job_ids: JobIdMap, locator: str) -> str:
+    try:
+        resolved = job_ids.resolve(tenant_id="local", locator=locator)
+    except CandidateCopyError as error:
+        raise EventIdentityUpcastError("event_job_identity_unresolved") from error
+    if resolved is None:
+        raise EventIdentityUpcastError("event_job_identity_invalid")
+    return resolved
+
+
+__all__ = [
+    "EVENT_IDENTITY_VERSION",
+    "EventIdentityUpcastError",
+    "UpcastedEventIdentity",
+    "upcast_v6_event_identity",
+]

--- a/workers/automation/src/jobctrl/infrastructure/migrations/identity_upcast.py
+++ b/workers/automation/src/jobctrl/infrastructure/migrations/identity_upcast.py
@@ -26,6 +26,8 @@ _SINGULAR_FIELDS = {
     "surviving_job_url": "surviving_job_id",
     "surviving_job_key": "surviving_job_id",
     "surviving_job_id": "surviving_job_id",
+    "candidateJobId": "candidateJobId",
+    "candidate_job_id": "candidate_job_id",
 }
 _PLURAL_FIELDS = {
     "jobUrls": "jobIds",
@@ -49,6 +51,7 @@ _PRIMARY_FIELDS = frozenset(
         "surviving_job_id",
     }
 )
+_NON_JOB_SCOPE_REFERENCES = frozenset({"pipeline"})
 
 
 class EventIdentityUpcastError(RuntimeError):
@@ -203,6 +206,8 @@ def _upcast_singular(
         return None, ()
     if not isinstance(value, str):
         raise EventIdentityUpcastError("event_job_identity_invalid")
+    if value.strip() in _NON_JOB_SCOPE_REFERENCES:
+        return value.strip(), ()
     resolved = _resolve_required(job_ids, value)
     return resolved, (resolved,)
 

--- a/workers/automation/src/jobctrl/infrastructure/migrations/v6_to_v7_events.py
+++ b/workers/automation/src/jobctrl/infrastructure/migrations/v6_to_v7_events.py
@@ -1,0 +1,271 @@
+"""Copy immutable v6 job events into the exact-v7 migration candidate."""
+
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+
+from jobctrl.infrastructure.migrations.identity_upcast import (
+    EVENT_IDENTITY_VERSION,
+    EventIdentityUpcastError,
+    upcast_v6_event_identity,
+)
+from jobctrl.infrastructure.migrations.schema_manifest import (
+    EXACT_V7_MANIFEST,
+    assert_exact_manifest,
+)
+from jobctrl.infrastructure.migrations.v6_to_v7_copy import (
+    CandidateCopyError,
+    JobIdMap,
+    build_job_id_map,
+)
+from jobctrl.infrastructure.migrations.v6_to_v7_preflight import (
+    assert_v6_migration_preflight,
+)
+
+_SOURCE_COLUMNS = (
+    "event_id",
+    "job_url",
+    "stage",
+    "event_type",
+    "level",
+    "message",
+    "occurred_at",
+    "payload_json",
+    "entity_kind",
+    "entity_ref",
+    "idempotency_key",
+)
+_TARGET_COLUMNS = (
+    "event_id",
+    "tenant_id",
+    "job_id",
+    "identity_version",
+    "stage",
+    "event_type",
+    "level",
+    "message",
+    "occurred_at",
+    "payload_json",
+    "entity_kind",
+    "entity_ref",
+    "idempotency_key",
+)
+
+
+class CandidateEventCopyError(RuntimeError):
+    """Raised when historical event identity cannot be copied exactly."""
+
+
+@dataclass(frozen=True)
+class CandidateEventCopyResult:
+    """Verified append-only event copy result for the migration coordinator."""
+
+    copied_events: int
+    sequence_high_water: int | None
+
+
+def copy_job_events(
+    source: sqlite3.Connection,
+    candidate: sqlite3.Connection,
+    *,
+    job_ids: JobIdMap,
+) -> CandidateEventCopyResult:
+    """Copy v6 events into the already-root-copied exact-v7 candidate.
+
+    This is a candidate-only transform. The admitted v6 source is read but
+    never rebuilt, altered, or otherwise written by this function.
+    """
+    assert_v6_migration_preflight(source)
+    assert_exact_manifest(candidate, EXACT_V7_MANIFEST)
+    _assert_candidate_job_ids(source, candidate, job_ids)
+    if _columns(source, "job_events") != _SOURCE_COLUMNS:
+        raise CandidateEventCopyError("source job_events columns do not match admitted v6")
+    if _columns(candidate, "job_events") != _TARGET_COLUMNS:
+        raise CandidateEventCopyError("candidate job_events columns do not match exact v7")
+    if _row_count(candidate, "job_events"):
+        raise CandidateEventCopyError("candidate job_events must be empty")
+    if _sequence_value(candidate, "job_events") is not None:
+        raise CandidateEventCopyError("candidate job_events must not have a sequence cursor")
+
+    source_rows = tuple(
+        tuple(row)
+        for row in source.execute(
+            f"SELECT {', '.join(_quote(column) for column in _SOURCE_COLUMNS)} "
+            "FROM job_events ORDER BY event_id"
+        ).fetchall()
+    )
+    source_sequence = _sequence_value(source, "job_events")
+    candidate_rows = _candidate_rows(source_rows, job_ids)
+    _validate_source_sequence(source_rows, source_sequence)
+
+    candidate.execute("SAVEPOINT v6_job_events_candidate_copy")
+    try:
+        if candidate_rows:
+            placeholders = ", ".join("?" for _ in _TARGET_COLUMNS)
+            candidate.executemany(
+                f"INSERT INTO job_events ({', '.join(_quote(column) for column in _TARGET_COLUMNS)}) "
+                f"VALUES ({placeholders})",
+                candidate_rows,
+            )
+        _copy_sequence_cursor(candidate, source_sequence)
+        _verify_candidate(
+            source=source,
+            candidate=candidate,
+            expected_source_rows=source_rows,
+            expected_candidate_rows=candidate_rows,
+            expected_sequence=source_sequence,
+        )
+        candidate.execute("RELEASE SAVEPOINT v6_job_events_candidate_copy")
+    except BaseException:
+        candidate.execute("ROLLBACK TO SAVEPOINT v6_job_events_candidate_copy")
+        candidate.execute("RELEASE SAVEPOINT v6_job_events_candidate_copy")
+        raise
+
+    return CandidateEventCopyResult(
+        copied_events=len(candidate_rows),
+        sequence_high_water=source_sequence,
+    )
+
+
+def _assert_candidate_job_ids(
+    source: sqlite3.Connection,
+    candidate: sqlite3.Connection,
+    job_ids: JobIdMap,
+) -> None:
+    try:
+        persisted = build_job_id_map(source, candidate)
+    except CandidateCopyError as error:
+        raise CandidateEventCopyError("candidate JobIdMap is not hydrated") from error
+    if dict(persisted.by_locator) != dict(job_ids.by_locator):
+        raise CandidateEventCopyError("candidate JobIdMap does not match root copy")
+
+
+def _candidate_rows(
+    source_rows: tuple[tuple[object, ...], ...],
+    job_ids: JobIdMap,
+) -> tuple[tuple[object, ...], ...]:
+    copied: list[tuple[object, ...]] = []
+    for row in source_rows:
+        values = dict(zip(_SOURCE_COLUMNS, row, strict=True))
+        try:
+            identity = upcast_v6_event_identity(
+                job_ids=job_ids,
+                event_type=values["event_type"],
+                event_job_locator=values["job_url"],
+                payload_json=values["payload_json"],
+                entity_kind=values["entity_kind"],
+                entity_ref=values["entity_ref"],
+            )
+        except EventIdentityUpcastError as error:
+            raise CandidateEventCopyError(str(error)) from error
+        copied.append(
+            (
+                values["event_id"],
+                "local",
+                identity.job_id,
+                EVENT_IDENTITY_VERSION,
+                values["stage"],
+                values["event_type"],
+                values["level"],
+                values["message"],
+                values["occurred_at"],
+                identity.payload_json,
+                values["entity_kind"],
+                identity.entity_ref,
+                values["idempotency_key"],
+            )
+        )
+    return tuple(copied)
+
+
+def _validate_source_sequence(
+    source_rows: tuple[tuple[object, ...], ...],
+    source_sequence: int | None,
+) -> None:
+    highest_event_id = max((int(row[0]) for row in source_rows), default=0)
+    if source_sequence is None:
+        if highest_event_id:
+            raise CandidateEventCopyError("source job_events is missing its sequence cursor")
+        return
+    if source_sequence < highest_event_id:
+        raise CandidateEventCopyError("source job_events sequence cursor is below its event IDs")
+
+
+def _copy_sequence_cursor(
+    candidate: sqlite3.Connection,
+    source_sequence: int | None,
+) -> None:
+    if source_sequence is None:
+        if _sequence_value(candidate, "job_events") is not None:
+            raise CandidateEventCopyError("candidate copy synthesized a sequence cursor")
+        return
+    updated = candidate.execute(
+        "UPDATE sqlite_sequence SET seq = ? WHERE name = 'job_events'",
+        (source_sequence,),
+    )
+    if updated.rowcount == 0:
+        candidate.execute(
+            "INSERT INTO sqlite_sequence(name, seq) VALUES ('job_events', ?)",
+            (source_sequence,),
+        )
+
+
+def _verify_candidate(
+    *,
+    source: sqlite3.Connection,
+    candidate: sqlite3.Connection,
+    expected_source_rows: tuple[tuple[object, ...], ...],
+    expected_candidate_rows: tuple[tuple[object, ...], ...],
+    expected_sequence: int | None,
+) -> None:
+    candidate_rows = tuple(
+        tuple(row)
+        for row in candidate.execute(
+            f"SELECT {', '.join(_quote(column) for column in _TARGET_COLUMNS)} "
+            "FROM job_events ORDER BY event_id"
+        ).fetchall()
+    )
+    if candidate_rows != expected_candidate_rows:
+        raise CandidateEventCopyError("candidate copy changed event ordering or scalars")
+    if _sequence_value(candidate, "job_events") != expected_sequence:
+        raise CandidateEventCopyError("candidate copy changed the event sequence high-water")
+    if candidate.execute("PRAGMA foreign_key_check").fetchall():
+        raise CandidateEventCopyError("candidate copy left a foreign-key violation")
+    assert_exact_manifest(candidate, EXACT_V7_MANIFEST)
+    source_rows_after = tuple(
+        tuple(row)
+        for row in source.execute(
+            f"SELECT {', '.join(_quote(column) for column in _SOURCE_COLUMNS)} "
+            "FROM job_events ORDER BY event_id"
+        ).fetchall()
+    )
+    if source_rows_after != expected_source_rows:
+        raise CandidateEventCopyError("candidate copy mutated the v6 source events")
+
+
+def _columns(conn: sqlite3.Connection, table: str) -> tuple[str, ...]:
+    rows = conn.execute(f"PRAGMA table_info({_quote(table)})").fetchall()
+    if not rows:
+        raise CandidateEventCopyError(f"missing required table: {table}")
+    return tuple(str(row[1]) for row in rows)
+
+
+def _row_count(conn: sqlite3.Connection, table: str) -> int:
+    return int(conn.execute(f"SELECT COUNT(*) FROM {_quote(table)}").fetchone()[0])
+
+
+def _sequence_value(conn: sqlite3.Connection, table: str) -> int | None:
+    row = conn.execute("SELECT seq FROM sqlite_sequence WHERE name = ?", (table,)).fetchone()
+    return None if row is None else int(row[0])
+
+
+def _quote(value: str) -> str:
+    return f'"{value.replace(chr(34), chr(34) * 2)}"'
+
+
+__all__ = [
+    "CandidateEventCopyError",
+    "CandidateEventCopyResult",
+    "copy_job_events",
+]

--- a/workers/automation/tests/test_v6_to_v7_event_copy.py
+++ b/workers/automation/tests/test_v6_to_v7_event_copy.py
@@ -1,0 +1,322 @@
+"""Focused contracts for candidate-side v6 event identity copying."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from jobctrl.infrastructure.migrations import v6_to_v7_events as events
+from jobctrl.infrastructure.migrations.schema_manifest import schema_dump
+from jobctrl.infrastructure.migrations.schema_v7 import create_exact_v7_schema
+from jobctrl.infrastructure.migrations.v6_to_v7_events import (
+    CandidateEventCopyError,
+    copy_job_events,
+)
+from jobctrl.infrastructure.migrations.v6_to_v7_root import copy_root_jobs
+from tests.v6_migration_fixture import create_shipped_v6_database
+
+_JOB_URL = "https://jobs.example/shipped-v6"
+_JOB_ID = "00000000-0000-4000-8000-000000000001"
+_UNTRUSTED_ANALYSIS_CONTEXT = {"userContext": "Attack vectors:\nPrompt injection"}
+
+
+def _connections(tmp_path: Path) -> tuple[sqlite3.Connection, sqlite3.Connection, Path]:
+    source_path = tmp_path / "source.db"
+    create_shipped_v6_database(source_path)
+    source = sqlite3.connect(source_path)
+    source.execute("PRAGMA foreign_keys = ON")
+    candidate = sqlite3.connect(tmp_path / "candidate.db")
+    candidate.execute("PRAGMA foreign_keys = ON")
+    create_exact_v7_schema(candidate)
+    return source, candidate, source_path
+
+
+def _allocator(*values: str):
+    allocated: Iterator[str] = iter(values)
+    return allocated.__next__
+
+
+def _copy_root(source: sqlite3.Connection, candidate: sqlite3.Connection):
+    return copy_root_jobs(
+        source,
+        candidate,
+        job_id_factory=_allocator(_JOB_ID),
+        migration_at="2026-07-30T10:00:00+00:00",
+    ).job_ids
+
+
+def _insert_event(
+    conn: sqlite3.Connection,
+    *,
+    event_id: int,
+    job_url: str | None = _JOB_URL,
+    payload: object | None = None,
+    event_type: str = "StageCompleted",
+    entity_kind: str | None = "job",
+    entity_ref: str | None = _JOB_URL,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO job_events (
+            event_id, job_url, stage, event_type, level, message, occurred_at,
+            payload_json, entity_kind, entity_ref, idempotency_key
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            event_id,
+            job_url,
+            "discover",
+            event_type,
+            "info",
+            f"event-{event_id}",
+            f"2026-07-30T10:0{event_id}:00+00:00",
+            json.dumps(payload, separators=(",", ":")) if payload is not None else None,
+            entity_kind,
+            entity_ref,
+            f"event-copy-{event_id}",
+        ),
+    )
+
+
+def test_candidate_event_copy_preserves_v6_history_and_only_rewrites_root_identity(
+    tmp_path: Path,
+) -> None:
+    source, candidate, source_path = _connections(tmp_path)
+    try:
+        nested = {
+            "jobUrl": _JOB_URL,
+            "job_ids": [_JOB_URL],
+            "untrusted": _UNTRUSTED_ANALYSIS_CONTEXT,
+        }
+        _insert_event(
+            source,
+            event_id=7,
+            payload={
+                "jobUrl": _JOB_URL,
+                "jobUrls": [_JOB_URL],
+                "job_keys": [_JOB_URL],
+                "survivingJobKey": _JOB_URL,
+                "untrusted": nested,
+            },
+        )
+        _insert_event(
+            source,
+            event_id=8,
+            job_url=None,
+            payload=_UNTRUSTED_ANALYSIS_CONTEXT,
+            entity_kind="pipeline",
+            entity_ref="discover:run-1",
+        )
+        source.execute("UPDATE sqlite_sequence SET seq = 41 WHERE name = 'job_events'")
+        source.commit()
+        before_schema = source.execute("PRAGMA schema_version").fetchone()[0]
+        before_changes = source.total_changes
+        before_bytes = source_path.read_bytes()
+        before_events = tuple(source.execute("SELECT * FROM job_events ORDER BY event_id").fetchall())
+        job_ids = _copy_root(source, candidate)
+
+        result = copy_job_events(source, candidate, job_ids=job_ids)
+
+        assert result.copied_events == 2
+        assert result.sequence_high_water == 41
+        rows = candidate.execute(
+            """
+            SELECT event_id, tenant_id, job_id, identity_version, stage, event_type,
+                   level, message, occurred_at, payload_json, entity_kind, entity_ref,
+                   idempotency_key
+            FROM job_events ORDER BY event_id
+            """
+        ).fetchall()
+        assert rows[0][:5] == (7, "local", _JOB_ID, 1, "discover")
+        assert rows[0][5:9] == (
+            "StageCompleted",
+            "info",
+            "event-7",
+            "2026-07-30T10:07:00+00:00",
+        )
+        assert rows[0][10:] == ("job", _JOB_ID, "event-copy-7")
+        assert json.loads(str(rows[0][9])) == {
+            "jobId": _JOB_ID,
+            "jobIds": [_JOB_ID],
+            "job_ids": [_JOB_ID],
+            "survivingJobId": _JOB_ID,
+            "untrusted": nested,
+        }
+        assert rows[1][:5] == (8, "local", None, 1, "discover")
+        assert rows[1][10:] == ("pipeline", "discover:run-1", "event-copy-8")
+        assert json.loads(str(rows[1][9])) == _UNTRUSTED_ANALYSIS_CONTEXT
+        assert candidate.execute(
+            "SELECT seq FROM sqlite_sequence WHERE name = 'job_events'"
+        ).fetchone() == (41,)
+        assert tuple(source.execute("SELECT * FROM job_events ORDER BY event_id").fetchall()) == before_events
+        assert source.execute("PRAGMA schema_version").fetchone()[0] == before_schema
+        assert source.total_changes == before_changes
+        assert source_path.read_bytes() == before_bytes
+        assert candidate.execute("PRAGMA foreign_key_check").fetchall() == []
+    finally:
+        source.close()
+        candidate.close()
+
+
+def test_duplicate_link_candidate_locator_remains_historical_root_data(
+    tmp_path: Path,
+) -> None:
+    source, candidate, _ = _connections(tmp_path)
+    try:
+        candidate_url = "https://jobs.example/rejected-candidate"
+        _insert_event(
+            source,
+            event_id=7,
+            event_type="DuplicateJobLinkRejected",
+            payload={
+                "candidateJobId": candidate_url,
+                "surviving_job_key": _JOB_URL,
+                "nested": {"candidateJobId": candidate_url},
+            },
+        )
+        source.commit()
+        job_ids = _copy_root(source, candidate)
+
+        copy_job_events(source, candidate, job_ids=job_ids)
+
+        payload = json.loads(
+            str(candidate.execute("SELECT payload_json FROM job_events").fetchone()[0])
+        )
+        assert payload == {
+            "candidatePostingUrl": candidate_url,
+            "nested": {"candidateJobId": candidate_url},
+            "surviving_job_id": _JOB_ID,
+        }
+    finally:
+        source.close()
+        candidate.close()
+
+
+@pytest.mark.parametrize(
+    "payload",
+    (
+        {"jobUrl": "https://jobs.example/unresolved"},
+        {"jobUrl": "https://jobs.example/second"},
+    ),
+)
+def test_candidate_event_copy_rejects_unresolved_or_conflicting_identity_without_writes(
+    tmp_path: Path,
+    payload: dict[str, str],
+) -> None:
+    source, candidate, source_path = _connections(tmp_path)
+    try:
+        source.execute(
+            "INSERT INTO jobs (url, title, discovered_at) VALUES (?, ?, ?)",
+            (
+                "https://jobs.example/second",
+                "Second fixture",
+                "2026-07-30T10:01:00+00:00",
+            ),
+        )
+        _insert_event(source, event_id=7, payload=payload)
+        source.commit()
+        before_bytes = source_path.read_bytes()
+        before_changes = source.total_changes
+        job_ids = copy_root_jobs(
+            source,
+            candidate,
+            job_id_factory=_allocator(
+                _JOB_ID,
+                "00000000-0000-4000-8000-000000000002",
+            ),
+            migration_at="2026-07-30T10:00:00+00:00",
+        ).job_ids
+
+        with pytest.raises(CandidateEventCopyError, match="event_job_identity"):
+            copy_job_events(source, candidate, job_ids=job_ids)
+
+        assert candidate.execute("SELECT COUNT(*) FROM job_events").fetchone() == (0,)
+        assert candidate.execute(
+            "SELECT seq FROM sqlite_sequence WHERE name = 'job_events'"
+        ).fetchone() is None
+        assert source.total_changes == before_changes
+        assert source_path.read_bytes() == before_bytes
+    finally:
+        source.close()
+        candidate.close()
+
+
+def test_candidate_event_copy_rolls_back_candidate_and_retries_same_source(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source, candidate, source_path = _connections(tmp_path)
+    try:
+        _insert_event(source, event_id=7, payload={"jobUrl": _JOB_URL})
+        source.commit()
+        before_bytes = source_path.read_bytes()
+        before_changes = source.total_changes
+        job_ids = _copy_root(source, candidate)
+        original_verify = events._verify_candidate
+        monkeypatch.setattr(
+            events,
+            "_verify_candidate",
+            lambda **_kwargs: (_ for _ in ()).throw(RuntimeError("candidate fault")),
+        )
+
+        with pytest.raises(RuntimeError, match="candidate fault"):
+            copy_job_events(source, candidate, job_ids=job_ids)
+
+        assert candidate.execute("SELECT COUNT(*) FROM job_events").fetchone() == (0,)
+        assert candidate.execute(
+            "SELECT seq FROM sqlite_sequence WHERE name = 'job_events'"
+        ).fetchone() is None
+        assert source.total_changes == before_changes
+        assert source_path.read_bytes() == before_bytes
+        monkeypatch.setattr(events, "_verify_candidate", original_verify)
+
+        copied = copy_job_events(source, candidate, job_ids=job_ids)
+
+        assert copied.copied_events == 1
+        assert candidate.execute("SELECT event_id, job_id FROM job_events").fetchone() == (7, _JOB_ID)
+    finally:
+        source.close()
+        candidate.close()
+
+
+def test_candidate_event_copy_keeps_the_exact_v7_schema_and_reopens(
+    tmp_path: Path,
+) -> None:
+    source, candidate, _ = _connections(tmp_path)
+    canonical = sqlite3.connect(":memory:")
+    candidate_path = Path(str(candidate.execute("PRAGMA database_list").fetchone()[2]))
+    try:
+        _insert_event(source, event_id=7, payload={"job_id": _JOB_URL})
+        source.execute("UPDATE sqlite_sequence SET seq = 13 WHERE name = 'job_events'")
+        source.commit()
+        job_ids = _copy_root(source, candidate)
+
+        copy_job_events(source, candidate, job_ids=job_ids)
+        create_exact_v7_schema(canonical)
+        assert tuple(row for row in schema_dump(candidate) if row[2] == "job_events") == tuple(
+            row for row in schema_dump(canonical) if row[2] == "job_events"
+        )
+        candidate.commit()
+    finally:
+        source.close()
+        canonical.close()
+        candidate.close()
+
+    reopened = sqlite3.connect(candidate_path)
+    try:
+        reopened.execute("PRAGMA foreign_keys = ON")
+        assert reopened.execute("SELECT event_id, job_id, identity_version FROM job_events").fetchone() == (
+            7,
+            _JOB_ID,
+            1,
+        )
+        assert reopened.execute(
+            "SELECT seq FROM sqlite_sequence WHERE name = 'job_events'"
+        ).fetchone() == (13,)
+        assert reopened.execute("PRAGMA foreign_key_check").fetchall() == []
+    finally:
+        reopened.close()

--- a/workers/automation/tests/test_v6_to_v7_event_copy.py
+++ b/workers/automation/tests/test_v6_to_v7_event_copy.py
@@ -196,6 +196,61 @@ def test_duplicate_link_candidate_locator_remains_historical_root_data(
         candidate.close()
 
 
+def test_pipeline_scope_and_content_duplicate_candidate_are_not_url_identities(
+    tmp_path: Path,
+) -> None:
+    source, candidate, _ = _connections(tmp_path)
+    try:
+        _insert_event(
+            source,
+            event_id=7,
+            job_url=None,
+            payload={"jobId": "pipeline"},
+            entity_kind="pipeline",
+            entity_ref="discover:run-1",
+        )
+        _insert_event(
+            source,
+            event_id=8,
+            job_url=None,
+            event_type="ContentDuplicateCandidateDetected",
+            payload={"candidateJobId": _JOB_URL},
+            entity_kind="duplicate-candidate",
+            entity_ref="observation-1",
+        )
+        source.commit()
+        job_ids = _copy_root(source, candidate)
+
+        copy_job_events(source, candidate, job_ids=job_ids)
+
+        rows = candidate.execute(
+            """
+            SELECT event_id, job_id, payload_json, entity_ref
+            FROM job_events
+            ORDER BY event_id
+            """
+        ).fetchall()
+        assert rows[0] == (
+            7,
+            None,
+            json.dumps({"jobId": "pipeline"}, separators=(",", ":"), sort_keys=True),
+            "discover:run-1",
+        )
+        assert rows[1] == (
+            8,
+            _JOB_ID,
+            json.dumps(
+                {"candidateJobId": _JOB_ID},
+                separators=(",", ":"),
+                sort_keys=True,
+            ),
+            "observation-1",
+        )
+    finally:
+        source.close()
+        candidate.close()
+
+
 @pytest.mark.parametrize(
     "payload",
     (


### PR DESCRIPTION
## Summary

- copy admitted v6 `job_events` into the exact-v7 candidate under a savepoint
- upcast only root event identity fields through the hydrated candidate JobId map
- preserve pipeline-scope sentinels and historical rejected-candidate locators
- resolve canonical duplicate-candidate references without rewriting opaque nested payload data
- preserve event ordering, scalar fields, idempotency keys, sequence high-water, foreign-key integrity, rollback/retry, reopen behavior, and source immutability

## Validation

- focused event/root-copy suite — 14 passed
- cumulative exact-schema, migration, and discovery identity suite through #581 — 111 passed
- focused Ruff — passed
- `git diff --check` — passed
- independent review — PASS, 0 Blocker/High/Medium/Low findings

## Stack

Base: `feat/job-id-v7-root-copy` (#579). Candidate work-item copying continues in #581.