### PR TITLE
refactor(materials): key queue selectors by JobId

### DIFF
--- a/workers/automation/src/jobctrl/domain/ports/materials.py
+++ b/workers/automation/src/jobctrl/domain/ports/materials.py
@@ -87,7 +87,7 @@ class MaterialsRepository(Protocol):
         tailored resume is approved. Rejected re-tailor attempts remain history
         and must not hide the last accepted artifact from downstream stages.
 
-    The selectors (``list_pending_*``) return job URLs, not full
+    The selectors (``list_pending_*``) return canonical JobIds, not full
     aggregates, so the queue runner can decide whether to load each one.
     """
 
@@ -135,7 +135,7 @@ class MaterialsRepository(Protocol):
         limit: int = 0,
         retailor: bool = False,
     ) -> list[JobId]:
-        """Return job URLs eligible for tailoring.
+        """Return canonical JobIds eligible for tailoring.
 
         Eligibility: full description present, ``fit_score >= min_score``,
         and either no MaterialsSet exists yet OR ``retailor=True`` (the
@@ -151,7 +151,7 @@ class MaterialsRepository(Protocol):
         min_score: int = 7,
         limit: int = 0,
     ) -> list[JobId]:
-        """Return job URLs that have an approved tailored resume but no
+        """Return canonical JobIds that have an approved tailored resume but no
         approved cover letter in the latest generation."""
         ...
 
@@ -161,7 +161,7 @@ class MaterialsRepository(Protocol):
         *,
         limit: int = 0,
     ) -> list[JobId]:
-        """Return job URLs whose latest generation has text artifacts but
+        """Return canonical JobIds whose latest generation has text artifacts but
         is missing one or more PDFs."""
         ...
 

--- a/workers/automation/src/jobctrl/infrastructure/materials/sqlite_repository.py
+++ b/workers/automation/src/jobctrl/infrastructure/materials/sqlite_repository.py
@@ -229,7 +229,7 @@ class SqliteMaterialsRepository:
         limit: int = 0,
         retailor: bool = False,
     ) -> list[JobId]:
-        """Return job URLs ready for tailoring per §4.5 lifecycle.
+        """Return JobIds ready for tailoring per §4.5 lifecycle.
 
         Eligibility:
 
@@ -242,67 +242,66 @@ class SqliteMaterialsRepository:
         will mint a new generation when it picks them up.
         """
         min_score = effective_tailoring_min_score(min_score)
-        params: list[Any] = [str(tenant_id)]
-        # Reuse the score subquery shape used elsewhere; keep it inline so
-        # this adapter stays self-contained.
-        score_join = (
-            "LEFT JOIN ("
-            "SELECT s.job_url AS sj_job_url, s.fit_score AS sj_fit_score, "
+        where = (
+            "AND approved_resumes.job_id IS NULL "
+            if not retailor
+            else ""
+        )
+        sql = (
+            "WITH latest_scores AS ("
+            "SELECT tenant_id, job_id, MAX(version) AS version "
+            "FROM job_scores WHERE tenant_id = ? "
+            "GROUP BY tenant_id, job_id"
+            "), scored_jobs AS ("
+            "SELECT s.tenant_id, s.job_id, s.fit_score, "
             "CASE WHEN json_valid(s.breakdown_json) "
             "THEN LOWER(COALESCE(CAST(json_extract(s.breakdown_json, '$.eligibility.status') AS TEXT), '')) "
-            "ELSE '' END AS sj_eligibility_status, "
+            "ELSE '' END AS eligibility_status, "
             "CASE WHEN json_valid(s.breakdown_json) "
             "THEN COALESCE("
             "json_array_length(s.breakdown_json, '$.eligibility.hard_blockers'), "
             "json_array_length(s.breakdown_json, '$.eligibility.hardBlockers'), "
             "json_array_length(s.breakdown_json, '$.eligibility.blockers'), "
-            "0) ELSE 0 END AS sj_hard_blocker_count "
+            "0) ELSE 0 END AS hard_blocker_count "
             "FROM job_scores s "
-            "INNER JOIN ("
-            "SELECT job_url, MAX(version) AS max_version FROM job_scores GROUP BY job_url"
-            ") latest ON latest.job_url = s.job_url AND latest.max_version = s.version "
-            "WHERE s.tenant_id = ?"
-            ") sj ON sj.sj_job_url = j.url"
-        )
-        materials_join = (
-            "LEFT JOIN ("
-            "SELECT DISTINCT m.job_url AS mj_job_url, tr.status AS mj_resume_status "
+            "INNER JOIN latest_scores latest "
+            "ON latest.tenant_id = s.tenant_id "
+            "AND latest.job_id = s.job_id "
+            "AND latest.version = s.version"
+            "), approved_resumes AS ("
+            "SELECT DISTINCT m.tenant_id, m.job_id "
             "FROM job_materials m "
-            "INNER JOIN job_materials_artifacts tr ON tr.job_url = m.job_url "
+            "INNER JOIN job_materials_artifacts tr "
+            "ON tr.tenant_id = m.tenant_id "
+            "AND tr.job_id = m.job_id "
             "AND tr.generation = m.generation "
             "AND tr.artifact_type = 'tailored_resume' "
             "AND tr.status = 'approved' "
             "WHERE m.tenant_id = ?"
-            ") mj ON mj.mj_job_url = j.url"
+            ") "
+            "SELECT j.job_id "
+            "FROM jobs j "
+            "INNER JOIN job_enrichments e "
+            "ON e.tenant_id = j.tenant_id AND e.job_id = j.job_id "
+            "INNER JOIN scored_jobs s "
+            "ON s.tenant_id = j.tenant_id AND s.job_id = j.job_id "
+            "LEFT JOIN approved_resumes "
+            "ON approved_resumes.tenant_id = j.tenant_id "
+            "AND approved_resumes.job_id = j.job_id "
+            "WHERE j.tenant_id = ? "
+            "AND e.full_description IS NOT NULL "
+            "AND s.fit_score >= ? "
+            "AND s.eligibility_status != 'blocked' "
+            "AND s.hard_blocker_count = 0 "
+            f"{where}"
+            "ORDER BY s.fit_score DESC, j.discovered_at DESC"
         )
-        params.append(str(tenant_id))
-
-        if retailor:
-            where = (
-                "j.full_description IS NOT NULL "
-                "AND COALESCE(sj.sj_fit_score, j.fit_score) >= ? "
-                "AND COALESCE(sj.sj_eligibility_status, '') != 'blocked' "
-                "AND COALESCE(sj.sj_hard_blocker_count, 0) = 0"
-            )
-        else:
-            where = (
-                "j.full_description IS NOT NULL "
-                "AND COALESCE(sj.sj_fit_score, j.fit_score) >= ? "
-                "AND COALESCE(sj.sj_eligibility_status, '') != 'blocked' "
-                "AND COALESCE(sj.sj_hard_blocker_count, 0) = 0 "
-                "AND mj.mj_resume_status IS NULL"
-            )
-        params.append(int(min_score))
-        sql = (
-            f"SELECT j.url FROM jobs j {score_join} {materials_join} "
-            f"WHERE {where} "
-            "ORDER BY COALESCE(sj.sj_fit_score, j.fit_score) DESC, j.discovered_at DESC"
-        )
+        params: list[Any] = [str(tenant_id), str(tenant_id), str(tenant_id), int(min_score)]
         if limit > 0:
             sql += " LIMIT ?"
             params.append(limit)
         rows = self._conn.execute(sql, params).fetchall()
-        return [JobId(row[0]) for row in rows if row[0]]
+        return [canonical_job_id(str(row[0])) for row in rows]
 
     def list_pending_cover(
         self,
@@ -311,68 +310,72 @@ class SqliteMaterialsRepository:
         min_score: int = 7,
         limit: int = 0,
     ) -> list[JobId]:
-        """Return job URLs whose current approved generation has an approved
+        """Return JobIds whose current approved generation has an approved
         tailored resume PDF but no approved cover letter."""
         min_score = effective_tailoring_min_score(min_score)
-        params: list[Any] = [str(tenant_id)]
-        score_join = (
-            "LEFT JOIN ("
-            "SELECT s.job_url AS sj_job_url, s.fit_score AS sj_fit_score, "
+        sql = (
+            "WITH latest_scores AS ("
+            "SELECT tenant_id, job_id, MAX(version) AS version "
+            "FROM job_scores WHERE tenant_id = ? "
+            "GROUP BY tenant_id, job_id"
+            "), scored_jobs AS ("
+            "SELECT s.tenant_id, s.job_id, s.fit_score, "
             "CASE WHEN json_valid(s.breakdown_json) "
             "THEN LOWER(COALESCE(CAST(json_extract(s.breakdown_json, '$.eligibility.status') AS TEXT), '')) "
-            "ELSE '' END AS sj_eligibility_status, "
+            "ELSE '' END AS eligibility_status, "
             "CASE WHEN json_valid(s.breakdown_json) "
             "THEN COALESCE("
             "json_array_length(s.breakdown_json, '$.eligibility.hard_blockers'), "
             "json_array_length(s.breakdown_json, '$.eligibility.hardBlockers'), "
             "json_array_length(s.breakdown_json, '$.eligibility.blockers'), "
-            "0) ELSE 0 END AS sj_hard_blocker_count "
+            "0) ELSE 0 END AS hard_blocker_count "
             "FROM job_scores s "
-            "INNER JOIN ("
-            "SELECT job_url, MAX(version) AS max_version FROM job_scores GROUP BY job_url"
-            ") latest ON latest.job_url = s.job_url AND latest.max_version = s.version "
-            "WHERE s.tenant_id = ?"
-            ") sj ON sj.sj_job_url = j.url"
-        )
-        params.append(str(tenant_id))
-        materials_join = (
-            "INNER JOIN ("
-            "SELECT m.job_url AS mj_job_url, m.generation AS mj_gen, "
-            "tr.status AS mj_resume_status, rpdf.status AS mj_resume_pdf_status, "
-            "cl.status AS mj_cover_status "
-            "FROM job_materials m "
-            "INNER JOIN ("
-            "SELECT job_url, MAX(generation) AS mg "
+            "INNER JOIN latest_scores latest "
+            "ON latest.tenant_id = s.tenant_id "
+            "AND latest.job_id = s.job_id "
+            "AND latest.version = s.version"
+            "), approved_resume_generations AS ("
+            "SELECT tenant_id, job_id, MAX(generation) AS generation "
             "FROM job_materials_artifacts "
-            "WHERE artifact_type = 'tailored_resume' AND status = 'approved' "
-            "GROUP BY job_url"
-            ") latest ON latest.job_url = m.job_url AND latest.mg = m.generation "
-            "INNER JOIN job_materials_artifacts tr ON tr.job_url = m.job_url "
-            "AND tr.generation = m.generation AND tr.artifact_type = 'tailored_resume' "
-            "AND tr.status = 'approved' "
-            "INNER JOIN job_materials_artifacts rpdf ON rpdf.job_url = m.job_url "
-            "AND rpdf.generation = m.generation AND rpdf.artifact_type = 'resume_pdf' "
-            "AND rpdf.status = 'approved' "
-            "LEFT JOIN job_materials_artifacts cl ON cl.job_url = m.job_url "
-            "AND cl.generation = m.generation AND cl.artifact_type = 'cover_letter' "
-            "AND cl.status = 'approved' "
-            "WHERE m.tenant_id = ?"
-            ") mj ON mj.mj_job_url = j.url"
+            "WHERE tenant_id = ? "
+            "AND artifact_type = 'tailored_resume' AND status = 'approved' "
+            "GROUP BY tenant_id, job_id"
+            ") "
+            "SELECT j.job_id "
+            "FROM jobs j "
+            "INNER JOIN scored_jobs s "
+            "ON s.tenant_id = j.tenant_id AND s.job_id = j.job_id "
+            "INNER JOIN approved_resume_generations current "
+            "ON current.tenant_id = j.tenant_id AND current.job_id = j.job_id "
+            "INNER JOIN job_materials m "
+            "ON m.tenant_id = current.tenant_id "
+            "AND m.job_id = current.job_id "
+            "AND m.generation = current.generation "
+            "INNER JOIN job_materials_artifacts tr "
+            "ON tr.tenant_id = m.tenant_id AND tr.job_id = m.job_id "
+            "AND tr.generation = m.generation "
+            "AND tr.artifact_type = 'tailored_resume' AND tr.status = 'approved' "
+            "INNER JOIN job_materials_artifacts rpdf "
+            "ON rpdf.tenant_id = m.tenant_id AND rpdf.job_id = m.job_id "
+            "AND rpdf.generation = m.generation "
+            "AND rpdf.artifact_type = 'resume_pdf' AND rpdf.status = 'approved' "
+            "LEFT JOIN job_materials_artifacts cl "
+            "ON cl.tenant_id = m.tenant_id AND cl.job_id = m.job_id "
+            "AND cl.generation = m.generation "
+            "AND cl.artifact_type = 'cover_letter' AND cl.status = 'approved' "
+            "WHERE j.tenant_id = ? "
+            "AND s.fit_score >= ? "
+            "AND s.eligibility_status != 'blocked' "
+            "AND s.hard_blocker_count = 0 "
+            "AND cl.artifact_id IS NULL "
+            "ORDER BY s.fit_score DESC, j.discovered_at DESC"
         )
-        params.append(int(min_score))
-        sql = (
-            f"SELECT j.url FROM jobs j {score_join} {materials_join} "
-            "WHERE COALESCE(sj.sj_fit_score, j.fit_score) >= ? "
-            "AND COALESCE(sj.sj_eligibility_status, '') != 'blocked' "
-            "AND COALESCE(sj.sj_hard_blocker_count, 0) = 0 "
-            "AND mj.mj_cover_status IS NULL "
-            "ORDER BY COALESCE(sj.sj_fit_score, j.fit_score) DESC, j.discovered_at DESC"
-        )
+        params: list[Any] = [str(tenant_id), str(tenant_id), str(tenant_id), int(min_score)]
         if limit > 0:
             sql += " LIMIT ?"
             params.append(limit)
         rows = self._conn.execute(sql, params).fetchall()
-        return [JobId(row[0]) for row in rows if row[0]]
+        return [canonical_job_id(str(row[0])) for row in rows]
 
     def list_pending_pdf(
         self,
@@ -380,34 +383,40 @@ class SqliteMaterialsRepository:
         *,
         limit: int = 0,
     ) -> list[JobId]:
-        """Return job URLs whose current approved generation has text artifacts but
+        """Return JobIds whose current approved generation has text artifacts but
         is missing one or more PDFs."""
-        params: list[Any] = [str(tenant_id)]
         sql = (
-            "SELECT m.job_url FROM job_materials m "
-            "INNER JOIN ("
-            "SELECT job_url, MAX(generation) AS mg "
+            "WITH latest_text_generations AS ("
+            "SELECT tenant_id, job_id, MAX(generation) AS generation "
             "FROM job_materials_artifacts "
-            "WHERE status = 'approved' "
+            "WHERE tenant_id = ? AND status = 'approved' "
             "AND artifact_type IN ('tailored_resume', 'cover_letter') "
-            "GROUP BY job_url"
-            ") latest ON latest.job_url = m.job_url AND latest.mg = m.generation "
-            "INNER JOIN job_materials_artifacts tr ON tr.job_url = m.job_url "
+            "GROUP BY tenant_id, job_id"
+            ") "
+            "SELECT m.job_id FROM job_materials m "
+            "INNER JOIN latest_text_generations latest "
+            "ON latest.tenant_id = m.tenant_id "
+            "AND latest.job_id = m.job_id "
+            "AND latest.generation = m.generation "
+            "INNER JOIN job_materials_artifacts tr "
+            "ON tr.tenant_id = m.tenant_id AND tr.job_id = m.job_id "
             "AND tr.generation = m.generation AND tr.status = 'approved' "
             "AND tr.artifact_type IN ('tailored_resume', 'cover_letter') "
-            "LEFT JOIN job_materials_artifacts pdf ON pdf.job_url = m.job_url "
+            "LEFT JOIN job_materials_artifacts pdf "
+            "ON pdf.tenant_id = m.tenant_id AND pdf.job_id = m.job_id "
             "AND pdf.generation = m.generation AND pdf.status = 'approved' "
             "AND ((tr.artifact_type = 'tailored_resume' AND pdf.artifact_type = 'resume_pdf') "
             "  OR (tr.artifact_type = 'cover_letter' AND pdf.artifact_type = 'cover_letter_pdf')) "
             "WHERE m.tenant_id = ? AND pdf.path IS NULL "
-            "GROUP BY m.job_url "
+            "GROUP BY m.tenant_id, m.job_id "
             "ORDER BY MAX(m.updated_at) DESC"
         )
+        params: list[Any] = [str(tenant_id), str(tenant_id)]
         if limit > 0:
             sql += " LIMIT ?"
             params.append(limit)
         rows = self._conn.execute(sql, params).fetchall()
-        return [JobId(row[0]) for row in rows if row[0]]
+        return [canonical_job_id(str(row[0])) for row in rows]
 
     def list_by_status(
         self,
@@ -420,22 +429,27 @@ class SqliteMaterialsRepository:
         artifact carries the requested status."""
         if not isinstance(status, ArtifactStatus):
             raise TypeError(f"list_by_status requires ArtifactStatus, got {type(status).__name__}")
-        params: list[Any] = [str(tenant_id), status.value]
         sql = (
-            "SELECT m.job_url, m.generation, m.status, m.created_at, m.updated_at, "
+            "WITH latest_materials AS ("
+            "SELECT tenant_id, job_id, MAX(generation) AS generation "
+            "FROM job_materials WHERE tenant_id = ? "
+            "GROUP BY tenant_id, job_id"
+            ") "
+            "SELECT m.job_id, m.generation, m.status, m.created_at, m.updated_at, "
             "m.last_validation_json, m.last_verdict_json, m.metadata_json "
             "FROM job_materials m "
-            "INNER JOIN ("
-            "SELECT job_url, MAX(generation) AS mg FROM job_materials GROUP BY job_url"
-            ") latest ON latest.job_url = m.job_url AND latest.mg = m.generation "
-            "INNER JOIN job_materials_artifacts tr ON tr.job_url = m.job_url "
+            "INNER JOIN latest_materials latest "
+            "ON latest.tenant_id = m.tenant_id "
+            "AND latest.job_id = m.job_id "
+            "AND latest.generation = m.generation "
+            "INNER JOIN job_materials_artifacts tr "
+            "ON tr.tenant_id = m.tenant_id AND tr.job_id = m.job_id "
             "AND tr.generation = m.generation AND tr.artifact_type = 'tailored_resume' "
             "AND tr.status = ? "
             "WHERE m.tenant_id = ? "
             "ORDER BY m.updated_at DESC"
         )
-        # Param order in the WHERE: tr.status (status.value) then tenant_id
-        params = [status.value, str(tenant_id)]
+        params: list[Any] = [str(tenant_id), status.value, str(tenant_id)]
         if limit > 0:
             sql += " LIMIT ?"
             params.append(limit)

--- a/workers/automation/tests/test_v7_materials_selectors.py
+++ b/workers/automation/tests/test_v7_materials_selectors.py
@@ -1,0 +1,230 @@
+"""Exact-v7 regression coverage for MaterialsRepository queue selectors."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from jobctrl.database import init_db
+from jobctrl.domain.identifiers import JobId, canonical_job_id
+from jobctrl.domain.materials import (
+    Artifact,
+    ArtifactStatus,
+    ArtifactType,
+    JudgeVerdict,
+    MaterialsSet,
+    MaterialsSetFactory,
+    RenderFormat,
+    ValidationResult,
+)
+from jobctrl.domain.tenant import TenantId
+from jobctrl.infrastructure.materials import SqliteMaterialsRepository
+
+_TENANT_A = TenantId("tenant-a")
+_TENANT_B = TenantId("tenant-b")
+
+
+@pytest.fixture()
+def conn(tmp_path: Path) -> sqlite3.Connection:
+    return init_db(tmp_path / "jobctrl-v7.db")
+
+
+def _job_id(value: str) -> JobId:
+    return canonical_job_id(value)
+
+
+def _seed_job(
+    conn: sqlite3.Connection,
+    *,
+    tenant_id: TenantId,
+    job_id: JobId,
+    url: str,
+    fit_score: int = 9,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO jobs (
+            tenant_id, job_id, url, title, company, site, discovered_at
+        ) VALUES (?, ?, ?, 'Engineer', 'Acme', 'example', ?)
+        """,
+        (str(tenant_id), str(job_id), url, "2026-07-31T10:00:00+00:00"),
+    )
+    conn.execute(
+        """
+        INSERT INTO job_enrichments (
+            tenant_id, job_id, current_status, full_description, updated_at
+        ) VALUES (?, ?, 'succeeded', 'Role description', ?)
+        """,
+        (str(tenant_id), str(job_id), "2026-07-31T10:01:00+00:00"),
+    )
+    conn.execute(
+        """
+        INSERT INTO job_scores (
+            tenant_id, job_id, version, fit_score, breakdown_json,
+            keywords_json, scored_at
+        ) VALUES (?, ?, 1, ?, '{}', '[]', ?)
+        """,
+        (str(tenant_id), str(job_id), fit_score, "2026-07-31T10:02:00+00:00"),
+    )
+    conn.commit()
+
+
+def _artifact(artifact_type: ArtifactType, path: str, render_format: RenderFormat) -> Artifact:
+    return Artifact.create(
+        type=artifact_type,
+        path=path,
+        created_at="2026-07-31T10:03:00+00:00",
+        render_format=render_format,
+    )
+
+
+def _approved_resume(tenant_id: TenantId, job_id: JobId):
+    return MaterialsSetFactory.initial(
+        tenant_id=tenant_id,
+        job_id=job_id,
+        created_at="2026-07-31T10:03:00+00:00",
+    ).with_resume_attempt(
+        _artifact(ArtifactType.TAILORED_RESUME, "/tmp/resume.txt", RenderFormat.TEXT),
+        validation=ValidationResult.success(),
+        verdict=JudgeVerdict.passed(),
+        updated_at="2026-07-31T10:04:00+00:00",
+    )
+
+
+def _rejected_resume(tenant_id: TenantId, job_id: JobId, generation: int) -> MaterialsSet:
+    return MaterialsSet(
+        tenant_id=tenant_id,
+        job_id=job_id,
+        generation=generation,
+        created_at="2026-07-31T10:08:00+00:00",
+        updated_at="2026-07-31T10:08:00+00:00",
+    ).with_resume_attempt(
+        _artifact(ArtifactType.TAILORED_RESUME, "/tmp/rejected-resume.txt", RenderFormat.TEXT),
+        validation=ValidationResult.failure(("unsupported claim",)),
+        verdict=JudgeVerdict.passed(),
+        updated_at="2026-07-31T10:09:00+00:00",
+    )
+
+
+def test_v7_tailor_selector_returns_job_ids_and_isolates_same_url_tenants(
+    conn: sqlite3.Connection,
+) -> None:
+    """A locator collision cannot hide another tenant's pending JobId."""
+    alpha_job_id = _job_id("11111111-1111-4111-8111-111111111111")
+    beta_job_id = alpha_job_id
+    shared_url = "https://jobs.example.test/role/locator-only"
+    _seed_job(
+        conn,
+        tenant_id=_TENANT_A,
+        job_id=alpha_job_id,
+        url=shared_url,
+    )
+    _seed_job(
+        conn,
+        tenant_id=_TENANT_B,
+        job_id=beta_job_id,
+        url=shared_url,
+    )
+    SqliteMaterialsRepository(conn).save(_approved_resume(_TENANT_B, beta_job_id))
+
+    assert SqliteMaterialsRepository(conn).list_pending_tailor(_TENANT_A) == [alpha_job_id]
+    assert SqliteMaterialsRepository(conn).list_pending_tailor(_TENANT_B) == []
+
+
+def test_v7_material_selectors_use_current_approved_job_id_generation(
+    conn: sqlite3.Connection,
+) -> None:
+    cover_job_id = _job_id("33333333-3333-4333-8333-333333333333")
+    pdf_job_id = _job_id("44444444-4444-4444-8444-444444444444")
+    complete_job_id = _job_id("55555555-5555-4555-8555-555555555555")
+    for job_id in (cover_job_id, pdf_job_id, complete_job_id):
+        _seed_job(
+            conn,
+            tenant_id=_TENANT_A,
+            job_id=job_id,
+            url=f"https://jobs.example.test/role/{job_id}",
+        )
+    for job_id in (cover_job_id, pdf_job_id):
+        _seed_job(
+            conn,
+            tenant_id=_TENANT_B,
+            job_id=job_id,
+            url=f"https://jobs.example.test/other/{job_id}",
+        )
+
+    repo = SqliteMaterialsRepository(conn)
+    cover_materials = _approved_resume(_TENANT_A, cover_job_id).with_resume_pdf(
+        _artifact(ArtifactType.RESUME_PDF, "/tmp/cover-resume.pdf", RenderFormat.LATEX_PDF),
+        updated_at="2026-07-31T10:05:00+00:00",
+    )
+    repo.save(cover_materials)
+    repo.save(_approved_resume(_TENANT_A, pdf_job_id))
+    repo.save(_rejected_resume(_TENANT_A, pdf_job_id, generation=2))
+    repo.save(
+        _approved_resume(_TENANT_B, cover_job_id)
+        .with_resume_pdf(
+            _artifact(ArtifactType.RESUME_PDF, "/tmp/other-cover-resume.pdf", RenderFormat.LATEX_PDF),
+            updated_at="2026-07-31T10:05:00+00:00",
+        )
+        .with_cover_letter(
+            _artifact(ArtifactType.COVER_LETTER, "/tmp/other-cover.txt", RenderFormat.TEXT),
+            validation=ValidationResult.success(),
+            updated_at="2026-07-31T10:06:00+00:00",
+        )
+    )
+    repo.save(
+        _approved_resume(_TENANT_B, pdf_job_id).with_resume_pdf(
+            _artifact(ArtifactType.RESUME_PDF, "/tmp/other-resume.pdf", RenderFormat.LATEX_PDF),
+            updated_at="2026-07-31T10:05:00+00:00",
+        )
+    )
+    repo.save(
+        _approved_resume(_TENANT_A, complete_job_id)
+        .with_resume_pdf(
+            _artifact(ArtifactType.RESUME_PDF, "/tmp/complete-resume.pdf", RenderFormat.LATEX_PDF),
+            updated_at="2026-07-31T10:05:00+00:00",
+        )
+        .with_cover_letter(
+            _artifact(ArtifactType.COVER_LETTER, "/tmp/complete-cover.txt", RenderFormat.TEXT),
+            validation=ValidationResult.success(),
+            updated_at="2026-07-31T10:06:00+00:00",
+        )
+        .with_cover_letter_pdf(
+            _artifact(
+                ArtifactType.COVER_LETTER_PDF,
+                "/tmp/complete-cover.pdf",
+                RenderFormat.HTML_PDF,
+            ),
+            updated_at="2026-07-31T10:07:00+00:00",
+        )
+    )
+
+    assert repo.list_pending_cover(_TENANT_A) == [cover_job_id]
+    assert repo.list_pending_pdf(_TENANT_A) == [pdf_job_id]
+    assert repo.list_pending_cover(_TENANT_B) == [pdf_job_id]
+    assert repo.list_pending_pdf(_TENANT_B) == [cover_job_id]
+    assert {materials.job_id for materials in repo.list_by_status(_TENANT_A, ArtifactStatus.APPROVED)} == {
+        cover_job_id,
+        complete_job_id,
+    }
+
+
+def test_v7_status_selector_isolates_latest_generations_by_tenant_and_job_id(
+    conn: sqlite3.Connection,
+) -> None:
+    alpha_job_id = _job_id("66666666-6666-4666-8666-666666666666")
+    beta_job_id = alpha_job_id
+    shared_url = "https://jobs.example.test/role/status-locator-only"
+    _seed_job(conn, tenant_id=_TENANT_A, job_id=alpha_job_id, url=shared_url)
+    _seed_job(conn, tenant_id=_TENANT_B, job_id=beta_job_id, url=shared_url)
+
+    repo = SqliteMaterialsRepository(conn)
+    repo.save(_approved_resume(_TENANT_A, alpha_job_id))
+    repo.save(_approved_resume(_TENANT_B, beta_job_id))
+    repo.save(_rejected_resume(_TENANT_B, beta_job_id, generation=2))
+
+    assert [materials.job_id for materials in repo.list_by_status(_TENANT_A, ArtifactStatus.APPROVED)] == [
+        alpha_job_id
+    ]


### PR DESCRIPTION
## Summary
- convert tailor, cover, PDF, and status selectors to exact tenant-scoped JobId joins
- return canonical UUID JobIds while retaining posting URLs only as external locators
- preserve score eligibility, current-approved, latest-generation, and ordering semantics
- add exact-v7 regressions for same UUIDs across tenants, including cover and PDF isolation

## Scope
This PR converts only material queue/status selectors. Template assignment and preparation workflow cutovers remain separate stacked PRs.

## Validation
- `workers/automation/.venv/bin/pytest -q workers/automation/tests/test_v7_materials_selectors.py workers/automation/tests/test_materials_use_cases.py` (66 passed)
- `workers/automation/.venv/bin/ruff check workers/automation/src/jobctrl/domain/ports/materials.py workers/automation/src/jobctrl/infrastructure/materials/sqlite_repository.py workers/automation/tests/test_v7_materials_selectors.py`
- `git diff --check`
- independent review: PASS, zero findings