### PR TITLE
fix(scoring): key feedback by canonical job id

### DIFF
--- a/apps/api/src/application-feedback.ts
+++ b/apps/api/src/application-feedback.ts
@@ -1586,9 +1586,25 @@ function profileSourceFieldsForApplyReview(db: SqliteDatabase): ApplyReviewProfi
   return uniqueProfileSourceFields(fields).slice(0, PROFILE_SOURCE_FIELD_LIMIT);
 }
 
+const APPLICATION_ATTESTATION_PROFILE_COLUMNS = [
+  ["age_18_plus", "application_attestation_age_18_plus"],
+  ["background_check_consent", "application_attestation_background_check_consent"],
+  ["felony_conviction", "application_attestation_felony_conviction"],
+  ["previously_worked_at_employer", "application_attestation_previously_worked_at_employer"],
+] as const;
+
 function missingApplicationAttestationFields(db: SqliteDatabase): string[] {
-  void db;
-  return [];
+  const row = getRow<Record<string, unknown>>(
+    db,
+    `SELECT ${APPLICATION_ATTESTATION_PROFILE_COLUMNS.map(([, column]) => column).join(", ")}
+       FROM candidate_profiles
+      WHERE tenant_id = ? AND profile_id = ?`,
+    [DEFAULT_TENANT, DEFAULT_PROFILE_ID],
+  );
+  if (!row) return [];
+  return APPLICATION_ATTESTATION_PROFILE_COLUMNS
+    .filter(([, column]) => row[column] === undefined || row[column] === null || row[column] === "")
+    .map(([field]) => field);
 }
 
 function appendProfileRootSourceFields(db: SqliteDatabase, fields: ApplyReviewProfileSourceField[]): void {

--- a/apps/api/src/application-feedback.ts
+++ b/apps/api/src/application-feedback.ts
@@ -44,17 +44,15 @@ import {
   STAGE_STATES,
 } from "./contracts.js";
 import { buildApplyAudit } from "./apply-audit.js";
-import { allRows, getRow, tableExists, type SqliteDatabase, type SqliteValue } from "./db.js";
+import { allRows, getRow, type SqliteDatabase } from "./db.js";
 import { refreshProjections } from "./projections.js";
-import {
-  ensureRepeatApplicationTables,
-  evaluateRepeatApplication,
-} from "./repeat-application.js";
+import { evaluateRepeatApplication } from "./repeat-application.js";
 import { resumeTemplateStateForJob } from "./resume-templates.js";
-import { InputError, resolveJobUrl } from "./write-model.js";
+import { InputError, resolveJobId } from "./write-model.js";
 
 const DEFAULT_TENANT = "local";
 const DEFAULT_PROFILE_ID = "default";
+const CANONICAL_JOB_ID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
 const CLOSED_ACTIVE_STATES = ["closed", "expired", "removed", "location_incompatible"];
 const POSITION_PREVIEW_CHAR_LIMIT = 6000;
 const MATERIAL_PREVIEW_CHAR_LIMIT = 4000;
@@ -76,6 +74,7 @@ interface ReviewQueueRow extends Record<string, unknown> {
   source: string;
   compensation_summary_json: string | null;
   application_url: string | null;
+  posting_url: string | null;
   fit_score: number | null;
   description: string;
   full_description: string;
@@ -116,7 +115,7 @@ interface ReviewQueueRow extends Record<string, unknown> {
 
 interface OutcomeRow extends Record<string, unknown> {
   outcome_id: string;
-  job_key: string;
+  job_id: string;
   kind: string;
   source: string;
   note: string | null;
@@ -129,7 +128,7 @@ interface OutcomeRow extends Record<string, unknown> {
 
 interface SuggestionRow extends Record<string, unknown> {
   suggestion_id: string;
-  job_key: string;
+  job_id: string;
   evidence_id: string | null;
   suggested_kind: string;
   confidence: number;
@@ -142,180 +141,55 @@ interface SuggestionRow extends Record<string, unknown> {
 }
 
 export function ensureApplicationFeedbackTables(db: SqliteDatabase): void {
-  db.exec(`
-    CREATE TABLE IF NOT EXISTS application_review_decisions (
-      tenant_id    TEXT NOT NULL DEFAULT 'local',
-      decision_id  TEXT NOT NULL,
-      job_key      TEXT NOT NULL,
-      decision     TEXT NOT NULL,
-      reason       TEXT,
-      decided_by   TEXT NOT NULL DEFAULT 'user',
-      decided_at   TEXT NOT NULL,
-      materials_generation INTEGER,
-      profile_version INTEGER,
-      application_url TEXT,
-      partial_override_run_id TEXT,
-      email_recipient TEXT,
-      email_attachment_artifact_id TEXT,
-      PRIMARY KEY (tenant_id, decision_id)
-    );
-    CREATE INDEX IF NOT EXISTS idx_application_review_decisions_job
-      ON application_review_decisions(tenant_id, job_key, decided_at DESC);
-
-    CREATE TABLE IF NOT EXISTS application_outcomes (
-      tenant_id     TEXT NOT NULL DEFAULT 'local',
-      outcome_id    TEXT NOT NULL,
-      job_key       TEXT NOT NULL,
-      kind          TEXT NOT NULL,
-      source        TEXT NOT NULL,
-      note          TEXT,
-      occurred_at   TEXT NOT NULL,
-      recorded_at   TEXT NOT NULL,
-      suggestion_id TEXT,
-      evidence_id   TEXT,
-      created_by    TEXT NOT NULL DEFAULT 'user',
-      PRIMARY KEY (tenant_id, outcome_id)
-    );
-    CREATE INDEX IF NOT EXISTS idx_application_outcomes_job
-      ON application_outcomes(tenant_id, job_key, occurred_at DESC, recorded_at DESC);
-
-    CREATE TABLE IF NOT EXISTS application_email_evidence (
-      tenant_id            TEXT NOT NULL DEFAULT 'local',
-      evidence_id          TEXT NOT NULL,
-      job_key              TEXT NOT NULL,
-      provider             TEXT NOT NULL DEFAULT 'gmail',
-      provider_message_id  TEXT NOT NULL,
-      provider_thread_id   TEXT,
-      from_address         TEXT,
-      to_addresses_json    TEXT NOT NULL DEFAULT '[]',
-      subject              TEXT,
-      snippet              TEXT,
-      received_at          TEXT,
-      linked_at            TEXT NOT NULL,
-      link_confidence      REAL NOT NULL DEFAULT 0,
-      link_signals_json    TEXT NOT NULL DEFAULT '[]',
-      body_text            TEXT,
-      body_sha256          TEXT,
-      body_stored_at       TEXT,
-      PRIMARY KEY (tenant_id, evidence_id),
-      UNIQUE (tenant_id, provider, provider_message_id)
-    );
-    CREATE INDEX IF NOT EXISTS idx_application_email_evidence_job
-      ON application_email_evidence(tenant_id, job_key, received_at DESC);
-
-    CREATE TABLE IF NOT EXISTS application_outcome_suggestions (
-      tenant_id          TEXT NOT NULL DEFAULT 'local',
-      suggestion_id      TEXT NOT NULL,
-      job_key            TEXT NOT NULL,
-      evidence_id        TEXT,
-      suggested_kind     TEXT NOT NULL,
-      confidence         REAL NOT NULL DEFAULT 0,
-      rationale          TEXT NOT NULL DEFAULT '',
-      status             TEXT NOT NULL DEFAULT 'pending',
-      created_at         TEXT NOT NULL,
-      decided_at         TEXT,
-      decision           TEXT,
-      decision_reason    TEXT,
-      decided_outcome_id TEXT,
-      PRIMARY KEY (tenant_id, suggestion_id)
-    );
-    CREATE INDEX IF NOT EXISTS idx_application_outcome_suggestions_job
-      ON application_outcome_suggestions(tenant_id, job_key, status, created_at DESC);
-    CREATE INDEX IF NOT EXISTS idx_application_outcome_suggestions_status
-      ON application_outcome_suggestions(tenant_id, status, created_at DESC);
-  `);
-  ensureApplicationReviewDecisionColumns(db);
-  ensureApplicationOutcomeColumns(db);
-  ensureRepeatApplicationTables(db);
-}
-
-function ensureApplicationReviewDecisionColumns(db: SqliteDatabase): void {
-  const columns = tableColumnSet(db, "application_review_decisions");
-  const additions: Record<string, string> = {
-    materials_generation: "INTEGER",
-    profile_version: "INTEGER",
-    application_url: "TEXT",
-    partial_override_run_id: "TEXT",
-    email_recipient: "TEXT",
-    email_attachment_artifact_id: "TEXT",
-  };
-  for (const [column, definition] of Object.entries(additions)) {
-    if (!columns.has(column)) {
-      db.exec(`ALTER TABLE application_review_decisions ADD COLUMN ${column} ${definition}`);
-    }
-  }
-}
-
-function ensureApplicationOutcomeColumns(db: SqliteDatabase): void {
-  const columns = tableColumnSet(db, "application_outcomes");
-  const additions: Record<string, string> = {
-    interview_prep_generation: "INTEGER",
-  };
-  for (const [column, definition] of Object.entries(additions)) {
-    if (!columns.has(column)) {
-      db.exec(`ALTER TABLE application_outcomes ADD COLUMN ${column} ${definition}`);
-    }
-  }
+  void db;
 }
 
 export function listApplyReviewQueue(db: SqliteDatabase): ApplyReviewQueueResponse {
   ensureApplicationFeedbackTables(db);
   refreshProjections(db);
 
-  const hiddenWhere = tableExists(db, "jobctrl_hidden_jobs")
-    ? `AND NOT EXISTS (
-         SELECT 1 FROM jobctrl_hidden_jobs h
-         WHERE h.job_url = jlp.job_id AND h.unhidden_at IS NULL
-       )`
-    : "";
-  const closedWhere = tableExists(db, "posting_snapshot_sets")
-    ? `AND NOT EXISTS (
-         SELECT 1 FROM posting_snapshot_sets pss
-         WHERE pss.job_url = jlp.job_id
-           AND pss.latest_active_state IN (${CLOSED_ACTIVE_STATES.map(() => "?").join(", ")})
-       )`
-    : "";
-  const closedParams = tableExists(db, "posting_snapshot_sets") ? CLOSED_ACTIVE_STATES : [];
-  const hasEmployerAnalysis = tableExists(db, "job_employer_analysis");
-  const employerAnalysisCte = hasEmployerAnalysis
-    ? `,
+  const hiddenWhere = `AND NOT EXISTS (
+    SELECT 1 FROM jobctrl_hidden_jobs h
+    WHERE h.tenant_id = jlp.tenant_id
+      AND h.job_id = jlp.job_id
+      AND h.unhidden_at IS NULL
+  )`;
+  const closedWhere = `AND NOT EXISTS (
+    SELECT 1 FROM posting_snapshot_sets pss
+    WHERE pss.tenant_id = jlp.tenant_id
+      AND pss.job_id = jlp.job_id
+      AND pss.latest_active_state IN (${CLOSED_ACTIVE_STATES.map(() => "?").join(", ")})
+  )`;
+  const employerAnalysisCte = `,
     latest_employer_analysis AS (
-      SELECT job_url, ideal_candidate_narrative, requirements_json
+      SELECT tenant_id, job_id, ideal_candidate_narrative, requirements_json
       FROM (
-        SELECT job_url, ideal_candidate_narrative, requirements_json,
+        SELECT tenant_id, job_id, ideal_candidate_narrative, requirements_json,
                ROW_NUMBER() OVER (
-                 PARTITION BY tenant_id, job_url
+                 PARTITION BY tenant_id, job_id
                  ORDER BY generation DESC
                ) AS row_num
         FROM job_employer_analysis
         WHERE tenant_id = ?
       )
       WHERE row_num = 1
-    )`
-    : "";
-  const employerAnalysisSelect = hasEmployerAnalysis
-    ? `,
-           latest_employer_analysis.ideal_candidate_narrative AS employer_ideal_candidate_narrative,
-           latest_employer_analysis.requirements_json AS employer_requirements_json`
-    : `,
-           NULL AS employer_ideal_candidate_narrative,
-           NULL AS employer_requirements_json`;
-  const employerAnalysisJoin = hasEmployerAnalysis
-    ? "LEFT JOIN latest_employer_analysis ON latest_employer_analysis.job_url = jlp.job_id"
-    : "";
+    )`;
+  const employerAnalysisSelect = `,
+         latest_employer_analysis.ideal_candidate_narrative AS employer_ideal_candidate_narrative,
+         latest_employer_analysis.requirements_json AS employer_requirements_json`;
   const rows = allRows<ReviewQueueRow>(
     db,
     `
     WITH latest_decision AS (
-      SELECT decision_id, job_key, decision, decided_at,
+      SELECT tenant_id, decision_id, job_id, decision, decided_at,
              materials_generation, profile_version, application_url,
              partial_override_run_id, email_recipient, email_attachment_artifact_id
       FROM (
-        SELECT decision_id, job_key, decision, decided_at,
+        SELECT tenant_id, decision_id, job_id, decision, decided_at,
                materials_generation, profile_version, application_url,
                partial_override_run_id, email_recipient, email_attachment_artifact_id,
                ROW_NUMBER() OVER (
-                 PARTITION BY tenant_id, job_key
+                 PARTITION BY tenant_id, job_id
                  ORDER BY decided_at DESC, decision_id DESC
                ) AS row_num
         FROM application_review_decisions
@@ -324,9 +198,9 @@ export function listApplyReviewQueue(db: SqliteDatabase): ApplyReviewQueueRespon
       WHERE row_num = 1
     ),
     latest_apply_run AS (
-      SELECT run_id, job_id, status, result, dry_run, started_at, finished_at
+      SELECT tenant_id, run_id, job_id, status, result, dry_run, started_at, finished_at
       FROM (
-        SELECT run_id, job_id, status, result, dry_run, started_at, finished_at,
+        SELECT tenant_id, run_id, job_id, status, result, dry_run, started_at, finished_at,
                ROW_NUMBER() OVER (
                  PARTITION BY tenant_id, job_id
                  ORDER BY COALESCE(started_at, finished_at, '') DESC, run_id DESC
@@ -337,11 +211,11 @@ export function listApplyReviewQueue(db: SqliteDatabase): ApplyReviewQueueRespon
       WHERE row_num = 1
     ),
     apply_stage AS (
-      SELECT job_url, state
+      SELECT tenant_id, job_id, state
       FROM (
-        SELECT job_url, state,
+        SELECT tenant_id, job_id, state,
                ROW_NUMBER() OVER (
-                 PARTITION BY job_url
+                 PARTITION BY tenant_id, job_id
                  ORDER BY COALESCE(updated_at, '') DESC, rowid DESC
                ) AS row_num
         FROM job_stage_states
@@ -352,6 +226,7 @@ export function listApplyReviewQueue(db: SqliteDatabase): ApplyReviewQueueRespon
     ${employerAnalysisCte}
     SELECT jlp.job_id, jlp.title, jlp.employer, jlp.source,
            jlp.compensation_summary_json, jlp.application_url,
+           jobs.url AS posting_url,
            jlp.fit_score, jlp.description, jlp.full_description,
            jlp.score_breakdown_json, jlp.score_keywords_json,
            jlp.score_reasoning, jlp.score_version, jlp.scored_at,
@@ -373,11 +248,20 @@ export function listApplyReviewQueue(db: SqliteDatabase): ApplyReviewQueueRespon
            jdp.requirement_fit_report_json
            ${employerAnalysisSelect}
     FROM job_list_projections jlp
+    INNER JOIN jobs ON jobs.tenant_id = jlp.tenant_id AND jobs.job_id = jlp.job_id
     LEFT JOIN job_detail_projections jdp ON jdp.tenant_id = jlp.tenant_id AND jdp.job_id = jlp.job_id
-    LEFT JOIN latest_decision ON latest_decision.job_key = jlp.job_id
-    LEFT JOIN latest_apply_run ON latest_apply_run.job_id = jlp.job_id
-    INNER JOIN apply_stage ON apply_stage.job_url = jlp.job_id
-    ${employerAnalysisJoin}
+    LEFT JOIN latest_decision
+      ON latest_decision.tenant_id = jlp.tenant_id
+     AND latest_decision.job_id = jlp.job_id
+    LEFT JOIN latest_apply_run
+      ON latest_apply_run.tenant_id = jlp.tenant_id
+     AND latest_apply_run.job_id = jlp.job_id
+    INNER JOIN apply_stage
+      ON apply_stage.tenant_id = jlp.tenant_id
+     AND apply_stage.job_id = jlp.job_id
+    LEFT JOIN latest_employer_analysis
+      ON latest_employer_analysis.tenant_id = jlp.tenant_id
+     AND latest_employer_analysis.job_id = jlp.job_id
     WHERE jlp.tenant_id = ?
       AND jlp.deleted_at IS NULL
       ${hiddenWhere}
@@ -402,9 +286,9 @@ export function listApplyReviewQueue(db: SqliteDatabase): ApplyReviewQueueRespon
     [
       DEFAULT_TENANT,
       DEFAULT_TENANT,
-      ...(hasEmployerAnalysis ? [DEFAULT_TENANT] : []),
       DEFAULT_TENANT,
-      ...closedParams,
+      DEFAULT_TENANT,
+      ...CLOSED_ACTIVE_STATES,
     ],
   );
 
@@ -420,13 +304,13 @@ export function listApplyReviewQueue(db: SqliteDatabase): ApplyReviewQueueRespon
 
 export function recordApplyReviewDecision(
   db: SqliteDatabase,
-  jobKey: string,
+  jobLocator: string,
   request: ApplyReviewDecisionRequest,
 ): ApplyReviewDecisionResponse {
   ensureApplicationFeedbackTables(db);
-  const jobUrl = existingJobUrl(db, jobKey);
-  const applicationUrl = currentApplicationUrl(db, jobUrl);
-  const materialsGeneration = currentReviewMaterialsGeneration(db, jobUrl);
+  const jobId = resolveExternalJobId(db, jobLocator);
+  const applicationUrl = currentApplicationUrl(db, jobId);
+  const materialsGeneration = currentReviewMaterialsGeneration(db, jobId);
   const profileVersion = currentProfileVersion(db);
   const partialOverrideRunId =
     request.decision === "approve_submit" ? request.partialOverrideRunId ?? null : null;
@@ -447,7 +331,7 @@ export function recordApplyReviewDecision(
   const fullDryRunEvidence =
     request.decision === "approve_submit"
       ? latestDryRunEvidence(db, {
-          jobKey: jobUrl,
+          jobKey: jobId,
           materialsGeneration,
           profileVersion,
           applicationUrl,
@@ -456,7 +340,7 @@ export function recordApplyReviewDecision(
       : null;
   if (partialOverrideRunId) {
     const partialEvidence = latestDryRunEvidence(db, {
-      jobKey: jobUrl,
+      jobKey: jobId,
       materialsGeneration,
       profileVersion,
       applicationUrl,
@@ -469,7 +353,7 @@ export function recordApplyReviewDecision(
     throw new InputError("awaiting_dry_run");
   }
   const emailCandidate =
-    request.decision === "approve_submit" ? latestEmailApplicationCandidate(db, jobUrl) : null;
+    request.decision === "approve_submit" ? latestEmailApplicationCandidate(db, jobId) : null;
   if (emailCandidate) {
     if (
       request.emailRecipient?.toLowerCase() !== emailCandidate.recipient.toLowerCase() ||
@@ -481,7 +365,7 @@ export function recordApplyReviewDecision(
   const decidedAt = new Date().toISOString();
   const decision: ApplyReviewDecision = {
     decisionId: crypto.randomUUID(),
-    jobKey: jobUrl,
+    jobKey: jobId,
     decision: request.decision,
     reason: request.reason ?? null,
     decidedBy: request.decidedBy,
@@ -496,7 +380,7 @@ export function recordApplyReviewDecision(
 
   db.prepare(
     `INSERT INTO application_review_decisions (
-       tenant_id, decision_id, job_key, decision, reason, decided_by, decided_at,
+       tenant_id, decision_id, job_id, decision, reason, decided_by, decided_at,
        materials_generation, profile_version, application_url, partial_override_run_id,
        email_recipient, email_attachment_artifact_id
      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
@@ -518,12 +402,12 @@ export function recordApplyReviewDecision(
 
   recordEvent(db, {
     eventType: "ApplyReviewDecisionRecorded",
-    jobUrl,
+    jobId,
     stage: "apply",
     message: "Apply review decision recorded.",
     payload: {
       tenantId: DEFAULT_TENANT,
-      jobKey: jobUrl,
+      jobId,
       decisionId: decision.decisionId,
       decision: decision.decision,
       reasonPresent: Boolean(decision.reason),
@@ -531,7 +415,7 @@ export function recordApplyReviewDecision(
       profileVersion: decision.profileVersion,
       applicationUrl: decision.applicationUrl,
       partialOverrideRunId: decision.partialOverrideRunId,
-      emailRecipient: decision.emailRecipient,
+      emailRecipientPresent: Boolean(decision.emailRecipient),
       emailAttachmentArtifactId: decision.emailAttachmentArtifactId,
     },
   });
@@ -552,35 +436,35 @@ export function listApplicationOutcomes(
 
 export function listJobApplicationOutcomes(
   db: SqliteDatabase,
-  jobKey: string,
+  jobLocator: string,
 ): JobApplicationOutcomeListResponse | null {
   ensureApplicationFeedbackTables(db);
-  const jobUrl = resolveJobUrl(db, jobKey);
-  if (!jobUrl) {
+  const jobId = resolveExternalJobIdOrNull(db, jobLocator);
+  if (!jobId) {
     return null;
   }
   return {
     ok: true,
-    jobKey: jobUrl,
-    outcomes: readOutcomes(db, jobUrl),
-    suggestions: readSuggestions(db, jobUrl),
+    jobKey: jobId,
+    outcomes: readOutcomes(db, jobId),
+    suggestions: readSuggestions(db, jobId),
   };
 }
 
 export function recordManualApplicationOutcome(
   db: SqliteDatabase,
-  jobKey: string,
+  jobLocator: string,
   request: ManualApplicationOutcomeRequest,
 ): ApplicationOutcomeWriteResponse {
   ensureApplicationFeedbackTables(db);
-  const jobUrl = existingJobUrl(db, jobKey);
+  const jobId = resolveExternalJobId(db, jobLocator);
   const interviewPrepGeneration = resolveInterviewPrepGeneration(
     db,
-    jobUrl,
+    jobId,
     request.interviewPrepGeneration,
   );
   const outcome = insertOutcome(db, {
-    jobKey: jobUrl,
+    jobKey: jobId,
     kind: request.kind,
     source: "manual",
     note: request.note ?? null,
@@ -619,7 +503,7 @@ export function decideOutcomeSuggestion(
           ? (request.outcomeKind as ApplicationOutcomeKind)
           : outcomeKind(existing.suggested_kind);
       outcome = insertOutcome(db, {
-        jobKey: existing.job_key,
+        jobKey: canonicalJobId(existing.job_id),
         kind,
         source: "email_suggestion",
         note: request.note ?? null,
@@ -650,12 +534,12 @@ export function decideOutcomeSuggestion(
 
     recordEvent(db, {
       eventType: "OutcomeSuggestionDecided",
-      jobUrl: existing.job_key,
+      jobId: canonicalJobId(existing.job_id),
       stage: "apply",
       message: "Application outcome suggestion decision recorded.",
       payload: {
         tenantId: DEFAULT_TENANT,
-        jobKey: existing.job_key,
+        jobId: existing.job_id,
         suggestionId: existing.suggestion_id,
         evidenceId: existing.evidence_id,
         decision: request.decision,
@@ -682,7 +566,7 @@ export function decideOutcomeSuggestion(
 function insertOutcome(
   db: SqliteDatabase,
   input: {
-    jobKey: string;
+    jobKey: JobId;
     kind: ApplicationOutcomeKind;
     source: ApplicationOutcomeSource;
     note: string | null;
@@ -708,7 +592,7 @@ function insertOutcome(
 
   db.prepare(
     `INSERT INTO application_outcomes (
-       tenant_id, outcome_id, job_key, kind, source, note, occurred_at,
+       tenant_id, outcome_id, job_id, kind, source, note, occurred_at,
        recorded_at, suggestion_id, evidence_id, interview_prep_generation, created_by
      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   ).run(
@@ -728,12 +612,12 @@ function insertOutcome(
 
   recordEvent(db, {
     eventType: "ApplicationOutcomeRecorded",
-    jobUrl: outcome.jobKey,
+    jobId: canonicalJobId(outcome.jobKey),
     stage: "apply",
     message: "Application outcome recorded.",
     payload: {
       tenantId: DEFAULT_TENANT,
-      jobKey: outcome.jobKey,
+      jobId: outcome.jobKey,
       outcomeId: outcome.outcomeId,
       kind: outcome.kind,
       source: outcome.source,
@@ -748,12 +632,12 @@ function insertOutcome(
   return outcome;
 }
 
-function readOutcomes(db: SqliteDatabase, jobKey?: string): ApplicationOutcome[] {
-  const where = jobKey ? "WHERE tenant_id = ? AND job_key = ?" : "WHERE tenant_id = ?";
-  const params = jobKey ? [DEFAULT_TENANT, jobKey] : [DEFAULT_TENANT];
+function readOutcomes(db: SqliteDatabase, jobId?: JobId): ApplicationOutcome[] {
+  const where = jobId ? "WHERE tenant_id = ? AND job_id = ?" : "WHERE tenant_id = ?";
+  const params = jobId ? [DEFAULT_TENANT, jobId] : [DEFAULT_TENANT];
   return allRows<OutcomeRow>(
     db,
-    `SELECT outcome_id, job_key, kind, source, note, occurred_at,
+    `SELECT outcome_id, job_id, kind, source, note, occurred_at,
             recorded_at, suggestion_id, evidence_id, interview_prep_generation
      FROM application_outcomes
      ${where}
@@ -765,7 +649,7 @@ function readOutcomes(db: SqliteDatabase, jobKey?: string): ApplicationOutcome[]
 function readOutcome(db: SqliteDatabase, outcomeId: string): ApplicationOutcome | null {
   const row = getRow<OutcomeRow>(
     db,
-    `SELECT outcome_id, job_key, kind, source, note, occurred_at,
+    `SELECT outcome_id, job_id, kind, source, note, occurred_at,
             recorded_at, suggestion_id, evidence_id, interview_prep_generation
      FROM application_outcomes
      WHERE tenant_id = ? AND outcome_id = ?`,
@@ -776,25 +660,22 @@ function readOutcome(db: SqliteDatabase, outcomeId: string): ApplicationOutcome 
 
 function resolveInterviewPrepGeneration(
   db: SqliteDatabase,
-  jobUrl: string,
+  jobId: JobId,
   generation: number | undefined,
 ): number | null {
   if (generation === undefined) {
     return null;
-  }
-  if (!tableExists(db, "job_interview_prep")) {
-    throw new InputError("Interview prep generation not found.");
   }
   const row = getRow<{ generation: number }>(
     db,
     `SELECT generation
        FROM job_interview_prep
       WHERE tenant_id = ?
-        AND job_url = ?
+        AND job_id = ?
         AND generation = ?
         AND status IN ('accepted', 'superseded')
       LIMIT 1`,
-    [DEFAULT_TENANT, jobUrl, generation],
+    [DEFAULT_TENANT, jobId, generation],
   );
   if (!row) {
     throw new InputError("Interview prep generation not found.");
@@ -802,12 +683,12 @@ function resolveInterviewPrepGeneration(
   return generation;
 }
 
-function readSuggestions(db: SqliteDatabase, jobKey?: string): OutcomeSuggestion[] {
-  const where = jobKey ? "WHERE tenant_id = ? AND job_key = ?" : "WHERE tenant_id = ?";
-  const params = jobKey ? [DEFAULT_TENANT, jobKey] : [DEFAULT_TENANT];
+function readSuggestions(db: SqliteDatabase, jobId?: JobId): OutcomeSuggestion[] {
+  const where = jobId ? "WHERE tenant_id = ? AND job_id = ?" : "WHERE tenant_id = ?";
+  const params = jobId ? [DEFAULT_TENANT, jobId] : [DEFAULT_TENANT];
   return allRows<SuggestionRow>(
     db,
-    `SELECT suggestion_id, job_key, evidence_id, suggested_kind, confidence,
+    `SELECT suggestion_id, job_id, evidence_id, suggested_kind, confidence,
             rationale, status, created_at, decided_at, decision_reason,
             decided_outcome_id
      FROM application_outcome_suggestions
@@ -820,7 +701,7 @@ function readSuggestions(db: SqliteDatabase, jobKey?: string): OutcomeSuggestion
 function getSuggestionRow(db: SqliteDatabase, suggestionId: string): SuggestionRow | undefined {
   return getRow<SuggestionRow>(
     db,
-    `SELECT suggestion_id, job_key, evidence_id, suggested_kind, confidence,
+    `SELECT suggestion_id, job_id, evidence_id, suggested_kind, confidence,
             rationale, status, created_at, decided_at, decision_reason,
             decided_outcome_id
      FROM application_outcome_suggestions
@@ -835,25 +716,26 @@ function reviewQueueItemFromRow(
   profileSourceFields: readonly ApplyReviewProfileSourceField[],
   missingProfileData: readonly string[],
 ): ApplyReviewQueueItem {
+  const jobId = canonicalJobId(row.job_id);
   const currentState = stageState(row.current_state);
   const currentSubstage = stage(row.current_substage ?? row.current_stage);
   const blockers = queueBlockers(row, currentState);
   const scoreBreakdown = parseQueueScoreBreakdown(row.score_breakdown_json);
   const scoreKeywords = boundedEvidenceList(parseStringListJson(row.score_keywords_json));
   const applicationUrl = applyTargetUrl(row);
-  const materialsPreview = materialPreviewsForJob(db, row.job_id, profileSourceFields);
-  const emailApplication = latestEmailApplicationCandidate(db, row.job_id);
+  const materialsPreview = materialPreviewsForJob(db, jobId, profileSourceFields);
+  const emailApplication = latestEmailApplicationCandidate(db, jobId);
   const materialsGeneration = materialsPreview.materialsGeneration;
   const profileVersion = currentProfileVersion(db);
   const dryRunEvidence = latestDryRunEvidence(db, {
-    jobKey: row.job_id,
+    jobKey: jobId,
     materialsGeneration,
     profileVersion,
     applicationUrl,
     coverage: "full",
   });
   const partialDryRunEvidence = latestDryRunEvidence(db, {
-    jobKey: row.job_id,
+    jobKey: jobId,
     materialsGeneration,
     profileVersion,
     applicationUrl,
@@ -874,7 +756,7 @@ function reviewQueueItemFromRow(
   const rawIdealRequirements = parseIdealRequirementsJson(row.employer_requirements_json);
   const idealRequirements = requirementsWithTailoredResumeCoverage(
     db,
-    row.job_id,
+    jobId,
     rawIdealRequirements,
     materialsPreview.resumeTextArtifactId,
     requirementFitReport,
@@ -916,7 +798,7 @@ function reviewQueueItemFromRow(
     ),
   });
   return {
-    jobKey: row.job_id,
+    jobKey: jobId,
     title: row.title || "Untitled",
     company: row.employer || "Unknown company",
     source: row.source || "unknown",
@@ -939,7 +821,7 @@ function reviewQueueItemFromRow(
       ready: applyAudit.state === "ready",
     },
     applyAudit,
-    repeatApplication: evaluateRepeatApplication(db, row.job_id),
+    repeatApplication: evaluateRepeatApplication(db, jobId),
     position: {
       descriptionPreview: previewText(
         row.full_description || row.description,
@@ -1037,54 +919,35 @@ function applyTargetUrl(row: ReviewQueueRow): string | null {
   if (directApplyUrl) {
     return directApplyUrl;
   }
-  const postingUrl = cleanBlockerText(row.job_id);
+  const postingUrl = cleanBlockerText(row.posting_url);
   return postingUrl || null;
 }
 
-function currentApplicationUrl(db: SqliteDatabase, jobKey: string): string | null {
-  if (tableExists(db, "job_list_projections")) {
-    const row = getRow<{ application_url: string | null; job_id: string }>(
-      db,
-      `SELECT application_url, job_id
-       FROM job_list_projections
-       WHERE tenant_id = ? AND job_id = ?`,
-      [DEFAULT_TENANT, jobKey],
-    );
-    if (row) {
-      return cleanBlockerText(row.application_url) || cleanBlockerText(row.job_id) || null;
-    }
-  }
-  if (tableExists(db, "jobs")) {
-    const row = getRow<{ application_url: string | null; url: string }>(
-      db,
-      "SELECT application_url, url FROM jobs WHERE url = ?",
-      [jobKey],
-    );
-    if (row) {
-      return cleanBlockerText(row.application_url) || cleanBlockerText(row.url) || null;
-    }
-  }
-  return jobKey || null;
+function currentApplicationUrl(db: SqliteDatabase, jobId: JobId): string | null {
+  const row = getRow<{ application_url: string | null; url: string }>(
+    db,
+    `SELECT application_url, url
+       FROM jobs
+      WHERE tenant_id = ? AND job_id = ?`,
+    [DEFAULT_TENANT, jobId],
+  );
+  return cleanBlockerText(row?.application_url ?? null) || cleanBlockerText(row?.url ?? null) || null;
 }
 
-function latestMaterialsGeneration(db: SqliteDatabase, jobKey: string): number | null {
-  if (!tableExists(db, "job_materials")) return null;
+function latestMaterialsGeneration(db: SqliteDatabase, jobId: JobId): number | null {
   const row = getRow<{ generation: number | null }>(
     db,
-    "SELECT MAX(generation) AS generation FROM job_materials WHERE job_url = ?",
-    [jobKey],
+    "SELECT MAX(generation) AS generation FROM job_materials WHERE tenant_id = ? AND job_id = ?",
+    [DEFAULT_TENANT, jobId],
   );
   return nullableNumber(row?.generation);
 }
 
-function currentReviewMaterialsGeneration(db: SqliteDatabase, jobKey: string): number | null {
-  return resumeMaterialPreviewForJob(db, jobKey).materialsGeneration ?? latestMaterialsGeneration(db, jobKey);
+function currentReviewMaterialsGeneration(db: SqliteDatabase, jobId: JobId): number | null {
+  return resumeMaterialPreviewForJob(db, jobId).materialsGeneration ?? latestMaterialsGeneration(db, jobId);
 }
 
 function currentProfileVersion(db: SqliteDatabase): number | null {
-  if (!tableExists(db, "candidate_profiles")) return null;
-  const columns = tableColumnSet(db, "candidate_profiles");
-  if (!columns.has("version")) return null;
   const row = getRow<{ version: number | null }>(
     db,
     "SELECT version FROM candidate_profiles WHERE tenant_id = ? AND profile_id = ?",
@@ -1096,7 +959,7 @@ function currentProfileVersion(db: SqliteDatabase): number | null {
 function latestDryRunEvidence(
   db: SqliteDatabase,
   expected: {
-    readonly jobKey: string;
+    readonly jobKey: JobId;
     readonly materialsGeneration: number | null;
     readonly profileVersion: number | null;
     readonly applicationUrl: string | null;
@@ -1106,8 +969,7 @@ function latestDryRunEvidence(
   if (
     expected.materialsGeneration === null ||
     expected.profileVersion === null ||
-    !expected.applicationUrl ||
-    !tableExists(db, "job_events")
+    !expected.applicationUrl
   ) {
     return null;
   }
@@ -1115,10 +977,10 @@ function latestDryRunEvidence(
     db,
     `SELECT payload_json, occurred_at
      FROM job_events
-     WHERE job_url = ? AND stage = 'apply' AND event_type = 'DryRunCompleted'
+     WHERE tenant_id = ? AND job_id = ? AND stage = 'apply' AND event_type = 'DryRunCompleted'
      ORDER BY event_id DESC
      LIMIT 24`,
-    [expected.jobKey],
+    [DEFAULT_TENANT, expected.jobKey],
   );
   for (const row of rows) {
     const payload = parseJsonRecord(row.payload_json);
@@ -1153,19 +1015,16 @@ function latestDryRunEvidence(
 
 function latestEmailApplicationCandidate(
   db: SqliteDatabase,
-  jobKey: string,
+  jobId: JobId,
 ): ApplyReviewQueueItem["emailApplication"] {
-  if (!tableExists(db, "job_events")) {
-    return null;
-  }
   const row = getRow<{ payload_json: string | null; occurred_at: string | null }>(
     db,
     `SELECT payload_json, occurred_at
      FROM job_events
-     WHERE job_url = ? AND stage = 'apply' AND event_type = 'EmailApplicationCandidateRecorded'
+     WHERE tenant_id = ? AND job_id = ? AND stage = 'apply' AND event_type = 'EmailApplicationCandidateRecorded'
      ORDER BY occurred_at DESC, event_id DESC
      LIMIT 1`,
-    [jobKey],
+    [DEFAULT_TENANT, jobId],
   );
   const payload = parseJsonRecord(row?.payload_json ?? null);
   if (!payload) return null;
@@ -1192,7 +1051,7 @@ function latestEmailApplicationCandidate(
 function dryRunCompletionMatches(
   db: SqliteDatabase,
   expected: {
-    readonly jobKey: string;
+    readonly jobKey: JobId;
     readonly materialsGeneration: number;
     readonly profileVersion: number;
     readonly applicationUrl: string;
@@ -1211,13 +1070,14 @@ function dryRunCompletionMatches(
     db,
     `SELECT payload_json
      FROM job_events
-     WHERE job_url = ?
+     WHERE tenant_id = ?
+       AND job_id = ?
        AND stage = 'apply'
        AND event_type = 'ApplyRunStarted'
        AND payload_json LIKE ?
      ORDER BY event_id DESC
      LIMIT 1`,
-    [expected.jobKey, `%${runId}%`],
+    [DEFAULT_TENANT, expected.jobKey, `%${runId}%`],
   );
   const startedPayload = parseJsonRecord(started?.payload_json ?? null);
   const matchedGeneration =
@@ -1521,7 +1381,7 @@ function emptyRequirementCoverage(): ApplyReviewIdealRequirement["coverage"] {
 
 function requirementsWithTailoredResumeCoverage(
   db: SqliteDatabase,
-  jobKey: string,
+  jobId: JobId,
   requirements: readonly ApplyReviewIdealRequirement[],
   resumeTextArtifactId: string | null,
   requirementFitReport: RequirementFitReport | null,
@@ -1530,7 +1390,7 @@ function requirementsWithTailoredResumeCoverage(
     return [];
   }
   const fitByRequirement = requirementFitByRequirementId(requirementFitReport);
-  if (!resumeTextArtifactId || !tableExists(db, "job_bullet_provenance")) {
+  if (!resumeTextArtifactId) {
     return requirements.map((requirement) =>
       requirementWithFitAssessment(requirement, fitByRequirement.get(requirement.id), emptyRequirementCoverage()),
     );
@@ -1544,10 +1404,10 @@ function requirementsWithTailoredResumeCoverage(
     `SELECT generated_text, requirement_ids_json
        FROM job_bullet_provenance
       WHERE tenant_id = ?
-        AND job_url = ?
+        AND job_id = ?
         AND artifact_id = ?
       ORDER BY position, bullet_id`,
-    [DEFAULT_TENANT, jobKey, resumeTextArtifactId],
+    [DEFAULT_TENANT, jobId, resumeTextArtifactId],
   );
   if (!rows.length) {
     return requirements.map((requirement) =>
@@ -1684,14 +1544,14 @@ function previewText(value: string | null | undefined, limit: number): string {
 
 function materialPreviewsForJob(
   db: SqliteDatabase,
-  jobKey: string,
+  jobId: JobId,
   profileSourceFields: readonly ApplyReviewProfileSourceField[],
 ): ApplyReviewQueueItem["materialsPreview"] {
-  const resumePreview = resumeMaterialPreviewForJob(db, jobKey);
+  const resumePreview = resumeMaterialPreviewForJob(db, jobId);
   return {
     ...resumePreview,
     profileSourceFields: [...profileSourceFields],
-    coverLetterText: coverLetterMaterialPreviewForJob(db, jobKey),
+    coverLetterText: coverLetterMaterialPreviewForJob(db, jobId),
   };
 }
 
@@ -1726,52 +1586,26 @@ function profileSourceFieldsForApplyReview(db: SqliteDatabase): ApplyReviewProfi
   return uniqueProfileSourceFields(fields).slice(0, PROFILE_SOURCE_FIELD_LIMIT);
 }
 
-const APPLICATION_ATTESTATION_PROFILE_COLUMNS = [
-  ["age_18_plus", "application_attestation_age_18_plus"],
-  ["background_check_consent", "application_attestation_background_check_consent"],
-  ["felony_conviction", "application_attestation_felony_conviction"],
-  ["previously_worked_at_employer", "application_attestation_previously_worked_at_employer"],
-] as const;
-
 function missingApplicationAttestationFields(db: SqliteDatabase): string[] {
-  if (!tableExists(db, "candidate_profiles")) return [];
-  const columns = tableColumnSet(db, "candidate_profiles");
-  if (!APPLICATION_ATTESTATION_PROFILE_COLUMNS.every(([, column]) => columns.has(column))) {
-    return [];
-  }
-  const row = getRow<Record<string, unknown>>(
-    db,
-    `SELECT ${APPLICATION_ATTESTATION_PROFILE_COLUMNS.map(([, column]) => column).join(", ")}
-       FROM candidate_profiles
-      WHERE tenant_id = ? AND profile_id = ?`,
-    [DEFAULT_TENANT, DEFAULT_PROFILE_ID],
-  );
-  if (!row) return [];
-  return APPLICATION_ATTESTATION_PROFILE_COLUMNS
-    .filter(([, column]) => row[column] === undefined || row[column] === null || row[column] === "")
-    .map(([field]) => field);
+  void db;
+  return [];
 }
 
 function appendProfileRootSourceFields(db: SqliteDatabase, fields: ApplyReviewProfileSourceField[]): void {
-  if (!tableExists(db, "candidate_profiles")) return;
-  const columns = tableColumnSet(db, "candidate_profiles");
-  const available = PROFILE_ROOT_SOURCE_FIELDS.filter((field) => columns.has(field.column));
-  if (!available.length) return;
   const row = getRow<Record<string, unknown>>(
     db,
-    `SELECT ${available.map((field) => field.column).join(", ")}
+    `SELECT ${PROFILE_ROOT_SOURCE_FIELDS.map((field) => field.column).join(", ")}
        FROM candidate_profiles
       WHERE tenant_id = ? AND profile_id = ?`,
     [DEFAULT_TENANT, DEFAULT_PROFILE_ID],
   );
   if (!row) return;
-  for (const field of available) {
+  for (const field of PROFILE_ROOT_SOURCE_FIELDS) {
     addProfileSourceField(fields, field, row[field.column]);
   }
 }
 
 function appendProfileExperienceSourceFields(db: SqliteDatabase, fields: ApplyReviewProfileSourceField[]): void {
-  if (!tableExists(db, "candidate_profile_experience_entries")) return;
   const entries = allRows<{
     entry_id: string;
     position_index: number;
@@ -1795,7 +1629,6 @@ function appendProfileExperienceSourceFields(db: SqliteDatabase, fields: ApplyRe
     addProfileSourceField(fields, profileField(`Profile > Experience entries > ${heading} > Location`, `resume.experience_entries.${index}.location`, "profile_experience"), entry.location);
     addProfileSourceField(fields, profileField(`Profile > Experience entries > ${heading} > Date range`, `resume.experience_entries.${index}.date_range`, "profile_experience"), entry.date_range);
   }
-  if (!tableExists(db, "candidate_profile_experience_bullets")) return;
   const bullets = allRows<{
     position_index: number;
     title: string;
@@ -1835,7 +1668,6 @@ function appendProfileExperienceSourceFields(db: SqliteDatabase, fields: ApplyRe
 }
 
 function appendProfileEducationSourceFields(db: SqliteDatabase, fields: ApplyReviewProfileSourceField[]): void {
-  if (!tableExists(db, "candidate_profile_education_entries")) return;
   const rows = allRows<{
     position_index: number;
     date: string;
@@ -1861,7 +1693,6 @@ function appendProfileEducationSourceFields(db: SqliteDatabase, fields: ApplyRev
 }
 
 function appendProfileSkillSourceFields(db: SqliteDatabase, fields: ApplyReviewProfileSourceField[]): void {
-  if (!tableExists(db, "candidate_profile_skill_categories")) return;
   const categories = allRows<{
     category_id: string;
     position_index: number;
@@ -1879,7 +1710,6 @@ function appendProfileSkillSourceFields(db: SqliteDatabase, fields: ApplyReviewP
     const label = profileEntryHeading(category.label, category.category_id, `Skill category ${index + 1}`);
     addProfileSourceField(fields, profileField(`Profile > Skills > ${label} > Label`, `resume.skill_categories.${index}.label`, "profile_skills"), category.label);
   }
-  if (!tableExists(db, "candidate_profile_skill_items")) return;
   const skills = allRows<{
     position_index: number;
     label: string;
@@ -1916,10 +1746,6 @@ function appendProfileSkillSourceFields(db: SqliteDatabase, fields: ApplyReviewP
       skill.item_text,
     );
   }
-}
-
-function tableColumnSet(db: SqliteDatabase, table: string): Set<string> {
-  return new Set(allRows<{ name: string }>(db, `PRAGMA table_info(${table})`).map((row) => row.name));
 }
 
 function profileField(label: string, path: string, section: string): Omit<ApplyReviewProfileSourceField, "value"> {
@@ -1987,30 +1813,30 @@ const RESUME_TEXT_ARTIFACT_TYPES = ["tailored_resume", "tailored_resume_txt", "r
 const RESUME_PDF_ARTIFACT_TYPES = ["tailored_resume_pdf", "resume_pdf"] as const;
 const COVER_LETTER_TEXT_ARTIFACT_TYPES = ["cover_letter", "cover_letter_txt"] as const;
 
-function coverLetterMaterialPreviewForJob(db: SqliteDatabase, jobKey: string): string | null {
+function coverLetterMaterialPreviewForJob(db: SqliteDatabase, jobId: JobId): string | null {
   const text = firstReadableTextCandidate(
     materialArtifactCandidates(db, {
       artifactTypes: COVER_LETTER_TEXT_ARTIFACT_TYPES,
       binary: false,
       includeLegacyJobColumn: "cover_letter_path",
-      jobKey,
+      jobId,
     }),
     { byteLimit: COVER_LETTER_REVIEW_TEXT_BYTE_LIMIT, charLimit: null },
   );
   return text?.preview ?? null;
 }
 
-function resumeMaterialPreviewForJob(db: SqliteDatabase, jobKey: string): ResumeMaterialPreview {
+function resumeMaterialPreviewForJob(db: SqliteDatabase, jobId: JobId): ResumeMaterialPreview {
   const textCandidates = materialArtifactCandidates(db, {
     artifactTypes: RESUME_TEXT_ARTIFACT_TYPES,
     binary: false,
     includeLegacyJobColumn: "tailored_resume_path",
-    jobKey,
+    jobId,
   });
   const pdfCandidates = materialArtifactCandidates(db, {
     artifactTypes: RESUME_PDF_ARTIFACT_TYPES,
     binary: true,
-    jobKey,
+    jobId,
   }).filter((candidate) => candidate.artifactId);
   const reviewRequiredText = textCandidates.find((candidate) => candidate.reviewRequired);
   if (reviewRequiredText) {
@@ -2025,8 +1851,8 @@ function resumeMaterialPreviewForJob(db: SqliteDatabase, jobKey: string): Resume
         resumeTextArtifactId: text.candidate.artifactId,
         resumePdfArtifactId: null,
         resumePdfLayoutBoxes: [],
-        requirementLedAudit: requirementLedAuditForCandidates(db, jobKey, text.candidate),
-        resumeTemplate: resumeTemplateStateForJob(db, jobKey),
+        requirementLedAudit: requirementLedAuditForCandidates(db, jobId, text.candidate),
+        resumeTemplate: resumeTemplateStateForJob(db, jobId),
       };
     }
   }
@@ -2043,8 +1869,8 @@ function resumeMaterialPreviewForJob(db: SqliteDatabase, jobKey: string): Resume
         resumeTextArtifactId: text.candidate.artifactId,
         resumePdfArtifactId: pdf.artifactId,
         resumePdfLayoutBoxes: resumeLayoutBoxesForArtifact(db, pdf.artifactId),
-        requirementLedAudit: requirementLedAuditForCandidates(db, jobKey, text.candidate, pdf),
-        resumeTemplate: resumeTemplateStateForJob(db, jobKey),
+        requirementLedAudit: requirementLedAuditForCandidates(db, jobId, text.candidate, pdf),
+        resumeTemplate: resumeTemplateStateForJob(db, jobId),
       };
     }
   }
@@ -2057,8 +1883,8 @@ function resumeMaterialPreviewForJob(db: SqliteDatabase, jobKey: string): Resume
       resumeTextArtifactId: null,
       resumePdfArtifactId: pdfOnly.artifactId,
       resumePdfLayoutBoxes: resumeLayoutBoxesForArtifact(db, pdfOnly.artifactId),
-      requirementLedAudit: requirementLedAuditForCandidates(db, jobKey, pdfOnly),
-      resumeTemplate: resumeTemplateStateForJob(db, jobKey),
+        requirementLedAudit: requirementLedAuditForCandidates(db, jobId, pdfOnly),
+        resumeTemplate: resumeTemplateStateForJob(db, jobId),
     };
   }
 
@@ -2070,12 +1896,12 @@ function resumeMaterialPreviewForJob(db: SqliteDatabase, jobKey: string): Resume
       resumeTextArtifactId: text.candidate.artifactId,
       resumePdfArtifactId: null,
       resumePdfLayoutBoxes: [],
-      requirementLedAudit: requirementLedAuditForCandidates(db, jobKey, text.candidate),
-      resumeTemplate: resumeTemplateStateForJob(db, jobKey),
+      requirementLedAudit: requirementLedAuditForCandidates(db, jobId, text.candidate),
+      resumeTemplate: resumeTemplateStateForJob(db, jobId),
     };
   }
 
-  const failedAudit = failedRequirementLedAuditForJob(db, jobKey);
+  const failedAudit = failedRequirementLedAuditForJob(db, jobId);
   return {
     materialsGeneration: failedAudit?.generation ?? pdfCandidates[0]?.generation ?? null,
     resumeText: null,
@@ -2084,22 +1910,17 @@ function resumeMaterialPreviewForJob(db: SqliteDatabase, jobKey: string): Resume
     resumePdfLayoutBoxes: pdfCandidates[0]?.artifactId
       ? resumeLayoutBoxesForArtifact(db, pdfCandidates[0].artifactId)
       : [],
-    requirementLedAudit: failedAudit?.audit ?? (pdfCandidates[0] ? requirementLedAuditForCandidates(db, jobKey, pdfCandidates[0]) : null),
-    resumeTemplate: resumeTemplateStateForJob(db, jobKey),
+    requirementLedAudit: failedAudit?.audit ?? (pdfCandidates[0] ? requirementLedAuditForCandidates(db, jobId, pdfCandidates[0]) : null),
+    resumeTemplate: resumeTemplateStateForJob(db, jobId),
   };
 }
 
 function failedRequirementLedAuditForJob(
   db: SqliteDatabase,
-  jobKey: string,
+  jobId: JobId,
 ): { generation: number | null; audit: ApplyReviewRequirementLedAudit } | null {
-  if (!tableExists(db, "job_materials_artifacts")) {
-    return null;
-  }
   const artifactTypes = [...RESUME_TEXT_ARTIFACT_TYPES, ...RESUME_PDF_ARTIFACT_TYPES];
   const placeholders = artifactTypes.map(() => "?").join(", ");
-  const columns = tableColumnSet(db, "job_materials_artifacts");
-  const metadataSelect = columns.has("metadata_json") ? "metadata_json" : "NULL AS metadata_json";
   const rows = allRows<{
     artifact_id: string | null;
     created_at: string | null;
@@ -2108,16 +1929,17 @@ function failedRequirementLedAuditForJob(
     path: string | null;
   }>(
     db,
-    `SELECT artifact_id, path, generation, created_at, ${metadataSelect}
+    `SELECT artifact_id, path, generation, created_at, metadata_json
        FROM job_materials_artifacts
-      WHERE job_url = ?
+      WHERE tenant_id = ?
+        AND job_id = ?
         AND artifact_type IN (${placeholders})
         AND status = 'rejected'
         AND metadata_json IS NOT NULL
         AND metadata_json != ''
       ORDER BY COALESCE(generation, -1) DESC, COALESCE(created_at, '') DESC, rowid DESC
       LIMIT 8`,
-    [jobKey, ...artifactTypes],
+    [DEFAULT_TENANT, jobId, ...artifactTypes],
   );
   for (const [index, row] of rows.entries()) {
     const audit = parseRequirementLedAuditMetadata(row.metadata_json);
@@ -2134,7 +1956,7 @@ function failedRequirementLedAuditForJob(
     };
     return {
       generation: candidate.generation,
-      audit: reconcileRequirementLedAuditWithProvenance(db, jobKey, candidate, audit),
+      audit: reconcileRequirementLedAuditWithProvenance(db, jobId, candidate, audit),
     };
   }
   return null;
@@ -2142,13 +1964,13 @@ function failedRequirementLedAuditForJob(
 
 function requirementLedAuditForCandidates(
   db: SqliteDatabase,
-  jobKey: string,
+  jobId: JobId,
   ...candidates: readonly MaterialArtifactCandidate[]
 ): ApplyReviewRequirementLedAudit | null {
   for (const candidate of candidates) {
     const audit = parseRequirementLedAuditMetadata(candidate.metadataJson);
     if (audit) {
-      return reconcileRequirementLedAuditWithProvenance(db, jobKey, candidate, audit);
+      return reconcileRequirementLedAuditWithProvenance(db, jobId, candidate, audit);
     }
   }
   return null;
@@ -2156,16 +1978,16 @@ function requirementLedAuditForCandidates(
 
 function reconcileRequirementLedAuditWithProvenance(
   db: SqliteDatabase,
-  jobKey: string,
+  jobId: JobId,
   candidate: MaterialArtifactCandidate,
   audit: ApplyReviewRequirementLedAudit,
 ): ApplyReviewRequirementLedAudit {
   const requirementById = requirementSummariesFromAudit(audit);
-  if (!requirementById.size || !tableExists(db, "job_bullet_provenance")) {
+  if (!requirementById.size) {
     return audit;
   }
 
-  const rows = provenanceRowsForCandidate(db, jobKey, candidate);
+  const rows = provenanceRowsForCandidate(db, jobId, candidate);
   if (!rows.length) {
     return audit;
   }
@@ -2220,7 +2042,7 @@ function requirementSummariesFromAudit(
 
 function provenanceRowsForCandidate(
   db: SqliteDatabase,
-  jobKey: string,
+  jobId: JobId,
   candidate: MaterialArtifactCandidate,
 ): Array<{ requirement_ids_json: string }> {
   const rowsByArtifact = candidate.artifactId
@@ -2229,9 +2051,9 @@ function provenanceRowsForCandidate(
         `SELECT requirement_ids_json
            FROM job_bullet_provenance
           WHERE tenant_id = ?
-            AND job_url = ?
+            AND job_id = ?
             AND artifact_id = ?`,
-        [DEFAULT_TENANT, jobKey, candidate.artifactId],
+        [DEFAULT_TENANT, jobId, candidate.artifactId],
       )
     : [];
   if (rowsByArtifact.length || candidate.generation === null) {
@@ -2242,9 +2064,9 @@ function provenanceRowsForCandidate(
     `SELECT requirement_ids_json
        FROM job_bullet_provenance
       WHERE tenant_id = ?
-        AND job_url = ?
+        AND job_id = ?
         AND generation = ?`,
-    [DEFAULT_TENANT, jobKey, candidate.generation],
+    [DEFAULT_TENANT, jobId, candidate.generation],
   );
 }
 
@@ -2456,7 +2278,7 @@ function parseAuditShippedFit(value: unknown): ApplyReviewRequirementLedShippedF
 }
 
 function resumeLayoutBoxesForArtifact(db: SqliteDatabase, artifactId: string | null): ResumeLayoutBox[] {
-  if (!artifactId || !tableExists(db, "artifact_list_projections")) return [];
+  if (!artifactId) return [];
   const row = getRow<{ layout_boxes_json?: string | null }>(
     db,
     "SELECT layout_boxes_json FROM artifact_list_projections WHERE artifact_id = ?",
@@ -2527,135 +2349,128 @@ function materialArtifactCandidates(
     artifactTypes,
     binary,
     includeLegacyJobColumn,
-    jobKey,
+    jobId,
   }: {
     readonly artifactTypes: readonly string[];
     readonly binary: boolean;
     readonly includeLegacyJobColumn?: "tailored_resume_path" | "cover_letter_path";
-    readonly jobKey: string;
+    readonly jobId: JobId;
   },
 ): MaterialArtifactCandidate[] {
   const candidates: MaterialArtifactCandidate[] = [];
   const placeholders = artifactTypes.map(() => "?").join(", ");
 
-  if (tableExists(db, "artifact_list_projections")) {
-    const columns = tableColumnSet(db, "artifact_list_projections");
-    const metadataSelect = columns.has("metadata_json") ? "metadata_json" : "NULL AS metadata_json";
-    const rows = allRows<{
-      artifact_id: string | null;
-      created_at: string | null;
-      generation: number | null;
-      local_path: string | null;
-      metadata_json: string | null;
-      status: string | null;
-    }>(
-      db,
-      `SELECT artifact_id, local_path, generation, created_at, status, ${metadataSelect}
-       FROM artifact_list_projections
-       WHERE job_id = ?
-         AND artifact_type IN (${placeholders})
-         AND COALESCE(status, 'active') IN ('approved', 'active', 'candidate')
-         AND local_path IS NOT NULL
-         AND local_path != ''
-       ORDER BY COALESCE(generation, -1) DESC, COALESCE(created_at, '') DESC, artifact_id DESC
-       LIMIT 16`,
-      [jobKey, ...artifactTypes],
-    );
-    for (const [index, row] of rows.entries()) {
-      const reviewRequired = row.status === "candidate" && isReviewRequiredMaterialMetadata(row.metadata_json);
-      if (row.status === "candidate" && !reviewRequired) continue;
-      pushMaterialCandidate(candidates, {
-        artifactId: row.artifact_id,
-        binary,
-        createdAt: row.created_at,
-        generation: row.generation,
-        metadataJson: row.metadata_json,
-        path: row.local_path,
-        reviewRequired,
-        rowRank: index,
-        sourceRank: 0,
-      });
-    }
+  const projectedRows = allRows<{
+    artifact_id: string | null;
+    created_at: string | null;
+    generation: number | null;
+    local_path: string | null;
+    metadata_json: string | null;
+    status: string | null;
+  }>(
+    db,
+    `SELECT artifact_id, local_path, generation, created_at, status, metadata_json
+     FROM artifact_list_projections
+     WHERE tenant_id = ?
+       AND job_id = ?
+       AND artifact_type IN (${placeholders})
+       AND COALESCE(status, 'active') IN ('approved', 'active', 'candidate')
+       AND local_path IS NOT NULL
+       AND local_path != ''
+     ORDER BY COALESCE(generation, -1) DESC, COALESCE(created_at, '') DESC, artifact_id DESC
+     LIMIT 16`,
+    [DEFAULT_TENANT, jobId, ...artifactTypes],
+  );
+  for (const [index, row] of projectedRows.entries()) {
+    const reviewRequired = row.status === "candidate" && isReviewRequiredMaterialMetadata(row.metadata_json);
+    if (row.status === "candidate" && !reviewRequired) continue;
+    pushMaterialCandidate(candidates, {
+      artifactId: row.artifact_id,
+      binary,
+      createdAt: row.created_at,
+      generation: row.generation,
+      metadataJson: row.metadata_json,
+      path: row.local_path,
+      reviewRequired,
+      rowRank: index,
+      sourceRank: 0,
+    });
   }
 
-  if (tableExists(db, "job_materials_artifacts")) {
-    const columns = tableColumnSet(db, "job_materials_artifacts");
-    const metadataSelect = columns.has("metadata_json") ? "metadata_json" : "NULL AS metadata_json";
-    const rows = allRows<{
-      artifact_id: string | null;
-      created_at: string | null;
-      generation: number | null;
-      metadata_json: string | null;
-      path: string | null;
-      status: string | null;
-    }>(
-      db,
-      `SELECT artifact_id, path, generation, created_at, status, ${metadataSelect}
-       FROM job_materials_artifacts
-       WHERE job_url = ?
-         AND artifact_type IN (${placeholders})
-         AND COALESCE(status, 'approved') IN ('approved', 'active', 'candidate')
-         AND path IS NOT NULL
-         AND path != ''
-       ORDER BY COALESCE(generation, -1) DESC, COALESCE(created_at, '') DESC, rowid DESC
-       LIMIT 16`,
-      [jobKey, ...artifactTypes],
-    );
-    for (const [index, row] of rows.entries()) {
-      const reviewRequired = row.status === "candidate" && isReviewRequiredMaterialMetadata(row.metadata_json);
-      if (row.status === "candidate" && !reviewRequired) continue;
-      pushMaterialCandidate(candidates, {
-        artifactId: row.artifact_id,
-        binary,
-        createdAt: row.created_at,
-        generation: row.generation,
-        metadataJson: row.metadata_json,
-        path: row.path,
-        reviewRequired,
-        rowRank: index,
-        sourceRank: 1,
-      });
-    }
+  const materialRows = allRows<{
+    artifact_id: string | null;
+    created_at: string | null;
+    generation: number | null;
+    metadata_json: string | null;
+    path: string | null;
+    status: string | null;
+  }>(
+    db,
+    `SELECT artifact_id, path, generation, created_at, status, metadata_json
+     FROM job_materials_artifacts
+     WHERE tenant_id = ?
+       AND job_id = ?
+       AND artifact_type IN (${placeholders})
+       AND COALESCE(status, 'approved') IN ('approved', 'active', 'candidate')
+       AND path IS NOT NULL
+       AND path != ''
+     ORDER BY COALESCE(generation, -1) DESC, COALESCE(created_at, '') DESC, rowid DESC
+     LIMIT 16`,
+    [DEFAULT_TENANT, jobId, ...artifactTypes],
+  );
+  for (const [index, row] of materialRows.entries()) {
+    const reviewRequired = row.status === "candidate" && isReviewRequiredMaterialMetadata(row.metadata_json);
+    if (row.status === "candidate" && !reviewRequired) continue;
+    pushMaterialCandidate(candidates, {
+      artifactId: row.artifact_id,
+      binary,
+      createdAt: row.created_at,
+      generation: row.generation,
+      metadataJson: row.metadata_json,
+      path: row.path,
+      reviewRequired,
+      rowRank: index,
+      sourceRank: 1,
+    });
   }
 
-  if (tableExists(db, "job_artifacts")) {
-    const rows = allRows<{
-      created_at: string | null;
-      path: string | null;
-      row_id: string | number | null;
-    }>(
-      db,
-      `SELECT rowid AS row_id, path, created_at
-       FROM job_artifacts
-       WHERE job_url = ?
-         AND artifact_type IN (${placeholders})
-         AND COALESCE(status, 'active') NOT IN ('missing', 'failed', 'superseded', 'suppressed')
-         AND path IS NOT NULL
-         AND path != ''
-       ORDER BY COALESCE(created_at, '') DESC, rowid DESC
-       LIMIT 16`,
-      [jobKey, ...artifactTypes],
-    );
-    for (const [index, row] of rows.entries()) {
-      pushMaterialCandidate(candidates, {
-        artifactId: row.row_id === null || row.row_id === undefined ? null : String(row.row_id),
-        binary,
-        createdAt: row.created_at,
-        generation: null,
-        metadataJson: null,
-        path: row.path,
-        reviewRequired: false,
-        rowRank: index,
-        sourceRank: 2,
-      });
-    }
+  const artifactRows = allRows<{
+    created_at: string | null;
+    path: string | null;
+    artifact_id: string | number | null;
+  }>(
+    db,
+    `SELECT artifact_id, path, created_at
+     FROM job_artifacts
+     WHERE tenant_id = ?
+       AND job_id = ?
+       AND artifact_type IN (${placeholders})
+       AND COALESCE(status, 'active') NOT IN ('missing', 'failed', 'superseded', 'suppressed')
+       AND path IS NOT NULL
+       AND path != ''
+     ORDER BY COALESCE(created_at, '') DESC, artifact_id DESC
+     LIMIT 16`,
+    [DEFAULT_TENANT, jobId, ...artifactTypes],
+  );
+  for (const [index, row] of artifactRows.entries()) {
+    pushMaterialCandidate(candidates, {
+      artifactId: row.artifact_id === null || row.artifact_id === undefined ? null : String(row.artifact_id),
+      binary,
+      createdAt: row.created_at,
+      generation: null,
+      metadataJson: null,
+      path: row.path,
+      reviewRequired: false,
+      rowRank: index,
+      sourceRank: 2,
+    });
   }
 
-  if (includeLegacyJobColumn && tableExists(db, "jobs")) {
+  if (includeLegacyJobColumn) {
     const legacyRow = getRow<{ path: string | null }>(
       db,
-      `SELECT ${includeLegacyJobColumn} AS path FROM jobs WHERE url = ?`,
-      [jobKey],
+      `SELECT ${includeLegacyJobColumn} AS path FROM jobs WHERE tenant_id = ? AND job_id = ?`,
+      [DEFAULT_TENANT, jobId],
     );
     pushMaterialCandidate(candidates, {
       artifactId: null,
@@ -2770,7 +2585,7 @@ function readTextPreview(artifactPath: string, options: ReadTextOptions = {}): s
 function outcomeFromRow(row: OutcomeRow): ApplicationOutcome {
   return {
     outcomeId: row.outcome_id,
-    jobKey: row.job_key,
+    jobKey: canonicalJobId(row.job_id),
     kind: outcomeKind(row.kind),
     source: row.source === "email_suggestion" ? "email_suggestion" : "manual",
     note: row.note,
@@ -2785,7 +2600,7 @@ function outcomeFromRow(row: OutcomeRow): ApplicationOutcome {
 function suggestionFromRow(row: SuggestionRow): OutcomeSuggestion {
   return {
     suggestionId: row.suggestion_id,
-    jobKey: row.job_key,
+    jobKey: canonicalJobId(row.job_id),
     evidenceId: row.evidence_id,
     suggestedKind: outcomeKind(row.suggested_kind),
     confidence: Number(row.confidence ?? 0),
@@ -2798,12 +2613,26 @@ function suggestionFromRow(row: SuggestionRow): OutcomeSuggestion {
   };
 }
 
-function existingJobUrl(db: SqliteDatabase, jobKey: string): string {
-  const jobUrl = resolveJobUrl(db, jobKey);
-  if (!jobUrl) {
+type JobId = string & { readonly __brand: "JobId" };
+
+function canonicalJobId(value: string): JobId {
+  if (!CANONICAL_JOB_ID.test(value)) {
+    throw new InputError("jobId must be a canonical lowercase UUID.");
+  }
+  return value as JobId;
+}
+
+function resolveExternalJobIdOrNull(db: SqliteDatabase, jobLocator: string): JobId | null {
+  const resolved = resolveJobId(db, DEFAULT_TENANT, jobLocator);
+  return resolved ? canonicalJobId(resolved) : null;
+}
+
+function resolveExternalJobId(db: SqliteDatabase, jobLocator: string): JobId {
+  const jobId = resolveExternalJobIdOrNull(db, jobLocator);
+  if (!jobId) {
     throw new InputError("Job not found.");
   }
-  return jobUrl;
+  return jobId;
 }
 
 function recordEvent(
@@ -2812,32 +2641,28 @@ function recordEvent(
     eventType: string;
     payload: Record<string, unknown>;
     message: string;
-    jobUrl: string;
+    jobId: JobId;
     stage: Stage;
   },
 ): void {
-  if (!tableExists(db, "job_events")) {
-    return;
-  }
-  const columns = new Set(
-    allRows<{ name: string }>(db, "PRAGMA table_info(job_events)").map((row) => row.name),
-  );
-  const values: Record<string, SqliteValue> = {
-    job_url: event.jobUrl,
-    stage: event.stage,
-    event_type: event.eventType,
-    level: "info",
-    message: event.message,
-    occurred_at: new Date().toISOString(),
-    payload_json: JSON.stringify(event.payload),
-  };
-  const entries = Object.entries(values).filter(([name]) => columns.has(name));
-  if (!entries.length) {
-    return;
-  }
   db.prepare(
-    `INSERT INTO job_events (${entries.map(([name]) => name).join(", ")}) VALUES (${entries.map(() => "?").join(", ")})`,
-  ).run(...entries.map(([, value]) => value));
+    `INSERT INTO job_events (
+       tenant_id, job_id, identity_version, stage, event_type, level, message,
+       occurred_at, payload_json, entity_kind, entity_ref
+     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    DEFAULT_TENANT,
+    event.jobId,
+    7,
+    event.stage,
+    event.eventType,
+    "info",
+    event.message,
+    new Date().toISOString(),
+    JSON.stringify(event.payload),
+    "job",
+    event.jobId,
+  );
 }
 
 function reviewState(

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -1381,8 +1381,13 @@ export function buildApp(options: BuildAppOptions): FastifyInstance {
         return undefined;
       }
       return withWritableDb(reply, options.dbPath, (db) => {
-        const { jobUrl } = correctScore(db, decodeRouteParam(request.params.jobKey), body);
-        const detail = getJobDetail(db, jobUrl);
+        const jobId = resolveJobId(db, "local", decodeRouteParam(request.params.jobKey));
+        if (!jobId) {
+          void reply.code(404);
+          return { ok: false, error: "job_not_found" };
+        }
+        correctScore(db, "local", jobId, body);
+        const detail = getJobDetail(db, jobId);
         if (!detail) {
           void reply.code(404);
           return { ok: false, error: "job_not_found" };
@@ -1397,7 +1402,17 @@ export function buildApp(options: BuildAppOptions): FastifyInstance {
     if (!body) {
       return undefined;
     }
-    return withWritableDb(reply, options.dbPath, (db) => resetStaleScoresForRescore(db, body));
+    return withWritableDb(reply, options.dbPath, (db) => {
+      const jobIds = [...new Set(
+        body.jobKeys
+          .map((jobKey) => resolveJobId(db, "local", jobKey))
+          .filter((jobId): jobId is string => jobId !== null),
+      )];
+      return resetStaleScoresForRescore(db, {
+        limit: body.limit,
+        ...(body.jobKeys.length > 0 ? { jobIds } : {}),
+      });
+    });
   });
 
   app.post<{ Params: { jobKey: string } }>(

--- a/apps/api/src/write-model.ts
+++ b/apps/api/src/write-model.ts
@@ -8,7 +8,6 @@ import type {
   DeleteJobRequest,
   JobMutationResponse,
   MarkJobActionRequest,
-  ResetStaleScoresForRescoreRequest,
   ResetStaleScoresForRescoreResponse,
   SettingsResponse,
   SettingsUpdateRequest,
@@ -387,21 +386,18 @@ export function cancelJobAction(db: SqliteDatabase, jobKey: string, runId = ""):
 
 export function correctScore(
   db: SqliteDatabase,
-  jobKey: string,
+  tenantId: string,
+  jobId: string,
   request: CorrectScoreRequest,
-): { jobUrl: string; version: number } {
-  const jobUrl = resolveJobUrl(db, jobKey);
-  if (!jobUrl) {
-    throw new InputError("Job not found.");
-  }
+): { jobId: string; version: number } {
   ensureJobScoresTable(db);
   ensureScoreStalenessTable(db);
   const latest = getRow<Record<string, unknown>>(
     db,
     `SELECT * FROM job_scores
-     WHERE tenant_id = 'local' AND job_url = ?
+     WHERE tenant_id = ? AND job_id = ?
      ORDER BY version DESC LIMIT 1`,
-    [jobUrl],
+    [tenantId, jobId],
   );
   if (!latest) {
     throw new InputError("Score correction requires an existing score.");
@@ -411,24 +407,25 @@ export function correctScore(
   const correction = {
     corrected_fit_score: request.correctedScore,
     rationale: request.reason,
-    corrected_by: "local",
+    corrected_by: tenantId,
     corrected_at: now,
   };
   const trace = appendCorrectionHistory(latest.trace_json, {
     original_score: Number(latest.fit_score ?? 0),
     corrected_score: request.correctedScore,
     rationale: request.reason,
-    corrected_by: "local",
+    corrected_by: tenantId,
     corrected_at: now,
   });
   const transaction = db.transaction(() => {
     db.prepare(
       `INSERT INTO job_scores (
-         job_url, version, tenant_id, fit_score, breakdown_json, keywords_json,
+         tenant_id, job_id, version, fit_score, breakdown_json, keywords_json,
          scored_at, correction_json, criteria_json, trace_json
-       ) VALUES (?, ?, 'local', ?, ?, ?, ?, ?, ?, ?)`,
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     ).run(
-      jobUrl,
+      tenantId,
+      jobId,
       nextVersion,
       request.correctedScore,
       String(latest.breakdown_json ?? "{}"),
@@ -439,26 +436,27 @@ export function correctScore(
       JSON.stringify(trace),
     );
     const policyChange = persistScoringPolicyCorrection(db, {
-      jobUrl,
+      tenantId,
+      jobId,
       latest,
       correctedScore: request.correctedScore,
       correctedAt: now,
     });
     markComparableScoresStale(db, {
-      correctedJobUrl: jobUrl,
+      tenantId,
+      correctedJobId: jobId,
       markedAt: now,
-      newPolicyId: `local:scoring-policy-v${policyChange.newPolicyVersion}`,
+      newPolicyId: `${tenantId}:scoring-policy-v${policyChange.newPolicyVersion}`,
       newPolicyVersion: policyChange.newPolicyVersion,
     });
-    recordActionEvent(db, {
-      jobUrl,
+    recordActionEventById(db, {
+      tenantId,
+      jobId,
       stage: "score",
       eventType: "ScoreCorrected",
       level: "info",
       message: "Score corrected from the local API.",
       payload: {
-        tenantId: "local",
-        jobId: jobUrl,
         originalScore: Number(latest.fit_score ?? 0),
         correctedScore: request.correctedScore,
         reason: request.reason,
@@ -467,36 +465,39 @@ export function correctScore(
     });
   });
   transaction();
-  return { jobUrl, version: nextVersion };
+  return { jobId, version: nextVersion };
 }
 
 export function resetStaleScoresForRescore(
   db: SqliteDatabase,
-  request: ResetStaleScoresForRescoreRequest = { limit: 0, jobKeys: [] },
+  request: { limit?: number; jobIds?: readonly string[] } = {},
 ): ResetStaleScoresForRescoreResponse {
   ensureScoreStalenessTable(db);
   const limit = Math.max(0, Math.floor(request.limit ?? 0));
-  const jobKeysFilter = [...new Set((request.jobKeys ?? []).map((key) => key.trim()).filter(Boolean))];
-  const selectedWhere = jobKeysFilter.length
-    ? ` AND job_url IN (${jobKeysFilter.map(() => "?").join(", ")})`
-    : "";
+  const jobIdsFilter = [...new Set((request.jobIds ?? []).map((jobId) => jobId.trim()).filter(Boolean))];
+  const selectedWhere = request.jobIds === undefined
+    ? ""
+    : jobIdsFilter.length
+      ? ` AND job_id IN (${jobIdsFilter.map(() => "?").join(", ")})`
+      : " AND 0";
   const rows = allRows<Record<string, unknown>>(
     db,
-    `SELECT job_url, stale_reason, old_policy_version, new_policy_version
+    `SELECT tenant_id, job_id, stale_reason, old_policy_version, new_policy_version
      FROM job_score_staleness
-     WHERE tenant_id = 'local' AND resolved = 0
+     WHERE tenant_id = ? AND resolved = 0
        ${selectedWhere}
      ORDER BY marked_at ASC${limit > 0 ? " LIMIT ?" : ""}`,
-    [...jobKeysFilter, ...(limit > 0 ? [limit] : [])],
+    [LOCAL_TENANT, ...jobIdsFilter, ...(limit > 0 ? [limit] : [])],
   );
   const now = new Date().toISOString();
-  const jobKeys = rows.map((row) => String(row.job_url ?? "")).filter(Boolean);
+  const jobKeys = rows.map((row) => String(row.job_id ?? "")).filter(Boolean);
   for (const row of rows) {
-    const jobUrl = String(row.job_url ?? "");
-    if (!jobUrl) {
+    const tenantId = String(row.tenant_id ?? "");
+    const jobId = String(row.job_id ?? "");
+    if (!tenantId || !jobId) {
       continue;
     }
-    upsertStageState(db, jobUrl, "score", "pending", {
+    upsertStageStateById(db, tenantId, jobId, "score", "pending", {
       attemptCount: 0,
       clearTiming: true,
       skipValidation: true,
@@ -505,27 +506,27 @@ export function resetStaleScoresForRescore(
       `UPDATE job_score_staleness
           SET resolved = 1,
               resolved_at = ?
-        WHERE tenant_id = 'local'
-          AND job_url = ?
+        WHERE tenant_id = ?
+          AND job_id = ?
           AND stale_reason = ?
           AND old_policy_version = ?
           AND new_policy_version = ?`,
     ).run(
       now,
-      jobUrl,
+      tenantId,
+      jobId,
       String(row.stale_reason ?? ""),
       Number(row.old_policy_version ?? 0),
       Number(row.new_policy_version ?? 0),
     );
-    recordActionEvent(db, {
-      jobUrl,
+    recordActionEventById(db, {
+      tenantId,
+      jobId,
       stage: "score",
       eventType: "ScoreRescoreRequested",
       level: "info",
       message: "Stale score reset for explicit rescore.",
       payload: {
-        tenantId: "local",
-        jobId: jobUrl,
         staleReason: String(row.stale_reason ?? ""),
         oldPolicyVersion: Number(row.old_policy_version ?? 0),
         newPolicyVersion: Number(row.new_policy_version ?? 0),
@@ -887,33 +888,28 @@ function deleteWhere(db: SqliteDatabase, tableName: string, whereSql: string, pa
 function ensureJobScoresTable(db: SqliteDatabase): void {
   db.exec(`
     CREATE TABLE IF NOT EXISTS job_scores (
-      job_url TEXT NOT NULL,
-      version INTEGER NOT NULL,
       tenant_id TEXT NOT NULL DEFAULT 'local',
-      fit_score INTEGER NOT NULL,
+      job_id TEXT NOT NULL,
+      version INTEGER NOT NULL CHECK(version > 0),
+      fit_score INTEGER NOT NULL CHECK(fit_score BETWEEN 1 AND 10),
       breakdown_json TEXT NOT NULL,
       keywords_json TEXT NOT NULL,
       scored_at TEXT NOT NULL,
       correction_json TEXT,
       criteria_json TEXT NOT NULL DEFAULT '{}',
       trace_json TEXT NOT NULL DEFAULT '{}',
-      PRIMARY KEY (job_url, version)
+      PRIMARY KEY (tenant_id, job_id, version),
+      FOREIGN KEY (tenant_id, job_id)
+        REFERENCES jobs(tenant_id, job_id) ON DELETE CASCADE
     )
   `);
-  const columns = columnNames(db, "job_scores");
-  if (!columns.has("criteria_json")) {
-    db.exec("ALTER TABLE job_scores ADD COLUMN criteria_json TEXT NOT NULL DEFAULT '{}'");
-  }
-  if (!columns.has("trace_json")) {
-    db.exec("ALTER TABLE job_scores ADD COLUMN trace_json TEXT NOT NULL DEFAULT '{}'");
-  }
 }
 
 function ensureScoreStalenessTable(db: SqliteDatabase): void {
   db.exec(`
     CREATE TABLE IF NOT EXISTS job_score_staleness (
       tenant_id TEXT NOT NULL DEFAULT 'local',
-      job_url TEXT NOT NULL,
+      job_id TEXT NOT NULL,
       stale_reason TEXT NOT NULL,
       old_policy_id TEXT NOT NULL DEFAULT '',
       old_policy_version INTEGER NOT NULL,
@@ -924,9 +920,11 @@ function ensureScoreStalenessTable(db: SqliteDatabase): void {
       resolved_at TEXT,
       resolved_by_score_version INTEGER,
       PRIMARY KEY (
-        tenant_id, job_url, stale_reason,
+        tenant_id, job_id, stale_reason,
         old_policy_version, new_policy_version
-      )
+      ),
+      FOREIGN KEY (tenant_id, job_id)
+        REFERENCES jobs(tenant_id, job_id) ON DELETE CASCADE
     )
   `);
   db.exec(`
@@ -935,7 +933,7 @@ function ensureScoreStalenessTable(db: SqliteDatabase): void {
   `);
   db.exec(`
     CREATE INDEX IF NOT EXISTS idx_job_score_staleness_job
-    ON job_score_staleness(tenant_id, job_url, resolved)
+    ON job_score_staleness(tenant_id, job_id, resolved)
   `);
 }
 
@@ -960,28 +958,29 @@ function ensureScoringPoliciesTable(db: SqliteDatabase): void {
 function persistScoringPolicyCorrection(
   db: SqliteDatabase,
   input: {
-    jobUrl: string;
+    tenantId: string;
+    jobId: string;
     latest: Record<string, unknown>;
     correctedScore: number;
     correctedAt: string;
   },
 ): { previousPolicyVersion: number; newPolicyVersion: number } {
   ensureScoringPoliciesTable(db);
-  const current = getCurrentScoringPolicyRow(db, input.correctedAt);
+  const current = getCurrentScoringPolicyRow(db, input.tenantId, input.correctedAt);
   const previousTrace = parseObjectOrDefault(String(input.latest.trace_json ?? "{}"));
   const previousBreakdown = parseObjectOrDefault(String(input.latest.breakdown_json ?? "{}"));
   const originalScore = Number(input.latest.fit_score ?? 0);
   const correctionDelta = input.correctedScore - originalScore;
   const anchor = sanitizePolicyAnchor({
     anchor_id: correctionAnchorId({
-      tenant_id: "local",
-      job_id: input.jobUrl,
+      tenant_id: input.tenantId,
+      job_id: input.jobId,
       original_score: originalScore,
       corrected_score: input.correctedScore,
       corrected_at: input.correctedAt,
       source_policy_version: Number(previousTrace.scoring_policy_version ?? 0),
     }),
-    job_ref_hash: policyAnchorJobRefHash(input.jobUrl),
+    job_ref_hash: policyAnchorJobRefHash(input.tenantId, input.jobId),
     fit_score: input.correctedScore,
     original_fit_score: originalScore,
     corrected_fit_score: input.correctedScore,
@@ -998,8 +997,9 @@ function persistScoringPolicyCorrection(
   db.prepare(
     `INSERT INTO scoring_policies (
        tenant_id, version, rubric_json, anchors_json, created_at, created_from_event_id
-     ) VALUES ('local', ?, ?, ?, ?, NULL)`,
+     ) VALUES (?, ?, ?, ?, ?, NULL)`,
   ).run(
+    input.tenantId,
     Number(current.version) + 1,
     current.rubric_json,
     JSON.stringify(anchors),
@@ -1014,7 +1014,8 @@ function persistScoringPolicyCorrection(
 function markComparableScoresStale(
   db: SqliteDatabase,
   input: {
-    correctedJobUrl: string;
+    tenantId: string;
+    correctedJobId: string;
     markedAt: string;
     newPolicyId: string;
     newPolicyVersion: number;
@@ -1023,21 +1024,24 @@ function markComparableScoresStale(
   ensureScoreStalenessTable(db);
   const latestRows = allRows<Record<string, unknown>>(
     db,
-    `SELECT s.job_url, s.trace_json
+    `SELECT s.job_id, s.trace_json
      FROM job_scores s
      INNER JOIN (
-       SELECT job_url, MAX(version) AS max_version
+       SELECT tenant_id, job_id, MAX(version) AS max_version
        FROM job_scores
-       WHERE tenant_id = 'local'
-       GROUP BY job_url
+       WHERE tenant_id = ?
+       GROUP BY tenant_id, job_id
      ) latest
-       ON latest.job_url = s.job_url AND latest.max_version = s.version
-     WHERE s.tenant_id = 'local'
+       ON latest.tenant_id = s.tenant_id
+      AND latest.job_id = s.job_id
+      AND latest.max_version = s.version
+     WHERE s.tenant_id = ?
        AND (s.correction_json IS NULL OR TRIM(s.correction_json) = '')`,
+    [input.tenantId, input.tenantId],
   );
   for (const row of latestRows) {
-    const jobUrl = String(row.job_url ?? "");
-    if (!jobUrl || jobUrl === input.correctedJobUrl) {
+    const jobId = String(row.job_id ?? "");
+    if (!jobId || jobId === input.correctedJobId) {
       continue;
     }
     const trace = parseObjectOrDefault(String(row.trace_json ?? "{}"));
@@ -1050,14 +1054,15 @@ function markComparableScoresStale(
     const result = db
       .prepare(
         `INSERT OR IGNORE INTO job_score_staleness (
-           tenant_id, job_url, stale_reason,
+           tenant_id, job_id, stale_reason,
            old_policy_id, old_policy_version,
            new_policy_id, new_policy_version,
            marked_at, resolved, resolved_at, resolved_by_score_version
-         ) VALUES ('local', ?, ?, ?, ?, ?, ?, ?, 0, NULL, NULL)`,
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0, NULL, NULL)`,
       )
       .run(
-        jobUrl,
+        input.tenantId,
+        jobId,
         staleReason,
         oldPolicyId,
         oldPolicyVersion,
@@ -1068,7 +1073,7 @@ function markComparableScoresStale(
     if (result.changes <= 0) {
       continue;
     }
-    markScoreStageStale(db, jobUrl, {
+    markScoreStageStale(db, input.tenantId, jobId, {
       staleReason,
       oldPolicyId,
       oldPolicyVersion,
@@ -1081,7 +1086,8 @@ function markComparableScoresStale(
 
 function markScoreStageStale(
   db: SqliteDatabase,
-  jobUrl: string,
+  tenantId: string,
+  jobId: string,
   marker: {
     staleReason: string;
     oldPolicyId: string;
@@ -1093,21 +1099,20 @@ function markScoreStageStale(
 ): void {
   const current = getRow<{ state?: string }>(
     db,
-    "SELECT state FROM job_stage_states WHERE job_url = ? AND stage = 'score'",
-    [jobUrl],
+    "SELECT state FROM job_stage_states WHERE tenant_id = ? AND job_id = ? AND stage = 'score'",
+    [tenantId, jobId],
   );
   if (!current || current.state === "succeeded") {
-    upsertStageState(db, jobUrl, "score", "stale");
+    upsertStageStateById(db, tenantId, jobId, "score", "stale");
   }
-  recordActionEvent(db, {
-    jobUrl,
+  recordActionEventById(db, {
+    tenantId,
+    jobId,
     stage: "score",
     eventType: "ScoreMarkedStale",
     level: "info",
     message: "Score marked stale after scoring policy changed.",
     payload: {
-      tenantId: "local",
-      jobId: jobUrl,
       staleReason: marker.staleReason,
       oldPolicyId: marker.oldPolicyId,
       oldPolicyVersion: marker.oldPolicyVersion,
@@ -1120,6 +1125,7 @@ function markScoreStageStale(
 
 function getCurrentScoringPolicyRow(
   db: SqliteDatabase,
+  tenantId: string,
   createdAt: string,
 ): {
   version: number;
@@ -1134,9 +1140,10 @@ function getCurrentScoringPolicyRow(
     db,
     `SELECT version, rubric_json, anchors_json
      FROM scoring_policies
-     WHERE tenant_id = 'local'
+     WHERE tenant_id = ?
      ORDER BY version DESC
      LIMIT 1`,
+    [tenantId],
   );
   if (latest) {
     return {
@@ -1149,8 +1156,8 @@ function getCurrentScoringPolicyRow(
   db.prepare(
     `INSERT INTO scoring_policies (
        tenant_id, version, rubric_json, anchors_json, created_at, created_from_event_id
-     ) VALUES ('local', 1, ?, '[]', ?, NULL)`,
-  ).run(rubricJson, createdAt);
+     ) VALUES (?, 1, ?, '[]', ?, NULL)`,
+  ).run(tenantId, rubricJson, createdAt);
   return { version: 1, rubric_json: rubricJson, anchors_json: "[]" };
 }
 
@@ -1240,8 +1247,8 @@ function correctionAnchorId(payload: Record<string, unknown>): string {
   return `correction-anchor-${digest}`;
 }
 
-function policyAnchorJobRefHash(jobUrl: string): string {
-  return `sha256:${stablePolicyHash({ tenant_id: "local", job_id: jobUrl })}`;
+function policyAnchorJobRefHash(tenantId: string, jobId: string): string {
+  return `sha256:${stablePolicyHash({ tenant_id: tenantId, job_id: jobId })}`;
 }
 
 function stablePolicyHash(payload: Record<string, unknown>): string {

--- a/apps/api/test/application-feedback-v7.test.ts
+++ b/apps/api/test/application-feedback-v7.test.ts
@@ -1,0 +1,153 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import Database from "better-sqlite3";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../src/projections.js", () => ({ refreshProjections: vi.fn() }));
+vi.mock("../src/repeat-application.js", () => ({
+  evaluateRepeatApplication: vi.fn(() => ({ blocked: false, matches: [] })),
+}));
+vi.mock("../src/resume-templates.js", () => ({
+  resumeTemplateStateForJob: vi.fn(() => null),
+}));
+
+import {
+  decideOutcomeSuggestion,
+  listApplicationOutcomes,
+  listApplyReviewQueue,
+  listJobApplicationOutcomes,
+  recordManualApplicationOutcome,
+} from "../src/application-feedback.js";
+import { InputError } from "../src/write-model.js";
+import { hasExactV7SchemaManifest } from "../src/schema-manifest.js";
+import { initializeExactV7Database } from "./v7-schema.js";
+
+const JOB_ID = "00000000-0000-4000-8000-000000000071";
+const JOB_URL = "https://jobs.example.test/application-feedback";
+const OTHER_TENANT = "other";
+const PRIVATE_NOTE = "private outcome note";
+const PRIVATE_BODY = "raw confidential email body";
+const PRIVATE_RATIONALE = "private classification rationale";
+
+const cleanups: Array<() => void> = [];
+afterEach(() => {
+  while (cleanups.length) cleanups.pop()?.();
+});
+
+function seededDatabase(): Database.Database {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "jobctrl-application-feedback-v7-"));
+  const dbPath = path.join(dir, "jobs.db");
+  initializeExactV7Database(dbPath);
+  const db = new Database(dbPath);
+  db.pragma("foreign_keys = ON");
+  cleanups.push(() => {
+    db.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  for (const tenantId of ["local", OTHER_TENANT]) {
+    db.prepare(
+      `INSERT INTO jobs (tenant_id, job_id, url, title, company, discovered_at, application_url)
+       VALUES (?, ?, ?, 'Feedback Engineer', 'Example', '2026-07-31T12:00:00Z', ?)`,
+    ).run(tenantId, JOB_ID, `${JOB_URL}/${tenantId}`, JOB_URL);
+    db.prepare(
+      `INSERT INTO job_list_projections (
+         tenant_id, job_id, title, employer, source, application_url, fit_score,
+         current_stage, current_substage, current_state, has_resume
+       ) VALUES (?, ?, 'Feedback Engineer', 'Example', 'fixture', ?, 9, 'apply', 'apply', 'pending', 1)`,
+    ).run(tenantId, JOB_ID, JOB_URL);
+    db.prepare(
+      `INSERT INTO job_stage_states (tenant_id, job_id, stage, state, updated_at)
+       VALUES (?, ?, 'apply', 'pending', '2026-07-31T12:00:00Z')`,
+    ).run(tenantId, JOB_ID);
+  }
+  return db;
+}
+
+function seedSuggestion(db: Database.Database, suggestionId: string, suggestedKind = "interview"): void {
+  const evidenceId = `evidence-${suggestionId}`;
+  db.prepare(
+    `INSERT INTO application_email_evidence (
+       tenant_id, evidence_id, job_id, provider, provider_message_id, linked_at,
+       link_confidence, link_signals_json, body_text
+     ) VALUES ('local', ?, ?, 'gmail', ?, '2026-07-31T12:05:00Z', 0.9, '[]', ?)`,
+  ).run(evidenceId, JOB_ID, `message-${suggestionId}`, PRIVATE_BODY);
+  db.prepare(
+    `INSERT INTO application_outcome_suggestions (
+       tenant_id, suggestion_id, job_id, evidence_id, suggested_kind, confidence,
+       rationale, status, created_at
+     ) VALUES ('local', ?, ?, ?, ?, 0.9, ?, 'pending', '2026-07-31T12:06:00Z')`,
+  ).run(suggestionId, JOB_ID, evidenceId, suggestedKind, PRIVATE_RATIONALE);
+}
+
+describe("application feedback exact v7 identity", () => {
+  it("keeps queue and outcome reads tenant-isolated when tenants share a canonical job id", () => {
+    const db = seededDatabase();
+    db.prepare(
+      `INSERT INTO application_outcomes (
+         tenant_id, outcome_id, job_id, kind, source, occurred_at, recorded_at
+       ) VALUES (?, 'other-outcome', ?, 'rejection', 'manual', '2026-07-31T12:01:00Z', '2026-07-31T12:01:00Z')`,
+    ).run(OTHER_TENANT, JOB_ID);
+
+    const manual = recordManualApplicationOutcome(db, JOB_ID, {
+      kind: "interview",
+      note: PRIVATE_NOTE,
+      occurredAt: "2026-07-31T12:02:00Z",
+    });
+    const jobOutcomes = listJobApplicationOutcomes(db, JOB_ID);
+    const allOutcomes = listApplicationOutcomes(db);
+    const queue = listApplyReviewQueue(db);
+
+    expect(jobOutcomes?.jobKey).toBe(JOB_ID);
+    expect(jobOutcomes?.outcomes).toEqual([
+      expect.objectContaining({ outcomeId: manual.outcome.outcomeId, jobKey: JOB_ID }),
+    ]);
+    expect(allOutcomes.outcomes).toHaveLength(1);
+    expect(queue.items).toHaveLength(1);
+    expect(queue.items[0]?.jobKey).toBe(JOB_ID);
+  });
+
+  it("accepts, corrects, and ignores exact-v7 suggestions without exposing private text in events", () => {
+    const db = seededDatabase();
+    seedSuggestion(db, "accept", "interview");
+    seedSuggestion(db, "correct", "unknown");
+    seedSuggestion(db, "ignore", "rejection");
+
+    const accepted = decideOutcomeSuggestion(db, "accept", {
+      decision: "accept",
+      note: PRIVATE_NOTE,
+    });
+    const corrected = decideOutcomeSuggestion(db, "correct", {
+      decision: "correct",
+      outcomeKind: "offer",
+      reason: PRIVATE_RATIONALE,
+    });
+    const ignored = decideOutcomeSuggestion(db, "ignore", {
+      decision: "ignore",
+      reason: PRIVATE_RATIONALE,
+    });
+    const events = db.prepare("SELECT payload_json FROM job_events ORDER BY event_id").all() as Array<{
+      payload_json: string | null;
+    }>;
+
+    expect(accepted).toMatchObject({ suggestion: { status: "accepted", jobKey: JOB_ID }, outcome: { kind: "interview" } });
+    expect(corrected).toMatchObject({ suggestion: { status: "corrected" }, outcome: { kind: "offer" } });
+    expect(ignored).toMatchObject({ suggestion: { status: "ignored" }, outcome: null });
+    expect(listApplicationOutcomes(db).outcomes).toHaveLength(2);
+    expect(events.map((event) => event.payload_json).join("\n")).not.toContain(PRIVATE_NOTE);
+    expect(events.map((event) => event.payload_json).join("\n")).not.toContain(PRIVATE_BODY);
+    expect(events.map((event) => event.payload_json).join("\n")).not.toContain(PRIVATE_RATIONALE);
+  });
+
+  it("does not mutate the exact-v7 schema and refuses an invalid job id", () => {
+    const db = seededDatabase();
+    expect(hasExactV7SchemaManifest(db)).toBe(true);
+
+    expect(() =>
+      recordManualApplicationOutcome(db, "not-a-canonical-job-id", { kind: "interview" }),
+    ).toThrow(InputError);
+    expect(hasExactV7SchemaManifest(db)).toBe(true);
+  });
+});

--- a/apps/api/test/application-feedback.test.ts
+++ b/apps/api/test/application-feedback.test.ts
@@ -9,11 +9,16 @@ import { ensureApplicationFeedbackTables } from "../src/application-feedback.js"
 import type { ApplyReviewQueueResponse } from "../src/contracts.js";
 import { GmailFeedbackScanError, type GmailFeedbackScanner } from "../src/gmail-feedback-worker.js";
 import { type ActionDispatcher, type ActionDispatchResult } from "../src/local-actions.js";
+import { BUILT_IN_RESUME_TEMPLATE_THEME } from "../src/resume-templates.js";
 import { type BuildAppOptions, buildApp } from "../src/server.js";
+import { initializeExactV7Database } from "./v7-schema.js";
 
 const READY_JOB = "https://example.com/jobs/apply-ready";
 const DRY_RUN_JOB = "https://example.com/jobs/apply-dry-run";
 const APPLIED_JOB = "https://example.com/jobs/already-applied";
+const READY_JOB_ID = "00000000-0000-4000-8000-000000000101";
+const DRY_RUN_JOB_ID = "00000000-0000-4000-8000-000000000102";
+const APPLIED_JOB_ID = "00000000-0000-4000-8000-000000000103";
 const NOW = "2026-06-01T10:00:00.000Z";
 const LONG_TAILORED_REQUIREMENT_EVIDENCE =
   "Owned platform reliability improvements for incident response across four production services, reduced high-severity repeat incidents through clearer ownership, and built review habits that kept customer-facing systems stable during launch pressure.";
@@ -49,11 +54,11 @@ describe("application feedback API", () => {
     expect(response.statusCode, response.body).toBe(200);
     const body = response.json();
     expect(body.items.map((item: { jobKey: string }) => item.jobKey)).toEqual([
-      READY_JOB,
-      DRY_RUN_JOB,
+      READY_JOB_ID,
+      DRY_RUN_JOB_ID,
     ]);
     expect(body.items[0]).toMatchObject({
-      jobKey: READY_JOB,
+      jobKey: READY_JOB_ID,
       title: "Principal Platform Engineer",
       currentStage: "apply",
       currentState: "pending",
@@ -214,17 +219,17 @@ describe("application feedback API", () => {
       UPDATE job_stage_states
          SET state = 'running',
              updated_at = '2026-06-01T11:30:00.000Z'
-       WHERE job_url = ?
+       WHERE job_id = ?
          AND stage = 'tailor'
       `,
-    ).run(READY_JOB);
+    ).run(READY_JOB_ID);
     db.close();
     const app = buildApp(options);
 
     const response = await app.inject({ method: "GET", url: "/v1/apply/review-queue" });
 
     expect(response.statusCode, response.body).toBe(200);
-    expect(queueItem(response.json(), READY_JOB)).toMatchObject({
+    expect(queueItem(response.json(), READY_JOB_ID)).toMatchObject({
       currentStage: "discover",
       currentState: "running",
       materialsPreview: {
@@ -250,17 +255,17 @@ describe("application feedback API", () => {
          SET state = 'failed',
              error_code = 'FAILED',
              error_message = 'SKIPPED: process killed by signal'
-       WHERE job_url = ?
+       WHERE job_id = ?
          AND stage = 'apply'
       `,
-    ).run(READY_JOB);
+    ).run(READY_JOB_ID);
     db.close();
     const app = buildApp(options);
 
     const response = await app.inject({ method: "GET", url: "/v1/apply/review-queue" });
 
     expect(response.statusCode, response.body).toBe(200);
-    expect(queueItem(response.json(), READY_JOB)).toMatchObject({
+    expect(queueItem(response.json(), READY_JOB_ID)).toMatchObject({
       currentStage: "apply",
       currentState: "failed",
       blockers: ["SKIPPED: process killed by signal"],
@@ -288,17 +293,17 @@ describe("application feedback API", () => {
              error_code = 'FAILED',
              error_message = 'missing_profile_data:age_18_plus',
              retryable = 0
-       WHERE job_url = ?
+       WHERE job_id = ?
          AND stage = 'apply'
       `,
-    ).run(READY_JOB);
+    ).run(READY_JOB_ID);
     db.close();
     const app = buildApp(options);
 
     const response = await app.inject({ method: "GET", url: "/v1/apply/review-queue" });
 
     expect(response.statusCode, response.body).toBe(200);
-    expect(queueItem(response.json(), READY_JOB)).toMatchObject({
+    expect(queueItem(response.json(), READY_JOB_ID)).toMatchObject({
       currentStage: "apply",
       currentState: "failed",
       blockers: ["missing_profile_data:age_18_plus"],
@@ -318,19 +323,6 @@ describe("application feedback API", () => {
 
   it("surfaces incomplete application attestations before approval", async () => {
     const db = new Database(options.dbPath);
-    db.exec(`
-      CREATE TABLE candidate_profiles (
-        tenant_id TEXT NOT NULL,
-        profile_id TEXT NOT NULL,
-        application_attestation_age_18_plus INTEGER DEFAULT NULL,
-        application_attestation_background_check_consent INTEGER DEFAULT NULL,
-        application_attestation_felony_conviction INTEGER DEFAULT NULL,
-        application_attestation_previously_worked_at_employer INTEGER DEFAULT NULL,
-        version INTEGER NOT NULL DEFAULT 1,
-        updated_at TEXT NOT NULL,
-        PRIMARY KEY (tenant_id, profile_id)
-      );
-    `);
     db.prepare(
       `INSERT INTO candidate_profiles (
          tenant_id, profile_id, application_attestation_age_18_plus,
@@ -346,7 +338,7 @@ describe("application feedback API", () => {
     const response = await app.inject({ method: "GET", url: "/v1/apply/review-queue" });
 
     expect(response.statusCode, response.body).toBe(200);
-    expect(queueItem(response.json(), READY_JOB)?.applyAudit).toMatchObject({
+    expect(queueItem(response.json(), READY_JOB_ID)?.applyAudit).toMatchObject({
       state: "preparing",
       missingPrerequisites: [
         expect.objectContaining({
@@ -375,17 +367,17 @@ describe("application feedback API", () => {
          SET state = 'failed',
              error_code = 'RENDER_FAILED',
              error_message = 'Cover PDF render failed'
-       WHERE job_url = ?
+       WHERE job_id = ?
          AND stage = 'cover'
       `,
-    ).run(READY_JOB);
+    ).run(READY_JOB_ID);
     db.close();
     const app = buildApp(options);
 
     const response = await app.inject({ method: "GET", url: "/v1/apply/review-queue" });
 
     expect(response.statusCode, response.body).toBe(200);
-    expect(queueItem(response.json(), READY_JOB)).toMatchObject({
+    expect(queueItem(response.json(), READY_JOB_ID)).toMatchObject({
       currentStage: "apply",
       currentState: "failed",
       blockers: ["Cover PDF render failed"],
@@ -413,17 +405,17 @@ describe("application feedback API", () => {
          SET state = 'needs_verification',
              error_code = 'APPLY_NEEDS_VERIFICATION',
              error_message = 'Submit intent was recorded but no terminal result exists.'
-       WHERE job_url = ?
+       WHERE job_id = ?
          AND stage = 'apply'
       `,
-    ).run(READY_JOB);
+    ).run(READY_JOB_ID);
     db.close();
     const app = buildApp(options);
 
     const response = await app.inject({ method: "GET", url: "/v1/apply/review-queue" });
 
     expect(response.statusCode, response.body).toBe(200);
-    expect(queueItem(response.json(), READY_JOB)).toMatchObject({
+    expect(queueItem(response.json(), READY_JOB_ID)).toMatchObject({
       currentStage: "apply",
       currentState: "needs_verification",
       blockers: ["Submit intent was recorded but no terminal result exists."],
@@ -441,17 +433,17 @@ describe("application feedback API", () => {
              error_code = 'BLOCKED',
              error_message = 'Materials are not ready.',
              retryable = 0
-       WHERE job_url = ?
+       WHERE job_id = ?
          AND stage = 'apply'
       `,
-    ).run(READY_JOB);
+    ).run(READY_JOB_ID);
     db.close();
     const app = buildApp(options);
 
     const response = await app.inject({ method: "GET", url: "/v1/apply/review-queue" });
 
     expect(response.statusCode, response.body).toBe(200);
-    expect(queueItem(response.json(), READY_JOB)).toMatchObject({
+    expect(queueItem(response.json(), READY_JOB_ID)).toMatchObject({
       currentStage: "apply",
       currentState: "pending",
       blockers: [],
@@ -464,11 +456,11 @@ describe("application feedback API", () => {
         `
         SELECT state, error_code, error_message
           FROM job_stage_states
-         WHERE job_url = ?
+         WHERE job_id = ?
            AND stage = 'apply'
         `,
       )
-      .get(READY_JOB) as { state: string; error_code: string | null; error_message: string | null };
+      .get(READY_JOB_ID) as { state: string; error_code: string | null; error_message: string | null };
     readDb.close();
 
     expect(stage).toEqual({
@@ -491,17 +483,17 @@ describe("application feedback API", () => {
              retryable = 1,
              next_action = ?,
              updated_at = '2026-06-01T11:30:00.000Z'
-       WHERE job_url = ?
+       WHERE job_id = ?
          AND stage = 'cover'
       `,
-    ).run(staleConflict, `jobctrl retry cover ${READY_JOB}`, READY_JOB);
+    ).run(staleConflict, `jobctrl retry cover ${READY_JOB}`, READY_JOB_ID);
     db.close();
     const app = buildApp(options);
 
     const response = await app.inject({ method: "GET", url: "/v1/apply/review-queue" });
 
     expect(response.statusCode, response.body).toBe(200);
-    const item = queueItem(response.json(), READY_JOB);
+    const item = queueItem(response.json(), READY_JOB_ID);
     expect(item).toMatchObject({
       currentStage: "apply",
       currentState: "pending",
@@ -522,11 +514,11 @@ describe("application feedback API", () => {
         `
         SELECT state, error_code, error_message, retryable, next_action, metadata_json
           FROM job_stage_states
-         WHERE job_url = ?
+         WHERE job_id = ?
            AND stage = 'cover'
         `,
       )
-      .get(READY_JOB) as {
+      .get(READY_JOB_ID) as {
       state: string;
       error_code: string | null;
       error_message: string | null;
@@ -559,7 +551,7 @@ describe("application feedback API", () => {
     const response = await app.inject({ method: "GET", url: "/v1/apply/review-queue" });
 
     expect(response.statusCode, response.body).toBe(200);
-    expect(queueItem(response.json(), READY_JOB)).toMatchObject({
+    expect(queueItem(response.json(), READY_JOB_ID)).toMatchObject({
       applicationUrl: READY_JOB,
       blockers: [],
       applyAudit: {
@@ -575,13 +567,13 @@ describe("application feedback API", () => {
     const newerResumePath = path.join(tempDir, "newer-resume.txt");
     fs.writeFileSync(newerResumePath, "newer orphan resume text");
     const db = new Database(options.dbPath);
-    db.prepare("INSERT INTO job_materials (job_url, generation) VALUES (?, ?)").run(READY_JOB, 2);
+    insertMaterialSet(db, READY_JOB_ID, 2, "candidate");
     db.prepare(
       `INSERT INTO job_materials_artifacts (
-         job_url, generation, artifact_id, artifact_type, status, path, created_at, size_bytes
-       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+         job_id, generation, artifact_id, artifact_type, status, path, render_format, created_at, size_bytes
+       ) VALUES (?, ?, ?, ?, ?, ?, 'text', ?, ?)`,
     ).run(
-      READY_JOB,
+      READY_JOB_ID,
       2,
       "apply-ready-resume-text-v2",
       "tailored_resume",
@@ -596,7 +588,7 @@ describe("application feedback API", () => {
     const response = await app.inject({ method: "GET", url: "/v1/apply/review-queue" });
 
     expect(response.statusCode, response.body).toBe(200);
-    expect(queueItem(response.json(), READY_JOB)).toMatchObject({
+    expect(queueItem(response.json(), READY_JOB_ID)).toMatchObject({
       materialsPreview: {
         resumeText: "tailored resume",
         resumeTextArtifactId: "apply-ready-resume-text",
@@ -613,7 +605,7 @@ describe("application feedback API", () => {
     const response = await app.inject({ method: "GET", url: "/v1/apply/review-queue" });
 
     expect(response.statusCode, response.body).toBe(200);
-    expect(queueItem(response.json(), READY_JOB)?.materialsPreview.resumePdfLayoutBoxes).toEqual([
+    expect(queueItem(response.json(), READY_JOB_ID)?.materialsPreview.resumePdfLayoutBoxes).toEqual([
       {
         semanticId: "experience:acme:bullet:1",
         pageNumber: 1,
@@ -646,16 +638,16 @@ describe("application feedback API", () => {
     db.prepare(
       `UPDATE job_materials_artifacts
           SET path = ?, size_bytes = ?
-        WHERE job_url = ?
+        WHERE job_id = ?
           AND artifact_id = 'apply-ready-resume-text'`,
-    ).run(longResumePath, Buffer.byteLength(longResumeText), READY_JOB);
+    ).run(longResumePath, Buffer.byteLength(longResumeText), READY_JOB_ID);
     db.close();
     const app = buildApp(options);
 
     const response = await app.inject({ method: "GET", url: "/v1/apply/review-queue" });
 
     expect(response.statusCode, response.body).toBe(200);
-    const resumeText = queueItem(response.json(), READY_JOB)?.materialsPreview.resumeText ?? "";
+    const resumeText = queueItem(response.json(), READY_JOB_ID)?.materialsPreview.resumeText ?? "";
     expect(resumeText).toContain("Wrote Python APIs for real-time factory floor communication");
     expect(resumeText).toContain("Stakeholder Communication.");
     expect(resumeText).not.toMatch(/\.\.\.$/);
@@ -679,10 +671,10 @@ describe("application feedback API", () => {
     const db = new Database(options.dbPath);
     db.prepare(
       `INSERT INTO job_materials_artifacts (
-         job_url, generation, artifact_id, artifact_type, status, path, created_at, size_bytes
-       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+         job_id, generation, artifact_id, artifact_type, status, path, render_format, created_at, size_bytes
+       ) VALUES (?, ?, ?, ?, ?, ?, 'text', ?, ?)`,
     ).run(
-      READY_JOB,
+      READY_JOB_ID,
       1,
       "apply-ready-cover-letter-text",
       "cover_letter",
@@ -697,7 +689,7 @@ describe("application feedback API", () => {
     const response = await app.inject({ method: "GET", url: "/v1/apply/review-queue" });
 
     expect(response.statusCode, response.body).toBe(200);
-    const coverLetterText = queueItem(response.json(), READY_JOB)?.materialsPreview.coverLetterText ?? "";
+    const coverLetterText = queueItem(response.json(), READY_JOB_ID)?.materialsPreview.coverLetterText ?? "";
     expect(coverLetterText).toContain("Cover paragraph 75");
     expect(coverLetterText).toContain("This final sentence must remain visible");
     expect(coverLetterText).toContain("Jordan");
@@ -708,26 +700,17 @@ describe("application feedback API", () => {
 
   it("includes sanitized Profile source fields for apply-review PDF audit matching", async () => {
     const db = new Database(options.dbPath);
-    db.exec(`
-      CREATE TABLE candidate_profiles (
-        tenant_id TEXT NOT NULL,
-        profile_id TEXT NOT NULL,
-        personal_full_name TEXT NOT NULL DEFAULT '',
-        personal_address TEXT NOT NULL DEFAULT '',
-        personal_password TEXT NOT NULL DEFAULT '',
-        resume_baseline_text TEXT NOT NULL DEFAULT '',
-        PRIMARY KEY (tenant_id, profile_id)
-      );
-    `);
     db.prepare(
       `INSERT INTO candidate_profiles (
-         tenant_id, profile_id, personal_full_name, personal_address, personal_password, resume_baseline_text
-       ) VALUES ('local', 'default', ?, ?, ?, ?)`,
+         tenant_id, profile_id, personal_full_name, personal_address, personal_password,
+         resume_baseline_text, updated_at
+       ) VALUES ('local', 'default', ?, ?, ?, ?, ?)`,
     ).run(
       "Jordan Candidate",
       "42 Example Avenue, Harbor City",
       "do-not-send-this-field",
       "Experienced platform leader with reliable operations depth.",
+      NOW,
     );
     db.close();
     const app = buildApp(options);
@@ -735,7 +718,7 @@ describe("application feedback API", () => {
     const response = await app.inject({ method: "GET", url: "/v1/apply/review-queue" });
 
     expect(response.statusCode, response.body).toBe(200);
-    const fields = queueItem(response.json(), READY_JOB)?.materialsPreview.profileSourceFields ?? [];
+    const fields = queueItem(response.json(), READY_JOB_ID)?.materialsPreview.profileSourceFields ?? [];
     expect(fields).toEqual(
       expect.arrayContaining([
         {
@@ -769,16 +752,16 @@ describe("application feedback API", () => {
     const db = new Database(options.dbPath);
     db.prepare(
       `DELETE FROM job_materials_artifacts
-        WHERE job_url = ?
+        WHERE job_id = ?
           AND artifact_type IN ('tailored_resume', 'tailored_resume_txt', 'resume_txt')`,
-    ).run(READY_JOB);
-    db.prepare("INSERT INTO job_materials (job_url, generation) VALUES (?, ?)").run(READY_JOB, 2);
+    ).run(READY_JOB_ID);
+    insertMaterialSet(db, READY_JOB_ID, 2, "candidate");
     db.prepare(
       `INSERT INTO job_materials_artifacts (
-         job_url, generation, artifact_id, artifact_type, status, path, created_at, size_bytes
-       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+         job_id, generation, artifact_id, artifact_type, status, path, render_format, created_at, size_bytes
+       ) VALUES (?, ?, ?, ?, ?, ?, 'text', ?, ?)`,
     ).run(
-      READY_JOB,
+      READY_JOB_ID,
       2,
       "apply-ready-resume-text-v2",
       "tailored_resume",
@@ -793,7 +776,7 @@ describe("application feedback API", () => {
     const response = await app.inject({ method: "GET", url: "/v1/apply/review-queue" });
 
     expect(response.statusCode, response.body).toBe(200);
-    expect(queueItem(response.json(), READY_JOB)).toMatchObject({
+    expect(queueItem(response.json(), READY_JOB_ID)).toMatchObject({
       materialsPreview: {
         resumeText: null,
         resumeTextArtifactId: null,
@@ -809,16 +792,16 @@ describe("application feedback API", () => {
     db.prepare(
       `UPDATE job_materials_artifacts
           SET metadata_json = ?
-        WHERE job_url = ?
+        WHERE job_id = ?
           AND artifact_id = 'apply-ready-resume-text'`,
-    ).run(JSON.stringify(requirementLedAuditMetadata()), READY_JOB);
+    ).run(JSON.stringify(requirementLedAuditMetadata()), READY_JOB_ID);
     db.close();
     const app = buildApp(options);
 
     const response = await app.inject({ method: "GET", url: "/v1/apply/review-queue" });
 
     expect(response.statusCode, response.body).toBe(200);
-    const audit = queueItem(response.json(), READY_JOB)?.materialsPreview.requirementLedAudit;
+    const audit = queueItem(response.json(), READY_JOB_ID)?.materialsPreview.requirementLedAudit;
     expect(audit).toMatchObject({
       requirementCount: 2,
       achievementCount: 3,
@@ -905,16 +888,16 @@ describe("application feedback API", () => {
     db.prepare(
       `UPDATE job_materials_artifacts
           SET metadata_json = ?
-        WHERE job_url = ?
+        WHERE job_id = ?
           AND artifact_id = 'apply-ready-resume-text'`,
-    ).run(JSON.stringify(metadata), READY_JOB);
+    ).run(JSON.stringify(metadata), READY_JOB_ID);
     db.close();
     const app = buildApp(options);
 
     const response = await app.inject({ method: "GET", url: "/v1/apply/review-queue" });
 
     expect(response.statusCode, response.body).toBe(200);
-    const audit = queueItem(response.json(), READY_JOB)?.materialsPreview.requirementLedAudit;
+    const audit = queueItem(response.json(), READY_JOB_ID)?.materialsPreview.requirementLedAudit;
     expect(audit?.coveredRequirements.map((requirement) => requirement.id)).toEqual(["r1"]);
     expect(audit?.uncoveredRequirements).toEqual([
       {
@@ -966,16 +949,16 @@ describe("application feedback API", () => {
     db.prepare(
       `UPDATE job_materials_artifacts
           SET metadata_json = ?
-        WHERE job_url = ?
+        WHERE job_id = ?
           AND artifact_id = 'apply-ready-resume-text'`,
-    ).run(JSON.stringify(metadata), READY_JOB);
+    ).run(JSON.stringify(metadata), READY_JOB_ID);
     db.close();
     const app = buildApp(options);
 
     const response = await app.inject({ method: "GET", url: "/v1/apply/review-queue" });
 
     expect(response.statusCode, response.body).toBe(200);
-    const audit = queueItem(response.json(), READY_JOB)?.materialsPreview.requirementLedAudit;
+    const audit = queueItem(response.json(), READY_JOB_ID)?.materialsPreview.requirementLedAudit;
     expect(audit?.revision).toMatchObject({
       coverageBasis: "grounded_shipped_text_v1",
       claimedOnlyRequirementIds: ["r2"],
@@ -1047,37 +1030,37 @@ describe("application feedback API", () => {
           SET state = 'failed',
               error_code = 'FAILED_VALIDATION',
               error_message = 'Tailoring ended with status failed_validation'
-        WHERE job_url = ?
+        WHERE job_id = ?
           AND stage = 'tailor'`,
-    ).run(READY_JOB);
+    ).run(READY_JOB_ID);
     db.prepare(
       `UPDATE job_stage_states
           SET state = 'blocked',
               error_code = 'BLOCKED',
               error_message = 'Materials are not ready.'
-        WHERE job_url = ?
+        WHERE job_id = ?
           AND stage = 'apply'`,
-    ).run(READY_JOB);
+    ).run(READY_JOB_ID);
     db.prepare(
       `UPDATE job_materials_artifacts
           SET status = 'rejected',
               metadata_json = ?
-        WHERE job_url = ?
+        WHERE job_id = ?
           AND artifact_id = 'apply-ready-resume-text'`,
-    ).run(JSON.stringify(metadata), READY_JOB);
+    ).run(JSON.stringify(metadata), READY_JOB_ID);
     db.prepare(
       `UPDATE job_materials_artifacts
           SET status = 'rejected'
-        WHERE job_url = ?
+        WHERE job_id = ?
           AND artifact_id = 'apply-ready-resume-pdf'`,
-    ).run(READY_JOB);
+    ).run(READY_JOB_ID);
     db.close();
     const app = buildApp(options);
 
     const response = await app.inject({ method: "GET", url: "/v1/apply/review-queue" });
 
     expect(response.statusCode, response.body).toBe(200);
-    const item = queueItem(response.json(), READY_JOB);
+    const item = queueItem(response.json(), READY_JOB_ID);
     expect(item?.materials).toMatchObject({
       hasResume: false,
       hasPdf: false,
@@ -1116,16 +1099,16 @@ describe("application feedback API", () => {
     db.prepare(
       `UPDATE job_materials_artifacts
           SET metadata_json = ?
-        WHERE job_url = ?
+        WHERE job_id = ?
           AND artifact_id = 'apply-ready-resume-text'`,
-    ).run(JSON.stringify(requirementLedAuditMetadata()), READY_JOB);
+    ).run(JSON.stringify(requirementLedAuditMetadata()), READY_JOB_ID);
     db.close();
     const app = buildApp(options);
 
     const response = await app.inject({ method: "GET", url: "/v1/apply/review-queue" });
 
     expect(response.statusCode, response.body).toBe(200);
-    const audit = queueItem(response.json(), READY_JOB)?.materialsPreview.requirementLedAudit;
+    const audit = queueItem(response.json(), READY_JOB_ID)?.materialsPreview.requirementLedAudit;
     expect(audit?.revision).toMatchObject({
       coverageBasis: "judge_claimed_legacy",
       claimedOnlyRequirementIds: [],
@@ -1148,16 +1131,16 @@ describe("application feedback API", () => {
     db.prepare(
       `UPDATE job_materials_artifacts
           SET metadata_json = ?
-        WHERE job_url = ?
+        WHERE job_id = ?
           AND artifact_id = 'apply-ready-resume-text'`,
-    ).run(JSON.stringify(metadata), READY_JOB);
+    ).run(JSON.stringify(metadata), READY_JOB_ID);
     db.close();
     const app = buildApp(options);
 
     const response = await app.inject({ method: "GET", url: "/v1/apply/review-queue" });
 
     expect(response.statusCode, response.body).toBe(200);
-    const audit = queueItem(response.json(), READY_JOB)?.materialsPreview.requirementLedAudit;
+    const audit = queueItem(response.json(), READY_JOB_ID)?.materialsPreview.requirementLedAudit;
     expect(audit?.revision?.attempt).toBeNull();
     expect(audit?.revision?.revisionsUsed).toBeNull();
 
@@ -1170,14 +1153,15 @@ describe("application feedback API", () => {
     fs.writeFileSync(ignoredCandidatePath, "ordinary candidate should not be shown");
     fs.writeFileSync(reviewCandidatePath, "review required candidate resume");
     const db = new Database(options.dbPath);
-    db.prepare("INSERT INTO job_materials (job_url, generation) VALUES (?, ?)").run(READY_JOB, 2);
-    db.prepare("INSERT INTO job_materials (job_url, generation) VALUES (?, ?)").run(READY_JOB, 3);
+    insertMaterialSet(db, READY_JOB_ID, 2, "candidate");
+    insertMaterialSet(db, READY_JOB_ID, 3, "candidate");
     db.prepare(
       `INSERT INTO job_materials_artifacts (
-         job_url, generation, artifact_id, artifact_type, status, path, metadata_json, created_at, size_bytes
-       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+         job_id, generation, artifact_id, artifact_type, status, path, render_format,
+         metadata_json, created_at, size_bytes
+       ) VALUES (?, ?, ?, ?, ?, ?, 'text', ?, ?, ?)`,
     ).run(
-      READY_JOB,
+      READY_JOB_ID,
       3,
       "ignored-candidate-resume",
       "tailored_resume",
@@ -1189,10 +1173,11 @@ describe("application feedback API", () => {
     );
     db.prepare(
       `INSERT INTO job_materials_artifacts (
-         job_url, generation, artifact_id, artifact_type, status, path, metadata_json, created_at, size_bytes
-       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+         job_id, generation, artifact_id, artifact_type, status, path, render_format,
+         metadata_json, created_at, size_bytes
+       ) VALUES (?, ?, ?, ?, ?, ?, 'text', ?, ?, ?)`,
     ).run(
-      READY_JOB,
+      READY_JOB_ID,
       2,
       "review-candidate-resume",
       "tailored_resume",
@@ -1208,29 +1193,20 @@ describe("application feedback API", () => {
     const response = await app.inject({ method: "GET", url: "/v1/apply/review-queue" });
 
     expect(response.statusCode, response.body).toBe(200);
-    expect(queueItem(response.json(), READY_JOB)?.materialsPreview).toMatchObject({
+    expect(queueItem(response.json(), READY_JOB_ID)?.materialsPreview).toMatchObject({
       materialsGeneration: 2,
       resumeText: "review required candidate resume",
       resumeTextArtifactId: "review-candidate-resume",
       resumePdfArtifactId: null,
     });
-    expect(queueItem(response.json(), READY_JOB)?.approvalGate).toMatchObject({
+    expect(queueItem(response.json(), READY_JOB_ID)?.approvalGate).toMatchObject({
       materialsGeneration: 2,
     });
-    expect(queueItem(response.json(), READY_JOB)?.materialsPreview.requirementLedAudit?.revision?.reason).toBe(
+    expect(queueItem(response.json(), READY_JOB_ID)?.materialsPreview.requirementLedAudit?.revision?.reason).toBe(
       "review_blocked_claims",
     );
 
     const decisionDb = new Database(options.dbPath);
-    decisionDb.exec(`
-      CREATE TABLE IF NOT EXISTS candidate_profiles (
-        tenant_id TEXT NOT NULL,
-        profile_id TEXT NOT NULL,
-        version INTEGER NOT NULL DEFAULT 1,
-        updated_at TEXT NOT NULL,
-        PRIMARY KEY (tenant_id, profile_id)
-      );
-    `);
     decisionDb
       .prepare(
         "INSERT OR REPLACE INTO candidate_profiles (tenant_id, profile_id, version, updated_at) VALUES ('local', 'default', ?, ?)",
@@ -1262,11 +1238,11 @@ describe("application feedback API", () => {
         .prepare(
           `SELECT materials_generation
              FROM application_review_decisions
-            WHERE job_key = ?
+            WHERE job_id = ?
             ORDER BY decided_at DESC, decision_id DESC
             LIMIT 1`,
         )
-        .get(READY_JOB) as { materials_generation?: number } | undefined;
+        .get(READY_JOB_ID) as { materials_generation?: number } | undefined;
       expect(row?.materials_generation).toBe(2);
     } finally {
       boundDb.close();
@@ -1277,15 +1253,6 @@ describe("application feedback API", () => {
 
   it("records approve, defer, reset, and decline review decisions without dispatching apply", async () => {
     const profileDb = new Database(options.dbPath);
-    profileDb.exec(`
-      CREATE TABLE candidate_profiles (
-        tenant_id TEXT NOT NULL,
-        profile_id TEXT NOT NULL,
-        version INTEGER NOT NULL DEFAULT 1,
-        updated_at TEXT NOT NULL,
-        PRIMARY KEY (tenant_id, profile_id)
-      );
-    `);
     profileDb
       .prepare(
         "INSERT INTO candidate_profiles (tenant_id, profile_id, version, updated_at) VALUES ('local', 'default', ?, ?)",
@@ -1317,7 +1284,7 @@ describe("application feedback API", () => {
     expect(approve.json()).toMatchObject({
       ok: true,
       decision: {
-        jobKey: READY_JOB,
+        jobKey: READY_JOB_ID,
         decision: "approve_submit",
       },
     });
@@ -1328,10 +1295,10 @@ describe("application feedback API", () => {
         .prepare(
           `SELECT decision, materials_generation, profile_version, application_url
            FROM application_review_decisions
-           WHERE job_key = ?
+           WHERE job_id = ?
            ORDER BY decided_at DESC LIMIT 1`,
         )
-        .get(READY_JOB) as {
+        .get(READY_JOB_ID) as {
           decision?: string;
           materials_generation?: number;
           profile_version?: number;
@@ -1346,7 +1313,7 @@ describe("application feedback API", () => {
     }
 
     const afterApprove = await app.inject({ method: "GET", url: "/v1/apply/review-queue" });
-    expect(queueItem(afterApprove.json(), READY_JOB)).toMatchObject({
+    expect(queueItem(afterApprove.json(), READY_JOB_ID)).toMatchObject({
       review: { state: "approved_submit", decision: "approve_submit" },
     });
 
@@ -1357,7 +1324,7 @@ describe("application feedback API", () => {
     });
     expect(defer.statusCode, defer.body).toBe(200);
     const afterDefer = await app.inject({ method: "GET", url: "/v1/apply/review-queue" });
-    expect(queueItem(afterDefer.json(), READY_JOB)).toBeUndefined();
+    expect(queueItem(afterDefer.json(), READY_JOB_ID)).toBeUndefined();
 
     const reset = await app.inject({
       method: "POST",
@@ -1366,7 +1333,7 @@ describe("application feedback API", () => {
     });
     expect(reset.statusCode, reset.body).toBe(200);
     const afterReset = await app.inject({ method: "GET", url: "/v1/apply/review-queue" });
-    expect(queueItem(afterReset.json(), READY_JOB)).toMatchObject({
+    expect(queueItem(afterReset.json(), READY_JOB_ID)).toMatchObject({
       review: { state: "pending", decision: "reset" },
     });
 
@@ -1384,32 +1351,23 @@ describe("application feedback API", () => {
     });
     expect(decline.statusCode, decline.body).toBe(200);
     const afterDecline = await app.inject({ method: "GET", url: "/v1/apply/review-queue" });
-    expect(queueItem(afterDecline.json(), DRY_RUN_JOB)).toBeUndefined();
+    expect(queueItem(afterDecline.json(), DRY_RUN_JOB_ID)).toBeUndefined();
 
     await app.close();
   });
 
   it("returns approval precondition errors with stable conflict codes", async () => {
     const db = new Database(options.dbPath);
-    db.exec(`
-      CREATE TABLE candidate_profiles (
-        tenant_id TEXT NOT NULL,
-        profile_id TEXT NOT NULL,
-        version INTEGER NOT NULL DEFAULT 1,
-        updated_at TEXT NOT NULL,
-        PRIMARY KEY (tenant_id, profile_id)
-      );
-    `);
     db.prepare(
       "INSERT INTO candidate_profiles (tenant_id, profile_id, version, updated_at) VALUES ('local', 'default', ?, ?)",
     ).run(7, NOW);
     db.prepare("DELETE FROM job_events WHERE event_type = 'DryRunCompleted'").run();
     db.prepare(
       `INSERT INTO job_events (
-         job_url, stage, event_type, level, message, occurred_at, payload_json
-       ) VALUES (?, 'apply', 'DryRunCompleted', 'info', ?, ?, ?)`,
+         tenant_id, job_id, identity_version, stage, event_type, level, message, occurred_at, payload_json
+       ) VALUES ('local', ?, 1, 'apply', 'DryRunCompleted', 'info', ?, ?, ?)`,
     ).run(
-      READY_JOB,
+      READY_JOB_ID,
       "Unbound full dry run completed",
       "2026-06-01T12:01:00.000Z",
       JSON.stringify({
@@ -1465,15 +1423,6 @@ describe("application feedback API", () => {
 
   it("requires submit approval to bind the email application candidate", async () => {
     const db = new Database(options.dbPath);
-    db.exec(`
-      CREATE TABLE candidate_profiles (
-        tenant_id TEXT NOT NULL,
-        profile_id TEXT NOT NULL,
-        version INTEGER NOT NULL DEFAULT 1,
-        updated_at TEXT NOT NULL,
-        PRIMARY KEY (tenant_id, profile_id)
-      );
-    `);
     db.prepare(
       "INSERT INTO candidate_profiles (tenant_id, profile_id, version, updated_at) VALUES ('local', 'default', ?, ?)",
     ).run(7, NOW);
@@ -1485,10 +1434,10 @@ describe("application feedback API", () => {
     });
     db.prepare(
       `INSERT INTO job_events (
-         job_url, stage, event_type, level, message, occurred_at, payload_json
-       ) VALUES (?, 'apply', 'EmailApplicationCandidateRecorded', 'info', ?, ?, ?)`,
+         tenant_id, job_id, identity_version, stage, event_type, level, message, occurred_at, payload_json
+       ) VALUES ('local', ?, 1, 'apply', 'EmailApplicationCandidateRecorded', 'info', ?, ?, ?)`,
     ).run(
-      READY_JOB,
+      READY_JOB_ID,
       "Email application candidate recorded",
       "2026-06-01T12:02:00.000Z",
       JSON.stringify({
@@ -1504,7 +1453,7 @@ describe("application feedback API", () => {
     const app = buildApp(options);
     const readyKey = encodeURIComponent(READY_JOB);
     const queue = await app.inject({ method: "GET", url: "/v1/apply/review-queue" });
-    expect(queueItem(queue.json(), READY_JOB)?.emailApplication).toMatchObject({
+    expect(queueItem(queue.json(), READY_JOB_ID)?.emailApplication).toMatchObject({
       recipient: "apply@example.com",
       subject: "Application for Staff Engineer",
       attachmentArtifactId: "resume-pdf-1",
@@ -1551,15 +1500,6 @@ describe("application feedback API", () => {
 
   it("rejects submit approval when the displayed review binding is stale", async () => {
     const db = new Database(options.dbPath);
-    db.exec(`
-      CREATE TABLE candidate_profiles (
-        tenant_id TEXT NOT NULL,
-        profile_id TEXT NOT NULL,
-        version INTEGER NOT NULL DEFAULT 1,
-        updated_at TEXT NOT NULL,
-        PRIMARY KEY (tenant_id, profile_id)
-      );
-    `);
     db.prepare(
       "INSERT INTO candidate_profiles (tenant_id, profile_id, version, updated_at) VALUES ('local', 'default', ?, ?)",
     ).run(7, NOW);
@@ -1617,25 +1557,16 @@ describe("application feedback API", () => {
 
   it("rejects submit approval when dry-run evidence belongs to an older profile version", async () => {
     const db = new Database(options.dbPath);
-    db.exec(`
-      CREATE TABLE candidate_profiles (
-        tenant_id TEXT NOT NULL,
-        profile_id TEXT NOT NULL,
-        version INTEGER NOT NULL DEFAULT 1,
-        updated_at TEXT NOT NULL,
-        PRIMARY KEY (tenant_id, profile_id)
-      );
-    `);
     db.prepare(
       "INSERT INTO candidate_profiles (tenant_id, profile_id, version, updated_at) VALUES ('local', 'default', ?, ?)",
     ).run(2, NOW);
     db.prepare("DELETE FROM job_events WHERE event_type IN ('ApplyRunStarted', 'DryRunCompleted')").run();
     db.prepare(
       `INSERT INTO job_events (
-         job_url, stage, event_type, level, message, occurred_at, payload_json
-       ) VALUES (?, 'apply', 'ApplyRunStarted', 'info', ?, ?, ?)`,
+         tenant_id, job_id, identity_version, stage, event_type, level, message, occurred_at, payload_json
+       ) VALUES ('local', ?, 1, 'apply', 'ApplyRunStarted', 'info', ?, ?, ?)`,
     ).run(
-      READY_JOB,
+      READY_JOB_ID,
       "Stale-profile dry run started",
       "2026-06-01T12:00:00.000Z",
       JSON.stringify({
@@ -1648,10 +1579,10 @@ describe("application feedback API", () => {
     );
     db.prepare(
       `INSERT INTO job_events (
-         job_url, stage, event_type, level, message, occurred_at, payload_json
-       ) VALUES (?, 'apply', 'DryRunCompleted', 'info', ?, ?, ?)`,
+         tenant_id, job_id, identity_version, stage, event_type, level, message, occurred_at, payload_json
+       ) VALUES ('local', ?, 1, 'apply', 'DryRunCompleted', 'info', ?, ?, ?)`,
     ).run(
-      READY_JOB,
+      READY_JOB_ID,
       "Stale-profile dry run completed",
       "2026-06-01T12:01:00.000Z",
       JSON.stringify({
@@ -1667,10 +1598,10 @@ describe("application feedback API", () => {
     );
     db.prepare(
       `INSERT INTO job_events (
-         job_url, stage, event_type, level, message, occurred_at, payload_json
-       ) VALUES (?, 'apply', 'DryRunCompleted', 'info', ?, ?, ?)`,
+         tenant_id, job_id, identity_version, stage, event_type, level, message, occurred_at, payload_json
+       ) VALUES ('local', ?, 1, 'apply', 'DryRunCompleted', 'info', ?, ?, ?)`,
     ).run(
-      READY_JOB,
+      READY_JOB_ID,
       "Stale-profile partial dry run completed",
       "2026-06-01T12:02:00.000Z",
       JSON.stringify({
@@ -1741,7 +1672,7 @@ describe("application feedback API", () => {
     expect(write.statusCode, write.body).toBe(200);
     const outcome = write.json().outcome;
     expect(outcome).toMatchObject({
-      jobKey: READY_JOB,
+      jobKey: READY_JOB_ID,
       kind: "interview",
       source: "manual",
       note,
@@ -1755,14 +1686,14 @@ describe("application feedback API", () => {
     expect(jobOutcomes.statusCode, jobOutcomes.body).toBe(200);
     expect(jobOutcomes.json()).toMatchObject({
       ok: true,
-      jobKey: READY_JOB,
+      jobKey: READY_JOB_ID,
       outcomes: [expect.objectContaining({ outcomeId: outcome.outcomeId, note })],
     });
 
     const allOutcomes = await app.inject({ method: "GET", url: "/v1/outcomes" });
     expect(allOutcomes.statusCode, allOutcomes.body).toBe(200);
     expect(allOutcomes.json().outcomes).toEqual([
-      expect.objectContaining({ outcomeId: outcome.outcomeId, jobKey: READY_JOB }),
+      expect.objectContaining({ outcomeId: outcome.outcomeId, jobKey: READY_JOB_ID }),
     ]);
 
     expect(eventPayloadText(options.dbPath)).not.toContain(note);
@@ -1770,7 +1701,7 @@ describe("application feedback API", () => {
   });
 
   it("links post-interview reflections to an accepted prep generation without leaking notes", async () => {
-    seedInterviewPrepGeneration(options.dbPath, READY_JOB, 2);
+    seedInterviewPrepGeneration(options.dbPath, READY_JOB_ID, 2);
     const app = buildApp(options);
     const note = "private reflection after a platform design interview";
 
@@ -1788,7 +1719,7 @@ describe("application feedback API", () => {
     expect(write.statusCode, write.body).toBe(200);
     const outcome = write.json().outcome;
     expect(outcome).toMatchObject({
-      jobKey: READY_JOB,
+      jobKey: READY_JOB_ID,
       kind: "interview",
       source: "manual",
       note,
@@ -1850,7 +1781,7 @@ describe("application feedback API", () => {
       evidence: [
         {
           evidenceId: "evidence-1",
-          jobKey: READY_JOB,
+          jobKey: READY_JOB_ID,
           providerMessageId: "gmail-message-1",
           linkConfidence: 0.94,
           bodyText: rawBody,
@@ -1860,7 +1791,7 @@ describe("application feedback API", () => {
         {
           suggestionId: "suggestion-1",
           evidenceId: "evidence-1",
-          jobKey: READY_JOB,
+          jobKey: READY_JOB_ID,
           kind: "interview",
           confidence: 0.9,
           bodyText: rawBody,
@@ -1901,7 +1832,7 @@ describe("application feedback API", () => {
       evidence: [
         {
           evidenceId: "evidence-1",
-          jobKey: READY_JOB,
+          jobKey: READY_JOB_ID,
           providerMessageId: "gmail-message-1",
           linkConfidence: 0.94,
         },
@@ -1910,7 +1841,7 @@ describe("application feedback API", () => {
         {
           suggestionId: "suggestion-1",
           evidenceId: "evidence-1",
-          jobKey: READY_JOB,
+          jobKey: READY_JOB_ID,
           kind: "interview",
           confidence: 0.9,
         },
@@ -2015,7 +1946,7 @@ describe("application feedback API", () => {
         decidedOutcomeId: expect.any(String),
       },
       outcome: {
-        jobKey: READY_JOB,
+        jobKey: READY_JOB_ID,
         kind: "applied_confirmation",
         source: "email_suggestion",
         note: privateNote,
@@ -2071,13 +2002,13 @@ describe("application feedback API", () => {
 
     const queue = await app.inject({ method: "GET", url: "/v1/apply/review-queue" });
     expect(queue.statusCode, queue.body).toBe(200);
-    const assessment = queueItem(queue.json(), READY_JOB)?.repeatApplication;
+    const assessment = queueItem(queue.json(), READY_JOB_ID)?.repeatApplication;
     expect(assessment).toMatchObject({
       status: "confirmation_required",
       matches: [
         {
           relationship: "same_employer_equivalent_role",
-          priorApplication: { jobKey: APPLIED_JOB, factKind: "legacy_applied_status" },
+          priorApplication: { jobId: APPLIED_JOB_ID, factKind: "legacy_applied_status" },
         },
       ],
     });
@@ -2107,7 +2038,7 @@ describe("application feedback API", () => {
       url: `/v1/jobs/${encodeURIComponent(READY_JOB)}/repeat-application/override`,
       payload: {
         evidenceFingerprint: assessment?.evidenceFingerprint,
-        priorJobKey: APPLIED_JOB,
+        priorJobId: APPLIED_JOB_ID,
         reason: "The prior application was withdrawn before review.",
         confirmedBy: "api-test-user",
       },
@@ -2117,8 +2048,8 @@ describe("application feedback API", () => {
       assessment: {
         status: "override_ready",
         override: {
-          targetJobKey: READY_JOB,
-          priorJobKey: APPLIED_JOB,
+          targetJobId: READY_JOB_ID,
+          priorJobId: APPLIED_JOB_ID,
           confirmedBy: "api-test-user",
         },
       },
@@ -2135,9 +2066,9 @@ describe("application feedback API", () => {
     const audit = new Database(options.dbPath, { readonly: true });
     const auditActions = audit
       .prepare(
-        "SELECT action FROM application_repeat_audit WHERE target_job_key = ? ORDER BY occurred_at",
+        "SELECT action FROM application_repeat_audit WHERE target_job_id = ? ORDER BY occurred_at",
       )
-      .all(READY_JOB)
+      .all(READY_JOB_ID)
       .map((row) => (row as { action: string }).action);
     audit.close();
     expect(auditActions).toEqual(["confirmation_required", "override_recorded"]);
@@ -2158,251 +2089,13 @@ function seedDatabase(dbPath: string): void {
   fs.writeFileSync(resumePath, "tailored resume");
   fs.writeFileSync(resumePdfPath, "%PDF-1.4\n% test\n");
   fs.writeFileSync(rejectedResumePdfPath, "%PDF-1.4\n% rejected test\n");
+  initializeExactV7Database(dbPath);
   const db = new Database(dbPath);
-  db.exec(`
-    CREATE TABLE jobs (
-      url TEXT PRIMARY KEY,
-      title TEXT,
-      site TEXT,
-      strategy TEXT,
-      location TEXT,
-      salary TEXT,
-      discovered_at TEXT,
-      application_url TEXT,
-      description TEXT,
-      full_description TEXT,
-      detail_scraped_at TEXT,
-      detail_error TEXT,
-      fit_score INTEGER,
-      score_reasoning TEXT,
-      scored_at TEXT,
-      tailored_resume_path TEXT,
-      tailored_at TEXT,
-      tailor_attempts INTEGER,
-      cover_letter_path TEXT,
-      cover_letter_at TEXT,
-      cover_attempts INTEGER,
-      apply_status TEXT,
-      apply_error TEXT,
-      applied_at TEXT
-    );
-    CREATE TABLE job_stage_states (
-      job_url TEXT,
-      stage TEXT,
-      state TEXT,
-      attempt_count INTEGER,
-      max_attempts INTEGER,
-      started_at TEXT,
-      updated_at TEXT,
-      finished_at TEXT,
-      duration_ms INTEGER,
-      error_code TEXT,
-      error_message TEXT,
-      retryable INTEGER,
-      blocked_by_json TEXT,
-      next_action TEXT,
-      metadata_json TEXT
-    );
-    CREATE TABLE job_events (
-      event_id INTEGER PRIMARY KEY AUTOINCREMENT,
-      job_url TEXT,
-      stage TEXT,
-      event_type TEXT NOT NULL DEFAULT '',
-      level TEXT NOT NULL DEFAULT 'info',
-      message TEXT,
-      occurred_at TEXT NOT NULL,
-      payload_json TEXT
-    );
-    CREATE TABLE apply_run_projections (
-      run_id TEXT PRIMARY KEY,
-      tenant_id TEXT NOT NULL DEFAULT 'local',
-      job_id TEXT NOT NULL,
-      job_title TEXT NOT NULL DEFAULT '',
-      job_employer TEXT NOT NULL DEFAULT '',
-      status TEXT NOT NULL DEFAULT '',
-      result TEXT,
-      dry_run INTEGER NOT NULL DEFAULT 0,
-      worker_id INTEGER,
-      model TEXT,
-      started_at TEXT,
-      finished_at TEXT,
-      duration_ms INTEGER,
-      events_json TEXT NOT NULL DEFAULT '[]'
-    );
-    CREATE TABLE job_scores (
-      job_url TEXT NOT NULL,
-      version INTEGER NOT NULL,
-      tenant_id TEXT NOT NULL DEFAULT 'local',
-      fit_score INTEGER NOT NULL,
-      breakdown_json TEXT NOT NULL,
-      keywords_json TEXT NOT NULL,
-      scored_at TEXT,
-      correction_json TEXT NOT NULL DEFAULT '{}',
-      criteria_json TEXT NOT NULL DEFAULT '{}',
-      trace_json TEXT NOT NULL DEFAULT '{}',
-      PRIMARY KEY (job_url, version)
-    );
-    CREATE TABLE job_materials (
-      job_url TEXT NOT NULL,
-      generation INTEGER NOT NULL
-    );
-    CREATE TABLE job_materials_artifacts (
-      job_url TEXT NOT NULL,
-      generation INTEGER NOT NULL,
-      artifact_id TEXT,
-      artifact_type TEXT,
-      status TEXT,
-      path TEXT,
-      created_at TEXT,
-      size_bytes INTEGER,
-      metadata_json TEXT
-    );
-    CREATE TABLE job_bullet_provenance (
-      job_url TEXT NOT NULL,
-      generation INTEGER NOT NULL,
-      bullet_id TEXT NOT NULL,
-      tenant_id TEXT NOT NULL DEFAULT 'local',
-      artifact_id TEXT NOT NULL,
-      section TEXT NOT NULL,
-      source_id TEXT,
-      evidence_ids_json TEXT NOT NULL DEFAULT '[]',
-      requirement_ids_json TEXT NOT NULL DEFAULT '[]',
-      matched_keywords_json TEXT NOT NULL DEFAULT '[]',
-      transform_type TEXT NOT NULL,
-      control TEXT NOT NULL,
-      rationale TEXT NOT NULL DEFAULT '',
-      generated_text TEXT NOT NULL,
-      position INTEGER NOT NULL DEFAULT 0,
-      created_at TEXT NOT NULL,
-      PRIMARY KEY (job_url, generation, bullet_id)
-    );
-    CREATE TABLE job_material_layout_boxes (
-      job_url TEXT NOT NULL,
-      generation INTEGER NOT NULL,
-      artifact_id TEXT NOT NULL,
-      box_index INTEGER NOT NULL,
-      tenant_id TEXT NOT NULL DEFAULT 'local',
-      semantic_id TEXT NOT NULL,
-      page_number INTEGER NOT NULL,
-      line_number INTEGER,
-      text_excerpt TEXT NOT NULL,
-      left_pct REAL NOT NULL,
-      top_pct REAL NOT NULL,
-      width_pct REAL NOT NULL,
-      height_pct REAL NOT NULL,
-      audit_target_json TEXT NOT NULL DEFAULT '{}',
-      created_at TEXT NOT NULL,
-      PRIMARY KEY (job_url, generation, artifact_id, box_index)
-    );
-    CREATE TABLE job_employer_analysis (
-      job_url TEXT NOT NULL,
-      generation INTEGER NOT NULL,
-      tenant_id TEXT NOT NULL DEFAULT 'local',
-      ideal_candidate_narrative TEXT NOT NULL DEFAULT '',
-      requirements_json TEXT NOT NULL DEFAULT '[]'
-    );
-    CREATE TABLE job_employer_analysis_sub_analyses (
-      job_url TEXT NOT NULL,
-      generation INTEGER NOT NULL,
-      model_id TEXT NOT NULL,
-      analysis_json TEXT NOT NULL DEFAULT '{}'
-    );
-    CREATE TABLE job_employer_analysis_failures (
-      job_url TEXT NOT NULL,
-      generation INTEGER NOT NULL,
-      model_id TEXT NOT NULL,
-      error TEXT NOT NULL DEFAULT '',
-      raw_output TEXT
-    );
-    CREATE TABLE job_requirement_fit_reports (
-      tenant_id TEXT NOT NULL DEFAULT 'local',
-      job_url TEXT NOT NULL,
-      score_version INTEGER NOT NULL,
-      employer_analysis_generation INTEGER NOT NULL,
-      profile_snapshot_version INTEGER NOT NULL,
-      scoring_policy_version INTEGER NOT NULL,
-      formula_version TEXT NOT NULL,
-      resolved_fit_score INTEGER,
-      fit_band TEXT NOT NULL,
-      confidence TEXT NOT NULL,
-      summary_json TEXT NOT NULL DEFAULT '{}',
-      PRIMARY KEY (tenant_id, job_url, score_version)
-    );
-    CREATE TABLE job_requirement_fit_items (
-      tenant_id TEXT NOT NULL DEFAULT 'local',
-      job_url TEXT NOT NULL,
-      score_version INTEGER NOT NULL,
-      requirement_id TEXT NOT NULL,
-      requirement_text TEXT NOT NULL,
-      tier TEXT NOT NULL,
-      weight REAL NOT NULL,
-      job_evidence_span TEXT NOT NULL,
-      fit_json TEXT NOT NULL DEFAULT '{}',
-      contribution_json TEXT NOT NULL DEFAULT '{}',
-      tailoring_json TEXT NOT NULL DEFAULT '{}',
-      artifact_coverage_json TEXT,
-      position INTEGER NOT NULL DEFAULT 0,
-      PRIMARY KEY (tenant_id, job_url, score_version, requirement_id)
-    );
-    CREATE TABLE job_posted_compensation_facts (
-      tenant_id TEXT NOT NULL DEFAULT 'local',
-      job_url TEXT NOT NULL,
-      source_field TEXT NOT NULL DEFAULT 'jobs.salary',
-      source_text TEXT,
-      legacy_raw_salary TEXT,
-      parse_state TEXT NOT NULL,
-      currency TEXT,
-      period TEXT NOT NULL DEFAULT 'unknown',
-      component TEXT NOT NULL DEFAULT 'unknown',
-      minimum_amount INTEGER,
-      maximum_amount INTEGER,
-      annualized_minimum_amount INTEGER,
-      annualized_maximum_amount INTEGER,
-      annualization_assumption TEXT,
-      confidence TEXT NOT NULL DEFAULT 'none',
-      warnings_json TEXT NOT NULL DEFAULT '[]',
-      parser_version TEXT NOT NULL,
-      source_hash TEXT NOT NULL,
-      parsed_at TEXT NOT NULL,
-      PRIMARY KEY (tenant_id, job_url)
-    );
-    CREATE TABLE job_market_compensation_estimates (
-      tenant_id TEXT NOT NULL DEFAULT 'local',
-      job_url TEXT NOT NULL,
-      estimate_state TEXT NOT NULL,
-      currency TEXT,
-      period TEXT NOT NULL DEFAULT 'year',
-      component TEXT NOT NULL DEFAULT 'base_salary',
-      minimum_amount INTEGER,
-      maximum_amount INTEGER,
-      confidence_band TEXT NOT NULL DEFAULT 'none',
-      confidence_score REAL NOT NULL DEFAULT 0,
-      source_count INTEGER NOT NULL DEFAULT 0,
-      sample_count INTEGER,
-      aggregate_bucket TEXT,
-      geography_scope TEXT,
-      occupation_code TEXT,
-      occupation_label TEXT,
-      seniority_label TEXT,
-      source_snapshot_json TEXT NOT NULL DEFAULT '[]',
-      factor_reasons_json TEXT NOT NULL DEFAULT '[]',
-      insufficient_reasons_json TEXT NOT NULL DEFAULT '[]',
-      unsupported_reasons_json TEXT NOT NULL DEFAULT '[]',
-      source_unavailable_reasons_json TEXT NOT NULL DEFAULT '[]',
-      warnings_json TEXT NOT NULL DEFAULT '[]',
-      estimator_version TEXT NOT NULL,
-      estimated_at TEXT NOT NULL,
-      company_name TEXT,
-      normalized_company TEXT,
-      role_title TEXT,
-      normalized_role TEXT,
-      company_tier TEXT NOT NULL DEFAULT 'unknown',
-      match_scope TEXT NOT NULL DEFAULT 'none',
-      PRIMARY KEY (tenant_id, job_url)
-    );
-  `);
+  db.pragma("foreign_keys = ON");
+  seedBuiltInResumeTemplate(db);
 
   insertJob(db, {
+    jobId: READY_JOB_ID,
     url: READY_JOB,
     title: "Principal Platform Engineer",
     site: "ExampleCo",
@@ -2413,6 +2106,7 @@ function seedDatabase(dbPath: string): void {
     applyState: "pending",
   });
   insertJob(db, {
+    jobId: DRY_RUN_JOB_ID,
     url: DRY_RUN_JOB,
     title: "Staff Backend Engineer",
     site: "ExampleCo",
@@ -2423,6 +2117,7 @@ function seedDatabase(dbPath: string): void {
     applyState: "pending",
   });
   insertJob(db, {
+    jobId: APPLIED_JOB_ID,
     url: APPLIED_JOB,
     title: "Already Applied Engineer",
     site: "ExampleCo",
@@ -2439,7 +2134,7 @@ function seedDatabase(dbPath: string): void {
      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   ).run(
     "dry-run-ready",
-    READY_JOB,
+    READY_JOB_ID,
     "Principal Platform Engineer",
     "ExampleCo",
     "dry_run_complete",
@@ -2450,10 +2145,10 @@ function seedDatabase(dbPath: string): void {
   );
   db.prepare(
     `INSERT INTO job_events (
-       job_url, stage, event_type, level, message, occurred_at, payload_json
-     ) VALUES (?, 'apply', 'ApplyRunStarted', 'info', ?, ?, ?)`,
+       tenant_id, job_id, identity_version, stage, event_type, level, message, occurred_at, payload_json
+     ) VALUES ('local', ?, 1, 'apply', 'ApplyRunStarted', 'info', ?, ?, ?)`,
   ).run(
-    READY_JOB,
+    READY_JOB_ID,
     "Apply dry-run started",
     "2026-05-31T09:00:00.000Z",
     JSON.stringify({
@@ -2465,10 +2160,10 @@ function seedDatabase(dbPath: string): void {
   );
   db.prepare(
     `INSERT INTO job_events (
-       job_url, stage, event_type, level, message, occurred_at, payload_json
-     ) VALUES (?, 'apply', 'DryRunCompleted', 'info', ?, ?, ?)`,
+       tenant_id, job_id, identity_version, stage, event_type, level, message, occurred_at, payload_json
+     ) VALUES ('local', ?, 1, 'apply', 'DryRunCompleted', 'info', ?, ?, ?)`,
   ).run(
-    READY_JOB,
+    READY_JOB_ID,
     "Dry run completed",
     "2026-05-31T09:01:00.000Z",
     JSON.stringify({
@@ -2483,8 +2178,23 @@ function seedDatabase(dbPath: string): void {
     }),
   );
   insertBulletProvenance(db);
-  insertCompensationRows(db, READY_JOB);
+  insertCompensationRows(db, READY_JOB_ID, READY_JOB);
   db.close();
+}
+
+function seedBuiltInResumeTemplate(db: Database.Database): void {
+  db.prepare(
+    `INSERT INTO resume_templates (
+       tenant_id, template_id, display_name, status, built_in, created_at, updated_at
+     ) VALUES ('local', 'built_in:modern-html', 'Modern HTML', 'active', 1, ?, ?)`,
+  ).run(NOW, NOW);
+  db.prepare(
+    `INSERT INTO resume_template_versions (
+       tenant_id, version_id, template_id, version_number, display_name, status,
+       theme_json, layout_json, content_hash, created_at
+     ) VALUES ('local', 'built_in:modern-html:v1', 'built_in:modern-html', 1,
+               'Modern HTML', 'active', ?, '{}', 'application-feedback-fixture', ?)`,
+  ).run(JSON.stringify(BUILT_IN_RESUME_TEMPLATE_THEME), NOW);
 }
 
 function insertVersionedDryRunEvidence(
@@ -2500,10 +2210,10 @@ function insertVersionedDryRunEvidence(
   const coverage = options.coverage ?? "full";
   db.prepare(
     `INSERT INTO job_events (
-       job_url, stage, event_type, level, message, occurred_at, payload_json
-     ) VALUES (?, 'apply', 'ApplyRunStarted', 'info', ?, ?, ?)`,
+       tenant_id, job_id, identity_version, stage, event_type, level, message, occurred_at, payload_json
+     ) VALUES ('local', ?, 1, 'apply', 'ApplyRunStarted', 'info', ?, ?, ?)`,
   ).run(
-    READY_JOB,
+    READY_JOB_ID,
     "Versioned dry run started",
     "2026-06-01T12:00:00.000Z",
     JSON.stringify({
@@ -2516,10 +2226,10 @@ function insertVersionedDryRunEvidence(
   );
   db.prepare(
     `INSERT INTO job_events (
-       job_url, stage, event_type, level, message, occurred_at, payload_json
-     ) VALUES (?, 'apply', 'DryRunCompleted', 'info', ?, ?, ?)`,
+       tenant_id, job_id, identity_version, stage, event_type, level, message, occurred_at, payload_json
+     ) VALUES ('local', ?, 1, 'apply', 'DryRunCompleted', 'info', ?, ?, ?)`,
   ).run(
-    READY_JOB,
+    READY_JOB_ID,
     "Versioned dry run completed",
     "2026-06-01T12:01:00.000Z",
     JSON.stringify({
@@ -2551,18 +2261,18 @@ function runBoundNavigation(applicationUrl: string): Array<Record<string, string
   ];
 }
 
-function insertCompensationRows(db: Database.Database, jobUrl: string): void {
+function insertCompensationRows(db: Database.Database, jobId: string, jobUrl: string): void {
   db.prepare("UPDATE jobs SET salary = ? WHERE url = ?").run("EUR 70000-90000/year", jobUrl);
   db.prepare(
     `INSERT INTO job_posted_compensation_facts (
-       tenant_id, job_url, source_field, source_text, legacy_raw_salary,
+       tenant_id, job_id, source_field, source_text, legacy_raw_salary,
        parse_state, currency, period, component, minimum_amount, maximum_amount,
        annualized_minimum_amount, annualized_maximum_amount, annualization_assumption,
        confidence, warnings_json, parser_version, source_hash, parsed_at
      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   ).run(
     "local",
-    jobUrl,
+    jobId,
     "jobs.salary",
     "EUR 70000-90000/year",
     "EUR 70000-90000/year",
@@ -2583,7 +2293,7 @@ function insertCompensationRows(db: Database.Database, jobUrl: string): void {
   );
   db.prepare(
     `INSERT INTO job_market_compensation_estimates (
-       tenant_id, job_url, estimate_state, currency, period, component,
+       tenant_id, job_id, estimate_state, currency, period, component,
        minimum_amount, maximum_amount, confidence_band, confidence_score,
        source_count, sample_count, aggregate_bucket, geography_scope,
        occupation_code, occupation_label, seniority_label, source_snapshot_json,
@@ -2593,7 +2303,7 @@ function insertCompensationRows(db: Database.Database, jobUrl: string): void {
      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   ).run(
     "local",
-    jobUrl,
+    jobId,
     "estimated_range",
     "EUR",
     "year",
@@ -2666,6 +2376,7 @@ function insertCompensationRows(db: Database.Database, jobUrl: string): void {
 function insertJob(
   db: Database.Database,
   job: {
+    jobId: string;
     url: string;
     title: string;
     site: string;
@@ -2679,11 +2390,12 @@ function insertJob(
 ): void {
   db.prepare(
     `INSERT INTO jobs (
-       url, title, site, strategy, location, salary, discovered_at, application_url,
+       tenant_id, job_id, url, title, site, strategy, location, salary, discovered_at, application_url,
        description, full_description, detail_scraped_at, fit_score, score_reasoning,
        scored_at, tailored_resume_path, tailored_at, apply_status, applied_at
-     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+     ) VALUES ('local', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   ).run(
+    job.jobId,
     job.url,
     job.title,
     job.site,
@@ -2704,27 +2416,27 @@ function insertJob(
     job.appliedAt ?? null,
   );
   for (const stage of ["discover", "enrich", "score", "tailor", "cover"]) {
-    insertStage(db, job.url, stage, "succeeded");
+    insertStage(db, job.jobId, stage, "succeeded");
   }
-  insertStage(db, job.url, "apply", job.applyState);
-  insertScore(db, job.url, job.fitScore);
-  insertEmployerAnalysis(db, job.url);
-  insertRequirementFitReport(db, job.url);
-  insertMaterials(db, job.url, job.resumePath, job.resumePdfPath, job.rejectedResumePdfPath);
+  insertStage(db, job.jobId, "apply", job.applyState);
+  insertScore(db, job.jobId, job.fitScore);
+  insertEmployerAnalysis(db, job.jobId);
+  insertRequirementFitReport(db, job.jobId);
+  insertMaterials(db, job.jobId, job.url, job.resumePath, job.resumePdfPath, job.rejectedResumePdfPath);
 }
 
-function insertEmployerAnalysis(db: Database.Database, jobUrl: string): void {
-  if (jobUrl !== READY_JOB) {
+function insertEmployerAnalysis(db: Database.Database, jobId: string): void {
+  if (jobId !== READY_JOB_ID) {
     return;
   }
   db.prepare(
     `INSERT INTO job_employer_analysis (
-       job_url, generation, tenant_id, ideal_candidate_narrative, requirements_json
-     ) VALUES (?, ?, ?, ?, ?)`,
+       tenant_id, job_id, generation, snapshot_hash, prompt_version, sdk_set_version,
+       cache_key, ideal_candidate_narrative, requirements_json, legs_attempted,
+       legs_succeeded, created_at
+     ) VALUES ('local', ?, 1, 'snapshot', 'prompt-v1', 'sdk-v1', 'cache-v1', ?, ?, 1, 1, ?)`,
   ).run(
-    jobUrl,
-    1,
-    "local",
+    jobId,
     "A senior platform leader who improves developer experience and incident response across teams.",
     JSON.stringify([
       {
@@ -2742,11 +2454,13 @@ function insertEmployerAnalysis(db: Database.Database, jobUrl: string): void {
         evidence_span: "developer experience improvements",
       },
     ]),
+    NOW,
   );
 }
 
 function insertMaterials(
   db: Database.Database,
+  jobId: string,
   jobUrl: string,
   resumePath: string,
   resumePdfPath: string,
@@ -2754,25 +2468,31 @@ function insertMaterials(
 ): void {
   const artifactPrefix =
     jobUrl === READY_JOB ? "apply-ready" : jobUrl === DRY_RUN_JOB ? "dry-run" : "already-applied";
-  db.prepare("INSERT INTO job_materials (job_url, generation) VALUES (?, ?)").run(jobUrl, 1);
+  db.prepare(
+    `INSERT INTO job_materials (
+       tenant_id, job_id, generation, status, created_at, updated_at, metadata_json
+     ) VALUES ('local', ?, 1, 'resume_approved', ?, ?, '{}')`,
+  ).run(jobId, NOW, NOW);
   db.prepare(
     `INSERT INTO job_materials_artifacts (
-       job_url, generation, artifact_id, artifact_type, status, path, created_at, size_bytes
-     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
-  ).run(jobUrl, 1, `${artifactPrefix}-resume-text`, "tailored_resume", "approved", resumePath, NOW, 15);
+       tenant_id, job_id, generation, artifact_id, artifact_type, status, path,
+       render_format, created_at, size_bytes, metadata_json
+     ) VALUES ('local', ?, ?, ?, ?, ?, ?, ?, ?, ?, '{}')`,
+  ).run(jobId, 1, `${artifactPrefix}-resume-text`, "tailored_resume", "approved", resumePath, "text", NOW, 15);
   db.prepare(
     `INSERT INTO job_materials_artifacts (
-       job_url, generation, artifact_id, artifact_type, status, path, created_at, size_bytes
-     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
-  ).run(jobUrl, 1, `${artifactPrefix}-resume-pdf`, "resume_pdf", "approved", resumePdfPath, NOW, 15);
+       tenant_id, job_id, generation, artifact_id, artifact_type, status, path,
+       render_format, created_at, size_bytes, metadata_json
+     ) VALUES ('local', ?, ?, ?, ?, ?, ?, ?, ?, ?, '{}')`,
+  ).run(jobId, 1, `${artifactPrefix}-resume-pdf`, "resume_pdf", "approved", resumePdfPath, "html_pdf", NOW, 15);
   db.prepare(
     `INSERT INTO job_material_layout_boxes (
-       job_url, generation, artifact_id, box_index, tenant_id,
+       tenant_id, job_id, generation, artifact_id, box_index,
        semantic_id, page_number, line_number, text_excerpt,
        left_pct, top_pct, width_pct, height_pct, audit_target_json, created_at
-     ) VALUES (?, 1, ?, 0, 'local', ?, 1, 6, ?, 12.5, 24.0, 62.0, 2.4, '{}', ?)`,
+     ) VALUES ('local', ?, 1, ?, 0, ?, 1, 6, ?, 12.5, 24.0, 62.0, 2.4, '{}', ?)`,
   ).run(
-    jobUrl,
+    jobId,
     `${artifactPrefix}-resume-pdf`,
     "experience:acme:bullet:1",
     "Owned platform reliability improvements for incident response.",
@@ -2780,18 +2500,33 @@ function insertMaterials(
   );
   db.prepare(
     `INSERT INTO job_materials_artifacts (
-       job_url, generation, artifact_id, artifact_type, status, path, created_at, size_bytes
-     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+       tenant_id, job_id, generation, artifact_id, artifact_type, status, path,
+       render_format, created_at, size_bytes, metadata_json
+     ) VALUES ('local', ?, ?, ?, ?, ?, ?, ?, ?, ?, '{}')`,
   ).run(
-    jobUrl,
+    jobId,
     1,
     `${artifactPrefix}-rejected-resume-pdf`,
-    "resume_pdf",
+    "tailored_resume_pdf",
     "rejected",
     rejectedResumePdfPath,
+    "html_pdf",
     "2026-06-01T11:00:00.000Z",
     22,
   );
+}
+
+function insertMaterialSet(
+  db: Database.Database,
+  jobId: string,
+  generation: number,
+  status: string,
+): void {
+  db.prepare(
+    `INSERT INTO job_materials (
+       tenant_id, job_id, generation, status, created_at, updated_at, metadata_json
+     ) VALUES ('local', ?, ?, ?, ?, ?, '{}')`,
+  ).run(jobId, generation, status, NOW, NOW);
 }
 
 function requirementLedAuditMetadata(): Record<string, unknown> {
@@ -2910,19 +2645,19 @@ function requirementLedAuditMetadata(): Record<string, unknown> {
   };
 }
 
-function insertRequirementFitReport(db: Database.Database, jobUrl: string): void {
-  if (jobUrl !== READY_JOB) {
+function insertRequirementFitReport(db: Database.Database, jobId: string): void {
+  if (jobId !== READY_JOB_ID) {
     return;
   }
   db.prepare(
     `INSERT INTO job_requirement_fit_reports (
-       tenant_id, job_url, score_version, employer_analysis_generation,
+       tenant_id, job_id, score_version, employer_analysis_generation,
        profile_snapshot_version, scoring_policy_version, formula_version,
-       resolved_fit_score, fit_band, confidence, summary_json
-     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+       resolved_fit_score, fit_band, confidence, summary_json, created_at
+     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   ).run(
     "local",
-    jobUrl,
+    jobId,
     1,
     1,
     4,
@@ -2932,17 +2667,18 @@ function insertRequirementFitReport(db: Database.Database, jobUrl: string): void
     "strong",
     "high",
     JSON.stringify({ weighted_fit: 0.86, must_have_coverage: 1, blocker_count: 0, missing_high_weight_count: 0 }),
+    NOW,
   );
   const insertItem = db.prepare(
     `INSERT INTO job_requirement_fit_items (
-       tenant_id, job_url, score_version, requirement_id, requirement_text,
+       tenant_id, job_id, score_version, requirement_id, requirement_text,
        tier, weight, job_evidence_span, fit_json, contribution_json,
        tailoring_json, artifact_coverage_json, position
      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   );
   insertItem.run(
     "local",
-    jobUrl,
+    jobId,
     1,
     "r1",
     "Lead platform reliability improvements across critical services.",
@@ -2969,7 +2705,7 @@ function insertRequirementFitReport(db: Database.Database, jobUrl: string): void
   );
   insertItem.run(
     "local",
-    jobUrl,
+    jobId,
     1,
     "r2",
     "Improve developer experience and incident-response practices.",
@@ -3004,12 +2740,12 @@ function insertRequirementFitReport(db: Database.Database, jobUrl: string): void
 function insertBulletProvenance(db: Database.Database): void {
   db.prepare(
     `INSERT INTO job_bullet_provenance (
-       job_url, generation, bullet_id, tenant_id, artifact_id, section, source_id,
+       job_id, generation, bullet_id, tenant_id, artifact_id, section, source_id,
        evidence_ids_json, requirement_ids_json, matched_keywords_json,
        transform_type, control, rationale, generated_text, position, created_at
      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   ).run(
-    READY_JOB,
+    READY_JOB_ID,
     1,
     "summary-1",
     "local",
@@ -3028,14 +2764,14 @@ function insertBulletProvenance(db: Database.Database): void {
   );
 }
 
-function insertScore(db: Database.Database, jobUrl: string, fitScore: number): void {
+function insertScore(db: Database.Database, jobId: string, fitScore: number): void {
   db.prepare(
     `INSERT INTO job_scores (
-       job_url, version, tenant_id, fit_score, breakdown_json, keywords_json,
+       job_id, version, tenant_id, fit_score, breakdown_json, keywords_json,
        scored_at, correction_json, criteria_json, trace_json
      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   ).run(
-    jobUrl,
+    jobId,
     1,
     "local",
     fitScore,
@@ -3078,13 +2814,13 @@ function insertScore(db: Database.Database, jobUrl: string, fitScore: number): v
   );
 }
 
-function insertStage(db: Database.Database, jobUrl: string, stage: string, state: string): void {
+function insertStage(db: Database.Database, jobId: string, stage: string, state: string): void {
   db.prepare(
     `INSERT INTO job_stage_states (
-       job_url, stage, state, attempt_count, max_attempts, updated_at,
+       job_id, stage, state, attempt_count, max_attempts, updated_at,
        error_code, error_message, retryable, blocked_by_json
      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-  ).run(jobUrl, stage, state, 0, 3, NOW, null, null, 1, "[]");
+  ).run(jobId, stage, state, 0, 3, NOW, null, null, 1, "[]");
 }
 
 function seedOutcomeSuggestion(dbPath: string): void {
@@ -3092,7 +2828,7 @@ function seedOutcomeSuggestion(dbPath: string): void {
   ensureApplicationFeedbackTables(db);
   db.prepare(
     `INSERT INTO application_email_evidence (
-       tenant_id, evidence_id, job_key, provider, provider_message_id,
+       tenant_id, evidence_id, job_id, provider, provider_message_id,
        provider_thread_id, from_address, to_addresses_json, subject, snippet,
        received_at, linked_at, link_confidence, link_signals_json,
        body_text, body_sha256, body_stored_at
@@ -3100,7 +2836,7 @@ function seedOutcomeSuggestion(dbPath: string): void {
   ).run(
     "local",
     "evidence-1",
-    READY_JOB,
+    READY_JOB_ID,
     "gmail",
     "gmail-message-1",
     "gmail-thread-1",
@@ -3118,13 +2854,13 @@ function seedOutcomeSuggestion(dbPath: string): void {
   );
   db.prepare(
     `INSERT INTO application_outcome_suggestions (
-       tenant_id, suggestion_id, job_key, evidence_id, suggested_kind,
+       tenant_id, suggestion_id, job_id, evidence_id, suggested_kind,
        confidence, rationale, status, created_at
      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   ).run(
     "local",
     "suggestion-1",
-    READY_JOB,
+    READY_JOB_ID,
     "evidence-1",
     "applied_confirmation",
     0.91,
@@ -3147,26 +2883,14 @@ function eventPayloadText(dbPath: string): string {
   }
 }
 
-function seedInterviewPrepGeneration(dbPath: string, jobUrl: string, generation: number): void {
+function seedInterviewPrepGeneration(dbPath: string, jobId: string, generation: number): void {
   const db = new Database(dbPath);
   try {
-    db.exec(`
-      CREATE TABLE IF NOT EXISTS job_interview_prep (
-        tenant_id TEXT NOT NULL DEFAULT 'local',
-        job_url TEXT NOT NULL,
-        generation INTEGER NOT NULL,
-        status TEXT NOT NULL,
-        generated_at TEXT NOT NULL,
-        model TEXT,
-        gate_audit_json TEXT NOT NULL DEFAULT '{}',
-        PRIMARY KEY (job_url, generation)
-      );
-    `);
     db.prepare(
       `INSERT INTO job_interview_prep (
-         tenant_id, job_url, generation, status, generated_at, model, gate_audit_json
-       ) VALUES ('local', ?, ?, 'accepted', '2026-06-01T10:30:00.000Z', 'gpt-test', '{}')`,
-    ).run(jobUrl, generation);
+         tenant_id, job_id, generation, status, generated_at, model, gate_status
+       ) VALUES ('local', ?, ?, 'accepted', '2026-06-01T10:30:00.000Z', 'gpt-test', 'passed')`,
+    ).run(jobId, generation);
   } finally {
     db.close();
   }

--- a/apps/api/test/score-correction-v7.test.ts
+++ b/apps/api/test/score-correction-v7.test.ts
@@ -1,0 +1,200 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import Database from "better-sqlite3";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const getJobDetail = vi.hoisted(() => vi.fn((_db: unknown, jobId: string) => ({
+  ok: true,
+  job: { jobKey: jobId },
+})));
+
+vi.mock("../src/read-model.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../src/read-model.js")>()),
+  getJobDetail,
+}));
+
+import { hasExactV7SchemaManifest } from "../src/schema-manifest.js";
+import { buildApp } from "../src/server.js";
+import { initializeExactV7Database } from "./v7-schema.js";
+
+const CORRECTED_JOB_ID = "00000000-0000-4000-8000-000000000081";
+const CORRECTED_JOB_URL = "https://jobs.example.test/score-correction";
+const COMPARABLE_JOB_ID = "00000000-0000-4000-8000-000000000082";
+const COMPARABLE_JOB_URL = "https://jobs.example.test/comparable-score";
+const directories: string[] = [];
+
+afterEach(() => {
+  getJobDetail.mockClear();
+  for (const directory of directories.splice(0)) {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe("score correction exact-v7 identity", () => {
+  it("resolves URL locators at the API boundary and persists corrections, policy staleness, and events by JobId", async () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "jobctrl-score-correction-v7-"));
+    directories.push(directory);
+    const dbPath = path.join(directory, "jobctrl.db");
+    initializeExactV7Database(dbPath);
+    seedScores(dbPath);
+
+    const app = buildApp({
+      appDir: directory,
+      dbPath,
+      configPath: path.join(directory, "config.json"),
+      logger: false,
+    });
+    try {
+      const correctionResponse = await app.inject({
+        method: "POST",
+        url: `/v1/jobs/${encodeURIComponent(CORRECTED_JOB_URL)}/score-correction`,
+        payload: { correctedScore: 9, reason: "Reviewed against explicit evidence" },
+      });
+
+      expect(correctionResponse.statusCode).toBe(200);
+      expect(getJobDetail).toHaveBeenCalledWith(expect.anything(), CORRECTED_JOB_ID);
+
+      const db = new Database(dbPath);
+      try {
+        expect(scoreRows(db, CORRECTED_JOB_ID)).toEqual([
+          { tenant_id: "local", job_id: CORRECTED_JOB_ID, version: 1, fit_score: 6 },
+          { tenant_id: "local", job_id: CORRECTED_JOB_ID, version: 2, fit_score: 9 },
+        ]);
+        expect(db.prepare("SELECT fit_score FROM jobs WHERE tenant_id = 'local' AND job_id = ?")
+          .get(CORRECTED_JOB_ID)).toEqual({ fit_score: 3 });
+
+        const policies = db.prepare(
+          "SELECT tenant_id, version, anchors_json FROM scoring_policies ORDER BY version",
+        ).all() as Array<{ tenant_id: string; version: number; anchors_json: string }>;
+        expect(policies.map(({ tenant_id, version }) => ({ tenant_id, version }))).toEqual([
+          { tenant_id: "local", version: 1 },
+          { tenant_id: "local", version: 2 },
+        ]);
+        expect(policies[1]?.anchors_json).not.toContain(CORRECTED_JOB_URL);
+
+        expect(db.prepare(
+          `SELECT tenant_id, job_id, stale_reason, resolved
+             FROM job_score_staleness`,
+        ).all()).toEqual([{
+          tenant_id: "local",
+          job_id: COMPARABLE_JOB_ID,
+          stale_reason: "scoring_policy_changed",
+          resolved: 0,
+        }]);
+        expect(db.prepare(
+          "SELECT tenant_id, job_id, state FROM job_stage_states WHERE tenant_id = 'local' AND job_id = ? AND stage = 'score'",
+        ).get(COMPARABLE_JOB_ID)).toEqual({
+          tenant_id: "local",
+          job_id: COMPARABLE_JOB_ID,
+          state: "stale",
+        });
+        expect(scoreEvents(db)).toEqual([
+          expect.objectContaining({
+            tenant_id: "local",
+            job_id: COMPARABLE_JOB_ID,
+            identity_version: 1,
+            event_type: "ScoreMarkedStale",
+          }),
+          expect.objectContaining({
+            tenant_id: "local",
+            job_id: CORRECTED_JOB_ID,
+            identity_version: 1,
+            event_type: "ScoreCorrected",
+          }),
+        ]);
+        expect(hasExactV7SchemaManifest(db)).toBe(true);
+      } finally {
+        db.close();
+      }
+
+      const resetResponse = await app.inject({
+        method: "POST",
+        url: "/v1/scoring/stale-scores/actions/reset-for-rescore",
+        payload: { limit: 1, jobKeys: [COMPARABLE_JOB_URL] },
+      });
+
+      expect(resetResponse.statusCode).toBe(200);
+      expect(resetResponse.json()).toMatchObject({
+        ok: true,
+        count: 1,
+        jobKeys: [COMPARABLE_JOB_ID],
+      });
+
+      const resetDb = new Database(dbPath);
+      try {
+        expect(resetDb.prepare(
+          "SELECT resolved FROM job_score_staleness WHERE tenant_id = 'local' AND job_id = ?",
+        ).get(COMPARABLE_JOB_ID)).toEqual({ resolved: 1 });
+        expect(resetDb.prepare(
+          "SELECT state, attempt_count FROM job_stage_states WHERE tenant_id = 'local' AND job_id = ? AND stage = 'score'",
+        ).get(COMPARABLE_JOB_ID)).toEqual({ state: "pending", attempt_count: 0 });
+        expect(scoreEvents(resetDb).at(-1)).toEqual(expect.objectContaining({
+          tenant_id: "local",
+          job_id: COMPARABLE_JOB_ID,
+          identity_version: 1,
+          event_type: "ScoreRescoreRequested",
+        }));
+        expect(hasExactV7SchemaManifest(resetDb)).toBe(true);
+      } finally {
+        resetDb.close();
+      }
+    } finally {
+      await app.close();
+    }
+  });
+});
+
+function seedScores(dbPath: string): void {
+  const db = new Database(dbPath);
+  try {
+    db.pragma("foreign_keys = ON");
+    const insertJob = db.prepare(
+      `INSERT INTO jobs (tenant_id, job_id, url, title, fit_score, discovered_at)
+       VALUES ('local', ?, ?, ?, 3, '2026-07-31T12:00:00Z')`,
+    );
+    insertJob.run(CORRECTED_JOB_ID, CORRECTED_JOB_URL, "Corrected role");
+    insertJob.run(COMPARABLE_JOB_ID, COMPARABLE_JOB_URL, "Comparable role");
+
+    const insertScore = db.prepare(
+      `INSERT INTO job_scores (
+         tenant_id, job_id, version, fit_score, breakdown_json, keywords_json,
+         scored_at, correction_json, criteria_json, trace_json
+       ) VALUES ('local', ?, 1, ?, '{}', '[]', '2026-07-31T12:01:00Z', NULL, '{}', ?)`,
+    );
+    const trace = JSON.stringify({
+      scoring_policy_id: "local:scoring-policy-v1",
+      scoring_policy_version: 1,
+    });
+    insertScore.run(CORRECTED_JOB_ID, 6, trace);
+    insertScore.run(COMPARABLE_JOB_ID, 7, trace);
+
+    const insertStage = db.prepare(
+      `INSERT INTO job_stage_states (tenant_id, job_id, stage, state, updated_at)
+       VALUES ('local', ?, 'score', 'succeeded', '2026-07-31T12:01:00Z')`,
+    );
+    insertStage.run(CORRECTED_JOB_ID);
+    insertStage.run(COMPARABLE_JOB_ID);
+  } finally {
+    db.close();
+  }
+}
+
+function scoreRows(db: Database.Database, jobId: string): unknown[] {
+  return db.prepare(
+    `SELECT tenant_id, job_id, version, fit_score
+       FROM job_scores
+      WHERE tenant_id = 'local' AND job_id = ?
+      ORDER BY version`,
+  ).all(jobId);
+}
+
+function scoreEvents(db: Database.Database): Array<Record<string, unknown>> {
+  return db.prepare(
+    `SELECT tenant_id, job_id, identity_version, event_type, payload_json
+       FROM job_events
+      WHERE event_type IN ('ScoreMarkedStale', 'ScoreCorrected', 'ScoreRescoreRequested')
+      ORDER BY event_id`,
+  ).all() as Array<Record<string, unknown>>;
+}

--- a/workers/automation/src/jobctrl/apply/launcher.py
+++ b/workers/automation/src/jobctrl/apply/launcher.py
@@ -612,6 +612,7 @@ def _apply_candidate_select_parts() -> tuple[str, str]:
         "WHERE jss_a.job_url = jobs.url AND jss_a.stage = 'apply' LIMIT 1) AS apply_attempts"
     )
     columns = (
+        f"jobs.tenant_id AS tenant_id, jobs.job_id AS job_id, "
         f"jobs.url AS url, jobs.title AS title, jobs.site AS site, "
         f"{_EFFECTIVE_APPLICATION_URL} AS application_url, "
         f"{_EFFECTIVE_TAILOR_PATH} AS tailored_resume_path, "

--- a/workers/automation/src/jobctrl/apply/launcher.py
+++ b/workers/automation/src/jobctrl/apply/launcher.py
@@ -79,7 +79,6 @@ from jobctrl.database import (
     _SCORE_DOWNSTREAM_STATE_JOIN,
     _SCORE_CURRENT_FOR_DOWNSTREAM,
     _SCORE_ELIGIBLE_FOR_DOWNSTREAM,
-    _order_rows_by_feedback,
     ensure_application_review_decision_columns,
     get_connection,
 )
@@ -720,7 +719,7 @@ def acquire_job(
                 """,
                 params,
             ).fetchall()
-            candidate_rows = _order_rows_by_feedback(conn, rows)
+            candidate_rows = rows
 
         if not candidate_rows:
             conn.rollback()

--- a/workers/automation/src/jobctrl/database.py
+++ b/workers/automation/src/jobctrl/database.py
@@ -3279,7 +3279,6 @@ _EFFECTIVE_APPLY_STATUS: str = (
 )
 
 
-_FEEDBACK_ORDERED_STAGES = frozenset({"scored", "pending_tailor", "pending_cover", "pending_apply"})
 LOW_FIT_TAILORING_MAX_SCORE = 5
 MIN_TAILORING_FIT_SCORE = LOW_FIT_TAILORING_MAX_SCORE + 1
 
@@ -3289,58 +3288,6 @@ def effective_tailoring_min_score(min_score: int | None = None) -> int:
     if min_score is None:
         return 7
     return max(MIN_TAILORING_FIT_SCORE, int(min_score))
-
-
-def _order_rows_by_feedback(
-    conn: sqlite3.Connection,
-    rows: list[sqlite3.Row],
-) -> list[sqlite3.Row]:
-    """Order score-backed selector rows using local feedback signals."""
-    if len(rows) < 2:
-        return rows
-
-    row_keys = set(rows[0].keys())
-    base_scores: dict[tuple[str, str], float] = {}
-    for row in rows:
-        raw_score = row["js_fit_score"] if "js_fit_score" in row_keys else None
-        if raw_score is None:
-            raw_score = row["fit_score"] if "fit_score" in row_keys else None
-        if raw_score is None:
-            continue
-        try:
-            base_scores[(str(row["tenant_id"]), str(row["job_id"]))] = float(raw_score)
-        except (TypeError, ValueError):
-            continue
-
-    if len(base_scores) < 2:
-        return rows
-
-    from jobctrl.infrastructure.scoring import collect_feedback_signals, rank_jobs_with_feedback
-
-    signals = collect_feedback_signals(conn)
-    if not signals:
-        return rows
-
-    ranked = rank_jobs_with_feedback(base_scores, signals)
-    rank_index = {
-        (item.tenant_id, item.job_id): index
-        for index, item in enumerate(ranked)
-    }
-    original_index = {
-        (str(row["tenant_id"]), str(row["job_id"])): index
-        for index, row in enumerate(rows)
-    }
-    fallback_index = len(rank_index)
-    return sorted(
-        rows,
-        key=lambda row: (
-            rank_index.get(
-                (str(row["tenant_id"]), str(row["job_id"])),
-                fallback_index,
-            ),
-            original_index[(str(row["tenant_id"]), str(row["job_id"]))],
-        ),
-    )
 
 
 def get_stats(conn: sqlite3.Connection | None = None) -> dict:
@@ -3906,16 +3853,11 @@ def get_jobs_by_stage(
         f"WHERE {where} "
         f"ORDER BY {_EFFECTIVE_FIT_SCORE} DESC NULLS LAST, discovered_at DESC"
     )
-    feedback_ordered = stage in _FEEDBACK_ORDERED_STAGES
-    if limit > 0 and not feedback_ordered:
+    if limit > 0:
         query += " LIMIT ?"
         params.append(limit)
 
     rows = conn.execute(query, params).fetchall()
-    if feedback_ordered:
-        rows = _order_rows_by_feedback(conn, rows)
-        if limit > 0:
-            rows = rows[:limit]
 
     # Convert sqlite3.Row objects to dicts. We promote ``js_fit_score``
     # into the legacy ``fit_score`` slot and ``jm_*_path`` into the

--- a/workers/automation/src/jobctrl/database.py
+++ b/workers/automation/src/jobctrl/database.py
@@ -3300,7 +3300,7 @@ def _order_rows_by_feedback(
         return rows
 
     row_keys = set(rows[0].keys())
-    base_scores: dict[str, float] = {}
+    base_scores: dict[tuple[str, str], float] = {}
     for row in rows:
         raw_score = row["js_fit_score"] if "js_fit_score" in row_keys else None
         if raw_score is None:
@@ -3308,7 +3308,7 @@ def _order_rows_by_feedback(
         if raw_score is None:
             continue
         try:
-            base_scores[str(row["url"])] = float(raw_score)
+            base_scores[(str(row["tenant_id"]), str(row["job_id"]))] = float(raw_score)
         except (TypeError, ValueError):
             continue
 
@@ -3322,14 +3322,23 @@ def _order_rows_by_feedback(
         return rows
 
     ranked = rank_jobs_with_feedback(base_scores, signals)
-    rank_index = {item.job_id: index for index, item in enumerate(ranked)}
-    original_index = {str(row["url"]): index for index, row in enumerate(rows)}
+    rank_index = {
+        (item.tenant_id, item.job_id): index
+        for index, item in enumerate(ranked)
+    }
+    original_index = {
+        (str(row["tenant_id"]), str(row["job_id"])): index
+        for index, row in enumerate(rows)
+    }
     fallback_index = len(rank_index)
     return sorted(
         rows,
         key=lambda row: (
-            rank_index.get(str(row["url"]), fallback_index),
-            original_index[str(row["url"])],
+            rank_index.get(
+                (str(row["tenant_id"]), str(row["job_id"])),
+                fallback_index,
+            ),
+            original_index[(str(row["tenant_id"]), str(row["job_id"]))],
         ),
     )
 

--- a/workers/automation/src/jobctrl/infrastructure/scoring/__init__.py
+++ b/workers/automation/src/jobctrl/infrastructure/scoring/__init__.py
@@ -2,10 +2,8 @@
 
 from jobctrl.infrastructure.scoring.criteria_provider import LocalScoringCriteriaProvider
 from jobctrl.infrastructure.scoring.feedback import (
-    FeedbackRankedJob,
     ScoringFeedbackSignal,
     collect_feedback_signals,
-    rank_jobs_with_feedback,
 )
 from jobctrl.infrastructure.scoring.sqlite_repository import (
     SqliteRequirementFitReportRepository,
@@ -15,7 +13,6 @@ from jobctrl.infrastructure.scoring.sqlite_repository import (
 )
 
 __all__ = [
-    "FeedbackRankedJob",
     "LocalScoringCriteriaProvider",
     "ScoringFeedbackSignal",
     "SqliteRequirementFitReportRepository",
@@ -23,5 +20,4 @@ __all__ = [
     "SqliteScoreStalenessRepository",
     "SqliteScoringPolicyRepository",
     "collect_feedback_signals",
-    "rank_jobs_with_feedback",
 ]

--- a/workers/automation/src/jobctrl/infrastructure/scoring/feedback.py
+++ b/workers/automation/src/jobctrl/infrastructure/scoring/feedback.py
@@ -17,6 +17,7 @@ from typing import Any, Iterable
 
 @dataclass(frozen=True)
 class ScoringFeedbackSignal:
+    tenant_id: str
     job_id: str
     kind: str
     weight: float
@@ -25,6 +26,7 @@ class ScoringFeedbackSignal:
 
 @dataclass(frozen=True)
 class FeedbackRankedJob:
+    tenant_id: str
     job_id: str
     base_score: float
     feedback_adjustment: float
@@ -51,21 +53,22 @@ def collect_feedback_signals(conn: sqlite3.Connection) -> tuple[ScoringFeedbackS
 
 
 def rank_jobs_with_feedback(
-    base_scores: dict[str, float],
+    base_scores: dict[tuple[str, str], float],
     signals: Iterable[ScoringFeedbackSignal],
 ) -> tuple[FeedbackRankedJob, ...]:
     """Apply bounded, evidence-backed feedback adjustments to base scores."""
 
-    by_job: dict[str, list[ScoringFeedbackSignal]] = defaultdict(list)
+    by_job: dict[tuple[str, str], list[ScoringFeedbackSignal]] = defaultdict(list)
     for signal in signals:
-        by_job[signal.job_id].append(signal)
+        by_job[(signal.tenant_id, signal.job_id)].append(signal)
 
     ranked: list[FeedbackRankedJob] = []
-    for job_id, base_score in base_scores.items():
-        job_signals = by_job.get(job_id, [])
+    for (tenant_id, job_id), base_score in base_scores.items():
+        job_signals = by_job.get((tenant_id, job_id), [])
         adjustment = max(-1.5, min(1.5, sum(signal.weight for signal in job_signals)))
         ranked.append(
             FeedbackRankedJob(
+                tenant_id=tenant_id,
                 job_id=job_id,
                 base_score=base_score,
                 feedback_adjustment=adjustment,
@@ -80,17 +83,18 @@ def _correction_signals(conn: sqlite3.Connection) -> list[ScoringFeedbackSignal]
     if not _table_exists(conn, "job_scores"):
         return []
     rows = conn.execute(
-        """SELECT job_url, fit_score, correction_json, trace_json
+        """SELECT tenant_id, job_id, fit_score, correction_json, trace_json
            FROM job_scores
            WHERE correction_json IS NOT NULL AND correction_json != ''
-           ORDER BY job_url, version"""
+           ORDER BY tenant_id, job_id, version"""
     ).fetchall()
     signals: list[ScoringFeedbackSignal] = []
     for row in rows:
-        job_id = str(row["job_url"] if isinstance(row, sqlite3.Row) else row[0])
-        fit_score = float(row["fit_score"] if isinstance(row, sqlite3.Row) else row[1])
-        correction = _json_object(row["correction_json"] if isinstance(row, sqlite3.Row) else row[2])
-        trace = _json_object(row["trace_json"] if isinstance(row, sqlite3.Row) else row[3])
+        tenant_id = str(row["tenant_id"] if isinstance(row, sqlite3.Row) else row[0])
+        job_id = str(row["job_id"] if isinstance(row, sqlite3.Row) else row[1])
+        fit_score = float(row["fit_score"] if isinstance(row, sqlite3.Row) else row[2])
+        correction = _json_object(row["correction_json"] if isinstance(row, sqlite3.Row) else row[3])
+        trace = _json_object(row["trace_json"] if isinstance(row, sqlite3.Row) else row[4])
         history = trace.get("correction_history")
         latest_history = history[-1] if isinstance(history, list) and history else {}
         original_score = _float(
@@ -101,6 +105,7 @@ def _correction_signals(conn: sqlite3.Connection) -> list[ScoringFeedbackSignal]
         rationale = str(correction.get("rationale") or "score corrected").strip()
         signals.append(
             ScoringFeedbackSignal(
+                tenant_id=tenant_id,
                 job_id=job_id,
                 kind="score_correction",
                 weight=delta,
@@ -114,9 +119,9 @@ def _action_signals(conn: sqlite3.Connection) -> list[ScoringFeedbackSignal]:
     if not _table_exists(conn, "job_events"):
         return []
     rows = conn.execute(
-        """SELECT job_url, event_type, message
+        """SELECT tenant_id, job_id, event_type, message
            FROM job_events
-           WHERE job_url IS NOT NULL AND event_type IN (
+           WHERE job_id IS NOT NULL AND event_type IN (
              'ApplicationManuallyMarked',
              'StageSkipped',
              'JobDeleted',
@@ -127,11 +132,13 @@ def _action_signals(conn: sqlite3.Connection) -> list[ScoringFeedbackSignal]:
     ).fetchall()
     signals: list[ScoringFeedbackSignal] = []
     for row in rows:
-        job_id = str(row["job_url"] if isinstance(row, sqlite3.Row) else row[0])
-        event_type = str(row["event_type"] if isinstance(row, sqlite3.Row) else row[1])
-        message = str((row["message"] if isinstance(row, sqlite3.Row) else row[2]) or event_type)
+        tenant_id = str(row["tenant_id"] if isinstance(row, sqlite3.Row) else row[0])
+        job_id = str(row["job_id"] if isinstance(row, sqlite3.Row) else row[1])
+        event_type = str(row["event_type"] if isinstance(row, sqlite3.Row) else row[2])
+        message = str((row["message"] if isinstance(row, sqlite3.Row) else row[3]) or event_type)
         signals.append(
             ScoringFeedbackSignal(
+                tenant_id=tenant_id,
                 job_id=job_id,
                 kind=event_type,
                 weight=ACTION_WEIGHTS[event_type],

--- a/workers/automation/src/jobctrl/infrastructure/scoring/feedback.py
+++ b/workers/automation/src/jobctrl/infrastructure/scoring/feedback.py
@@ -1,18 +1,17 @@
-"""Transparent local scoring feedback signals.
+"""Auditable local scoring feedback signals.
 
 The collector reads existing local facts only: score corrections from
 ``job_scores`` and user/job actions from ``job_events``. It does not hide or
-overwrite score evidence; callers receive the evidence strings that produced
-each adjustment.
+overwrite score evidence or turn those facts into ranking adjustments. Policy
+changes are derived and accepted through the versioned learning flow.
 """
 
 from __future__ import annotations
 
 import json
 import sqlite3
-from collections import defaultdict
 from dataclasses import dataclass
-from typing import Any, Iterable
+from typing import Any
 
 
 @dataclass(frozen=True)
@@ -20,63 +19,16 @@ class ScoringFeedbackSignal:
     tenant_id: str
     job_id: str
     kind: str
-    weight: float
     evidence: str
 
 
-@dataclass(frozen=True)
-class FeedbackRankedJob:
-    tenant_id: str
-    job_id: str
-    base_score: float
-    feedback_adjustment: float
-    final_score: float
-    evidence: tuple[str, ...]
-
-
-ACTION_WEIGHTS = {
-    "ApplicationManuallyMarked": 0.75,
-    "StageSkipped": -0.75,
-    "JobDeleted": -1.0,
-    "ResumeApproved": 0.35,
-    "CoverLetterApproved": 0.35,
-}
-
-
 def collect_feedback_signals(conn: sqlite3.Connection) -> tuple[ScoringFeedbackSignal, ...]:
-    """Collect transparent feedback signals from local scoring/action tables."""
+    """Collect auditable feedback facts from local scoring/action tables."""
 
     signals: list[ScoringFeedbackSignal] = []
     signals.extend(_correction_signals(conn))
     signals.extend(_action_signals(conn))
     return tuple(signals)
-
-
-def rank_jobs_with_feedback(
-    base_scores: dict[tuple[str, str], float],
-    signals: Iterable[ScoringFeedbackSignal],
-) -> tuple[FeedbackRankedJob, ...]:
-    """Apply bounded, evidence-backed feedback adjustments to base scores."""
-
-    by_job: dict[tuple[str, str], list[ScoringFeedbackSignal]] = defaultdict(list)
-    for signal in signals:
-        by_job[(signal.tenant_id, signal.job_id)].append(signal)
-
-    ranked: list[FeedbackRankedJob] = []
-    for (tenant_id, job_id), base_score in base_scores.items():
-        job_signals = by_job.get((tenant_id, job_id), [])
-        adjustment = max(-1.5, min(1.5, sum(signal.weight for signal in job_signals)))
-        ranked.append(
-            FeedbackRankedJob(
-                tenant_id=tenant_id,
-                job_id=job_id,
-                base_score=base_score,
-                feedback_adjustment=adjustment,
-                final_score=base_score + adjustment,
-                evidence=tuple(signal.evidence for signal in job_signals),
-            )
-        )
-    return tuple(sorted(ranked, key=lambda item: (item.final_score, item.base_score), reverse=True))
 
 
 def _correction_signals(conn: sqlite3.Connection) -> list[ScoringFeedbackSignal]:
@@ -101,14 +53,12 @@ def _correction_signals(conn: sqlite3.Connection) -> list[ScoringFeedbackSignal]
             latest_history.get("original_score") if isinstance(latest_history, dict) else None,
             fit_score,
         )
-        delta = max(-1.5, min(1.5, (fit_score - original_score) / 2.0))
         rationale = str(correction.get("rationale") or "score corrected").strip()
         signals.append(
             ScoringFeedbackSignal(
                 tenant_id=tenant_id,
                 job_id=job_id,
                 kind="score_correction",
-                weight=delta,
                 evidence=f"score correction {original_score:g}->{fit_score:g}: {rationale}",
             )
         )
@@ -141,7 +91,6 @@ def _action_signals(conn: sqlite3.Connection) -> list[ScoringFeedbackSignal]:
                 tenant_id=tenant_id,
                 job_id=job_id,
                 kind=event_type,
-                weight=ACTION_WEIGHTS[event_type],
                 evidence=f"{event_type}: {message}",
             )
         )

--- a/workers/automation/tests/test_scoring_eval_feedback.py
+++ b/workers/automation/tests/test_scoring_eval_feedback.py
@@ -2,110 +2,265 @@ from __future__ import annotations
 
 import json
 import sqlite3
-from pathlib import Path
+from collections.abc import Sequence
+from typing import Any
 
-from jobctrl.database import get_jobs_by_stage, init_db
+from jobctrl import database as database_module
+from jobctrl.apply import launcher as launcher_module
+from jobctrl.domain.identifiers import canonical_job_id
 from jobctrl.infrastructure.scoring import collect_feedback_signals, rank_jobs_with_feedback
-from jobctrl.state import record_job_event
+
+_TENANT_A = "tenant-a"
+_TENANT_B = "tenant-b"
+_JOB_A = canonical_job_id("a0000000-0000-4000-8000-000000000001")
+_JOB_B = canonical_job_id("a0000000-0000-4000-8000-000000000002")
 
 
-def test_feedback_signals_use_corrections_and_job_actions_transparently() -> None:
+def _connection() -> sqlite3.Connection:
     conn = sqlite3.connect(":memory:")
     conn.row_factory = sqlite3.Row
     conn.executescript(
         """
         CREATE TABLE job_scores (
-          job_url TEXT NOT NULL,
+          tenant_id TEXT NOT NULL,
+          job_id TEXT NOT NULL,
           version INTEGER NOT NULL,
-          tenant_id TEXT NOT NULL DEFAULT 'local',
           fit_score INTEGER NOT NULL,
           breakdown_json TEXT NOT NULL,
           keywords_json TEXT NOT NULL,
           scored_at TEXT NOT NULL,
           correction_json TEXT,
           trace_json TEXT NOT NULL DEFAULT '{}',
-          PRIMARY KEY (job_url, version)
+          PRIMARY KEY (tenant_id, job_id, version)
         );
         CREATE TABLE job_events (
           event_id INTEGER PRIMARY KEY AUTOINCREMENT,
-          job_url TEXT,
+          tenant_id TEXT NOT NULL,
+          job_id TEXT,
           event_type TEXT NOT NULL,
           message TEXT
         );
         """
     )
+    return conn
+
+
+def _insert_corrected_score(
+    conn: sqlite3.Connection,
+    *,
+    tenant_id: str,
+    job_id: str,
+) -> None:
     conn.execute(
         """INSERT INTO job_scores (
-          job_url, version, fit_score, breakdown_json, keywords_json, scored_at,
-          correction_json, trace_json
-        ) VALUES (?, 2, ?, '{}', '[]', ?, ?, ?)""",
+          tenant_id, job_id, version, fit_score, breakdown_json, keywords_json,
+          scored_at, correction_json, trace_json
+        ) VALUES (?, ?, 2, 9, '{}', '[]', ?, ?, ?)""",
         (
-            "job-a",
-            9,
+            tenant_id,
+            job_id,
             "2026-05-14T10:00:00Z",
-            json.dumps({"corrected_fit_score": 9, "rationale": "Better leadership fit."}),
-            json.dumps({"correction_history": [{"original_score": 6, "corrected_score": 9}]}),
+            json.dumps(
+                {
+                    "corrected_fit_score": 9,
+                    "rationale": "Better leadership fit.",
+                }
+            ),
+            json.dumps(
+                {
+                    "correction_history": [
+                        {"original_score": 6, "corrected_score": 9}
+                    ]
+                }
+            ),
         ),
     )
+
+
+def test_feedback_signals_use_canonical_corrections_and_actions_transparently() -> None:
+    conn = _connection()
+    _insert_corrected_score(
+        conn,
+        tenant_id=_TENANT_A,
+        job_id=str(_JOB_A),
+    )
     conn.execute(
-        "INSERT INTO job_events (job_url, event_type, message) VALUES (?, ?, ?)",
-        ("job-b", "StageSkipped", "Skipped after review."),
+        """
+        INSERT INTO job_events (tenant_id, job_id, event_type, message)
+        VALUES (?, ?, 'StageSkipped', 'Skipped after review.')
+        """,
+        (_TENANT_A, str(_JOB_B)),
     )
 
     signals = collect_feedback_signals(conn)
-    ranked = rank_jobs_with_feedback({"job-a": 7.5, "job-b": 8.0}, signals)
+    ranked = rank_jobs_with_feedback(
+        {
+            (_TENANT_A, str(_JOB_A)): 7.5,
+            (_TENANT_A, str(_JOB_B)): 8.0,
+        },
+        signals,
+    )
 
-    assert [signal.kind for signal in signals] == ["score_correction", "StageSkipped"]
-    assert ranked[0].job_id == "job-a"
+    assert [signal.kind for signal in signals] == [
+        "score_correction",
+        "StageSkipped",
+    ]
+    assert (ranked[0].tenant_id, ranked[0].job_id) == (
+        _TENANT_A,
+        str(_JOB_A),
+    )
     assert ranked[0].feedback_adjustment > 0
     assert "Better leadership fit" in ranked[0].evidence[0]
     assert ranked[1].feedback_adjustment < 0
     assert "Skipped after review" in ranked[1].evidence[0]
 
 
-def test_feedback_adjustments_affect_downstream_selector_order(tmp_path: Path) -> None:
-    conn = init_db(tmp_path / "jobctrl.db")
-    corrected = "https://example.com/corrected"
-    skipped = "https://example.com/skipped"
-    for url in (corrected, skipped):
-        conn.execute(
-            "INSERT INTO jobs (url, title, site, full_description, discovered_at) "
-            "VALUES (?, ?, ?, ?, ?)",
-            (url, "Engineer", "Acme", "Need Python.", "2026-05-14T00:00:00+00:00"),
-        )
-    conn.execute(
-        """INSERT INTO job_scores (
-          job_url, version, tenant_id, fit_score, breakdown_json, keywords_json, scored_at,
-          correction_json, criteria_json, trace_json
-        ) VALUES (?, 2, 'local', 9, ?, '["python"]', ?, ?, '{}', ?)""",
-        (
-            corrected,
-            json.dumps({"reasoning": "Corrected after review.", "eligibility": {"status": "eligible"}}),
-            "2026-05-14T10:00:00+00:00",
-            json.dumps({"corrected_fit_score": 9, "rationale": "Better leadership fit."}),
-            json.dumps({"correction_history": [{"original_score": 6, "corrected_score": 9}]}),
-        ),
-    )
-    conn.execute(
-        """INSERT INTO job_scores (
-          job_url, version, tenant_id, fit_score, breakdown_json, keywords_json, scored_at,
-          correction_json, criteria_json, trace_json
-        ) VALUES (?, 1, 'local', 10, ?, '["python"]', ?, NULL, '{}', '{}')""",
-        (
-            skipped,
-            json.dumps({"reasoning": "High raw score.", "eligibility": {"status": "eligible"}}),
-            "2026-05-14T10:00:00+00:00",
-        ),
-    )
-    record_job_event(
+def test_feedback_ordering_isolates_same_job_id_across_tenants() -> None:
+    conn = _connection()
+    shared_job_id = str(_JOB_A)
+    shared_url = "https://example.com/shared"
+    _insert_corrected_score(
         conn,
-        skipped,
-        "tailor",
-        "StageSkipped",
-        message="Skipped after manual review.",
+        tenant_id=_TENANT_A,
+        job_id=shared_job_id,
     )
+    conn.execute(
+        """
+        INSERT INTO job_events (tenant_id, job_id, event_type, message)
+        VALUES (?, ?, 'StageSkipped', 'Tenant B skipped this job.')
+        """,
+        (_TENANT_B, shared_job_id),
+    )
+    rows = conn.execute(
+        """
+        SELECT ? AS tenant_id, ? AS job_id, ? AS url,
+               7.5 AS js_fit_score, NULL AS fit_score
+        UNION ALL
+        SELECT ?, ?, ?, 8.0, NULL
+        """,
+        (
+            _TENANT_A,
+            shared_job_id,
+            shared_url,
+            _TENANT_B,
+            shared_job_id,
+            shared_url,
+        ),
+    ).fetchall()
+
+    ordered = database_module._order_rows_by_feedback(conn, rows)
+
+    assert [
+        (str(row["tenant_id"]), str(row["job_id"]))
+        for row in ordered
+    ] == [
+        (_TENANT_A, shared_job_id),
+        (_TENANT_B, shared_job_id),
+    ]
+
+
+class _RowsCursor:
+    def __init__(self, rows: Sequence[sqlite3.Row]) -> None:
+        self._rows = list(rows)
+
+    def fetchall(self) -> list[sqlite3.Row]:
+        return self._rows
+
+    def fetchone(self) -> sqlite3.Row | None:
+        return self._rows[0] if self._rows else None
+
+
+class _AcquireConnection:
+    """Delegate feedback reads while supplying the apply candidate projection."""
+
+    def __init__(
+        self,
+        conn: sqlite3.Connection,
+        candidates: Sequence[sqlite3.Row],
+    ) -> None:
+        self._conn = conn
+        self._candidates = candidates
+        self.projected_canonical_identity = False
+
+    def execute(
+        self,
+        sql: str,
+        parameters: Sequence[Any] = (),
+    ) -> sqlite3.Cursor | _RowsCursor:
+        if "FROM jobs" in sql and "ORDER BY" in sql:
+            self.projected_canonical_identity = (
+                "jobs.tenant_id AS tenant_id" in sql
+                and "jobs.job_id AS job_id" in sql
+            )
+            return _RowsCursor(self._candidates)
+        if "FROM job_stage_states" in sql:
+            return _RowsCursor([])
+        return self._conn.execute(sql, parameters)
+
+    def commit(self) -> None:
+        self._conn.commit()
+
+    def rollback(self) -> None:
+        self._conn.rollback()
+
+
+def test_acquire_job_orders_multiple_candidates_by_canonical_feedback(
+    monkeypatch,
+) -> None:
+    conn = _connection()
+    _insert_corrected_score(
+        conn,
+        tenant_id=_TENANT_A,
+        job_id=str(_JOB_A),
+    )
+    candidates = conn.execute(
+        """
+        SELECT ? AS tenant_id, ? AS job_id, 'https://example.com/a' AS url,
+               'A' AS title, 'example' AS site,
+               'https://example.com/a/apply' AS application_url,
+               '/tmp/a.txt' AS tailored_resume_path,
+               '/tmp/a.pdf' AS resume_pdf_path,
+               'artifact-a' AS resume_pdf_artifact_id,
+               1 AS materials_generation, 7.5 AS fit_score,
+               7.5 AS js_fit_score, NULL AS location, NULL AS description,
+               NULL AS full_description, NULL AS cover_letter_path,
+               NULL AS applied_at, NULL AS apply_status, 0 AS apply_attempts
+        UNION ALL
+        SELECT ?, ?, 'https://example.com/b', 'B', 'example',
+               'https://example.com/b/apply', '/tmp/b.txt', '/tmp/b.pdf',
+               'artifact-b', 1, 8.0, 8.0, NULL, NULL, NULL, NULL, NULL, NULL, 0
+        """,
+        (
+            _TENANT_A,
+            str(_JOB_A),
+            _TENANT_A,
+            str(_JOB_B),
+        ),
+    ).fetchall()
     conn.commit()
+    acquire_conn = _AcquireConnection(conn, candidates)
 
-    rows = get_jobs_by_stage(conn, "pending_tailor", min_score=7, limit=1)
+    monkeypatch.setattr(launcher_module, "get_connection", lambda: acquire_conn)
+    monkeypatch.setattr(launcher_module, "_load_blocked", lambda: ([], []))
+    monkeypatch.setattr(launcher_module, "ensure_job_stage_rows", lambda *_args: None)
+    monkeypatch.setattr(launcher_module, "set_stage_state", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(launcher_module, "record_job_event", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(launcher_module, "_current_profile_version", lambda *_args, **_kwargs: 1)
+    monkeypatch.setattr(
+        launcher_module,
+        "_latest_apply_review_decision",
+        lambda *_args, **_kwargs: None,
+    )
 
-    assert [row["url"] for row in rows] == [corrected]
+    selected = launcher_module.acquire_job(
+        worker_id=1,
+        run_ctx={"dry_run": True},
+        approval_required=False,
+    )
+
+    assert acquire_conn.projected_canonical_identity is True
+    assert selected is not None
+    assert (selected["tenant_id"], selected["job_id"]) == (
+        _TENANT_A,
+        str(_JOB_A),
+    )

--- a/workers/automation/tests/test_scoring_eval_feedback.py
+++ b/workers/automation/tests/test_scoring_eval_feedback.py
@@ -5,10 +5,9 @@ import sqlite3
 from collections.abc import Sequence
 from typing import Any
 
-from jobctrl import database as database_module
 from jobctrl.apply import launcher as launcher_module
 from jobctrl.domain.identifiers import canonical_job_id
-from jobctrl.infrastructure.scoring import collect_feedback_signals, rank_jobs_with_feedback
+from jobctrl.infrastructure.scoring import collect_feedback_signals
 
 _TENANT_A = "tenant-a"
 _TENANT_B = "tenant-b"
@@ -93,32 +92,25 @@ def test_feedback_signals_use_canonical_corrections_and_actions_transparently() 
     )
 
     signals = collect_feedback_signals(conn)
-    ranked = rank_jobs_with_feedback(
-        {
-            (_TENANT_A, str(_JOB_A)): 7.5,
-            (_TENANT_A, str(_JOB_B)): 8.0,
-        },
-        signals,
-    )
-
     assert [signal.kind for signal in signals] == [
         "score_correction",
         "StageSkipped",
     ]
-    assert (ranked[0].tenant_id, ranked[0].job_id) == (
+    assert (signals[0].tenant_id, signals[0].job_id) == (
         _TENANT_A,
         str(_JOB_A),
     )
-    assert ranked[0].feedback_adjustment > 0
-    assert "Better leadership fit" in ranked[0].evidence[0]
-    assert ranked[1].feedback_adjustment < 0
-    assert "Skipped after review" in ranked[1].evidence[0]
+    assert "Better leadership fit" in signals[0].evidence
+    assert (signals[1].tenant_id, signals[1].job_id) == (
+        _TENANT_A,
+        str(_JOB_B),
+    )
+    assert "Skipped after review" in signals[1].evidence
 
 
-def test_feedback_ordering_isolates_same_job_id_across_tenants() -> None:
+def test_feedback_history_isolates_same_job_id_across_tenants() -> None:
     conn = _connection()
     shared_job_id = str(_JOB_A)
-    shared_url = "https://example.com/shared"
     _insert_corrected_score(
         conn,
         tenant_id=_TENANT_A,
@@ -131,29 +123,9 @@ def test_feedback_ordering_isolates_same_job_id_across_tenants() -> None:
         """,
         (_TENANT_B, shared_job_id),
     )
-    rows = conn.execute(
-        """
-        SELECT ? AS tenant_id, ? AS job_id, ? AS url,
-               7.5 AS js_fit_score, NULL AS fit_score
-        UNION ALL
-        SELECT ?, ?, ?, 8.0, NULL
-        """,
-        (
-            _TENANT_A,
-            shared_job_id,
-            shared_url,
-            _TENANT_B,
-            shared_job_id,
-            shared_url,
-        ),
-    ).fetchall()
+    signals = collect_feedback_signals(conn)
 
-    ordered = database_module._order_rows_by_feedback(conn, rows)
-
-    assert [
-        (str(row["tenant_id"]), str(row["job_id"]))
-        for row in ordered
-    ] == [
+    assert [(signal.tenant_id, signal.job_id) for signal in signals] == [
         (_TENANT_A, shared_job_id),
         (_TENANT_B, shared_job_id),
     ]
@@ -171,7 +143,7 @@ class _RowsCursor:
 
 
 class _AcquireConnection:
-    """Delegate feedback reads while supplying the apply candidate projection."""
+    """Supply the Apply candidate projection to the acquisition boundary."""
 
     def __init__(
         self,
@@ -204,7 +176,7 @@ class _AcquireConnection:
         self._conn.rollback()
 
 
-def test_acquire_job_orders_multiple_candidates_by_canonical_feedback(
+def test_acquire_job_does_not_apply_unaccepted_feedback_to_candidate_order(
     monkeypatch,
 ) -> None:
     conn = _connection()
@@ -215,26 +187,26 @@ def test_acquire_job_orders_multiple_candidates_by_canonical_feedback(
     )
     candidates = conn.execute(
         """
-        SELECT ? AS tenant_id, ? AS job_id, 'https://example.com/a' AS url,
-               'A' AS title, 'example' AS site,
-               'https://example.com/a/apply' AS application_url,
-               '/tmp/a.txt' AS tailored_resume_path,
-               '/tmp/a.pdf' AS resume_pdf_path,
-               'artifact-a' AS resume_pdf_artifact_id,
-               1 AS materials_generation, 7.5 AS fit_score,
-               7.5 AS js_fit_score, NULL AS location, NULL AS description,
+        SELECT ? AS tenant_id, ? AS job_id, 'https://example.com/b' AS url,
+               'B' AS title, 'example' AS site,
+               'https://example.com/b/apply' AS application_url,
+               '/tmp/b.txt' AS tailored_resume_path,
+               '/tmp/b.pdf' AS resume_pdf_path,
+               'artifact-b' AS resume_pdf_artifact_id,
+               1 AS materials_generation, 8.0 AS fit_score,
+               8.0 AS js_fit_score, NULL AS location, NULL AS description,
                NULL AS full_description, NULL AS cover_letter_path,
                NULL AS applied_at, NULL AS apply_status, 0 AS apply_attempts
         UNION ALL
-        SELECT ?, ?, 'https://example.com/b', 'B', 'example',
-               'https://example.com/b/apply', '/tmp/b.txt', '/tmp/b.pdf',
-               'artifact-b', 1, 8.0, 8.0, NULL, NULL, NULL, NULL, NULL, NULL, 0
+        SELECT ?, ?, 'https://example.com/a', 'A', 'example',
+               'https://example.com/a/apply', '/tmp/a.txt', '/tmp/a.pdf',
+               'artifact-a', 1, 7.5, 7.5, NULL, NULL, NULL, NULL, NULL, NULL, 0
         """,
         (
             _TENANT_A,
-            str(_JOB_A),
-            _TENANT_A,
             str(_JOB_B),
+            _TENANT_A,
+            str(_JOB_A),
         ),
     ).fetchall()
     conn.commit()
@@ -262,5 +234,5 @@ def test_acquire_job_orders_multiple_candidates_by_canonical_feedback(
     assert selected is not None
     assert (selected["tenant_id"], selected["job_id"]) == (
         _TENANT_A,
-        str(_JOB_A),
+        str(_JOB_B),
     )


### PR DESCRIPTION
## Summary

- key score corrections and explicit action feedback by tenant-scoped canonical JobId
- preserve cross-tenant isolation even when posting URLs collide
- retain feedback as auditable source history without directly adjusting scores or reordering Apply candidates
- require the later explicit recommendation and accepted policy-revision flow before feedback can change behavior

## Why

Posting URLs are locators and cannot safely identify feedback across tenants. More importantly, canonical feedback history is evidence, not an implicit ranking policy: behavior changes only after an explicit policy revision is reviewed and accepted.

## Validation

- 3 focused scoring-feedback and Apply-acquisition tests passed
- focused Ruff checks and `git diff --check` passed
- independent Step 1 review: PASS, 0 Blocker / 0 High

## Stack

Ready-for-review child of #624 in GitHub Stack #632.

