### PR TITLE
feat(storage): add v7 dashboard row serializer

### DIFF
--- a/workers/automation/src/jobctrl/infrastructure/migrations/v7_dashboard_projection_rows.py
+++ b/workers/automation/src/jobctrl/infrastructure/migrations/v7_dashboard_projection_rows.py
@@ -1,0 +1,494 @@
+"""Build deterministic v7 dashboard rows from canonical candidate data."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import uuid
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+from jobctrl.infrastructure.migrations import (
+    v6_to_v7_job_detail_projections as job_details,
+)
+from jobctrl.infrastructure.migrations.v7_dashboard_outcome_conversion import (
+    build_dashboard_outcome_conversion,
+)
+from jobctrl.infrastructure.migrations.v7_job_list_projection_rows import (
+    JOB_LIST_PROJECTIONS_COLUMNS,
+    CandidateJobListProjectionsError,
+    _projection_rows as job_list_projection_rows,
+)
+from jobctrl.infrastructure.projections import projection_builder
+
+DASHBOARD_PROJECTIONS_TABLE = "dashboard_projections"
+DASHBOARD_PROJECTIONS_COLUMNS = (
+    "tenant_id",
+    "total_jobs",
+    "failures",
+    "blocked",
+    "ready",
+    "applied",
+    "dry_runs",
+    "funnel_json",
+    "by_source_json",
+    "score_distribution_json",
+    "outcome_conversion_json",
+    "generated_at",
+)
+
+_CLOSED_STATES = frozenset(
+    {"closed", "expired", "removed", "location_incompatible"}
+)
+_STAGE_STATES = frozenset(
+    {
+        "blocked",
+        "canceled",
+        "exhausted",
+        "failed",
+        "needs_verification",
+        "pending",
+        "queued",
+        "running",
+        "skipped",
+        "stale",
+        "succeeded",
+    }
+)
+
+
+class CandidateDashboardProjectionsError(RuntimeError):
+    """Raised when a complete dashboard row cannot be derived safely."""
+
+
+def _projection_rows(
+    candidate: sqlite3.Connection,
+    migration_at: str,
+) -> tuple[tuple[object, ...], ...]:
+    """Serialize one complete v7 dashboard row per candidate tenant.
+
+    The serializer consumes the already rebuilt job list, job detail, and apply
+    projections plus canonical v7 lifecycle and outcome rows. It never reads the
+    legacy dashboard cache or free-text outcome/suggestion fields.
+    """
+    timestamp = _required_text(migration_at, "migration_at")
+    if candidate.execute("PRAGMA foreign_key_check").fetchall():
+        raise CandidateDashboardProjectionsError(
+            "dashboard serialization requires foreign-key-clean v7 inputs"
+        )
+    _assert_exact_upstream_projections(candidate, timestamp)
+    roots = _root_keys(candidate)
+    job_rows = _rows_by_key(
+        candidate,
+        """
+        SELECT tenant_id, job_id, source, fit_score, fit_band, current_stage,
+               current_state, has_resume, apply_status, applied_at, apply_mode,
+               resume_template_id, resume_template_name,
+               tailoring_policy_version, deleted_at
+        FROM job_list_projections
+        ORDER BY tenant_id, job_id
+        """,
+        "job-list",
+    )
+    detail_rows = _rows_by_key(
+        candidate,
+        """
+        SELECT tenant_id, job_id, stages_json
+        FROM job_detail_projections
+        ORDER BY tenant_id, job_id
+        """,
+        "job-detail",
+    )
+    if set(job_rows) != roots or set(detail_rows) != roots:
+        raise CandidateDashboardProjectionsError(
+            "dashboard serialization requires complete v7 job-list and job-detail projections"
+        )
+
+    deleted = _active_deleted(candidate)
+    hidden = _active_hidden(candidate)
+    closed = _closed_jobs(candidate)
+    for key, row in job_rows.items():
+        projected_deleted_at = _optional_text(row["deleted_at"])
+        canonical_deleted_at = deleted.get(key)
+        if projected_deleted_at != canonical_deleted_at:
+            raise CandidateDashboardProjectionsError(
+                "job-list deletion state must match canonical v7 lifecycle state"
+            )
+
+    dry_run_jobs = _dry_run_jobs(candidate, roots)
+    tenants = sorted({tenant_id for tenant_id, _ in roots} | {"local"})
+    output: list[tuple[object, ...]] = []
+    for tenant_id in tenants:
+        active = [
+            row
+            for key, row in job_rows.items()
+            if key[0] == tenant_id
+            and key not in deleted
+            and key not in hidden
+            and key not in closed
+        ]
+        active_keys = {
+            (tenant_id, _required_uuid(row["job_id"], "job-list job_id"))
+            for row in active
+        }
+        funnel = _funnel(active_keys, detail_rows)
+        by_source = _by_source(active)
+        score_distribution = _score_distribution(active)
+        output.append(
+            (
+                tenant_id,
+                len(active),
+                sum(
+                    _text(row["current_state"]) in {"failed", "exhausted"}
+                    for row in active
+                ),
+                sum(_text(row["current_state"]) == "blocked" for row in active),
+                sum(
+                    _text(row["current_stage"]) == "apply"
+                    and _text(row["current_state"]) == "pending"
+                    and _integer(row["has_resume"], "job-list has_resume") == 1
+                    for row in active
+                ),
+                sum(_is_applied(row) for row in active),
+                sum(key in active_keys for key in dry_run_jobs if key[0] == tenant_id),
+                _json(funnel),
+                _json(by_source),
+                _json(score_distribution),
+                _json(
+                    build_dashboard_outcome_conversion(
+                        candidate,
+                        tenant_id=tenant_id,
+                        active_rows=active,
+                        root_job_ids={
+                            job_id
+                            for root_tenant_id, job_id in roots
+                            if root_tenant_id == tenant_id
+                        },
+                    )
+                ),
+                timestamp,
+            )
+        )
+
+    if any(len(row) != len(DASHBOARD_PROJECTIONS_COLUMNS) for row in output):
+        raise CandidateDashboardProjectionsError(
+            "dashboard serializer must emit every v7 column"
+        )
+    return tuple(output)
+
+
+def _assert_exact_upstream_projections(
+    candidate: sqlite3.Connection,
+    migration_at: str,
+) -> None:
+    try:
+        expected_details = job_details._projection_rows(
+            candidate, migration_at=migration_at
+        )
+    except job_details.CandidateJobDetailProjectionsError as error:
+        raise CandidateDashboardProjectionsError(
+            "candidate job-detail projections cannot be verified"
+        ) from error
+    actual_details = _complete_rows(
+        candidate,
+        "job_detail_projections",
+        job_details._COLUMNS,
+        order="tenant_id, job_id",
+    )
+    if actual_details != expected_details:
+        raise CandidateDashboardProjectionsError(
+            "candidate job_detail_projections must match the canonical rebuild"
+        )
+
+    try:
+        expected_list = job_list_projection_rows(candidate, migration_at)
+    except CandidateJobListProjectionsError as error:
+        raise CandidateDashboardProjectionsError(
+            "candidate job-list projections cannot be verified"
+        ) from error
+    actual_list = _complete_rows(
+        candidate,
+        "job_list_projections",
+        JOB_LIST_PROJECTIONS_COLUMNS,
+        order="tenant_id, job_id",
+    )
+    if actual_list != expected_list:
+        raise CandidateDashboardProjectionsError(
+            "candidate job_list_projections must match the canonical rebuild"
+        )
+
+
+def _complete_rows(
+    candidate: sqlite3.Connection,
+    table: str,
+    columns: tuple[str, ...],
+    *,
+    order: str,
+) -> tuple[tuple[object, ...], ...]:
+    identifiers = ", ".join(f'"{column}"' for column in columns)
+    return tuple(
+        tuple(row)
+        for row in candidate.execute(
+            f'SELECT {identifiers} FROM "{table}" ORDER BY {order}'
+        ).fetchall()
+    )
+
+
+def _root_keys(candidate: sqlite3.Connection) -> set[tuple[str, str]]:
+    roots: set[tuple[str, str]] = set()
+    for tenant_id, job_id in candidate.execute(
+        "SELECT tenant_id, job_id FROM jobs ORDER BY tenant_id, job_id"
+    ).fetchall():
+        key = (
+            _required_text(tenant_id, "job tenant_id"),
+            _required_uuid(job_id, "job job_id"),
+        )
+        if key in roots:
+            raise CandidateDashboardProjectionsError(
+                "candidate job roots must be unique"
+            )
+        roots.add(key)
+    return roots
+
+
+def _rows_by_key(
+    candidate: sqlite3.Connection,
+    query: str,
+    label: str,
+) -> dict[tuple[str, str], dict[str, object]]:
+    cursor = candidate.execute(query)
+    columns = tuple(column[0] for column in cursor.description or ())
+    rows: dict[tuple[str, str], dict[str, object]] = {}
+    for values in cursor.fetchall():
+        row = dict(zip(columns, values, strict=True))
+        key = (
+            _required_text(row.get("tenant_id"), f"{label} tenant_id"),
+            _required_uuid(row.get("job_id"), f"{label} job_id"),
+        )
+        if key in rows:
+            raise CandidateDashboardProjectionsError(
+                f"candidate {label} rows must be unique per job"
+            )
+        rows[key] = row
+    return rows
+
+
+def _active_deleted(
+    candidate: sqlite3.Connection,
+) -> dict[tuple[str, str], str]:
+    return {
+        (
+            _required_text(tenant_id, "deleted-job tenant_id"),
+            _required_uuid(job_id, "deleted-job job_id"),
+        ): _required_text(deleted_at, "deleted-job deleted_at")
+        for tenant_id, job_id, deleted_at in candidate.execute(
+            """
+            SELECT tenant_id, job_id, deleted_at
+            FROM jobctrl_deleted_jobs
+            WHERE restored_at IS NULL
+               OR julianday(restored_at) <= julianday(deleted_at)
+            ORDER BY tenant_id, job_id
+            """
+        ).fetchall()
+    }
+
+
+def _active_hidden(candidate: sqlite3.Connection) -> set[tuple[str, str]]:
+    return {
+        (
+            _required_text(tenant_id, "hidden-job tenant_id"),
+            _required_uuid(job_id, "hidden-job job_id"),
+        )
+        for tenant_id, job_id in candidate.execute(
+            """
+            SELECT tenant_id, job_id
+            FROM jobctrl_hidden_jobs
+            WHERE unhidden_at IS NULL
+            ORDER BY tenant_id, job_id
+            """
+        ).fetchall()
+    }
+
+
+def _closed_jobs(candidate: sqlite3.Connection) -> set[tuple[str, str]]:
+    closed: set[tuple[str, str]] = set()
+    for tenant_id, job_id, active_state in candidate.execute(
+        """
+        SELECT tenant_id, job_id, latest_active_state
+        FROM posting_snapshot_sets
+        ORDER BY tenant_id, job_id
+        """
+    ).fetchall():
+        if _text(active_state).strip().lower() in _CLOSED_STATES:
+            closed.add(
+                (
+                    _required_text(tenant_id, "posting snapshot tenant_id"),
+                    _required_uuid(job_id, "posting snapshot job_id"),
+                )
+            )
+    return closed
+
+
+def _dry_run_jobs(
+    candidate: sqlite3.Connection,
+    roots: set[tuple[str, str]],
+) -> tuple[tuple[str, str], ...]:
+    jobs: list[tuple[str, str]] = []
+    for tenant_id, job_id, dry_run in candidate.execute(
+        """
+        SELECT tenant_id, job_id, dry_run
+        FROM apply_run_projections
+        ORDER BY tenant_id, run_id
+        """
+    ).fetchall():
+        key = (
+            _required_text(tenant_id, "apply-run tenant_id"),
+            _required_uuid(job_id, "apply-run job_id"),
+        )
+        if key not in roots:
+            raise CandidateDashboardProjectionsError(
+                "apply-run projection must reference a canonical v7 job"
+            )
+        parsed_dry_run = _integer(dry_run, "apply-run dry_run")
+        if parsed_dry_run not in {0, 1}:
+            raise CandidateDashboardProjectionsError(
+                "apply-run dry_run must be 0 or 1"
+            )
+        if parsed_dry_run == 1:
+            jobs.append(key)
+    return tuple(jobs)
+
+
+def _funnel(
+    active_keys: set[tuple[str, str]],
+    detail_rows: Mapping[tuple[str, str], Mapping[str, object]],
+) -> list[dict[str, object]]:
+    counts = {
+        stage: {
+            "total": 0,
+            "succeeded": 0,
+            "running": 0,
+            "pending": 0,
+            "blocked": 0,
+            "failed": 0,
+        }
+        for stage in projection_builder.STAGE_ORDER
+    }
+    for key in sorted(active_keys):
+        stages = _json_list_of_dicts(
+            detail_rows[key]["stages_json"], "job-detail stages_json"
+        )
+        for stage_row in stages:
+            stage = stage_row.get("stage")
+            state = stage_row.get("state")
+            if not isinstance(stage, str) or stage not in counts:
+                raise CandidateDashboardProjectionsError(
+                    "job-detail stage must be a canonical stage name"
+                )
+            if not isinstance(state, str) or state not in _STAGE_STATES:
+                raise CandidateDashboardProjectionsError(
+                    "job-detail state must be a canonical stage state"
+                )
+            if state == "skipped":
+                continue
+            counts[stage]["total"] += 1
+            if state in {"failed", "exhausted"}:
+                counts[stage]["failed"] += 1
+            elif state in {"running", "queued"}:
+                counts[stage]["running"] += 1
+            elif state == "blocked":
+                counts[stage]["blocked"] += 1
+            elif state == "succeeded":
+                counts[stage]["succeeded"] += 1
+            else:
+                counts[stage]["pending"] += 1
+    return [
+        {"stage": stage, **counts[stage]} for stage in projection_builder.STAGE_ORDER
+    ]
+
+
+def _by_source(rows: Iterable[Mapping[str, object]]) -> list[list[object]]:
+    counts: dict[str, int] = {}
+    for row in rows:
+        source = _optional_text(row["source"]) or "unknown"
+        counts[source] = counts.get(source, 0) + 1
+    return [
+        [source, count]
+        for source, count in sorted(counts.items(), key=lambda item: (-item[1], item[0]))
+    ]
+
+
+def _score_distribution(
+    rows: Iterable[Mapping[str, object]],
+) -> list[list[int]]:
+    counts: dict[int, int] = {}
+    for row in rows:
+        score = _optional_integer(row["fit_score"], "job-list fit_score")
+        if score is not None:
+            counts[score] = counts.get(score, 0) + 1
+    return [[score, counts[score]] for score in sorted(counts, reverse=True)]
+
+
+def _is_applied(row: Mapping[str, object]) -> bool:
+    return bool(_optional_text(row["applied_at"])) or _text(
+        row["apply_status"]
+    ) == "applied"
+
+
+def _json(value: object) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def _json_list_of_dicts(value: object, label: str) -> list[dict[str, Any]]:
+    try:
+        parsed = json.loads(_required_text(value, label))
+    except json.JSONDecodeError as exc:
+        raise CandidateDashboardProjectionsError(f"{label} must be valid JSON") from exc
+    if not isinstance(parsed, list) or any(not isinstance(item, dict) for item in parsed):
+        raise CandidateDashboardProjectionsError(
+            f"{label} must be a JSON array of objects"
+        )
+    return parsed
+
+
+def _required_uuid(value: object, label: str) -> str:
+    text = _required_text(value, label)
+    try:
+        parsed = uuid.UUID(text)
+    except (ValueError, AttributeError) as exc:
+        raise CandidateDashboardProjectionsError(
+            f"{label} must be a canonical UUID"
+        ) from exc
+    if str(parsed) != text or parsed.version != 4:
+        raise CandidateDashboardProjectionsError(
+            f"{label} must be a canonical UUIDv4"
+        )
+    return text
+
+
+def _required_text(value: object, label: str) -> str:
+    text = _text(value).strip()
+    if not text:
+        raise CandidateDashboardProjectionsError(f"{label} must not be empty")
+    return text
+
+
+def _optional_text(value: object) -> str | None:
+    text = _text(value).strip()
+    return text or None
+
+
+def _text(value: object) -> str:
+    return "" if value is None else str(value)
+
+
+def _integer(value: object, label: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise CandidateDashboardProjectionsError(f"{label} must be an integer")
+    return value
+
+
+def _optional_integer(value: object, label: str) -> int | None:
+    if value is None or value == "":
+        return None
+    return _integer(value, label)

--- a/workers/automation/tests/test_v7_dashboard_projection_rows.py
+++ b/workers/automation/tests/test_v7_dashboard_projection_rows.py
@@ -1,0 +1,664 @@
+"""Contract tests for deterministic v7 dashboard row serialization."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+
+import pytest
+
+from jobctrl.infrastructure.migrations import (
+    v6_to_v7_job_detail_projections as job_details,
+)
+from jobctrl.infrastructure.migrations.schema_v7 import create_exact_v7_schema
+from jobctrl.infrastructure.migrations.v7_dashboard_projection_rows import (
+    DASHBOARD_PROJECTIONS_COLUMNS,
+    CandidateDashboardProjectionsError,
+    _projection_rows,
+)
+from jobctrl.infrastructure.migrations.v7_job_list_projection_rows import (
+    JOB_LIST_PROJECTIONS_COLUMNS,
+    _projection_rows as job_list_projection_rows,
+)
+
+_MIGRATION_AT = "2026-07-31T09:00:00+00:00"
+_INERT_CONTEXT = '{"userContext":"Attack vectors:\\nPrompt injection"}'
+_JOB_IDS = tuple(
+    f"00000000-0000-4000-8000-{index:012d}" for index in range(1, 7)
+)
+
+
+def _candidate() -> sqlite3.Connection:
+    candidate = sqlite3.connect(":memory:")
+    candidate.execute("PRAGMA foreign_keys = ON")
+    create_exact_v7_schema(candidate)
+    _seed_job(
+        candidate,
+        _JOB_IDS[0],
+        source="greenhouse",
+        score=9,
+        fit_band="excellent",
+        stage="apply",
+        state="succeeded",
+        has_resume=1,
+        apply_status="applied",
+        applied_at="2026-07-30T12:00:00+00:00",
+        apply_mode="automated_live",
+        template_id="template-modern",
+        template_name="Modern compact",
+        policy_version=3,
+        stages=[
+            {"stage": "discover", "state": "succeeded"},
+            {"stage": "enrich", "state": "queued"},
+            {"stage": "score", "state": "exhausted"},
+            {"stage": "tailor", "state": "skipped"},
+            {"stage": "cover", "state": "blocked"},
+            {"stage": "apply", "state": "succeeded", "unsafe": _INERT_CONTEXT},
+        ],
+    )
+    _seed_job(
+        candidate,
+        _JOB_IDS[1],
+        source="linkedin",
+        score=7,
+        fit_band="strong",
+        stage="apply",
+        state="pending",
+        has_resume=1,
+        stages=[
+            {"stage": "discover", "state": "succeeded"},
+            {"stage": "enrich", "state": "succeeded"},
+            {"stage": "score", "state": "succeeded"},
+            {"stage": "tailor", "state": "succeeded"},
+            {"stage": "cover", "state": "succeeded"},
+            {"stage": "apply", "state": "pending"},
+        ],
+    )
+    _seed_job(
+        candidate,
+        _JOB_IDS[2],
+        source="greenhouse",
+        score=8,
+        stage="apply",
+        state="succeeded",
+        apply_status="applied",
+        applied_at="2026-07-30T12:00:00+00:00",
+    )
+    candidate.execute(
+        """
+        INSERT INTO jobctrl_hidden_jobs (
+            tenant_id, job_id, hidden_at, reason, unhidden_at
+        ) VALUES ('local', ?, ?, 'not relevant', NULL)
+        """,
+        (_JOB_IDS[2], _MIGRATION_AT),
+    )
+    _seed_job(
+        candidate,
+        _JOB_IDS[3],
+        source="lever",
+        score=6,
+        stage="apply",
+        state="succeeded",
+    )
+    candidate.execute(
+        """
+        INSERT INTO posting_snapshot_sets (
+            tenant_id, job_id, snapshot_set_json, latest_active_state, updated_at
+        ) VALUES ('local', ?, '{}', 'closed', ?)
+        """,
+        (_JOB_IDS[3], _MIGRATION_AT),
+    )
+    _seed_job(
+        candidate,
+        _JOB_IDS[4],
+        source="ashby",
+        score=5,
+        stage="apply",
+        state="succeeded",
+        deleted_at="2026-07-30T08:00:00+00:00",
+    )
+    candidate.execute(
+        """
+        INSERT INTO jobctrl_deleted_jobs (
+            tenant_id, job_id, deleted_at, reason, restored_at
+        ) VALUES ('local', ?, '2026-07-30T08:00:00+00:00', 'duplicate', NULL)
+        """,
+        (_JOB_IDS[4],),
+    )
+    _seed_job(
+        candidate,
+        _JOB_IDS[5],
+        source="greenhouse",
+        score=None,
+        stage="enrich",
+        state="exhausted",
+        stages=[
+            {"stage": "discover", "state": "succeeded"},
+            {"stage": "enrich", "state": "succeeded"},
+            {"stage": "score", "state": "exhausted"},
+        ],
+    )
+    candidate.execute(
+        """
+        INSERT INTO jobctrl_deleted_jobs (
+            tenant_id, job_id, deleted_at, reason, restored_at
+        ) VALUES ('local', ?, '2026-07-30T07:00:00+00:00', 'mistake',
+                  '2026-07-30T07:01:00+00:00')
+        """,
+        (_JOB_IDS[5],),
+    )
+    for index, job_id in enumerate(_JOB_IDS, start=1):
+        candidate.execute(
+            """
+            INSERT INTO apply_run_projections (
+                run_id, tenant_id, job_id, dry_run, events_json
+            ) VALUES (?, 'local', ?, 1, '[]')
+            """,
+            (f"run-{index}", job_id),
+        )
+    candidate.execute(
+        """
+        INSERT INTO application_outcomes (
+            tenant_id, outcome_id, job_id, kind, source, note, occurred_at,
+            recorded_at, created_by
+        ) VALUES ('local', 'outcome-1', ?, 'interview', 'manual', ?,
+                  '2026-07-30T13:00:00+00:00', ?, 'user')
+        """,
+        (_JOB_IDS[0], _INERT_CONTEXT, _MIGRATION_AT),
+    )
+    candidate.execute(
+        """
+        INSERT INTO application_outcome_suggestions (
+            tenant_id, suggestion_id, job_id, suggested_kind, confidence,
+            rationale, status, created_at
+        ) VALUES ('local', 'suggestion-1', ?, 'interview', 0.9, ?,
+                  'accepted', ?)
+        """,
+        (_JOB_IDS[0], _INERT_CONTEXT, _MIGRATION_AT),
+    )
+    _canonicalize_upstream_projections(candidate)
+    candidate.commit()
+    return candidate
+
+
+def _canonicalize_upstream_projections(candidate: sqlite3.Connection) -> None:
+    rows = candidate.execute(
+        """
+        SELECT job_id, source, fit_score, fit_band, apply_status, applied_at,
+               has_resume, resume_template_id, resume_template_name,
+               tailoring_policy_version
+        FROM job_list_projections
+        ORDER BY job_id
+        """
+    ).fetchall()
+    for (
+        job_id,
+        source,
+        fit_score,
+        fit_band,
+        apply_status,
+        applied_at,
+        has_resume,
+        template_id,
+        template_name,
+        policy_version,
+    ) in rows:
+        locator = candidate.execute(
+            "SELECT url FROM jobs WHERE tenant_id = 'local' AND job_id = ?",
+            (job_id,),
+        ).fetchone()[0]
+        candidate.execute(
+            """
+            UPDATE jobs
+            SET site = ?, apply_status = ?, applied_at = ?
+            WHERE tenant_id = 'local' AND job_id = ?
+            """,
+            (source, apply_status, applied_at, job_id),
+        )
+        candidate.execute(
+            """
+            INSERT INTO job_locators (
+                tenant_id, job_id, locator_kind, locator_value, is_current,
+                first_seen_at, last_seen_at, retired_at
+            ) VALUES ('local', ?, 'posting_url', ?, 1, ?, ?, NULL)
+            """,
+            (job_id, locator, _MIGRATION_AT, _MIGRATION_AT),
+        )
+        if fit_score is not None:
+            candidate.execute(
+                """
+                INSERT INTO job_scores (
+                    tenant_id, job_id, version, fit_score, breakdown_json,
+                    keywords_json, scored_at
+                ) VALUES ('local', ?, 1, ?, '{}', '[]', ?)
+                """,
+                (job_id, fit_score, _MIGRATION_AT),
+            )
+        if fit_band is not None:
+            candidate.execute(
+                """
+                INSERT INTO job_requirement_fit_reports (
+                    tenant_id, job_id, score_version,
+                    employer_analysis_generation, profile_snapshot_version,
+                    scoring_policy_version, formula_version,
+                    resolved_fit_score, fit_band, confidence, summary_json,
+                    created_at
+                ) VALUES ('local', ?, 1, 1, 1, 1, 'test', ?, ?, 'medium',
+                          '{}', ?)
+                """,
+                (job_id, fit_score, fit_band, _MIGRATION_AT),
+            )
+        stages_json = candidate.execute(
+            """
+            SELECT stages_json FROM job_detail_projections
+            WHERE tenant_id = 'local' AND job_id = ?
+            """,
+            (job_id,),
+        ).fetchone()[0]
+        for stage in json.loads(stages_json):
+            candidate.execute(
+                """
+                INSERT INTO job_stage_states (
+                    tenant_id, job_id, stage, state, attempt_count,
+                    max_attempts, updated_at, retryable, blocked_by_json,
+                    version
+                ) VALUES ('local', ?, ?, ?, 1, 3, ?, 1, '[]', 1)
+                """,
+                (job_id, stage["stage"], stage["state"], _MIGRATION_AT),
+            )
+        if has_resume:
+            metadata = json.dumps(
+                {
+                    "resume_template": {
+                        "templateId": template_id,
+                        "templateName": template_name,
+                    },
+                    "tailoringPolicyVersion": policy_version,
+                }
+            )
+            candidate.execute(
+                """
+                INSERT INTO job_materials (
+                    tenant_id, job_id, generation, status, created_at,
+                    updated_at, metadata_json
+                ) VALUES ('local', ?, 1, 'resume_approved', ?, ?, ?)
+                """,
+                (job_id, _MIGRATION_AT, _MIGRATION_AT, metadata),
+            )
+            candidate.execute(
+                """
+                INSERT INTO job_materials_artifacts (
+                    tenant_id, job_id, generation, artifact_type, artifact_id,
+                    status, path, render_format, size_bytes, metadata_json,
+                    created_at
+                ) VALUES ('local', ?, 1, 'tailored_resume', ?, 'approved', ?,
+                          'text', 100, ?, ?)
+                """,
+                (
+                    job_id,
+                    f"resume-{job_id}",
+                    f"/tmp/{job_id}.txt",
+                    metadata,
+                    _MIGRATION_AT,
+                ),
+            )
+        if applied_at:
+            candidate.execute(
+                """
+                UPDATE apply_run_projections
+                SET status = 'succeeded', result = 'applied', dry_run = 0,
+                    finished_at = ?
+                WHERE tenant_id = 'local' AND job_id = ?
+                """,
+                (applied_at, job_id),
+            )
+
+    candidate.execute("DELETE FROM job_detail_projections")
+    candidate.executemany(
+        f"""
+        INSERT INTO job_detail_projections ({", ".join(job_details._COLUMNS)})
+        VALUES ({", ".join("?" for _ in job_details._COLUMNS)})
+        """,
+        job_details._projection_rows(candidate, migration_at=_MIGRATION_AT),
+    )
+    candidate.execute("DELETE FROM job_list_projections")
+    candidate.executemany(
+        f"""
+        INSERT INTO job_list_projections ({", ".join(JOB_LIST_PROJECTIONS_COLUMNS)})
+        VALUES ({", ".join("?" for _ in JOB_LIST_PROJECTIONS_COLUMNS)})
+        """,
+        job_list_projection_rows(candidate, _MIGRATION_AT),
+    )
+
+
+def _refresh_upstream_projections(candidate: sqlite3.Connection) -> None:
+    candidate.execute("DELETE FROM job_detail_projections")
+    candidate.executemany(
+        f"""
+        INSERT INTO job_detail_projections ({", ".join(job_details._COLUMNS)})
+        VALUES ({", ".join("?" for _ in job_details._COLUMNS)})
+        """,
+        job_details._projection_rows(candidate, migration_at=_MIGRATION_AT),
+    )
+    candidate.execute("DELETE FROM job_list_projections")
+    candidate.executemany(
+        f"""
+        INSERT INTO job_list_projections ({", ".join(JOB_LIST_PROJECTIONS_COLUMNS)})
+        VALUES ({", ".join("?" for _ in JOB_LIST_PROJECTIONS_COLUMNS)})
+        """,
+        job_list_projection_rows(candidate, _MIGRATION_AT),
+    )
+
+
+def _seed_job(
+    candidate: sqlite3.Connection,
+    job_id: str,
+    *,
+    source: str,
+    score: int | None,
+    fit_band: str | None = None,
+    stage: str,
+    state: str,
+    has_resume: int = 0,
+    apply_status: str | None = None,
+    applied_at: str | None = None,
+    apply_mode: str | None = None,
+    template_id: str | None = None,
+    template_name: str | None = None,
+    policy_version: int | None = None,
+    deleted_at: str | None = None,
+    stages: list[dict[str, object]] | None = None,
+) -> None:
+    locator = f"https://jobs.example/{job_id}"
+    candidate.execute(
+        """
+        INSERT INTO jobs (url, title, company, tenant_id, job_id)
+        VALUES (?, 'Role', 'Example', 'local', ?)
+        """,
+        (locator, job_id),
+    )
+    candidate.execute(
+        """
+        INSERT INTO job_list_projections (
+            tenant_id, job_id, title, employer, source, fit_score, fit_band,
+            current_stage, current_substage, current_state, has_resume,
+            apply_status, applied_at, apply_mode, resume_template_id,
+            resume_template_name, tailoring_policy_version, deleted_at,
+            last_updated_at
+        ) VALUES ('local', ?, 'Role', 'Example', ?, ?, ?, ?, ?, ?, ?, ?, ?,
+                  ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            job_id,
+            source,
+            score,
+            fit_band,
+            stage,
+            stage,
+            state,
+            has_resume,
+            apply_status,
+            applied_at,
+            apply_mode,
+            template_id,
+            template_name,
+            policy_version,
+            deleted_at,
+            _MIGRATION_AT,
+        ),
+    )
+    candidate.execute(
+        """
+        INSERT INTO job_detail_projections (
+            tenant_id, job_id, stages_json, last_updated_at
+        ) VALUES ('local', ?, ?, ?)
+        """,
+        (job_id, json.dumps(stages or []), _MIGRATION_AT),
+    )
+
+
+def _row() -> dict[str, object]:
+    rows = _projection_rows(_candidate(), _MIGRATION_AT)
+    assert len(rows) == 1
+    return dict(zip(DASHBOARD_PROJECTIONS_COLUMNS, rows[0], strict=True))
+
+
+def test_projection_row_rebuilds_complete_privacy_safe_dashboard() -> None:
+    row = _row()
+
+    assert row["tenant_id"] == "local"
+    assert row["total_jobs"] == 3
+    assert row["failures"] == 1
+    assert row["blocked"] == 0
+    assert row["ready"] == 1
+    assert row["applied"] == 1
+    assert row["dry_runs"] == 2
+    assert row["generated_at"] == _MIGRATION_AT
+
+    assert json.loads(str(row["by_source_json"])) == [
+        ["greenhouse", 2],
+        ["linkedin", 1],
+    ]
+    assert json.loads(str(row["score_distribution_json"])) == [[9, 1], [7, 1]]
+    funnel = {
+        stage["stage"]: stage for stage in json.loads(str(row["funnel_json"]))
+    }
+    assert tuple(funnel) == ("discover", "enrich", "score", "tailor", "cover", "apply")
+    assert funnel["discover"] == {
+        "stage": "discover",
+        "total": 3,
+        "succeeded": 3,
+        "running": 0,
+        "pending": 0,
+        "blocked": 0,
+        "failed": 0,
+    }
+    assert funnel["enrich"]["running"] == 1
+    assert funnel["score"]["failed"] == 2
+    assert funnel["tailor"]["total"] == 2
+    assert funnel["cover"]["blocked"] == 1
+    assert funnel["apply"]["succeeded"] == 1
+    assert funnel["apply"]["pending"] == 2
+
+    conversion = json.loads(str(row["outcome_conversion_json"]))
+    assert conversion["version"] == 2
+    assert conversion["totals"] == {
+        "applied": 1,
+        "reply": 1,
+        "interview": 1,
+        "offer": 0,
+        "rejection": 0,
+    }
+    assert conversion["bySource"] == [
+        {
+            "source": "greenhouse",
+            "applied": 1,
+            "reply": 1,
+            "interview": 1,
+            "offer": 0,
+            "rejection": 0,
+        }
+    ]
+    assert conversion["byBand"][0]["band"] == "perfect"
+    assert conversion["byFitBand"][0]["fitBand"] == "excellent"
+    assert conversion["byApplyMode"][0]["applyMode"] == "automated_live"
+    assert conversion["byTemplate"][0]["templateId"] == "template-modern"
+    assert conversion["byPolicy"][0]["tailoringPolicyVersion"] == 3
+    assert conversion["timeToResponseMinutes"] == [60]
+    assert conversion["suggestionAccuracy"] == {
+        "decided": 1,
+        "accepted": 1,
+        "corrected": 0,
+        "ignored": 0,
+    }
+
+    serialized = json.dumps(row, sort_keys=True)
+    assert "Attack vectors" not in serialized
+    assert "Prompt injection" not in serialized
+    assert "rationale" not in serialized
+    assert "note" not in serialized
+
+
+def test_projection_row_is_deterministic_and_ignores_stale_dashboard_cache() -> None:
+    candidate = _candidate()
+    candidate.execute(
+        """
+        INSERT INTO dashboard_projections (
+            tenant_id, total_jobs, failures, outcome_conversion_json, generated_at
+        ) VALUES ('local', 999, 999, ?, 'stale')
+        """,
+        (_INERT_CONTEXT,),
+    )
+
+    first = _projection_rows(candidate, _MIGRATION_AT)
+    second = _projection_rows(candidate, _MIGRATION_AT)
+
+    assert first == second
+    row = dict(zip(DASHBOARD_PROJECTIONS_COLUMNS, first[0], strict=True))
+    assert row["total_jobs"] == 3
+    assert _INERT_CONTEXT not in str(row)
+
+
+def test_projection_row_materializes_empty_local_workspace() -> None:
+    candidate = sqlite3.connect(":memory:")
+    candidate.execute("PRAGMA foreign_keys = ON")
+    create_exact_v7_schema(candidate)
+
+    rows = _projection_rows(candidate, _MIGRATION_AT)
+
+    assert len(rows) == 1
+    row = dict(zip(DASHBOARD_PROJECTIONS_COLUMNS, rows[0], strict=True))
+    assert row["tenant_id"] == "local"
+    assert row["total_jobs"] == 0
+    assert row["failures"] == 0
+    assert row["blocked"] == 0
+    assert row["ready"] == 0
+    assert row["applied"] == 0
+    assert row["dry_runs"] == 0
+    assert json.loads(str(row["by_source_json"])) == []
+    assert json.loads(str(row["score_distribution_json"])) == []
+    assert json.loads(str(row["outcome_conversion_json"]))["totals"]["applied"] == 0
+    assert row["generated_at"] == _MIGRATION_AT
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        "DELETE FROM job_detail_projections WHERE job_id = '00000000-0000-4000-8000-000000000001'",
+        "UPDATE job_detail_projections SET stages_json = 'not-json' "
+        "WHERE job_id = '00000000-0000-4000-8000-000000000001'",
+        "UPDATE job_list_projections SET deleted_at = NULL "
+        "WHERE job_id = '00000000-0000-4000-8000-000000000005'",
+    ],
+)
+def test_projection_row_rejects_incomplete_or_divergent_inputs(
+    mutation: str,
+) -> None:
+    candidate = _candidate()
+    candidate.execute(mutation)
+
+    with pytest.raises(CandidateDashboardProjectionsError):
+        _projection_rows(candidate, _MIGRATION_AT)
+
+
+def test_projection_row_rejects_url_shaped_job_identity() -> None:
+    candidate = _candidate()
+    candidate.execute("PRAGMA foreign_keys = OFF")
+    candidate.execute(
+        """
+        UPDATE job_list_projections
+        SET job_id = 'https://jobs.example/legacy'
+        WHERE job_id = ?
+        """,
+        (_JOB_IDS[0],),
+    )
+
+    with pytest.raises(CandidateDashboardProjectionsError):
+        _projection_rows(candidate, _MIGRATION_AT)
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        "UPDATE job_list_projections SET has_resume = 2 "
+        "WHERE job_id = '00000000-0000-4000-8000-000000000001'",
+        "UPDATE job_list_projections SET fit_score = 7.5 "
+        "WHERE job_id = '00000000-0000-4000-8000-000000000001'",
+        "UPDATE job_detail_projections "
+        """SET stages_json = '[{"stage":"discover","state":42}]' """
+        "WHERE job_id = '00000000-0000-4000-8000-000000000001'",
+        "UPDATE apply_run_projections SET dry_run = 2 "
+        "WHERE job_id = '00000000-0000-4000-8000-000000000002'",
+        "UPDATE application_outcome_suggestions "
+        "SET job_id = 'https://jobs.example/legacy' "
+        "WHERE suggestion_id = 'suggestion-1'",
+    ],
+)
+def test_projection_row_rejects_malformed_upstream_values(mutation: str) -> None:
+    candidate = _candidate()
+    candidate.execute("PRAGMA foreign_keys = OFF")
+    candidate.execute(mutation)
+
+    with pytest.raises(CandidateDashboardProjectionsError):
+        _projection_rows(candidate, _MIGRATION_AT)
+
+
+def test_projection_row_rejects_canonical_fractional_score() -> None:
+    candidate = _candidate()
+    candidate.execute(
+        """
+        UPDATE job_scores SET fit_score = 7.5
+        WHERE tenant_id = 'local' AND job_id = ?
+        """,
+        (_JOB_IDS[0],),
+    )
+    _refresh_upstream_projections(candidate)
+
+    with pytest.raises(
+        CandidateDashboardProjectionsError, match="fit_score must be an integer"
+    ):
+        _projection_rows(candidate, _MIGRATION_AT)
+
+
+def test_projection_row_rejects_canonical_non_text_stage_state() -> None:
+    candidate = _candidate()
+    candidate.execute(
+        """
+        UPDATE job_stage_states SET state = X'6661696C6564'
+        WHERE tenant_id = 'local' AND job_id = ? AND stage = 'score'
+        """,
+        (_JOB_IDS[0],),
+    )
+    _refresh_upstream_projections(candidate)
+
+    with pytest.raises(
+        CandidateDashboardProjectionsError, match="canonical stage state"
+    ):
+        _projection_rows(candidate, _MIGRATION_AT)
+
+
+@pytest.mark.parametrize("state", ["needs_verification", "stale", "canceled"])
+def test_projection_row_accepts_supported_nonterminal_stage_states(
+    state: str,
+) -> None:
+    candidate = _candidate()
+    candidate.execute(
+        """
+        UPDATE job_stage_states SET state = ?
+        WHERE tenant_id = 'local' AND job_id = ? AND stage = 'score'
+        """,
+        (state, _JOB_IDS[0]),
+    )
+    _refresh_upstream_projections(candidate)
+
+    row = dict(
+        zip(
+            DASHBOARD_PROJECTIONS_COLUMNS,
+            _projection_rows(candidate, _MIGRATION_AT)[0],
+            strict=True,
+        )
+    )
+    funnel = {
+        item["stage"]: item for item in json.loads(str(row["funnel_json"]))
+    }
+    assert funnel["score"]["pending"] >= 1


### PR DESCRIPTION
## Summary
- serialize all 12 v7 dashboard columns from exact canonical candidate inputs
- require complete canonical parity for job-list and job-detail projections before aggregation
- filter active deleted, hidden, closed, expired, removed, and location-incompatible jobs
- deterministically build counts, funnel, source/score distributions, conversion data, and the empty local dashboard
- reject fractional scalars, invalid flags, malformed or unknown stage states, URL-shaped identity, and foreign-key-broken inputs

## Why
Dashboard assembly must fail closed on stale or malformed upstream data instead of trusting matching UUID key sets. This PR is the pure transformation contract; it performs no database writes.

## Stack
- Base: #598
- Depends on: #597
- Next: atomic dashboard projection writer

## Validation
- focused serializer tests: 17 passed
- supported needs-verification, stale, and canceled states: accepted
- malformed canonical score/state and prior adversarial matrix: rejected
- independent review: PASS, no findings
- cumulative independent QA: PASS, no findings
- cumulative v6 to v7 migration suite at stack head: 198 passed
- Ruff and git diff --check: passed