### PR TITLE
refactor(preparation): key workflow fan-out by JobId

### DIFF
--- a/workers/automation/src/jobctrl/materials/activities.py
+++ b/workers/automation/src/jobctrl/materials/activities.py
@@ -11,6 +11,7 @@ from temporalio import activity
 
 from jobctrl.domain.discovery.execution import DiscoveryExecutionRef
 from jobctrl.domain.errors import JobCtrlError, LlmTransientError, to_application_error
+from jobctrl.domain.identifiers import JobId, canonical_job_id
 from jobctrl.infrastructure.temporal.pipeline_step_lifecycle import (
     PipelineStepScope,
     begin_pipeline_step_attempt,
@@ -59,7 +60,7 @@ class TailorActivityOutput:
 @dataclass(frozen=True)
 class TailorJobActivityInput:
     tenant_id: str
-    job_url: str
+    job_id: JobId
     min_score: int = 7
     workers: int = 1
     validation_mode: str = "normal"
@@ -70,6 +71,9 @@ class TailorJobActivityInput:
     tailor_judge_model: str | None = None
     tailor_judge_min_score: float | None = None
     llm_model: str = DEFAULT_PIPELINE_LLM_MODEL_SPEC
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "job_id", canonical_job_id(str(self.job_id)))
 
 
 @dataclass(frozen=True)
@@ -172,11 +176,7 @@ async def tailor_activity(payload: TailorActivityInput) -> TailorActivityOutput:
         stage_result, elapsed, status = result
         errors: dict[str, str] = {}
         if status not in _SUCCESS_STATUSES:
-            errors["tailor"] = str(
-                stage_result.get("error")
-                or stage_result.get("error_message")
-                or status
-            )
+            errors["tailor"] = str(stage_result.get("error") or stage_result.get("error_message") or status)
         stages = [{"stage": "tailor", "status": status, "elapsed": elapsed, **stage_result}]
         activity_result = {
             "status": status,
@@ -338,7 +338,7 @@ def _tailor_one_job(payload: TailorJobActivityInput) -> dict[str, Any]:
     from jobctrl.scoring.tailor import tailor_job_by_url
 
     return tailor_job_by_url(
-        payload.job_url,
+        payload.job_id,
         min_score=payload.min_score,
         validation_mode=payload.validation_mode,
         workers=payload.workers,
@@ -385,10 +385,13 @@ class CoverActivityOutput:
 @dataclass(frozen=True)
 class CoverLetterActivityInput:
     tenant_id: str
-    job_url: str
+    job_id: JobId
     min_score: int = 7
     validation_mode: str = "normal"
     llm_model: str = DEFAULT_PIPELINE_LLM_MODEL_SPEC
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "job_id", canonical_job_id(str(self.job_id)))
 
 
 @dataclass(frozen=True)
@@ -402,28 +405,19 @@ class CoverLetterActivityOutput:
 @dataclass(frozen=True)
 class RenderPdfActivityInput:
     tenant_id: str
-    job_url: str
+    job_id: JobId
     expected_app_dir: str | None = None
     expected_db_path: str | None = None
     discovery_execution: DiscoveryExecutionRef | None = None
     pipeline_step_idempotency_key: str | None = None
 
     def __post_init__(self) -> None:
-        if (self.discovery_execution is None) != (
-            self.pipeline_step_idempotency_key is None
-        ):
-            raise ValueError(
-                "discovery_execution and pipeline_step_idempotency_key must be supplied together"
-            )
-        if (
-            self.discovery_execution is not None
-            and self.discovery_execution.tenant_id != self.tenant_id
-        ):
+        object.__setattr__(self, "job_id", canonical_job_id(str(self.job_id)))
+        if (self.discovery_execution is None) != (self.pipeline_step_idempotency_key is None):
+            raise ValueError("discovery_execution and pipeline_step_idempotency_key must be supplied together")
+        if self.discovery_execution is not None and self.discovery_execution.tenant_id != self.tenant_id:
             raise ValueError("PDF tenant does not match discovery execution")
-        if (
-            self.pipeline_step_idempotency_key is not None
-            and not self.pipeline_step_idempotency_key.strip()
-        ):
+        if self.pipeline_step_idempotency_key is not None and not self.pipeline_step_idempotency_key.strip():
             raise ValueError("PDF pipeline-step idempotency key must be non-empty")
 
 
@@ -503,11 +497,7 @@ async def cover_activity(payload: CoverActivityInput) -> CoverActivityOutput:
         stage_result, elapsed, status = result
         errors: dict[str, str] = {}
         if status not in _SUCCESS_STATUSES:
-            errors["cover"] = str(
-                stage_result.get("error")
-                or stage_result.get("error_message")
-                or status
-            )
+            errors["cover"] = str(stage_result.get("error") or stage_result.get("error_message") or status)
         stages = [{"stage": "cover", "status": status, "elapsed": elapsed, **stage_result}]
         activity_result = {
             "status": status,
@@ -551,7 +541,7 @@ def _run_selected_cover(
                     "dry_run": True,
                 }
             ],
-    }
+        }
 
     t0 = time.time()
     generated = 0
@@ -642,7 +632,7 @@ def _cover_one_job(payload: CoverLetterActivityInput) -> dict[str, Any]:
     from jobctrl.scoring.cover_letter import cover_letter_by_url
 
     return cover_letter_by_url(
-        payload.job_url,
+        payload.job_id,
         min_score=payload.min_score,
         validation_mode=payload.validation_mode,
         llm_model=payload.llm_model,
@@ -712,7 +702,6 @@ async def render_pdf_activity(payload: RenderPdfActivityInput) -> RenderPdfActiv
 
 def _render_pdf_for_job(payload: RenderPdfActivityInput) -> dict[str, Any]:
     from jobctrl.database import get_connection
-    from jobctrl.domain.identifiers import JobId
     from jobctrl.domain.materials.use_cases import RenderPdfUseCase
     from jobctrl.domain.tenant import TenantId
     from jobctrl.infrastructure.materials import (
@@ -730,7 +719,7 @@ def _render_pdf_for_job(payload: RenderPdfActivityInput) -> dict[str, Any]:
         resume_renderer=HtmlResumePdfAdapter(),
         cover_letter_renderer=PlaywrightHtmlPdfAdapter(),
     ).execute(
-        job_id=JobId(payload.job_url),
+        job_id=payload.job_id,
         profile_dict=profile.as_dict(),
         tenant_id=tenant_id,
     )

--- a/workers/automation/src/jobctrl/pipeline/preparation.py
+++ b/workers/automation/src/jobctrl/pipeline/preparation.py
@@ -18,7 +18,7 @@ from temporalio.client import WorkflowHandle
 from temporalio.common import WorkflowIDConflictPolicy
 
 from jobctrl import database as db_module
-from jobctrl.database import get_connection, get_jobs_by_stage
+from jobctrl.database import get_connection
 from jobctrl.domain.discovery.execution import (
     DiscoveryExecutionCohortKind,
     DiscoveryExecutionRef,
@@ -26,11 +26,10 @@ from jobctrl.domain.discovery.execution import (
     validate_required_steps,
 )
 from jobctrl.domain.identifiers import JobId, canonical_job_id
-from jobctrl.domain.materials.use_cases import SuppressTailoredArtifactsUseCase
 from jobctrl.domain.preparation import PreparationWorkItemKind, make_preparation_idempotency_key
 from jobctrl.domain.rpc.messages import WorkflowStartSpec
 from jobctrl.domain.tenant import LOCAL_TENANT, TenantId
-from jobctrl.infrastructure.materials import SqliteMaterialsRepository, SqliteTailoringPolicyRepository
+from jobctrl.infrastructure.materials import SqliteTailoringPolicyRepository
 from jobctrl.infrastructure.discovery.sqlite_execution_repository import (
     SqliteDiscoveryExecutionRepository,
 )
@@ -50,6 +49,51 @@ from jobctrl.state import utc_now
 log = logging.getLogger(__name__)
 
 PREPARATION_CHILD_BATCH_SIZE = 25
+
+_LATEST_SCORES_CTE = """
+latest_scores AS (
+    SELECT scores.tenant_id,
+           scores.job_id,
+           scores.fit_score,
+           CASE WHEN json_valid(scores.breakdown_json)
+                THEN LOWER(COALESCE(
+                    CAST(json_extract(scores.breakdown_json, '$.eligibility.status') AS TEXT),
+                    ''
+                ))
+                ELSE ''
+           END AS eligibility_status,
+           CASE WHEN json_valid(scores.breakdown_json)
+                THEN COALESCE(
+                    json_array_length(scores.breakdown_json, '$.eligibility.hard_blockers'),
+                    json_array_length(scores.breakdown_json, '$.eligibility.hardBlockers'),
+                    json_array_length(scores.breakdown_json, '$.eligibility.blockers'),
+                    0
+                )
+                ELSE 0
+           END AS hard_blocker_count
+      FROM job_scores scores
+      INNER JOIN (
+          SELECT tenant_id, job_id, MAX(version) AS version
+            FROM job_scores
+           GROUP BY tenant_id, job_id
+      ) latest
+        ON latest.tenant_id = scores.tenant_id
+       AND latest.job_id = scores.job_id
+       AND latest.version = scores.version
+)
+"""
+
+_LATEST_ACTIVE_MATERIALS_CTE = """
+latest_active_materials AS (
+    SELECT tenant_id, job_id, MAX(generation) AS generation
+      FROM job_materials_artifacts
+     WHERE status = 'approved'
+       AND artifact_type IN (
+            'tailored_resume', 'cover_letter', 'resume_pdf', 'cover_letter_pdf'
+       )
+     GROUP BY tenant_id, job_id
+)
+"""
 
 
 @dataclass(frozen=True)
@@ -380,8 +424,12 @@ def _derive_targets(
     score_target_version = current_scoring_policy_version(conn, tenant_id)
     targets: dict[JobId, PreparationTarget] = {}
 
-    for job in get_jobs_by_stage(conn=conn, stage="pending_score", limit=0):
-        job_id = canonical_job_id(str(job["job_id"]))
+    for job_id in _preparation_job_ids(
+        conn,
+        tenant_id=tenant_id,
+        stage="pending_score",
+        min_score=min_score,
+    ):
         targets[job_id] = _target(
             tenant_id=tenant_id,
             job_id=job_id,
@@ -405,8 +453,12 @@ def _derive_targets(
     # once (``include_pending_tailor=True``) and derive score-only thereafter.
     if include_pending_tailor:
         tailoring_target_version = current_tailoring_policy_version(conn, tenant_id)
-        for job in get_jobs_by_stage(conn=conn, stage="pending_tailor", min_score=min_score, limit=0):
-            job_id = canonical_job_id(str(job["job_id"]))
+        for job_id in _preparation_job_ids(
+            conn,
+            tenant_id=tenant_id,
+            stage="pending_tailor",
+            min_score=min_score,
+        ):
             if job_id in targets:
                 continue
             targets[job_id] = _target(
@@ -423,6 +475,136 @@ def _derive_targets(
             )
 
     return [targets[job_id] for job_id in sorted(targets)]
+
+
+def _preparation_job_ids(
+    conn: sqlite3.Connection,
+    *,
+    tenant_id: TenantId,
+    stage: str,
+    min_score: int,
+) -> list[JobId]:
+    """Select exact-v7 preparation candidates by canonical identity."""
+    if stage == "pending_score":
+        rows = conn.execute(
+            f"""
+            WITH {_LATEST_SCORES_CTE}
+            SELECT jobs.job_id
+              FROM jobs
+              INNER JOIN job_enrichments enrichment
+                ON enrichment.tenant_id = jobs.tenant_id
+               AND enrichment.job_id = jobs.job_id
+              LEFT JOIN latest_scores score
+                ON score.tenant_id = jobs.tenant_id
+               AND score.job_id = jobs.job_id
+              LEFT JOIN job_stage_states score_stage
+                ON score_stage.tenant_id = jobs.tenant_id
+               AND score_stage.job_id = jobs.job_id
+               AND score_stage.stage = 'score'
+              LEFT JOIN posting_snapshot_sets snapshots
+                ON snapshots.tenant_id = jobs.tenant_id
+               AND snapshots.job_id = jobs.job_id
+             WHERE jobs.tenant_id = ?
+               AND NOT EXISTS (
+                    SELECT 1
+                      FROM jobctrl_deleted_jobs deleted
+                     WHERE deleted.tenant_id = jobs.tenant_id
+                       AND deleted.job_id = jobs.job_id
+                       AND (
+                            deleted.restored_at IS NULL
+                            OR julianday(deleted.restored_at) <= julianday(deleted.deleted_at)
+                       )
+               )
+               AND enrichment.full_description IS NOT NULL
+               AND score.job_id IS NULL
+               AND COALESCE(score_stage.state, 'pending') = 'pending'
+               AND COALESCE(score_stage.attempt_count, 0) < 5
+               AND (
+                    snapshots.latest_active_state IS NULL
+                    OR snapshots.latest_active_state NOT IN (
+                        'closed', 'expired', 'removed', 'location_incompatible'
+                    )
+               )
+             ORDER BY jobs.discovered_at DESC, jobs.job_id
+            """,
+            (str(tenant_id),),
+        ).fetchall()
+    elif stage == "pending_tailor":
+        rows = conn.execute(
+            f"""
+            WITH {_LATEST_SCORES_CTE},
+                 {_LATEST_ACTIVE_MATERIALS_CTE}
+            SELECT jobs.job_id
+              FROM jobs
+              INNER JOIN job_enrichments enrichment
+                ON enrichment.tenant_id = jobs.tenant_id
+               AND enrichment.job_id = jobs.job_id
+              INNER JOIN latest_scores score
+                ON score.tenant_id = jobs.tenant_id
+               AND score.job_id = jobs.job_id
+              LEFT JOIN job_stage_states score_stage
+                ON score_stage.tenant_id = jobs.tenant_id
+               AND score_stage.job_id = jobs.job_id
+               AND score_stage.stage = 'score'
+              LEFT JOIN job_stage_states tailor_stage
+                ON tailor_stage.tenant_id = jobs.tenant_id
+               AND tailor_stage.job_id = jobs.job_id
+               AND tailor_stage.stage = 'tailor'
+              LEFT JOIN job_score_staleness stale_score
+                ON stale_score.tenant_id = jobs.tenant_id
+               AND stale_score.job_id = jobs.job_id
+               AND stale_score.resolved = 0
+              LEFT JOIN posting_snapshot_sets snapshots
+                ON snapshots.tenant_id = jobs.tenant_id
+               AND snapshots.job_id = jobs.job_id
+              LEFT JOIN latest_active_materials materials
+                ON materials.tenant_id = jobs.tenant_id
+               AND materials.job_id = jobs.job_id
+              LEFT JOIN job_materials_artifacts tailored_resume
+                ON tailored_resume.tenant_id = materials.tenant_id
+               AND tailored_resume.job_id = materials.job_id
+               AND tailored_resume.generation = materials.generation
+               AND tailored_resume.artifact_type = 'tailored_resume'
+               AND tailored_resume.status = 'approved'
+             WHERE jobs.tenant_id = ?
+               AND NOT EXISTS (
+                    SELECT 1
+                      FROM jobctrl_deleted_jobs deleted
+                     WHERE deleted.tenant_id = jobs.tenant_id
+                       AND deleted.job_id = jobs.job_id
+                       AND (
+                            deleted.restored_at IS NULL
+                            OR julianday(deleted.restored_at) <= julianday(deleted.deleted_at)
+                       )
+               )
+               AND enrichment.full_description IS NOT NULL
+               AND score.fit_score >= ?
+               AND score.eligibility_status != 'blocked'
+               AND score.hard_blocker_count = 0
+               AND (score_stage.state IS NULL OR score_stage.state = 'succeeded')
+               AND stale_score.job_id IS NULL
+               AND COALESCE(tailor_stage.state, 'pending') = 'pending'
+               AND COALESCE(tailor_stage.attempt_count, 0) < 5
+               AND (
+                    snapshots.latest_active_state IS NULL
+                    OR snapshots.latest_active_state NOT IN (
+                        'closed', 'expired', 'removed', 'location_incompatible'
+                    )
+               )
+               AND (
+                    snapshots.latest_confidence IS NULL
+                    OR snapshots.latest_confidence != 'low'
+                    OR snapshots.latest_quarantine_reason IS NULL
+                    OR snapshots.latest_quarantine_reason IN ('none', '')
+               )
+               AND tailored_resume.artifact_id IS NULL
+             ORDER BY score.fit_score DESC, jobs.discovered_at DESC, jobs.job_id
+            """,
+            (str(tenant_id), int(min_score)),
+        ).fetchall()
+    else:
+        raise ValueError(f"unsupported preparation stage: {stage}")
+    return [canonical_job_id(str(row["job_id"] if isinstance(row, sqlite3.Row) else row[0])) for row in rows]
 
 
 def _target(
@@ -640,33 +822,49 @@ def _unselected_work_plan_outcome(
     job_id: JobId,
     min_score: int,
 ) -> tuple[DiscoveryExecutionWorkPlanState, str]:
-    is_deleted = "0"
-    if _table_exists(conn, "jobctrl_deleted_jobs"):
-        is_deleted = """
-            CASE WHEN EXISTS (
-                 SELECT 1
-                  FROM jobctrl_deleted_jobs deleted
-                 WHERE deleted.tenant_id = jobs.tenant_id
-                   AND deleted.job_id = jobs.job_id
-                   AND (
-                       deleted.restored_at IS NULL
-                       OR julianday(deleted.restored_at) <= julianday(deleted.deleted_at)
-                   )
-            ) THEN 1 ELSE 0 END
-        """
     row = conn.execute(
         f"""
-        SELECT {db_module._EFFECTIVE_FIT_SCORE} AS effective_score,
-               CASE WHEN {db_module._SCORE_ELIGIBLE_FOR_DOWNSTREAM}
+        WITH {_LATEST_SCORES_CTE},
+             {_LATEST_ACTIVE_MATERIALS_CTE}
+        SELECT score.fit_score AS effective_score,
+               CASE WHEN score.eligibility_status != 'blocked'
+                         AND score.hard_blocker_count = 0
                     THEN 1 ELSE 0 END AS score_eligible,
-               pss.latest_active_state AS active_state,
-               jm.jm_resume_pdf_path AS resume_pdf_path,
-               jm.jm_cover_pdf_path AS cover_pdf_path,
-               {is_deleted} AS is_deleted
+               snapshots.latest_active_state AS active_state,
+               resume_pdf.artifact_id IS NOT NULL AS has_resume_pdf,
+               cover_pdf.artifact_id IS NOT NULL AS has_cover_pdf,
+               EXISTS (
+                    SELECT 1
+                      FROM jobctrl_deleted_jobs deleted
+                     WHERE deleted.tenant_id = jobs.tenant_id
+                       AND deleted.job_id = jobs.job_id
+                       AND (
+                            deleted.restored_at IS NULL
+                            OR julianday(deleted.restored_at) <= julianday(deleted.deleted_at)
+                       )
+               ) AS is_deleted
           FROM jobs
-          {db_module._LATEST_SCORE_JOIN}
-          {db_module._LATEST_MATERIALS_JOIN}
-          {db_module._ACTIVE_STATE_JOIN}
+          LEFT JOIN latest_scores score
+            ON score.tenant_id = jobs.tenant_id
+           AND score.job_id = jobs.job_id
+          LEFT JOIN posting_snapshot_sets snapshots
+            ON snapshots.tenant_id = jobs.tenant_id
+           AND snapshots.job_id = jobs.job_id
+          LEFT JOIN latest_active_materials materials
+            ON materials.tenant_id = jobs.tenant_id
+           AND materials.job_id = jobs.job_id
+          LEFT JOIN job_materials_artifacts resume_pdf
+            ON resume_pdf.tenant_id = materials.tenant_id
+           AND resume_pdf.job_id = materials.job_id
+           AND resume_pdf.generation = materials.generation
+           AND resume_pdf.artifact_type = 'resume_pdf'
+           AND resume_pdf.status = 'approved'
+          LEFT JOIN job_materials_artifacts cover_pdf
+            ON cover_pdf.tenant_id = materials.tenant_id
+           AND cover_pdf.job_id = materials.job_id
+           AND cover_pdf.generation = materials.generation
+           AND cover_pdf.artifact_type = 'cover_letter_pdf'
+           AND cover_pdf.status = 'approved'
          WHERE jobs.tenant_id = ?
            AND jobs.job_id = ?
         """,
@@ -684,7 +882,7 @@ def _unselected_work_plan_outcome(
         return ("not_eligible", "job_not_actionable")
     if str(row["active_state"] or "") in {"closed", "expired", "removed", "location_incompatible"}:
         return ("not_eligible", "posting_not_actionable")
-    if row["resume_pdf_path"] and row["cover_pdf_path"]:
+    if bool(row["has_resume_pdf"]) and bool(row["has_cover_pdf"]):
         return ("not_eligible", "preparation_already_accounted")
 
     stage_rows = conn.execute(
@@ -707,16 +905,6 @@ def _unselected_work_plan_outcome(
     ):
         return ("not_eligible", "preparation_explicitly_skipped")
     return ("failed", "preparation_target_not_selected")
-
-
-def _table_exists(conn: sqlite3.Connection, table_name: str) -> bool:
-    return (
-        conn.execute(
-            "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?",
-            (table_name,),
-        ).fetchone()
-        is not None
-    )
 
 
 def _run_start_batch(specs: list[WorkflowStartSpec], starter: WorkflowStarter) -> list[WorkflowHandle]:
@@ -774,21 +962,83 @@ def _suppress_ineligible_artifacts(
     tenant_id: TenantId,
     min_score: int,
 ) -> int:
-    use_case = SuppressTailoredArtifactsUseCase(repository=SqliteMaterialsRepository(conn))
     suppressed = 0
     for job_id in _jobs_needing_artifact_suppression(
         conn,
         tenant_id=tenant_id,
         min_score=min_score,
     ):
-        outcome = use_case.execute(
+        suppressed += _suppress_active_artifacts(
+            conn,
             tenant_id=tenant_id,
             job_id=job_id,
             reason="threshold_or_hard_blocker_ineligible",
             suppressed_at=utc_now(),
         )
-        suppressed += int(outcome.suppressed)
     return suppressed
+
+
+def _suppress_active_artifacts(
+    conn: sqlite3.Connection,
+    *,
+    tenant_id: TenantId,
+    job_id: JobId,
+    reason: str,
+    suppressed_at: str,
+) -> int:
+    generation_row = conn.execute(
+        f"""
+        WITH {_LATEST_ACTIVE_MATERIALS_CTE}
+        SELECT generation
+          FROM latest_active_materials
+         WHERE tenant_id = ?
+           AND job_id = ?
+        """,
+        (str(tenant_id), str(job_id)),
+    ).fetchone()
+    generation = generation_row[0] if generation_row is not None else None
+    if generation is None:
+        return 0
+
+    update_metadata = """
+        json_set(
+            CASE
+                WHEN json_valid(metadata_json) AND json_type(metadata_json) = 'object'
+                    THEN metadata_json
+                ELSE '{}'
+            END,
+            '$.suppression',
+            json_object('reason', ?, 'suppressed_at', ?)
+        )
+    """
+    cursor = conn.execute(
+        f"""
+        UPDATE job_materials_artifacts
+           SET status = 'suppressed',
+               metadata_json = {update_metadata},
+               superseded_at = NULL
+         WHERE tenant_id = ?
+           AND job_id = ?
+           AND generation = ?
+           AND status = 'approved'
+        """,
+        (reason, suppressed_at, str(tenant_id), str(job_id), generation),
+    )
+    if cursor.rowcount == 0:
+        return 0
+    conn.execute(
+        f"""
+        UPDATE job_materials
+           SET metadata_json = {update_metadata},
+               updated_at = ?
+         WHERE tenant_id = ?
+           AND job_id = ?
+           AND generation = ?
+        """,
+        (reason, suppressed_at, suppressed_at, str(tenant_id), str(job_id), generation),
+    )
+    conn.commit()
+    return 1
 
 
 def _jobs_needing_artifact_suppression(
@@ -799,18 +1049,31 @@ def _jobs_needing_artifact_suppression(
 ) -> list[JobId]:
     rows = conn.execute(
         f"""
+        WITH {_LATEST_SCORES_CTE},
+             {_LATEST_ACTIVE_MATERIALS_CTE}
         SELECT jobs.job_id
         FROM jobs
-        {db_module._LATEST_SCORE_JOIN}
-        {db_module._LATEST_MATERIALS_JOIN}
+        LEFT JOIN latest_scores score
+          ON score.tenant_id = jobs.tenant_id
+         AND score.job_id = jobs.job_id
+        LEFT JOIN latest_active_materials materials
+          ON materials.tenant_id = jobs.tenant_id
+         AND materials.job_id = jobs.job_id
+        LEFT JOIN job_materials_artifacts tailored_resume
+          ON tailored_resume.tenant_id = materials.tenant_id
+         AND tailored_resume.job_id = materials.job_id
+         AND tailored_resume.generation = materials.generation
+         AND tailored_resume.artifact_type = 'tailored_resume'
+         AND tailored_resume.status = 'approved'
         WHERE jobs.tenant_id = ?
-          AND {db_module._EFFECTIVE_TAILOR_PATH} IS NOT NULL
+          AND tailored_resume.artifact_id IS NOT NULL
           AND (
-            {db_module._EFFECTIVE_FIT_SCORE} IS NULL
-            OR {db_module._EFFECTIVE_FIT_SCORE} < ?
-            OR NOT {db_module._SCORE_ELIGIBLE_FOR_DOWNSTREAM}
+            score.fit_score IS NULL
+            OR score.fit_score < ?
+            OR score.eligibility_status = 'blocked'
+            OR score.hard_blocker_count > 0
           )
-        ORDER BY jobs.discovered_at DESC
+        ORDER BY jobs.discovered_at DESC, jobs.job_id
         """,
         (tenant_id, int(min_score)),
     ).fetchall()

--- a/workers/automation/src/jobctrl/pipeline/preparation.py
+++ b/workers/automation/src/jobctrl/pipeline/preparation.py
@@ -25,7 +25,7 @@ from jobctrl.domain.discovery.execution import (
     DiscoveryExecutionWorkPlanState,
     validate_required_steps,
 )
-from jobctrl.domain.identifiers import JobId
+from jobctrl.domain.identifiers import JobId, canonical_job_id
 from jobctrl.domain.materials.use_cases import SuppressTailoredArtifactsUseCase
 from jobctrl.domain.preparation import PreparationWorkItemKind, make_preparation_idempotency_key
 from jobctrl.domain.rpc.messages import WorkflowStartSpec
@@ -54,10 +54,15 @@ PREPARATION_CHILD_BATCH_SIZE = 25
 
 @dataclass(frozen=True)
 class PreparationTarget:
-    job_url: str
+    tenant_id: TenantId
+    job_id: JobId
     idempotency_key: str
     target_version: str
     steps: list[str]
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "tenant_id", TenantId(str(self.tenant_id)))
+        object.__setattr__(self, "job_id", canonical_job_id(str(self.job_id)))
 
 
 @dataclass(frozen=True)
@@ -191,7 +196,7 @@ def start_discovery_preparation_workflows(
 
 
 def start_job_preparation_workflow(
-    job_url: str,
+    job_id: JobId,
     *,
     min_score: int = 7,
     workers: int = 1,
@@ -215,12 +220,13 @@ def start_job_preparation_workflow(
     version, latest source event), so `USE_EXISTING` makes the per-job handoff
     and the reconciling fan-outs converge on exactly one execution per job (I1).
     """
+    stable_job_id = canonical_job_id(str(job_id))
     try:
         conn = get_connection()
         target_version = current_scoring_policy_version(conn, tenant_id)
         spec = build_preparation_workflow_spec(
             tenant_id=tenant_id,
-            job_url=job_url,
+            job_id=stable_job_id,
             steps=["score", "tailor", "cover", "pdf"],
             kind=PreparationWorkItemKind.SCORE_JOB,
             target_version=target_version,
@@ -232,9 +238,7 @@ def start_job_preparation_workflow(
             tailor_judge_model=tailor_judge_model,
             tailor_judge_min_score=tailor_judge_min_score,
             discovery_execution=discovery_execution,
-            discovery_cohort_kind=(
-                discovery_cohort_kind if discovery_execution is not None else None
-            ),
+            discovery_cohort_kind=(discovery_cohort_kind if discovery_execution is not None else None),
         )
         if discovery_execution is not None:
             preparation_payload = spec.args[0]
@@ -243,7 +247,8 @@ def start_job_preparation_workflow(
             workflow_cohorts_to_start = _record_preparation_work_plans(
                 [
                     PreparationTarget(
-                        job_url=job_url,
+                        tenant_id=tenant_id,
+                        job_id=stable_job_id,
                         idempotency_key=preparation_payload.idempotency_key,
                         target_version=preparation_payload.target_version,
                         steps=list(preparation_payload.steps),
@@ -263,7 +268,7 @@ def start_job_preparation_workflow(
         if discovery_execution is not None:
             _mark_job_work_plan_failed(
                 discovery_execution,
-                job_url=job_url,
+                job_id=stable_job_id,
                 reason="work_plan_persistence_failed",
             )
         raise
@@ -275,7 +280,7 @@ def start_job_preparation_workflow(
 def build_preparation_workflow_spec(
     *,
     tenant_id: TenantId,
-    job_url: str,
+    job_id: JobId,
     steps: list[str],
     kind: PreparationWorkItemKind,
     target_version: int,
@@ -296,17 +301,26 @@ def build_preparation_workflow_spec(
     discovery_execution: DiscoveryExecutionRef | None = None,
     discovery_cohort_kind: DiscoveryExecutionCohortKind | None = None,
 ) -> WorkflowStartSpec:
-    source_event = source_event_id if source_event_id is not None else _latest_source_event_id(get_connection(), job_url)
+    stable_job_id = canonical_job_id(str(job_id))
+    source_event = (
+        source_event_id
+        if source_event_id is not None
+        else _latest_source_event_id(
+            get_connection(),
+            tenant_id=tenant_id,
+            job_id=stable_job_id,
+        )
+    )
     idempotency_key = make_preparation_idempotency_key(
         tenant_id=tenant_id,
-        job_id=JobId(job_url),
+        job_id=stable_job_id,
         kind=kind,
         target_version=target_version,
         source_event_id=source_event,
     )
     payload = JobPreparationInput(
         tenant_id=str(tenant_id),
-        job_url=job_url,
+        job_id=stable_job_id,
         steps=list(steps),
         target_version=str(target_version),
         idempotency_key=idempotency_key,
@@ -343,8 +357,17 @@ def current_tailoring_policy_version(conn: sqlite3.Connection, tenant_id: Tenant
     return policy.version if policy is not None else 1
 
 
-def latest_source_event_id(conn: sqlite3.Connection, job_url: str) -> str:
-    return _latest_source_event_id(conn, job_url)
+def latest_source_event_id(
+    conn: sqlite3.Connection,
+    *,
+    tenant_id: TenantId,
+    job_id: JobId,
+) -> str:
+    return _latest_source_event_id(
+        conn,
+        tenant_id=tenant_id,
+        job_id=canonical_job_id(str(job_id)),
+    )
 
 
 def _derive_targets(
@@ -355,16 +378,20 @@ def _derive_targets(
     include_pending_tailor: bool = True,
 ) -> list[PreparationTarget]:
     score_target_version = current_scoring_policy_version(conn, tenant_id)
-    targets: dict[str, PreparationTarget] = {}
+    targets: dict[JobId, PreparationTarget] = {}
 
     for job in get_jobs_by_stage(conn=conn, stage="pending_score", limit=0):
-        job_url = str(job["url"])
-        targets[job_url] = _target(
+        job_id = canonical_job_id(str(job["job_id"]))
+        targets[job_id] = _target(
             tenant_id=tenant_id,
-            job_url=job_url,
+            job_id=job_id,
             kind=PreparationWorkItemKind.SCORE_JOB,
             target_version=score_target_version,
-            source_event_id=_latest_source_event_id(conn, job_url),
+            source_event_id=_latest_source_event_id(
+                conn,
+                tenant_id=tenant_id,
+                job_id=job_id,
+            ),
             steps=["score", "tailor", "cover", "pdf"],
         )
 
@@ -379,25 +406,29 @@ def _derive_targets(
     if include_pending_tailor:
         tailoring_target_version = current_tailoring_policy_version(conn, tenant_id)
         for job in get_jobs_by_stage(conn=conn, stage="pending_tailor", min_score=min_score, limit=0):
-            job_url = str(job["url"])
-            if job_url in targets:
+            job_id = canonical_job_id(str(job["job_id"]))
+            if job_id in targets:
                 continue
-            targets[job_url] = _target(
+            targets[job_id] = _target(
                 tenant_id=tenant_id,
-                job_url=job_url,
+                job_id=job_id,
                 kind=PreparationWorkItemKind.TAILOR_RESUME,
                 target_version=tailoring_target_version,
-                source_event_id=_latest_source_event_id(conn, job_url),
+                source_event_id=_latest_source_event_id(
+                    conn,
+                    tenant_id=tenant_id,
+                    job_id=job_id,
+                ),
                 steps=["tailor", "cover", "pdf"],
             )
 
-    return [targets[job_url] for job_url in sorted(targets)]
+    return [targets[job_id] for job_id in sorted(targets)]
 
 
 def _target(
     *,
     tenant_id: TenantId,
-    job_url: str,
+    job_id: JobId,
     kind: PreparationWorkItemKind,
     target_version: int,
     source_event_id: str,
@@ -405,13 +436,14 @@ def _target(
 ) -> PreparationTarget:
     idempotency_key = make_preparation_idempotency_key(
         tenant_id=tenant_id,
-        job_id=JobId(job_url),
+        job_id=job_id,
         kind=kind,
         target_version=target_version,
         source_event_id=source_event_id,
     )
     return PreparationTarget(
-        job_url=job_url,
+        tenant_id=tenant_id,
+        job_id=job_id,
         idempotency_key=idempotency_key,
         target_version=str(target_version),
         steps=list(steps),
@@ -432,9 +464,11 @@ def _workflow_spec_for_target(
     discovery_execution: DiscoveryExecutionRef | None,
     discovery_cohort_kind: DiscoveryExecutionCohortKind,
 ) -> WorkflowStartSpec:
+    if target.tenant_id != tenant_id:
+        raise ValueError("preparation target tenant does not match workflow tenant")
     payload = JobPreparationInput(
         tenant_id=str(tenant_id),
-        job_url=target.job_url,
+        job_id=target.job_id,
         steps=list(target.steps),
         target_version=target.target_version,
         idempotency_key=target.idempotency_key,
@@ -446,9 +480,7 @@ def _workflow_spec_for_target(
         tailor_judge_model=tailor_judge_model,
         tailor_judge_min_score=tailor_judge_min_score,
         discovery_execution=discovery_execution,
-        discovery_cohort_kind=(
-            discovery_cohort_kind if discovery_execution is not None else None
-        ),
+        discovery_cohort_kind=(discovery_cohort_kind if discovery_execution is not None else None),
     )
     return WorkflowStartSpec(
         workflow=JobPreparationWorkflow,
@@ -482,15 +514,15 @@ def _record_preparation_work_plans(
         if discovery_cohort_kind == "existing_backlog":
             membership = repository.link_job(
                 discovery_execution,
-                target.job_url,
+                target.job_id,
                 cohort_kind="existing_backlog",
             )
         else:
-            membership = repository.get(discovery_execution, target.job_url)
+            membership = repository.get(discovery_execution, target.job_id)
             if membership is None:
                 membership = repository.link_job(
                     discovery_execution,
-                    target.job_url,
+                    target.job_id,
                     cohort_kind="existing_backlog",
                 )
         workflow_id = preparation_workflow_id(target.idempotency_key)
@@ -508,7 +540,7 @@ def _record_preparation_work_plans(
             continue
         repository.set_work_plan(
             discovery_execution,
-            target.job_url,
+            target.job_id,
             state="planned",
             required_steps=target.steps,
             preparation_workflow_id=workflow_id,
@@ -543,7 +575,7 @@ def _mark_pending_work_plans_failed(
             continue
         repository.set_work_plan(
             discovery_execution,
-            membership.job_url,
+            membership.job_id,
             state="failed",
             reason=reason,
         )
@@ -552,16 +584,16 @@ def _mark_pending_work_plans_failed(
 def _mark_job_work_plan_failed(
     discovery_execution: DiscoveryExecutionRef,
     *,
-    job_url: str,
+    job_id: JobId,
     reason: str,
 ) -> None:
     repository = SqliteDiscoveryExecutionRepository(get_connection())
-    membership = repository.get(discovery_execution, job_url)
+    membership = repository.get(discovery_execution, job_id)
     if membership is None or membership.work_plan_state != "pending":
         return
     repository.set_work_plan(
         discovery_execution,
-        job_url,
+        job_id,
         state="failed",
         reason=reason,
     )
@@ -589,12 +621,13 @@ def _finalize_unplanned_observed_work_plans(
             continue
         state, reason = _unselected_work_plan_outcome(
             conn,
-            job_url=membership.job_url,
+            tenant_id=TenantId(discovery_execution.tenant_id),
+            job_id=membership.job_id,
             min_score=min_score,
         )
         repository.set_work_plan(
             discovery_execution,
-            membership.job_url,
+            membership.job_id,
             state=state,
             reason=reason,
         )
@@ -603,16 +636,18 @@ def _finalize_unplanned_observed_work_plans(
 def _unselected_work_plan_outcome(
     conn: sqlite3.Connection,
     *,
-    job_url: str,
+    tenant_id: TenantId,
+    job_id: JobId,
     min_score: int,
 ) -> tuple[DiscoveryExecutionWorkPlanState, str]:
     is_deleted = "0"
     if _table_exists(conn, "jobctrl_deleted_jobs"):
         is_deleted = """
             CASE WHEN EXISTS (
-                SELECT 1
+                 SELECT 1
                   FROM jobctrl_deleted_jobs deleted
-                 WHERE deleted.job_url = jobs.url
+                 WHERE deleted.tenant_id = jobs.tenant_id
+                   AND deleted.job_id = jobs.job_id
                    AND (
                        deleted.restored_at IS NULL
                        OR julianday(deleted.restored_at) <= julianday(deleted.deleted_at)
@@ -632,9 +667,10 @@ def _unselected_work_plan_outcome(
           {db_module._LATEST_SCORE_JOIN}
           {db_module._LATEST_MATERIALS_JOIN}
           {db_module._ACTIVE_STATE_JOIN}
-         WHERE jobs.url = ?
+         WHERE jobs.tenant_id = ?
+           AND jobs.job_id = ?
         """,
-        (job_url,),
+        (tenant_id, job_id),
     ).fetchone()
     if row is None:
         return ("failed", "canonical_job_missing")
@@ -654,11 +690,12 @@ def _unselected_work_plan_outcome(
     stage_rows = conn.execute(
         """
         SELECT stage, state
-          FROM job_stage_states
-         WHERE job_url = ?
+         FROM job_stage_states
+         WHERE tenant_id = ?
+           AND job_id = ?
            AND stage IN ('score', 'tailor', 'cover', 'apply')
         """,
-        (job_url,),
+        (tenant_id, job_id),
     ).fetchall()
     stage_states = {str(stage_row["stage"]): str(stage_row["state"]) for stage_row in stage_rows}
     if stage_states.get("apply") == "succeeded":
@@ -702,12 +739,18 @@ def _batches(items: list[WorkflowStartSpec], size: int) -> list[list[WorkflowSta
     return [items[index : index + size] for index in range(0, len(items), size)]
 
 
-def _latest_source_event_id(conn: sqlite3.Connection, job_url: str) -> str:
+def _latest_source_event_id(
+    conn: sqlite3.Connection,
+    *,
+    tenant_id: TenantId,
+    job_id: JobId,
+) -> str:
     row = conn.execute(
         """
         SELECT event_id
         FROM job_events
-        WHERE job_url = ?
+        WHERE tenant_id = ?
+          AND job_id = ?
           AND event_type IN (
             'JobDiscovered',
             'JobUpdated',
@@ -718,7 +761,7 @@ def _latest_source_event_id(conn: sqlite3.Connection, job_url: str) -> str:
         ORDER BY event_id DESC
         LIMIT 1
         """,
-        (job_url,),
+        (tenant_id, job_id),
     ).fetchone()
     if row is None:
         return ""
@@ -733,7 +776,11 @@ def _suppress_ineligible_artifacts(
 ) -> int:
     use_case = SuppressTailoredArtifactsUseCase(repository=SqliteMaterialsRepository(conn))
     suppressed = 0
-    for job_id in _jobs_needing_artifact_suppression(conn, min_score=min_score):
+    for job_id in _jobs_needing_artifact_suppression(
+        conn,
+        tenant_id=tenant_id,
+        min_score=min_score,
+    ):
         outcome = use_case.execute(
             tenant_id=tenant_id,
             job_id=job_id,
@@ -747,15 +794,17 @@ def _suppress_ineligible_artifacts(
 def _jobs_needing_artifact_suppression(
     conn: sqlite3.Connection,
     *,
+    tenant_id: TenantId,
     min_score: int,
 ) -> list[JobId]:
     rows = conn.execute(
         f"""
-        SELECT jobs.url
+        SELECT jobs.job_id
         FROM jobs
         {db_module._LATEST_SCORE_JOIN}
         {db_module._LATEST_MATERIALS_JOIN}
-        WHERE {db_module._EFFECTIVE_TAILOR_PATH} IS NOT NULL
+        WHERE jobs.tenant_id = ?
+          AND {db_module._EFFECTIVE_TAILOR_PATH} IS NOT NULL
           AND (
             {db_module._EFFECTIVE_FIT_SCORE} IS NULL
             OR {db_module._EFFECTIVE_FIT_SCORE} < ?
@@ -763,9 +812,9 @@ def _jobs_needing_artifact_suppression(
           )
         ORDER BY jobs.discovered_at DESC
         """,
-        (int(min_score),),
+        (tenant_id, int(min_score)),
     ).fetchall()
-    return [JobId(str(row["url"] if isinstance(row, sqlite3.Row) else row[0])) for row in rows]
+    return [canonical_job_id(str(row["job_id"] if isinstance(row, sqlite3.Row) else row[0])) for row in rows]
 
 
 __all__ = [

--- a/workers/automation/src/jobctrl/preparation/workflow.py
+++ b/workers/automation/src/jobctrl/preparation/workflow.py
@@ -15,6 +15,7 @@ with workflow.unsafe.imports_passed_through():
         DiscoveryExecutionCohortKind,
         DiscoveryExecutionRef,
     )
+    from jobctrl.domain.identifiers import JobId, canonical_job_id
     from jobctrl.infrastructure.temporal.finalize import (
         emit_workflow_outcome,
         emit_workflow_started,
@@ -45,7 +46,7 @@ PREPARATION_STEP_ORDER: tuple[str, ...] = ("score", "tailor", "cover", "pdf")
 @dataclass(frozen=True)
 class JobPreparationInput:
     tenant_id: str
-    job_url: str
+    job_id: JobId
     steps: list[str]
     target_version: str
     idempotency_key: str
@@ -66,14 +67,10 @@ class JobPreparationInput:
     discovery_cohort_kind: DiscoveryExecutionCohortKind | None = None
 
     def __post_init__(self) -> None:
+        object.__setattr__(self, "job_id", canonical_job_id(str(self.job_id)))
         if (self.discovery_execution is None) != (self.discovery_cohort_kind is None):
-            raise ValueError(
-                "discovery_execution and discovery_cohort_kind must be supplied together"
-            )
-        if (
-            self.discovery_execution is not None
-            and self.discovery_execution.tenant_id != self.tenant_id
-        ):
+            raise ValueError("discovery_execution and discovery_cohort_kind must be supplied together")
+        if self.discovery_execution is not None and self.discovery_execution.tenant_id != self.tenant_id:
             raise ValueError("preparation tenant does not match discovery execution")
 
 
@@ -185,7 +182,7 @@ async def _execute_step(step: str, payload: JobPreparationInput) -> Any:
             score_job_activity,
             ScoreJobActivityInput(
                 tenant_id=payload.tenant_id,
-                job_url=payload.job_url,
+                job_id=payload.job_id,
                 rescore=payload.rescore,
                 llm_model=payload.llm_model,
             ),
@@ -198,7 +195,7 @@ async def _execute_step(step: str, payload: JobPreparationInput) -> Any:
             tailor_job_activity,
             TailorJobActivityInput(
                 tenant_id=payload.tenant_id,
-                job_url=payload.job_url,
+                job_id=payload.job_id,
                 min_score=payload.min_score,
                 workers=payload.workers,
                 validation_mode=payload.validation_mode,
@@ -219,7 +216,7 @@ async def _execute_step(step: str, payload: JobPreparationInput) -> Any:
             cover_letter_activity,
             CoverLetterActivityInput(
                 tenant_id=payload.tenant_id,
-                job_url=payload.job_url,
+                job_id=payload.job_id,
                 min_score=payload.min_score,
                 validation_mode=payload.validation_mode,
                 llm_model=payload.llm_model,
@@ -233,14 +230,12 @@ async def _execute_step(step: str, payload: JobPreparationInput) -> Any:
             render_pdf_activity,
             RenderPdfActivityInput(
                 tenant_id=payload.tenant_id,
-                job_url=payload.job_url,
+                job_id=payload.job_id,
                 expected_app_dir=payload.expected_app_dir,
                 expected_db_path=payload.expected_db_path,
                 discovery_execution=payload.discovery_execution,
                 pipeline_step_idempotency_key=(
-                    payload.idempotency_key
-                    if payload.discovery_execution is not None
-                    else None
+                    payload.idempotency_key if payload.discovery_execution is not None else None
                 ),
             ),
             start_to_close_timeout=_DEFAULT_TIMEOUT,
@@ -276,7 +271,7 @@ def _ordered_steps(steps: list[str]) -> list[str]:
 
 def _input_summary(payload: JobPreparationInput) -> dict[str, Any]:
     summary: dict[str, Any] = {
-        "jobUrl": payload.job_url,
+        "jobId": str(payload.job_id),
         "steps": list(payload.steps),
         "targetVersion": payload.target_version,
         "idempotencyKey": payload.idempotency_key,

--- a/workers/automation/src/jobctrl/scoring/activities.py
+++ b/workers/automation/src/jobctrl/scoring/activities.py
@@ -11,6 +11,7 @@ from typing import Any
 from temporalio import activity
 
 from jobctrl.domain.errors import JobCtrlError, LlmTransientError, to_application_error
+from jobctrl.domain.identifiers import JobId, canonical_job_id
 from jobctrl.model_defaults import DEFAULT_PIPELINE_LLM_MODEL_SPEC
 
 
@@ -42,9 +43,12 @@ class ScoreActivityOutput:
 @dataclass(frozen=True)
 class ScoreJobActivityInput:
     tenant_id: str
-    job_url: str
+    job_id: JobId
     rescore: bool = False
     llm_model: str = DEFAULT_PIPELINE_LLM_MODEL_SPEC
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "job_id", canonical_job_id(str(self.job_id)))
 
 
 @dataclass(frozen=True)
@@ -139,11 +143,7 @@ async def score_activity(payload: ScoreActivityInput) -> ScoreActivityOutput:
         stage_result, elapsed, status = result
         errors: dict[str, str] = {}
         if status not in _SUCCESS_STATUSES:
-            errors["score"] = str(
-                stage_result.get("error")
-                or stage_result.get("error_message")
-                or status
-            )
+            errors["score"] = str(stage_result.get("error") or stage_result.get("error_message") or status)
         stages = [{"stage": "score", "status": status, "elapsed": elapsed, **stage_result}]
         activity_result = {
             "status": status,
@@ -304,7 +304,7 @@ def _score_one_job(payload: ScoreJobActivityInput) -> dict[str, Any]:
     from jobctrl.scoring.scorer import score_job_by_url
 
     outcome = score_job_by_url(
-        payload.job_url,
+        payload.job_id,
         tenant_id=TenantId(payload.tenant_id),
         rescore=payload.rescore,
         llm_model=payload.llm_model,

--- a/workers/automation/tests/test_discovery_preparation_orchestration.py
+++ b/workers/automation/tests/test_discovery_preparation_orchestration.py
@@ -15,6 +15,7 @@ from jobctrl.domain.identifiers import JobId
 from jobctrl.domain.preparation import PreparationWorkItemKind
 from jobctrl.domain.tenant import LOCAL_TENANT
 from jobctrl.discovery.workflow import DiscoverWorkflow
+from jobctrl.infrastructure.migrations.schema_v7 import create_exact_v7_schema
 from jobctrl.infrastructure.temporal.registry import WORKFLOWS
 from jobctrl.pipeline import preparation, runner
 from jobctrl.preparation.workflow import JobPreparationInput, JobPreparationWorkflow
@@ -54,15 +55,15 @@ def test_derive_preparation_targets_is_sorted_and_prefers_score_workflow(
     conn: sqlite3.Connection,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    def fake_jobs(*, stage: str, **_kwargs):
+    def fake_job_ids(_conn, *, stage: str, **_kwargs):
         if stage == "pending_score":
-            return [{"job_id": _job_id(2)}, {"job_id": _job_id(1)}]
+            return [_job_id(2), _job_id(1)]
         if stage == "pending_tailor":
-            return [{"job_id": _job_id(1)}, {"job_id": _job_id(3)}]
+            return [_job_id(1), _job_id(3)]
         return []
 
     monkeypatch.setattr(preparation, "get_connection", lambda: conn)
-    monkeypatch.setattr(preparation, "get_jobs_by_stage", fake_jobs)
+    monkeypatch.setattr(preparation, "_preparation_job_ids", fake_job_ids)
     monkeypatch.setattr(preparation, "_suppress_ineligible_artifacts", lambda *_args, **_kwargs: 0)
     monkeypatch.setattr(preparation, "current_scoring_policy_version", lambda *_args, **_kwargs: 11)
     monkeypatch.setattr(preparation, "current_tailoring_policy_version", lambda *_args, **_kwargs: 7)
@@ -93,16 +94,16 @@ def test_derive_targets_score_only_skips_pending_tailor(
     own SCORE_JOB workflow) is NOT re-derived as a duplicate TAILOR_RESUME
     target. Score-only passes only start fresh SCORE_JOB work."""
 
-    def fake_jobs(*, stage: str, **_kwargs):
+    def fake_job_ids(_conn, *, stage: str, **_kwargs):
         if stage == "pending_score":
-            return [{"job_id": _job_id(10)}]
+            return [_job_id(10)]
         if stage == "pending_tailor":
             # A job scored earlier this run, now mid-tailor.
-            return [{"job_id": _job_id(11)}]
+            return [_job_id(11)]
         return []
 
     monkeypatch.setattr(preparation, "get_connection", lambda: conn)
-    monkeypatch.setattr(preparation, "get_jobs_by_stage", fake_jobs)
+    monkeypatch.setattr(preparation, "_preparation_job_ids", fake_job_ids)
     monkeypatch.setattr(preparation, "_suppress_ineligible_artifacts", lambda *_args, **_kwargs: 0)
     monkeypatch.setattr(preparation, "current_scoring_policy_version", lambda *_args, **_kwargs: 3)
     monkeypatch.setattr(preparation, "current_tailoring_policy_version", lambda *_args, **_kwargs: 5)
@@ -127,6 +128,171 @@ def test_derive_targets_score_only_skips_pending_tailor(
     # so the mid-tailor job cannot get a second, racing prep workflow.
     assert [target.job_id for target in score_only] == [_job_id(10)]
     assert score_only[0].steps == ["score", "tailor", "cover", "pdf"]
+
+
+def test_derive_preparation_targets_uses_exact_v7_job_identity_queries(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The synchronous fan-out works on the sealed v7 schema without URL joins."""
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    create_exact_v7_schema(conn)
+    now = "2026-07-31T09:00:00+00:00"
+    pending_score_id = _job_id(60)
+    pending_tailor_id = _job_id(61)
+    suppressed_id = _job_id(62)
+    deleted_score_id = _job_id(63)
+    deleted_tailor_id = _job_id(64)
+    restored_score_id = _job_id(65)
+    other_tenant_id = _job_id(60)
+
+    try:
+        for tenant_id, job_id in (
+            (LOCAL_TENANT, pending_score_id),
+            (LOCAL_TENANT, pending_tailor_id),
+            (LOCAL_TENANT, suppressed_id),
+            (LOCAL_TENANT, deleted_score_id),
+            (LOCAL_TENANT, deleted_tailor_id),
+            (LOCAL_TENANT, restored_score_id),
+            ("other", other_tenant_id),
+        ):
+            conn.execute(
+                """
+                INSERT INTO jobs (tenant_id, job_id, url, discovered_at)
+                VALUES (?, ?, ?, ?)
+                """,
+                (str(tenant_id), str(job_id), f"https://jobs.example/{tenant_id}/{job_id}", now),
+            )
+        conn.executemany(
+            """
+            INSERT INTO job_enrichments (
+                tenant_id, job_id, current_status, full_description, updated_at
+            ) VALUES (?, ?, 'enriched', 'Canonical description', ?)
+            """,
+            [
+                (str(LOCAL_TENANT), str(pending_score_id), now),
+                (str(LOCAL_TENANT), str(pending_tailor_id), now),
+                (str(LOCAL_TENANT), str(deleted_score_id), now),
+                (str(LOCAL_TENANT), str(deleted_tailor_id), now),
+                (str(LOCAL_TENANT), str(restored_score_id), now),
+                ("other", str(other_tenant_id), now),
+            ],
+        )
+        conn.executemany(
+            """
+            INSERT INTO job_scores (
+                tenant_id, job_id, version, fit_score, breakdown_json,
+                keywords_json, scored_at
+            ) VALUES (?, ?, 1, ?, ?, '[]', ?)
+            """,
+            [
+                (
+                    str(LOCAL_TENANT),
+                    str(pending_tailor_id),
+                    8,
+                    '{"eligibility":{"status":"eligible","hard_blockers":[]}}',
+                    now,
+                ),
+                (
+                    str(LOCAL_TENANT),
+                    str(deleted_tailor_id),
+                    8,
+                    '{"eligibility":{"status":"eligible","hard_blockers":[]}}',
+                    now,
+                ),
+                (str(LOCAL_TENANT), str(suppressed_id), 5, "{}", now),
+            ],
+        )
+        conn.executemany(
+            """
+            INSERT INTO job_stage_states (
+                tenant_id, job_id, stage, state, attempt_count, updated_at
+            ) VALUES (?, ?, 'score', 'succeeded', 1, ?)
+            """,
+            (
+                (str(LOCAL_TENANT), str(pending_tailor_id), now),
+                (str(LOCAL_TENANT), str(deleted_tailor_id), now),
+            ),
+        )
+        conn.executemany(
+            """
+            INSERT INTO jobctrl_deleted_jobs (
+                tenant_id, job_id, deleted_at, reason, restored_at
+            ) VALUES (?, ?, ?, 'fixture', ?)
+            """,
+            (
+                (
+                    str(LOCAL_TENANT),
+                    str(deleted_score_id),
+                    "2026-07-31T09:01:00+00:00",
+                    None,
+                ),
+                (
+                    str(LOCAL_TENANT),
+                    str(deleted_tailor_id),
+                    "2026-07-31T09:01:00+00:00",
+                    None,
+                ),
+                (
+                    str(LOCAL_TENANT),
+                    str(restored_score_id),
+                    "2026-07-31T09:01:00+00:00",
+                    "2026-07-31T09:02:00+00:00",
+                ),
+            ),
+        )
+        conn.execute(
+            """
+            INSERT INTO job_materials (
+                tenant_id, job_id, generation, status, created_at, updated_at, metadata_json
+            ) VALUES (?, ?, 1, 'resume_approved', ?, ?, '{"source":"fixture"}')
+            """,
+            (str(LOCAL_TENANT), str(suppressed_id), now, now),
+        )
+        conn.execute(
+            """
+            INSERT INTO job_materials_artifacts (
+                tenant_id, job_id, generation, artifact_type, artifact_id, status,
+                path, render_format, metadata_json, created_at
+            ) VALUES (?, ?, 1, 'tailored_resume', 'resume-62', 'approved',
+                      '/tmp/resume-62.txt', 'text', '{"source":"fixture"}', ?)
+            """,
+            (str(LOCAL_TENANT), str(suppressed_id), now),
+        )
+        conn.commit()
+        monkeypatch.setattr(preparation, "get_connection", lambda: conn)
+
+        targets = preparation.derive_preparation_targets(
+            preparation.DerivePreparationTargetsInput(tenant_id=str(LOCAL_TENANT), min_score=7)
+        )
+
+        assert [target.job_id for target in targets] == [
+            pending_score_id,
+            pending_tailor_id,
+            restored_score_id,
+        ]
+        assert targets[0].steps == ["score", "tailor", "cover", "pdf"]
+        assert targets[1].steps == ["tailor", "cover", "pdf"]
+        assert targets[2].steps == ["score", "tailor", "cover", "pdf"]
+        suppressed = conn.execute(
+            """
+            SELECT status, metadata_json
+            FROM job_materials_artifacts
+            WHERE tenant_id = ? AND job_id = ? AND generation = 1
+            """,
+            (str(LOCAL_TENANT), str(suppressed_id)),
+        ).fetchone()
+        assert suppressed is not None
+        assert suppressed["status"] == "suppressed"
+        assert '"reason":"threshold_or_hard_blocker_ineligible"' in suppressed["metadata_json"]
+        assert preparation._unselected_work_plan_outcome(
+            conn,
+            tenant_id=LOCAL_TENANT,
+            job_id=suppressed_id,
+            min_score=7,
+        ) == ("not_eligible", "score_below_threshold")
+    finally:
+        conn.close()
 
 
 class _FakeUseExistingStarter:

--- a/workers/automation/tests/test_discovery_preparation_orchestration.py
+++ b/workers/automation/tests/test_discovery_preparation_orchestration.py
@@ -11,6 +11,7 @@ import pytest
 
 from jobctrl.database import init_db
 from jobctrl.domain.discovery.scheduler import ScheduledSource
+from jobctrl.domain.identifiers import JobId
 from jobctrl.domain.preparation import PreparationWorkItemKind
 from jobctrl.domain.tenant import LOCAL_TENANT
 from jobctrl.discovery.workflow import DiscoverWorkflow
@@ -18,6 +19,10 @@ from jobctrl.infrastructure.temporal.registry import WORKFLOWS
 from jobctrl.pipeline import preparation, runner
 from jobctrl.preparation.workflow import JobPreparationInput, JobPreparationWorkflow
 from jobctrl.workflow_specs import build_run_stage_workflow_spec
+
+
+def _job_id(index: int) -> JobId:
+    return JobId(f"10000000-0000-4000-8000-{index:012d}")
 
 
 @pytest.fixture()
@@ -51,9 +56,9 @@ def test_derive_preparation_targets_is_sorted_and_prefers_score_workflow(
 ) -> None:
     def fake_jobs(*, stage: str, **_kwargs):
         if stage == "pending_score":
-            return [{"url": "https://example.com/job/b"}, {"url": "https://example.com/job/a"}]
+            return [{"job_id": _job_id(2)}, {"job_id": _job_id(1)}]
         if stage == "pending_tailor":
-            return [{"url": "https://example.com/job/a"}, {"url": "https://example.com/job/c"}]
+            return [{"job_id": _job_id(1)}, {"job_id": _job_id(3)}]
         return []
 
     monkeypatch.setattr(preparation, "get_connection", lambda: conn)
@@ -61,17 +66,18 @@ def test_derive_preparation_targets_is_sorted_and_prefers_score_workflow(
     monkeypatch.setattr(preparation, "_suppress_ineligible_artifacts", lambda *_args, **_kwargs: 0)
     monkeypatch.setattr(preparation, "current_scoring_policy_version", lambda *_args, **_kwargs: 11)
     monkeypatch.setattr(preparation, "current_tailoring_policy_version", lambda *_args, **_kwargs: 7)
-    monkeypatch.setattr(preparation, "_latest_source_event_id", lambda _conn, url: f"event:{url.rsplit('/', 1)[-1]}")
+    monkeypatch.setattr(
+        preparation,
+        "_latest_source_event_id",
+        lambda _conn, *, tenant_id, job_id: f"event:{job_id}",
+    )
 
     targets = preparation.derive_preparation_targets(
         preparation.DerivePreparationTargetsInput(tenant_id=str(LOCAL_TENANT), min_score=7)
     )
 
-    assert [target.job_url for target in targets] == [
-        "https://example.com/job/a",
-        "https://example.com/job/b",
-        "https://example.com/job/c",
-    ]
+    assert [target.job_id for target in targets] == [_job_id(1), _job_id(2), _job_id(3)]
+    assert {target.tenant_id for target in targets} == {LOCAL_TENANT}
     assert targets[0].steps == ["score", "tailor", "cover", "pdf"]
     assert targets[0].target_version == "11"
     assert targets[2].steps == ["tailor", "cover", "pdf"]
@@ -89,10 +95,10 @@ def test_derive_targets_score_only_skips_pending_tailor(
 
     def fake_jobs(*, stage: str, **_kwargs):
         if stage == "pending_score":
-            return [{"url": "https://example.com/job/fresh"}]
+            return [{"job_id": _job_id(10)}]
         if stage == "pending_tailor":
             # A job scored earlier this run, now mid-tailor.
-            return [{"url": "https://example.com/job/mid-tailor"}]
+            return [{"job_id": _job_id(11)}]
         return []
 
     monkeypatch.setattr(preparation, "get_connection", lambda: conn)
@@ -100,7 +106,11 @@ def test_derive_targets_score_only_skips_pending_tailor(
     monkeypatch.setattr(preparation, "_suppress_ineligible_artifacts", lambda *_args, **_kwargs: 0)
     monkeypatch.setattr(preparation, "current_scoring_policy_version", lambda *_args, **_kwargs: 3)
     monkeypatch.setattr(preparation, "current_tailoring_policy_version", lambda *_args, **_kwargs: 5)
-    monkeypatch.setattr(preparation, "_latest_source_event_id", lambda _conn, url: f"event:{url.rsplit('/', 1)[-1]}")
+    monkeypatch.setattr(
+        preparation,
+        "_latest_source_event_id",
+        lambda _conn, *, tenant_id, job_id: f"event:{job_id}",
+    )
 
     full = preparation.derive_preparation_targets(
         preparation.DerivePreparationTargetsInput(tenant_id=str(LOCAL_TENANT), min_score=7)
@@ -112,13 +122,10 @@ def test_derive_targets_score_only_skips_pending_tailor(
     )
 
     # The default (first-pass) derive sweeps both the fresh job and the straggler.
-    assert {target.job_url for target in full} == {
-        "https://example.com/job/fresh",
-        "https://example.com/job/mid-tailor",
-    }
+    assert {target.job_id for target in full} == {_job_id(10), _job_id(11)}
     # Score-only (every subsequent streaming pass) never touches pending_tailor,
     # so the mid-tailor job cannot get a second, racing prep workflow.
-    assert [target.job_url for target in score_only] == ["https://example.com/job/fresh"]
+    assert [target.job_id for target in score_only] == [_job_id(10)]
     assert score_only[0].steps == ["score", "tailor", "cover", "pdf"]
 
 
@@ -151,13 +158,15 @@ def test_streaming_fanout_dedups_repeated_passes_via_deterministic_ids(
     executions."""
     targets = [
         preparation.PreparationTarget(
-            job_url="https://example.com/job/a",
+            tenant_id=LOCAL_TENANT,
+            job_id=_job_id(20),
             idempotency_key="preparation:key-a",
             target_version="3",
             steps=["score", "tailor", "cover", "pdf"],
         ),
         preparation.PreparationTarget(
-            job_url="https://example.com/job/b",
+            tenant_id=LOCAL_TENANT,
+            job_id=_job_id(21),
             idempotency_key="preparation:key-b",
             target_version="3",
             steps=["score", "tailor", "cover", "pdf"],
@@ -193,7 +202,11 @@ def test_per_job_handoff_id_converges_with_fanout_and_forks_on_reenrichment(
     material change — legitimately forks a new prep workflow."""
     monkeypatch.setattr(preparation, "get_connection", lambda: conn)
     monkeypatch.setattr(preparation, "current_scoring_policy_version", lambda *_a, **_k: 4)
-    monkeypatch.setattr(preparation, "_latest_source_event_id", lambda _conn, _url: "event-A")
+    monkeypatch.setattr(
+        preparation,
+        "_latest_source_event_id",
+        lambda _conn, *, tenant_id, job_id: "event-A",
+    )
 
     requested: list[str] = []
     requested_payloads: list[JobPreparationInput] = []
@@ -203,8 +216,8 @@ def test_per_job_handoff_id_converges_with_fanout_and_forks_on_reenrichment(
         requested_payloads.append(spec.args[0])
         return SimpleNamespace(id=spec.workflow_id)
 
-    job_url = "https://example.com/job/x"
-    preparation.start_job_preparation_workflow(job_url, workflow_starter=fake_starter)
+    job_id = _job_id(30)
+    preparation.start_job_preparation_workflow(job_id, workflow_starter=fake_starter)
     handoff_id = requested[-1]
     assert requested_payloads[-1].discovery_execution is None
     assert requested_payloads[-1].discovery_cohort_kind is None
@@ -212,7 +225,7 @@ def test_per_job_handoff_id_converges_with_fanout_and_forks_on_reenrichment(
     # Identical to what a SCORE_JOB fan-out derive produces for the same job.
     fanout_spec = preparation.build_preparation_workflow_spec(
         tenant_id=LOCAL_TENANT,
-        job_url=job_url,
+        job_id=job_id,
         steps=["score", "tailor", "cover", "pdf"],
         kind=PreparationWorkItemKind.SCORE_JOB,
         target_version=4,
@@ -222,12 +235,16 @@ def test_per_job_handoff_id_converges_with_fanout_and_forks_on_reenrichment(
     assert handoff_id.startswith("prep-preparation:")
 
     # A benign repeated handoff for the same source event reuses the id (dedup).
-    preparation.start_job_preparation_workflow(job_url, workflow_starter=fake_starter)
+    preparation.start_job_preparation_workflow(job_id, workflow_starter=fake_starter)
     assert requested[-1] == handoff_id
 
     # Re-enrichment producing a new source event forks a new id (material change).
-    monkeypatch.setattr(preparation, "_latest_source_event_id", lambda _conn, _url: "event-B")
-    preparation.start_job_preparation_workflow(job_url, workflow_starter=fake_starter)
+    monkeypatch.setattr(
+        preparation,
+        "_latest_source_event_id",
+        lambda _conn, *, tenant_id, job_id: "event-B",
+    )
+    preparation.start_job_preparation_workflow(job_id, workflow_starter=fake_starter)
     assert requested[-1] != handoff_id
 
 
@@ -236,7 +253,8 @@ def test_preparation_fan_out_starts_batches_of_at_most_25(
 ) -> None:
     targets = [
         preparation.PreparationTarget(
-            job_url=f"https://example.com/job/{index:02d}",
+            tenant_id=LOCAL_TENANT,
+            job_id=_job_id(100 + index),
             idempotency_key=f"preparation:key-{index:02d}",
             target_version="1",
             steps=["score"],
@@ -266,7 +284,7 @@ def test_build_preparation_workflow_spec_uses_deterministic_id(
     monkeypatch.setattr(preparation, "get_connection", lambda: conn)
     spec = preparation.build_preparation_workflow_spec(
         tenant_id=LOCAL_TENANT,
-        job_url="https://example.com/job/one",
+        job_id=_job_id(40),
         steps=["tailor", "cover", "pdf"],
         kind=PreparationWorkItemKind.TAILOR_RESUME,
         target_version=7,
@@ -279,7 +297,7 @@ def test_build_preparation_workflow_spec_uses_deterministic_id(
     (payload,) = spec.args
     assert isinstance(payload, JobPreparationInput)
     assert payload.steps == ["tailor", "cover", "pdf"]
-    assert payload.job_url == "https://example.com/job/one"
+    assert payload.job_id == _job_id(40)
     assert spec.workflow_id == f"prep-{payload.idempotency_key}"
 
 

--- a/workers/automation/tests/test_pipeline_step_lifecycle_emission.py
+++ b/workers/automation/tests/test_pipeline_step_lifecycle_emission.py
@@ -14,6 +14,7 @@ from temporalio.exceptions import ApplicationError
 from jobctrl.discovery import activities as discovery_activities
 from jobctrl.discovery import workflow as discovery_workflow
 from jobctrl.domain.discovery.execution import DiscoveryExecutionRef
+from jobctrl.domain.identifiers import JobId
 from jobctrl.infrastructure.temporal.pipeline_step_lifecycle import (
     PipelineStepScope,
     begin_pipeline_step_attempt,
@@ -21,6 +22,9 @@ from jobctrl.infrastructure.temporal.pipeline_step_lifecycle import (
 )
 from jobctrl.materials import activities as materials_activities
 from jobctrl.preparation import workflow as preparation_workflow
+
+
+_JOB_ID = JobId("20000000-0000-4000-8000-000000000001")
 
 
 def _execution() -> DiscoveryExecutionRef:
@@ -175,9 +179,7 @@ def test_attempt_never_fabricates_missing_queue_metadata_or_terminal_fact() -> N
         scope,
         info=SimpleNamespace(
             attempt=1,
-            current_attempt_scheduled_time=datetime(
-                2026, 7, 14, 8, 59, tzinfo=UTC
-            ),
+            current_attempt_scheduled_time=datetime(2026, 7, 14, 8, 59, tzinfo=UTC),
             started_time=datetime(2026, 7, 14, 9, 0, tzinfo=UTC),
         ),
         writer=events.append,
@@ -262,6 +264,7 @@ async def test_discovery_activities_use_stable_scopes_and_terminal_counts(
         "jobctrl.infrastructure.temporal.run_in_activity.run_blocking_with_heartbeat",
         fake_run_blocking,
     )
+
     def fake_source_family(family: str, **kwargs: Any) -> dict[str, Any]:
         source_kwargs.update(kwargs)
         return {
@@ -322,19 +325,14 @@ async def test_discovery_activities_use_stable_scopes_and_terminal_counts(
         )
     )
 
-    assert [
-        (scope.step_kind, scope.item_key, scope.detail_code)
-        for scope, _kwargs, _recorder in scopes
-    ] == [
+    assert [(scope.step_kind, scope.item_key, scope.detail_code) for scope, _kwargs, _recorder in scopes] == [
         ("source_family", "family:workday", "source_family"),
         ("enrichment_pass", "streaming:pass-4", "streaming_pass"),
         ("existing_backlog_sweep", "existing_backlog", "existing_backlog"),
     ]
     assert scopes[0][1] == {"item_count": 1}
     assert source_kwargs["activity_attempt"] == 2
-    assert source_kwargs["activity_owner_token"] == (
-        "source-family:activity-run-2:2"
-    )
+    assert source_kwargs["activity_owner_token"] == ("source-family:activity-run-2:2")
     assert [recorder.completed_counts for _, _, recorder in scopes] == [
         [1],
         [2],
@@ -438,7 +436,7 @@ async def test_pdf_error_status_emits_safe_failed_terminal(
     output = await materials_activities.render_pdf_activity(
         materials_activities.RenderPdfActivityInput(
             tenant_id="local",
-            job_url="https://example.com/private-job",
+            job_id=_JOB_ID,
             discovery_execution=_execution(),
             pipeline_step_idempotency_key=raw_idempotency_key,
         )
@@ -447,9 +445,7 @@ async def test_pdf_error_status_emits_safe_failed_terminal(
     assert output.status == "error"
     assert captured["scope"].step_kind == "pdf_render"
     assert captured["scope"].detail_code == "pdf_render"
-    assert captured["scope"].item_key == pdf_pipeline_step_item_key(
-        raw_idempotency_key
-    )
+    assert captured["scope"].item_key == pdf_pipeline_step_item_key(raw_idempotency_key)
     assert raw_idempotency_key not in captured["scope"].item_key
     assert recorder.completed_counts == []
     assert recorder.failures == [
@@ -483,7 +479,7 @@ async def test_preparation_workflow_forwards_discovery_scope_to_pdf_activity(
         "pdf",
         preparation_workflow.JobPreparationInput(
             tenant_id="local",
-            job_url="https://example.com/private-job",
+            job_id=_JOB_ID,
             steps=["pdf"],
             target_version="1",
             idempotency_key="preparation:opaque-key",
@@ -497,7 +493,7 @@ async def test_preparation_workflow_forwards_discovery_scope_to_pdf_activity(
     assert captured["activity"] is materials_activities.render_pdf_activity
     assert captured["payload"] == materials_activities.RenderPdfActivityInput(
         tenant_id="local",
-        job_url="https://example.com/private-job",
+        job_id=_JOB_ID,
         expected_app_dir="/expected/app",
         expected_db_path="/expected/jobctrl.db",
         discovery_execution=execution,
@@ -521,7 +517,7 @@ def test_pdf_scope_rejects_an_empty_idempotency_key() -> None:
     with pytest.raises(ValueError, match="must be non-empty"):
         materials_activities.RenderPdfActivityInput(
             tenant_id="local",
-            job_url="https://example.com/private-job",
+            job_id=_JOB_ID,
             discovery_execution=_execution(),
             pipeline_step_idempotency_key="",
         )

--- a/workers/automation/tests/test_workflow_job_preparation.py
+++ b/workers/automation/tests/test_workflow_job_preparation.py
@@ -16,6 +16,7 @@ from temporalio.exceptions import ActivityError, ApplicationError
 from temporalio.testing import WorkflowEnvironment
 from temporalio.worker import UnsandboxedWorkflowRunner, Worker
 
+from jobctrl.domain.identifiers import JobId
 from jobctrl.domain.preparation import PreparationWorkItemKind
 from jobctrl.domain.tenant import LOCAL_TENANT
 from jobctrl.materials.activities import cover_letter_activity, render_pdf_activity, tailor_job_activity
@@ -24,6 +25,9 @@ from jobctrl.preparation import workflow as prep_workflow_mod
 from jobctrl.preparation.workflow import JobPreparationInput, JobPreparationWorkflow
 from jobctrl.scoring.activities import score_job_activity
 from jobctrl.llm import SpendBudgetStatus
+
+
+_JOB_ID = JobId("10000000-0000-4000-8000-000000000001")
 
 
 @activity.defn(name="check_spend_budget")
@@ -51,7 +55,7 @@ async def test_preparation_workflow_runs_requested_steps_in_order(monkeypatch: p
     result = await JobPreparationWorkflow()._execute_steps(
         JobPreparationInput(
             tenant_id="local",
-            job_url="https://example.com/job/prep",
+            job_id=_JOB_ID,
             steps=["pdf", "score", "cover", "tailor"],
             target_version="1",
             idempotency_key="preparation:test",
@@ -66,6 +70,8 @@ async def test_preparation_workflow_runs_requested_steps_in_order(monkeypatch: p
         "cover_letter_activity",
         "render_pdf_activity",
     ]
+    assert [payload.job_id for _fn, payload in calls] == [_JOB_ID] * 4
+    assert all(not hasattr(payload, "job_url") for _fn, payload in calls)
 
 
 @pytest.mark.asyncio
@@ -80,7 +86,7 @@ async def test_preparation_workflow_treats_already_done_step_as_complete(
     result = await JobPreparationWorkflow()._execute_steps(
         JobPreparationInput(
             tenant_id="local",
-            job_url="https://example.com/job/prep",
+            job_id=_JOB_ID,
             steps=["cover"],
             target_version="1",
             idempotency_key="preparation:test",
@@ -89,6 +95,17 @@ async def test_preparation_workflow_treats_already_done_step_as_complete(
 
     assert result.steps_completed == ["cover"]
     assert result.failure is None
+
+
+def test_preparation_workflow_rejects_url_shaped_job_id() -> None:
+    with pytest.raises(ValueError, match="JobId must be a canonical UUID"):
+        JobPreparationInput(
+            tenant_id="local",
+            job_id=JobId("https://example.com/jobs/legacy"),
+            steps=["score"],
+            target_version="1",
+            idempotency_key="preparation:test",
+        )
 
 
 @pytest.mark.asyncio
@@ -116,7 +133,7 @@ async def test_preparation_workflow_records_failed_step_and_error_code(
     result = await JobPreparationWorkflow()._execute_steps(
         JobPreparationInput(
             tenant_id="local",
-            job_url="https://example.com/job/prep",
+            job_id=_JOB_ID,
             steps=["score", "tailor", "cover"],
             target_version="1",
             idempotency_key="preparation:test",
@@ -130,11 +147,10 @@ async def test_preparation_workflow_records_failed_step_and_error_code(
     assert result.failure.startswith("tailor:")
 
 
-def test_preparation_workflow_specs_are_deterministic_for_duplicate_triggers(
-) -> None:
+def test_preparation_workflow_specs_are_deterministic_for_duplicate_triggers() -> None:
     first = preparation.build_preparation_workflow_spec(
         tenant_id=LOCAL_TENANT,
-        job_url="https://example.com/job/retry",
+        job_id=_JOB_ID,
         steps=["tailor", "cover", "pdf"],
         kind=PreparationWorkItemKind.TAILOR_RESUME,
         target_version=3,
@@ -142,7 +158,7 @@ def test_preparation_workflow_specs_are_deterministic_for_duplicate_triggers(
     )
     second = preparation.build_preparation_workflow_spec(
         tenant_id=LOCAL_TENANT,
-        job_url="https://example.com/job/retry",
+        job_id=_JOB_ID,
         steps=["tailor", "cover", "pdf"],
         kind=PreparationWorkItemKind.TAILOR_RESUME,
         target_version=3,
@@ -197,7 +213,7 @@ async def test_duplicate_preparation_workflow_start_attaches_without_duplicate_s
 
     payload = JobPreparationInput(
         tenant_id="local",
-        job_url="https://example.com/job/prep",
+        job_id=_JOB_ID,
         steps=["score", "tailor", "cover", "pdf"],
         target_version="1",
         idempotency_key=workflow_id.removeprefix("prep-"),
@@ -260,9 +276,7 @@ async def test_preparation_workflow_fails_fast_when_budget_exceeded_and_spends_n
         from jobctrl.domain.errors import BudgetExceededError, to_application_error
 
         raise to_application_error(
-            BudgetExceededError(
-                "LLM daily spend budget exceeded: $30.0000 spent of $25.00 for 2026-07-05."
-            )
+            BudgetExceededError("LLM daily spend budget exceeded: $30.0000 spent of $25.00 for 2026-07-05.")
         )
 
     @activity.defn(name="record_workflow_started")
@@ -295,7 +309,7 @@ async def test_preparation_workflow_fails_fast_when_budget_exceeded_and_spends_n
 
     payload = JobPreparationInput(
         tenant_id="local",
-        job_url="https://example.com/job/budget",
+        job_id=_JOB_ID,
         steps=["score", "tailor", "cover", "pdf"],
         target_version="1",
         idempotency_key=f"preparation:{uuid.uuid4().hex}",
@@ -390,7 +404,7 @@ async def test_preparation_workflow_resumes_at_cover_after_worker_restart(
     ]
     payload = JobPreparationInput(
         tenant_id="local",
-        job_url="https://example.com/job/prep",
+        job_id=_JOB_ID,
         steps=["score", "tailor", "cover", "pdf"],
         target_version="1",
         idempotency_key=f"preparation:{uuid.uuid4().hex}",


### PR DESCRIPTION
## Summary
- carry canonical UUID JobIds through preparation targets, workflow inputs, safe summaries, idempotency keys, and per-job activity DTOs
- replace preparation score/tailor selection, artifact suppression, and unselected evaluation with exact-v7 tenant+JobId queries
- exclude active soft-deletion tombstones while retaining restored jobs
- add an unmocked sealed-v7 regression covering selection, suppression, tenant isolation, deletion, and restoration

## Scope
This PR converts the preparation fan-out and workflow contract as one coherent slice. The deeper single-job score/tailor/cover helper implementations remain separate child PRs.

## Validation
- `workers/automation/.venv/bin/pytest -q workers/automation/tests/test_discovery_preparation_orchestration.py workers/automation/tests/test_pipeline_step_lifecycle_emission.py workers/automation/tests/test_workflow_job_preparation.py` (31 passed)
- touched-file Ruff checks
- `git diff --check`
- independent review: PASS, zero findings