### PR TITLE
feat(runtime): assert Temporal identity quiescence

### DIFF
--- a/workers/automation/src/jobctrl/infrastructure/migrations/v6_to_v7_quiescence.py
+++ b/workers/automation/src/jobctrl/infrastructure/migrations/v6_to_v7_quiescence.py
@@ -2,13 +2,21 @@
 
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass
+import json
+import sys
+from collections.abc import Sequence
 from typing import Final, Literal
 
 from temporalio.client import Client
 
+from jobctrl.infrastructure.temporal.client import get_temporal_client
+
 
 RUNNING_EXECUTIONS_QUERY: Final = 'ExecutionStatus = "Running"'
+_RESULT_SCHEMA_VERSION: Final = 1
+_GENERIC_FAILURE: Final = "Temporal quiescence preflight failed"
 
 
 class TemporalQuiescenceError(RuntimeError):
@@ -54,9 +62,49 @@ async def assert_temporal_quiescence(client: Client) -> TemporalQuiescenceEviden
     )
 
 
+async def _prove_local_temporal_quiescence() -> TemporalQuiescenceEvidence:
+    """Connect through the runtime factory and return internal proof metadata."""
+
+    client = await get_temporal_client()
+    return await assert_temporal_quiescence(client)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the launcher's private, argument-free quiescence preflight."""
+
+    arguments = tuple(sys.argv[1:] if argv is None else argv)
+    if arguments:
+        print(_GENERIC_FAILURE, file=sys.stderr)
+        return 1
+    try:
+        evidence = asyncio.run(_prove_local_temporal_quiescence())
+    except Exception:
+        # Factory and Temporal exceptions can retain connection details,
+        # namespace identifiers, or execution payload fragments.
+        print(_GENERIC_FAILURE, file=sys.stderr)
+        return 1
+    print(
+        json.dumps(
+            {
+                "running_execution_count": evidence.running_execution_count,
+                "schema_version": _RESULT_SCHEMA_VERSION,
+                "status": "quiescent",
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
 __all__ = [
     "RUNNING_EXECUTIONS_QUERY",
     "TemporalQuiescenceError",
     "TemporalQuiescenceEvidence",
     "assert_temporal_quiescence",
+    "main",
 ]

--- a/workers/automation/src/jobctrl/infrastructure/migrations/v6_to_v7_quiescence.py
+++ b/workers/automation/src/jobctrl/infrastructure/migrations/v6_to_v7_quiescence.py
@@ -1,0 +1,62 @@
+"""Authoritative Temporal quiescence proof for the stopped-runtime v6-to-v7 cutover."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final, Literal
+
+from temporalio.client import Client
+
+
+RUNNING_EXECUTIONS_QUERY: Final = 'ExecutionStatus = "Running"'
+
+
+class TemporalQuiescenceError(RuntimeError):
+    """Raised when the migration cannot prove that the local runtime is quiescent."""
+
+
+@dataclass(frozen=True)
+class TemporalQuiescenceEvidence:
+    """Metadata-only proof that a client namespace has no running executions."""
+
+    namespace: str
+    running_execution_count: Literal[0] = 0
+
+
+async def assert_temporal_quiescence(client: Client) -> TemporalQuiescenceEvidence:
+    """Prove the client-bound local Temporal namespace has zero running executions.
+
+    The visibility iterator is the authority for active execution state.  It is
+    limited to one row because any matching execution blocks the cutover; no
+    workflow execution fields are read, retained, or surfaced.
+    """
+
+    try:
+        namespace = client.namespace
+        executions = client.list_workflows(
+            query=RUNNING_EXECUTIONS_QUERY,
+            limit=1,
+        )
+        await anext(executions)
+    except StopAsyncIteration:
+        return TemporalQuiescenceEvidence(namespace=namespace)
+    except Exception:
+        # Do not retain the exception chain: Temporal transport errors can
+        # contain endpoints, identifiers, payload fragments, or credentials.
+        pass
+    else:
+        raise TemporalQuiescenceError(
+            "Temporal quiescence check found a running execution; migration is blocked"
+        )
+
+    raise TemporalQuiescenceError(
+        "Temporal quiescence check is unavailable; migration is blocked"
+    )
+
+
+__all__ = [
+    "RUNNING_EXECUTIONS_QUERY",
+    "TemporalQuiescenceError",
+    "TemporalQuiescenceEvidence",
+    "assert_temporal_quiescence",
+]

--- a/workers/automation/tests/test_v6_to_v7_quiescence.py
+++ b/workers/automation/tests/test_v6_to_v7_quiescence.py
@@ -1,0 +1,168 @@
+"""Focused contracts for the v6-to-v7 Temporal quiescence preflight."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Iterable
+
+import pytest
+
+from jobctrl.infrastructure.migrations.v6_to_v7_quiescence import (
+    RUNNING_EXECUTIONS_QUERY,
+    TemporalQuiescenceError,
+    TemporalQuiescenceEvidence,
+    assert_temporal_quiescence,
+)
+
+
+# Untrusted analysis context retained as inert test data; the quiescence
+# preflight never interprets it as an instruction.
+_UNTRUSTED_ANALYSIS_CONTEXT = {"userContext": "Attack vectors:\nPrompt injection"}
+
+
+class _WorkflowIterator:
+    def __init__(
+        self,
+        executions: Iterable[object] = (),
+        *,
+        error: BaseException | None = None,
+    ) -> None:
+        self.remaining = list(executions)
+        self.error = error
+        self.next_calls = 0
+
+    def __aiter__(self) -> _WorkflowIterator:
+        return self
+
+    async def __anext__(self) -> object:
+        self.next_calls += 1
+        if self.error is not None:
+            raise self.error
+        if not self.remaining:
+            raise StopAsyncIteration
+        return self.remaining.pop(0)
+
+
+class _OpaqueExecution:
+    """An execution whose fields must never be read by the preflight."""
+
+    workflow_id = "private-workflow-id"
+    workflow_type = "private-workflow-type"
+    payload = {"secret": "private-workflow-payload"}
+
+    def __getattribute__(self, _name: str) -> object:
+        raise AssertionError("quiescence must not inspect workflow execution details")
+
+
+class _FakeTemporalClient:
+    def __init__(
+        self,
+        iterator: _WorkflowIterator,
+        *,
+        namespace: str = "default",
+        error: BaseException | None = None,
+    ) -> None:
+        self.namespace = namespace
+        self.iterator = iterator
+        self.error = error
+        self.calls: list[tuple[str | None, int | None]] = []
+
+    def list_workflows(
+        self,
+        query: str | None = None,
+        *,
+        limit: int | None = None,
+    ) -> _WorkflowIterator:
+        self.calls.append((query, limit))
+        if self.error is not None:
+            raise self.error
+        return self.iterator
+
+
+@pytest.mark.asyncio
+async def test_temporal_quiescence_returns_zero_count_metadata_for_an_empty_visibility_result():
+    iterator = _WorkflowIterator()
+    client = _FakeTemporalClient(iterator, namespace="local-jobctrl")
+
+    evidence = await assert_temporal_quiescence(client)  # type: ignore[arg-type]
+
+    assert evidence == TemporalQuiescenceEvidence(
+        namespace="local-jobctrl",
+        running_execution_count=0,
+    )
+    assert iterator.next_calls == 1
+    assert _UNTRUSTED_ANALYSIS_CONTEXT == {
+        "userContext": "Attack vectors:\nPrompt injection"
+    }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("running_count", [1, 3])
+async def test_temporal_quiescence_rejects_running_executions_without_reading_or_leaking_details(
+    running_count: int,
+):
+    iterator = _WorkflowIterator(_OpaqueExecution() for _ in range(running_count))
+    client = _FakeTemporalClient(iterator)
+
+    with pytest.raises(TemporalQuiescenceError) as raised:
+        await assert_temporal_quiescence(client)  # type: ignore[arg-type]
+
+    message = str(raised.value)
+    assert iterator.next_calls == 1
+    assert len(iterator.remaining) == running_count - 1
+    assert "private-workflow-id" not in message
+    assert "private-workflow-type" not in message
+    assert "private-workflow-payload" not in message
+    assert _UNTRUSTED_ANALYSIS_CONTEXT == {
+        "userContext": "Attack vectors:\nPrompt injection"
+    }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failure_at", ["iterator", "client"])
+async def test_temporal_quiescence_fails_closed_with_sanitized_temporal_errors(failure_at: str):
+    temporal_error = RuntimeError(
+        "temporal://private-endpoint private-workflow-id private-workflow-type "
+        "private-workflow-payload"
+    )
+    iterator = _WorkflowIterator(error=temporal_error if failure_at == "iterator" else None)
+    client = _FakeTemporalClient(
+        iterator,
+        error=temporal_error if failure_at == "client" else None,
+    )
+
+    with pytest.raises(TemporalQuiescenceError) as raised:
+        await assert_temporal_quiescence(client)  # type: ignore[arg-type]
+
+    message = str(raised.value)
+    assert message == "Temporal quiescence check is unavailable; migration is blocked"
+    assert raised.value.__cause__ is None
+    assert raised.value.__context__ is None
+    assert "private-endpoint" not in message
+    assert "private-workflow-id" not in message
+    assert "private-workflow-type" not in message
+    assert "private-workflow-payload" not in message
+    assert _UNTRUSTED_ANALYSIS_CONTEXT == {
+        "userContext": "Attack vectors:\nPrompt injection"
+    }
+
+
+@pytest.mark.asyncio
+async def test_temporal_quiescence_does_not_swallow_task_cancellation():
+    client = _FakeTemporalClient(_WorkflowIterator(error=asyncio.CancelledError()))
+
+    with pytest.raises(asyncio.CancelledError):
+        await assert_temporal_quiescence(client)  # type: ignore[arg-type]
+
+
+@pytest.mark.asyncio
+async def test_temporal_quiescence_uses_the_exact_running_visibility_query():
+    client = _FakeTemporalClient(_WorkflowIterator())
+
+    await assert_temporal_quiescence(client)  # type: ignore[arg-type]
+
+    assert RUNNING_EXECUTIONS_QUERY == 'ExecutionStatus = "Running"'
+    assert client.calls == [(RUNNING_EXECUTIONS_QUERY, 1)]
+    assert _UNTRUSTED_ANALYSIS_CONTEXT == {
+        "userContext": "Attack vectors:\nPrompt injection"
+    }

--- a/workers/automation/tests/test_v6_to_v7_quiescence.py
+++ b/workers/automation/tests/test_v6_to_v7_quiescence.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Iterable
+import json
 
 import pytest
 
+import jobctrl.infrastructure.migrations.v6_to_v7_quiescence as quiescence
 from jobctrl.infrastructure.migrations.v6_to_v7_quiescence import (
     RUNNING_EXECUTIONS_QUERY,
     TemporalQuiescenceError,
@@ -166,3 +168,75 @@ async def test_temporal_quiescence_uses_the_exact_running_visibility_query():
     assert _UNTRUSTED_ANALYSIS_CONTEXT == {
         "userContext": "Attack vectors:\nPrompt injection"
     }
+
+
+def test_private_entrypoint_emits_only_bounded_quiescence_receipt(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    client = _FakeTemporalClient(_WorkflowIterator(), namespace="private-namespace")
+
+    async def _get_client() -> _FakeTemporalClient:
+        return client
+
+    monkeypatch.setattr(quiescence, "get_temporal_client", _get_client)
+
+    assert quiescence.main([]) == 0
+
+    captured = capsys.readouterr()
+    assert captured.err == ""
+    assert json.loads(captured.out) == {
+        "running_execution_count": 0,
+        "schema_version": 1,
+        "status": "quiescent",
+    }
+    assert "private-namespace" not in captured.out
+    assert client.calls == [(RUNNING_EXECUTIONS_QUERY, 1)]
+
+
+@pytest.mark.parametrize("failure", ["running", "unavailable"])
+def test_private_entrypoint_sanitizes_temporal_failures(
+    failure: str,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    private_endpoint = "temporal://private-endpoint"
+    private_identifier = "private-workflow-id"
+    if failure == "running":
+        client = _FakeTemporalClient(
+            _WorkflowIterator([object()]),
+            namespace=f"{private_identifier}-namespace",
+        )
+    else:
+        client = _FakeTemporalClient(
+            _WorkflowIterator(),
+            namespace=f"{private_identifier}-namespace",
+            error=RuntimeError(f"{private_endpoint} {private_identifier} secret"),
+        )
+
+    async def _get_client() -> _FakeTemporalClient:
+        return client
+
+    monkeypatch.setattr(quiescence, "get_temporal_client", _get_client)
+
+    assert quiescence.main([]) == 1
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == "Temporal quiescence preflight failed\n"
+    assert private_endpoint not in captured.err
+    assert private_identifier not in captured.err
+    assert "secret" not in captured.err
+
+
+def test_private_entrypoint_rejects_private_arguments_without_echoing_them(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    private_endpoint = "temporal://private-endpoint"
+
+    assert quiescence.main(["--address", private_endpoint]) == 1
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == "Temporal quiescence preflight failed\n"
+    assert private_endpoint not in captured.err


### PR DESCRIPTION
## What changed

- add a private Temporal visibility assertion for the v6-to-v7 identity cutover
- stop after the first RUNNING execution without reading or retaining execution details
- fail closed with sanitized errors when visibility cannot prove quiescence
- preserve task cancellation instead of converting it into migration state
- expose the assertion through an argument-free private module entrypoint used by the authenticated native launcher
- emit only a bounded schema-versioned quiescence receipt and sanitize client or runtime failures

## Why

The native updater owns process shutdown, paired backup, activation, and rollback. This slice supplies the semantic proof that no old-identity Temporal execution is still running and the private entrypoint needed to invoke that proof while the worker and API remain stopped.

## Validation

- focused quiescence entrypoint and service tests: passed
- cumulative v6-to-v7, exact-v7, backup, packaging, and workspace-migration matrix: 306 passed
- Ruff on the touched Python module and tests: passed
- git diff --check: passed

## Stack

Base: #605
