### PR TITLE
fix(materials): resolve resume templates by JobId

### DIFF
--- a/apps/api/src/resume-templates.ts
+++ b/apps/api/src/resume-templates.ts
@@ -2,6 +2,8 @@ import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 
+import type { JobId } from "@jobctrl/domain-types";
+
 import type {
   EnsureCurrentResumeMaterialsResponse,
   JobResumeTemplateAssignmentRequest,
@@ -27,7 +29,7 @@ import {
   ResumeTemplateLayoutSchema,
   ResumeTemplateThemeSchema,
 } from "./contracts.js";
-import { allRows, getRow, tableExists, type SqliteDatabase, type SqliteValue } from "./db.js";
+import { allRows, getRow, type SqliteDatabase } from "./db.js";
 import { defaultResumeHtmlPdfRenderer, type ResumeHtmlPdfRenderer } from "./resume-pdf-render.js";
 
 const DEFAULT_TENANT = "local";
@@ -37,6 +39,7 @@ const BUILT_IN_VERSION_ID = "built_in:modern-html:v1";
 const TEMPLATE_METADATA_KEY = "resume_template";
 const TEMPLATE_REFRESH_SOURCE = "resume_template_lazy_refresh";
 const TEXT_BYTE_LIMIT = 128_000;
+const CANONICAL_JOB_ID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
 
 export class ResumeTemplateInputError extends Error {}
 
@@ -81,7 +84,6 @@ interface MaterialArtifactRow extends Record<string, unknown> {
 
 interface RefreshAttemptRow extends Record<string, unknown> {
   attempt_id: string;
-  job_url: string;
   status: string;
   from_generation: number | null;
   to_generation: number | null;
@@ -114,81 +116,7 @@ export const BUILT_IN_RESUME_TEMPLATE_THEME: ResumeTemplateTheme =
     hiddenSections: [],
   });
 
-const EMPTY_LAYOUT: ResumeTemplateLayout = ResumeTemplateLayoutSchema.parse({});
-
-export function ensureResumeTemplateTables(db: SqliteDatabase): void {
-  db.exec(`
-    CREATE TABLE IF NOT EXISTS resume_templates (
-      tenant_id    TEXT NOT NULL DEFAULT 'local',
-      template_id  TEXT NOT NULL,
-      display_name TEXT NOT NULL,
-      status       TEXT NOT NULL DEFAULT 'active',
-      built_in     INTEGER NOT NULL DEFAULT 0,
-      created_at   TEXT NOT NULL,
-      updated_at   TEXT NOT NULL,
-      PRIMARY KEY (tenant_id, template_id)
-    );
-    CREATE TABLE IF NOT EXISTS resume_template_versions (
-      tenant_id      TEXT NOT NULL DEFAULT 'local',
-      version_id     TEXT NOT NULL,
-      template_id    TEXT NOT NULL,
-      version_number INTEGER NOT NULL,
-      display_name   TEXT NOT NULL,
-      status         TEXT NOT NULL DEFAULT 'active',
-      theme_json     TEXT NOT NULL,
-      layout_json    TEXT NOT NULL DEFAULT '{}',
-      content_hash   TEXT NOT NULL,
-      created_at     TEXT NOT NULL,
-      PRIMARY KEY (tenant_id, version_id),
-      UNIQUE (tenant_id, template_id, version_number)
-    );
-    CREATE INDEX IF NOT EXISTS idx_resume_template_versions_template
-      ON resume_template_versions(tenant_id, template_id, version_number DESC);
-
-    CREATE TABLE IF NOT EXISTS resume_template_defaults (
-      tenant_id   TEXT NOT NULL DEFAULT 'local',
-      profile_id  TEXT NOT NULL DEFAULT 'default',
-      template_id TEXT NOT NULL,
-      version_id  TEXT NOT NULL,
-      updated_at  TEXT NOT NULL,
-      PRIMARY KEY (tenant_id, profile_id)
-    );
-
-    CREATE TABLE IF NOT EXISTS job_resume_template_assignments (
-      tenant_id   TEXT NOT NULL DEFAULT 'local',
-      job_url     TEXT NOT NULL,
-      template_id TEXT NOT NULL,
-      version_id  TEXT NOT NULL,
-      updated_at  TEXT NOT NULL,
-      PRIMARY KEY (tenant_id, job_url)
-    );
-    CREATE INDEX IF NOT EXISTS idx_job_resume_template_assignments_template
-      ON job_resume_template_assignments(tenant_id, template_id, version_id);
-
-    CREATE TABLE IF NOT EXISTS resume_template_refresh_attempts (
-      tenant_id           TEXT NOT NULL DEFAULT 'local',
-      attempt_id          TEXT NOT NULL,
-      job_url             TEXT NOT NULL,
-      status              TEXT NOT NULL,
-      from_generation     INTEGER,
-      to_generation       INTEGER,
-      template_id         TEXT,
-      template_version_id TEXT,
-      template_hash       TEXT,
-      error_message       TEXT,
-      metadata_json       TEXT NOT NULL DEFAULT '{}',
-      created_at          TEXT NOT NULL,
-      completed_at        TEXT,
-      PRIMARY KEY (tenant_id, attempt_id)
-    );
-    CREATE INDEX IF NOT EXISTS idx_resume_template_refresh_attempts_job
-      ON resume_template_refresh_attempts(tenant_id, job_url, created_at DESC);
-  `);
-  seedBuiltInResumeTemplate(db);
-}
-
 export function listResumeTemplates(db: SqliteDatabase): ResumeTemplateListResponse {
-  ensureResumeTemplateTables(db);
   const rows = allRows<TemplateRow>(
     db,
     `SELECT *
@@ -210,7 +138,6 @@ export function listResumeTemplates(db: SqliteDatabase): ResumeTemplateListRespo
 }
 
 export function getResumeTemplateDetail(db: SqliteDatabase, templateId: string): ResumeTemplateDetailResponse | null {
-  ensureResumeTemplateTables(db);
   const template = templateSummaryFromRow(db, getTemplateRow(db, templateId));
   return template ? { ok: true, template } : null;
 }
@@ -219,7 +146,6 @@ export function createResumeTemplateVersion(
   db: SqliteDatabase,
   request: ResumeTemplateVersionSaveRequest,
 ): ResumeTemplateVersionSaveResponse {
-  ensureResumeTemplateTables(db);
   const normalized = normalizeTemplateVersionRequest(request);
   assertTemplatePayloadSafe(db, normalized);
 
@@ -230,29 +156,41 @@ export function createResumeTemplateVersion(
   const versionId = `${templateId}:v${versionNumber}:${crypto.randomUUID().slice(0, 8)}`;
   const contentHash = templateContentHash(normalized.theme, normalized.layout);
 
-  insertDynamicRow(db, "resume_templates", {
-    tenant_id: DEFAULT_TENANT,
-    template_id: templateId,
-    display_name: normalized.displayName,
-    status: "active",
-    built_in: existing?.built_in ?? 0,
-    created_at: existing?.created_at ?? now,
-    updated_at: now,
-  });
-  insertDynamicRow(db, "resume_template_versions", {
-    tenant_id: DEFAULT_TENANT,
-    version_id: versionId,
-    template_id: templateId,
-    version_number: versionNumber,
-    display_name: normalized.displayName,
-    status: "active",
-    theme_json: JSON.stringify(normalized.theme),
-    layout_json: JSON.stringify(normalized.layout),
-    content_hash: contentHash,
-    created_at: now,
-  });
+  db.prepare(
+    `INSERT INTO resume_templates (
+       tenant_id, template_id, display_name, status, built_in, created_at, updated_at
+     ) VALUES (?, ?, ?, 'active', ?, ?, ?)
+     ON CONFLICT(tenant_id, template_id) DO UPDATE SET
+       display_name = excluded.display_name,
+       status = excluded.status,
+       built_in = excluded.built_in,
+       updated_at = excluded.updated_at`,
+  ).run(
+    DEFAULT_TENANT,
+    templateId,
+    normalized.displayName,
+    existing?.built_in ?? 0,
+    existing?.created_at ?? now,
+    now,
+  );
+  db.prepare(
+    `INSERT INTO resume_template_versions (
+       tenant_id, version_id, template_id, version_number, display_name, status,
+       theme_json, layout_json, content_hash, created_at
+     ) VALUES (?, ?, ?, ?, ?, 'active', ?, ?, ?, ?)`,
+  ).run(
+    DEFAULT_TENANT,
+    versionId,
+    templateId,
+    versionNumber,
+    normalized.displayName,
+    JSON.stringify(normalized.theme),
+    JSON.stringify(normalized.layout),
+    contentHash,
+    now,
+  );
   recordTemplateEvent(db, {
-    jobUrl: null,
+    jobId: null,
     eventType: "ResumeTemplateVersionSaved",
     message: `Resume template saved: ${normalized.displayName}`,
     payload: {
@@ -275,18 +213,25 @@ export function setDefaultResumeTemplate(
   db: SqliteDatabase,
   request: ResumeTemplateDefaultSelectionRequest,
 ): ResumeTemplateDefaultSelectionResponse {
-  ensureResumeTemplateTables(db);
   const effective = resolveTemplateByRequest(db, request.templateId, request.versionId, "profile_default");
   const now = new Date().toISOString();
-  insertDynamicRow(db, "resume_template_defaults", {
-    tenant_id: DEFAULT_TENANT,
-    profile_id: DEFAULT_PROFILE_ID,
-    template_id: effective.metadata.templateId,
-    version_id: effective.metadata.templateVersionId,
-    updated_at: now,
-  });
+  db.prepare(
+    `INSERT INTO resume_template_defaults (
+       tenant_id, profile_id, template_id, version_id, updated_at
+     ) VALUES (?, ?, ?, ?, ?)
+     ON CONFLICT(tenant_id, profile_id) DO UPDATE SET
+       template_id = excluded.template_id,
+       version_id = excluded.version_id,
+       updated_at = excluded.updated_at`,
+  ).run(
+    DEFAULT_TENANT,
+    DEFAULT_PROFILE_ID,
+    effective.metadata.templateId,
+    effective.metadata.templateVersionId,
+    now,
+  );
   recordTemplateEvent(db, {
-    jobUrl: null,
+    jobId: null,
     eventType: "ResumeTemplateDefaultChanged",
     message: `Default resume template changed to ${effective.metadata.templateName}`,
     payload: {
@@ -300,39 +245,47 @@ export function setDefaultResumeTemplate(
 
 export function setJobResumeTemplateAssignment(
   db: SqliteDatabase,
-  jobKey: string,
+  jobId: string,
   request: JobResumeTemplateAssignmentRequest,
 ): JobResumeTemplateAssignmentResponse {
-  ensureResumeTemplateTables(db);
-  assertJobExists(db, jobKey);
+  const stableJobId = requireJobId(jobId);
+  assertJobExists(db, stableJobId);
   const now = new Date().toISOString();
   let overrideTemplate: ResumeTemplateMetadata | null = null;
 
   if (request.templateId === null) {
     db.prepare(
-      "DELETE FROM job_resume_template_assignments WHERE tenant_id = ? AND job_url = ?",
-    ).run(DEFAULT_TENANT, jobKey);
+      "DELETE FROM job_resume_template_assignments WHERE tenant_id = ? AND job_id = ?",
+    ).run(DEFAULT_TENANT, stableJobId);
   } else if (request.templateId) {
     const effective = resolveTemplateByRequest(db, request.templateId, request.versionId ?? undefined, "job_override");
-    insertDynamicRow(db, "job_resume_template_assignments", {
-      tenant_id: DEFAULT_TENANT,
-      job_url: jobKey,
-      template_id: effective.metadata.templateId,
-      version_id: effective.metadata.templateVersionId,
-      updated_at: now,
-    });
+    db.prepare(
+      `INSERT INTO job_resume_template_assignments (
+         tenant_id, job_id, template_id, version_id, updated_at
+       ) VALUES (?, ?, ?, ?, ?)
+       ON CONFLICT(tenant_id, job_id) DO UPDATE SET
+         template_id = excluded.template_id,
+         version_id = excluded.version_id,
+         updated_at = excluded.updated_at`,
+    ).run(
+      DEFAULT_TENANT,
+      stableJobId,
+      effective.metadata.templateId,
+      effective.metadata.templateVersionId,
+      now,
+    );
     overrideTemplate = effective.metadata;
   }
 
-  const effectiveTemplate = resolveEffectiveResumeTemplate(db, jobKey);
+  const effectiveTemplate = resolveEffectiveResumeTemplateForJob(db, stableJobId);
   recordTemplateEvent(db, {
-    jobUrl: jobKey,
+    jobId: stableJobId,
     eventType: "JobResumeTemplateAssigned",
     message: overrideTemplate
       ? `Job resume template set to ${overrideTemplate.templateName}`
       : "Job resume template override cleared",
     payload: {
-      jobId: jobKey,
+      jobId: stableJobId,
       templateId: overrideTemplate?.templateId ?? null,
       templateVersionId: overrideTemplate?.templateVersionId ?? null,
       assignedAt: now,
@@ -340,22 +293,25 @@ export function setJobResumeTemplateAssignment(
   });
   return {
     ok: true,
-    jobKey,
+    jobKey: stableJobId,
     effectiveTemplate: effectiveTemplate.metadata,
     overrideTemplate,
-    templateState: resumeTemplateStateForJob(db, jobKey),
+    templateState: resumeTemplateStateForJobId(db, stableJobId),
   };
 }
 
-export function resolveEffectiveResumeTemplate(db: SqliteDatabase, jobKey?: string | null): EffectiveTemplate {
-  ensureResumeTemplateTables(db);
-  if (jobKey) {
+export function resolveEffectiveResumeTemplate(db: SqliteDatabase, jobId?: string | null): EffectiveTemplate {
+  return resolveEffectiveResumeTemplateForJob(db, jobId ? requireJobId(jobId) : null);
+}
+
+function resolveEffectiveResumeTemplateForJob(db: SqliteDatabase, jobId?: JobId | null): EffectiveTemplate {
+  if (jobId) {
     const assignment = getRow<AssignmentRow>(
       db,
       `SELECT template_id, version_id, updated_at
          FROM job_resume_template_assignments
-        WHERE tenant_id = ? AND job_url = ?`,
-      [DEFAULT_TENANT, jobKey],
+        WHERE tenant_id = ? AND job_id = ?`,
+      [DEFAULT_TENANT, jobId],
     );
     if (assignment?.template_id && assignment.version_id) {
       return resolveTemplateByRequest(db, assignment.template_id, assignment.version_id, "job_override");
@@ -366,11 +322,14 @@ export function resolveEffectiveResumeTemplate(db: SqliteDatabase, jobKey?: stri
   return resolveBuiltInTemplate(db);
 }
 
-export function resumeTemplateStateForJob(db: SqliteDatabase, jobKey: string): ResumeTemplateState | null {
-  ensureResumeTemplateTables(db);
-  const effective = resolveEffectiveResumeTemplate(db, jobKey).metadata;
-  const material = latestResumeMaterial(db, jobKey);
-  const lastRefreshAttempt = latestRefreshAttempt(db, jobKey);
+export function resumeTemplateStateForJob(db: SqliteDatabase, jobId: string): ResumeTemplateState | null {
+  return resumeTemplateStateForJobId(db, requireJobId(jobId));
+}
+
+function resumeTemplateStateForJobId(db: SqliteDatabase, jobId: JobId): ResumeTemplateState | null {
+  const effective = resolveEffectiveResumeTemplateForJob(db, jobId).metadata;
+  const material = latestResumeMaterial(db, jobId);
+  const lastRefreshAttempt = latestRefreshAttempt(db, jobId);
   const snapshot = material ? snapshotFromMaterial(db, effective, material) : null;
   const stale = snapshot !== null && !sameTemplateSnapshot(snapshot, effective);
   const state = stateFromRefreshAttempt(lastRefreshAttempt, stale, material);
@@ -385,25 +344,25 @@ export function resumeTemplateStateForJob(db: SqliteDatabase, jobKey: string): R
 
 export function resumeTemplateStateForArtifact(
   db: SqliteDatabase,
-  jobKey: string,
+  jobId: string,
   artifactMetadataJson: string | null,
 ): ResumeTemplateState | null {
-  ensureResumeTemplateTables(db);
-  const effective = resolveEffectiveResumeTemplate(db, jobKey).metadata;
+  const stableJobId = requireJobId(jobId);
+  const effective = resolveEffectiveResumeTemplateForJob(db, stableJobId).metadata;
   const snapshot = snapshotFromMetadata(parseJsonRecord(artifactMetadataJson)) ?? null;
-  if (!snapshot) return resumeTemplateStateForJob(db, jobKey);
+  if (!snapshot) return resumeTemplateStateForJobId(db, stableJobId);
   const stale = !sameTemplateSnapshot(snapshot, effective);
   return {
     effective,
     snapshot,
     state: stale ? "template_stale" : "template_current",
     reason: stale ? "Artifact was rendered with a different resume template version." : null,
-    lastRefreshAttempt: latestRefreshAttempt(db, jobKey),
+    lastRefreshAttempt: latestRefreshAttempt(db, stableJobId),
   };
 }
 
-export function templateMetadataForMaterial(db: SqliteDatabase, jobKey: string): ResumeTemplateMetadata {
-  return resolveEffectiveResumeTemplate(db, jobKey).metadata;
+export function templateMetadataForMaterial(db: SqliteDatabase, jobId: string): ResumeTemplateMetadata {
+  return resolveEffectiveResumeTemplateForJob(db, requireJobId(jobId)).metadata;
 }
 
 export function templateMetadataPayload(metadata: ResumeTemplateMetadata): Record<string, unknown> {
@@ -419,29 +378,29 @@ export function templateMetadataPayload(metadata: ResumeTemplateMetadata): Recor
 
 export function ensureCurrentResumeTemplateMaterials(
   db: SqliteDatabase,
-  jobKey: string,
+  jobId: string,
   options: { force?: boolean } = {},
   renderPdf: ResumeHtmlPdfRenderer = defaultResumeHtmlPdfRenderer,
 ): EnsureCurrentResumeMaterialsResponse {
-  ensureResumeTemplateTables(db);
-  assertJobExists(db, jobKey);
+  const stableJobId = requireJobId(jobId);
+  assertJobExists(db, stableJobId);
 
-  const initialState = resumeTemplateStateForJob(db, jobKey);
+  const initialState = resumeTemplateStateForJobId(db, stableJobId);
   if (!initialState) {
-    return noRefreshResponse(jobKey, "not_required", null, null, "No resume template state is available.");
+    return noRefreshResponse(stableJobId, "not_required", null, null, "No resume template state is available.");
   }
   if (!options.force && initialState.state === "template_current") {
-    return noRefreshResponse(jobKey, "not_required", initialState, null, "Resume materials already use the effective template.");
+    return noRefreshResponse(stableJobId, "not_required", initialState, null, "Resume materials already use the effective template.");
   }
 
-  const material = latestResumeMaterial(db, jobKey);
+  const material = latestResumeMaterial(db, stableJobId);
   const reusableMaterial =
     material && material.text
       ? { generation: material.generation, text: material.text, pdf: material.pdf }
       : null;
   if (!reusableMaterial) {
     const attempt = recordRefreshAttempt(db, {
-      jobKey,
+      jobId: stableJobId,
       status: "unavailable",
       fromGeneration: material?.generation ?? null,
       toGeneration: null,
@@ -449,11 +408,11 @@ export function ensureCurrentResumeTemplateMaterials(
       errorMessage: "Latest accepted resume has no reusable text source for render-only refresh.",
     });
     recordTemplateEvent(db, {
-      jobUrl: jobKey,
+      jobId: stableJobId,
       eventType: "ResumeTemplateRefreshFailed",
       message: "Resume template refresh unavailable",
       payload: {
-        jobId: jobKey,
+        jobId: stableJobId,
         attemptId: attempt.attemptId,
         status: "unavailable",
         errorMessage: attempt.errorMessage ?? "",
@@ -462,9 +421,9 @@ export function ensureCurrentResumeTemplateMaterials(
     });
     return {
       ok: true,
-      jobKey,
+      jobKey: stableJobId,
       status: "unavailable",
-      templateState: resumeTemplateStateForJob(db, jobKey),
+      templateState: resumeTemplateStateForJobId(db, stableJobId),
       attempt,
       generation: null,
       message: attempt.errorMessage,
@@ -472,7 +431,7 @@ export function ensureCurrentResumeTemplateMaterials(
   }
 
   recordRefreshAttempt(db, {
-    jobKey,
+    jobId: stableJobId,
     status: "queued",
     fromGeneration: reusableMaterial.generation,
     toGeneration: null,
@@ -481,9 +440,9 @@ export function ensureCurrentResumeTemplateMaterials(
   });
 
   try {
-    const refreshed = persistRenderOnlyRefresh(db, jobKey, reusableMaterial, initialState.effective, renderPdf);
+    const refreshed = persistRenderOnlyRefresh(db, stableJobId, reusableMaterial, initialState.effective, renderPdf);
     const attempt = recordRefreshAttempt(db, {
-      jobKey,
+      jobId: stableJobId,
       status: "completed",
       fromGeneration: reusableMaterial.generation,
       toGeneration: refreshed.generation,
@@ -491,11 +450,11 @@ export function ensureCurrentResumeTemplateMaterials(
       errorMessage: null,
     });
     recordTemplateEvent(db, {
-      jobUrl: jobKey,
+      jobId: stableJobId,
       eventType: "ResumeTemplateRefreshCompleted",
       message: "Resume template refresh completed",
       payload: {
-        jobId: jobKey,
+        jobId: stableJobId,
         attemptId: attempt.attemptId,
         generation: refreshed.generation,
         templateId: initialState.effective.templateId,
@@ -505,9 +464,9 @@ export function ensureCurrentResumeTemplateMaterials(
     });
     return {
       ok: true,
-      jobKey,
+      jobKey: stableJobId,
       status: "completed",
-      templateState: resumeTemplateStateForJob(db, jobKey),
+      templateState: resumeTemplateStateForJobId(db, stableJobId),
       attempt,
       generation: refreshed.generation,
       message: "Resume materials were refreshed with the effective template.",
@@ -515,7 +474,7 @@ export function ensureCurrentResumeTemplateMaterials(
   } catch (error) {
     const message = error instanceof Error ? error.message : "Template refresh failed.";
     const attempt = recordRefreshAttempt(db, {
-      jobKey,
+      jobId: stableJobId,
       status: "failed",
       fromGeneration: reusableMaterial.generation,
       toGeneration: null,
@@ -523,11 +482,11 @@ export function ensureCurrentResumeTemplateMaterials(
       errorMessage: message,
     });
     recordTemplateEvent(db, {
-      jobUrl: jobKey,
+      jobId: stableJobId,
       eventType: "ResumeTemplateRefreshFailed",
       message: "Resume template refresh failed",
       payload: {
-        jobId: jobKey,
+        jobId: stableJobId,
         attemptId: attempt.attemptId,
         status: "failed",
         errorMessage: message,
@@ -536,9 +495,9 @@ export function ensureCurrentResumeTemplateMaterials(
     });
     return {
       ok: true,
-      jobKey,
+      jobKey: stableJobId,
       status: "failed",
-      templateState: resumeTemplateStateForJob(db, jobKey),
+      templateState: resumeTemplateStateForJobId(db, stableJobId),
       attempt,
       generation: null,
       message,
@@ -551,80 +510,38 @@ export function resolveCurrentResumeArtifactIdForOpen(
   artifactId: string,
   renderPdf: ResumeHtmlPdfRenderer = defaultResumeHtmlPdfRenderer,
 ): string {
-  ensureResumeTemplateTables(db);
-  if (!tableExists(db, "job_materials_artifacts")) return artifactId;
-  const columns = tableColumnSet(db, "job_materials_artifacts");
-  if (
-    !columns.includes("job_url") ||
-    !columns.includes("artifact_type") ||
-    !columns.includes("artifact_id") ||
-    !columns.includes("generation")
-  ) {
-    return artifactId;
-  }
   const row = getRow<{
-    job_url: string;
+    job_id: string;
     artifact_type: string;
     generation: number | string | null;
   }>(
     db,
-    `SELECT job_url, artifact_type, generation
+    `SELECT job_id, artifact_type, generation
        FROM job_materials_artifacts
-      WHERE artifact_id = ?`,
-    [artifactId],
+      WHERE tenant_id = ? AND artifact_id = ?`,
+    [DEFAULT_TENANT, artifactId],
   );
   if (!row || (row.artifact_type !== "tailored_resume" && row.artifact_type !== "resume_pdf")) {
     return artifactId;
   }
 
-  const refresh = ensureCurrentResumeTemplateMaterials(db, row.job_url, {}, renderPdf);
+  const jobId = requireJobId(row.job_id);
+  const refresh = ensureCurrentResumeTemplateMaterials(db, jobId, {}, renderPdf);
   if (refresh.status !== "completed" && refresh.status !== "not_required") {
     return artifactId;
   }
-  const statusWhere = columns.includes("status") ? "AND COALESCE(status, 'approved') IN ('approved', 'active')" : "";
-  const orderBy = columns.includes("created_at")
-    ? "generation DESC, datetime(created_at) DESC, artifact_id DESC"
-    : "generation DESC, artifact_id DESC";
   const latest = getRow<{ artifact_id: string }>(
     db,
     `SELECT artifact_id
        FROM job_materials_artifacts
-      WHERE job_url = ?
+      WHERE tenant_id = ? AND job_id = ?
         AND artifact_type = ?
-        ${statusWhere}
-      ORDER BY ${orderBy}
+        AND status IN ('approved', 'active')
+      ORDER BY generation DESC, datetime(created_at) DESC, artifact_id DESC
       LIMIT 1`,
-    [row.job_url, row.artifact_type],
+    [DEFAULT_TENANT, jobId, row.artifact_type],
   );
   return latest?.artifact_id ?? artifactId;
-}
-
-function seedBuiltInResumeTemplate(db: SqliteDatabase): void {
-  const now = new Date().toISOString();
-  const theme = BUILT_IN_RESUME_TEMPLATE_THEME;
-  const layout = EMPTY_LAYOUT;
-  const hash = templateContentHash(theme, layout);
-  insertDynamicRow(db, "resume_templates", {
-    tenant_id: DEFAULT_TENANT,
-    template_id: BUILT_IN_TEMPLATE_ID,
-    display_name: "Modern HTML",
-    status: "active",
-    built_in: 1,
-    created_at: now,
-    updated_at: now,
-  });
-  insertDynamicRow(db, "resume_template_versions", {
-    tenant_id: DEFAULT_TENANT,
-    version_id: BUILT_IN_VERSION_ID,
-    template_id: BUILT_IN_TEMPLATE_ID,
-    version_number: 1,
-    display_name: "Modern HTML",
-    status: "active",
-    theme_json: JSON.stringify(theme),
-    layout_json: JSON.stringify(layout),
-    content_hash: hash,
-    created_at: now,
-  });
 }
 
 function normalizeTemplateVersionRequest(
@@ -662,40 +579,27 @@ function assertTemplatePayloadSafe(db: SqliteDatabase, request: ResumeTemplateVe
 
 function sensitiveFactSentinels(db: SqliteDatabase): string[] {
   const facts = new Set<string>();
-  if (tableExists(db, "candidate_profiles")) {
-    const columns = tableColumnSet(db, "candidate_profiles");
-    const selected = [
-      "personal_full_name",
-      "personal_email",
-      "personal_phone",
-      "personal_linkedin_url",
-      "personal_github_url",
-      "personal_portfolio_url",
-      "personal_website_url",
-    ].filter((column) => columns.includes(column));
-    if (selected.length) {
-      const row = getRow<Record<string, unknown>>(
-        db,
-        `SELECT ${selected.join(", ")} FROM candidate_profiles WHERE tenant_id = ? AND profile_id = ?`,
-        [DEFAULT_TENANT, DEFAULT_PROFILE_ID],
-      );
-      for (const value of Object.values(row ?? {})) addSensitiveFact(facts, value);
-    }
-  }
-  if (tableExists(db, "jobs")) {
-    const columns = tableColumnSet(db, "jobs");
-    const selected = ["title", "company", "employer", "application_url"].filter((column) =>
-      columns.includes(column),
-    );
-    if (selected.length) {
-      const rows = allRows<Record<string, unknown>>(
-        db,
-        `SELECT ${selected.join(", ")} FROM jobs ORDER BY discovered_at DESC LIMIT 25`,
-      );
-      for (const row of rows) {
-        for (const value of Object.values(row)) addSensitiveFact(facts, value);
-      }
-    }
+  const profile = getRow<Record<string, unknown>>(
+    db,
+    `SELECT personal_full_name, personal_email, personal_phone,
+            personal_linkedin_url, personal_github_url,
+            personal_portfolio_url, personal_website_url
+       FROM candidate_profiles
+      WHERE tenant_id = ? AND profile_id = ?`,
+    [DEFAULT_TENANT, DEFAULT_PROFILE_ID],
+  );
+  for (const value of Object.values(profile ?? {})) addSensitiveFact(facts, value);
+  const jobs = allRows<Record<string, unknown>>(
+    db,
+    `SELECT title, company, application_url
+       FROM jobs
+      WHERE tenant_id = ?
+      ORDER BY discovered_at DESC
+      LIMIT 25`,
+    [DEFAULT_TENANT],
+  );
+  for (const job of jobs) {
+    for (const value of Object.values(job)) addSensitiveFact(facts, value);
   }
   return [...facts];
 }
@@ -828,32 +732,18 @@ function metadataFromVersion(
 
 function latestResumeMaterial(
   db: SqliteDatabase,
-  jobKey: string,
+  jobId: JobId,
 ): { generation: number; text: MaterialArtifactRow | null; pdf: MaterialArtifactRow | null } | null {
-  if (!tableExists(db, "job_materials_artifacts")) return null;
-  const columns = tableColumnSet(db, "job_materials_artifacts");
-  if (!columns.includes("artifact_type") || !columns.includes("generation")) return null;
-  const selectColumns = [
-    columns.includes("artifact_id") ? "artifact_id" : "NULL AS artifact_id",
-    "artifact_type",
-    "generation",
-    columns.includes("path") ? "path" : "NULL AS path",
-    columns.includes("render_format") ? "render_format" : "NULL AS render_format",
-    columns.includes("metadata_json") ? "metadata_json" : "NULL AS metadata_json",
-    columns.includes("created_at") ? "created_at" : "NULL AS created_at",
-  ].join(", ");
-  const jobColumn = columns.includes("job_url") ? "job_url" : columns.includes("job_id") ? "job_id" : null;
-  if (!jobColumn) return null;
-  const statusWhere = columns.includes("status") ? "AND COALESCE(status, 'approved') IN ('approved', 'active')" : "";
   const rows = allRows<MaterialArtifactRow>(
     db,
-    `SELECT ${selectColumns}
+    `SELECT artifact_id, artifact_type, generation, path, render_format,
+            metadata_json, created_at
        FROM job_materials_artifacts
-      WHERE ${jobColumn} = ?
+      WHERE tenant_id = ? AND job_id = ?
         AND artifact_type IN ('tailored_resume', 'resume_pdf')
-        ${statusWhere}
+        AND status IN ('approved', 'active')
       ORDER BY generation DESC, CASE artifact_type WHEN 'resume_pdf' THEN 0 ELSE 1 END`,
-    [jobKey],
+    [DEFAULT_TENANT, jobId],
   );
   const generation = rows[0]?.generation === undefined ? null : Number(rows[0].generation);
   if (!generation) return null;
@@ -934,24 +824,25 @@ function reasonForTemplateState(
   return `Rendered with ${snapshot.templateName}; current effective template is ${effective.templateName}.`;
 }
 
-function latestRefreshAttempt(db: SqliteDatabase, jobKey: string): ResumeTemplateRefreshAttempt | null {
-  if (!tableExists(db, "resume_template_refresh_attempts")) return null;
+function latestRefreshAttempt(db: SqliteDatabase, jobId: JobId): ResumeTemplateRefreshAttempt | null {
   const row = getRow<RefreshAttemptRow>(
     db,
     `SELECT *
        FROM resume_template_refresh_attempts
-      WHERE tenant_id = ? AND job_url = ?
-      ORDER BY created_at DESC, attempt_id DESC
+      WHERE tenant_id = ? AND job_id = ?
+      ORDER BY created_at DESC,
+               CASE WHEN completed_at IS NULL THEN 1 ELSE 0 END,
+               attempt_id DESC
       LIMIT 1`,
-    [DEFAULT_TENANT, jobKey],
+    [DEFAULT_TENANT, jobId],
   );
-  return row ? refreshAttemptFromRow(row) : null;
+  return row ? refreshAttemptFromRow(row, jobId) : null;
 }
 
 function recordRefreshAttempt(
   db: SqliteDatabase,
   input: {
-    jobKey: string;
+    jobId: JobId;
     status: ResumeTemplateRefreshStatus;
     fromGeneration: number | null;
     toGeneration: number | null;
@@ -961,35 +852,41 @@ function recordRefreshAttempt(
 ): ResumeTemplateRefreshAttempt {
   const now = new Date().toISOString();
   const attemptId = `template_refresh_${crypto.randomUUID()}`;
-  insertDynamicRow(db, "resume_template_refresh_attempts", {
-    tenant_id: DEFAULT_TENANT,
-    attempt_id: attemptId,
-    job_url: input.jobKey,
-    status: input.status,
-    from_generation: input.fromGeneration,
-    to_generation: input.toGeneration,
-    template_id: input.effective.templateId,
-    template_version_id: input.effective.templateVersionId,
-    template_hash: input.effective.templateHash,
-    error_message: input.errorMessage,
-    metadata_json: JSON.stringify({ source: TEMPLATE_REFRESH_SOURCE }),
-    created_at: now,
-    completed_at: input.status === "queued" ? null : now,
-  });
+  db.prepare(
+    `INSERT INTO resume_template_refresh_attempts (
+       tenant_id, attempt_id, job_id, status, from_generation, to_generation,
+       template_id, template_version_id, template_hash, error_message,
+       metadata_json, created_at, completed_at
+     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    DEFAULT_TENANT,
+    attemptId,
+    input.jobId,
+    input.status,
+    input.fromGeneration,
+    input.toGeneration,
+    input.effective.templateId,
+    input.effective.templateVersionId,
+    input.effective.templateHash,
+    input.errorMessage,
+    JSON.stringify({ source: TEMPLATE_REFRESH_SOURCE }),
+    now,
+    input.status === "queued" ? null : now,
+  );
   const row = getRow<RefreshAttemptRow>(
     db,
     "SELECT * FROM resume_template_refresh_attempts WHERE tenant_id = ? AND attempt_id = ?",
     [DEFAULT_TENANT, attemptId],
   );
   if (!row) throw new Error("Template refresh attempt was not persisted.");
-  return refreshAttemptFromRow(row);
+  return refreshAttemptFromRow(row, input.jobId);
 }
 
-function refreshAttemptFromRow(row: RefreshAttemptRow): ResumeTemplateRefreshAttempt {
+function refreshAttemptFromRow(row: RefreshAttemptRow, jobId: JobId): ResumeTemplateRefreshAttempt {
   const status = stringValue(row.status);
   return {
     attemptId: row.attempt_id,
-    jobKey: row.job_url,
+    jobKey: jobId,
     status:
       status === "queued" ||
       status === "completed" ||
@@ -1009,7 +906,7 @@ function refreshAttemptFromRow(row: RefreshAttemptRow): ResumeTemplateRefreshAtt
 
 function persistRenderOnlyRefresh(
   db: SqliteDatabase,
-  jobKey: string,
+  jobId: JobId,
   material: { generation: number; text: MaterialArtifactRow; pdf: MaterialArtifactRow | null },
   effective: ResumeTemplateMetadata,
   renderPdf: ResumeHtmlPdfRenderer,
@@ -1024,8 +921,8 @@ function persistRenderOnlyRefresh(
 
   const outputDir = path.dirname(material.pdf?.path || material.text.path);
   fs.mkdirSync(outputDir, { recursive: true });
-  const generation = nextMaterialGeneration(db, jobKey);
-  const suffix = stableHash([jobKey, generation, effective.templateVersionId, effective.templateHash]).slice(0, 16);
+  const generation = nextMaterialGeneration(db, jobId);
+  const suffix = stableHash([jobId, generation, effective.templateVersionId, effective.templateHash]).slice(0, 16);
   const textArtifactId = `template_refresh_text_${suffix}`;
   const pdfArtifactId = `template_refresh_pdf_${suffix}`;
   const baseName = `resume-template-refresh-${suffix}`;
@@ -1040,109 +937,144 @@ function persistRenderOnlyRefresh(
   fs.writeFileSync(htmlPath, htmlForTemplateRefresh(text, effective), "utf8");
   renderPdf({ htmlPath, pdfPath });
 
-  insertDynamicRow(db, "job_materials", {
-    job_url: jobKey,
+  db.prepare(
+    `INSERT INTO job_materials (
+       tenant_id, job_id, generation, status, created_at, updated_at,
+       last_validation_json, last_verdict_json, metadata_json
+     ) VALUES (?, ?, ?, 'resume_approved', ?, ?, ?, ?, ?)`,
+  ).run(
+    DEFAULT_TENANT,
+    jobId,
     generation,
-    tenant_id: DEFAULT_TENANT,
-    status: "resume_approved",
-    created_at: now,
-    updated_at: now,
-    last_validation_json: JSON.stringify({ passed: true, errors: [], warnings: [] }),
-    last_verdict_json: JSON.stringify({ approved: true, source: TEMPLATE_REFRESH_SOURCE }),
-    metadata_json: JSON.stringify({
+    now,
+    now,
+    JSON.stringify({ passed: true, errors: [], warnings: [] }),
+    JSON.stringify({ approved: true, source: TEMPLATE_REFRESH_SOURCE }),
+    JSON.stringify({
       source: TEMPLATE_REFRESH_SOURCE,
       base_generation: material.generation,
       [TEMPLATE_METADATA_KEY]: templateMetadata,
     }),
-  });
-  insertDynamicRow(db, "job_materials_artifacts", {
-    job_url: jobKey,
+  );
+  insertMaterialArtifact(db, {
+    jobId,
     generation,
-    artifact_type: "tailored_resume",
-    artifact_id: textArtifactId,
-    status: "approved",
+    artifactType: "tailored_resume",
+    artifactId: textArtifactId,
     path: textPath,
-    render_format: "text",
-    size_bytes: fs.statSync(textPath).size,
-    metadata_json: JSON.stringify({
+    renderFormat: "text",
+    sizeBytes: fs.statSync(textPath).size,
+    metadata: {
       source: TEMPLATE_REFRESH_SOURCE,
       base_resume_text_artifact_id: material.text.artifact_id,
       [TEMPLATE_METADATA_KEY]: templateMetadata,
-    }),
-    created_at: now,
-    superseded_at: null,
+    },
+    createdAt: now,
   });
-  insertDynamicRow(db, "job_materials_artifacts", {
-    job_url: jobKey,
+  insertMaterialArtifact(db, {
+    jobId,
     generation,
-    artifact_type: "resume_pdf",
-    artifact_id: pdfArtifactId,
-    status: "approved",
+    artifactType: "resume_pdf",
+    artifactId: pdfArtifactId,
     path: pdfPath,
-    render_format: "html_pdf",
-    size_bytes: fs.statSync(pdfPath).size,
-    metadata_json: JSON.stringify({
+    renderFormat: "html_pdf",
+    sizeBytes: fs.statSync(pdfPath).size,
+    metadata: {
       source: TEMPLATE_REFRESH_SOURCE,
       html_path: htmlPath,
       base_resume_pdf_artifact_id: material.pdf?.artifact_id ?? null,
       layout_box_count: layoutBoxes.length,
       [TEMPLATE_METADATA_KEY]: templateMetadata,
-    }),
-    created_at: now,
-    superseded_at: null,
+    },
+    createdAt: now,
   });
-  replaceLayoutBoxes(db, jobKey, generation, pdfArtifactId, layoutBoxes, now);
+  replaceLayoutBoxes(db, jobId, generation, pdfArtifactId, layoutBoxes, now);
   return { generation };
 }
 
-function nextMaterialGeneration(db: SqliteDatabase, jobKey: string): number {
-  const values: number[] = [];
-  for (const table of ["job_materials", "job_materials_artifacts"]) {
-    if (!tableExists(db, table)) continue;
-    const row = getRow<{ max_generation: number | null }>(
-      db,
-      `SELECT MAX(generation) AS max_generation FROM ${table} WHERE ${table === "job_materials" ? "job_url" : "job_url"} = ?`,
-      [jobKey],
-    );
-    if (row?.max_generation !== null && row?.max_generation !== undefined) values.push(Number(row.max_generation));
-  }
-  return Math.max(0, ...values.filter(Number.isFinite)) + 1;
+function insertMaterialArtifact(
+  db: SqliteDatabase,
+  input: {
+    jobId: JobId;
+    generation: number;
+    artifactType: "tailored_resume" | "resume_pdf";
+    artifactId: string;
+    path: string;
+    renderFormat: "text" | "html_pdf";
+    sizeBytes: number;
+    metadata: Record<string, unknown>;
+    createdAt: string;
+  },
+): void {
+  db.prepare(
+    `INSERT INTO job_materials_artifacts (
+       tenant_id, job_id, generation, artifact_type, artifact_id, status,
+       path, render_format, size_bytes, metadata_json, created_at, superseded_at
+     ) VALUES (?, ?, ?, ?, ?, 'approved', ?, ?, ?, ?, ?, NULL)`,
+  ).run(
+    DEFAULT_TENANT,
+    input.jobId,
+    input.generation,
+    input.artifactType,
+    input.artifactId,
+    input.path,
+    input.renderFormat,
+    input.sizeBytes,
+    JSON.stringify(input.metadata),
+    input.createdAt,
+  );
+}
+
+function nextMaterialGeneration(db: SqliteDatabase, jobId: JobId): number {
+  const row = getRow<{ max_generation: number | null }>(
+    db,
+    `SELECT MAX(generation) AS max_generation
+       FROM job_materials
+      WHERE tenant_id = ? AND job_id = ?`,
+    [DEFAULT_TENANT, jobId],
+  );
+  return Math.max(0, Number(row?.max_generation ?? 0)) + 1;
 }
 
 function replaceLayoutBoxes(
   db: SqliteDatabase,
-  jobKey: string,
+  jobId: JobId,
   generation: number,
   artifactId: string,
   boxes: readonly ResumeLayoutBox[],
   createdAt: string,
 ): void {
-  if (!tableExists(db, "job_material_layout_boxes")) return;
   db.prepare(
-    "DELETE FROM job_material_layout_boxes WHERE job_url = ? AND generation = ? AND artifact_id = ?",
-  ).run(jobKey, generation, artifactId);
+    "DELETE FROM job_material_layout_boxes WHERE tenant_id = ? AND job_id = ? AND generation = ? AND artifact_id = ?",
+  ).run(DEFAULT_TENANT, jobId, generation, artifactId);
   for (const [index, box] of boxes.entries()) {
-    insertDynamicRow(db, "job_material_layout_boxes", {
-      job_url: jobKey,
+    db.prepare(
+      `INSERT INTO job_material_layout_boxes (
+         tenant_id, job_id, generation, artifact_id, box_index, semantic_id,
+         page_number, line_number, text_excerpt, left_pct, top_pct, width_pct,
+         height_pct, audit_target_json, created_at
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    ).run(
+      DEFAULT_TENANT,
+      jobId,
       generation,
-      artifact_id: artifactId,
-      box_index: index,
-      tenant_id: DEFAULT_TENANT,
-      semantic_id: box.semanticId,
-      page_number: box.pageNumber,
-      line_number: box.lineNumber,
-      text_excerpt: box.textExcerpt,
-      left_pct: box.leftPct,
-      top_pct: box.topPct,
-      width_pct: box.widthPct,
-      height_pct: box.heightPct,
-      audit_target_json: JSON.stringify({
+      artifactId,
+      index,
+      box.semanticId,
+      box.pageNumber,
+      box.lineNumber,
+      box.textExcerpt,
+      box.leftPct,
+      box.topPct,
+      box.widthPct,
+      box.heightPct,
+      JSON.stringify({
         source: TEMPLATE_REFRESH_SOURCE,
         semanticId: box.semanticId,
         lineNumber: box.lineNumber,
       }),
-      created_at: createdAt,
-    });
+      createdAt,
+    );
   }
 }
 
@@ -1206,7 +1138,7 @@ function htmlForTemplateRefresh(text: string, effective: ResumeTemplateMetadata)
 }
 
 function noRefreshResponse(
-  jobKey: string,
+  jobId: JobId,
   status: ResumeTemplateRefreshStatus,
   templateState: ResumeTemplateState | null,
   attempt: ResumeTemplateRefreshAttempt | null,
@@ -1214,7 +1146,7 @@ function noRefreshResponse(
 ): EnsureCurrentResumeMaterialsResponse {
   return {
     ok: true,
-    jobKey,
+    jobKey: jobId,
     status,
     templateState,
     attempt,
@@ -1223,62 +1155,49 @@ function noRefreshResponse(
   };
 }
 
-function assertJobExists(db: SqliteDatabase, jobKey: string): void {
-  if (!tableExists(db, "jobs")) return;
-  const row = getRow<{ url: string }>(
+function requireJobId(value: string): JobId {
+  if (!CANONICAL_JOB_ID.test(value)) {
+    throw new ResumeTemplateInputError("jobId must be a canonical lowercase UUID");
+  }
+  return value as JobId;
+}
+
+function assertJobExists(db: SqliteDatabase, jobId: JobId): void {
+  const row = getRow<{ job_id: string }>(
     db,
-    "SELECT url FROM jobs WHERE url = ? OR application_url = ? LIMIT 1",
-    [jobKey, jobKey],
+    "SELECT job_id FROM jobs WHERE tenant_id = ? AND job_id = ?",
+    [DEFAULT_TENANT, jobId],
   );
-  if (!row) throw new ResumeTemplateInputError(`Job not found: ${jobKey}`);
+  if (!row) throw new ResumeTemplateInputError(`Job not found: ${jobId}`);
 }
 
 function recordTemplateEvent(
   db: SqliteDatabase,
   event: {
-    jobUrl: string | null;
+    jobId: JobId | null;
     eventType: string;
     message: string;
     payload: Record<string, unknown>;
   },
 ): void {
-  if (!tableExists(db, "job_events")) return;
-  const columns = tableColumnSet(db, "job_events");
-  const values = {
-    job_url: event.jobUrl,
-    stage: "tailor",
-    event_type: event.eventType,
-    level: event.eventType.endsWith("Failed") ? "warn" : "info",
-    message: event.message,
-    occurred_at: new Date().toISOString(),
-    payload_json: JSON.stringify({
+  db.prepare(
+    `INSERT INTO job_events (
+       tenant_id, job_id, identity_version, stage, event_type, level,
+       message, occurred_at, payload_json, entity_kind, entity_ref, idempotency_key
+     ) VALUES (?, ?, 1, 'tailor', ?, ?, ?, ?, ?, NULL, NULL, NULL)`,
+  ).run(
+    DEFAULT_TENANT,
+    event.jobId,
+    event.eventType,
+    event.eventType.endsWith("Failed") ? "warn" : "info",
+    event.message,
+    new Date().toISOString(),
+    JSON.stringify({
       tenantId: DEFAULT_TENANT,
-      ...(event.jobUrl ? { jobId: event.jobUrl } : {}),
+      ...(event.jobId ? { jobId: event.jobId } : {}),
       ...event.payload,
     }),
-  };
-  const entries = Object.entries(values).filter(([name]) => columns.includes(name));
-  if (!entries.length) return;
-  db.prepare(
-    `INSERT INTO job_events (${entries.map(([name]) => name).join(", ")}) VALUES (${entries.map(() => "?").join(", ")})`,
-  ).run(...entries.map(([, value]) => value));
-}
-
-function insertDynamicRow(
-  db: SqliteDatabase,
-  tableName: string,
-  values: Record<string, SqliteValue>,
-): void {
-  const columns = tableColumnSet(db, tableName).filter((column) => Object.hasOwn(values, column));
-  if (!columns.length) return;
-  const placeholders = columns.map(() => "?").join(", ");
-  db.prepare(
-    `INSERT OR REPLACE INTO ${tableName} (${columns.join(", ")}) VALUES (${placeholders})`,
-  ).run(...columns.map((column) => values[column] ?? null));
-}
-
-function tableColumnSet(db: SqliteDatabase, tableName: string): string[] {
-  return allRows<{ name: string }>(db, `PRAGMA table_info(${tableName})`).map((row) => row.name);
+  );
 }
 
 function templateContentHash(theme: ResumeTemplateTheme, layout: ResumeTemplateLayout): string {

--- a/apps/api/test/resume-templates.test.ts
+++ b/apps/api/test/resume-templates.test.ts
@@ -8,17 +8,20 @@ import {
   BUILT_IN_RESUME_TEMPLATE_THEME,
   createResumeTemplateVersion,
   ensureCurrentResumeTemplateMaterials,
-  ensureResumeTemplateTables,
   getResumeTemplateDetail,
   listResumeTemplates,
   resolveCurrentResumeArtifactIdForOpen,
   ResumeTemplateInputError,
+  resumeTemplateStateForJob,
   setDefaultResumeTemplate,
   setJobResumeTemplateAssignment,
 } from "../src/resume-templates.js";
 import type { ResumeHtmlPdfRenderer } from "../src/resume-pdf-render.js";
 
-const JOB_KEY = "https://example.com/jobs/template-engineer";
+const JOB_ID = "11111111-1111-4111-8111-11111111111a";
+const JOB_URL = "https://example.com/jobs/template-engineer";
+const UUID_SHAPED_URL = "22222222-2222-4222-8222-222222222222";
+const UUID_SHAPED_URL_OWNER_JOB_ID = "33333333-3333-4333-8333-333333333333";
 const NOW = "2026-06-24T10:00:00.000Z";
 
 // Stand-in for the Playwright HTML-to-PDF subprocess: it renders the exact HTML
@@ -44,7 +47,6 @@ afterEach(() => {
 
 describe("resume template service", () => {
   it("saves style-only template versions, default selection, and per-job overrides", () => {
-    ensureResumeTemplateTables(db);
     const initial = listResumeTemplates(db);
     expect(initial.templates).toHaveLength(1);
     expect(initial.templates[0]).toMatchObject({ builtIn: true, displayName: "Modern HTML" });
@@ -73,7 +75,7 @@ describe("resume template service", () => {
       templateId: saved.template.templateId,
     });
 
-    const assignment = setJobResumeTemplateAssignment(db, JOB_KEY, {
+    const assignment = setJobResumeTemplateAssignment(db, JOB_ID, {
       templateId: saved.template.templateId,
       versionId: saved.template.activeVersion.versionId,
     });
@@ -157,7 +159,7 @@ describe("resume template service", () => {
       versionId: saved.template.activeVersion.versionId,
     });
 
-    const refresh = ensureCurrentResumeTemplateMaterials(db, JOB_KEY, {}, renderHtmlToPdf);
+    const refresh = ensureCurrentResumeTemplateMaterials(db, JOB_ID, {}, renderHtmlToPdf);
     expect(refresh.status).toBe("completed");
     expect(refresh.generation).toBe(2);
     expect(refresh.templateState?.state).toBe("template_current");
@@ -221,7 +223,7 @@ describe("resume template service", () => {
       versionId: saved.template.activeVersion.versionId,
     });
 
-    const refresh = ensureCurrentResumeTemplateMaterials(db, JOB_KEY, {}, renderHtmlToPdf);
+    const refresh = ensureCurrentResumeTemplateMaterials(db, JOB_ID, {}, renderHtmlToPdf);
     expect(refresh.status).toBe("unavailable");
     expect(refresh.generation).toBeNull();
     expect(refresh.templateState?.state).toBe("refresh_unavailable");
@@ -263,7 +265,7 @@ describe("resume template service", () => {
       versionId: saved.template.activeVersion.versionId,
     });
 
-    const refresh = ensureCurrentResumeTemplateMaterials(db, JOB_KEY, {}, renderHtmlToPdf);
+    const refresh = ensureCurrentResumeTemplateMaterials(db, JOB_ID, {}, renderHtmlToPdf);
     expect(refresh.status).toBe("completed");
 
     const refreshedPdf = db
@@ -291,7 +293,7 @@ describe("resume template service", () => {
     const failingRenderer: ResumeHtmlPdfRenderer = () => {
       throw new Error("chromium unavailable");
     };
-    const refresh = ensureCurrentResumeTemplateMaterials(db, JOB_KEY, {}, failingRenderer);
+    const refresh = ensureCurrentResumeTemplateMaterials(db, JOB_ID, {}, failingRenderer);
     expect(refresh.status).toBe("failed");
     expect(refresh.generation).toBeNull();
     expect(refresh.templateState?.state).toBe("refresh_failed");
@@ -310,6 +312,66 @@ describe("resume template service", () => {
       .get() as { payload_json: string } | undefined;
     expect(failedEvent?.payload_json).toContain("failed");
   });
+
+  it("uses exact-v7 tenant and JobId keys for assignments, materials, layout, attempts, and events", () => {
+    const saved = createResumeTemplateVersion(db, {
+      displayName: "Tenant-isolated template",
+      theme: { ...BUILT_IN_RESUME_TEMPLATE_THEME, fontFamily: "serif" },
+      layout: {},
+    });
+    setJobResumeTemplateAssignment(db, JOB_ID, {
+      templateId: saved.template.templateId,
+      versionId: saved.template.activeVersion.versionId,
+    });
+    db.prepare(
+      `INSERT INTO job_resume_template_assignments (
+         tenant_id, job_id, template_id, version_id, updated_at
+       ) VALUES ('other', ?, 'built_in:modern-html', 'built_in:modern-html:v1', ?)`,
+    ).run(JOB_ID, NOW);
+
+    expect(resumeTemplateStateForJob(db, JOB_ID)?.effective.templateId).toBe(saved.template.templateId);
+    const refresh = ensureCurrentResumeTemplateMaterials(db, JOB_ID, {}, renderHtmlToPdf);
+    expect(refresh.status).toBe("completed");
+
+    expect(
+      db.prepare(
+        "SELECT tenant_id, job_id FROM job_resume_template_assignments WHERE job_id = ? ORDER BY tenant_id",
+      ).all(JOB_ID),
+    ).toEqual([
+      { tenant_id: "local", job_id: JOB_ID },
+      { tenant_id: "other", job_id: JOB_ID },
+    ]);
+    expect(
+      db.prepare(
+        "SELECT DISTINCT tenant_id, job_id FROM resume_template_refresh_attempts ORDER BY tenant_id, job_id",
+      ).all(),
+    ).toEqual([{ tenant_id: "local", job_id: JOB_ID }]);
+    expect(
+      db.prepare(
+        "SELECT DISTINCT tenant_id, job_id FROM job_material_layout_boxes ORDER BY tenant_id, job_id",
+      ).all(),
+    ).toEqual([{ tenant_id: "local", job_id: JOB_ID }]);
+    expect(
+      db.prepare(
+        "SELECT tenant_id, job_id, identity_version FROM job_events WHERE job_id = ?",
+      ).all(JOB_ID),
+    ).toEqual([
+      { tenant_id: "local", job_id: JOB_ID, identity_version: 1 },
+      { tenant_id: "local", job_id: JOB_ID, identity_version: 1 },
+    ]);
+  });
+
+  it("refuses invalid UUIDs and never treats posting or application URLs as identity", () => {
+    expect(() => setJobResumeTemplateAssignment(db, JOB_URL, { templateId: null })).toThrow(
+      "jobId must be a canonical lowercase UUID",
+    );
+    expect(() => resumeTemplateStateForJob(db, JOB_ID.toUpperCase())).toThrow(
+      "jobId must be a canonical lowercase UUID",
+    );
+    expect(() => ensureCurrentResumeTemplateMaterials(db, UUID_SHAPED_URL, {}, renderHtmlToPdf)).toThrow(
+      `Job not found: ${UUID_SHAPED_URL}`,
+    );
+  });
 });
 
 function seedDatabase(database: Database.Database): void {
@@ -327,82 +389,169 @@ function seedDatabase(database: Database.Database): void {
   fs.writeFileSync(pdfPath, "%PDF-1.4\n% template test\n");
   database.exec(`
     CREATE TABLE jobs (
-      url TEXT PRIMARY KEY,
+      tenant_id TEXT NOT NULL,
+      job_id TEXT NOT NULL,
+      url TEXT NOT NULL,
       title TEXT,
       company TEXT,
       application_url TEXT,
-      discovered_at TEXT
+      discovered_at TEXT,
+      PRIMARY KEY (tenant_id, job_id),
+      UNIQUE (tenant_id, url)
     );
     CREATE TABLE candidate_profiles (
-      tenant_id TEXT,
-      profile_id TEXT,
-      personal_full_name TEXT,
-      personal_email TEXT,
-      personal_phone TEXT,
-      personal_linkedin_url TEXT,
-      personal_github_url TEXT,
-      personal_portfolio_url TEXT,
-      personal_website_url TEXT,
+      tenant_id TEXT NOT NULL,
+      profile_id TEXT NOT NULL,
+      personal_full_name TEXT NOT NULL DEFAULT '',
+      personal_email TEXT NOT NULL DEFAULT '',
+      personal_phone TEXT NOT NULL DEFAULT '',
+      personal_linkedin_url TEXT NOT NULL DEFAULT '',
+      personal_github_url TEXT NOT NULL DEFAULT '',
+      personal_portfolio_url TEXT NOT NULL DEFAULT '',
+      personal_website_url TEXT NOT NULL DEFAULT '',
       PRIMARY KEY (tenant_id, profile_id)
     );
     CREATE TABLE job_events (
       event_id INTEGER PRIMARY KEY AUTOINCREMENT,
-      job_url TEXT,
+      tenant_id TEXT NOT NULL,
+      job_id TEXT,
+      identity_version INTEGER NOT NULL,
       stage TEXT,
       event_type TEXT NOT NULL,
-      level TEXT NOT NULL,
+      level TEXT NOT NULL DEFAULT 'info',
       message TEXT,
       occurred_at TEXT NOT NULL,
-      payload_json TEXT
+      payload_json TEXT,
+      entity_kind TEXT,
+      entity_ref TEXT,
+      idempotency_key TEXT,
+      FOREIGN KEY (tenant_id, job_id) REFERENCES jobs(tenant_id, job_id) ON DELETE CASCADE
     );
     CREATE TABLE job_materials (
-      job_url TEXT NOT NULL,
-      generation INTEGER NOT NULL,
-      tenant_id TEXT,
-      status TEXT,
-      created_at TEXT,
-      updated_at TEXT,
+      tenant_id TEXT NOT NULL DEFAULT 'local',
+      job_id TEXT NOT NULL,
+      generation INTEGER NOT NULL CHECK(generation > 0),
+      status TEXT NOT NULL,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
       last_validation_json TEXT,
       last_verdict_json TEXT,
       metadata_json TEXT,
-      PRIMARY KEY (job_url, generation)
+      PRIMARY KEY (tenant_id, job_id, generation),
+      FOREIGN KEY (tenant_id, job_id) REFERENCES jobs(tenant_id, job_id) ON DELETE CASCADE
     );
     CREATE TABLE job_materials_artifacts (
-      job_url TEXT NOT NULL,
-      generation INTEGER NOT NULL,
+      tenant_id TEXT NOT NULL DEFAULT 'local',
+      job_id TEXT NOT NULL,
+      generation INTEGER NOT NULL CHECK(generation > 0),
       artifact_type TEXT NOT NULL,
       artifact_id TEXT NOT NULL,
-      status TEXT,
-      path TEXT,
-      render_format TEXT,
+      status TEXT NOT NULL,
+      path TEXT NOT NULL,
+      render_format TEXT NOT NULL,
       size_bytes INTEGER,
       metadata_json TEXT,
-      created_at TEXT,
+      created_at TEXT NOT NULL,
       superseded_at TEXT,
-      PRIMARY KEY (job_url, generation, artifact_id)
+      PRIMARY KEY (tenant_id, job_id, generation, artifact_type),
+      FOREIGN KEY (tenant_id, job_id, generation)
+        REFERENCES job_materials(tenant_id, job_id, generation) ON DELETE CASCADE
     );
     CREATE TABLE job_material_layout_boxes (
-      job_url TEXT NOT NULL,
-      generation INTEGER NOT NULL,
+      tenant_id TEXT NOT NULL DEFAULT 'local',
+      job_id TEXT NOT NULL,
+      generation INTEGER NOT NULL CHECK(generation > 0),
       artifact_id TEXT NOT NULL,
       box_index INTEGER NOT NULL,
-      tenant_id TEXT,
-      semantic_id TEXT,
-      page_number INTEGER,
+      semantic_id TEXT NOT NULL,
+      page_number INTEGER NOT NULL,
       line_number INTEGER,
-      text_excerpt TEXT,
-      left_pct REAL,
-      top_pct REAL,
-      width_pct REAL,
-      height_pct REAL,
-      audit_target_json TEXT,
-      created_at TEXT,
-      PRIMARY KEY (job_url, generation, artifact_id, box_index)
+      text_excerpt TEXT NOT NULL,
+      left_pct REAL NOT NULL,
+      top_pct REAL NOT NULL,
+      width_pct REAL NOT NULL,
+      height_pct REAL NOT NULL,
+      audit_target_json TEXT NOT NULL DEFAULT '{}',
+      created_at TEXT NOT NULL,
+      PRIMARY KEY (tenant_id, job_id, generation, artifact_id, box_index),
+      FOREIGN KEY (tenant_id, job_id, generation)
+        REFERENCES job_materials(tenant_id, job_id, generation) ON DELETE CASCADE
+    );
+    CREATE TABLE resume_templates (
+      tenant_id TEXT NOT NULL DEFAULT 'local',
+      template_id TEXT NOT NULL,
+      display_name TEXT NOT NULL,
+      status TEXT NOT NULL DEFAULT 'active',
+      built_in INTEGER NOT NULL DEFAULT 0,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
+      PRIMARY KEY (tenant_id, template_id)
+    );
+    CREATE TABLE resume_template_versions (
+      tenant_id TEXT NOT NULL DEFAULT 'local',
+      version_id TEXT NOT NULL,
+      template_id TEXT NOT NULL,
+      version_number INTEGER NOT NULL,
+      display_name TEXT NOT NULL,
+      status TEXT NOT NULL DEFAULT 'active',
+      theme_json TEXT NOT NULL,
+      layout_json TEXT NOT NULL DEFAULT '{}',
+      content_hash TEXT NOT NULL,
+      created_at TEXT NOT NULL,
+      PRIMARY KEY (tenant_id, version_id),
+      UNIQUE (tenant_id, template_id, version_number)
+    );
+    CREATE TABLE resume_template_defaults (
+      tenant_id TEXT NOT NULL DEFAULT 'local',
+      profile_id TEXT NOT NULL DEFAULT 'default',
+      template_id TEXT NOT NULL,
+      version_id TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
+      PRIMARY KEY (tenant_id, profile_id)
+    );
+    CREATE TABLE job_resume_template_assignments (
+      tenant_id TEXT NOT NULL DEFAULT 'local',
+      job_id TEXT NOT NULL,
+      template_id TEXT NOT NULL,
+      version_id TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
+      PRIMARY KEY (tenant_id, job_id),
+      FOREIGN KEY (tenant_id, job_id) REFERENCES jobs(tenant_id, job_id) ON DELETE CASCADE
+    );
+    CREATE TABLE resume_template_refresh_attempts (
+      tenant_id TEXT NOT NULL DEFAULT 'local',
+      attempt_id TEXT NOT NULL,
+      job_id TEXT NOT NULL,
+      status TEXT NOT NULL,
+      from_generation INTEGER,
+      to_generation INTEGER,
+      template_id TEXT,
+      template_version_id TEXT,
+      template_hash TEXT,
+      error_message TEXT,
+      metadata_json TEXT NOT NULL DEFAULT '{}',
+      created_at TEXT NOT NULL,
+      completed_at TEXT,
+      PRIMARY KEY (tenant_id, attempt_id),
+      FOREIGN KEY (tenant_id, job_id) REFERENCES jobs(tenant_id, job_id) ON DELETE CASCADE
     );
   `);
+  database.pragma("foreign_keys = ON");
   database
-    .prepare("INSERT INTO jobs (url, title, company, application_url, discovered_at) VALUES (?, ?, ?, ?, ?)")
-    .run(JOB_KEY, "Senior Platform Engineer", "Globex Infrastructure", "https://apply.example.com/globex", NOW);
+    .prepare(
+      "INSERT INTO jobs (tenant_id, job_id, url, title, company, application_url, discovered_at) VALUES ('local', ?, ?, ?, ?, ?, ?)",
+    )
+    .run(JOB_ID, JOB_URL, "Senior Platform Engineer", "Globex Infrastructure", "https://apply.example.com/globex", NOW);
+  database
+    .prepare(
+      "INSERT INTO jobs (tenant_id, job_id, url, title, company, application_url, discovered_at) VALUES ('local', ?, ?, ?, ?, ?, ?)",
+    )
+    .run(UUID_SHAPED_URL_OWNER_JOB_ID, UUID_SHAPED_URL, "URL-shaped locator", "Example", "https://apply.example.com/uuid", NOW);
+  database
+    .prepare(
+      "INSERT INTO jobs (tenant_id, job_id, url, title, company, application_url, discovered_at) VALUES ('other', ?, ?, ?, ?, ?, ?)",
+    )
+    .run(JOB_ID, "https://other.example/jobs/template-engineer", "Other tenant job", "Other", "https://other.example/apply", NOW);
   database
     .prepare(
       `INSERT INTO candidate_profiles (
@@ -413,12 +562,12 @@ function seedDatabase(database: Database.Database): void {
   database
     .prepare(
       `INSERT INTO job_materials (
-         job_url, generation, tenant_id, status, created_at, updated_at,
+         tenant_id, job_id, generation, status, created_at, updated_at,
          last_validation_json, last_verdict_json, metadata_json
-       ) VALUES (?, 1, 'local', 'resume_approved', ?, ?, ?, ?, ?)`,
+       ) VALUES ('local', ?, 1, 'resume_approved', ?, ?, ?, ?, ?)`,
     )
     .run(
-      JOB_KEY,
+      JOB_ID,
       NOW,
       NOW,
       JSON.stringify({ passed: true, errors: [], warnings: [] }),
@@ -437,12 +586,12 @@ function seedDatabase(database: Database.Database): void {
   database
     .prepare(
       `INSERT INTO job_materials_artifacts (
-         job_url, generation, artifact_type, artifact_id, status, path, render_format,
+         tenant_id, job_id, generation, artifact_type, artifact_id, status, path, render_format,
          size_bytes, metadata_json, created_at, superseded_at
-       ) VALUES (?, 1, ?, ?, 'approved', ?, ?, ?, ?, ?, NULL)`,
+       ) VALUES ('local', ?, 1, ?, ?, 'approved', ?, ?, ?, ?, ?, NULL)`,
     )
     .run(
-      JOB_KEY,
+      JOB_ID,
       "tailored_resume",
       "resume-text-v1",
       resumePath,
@@ -454,12 +603,12 @@ function seedDatabase(database: Database.Database): void {
   database
     .prepare(
       `INSERT INTO job_materials_artifacts (
-         job_url, generation, artifact_type, artifact_id, status, path, render_format,
+         tenant_id, job_id, generation, artifact_type, artifact_id, status, path, render_format,
          size_bytes, metadata_json, created_at, superseded_at
-       ) VALUES (?, 1, ?, ?, 'approved', ?, ?, ?, ?, ?, NULL)`,
+       ) VALUES ('local', ?, 1, ?, ?, 'approved', ?, ?, ?, ?, ?, NULL)`,
     )
     .run(
-      JOB_KEY,
+      JOB_ID,
       "resume_pdf",
       "resume-pdf-v1",
       pdfPath,
@@ -468,4 +617,24 @@ function seedDatabase(database: Database.Database): void {
       JSON.stringify({ resume_template: { templateId: "built_in:modern-html", templateVersionId: "built_in:modern-html:v1", templateVersionNumber: 1, templateName: "Modern HTML", templateHash: "seed-hash", assignmentSource: "built_in" } }),
       NOW,
     );
+  seedBuiltInTemplate(database);
+}
+
+function seedBuiltInTemplate(database: Database.Database): void {
+  database
+    .prepare(
+      `INSERT INTO resume_templates (
+         tenant_id, template_id, display_name, status, built_in, created_at, updated_at
+       ) VALUES ('local', 'built_in:modern-html', 'Modern HTML', 'active', 1, ?, ?)`,
+    )
+    .run(NOW, NOW);
+  database
+    .prepare(
+      `INSERT INTO resume_template_versions (
+         tenant_id, version_id, template_id, version_number, display_name, status,
+         theme_json, layout_json, content_hash, created_at
+       ) VALUES ('local', 'built_in:modern-html:v1', 'built_in:modern-html', 1,
+                 'Modern HTML', 'active', ?, '{}', 'seed-hash', ?)`,
+    )
+    .run(JSON.stringify(BUILT_IN_RESUME_TEMPLATE_THEME), NOW);
 }

--- a/workers/automation/src/jobctrl/database.py
+++ b/workers/automation/src/jobctrl/database.py
@@ -1844,50 +1844,12 @@ def ensure_resume_template_tables(conn: sqlite3.Connection | None = None) -> lis
         """
     )
 
-    import hashlib
+    from jobctrl.infrastructure.migrations.resume_template_seed import (
+        seed_builtin_resume_template,
+    )
 
-    theme = {
-        "pageSize": "a4",
-        "fontFamily": "sans",
-        "fontScale": 1,
-        "density": "balanced",
-        "marginMm": {"top": 16.5, "right": 17.5, "bottom": 18, "left": 17.5},
-        "headerLayout": "centered",
-        "sectionHeadingStyle": "rule",
-        "alignment": "justified",
-        "bulletSpacing": "normal",
-        "accentColor": "#111111",
-        "sectionOrder": ["summary", "experience", "education", "skills"],
-        "hiddenSections": [],
-    }
-    layout: dict[str, object] = {}
-    content_hash = hashlib.sha256(
-        json.dumps([theme, layout], separators=(",", ":")).encode("utf-8")
-    ).hexdigest()
     now = datetime.now(timezone.utc).isoformat()
-    conn.execute(
-        """
-        INSERT OR IGNORE INTO resume_templates (
-            tenant_id, template_id, display_name, status, built_in, created_at, updated_at
-        ) VALUES ('local', 'built_in:modern-html', 'Modern HTML', 'active', 1, ?, ?)
-        """,
-        (now, now),
-    )
-    conn.execute(
-        """
-        INSERT OR IGNORE INTO resume_template_versions (
-            tenant_id, version_id, template_id, version_number, display_name, status,
-            theme_json, layout_json, content_hash, created_at
-        ) VALUES ('local', 'built_in:modern-html:v1', 'built_in:modern-html', 1,
-                  'Modern HTML', 'active', ?, ?, ?, ?)
-        """,
-        (
-            json.dumps(theme, sort_keys=True),
-            json.dumps(layout, sort_keys=True),
-            content_hash,
-            now,
-        ),
-    )
+    seed_builtin_resume_template(conn, created_at=now)
     conn.commit()
     return [
         "resume_templates",

--- a/workers/automation/src/jobctrl/domain/materials/use_cases.py
+++ b/workers/automation/src/jobctrl/domain/materials/use_cases.py
@@ -1699,7 +1699,11 @@ class TailorResumeUseCase:
             validation_mode=validation_mode,
             tenant_id=tenant_id,
         )
-        resume_template = _resolve_effective_resume_template(self._repository, job_id)
+        resume_template = _resolve_effective_resume_template(
+            self._repository,
+            tenant_id,
+            job_id,
+        )
         policy_metadata = tailoring_policy.as_artifact_metadata()
         tailoring_metadata = {
             "validation_mode": validation_mode,
@@ -3331,13 +3335,14 @@ def _load_current_approved_materials(
 
 def _resolve_effective_resume_template(
     repository: MaterialsRepository,
+    tenant_id: TenantId,
     job_id: JobId,
 ) -> dict[str, Any] | None:
     resolver = getattr(repository, "resolve_effective_resume_template", None)
     if not callable(resolver):
         return None
     try:
-        resolved = resolver(job_id)
+        resolved = resolver(tenant_id, job_id)
     except Exception:  # noqa: BLE001 -- template metadata must not block tailoring
         log.exception("Failed to resolve effective resume template for %s", job_id)
         return None
@@ -3750,7 +3755,11 @@ class RenderPdfUseCase:
         ):
             text_path = Path(materials.tailored_resume.path)
             pdf_path = text_path.with_suffix(".pdf")
-            resume_template = _resolve_effective_resume_template(self._repository, job_id)
+            resume_template = _resolve_effective_resume_template(
+                self._repository,
+                tenant_id,
+                job_id,
+            )
             try:
                 pdf_artifact = self._resume_renderer.render_resume_to_pdf(
                     tailored_payload=tailored_payload,

--- a/workers/automation/src/jobctrl/infrastructure/materials/sqlite_repository.py
+++ b/workers/automation/src/jobctrl/infrastructure/materials/sqlite_repository.py
@@ -171,26 +171,29 @@ class SqliteMaterialsRepository:
             return None
         return self._row_to_materials(row, tenant_id)
 
-    def resolve_effective_resume_template(self, job_id: JobId) -> dict[str, Any]:
+    def resolve_effective_resume_template(
+        self,
+        tenant_id: TenantId,
+        job_id: JobId,
+    ) -> dict[str, Any]:
         """Return the effective resume template for ``job_id``.
 
         This is an infrastructure convenience used by local render wiring. It
         mirrors the TypeScript API resolution order: per-job override, profile
         default, built-in default.
         """
-        from jobctrl.database import ensure_resume_template_tables
-
-        ensure_resume_template_tables(self._conn)
+        stable_job_id = canonical_job_id(str(job_id))
         assignment = self._conn.execute(
             """
             SELECT template_id, version_id
               FROM job_resume_template_assignments
-             WHERE tenant_id = 'local' AND job_url = ?
+             WHERE tenant_id = ? AND job_id = ?
             """,
-            (str(job_id),),
+            (str(tenant_id), str(stable_job_id)),
         ).fetchone()
         if assignment is not None:
             resolved = self._template_by_id(
+                tenant_id,
                 str(assignment["template_id"]),
                 str(assignment["version_id"]),
                 "job_override",
@@ -201,11 +204,13 @@ class SqliteMaterialsRepository:
             """
             SELECT template_id, version_id
               FROM resume_template_defaults
-             WHERE tenant_id = 'local' AND profile_id = 'default'
-            """
+             WHERE tenant_id = ? AND profile_id = 'default'
+            """,
+            (str(tenant_id),),
         ).fetchone()
         if default is not None:
             resolved = self._template_by_id(
+                tenant_id,
                 str(default["template_id"]),
                 str(default["version_id"]),
                 "profile_default",
@@ -213,6 +218,7 @@ class SqliteMaterialsRepository:
             if resolved:
                 return resolved
         resolved = self._template_by_id(
+            tenant_id,
             "built_in:modern-html",
             "built_in:modern-html:v1",
             "built_in",
@@ -718,6 +724,7 @@ class SqliteMaterialsRepository:
 
     def _template_by_id(
         self,
+        tenant_id: TenantId,
         template_id: str,
         version_id: str,
         assignment_source: str,
@@ -731,12 +738,12 @@ class SqliteMaterialsRepository:
               JOIN resume_template_versions v
                 ON v.tenant_id = t.tenant_id
                AND v.template_id = t.template_id
-             WHERE t.tenant_id = 'local'
+             WHERE t.tenant_id = ?
                AND t.template_id = ?
                AND v.version_id = ?
              LIMIT 1
             """,
-            (template_id, version_id),
+            (str(tenant_id), template_id, version_id),
         ).fetchone()
         if row is None:
             return None

--- a/workers/automation/src/jobctrl/infrastructure/migrations/resume_template_seed.py
+++ b/workers/automation/src/jobctrl/infrastructure/migrations/resume_template_seed.py
@@ -1,0 +1,67 @@
+"""Canonical built-in resume-template seed for v7 storage paths."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+from typing import Final
+
+
+_BUILT_IN_TEMPLATE_ID: Final = "built_in:modern-html"
+_BUILT_IN_VERSION_ID: Final = "built_in:modern-html:v1"
+_BUILT_IN_CREATED_AT: Final = "1970-01-01T00:00:00+00:00"
+_BUILT_IN_THEME: Final = {
+    "pageSize": "a4",
+    "fontFamily": "sans",
+    "fontScale": 1,
+    "density": "balanced",
+    "marginMm": {"top": 16.5, "right": 17.5, "bottom": 18, "left": 17.5},
+    "headerLayout": "centered",
+    "sectionHeadingStyle": "rule",
+    "alignment": "justified",
+    "bulletSpacing": "normal",
+    "accentColor": "#111111",
+    "sectionOrder": ["summary", "experience", "education", "skills"],
+    "hiddenSections": [],
+}
+_BUILT_IN_LAYOUT: Final[dict[str, object]] = {}
+
+
+def seed_builtin_resume_template(
+    conn: sqlite3.Connection,
+    *,
+    created_at: str = _BUILT_IN_CREATED_AT,
+) -> None:
+    """Add the local built-in template without replacing a persisted seed."""
+    theme_json = json.dumps(_BUILT_IN_THEME, sort_keys=True)
+    layout_json = json.dumps(_BUILT_IN_LAYOUT, sort_keys=True)
+    content_hash = hashlib.sha256(
+        json.dumps([_BUILT_IN_THEME, _BUILT_IN_LAYOUT], separators=(",", ":")).encode(
+            "utf-8"
+        )
+    ).hexdigest()
+    conn.execute(
+        """
+        INSERT OR IGNORE INTO resume_templates (
+            tenant_id, template_id, display_name, status, built_in, created_at, updated_at
+        ) VALUES ('local', ?, 'Modern HTML', 'active', 1, ?, ?)
+        """,
+        (_BUILT_IN_TEMPLATE_ID, created_at, created_at),
+    )
+    conn.execute(
+        """
+        INSERT OR IGNORE INTO resume_template_versions (
+            tenant_id, version_id, template_id, version_number, display_name, status,
+            theme_json, layout_json, content_hash, created_at
+        ) VALUES ('local', ?, ?, 1, 'Modern HTML', 'active', ?, ?, ?, ?)
+        """,
+        (
+            _BUILT_IN_VERSION_ID,
+            _BUILT_IN_TEMPLATE_ID,
+            theme_json,
+            layout_json,
+            content_hash,
+            created_at,
+        ),
+    )

--- a/workers/automation/src/jobctrl/infrastructure/migrations/schema_v7.py
+++ b/workers/automation/src/jobctrl/infrastructure/migrations/schema_v7.py
@@ -6,6 +6,9 @@ import sqlite3
 from collections.abc import Callable
 from importlib.resources import files
 
+from jobctrl.infrastructure.migrations.resume_template_seed import (
+    seed_builtin_resume_template,
+)
 from jobctrl.infrastructure.migrations.schema_manifest import (
     EXACT_V7_MANIFEST,
     SchemaManifestError,
@@ -69,6 +72,7 @@ def _create_exact_v7_schema(
         for statement in _schema_statements():
             execute(statement)
         if stamp_version:
+            seed_builtin_resume_template(conn)
             execute(f"PRAGMA user_version = {EXACT_V7_MANIFEST.version}")
         assert_exact_manifest(conn, EXACT_V7_MANIFEST)
         conn.execute("RELEASE SAVEPOINT exact_v7_schema")

--- a/workers/automation/src/jobctrl/infrastructure/migrations/v6_to_v7_copy.py
+++ b/workers/automation/src/jobctrl/infrastructure/migrations/v6_to_v7_copy.py
@@ -9,6 +9,9 @@ from dataclasses import dataclass
 from types import MappingProxyType
 from typing import Final
 
+from jobctrl.infrastructure.migrations.resume_template_seed import (
+    seed_builtin_resume_template,
+)
 from jobctrl.infrastructure.migrations.schema_manifest import (
     EXACT_V7_MANIFEST,
     assert_exact_manifest,
@@ -142,6 +145,7 @@ def copy_direct_and_scalar_tables(
     try:
         for table in ordered_tables:
             _copy_table(source, candidate, table, job_ids)
+        seed_builtin_resume_template(candidate)
         violations = candidate.execute("PRAGMA foreign_key_check").fetchall()
         if violations:
             raise CandidateCopyError(

--- a/workers/automation/tests/test_materials_repository_v7.py
+++ b/workers/automation/tests/test_materials_repository_v7.py
@@ -124,6 +124,170 @@ def _rejected(generation: int) -> MaterialsSet:
     )
 
 
+def _seed_resume_template(
+    conn: sqlite3.Connection,
+    *,
+    tenant_id: TenantId,
+    template_id: str,
+    version_id: str,
+    name: str,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO resume_templates (
+            tenant_id, template_id, display_name, status, built_in, created_at, updated_at
+        ) VALUES (?, ?, ?, 'active', ?, ?, ?)
+        """,
+        (
+            str(tenant_id),
+            template_id,
+            name,
+            int(template_id.startswith("built_in:")),
+            CREATED_AT,
+            CREATED_AT,
+        ),
+    )
+    conn.execute(
+        """
+        INSERT INTO resume_template_versions (
+            tenant_id, version_id, template_id, version_number, display_name,
+            status, theme_json, layout_json, content_hash, created_at
+        ) VALUES (?, ?, ?, 1, ?, 'active', ?, '{}', ?, ?)
+        """,
+        (
+            str(tenant_id),
+            version_id,
+            template_id,
+            name,
+            '{"template": "' + template_id + '"}',
+            f"hash:{template_id}",
+            CREATED_AT,
+        ),
+    )
+
+
+def test_fresh_v7_resolves_the_builtin_template_without_runtime_setup(
+    conn: sqlite3.Connection,
+) -> None:
+    resolved = SqliteMaterialsRepository(conn).resolve_effective_resume_template(
+        LOCAL_TENANT,
+        JOB_ID,
+    )
+
+    assert resolved["metadata"]["templateId"] == "built_in:modern-html"
+    assert resolved["metadata"]["assignmentSource"] == "built_in"
+
+
+def test_effective_template_resolution_uses_v7_identity_and_precedence(
+    conn: sqlite3.Connection,
+) -> None:
+    repo = SqliteMaterialsRepository(conn)
+    _seed_resume_template(
+        conn,
+        tenant_id=LOCAL_TENANT,
+        template_id="profile-template",
+        version_id="profile-version",
+        name="Profile default",
+    )
+    _seed_resume_template(
+        conn,
+        tenant_id=LOCAL_TENANT,
+        template_id="job-template",
+        version_id="job-version",
+        name="Job override",
+    )
+    conn.execute(
+        """
+        INSERT INTO resume_template_defaults (
+            tenant_id, profile_id, template_id, version_id, updated_at
+        ) VALUES (?, 'default', 'profile-template', 'profile-version', ?)
+        """,
+        (str(LOCAL_TENANT), CREATED_AT),
+    )
+    conn.execute(
+        """
+        INSERT INTO job_resume_template_assignments (
+            tenant_id, job_id, template_id, version_id, updated_at
+        ) VALUES (?, ?, 'job-template', 'job-version', ?)
+        """,
+        (str(LOCAL_TENANT), str(JOB_ID), CREATED_AT),
+    )
+    conn.commit()
+
+    override = repo.resolve_effective_resume_template(LOCAL_TENANT, JOB_ID)
+    assert override["metadata"]["templateId"] == "job-template"
+    assert override["metadata"]["assignmentSource"] == "job_override"
+
+    conn.execute("DELETE FROM job_resume_template_assignments")
+    default = repo.resolve_effective_resume_template(LOCAL_TENANT, JOB_ID)
+    assert default["metadata"]["templateId"] == "profile-template"
+    assert default["metadata"]["assignmentSource"] == "profile_default"
+
+    conn.execute("DELETE FROM resume_template_defaults")
+    built_in = repo.resolve_effective_resume_template(LOCAL_TENANT, JOB_ID)
+    assert built_in["metadata"]["templateId"] == "built_in:modern-html"
+    assert built_in["metadata"]["assignmentSource"] == "built_in"
+
+    with pytest.raises(ValueError, match="canonical UUID"):
+        repo.resolve_effective_resume_template(LOCAL_TENANT, JobId(JOB_URL))
+
+
+def test_effective_template_resolution_is_tenant_scoped(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        """
+        INSERT INTO jobs (tenant_id, job_id, url, title, site)
+        VALUES (?, ?, ?, ?, ?)
+        """,
+        (str(OTHER_TENANT), str(JOB_ID), JOB_URL, "Materials Engineer", "Example"),
+    )
+    _seed_resume_template(
+        conn,
+        tenant_id=LOCAL_TENANT,
+        template_id="local-template",
+        version_id="local-version",
+        name="Local default",
+    )
+    _seed_resume_template(
+        conn,
+        tenant_id=OTHER_TENANT,
+        template_id="other-template",
+        version_id="other-version",
+        name="Other default",
+    )
+    conn.executemany(
+        """
+        INSERT INTO resume_template_defaults (
+            tenant_id, profile_id, template_id, version_id, updated_at
+        ) VALUES (?, 'default', ?, ?, ?)
+        """,
+        (
+            (str(LOCAL_TENANT), "local-template", "local-version", CREATED_AT),
+            (str(OTHER_TENANT), "other-template", "other-version", CREATED_AT),
+        ),
+    )
+    conn.executemany(
+        """
+        INSERT INTO job_resume_template_assignments (
+            tenant_id, job_id, template_id, version_id, updated_at
+        ) VALUES (?, ?, ?, ?, ?)
+        """,
+        (
+            (str(LOCAL_TENANT), str(JOB_ID), "local-template", "local-version", CREATED_AT),
+            (str(OTHER_TENANT), str(JOB_ID), "other-template", "other-version", CREATED_AT),
+        ),
+    )
+    conn.commit()
+
+    resolved = SqliteMaterialsRepository(conn).resolve_effective_resume_template(
+        OTHER_TENANT,
+        JOB_ID,
+    )
+
+    assert resolved["metadata"]["templateId"] == "other-template"
+    assert resolved["metadata"]["assignmentSource"] == "job_override"
+    assert resolved["theme"] == {"template": "other-template"}
+
+
 def test_exact_v7_round_trip_persists_artifact_and_layout_identity(
     conn: sqlite3.Connection,
 ) -> None:

--- a/workers/automation/tests/test_materials_use_cases.py
+++ b/workers/automation/tests/test_materials_use_cases.py
@@ -300,7 +300,7 @@ class _TemplateRepository(_FakeRepository):
         super().__init__()
         self.resume_template = resume_template
 
-    def resolve_effective_resume_template(self, job_id) -> dict:
+    def resolve_effective_resume_template(self, tenant_id, job_id) -> dict:
         return self.resume_template
 
 

--- a/workers/automation/tests/test_v6_to_v7_artifact_list_projections.py
+++ b/workers/automation/tests/test_v6_to_v7_artifact_list_projections.py
@@ -9,7 +9,9 @@ from pathlib import Path
 
 import pytest
 
-from jobctrl.infrastructure.migrations.schema_v7 import create_exact_v7_schema
+from jobctrl.infrastructure.migrations.schema_v7 import (
+    create_unstamped_exact_v7_candidate,
+)
 from jobctrl.infrastructure.migrations.v6_to_v7_artifact_list_projections import (
     CandidateArtifactListProjectionsError,
     rebuild_artifact_list_projections,
@@ -60,7 +62,7 @@ def _databases(
     candidate_path = tmp_path / "candidate.db"
     candidate = sqlite3.connect(candidate_path)
     candidate.execute("PRAGMA foreign_keys = ON")
-    create_exact_v7_schema(candidate)
+    create_unstamped_exact_v7_candidate(candidate)
     return source, candidate, source_path, candidate_path
 
 

--- a/workers/automation/tests/test_v6_to_v7_candidate.py
+++ b/workers/automation/tests/test_v6_to_v7_candidate.py
@@ -411,8 +411,48 @@ def test_population_accepts_an_empty_shipped_workspace_without_spurious_rows(
             for table in sorted(target_tables())
             if candidate.execute(f'SELECT COUNT(*) FROM "{table}"').fetchone()[0]
         }
-        assert nonempty_rows == {"dashboard_projections": 1}
+        assert nonempty_rows == {
+            "dashboard_projections": 1,
+            "resume_template_versions": 1,
+            "resume_templates": 1,
+        }
         assert _sequence_rows(candidate) == ()
+    finally:
+        source.close()
+        candidate.close()
+
+
+def test_population_seeds_the_builtin_template_when_v6_omits_it(
+    tmp_path: Path,
+) -> None:
+    source, candidate = _connections(tmp_path)
+    try:
+        source.execute("DELETE FROM job_resume_template_assignments")
+        source.execute("DELETE FROM resume_template_defaults")
+        source.execute("DELETE FROM resume_template_versions")
+        source.execute("DELETE FROM resume_templates")
+        source.commit()
+
+        result = populate_v7_candidate(
+            source,
+            candidate,
+            migration_at=_MIGRATION_AT,
+            job_id_factory=_allocator(*_JOB_IDS),
+        )
+
+        _assert_successful_result(
+            result,
+            candidate,
+            source_digest=source_logical_digest(source),
+            source_total_changes=source.total_changes,
+        )
+        assert candidate.execute(
+            """
+            SELECT template_id, version_id
+            FROM resume_templates
+            JOIN resume_template_versions USING (tenant_id, template_id)
+            """
+        ).fetchall() == [("built_in:modern-html", "built_in:modern-html:v1")]
     finally:
         source.close()
         candidate.close()

--- a/workers/automation/tests/test_v6_to_v7_copy.py
+++ b/workers/automation/tests/test_v6_to_v7_copy.py
@@ -7,7 +7,9 @@ from pathlib import Path
 
 import pytest
 
-from jobctrl.infrastructure.migrations.schema_v7 import create_exact_v7_schema
+from jobctrl.infrastructure.migrations.schema_v7 import (
+    create_unstamped_exact_v7_candidate,
+)
 from jobctrl.infrastructure.migrations.v6_to_v7_copy import (
     CandidateCopyError,
     copy_direct_and_scalar_tables,
@@ -41,7 +43,7 @@ def _connections(
 
     candidate = sqlite3.connect(tmp_path / "candidate.db")
     candidate.execute("PRAGMA foreign_keys = ON")
-    create_exact_v7_schema(candidate)
+    create_unstamped_exact_v7_candidate(candidate)
     if hydrate_jobs:
         _hydrate_candidate_jobs(source, candidate)
     return source, candidate

--- a/workers/automation/tests/test_v6_to_v7_copy.py
+++ b/workers/automation/tests/test_v6_to_v7_copy.py
@@ -263,7 +263,7 @@ def test_candidate_copy_preserves_runtime_profile_attestations(tmp_path: Path) -
     source.execute("PRAGMA foreign_keys = ON")
     candidate = sqlite3.connect(tmp_path / "candidate.db")
     candidate.execute("PRAGMA foreign_keys = ON")
-    create_exact_v7_schema(candidate)
+    create_unstamped_exact_v7_candidate(candidate)
     _hydrate_candidate_jobs(source, candidate)
     try:
         source.execute(

--- a/workers/automation/tests/test_v6_to_v7_duplicate_links.py
+++ b/workers/automation/tests/test_v6_to_v7_duplicate_links.py
@@ -11,7 +11,9 @@ import pytest
 
 from jobctrl.domain.discovery.identity import normalize_observed_url
 from jobctrl.infrastructure.migrations import v6_to_v7_duplicate_links as duplicate_links
-from jobctrl.infrastructure.migrations.schema_v7 import create_exact_v7_schema
+from jobctrl.infrastructure.migrations.schema_v7 import (
+    create_unstamped_exact_v7_candidate,
+)
 from jobctrl.infrastructure.migrations.v6_to_v7_copy import copy_direct_and_scalar_tables
 from jobctrl.infrastructure.migrations.v6_to_v7_duplicate_links import (
     CandidateDuplicateLinkCopyError,
@@ -39,7 +41,7 @@ def _connections(tmp_path: Path) -> tuple[sqlite3.Connection, sqlite3.Connection
     source.execute("PRAGMA foreign_keys = ON")
     candidate = sqlite3.connect(tmp_path / "candidate.db")
     candidate.execute("PRAGMA foreign_keys = ON")
-    create_exact_v7_schema(candidate)
+    create_unstamped_exact_v7_candidate(candidate)
     return source, candidate, source_path
 
 

--- a/workers/automation/tests/test_v6_to_v7_feedback_copy.py
+++ b/workers/automation/tests/test_v6_to_v7_feedback_copy.py
@@ -10,7 +10,9 @@ from pathlib import Path
 import pytest
 
 from jobctrl.infrastructure.gmail.feedback import ensure_application_feedback_tables
-from jobctrl.infrastructure.migrations.schema_v7 import create_exact_v7_schema
+from jobctrl.infrastructure.migrations.schema_v7 import (
+    create_unstamped_exact_v7_candidate,
+)
 from jobctrl.infrastructure.migrations.v6_to_v7_copy import (
     CandidateCopyError,
     copy_direct_and_scalar_tables,
@@ -47,7 +49,7 @@ def _connections(
     candidate_path = tmp_path / "candidate.db"
     candidate = sqlite3.connect(candidate_path)
     candidate.execute("PRAGMA foreign_keys = ON")
-    create_exact_v7_schema(candidate)
+    create_unstamped_exact_v7_candidate(candidate)
     copy_root_jobs(
         source,
         candidate,

--- a/workers/automation/tests/test_v6_to_v7_job_detail_projections.py
+++ b/workers/automation/tests/test_v6_to_v7_job_detail_projections.py
@@ -10,7 +10,9 @@ from pathlib import Path
 import pytest
 
 from jobctrl.infrastructure.migrations import v6_to_v7_job_detail_projections as detail
-from jobctrl.infrastructure.migrations.schema_v7 import create_exact_v7_schema
+from jobctrl.infrastructure.migrations.schema_v7 import (
+    create_unstamped_exact_v7_candidate,
+)
 from jobctrl.infrastructure.migrations.v6_to_v7_copy import (
     JobIdMap,
     copy_direct_and_scalar_tables,
@@ -49,7 +51,7 @@ def _databases(tmp_path: Path) -> tuple[sqlite3.Connection, sqlite3.Connection, 
     candidate_path = tmp_path / "candidate.db"
     candidate = sqlite3.connect(candidate_path)
     candidate.execute("PRAGMA foreign_keys = ON")
-    create_exact_v7_schema(candidate)
+    create_unstamped_exact_v7_candidate(candidate)
     return source, candidate, source_path, candidate_path
 
 

--- a/workers/automation/tests/test_v6_to_v7_job_list_projections.py
+++ b/workers/automation/tests/test_v6_to_v7_job_list_projections.py
@@ -10,7 +10,9 @@ from pathlib import Path
 import pytest
 
 from jobctrl.infrastructure.migrations import v6_to_v7_job_list_projections as migration
-from jobctrl.infrastructure.migrations.schema_v7 import create_exact_v7_schema
+from jobctrl.infrastructure.migrations.schema_v7 import (
+    create_unstamped_exact_v7_candidate,
+)
 from jobctrl.infrastructure.migrations.v6_to_v7_apply_run_projections import (
     rebuild_apply_run_projections,
 )
@@ -50,7 +52,7 @@ def _databases(
     candidate_path = tmp_path / "candidate.db"
     candidate = sqlite3.connect(candidate_path)
     candidate.execute("PRAGMA foreign_keys = ON")
-    create_exact_v7_schema(candidate)
+    create_unstamped_exact_v7_candidate(candidate)
     return source, candidate, source_path, candidate_path
 
 


### PR DESCRIPTION
## Summary

- resolve per-job resume-template assignments with explicit tenant-scoped canonical JobId keys
- preserve job override, profile default, and built-in fallback precedence
- remove runtime schema initialization from the converted resolver path
- seed the canonical built-in template through fresh-v7 and migration-candidate owners while preserving customized source rows
- keep the inherited runtime-profile copy regression on the unstamped migration-candidate constructor introduced by the lower schema layer

## Scope

This PR converts resume-template resolution and its required canonical seed ownership. Queue selectors are isolated in the parent PR; preparation workflow identity remains the next stack layer.

## Validation

- focused exact-v7 materials, schema, candidate/copy, projection-copy, and use-case suites — 130 passed
- `pytest -q workers/automation/tests/test_v6_to_v7_copy.py` after the lower correction was rebased — 8 passed
- touched-file Ruff checks — passed
- `git diff --check` — passed
- prior independent review — PASS, zero findings
