### PR TITLE
feat(storage): add v7 dashboard outcome conversion

### DIFF
--- a/workers/automation/src/jobctrl/infrastructure/migrations/v7_dashboard_outcome_conversion.py
+++ b/workers/automation/src/jobctrl/infrastructure/migrations/v7_dashboard_outcome_conversion.py
@@ -1,0 +1,299 @@
+"""Fold privacy-safe v7 application outcomes into dashboard conversion counts."""
+
+from __future__ import annotations
+
+import sqlite3
+import uuid
+from collections.abc import Mapping
+
+from jobctrl.infrastructure.projections import projection_builder
+
+
+class CandidateDashboardOutcomeConversionError(RuntimeError):
+    """Raised when v7 outcome conversion cannot be derived safely."""
+
+
+def build_dashboard_outcome_conversion(
+    candidate: sqlite3.Connection,
+    *,
+    tenant_id: str,
+    active_rows: list[Mapping[str, object]],
+    root_job_ids: set[str],
+) -> dict[str, object]:
+    """Return version-2 raw conversion counts for one tenant.
+
+    Only outcome identity, kind, and occurrence time plus decided suggestion
+    status are selected. Notes, evidence, rationale, and decision text never
+    enter this derived dashboard shape.
+    """
+    tenant = _required_text(tenant_id, "tenant_id")
+    roots = {_required_uuid(job_id, "root job_id") for job_id in root_job_ids}
+    outcomes = _outcomes(candidate, tenant, roots)
+    suggestion_accuracy = _suggestion_accuracy(candidate, tenant)
+    applied_rows = [row for row in active_rows if _is_applied(row)]
+    totals = _blank_conversion_counts()
+    by_source: dict[str, dict[str, int]] = {}
+    by_band: dict[str, dict[str, int]] = {}
+    by_fit_band: dict[str, dict[str, int]] = {}
+    by_apply_mode: dict[str, dict[str, int]] = {}
+    by_template: dict[str, dict[str, object]] = {}
+    by_policy: dict[str, dict[str, int]] = {}
+    response_minutes: list[int] = []
+
+    for row in applied_rows:
+        job_id = _required_uuid(row.get("job_id"), "job-list job_id")
+        if job_id not in roots:
+            raise CandidateDashboardOutcomeConversionError(
+                "active dashboard row must reference a canonical v7 job"
+            )
+        job_outcomes = outcomes.get(job_id, ())
+        source = _optional_text(row.get("source")) or "unknown"
+        band = projection_builder._score_band(
+            _optional_integer(row.get("fit_score"), "job-list fit_score")
+        )
+        fit_band = projection_builder._fit_band(
+            _optional_text(row.get("fit_band"))
+        )
+        apply_mode = projection_builder._apply_mode(
+            _optional_text(row.get("apply_mode"))
+        )
+        template_id = projection_builder._template_key(
+            _optional_text(row.get("resume_template_id"))
+        )
+        template_name = (
+            None
+            if template_id == "unreported"
+            else projection_builder._projection_text(
+                row.get("resume_template_name")
+            )
+        )
+        policy = projection_builder._policy_key(
+            _optional_integer(
+                row.get("tailoring_policy_version"),
+                "job-list tailoring_policy_version",
+            )
+        )
+        first_response = projection_builder._first_response_minutes(
+            _optional_text(row.get("applied_at")),
+            job_outcomes,
+        )
+        if first_response is not None:
+            response_minutes.append(first_response)
+        template_bucket = by_template.setdefault(
+            template_id,
+            {"templateName": template_name, "counts": _blank_conversion_counts()},
+        )
+        if not template_bucket["templateName"] and template_name:
+            template_bucket["templateName"] = template_name
+        buckets: tuple[dict[str, int], ...] = (
+            totals,
+            by_source.setdefault(source, _blank_conversion_counts()),
+            by_band.setdefault(band, _blank_conversion_counts()),
+            by_fit_band.setdefault(fit_band, _blank_conversion_counts()),
+            by_apply_mode.setdefault(apply_mode, _blank_conversion_counts()),
+            _conversion_bucket(template_bucket),
+            by_policy.setdefault(policy, _blank_conversion_counts()),
+        )
+        for bucket in buckets:
+            bucket["applied"] += 1
+            if projection_builder._has_any_kind(
+                job_outcomes, projection_builder._REPLY_OUTCOME_KINDS
+            ):
+                bucket["reply"] += 1
+            if projection_builder._has_any_kind(
+                job_outcomes, projection_builder._INTERVIEW_OUTCOME_KINDS
+            ):
+                bucket["interview"] += 1
+            if projection_builder._has_any_kind(
+                job_outcomes, projection_builder._OFFER_OUTCOME_KINDS
+            ):
+                bucket["offer"] += 1
+            if projection_builder._has_any_kind(
+                job_outcomes, projection_builder._REJECTION_OUTCOME_KINDS
+            ):
+                bucket["rejection"] += 1
+
+    return {
+        "version": 2,
+        "totals": totals,
+        "bySource": [
+            {"source": source, **counts}
+            for source, counts in sorted(
+                by_source.items(), key=lambda item: (-item[1]["applied"], item[0])
+            )
+        ],
+        "byBand": [
+            {"band": band, **by_band[band]}
+            for band in projection_builder.SCORE_BAND_ORDER
+            if band in by_band
+        ],
+        "byFitBand": [
+            {"fitBand": band, **by_fit_band[band]}
+            for band in projection_builder.FIT_BAND_ORDER
+            if band in by_fit_band
+        ],
+        "byApplyMode": [
+            {"applyMode": mode, **by_apply_mode[mode]}
+            for mode in projection_builder.APPLY_MODE_ORDER
+            if mode in by_apply_mode
+        ],
+        "byTemplate": [
+            {
+                "templateId": template_id,
+                "templateName": bucket["templateName"],
+                **_conversion_bucket(bucket),
+            }
+            for template_id, bucket in sorted(
+                by_template.items(),
+                key=lambda item: (
+                    -_conversion_bucket(item[1])["applied"],
+                    str(item[1]["templateName"] or item[0]),
+                    item[0],
+                ),
+            )
+        ],
+        "byPolicy": [
+            {
+                "tailoringPolicyVersion": projection_builder._policy_version_from_key(
+                    key
+                ),
+                "policyLabel": projection_builder._policy_label(
+                    projection_builder._policy_version_from_key(key)
+                ),
+                **counts,
+            }
+            for key, counts in sorted(
+                by_policy.items(),
+                key=lambda item: (
+                    -item[1]["applied"],
+                    projection_builder._policy_version_from_key(item[0])
+                    if projection_builder._policy_version_from_key(item[0])
+                    is not None
+                    else 9_007_199_254_740_991,
+                ),
+            )
+        ],
+        "timeToResponseMinutes": sorted(response_minutes),
+        "suggestionAccuracy": suggestion_accuracy,
+    }
+
+
+def _outcomes(
+    candidate: sqlite3.Connection,
+    tenant_id: str,
+    root_job_ids: set[str],
+) -> dict[str, tuple[dict[str, str], ...]]:
+    grouped: dict[str, list[dict[str, str]]] = {}
+    for job_id, kind, occurred_at in candidate.execute(
+        """
+        SELECT job_id, kind, occurred_at
+        FROM application_outcomes
+        WHERE tenant_id = ?
+        ORDER BY job_id, occurred_at, outcome_id
+        """,
+        (tenant_id,),
+    ).fetchall():
+        stable_job_id = _required_uuid(job_id, "outcome job_id")
+        if stable_job_id not in root_job_ids:
+            raise CandidateDashboardOutcomeConversionError(
+                "application outcome must reference a canonical v7 job"
+            )
+        grouped.setdefault(stable_job_id, []).append(
+            {
+                "kind": _required_text(kind, "outcome kind"),
+                "occurredAt": _required_text(occurred_at, "outcome occurred_at"),
+            }
+        )
+    return {job_id: tuple(values) for job_id, values in grouped.items()}
+
+
+def _suggestion_accuracy(
+    candidate: sqlite3.Connection,
+    tenant_id: str,
+) -> dict[str, int]:
+    counts = _blank_suggestion_accuracy()
+    for (status,) in candidate.execute(
+        """
+        SELECT status
+        FROM application_outcome_suggestions
+        WHERE tenant_id = ?
+          AND status IN ('accepted', 'corrected', 'ignored')
+        ORDER BY suggestion_id
+        """,
+        (tenant_id,),
+    ).fetchall():
+        normalized = _required_text(status, "outcome suggestion status").lower()
+        counts["decided"] += 1
+        counts[normalized] += 1
+    return counts
+
+
+def _conversion_bucket(bucket: Mapping[str, object]) -> dict[str, int]:
+    counts = bucket.get("counts")
+    if not isinstance(counts, dict):
+        raise CandidateDashboardOutcomeConversionError(
+            "dashboard template conversion bucket is malformed"
+        )
+    return counts
+
+
+def _is_applied(row: Mapping[str, object]) -> bool:
+    return bool(_optional_text(row.get("applied_at"))) or _text(
+        row.get("apply_status")
+    ) == "applied"
+
+
+def _blank_conversion_counts() -> dict[str, int]:
+    return {"applied": 0, "reply": 0, "interview": 0, "offer": 0, "rejection": 0}
+
+
+def _blank_suggestion_accuracy() -> dict[str, int]:
+    return {"decided": 0, "accepted": 0, "corrected": 0, "ignored": 0}
+
+
+def _required_uuid(value: object, label: str) -> str:
+    text = _required_text(value, label)
+    try:
+        parsed = uuid.UUID(text)
+    except (ValueError, AttributeError) as exc:
+        raise CandidateDashboardOutcomeConversionError(
+            f"{label} must be a canonical UUID"
+        ) from exc
+    if str(parsed) != text or parsed.version != 4:
+        raise CandidateDashboardOutcomeConversionError(
+            f"{label} must be a canonical UUIDv4"
+        )
+    return text
+
+
+def _required_text(value: object, label: str) -> str:
+    text = _text(value).strip()
+    if not text:
+        raise CandidateDashboardOutcomeConversionError(
+            f"{label} must not be empty"
+        )
+    return text
+
+
+def _optional_text(value: object) -> str | None:
+    text = _text(value).strip()
+    return text or None
+
+
+def _text(value: object) -> str:
+    return "" if value is None else str(value)
+
+
+def _optional_integer(value: object, label: str) -> int | None:
+    if value is None or value == "":
+        return None
+    if isinstance(value, bool):
+        raise CandidateDashboardOutcomeConversionError(
+            f"{label} must be an integer"
+        )
+    try:
+        return int(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError) as exc:
+        raise CandidateDashboardOutcomeConversionError(
+            f"{label} must be an integer"
+        ) from exc

--- a/workers/automation/tests/test_v7_dashboard_outcome_conversion.py
+++ b/workers/automation/tests/test_v7_dashboard_outcome_conversion.py
@@ -1,0 +1,235 @@
+"""Contract tests for privacy-safe v7 dashboard outcome conversion."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+
+import pytest
+
+from jobctrl.infrastructure.migrations.schema_v7 import create_exact_v7_schema
+from jobctrl.infrastructure.migrations.v7_dashboard_outcome_conversion import (
+    CandidateDashboardOutcomeConversionError,
+    build_dashboard_outcome_conversion,
+)
+
+_MIGRATION_AT = "2026-07-31T09:00:00+00:00"
+_INERT_CONTEXT = '{"userContext":"Attack vectors:\\nPrompt injection"}'
+_JOB_IDS = tuple(
+    f"00000000-0000-4000-8000-{index:012d}" for index in range(1, 5)
+)
+
+
+def _candidate() -> sqlite3.Connection:
+    candidate = sqlite3.connect(":memory:")
+    candidate.execute("PRAGMA foreign_keys = ON")
+    create_exact_v7_schema(candidate)
+    for job_id in _JOB_IDS:
+        candidate.execute(
+            """
+            INSERT INTO jobs (url, title, company, tenant_id, job_id)
+            VALUES (?, 'Role', 'Example', 'local', ?)
+            """,
+            (f"https://jobs.example/{job_id}", job_id),
+        )
+    candidate.executemany(
+        """
+        INSERT INTO application_outcomes (
+            tenant_id, outcome_id, job_id, kind, source, note, occurred_at,
+            recorded_at, created_by
+        ) VALUES ('local', ?, ?, ?, 'manual', ?, ?, ?, 'user')
+        """,
+        [
+            (
+                "outcome-live",
+                _JOB_IDS[0],
+                "interview",
+                _INERT_CONTEXT,
+                "2026-07-30T13:00:00+00:00",
+                _MIGRATION_AT,
+            ),
+            (
+                "outcome-manual",
+                _JOB_IDS[1],
+                "rejection",
+                _INERT_CONTEXT,
+                "2026-07-30T11:00:00+00:00",
+                _MIGRATION_AT,
+            ),
+            (
+                "outcome-inactive",
+                _JOB_IDS[3],
+                "offer",
+                _INERT_CONTEXT,
+                "2026-07-30T14:00:00+00:00",
+                _MIGRATION_AT,
+            ),
+        ],
+    )
+    candidate.executemany(
+        """
+        INSERT INTO application_outcome_suggestions (
+            tenant_id, suggestion_id, job_id, suggested_kind, confidence,
+            rationale, status, created_at
+        ) VALUES ('local', ?, ?, 'interview', 0.9, ?, ?, ?)
+        """,
+        [
+            ("suggestion-accepted", _JOB_IDS[0], _INERT_CONTEXT, "accepted", _MIGRATION_AT),
+            ("suggestion-corrected", _JOB_IDS[1], _INERT_CONTEXT, "corrected", _MIGRATION_AT),
+            ("suggestion-ignored", _JOB_IDS[2], _INERT_CONTEXT, "ignored", _MIGRATION_AT),
+            ("suggestion-pending", _JOB_IDS[3], _INERT_CONTEXT, "pending", _MIGRATION_AT),
+        ],
+    )
+    candidate.commit()
+    return candidate
+
+
+def _active_rows() -> list[dict[str, object]]:
+    return [
+        {
+            "job_id": _JOB_IDS[0],
+            "source": "greenhouse",
+            "fit_score": 9,
+            "fit_band": "excellent",
+            "apply_status": "applied",
+            "applied_at": "2026-07-30T12:00:00+00:00",
+            "apply_mode": "automated_live",
+            "resume_template_id": "template-modern",
+            "resume_template_name": "Modern compact",
+            "tailoring_policy_version": 3,
+        },
+        {
+            "job_id": _JOB_IDS[1],
+            "source": "linkedin",
+            "fit_score": 7,
+            "fit_band": "strong",
+            "apply_status": "applied",
+            "applied_at": "2026-07-30T12:00:00+00:00",
+            "apply_mode": "manual_marked",
+            "resume_template_id": "template-plain",
+            "resume_template_name": "Plain ATS",
+            "tailoring_policy_version": 4,
+        },
+        {
+            "job_id": _JOB_IDS[2],
+            "source": "",
+            "fit_score": None,
+            "fit_band": None,
+            "apply_status": None,
+            "applied_at": None,
+            "apply_mode": None,
+            "resume_template_id": None,
+            "resume_template_name": None,
+            "tailoring_policy_version": None,
+        },
+    ]
+
+
+def test_conversion_preserves_raw_counts_and_excludes_sensitive_text() -> None:
+    conversion = build_dashboard_outcome_conversion(
+        _candidate(),
+        tenant_id="local",
+        active_rows=_active_rows(),
+        root_job_ids=set(_JOB_IDS),
+    )
+
+    assert conversion["version"] == 2
+    assert conversion["totals"] == {
+        "applied": 2,
+        "reply": 2,
+        "interview": 1,
+        "offer": 0,
+        "rejection": 1,
+    }
+    assert conversion["bySource"] == [
+        {
+            "source": "greenhouse",
+            "applied": 1,
+            "reply": 1,
+            "interview": 1,
+            "offer": 0,
+            "rejection": 0,
+        },
+        {
+            "source": "linkedin",
+            "applied": 1,
+            "reply": 1,
+            "interview": 0,
+            "offer": 0,
+            "rejection": 1,
+        },
+    ]
+    assert [item["band"] for item in conversion["byBand"]] == ["perfect", "strong"]
+    assert [item["fitBand"] for item in conversion["byFitBand"]] == [
+        "excellent",
+        "strong",
+    ]
+    assert [item["applyMode"] for item in conversion["byApplyMode"]] == [
+        "automated_live",
+        "manual_marked",
+    ]
+    assert [item["templateId"] for item in conversion["byTemplate"]] == [
+        "template-modern",
+        "template-plain",
+    ]
+    assert [item["tailoringPolicyVersion"] for item in conversion["byPolicy"]] == [
+        3,
+        4,
+    ]
+    assert conversion["timeToResponseMinutes"] == [60]
+    assert conversion["suggestionAccuracy"] == {
+        "decided": 3,
+        "accepted": 1,
+        "corrected": 1,
+        "ignored": 1,
+    }
+
+    serialized = json.dumps(conversion, sort_keys=True)
+    assert "Attack vectors" not in serialized
+    assert "Prompt injection" not in serialized
+    assert "rationale" not in serialized
+    assert "note" not in serialized
+
+
+def test_conversion_is_deterministic_and_keeps_small_samples() -> None:
+    candidate = _candidate()
+    rows = _active_rows()
+    rows[0]["resume_template_id"] = "template-z"
+    rows[0]["resume_template_name"] = "Shared"
+    rows[1]["resume_template_id"] = "template-a"
+    rows[1]["resume_template_name"] = "Shared"
+
+    first = build_dashboard_outcome_conversion(
+        candidate,
+        tenant_id="local",
+        active_rows=rows,
+        root_job_ids=set(_JOB_IDS),
+    )
+    second = build_dashboard_outcome_conversion(
+        candidate,
+        tenant_id="local",
+        active_rows=list(reversed(rows)),
+        root_job_ids=set(reversed(_JOB_IDS)),
+    )
+
+    assert first == second
+    assert first["totals"]["applied"] == 2
+    assert [item["templateId"] for item in first["byTemplate"]] == [
+        "template-a",
+        "template-z",
+    ]
+
+
+def test_conversion_rejects_url_shaped_identity() -> None:
+    rows = _active_rows()
+    rows[0]["job_id"] = "https://jobs.example/legacy"
+
+    with pytest.raises(
+        CandidateDashboardOutcomeConversionError, match="canonical UUID"
+    ):
+        build_dashboard_outcome_conversion(
+            _candidate(),
+            tenant_id="local",
+            active_rows=rows,
+            root_job_ids=set(_JOB_IDS),
+        )


### PR DESCRIPTION
## Summary
- add a pure version-2 dashboard outcome-conversion fold for canonical v7 JobIds
- preserve raw counts across source, score, fit, apply-mode, template, and policy dimensions
- keep outcome notes, suggestion rationale, evidence, and other sensitive text out of the projection
- make equal template-name ordering deterministic with a template-ID tiebreaker

## Why
The dashboard migration needs a small, reviewable conversion contract before row assembly or database writes. This PR contains only the privacy-safe outcome fold.

## Stack
- Base: #596
- Next: cross-runtime template ordering parity

## Validation
- focused conversion tests: 3 passed
- cumulative dashboard contracts at stack head: 26 passed
- cumulative v6 to v7 migration suite at stack head: 198 passed
- independent review: PASS, no findings
- cumulative independent QA: PASS, no findings
- Ruff and git diff --check: passed