### PR TITLE
refactor(materials): key employer analysis by JobId

### DIFF
--- a/workers/automation/src/jobctrl/infrastructure/materials/employer_analysis_repository.py
+++ b/workers/automation/src/jobctrl/infrastructure/materials/employer_analysis_repository.py
@@ -1,10 +1,9 @@
-"""SqliteEmployerAnalysisRepository — local-mode adapter (Phase 1).
+"""Exact-v7 SQLite adapter for employer-analysis aggregates.
 
 Persists :class:`EmployerAnalysis` aggregates to the canonical
-``job_employer_analysis`` (+ ``_sub_analyses`` / ``_failures``) tables created
-by :func:`database.ensure_employer_analysis_tables`. Mirrors
-:class:`SqliteMaterialsRepository`: one connection per adapter, eager commit,
-monotonic generation allocation, and supersede-not-destroy semantics (D-13).
+``job_employer_analysis`` (+ ``_sub_analyses`` / ``_failures``) tables.
+The database lifecycle owns schema creation and migration; this runtime
+repository requires the exact-v7 tenant-scoped ``JobId`` shape.
 
 The cache short-circuit (D-11/D-12) is served by :meth:`get_by_cache_key`,
 which returns the latest analysis matching a snapshot+version cache key so a
@@ -17,8 +16,7 @@ import json
 import sqlite3
 from typing import Any
 
-from jobctrl.database import ensure_employer_analysis_tables
-from jobctrl.domain.identifiers import JobId
+from jobctrl.domain.identifiers import JobId, canonical_job_id
 from jobctrl.domain.materials.analysis import (
     AnalysisAgreement,
     AnalysisFailure,
@@ -35,8 +33,6 @@ class SqliteEmployerAnalysisRepository:
 
     def __init__(self, conn: sqlite3.Connection) -> None:
         self._conn = conn
-        # Idempotent — safe if init_db already ran; keeps test setup minimal.
-        ensure_employer_analysis_tables(conn)
 
     # ------------------------------------------------------------------ read
 
@@ -47,27 +43,28 @@ class SqliteEmployerAnalysisRepository:
         *,
         generation: int | None = None,
     ) -> EmployerAnalysis | None:
+        stable_job_id = canonical_job_id(str(job_id))
         if generation is None:
             row = self._conn.execute(
                 """
                 SELECT * FROM job_employer_analysis
-                WHERE job_url = ? AND tenant_id = ?
+                WHERE tenant_id = ? AND job_id = ?
                 ORDER BY generation DESC
                 LIMIT 1
                 """,
-                (str(job_id), str(tenant_id)),
+                (str(tenant_id), str(stable_job_id)),
             ).fetchone()
         else:
             row = self._conn.execute(
                 """
                 SELECT * FROM job_employer_analysis
-                WHERE job_url = ? AND tenant_id = ? AND generation = ?
+                WHERE tenant_id = ? AND job_id = ? AND generation = ?
                 """,
-                (str(job_id), str(tenant_id), int(generation)),
+                (str(tenant_id), str(stable_job_id), int(generation)),
             ).fetchone()
         if row is None:
             return None
-        return self._row_to_analysis(row, tenant_id, job_id)
+        return self._row_to_analysis(row, tenant_id, stable_job_id)
 
     def get_by_cache_key(
         self,
@@ -75,18 +72,19 @@ class SqliteEmployerAnalysisRepository:
         job_id: JobId,
         cache_key: str,
     ) -> EmployerAnalysis | None:
+        stable_job_id = canonical_job_id(str(job_id))
         row = self._conn.execute(
             """
             SELECT * FROM job_employer_analysis
-            WHERE job_url = ? AND tenant_id = ? AND cache_key = ?
+            WHERE tenant_id = ? AND job_id = ? AND cache_key = ?
             ORDER BY generation DESC
             LIMIT 1
             """,
-            (str(job_id), str(tenant_id), cache_key),
+            (str(tenant_id), str(stable_job_id), cache_key),
         ).fetchone()
         if row is None:
             return None
-        return self._row_to_analysis(row, tenant_id, job_id)
+        return self._row_to_analysis(row, tenant_id, stable_job_id)
 
     # ----------------------------------------------------------------- write
 
@@ -98,7 +96,23 @@ class SqliteEmployerAnalysisRepository:
         generation again overwrites the canonical row + replaces its child rows.
         Prior generations are NEVER deleted — they remain audit history.
         """
-        job_url = str(analysis.job_id)
+        job_id = canonical_job_id(str(analysis.job_id))
+        savepoint = "employer_analysis_aggregate_save"
+        self._conn.execute(f"SAVEPOINT {savepoint}")
+        try:
+            self._save_rows(analysis, job_id)
+        except BaseException:
+            self._conn.execute(f"ROLLBACK TO SAVEPOINT {savepoint}")
+            self._conn.execute(f"RELEASE SAVEPOINT {savepoint}")
+            raise
+        else:
+            self._conn.execute(f"RELEASE SAVEPOINT {savepoint}")
+
+    def _save_rows(
+        self,
+        analysis: EmployerAnalysis,
+        job_id: JobId,
+    ) -> None:
         tenant = str(analysis.tenant_id)
         generation = analysis.generation
         canonical = analysis.canonical
@@ -106,13 +120,13 @@ class SqliteEmployerAnalysisRepository:
         self._conn.execute(
             """
             INSERT INTO job_employer_analysis (
-                job_url, generation, tenant_id, snapshot_hash, prompt_version,
+                tenant_id, job_id, generation, snapshot_hash, prompt_version,
                 sdk_set_version, cache_key, role_framing, inferred_seniority,
                 ideal_candidate_narrative, requirements_json, keywords_json,
                 agreement_json, eeo_screen_json, legs_attempted, legs_succeeded,
                 created_at
             ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            ON CONFLICT(job_url, generation) DO UPDATE SET
+            ON CONFLICT(tenant_id, job_id, generation) DO UPDATE SET
                 snapshot_hash             = excluded.snapshot_hash,
                 prompt_version            = excluded.prompt_version,
                 sdk_set_version           = excluded.sdk_set_version,
@@ -129,9 +143,9 @@ class SqliteEmployerAnalysisRepository:
                 created_at                = excluded.created_at
             """,
             (
-                job_url,
-                generation,
                 tenant,
+                str(job_id),
+                generation,
                 analysis.snapshot_hash,
                 analysis.prompt_version,
                 analysis.sdk_set_version,
@@ -142,9 +156,7 @@ class SqliteEmployerAnalysisRepository:
                 json.dumps([req.model_dump() for req in canonical.requirements], ensure_ascii=False),
                 json.dumps([kw.model_dump() for kw in canonical.keywords], ensure_ascii=False),
                 json.dumps(analysis.agreement.to_dict(), ensure_ascii=False),
-                json.dumps(
-                    [hit.to_dict() for hit in analysis.eeo_screen_hits], ensure_ascii=False
-                ),
+                json.dumps([hit.to_dict() for hit in analysis.eeo_screen_hits], ensure_ascii=False),
                 analysis.legs_attempted,
                 analysis.legs_succeeded,
                 analysis.created_at,
@@ -153,49 +165,55 @@ class SqliteEmployerAnalysisRepository:
 
         # Replace child rows for this generation (idempotent re-save).
         self._conn.execute(
-            "DELETE FROM job_employer_analysis_sub_analyses WHERE job_url = ? AND generation = ?",
-            (job_url, generation),
+            "DELETE FROM job_employer_analysis_sub_analyses WHERE tenant_id = ? AND job_id = ? AND generation = ?",
+            (tenant, str(job_id), generation),
         )
         for draft in analysis.sub_analyses:
             self._conn.execute(
                 """
                 INSERT INTO job_employer_analysis_sub_analyses (
-                    job_url, generation, model_id, tenant_id, analysis_json
+                    tenant_id, job_id, generation, model_id, analysis_json
                 ) VALUES (?, ?, ?, ?, ?)
                 """,
                 (
-                    job_url,
+                    tenant,
+                    str(job_id),
                     generation,
                     draft.model_id,
-                    tenant,
                     json.dumps(draft.model_dump(exclude={"model_id"}), ensure_ascii=False),
                 ),
             )
 
         self._conn.execute(
-            "DELETE FROM job_employer_analysis_failures WHERE job_url = ? AND generation = ?",
-            (job_url, generation),
+            "DELETE FROM job_employer_analysis_failures WHERE tenant_id = ? AND job_id = ? AND generation = ?",
+            (tenant, str(job_id), generation),
         )
         for failure in analysis.failures:
             self._conn.execute(
                 """
                 INSERT INTO job_employer_analysis_failures (
-                    job_url, generation, model_id, tenant_id, error, raw_output
+                    tenant_id, job_id, generation, model_id, error, raw_output
                 ) VALUES (?, ?, ?, ?, ?, ?)
                 """,
-                (job_url, generation, failure.model_id, tenant, failure.error, failure.raw_output),
+                (
+                    tenant,
+                    str(job_id),
+                    generation,
+                    failure.model_id,
+                    failure.error,
+                    failure.raw_output,
+                ),
             )
-
-        self._conn.commit()
 
     def next_generation(self, tenant_id: TenantId, job_id: JobId) -> int:
         """Return the next generation to write for ``(tenant, job)`` (>= 1)."""
+        stable_job_id = canonical_job_id(str(job_id))
         row = self._conn.execute(
             """
             SELECT MAX(generation) FROM job_employer_analysis
-            WHERE job_url = ? AND tenant_id = ?
+            WHERE tenant_id = ? AND job_id = ?
             """,
-            (str(job_id), str(tenant_id)),
+            (str(tenant_id), str(stable_job_id)),
         ).fetchone()
         current = row[0] if row is not None else None
         return int(current) + 1 if current is not None else 1
@@ -219,22 +237,21 @@ class SqliteEmployerAnalysisRepository:
         sub_rows = self._conn.execute(
             """
             SELECT model_id, analysis_json FROM job_employer_analysis_sub_analyses
-            WHERE job_url = ? AND generation = ?
+            WHERE tenant_id = ? AND job_id = ? AND generation = ?
             ORDER BY model_id
             """,
-            (str(job_id), generation),
+            (str(tenant_id), str(job_id), generation),
         ).fetchall()
         sub_analyses = tuple(
-            JobAnalysisDraft(model_id=sub["model_id"], **json.loads(sub["analysis_json"]))
-            for sub in sub_rows
+            JobAnalysisDraft(model_id=sub["model_id"], **json.loads(sub["analysis_json"])) for sub in sub_rows
         )
         failure_rows = self._conn.execute(
             """
             SELECT model_id, error, raw_output FROM job_employer_analysis_failures
-            WHERE job_url = ? AND generation = ?
+            WHERE tenant_id = ? AND job_id = ? AND generation = ?
             ORDER BY model_id
             """,
-            (str(job_id), generation),
+            (str(tenant_id), str(job_id), generation),
         ).fetchall()
         failures = tuple(
             AnalysisFailure(
@@ -244,10 +261,7 @@ class SqliteEmployerAnalysisRepository:
             )
             for f in failure_rows
         )
-        eeo_screen_hits = tuple(
-            EeoScreenHit.from_dict(item)
-            for item in _json_list(_row_get(row, "eeo_screen_json"))
-        )
+        eeo_screen_hits = tuple(EeoScreenHit.from_dict(item) for item in _json_list(row["eeo_screen_json"]))
         return EmployerAnalysis(
             tenant_id=tenant_id,
             job_id=job_id,
@@ -277,11 +291,6 @@ def _json_list(value: Any) -> list[dict[str, Any]]:
         return []
     parsed = json.loads(value)
     return [item for item in parsed if isinstance(item, dict)] if isinstance(parsed, list) else []
-
-
-def _row_get(row: sqlite3.Row, key: str) -> Any:
-    """Read a column from a sqlite3.Row, tolerating its absence on older rows."""
-    return row[key] if key in row.keys() else None
 
 
 __all__ = ["SqliteEmployerAnalysisRepository"]

--- a/workers/automation/tests/test_employer_analysis_repository.py
+++ b/workers/automation/tests/test_employer_analysis_repository.py
@@ -26,10 +26,12 @@ from jobctrl.domain.materials.analysis import (
     JobAnalysisDraft,
     compute_snapshot_hash,
 )
-from jobctrl.domain.tenant import LOCAL_TENANT
+from jobctrl.domain.tenant import LOCAL_TENANT, TenantId
 from jobctrl.infrastructure.materials import SqliteEmployerAnalysisRepository
 
+JOB_ID = JobId("00000000-0000-4000-8000-000000000031")
 JOB_URL = "https://example.com/jobs/staff-be"
+OTHER_TENANT = TenantId("other")
 JD = "Staff Backend Engineer. Requires 8+ years in Go. Kafka is a plus."
 
 
@@ -38,8 +40,17 @@ def conn(tmp_path) -> Iterator[sqlite3.Connection]:
     db_path = tmp_path / "jobs.db"
     connection = init_db(db_path)
     connection.execute(
-        "INSERT INTO jobs (url, title, site) VALUES (?, ?, ?)",
-        (JOB_URL, "Staff Backend Engineer", "example"),
+        """
+        INSERT INTO jobs (tenant_id, job_id, url, title, site)
+        VALUES (?, ?, ?, ?, ?)
+        """,
+        (
+            str(LOCAL_TENANT),
+            str(JOB_ID),
+            JOB_URL,
+            "Staff Backend Engineer",
+            "example",
+        ),
     )
     connection.commit()
     yield connection
@@ -60,16 +71,19 @@ def _analysis() -> JobAnalysis:
                 "evidence_span": "8+ years in Go",
             }
         ],
-        keywords=[
-            {"keyword": "Go", "evidence_span": "8+ years in Go", "requirement_ref": "r1"}
-        ],
+        keywords=[{"keyword": "Go", "evidence_span": "8+ years in Go", "requirement_ref": "r1"}],
     )
 
 
-def _record(generation: int) -> EmployerAnalysis:
+def _record(
+    generation: int,
+    *,
+    job_id: JobId = JOB_ID,
+    tenant_id: TenantId = LOCAL_TENANT,
+) -> EmployerAnalysis:
     return EmployerAnalysis.build(
-        tenant_id=LOCAL_TENANT,
-        job_id=JobId(JOB_URL),
+        tenant_id=tenant_id,
+        job_id=job_id,
         generation=generation,
         snapshot_hash=compute_snapshot_hash(JD),
         canonical=_analysis(),
@@ -84,7 +98,7 @@ def test_round_trip_preserves_canonical_subanalyses_failures(conn: sqlite3.Conne
     repo = SqliteEmployerAnalysisRepository(conn)
     repo.save(_record(generation=1))
 
-    loaded = repo.load(LOCAL_TENANT, JobId(JOB_URL))
+    loaded = repo.load(LOCAL_TENANT, JOB_ID)
     assert loaded is not None
     assert loaded.generation == 1
     assert loaded.canonical.requirements[0].tier == "must_have"
@@ -102,19 +116,19 @@ def test_cache_hit_by_snapshot_and_version(conn: sqlite3.Connection) -> None:
     record = _record(generation=1)
     repo.save(record)
 
-    hit = repo.get_by_cache_key(LOCAL_TENANT, JobId(JOB_URL), record.cache_key)
+    hit = repo.get_by_cache_key(LOCAL_TENANT, JOB_ID, record.cache_key)
     assert hit is not None
     assert hit.generation == 1
 
-    miss = repo.get_by_cache_key(LOCAL_TENANT, JobId(JOB_URL), "different-snapshot:p:s")
+    miss = repo.get_by_cache_key(LOCAL_TENANT, JOB_ID, "different-snapshot:p:s")
     assert miss is None
 
 
 def test_next_generation_is_monotonic(conn: sqlite3.Connection) -> None:
     repo = SqliteEmployerAnalysisRepository(conn)
-    assert repo.next_generation(LOCAL_TENANT, JobId(JOB_URL)) == 1
+    assert repo.next_generation(LOCAL_TENANT, JOB_ID) == 1
     repo.save(_record(generation=1))
-    assert repo.next_generation(LOCAL_TENANT, JobId(JOB_URL)) == 2
+    assert repo.next_generation(LOCAL_TENANT, JOB_ID) == 2
 
 
 def test_new_generation_supersedes_but_does_not_destroy_prior(conn: sqlite3.Connection) -> None:
@@ -123,10 +137,10 @@ def test_new_generation_supersedes_but_does_not_destroy_prior(conn: sqlite3.Conn
     repo.save(_record(generation=2))
 
     # load() returns the latest...
-    latest = repo.load(LOCAL_TENANT, JobId(JOB_URL))
+    latest = repo.load(LOCAL_TENANT, JOB_ID)
     assert latest is not None and latest.generation == 2
     # ...but the prior generation remains as audit history (D-13).
-    prior = repo.load(LOCAL_TENANT, JobId(JOB_URL), generation=1)
+    prior = repo.load(LOCAL_TENANT, JOB_ID, generation=1)
     assert prior is not None and prior.generation == 1
 
 
@@ -134,7 +148,7 @@ def test_round_trip_preserves_eeo_screen_hits(conn: sqlite3.Connection) -> None:
     repo = SqliteEmployerAnalysisRepository(conn)
     record = EmployerAnalysis.build(
         tenant_id=LOCAL_TENANT,
-        job_id=JobId(JOB_URL),
+        job_id=JOB_ID,
         generation=1,
         snapshot_hash=compute_snapshot_hash(JD),
         canonical=_analysis(),
@@ -153,7 +167,7 @@ def test_round_trip_preserves_eeo_screen_hits(conn: sqlite3.Connection) -> None:
     )
     repo.save(record)
 
-    loaded = repo.load(LOCAL_TENANT, JobId(JOB_URL))
+    loaded = repo.load(LOCAL_TENANT, JOB_ID)
     assert loaded is not None
     assert loaded.eeo_screen_hits == record.eeo_screen_hits
 
@@ -164,7 +178,7 @@ def test_resave_same_generation_overwrites_children(conn: sqlite3.Connection) ->
     # Re-save the same generation with no failures -> child rows replaced.
     no_failures = EmployerAnalysis.build(
         tenant_id=LOCAL_TENANT,
-        job_id=JobId(JOB_URL),
+        job_id=JOB_ID,
         generation=1,
         snapshot_hash=compute_snapshot_hash(JD),
         canonical=_analysis(),
@@ -174,7 +188,99 @@ def test_resave_same_generation_overwrites_children(conn: sqlite3.Connection) ->
         legs_attempted=1,
     )
     repo.save(no_failures)
-    loaded = repo.load(LOCAL_TENANT, JobId(JOB_URL))
+    loaded = repo.load(LOCAL_TENANT, JOB_ID)
     assert loaded is not None
     assert loaded.failures == ()
     assert loaded.ensemble_completeness == "1/1"
+
+
+def test_failed_child_replacement_preserves_complete_prior_aggregate(
+    conn: sqlite3.Connection,
+) -> None:
+    repo = SqliteEmployerAnalysisRepository(conn)
+    prior = _record(generation=1)
+    repo.save(prior)
+    draft = JobAnalysisDraft(
+        model_id="duplicate-model",
+        **_analysis().model_dump(),
+    )
+    invalid_replacement = EmployerAnalysis.build(
+        tenant_id=LOCAL_TENANT,
+        job_id=JOB_ID,
+        generation=1,
+        snapshot_hash="replacement-snapshot",
+        canonical=_analysis().model_copy(update={"role_framing": "Replacement framing."}),
+        sub_analyses=(draft, draft),
+        failures=(),
+        agreement=AnalysisAgreement(score=1.0),
+        legs_attempted=2,
+    )
+
+    with pytest.raises(sqlite3.IntegrityError):
+        repo.save(invalid_replacement)
+
+    assert conn.in_transaction is False
+    conn.commit()
+    preserved = repo.load(LOCAL_TENANT, JOB_ID)
+    assert preserved is not None
+    assert preserved.snapshot_hash == prior.snapshot_hash
+    assert preserved.canonical.role_framing == prior.canonical.role_framing
+    assert preserved.failures == prior.failures
+    assert preserved.sub_analyses == prior.sub_analyses
+
+
+def test_repository_requires_canonical_job_id(conn: sqlite3.Connection) -> None:
+    repo = SqliteEmployerAnalysisRepository(conn)
+
+    with pytest.raises(ValueError, match="canonical UUID"):
+        repo.load(LOCAL_TENANT, JobId(JOB_URL))
+    with pytest.raises(ValueError, match="canonical UUID"):
+        repo.get_by_cache_key(LOCAL_TENANT, JobId(JOB_URL), "cache-key")
+    with pytest.raises(ValueError, match="canonical UUID"):
+        repo.next_generation(LOCAL_TENANT, JobId(JOB_URL))
+    with pytest.raises(ValueError, match="canonical UUID"):
+        repo.save(_record(generation=1, job_id=JobId(JOB_URL)))
+
+
+def test_repository_does_not_create_runtime_schema() -> None:
+    connection = sqlite3.connect(":memory:")
+    try:
+        SqliteEmployerAnalysisRepository(connection)
+
+        tables = connection.execute("SELECT name FROM sqlite_master WHERE type = 'table'").fetchall()
+        assert tables == []
+    finally:
+        connection.close()
+
+
+def test_same_job_id_is_isolated_by_tenant(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        """
+        INSERT INTO jobs (tenant_id, job_id, url, title, site)
+        VALUES (?, ?, ?, ?, ?)
+        """,
+        (
+            str(OTHER_TENANT),
+            str(JOB_ID),
+            JOB_URL,
+            "Staff Backend Engineer",
+            "example",
+        ),
+    )
+    conn.commit()
+    repo = SqliteEmployerAnalysisRepository(conn)
+
+    repo.save(_record(generation=1))
+    repo.save(_record(generation=1, tenant_id=OTHER_TENANT))
+
+    local = repo.load(LOCAL_TENANT, JOB_ID)
+    other = repo.load(OTHER_TENANT, JOB_ID)
+    assert local is not None and local.tenant_id == LOCAL_TENANT
+    assert other is not None and other.tenant_id == OTHER_TENANT
+    assert (
+        conn.execute(
+            "SELECT COUNT(*) FROM job_employer_analysis WHERE job_id = ? AND generation = 1",
+            (str(JOB_ID),),
+        ).fetchone()[0]
+        == 2
+    )


### PR DESCRIPTION
## What changed

- keys employer-analysis parents and child records by tenant-scoped canonical JobId
- removes repository-owned runtime schema creation and the older-row compatibility read
- preserves generation history and tenant isolation with exact-v7 composite keys
- makes aggregate replacement atomic with savepoint rollback on child-write failure

## Why

The v7 cutover makes JobId the sole internal job identity. This small stack step moves only employer-analysis persistence onto the exact-v7 contract; adjacent materials repositories and workflow callers remain separate review PRs.

## Validation

- 24 focused repository and exact-v7 schema tests passed
- regression proves failed child replacement preserves the prior complete aggregate
- Ruff lint and format checks passed
- git diff --check passed
- independent review passed with zero findings