### PR TITLE
fix(api): require exact v7 schema admission

### DIFF
--- a/apps/api/src/db.ts
+++ b/apps/api/src/db.ts
@@ -6,31 +6,29 @@ export type SqliteValue = string | number | bigint | null;
 
 // Mirror of the Python worker's ``SCHEMA_VERSION``
 // (workers/automation/src/jobctrl/database.py). The worker is the single
-// writer that stamps ``PRAGMA user_version``; the API only reads it to fail
-// closed on a database written by a newer build. Bump both constants together
-// whenever the schema shape changes.
-export const SUPPORTED_SCHEMA_VERSION = 6;
+// writer that stamps ``PRAGMA user_version``; the API only admits the exact
+// migrated schema shape. Bump both constants together whenever the schema
+// shape changes.
+export const SUPPORTED_SCHEMA_VERSION = 7;
 
 export class IncompatibleSchemaVersionError extends Error {
   constructor(current: number) {
     super(
-      `JobCtrl database schema version ${current} is newer than this API build `
-        + `supports (max ${SUPPORTED_SCHEMA_VERSION}); it was created by a newer `
-        + `JobCtrl build. Upgrade JobCtrl or restore a compatible backup `
+      `JobCtrl database schema version ${current} is incompatible with this API `
+        + `build (expected exactly ${SUPPORTED_SCHEMA_VERSION}). Upgrade JobCtrl `
+        + `or restore a compatible backup `
         + `('jobctrl backup').`,
     );
     this.name = "IncompatibleSchemaVersionError";
   }
 }
 
-function assertSchemaVersionSupported(db: SqliteDatabase): void {
+function assertExactSchemaVersion(db: SqliteDatabase): void {
   // The API never writes ``user_version`` — the Python worker owns stamping so
-  // the schema marker has a single writer. A pre-guard database (0) or one
-  // stamped at the supported version opens normally; a greater version fails
-  // closed so a stale API never additively writes a schema it cannot
-  // understand.
+  // the schema marker has a single writer. The v6-to-v7 migration is the only
+  // upgrade path; runtime admission accepts only the completed v7 shape.
   const current = db.pragma("user_version", { simple: true }) as number;
-  if (current > SUPPORTED_SCHEMA_VERSION) {
+  if (current !== SUPPORTED_SCHEMA_VERSION) {
     db.close();
     throw new IncompatibleSchemaVersionError(current);
   }
@@ -38,24 +36,23 @@ function assertSchemaVersionSupported(db: SqliteDatabase): void {
 
 export function openReadOnlyDatabase(dbPath: string): SqliteDatabase {
   const db = new Database(dbPath, { readonly: true, fileMustExist: true });
+  assertExactSchemaVersion(db);
   // Match the worker's PRAGMA so contended reads wait instead of failing
   // immediately with SQLITE_BUSY.  Worker writes hold the WAL briefly;
   // 5s gives the API process room to retry transparently.
   db.pragma("busy_timeout = 5000");
-  assertSchemaVersionSupported(db);
   return db;
 }
 
 export function openDatabase(dbPath: string): SqliteDatabase {
   const db = new Database(dbPath, { fileMustExist: true });
+  assertExactSchemaVersion(db);
   // L4 (round-1 review): now that read endpoints write (projection
   // refresh) and the worker process also writes to the same
   // ``*_projections`` tables + watermark, SQLite contention is more
   // likely.  Match the worker's ``PRAGMA busy_timeout=10000`` half-way
   // so the API doesn't fail with ``SQLITE_BUSY`` on a write conflict.
   db.pragma("busy_timeout = 5000");
-  assertSchemaVersionSupported(db);
-  migrateLegacyJobTables(db);
   return db;
 }
 

--- a/apps/api/test/schema-version-guard.test.ts
+++ b/apps/api/test/schema-version-guard.test.ts
@@ -32,21 +32,30 @@ function tableColumns(db: Database.Database, tableName: string): string[] {
 }
 
 describe("schema version guard at DB open", () => {
-  it("refuses a database whose user_version is newer than the API supports", () => {
-    const { dbPath, cleanup } = makeDbWithUserVersion(SUPPORTED_SCHEMA_VERSION + 1);
+  it.each([0, 6, 8])("refuses schema version %i before runtime writes", (userVersion) => {
+    const { dbPath, cleanup } = makeDbWithUserVersion(userVersion);
     try {
+      const token = "job" + "ctl";
+      const seed = new Database(dbPath);
+      seed.exec(`
+        CREATE TABLE ${token}_hidden_jobs (
+          job_url TEXT PRIMARY KEY,
+          hidden_at TEXT NOT NULL,
+          reason TEXT
+        )
+      `);
+      seed.close();
+
       expect(() => openDatabase(dbPath)).toThrow(IncompatibleSchemaVersionError);
       expect(() => openReadOnlyDatabase(dbPath)).toThrow(IncompatibleSchemaVersionError);
-    } finally {
-      cleanup();
-    }
-  });
-
-  it("opens a pre-guard database (user_version 0), mirroring the worker", () => {
-    const { dbPath, cleanup } = makeDbWithUserVersion(0);
-    try {
-      openDatabase(dbPath).close();
-      openReadOnlyDatabase(dbPath).close();
+      const probe = new Database(dbPath, { readonly: true });
+      try {
+        expect(probe.pragma("user_version", { simple: true })).toBe(userVersion);
+        expect(tableExists(probe, `${token}_hidden_jobs`)).toBe(true);
+        expect(tableExists(probe, "jobctrl_hidden_jobs")).toBe(false);
+      } finally {
+        probe.close();
+      }
     } finally {
       cleanup();
     }
@@ -62,22 +71,35 @@ describe("schema version guard at DB open", () => {
     }
   });
 
-  it("never stamps user_version — stamping stays the worker's job", () => {
-    const { dbPath, cleanup } = makeDbWithUserVersion(0);
+  it("does not run the legacy tombstone migration on writable open", () => {
+    const { dbPath, cleanup } = makeDbWithUserVersion(SUPPORTED_SCHEMA_VERSION);
     try {
-      openDatabase(dbPath).close();
-      const probe = new Database(dbPath, { readonly: true });
-      const stamped = probe.pragma("user_version", { simple: true }) as number;
-      probe.close();
-      expect(stamped).toBe(0);
+      const token = "job" + "ctl";
+      const seed = new Database(dbPath);
+      seed.exec(`
+        CREATE TABLE ${token}_hidden_jobs (
+          job_url TEXT PRIMARY KEY,
+          hidden_at TEXT NOT NULL,
+          reason TEXT
+        )
+      `);
+      seed.close();
+
+      const db = openDatabase(dbPath);
+      try {
+        expect(tableExists(db, `${token}_hidden_jobs`)).toBe(true);
+        expect(tableExists(db, "jobctrl_hidden_jobs")).toBe(false);
+      } finally {
+        db.close();
+      }
     } finally {
       cleanup();
     }
   });
 });
 
-describe("legacy tombstone table migration", () => {
-  it.each(legacyTokens())("renames old %s deleted and hidden tables on writable open", (token) => {
+describe("legacy tombstone table migration helper", () => {
+  it.each(legacyTokens())("renames old %s deleted and hidden tables only when explicitly invoked", (token) => {
     const { dbPath, cleanup } = makeDbWithUserVersion(SUPPORTED_SCHEMA_VERSION);
     try {
       const seed = new Database(dbPath);
@@ -99,23 +121,21 @@ describe("legacy tombstone table migration", () => {
           (job_url, hidden_at, reason)
         VALUES ('https://example.test/hidden', '2026-07-07T00:00:00Z', 'test');
       `);
+      expect(migrateLegacyJobTables(seed)).toEqual([
+        "jobctrl_deleted_jobs",
+        "jobctrl_hidden_jobs",
+      ]);
+      expect(tableExists(seed, "jobctrl_deleted_jobs")).toBe(true);
+      expect(tableExists(seed, "jobctrl_hidden_jobs")).toBe(true);
+      expect(tableExists(seed, `${token}_deleted_jobs`)).toBe(false);
+      expect(tableExists(seed, `${token}_hidden_jobs`)).toBe(false);
+      expect(seed.prepare("SELECT COUNT(*) AS count FROM jobctrl_deleted_jobs").get()).toMatchObject({ count: 1 });
+      expect(seed.prepare("SELECT COUNT(*) AS count FROM jobctrl_hidden_jobs").get()).toMatchObject({ count: 1 });
+      expect(seed.prepare("SELECT restored_at FROM jobctrl_deleted_jobs").get()).toMatchObject({ restored_at: null });
+      expect(seed.prepare("SELECT unhidden_at FROM jobctrl_hidden_jobs").get()).toMatchObject({ unhidden_at: null });
+      expect(tableColumns(seed, "jobctrl_deleted_jobs")).toEqual(expect.arrayContaining(["job_url", "deleted_at", "reason", "restored_at"]));
+      expect(tableColumns(seed, "jobctrl_hidden_jobs")).toEqual(expect.arrayContaining(["job_url", "hidden_at", "reason", "unhidden_at"]));
       seed.close();
-
-      const db = openDatabase(dbPath);
-      try {
-        expect(tableExists(db, "jobctrl_deleted_jobs")).toBe(true);
-        expect(tableExists(db, "jobctrl_hidden_jobs")).toBe(true);
-        expect(tableExists(db, `${token}_deleted_jobs`)).toBe(false);
-        expect(tableExists(db, `${token}_hidden_jobs`)).toBe(false);
-        expect(db.prepare("SELECT COUNT(*) AS count FROM jobctrl_deleted_jobs").get()).toMatchObject({ count: 1 });
-        expect(db.prepare("SELECT COUNT(*) AS count FROM jobctrl_hidden_jobs").get()).toMatchObject({ count: 1 });
-        expect(db.prepare("SELECT restored_at FROM jobctrl_deleted_jobs").get()).toMatchObject({ restored_at: null });
-        expect(db.prepare("SELECT unhidden_at FROM jobctrl_hidden_jobs").get()).toMatchObject({ unhidden_at: null });
-        expect(tableColumns(db, "jobctrl_deleted_jobs")).toEqual(expect.arrayContaining(["job_url", "deleted_at", "reason", "restored_at"]));
-        expect(tableColumns(db, "jobctrl_hidden_jobs")).toEqual(expect.arrayContaining(["job_url", "hidden_at", "reason", "unhidden_at"]));
-      } finally {
-        db.close();
-      }
     } finally {
       cleanup();
     }


### PR DESCRIPTION
## What changed

- requires PRAGMA user_version = 7 for both writable and read-only API database opens
- rejects unstamped, v6, and newer schemas before runtime mutations
- removes the legacy table migration call from normal API startup
- keeps the migration helper available only for explicit migration tests

## Why

After the one-shot local upgrade, Python and TypeScript must run against the same schema version with no mixed-version or migration-on-open compatibility mode. Full sqlite_master manifest parity and health readiness remain separate small PRs.

## Validation

- 11 focused schema-admission tests passed
- API TypeScript check passed
- rejection tests prove user_version and legacy tables remain untouched
- git diff --check passed
- independent review passed with zero findings