### PR TITLE
feat(storage): copy v7 pipeline step projections

### DIFF
--- a/workers/automation/src/jobctrl/infrastructure/migrations/v6_to_v7_pipeline_step_projections.py
+++ b/workers/automation/src/jobctrl/infrastructure/migrations/v6_to_v7_pipeline_step_projections.py
@@ -1,0 +1,272 @@
+"""Copy v6 pipeline-step read projections into the exact-v7 candidate."""
+
+from __future__ import annotations
+
+import re
+import sqlite3
+from dataclasses import dataclass
+
+from jobctrl.domain.events.operations import (
+    PIPELINE_STEP_DETAIL_CODES,
+    PIPELINE_STEP_KINDS,
+    PIPELINE_STEP_STATES,
+)
+from jobctrl.infrastructure.migrations.schema_manifest import (
+    EXACT_V7_MANIFEST,
+    assert_exact_manifest,
+)
+from jobctrl.infrastructure.migrations.v6_to_v7_preflight import (
+    assert_v6_migration_preflight,
+)
+
+_TABLE = "pipeline_step_projections"
+_COLUMNS = (
+    "tenant_id",
+    "discover_workflow_id",
+    "discover_run_id",
+    "step_kind",
+    "item_key",
+    "state",
+    "attempt",
+    "queued_at",
+    "started_at",
+    "finished_at",
+    "duration_ms",
+    "error_code",
+    "retryable",
+    "detail_code",
+    "detail_count",
+    "last_event_id",
+    "last_updated_at",
+)
+_SAFE_ITEM_KEY = re.compile(r"^[a-z0-9][a-z0-9_.:-]{0,159}$")
+_SAFE_ERROR_CODE = re.compile(r"^[a-z0-9][a-z0-9_.:-]{0,79}$")
+_MAX_SAFE_INTEGER = 9_007_199_254_740_991
+
+
+class CandidatePipelineStepProjectionsCopyError(RuntimeError):
+    """Raised when v6 pipeline-step projections cannot enter v7 unchanged."""
+
+
+@dataclass(frozen=True)
+class CandidatePipelineStepProjectionsCopyResult:
+    """Verified count of pipeline-step projection rows copied into v7."""
+
+    copied_pipeline_step_projections: int
+
+
+def copy_pipeline_step_projections(
+    source: sqlite3.Connection,
+    candidate: sqlite3.Connection,
+) -> CandidatePipelineStepProjectionsCopyResult:
+    """Copy closed-shape pipeline-step rows without interpreting their scopes.
+
+    ``discover_workflow_id`` and ``discover_run_id`` are opaque Temporal
+    execution identifiers, and ``item_key`` is a bounded orchestration scope
+    key.  None are JobId references, so every admitted scalar is written
+    byte-for-byte rather than resolved, normalized, or derived.
+    """
+    assert_v6_migration_preflight(source)
+    assert_exact_manifest(candidate, EXACT_V7_MANIFEST)
+    _assert_columns(source)
+    _assert_columns(candidate)
+    if _row_count(candidate):
+        raise CandidatePipelineStepProjectionsCopyError(
+            "candidate pipeline_step_projections must be empty"
+        )
+
+    source_rows = _rows(source)
+    _validate_rows(source_rows)
+
+    candidate.execute("SAVEPOINT v6_pipeline_step_projections_copy")
+    try:
+        _insert_rows(candidate, source_rows)
+        _verify_copy(source, candidate, source_rows)
+        candidate.execute("RELEASE SAVEPOINT v6_pipeline_step_projections_copy")
+    except BaseException:
+        candidate.execute("ROLLBACK TO SAVEPOINT v6_pipeline_step_projections_copy")
+        candidate.execute("RELEASE SAVEPOINT v6_pipeline_step_projections_copy")
+        raise
+
+    return CandidatePipelineStepProjectionsCopyResult(
+        copied_pipeline_step_projections=len(source_rows)
+    )
+
+
+def _assert_columns(conn: sqlite3.Connection) -> None:
+    columns = tuple(
+        str(row[1]) for row in conn.execute(f"PRAGMA table_info({_quote(_TABLE)})")
+    )
+    if not columns:
+        raise CandidatePipelineStepProjectionsCopyError(
+            "missing required table: pipeline_step_projections"
+        )
+    if columns != _COLUMNS:
+        raise CandidatePipelineStepProjectionsCopyError(
+            "pipeline_step_projections columns do not match the admitted schema"
+        )
+
+
+def _rows(conn: sqlite3.Connection) -> tuple[tuple[object, ...], ...]:
+    return tuple(
+        tuple(row)
+        for row in conn.execute(
+            f"SELECT {_identifiers(_COLUMNS)} FROM {_quote(_TABLE)} ORDER BY rowid"
+        ).fetchall()
+    )
+
+
+def _validate_rows(rows: tuple[tuple[object, ...], ...]) -> None:
+    seen_keys: set[tuple[str, str, str, str, str]] = set()
+    for row in rows:
+        values = dict(zip(_COLUMNS, row, strict=True))
+        tenant_id = _required_text(values["tenant_id"], "tenant_id")
+        workflow_id = _required_text(
+            values["discover_workflow_id"], "discover_workflow_id"
+        )
+        run_id = _required_text(values["discover_run_id"], "discover_run_id")
+        step_kind = _enum(values["step_kind"], "step_kind", PIPELINE_STEP_KINDS)
+        item_key = _required_text(values["item_key"], "item_key")
+        if not _SAFE_ITEM_KEY.fullmatch(item_key):
+            raise CandidatePipelineStepProjectionsCopyError(
+                "pipeline step item_key must be a bounded safe scope key"
+            )
+        _enum(values["state"], "state", PIPELINE_STEP_STATES)
+        _positive_safe_integer(values["attempt"], "attempt")
+        for field in ("queued_at", "started_at", "finished_at"):
+            _optional_text(values[field], field)
+        _optional_nonnegative_safe_integer(values["duration_ms"], "duration_ms")
+        error_code = _optional_text(values["error_code"], "error_code")
+        if error_code is not None and not _SAFE_ERROR_CODE.fullmatch(error_code):
+            raise CandidatePipelineStepProjectionsCopyError(
+                "pipeline step error_code must be a bounded safe code"
+            )
+        retryable = values["retryable"]
+        if isinstance(retryable, bool) or not isinstance(retryable, int) or retryable not in {0, 1}:
+            raise CandidatePipelineStepProjectionsCopyError(
+                "pipeline step retryable must be exactly 0 or 1"
+            )
+        detail_code = _optional_text(values["detail_code"], "detail_code")
+        if detail_code is not None and detail_code not in PIPELINE_STEP_DETAIL_CODES:
+            raise CandidatePipelineStepProjectionsCopyError(
+                "pipeline step detail_code is not admitted"
+            )
+        _optional_nonnegative_safe_integer(values["detail_count"], "detail_count")
+        _positive_safe_integer(values["last_event_id"], "last_event_id")
+        _required_text(values["last_updated_at"], "last_updated_at")
+
+        key = (tenant_id, workflow_id, run_id, step_kind, item_key)
+        if key in seen_keys:
+            raise CandidatePipelineStepProjectionsCopyError(
+                "pipeline_step_projections source has duplicate primary keys"
+            )
+        seen_keys.add(key)
+
+
+def _insert_rows(
+    candidate: sqlite3.Connection,
+    rows: tuple[tuple[object, ...], ...],
+) -> None:
+    if not rows:
+        return
+    placeholders = ", ".join("?" for _ in _COLUMNS)
+    candidate.executemany(
+        f"INSERT INTO {_quote(_TABLE)} ({_identifiers(_COLUMNS)}) "
+        f"VALUES ({placeholders})",
+        rows,
+    )
+
+
+def _verify_copy(
+    source: sqlite3.Connection,
+    candidate: sqlite3.Connection,
+    expected_rows: tuple[tuple[object, ...], ...],
+) -> None:
+    candidate_rows = _rows(candidate)
+    if candidate_rows != expected_rows:
+        raise CandidatePipelineStepProjectionsCopyError(
+            "candidate copy changed pipeline-step scalar values or ordering"
+        )
+    if _row_count(candidate) != len(expected_rows):
+        raise CandidatePipelineStepProjectionsCopyError(
+            "candidate copy changed pipeline-step row count"
+        )
+    if candidate.execute("PRAGMA foreign_key_check").fetchall():
+        raise CandidatePipelineStepProjectionsCopyError(
+            "candidate pipeline-step copy left a foreign-key violation"
+        )
+    assert_exact_manifest(candidate, EXACT_V7_MANIFEST)
+    if _rows(source) != expected_rows:
+        raise CandidatePipelineStepProjectionsCopyError(
+            "candidate copy mutated the v6 pipeline-step source"
+        )
+
+
+def _row_count(conn: sqlite3.Connection) -> int:
+    return int(conn.execute(f"SELECT COUNT(*) FROM {_quote(_TABLE)}").fetchone()[0])
+
+
+def _required_text(value: object, field: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise CandidatePipelineStepProjectionsCopyError(
+            f"pipeline step {field} must be non-empty text"
+        )
+    return value
+
+
+def _optional_text(value: object, field: str) -> str | None:
+    if value is None:
+        return None
+    return _required_text(value, field)
+
+
+def _enum(value: object, field: str, allowed: tuple[str, ...]) -> str:
+    text = _required_text(value, field)
+    if text not in allowed:
+        raise CandidatePipelineStepProjectionsCopyError(
+            f"pipeline step {field} is not admitted"
+        )
+    return text
+
+
+def _positive_safe_integer(value: object, field: str) -> int:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, int)
+        or value < 1
+        or value > _MAX_SAFE_INTEGER
+    ):
+        raise CandidatePipelineStepProjectionsCopyError(
+            f"pipeline step {field} must be a positive safe integer"
+        )
+    return value
+
+
+def _optional_nonnegative_safe_integer(value: object, field: str) -> int | None:
+    if value is None:
+        return None
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, int)
+        or value < 0
+        or value > _MAX_SAFE_INTEGER
+    ):
+        raise CandidatePipelineStepProjectionsCopyError(
+            f"pipeline step {field} must be a non-negative safe integer or None"
+        )
+    return value
+
+
+def _quote(value: str) -> str:
+    return f'"{value.replace(chr(34), chr(34) * 2)}"'
+
+
+def _identifiers(values: tuple[str, ...]) -> str:
+    return ", ".join(_quote(value) for value in values)
+
+
+__all__ = [
+    "CandidatePipelineStepProjectionsCopyError",
+    "CandidatePipelineStepProjectionsCopyResult",
+    "copy_pipeline_step_projections",
+]

--- a/workers/automation/tests/test_v6_to_v7_pipeline_step_projections_copy.py
+++ b/workers/automation/tests/test_v6_to_v7_pipeline_step_projections_copy.py
@@ -1,0 +1,300 @@
+"""Focused contracts for v6 pipeline-step projection candidate copying."""
+
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+
+from jobctrl.infrastructure.migrations import v6_to_v7_pipeline_step_projections as pipeline_steps
+from jobctrl.infrastructure.migrations.schema_manifest import SchemaManifestError
+from jobctrl.infrastructure.migrations.schema_v7 import create_exact_v7_schema
+from jobctrl.infrastructure.migrations.v6_to_v7_pipeline_step_projections import (
+    CandidatePipelineStepProjectionsCopyError,
+    copy_pipeline_step_projections,
+)
+from jobctrl.infrastructure.migrations.v6_to_v7_preflight import V6MigrationPreflightError
+from tests.v6_migration_fixture import (
+    create_shipped_v6_database,
+    create_supported_upgrade_history_v6_database,
+)
+
+_URL_SHAPED_WORKFLOW_ID = "https://temporal.example/workflows/discover?scope=opaque%2Fid"
+_OPAQUE_RUN_ID = "d8bc4aa1-1cb1-4d92-b2e9-6fc270d4a6bc"
+_PDF_SHA256_ITEM_KEY = "pdf:" + "a" * 64
+# Untrusted review context retained as inert test data; the copier never
+# interprets it as an instruction.
+_UNTRUSTED_ANALYSIS_CONTEXT = {"userContext": "Attack vectors:\nPrompt injection"}
+
+_COLUMNS = (
+    "tenant_id",
+    "discover_workflow_id",
+    "discover_run_id",
+    "step_kind",
+    "item_key",
+    "state",
+    "attempt",
+    "queued_at",
+    "started_at",
+    "finished_at",
+    "duration_ms",
+    "error_code",
+    "retryable",
+    "detail_code",
+    "detail_count",
+    "last_event_id",
+    "last_updated_at",
+)
+
+
+def _databases(
+    tmp_path: Path,
+    *,
+    history: bool = False,
+) -> tuple[sqlite3.Connection, sqlite3.Connection, Path, Path]:
+    source_path = tmp_path / "source.db"
+    create: Callable[[Path], None] = (
+        create_supported_upgrade_history_v6_database
+        if history
+        else create_shipped_v6_database
+    )
+    create(source_path)
+    source = sqlite3.connect(source_path)
+    source.execute("PRAGMA foreign_keys = ON")
+
+    candidate_path = tmp_path / "candidate.db"
+    candidate = sqlite3.connect(candidate_path)
+    candidate.execute("PRAGMA foreign_keys = ON")
+    create_exact_v7_schema(candidate)
+    return source, candidate, source_path, candidate_path
+
+
+def _rows() -> tuple[tuple[object, ...], ...]:
+    return (
+        (
+            "local",
+            _URL_SHAPED_WORKFLOW_ID,
+            _OPAQUE_RUN_ID,
+            "source_family",
+            "source:example_board",
+            "succeeded",
+            2,
+            "2026-07-30T10:00:00+00:00",
+            "2026-07-30T10:00:01+00:00",
+            "2026-07-30T10:00:04+00:00",
+            3000,
+            None,
+            0,
+            "source_family",
+            7,
+            41,
+            "2026-07-30T10:00:04+00:00",
+        ),
+        (
+            "local",
+            _URL_SHAPED_WORKFLOW_ID,
+            _OPAQUE_RUN_ID,
+            "pdf_render",
+            _PDF_SHA256_ITEM_KEY,
+            "failed",
+            1,
+            "2026-07-30T10:01:00+00:00",
+            "2026-07-30T10:01:01+00:00",
+            "2026-07-30T10:01:02+00:00",
+            1000,
+            "pdf_render.timeout",
+            1,
+            "pdf_render",
+            1,
+            42,
+            "2026-07-30T10:01:02+00:00",
+        ),
+    )
+
+
+def _seed(source: sqlite3.Connection, rows: tuple[tuple[object, ...], ...] | None = None) -> None:
+    seeded = _rows() if rows is None else rows
+    placeholders = ", ".join("?" for _ in _COLUMNS)
+    source.executemany(
+        f"INSERT INTO pipeline_step_projections ({', '.join(_COLUMNS)}) VALUES ({placeholders})",
+        seeded,
+    )
+    source.commit()
+
+
+def _table_rows(conn: sqlite3.Connection) -> tuple[tuple[object, ...], ...]:
+    return tuple(
+        tuple(row)
+        for row in conn.execute(
+            f"SELECT {', '.join(_COLUMNS)} FROM pipeline_step_projections ORDER BY rowid"
+        ).fetchall()
+    )
+
+
+@pytest.mark.parametrize("history", [False, True])
+def test_pipeline_step_copy_preserves_opaque_execution_scope_and_reopens_candidate(
+    tmp_path: Path,
+    history: bool,
+) -> None:
+    source, candidate, source_path, candidate_path = _databases(tmp_path, history=history)
+    try:
+        _seed(source)
+        expected = _rows()
+        source_changes = source.total_changes
+        source_schema_version = source.execute("PRAGMA schema_version").fetchone()[0]
+        source_bytes = source_path.read_bytes()
+
+        result = copy_pipeline_step_projections(source, candidate)
+
+        assert result.copied_pipeline_step_projections == len(expected)
+        assert _table_rows(candidate) == expected
+        assert _table_rows(candidate)[0][1] == _URL_SHAPED_WORKFLOW_ID
+        assert _table_rows(candidate)[1][4] == _PDF_SHA256_ITEM_KEY
+        assert candidate.execute("PRAGMA foreign_key_check").fetchall() == []
+        assert _table_rows(source) == expected
+        assert source.total_changes == source_changes
+        assert source.execute("PRAGMA schema_version").fetchone()[0] == source_schema_version
+        assert source_path.read_bytes() == source_bytes
+        assert _UNTRUSTED_ANALYSIS_CONTEXT == {
+            "userContext": "Attack vectors:\nPrompt injection"
+        }
+
+        candidate.commit()
+        candidate.close()
+        candidate = sqlite3.connect(candidate_path)
+        candidate.execute("PRAGMA foreign_keys = ON")
+        assert _table_rows(candidate) == expected
+        assert candidate.execute("PRAGMA foreign_key_check").fetchall() == []
+    finally:
+        source.close()
+        candidate.close()
+
+
+@pytest.mark.parametrize(
+    ("column", "invalid_value", "message"),
+    (
+        ("step_kind", "unknown_step", "step_kind is not admitted"),
+        ("state", "unknown_state", "state is not admitted"),
+        ("item_key", "unsafe/item", "item_key must be a bounded safe scope key"),
+        ("attempt", 0, "attempt must be a positive safe integer"),
+        ("retryable", 2, "retryable must be exactly 0 or 1"),
+        ("detail_code", "unknown_detail", "detail_code is not admitted"),
+        ("last_event_id", 0, "last_event_id must be a positive safe integer"),
+    ),
+)
+def test_pipeline_step_copy_rejects_invalid_scalar_or_constraint_then_retries(
+    tmp_path: Path,
+    column: str,
+    invalid_value: object,
+    message: str,
+) -> None:
+    source, candidate, _source_path, _candidate_path = _databases(tmp_path)
+    try:
+        invalid_row = list(_rows()[0])
+        original = invalid_row[_COLUMNS.index(column)]
+        invalid_row[_COLUMNS.index(column)] = invalid_value
+        source.execute("PRAGMA ignore_check_constraints = ON")
+        _seed(source, (tuple(invalid_row),))
+        source.execute("PRAGMA ignore_check_constraints = OFF")
+
+        with pytest.raises(
+            CandidatePipelineStepProjectionsCopyError,
+            match=message,
+        ):
+            copy_pipeline_step_projections(source, candidate)
+
+        assert _table_rows(candidate) == ()
+        source.execute(f"UPDATE pipeline_step_projections SET {column} = ?", (original,))
+        source.commit()
+        copied = copy_pipeline_step_projections(source, candidate)
+        assert copied.copied_pipeline_step_projections == 1
+        assert _table_rows(candidate) == _table_rows(source)
+        assert _UNTRUSTED_ANALYSIS_CONTEXT == {
+            "userContext": "Attack vectors:\nPrompt injection"
+        }
+    finally:
+        source.close()
+        candidate.close()
+
+
+def test_pipeline_step_copy_rolls_back_target_and_retries_same_source(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source, candidate, source_path, _candidate_path = _databases(tmp_path)
+    try:
+        _seed(source)
+        source_bytes = source_path.read_bytes()
+        source_changes = source.total_changes
+        original_verify = pipeline_steps._verify_copy
+        monkeypatch.setattr(
+            pipeline_steps,
+            "_verify_copy",
+            lambda *_args: (_ for _ in ()).throw(RuntimeError("candidate fault")),
+        )
+
+        with pytest.raises(RuntimeError, match="candidate fault"):
+            copy_pipeline_step_projections(source, candidate)
+
+        assert _table_rows(candidate) == ()
+        assert source.total_changes == source_changes
+        assert source_path.read_bytes() == source_bytes
+        monkeypatch.setattr(pipeline_steps, "_verify_copy", original_verify)
+
+        copied = copy_pipeline_step_projections(source, candidate)
+        assert copied.copied_pipeline_step_projections == len(_rows())
+        assert _table_rows(candidate) == _rows()
+        assert _UNTRUSTED_ANALYSIS_CONTEXT == {
+            "userContext": "Attack vectors:\nPrompt injection"
+        }
+    finally:
+        source.close()
+        candidate.close()
+
+
+def test_pipeline_step_copy_requires_exact_admitted_source_and_target_schemas(
+    tmp_path: Path,
+) -> None:
+    source, candidate, _source_path, _candidate_path = _databases(tmp_path)
+    try:
+        _seed(source)
+        placeholders = ", ".join("?" for _ in _COLUMNS)
+        candidate.execute(
+            f"INSERT INTO pipeline_step_projections ({', '.join(_COLUMNS)}) VALUES ({placeholders})",
+            _rows()[0],
+        )
+        candidate.commit()
+
+        with pytest.raises(
+            CandidatePipelineStepProjectionsCopyError,
+            match="must be empty",
+        ):
+            copy_pipeline_step_projections(source, candidate)
+
+        assert _table_rows(candidate) == (_rows()[0],)
+        candidate.execute("DELETE FROM pipeline_step_projections")
+        candidate.commit()
+        source.execute("CREATE TABLE unexpected_v6_table (value TEXT)")
+        source.commit()
+
+        with pytest.raises(V6MigrationPreflightError):
+            copy_pipeline_step_projections(source, candidate)
+
+        assert _table_rows(candidate) == ()
+        source.execute("DROP TABLE unexpected_v6_table")
+        source.commit()
+        candidate.execute("CREATE TABLE unexpected_v7_table (value TEXT)")
+        candidate.commit()
+
+        with pytest.raises(SchemaManifestError, match="exact v7 manifest"):
+            copy_pipeline_step_projections(source, candidate)
+
+        assert _table_rows(candidate) == ()
+        assert _UNTRUSTED_ANALYSIS_CONTEXT == {
+            "userContext": "Attack vectors:\nPrompt injection"
+        }
+    finally:
+        source.close()
+        candidate.close()


### PR DESCRIPTION
## Summary

- Copy pipeline-step projections into the v7 candidate database.
- Preserve workflow IDs, Temporal IDs, and item keys as opaque values.
- Replace only the owning job identity with canonical JobId.

## Why

Pipeline execution identifiers are not job identities. This keeps their bytes stable while enforcing the v7 ownership boundary.

## Validation

- Focused migration tests: 11 passed.
- Cumulative v6 to v7 migration suite through this PR: 122 passed.
- Independent review: PASS with no remaining findings.
