### PR TITLE
fix(api): enforce exact v7 schema manifest

### DIFF
--- a/apps/api/src/db.ts
+++ b/apps/api/src/db.ts
@@ -1,6 +1,8 @@
 import fs from "node:fs";
 import Database from "better-sqlite3";
 
+import { EXACT_V7_SCHEMA_MANIFEST, hasExactV7SchemaManifest } from "./schema-manifest.js";
+
 export type SqliteDatabase = Database.Database;
 export type SqliteValue = string | number | bigint | null;
 
@@ -9,7 +11,7 @@ export type SqliteValue = string | number | bigint | null;
 // writer that stamps ``PRAGMA user_version``; the API only admits the exact
 // migrated schema shape. Bump both constants together whenever the schema
 // shape changes.
-export const SUPPORTED_SCHEMA_VERSION = 7;
+export const SUPPORTED_SCHEMA_VERSION = EXACT_V7_SCHEMA_MANIFEST.version;
 
 export class IncompatibleSchemaVersionError extends Error {
   constructor(current: number) {
@@ -23,6 +25,16 @@ export class IncompatibleSchemaVersionError extends Error {
   }
 }
 
+export class IncompatibleSchemaManifestError extends Error {
+  constructor() {
+    super(
+      "JobCtrl database schema does not match the exact v7 manifest; restore "
+        + "a compatible backup or complete the documented stopped-runtime migration.",
+    );
+    this.name = "IncompatibleSchemaManifestError";
+  }
+}
+
 function assertExactSchemaVersion(db: SqliteDatabase): void {
   // The API never writes ``user_version`` — the Python worker owns stamping so
   // the schema marker has a single writer. The v6-to-v7 migration is the only
@@ -31,6 +43,10 @@ function assertExactSchemaVersion(db: SqliteDatabase): void {
   if (current !== SUPPORTED_SCHEMA_VERSION) {
     db.close();
     throw new IncompatibleSchemaVersionError(current);
+  }
+  if (!hasExactV7SchemaManifest(db)) {
+    db.close();
+    throw new IncompatibleSchemaManifestError();
   }
 }
 

--- a/apps/api/src/schema-manifest.ts
+++ b/apps/api/src/schema-manifest.ts
@@ -1,0 +1,94 @@
+import { createHash } from "node:crypto";
+import type Database from "better-sqlite3";
+
+export type SchemaManifest = {
+  version: number;
+  objectCount: number;
+  tableCount: number;
+  fingerprint: string;
+};
+
+// Checked against the Python worker's authoritative
+// ``infrastructure/migrations/schema_manifest.py`` by the API schema guard
+// tests. Keep the raw SQLite DDL fingerprint exact; normalization would admit
+// a different schema.
+export const EXACT_V7_SCHEMA_MANIFEST: SchemaManifest = {
+  version: 7,
+  objectCount: 197,
+  tableCount: 101,
+  fingerprint: "14e3ee939ca12ae4535fca7ab031671976b2375c911a51ada89851113bb5e4af",
+};
+
+type SqliteMasterRow = [type: string, name: string, tableName: string, sql: string];
+
+type SqliteMasterQueryRow = {
+  type: unknown;
+  name: unknown;
+  tbl_name: unknown;
+  sql: unknown;
+};
+
+const SQLITE_OWNED_SCHEMA_ROWS: readonly SqliteMasterRow[] = [
+  ["table", "sqlite_sequence", "sqlite_sequence", "CREATE TABLE sqlite_sequence(name,seq)"],
+  ["table", "sqlite_stat1", "sqlite_stat1", "CREATE TABLE sqlite_stat1(tbl,idx,stat)"],
+  ["table", "sqlite_stat4", "sqlite_stat4", "CREATE TABLE sqlite_stat4(tbl,idx,neq,nlt,ndlt,sample)"],
+];
+
+function isSqliteOwnedSchemaRow(row: SqliteMasterRow): boolean {
+  const [objectType, name, tableName, sql] = row;
+  if (objectType === "index" && name.startsWith("sqlite_autoindex_") && tableName && sql === "") {
+    return true;
+  }
+  return SQLITE_OWNED_SCHEMA_ROWS.some((owned) => owned.every((value, index) => value === row[index]));
+}
+
+function ensureAsciiJson(value: unknown): string {
+  return JSON.stringify(value).replace(/[\u0080-\u{10ffff}]/gu, (character) => {
+    const codePoint = character.codePointAt(0);
+    if (codePoint === undefined || codePoint <= 0xffff) {
+      return `\\u${character.charCodeAt(0).toString(16).padStart(4, "0")}`;
+    }
+    const offset = codePoint - 0x10000;
+    const high = 0xd800 + (offset >> 10);
+    const low = 0xdc00 + (offset & 0x3ff);
+    return `\\u${high.toString(16)}\\u${low.toString(16)}`;
+  });
+}
+
+export function schemaManifest(
+  db: Pick<Database.Database, "prepare">,
+  version: number,
+): SchemaManifest {
+  const rows = db.prepare(
+    `
+      SELECT type, name, tbl_name, COALESCE(sql, '') AS sql
+      FROM sqlite_master
+      ORDER BY type, name
+    `,
+  ).all() as SqliteMasterQueryRow[];
+  const dump = rows
+    .map((row): SqliteMasterRow => [
+      String(row.type),
+      String(row.name),
+      String(row.tbl_name),
+      String(row.sql),
+    ])
+    .filter((row) => !isSqliteOwnedSchemaRow(row));
+
+  return {
+    version,
+    objectCount: dump.length,
+    tableCount: dump.filter(([objectType]) => objectType === "table").length,
+    fingerprint: createHash("sha256").update(ensureAsciiJson(dump)).digest("hex"),
+  };
+}
+
+export function hasExactV7SchemaManifest(db: Pick<Database.Database, "prepare">): boolean {
+  const observed = schemaManifest(db, EXACT_V7_SCHEMA_MANIFEST.version);
+  return (
+    observed.version === EXACT_V7_SCHEMA_MANIFEST.version
+    && observed.objectCount === EXACT_V7_SCHEMA_MANIFEST.objectCount
+    && observed.tableCount === EXACT_V7_SCHEMA_MANIFEST.tableCount
+    && observed.fingerprint === EXACT_V7_SCHEMA_MANIFEST.fingerprint
+  );
+}

--- a/apps/api/src/schema-manifest.ts
+++ b/apps/api/src/schema-manifest.ts
@@ -16,7 +16,7 @@ export const EXACT_V7_SCHEMA_MANIFEST: SchemaManifest = {
   version: 7,
   objectCount: 197,
   tableCount: 101,
-  fingerprint: "14e3ee939ca12ae4535fca7ab031671976b2375c911a51ada89851113bb5e4af",
+  fingerprint: "b24a3c1c366b40a8acf3b27f4eb237ef63e52d7ebc55166b7df58970afbd0d80",
 };
 
 type SqliteMasterRow = [type: string, name: string, tableName: string, sql: string];

--- a/apps/api/test/schema-version-guard.test.ts
+++ b/apps/api/test/schema-version-guard.test.ts
@@ -149,7 +149,7 @@ describe("schema version guard at DB open", () => {
       version: SUPPORTED_SCHEMA_VERSION,
       objectCount: 197,
       tableCount: 101,
-      fingerprint: "14e3ee939ca12ae4535fca7ab031671976b2375c911a51ada89851113bb5e4af",
+      fingerprint: "b24a3c1c366b40a8acf3b27f4eb237ef63e52d7ebc55166b7df58970afbd0d80",
     });
   });
 });

--- a/apps/api/test/schema-version-guard.test.ts
+++ b/apps/api/test/schema-version-guard.test.ts
@@ -2,9 +2,11 @@ import { describe, expect, it } from "vitest";
 import path from "node:path";
 import os from "node:os";
 import fs from "node:fs";
+import { fileURLToPath } from "node:url";
 import Database from "better-sqlite3";
 
 import {
+  IncompatibleSchemaManifestError,
   IncompatibleSchemaVersionError,
   SUPPORTED_SCHEMA_VERSION,
   migrateLegacyJobTables,
@@ -12,12 +14,27 @@ import {
   openReadOnlyDatabase,
   tableExists,
 } from "../src/db.js";
+import { EXACT_V7_SCHEMA_MANIFEST } from "../src/schema-manifest.js";
 
 function makeDbWithUserVersion(userVersion: number): { dbPath: string; cleanup: () => void } {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "jobctrl-api-schema-version-"));
   const dbPath = path.join(dir, "jobs.db");
   const db = new Database(dbPath);
   db.pragma(`user_version = ${userVersion}`);
+  db.close();
+  return { dbPath, cleanup: () => fs.rmSync(dir, { recursive: true, force: true }) };
+}
+
+function makeExactV7Database(): { dbPath: string; cleanup: () => void } {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "jobctrl-api-exact-v7-"));
+  const dbPath = path.join(dir, "jobs.db");
+  const schemaPath = path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    "../../../workers/automation/src/jobctrl/infrastructure/migrations/schema_v7.sql",
+  );
+  const db = new Database(dbPath);
+  db.exec(fs.readFileSync(schemaPath, "utf8"));
+  db.pragma(`user_version = ${SUPPORTED_SCHEMA_VERSION}`);
   db.close();
   return { dbPath, cleanup: () => fs.rmSync(dir, { recursive: true, force: true }) };
 }
@@ -61,8 +78,8 @@ describe("schema version guard at DB open", () => {
     }
   });
 
-  it("opens a database stamped at exactly the supported version", () => {
-    const { dbPath, cleanup } = makeDbWithUserVersion(SUPPORTED_SCHEMA_VERSION);
+  it("opens the exact v7 schema", () => {
+    const { dbPath, cleanup } = makeExactV7Database();
     try {
       openDatabase(dbPath).close();
       openReadOnlyDatabase(dbPath).close();
@@ -71,7 +88,24 @@ describe("schema version guard at DB open", () => {
     }
   });
 
-  it("does not run the legacy tombstone migration on writable open", () => {
+  it("rejects a merely stamped v7 database before runtime writes", () => {
+    const { dbPath, cleanup } = makeDbWithUserVersion(SUPPORTED_SCHEMA_VERSION);
+    try {
+      expect(() => openDatabase(dbPath)).toThrow(IncompatibleSchemaManifestError);
+      expect(() => openReadOnlyDatabase(dbPath)).toThrow(IncompatibleSchemaManifestError);
+      const probe = new Database(dbPath, { readonly: true });
+      try {
+        expect(probe.pragma("user_version", { simple: true })).toBe(SUPPORTED_SCHEMA_VERSION);
+        expect(tableExists(probe, "jobs")).toBe(false);
+      } finally {
+        probe.close();
+      }
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("rejects a malformed v7 database without running legacy tombstone migration", () => {
     const { dbPath, cleanup } = makeDbWithUserVersion(SUPPORTED_SCHEMA_VERSION);
     try {
       const token = "job" + "ctl";
@@ -85,16 +119,38 @@ describe("schema version guard at DB open", () => {
       `);
       seed.close();
 
-      const db = openDatabase(dbPath);
+      expect(() => openDatabase(dbPath)).toThrow(IncompatibleSchemaManifestError);
+      expect(() => openReadOnlyDatabase(dbPath)).toThrow(IncompatibleSchemaManifestError);
+      const probe = new Database(dbPath, { readonly: true });
       try {
-        expect(tableExists(db, `${token}_hidden_jobs`)).toBe(true);
-        expect(tableExists(db, "jobctrl_hidden_jobs")).toBe(false);
+        expect(probe.pragma("user_version", { simple: true })).toBe(SUPPORTED_SCHEMA_VERSION);
+        expect(tableExists(probe, `${token}_hidden_jobs`)).toBe(true);
+        expect(tableExists(probe, "jobctrl_hidden_jobs")).toBe(false);
       } finally {
-        db.close();
+        probe.close();
       }
     } finally {
       cleanup();
     }
+  });
+
+  it("keeps the checked TypeScript manifest aligned with the Python owner", () => {
+    const pythonManifestPath = path.resolve(
+      path.dirname(fileURLToPath(import.meta.url)),
+      "../../../workers/automation/src/jobctrl/infrastructure/migrations/schema_manifest.py",
+    );
+    const pythonManifest = fs.readFileSync(pythonManifestPath, "utf8");
+
+    expect(pythonManifest).toContain("version=7,");
+    expect(pythonManifest).toContain("object_count=197,");
+    expect(pythonManifest).toContain("table_count=101,");
+    expect(pythonManifest).toContain(`fingerprint=\"${EXACT_V7_SCHEMA_MANIFEST.fingerprint}\",`);
+    expect(EXACT_V7_SCHEMA_MANIFEST).toEqual({
+      version: SUPPORTED_SCHEMA_VERSION,
+      objectCount: 197,
+      tableCount: 101,
+      fingerprint: "14e3ee939ca12ae4535fca7ab031671976b2375c911a51ada89851113bb5e4af",
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
- compute the exact SQLite schema manifest in TypeScript using the canonical object ordering and exclusions
- reject databases whose v7 object/table counts or fingerprint do not match the Python contract
- close rejected connections before any runtime mutation
- verify TypeScript manifest parity against the canonical schema and Python manifest constants

## Scope
This is the TypeScript admission-manifest slice only. Health-route readiness remains a later PR.

## Validation
- `corepack pnpm --filter @jobctrl/api exec vitest run test/schema-version-guard.test.ts` (13 passed)
- `corepack pnpm --filter @jobctrl/api check`
- `git diff --check`
- independent review: PASS, zero findings