### PR TITLE
feat(migration): resolve duplicate link identities

### DIFF
--- a/workers/automation/src/jobctrl/infrastructure/migrations/identity_upcast.py
+++ b/workers/automation/src/jobctrl/infrastructure/migrations/identity_upcast.py
@@ -10,6 +10,10 @@ from jobctrl.infrastructure.migrations.v6_to_v7_copy import (
     CandidateCopyError,
     JobIdMap,
 )
+from jobctrl.infrastructure.migrations.v6_to_v7_duplicate_links import (
+    DuplicateLinkIdentityResolver,
+    DuplicateLinkResolutionError,
+)
 
 EVENT_IDENTITY_VERSION = 1
 
@@ -70,6 +74,7 @@ class UpcastedEventIdentity:
 def upcast_v6_event_identity(
     *,
     job_ids: JobIdMap,
+    duplicate_links: DuplicateLinkIdentityResolver | None = None,
     event_type: object,
     event_job_locator: object,
     payload_json: object,
@@ -80,6 +85,7 @@ def upcast_v6_event_identity(
     column_job_id = _resolve_optional(job_ids, event_job_locator)
     rewritten_payload, payload_primary, payload_references = _upcast_payload(
         job_ids=job_ids,
+        duplicate_links=duplicate_links,
         event_type=event_type,
         payload_json=payload_json,
     )
@@ -120,6 +126,7 @@ def upcast_v6_event_identity(
 def _upcast_payload(
     *,
     job_ids: JobIdMap,
+    duplicate_links: DuplicateLinkIdentityResolver | None,
     event_type: object,
     payload_json: object,
 ) -> tuple[str | None, tuple[str, ...], frozenset[str]]:
@@ -134,6 +141,15 @@ def _upcast_payload(
         return str(payload_json), (), frozenset()
 
     normalized = _normalize_duplicate_link_payload(event_type, decoded)
+    if event_type == "DuplicateJobLinked":
+        if duplicate_links is None:
+            raise EventIdentityUpcastError("duplicate_link_event_resolver_required")
+        try:
+            normalized = duplicate_links.rewrite_duplicate_linked_event_payload(
+                normalized
+            )
+        except DuplicateLinkResolutionError as error:
+            raise EventIdentityUpcastError(str(error)) from error
     transformed: dict[str, Any] = {}
     primary: set[str] = set()
     references: set[str] = set()

--- a/workers/automation/src/jobctrl/infrastructure/migrations/v6_to_v7_duplicate_links.py
+++ b/workers/automation/src/jobctrl/infrastructure/migrations/v6_to_v7_duplicate_links.py
@@ -1,0 +1,464 @@
+"""Copy v6 duplicate-link audit rows with proven stable identities."""
+
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+from typing import Any
+
+from jobctrl.domain.discovery.identity import normalize_observed_url
+from jobctrl.infrastructure.migrations.schema_manifest import (
+    EXACT_V7_MANIFEST,
+    assert_exact_manifest,
+)
+from jobctrl.infrastructure.migrations.v6_to_v7_copy import (
+    CandidateCopyError,
+    JobIdMap,
+    build_job_id_map,
+)
+from jobctrl.infrastructure.migrations.v6_to_v7_preflight import (
+    assert_v6_migration_preflight,
+)
+
+_COLUMNS = (
+    "tenant_id",
+    "duplicate_link_id",
+    "surviving_job_id",
+    "superseded_job_or_observation_id",
+    "reason",
+    "confidence",
+    "linked_at",
+)
+_EVENT_LINK_ID_FIELDS = ("duplicate_link_id", "duplicateLinkId")
+_EVENT_SURVIVOR_FIELDS = (
+    "surviving_job_id",
+    "survivingJobId",
+    "surviving_job_url",
+    "survivingJobUrl",
+    "surviving_job_key",
+    "survivingJobKey",
+)
+_EVENT_SUPERSEDED_FIELDS = (
+    "superseded_job_or_observation_id",
+    "supersededJobOrObservationId",
+)
+
+
+class CandidateDuplicateLinkCopyError(RuntimeError):
+    """Raised when a duplicate-link reference cannot be proven in v7."""
+
+
+class DuplicateLinkResolutionError(RuntimeError):
+    """Raised when one legacy duplicate-link identity is ambiguous or invalid."""
+
+
+@dataclass(frozen=True)
+class ResolvedDuplicateLink:
+    """The v7 identities of one accepted duplicate-link audit row."""
+
+    surviving_job_id: str
+    superseded_job_or_observation_id: str
+
+
+@dataclass(frozen=True)
+class CandidateDuplicateLinkCopyResult:
+    """Verified duplicate-link copy result for the migration coordinator."""
+
+    copied_links: int
+
+
+class DuplicateLinkIdentityResolver:
+    """Resolve legacy duplicate links without inventing durable identities."""
+
+    def __init__(
+        self,
+        source: sqlite3.Connection,
+        candidate: sqlite3.Connection,
+        *,
+        job_ids: JobIdMap,
+    ) -> None:
+        self._source = source
+        self._candidate = candidate
+        self._job_ids = job_ids
+
+    def resolve_link(
+        self,
+        *,
+        tenant_id: object,
+        surviving_job_locator: object,
+        superseded_reference: object,
+    ) -> ResolvedDuplicateLink:
+        """Resolve a v6 link to the only admissible v7 reference shape."""
+        tenant = _tenant_id(tenant_id)
+        survivor = self._resolve_survivor(tenant, surviving_job_locator)
+        reference = _required_text(
+            superseded_reference,
+            "duplicate_superseded_reference_invalid",
+        )
+
+        direct_observations = self._source.execute(
+            """
+            SELECT source_observation_id, job_url
+              FROM job_source_observations
+             WHERE tenant_id = ? AND source_observation_id = ?
+            """,
+            (tenant, reference),
+        ).fetchall()
+        if len(direct_observations) > 1:
+            raise DuplicateLinkResolutionError(
+                "duplicate_superseded_reference_multiple"
+            )
+        if direct_observations:
+            observation_id, observation_owner = direct_observations[0]
+            self._require_observation_owner(
+                tenant=tenant,
+                observation_id=observation_id,
+                observation_owner_locator=observation_owner,
+                survivor_job_id=survivor,
+            )
+            return ResolvedDuplicateLink(
+                surviving_job_id=survivor,
+                superseded_job_or_observation_id=str(observation_id),
+            )
+
+        normalized_reference = normalize_observed_url(reference)
+        observation_rows = self._source.execute(
+            """
+            SELECT source_observation_id, job_url
+              FROM job_source_observations
+             WHERE tenant_id = ? AND normalized_observed_url = ?
+            """,
+            (tenant, normalized_reference),
+        ).fetchall()
+        if len(observation_rows) > 1:
+            raise DuplicateLinkResolutionError(
+                "duplicate_superseded_reference_multiple"
+            )
+
+        observation_id: str | None = None
+        if observation_rows:
+            raw_observation_id, observation_owner = observation_rows[0]
+            self._require_observation_owner(
+                tenant=tenant,
+                observation_id=raw_observation_id,
+                observation_owner_locator=observation_owner,
+                survivor_job_id=survivor,
+            )
+            observation_id = str(raw_observation_id)
+
+        aggregate_id = self._job_ids.by_locator.get((tenant, reference))
+        if aggregate_id == survivor:
+            raise DuplicateLinkResolutionError("duplicate_superseded_reference_self")
+        if observation_id is not None and aggregate_id is not None:
+            raise DuplicateLinkResolutionError(
+                "duplicate_superseded_reference_ambiguous"
+            )
+        if observation_id is not None:
+            return ResolvedDuplicateLink(
+                surviving_job_id=survivor,
+                superseded_job_or_observation_id=observation_id,
+            )
+        if aggregate_id is not None:
+            return ResolvedDuplicateLink(
+                surviving_job_id=survivor,
+                superseded_job_or_observation_id=aggregate_id,
+            )
+        raise DuplicateLinkResolutionError("duplicate_superseded_reference_missing")
+
+    def rewrite_duplicate_linked_event_payload(
+        self,
+        payload: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Upcast a ``DuplicateJobLinked`` payload only when it matches its row."""
+        duplicate_link_id = _event_value(
+            payload,
+            _EVENT_LINK_ID_FIELDS,
+            "duplicate_link_event_identity_invalid",
+        )
+        surviving_locator = _event_value(
+            payload,
+            _EVENT_SURVIVOR_FIELDS,
+            "duplicate_link_event_identity_invalid",
+        )
+        superseded_reference = _event_value(
+            payload,
+            _EVENT_SUPERSEDED_FIELDS,
+            "duplicate_link_event_identity_invalid",
+        )
+        source_rows = self._source.execute(
+            """
+            SELECT surviving_job_id, superseded_job_or_observation_id
+              FROM job_duplicate_links
+             WHERE tenant_id = ? AND duplicate_link_id = ?
+            """,
+            ("local", duplicate_link_id),
+        ).fetchall()
+        if len(source_rows) != 1:
+            raise DuplicateLinkResolutionError("duplicate_link_event_link_missing")
+        source_survivor, source_superseded = source_rows[0]
+        if (
+            str(source_survivor) != surviving_locator
+            or str(source_superseded) != superseded_reference
+        ):
+            raise DuplicateLinkResolutionError("duplicate_link_event_table_conflict")
+
+        resolved = self.resolve_link(
+            tenant_id="local",
+            surviving_job_locator=source_survivor,
+            superseded_reference=source_superseded,
+        )
+        candidate_rows = self._candidate.execute(
+            """
+            SELECT surviving_job_id, superseded_job_or_observation_id
+              FROM job_duplicate_links
+             WHERE tenant_id = ? AND duplicate_link_id = ?
+            """,
+            ("local", duplicate_link_id),
+        ).fetchall()
+        if len(candidate_rows) != 1:
+            raise DuplicateLinkResolutionError("duplicate_link_event_candidate_missing")
+        if tuple(str(value) for value in candidate_rows[0]) != (
+            resolved.surviving_job_id,
+            resolved.superseded_job_or_observation_id,
+        ):
+            raise DuplicateLinkResolutionError("duplicate_link_event_table_conflict")
+
+        rewritten = dict(payload)
+        for field in _EVENT_SUPERSEDED_FIELDS:
+            if field in rewritten:
+                rewritten[field] = resolved.superseded_job_or_observation_id
+        return rewritten
+
+    def _resolve_survivor(self, tenant_id: str, locator: object) -> str:
+        try:
+            resolved = self._job_ids.resolve(tenant_id=tenant_id, locator=locator)
+        except CandidateCopyError as error:
+            raise DuplicateLinkResolutionError(
+                "duplicate_surviving_job_identity_unresolved"
+            ) from error
+        if resolved is None:
+            raise DuplicateLinkResolutionError(
+                "duplicate_surviving_job_identity_invalid"
+            )
+        return resolved
+
+    def _require_observation_owner(
+        self,
+        *,
+        tenant: str,
+        observation_id: object,
+        observation_owner_locator: object,
+        survivor_job_id: str,
+    ) -> None:
+        try:
+            observation_owner = self._job_ids.resolve(
+                tenant_id=tenant,
+                locator=observation_owner_locator,
+            )
+        except CandidateCopyError as error:
+            raise DuplicateLinkResolutionError(
+                "duplicate_superseded_observation_owner_unresolved"
+            ) from error
+        if observation_owner != survivor_job_id:
+            raise DuplicateLinkResolutionError(
+                "duplicate_superseded_reference_owner_mismatch"
+            )
+        candidate_rows = self._candidate.execute(
+            """
+            SELECT job_id
+              FROM job_source_observations
+             WHERE tenant_id = ? AND source_observation_id = ?
+            """,
+            (tenant, str(observation_id)),
+        ).fetchall()
+        if len(candidate_rows) != 1:
+            raise DuplicateLinkResolutionError(
+                "candidate_duplicate_observation_missing"
+            )
+        if str(candidate_rows[0][0]) != survivor_job_id:
+            raise DuplicateLinkResolutionError(
+                "candidate_duplicate_observation_owner_mismatch"
+            )
+
+
+def copy_duplicate_links(
+    source: sqlite3.Connection,
+    candidate: sqlite3.Connection,
+    *,
+    job_ids: JobIdMap,
+) -> CandidateDuplicateLinkCopyResult:
+    """Copy v6 duplicate links after source observations have stable Job owners."""
+    assert_v6_migration_preflight(source)
+    assert_exact_manifest(candidate, EXACT_V7_MANIFEST)
+    _assert_candidate_job_ids(source, candidate, job_ids)
+    _assert_columns(source, "source")
+    _assert_columns(candidate, "candidate")
+    if _row_count(candidate, "job_duplicate_links"):
+        raise CandidateDuplicateLinkCopyError(
+            "candidate job_duplicate_links must be empty"
+        )
+    _assert_observations_ready(source, candidate)
+
+    source_rows = tuple(
+        tuple(row)
+        for row in source.execute(
+            f"SELECT {', '.join(_quote(column) for column in _COLUMNS)} "
+            "FROM job_duplicate_links ORDER BY tenant_id, duplicate_link_id"
+        ).fetchall()
+    )
+    resolver = DuplicateLinkIdentityResolver(source, candidate, job_ids=job_ids)
+    target_rows: list[tuple[object, ...]] = []
+    for row in source_rows:
+        values = dict(zip(_COLUMNS, row, strict=True))
+        try:
+            resolved = resolver.resolve_link(
+                tenant_id=values["tenant_id"],
+                surviving_job_locator=values["surviving_job_id"],
+                superseded_reference=values["superseded_job_or_observation_id"],
+            )
+        except DuplicateLinkResolutionError as error:
+            raise CandidateDuplicateLinkCopyError(str(error)) from error
+        target_rows.append(
+            (
+                _tenant_id(values["tenant_id"]),
+                values["duplicate_link_id"],
+                resolved.surviving_job_id,
+                resolved.superseded_job_or_observation_id,
+                values["reason"],
+                values["confidence"],
+                values["linked_at"],
+            )
+        )
+
+    candidate.execute("SAVEPOINT v6_duplicate_links_candidate_copy")
+    try:
+        if target_rows:
+            placeholders = ", ".join("?" for _ in _COLUMNS)
+            candidate.executemany(
+                f"INSERT INTO job_duplicate_links ({', '.join(_quote(column) for column in _COLUMNS)}) "
+                f"VALUES ({placeholders})",
+                target_rows,
+            )
+        _verify_candidate(source, candidate, source_rows, tuple(target_rows))
+        candidate.execute("RELEASE SAVEPOINT v6_duplicate_links_candidate_copy")
+    except BaseException:
+        candidate.execute("ROLLBACK TO SAVEPOINT v6_duplicate_links_candidate_copy")
+        candidate.execute("RELEASE SAVEPOINT v6_duplicate_links_candidate_copy")
+        raise
+    return CandidateDuplicateLinkCopyResult(copied_links=len(target_rows))
+
+
+def _assert_candidate_job_ids(
+    source: sqlite3.Connection,
+    candidate: sqlite3.Connection,
+    job_ids: JobIdMap,
+) -> None:
+    try:
+        persisted = build_job_id_map(source, candidate)
+    except CandidateCopyError as error:
+        raise CandidateDuplicateLinkCopyError(
+            "candidate JobIdMap is not hydrated"
+        ) from error
+    if dict(persisted.by_locator) != dict(job_ids.by_locator):
+        raise CandidateDuplicateLinkCopyError(
+            "candidate JobIdMap does not match root copy"
+        )
+
+
+def _assert_columns(conn: sqlite3.Connection, label: str) -> None:
+    columns = tuple(
+        str(row[1]) for row in conn.execute("PRAGMA table_info(job_duplicate_links)")
+    )
+    if columns != _COLUMNS:
+        raise CandidateDuplicateLinkCopyError(
+            f"{label} job_duplicate_links columns do not match admitted v6/exact v7"
+        )
+
+
+def _assert_observations_ready(
+    source: sqlite3.Connection,
+    candidate: sqlite3.Connection,
+) -> None:
+    if _row_count(source, "job_source_observations") != _row_count(
+        candidate, "job_source_observations"
+    ):
+        raise CandidateDuplicateLinkCopyError(
+            "candidate duplicate links require copied source observations"
+        )
+
+
+def _verify_candidate(
+    source: sqlite3.Connection,
+    candidate: sqlite3.Connection,
+    expected_source_rows: tuple[tuple[object, ...], ...],
+    expected_target_rows: tuple[tuple[object, ...], ...],
+) -> None:
+    candidate_rows = tuple(
+        tuple(row)
+        for row in candidate.execute(
+            f"SELECT {', '.join(_quote(column) for column in _COLUMNS)} "
+            "FROM job_duplicate_links ORDER BY tenant_id, duplicate_link_id"
+        ).fetchall()
+    )
+    if candidate_rows != expected_target_rows:
+        raise CandidateDuplicateLinkCopyError(
+            "candidate duplicate-link copy changed rows or ordering"
+        )
+    if candidate.execute("PRAGMA foreign_key_check").fetchall():
+        raise CandidateDuplicateLinkCopyError(
+            "candidate duplicate-link copy left a foreign-key violation"
+        )
+    assert_exact_manifest(candidate, EXACT_V7_MANIFEST)
+    source_rows_after = tuple(
+        tuple(row)
+        for row in source.execute(
+            f"SELECT {', '.join(_quote(column) for column in _COLUMNS)} "
+            "FROM job_duplicate_links ORDER BY tenant_id, duplicate_link_id"
+        ).fetchall()
+    )
+    if source_rows_after != expected_source_rows:
+        raise CandidateDuplicateLinkCopyError(
+            "candidate duplicate-link copy mutated the v6 source"
+        )
+
+
+def _event_value(
+    payload: dict[str, Any],
+    fields: tuple[str, ...],
+    error: str,
+) -> str:
+    values = [payload[field] for field in fields if field in payload]
+    if not values or any(not isinstance(value, str) or not value.strip() for value in values):
+        raise DuplicateLinkResolutionError(error)
+    text = str(values[0])
+    if any(str(value) != text for value in values[1:]):
+        raise DuplicateLinkResolutionError("duplicate_link_event_table_conflict")
+    return text
+
+
+def _required_text(value: object, error: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise DuplicateLinkResolutionError(error)
+    return value
+
+
+def _row_count(conn: sqlite3.Connection, table: str) -> int:
+    return int(conn.execute(f"SELECT COUNT(*) FROM {_quote(table)}").fetchone()[0])
+
+
+def _tenant_id(value: object) -> str:
+    return str(value or "").strip() or "local"
+
+
+def _quote(value: str) -> str:
+    return f'"{value.replace(chr(34), chr(34) * 2)}"'
+
+
+__all__ = [
+    "CandidateDuplicateLinkCopyError",
+    "CandidateDuplicateLinkCopyResult",
+    "DuplicateLinkIdentityResolver",
+    "DuplicateLinkResolutionError",
+    "ResolvedDuplicateLink",
+    "copy_duplicate_links",
+]

--- a/workers/automation/src/jobctrl/infrastructure/migrations/v6_to_v7_events.py
+++ b/workers/automation/src/jobctrl/infrastructure/migrations/v6_to_v7_events.py
@@ -19,6 +19,9 @@ from jobctrl.infrastructure.migrations.v6_to_v7_copy import (
     JobIdMap,
     build_job_id_map,
 )
+from jobctrl.infrastructure.migrations.v6_to_v7_duplicate_links import (
+    DuplicateLinkIdentityResolver,
+)
 from jobctrl.infrastructure.migrations.v6_to_v7_preflight import (
     assert_v6_migration_preflight,
 )
@@ -96,7 +99,12 @@ def copy_job_events(
         ).fetchall()
     )
     source_sequence = _sequence_value(source, "job_events")
-    candidate_rows = _candidate_rows(source_rows, job_ids)
+    duplicate_links = DuplicateLinkIdentityResolver(
+        source,
+        candidate,
+        job_ids=job_ids,
+    )
+    candidate_rows = _candidate_rows(source_rows, job_ids, duplicate_links)
     _validate_source_sequence(source_rows, source_sequence)
 
     candidate.execute("SAVEPOINT v6_job_events_candidate_copy")
@@ -144,6 +152,7 @@ def _assert_candidate_job_ids(
 def _candidate_rows(
     source_rows: tuple[tuple[object, ...], ...],
     job_ids: JobIdMap,
+    duplicate_links: DuplicateLinkIdentityResolver,
 ) -> tuple[tuple[object, ...], ...]:
     copied: list[tuple[object, ...]] = []
     for row in source_rows:
@@ -151,6 +160,7 @@ def _candidate_rows(
         try:
             identity = upcast_v6_event_identity(
                 job_ids=job_ids,
+                duplicate_links=duplicate_links,
                 event_type=values["event_type"],
                 event_job_locator=values["job_url"],
                 payload_json=values["payload_json"],

--- a/workers/automation/tests/test_v6_to_v7_duplicate_links.py
+++ b/workers/automation/tests/test_v6_to_v7_duplicate_links.py
@@ -1,0 +1,387 @@
+"""Focused contracts for v6 duplicate-link identity migration."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from jobctrl.domain.discovery.identity import normalize_observed_url
+from jobctrl.infrastructure.migrations import v6_to_v7_duplicate_links as duplicate_links
+from jobctrl.infrastructure.migrations.schema_v7 import create_exact_v7_schema
+from jobctrl.infrastructure.migrations.v6_to_v7_copy import copy_direct_and_scalar_tables
+from jobctrl.infrastructure.migrations.v6_to_v7_duplicate_links import (
+    CandidateDuplicateLinkCopyError,
+    copy_duplicate_links,
+)
+from jobctrl.infrastructure.migrations.v6_to_v7_events import (
+    CandidateEventCopyError,
+    copy_job_events,
+)
+from jobctrl.infrastructure.migrations.v6_to_v7_root import copy_root_jobs
+from tests.v6_migration_fixture import create_shipped_v6_database
+
+_OWNER_URL = "https://jobs.example/shipped-v6"
+_OWNER_ID = "00000000-0000-4000-8000-000000000001"
+_PRIOR_URL = "https://jobs.example/prior"
+_PRIOR_ID = "00000000-0000-4000-8000-000000000002"
+_OBSERVED_URL = "https://careers.example/platform-engineer?utm_source=board"
+_NOW = "2026-07-30T10:00:00+00:00"
+
+
+def _connections(tmp_path: Path) -> tuple[sqlite3.Connection, sqlite3.Connection, Path]:
+    source_path = tmp_path / "source.db"
+    create_shipped_v6_database(source_path)
+    source = sqlite3.connect(source_path)
+    source.execute("PRAGMA foreign_keys = ON")
+    candidate = sqlite3.connect(tmp_path / "candidate.db")
+    candidate.execute("PRAGMA foreign_keys = ON")
+    create_exact_v7_schema(candidate)
+    return source, candidate, source_path
+
+
+def _allocator(*values: str):
+    allocated: Iterator[str] = iter(values)
+    return allocated.__next__
+
+
+def _prepare_candidate(
+    source: sqlite3.Connection,
+    candidate: sqlite3.Connection,
+    *,
+    job_ids: tuple[str, ...] = (_OWNER_ID,),
+):
+    root = copy_root_jobs(
+        source,
+        candidate,
+        job_id_factory=_allocator(*job_ids),
+        migration_at=_NOW,
+    )
+    copy_direct_and_scalar_tables(source, candidate)
+    return root.job_ids
+
+
+def _insert_job(conn: sqlite3.Connection, url: str) -> None:
+    conn.execute(
+        "INSERT INTO jobs (url, title, discovered_at) VALUES (?, ?, ?)",
+        (url, "Legacy duplicate", _NOW),
+    )
+
+
+def _insert_observation(
+    conn: sqlite3.Connection,
+    *,
+    observation_id: str,
+    job_url: str = _OWNER_URL,
+    observed_url: str = _OBSERVED_URL,
+    source_native_id: str | None = None,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO job_source_observations (
+            tenant_id, source_observation_id, job_url, source_id,
+            source_native_id, observed_url, normalized_observed_url, run_id,
+            observed_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            "local",
+            observation_id,
+            job_url,
+            "legacy-test",
+            source_native_id or observed_url,
+            observed_url,
+            normalize_observed_url(observed_url),
+            "legacy-run",
+            _NOW,
+        ),
+    )
+
+
+def _insert_link(
+    conn: sqlite3.Connection,
+    *,
+    duplicate_link_id: str = "dup:legacy",
+    surviving_url: str = _OWNER_URL,
+    superseded_reference: str = _OBSERVED_URL,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO job_duplicate_links (
+            tenant_id, duplicate_link_id, surviving_job_id,
+            superseded_job_or_observation_id, reason, confidence, linked_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            "local",
+            duplicate_link_id,
+            surviving_url,
+            superseded_reference,
+            "content_fingerprint_match",
+            0.95,
+            _NOW,
+        ),
+    )
+
+
+def _insert_duplicate_linked_event(
+    conn: sqlite3.Connection,
+    *,
+    duplicate_link_id: str,
+    surviving_url: str = _OWNER_URL,
+    superseded_reference: str = _OBSERVED_URL,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO job_events (
+            event_id, job_url, stage, event_type, level, message, occurred_at,
+            payload_json, entity_kind, entity_ref, idempotency_key
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            1,
+            surviving_url,
+            "discover",
+            "DuplicateJobLinked",
+            "info",
+            "legacy duplicate",
+            _NOW,
+            json.dumps(
+                {
+                    "duplicate_link_id": duplicate_link_id,
+                    "surviving_job_id": surviving_url,
+                    "superseded_job_or_observation_id": superseded_reference,
+                    "reason": "content_fingerprint_match",
+                    "confidence": 0.95,
+                },
+                separators=(",", ":"),
+            ),
+            "job",
+            surviving_url,
+            "duplicate-event",
+        ),
+    )
+
+
+def test_jobspy_url_reference_resolves_to_the_actual_replaced_observation_id(
+    tmp_path: Path,
+) -> None:
+    source, candidate, source_path = _connections(tmp_path)
+    try:
+        jobspy_observation_id = "jobspy:6be241de5c381a3983880d15"
+        _insert_observation(
+            source,
+            observation_id=jobspy_observation_id,
+            source_native_id=normalize_observed_url(_OBSERVED_URL),
+        )
+        _insert_link(source, duplicate_link_id="content:legacy")
+        source.commit()
+        source_bytes = source_path.read_bytes()
+
+        job_ids = _prepare_candidate(source, candidate)
+        copied = copy_duplicate_links(source, candidate, job_ids=job_ids)
+
+        assert copied.copied_links == 1
+        assert candidate.execute(
+            """
+            SELECT surviving_job_id, superseded_job_or_observation_id
+              FROM job_duplicate_links
+            """
+        ).fetchone() == (_OWNER_ID, jobspy_observation_id)
+        assert source_path.read_bytes() == source_bytes
+        candidate.close()
+        candidate = sqlite3.connect(tmp_path / "candidate.db")
+        candidate.execute("PRAGMA foreign_keys = ON")
+        assert candidate.execute("PRAGMA foreign_key_check").fetchall() == []
+        assert candidate.execute(
+            "SELECT superseded_job_or_observation_id FROM job_duplicate_links"
+        ).fetchone() == (jobspy_observation_id,)
+    finally:
+        source.close()
+        candidate.close()
+
+
+def test_smartextract_url_reference_and_event_share_the_observation_resolution(
+    tmp_path: Path,
+) -> None:
+    source, candidate, _ = _connections(tmp_path)
+    try:
+        observation_id = "obs:8ef58c4f3cfb4adca20d4712b10caef7"
+        _insert_observation(source, observation_id=observation_id)
+        _insert_link(source, duplicate_link_id="dup:smart")
+        _insert_duplicate_linked_event(source, duplicate_link_id="dup:smart")
+        source.commit()
+
+        job_ids = _prepare_candidate(source, candidate)
+        copy_duplicate_links(source, candidate, job_ids=job_ids)
+        copy_job_events(source, candidate, job_ids=job_ids)
+
+        payload = json.loads(
+            str(candidate.execute("SELECT payload_json FROM job_events").fetchone()[0])
+        )
+        assert payload["surviving_job_id"] == _OWNER_ID
+        assert payload["superseded_job_or_observation_id"] == observation_id
+        assert candidate.execute(
+            """
+            SELECT surviving_job_id, superseded_job_or_observation_id
+              FROM job_duplicate_links WHERE duplicate_link_id = 'dup:smart'
+            """
+        ).fetchone() == (_OWNER_ID, observation_id)
+    finally:
+        source.close()
+        candidate.close()
+
+
+def test_existing_observation_id_is_preserved_only_for_the_surviving_owner(
+    tmp_path: Path,
+) -> None:
+    source, candidate, _ = _connections(tmp_path)
+    try:
+        observation_id = "obs:already-canonical"
+        _insert_observation(source, observation_id=observation_id)
+        _insert_link(source, superseded_reference=observation_id)
+        source.commit()
+
+        job_ids = _prepare_candidate(source, candidate)
+        copy_duplicate_links(source, candidate, job_ids=job_ids)
+
+        assert candidate.execute(
+            "SELECT superseded_job_or_observation_id FROM job_duplicate_links"
+        ).fetchone() == (observation_id,)
+    finally:
+        source.close()
+        candidate.close()
+
+
+def test_real_two_aggregate_collapse_resolves_the_second_job_to_its_job_id(
+    tmp_path: Path,
+) -> None:
+    source, candidate, _ = _connections(tmp_path)
+    try:
+        _insert_job(source, _PRIOR_URL)
+        _insert_link(source, superseded_reference=_PRIOR_URL)
+        source.commit()
+
+        job_ids = _prepare_candidate(source, candidate, job_ids=(_OWNER_ID, _PRIOR_ID))
+        copy_duplicate_links(source, candidate, job_ids=job_ids)
+
+        assert candidate.execute(
+            "SELECT surviving_job_id, superseded_job_or_observation_id FROM job_duplicate_links"
+        ).fetchone() == (_OWNER_ID, _PRIOR_ID)
+    finally:
+        source.close()
+        candidate.close()
+
+
+@pytest.mark.parametrize(
+    ("setup", "expected_error"),
+    (
+        ("missing", "duplicate_superseded_reference_missing"),
+        ("self", "duplicate_superseded_reference_self"),
+        ("owner_mismatch", "duplicate_superseded_reference_owner_mismatch"),
+        ("ambiguous", "duplicate_superseded_reference_ambiguous"),
+    ),
+)
+def test_duplicate_link_copy_fails_closed_for_unproven_or_ambiguous_references(
+    tmp_path: Path,
+    setup: str,
+    expected_error: str,
+) -> None:
+    source, candidate, _ = _connections(tmp_path)
+    try:
+        job_ids = (_OWNER_ID,)
+        superseded_reference = _OBSERVED_URL
+        if setup == "self":
+            superseded_reference = _OWNER_URL
+        elif setup == "owner_mismatch":
+            _insert_job(source, _PRIOR_URL)
+            _insert_observation(
+                source,
+                observation_id="obs:other-owner",
+                job_url=_PRIOR_URL,
+            )
+            job_ids = (_OWNER_ID, _PRIOR_ID)
+        elif setup == "ambiguous":
+            _insert_job(source, _PRIOR_URL)
+            _insert_observation(
+                source,
+                observation_id="obs:owner-but-root-exists",
+                observed_url=_PRIOR_URL,
+            )
+            superseded_reference = _PRIOR_URL
+            job_ids = (_OWNER_ID, _PRIOR_ID)
+        _insert_link(source, superseded_reference=superseded_reference)
+        source.commit()
+
+        resolved_job_ids = _prepare_candidate(source, candidate, job_ids=job_ids)
+        with pytest.raises(CandidateDuplicateLinkCopyError, match=expected_error):
+            copy_duplicate_links(source, candidate, job_ids=resolved_job_ids)
+
+        assert candidate.execute("SELECT COUNT(*) FROM job_duplicate_links").fetchone() == (0,)
+    finally:
+        source.close()
+        candidate.close()
+
+
+def test_duplicate_link_copy_rolls_back_and_retries_without_mutating_v6_source(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source, candidate, source_path = _connections(tmp_path)
+    try:
+        _insert_observation(source, observation_id="obs:retry")
+        _insert_link(source)
+        source.commit()
+        source_bytes = source_path.read_bytes()
+        job_ids = _prepare_candidate(source, candidate)
+        original_verify = duplicate_links._verify_candidate
+        monkeypatch.setattr(
+            duplicate_links,
+            "_verify_candidate",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("candidate fault")),
+        )
+
+        with pytest.raises(RuntimeError, match="candidate fault"):
+            copy_duplicate_links(source, candidate, job_ids=job_ids)
+
+        assert candidate.execute("SELECT COUNT(*) FROM job_duplicate_links").fetchone() == (0,)
+        assert source_path.read_bytes() == source_bytes
+        monkeypatch.setattr(duplicate_links, "_verify_candidate", original_verify)
+
+        copied = copy_duplicate_links(source, candidate, job_ids=job_ids)
+        assert copied.copied_links == 1
+        assert candidate.execute("PRAGMA foreign_key_check").fetchall() == []
+    finally:
+        source.close()
+        candidate.close()
+
+
+def test_duplicate_linked_event_rejects_a_payload_that_disagrees_with_its_row(
+    tmp_path: Path,
+) -> None:
+    source, candidate, source_path = _connections(tmp_path)
+    try:
+        observation_id = "obs:event-consistency"
+        _insert_observation(source, observation_id=observation_id)
+        _insert_link(source, duplicate_link_id="dup:event")
+        _insert_duplicate_linked_event(
+            source,
+            duplicate_link_id="dup:event",
+            superseded_reference="https://different.example/role",
+        )
+        source.commit()
+        source_bytes = source_path.read_bytes()
+
+        job_ids = _prepare_candidate(source, candidate)
+        copy_duplicate_links(source, candidate, job_ids=job_ids)
+        with pytest.raises(CandidateEventCopyError, match="duplicate_link_event_table_conflict"):
+            copy_job_events(source, candidate, job_ids=job_ids)
+
+        assert candidate.execute("SELECT COUNT(*) FROM job_events").fetchone() == (0,)
+        assert source_path.read_bytes() == source_bytes
+    finally:
+        source.close()
+        candidate.close()


### PR DESCRIPTION
## Summary

- Resolve duplicate-job links through the admitted locator to JobId map.
- Reject missing, self-referential, cross-owner, and ambiguous links.
- Apply the same resolution rules to canonical rows and DuplicateJobLinked events.

## Why

Duplicate links cross job roots and must resolve deterministically before the URL-shaped v6 identity is retired.

## Validation

- Focused migration tests: 23 passed.
- Cumulative v6 to v7 migration suite through this PR: 132 passed.
- Independent review: PASS with no remaining findings.

A broader legacy test group still has 12 inherited SmartExtract failures in untouched job_url runtime paths. Those are intentionally reserved for the runtime cutover.
