### PR TITLE
feat(storage): rebuild v7 apply-run projections

### DIFF
--- a/workers/automation/src/jobctrl/infrastructure/migrations/v6_to_v7_apply_run_projections.py
+++ b/workers/automation/src/jobctrl/infrastructure/migrations/v6_to_v7_apply_run_projections.py
@@ -1,0 +1,556 @@
+"""Rebuild v7 apply-run projections from copied canonical job events."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from collections import defaultdict
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from jobctrl.infrastructure.migrations.schema_manifest import (
+    EXACT_V7_MANIFEST,
+    assert_exact_manifest,
+)
+from jobctrl.infrastructure.migrations.identity_upcast import EVENT_IDENTITY_VERSION
+from jobctrl.infrastructure.migrations.v6_to_v7_copy import (
+    CandidateCopyError,
+    JobIdMap,
+    build_job_id_map,
+)
+from jobctrl.infrastructure.migrations.v6_to_v7_preflight import (
+    assert_v6_migration_preflight,
+)
+
+_PROJECTION_COLUMNS = (
+    "run_id",
+    "tenant_id",
+    "job_id",
+    "job_title",
+    "job_employer",
+    "status",
+    "result",
+    "dry_run",
+    "worker_id",
+    "model",
+    "started_at",
+    "finished_at",
+    "duration_ms",
+    "events_json",
+)
+_EVENT_COLUMNS = (
+    "event_id",
+    "tenant_id",
+    "job_id",
+    "identity_version",
+    "stage",
+    "event_type",
+    "level",
+    "message",
+    "occurred_at",
+    "payload_json",
+    "entity_kind",
+    "entity_ref",
+    "idempotency_key",
+)
+
+_TERMINAL_EVENT_STATUS: Mapping[str, tuple[str, str | None]] = {
+    "ApplicationSubmitted": ("succeeded", "applied"),
+    "DryRunCompleted": ("dry_run_complete", "dry_run_complete"),
+    "ApplyManualSkip": ("manual", "manual"),
+    # ``LockReleased`` remains a fallback only. A preceding terminal verdict
+    # is more specific and must not be overwritten by lock cleanup.
+    "LockReleased": ("failed", "failed"),
+}
+_STATUS_FROM_RESULT: Mapping[str, str] = {
+    "applied": "succeeded",
+    "failed": "failed",
+    "captcha": "captcha",
+    "login_issue": "login_issue",
+    "expired": "expired",
+    "manual": "manual",
+    "email_only": "manual",
+    "dry_run_complete": "dry_run_complete",
+}
+
+
+class CandidateApplyRunProjectionsError(RuntimeError):
+    """Raised when v7 apply-run projections cannot be rebuilt safely."""
+
+
+@dataclass(frozen=True)
+class CandidateApplyRunProjectionsResult:
+    """Verified candidate apply-run projection rebuild result."""
+
+    rebuilt_apply_runs: int
+
+
+@dataclass(frozen=True)
+class _ApplyEvent:
+    event_id: int
+    tenant_id: str
+    job_id: str
+    event_type: str
+    level: str
+    message: str | None
+    occurred_at: str | None
+    payload: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class _JobMetadata:
+    title: str
+    employer: str
+
+
+def rebuild_apply_run_projections(
+    source: sqlite3.Connection,
+    candidate: sqlite3.Connection,
+    *,
+    job_ids: JobIdMap,
+) -> CandidateApplyRunProjectionsResult:
+    """Rebuild apply-run read rows from the copied v7 event history.
+
+    v6 ``apply_run_projections`` is a URL-keyed materialized cache. It is
+    deliberately not a source for this candidate transform: each v7 row is
+    folded from the already-upcast ``job_events`` history instead.
+    """
+    assert_v6_migration_preflight(source)
+    assert_exact_manifest(candidate, EXACT_V7_MANIFEST)
+    _assert_authoritative_roots(source, candidate, job_ids)
+    _assert_columns(source, "apply_run_projections", _PROJECTION_COLUMNS)
+    _assert_columns(candidate, "apply_run_projections", _PROJECTION_COLUMNS)
+    _assert_columns(candidate, "job_events", _EVENT_COLUMNS)
+    _assert_empty_target(candidate)
+
+    source_rows = _rows(source, "apply_run_projections", _PROJECTION_COLUMNS)
+    jobs = _candidate_job_metadata(candidate)
+    events_by_run = _candidate_events_by_run(candidate, jobs)
+    projections = tuple(
+        _project_run(run_id, events, jobs)
+        for run_id, events in sorted(events_by_run.items())
+    )
+
+    candidate.execute("SAVEPOINT v6_apply_run_projection_rebuild")
+    try:
+        _insert_projections(candidate, projections)
+        _verify_candidate(
+            source=source,
+            candidate=candidate,
+            expected_source_rows=source_rows,
+            expected_projections=projections,
+        )
+        candidate.execute("RELEASE SAVEPOINT v6_apply_run_projection_rebuild")
+    except BaseException:
+        candidate.execute("ROLLBACK TO SAVEPOINT v6_apply_run_projection_rebuild")
+        candidate.execute("RELEASE SAVEPOINT v6_apply_run_projection_rebuild")
+        raise
+
+    return CandidateApplyRunProjectionsResult(
+        rebuilt_apply_runs=len(projections),
+    )
+
+
+def _assert_authoritative_roots(
+    source: sqlite3.Connection,
+    candidate: sqlite3.Connection,
+    job_ids: JobIdMap,
+) -> None:
+    try:
+        candidate_job_ids = build_job_id_map(source, candidate)
+    except CandidateCopyError as error:
+        raise CandidateApplyRunProjectionsError(
+            "apply-run projection rebuild requires hydrated candidate roots"
+        ) from error
+    if dict(candidate_job_ids.by_locator) != dict(job_ids.by_locator):
+        raise CandidateApplyRunProjectionsError(
+            "supplied JobIdMap does not match hydrated candidate roots"
+        )
+    current_locators = {
+        (str(tenant_id), str(locator)): str(job_id)
+        for tenant_id, locator, job_id in candidate.execute(
+            """
+            SELECT tenant_id, locator_value, job_id
+            FROM job_locators
+            WHERE locator_kind = 'posting_url'
+              AND is_current = 1
+              AND retired_at IS NULL
+            """
+        ).fetchall()
+    }
+    if (
+        current_locators != dict(job_ids.by_locator)
+        or _row_count(candidate, "job_locators") != len(current_locators)
+    ):
+        raise CandidateApplyRunProjectionsError(
+            "apply-run projection rebuild requires hydrated candidate root locators"
+        )
+
+
+def _assert_empty_target(candidate: sqlite3.Connection) -> None:
+    if _row_count(candidate, "apply_run_projections"):
+        raise CandidateApplyRunProjectionsError(
+            "candidate apply_run_projections must be empty"
+        )
+
+
+def _candidate_job_metadata(
+    candidate: sqlite3.Connection,
+) -> dict[tuple[str, str], _JobMetadata]:
+    jobs: dict[tuple[str, str], _JobMetadata] = {}
+    for tenant_id, job_id, title, company in candidate.execute(
+        "SELECT tenant_id, job_id, title, company FROM jobs"
+    ).fetchall():
+        tenant = _required_text(tenant_id, "candidate job tenant_id")
+        stable_job_id = _required_text(job_id, "candidate job job_id")
+        key = (tenant, stable_job_id)
+        if key in jobs:
+            raise CandidateApplyRunProjectionsError(
+                "candidate jobs contains duplicate stable identity"
+            )
+        jobs[key] = _JobMetadata(
+            title=_text_or_default(title, "Untitled"),
+            employer=_text_or_default(company, "Unknown company"),
+        )
+    return jobs
+
+
+def _candidate_events_by_run(
+    candidate: sqlite3.Connection,
+    jobs: Mapping[tuple[str, str], _JobMetadata],
+) -> dict[str, list[_ApplyEvent]]:
+    events_by_run: dict[str, list[_ApplyEvent]] = defaultdict(list)
+    run_identities: dict[str, tuple[str, str]] = {}
+    rows = candidate.execute(
+        """
+        SELECT event_id, tenant_id, job_id, event_type, level, message,
+               occurred_at, payload_json, identity_version
+        FROM job_events
+        WHERE stage = 'apply'
+        ORDER BY event_id ASC
+        """
+    ).fetchall()
+    for row in rows:
+        event = _parse_apply_event(row, jobs)
+        if event is None:
+            continue
+        run_id = _run_id_for_projection(event.payload)
+        if run_id is None:
+            continue
+        identity = (event.tenant_id, event.job_id)
+        previous = run_identities.setdefault(run_id, identity)
+        if previous != identity:
+            raise CandidateApplyRunProjectionsError(
+                "apply run contains conflicting candidate job identities"
+            )
+        events_by_run[run_id].append(event)
+    return dict(events_by_run)
+
+
+def _parse_apply_event(
+    row: tuple[object, ...],
+    jobs: Mapping[tuple[str, str], _JobMetadata],
+) -> _ApplyEvent | None:
+    (
+        event_id,
+        tenant_id,
+        job_id,
+        event_type,
+        level,
+        message,
+        occurred_at,
+        payload_json,
+        identity_version,
+    ) = row
+    if identity_version != EVENT_IDENTITY_VERSION:
+        raise CandidateApplyRunProjectionsError(
+            "candidate apply event does not have the v7 event identity version"
+        )
+    parsed_event_id = _required_event_id(event_id)
+    tenant = _required_text(tenant_id, "candidate apply event tenant_id")
+    stable_job_id = _required_text(job_id, "candidate apply event job_id")
+    if (tenant, stable_job_id) not in jobs:
+        raise CandidateApplyRunProjectionsError(
+            "candidate apply event does not reference a hydrated job root"
+        )
+    parsed_event_type = _required_text(event_type, "candidate apply event event_type")
+    parsed_level = _text_or_default(level, "info")
+    parsed_message = _optional_text(message)
+    parsed_occurred_at = _optional_text(occurred_at)
+    if payload_json is None:
+        return None
+    try:
+        payload = json.loads(str(payload_json))
+    except json.JSONDecodeError as error:
+        # The event upcast rejects this before a candidate exists. Keep this
+        # guard for an externally corrupted candidate rather than guessing.
+        raise CandidateApplyRunProjectionsError(
+            "candidate apply event payload_json is invalid"
+        ) from error
+    if not isinstance(payload, dict):
+        return None
+    if _run_id_for_projection(payload) is None:
+        return None
+    return _ApplyEvent(
+        event_id=parsed_event_id,
+        tenant_id=tenant,
+        job_id=stable_job_id,
+        event_type=parsed_event_type,
+        level=parsed_level,
+        message=parsed_message,
+        occurred_at=parsed_occurred_at,
+        payload=payload,
+    )
+
+
+def _project_run(
+    run_id: str,
+    events: list[_ApplyEvent],
+    jobs: Mapping[tuple[str, str], _JobMetadata],
+) -> tuple[object, ...]:
+    if not events:
+        raise CandidateApplyRunProjectionsError("apply run has no events")
+    first_event = events[0]
+    metadata = jobs[(first_event.tenant_id, first_event.job_id)]
+    status = "starting"
+    result: str | None = None
+    started_at: str | None = None
+    finished_at: str | None = None
+    duration_ms: int | None = None
+    worker_id: int | None = None
+    model: str | None = None
+    dry_run = False
+
+    timeline: list[dict[str, Any]] = []
+    for event in events:
+        payload = event.payload
+        if event.event_type == "ApplyRunStarted":
+            payload_started_at = _payload_text(payload, "started_at")
+            started_at = (
+                payload_started_at
+                if payload_started_at is not None
+                else event.occurred_at
+            )
+            if isinstance(payload.get("model"), str) and payload["model"]:
+                model = payload["model"]
+            worker_id = _payload_worker_id(payload.get("worker_id"), worker_id)
+            if "dry_run" in payload:
+                dry_run = bool(payload["dry_run"])
+            status = "starting"
+        elif event.event_type == "ApplyRunInProgress":
+            if status == "starting":
+                status = "in_progress"
+        elif event.event_type in _TERMINAL_EVENT_STATUS:
+            if event.event_type == "LockReleased" and result is not None:
+                timeline.append(_timeline_entry(event))
+                continue
+            status, default_result = _TERMINAL_EVENT_STATUS[event.event_type]
+            payload_result = _payload_string(payload, "result")
+            result = payload_result if payload_result is not None else default_result
+            payload_finished_at = _payload_text(payload, "finished_at")
+            finished_at = (
+                payload_finished_at
+                if payload_finished_at is not None
+                else event.occurred_at
+            )
+            duration_ms = _payload_duration(payload, duration_ms)
+            if event.event_type == "DryRunCompleted":
+                dry_run = True
+        elif event.event_type == "ApplicationFailed":
+            result_kind = _failed_result_kind(payload)
+            status = _STATUS_FROM_RESULT.get(str(result_kind), "failed") if result_kind else "failed"
+            result = str(result_kind) if result_kind else "failed"
+            payload_finished_at = _payload_text(payload, "finished_at")
+            finished_at = (
+                payload_finished_at
+                if payload_finished_at is not None
+                else event.occurred_at
+            )
+            duration_ms = _payload_duration(payload, duration_ms)
+        timeline.append(_timeline_entry(event))
+
+    return (
+        run_id,
+        first_event.tenant_id,
+        first_event.job_id,
+        metadata.title,
+        metadata.employer,
+        status,
+        result,
+        1 if dry_run else 0,
+        worker_id,
+        model,
+        started_at,
+        finished_at,
+        duration_ms,
+        json.dumps(timeline),
+    )
+
+
+def _timeline_entry(event: _ApplyEvent) -> dict[str, Any]:
+    entry: dict[str, Any] = {
+        "event_type": event.event_type,
+        "level": event.level,
+        "occurred_at": event.occurred_at,
+    }
+    if event.message:
+        entry["message"] = event.message
+    if event.payload:
+        entry["payload"] = event.payload
+    return entry
+
+
+def _insert_projections(
+    candidate: sqlite3.Connection,
+    projections: tuple[tuple[object, ...], ...],
+) -> None:
+    if not projections:
+        return
+    placeholders = ", ".join("?" for _ in _PROJECTION_COLUMNS)
+    candidate.executemany(
+        f"INSERT INTO apply_run_projections ({_identifiers(_PROJECTION_COLUMNS)}) "
+        f"VALUES ({placeholders})",
+        projections,
+    )
+
+
+def _verify_candidate(
+    *,
+    source: sqlite3.Connection,
+    candidate: sqlite3.Connection,
+    expected_source_rows: tuple[tuple[object, ...], ...],
+    expected_projections: tuple[tuple[object, ...], ...],
+) -> None:
+    candidate_rows = _rows(candidate, "apply_run_projections", _PROJECTION_COLUMNS)
+    if candidate_rows != expected_projections:
+        raise CandidateApplyRunProjectionsError(
+            "candidate apply-run projection rebuild changed projection rows"
+        )
+    if _row_count(candidate, "apply_run_projections") != len(expected_projections):
+        raise CandidateApplyRunProjectionsError(
+            "candidate apply-run projection rebuild changed run count"
+        )
+    if candidate.execute("PRAGMA foreign_key_check").fetchall():
+        raise CandidateApplyRunProjectionsError(
+            "candidate apply-run projection rebuild left a foreign-key violation"
+        )
+    assert_exact_manifest(candidate, EXACT_V7_MANIFEST)
+    if _rows(source, "apply_run_projections", _PROJECTION_COLUMNS) != expected_source_rows:
+        raise CandidateApplyRunProjectionsError(
+            "candidate apply-run projection rebuild mutated the v6 source"
+        )
+
+
+def _run_id_for_projection(payload: Mapping[str, Any]) -> str | None:
+    """Return an apply-run identity, preserving job-level audit events.
+
+    The event stream also records apply-stage audit facts such as manual user
+    marks. They have no ``run_id`` key and remain canonical event history, but
+    are not members of an apply-run projection. Once a payload claims a run
+    identity, it must have the exact supported shape.
+    """
+    if "run_id" not in payload:
+        return None
+    return _required_text(payload["run_id"], "candidate apply event run_id")
+
+
+def _payload_text(payload: Mapping[str, Any], key: str) -> str | None:
+    value = payload.get(key)
+    return str(value) if value is not None else None
+
+
+def _payload_string(payload: Mapping[str, Any], key: str) -> str | None:
+    value = payload.get(key)
+    return value if isinstance(value, str) else None
+
+
+def _payload_worker_id(value: object, current: int | None) -> int | None:
+    if isinstance(value, (int, float)):
+        return int(value)
+    if isinstance(value, str) and value.isdigit():
+        return int(value)
+    return current
+
+
+def _payload_duration(payload: Mapping[str, Any], current: int | None) -> int | None:
+    if "duration_ms" not in payload:
+        return current
+    try:
+        return int(payload["duration_ms"])
+    except (TypeError, ValueError):
+        return current
+
+
+def _failed_result_kind(payload: Mapping[str, Any]) -> object | None:
+    result = payload.get("result")
+    if isinstance(result, dict):
+        return result.get("kind")
+    return result if isinstance(result, str) else None
+
+
+def _rows(
+    conn: sqlite3.Connection,
+    table: str,
+    columns: tuple[str, ...],
+) -> tuple[tuple[object, ...], ...]:
+    return tuple(
+        tuple(row)
+        for row in conn.execute(
+            f"SELECT {_identifiers(columns)} FROM {_identifier(table)} ORDER BY rowid"
+        ).fetchall()
+    )
+
+
+def _assert_columns(
+    conn: sqlite3.Connection,
+    table: str,
+    expected: tuple[str, ...],
+) -> None:
+    columns = tuple(
+        str(row[1])
+        for row in conn.execute(f"PRAGMA table_info({_identifier(table)})").fetchall()
+    )
+    if columns != expected:
+        raise CandidateApplyRunProjectionsError(
+            f"{table} columns do not match the admitted schema"
+        )
+
+
+def _required_text(value: object, label: str) -> str:
+    if not isinstance(value, str) or not value or value != value.strip():
+        raise CandidateApplyRunProjectionsError(f"malformed {label}")
+    return value
+
+
+def _optional_text(value: object) -> str | None:
+    return value if isinstance(value, str) and value else None
+
+
+def _text_or_default(value: object, default: str) -> str:
+    return value if isinstance(value, str) and value else default
+
+
+def _required_event_id(value: object) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise CandidateApplyRunProjectionsError("malformed candidate apply event event_id")
+    return value
+
+
+def _row_count(conn: sqlite3.Connection, table: str) -> int:
+    return int(conn.execute(f"SELECT COUNT(*) FROM {_identifier(table)}").fetchone()[0])
+
+
+def _identifier(value: str) -> str:
+    return f'"{value.replace(chr(34), chr(34) * 2)}"'
+
+
+def _identifiers(values: tuple[str, ...]) -> str:
+    return ", ".join(_identifier(value) for value in values)
+
+
+__all__ = [
+    "CandidateApplyRunProjectionsError",
+    "CandidateApplyRunProjectionsResult",
+    "rebuild_apply_run_projections",
+]

--- a/workers/automation/tests/test_v6_to_v7_apply_run_projections.py
+++ b/workers/automation/tests/test_v6_to_v7_apply_run_projections.py
@@ -1,0 +1,683 @@
+"""Focused contracts for rebuilding v7 apply-run projections from events."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from jobctrl.infrastructure.migrations import v6_to_v7_apply_run_projections as apply_runs
+from jobctrl.infrastructure.migrations.schema_manifest import schema_dump
+from jobctrl.infrastructure.migrations.schema_v7 import create_exact_v7_schema
+from jobctrl.infrastructure.migrations.v6_to_v7_apply_run_projections import (
+    CandidateApplyRunProjectionsError,
+    rebuild_apply_run_projections,
+)
+from jobctrl.infrastructure.migrations.v6_to_v7_events import (
+    CandidateEventCopyError,
+    copy_job_events,
+)
+from jobctrl.infrastructure.migrations.v6_to_v7_root import copy_root_jobs
+from tests.v6_migration_fixture import create_shipped_v6_database
+
+_JOB_URL = "https://jobs.example/shipped-v6"
+_JOB_ID = "00000000-0000-4000-8000-000000000001"
+_SECOND_JOB_URL = "https://jobs.example/second"
+_SECOND_JOB_ID = "00000000-0000-4000-8000-000000000002"
+# Untrusted context is fixture data only. The candidate projector preserves it
+# inside the event payload and never interprets it as an instruction.
+_UNTRUSTED_CONTEXT = {"userContext": "Attack vectors:\nPrompt injection"}
+
+
+def _allocator(*values: str):
+    allocated: Iterator[str] = iter(values)
+    return allocated.__next__
+
+
+def _connections(tmp_path: Path) -> tuple[sqlite3.Connection, sqlite3.Connection, Path]:
+    source_path = tmp_path / "source.db"
+    create_shipped_v6_database(source_path)
+    source = sqlite3.connect(source_path)
+    source.execute("PRAGMA foreign_keys = ON")
+    candidate_path = tmp_path / "candidate.db"
+    candidate = sqlite3.connect(candidate_path)
+    candidate.execute("PRAGMA foreign_keys = ON")
+    create_exact_v7_schema(candidate)
+    return source, candidate, candidate_path
+
+
+def _copy_roots_and_events(
+    source: sqlite3.Connection,
+    candidate: sqlite3.Connection,
+    *job_ids: str,
+):
+    roots = copy_root_jobs(
+        source,
+        candidate,
+        job_id_factory=_allocator(*job_ids),
+        migration_at="2026-07-30T10:00:00+00:00",
+    )
+    copy_job_events(source, candidate, job_ids=roots.job_ids)
+    return roots.job_ids
+
+
+def _insert_source_event(
+    source: sqlite3.Connection,
+    *,
+    event_id: int,
+    job_url: str = _JOB_URL,
+    event_type: str,
+    payload: object | None,
+    occurred_at: str,
+    message: str | None = None,
+) -> None:
+    source.execute(
+        """
+        INSERT INTO job_events (
+            event_id, job_url, stage, event_type, level, message, occurred_at,
+            payload_json, entity_kind, entity_ref, idempotency_key
+        ) VALUES (?, ?, 'apply', ?, 'info', ?, ?, ?, 'job', ?, ?)
+        """,
+        (
+            event_id,
+            job_url,
+            event_type,
+            message,
+            occurred_at,
+            json.dumps(payload, separators=(",", ":")) if payload is not None else None,
+            job_url,
+            f"apply-event-{event_id}",
+        ),
+    )
+
+
+def _insert_stale_source_projection(source: sqlite3.Connection) -> None:
+    source.execute(
+        """
+        INSERT INTO apply_run_projections (
+            run_id, tenant_id, job_id, job_title, job_employer, status, result,
+            dry_run, worker_id, model, started_at, finished_at, duration_ms,
+            events_json
+        ) VALUES (?, 'local', ?, 'Stale', 'Stale Corp', 'failed', 'failed', 0,
+                  1, 'stale-model', ?, ?, 1, ?)
+        """,
+        (
+            "run-1",
+            _JOB_URL,
+            "2026-07-30T09:00:00+00:00",
+            "2026-07-30T09:00:01+00:00",
+            json.dumps(
+                [
+                    {
+                        "event_type": "ApplicationFailed",
+                        "payload": {"job_id": _JOB_URL, "stale": True},
+                    }
+                ]
+            ),
+        ),
+    )
+
+
+def test_rebuild_uses_candidate_events_not_the_v6_projection_and_preserves_payload(
+    tmp_path: Path,
+) -> None:
+    source, candidate, _ = _connections(tmp_path)
+    try:
+        source.execute("UPDATE jobs SET company = ?, site = ? WHERE url = ?", ("Example Corp", "greenhouse", _JOB_URL))
+        _insert_stale_source_projection(source)
+        _insert_source_event(
+            source,
+            event_id=7,
+            event_type="ApplyRunStarted",
+            occurred_at="2026-07-30T10:00:00+00:00",
+            message="starting",
+            payload={
+                "run_id": "run-1",
+                "job_id": _JOB_URL,
+                "started_at": "2026-07-30T09:59:59+00:00",
+                "worker_id": "12",
+                "model": "test-model",
+                "dry_run": False,
+                "context": _UNTRUSTED_CONTEXT,
+            },
+        )
+        _insert_source_event(
+            source,
+            event_id=8,
+            event_type="ApplyRunInProgress",
+            occurred_at="2026-07-30T10:01:00+00:00",
+            payload={"run_id": "run-1", "job_id": _JOB_URL},
+        )
+        _insert_source_event(
+            source,
+            event_id=9,
+            event_type="ApplicationSubmitted",
+            occurred_at="2026-07-30T10:02:00+00:00",
+            message="submitted",
+            payload={
+                "run_id": "run-1",
+                "job_id": _JOB_URL,
+                "result": "applied",
+                "finished_at": "2026-07-30T10:01:58+00:00",
+                "duration_ms": "119000",
+                "context": _UNTRUSTED_CONTEXT,
+            },
+        )
+        _insert_source_event(
+            source,
+            event_id=10,
+            event_type="LockReleased",
+            occurred_at="2026-07-30T10:03:00+00:00",
+            payload={"run_id": "run-1", "job_id": _JOB_URL},
+        )
+        source.commit()
+        source_bytes = Path(str(source.execute("PRAGMA database_list").fetchone()[2])).read_bytes()
+        source_rows = tuple(source.execute("SELECT * FROM apply_run_projections").fetchall())
+        source_changes = source.total_changes
+        job_ids = _copy_roots_and_events(source, candidate, _JOB_ID)
+
+        result = rebuild_apply_run_projections(source, candidate, job_ids=job_ids)
+
+        assert result.rebuilt_apply_runs == 1
+        row = candidate.execute(
+            """
+            SELECT run_id, tenant_id, job_id, job_title, job_employer, status,
+                   result, dry_run, worker_id, model, started_at, finished_at,
+                   duration_ms, events_json
+            FROM apply_run_projections
+            """
+        ).fetchone()
+        assert row is not None
+        assert row[:13] == (
+            "run-1",
+            "local",
+            _JOB_ID,
+            "Shipped V6 fixture",
+            "Example Corp",
+            "succeeded",
+            "applied",
+            0,
+            12,
+            "test-model",
+            "2026-07-30T09:59:59+00:00",
+            "2026-07-30T10:01:58+00:00",
+            119000,
+        )
+        timeline = json.loads(str(row[13]))
+        assert [entry["event_type"] for entry in timeline] == [
+            "ApplyRunStarted",
+            "ApplyRunInProgress",
+            "ApplicationSubmitted",
+            "LockReleased",
+        ]
+        assert timeline[0]["payload"] == {
+            "context": _UNTRUSTED_CONTEXT,
+            "dry_run": False,
+            "job_id": _JOB_ID,
+            "model": "test-model",
+            "run_id": "run-1",
+            "started_at": "2026-07-30T09:59:59+00:00",
+            "worker_id": "12",
+        }
+        assert timeline[2]["payload"]["job_id"] == _JOB_ID
+        assert _UNTRUSTED_CONTEXT == {
+            "userContext": "Attack vectors:\nPrompt injection"
+        }
+        assert tuple(source.execute("SELECT * FROM apply_run_projections").fetchall()) == source_rows
+        assert source.total_changes == source_changes
+        assert Path(str(source.execute("PRAGMA database_list").fetchone()[2])).read_bytes() == source_bytes
+        assert candidate.execute("PRAGMA foreign_key_check").fetchall() == []
+    finally:
+        source.close()
+        candidate.close()
+
+
+@pytest.mark.parametrize(
+    "payload",
+    (
+        {"run_id": None, "job_id": _JOB_URL},
+        {"run_id": "", "job_id": _JOB_URL},
+        {"run_id": " run-1 ", "job_id": _JOB_URL},
+        {"run_id": 7, "job_id": _JOB_URL},
+    ),
+)
+def test_rebuild_rejects_malformed_apply_run_identity_without_writes(
+    tmp_path: Path,
+    payload: dict[str, object],
+) -> None:
+    source, candidate, _ = _connections(tmp_path)
+    try:
+        _insert_source_event(
+            source,
+            event_id=7,
+            event_type="ApplyRunStarted",
+            occurred_at="2026-07-30T10:00:00+00:00",
+            payload=payload,
+        )
+        source.commit()
+        source_bytes = Path(str(source.execute("PRAGMA database_list").fetchone()[2])).read_bytes()
+        source_changes = source.total_changes
+        job_ids = _copy_roots_and_events(source, candidate, _JOB_ID)
+
+        with pytest.raises(CandidateApplyRunProjectionsError, match="run_id"):
+            rebuild_apply_run_projections(source, candidate, job_ids=job_ids)
+
+        assert candidate.execute("SELECT COUNT(*) FROM apply_run_projections").fetchone() == (0,)
+        assert source.total_changes == source_changes
+        assert Path(str(source.execute("PRAGMA database_list").fetchone()[2])).read_bytes() == source_bytes
+    finally:
+        source.close()
+        candidate.close()
+
+
+def test_rebuild_preserves_no_run_apply_audit_event_without_a_projection(
+    tmp_path: Path,
+) -> None:
+    source, candidate, _ = _connections(tmp_path)
+    try:
+        payload = {
+            "reason": "User confirmed submission outside the browser flow.",
+            "marked_at": "2026-07-30T10:00:00+00:00",
+            "source": "user_attestation",
+            "context": _UNTRUSTED_CONTEXT,
+        }
+        _insert_source_event(
+            source,
+            event_id=7,
+            event_type="ApplicationManuallyMarked",
+            occurred_at="2026-07-30T10:00:00+00:00",
+            payload=payload,
+        )
+        source.commit()
+        source_bytes = Path(str(source.execute("PRAGMA database_list").fetchone()[2])).read_bytes()
+        job_ids = _copy_roots_and_events(source, candidate, _JOB_ID)
+
+        result = rebuild_apply_run_projections(source, candidate, job_ids=job_ids)
+
+        assert result.rebuilt_apply_runs == 0
+        assert candidate.execute("SELECT COUNT(*) FROM apply_run_projections").fetchone() == (0,)
+        event = candidate.execute(
+            "SELECT job_id, event_type, payload_json FROM job_events"
+        ).fetchone()
+        assert event is not None
+        assert event[:2] == (_JOB_ID, "ApplicationManuallyMarked")
+        assert json.loads(str(event[2])) == payload
+        assert Path(str(source.execute("PRAGMA database_list").fetchone()[2])).read_bytes() == source_bytes
+        assert _UNTRUSTED_CONTEXT == {
+            "userContext": "Attack vectors:\nPrompt injection"
+        }
+    finally:
+        source.close()
+        candidate.close()
+
+
+@pytest.mark.parametrize("payload", (None, [_UNTRUSTED_CONTEXT]))
+def test_rebuild_skips_null_and_non_object_apply_event_payloads(
+    tmp_path: Path,
+    payload: object | None,
+) -> None:
+    source, candidate, _ = _connections(tmp_path)
+    try:
+        _insert_source_event(
+            source,
+            event_id=7,
+            event_type="ApplicationManuallyMarked",
+            occurred_at="2026-07-30T10:00:00+00:00",
+            payload=payload,
+        )
+        source.commit()
+        job_ids = _copy_roots_and_events(source, candidate, _JOB_ID)
+
+        result = rebuild_apply_run_projections(source, candidate, job_ids=job_ids)
+
+        assert result.rebuilt_apply_runs == 0
+        assert candidate.execute("SELECT COUNT(*) FROM apply_run_projections").fetchone() == (0,)
+        payload_json = candidate.execute("SELECT payload_json FROM job_events").fetchone()
+        assert payload_json is not None
+        if payload is None:
+            assert payload_json == (None,)
+        else:
+            assert json.loads(str(payload_json[0])) == payload
+    finally:
+        source.close()
+        candidate.close()
+
+
+def test_event_copy_rejects_invalid_apply_payload_before_projection_rebuild(
+    tmp_path: Path,
+) -> None:
+    source, candidate, _ = _connections(tmp_path)
+    try:
+        _insert_source_event(
+            source,
+            event_id=7,
+            event_type="ApplyRunStarted",
+            occurred_at="2026-07-30T10:00:00+00:00",
+            payload={
+                "run_id": "run-1",
+                "job_id": _JOB_URL,
+                "context": _UNTRUSTED_CONTEXT,
+            },
+        )
+        source.execute("UPDATE job_events SET payload_json = '{' WHERE event_id = 7")
+        source.commit()
+        roots = copy_root_jobs(
+            source,
+            candidate,
+            job_id_factory=_allocator(_JOB_ID),
+            migration_at="2026-07-30T10:00:00+00:00",
+        )
+
+        with pytest.raises(CandidateEventCopyError, match="event_payload_invalid"):
+            copy_job_events(source, candidate, job_ids=roots.job_ids)
+
+        assert candidate.execute("SELECT COUNT(*) FROM job_events").fetchone() == (0,)
+        assert candidate.execute("SELECT COUNT(*) FROM apply_run_projections").fetchone() == (0,)
+    finally:
+        source.close()
+        candidate.close()
+
+
+def test_rebuild_validates_no_run_event_root_before_skipping_it(
+    tmp_path: Path,
+) -> None:
+    source, candidate, _ = _connections(tmp_path)
+    try:
+        _insert_source_event(
+            source,
+            event_id=7,
+            event_type="ApplicationManuallyMarked",
+            occurred_at="2026-07-30T10:00:00+00:00",
+            payload=None,
+        )
+        source.commit()
+        job_ids = _copy_roots_and_events(source, candidate, _JOB_ID)
+        candidate.commit()
+        candidate.execute("PRAGMA foreign_keys = OFF")
+        candidate.execute(
+            "UPDATE job_events SET job_id = ? WHERE event_id = 7",
+            ("00000000-0000-4000-8000-000000000099",),
+        )
+        candidate.commit()
+        candidate.execute("PRAGMA foreign_keys = ON")
+
+        with pytest.raises(CandidateApplyRunProjectionsError, match="hydrated job root"):
+            rebuild_apply_run_projections(source, candidate, job_ids=job_ids)
+
+        assert candidate.execute("SELECT COUNT(*) FROM apply_run_projections").fetchone() == (0,)
+    finally:
+        source.close()
+        candidate.close()
+
+
+@pytest.mark.parametrize(
+    ("event_type", "terminal_payload", "expected_status", "expected_result", "expected_dry_run"),
+    (
+        ("ApplicationFailed", {"result": {"kind": "captcha"}}, "captcha", "captcha", 0),
+        (
+            "ApplicationFailed",
+            {"result": {"kind": "login_issue"}},
+            "login_issue",
+            "login_issue",
+            0,
+        ),
+        ("ApplicationFailed", {"result": {"kind": "expired"}}, "expired", "expired", 0),
+        ("ApplicationFailed", {"result": {"kind": "manual"}}, "manual", "manual", 0),
+        (
+            "ApplicationFailed",
+            {"result": {"kind": "dry_run_complete"}},
+            "dry_run_complete",
+            "dry_run_complete",
+            0,
+        ),
+        (
+            "ApplicationFailed",
+            {"result": {"kind": "email_only"}},
+            "manual",
+            "email_only",
+            0,
+        ),
+        ("DryRunCompleted", {}, "dry_run_complete", "dry_run_complete", 1),
+        ("ApplyManualSkip", {}, "manual", "manual", 0),
+        ("LockReleased", {}, "failed", "failed", 0),
+    ),
+)
+def test_rebuild_matches_terminal_lifecycle_folds(
+    tmp_path: Path,
+    event_type: str,
+    terminal_payload: dict[str, object],
+    expected_status: str,
+    expected_result: str,
+    expected_dry_run: int,
+) -> None:
+    source, candidate, _ = _connections(tmp_path)
+    try:
+        _insert_source_event(
+            source,
+            event_id=7,
+            event_type="ApplyRunStarted",
+            occurred_at="2026-07-30T10:00:00+00:00",
+            payload={
+                "run_id": "run-1",
+                "job_id": _JOB_URL,
+                "context": _UNTRUSTED_CONTEXT,
+            },
+        )
+        _insert_source_event(
+            source,
+            event_id=8,
+            event_type=event_type,
+            occurred_at="2026-07-30T10:01:00+00:00",
+            payload={
+                "run_id": "run-1",
+                "job_id": _JOB_URL,
+                "context": _UNTRUSTED_CONTEXT,
+                **terminal_payload,
+            },
+        )
+        source.commit()
+        job_ids = _copy_roots_and_events(source, candidate, _JOB_ID)
+
+        rebuild_apply_run_projections(source, candidate, job_ids=job_ids)
+
+        projection = candidate.execute(
+            "SELECT status, result, dry_run, events_json FROM apply_run_projections"
+        ).fetchone()
+        assert projection is not None
+        assert projection[:3] == (expected_status, expected_result, expected_dry_run)
+        assert json.loads(str(projection[3]))[-1]["payload"]["context"] == _UNTRUSTED_CONTEXT
+    finally:
+        source.close()
+        candidate.close()
+
+
+def test_rebuild_never_uses_source_board_as_an_employer_fallback(
+    tmp_path: Path,
+) -> None:
+    source, candidate, _ = _connections(tmp_path)
+    try:
+        source.execute(
+            "UPDATE jobs SET company = NULL, site = ? WHERE url = ?",
+            ("greenhouse", _JOB_URL),
+        )
+        _insert_source_event(
+            source,
+            event_id=7,
+            event_type="ApplyRunStarted",
+            occurred_at="2026-07-30T10:00:00+00:00",
+            payload={
+                "run_id": "run-1",
+                "job_id": _JOB_URL,
+                "context": _UNTRUSTED_CONTEXT,
+            },
+        )
+        source.commit()
+        job_ids = _copy_roots_and_events(source, candidate, _JOB_ID)
+
+        rebuild_apply_run_projections(source, candidate, job_ids=job_ids)
+
+        assert candidate.execute(
+            "SELECT job_employer FROM apply_run_projections"
+        ).fetchone() == ("Unknown company",)
+    finally:
+        source.close()
+        candidate.close()
+
+
+def test_rebuild_rejects_conflicting_job_identity_for_a_run_without_writes(
+    tmp_path: Path,
+) -> None:
+    source, candidate, _ = _connections(tmp_path)
+    try:
+        source.execute(
+            "INSERT INTO jobs (url, title, discovered_at) VALUES (?, ?, ?)",
+            (_SECOND_JOB_URL, "Second fixture", "2026-07-30T09:00:00+00:00"),
+        )
+        _insert_source_event(
+            source,
+            event_id=7,
+            event_type="ApplyRunStarted",
+            occurred_at="2026-07-30T10:00:00+00:00",
+            payload={"run_id": "shared-run", "job_id": _JOB_URL},
+        )
+        _insert_source_event(
+            source,
+            event_id=8,
+            job_url=_SECOND_JOB_URL,
+            event_type="ApplicationFailed",
+            occurred_at="2026-07-30T10:01:00+00:00",
+            payload={"run_id": "shared-run", "job_id": _SECOND_JOB_URL},
+        )
+        source.commit()
+        source_bytes = Path(str(source.execute("PRAGMA database_list").fetchone()[2])).read_bytes()
+        job_ids = _copy_roots_and_events(source, candidate, _JOB_ID, _SECOND_JOB_ID)
+
+        with pytest.raises(CandidateApplyRunProjectionsError, match="conflicting"):
+            rebuild_apply_run_projections(source, candidate, job_ids=job_ids)
+
+        assert candidate.execute("SELECT COUNT(*) FROM apply_run_projections").fetchone() == (0,)
+        assert Path(str(source.execute("PRAGMA database_list").fetchone()[2])).read_bytes() == source_bytes
+    finally:
+        source.close()
+        candidate.close()
+
+
+def test_rebuild_requires_empty_target_and_hydrated_roots(tmp_path: Path) -> None:
+    source, candidate, _ = _connections(tmp_path)
+    try:
+        _insert_source_event(
+            source,
+            event_id=7,
+            event_type="ApplyRunStarted",
+            occurred_at="2026-07-30T10:00:00+00:00",
+            payload={"run_id": "run-1", "job_id": _JOB_URL},
+        )
+        source.commit()
+        job_ids = _copy_roots_and_events(source, candidate, _JOB_ID)
+        candidate.execute(
+            """
+            INSERT INTO apply_run_projections (
+                run_id, tenant_id, job_id, job_title, job_employer, status,
+                events_json
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            ("existing", "local", _JOB_ID, "Existing", "Example Corp", "starting", "[]"),
+        )
+
+        with pytest.raises(CandidateApplyRunProjectionsError, match="must be empty"):
+            rebuild_apply_run_projections(source, candidate, job_ids=job_ids)
+
+        candidate.execute("DELETE FROM apply_run_projections")
+        candidate.execute("DELETE FROM job_locators")
+        with pytest.raises(CandidateApplyRunProjectionsError, match="root locators"):
+            rebuild_apply_run_projections(source, candidate, job_ids=job_ids)
+    finally:
+        source.close()
+        candidate.close()
+
+
+def test_rebuild_rolls_back_candidate_fault_and_retries_same_source(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source, candidate, _ = _connections(tmp_path)
+    try:
+        _insert_source_event(
+            source,
+            event_id=7,
+            event_type="ApplyRunStarted",
+            occurred_at="2026-07-30T10:00:00+00:00",
+            payload={"run_id": "run-1", "job_id": _JOB_URL},
+        )
+        source.commit()
+        source_bytes = Path(str(source.execute("PRAGMA database_list").fetchone()[2])).read_bytes()
+        job_ids = _copy_roots_and_events(source, candidate, _JOB_ID)
+        original_verify = apply_runs._verify_candidate
+        monkeypatch.setattr(
+            apply_runs,
+            "_verify_candidate",
+            lambda **_kwargs: (_ for _ in ()).throw(RuntimeError("candidate fault")),
+        )
+
+        with pytest.raises(RuntimeError, match="candidate fault"):
+            rebuild_apply_run_projections(source, candidate, job_ids=job_ids)
+
+        assert candidate.execute("SELECT COUNT(*) FROM apply_run_projections").fetchone() == (0,)
+        assert Path(str(source.execute("PRAGMA database_list").fetchone()[2])).read_bytes() == source_bytes
+        monkeypatch.setattr(apply_runs, "_verify_candidate", original_verify)
+
+        result = rebuild_apply_run_projections(source, candidate, job_ids=job_ids)
+
+        assert result.rebuilt_apply_runs == 1
+        assert candidate.execute(
+            "SELECT run_id, job_id FROM apply_run_projections"
+        ).fetchone() == ("run-1", _JOB_ID)
+    finally:
+        source.close()
+        candidate.close()
+
+
+def test_rebuild_keeps_exact_v7_schema_and_reopens(tmp_path: Path) -> None:
+    source, candidate, candidate_path = _connections(tmp_path)
+    canonical = sqlite3.connect(":memory:")
+    try:
+        _insert_source_event(
+            source,
+            event_id=7,
+            event_type="ApplicationFailed",
+            occurred_at="2026-07-30T10:00:00+00:00",
+            payload={
+                "run_id": "run-1",
+                "job_id": _JOB_URL,
+                "result": {"kind": "captcha"},
+                "duration_ms": 99,
+            },
+        )
+        source.commit()
+        job_ids = _copy_roots_and_events(source, candidate, _JOB_ID)
+
+        rebuild_apply_run_projections(source, candidate, job_ids=job_ids)
+        create_exact_v7_schema(canonical)
+        assert tuple(
+            row for row in schema_dump(candidate) if row[2] == "apply_run_projections"
+        ) == tuple(
+            row for row in schema_dump(canonical) if row[2] == "apply_run_projections"
+        )
+        candidate.commit()
+    finally:
+        source.close()
+        canonical.close()
+        candidate.close()
+
+    reopened = sqlite3.connect(candidate_path)
+    try:
+        reopened.execute("PRAGMA foreign_keys = ON")
+        assert reopened.execute(
+            "SELECT run_id, job_id, status, result, duration_ms FROM apply_run_projections"
+        ).fetchone() == ("run-1", _JOB_ID, "captcha", "captcha", 99)
+        assert reopened.execute("PRAGMA foreign_key_check").fetchall() == []
+    finally:
+        reopened.close()


### PR DESCRIPTION
## Summary

- Rebuild v7 apply-run projections from candidate job events.
- Ignore the stale v6 projection cache and keep canonical JobId ownership.
- Handle no-run, email-only, and employer attribution without URL or site fallbacks.

## Why

Apply status is derived data. Reconstructing it from admitted events avoids carrying URL-shaped identities and stale cached state into v7.

## Validation

- Focused migration tests: 44 passed.
- Cumulative v6 to v7 migration suite through this PR: 111 passed.
- Independent review: PASS with no remaining findings.
