### PR TITLE
fix(rpc): resolve job locators to canonical ids

### DIFF
--- a/apps/api/src/local-actions.ts
+++ b/apps/api/src/local-actions.ts
@@ -482,7 +482,7 @@ function mapCommandToRpc(command: ActionCommandPayload, context: ActionDispatchC
         tenantId: "local",
         expectedAppDir: context.appDir,
         expectedDbPath: context.dbPath,
-        jobUrl: command.jobKey,
+        ...(command.jobId ? { jobId: command.jobId } : { jobUrl: command.jobKey }),
         dryRun: Boolean(command.dryRun),
         ...(command.reason ? { reason: command.reason } : {}),
       },
@@ -511,7 +511,11 @@ function mapCommandToRpc(command: ActionCommandPayload, context: ActionDispatchC
   if (command.action === "retailor_job") {
     return {
       method: "retailor_job",
-      params: retailorRpcParams(command, context, command.jobKey),
+      params: retailorRpcParams(
+        command,
+        context,
+        command.jobId ? { jobId: command.jobId } : { jobUrl: command.jobKey },
+      ),
     };
   }
   if (command.action === "retailor_current_policy") {
@@ -673,10 +677,12 @@ function tailorRpcParams(
   return params;
 }
 
+type PreparationJobLocator = { jobId: string } | { jobUrl: string };
+
 function retailorRpcParams(
   command: ActionCommandPayload,
   context: ActionDispatchContext,
-  jobUrl?: string,
+  locator?: PreparationJobLocator,
 ): Record<string, unknown> {
   const params: Record<string, unknown> = {
     tenantId: "local",
@@ -685,8 +691,8 @@ function retailorRpcParams(
     dryRun: Boolean(command.dryRun),
     suppressExistingArtifacts: Boolean(command.suppressExistingArtifacts),
   };
-  if (jobUrl) {
-    params.jobUrl = jobUrl;
+  if (locator) {
+    Object.assign(params, locator);
   } else {
     params.limit = command.limit ?? 100;
     params.jobUrls = command.jobKeys ?? [];

--- a/apps/api/src/local-actions.ts
+++ b/apps/api/src/local-actions.ts
@@ -133,13 +133,10 @@ export function createActionDispatcher(
       return { status: "reset", message: "Stage reset for retry." };
     }
 
-    if (
-      (command.action === "rescore_job" || command.action === "retailor_job") &&
-      !command.jobId
-    ) {
+    if (requiresCanonicalJobId(command) && !command.jobId) {
       return {
         status: "failed",
-        message: "Pipeline job selection requires a canonical jobId.",
+        message: "Job-scoped actions require a canonical jobId.",
       };
     }
 
@@ -506,7 +503,7 @@ function mapCommandToRpc(command: ActionCommandPayload, context: ActionDispatchC
         expectedAppDir: context.appDir,
         expectedDbPath: context.dbPath,
         limit: command.limit ?? 100,
-        jobUrls: command.jobKeys ?? [],
+        jobIds: command.jobIds ?? [],
         dryRun: Boolean(command.dryRun),
         ...(command.reason ? { reason: command.reason } : {}),
       },
@@ -515,7 +512,7 @@ function mapCommandToRpc(command: ActionCommandPayload, context: ActionDispatchC
   if (command.action === "tailor_job") {
     return {
       method: "tailor_job",
-      params: tailorRpcParams(command, context, command.jobKey),
+      params: tailorRpcParams(command, context, command.jobId!),
     };
   }
   if (command.action === "retailor_job") {
@@ -537,7 +534,7 @@ function mapCommandToRpc(command: ActionCommandPayload, context: ActionDispatchC
         tenantId: "local",
         expectedAppDir: context.appDir,
         expectedDbPath: context.dbPath,
-        jobUrl: command.jobKey,
+        jobId: command.jobId,
         force: Boolean(command.retailor),
       },
     };
@@ -568,7 +565,7 @@ function mapCommandToRpc(command: ActionCommandPayload, context: ActionDispatchC
         tenantId: "local",
         expectedAppDir: context.appDir,
         expectedDbPath: context.dbPath,
-        jobUrl: command.jobKey,
+        jobId: command.jobId,
         llmModel: command.llmModel ?? DEFAULT_PIPELINE_LLM_MODEL,
       },
     };
@@ -609,6 +606,23 @@ function retryContinuationStages(stage: NonNullable<ActionCommandPayload["stage"
   }
 }
 
+function requiresCanonicalJobId(command: ActionCommandPayload): boolean {
+  if (command.action === "retry_stage") {
+    return Boolean(command.runAfter) && command.jobKey !== PIPELINE_ACTION_JOB_KEY;
+  }
+  if (command.action === "run_stage") {
+    return command.jobKey !== PIPELINE_ACTION_JOB_KEY;
+  }
+  return (
+    command.action === "rescore_job" ||
+    command.action === "tailor_job" ||
+    command.action === "retailor_job" ||
+    command.action === "analyze_job" ||
+    command.action === "generate_interview_prep" ||
+    (command.action === "apply" && command.jobKey !== PIPELINE_ACTION_JOB_KEY)
+  );
+}
+
 function runStageRpcParams(command: ActionCommandPayload, context: ActionDispatchContext): Record<string, unknown> {
   const stages =
     command.stages && command.stages.length > 0
@@ -646,11 +660,11 @@ function runStageRpcParams(command: ActionCommandPayload, context: ActionDispatc
   if (command.tailorJudgeMinScore !== undefined) {
     params.tailorJudgeMinScore = command.tailorJudgeMinScore;
   }
-  if (command.jobKey !== PIPELINE_ACTION_JOB_KEY) {
-    params.jobUrl = command.jobKey;
+  if (command.jobId) {
+    params.jobId = command.jobId;
   }
-  if (command.jobKeys && command.jobKeys.length > 0) {
-    params.jobUrls = command.jobKeys;
+  if (command.jobIds && command.jobIds.length > 0) {
+    params.jobIds = command.jobIds;
   }
   return params;
 }
@@ -658,13 +672,13 @@ function runStageRpcParams(command: ActionCommandPayload, context: ActionDispatc
 function tailorRpcParams(
   command: ActionCommandPayload,
   context: ActionDispatchContext,
-  jobUrl: string,
+  jobId: string,
 ): Record<string, unknown> {
   const params: Record<string, unknown> = {
     tenantId: "local",
     expectedAppDir: context.appDir,
     expectedDbPath: context.dbPath,
-    jobUrl,
+    jobId,
     dryRun: Boolean(command.dryRun),
     allowLowFitOverride: true,
   };
@@ -701,7 +715,7 @@ function retailorRpcParams(
     Object.assign(params, locator);
   } else {
     params.limit = command.limit ?? 100;
-    params.jobUrls = command.jobKeys ?? [];
+    params.jobIds = command.jobIds ?? [];
   }
   if (command.reason) {
     params.reason = command.reason;
@@ -731,8 +745,8 @@ function applyRpcParams(command: ActionCommandPayload, context: ActionDispatchCo
     headless: Boolean(command.headless),
     continuous: Boolean(command.continuous),
   };
-  if (command.jobKey !== PIPELINE_ACTION_JOB_KEY) {
-    params.jobUrl = command.jobKey;
+  if (command.jobId) {
+    params.jobId = command.jobId;
   }
   return params;
 }

--- a/apps/api/src/local-actions.ts
+++ b/apps/api/src/local-actions.ts
@@ -133,6 +133,16 @@ export function createActionDispatcher(
       return { status: "reset", message: "Stage reset for retry." };
     }
 
+    if (
+      (command.action === "rescore_job" || command.action === "retailor_job") &&
+      !command.jobId
+    ) {
+      return {
+        status: "failed",
+        message: "Pipeline job selection requires a canonical jobId.",
+      };
+    }
+
     const rpcCall = mapCommandToRpc(command, context);
     if (!rpcCall) {
       return {
@@ -482,7 +492,7 @@ function mapCommandToRpc(command: ActionCommandPayload, context: ActionDispatchC
         tenantId: "local",
         expectedAppDir: context.appDir,
         expectedDbPath: context.dbPath,
-        ...(command.jobId ? { jobId: command.jobId } : { jobUrl: command.jobKey }),
+        jobId: command.jobId,
         dryRun: Boolean(command.dryRun),
         ...(command.reason ? { reason: command.reason } : {}),
       },
@@ -511,11 +521,7 @@ function mapCommandToRpc(command: ActionCommandPayload, context: ActionDispatchC
   if (command.action === "retailor_job") {
     return {
       method: "retailor_job",
-      params: retailorRpcParams(
-        command,
-        context,
-        command.jobId ? { jobId: command.jobId } : { jobUrl: command.jobKey },
-      ),
+      params: retailorRpcParams(command, context, { jobId: command.jobId! }),
     };
   }
   if (command.action === "retailor_current_policy") {
@@ -677,7 +683,7 @@ function tailorRpcParams(
   return params;
 }
 
-type PreparationJobLocator = { jobId: string } | { jobUrl: string };
+type PreparationJobLocator = { jobId: string };
 
 function retailorRpcParams(
   command: ActionCommandPayload,

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -1190,7 +1190,7 @@ export function buildApp(options: BuildAppOptions): FastifyInstance {
         : [];
 
       for (const group of runnableGroups) {
-        const command = bulkRetryRunStageCommand(group.stage, group.jobUrls, body);
+        const command = bulkRetryRunStageCommand(db, group.stage, group.jobUrls, body);
         const dispatch = await actionDispatcher(command, actionContext);
         if (dispatch.workflowId) {
           recordPipelineWorkflowStarted(
@@ -1198,7 +1198,7 @@ export function buildApp(options: BuildAppOptions): FastifyInstance {
             group.stage,
             dispatch.workflowId,
             dispatch.runId,
-            bulkRetryWorkflowPayload(command, dispatch, group.jobUrls),
+            bulkRetryWorkflowPayload(command, dispatch),
           );
         }
         if (dispatch.status === "queued") {
@@ -1253,7 +1253,7 @@ export function buildApp(options: BuildAppOptions): FastifyInstance {
       }
 
       for (const group of runnableGroups) {
-        const command = pendingPreparationRunStageCommand(group.stage, group.jobUrls, body);
+        const command = pendingPreparationRunStageCommand(db, group.stage, group.jobUrls, body);
         const dispatch = await actionDispatcher(command, actionContext);
         if (dispatch.workflowId) {
           recordPipelineWorkflowStarted(
@@ -1261,7 +1261,7 @@ export function buildApp(options: BuildAppOptions): FastifyInstance {
             group.stage,
             dispatch.workflowId,
             dispatch.runId,
-            pendingPreparationWorkflowPayload(command, dispatch, group.jobUrls),
+            pendingPreparationWorkflowPayload(command, dispatch),
           );
         }
         if (dispatch.status === "queued") {
@@ -1437,21 +1437,23 @@ export function buildApp(options: BuildAppOptions): FastifyInstance {
     if (!body) {
       return undefined;
     }
-    const command: ActionCommandPayload = {
-      action: "rescore_jobs_not_on_current_scoring_policy",
-      jobKey: PIPELINE_ACTION_JOB_KEY,
-      jobKeys: body.jobKeys,
-      limit: body.limit,
-      dryRun: body.dryRun,
-    };
-    if (body.reason) command.reason = body.reason;
-    const workerReady = requireWorkerReady(reply, options.dbPath, requireHealthyWorkerForActions);
-    if (!workerReady) {
-      return undefined;
-    }
-    const dispatch = await actionDispatcher(command, actionContext);
-    void reply.code(202);
-    return buildActionResponse(command, dispatch);
+    return withWritableDb(reply, options.dbPath, async (db) => {
+      const command: ActionCommandPayload = {
+        action: "rescore_jobs_not_on_current_scoring_policy",
+        jobKey: PIPELINE_ACTION_JOB_KEY,
+        jobIds: requireJobIds(db, body.jobKeys),
+        limit: body.limit,
+        dryRun: body.dryRun,
+      };
+      if (body.reason) command.reason = body.reason;
+      const workerReady = requireWorkerReady(reply, options.dbPath, requireHealthyWorkerForActions);
+      if (!workerReady) {
+        return undefined;
+      }
+      const dispatch = await actionDispatcher(command, actionContext);
+      void reply.code(202);
+      return buildActionResponse(command, dispatch);
+    });
   });
 
   app.delete<{ Params: { jobKey: string } }>("/v1/jobs/:jobKey", async (request, reply) => {
@@ -1502,9 +1504,11 @@ export function buildApp(options: BuildAppOptions): FastifyInstance {
       const reset = resetJobStage(db, decodeRouteParam(request.params.jobKey), body.stage, {
         resetAttempts: body.resetAttempts,
       });
+      const jobId = requireJobId(db, reset.jobUrl);
       const command: ActionCommandPayload = {
         action: "retry_stage" as const,
-        jobKey: reset.jobUrl,
+        jobKey: jobId,
+        jobId,
         stage: body.stage,
         resetAttempts: body.resetAttempts,
         runAfter: body.runAfter,
@@ -1536,9 +1540,11 @@ export function buildApp(options: BuildAppOptions): FastifyInstance {
         return { ok: false, error: "job_not_found" };
       }
       refreshProjections(db);
+      const jobId = requireJobId(db, jobUrl);
       const command: ActionCommandPayload = {
         action: "run_stage",
-        jobKey: jobUrl,
+        jobKey: jobId,
+        jobId,
         stage: body.stage,
         stages,
         dryRun: body.dryRun,
@@ -1595,9 +1601,11 @@ export function buildApp(options: BuildAppOptions): FastifyInstance {
         void reply.code(400);
         return { ok: false, error: "no_material_stage_requested" };
       }
+      const jobId = requireJobId(db, jobUrl);
       const command: ActionCommandPayload = {
         action: "run_stage",
-        jobKey: jobUrl,
+        jobKey: jobId,
+        jobId,
         stage: primaryStage,
         stages: body.stages,
         dryRun: body.dryRun,
@@ -1627,9 +1635,11 @@ export function buildApp(options: BuildAppOptions): FastifyInstance {
         return { ok: false, error: "job_not_found" };
       }
       refreshProjections(db);
+      const jobId = requireJobId(db, jobUrl);
       const command: ActionCommandPayload = {
         action: "generate_interview_prep",
-        jobKey: jobUrl,
+        jobKey: jobId,
+        jobId,
       };
       if (body.llmModel) {
         command.llmModel = body.llmModel;
@@ -1642,7 +1652,7 @@ export function buildApp(options: BuildAppOptions): FastifyInstance {
         message: "Interview preparation requested by user",
         payload: {
           tenantId: "local",
-          jobId: jobUrl,
+          jobId,
         },
       });
       const workerReady = requireWorkerReady(reply, options.dbPath, requireHealthyWorkerForActions);
@@ -1665,9 +1675,11 @@ export function buildApp(options: BuildAppOptions): FastifyInstance {
       if (!jobUrl) {
         return { ok: false, error: "job_not_found" };
       }
+      const jobId = requireJobId(db, jobUrl);
       const command: ActionCommandPayload = {
         action: "tailor_job",
-        jobKey: jobUrl,
+        jobKey: jobId,
+        jobId,
         dryRun: body.dryRun,
         tailorModels: body.tailorModels,
       };
@@ -1684,7 +1696,7 @@ export function buildApp(options: BuildAppOptions): FastifyInstance {
         message: "Tailoring requested by user",
         payload: {
           tenantId: "local",
-          jobId: jobUrl,
+          jobId,
           dryRun: body.dryRun,
           reason: body.reason ?? "manual_tailor",
           allowLowFitOverride: true,
@@ -1758,27 +1770,29 @@ export function buildApp(options: BuildAppOptions): FastifyInstance {
     if (!body) {
       return undefined;
     }
-    const command: ActionCommandPayload = {
-      action: "retailor_current_policy",
-      jobKey: PIPELINE_ACTION_JOB_KEY,
-      jobKeys: body.jobKeys,
-      limit: body.limit,
-      dryRun: body.dryRun,
-      suppressExistingArtifacts: body.suppressExistingArtifacts,
-      tailorModels: body.tailorModels,
-    };
-    if (body.reason) command.reason = body.reason;
-    if (body.tailorJudgeModel) command.tailorJudgeModel = body.tailorJudgeModel;
-    if (body.tailorJudgeMinScore !== undefined) {
-      command.tailorJudgeMinScore = body.tailorJudgeMinScore;
-    }
-    const workerReady = requireWorkerReady(reply, options.dbPath, requireHealthyWorkerForActions);
-    if (!workerReady) {
-      return undefined;
-    }
-    const dispatch = await actionDispatcher(command, actionContext);
-    void reply.code(202);
-    return buildActionResponse(command, dispatch);
+    return withWritableDb(reply, options.dbPath, async (db) => {
+      const command: ActionCommandPayload = {
+        action: "retailor_current_policy",
+        jobKey: PIPELINE_ACTION_JOB_KEY,
+        jobIds: requireJobIds(db, body.jobKeys),
+        limit: body.limit,
+        dryRun: body.dryRun,
+        suppressExistingArtifacts: body.suppressExistingArtifacts,
+        tailorModels: body.tailorModels,
+      };
+      if (body.reason) command.reason = body.reason;
+      if (body.tailorJudgeModel) command.tailorJudgeModel = body.tailorJudgeModel;
+      if (body.tailorJudgeMinScore !== undefined) {
+        command.tailorJudgeMinScore = body.tailorJudgeMinScore;
+      }
+      const workerReady = requireWorkerReady(reply, options.dbPath, requireHealthyWorkerForActions);
+      if (!workerReady) {
+        return undefined;
+      }
+      const dispatch = await actionDispatcher(command, actionContext);
+      void reply.code(202);
+      return buildActionResponse(command, dispatch);
+    });
   });
 
   app.post<{ Params: { jobKey: string } }>("/v1/jobs/:jobKey/actions/apply", async (request, reply) => {
@@ -1794,9 +1808,11 @@ export function buildApp(options: BuildAppOptions): FastifyInstance {
       if (!body.dryRun) {
         assertLiveApplicationMayDispatch(db, jobUrl);
       }
-      const command = {
+      const jobId = requireJobId(db, jobUrl);
+      const command: ActionCommandPayload = {
         action: "apply" as const,
-        jobKey: jobUrl,
+        jobKey: jobId,
+        jobId,
         dryRun: body.dryRun,
         headless: body.headless,
         limit: body.limit,
@@ -3496,6 +3512,10 @@ function requireJobId(db: ApiDb, jobLocator: string): string {
   return jobId;
 }
 
+function requireJobIds(db: ApiDb, jobLocators: readonly string[]): string[] {
+  return [...new Set(jobLocators.map((jobLocator) => requireJobId(db, jobLocator)))];
+}
+
 function firstEligiblePendingPreparationStage(
   db: ApiDb,
   jobUrl: string,
@@ -3519,6 +3539,7 @@ function stageCountsForTargets(targets: readonly RetryFailedJobTarget[]): Partia
 }
 
 function bulkRetryRunStageCommand(
+  db: ApiDb,
   stage: Stage,
   jobUrls: readonly string[],
   request: BulkRetryFailedRequest,
@@ -3527,7 +3548,7 @@ function bulkRetryRunStageCommand(
   const command: ActionCommandPayload = {
     action: "run_stage",
     jobKey: PIPELINE_ACTION_JOB_KEY,
-    jobKeys: [...jobUrls],
+    jobIds: requireJobIds(db, jobUrls),
     stage,
     stages,
     dryRun: request.dryRun,
@@ -3544,11 +3565,12 @@ function bulkRetryRunStageCommand(
 }
 
 function pendingPreparationRunStageCommand(
+  db: ApiDb,
   stage: Stage,
   jobUrls: readonly string[],
   request: BulkRunPendingPreparationRequest,
 ): ActionCommandPayload {
-  const command = bulkRetryRunStageCommand(stage, jobUrls, {
+  const command = bulkRetryRunStageCommand(db, stage, jobUrls, {
     allMatching: false,
     jobKeys: [...jobUrls],
     runAfter: true,
@@ -3568,15 +3590,14 @@ function pendingPreparationRunStageCommand(
 function bulkRetryWorkflowPayload(
   command: ActionCommandPayload,
   dispatch: ActionDispatchResult,
-  jobUrls: readonly string[],
 ): Record<string, unknown> {
   return {
     source: "bulk_retry_failed",
     action: command.action,
     stage: command.stage,
     stages: command.stages ?? [],
-    jobUrls: [...jobUrls],
-    jobCount: jobUrls.length,
+    jobIds: command.jobIds ?? [],
+    jobCount: command.jobIds?.length ?? 0,
     requestedWorkers: command.workers,
     requestedLimit: command.limit,
     requestedMinScore: command.minScore,
@@ -3589,10 +3610,9 @@ function bulkRetryWorkflowPayload(
 function pendingPreparationWorkflowPayload(
   command: ActionCommandPayload,
   dispatch: ActionDispatchResult,
-  jobUrls: readonly string[],
 ): Record<string, unknown> {
   return {
-    ...bulkRetryWorkflowPayload(command, dispatch, jobUrls),
+    ...bulkRetryWorkflowPayload(command, dispatch),
     source: "bulk_run_pending_preparation",
   };
 }

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -1412,9 +1412,11 @@ export function buildApp(options: BuildAppOptions): FastifyInstance {
         if (!jobUrl) {
           return { ok: false, error: "job_not_found" };
         }
+        const jobId = requireJobId(db, jobUrl);
         const command: ActionCommandPayload = {
           action: "rescore_job",
-          jobKey: jobUrl,
+          jobKey: jobId,
+          jobId,
           dryRun: body.dryRun,
         };
         if (body.reason) command.reason = body.reason;
@@ -1711,9 +1713,11 @@ export function buildApp(options: BuildAppOptions): FastifyInstance {
         if (!jobUrl) {
           return { ok: false, error: "job_not_found" };
         }
+        const jobId = requireJobId(db, jobUrl);
         const command: ActionCommandPayload = {
           action: "retailor_job",
-          jobKey: jobUrl,
+          jobKey: jobId,
+          jobId,
           dryRun: body.dryRun,
           suppressExistingArtifacts: body.suppressExistingArtifacts,
           tailorModels: body.tailorModels,
@@ -1731,7 +1735,7 @@ export function buildApp(options: BuildAppOptions): FastifyInstance {
           message: "Current-policy re-tailoring requested by user",
           payload: {
             tenantId: "local",
-            jobId: jobUrl,
+            jobId,
             dryRun: body.dryRun,
             reason: body.reason ?? "current_policy_retailor",
             suppressExistingArtifacts: body.suppressExistingArtifacts,
@@ -3482,6 +3486,14 @@ function candidateJobUrls(
     }
   }
   return [...unique];
+}
+
+function requireJobId(db: ApiDb, jobLocator: string): string {
+  const jobId = resolveJobId(db, "local", jobLocator);
+  if (!jobId) {
+    throw new InputError(`Unknown job selection: ${jobLocator}`);
+  }
+  return jobId;
 }
 
 function firstEligiblePendingPreparationStage(

--- a/apps/api/test/json-rpc-adapter.test.ts
+++ b/apps/api/test/json-rpc-adapter.test.ts
@@ -230,7 +230,8 @@ describe("createActionDispatcher (JSON-RPC adapter)", () => {
     await dispatcher(
       {
         action: "rescore_job",
-        jobKey: "https://example.com/jobs/current",
+        jobKey: CANONICAL_JOB_ID,
+        jobId: CANONICAL_JOB_ID,
         dryRun: true,
         reason: "policy refresh",
       },
@@ -261,7 +262,8 @@ describe("createActionDispatcher (JSON-RPC adapter)", () => {
     await dispatcher(
       {
         action: "retailor_job",
-        jobKey: "https://example.com/jobs/current",
+        jobKey: CANONICAL_JOB_ID,
+        jobId: CANONICAL_JOB_ID,
         dryRun: true,
         suppressExistingArtifacts: false,
         tailorModels: ["gemini:test"],
@@ -288,7 +290,7 @@ describe("createActionDispatcher (JSON-RPC adapter)", () => {
           tenantId: "local",
           expectedAppDir: "/tmp",
           expectedDbPath: "/tmp/jobctrl.db",
-          jobUrl: "https://example.com/jobs/current",
+          jobId: CANONICAL_JOB_ID,
           dryRun: true,
           reason: "policy refresh",
         },
@@ -325,7 +327,7 @@ describe("createActionDispatcher (JSON-RPC adapter)", () => {
           tenantId: "local",
           expectedAppDir: "/tmp",
           expectedDbPath: "/tmp/jobctrl.db",
-          jobUrl: "https://example.com/jobs/current",
+          jobId: CANONICAL_JOB_ID,
           dryRun: true,
           suppressExistingArtifacts: false,
           tailorModels: ["gemini:test"],
@@ -397,6 +399,25 @@ describe("createActionDispatcher (JSON-RPC adapter)", () => {
     ]);
   });
 
+  it("fails closed when direct maintenance actions lack a canonical job id", async () => {
+    const fake = new FakeDispatcher();
+    const dispatcher = createActionDispatcher(fake);
+    const context = { appDir: "/tmp", dbPath: "/tmp/jobctrl.db" };
+
+    for (const action of ["rescore_job", "retailor_job"] as const) {
+      const result = await dispatcher(
+        { action, jobKey: "https://example.com/jobs/legacy" },
+        context,
+      );
+      expect(result).toMatchObject({
+        status: "failed",
+        message: "Pipeline job selection requires a canonical jobId.",
+      });
+    }
+
+    expect(fake.calls).toEqual([]);
+  });
+
   it("surfaces workflow start identifiers for preparation maintenance actions", async () => {
     const fake = new FakeDispatcher();
     const dispatcher = createActionDispatcher(fake);
@@ -404,7 +425,8 @@ describe("createActionDispatcher (JSON-RPC adapter)", () => {
     const commands: ActionCommandPayload[] = [
       {
         action: "rescore_job",
-        jobKey: "https://example.com/jobs/current",
+        jobKey: CANONICAL_JOB_ID,
+        jobId: CANONICAL_JOB_ID,
       },
       {
         action: "rescore_jobs_not_on_current_scoring_policy",
@@ -412,7 +434,8 @@ describe("createActionDispatcher (JSON-RPC adapter)", () => {
       },
       {
         action: "retailor_job",
-        jobKey: "https://example.com/jobs/current",
+        jobKey: CANONICAL_JOB_ID,
+        jobId: CANONICAL_JOB_ID,
       },
       {
         action: "retailor_current_policy",
@@ -592,7 +615,7 @@ describe("createActionDispatcher (JSON-RPC adapter)", () => {
     );
     await dispatcher({ action: "apply", jobKey: "https://example.com/jobs/current" }, context);
     await dispatcher({ action: "cancel", jobKey: "pipeline", runId: "run-1" }, context);
-    await dispatcher({ action: "rescore_job", jobKey: "https://example.com/jobs/current" }, context);
+    await dispatcher({ action: "rescore_job", jobKey: CANONICAL_JOB_ID, jobId: CANONICAL_JOB_ID }, context);
     await dispatcher({ action: "refresh_compensation", jobKey: "https://example.com/jobs/current" }, context);
     await dispatcher({ action: "generate_interview_prep", jobKey: "https://example.com/jobs/current" }, context);
     await dispatcher(
@@ -602,7 +625,7 @@ describe("createActionDispatcher (JSON-RPC adapter)", () => {
       },
       context,
     );
-    await dispatcher({ action: "retailor_job", jobKey: "https://example.com/jobs/current" }, context);
+    await dispatcher({ action: "retailor_job", jobKey: CANONICAL_JOB_ID, jobId: CANONICAL_JOB_ID }, context);
     await dispatcher({ action: "retailor_current_policy", jobKey: "pipeline" }, context);
 
     const dispatchedMethods = [...new Set(fake.calls.map((call) => call.method))];

--- a/apps/api/test/json-rpc-adapter.test.ts
+++ b/apps/api/test/json-rpc-adapter.test.ts
@@ -24,6 +24,7 @@ import type {
 import type { JsonRpcResponse, RpcMethod } from "../src/contracts.js";
 
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
+const CANONICAL_JOB_ID = "11111111-1111-4111-8111-111111111111";
 
 class FakeDispatcher implements JsonRpcDispatcher {
   public readonly calls: Array<{ method: RpcMethod; params: Record<string, unknown> }> = [];
@@ -342,6 +343,55 @@ describe("createActionDispatcher (JSON-RPC adapter)", () => {
           jobUrls: ["https://example.com/jobs/current"],
           dryRun: false,
           suppressExistingArtifacts: false,
+        },
+      },
+    ]);
+  });
+
+  it("dispatches canonical job ids for direct rescore and retailor actions", async () => {
+    const fake = new FakeDispatcher();
+    const dispatcher = createActionDispatcher(fake);
+    const context = { appDir: "/tmp", dbPath: "/tmp/jobctrl.db" };
+
+    await dispatcher(
+      {
+        action: "rescore_job",
+        jobKey: CANONICAL_JOB_ID,
+        jobId: CANONICAL_JOB_ID,
+        dryRun: true,
+      },
+      context,
+    );
+    await dispatcher(
+      {
+        action: "retailor_job",
+        jobKey: CANONICAL_JOB_ID,
+        jobId: CANONICAL_JOB_ID,
+        suppressExistingArtifacts: true,
+      },
+      context,
+    );
+
+    expect(fake.calls).toEqual([
+      {
+        method: "rescore_job",
+        params: {
+          tenantId: "local",
+          expectedAppDir: "/tmp",
+          expectedDbPath: "/tmp/jobctrl.db",
+          jobId: CANONICAL_JOB_ID,
+          dryRun: true,
+        },
+      },
+      {
+        method: "retailor_job",
+        params: {
+          tenantId: "local",
+          expectedAppDir: "/tmp",
+          expectedDbPath: "/tmp/jobctrl.db",
+          jobId: CANONICAL_JOB_ID,
+          dryRun: false,
+          suppressExistingArtifacts: true,
         },
       },
     ]);

--- a/apps/api/test/json-rpc-adapter.test.ts
+++ b/apps/api/test/json-rpc-adapter.test.ts
@@ -56,7 +56,8 @@ describe("createActionDispatcher (JSON-RPC adapter)", () => {
     const result = await dispatcher(
       {
         action: "apply",
-        jobKey: "https://example.com/jobs/x",
+        jobKey: CANONICAL_JOB_ID,
+        jobId: CANONICAL_JOB_ID,
         limit: 1,
         dryRun: true,
         model: "default",
@@ -70,7 +71,7 @@ describe("createActionDispatcher (JSON-RPC adapter)", () => {
       tenantId: "local",
       expectedAppDir: "/tmp",
       expectedDbPath: "/tmp/jobctrl.db",
-      jobUrl: "https://example.com/jobs/x",
+      jobId: CANONICAL_JOB_ID,
       limit: 1,
       dryRun: true,
       model: "default",
@@ -86,7 +87,8 @@ describe("createActionDispatcher (JSON-RPC adapter)", () => {
     const result = await dispatcher(
       {
         action: "retry_stage",
-        jobKey: "https://example.com/jobs/x",
+        jobKey: CANONICAL_JOB_ID,
+        jobId: CANONICAL_JOB_ID,
         stage: "apply",
         runAfter: true,
         dryRun: true,
@@ -106,7 +108,8 @@ describe("createActionDispatcher (JSON-RPC adapter)", () => {
     const result = await dispatcher(
       {
         action: "retry_stage",
-        jobKey: "https://example.com/jobs/x",
+        jobKey: CANONICAL_JOB_ID,
+        jobId: CANONICAL_JOB_ID,
         stage: "enrich",
         stages: ["enrich", "score", "tailor", "cover"],
         runAfter: true,
@@ -122,7 +125,7 @@ describe("createActionDispatcher (JSON-RPC adapter)", () => {
         tenantId: "local",
         expectedAppDir: "/tmp",
         expectedDbPath: "/tmp/jobctrl.db",
-        jobUrl: "https://example.com/jobs/x",
+        jobId: CANONICAL_JOB_ID,
         stage: "enrich",
         stages: ["enrich", "score", "tailor", "cover"],
         limit: 1,
@@ -139,7 +142,8 @@ describe("createActionDispatcher (JSON-RPC adapter)", () => {
     await dispatcher(
       {
         action: "retry_stage",
-        jobKey: "https://example.com/jobs/x",
+        jobKey: CANONICAL_JOB_ID,
+        jobId: CANONICAL_JOB_ID,
         stage: "tailor",
         runAfter: true,
         dryRun: true,
@@ -151,7 +155,7 @@ describe("createActionDispatcher (JSON-RPC adapter)", () => {
     expect(fake.calls[0]).toEqual({
       method: "run_stage",
       params: expect.objectContaining({
-        jobUrl: "https://example.com/jobs/x",
+        jobId: CANONICAL_JOB_ID,
         stage: "tailor",
         stages: ["tailor", "cover"],
         limit: 1,
@@ -241,7 +245,7 @@ describe("createActionDispatcher (JSON-RPC adapter)", () => {
       {
         action: "rescore_jobs_not_on_current_scoring_policy",
         jobKey: "pipeline",
-        jobKeys: ["https://example.com/jobs/stale"],
+        jobIds: [CANONICAL_JOB_ID],
         limit: 10,
         dryRun: true,
       },
@@ -250,7 +254,8 @@ describe("createActionDispatcher (JSON-RPC adapter)", () => {
     await dispatcher(
       {
         action: "tailor_job",
-        jobKey: "https://example.com/jobs/current",
+        jobKey: CANONICAL_JOB_ID,
+        jobId: CANONICAL_JOB_ID,
         dryRun: true,
         reason: "manual_tailor",
         tailorModels: ["gemini:test"],
@@ -276,7 +281,7 @@ describe("createActionDispatcher (JSON-RPC adapter)", () => {
       {
         action: "retailor_current_policy",
         jobKey: "pipeline",
-        jobKeys: ["https://example.com/jobs/current"],
+        jobIds: [CANONICAL_JOB_ID],
         limit: 5,
         dryRun: false,
       },
@@ -302,7 +307,7 @@ describe("createActionDispatcher (JSON-RPC adapter)", () => {
           expectedAppDir: "/tmp",
           expectedDbPath: "/tmp/jobctrl.db",
           limit: 10,
-          jobUrls: ["https://example.com/jobs/stale"],
+          jobIds: [CANONICAL_JOB_ID],
           dryRun: true,
         },
       },
@@ -312,7 +317,7 @@ describe("createActionDispatcher (JSON-RPC adapter)", () => {
           tenantId: "local",
           expectedAppDir: "/tmp",
           expectedDbPath: "/tmp/jobctrl.db",
-          jobUrl: "https://example.com/jobs/current",
+          jobId: CANONICAL_JOB_ID,
           dryRun: true,
           allowLowFitOverride: true,
           reason: "manual_tailor",
@@ -342,7 +347,7 @@ describe("createActionDispatcher (JSON-RPC adapter)", () => {
           expectedAppDir: "/tmp",
           expectedDbPath: "/tmp/jobctrl.db",
           limit: 5,
-          jobUrls: ["https://example.com/jobs/current"],
+          jobIds: [CANONICAL_JOB_ID],
           dryRun: false,
           suppressExistingArtifacts: false,
         },
@@ -399,19 +404,27 @@ describe("createActionDispatcher (JSON-RPC adapter)", () => {
     ]);
   });
 
-  it("fails closed when direct maintenance actions lack a canonical job id", async () => {
+  it("fails closed when job-scoped actions lack a canonical job id", async () => {
     const fake = new FakeDispatcher();
     const dispatcher = createActionDispatcher(fake);
     const context = { appDir: "/tmp", dbPath: "/tmp/jobctrl.db" };
 
-    for (const action of ["rescore_job", "retailor_job"] as const) {
-      const result = await dispatcher(
-        { action, jobKey: "https://example.com/jobs/legacy" },
-        context,
-      );
+    const commands: ActionCommandPayload[] = [
+      { action: "retry_stage", jobKey: "https://example.com/jobs/legacy", stage: "score", runAfter: true },
+      { action: "run_stage", jobKey: "https://example.com/jobs/legacy", stage: "score" },
+      { action: "rescore_job", jobKey: "https://example.com/jobs/legacy" },
+      { action: "tailor_job", jobKey: "https://example.com/jobs/legacy" },
+      { action: "retailor_job", jobKey: "https://example.com/jobs/legacy" },
+      { action: "analyze_job", jobKey: "https://example.com/jobs/legacy" },
+      { action: "generate_interview_prep", jobKey: "https://example.com/jobs/legacy" },
+      { action: "apply", jobKey: "https://example.com/jobs/legacy" },
+    ];
+
+    for (const command of commands) {
+      const result = await dispatcher(command, context);
       expect(result).toMatchObject({
         status: "failed",
-        message: "Pipeline job selection requires a canonical jobId.",
+        message: "Job-scoped actions require a canonical jobId.",
       });
     }
 
@@ -564,7 +577,8 @@ describe("createActionDispatcher (JSON-RPC adapter)", () => {
     const result = await dispatcher(
       {
         action: "generate_interview_prep",
-        jobKey: "https://example.com/jobs/current",
+        jobKey: CANONICAL_JOB_ID,
+        jobId: CANONICAL_JOB_ID,
         llmModel: "gpt-test",
       },
       { appDir: "/tmp", dbPath: "/tmp/jobctrl.db" },
@@ -577,12 +591,41 @@ describe("createActionDispatcher (JSON-RPC adapter)", () => {
           tenantId: "local",
           expectedAppDir: "/tmp",
           expectedDbPath: "/tmp/jobctrl.db",
-          jobUrl: "https://example.com/jobs/current",
+          jobId: CANONICAL_JOB_ID,
           llmModel: "gpt-test",
         },
       },
     ]);
     expect(result).toMatchObject({ status: "queued", runId: "run-fake" });
+  });
+
+  it("maps employer analysis by canonical job ID without a URL-shaped RPC param", async () => {
+    const fake = new FakeDispatcher();
+    const dispatcher = createActionDispatcher(fake);
+
+    await dispatcher(
+      {
+        action: "analyze_job",
+        jobKey: CANONICAL_JOB_ID,
+        jobId: CANONICAL_JOB_ID,
+        retailor: true,
+      },
+      { appDir: "/tmp", dbPath: "/tmp/jobctrl.db" },
+    );
+
+    expect(fake.calls).toEqual([
+      {
+        method: "analyze_job",
+        params: {
+          tenantId: "local",
+          expectedAppDir: "/tmp",
+          expectedDbPath: "/tmp/jobctrl.db",
+          jobId: CANONICAL_JOB_ID,
+          force: true,
+        },
+      },
+    ]);
+    expect(fake.calls[0]?.params).not.toHaveProperty("jobUrl");
   });
 
   it("dispatches only RPC methods registered by the Python worker", async () => {
@@ -607,17 +650,21 @@ describe("createActionDispatcher (JSON-RPC adapter)", () => {
     await dispatcher(
       {
         action: "retry_stage",
-        jobKey: "https://example.com/jobs/current",
+        jobKey: CANONICAL_JOB_ID,
+        jobId: CANONICAL_JOB_ID,
         stage: "apply",
         runAfter: true,
       },
       context,
     );
-    await dispatcher({ action: "apply", jobKey: "https://example.com/jobs/current" }, context);
+    await dispatcher({ action: "apply", jobKey: CANONICAL_JOB_ID, jobId: CANONICAL_JOB_ID }, context);
     await dispatcher({ action: "cancel", jobKey: "pipeline", runId: "run-1" }, context);
     await dispatcher({ action: "rescore_job", jobKey: CANONICAL_JOB_ID, jobId: CANONICAL_JOB_ID }, context);
     await dispatcher({ action: "refresh_compensation", jobKey: "https://example.com/jobs/current" }, context);
-    await dispatcher({ action: "generate_interview_prep", jobKey: "https://example.com/jobs/current" }, context);
+    await dispatcher(
+      { action: "generate_interview_prep", jobKey: CANONICAL_JOB_ID, jobId: CANONICAL_JOB_ID },
+      context,
+    );
     await dispatcher(
       {
         action: "rescore_jobs_not_on_current_scoring_policy",
@@ -655,7 +702,7 @@ describe("createActionDispatcher (JSON-RPC adapter)", () => {
     expect(fake.calls[0]?.method).toBe("run_stage");
   });
 
-  it("passes selected job URLs through global run-stage RPC", async () => {
+  it("passes selected canonical job IDs through global run-stage RPC", async () => {
     const fake = new FakeDispatcher();
     const dispatcher = createActionDispatcher(fake);
 
@@ -663,7 +710,7 @@ describe("createActionDispatcher (JSON-RPC adapter)", () => {
       {
         action: "run_stage",
         jobKey: "pipeline",
-        jobKeys: ["https://example.com/jobs/a", "https://example.com/jobs/b"],
+        jobIds: [CANONICAL_JOB_ID],
         stage: "score",
         stages: ["score", "tailor", "cover"],
         limit: 2,
@@ -675,7 +722,7 @@ describe("createActionDispatcher (JSON-RPC adapter)", () => {
     expect(fake.calls[0]).toEqual({
       method: "run_stage",
       params: expect.objectContaining({
-        jobUrls: ["https://example.com/jobs/a", "https://example.com/jobs/b"],
+        jobIds: [CANONICAL_JOB_ID],
         stage: "score",
         stages: ["score", "tailor", "cover"],
         limit: 2,
@@ -884,7 +931,8 @@ describe("createActionDispatcher (JSON-RPC adapter)", () => {
     const result = await dispatcher(
       {
         action: "retry_stage",
-        jobKey: "https://example.com/jobs/x",
+        jobKey: CANONICAL_JOB_ID,
+        jobId: CANONICAL_JOB_ID,
         stage: "apply",
         runAfter: false,
         dryRun: true,
@@ -924,14 +972,15 @@ describe("createActionDispatcher (JSON-RPC adapter)", () => {
     fake.setResponse({
       jsonrpc: "2.0",
       id: 1,
-      error: { code: -32602, message: "Invalid params: missing jobUrl" },
+      error: { code: -32602, message: "Invalid params: missing jobId" },
     } as JsonRpcResponse);
     const dispatcher = createActionDispatcher(fake);
 
     const result = await dispatcher(
       {
         action: "apply",
-        jobKey: "https://example.com/jobs/y",
+        jobKey: CANONICAL_JOB_ID,
+        jobId: CANONICAL_JOB_ID,
         limit: 1,
         dryRun: true,
       },
@@ -940,7 +989,7 @@ describe("createActionDispatcher (JSON-RPC adapter)", () => {
 
     expect(result).toMatchObject({
       status: "failed",
-      message: "Invalid params: missing jobUrl",
+      message: "Invalid params: missing jobId",
     });
   });
 
@@ -956,7 +1005,8 @@ describe("createActionDispatcher (JSON-RPC adapter)", () => {
     const result: ActionDispatchResult = await dispatcher(
       {
         action: "apply",
-        jobKey: "https://example.com/jobs/y",
+        jobKey: CANONICAL_JOB_ID,
+        jobId: CANONICAL_JOB_ID,
         limit: 1,
         dryRun: true,
       },
@@ -973,7 +1023,8 @@ describe("createActionDispatcher (JSON-RPC adapter)", () => {
     await dispatcher(
       {
         action: "apply",
-        jobKey: "https://example.com/jobs/z",
+        jobKey: CANONICAL_JOB_ID,
+        jobId: CANONICAL_JOB_ID,
         limit: 1,
         dryRun: true,
       },

--- a/apps/api/test/rpc-contracts.test.ts
+++ b/apps/api/test/rpc-contracts.test.ts
@@ -25,6 +25,8 @@ import {
   TailorJobParamsSchema,
 } from "../src/contracts.js";
 
+const CANONICAL_JOB_ID = "11111111-1111-4111-8111-111111111111";
+
 describe("cancel_run RPC contract", () => {
   it("registers cancel_run in RpcMethods", () => {
     expect(RpcMethods.CancelRun).toBe("cancel_run");
@@ -228,6 +230,11 @@ describe("preparation RPC contracts", () => {
       jobUrl: "https://example.test/job/1",
       dryRun: false,
     });
+    expect(RescoreJobParamsSchema.parse({ jobId: CANONICAL_JOB_ID })).toEqual({
+      tenantId: "local",
+      jobId: CANONICAL_JOB_ID,
+      dryRun: false,
+    });
   });
 
   it("parses and rejects refresh_compensation payloads", () => {
@@ -339,6 +346,13 @@ describe("preparation RPC contracts", () => {
   it("rejects invalid rescore_job request payloads", () => {
     expect(() => RescoreJobParamsSchema.parse({})).toThrow();
     expect(() => RescoreJobParamsSchema.parse({ jobUrl: "" })).toThrow();
+    expect(() => RescoreJobParamsSchema.parse({ jobId: "https://example.test/job/1" })).toThrow();
+    expect(() =>
+      RescoreJobParamsSchema.parse({
+        jobId: CANONICAL_JOB_ID,
+        jobUrl: "https://example.test/job/1",
+      }),
+    ).toThrow();
   });
 
   it("parses and defaults bulk rescore request payloads", () => {
@@ -373,6 +387,13 @@ describe("preparation RPC contracts", () => {
       suppressExistingArtifacts: true,
       tailorModels: [],
     });
+    expect(RetailorJobParamsSchema.parse({ jobId: CANONICAL_JOB_ID })).toEqual({
+      tenantId: "local",
+      jobId: CANONICAL_JOB_ID,
+      dryRun: false,
+      suppressExistingArtifacts: true,
+      tailorModels: [],
+    });
   });
 
   it("parses and defaults tailor_job request payloads", () => {
@@ -401,6 +422,13 @@ describe("preparation RPC contracts", () => {
 
   it("rejects invalid retailor_job request payloads", () => {
     expect(() => RetailorJobParamsSchema.parse({})).toThrow();
+    expect(() => RetailorJobParamsSchema.parse({ jobId: "not-a-job-id" })).toThrow();
+    expect(() =>
+      RetailorJobParamsSchema.parse({
+        jobId: CANONICAL_JOB_ID,
+        jobUrl: "https://example.test/job/1",
+      }),
+    ).toThrow();
     expect(() =>
       RetailorJobParamsSchema.parse({
         jobUrl: "https://example.test/job/1",

--- a/apps/api/test/rpc-contracts.test.ts
+++ b/apps/api/test/rpc-contracts.test.ts
@@ -222,15 +222,10 @@ describe("preparation RPC contracts", () => {
 
   it("parses and defaults rescore_job request payloads", () => {
     const parsed = RescoreJobParamsSchema.parse({
-      jobUrl: "https://example.test/job/1",
+      jobId: CANONICAL_JOB_ID,
     });
 
     expect(parsed).toEqual({
-      tenantId: "local",
-      jobUrl: "https://example.test/job/1",
-      dryRun: false,
-    });
-    expect(RescoreJobParamsSchema.parse({ jobId: CANONICAL_JOB_ID })).toEqual({
       tenantId: "local",
       jobId: CANONICAL_JOB_ID,
       dryRun: false,
@@ -377,17 +372,10 @@ describe("preparation RPC contracts", () => {
 
   it("parses and defaults retailor_job request payloads", () => {
     const parsed = RetailorJobParamsSchema.parse({
-      jobUrl: "https://example.test/job/1",
+      jobId: CANONICAL_JOB_ID,
     });
 
     expect(parsed).toEqual({
-      tenantId: "local",
-      jobUrl: "https://example.test/job/1",
-      dryRun: false,
-      suppressExistingArtifacts: true,
-      tailorModels: [],
-    });
-    expect(RetailorJobParamsSchema.parse({ jobId: CANONICAL_JOB_ID })).toEqual({
       tenantId: "local",
       jobId: CANONICAL_JOB_ID,
       dryRun: false,
@@ -431,7 +419,7 @@ describe("preparation RPC contracts", () => {
     ).toThrow();
     expect(() =>
       RetailorJobParamsSchema.parse({
-        jobUrl: "https://example.test/job/1",
+        jobId: CANONICAL_JOB_ID,
         tailorJudgeMinScore: 1.1,
       }),
     ).toThrow();

--- a/apps/api/test/rpc-contracts.test.ts
+++ b/apps/api/test/rpc-contracts.test.ts
@@ -6,6 +6,9 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  AnalyzeJobParamsSchema,
+  AnalyzeJobResultSchema,
+  ApplyParamsSchema,
   CancelRunParamsSchema,
   CancelRunResultSchema,
   DEFAULT_PIPELINE_LLM_MODEL,
@@ -21,6 +24,7 @@ import {
   RetailorCurrentPolicyParamsSchema,
   RetailorJobParamsSchema,
   RpcMethods,
+  RunStageParamsSchema,
   SettingsUpdateRequestSchema,
   TailorJobParamsSchema,
 } from "../src/contracts.js";
@@ -220,6 +224,53 @@ describe("preparation RPC contracts", () => {
     expect(RpcMethods.GenerateInterviewPrep).toBe("generate_interview_prep");
   });
 
+  it("accepts global, single-job, and explicit bulk run-stage selectors by canonical ID", () => {
+    expect(RunStageParamsSchema.parse({ stage: "score" })).toMatchObject({
+      tenantId: "local",
+      stage: "score",
+    });
+    expect(
+      RunStageParamsSchema.parse({ stage: "score", jobId: CANONICAL_JOB_ID }),
+    ).toMatchObject({ jobId: CANONICAL_JOB_ID });
+    expect(
+      RunStageParamsSchema.parse({ stage: "score", jobIds: [CANONICAL_JOB_ID] }),
+    ).toMatchObject({ jobIds: [CANONICAL_JOB_ID] });
+  });
+
+  it("rejects URL-shaped or ambiguous run-stage selectors", () => {
+    expect(() =>
+      RunStageParamsSchema.parse({
+        stage: "score",
+        jobUrl: "https://example.test/job/1",
+      }),
+    ).toThrow();
+    expect(() =>
+      RunStageParamsSchema.parse({
+        stage: "score",
+        jobUrls: ["https://example.test/job/1"],
+      }),
+    ).toThrow();
+    expect(() =>
+      RunStageParamsSchema.parse({
+        stage: "score",
+        jobId: "https://example.test/job/1",
+      }),
+    ).toThrow();
+    expect(() =>
+      RunStageParamsSchema.parse({
+        stage: "score",
+        jobIds: ["https://example.test/job/1"],
+      }),
+    ).toThrow();
+    expect(() =>
+      RunStageParamsSchema.parse({
+        stage: "score",
+        jobId: CANONICAL_JOB_ID,
+        jobIds: [CANONICAL_JOB_ID],
+      }),
+    ).toThrow();
+  });
+
   it("parses and defaults rescore_job request payloads", () => {
     const parsed = RescoreJobParamsSchema.parse({
       jobId: CANONICAL_JOB_ID,
@@ -302,7 +353,7 @@ describe("preparation RPC contracts", () => {
 
   it("parses and rejects stored interview prep generation payloads", () => {
     const parsed = GenerateInterviewPrepParamsSchema.parse({
-      jobUrl: "https://example.test/job/interview",
+      jobId: CANONICAL_JOB_ID,
       expectedAppDir: "/tmp/jobctrl",
       expectedDbPath: "/tmp/jobctrl/jobctrl.db",
     });
@@ -311,11 +362,12 @@ describe("preparation RPC contracts", () => {
       tenantId: "local",
       expectedAppDir: "/tmp/jobctrl",
       expectedDbPath: "/tmp/jobctrl/jobctrl.db",
-      jobUrl: "https://example.test/job/interview",
+      jobId: CANONICAL_JOB_ID,
       llmModel: DEFAULT_PIPELINE_LLM_MODEL,
     });
     expect(() => GenerateInterviewPrepParamsSchema.parse({})).toThrow();
-    expect(() => GenerateInterviewPrepParamsSchema.parse({ jobUrl: "" })).toThrow();
+    expect(() => GenerateInterviewPrepParamsSchema.parse({ jobUrl: "https://example.test/job/interview" })).toThrow();
+    expect(() => GenerateInterviewPrepParamsSchema.parse({ jobId: "https://example.test/job/interview" })).toThrow();
   });
 
   it("parses the REST generate-interview-prep request body", () => {
@@ -356,7 +408,7 @@ describe("preparation RPC contracts", () => {
     expect(parsed).toEqual({
       tenantId: "local",
       limit: 100,
-      jobUrls: [],
+      jobIds: [],
       dryRun: false,
     });
   });
@@ -366,7 +418,7 @@ describe("preparation RPC contracts", () => {
       RescoreJobsNotOnCurrentScoringPolicyParamsSchema.parse({ limit: 0 }),
     ).toThrow();
     expect(() =>
-      RescoreJobsNotOnCurrentScoringPolicyParamsSchema.parse({ jobUrls: [""] }),
+      RescoreJobsNotOnCurrentScoringPolicyParamsSchema.parse({ jobIds: ["https://example.test/job/1"] }),
     ).toThrow();
   });
 
@@ -386,12 +438,12 @@ describe("preparation RPC contracts", () => {
 
   it("parses and defaults tailor_job request payloads", () => {
     const parsed = TailorJobParamsSchema.parse({
-      jobUrl: "https://example.test/job/1",
+      jobId: CANONICAL_JOB_ID,
     });
 
     expect(parsed).toEqual({
       tenantId: "local",
-      jobUrl: "https://example.test/job/1",
+      jobId: CANONICAL_JOB_ID,
       dryRun: false,
       allowLowFitOverride: true,
       tailorModels: [],
@@ -402,9 +454,12 @@ describe("preparation RPC contracts", () => {
     expect(() => TailorJobParamsSchema.parse({})).toThrow();
     expect(() =>
       TailorJobParamsSchema.parse({
-        jobUrl: "https://example.test/job/1",
+        jobId: CANONICAL_JOB_ID,
         tailorJudgeMinScore: 1.1,
       }),
+    ).toThrow();
+    expect(() =>
+      TailorJobParamsSchema.parse({ jobUrl: "https://example.test/job/1" }),
     ).toThrow();
   });
 
@@ -431,7 +486,7 @@ describe("preparation RPC contracts", () => {
     expect(parsed).toEqual({
       tenantId: "local",
       limit: 100,
-      jobUrls: [],
+      jobIds: [],
       dryRun: false,
       suppressExistingArtifacts: true,
       tailorModels: [],
@@ -442,8 +497,60 @@ describe("preparation RPC contracts", () => {
     expect(() => RetailorCurrentPolicyParamsSchema.parse({ limit: 0 })).toThrow();
     expect(() =>
       RetailorCurrentPolicyParamsSchema.parse({
+        jobIds: ["https://example.test/job/1"],
+      }),
+    ).toThrow();
+    expect(() =>
+      RetailorCurrentPolicyParamsSchema.parse({
         tailorModels: ["a", "b", "c", "d", "e", "f"],
       }),
+    ).toThrow();
+  });
+
+  it("parses canonical analyze params and results and rejects URL locators", () => {
+    expect(
+      AnalyzeJobParamsSchema.parse({ jobId: CANONICAL_JOB_ID }),
+    ).toEqual({ tenantId: "local", jobId: CANONICAL_JOB_ID, force: false });
+    expect(
+      AnalyzeJobResultSchema.parse({
+        jobId: CANONICAL_JOB_ID,
+        generation: 2,
+        cacheKey: "cache-key",
+        cached: false,
+        legsAttempted: 3,
+        legsSucceeded: 3,
+        degraded: false,
+      }),
+    ).toMatchObject({ jobId: CANONICAL_JOB_ID, generation: 2 });
+    expect(() =>
+      AnalyzeJobParamsSchema.parse({ jobUrl: "https://example.test/job/1" }),
+    ).toThrow();
+    expect(() =>
+      AnalyzeJobParamsSchema.parse({ jobId: "https://example.test/job/1" }),
+    ).toThrow();
+    expect(() =>
+      AnalyzeJobResultSchema.parse({
+        jobUrl: "https://example.test/job/1",
+        generation: 2,
+        cacheKey: "cache-key",
+        cached: false,
+        legsAttempted: 3,
+        legsSucceeded: 3,
+        degraded: false,
+      }),
+    ).toThrow();
+  });
+
+  it("keeps global apply while requiring canonical IDs for explicit targets", () => {
+    expect(ApplyParamsSchema.parse({})).toMatchObject({ tenantId: "local" });
+    expect(ApplyParamsSchema.parse({ jobId: CANONICAL_JOB_ID })).toMatchObject({
+      jobId: CANONICAL_JOB_ID,
+    });
+    expect(() =>
+      ApplyParamsSchema.parse({ jobUrl: "https://example.test/job/1" }),
+    ).toThrow();
+    expect(() =>
+      ApplyParamsSchema.parse({ jobId: "https://example.test/job/1" }),
     ).toThrow();
   });
 });

--- a/apps/web/src/demo/DemoScenarioEngine.test.ts
+++ b/apps/web/src/demo/DemoScenarioEngine.test.ts
@@ -84,29 +84,33 @@ describe("DemoScenarioEngine", () => {
 
   it("runs Discover as a successful deterministic Q/R/T workflow and updates the source projection", async () => {
     const fixture = await buildEngine();
-    await expect(
-      fixture.engine.execute("runPipelineStages", [{
-        stages: ["discover"],
-        limit: 25,
-        workers: 1,
-        minScore: 7,
-        validationMode: "normal",
-        dryRun: true,
-        rescore: false,
-        retailor: false,
-        headless: false,
-        model: "default",
-        llmModel: "simulated",
-        tailorModels: [],
-        continuous: false,
-      }]),
-    ).resolves.toMatchObject({
+    const response = await fixture.engine.execute("runPipelineStages", [{
+      stages: ["discover"],
+      limit: 25,
+      workers: 1,
+      minScore: 7,
+      validationMode: "normal",
+      dryRun: true,
+      rescore: false,
+      retailor: false,
+      headless: false,
+      model: "default",
+      llmModel: "simulated",
+      tailorModels: [],
+      continuous: false,
+    }]);
+    expect(response).toMatchObject({
       ok: true,
       action: "run_stage",
       status: "queued",
       jobKey: "pipeline",
+      command: {
+        stages: ["discover"],
+        jobIds: [],
+      },
       actions: [expect.objectContaining({ status: "queued" })],
     });
+    expect(response).not.toHaveProperty("command.jobKeys");
     await fixture.advance(150);
     await fixture.advance(650);
 

--- a/apps/web/src/demo/DemoScenarioEngine.ts
+++ b/apps/web/src/demo/DemoScenarioEngine.ts
@@ -1093,9 +1093,9 @@ function actionResponse(pending: DemoScenarioInvocation): ActionRunResponse {
     action: spec.action,
     jobKey,
     ...(pending.targetRefs.stage ? { stage: pending.targetRefs.stage } : {}),
-    stages: pending.safeCommand.stages,
+    stages: [...pending.safeCommand.stages],
     dryRun: pending.safeCommand.dryRun,
-    jobKeys: pending.targetRefs.jobKeys,
+    jobIds: [...pending.targetRefs.jobKeys],
     ...(pending.safeCommand.limit === null ? {} : { limit: pending.safeCommand.limit }),
     runId: pending.runId,
   } as ActionRunResponse["command"];

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -191,15 +191,11 @@ export const RescoreJobParamsSchema = z
     tenantId: TenantParam,
     expectedAppDir: z.string().trim().min(1).optional(),
     expectedDbPath: z.string().trim().min(1).optional(),
-    jobId: CanonicalJobIdParam.optional(),
-    jobUrl: z.string().min(1).optional(),
+    jobId: CanonicalJobIdParam,
     dryRun: z.boolean().default(false),
     reason: z.string().trim().max(400).optional(),
   })
-  .strict()
-  .refine((params) => (params.jobId !== undefined) !== (params.jobUrl !== undefined), {
-    message: "provide exactly one of jobId or jobUrl",
-  });
+  .strict();
 export type RescoreJobParams = z.infer<typeof RescoreJobParamsSchema>;
 
 export const RescoreJobsNotOnCurrentScoringPolicyParamsSchema = z
@@ -389,8 +385,7 @@ export const RetailorJobParamsSchema = z
     tenantId: TenantParam,
     expectedAppDir: z.string().trim().min(1).optional(),
     expectedDbPath: z.string().trim().min(1).optional(),
-    jobId: CanonicalJobIdParam.optional(),
-    jobUrl: z.string().min(1).optional(),
+    jobId: CanonicalJobIdParam,
     dryRun: z.boolean().default(false),
     suppressExistingArtifacts: z.boolean().default(true),
     reason: z.string().trim().max(400).optional(),
@@ -398,10 +393,7 @@ export const RetailorJobParamsSchema = z
     tailorJudgeModel: z.string().trim().min(1).max(120).optional(),
     tailorJudgeMinScore: z.number().min(0).max(1).optional(),
   })
-  .strict()
-  .refine((params) => (params.jobId !== undefined) !== (params.jobUrl !== undefined), {
-    message: "provide exactly one of jobId or jobUrl",
-  });
+  .strict();
 export type RetailorJobParams = z.infer<typeof RetailorJobParamsSchema>;
 
 export const RetailorCurrentPolicyParamsSchema = z

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -106,7 +106,8 @@ export const RunStageParamsSchema = z
     expectedDbPath: z.string().trim().min(1).optional(),
     stage: z.enum(STAGES),
     stages: z.array(z.enum(STAGES)).min(1).max(STAGES.length).optional(),
-    jobUrl: z.string().optional(),
+    jobId: CanonicalJobIdParam.optional(),
+    jobIds: z.array(CanonicalJobIdParam).max(5000).optional(),
     limit: z.number().int().min(0).default(0),
     workers: z.number().int().min(1).default(1),
     minScore: z.number().int().min(0).max(10).default(7),
@@ -122,7 +123,10 @@ export const RunStageParamsSchema = z
     tailorJudgeMinScore: z.number().min(0).max(1).optional(),
     continuous: z.boolean().default(false),
   })
-  .strict();
+  .strict()
+  .refine((params) => !("jobId" in params && "jobIds" in params), {
+    message: "provide jobId or jobIds, not both",
+  });
 export type RunStageParams = z.infer<typeof RunStageParamsSchema>;
 
 /**
@@ -204,7 +208,7 @@ export const RescoreJobsNotOnCurrentScoringPolicyParamsSchema = z
     expectedAppDir: z.string().trim().min(1).optional(),
     expectedDbPath: z.string().trim().min(1).optional(),
     limit: z.number().int().min(1).max(1000).default(100),
-    jobUrls: z.array(z.string().trim().min(1)).max(5000).default([]),
+    jobIds: z.array(CanonicalJobIdParam).max(5000).default([]),
     dryRun: z.boolean().default(false),
     reason: z.string().trim().max(400).optional(),
   })
@@ -218,7 +222,7 @@ export const TailorJobParamsSchema = z
     tenantId: TenantParam,
     expectedAppDir: z.string().trim().min(1).optional(),
     expectedDbPath: z.string().trim().min(1).optional(),
-    jobUrl: z.string().min(1),
+    jobId: CanonicalJobIdParam,
     dryRun: z.boolean().default(false),
     allowLowFitOverride: z.boolean().default(true),
     reason: z.string().trim().max(400).optional(),
@@ -241,7 +245,7 @@ export const AnalyzeJobParamsSchema = z
     tenantId: TenantParam,
     expectedAppDir: z.string().trim().min(1).optional(),
     expectedDbPath: z.string().trim().min(1).optional(),
-    jobUrl: z.string().min(1),
+    jobId: CanonicalJobIdParam,
     force: z.boolean().default(false),
   })
   .strict();
@@ -249,7 +253,7 @@ export type AnalyzeJobParams = z.infer<typeof AnalyzeJobParamsSchema>;
 
 export const AnalyzeJobResultSchema = z
   .object({
-    jobUrl: z.string(),
+    jobId: CanonicalJobIdParam,
     generation: z.number().int(),
     cacheKey: z.string(),
     cached: z.boolean(),
@@ -302,7 +306,7 @@ export const GenerateInterviewPrepParamsSchema = z
     tenantId: TenantParam,
     expectedAppDir: z.string().trim().min(1).optional(),
     expectedDbPath: z.string().trim().min(1).optional(),
-    jobUrl: z.string().min(1),
+    jobId: CanonicalJobIdParam,
     llmModel: z.string().trim().min(1).max(120).default(DEFAULT_PIPELINE_LLM_MODEL),
   })
   .strict();
@@ -402,7 +406,7 @@ export const RetailorCurrentPolicyParamsSchema = z
     expectedAppDir: z.string().trim().min(1).optional(),
     expectedDbPath: z.string().trim().min(1).optional(),
     limit: z.number().int().min(1).max(1000).default(100),
-    jobUrls: z.array(z.string().trim().min(1)).max(5000).default([]),
+    jobIds: z.array(CanonicalJobIdParam).max(5000).default([]),
     dryRun: z.boolean().default(false),
     suppressExistingArtifacts: z.boolean().default(true),
     reason: z.string().trim().max(400).optional(),
@@ -418,7 +422,7 @@ export const ApplyParamsSchema = z
     tenantId: TenantParam,
     expectedAppDir: z.string().trim().min(1).optional(),
     expectedDbPath: z.string().trim().min(1).optional(),
-    jobUrl: z.string().optional(),
+    jobId: CanonicalJobIdParam.optional(),
     limit: z.number().int().min(1).default(1),
     workers: z.number().int().min(1).default(1),
     minScore: z.number().int().min(0).max(10).default(7),

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -90,6 +90,12 @@ export const RpcMethods = {
 export type RpcMethod = (typeof RpcMethods)[keyof typeof RpcMethods];
 
 const TenantParam = z.string().trim().min(1).default("local");
+const CanonicalJobIdParam = z
+  .string()
+  .regex(
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+    "jobId must be a canonical lowercase UUID",
+  );
 
 /* --- complex commands (delegated to Python JSON-RPC / Temporal) ---------- */
 
@@ -185,11 +191,15 @@ export const RescoreJobParamsSchema = z
     tenantId: TenantParam,
     expectedAppDir: z.string().trim().min(1).optional(),
     expectedDbPath: z.string().trim().min(1).optional(),
-    jobUrl: z.string().min(1),
+    jobId: CanonicalJobIdParam.optional(),
+    jobUrl: z.string().min(1).optional(),
     dryRun: z.boolean().default(false),
     reason: z.string().trim().max(400).optional(),
   })
-  .strict();
+  .strict()
+  .refine((params) => (params.jobId !== undefined) !== (params.jobUrl !== undefined), {
+    message: "provide exactly one of jobId or jobUrl",
+  });
 export type RescoreJobParams = z.infer<typeof RescoreJobParamsSchema>;
 
 export const RescoreJobsNotOnCurrentScoringPolicyParamsSchema = z
@@ -379,7 +389,8 @@ export const RetailorJobParamsSchema = z
     tenantId: TenantParam,
     expectedAppDir: z.string().trim().min(1).optional(),
     expectedDbPath: z.string().trim().min(1).optional(),
-    jobUrl: z.string().min(1),
+    jobId: CanonicalJobIdParam.optional(),
+    jobUrl: z.string().min(1).optional(),
     dryRun: z.boolean().default(false),
     suppressExistingArtifacts: z.boolean().default(true),
     reason: z.string().trim().max(400).optional(),
@@ -387,7 +398,10 @@ export const RetailorJobParamsSchema = z
     tailorJudgeModel: z.string().trim().min(1).max(120).optional(),
     tailorJudgeMinScore: z.number().min(0).max(1).optional(),
   })
-  .strict();
+  .strict()
+  .refine((params) => (params.jobId !== undefined) !== (params.jobUrl !== undefined), {
+    message: "provide exactly one of jobId or jobUrl",
+  });
 export type RetailorJobParams = z.infer<typeof RetailorJobParamsSchema>;
 
 export const RetailorCurrentPolicyParamsSchema = z

--- a/packages/contracts/src/schemas.ts
+++ b/packages/contracts/src/schemas.ts
@@ -3957,6 +3957,7 @@ export interface ActionCommandPayload {
     | "mark_skipped"
     | "profile_import";
   jobKey: string;
+  jobId?: string;
   stage?: Stage;
   stages?: Stage[];
   resetAttempts?: boolean;

--- a/packages/contracts/src/schemas.ts
+++ b/packages/contracts/src/schemas.ts
@@ -3963,7 +3963,7 @@ export interface ActionCommandPayload {
   resetAttempts?: boolean;
   runAfter?: boolean;
   dryRun?: boolean;
-  jobKeys?: string[];
+  jobIds?: string[];
   limit?: number;
   workers?: number;
   minScore?: number;

--- a/workers/automation/src/jobctrl/infrastructure/discovery/sqlite_identity_resolver.py
+++ b/workers/automation/src/jobctrl/infrastructure/discovery/sqlite_identity_resolver.py
@@ -55,6 +55,32 @@ class SqliteJobIdentityResolver:
         tenant_id: TenantId,
         posting_url: PostingUrl,
     ) -> ResolvedJobIdentity | None:
+        return self._resolve_by_posting_url(
+            tenant_id,
+            posting_url,
+            require_current=False,
+        )
+
+    def resolve_current_by_posting_url(
+        self,
+        tenant_id: TenantId,
+        posting_url: PostingUrl,
+    ) -> ResolvedJobIdentity | None:
+        """Resolve only an active posting URL used at an RPC admission boundary."""
+        return self._resolve_by_posting_url(
+            tenant_id,
+            posting_url,
+            require_current=True,
+        )
+
+    def _resolve_by_posting_url(
+        self,
+        tenant_id: TenantId,
+        posting_url: PostingUrl,
+        *,
+        require_current: bool,
+    ) -> ResolvedJobIdentity | None:
+        current_filter = "AND a.is_current = 1 AND a.retired_at IS NULL" if require_current else ""
         row = self._conn.execute(
             f"""
             SELECT
@@ -68,6 +94,7 @@ class SqliteJobIdentityResolver:
             WHERE a.tenant_id = ?
               AND a.locator_kind = 'posting_url'
               AND a.locator_value = ?
+              {current_filter}
             LIMIT 1
             """,
             (str(tenant_id), posting_url.value),

--- a/workers/automation/src/jobctrl/infrastructure/rpc/handlers.py
+++ b/workers/automation/src/jobctrl/infrastructure/rpc/handlers.py
@@ -23,12 +23,10 @@ import logging
 from typing import Any
 
 from jobctrl.database import get_connection
-from jobctrl.domain.discovery.value_objects import PostingUrl
 from jobctrl.domain.identifiers import JobId, canonical_job_id
 from jobctrl.domain.rpc.messages import WorkflowStartSpec
 from jobctrl.domain.preparation import PreparationWorkItemKind
 from jobctrl.domain.tenant import LOCAL_TENANT, TenantId
-from jobctrl.infrastructure.discovery import SqliteJobIdentityResolver
 from jobctrl.infrastructure.preparation import SqlitePreparationTargetReader
 from jobctrl.infrastructure.rpc.server import JsonRpcServer, invalid_params
 from jobctrl.infrastructure.rpc.workflow_starter import WorkflowCanceler
@@ -80,13 +78,31 @@ def _bool_param(params: dict[str, Any], name: str, *, default: bool = False) -> 
     return bool(raw)
 
 
-def _job_urls(params: dict[str, Any]) -> tuple[str, ...]:
-    raw = params.get("jobUrls") or ()
+def _reject_job_url_params(params: dict[str, Any]) -> None:
+    if "jobUrl" in params:
+        raise invalid_params("jobUrl is not supported; use canonical jobId")
+    if "jobUrls" in params:
+        raise invalid_params("jobUrls is not supported; use canonical jobIds")
+
+
+def _job_ids(params: dict[str, Any]) -> tuple[JobId, ...]:
+    _reject_job_url_params(params)
+    if "jobId" in params:
+        raise invalid_params("jobId is not supported on a bulk selector; use jobIds")
+    raw = params.get("jobIds", ())
+    if not isinstance(raw, list):
+        raise invalid_params("jobIds must be an array")
     if not raw:
         return ()
-    if not isinstance(raw, list):
-        raise invalid_params("jobUrls must be an array")
-    return tuple(str(item).strip() for item in raw if str(item).strip())
+    try:
+        return tuple(
+            dict.fromkeys(
+                canonical_job_id(str(item))
+                for item in raw
+            )
+        )
+    except ValueError as exc:
+        raise invalid_params(str(exc)) from exc
 
 
 def _source_ids(params: dict[str, Any]) -> tuple[str, ...]:
@@ -96,30 +112,6 @@ def _source_ids(params: dict[str, Any]) -> tuple[str, ...]:
     if not isinstance(raw, list):
         raise invalid_params("sourceIds must be an array")
     return tuple(dict.fromkeys(str(item).strip() for item in raw if str(item).strip()))
-
-
-def _load_current_job(
-    conn: Any,
-    *,
-    tenant_id: TenantId,
-    job_url: str,
-) -> dict[str, Any]:
-    """Resolve an active URL locator and load its non-deleted canonical target."""
-
-    try:
-        posting_url = PostingUrl(value=job_url)
-    except ValueError as exc:
-        raise invalid_params(f"invalid jobUrl: {job_url}") from exc
-    identity = SqliteJobIdentityResolver(conn).resolve_current_by_posting_url(
-        tenant_id,
-        posting_url,
-    )
-    if identity is None:
-        raise invalid_params(f"unknown or inactive jobUrl: {job_url}")
-    job = SqlitePreparationTargetReader(conn).load(tenant_id, identity.job_id)
-    if job is None:
-        raise invalid_params(f"unknown or inactive jobUrl: {job_url}")
-    return job
 
 
 def _load_current_job_by_id(
@@ -136,8 +128,9 @@ def _load_current_job_by_id(
 
 
 def _required_job_id(params: dict[str, Any]) -> JobId:
-    if "jobUrl" in params:
-        raise invalid_params("jobUrl is not supported; use canonical jobId")
+    _reject_job_url_params(params)
+    if "jobIds" in params:
+        raise invalid_params("jobIds is not supported on a single-job command; use jobId")
     try:
         return canonical_job_id(str(_require(params, "jobId")))
     except ValueError as exc:
@@ -146,6 +139,85 @@ def _required_job_id(params: dict[str, Any]) -> JobId:
 
 def _job_id(job: dict[str, Any]) -> JobId:
     return canonical_job_id(str(job["job_id"]))
+
+
+def _current_job_url(job: dict[str, Any]) -> str:
+    job_url = str(job.get("url") or "").strip()
+    if not job_url:
+        raise invalid_params(f"jobId {job.get('job_id')} has no current posting URL")
+    return job_url
+
+
+def _selected_job_ids(params: dict[str, Any]) -> tuple[JobId | None, tuple[JobId, ...]]:
+    _reject_job_url_params(params)
+    if "jobId" in params and "jobIds" in params:
+        raise invalid_params("provide jobId or jobIds, not both")
+    if "jobId" in params:
+        try:
+            return canonical_job_id(str(_require(params, "jobId"))), ()
+        except ValueError as exc:
+            raise invalid_params(str(exc)) from exc
+    if "jobIds" not in params:
+        return None, ()
+    raw_many = params["jobIds"]
+    if not isinstance(raw_many, list):
+        raise invalid_params("jobIds must be an array")
+    if not raw_many:
+        return None, ()
+    try:
+        return None, tuple(
+            dict.fromkeys(
+                canonical_job_id(str(item))
+                for item in raw_many
+            )
+        )
+    except ValueError as exc:
+        raise invalid_params(str(exc)) from exc
+
+
+def _load_current_job_urls_by_id(
+    conn: Any,
+    *,
+    tenant_id: TenantId,
+    job_ids: tuple[JobId, ...],
+) -> tuple[str, ...]:
+    return tuple(
+        _current_job_url(
+            _load_current_job_by_id(conn, tenant_id=tenant_id, job_id=job_id)
+        )
+        for job_id in job_ids
+    )
+
+
+def _legacy_workflow_locator_params(params: dict[str, Any]) -> dict[str, Any]:
+    """Adapt canonical RPC IDs to the pre-#623/#628 workflow input contract.
+
+    The current URL is loaded by tenant-scoped ``JobId`` here; no caller URL
+    crosses JSON-RPC. The mapped runtime PRs remove this adapter after rebase.
+    """
+
+    tenant_id = TenantId(_tenant_id(params))
+    job_id, job_ids = _selected_job_ids(params)
+    adapted = {
+        key: value
+        for key, value in params.items()
+        if key not in {"jobId", "jobIds"}
+    }
+    if job_id is None and not job_ids:
+        return adapted
+    conn = get_connection()
+    if job_id is not None:
+        job = _load_current_job_by_id(conn, tenant_id=tenant_id, job_id=job_id)
+        adapted["jobUrl"] = _current_job_url(job)
+    else:
+        adapted["jobUrls"] = list(
+            _load_current_job_urls_by_id(
+                conn,
+                tenant_id=tenant_id,
+                job_ids=job_ids,
+            )
+        )
+    return adapted
 
 
 # ---------------------------------------------------------------------------
@@ -167,7 +239,7 @@ def _stage_list(params: dict[str, Any]) -> list[str]:
 
 def run_stage(params: dict[str, Any]) -> WorkflowStartSpec:
     try:
-        return build_run_stage_workflow_spec(params)
+        return build_run_stage_workflow_spec(_legacy_workflow_locator_params(params))
     except ValueError as exc:
         raise invalid_params(str(exc)) from exc
 
@@ -207,7 +279,7 @@ def rescore_jobs_not_on_current_scoring_policy(params: dict[str, Any]) -> Workfl
         stages=["score"],
         limit=int(params.get("limit", 100)),
         rescore=True,
-        job_urls=_job_urls(params),
+        job_ids=_job_ids(params),
         score_current_policy_only=True,
     )
 
@@ -259,9 +331,15 @@ def retailor_job(params: dict[str, Any]) -> WorkflowStartSpec:
 
 def tailor_job(params: dict[str, Any]) -> WorkflowStartSpec:
     tenant_id = TenantId(_tenant_id(params))
-    job_url = str(_require(params, "jobUrl"))
+    requested_job_id = _required_job_id(params)
     conn = get_connection()
-    job_id = _job_id(_load_current_job(conn, tenant_id=tenant_id, job_url=job_url))
+    job_id = _job_id(
+        _load_current_job_by_id(
+            conn,
+            tenant_id=tenant_id,
+            job_id=requested_job_id,
+        )
+    )
     raw_judge_min_score = params.get("tailorJudgeMinScore")
     return build_preparation_workflow_spec(
         tenant_id=tenant_id,
@@ -306,23 +384,23 @@ def analyze_job(params: dict[str, Any]) -> dict[str, Any]:
     can see a degraded run immediately (D-08).
     """
     tenant_id = TenantId(_tenant_id(params))
-    job_url = str(_require(params, "jobUrl"))
+    job_id = _required_job_id(params)
     force = _bool_param(params, "force", default=False)
 
     from jobctrl.scoring.tailor import _build_analyze_use_case
 
     conn = get_connection()
-    job = _load_current_job(conn, tenant_id=tenant_id, job_url=job_url)
+    job = _load_current_job_by_id(conn, tenant_id=tenant_id, job_id=job_id)
     if not (job.get("full_description") or job.get("description")):
         raise invalid_params(
-            f"job {job_url} has no description to analyze; enrich it first"
+            f"jobId {job_id} has no description to analyze; enrich it first"
         )
 
     use_case = _build_analyze_use_case(conn=conn)
     outcome = use_case.execute(job=job, tenant_id=tenant_id, force=force)
     record = outcome.analysis
     return {
-        "jobUrl": job_url,
+        "jobId": str(job_id),
         "generation": record.generation,
         "cacheKey": record.cache_key,
         "cached": outcome.cached,
@@ -487,7 +565,7 @@ def retailor_current_policy(params: dict[str, Any]) -> WorkflowStartSpec:
         stages=["tailor", "cover"],
         limit=int(params.get("limit", 100)),
         retailor=True,
-        job_urls=_job_urls(params),
+        job_ids=_job_ids(params),
         tailor_current_policy_only=True,
         suppress_existing_artifacts=_bool_param(
             params, "suppressExistingArtifacts", default=False
@@ -502,21 +580,29 @@ def _pipeline_workflow_spec(
     limit: int,
     rescore: bool = False,
     retailor: bool = False,
-    job_url: str | None = None,
-    job_urls: tuple[str, ...] = (),
+    job_id: JobId | None = None,
+    job_ids: tuple[JobId, ...] = (),
     score_current_policy_only: bool = False,
     tailor_current_policy_only: bool = False,
     suppress_existing_artifacts: bool = False,
     allow_low_fit_override: bool = False,
 ) -> WorkflowStartSpec:
+    tenant_id = TenantId(_tenant_id(params))
+    conn = get_connection()
+    selected_job_ids = (job_id,) if job_id is not None else job_ids
+    job_urls = _load_current_job_urls_by_id(
+        conn,
+        tenant_id=tenant_id,
+        job_ids=selected_job_ids,
+    )
     return build_pipeline_workflow_spec(
         params,
         stages=stages,
         limit=limit,
         rescore=rescore,
         retailor=retailor,
-        job_url=job_url,
-        job_urls=job_urls,
+        job_url=job_urls[0] if job_id is not None else None,
+        job_urls=job_urls if job_id is None else (),
         score_current_policy_only=score_current_policy_only,
         tailor_current_policy_only=tailor_current_policy_only,
         suppress_existing_artifacts=suppress_existing_artifacts,
@@ -552,13 +638,21 @@ def _apply_workflow_id(tenant_id: str, job_key: str) -> str:
 
 def apply_action(params: dict[str, Any]) -> WorkflowStartSpec:
     """Build a :class:`WorkflowStartSpec` for :class:`ApplyWorkflow`."""
-    return build_apply_workflow_spec(params)
+    try:
+        if "jobIds" in params:
+            raise invalid_params("jobIds is not supported by apply; use jobId")
+        return build_apply_workflow_spec(_legacy_workflow_locator_params(params))
+    except ValueError as exc:
+        raise invalid_params(str(exc)) from exc
 
 
 def generate_interview_prep(params: dict[str, Any]) -> WorkflowStartSpec:
     """Build a workflow spec for user-triggered stored interview prep."""
     try:
-        return build_interview_prep_workflow_spec(params)
+        _required_job_id(params)
+        return build_interview_prep_workflow_spec(
+            _legacy_workflow_locator_params(params)
+        )
     except ValueError as exc:
         raise invalid_params(str(exc)) from exc
 

--- a/workers/automation/src/jobctrl/infrastructure/rpc/handlers.py
+++ b/workers/automation/src/jobctrl/infrastructure/rpc/handlers.py
@@ -23,9 +23,13 @@ import logging
 from typing import Any
 
 from jobctrl.database import get_connection
+from jobctrl.domain.discovery.value_objects import PostingUrl
+from jobctrl.domain.identifiers import JobId, canonical_job_id
 from jobctrl.domain.rpc.messages import WorkflowStartSpec
 from jobctrl.domain.preparation import PreparationWorkItemKind
 from jobctrl.domain.tenant import LOCAL_TENANT, TenantId
+from jobctrl.infrastructure.discovery import SqliteJobIdentityResolver
+from jobctrl.infrastructure.preparation import SqlitePreparationTargetReader
 from jobctrl.infrastructure.rpc.server import JsonRpcServer, invalid_params
 from jobctrl.infrastructure.rpc.workflow_starter import WorkflowCanceler
 from jobctrl.model_defaults import DEFAULT_PIPELINE_LLM_MODEL_SPEC
@@ -94,6 +98,34 @@ def _source_ids(params: dict[str, Any]) -> tuple[str, ...]:
     return tuple(dict.fromkeys(str(item).strip() for item in raw if str(item).strip()))
 
 
+def _load_current_job(
+    conn: Any,
+    *,
+    tenant_id: TenantId,
+    job_url: str,
+) -> dict[str, Any]:
+    """Resolve an active URL locator and load its non-deleted canonical target."""
+
+    try:
+        posting_url = PostingUrl(value=job_url)
+    except ValueError as exc:
+        raise invalid_params(f"invalid jobUrl: {job_url}") from exc
+    identity = SqliteJobIdentityResolver(conn).resolve_current_by_posting_url(
+        tenant_id,
+        posting_url,
+    )
+    if identity is None:
+        raise invalid_params(f"unknown or inactive jobUrl: {job_url}")
+    job = SqlitePreparationTargetReader(conn).load(tenant_id, identity.job_id)
+    if job is None:
+        raise invalid_params(f"unknown or inactive jobUrl: {job_url}")
+    return job
+
+
+def _job_id(job: dict[str, Any]) -> JobId:
+    return canonical_job_id(str(job["job_id"]))
+
+
 # ---------------------------------------------------------------------------
 # Local-action wrappers (sync — return LocalActionResult dict)
 # ---------------------------------------------------------------------------
@@ -122,13 +154,18 @@ def rescore_job(params: dict[str, Any]) -> WorkflowStartSpec:
     tenant_id = TenantId(_tenant_id(params))
     job_url = str(_require(params, "jobUrl"))
     conn = get_connection()
+    job_id = _job_id(_load_current_job(conn, tenant_id=tenant_id, job_url=job_url))
     return build_preparation_workflow_spec(
         tenant_id=tenant_id,
-        job_url=job_url,
+        job_id=job_id,
         steps=["score"],
         kind=PreparationWorkItemKind.SCORE_JOB,
         target_version=current_scoring_policy_version(conn, tenant_id),
-        source_event_id=latest_source_event_id(conn, job_url),
+        source_event_id=latest_source_event_id(
+            conn,
+            tenant_id=tenant_id,
+            job_id=job_id,
+        ),
         rescore=True,
         llm_model=str(params.get("llmModel") or DEFAULT_PIPELINE_LLM_MODEL_SPEC),
         expected_app_dir=params.get("expectedAppDir"),
@@ -151,14 +188,19 @@ def retailor_job(params: dict[str, Any]) -> WorkflowStartSpec:
     tenant_id = TenantId(_tenant_id(params))
     job_url = str(_require(params, "jobUrl"))
     conn = get_connection()
+    job_id = _job_id(_load_current_job(conn, tenant_id=tenant_id, job_url=job_url))
     raw_judge_min_score = params.get("tailorJudgeMinScore")
     return build_preparation_workflow_spec(
         tenant_id=tenant_id,
-        job_url=job_url,
+        job_id=job_id,
         steps=["tailor", "cover", "pdf"],
         kind=PreparationWorkItemKind.TAILOR_RESUME,
         target_version=current_tailoring_policy_version(conn, tenant_id),
-        source_event_id=latest_source_event_id(conn, job_url),
+        source_event_id=latest_source_event_id(
+            conn,
+            tenant_id=tenant_id,
+            job_id=job_id,
+        ),
         min_score=int(params.get("minScore", 7)),
         workers=int(params.get("workers", 1)),
         validation_mode=str(params.get("validationMode", "normal")),
@@ -185,14 +227,19 @@ def tailor_job(params: dict[str, Any]) -> WorkflowStartSpec:
     tenant_id = TenantId(_tenant_id(params))
     job_url = str(_require(params, "jobUrl"))
     conn = get_connection()
+    job_id = _job_id(_load_current_job(conn, tenant_id=tenant_id, job_url=job_url))
     raw_judge_min_score = params.get("tailorJudgeMinScore")
     return build_preparation_workflow_spec(
         tenant_id=tenant_id,
-        job_url=job_url,
+        job_id=job_id,
         steps=["tailor", "cover", "pdf"],
         kind=PreparationWorkItemKind.TAILOR_RESUME,
         target_version=current_tailoring_policy_version(conn, tenant_id),
-        source_event_id=latest_source_event_id(conn, job_url),
+        source_event_id=latest_source_event_id(
+            conn,
+            tenant_id=tenant_id,
+            job_id=job_id,
+        ),
         min_score=int(params.get("minScore", 7)),
         workers=int(params.get("workers", 1)),
         validation_mode=str(params.get("validationMode", "normal")),
@@ -224,25 +271,21 @@ def analyze_job(params: dict[str, Any]) -> dict[str, Any]:
     the persisted record's identity + the degraded-ensemble signal so a caller
     can see a degraded run immediately (D-08).
     """
-    tenant_id = _tenant_id(params)
+    tenant_id = TenantId(_tenant_id(params))
     job_url = str(_require(params, "jobUrl"))
     force = _bool_param(params, "force", default=False)
 
-    from jobctrl.database import get_connection, load_job_with_enrichment
-    from jobctrl.domain.tenant import TenantId
     from jobctrl.scoring.tailor import _build_analyze_use_case
 
     conn = get_connection()
-    job = load_job_with_enrichment(conn, job_url)
-    if job is None:
-        raise invalid_params(f"unknown jobUrl: {job_url}")
+    job = _load_current_job(conn, tenant_id=tenant_id, job_url=job_url)
     if not (job.get("full_description") or job.get("description")):
         raise invalid_params(
             f"job {job_url} has no description to analyze; enrich it first"
         )
 
     use_case = _build_analyze_use_case(conn=conn)
-    outcome = use_case.execute(job=job, tenant_id=TenantId(tenant_id), force=force)
+    outcome = use_case.execute(job=job, tenant_id=tenant_id, force=force)
     record = outcome.analysis
     return {
         "jobUrl": job_url,

--- a/workers/automation/src/jobctrl/infrastructure/rpc/handlers.py
+++ b/workers/automation/src/jobctrl/infrastructure/rpc/handlers.py
@@ -122,6 +122,38 @@ def _load_current_job(
     return job
 
 
+def _load_preparation_target(
+    conn: Any,
+    *,
+    tenant_id: TenantId,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """Load one target from exactly one canonical ID or external URL locator."""
+
+    raw_job_id = params.get("jobId")
+    raw_job_url = params.get("jobUrl")
+    has_job_id = raw_job_id not in (None, "")
+    has_job_url = raw_job_url not in (None, "")
+    if has_job_id == has_job_url:
+        raise invalid_params("provide exactly one of jobId or jobUrl")
+
+    if has_job_id:
+        try:
+            stable_job_id = canonical_job_id(str(raw_job_id))
+        except ValueError as exc:
+            raise invalid_params(f"invalid jobId: {raw_job_id}") from exc
+        job = SqlitePreparationTargetReader(conn).load(tenant_id, stable_job_id)
+        if job is None:
+            raise invalid_params(f"unknown or inactive jobId: {raw_job_id}")
+        return job
+
+    return _load_current_job(
+        conn,
+        tenant_id=tenant_id,
+        job_url=str(raw_job_url),
+    )
+
+
 def _job_id(job: dict[str, Any]) -> JobId:
     return canonical_job_id(str(job["job_id"]))
 
@@ -152,9 +184,8 @@ def run_stage(params: dict[str, Any]) -> WorkflowStartSpec:
 
 def rescore_job(params: dict[str, Any]) -> WorkflowStartSpec:
     tenant_id = TenantId(_tenant_id(params))
-    job_url = str(_require(params, "jobUrl"))
     conn = get_connection()
-    job_id = _job_id(_load_current_job(conn, tenant_id=tenant_id, job_url=job_url))
+    job_id = _job_id(_load_preparation_target(conn, tenant_id=tenant_id, params=params))
     return build_preparation_workflow_spec(
         tenant_id=tenant_id,
         job_id=job_id,
@@ -186,9 +217,8 @@ def rescore_jobs_not_on_current_scoring_policy(params: dict[str, Any]) -> Workfl
 
 def retailor_job(params: dict[str, Any]) -> WorkflowStartSpec:
     tenant_id = TenantId(_tenant_id(params))
-    job_url = str(_require(params, "jobUrl"))
     conn = get_connection()
-    job_id = _job_id(_load_current_job(conn, tenant_id=tenant_id, job_url=job_url))
+    job_id = _job_id(_load_preparation_target(conn, tenant_id=tenant_id, params=params))
     raw_judge_min_score = params.get("tailorJudgeMinScore")
     return build_preparation_workflow_spec(
         tenant_id=tenant_id,

--- a/workers/automation/src/jobctrl/infrastructure/rpc/handlers.py
+++ b/workers/automation/src/jobctrl/infrastructure/rpc/handlers.py
@@ -122,36 +122,26 @@ def _load_current_job(
     return job
 
 
-def _load_preparation_target(
+def _load_current_job_by_id(
     conn: Any,
     *,
     tenant_id: TenantId,
-    params: dict[str, Any],
+    job_id: JobId,
 ) -> dict[str, Any]:
-    """Load one target from exactly one canonical ID or external URL locator."""
+    """Load a non-deleted canonical target without accepting a URL locator."""
+    job = SqlitePreparationTargetReader(conn).load(tenant_id, job_id)
+    if job is None:
+        raise invalid_params(f"unknown or inactive jobId: {job_id}")
+    return job
 
-    raw_job_id = params.get("jobId")
-    raw_job_url = params.get("jobUrl")
-    has_job_id = raw_job_id not in (None, "")
-    has_job_url = raw_job_url not in (None, "")
-    if has_job_id == has_job_url:
-        raise invalid_params("provide exactly one of jobId or jobUrl")
 
-    if has_job_id:
-        try:
-            stable_job_id = canonical_job_id(str(raw_job_id))
-        except ValueError as exc:
-            raise invalid_params(f"invalid jobId: {raw_job_id}") from exc
-        job = SqlitePreparationTargetReader(conn).load(tenant_id, stable_job_id)
-        if job is None:
-            raise invalid_params(f"unknown or inactive jobId: {raw_job_id}")
-        return job
-
-    return _load_current_job(
-        conn,
-        tenant_id=tenant_id,
-        job_url=str(raw_job_url),
-    )
+def _required_job_id(params: dict[str, Any]) -> JobId:
+    if "jobUrl" in params:
+        raise invalid_params("jobUrl is not supported; use canonical jobId")
+    try:
+        return canonical_job_id(str(_require(params, "jobId")))
+    except ValueError as exc:
+        raise invalid_params(str(exc)) from exc
 
 
 def _job_id(job: dict[str, Any]) -> JobId:
@@ -184,8 +174,15 @@ def run_stage(params: dict[str, Any]) -> WorkflowStartSpec:
 
 def rescore_job(params: dict[str, Any]) -> WorkflowStartSpec:
     tenant_id = TenantId(_tenant_id(params))
+    requested_job_id = _required_job_id(params)
     conn = get_connection()
-    job_id = _job_id(_load_preparation_target(conn, tenant_id=tenant_id, params=params))
+    job_id = _job_id(
+        _load_current_job_by_id(
+            conn,
+            tenant_id=tenant_id,
+            job_id=requested_job_id,
+        )
+    )
     return build_preparation_workflow_spec(
         tenant_id=tenant_id,
         job_id=job_id,
@@ -217,8 +214,15 @@ def rescore_jobs_not_on_current_scoring_policy(params: dict[str, Any]) -> Workfl
 
 def retailor_job(params: dict[str, Any]) -> WorkflowStartSpec:
     tenant_id = TenantId(_tenant_id(params))
+    requested_job_id = _required_job_id(params)
     conn = get_connection()
-    job_id = _job_id(_load_preparation_target(conn, tenant_id=tenant_id, params=params))
+    job_id = _job_id(
+        _load_current_job_by_id(
+            conn,
+            tenant_id=tenant_id,
+            job_id=requested_job_id,
+        )
+    )
     raw_judge_min_score = params.get("tailorJudgeMinScore")
     return build_preparation_workflow_spec(
         tenant_id=tenant_id,

--- a/workers/automation/tests/test_jsonrpc_handlers.py
+++ b/workers/automation/tests/test_jsonrpc_handlers.py
@@ -12,6 +12,7 @@ from unittest.mock import Mock
 import pytest
 from temporalio.common import WorkflowIDConflictPolicy
 
+from jobctrl.apply.workflow import ApplyWorkflow, ApplyWorkflowInput
 from jobctrl.database import close_connection, get_connection, init_db
 from jobctrl.discovery.workflow import DiscoverWorkflow, DiscoverWorkflowInput
 from jobctrl.domain.compensation import ReportedCompensationObservation
@@ -87,9 +88,13 @@ def _server() -> JsonRpcServer:
 
 def _seed_job(db_path: Path, url: str = "https://example.com/job/1") -> None:
     conn = get_connection(db_path)
+    job_id = uuid.uuid5(uuid.NAMESPACE_URL, f"local:{url}")
     conn.execute(
-        "INSERT INTO jobs (url, title, discovered_at) VALUES (?, ?, datetime('now'))",
-        (url, "Test job"),
+        """
+        INSERT INTO jobs (tenant_id, job_id, url, title, discovered_at)
+        VALUES ('local', ?, ?, ?, datetime('now'))
+        """,
+        (str(job_id), url, "Test job"),
     )
     conn.commit()
 
@@ -228,8 +233,15 @@ def test_provider_models_dispatches_sanitized_catalog(monkeypatch) -> None:
     verify_auth.assert_not_called()
 
 
-def test_generate_interview_prep_starts_user_triggered_workflow() -> None:
+def test_generate_interview_prep_starts_user_triggered_workflow(tmp_db: Path) -> None:
     seen: list[WorkflowStartSpec] = []
+    job_url = "https://example.com/job/interview"
+    job_id = _seed_v7_current_locator(
+        get_connection(tmp_db),
+        tenant_id=TenantId("local"),
+        job_url=job_url,
+        job_id=JobId("10000000-0000-4000-8000-000000000001"),
+    )
 
     async def starter(spec: WorkflowStartSpec) -> _StubHandle:
         seen.append(spec)
@@ -245,7 +257,7 @@ def test_generate_interview_prep_starts_user_triggered_workflow() -> None:
                 "tenantId": "local",
                 "expectedAppDir": "/tmp/jobctrl",
                 "expectedDbPath": "/tmp/jobctrl/jobctrl.db",
-                "jobUrl": "https://example.com/job/interview",
+                "jobId": str(job_id),
                 "llmModel": "gpt-test",
             },
             id=1,
@@ -260,13 +272,13 @@ def test_generate_interview_prep_starts_user_triggered_workflow() -> None:
     }
     assert len(seen) == 1
     assert seen[0].workflow is InterviewPrepWorkflow
-    assert seen[0].workflow_id == "interview-prep-local-https://example.com/job/interview"
+    assert seen[0].workflow_id == f"interview-prep-local-{job_url}"
     (payload,) = seen[0].args
     assert payload == InterviewPrepWorkflowInput(
         tenant_id="local",
         expected_app_dir="/tmp/jobctrl",
         expected_db_path="/tmp/jobctrl/jobctrl.db",
-        job_url="https://example.com/job/interview",
+        job_url=job_url,
         llm_model="gpt-test",
     )
 
@@ -318,10 +330,12 @@ def test_refresh_compensation_ignores_company_metric_money(tmp_db: Path) -> None
     conn.execute(
         """
         INSERT INTO jobs (
-            url, title, site, location, salary, description, full_description, discovered_at
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            tenant_id, job_id, url, title, site, location, salary, description,
+            full_description, discovered_at
+        ) VALUES ('local', ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """,
         (
+            str(uuid.uuid5(uuid.NAMESPACE_URL, f"local:{selected_url}")),
             selected_url,
             "Senior Platform Engineer",
             "Moniepoint",
@@ -366,10 +380,12 @@ def test_refresh_compensation_does_not_match_ote_inside_words(tmp_db: Path) -> N
     conn.execute(
         """
         INSERT INTO jobs (
-            url, title, site, location, salary, description, full_description, discovered_at
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            tenant_id, job_id, url, title, site, location, salary, description,
+            full_description, discovered_at
+        ) VALUES ('local', ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """,
         (
+            str(uuid.uuid5(uuid.NAMESPACE_URL, f"local:{selected_url}")),
             selected_url,
             "Senior Platform Engineer",
             "Acme",
@@ -464,10 +480,12 @@ def test_refresh_compensation_core_updates_one_job(tmp_db: Path, tmp_path: Path)
     conn.execute(
         """
         INSERT INTO jobs (
-            url, title, site, location, salary, description, full_description, discovered_at
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            tenant_id, job_id, url, title, site, location, salary, description,
+            full_description, discovered_at
+        ) VALUES ('local', ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """,
         (
+            str(uuid.uuid5(uuid.NAMESPACE_URL, f"local:{selected_url}")),
             selected_url,
             "Senior Platform Engineer",
             "Acme AI",
@@ -479,8 +497,14 @@ def test_refresh_compensation_core_updates_one_job(tmp_db: Path, tmp_path: Path)
         ),
     )
     conn.execute(
-        "INSERT INTO jobs (url, title, site, location, salary, description, discovered_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        """
+        INSERT INTO jobs (
+            tenant_id, job_id, url, title, site, location, salary, description,
+            discovered_at
+        ) VALUES ('local', ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
         (
+            str(uuid.uuid5(uuid.NAMESPACE_URL, f"local:{other_url}")),
             other_url,
             "Staff Platform Engineer",
             "Acme AI",
@@ -563,10 +587,12 @@ def test_refresh_compensation_core_updates_all_jobs(tmp_db: Path, tmp_path: Path
     conn.execute(
         """
         INSERT INTO jobs (
-            url, title, site, location, salary, description, full_description, discovered_at
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            tenant_id, job_id, url, title, site, location, salary, description,
+            full_description, discovered_at
+        ) VALUES ('local', ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """,
         (
+            str(uuid.uuid5(uuid.NAMESPACE_URL, f"local:{first_url}")),
             first_url,
             "Senior Platform Engineer",
             "Acme AI",
@@ -578,8 +604,14 @@ def test_refresh_compensation_core_updates_all_jobs(tmp_db: Path, tmp_path: Path
         ),
     )
     conn.execute(
-        "INSERT INTO jobs (url, title, site, location, salary, description, discovered_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        """
+        INSERT INTO jobs (
+            tenant_id, job_id, url, title, site, location, salary, description,
+            discovered_at
+        ) VALUES ('local', ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
         (
+            str(uuid.uuid5(uuid.NAMESPACE_URL, f"local:{second_url}")),
             second_url,
             "Staff Platform Engineer",
             "Acme AI",
@@ -625,10 +657,13 @@ def test_refresh_compensation_without_observations_uses_euro_top_tech_and_update
     job_url = "https://example.com/jobs/staff-engineer"
     conn.execute(
         """
-        INSERT INTO jobs (url, title, site, location, salary, description, discovered_at)
-        VALUES (?, ?, ?, ?, ?, ?, ?)
+        INSERT INTO jobs (
+            tenant_id, job_id, url, title, site, location, salary, description,
+            discovered_at
+        ) VALUES ('local', ?, ?, ?, ?, ?, ?, ?, ?)
         """,
         (
+            str(uuid.uuid5(uuid.NAMESPACE_URL, f"local:{job_url}")),
             job_url,
             "Staff Software Engineer",
             "Acme AI",
@@ -693,10 +728,13 @@ def test_refresh_compensation_loads_all_configured_sources_by_default(
     job_url = "https://example.com/jobs/platform"
     conn.execute(
         """
-        INSERT INTO jobs (url, title, site, location, salary, description, discovered_at)
-        VALUES (?, ?, ?, ?, ?, ?, ?)
+        INSERT INTO jobs (
+            tenant_id, job_id, url, title, site, location, salary, description,
+            discovered_at
+        ) VALUES ('local', ?, ?, ?, ?, ?, ?, ?, ?)
         """,
         (
+            str(uuid.uuid5(uuid.NAMESPACE_URL, f"local:{job_url}")),
             job_url,
             "Senior Platform Engineer",
             "Acme AI",
@@ -846,6 +884,23 @@ def test_missing_tenant_id_falls_back_to_local(tmp_db: Path, caplog) -> None:
 
 def test_run_stage_starts_job_pipeline_workflow(tmp_db: Path) -> None:
     seen: list[WorkflowStartSpec] = []
+    selected_jobs = (
+        (
+            JobId("20000000-0000-4000-8000-000000000021"),
+            "https://example.com/job/score-a",
+        ),
+        (
+            JobId("20000000-0000-4000-8000-000000000022"),
+            "https://example.com/job/score-b",
+        ),
+    )
+    for job_id, job_url in selected_jobs:
+        _seed_v7_current_locator(
+            get_connection(tmp_db),
+            tenant_id=TenantId("local"),
+            job_url=job_url,
+            job_id=job_id,
+        )
 
     async def starter(spec: WorkflowStartSpec) -> _StubHandle:
         seen.append(spec)
@@ -863,10 +918,7 @@ def test_run_stage_starts_job_pipeline_workflow(tmp_db: Path) -> None:
                 "expectedDbPath": "/tmp/jobctrl/jobctrl.db",
                 "stage": "score",
                 "stages": ["score", "tailor"],
-                "jobUrls": [
-                    "https://example.com/job/score-a",
-                    "https://example.com/job/score-b",
-                ],
+                "jobIds": [str(job_id) for job_id, _job_url in selected_jobs],
                 "limit": 5,
                 "workers": 2,
                 "minScore": 8,
@@ -1013,9 +1065,9 @@ def test_run_stage_preserves_omitted_tailor_judge_threshold(tmp_db: Path) -> Non
                 "expectedAppDir": "/tmp/jobctrl",
                 "expectedDbPath": "/tmp/jobctrl/jobctrl.db",
                 "limit": 10,
-                "jobUrls": [
-                    "https://example.com/job/score-a",
-                    "https://example.com/job/score-b",
+                "jobIds": [
+                    "20000000-0000-4000-8000-000000000002",
+                    "20000000-0000-4000-8000-000000000003",
                 ],
                 "dryRun": False,
             },
@@ -1039,7 +1091,7 @@ def test_run_stage_preserves_omitted_tailor_judge_threshold(tmp_db: Path) -> Non
                 "tenantId": "local",
                 "expectedAppDir": "/tmp/jobctrl",
                 "expectedDbPath": "/tmp/jobctrl/jobctrl.db",
-                "jobUrl": "https://example.com/job/tailor",
+                "jobId": "20000000-0000-4000-8000-000000000008",
                 "dryRun": True,
                 "allowLowFitOverride": True,
                 "tailorModels": ["local:draft-a"],
@@ -1049,7 +1101,7 @@ def test_run_stage_preserves_omitted_tailor_judge_threshold(tmp_db: Path) -> Non
             {
                 "steps": ["tailor", "cover", "pdf"],
                 "retailor": False,
-                "job_url": "https://example.com/job/tailor",
+                "job_id": JobId("20000000-0000-4000-8000-000000000008"),
                 "allow_low_fit_override": True,
                 "tailor_models": ("local:draft-a",),
                 "tailor_judge_model": "gemini:judge-c",
@@ -1101,9 +1153,9 @@ def test_run_stage_preserves_omitted_tailor_judge_threshold(tmp_db: Path) -> Non
                 "expectedAppDir": "/tmp/jobctrl",
                 "expectedDbPath": "/tmp/jobctrl/jobctrl.db",
                 "limit": 5,
-                "jobUrls": [
-                    "https://example.com/job/tailor-a",
-                    "https://example.com/job/tailor-b",
+                "jobIds": [
+                    "20000000-0000-4000-8000-000000000011",
+                    "20000000-0000-4000-8000-000000000012",
                 ],
                 "dryRun": False,
                 "suppressExistingArtifacts": True,
@@ -1130,7 +1182,7 @@ def test_run_stage_preserves_omitted_tailor_judge_threshold(tmp_db: Path) -> Non
                 "expectedAppDir": "/tmp/jobctrl",
                 "expectedDbPath": "/tmp/jobctrl/jobctrl.db",
                 "limit": 5,
-                "jobUrls": ["https://example.com/job/tailor-a"],
+                "jobIds": ["20000000-0000-4000-8000-000000000011"],
             },
             {
                 "stages": ["tailor", "cover"],
@@ -1159,24 +1211,25 @@ def test_current_policy_maintenance_methods_start_pipeline_workflows(
         return _StubHandle("maintenance-wf", "maintenance-run")
 
     if method in {"rescore_job", "tailor_job", "retailor_job"}:
-        if method in {"rescore_job", "retailor_job"}:
-            job_id = JobId(str(params["jobId"]))
-            job_url = f"https://example.com/job/{method}"
-        else:
-            job_url = str(params["jobUrl"])
-            job_id = None
-        job_id = _seed_v7_current_locator(
+        job_id = JobId(str(params["jobId"]))
+        _seed_v7_current_locator(
             get_connection(tmp_db),
             tenant_id=TenantId("local"),
-            job_url=job_url,
+            job_url=f"https://example.com/job/{method}-{job_id}",
             job_id=job_id,
         )
-        expected_payload = {
-            key: value
-            for key, value in expected_payload.items()
-            if key != "job_url"
-        }
-        expected_payload["job_id"] = job_id
+    else:
+        for job_id, job_url in zip(
+            params["jobIds"],
+            expected_payload["job_urls"],
+            strict=True,
+        ):
+            _seed_v7_current_locator(
+                get_connection(tmp_db),
+                tenant_id=TenantId("local"),
+                job_url=str(job_url),
+                job_id=JobId(str(job_id)),
+            )
 
     server = JsonRpcServer(workflow_starter=starter)
     register_default_handlers(server, canceler=_stub_canceler)
@@ -1206,7 +1259,10 @@ def test_current_policy_maintenance_methods_start_pipeline_workflows(
     assert payload.tenant_id == "local"
 
 
-def test_v7_job_url_workflow_locators_are_tenant_scoped(tmp_db: Path, monkeypatch) -> None:
+def test_v7_canonical_job_ids_disambiguate_the_same_url_by_tenant(
+    tmp_db: Path,
+    monkeypatch,
+) -> None:
     tenant_a = TenantId("tenant-a")
     tenant_b = TenantId("tenant-b")
     job_url = "https://example.com/jobs/same-url"
@@ -1243,11 +1299,10 @@ def test_v7_job_url_workflow_locators_are_tenant_scoped(tmp_db: Path, monkeypatc
         ("tailor_job", tenant_b, job_id_b),
         ("retailor_job", tenant_a, job_id_a),
     ):
-        params: dict[str, str] = {"tenantId": str(tenant_id)}
-        if method in {"rescore_job", "retailor_job"}:
-            params["jobId"] = str(expected_job_id)
-        else:
-            params["jobUrl"] = job_url
+        params = {
+            "tenantId": str(tenant_id),
+            "jobId": str(expected_job_id),
+        }
         response = server.dispatch(
             JsonRpcRequest(
                 method=method,
@@ -1270,7 +1325,7 @@ def test_v7_job_url_workflow_locators_are_tenant_scoped(tmp_db: Path, monkeypatc
     ]
 
 
-@pytest.mark.parametrize("method", ("rescore_job", "retailor_job"))
+@pytest.mark.parametrize("method", ("rescore_job", "tailor_job", "retailor_job"))
 def test_v7_job_id_workflow_targets_are_loaded_directly_and_tenant_scoped(
     tmp_db: Path,
     method: str,
@@ -1325,7 +1380,7 @@ def test_v7_job_id_workflow_targets_are_loaded_directly_and_tenant_scoped(
     }
 
 
-@pytest.mark.parametrize("method", ("rescore_job", "retailor_job"))
+@pytest.mark.parametrize("method", ("rescore_job", "tailor_job", "retailor_job"))
 @pytest.mark.parametrize(
     ("params", "expected_message"),
     [
@@ -1363,36 +1418,127 @@ def test_v7_direct_preparation_identity_requires_one_canonical_job_id(
 
 
 @pytest.mark.parametrize(
-    "method",
-    ("tailor_job", "analyze_job"),
+    ("method", "params"),
+    [
+        ("run_stage", {"stage": "score", "jobUrl": "https://example.com/jobs/legacy"}),
+        (
+            "run_stage",
+            {"stage": "score", "jobUrls": ["https://example.com/jobs/legacy"]},
+        ),
+        (
+            "rescore_jobs_not_on_current_scoring_policy",
+            {"jobUrls": ["https://example.com/jobs/legacy"]},
+        ),
+        ("analyze_job", {"jobUrl": "https://example.com/jobs/legacy"}),
+        (
+            "generate_interview_prep",
+            {"jobUrl": "https://example.com/jobs/legacy"},
+        ),
+        ("apply", {"jobUrl": "https://example.com/jobs/legacy"}),
+        (
+            "retailor_current_policy",
+            {"jobUrls": ["https://example.com/jobs/legacy"]},
+        ),
+    ],
 )
-def test_v7_job_url_locators_reject_unknown_and_retired_jobs(
+def test_v7_rpc_identity_boundary_rejects_url_locator_params(
+    method: str,
+    params: dict[str, object],
+) -> None:
+    response = _server().dispatch(JsonRpcRequest(method=method, params=params, id=1))
+
+    assert response is not None
+    body = response.to_dict()
+    assert body["error"]["code"] == INVALID_PARAMS
+    assert "is not supported" in body["error"]["message"]
+
+
+@pytest.mark.parametrize(
+    ("method", "params"),
+    [
+        ("run_stage", {"stage": "score", "jobId": "https://example.com/jobs/not-an-id"}),
+        (
+            "run_stage",
+            {"stage": "score", "jobIds": ["https://example.com/jobs/not-an-id"]},
+        ),
+        (
+            "rescore_jobs_not_on_current_scoring_policy",
+            {"jobIds": ["https://example.com/jobs/not-an-id"]},
+        ),
+        ("analyze_job", {"jobId": "https://example.com/jobs/not-an-id"}),
+        (
+            "generate_interview_prep",
+            {"jobId": "https://example.com/jobs/not-an-id"},
+        ),
+        ("apply", {"jobId": "https://example.com/jobs/not-an-id"}),
+        (
+            "retailor_current_policy",
+            {"jobIds": ["https://example.com/jobs/not-an-id"]},
+        ),
+    ],
+)
+def test_v7_rpc_identity_boundary_rejects_url_shaped_job_ids(
+    method: str,
+    params: dict[str, object],
+) -> None:
+    response = _server().dispatch(JsonRpcRequest(method=method, params=params, id=1))
+
+    assert response is not None
+    body = response.to_dict()
+    assert body["error"]["code"] == INVALID_PARAMS
+    assert "JobId must be a canonical UUID" in body["error"]["message"]
+
+
+def test_v7_apply_preserves_global_and_explicit_job_semantics(
+    tmp_db: Path,
+    monkeypatch,
+) -> None:
+    job_url = "https://example.com/jobs/apply"
+    job_id = _seed_v7_current_locator(
+        get_connection(tmp_db),
+        tenant_id=TenantId("local"),
+        job_url=job_url,
+        job_id=JobId("60000000-0000-4000-8000-000000000006"),
+    )
+    monkeypatch.setattr(
+        "jobctrl.browser_capabilities.require_system_browser_capability",
+        lambda _capability_id: None,
+    )
+
+    explicit = handlers_mod.apply_action(
+        {"tenantId": "local", "jobId": str(job_id), "dryRun": True}
+    )
+    global_selection = handlers_mod.apply_action(
+        {"tenantId": "local", "dryRun": True}
+    )
+
+    assert explicit.workflow is ApplyWorkflow
+    assert explicit.workflow_id == f"apply-local-{job_url}"
+    assert explicit.args == (
+        ApplyWorkflowInput(tenant_id="local", job_url=job_url, dry_run=True),
+    )
+    assert global_selection.workflow is ApplyWorkflow
+    assert global_selection.workflow_id is None
+    assert global_selection.args == (
+        ApplyWorkflowInput(tenant_id="local", job_url=None, dry_run=True),
+    )
+
+
+@pytest.mark.parametrize(
+    "method",
+    ("tailor_job", "analyze_job", "generate_interview_prep"),
+)
+def test_v7_canonical_job_ids_reject_unknown_and_deleted_jobs(
     tmp_db: Path,
     method: str,
 ) -> None:
     tenant_id = TenantId("tenant-a")
-    active_url = "https://example.com/jobs/active"
-    retired_url = "https://example.com/jobs/retired"
     deleted_url = "https://example.com/jobs/deleted"
     conn = get_connection(tmp_db)
-    _seed_v7_current_locator(conn, tenant_id=tenant_id, job_url=active_url)
-    retired_job_id = _seed_v7_current_locator(
-        conn,
-        tenant_id=tenant_id,
-        job_url=retired_url,
-    )
     deleted_job_id = _seed_v7_current_locator(
         conn,
         tenant_id=tenant_id,
         job_url=deleted_url,
-    )
-    conn.execute(
-        """
-        UPDATE job_locators
-        SET is_current = 0, retired_at = '2026-07-30T11:00:00+00:00'
-        WHERE tenant_id = ? AND job_id = ? AND locator_kind = 'posting_url'
-        """,
-        (str(tenant_id), str(retired_job_id)),
     )
     conn.execute(
         """
@@ -1405,15 +1551,14 @@ def test_v7_job_url_locators_reject_unknown_and_retired_jobs(
     conn.commit()
     server = _server()
 
-    for job_url in (
-        "https://example.com/jobs/missing",
-        retired_url,
-        deleted_url,
+    for job_id in (
+        JobId("90000000-0000-4000-8000-000000000009"),
+        deleted_job_id,
     ):
         response = server.dispatch(
             JsonRpcRequest(
                 method=method,
-                params={"tenantId": str(tenant_id), "jobUrl": job_url},
+                params={"tenantId": str(tenant_id), "jobId": str(job_id)},
                 id=1,
             )
         )
@@ -1421,7 +1566,7 @@ def test_v7_job_url_locators_reject_unknown_and_retired_jobs(
         assert response is not None
         body = response.to_dict()
         assert body["error"]["code"] == INVALID_PARAMS
-        assert "unknown or inactive jobUrl" in body["error"]["message"]
+        assert "unknown or inactive jobId" in body["error"]["message"]
 
 
 def test_analyze_job_loads_the_canonical_tenant_scoped_target(
@@ -1467,13 +1612,21 @@ def test_analyze_job_loads_the_canonical_tenant_scoped_target(
     response = _server().dispatch(
         JsonRpcRequest(
             method="analyze_job",
-            params={"tenantId": str(tenant_a), "jobUrl": job_url, "force": True},
+            params={"tenantId": str(tenant_a), "jobId": str(job_id_a), "force": True},
             id=1,
         )
     )
 
     assert response is not None
-    assert response.to_dict()["result"]["cacheKey"] == "canonical-cache-key"
+    assert response.to_dict()["result"] == {
+        "jobId": str(job_id_a),
+        "generation": 2,
+        "cacheKey": "canonical-cache-key",
+        "cached": False,
+        "legsAttempted": 3,
+        "legsSucceeded": 3,
+        "degraded": False,
+    }
     assert captured["tenant_id"] == tenant_a
     assert captured["force"] is True
     assert captured["job"] == {
@@ -1501,12 +1654,20 @@ def test_retailor_job_duplicate_dispatch_uses_existing_workflow_without_duplicat
 ) -> None:
     conn = get_connection(tmp_db)
     job_url = "https://example.com/job/retailor-idempotent"
-    _seed_job(tmp_db, job_url)
+    job_id = _seed_v7_current_locator(
+        conn,
+        tenant_id=TenantId("local"),
+        job_url=job_url,
+    )
     _seed_tailoring_policy(conn, version=3)
     _seed_tailored_artifact(conn, job_url, policy_version=3)
     before = conn.execute(
-        "SELECT COUNT(*), COUNT(DISTINCT artifact_id) FROM job_materials_artifacts WHERE job_url = ?",
-        (job_url,),
+        """
+        SELECT COUNT(*), COUNT(DISTINCT artifact_id)
+        FROM job_materials_artifacts
+        WHERE tenant_id = 'local' AND job_id = ?
+        """,
+        (str(job_id),),
     ).fetchone()
     seen: list[WorkflowStartSpec] = []
 
@@ -1522,7 +1683,7 @@ def test_retailor_job_duplicate_dispatch_uses_existing_workflow_without_duplicat
             "tenantId": "local",
             "expectedAppDir": "/tmp/jobctrl",
             "expectedDbPath": "/tmp/jobctrl/jobctrl.db",
-            "jobUrl": job_url,
+            "jobId": str(job_id),
             "dryRun": False,
         },
         id=1,
@@ -1540,8 +1701,12 @@ def test_retailor_job_duplicate_dispatch_uses_existing_workflow_without_duplicat
     assert seen[0].id_conflict_policy is WorkflowIDConflictPolicy.USE_EXISTING
     assert seen[1].id_conflict_policy is WorkflowIDConflictPolicy.USE_EXISTING
     after = conn.execute(
-        "SELECT COUNT(*), COUNT(DISTINCT artifact_id) FROM job_materials_artifacts WHERE job_url = ?",
-        (job_url,),
+        """
+        SELECT COUNT(*), COUNT(DISTINCT artifact_id)
+        FROM job_materials_artifacts
+        WHERE tenant_id = 'local' AND job_id = ?
+        """,
+        (str(job_id),),
     ).fetchone()
     assert tuple(before) == (1, 1)
     assert tuple(after) == tuple(before)
@@ -1985,11 +2150,12 @@ def test_profile_import_requires_pdf_path(tmp_db: Path) -> None:
 
 
 def _seed_enriched_job(conn, url: str) -> None:
-    conn.execute(
-        "INSERT INTO jobs (url, title, full_description, discovered_at) VALUES (?, ?, ?, ?)",
-        (url, "Test job", "Full description", "2026-05-26T10:00:00+00:00"),
+    _seed_v7_current_locator(
+        conn,
+        tenant_id=TenantId("local"),
+        job_url=url,
+        job_id=JobId(str(uuid.uuid5(uuid.NAMESPACE_URL, f"local:{url}"))),
     )
-    conn.commit()
 
 
 def _seed_v7_current_locator(
@@ -2072,16 +2238,21 @@ def _seed_score(
     fit_score: int = 8,
     correction: dict[str, object] | None = None,
 ) -> None:
+    job = conn.execute(
+        "SELECT job_id FROM jobs WHERE tenant_id = 'local' AND url = ?",
+        (url,),
+    ).fetchone()
+    assert job is not None
     conn.execute(
         """
         INSERT INTO job_scores (
-            job_url, version, tenant_id, fit_score, breakdown_json, keywords_json,
+            tenant_id, job_id, version, fit_score, breakdown_json, keywords_json,
             scored_at, correction_json, criteria_json, trace_json
-        ) VALUES (?, 1, 'local', ?, ?, '[]', '2026-05-26T10:00:00+00:00',
+        ) VALUES ('local', ?, 1, ?, ?, '[]', '2026-05-26T10:00:00+00:00',
             ?, '{}', ?)
         """,
         (
-            url,
+            str(job["job_id"]),
             fit_score,
             json.dumps({"reasoning": "ok", "eligibility": {"status": "eligible", "hard_blockers": []}}),
             json.dumps(correction) if correction is not None else None,
@@ -2092,25 +2263,31 @@ def _seed_score(
 
 
 def _seed_tailored_artifact(conn, url: str, *, policy_version: int) -> None:
+    job = conn.execute(
+        "SELECT job_id FROM jobs WHERE tenant_id = 'local' AND url = ?",
+        (url,),
+    ).fetchone()
+    assert job is not None
+    job_id = str(job["job_id"])
     conn.execute(
         """
         INSERT INTO job_materials (
-            job_url, generation, tenant_id, status, created_at, updated_at, metadata_json
-        ) VALUES (?, 1, 'local', 'resume_approved',
+            tenant_id, job_id, generation, status, created_at, updated_at, metadata_json
+        ) VALUES ('local', ?, 1, 'resume_approved',
             '2026-05-26T10:00:00+00:00', '2026-05-26T10:00:00+00:00', '{}')
         """,
-        (url,),
+        (job_id,),
     )
     conn.execute(
         """
         INSERT INTO job_materials_artifacts (
-            job_url, generation, artifact_type, artifact_id, status, path,
-            render_format, size_bytes, metadata_json, created_at, superseded_at
-        ) VALUES (?, 1, 'tailored_resume', ?, 'approved', ?, 'text', 12, ?,
+            tenant_id, job_id, generation, artifact_type, artifact_id, status,
+            path, render_format, size_bytes, metadata_json, created_at, superseded_at
+        ) VALUES ('local', ?, 1, 'tailored_resume', ?, 'approved', ?, 'text', 12, ?,
             '2026-05-26T10:00:00+00:00', NULL)
         """,
         (
-            url,
+            job_id,
             f"artifact-{policy_version}-{url.rsplit('/', 1)[-1]}",
             f"/tmp/{url.rsplit('/', 1)[-1]}.txt",
             json.dumps({"tailoring_policy_version": policy_version}),

--- a/workers/automation/tests/test_jsonrpc_handlers.py
+++ b/workers/automation/tests/test_jsonrpc_handlers.py
@@ -997,13 +997,13 @@ def test_run_stage_preserves_omitted_tailor_judge_threshold(tmp_db: Path) -> Non
                 "tenantId": "local",
                 "expectedAppDir": "/tmp/jobctrl",
                 "expectedDbPath": "/tmp/jobctrl/jobctrl.db",
-                "jobUrl": "https://example.com/job/score",
+                "jobId": "20000000-0000-4000-8000-000000000001",
                 "dryRun": True,
             },
             {
                 "steps": ["score"],
                 "rescore": True,
-                "job_url": "https://example.com/job/score",
+                "job_id": JobId("20000000-0000-4000-8000-000000000001"),
             },
         ),
         (
@@ -1062,7 +1062,7 @@ def test_run_stage_preserves_omitted_tailor_judge_threshold(tmp_db: Path) -> Non
                 "tenantId": "local",
                 "expectedAppDir": "/tmp/jobctrl",
                 "expectedDbPath": "/tmp/jobctrl/jobctrl.db",
-                "jobUrl": "https://example.com/job/tailor",
+                "jobId": "20000000-0000-4000-8000-000000000009",
                 "dryRun": True,
                 "suppressExistingArtifacts": False,
                 "tailorModels": ["local:draft-a"],
@@ -1072,7 +1072,7 @@ def test_run_stage_preserves_omitted_tailor_judge_threshold(tmp_db: Path) -> Non
             {
                 "steps": ["tailor", "cover", "pdf"],
                 "retailor": True,
-                "job_url": "https://example.com/job/tailor",
+                "job_id": JobId("20000000-0000-4000-8000-000000000009"),
                 "suppress_existing_artifacts": False,
                 "tailor_models": ("local:draft-a",),
                 "tailor_judge_model": "gemini:judge-c",
@@ -1085,12 +1085,12 @@ def test_run_stage_preserves_omitted_tailor_judge_threshold(tmp_db: Path) -> Non
                 "tenantId": "local",
                 "expectedAppDir": "/tmp/jobctrl",
                 "expectedDbPath": "/tmp/jobctrl/jobctrl.db",
-                "jobUrl": "https://example.com/job/tailor",
+                "jobId": "20000000-0000-4000-8000-000000000010",
             },
             {
                 "steps": ["tailor", "cover", "pdf"],
                 "retailor": True,
-                "job_url": "https://example.com/job/tailor",
+                "job_id": JobId("20000000-0000-4000-8000-000000000010"),
                 "suppress_existing_artifacts": False,
             },
         ),
@@ -1159,11 +1159,17 @@ def test_current_policy_maintenance_methods_start_pipeline_workflows(
         return _StubHandle("maintenance-wf", "maintenance-run")
 
     if method in {"rescore_job", "tailor_job", "retailor_job"}:
-        job_url = str(params["jobUrl"])
+        if method in {"rescore_job", "retailor_job"}:
+            job_id = JobId(str(params["jobId"]))
+            job_url = f"https://example.com/job/{method}"
+        else:
+            job_url = str(params["jobUrl"])
+            job_id = None
         job_id = _seed_v7_current_locator(
             get_connection(tmp_db),
             tenant_id=TenantId("local"),
             job_url=job_url,
+            job_id=job_id,
         )
         expected_payload = {
             key: value
@@ -1237,10 +1243,15 @@ def test_v7_job_url_workflow_locators_are_tenant_scoped(tmp_db: Path, monkeypatc
         ("tailor_job", tenant_b, job_id_b),
         ("retailor_job", tenant_a, job_id_a),
     ):
+        params: dict[str, str] = {"tenantId": str(tenant_id)}
+        if method in {"rescore_job", "retailor_job"}:
+            params["jobId"] = str(expected_job_id)
+        else:
+            params["jobUrl"] = job_url
         response = server.dispatch(
             JsonRpcRequest(
                 method=method,
-                params={"tenantId": str(tenant_id), "jobUrl": job_url},
+                params=params,
                 id=1,
             )
         )
@@ -1318,22 +1329,26 @@ def test_v7_job_id_workflow_targets_are_loaded_directly_and_tenant_scoped(
 @pytest.mark.parametrize(
     ("params", "expected_message"),
     [
-        ({"tenantId": "local"}, "provide exactly one of jobId or jobUrl"),
+        ({"tenantId": "local"}, "missing required param: jobId"),
+        (
+            {"tenantId": "local", "jobUrl": "https://example.com/jobs/legacy"},
+            "jobUrl is not supported",
+        ),
         (
             {
                 "tenantId": "local",
                 "jobId": "50000000-0000-4000-8000-000000000005",
                 "jobUrl": "https://example.com/jobs/both",
             },
-            "provide exactly one of jobId or jobUrl",
+            "jobUrl is not supported",
         ),
         (
             {"tenantId": "local", "jobId": "https://example.com/jobs/not-an-id"},
-            "invalid jobId",
+            "JobId must be a canonical UUID",
         ),
     ],
 )
-def test_v7_direct_preparation_identity_requires_exactly_one_valid_locator(
+def test_v7_direct_preparation_identity_requires_one_canonical_job_id(
     tmp_db: Path,
     method: str,
     params: dict[str, object],
@@ -1349,7 +1364,7 @@ def test_v7_direct_preparation_identity_requires_exactly_one_valid_locator(
 
 @pytest.mark.parametrize(
     "method",
-    ("rescore_job", "tailor_job", "retailor_job", "analyze_job"),
+    ("tailor_job", "analyze_job"),
 )
 def test_v7_job_url_locators_reject_unknown_and_retired_jobs(
     tmp_db: Path,

--- a/workers/automation/tests/test_jsonrpc_handlers.py
+++ b/workers/automation/tests/test_jsonrpc_handlers.py
@@ -1259,6 +1259,94 @@ def test_v7_job_url_workflow_locators_are_tenant_scoped(tmp_db: Path, monkeypatc
     ]
 
 
+@pytest.mark.parametrize("method", ("rescore_job", "retailor_job"))
+def test_v7_job_id_workflow_targets_are_loaded_directly_and_tenant_scoped(
+    tmp_db: Path,
+    method: str,
+) -> None:
+    tenant_id = TenantId("tenant-a")
+    job_id = _seed_v7_current_locator(
+        get_connection(tmp_db),
+        tenant_id=tenant_id,
+        job_url="https://example.com/jobs/direct-job-id",
+        job_id=JobId("50000000-0000-4000-8000-000000000005"),
+    )
+    conn = get_connection(tmp_db)
+    conn.execute(
+        "DELETE FROM job_locators WHERE tenant_id = ? AND job_id = ?",
+        (str(tenant_id), str(job_id)),
+    )
+    conn.commit()
+    seen: list[WorkflowStartSpec] = []
+
+    async def starter(spec: WorkflowStartSpec) -> _StubHandle:
+        seen.append(spec)
+        return _StubHandle("job-preparation", "preparation-run")
+
+    server = JsonRpcServer(workflow_starter=starter)
+    register_default_handlers(server, canceler=_stub_canceler)
+    response = server.dispatch(
+        JsonRpcRequest(
+            method=method,
+            params={"tenantId": str(tenant_id), "jobId": str(job_id)},
+            id=1,
+        )
+    )
+
+    assert response is not None
+    assert "error" not in response.to_dict()
+    (payload,) = seen[0].args
+    assert isinstance(payload, JobPreparationInput)
+    assert payload.tenant_id == str(tenant_id)
+    assert payload.job_id == job_id
+
+    wrong_tenant = server.dispatch(
+        JsonRpcRequest(
+            method=method,
+            params={"tenantId": "tenant-b", "jobId": str(job_id)},
+            id=2,
+        )
+    )
+    assert wrong_tenant is not None
+    assert wrong_tenant.to_dict()["error"] == {
+        "code": INVALID_PARAMS,
+        "message": f"unknown or inactive jobId: {job_id}",
+    }
+
+
+@pytest.mark.parametrize("method", ("rescore_job", "retailor_job"))
+@pytest.mark.parametrize(
+    ("params", "expected_message"),
+    [
+        ({"tenantId": "local"}, "provide exactly one of jobId or jobUrl"),
+        (
+            {
+                "tenantId": "local",
+                "jobId": "50000000-0000-4000-8000-000000000005",
+                "jobUrl": "https://example.com/jobs/both",
+            },
+            "provide exactly one of jobId or jobUrl",
+        ),
+        (
+            {"tenantId": "local", "jobId": "https://example.com/jobs/not-an-id"},
+            "invalid jobId",
+        ),
+    ],
+)
+def test_v7_direct_preparation_identity_requires_exactly_one_valid_locator(
+    tmp_db: Path,
+    method: str,
+    params: dict[str, object],
+    expected_message: str,
+) -> None:
+    response = _server().dispatch(JsonRpcRequest(method=method, params=params, id=1))
+
+    assert response is not None
+    body = response.to_dict()
+    assert body["error"]["code"] == INVALID_PARAMS
+    assert expected_message in body["error"]["message"]
+
+
 @pytest.mark.parametrize(
     "method",
     ("rescore_job", "tailor_job", "retailor_job", "analyze_job"),

--- a/workers/automation/tests/test_jsonrpc_handlers.py
+++ b/workers/automation/tests/test_jsonrpc_handlers.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import uuid
 from dataclasses import fields
 from pathlib import Path
 from types import SimpleNamespace
@@ -15,6 +16,8 @@ from jobctrl.database import close_connection, get_connection, init_db
 from jobctrl.discovery.workflow import DiscoverWorkflow, DiscoverWorkflowInput
 from jobctrl.domain.compensation import ReportedCompensationObservation
 from jobctrl.domain.interview import INTERVIEW_PREP_ITEM_KINDS, INTERVIEW_PREP_STATUSES
+from jobctrl.domain.identifiers import JobId
+from jobctrl.domain.tenant import TenantId
 from jobctrl.infrastructure.compensation import refresh as compensation_refresh_mod
 from jobctrl.infrastructure.compensation import sqlite_market_repository as market_repository_mod
 from jobctrl.infrastructure.compensation.refresh import refresh_compensation_facts
@@ -1155,6 +1158,20 @@ def test_current_policy_maintenance_methods_start_pipeline_workflows(
         seen.append(spec)
         return _StubHandle("maintenance-wf", "maintenance-run")
 
+    if method in {"rescore_job", "tailor_job", "retailor_job"}:
+        job_url = str(params["jobUrl"])
+        job_id = _seed_v7_current_locator(
+            get_connection(tmp_db),
+            tenant_id=TenantId("local"),
+            job_url=job_url,
+        )
+        expected_payload = {
+            key: value
+            for key, value in expected_payload.items()
+            if key != "job_url"
+        }
+        expected_payload["job_id"] = job_id
+
     server = JsonRpcServer(workflow_starter=starter)
     register_default_handlers(server, canceler=_stub_canceler)
 
@@ -1181,6 +1198,199 @@ def test_current_policy_maintenance_methods_start_pipeline_workflows(
     for name, value in expected_payload.items():
         assert getattr(payload, name) == value
     assert payload.tenant_id == "local"
+
+
+def test_v7_job_url_workflow_locators_are_tenant_scoped(tmp_db: Path, monkeypatch) -> None:
+    tenant_a = TenantId("tenant-a")
+    tenant_b = TenantId("tenant-b")
+    job_url = "https://example.com/jobs/same-url"
+    job_id_a = _seed_v7_current_locator(
+        get_connection(tmp_db),
+        tenant_id=tenant_a,
+        job_url=job_url,
+        job_id=JobId("10000000-0000-4000-8000-000000000001"),
+    )
+    job_id_b = _seed_v7_current_locator(
+        get_connection(tmp_db),
+        tenant_id=tenant_b,
+        job_url=job_url,
+        job_id=JobId("20000000-0000-4000-8000-000000000002"),
+    )
+    source_event_calls: list[tuple[TenantId, JobId]] = []
+
+    def fake_latest_source_event_id(conn, *, tenant_id: TenantId, job_id: JobId) -> str:
+        source_event_calls.append((tenant_id, job_id))
+        return "source-event"
+
+    monkeypatch.setattr(handlers_mod, "latest_source_event_id", fake_latest_source_event_id)
+    seen: list[WorkflowStartSpec] = []
+
+    async def starter(spec: WorkflowStartSpec) -> _StubHandle:
+        seen.append(spec)
+        return _StubHandle("job-preparation", "preparation-run")
+
+    server = JsonRpcServer(workflow_starter=starter)
+    register_default_handlers(server, canceler=_stub_canceler)
+
+    for method, tenant_id, expected_job_id in (
+        ("rescore_job", tenant_a, job_id_a),
+        ("tailor_job", tenant_b, job_id_b),
+        ("retailor_job", tenant_a, job_id_a),
+    ):
+        response = server.dispatch(
+            JsonRpcRequest(
+                method=method,
+                params={"tenantId": str(tenant_id), "jobUrl": job_url},
+                id=1,
+            )
+        )
+
+        assert response is not None
+        assert "error" not in response.to_dict()
+        (payload,) = seen[-1].args
+        assert isinstance(payload, JobPreparationInput)
+        assert payload.tenant_id == str(tenant_id)
+        assert payload.job_id == expected_job_id
+
+    assert source_event_calls == [
+        (tenant_a, job_id_a),
+        (tenant_b, job_id_b),
+        (tenant_a, job_id_a),
+    ]
+
+
+@pytest.mark.parametrize(
+    "method",
+    ("rescore_job", "tailor_job", "retailor_job", "analyze_job"),
+)
+def test_v7_job_url_locators_reject_unknown_and_retired_jobs(
+    tmp_db: Path,
+    method: str,
+) -> None:
+    tenant_id = TenantId("tenant-a")
+    active_url = "https://example.com/jobs/active"
+    retired_url = "https://example.com/jobs/retired"
+    deleted_url = "https://example.com/jobs/deleted"
+    conn = get_connection(tmp_db)
+    _seed_v7_current_locator(conn, tenant_id=tenant_id, job_url=active_url)
+    retired_job_id = _seed_v7_current_locator(
+        conn,
+        tenant_id=tenant_id,
+        job_url=retired_url,
+    )
+    deleted_job_id = _seed_v7_current_locator(
+        conn,
+        tenant_id=tenant_id,
+        job_url=deleted_url,
+    )
+    conn.execute(
+        """
+        UPDATE job_locators
+        SET is_current = 0, retired_at = '2026-07-30T11:00:00+00:00'
+        WHERE tenant_id = ? AND job_id = ? AND locator_kind = 'posting_url'
+        """,
+        (str(tenant_id), str(retired_job_id)),
+    )
+    conn.execute(
+        """
+        INSERT INTO jobctrl_deleted_jobs (
+            tenant_id, job_id, deleted_at, reason
+        ) VALUES (?, ?, '2026-07-30T11:00:00+00:00', 'user_deleted')
+        """,
+        (str(tenant_id), str(deleted_job_id)),
+    )
+    conn.commit()
+    server = _server()
+
+    for job_url in (
+        "https://example.com/jobs/missing",
+        retired_url,
+        deleted_url,
+    ):
+        response = server.dispatch(
+            JsonRpcRequest(
+                method=method,
+                params={"tenantId": str(tenant_id), "jobUrl": job_url},
+                id=1,
+            )
+        )
+
+        assert response is not None
+        body = response.to_dict()
+        assert body["error"]["code"] == INVALID_PARAMS
+        assert "unknown or inactive jobUrl" in body["error"]["message"]
+
+
+def test_analyze_job_loads_the_canonical_tenant_scoped_target(
+    tmp_db: Path,
+    monkeypatch,
+) -> None:
+    tenant_a = TenantId("tenant-a")
+    tenant_b = TenantId("tenant-b")
+    job_url = "https://example.com/jobs/analyze"
+    job_id_a = _seed_v7_current_locator(
+        get_connection(tmp_db),
+        tenant_id=tenant_a,
+        job_url=job_url,
+        job_id=JobId("30000000-0000-4000-8000-000000000003"),
+        full_description="Tenant A canonical description",
+    )
+    _seed_v7_current_locator(
+        get_connection(tmp_db),
+        tenant_id=tenant_b,
+        job_url=job_url,
+        job_id=JobId("40000000-0000-4000-8000-000000000004"),
+        full_description="Tenant B canonical description",
+    )
+    captured: dict[str, object] = {}
+
+    class _UseCase:
+        def execute(self, *, job, tenant_id, force):
+            captured.update(job=job, tenant_id=tenant_id, force=force)
+            return SimpleNamespace(
+                analysis=SimpleNamespace(
+                    generation=2,
+                    cache_key="canonical-cache-key",
+                    legs_attempted=3,
+                    legs_succeeded=3,
+                    is_degraded=False,
+                ),
+                cached=False,
+            )
+
+    from jobctrl.scoring import tailor as tailor_mod
+
+    monkeypatch.setattr(tailor_mod, "_build_analyze_use_case", lambda **_kwargs: _UseCase())
+    response = _server().dispatch(
+        JsonRpcRequest(
+            method="analyze_job",
+            params={"tenantId": str(tenant_a), "jobUrl": job_url, "force": True},
+            id=1,
+        )
+    )
+
+    assert response is not None
+    assert response.to_dict()["result"]["cacheKey"] == "canonical-cache-key"
+    assert captured["tenant_id"] == tenant_a
+    assert captured["force"] is True
+    assert captured["job"] == {
+        "tenant_id": str(tenant_a),
+        "job_id": str(job_id_a),
+        "url": job_url,
+        "title": "Test job",
+        "company": "Acme",
+        "salary": None,
+        "description": "Summary",
+        "location": "Remote",
+        "site": "example",
+        "strategy": "search",
+        "discovered_at": "2026-07-30T10:00:00+00:00",
+        "enrichment_status": "enriched",
+        "full_description": "Tenant A canonical description",
+        "application_url": None,
+        "detail_scraped_at": "2026-07-30T10:01:00+00:00",
+        "extraction_tier": "high",
+    }
 
 
 def test_retailor_job_duplicate_dispatch_uses_existing_workflow_without_duplicate_artifacts(
@@ -1677,6 +1887,49 @@ def _seed_enriched_job(conn, url: str) -> None:
         (url, "Test job", "Full description", "2026-05-26T10:00:00+00:00"),
     )
     conn.commit()
+
+
+def _seed_v7_current_locator(
+    conn,
+    *,
+    tenant_id: TenantId,
+    job_url: str,
+    job_id: JobId | None = None,
+    full_description: str = "Full description",
+) -> JobId:
+    stable_job_id = job_id or JobId(str(uuid.uuid5(uuid.NAMESPACE_URL, f"{tenant_id}:{job_url}")))
+    conn.execute(
+        """
+        INSERT INTO jobs (
+            tenant_id, job_id, url, title, company, salary, description,
+            location, site, strategy, discovered_at
+        ) VALUES (?, ?, ?, 'Test job', 'Acme', NULL, 'Summary', 'Remote',
+                  'example', 'search', '2026-07-30T10:00:00+00:00')
+        """,
+        (str(tenant_id), str(stable_job_id), job_url),
+    )
+    conn.execute(
+        """
+        INSERT INTO job_locators (
+            tenant_id, job_id, locator_kind, locator_value, is_current,
+            first_seen_at, last_seen_at, retired_at
+        ) VALUES (?, ?, 'posting_url', ?, 1, '2026-07-30T10:00:00+00:00',
+                  '2026-07-30T10:00:00+00:00', NULL)
+        """,
+        (str(tenant_id), str(stable_job_id), job_url),
+    )
+    conn.execute(
+        """
+        INSERT INTO job_enrichments (
+            tenant_id, job_id, current_status, full_description,
+            application_url, enriched_at, extraction_tier, updated_at
+        ) VALUES (?, ?, 'enriched', ?, NULL, '2026-07-30T10:01:00+00:00',
+                  'high', '2026-07-30T10:01:00+00:00')
+        """,
+        (str(tenant_id), str(stable_job_id), full_description),
+    )
+    conn.commit()
+    return stable_job_id
 
 
 def _seed_scoring_policy(conn, *, version: int) -> None:


### PR DESCRIPTION
## Summary

- resolve external job locators once in the TypeScript REST API
- carry only canonical `jobId` / `jobIds` values through action commands and JSON-RPC
- return canonical `jobIds` from demo action commands without leaking readonly internal collections
- reject `jobUrl` / `jobUrls` in Python runtime handlers instead of retaining a legacy internal URL path
- validate tenant-scoped current Jobs before preparation, analysis, interview, Apply, and contact-research dispatch
- preserve global Apply and bulk-maintenance selector semantics without turning the pipeline sentinel into a locator

## Why

URLs are external locators in v7, not runtime identity. This correction makes the REST boundary the resolution point and prevents URL-shaped identifiers from reaching Python workflows or persistence.

## Validation

- Python JSON-RPC handler suite: 79 passed
- TypeScript adapter and RPC contract suites: 60 passed
- demo scenario engine regression: 8 passed
- cumulative workspace TypeScript check: passed
- API typecheck: passed
- cumulative Step 3 Python suite: 185 passed
- cumulative focused API RPC/projection suite: 106 passed
- focused Ruff and `git diff --check`: passed
- independent cumulative review: PASS, 0 Blocker / 0 High
- independent cumulative QA: PASS, 0 Blocker / 0 High

## Stack

Ready-for-review child of #620. Later mapped runtime PRs consume the canonical IDs directly; no permanent compatibility adapter remains.
