### PR TITLE
refactor(storage): join selectors by canonical job id

### DIFF
--- a/workers/automation/src/jobctrl/database.py
+++ b/workers/automation/src/jobctrl/database.py
@@ -2999,14 +2999,9 @@ def _backfill_one_observation_row(
 
 
 # ---------------------------------------------------------------------------
-# job_enrichments read fragments — used by every selector / stat that
-# previously read bare ``jobs.full_description`` / ``jobs.application_url``
-# / ``jobs.detail_scraped_at`` / ``jobs.detail_error``. After Phase 7 the
-# canonical enrichment fields live in ``job_enrichments``; the legacy
-# ``jobs.*`` columns stay as a read-only fallback for un-backfilled rows.
-# Use these COALESCE expressions everywhere the old code read bare columns
-# so the worker queue selectors see new repository writes immediately and
-# don't starve.
+# job_enrichments read fragments — selectors and status counts derive
+# enrichment only from the canonical aggregate. Retired wide ``jobs``
+# columns must not affect v7 eligibility.
 # ---------------------------------------------------------------------------
 
 _ENRICHMENT_JOIN: str = (
@@ -3018,26 +3013,14 @@ _ENRICHMENT_JOIN: str = (
     "AND jss_enrich.stage = 'enrich'"
 )
 
-_EFFECTIVE_FULL_DESCRIPTION: str = "COALESCE(je.full_description, jobs.full_description)"
-_EFFECTIVE_APPLICATION_URL: str = "COALESCE(je.application_url, jobs.application_url)"
+_EFFECTIVE_FULL_DESCRIPTION: str = "je.full_description"
+_EFFECTIVE_APPLICATION_URL: str = "je.application_url"
 _EFFECTIVE_APPLY_TARGET_URL: str = (
     f"COALESCE(NULLIF({_EFFECTIVE_APPLICATION_URL}, ''), jobs.url)"
 )
-_EFFECTIVE_DETAIL_SCRAPED_AT: str = "COALESCE(je.enriched_at, jobs.detail_scraped_at)"
-# Per §7.1 the canonical "this job has been enriched" predicate is the
-# aggregate's terminal status; un-backfilled rows fall back to the legacy
-# detail_scraped_at column.
-_ENRICHMENT_DONE: str = "(je.current_status = 'enriched' OR jobs.detail_scraped_at IS NOT NULL)"
-# Phase 7 (S-26 round-1 review M3): the aggregate status is the primary
-# enrichment signal, but the live local DB can contain historical jobs with
-# legacy description columns and a canonical ``job_stage_states.enrich =
-# succeeded`` row before a ``job_enrichments`` aggregate exists. Those rows
-# must not be re-picked by runners, because the state machine correctly
-# rejects succeeded -> running. A reset clears the stage row back to pending,
-# so retries still work even when legacy detail columns remain populated.
 _ENRICHMENT_PENDING: str = (
     "(je.job_id IS NULL OR je.current_status = 'pending') "
-    "AND COALESCE(jss_enrich.state, CASE WHEN jobs.detail_scraped_at IS NOT NULL THEN 'succeeded' ELSE 'pending' END) = 'pending'"
+    "AND COALESCE(jss_enrich.state, 'pending') = 'pending'"
 )
 
 # Closed/removed posting states are Enrichment-owned facts, not user
@@ -3070,14 +3053,8 @@ _ENRICHMENT_NOT_QUARANTINED: str = (
 
 
 # ---------------------------------------------------------------------------
-# job_materials read fragments — used by the queue selectors that
-# previously read bare ``jobs.tailored_resume_path`` / ``cover_letter_path``.
-# After Phase 6 the canonical artifact paths live in ``job_materials_artifacts``
-# (latest generation per ``job_url``); the legacy ``jobs.*_path`` columns
-# stay as read-only fallback for historical rows that have no canonical
-# materials row. Once ``job_materials`` exists, approved artifacts are the
-# only active paths; suppressed artifacts must not fall through to legacy
-# columns left populated by the backfill.
+# job_materials read fragments — queue selectors derive material readiness
+# only from approved canonical artifacts.
 # ---------------------------------------------------------------------------
 
 # LEFT JOIN that surfaces the latest generation's tailored-resume and
@@ -3122,34 +3099,17 @@ _LATEST_MATERIALS_JOIN: str = (
     ") jm ON jm.jm_tenant_id = jobs.tenant_id AND jm.jm_job_id = jobs.job_id"
 )
 
-_EFFECTIVE_TAILOR_PATH: str = (
-    "CASE WHEN jm.jm_job_id IS NOT NULL THEN jm.jm_tailored_path "
-    "ELSE jobs.tailored_resume_path END"
-)
-_EFFECTIVE_COVER_PATH: str = (
-    "CASE WHEN jm.jm_job_id IS NOT NULL THEN jm.jm_cover_path "
-    "ELSE jobs.cover_letter_path END"
-)
+_EFFECTIVE_TAILOR_PATH: str = "jm.jm_tailored_path"
+_EFFECTIVE_COVER_PATH: str = "jm.jm_cover_path"
 _READY_TAILORED_RESUME_WITH_PDF: str = (
-    "((jm.jm_job_id IS NOT NULL "
-    "AND jm.jm_tailored_path IS NOT NULL AND jm.jm_tailored_path != '' "
-    "AND jm.jm_resume_pdf_path IS NOT NULL AND jm.jm_resume_pdf_path != '') "
-    "OR (jm.jm_job_id IS NULL "
-    "AND jobs.tailored_resume_path IS NOT NULL AND jobs.tailored_resume_path != ''))"
+    "(jm.jm_tailored_path IS NOT NULL AND jm.jm_tailored_path != '' "
+    "AND jm.jm_resume_pdf_path IS NOT NULL AND jm.jm_resume_pdf_path != '')"
 )
 
 
 # ---------------------------------------------------------------------------
-# job_stage_states attempt-counter read fragments — round-2 review H1.
-# After Phase 6 the new tailor / cover use cases never bump
-# ``jobs.tailor_attempts`` / ``jobs.cover_attempts``; the canonical attempt
-# counter advances on ``job_stage_states.attempt_count``. The bare-column
-# ``< 5`` predicate the queue selectors used would let exhausted jobs back
-# in indefinitely. ``_LATEST_STAGE_ATTEMPTS_JOIN`` surfaces the per-stage
-# attempt count + state so selectors can:
-#   * exclude tailor/cover jobs whose stage state is ``exhausted``
-#   * fall back to the legacy ``jobs.tailor_attempts`` / ``cover_attempts``
-#     for un-migrated rows.
+# job_stage_states attempt-counter read fragments. Stage state is the only
+# authority for retry limits and exhaustion.
 # ---------------------------------------------------------------------------
 
 _LATEST_STAGE_ATTEMPTS_JOIN: str = (
@@ -3167,20 +3127,13 @@ _LATEST_STAGE_ATTEMPTS_JOIN: str = (
     "AND jss_c.jss_c_job_id = jobs.job_id"
 )
 
-# COALESCE picks the canonical (job_stage_states) counter first, falling
-# back to the legacy column for un-migrated rows. ``state = 'exhausted'``
-# is the new exhaustion signal — tested separately below.
-_EFFECTIVE_TAILOR_ATTEMPTS: str = "COALESCE(jss_t.jss_t_attempts, jobs.tailor_attempts, 0)"
-_EFFECTIVE_COVER_ATTEMPTS: str = "COALESCE(jss_c.jss_c_attempts, jobs.cover_attempts, 0)"
+_EFFECTIVE_TAILOR_ATTEMPTS: str = "COALESCE(jss_t.jss_t_attempts, 0)"
+_EFFECTIVE_COVER_ATTEMPTS: str = "COALESCE(jss_c.jss_c_attempts, 0)"
 _TAILOR_NOT_EXHAUSTED: str = "(jss_t.jss_t_state IS NULL OR jss_t.jss_t_state != 'exhausted')"
 _COVER_NOT_EXHAUSTED: str = "(jss_c.jss_c_state IS NULL OR jss_c.jss_c_state != 'exhausted')"
 
 
-# Stale-score guard for downstream stages. Legacy rows can have a pending
-# score-stage row while their usable score still lives only in
-# ``jobs.fit_score``; those remain eligible unless explicitly stale or
-# carrying an unresolved marker. Once the usable score comes from
-# ``job_scores``, downstream work requires a succeeded score-stage row.
+# Stale-score guard for downstream stages.
 _SCORE_DOWNSTREAM_STATE_JOIN: str = (
     "LEFT JOIN ("
     "SELECT tenant_id AS jss_s_tenant_id, job_id AS jss_s_job_id, "
@@ -3210,15 +3163,8 @@ _EFFECTIVE_SCORE_ATTEMPTS: str = "COALESCE(jss_s.jss_s_attempts, 0)"
 
 
 # ---------------------------------------------------------------------------
-# job_scores read fragments — used by every selector / stat that previously
-# read bare ``jobs.fit_score``. After Phase 5 the canonical fit score lives
-# in ``job_scores`` (latest version per ``job_url``); the legacy
-# ``jobs.fit_score`` column stays as a read-only fallback for historical
-# rows that were never re-scored. ``_EFFECTIVE_FIT_SCORE`` is the COALESCE
-# expression every WHERE / ORDER BY / aggregate query should use instead of
-# bare ``fit_score`` so the worker queue selectors see new scores
-# immediately and don't re-pick already-scored jobs forever (round-1
-# review B1).
+# job_scores read fragments — selectors and status counts use the latest
+# canonical score aggregate.
 # ---------------------------------------------------------------------------
 
 _LATEST_SCORE_JOIN: str = (
@@ -3243,20 +3189,15 @@ _LATEST_SCORE_JOIN: str = (
     ") js ON js.js_tenant_id = jobs.tenant_id AND js.js_job_id = jobs.job_id"
 )
 
-_EFFECTIVE_FIT_SCORE: str = "COALESCE(js.js_fit_score, jobs.fit_score)"
+_EFFECTIVE_FIT_SCORE: str = "js.js_fit_score"
 _SCORE_ELIGIBLE_FOR_DOWNSTREAM: str = (
     "(COALESCE(js.js_eligibility_status, '') != 'blocked' AND COALESCE(js.js_hard_blocker_count, 0) = 0)"
 )
 
 
 # ---------------------------------------------------------------------------
-# Apply read-side (PR 4 of the Temporal stack). The bespoke
-# ``apply_runs`` table is gone; ``apply_run_projections`` (built from
-# ``job_events`` by the projection builder) is the canonical apply
-# lifecycle row. This LEFT JOIN promotes the latest projection row's
-# status / finished_at into the legacy column slots so queue selectors
-# (``pending_apply``, ``applied``) and ``get_stats`` see new writes
-# without re-deriving from events at every read site.
+# Apply read-side. ``apply_run_projections`` is the canonical apply
+# lifecycle row for selectors and status counts.
 # ---------------------------------------------------------------------------
 
 # Tie-break by run_id when two apply runs share the same ``started_at``.
@@ -3277,15 +3218,11 @@ _LATEST_APPLY_RUN_JOIN: str = (
     ") ar ON ar.ar_tenant_id = jobs.tenant_id AND ar.ar_job_id = jobs.job_id"
 )
 
-# Applied = any apply run with status='succeeded' for the job (we
-# COALESCE with the legacy column so historical rows stay visible).
-_EFFECTIVE_APPLIED_AT: str = "CASE WHEN ar.ar_status = 'succeeded' THEN ar.ar_finished_at ELSE jobs.applied_at END"
+# Applied = any latest apply run with status='succeeded' for the job.
+_EFFECTIVE_APPLIED_AT: str = "CASE WHEN ar.ar_status = 'succeeded' THEN ar.ar_finished_at END"
 
-# Apply status string suitable for read-model consumption — collapses
-# ``starting`` / ``in_progress`` into the historical ``in_progress``
-# label so callers needn't relearn the labels.
+# Apply status string suitable for read-model consumption.
 _EFFECTIVE_APPLY_STATUS: str = (
-    "COALESCE("
     "CASE ar.ar_status "
     "WHEN 'starting' THEN 'in_progress' "
     "WHEN 'in_progress' THEN 'in_progress' "
@@ -3296,8 +3233,7 @@ _EFFECTIVE_APPLY_STATUS: str = (
     "WHEN 'expired' THEN 'expired' "
     "WHEN 'manual' THEN 'manual' "
     "WHEN 'dry_run_complete' THEN 'dry_run' "
-    "ELSE NULL END, "
-    "jobs.apply_status)"
+    "ELSE NULL END"
 )
 
 
@@ -3339,10 +3275,7 @@ def get_stats(conn: sqlite3.Connection | None = None) -> dict:
     rows = conn.execute("SELECT site, COUNT(*) as cnt FROM jobs GROUP BY site ORDER BY cnt DESC").fetchall()
     stats["by_site"] = [(row[0], row[1]) for row in rows]
 
-    # Enrichment stage — Phase 7 (S-26): read through the
-    # ``job_enrichments`` join so dashboard counts reflect new
-    # JobEnrichment writes (jobs.full_description / jobs.application_url
-    # are NULL on the new path).
+    # Enrichment stage — derive dashboard counts from JobEnrichment.
     stats["pending_detail"] = conn.execute(
         f"SELECT COUNT(*) FROM jobs {_ENRICHMENT_JOIN} WHERE {_ENRICHMENT_PENDING}"
     ).fetchone()[0]
@@ -3353,13 +3286,10 @@ def get_stats(conn: sqlite3.Connection | None = None) -> dict:
 
     stats["detail_errors"] = conn.execute(
         f"SELECT COUNT(*) FROM jobs {_ENRICHMENT_JOIN} "
-        f"WHERE je.current_status = 'failed' OR jobs.detail_error IS NOT NULL"
+        "WHERE je.current_status = 'failed'"
     ).fetchone()[0]
 
-    # Scoring stage — round-1 review B2: read through the same job_scores
-    # LEFT JOIN that the worker queue selectors use, so dashboard stats
-    # reflect new scores written through ScoreRepository (jobs.fit_score is
-    # now NULL on the new path).
+    # Scoring stage — use the same canonical score join as worker queues.
     stats["scored"] = conn.execute(
         f"SELECT COUNT(*) FROM jobs {_LATEST_SCORE_JOIN} WHERE {_EFFECTIVE_FIT_SCORE} IS NOT NULL"
     ).fetchone()[0]
@@ -3370,8 +3300,7 @@ def get_stats(conn: sqlite3.Connection | None = None) -> dict:
         f"AND {_EFFECTIVE_FIT_SCORE} IS NULL"
     ).fetchone()[0]
 
-    # Score distribution — group by the effective score so legacy and new
-    # rows fold into the same buckets.
+    # Score distribution — group by the latest canonical score.
     dist_rows = conn.execute(
         f"SELECT {_EFFECTIVE_FIT_SCORE} AS effective_score, COUNT(*) AS cnt "
         f"FROM jobs {_LATEST_SCORE_JOIN} "
@@ -3380,12 +3309,8 @@ def get_stats(conn: sqlite3.Connection | None = None) -> dict:
     ).fetchall()
     stats["score_distribution"] = [(row[0], row[1]) for row in dist_rows]
 
-    # Tailoring + cover letter stages — round-2 review B2: read through the
-    # same materials + stage-attempts joins the worker queue selectors use,
-    # so dashboard counts reflect new MaterialsSet writes (jobs.*_path is
-    # NULL on the new path) AND honour the new attempt-counter / exhaustion
-    # signal that lives in ``job_stage_states``. Without these joins the
-    # dashboard would freeze at the backfill snapshot value.
+    # Tailoring + cover letter stages — material status and attempt limits
+    # come from canonical artifacts and job stage state.
     stats["tailored"] = conn.execute(
         f"SELECT COUNT(*) FROM jobs {_LATEST_MATERIALS_JOIN} WHERE {_EFFECTIVE_TAILOR_PATH} IS NOT NULL"
     ).fetchone()[0]
@@ -3417,9 +3342,7 @@ def get_stats(conn: sqlite3.Connection | None = None) -> dict:
         f"AND ({_EFFECTIVE_COVER_ATTEMPTS} >= 5 OR jss_c.jss_c_state = 'exhausted')"
     ).fetchone()[0]
 
-    # Application stage (PR 4) — read through the ``apply_run_projections``
-    # join so dashboard counts reflect lifecycle events (jobs.applied_at /
-    # apply_status / apply_error are NULL on the new write path).
+    # Application stage — status comes from apply-run projections.
     stats["applied"] = conn.execute(
         f"SELECT COUNT(*) FROM jobs {_LATEST_APPLY_RUN_JOIN} {_ACTIVE_STATE_JOIN} "
         f"WHERE {_EFFECTIVE_APPLIED_AT} IS NOT NULL "
@@ -3428,8 +3351,7 @@ def get_stats(conn: sqlite3.Connection | None = None) -> dict:
 
     stats["apply_errors"] = conn.execute(
         f"SELECT COUNT(*) FROM jobs {_LATEST_APPLY_RUN_JOIN} {_ACTIVE_STATE_JOIN} "
-        f"WHERE (ar.ar_status IN ('failed', 'captcha', 'login_issue', 'expired') "
-        f"OR jobs.apply_error IS NOT NULL) "
+        "WHERE ar.ar_status IN ('failed', 'captcha', 'login_issue', 'expired') "
         f"AND {_NOT_CLOSED_ACTIVE_STATE}"
     ).fetchone()[0]
 
@@ -3675,12 +3597,9 @@ def load_job_with_enrichment(
     je_at = record.pop("je_enriched_at", None)
     record.pop("je_current_status", None)
     record.pop("je_extraction_tier", None)
-    if je_full is not None:
-        record["full_description"] = je_full
-    if je_app is not None:
-        record["application_url"] = je_app
-    if je_at is not None:
-        record["detail_scraped_at"] = je_at
+    record["full_description"] = je_full
+    record["application_url"] = je_app
+    record["detail_scraped_at"] = je_at
     # PR 4 of the Temporal stack: promote ``apply_run_projections``
     # columns into the legacy column slots.
     record.pop("ar_status", None)
@@ -3688,12 +3607,9 @@ def load_job_with_enrichment(
     ar_applied = record.pop("effective_applied_at", None)
     ar_status = record.pop("effective_apply_status", None)
     ar_run_id = record.pop("ar_run_id", None)
-    if ar_applied is not None:
-        record["applied_at"] = ar_applied
-    if ar_status is not None:
-        record["apply_status"] = ar_status
-    if ar_run_id is not None:
-        record["apply_task_id"] = ar_run_id
+    record["applied_at"] = ar_applied
+    record["apply_status"] = ar_status
+    record["apply_task_id"] = ar_run_id
     return record
 
 
@@ -3724,37 +3640,8 @@ def get_jobs_by_stage(
     if stage in ("pending_tailor", "pending_cover"):
         min_score = effective_tailoring_min_score(min_score)
 
-    # Round-1 review B1: every predicate that historically read bare
-    # ``fit_score`` now reads through ``_EFFECTIVE_FIT_SCORE`` (COALESCE
-    # over the latest job_scores row + legacy column). New scores written
-    # via ``ScoreRepository.save`` leave ``jobs.fit_score`` NULL, so without
-    # this LEFT JOIN ``pending_score`` would loop forever and
-    # ``pending_tailor`` / ``pending_cover`` would starve.
-    #
-    # Phase 6 (S-20) extends the same pattern to the Materials Generation
-    # context: ``_EFFECTIVE_TAILOR_PATH`` / ``_EFFECTIVE_COVER_PATH`` read
-    # through the latest ``job_materials_artifacts`` generation, with the
-    # legacy ``jobs.tailored_resume_path`` / ``jobs.cover_letter_path``
-    # columns as a read-only fallback for un-backfilled rows. New tailor
-    # / cover writes go ONLY to ``job_materials`` (no-strangler) so this
-    # join is what keeps the pipeline observable.
-    # Round-2 review H1: drop the bare ``tailor_attempts < 5`` /
-    # ``cover_attempts < 5`` predicates. New code never bumps those columns;
-    # the canonical attempt + exhaustion signals live in
-    # ``job_stage_states`` (state='exhausted' when the runner gives up).
-    # We exclude exhausted jobs via ``_TAILOR_NOT_EXHAUSTED`` /
-    # ``_COVER_NOT_EXHAUSTED`` and fold the legacy ``tailor_attempts`` /
-    # ``cover_attempts`` columns through ``_EFFECTIVE_*_ATTEMPTS`` so
-    # un-migrated rows that never got a ``job_stage_states`` row still
-    # honour the legacy ≥ 5 cap.
-    # Phase 7 (S-26): every predicate that historically read bare
-    # ``full_description`` / ``application_url`` / ``detail_scraped_at``
-    # / ``detail_error`` now reads through the ``_EFFECTIVE_*`` COALESCE
-    # expressions backed by the ``job_enrichments`` table. New
-    # enrichment writes target ``job_enrichments`` only (no-strangler);
-    # without this join ``pending_score`` would loop forever (description
-    # column stays NULL on the new path) and ``pending_detail`` would
-    # double-pick already-enriched jobs.
+    # Queue predicates derive score, material, retry, enrichment, and apply
+    # state only from their canonical v7 aggregate or projection.
     pending_tailor_where = (
         f"{_EFFECTIVE_FIT_SCORE} >= ? AND {_EFFECTIVE_FULL_DESCRIPTION} IS NOT NULL "
         f"AND {_SCORE_ELIGIBLE_FOR_DOWNSTREAM} "
@@ -3896,18 +3783,16 @@ def get_jobs_by_stage(
     for row in rows:
         record = dict(zip(columns, row))
         js_value = record.pop("js_fit_score", None)
-        if js_value is not None:
-            record["fit_score"] = js_value
-        jm_job_id = record.pop("jm_job_id", None)
+        record["fit_score"] = js_value
+        record.pop("jm_job_id", None)
         jm_tailored = record.pop("jm_tailored_path", None)
         jm_tailored_at = record.pop("jm_tailored_at", None)
         jm_cover = record.pop("jm_cover_path", None)
         jm_cover_at = record.pop("jm_cover_at", None)
-        if jm_job_id is not None:
-            record["tailored_resume_path"] = jm_tailored
-            record["tailored_at"] = jm_tailored_at
-            record["cover_letter_path"] = jm_cover
-            record["cover_letter_at"] = jm_cover_at
+        record["tailored_resume_path"] = jm_tailored
+        record["tailored_at"] = jm_tailored_at
+        record["cover_letter_path"] = jm_cover
+        record["cover_letter_at"] = jm_cover_at
         # Phase 7 (S-26): promote enrichment fields from job_enrichments
         # into the legacy column slots so downstream consumers (apply,
         # scoring, tailor) that still read ``full_description`` /
@@ -3918,12 +3803,9 @@ def get_jobs_by_stage(
         je_at = record.pop("je_enriched_at", None)
         record.pop("je_current_status", None)
         record.pop("je_extraction_tier", None)
-        if je_full is not None:
-            record["full_description"] = je_full
-        if je_app is not None:
-            record["application_url"] = je_app
-        if je_at is not None:
-            record["detail_scraped_at"] = je_at
+        record["full_description"] = je_full
+        record["application_url"] = je_app
+        record["detail_scraped_at"] = je_at
         # PR 4 of the Temporal stack: promote ``apply_run_projections``
         # columns into the legacy column slots so consumers (TS
         # read-model, Rich dashboard, legacy CLI) that still read
@@ -3934,11 +3816,8 @@ def get_jobs_by_stage(
         record.pop("ar_status", None)
         record.pop("ar_finished_at", None)
         ar_run_id = record.pop("ar_run_id", None)
-        if ar_applied is not None:
-            record["applied_at"] = ar_applied
-        if ar_status is not None:
-            record["apply_status"] = ar_status
-        if ar_run_id is not None:
-            record["apply_task_id"] = ar_run_id
+        record["applied_at"] = ar_applied
+        record["apply_status"] = ar_status
+        record["apply_task_id"] = ar_run_id
         out.append(record)
     return out

--- a/workers/automation/src/jobctrl/database.py
+++ b/workers/automation/src/jobctrl/database.py
@@ -3010,9 +3010,12 @@ def _backfill_one_observation_row(
 # ---------------------------------------------------------------------------
 
 _ENRICHMENT_JOIN: str = (
-    "LEFT JOIN job_enrichments je ON je.job_url = jobs.url "
+    "LEFT JOIN job_enrichments je "
+    "ON je.tenant_id = jobs.tenant_id AND je.job_id = jobs.job_id "
     "LEFT JOIN job_stage_states jss_enrich "
-    "ON jss_enrich.job_url = jobs.url AND jss_enrich.stage = 'enrich'"
+    "ON jss_enrich.tenant_id = jobs.tenant_id "
+    "AND jss_enrich.job_id = jobs.job_id "
+    "AND jss_enrich.stage = 'enrich'"
 )
 
 _EFFECTIVE_FULL_DESCRIPTION: str = "COALESCE(je.full_description, jobs.full_description)"
@@ -3033,7 +3036,7 @@ _ENRICHMENT_DONE: str = "(je.current_status = 'enriched' OR jobs.detail_scraped_
 # rejects succeeded -> running. A reset clears the stage row back to pending,
 # so retries still work even when legacy detail columns remain populated.
 _ENRICHMENT_PENDING: str = (
-    "(je.job_url IS NULL OR je.current_status = 'pending') "
+    "(je.job_id IS NULL OR je.current_status = 'pending') "
     "AND COALESCE(jss_enrich.state, CASE WHEN jobs.detail_scraped_at IS NOT NULL THEN 'succeeded' ELSE 'pending' END) = 'pending'"
 )
 
@@ -3043,7 +3046,7 @@ _ENRICHMENT_PENDING: str = (
 _CLOSED_ACTIVE_STATES_SQL = "'closed', 'expired', 'removed', 'location_incompatible'"
 _ACTIVE_STATE_JOIN: str = (
     "LEFT JOIN posting_snapshot_sets pss "
-    "ON pss.tenant_id = 'local' AND pss.job_url = jobs.url"
+    "ON pss.tenant_id = jobs.tenant_id AND pss.job_id = jobs.job_id"
 )
 _NOT_CLOSED_ACTIVE_STATE: str = (
     f"(pss.latest_active_state IS NULL OR pss.latest_active_state NOT IN ({_CLOSED_ACTIVE_STATES_SQL}))"
@@ -3081,50 +3084,57 @@ _ENRICHMENT_NOT_QUARANTINED: str = (
 # cover-letter artifact paths under fixed aliases.
 _LATEST_MATERIALS_JOIN: str = (
     "LEFT JOIN ("
-    "SELECT history.job_url AS jm_job_url, latest.max_generation AS jm_generation, "
+    "SELECT history.tenant_id AS jm_tenant_id, history.job_id AS jm_job_id, "
+    "latest.max_generation AS jm_generation, "
     "m.status AS jm_status, "
     "tr.path AS jm_tailored_path, tr.created_at AS jm_tailored_at, "
     "cl.path AS jm_cover_path, cl.created_at AS jm_cover_at, "
     "rpdf.path AS jm_resume_pdf_path, rpdf.artifact_id AS jm_resume_pdf_artifact_id, "
     "cpdf.path AS jm_cover_pdf_path "
-    "FROM (SELECT DISTINCT job_url FROM job_materials) history "
+    "FROM (SELECT DISTINCT tenant_id, job_id FROM job_materials) history "
     "LEFT JOIN ("
-    "SELECT job_url, MAX(generation) AS max_generation "
+    "SELECT tenant_id, job_id, MAX(generation) AS max_generation "
     "FROM job_materials_artifacts "
     "WHERE status = 'approved' "
     "AND artifact_type IN ('tailored_resume', 'cover_letter', 'resume_pdf', 'cover_letter_pdf') "
-    "GROUP BY job_url"
-    ") latest ON latest.job_url = history.job_url "
+    "GROUP BY tenant_id, job_id"
+    ") latest ON latest.tenant_id = history.tenant_id "
+    "AND latest.job_id = history.job_id "
     "LEFT JOIN job_materials m "
-    "ON m.job_url = history.job_url AND m.generation = latest.max_generation "
+    "ON m.tenant_id = history.tenant_id AND m.job_id = history.job_id "
+    "AND m.generation = latest.max_generation "
     "LEFT JOIN job_materials_artifacts tr "
-    "ON tr.job_url = history.job_url AND tr.generation = latest.max_generation "
+    "ON tr.tenant_id = history.tenant_id AND tr.job_id = history.job_id "
+    "AND tr.generation = latest.max_generation "
     "AND tr.artifact_type = 'tailored_resume' AND tr.status = 'approved' "
     "LEFT JOIN job_materials_artifacts cl "
-    "ON cl.job_url = history.job_url AND cl.generation = latest.max_generation "
+    "ON cl.tenant_id = history.tenant_id AND cl.job_id = history.job_id "
+    "AND cl.generation = latest.max_generation "
     "AND cl.artifact_type = 'cover_letter' AND cl.status = 'approved' "
     "LEFT JOIN job_materials_artifacts rpdf "
-    "ON rpdf.job_url = history.job_url AND rpdf.generation = latest.max_generation "
+    "ON rpdf.tenant_id = history.tenant_id AND rpdf.job_id = history.job_id "
+    "AND rpdf.generation = latest.max_generation "
     "AND rpdf.artifact_type = 'resume_pdf' AND rpdf.status = 'approved' "
     "LEFT JOIN job_materials_artifacts cpdf "
-    "ON cpdf.job_url = history.job_url AND cpdf.generation = latest.max_generation "
+    "ON cpdf.tenant_id = history.tenant_id AND cpdf.job_id = history.job_id "
+    "AND cpdf.generation = latest.max_generation "
     "AND cpdf.artifact_type = 'cover_letter_pdf' AND cpdf.status = 'approved'"
-    ") jm ON jm.jm_job_url = jobs.url"
+    ") jm ON jm.jm_tenant_id = jobs.tenant_id AND jm.jm_job_id = jobs.job_id"
 )
 
 _EFFECTIVE_TAILOR_PATH: str = (
-    "CASE WHEN jm.jm_job_url IS NOT NULL THEN jm.jm_tailored_path "
+    "CASE WHEN jm.jm_job_id IS NOT NULL THEN jm.jm_tailored_path "
     "ELSE jobs.tailored_resume_path END"
 )
 _EFFECTIVE_COVER_PATH: str = (
-    "CASE WHEN jm.jm_job_url IS NOT NULL THEN jm.jm_cover_path "
+    "CASE WHEN jm.jm_job_id IS NOT NULL THEN jm.jm_cover_path "
     "ELSE jobs.cover_letter_path END"
 )
 _READY_TAILORED_RESUME_WITH_PDF: str = (
-    "((jm.jm_job_url IS NOT NULL "
+    "((jm.jm_job_id IS NOT NULL "
     "AND jm.jm_tailored_path IS NOT NULL AND jm.jm_tailored_path != '' "
     "AND jm.jm_resume_pdf_path IS NOT NULL AND jm.jm_resume_pdf_path != '') "
-    "OR (jm.jm_job_url IS NULL "
+    "OR (jm.jm_job_id IS NULL "
     "AND jobs.tailored_resume_path IS NOT NULL AND jobs.tailored_resume_path != ''))"
 )
 
@@ -3144,13 +3154,17 @@ _READY_TAILORED_RESUME_WITH_PDF: str = (
 
 _LATEST_STAGE_ATTEMPTS_JOIN: str = (
     "LEFT JOIN ("
-    "SELECT job_url AS jss_t_job_url, attempt_count AS jss_t_attempts, state AS jss_t_state "
+    "SELECT tenant_id AS jss_t_tenant_id, job_id AS jss_t_job_id, "
+    "attempt_count AS jss_t_attempts, state AS jss_t_state "
     "FROM job_stage_states WHERE stage = 'tailor'"
-    ") jss_t ON jss_t.jss_t_job_url = jobs.url "
+    ") jss_t ON jss_t.jss_t_tenant_id = jobs.tenant_id "
+    "AND jss_t.jss_t_job_id = jobs.job_id "
     "LEFT JOIN ("
-    "SELECT job_url AS jss_c_job_url, attempt_count AS jss_c_attempts, state AS jss_c_state "
+    "SELECT tenant_id AS jss_c_tenant_id, job_id AS jss_c_job_id, "
+    "attempt_count AS jss_c_attempts, state AS jss_c_state "
     "FROM job_stage_states WHERE stage = 'cover'"
-    ") jss_c ON jss_c.jss_c_job_url = jobs.url"
+    ") jss_c ON jss_c.jss_c_tenant_id = jobs.tenant_id "
+    "AND jss_c.jss_c_job_id = jobs.job_id"
 )
 
 # COALESCE picks the canonical (job_stage_states) counter first, falling
@@ -3169,17 +3183,20 @@ _COVER_NOT_EXHAUSTED: str = "(jss_c.jss_c_state IS NULL OR jss_c.jss_c_state != 
 # ``job_scores``, downstream work requires a succeeded score-stage row.
 _SCORE_DOWNSTREAM_STATE_JOIN: str = (
     "LEFT JOIN ("
-    "SELECT job_url AS jss_s_job_url, state AS jss_s_state, "
+    "SELECT tenant_id AS jss_s_tenant_id, job_id AS jss_s_job_id, "
+    "state AS jss_s_state, "
     "attempt_count AS jss_s_attempts "
     "FROM job_stage_states WHERE stage = 'score'"
-    ") jss_s ON jss_s.jss_s_job_url = jobs.url "
+    ") jss_s ON jss_s.jss_s_tenant_id = jobs.tenant_id "
+    "AND jss_s.jss_s_job_id = jobs.job_id "
     "LEFT JOIN ("
-    "SELECT DISTINCT job_url AS jss_stale_job_url "
+    "SELECT DISTINCT tenant_id AS jss_stale_tenant_id, job_id AS jss_stale_job_id "
     "FROM job_score_staleness WHERE resolved = 0"
-    ") jss_stale ON jss_stale.jss_stale_job_url = jobs.url"
+    ") jss_stale ON jss_stale.jss_stale_tenant_id = jobs.tenant_id "
+    "AND jss_stale.jss_stale_job_id = jobs.job_id"
 )
 _SCORE_CURRENT_FOR_DOWNSTREAM: str = (
-    "(jss_stale.jss_stale_job_url IS NULL "
+    "(jss_stale.jss_stale_job_id IS NULL "
     "AND (jss_s.jss_s_state IS NULL "
     "OR jss_s.jss_s_state = 'succeeded' "
     "OR (js.js_fit_score IS NULL AND jss_s.jss_s_state != 'stale')))"
@@ -3206,7 +3223,8 @@ _EFFECTIVE_SCORE_ATTEMPTS: str = "COALESCE(jss_s.jss_s_attempts, 0)"
 
 _LATEST_SCORE_JOIN: str = (
     "LEFT JOIN ("
-    "SELECT s.job_url AS js_job_url, s.fit_score AS js_fit_score, "
+    "SELECT s.tenant_id AS js_tenant_id, s.job_id AS js_job_id, "
+    "s.fit_score AS js_fit_score, "
     "CASE WHEN json_valid(s.breakdown_json) "
     "THEN LOWER(COALESCE(CAST(json_extract(s.breakdown_json, '$.eligibility.status') AS TEXT), '')) "
     "ELSE '' END AS js_eligibility_status, "
@@ -3218,9 +3236,11 @@ _LATEST_SCORE_JOIN: str = (
     "0) ELSE 0 END AS js_hard_blocker_count "
     "FROM job_scores s "
     "INNER JOIN ("
-    "SELECT job_url, MAX(version) AS max_version FROM job_scores GROUP BY job_url"
-    ") latest ON latest.job_url = s.job_url AND latest.max_version = s.version"
-    ") js ON js.js_job_url = jobs.url"
+    "SELECT tenant_id, job_id, MAX(version) AS max_version "
+    "FROM job_scores GROUP BY tenant_id, job_id"
+    ") latest ON latest.tenant_id = s.tenant_id AND latest.job_id = s.job_id "
+    "AND latest.max_version = s.version"
+    ") js ON js.js_tenant_id = jobs.tenant_id AND js.js_job_id = jobs.job_id"
 )
 
 _EFFECTIVE_FIT_SCORE: str = "COALESCE(js.js_fit_score, jobs.fit_score)"
@@ -3242,17 +3262,19 @@ _SCORE_ELIGIBLE_FOR_DOWNSTREAM: str = (
 # Tie-break by run_id when two apply runs share the same ``started_at``.
 _LATEST_APPLY_RUN_JOIN: str = (
     "LEFT JOIN ("
-    "SELECT ar.job_id AS ar_job_url, ar.status AS ar_status, "
+    "SELECT ar.tenant_id AS ar_tenant_id, ar.job_id AS ar_job_id, "
+    "ar.status AS ar_status, "
     "ar.result AS ar_result, ar.finished_at AS ar_finished_at, "
     "ar.started_at AS ar_started_at, ar.run_id AS ar_run_id "
     "FROM apply_run_projections ar "
     "WHERE ar.run_id = ("
     "SELECT run_id FROM apply_run_projections ar_inner "
-    "WHERE ar_inner.job_id = ar.job_id "
+    "WHERE ar_inner.tenant_id = ar.tenant_id "
+    "AND ar_inner.job_id = ar.job_id "
     "ORDER BY ar_inner.started_at DESC, ar_inner.run_id DESC "
     "LIMIT 1"
     ")"
-    ") ar ON ar.ar_job_url = jobs.url"
+    ") ar ON ar.ar_tenant_id = jobs.tenant_id AND ar.ar_job_id = jobs.job_id"
 )
 
 # Applied = any apply run with status='succeeded' for the job (we
@@ -3455,13 +3477,16 @@ def count_ready_to_apply(
         _ENRICHMENT_NOT_QUARANTINED,
         "NOT EXISTS ("
         "SELECT 1 FROM job_stage_states jss_active "
-        "WHERE jss_active.job_url = jobs.url "
+        "WHERE jss_active.tenant_id = jobs.tenant_id "
+        "AND jss_active.job_id = jobs.job_id "
         "AND jss_active.stage = 'apply' "
         "AND jss_active.state IN ('running', 'succeeded')"
         ")",
         "COALESCE(("
         "SELECT jss_a.attempt_count FROM job_stage_states jss_a "
-        "WHERE jss_a.job_url = jobs.url AND jss_a.stage = 'apply' LIMIT 1"
+        "WHERE jss_a.tenant_id = jobs.tenant_id "
+        "AND jss_a.job_id = jobs.job_id "
+        "AND jss_a.stage = 'apply' LIMIT 1"
         "), 0) < ?",
         "(ar.ar_status IS NULL OR ar.ar_status NOT IN ('starting', 'in_progress'))",
     ]
@@ -3826,7 +3851,7 @@ def get_jobs_by_stage(
     # round-trip through the repository.
     query = (
         f"SELECT jobs.*, js.js_fit_score AS js_fit_score, "
-        f"jm.jm_job_url AS jm_job_url, "
+        f"jm.jm_job_id AS jm_job_id, "
         f"jm.jm_tailored_path AS jm_tailored_path, "
         f"jm.jm_tailored_at AS jm_tailored_at, "
         f"jm.jm_cover_path AS jm_cover_path, "
@@ -3873,12 +3898,12 @@ def get_jobs_by_stage(
         js_value = record.pop("js_fit_score", None)
         if js_value is not None:
             record["fit_score"] = js_value
-        jm_job_url = record.pop("jm_job_url", None)
+        jm_job_id = record.pop("jm_job_id", None)
         jm_tailored = record.pop("jm_tailored_path", None)
         jm_tailored_at = record.pop("jm_tailored_at", None)
         jm_cover = record.pop("jm_cover_path", None)
         jm_cover_at = record.pop("jm_cover_at", None)
-        if jm_job_url is not None:
+        if jm_job_id is not None:
             record["tailored_resume_path"] = jm_tailored
             record["tailored_at"] = jm_tailored_at
             record["cover_letter_path"] = jm_cover

--- a/workers/automation/tests/test_exact_v7_selector_job_identity.py
+++ b/workers/automation/tests/test_exact_v7_selector_job_identity.py
@@ -1,0 +1,260 @@
+"""Exact-v7 selector identity regressions.
+
+The runtime returns URLs as locators, but selector joins must use the
+tenant-scoped canonical job_id. These fixtures deliberately give two tenants
+the same URL to prove no queue state crosses the aggregate boundary.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from jobctrl.database import count_ready_to_apply, get_jobs_by_stage, init_db
+
+
+LOCAL_TENANT = "local"
+OTHER_TENANT = "other"
+SHARED_URL = "https://example.test/jobs/shared"
+TIMESTAMP = "2026-07-31T12:00:00+00:00"
+LOCAL_JOB_ID = "90000000-0000-4000-8000-000000000001"
+OTHER_JOB_ID = "90000000-0000-4000-8000-000000000002"
+
+
+@pytest.fixture()
+def conn(tmp_path: Path) -> sqlite3.Connection:
+    return init_db(tmp_path / "jobctrl.db")
+
+
+def _insert_job(conn: sqlite3.Connection, tenant_id: str, job_id: str) -> None:
+    conn.execute(
+        """
+        INSERT INTO jobs (
+            tenant_id, job_id, url, title, site, discovered_at
+        ) VALUES (?, ?, ?, 'Engineer', 'Example', ?)
+        """,
+        (tenant_id, job_id, SHARED_URL, TIMESTAMP),
+    )
+
+
+def _insert_enrichment(
+    conn: sqlite3.Connection,
+    tenant_id: str,
+    job_id: str,
+    *,
+    status: str = "enriched",
+    description: str | None = "Build reliable systems.",
+    application_url: str | None = None,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO job_enrichments (
+            tenant_id, job_id, current_status, full_description,
+            application_url, updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?)
+        """,
+        (tenant_id, job_id, status, description, application_url, TIMESTAMP),
+    )
+
+
+def _insert_score(
+    conn: sqlite3.Connection,
+    tenant_id: str,
+    job_id: str,
+    *,
+    fit_score: int = 9,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO job_scores (
+            tenant_id, job_id, version, fit_score, breakdown_json,
+            keywords_json, scored_at
+        ) VALUES (?, ?, 1, ?, '{}', '[]', ?)
+        """,
+        (tenant_id, job_id, fit_score, TIMESTAMP),
+    )
+
+
+def _insert_materials(
+    conn: sqlite3.Connection,
+    tenant_id: str,
+    job_id: str,
+    *,
+    artifact_types: tuple[str, ...],
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO job_materials (
+            tenant_id, job_id, generation, status, created_at, updated_at
+        ) VALUES (?, ?, 1, 'approved', ?, ?)
+        """,
+        (tenant_id, job_id, TIMESTAMP, TIMESTAMP),
+    )
+    for artifact_type in artifact_types:
+        conn.execute(
+            """
+            INSERT INTO job_materials_artifacts (
+                tenant_id, job_id, generation, artifact_type, artifact_id,
+                status, path, render_format, created_at
+            ) VALUES (?, ?, 1, ?, ?, 'approved', ?, 'text', ?)
+            """,
+            (
+                tenant_id,
+                job_id,
+                artifact_type,
+                f"{job_id}:{artifact_type}",
+                f"/tmp/{job_id}-{artifact_type}",
+                TIMESTAMP,
+            ),
+        )
+
+
+def _identities(rows: list[dict]) -> set[tuple[str, str, str]]:
+    return {(row["tenant_id"], row["job_id"], row["url"]) for row in rows}
+
+
+def test_pending_score_uses_exact_v7_identity_for_enrichment_and_scores(
+    conn: sqlite3.Connection,
+) -> None:
+    _insert_job(conn, LOCAL_TENANT, LOCAL_JOB_ID)
+    _insert_job(conn, OTHER_TENANT, OTHER_JOB_ID)
+    _insert_enrichment(conn, LOCAL_TENANT, LOCAL_JOB_ID)
+    _insert_enrichment(
+        conn,
+        OTHER_TENANT,
+        OTHER_JOB_ID,
+        status="pending",
+        description=None,
+    )
+    _insert_score(conn, OTHER_TENANT, OTHER_JOB_ID)
+    conn.commit()
+
+    assert _identities(get_jobs_by_stage(conn, "pending_score")) == {
+        (LOCAL_TENANT, LOCAL_JOB_ID, SHARED_URL)
+    }
+
+
+def test_pending_detail_uses_exact_v7_enrichment_identity(
+    conn: sqlite3.Connection,
+) -> None:
+    _insert_job(conn, LOCAL_TENANT, LOCAL_JOB_ID)
+    _insert_job(conn, OTHER_TENANT, OTHER_JOB_ID)
+    _insert_enrichment(conn, OTHER_TENANT, OTHER_JOB_ID)
+    conn.commit()
+
+    assert _identities(get_jobs_by_stage(conn, "pending_detail")) == {
+        (LOCAL_TENANT, LOCAL_JOB_ID, SHARED_URL)
+    }
+
+
+def test_pending_tailor_does_not_cross_tenant_materials_or_stage_state(
+    conn: sqlite3.Connection,
+) -> None:
+    _insert_job(conn, LOCAL_TENANT, LOCAL_JOB_ID)
+    _insert_job(conn, OTHER_TENANT, OTHER_JOB_ID)
+    _insert_enrichment(conn, LOCAL_TENANT, LOCAL_JOB_ID)
+    _insert_enrichment(conn, OTHER_TENANT, OTHER_JOB_ID)
+    _insert_score(conn, LOCAL_TENANT, LOCAL_JOB_ID)
+    _insert_score(conn, OTHER_TENANT, OTHER_JOB_ID)
+    _insert_materials(
+        conn,
+        OTHER_TENANT,
+        OTHER_JOB_ID,
+        artifact_types=("tailored_resume",),
+    )
+    conn.execute(
+        """
+        INSERT INTO job_stage_states (
+            tenant_id, job_id, stage, state, attempt_count, updated_at
+        ) VALUES (?, ?, 'tailor', 'exhausted', 5, ?)
+        """,
+        (OTHER_TENANT, OTHER_JOB_ID, TIMESTAMP),
+    )
+    conn.execute(
+        """
+        INSERT INTO job_score_staleness (
+            tenant_id, job_id, stale_reason, old_policy_version,
+            new_policy_version, marked_at
+        ) VALUES (?, ?, 'policy_changed', 1, 2, ?)
+        """,
+        (OTHER_TENANT, OTHER_JOB_ID, TIMESTAMP),
+    )
+    conn.commit()
+
+    assert _identities(get_jobs_by_stage(conn, "pending_tailor", min_score=7)) == {
+        (LOCAL_TENANT, LOCAL_JOB_ID, SHARED_URL)
+    }
+
+
+def test_pending_apply_does_not_cross_tenant_apply_or_posting_state(
+    conn: sqlite3.Connection,
+) -> None:
+    _insert_job(conn, LOCAL_TENANT, LOCAL_JOB_ID)
+    _insert_job(conn, OTHER_TENANT, OTHER_JOB_ID)
+    _insert_enrichment(conn, LOCAL_TENANT, LOCAL_JOB_ID)
+    _insert_enrichment(conn, OTHER_TENANT, OTHER_JOB_ID)
+    _insert_score(conn, LOCAL_TENANT, LOCAL_JOB_ID)
+    _insert_score(conn, OTHER_TENANT, OTHER_JOB_ID)
+    _insert_materials(
+        conn,
+        LOCAL_TENANT,
+        LOCAL_JOB_ID,
+        artifact_types=("tailored_resume", "resume_pdf"),
+    )
+    conn.execute(
+        """
+        INSERT INTO apply_run_projections (
+            run_id, tenant_id, job_id, status, started_at, finished_at
+        ) VALUES ('other-run', ?, ?, 'succeeded', ?, ?)
+        """,
+        (OTHER_TENANT, OTHER_JOB_ID, TIMESTAMP, TIMESTAMP),
+    )
+    conn.execute(
+        """
+        INSERT INTO posting_snapshot_sets (
+            tenant_id, job_id, snapshot_set_json, latest_active_state, updated_at
+        ) VALUES (?, ?, '{}', 'closed', ?)
+        """,
+        (OTHER_TENANT, OTHER_JOB_ID, TIMESTAMP),
+    )
+    conn.commit()
+
+    assert _identities(get_jobs_by_stage(conn, "pending_apply", min_score=7)) == {
+        (LOCAL_TENANT, LOCAL_JOB_ID, SHARED_URL)
+    }
+
+
+def test_ready_apply_count_uses_exact_v7_stage_identity(
+    conn: sqlite3.Connection,
+) -> None:
+    for tenant_id, job_id in (
+        (LOCAL_TENANT, LOCAL_JOB_ID),
+        (OTHER_TENANT, OTHER_JOB_ID),
+    ):
+        _insert_job(conn, tenant_id, job_id)
+        _insert_enrichment(
+            conn,
+            tenant_id,
+            job_id,
+            application_url=f"https://apply.example.test/{job_id}",
+        )
+        _insert_score(conn, tenant_id, job_id)
+        _insert_materials(
+            conn,
+            tenant_id,
+            job_id,
+            artifact_types=("tailored_resume", "resume_pdf"),
+        )
+    conn.execute(
+        """
+        INSERT INTO job_stage_states (
+            tenant_id, job_id, stage, state, attempt_count, updated_at
+        ) VALUES (?, ?, 'apply', 'running', 1, ?)
+        """,
+        (OTHER_TENANT, OTHER_JOB_ID, TIMESTAMP),
+    )
+    conn.commit()
+
+    assert count_ready_to_apply(conn, min_score=7) == 1

--- a/workers/automation/tests/test_exact_v7_selector_job_identity.py
+++ b/workers/automation/tests/test_exact_v7_selector_job_identity.py
@@ -12,7 +12,7 @@ from pathlib import Path
 
 import pytest
 
-from jobctrl.database import count_ready_to_apply, get_jobs_by_stage, init_db
+from jobctrl.database import count_ready_to_apply, get_jobs_by_stage, get_stats, init_db
 
 
 LOCAL_TENANT = "local"
@@ -21,6 +21,8 @@ SHARED_URL = "https://example.test/jobs/shared"
 TIMESTAMP = "2026-07-31T12:00:00+00:00"
 LOCAL_JOB_ID = "90000000-0000-4000-8000-000000000001"
 OTHER_JOB_ID = "90000000-0000-4000-8000-000000000002"
+TAILOR_JOB_ID = "90000000-0000-4000-8000-000000000003"
+TAILOR_URL = "https://example.test/jobs/tailor"
 
 
 @pytest.fixture()
@@ -28,14 +30,20 @@ def conn(tmp_path: Path) -> sqlite3.Connection:
     return init_db(tmp_path / "jobctrl.db")
 
 
-def _insert_job(conn: sqlite3.Connection, tenant_id: str, job_id: str) -> None:
+def _insert_job(
+    conn: sqlite3.Connection,
+    tenant_id: str,
+    job_id: str,
+    *,
+    url: str = SHARED_URL,
+) -> None:
     conn.execute(
         """
         INSERT INTO jobs (
             tenant_id, job_id, url, title, site, discovered_at
         ) VALUES (?, ?, ?, 'Engineer', 'Example', ?)
         """,
-        (tenant_id, job_id, SHARED_URL, TIMESTAMP),
+        (tenant_id, job_id, url, TIMESTAMP),
     )
 
 
@@ -258,3 +266,93 @@ def test_ready_apply_count_uses_exact_v7_stage_identity(
     conn.commit()
 
     assert count_ready_to_apply(conn, min_score=7) == 1
+
+
+def test_exact_v7_selectors_ignore_retired_wide_job_state(
+    conn: sqlite3.Connection,
+) -> None:
+    _insert_job(conn, OTHER_TENANT, OTHER_JOB_ID)
+    _insert_job(conn, LOCAL_TENANT, LOCAL_JOB_ID)
+    _insert_job(conn, LOCAL_TENANT, TAILOR_JOB_ID, url=TAILOR_URL)
+    _insert_enrichment(
+        conn,
+        LOCAL_TENANT,
+        LOCAL_JOB_ID,
+        application_url="https://apply.example.test/canonical",
+    )
+    _insert_enrichment(conn, LOCAL_TENANT, TAILOR_JOB_ID)
+    _insert_score(conn, LOCAL_TENANT, LOCAL_JOB_ID)
+    _insert_score(conn, LOCAL_TENANT, TAILOR_JOB_ID)
+    _insert_materials(
+        conn,
+        LOCAL_TENANT,
+        LOCAL_JOB_ID,
+        artifact_types=("tailored_resume", "resume_pdf"),
+    )
+    conn.execute(
+        """
+        UPDATE jobs
+        SET full_description = 'retired description',
+            application_url = 'https://apply.example.test/retired',
+            detail_scraped_at = ?, detail_error = 'retired detail error',
+            fit_score = 10, tailored_resume_path = '/tmp/retired-resume.txt',
+            cover_letter_path = '/tmp/retired-cover.txt',
+            tailor_attempts = 5, cover_attempts = 5,
+            applied_at = ?, apply_status = 'applied', apply_error = 'retired apply error'
+        WHERE tenant_id = ? AND job_id = ?
+        """,
+        (TIMESTAMP, TIMESTAMP, OTHER_TENANT, OTHER_JOB_ID),
+    )
+    conn.execute(
+        """
+        UPDATE jobs
+        SET cover_letter_path = '/tmp/retired-cover.txt', cover_attempts = 5,
+            applied_at = ?, apply_status = 'applied', apply_error = 'retired apply error'
+        WHERE tenant_id = ? AND job_id = ?
+        """,
+        (TIMESTAMP, LOCAL_TENANT, LOCAL_JOB_ID),
+    )
+    conn.execute(
+        """
+        UPDATE jobs
+        SET tailored_resume_path = '/tmp/retired-resume.txt', tailor_attempts = 5
+        WHERE tenant_id = ? AND job_id = ?
+        """,
+        (LOCAL_TENANT, TAILOR_JOB_ID),
+    )
+    conn.commit()
+
+    pending_detail = get_jobs_by_stage(conn, "pending_detail")
+    assert _identities(pending_detail) == {
+        (OTHER_TENANT, OTHER_JOB_ID, SHARED_URL)
+    }
+    assert pending_detail[0]["full_description"] is None
+    assert pending_detail[0]["application_url"] is None
+    assert pending_detail[0]["fit_score"] is None
+    assert pending_detail[0]["tailored_resume_path"] is None
+    assert _identities(get_jobs_by_stage(conn, "pending_score")) == set()
+    assert _identities(get_jobs_by_stage(conn, "pending_tailor", min_score=7)) == {
+        (LOCAL_TENANT, TAILOR_JOB_ID, TAILOR_URL)
+    }
+    assert _identities(get_jobs_by_stage(conn, "pending_cover", min_score=7)) == {
+        (LOCAL_TENANT, LOCAL_JOB_ID, SHARED_URL)
+    }
+    pending_apply = get_jobs_by_stage(conn, "pending_apply", min_score=7)
+    assert _identities(pending_apply) == {(LOCAL_TENANT, LOCAL_JOB_ID, SHARED_URL)}
+    assert pending_apply[0]["applied_at"] is None
+    assert pending_apply[0]["apply_status"] is None
+    assert pending_apply[0]["cover_letter_path"] is None
+    assert _identities(get_jobs_by_stage(conn, "applied")) == set()
+    assert count_ready_to_apply(conn, min_score=7) == 1
+
+    stats = get_stats(conn)
+    assert stats["with_description"] == 2
+    assert stats["detail_errors"] == 0
+    assert stats["scored"] == 2
+    assert stats["tailored"] == 1
+    assert stats["with_cover_letter"] == 0
+    assert stats["tailor_exhausted"] == 0
+    assert stats["cover_exhausted"] == 0
+    assert stats["applied"] == 0
+    assert stats["apply_errors"] == 0
+    assert stats["ready_to_apply"] == 1

--- a/workers/automation/tests/test_tailor_retailor.py
+++ b/workers/automation/tests/test_tailor_retailor.py
@@ -3,6 +3,7 @@
 import json
 from pathlib import Path
 from types import SimpleNamespace
+from uuid import NAMESPACE_URL, uuid5
 
 from typer.testing import CliRunner
 
@@ -36,36 +37,103 @@ from jobctrl.infrastructure.materials import HtmlResumePdfAdapter
 _JOB_ID = canonical_job_id("80000000-0000-4000-8000-000000000001")
 
 
-def _insert_job(conn, *, url: str, fit_score: int = 9, tailored_resume_path=None, tailor_attempts: int = 0) -> None:
+def _job_id_for_url(url: str):
+    return canonical_job_id(str(uuid5(NAMESPACE_URL, url)))
+
+
+def _insert_job(
+    conn,
+    *,
+    url: str,
+    fit_score: int = 9,
+    material_path: str | None = None,
+):
+    job_id = _job_id_for_url(url)
+    timestamp = "2026-06-01T00:00:00+00:00"
     conn.execute(
         """
         INSERT INTO jobs (
-            url, title, site, full_description, fit_score, tailored_resume_path, tailor_attempts
-        ) VALUES (?, ?, ?, ?, ?, ?, ?)
+            tenant_id, job_id, url, title, site, discovered_at
+        ) VALUES (?, ?, ?, ?, ?, ?)
         """,
         (
+            str(LOCAL_TENANT),
+            str(job_id),
             url,
             "Backend Engineer",
             "Acme",
-            "Build APIs and distributed systems.",
-            fit_score,
-            tailored_resume_path,
-            tailor_attempts,
+            timestamp,
         ),
     )
-    conn.commit()
-
-
-def _insert_blocked_score(conn, *, url: str, blocker: str = "No sponsorship.") -> None:
+    conn.execute(
+        """
+        INSERT INTO job_locators (
+            tenant_id, job_id, locator_kind, locator_value,
+            is_current, first_seen_at, last_seen_at
+        ) VALUES (?, ?, 'posting_url', ?, 1, ?, ?)
+        """,
+        (str(LOCAL_TENANT), str(job_id), url, timestamp, timestamp),
+    )
+    conn.execute(
+        """
+        INSERT INTO job_enrichments (
+            tenant_id, job_id, current_status, full_description, updated_at
+        ) VALUES (?, ?, 'enriched', ?, ?)
+        """,
+        (
+            str(LOCAL_TENANT),
+            str(job_id),
+            "Build APIs and distributed systems.",
+            timestamp,
+        ),
+    )
     conn.execute(
         """
         INSERT INTO job_scores (
-            job_url, version, tenant_id, fit_score, breakdown_json,
-            keywords_json, scored_at, correction_json, criteria_json, trace_json
-        ) VALUES (?, 1, 'local', 10, ?, '[]', ?, NULL, '{}', '{}')
+            tenant_id, job_id, version, fit_score, breakdown_json,
+            keywords_json, scored_at
+        ) VALUES (?, ?, 1, ?, '{}', '[]', ?)
+        """,
+        (str(LOCAL_TENANT), str(job_id), fit_score, timestamp),
+    )
+    if material_path is not None:
+        conn.execute(
+            """
+            INSERT INTO job_materials (
+                tenant_id, job_id, generation, status, created_at, updated_at
+            ) VALUES (?, ?, 1, 'approved', ?, ?)
+            """,
+            (str(LOCAL_TENANT), str(job_id), timestamp, timestamp),
+        )
+        conn.execute(
+            """
+            INSERT INTO job_materials_artifacts (
+                tenant_id, job_id, generation, artifact_type, artifact_id,
+                status, path, render_format, created_at
+            ) VALUES (?, ?, 1, 'tailored_resume', ?, 'approved', ?, 'text', ?)
+            """,
+            (
+                str(LOCAL_TENANT),
+                str(job_id),
+                f"{job_id}:tailored_resume",
+                material_path,
+                timestamp,
+            ),
+        )
+    conn.commit()
+    return job_id
+
+
+def _insert_blocked_score(conn, *, url: str, blocker: str = "No sponsorship.") -> None:
+    job_id = _job_id_for_url(url)
+    conn.execute(
+        """
+        UPDATE job_scores
+        SET fit_score = ?, breakdown_json = ?
+        WHERE tenant_id = ? AND job_id = ?
         """,
         (
-            url,
+            10,
             json.dumps(
                 {
                     "reasoning": "Strong match but blocked.",
@@ -78,7 +146,8 @@ def _insert_blocked_score(conn, *, url: str, blocker: str = "No sponsorship.") -
                 },
                 sort_keys=True,
             ),
-            "2026-06-02T00:00:00+00:00",
+            str(LOCAL_TENANT),
+            str(job_id),
         ),
     )
     conn.commit()
@@ -89,19 +158,26 @@ def test_get_jobs_by_stage_retailor_includes_already_tailored_jobs(tmp_path):
     conn = init_db(db_path)
 
     try:
-        _insert_job(conn, url="https://example.com/new")
-        _insert_job(
+        new_job_id = _insert_job(conn, url="https://example.com/new")
+        existing_job_id = _insert_job(
             conn,
             url="https://example.com/existing",
-            tailored_resume_path="/tmp/existing.txt",
-            tailor_attempts=7,
+            material_path="/tmp/existing.txt",
         )
-        _insert_job(
+        exhausted_job_id = _insert_job(
             conn,
             url="https://example.com/exhausted",
-            tailored_resume_path=None,
-            tailor_attempts=5,
         )
+        ensure_job_stage_rows(conn, exhausted_job_id)
+        set_stage_state(
+            conn,
+            exhausted_job_id,
+            "tailor",
+            "exhausted",
+            attempt_count=5,
+            validate_transition=False,
+        )
+        conn.commit()
 
         pending = get_jobs_by_stage(conn=conn, stage="pending_tailor", min_score=7, limit=0)
         retailor_pending = get_jobs_by_stage(
@@ -112,10 +188,10 @@ def test_get_jobs_by_stage_retailor_includes_already_tailored_jobs(tmp_path):
             retailor=True,
         )
 
-        assert {job["url"] for job in pending} == {"https://example.com/new"}
-        assert {job["url"] for job in retailor_pending} == {
-            "https://example.com/new",
-            "https://example.com/existing",
+        assert {job["job_id"] for job in pending} == {str(new_job_id)}
+        assert {job["job_id"] for job in retailor_pending} == {
+            str(new_job_id),
+            str(existing_job_id),
         }
     finally:
         close_connection(db_path)
@@ -130,8 +206,7 @@ def test_count_pending_retailor_includes_already_tailored_jobs(tmp_path, monkeyp
         _insert_job(
             conn,
             url="https://example.com/existing",
-            tailored_resume_path="/tmp/existing.txt",
-            tailor_attempts=9,
+            material_path="/tmp/existing.txt",
         )
 
         monkeypatch.setattr("jobctrl.pipeline.runner.get_connection", lambda: get_connection(db_path))
@@ -151,7 +226,7 @@ def test_tailor_job_by_url_does_not_enumerate_unrelated_pending_jobs(tmp_path, m
 
     try:
         _insert_job(conn, url=target_url, fit_score=8)
-        _insert_job(conn, url=unrelated_url, fit_score=10)
+        unrelated_job_id = _insert_job(conn, url=unrelated_url, fit_score=10)
 
         def forbidden_batch_selector(*_args, **_kwargs):
             raise AssertionError("single-job tailoring must not call get_jobs_by_stage")
@@ -184,8 +259,9 @@ def test_tailor_job_by_url_does_not_enumerate_unrelated_pending_jobs(tmp_path, m
         assert result["status"] == "approved"
         assert calls == [target_url]
         unrelated_stage = conn.execute(
-            "SELECT state FROM job_stage_states WHERE job_url = ? AND stage = 'tailor'",
-            (unrelated_url,),
+            "SELECT state FROM job_stage_states "
+            "WHERE tenant_id = ? AND job_id = ? AND stage = 'tailor'",
+            (str(LOCAL_TENANT), str(unrelated_job_id)),
         ).fetchone()
         assert unrelated_stage is None
     finally:
@@ -207,11 +283,23 @@ def test_tailor_job_by_url_resets_stale_cover_success_after_new_resume(
     target_url = "https://example.com/stale-cover"
 
     try:
-        _insert_job(conn, url=target_url, fit_score=8)
-        ensure_job_stage_rows(conn, target_url, discovered_at="2026-06-01T00:00:00+00:00")
+        target_job_id = _insert_job(conn, url=target_url, fit_score=8)
+        ensure_job_stage_rows(
+            conn,
+            target_job_id,
+            discovered_at="2026-06-01T00:00:00+00:00",
+        )
         set_stage_state(
             conn,
-            target_url,
+            target_job_id,
+            "score",
+            "succeeded",
+            attempt_count=1,
+            validate_transition=False,
+        )
+        set_stage_state(
+            conn,
+            target_job_id,
             "tailor",
             "succeeded",
             attempt_count=1,
@@ -220,7 +308,7 @@ def test_tailor_job_by_url_resets_stale_cover_success_after_new_resume(
         )
         set_stage_state(
             conn,
-            target_url,
+            target_job_id,
             "cover",
             "succeeded",
             attempt_count=2,
@@ -262,9 +350,9 @@ def test_tailor_job_by_url_resets_stale_cover_success_after_new_resume(
             SELECT state, attempt_count, started_at, finished_at, duration_ms,
                    error_code, error_message, next_action
             FROM job_stage_states
-            WHERE job_url = ? AND stage = 'cover'
+            WHERE tenant_id = ? AND job_id = ? AND stage = 'cover'
             """,
-            (target_url,),
+            (str(LOCAL_TENANT), str(target_job_id)),
         ).fetchone()
         assert dict(cover) == {
             "state": "pending",
@@ -280,11 +368,11 @@ def test_tailor_job_by_url_resets_stale_cover_success_after_new_resume(
             """
             SELECT event_type, message
             FROM job_events
-            WHERE job_url = ? AND stage = 'cover'
+            WHERE tenant_id = ? AND job_id = ? AND stage = 'cover'
             ORDER BY rowid DESC
             LIMIT 1
             """,
-            (target_url,),
+            (str(LOCAL_TENANT), str(target_job_id)),
         ).fetchone()
         assert event["event_type"] == "StageReset"
         assert event["message"] == "Cover stage reset after tailored resume generation"
@@ -298,7 +386,7 @@ def test_tailor_job_by_url_skips_score_five_by_default(tmp_path, monkeypatch):
     target_url = "https://example.com/low-fit"
 
     try:
-        _insert_job(conn, url=target_url, fit_score=5)
+        target_job_id = _insert_job(conn, url=target_url, fit_score=5)
 
         def fail_tailor_one_job(*_args, **_kwargs):
             raise AssertionError("score-five jobs must not tailor by default")
@@ -313,7 +401,12 @@ def test_tailor_job_by_url_skips_score_five_by_default(tmp_path, monkeypatch):
             llm_model=None,
         )
 
-        assert result == {"url": target_url, "status": "skipped", "reason": "not_eligible"}
+        assert result == {
+            "url": target_url,
+            "job_id": str(target_job_id),
+            "status": "skipped",
+            "reason": "not_eligible",
+        }
     finally:
         close_connection(db_path)
 
@@ -364,7 +457,7 @@ def test_tailor_job_by_url_surfaces_blocked_score_eligibility(tmp_path, monkeypa
     target_url = "https://example.com/blocked"
 
     try:
-        _insert_job(conn, url=target_url, fit_score=10)
+        target_job_id = _insert_job(conn, url=target_url, fit_score=10)
         _insert_blocked_score(conn, url=target_url)
 
         def fail_tailor_one_job(*_args, **_kwargs):
@@ -383,6 +476,7 @@ def test_tailor_job_by_url_surfaces_blocked_score_eligibility(tmp_path, monkeypa
 
         assert result == {
             "url": target_url,
+            "job_id": str(target_job_id),
             "status": "skipped",
             "reason": "score_eligibility_blocked",
         }
@@ -390,10 +484,11 @@ def test_tailor_job_by_url_surfaces_blocked_score_eligibility(tmp_path, monkeypa
             """
             SELECT stage, state, error_code, error_message, blocked_by_json, next_action
             FROM job_stage_states
-            WHERE job_url = ? AND stage IN ('tailor', 'cover', 'apply')
+            WHERE tenant_id = ? AND job_id = ?
+              AND stage IN ('tailor', 'cover', 'apply')
             ORDER BY stage
             """,
-            (target_url,),
+            (str(LOCAL_TENANT), str(target_job_id)),
         ).fetchall()
         assert {row["stage"]: row["state"] for row in rows} == {
             "apply": "blocked",


### PR DESCRIPTION
## Summary
- join enrichment, scoring, materials, stage, posting-state, and apply projections by tenant-scoped JobId
- make ready-to-apply counts use canonical stage identity
- add same-URL cross-tenant regressions for detail, score, tailor, and apply selectors
- migrate the focused tailor/re-tailor fixtures to exact schema v7

## Why
Posting URLs are locators, not aggregate identity. Queue selectors must stay tenant-isolated after the one-shot v6 to v7 migration.

## Validation
- 25 focused exact-v7, feedback, and tailor/re-tailor tests passed
- focused Ruff checks passed
- git diff --check passed
- independent review: PASS (0 findings)
- independent QA: PASS (0 findings)

## Stack
- Depends on #625
- Active apply acquisition is intentionally the next bounded runtime slice