### PR TITLE
feat(storage): populate v7 migration candidates

### DIFF
--- a/workers/automation/src/jobctrl/infrastructure/migrations/v6_to_v7_candidate.py
+++ b/workers/automation/src/jobctrl/infrastructure/migrations/v6_to_v7_candidate.py
@@ -1,0 +1,325 @@
+"""Populate an unstamped exact-v7 candidate from an admitted v6 database."""
+
+from __future__ import annotations
+
+import hashlib
+import sqlite3
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Final, Protocol
+
+from jobctrl.infrastructure.migrations.schema_manifest import (
+    EXACT_V7_MANIFEST,
+    assert_exact_manifest,
+    schema_dump,
+)
+from jobctrl.infrastructure.migrations.schema_v7 import (
+    create_unstamped_exact_v7_candidate,
+)
+from jobctrl.infrastructure.migrations.v6_to_v7_plan import target_tables
+from jobctrl.infrastructure.migrations.v6_to_v7_population_steps import (
+    CANDIDATE_POPULATION_STEPS,
+    CandidatePopulationArgumentProfile,
+    CandidatePopulationStep,
+)
+from jobctrl.infrastructure.migrations.v6_to_v7_preflight import (
+    assert_v6_migration_preflight,
+)
+
+_OUTER_SAVEPOINT: Final = "v6_to_v7_candidate_population"
+
+
+class _Digest(Protocol):
+    def update(self, data: bytes, /) -> object: ...
+
+
+class CandidatePopulationError(RuntimeError):
+    """Raised when candidate population cannot satisfy its closed contract."""
+
+
+@dataclass(frozen=True)
+class CandidatePopulationStepReceipt:
+    """Metadata-only record of one completed candidate population writer."""
+
+    step_id: str
+    owned_tables: tuple[str, ...]
+    table_row_counts: tuple[tuple[str, int], ...]
+
+
+@dataclass(frozen=True)
+class CandidatePopulationResult:
+    """Metadata-only result for an unstamped, validated v7 candidate."""
+
+    migration_at: str
+    steps: tuple[CandidatePopulationStepReceipt, ...]
+    table_row_counts: tuple[tuple[str, int], ...]
+    event_sequence_high_water: int | None
+
+
+def populate_v7_candidate(
+    source: sqlite3.Connection,
+    candidate: sqlite3.Connection,
+    *,
+    migration_at: str,
+    job_id_factory: Callable[[], str] | None = None,
+    _after_step: Callable[[str], None] | None = None,
+) -> CandidatePopulationResult:
+    """Populate and verify an unstamped exact-v7 candidate atomically.
+
+    The returned receipts deliberately contain only table names, counts, and
+    the primitive event sequence cursor.  They never retain source rows,
+    locators, or the transient JobId map used by the transforms.
+    """
+    _assert_raw_candidate(source, candidate)
+    assert_v6_migration_preflight(source)
+
+    source_total_changes = source.total_changes
+    source_digest = _logical_digest(source)
+    source_query_only = int(source.execute("PRAGMA query_only").fetchone()[0])
+    source_query_only_restored = False
+    source.execute("PRAGMA query_only = ON")
+    try:
+        candidate.execute(f"SAVEPOINT {_OUTER_SAVEPOINT}")
+        try:
+            create_unstamped_exact_v7_candidate(candidate)
+            receipts, event_sequence_high_water = _run_population_steps(
+                source,
+                candidate,
+                migration_at=migration_at,
+                job_id_factory=job_id_factory,
+                after_step=_after_step,
+            )
+            final_counts = _target_table_counts(candidate)
+            _assert_final_candidate(
+                source=source,
+                candidate=candidate,
+                source_total_changes=source_total_changes,
+                source_digest=source_digest,
+                receipts=receipts,
+                final_counts=final_counts,
+            )
+            source.execute(f"PRAGMA query_only = {source_query_only}")
+            source_query_only_restored = True
+            candidate.execute(f"RELEASE SAVEPOINT {_OUTER_SAVEPOINT}")
+        except BaseException:
+            candidate.execute(f"ROLLBACK TO SAVEPOINT {_OUTER_SAVEPOINT}")
+            candidate.execute(f"RELEASE SAVEPOINT {_OUTER_SAVEPOINT}")
+            raise
+    finally:
+        if not source_query_only_restored:
+            source.execute(f"PRAGMA query_only = {source_query_only}")
+
+    return CandidatePopulationResult(
+        migration_at=migration_at,
+        steps=receipts,
+        table_row_counts=final_counts,
+        event_sequence_high_water=event_sequence_high_water,
+    )
+
+
+def _assert_raw_candidate(
+    source: sqlite3.Connection,
+    candidate: sqlite3.Connection,
+) -> None:
+    if source is candidate:
+        raise CandidatePopulationError("source and candidate must be distinct")
+    if source.in_transaction or candidate.in_transaction:
+        raise CandidatePopulationError("candidate population requires connections without active transactions")
+    if candidate.execute("SELECT 1 FROM sqlite_master LIMIT 1").fetchone() is not None:
+        raise CandidatePopulationError("candidate population requires a raw empty schema")
+    if int(candidate.execute("PRAGMA user_version").fetchone()[0]) != 0:
+        raise CandidatePopulationError("candidate population requires candidate user_version 0")
+
+
+def _run_population_steps(
+    source: sqlite3.Connection,
+    candidate: sqlite3.Connection,
+    *,
+    migration_at: str,
+    job_id_factory: Callable[[], str] | None,
+    after_step: Callable[[str], None] | None,
+) -> tuple[tuple[CandidatePopulationStepReceipt, ...], int | None]:
+    receipts: list[CandidatePopulationStepReceipt] = []
+    job_ids: object | None = None
+    event_sequence_high_water: int | None = None
+
+    for step in CANDIDATE_POPULATION_STEPS:
+        result = _run_step(
+            step,
+            source,
+            candidate,
+            job_ids=job_ids,
+            migration_at=migration_at,
+            job_id_factory=job_id_factory,
+        )
+        if step.argument_profile is CandidatePopulationArgumentProfile.ROOT:
+            job_ids = _root_job_ids(result)
+        if step.step_id == "events":
+            event_sequence_high_water = _event_sequence_high_water(result)
+
+        receipt = CandidatePopulationStepReceipt(
+            step_id=step.step_id,
+            owned_tables=tuple(sorted(step.owned_tables)),
+            table_row_counts=_table_counts(candidate, step.owned_tables),
+        )
+        receipts.append(receipt)
+        if after_step is not None:
+            after_step(step.step_id)
+
+    return tuple(receipts), event_sequence_high_water
+
+
+def _run_step(
+    step: CandidatePopulationStep,
+    source: sqlite3.Connection,
+    candidate: sqlite3.Connection,
+    *,
+    job_ids: object | None,
+    migration_at: str,
+    job_id_factory: Callable[[], str] | None,
+) -> object:
+    if step.argument_profile is CandidatePopulationArgumentProfile.PLAIN:
+        return step.writer(source, candidate)
+    if step.argument_profile is CandidatePopulationArgumentProfile.ROOT:
+        return step.writer(
+            source,
+            candidate,
+            job_id_factory=job_id_factory,
+            migration_at=migration_at,
+        )
+    if job_ids is None:
+        raise CandidatePopulationError("candidate population is missing root JobIds")
+    if step.argument_profile is CandidatePopulationArgumentProfile.JOB_IDS:
+        return step.writer(source, candidate, job_ids=job_ids)
+    if step.argument_profile is CandidatePopulationArgumentProfile.JOB_IDS_AND_MIGRATION_AT:
+        return step.writer(
+            source,
+            candidate,
+            job_ids=job_ids,
+            migration_at=migration_at,
+        )
+    raise CandidatePopulationError("candidate population has an unknown step profile")
+
+
+def _root_job_ids(result: object) -> object:
+    job_ids = getattr(result, "job_ids", None)
+    if job_ids is None:
+        raise CandidatePopulationError("root population did not produce JobIds")
+    return job_ids
+
+
+def _event_sequence_high_water(result: object) -> int | None:
+    sequence_high_water = getattr(result, "sequence_high_water", None)
+    if sequence_high_water is None:
+        return None
+    if isinstance(sequence_high_water, bool) or not isinstance(sequence_high_water, int):
+        raise CandidatePopulationError("event population returned an invalid sequence")
+    return sequence_high_water
+
+
+def _assert_final_candidate(
+    *,
+    source: sqlite3.Connection,
+    candidate: sqlite3.Connection,
+    source_total_changes: int,
+    source_digest: str,
+    receipts: tuple[CandidatePopulationStepReceipt, ...],
+    final_counts: tuple[tuple[str, int], ...],
+) -> None:
+    assert_exact_manifest(candidate, EXACT_V7_MANIFEST)
+    if int(candidate.execute("PRAGMA user_version").fetchone()[0]) != 0:
+        raise CandidatePopulationError("candidate population must leave user_version 0")
+    if candidate.execute("PRAGMA foreign_key_check").fetchall():
+        raise CandidatePopulationError("candidate population left foreign-key violations")
+    if tuple(candidate.execute("PRAGMA integrity_check").fetchall()) != (("ok",),):
+        raise CandidatePopulationError("candidate population failed integrity_check")
+    receipt_counts = tuple(sorted((table, count) for receipt in receipts for table, count in receipt.table_row_counts))
+    if final_counts != receipt_counts:
+        raise CandidatePopulationError("candidate population final table counts differ from step receipts")
+    if source.total_changes != source_total_changes or _logical_digest(source) != source_digest:
+        raise CandidatePopulationError("candidate population altered the v6 source")
+
+
+def _target_table_counts(candidate: sqlite3.Connection) -> tuple[tuple[str, int], ...]:
+    return _table_counts(candidate, target_tables())
+
+
+def _table_counts(
+    conn: sqlite3.Connection,
+    tables: frozenset[str],
+) -> tuple[tuple[str, int], ...]:
+    return tuple(
+        (
+            table,
+            int(conn.execute(f"SELECT COUNT(*) FROM {_quote_identifier(table)}").fetchone()[0]),
+        )
+        for table in sorted(tables)
+    )
+
+
+def _logical_digest(conn: sqlite3.Connection) -> str:
+    """Hash schema and durable values without interpreting stored content."""
+    digest = hashlib.sha256()
+    _digest_value(digest, int(conn.execute("PRAGMA user_version").fetchone()[0]))
+    dump = schema_dump(conn)
+    _digest_value(digest, dump)
+    for object_type, table, _, _ in dump:
+        if object_type != "table":
+            continue
+        columns = _table_columns(conn, table)
+        _digest_value(digest, table)
+        _digest_value(digest, columns)
+        select_columns = ", ".join(_quote_identifier(column) for column in columns)
+        order_by = ", ".join(_quote_identifier(column) for column in columns)
+        rows = conn.execute(f"SELECT {select_columns} FROM {_quote_identifier(table)} ORDER BY {order_by}")
+        for row in rows:
+            _digest_value(digest, tuple(row))
+    _digest_value(digest, _sequence_rows(conn))
+    return digest.hexdigest()
+
+
+def _table_columns(conn: sqlite3.Connection, table: str) -> tuple[str, ...]:
+    return tuple(str(row[1]) for row in conn.execute(f"PRAGMA table_info({_quote_identifier(table)})"))
+
+
+def _sequence_rows(conn: sqlite3.Connection) -> tuple[tuple[object, ...], ...]:
+    exists = conn.execute("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'sqlite_sequence'").fetchone()
+    if exists is None:
+        return ()
+    return tuple(tuple(row) for row in conn.execute("SELECT name, seq FROM sqlite_sequence ORDER BY name"))
+
+
+def _digest_value(digest: _Digest, value: object) -> None:
+    if value is None:
+        encoded = b"n"
+    elif isinstance(value, bytes):
+        encoded = b"b" + value
+    elif isinstance(value, str):
+        encoded = b"s" + value.encode("utf-8")
+    elif isinstance(value, int):
+        encoded = b"i" + str(value).encode("ascii")
+    elif isinstance(value, float):
+        encoded = b"f" + value.hex().encode("ascii")
+    elif isinstance(value, tuple):
+        encoded = b"t"
+        digest.update(len(encoded).to_bytes(8, "big"))
+        digest.update(encoded)
+        for item in value:
+            _digest_value(digest, item)
+        return
+    else:
+        raise CandidatePopulationError("source contains an unsupported SQLite value")
+    digest.update(len(encoded).to_bytes(8, "big"))
+    digest.update(encoded)
+
+
+def _quote_identifier(identifier: str) -> str:
+    return '"' + identifier.replace('"', '""') + '"'
+
+
+__all__ = [
+    "CandidatePopulationError",
+    "CandidatePopulationResult",
+    "CandidatePopulationStepReceipt",
+    "populate_v7_candidate",
+]

--- a/workers/automation/tests/test_v6_to_v7_candidate.py
+++ b/workers/automation/tests/test_v6_to_v7_candidate.py
@@ -1,0 +1,426 @@
+"""End-to-end safety contracts for v6-to-v7 candidate population."""
+
+from __future__ import annotations
+
+import sqlite3
+from collections import Counter
+from collections.abc import Callable, Iterator
+from pathlib import Path
+
+import pytest
+
+from jobctrl.infrastructure.migrations.schema_manifest import (
+    EXACT_V7_MANIFEST,
+    assert_exact_manifest,
+    schema_dump,
+)
+from jobctrl.infrastructure.migrations.v6_to_v7_candidate import (
+    CandidatePopulationError,
+    populate_v7_candidate,
+)
+from jobctrl.infrastructure.migrations.v6_to_v7_copy import CandidateCopyError
+from jobctrl.infrastructure.migrations.v6_to_v7_plan import target_tables
+from jobctrl.infrastructure.migrations.v6_to_v7_preflight import (
+    V6MigrationPreflightError,
+)
+from tests.v6_migration_fixture import (
+    create_shipped_v6_database,
+    create_supported_upgrade_history_v6_database,
+)
+
+
+_MIGRATION_AT = "2026-07-31T10:00:00+00:00"
+_SOURCE_URL = "https://jobs.example/shipped-v6"
+_SOURCE_TITLE = "Shipped V6 fixture"
+_STEP_IDS = (
+    "root",
+    "direct_scalar",
+    "duplicate_links",
+    "events",
+    "work_items",
+    "contact_projections",
+    "pipeline_step_projections",
+    "workflow_run_projections",
+    "apply_run_projections",
+    "artifact_list_projections",
+    "job_detail_projections",
+    "evidence_usage_projections",
+    "job_list_projections",
+    "dashboard_projections",
+)
+_JOB_IDS = (
+    "00000000-0000-4000-8000-000000000001",
+    "00000000-0000-4000-8000-000000000002",
+)
+
+
+def _allocator(*values: str) -> Callable[[], str]:
+    allocated: Iterator[str] = iter(values)
+    return allocated.__next__
+
+
+def _connections(
+    tmp_path: Path,
+    *,
+    source_name: str = "source.db",
+    candidate_name: str = "candidate.db",
+    history: bool = False,
+) -> tuple[sqlite3.Connection, sqlite3.Connection]:
+    source_path = tmp_path / source_name
+    create = create_supported_upgrade_history_v6_database if history else create_shipped_v6_database
+    create(source_path)
+    source = sqlite3.connect(source_path)
+    candidate = sqlite3.connect(tmp_path / candidate_name)
+    source.execute("PRAGMA foreign_keys = ON")
+    candidate.execute("PRAGMA foreign_keys = ON")
+    return source, candidate
+
+
+def _logical_dump(conn: sqlite3.Connection) -> tuple[object, ...]:
+    return (
+        conn.execute("PRAGMA user_version").fetchone()[0],
+        schema_dump(conn),
+        tuple(conn.iterdump()),
+    )
+
+
+def _source_snapshot(conn: sqlite3.Connection) -> tuple[object, ...]:
+    return (
+        conn.execute("PRAGMA schema_version").fetchone()[0],
+        conn.execute("PRAGMA user_version").fetchone()[0],
+        conn.total_changes,
+        _logical_dump(conn),
+    )
+
+
+def _assert_source_unchanged(
+    conn: sqlite3.Connection,
+    snapshot: tuple[object, ...],
+) -> None:
+    assert _source_snapshot(conn) == snapshot
+
+
+def _assert_raw_candidate(conn: sqlite3.Connection) -> None:
+    assert schema_dump(conn) == ()
+    assert conn.execute("PRAGMA user_version").fetchone() == (0,)
+    assert conn.execute("SELECT name FROM sqlite_master WHERE name = 'sqlite_sequence'").fetchone() is None
+
+
+def _sequence_rows(conn: sqlite3.Connection) -> tuple[tuple[object, ...], ...]:
+    if conn.execute("SELECT 1 FROM sqlite_master WHERE name = 'sqlite_sequence'").fetchone() is None:
+        return ()
+    return tuple(conn.execute("SELECT name, seq FROM sqlite_sequence ORDER BY name"))
+
+
+def _assert_successful_result(result: object, candidate: sqlite3.Connection) -> None:
+    assert getattr(result, "migration_at") == _MIGRATION_AT
+    receipts = tuple(getattr(result, "steps"))
+    assert tuple(getattr(receipt, "step_id") for receipt in receipts) == _STEP_IDS
+    assert len(receipts) == len(_STEP_IDS)
+
+    owned_tables = [table for receipt in receipts for table in getattr(receipt, "owned_tables")]
+    assert set(owned_tables) == target_tables()
+    assert Counter(owned_tables) == Counter(set(owned_tables))
+    assert len(owned_tables) == EXACT_V7_MANIFEST.table_count
+
+    for receipt in receipts:
+        counts = dict(getattr(receipt, "table_row_counts"))
+        assert set(counts) == set(getattr(receipt, "owned_tables"))
+        for table, count in counts.items():
+            assert candidate.execute(f'SELECT COUNT(*) FROM "{table}"').fetchone() == (count,)
+
+    receipt_counts = tuple(
+        sorted((table, count) for receipt in receipts for table, count in getattr(receipt, "table_row_counts"))
+    )
+    assert tuple(getattr(result, "table_row_counts")) == receipt_counts
+
+    assert getattr(result, "event_sequence_high_water") == next(
+        (int(seq) for name, seq in _sequence_rows(candidate) if name == "job_events"),
+        None,
+    )
+    assert_exact_manifest(candidate, EXACT_V7_MANIFEST)
+    assert candidate.execute("PRAGMA user_version").fetchone() == (0,)
+    assert candidate.execute("PRAGMA foreign_key_check").fetchall() == []
+    assert candidate.execute("PRAGMA integrity_check").fetchall() == [("ok",)]
+
+
+def _callback_step_id(args: tuple[object, ...], kwargs: dict[str, object]) -> str | None:
+    for value in (*args, *kwargs.values()):
+        step_id = getattr(value, "step_id", value)
+        if isinstance(step_id, str) and step_id in _STEP_IDS:
+            return step_id
+    return None
+
+
+def test_population_builds_an_exact_unstamped_candidate_without_exposing_source_data(
+    tmp_path: Path,
+) -> None:
+    source, candidate = _connections(tmp_path)
+    try:
+        source.execute("PRAGMA query_only = 1")
+        before = _source_snapshot(source)
+
+        result = populate_v7_candidate(
+            source,
+            candidate,
+            migration_at=_MIGRATION_AT,
+            job_id_factory=_allocator(*_JOB_IDS),
+        )
+
+        _assert_successful_result(result, candidate)
+        _assert_source_unchanged(source, before)
+        assert source.execute("PRAGMA query_only").fetchone() == (1,)
+        assert _SOURCE_URL not in repr(result)
+        assert _SOURCE_TITLE not in repr(result)
+    finally:
+        source.close()
+        candidate.close()
+
+
+def test_population_is_deterministic_for_fresh_equivalent_candidates(
+    tmp_path: Path,
+) -> None:
+    source, first = _connections(tmp_path, candidate_name="first.db")
+    second_source, second = _connections(
+        tmp_path,
+        source_name="second-source.db",
+        candidate_name="second.db",
+    )
+    try:
+        first_result = populate_v7_candidate(
+            source,
+            first,
+            migration_at=_MIGRATION_AT,
+            job_id_factory=_allocator(*_JOB_IDS),
+        )
+        second_result = populate_v7_candidate(
+            second_source,
+            second,
+            migration_at=_MIGRATION_AT,
+            job_id_factory=_allocator(*_JOB_IDS),
+        )
+
+        assert second_result == first_result
+        assert _logical_dump(second) == _logical_dump(first)
+        assert _sequence_rows(second) == _sequence_rows(first)
+    finally:
+        source.close()
+        first.close()
+        second_source.close()
+        second.close()
+
+
+def test_population_rolls_back_a_late_failure_and_retries_from_the_same_raw_candidate(
+    tmp_path: Path,
+) -> None:
+    source, candidate = _connections(tmp_path)
+    reference_source, reference = _connections(
+        tmp_path,
+        source_name="reference-source.db",
+        candidate_name="reference.db",
+    )
+    seen_steps: list[str] = []
+    source.execute("PRAGMA query_only = 0")
+    before = _source_snapshot(source)
+
+    def fail_after_dashboard(*args: object, **kwargs: object) -> None:
+        assert source.execute("PRAGMA query_only").fetchone() == (1,)
+        step_id = _callback_step_id(args, dict(kwargs))
+        if step_id is not None:
+            seen_steps.append(step_id)
+        if step_id == "dashboard_projections":
+            raise RuntimeError("forced failure after dashboard projection rebuild")
+
+    try:
+        with pytest.raises(RuntimeError, match="forced failure"):
+            populate_v7_candidate(
+                source,
+                candidate,
+                migration_at=_MIGRATION_AT,
+                job_id_factory=_allocator(*_JOB_IDS),
+                _after_step=fail_after_dashboard,
+            )
+
+        assert seen_steps[-1:] == ["dashboard_projections"]
+        _assert_raw_candidate(candidate)
+        _assert_source_unchanged(source, before)
+        assert source.execute("PRAGMA query_only").fetchone() == (0,)
+
+        retry_result = populate_v7_candidate(
+            source,
+            candidate,
+            migration_at=_MIGRATION_AT,
+            job_id_factory=_allocator(*_JOB_IDS),
+        )
+        reference_result = populate_v7_candidate(
+            reference_source,
+            reference,
+            migration_at=_MIGRATION_AT,
+            job_id_factory=_allocator(*_JOB_IDS),
+        )
+
+        assert retry_result == reference_result
+        assert _logical_dump(candidate) == _logical_dump(reference)
+    finally:
+        source.close()
+        candidate.close()
+        reference_source.close()
+        reference.close()
+
+
+def test_population_rejects_invalid_entry_states_without_mutating_candidates(
+    tmp_path: Path,
+) -> None:
+    source, candidate = _connections(tmp_path)
+    try:
+        candidate.execute("PRAGMA user_version = 6")
+        before = _logical_dump(candidate)
+        with pytest.raises(CandidatePopulationError):
+            populate_v7_candidate(source, candidate, migration_at=_MIGRATION_AT)
+        assert _logical_dump(candidate) == before
+    finally:
+        source.close()
+        candidate.close()
+
+    source, candidate = _connections(
+        tmp_path,
+        source_name="nonempty-source.db",
+        candidate_name="nonempty-candidate.db",
+    )
+    try:
+        candidate.execute("CREATE TABLE unrelated_entry_state (value TEXT)")
+        before = _logical_dump(candidate)
+        with pytest.raises(CandidatePopulationError):
+            populate_v7_candidate(source, candidate, migration_at=_MIGRATION_AT)
+        assert _logical_dump(candidate) == before
+    finally:
+        source.close()
+        candidate.close()
+
+    source, candidate = _connections(
+        tmp_path,
+        source_name="residual-source.db",
+        candidate_name="residual-candidate.db",
+    )
+    try:
+        candidate.execute("CREATE TABLE discarded (id INTEGER PRIMARY KEY AUTOINCREMENT)")
+        candidate.execute("DROP TABLE discarded")
+        before = _logical_dump(candidate)
+        with pytest.raises(
+            CandidatePopulationError,
+            match="requires a raw empty schema",
+        ):
+            populate_v7_candidate(source, candidate, migration_at=_MIGRATION_AT)
+        assert _logical_dump(candidate) == before
+    finally:
+        source.close()
+        candidate.close()
+
+    source, candidate = _connections(
+        tmp_path,
+        source_name="transaction-source.db",
+        candidate_name="transaction-candidate.db",
+    )
+    try:
+        candidate.execute("BEGIN")
+        before = _logical_dump(candidate)
+        with pytest.raises(CandidatePopulationError):
+            populate_v7_candidate(source, candidate, migration_at=_MIGRATION_AT)
+        assert candidate.in_transaction
+        assert _logical_dump(candidate) == before
+        candidate.execute("ROLLBACK")
+    finally:
+        source.close()
+        candidate.close()
+
+    source, unused_candidate = _connections(tmp_path, source_name="same-source.db")
+    try:
+        before = _source_snapshot(source)
+        with pytest.raises(CandidatePopulationError):
+            populate_v7_candidate(source, source, migration_at=_MIGRATION_AT)
+        _assert_source_unchanged(source, before)
+    finally:
+        source.close()
+        unused_candidate.close()
+
+    unsupported = sqlite3.connect(tmp_path / "unsupported.db")
+    unsupported.execute("CREATE TABLE unrelated_source (value TEXT)")
+    candidate = sqlite3.connect(tmp_path / "unsupported-candidate.db")
+    try:
+        before = _logical_dump(candidate)
+        with pytest.raises(V6MigrationPreflightError):
+            populate_v7_candidate(unsupported, candidate, migration_at=_MIGRATION_AT)
+        assert _logical_dump(candidate) == before
+    finally:
+        unsupported.close()
+        candidate.close()
+
+
+def test_population_accepts_an_empty_shipped_workspace_without_spurious_rows(
+    tmp_path: Path,
+) -> None:
+    source, candidate = _connections(tmp_path)
+    try:
+        source.execute("DELETE FROM jobs")
+        source.commit()
+
+        result = populate_v7_candidate(
+            source,
+            candidate,
+            migration_at=_MIGRATION_AT,
+            job_id_factory=_allocator(*_JOB_IDS),
+        )
+
+        _assert_successful_result(result, candidate)
+        nonempty_rows = {
+            table: candidate.execute(f'SELECT COUNT(*) FROM "{table}"').fetchone()[0]
+            for table in sorted(target_tables())
+            if candidate.execute(f'SELECT COUNT(*) FROM "{table}"').fetchone()[0]
+        }
+        assert nonempty_rows == {"dashboard_projections": 1}
+        assert _sequence_rows(candidate) == ()
+    finally:
+        source.close()
+        candidate.close()
+
+
+def test_population_accepts_only_empty_retired_upgrade_history_tables(
+    tmp_path: Path,
+) -> None:
+    source, candidate = _connections(tmp_path, history=True)
+    try:
+        result = populate_v7_candidate(
+            source,
+            candidate,
+            migration_at=_MIGRATION_AT,
+            job_id_factory=_allocator(*_JOB_IDS),
+        )
+        _assert_successful_result(result, candidate)
+    finally:
+        source.close()
+        candidate.close()
+
+    source, candidate = _connections(
+        tmp_path,
+        source_name="retired-source.db",
+        candidate_name="retired-candidate.db",
+        history=True,
+    )
+    try:
+        source.execute("INSERT INTO discovery_run_projections (run_id) VALUES ('retired-run')")
+        source.commit()
+        before = _source_snapshot(source)
+
+        with pytest.raises(CandidateCopyError):
+            populate_v7_candidate(
+                source,
+                candidate,
+                migration_at=_MIGRATION_AT,
+                job_id_factory=_allocator(*_JOB_IDS),
+            )
+
+        _assert_raw_candidate(candidate)
+        _assert_source_unchanged(source, before)
+    finally:
+        source.close()
+        candidate.close()


### PR DESCRIPTION
## What changed

- populate a raw empty SQLite candidate through all 14 declared v6-to-v7 transforms under one outer savepoint
- construct the exact v7 schema without stamping `user_version`
- force the source connection read-only during population and verify a logical source digest plus change counter
- return metadata-only, immutable receipts covering all 101 target tables without retaining URLs, source rows, or the transient JobId map
- verify exact manifest, version 0, foreign keys, integrity, and exhaustive final counts before releasing the candidate
- roll schema, rows, and sequences back to a truly raw candidate on early or late failure so the same connection can retry

## Why

This is the executable data-copy phase of the one-shot local v6-to-v7 migration. It keeps population atomic and auditable while deliberately leaving final verification/stamping and file swap to subsequent small PRs. It does not add mixed-schema runtime behavior or a compatibility layer.

## Validation

- `workers/automation/.venv/bin/pytest -q workers/automation/tests/test_v6_to_v7_candidate.py` — 6 passed
- `workers/automation/.venv/bin/pytest -q workers/automation/tests/test_v6_to_v7*.py workers/automation/tests/test_v7*.py` — 180 passed
- independent cumulative migration review suite — 194 passed
- `workers/automation/.venv/bin/ruff check workers/automation/src/jobctrl/infrastructure/migrations/v6_to_v7_candidate.py workers/automation/tests/test_v6_to_v7_candidate.py` — passed
- `workers/automation/.venv/bin/ruff format --check workers/automation/src/jobctrl/infrastructure/migrations/v6_to_v7_candidate.py workers/automation/tests/test_v6_to_v7_candidate.py` — passed
- `git diff --check` — passed
- independent Tier 3 review — PASS, no findings
- independent Tier 3 QA — PASS, no findings

## Stack

- Depends on #602
- Final verification/stamping, quiescence, and paired backup/swap remain separate follow-up PRs.
