### PR TITLE
feat(storage): rebuild v7 dashboard projections

### DIFF
--- a/workers/automation/src/jobctrl/infrastructure/migrations/v6_to_v7_dashboard_projections.py
+++ b/workers/automation/src/jobctrl/infrastructure/migrations/v6_to_v7_dashboard_projections.py
@@ -1,0 +1,330 @@
+"""Atomically persist complete v7 dashboard rows during the v6 cutover."""
+
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+
+from jobctrl.infrastructure.migrations import (
+    v6_to_v7_apply_run_projections as apply_runs,
+)
+from jobctrl.infrastructure.migrations import (
+    v6_to_v7_job_detail_projections as job_details,
+)
+from jobctrl.infrastructure.migrations.schema_manifest import (
+    EXACT_V7_MANIFEST,
+    assert_exact_manifest,
+)
+from jobctrl.infrastructure.migrations.v6_to_v7_copy import (
+    CandidateCopyError,
+    JobIdMap,
+    build_job_id_map,
+)
+from jobctrl.infrastructure.migrations.v6_to_v7_preflight import (
+    assert_v6_migration_preflight,
+)
+from jobctrl.infrastructure.migrations.v7_dashboard_projection_rows import (
+    DASHBOARD_PROJECTIONS_COLUMNS,
+    DASHBOARD_PROJECTIONS_TABLE,
+    CandidateDashboardProjectionsError,
+    _projection_rows,
+    _required_text,
+)
+from jobctrl.infrastructure.migrations.v7_job_list_projection_rows import (
+    CandidateJobListProjectionsError,
+    JOB_LIST_PROJECTIONS_COLUMNS,
+    _projection_rows as job_list_projection_rows,
+)
+
+_TABLE = DASHBOARD_PROJECTIONS_TABLE
+_COLUMNS = DASHBOARD_PROJECTIONS_COLUMNS
+_CANONICAL_TABLES = (
+    "jobs",
+    "job_locators",
+    "job_list_projections",
+    "job_detail_projections",
+    "apply_run_projections",
+    "job_events",
+    "posting_snapshot_sets",
+    "jobctrl_deleted_jobs",
+    "jobctrl_hidden_jobs",
+    "application_outcomes",
+    "application_outcome_suggestions",
+)
+
+
+@dataclass(frozen=True)
+class CandidateDashboardProjectionsResult:
+    """Verified candidate dashboard projection rebuild result."""
+
+    rebuilt_dashboard_projections: int
+
+
+def rebuild_dashboard_projections(
+    source: sqlite3.Connection,
+    candidate: sqlite3.Connection,
+    *,
+    job_ids: JobIdMap,
+    migration_at: str,
+) -> CandidateDashboardProjectionsResult:
+    """Rebuild dashboard rows without trusting either v6 dashboard/list cache."""
+    assert_v6_migration_preflight(source)
+    assert_exact_manifest(candidate, EXACT_V7_MANIFEST)
+    _assert_columns(candidate, _TABLE, _COLUMNS)
+    _assert_authoritative_roots(source, candidate, job_ids)
+    timestamp = _required_text(migration_at, "migration_at")
+    _assert_upstream_projections(candidate, timestamp)
+    _assert_empty_target(candidate)
+
+    source_snapshot = _source_snapshot(source)
+    canonical_snapshot = _canonical_snapshot(candidate)
+    rows = _projection_rows(candidate, timestamp)
+
+    candidate.execute("SAVEPOINT v6_dashboard_projection_rebuild")
+    try:
+        _insert_rows(candidate, rows)
+        _verify_candidate(
+            source=source,
+            candidate=candidate,
+            expected_rows=rows,
+            source_snapshot=source_snapshot,
+            canonical_snapshot=canonical_snapshot,
+        )
+        candidate.execute("RELEASE SAVEPOINT v6_dashboard_projection_rebuild")
+    except BaseException:
+        candidate.execute("ROLLBACK TO SAVEPOINT v6_dashboard_projection_rebuild")
+        candidate.execute("RELEASE SAVEPOINT v6_dashboard_projection_rebuild")
+        raise
+
+    return CandidateDashboardProjectionsResult(
+        rebuilt_dashboard_projections=len(rows),
+    )
+
+
+def _assert_authoritative_roots(
+    source: sqlite3.Connection,
+    candidate: sqlite3.Connection,
+    job_ids: JobIdMap,
+) -> None:
+    try:
+        hydrated = build_job_id_map(source, candidate)
+    except CandidateCopyError as error:
+        raise CandidateDashboardProjectionsError(
+            "dashboard projection rebuild requires hydrated candidate roots"
+        ) from error
+    if dict(hydrated.by_locator) != dict(job_ids.by_locator):
+        raise CandidateDashboardProjectionsError(
+            "supplied JobIdMap does not match hydrated candidate roots"
+        )
+    locators = {
+        (str(tenant_id), str(locator)): str(job_id)
+        for tenant_id, job_id, locator in candidate.execute(
+            """
+            SELECT tenant_id, job_id, locator_value
+            FROM job_locators
+            WHERE locator_kind = 'posting_url'
+              AND is_current = 1
+              AND retired_at IS NULL
+            """
+        ).fetchall()
+    }
+    if (
+        locators != dict(job_ids.by_locator)
+        or _row_count(candidate, "job_locators") != len(locators)
+    ):
+        raise CandidateDashboardProjectionsError(
+            "dashboard projection rebuild requires exactly one current root locator per JobId"
+        )
+
+
+def _assert_upstream_projections(
+    candidate: sqlite3.Connection,
+    migration_at: str,
+) -> None:
+    _assert_apply_projection(candidate)
+    try:
+        expected_details = job_details._projection_rows(
+            candidate, migration_at=migration_at
+        )
+    except job_details.CandidateJobDetailProjectionsError as error:
+        raise CandidateDashboardProjectionsError(
+            "candidate job-detail projections cannot be verified"
+        ) from error
+    actual_details = _rows(
+        candidate,
+        "job_detail_projections",
+        job_details._COLUMNS,
+        order="tenant_id, job_id",
+    )
+    if actual_details != expected_details:
+        raise CandidateDashboardProjectionsError(
+            "candidate job_detail_projections must match the canonical rebuild"
+        )
+
+    try:
+        expected_list = job_list_projection_rows(candidate, migration_at)
+    except CandidateJobListProjectionsError as error:
+        raise CandidateDashboardProjectionsError(
+            "candidate job-list projections cannot be verified"
+        ) from error
+    actual_list = _rows(
+        candidate,
+        "job_list_projections",
+        JOB_LIST_PROJECTIONS_COLUMNS,
+        order="tenant_id, job_id",
+    )
+    if actual_list != expected_list:
+        raise CandidateDashboardProjectionsError(
+            "candidate job_list_projections must match the canonical rebuild"
+        )
+
+
+def _assert_apply_projection(candidate: sqlite3.Connection) -> None:
+    try:
+        jobs = apply_runs._candidate_job_metadata(candidate)
+        events = apply_runs._candidate_events_by_run(candidate, jobs)
+        expected_apply = tuple(
+            apply_runs._project_run(run_id, run_events, jobs)
+            for run_id, run_events in sorted(events.items())
+        )
+        actual_apply = apply_runs._rows(
+            candidate,
+            "apply_run_projections",
+            apply_runs._PROJECTION_COLUMNS,
+        )
+    except apply_runs.CandidateApplyRunProjectionsError as error:
+        raise CandidateDashboardProjectionsError(
+            "candidate apply-run projections cannot be verified"
+        ) from error
+    if actual_apply != expected_apply:
+        raise CandidateDashboardProjectionsError(
+            "candidate apply_run_projections must match the canonical event rebuild"
+        )
+
+
+def _assert_empty_target(candidate: sqlite3.Connection) -> None:
+    if _row_count(candidate, _TABLE):
+        raise CandidateDashboardProjectionsError(
+            "candidate dashboard_projections must be empty"
+        )
+
+
+def _insert_rows(
+    candidate: sqlite3.Connection,
+    rows: tuple[tuple[object, ...], ...],
+) -> None:
+    if not rows:
+        return
+    candidate.executemany(
+        f"INSERT INTO {_identifier(_TABLE)} ({_identifiers(_COLUMNS)}) "
+        f"VALUES ({', '.join('?' for _ in _COLUMNS)})",
+        rows,
+    )
+
+
+def _verify_candidate(
+    *,
+    source: sqlite3.Connection,
+    candidate: sqlite3.Connection,
+    expected_rows: tuple[tuple[object, ...], ...],
+    source_snapshot: tuple[int, int],
+    canonical_snapshot: tuple[tuple[str, tuple[tuple[object, ...], ...]], ...],
+) -> None:
+    if _rows(candidate, _TABLE, _COLUMNS, order="tenant_id") != expected_rows:
+        raise CandidateDashboardProjectionsError(
+            "candidate rebuild changed dashboard projection rows"
+        )
+    if _row_count(candidate, _TABLE) != len(expected_rows):
+        raise CandidateDashboardProjectionsError(
+            "candidate rebuild changed dashboard projection row count"
+        )
+    if _source_snapshot(source) != source_snapshot:
+        raise CandidateDashboardProjectionsError(
+            "candidate rebuild mutated the v6 source database"
+        )
+    if _canonical_snapshot(candidate) != canonical_snapshot:
+        raise CandidateDashboardProjectionsError(
+            "candidate rebuild mutated canonical dashboard inputs"
+        )
+    if candidate.execute("PRAGMA foreign_key_check").fetchall():
+        raise CandidateDashboardProjectionsError(
+            "candidate rebuild left a foreign-key violation"
+        )
+    assert_v6_migration_preflight(source)
+    assert_exact_manifest(candidate, EXACT_V7_MANIFEST)
+
+
+def _canonical_snapshot(
+    candidate: sqlite3.Connection,
+) -> tuple[tuple[str, tuple[tuple[object, ...], ...]], ...]:
+    return tuple(
+        (table, _rows(candidate, table, _columns(candidate, table), order="rowid"))
+        for table in _CANONICAL_TABLES
+    )
+
+
+def _source_snapshot(source: sqlite3.Connection) -> tuple[int, int]:
+    """Capture mutation-only source state without reading stale caches."""
+    return (
+        source.total_changes,
+        int(source.execute("PRAGMA schema_version").fetchone()[0]),
+    )
+
+
+def _assert_columns(
+    conn: sqlite3.Connection,
+    table: str,
+    expected: tuple[str, ...],
+) -> None:
+    if _columns(conn, table) != expected:
+        raise CandidateDashboardProjectionsError(
+            f"{table} columns do not match the exact v7 schema"
+        )
+
+
+def _columns(conn: sqlite3.Connection, table: str) -> tuple[str, ...]:
+    columns = tuple(
+        str(row[1])
+        for row in conn.execute(
+            f"PRAGMA table_info({_identifier(table)})"
+        ).fetchall()
+    )
+    if not columns:
+        raise CandidateDashboardProjectionsError(
+            f"missing required table: {table}"
+        )
+    return columns
+
+
+def _rows(
+    conn: sqlite3.Connection,
+    table: str,
+    columns: tuple[str, ...],
+    *,
+    order: str,
+) -> tuple[tuple[object, ...], ...]:
+    return tuple(
+        tuple(row)
+        for row in conn.execute(
+            f"SELECT {_identifiers(columns)} FROM {_identifier(table)} ORDER BY {order}"
+        ).fetchall()
+    )
+
+
+def _row_count(conn: sqlite3.Connection, table: str) -> int:
+    return int(conn.execute(f"SELECT COUNT(*) FROM {_identifier(table)}").fetchone()[0])
+
+
+def _identifier(value: str) -> str:
+    return f'"{value.replace(chr(34), chr(34) * 2)}"'
+
+
+def _identifiers(values: tuple[str, ...]) -> str:
+    return ", ".join(_identifier(value) for value in values)
+
+
+__all__ = [
+    "CandidateDashboardProjectionsError",
+    "CandidateDashboardProjectionsResult",
+    "rebuild_dashboard_projections",
+]

--- a/workers/automation/tests/test_v6_to_v7_dashboard_projections.py
+++ b/workers/automation/tests/test_v6_to_v7_dashboard_projections.py
@@ -1,0 +1,277 @@
+"""Safety contracts for rebuilding v7 dashboard projections."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from jobctrl.infrastructure.migrations import v6_to_v7_dashboard_projections as migration
+from jobctrl.infrastructure.migrations.v6_to_v7_copy import JobIdMap
+from jobctrl.infrastructure.migrations.v6_to_v7_dashboard_projections import (
+    CandidateDashboardProjectionsError,
+    rebuild_dashboard_projections,
+)
+from jobctrl.infrastructure.migrations.v6_to_v7_job_detail_projections import (
+    rebuild_job_detail_projections,
+)
+from jobctrl.infrastructure.migrations.v6_to_v7_job_list_projections import (
+    rebuild_job_list_projections,
+)
+from tests.test_v6_to_v7_job_list_projections import (
+    _databases,
+    _hydrate,
+    _seed_source,
+)
+
+_MIGRATION_AT = "2026-07-31T09:00:00+00:00"
+_INERT_CONTEXT = '{"userContext":"Attack vectors:\\nPrompt injection"}'
+
+
+def _hydrate_dashboard_inputs(
+    source: sqlite3.Connection,
+    candidate: sqlite3.Connection,
+) -> JobIdMap:
+    job_ids = _hydrate(source, candidate)
+    rebuild_job_detail_projections(
+        source,
+        candidate,
+        job_ids=job_ids,
+        migration_at=_MIGRATION_AT,
+    )
+    rebuild_job_list_projections(
+        source,
+        candidate,
+        job_ids=job_ids,
+        migration_at=_MIGRATION_AT,
+    )
+    return job_ids
+
+
+def _seed_stale_dashboard(source: sqlite3.Connection) -> None:
+    source.execute(
+        """
+        INSERT INTO dashboard_projections (
+            tenant_id, total_jobs, failures, blocked, ready, applied, dry_runs,
+            funnel_json, by_source_json, score_distribution_json,
+            outcome_conversion_json, generated_at
+        ) VALUES ('local', 999, 999, 999, 999, 999, 999, ?, ?, ?, ?, 'stale')
+        ON CONFLICT(tenant_id) DO UPDATE SET
+            total_jobs = excluded.total_jobs,
+            failures = excluded.failures,
+            outcome_conversion_json = excluded.outcome_conversion_json,
+            generated_at = excluded.generated_at
+        """,
+        (_INERT_CONTEXT, _INERT_CONTEXT, _INERT_CONTEXT, _INERT_CONTEXT),
+    )
+    source.commit()
+
+
+def test_rebuild_ignores_v6_caches_and_reopens(
+    tmp_path: Path,
+) -> None:
+    source, candidate, source_path, candidate_path = _databases(tmp_path)
+    try:
+        _seed_source(source)
+        _seed_stale_dashboard(source)
+        source_bytes = source_path.read_bytes()
+        source_cache = tuple(
+            source.execute("SELECT * FROM dashboard_projections").fetchall()
+        )
+        with pytest.raises(
+            CandidateDashboardProjectionsError,
+            match="hydrated candidate roots",
+        ):
+            rebuild_dashboard_projections(
+                source,
+                candidate,
+                job_ids=JobIdMap({}),
+                migration_at=_MIGRATION_AT,
+            )
+
+        job_ids = _hydrate_dashboard_inputs(source, candidate)
+        result = rebuild_dashboard_projections(
+            source,
+            candidate,
+            job_ids=job_ids,
+            migration_at=_MIGRATION_AT,
+        )
+
+        assert result.rebuilt_dashboard_projections == 1
+        row = candidate.execute(
+            """
+            SELECT tenant_id, total_jobs, failures, blocked, ready, applied,
+                   dry_runs, generated_at, outcome_conversion_json
+            FROM dashboard_projections
+            """
+        ).fetchone()
+        assert row[:8] == (
+            "local",
+            1,
+            0,
+            0,
+            0,
+            1,
+            0,
+            _MIGRATION_AT,
+        )
+        assert "Attack vectors" not in str(row)
+        assert tuple(
+            source.execute("SELECT * FROM dashboard_projections").fetchall()
+        ) == source_cache
+        assert source_path.read_bytes() == source_bytes
+        assert candidate.execute("PRAGMA foreign_key_check").fetchall() == []
+        with pytest.raises(
+            CandidateDashboardProjectionsError, match="must be empty"
+        ):
+            rebuild_dashboard_projections(
+                source,
+                candidate,
+                job_ids=job_ids,
+                migration_at=_MIGRATION_AT,
+            )
+
+        candidate.commit()
+        candidate.close()
+        candidate = sqlite3.connect(candidate_path)
+        candidate.execute("PRAGMA foreign_keys = ON")
+        assert candidate.execute(
+            "SELECT total_jobs, applied FROM dashboard_projections"
+        ).fetchone() == (1, 1)
+        assert candidate.execute("PRAGMA foreign_key_check").fetchall() == []
+    finally:
+        source.close()
+        candidate.close()
+
+
+def test_post_insert_failure_rolls_back_then_retries(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source, candidate, _source_path, _candidate_path = _databases(tmp_path)
+    try:
+        _seed_source(source)
+        job_ids = _hydrate_dashboard_inputs(source, candidate)
+        original_verify = migration._verify_candidate
+
+        def fail_after_insert(**_: object) -> None:
+            raise CandidateDashboardProjectionsError(
+                "injected verification failure"
+            )
+
+        monkeypatch.setattr(migration, "_verify_candidate", fail_after_insert)
+        with pytest.raises(
+            CandidateDashboardProjectionsError,
+            match="injected verification failure",
+        ):
+            rebuild_dashboard_projections(
+                source,
+                candidate,
+                job_ids=job_ids,
+                migration_at=_MIGRATION_AT,
+            )
+        assert candidate.execute(
+            "SELECT COUNT(*) FROM dashboard_projections"
+        ).fetchone() == (0,)
+
+        monkeypatch.setattr(migration, "_verify_candidate", original_verify)
+        result = rebuild_dashboard_projections(
+            source,
+            candidate,
+            job_ids=job_ids,
+            migration_at=_MIGRATION_AT,
+        )
+        assert result.rebuilt_dashboard_projections == 1
+        assert candidate.execute("PRAGMA foreign_key_check").fetchall() == []
+    finally:
+        source.close()
+        candidate.close()
+
+
+def test_canonical_input_mutation_rolls_back_all_writes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source, candidate, _source_path, _candidate_path = _databases(tmp_path)
+    try:
+        _seed_source(source)
+        job_ids = _hydrate_dashboard_inputs(source, candidate)
+        original_insert = migration._insert_rows
+        before_list = tuple(
+            candidate.execute("SELECT * FROM job_list_projections").fetchall()
+        )
+
+        def mutate_after_insert(
+            destination: sqlite3.Connection,
+            rows: tuple[tuple[object, ...], ...],
+        ) -> None:
+            original_insert(destination, rows)
+            destination.execute(
+                "UPDATE job_list_projections SET title = 'mutated input'"
+            )
+
+        monkeypatch.setattr(migration, "_insert_rows", mutate_after_insert)
+        with pytest.raises(
+            CandidateDashboardProjectionsError,
+            match="mutated canonical dashboard inputs",
+        ):
+            rebuild_dashboard_projections(
+                source,
+                candidate,
+                job_ids=job_ids,
+                migration_at=_MIGRATION_AT,
+            )
+        assert candidate.execute(
+            "SELECT COUNT(*) FROM dashboard_projections"
+        ).fetchone() == (0,)
+        assert tuple(
+            candidate.execute("SELECT * FROM job_list_projections").fetchall()
+        ) == before_list
+    finally:
+        source.close()
+        candidate.close()
+
+
+@pytest.mark.parametrize(
+    ("mutation", "message"),
+    [
+        (
+            "UPDATE job_detail_projections SET stages_json = '[]'",
+            "job_detail_projections",
+        ),
+        (
+            "UPDATE job_list_projections SET title = 'stale cache'",
+            "job_list_projections",
+        ),
+        (
+            "DELETE FROM apply_run_projections",
+            "apply_run_projections",
+        ),
+    ],
+)
+def test_incomplete_or_stale_upstream_projection_is_rejected_before_write(
+    tmp_path: Path,
+    mutation: str,
+    message: str,
+) -> None:
+    source, candidate, _source_path, _candidate_path = _databases(tmp_path)
+    try:
+        _seed_source(source)
+        job_ids = _hydrate_dashboard_inputs(source, candidate)
+        candidate.execute(mutation)
+
+        with pytest.raises(CandidateDashboardProjectionsError, match=message):
+            rebuild_dashboard_projections(
+                source,
+                candidate,
+                job_ids=job_ids,
+                migration_at=_MIGRATION_AT,
+            )
+        assert candidate.execute(
+            "SELECT COUNT(*) FROM dashboard_projections"
+        ).fetchone() == (0,)
+        assert candidate.execute("PRAGMA foreign_key_check").fetchall() == []
+    finally:
+        source.close()
+        candidate.close()


### PR DESCRIPTION
## Summary
- atomically persist complete v7 dashboard rows from the reviewed serializer
- verify apply-run, job-detail, and job-list prerequisites by exact canonical recomputation
- require admitted v6 source, exact-v7 candidate manifest, hydrated roots, and an empty target
- preserve source and canonical input immutability with savepoint rollback, retry, reopen, and foreign-key checks
- ignore stale v6 dashboard and list caches

## Why
The migration must not publish a dashboard from incomplete or stale upstream projections. Exact parity is checked before any write, and every post-insert failure rolls back cleanly.

## Stack
- Base: #599
- Depends on: #597 and #598

## Validation
- focused dashboard stack: 26 passed
- writer rollback/retry/reopen/upstream parity: 6 passed
- cumulative v6 to v7 migration suite: 198 passed
- TypeScript projection suite: 35 passed
- API typecheck: passed
- independent review: PASS, no findings
- independent cumulative QA: PASS, no findings
- Ruff and git diff --check: passed

## Deferred cumulative boundary
Final candidate orchestration, runtime cutover, and paired backup/restore QA remain in later stack phases.