### PR TITLE
refactor(scoring): run per-job scoring by canonical id

### DIFF
--- a/workers/automation/src/jobctrl/domain/materials/analyze_use_case.py
+++ b/workers/automation/src/jobctrl/domain/materials/analyze_use_case.py
@@ -33,7 +33,7 @@ from jobctrl.domain.events import (
     EmployerAnalyzedPayload,
     create_employer_analyzed,
 )
-from jobctrl.domain.identifiers import JobId
+from jobctrl.domain.identifiers import JobId, canonical_job_id
 from jobctrl.domain.materials.analysis import (
     PROMPT_VERSION,
     SDK_SET_VERSION,
@@ -135,7 +135,7 @@ class AnalyzeJobUseCase:
         tenant_id: TenantId = LOCAL_TENANT,
         force: bool = False,
     ) -> AnalyzeJobOutcome:
-        job_id = JobId(str(job["url"]))
+        job_id = canonical_job_id(str(job["job_id"]))
         jd_snapshot = build_jd_snapshot(job)
         snapshot_hash = compute_snapshot_hash(jd_snapshot)
         from jobctrl.domain.materials.analysis import cache_key as _cache_key

--- a/workers/automation/src/jobctrl/scoring/activities.py
+++ b/workers/automation/src/jobctrl/scoring/activities.py
@@ -274,7 +274,7 @@ def _raise_on_failure(stage: str, result: dict[str, Any], error_type: type[JobCt
 
 @activity.defn(name="score_job")
 async def score_job_activity(payload: ScoreJobActivityInput) -> ScoreJobActivityOutput:
-    """Score one job by URL for ``JobPreparationWorkflow``."""
+    """Score one canonical JobId for ``JobPreparationWorkflow``."""
     from jobctrl.infrastructure.temporal.run_in_activity import run_blocking_with_heartbeat
 
     try:
@@ -301,9 +301,9 @@ async def score_job_activity(payload: ScoreJobActivityInput) -> ScoreJobActivity
 def _score_one_job(payload: ScoreJobActivityInput) -> dict[str, Any]:
     from jobctrl.domain.errors import MissingInputError
     from jobctrl.domain.tenant import TenantId
-    from jobctrl.scoring.scorer import score_job_by_url
+    from jobctrl.scoring.scorer import score_job_by_id
 
-    outcome = score_job_by_url(
+    outcome = score_job_by_id(
         payload.job_id,
         tenant_id=TenantId(payload.tenant_id),
         rescore=payload.rescore,

--- a/workers/automation/src/jobctrl/scoring/employer_analysis.py
+++ b/workers/automation/src/jobctrl/scoring/employer_analysis.py
@@ -9,7 +9,9 @@ from __future__ import annotations
 
 import sqlite3
 
+from jobctrl.domain.identifiers import canonical_job_id
 from jobctrl.domain.ports.events import EventPublisher
+from jobctrl.domain.tenant import TenantId
 from jobctrl.infrastructure.materials import SqliteEmployerAnalysisRepository
 from jobctrl.infrastructure.setup_probes import analysis_sdk_set_version, enabled_analysis_legs
 from jobctrl.state import record_job_event
@@ -26,15 +28,18 @@ class EmployerAnalyzedEventRecorder:
         if getattr(event, "event_type", None) != "EmployerAnalyzed":
             return
         payload = dict(getattr(event, "payload", {}) or {})
-        job_url = str(payload.get("job_id") or "")
-        if not job_url:
+        raw_job_id = str(payload.get("job_id") or "")
+        if not raw_job_id:
             return
+        job_id = canonical_job_id(raw_job_id)
+        tenant_id = TenantId(str(getattr(event, "tenant_id", "")))
         completeness = f"{payload.get('legs_succeeded')}/{payload.get('legs_attempted')}"
         record_job_event(
             self._conn,
-            job_url,
+            job_id,
             self._stage,
             "EmployerAnalyzed",
+            tenant_id=tenant_id,
             message=f"Employer analysis generation {payload.get('generation')} ({completeness} legs)",
             payload=payload,
         )
@@ -81,10 +86,13 @@ def build_analyze_use_case(
     if "antigravity" in enabled_legs:
         adapters.append(AntigravityAnalysisAdapter())
     adapter_providers = {
-        "claude" if isinstance(adapter, ClaudeAnalysisAdapter) else
-        "codex" if isinstance(adapter, CodexAnalysisAdapter) else
-        "google" if isinstance(adapter, AntigravityAnalysisAdapter) else
-        "local"
+        "claude"
+        if isinstance(adapter, ClaudeAnalysisAdapter)
+        else "codex"
+        if isinstance(adapter, CodexAnalysisAdapter)
+        else "google"
+        if isinstance(adapter, AntigravityAnalysisAdapter)
+        else "local"
         for adapter in adapters
     }
     if selected_provider == "claude" and "claude" not in adapter_providers:

--- a/workers/automation/src/jobctrl/scoring/scorer.py
+++ b/workers/automation/src/jobctrl/scoring/scorer.py
@@ -513,7 +513,13 @@ def run_scoring(
                 message=f"Fit score {outcome.score.fit_score.value}/10",
                 payload={"keywords": list(outcome.score.matched_keywords)},
             )
-            _sync_score_eligibility_stage_state(conn, url, outcome.score, now=finished_at)
+            _sync_score_eligibility_stage_state(
+                conn,
+                tenant_id=tenant_id,
+                job_id=outcome.score.job_id,
+                score=outcome.score,
+                now=finished_at,
+            )
         else:
             set_stage_state(
                 conn,
@@ -625,6 +631,7 @@ def score_job_by_url(
                 conn,
                 job=job,
                 score=outcome.score,
+                tenant_id=tenant_id,
                 started_at=utc_now(),
                 validate_transition=False,
             )
@@ -702,7 +709,13 @@ def score_job_by_url(
             message=f"Fit score {outcome.score.fit_score.value}/10",
             payload={"keywords": list(outcome.score.matched_keywords)},
         )
-        _sync_score_eligibility_stage_state(conn, job_url, outcome.score, now=finished_at)
+        _sync_score_eligibility_stage_state(
+            conn,
+            tenant_id=tenant_id,
+            job_id=outcome.score.job_id,
+            score=outcome.score,
+            now=finished_at,
+        )
     else:
         set_stage_state(
             conn,
@@ -749,7 +762,12 @@ def _ensure_existing_score_stage_succeeded(
     ).fetchone()
     state = _row_value(row, "state", 0)
     if state == "succeeded":
-        _sync_score_eligibility_stage_state(conn, job_url, score)
+        _sync_score_eligibility_stage_state(
+            conn,
+            tenant_id=tenant_id,
+            job_id=score.job_id,
+            score=score,
+        )
         conn.commit()
         return
 
@@ -774,7 +792,13 @@ def _ensure_existing_score_stage_succeeded(
         message=f"Fit score {score.fit_score.value}/10",
         payload={"keywords": list(score.matched_keywords)},
     )
-    _sync_score_eligibility_stage_state(conn, job_url, score, now=finished_at)
+    _sync_score_eligibility_stage_state(
+        conn,
+        tenant_id=tenant_id,
+        job_id=score.job_id,
+        score=score,
+        now=finished_at,
+    )
     conn.commit()
 
 
@@ -783,6 +807,7 @@ def _record_score_stage_succeeded(
     *,
     job: dict[str, Any],
     score: JobScore,
+    tenant_id: TenantId,
     started_at: str | None = None,
     finished_at: str | None = None,
     validate_transition: bool = False,
@@ -809,21 +834,29 @@ def _record_score_stage_succeeded(
         payload={"keywords": list(score.matched_keywords)},
         occurred_at=finished_at,
     )
-    _sync_score_eligibility_stage_state(conn, job_url, score, now=finished_at)
+    _sync_score_eligibility_stage_state(
+        conn,
+        tenant_id=tenant_id,
+        job_id=score.job_id,
+        score=score,
+        now=finished_at,
+    )
     conn.commit()
 
 
 def _sync_score_eligibility_stage_state(
     conn: sqlite3.Connection,
-    job_url: str,
-    score: JobScore,
     *,
+    tenant_id: TenantId,
+    job_id: JobId,
+    score: JobScore,
     now: str | None = None,
 ) -> None:
     eligibility = score.breakdown.eligibility
     reconcile_score_eligibility_blockers(
         conn,
-        job_url=job_url,
+        tenant_id=tenant_id,
+        job_id=job_id,
         eligibility_status=eligibility.status,
         hard_blockers=list(eligibility.hard_blockers),
         now=now,

--- a/workers/automation/src/jobctrl/scoring/scorer.py
+++ b/workers/automation/src/jobctrl/scoring/scorer.py
@@ -609,7 +609,7 @@ def score_job_by_url(
 ) -> ScoreJobOutcome:
     """Resolve one tenant-scoped posting locator, then score its JobId."""
     conn = get_connection()
-    identity = SqliteJobIdentityResolver(conn).resolve_by_posting_url(
+    identity = SqliteJobIdentityResolver(conn).resolve_current_by_posting_url(
         tenant_id,
         PostingUrl(value=job_url),
     )

--- a/workers/automation/src/jobctrl/scoring/scorer.py
+++ b/workers/automation/src/jobctrl/scoring/scorer.py
@@ -26,8 +26,9 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Any, Mapping, Protocol
 
 from jobctrl.config import RESUME_PATH
-from jobctrl.database import get_connection, get_jobs_by_stage, load_job_with_enrichment
-from jobctrl.domain.identifiers import JobId
+from jobctrl.database import get_connection, get_jobs_by_stage
+from jobctrl.domain.discovery.value_objects import PostingUrl
+from jobctrl.domain.identifiers import JobId, canonical_job_id
 from jobctrl.domain.job_content_identity import (
     job_content_fingerprint,
     normalize_location_for_repost_match,
@@ -57,8 +58,10 @@ from jobctrl.domain.scoring.value_objects import ScoringCriteria
 from jobctrl.domain.tenant import LOCAL_TENANT, TenantId
 from jobctrl.infrastructure.llm import LlmAdapter, get_llm_adapter
 from jobctrl.infrastructure.materials import SqliteEmployerAnalysisRepository
+from jobctrl.infrastructure.discovery import SqliteJobIdentityResolver
 from jobctrl.model_defaults import DEFAULT_PIPELINE_LLM_MODEL_SPEC
 from jobctrl.infrastructure.profile.factory import get_profile_repository
+from jobctrl.infrastructure.preparation import SqlitePreparationTargetReader
 from jobctrl.infrastructure.scoring import (
     LocalScoringCriteriaProvider,
     SqliteRequirementFitReportRepository,
@@ -86,8 +89,7 @@ class AnalyzeJobUseCaseLike(Protocol):
         job: dict,
         tenant_id: TenantId = LOCAL_TENANT,
         force: bool = False,
-    ) -> Any:
-        ...
+    ) -> Any: ...
 
 
 # ---------------------------------------------------------------------------
@@ -123,11 +125,7 @@ def _build_use_case(
         if requirement_fit_repository is None:
             requirement_fit_repository = SqliteRequirementFitReportRepository(repository.connection)
     if llm_port is None:
-        llm_port = (
-            LlmAdapter(default_model=llm_model)
-            if llm_model
-            else get_llm_adapter()
-        )
+        llm_port = LlmAdapter(default_model=llm_model) if llm_model else get_llm_adapter()
     return ScoreJobUseCase(
         repository=repository,
         llm=llm_port,
@@ -177,13 +175,8 @@ def score_job(
             llm_model=llm_model,
             publisher=publisher,
         )
-    if (
-        employer_analysis is None
-        and (
-            employer_analysis_repository is not None
-            or analyze_use_case is not None
-            or require_employer_analysis
-        )
+    if employer_analysis is None and (
+        employer_analysis_repository is not None or analyze_use_case is not None or require_employer_analysis
     ):
         conn = _analysis_connection_for_repository(repository)
         if employer_analysis_repository is None:
@@ -296,7 +289,13 @@ def run_scoring(
 
     started_ats: dict[str, str] = {}
     for job in jobs:
-        ensure_job_stage_rows(conn, job["url"], discovered_at=job.get("discovered_at"))
+        job_id = canonical_job_id(str(job["job_id"]))
+        ensure_job_stage_rows(
+            conn,
+            job_id,
+            tenant_id=tenant_id,
+            discovered_at=job.get("discovered_at"),
+        )
         started_at = utc_now()
         started_ats[job["url"]] = started_at
         # Runner owns the restart policy: a job that previously failed
@@ -305,16 +304,28 @@ def run_scoring(
         # Pending (via Reset). Skip validation; the writer is the runner.
         set_stage_state(
             conn,
-            job["url"],
+            job_id,
             "score",
             "running",
+            tenant_id=tenant_id,
             # Preserve the attempt counter across re-selection — see
             # _score_attempt_count; a bare running write would reset it to 0.
-            attempt_count=_score_attempt_count(conn, job["url"]),
+            attempt_count=_score_attempt_count(
+                conn,
+                tenant_id=tenant_id,
+                job_id=job_id,
+            ),
             started_at=started_at,
             validate_transition=False,
         )
-        record_job_event(conn, job["url"], "score", "StageStarted", message="Scoring started")
+        record_job_event(
+            conn,
+            job_id,
+            "score",
+            "StageStarted",
+            tenant_id=tenant_id,
+            message="Scoring started",
+        )
 
     reusable_scores = (
         {}
@@ -445,7 +456,9 @@ def run_scoring(
             else:
                 try:
                     outcome = use_case.persist_outcome(
-                        job=job, parse=parse, tenant_id=tenant_id,
+                        job=job,
+                        parse=parse,
+                        tenant_id=tenant_id,
                     )
                 except Exception as exc:  # noqa: BLE001 — surface as a stage failure
                     log.error("Score persistence failed for %r: %s", job.get("title", "?"), exc)
@@ -486,7 +499,10 @@ def run_scoring(
             score_value = outcome.score.fit_score.value if outcome.ok and outcome.score else 0
             log.info(
                 "[%d/%d] score=%d  %s",
-                completed, len(jobs_to_compute), score_value, str(job.get("title", "?"))[:60],
+                completed,
+                len(jobs_to_compute),
+                score_value,
+                str(job.get("title", "?"))[:60],
             )
 
     errors = sum(1 for _, outcome in results if not outcome.ok)
@@ -495,21 +511,24 @@ def run_scoring(
     finished_at = utc_now()
     for job, outcome in results:
         url = job["url"]
+        job_id = canonical_job_id(str(job["job_id"]))
         if outcome.ok and outcome.score is not None:
             set_stage_state(
                 conn,
-                url,
+                job_id,
                 "score",
                 "succeeded",
+                tenant_id=tenant_id,
                 attempt_count=1,
                 started_at=started_ats.get(url),
                 finished_at=finished_at,
             )
             record_job_event(
                 conn,
-                url,
+                job_id,
                 "score",
                 "StageCompleted",
+                tenant_id=tenant_id,
                 message=f"Fit score {outcome.score.fit_score.value}/10",
                 payload={"keywords": list(outcome.score.matched_keywords)},
             )
@@ -523,10 +542,16 @@ def run_scoring(
         else:
             set_stage_state(
                 conn,
-                url,
+                job_id,
                 "score",
                 "failed",
-                attempt_count=_score_attempt_count(conn, url) + 1,
+                tenant_id=tenant_id,
+                attempt_count=_score_attempt_count(
+                    conn,
+                    tenant_id=tenant_id,
+                    job_id=job_id,
+                )
+                + 1,
                 started_at=started_ats.get(url),
                 finished_at=finished_at,
                 error_code="SCORE_FAILED",
@@ -536,9 +561,10 @@ def run_scoring(
             )
             record_job_event(
                 conn,
-                url,
+                job_id,
                 "score",
                 "StageFailed",
+                tenant_id=tenant_id,
                 level="error",
                 message=outcome.error or "Scoring failed",
             )
@@ -547,7 +573,10 @@ def run_scoring(
     elapsed = time.time() - t0
     log.info(
         "Done: %d scored, %d failed in %.1fs (%.1f jobs/sec)",
-        scored_count, errors, elapsed, scored_count / elapsed if elapsed > 0 else 0,
+        scored_count,
+        errors,
+        elapsed,
+        scored_count / elapsed if elapsed > 0 else 0,
     )
 
     distribution = _score_distribution(repository, tenant_id)
@@ -578,7 +607,54 @@ def score_job_by_url(
     analyze_use_case: AnalyzeJobUseCaseLike | None = None,
     require_employer_analysis: bool = True,
 ) -> ScoreJobOutcome:
-    """Score exactly one enriched job by URL.
+    """Resolve one tenant-scoped posting locator, then score its JobId."""
+    conn = get_connection()
+    identity = SqliteJobIdentityResolver(conn).resolve_by_posting_url(
+        tenant_id,
+        PostingUrl(value=job_url),
+    )
+    if identity is None:
+        return ScoreJobOutcome(ok=False, score=None, error=f"Job not found: {job_url}")
+    return score_job_by_id(
+        identity.job_id,
+        tenant_id=tenant_id,
+        rescore=rescore,
+        llm_model=llm_model,
+        profile_snapshot=profile_snapshot,
+        resume_text=resume_text,
+        criteria=criteria,
+        repository=repository,
+        policy_repository=policy_repository,
+        requirement_fit_repository=requirement_fit_repository,
+        llm_port=llm_port,
+        publisher=publisher,
+        employer_analysis=employer_analysis,
+        employer_analysis_repository=employer_analysis_repository,
+        analyze_use_case=analyze_use_case,
+        require_employer_analysis=require_employer_analysis,
+    )
+
+
+def score_job_by_id(
+    job_id: JobId,
+    *,
+    tenant_id: TenantId = LOCAL_TENANT,
+    rescore: bool = False,
+    llm_model: str | None = DEFAULT_PIPELINE_LLM_MODEL_SPEC,
+    profile_snapshot: ProfileSnapshot | None = None,
+    resume_text: str | None = None,
+    criteria: ScoringCriteria | None = None,
+    repository: ScoreRepository | None = None,
+    policy_repository: ScoringPolicyRepository | None = None,
+    requirement_fit_repository: RequirementFitReportRepository | None = None,
+    llm_port: LlmPort | None = None,
+    publisher: EventPublisher | None = None,
+    employer_analysis: EmployerAnalysis | None = None,
+    employer_analysis_repository: EmployerAnalysisRepository | None = None,
+    analyze_use_case: AnalyzeJobUseCaseLike | None = None,
+    require_employer_analysis: bool = True,
+) -> ScoreJobOutcome:
+    """Score exactly one enriched job by tenant-scoped canonical JobId.
 
     Internal Discovery preparation uses per-job workflows keyed to one job, so
     it cannot safely call the batch selector-based ``run_scoring`` helper. This
@@ -586,12 +662,13 @@ def score_job_by_url(
     targeting one workflow step only. ``rescore=True`` forces a new score
     version even when the job already has a current score.
     """
+    stable_job_id = canonical_job_id(str(job_id))
     conn = get_connection()
-    job = load_job_with_enrichment(conn, job_url)
+    job = SqlitePreparationTargetReader(conn).load(tenant_id, stable_job_id)
     if job is None:
-        return ScoreJobOutcome(ok=False, score=None, error=f"Job not found: {job_url}")
+        return ScoreJobOutcome(ok=False, score=None, error=f"Job not found: {stable_job_id}")
     if not job.get("full_description"):
-        return ScoreJobOutcome(ok=False, score=None, error=f"Job is not enriched: {job_url}")
+        return ScoreJobOutcome(ok=False, score=None, error=f"Job is not enriched: {stable_job_id}")
 
     if profile_snapshot is None:
         profile_snapshot = get_profile_repository().load_snapshot(tenant_id)
@@ -606,7 +683,7 @@ def score_job_by_url(
         repository = SqliteScoreRepository(conn)
     if policy_repository is None:
         policy_repository = SqliteScoringPolicyRepository(conn)
-    existing = repository.load(tenant_id, JobId(job_url))
+    existing = repository.load(tenant_id, stable_job_id)
     reusable_repost_score = _preferred_direct_score_for_repost(
         conn=conn,
         job=job,
@@ -616,9 +693,7 @@ def score_job_by_url(
         profile_snapshot=profile_snapshot,
     )
     if reusable_repost_score is not None and (
-        rescore
-        or existing is None
-        or not _scores_equal_for_display(existing, reusable_repost_score)
+        rescore or existing is None or not _scores_equal_for_display(existing, reusable_repost_score)
     ):
         outcome = _persist_reused_score(
             repository=repository,
@@ -657,20 +732,37 @@ def score_job_by_url(
             require=require_employer_analysis,
         )
 
-    ensure_job_stage_rows(conn, job_url, discovered_at=job.get("discovered_at"))
+    ensure_job_stage_rows(
+        conn,
+        stable_job_id,
+        tenant_id=tenant_id,
+        discovered_at=job.get("discovered_at"),
+    )
     started_at = utc_now()
     set_stage_state(
         conn,
-        job_url,
+        stable_job_id,
         "score",
         "running",
+        tenant_id=tenant_id,
         # Preserve the attempt counter across re-selection — see
         # _score_attempt_count; a bare running write would reset it to 0.
-        attempt_count=_score_attempt_count(conn, job_url),
+        attempt_count=_score_attempt_count(
+            conn,
+            tenant_id=tenant_id,
+            job_id=stable_job_id,
+        ),
         started_at=started_at,
         validate_transition=False,
     )
-    record_job_event(conn, job_url, "score", "StageStarted", message="Scoring started")
+    record_job_event(
+        conn,
+        stable_job_id,
+        "score",
+        "StageStarted",
+        tenant_id=tenant_id,
+        message="Scoring started",
+    )
     conn.commit()
 
     outcome = score_job(
@@ -694,18 +786,20 @@ def score_job_by_url(
     if outcome.ok and outcome.score is not None:
         set_stage_state(
             conn,
-            job_url,
+            stable_job_id,
             "score",
             "succeeded",
+            tenant_id=tenant_id,
             attempt_count=1,
             started_at=started_at,
             finished_at=finished_at,
         )
         record_job_event(
             conn,
-            job_url,
+            stable_job_id,
             "score",
             "StageCompleted",
+            tenant_id=tenant_id,
             message=f"Fit score {outcome.score.fit_score.value}/10",
             payload={"keywords": list(outcome.score.matched_keywords)},
         )
@@ -719,23 +813,30 @@ def score_job_by_url(
     else:
         set_stage_state(
             conn,
-            job_url,
+            stable_job_id,
             "score",
             "failed",
-            attempt_count=_score_attempt_count(conn, job_url) + 1,
+            tenant_id=tenant_id,
+            attempt_count=_score_attempt_count(
+                conn,
+                tenant_id=tenant_id,
+                job_id=stable_job_id,
+            )
+            + 1,
             started_at=started_at,
             finished_at=finished_at,
             error_code="SCORE_FAILED",
             error_message=outcome.error or "Scoring failed",
             retryable=True,
-            next_action=f"jobctrl retry score {job_url}",
+            next_action=f"jobctrl retry score {job.get('url') or stable_job_id}",
             validate_transition=False,
         )
         record_job_event(
             conn,
-            job_url,
+            stable_job_id,
             "score",
             "StageFailed",
+            tenant_id=tenant_id,
             level="error",
             message=outcome.error or "Scoring failed",
         )
@@ -750,15 +851,21 @@ def _ensure_existing_score_stage_succeeded(
     score: JobScore,
     tenant_id: TenantId,
 ) -> None:
-    job_url = str(score.job_id)
-    if _has_unresolved_score_staleness(conn, tenant_id=tenant_id, job_url=job_url):
+    job_id = canonical_job_id(str(score.job_id))
+    if _has_unresolved_score_staleness(conn, tenant_id=tenant_id, job_id=job_id):
         return
 
-    ensure_job_stage_rows(conn, job_url, discovered_at=job.get("discovered_at"))
+    ensure_job_stage_rows(
+        conn,
+        job_id,
+        tenant_id=tenant_id,
+        discovered_at=job.get("discovered_at"),
+    )
     row = conn.execute(
         "SELECT state, started_at, attempt_count "
-        "FROM job_stage_states WHERE job_url = ? AND stage = 'score'",
-        (job_url,),
+        "FROM job_stage_states "
+        "WHERE tenant_id = ? AND job_id = ? AND stage = 'score'",
+        (str(tenant_id), str(job_id)),
     ).fetchone()
     state = _row_value(row, "state", 0)
     if state == "succeeded":
@@ -776,9 +883,10 @@ def _ensure_existing_score_stage_succeeded(
     attempt_count = max(int(_row_value(row, "attempt_count", 2) or 0), 1)
     set_stage_state(
         conn,
-        job_url,
+        job_id,
         "score",
         "succeeded",
+        tenant_id=tenant_id,
         attempt_count=attempt_count,
         started_at=str(started_at),
         finished_at=finished_at,
@@ -786,9 +894,10 @@ def _ensure_existing_score_stage_succeeded(
     )
     record_job_event(
         conn,
-        job_url,
+        job_id,
         "score",
         "StageCompleted",
+        tenant_id=tenant_id,
         message=f"Fit score {score.fit_score.value}/10",
         payload={"keywords": list(score.matched_keywords)},
     )
@@ -812,14 +921,20 @@ def _record_score_stage_succeeded(
     finished_at: str | None = None,
     validate_transition: bool = False,
 ) -> None:
-    job_url = str(score.job_id)
+    job_id = canonical_job_id(str(score.job_id))
     finished_at = finished_at or utc_now()
-    ensure_job_stage_rows(conn, job_url, discovered_at=job.get("discovered_at"))
+    ensure_job_stage_rows(
+        conn,
+        job_id,
+        tenant_id=tenant_id,
+        discovered_at=job.get("discovered_at"),
+    )
     set_stage_state(
         conn,
-        job_url,
+        job_id,
         "score",
         "succeeded",
+        tenant_id=tenant_id,
         attempt_count=1,
         started_at=started_at or finished_at,
         finished_at=finished_at,
@@ -827,9 +942,10 @@ def _record_score_stage_succeeded(
     )
     record_job_event(
         conn,
-        job_url,
+        job_id,
         "score",
         "StageCompleted",
+        tenant_id=tenant_id,
         message=f"Fit score {score.fit_score.value}/10",
         payload={"keywords": list(score.matched_keywords)},
         occurred_at=finished_at,
@@ -867,18 +983,18 @@ def _has_unresolved_score_staleness(
     conn: sqlite3.Connection,
     *,
     tenant_id: TenantId,
-    job_url: str,
+    job_id: JobId,
 ) -> bool:
     row = conn.execute(
         """
         SELECT 1
         FROM job_score_staleness
         WHERE tenant_id = ?
-          AND job_url = ?
+          AND job_id = ?
           AND resolved = 0
         LIMIT 1
         """,
-        (str(tenant_id), job_url),
+        (str(tenant_id), str(canonical_job_id(str(job_id)))),
     ).fetchone()
     return row is not None
 
@@ -891,7 +1007,12 @@ def _row_value(row: Any, key: str, index: int) -> Any:
     return row[index]
 
 
-def _score_attempt_count(conn: sqlite3.Connection, job_url: str) -> int:
+def _score_attempt_count(
+    conn: sqlite3.Connection,
+    *,
+    tenant_id: TenantId,
+    job_id: JobId,
+) -> int:
     """Current score-stage attempt count (0 if unrecorded).
 
     ``set_stage_state`` resets ``attempt_count`` to 0 whenever it is
@@ -902,8 +1023,8 @@ def _score_attempt_count(conn: sqlite3.Connection, job_url: str) -> int:
     failing job from re-billing the LLM on every batch.
     """
     row = conn.execute(
-        "SELECT attempt_count FROM job_stage_states WHERE job_url = ? AND stage = 'score'",
-        (job_url,),
+        "SELECT attempt_count FROM job_stage_states WHERE tenant_id = ? AND job_id = ? AND stage = 'score'",
+        (str(tenant_id), str(canonical_job_id(str(job_id)))),
     ).fetchone()
     return int(_row_value(row, "attempt_count", 0) or 0)
 
@@ -940,13 +1061,9 @@ def _ensure_employer_analysis_for_job(
         analysis = getattr(outcome, "analysis", None)
         if _is_usable_employer_analysis(analysis, job):
             return analysis
-        raise ValueError(
-            "Employer analysis did not produce grounded requirements for this job."
-        )
+        raise ValueError("Employer analysis did not produce grounded requirements for this job.")
     if require:
-        raise ValueError(
-            "Scoring requires employer analysis before a fresh score can be computed."
-        )
+        raise ValueError("Scoring requires employer analysis before a fresh score can be computed.")
     return None
 
 
@@ -956,12 +1073,15 @@ def _is_usable_employer_analysis(
 ) -> bool:
     if analysis is None:
         return False
-    job_url = str(job.get("url") or "").strip()
-    if job_url and str(analysis.job_id) != job_url:
+    job_id = canonical_job_id(str(job["job_id"]))
+    tenant_id = TenantId(str(job["tenant_id"]))
+    if analysis.job_id != job_id or analysis.tenant_id != tenant_id:
         log.warning(
-            "Ignoring employer analysis for %s while scoring %s",
+            "Ignoring employer analysis for tenant=%s job=%s while scoring tenant=%s job=%s",
+            analysis.tenant_id,
             analysis.job_id,
-            job_url,
+            tenant_id,
+            job_id,
         )
         return False
     return bool(analysis.canonical.requirements)
@@ -973,10 +1093,8 @@ def _load_employer_analysis_for_job(
     tenant_id: TenantId,
     job: dict[str, Any],
 ) -> EmployerAnalysis | None:
-    job_url = str(job.get("url") or "").strip()
-    if not job_url:
-        return None
-    analysis = repository.load(tenant_id, JobId(job_url))
+    job_id = canonical_job_id(str(job["job_id"]))
+    analysis = repository.load(tenant_id, job_id)
     if not _is_usable_employer_analysis(analysis, job):
         return None
     return analysis
@@ -1032,54 +1150,63 @@ def _preferred_direct_score_for_repost(
 
     if not _is_reference_repost_candidate(conn, job, tenant_id=tenant_id):
         return None
-    deleted_join = (
-        """
-        LEFT JOIN jobctrl_deleted_jobs d
-          ON d.job_url = j.url
-         AND (d.restored_at IS NULL OR julianday(d.restored_at) <= julianday(d.deleted_at))
-        """
-        if _table_exists(conn, "jobctrl_deleted_jobs")
-        else ""
-    )
-    deleted_filter = "AND d.job_url IS NULL" if deleted_join else ""
     rows = conn.execute(
-        f"""
-        SELECT j.url, j.title, j.location,
-               COALESCE(je.application_url, j.application_url) AS application_url,
+        """
+        SELECT j.job_id, j.url, j.title, j.location,
+               je.application_url AS application_url,
                COALESCE(c.ats_kind, 'other') AS ats_kind,
                s.scored_at
         FROM jobs j
-        LEFT JOIN job_enrichments je ON je.job_url = j.url
+        LEFT JOIN job_enrichments je
+          ON je.tenant_id = j.tenant_id
+         AND je.job_id = j.job_id
         LEFT JOIN job_canonical_identities c
-          ON c.tenant_id = ? AND c.job_url = j.url
-        {deleted_join}
+          ON c.tenant_id = j.tenant_id
+         AND c.job_id = j.job_id
+        LEFT JOIN jobctrl_deleted_jobs d
+          ON d.tenant_id = j.tenant_id
+         AND d.job_id = j.job_id
+         AND (
+             d.restored_at IS NULL
+             OR julianday(d.restored_at) <= julianday(d.deleted_at)
+         )
         INNER JOIN (
-            SELECT job_url, MAX(version) AS max_version
+            SELECT tenant_id, job_id, MAX(version) AS max_version
             FROM job_scores
             WHERE tenant_id = ?
-            GROUP BY job_url
-        ) latest ON latest.job_url = j.url
+            GROUP BY tenant_id, job_id
+        ) latest
+          ON latest.tenant_id = j.tenant_id
+         AND latest.job_id = j.job_id
         INNER JOIN job_scores s
-          ON s.tenant_id = ?
-         AND s.job_url = latest.job_url
+          ON s.tenant_id = latest.tenant_id
+         AND s.job_id = latest.job_id
          AND s.version = latest.max_version
-        WHERE j.url != ?
-          {deleted_filter}
+        WHERE j.tenant_id = ?
+          AND j.job_id != ?
+          AND d.job_id IS NULL
           AND (
-            COALESCE(je.application_url, j.application_url, '') != ''
+            COALESCE(je.application_url, '') != ''
             OR COALESCE(c.ats_kind, 'other') != 'other'
           )
         ORDER BY
           CASE WHEN COALESCE(c.ats_kind, 'other') != 'other' THEN 0 ELSE 1 END,
           s.scored_at DESC
         """,
-        (str(tenant_id), str(tenant_id), str(tenant_id), str(job.get("url") or "")),
+        (
+            str(tenant_id),
+            str(tenant_id),
+            str(canonical_job_id(str(job["job_id"]))),
+        ),
     ).fetchall()
     for row in rows:
         candidate = dict(row)
         if not _same_reference_repost_opportunity(job, candidate):
             continue
-        score = repository.load(tenant_id, JobId(str(candidate["url"])))
+        score = repository.load(
+            tenant_id,
+            canonical_job_id(str(candidate["job_id"])),
+        )
         if score is None:
             continue
         if not _score_matches_context(
@@ -1102,18 +1229,16 @@ def _is_reference_repost_candidate(
         return False
     if not role_title_has_reference_suffix(job.get("title")):
         return False
-    job_url = str(job.get("url") or "")
-    if not job_url:
-        return False
+    job_id = canonical_job_id(str(job["job_id"]))
     row = conn.execute(
         """
         SELECT ats_kind
         FROM job_canonical_identities
-        WHERE tenant_id = ? AND job_url = ?
+        WHERE tenant_id = ? AND job_id = ?
         ORDER BY confidence DESC
         LIMIT 1
         """,
-        (str(tenant_id), job_url),
+        (str(tenant_id), str(job_id)),
     ).fetchone()
     if row is None:
         return True
@@ -1139,14 +1264,6 @@ def _scores_equal_for_display(left: JobScore, right: JobScore) -> bool:
     )
 
 
-def _table_exists(conn: sqlite3.Connection, table_name: str) -> bool:
-    row = conn.execute(
-        "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ? LIMIT 1",
-        (table_name,),
-    ).fetchone()
-    return row is not None
-
-
 def _score_content_key(job: dict[str, Any]) -> str | None:
     return job_content_fingerprint(
         title=job.get("title"),
@@ -1170,20 +1287,24 @@ def _reusable_scores_by_content_key(
         return {}
     rows = conn.execute(
         """
-        SELECT j.url, j.title, j.company,
-               COALESCE(je.full_description, j.full_description) AS full_description
+        SELECT j.job_id, j.url, j.title, j.company, je.full_description
         FROM jobs j
-        LEFT JOIN job_enrichments je ON je.job_url = j.url
+        INNER JOIN job_enrichments je
+          ON je.tenant_id = j.tenant_id
+         AND je.job_id = j.job_id
         INNER JOIN (
-            SELECT s.job_url, MAX(s.version) AS max_version
+            SELECT s.tenant_id, s.job_id, MAX(s.version) AS max_version
             FROM job_scores s
             WHERE s.tenant_id = ?
-            GROUP BY s.job_url
-        ) latest ON latest.job_url = j.url
+            GROUP BY s.tenant_id, s.job_id
+        ) latest
+          ON latest.tenant_id = j.tenant_id
+         AND latest.job_id = j.job_id
         INNER JOIN job_scores s
-            ON s.job_url = latest.job_url
+            ON s.tenant_id = latest.tenant_id
+           AND s.job_id = latest.job_id
            AND s.version = latest.max_version
-           AND s.tenant_id = ?
+        WHERE j.tenant_id = ?
         ORDER BY s.scored_at DESC
         """,
         (str(tenant_id), str(tenant_id)),
@@ -1195,7 +1316,10 @@ def _reusable_scores_by_content_key(
         key = _score_content_key(job)
         if key is None or key not in wanted_keys or key in reusable:
             continue
-        score = repository.load(tenant_id, JobId(str(job["url"])))
+        score = repository.load(
+            tenant_id,
+            canonical_job_id(str(job["job_id"])),
+        )
         if score is None or not _score_matches_context(
             score=score,
             criteria=criteria,
@@ -1226,7 +1350,7 @@ def _persist_reused_score(
     job: dict[str, Any],
     source_score: JobScore,
 ) -> ScoreJobOutcome:
-    job_id = JobId(str(job["url"]))
+    job_id = canonical_job_id(str(job["job_id"]))
     previous = repository.load(tenant_id, job_id)
     scored_at = utc_now()
     if previous is None:

--- a/workers/automation/src/jobctrl/scoring/tailor.py
+++ b/workers/automation/src/jobctrl/scoring/tailor.py
@@ -788,14 +788,20 @@ def _reconcile_score_eligibility_skip(
     if eligibility.status != "blocked" and not eligibility.hard_blockers:
         return False
     row = conn.execute(
-        "SELECT discovered_at FROM jobs WHERE url = ?",
-        (job_url,),
+        "SELECT discovered_at FROM jobs WHERE tenant_id = ? AND job_id = ?",
+        (str(tenant_id), str(score.job_id)),
     ).fetchone()
     discovered_at = row["discovered_at"] if row is not None else None
-    ensure_job_stage_rows(conn, job_url, discovered_at=discovered_at)
+    ensure_job_stage_rows(
+        conn,
+        score.job_id,
+        tenant_id=tenant_id,
+        discovered_at=discovered_at,
+    )
     reconcile_score_eligibility_blockers(
         conn,
-        job_url=job_url,
+        tenant_id=tenant_id,
+        job_id=score.job_id,
         eligibility_status=eligibility.status,
         hard_blockers=list(eligibility.hard_blockers),
     )

--- a/workers/automation/src/jobctrl/scoring/tailor.py
+++ b/workers/automation/src/jobctrl/scoring/tailor.py
@@ -93,9 +93,7 @@ def _build_llm_policy(
     configured_models = config.get_tailoring_generator_models()
     configured_judge_model = config.get_tailoring_judge_model()
     judge_min_score = (
-        config.get_tailoring_judge_min_score()
-        if tailor_judge_min_score is None
-        else tailor_judge_min_score
+        config.get_tailoring_judge_min_score() if tailor_judge_min_score is None else tailor_judge_min_score
     )
     return TailoringLlmPolicy(
         candidate_models=tailor_models or configured_models or ((llm_model,) if llm_model else ()),
@@ -168,9 +166,7 @@ def _build_use_case(
     if policy_repository is None:
         policy_repository = SqliteTailoringPolicyRepository(conn)
     if provenance_repository is None:
-        provenance_repository = SqliteBulletProvenanceRepository(
-            conn, unit_of_work=unit_of_work
-        )
+        provenance_repository = SqliteBulletProvenanceRepository(conn, unit_of_work=unit_of_work)
     if requirement_fit_repository is None:
         requirement_fit_repository = SqliteRequirementFitReportRepository(conn)
     if llm_port is None:
@@ -247,8 +243,7 @@ def _mark_cover_pending_after_tailor_success(
         sort_keys=True,
     )
     conn.execute(
-        "UPDATE jobs SET cover_letter_path = NULL, cover_letter_at = NULL, cover_attempts = 0 "
-        "WHERE url = ?",
+        "UPDATE jobs SET cover_letter_path = NULL, cover_letter_at = NULL, cover_attempts = 0 WHERE url = ?",
         (job_url,),
     )
     conn.execute(
@@ -419,6 +414,7 @@ def run_tailoring(
     """
     if snapshot is None:
         from jobctrl.infrastructure.profile import get_profile_repository
+
         snapshot = get_profile_repository().load_snapshot(tenant_id)
 
     conn = get_connection()
@@ -516,8 +512,13 @@ def run_tailoring(
                 result = future.result()
             except Exception as e:
                 result = {
-                    "url": job["url"], "title": job["title"], "site": job.get("site"),
-                    "status": "error", "attempts": 0, "path": None, "pdf_path": None,
+                    "url": job["url"],
+                    "title": job["title"],
+                    "site": job.get("site"),
+                    "status": "error",
+                    "attempts": 0,
+                    "path": None,
+                    "pdf_path": None,
                     "materials": None,
                 }
                 log.error("%d/%d [ERROR] %s -- %s", completed, len(jobs), job["title"][:40], e)
@@ -529,7 +530,8 @@ def run_tailoring(
             rate = completed / elapsed if elapsed > 0 else 0
             log.info(
                 "%d/%d [%s] attempts=%s | %.1f jobs/min | %s",
-                completed, len(jobs),
+                completed,
+                len(jobs),
                 str(result.get("status", "error")).upper(),
                 result.get("attempts", "?"),
                 rate * 60,
@@ -570,10 +572,7 @@ def run_tailoring(
                 reason="tailor_stage_completed",
             )
         else:
-            exhausted = (
-                attempts >= config.DEFAULTS["max_tailor_attempts"]
-                or r.get("status") == "exhausted_retries"
-            )
+            exhausted = attempts >= config.DEFAULTS["max_tailor_attempts"] or r.get("status") == "exhausted_retries"
             set_stage_state(
                 conn,
                 url,
@@ -587,9 +586,7 @@ def run_tailoring(
                 error_message=f"Tailoring ended with status {r.get('status', 'error')}",
                 retryable=True,
                 next_action=(
-                    f"jobctrl retry tailor {url} --reset-attempts"
-                    if exhausted
-                    else f"jobctrl retry tailor {url}"
+                    f"jobctrl retry tailor {url} --reset-attempts" if exhausted else f"jobctrl retry tailor {url}"
                 ),
             )
             record_job_event(
@@ -740,10 +737,7 @@ def tailor_job_by_url(
             reason="tailor_stage_completed",
         )
     else:
-        exhausted = (
-            attempts >= config.DEFAULTS["max_tailor_attempts"]
-            or result.get("status") == "exhausted_retries"
-        )
+        exhausted = attempts >= config.DEFAULTS["max_tailor_attempts"] or result.get("status") == "exhausted_retries"
         set_stage_state(
             conn,
             job_url,
@@ -757,9 +751,7 @@ def tailor_job_by_url(
             error_message=f"Tailoring ended with status {result.get('status', 'error')}",
             retryable=True,
             next_action=(
-                f"jobctrl retry tailor {job_url} --reset-attempts"
-                if exhausted
-                else f"jobctrl retry tailor {job_url}"
+                f"jobctrl retry tailor {job_url} --reset-attempts" if exhausted else f"jobctrl retry tailor {job_url}"
             ),
             validate_transition=False,
         )

--- a/workers/automation/src/jobctrl/state.py
+++ b/workers/automation/src/jobctrl/state.py
@@ -495,18 +495,25 @@ def reconcile_dependency_blockers(
 def reconcile_score_eligibility_blockers(
     conn,
     *,
-    job_url: str,
+    tenant_id: TenantId,
+    job_id: JobId,
     eligibility_status: str | None,
     hard_blockers: list[str] | tuple[str, ...] | None = None,
     now: str | None = None,
 ) -> int:
     """Keep downstream stage rows aligned with score hard-blocker eligibility."""
+    stable_job_id = canonical_job_id(str(job_id))
     blockers = _clean_blocker_reasons(hard_blockers)
     blocked = str(eligibility_status or "").strip().lower() == "blocked" or bool(blockers)
     updated_at = now or utc_now()
 
     if not blocked:
-        return _clear_score_eligibility_blockers(conn, job_url=job_url, now=updated_at)
+        return _clear_score_eligibility_blockers(
+            conn,
+            tenant_id=tenant_id,
+            job_id=stable_job_id,
+            now=updated_at,
+        )
 
     reason = ", ".join(blockers) if blockers else str(eligibility_status or "blocked")
     message = f"{SCORE_ELIGIBILITY_BLOCKED_MESSAGE_PREFIX}: {reason}"
@@ -515,10 +522,11 @@ def reconcile_score_eligibility_blockers(
         f"""
         SELECT stage, state, attempt_count
           FROM job_stage_states
-         WHERE job_url = ?
+         WHERE tenant_id = ?
+           AND job_id = ?
            AND stage IN ({", ".join("?" for _ in _SCORE_ELIGIBILITY_DOWNSTREAM_STAGES)})
         """,
-        (job_url, *_SCORE_ELIGIBILITY_DOWNSTREAM_STAGES),
+        (str(tenant_id), str(stable_job_id), *_SCORE_ELIGIBILITY_DOWNSTREAM_STAGES),
     ).fetchall()
     for row in rows:
         stage = str(row["stage"])
@@ -528,9 +536,10 @@ def reconcile_score_eligibility_blockers(
         attempt_count = int(row["attempt_count"] or 0)
         set_stage_state(
             conn,
-            job_url,
+            stable_job_id,
             stage,
             "blocked",
+            tenant_id=tenant_id,
             attempt_count=attempt_count,
             error_code=SCORE_ELIGIBILITY_BLOCKED_ERROR_CODE,
             error_message=message,
@@ -545,9 +554,10 @@ def reconcile_score_eligibility_blockers(
         )
         record_job_event(
             conn,
-            job_url,
+            stable_job_id,
             stage,
             "StageBlocked",
+            tenant_id=tenant_id,
             level="warning",
             message=message,
             occurred_at=updated_at,
@@ -562,28 +572,49 @@ def reconcile_score_eligibility_blockers(
     return changed
 
 
-def _clear_score_eligibility_blockers(conn, *, job_url: str, now: str) -> int:
+def _clear_score_eligibility_blockers(
+    conn,
+    *,
+    tenant_id: TenantId,
+    job_id: JobId,
+    now: str,
+) -> int:
     rows = conn.execute(
         """
         SELECT stage, attempt_count
           FROM job_stage_states
-         WHERE job_url = ?
+         WHERE tenant_id = ?
+           AND job_id = ?
            AND state = 'blocked'
            AND error_code = ?
         """,
-        (job_url, SCORE_ELIGIBILITY_BLOCKED_ERROR_CODE),
+        (str(tenant_id), str(job_id), SCORE_ELIGIBILITY_BLOCKED_ERROR_CODE),
     ).fetchall()
     cleared = 0
     for row in rows:
         stage = str(row["stage"])
         attempt_count = int(row["attempt_count"] or 0)
-        restored = _restored_state_after_score_eligibility_cleared(conn, job_url=job_url, stage=stage)
-        set_stage_state(conn, job_url, stage, attempt_count=attempt_count, validate_transition=False, **restored)
+        restored = _restored_state_after_score_eligibility_cleared(
+            conn,
+            tenant_id=tenant_id,
+            job_id=job_id,
+            stage=stage,
+        )
+        set_stage_state(
+            conn,
+            job_id,
+            stage,
+            tenant_id=tenant_id,
+            attempt_count=attempt_count,
+            validate_transition=False,
+            **restored,
+        )
         record_job_event(
             conn,
-            job_url,
+            job_id,
             stage,
             "StageReset",
+            tenant_id=tenant_id,
             message=f"{stage} unblocked after score eligibility cleared.",
             occurred_at=now,
             payload={
@@ -596,13 +627,19 @@ def _clear_score_eligibility_blockers(conn, *, job_url: str, now: str) -> int:
     return cleared
 
 
-def _restored_state_after_score_eligibility_cleared(conn, *, job_url: str, stage: str) -> dict[str, Any]:
+def _restored_state_after_score_eligibility_cleared(
+    conn,
+    *,
+    tenant_id: TenantId,
+    job_id: JobId,
+    stage: str,
+) -> dict[str, Any]:
     if stage == "tailor":
         return {"state": "pending"}
     if stage == "cover":
         return (
             {"state": "pending"}
-            if _stage_is_succeeded(conn, job_url=job_url, stage="tailor")
+            if _stage_is_succeeded(conn, tenant_id=tenant_id, job_id=job_id, stage="tailor")
             else {
                 "state": "blocked",
                 "error_code": "BLOCKED",
@@ -612,7 +649,7 @@ def _restored_state_after_score_eligibility_cleared(conn, *, job_url: str, stage
     if stage == "apply":
         return (
             {"state": "pending"}
-            if _stage_is_succeeded(conn, job_url=job_url, stage="tailor")
+            if _stage_is_succeeded(conn, tenant_id=tenant_id, job_id=job_id, stage="tailor")
             else {
                 "state": "blocked",
                 "error_code": "BLOCKED",
@@ -622,10 +659,16 @@ def _restored_state_after_score_eligibility_cleared(conn, *, job_url: str, stage
     return {"state": "pending"}
 
 
-def _stage_is_succeeded(conn, *, job_url: str, stage: str) -> bool:
+def _stage_is_succeeded(
+    conn,
+    *,
+    tenant_id: TenantId,
+    job_id: JobId,
+    stage: str,
+) -> bool:
     row = conn.execute(
-        "SELECT state FROM job_stage_states WHERE job_url = ? AND stage = ?",
-        (job_url, stage),
+        "SELECT state FROM job_stage_states WHERE tenant_id = ? AND job_id = ? AND stage = ?",
+        (str(tenant_id), str(job_id), stage),
     ).fetchone()
     return bool(row and str(row["state"]) == "succeeded")
 

--- a/workers/automation/tests/test_analyze_job_use_case.py
+++ b/workers/automation/tests/test_analyze_job_use_case.py
@@ -8,9 +8,11 @@ generation versioning (D-13), grounding re-validation before persist, and the
 
 from __future__ import annotations
 
+import uuid
+
 import pytest
 
-from jobctrl.domain.identifiers import JobId
+from jobctrl.domain.identifiers import JobId, canonical_job_id
 from jobctrl.domain.materials.analysis import (
     AnalysisAgreement,
     EmployerAnalysis,
@@ -23,8 +25,14 @@ from jobctrl.domain.materials.analysis import (
 from jobctrl.domain.materials.analyze_use_case import AnalyzeJobUseCase, build_jd_snapshot
 from jobctrl.domain.tenant import LOCAL_TENANT
 
+def _job_id_for(url: str) -> JobId:
+    return canonical_job_id(str(uuid.uuid5(uuid.NAMESPACE_URL, url)))
+
+
+_JOB_URL = "https://example.com/jobs/staff"
 JOB = {
-    "url": "https://example.com/jobs/staff",
+    "job_id": str(_job_id_for(_JOB_URL)),
+    "url": _JOB_URL,
     "title": "Staff Engineer",
     "full_description": "Requires 8+ years in Go. Kafka is a plus.",
 }
@@ -140,9 +148,21 @@ class TestAnalyzeJobUseCase:
 
         assert result.cached is False
         assert result.analysis.generation == 1
+        assert result.analysis.job_id == JobId(JOB["job_id"])
+        assert result.analysis.job_id != JobId(JOB["url"])
         assert calls["count"] == 1
         assert len(repo.saved) == 1
         assert any(getattr(e, "event_type", "") == "EmployerAnalyzed" for e in publisher.events)
+
+    async def test_url_shaped_job_id_is_rejected_before_analysis(self) -> None:
+        runner, calls = _runner_returning(_outcome())
+        use_case = _use_case(repo=_InMemoryRepo(), runner=runner)
+        job = {**JOB, "job_id": JOB["url"]}
+
+        with pytest.raises(ValueError, match="canonical UUID"):
+            await use_case.execute_async(job=job, tenant_id=LOCAL_TENANT)
+
+        assert calls["count"] == 0
 
     async def test_second_run_same_snapshot_hits_cache_and_skips_ensemble(self) -> None:
         repo = _InMemoryRepo()
@@ -169,7 +189,7 @@ class TestAnalyzeJobUseCase:
         assert forced.analysis.generation == 2
         assert calls["count"] == 2
         # Prior generation retained as audit history (D-13).
-        assert repo.load(LOCAL_TENANT, JobId(JOB["url"]), generation=1) is not None
+        assert repo.load(LOCAL_TENANT, JobId(JOB["job_id"]), generation=1) is not None
 
     async def test_degraded_ensemble_is_persisted_with_completeness(self) -> None:
         from jobctrl.domain.materials.analysis import AnalysisFailure
@@ -222,8 +242,10 @@ class TestAnalyzeJobUseCase:
         # (formatting-tolerant) AND snap, so the saved record's spans are the JD's
         # verbatim text (D-15) even if a runner skipped snapping.
         repo = _InMemoryRepo()
+        job_url = "https://example.com/jobs/soc"
         job = {
-            "url": "https://example.com/jobs/soc",
+            "job_id": str(_job_id_for(job_url)),
+            "url": job_url,
             "title": "Head of Security Operations",
             "full_description": "You will run a high‑availability SOC and own IR.",
         }
@@ -267,8 +289,10 @@ class TestAnalyzeJobUseCase:
         # The runner returns a canonical that carries a protected-class
         # requirement whose evidence span IS grounded in the JD — so only the
         # EEO screen (not grounding) can stop it reaching the persisted record.
+        job_url = "https://example.com/jobs/grad"
         job = {
-            "url": "https://example.com/jobs/grad",
+            "job_id": str(_job_id_for(job_url)),
+            "url": job_url,
             "title": "Engineer",
             "full_description": "Requires 8+ years in Go. Seeking a recent grad.",
         }

--- a/workers/automation/tests/test_analyze_job_use_case.py
+++ b/workers/automation/tests/test_analyze_job_use_case.py
@@ -25,6 +25,7 @@ from jobctrl.domain.materials.analysis import (
 from jobctrl.domain.materials.analyze_use_case import AnalyzeJobUseCase, build_jd_snapshot
 from jobctrl.domain.tenant import LOCAL_TENANT
 
+
 def _job_id_for(url: str) -> JobId:
     return canonical_job_id(str(uuid.uuid5(uuid.NAMESPACE_URL, url)))
 
@@ -103,9 +104,7 @@ def _outcome(role: str = "Own the platform.", *, drafts=1, attempted=2, failures
     canonical = _canonical(role)
     return EnsembleOutcome(
         canonical=canonical,
-        drafts=tuple(
-            JobAnalysisDraft(model_id=f"m{i}", **canonical.model_dump()) for i in range(drafts)
-        ),
+        drafts=tuple(JobAnalysisDraft(model_id=f"m{i}", **canonical.model_dump()) for i in range(drafts)),
         failures=failures,
         agreement=AnalysisAgreement(score=1.0),
         legs_attempted=attempted,
@@ -214,9 +213,7 @@ class TestAnalyzeJobUseCase:
             inferred_seniority="staff",
             ideal_candidate_narrative="y",
             requirements=[
-                Requirement(
-                    id="r1", text="Rust", tier="must_have", weight=0.5, evidence_span="ten years of Rust"
-                )
+                Requirement(id="r1", text="Rust", tier="must_have", weight=0.5, evidence_span="ten years of Rust")
             ],
             keywords=[],
         )
@@ -262,11 +259,7 @@ class TestAnalyzeJobUseCase:
                     evidence_span="high-availability SOC",  # ASCII hyphen
                 )
             ],
-            keywords=[
-                ReasonedKeyword(
-                    keyword="HA", evidence_span="high-availability", requirement_ref="r1"
-                )
-            ],
+            keywords=[ReasonedKeyword(keyword="HA", evidence_span="high-availability", requirement_ref="r1")],
         )
         outcome = EnsembleOutcome(
             canonical=ascii_canonical,

--- a/workers/automation/tests/test_score_eligibility_stage_state.py
+++ b/workers/automation/tests/test_score_eligibility_stage_state.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 import sqlite3
-from pathlib import Path
 
 import pytest
 
-from jobctrl.database import init_db
+from jobctrl.domain.identifiers import JobId, canonical_job_id
+from jobctrl.domain.tenant import TenantId
+from jobctrl.infrastructure.migrations.schema_v7 import create_exact_v7_schema
 from jobctrl.state import (
     SCORE_ELIGIBILITY_BLOCKED_ERROR_CODE,
     ensure_job_stage_rows,
@@ -13,34 +14,81 @@ from jobctrl.state import (
     set_stage_state,
 )
 
+_TENANT_A = TenantId("tenant-a")
+_TENANT_B = TenantId("tenant-b")
+_JOB_ID = canonical_job_id("00000000-0000-4000-8000-000000000001")
+
 
 @pytest.fixture()
-def conn(tmp_path: Path) -> sqlite3.Connection:
-    return init_db(tmp_path / "jobctrl.db")
+def conn() -> sqlite3.Connection:
+    candidate = sqlite3.connect(":memory:")
+    candidate.row_factory = sqlite3.Row
+    candidate.execute("PRAGMA foreign_keys = ON")
+    create_exact_v7_schema(candidate)
+    return candidate
 
 
-def _seed_scored_job(conn: sqlite3.Connection, url: str) -> None:
+def _seed_scored_job(
+    conn: sqlite3.Connection,
+    *,
+    tenant_id: TenantId,
+    job_id: JobId,
+    url: str,
+) -> None:
     conn.execute(
         """
-        INSERT INTO jobs (url, title, site, full_description, discovered_at)
-        VALUES (?, ?, ?, ?, ?)
+        INSERT INTO jobs (
+            tenant_id, job_id, url, title, company, full_description, discovered_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?)
         """,
-        (url, "Engineer", "Acme", "Need Python.", "2024-01-01T00:00:00+00:00"),
+        (
+            str(tenant_id),
+            str(job_id),
+            url,
+            "Engineer",
+            "Acme",
+            "Need Python.",
+            "2024-01-01T00:00:00+00:00",
+        ),
     )
-    ensure_job_stage_rows(conn, url, discovered_at="2024-01-01T00:00:00+00:00")
-    set_stage_state(conn, url, "enrich", "succeeded", validate_transition=False)
-    set_stage_state(conn, url, "score", "succeeded", validate_transition=False)
+    ensure_job_stage_rows(
+        conn,
+        job_id,
+        tenant_id=tenant_id,
+        discovered_at="2024-01-01T00:00:00+00:00",
+    )
+    set_stage_state(
+        conn,
+        job_id,
+        "enrich",
+        "succeeded",
+        tenant_id=tenant_id,
+        validate_transition=False,
+    )
+    set_stage_state(
+        conn,
+        job_id,
+        "score",
+        "succeeded",
+        tenant_id=tenant_id,
+        validate_transition=False,
+    )
     conn.commit()
 
 
-def _stage_rows(conn: sqlite3.Connection, url: str) -> dict[str, sqlite3.Row]:
+def _stage_rows(
+    conn: sqlite3.Connection,
+    *,
+    tenant_id: TenantId,
+    job_id: JobId,
+) -> dict[str, sqlite3.Row]:
     rows = conn.execute(
         """
         SELECT stage, state, error_code, error_message, retryable, blocked_by_json
         FROM job_stage_states
-        WHERE job_url = ?
+        WHERE tenant_id = ? AND job_id = ?
         """,
-        (url,),
+        (str(tenant_id), str(job_id)),
     ).fetchall()
     return {str(row["stage"]): row for row in rows}
 
@@ -49,18 +97,19 @@ def test_score_eligibility_blocker_blocks_actionable_downstream_stages(
     conn: sqlite3.Connection,
 ) -> None:
     url = "https://example.com/job/blocked"
-    _seed_scored_job(conn, url)
+    _seed_scored_job(conn, tenant_id=_TENANT_A, job_id=_JOB_ID, url=url)
 
     changed = reconcile_score_eligibility_blockers(
         conn,
-        job_url=url,
+        tenant_id=_TENANT_A,
+        job_id=_JOB_ID,
         eligibility_status="blocked",
         hard_blockers=["posted compensation appears below profile minimum"],
         now="2024-01-02T00:00:00+00:00",
     )
 
     assert changed == 3
-    rows = _stage_rows(conn, url)
+    rows = _stage_rows(conn, tenant_id=_TENANT_A, job_id=_JOB_ID)
     for stage in ("tailor", "cover", "apply"):
         row = rows[stage]
         assert row["state"] == "blocked"
@@ -72,27 +121,56 @@ def test_score_eligibility_blocker_blocks_actionable_downstream_stages(
 
 def test_score_eligibility_clear_restores_dependency_states(conn: sqlite3.Connection) -> None:
     url = "https://example.com/job/cleared"
-    _seed_scored_job(conn, url)
+    _seed_scored_job(conn, tenant_id=_TENANT_A, job_id=_JOB_ID, url=url)
     reconcile_score_eligibility_blockers(
         conn,
-        job_url=url,
+        tenant_id=_TENANT_A,
+        job_id=_JOB_ID,
         eligibility_status="blocked",
         hard_blockers=["candidate requires sponsorship"],
     )
 
     changed = reconcile_score_eligibility_blockers(
         conn,
-        job_url=url,
+        tenant_id=_TENANT_A,
+        job_id=_JOB_ID,
         eligibility_status="eligible",
         hard_blockers=[],
         now="2024-01-03T00:00:00+00:00",
     )
 
     assert changed == 3
-    rows = _stage_rows(conn, url)
+    rows = _stage_rows(conn, tenant_id=_TENANT_A, job_id=_JOB_ID)
     assert rows["tailor"]["state"] == "pending"
     assert rows["tailor"]["error_code"] is None
     assert rows["cover"]["state"] == "blocked"
     assert rows["cover"]["error_message"] == "tailor has not completed."
     assert rows["apply"]["state"] == "blocked"
     assert rows["apply"]["error_message"] == "Materials are not ready."
+
+
+def test_score_eligibility_blockers_are_tenant_scoped(conn: sqlite3.Connection) -> None:
+    _seed_scored_job(
+        conn,
+        tenant_id=_TENANT_A,
+        job_id=_JOB_ID,
+        url="https://example.com/job/tenant-a",
+    )
+    _seed_scored_job(
+        conn,
+        tenant_id=_TENANT_B,
+        job_id=_JOB_ID,
+        url="https://example.com/job/tenant-b",
+    )
+
+    changed = reconcile_score_eligibility_blockers(
+        conn,
+        tenant_id=_TENANT_A,
+        job_id=_JOB_ID,
+        eligibility_status="blocked",
+        hard_blockers=["candidate requires sponsorship"],
+    )
+
+    assert changed == 3
+    assert _stage_rows(conn, tenant_id=_TENANT_A, job_id=_JOB_ID)["tailor"]["state"] == "blocked"
+    assert _stage_rows(conn, tenant_id=_TENANT_B, job_id=_JOB_ID)["tailor"]["state"] == "pending"

--- a/workers/automation/tests/test_scorer.py
+++ b/workers/automation/tests/test_scorer.py
@@ -8,6 +8,7 @@ through the ``ScoreRepository`` adapter — never to the legacy
 from __future__ import annotations
 
 import sqlite3
+import uuid
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
@@ -147,11 +148,42 @@ def _stub_default_analyzer(monkeypatch) -> None:
     )
 
 
+def _job_id(url: str) -> JobId:
+    return JobId(str(uuid.uuid5(uuid.NAMESPACE_URL, url)))
+
+
+def _stage_row(conn: sqlite3.Connection, url: str, stage: str) -> sqlite3.Row | None:
+    return conn.execute(
+        """
+        SELECT states.*
+        FROM job_stage_states states
+        JOIN jobs
+          ON jobs.tenant_id = states.tenant_id
+         AND jobs.job_id = states.job_id
+        WHERE jobs.tenant_id = ? AND jobs.url = ? AND states.stage = ?
+        """,
+        (LOCAL_TENANT, url, stage),
+    ).fetchone()
+
+
 def _seed_pending_job(conn: sqlite3.Connection, url: str) -> None:
+    job_id = _job_id(url)
     conn.execute(
-        "INSERT INTO jobs (url, title, site, full_description, discovered_at) "
-        "VALUES (?, ?, ?, ?, ?)",
-        (url, "Engineer", "Acme", "Need Python.", "2024-01-01T00:00:00+00:00"),
+        "INSERT INTO jobs (tenant_id, job_id, url, title, site, discovered_at) "
+        "VALUES (?, ?, ?, ?, ?, ?)",
+        (LOCAL_TENANT, job_id, url, "Engineer", "Acme", "2024-01-01T00:00:00+00:00"),
+    )
+    conn.execute(
+        "INSERT INTO job_enrichments "
+        "(tenant_id, job_id, current_status, full_description, updated_at) "
+        "VALUES (?, ?, 'enriched', 'Need Python.', ?)",
+        (LOCAL_TENANT, job_id, "2024-01-01T00:00:00+00:00"),
+    )
+    conn.execute(
+        "INSERT INTO job_locators "
+        "(tenant_id, job_id, locator_kind, locator_value, is_current, first_seen_at, last_seen_at) "
+        "VALUES (?, ?, 'posting_url', ?, 1, ?, ?)",
+        (LOCAL_TENANT, job_id, url, "2024-01-01T00:00:00+00:00", "2024-01-01T00:00:00+00:00"),
     )
     conn.commit()
 
@@ -180,7 +212,7 @@ def _employer_analysis(job_url: str) -> EmployerAnalysis:
     )
     return EmployerAnalysis.build(
         tenant_id=LOCAL_TENANT,
-        job_id=JobId(job_url),
+        job_id=_job_id(job_url),
         generation=1,
         snapshot_hash=compute_snapshot_hash("Need Python."),
         canonical=canonical,
@@ -202,10 +234,23 @@ def _seed_pending_job_with_description(
     location: str = "Remote",
     application_url: str | None = None,
 ) -> None:
+    job_id = _job_id(url)
     conn.execute(
-        "INSERT INTO jobs (url, title, company, site, location, full_description, discovered_at, application_url) "
+        "INSERT INTO jobs (tenant_id, job_id, url, title, company, site, location, discovered_at) "
         "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-        (url, title, company, "linkedin", location, description, discovered_at, application_url),
+        (LOCAL_TENANT, job_id, url, title, company, "linkedin", location, discovered_at),
+    )
+    conn.execute(
+        "INSERT INTO job_enrichments "
+        "(tenant_id, job_id, current_status, full_description, application_url, updated_at) "
+        "VALUES (?, ?, 'enriched', ?, ?, ?)",
+        (LOCAL_TENANT, job_id, description, application_url, discovered_at),
+    )
+    conn.execute(
+        "INSERT INTO job_locators "
+        "(tenant_id, job_id, locator_kind, locator_value, is_current, first_seen_at, last_seen_at) "
+        "VALUES (?, ?, 'posting_url', ?, 1, ?, ?)",
+        (LOCAL_TENANT, job_id, url, discovered_at, discovered_at),
     )
     conn.commit()
 
@@ -252,7 +297,9 @@ def test_score_job_writes_only_to_job_scores(
         }
     )
 
-    job_dict = dict(conn.execute("SELECT * FROM jobs WHERE url=?", (url,)).fetchone())
+    job_dict = dict(
+        conn.execute("SELECT * FROM jobs WHERE tenant_id = ? AND url = ?", (LOCAL_TENANT, url)).fetchone()
+    )
     outcome = scorer_module.score_job(
         profile_snapshot,
         job_dict,
@@ -262,14 +309,14 @@ def test_score_job_writes_only_to_job_scores(
     assert outcome.ok is True
 
     # New path persisted into job_scores.
-    persisted = repo.load(LOCAL_TENANT, JobId(url))
+    persisted = repo.load(LOCAL_TENANT, _job_id(url))
     assert persisted is not None
     assert persisted.fit_score.value == 8
 
     # Legacy ``jobs.fit_score`` was NOT written by the new path.
     legacy_row = conn.execute(
-        "SELECT fit_score, score_reasoning, scored_at FROM jobs WHERE url=?",
-        (url,),
+        "SELECT fit_score, score_reasoning, scored_at FROM jobs WHERE tenant_id = ? AND url = ?",
+        (LOCAL_TENANT, url),
     ).fetchone()
     assert legacy_row["fit_score"] is None
     assert legacy_row["score_reasoning"] is None
@@ -303,7 +350,9 @@ def test_score_job_with_explicit_sqlite_repository_uses_persisted_policy(
         }
     )
 
-    job_dict = dict(conn.execute("SELECT * FROM jobs WHERE url=?", (url,)).fetchone())
+    job_dict = dict(
+        conn.execute("SELECT * FROM jobs WHERE tenant_id = ? AND url = ?", (LOCAL_TENANT, url)).fetchone()
+    )
     outcome = scorer_module.score_job(
         profile_snapshot,
         job_dict,
@@ -312,7 +361,7 @@ def test_score_job_with_explicit_sqlite_repository_uses_persisted_policy(
     )
 
     assert outcome.ok is True
-    persisted = repo.load(LOCAL_TENANT, JobId(url))
+    persisted = repo.load(LOCAL_TENANT, _job_id(url))
     assert persisted is not None
     assert persisted.fit_score.value == 1
     assert persisted.trace.scoring_policy_id == "local:scoring-policy-v2"
@@ -333,7 +382,7 @@ def test_score_job_by_url_repairs_existing_score_stage_state(
     repo = SqliteScoreRepository(conn)
     existing = JobScore.initial(
         tenant_id=LOCAL_TENANT,
-        job_id=JobId(url),
+        job_id=_job_id(url),
         fit_score=FitScore.create(8),
         breakdown=ScoreBreakdown(reasoning="persisted before stage repair"),
         matched_keywords=MatchedKeywords.from_iterable(["python"]),
@@ -342,7 +391,7 @@ def test_score_job_by_url_repairs_existing_score_stage_state(
     repo.save(existing)
     set_stage_state(
         conn,
-        url,
+        _job_id(url),
         "score",
         "failed",
         error_code="SCORE_FAILED",
@@ -374,16 +423,21 @@ def test_score_job_by_url_repairs_existing_score_stage_state(
     assert outcome.score is not None
     assert outcome.score.fit_score.value == 8
     assert llm.calls == 0
-    stage_row = conn.execute(
-        "SELECT state, error_code, error_message "
-        "FROM job_stage_states WHERE job_url = ? AND stage = 'score'",
-        (url,),
-    ).fetchone()
+    stage_row = _stage_row(conn, url, "score")
     assert stage_row["state"] == "succeeded"
     assert stage_row["error_code"] is None
     assert stage_row["error_message"] is None
     events = conn.execute(
-        "SELECT event_type FROM job_events WHERE job_url = ? AND stage = 'score'",
+        """
+        SELECT event_type
+        FROM job_events
+        WHERE tenant_id = 'local'
+          AND job_id = (
+            SELECT job_id FROM jobs
+            WHERE tenant_id = 'local' AND url = ?
+          )
+          AND stage = 'score'
+        """,
         (url,),
     ).fetchall()
     assert [row["event_type"] for row in events] == ["StageCompleted"]
@@ -400,7 +454,7 @@ def test_score_job_by_url_syncs_existing_blocked_score_to_downstream_stages(
     repo.save(
         JobScore.initial(
             tenant_id=LOCAL_TENANT,
-            job_id=JobId(url),
+            job_id=_job_id(url),
             fit_score=FitScore.create(9),
             breakdown=ScoreBreakdown(
                 reasoning="persisted blocked score",
@@ -428,9 +482,14 @@ def test_score_job_by_url_syncs_existing_blocked_score_to_downstream_stages(
     rows = conn.execute(
         """
         SELECT stage, state, error_code, error_message
-        FROM job_stage_states
-        WHERE job_url = ? AND stage IN ('tailor', 'cover', 'apply')
-        ORDER BY stage
+        FROM job_stage_states states
+        JOIN jobs
+          ON jobs.tenant_id = states.tenant_id
+         AND jobs.job_id = states.job_id
+        WHERE jobs.tenant_id = 'local'
+          AND jobs.url = ?
+          AND states.stage IN ('tailor', 'cover', 'apply')
+        ORDER BY states.stage
         """,
         (url,),
     ).fetchall()
@@ -473,8 +532,16 @@ def test_score_job_by_url_reuses_direct_score_for_reference_repost(
     conn.execute(
         """
         INSERT INTO job_canonical_identities (
-            tenant_id, job_url, canonical_url, ats_kind, source_native_id, confidence, resolved_at
-        ) VALUES ('local', ?, ?, 'workday', 'AI-Security-Director_R53680', 0.82, ?)
+            tenant_id, job_id, canonical_url, ats_kind, source_native_id, confidence, resolved_at
+        ) VALUES (
+            'local',
+            (SELECT job_id FROM jobs WHERE tenant_id = 'local' AND url = ?),
+            ?,
+            'workday',
+            'AI-Security-Director_R53680',
+            0.82,
+            ?
+        )
         """,
         (
             direct_url,
@@ -486,7 +553,7 @@ def test_score_job_by_url_reuses_direct_score_for_reference_repost(
     repo.save(
         JobScore.initial(
             tenant_id=LOCAL_TENANT,
-            job_id=JobId(direct_url),
+            job_id=_job_id(direct_url),
             fit_score=FitScore.create(9),
             breakdown=ScoreBreakdown(reasoning="Direct canonical score."),
             matched_keywords=MatchedKeywords.from_iterable(["AI Security"]),
@@ -521,14 +588,19 @@ def test_score_job_by_url_reuses_direct_score_for_reference_repost(
 
     assert outcome.ok is True
     assert llm.calls == 0
-    repost_score = repo.load(LOCAL_TENANT, JobId(repost_url))
+    repost_score = repo.load(LOCAL_TENANT, _job_id(repost_url))
     assert repost_score is not None
     assert repost_score.fit_score.value == 9
     event = conn.execute(
         """
         SELECT event_type, message
         FROM job_events
-        WHERE job_url = ? AND stage = 'score'
+        WHERE tenant_id = 'local'
+          AND job_id = (
+            SELECT job_id FROM jobs
+            WHERE tenant_id = 'local' AND url = ?
+          )
+          AND stage = 'score'
         ORDER BY event_id DESC
         LIMIT 1
         """,
@@ -543,19 +615,14 @@ def test_score_job_prompt_uses_company_not_source(
     profile_snapshot,
 ) -> None:
     url = "https://example.com/job/company"
-    conn.execute(
-        "INSERT INTO jobs (url, title, company, site, full_description, discovered_at) "
-        "VALUES (?, ?, ?, ?, ?, ?)",
-        (
-            url,
-            "Director, Security Engineering",
-            "Auctane",
-            "linkedin",
-            "Lead security engineering teams.",
-            "2024-01-01T00:00:00+00:00",
-        ),
+    _seed_pending_job_with_description(
+        conn,
+        url=url,
+        title="Director, Security Engineering",
+        company="Auctane",
+        description="Lead security engineering teams.",
+        discovered_at="2024-01-01T00:00:00+00:00",
     )
-    conn.commit()
     repo = SqliteScoreRepository(conn)
     llm = _ScriptedLlm(
         {
@@ -568,7 +635,18 @@ def test_score_job_prompt_uses_company_not_source(
         }
     )
 
-    job_dict = dict(conn.execute("SELECT * FROM jobs WHERE url=?", (url,)).fetchone())
+    job_dict = dict(
+        conn.execute(
+            """
+            SELECT jobs.*, je.full_description
+            FROM jobs
+            JOIN job_enrichments je
+              ON je.tenant_id = jobs.tenant_id AND je.job_id = jobs.job_id
+            WHERE jobs.tenant_id = ? AND jobs.url = ?
+            """,
+            (LOCAL_TENANT, url),
+        ).fetchone()
+    )
     outcome = scorer_module.score_job(
         profile_snapshot,
         job_dict,
@@ -620,21 +698,18 @@ def test_run_scoring_persists_via_repository_only(
     assert summary["distribution"] == [(7, 1)]
 
     # New aggregate persisted.
-    loaded = repo.load(LOCAL_TENANT, JobId(url))
+    loaded = repo.load(LOCAL_TENANT, _job_id(url))
     assert loaded is not None and loaded.fit_score.value == 7
 
     # Legacy ``jobs`` columns untouched.
     legacy = conn.execute(
-        "SELECT fit_score, scored_at FROM jobs WHERE url=?", (url,)
+        "SELECT fit_score, scored_at FROM jobs WHERE tenant_id = ? AND url = ?", (LOCAL_TENANT, url)
     ).fetchone()
     assert legacy["fit_score"] is None
     assert legacy["scored_at"] is None
 
     # Stage state row reflects success.
-    stage_row = conn.execute(
-        "SELECT state FROM job_stage_states WHERE job_url=? AND stage='score'",
-        (url,),
-    ).fetchone()
+    stage_row = _stage_row(conn, url, "score")
     assert stage_row["state"] == "succeeded"
 
 
@@ -679,7 +754,7 @@ def test_run_scoring_loads_and_persists_local_scoring_criteria(
 
     assert summary["scored"] == 1
     assert provider.loaded is True
-    loaded = repo.load(LOCAL_TENANT, JobId(url))
+    loaded = repo.load(LOCAL_TENANT, _job_id(url))
     assert loaded is not None
     assert loaded.criteria.criteria_text == "Favor platform reliability leadership."
     assert loaded.criteria.target_criteria == "Remote infrastructure roles."
@@ -735,7 +810,7 @@ def test_run_scoring_loads_persisted_employer_analysis_into_prompt(
     assert "REQUIREMENT FIT INPUTS" in prompt_payload
     assert '"id": "req-python-platform"' in prompt_payload
     assert '"employer_analysis_generation": 1' in prompt_payload
-    report = SqliteRequirementFitReportRepository(conn).load(LOCAL_TENANT, JobId(url))
+    report = SqliteRequirementFitReportRepository(conn).load(LOCAL_TENANT, _job_id(url))
     assert report is not None
     assert report.score_version == 1
     assert report.employer_analysis_generation == 1
@@ -792,7 +867,7 @@ def test_run_scoring_generates_employer_analysis_before_prompt(
     prompt_payload = llm.messages[0][1].content
     assert "REQUIREMENT FIT INPUTS" in prompt_payload
     assert '"id": "req-python-platform"' in prompt_payload
-    report = SqliteRequirementFitReportRepository(conn).load(LOCAL_TENANT, JobId(url))
+    report = SqliteRequirementFitReportRepository(conn).load(LOCAL_TENANT, _job_id(url))
     assert report is not None
     assert report.employer_analysis_generation == 1
 
@@ -830,11 +905,7 @@ def test_run_scoring_fails_before_llm_when_employer_analysis_fails(
     assert summary["errors"] == 1
     assert analyze.calls == 1
     assert llm.calls == 0
-    stage_row = conn.execute(
-        "SELECT state, error_code, error_message "
-        "FROM job_stage_states WHERE job_url = ? AND stage = 'score'",
-        (url,),
-    ).fetchone()
+    stage_row = _stage_row(conn, url, "score")
     assert stage_row["state"] == "failed"
     assert stage_row["error_code"] == "SCORE_FAILED"
     assert "analysis unavailable" in stage_row["error_message"]
@@ -895,8 +966,8 @@ def test_run_scoring_reuses_same_content_score_for_duplicate_jobs(
     assert summary["scored"] == 2
     assert summary["errors"] == 0
     assert llm.calls == 1
-    first_score = repo.load(LOCAL_TENANT, JobId(first_url))
-    duplicate_score = repo.load(LOCAL_TENANT, JobId(duplicate_url))
+    first_score = repo.load(LOCAL_TENANT, _job_id(first_url))
+    duplicate_score = repo.load(LOCAL_TENANT, _job_id(duplicate_url))
     assert first_score is not None and first_score.fit_score.value == 9
     assert duplicate_score is not None and duplicate_score.fit_score.value == 9
 
@@ -963,7 +1034,7 @@ def test_run_scoring_reuses_existing_same_content_score_without_llm(
     assert summary["scored"] == 1
     assert summary["errors"] == 0
     assert second_llm.calls == 0
-    pending_score = repo.load(LOCAL_TENANT, JobId(pending_url))
+    pending_score = repo.load(LOCAL_TENANT, _job_id(pending_url))
     assert pending_score is not None and pending_score.fit_score.value == 9
 
 
@@ -995,8 +1066,16 @@ def test_run_scoring_reuses_direct_score_for_reference_repost_without_llm(
     conn.execute(
         """
         INSERT INTO job_canonical_identities (
-            tenant_id, job_url, canonical_url, ats_kind, source_native_id, confidence, resolved_at
-        ) VALUES ('local', ?, ?, 'workday', 'AI-Security-Director_R53680', 0.82, ?)
+            tenant_id, job_id, canonical_url, ats_kind, source_native_id, confidence, resolved_at
+        ) VALUES (
+            'local',
+            (SELECT job_id FROM jobs WHERE tenant_id = 'local' AND url = ?),
+            ?,
+            'workday',
+            'AI-Security-Director_R53680',
+            0.82,
+            ?
+        )
         """,
         (
             direct_url,
@@ -1008,7 +1087,7 @@ def test_run_scoring_reuses_direct_score_for_reference_repost_without_llm(
     repo.save(
         JobScore.initial(
             tenant_id=LOCAL_TENANT,
-            job_id=JobId(direct_url),
+            job_id=_job_id(direct_url),
             fit_score=FitScore.create(9),
             breakdown=ScoreBreakdown(reasoning="Direct canonical score."),
             matched_keywords=MatchedKeywords.from_iterable(["AI Security"]),
@@ -1043,7 +1122,7 @@ def test_run_scoring_reuses_direct_score_for_reference_repost_without_llm(
     assert summary["scored"] == 1
     assert summary["errors"] == 0
     assert llm.calls == 0
-    repost_score = repo.load(LOCAL_TENANT, JobId(repost_url))
+    repost_score = repo.load(LOCAL_TENANT, _job_id(repost_url))
     assert repost_score is not None
     assert repost_score.fit_score.value == 9
 
@@ -1074,12 +1153,9 @@ def test_run_scoring_records_failure_state_when_llm_returns_garbage(
     )
     assert summary["scored"] == 0
     assert summary["errors"] == 1
-    assert repo.load(LOCAL_TENANT, JobId(url)) is None
+    assert repo.load(LOCAL_TENANT, _job_id(url)) is None
 
-    stage_row = conn.execute(
-        "SELECT state, error_message FROM job_stage_states WHERE job_url=? AND stage='score'",
-        (url,),
-    ).fetchone()
+    stage_row = _stage_row(conn, url, "score")
     assert stage_row["state"] == "failed"
     assert "outside" in (stage_row["error_message"] or "").lower()
 
@@ -1126,8 +1202,8 @@ def test_run_scoring_preselects_retrieval_top_k_before_llm(
 
     assert summary["scored"] == 1
     assert summary["errors"] == 0
-    assert repo.load(LOCAL_TENANT, JobId(relevant_url)) is not None
-    assert repo.load(LOCAL_TENANT, JobId(stale_irrelevant_url)) is None
+    assert repo.load(LOCAL_TENANT, _job_id(relevant_url)) is not None
+    assert repo.load(LOCAL_TENANT, _job_id(stale_irrelevant_url)) is None
 
 
 # ---------------------------------------------------------------------------
@@ -1138,10 +1214,7 @@ def test_run_scoring_preselects_retrieval_top_k_before_llm(
 
 
 def _score_attempt_count(conn: sqlite3.Connection, url: str) -> int:
-    row = conn.execute(
-        "SELECT attempt_count FROM job_stage_states WHERE job_url=? AND stage='score'",
-        (url,),
-    ).fetchone()
+    row = _stage_row(conn, url, "score")
     return int(row["attempt_count"]) if row is not None else 0
 
 

--- a/workers/automation/tests/test_v7_score_runtime.py
+++ b/workers/automation/tests/test_v7_score_runtime.py
@@ -250,6 +250,83 @@ def test_score_by_id_blocks_downstream_stages_for_hard_blocker(
         assert state_by_stage[stage] == ("blocked", "SCORE_ELIGIBILITY_BLOCKED")
 
 
+def test_existing_score_repairs_stage_only_when_not_stale(
+    conn: sqlite3.Connection,
+) -> None:
+    _seed_target(conn, tenant_id=_TENANT_A, job_id=_JOB_ID_A)
+    llm = _StrongLlm()
+    first = _score_by_id(
+        conn,
+        tenant_id=_TENANT_A,
+        job_id=_JOB_ID_A,
+        llm=llm,
+    )
+    assert first.ok is True
+
+    conn.execute(
+        """
+        UPDATE job_stage_states
+        SET state = 'failed', finished_at = NULL
+        WHERE tenant_id = ? AND job_id = ? AND stage = 'score'
+        """,
+        (str(_TENANT_A), str(_JOB_ID_A)),
+    )
+    conn.commit()
+    reused = _score_by_id(
+        conn,
+        tenant_id=_TENANT_A,
+        job_id=_JOB_ID_A,
+        llm=llm,
+    )
+    assert reused.ok is True
+    assert llm.calls == 1
+    repaired_state = conn.execute(
+        """
+        SELECT state
+        FROM job_stage_states
+        WHERE tenant_id = ? AND job_id = ? AND stage = 'score'
+        """,
+        (str(_TENANT_A), str(_JOB_ID_A)),
+    ).fetchone()
+    assert repaired_state["state"] == "succeeded"
+
+    conn.execute(
+        """
+        UPDATE job_stage_states
+        SET state = 'stale', finished_at = NULL
+        WHERE tenant_id = ? AND job_id = ? AND stage = 'score'
+        """,
+        (str(_TENANT_A), str(_JOB_ID_A)),
+    )
+    conn.execute(
+        """
+        INSERT INTO job_score_staleness (
+            tenant_id, job_id, stale_reason, old_policy_version,
+            new_policy_version, marked_at
+        ) VALUES (?, ?, 'policy_changed', 1, 2, '2026-07-30T11:00:00+00:00')
+        """,
+        (str(_TENANT_A), str(_JOB_ID_A)),
+    )
+    conn.commit()
+    still_stale = _score_by_id(
+        conn,
+        tenant_id=_TENANT_A,
+        job_id=_JOB_ID_A,
+        llm=llm,
+    )
+    assert still_stale.ok is True
+    assert llm.calls == 1
+    stale_state = conn.execute(
+        """
+        SELECT state
+        FROM job_stage_states
+        WHERE tenant_id = ? AND job_id = ? AND stage = 'score'
+        """,
+        (str(_TENANT_A), str(_JOB_ID_A)),
+    ).fetchone()
+    assert stale_state["state"] == "stale"
+
+
 def test_score_by_id_rejects_url_shaped_identity_before_llm(
     conn: sqlite3.Connection,
 ) -> None:

--- a/workers/automation/tests/test_v7_score_runtime.py
+++ b/workers/automation/tests/test_v7_score_runtime.py
@@ -1,0 +1,299 @@
+"""Exact-v7 integration tests for per-job scoring runtime identity."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from jobctrl.database import init_db
+from jobctrl.domain.events.materials import (
+    EmployerAnalyzedPayload,
+    create_employer_analyzed,
+)
+from jobctrl.domain.identifiers import JobId, canonical_job_id
+from jobctrl.domain.profile.aggregate import Profile
+from jobctrl.domain.profile.snapshot import ProfileSnapshot
+from jobctrl.domain.scoring import ScoringCriteria
+from jobctrl.domain.tenant import TenantId
+from jobctrl.infrastructure.scoring import SqliteScoreRepository
+from jobctrl.scoring import scorer as scorer_module
+from jobctrl.scoring.employer_analysis import EmployerAnalyzedEventRecorder
+
+
+_TENANT_A = TenantId("tenant-a")
+_TENANT_B = TenantId("tenant-b")
+_JOB_ID_A = canonical_job_id("10000000-0000-4000-8000-000000000001")
+_JOB_ID_B = canonical_job_id("20000000-0000-4000-8000-000000000002")
+_POSTING_URL = "https://jobs.example.test/roles/platform-engineer"
+
+
+class _StrongLlm:
+    model = "test-model"
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def chat_json(self, *_args, **_kwargs) -> dict:
+        self.calls += 1
+        return {
+            "score": 8,
+            "technical_fit": 8,
+            "experience_fit": 8,
+            "role_fit": 8,
+            "fit_band": "strong",
+            "confidence": "high",
+            "eligibility": {
+                "status": "eligible",
+                "hard_blockers": [],
+                "warnings": [],
+            },
+            "matched_signals": ["Python"],
+            "missing_signals": [],
+            "transferable_signals": [],
+            "keywords": ["python"],
+            "reasoning": "Strong fit.",
+        }
+
+
+class _BlockedLlm(_StrongLlm):
+    def chat_json(self, *_args, **_kwargs) -> dict:
+        payload = super().chat_json(*_args, **_kwargs)
+        payload["eligibility"] = {
+            "status": "blocked",
+            "hard_blockers": ["Work authorization required."],
+            "warnings": [],
+        }
+        return payload
+
+
+@pytest.fixture()
+def conn(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> sqlite3.Connection:
+    connection = init_db(tmp_path / "jobctrl-v7.db")
+    monkeypatch.setattr(scorer_module, "get_connection", lambda: connection)
+    return connection
+
+
+def _profile_snapshot(tenant_id: TenantId) -> ProfileSnapshot:
+    profile = Profile.from_dict(
+        tenant_id,
+        {
+            "personal": {"full_name": "Candidate"},
+            "resume": {
+                "executive_profile": {"baseline_text": "Python platform engineer."},
+                "experience_entries": [
+                    {
+                        "id": "platform",
+                        "title": "Platform Engineer",
+                        "company": "Previous Co",
+                        "bullets": ["Built Python services."],
+                    }
+                ],
+                "education_entries": [],
+                "skill_categories": [],
+            },
+        },
+    )
+    return ProfileSnapshot.from_profile(profile)
+
+
+def _seed_target(
+    conn: sqlite3.Connection,
+    *,
+    tenant_id: TenantId,
+    job_id: JobId,
+    posting_url: str = _POSTING_URL,
+) -> None:
+    now = "2026-07-30T10:00:00+00:00"
+    conn.execute(
+        """
+        INSERT INTO jobs (
+            tenant_id, job_id, url, title, company, location, site,
+            strategy, discovered_at
+        ) VALUES (?, ?, ?, 'Platform Engineer', 'Acme', 'Remote',
+                  'example', 'search', ?)
+        """,
+        (str(tenant_id), str(job_id), posting_url, now),
+    )
+    conn.execute(
+        """
+        INSERT INTO job_locators (
+            tenant_id, job_id, locator_kind, locator_value, is_current,
+            first_seen_at, last_seen_at
+        ) VALUES (?, ?, 'posting_url', ?, 1, ?, ?)
+        """,
+        (str(tenant_id), str(job_id), posting_url, now, now),
+    )
+    conn.execute(
+        """
+        INSERT INTO job_enrichments (
+            tenant_id, job_id, current_status, full_description,
+            enriched_at, extraction_tier, updated_at
+        ) VALUES (?, ?, 'enriched', 'Build Python platform services.', ?,
+                  'high', ?)
+        """,
+        (str(tenant_id), str(job_id), now, now),
+    )
+    conn.commit()
+
+
+def _score_by_id(
+    conn: sqlite3.Connection,
+    *,
+    tenant_id: TenantId,
+    job_id: JobId,
+    llm: _StrongLlm,
+):
+    return scorer_module.score_job_by_id(
+        job_id,
+        tenant_id=tenant_id,
+        profile_snapshot=_profile_snapshot(tenant_id),
+        resume_text="Python platform engineer.",
+        criteria=ScoringCriteria(),
+        repository=SqliteScoreRepository(conn),
+        llm_port=llm,
+        require_employer_analysis=False,
+    )
+
+
+def test_score_by_id_isolates_same_job_id_across_tenants(
+    conn: sqlite3.Connection,
+) -> None:
+    _seed_target(conn, tenant_id=_TENANT_A, job_id=_JOB_ID_A)
+    _seed_target(conn, tenant_id=_TENANT_B, job_id=_JOB_ID_A)
+    llm = _StrongLlm()
+
+    outcome = _score_by_id(
+        conn,
+        tenant_id=_TENANT_A,
+        job_id=_JOB_ID_A,
+        llm=llm,
+    )
+
+    assert outcome.ok is True
+    assert outcome.score is not None
+    assert outcome.score.job_id == _JOB_ID_A
+    assert llm.calls == 1
+    assert SqliteScoreRepository(conn).load(_TENANT_A, _JOB_ID_A) is not None
+    assert SqliteScoreRepository(conn).load(_TENANT_B, _JOB_ID_A) is None
+    stage_rows = conn.execute(
+        """
+        SELECT tenant_id, job_id, state
+        FROM job_stage_states
+        WHERE stage = 'score'
+        ORDER BY tenant_id
+        """
+    ).fetchall()
+    assert [(row["tenant_id"], row["job_id"], row["state"]) for row in stage_rows] == [
+        (str(_TENANT_A), str(_JOB_ID_A), "succeeded"),
+    ]
+    event = conn.execute(
+        """
+        SELECT tenant_id, job_id, identity_version
+        FROM job_events
+        WHERE event_type = 'StageCompleted'
+        """
+    ).fetchone()
+    assert tuple(event) == (str(_TENANT_A), str(_JOB_ID_A), 1)
+
+
+def test_url_adapter_resolves_locator_inside_requested_tenant(
+    conn: sqlite3.Connection,
+) -> None:
+    _seed_target(conn, tenant_id=_TENANT_A, job_id=_JOB_ID_A)
+    _seed_target(conn, tenant_id=_TENANT_B, job_id=_JOB_ID_B)
+
+    outcome = scorer_module.score_job_by_url(
+        _POSTING_URL,
+        tenant_id=_TENANT_B,
+        profile_snapshot=_profile_snapshot(_TENANT_B),
+        resume_text="Python platform engineer.",
+        criteria=ScoringCriteria(),
+        repository=SqliteScoreRepository(conn),
+        llm_port=_StrongLlm(),
+        require_employer_analysis=False,
+    )
+
+    assert outcome.ok is True
+    assert outcome.score is not None
+    assert outcome.score.job_id == _JOB_ID_B
+    assert SqliteScoreRepository(conn).load(_TENANT_A, _JOB_ID_A) is None
+    assert SqliteScoreRepository(conn).load(_TENANT_B, _JOB_ID_B) is not None
+
+
+def test_score_by_id_blocks_downstream_stages_for_hard_blocker(
+    conn: sqlite3.Connection,
+) -> None:
+    _seed_target(conn, tenant_id=_TENANT_A, job_id=_JOB_ID_A)
+
+    outcome = _score_by_id(
+        conn,
+        tenant_id=_TENANT_A,
+        job_id=_JOB_ID_A,
+        llm=_BlockedLlm(),
+    )
+
+    assert outcome.ok is True
+    rows = conn.execute(
+        """
+        SELECT stage, state, error_code
+        FROM job_stage_states
+        WHERE tenant_id = ? AND job_id = ?
+        ORDER BY stage
+        """,
+        (str(_TENANT_A), str(_JOB_ID_A)),
+    ).fetchall()
+    state_by_stage = {row["stage"]: (row["state"], row["error_code"]) for row in rows}
+    assert state_by_stage["score"] == ("succeeded", None)
+    for stage in ("tailor", "cover", "apply"):
+        assert state_by_stage[stage] == ("blocked", "SCORE_ELIGIBILITY_BLOCKED")
+
+
+def test_score_by_id_rejects_url_shaped_identity_before_llm(
+    conn: sqlite3.Connection,
+) -> None:
+    llm = _StrongLlm()
+
+    with pytest.raises(ValueError, match="canonical UUID"):
+        _score_by_id(
+            conn,
+            tenant_id=_TENANT_A,
+            job_id=JobId(_POSTING_URL),
+            llm=llm,
+        )
+
+    assert llm.calls == 0
+
+
+def test_employer_analysis_event_preserves_tenant_and_job_id(
+    conn: sqlite3.Connection,
+) -> None:
+    event = create_employer_analyzed(
+        _TENANT_B,
+        EmployerAnalyzedPayload(
+            job_id=str(_JOB_ID_B),
+            generation=2,
+            snapshot_hash="snapshot",
+            cache_key="cache-key",
+            legs_attempted=3,
+            legs_succeeded=2,
+            analyzed_at="2026-07-30T10:00:00+00:00",
+        ),
+    )
+
+    EmployerAnalyzedEventRecorder(conn, stage="score").publish(event)
+
+    row = conn.execute(
+        """
+        SELECT tenant_id, job_id, stage, event_type
+        FROM job_events
+        WHERE event_type = 'EmployerAnalyzed'
+        """
+    ).fetchone()
+    assert tuple(row) == (
+        str(_TENANT_B),
+        str(_JOB_ID_B),
+        "score",
+        "EmployerAnalyzed",
+    )


### PR DESCRIPTION
## Summary

- run the preparation score activity through an exact tenant-scoped JobId entrypoint
- key score stage state, eligibility, staleness, employer analysis, repost reuse, and events by canonical identity
- keep posting URLs only as active locator inputs at the external adapter boundary
- add exact-v7 runtime regressions for tenant isolation, hard blockers, stage repair, staleness, and event identity

## Why

The v7 repositories and preparation workflow already use canonical JobId, but the executable score runner still treated posting URLs as stored identity. This closes the per-job runtime path without adding a compatibility layer.

## Validation

- 82 focused tests passed
- reviewer gate: PASS
- QA gate: PASS
- Ruff, compileall, and git diff checks passed

## Stack

Depends on #621. Batch selectors and the tailor/cover runtime are intentionally separate follow-up PRs.