### PR TITLE
feat(storage): copy v7 work-item candidates

### DIFF
--- a/workers/automation/src/jobctrl/infrastructure/migrations/v6_to_v7_work_items.py
+++ b/workers/automation/src/jobctrl/infrastructure/migrations/v6_to_v7_work_items.py
@@ -1,0 +1,434 @@
+"""Structured v6-to-v7 candidate copy for quarantine and preparation rows."""
+
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+from jobctrl.domain.identifiers import JobId
+from jobctrl.domain.preparation import (
+    PreparationWorkItemKind,
+    PreparationWorkItemState,
+    make_preparation_idempotency_key,
+)
+from jobctrl.domain.tenant import TenantId
+from jobctrl.infrastructure.migrations.schema_manifest import (
+    EXACT_V7_MANIFEST,
+    assert_exact_manifest,
+)
+from jobctrl.infrastructure.migrations.v6_to_v7_copy import (
+    CandidateCopyError,
+    JobIdMap,
+    build_job_id_map,
+)
+from jobctrl.infrastructure.migrations.v6_to_v7_preflight import (
+    assert_v6_migration_preflight,
+)
+
+
+class CandidateWorkItemsCopyError(RuntimeError):
+    """Raised when structured work-item rows cannot safely enter the candidate."""
+
+
+@dataclass(frozen=True)
+class CandidateWorkItemsCopyResult:
+    """Counts of structured rows copied into the exact-v7 candidate."""
+
+    copied_quarantine_entries: int
+    copied_preparation_work_items: int
+
+
+_SOURCE_QUARANTINE_COLUMNS = (
+    "tenant_id",
+    "job_id",
+    "job_key",
+    "title",
+    "company",
+    "source_id",
+    "posting_url",
+    "reason",
+    "confidence",
+    "snapshot_version",
+    "captured_at",
+    "notice_text",
+    "status",
+    "decision_reason",
+    "decided_at",
+)
+_TARGET_QUARANTINE_COLUMNS = tuple(
+    column for column in _SOURCE_QUARANTINE_COLUMNS if column != "job_key"
+)
+_WORK_ITEM_COLUMNS = (
+    "item_id",
+    "tenant_id",
+    "job_id",
+    "kind",
+    "target_version",
+    "source_event_id",
+    "state",
+    "idempotency_key",
+    "attempts",
+    "last_error",
+    "created_at",
+    "updated_at",
+    "available_at",
+)
+
+
+def copy_structured_work_items(
+    source: sqlite3.Connection,
+    candidate: sqlite3.Connection,
+    *,
+    job_ids: JobIdMap,
+) -> CandidateWorkItemsCopyResult:
+    """Copy the two structured work-item tables into a hydrated v7 candidate.
+
+    This copier deliberately accepts the root-copy result rather than rebuilding
+    identity from v6 rows. It independently verifies that the supplied map is
+    the exact map already represented by candidate roots before any child row
+    is written.
+    """
+    assert_v6_migration_preflight(source)
+    assert_exact_manifest(candidate, EXACT_V7_MANIFEST)
+    _assert_authoritative_roots(source, candidate, job_ids)
+    _assert_empty_target_tables(candidate)
+    _assert_columns(
+        source,
+        "discovery_quarantine_entries",
+        _SOURCE_QUARANTINE_COLUMNS,
+    )
+    _assert_columns(
+        candidate,
+        "discovery_quarantine_entries",
+        _TARGET_QUARANTINE_COLUMNS,
+    )
+    _assert_columns(source, "preparation_work_items", _WORK_ITEM_COLUMNS)
+    _assert_columns(candidate, "preparation_work_items", _WORK_ITEM_COLUMNS)
+
+    quarantine_rows = _source_rows(
+        source,
+        "discovery_quarantine_entries",
+        _SOURCE_QUARANTINE_COLUMNS,
+    )
+    work_item_rows = _source_rows(
+        source,
+        "preparation_work_items",
+        _WORK_ITEM_COLUMNS,
+    )
+
+    candidate.execute("SAVEPOINT v6_structured_work_items_copy")
+    try:
+        _copy_quarantine_entries(candidate, quarantine_rows, job_ids)
+        _copy_preparation_work_items(candidate, work_item_rows, job_ids)
+        _verify_copy_counts(
+            candidate,
+            quarantine_entries=len(quarantine_rows),
+            preparation_work_items=len(work_item_rows),
+        )
+        _verify_foreign_keys(candidate)
+        candidate.execute("RELEASE SAVEPOINT v6_structured_work_items_copy")
+    except BaseException:
+        candidate.execute("ROLLBACK TO SAVEPOINT v6_structured_work_items_copy")
+        candidate.execute("RELEASE SAVEPOINT v6_structured_work_items_copy")
+        raise
+
+    return CandidateWorkItemsCopyResult(
+        copied_quarantine_entries=len(quarantine_rows),
+        copied_preparation_work_items=len(work_item_rows),
+    )
+
+
+def _assert_authoritative_roots(
+    source: sqlite3.Connection,
+    candidate: sqlite3.Connection,
+    job_ids: JobIdMap,
+) -> None:
+    try:
+        candidate_job_ids = build_job_id_map(source, candidate)
+    except CandidateCopyError as error:
+        raise CandidateWorkItemsCopyError(
+            "structured work-item copy requires hydrated candidate roots"
+        ) from error
+    if dict(candidate_job_ids.by_locator) != dict(job_ids.by_locator):
+        raise CandidateWorkItemsCopyError(
+            "supplied JobIdMap does not match hydrated candidate roots"
+        )
+    current_locators = {
+        (str(tenant_id), str(locator)): str(job_id)
+        for tenant_id, locator, job_id in candidate.execute(
+            """
+            SELECT tenant_id, locator_value, job_id
+            FROM job_locators
+            WHERE locator_kind = 'posting_url'
+              AND is_current = 1
+              AND retired_at IS NULL
+            """
+        ).fetchall()
+    }
+    if (
+        current_locators != dict(job_ids.by_locator)
+        or _row_count(candidate, "job_locators") != len(current_locators)
+    ):
+        raise CandidateWorkItemsCopyError(
+            "structured work-item copy requires hydrated candidate root locators"
+        )
+
+
+def _assert_empty_target_tables(candidate: sqlite3.Connection) -> None:
+    for table in ("discovery_quarantine_entries", "preparation_work_items"):
+        if _row_count(candidate, table):
+            raise CandidateWorkItemsCopyError(
+                f"candidate table must be empty: {table}"
+            )
+
+
+def _copy_quarantine_entries(
+    candidate: sqlite3.Connection,
+    source_rows: tuple[Mapping[str, object], ...],
+    job_ids: JobIdMap,
+) -> None:
+    target_rows: list[tuple[object, ...]] = []
+    for row in source_rows:
+        tenant_id = _tenant_id(row["tenant_id"])
+        legacy_job_id = _legacy_locator(row["job_id"], "quarantine job_id")
+        legacy_job_key = _legacy_locator(row["job_key"], "quarantine job_key")
+        if legacy_job_id != legacy_job_key:
+            raise CandidateWorkItemsCopyError(
+                "v6 quarantine job_id and job_key disagree"
+            )
+        job_id = _resolve_job_id(job_ids, tenant_id, legacy_job_id)
+        posting_url = _optional_locator(row["posting_url"], "quarantine posting_url")
+        target_rows.append(
+            (
+                tenant_id,
+                job_id,
+                row["title"],
+                row["company"],
+                row["source_id"],
+                posting_url,
+                row["reason"],
+                row["confidence"],
+                row["snapshot_version"],
+                row["captured_at"],
+                row["notice_text"],
+                row["status"],
+                row["decision_reason"],
+                row["decided_at"],
+            )
+        )
+    _insert_rows(
+        candidate,
+        "discovery_quarantine_entries",
+        _TARGET_QUARANTINE_COLUMNS,
+        target_rows,
+    )
+
+
+def _copy_preparation_work_items(
+    candidate: sqlite3.Connection,
+    source_rows: tuple[Mapping[str, object], ...],
+    job_ids: JobIdMap,
+) -> None:
+    target_rows: list[tuple[object, ...]] = []
+    for row in source_rows:
+        tenant_id = _tenant_id(row["tenant_id"])
+        job_id = _resolve_job_id(
+            job_ids,
+            tenant_id,
+            _legacy_locator(row["job_id"], "preparation work-item job_id"),
+        )
+        kind = _work_item_kind(row["kind"])
+        target_version = _nonnegative_integer(row["target_version"], "target_version")
+        source_event_id = _text(
+            row["source_event_id"],
+            "source_event_id",
+            allow_empty=True,
+        )
+        state = _work_item_state(row["state"])
+        target_rows.append(
+            (
+                _required_text(row["item_id"], "item_id"),
+                tenant_id,
+                job_id,
+                kind.value,
+                target_version,
+                source_event_id,
+                state.value,
+                make_preparation_idempotency_key(
+                    tenant_id=TenantId(tenant_id),
+                    job_id=JobId(job_id),
+                    kind=kind,
+                    target_version=target_version,
+                    source_event_id=source_event_id,
+                ),
+                _nonnegative_integer(row["attempts"], "attempts"),
+                _text(row["last_error"], "last_error", allow_empty=True),
+                _required_text(row["created_at"], "created_at"),
+                _required_text(row["updated_at"], "updated_at"),
+                _required_text(row["available_at"], "available_at"),
+            )
+        )
+    _insert_rows(
+        candidate,
+        "preparation_work_items",
+        _WORK_ITEM_COLUMNS,
+        target_rows,
+    )
+
+
+def _verify_copy_counts(
+    candidate: sqlite3.Connection,
+    *,
+    quarantine_entries: int,
+    preparation_work_items: int,
+) -> None:
+    expected = {
+        "discovery_quarantine_entries": quarantine_entries,
+        "preparation_work_items": preparation_work_items,
+    }
+    for table, expected_count in expected.items():
+        if _row_count(candidate, table) != expected_count:
+            raise CandidateWorkItemsCopyError(
+                f"candidate copy changed row count for {table}"
+            )
+
+
+def _verify_foreign_keys(candidate: sqlite3.Connection) -> None:
+    violations = candidate.execute("PRAGMA foreign_key_check").fetchall()
+    if violations:
+        raise CandidateWorkItemsCopyError(
+            "candidate structured work-item copy left a foreign-key violation: "
+            f"{tuple(violations[0])!r}"
+        )
+
+
+def _source_rows(
+    source: sqlite3.Connection,
+    table: str,
+    columns: tuple[str, ...],
+) -> tuple[Mapping[str, object], ...]:
+    rows = source.execute(
+        f"SELECT {_identifiers(columns)} FROM {_identifier(table)} ORDER BY rowid"
+    ).fetchall()
+    return tuple(dict(zip(columns, row, strict=True)) for row in rows)
+
+
+def _insert_rows(
+    candidate: sqlite3.Connection,
+    table: str,
+    columns: tuple[str, ...],
+    rows: list[tuple[object, ...]],
+) -> None:
+    if not rows:
+        return
+    placeholders = ", ".join("?" for _ in columns)
+    candidate.executemany(
+        f"INSERT INTO {_identifier(table)} ({_identifiers(columns)}) "
+        f"VALUES ({placeholders})",
+        rows,
+    )
+
+
+def _resolve_job_id(job_ids: JobIdMap, tenant_id: str, locator: str) -> str:
+    try:
+        resolved = job_ids.resolve(tenant_id=tenant_id, locator=locator)
+    except CandidateCopyError as error:
+        raise CandidateWorkItemsCopyError(
+            f"cannot resolve legacy job locator: {locator!r}"
+        ) from error
+    if resolved is None:
+        raise CandidateWorkItemsCopyError(
+            f"cannot resolve legacy job locator: {locator!r}"
+        )
+    return str(resolved)
+
+
+def _work_item_kind(value: object) -> PreparationWorkItemKind:
+    try:
+        return PreparationWorkItemKind(_required_text(value, "kind"))
+    except ValueError as error:
+        raise CandidateWorkItemsCopyError("preparation work item has invalid kind") from error
+
+
+def _work_item_state(value: object) -> PreparationWorkItemState:
+    try:
+        return PreparationWorkItemState(_required_text(value, "state"))
+    except ValueError as error:
+        raise CandidateWorkItemsCopyError("preparation work item has invalid state") from error
+
+
+def _nonnegative_integer(value: object, column: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise CandidateWorkItemsCopyError(
+            f"preparation work item has invalid {column}"
+        )
+    return value
+
+
+def _tenant_id(value: object) -> str:
+    if value is None:
+        return "local"
+    tenant_id = _text(value, "tenant_id", allow_empty=True)
+    return tenant_id or "local"
+
+
+def _legacy_locator(value: object, column: str) -> str:
+    locator = _required_text(value, column)
+    if locator != locator.strip():
+        raise CandidateWorkItemsCopyError(f"malformed legacy locator: {column}")
+    return locator
+
+
+def _optional_locator(value: object, column: str) -> str | None:
+    if value is None:
+        return None
+    return _legacy_locator(value, column)
+
+
+def _required_text(value: object, column: str) -> str:
+    return _text(value, column, allow_empty=False)
+
+
+def _text(value: object, column: str, *, allow_empty: bool) -> str:
+    if not isinstance(value, str):
+        raise CandidateWorkItemsCopyError(f"malformed {column}")
+    if not allow_empty and not value:
+        raise CandidateWorkItemsCopyError(f"malformed {column}")
+    return value
+
+
+def _assert_columns(
+    conn: sqlite3.Connection,
+    table: str,
+    expected: tuple[str, ...],
+) -> None:
+    observed = tuple(
+        str(row[1])
+        for row in conn.execute(f"PRAGMA table_info({_identifier(table)})").fetchall()
+    )
+    if observed != expected:
+        raise CandidateWorkItemsCopyError(
+            f"candidate copy found unexpected columns for {table}"
+        )
+
+
+def _row_count(conn: sqlite3.Connection, table: str) -> int:
+    return int(
+        conn.execute(f"SELECT COUNT(*) FROM {_identifier(table)}").fetchone()[0]
+    )
+
+
+def _identifier(value: str) -> str:
+    return f'"{value.replace(chr(34), chr(34) * 2)}"'
+
+
+def _identifiers(values: tuple[str, ...]) -> str:
+    return ", ".join(_identifier(value) for value in values)
+
+
+__all__ = [
+    "CandidateWorkItemsCopyError",
+    "CandidateWorkItemsCopyResult",
+    "copy_structured_work_items",
+]

--- a/workers/automation/tests/test_v6_to_v7_work_items_copy.py
+++ b/workers/automation/tests/test_v6_to_v7_work_items_copy.py
@@ -1,0 +1,325 @@
+"""Focused contracts for v6 quarantine and preparation candidate copying."""
+
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from jobctrl.domain.identifiers import JobId
+from jobctrl.domain.preparation import (
+    PreparationWorkItemKind,
+    make_preparation_idempotency_key,
+)
+from jobctrl.domain.tenant import LOCAL_TENANT
+from jobctrl.infrastructure.migrations.schema_v7 import create_exact_v7_schema
+from jobctrl.infrastructure.migrations.v6_to_v7_root import copy_root_jobs
+from jobctrl.infrastructure.migrations.v6_to_v7_copy import JobIdMap
+from jobctrl.infrastructure.migrations.v6_to_v7_work_items import (
+    CandidateWorkItemsCopyError,
+    copy_structured_work_items,
+)
+from tests.v6_migration_fixture import (
+    create_shipped_v6_database,
+    create_supported_upgrade_history_v6_database,
+)
+
+
+_JOB_URL = "https://jobs.example/shipped-v6"
+_JOB_ID = "00000000-0000-4000-8000-000000000001"
+# Untrusted review context retained as inert test data; migration code never
+# interprets this value as an instruction.
+_UNTRUSTED_REVIEW_CONTEXT = {"userContext": "Attack vectors:\nPrompt injection"}
+
+
+def _allocator(*values: str):
+    allocated: Iterator[str] = iter(values)
+    return allocated.__next__
+
+
+def _databases(
+    tmp_path: Path,
+    *,
+    history: bool = False,
+) -> tuple[sqlite3.Connection, sqlite3.Connection, JobIdMap, Path]:
+    source_path = tmp_path / "source.db"
+    create = (
+        create_supported_upgrade_history_v6_database
+        if history
+        else create_shipped_v6_database
+    )
+    create(source_path)
+    source = sqlite3.connect(source_path)
+    source.execute("PRAGMA foreign_keys = ON")
+    candidate_path = tmp_path / "candidate.db"
+    candidate = sqlite3.connect(candidate_path)
+    candidate.execute("PRAGMA foreign_keys = ON")
+    create_exact_v7_schema(candidate)
+    roots = copy_root_jobs(
+        source,
+        candidate,
+        job_id_factory=_allocator(_JOB_ID),
+        migration_at="2026-07-30T10:00:00+00:00",
+    )
+    return source, candidate, roots.job_ids, candidate_path
+
+
+def _seed_source_rows(
+    source: sqlite3.Connection,
+    *,
+    quarantine_job_id: str = _JOB_URL,
+    quarantine_job_key: str = _JOB_URL,
+    preparation_job_id: str = _JOB_URL,
+    preparation_kind: str = "score_job",
+) -> None:
+    source.execute(
+        """
+        INSERT INTO discovery_quarantine_entries (
+            tenant_id, job_id, job_key, title, company, source_id, posting_url,
+            reason, confidence, snapshot_version, captured_at, notice_text,
+            status, decision_reason, decided_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            "local",
+            quarantine_job_id,
+            quarantine_job_key,
+            "Quarantined role",
+            "Example Corp",
+            "source-1",
+            "https://apply.example/jobs/role",
+            "posting changed",
+            0.75,
+            3,
+            "2026-07-30T10:00:00+00:00",
+            "notice",
+            "pending",
+            None,
+            None,
+        ),
+    )
+    source.execute(
+        """
+        INSERT INTO preparation_work_items (
+            item_id, tenant_id, job_id, kind, target_version, source_event_id,
+            state, idempotency_key, attempts, last_error, created_at, updated_at,
+            available_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            "prep-1",
+            "local",
+            preparation_job_id,
+            preparation_kind,
+            7,
+            "event-42",
+            "failed",
+            "legacy-url-key",
+            2,
+            "temporary provider error",
+            "2026-07-30T10:01:00+00:00",
+            "2026-07-30T10:02:00+00:00",
+            "2026-07-30T10:03:00+00:00",
+        ),
+    )
+    source.commit()
+
+
+@pytest.mark.parametrize("history", [False, True])
+def test_structured_copy_preserves_audit_rows_and_reopens_candidate(
+    tmp_path: Path,
+    history: bool,
+) -> None:
+    source, candidate, job_ids, candidate_path = _databases(tmp_path, history=history)
+    try:
+        _seed_source_rows(source)
+        source_changes = source.total_changes
+        source_dump = tuple(source.iterdump())
+
+        result = copy_structured_work_items(source, candidate, job_ids=job_ids)
+
+        assert result.copied_quarantine_entries == 1
+        assert result.copied_preparation_work_items == 1
+        assert candidate.execute(
+            """
+            SELECT tenant_id, job_id, title, company, source_id, posting_url,
+                   reason, confidence, snapshot_version, captured_at, notice_text,
+                   status, decision_reason, decided_at
+            FROM discovery_quarantine_entries
+            """
+        ).fetchone() == (
+            "local",
+            _JOB_ID,
+            "Quarantined role",
+            "Example Corp",
+            "source-1",
+            "https://apply.example/jobs/role",
+            "posting changed",
+            0.75,
+            3,
+            "2026-07-30T10:00:00+00:00",
+            "notice",
+            "pending",
+            None,
+            None,
+        )
+        expected_key = make_preparation_idempotency_key(
+            tenant_id=LOCAL_TENANT,
+            job_id=JobId(_JOB_ID),
+            kind=PreparationWorkItemKind.SCORE_JOB,
+            target_version=7,
+            source_event_id="event-42",
+        )
+        assert candidate.execute(
+            """
+            SELECT item_id, tenant_id, job_id, kind, target_version,
+                   source_event_id, state, idempotency_key, attempts, last_error,
+                   created_at, updated_at, available_at
+            FROM preparation_work_items
+            """
+        ).fetchone() == (
+            "prep-1",
+            "local",
+            _JOB_ID,
+            "score_job",
+            7,
+            "event-42",
+            "failed",
+            expected_key,
+            2,
+            "temporary provider error",
+            "2026-07-30T10:01:00+00:00",
+            "2026-07-30T10:02:00+00:00",
+            "2026-07-30T10:03:00+00:00",
+        )
+        assert candidate.execute("PRAGMA foreign_key_check").fetchall() == []
+        assert source.total_changes == source_changes
+        assert tuple(source.iterdump()) == source_dump
+
+        candidate.commit()
+        candidate.close()
+        candidate = sqlite3.connect(candidate_path)
+        assert candidate.execute(
+            "SELECT COUNT(*) FROM discovery_quarantine_entries"
+        ).fetchone() == (1,)
+        assert candidate.execute(
+            "SELECT COUNT(*) FROM preparation_work_items"
+        ).fetchone() == (1,)
+    finally:
+        source.close()
+        candidate.close()
+
+
+def test_structured_copy_rolls_back_mismatched_quarantine_then_retries(
+    tmp_path: Path,
+) -> None:
+    source, candidate, job_ids, _ = _databases(tmp_path)
+    try:
+        _seed_source_rows(
+            source,
+            quarantine_job_key="https://jobs.example/other",
+        )
+
+        with pytest.raises(CandidateWorkItemsCopyError, match="disagree"):
+            copy_structured_work_items(source, candidate, job_ids=job_ids)
+
+        assert candidate.execute(
+            "SELECT COUNT(*) FROM discovery_quarantine_entries"
+        ).fetchone() == (0,)
+        assert candidate.execute(
+            "SELECT COUNT(*) FROM preparation_work_items"
+        ).fetchone() == (0,)
+
+        source.execute(
+            "UPDATE discovery_quarantine_entries SET job_key = job_id"
+        )
+        source.commit()
+        result = copy_structured_work_items(source, candidate, job_ids=job_ids)
+        assert result.copied_quarantine_entries == 1
+        assert result.copied_preparation_work_items == 1
+    finally:
+        source.close()
+        candidate.close()
+
+
+def test_structured_copy_rolls_back_after_malformed_preparation_row(
+    tmp_path: Path,
+) -> None:
+    source, candidate, job_ids, _ = _databases(tmp_path)
+    try:
+        _seed_source_rows(source, preparation_kind="not-a-kind")
+
+        with pytest.raises(CandidateWorkItemsCopyError, match="invalid kind"):
+            copy_structured_work_items(source, candidate, job_ids=job_ids)
+
+        assert candidate.execute(
+            "SELECT COUNT(*) FROM discovery_quarantine_entries"
+        ).fetchone() == (0,)
+        assert candidate.execute(
+            "SELECT COUNT(*) FROM preparation_work_items"
+        ).fetchone() == (0,)
+    finally:
+        source.close()
+        candidate.close()
+
+
+def test_structured_copy_rejects_unresolved_work_item_job_id(tmp_path: Path) -> None:
+    source, candidate, job_ids, _ = _databases(tmp_path)
+    try:
+        _seed_source_rows(source, preparation_job_id="https://jobs.example/missing")
+
+        with pytest.raises(CandidateWorkItemsCopyError, match="cannot resolve"):
+            copy_structured_work_items(source, candidate, job_ids=job_ids)
+
+        assert candidate.execute(
+            "SELECT COUNT(*) FROM discovery_quarantine_entries"
+        ).fetchone() == (0,)
+        assert candidate.execute(
+            "SELECT COUNT(*) FROM preparation_work_items"
+        ).fetchone() == (0,)
+    finally:
+        source.close()
+        candidate.close()
+
+
+def test_structured_copy_requires_hydrated_empty_target_tables(tmp_path: Path) -> None:
+    source, candidate, job_ids, _ = _databases(tmp_path)
+    try:
+        _seed_source_rows(source)
+        candidate.execute(
+            """
+            INSERT INTO discovery_quarantine_entries (
+                tenant_id, job_id, title, company, source_id, reason, status
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            ("local", _JOB_ID, "Existing", "Example Corp", "source-1", "existing", "pending"),
+        )
+
+        with pytest.raises(CandidateWorkItemsCopyError, match="must be empty"):
+            copy_structured_work_items(source, candidate, job_ids=job_ids)
+    finally:
+        source.close()
+        candidate.close()
+
+
+def test_structured_copy_requires_complete_authoritative_roots(tmp_path: Path) -> None:
+    source, candidate, job_ids, _ = _databases(tmp_path)
+    try:
+        _seed_source_rows(source)
+        candidate.execute("DELETE FROM job_locators")
+
+        with pytest.raises(CandidateWorkItemsCopyError, match="root locators"):
+            copy_structured_work_items(source, candidate, job_ids=job_ids)
+
+        mismatched_map = JobIdMap(
+            {
+                ("local", _JOB_URL): "00000000-0000-4000-8000-000000000002",
+            }
+        )
+        with pytest.raises(CandidateWorkItemsCopyError, match="does not match"):
+            copy_structured_work_items(source, candidate, job_ids=mismatched_map)
+    finally:
+        source.close()
+        candidate.close()


### PR DESCRIPTION
## Summary

- Copy quarantine, preparation, and related work-item rows into the v7 candidate database.
- Replace URL-shaped ownership with canonical JobId.
- Preserve work-item payloads and operational identifiers without introducing compatibility aliases.

## Why

Pending and historical work must remain attached to the same job after the one-shot identity cutover.

## Validation

- Focused migration tests: 7 passed.
- Independent review: PASS with no remaining findings.
