### PR TITLE
refactor(materials): key aggregate storage by JobId

### DIFF
--- a/workers/automation/src/jobctrl/domain/materials/aggregate.py
+++ b/workers/automation/src/jobctrl/domain/materials/aggregate.py
@@ -26,6 +26,7 @@ Invariants enforced here:
 
 from __future__ import annotations
 
+import uuid
 from dataclasses import dataclass, field, replace
 from typing import Any, Mapping
 
@@ -99,6 +100,11 @@ class MaterialsSet:
     last_validation: ValidationResult | None = None
     last_verdict: JudgeVerdict | None = None
     metadata: dict[str, Any] = field(default_factory=dict)
+    lineage_id: str = field(
+        default_factory=lambda: uuid.uuid4().hex,
+        repr=False,
+        compare=False,
+    )
 
     # ------------------------------------------------------------------
     # Invariants
@@ -122,6 +128,12 @@ class MaterialsSet:
             raise TypeError("MaterialsSet.updated_at must be a str")
         if not isinstance(self.metadata, dict):
             raise TypeError("MaterialsSet.metadata must be a dict")
+        try:
+            lineage_uuid = uuid.UUID(hex=self.lineage_id)
+        except (AttributeError, TypeError, ValueError) as exc:
+            raise ValueError("MaterialsSet.lineage_id must be a UUID hex string") from exc
+        if lineage_uuid.hex != self.lineage_id:
+            raise ValueError("MaterialsSet.lineage_id must be canonical lowercase UUID hex")
 
         # Type sanity per slot.
         for slot, expected in (

--- a/workers/automation/src/jobctrl/domain/ports/materials.py
+++ b/workers/automation/src/jobctrl/domain/ports/materials.py
@@ -78,8 +78,9 @@ class MaterialsRepository(Protocol):
       * :meth:`save` enforces that ``materials.generation`` is exactly one
         greater than the latest persisted generation for ``(tenant_id,
         job_id)`` — or ``1`` when none exists. The same generation may be
-        saved multiple times (idempotent overwrite within the generation;
-        artifact additions during the same generation use this path).
+        saved multiple times only when its collision-resistant lineage token
+        matches the persisted aggregate (idempotent enrichment within the
+        generation; artifact additions use this path).
       * :meth:`load` returns the LATEST generation by default. Pass
         ``generation=`` to read a specific historical row.
       * :meth:`load_current_approved` returns the newest generation whose
@@ -117,8 +118,9 @@ class MaterialsRepository(Protocol):
         The repository is responsible for:
 
           * Allocating ``generation`` monotonically per ``(tenant_id,
-            job_id)`` — re-saving the *same* generation overwrites the
-            row (used when adding artifacts mid-flow).
+            job_id)`` — re-saving the *same* generation updates the row only
+            when its collision-resistant lineage token matches (used when
+            adding artifacts mid-flow without admitting stale creators).
           * Persisting every artifact slot atomically with the parent
             row. SQLite uses a transaction; the cloud adapter will use
             an outbox.

--- a/workers/automation/src/jobctrl/infrastructure/materials/sqlite_repository.py
+++ b/workers/automation/src/jobctrl/infrastructure/materials/sqlite_repository.py
@@ -1,16 +1,16 @@
-"""SqliteMaterialsRepository — local-mode adapter for the Materials context.
+"""SQLite adapters for the Materials context.
 
-Persists :class:`MaterialsSet` aggregates to the ``job_materials`` +
-``job_materials_artifacts`` tables created by
-:func:`database.ensure_materials_tables`. Generation invariants are
-enforced at save time: a fresh aggregate must carry
-``generation = current_max + 1`` (or ``1`` when none exists). Saving the
-*same* generation again is allowed and overwrites the row — that's how
-use cases append cover letters / PDFs to an existing generation.
+``SqliteMaterialsRepository`` persists :class:`MaterialsSet` aggregates to the
+exact-v7 tenant-scoped ``job_materials`` and ``job_materials_artifacts`` tables.
+Generation invariants are enforced atomically at save time: a fresh aggregate
+must carry ``generation = current_max + 1`` (or ``1`` when none exists).
+Saving the *same* generation again is allowed only when its collision-resistant
+lineage token matches the persisted aggregate — that's how use cases append
+cover letters / PDFs without letting a stale concurrent creator replace the
+winning generation.
 
-Local-mode treats ``job_id`` as the legacy ``jobs.url`` primary key. When
-the cloud cutover (Phase 9) introduces stable system-generated ``JobId``
-values, the adapter swaps the column without touching the port.
+Internal aggregate identity is the stable tenant-scoped ``JobId``. URLs are
+external locators and are not accepted by the aggregate persistence methods.
 
 See ddd-target.md §7.1 / §7.2 (per-aggregate repository, schema decoupling).
 """
@@ -24,7 +24,7 @@ from datetime import datetime, timezone
 from typing import Any
 
 from jobctrl.database import effective_tailoring_min_score, ensure_tailoring_policy_tables
-from jobctrl.domain.identifiers import JobId
+from jobctrl.domain.identifiers import JobId, canonical_job_id
 from jobctrl.domain.materials.aggregate import MaterialsSet
 from jobctrl.domain.materials.entities import Artifact
 from jobctrl.domain.materials.policy import TailoringPolicy
@@ -37,6 +37,8 @@ from jobctrl.domain.materials.value_objects import (
 )
 from jobctrl.domain.tenant import LOCAL_TENANT, TenantId
 from jobctrl.infrastructure.materials.unit_of_work import SqliteUnitOfWork
+
+_LINEAGE_KEY = "__jobctrl_materials_lineage_id"
 
 
 # ---------------------------------------------------------------------------
@@ -99,27 +101,28 @@ class SqliteMaterialsRepository:
         *,
         generation: int | None = None,
     ) -> MaterialsSet | None:
+        stable_job_id = canonical_job_id(str(job_id))
         if generation is None:
             row = self._conn.execute(
                 """
-                SELECT job_url, generation, status, created_at, updated_at,
+                SELECT job_id, generation, status, created_at, updated_at,
                        last_validation_json, last_verdict_json, metadata_json
                 FROM job_materials
-                WHERE job_url = ? AND tenant_id = ?
+                WHERE tenant_id = ? AND job_id = ?
                 ORDER BY generation DESC
                 LIMIT 1
                 """,
-                (str(job_id), str(tenant_id)),
+                (str(tenant_id), str(stable_job_id)),
             ).fetchone()
         else:
             row = self._conn.execute(
                 """
-                SELECT job_url, generation, status, created_at, updated_at,
+                SELECT job_id, generation, status, created_at, updated_at,
                        last_validation_json, last_verdict_json, metadata_json
                 FROM job_materials
-                WHERE job_url = ? AND tenant_id = ? AND generation = ?
+                WHERE tenant_id = ? AND job_id = ? AND generation = ?
                 """,
-                (str(job_id), str(tenant_id), int(generation)),
+                (str(tenant_id), str(stable_job_id), int(generation)),
             ).fetchone()
         if row is None:
             return None
@@ -137,24 +140,32 @@ class SqliteMaterialsRepository:
         such as cover/PDF generation need this approved-material view instead of
         the raw latest generation.
         """
+        stable_job_id = canonical_job_id(str(job_id))
         row = self._conn.execute(
             """
-            SELECT m.job_url, m.generation, m.status, m.created_at, m.updated_at,
+            SELECT m.job_id, m.generation, m.status, m.created_at, m.updated_at,
                    m.last_validation_json, m.last_verdict_json, m.metadata_json
             FROM job_materials m
             INNER JOIN (
-                SELECT job_url, MAX(generation) AS generation
+                SELECT tenant_id, job_id, MAX(generation) AS generation
                 FROM job_materials_artifacts
-                WHERE job_url = ?
+                WHERE tenant_id = ?
+                  AND job_id = ?
                   AND artifact_type = 'tailored_resume'
                   AND status = 'approved'
-                GROUP BY job_url
+                GROUP BY tenant_id, job_id
             ) current
-              ON current.job_url = m.job_url
+              ON current.tenant_id = m.tenant_id
+             AND current.job_id = m.job_id
              AND current.generation = m.generation
-            WHERE m.job_url = ? AND m.tenant_id = ?
+            WHERE m.tenant_id = ? AND m.job_id = ?
             """,
-            (str(job_id), str(job_id), str(tenant_id)),
+            (
+                str(tenant_id),
+                str(stable_job_id),
+                str(tenant_id),
+                str(stable_job_id),
+            ),
         ).fetchone()
         if row is None:
             return None
@@ -408,9 +419,7 @@ class SqliteMaterialsRepository:
         """Return latest-generation aggregates whose tailored resume
         artifact carries the requested status."""
         if not isinstance(status, ArtifactStatus):
-            raise TypeError(
-                f"list_by_status requires ArtifactStatus, got {type(status).__name__}"
-            )
+            raise TypeError(f"list_by_status requires ArtifactStatus, got {type(status).__name__}")
         params: list[Any] = [str(tenant_id), status.value]
         sql = (
             "SELECT m.job_url, m.generation, m.status, m.created_at, m.updated_at, "
@@ -438,70 +447,119 @@ class SqliteMaterialsRepository:
     # ------------------------------------------------------------------
 
     def save(self, materials: MaterialsSet) -> None:
-        latest = self._conn.execute(
-            "SELECT COALESCE(MAX(generation), 0) AS g FROM job_materials "
-            "WHERE job_url = ? AND tenant_id = ?",
-            (str(materials.job_id), str(materials.tenant_id)),
-        ).fetchone()
-        current_max = int(latest[0] if latest else 0)
-        existing = self._conn.execute(
-            "SELECT 1 FROM job_materials WHERE job_url = ? AND tenant_id = ? AND generation = ?",
-            (str(materials.job_id), str(materials.tenant_id), materials.generation),
-        ).fetchone()
-        # Allow either: update an existing generation or mint exactly the next one.
-        # Failed re-tailors can leave newer rejected generations while the last
-        # approved generation remains the current downstream material for cover/PDF.
-        if existing is None and materials.generation != current_max + 1:
-            raise MaterialsGenerationConflict(
-                job_id=materials.job_id,
-                attempted=materials.generation,
-                expected=current_max + 1,
-            )
+        stable_job_id = canonical_job_id(str(materials.job_id))
+        savepoint = "materials_aggregate_save"
+        self._conn.execute(f"SAVEPOINT {savepoint}")
+        try:
+            self._save_rows(materials, stable_job_id)
+        except BaseException:
+            self._conn.execute(f"ROLLBACK TO SAVEPOINT {savepoint}")
+            self._conn.execute(f"RELEASE SAVEPOINT {savepoint}")
+            raise
+        else:
+            self._conn.execute(f"RELEASE SAVEPOINT {savepoint}")
 
-        # Upsert the parent row.
-        self._conn.execute(
+    def _save_rows(
+        self,
+        materials: MaterialsSet,
+        job_id: JobId,
+    ) -> None:
+        # Insert the next generation or enrich an existing generation whose
+        # collision-resistant lineage token matches. Keeping allocation and the
+        # optimistic lineage check in one SQLite statement closes the stale
+        # writer window between a separate SELECT and UPSERT.
+        metadata_json = _dumps(
+            {
+                **dict(materials.metadata),
+                _LINEAGE_KEY: materials.lineage_id,
+            }
+        )
+        parent = self._conn.execute(
             """
             INSERT INTO job_materials (
-                job_url, generation, tenant_id, status,
+                tenant_id, job_id, generation, status,
                 created_at, updated_at,
                 last_validation_json, last_verdict_json, metadata_json
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-            ON CONFLICT(job_url, generation) DO UPDATE SET
+            )
+            SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?
+            WHERE
+                ? = (
+                    SELECT COALESCE(MAX(generation), 0) + 1
+                    FROM job_materials
+                    WHERE tenant_id = ? AND job_id = ?
+                )
+                OR EXISTS (
+                    SELECT 1
+                    FROM job_materials
+                    WHERE tenant_id = ?
+                      AND job_id = ?
+                      AND generation = ?
+                      AND COALESCE(
+                          json_extract(metadata_json, '$.__jobctrl_materials_lineage_id'),
+                          ?
+                      ) = ?
+                )
+            ON CONFLICT(tenant_id, job_id, generation) DO UPDATE SET
                 status = excluded.status,
                 updated_at = excluded.updated_at,
                 last_validation_json = excluded.last_validation_json,
                 last_verdict_json = excluded.last_verdict_json,
                 metadata_json = excluded.metadata_json
+            WHERE COALESCE(
+                      json_extract(
+                          job_materials.metadata_json,
+                          '$.__jobctrl_materials_lineage_id'
+                      ),
+                      json_extract(
+                          excluded.metadata_json,
+                          '$.__jobctrl_materials_lineage_id'
+                      )
+                  ) = json_extract(
+                      excluded.metadata_json,
+                      '$.__jobctrl_materials_lineage_id'
+                  )
             """,
             (
-                str(materials.job_id),
-                materials.generation,
                 str(materials.tenant_id),
+                str(job_id),
+                materials.generation,
                 materials.status,
                 materials.created_at,
                 materials.updated_at,
-                _dumps(
-                    materials.last_validation.to_dict() if materials.last_validation else None
-                ),
-                _dumps(
-                    materials.last_verdict.to_dict() if materials.last_verdict else None
-                ),
-                _dumps(materials.metadata) if materials.metadata else None,
+                _dumps(materials.last_validation.to_dict() if materials.last_validation else None),
+                _dumps(materials.last_verdict.to_dict() if materials.last_verdict else None),
+                metadata_json,
+                materials.generation,
+                str(materials.tenant_id),
+                str(job_id),
+                str(materials.tenant_id),
+                str(job_id),
+                materials.generation,
+                materials.lineage_id,
+                materials.lineage_id,
             ),
         )
+        if parent.rowcount == 0:
+            latest = self._conn.execute(
+                """
+                SELECT COALESCE(MAX(generation), 0)
+                FROM job_materials
+                WHERE tenant_id = ? AND job_id = ?
+                """,
+                (str(materials.tenant_id), str(job_id)),
+            ).fetchone()
+            current_max = int(latest[0] if latest else 0)
+            raise MaterialsGenerationConflict(
+                job_id=job_id,
+                attempted=materials.generation,
+                expected=current_max + 1,
+            )
 
         # Persist every present artifact slot. Slots that were dropped
         # between two saves of the same generation are left untouched —
         # use cases append, never delete.
         for artifact in materials.artifacts:
-            self._upsert_artifact(materials, artifact)
-
-        self._commit()
-
-    def _commit(self) -> None:
-        """Commit now, unless an active unit of work owns the transaction."""
-        if self._unit_of_work is None or not self._unit_of_work.active:
-            self._conn.commit()
+            self._upsert_artifact(materials, job_id, artifact)
 
     def suppress_active_artifacts(
         self,
@@ -522,16 +580,36 @@ class SqliteMaterialsRepository:
     # Internals
     # ------------------------------------------------------------------
 
-    def _upsert_artifact(self, materials: MaterialsSet, artifact: Artifact) -> None:
+    def _upsert_artifact(
+        self,
+        materials: MaterialsSet,
+        job_id: JobId,
+        artifact: Artifact,
+    ) -> None:
         metadata, layout_boxes = _metadata_and_layout_boxes(artifact.metadata)
+        previous = self._conn.execute(
+            """
+            SELECT artifact_id
+            FROM job_materials_artifacts
+            WHERE tenant_id = ? AND job_id = ?
+              AND generation = ? AND artifact_type = ?
+            """,
+            (
+                str(materials.tenant_id),
+                str(job_id),
+                materials.generation,
+                artifact.type.value,
+            ),
+        ).fetchone()
+        previous_artifact_id = str(previous["artifact_id"]) if previous is not None else None
         self._conn.execute(
             """
             INSERT INTO job_materials_artifacts (
-                job_url, generation, artifact_type, artifact_id,
+                tenant_id, job_id, generation, artifact_type, artifact_id,
                 status, path, render_format, size_bytes,
                 metadata_json, created_at, superseded_at
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            ON CONFLICT(job_url, generation, artifact_type) DO UPDATE SET
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(tenant_id, job_id, generation, artifact_type) DO UPDATE SET
                 artifact_id = excluded.artifact_id,
                 status = excluded.status,
                 path = excluded.path,
@@ -542,7 +620,8 @@ class SqliteMaterialsRepository:
                 superseded_at = excluded.superseded_at
             """,
             (
-                str(materials.job_id),
+                str(materials.tenant_id),
+                str(job_id),
                 materials.generation,
                 artifact.type.value,
                 artifact.artifact_id,
@@ -555,33 +634,49 @@ class SqliteMaterialsRepository:
                 artifact.superseded_at,
             ),
         )
-        self._replace_layout_boxes(materials, artifact, layout_boxes)
+        self._replace_layout_boxes(
+            materials,
+            job_id,
+            artifact,
+            layout_boxes,
+            previous_artifact_id=previous_artifact_id,
+        )
 
     def _replace_layout_boxes(
         self,
         materials: MaterialsSet,
+        job_id: JobId,
         artifact: Artifact,
         layout_boxes: list[dict[str, Any]],
+        *,
+        previous_artifact_id: str | None,
     ) -> None:
-        try:
-            self._conn.execute(
-                """
-                DELETE FROM job_material_layout_boxes
-                WHERE job_url = ? AND generation = ? AND artifact_id = ?
-                """,
-                (str(materials.job_id), materials.generation, artifact.artifact_id),
-            )
-        except sqlite3.OperationalError:
-            return
+        artifact_ids = {artifact.artifact_id}
+        if previous_artifact_id is not None:
+            artifact_ids.add(previous_artifact_id)
+        placeholders = ", ".join("?" for _ in artifact_ids)
+        self._conn.execute(
+            f"""
+            DELETE FROM job_material_layout_boxes
+            WHERE tenant_id = ? AND job_id = ?
+              AND generation = ? AND artifact_id IN ({placeholders})
+            """,
+            (
+                str(materials.tenant_id),
+                str(job_id),
+                materials.generation,
+                *sorted(artifact_ids),
+            ),
+        )
         if not layout_boxes:
             return
         rows = [
             (
-                str(materials.job_id),
+                str(materials.tenant_id),
+                str(job_id),
                 materials.generation,
                 artifact.artifact_id,
                 index,
-                str(materials.tenant_id),
                 box["semantic_id"],
                 box["page_number"],
                 box.get("line_number"),
@@ -598,7 +693,7 @@ class SqliteMaterialsRepository:
         self._conn.executemany(
             """
             INSERT INTO job_material_layout_boxes (
-                job_url, generation, artifact_id, box_index, tenant_id,
+                tenant_id, job_id, generation, artifact_id, box_index,
                 semantic_id, page_number, line_number, text_excerpt,
                 left_pct, top_pct, width_pct, height_pct, audit_target_json,
                 created_at
@@ -647,7 +742,7 @@ class SqliteMaterialsRepository:
 
     def _row_to_materials(self, row: Any, tenant_id: TenantId) -> MaterialsSet:
         if isinstance(row, sqlite3.Row):
-            job_url = row["job_url"]
+            job_id = canonical_job_id(str(row["job_id"]))
             generation = row["generation"]
             status = row["status"]
             created_at = row["created_at"]
@@ -657,7 +752,7 @@ class SqliteMaterialsRepository:
             metadata_json = row["metadata_json"]
         else:
             (
-                job_url,
+                raw_job_id,
                 generation,
                 status,
                 created_at,
@@ -666,15 +761,16 @@ class SqliteMaterialsRepository:
                 verdict_json,
                 metadata_json,
             ) = row
+            job_id = canonical_job_id(str(raw_job_id))
 
         artifact_rows = self._conn.execute(
             """
             SELECT artifact_type, artifact_id, status, path, render_format,
                    size_bytes, metadata_json, created_at, superseded_at
             FROM job_materials_artifacts
-            WHERE job_url = ? AND generation = ?
+            WHERE tenant_id = ? AND job_id = ? AND generation = ?
             """,
-            (str(job_url), int(generation)),
+            (str(tenant_id), str(job_id), int(generation)),
         ).fetchall()
 
         slot_kwargs: dict[str, Artifact | None] = {
@@ -697,24 +793,20 @@ class SqliteMaterialsRepository:
                 path=str(art_row["path"]),
                 render_format=RenderFormat(art_row["render_format"]),
                 created_at=str(art_row["created_at"]),
-                size_bytes=(
-                    int(art_row["size_bytes"])
-                    if art_row["size_bytes"] is not None
-                    else None
-                ),
+                size_bytes=(int(art_row["size_bytes"]) if art_row["size_bytes"] is not None else None),
                 metadata=_loads(art_row["metadata_json"]) or {},
-                superseded_at=(
-                    str(art_row["superseded_at"]) if art_row["superseded_at"] else None
-                ),
+                superseded_at=(str(art_row["superseded_at"]) if art_row["superseded_at"] else None),
             )
             slot_kwargs[slot_for_type[artifact.type]] = artifact
 
         validation = ValidationResult.from_dict(_loads(validation_json)) if validation_json else None
         verdict = JudgeVerdict.from_dict(_loads(verdict_json))
 
+        metadata = _loads(metadata_json) or {}
+        lineage_id = str(metadata.pop(_LINEAGE_KEY, "")) or None
         return MaterialsSet(
             tenant_id=tenant_id or LOCAL_TENANT,
-            job_id=JobId(str(job_url)),
+            job_id=job_id,
             generation=int(generation),
             status=str(status),
             created_at=str(created_at),
@@ -725,7 +817,8 @@ class SqliteMaterialsRepository:
             cover_letter_pdf=slot_kwargs["cover_letter_pdf"],
             last_validation=validation,
             last_verdict=verdict,
-            metadata=_loads(metadata_json) or {},
+            metadata=metadata,
+            **({"lineage_id": lineage_id} if lineage_id is not None else {}),
         )
 
 

--- a/workers/automation/tests/test_materials_repository.py
+++ b/workers/automation/tests/test_materials_repository.py
@@ -1,17 +1,11 @@
-"""Phase 6 / S-20: SqliteMaterialsRepository round-trip + backfill + generation invariants.
-
-Each test runs against a tmp SQLite database via the public ``init_db``
-helper so the schema (including ``ensure_materials_tables`` + backfill)
-is exercised end-to-end. The legacy ``jobs.tailored_resume_path`` /
-``jobs.cover_letter_path`` columns are written directly by these tests
-to seed the backfill path.
-"""
+"""Exact-v7 ``SqliteMaterialsRepository`` round-trip and generation invariants."""
 
 from __future__ import annotations
 
 import json
 import sqlite3
 import threading
+import uuid
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
@@ -19,7 +13,6 @@ import pytest
 
 from jobctrl.database import (
     close_connection,
-    ensure_materials_tables,
     get_connection,
     get_jobs_by_stage,
     get_stats,
@@ -56,14 +49,20 @@ def conn(tmp_path: Path) -> sqlite3.Connection:
     return init_db(db_path)
 
 
-def _seed_job(conn: sqlite3.Connection, url: str = "https://example.com/job/1") -> str:
+def _seed_job(conn: sqlite3.Connection, url: str = "https://example.com/job/1") -> JobId:
+    job_id = JobId(str(uuid.uuid5(uuid.NAMESPACE_URL, url)))
     conn.execute(
-        "INSERT INTO jobs (url, title, site, full_description, fit_score, discovered_at) "
+        "INSERT INTO jobs (tenant_id, job_id, url, title, site, discovered_at) "
         "VALUES (?, ?, ?, ?, ?, ?)",
-        (url, "Engineer", "Acme", "Description", 9, "2024-01-01T00:00:00+00:00"),
+        (LOCAL_TENANT, job_id, url, "Engineer", "Acme", "2024-01-01T00:00:00+00:00"),
+    )
+    conn.execute(
+        "INSERT INTO job_enrichments (tenant_id, job_id, current_status, full_description, "
+        "updated_at) VALUES (?, ?, ?, ?, ?)",
+        (LOCAL_TENANT, job_id, "enriched", "Description", "2024-01-01T00:00:00+00:00"),
     )
     conn.commit()
-    return url
+    return job_id
 
 
 def _make_artifact(
@@ -83,38 +82,38 @@ def _make_artifact(
     )
 
 
-def _initial(url: str) -> MaterialsSet:
+def _initial(job_id: JobId) -> MaterialsSet:
     return MaterialsSet.initial(
         tenant_id=LOCAL_TENANT,
-        job_id=JobId(url),
+        job_id=job_id,
         created_at="2024-01-01T00:00:00+00:00",
     )
 
 
-def _approved(url: str) -> MaterialsSet:
-    return _initial(url).with_resume_attempt(
-        _make_artifact(ArtifactType.TAILORED_RESUME, path=f"/tmp/{url[-3:]}.txt"),
+def _approved(job_id: JobId) -> MaterialsSet:
+    return _initial(job_id).with_resume_attempt(
+        _make_artifact(ArtifactType.TAILORED_RESUME, path=f"/tmp/{job_id[-3:]}.txt"),
         validation=ValidationResult.success(),
         verdict=JudgeVerdict.passed(),
         updated_at="2024-01-02T00:00:00+00:00",
     )
 
 
-def _approved_with_pdf(url: str) -> MaterialsSet:
-    return _approved(url).with_resume_pdf(
+def _approved_with_pdf(job_id: JobId) -> MaterialsSet:
+    return _approved(job_id).with_resume_pdf(
         _make_artifact(
             ArtifactType.RESUME_PDF,
-            path=f"/tmp/{url[-3:]}.pdf",
+            path=f"/tmp/{job_id[-3:]}.pdf",
             render_format=RenderFormat.LATEX_PDF,
         ),
         updated_at="2024-01-02T01:00:00+00:00",
     )
 
 
-def _rejected(url: str, *, generation: int = 2) -> MaterialsSet:
+def _rejected(job_id: JobId, *, generation: int = 2) -> MaterialsSet:
     return MaterialsSet(
         tenant_id=LOCAL_TENANT,
-        job_id=JobId(url),
+        job_id=job_id,
         generation=generation,
         created_at="2024-01-03T00:00:00+00:00",
         updated_at="2024-01-03T00:00:00+00:00",
@@ -279,7 +278,7 @@ def test_approved_cover_refresh_supersedes_stale_pdf_and_projects_pending_pdf(
     assert loaded.status == "cover_letter_ready"
     assert repo.list_pending_pdf(LOCAL_TENANT) == [JobId(url)]
     pending_pdf = get_jobs_by_stage(conn, stage="pending_pdf", limit=0)
-    assert [row["url"] for row in pending_pdf] == [url]
+    assert [row["job_id"] for row in pending_pdf] == [url]
     assert pending_pdf[0]["cover_letter_path"] == str(new_cover_path)
 
 
@@ -398,9 +397,9 @@ def test_save_persists_resume_layout_boxes_outside_artifact_metadata(
         """
         SELECT metadata_json
         FROM job_materials_artifacts
-        WHERE job_url = ? AND artifact_id = ?
+        WHERE tenant_id = ? AND job_id = ? AND artifact_id = ?
         """,
-        (url, pdf.artifact_id),
+        (LOCAL_TENANT, url, pdf.artifact_id),
     ).fetchone()
     assert artifact_row is not None
     assert json.loads(artifact_row["metadata_json"]) == {"layout_source": "html_resume_dom"}
@@ -410,9 +409,9 @@ def test_save_persists_resume_layout_boxes_outside_artifact_metadata(
         SELECT semantic_id, page_number, line_number, text_excerpt,
                left_pct, top_pct, width_pct, height_pct, audit_target_json
         FROM job_material_layout_boxes
-        WHERE job_url = ? AND artifact_id = ?
+        WHERE tenant_id = ? AND job_id = ? AND artifact_id = ?
         """,
-        (url, pdf.artifact_id),
+        (LOCAL_TENANT, url, pdf.artifact_id),
     ).fetchall()
     assert len(rows) == 1
     row = rows[0]
@@ -450,18 +449,18 @@ def test_loads_resume_review_promoted_generation_without_deleting_prior_material
     conn.execute(
         """
         INSERT INTO job_materials (
-            job_url, generation, tenant_id, status, created_at, updated_at,
+            tenant_id, job_id, generation, status, created_at, updated_at,
             last_validation_json, last_verdict_json, metadata_json
-        ) VALUES (?, 1, 'local', 'resume_approved', ?, ?, '{}', '{}', '{}')
+        ) VALUES ('local', ?, 1, 'resume_approved', ?, ?, '{}', '{}', '{}')
         """,
         (url, now, now),
     )
     conn.execute(
         """
         INSERT INTO job_materials (
-            job_url, generation, tenant_id, status, created_at, updated_at,
+            tenant_id, job_id, generation, status, created_at, updated_at,
             last_validation_json, last_verdict_json, metadata_json
-        ) VALUES (?, 2, 'local', 'resume_approved', ?, ?, ?, ?, ?)
+        ) VALUES ('local', ?, 2, 'resume_approved', ?, ?, ?, ?, ?)
         """,
         (
             url,
@@ -482,9 +481,9 @@ def test_loads_resume_review_promoted_generation_without_deleting_prior_material
     conn.executemany(
         """
         INSERT INTO job_materials_artifacts (
-            job_url, generation, artifact_type, artifact_id, status, path,
+            tenant_id, job_id, generation, artifact_type, artifact_id, status, path,
             render_format, size_bytes, metadata_json, created_at, superseded_at
-        ) VALUES (?, ?, ?, ?, 'approved', ?, ?, ?, ?, ?, NULL)
+        ) VALUES ('local', ?, ?, ?, ?, 'approved', ?, ?, ?, ?, ?, NULL)
         """,
         [
             (
@@ -542,10 +541,10 @@ def test_loads_resume_review_promoted_generation_without_deleting_prior_material
     conn.execute(
         """
         INSERT INTO job_material_layout_boxes (
-            job_url, generation, artifact_id, box_index, tenant_id,
+            tenant_id, job_id, generation, artifact_id, box_index,
             semantic_id, page_number, line_number, text_excerpt,
             left_pct, top_pct, width_pct, height_pct, audit_target_json, created_at
-        ) VALUES (?, 2, 'edited-pdf', 0, 'local',
+        ) VALUES ('local', ?, 2, 'edited-pdf', 0,
                   'edited:line:1', 1, 1, 'edited resume',
                   10, 8, 80, 1.7, '{}', ?)
         """,
@@ -567,19 +566,19 @@ def test_loads_resume_review_promoted_generation_without_deleting_prior_material
         """
         SELECT status
         FROM job_materials_artifacts
-        WHERE job_url = ? AND generation = 1
+        WHERE tenant_id = ? AND job_id = ? AND generation = 1
         ORDER BY artifact_type
         """,
-        (url,),
+        (LOCAL_TENANT, url),
     ).fetchall()
     assert [row["status"] for row in prior_statuses] == ["approved", "approved"]
     box = conn.execute(
         """
         SELECT semantic_id, line_number, text_excerpt
         FROM job_material_layout_boxes
-        WHERE job_url = ? AND generation = 2 AND artifact_id = 'edited-pdf'
+        WHERE tenant_id = ? AND job_id = ? AND generation = 2 AND artifact_id = 'edited-pdf'
         """,
-        (url,),
+        (LOCAL_TENANT, url),
     ).fetchone()
     assert dict(box) == {
         "semantic_id": "edited:line:1",
@@ -593,26 +592,27 @@ def test_loads_resume_review_promoted_generation_without_deleting_prior_material
 # ---------------------------------------------------------------------------
 
 
-def _seed_with_score(conn: sqlite3.Connection, url: str, fit_score: int = 9) -> str:
+def _seed_with_score(conn: sqlite3.Connection, url: str, fit_score: int = 9) -> JobId:
+    job_id = _seed_job(conn, url)
     conn.execute(
-        "INSERT INTO jobs (url, title, site, full_description, fit_score, discovered_at) "
-        "VALUES (?, ?, ?, ?, ?, ?)",
-        (url, "Engineer", "Acme", "desc", fit_score, "2024-01-01T00:00:00+00:00"),
+        "INSERT INTO job_scores (tenant_id, job_id, version, fit_score, breakdown_json, "
+        "keywords_json, scored_at) VALUES (?, ?, 1, ?, '{}', '[]', ?)",
+        (LOCAL_TENANT, job_id, fit_score, "2024-01-01T00:00:00+00:00"),
     )
     conn.commit()
-    return url
+    return job_id
 
 
-def _seed_blocked_latest_score(conn: sqlite3.Connection, url: str, fit_score: int = 9) -> None:
+def _seed_blocked_latest_score(conn: sqlite3.Connection, job_id: JobId, fit_score: int = 9) -> None:
     conn.execute(
         """
         INSERT INTO job_scores (
-            job_url, version, tenant_id, fit_score, breakdown_json,
+            tenant_id, job_id, version, fit_score, breakdown_json,
             keywords_json, scored_at, correction_json, criteria_json, trace_json
-        ) VALUES (?, 1, 'local', ?, ?, '["python"]', ?, NULL, '{}', '{}')
+        ) VALUES ('local', ?, 2, ?, ?, '["python"]', ?, NULL, '{}', '{}')
         """,
         (
-            url,
+            job_id,
             fit_score,
             json.dumps(
                 {
@@ -783,48 +783,29 @@ def test_suppress_active_artifacts_hides_without_deleting_history(conn: sqlite3.
     assert suppressed.tailored_resume.status is ArtifactStatus.SUPPRESSED
     assert suppressed.tailored_resume.metadata["suppression"]["reason"] == "threshold_raised"
     row_count = conn.execute(
-        "SELECT COUNT(*) FROM job_materials_artifacts WHERE job_url = ?",
-        (url,),
+        "SELECT COUNT(*) FROM job_materials_artifacts WHERE tenant_id = ? AND job_id = ?",
+        (LOCAL_TENANT, url),
     ).fetchone()[0]
     assert row_count == 2
     assert repo.list_pending_tailor(LOCAL_TENANT, min_score=7) == [JobId(url)]
 
 
-def test_suppress_backfilled_legacy_job_makes_selectors_treat_paths_inactive(
-    tmp_path: Path,
+def test_suppress_active_artifacts_removes_canonical_paths_from_selectors(
+    conn: sqlite3.Connection,
 ) -> None:
-    db_path = tmp_path / "legacy.db"
-    conn = init_db(db_path)
-    url = "https://example.com/backfilled-suppress"
-    resume_path = str(tmp_path / "tailored.txt")
-    cover_path = str(tmp_path / "cover.txt")
-    (tmp_path / "tailored.txt").write_text("tailored", encoding="utf-8")
-    (tmp_path / "cover.txt").write_text("cover", encoding="utf-8")
-    conn.execute(
-        "INSERT INTO jobs (url, title, full_description, fit_score, tailored_resume_path, "
-        "tailored_at, cover_letter_path, cover_letter_at, discovered_at) "
-        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
-        (
-            url,
-            "Engineer",
-            "Description",
-            9,
-            resume_path,
-            "2024-01-01T00:00:00+00:00",
-            cover_path,
-            "2024-01-01T01:00:00+00:00",
-            "2024-01-01T00:00:00+00:00",
-        ),
-    )
-    conn.execute("DROP TABLE job_materials_artifacts")
-    conn.execute("DROP TABLE job_materials")
-    conn.commit()
-    ensure_materials_tables(conn)
+    locator = "https://example.com/canonical-suppress"
+    job_id = _seed_with_score(conn, locator)
     repo = SqliteMaterialsRepository(conn)
+    materials = _approved_with_pdf(job_id).with_cover_letter(
+        _make_artifact(ArtifactType.COVER_LETTER, path="/tmp/cover.txt"),
+        validation=ValidationResult.success(),
+        updated_at="2024-01-03T00:00:00+00:00",
+    )
+    repo.save(materials)
 
     repo.suppress_active_artifacts(
         LOCAL_TENANT,
-        JobId(url),
+        job_id,
         reason="threshold_raised",
         suppressed_at="2026-05-26T00:00:00+00:00",
     )
@@ -834,11 +815,11 @@ def test_suppress_backfilled_legacy_job_makes_selectors_treat_paths_inactive(
     assert stats["with_cover_letter"] == 0
     assert stats["untailored_eligible"] == 1
     pending_tailor = get_jobs_by_stage(conn=conn, stage="pending_tailor", min_score=7, limit=0)
-    assert [row["url"] for row in pending_tailor] == [url]
+    assert [row["url"] for row in pending_tailor] == [locator]
     assert pending_tailor[0]["tailored_resume_path"] is None
     assert pending_tailor[0]["cover_letter_path"] is None
     tailored = get_jobs_by_stage(conn=conn, stage="tailored")
-    assert url not in {row["url"] for row in tailored}
+    assert locator not in {row["url"] for row in tailored}
 
 
 # ---------------------------------------------------------------------------
@@ -931,83 +912,3 @@ def test_tailoring_policy_repository_resolves_current_concurrently(
         assert count == expected_count
     finally:
         close_connection(db_path)
-
-
-# ---------------------------------------------------------------------------
-# Backfill
-# ---------------------------------------------------------------------------
-
-
-def test_backfill_copies_legacy_columns_into_job_materials(tmp_path: Path) -> None:
-    db_path = tmp_path / "legacy.db"
-    conn = init_db(db_path)
-    conn.execute(
-        "INSERT INTO jobs (url, title, fit_score, tailored_resume_path, tailored_at, "
-        "cover_letter_path, cover_letter_at) "
-        "VALUES (?, ?, ?, ?, ?, ?, ?)",
-        (
-            "https://example.com/legacy",
-            "Engineer",
-            9,
-            str(tmp_path / "tailored.txt"),
-            "2023-12-01T00:00:00+00:00",
-            str(tmp_path / "cover.txt"),
-            "2023-12-02T00:00:00+00:00",
-        ),
-    )
-    # Touch the files so size_bytes is captured.
-    (tmp_path / "tailored.txt").write_text("tailored", encoding="utf-8")
-    (tmp_path / "cover.txt").write_text("dear hiring manager", encoding="utf-8")
-    # Drop and re-create so the backfill fires against the seeded row.
-    conn.execute("DROP TABLE job_materials_artifacts")
-    conn.execute("DROP TABLE job_materials")
-    conn.commit()
-    ensure_materials_tables(conn)
-
-    repo = SqliteMaterialsRepository(conn)
-    loaded = repo.load(LOCAL_TENANT, JobId("https://example.com/legacy"))
-    assert loaded is not None
-    assert loaded.generation == 1
-    assert loaded.tailored_resume is not None
-    assert loaded.tailored_resume.status is ArtifactStatus.APPROVED
-    assert loaded.cover_letter is not None
-    assert loaded.cover_letter.status is ArtifactStatus.APPROVED
-    assert loaded.tailored_resume.size_bytes is not None and loaded.tailored_resume.size_bytes > 0
-
-
-def test_backfill_is_idempotent(tmp_path: Path) -> None:
-    db_path = tmp_path / "legacy.db"
-    conn = init_db(db_path)
-    conn.execute(
-        "INSERT INTO jobs (url, fit_score, tailored_resume_path, tailored_at) "
-        "VALUES (?, ?, ?, ?)",
-        ("https://example.com/legacy", 9, str(tmp_path / "x.txt"), "2024-01-01T00:00:00+00:00"),
-    )
-    (tmp_path / "x.txt").write_text("ok", encoding="utf-8")
-    conn.execute("DROP TABLE job_materials_artifacts")
-    conn.execute("DROP TABLE job_materials")
-    conn.commit()
-    ensure_materials_tables(conn)
-    ensure_materials_tables(conn)  # second call is a no-op
-
-    count = conn.execute(
-        "SELECT COUNT(*) FROM job_materials WHERE job_url = ?",
-        ("https://example.com/legacy",),
-    ).fetchone()[0]
-    assert count == 1
-
-
-def test_backfill_skips_rows_without_legacy_path(tmp_path: Path) -> None:
-    db_path = tmp_path / "legacy.db"
-    conn = init_db(db_path)
-    conn.execute(
-        "INSERT INTO jobs (url, fit_score) VALUES (?, ?)",
-        ("https://example.com/none", 9),
-    )
-    conn.execute("DROP TABLE job_materials_artifacts")
-    conn.execute("DROP TABLE job_materials")
-    conn.commit()
-    ensure_materials_tables(conn)
-
-    count = conn.execute("SELECT COUNT(*) FROM job_materials").fetchone()[0]
-    assert count == 0

--- a/workers/automation/tests/test_materials_repository_v7.py
+++ b/workers/automation/tests/test_materials_repository_v7.py
@@ -1,0 +1,352 @@
+"""Exact-v7 aggregate persistence tests for SqliteMaterialsRepository."""
+
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from jobctrl.database import init_db
+from jobctrl.domain.identifiers import JobId
+from jobctrl.domain.materials import (
+    Artifact,
+    ArtifactStatus,
+    ArtifactType,
+    JudgeVerdict,
+    MaterialsSet,
+    RenderFormat,
+    ValidationResult,
+)
+from jobctrl.domain.tenant import LOCAL_TENANT, TenantId
+from jobctrl.infrastructure.materials import (
+    MaterialsGenerationConflict,
+    SqliteMaterialsRepository,
+    SqliteUnitOfWork,
+)
+
+JOB_ID = JobId("00000000-0000-4000-8000-000000000051")
+JOB_URL = "https://example.test/jobs/materials"
+OTHER_TENANT = TenantId("other")
+CREATED_AT = "2026-07-30T10:00:00+00:00"
+
+
+@pytest.fixture()
+def conn(tmp_path: Path) -> Iterator[sqlite3.Connection]:
+    connection = init_db(tmp_path / "jobctrl.db")
+    connection.execute("PRAGMA foreign_keys = ON")
+    connection.execute(
+        """
+        INSERT INTO jobs (tenant_id, job_id, url, title, site)
+        VALUES (?, ?, ?, ?, ?)
+        """,
+        (
+            str(LOCAL_TENANT),
+            str(JOB_ID),
+            JOB_URL,
+            "Materials Engineer",
+            "Example",
+        ),
+    )
+    connection.commit()
+    yield connection
+    connection.close()
+
+
+def _resume(
+    path: str,
+    *,
+    status: ArtifactStatus = ArtifactStatus.CANDIDATE,
+    layout_boxes: list[dict[str, object]] | None = None,
+) -> Artifact:
+    artifact = Artifact.create(
+        type=ArtifactType.TAILORED_RESUME,
+        path=path,
+        created_at=CREATED_AT,
+        render_format=RenderFormat.TEXT,
+        size_bytes=128,
+        metadata={"layout_boxes": layout_boxes or []},
+    )
+    return artifact.with_status(status)
+
+
+def _approved(
+    *,
+    tenant_id: TenantId = LOCAL_TENANT,
+    job_id: JobId = JOB_ID,
+    generation: int = 1,
+    path: str = "/tmp/resume.txt",
+    created_at: str = CREATED_AT,
+    lineage_id: str | None = None,
+    layout_boxes: list[dict[str, object]] | None = None,
+) -> MaterialsSet:
+    materials_kwargs: dict[str, object] = {}
+    if lineage_id is not None:
+        materials_kwargs["lineage_id"] = lineage_id
+    return MaterialsSet(
+        tenant_id=tenant_id,
+        job_id=job_id,
+        generation=generation,
+        created_at=created_at,
+        updated_at=created_at,
+        **materials_kwargs,
+    ).with_resume_attempt(
+        Artifact.create(
+            type=ArtifactType.TAILORED_RESUME,
+            path=path,
+            created_at=created_at,
+            render_format=RenderFormat.TEXT,
+            size_bytes=128,
+            metadata={"layout_boxes": layout_boxes or []},
+        ),
+        validation=ValidationResult.success(),
+        verdict=JudgeVerdict.passed(),
+        updated_at=created_at,
+    )
+
+
+def _rejected(generation: int) -> MaterialsSet:
+    return MaterialsSet(
+        tenant_id=LOCAL_TENANT,
+        job_id=JOB_ID,
+        generation=generation,
+        created_at=CREATED_AT,
+        updated_at=CREATED_AT,
+    ).with_resume_attempt(
+        _resume(
+            f"/tmp/rejected-{generation}.txt",
+            status=ArtifactStatus.REJECTED,
+        ),
+        validation=ValidationResult.failure(("unsupported claim",)),
+        verdict=JudgeVerdict.passed(),
+        updated_at=CREATED_AT,
+    )
+
+
+def test_exact_v7_round_trip_persists_artifact_and_layout_identity(
+    conn: sqlite3.Connection,
+) -> None:
+    repo = SqliteMaterialsRepository(conn)
+    box = {
+        "semantic_id": "experience:acme",
+        "page_number": 1,
+        "line_number": 12,
+        "text_excerpt": "Reduced latency.",
+        "left_pct": 10.0,
+        "top_pct": 20.0,
+        "width_pct": 30.0,
+        "height_pct": 4.0,
+        "audit_target": {"kind": "bullet"},
+    }
+
+    repo.save(_approved(layout_boxes=[box]))
+
+    loaded = repo.load(LOCAL_TENANT, JOB_ID)
+    assert loaded is not None
+    assert loaded.job_id == JOB_ID
+    assert loaded.tailored_resume is not None
+    assert loaded.tailored_resume.status is ArtifactStatus.APPROVED
+    artifact_identity = conn.execute("SELECT tenant_id, job_id, generation FROM job_materials_artifacts").fetchone()
+    layout_identity = conn.execute(
+        "SELECT tenant_id, job_id, generation, semantic_id FROM job_material_layout_boxes"
+    ).fetchone()
+    assert tuple(artifact_identity) == (str(LOCAL_TENANT), str(JOB_ID), 1)
+    assert tuple(layout_identity) == (
+        str(LOCAL_TENANT),
+        str(JOB_ID),
+        1,
+        "experience:acme",
+    )
+
+
+def test_same_generation_artifact_replacement_removes_prior_layout_boxes(
+    conn: sqlite3.Connection,
+) -> None:
+    repo = SqliteMaterialsRepository(conn)
+    prior = _approved(
+        path="/tmp/prior.txt",
+        layout_boxes=[
+            {
+                "semantic_id": "prior",
+                "page_number": 1,
+                "text_excerpt": "Prior text.",
+                "left_pct": 1,
+                "top_pct": 2,
+                "width_pct": 3,
+                "height_pct": 4,
+            }
+        ],
+    )
+    replacement = _approved(
+        path="/tmp/replacement.txt",
+        lineage_id=prior.lineage_id,
+        layout_boxes=[
+            {
+                "semantic_id": "replacement",
+                "page_number": 1,
+                "text_excerpt": "Replacement text.",
+                "left_pct": 5,
+                "top_pct": 6,
+                "width_pct": 7,
+                "height_pct": 8,
+            }
+        ],
+    )
+    assert prior.tailored_resume is not None
+    assert replacement.tailored_resume is not None
+    assert prior.tailored_resume.artifact_id != replacement.tailored_resume.artifact_id
+
+    repo.save(prior)
+    repo.save(replacement)
+
+    artifact_ids = tuple(
+        str(row["artifact_id"])
+        for row in conn.execute(
+            "SELECT artifact_id FROM job_material_layout_boxes WHERE tenant_id = ? AND job_id = ? AND generation = 1",
+            (str(LOCAL_TENANT), str(JOB_ID)),
+        ).fetchall()
+    )
+    assert artifact_ids == (replacement.tailored_resume.artifact_id,)
+
+
+def test_current_approved_ignores_newer_rejected_generation(
+    conn: sqlite3.Connection,
+) -> None:
+    repo = SqliteMaterialsRepository(conn)
+    repo.save(_approved())
+    repo.save(_rejected(2))
+
+    latest = repo.load(LOCAL_TENANT, JOB_ID)
+    current = repo.load_current_approved(LOCAL_TENANT, JOB_ID)
+    assert latest is not None and latest.generation == 2
+    assert current is not None and current.generation == 1
+
+
+def test_generation_allocation_is_monotonic(conn: sqlite3.Connection) -> None:
+    repo = SqliteMaterialsRepository(conn)
+    repo.save(_approved())
+
+    with pytest.raises(MaterialsGenerationConflict) as error:
+        repo.save(_approved(generation=3))
+
+    assert error.value.job_id == JOB_ID
+    assert error.value.expected == 2
+
+
+def test_stale_next_generation_writer_cannot_replace_winning_aggregate(
+    conn: sqlite3.Connection,
+) -> None:
+    repo = SqliteMaterialsRepository(conn)
+    repo.save(_approved())
+    first_snapshot = _approved(
+        generation=2,
+        path="/tmp/g2-first.txt",
+    )
+    stale_snapshot = _approved(
+        generation=2,
+        path="/tmp/g2-stale.txt",
+    )
+
+    with SqliteUnitOfWork(conn):
+        repo.save(first_snapshot)
+    with pytest.raises(MaterialsGenerationConflict) as error:
+        with SqliteUnitOfWork(conn):
+            repo.save(stale_snapshot)
+
+    persisted = repo.load(LOCAL_TENANT, JOB_ID, generation=2)
+    assert persisted is not None and persisted.tailored_resume is not None
+    assert persisted.created_at == stale_snapshot.created_at
+    assert persisted.lineage_id == first_snapshot.lineage_id
+    assert persisted.tailored_resume.path == "/tmp/g2-first.txt"
+    assert error.value.job_id == JOB_ID
+    assert error.value.expected == 3
+
+
+def test_repository_rejects_url_shaped_job_identity(
+    conn: sqlite3.Connection,
+) -> None:
+    repo = SqliteMaterialsRepository(conn)
+
+    with pytest.raises(ValueError, match="canonical UUID"):
+        repo.load(LOCAL_TENANT, JobId(JOB_URL))
+    with pytest.raises(ValueError, match="canonical UUID"):
+        repo.save(_approved(job_id=JobId(JOB_URL)))
+    assert conn.execute("SELECT COUNT(*) FROM job_materials").fetchone()[0] == 0
+
+
+def test_same_job_id_is_isolated_by_tenant(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        """
+        INSERT INTO jobs (tenant_id, job_id, url, title, site)
+        VALUES (?, ?, ?, ?, ?)
+        """,
+        (
+            str(OTHER_TENANT),
+            str(JOB_ID),
+            JOB_URL,
+            "Materials Engineer",
+            "Example",
+        ),
+    )
+    conn.commit()
+    repo = SqliteMaterialsRepository(conn)
+
+    repo.save(_approved(path="/tmp/local.txt"))
+    repo.save(
+        _approved(
+            tenant_id=OTHER_TENANT,
+            path="/tmp/other.txt",
+        )
+    )
+
+    local = repo.load(LOCAL_TENANT, JOB_ID)
+    other = repo.load(OTHER_TENANT, JOB_ID)
+    assert local is not None and local.tailored_resume is not None
+    assert other is not None and other.tailored_resume is not None
+    assert local.tailored_resume.path == "/tmp/local.txt"
+    assert other.tailored_resume.path == "/tmp/other.txt"
+    assert (
+        conn.execute(
+            "SELECT COUNT(*) FROM job_materials WHERE job_id = ?",
+            (str(JOB_ID),),
+        ).fetchone()[0]
+        == 2
+    )
+
+
+def test_failed_artifact_write_rolls_back_parent_row(
+    conn: sqlite3.Connection,
+) -> None:
+    conn.execute(
+        """
+        CREATE TEMP TRIGGER reject_material_artifact
+        BEFORE INSERT ON job_materials_artifacts
+        BEGIN
+            SELECT RAISE(ABORT, 'forced artifact failure');
+        END
+        """
+    )
+    repo = SqliteMaterialsRepository(conn)
+
+    with pytest.raises(sqlite3.IntegrityError, match="forced artifact failure"):
+        repo.save(_approved())
+
+    assert conn.in_transaction is False
+    assert conn.execute("SELECT COUNT(*) FROM job_materials").fetchone()[0] == 0
+    assert conn.execute("SELECT COUNT(*) FROM job_materials_artifacts").fetchone()[0] == 0
+
+
+def test_savepoint_does_not_commit_enclosing_unit_of_work(
+    conn: sqlite3.Connection,
+) -> None:
+    unit_of_work = SqliteUnitOfWork(conn)
+    repo = SqliteMaterialsRepository(conn, unit_of_work=unit_of_work)
+
+    with pytest.raises(RuntimeError, match="rollback outer transaction"):
+        with unit_of_work:
+            repo.save(_approved())
+            assert conn.in_transaction is True
+            raise RuntimeError("rollback outer transaction")
+
+    assert repo.load(LOCAL_TENANT, JOB_ID) is None

--- a/workers/automation/tests/test_materials_unit_of_work.py
+++ b/workers/automation/tests/test_materials_unit_of_work.py
@@ -48,6 +48,7 @@ from jobctrl.infrastructure.materials import (
 )
 
 JOB_URL = "https://example.com/job/uow"
+JOB_ID = JobId("00000000-0000-4000-8000-000000000044")
 
 
 # ---------------------------------------------------------------------------
@@ -59,9 +60,9 @@ JOB_URL = "https://example.com/job/uow"
 def conn(tmp_path: Path) -> sqlite3.Connection:
     connection = init_db(tmp_path / "jobctrl.db")
     connection.execute(
-        "INSERT INTO jobs (url, title, site, full_description, fit_score, discovered_at) "
-        "VALUES (?, ?, ?, ?, ?, ?)",
-        (JOB_URL, "Senior Backend Engineer", "Acme", "Own Python services.", 9, "2024-01-01T00:00:00+00:00"),
+        "INSERT INTO jobs (tenant_id, job_id, url, title, site, full_description, fit_score, discovered_at) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        (LOCAL_TENANT, JOB_ID, JOB_URL, "Senior Backend Engineer", "Acme", "Own Python services.", 9, "2024-01-01T00:00:00+00:00"),
     )
     connection.commit()
     return connection
@@ -93,7 +94,7 @@ def _approve_with_pdf(base: MaterialsSet, *, resume_path: str, pdf_path: str, up
 def _gen1_approved() -> MaterialsSet:
     base = MaterialsSet.initial(
         tenant_id=LOCAL_TENANT,
-        job_id=JobId(JOB_URL),
+        job_id=JOB_ID,
         created_at="2024-01-01T00:00:00+00:00",
     )
     return _approve_with_pdf(
@@ -107,7 +108,7 @@ def _gen1_approved() -> MaterialsSet:
 def _provenance_set(generation: int, *, artifact_id: str, text: str) -> BulletProvenanceSet:
     return BulletProvenanceSet(
         tenant_id=LOCAL_TENANT,
-        job_id=JobId(JOB_URL),
+        job_id=JOB_ID,
         generation=generation,
         artifact_id=artifact_id,
         bullets=(
@@ -152,7 +153,7 @@ class _FailAfterNSaves:
 def _next_generation_approved(materials_repo: SqliteMaterialsRepository) -> tuple[MaterialsSet, MaterialsSet]:
     """Return ``(superseded_gen1, approved_gen2)`` from the persisted gen 1."""
     superseded, fresh = MaterialsSetFactory.next_generation(
-        materials_repo.load(LOCAL_TENANT, JobId(JOB_URL)),
+        materials_repo.load(LOCAL_TENANT, JOB_ID),
         created_at="2024-01-03T00:00:00+00:00",
     )
     gen2 = _approve_with_pdf(
@@ -184,14 +185,14 @@ def test_flip_rolls_back_when_new_generation_save_fails(conn: sqlite3.Connection
             failing.save(superseded)
             failing.save(gen2)
 
-    current = materials.load_current_approved(LOCAL_TENANT, JobId(JOB_URL))
+    current = materials.load_current_approved(LOCAL_TENANT, JOB_ID)
     assert current is not None
     assert current.generation == 1
     assert current.is_resume_approved
     assert current.tailored_resume is not None
     assert current.tailored_resume.status is ArtifactStatus.APPROVED
     # The rolled-back generation 2 left no row behind.
-    assert materials.load(LOCAL_TENANT, JobId(JOB_URL), generation=2) is None
+    assert materials.load(LOCAL_TENANT, JOB_ID, generation=2) is None
 
 
 def test_flip_rolls_back_when_provenance_save_fails(conn: sqlite3.Connection) -> None:
@@ -204,7 +205,7 @@ def test_flip_rolls_back_when_provenance_save_fails(conn: sqlite3.Connection) ->
 
     materials.save(_gen1_approved())
     gen1_artifact_id = (
-        materials.load(LOCAL_TENANT, JobId(JOB_URL)).tailored_resume.artifact_id  # type: ignore[union-attr]
+        materials.load(LOCAL_TENANT, JOB_ID).tailored_resume.artifact_id  # type: ignore[union-attr]
     )
     provenance.save(_provenance_set(1, artifact_id=gen1_artifact_id, text="Gen 1 grounded bullet."))
 
@@ -221,14 +222,14 @@ def test_flip_rolls_back_when_provenance_save_fails(conn: sqlite3.Connection) ->
             )
 
     # Preservation invariant: generation 1 is still the current approved resume.
-    current = materials.load_current_approved(LOCAL_TENANT, JobId(JOB_URL))
+    current = materials.load_current_approved(LOCAL_TENANT, JOB_ID)
     assert current is not None
     assert current.generation == 1
     assert current.is_resume_approved
     # Generation 1 provenance survived; generation 2 orphaned nothing.
-    assert provenance.load(LOCAL_TENANT, JobId(JOB_URL), generation=1) is not None
-    assert provenance.load(LOCAL_TENANT, JobId(JOB_URL), generation=2) is None
-    assert materials.load(LOCAL_TENANT, JobId(JOB_URL), generation=2) is None
+    assert provenance.load(LOCAL_TENANT, JOB_ID, generation=1) is not None
+    assert provenance.load(LOCAL_TENANT, JOB_ID, generation=2) is None
+    assert materials.load(LOCAL_TENANT, JOB_ID, generation=2) is None
 
 
 def test_flip_commits_once_on_success(conn: sqlite3.Connection) -> None:
@@ -249,12 +250,12 @@ def test_flip_commits_once_on_success(conn: sqlite3.Connection) -> None:
             _provenance_set(2, artifact_id=gen2_artifact_id, text="Gen 2 grounded bullet.")
         )
 
-    current = materials.load_current_approved(LOCAL_TENANT, JobId(JOB_URL))
+    current = materials.load_current_approved(LOCAL_TENANT, JOB_ID)
     assert current is not None and current.generation == 2 and current.is_resume_approved
-    assert provenance.load(LOCAL_TENANT, JobId(JOB_URL), generation=2) is not None
+    assert provenance.load(LOCAL_TENANT, JOB_ID, generation=2) is not None
     # Generation 1 was superseded, so it is no longer the current approved resume,
     # but its row is retained as audit history.
-    assert materials.load(LOCAL_TENANT, JobId(JOB_URL), generation=1) is not None
+    assert materials.load(LOCAL_TENANT, JOB_ID, generation=1) is not None
 
 
 def test_flip_holds_one_explicit_transaction_and_locks_out_competitors(
@@ -296,9 +297,9 @@ def test_flip_holds_one_explicit_transaction_and_locks_out_competitors(
     finally:
         competitor.close()
 
-    current = materials.load_current_approved(LOCAL_TENANT, JobId(JOB_URL))
+    current = materials.load_current_approved(LOCAL_TENANT, JOB_ID)
     assert current is not None and current.generation == 2 and current.is_resume_approved
-    assert provenance.load(LOCAL_TENANT, JobId(JOB_URL), generation=2) is not None
+    assert provenance.load(LOCAL_TENANT, JOB_ID, generation=2) is not None
 
 
 # ---------------------------------------------------------------------------
@@ -322,7 +323,7 @@ def test_without_unit_of_work_new_generation_failure_loses_current_resume(
         failing.save(superseded)  # commits immediately
         failing.save(gen2)  # never runs
 
-    assert materials.load_current_approved(LOCAL_TENANT, JobId(JOB_URL)) is None
+    assert materials.load_current_approved(LOCAL_TENANT, JOB_ID) is None
 
 
 def test_without_unit_of_work_provenance_failure_orphans_approved_generation(
@@ -343,6 +344,6 @@ def test_without_unit_of_work_provenance_failure_orphans_approved_generation(
         materials.save(gen2)  # commits
         failing_provenance.save(_provenance_set(2, artifact_id="art-gen2", text="orphan"))
 
-    current = materials.load_current_approved(LOCAL_TENANT, JobId(JOB_URL))
+    current = materials.load_current_approved(LOCAL_TENANT, JOB_ID)
     assert current is not None and current.generation == 2
-    assert provenance.load(LOCAL_TENANT, JobId(JOB_URL), generation=2) is None
+    assert provenance.load(LOCAL_TENANT, JOB_ID, generation=2) is None


### PR DESCRIPTION
## Summary
- persist material aggregates, artifacts, and layout boxes with exact tenant-scoped JobId keys
- reject URL-shaped identities and remove runtime schema/table compatibility from the converted aggregate path
- enforce atomic generation allocation and collision-resistant lineage checks so stale writers cannot replace a winning generation
- preserve approved-generation selection, tenant isolation, artifact replacement cleanup, and enclosing transaction boundaries

## Scope
This is one reviewable slice in the v7 cutover stack. Queue selectors and resume-template assignment resolution remain in later PRs.

## Validation
- `workers/automation/.venv/bin/pytest -q workers/automation/tests/test_materials_use_cases.py workers/automation/tests/test_materials_repository_v7.py workers/automation/tests/test_exact_v7_schema.py` (86 passed)
- `workers/automation/.venv/bin/ruff check workers/automation/src/jobctrl/domain/materials/aggregate.py workers/automation/src/jobctrl/domain/ports/materials.py workers/automation/src/jobctrl/infrastructure/materials/sqlite_repository.py workers/automation/tests/test_materials_repository_v7.py`
- `git diff --check`
- independent review: PASS, zero findings