### PR TITLE
feat(storage): add unstamped v7 candidate schema

### DIFF
--- a/workers/automation/src/jobctrl/infrastructure/migrations/schema_v7.py
+++ b/workers/automation/src/jobctrl/infrastructure/migrations/schema_v7.py
@@ -39,14 +39,37 @@ def create_exact_v7_schema(
     _execute: Callable[[str], object] | None = None,
 ) -> None:
     """Install the complete target schema into an empty SQLite database."""
+    _create_exact_v7_schema(conn, stamp_version=True, _execute=_execute)
+
+
+def create_unstamped_exact_v7_candidate(
+    conn: sqlite3.Connection,
+    *,
+    _execute: Callable[[str], object] | None = None,
+) -> None:
+    """Build an exact-v7 migration candidate without stamping its version."""
+    _create_exact_v7_schema(conn, stamp_version=False, _execute=_execute)
+
+
+def _create_exact_v7_schema(
+    conn: sqlite3.Connection,
+    *,
+    stamp_version: bool,
+    _execute: Callable[[str], object] | None,
+) -> None:
     if schema_dump(conn):
         raise SchemaManifestError("exact v7 creation requires an empty schema")
+    if not stamp_version and conn.execute("PRAGMA user_version").fetchone()[0] != 0:
+        raise SchemaManifestError(
+            "unstamped exact v7 candidate creation requires user_version 0"
+        )
     execute = _execute or conn.execute
     conn.execute("SAVEPOINT exact_v7_schema")
     try:
         for statement in _schema_statements():
             execute(statement)
-        execute(f"PRAGMA user_version = {EXACT_V7_MANIFEST.version}")
+        if stamp_version:
+            execute(f"PRAGMA user_version = {EXACT_V7_MANIFEST.version}")
         assert_exact_manifest(conn, EXACT_V7_MANIFEST)
         conn.execute("RELEASE SAVEPOINT exact_v7_schema")
     except BaseException:

--- a/workers/automation/tests/test_exact_v7_schema.py
+++ b/workers/automation/tests/test_exact_v7_schema.py
@@ -16,11 +16,15 @@ from jobctrl.database import (
 from jobctrl.infrastructure.migrations import schema_v7
 from jobctrl.infrastructure.migrations.schema_manifest import (
     EXACT_V7_MANIFEST,
+    SchemaManifestError,
     assert_exact_manifest,
     schema_dump,
     schema_manifest,
 )
-from jobctrl.infrastructure.migrations.schema_v7 import create_exact_v7_schema
+from jobctrl.infrastructure.migrations.schema_v7 import (
+    create_exact_v7_schema,
+    create_unstamped_exact_v7_candidate,
+)
 from jobctrl.infrastructure import runtime_identity
 
 
@@ -116,6 +120,59 @@ def test_fresh_v7_creation_matches_the_exact_manifest(tmp_path: Path) -> None:
         "application_preference_how_heard",
     } <= profile_columns
     close_connection(db_path)
+
+
+def test_unstamped_v7_candidate_matches_the_exact_manifest_without_version_stamp() -> None:
+    conn = sqlite3.connect(":memory:")
+
+    def deny_version_pragma(
+        action: int,
+        argument1: str | None,
+        argument2: str | None,
+        _database: str | None,
+        _source: str | None,
+    ) -> int:
+        if (
+            action == sqlite3.SQLITE_PRAGMA
+            and argument1 == "user_version"
+            and argument2 is not None
+        ):
+            return sqlite3.SQLITE_DENY
+        return sqlite3.SQLITE_OK
+
+    try:
+        conn.set_authorizer(deny_version_pragma)
+        create_unstamped_exact_v7_candidate(conn)
+        conn.set_authorizer(None)
+
+        assert_exact_manifest(conn, EXACT_V7_MANIFEST)
+        assert conn.execute("PRAGMA user_version").fetchone()[0] == 0
+    finally:
+        conn.set_authorizer(None)
+        conn.close()
+
+
+@pytest.mark.parametrize("version", (1, 6, SCHEMA_VERSION, 99))
+def test_unstamped_v7_candidate_rejects_nonzero_version_without_mutation(
+    version: int,
+) -> None:
+    conn = sqlite3.connect(":memory:")
+    conn.execute(f"PRAGMA user_version = {version}")
+    before = schema_dump(conn), conn.execute("PRAGMA user_version").fetchone()[0]
+
+    try:
+        with pytest.raises(
+            SchemaManifestError,
+            match="unstamped exact v7 candidate creation requires user_version 0",
+        ):
+            create_unstamped_exact_v7_candidate(conn)
+
+        assert (
+            schema_dump(conn),
+            conn.execute("PRAGMA user_version").fetchone()[0],
+        ) == before
+    finally:
+        conn.close()
 
 
 def test_exact_v7_reopen_has_no_writes_or_schema_or_data_changes(tmp_path: Path) -> None:
@@ -327,6 +384,37 @@ def test_fresh_schema_fault_leaves_no_partial_stamped_v7_database(tmp_path: Path
     conn.close()
     assert executed == 2
     assert _complete_database_dump(db_path) == before
+
+
+def test_unstamped_candidate_fault_rolls_back_and_can_retry() -> None:
+    conn = sqlite3.connect(":memory:")
+    before = schema_dump(conn)
+    executed = 0
+
+    def fail_after_partial_creation(statement: str) -> object:
+        nonlocal executed
+        executed += 1
+        if executed == 2:
+            raise RuntimeError("fixture candidate creation failure")
+        return conn.execute(statement)
+
+    try:
+        with pytest.raises(RuntimeError, match="fixture candidate creation failure"):
+            create_unstamped_exact_v7_candidate(
+                conn,
+                _execute=fail_after_partial_creation,
+            )
+
+        assert executed == 2
+        assert schema_dump(conn) == before
+        assert conn.execute("PRAGMA user_version").fetchone()[0] == 0
+
+        create_unstamped_exact_v7_candidate(conn)
+
+        assert_exact_manifest(conn, EXACT_V7_MANIFEST)
+        assert conn.execute("PRAGMA user_version").fetchone()[0] == 0
+    finally:
+        conn.close()
 
 
 def test_failed_fresh_init_removes_its_file_and_can_retry(


### PR DESCRIPTION
## What changed

- add a constructor for an exact-v7 migration candidate that deliberately leaves `PRAGMA user_version` at zero
- reject nonzero candidate version stamps before any schema mutation
- keep the existing fresh-database constructor stamped at v7
- share the same exact manifest and savepoint rollback path between both constructors
- cover no-stamp behavior, nonzero-version rejection, partial-construction rollback, and clean retry

## Why

A migrated database must not advertise v7 until candidate population and final verification have succeeded. This is the minimal schema primitive required by the following migration-coordinator PRs; it does not add a compatibility path or expose a user-facing migration command.

## Validation

- `workers/automation/.venv/bin/pytest -q workers/automation/tests/test_v6_to_v7*.py workers/automation/tests/test_v7*.py` — 168 passed
- `uv run --frozen --project workers/automation --extra dev pytest -q workers/automation/tests/test_exact_v7_schema.py workers/automation/tests/test_schema_v7_packaging.py` — 15 passed
- `uv run --frozen --project workers/automation --extra dev ruff check workers/automation/src/jobctrl/infrastructure/migrations/schema_v7.py workers/automation/tests/test_exact_v7_schema.py` — passed
- `git diff --check` — passed
- independent Tier 3 groundwork review — PASS, no remaining findings

## Stack

- Depends on #600
- Product-path migration QA is intentionally deferred until the executable coordinator and final-stamp slices are present; this groundwork PR contains focused rollback and version-stamp safety tests.
