### PR TITLE
feat(storage): build sealed v7 database candidates

### DIFF
--- a/workers/automation/src/jobctrl/infrastructure/migrations/v6_to_v7_execute.py
+++ b/workers/automation/src/jobctrl/infrastructure/migrations/v6_to_v7_execute.py
@@ -1,0 +1,233 @@
+"""Private file-to-file executor for the stopped-runtime v6-to-v7 cutover."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import sqlite3
+import stat
+import sys
+from collections.abc import Callable, Sequence
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Final, Literal
+
+from jobctrl.database import close_connection, open_exact_v7_database
+from jobctrl.infrastructure.migrations.schema_manifest import EXACT_V7_MANIFEST
+from jobctrl.infrastructure.migrations.v6_to_v7_candidate import (
+    populate_v7_candidate,
+)
+from jobctrl.infrastructure.migrations.v6_to_v7_verify import (
+    verify_and_stamp_v7_candidate,
+)
+
+_RESULT_SCHEMA_VERSION: Final = 1
+_GENERIC_FAILURE: Final = "v6-to-v7 candidate execution failed"
+
+
+class CandidateExecutionError(RuntimeError):
+    """Raised when a sealed v7 candidate cannot be produced safely."""
+
+
+@dataclass(frozen=True)
+class CandidateExecutionResult:
+    """Bounded receipt for one closed and fsynced exact-v7 candidate."""
+
+    schema_version: Literal[1]
+    status: Literal["ready"]
+    user_version: Literal[7]
+    source_digest: str
+    candidate_logical_digest: str
+    candidate_sha256: str
+    job_count: int
+    table_count: int
+
+
+def execute_v6_to_v7_candidate(
+    source_path: Path | str,
+    candidate_path: Path | str,
+    *,
+    migration_at: str,
+    job_id_factory: Callable[[], str] | None = None,
+    _after_stamp: Callable[[], None] | None = None,
+) -> CandidateExecutionResult:
+    """Build an exact-v7 file from a standalone v6 paired-backup member.
+
+    This function never replaces the live database. The authenticated native
+    lifecycle owns quiescence, paired backup verification, installation, and
+    rollback.
+    """
+
+    source = Path(source_path)
+    candidate = Path(candidate_path)
+    source_connection: sqlite3.Connection | None = None
+    candidate_connection: sqlite3.Connection | None = None
+    created_identity: tuple[int, int] | None = None
+    try:
+        _assert_paths(source, candidate)
+        descriptor = os.open(
+            candidate,
+            os.O_CREAT | os.O_EXCL | os.O_WRONLY,
+            0o600,
+        )
+        try:
+            os.fchmod(descriptor, 0o600)
+            created = os.fstat(descriptor)
+            created_identity = (created.st_dev, created.st_ino)
+        finally:
+            os.close(descriptor)
+
+        source_connection = sqlite3.connect(
+            f"{source.resolve().as_uri()}?mode=ro",
+            uri=True,
+        )
+        source_connection.execute("PRAGMA foreign_keys = ON")
+        candidate_connection = sqlite3.connect(candidate)
+        candidate_connection.execute("PRAGMA foreign_keys = ON")
+
+        population = populate_v7_candidate(
+            source_connection,
+            candidate_connection,
+            migration_at=migration_at,
+            job_id_factory=job_id_factory,
+        )
+        verification = verify_and_stamp_v7_candidate(
+            source_connection,
+            candidate_connection,
+            population,
+            _after_stamp=_after_stamp,
+        )
+        candidate_connection.commit()
+        candidate_connection.close()
+        candidate_connection = None
+        source_connection.close()
+        source_connection = None
+
+        reopened = open_exact_v7_database(candidate)
+        try:
+            if int(reopened.execute("PRAGMA user_version").fetchone()[0]) != EXACT_V7_MANIFEST.version:
+                raise CandidateExecutionError(_GENERIC_FAILURE)
+        finally:
+            close_connection(candidate)
+
+        _fsync_regular_file(candidate)
+        _fsync_directory(candidate.parent)
+        return CandidateExecutionResult(
+            schema_version=_RESULT_SCHEMA_VERSION,
+            status="ready",
+            user_version=EXACT_V7_MANIFEST.version,
+            source_digest=population.source_digest,
+            candidate_logical_digest=population.candidate_digest,
+            candidate_sha256=_sha256_file(candidate),
+            job_count=verification.job_count,
+            table_count=EXACT_V7_MANIFEST.table_count,
+        )
+    except BaseException as error:
+        if candidate_connection is not None:
+            candidate_connection.close()
+        if source_connection is not None:
+            source_connection.close()
+        close_connection(candidate)
+        if created_identity is not None:
+            _remove_created_candidate(candidate, created_identity)
+        if isinstance(error, Exception):
+            raise CandidateExecutionError(_GENERIC_FAILURE) from None
+        raise
+
+
+def _assert_paths(source: Path, candidate: Path) -> None:
+    source_stat = source.lstat()
+    if not stat.S_ISREG(source_stat.st_mode):
+        raise CandidateExecutionError(_GENERIC_FAILURE)
+    if os.path.abspath(source) == os.path.abspath(candidate):
+        raise CandidateExecutionError(_GENERIC_FAILURE)
+    if os.path.lexists(candidate):
+        raise CandidateExecutionError(_GENERIC_FAILURE)
+    if any(os.path.lexists(f"{candidate}{suffix}") for suffix in ("-journal", "-shm", "-wal")):
+        raise CandidateExecutionError(_GENERIC_FAILURE)
+    parent_stat = candidate.parent.stat()
+    if not stat.S_ISDIR(parent_stat.st_mode):
+        raise CandidateExecutionError(_GENERIC_FAILURE)
+
+
+def _remove_created_candidate(
+    candidate: Path,
+    created_identity: tuple[int, int],
+) -> None:
+    try:
+        current = candidate.lstat()
+    except FileNotFoundError:
+        current = None
+    if current is not None and (current.st_dev, current.st_ino) == created_identity:
+        candidate.unlink()
+    for suffix in ("-journal", "-shm", "-wal"):
+        Path(f"{candidate}{suffix}").unlink(missing_ok=True)
+
+
+def _fsync_regular_file(path: Path) -> None:
+    descriptor = os.open(path, os.O_RDONLY)
+    try:
+        opened = os.fstat(descriptor)
+        if not stat.S_ISREG(opened.st_mode):
+            raise CandidateExecutionError(_GENERIC_FAILURE)
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _fsync_directory(path: Path) -> None:
+    descriptor = os.open(path, os.O_RDONLY)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the authenticated launcher's private migration subprocess."""
+
+    parser = _PrivateArgumentParser(add_help=False)
+    parser.add_argument("--source", required=True)
+    parser.add_argument("--candidate", required=True)
+    parser.add_argument("--migration-at", required=True)
+    try:
+        arguments = parser.parse_args(argv)
+        result = execute_v6_to_v7_candidate(
+            arguments.source,
+            arguments.candidate,
+            migration_at=arguments.migration_at,
+        )
+    except CandidateExecutionError:
+        print(_GENERIC_FAILURE, file=sys.stderr)
+        return 1
+    print(json.dumps(asdict(result), sort_keys=True, separators=(",", ":")))
+    return 0
+
+
+class _PrivateArgumentParser(argparse.ArgumentParser):
+    """Arg parser that never echoes private transition arguments."""
+
+    def error(self, _message: str) -> None:
+        raise CandidateExecutionError(_GENERIC_FAILURE)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
+__all__ = [
+    "CandidateExecutionError",
+    "CandidateExecutionResult",
+    "execute_v6_to_v7_candidate",
+    "main",
+]

--- a/workers/automation/tests/test_v6_to_v7_execute.py
+++ b/workers/automation/tests/test_v6_to_v7_execute.py
@@ -1,0 +1,242 @@
+"""File-boundary contracts for the private v6-to-v7 executor."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+from collections.abc import Callable, Iterator
+from pathlib import Path
+
+import pytest
+
+from jobctrl.database import close_connection, open_exact_v7_database
+from jobctrl.infrastructure.migrations.v6_to_v7_execute import (
+    CandidateExecutionError,
+    execute_v6_to_v7_candidate,
+    main,
+)
+from tests.v6_migration_fixture import (
+    create_shipped_v6_database,
+    create_supported_upgrade_history_v6_database,
+)
+
+_MIGRATION_AT = "2026-07-31T14:00:00+00:00"
+_JOB_ID = "00000000-0000-4000-8000-000000000001"
+_UNTRUSTED_ANALYSIS_CONTEXT = '{"userContext":"Attack vectors:\\nPrompt injection"}'
+
+
+def _allocator(*values: str) -> Callable[[], str]:
+    allocated: Iterator[str] = iter(values)
+    return allocated.__next__
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+@pytest.mark.parametrize("history", [False, True])
+def test_executor_builds_a_closed_exact_v7_candidate_without_mutating_source(
+    tmp_path: Path,
+    history: bool,
+) -> None:
+    source = tmp_path / "paired-backup-jobctrl.db"
+    candidate = tmp_path / "jobctrl.db.v7-candidate"
+    create = create_supported_upgrade_history_v6_database if history else create_shipped_v6_database
+    create(source)
+    before = source.read_bytes()
+
+    result = execute_v6_to_v7_candidate(
+        source,
+        candidate,
+        migration_at=_MIGRATION_AT,
+        job_id_factory=_allocator(_JOB_ID),
+    )
+
+    assert source.read_bytes() == before
+    assert candidate.stat().st_mode & 0o777 == 0o600
+    assert result.schema_version == 1
+    assert result.status == "ready"
+    assert result.user_version == 7
+    assert result.job_count == 1
+    assert result.candidate_sha256 == _sha256(candidate)
+    assert len(result.source_digest) == 64
+    assert len(result.candidate_logical_digest) == 64
+    reopened = open_exact_v7_database(candidate)
+    try:
+        assert tuple(reopened.execute("PRAGMA user_version").fetchone()) == (7,)
+        assert tuple(
+            reopened.execute("SELECT job_id FROM jobs").fetchone()
+        ) == (_JOB_ID,)
+    finally:
+        close_connection(candidate)
+
+
+@pytest.mark.parametrize(
+    "case",
+    ["same", "existing", "existing-sidecar", "source-symlink", "candidate-symlink"],
+)
+def test_executor_rejects_unsafe_path_shapes_without_mutating_source(
+    tmp_path: Path,
+    case: str,
+) -> None:
+    source = tmp_path / "source.db"
+    candidate = tmp_path / "candidate.db"
+    create_shipped_v6_database(source)
+    before = source.read_bytes()
+    if case == "same":
+        candidate = source
+    elif case == "existing":
+        candidate.write_bytes(b"owned")
+    elif case == "existing-sidecar":
+        Path(f"{candidate}-wal").write_bytes(b"owned-sidecar")
+    elif case == "source-symlink":
+        real_source = source
+        source = tmp_path / "source-link.db"
+        source.symlink_to(real_source)
+    else:
+        candidate.symlink_to(tmp_path / "missing.db")
+
+    with pytest.raises(CandidateExecutionError) as raised:
+        execute_v6_to_v7_candidate(
+            source,
+            candidate,
+            migration_at=_MIGRATION_AT,
+        )
+
+    assert str(raised.value) == "v6-to-v7 candidate execution failed"
+    assert raised.value.__cause__ is None
+    assert source.resolve().read_bytes() == before
+    if case == "existing":
+        assert candidate.read_bytes() == b"owned"
+    if case == "existing-sidecar":
+        assert Path(f"{candidate}-wal").read_bytes() == b"owned-sidecar"
+    if case == "candidate-symlink":
+        assert candidate.is_symlink()
+
+
+def test_executor_rejects_unsupported_schema_and_cleans_its_candidate(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "source.db"
+    candidate = tmp_path / "candidate.db"
+    connection = sqlite3.connect(source)
+    connection.execute("PRAGMA user_version = 5")
+    connection.commit()
+    connection.close()
+    before = source.read_bytes()
+
+    with pytest.raises(CandidateExecutionError):
+        execute_v6_to_v7_candidate(
+            source,
+            candidate,
+            migration_at=_MIGRATION_AT,
+        )
+
+    assert source.read_bytes() == before
+    assert not candidate.exists()
+    assert not Path(f"{candidate}-journal").exists()
+
+
+def test_late_failure_cleans_candidate_leaves_source_unchanged_and_retries(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "source.db"
+    candidate = tmp_path / "candidate.db"
+    create_shipped_v6_database(source)
+    before = source.read_bytes()
+
+    with pytest.raises(CandidateExecutionError):
+        execute_v6_to_v7_candidate(
+            source,
+            candidate,
+            migration_at=_MIGRATION_AT,
+            job_id_factory=_allocator(_JOB_ID),
+            _after_stamp=lambda: (_ for _ in ()).throw(
+                RuntimeError(f"{_UNTRUSTED_ANALYSIS_CONTEXT} private source text")
+            ),
+        )
+
+    assert source.read_bytes() == before
+    assert not candidate.exists()
+    result = execute_v6_to_v7_candidate(
+        source,
+        candidate,
+        migration_at=_MIGRATION_AT,
+        job_id_factory=_allocator(_JOB_ID),
+    )
+    assert result.user_version == 7
+
+
+def test_private_module_receipt_is_bounded_and_failure_is_sanitized(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    source = tmp_path / "source.db"
+    candidate = tmp_path / "candidate.db"
+    create_shipped_v6_database(source)
+    connection = sqlite3.connect(source)
+    connection.execute(
+        "UPDATE jobs SET description = ?",
+        (f"{_UNTRUSTED_ANALYSIS_CONTEXT} private source text",),
+    )
+    connection.commit()
+    connection.close()
+
+    assert main(
+        [
+            "--source",
+            str(source),
+            "--candidate",
+            str(candidate),
+            "--migration-at",
+            _MIGRATION_AT,
+        ]
+    ) == 0
+    captured = capsys.readouterr()
+    receipt = json.loads(captured.out)
+    assert captured.err == ""
+    assert set(receipt) == {
+        "candidate_logical_digest",
+        "candidate_sha256",
+        "job_count",
+        "schema_version",
+        "source_digest",
+        "status",
+        "table_count",
+        "user_version",
+    }
+    assert str(source) not in captured.out
+    assert str(candidate) not in captured.out
+    assert "private source text" not in captured.out
+    assert _UNTRUSTED_ANALYSIS_CONTEXT not in captured.out
+
+    assert main(
+        [
+            "--source",
+            str(source),
+            "--candidate",
+            str(candidate),
+            "--migration-at",
+            _MIGRATION_AT,
+        ]
+    ) == 1
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == "v6-to-v7 candidate execution failed\n"
+    assert str(source) not in captured.err
+    assert str(candidate) not in captured.err
+    assert _UNTRUSTED_ANALYSIS_CONTEXT not in captured.err
+
+
+def test_private_module_argument_errors_do_not_echo_private_values(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    private_path = "/private/sensitive/jobctrl.db"
+
+    assert main(["--source", private_path]) == 1
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == "v6-to-v7 candidate execution failed\n"
+    assert private_path not in captured.err


### PR DESCRIPTION
## What changed

- add a private file-to-file executor around the verified v6-to-v7 population and seal
- read only from the standalone paired-backup member
- create an exclusive mode-0600 candidate, reopen it through the exact-v7 runtime gate, fsync it, and return bounded logical and physical digests
- clean only the newly created candidate on failure so the source remains retryable
- expose a sanitized private Python module entrypoint for later authenticated launcher use

## Why

The native lifecycle must retain ownership of process stopping, paired backup verification, live database replacement, and rollback. This slice produces only the sealed file that lifecycle can later authenticate and install.

## Validation

- 11 focused executor tests passed
- 218 cumulative v6-to-v7 and v7 tests passed
- Ruff passed
- git diff --check passed
- independent review: PASS with zero findings

## Stack

Base: #606