### PR TITLE
fix(projections): stabilize template conversion order

### DIFF
--- a/apps/api/src/projections.ts
+++ b/apps/api/src/projections.ts
@@ -4015,6 +4015,20 @@ function policyLabel(version: number | null): string {
   return version === null ? "Unreported" : `Policy v${version}`;
 }
 
+function compareUnicodeOrdinal(left: string, right: string): number {
+  const leftCodePoints = [...left];
+  const rightCodePoints = [...right];
+  const sharedLength = Math.min(leftCodePoints.length, rightCodePoints.length);
+  for (let index = 0; index < sharedLength; index += 1) {
+    const leftCodePoint = leftCodePoints[index]!.codePointAt(0)!;
+    const rightCodePoint = rightCodePoints[index]!.codePointAt(0)!;
+    if (leftCodePoint !== rightCodePoint) {
+      return leftCodePoint < rightCodePoint ? -1 : 1;
+    }
+  }
+  return leftCodePoints.length - rightCodePoints.length;
+}
+
 function buildOutcomeConversion(
   db: SqliteDatabase,
   tenantId: string,
@@ -4111,7 +4125,14 @@ function buildOutcomeConversion(
   }));
   const byTemplateList = [...byTemplate.entries()]
     .map(([templateId, bucket]) => ({ templateId, templateName: bucket.templateName, ...bucket.counts }))
-    .sort((a, b) => b.applied - a.applied || (a.templateName ?? a.templateId).localeCompare(b.templateName ?? b.templateId));
+    .sort((a, b) =>
+      b.applied - a.applied
+      || compareUnicodeOrdinal(
+        a.templateName ?? a.templateId,
+        b.templateName ?? b.templateId,
+      )
+      || compareUnicodeOrdinal(a.templateId, b.templateId),
+    );
   const byPolicyList = [...byPolicy.entries()]
     .map((entry) => {
       const [key, counts] = entry;

--- a/apps/api/test/projections.test.ts
+++ b/apps/api/test/projections.test.ts
@@ -4395,6 +4395,54 @@ describe("dashboard outcome-conversion projection", () => {
     }
   });
 
+  it("breaks equal template-count and name ties by template id", async () => {
+    const { dbPath, cleanup } = withTempDb();
+    try {
+      seedConversionDb(dbPath);
+      const fixturePath = path.join(
+        fileURLToPath(new URL("../../..", import.meta.url)),
+        "packages/domain-types/test/fixtures/dashboard_template_order.json",
+      );
+      const fixture = JSON.parse(fs.readFileSync(fixturePath, "utf8")) as {
+        entries: Array<{
+          templateId: string;
+          templateName: string;
+          applied: number;
+        }>;
+        expectedTemplateIds: string[];
+      };
+      seedJobs(
+        dbPath,
+        fixture.entries.flatMap((entry, entryIndex) =>
+          Array.from({ length: entry.applied }, (_, applicationIndex) => ({
+            url: `https://example.com/template-order-${entryIndex}-${applicationIndex}`,
+            site: "greenhouse",
+            fitScore: 9,
+            applied: true,
+            template: { id: entry.templateId, name: entry.templateName },
+          })),
+        ),
+      );
+      const app = buildApp({
+        dbPath,
+        configPath: path.join(path.dirname(dbPath), "config.json"),
+      });
+      try {
+        const res = await app.inject({ method: "GET", url: "/v1/analytics/outcomes" });
+        expect(res.statusCode, res.body).toBe(200);
+        expect(
+          res.json().byTemplate.map(
+            (entry: { templateId: string }) => entry.templateId,
+          ),
+        ).toEqual(fixture.expectedTemplateIds);
+      } finally {
+        await app.close();
+      }
+    } finally {
+      cleanup();
+    }
+  });
+
   it("returns an empty conversion with null rates when nothing is applied", async () => {
     const { dbPath, cleanup } = withTempDb();
     try {

--- a/packages/domain-types/test/fixtures/dashboard_template_order.json
+++ b/packages/domain-types/test/fixtures/dashboard_template_order.json
@@ -1,0 +1,42 @@
+{
+  "entries": [
+    {
+      "templateId": "template-name-accent",
+      "templateName": "éclair",
+      "applied": 2
+    },
+    {
+      "templateId": "template-name-ascii",
+      "templateName": "Zebra",
+      "applied": 2
+    },
+    {
+      "templateId": "template-😀",
+      "templateName": "Shared",
+      "applied": 1
+    },
+    {
+      "templateId": "template-a",
+      "templateName": "Shared",
+      "applied": 1
+    },
+    {
+      "templateId": "template-",
+      "templateName": "Shared",
+      "applied": 1
+    },
+    {
+      "templateId": "template-Z",
+      "templateName": "Shared",
+      "applied": 1
+    }
+  ],
+  "expectedTemplateIds": [
+    "template-name-ascii",
+    "template-name-accent",
+    "template-Z",
+    "template-a",
+    "template-",
+    "template-😀"
+  ]
+}

--- a/workers/automation/src/jobctrl/infrastructure/projections/projection_builder.py
+++ b/workers/automation/src/jobctrl/infrastructure/projections/projection_builder.py
@@ -553,6 +553,19 @@ def _template_key(value: str | None) -> str:
     return _projection_text(value) or "unreported"
 
 
+def _template_conversion_sort_key(
+    item: tuple[str, dict[str, object]],
+) -> tuple[int, str, str]:
+    template_id, bucket = item
+    counts = bucket["counts"]
+    assert isinstance(counts, dict)
+    return (
+        -int(counts["applied"]),
+        str(bucket.get("templateName") or template_id),
+        template_id,
+    )
+
+
 def _policy_key(value: int | None) -> str:
     return "unreported" if value is None else str(int(value))
 
@@ -3160,10 +3173,7 @@ class ProjectionBuilder:
             }
             for template_id, bucket in sorted(
                 by_template.items(),
-                key=lambda item: (
-                    -int(item[1]["counts"]["applied"]),  # type: ignore[index]
-                    str(item[1].get("templateName") or item[0]),
-                ),
+                key=_template_conversion_sort_key,
             )
         ]
         by_policy_list = []

--- a/workers/automation/tests/test_dashboard_projection.py
+++ b/workers/automation/tests/test_dashboard_projection.py
@@ -10,7 +10,10 @@ from typing import Iterator
 import pytest
 
 from jobctrl.database import close_connection, init_db
-from jobctrl.infrastructure.projections.projection_builder import ProjectionBuilder
+from jobctrl.infrastructure.projections.projection_builder import (
+    ProjectionBuilder,
+    _template_conversion_sort_key,
+)
 from jobctrl.state import record_job_event, set_stage_state, utc_now
 
 
@@ -767,6 +770,32 @@ def test_outcome_conversion_counts_by_material_and_feedback_rows(conn: sqlite3.C
         "corrected": 1,
         "ignored": 1,
     }
+
+
+def test_outcome_conversion_breaks_template_name_ties_by_id() -> None:
+    fixture = json.loads(
+        (
+            Path(__file__).parents[3]
+            / "packages/domain-types/test/fixtures/dashboard_template_order.json"
+        ).read_text()
+    )
+    buckets = [
+        (
+            entry["templateId"],
+            {
+                "templateName": entry["templateName"],
+                "counts": {"applied": entry["applied"]},
+            },
+        )
+        for entry in fixture["entries"]
+    ]
+
+    assert [
+        template_id
+        for template_id, _ in sorted(
+            buckets, key=_template_conversion_sort_key
+        )
+    ] == fixture["expectedTemplateIds"]
 
 
 def test_outcome_conversion_uses_artifact_metadata_without_parent_material_table(


### PR DESCRIPTION
## Summary
- define one Unicode code-point comparator for TypeScript template conversion ordering
- align it with Python ordinal tuple ordering for both template names and IDs
- add one shared mixed-case, private-use, and astral Unicode fixture consumed by both runtimes

## Why
Locale-sensitive ordering could make equal-count conversion buckets differ across the Python and TypeScript writers. The shared fixture makes the ordering contract explicit and deterministic.

## Stack
- Base: #597
- Next: complete dashboard row serializer

## Validation
- TypeScript projection suite: 35 passed
- Python comparator fixture: passed
- API typecheck: passed
- independent review: PASS, no findings
- cumulative independent QA: PASS, no findings
- Ruff and git diff --check: passed

## Deferred cumulative boundary
The approved unreleased identity stack has existing URL-keyed Python projection tests and one unrelated compensation-audit API failure. Both were reproduced identically on the parent; final runtime-cutover QA remains required.