### PR TITLE
feat(storage): rebuild v7 job-list projections

### DIFF
--- a/workers/automation/src/jobctrl/infrastructure/migrations/v6_to_v7_job_list_projections.py
+++ b/workers/automation/src/jobctrl/infrastructure/migrations/v6_to_v7_job_list_projections.py
@@ -1,0 +1,317 @@
+"""Atomically persist complete v7 job-list rows during the v6 cutover."""
+
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+
+from jobctrl.infrastructure.migrations import (
+    v6_to_v7_apply_run_projections as apply_runs,
+)
+from jobctrl.infrastructure.migrations import (
+    v6_to_v7_artifact_list_projections as artifacts,
+)
+from jobctrl.infrastructure.migrations.schema_manifest import (
+    EXACT_V7_MANIFEST,
+    assert_exact_manifest,
+)
+from jobctrl.infrastructure.migrations.v6_to_v7_copy import (
+    CandidateCopyError,
+    JobIdMap,
+    build_job_id_map,
+)
+from jobctrl.infrastructure.migrations.v6_to_v7_preflight import (
+    assert_v6_migration_preflight,
+)
+from jobctrl.infrastructure.migrations.v7_job_list_projection_rows import (
+    CandidateJobListProjectionsError,
+    JOB_LIST_PROJECTIONS_COLUMNS,
+    JOB_LIST_PROJECTIONS_TABLE,
+    _projection_rows,
+    _required_text,
+)
+
+_TABLE = JOB_LIST_PROJECTIONS_TABLE
+_COLUMNS = JOB_LIST_PROJECTIONS_COLUMNS
+_CANONICAL_TABLES = (
+    "jobs",
+    "job_locators",
+    "job_enrichments",
+    "job_scores",
+    "job_requirement_fit_reports",
+    "job_stage_states",
+    "job_posted_compensation_facts",
+    "job_market_compensation_estimates",
+    "job_materials",
+    "job_materials_artifacts",
+    "apply_run_projections",
+    "artifact_list_projections",
+    "job_events",
+    "application_outcomes",
+    "jobctrl_deleted_jobs",
+)
+
+
+@dataclass(frozen=True)
+class CandidateJobListProjectionsResult:
+    """Verified candidate job-list projection rebuild result."""
+
+    rebuilt_job_list_projections: int
+
+
+def rebuild_job_list_projections(
+    source: sqlite3.Connection,
+    candidate: sqlite3.Connection,
+    *,
+    job_ids: JobIdMap,
+    migration_at: str,
+) -> CandidateJobListProjectionsResult:
+    """Rebuild complete list rows without trusting the v6 list cache.
+
+    This is a stopped-runtime, one-shot v6-to-v7 cutover step.  It requires
+    the canonical root rewrite plus already-rebuilt apply and artifact
+    projections, and leaves the source database byte-for-byte unchanged.
+    """
+    assert_v6_migration_preflight(source)
+    assert_exact_manifest(candidate, EXACT_V7_MANIFEST)
+    _assert_columns(candidate, _TABLE, _COLUMNS)
+    _assert_authoritative_roots(source, candidate, job_ids)
+    _assert_upstream_projections(candidate)
+    _assert_empty_target(candidate)
+    timestamp = _required_text(migration_at, "migration_at")
+
+    source_snapshot = _source_snapshot(source)
+    canonical_snapshot = _canonical_snapshot(candidate)
+    rows = _projection_rows(candidate, timestamp)
+
+    candidate.execute("SAVEPOINT v6_job_list_projection_rebuild")
+    try:
+        _insert_rows(candidate, rows)
+        _verify_candidate(
+            source=source,
+            candidate=candidate,
+            expected_rows=rows,
+            source_snapshot=source_snapshot,
+            canonical_snapshot=canonical_snapshot,
+        )
+        candidate.execute("RELEASE SAVEPOINT v6_job_list_projection_rebuild")
+    except BaseException:
+        candidate.execute("ROLLBACK TO SAVEPOINT v6_job_list_projection_rebuild")
+        candidate.execute("RELEASE SAVEPOINT v6_job_list_projection_rebuild")
+        raise
+
+    return CandidateJobListProjectionsResult(
+        rebuilt_job_list_projections=len(rows),
+    )
+
+
+def _assert_authoritative_roots(
+    source: sqlite3.Connection,
+    candidate: sqlite3.Connection,
+    job_ids: JobIdMap,
+) -> None:
+    try:
+        hydrated = build_job_id_map(source, candidate)
+    except CandidateCopyError as error:
+        raise CandidateJobListProjectionsError(
+            "job-list projection rebuild requires hydrated candidate roots"
+        ) from error
+    if dict(hydrated.by_locator) != dict(job_ids.by_locator):
+        raise CandidateJobListProjectionsError(
+            "supplied JobIdMap does not match hydrated candidate roots"
+        )
+    locators = {
+        (str(tenant_id), str(locator)): str(job_id)
+        for tenant_id, job_id, locator in candidate.execute(
+            """
+            SELECT tenant_id, job_id, locator_value
+            FROM job_locators
+            WHERE locator_kind = 'posting_url'
+              AND is_current = 1
+              AND retired_at IS NULL
+            """
+        ).fetchall()
+    }
+    if (
+        locators != dict(job_ids.by_locator)
+        or _row_count(candidate, "job_locators") != len(locators)
+    ):
+        raise CandidateJobListProjectionsError(
+            "job-list projection rebuild requires exactly one current root locator per JobId"
+        )
+
+
+def _assert_upstream_projections(candidate: sqlite3.Connection) -> None:
+    try:
+        apply_jobs = apply_runs._candidate_job_metadata(candidate)
+        apply_events = apply_runs._candidate_events_by_run(candidate, apply_jobs)
+        expected_apply_rows = tuple(
+            apply_runs._project_run(run_id, events, apply_jobs)
+            for run_id, events in sorted(apply_events.items())
+        )
+        actual_apply_rows = apply_runs._rows(
+            candidate,
+            "apply_run_projections",
+            apply_runs._PROJECTION_COLUMNS,
+        )
+    except apply_runs.CandidateApplyRunProjectionsError as error:
+        raise CandidateJobListProjectionsError(
+            "candidate apply-run projection cannot be verified"
+        ) from error
+    if actual_apply_rows != expected_apply_rows:
+        raise CandidateJobListProjectionsError(
+            "candidate apply_run_projections must match the canonical event rebuild"
+        )
+
+    try:
+        artifact_jobs = artifacts._candidate_job_metadata(candidate)
+        layout_by_artifact, provenance_by_artifact = artifacts._candidate_audits(
+            candidate
+        )
+        canonical_artifacts = artifacts._candidate_artifacts(
+            candidate,
+            artifact_jobs,
+        )
+        expected_artifact_rows = artifacts._project_artifacts(
+            canonical_artifacts,
+            artifact_jobs,
+            layout_by_artifact,
+            provenance_by_artifact,
+        )
+        actual_artifact_rows = artifacts._rows(
+            candidate,
+            "artifact_list_projections",
+            artifacts._COLUMNS,
+        )
+    except artifacts.CandidateArtifactListProjectionsError as error:
+        raise CandidateJobListProjectionsError(
+            "candidate artifact projection cannot be verified"
+        ) from error
+    if actual_artifact_rows != expected_artifact_rows:
+        raise CandidateJobListProjectionsError(
+            "candidate artifact_list_projections must match the canonical artifact rebuild"
+        )
+
+
+def _assert_empty_target(candidate: sqlite3.Connection) -> None:
+    if _row_count(candidate, _TABLE):
+        raise CandidateJobListProjectionsError(
+            "candidate job_list_projections must be empty"
+        )
+
+
+def _insert_rows(
+    candidate: sqlite3.Connection,
+    rows: tuple[tuple[object, ...], ...],
+) -> None:
+    if not rows:
+        return
+    candidate.executemany(
+        f"INSERT INTO {_identifier(_TABLE)} ({_identifiers(_COLUMNS)}) "
+        f"VALUES ({', '.join('?' for _ in _COLUMNS)})",
+        rows,
+    )
+
+
+def _verify_candidate(
+    *,
+    source: sqlite3.Connection,
+    candidate: sqlite3.Connection,
+    expected_rows: tuple[tuple[object, ...], ...],
+    source_snapshot: tuple[int, int],
+    canonical_snapshot: tuple[tuple[str, tuple[tuple[object, ...], ...]], ...],
+) -> None:
+    if _rows(candidate, _TABLE, _COLUMNS, order="tenant_id, job_id") != expected_rows:
+        raise CandidateJobListProjectionsError(
+            "candidate rebuild changed job-list projection rows"
+        )
+    if _row_count(candidate, _TABLE) != len(expected_rows):
+        raise CandidateJobListProjectionsError(
+            "candidate rebuild changed job-list projection row count"
+        )
+    if _source_snapshot(source) != source_snapshot:
+        raise CandidateJobListProjectionsError(
+            "candidate rebuild mutated the v6 source database"
+        )
+    if _canonical_snapshot(candidate) != canonical_snapshot:
+        raise CandidateJobListProjectionsError(
+            "candidate rebuild mutated canonical job-list inputs"
+        )
+    if candidate.execute("PRAGMA foreign_key_check").fetchall():
+        raise CandidateJobListProjectionsError(
+            "candidate rebuild left a foreign-key violation"
+        )
+    assert_v6_migration_preflight(source)
+    assert_exact_manifest(candidate, EXACT_V7_MANIFEST)
+
+
+def _canonical_snapshot(
+    candidate: sqlite3.Connection,
+) -> tuple[tuple[str, tuple[tuple[object, ...], ...]], ...]:
+    return tuple(
+        (table, _rows(candidate, table, _columns(candidate, table), order="rowid"))
+        for table in _CANONICAL_TABLES
+    )
+
+
+def _source_snapshot(source: sqlite3.Connection) -> tuple[int, int]:
+    """Capture mutation-only source state without reading the stale list cache."""
+    return (
+        source.total_changes,
+        int(source.execute("PRAGMA schema_version").fetchone()[0]),
+    )
+
+
+def _assert_columns(
+    conn: sqlite3.Connection,
+    table: str,
+    expected: tuple[str, ...],
+) -> None:
+    if _columns(conn, table) != expected:
+        raise CandidateJobListProjectionsError(
+            f"{table} columns do not match the exact v7 schema"
+        )
+
+
+def _columns(conn: sqlite3.Connection, table: str) -> tuple[str, ...]:
+    columns = tuple(
+        str(row[1])
+        for row in conn.execute(f"PRAGMA table_info({_identifier(table)})").fetchall()
+    )
+    if not columns:
+        raise CandidateJobListProjectionsError(f"missing required table: {table}")
+    return columns
+
+
+def _rows(
+    conn: sqlite3.Connection,
+    table: str,
+    columns: tuple[str, ...],
+    *,
+    order: str,
+) -> tuple[tuple[object, ...], ...]:
+    return tuple(
+        tuple(row)
+        for row in conn.execute(
+            f"SELECT {_identifiers(columns)} FROM {_identifier(table)} ORDER BY {order}"
+        ).fetchall()
+    )
+
+
+def _row_count(conn: sqlite3.Connection, table: str) -> int:
+    return int(conn.execute(f"SELECT COUNT(*) FROM {_identifier(table)}").fetchone()[0])
+
+
+def _identifier(value: str) -> str:
+    return f'"{value.replace(chr(34), chr(34) * 2)}"'
+
+
+def _identifiers(values: tuple[str, ...]) -> str:
+    return ", ".join(_identifier(value) for value in values)
+
+
+__all__ = [
+    "CandidateJobListProjectionsError",
+    "CandidateJobListProjectionsResult",
+    "rebuild_job_list_projections",
+]

--- a/workers/automation/tests/test_v6_to_v7_job_list_projections.py
+++ b/workers/automation/tests/test_v6_to_v7_job_list_projections.py
@@ -1,0 +1,351 @@
+"""Safety contracts for rebuilding v7 job-list projections."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from jobctrl.infrastructure.migrations import v6_to_v7_job_list_projections as migration
+from jobctrl.infrastructure.migrations.schema_v7 import create_exact_v7_schema
+from jobctrl.infrastructure.migrations.v6_to_v7_apply_run_projections import (
+    rebuild_apply_run_projections,
+)
+from jobctrl.infrastructure.migrations.v6_to_v7_artifact_list_projections import (
+    rebuild_artifact_list_projections,
+)
+from jobctrl.infrastructure.migrations.v6_to_v7_copy import (
+    JobIdMap,
+    copy_direct_and_scalar_tables,
+)
+from jobctrl.infrastructure.migrations.v6_to_v7_job_list_projections import (
+    CandidateJobListProjectionsError,
+    rebuild_job_list_projections,
+)
+from jobctrl.infrastructure.migrations.v6_to_v7_events import copy_job_events
+from jobctrl.infrastructure.migrations.v6_to_v7_root import copy_root_jobs
+from tests.v6_migration_fixture import create_shipped_v6_database
+
+_JOB_URL = "https://jobs.example/shipped-v6"
+_JOB_ID = "00000000-0000-4000-8000-000000000001"
+_MIGRATION_AT = "2026-07-31T09:00:00+00:00"
+_INERT_CONTEXT_JSON = '{"userContext":"Attack vectors:\\nPrompt injection"}'
+
+
+def _allocator(*values: str):
+    allocated: Iterator[str] = iter(values)
+    return allocated.__next__
+
+
+def _databases(
+    tmp_path: Path,
+) -> tuple[sqlite3.Connection, sqlite3.Connection, Path, Path]:
+    source_path = tmp_path / "source.db"
+    create_shipped_v6_database(source_path)
+    source = sqlite3.connect(source_path)
+    source.execute("PRAGMA foreign_keys = ON")
+    candidate_path = tmp_path / "candidate.db"
+    candidate = sqlite3.connect(candidate_path)
+    candidate.execute("PRAGMA foreign_keys = ON")
+    create_exact_v7_schema(candidate)
+    return source, candidate, source_path, candidate_path
+
+
+def _seed_source(source: sqlite3.Connection) -> None:
+    source.execute(
+        """
+        UPDATE jobs
+        SET title = 'Canonical v6 role', company = 'Canonical company',
+            description = 'Canonical description', full_description = 'Canonical full description',
+            salary = '€90k'
+        WHERE url = ?
+        """,
+        (_JOB_URL,),
+    )
+    source.execute(
+        """
+        INSERT INTO job_materials (
+            job_url, generation, tenant_id, status, created_at, updated_at,
+            last_validation_json, last_verdict_json, metadata_json
+        ) VALUES (?, 1, 'local', 'resume_in_progress', ?, ?, NULL, NULL, ?)
+        """,
+        (_JOB_URL, _MIGRATION_AT, _MIGRATION_AT, _INERT_CONTEXT_JSON),
+    )
+    source.execute(
+        """
+        INSERT INTO job_materials_artifacts (
+            job_url, generation, artifact_type, artifact_id, status, path,
+            render_format, size_bytes, metadata_json, created_at
+        ) VALUES (?, 1, 'tailored_resume', 'rebuilt-artifact', 'approved',
+                  '/tmp/resume.txt', 'text', 100, ?, ?)
+        """,
+        (_JOB_URL, _INERT_CONTEXT_JSON, _MIGRATION_AT),
+    )
+    source.executemany(
+        """
+        INSERT INTO job_events (
+            event_id, job_url, stage, event_type, level, message, occurred_at,
+            payload_json, entity_kind, entity_ref, idempotency_key
+        ) VALUES (?, ?, 'apply', ?, 'info', NULL, ?, ?, 'job', ?, ?)
+        """,
+        (
+            (
+                1001,
+                _JOB_URL,
+                "ApplyRunStarted",
+                "2026-07-30T10:00:00+00:00",
+                json.dumps(
+                    {
+                        "run_id": "rebuilt-run",
+                        "job_id": _JOB_URL,
+                        "started_at": "2026-07-30T10:00:00+00:00",
+                        "dry_run": False,
+                    }
+                ),
+                _JOB_URL,
+                "job-list-apply-started",
+            ),
+            (
+                1002,
+                _JOB_URL,
+                "ApplicationSubmitted",
+                "2026-07-30T10:01:00+00:00",
+                json.dumps(
+                    {
+                        "run_id": "rebuilt-run",
+                        "job_id": _JOB_URL,
+                        "result": "applied",
+                        "finished_at": "2026-07-30T10:01:00+00:00",
+                    }
+                ),
+                _JOB_URL,
+                "job-list-apply-submitted",
+            ),
+        ),
+    )
+    # This URL-keyed v6 cache is deliberately stale and must never be read.
+    source.execute(
+        """
+        INSERT INTO job_list_projections (
+            tenant_id, job_id, title, source, score_keywords_json, score_reasoning,
+            current_stage, current_substage, current_state, last_updated_at
+        ) VALUES ('local', ?, 'STALE URL CACHE', 'stale', '[]', 'stale',
+                  'apply', 'apply', 'succeeded', ?)
+        """,
+        (_JOB_URL, _MIGRATION_AT),
+    )
+    source.commit()
+
+
+def _hydrate(source: sqlite3.Connection, candidate: sqlite3.Connection) -> JobIdMap:
+    roots = copy_root_jobs(
+        source,
+        candidate,
+        job_id_factory=_allocator(_JOB_ID),
+        migration_at=_MIGRATION_AT,
+    )
+    copy_direct_and_scalar_tables(source, candidate)
+    copy_job_events(source, candidate, job_ids=roots.job_ids)
+    rebuild_apply_run_projections(source, candidate, job_ids=roots.job_ids)
+    rebuild_artifact_list_projections(source, candidate, job_ids=roots.job_ids)
+    return roots.job_ids
+
+
+def test_rebuild_uses_canonical_candidate_rows_ignores_v6_cache_and_reopens(
+    tmp_path: Path,
+) -> None:
+    source, candidate, source_path, candidate_path = _databases(tmp_path)
+    try:
+        _seed_source(source)
+        source_bytes = source_path.read_bytes()
+        source_cache = tuple(
+            source.execute("SELECT * FROM job_list_projections").fetchall()
+        )
+        with pytest.raises(
+            CandidateJobListProjectionsError,
+            match="hydrated candidate roots",
+        ):
+            rebuild_job_list_projections(
+                source,
+                candidate,
+                job_ids=JobIdMap({}),
+                migration_at=_MIGRATION_AT,
+            )
+
+        job_ids = _hydrate(source, candidate)
+        result = rebuild_job_list_projections(
+            source,
+            candidate,
+            job_ids=job_ids,
+            migration_at=_MIGRATION_AT,
+        )
+
+        assert result.rebuilt_job_list_projections == 1
+        row = candidate.execute(
+            """
+            SELECT job_id, title, artifact_count, apply_status, applied_at,
+                   apply_mode, last_updated_at
+            FROM job_list_projections
+            """
+        ).fetchone()
+        assert row == (
+            _JOB_ID,
+            "Canonical v6 role",
+            1,
+            "applied",
+            "2026-07-30T10:01:00+00:00",
+            "automated_live",
+            _MIGRATION_AT,
+        )
+        assert "STALE URL CACHE" not in str(row)
+        assert tuple(source.execute("SELECT * FROM job_list_projections").fetchall()) == source_cache
+        assert source_path.read_bytes() == source_bytes
+        assert candidate.execute("PRAGMA foreign_key_check").fetchall() == []
+        assert candidate.execute(
+            "SELECT metadata_json FROM job_materials"
+        ).fetchone() == (_INERT_CONTEXT_JSON,)
+        with pytest.raises(CandidateJobListProjectionsError, match="must be empty"):
+            rebuild_job_list_projections(
+                source,
+                candidate,
+                job_ids=job_ids,
+                migration_at=_MIGRATION_AT,
+            )
+
+        candidate.commit()
+        candidate.close()
+        candidate = sqlite3.connect(candidate_path)
+        candidate.execute("PRAGMA foreign_keys = ON")
+        assert candidate.execute("SELECT job_id FROM job_list_projections").fetchone() == (
+            _JOB_ID,
+        )
+        assert candidate.execute("PRAGMA foreign_key_check").fetchall() == []
+    finally:
+        source.close()
+        candidate.close()
+
+
+def test_post_insert_failure_rolls_back_then_retries(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source, candidate, _source_path, _candidate_path = _databases(tmp_path)
+    try:
+        _seed_source(source)
+        job_ids = _hydrate(source, candidate)
+        original_verify = migration._verify_candidate
+
+        def fail_after_insert(**_: object) -> None:
+            raise CandidateJobListProjectionsError("injected verification failure")
+
+        monkeypatch.setattr(migration, "_verify_candidate", fail_after_insert)
+        with pytest.raises(
+            CandidateJobListProjectionsError,
+            match="injected verification failure",
+        ):
+            rebuild_job_list_projections(
+                source,
+                candidate,
+                job_ids=job_ids,
+                migration_at=_MIGRATION_AT,
+            )
+        assert candidate.execute("SELECT COUNT(*) FROM job_list_projections").fetchone() == (0,)
+
+        monkeypatch.setattr(migration, "_verify_candidate", original_verify)
+        result = rebuild_job_list_projections(
+            source,
+            candidate,
+            job_ids=job_ids,
+            migration_at=_MIGRATION_AT,
+        )
+        assert result.rebuilt_job_list_projections == 1
+        assert candidate.execute("PRAGMA foreign_key_check").fetchall() == []
+    finally:
+        source.close()
+        candidate.close()
+
+
+def test_canonical_input_mutation_rolls_back_the_projection_write(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source, candidate, _source_path, _candidate_path = _databases(tmp_path)
+    try:
+        _seed_source(source)
+        job_ids = _hydrate(source, candidate)
+        original_insert = migration._insert_rows
+        before_jobs = tuple(candidate.execute("SELECT * FROM jobs").fetchall())
+
+        def mutate_after_insert(
+            destination: sqlite3.Connection,
+            rows: tuple[tuple[object, ...], ...],
+        ) -> None:
+            original_insert(destination, rows)
+            destination.execute("UPDATE jobs SET title = 'mutated candidate input'")
+
+        monkeypatch.setattr(migration, "_insert_rows", mutate_after_insert)
+        with pytest.raises(
+            CandidateJobListProjectionsError,
+            match="mutated canonical job-list inputs",
+        ):
+            rebuild_job_list_projections(
+                source,
+                candidate,
+                job_ids=job_ids,
+                migration_at=_MIGRATION_AT,
+            )
+        assert candidate.execute("SELECT COUNT(*) FROM job_list_projections").fetchone() == (0,)
+        assert tuple(candidate.execute("SELECT * FROM jobs").fetchall()) == before_jobs
+        assert candidate.execute("PRAGMA foreign_key_check").fetchall() == []
+    finally:
+        source.close()
+        candidate.close()
+
+
+@pytest.mark.parametrize(
+    ("table", "mutation"),
+    (
+        ("apply_run_projections", "DELETE FROM apply_run_projections"),
+        (
+            "apply_run_projections",
+            "UPDATE apply_run_projections SET status = 'failed'",
+        ),
+        ("artifact_list_projections", "DELETE FROM artifact_list_projections"),
+        (
+            "artifact_list_projections",
+            "UPDATE artifact_list_projections SET job_title = 'stale title'",
+        ),
+    ),
+)
+def test_rebuild_rejects_incomplete_or_stale_upstream_projections(
+    tmp_path: Path,
+    table: str,
+    mutation: str,
+) -> None:
+    source, candidate, _, _ = _databases(tmp_path)
+    try:
+        _seed_source(source)
+        job_ids = _hydrate(source, candidate)
+        candidate.execute(mutation)
+
+        with pytest.raises(
+            CandidateJobListProjectionsError,
+            match=f"candidate {table} must match the canonical",
+        ):
+            rebuild_job_list_projections(
+                source,
+                candidate,
+                job_ids=job_ids,
+                migration_at=_MIGRATION_AT,
+            )
+
+        assert candidate.execute(
+            "SELECT COUNT(*) FROM job_list_projections"
+        ).fetchone() == (0,)
+        assert candidate.execute("PRAGMA foreign_key_check").fetchall() == []
+    finally:
+        source.close()
+        candidate.close()


### PR DESCRIPTION
## Summary
- rebuild v7 job-list projections atomically from canonical candidate data
- verify apply-run and artifact-list prerequisites by exact canonical recomputation before any job-list write
- preserve source immutability, savepoint rollback, retry safety, foreign-key integrity, and exact-v7 manifest checks
- reject empty, stale-rooted, or content-divergent prerequisite projections

## Why
The migration must never accept a superficially populated but stale upstream projection. Exact row parity makes the writer fail closed before it can publish a partially trustworthy job list.

## Stack
- Base: #595
- Depends on: #594

## Validation
- focused serializer and writer suite: 9 passed
- cumulative v6 to v7 migration and packaging suite: 137 passed
- empty and stale apply/artifact fault cases: rejected before writes
- valid rebuild, rollback/retry, reopen, source-integrity, and foreign-key checks: passed
- Ruff and git diff --check: passed
- independent review: PASS, no findings
- independent QA: PASS, no findings