### PR TITLE
feat(storage): bind v7 candidates to source state

### DIFF
--- a/workers/automation/src/jobctrl/infrastructure/migrations/v6_to_v7_candidate.py
+++ b/workers/automation/src/jobctrl/infrastructure/migrations/v6_to_v7_candidate.py
@@ -51,6 +51,9 @@ class CandidatePopulationResult:
     """Metadata-only result for an unstamped, validated v7 candidate."""
 
     migration_at: str
+    candidate_digest: str
+    source_digest: str
+    source_total_changes: int
     steps: tuple[CandidatePopulationStepReceipt, ...]
     table_row_counts: tuple[tuple[str, int], ...]
     event_sequence_high_water: int | None
@@ -74,7 +77,7 @@ def populate_v7_candidate(
     assert_v6_migration_preflight(source)
 
     source_total_changes = source.total_changes
-    source_digest = _logical_digest(source)
+    source_digest = source_logical_digest(source)
     source_query_only = int(source.execute("PRAGMA query_only").fetchone()[0])
     source_query_only_restored = False
     source.execute("PRAGMA query_only = ON")
@@ -98,6 +101,7 @@ def populate_v7_candidate(
                 receipts=receipts,
                 final_counts=final_counts,
             )
+            candidate_digest = candidate_logical_digest(candidate)
             source.execute(f"PRAGMA query_only = {source_query_only}")
             source_query_only_restored = True
             candidate.execute(f"RELEASE SAVEPOINT {_OUTER_SAVEPOINT}")
@@ -111,6 +115,9 @@ def populate_v7_candidate(
 
     return CandidatePopulationResult(
         migration_at=migration_at,
+        candidate_digest=candidate_digest,
+        source_digest=source_digest,
+        source_total_changes=source_total_changes,
         steps=receipts,
         table_row_counts=final_counts,
         event_sequence_high_water=event_sequence_high_water,
@@ -236,7 +243,7 @@ def _assert_final_candidate(
     receipt_counts = tuple(sorted((table, count) for receipt in receipts for table, count in receipt.table_row_counts))
     if final_counts != receipt_counts:
         raise CandidatePopulationError("candidate population final table counts differ from step receipts")
-    if source.total_changes != source_total_changes or _logical_digest(source) != source_digest:
+    if source.total_changes != source_total_changes or source_logical_digest(source) != source_digest:
         raise CandidatePopulationError("candidate population altered the v6 source")
 
 
@@ -257,10 +264,24 @@ def _table_counts(
     )
 
 
-def _logical_digest(conn: sqlite3.Connection) -> str:
-    """Hash schema and durable values without interpreting stored content."""
+def source_logical_digest(conn: sqlite3.Connection) -> str:
+    """Hash source version, schema, and values without interpreting content."""
+    return _database_logical_digest(conn, include_user_version=True)
+
+
+def candidate_logical_digest(conn: sqlite3.Connection) -> str:
+    """Hash candidate schema and values independently of its version stamp."""
+    return _database_logical_digest(conn, include_user_version=False)
+
+
+def _database_logical_digest(
+    conn: sqlite3.Connection,
+    *,
+    include_user_version: bool,
+) -> str:
     digest = hashlib.sha256()
-    _digest_value(digest, int(conn.execute("PRAGMA user_version").fetchone()[0]))
+    if include_user_version:
+        _digest_value(digest, int(conn.execute("PRAGMA user_version").fetchone()[0]))
     dump = schema_dump(conn)
     _digest_value(digest, dump)
     for object_type, table, _, _ in dump:
@@ -321,5 +342,7 @@ __all__ = [
     "CandidatePopulationError",
     "CandidatePopulationResult",
     "CandidatePopulationStepReceipt",
+    "candidate_logical_digest",
     "populate_v7_candidate",
+    "source_logical_digest",
 ]

--- a/workers/automation/tests/test_v6_to_v7_candidate.py
+++ b/workers/automation/tests/test_v6_to_v7_candidate.py
@@ -16,7 +16,9 @@ from jobctrl.infrastructure.migrations.schema_manifest import (
 )
 from jobctrl.infrastructure.migrations.v6_to_v7_candidate import (
     CandidatePopulationError,
+    candidate_logical_digest,
     populate_v7_candidate,
+    source_logical_digest,
 )
 from jobctrl.infrastructure.migrations.v6_to_v7_copy import CandidateCopyError
 from jobctrl.infrastructure.migrations.v6_to_v7_plan import target_tables
@@ -112,8 +114,23 @@ def _sequence_rows(conn: sqlite3.Connection) -> tuple[tuple[object, ...], ...]:
     return tuple(conn.execute("SELECT name, seq FROM sqlite_sequence ORDER BY name"))
 
 
-def _assert_successful_result(result: object, candidate: sqlite3.Connection) -> None:
+def _assert_successful_result(
+    result: object,
+    candidate: sqlite3.Connection,
+    *,
+    source_digest: str,
+    source_total_changes: int,
+) -> None:
     assert getattr(result, "migration_at") == _MIGRATION_AT
+    candidate_digest = getattr(result, "candidate_digest")
+    assert candidate_digest == candidate_logical_digest(candidate)
+    assert len(candidate_digest) == 64
+    assert int(candidate_digest, 16) >= 0
+    observed_source_digest = getattr(result, "source_digest")
+    assert observed_source_digest == source_digest
+    assert len(observed_source_digest) == 64
+    assert int(observed_source_digest, 16) >= 0
+    assert getattr(result, "source_total_changes") == source_total_changes
     receipts = tuple(getattr(result, "steps"))
     assert tuple(getattr(receipt, "step_id") for receipt in receipts) == _STEP_IDS
     assert len(receipts) == len(_STEP_IDS)
@@ -167,11 +184,23 @@ def test_population_builds_an_exact_unstamped_candidate_without_exposing_source_
             job_id_factory=_allocator(*_JOB_IDS),
         )
 
-        _assert_successful_result(result, candidate)
+        _assert_successful_result(
+            result,
+            candidate,
+            source_digest=source_logical_digest(source),
+            source_total_changes=int(before[2]),
+        )
         _assert_source_unchanged(source, before)
         assert source.execute("PRAGMA query_only").fetchone() == (1,)
         assert _SOURCE_URL not in repr(result)
         assert _SOURCE_TITLE not in repr(result)
+
+        candidate.execute("PRAGMA user_version = 7")
+        assert candidate_logical_digest(candidate) == result.candidate_digest
+        candidate.execute("PRAGMA user_version = 0")
+        candidate.execute("UPDATE dashboard_projections SET generated_at = 'tampered'")
+        candidate.commit()
+        assert candidate_logical_digest(candidate) != result.candidate_digest
     finally:
         source.close()
         candidate.close()
@@ -371,7 +400,12 @@ def test_population_accepts_an_empty_shipped_workspace_without_spurious_rows(
             job_id_factory=_allocator(*_JOB_IDS),
         )
 
-        _assert_successful_result(result, candidate)
+        _assert_successful_result(
+            result,
+            candidate,
+            source_digest=source_logical_digest(source),
+            source_total_changes=source.total_changes,
+        )
         nonempty_rows = {
             table: candidate.execute(f'SELECT COUNT(*) FROM "{table}"').fetchone()[0]
             for table in sorted(target_tables())
@@ -395,7 +429,12 @@ def test_population_accepts_only_empty_retired_upgrade_history_tables(
             migration_at=_MIGRATION_AT,
             job_id_factory=_allocator(*_JOB_IDS),
         )
-        _assert_successful_result(result, candidate)
+        _assert_successful_result(
+            result,
+            candidate,
+            source_digest=source_logical_digest(source),
+            source_total_changes=source.total_changes,
+        )
     finally:
         source.close()
         candidate.close()


### PR DESCRIPTION
## What changed

- retain the already-computed logical source SHA-256 digest and source connection change counter in the population result
- retain a deterministic full candidate-content SHA-256 digest that covers schema, every durable value, and sequence state while deliberately excluding only `user_version`
- expose the single source and candidate digest implementations for the following verifier PR
- verify the bindings are deterministic, opaque, version-independent where required, and contain no source URL or job text

## Why

The following verifier/stamp PR must prove it is sealing the exact candidate produced from the same admitted v6 source connection and logical state. These metadata-only bindings close that handoff without retaining source rows, URLs, JSON, or the JobId map, and ensure same-row-count scalar or structured-data changes cannot be sealed.

## Validation

- `workers/automation/.venv/bin/pytest -q workers/automation/tests/test_v6_to_v7_candidate.py` — 6 passed
- `workers/automation/.venv/bin/ruff check workers/automation/src/jobctrl/infrastructure/migrations/v6_to_v7_candidate.py workers/automation/tests/test_v6_to_v7_candidate.py` — passed
- `workers/automation/.venv/bin/ruff format --check workers/automation/src/jobctrl/infrastructure/migrations/v6_to_v7_candidate.py workers/automation/tests/test_v6_to_v7_candidate.py` — passed
- `git diff --check` — passed
- independent Tier 3 groundwork review — PASS, no findings
- direct version-independence, same-count scalar mutation, restored-content, and schema-mutation probes — passed

## Stack

- Depends on #603
- This is receipt metadata only; candidate verification and stamping remain the next separate PR.
