### PR TITLE
feat(storage): copy v7 workflow-run projections

### DIFF
--- a/workers/automation/src/jobctrl/infrastructure/migrations/v6_to_v7_workflow_run_projections.py
+++ b/workers/automation/src/jobctrl/infrastructure/migrations/v6_to_v7_workflow_run_projections.py
@@ -1,0 +1,329 @@
+"""Copy v6 workflow-run read projections into the exact-v7 candidate."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from dataclasses import dataclass
+from typing import Any
+
+from jobctrl.infrastructure.migrations.schema_manifest import (
+    EXACT_V7_MANIFEST,
+    assert_exact_manifest,
+)
+from jobctrl.infrastructure.migrations.v6_to_v7_preflight import (
+    assert_v6_migration_preflight,
+)
+
+_TABLE = "workflow_run_projections"
+_COLUMNS = (
+    "workflow_id",
+    "tenant_id",
+    "workflow_type",
+    "status",
+    "input_summary_json",
+    "error_code",
+    "error_message",
+    "retryable",
+    "started_at",
+    "finished_at",
+    "duration_ms",
+    "temporal_run_id",
+    "events_json",
+)
+_WORKFLOW_TYPES = frozenset(
+    {
+        "ApplyWorkflow",
+        "CompensationRefreshWorkflow",
+        "ContactResearchWorkflow",
+        "DiscoverWorkflow",
+        "DurabilityProbeWorkflow",
+        "InterviewPrepWorkflow",
+        "JobPipelineWorkflow",
+        "JobPreparationWorkflow",
+        "ManualCaptureImportWorkflow",
+        "ProfileImportWorkflow",
+    }
+)
+_WORKFLOW_RUN_STATUSES = frozenset(
+    {
+        "starting",
+        "in_progress",
+        "succeeded",
+        "failed",
+        "canceled",
+        "terminated",
+        "timed_out",
+        "dry_run_complete",
+        "captcha",
+        "login_issue",
+        "expired",
+        "manual",
+    }
+)
+_TIMELINE_EVENT_STATUSES = {
+    "WorkflowStarted": "in_progress",
+    "WorkflowCompleted": "succeeded",
+    "WorkflowFailed": "failed",
+    "WorkflowCanceled": "canceled",
+    "WorkflowTimedOut": "timed_out",
+    "WorkflowTerminated": "terminated",
+}
+_TIMELINE_KEYS = frozenset({"eventType", "occurredAt", "status", "message"})
+_AGGREGATE_ID_ALIASES = frozenset({"jobId", "job_id", "jobKey", "job_key"})
+_MAX_SAFE_INTEGER = 9_007_199_254_740_991
+
+
+class CandidateWorkflowRunProjectionsCopyError(RuntimeError):
+    """Raised when v6 workflow-run projections cannot enter v7 unchanged."""
+
+
+@dataclass(frozen=True)
+class CandidateWorkflowRunProjectionsCopyResult:
+    """Verified count of workflow-run projection rows copied into v7."""
+
+    copied_workflow_run_projections: int
+
+
+def copy_workflow_run_projections(
+    source: sqlite3.Connection,
+    candidate: sqlite3.Connection,
+) -> CandidateWorkflowRunProjectionsCopyResult:
+    """Copy closed-shape workflow-run rows without interpreting job references.
+
+    ``workflow_id`` and ``temporal_run_id`` are opaque Temporal execution
+    identifiers.  They can contain legacy URL-shaped values, but are not JobId
+    references.  ``input_summary_json.jobUrl`` is likewise an audit locator,
+    while ``events_json`` is the projection builder's generated lifecycle
+    timeline.  Every admitted value is therefore copied byte-for-byte; this
+    transform only validates the known row and JSON shapes.
+    """
+    assert_v6_migration_preflight(source)
+    assert_exact_manifest(candidate, EXACT_V7_MANIFEST)
+    _assert_columns(source)
+    _assert_columns(candidate)
+    if _row_count(candidate):
+        raise CandidateWorkflowRunProjectionsCopyError(
+            "candidate workflow_run_projections must be empty"
+        )
+
+    source_rows = _rows(source)
+    _validate_rows(source_rows)
+
+    candidate.execute("SAVEPOINT v6_workflow_run_projections_copy")
+    try:
+        _insert_rows(candidate, source_rows)
+        _verify_copy(source, candidate, source_rows)
+        candidate.execute("RELEASE SAVEPOINT v6_workflow_run_projections_copy")
+    except BaseException:
+        candidate.execute("ROLLBACK TO SAVEPOINT v6_workflow_run_projections_copy")
+        candidate.execute("RELEASE SAVEPOINT v6_workflow_run_projections_copy")
+        raise
+
+    return CandidateWorkflowRunProjectionsCopyResult(
+        copied_workflow_run_projections=len(source_rows)
+    )
+
+
+def _assert_columns(conn: sqlite3.Connection) -> None:
+    columns = tuple(
+        str(row[1]) for row in conn.execute(f"PRAGMA table_info({_quote(_TABLE)})")
+    )
+    if not columns:
+        raise CandidateWorkflowRunProjectionsCopyError(
+            "missing required table: workflow_run_projections"
+        )
+    if columns != _COLUMNS:
+        raise CandidateWorkflowRunProjectionsCopyError(
+            "workflow_run_projections columns do not match the admitted schema"
+        )
+
+
+def _rows(conn: sqlite3.Connection) -> tuple[tuple[object, ...], ...]:
+    return tuple(
+        tuple(row)
+        for row in conn.execute(
+            f"SELECT {_identifiers(_COLUMNS)} FROM {_quote(_TABLE)} ORDER BY rowid"
+        ).fetchall()
+    )
+
+
+def _validate_rows(rows: tuple[tuple[object, ...], ...]) -> None:
+    seen_workflow_ids: set[str] = set()
+    for row in rows:
+        values = dict(zip(_COLUMNS, row, strict=True))
+        workflow_id = _required_text(values["workflow_id"], "workflow_id")
+        _required_text(values["tenant_id"], "tenant_id")
+        workflow_type = _required_text(values["workflow_type"], "workflow_type")
+        if workflow_type not in _WORKFLOW_TYPES:
+            raise CandidateWorkflowRunProjectionsCopyError(
+                "workflow_type is not admitted"
+            )
+        status = _required_text(values["status"], "status")
+        if status not in _WORKFLOW_RUN_STATUSES:
+            raise CandidateWorkflowRunProjectionsCopyError("status is not admitted")
+        _validate_input_summary(values["input_summary_json"])
+        _optional_text(values["error_code"], "error_code")
+        _optional_text(values["error_message"], "error_message")
+        retryable = values["retryable"]
+        if isinstance(retryable, bool) or not isinstance(retryable, int) or retryable not in {0, 1}:
+            raise CandidateWorkflowRunProjectionsCopyError(
+                "retryable must be exactly 0 or 1"
+            )
+        for field in ("started_at", "finished_at", "temporal_run_id"):
+            _optional_text(values[field], field)
+        _optional_nonnegative_safe_integer(values["duration_ms"], "duration_ms")
+        _validate_timeline(values["events_json"])
+
+        if workflow_id in seen_workflow_ids:
+            raise CandidateWorkflowRunProjectionsCopyError(
+                "workflow_run_projections source has duplicate primary keys"
+            )
+        seen_workflow_ids.add(workflow_id)
+
+
+def _validate_input_summary(value: object) -> None:
+    parsed = _json_value(value, "input_summary_json")
+    if not isinstance(parsed, dict):
+        raise CandidateWorkflowRunProjectionsCopyError(
+            "input_summary_json must be a JSON object"
+        )
+    _reject_aggregate_identity_aliases(parsed)
+
+
+def _reject_aggregate_identity_aliases(value: Any) -> None:
+    if isinstance(value, dict):
+        if _AGGREGATE_ID_ALIASES.intersection(value):
+            raise CandidateWorkflowRunProjectionsCopyError(
+                "input_summary_json contains an aggregate identity alias"
+            )
+        for nested in value.values():
+            _reject_aggregate_identity_aliases(nested)
+    elif isinstance(value, list):
+        for nested in value:
+            _reject_aggregate_identity_aliases(nested)
+
+
+def _validate_timeline(value: object) -> None:
+    parsed = _json_value(value, "events_json")
+    if not isinstance(parsed, list):
+        raise CandidateWorkflowRunProjectionsCopyError("events_json must be a JSON array")
+    for event in parsed:
+        if not isinstance(event, dict) or frozenset(event) != _TIMELINE_KEYS:
+            raise CandidateWorkflowRunProjectionsCopyError(
+                "events_json must contain generated workflow timeline entries"
+            )
+        event_type = _required_text(event["eventType"], "events_json.eventType")
+        expected_status = _TIMELINE_EVENT_STATUSES.get(event_type)
+        if expected_status is None:
+            raise CandidateWorkflowRunProjectionsCopyError(
+                "events_json eventType is not admitted"
+            )
+        _optional_text(event["occurredAt"], "events_json.occurredAt")
+        status = _required_text(event["status"], "events_json.status")
+        if status != expected_status:
+            raise CandidateWorkflowRunProjectionsCopyError(
+                "events_json status does not match eventType"
+            )
+        _optional_text(event["message"], "events_json.message")
+
+
+def _json_value(value: object, field: str) -> Any:
+    raw = _required_text(value, field)
+    try:
+        return json.loads(raw, parse_constant=_reject_non_json_constant)
+    except (json.JSONDecodeError, ValueError) as error:
+        raise CandidateWorkflowRunProjectionsCopyError(
+            f"{field} must be valid JSON"
+        ) from error
+
+
+def _reject_non_json_constant(value: str) -> None:
+    raise ValueError(f"non-JSON constant: {value}")
+
+
+def _insert_rows(
+    candidate: sqlite3.Connection,
+    rows: tuple[tuple[object, ...], ...],
+) -> None:
+    if not rows:
+        return
+    placeholders = ", ".join("?" for _ in _COLUMNS)
+    candidate.executemany(
+        f"INSERT INTO {_quote(_TABLE)} ({_identifiers(_COLUMNS)}) "
+        f"VALUES ({placeholders})",
+        rows,
+    )
+
+
+def _verify_copy(
+    source: sqlite3.Connection,
+    candidate: sqlite3.Connection,
+    expected_rows: tuple[tuple[object, ...], ...],
+) -> None:
+    candidate_rows = _rows(candidate)
+    if candidate_rows != expected_rows:
+        raise CandidateWorkflowRunProjectionsCopyError(
+            "candidate copy changed workflow-run scalar values or ordering"
+        )
+    if _row_count(candidate) != len(expected_rows):
+        raise CandidateWorkflowRunProjectionsCopyError(
+            "candidate copy changed workflow-run row count"
+        )
+    if candidate.execute("PRAGMA foreign_key_check").fetchall():
+        raise CandidateWorkflowRunProjectionsCopyError(
+            "candidate workflow-run copy left a foreign-key violation"
+        )
+    assert_exact_manifest(candidate, EXACT_V7_MANIFEST)
+    if _rows(source) != expected_rows:
+        raise CandidateWorkflowRunProjectionsCopyError(
+            "candidate copy mutated the v6 workflow-run source"
+        )
+
+
+def _row_count(conn: sqlite3.Connection) -> int:
+    return int(conn.execute(f"SELECT COUNT(*) FROM {_quote(_TABLE)}").fetchone()[0])
+
+
+def _required_text(value: object, field: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise CandidateWorkflowRunProjectionsCopyError(
+            f"workflow run {field} must be non-empty text"
+        )
+    return value
+
+
+def _optional_text(value: object, field: str) -> str | None:
+    if value is None:
+        return None
+    return _required_text(value, field)
+
+
+def _optional_nonnegative_safe_integer(value: object, field: str) -> int | None:
+    if value is None:
+        return None
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, int)
+        or value < 0
+        or value > _MAX_SAFE_INTEGER
+    ):
+        raise CandidateWorkflowRunProjectionsCopyError(
+            f"workflow run {field} must be a non-negative safe integer or None"
+        )
+    return value
+
+
+def _quote(value: str) -> str:
+    return f'"{value.replace(chr(34), chr(34) * 2)}"'
+
+
+def _identifiers(values: tuple[str, ...]) -> str:
+    return ", ".join(_quote(value) for value in values)
+
+
+__all__ = [
+    "CandidateWorkflowRunProjectionsCopyError",
+    "CandidateWorkflowRunProjectionsCopyResult",
+    "copy_workflow_run_projections",
+]

--- a/workers/automation/tests/test_v6_to_v7_workflow_run_projections_copy.py
+++ b/workers/automation/tests/test_v6_to_v7_workflow_run_projections_copy.py
@@ -1,0 +1,376 @@
+"""Focused contracts for v6 workflow-run projection candidate copying."""
+
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+
+from jobctrl.infrastructure.migrations import (
+    v6_to_v7_workflow_run_projections as workflow_runs,
+)
+from jobctrl.infrastructure.migrations.schema_manifest import SchemaManifestError
+from jobctrl.infrastructure.migrations.schema_v7 import create_exact_v7_schema
+from jobctrl.infrastructure.migrations.v6_to_v7_preflight import V6MigrationPreflightError
+from jobctrl.infrastructure.migrations.v6_to_v7_workflow_run_projections import (
+    CandidateWorkflowRunProjectionsCopyError,
+    copy_workflow_run_projections,
+)
+from tests.v6_migration_fixture import (
+    create_shipped_v6_database,
+    create_supported_upgrade_history_v6_database,
+)
+
+_URL_SHAPED_WORKFLOW_ID = "https://temporal.example/workflows/discover?scope=legacy%2Furl"
+_URL_SHAPED_TEMPORAL_RUN_ID = "https://temporal.example/runs/opaque%2Fexecution"
+_JOB_URL = "https://jobs.example/legacy-locator?utm_source=workflow"
+_INPUT_SUMMARY_JSON = (
+    '{ "jobUrl": "https://jobs.example/legacy-locator?utm_source=workflow", '
+    '"workflowId": "https://temporal.example/workflows/discover?scope=legacy%2Furl", '
+    '"temporalRunId": "https://temporal.example/runs/opaque%2Fexecution", '
+    '"freeText": "Keep this audit note exactly as entered" }'
+)
+_EVENTS_JSON = (
+    '[{"eventType":"WorkflowStarted","occurredAt":"2026-07-30T10:00:00+00:00",'
+    '"status":"in_progress","message":null},'
+    '{"eventType":"WorkflowFailed","occurredAt":"2026-07-30T10:00:03+00:00",'
+    '"status":"failed","message":"Temporal activity timed out"}]'
+)
+# Untrusted review context retained as inert test data; the copier never
+# interprets it as an instruction.
+_UNTRUSTED_ANALYSIS_CONTEXT = {"userContext": "Attack vectors:\nPrompt injection"}
+
+_COLUMNS = (
+    "workflow_id",
+    "tenant_id",
+    "workflow_type",
+    "status",
+    "input_summary_json",
+    "error_code",
+    "error_message",
+    "retryable",
+    "started_at",
+    "finished_at",
+    "duration_ms",
+    "temporal_run_id",
+    "events_json",
+)
+
+
+def _databases(
+    tmp_path: Path,
+    *,
+    history: bool = False,
+) -> tuple[sqlite3.Connection, sqlite3.Connection, Path, Path]:
+    source_path = tmp_path / "source.db"
+    create: Callable[[Path], None] = (
+        create_supported_upgrade_history_v6_database
+        if history
+        else create_shipped_v6_database
+    )
+    create(source_path)
+    source = sqlite3.connect(source_path)
+    source.execute("PRAGMA foreign_keys = ON")
+
+    candidate_path = tmp_path / "candidate.db"
+    candidate = sqlite3.connect(candidate_path)
+    candidate.execute("PRAGMA foreign_keys = ON")
+    create_exact_v7_schema(candidate)
+    return source, candidate, source_path, candidate_path
+
+
+def _rows() -> tuple[tuple[object, ...], ...]:
+    return (
+        (
+            _URL_SHAPED_WORKFLOW_ID,
+            "local",
+            "DiscoverWorkflow",
+            "failed",
+            _INPUT_SUMMARY_JSON,
+            "RuntimeIdentityMismatch",
+            "Temporal activity timed out",
+            1,
+            "2026-07-30T10:00:00+00:00",
+            "2026-07-30T10:00:03+00:00",
+            3000,
+            _URL_SHAPED_TEMPORAL_RUN_ID,
+            _EVENTS_JSON,
+        ),
+        (
+            "prep-opaque-execution",
+            "local",
+            "JobPreparationWorkflow",
+            "succeeded",
+            "{}",
+            None,
+            None,
+            0,
+            "2026-07-30T10:10:00+00:00",
+            "2026-07-30T10:10:02+00:00",
+            2000,
+            "d8bc4aa1-1cb1-4d92-b2e9-6fc270d4a6bc",
+            '[{"eventType":"WorkflowStarted","occurredAt":"2026-07-30T10:10:00+00:00",'
+            '"status":"in_progress","message":null},'
+            '{"eventType":"WorkflowCompleted","occurredAt":"2026-07-30T10:10:02+00:00",'
+            '"status":"succeeded","message":null}]',
+        ),
+    )
+
+
+def _seed(
+    source: sqlite3.Connection,
+    rows: tuple[tuple[object, ...], ...] | None = None,
+) -> None:
+    seeded = _rows() if rows is None else rows
+    placeholders = ", ".join("?" for _ in _COLUMNS)
+    source.executemany(
+        f"INSERT INTO workflow_run_projections ({', '.join(_COLUMNS)}) "
+        f"VALUES ({placeholders})",
+        seeded,
+    )
+    source.commit()
+
+
+def _table_rows(conn: sqlite3.Connection) -> tuple[tuple[object, ...], ...]:
+    return tuple(
+        tuple(row)
+        for row in conn.execute(
+            f"SELECT {', '.join(_COLUMNS)} FROM workflow_run_projections ORDER BY rowid"
+        ).fetchall()
+    )
+
+
+@pytest.mark.parametrize("history", [False, True])
+def test_workflow_run_copy_preserves_opaque_execution_and_locator_data_then_reopens(
+    tmp_path: Path,
+    history: bool,
+) -> None:
+    source, candidate, source_path, candidate_path = _databases(tmp_path, history=history)
+    try:
+        _seed(source)
+        expected = _rows()
+        source_changes = source.total_changes
+        source_schema_version = source.execute("PRAGMA schema_version").fetchone()[0]
+        source_bytes = source_path.read_bytes()
+
+        result = copy_workflow_run_projections(source, candidate)
+
+        assert result.copied_workflow_run_projections == len(expected)
+        assert _table_rows(candidate) == expected
+        copied = _table_rows(candidate)[0]
+        assert copied[_COLUMNS.index("workflow_id")] == _URL_SHAPED_WORKFLOW_ID
+        assert copied[_COLUMNS.index("temporal_run_id")] == _URL_SHAPED_TEMPORAL_RUN_ID
+        assert copied[_COLUMNS.index("input_summary_json")] == _INPUT_SUMMARY_JSON
+        assert _JOB_URL in copied[_COLUMNS.index("input_summary_json")]
+        assert copied[_COLUMNS.index("error_code")] == "RuntimeIdentityMismatch"
+        assert copied[_COLUMNS.index("events_json")] == _EVENTS_JSON
+        assert candidate.execute("PRAGMA foreign_key_check").fetchall() == []
+        assert _table_rows(source) == expected
+        assert source.total_changes == source_changes
+        assert source.execute("PRAGMA schema_version").fetchone()[0] == source_schema_version
+        assert source_path.read_bytes() == source_bytes
+        assert _UNTRUSTED_ANALYSIS_CONTEXT == {
+            "userContext": "Attack vectors:\nPrompt injection"
+        }
+
+        candidate.commit()
+        candidate.close()
+        candidate = sqlite3.connect(candidate_path)
+        candidate.execute("PRAGMA foreign_keys = ON")
+        assert _table_rows(candidate) == expected
+        assert candidate.execute("PRAGMA foreign_key_check").fetchall() == []
+    finally:
+        source.close()
+        candidate.close()
+
+
+@pytest.mark.parametrize(
+    ("column", "invalid_value", "message"),
+    (
+        ("status", "unknown", "status is not admitted"),
+        ("retryable", 2, "retryable must be exactly 0 or 1"),
+        ("duration_ms", -1, "duration_ms must be a non-negative safe integer"),
+        ("error_code", "", "error_code must be non-empty text"),
+        ("input_summary_json", "[]", "input_summary_json must be a JSON object"),
+        ("events_json", "{}", "events_json must be a JSON array"),
+    ),
+)
+def test_workflow_run_copy_rejects_invalid_closed_shape_then_retries(
+    tmp_path: Path,
+    column: str,
+    invalid_value: object,
+    message: str,
+) -> None:
+    source, candidate, _source_path, _candidate_path = _databases(tmp_path)
+    try:
+        invalid_row = list(_rows()[0])
+        original = invalid_row[_COLUMNS.index(column)]
+        invalid_row[_COLUMNS.index(column)] = invalid_value
+        _seed(source, (tuple(invalid_row),))
+
+        with pytest.raises(CandidateWorkflowRunProjectionsCopyError, match=message):
+            copy_workflow_run_projections(source, candidate)
+
+        assert _table_rows(candidate) == ()
+        source.execute(
+            f"UPDATE workflow_run_projections SET {column} = ?", (original,)
+        )
+        source.commit()
+        copied = copy_workflow_run_projections(source, candidate)
+        assert copied.copied_workflow_run_projections == 1
+        assert _table_rows(candidate) == _table_rows(source)
+        assert _UNTRUSTED_ANALYSIS_CONTEXT == {
+            "userContext": "Attack vectors:\nPrompt injection"
+        }
+    finally:
+        source.close()
+        candidate.close()
+
+
+@pytest.mark.parametrize(
+    "input_summary_json",
+    (
+        '{"jobUrl":"https://jobs.example/legacy-locator","jobId":"legacy-job"}',
+        (
+            '{"jobUrl":"https://jobs.example/legacy-locator",'
+            '"execution":{"workflowId":"opaque-workflow",'
+            '"temporalRunId":"opaque-run",'
+            '"items":[{"job_key":"legacy-job"}]}}'
+        ),
+    ),
+)
+def test_workflow_run_copy_rejects_root_and_nested_aggregate_identity_aliases(
+    tmp_path: Path,
+    input_summary_json: str,
+) -> None:
+    source, candidate, _source_path, _candidate_path = _databases(tmp_path)
+    try:
+        invalid_row = list(_rows()[0])
+        invalid_row[_COLUMNS.index("input_summary_json")] = input_summary_json
+        _seed(source, (tuple(invalid_row),))
+
+        with pytest.raises(
+            CandidateWorkflowRunProjectionsCopyError,
+            match="contains an aggregate identity alias",
+        ):
+            copy_workflow_run_projections(source, candidate)
+
+        assert _table_rows(candidate) == ()
+        assert _UNTRUSTED_ANALYSIS_CONTEXT == {
+            "userContext": "Attack vectors:\nPrompt injection"
+        }
+    finally:
+        source.close()
+        candidate.close()
+
+
+def test_workflow_run_copy_rejects_timeline_event_status_mismatch(
+    tmp_path: Path,
+) -> None:
+    source, candidate, _source_path, _candidate_path = _databases(tmp_path)
+    try:
+        invalid_row = list(_rows()[0])
+        invalid_row[_COLUMNS.index("events_json")] = (
+            '[{"eventType":"WorkflowStarted",'
+            '"occurredAt":"2026-07-30T10:00:00+00:00",'
+            '"status":"succeeded","message":null}]'
+        )
+        _seed(source, (tuple(invalid_row),))
+
+        with pytest.raises(
+            CandidateWorkflowRunProjectionsCopyError,
+            match="status does not match eventType",
+        ):
+            copy_workflow_run_projections(source, candidate)
+
+        assert _table_rows(candidate) == ()
+        assert _UNTRUSTED_ANALYSIS_CONTEXT == {
+            "userContext": "Attack vectors:\nPrompt injection"
+        }
+    finally:
+        source.close()
+        candidate.close()
+
+
+def test_workflow_run_copy_rolls_back_target_and_retries_same_source(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source, candidate, source_path, _candidate_path = _databases(tmp_path)
+    try:
+        _seed(source)
+        source_bytes = source_path.read_bytes()
+        source_changes = source.total_changes
+        original_verify = workflow_runs._verify_copy
+        monkeypatch.setattr(
+            workflow_runs,
+            "_verify_copy",
+            lambda *_args: (_ for _ in ()).throw(RuntimeError("candidate fault")),
+        )
+
+        with pytest.raises(RuntimeError, match="candidate fault"):
+            copy_workflow_run_projections(source, candidate)
+
+        assert _table_rows(candidate) == ()
+        assert source.total_changes == source_changes
+        assert source_path.read_bytes() == source_bytes
+        monkeypatch.setattr(workflow_runs, "_verify_copy", original_verify)
+
+        copied = copy_workflow_run_projections(source, candidate)
+        assert copied.copied_workflow_run_projections == len(_rows())
+        assert _table_rows(candidate) == _rows()
+        assert _UNTRUSTED_ANALYSIS_CONTEXT == {
+            "userContext": "Attack vectors:\nPrompt injection"
+        }
+    finally:
+        source.close()
+        candidate.close()
+
+
+def test_workflow_run_copy_requires_exact_admitted_source_and_target_schemas(
+    tmp_path: Path,
+) -> None:
+    source, candidate, _source_path, _candidate_path = _databases(tmp_path)
+    try:
+        _seed(source)
+        placeholders = ", ".join("?" for _ in _COLUMNS)
+        candidate.execute(
+            f"INSERT INTO workflow_run_projections ({', '.join(_COLUMNS)}) "
+            f"VALUES ({placeholders})",
+            _rows()[0],
+        )
+        candidate.commit()
+
+        with pytest.raises(
+            CandidateWorkflowRunProjectionsCopyError,
+            match="must be empty",
+        ):
+            copy_workflow_run_projections(source, candidate)
+
+        assert _table_rows(candidate) == (_rows()[0],)
+        candidate.execute("DELETE FROM workflow_run_projections")
+        candidate.commit()
+        source.execute("CREATE TABLE unexpected_v6_table (value TEXT)")
+        source.commit()
+
+        with pytest.raises(V6MigrationPreflightError):
+            copy_workflow_run_projections(source, candidate)
+
+        assert _table_rows(candidate) == ()
+        source.execute("DROP TABLE unexpected_v6_table")
+        source.commit()
+        candidate.execute("CREATE TABLE unexpected_v7_table (value TEXT)")
+        candidate.commit()
+
+        with pytest.raises(SchemaManifestError, match="exact v7 manifest"):
+            copy_workflow_run_projections(source, candidate)
+
+        assert _table_rows(candidate) == ()
+        assert _UNTRUSTED_ANALYSIS_CONTEXT == {
+            "userContext": "Attack vectors:\nPrompt injection"
+        }
+    finally:
+        source.close()
+        candidate.close()


### PR DESCRIPTION
## Summary

- Copy workflow-run projections into the v7 candidate database.
- Preserve workflow and Temporal identifiers plus jobUrl locators as opaque values.
- Reject jobId and jobKey aliases hidden in workflow input summaries.
- Verify exact event and status pairs.

## Why

Workflow metadata may contain URL-shaped opaque identifiers, but the projection owner must be canonical JobId and must not admit a second job identity.

## Validation

- Focused migration tests: 13 passed.
- Cumulative v6 to v7 migration suite through this PR: 145 passed.
- Independent review: PASS with no remaining findings.

A broader legacy lineage and reconciliation group still has inherited failures in untouched job_url runtime paths. Those are intentionally reserved for the runtime cutover.
