### PR TITLE
refactor(materials): tailor jobs by canonical id

### DIFF
--- a/workers/automation/src/jobctrl/domain/materials/quality.py
+++ b/workers/automation/src/jobctrl/domain/materials/quality.py
@@ -12,6 +12,7 @@ from collections import Counter
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
+from jobctrl.domain.identifiers import canonical_job_id
 from jobctrl.domain.materials.analysis import EmployerAnalysis
 from jobctrl.domain.materials.policy import (
     RequirementLedTailoringControls,
@@ -986,8 +987,8 @@ def _requirement_fit_report_matches(
 ) -> bool:
     if requirement_fit_report is None:
         return False
-    job_url = str(job.get("url") or "").strip()
-    if job_url and str(getattr(requirement_fit_report, "job_id", "") or "") != job_url:
+    job_id = canonical_job_id(str(job["job_id"]))
+    if getattr(requirement_fit_report, "job_id", None) != job_id:
         return False
     generation = int(getattr(requirement_fit_report, "employer_analysis_generation", 0) or 0)
     return generation == employer_analysis.generation

--- a/workers/automation/src/jobctrl/domain/materials/requirement_coverage.py
+++ b/workers/automation/src/jobctrl/domain/materials/requirement_coverage.py
@@ -9,6 +9,7 @@ from collections.abc import Mapping as MappingABC
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
+from jobctrl.domain.identifiers import canonical_job_id
 from jobctrl.domain.materials.analysis import EmployerAnalysis
 from jobctrl.domain.materials.policy import RequirementLedTailoringControls
 
@@ -728,7 +729,7 @@ def build_target_profile(
     nice_to_have = tuple(requirement for requirement in requirements if requirement.tier != "must_have")
     job_skills = _clean_string_tuple(job.get("skills", ()))
     return TargetProfile(
-        job_id=str(job.get("url") or getattr(requirement_fit_report, "job_id", "") or ""),
+        job_id=str(canonical_job_id(str(job["job_id"]))),
         target_role=str(job.get("title") or job.get("role_title") or ""),
         seniority=str(employer_analysis.canonical.inferred_seniority or ""),
         must_have_requirements=must_have,

--- a/workers/automation/src/jobctrl/domain/materials/use_cases.py
+++ b/workers/automation/src/jobctrl/domain/materials/use_cases.py
@@ -56,7 +56,7 @@ from jobctrl.domain.events import (
     create_resume_approved,
     create_resume_failed,
 )
-from jobctrl.domain.identifiers import JobId
+from jobctrl.domain.identifiers import JobId, canonical_job_id
 from jobctrl.domain.materials.aggregate import (
     MaterialsLifecycle,
     MaterialsSet,
@@ -1564,6 +1564,7 @@ class TailorResumeUseCase:
         self,
         *,
         job: dict,
+        job_id: JobId | None = None,
         profile_snapshot: ProfileSnapshot,
         tailored_dir: Path,
         validation_mode: str = "normal",
@@ -1573,7 +1574,8 @@ class TailorResumeUseCase:
         employer_analysis: EmployerAnalysis | None = None,
         requirement_fit_report: "RequirementFitReport | None" = None,
     ) -> TailorOutcome:
-        job_id = JobId(str(job["url"]))
+        stable_job_id = job_id if job_id is not None else job.get("job_id")
+        job_id = canonical_job_id(str(stable_job_id))
         # D-20: run/reuse the canonical employer analysis as the front-half
         # sub-step of tailor (cache-backed, so a re-tailor reuses it). The
         # analysis drives keyword selection in ``build_tailoring_plan``.

--- a/workers/automation/src/jobctrl/materials/activities.py
+++ b/workers/automation/src/jobctrl/materials/activities.py
@@ -306,7 +306,7 @@ def _limited_job_urls(job_urls: tuple[str, ...], limit: int) -> tuple[str, ...]:
 
 @activity.defn(name="tailor_job")
 async def tailor_job_activity(payload: TailorJobActivityInput) -> TailorJobActivityOutput:
-    """Tailor one job by URL for ``JobPreparationWorkflow``."""
+    """Tailor one canonical JobId for ``JobPreparationWorkflow``."""
     from jobctrl.infrastructure.temporal.run_in_activity import run_blocking_with_heartbeat
 
     try:
@@ -335,9 +335,9 @@ async def tailor_job_activity(payload: TailorJobActivityInput) -> TailorJobActiv
 
 def _tailor_one_job(payload: TailorJobActivityInput) -> dict[str, Any]:
     from jobctrl.domain.tenant import TenantId
-    from jobctrl.scoring.tailor import tailor_job_by_url
+    from jobctrl.scoring.tailor import tailor_job_by_id
 
-    return tailor_job_by_url(
+    return tailor_job_by_id(
         payload.job_id,
         min_score=payload.min_score,
         validation_mode=payload.validation_mode,

--- a/workers/automation/src/jobctrl/scoring/tailor.py
+++ b/workers/automation/src/jobctrl/scoring/tailor.py
@@ -982,6 +982,69 @@ def _load_tailor_eligible_job_by_id(
     stable_job_id = canonical_job_id(str(job_id))
     if not str(job.get("full_description") or "").strip():
         return None
+    score_stage = conn.execute(
+        """
+        SELECT state
+        FROM job_stage_states
+        WHERE tenant_id = ? AND job_id = ? AND stage = 'score'
+        """,
+        (str(tenant_id), str(stable_job_id)),
+    ).fetchone()
+    if score_stage is not None and str(score_stage["state"]) != "succeeded":
+        return None
+    if conn.execute(
+        """
+        SELECT 1
+        FROM job_score_staleness
+        WHERE tenant_id = ? AND job_id = ? AND resolved = 0
+        LIMIT 1
+        """,
+        (str(tenant_id), str(stable_job_id)),
+    ).fetchone() is not None:
+        return None
+    posting_state = conn.execute(
+        """
+        SELECT latest_active_state, latest_confidence, latest_quarantine_reason
+        FROM posting_snapshot_sets
+        WHERE tenant_id = ? AND job_id = ?
+        """,
+        (str(tenant_id), str(stable_job_id)),
+    ).fetchone()
+    if posting_state is not None:
+        active_state = str(posting_state["latest_active_state"] or "").lower()
+        if active_state in {
+            "closed",
+            "expired",
+            "removed",
+            "location_incompatible",
+        }:
+            return None
+        confidence = str(posting_state["latest_confidence"] or "").lower()
+        quarantine_reason = str(
+            posting_state["latest_quarantine_reason"] or ""
+        ).lower()
+        if confidence == "low" and quarantine_reason not in {"", "none"}:
+            return None
+    tailor_stage = conn.execute(
+        """
+        SELECT state, attempt_count
+        FROM job_stage_states
+        WHERE tenant_id = ? AND job_id = ? AND stage = 'tailor'
+        """,
+        (str(tenant_id), str(stable_job_id)),
+    ).fetchone()
+    if tailor_stage is not None:
+        tailor_state = str(tailor_stage["state"])
+        attempt_count = int(tailor_stage["attempt_count"] or 0)
+        if tailor_state == "exhausted" or attempt_count >= 5:
+            return None
+        if not retailor and tailor_state not in {
+            "pending",
+            "running",
+            "failed",
+            "stale",
+        }:
+            return None
     score = SqliteScoreRepository(conn).load(tenant_id, stable_job_id)
     if score is None:
         return None

--- a/workers/automation/src/jobctrl/scoring/tailor.py
+++ b/workers/automation/src/jobctrl/scoring/tailor.py
@@ -34,7 +34,8 @@ from jobctrl import database as db_module
 from jobctrl import config
 from jobctrl.config import TAILORED_DIR
 from jobctrl.database import get_connection, get_jobs_by_stage
-from jobctrl.domain.identifiers import JobId
+from jobctrl.domain.discovery.value_objects import PostingUrl
+from jobctrl.domain.identifiers import JobId, canonical_job_id
 from jobctrl.domain.materials.services import ContentValidator, ResumeAssembler
 from jobctrl.domain.materials.use_cases import (
     TailorOutcome,
@@ -53,6 +54,7 @@ from jobctrl.domain.ports.materials import (
 from jobctrl.domain.profile.snapshot import ProfileSnapshot
 from jobctrl.domain.tenant import LOCAL_TENANT, TenantId
 from jobctrl.infrastructure.llm import get_llm_adapter
+from jobctrl.infrastructure.discovery import SqliteJobIdentityResolver
 from jobctrl.infrastructure.materials import (
     HtmlResumePdfAdapter,
     SqliteBulletProvenanceRepository,
@@ -60,6 +62,7 @@ from jobctrl.infrastructure.materials import (
     SqliteTailoringPolicyRepository,
     SqliteUnitOfWork,
 )
+from jobctrl.infrastructure.preparation import SqlitePreparationTargetReader
 from jobctrl.infrastructure.scoring import (
     SqliteRequirementFitReportRepository,
     SqliteScoreRepository,
@@ -205,12 +208,12 @@ def _build_pdf_renderer() -> PdfRendererPort:
 
 
 def _load_requirement_fit_report_for_job(*, tenant_id: TenantId, job: dict):
-    job_url = str(job.get("url") or "").strip()
-    if not job_url:
+    job_id = job.get("job_id")
+    if not job_id:
         return None
     return SqliteRequirementFitReportRepository(get_connection()).load(
         tenant_id,
-        JobId(job_url),
+        canonical_job_id(str(job_id)),
     )
 
 
@@ -230,12 +233,12 @@ def _mark_cover_pending_after_tailor_success(
     *,
     reason: str,
 ) -> None:
-    """Invalidate downstream cover readiness after a new resume generation.
+    """Legacy batch-runner cover reset.
 
-    A stale ``cover=succeeded`` row is unsafe after re-tailoring because it can
-    refer to a superseded cover letter from an older material generation. The
-    cover stage must become visibly pending so the next pipeline step generates
-    cover artifacts for the current approved resume.
+    ``run_tailoring`` remains outside the canonical JobId cutover in this
+    slice. Its URL-shaped selector is kept untouched until its own bounded
+    migration; the per-job preparation entry point uses the exact helper
+    below.
     """
     now = utc_now()
     metadata = json.dumps(
@@ -271,6 +274,56 @@ def _mark_cover_pending_after_tailor_success(
         job_url,
         "cover",
         "StageReset",
+        message="Cover stage reset after tailored resume generation",
+        payload={"reason": reason},
+    )
+
+
+def _mark_cover_pending_after_tailor_success_by_id(
+    conn: sqlite3.Connection,
+    job_id: JobId,
+    *,
+    tenant_id: TenantId,
+    reason: str,
+) -> None:
+    """Invalidate downstream cover readiness after a new resume generation.
+
+    A stale ``cover=succeeded`` row is unsafe after re-tailoring because it can
+    refer to a superseded cover letter from an older material generation. The
+    cover stage must become visibly pending so the next pipeline step generates
+    cover artifacts for the current approved resume.
+    """
+    now = utc_now()
+    metadata = json.dumps(
+        {"invalidated_at": now, "reason": reason},
+        sort_keys=True,
+    )
+    conn.execute(
+        """
+        UPDATE job_stage_states
+        SET state = 'pending',
+            attempt_count = 0,
+            max_attempts = 5,
+            started_at = NULL,
+            updated_at = ?,
+            finished_at = NULL,
+            duration_ms = NULL,
+            error_code = NULL,
+            error_message = NULL,
+            retryable = 1,
+            blocked_by_json = '[]',
+            next_action = NULL,
+            metadata_json = ?
+        WHERE tenant_id = ? AND job_id = ? AND stage = 'cover'
+        """,
+        (now, metadata, str(tenant_id), str(canonical_job_id(str(job_id)))),
+    )
+    record_job_event(
+        conn,
+        job_id,
+        "cover",
+        "StageReset",
+        tenant_id=tenant_id,
         message="Cover stage reset after tailored resume generation",
         payload={"reason": reason},
     )
@@ -316,6 +369,7 @@ def _tailor_one_job(
     # only surfaces the resulting outcome.
     outcome = use_case.execute(
         job=job,
+        job_id=canonical_job_id(str(job["job_id"])),
         profile_snapshot=snapshot,
         tailored_dir=TAILORED_DIR,
         validation_mode=validation_mode,
@@ -634,21 +688,72 @@ def tailor_job_by_url(
     suppress_existing_artifacts: bool = False,
     allow_low_fit_override: bool = False,
 ) -> dict:
-    """Tailor exactly one eligible job by URL.
-
-    Durable Discovery-preparation items are job-scoped. This helper keeps the
-    existing Materials use case and stage-state behavior while avoiding the
-    batch ``pending_tailor`` selector from choosing a different job.
-    """
-    if snapshot is None:
-        from jobctrl.infrastructure.profile import get_profile_repository
-
-        snapshot = get_profile_repository().load_snapshot(tenant_id)
-
+    """Resolve an active external posting locator, then tailor its JobId."""
     conn = get_connection()
-    job = _load_tailor_eligible_job_by_url(
+    identity = SqliteJobIdentityResolver(conn).resolve_current_by_posting_url(
+        tenant_id,
+        PostingUrl(value=job_url),
+    )
+    if identity is None:
+        return {"url": job_url, "status": "skipped", "reason": "not_found"}
+    return tailor_job_by_id(
+        identity.job_id,
+        min_score=min_score,
+        validation_mode=validation_mode,
+        workers=workers,
+        retailor=retailor,
+        snapshot=snapshot,
+        tenant_id=tenant_id,
+        llm_model=llm_model,
+        tailor_models=tailor_models,
+        tailor_judge_model=tailor_judge_model,
+        tailor_judge_min_score=tailor_judge_min_score,
+        pdf_renderer=pdf_renderer,
+        suppress_existing_artifacts=suppress_existing_artifacts,
+        allow_low_fit_override=allow_low_fit_override,
+    )
+
+
+def tailor_job_by_id(
+    job_id: JobId,
+    *,
+    min_score: int = 7,
+    validation_mode: str = "normal",
+    workers: int = 1,
+    retailor: bool = False,
+    snapshot: ProfileSnapshot | None = None,
+    tenant_id: TenantId = LOCAL_TENANT,
+    llm_model: str | None = DEFAULT_PIPELINE_LLM_MODEL_SPEC,
+    tailor_models: tuple[str, ...] = (),
+    tailor_judge_model: str | None = None,
+    tailor_judge_min_score: float | None = None,
+    pdf_renderer: PdfRendererPort | None = None,
+    suppress_existing_artifacts: bool = False,
+    allow_low_fit_override: bool = False,
+) -> dict:
+    """Tailor one active, eligible JobId for its tenant-scoped preparation step.
+
+    This is the canonical single-job entry point. It deliberately does not use
+    the batch selector or URL-shaped primary keys: a preparation workflow owns
+    one JobId, and all target, score, materials, state, and event access stays
+    scoped to that identity.
+    """
+    stable_job_id = canonical_job_id(str(job_id))
+    conn = get_connection()
+    target_reader = SqlitePreparationTargetReader(conn)
+    target = target_reader.load(tenant_id, stable_job_id)
+    if target is None:
+        return {
+            "job_id": str(stable_job_id),
+            "status": "skipped",
+            "reason": "not_found",
+        }
+
+    job = _load_tailor_eligible_job_by_id(
         conn,
-        job_url,
+        tenant_id=tenant_id,
+        job_id=stable_job_id,
+        job=target,
         min_score=min_score,
         retailor=retailor,
         allow_low_fit_override=allow_low_fit_override,
@@ -656,23 +761,36 @@ def tailor_job_by_url(
     if job is None:
         if _reconcile_score_eligibility_skip(
             conn,
-            job_url=job_url,
+            job_id=stable_job_id,
             tenant_id=tenant_id,
         ):
             conn.commit()
             return {
-                "url": job_url,
+                "url": target["url"],
+                "job_id": str(stable_job_id),
                 "status": "skipped",
                 "reason": "score_eligibility_blocked",
             }
         _record_tailor_skip(
             conn,
-            job_url=job_url,
+            job_id=stable_job_id,
+            tenant_id=tenant_id,
+            discovered_at=target.get("discovered_at"),
             reason="not_eligible",
             message="Tailoring skipped because the job is not currently eligible.",
         )
         conn.commit()
-        return {"url": job_url, "status": "skipped", "reason": "not_eligible"}
+        return {
+            "url": target["url"],
+            "job_id": str(stable_job_id),
+            "status": "skipped",
+            "reason": "not_eligible",
+        }
+
+    if snapshot is None:
+        from jobctrl.infrastructure.profile import get_profile_repository
+
+        snapshot = get_profile_repository().load_snapshot(tenant_id)
 
     worker_count = max(1, workers)
     _ = worker_count  # same validation surface as batch runner; single work item runs one job.
@@ -686,17 +804,30 @@ def tailor_job_by_url(
         llm_model=llm_model,
     )
 
-    ensure_job_stage_rows(conn, job_url, discovered_at=job.get("discovered_at"))
+    ensure_job_stage_rows(
+        conn,
+        stable_job_id,
+        tenant_id=tenant_id,
+        discovered_at=job.get("discovered_at"),
+    )
     started_at = utc_now()
     set_stage_state(
         conn,
-        job_url,
+        stable_job_id,
         "tailor",
         "running",
+        tenant_id=tenant_id,
         started_at=started_at,
         validate_transition=False,
     )
-    record_job_event(conn, job_url, "tailor", "StageStarted", message="Tailoring started")
+    record_job_event(
+        conn,
+        stable_job_id,
+        "tailor",
+        "StageStarted",
+        tenant_id=tenant_id,
+        message="Tailoring started",
+    )
     conn.commit()
 
     result = _tailor_one_job(
@@ -716,33 +847,37 @@ def tailor_job_by_url(
     if result.get("status") == "approved":
         set_stage_state(
             conn,
-            job_url,
+            stable_job_id,
             "tailor",
             "succeeded",
+            tenant_id=tenant_id,
             attempt_count=attempts,
             started_at=started_at,
             finished_at=finished_at,
         )
         record_job_event(
             conn,
-            job_url,
+            stable_job_id,
             "tailor",
             "StageCompleted",
+            tenant_id=tenant_id,
             message="Tailoring approved",
             payload={"attempts": attempts},
         )
-        _mark_cover_pending_after_tailor_success(
+        _mark_cover_pending_after_tailor_success_by_id(
             conn,
-            job_url,
+            stable_job_id,
+            tenant_id=tenant_id,
             reason="tailor_stage_completed",
         )
     else:
         exhausted = attempts >= config.DEFAULTS["max_tailor_attempts"] or result.get("status") == "exhausted_retries"
         set_stage_state(
             conn,
-            job_url,
+            stable_job_id,
             "tailor",
             "exhausted" if exhausted else "failed",
+            tenant_id=tenant_id,
             attempt_count=attempts,
             max_attempts=config.DEFAULTS["max_tailor_attempts"],
             started_at=started_at,
@@ -751,15 +886,20 @@ def tailor_job_by_url(
             error_message=f"Tailoring ended with status {result.get('status', 'error')}",
             retryable=True,
             next_action=(
-                f"jobctrl retry tailor {job_url} --reset-attempts" if exhausted else f"jobctrl retry tailor {job_url}"
+                (
+                    f"jobctrl retry tailor {job['url']} --reset-attempts"
+                    if exhausted
+                    else f"jobctrl retry tailor {job['url']}"
+                )
             ),
             validate_transition=False,
         )
         record_job_event(
             conn,
-            job_url,
+            stable_job_id,
             "tailor",
             "StageFailed",
+            tenant_id=tenant_id,
             level="error",
             message=f"Tailoring ended with status {result.get('status', 'error')}",
         )
@@ -770,10 +910,11 @@ def tailor_job_by_url(
 def _reconcile_score_eligibility_skip(
     conn: sqlite3.Connection,
     *,
-    job_url: str,
+    job_id: JobId,
     tenant_id: TenantId,
 ) -> bool:
-    score = SqliteScoreRepository(conn).load(tenant_id, JobId(job_url))
+    stable_job_id = canonical_job_id(str(job_id))
+    score = SqliteScoreRepository(conn).load(tenant_id, stable_job_id)
     if score is None:
         return False
     eligibility = score.breakdown.eligibility
@@ -803,113 +944,56 @@ def _reconcile_score_eligibility_skip(
 def _record_tailor_skip(
     conn: sqlite3.Connection,
     *,
-    job_url: str,
+    job_id: JobId,
+    tenant_id: TenantId,
+    discovered_at: str | None,
     reason: str,
     message: str,
 ) -> None:
-    row = conn.execute(
-        "SELECT discovered_at FROM jobs WHERE url = ?",
-        (job_url,),
-    ).fetchone()
-    discovered_at = row["discovered_at"] if row is not None else None
-    ensure_job_stage_rows(conn, job_url, discovered_at=discovered_at)
+    stable_job_id = canonical_job_id(str(job_id))
+    ensure_job_stage_rows(
+        conn,
+        stable_job_id,
+        tenant_id=tenant_id,
+        discovered_at=discovered_at,
+    )
     record_job_event(
         conn,
-        job_url,
+        stable_job_id,
         "tailor",
         "StageSkipped",
+        tenant_id=tenant_id,
         level="warning",
         message=message,
         payload={"reason": reason},
     )
 
 
-def _load_tailor_eligible_job_by_url(
+def _load_tailor_eligible_job_by_id(
     conn: sqlite3.Connection,
-    job_url: str,
     *,
+    tenant_id: TenantId,
+    job_id: JobId,
+    job: dict,
     min_score: int,
     retailor: bool,
     allow_low_fit_override: bool = False,
 ) -> dict | None:
-    min_score = 0 if allow_low_fit_override else db_module.effective_tailoring_min_score(min_score)
-    if retailor:
-        where = (
-            f"{db_module._EFFECTIVE_FIT_SCORE} >= ? "
-            f"AND {db_module._EFFECTIVE_FULL_DESCRIPTION} IS NOT NULL "
-            f"AND {db_module._SCORE_ELIGIBLE_FOR_DOWNSTREAM} "
-            f"AND {db_module._SCORE_CURRENT_FOR_DOWNSTREAM} "
-            f"AND {db_module._TAILOR_NOT_EXHAUSTED} "
-            f"AND ({db_module._EFFECTIVE_TAILOR_PATH} IS NOT NULL "
-            f"OR {db_module._EFFECTIVE_TAILOR_ATTEMPTS} < 5)"
-        )
-    else:
-        where = (
-            f"{db_module._EFFECTIVE_FIT_SCORE} >= ? "
-            f"AND {db_module._EFFECTIVE_FULL_DESCRIPTION} IS NOT NULL "
-            f"AND {db_module._SCORE_ELIGIBLE_FOR_DOWNSTREAM} "
-            f"AND {db_module._SCORE_CURRENT_FOR_DOWNSTREAM} "
-            f"AND {db_module._EFFECTIVE_TAILOR_PATH} IS NULL "
-            f"AND {db_module._TAILOR_NOT_EXHAUSTED} "
-            f"AND {db_module._EFFECTIVE_TAILOR_ATTEMPTS} < 5"
-        )
-    row = conn.execute(
-        f"""
-        SELECT jobs.*, js.js_fit_score AS js_fit_score,
-               jm.jm_job_url AS jm_job_url,
-               jm.jm_tailored_path AS jm_tailored_path,
-               jm.jm_tailored_at AS jm_tailored_at,
-               jm.jm_cover_path AS jm_cover_path,
-               jm.jm_cover_at AS jm_cover_at,
-               jm.jm_resume_pdf_path AS jm_resume_pdf_path,
-               jm.jm_cover_pdf_path AS jm_cover_pdf_path,
-               jm.jm_generation AS jm_generation,
-               jm.jm_status AS jm_status,
-               je.full_description AS je_full_description,
-               je.application_url AS je_application_url,
-               je.enriched_at AS je_enriched_at,
-               je.current_status AS je_current_status,
-               je.extraction_tier AS je_extraction_tier
-        FROM jobs {db_module._LATEST_SCORE_JOIN} {db_module._LATEST_MATERIALS_JOIN}
-        {db_module._LATEST_STAGE_ATTEMPTS_JOIN} {db_module._SCORE_DOWNSTREAM_STATE_JOIN}
-        {db_module._ENRICHMENT_JOIN}
-        WHERE jobs.url = ? AND {where}
-        LIMIT 1
-        """,
-        (job_url, int(min_score)),
-    ).fetchone()
-    if row is None:
+    stable_job_id = canonical_job_id(str(job_id))
+    if not str(job.get("full_description") or "").strip():
         return None
-    return _promote_tailor_job_row(row)
-
-
-def _promote_tailor_job_row(row: sqlite3.Row) -> dict:
-    record = dict(row)
-    js_value = record.pop("js_fit_score", None)
-    if js_value is not None:
-        record["fit_score"] = js_value
-    jm_job_url = record.pop("jm_job_url", None)
-    jm_tailored = record.pop("jm_tailored_path", None)
-    jm_tailored_at = record.pop("jm_tailored_at", None)
-    jm_cover = record.pop("jm_cover_path", None)
-    jm_cover_at = record.pop("jm_cover_at", None)
-    if jm_job_url is not None:
-        record["tailored_resume_path"] = jm_tailored
-        record["tailored_at"] = jm_tailored_at
-        record["cover_letter_path"] = jm_cover
-        record["cover_letter_at"] = jm_cover_at
-    je_full = record.pop("je_full_description", None)
-    je_app = record.pop("je_application_url", None)
-    je_at = record.pop("je_enriched_at", None)
-    record.pop("je_current_status", None)
-    record.pop("je_extraction_tier", None)
-    if je_full is not None:
-        record["full_description"] = je_full
-    if je_app is not None:
-        record["application_url"] = je_app
-    if je_at is not None:
-        record["detail_scraped_at"] = je_at
-    return record
+    score = SqliteScoreRepository(conn).load(tenant_id, stable_job_id)
+    if score is None:
+        return None
+    eligibility = score.breakdown.eligibility
+    if eligibility.status == "blocked" or eligibility.hard_blockers:
+        return None
+    effective_min_score = 0 if allow_low_fit_override else db_module.effective_tailoring_min_score(min_score)
+    if score.fit_score.value < effective_min_score:
+        return None
+    if not retailor and SqliteMaterialsRepository(conn).load_current_approved(tenant_id, stable_job_id) is not None:
+        return None
+    return job
 
 
 __all__ = [
@@ -919,5 +1003,6 @@ __all__ = [
     "_tailor_one_job",
     "run_tailoring",
     "tailor_resume",
+    "tailor_job_by_id",
     "tailor_job_by_url",
 ]

--- a/workers/automation/tests/test_materials_quality.py
+++ b/workers/automation/tests/test_materials_quality.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from jobctrl.domain.identifiers import JobId
+from jobctrl.domain.identifiers import JobId, canonical_job_id
 from jobctrl.domain.materials.analysis import (
     AnalysisAgreement,
     EmployerAnalysis,
@@ -27,8 +27,13 @@ from jobctrl.domain.scoring import (
 )
 from jobctrl.domain.tenant import LOCAL_TENANT
 
+_JOB_ID = canonical_job_id("50000000-0000-4000-8000-000000000001")
+_OTHER_JOB_ID = canonical_job_id("50000000-0000-4000-8000-000000000002")
 
-def _employer_analysis(*keywords: str, job_url: str = "https://example.com/senior-backend") -> EmployerAnalysis:
+
+def _employer_analysis(
+    *keywords: str, job_id: JobId = _JOB_ID
+) -> EmployerAnalysis:
     """Minimal canonical analysis supplying the given job keywords (Phase 1, D-21).
 
     ``build_tailoring_plan`` now sources its keywords from the persisted
@@ -44,7 +49,7 @@ def _employer_analysis(*keywords: str, job_url: str = "https://example.com/senio
     )
     return EmployerAnalysis.build(
         tenant_id=LOCAL_TENANT,
-        job_id=JobId(job_url),
+        job_id=job_id,
         generation=1,
         snapshot_hash=compute_snapshot_hash(" ".join(keywords) or "jd"),
         canonical=canonical,
@@ -55,7 +60,7 @@ def _employer_analysis(*keywords: str, job_url: str = "https://example.com/senio
     )
 
 
-def _requirement_analysis(job_url: str = "https://example.com/senior-backend") -> EmployerAnalysis:
+def _requirement_analysis(job_id: JobId = _JOB_ID) -> EmployerAnalysis:
     canonical = JobAnalysis(
         role_framing="Backend ownership.",
         inferred_seniority="senior",
@@ -91,7 +96,7 @@ def _requirement_analysis(job_url: str = "https://example.com/senior-backend") -
     )
     return EmployerAnalysis.build(
         tenant_id=LOCAL_TENANT,
-        job_id=JobId(job_url),
+        job_id=job_id,
         generation=1,
         snapshot_hash=compute_snapshot_hash("Python API Salesforce"),
         canonical=canonical,
@@ -102,9 +107,9 @@ def _requirement_analysis(job_url: str = "https://example.com/senior-backend") -
     )
 
 
-def _requirement_fit_report(job_url: str = "https://example.com/senior-backend") -> RequirementFitReport:
+def _requirement_fit_report(job_id: JobId = _JOB_ID) -> RequirementFitReport:
     return RequirementFitReport(
-        job_id=job_url,
+        job_id=job_id,
         score_version=1,
         employer_analysis_generation=1,
         profile_snapshot_version=1,
@@ -235,6 +240,7 @@ def _profile() -> dict:
 
 def _senior_job() -> dict:
     return {
+        "job_id": str(_JOB_ID),
         "url": "https://example.com/senior-backend",
         "title": "Senior Backend Engineer",
         "skills": ["Python", "PostgreSQL", "API performance"],
@@ -315,7 +321,7 @@ def test_quality_counts_fixed_education_in_final_resume_evidence() -> None:
     )
     analysis = EmployerAnalysis.build(
         tenant_id=LOCAL_TENANT,
-        job_id=JobId("https://example.com/senior-backend"),
+        job_id=_JOB_ID,
         generation=1,
         snapshot_hash=compute_snapshot_hash("degree"),
         canonical=canonical,
@@ -325,7 +331,7 @@ def test_quality_counts_fixed_education_in_final_resume_evidence() -> None:
         legs_attempted=1,
     )
     report = RequirementFitReport(
-        job_id="https://example.com/senior-backend",
+        job_id=_JOB_ID,
         score_version=1,
         employer_analysis_generation=1,
         profile_snapshot_version=1,
@@ -464,6 +470,7 @@ def test_build_tailoring_plan_sources_keywords_from_canonical_analysis() -> None
     # D-21: keywords come from the persisted, evidence-grounded employer
     # analysis — the old _extract_job_keywords stopword heuristic is gone.
     job = {
+        "job_id": str(_JOB_ID),
         "url": "https://example.com/platform",
         "title": "Head of Platform Engineering",
         # Marketing copy in the JD must NOT leak into keywords; only the
@@ -475,7 +482,7 @@ def test_build_tailoring_plan_sources_keywords_from_canonical_analysis() -> None
         "kubernetes",
         "ci/cd",
         "observability",
-        job_url="https://example.com/platform",
+        job_id=_JOB_ID,
     )
 
     plan = build_tailoring_plan(_profile(), job, employer_analysis=analysis)
@@ -514,7 +521,7 @@ def test_build_tailoring_plan_uses_requirement_fit_directives() -> None:
 
 def test_build_tailoring_plan_ignores_stale_requirement_fit_report_for_coverage() -> None:
     analysis = _requirement_analysis()
-    stale_report = _requirement_fit_report("https://example.com/old-job")
+    stale_report = _requirement_fit_report(_OTHER_JOB_ID)
 
     plan = build_tailoring_plan(
         _profile(),
@@ -700,6 +707,7 @@ def test_quality_requires_seniority_signal_for_senior_roles_when_evidence_exists
 
 def test_mid_level_jobs_do_not_require_executive_framing() -> None:
     job = {
+        "job_id": str(_JOB_ID),
         "url": "https://example.com/backend",
         "title": "Backend Engineer",
         "skills": ["Python"],
@@ -722,6 +730,7 @@ def test_mid_level_jobs_do_not_require_executive_framing() -> None:
 
 def test_mid_level_jobs_warn_on_executive_style_overreach() -> None:
     job = {
+        "job_id": str(_JOB_ID),
         "url": "https://example.com/backend",
         "title": "Backend Engineer",
         "skills": ["Python"],

--- a/workers/automation/tests/test_materials_quality_eval.py
+++ b/workers/automation/tests/test_materials_quality_eval.py
@@ -29,6 +29,7 @@ from jobctrl.domain.tenant import LOCAL_TENANT
 
 
 FIXTURE = Path(__file__).parent / "fixtures" / "resume_tailoring_quality_eval.json"
+JOB_ID = JobId("00000000-0000-4000-8000-000000000042")
 
 
 def _employer_analysis(*keywords: str) -> EmployerAnalysis:
@@ -42,7 +43,7 @@ def _employer_analysis(*keywords: str) -> EmployerAnalysis:
     )
     return EmployerAnalysis.build(
         tenant_id=LOCAL_TENANT,
-        job_id=JobId("https://example.com/eval"),
+        job_id=JOB_ID,
         generation=1,
         snapshot_hash=compute_snapshot_hash(" ".join(keywords) or "jd"),
         canonical=canonical,
@@ -69,7 +70,7 @@ def test_tailoring_quality_eval_preserves_claim_safety_controls(
 ) -> None:
     plan = build_tailoring_plan(
         fixture["profile"],
-        fixture["jobs"]["high_fit_senior_backend"],
+        _job_for_plan(fixture["jobs"]["high_fit_senior_backend"]),
         employer_analysis=_employer_analysis("python", "latency"),
     )
 
@@ -92,7 +93,7 @@ def test_tailoring_quality_eval_covers_combined_failure_modes(
     }
 
     for case in fixture["quality_cases"]:
-        job = fixture["jobs"][case["job"]]
+        job = _job_for_plan(fixture["jobs"][case["job"]])
         # The analysis reflects the job: its keywords are the job's skills (lower-
         # cased) plus the canonical backend terms, so required-evidence selection
         # mirrors what a real ensemble analysis of this posting would drive.
@@ -164,6 +165,10 @@ def _payload(bullet: str) -> dict[str, Any]:
             {"id": "languages", "items": ["Python", "Go"]},
         ],
     }
+
+
+def _job_for_plan(job: dict[str, Any]) -> dict[str, Any]:
+    return {**job, "job_id": JOB_ID}
 
 
 def _resume_text(bullet: str) -> str:

--- a/workers/automation/tests/test_materials_use_cases.py
+++ b/workers/automation/tests/test_materials_use_cases.py
@@ -19,7 +19,7 @@ from typing import Any, Iterable
 
 import pytest
 
-from jobctrl.domain.identifiers import JobId
+from jobctrl.domain.identifiers import JobId, canonical_job_id
 from jobctrl.domain.materials import (
     Artifact,
     ArtifactStatus,
@@ -147,6 +147,7 @@ def snapshot() -> ProfileSnapshot:
 @pytest.fixture()
 def job() -> dict:
     return {
+        "job_id": "10000000-0000-4000-8000-000000000001",
         "url": "https://example.com/job/1",
         "title": "Backend Engineer",
         "site": "Acme",
@@ -190,7 +191,7 @@ class _FakeAnalyzeUseCase:
         )
         analysis = EmployerAnalysis.build(
             tenant_id=tenant_id,
-            job_id=JobId(str(job["url"])),
+            job_id=canonical_job_id(str(job["job_id"])),
             generation=1,
             snapshot_hash=compute_snapshot_hash(str(job.get("full_description") or "jd")),
             canonical=canonical,
@@ -226,7 +227,7 @@ def _analysis_with_keywords(job: dict, keywords: list[str]):
     )
     return EmployerAnalysis.build(
         tenant_id=LOCAL_TENANT,
-        job_id=JobId(str(job["url"])),
+        job_id=canonical_job_id(str(job["job_id"])),
         generation=1,
         snapshot_hash=compute_snapshot_hash(str(job.get("full_description") or "jd")),
         canonical=canonical,
@@ -1546,7 +1547,7 @@ def test_tailor_use_case_retailor_supersedes_previous_generation(
     # Pre-seed a previous approved generation.
     initial = MaterialsSetFactory.initial(
         tenant_id=LOCAL_TENANT,
-        job_id=JobId(job["url"]),
+        job_id=canonical_job_id(str(job["job_id"])),
         created_at="2024-01-01T00:00:00+00:00",
     ).with_resume_attempt(
         Artifact.create(
@@ -1593,7 +1594,7 @@ def test_tailor_use_case_retailor_suppresses_previous_generation_when_requested(
     repo = _FakeRepository()
     initial = MaterialsSetFactory.initial(
         tenant_id=LOCAL_TENANT,
-        job_id=JobId(job["url"]),
+        job_id=canonical_job_id(str(job["job_id"])),
         created_at="2024-01-01T00:00:00+00:00",
     ).with_resume_attempt(
         Artifact.create(
@@ -1649,7 +1650,7 @@ def test_tailor_use_case_failed_retailor_keeps_previous_generation_active(
     repo = _FakeRepository()
     initial = MaterialsSetFactory.initial(
         tenant_id=LOCAL_TENANT,
-        job_id=JobId(job["url"]),
+        job_id=canonical_job_id(str(job["job_id"])),
         created_at="2024-01-01T00:00:00+00:00",
     ).with_resume_attempt(
         Artifact.create(
@@ -1685,7 +1686,7 @@ def test_tailor_use_case_failed_retailor_keeps_previous_generation_active(
     assert outcome.materials.generation == 2
     assert outcome.materials.tailored_resume is not None
     assert outcome.materials.tailored_resume.status is ArtifactStatus.REJECTED
-    previous = repo.load(LOCAL_TENANT, JobId(job["url"]), generation=1)
+    previous = repo.load(LOCAL_TENANT, canonical_job_id(str(job["job_id"])), generation=1)
     assert previous is not None
     assert previous.tailored_resume is not None
     assert previous.tailored_resume.status is ArtifactStatus.APPROVED
@@ -1716,7 +1717,7 @@ def test_tailor_use_case_renders_and_attaches_resume_pdf_when_renderer_present(
     assert outcome.materials.resume_pdf is not None
     assert outcome.pdf_path == str(Path(outcome.text_path).with_suffix(".pdf"))
     assert renderer.calls and renderer.calls[0]["tailored_payload"] == outcome.final_payload
-    saved = repo.load(LOCAL_TENANT, JobId(job["url"]))
+    saved = repo.load(LOCAL_TENANT, canonical_job_id(str(job["job_id"])))
     assert saved is not None and saved.resume_pdf is not None
     assert any(getattr(e, "event_type", "") == "ResumeApproved" for e in publisher.events)
 
@@ -1748,7 +1749,7 @@ def test_tailor_use_case_first_generation_pdf_failure_leaves_nothing_current(
     assert outcome.materials is not None
     assert outcome.materials.tailored_resume is not None
     assert outcome.materials.tailored_resume.status is ArtifactStatus.REJECTED
-    assert repo.load_current_approved(LOCAL_TENANT, JobId(job["url"])) is None
+    assert repo.load_current_approved(LOCAL_TENANT, canonical_job_id(str(job["job_id"]))) is None
     assert not any(getattr(e, "event_type", "") == "ResumeApproved" for e in publisher.events)
     assert any(getattr(e, "event_type", "") == "ResumeFailed" for e in publisher.events)
 
@@ -1763,7 +1764,7 @@ def test_tailor_use_case_rejects_prose_skill_fabrication_and_preserves_prior(
     repo = _FakeRepository()
     approved_gen1 = MaterialsSetFactory.initial(
         tenant_id=LOCAL_TENANT,
-        job_id=JobId(job["url"]),
+        job_id=canonical_job_id(str(job["job_id"])),
         created_at="2024-01-01T00:00:00+00:00",
     ).with_resume_attempt(
         Artifact.create(
@@ -1810,7 +1811,7 @@ def test_tailor_use_case_rejects_prose_skill_fabrication_and_preserves_prior(
     )
 
     # The last accepted generation is preserved, not superseded/destroyed.
-    still_approved = repo.load_current_approved(LOCAL_TENANT, JobId(job["url"]))
+    still_approved = repo.load_current_approved(LOCAL_TENANT, canonical_job_id(str(job["job_id"])))
     assert still_approved is not None
     assert still_approved.generation == 1
     assert still_approved.is_resume_approved
@@ -1986,7 +1987,7 @@ def test_tailor_use_case_hard_fails_when_every_candidate_trips_gate(
     repo = _FakeRepository()
     approved_gen1 = MaterialsSetFactory.initial(
         tenant_id=LOCAL_TENANT,
-        job_id=JobId(job["url"]),
+        job_id=canonical_job_id(str(job["job_id"])),
         created_at="2024-01-01T00:00:00+00:00",
     ).with_resume_attempt(
         Artifact.create(
@@ -2030,7 +2031,7 @@ def test_tailor_use_case_hard_fails_when_every_candidate_trips_gate(
     assert history[0]["candidates"][0]["status"] == "failed_fabrication_gate"
     assert history[1]["candidates"][0]["status"] == "failed_fabrication_gate"
     # The last accepted generation survives untouched.
-    still = repo.load_current_approved(LOCAL_TENANT, JobId(job["url"]))
+    still = repo.load_current_approved(LOCAL_TENANT, canonical_job_id(str(job["job_id"])))
     assert still is not None
     assert still.generation == 1
     assert still.is_resume_approved
@@ -2779,7 +2780,7 @@ def test_render_pdf_use_case_renders_missing_pdfs(tmp_path: Path, job: dict) -> 
 
     materials = MaterialsSetFactory.initial(
         tenant_id=LOCAL_TENANT,
-        job_id=JobId(job["url"]),
+        job_id=canonical_job_id(str(job["job_id"])),
         created_at="2024-01-01T00:00:00+00:00",
     ).with_resume_attempt(
         Artifact.create(
@@ -2812,7 +2813,7 @@ def test_render_pdf_use_case_renders_missing_pdfs(tmp_path: Path, job: dict) -> 
         publisher=publisher,
     )
     outcome = use_case.execute(
-        job_id=JobId(job["url"]),
+        job_id=canonical_job_id(str(job["job_id"])),
         tailored_payload=_good_json_payload_dict(),
         profile_dict=_profile_dict(),
     )
@@ -2844,7 +2845,7 @@ def test_render_pdf_use_case_passes_effective_template_to_resume_renderer(
     repo.save(
         MaterialsSetFactory.initial(
             tenant_id=LOCAL_TENANT,
-            job_id=JobId(job["url"]),
+            job_id=canonical_job_id(str(job["job_id"])),
             created_at="2024-01-01T00:00:00+00:00",
         ).with_resume_attempt(
             Artifact.create(
@@ -2866,7 +2867,7 @@ def test_render_pdf_use_case_passes_effective_template_to_resume_renderer(
         cover_letter_renderer=renderer,
     )
     outcome = use_case.execute(
-        job_id=JobId(job["url"]),
+        job_id=canonical_job_id(str(job["job_id"])),
         tailored_payload=_good_json_payload_dict(),
         profile_dict=_profile_dict(),
     )
@@ -2885,7 +2886,7 @@ def test_render_pdf_use_case_noop_when_pdfs_already_present(
     resume_path.write_text("body", encoding="utf-8")
     materials = MaterialsSetFactory.initial(
         tenant_id=LOCAL_TENANT,
-        job_id=JobId(job["url"]),
+        job_id=canonical_job_id(str(job["job_id"])),
         created_at="2024-01-01T00:00:00+00:00",
     ).with_resume_attempt(
         Artifact.create(
@@ -2915,7 +2916,7 @@ def test_render_pdf_use_case_noop_when_pdfs_already_present(
         cover_letter_renderer=renderer,
     )
     outcome = use_case.execute(
-        job_id=JobId(job["url"]),
+        job_id=canonical_job_id(str(job["job_id"])),
         tailored_payload=_good_json_payload_dict(),
         profile_dict=_profile_dict(),
     )

--- a/workers/automation/tests/test_requirement_led_tailoring.py
+++ b/workers/automation/tests/test_requirement_led_tailoring.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from jobctrl.domain.identifiers import JobId
+from jobctrl.domain.identifiers import canonical_job_id
 from jobctrl.domain.materials.analysis import (
     AnalysisAgreement,
     EmployerAnalysis,
@@ -59,6 +59,8 @@ from jobctrl.domain.scoring import (
 )
 from jobctrl.domain.tenant import LOCAL_TENANT
 
+_JOB_ID = canonical_job_id("40000000-0000-4000-8000-000000000001")
+
 
 def _employer_analysis(*keywords: str) -> EmployerAnalysis:
     canonical = JobAnalysis(
@@ -70,7 +72,7 @@ def _employer_analysis(*keywords: str) -> EmployerAnalysis:
     )
     return EmployerAnalysis.build(
         tenant_id=LOCAL_TENANT,
-        job_id=JobId("https://example.com/senior-backend"),
+        job_id=_JOB_ID,
         generation=1,
         snapshot_hash=compute_snapshot_hash(" ".join(keywords) or "jd"),
         canonical=canonical,
@@ -117,7 +119,7 @@ def _requirement_analysis() -> EmployerAnalysis:
     )
     return EmployerAnalysis.build(
         tenant_id=LOCAL_TENANT,
-        job_id=JobId("https://example.com/senior-backend"),
+        job_id=_JOB_ID,
         generation=1,
         snapshot_hash=compute_snapshot_hash("Python API Salesforce"),
         canonical=canonical,
@@ -143,7 +145,7 @@ def _requirement_fit_report(
         reason="No grounded Salesforce evidence.",
     )
     return RequirementFitReport(
-        job_id="https://example.com/senior-backend",
+        job_id=_JOB_ID,
         score_version=1,
         employer_analysis_generation=1,
         profile_snapshot_version=1,
@@ -260,6 +262,7 @@ def _profile() -> dict:
 
 def _senior_job() -> dict:
     return {
+        "job_id": str(_JOB_ID),
         "url": "https://example.com/senior-backend",
         "title": "Senior Backend Engineer",
         "skills": ["Python", "PostgreSQL", "API performance"],
@@ -392,6 +395,7 @@ def test_target_profile_adapter_uses_analysis_fit_and_profile_evidence() -> None
     target_profile = plan.target_profile
 
     assert target_profile is not None
+    assert target_profile.job_id == str(_JOB_ID)
     assert target_profile.target_role == "Senior Backend Engineer"
     assert target_profile.seniority == "senior"
     assert [item.requirement_id for item in target_profile.must_have_requirements] == [
@@ -450,7 +454,7 @@ def test_education_requirement_fit_evidence_is_claimable_in_coverage_graph() -> 
     )
     analysis = EmployerAnalysis.build(
         tenant_id=LOCAL_TENANT,
-        job_id=JobId("https://example.com/senior-backend"),
+        job_id=_JOB_ID,
         generation=1,
         snapshot_hash=compute_snapshot_hash("degree"),
         canonical=canonical,
@@ -460,7 +464,7 @@ def test_education_requirement_fit_evidence_is_claimable_in_coverage_graph() -> 
         legs_attempted=1,
     )
     report = RequirementFitReport(
-        job_id="https://example.com/senior-backend",
+        job_id=_JOB_ID,
         score_version=1,
         employer_analysis_generation=1,
         profile_snapshot_version=1,
@@ -928,7 +932,7 @@ def test_grounded_gate_reproduces_apply_review_contradiction_shape() -> None:
         for index in range(1, 10)
     )
     target = TargetProfile(
-        job_id="https://example.com/digital-hub-director",
+        job_id=str(_JOB_ID),
         target_role="Digital Hub Director",
         seniority="director",
         must_have_requirements=requirements[:8],

--- a/workers/automation/tests/test_tailor_provenance_integration.py
+++ b/workers/automation/tests/test_tailor_provenance_integration.py
@@ -19,7 +19,7 @@ from pathlib import Path
 
 import pytest
 
-from jobctrl.domain.identifiers import JobId
+from jobctrl.domain.identifiers import canonical_job_id
 from jobctrl.domain.materials import (
     Artifact,
     ArtifactStatus,
@@ -54,6 +54,7 @@ from jobctrl.domain.scoring import (
 from jobctrl.domain.tenant import LOCAL_TENANT
 
 JOB_URL = "https://example.com/job/provenance"
+JOB_ID = canonical_job_id("70000000-0000-4000-8000-000000000001")
 
 
 # --------------------------------------------------------------------------
@@ -89,7 +90,7 @@ class _FakeAnalyze:
         )
         analysis = EmployerAnalysis.build(
             tenant_id=tenant_id,
-            job_id=JobId(str(job["url"])),
+            job_id=canonical_job_id(str(job["job_id"])),
             generation=1,
             snapshot_hash=compute_snapshot_hash(str(job.get("full_description") or "jd")),
             canonical=canonical,
@@ -346,6 +347,7 @@ def _snapshot() -> ProfileSnapshot:
 
 def _job() -> dict:
     return {
+        "job_id": str(JOB_ID),
         "url": JOB_URL,
         "title": "Senior Backend Engineer",
         "site": "Acme",
@@ -363,7 +365,7 @@ def _requirement_fit_report() -> RequirementFitReport:
         )
 
     return RequirementFitReport(
-        job_id=JOB_URL,
+        job_id=JOB_ID,
         score_version=1,
         employer_analysis_generation=1,
         profile_snapshot_version=1,
@@ -589,7 +591,7 @@ def test_accepted_resume_records_provenance_and_publishes_event(tmp_path: Path) 
     assert outcome.materials is not None and outcome.materials.is_resume_approved
 
     # Provenance was saved for the accepted generation, bound to the artifact.
-    saved = provenance_repo.load(LOCAL_TENANT, JobId(JOB_URL))
+    saved = provenance_repo.load(LOCAL_TENANT, JOB_ID)
     assert saved is not None
     assert saved.artifact_id == outcome.materials.tailored_resume.artifact_id
     assert saved.generation == outcome.materials.generation
@@ -677,7 +679,7 @@ def test_suffixed_bare_magnitude_is_hard_rejected_by_detector_and_writes_no_prov
     assert outcome.materials is not None
     assert not outcome.materials.is_resume_approved
     # No provenance was persisted for the rejected candidate.
-    assert provenance_repo.load(LOCAL_TENANT, JobId(JOB_URL)) is None
+    assert provenance_repo.load(LOCAL_TENANT, JOB_ID) is None
     assert not any(
         getattr(e, "event_type", "") == "BulletProvenanceRecorded" for e in publisher.events
     )
@@ -709,7 +711,7 @@ def test_fabricated_employer_is_hard_rejected_by_detector_and_writes_no_provenan
     assert not outcome.materials.is_resume_approved
     # No provenance was persisted for a rejected candidate (last accepted
     # generation, if any, is preserved — here there is none).
-    assert provenance_repo.load(LOCAL_TENANT, JobId(JOB_URL)) is None
+    assert provenance_repo.load(LOCAL_TENANT, JOB_ID) is None
     assert not any(
         getattr(e, "event_type", "") == "BulletProvenanceRecorded" for e in publisher.events
     )
@@ -757,7 +759,7 @@ def test_retailor_pdf_render_failure_preserves_previous_approved_generation(
     assert gen1.materials is not None and gen1.materials.generation == 1
     assert gen1.materials.resume_pdf is not None
     assert gen1.pdf_path is not None
-    assert provenance_repo.load(LOCAL_TENANT, JobId(JOB_URL), generation=1) is not None
+    assert provenance_repo.load(LOCAL_TENANT, JOB_ID, generation=1) is not None
     assert (
         sum(1 for e in publisher.events if getattr(e, "event_type", "") == "ResumeApproved")
         == 1
@@ -781,7 +783,7 @@ def test_retailor_pdf_render_failure_preserves_previous_approved_generation(
 
     # Preservation invariant: generation 1 is STILL the current approved resume,
     # with its PDF and provenance intact.
-    current = materials_repo.load_current_approved(LOCAL_TENANT, JobId(JOB_URL))
+    current = materials_repo.load_current_approved(LOCAL_TENANT, JOB_ID)
     assert current is not None
     assert current.generation == 1
     assert current.is_resume_approved
@@ -790,8 +792,8 @@ def test_retailor_pdf_render_failure_preserves_previous_approved_generation(
     assert current.tailored_resume.status is ArtifactStatus.APPROVED
 
     # Generation 1 provenance survived; the failed generation 2 orphaned none.
-    assert provenance_repo.load(LOCAL_TENANT, JobId(JOB_URL), generation=1) is not None
-    assert provenance_repo.load(LOCAL_TENANT, JobId(JOB_URL), generation=2) is None
+    assert provenance_repo.load(LOCAL_TENANT, JOB_ID, generation=1) is not None
+    assert provenance_repo.load(LOCAL_TENANT, JOB_ID, generation=2) is None
 
     # No dangling second ResumeApproved; the failed re-tailor published ResumeFailed.
     assert (
@@ -832,7 +834,7 @@ def test_tailor_opens_unit_of_work_around_generation_flip(tmp_path: Path) -> Non
     # The flip opened the unit of work and committed it (clean exit) exactly once.
     assert unit_of_work.events == ["enter", "exit_ok"]
     # Provenance + the BulletProvenanceRecorded event still land on the happy path.
-    assert provenance_repo.load(LOCAL_TENANT, JobId(JOB_URL)) is not None
+    assert provenance_repo.load(LOCAL_TENANT, JOB_ID) is not None
     assert any(
         getattr(e, "event_type", "") == "BulletProvenanceRecorded" for e in publisher.events
     )

--- a/workers/automation/tests/test_tailor_retailor.py
+++ b/workers/automation/tests/test_tailor_retailor.py
@@ -8,7 +8,7 @@ from typer.testing import CliRunner
 
 from jobctrl.cli import app
 from jobctrl.database import close_connection, get_connection, get_jobs_by_stage, init_db
-from jobctrl.domain.identifiers import JobId
+from jobctrl.domain.identifiers import canonical_job_id
 from jobctrl.domain.materials import (
     Artifact,
     ArtifactStatus,
@@ -32,6 +32,8 @@ from jobctrl.scoring.tailor import (
     tailor_job_by_url,
 )
 from jobctrl.infrastructure.materials import HtmlResumePdfAdapter
+
+_JOB_ID = canonical_job_id("80000000-0000-4000-8000-000000000001")
 
 
 def _insert_job(conn, *, url: str, fit_score: int = 9, tailored_resume_path=None, tailor_attempts: int = 0) -> None:
@@ -521,6 +523,7 @@ def test_tailor_one_job_surfaces_use_case_pdf_path(tmp_path):
     # The use case owns PDF rendering (it renders the approved resume before
     # superseding the prior generation). The runner only surfaces the outcome.
     job = {
+        "job_id": str(_JOB_ID),
         "url": "https://example.com/pdf-job",
         "title": "Platform Engineer",
         "site": "example",
@@ -530,7 +533,7 @@ def test_tailor_one_job_surfaces_use_case_pdf_path(tmp_path):
     text_path.write_text("tailored resume", encoding="utf-8")
     materials = MaterialsSetFactory.initial(
         tenant_id=LOCAL_TENANT,
-        job_id=JobId(job["url"]),
+        job_id=_JOB_ID,
         created_at="2026-05-25T00:00:00+00:00",
     ).with_resume_attempt(
         Artifact.create(
@@ -566,6 +569,7 @@ def test_tailor_one_job_surfaces_use_case_pdf_failure(tmp_path):
     # A PDF render failure is handled inside the use case (it demotes the new
     # generation and returns an error outcome); the runner passes it through.
     job = {
+        "job_id": str(_JOB_ID),
         "url": "https://example.com/pdf-job",
         "title": "Platform Engineer",
         "site": "example",
@@ -575,7 +579,7 @@ def test_tailor_one_job_surfaces_use_case_pdf_failure(tmp_path):
     text_path.write_text("tailored resume", encoding="utf-8")
     rejected = MaterialsSetFactory.initial(
         tenant_id=LOCAL_TENANT,
-        job_id=JobId(job["url"]),
+        job_id=_JOB_ID,
         created_at="2026-05-25T00:00:00+00:00",
     ).with_resume_attempt(
         Artifact.create(

--- a/workers/automation/tests/test_tailor_voice_audit_integration.py
+++ b/workers/automation/tests/test_tailor_voice_audit_integration.py
@@ -62,6 +62,7 @@ from jobctrl.infrastructure.materials.html_resume_pdf import (
 )
 
 JOB_URL = "https://example.com/job/voice"
+JOB_ID = JobId("00000000-0000-4000-8000-000000000043")
 
 
 # --------------------------------------------------------------------------
@@ -93,7 +94,7 @@ class _FakeAnalyze:
         )
         analysis = EmployerAnalysis.build(
             tenant_id=tenant_id,
-            job_id=JobId(str(job["url"])),
+            job_id=JobId(str(job["job_id"])),
             generation=1,
             snapshot_hash=compute_snapshot_hash(str(job.get("full_description") or "jd")),
             canonical=canonical,
@@ -277,6 +278,7 @@ def _snapshot() -> ProfileSnapshot:
 
 def _job() -> dict:
     return {
+        "job_id": JOB_ID,
         "url": JOB_URL,
         "title": "Senior Backend Engineer",
         "site": "Acme",
@@ -292,7 +294,7 @@ def _requirement_fit_report() -> RequirementFitReport:
         weighted_impact=1.125,
     )
     return RequirementFitReport(
-        job_id=JOB_URL,
+        job_id=JOB_ID,
         score_version=1,
         employer_analysis_generation=1,
         profile_snapshot_version=1,
@@ -442,7 +444,7 @@ def test_voice_runs_before_audit_and_provenance_anchors_to_voiced_text(tmp_path:
 
     assert outcome.status == "approved"
     assert voice.calls, "voice pass must have run"
-    saved = provenance_repo.load(LOCAL_TENANT, JobId(JOB_URL))
+    saved = provenance_repo.load(LOCAL_TENANT, JOB_ID)
     assert saved is not None
     experience = next(row for row in saved.bullets if row.section == "experience")
     # The provenance anchors to the VOICED bullet, not the buzzword generator draft.
@@ -498,7 +500,7 @@ def test_gate_grounding_and_shipped_fit_persist_with_lifecycle_labels(tmp_path: 
     # Persisted provenance rows carry the grounded claim requirement link on the
     # voiced bullet, and enrichment never injected the claim's evidence ids
     # beyond what the builder bound from the profile.
-    saved = provenance_repo.load(LOCAL_TENANT, JobId(JOB_URL))
+    saved = provenance_repo.load(LOCAL_TENANT, JOB_ID)
     assert saved is not None
     experience = next(row for row in saved.bullets if row.section == "experience")
     assert "req_latency" in experience.requirement_ids
@@ -525,7 +527,7 @@ def test_voiced_bullet_is_recorded_as_voice_transform(tmp_path: Path) -> None:
         job=_job(), profile_snapshot=_snapshot(), tailored_dir=tmp_path
     )
 
-    saved = provenance_repo.load(LOCAL_TENANT, JobId(JOB_URL))
+    saved = provenance_repo.load(LOCAL_TENANT, JOB_ID)
     assert saved is not None
     experience = next(row for row in saved.bullets if row.section == "experience")
     assert experience.transform_type is TransformType.VOICE
@@ -559,7 +561,7 @@ def test_voice_introduced_fabrication_is_rejected_and_pre_voice_ships(tmp_path: 
 
     # The resume is STILL approved — the pre-voice candidate was clean and grounded.
     assert outcome.status == "approved"
-    saved = provenance_repo.load(LOCAL_TENANT, JobId(JOB_URL))
+    saved = provenance_repo.load(LOCAL_TENANT, JOB_ID)
     assert saved is not None
     shipped = Path(outcome.text_path).read_text(encoding="utf-8")
     # The fabricated "10m users" never reaches the shipped resume or the provenance.
@@ -594,7 +596,7 @@ def test_coverage_is_computed_against_rendered_text_and_provenance_backed(tmp_pa
         job=_job(), profile_snapshot=_snapshot(), tailored_dir=tmp_path
     )
 
-    saved = provenance_repo.load(LOCAL_TENANT, JobId(JOB_URL))
+    saved = provenance_repo.load(LOCAL_TENANT, JOB_ID)
     assert saved is not None and saved.coverage is not None
     coverage = saved.coverage
     assert coverage.computed_against == "rendered_text"
@@ -625,7 +627,7 @@ def test_round_trip_audited_bullet_text_equals_rendered_text(tmp_path: Path) -> 
         job=_job(), profile_snapshot=_snapshot(), tailored_dir=tmp_path
     )
 
-    saved = provenance_repo.load(LOCAL_TENANT, JobId(JOB_URL))
+    saved = provenance_repo.load(LOCAL_TENANT, JOB_ID)
     assert saved is not None
     shipped = Path(outcome.text_path).read_text(encoding="utf-8")
     # The rendered resume lines (sanitised exactly as the assembler ships them).
@@ -674,7 +676,7 @@ def test_round_trip_audited_bullet_text_equals_rendered_html_resume(tmp_path: Pa
     assert outcome.status == "approved"
     assert outcome.final_payload is not None
 
-    saved = provenance_repo.load(LOCAL_TENANT, JobId(JOB_URL))
+    saved = provenance_repo.load(LOCAL_TENANT, JOB_ID)
     assert saved is not None and saved.bullets
 
     # Render the ACCEPTED (voiced) payload through the resume document builder
@@ -722,7 +724,7 @@ def test_voice_failure_falls_back_to_pre_voice_candidate(tmp_path: Path) -> None
     )
 
     assert outcome.status == "approved"
-    saved = provenance_repo.load(LOCAL_TENANT, JobId(JOB_URL))
+    saved = provenance_repo.load(LOCAL_TENANT, JOB_ID)
     assert saved is not None
     assert saved.voice is not None and saved.voice.ran and not saved.voice.accepted
     # The pre-voice (buzzword-y but grounded) bullet shipped — no voice transform rows.
@@ -753,7 +755,7 @@ def test_no_voice_port_keeps_pre_phase3_behaviour(tmp_path: Path) -> None:
         ).execute(job=_job(), profile_snapshot=_snapshot(), tailored_dir=tmp_path)
 
     assert outcome.status == "approved"
-    saved = provenance_repo.load(LOCAL_TENANT, JobId(JOB_URL))
+    saved = provenance_repo.load(LOCAL_TENANT, JOB_ID)
     assert saved is not None
     # Coverage is still computed canonically (Phase 3 computes it regardless of voice).
     assert saved.coverage is not None

--- a/workers/automation/tests/test_v7_tailor_runtime.py
+++ b/workers/automation/tests/test_v7_tailor_runtime.py
@@ -104,6 +104,20 @@ def _seed_job(
             now,
         ),
     )
+    tailor_module.ensure_job_stage_rows(
+        conn,
+        job_id,
+        tenant_id=tenant_id,
+        discovered_at=now,
+    )
+    conn.execute(
+        """
+        UPDATE job_stage_states
+        SET state = 'succeeded'
+        WHERE tenant_id = ? AND job_id = ? AND stage = 'score'
+        """,
+        (str(tenant_id), str(job_id)),
+    )
     conn.commit()
 
 
@@ -155,13 +169,14 @@ def test_tailor_job_by_id_is_tenant_scoped_and_writes_canonical_state(
         (str(_TENANT_A), str(_JOB_ID)),
     ).fetchone()
     assert state["state"] == "succeeded"
-    assert conn.execute(
+    other_tenant_state = conn.execute(
         """
-        SELECT 1 FROM job_stage_states
+        SELECT state FROM job_stage_states
         WHERE tenant_id = ? AND job_id = ? AND stage = 'tailor'
         """,
         (str(_TENANT_B), str(_JOB_ID)),
-    ).fetchone() is None
+    ).fetchone()
+    assert other_tenant_state["state"] == "pending"
     event = conn.execute(
         """
         SELECT tenant_id, job_id, event_type FROM job_events
@@ -255,6 +270,203 @@ def test_tailor_job_by_id_skips_blocked_scores_without_generation(
         "cover": "blocked",
         "tailor": "blocked",
     }
+
+
+@pytest.mark.parametrize(
+    ("score_state", "seed_staleness"),
+    [
+        ("stale", False),
+        ("succeeded", True),
+    ],
+)
+def test_tailor_job_by_id_rejects_stale_score_state_before_generation(
+    conn: sqlite3.Connection,
+    monkeypatch: pytest.MonkeyPatch,
+    score_state: str,
+    seed_staleness: bool,
+) -> None:
+    _seed_job(conn, tenant_id=_TENANT_A, url="https://example.com/stale-score")
+    tailor_module.ensure_job_stage_rows(
+        conn,
+        _JOB_ID,
+        tenant_id=_TENANT_A,
+        discovered_at="2026-07-31T12:00:00+00:00",
+    )
+    conn.execute(
+        """
+        UPDATE job_stage_states
+        SET state = ?
+        WHERE tenant_id = ? AND job_id = ? AND stage = 'score'
+        """,
+        (score_state, str(_TENANT_A), str(_JOB_ID)),
+    )
+    if seed_staleness:
+        conn.execute(
+            """
+            INSERT INTO job_score_staleness (
+                tenant_id, job_id, stale_reason,
+                old_policy_version, new_policy_version, marked_at
+            ) VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (
+                str(_TENANT_A),
+                str(_JOB_ID),
+                "policy_changed",
+                1,
+                2,
+                "2026-07-31T12:00:01+00:00",
+            ),
+        )
+    conn.commit()
+    monkeypatch.setattr(tailor_module, "get_connection", lambda: conn)
+    monkeypatch.setattr(
+        tailor_module,
+        "_tailor_one_job",
+        lambda *_args, **_kwargs: pytest.fail("stale score reached generation"),
+    )
+
+    result = tailor_module.tailor_job_by_id(
+        _JOB_ID,
+        tenant_id=_TENANT_A,
+        snapshot=SimpleNamespace(),
+        llm_model=None,
+    )
+
+    assert result["reason"] == "not_eligible"
+
+
+@pytest.mark.parametrize(
+    ("active_state", "confidence", "quarantine_reason"),
+    [
+        ("closed", "high", None),
+        ("active", "low", "contradictory_snapshot"),
+    ],
+)
+def test_tailor_job_by_id_rejects_inactive_or_quarantined_postings(
+    conn: sqlite3.Connection,
+    monkeypatch: pytest.MonkeyPatch,
+    active_state: str,
+    confidence: str,
+    quarantine_reason: str | None,
+) -> None:
+    _seed_job(conn, tenant_id=_TENANT_A, url="https://example.com/quarantined")
+    conn.execute(
+        """
+        INSERT INTO posting_snapshot_sets (
+            tenant_id, job_id, snapshot_set_json, latest_snapshot_version,
+            latest_active_state, latest_confidence,
+            latest_quarantine_reason, updated_at
+        ) VALUES (?, ?, '{}', 1, ?, ?, ?, ?)
+        """,
+        (
+            str(_TENANT_A),
+            str(_JOB_ID),
+            active_state,
+            confidence,
+            quarantine_reason,
+            "2026-07-31T12:00:01+00:00",
+        ),
+    )
+    conn.commit()
+    monkeypatch.setattr(tailor_module, "get_connection", lambda: conn)
+    monkeypatch.setattr(
+        tailor_module,
+        "_tailor_one_job",
+        lambda *_args, **_kwargs: pytest.fail(
+            "inactive or quarantined posting reached generation"
+        ),
+    )
+
+    result = tailor_module.tailor_job_by_id(
+        _JOB_ID,
+        tenant_id=_TENANT_A,
+        snapshot=SimpleNamespace(),
+        llm_model=None,
+    )
+
+    assert result["reason"] == "not_eligible"
+
+
+def test_tailor_job_by_id_allows_explicit_low_confidence_override_state(
+    conn: sqlite3.Connection,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _seed_job(conn, tenant_id=_TENANT_A, url="https://example.com/override")
+    conn.execute(
+        """
+        INSERT INTO posting_snapshot_sets (
+            tenant_id, job_id, snapshot_set_json, latest_snapshot_version,
+            latest_active_state, latest_confidence,
+            latest_quarantine_reason, updated_at
+        ) VALUES (?, ?, '{}', 1, 'active', 'low', 'none', ?)
+        """,
+        (
+            str(_TENANT_A),
+            str(_JOB_ID),
+            "2026-07-31T12:00:01+00:00",
+        ),
+    )
+    conn.commit()
+    calls: list[str] = []
+
+    def fake_tailor(job: dict, *_args, **_kwargs) -> dict:
+        calls.append(str(job["job_id"]))
+        return _fake_approved_result(job)
+
+    monkeypatch.setattr(tailor_module, "get_connection", lambda: conn)
+    monkeypatch.setattr(tailor_module, "TAILORED_DIR", tmp_path / "tailored")
+    monkeypatch.setattr(tailor_module, "_build_pdf_renderer", lambda: object())
+    monkeypatch.setattr(tailor_module, "_tailor_one_job", fake_tailor)
+
+    result = tailor_module.tailor_job_by_id(
+        _JOB_ID,
+        tenant_id=_TENANT_A,
+        snapshot=SimpleNamespace(),
+        llm_model=None,
+    )
+
+    assert result["status"] == "approved"
+    assert calls == [str(_JOB_ID)]
+
+
+@pytest.mark.parametrize("retry_state", ["running", "failed"])
+def test_tailor_job_by_id_allows_temporal_retry_to_reenter_generation(
+    conn: sqlite3.Connection,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    retry_state: str,
+) -> None:
+    _seed_job(conn, tenant_id=_TENANT_A, url="https://example.com/retry")
+    conn.execute(
+        """
+        UPDATE job_stage_states
+        SET state = ?, attempt_count = 1
+        WHERE tenant_id = ? AND job_id = ? AND stage = 'tailor'
+        """,
+        (retry_state, str(_TENANT_A), str(_JOB_ID)),
+    )
+    conn.commit()
+    calls: list[str] = []
+
+    def fake_tailor(job: dict, *_args, **_kwargs) -> dict:
+        calls.append(str(job["job_id"]))
+        return _fake_approved_result(job)
+
+    monkeypatch.setattr(tailor_module, "get_connection", lambda: conn)
+    monkeypatch.setattr(tailor_module, "TAILORED_DIR", tmp_path / "tailored")
+    monkeypatch.setattr(tailor_module, "_build_pdf_renderer", lambda: object())
+    monkeypatch.setattr(tailor_module, "_tailor_one_job", fake_tailor)
+
+    result = tailor_module.tailor_job_by_id(
+        _JOB_ID,
+        tenant_id=_TENANT_A,
+        snapshot=SimpleNamespace(),
+        llm_model=None,
+    )
+
+    assert result["status"] == "approved"
+    assert calls == [str(_JOB_ID)]
 
 
 def test_tailor_job_by_id_rejects_deleted_and_url_shaped_targets_before_generation(

--- a/workers/automation/tests/test_v7_tailor_runtime.py
+++ b/workers/automation/tests/test_v7_tailor_runtime.py
@@ -1,0 +1,358 @@
+"""Exact-v7 proof for the canonical per-job tailoring execution path."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from jobctrl.domain.identifiers import JobId, canonical_job_id
+from jobctrl.domain.tenant import TenantId
+from jobctrl.infrastructure.migrations.schema_v7 import create_exact_v7_schema
+from jobctrl.materials import activities as activities_module
+from jobctrl.materials.activities import TailorJobActivityInput
+from jobctrl.scoring import tailor as tailor_module
+
+_TENANT_A = TenantId("tenant-a")
+_TENANT_B = TenantId("tenant-b")
+_JOB_ID = canonical_job_id("30000000-0000-4000-8000-000000000001")
+
+
+@pytest.fixture()
+def conn() -> sqlite3.Connection:
+    candidate = sqlite3.connect(":memory:")
+    candidate.row_factory = sqlite3.Row
+    candidate.execute("PRAGMA foreign_keys = ON")
+    create_exact_v7_schema(candidate)
+    return candidate
+
+
+def _seed_job(
+    conn: sqlite3.Connection,
+    *,
+    tenant_id: TenantId,
+    job_id: JobId = _JOB_ID,
+    url: str,
+    fit_score: int = 8,
+    eligibility_status: str = "eligible",
+    hard_blockers: list[str] | None = None,
+) -> None:
+    now = "2026-07-31T12:00:00+00:00"
+    conn.execute(
+        """
+        INSERT INTO jobs (
+            tenant_id, job_id, url, title, company, description, discovered_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            str(tenant_id),
+            str(job_id),
+            url,
+            "Platform Engineer",
+            "Acme",
+            "Build reliable backend systems.",
+            now,
+        ),
+    )
+    conn.execute(
+        """
+        INSERT INTO job_enrichments (
+            tenant_id, job_id, current_status, full_description,
+            application_url, enriched_at, extraction_tier, attempts_json, updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, '[]', ?)
+        """,
+        (
+            str(tenant_id),
+            str(job_id),
+            "enriched",
+            "Build reliable backend systems with Python.",
+            url,
+            now,
+            "full",
+            now,
+        ),
+    )
+    conn.execute(
+        """
+        INSERT INTO job_scores (
+            tenant_id, job_id, version, fit_score, breakdown_json,
+            keywords_json, scored_at, correction_json, criteria_json, trace_json
+        ) VALUES (?, ?, 1, ?, ?, '[]', ?, NULL, '{}', '{}')
+        """,
+        (
+            str(tenant_id),
+            str(job_id),
+            fit_score,
+            json.dumps(
+                {
+                    "technical_fit": fit_score,
+                    "experience_fit": fit_score,
+                    "role_fit": fit_score,
+                    "reasoning": "seeded exact-v7 score",
+                    "fit_band": "excellent",
+                    "confidence": "high",
+                    "eligibility": {
+                        "status": eligibility_status,
+                        "hard_blockers": hard_blockers or [],
+                        "warnings": [],
+                    },
+                }
+            ),
+            now,
+        ),
+    )
+    conn.commit()
+
+
+def _fake_approved_result(job: dict) -> dict:
+    return {
+        "url": job["url"],
+        "title": job["title"],
+        "site": job.get("site"),
+        "status": "approved",
+        "attempts": 1,
+        "path": "/tmp/tailored.txt",
+        "pdf_path": "/tmp/tailored.pdf",
+        "materials": SimpleNamespace(generation=1),
+    }
+
+
+def test_tailor_job_by_id_is_tenant_scoped_and_writes_canonical_state(
+    conn: sqlite3.Connection,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _seed_job(conn, tenant_id=_TENANT_A, url="https://example.com/a")
+    _seed_job(conn, tenant_id=_TENANT_B, url="https://example.com/b")
+    calls: list[tuple[str, str]] = []
+
+    def fake_tailor(job: dict, *_args, **_kwargs) -> dict:
+        calls.append((str(job["tenant_id"]), str(job["url"])))
+        return _fake_approved_result(job)
+
+    monkeypatch.setattr(tailor_module, "get_connection", lambda: conn)
+    monkeypatch.setattr(tailor_module, "TAILORED_DIR", tmp_path / "tailored")
+    monkeypatch.setattr(tailor_module, "_build_pdf_renderer", lambda: object())
+    monkeypatch.setattr(tailor_module, "_tailor_one_job", fake_tailor)
+
+    result = tailor_module.tailor_job_by_id(
+        _JOB_ID,
+        tenant_id=_TENANT_A,
+        snapshot=SimpleNamespace(),
+        llm_model=None,
+    )
+
+    assert result["status"] == "approved"
+    assert calls == [(str(_TENANT_A), "https://example.com/a")]
+    state = conn.execute(
+        """
+        SELECT state FROM job_stage_states
+        WHERE tenant_id = ? AND job_id = ? AND stage = 'tailor'
+        """,
+        (str(_TENANT_A), str(_JOB_ID)),
+    ).fetchone()
+    assert state["state"] == "succeeded"
+    assert conn.execute(
+        """
+        SELECT 1 FROM job_stage_states
+        WHERE tenant_id = ? AND job_id = ? AND stage = 'tailor'
+        """,
+        (str(_TENANT_B), str(_JOB_ID)),
+    ).fetchone() is None
+    event = conn.execute(
+        """
+        SELECT tenant_id, job_id, event_type FROM job_events
+        WHERE tenant_id = ? AND job_id = ? AND stage = 'tailor'
+        ORDER BY event_id DESC LIMIT 1
+        """,
+        (str(_TENANT_A), str(_JOB_ID)),
+    ).fetchone()
+    assert dict(event) == {
+        "tenant_id": str(_TENANT_A),
+        "job_id": str(_JOB_ID),
+        "event_type": "StageCompleted",
+    }
+
+
+def test_tailor_job_by_id_enforces_score_boundary_before_generation(
+    conn: sqlite3.Connection,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _seed_job(conn, tenant_id=_TENANT_A, url="https://example.com/low-fit", fit_score=6)
+    calls: list[str] = []
+
+    def fake_tailor(job: dict, *_args, **_kwargs) -> dict:
+        calls.append(str(job["job_id"]))
+        return _fake_approved_result(job)
+
+    monkeypatch.setattr(tailor_module, "get_connection", lambda: conn)
+    monkeypatch.setattr(tailor_module, "TAILORED_DIR", tmp_path / "tailored")
+    monkeypatch.setattr(tailor_module, "_build_pdf_renderer", lambda: object())
+    monkeypatch.setattr(tailor_module, "_tailor_one_job", fake_tailor)
+
+    skipped = tailor_module.tailor_job_by_id(
+        _JOB_ID,
+        tenant_id=_TENANT_A,
+        min_score=7,
+        snapshot=SimpleNamespace(),
+        llm_model=None,
+    )
+    approved = tailor_module.tailor_job_by_id(
+        _JOB_ID,
+        tenant_id=_TENANT_A,
+        min_score=7,
+        allow_low_fit_override=True,
+        snapshot=SimpleNamespace(),
+        llm_model=None,
+    )
+
+    assert skipped["reason"] == "not_eligible"
+    assert approved["status"] == "approved"
+    assert calls == [str(_JOB_ID)]
+
+
+def test_tailor_job_by_id_skips_blocked_scores_without_generation(
+    conn: sqlite3.Connection,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _seed_job(
+        conn,
+        tenant_id=_TENANT_A,
+        url="https://example.com/blocked",
+        eligibility_status="blocked",
+        hard_blockers=["Sponsorship is required."],
+    )
+
+    monkeypatch.setattr(tailor_module, "get_connection", lambda: conn)
+    monkeypatch.setattr(
+        tailor_module,
+        "_tailor_one_job",
+        lambda *_args, **_kwargs: pytest.fail("blocked job reached generation"),
+    )
+
+    result = tailor_module.tailor_job_by_id(
+        _JOB_ID,
+        tenant_id=_TENANT_A,
+        snapshot=SimpleNamespace(),
+        llm_model=None,
+    )
+
+    assert result["reason"] == "score_eligibility_blocked"
+    rows = conn.execute(
+        """
+        SELECT stage, state FROM job_stage_states
+        WHERE tenant_id = ? AND job_id = ? AND stage IN ('tailor', 'cover', 'apply')
+        ORDER BY stage
+        """,
+        (str(_TENANT_A), str(_JOB_ID)),
+    ).fetchall()
+    assert {row["stage"]: row["state"] for row in rows} == {
+        "apply": "blocked",
+        "cover": "blocked",
+        "tailor": "blocked",
+    }
+
+
+def test_tailor_job_by_id_rejects_deleted_and_url_shaped_targets_before_generation(
+    conn: sqlite3.Connection,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _seed_job(conn, tenant_id=_TENANT_A, url="https://example.com/deleted")
+    conn.execute(
+        """
+        INSERT INTO jobctrl_deleted_jobs (tenant_id, job_id, deleted_at, reason, restored_at)
+        VALUES (?, ?, ?, ?, NULL)
+        """,
+        (str(_TENANT_A), str(_JOB_ID), "2026-07-31T12:00:01+00:00", "test"),
+    )
+    conn.commit()
+    monkeypatch.setattr(tailor_module, "get_connection", lambda: conn)
+    monkeypatch.setattr(
+        tailor_module,
+        "_tailor_one_job",
+        lambda *_args, **_kwargs: pytest.fail("rejected job reached generation"),
+    )
+
+    deleted = tailor_module.tailor_job_by_id(
+        _JOB_ID,
+        tenant_id=_TENANT_A,
+        snapshot=SimpleNamespace(),
+        llm_model=None,
+    )
+
+    assert deleted == {
+        "job_id": str(_JOB_ID),
+        "status": "skipped",
+        "reason": "not_found",
+    }
+    assert conn.execute("SELECT COUNT(*) FROM job_events").fetchone()[0] == 0
+    monkeypatch.setattr(
+        tailor_module,
+        "get_connection",
+        lambda: pytest.fail("URL-shaped JobId must fail before opening storage"),
+    )
+    with pytest.raises(ValueError, match="JobId must be a canonical UUID"):
+        tailor_module.tailor_job_by_id(
+            JobId("https://example.com/legacy"),
+            tenant_id=_TENANT_A,
+        )
+
+
+def test_tailor_job_activity_wires_canonical_job_id_to_runtime(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_tailor_job_by_id(job_id: JobId, **kwargs: object) -> dict[str, object]:
+        captured["job_id"] = job_id
+        captured.update(kwargs)
+        return {"status": "approved"}
+
+    monkeypatch.setattr(tailor_module, "tailor_job_by_id", fake_tailor_job_by_id)
+    payload = TailorJobActivityInput(
+        tenant_id=str(_TENANT_A),
+        job_id=_JOB_ID,
+        min_score=8,
+        retailor=True,
+    )
+
+    assert activities_module._tailor_one_job(payload) == {"status": "approved"}
+    assert captured["job_id"] == _JOB_ID
+    assert captured["tenant_id"] == _TENANT_A
+    assert captured["min_score"] == 8
+    assert captured["retailor"] is True
+
+
+def test_tailor_one_job_passes_canonical_id_to_materials_use_case() -> None:
+    captured: dict[str, object] = {}
+
+    class FakeUseCase:
+        def execute(self, **kwargs: object) -> SimpleNamespace:
+            captured.update(kwargs)
+            return SimpleNamespace(
+                text_path="/tmp/tailored.txt",
+                pdf_path="/tmp/tailored.pdf",
+                status="approved",
+                attempts=1,
+                materials=SimpleNamespace(generation=1),
+                error=None,
+            )
+
+    result = tailor_module._tailor_one_job(
+        {
+            "job_id": str(_JOB_ID),
+            "url": "https://example.com/materials",
+            "title": "Platform Engineer",
+        },
+        "",
+        SimpleNamespace(),
+        "normal",
+        use_case=FakeUseCase(),
+    )
+
+    assert result["status"] == "approved"
+    assert captured["job_id"] == _JOB_ID

--- a/workers/automation/tests/test_workflow_job_preparation.py
+++ b/workers/automation/tests/test_workflow_job_preparation.py
@@ -451,3 +451,73 @@ async def test_preparation_workflow_resumes_at_cover_after_worker_restart(
     assert result.steps_completed == ["score", "tailor", "cover", "pdf"]
     assert result.steps_failed == []
     assert calls == ["score", "tailor", "cover", "cover", "pdf"]
+
+
+@pytest.mark.asyncio
+async def test_preparation_workflow_retries_transient_tailor_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    queue = f"prep-tailor-retry-{uuid.uuid4()}"
+    attempts = 0
+
+    @activity.defn(name="record_workflow_started")
+    async def record_started(_payload) -> None:
+        return None
+
+    @activity.defn(name="record_workflow_outcome")
+    async def record_outcome(_payload) -> None:
+        return None
+
+    def fake_tailor_job(_payload) -> dict[str, object]:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise RuntimeError("temporary tailoring outage")
+        return {"status": "approved", "materials": SimpleNamespace(generation=1)}
+
+    monkeypatch.setattr("jobctrl.materials.activities._tailor_one_job", fake_tailor_job)
+    payload = JobPreparationInput(
+        tenant_id="local",
+        job_id=_JOB_ID,
+        steps=["tailor"],
+        target_version="1",
+        idempotency_key=f"preparation:{uuid.uuid4().hex}",
+    )
+    original_tailor_retry = prep_workflow_mod._TAILOR_RETRY
+    prep_workflow_mod._TAILOR_RETRY = RetryPolicy(
+        initial_interval=timedelta(milliseconds=100),
+        maximum_interval=timedelta(milliseconds=100),
+        maximum_attempts=3,
+        non_retryable_error_types=["configuration", "authentication", "missing_input"],
+    )
+
+    try:
+        async with await WorkflowEnvironment.start_time_skipping() as env:
+            async with Worker(
+                env.client,
+                task_queue=queue,
+                workflows=[JobPreparationWorkflow],
+                activities=[
+                    _check_spend_budget,
+                    record_started,
+                    record_outcome,
+                    tailor_job_activity,
+                ],
+                workflow_runner=UnsandboxedWorkflowRunner(),
+            ):
+                result = await asyncio.wait_for(
+                    env.client.execute_workflow(
+                        JobPreparationWorkflow.run,
+                        payload,
+                        id=f"prep-{payload.idempotency_key}",
+                        task_queue=queue,
+                        id_conflict_policy=WorkflowIDConflictPolicy.USE_EXISTING,
+                    ),
+                    timeout=30,
+                )
+    finally:
+        prep_workflow_mod._TAILOR_RETRY = original_tailor_retry
+
+    assert result.steps_completed == ["tailor"]
+    assert result.steps_failed == []
+    assert attempts == 2


### PR DESCRIPTION
## Summary

- route per-job tailoring through tenant-scoped canonical `JobId` while retaining posting URLs only as admission locators
- preserve score freshness, posting actionability, quarantine, retry, blocker, and attempt-limit gates
- key requirement-fit reports, target profiles, materials, state, and events by canonical identity
- keep the last accepted artifact reviewable across failed re-tailor and PDF-render attempts

## Stack

- Stacked on #622
- This PR is the bounded tailoring runtime slice; cover generation and batch selector migration follow separately

## Validation

- 136 focused Python tests passed across exact-v7 tailoring, materials quality/use cases, provenance, workflow retry, and directly affected re-tailor paths
- independent review: PASS (0 Blocker / 0 High / 0 Medium / 0 Low)
- independent QA: PASS (0 Blocker / 0 High / 0 Medium / 0 Low)
- Ruff passed on all touched Python files
- `git diff --check` passed

## Known stack note

Seven inherited legacy selector fixtures in `test_tailor_retailor.py` still insert pre-v7 job rows and are assigned to the separate exact-v7 selector PR. The bounded runtime behavior here is independently covered against the exact-v7 schema.