### PR TITLE
feat(contracts): use job ids in compensation audits

### DIFF
--- a/apps/api/src/projections.ts
+++ b/apps/api/src/projections.ts
@@ -21,6 +21,12 @@
  * materialises it.
  */
 import { PROJECTION_WATERMARK_NAME, STAGES } from "./contracts.js";
+import type {
+  JobCompensationAuditMarketResponse,
+  JobCompensationAuditPostedResponse,
+  MarketCompensationEstimateResponse,
+  PostedCompensationFactResponse,
+} from "./contracts.js";
 import { allRows, getRow, tableExists, type SqliteDatabase, type SqliteValue } from "./db.js";
 import { normalizeJobLocation } from "./location-normalization.js";
 import { getMarketCompensationEstimate } from "./market-compensation-estimates.js";
@@ -3163,7 +3169,7 @@ function rebuildJobProjections(db: SqliteDatabase, tenantId: string, jobUrl: str
   const scoreReasoning = score.reasoning || stringField(job.score_reasoning);
   const scoreBreakdownJson = score.breakdown ? JSON.stringify(score.breakdown) : null;
   const scoreKeywordsJson = JSON.stringify(score.keywords);
-  const compensationProjection = buildCompensationProjection(db, jobUrl);
+  const compensationProjection = buildCompensationProjection(db, jobUrl, jobUrl);
 
   const hasCanonicalMaterials = materials.hasCanonicalHistory;
   const tailorPath = hasCanonicalMaterials ? materials.tailorPath : nullableString(job.tailored_resume_path);
@@ -3439,31 +3445,64 @@ interface CompensationProjectionPair {
   auditJson: string;
 }
 
-function buildCompensationProjection(db: SqliteDatabase, jobUrl: string): CompensationProjectionPair {
+export function buildCompensationProjection(
+  db: SqliteDatabase,
+  jobLocator: string,
+  jobId: string,
+): CompensationProjectionPair {
   const posted =
-    getPostedCompensationFact(db, jobUrl) ??
+    getPostedCompensationFact(db, jobLocator) ??
     ({
       ok: true,
       recordStatus: "not_recorded",
-      jobKey: jobUrl,
+      jobKey: jobLocator,
       legacyRawSalary: null,
     } as const);
   const market =
-    getMarketCompensationEstimate(db, jobUrl) ??
+    getMarketCompensationEstimate(db, jobLocator) ??
     ({
       ok: true,
       recordStatus: "not_requested",
-      jobKey: jobUrl,
+      jobKey: jobLocator,
     } as const);
+  const auditPosted = compensationAuditPosted(posted, jobId);
+  const auditMarket = compensationAuditMarket(market, jobId);
   const summary = buildCompensationSummary(posted, market);
   return {
     summaryJson: JSON.stringify(summary),
     auditJson: JSON.stringify({
       projectionVersion: COMPENSATION_PROJECTION_VERSION,
-      posted,
-      market,
+      posted: auditPosted,
+      market: auditMarket,
     }),
   };
+}
+
+function compensationAuditPosted(
+  response: PostedCompensationFactResponse,
+  jobId: string,
+): JobCompensationAuditPostedResponse {
+  if (response.recordStatus === "recorded") {
+    const { jobKey: _jobKey, ...fact } = response.fact;
+    return { ...response, fact: { ...fact, jobId } };
+  }
+  return {
+    ok: true,
+    recordStatus: "not_recorded",
+    jobId,
+    legacyRawSalary: response.legacyRawSalary,
+  };
+}
+
+function compensationAuditMarket(
+  response: MarketCompensationEstimateResponse,
+  jobId: string,
+): JobCompensationAuditMarketResponse {
+  if (response.recordStatus === "recorded") {
+    const { jobKey: _jobKey, ...estimate } = response.estimate;
+    return { ...response, estimate: { ...estimate, jobId } };
+  }
+  return { ok: true, recordStatus: "not_requested", jobId };
 }
 
 function buildCompensationSummary(

--- a/apps/api/src/read-model.ts
+++ b/apps/api/src/read-model.ts
@@ -1287,13 +1287,48 @@ function parseCompensationSummary(value: string | null): JobCompensationSummary 
   }
 }
 
-function parseCompensationAudit(value: string | null): JobCompensationAudit | null {
+export function parseCompensationAudit(value: string | null): JobCompensationAudit | null {
   if (!value) return null;
   try {
-    return JSON.parse(value) as JobCompensationAudit;
+    const audit: unknown = JSON.parse(value);
+    if (!isCompensationAudit(audit) || containsLegacyJobKey(audit)) return null;
+    return audit;
   } catch {
     return null;
   }
+}
+
+function isCompensationAudit(value: unknown): value is JobCompensationAudit {
+  if (!isRecord(value) || typeof value.projectionVersion !== "number") return false;
+  return isCompensationAuditPosted(value.posted) && isCompensationAuditMarket(value.market);
+}
+
+function isCompensationAuditPosted(value: unknown): boolean {
+  if (!isRecord(value) || value.ok !== true) return false;
+  if (value.recordStatus === "recorded") {
+    return isRecord(value.fact) && typeof value.fact.jobId === "string";
+  }
+  return (
+    value.recordStatus === "not_recorded" &&
+    typeof value.jobId === "string" &&
+    (typeof value.legacyRawSalary === "string" || value.legacyRawSalary === null)
+  );
+}
+
+function isCompensationAuditMarket(value: unknown): boolean {
+  if (!isRecord(value) || value.ok !== true) return false;
+  if (value.recordStatus === "recorded") {
+    return isRecord(value.estimate) && typeof value.estimate.jobId === "string";
+  }
+  return value.recordStatus === "not_requested" && typeof value.jobId === "string";
+}
+
+function containsLegacyJobKey(value: unknown): boolean {
+  if (Array.isArray(value)) return value.some(containsLegacyJobKey);
+  if (!isRecord(value)) return false;
+  return Object.entries(value).some(
+    ([key, nested]) => key === "jobKey" || containsLegacyJobKey(nested),
+  );
 }
 
 interface JobAuditEventRow extends Record<string, unknown> {

--- a/apps/api/test/compensation-audit-contract.test.ts
+++ b/apps/api/test/compensation-audit-contract.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "vitest";
+import Database from "better-sqlite3";
+
+import { buildCompensationProjection } from "../src/projections.js";
+import { parseCompensationAudit } from "../src/read-model.js";
+
+describe("compensation audit identity contract", () => {
+  it("emits the supplied jobId and rejects legacy jobKey audit payloads", () => {
+    const db = new Database(":memory:");
+    const locator = "https://example.com/jobs/legacy-locator";
+    const jobId = "123e4567-e89b-12d3-a456-426614174000";
+    db.exec("CREATE TABLE jobs (url TEXT PRIMARY KEY, salary TEXT)");
+    db.prepare("INSERT INTO jobs (url, salary) VALUES (?, ?)").run(locator, "EUR 90000/year");
+
+    const absentAudit = JSON.parse(buildCompensationProjection(db, locator, jobId).auditJson);
+    expect(absentAudit).toMatchObject({
+      posted: {
+        ok: true,
+        recordStatus: "not_recorded",
+        jobId,
+        legacyRawSalary: "EUR 90000/year",
+      },
+      market: { ok: true, recordStatus: "not_requested", jobId },
+    });
+    expect(JSON.stringify(absentAudit)).not.toContain('"jobKey"');
+    expect(parseCompensationAudit(JSON.stringify(absentAudit))).toEqual(absentAudit);
+
+    installCompensationTables(db);
+    insertRecordedCompensation(db, locator);
+    const recordedAudit = JSON.parse(buildCompensationProjection(db, locator, jobId).auditJson);
+
+    expect(recordedAudit.posted.fact.jobId).toBe(jobId);
+    expect(recordedAudit.market.estimate.jobId).toBe(jobId);
+    expect(JSON.stringify(recordedAudit)).not.toContain('"jobKey"');
+
+    recordedAudit.posted.fact.jobKey = locator;
+    expect(parseCompensationAudit(JSON.stringify(recordedAudit))).toBeNull();
+    db.close();
+  });
+});
+
+function installCompensationTables(db: Database.Database): void {
+  db.exec(`
+    CREATE TABLE job_posted_compensation_facts (
+      tenant_id TEXT, job_url TEXT, source_field TEXT, source_text TEXT,
+      legacy_raw_salary TEXT, parse_state TEXT, currency TEXT, period TEXT,
+      component TEXT, minimum_amount INTEGER, maximum_amount INTEGER,
+      annualized_minimum_amount INTEGER, annualized_maximum_amount INTEGER,
+      annualization_assumption TEXT, confidence TEXT, warnings_json TEXT,
+      parser_version TEXT, source_hash TEXT, parsed_at TEXT
+    );
+    CREATE TABLE job_market_compensation_estimates (
+      tenant_id TEXT, job_url TEXT, estimate_state TEXT, currency TEXT,
+      period TEXT, component TEXT, minimum_amount INTEGER, maximum_amount INTEGER,
+      confidence_interval_minimum_amount INTEGER,
+      confidence_interval_maximum_amount INTEGER, confidence_band TEXT,
+      confidence_score REAL, source_count INTEGER, sample_count INTEGER,
+      aggregate_bucket TEXT, geography_scope TEXT, occupation_code TEXT,
+      occupation_label TEXT, seniority_label TEXT, source_snapshot_json TEXT,
+      factor_reasons_json TEXT, selected_evidence_json TEXT,
+      insufficient_reasons_json TEXT, unsupported_reasons_json TEXT,
+      source_unavailable_reasons_json TEXT, warnings_json TEXT,
+      estimator_version TEXT, estimated_at TEXT, company_name TEXT,
+      normalized_company TEXT, role_title TEXT, normalized_role TEXT,
+      company_tier TEXT, match_scope TEXT
+    );
+  `);
+}
+
+function insertRecordedCompensation(db: Database.Database, locator: string): void {
+  db.prepare(
+    `INSERT INTO job_posted_compensation_facts VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    "local",
+    locator,
+    "jobs.salary",
+    "EUR 90000/year",
+    "EUR 90000/year",
+    "parsed_range",
+    "EUR",
+    "year",
+    "base_salary",
+    90000,
+    120000,
+    90000,
+    120000,
+    null,
+    "high",
+    "[]",
+    "posted-compensation-v1",
+    "hash-posted",
+    "2026-07-31T00:00:00Z",
+  );
+  db.prepare(
+    `INSERT INTO job_market_compensation_estimates VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    "local",
+    locator,
+    "estimated_range",
+    "EUR",
+    "year",
+    "total_compensation",
+    100000,
+    130000,
+    90000,
+    140000,
+    "medium",
+    0.75,
+    1,
+    1,
+    "reported company-role compensation",
+    "Europe",
+    null,
+    null,
+    null,
+    "[]",
+    "[]",
+    "[]",
+    "[]",
+    "[]",
+    "[]",
+    "[]",
+    "company-role-reported-compensation-v1",
+    "2026-07-31T00:00:00Z",
+    null,
+    null,
+    null,
+    null,
+    "unknown",
+    "none",
+  );
+}

--- a/packages/contracts/src/schemas.ts
+++ b/packages/contracts/src/schemas.ts
@@ -2618,8 +2618,8 @@ export interface JobCompensationSummary {
 
 export interface JobCompensationAudit {
   projectionVersion: number;
-  posted: PostedCompensationFactResponse;
-  market: MarketCompensationEstimateResponse;
+  posted: JobCompensationAuditPostedResponse;
+  market: JobCompensationAuditMarketResponse;
 }
 
 export interface JobSummary {
@@ -5022,6 +5022,27 @@ export type PostedCompensationFactResponse =
   | PostedCompensationFactRecordedResponse
   | PostedCompensationFactNotRecordedResponse;
 
+type CompensationAuditJobIdentity<T> = T extends { jobKey: string }
+  ? Omit<T, "jobKey"> & { jobId: string }
+  : T;
+
+export type JobCompensationAuditPostedFact = CompensationAuditJobIdentity<
+  PostedCompensationFact
+>;
+
+export type JobCompensationAuditPostedResponse =
+  | {
+      ok: true;
+      recordStatus: "recorded";
+      fact: JobCompensationAuditPostedFact;
+    }
+  | {
+      ok: true;
+      recordStatus: "not_recorded";
+      jobId: string;
+      legacyRawSalary: string | null;
+    };
+
 export const MARKET_COMPENSATION_ESTIMATE_STATES = [
   "not_requested",
   "unsupported",
@@ -5237,6 +5258,22 @@ export interface MarketCompensationEstimateNotRequestedResponse {
 export type MarketCompensationEstimateResponse =
   | MarketCompensationEstimateRecordedResponse
   | MarketCompensationEstimateNotRequestedResponse;
+
+export type JobCompensationAuditMarketEstimate = CompensationAuditJobIdentity<
+  MarketCompensationEstimate
+>;
+
+export type JobCompensationAuditMarketResponse =
+  | {
+      ok: true;
+      recordStatus: "recorded";
+      estimate: JobCompensationAuditMarketEstimate;
+    }
+  | {
+      ok: true;
+      recordStatus: "not_requested";
+      jobId: string;
+    };
 
 export const QuarantineDecisionSchema = z
   .object({

--- a/packages/domain-types/test/fixtures/audit_projection_parity.json
+++ b/packages/domain-types/test/fixtures/audit_projection_parity.json
@@ -563,12 +563,12 @@
     "jobDetail": {
       "compensation_audit_json": {
         "market": {
-          "jobKey": "https://example.com/jobs/parity-developer-platform",
+          "jobId": "https://example.com/jobs/parity-developer-platform",
           "ok": true,
           "recordStatus": "not_requested"
         },
         "posted": {
-          "jobKey": "https://example.com/jobs/parity-developer-platform",
+          "jobId": "https://example.com/jobs/parity-developer-platform",
           "legacyRawSalary": "EUR 90000-120000/year",
           "ok": true,
           "recordStatus": "not_recorded"

--- a/workers/automation/src/jobctrl/infrastructure/projections/projection_builder.py
+++ b/workers/automation/src/jobctrl/infrastructure/projections/projection_builder.py
@@ -1427,8 +1427,9 @@ class ProjectionBuilder:
             job_row, "full_description"
         )
         compensation_summary, compensation_audit = self._build_compensation_projection(
-            job_url,
-            _row_nullable_str(job_row, "salary"),
+            job_id=job_url,
+            job_locator=job_url,
+            legacy_raw_salary=_row_nullable_str(job_row, "salary"),
         )
 
         last_updated_at = _utc_now()
@@ -1932,11 +1933,17 @@ class ProjectionBuilder:
 
     def _build_compensation_projection(
         self,
-        job_url: str,
+        *,
+        job_id: str,
+        job_locator: str,
         legacy_raw_salary: str | None,
     ) -> tuple[str, str]:
-        posted = self._load_posted_compensation(job_url, legacy_raw_salary)
-        market = self._load_market_compensation(job_url)
+        posted = self._load_posted_compensation(
+            job_locator,
+            legacy_raw_salary,
+            job_id,
+        )
+        market = self._load_market_compensation(job_locator, job_id)
         posted_warning_count = (
             len(posted["fact"]["warnings"])
             if posted["recordStatus"] == "recorded" and isinstance(posted.get("fact"), dict)
@@ -2033,8 +2040,9 @@ class ProjectionBuilder:
 
     def _load_posted_compensation(
         self,
-        job_url: str,
+        job_locator: str,
         legacy_raw_salary: str | None,
+        job_id: str,
     ) -> dict[str, Any]:
         try:
             row = self._conn.execute(
@@ -2048,7 +2056,7 @@ class ProjectionBuilder:
                 FROM job_posted_compensation_facts
                 WHERE tenant_id = ? AND job_url = ?
                 """,
-                (str(self._tenant_id), job_url),
+                (str(self._tenant_id), job_locator),
             ).fetchone()
         except sqlite3.OperationalError:
             row = None
@@ -2056,13 +2064,13 @@ class ProjectionBuilder:
             return {
                 "ok": True,
                 "recordStatus": "not_recorded",
-                "jobKey": job_url,
+                "jobId": job_id,
                 "legacyRawSalary": _nullable_text(legacy_raw_salary),
             }
-        fact = _posted_fact_from_row(row)
+        fact = _posted_fact_from_row(row, job_id)
         return {"ok": True, "recordStatus": "recorded", "fact": fact}
 
-    def _load_market_compensation(self, job_url: str) -> dict[str, Any]:
+    def _load_market_compensation(self, job_locator: str, job_id: str) -> dict[str, Any]:
         try:
             row = self._conn.execute(
                 """
@@ -2083,18 +2091,18 @@ class ProjectionBuilder:
                 FROM job_market_compensation_estimates
                 WHERE tenant_id = ? AND job_url = ?
                 """,
-                (str(self._tenant_id), job_url),
+                (str(self._tenant_id), job_locator),
             ).fetchone()
         except sqlite3.OperationalError:
             row = None
         if row is None:
-            return {"ok": True, "recordStatus": "not_requested", "jobKey": job_url}
+            return {"ok": True, "recordStatus": "not_requested", "jobId": job_id}
         if not _row_str(row, "estimator_version").startswith("company-role-reported-compensation-"):
-            return {"ok": True, "recordStatus": "not_requested", "jobKey": job_url}
+            return {"ok": True, "recordStatus": "not_requested", "jobId": job_id}
         estimate_state = _row_str(row, "estimate_state")
         if estimate_state not in MARKET_RECORDED_STATES:
-            return {"ok": True, "recordStatus": "not_requested", "jobKey": job_url}
-        estimate = _market_estimate_from_row(row)
+            return {"ok": True, "recordStatus": "not_requested", "jobId": job_id}
+        estimate = _market_estimate_from_row(row, job_id)
         return {"ok": True, "recordStatus": "recorded", "estimate": estimate}
 
     # ------------------------------------------------------------- joiners
@@ -4131,11 +4139,11 @@ def _row_float(row: object, key: str) -> float:
         return 0.0
 
 
-def _posted_fact_from_row(row: object) -> dict[str, Any]:
+def _posted_fact_from_row(row: object, job_id: str) -> dict[str, Any]:
     warnings = _warnings(_row_str(row, "warnings_json"), POSTED_COMPENSATION_WARNING_MESSAGES)
     base: dict[str, Any] = {
         "tenantId": _row_str(row, "tenant_id"),
-        "jobKey": _row_str(row, "job_url"),
+        "jobId": job_id,
         "sourceField": _row_str(row, "source_field"),
         "legacyRawSalary": _nullable_text(_row_get(row, "legacy_raw_salary")),
         "parserVersion": _row_str(row, "parser_version"),
@@ -4183,13 +4191,13 @@ def _posted_fact_from_row(row: object) -> dict[str, Any]:
     }
 
 
-def _market_estimate_from_row(row: object) -> dict[str, Any]:
+def _market_estimate_from_row(row: object, job_id: str) -> dict[str, Any]:
     sources = _market_sources(_row_str(row, "source_snapshot_json"))
     estimate_state = _row_str(row, "estimate_state")
     confidence_band = _confidence_band(_row_get(row, "confidence_band"))
     base: dict[str, Any] = {
         "tenantId": _row_str(row, "tenant_id"),
-        "jobKey": _row_str(row, "job_url"),
+        "jobId": job_id,
         "estimateState": estimate_state,
         "confidenceBand": confidence_band,
         "confidenceScore": _number(_row_get(row, "confidence_score")),

--- a/workers/automation/tests/test_compensation_audit_contract.py
+++ b/workers/automation/tests/test_compensation_audit_contract.py
@@ -1,0 +1,147 @@
+"""Compensation audit identity contract across the Python projection builder."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from jobctrl.database import close_connection, init_db
+from jobctrl.infrastructure.projections.projection_builder import ProjectionBuilder
+
+
+def test_compensation_audit_uses_explicit_job_id_without_legacy_job_key(tmp_path: Path) -> None:
+    db_path = tmp_path / "jobs.db"
+    conn = init_db(db_path)
+    locator = "https://example.com/jobs/legacy-locator"
+    job_id = "123e4567-e89b-12d3-a456-426614174000"
+    try:
+        builder = ProjectionBuilder(conn_factory=lambda: conn)
+        _install_compensation_tables(conn)
+
+        with builder._bind(conn):
+            _summary, absent_audit_json = builder._build_compensation_projection(
+                job_id=job_id,
+                job_locator=locator,
+                legacy_raw_salary="EUR 90000/year",
+            )
+
+            _insert_recorded_compensation(conn, locator)
+            _summary, recorded_audit_json = builder._build_compensation_projection(
+                job_id=job_id,
+                job_locator=locator,
+                legacy_raw_salary="EUR 90000/year",
+            )
+
+        absent_audit = json.loads(absent_audit_json)
+        assert absent_audit["posted"] == {
+            "ok": True,
+            "recordStatus": "not_recorded",
+            "jobId": job_id,
+            "legacyRawSalary": "EUR 90000/year",
+        }
+        assert absent_audit["market"] == {
+            "ok": True,
+            "recordStatus": "not_requested",
+            "jobId": job_id,
+        }
+
+        recorded_audit = json.loads(recorded_audit_json)
+        assert recorded_audit["posted"]["fact"]["jobId"] == job_id
+        assert recorded_audit["market"]["estimate"]["jobId"] == job_id
+        assert '"jobKey"' not in absent_audit_json
+        assert '"jobKey"' not in recorded_audit_json
+    finally:
+        close_connection(db_path)
+
+
+def _install_compensation_tables(conn) -> None:
+    conn.executescript(
+        """
+        DROP TABLE job_posted_compensation_facts;
+        DROP TABLE job_market_compensation_estimates;
+        CREATE TABLE job_posted_compensation_facts (
+            tenant_id TEXT, job_url TEXT, source_field TEXT, source_text TEXT,
+            legacy_raw_salary TEXT, parse_state TEXT, currency TEXT, period TEXT,
+            component TEXT, minimum_amount INTEGER, maximum_amount INTEGER,
+            annualized_minimum_amount INTEGER, annualized_maximum_amount INTEGER,
+            annualization_assumption TEXT, confidence TEXT, warnings_json TEXT,
+            parser_version TEXT, source_hash TEXT, parsed_at TEXT
+        );
+        CREATE TABLE job_market_compensation_estimates (
+            tenant_id TEXT, job_url TEXT, estimate_state TEXT, currency TEXT,
+            period TEXT, component TEXT, minimum_amount INTEGER, maximum_amount INTEGER,
+            confidence_interval_minimum_amount INTEGER,
+            confidence_interval_maximum_amount INTEGER, confidence_band TEXT,
+            confidence_score REAL, source_count INTEGER, sample_count INTEGER,
+            aggregate_bucket TEXT, geography_scope TEXT, occupation_code TEXT,
+            occupation_label TEXT, seniority_label TEXT, source_snapshot_json TEXT,
+            factor_reasons_json TEXT, selected_evidence_json TEXT,
+            insufficient_reasons_json TEXT, unsupported_reasons_json TEXT,
+            source_unavailable_reasons_json TEXT, warnings_json TEXT,
+            estimator_version TEXT, estimated_at TEXT, company_name TEXT,
+            normalized_company TEXT, role_title TEXT, normalized_role TEXT,
+            company_tier TEXT, match_scope TEXT
+        );
+        """
+    )
+
+
+def _insert_recorded_compensation(conn, locator: str) -> None:
+    conn.execute(
+        """
+        INSERT INTO job_posted_compensation_facts (
+            tenant_id, job_url, source_field, source_text, legacy_raw_salary,
+            parse_state, currency, period, component, confidence, warnings_json,
+            parser_version, source_hash, parsed_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            "local",
+            locator,
+            "jobs.salary",
+            "EUR 90000/year",
+            "EUR 90000/year",
+            "parsed_range",
+            "EUR",
+            "year",
+            "base_salary",
+            "high",
+            "[]",
+            "posted-compensation-v1",
+            "hash-posted",
+            "2026-07-31T00:00:00Z",
+        ),
+    )
+    conn.execute(
+        """
+        INSERT INTO job_market_compensation_estimates (
+            tenant_id, job_url, estimate_state, currency, period, component,
+            confidence_band, confidence_score, source_count, source_snapshot_json,
+            factor_reasons_json, selected_evidence_json, insufficient_reasons_json,
+            unsupported_reasons_json, source_unavailable_reasons_json, warnings_json,
+            estimator_version, estimated_at, company_tier, match_scope
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            "local",
+            locator,
+            "estimated_range",
+            "EUR",
+            "year",
+            "total_compensation",
+            "medium",
+            0.75,
+            1,
+            "[]",
+            "[]",
+            "[]",
+            "[]",
+            "[]",
+            "[]",
+            "[]",
+            "company-role-reported-compensation-v1",
+            "2026-07-31T00:00:00Z",
+            "unknown",
+            "none",
+        ),
+    )


### PR DESCRIPTION
## Summary

- Give nested compensation-audit posted and market records an exact canonical jobId identity.
- Keep job locators separate for canonical compensation lookups and preserve explicit source URL evidence.
- Cover recorded and absent posted/market branches in both Python and TypeScript.
- Reject legacy jobKey anywhere in a compensation-audit payload.

## Why

Compensation audit JSON is persisted inside the job-detail projection. Its nested identity must not retain the URL-shaped pre-v7 job key.

## Validation

- Focused Python compensation contract: 1 passed.
- Focused TypeScript compensation contract and projection parity: 3 passed.
- API projection suite: 34 passed.
- Python compensation parser tests: 30 passed.
- TypeScript compensation parser/policy tests: 26 passed.
- Domain-types tests: 179 passed.
- Contracts, domain-types, and API typechecks: passed.
- Ruff and diff checks: passed.
- Independent review: PASS with no findings.
- Independent QA: PASS with no findings.

## Deferred runtime wiring

This unreleased contract slice separates locator and identity arguments and proves canonical UUID precedence. The later exact-v7 ProjectionBuilder/runtime cutover must pass the persisted job_id instead of the old pre-cutover value; no alias or compatibility fallback is introduced here.
