### PR TITLE
feat(contracts): canonicalize detail projection job ids

### DIFF
--- a/apps/api/src/projections.ts
+++ b/apps/api/src/projections.ts
@@ -1908,7 +1908,7 @@ function loadRequirementFitReportJson(
     [tenantId, jobUrl, scoreVersion],
   );
   const readModel = {
-    jobKey: row.job_url,
+    jobId: jobUrl,
     scoreVersion,
     employerAnalysisGeneration: Number(row.employer_analysis_generation ?? 0),
     profileSnapshotVersion: Number(row.profile_snapshot_version ?? 0),
@@ -1972,7 +1972,7 @@ function loadInterviewPrepJson(
     [tenantId, jobUrl, generation],
   );
   const readModel = {
-    jobKey: row.job_url,
+    jobId: jobUrl,
     generation,
     status: row.status,
     generatedAt: row.generated_at,

--- a/apps/api/test/projections.test.ts
+++ b/apps/api/test/projections.test.ts
@@ -2521,7 +2521,7 @@ describe("apply_run_projections without legacy apply_runs table", () => {
         expect(detailRes.statusCode, detailRes.body).toBe(200);
         const report = detailRes.json().requirementFitReport;
         expect(report).toMatchObject({
-          jobKey: jobUrl,
+          jobId: jobUrl,
           scoreVersion: 2,
           employerAnalysisGeneration: 2,
           profileSnapshotVersion: 3,
@@ -2537,6 +2537,7 @@ describe("apply_run_projections without legacy apply_runs table", () => {
             missingHighWeightCount: 0,
           },
         });
+        expect(report).not.toHaveProperty("jobKey");
         expect(report.assessments[0]).toMatchObject({
           requirementId: "r1",
           requirementText: "5+ years Python",

--- a/packages/contracts/src/schemas.ts
+++ b/packages/contracts/src/schemas.ts
@@ -2362,7 +2362,7 @@ export interface RequirementFitSummary {
 }
 
 export interface RequirementFitReport {
-  jobKey: string;
+  jobId: string;
   scoreVersion: number;
   employerAnalysisGeneration: number;
   profileSnapshotVersion: number;
@@ -2506,7 +2506,7 @@ export interface InterviewPrepItem {
 }
 
 export interface InterviewPrep {
-  jobKey: string;
+  jobId: string;
   generation: number;
   status: InterviewPrepStatus;
   generatedAt: string;

--- a/packages/domain-types/src/interview/index.ts
+++ b/packages/domain-types/src/interview/index.ts
@@ -41,7 +41,7 @@ export interface InterviewPrepItem {
 }
 
 export interface InterviewPrep {
-  readonly jobKey: string;
+  readonly jobId: string;
   readonly generation: number;
   readonly status: InterviewPrepStatus;
   readonly generatedAt: string;

--- a/packages/domain-types/src/scoring/score.ts
+++ b/packages/domain-types/src/scoring/score.ts
@@ -179,7 +179,7 @@ export interface RequirementFitSummary {
 }
 
 export interface RequirementFitReport {
-  readonly jobKey: string;
+  readonly jobId: string;
   readonly scoreVersion: number;
   readonly employerAnalysisGeneration: number;
   readonly profileSnapshotVersion: number;

--- a/packages/domain-types/test/fixtures/audit_projection_parity.json
+++ b/packages/domain-types/test/fixtures/audit_projection_parity.json
@@ -735,7 +735,7 @@
             ]
           }
         ],
-        "jobKey": "https://example.com/jobs/parity-developer-platform",
+        "jobId": "https://example.com/jobs/parity-developer-platform",
         "model": "gpt-test",
         "status": "accepted"
       },
@@ -1170,7 +1170,7 @@
       ]
     },
     "interviewPrepJson": {
-      "jobKey": "https://example.com/jobs/parity-developer-platform",
+      "jobId": "https://example.com/jobs/parity-developer-platform",
       "generation": 2,
       "status": "accepted",
       "generatedAt": "2026-06-08T12:25:00+00:00",

--- a/packages/domain-types/test/operations.test.ts
+++ b/packages/domain-types/test/operations.test.ts
@@ -67,12 +67,73 @@ describe("Operations projection types", () => {
       scoreVersion: listProjection.scoreVersion,
       scoredAt: listProjection.scoredAt,
       stages: [],
-      requirementFitReport: null,
-      interviewPrep: null,
+      requirementFitReport: {
+        jobId: listProjection.jobId,
+        scoreVersion: 2,
+        employerAnalysisGeneration: 1,
+        profileSnapshotVersion: 3,
+        scoringPolicyVersion: 4,
+        formulaVersion: "requirement-fit-v1",
+        resolvedFitScore: 8,
+        fitBand: "strong",
+        confidence: "high",
+        summary: {
+          weightedFit: 0.8,
+          mustHaveCoverage: 1,
+          blockerCount: 0,
+          missingHighWeightCount: 0,
+        },
+        assessments: [
+          {
+            requirementId: "r1",
+            requirementText: "Build Python services",
+            tier: "must_have",
+            weight: 1,
+            jobEvidenceSpan: "Python services",
+            fit: {
+              kind: "matched",
+              evidenceIds: ["evidence-python"],
+              strength: "direct",
+            },
+            contribution: {
+              maxPoints: 10,
+              awardedPoints: 10,
+              weightedImpact: 0.8,
+              rationale: "Direct evidence.",
+            },
+            tailoring: {
+              action: "double_down",
+              priority: 1,
+              allowedEvidenceIds: ["evidence-python"],
+              targetKeywords: ["python"],
+              prohibitedClaims: [],
+              instruction: "Use the existing evidence.",
+            },
+            artifactCoverage: null,
+          },
+        ],
+      },
+      interviewPrep: {
+        jobId: listProjection.jobId,
+        generation: 1,
+        status: "accepted",
+        generatedAt: "2026-05-05T09:30:00+00:00",
+        model: "gpt-test",
+        gateAudit: {
+          status: "passed",
+          fabricationFindings: [],
+          groundingFindings: [],
+          judgeVerdict: "grounded",
+          warnings: [],
+        },
+        items: [],
+      },
       lastUpdatedAt: listProjection.lastUpdatedAt,
     };
 
     expect(listProjection.scoreBreakdown?.technicalFit).toBe(9);
     expect(detailProjection.scoreKeywords).toEqual(["python", "fastapi"]);
+    expect(detailProjection.requirementFitReport?.jobId).toBe(listProjection.jobId);
+    expect(detailProjection.interviewPrep?.jobId).toBe(listProjection.jobId);
   });
 });

--- a/workers/automation/src/jobctrl/domain/interview/use_cases.py
+++ b/workers/automation/src/jobctrl/domain/interview/use_cases.py
@@ -227,7 +227,7 @@ class GenerateInterviewPrepUseCase:
             warnings=tuple(dict.fromkeys((*gate.warnings, *judge.warnings))),
         )
         prep = InterviewPrep(
-            job_key=str(job_id),
+            job_id=str(job_id),
             generation=generation,
             status="accepted",
             generated_at=generated_at,
@@ -337,7 +337,7 @@ class GenerateInterviewPrepUseCase:
             warnings=warnings,
         )
         prep = InterviewPrep(
-            job_key=str(job_id),
+            job_id=str(job_id),
             generation=generation,
             status="failed",
             generated_at=generated_at,
@@ -361,7 +361,7 @@ class GenerateInterviewPrepUseCase:
                 create_interview_prep_generated(
                     tenant_id,
                     InterviewPrepGeneratedPayload(
-                        job_id=prep.job_key,
+                        job_id=prep.job_id,
                         generation=prep.generation,
                         item_count=len(prep.items),
                         generated_at=prep.generated_at,
@@ -369,7 +369,7 @@ class GenerateInterviewPrepUseCase:
                 )
             )
         except Exception:  # noqa: BLE001
-            log.exception("Failed to publish InterviewPrepGenerated for %s", prep.job_key)
+            log.exception("Failed to publish InterviewPrepGenerated for %s", prep.job_id)
 
     def _publish_failed(self, tenant_id: TenantId, prep: InterviewPrep) -> None:
         if self._publisher is None:
@@ -382,7 +382,7 @@ class GenerateInterviewPrepUseCase:
                 create_interview_prep_failed(
                     tenant_id,
                     InterviewPrepFailedPayload(
-                        job_id=prep.job_key,
+                        job_id=prep.job_id,
                         generation=prep.generation,
                         failed_at=prep.generated_at,
                         reason_count=reason_count,
@@ -390,7 +390,7 @@ class GenerateInterviewPrepUseCase:
                 )
             )
         except Exception:  # noqa: BLE001
-            log.exception("Failed to publish InterviewPrepFailed for %s", prep.job_key)
+            log.exception("Failed to publish InterviewPrepFailed for %s", prep.job_id)
 
 
 def _outcome_from_existing(prep: InterviewPrep) -> InterviewPrepGenerationOutcome:

--- a/workers/automation/src/jobctrl/domain/interview/value_objects.py
+++ b/workers/automation/src/jobctrl/domain/interview/value_objects.py
@@ -138,7 +138,7 @@ class InterviewPrepItem:
 class InterviewPrep:
     """Generation-versioned prep for one job application."""
 
-    job_key: str
+    job_id: str
     generation: int
     status: InterviewPrepStatus
     generated_at: str
@@ -147,8 +147,8 @@ class InterviewPrep:
     model: str | None = None
 
     def __post_init__(self) -> None:
-        if not self.job_key.strip():
-            raise ValueError("InterviewPrep.job_key must be non-empty")
+        if not self.job_id.strip():
+            raise ValueError("InterviewPrep.job_id must be non-empty")
         if self.generation < 1:
             raise ValueError("InterviewPrep.generation must be >= 1")
         if self.status not in INTERVIEW_PREP_STATUSES:
@@ -167,7 +167,7 @@ class InterviewPrep:
 
     def to_read_model(self) -> dict[str, Any]:
         return {
-            "jobKey": self.job_key,
+            "jobId": self.job_id,
             "generation": self.generation,
             "status": self.status,
             "generatedAt": self.generated_at,
@@ -179,7 +179,7 @@ class InterviewPrep:
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> "InterviewPrep":
         return cls(
-            job_key=str(data["jobKey"]),
+            job_id=str(data["jobId"]),
             generation=int(data["generation"]),
             status=str(data["status"]),  # type: ignore[arg-type]
             generated_at=str(data["generatedAt"]),

--- a/workers/automation/src/jobctrl/domain/scoring/value_objects.py
+++ b/workers/automation/src/jobctrl/domain/scoring/value_objects.py
@@ -841,7 +841,7 @@ class RequirementFitReport:
     def from_dict(cls, data: dict[str, Any] | None) -> "RequirementFitReport":
         data = data or {}
         return cls(
-            job_id=str(data.get("job_id", data.get("jobKey", data.get("jobId", ""))) or ""),
+            job_id=str(data.get("job_id", data.get("jobId", "")) or ""),
             score_version=_int_or_default(data.get("score_version", data.get("scoreVersion", 0)), 0),
             employer_analysis_generation=_int_or_default(
                 data.get("employer_analysis_generation", data.get("employerAnalysisGeneration", 0)),
@@ -892,7 +892,7 @@ class RequirementFitReport:
         """Serialise the API/detail DTO for requirement-led fit evidence."""
 
         return {
-            "jobKey": self.job_id,
+            "jobId": self.job_id,
             "scoreVersion": self.score_version,
             "employerAnalysisGeneration": self.employer_analysis_generation,
             "profileSnapshotVersion": self.profile_snapshot_version,

--- a/workers/automation/src/jobctrl/infrastructure/interview/sqlite_repository.py
+++ b/workers/automation/src/jobctrl/infrastructure/interview/sqlite_repository.py
@@ -73,7 +73,7 @@ class SqliteInterviewPrepRepository:
         tenant_id: TenantId,
         origin_run_id: str = "",
     ) -> None:
-        job_url = str(prep.job_key)
+        job_url = str(prep.job_id)
         tenant = str(tenant_id)
         if prep.status == "accepted":
             self._conn.execute(
@@ -220,7 +220,7 @@ class SqliteInterviewPrepRepository:
             warnings=tuple(_load_list(row["warnings_json"])),
         )
         return InterviewPrep(
-            job_key=str(row["job_url"]),
+            job_id=str(row["job_url"]),
             generation=int(row["generation"]),
             status=str(row["status"]),  # type: ignore[arg-type]
             generated_at=str(row["generated_at"]),

--- a/workers/automation/src/jobctrl/infrastructure/projections/projection_builder.py
+++ b/workers/automation/src/jobctrl/infrastructure/projections/projection_builder.py
@@ -2429,7 +2429,10 @@ class ProjectionBuilder:
             return None
         if record is None:
             return None
-        return json.dumps(record.to_read_model(), ensure_ascii=False)
+        read_model = record.to_read_model()
+        read_model.pop("jobKey", None)
+        read_model["jobId"] = job_url
+        return json.dumps(read_model, ensure_ascii=False)
 
     def _load_interview_prep(self, job_url: str) -> str | None:
         """Project the latest accepted interview-prep read shape.
@@ -2447,7 +2450,10 @@ class ProjectionBuilder:
             return None
         if record is None:
             return None
-        return json.dumps(record.to_read_model(), ensure_ascii=False)
+        read_model = record.to_read_model()
+        read_model.pop("jobKey", None)
+        read_model["jobId"] = job_url
+        return json.dumps(read_model, ensure_ascii=False)
 
     def _load_bullet_provenance_by_artifact(self, job_url: str) -> "_ProvenanceProjection":
         """Project provenance + coverage + voice read shapes, keyed by artifact.

--- a/workers/automation/tests/test_detail_projection_job_id_contract.py
+++ b/workers/automation/tests/test_detail_projection_job_id_contract.py
@@ -1,0 +1,51 @@
+"""Job-detail root identities use the current canonical JobId."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from typing import Any
+
+from jobctrl.infrastructure.interview import SqliteInterviewPrepRepository
+from jobctrl.infrastructure.projections.projection_builder import ProjectionBuilder
+from jobctrl.infrastructure.scoring import SqliteRequirementFitReportRepository
+
+
+class _ReadModel:
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self._payload = payload
+
+    def to_read_model(self) -> dict[str, Any]:
+        return dict(self._payload)
+
+
+def test_detail_projection_roots_use_the_passed_job_id_without_job_key(
+    monkeypatch,
+) -> None:
+    conn = sqlite3.connect(":memory:")
+    builder = ProjectionBuilder(conn_factory=lambda: conn)
+    job_id = "00000000-0000-4000-8000-000000000001"
+
+    requirement_fit = _ReadModel(
+        {"jobId": "stale-requirement-fit-job", "jobKey": "obsolete", "scoreVersion": 2}
+    )
+    interview_prep = _ReadModel(
+        {"jobId": "stale-interview-prep-job", "jobKey": "obsolete", "generation": 3}
+    )
+    monkeypatch.setattr(
+        SqliteRequirementFitReportRepository,
+        "load",
+        lambda *_: requirement_fit,
+    )
+    monkeypatch.setattr(
+        SqliteInterviewPrepRepository,
+        "load_latest",
+        lambda *_args, **_kwargs: interview_prep,
+    )
+
+    with builder._bind(conn):
+        requirement_payload = json.loads(builder._load_requirement_fit_report(job_id) or "{}")
+        interview_payload = json.loads(builder._load_interview_prep(job_id) or "{}")
+
+    assert requirement_payload == {"jobId": job_id, "scoreVersion": 2}
+    assert interview_payload == {"jobId": job_id, "generation": 3}

--- a/workers/automation/tests/test_evidence_interview_value_objects.py
+++ b/workers/automation/tests/test_evidence_interview_value_objects.py
@@ -83,7 +83,7 @@ def test_evidence_map_entry_round_trips_to_camel_case_read_model() -> None:
 
 def test_interview_prep_round_trips_and_requires_grounded_star_evidence() -> None:
     prep = InterviewPrep(
-        job_key="job-1",
+        job_id="job-1",
         generation=1,
         status="accepted",
         generated_at="2026-07-05T12:00:00Z",
@@ -110,11 +110,17 @@ def test_interview_prep_round_trips_and_requires_grounded_star_evidence() -> Non
 
     read_model = prep.to_read_model()
 
-    assert read_model["jobKey"] == "job-1"
+    assert read_model["jobId"] == "job-1"
+    assert "jobKey" not in read_model
     assert read_model["gateAudit"]["status"] == "passed"
     assert read_model["items"][0]["kind"] == "star_draft"
     assert read_model["items"][0]["evidenceIds"] == ["evidence-1"]
     assert InterviewPrep.from_dict(read_model).to_read_model() == read_model
+
+    legacy_read_model = dict(read_model)
+    legacy_read_model["jobKey"] = legacy_read_model.pop("jobId")
+    with pytest.raises(KeyError, match="jobId"):
+        InterviewPrep.from_dict(legacy_read_model)
 
     with pytest.raises(ValueError, match="star_draft"):
         InterviewPrepItem(
@@ -133,7 +139,7 @@ def test_interview_prep_has_no_live_assistance_status() -> None:
 
     with pytest.raises(ValueError, match="unknown interview prep status"):
         InterviewPrep(
-            job_key="job-1",
+            job_id="job-1",
             generation=1,
             status="live",  # type: ignore[arg-type]
             generated_at="2026-07-05T12:00:00Z",

--- a/workers/automation/tests/test_score_aggregate.py
+++ b/workers/automation/tests/test_score_aggregate.py
@@ -144,8 +144,9 @@ def test_requirement_fit_report_round_trips_through_dict() -> None:
     assert restored == original
     assert restored.assessments[0].fit.evidence_ids == ("ev-platform-leadership",)
     assert restored.assessments[0].tailoring.action == "double_down"
-    assert original.to_read_model() == {
-        "jobKey": "https://example.com/job/1",
+    read_model = original.to_read_model()
+    assert read_model == {
+        "jobId": "https://example.com/job/1",
         "scoreVersion": 3,
         "employerAnalysisGeneration": 2,
         "profileSnapshotVersion": 7,
@@ -195,6 +196,12 @@ def test_requirement_fit_report_round_trips_through_dict() -> None:
             }
         ],
     }
+    assert "jobKey" not in read_model
+
+    legacy_read_model = dict(read_model)
+    legacy_read_model["jobKey"] = legacy_read_model.pop("jobId")
+    with pytest.raises(ValueError, match="RequirementFitReport.job_id"):
+        RequirementFitReport.from_dict(legacy_read_model)
 
 
 def test_requirement_fit_status_requires_evidence_for_matched() -> None:


### PR DESCRIPTION
## Summary

- Make RequirementFitReport and InterviewPrep detail payloads expose canonical jobId only.
- Rename the live Python InterviewPrep field and its direct consumers from job_key to job_id.
- Align shared TypeScript domain interfaces, API schemas, projection builders, and focused fixtures.
- Prove a passed canonical UUID replaces stale payload jobId and removes obsolete jobKey.

## Why

These audit payloads are part of the persisted job-detail read model. They must not carry a second URL-shaped identity into the one-shot v7 cutover.

## Validation

- Focused Python tests: 42 passed.
- Domain-types tests: 179 passed.
- API projection tests: 34 passed.
- Domain-types, contracts, and API typechecks: passed.
- Ruff and diff checks: passed.
- Independent review: PASS with no findings.
- Independent QA: PASS with no findings.
- Rebase onto the exact #588 head preserved the reviewed patch ID.

## Deferred runtime gate

The existing full Python cross-runtime projection harness still reaches legacy job_url SQL against exact v7 tables. That pre-existing runtime cutover is intentionally not papered over with a fixture compatibility schema; it remains a required later v7 ProjectionBuilder/runtime slice.
