### PR TITLE
feat(storage): add v7 job-list row serializer

### DIFF
--- a/workers/automation/src/jobctrl/infrastructure/migrations/v6_to_v7_job_detail_projections.py
+++ b/workers/automation/src/jobctrl/infrastructure/migrations/v6_to_v7_job_detail_projections.py
@@ -297,7 +297,7 @@ def _score_projection(
 ) -> dict[str, object]:
     row = candidate.execute(
         """
-        SELECT version, scored_at, breakdown_json, keywords_json,
+        SELECT version, fit_score, scored_at, breakdown_json, keywords_json,
                criteria_json, trace_json, correction_json
         FROM job_scores
         WHERE tenant_id = ? AND job_id = ?
@@ -309,6 +309,7 @@ def _score_projection(
     if row is None:
         return {
             "version": None,
+            "fit_score": None,
             "scored_at": None,
             "breakdown_json": None,
             "keywords_json": "[]",
@@ -317,13 +318,14 @@ def _score_projection(
             "trace_json": None,
             "correction_json": None,
         }
-    breakdown = _json_value(row[2], default={})
+    breakdown = _json_value(row[3], default={})
     legacy = isinstance(breakdown, dict) and breakdown.get("legacy") is True
     reasoning = breakdown.get("reasoning", "") if isinstance(breakdown, dict) else ""
-    keywords = _json_value(row[3], default=[])
+    keywords = _json_value(row[4], default=[])
     return {
         "version": row[0],
-        "scored_at": row[1],
+        "fit_score": row[1],
+        "scored_at": row[2],
         "breakdown_json": (
             None
             if legacy
@@ -332,9 +334,9 @@ def _score_projection(
         "keywords_json": _json([] if legacy and keywords == ["legacy"] else keywords),
         "reasoning": reasoning if isinstance(reasoning, str) else "",
         # Criteria, trace, and correction are opaque generation-time audit data.
-        "criteria_json": row[4],
-        "trace_json": row[5],
-        "correction_json": row[6],
+        "criteria_json": row[5],
+        "trace_json": row[6],
+        "correction_json": row[7],
     }
 
 

--- a/workers/automation/src/jobctrl/infrastructure/migrations/v7_job_list_projection_rows.py
+++ b/workers/automation/src/jobctrl/infrastructure/migrations/v7_job_list_projection_rows.py
@@ -1,0 +1,515 @@
+"""Build complete v7 job-list rows from hydrated canonical candidate data."""
+
+from __future__ import annotations
+
+import sqlite3
+import uuid
+
+from jobctrl.infrastructure.migrations import v6_to_v7_job_detail_projections as detail
+from jobctrl.infrastructure.projections import projection_builder
+from jobctrl.infrastructure.projections.location_normalization import (
+    normalize_job_location,
+)
+
+JOB_LIST_PROJECTIONS_TABLE = "job_list_projections"
+JOB_LIST_PROJECTIONS_COLUMNS = (
+    "tenant_id",
+    "job_id",
+    "title",
+    "employer",
+    "source",
+    "strategy",
+    "location",
+    "salary",
+    "application_url",
+    "discovered_at",
+    "description",
+    "full_description",
+    "fit_score",
+    "fit_band",
+    "compensation_summary_json",
+    "score_breakdown_json",
+    "score_keywords_json",
+    "score_reasoning",
+    "score_version",
+    "scored_at",
+    "score_criteria_json",
+    "score_trace_json",
+    "score_correction_json",
+    "current_stage",
+    "current_substage",
+    "current_state",
+    "current_error_code",
+    "current_error_message",
+    "current_next_action",
+    "has_resume",
+    "has_cover_letter",
+    "has_pdf",
+    "apply_status",
+    "applied_at",
+    "apply_mode",
+    "resume_template_id",
+    "resume_template_name",
+    "tailoring_policy_version",
+    "artifact_count",
+    "deleted_at",
+    "last_updated_at",
+)
+
+_MATERIAL_ARTIFACT_TYPES = (
+    "tailored_resume",
+    "cover_letter",
+    "resume_pdf",
+    "cover_letter_pdf",
+)
+_RESUME_METADATA_ARTIFACT_TYPES = (
+    "tailored_resume",
+    "tailored_resume_txt",
+    "resume_pdf",
+)
+
+
+class CandidateJobListProjectionsError(RuntimeError):
+    """Raised when a complete job-list row cannot be derived safely."""
+
+
+def _projection_rows(
+    candidate: sqlite3.Connection,
+    migration_at: str,
+) -> tuple[tuple[object, ...], ...]:
+    """Serialize every complete v7 job-list row from canonical candidate rows.
+
+    The candidate must already contain UUID roots and any upstream projection
+    inputs (apply runs and artifacts).  The target ``job_list_projections``
+    table, legacy URL caches, and mutable resume-template selection tables are
+    intentionally never read.
+    """
+    timestamp = _required_text(migration_at, "migration_at")
+    _assert_hydrated_roots(candidate)
+
+    rows: list[tuple[object, ...]] = []
+    for job in candidate.execute(
+        """
+        SELECT tenant_id, job_id, url, title, company, salary, description,
+               location, site, strategy, discovered_at, full_description,
+               application_url, apply_status, applied_at
+        FROM jobs
+        ORDER BY tenant_id, job_id
+        """
+    ).fetchall():
+        (
+            tenant_id,
+            job_id,
+            job_url,
+            title,
+            company,
+            salary,
+            description,
+            location,
+            site,
+            strategy,
+            discovered_at,
+            full_description,
+            application_url,
+            legacy_apply_status,
+            legacy_applied_at,
+        ) = job
+        tenant = _required_text(tenant_id, "candidate job tenant_id")
+        stable_job_id = _required_uuid(job_id, "candidate job job_id")
+        locator = _required_text(job_url, "candidate job url")
+        enrichment = _enrichment(candidate, tenant, stable_job_id)
+        selected_application_url = (
+            enrichment[1]
+            if enrichment[1] is not None
+            else _optional_text(application_url)
+        )
+        selected_full_description = (
+            enrichment[0]
+            if enrichment[0] is not None
+            else _text_or_empty(full_description)
+        )
+        score = detail._score_projection(candidate, tenant, stable_job_id)
+        compensation_summary, _ = detail._compensation_projection(
+            candidate,
+            tenant,
+            stable_job_id,
+            salary,
+        )
+        material = _current_material(candidate, tenant, stable_job_id)
+        current = _current_stage(
+            candidate,
+            tenant,
+            stable_job_id,
+            has_resume=material[0],
+        )
+        (
+            has_resume,
+            has_cover_letter,
+            has_pdf,
+            resume_template_id,
+            resume_template_name,
+            tailoring_policy_version,
+        ) = material
+        apply_status, applied_at, apply_mode = _apply_projection(
+            candidate,
+            tenant,
+            stable_job_id,
+            legacy_apply_status,
+            legacy_applied_at,
+        )
+        rows.append(
+            (
+                tenant,
+                stable_job_id,
+                _text_or_default(title, "Untitled"),
+                _text_or_default(company, projection_builder._company_name(
+                    _text_or_empty(site), selected_application_url or locator
+                )),
+                _text_or_default(site, "unknown"),
+                _text_or_empty(strategy),
+                normalize_job_location(_text_or_empty(location)),
+                _text_or_empty(salary),
+                selected_application_url,
+                _optional_text(discovered_at),
+                _text_or_empty(description),
+                selected_full_description,
+                score["fit_score"],
+                _latest_requirement_fit_band(candidate, tenant, stable_job_id),
+                compensation_summary,
+                score["breakdown_json"],
+                score["keywords_json"],
+                score["reasoning"],
+                score["version"],
+                score["scored_at"],
+                score["criteria_json"],
+                score["trace_json"],
+                score["correction_json"],
+                *current,
+                has_resume,
+                has_cover_letter,
+                has_pdf,
+                apply_status,
+                applied_at,
+                apply_mode,
+                resume_template_id,
+                resume_template_name,
+                tailoring_policy_version,
+                _artifact_count(candidate, tenant, stable_job_id),
+                _active_deleted_at(candidate, tenant, stable_job_id),
+                timestamp,
+            )
+        )
+
+    if any(len(row) != len(JOB_LIST_PROJECTIONS_COLUMNS) for row in rows):
+        raise CandidateJobListProjectionsError(
+            "job-list projection serializer must emit every v7 column"
+        )
+    return tuple(rows)
+
+
+def _assert_hydrated_roots(candidate: sqlite3.Connection) -> None:
+    jobs: dict[tuple[str, str], str] = {}
+    for tenant_id, job_id, url in candidate.execute(
+        "SELECT tenant_id, job_id, url FROM jobs ORDER BY tenant_id, job_id"
+    ).fetchall():
+        tenant = _required_text(tenant_id, "candidate job tenant_id")
+        stable_job_id = _required_uuid(job_id, "candidate job job_id")
+        locator = _required_text(url, "candidate job url")
+        key = (tenant, locator)
+        if key in jobs:
+            raise CandidateJobListProjectionsError(
+                "candidate job roots must have unique posting locators"
+            )
+        jobs[key] = stable_job_id
+    locators = {
+        (_required_text(tenant_id, "candidate locator tenant_id"), _required_text(locator, "candidate locator value")): _required_uuid(job_id, "candidate locator job_id")
+        for tenant_id, job_id, locator in candidate.execute(
+            """
+            SELECT tenant_id, job_id, locator_value
+            FROM job_locators
+            WHERE locator_kind = 'posting_url'
+              AND is_current = 1
+              AND retired_at IS NULL
+            """
+        ).fetchall()
+    }
+    if jobs != locators or _row_count(candidate, "job_locators") != len(locators):
+        raise CandidateJobListProjectionsError(
+            "job-list row serializer requires exactly one hydrated root locator per job"
+        )
+
+
+def _enrichment(
+    candidate: sqlite3.Connection,
+    tenant_id: str,
+    job_id: str,
+) -> tuple[str | None, str | None]:
+    row = candidate.execute(
+        """
+        SELECT full_description, application_url
+        FROM job_enrichments
+        WHERE tenant_id = ? AND job_id = ?
+        """,
+        (tenant_id, job_id),
+    ).fetchone()
+    if row is None:
+        return None, None
+    return _optional_text(row[0]), _optional_text(row[1])
+
+
+def _latest_requirement_fit_band(
+    candidate: sqlite3.Connection,
+    tenant_id: str,
+    job_id: str,
+) -> str | None:
+    row = candidate.execute(
+        """
+        SELECT fit_band
+        FROM job_requirement_fit_reports
+        WHERE tenant_id = ? AND job_id = ?
+        ORDER BY score_version DESC
+        LIMIT 1
+        """,
+        (tenant_id, job_id),
+    ).fetchone()
+    if row is None:
+        return None
+    return projection_builder._fit_band(_optional_text(row[0]))
+
+
+def _current_stage(
+    candidate: sqlite3.Connection,
+    tenant_id: str,
+    job_id: str,
+    *,
+    has_resume: bool,
+) -> tuple[str, str, str, str | None, str | None, str | None]:
+    stages = detail._stages(candidate, tenant_id, job_id)
+    first_actionable = next(
+        (stage for stage in stages if stage["state"] not in {"succeeded", "skipped"}),
+        stages[-1] if stages else None,
+    )
+    if first_actionable is None:
+        return "discover", "discover", "pending", None, None, None
+    return (
+        projection_builder._job_list_stage(
+            str(first_actionable["stage"]), has_resume=has_resume
+        ),
+        str(first_actionable["stage"]),
+        str(first_actionable["state"]),
+        _optional_text(first_actionable["error_code"]),
+        _optional_text(first_actionable["error_message"]),
+        _optional_text(first_actionable["next_action"]),
+    )
+
+
+def _current_material(
+    candidate: sqlite3.Connection,
+    tenant_id: str,
+    job_id: str,
+) -> tuple[object, ...]:
+    row = candidate.execute(
+        """
+        SELECT MAX(generation)
+        FROM job_materials_artifacts
+        WHERE tenant_id = ? AND job_id = ?
+          AND status = 'approved'
+          AND artifact_type IN (?, ?, ?, ?)
+        """,
+        (tenant_id, job_id, *_MATERIAL_ARTIFACT_TYPES),
+    ).fetchone()
+    if row is None or row[0] is None:
+        return False, False, False, None, None, None
+    generation = _positive_integer(row[0], "approved material generation")
+    artifacts = candidate.execute(
+        """
+        SELECT artifact_type, path, metadata_json, created_at, artifact_id
+        FROM job_materials_artifacts
+        WHERE tenant_id = ? AND job_id = ? AND generation = ?
+          AND status = 'approved'
+        ORDER BY CASE artifact_type
+                   WHEN 'tailored_resume' THEN 0
+                   WHEN 'tailored_resume_txt' THEN 1
+                   WHEN 'resume_pdf' THEN 2
+                   ELSE 3
+                 END,
+                 created_at DESC,
+                 artifact_id DESC
+        """,
+        (tenant_id, job_id, generation),
+    ).fetchall()
+    approved = {
+        str(artifact_type): _optional_text(path)
+        for artifact_type, path, _metadata_json, _created_at, _artifact_id in artifacts
+    }
+    metadata_jsons = [
+        _optional_text(metadata_json)
+        for artifact_type, _path, metadata_json, _created_at, _artifact_id in artifacts
+        if str(artifact_type) in _RESUME_METADATA_ARTIFACT_TYPES
+    ]
+    material = candidate.execute(
+        """
+        SELECT metadata_json
+        FROM job_materials
+        WHERE tenant_id = ? AND job_id = ? AND generation = ?
+        """,
+        (tenant_id, job_id, generation),
+    ).fetchone()
+    if material is not None:
+        metadata_jsons.append(_optional_text(material[0]))
+    analytics = projection_builder._merge_material_analytics(metadata_jsons)
+    return (
+        bool(approved.get("tailored_resume")),
+        bool(approved.get("cover_letter")),
+        bool(approved.get("resume_pdf") or approved.get("cover_letter_pdf")),
+        analytics["resume_template_id"],
+        analytics["resume_template_name"],
+        analytics["tailoring_policy_version"],
+    )
+
+
+def _apply_projection(
+    candidate: sqlite3.Connection,
+    tenant_id: str,
+    job_id: str,
+    legacy_apply_status: object,
+    legacy_applied_at: object,
+) -> tuple[str | None, str | None, str | None]:
+    run = candidate.execute(
+        """
+        SELECT status, finished_at, dry_run
+        FROM apply_run_projections
+        WHERE tenant_id = ? AND job_id = ?
+        ORDER BY started_at DESC, run_id DESC
+        LIMIT 1
+        """,
+        (tenant_id, job_id),
+    ).fetchone()
+    run_status = _optional_text(run[0]) if run is not None else None
+    run_finished_at = _optional_text(run[1]) if run is not None else None
+    dry_run = bool(run[2]) if run is not None else False
+    legacy_status = _optional_text(legacy_apply_status)
+    legacy_at = _optional_text(legacy_applied_at)
+    apply_status = projection_builder._derive_apply_status(run_status, legacy_status)
+    applied_at = run_finished_at if run_status == "succeeded" else legacy_at
+    if run_status == "succeeded" and not dry_run:
+        return apply_status, applied_at, "automated_live"
+    if not (legacy_at or legacy_status == "applied"):
+        return apply_status, applied_at, None
+    manually_marked = candidate.execute(
+        """
+        SELECT 1 FROM job_events
+        WHERE tenant_id = ? AND job_id = ?
+          AND event_type = 'ApplicationManuallyMarked'
+        LIMIT 1
+        """,
+        (tenant_id, job_id),
+    ).fetchone()
+    if manually_marked is not None:
+        return apply_status, applied_at, "manual_marked"
+    externally_confirmed = candidate.execute(
+        """
+        SELECT 1 FROM application_outcomes
+        WHERE tenant_id = ? AND job_id = ?
+          AND kind = 'applied_confirmation'
+        LIMIT 1
+        """,
+        (tenant_id, job_id),
+    ).fetchone()
+    return (
+        apply_status,
+        applied_at,
+        "external_confirmed" if externally_confirmed is not None else "manual_marked",
+    )
+
+
+def _artifact_count(candidate: sqlite3.Connection, tenant_id: str, job_id: str) -> int:
+    return int(
+        candidate.execute(
+            """
+            SELECT COUNT(*) FROM artifact_list_projections
+            WHERE tenant_id = ? AND job_id = ? AND status != 'suppressed'
+            """,
+            (tenant_id, job_id),
+        ).fetchone()[0]
+    )
+
+
+def _active_deleted_at(
+    candidate: sqlite3.Connection,
+    tenant_id: str,
+    job_id: str,
+) -> str | None:
+    row = candidate.execute(
+        """
+        SELECT deleted_at
+        FROM jobctrl_deleted_jobs
+        WHERE tenant_id = ? AND job_id = ?
+          AND (restored_at IS NULL OR julianday(restored_at) <= julianday(deleted_at))
+        """,
+        (tenant_id, job_id),
+    ).fetchone()
+    return _optional_text(row[0]) if row is not None else None
+
+
+def _required_uuid(value: object, field: str) -> str:
+    text = _required_text(value, field).lower()
+    try:
+        parsed = uuid.UUID(text)
+    except ValueError as error:
+        raise CandidateJobListProjectionsError(
+            f"{field} must be a canonical UUID"
+        ) from error
+    if str(parsed) != text:
+        raise CandidateJobListProjectionsError(
+            f"{field} must be a canonical UUID"
+        )
+    return text
+
+
+def _positive_integer(value: object, field: str) -> int:
+    if isinstance(value, bool):
+        raise CandidateJobListProjectionsError(f"{field} must be a positive integer")
+    try:
+        parsed = int(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError) as error:
+        raise CandidateJobListProjectionsError(
+            f"{field} must be a positive integer"
+        ) from error
+    if parsed < 1:
+        raise CandidateJobListProjectionsError(f"{field} must be a positive integer")
+    return parsed
+
+
+def _row_count(candidate: sqlite3.Connection, table: str) -> int:
+    return int(candidate.execute(f'SELECT COUNT(*) FROM "{table}"').fetchone()[0])
+
+
+def _required_text(value: object, field: str) -> str:
+    text = _optional_text(value)
+    if text is None:
+        raise CandidateJobListProjectionsError(f"{field} must be non-empty text")
+    return text
+
+
+def _optional_text(value: object) -> str | None:
+    if value is None:
+        return None
+    text = str(value)
+    return text if text else None
+
+
+def _text_or_empty(value: object) -> str:
+    return "" if value is None else str(value)
+
+
+def _text_or_default(value: object, default: str) -> str:
+    text = _text_or_empty(value)
+    return text or default
+
+
+__all__ = [
+    "CandidateJobListProjectionsError",
+    "JOB_LIST_PROJECTIONS_COLUMNS",
+    "JOB_LIST_PROJECTIONS_TABLE",
+]

--- a/workers/automation/tests/test_v7_job_list_projection_rows.py
+++ b/workers/automation/tests/test_v7_job_list_projection_rows.py
@@ -1,0 +1,396 @@
+"""Contract tests for complete v7 job-list row serialization."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+
+from jobctrl.infrastructure.migrations.schema_v7 import create_exact_v7_schema
+from jobctrl.infrastructure.migrations.v7_job_list_projection_rows import (
+    JOB_LIST_PROJECTIONS_COLUMNS,
+    _projection_rows,
+)
+
+_JOB_ID = "00000000-0000-4000-8000-000000000001"
+_JOB_URL = "https://jobs.example/platform-engineer"
+_MIGRATION_AT = "2026-07-31T09:00:00+00:00"
+_INERT_CONTEXT_JSON = '{"userContext":"Attack vectors:\\nPrompt injection"}'
+
+
+def _candidate() -> sqlite3.Connection:
+    candidate = sqlite3.connect(":memory:")
+    candidate.execute("PRAGMA foreign_keys = ON")
+    create_exact_v7_schema(candidate)
+    candidate.execute(
+        """
+        INSERT INTO jobs (
+            url, title, company, salary, description, location, site, strategy,
+            discovered_at, full_description, application_url, apply_status,
+            applied_at, tenant_id, job_id
+        ) VALUES (?, 'Platform Engineer', '', '€95k', 'Short summary',
+                  'MD, ES, remoto', 'greenhouse', 'focused',
+                  '2026-07-30T09:00:00+00:00', 'Original description',
+                  NULL, 'applied', '2026-07-30T12:00:00+00:00', 'local', ?)
+        """,
+        (_JOB_URL, _JOB_ID),
+    )
+    candidate.execute(
+        """
+        INSERT INTO job_locators (
+            tenant_id, job_id, locator_kind, locator_value, is_current,
+            first_seen_at, last_seen_at, retired_at
+        ) VALUES ('local', ?, 'posting_url', ?, 1, ?, ?, NULL)
+        """,
+        (_JOB_ID, _JOB_URL, _MIGRATION_AT, _MIGRATION_AT),
+    )
+    candidate.execute(
+        """
+        INSERT INTO job_enrichments (
+            tenant_id, job_id, current_status, full_description,
+            application_url, enriched_at, extraction_tier, attempts_json, updated_at
+        ) VALUES ('local', ?, 'succeeded', 'Canonical enriched description',
+                  'https://boards.greenhouse.io/exampleco/jobs/42', ?, 'html', '[]', ?)
+        """,
+        (_JOB_ID, _MIGRATION_AT, _MIGRATION_AT),
+    )
+    candidate.executemany(
+        """
+        INSERT INTO job_scores (
+            tenant_id, job_id, version, fit_score, breakdown_json, keywords_json,
+            scored_at, correction_json, criteria_json, trace_json
+        ) VALUES ('local', ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        [
+            (
+                _JOB_ID,
+                1,
+                4,
+                '{"reasoning":"older score"}',
+                '["older"]',
+                "2026-07-30T09:30:00+00:00",
+                '{"old":true}',
+                '{"old":true}',
+                '{"old":true}',
+            ),
+            (
+                _JOB_ID,
+                3,
+                8,
+                '{"technical_fit":9,"experience_fit":8,"role_fit":7,'
+                '"reasoning":"canonical score","matched_signals":["Python"]}',
+                '["Python"]',
+                "2026-07-30T10:00:00+00:00",
+                '{"opaque":{"repair":"keep-exact"}}',
+                '{"opaque":{"criterion":"keep-exact"}}',
+                '{"opaque":{"trace":"keep-exact"}}',
+            ),
+        ],
+    )
+    candidate.executemany(
+        """
+        INSERT INTO job_requirement_fit_reports (
+            tenant_id, job_id, score_version, employer_analysis_generation,
+            profile_snapshot_version, scoring_policy_version, formula_version,
+            resolved_fit_score, fit_band, confidence, summary_json, created_at
+        ) VALUES ('local', ?, ?, 1, 1, 1, 'requirement-fit-v1', ?, ?, 'high', '{}', ?)
+        """,
+        [
+            (_JOB_ID, 1, 4, "poor", _MIGRATION_AT),
+            (_JOB_ID, 3, 8, "strong", _MIGRATION_AT),
+        ],
+    )
+    candidate.executemany(
+        """
+        INSERT INTO job_stage_states (
+            tenant_id, job_id, stage, state, attempt_count, max_attempts,
+            updated_at, error_code, error_message, retryable, blocked_by_json,
+            next_action, version
+        ) VALUES ('local', ?, ?, ?, 1, 3, ?, ?, ?, 1, '[]', ?, 1)
+        """,
+        [
+            (_JOB_ID, "discover", "succeeded", _MIGRATION_AT, None, None, None),
+            (_JOB_ID, "enrich", "skipped", _MIGRATION_AT, None, None, None),
+            (_JOB_ID, "score", "succeeded", _MIGRATION_AT, None, None, None),
+            (
+                _JOB_ID,
+                "tailor",
+                "failed",
+                _MIGRATION_AT,
+                "quality_gate",
+                "needs revision",
+                "retry_tailor",
+            ),
+        ],
+    )
+    _seed_materials(candidate)
+    _seed_mutable_template_drift(candidate)
+    candidate.executemany(
+        """
+        INSERT INTO artifact_list_projections (
+            artifact_id, tenant_id, job_id, job_title, job_employer,
+            artifact_type, status, local_path
+        ) VALUES (?, 'local', ?, 'Cache title', 'Cache employer', ?, ?, ?)
+        """,
+        [
+            ("artifact-active", _JOB_ID, "tailored_resume", "approved", "/tmp/resume.txt"),
+            ("artifact-pdf", _JOB_ID, "resume_pdf", "approved", "/tmp/resume.pdf"),
+            ("artifact-suppressed", _JOB_ID, "debug", "suppressed", "/tmp/debug.txt"),
+        ],
+    )
+    candidate.execute(
+        """
+        INSERT INTO job_list_projections (tenant_id, job_id, title)
+        VALUES ('local', ?, 'STALE URL CACHE')
+        """,
+        (_JOB_URL,),
+    )
+    candidate.execute(
+        """
+        INSERT INTO apply_run_projections (
+            run_id, tenant_id, job_id, job_title, job_employer, status, result,
+            dry_run, started_at, finished_at, events_json
+        ) VALUES ('run-latest', 'local', ?, 'Ignored title', 'Ignored employer',
+                  'succeeded', 'applied', 0, '2026-07-30T13:00:00+00:00',
+                  '2026-07-30T13:05:00+00:00', '[]')
+        """,
+        (_JOB_ID,),
+    )
+    candidate.execute(
+        """
+        INSERT INTO jobctrl_deleted_jobs (
+            tenant_id, job_id, deleted_at, reason, restored_at
+        ) VALUES ('local', ?, '2026-07-30T14:00:00+00:00', 'duplicate',
+                  '2026-07-30T13:59:00+00:00')
+        """,
+        (_JOB_ID,),
+    )
+    return candidate
+
+
+def _seed_materials(candidate: sqlite3.Connection) -> None:
+    accepted_metadata = json.dumps(
+        {
+            "resume_template": {
+                "templateId": "accepted-template",
+                "templateName": "Accepted template",
+            },
+            "tailoringPolicyVersion": 7,
+        }
+    )
+    candidate.executemany(
+        """
+        INSERT INTO job_materials (
+            tenant_id, job_id, generation, status, created_at, updated_at,
+            metadata_json
+        ) VALUES ('local', ?, ?, ?, ?, ?, ?)
+        """,
+        [
+            (_JOB_ID, 4, "complete", _MIGRATION_AT, _MIGRATION_AT, _INERT_CONTEXT_JSON),
+            (_JOB_ID, 5, "resume_in_progress", _MIGRATION_AT, _MIGRATION_AT, _INERT_CONTEXT_JSON),
+        ],
+    )
+    candidate.executemany(
+        """
+        INSERT INTO job_materials_artifacts (
+            tenant_id, job_id, generation, artifact_type, artifact_id, status,
+            path, render_format, size_bytes, metadata_json, created_at, superseded_at
+        ) VALUES ('local', ?, ?, ?, ?, ?, ?, 'text', 100, ?, ?, NULL)
+        """,
+        [
+            (
+                _JOB_ID,
+                4,
+                "tailored_resume",
+                "accepted-resume",
+                "approved",
+                "/tmp/accepted-resume.txt",
+                accepted_metadata,
+                _MIGRATION_AT,
+            ),
+            (
+                _JOB_ID,
+                4,
+                "cover_letter",
+                "accepted-cover",
+                "approved",
+                "/tmp/accepted-cover.txt",
+                None,
+                _MIGRATION_AT,
+            ),
+            (
+                _JOB_ID,
+                4,
+                "resume_pdf",
+                "accepted-resume-pdf",
+                "approved",
+                "/tmp/accepted-resume.pdf",
+                None,
+                _MIGRATION_AT,
+            ),
+            (
+                _JOB_ID,
+                5,
+                "tailored_resume",
+                "rejected-resume",
+                "rejected",
+                "/tmp/rejected-resume.txt",
+                json.dumps(
+                    {
+                        "resume_template": {
+                            "templateId": "rejected-template",
+                            "templateName": "Rejected template",
+                        },
+                        "tailoringPolicyVersion": 99,
+                    }
+                ),
+                _MIGRATION_AT,
+            ),
+        ],
+    )
+
+
+def _seed_mutable_template_drift(candidate: sqlite3.Connection) -> None:
+    candidate.execute(
+        """
+        INSERT INTO resume_templates (
+            tenant_id, template_id, display_name, status, built_in, created_at, updated_at
+        ) VALUES ('local', 'mutable-template', 'Mutable default', 'active', 0, ?, ?)
+        """,
+        (_MIGRATION_AT, _MIGRATION_AT),
+    )
+    candidate.execute(
+        """
+        INSERT INTO resume_template_versions (
+            tenant_id, version_id, template_id, version_number, display_name,
+            status, theme_json, layout_json, content_hash, created_at
+        ) VALUES ('local', 'mutable-version', 'mutable-template', 1, 'Mutable default',
+                  'active', '{}', '{}', 'hash', ?)
+        """,
+        (_MIGRATION_AT,),
+    )
+    candidate.execute(
+        """
+        INSERT INTO resume_template_defaults (
+            tenant_id, profile_id, template_id, version_id, updated_at
+        ) VALUES ('local', 'default', 'mutable-template', 'mutable-version', ?)
+        """,
+        (_MIGRATION_AT,),
+    )
+    candidate.execute(
+        """
+        INSERT INTO job_resume_template_assignments (
+            tenant_id, job_id, template_id, version_id, updated_at
+        ) VALUES ('local', ?, 'mutable-template', 'mutable-version', ?)
+        """,
+        (_JOB_ID, _MIGRATION_AT),
+    )
+
+
+def _row(candidate: sqlite3.Connection) -> dict[str, object]:
+    rows = _projection_rows(candidate, _MIGRATION_AT)
+    assert len(rows) == 1
+    assert len(rows[0]) == 41
+    assert len(JOB_LIST_PROJECTIONS_COLUMNS) == 41
+    return dict(zip(JOB_LIST_PROJECTIONS_COLUMNS, rows[0], strict=True))
+
+
+def test_serializes_every_v7_column_from_canonical_uuid_rows() -> None:
+    candidate = _candidate()
+    try:
+        row = _row(candidate)
+
+        assert row["job_id"] == _JOB_ID
+        assert row["job_id"] != _JOB_URL
+        assert "STALE URL CACHE" not in json.dumps(row)
+        assert row["title"] == "Platform Engineer"
+        assert row["employer"] == "Exampleco"
+        assert row["location"] == "Community of Madrid, Spain (Remote)"
+        assert row["full_description"] == "Canonical enriched description"
+        assert row["fit_score"] == 8
+        assert row["fit_band"] == "strong"
+        assert row["score_version"] == 3
+        assert row["score_reasoning"] == "canonical score"
+        assert row["score_criteria_json"] == '{"opaque":{"criterion":"keep-exact"}}'
+        assert row["score_trace_json"] == '{"opaque":{"trace":"keep-exact"}}'
+        assert row["score_correction_json"] == '{"opaque":{"repair":"keep-exact"}}'
+        assert json.loads(str(row["score_breakdown_json"])) == {
+            "technicalFit": 9,
+            "experienceFit": 8,
+            "roleFit": 7,
+            "reasoning": "canonical score",
+            "fitBand": "plausible",
+            "confidence": "medium",
+            "eligibility": {
+                "status": "unknown",
+                "hardBlockers": [],
+                "warnings": [],
+            },
+            "matchedSignals": ["Python"],
+            "missingSignals": [],
+            "transferableSignals": [],
+        }
+        assert json.loads(str(row["compensation_summary_json"]))["legacyRawSalary"] == "€95k"
+        assert (
+            row["current_stage"],
+            row["current_substage"],
+            row["current_state"],
+            row["current_error_code"],
+            row["current_error_message"],
+            row["current_next_action"],
+        ) == ("discover", "tailor", "failed", "quality_gate", "needs revision", "retry_tailor")
+        assert (row["has_resume"], row["has_cover_letter"], row["has_pdf"]) == (True, True, True)
+        assert row["resume_template_id"] == "accepted-template"
+        assert row["resume_template_name"] == "Accepted template"
+        assert row["tailoring_policy_version"] == 7
+        assert row["artifact_count"] == 2
+        assert row["apply_status"] == "applied"
+        assert row["applied_at"] == "2026-07-30T13:05:00+00:00"
+        assert row["apply_mode"] == "automated_live"
+        assert row["deleted_at"] == "2026-07-30T14:00:00+00:00"
+        assert row["last_updated_at"] == _MIGRATION_AT
+        assert candidate.execute(
+            "SELECT metadata_json FROM job_materials WHERE generation = 4"
+        ).fetchone() == (_INERT_CONTEXT_JSON,)
+    finally:
+        candidate.close()
+
+
+def test_apply_legacy_fallbacks_and_active_delete_lifecycle() -> None:
+    candidate = _candidate()
+    try:
+        candidate.execute("DELETE FROM apply_run_projections")
+        candidate.execute(
+            """
+            INSERT INTO job_events (
+                tenant_id, job_id, identity_version, stage, event_type, occurred_at
+            ) VALUES ('local', ?, 1, 'apply', 'ApplicationManuallyMarked', ?)
+            """,
+            (_JOB_ID, _MIGRATION_AT),
+        )
+        row = _row(candidate)
+        assert row["apply_status"] == "applied"
+        assert row["applied_at"] == "2026-07-30T12:00:00+00:00"
+        assert row["apply_mode"] == "manual_marked"
+
+        candidate.execute("DELETE FROM job_events")
+        candidate.execute(
+            """
+            INSERT INTO application_outcomes (
+                tenant_id, outcome_id, job_id, kind, source, occurred_at, recorded_at
+            ) VALUES ('local', 'outcome-1', ?, 'applied_confirmation', 'gmail', ?, ?)
+            """,
+            (_JOB_ID, _MIGRATION_AT, _MIGRATION_AT),
+        )
+        candidate.execute(
+            """
+            UPDATE jobctrl_deleted_jobs
+            SET restored_at = '2026-07-30T14:01:00+00:00'
+            WHERE tenant_id = 'local' AND job_id = ?
+            """,
+            (_JOB_ID,),
+        )
+        row = _row(candidate)
+        assert row["apply_mode"] == "external_confirmed"
+        assert row["deleted_at"] is None
+    finally:
+        candidate.close()


### PR DESCRIPTION
## Summary
- add a pure serializer for all 41 v7 job-list projection columns
- derive identity, scoring, compensation, workflow stages, accepted material metadata, artifacts, apply state, lifecycle, and deletion state from canonical v7 inputs
- ignore stale v6 job-list cache rows and rejected newer generated materials

## Why
The one-shot v6 to v7 migration needs a deterministic, reviewable row contract before database writes are introduced. This PR contains only the pure transformation layer.

## Stack
- Base: #594
- Next: atomic job-list projection writer

## Validation
- focused serializer and writer suite: 9 passed
- cumulative v6 to v7 migration and packaging suite: 137 passed
- Ruff and git diff --check: passed
- independent review: PASS, no findings
- independent QA of the cumulative child: PASS, no findings