### PR TITLE
fix(preparation): enforce v7 work item identity

### DIFF
--- a/workers/automation/src/jobctrl/infrastructure/preparation/sqlite_repository.py
+++ b/workers/automation/src/jobctrl/infrastructure/preparation/sqlite_repository.py
@@ -6,8 +6,7 @@ import sqlite3
 from datetime import datetime, timezone
 from typing import Any
 
-from jobctrl.database import ensure_preparation_work_item_tables
-from jobctrl.domain.identifiers import JobId
+from jobctrl.domain.identifiers import JobId, canonical_job_id
 from jobctrl.domain.preparation import (
     PreparationWorkItem,
     PreparationWorkItemKind,
@@ -22,7 +21,6 @@ class SqlitePreparationWorkItemRepository:
 
     def __init__(self, conn: sqlite3.Connection) -> None:
         self._conn = conn
-        ensure_preparation_work_item_tables(conn)
 
     def enqueue(
         self,
@@ -35,22 +33,24 @@ class SqlitePreparationWorkItemRepository:
         available_at: str | None = None,
         now: str | None = None,
     ) -> PreparationWorkItem:
+        stable_job_id = canonical_job_id(str(job_id))
+        normalized_source_event_id = str(source_event_id or "").strip()
         created_at = now or _utc_now()
         available = available_at or created_at
         item = PreparationWorkItem.queued(
             tenant_id=tenant_id,
-            job_id=job_id,
+            job_id=stable_job_id,
             kind=kind,
             target_version=target_version,
-            source_event_id=source_event_id,
+            source_event_id=normalized_source_event_id,
             created_at=created_at,
             available_at=available,
             idempotency_key=make_preparation_idempotency_key(
                 tenant_id=tenant_id,
-                job_id=job_id,
+                job_id=stable_job_id,
                 kind=kind,
                 target_version=target_version,
-                source_event_id=source_event_id,
+                source_event_id=normalized_source_event_id,
             ),
         )
         self._conn.execute(
@@ -121,7 +121,7 @@ def _row_to_item(row: Any) -> PreparationWorkItem:
     return PreparationWorkItem(
         item_id=str(_row_value(row, "item_id", 0)),
         tenant_id=TenantId(str(_row_value(row, "tenant_id", 1))),
-        job_id=JobId(str(_row_value(row, "job_id", 2))),
+        job_id=canonical_job_id(str(_row_value(row, "job_id", 2))),
         kind=PreparationWorkItemKind(str(_row_value(row, "kind", 3))),
         target_version=int(_row_value(row, "target_version", 4)),
         source_event_id=str(_row_value(row, "source_event_id", 5) or ""),

--- a/workers/automation/tests/test_preparation_work_items.py
+++ b/workers/automation/tests/test_preparation_work_items.py
@@ -8,15 +8,34 @@ from pathlib import Path
 import pytest
 
 from jobctrl.database import init_db
-from jobctrl.domain.identifiers import JobId
+from jobctrl.domain.identifiers import JobId, canonical_job_id
 from jobctrl.domain.preparation import PreparationWorkItemKind
-from jobctrl.domain.tenant import LOCAL_TENANT
+from jobctrl.domain.tenant import LOCAL_TENANT, TenantId
 from jobctrl.infrastructure.preparation import SqlitePreparationWorkItemRepository
+
+_IDEMPOTENT_JOB_ID = canonical_job_id("1e7c4a99-8a1a-4969-85fe-402ad88bd372")
+_VERSIONED_JOB_ID = canonical_job_id("7b6d6d88-8f7b-4d63-b9dd-a644bfdfaeef")
+_TENANT_SCOPED_JOB_ID = canonical_job_id("3e6f909e-bb61-4ca6-a827-2b7bbfba57f5")
+_NORMALIZED_EVENT_JOB_ID = canonical_job_id("17e78790-276c-4f51-93f1-4a8e1e95f995")
+_MISSING_JOB_ID = canonical_job_id("e1f0c42f-4a31-43a1-97d8-6964171e1f62")
 
 
 @pytest.fixture()
 def conn(tmp_path: Path) -> sqlite3.Connection:
-    return init_db(tmp_path / "jobctrl.db")
+    connection = init_db(tmp_path / "jobctrl.db")
+    connection.execute("PRAGMA foreign_keys = ON")
+    connection.executemany(
+        "INSERT INTO jobs (tenant_id, job_id, url) VALUES (?, ?, ?)",
+        (
+            (str(LOCAL_TENANT), str(_IDEMPOTENT_JOB_ID), "https://example.com/job/1"),
+            (str(LOCAL_TENANT), str(_VERSIONED_JOB_ID), "https://example.com/job/2"),
+            (str(LOCAL_TENANT), str(_TENANT_SCOPED_JOB_ID), "https://example.com/job/3"),
+            ("other", str(_TENANT_SCOPED_JOB_ID), "https://example.com/other/job/3"),
+            (str(LOCAL_TENANT), str(_NORMALIZED_EVENT_JOB_ID), "https://example.com/job/4"),
+        ),
+    )
+    connection.commit()
+    return connection
 
 
 def test_enqueue_is_idempotent_for_work_item_key(conn: sqlite3.Connection) -> None:
@@ -24,7 +43,7 @@ def test_enqueue_is_idempotent_for_work_item_key(conn: sqlite3.Connection) -> No
 
     first = repo.enqueue(
         tenant_id=LOCAL_TENANT,
-        job_id=JobId("https://example.com/job/1"),
+        job_id=_IDEMPOTENT_JOB_ID,
         kind=PreparationWorkItemKind.SCORE_JOB,
         target_version=3,
         source_event_id="event-1",
@@ -32,7 +51,7 @@ def test_enqueue_is_idempotent_for_work_item_key(conn: sqlite3.Connection) -> No
     )
     second = repo.enqueue(
         tenant_id=LOCAL_TENANT,
-        job_id=JobId("https://example.com/job/1"),
+        job_id=_IDEMPOTENT_JOB_ID,
         kind=PreparationWorkItemKind.SCORE_JOB,
         target_version=3,
         source_event_id="event-1",
@@ -49,7 +68,7 @@ def test_enqueue_distinguishes_target_version_and_source_event(conn: sqlite3.Con
     repo = SqlitePreparationWorkItemRepository(conn)
     kwargs = {
         "tenant_id": LOCAL_TENANT,
-        "job_id": JobId("https://example.com/job/2"),
+        "job_id": _VERSIONED_JOB_ID,
         "kind": PreparationWorkItemKind.TAILOR_RESUME,
     }
 
@@ -74,3 +93,88 @@ def test_enqueue_distinguishes_target_version_and_source_event(conn: sqlite3.Con
 
     assert len({first.item_id, second.item_id, third.item_id}) == 3
     assert len({first.idempotency_key, second.idempotency_key, third.idempotency_key}) == 3
+
+
+def test_enqueue_rejects_url_shaped_job_id(conn: sqlite3.Connection) -> None:
+    repo = SqlitePreparationWorkItemRepository(conn)
+
+    with pytest.raises(ValueError, match="JobId must be a canonical UUID"):
+        repo.enqueue(
+            tenant_id=LOCAL_TENANT,
+            job_id=JobId("https://example.com/job/3"),
+            kind=PreparationWorkItemKind.SCORE_JOB,
+            target_version=1,
+        )
+
+    assert conn.execute("SELECT COUNT(*) FROM preparation_work_items").fetchone()[0] == 0
+
+
+def test_enqueue_normalizes_source_event_id_for_idempotency(conn: sqlite3.Connection) -> None:
+    repo = SqlitePreparationWorkItemRepository(conn)
+    kwargs = {
+        "tenant_id": LOCAL_TENANT,
+        "job_id": _NORMALIZED_EVENT_JOB_ID,
+        "kind": PreparationWorkItemKind.SCORE_JOB,
+        "target_version": 1,
+    }
+
+    first = repo.enqueue(
+        **kwargs,
+        source_event_id="event-a ",
+        now="2026-05-26T00:00:00+00:00",
+    )
+    second = repo.enqueue(
+        **kwargs,
+        source_event_id="event-a",
+        now="2026-05-26T00:01:00+00:00",
+    )
+
+    assert second.item_id == first.item_id
+    assert second.idempotency_key == first.idempotency_key
+    assert second.source_event_id == "event-a"
+    assert conn.execute("SELECT COUNT(*) FROM preparation_work_items").fetchone()[0] == 1
+
+
+def test_enqueue_scopes_canonical_job_id_by_tenant(conn: sqlite3.Connection) -> None:
+    repo = SqlitePreparationWorkItemRepository(conn)
+    kwargs = {
+        "job_id": _TENANT_SCOPED_JOB_ID,
+        "kind": PreparationWorkItemKind.SCORE_JOB,
+        "target_version": 1,
+        "source_event_id": "event-1",
+        "now": "2026-05-26T00:00:00+00:00",
+    }
+
+    local_item = repo.enqueue(tenant_id=LOCAL_TENANT, **kwargs)
+    other_tenant_item = repo.enqueue(tenant_id=TenantId("other"), **kwargs)
+
+    assert local_item.tenant_id == LOCAL_TENANT
+    assert other_tenant_item.tenant_id == TenantId("other")
+    assert local_item.item_id != other_tenant_item.item_id
+    assert conn.execute("SELECT COUNT(*) FROM preparation_work_items").fetchone()[0] == 2
+
+
+def test_enqueue_rejects_nonexistent_and_cross_tenant_job_roots(conn: sqlite3.Connection) -> None:
+    repo = SqlitePreparationWorkItemRepository(conn)
+    kwargs = {
+        "kind": PreparationWorkItemKind.SCORE_JOB,
+        "target_version": 1,
+    }
+
+    with pytest.raises(sqlite3.IntegrityError, match="FOREIGN KEY constraint failed"):
+        repo.enqueue(tenant_id=LOCAL_TENANT, job_id=_MISSING_JOB_ID, **kwargs)
+    with pytest.raises(sqlite3.IntegrityError, match="FOREIGN KEY constraint failed"):
+        repo.enqueue(tenant_id=TenantId("other"), job_id=_IDEMPOTENT_JOB_ID, **kwargs)
+
+    assert conn.execute("SELECT COUNT(*) FROM preparation_work_items").fetchone()[0] == 0
+
+
+def test_repository_does_not_create_preparation_tables_at_runtime() -> None:
+    conn = sqlite3.connect(":memory:")
+
+    SqlitePreparationWorkItemRepository(conn)
+
+    assert (
+        conn.execute("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'preparation_work_items'").fetchone()
+        is None
+    )


### PR DESCRIPTION
## What changed

- removes runtime creation of the preparation work-item table
- requires canonical tenant-scoped JobId values on enqueue and hydration
- normalizes source event IDs once before both persistence and idempotency hashing
- verifies exact-v7 job-root foreign keys and cross-tenant rejection

## Why

Preparation work items must consume the migrated stable identity contract without a URL fallback or repository-owned compatibility schema. This PR is intentionally limited to the repository boundary; Temporal preparation workflow DTOs follow in a separate review step.

## Validation

- 7 focused preparation repository tests passed
- coverage includes event-ID normalization, tenant isolation, orphan/cross-tenant FK rejection, and no runtime schema creation
- Ruff lint and format checks passed
- git diff --check passed
- independent review passed with zero findings