### PR TITLE
refactor(materials): key bullet provenance by JobId

### DIFF
--- a/workers/automation/src/jobctrl/infrastructure/materials/bullet_provenance_repository.py
+++ b/workers/automation/src/jobctrl/infrastructure/materials/bullet_provenance_repository.py
@@ -1,10 +1,8 @@
-"""SqliteBulletProvenanceRepository — local-mode adapter (Phase 2).
+"""Exact-v7 SQLite adapter for bullet provenance.
 
 Persists :class:`BulletProvenanceSet` to the canonical ``job_bullet_provenance``
-table created by :func:`database.ensure_bullet_provenance_tables`. Mirrors
-:class:`SqliteEmployerAnalysisRepository`: one connection per adapter, eager
-commit, generation-versioned, supersede-not-destroy semantics (Anti-Pattern 4 /
-success criterion 5).
+table. The database lifecycle owns schema creation and migration; this runtime
+repository requires the exact-v7 tenant-scoped ``JobId`` shape.
 
 A re-save of the SAME generation replaces that generation's rows (idempotent
 mid-flow re-save); writing a HIGHER generation leaves prior generations intact as
@@ -17,8 +15,7 @@ from __future__ import annotations
 import json
 import sqlite3
 
-from jobctrl.database import ensure_bullet_provenance_tables
-from jobctrl.domain.identifiers import JobId
+from jobctrl.domain.identifiers import JobId, canonical_job_id
 from jobctrl.domain.materials.coverage_audit import KeywordCoverage
 from jobctrl.domain.materials.provenance import BulletProvenance, BulletProvenanceSet
 from jobctrl.domain.materials.voice import VoicePassRecord
@@ -42,8 +39,6 @@ class SqliteBulletProvenanceRepository:
     ) -> None:
         self._conn = conn
         self._unit_of_work = unit_of_work
-        # Idempotent — safe if init_db already ran; keeps test setup minimal.
-        ensure_bullet_provenance_tables(conn)
 
     # ------------------------------------------------------------------ read
 
@@ -54,13 +49,14 @@ class SqliteBulletProvenanceRepository:
         *,
         generation: int | None = None,
     ) -> BulletProvenanceSet | None:
+        stable_job_id = canonical_job_id(str(job_id))
         if generation is None:
             gen_row = self._conn.execute(
                 """
                 SELECT MAX(generation) FROM job_bullet_provenance
-                WHERE job_url = ? AND tenant_id = ?
+                WHERE tenant_id = ? AND job_id = ?
                 """,
-                (str(job_id), str(tenant_id)),
+                (str(tenant_id), str(stable_job_id)),
             ).fetchone()
             current = gen_row[0] if gen_row is not None else None
             if current is None:
@@ -70,27 +66,22 @@ class SqliteBulletProvenanceRepository:
         rows = self._conn.execute(
             """
             SELECT * FROM job_bullet_provenance
-            WHERE job_url = ? AND tenant_id = ? AND generation = ?
+            WHERE tenant_id = ? AND job_id = ? AND generation = ?
             ORDER BY position, bullet_id
             """,
-            (str(job_id), str(tenant_id), int(generation)),
+            (str(tenant_id), str(stable_job_id), int(generation)),
         ).fetchall()
         if not rows:
             return None
 
         bullets = tuple(self._row_to_bullet(row) for row in rows)
         first = rows[0]
-        # Phase 3: coverage + voice are set-level facts denormalised onto every row;
-        # read them off the first row (``_row_value`` tolerates a pre-Phase-3 row
-        # that predates the columns). ``from_read_model`` / ``from_dict`` return
-        # None when the stored value is absent/empty.
-        coverage = KeywordCoverage.from_read_model(
-            _load_json(_row_value(first, "coverage_json"))
-        )
-        voice = VoicePassRecord.from_dict(_load_json(_row_value(first, "voice_json")))
+        # Coverage + voice are set-level facts denormalised onto every row.
+        coverage = KeywordCoverage.from_read_model(_load_json(first["coverage_json"]))
+        voice = VoicePassRecord.from_dict(_load_json(first["voice_json"]))
         return BulletProvenanceSet(
             tenant_id=tenant_id,
-            job_id=job_id,
+            job_id=stable_job_id,
             generation=int(generation),
             artifact_id=str(first["artifact_id"]),
             bullets=bullets,
@@ -109,10 +100,10 @@ class SqliteBulletProvenanceRepository:
         re-tailor that produced no accepted candidate writes no rows and leaves
         the last accepted generation intact.
         """
+        job_id = canonical_job_id(str(provenance.job_id))
         if provenance.is_empty:
             return
 
-        job_url = str(provenance.job_id)
         tenant = str(provenance.tenant_id)
         generation = provenance.generation
 
@@ -121,47 +112,51 @@ class SqliteBulletProvenanceRepository:
         coverage_json = _dump_json(provenance.coverage_to_read_model())
         voice_json = _dump_json(provenance.voice_to_read_model())
 
-        self._conn.execute(
-            "DELETE FROM job_bullet_provenance WHERE job_url = ? AND tenant_id = ? AND generation = ?",
-            (job_url, tenant, generation),
-        )
-        for position, bullet in enumerate(provenance.bullets):
+        savepoint = "bullet_provenance_set_save"
+        self._conn.execute(f"SAVEPOINT {savepoint}")
+        try:
             self._conn.execute(
-                """
-                INSERT INTO job_bullet_provenance (
-                    job_url, generation, bullet_id, tenant_id, artifact_id,
-                    section, source_id, evidence_ids_json, requirement_ids_json,
-                    matched_keywords_json, transform_type, control, rationale,
-                    generated_text, position, created_at, coverage_json, voice_json
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                """,
-                (
-                    job_url,
-                    generation,
-                    bullet.bullet_id,
-                    tenant,
-                    provenance.artifact_id,
-                    bullet.section,
-                    bullet.source_id,
-                    json.dumps(list(bullet.evidence_ids), ensure_ascii=False),
-                    json.dumps(list(bullet.requirement_ids), ensure_ascii=False),
-                    json.dumps(list(bullet.matched_keywords), ensure_ascii=False),
-                    bullet.transform_type.value,
-                    bullet.control.value,
-                    bullet.rationale,
-                    bullet.generated_text,
-                    position,
-                    provenance.created_at,
-                    coverage_json,
-                    voice_json,
-                ),
+                "DELETE FROM job_bullet_provenance WHERE tenant_id = ? AND job_id = ? AND generation = ?",
+                (tenant, str(job_id), generation),
             )
-        self._commit()
-
-    def _commit(self) -> None:
-        """Commit now, unless an active unit of work owns the transaction."""
-        if self._unit_of_work is None or not self._unit_of_work.active:
-            self._conn.commit()
+            for position, bullet in enumerate(provenance.bullets):
+                self._conn.execute(
+                    """
+                    INSERT INTO job_bullet_provenance (
+                        tenant_id, job_id, generation, bullet_id, artifact_id,
+                        section, source_id, evidence_ids_json,
+                        requirement_ids_json, matched_keywords_json,
+                        transform_type, control, rationale, generated_text,
+                        position, created_at, coverage_json, voice_json
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        tenant,
+                        str(job_id),
+                        generation,
+                        bullet.bullet_id,
+                        provenance.artifact_id,
+                        bullet.section,
+                        bullet.source_id,
+                        json.dumps(list(bullet.evidence_ids), ensure_ascii=False),
+                        json.dumps(list(bullet.requirement_ids), ensure_ascii=False),
+                        json.dumps(list(bullet.matched_keywords), ensure_ascii=False),
+                        bullet.transform_type.value,
+                        bullet.control.value,
+                        bullet.rationale,
+                        bullet.generated_text,
+                        position,
+                        provenance.created_at,
+                        coverage_json,
+                        voice_json,
+                    ),
+                )
+        except BaseException:
+            self._conn.execute(f"ROLLBACK TO SAVEPOINT {savepoint}")
+            self._conn.execute(f"RELEASE SAVEPOINT {savepoint}")
+            raise
+        else:
+            self._conn.execute(f"RELEASE SAVEPOINT {savepoint}")
 
     # --------------------------------------------------------------- mapping
 
@@ -186,14 +181,6 @@ class SqliteBulletProvenanceRepository:
 def _dump_json(value: dict | None) -> str | None:
     """Serialise a set-level read shape to JSON, or NULL when absent."""
     return json.dumps(value, ensure_ascii=False) if value is not None else None
-
-
-def _row_value(row: sqlite3.Row, column: str) -> str | None:
-    """Read an optional column, tolerating a row that predates it (pre-Phase-3)."""
-    try:
-        return row[column]
-    except (IndexError, KeyError):
-        return None
 
 
 def _load_json(value: str | None) -> dict | None:

--- a/workers/automation/tests/test_bullet_provenance.py
+++ b/workers/automation/tests/test_bullet_provenance.py
@@ -104,7 +104,7 @@ def _analysis(
     )
     return EmployerAnalysis.build(
         tenant_id=LOCAL_TENANT,
-        job_id=JobId(JOB_URL),
+        job_id=PERSISTED_JOB_ID,
         generation=1,
         snapshot_hash=compute_snapshot_hash("jd"),
         canonical=canonical,
@@ -208,6 +208,7 @@ def _numberless_profile() -> dict:
 
 def _job() -> dict:
     return {
+        "job_id": PERSISTED_JOB_ID,
         "url": JOB_URL,
         "title": "Senior Backend Engineer",
         "full_description": "Own Python backend services and improve API latency.",

--- a/workers/automation/tests/test_bullet_provenance.py
+++ b/workers/automation/tests/test_bullet_provenance.py
@@ -49,9 +49,12 @@ from jobctrl.infrastructure.materials.bullet_provenance_repository import (
     SqliteBulletProvenanceRepository,
 )
 from jobctrl.infrastructure.materials.html_resume_pdf import build_resume_document
-from jobctrl.domain.tenant import LOCAL_TENANT
+from jobctrl.infrastructure.materials.unit_of_work import SqliteUnitOfWork
+from jobctrl.domain.tenant import LOCAL_TENANT, TenantId
 
 JOB_URL = "https://example.com/senior-backend"
+PERSISTED_JOB_ID = JobId("00000000-0000-4000-8000-000000000041")
+OTHER_TENANT = TenantId("other")
 
 
 # --------------------------------------------------------------------------
@@ -129,10 +132,7 @@ def _profile() -> dict:
                     "achievement_evidence": [
                         {
                             "id": "ev_latency",
-                            "source_text": (
-                                "Reduced API latency 35% by replacing synchronous "
-                                "enrichment calls."
-                            ),
+                            "source_text": ("Reduced API latency 35% by replacing synchronous enrichment calls."),
                             "scope": "owned service",
                             "action": "replaced synchronous enrichment calls",
                             "tools": ["Python", "PostgreSQL"],
@@ -711,9 +711,7 @@ def _html_skill_labels(profile: dict, payload: dict) -> set[str]:
     return {category["label"] for category in build_resume_document(payload, profile)["skills"]}
 
 
-def _provenance_skill_labels(
-    profile: dict, payload: dict, analysis: EmployerAnalysis
-) -> set[str]:
+def _provenance_skill_labels(profile: dict, payload: dict, analysis: EmployerAnalysis) -> set[str]:
     """Skill-category labels the provenance audit trail claims shipped."""
     rows = _build(profile, payload, analysis)
     return {row.generated_text.split(":", 1)[0] for row in rows if row.section == "skills"}
@@ -782,9 +780,7 @@ def test_matched_keywords_and_requirement_ids_bind_to_analysis() -> None:
 def test_quantify_from_evidence_transform_when_metric_introduced() -> None:
     # Source bullet has no metric; tailored bullet surfaces a verified metric.
     profile = _profile()
-    profile["resume"]["experience_entries"][0]["bullets"] = [
-        "Replaced synchronous enrichment calls."
-    ]
+    profile["resume"]["experience_entries"][0]["bullets"] = ["Replaced synchronous enrichment calls."]
     rows = _build(
         profile,
         _payload(bullets=["Replaced synchronous calls, cutting 35% latency reduction."]),
@@ -870,9 +866,7 @@ def test_detector_grounds_profile_summary_and_experience_metadata_numbers() -> N
         "current_job_title": "Director of Engineering",
         "current_company": "Acme Corp",
     }
-    profile["resume"]["executive_profile"] = {
-        "baseline_text": "Engineering Director with 12+ years of experience."
-    }
+    profile["resume"]["executive_profile"] = {"baseline_text": "Engineering Director with 12+ years of experience."}
     corpus = build_evidence_corpus(profile)
     findings = find_fabricated_tokens(
         "executive_profile#0",
@@ -964,9 +958,7 @@ def test_detector_grounds_equivalent_money_renderings() -> None:
         ("Scaled to 35 million users.", "35 million"),
     ],
 )
-def test_detector_flags_suffixed_bare_magnitude_against_numberless_profile(
-    bullet: str, needle: str
-) -> None:
+def test_detector_flags_suffixed_bare_magnitude_against_numberless_profile(bullet: str, needle: str) -> None:
     """Regression (criterion 4 / CONTROL-03): a bare magnitude with a suffix and NO
     leading ``$`` (``10M`` / ``5K`` / ``2B`` / ``100K`` / ``3.5M`` / ``35 million``)
     is a numeric the model invented. Before the fix the trailing ``\\b`` of the
@@ -975,9 +967,7 @@ def test_detector_flags_suffixed_bare_magnitude_against_numberless_profile(
     against a numberless profile. Each must now be flagged."""
     profile = _numberless_profile()  # the profile carries NO numerics at all
     corpus = build_evidence_corpus(profile)
-    findings = find_fabricated_tokens(
-        "experience:acme_swe#0", bullet, corpus, employers=employer_name_set(profile)
-    )
+    findings = find_fabricated_tokens("experience:acme_swe#0", bullet, corpus, employers=employer_name_set(profile))
     numeric = [f for f in findings if f.kind == "numeric"]
     assert numeric, (bullet, findings)
     assert all(f.control is ControlRule.NEVER_FABRICATE_METRICS for f in numeric)
@@ -1024,9 +1014,7 @@ def test_metrics_hungry_job_with_numberless_profile_yields_zero_unsourced_numeri
     )
     plan = build_tailoring_plan(profile, _job(), employer_analysis=analysis)
     rows = build_bullet_provenance(profile, _job(), greedy_payload, plan, analysis)
-    findings = scan_resume_bullets(
-        [(row.bullet_id, row.generated_text) for row in rows], corpus, employers=employers
-    )
+    findings = scan_resume_bullets([(row.bullet_id, row.generated_text) for row in rows], corpus, employers=employers)
     fabricated_numerics = [f.token for f in findings if f.kind == "numeric"]
     # Every injected number (40%, 5 million, 12, 99.99%) is unsourced and flagged.
     assert fabricated_numerics, "detector must flag the injected numerics"
@@ -1078,9 +1066,7 @@ def test_detector_flags_ungrounded_lead_title_phrase() -> None:
         employers=employer_name_set(profile),
     )
     assert any(
-        f.kind == "title"
-        and f.token.lower() == "lead engineer"
-        and f.control is ControlRule.NEVER_FABRICATE_TITLES
+        f.kind == "title" and f.token.lower() == "lead engineer" and f.control is ControlRule.NEVER_FABRICATE_TITLES
         for f in findings
     )
 
@@ -1288,9 +1274,7 @@ def _reviewer_scenario_profile() -> dict:
         "personal": {"full_name": "Dana Ops", "email": "dana@example.com"},
         "resume_constraints": {"real_metrics": []},
         "resume": {
-            "executive_profile": {
-                "baseline_text": "Backend engineer who ships reliable, scalable services."
-            },
+            "executive_profile": {"baseline_text": "Backend engineer who ships reliable, scalable services."},
             "experience_entries": [
                 {
                     "id": "acme_swe",
@@ -1490,9 +1474,19 @@ def conn(tmp_path) -> Iterator[sqlite3.Connection]:
     """A real tmp-file DB with the canonical schema (avoids the shared
     ``:memory:`` singleton that ``get_connection`` returns)."""
     connection = init_db(tmp_path / "jobs.db")
+    connection.execute("PRAGMA foreign_keys = ON")
     connection.execute(
-        "INSERT INTO jobs (url, title, site) VALUES (?, ?, ?)",
-        (JOB_URL, "Senior Backend Engineer", "example"),
+        """
+        INSERT INTO jobs (tenant_id, job_id, url, title, site)
+        VALUES (?, ?, ?, ?, ?)
+        """,
+        (
+            str(LOCAL_TENANT),
+            str(PERSISTED_JOB_ID),
+            JOB_URL,
+            "Senior Backend Engineer",
+            "example",
+        ),
     )
     connection.commit()
     yield connection
@@ -1502,17 +1496,26 @@ def conn(tmp_path) -> Iterator[sqlite3.Connection]:
 def _seed_materials_generation(connection: sqlite3.Connection, generation: int, *, ts: str) -> None:
     """Insert the ``job_materials`` FK parent row for a generation."""
     connection.execute(
-        "INSERT INTO job_materials (job_url, generation, tenant_id, status, created_at, updated_at) "
-        "VALUES (?, ?, 'local', 'complete', ?, ?)",
-        (JOB_URL, generation, ts, ts),
+        """
+        INSERT INTO job_materials (
+            tenant_id, job_id, generation, status, created_at, updated_at
+        ) VALUES (?, ?, ?, 'complete', ?, ?)
+        """,
+        (str(LOCAL_TENANT), str(PERSISTED_JOB_ID), generation, ts, ts),
     )
     connection.commit()
 
 
-def _provenance_set(generation: int, *, artifact_id: str, text: str) -> BulletProvenanceSet:
+def _provenance_set(
+    generation: int,
+    *,
+    artifact_id: str,
+    text: str,
+    tenant_id: TenantId = LOCAL_TENANT,
+) -> BulletProvenanceSet:
     return BulletProvenanceSet(
-        tenant_id=LOCAL_TENANT,
-        job_id=JobId(JOB_URL),
+        tenant_id=tenant_id,
+        job_id=PERSISTED_JOB_ID,
         generation=generation,
         artifact_id=artifact_id,
         bullets=(
@@ -1537,7 +1540,7 @@ def test_repository_round_trip_preserves_canonical_fields(conn: sqlite3.Connecti
     repo = SqliteBulletProvenanceRepository(conn)
     repo.save(_provenance_set(1, artifact_id="art-1", text="Reduced API latency 35%."))
 
-    loaded = repo.load(LOCAL_TENANT, JobId(JOB_URL))
+    loaded = repo.load(LOCAL_TENANT, PERSISTED_JOB_ID)
     assert loaded is not None
     assert loaded.generation == 1
     assert loaded.artifact_id == "art-1"
@@ -1554,12 +1557,108 @@ def test_failed_retailor_never_destroys_last_accepted_generation(conn: sqlite3.C
     repo.save(_provenance_set(2, artifact_id="art-gen2", text="Gen 2 bullet."))
 
     # The latest generation is served by default...
-    latest = repo.load(LOCAL_TENANT, JobId(JOB_URL))
+    latest = repo.load(LOCAL_TENANT, PERSISTED_JOB_ID)
     assert latest is not None and latest.generation == 2 and latest.artifact_id == "art-gen2"
     # ...and generation 1's provenance is retained as audit history (not destroyed).
-    historical = repo.load(LOCAL_TENANT, JobId(JOB_URL), generation=1)
+    historical = repo.load(LOCAL_TENANT, PERSISTED_JOB_ID, generation=1)
     assert historical is not None
     assert historical.bullets[0].generated_text == "Gen 1 bullet."
+
+
+def test_same_generation_save_replaces_only_that_generation(
+    conn: sqlite3.Connection,
+) -> None:
+    _seed_materials_generation(conn, 1, ts="2026-06-08T12:00:00Z")
+    repo = SqliteBulletProvenanceRepository(conn)
+    repo.save(
+        _provenance_set(
+            1,
+            artifact_id="art-prior",
+            text="Prior bullet.",
+        )
+    )
+
+    repo.save(
+        _provenance_set(
+            1,
+            artifact_id="art-replacement",
+            text="Replacement bullet.",
+        )
+    )
+
+    loaded = repo.load(LOCAL_TENANT, PERSISTED_JOB_ID)
+    assert loaded is not None
+    assert loaded.artifact_id == "art-replacement"
+    assert tuple(bullet.generated_text for bullet in loaded.bullets) == ("Replacement bullet.",)
+    assert (
+        conn.execute(
+            "SELECT COUNT(*) FROM job_bullet_provenance WHERE tenant_id = ? AND job_id = ? AND generation = 1",
+            (str(LOCAL_TENANT), str(PERSISTED_JOB_ID)),
+        ).fetchone()[0]
+        == 1
+    )
+
+
+def test_same_job_id_and_generation_are_isolated_by_tenant(
+    conn: sqlite3.Connection,
+) -> None:
+    _seed_materials_generation(conn, 1, ts="2026-06-08T12:00:00Z")
+    conn.execute(
+        """
+        INSERT INTO jobs (tenant_id, job_id, url, title, site)
+        VALUES (?, ?, ?, ?, ?)
+        """,
+        (
+            str(OTHER_TENANT),
+            str(PERSISTED_JOB_ID),
+            JOB_URL,
+            "Senior Backend Engineer",
+            "example",
+        ),
+    )
+    conn.execute(
+        """
+        INSERT INTO job_materials (
+            tenant_id, job_id, generation, status, created_at, updated_at
+        ) VALUES (?, ?, 1, 'complete', ?, ?)
+        """,
+        (
+            str(OTHER_TENANT),
+            str(PERSISTED_JOB_ID),
+            "2026-06-08T12:00:00Z",
+            "2026-06-08T12:00:00Z",
+        ),
+    )
+    conn.commit()
+    repo = SqliteBulletProvenanceRepository(conn)
+
+    repo.save(
+        _provenance_set(
+            1,
+            artifact_id="art-local",
+            text="Local bullet.",
+        )
+    )
+    repo.save(
+        _provenance_set(
+            1,
+            artifact_id="art-other",
+            text="Other tenant bullet.",
+            tenant_id=OTHER_TENANT,
+        )
+    )
+
+    local = repo.load(LOCAL_TENANT, PERSISTED_JOB_ID)
+    other = repo.load(OTHER_TENANT, PERSISTED_JOB_ID)
+    assert local is not None and local.artifact_id == "art-local"
+    assert other is not None and other.artifact_id == "art-other"
+    assert (
+        conn.execute(
+            "SELECT COUNT(*) FROM job_bullet_provenance WHERE job_id = ? AND generation = 1",
+            (str(PERSISTED_JOB_ID),),
+        ).fetchone()[0]
+        == 2
+    )
 
 
 def test_saving_empty_provenance_set_is_a_noop(conn: sqlite3.Connection) -> None:
@@ -1567,10 +1666,99 @@ def test_saving_empty_provenance_set_is_a_noop(conn: sqlite3.Connection) -> None
     repo = SqliteBulletProvenanceRepository(conn)
     empty = BulletProvenanceSet(
         tenant_id=LOCAL_TENANT,
-        job_id=JobId(JOB_URL),
+        job_id=PERSISTED_JOB_ID,
         generation=1,
         artifact_id="art-empty",
         bullets=(),
     )
     repo.save(empty)
-    assert repo.load(LOCAL_TENANT, JobId(JOB_URL)) is None
+    assert repo.load(LOCAL_TENANT, PERSISTED_JOB_ID) is None
+
+
+def test_failed_replacement_preserves_complete_prior_generation(
+    conn: sqlite3.Connection,
+) -> None:
+    _seed_materials_generation(conn, 1, ts="2026-06-08T12:00:00Z")
+    repo = SqliteBulletProvenanceRepository(conn)
+    prior = _provenance_set(
+        1,
+        artifact_id="art-prior",
+        text="Prior accepted bullet.",
+    )
+    repo.save(prior)
+    invalid = BulletProvenanceSet(
+        tenant_id=LOCAL_TENANT,
+        job_id=PERSISTED_JOB_ID,
+        generation=1,
+        artifact_id="art-replacement",
+        bullets=(prior.bullets[0], prior.bullets[0]),
+    )
+
+    with pytest.raises(sqlite3.IntegrityError):
+        repo.save(invalid)
+
+    assert conn.in_transaction is False
+    conn.commit()
+    preserved = repo.load(LOCAL_TENANT, PERSISTED_JOB_ID)
+    assert preserved is not None
+    assert preserved.artifact_id == "art-prior"
+    assert preserved.bullets == prior.bullets
+
+
+def test_repository_savepoint_does_not_commit_enclosing_unit_of_work(
+    conn: sqlite3.Connection,
+) -> None:
+    _seed_materials_generation(conn, 1, ts="2026-06-08T12:00:00Z")
+    unit_of_work = SqliteUnitOfWork(conn)
+    repo = SqliteBulletProvenanceRepository(
+        conn,
+        unit_of_work=unit_of_work,
+    )
+
+    with pytest.raises(RuntimeError, match="rollback outer transaction"):
+        with unit_of_work:
+            repo.save(
+                _provenance_set(
+                    1,
+                    artifact_id="art-staged",
+                    text="Staged bullet.",
+                )
+            )
+            assert conn.in_transaction is True
+            raise RuntimeError("rollback outer transaction")
+
+    assert repo.load(LOCAL_TENANT, PERSISTED_JOB_ID) is None
+
+
+def test_repository_rejects_url_shaped_job_id(
+    conn: sqlite3.Connection,
+) -> None:
+    repo = SqliteBulletProvenanceRepository(conn)
+
+    with pytest.raises(ValueError, match="canonical UUID"):
+        repo.load(LOCAL_TENANT, JobId(JOB_URL))
+    with pytest.raises(ValueError, match="canonical UUID"):
+        repo.save(
+            BulletProvenanceSet(
+                tenant_id=LOCAL_TENANT,
+                job_id=JobId(JOB_URL),
+                generation=1,
+                artifact_id="art-empty",
+                bullets=(),
+            )
+        )
+
+
+def test_repository_does_not_create_runtime_schema() -> None:
+    connection = sqlite3.connect(":memory:")
+    try:
+        SqliteBulletProvenanceRepository(connection)
+
+        assert (
+            connection.execute(
+                "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'job_bullet_provenance'"
+            ).fetchone()
+            is None
+        )
+    finally:
+        connection.close()


### PR DESCRIPTION
## What changed

- keys bullet-provenance reads and writes by tenant-scoped canonical JobId
- removes runtime schema creation and pre-v7 optional-column compatibility reads
- makes same-generation replacement atomic while preserving enclosing unit-of-work rollback
- preserves prior generation history and rejects URL-shaped internal identities

## Why

The v7 cutover makes JobId the sole internal job identity. This review step is limited to bullet-provenance persistence and its exact-v7 invariants; the core materials repository and workflow callers remain separate PRs.

## Validation

- 74 focused bullet-provenance and exact-v7 schema tests passed
- coverage includes two-tenant isolation, successful replacement, failed replacement rollback, and enclosing unit-of-work rollback
- Ruff lint and format checks passed
- git diff --check passed
- independent review passed with zero findings