### PR TITLE
test(storage): migrate selector suites to canonical ids

### DIFF
--- a/workers/automation/tests/test_apply_queue_selectors.py
+++ b/workers/automation/tests/test_apply_queue_selectors.py
@@ -19,7 +19,7 @@ from jobctrl.database import (
     get_stats,
     init_db,
 )
-from jobctrl.domain.identifiers import JobId
+from jobctrl.domain.identifiers import JobId, canonical_job_id
 from jobctrl.domain.materials import (
     Artifact,
     ArtifactType,
@@ -68,6 +68,39 @@ def _insert_apply_ready_job(
     conn.commit()
 
 
+def _selector_job_id(number: int) -> JobId:
+    return canonical_job_id(f"90000000-0000-4000-8000-{number:012d}")
+
+
+def _insert_selector_apply_ready_job(
+    conn,
+    *,
+    job_id: JobId,
+    posting_url: str = "https://example.com/job",
+    application_url: str | None = "https://example.com/apply",
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO jobs (
+            tenant_id, job_id, url, title, site, full_description,
+            application_url, fit_score, tailored_resume_path
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            str(LOCAL_TENANT),
+            str(job_id),
+            posting_url,
+            "Eng",
+            "ExampleCo",
+            "Build distributed systems.",
+            application_url,
+            9,
+            "/tmp/resume.txt",
+        ),
+    )
+    conn.commit()
+
+
 def _mark_closed(conn, url: str, state: str = "removed") -> None:
     conn.execute(
         """
@@ -80,6 +113,22 @@ def _mark_closed(conn, url: str, state: str = "removed") -> None:
             updated_at = excluded.updated_at
         """,
         (str(LOCAL_TENANT), url, state, utc_now()),
+    )
+    conn.commit()
+
+
+def _mark_selector_closed(conn, job_id: JobId, state: str = "removed") -> None:
+    conn.execute(
+        """
+        INSERT INTO posting_snapshot_sets (
+            tenant_id, job_id, snapshot_set_json, latest_snapshot_version,
+            latest_active_state, updated_at
+        ) VALUES (?, ?, '{}', 0, ?, ?)
+        ON CONFLICT(tenant_id, job_id) DO UPDATE SET
+            latest_active_state = excluded.latest_active_state,
+            updated_at = excluded.updated_at
+        """,
+        (str(LOCAL_TENANT), str(job_id), state, utc_now()),
     )
     conn.commit()
 
@@ -105,19 +154,22 @@ def _make_resume_pdf_artifact(path: str = "/tmp/resume.pdf") -> Artifact:
 def _insert_canonical_apply_job(
     conn,
     *,
-    url: str = "https://example.com/canonical-job",
+    job_id: JobId,
+    posting_url: str = "https://example.com/canonical-job",
     application_url: str | None = "https://example.com/apply",
     with_pdf: bool,
 ) -> None:
     conn.execute(
         """
         INSERT INTO jobs (
-            url, title, site, full_description, application_url,
-            fit_score
-        ) VALUES (?, ?, ?, ?, ?, ?)
+            tenant_id, job_id, url, title, site, full_description,
+            application_url, fit_score
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
         """,
         (
-            url,
+            str(LOCAL_TENANT),
+            str(job_id),
+            posting_url,
             "Eng",
             "ExampleCo",
             "Build distributed systems.",
@@ -127,7 +179,7 @@ def _insert_canonical_apply_job(
     )
     materials = MaterialsSetFactory.initial(
         tenant_id=LOCAL_TENANT,
-        job_id=JobId(url),
+        job_id=job_id,
         created_at="2024-01-01T00:00:00+00:00",
     ).with_resume_attempt(
         _make_resume_artifact(),
@@ -144,16 +196,17 @@ def _insert_canonical_apply_job(
     conn.commit()
 
 
-def _insert_blocked_score(conn, url: str, *, fit_score: int = 9) -> None:
+def _insert_blocked_score(conn, job_id: JobId, *, fit_score: int = 9) -> None:
     conn.execute(
         """
         INSERT INTO job_scores (
-            job_url, version, tenant_id, fit_score, breakdown_json,
+            tenant_id, job_id, version, fit_score, breakdown_json,
             keywords_json, scored_at, correction_json, criteria_json, trace_json
-        ) VALUES (?, 1, 'local', ?, ?, '["python"]', ?, NULL, '{}', '{}')
+        ) VALUES (?, ?, 1, ?, ?, '["python"]', ?, NULL, '{}', '{}')
         """,
         (
-            url,
+            str(LOCAL_TENANT),
+            str(job_id),
             fit_score,
             json.dumps(
                 {
@@ -172,16 +225,17 @@ def _insert_blocked_score(conn, url: str, *, fit_score: int = 9) -> None:
     conn.commit()
 
 
-def _insert_allowed_score(conn, url: str, *, fit_score: int = 9) -> None:
+def _insert_allowed_score(conn, job_id: JobId, *, fit_score: int = 9) -> None:
     conn.execute(
         """
         INSERT INTO job_scores (
-            job_url, version, tenant_id, fit_score, breakdown_json,
+            tenant_id, job_id, version, fit_score, breakdown_json,
             keywords_json, scored_at, correction_json, criteria_json, trace_json
-        ) VALUES (?, 1, 'local', ?, ?, '["python"]', ?, NULL, '{}', '{}')
+        ) VALUES (?, ?, 1, ?, ?, '["python"]', ?, NULL, '{}', '{}')
         """,
         (
-            url,
+            str(LOCAL_TENANT),
+            str(job_id),
             fit_score,
             json.dumps(
                 {
@@ -200,18 +254,18 @@ def _insert_allowed_score(conn, url: str, *, fit_score: int = 9) -> None:
     conn.commit()
 
 
-def _insert_active_score_staleness_marker(conn, url: str) -> None:
+def _insert_active_score_staleness_marker(conn, job_id: JobId) -> None:
     conn.execute(
         """
         INSERT INTO job_score_staleness (
-            tenant_id, job_url, stale_reason,
+            tenant_id, job_id, stale_reason,
             old_policy_id, old_policy_version,
             new_policy_id, new_policy_version,
             marked_at, resolved, resolved_at, resolved_by_score_version
         ) VALUES (?, ?, 'scoring_policy_changed', 'local:scoring-policy-v1', 1,
                   'local:scoring-policy-v2', 2, '2026-05-19T00:00:00+00:00', 0, NULL, NULL)
         """,
-        (str(LOCAL_TENANT), url),
+        (str(LOCAL_TENANT), str(job_id)),
     )
     conn.commit()
 
@@ -247,69 +301,104 @@ def _emit_failed(conn, url: str, run_id: str, *, when: str = "t9") -> None:
 
 
 def test_pending_apply_includes_jobs_with_no_apply_run(conn):
-    _insert_apply_ready_job(conn)
+    job_id = _selector_job_id(1)
+    _insert_selector_apply_ready_job(conn, job_id=job_id)
+
     rows = get_jobs_by_stage(conn, "pending_apply", min_score=7)
-    assert len(rows) == 1
-    assert rows[0]["url"] == "https://example.com/job"
+
+    assert [
+        (row["tenant_id"], row["job_id"], row["url"])
+        for row in rows
+    ] == [(str(LOCAL_TENANT), str(job_id), "https://example.com/job")]
 
 
 def test_pending_apply_can_start_from_posting_url_when_direct_apply_url_missing(conn):
-    _insert_apply_ready_job(
+    job_id = _selector_job_id(2)
+    posting_url = "https://example.com/posting-only"
+    _insert_selector_apply_ready_job(
         conn,
-        url="https://example.com/posting-only",
+        job_id=job_id,
+        posting_url=posting_url,
         application_url=None,
     )
 
     rows = get_jobs_by_stage(conn, "pending_apply", min_score=7)
 
-    assert len(rows) == 1
-    assert rows[0]["url"] == "https://example.com/posting-only"
+    assert [
+        (row["tenant_id"], row["job_id"], row["url"])
+        for row in rows
+    ] == [(str(LOCAL_TENANT), str(job_id), posting_url)]
     assert count_ready_to_apply(conn, min_score=7) == 1
     assert (
         count_ready_to_apply(
             conn,
             min_score=7,
-            target_url="https://example.com/posting-only",
+            target_url=posting_url,
         )
         == 1
     )
 
 
 def test_pending_apply_excludes_canonical_text_only_resume(conn):
-    url = "https://example.com/canonical-text-only"
-    _insert_canonical_apply_job(conn, url=url, with_pdf=False)
+    job_id = _selector_job_id(3)
+    posting_url = "https://example.com/canonical-text-only"
+    _insert_canonical_apply_job(
+        conn,
+        job_id=job_id,
+        posting_url=posting_url,
+        with_pdf=False,
+    )
 
     rows = get_jobs_by_stage(conn, "pending_apply", min_score=7)
 
     assert {row["url"] for row in rows} == set()
     assert count_ready_to_apply(conn, min_score=7) == 0
-    assert count_ready_to_apply(conn, min_score=7, target_url=url) == 0
+    assert count_ready_to_apply(conn, min_score=7, target_url=posting_url) == 0
     assert get_stats(conn)["ready_to_apply"] == 0
 
 
 def test_pending_apply_includes_canonical_resume_with_pdf(conn):
-    url = "https://example.com/canonical-with-pdf"
-    _insert_canonical_apply_job(conn, url=url, with_pdf=True)
+    job_id = _selector_job_id(4)
+    posting_url = "https://example.com/canonical-with-pdf"
+    _insert_canonical_apply_job(
+        conn,
+        job_id=job_id,
+        posting_url=posting_url,
+        with_pdf=True,
+    )
 
     rows = get_jobs_by_stage(conn, "pending_apply", min_score=7)
 
-    assert [row["url"] for row in rows] == [url]
+    assert [
+        (row["tenant_id"], row["job_id"], row["url"])
+        for row in rows
+    ] == [(str(LOCAL_TENANT), str(job_id), posting_url)]
     assert rows[0]["tailored_resume_path"] == "/tmp/resume.txt"
     assert rows[0]["jm_resume_pdf_path"] == "/tmp/resume.pdf"
     assert count_ready_to_apply(conn, min_score=7) == 1
-    assert count_ready_to_apply(conn, min_score=7, target_url=url) == 1
+    assert count_ready_to_apply(conn, min_score=7, target_url=posting_url) == 1
     assert get_stats(conn)["ready_to_apply"] == 1
 
 
 def test_pending_apply_excludes_high_score_blocked_jobs(conn):
-    _insert_apply_ready_job(conn, url="https://example.com/allowed")
-    _insert_apply_ready_job(conn, url="https://example.com/blocked")
-    _insert_blocked_score(conn, "https://example.com/blocked", fit_score=10)
+    allowed_job_id = _selector_job_id(5)
+    blocked_job_id = _selector_job_id(6)
+    _insert_selector_apply_ready_job(
+        conn,
+        job_id=allowed_job_id,
+        posting_url="https://example.com/allowed",
+    )
+    _insert_selector_apply_ready_job(
+        conn,
+        job_id=blocked_job_id,
+        posting_url="https://example.com/blocked",
+    )
+    _insert_blocked_score(conn, blocked_job_id, fit_score=10)
 
     rows = get_jobs_by_stage(conn, "pending_apply", min_score=7)
-    urls = {row["url"] for row in rows}
-    assert "https://example.com/allowed" in urls
-    assert "https://example.com/blocked" not in urls
+    identities = {(row["tenant_id"], row["job_id"]) for row in rows}
+    assert (str(LOCAL_TENANT), str(allowed_job_id)) in identities
+    assert (str(LOCAL_TENANT), str(blocked_job_id)) not in identities
 
 
 @pytest.mark.parametrize(
@@ -321,29 +410,38 @@ def test_pending_apply_excludes_high_score_blocked_jobs(conn):
     ],
 )
 def test_pending_apply_excludes_non_current_scores(conn, score_state: str, active_marker: bool):
-    url = f"https://example.com/non-current-apply-{score_state}-{active_marker}"
-    _insert_apply_ready_job(conn, url=url)
-    _insert_allowed_score(conn, url)
-    ensure_job_stage_rows(conn, url)
-    set_stage_state(conn, url, "score", score_state, validate_transition=False)
+    job_id = _selector_job_id(7)
+    posting_url = f"https://example.com/non-current-apply-{score_state}-{active_marker}"
+    _insert_selector_apply_ready_job(conn, job_id=job_id, posting_url=posting_url)
+    _insert_allowed_score(conn, job_id)
+    ensure_job_stage_rows(conn, job_id, tenant_id=LOCAL_TENANT)
+    set_stage_state(
+        conn,
+        job_id,
+        "score",
+        score_state,
+        tenant_id=LOCAL_TENANT,
+        validate_transition=False,
+    )
     if active_marker:
-        _insert_active_score_staleness_marker(conn, url)
+        _insert_active_score_staleness_marker(conn, job_id)
 
     rows = get_jobs_by_stage(conn, "pending_apply", min_score=7)
-    urls = {row["url"] for row in rows}
-    assert url not in urls
+    identities = {(row["tenant_id"], row["job_id"]) for row in rows}
+    assert (str(LOCAL_TENANT), str(job_id)) not in identities
 
 
 def test_pending_apply_excludes_closed_postings(conn):
-    url = "https://example.com/closed-apply"
-    _insert_apply_ready_job(conn, url=url)
-    _mark_closed(conn, url)
+    job_id = _selector_job_id(8)
+    posting_url = "https://example.com/closed-apply"
+    _insert_selector_apply_ready_job(conn, job_id=job_id, posting_url=posting_url)
+    _mark_selector_closed(conn, job_id)
 
     rows = get_jobs_by_stage(conn, "pending_apply", min_score=7)
-    urls = {row["url"] for row in rows}
-    assert url not in urls
+    identities = {(row["tenant_id"], row["job_id"]) for row in rows}
+    assert (str(LOCAL_TENANT), str(job_id)) not in identities
     assert count_ready_to_apply(conn, min_score=7) == 0
-    assert count_ready_to_apply(conn, min_score=7, target_url=url) == 0
+    assert count_ready_to_apply(conn, min_score=7, target_url=posting_url) == 0
     assert get_stats(conn)["ready_to_apply"] == 0
 
 

--- a/workers/automation/tests/test_materials_queue_selectors.py
+++ b/workers/automation/tests/test_materials_queue_selectors.py
@@ -3,15 +3,14 @@
 Mirrors the Phase 5 ``test_score_queue_selectors`` pattern: after the
 :class:`SqliteMaterialsRepository` saves a MaterialsSet, the
 ``get_jobs_by_stage`` selectors (which back the worker queues +
-``pipeline.apply_jobs``) must reflect the new materials immediately —
-the legacy ``jobs.tailored_resume_path`` / ``jobs.cover_letter_path``
-columns stay empty on the new write path, so the LEFT JOIN is what
-keeps the pipeline observable.
+``pipeline.apply_jobs``) must reflect newly saved materials immediately,
+without writing the deprecated path columns on ``jobs``.
 """
 
 from __future__ import annotations
 
 import sqlite3
+import uuid
 from pathlib import Path
 
 import pytest
@@ -43,6 +42,35 @@ def _seed_job(conn: sqlite3.Connection, url: str, fit_score: int = 9) -> str:
     )
     conn.commit()
     return url
+
+
+def _selector_job_id(name: str) -> JobId:
+    return JobId(str(uuid.uuid5(uuid.NAMESPACE_URL, f"jobctrl-selector-test:{name}")))
+
+
+def _seed_selector_job(
+    conn: sqlite3.Connection,
+    name: str,
+    fit_score: int = 9,
+) -> JobId:
+    job_id = _selector_job_id(name)
+    conn.execute(
+        "INSERT INTO jobs "
+        "(tenant_id, job_id, url, title, site, full_description, fit_score, discovered_at) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        (
+            LOCAL_TENANT,
+            job_id,
+            f"https://example.com/{name}",
+            "Engineer",
+            "Acme",
+            "desc",
+            fit_score,
+            "2024-01-01T00:00:00+00:00",
+        ),
+    )
+    conn.commit()
+    return job_id
 
 
 def _make_resume_artifact(path: str = "/tmp/r.txt") -> Artifact:
@@ -78,12 +106,12 @@ def _make_resume_pdf_artifact(path: str = "/tmp/r.pdf") -> Artifact:
 
 
 def test_pending_tailor_excludes_jobs_with_approved_resume(conn: sqlite3.Connection) -> None:
-    url_pending = _seed_job(conn, "https://example.com/pending")
-    url_done = _seed_job(conn, "https://example.com/done")
+    pending_job_id = _seed_selector_job(conn, "pending")
+    done_job_id = _seed_selector_job(conn, "done")
     repo = SqliteMaterialsRepository(conn)
     materials = MaterialsSetFactory.initial(
         tenant_id=LOCAL_TENANT,
-        job_id=JobId(url_done),
+        job_id=done_job_id,
         created_at="2024-01-01T00:00:00+00:00",
     ).with_resume_attempt(
         _make_resume_artifact(),
@@ -94,17 +122,17 @@ def test_pending_tailor_excludes_jobs_with_approved_resume(conn: sqlite3.Connect
     repo.save(materials)
 
     rows = get_jobs_by_stage(conn=conn, stage="pending_tailor", min_score=7, limit=0)
-    urls = {row["url"] for row in rows}
-    assert url_pending in urls
-    assert url_done not in urls
+    job_ids = {row["job_id"] for row in rows}
+    assert pending_job_id in job_ids
+    assert done_job_id not in job_ids
 
 
 def test_pending_tailor_with_retailor_includes_done_jobs(conn: sqlite3.Connection) -> None:
-    url_done = _seed_job(conn, "https://example.com/done")
+    done_job_id = _seed_selector_job(conn, "done")
     repo = SqliteMaterialsRepository(conn)
     materials = MaterialsSetFactory.initial(
         tenant_id=LOCAL_TENANT,
-        job_id=JobId(url_done),
+        job_id=done_job_id,
         created_at="2024-01-01T00:00:00+00:00",
     ).with_resume_attempt(
         _make_resume_artifact(),
@@ -117,20 +145,18 @@ def test_pending_tailor_with_retailor_includes_done_jobs(conn: sqlite3.Connectio
     rows = get_jobs_by_stage(
         conn=conn, stage="pending_tailor", min_score=7, limit=0, retailor=True
     )
-    assert url_done in {row["url"] for row in rows}
+    assert done_job_id in {row["job_id"] for row in rows}
 
 
-def test_pending_tailor_promotes_jm_path_into_legacy_dict_slot(
+def test_tailored_selector_exposes_canonical_material_path(
     conn: sqlite3.Connection,
 ) -> None:
-    """The dict surfaced to legacy callers carries the joined materials path
-    in the ``tailored_resume_path`` slot so untouched consumers (apply
-    launcher) keep working."""
-    url = _seed_job(conn, "https://example.com/done")
+    """The tailored selector exposes the canonical resume path to consumers."""
+    job_id = _seed_selector_job(conn, "done")
     repo = SqliteMaterialsRepository(conn)
     materials = MaterialsSetFactory.initial(
         tenant_id=LOCAL_TENANT,
-        job_id=JobId(url),
+        job_id=job_id,
         created_at="2024-01-01T00:00:00+00:00",
     ).with_resume_attempt(
         _make_resume_artifact("/tmp/specific-path.txt"),
@@ -142,7 +168,9 @@ def test_pending_tailor_promotes_jm_path_into_legacy_dict_slot(
 
     rows = get_jobs_by_stage(conn=conn, stage="tailored")
     assert any(
-        row["url"] == url and row.get("tailored_resume_path") == "/tmp/specific-path.txt"
+        row["tenant_id"] == LOCAL_TENANT
+        and row["job_id"] == job_id
+        and row["tailored_resume_path"] == "/tmp/specific-path.txt"
         for row in rows
     )
 
@@ -155,13 +183,13 @@ def test_pending_tailor_promotes_jm_path_into_legacy_dict_slot(
 def test_pending_cover_returns_only_jobs_with_resume_no_cover(
     conn: sqlite3.Connection,
 ) -> None:
-    url_resume = _seed_job(conn, "https://example.com/resume-only")
-    url_text_only = _seed_job(conn, "https://example.com/text-only")
-    url_full = _seed_job(conn, "https://example.com/full")
+    resume_job_id = _seed_selector_job(conn, "resume-only")
+    text_only_job_id = _seed_selector_job(conn, "text-only")
+    full_job_id = _seed_selector_job(conn, "full")
     repo = SqliteMaterialsRepository(conn)
     base = MaterialsSetFactory.initial(
         tenant_id=LOCAL_TENANT,
-        job_id=JobId(url_resume),
+        job_id=resume_job_id,
         created_at="2024-01-01T00:00:00+00:00",
     ).with_resume_attempt(
         _make_resume_artifact(),
@@ -175,7 +203,7 @@ def test_pending_cover_returns_only_jobs_with_resume_no_cover(
     repo.save(base)
     text_only = MaterialsSetFactory.initial(
         tenant_id=LOCAL_TENANT,
-        job_id=JobId(url_text_only),
+        job_id=text_only_job_id,
         created_at="2024-01-01T00:00:00+00:00",
     ).with_resume_attempt(
         _make_resume_artifact("/tmp/text-only-r.txt"),
@@ -186,7 +214,7 @@ def test_pending_cover_returns_only_jobs_with_resume_no_cover(
     repo.save(text_only)
     full = MaterialsSetFactory.initial(
         tenant_id=LOCAL_TENANT,
-        job_id=JobId(url_full),
+        job_id=full_job_id,
         created_at="2024-01-01T00:00:00+00:00",
     ).with_resume_attempt(
         _make_resume_artifact("/tmp/full-r.txt"),
@@ -204,10 +232,10 @@ def test_pending_cover_returns_only_jobs_with_resume_no_cover(
     repo.save(full)
 
     rows = get_jobs_by_stage(conn=conn, stage="pending_cover", min_score=7, limit=0)
-    urls = {row["url"] for row in rows}
-    assert url_resume in urls
-    assert url_text_only not in urls
-    assert url_full not in urls
+    job_ids = {row["job_id"] for row in rows}
+    assert resume_job_id in job_ids
+    assert text_only_job_id not in job_ids
+    assert full_job_id not in job_ids
 
 
 # ---------------------------------------------------------------------------
@@ -218,11 +246,11 @@ def test_pending_cover_returns_only_jobs_with_resume_no_cover(
 def test_pending_pdf_includes_jobs_with_text_but_missing_pdf(
     conn: sqlite3.Connection,
 ) -> None:
-    url = _seed_job(conn, "https://example.com/needs-pdf")
+    job_id = _seed_selector_job(conn, "needs-pdf")
     repo = SqliteMaterialsRepository(conn)
     materials = MaterialsSetFactory.initial(
         tenant_id=LOCAL_TENANT,
-        job_id=JobId(url),
+        job_id=job_id,
         created_at="2024-01-01T00:00:00+00:00",
     ).with_resume_attempt(
         _make_resume_artifact(),
@@ -233,7 +261,7 @@ def test_pending_pdf_includes_jobs_with_text_but_missing_pdf(
     repo.save(materials)
 
     rows = get_jobs_by_stage(conn=conn, stage="pending_pdf", limit=0)
-    assert url in {row["url"] for row in rows}
+    assert job_id in {row["job_id"] for row in rows}
 
 
 # ---------------------------------------------------------------------------
@@ -242,14 +270,13 @@ def test_pending_pdf_includes_jobs_with_text_but_missing_pdf(
 
 
 def test_get_stats_tailored_count_reflects_materials_writes(conn: sqlite3.Connection) -> None:
-    """``stats['tailored']`` must reflect a freshly-saved MaterialsSet
-    even though new code never writes ``jobs.tailored_resume_path``."""
-    url = _seed_job(conn, "https://example.com/job")
+    """``stats['tailored']`` must reflect a freshly-saved MaterialsSet."""
+    job_id = _seed_selector_job(conn, "job")
     repo = SqliteMaterialsRepository(conn)
     repo.save(
         MaterialsSetFactory.initial(
             tenant_id=LOCAL_TENANT,
-            job_id=JobId(url),
+            job_id=job_id,
             created_at="2024-01-01T00:00:00+00:00",
         ).with_resume_attempt(
             _make_resume_artifact(),
@@ -260,21 +287,20 @@ def test_get_stats_tailored_count_reflects_materials_writes(conn: sqlite3.Connec
     )
     stats = get_stats(conn)
     assert stats["tailored"] == 1
-    # Legacy column stays NULL on the new path.
-    legacy_count = conn.execute(
+    deprecated_count = conn.execute(
         "SELECT COUNT(*) FROM jobs WHERE tailored_resume_path IS NOT NULL"
     ).fetchone()[0]
-    assert legacy_count == 0
+    assert deprecated_count == 0
 
 
 def test_get_stats_with_cover_letter_count_reflects_materials_writes(
     conn: sqlite3.Connection,
 ) -> None:
-    url = _seed_job(conn, "https://example.com/job")
+    job_id = _seed_selector_job(conn, "job")
     repo = SqliteMaterialsRepository(conn)
     materials = MaterialsSetFactory.initial(
         tenant_id=LOCAL_TENANT,
-        job_id=JobId(url),
+        job_id=job_id,
         created_at="2024-01-01T00:00:00+00:00",
     ).with_resume_attempt(
         _make_resume_artifact(),
@@ -293,16 +319,17 @@ def test_get_stats_with_cover_letter_count_reflects_materials_writes(
 
 def test_get_stats_ready_to_apply_reflects_materials_writes(conn: sqlite3.Connection) -> None:
     """``ready_to_apply`` requires tailored text, resume PDF, and application_url."""
-    url = _seed_job(conn, "https://example.com/job")
+    job_id = _seed_selector_job(conn, "job")
     conn.execute(
-        "UPDATE jobs SET application_url = 'https://example.com/apply' WHERE url = ?",
-        (url,),
+        "UPDATE jobs SET application_url = 'https://example.com/apply' "
+        "WHERE tenant_id = ? AND job_id = ?",
+        (LOCAL_TENANT, job_id),
     )
     repo = SqliteMaterialsRepository(conn)
     repo.save(
         MaterialsSetFactory.initial(
             tenant_id=LOCAL_TENANT,
-            job_id=JobId(url),
+            job_id=job_id,
             created_at="2024-01-01T00:00:00+00:00",
         ).with_resume_attempt(
             _make_resume_artifact(),
@@ -321,16 +348,17 @@ def test_get_stats_ready_to_apply_reflects_materials_writes(conn: sqlite3.Connec
 def test_get_stats_ready_to_apply_excludes_text_only_tailored_materials(
     conn: sqlite3.Connection,
 ) -> None:
-    url = _seed_job(conn, "https://example.com/text-only")
+    job_id = _seed_selector_job(conn, "text-only")
     conn.execute(
-        "UPDATE jobs SET application_url = 'https://example.com/apply' WHERE url = ?",
-        (url,),
+        "UPDATE jobs SET application_url = 'https://example.com/apply' "
+        "WHERE tenant_id = ? AND job_id = ?",
+        (LOCAL_TENANT, job_id),
     )
     repo = SqliteMaterialsRepository(conn)
     repo.save(
         MaterialsSetFactory.initial(
             tenant_id=LOCAL_TENANT,
-            job_id=JobId(url),
+            job_id=job_id,
             created_at="2024-01-01T00:00:00+00:00",
         ).with_resume_attempt(
             _make_resume_artifact(),
@@ -352,13 +380,13 @@ def test_pipeline_count_pending_cover_excludes_text_only_tailored_materials(
     from jobctrl import pipeline
     from jobctrl.pipeline import runner as pipeline_runner
 
-    url_text_only = _seed_job(conn, "https://example.com/text-only")
-    url_with_pdf = _seed_job(conn, "https://example.com/with-pdf")
+    text_only_job_id = _seed_selector_job(conn, "text-only")
+    with_pdf_job_id = _seed_selector_job(conn, "with-pdf")
     repo = SqliteMaterialsRepository(conn)
     repo.save(
         MaterialsSetFactory.initial(
             tenant_id=LOCAL_TENANT,
-            job_id=JobId(url_text_only),
+            job_id=text_only_job_id,
             created_at="2024-01-01T00:00:00+00:00",
         ).with_resume_attempt(
             _make_resume_artifact("/tmp/text-only-r.txt"),
@@ -370,7 +398,7 @@ def test_pipeline_count_pending_cover_excludes_text_only_tailored_materials(
     repo.save(
         MaterialsSetFactory.initial(
             tenant_id=LOCAL_TENANT,
-            job_id=JobId(url_with_pdf),
+            job_id=with_pdf_job_id,
             created_at="2024-01-01T00:00:00+00:00",
         ).with_resume_attempt(
             _make_resume_artifact("/tmp/with-pdf-r.txt"),
@@ -391,13 +419,13 @@ def test_get_stats_untailored_eligible_excludes_materials_tailored(
     conn: sqlite3.Connection,
 ) -> None:
     """Once a job is tailored via materials, ``untailored_eligible`` drops it."""
-    url_tailored = _seed_job(conn, "https://example.com/tailored")
-    url_pending = _seed_job(conn, "https://example.com/pending")
+    tailored_job_id = _seed_selector_job(conn, "tailored")
+    pending_job_id = _seed_selector_job(conn, "pending")
     repo = SqliteMaterialsRepository(conn)
     repo.save(
         MaterialsSetFactory.initial(
             tenant_id=LOCAL_TENANT,
-            job_id=JobId(url_tailored),
+            job_id=tailored_job_id,
             created_at="2024-01-01T00:00:00+00:00",
         ).with_resume_attempt(
             _make_resume_artifact(),
@@ -416,11 +444,11 @@ def test_get_stats_untailored_eligible_excludes_materials_tailored(
     from jobctrl.infrastructure.scoring import SqliteScoreRepository
 
     score_repo = SqliteScoreRepository(conn)
-    for url in (url_tailored, url_pending):
+    for job_id in (tailored_job_id, pending_job_id):
         score_repo.save(
             JobScore.initial(
                 tenant_id=LOCAL_TENANT,
-                job_id=JobId(url),
+                job_id=job_id,
                 fit_score=FitScore.create(9),
                 breakdown=ScoreBreakdown(reasoning="ok"),
                 matched_keywords=MatchedKeywords.from_iterable(["python"]),
@@ -434,18 +462,31 @@ def test_get_stats_untailored_eligible_excludes_materials_tailored(
 
 def test_get_stats_tailor_exhausted_reads_stage_state(conn: sqlite3.Connection) -> None:
     """``tailor_exhausted`` honours the new ``job_stage_states.state``."""
-    url = _seed_job(conn, "https://example.com/job")
+    job_id = _seed_selector_job(conn, "job")
     from jobctrl.state import ensure_job_stage_rows, set_stage_state
 
-    ensure_job_stage_rows(conn, url, discovered_at="2024-01-01T00:00:00+00:00")
+    ensure_job_stage_rows(
+        conn,
+        job_id,
+        tenant_id=LOCAL_TENANT,
+        discovered_at="2024-01-01T00:00:00+00:00",
+    )
     # Walk the state machine: pending → running → failed → exhausted.
-    set_stage_state(conn, url, "tailor", "running", started_at="2024-01-02T00:00:00+00:00")
-    set_stage_state(conn, url, "tailor", "failed", attempt_count=4)
     set_stage_state(
         conn,
-        url,
+        job_id,
+        "tailor",
+        "running",
+        tenant_id=LOCAL_TENANT,
+        started_at="2024-01-02T00:00:00+00:00",
+    )
+    set_stage_state(conn, job_id, "tailor", "failed", tenant_id=LOCAL_TENANT, attempt_count=4)
+    set_stage_state(
+        conn,
+        job_id,
         "tailor",
         "exhausted",
+        tenant_id=LOCAL_TENANT,
         attempt_count=5,
         max_attempts=5,
         finished_at="2024-01-02T00:00:00+00:00",
@@ -464,24 +505,37 @@ def test_pending_tailor_excludes_exhausted_jobs_via_stage_state(
 ) -> None:
     """A job whose ``job_stage_states.state == 'exhausted'`` for tailor
     must NOT appear in the pending_tailor selector."""
-    url = _seed_job(conn, "https://example.com/exhausted")
+    job_id = _seed_selector_job(conn, "exhausted")
     from jobctrl.state import ensure_job_stage_rows, set_stage_state
 
-    ensure_job_stage_rows(conn, url, discovered_at="2024-01-01T00:00:00+00:00")
+    ensure_job_stage_rows(
+        conn,
+        job_id,
+        tenant_id=LOCAL_TENANT,
+        discovered_at="2024-01-01T00:00:00+00:00",
+    )
     # Walk the state machine: pending → running → failed → exhausted.
-    set_stage_state(conn, url, "tailor", "running", started_at="2024-01-02T00:00:00+00:00")
-    set_stage_state(conn, url, "tailor", "failed", attempt_count=4)
     set_stage_state(
         conn,
-        url,
+        job_id,
+        "tailor",
+        "running",
+        tenant_id=LOCAL_TENANT,
+        started_at="2024-01-02T00:00:00+00:00",
+    )
+    set_stage_state(conn, job_id, "tailor", "failed", tenant_id=LOCAL_TENANT, attempt_count=4)
+    set_stage_state(
+        conn,
+        job_id,
         "tailor",
         "exhausted",
+        tenant_id=LOCAL_TENANT,
         attempt_count=5,
         max_attempts=5,
         finished_at="2024-01-02T00:00:00+00:00",
     )
     rows = get_jobs_by_stage(conn=conn, stage="pending_tailor", min_score=7, limit=0)
-    assert url not in {row["url"] for row in rows}
+    assert job_id not in {row["job_id"] for row in rows}
 
 
 def test_pending_tailor_excludes_jobs_with_high_attempt_count(
@@ -490,22 +544,35 @@ def test_pending_tailor_excludes_jobs_with_high_attempt_count(
     """A job whose ``job_stage_states.attempt_count >= 5`` for tailor
     must NOT appear in pending_tailor — even when ``state`` isn't yet
     'exhausted'."""
-    url = _seed_job(conn, "https://example.com/many-attempts")
+    job_id = _seed_selector_job(conn, "many-attempts")
     from jobctrl.state import ensure_job_stage_rows, set_stage_state
 
-    ensure_job_stage_rows(conn, url, discovered_at="2024-01-01T00:00:00+00:00")
-    set_stage_state(conn, url, "tailor", "running", started_at="2024-01-02T00:00:00+00:00")
+    ensure_job_stage_rows(
+        conn,
+        job_id,
+        tenant_id=LOCAL_TENANT,
+        discovered_at="2024-01-01T00:00:00+00:00",
+    )
     set_stage_state(
         conn,
-        url,
+        job_id,
+        "tailor",
+        "running",
+        tenant_id=LOCAL_TENANT,
+        started_at="2024-01-02T00:00:00+00:00",
+    )
+    set_stage_state(
+        conn,
+        job_id,
         "tailor",
         "failed",
+        tenant_id=LOCAL_TENANT,
         attempt_count=5,
         max_attempts=5,
         finished_at="2024-01-02T00:00:00+00:00",
     )
     rows = get_jobs_by_stage(conn=conn, stage="pending_tailor", min_score=7, limit=0)
-    assert url not in {row["url"] for row in rows}
+    assert job_id not in {row["job_id"] for row in rows}
 
 
 # ---------------------------------------------------------------------------

--- a/workers/automation/tests/test_materials_queue_selectors.py
+++ b/workers/automation/tests/test_materials_queue_selectors.py
@@ -27,6 +27,7 @@ from jobctrl.domain.materials import (
 )
 from jobctrl.domain.tenant import LOCAL_TENANT
 from jobctrl.infrastructure.materials import SqliteMaterialsRepository
+from jobctrl.state import ensure_job_stage_rows, set_stage_state
 
 
 @pytest.fixture()
@@ -35,10 +36,37 @@ def conn(tmp_path: Path) -> sqlite3.Connection:
 
 
 def _seed_job(conn: sqlite3.Connection, url: str, fit_score: int = 9) -> str:
+    job_id = _job_id(url)
     conn.execute(
-        "INSERT INTO jobs (url, title, site, full_description, fit_score, discovered_at) "
+        "INSERT INTO jobs (tenant_id, job_id, url, title, site, discovered_at) "
         "VALUES (?, ?, ?, ?, ?, ?)",
-        (url, "Engineer", "Acme", "desc", fit_score, "2024-01-01T00:00:00+00:00"),
+        (LOCAL_TENANT, job_id, url, "Engineer", "Acme", "2024-01-01T00:00:00+00:00"),
+    )
+    conn.execute(
+        "INSERT INTO job_enrichments "
+        "(tenant_id, job_id, current_status, full_description, updated_at) "
+        "VALUES (?, ?, 'enriched', 'desc', ?)",
+        (LOCAL_TENANT, job_id, "2024-01-01T00:00:00+00:00"),
+    )
+    conn.execute(
+        "INSERT INTO job_scores "
+        "(tenant_id, job_id, version, fit_score, breakdown_json, keywords_json, scored_at) "
+        "VALUES (?, ?, 1, ?, '{}', '[]', ?)",
+        (LOCAL_TENANT, job_id, fit_score, "2024-01-01T00:00:00+00:00"),
+    )
+    ensure_job_stage_rows(
+        conn,
+        job_id,
+        tenant_id=LOCAL_TENANT,
+        discovered_at="2024-01-01T00:00:00+00:00",
+    )
+    set_stage_state(
+        conn,
+        job_id,
+        "score",
+        "succeeded",
+        tenant_id=LOCAL_TENANT,
+        validate_transition=False,
     )
     conn.commit()
     return url
@@ -48,29 +76,18 @@ def _selector_job_id(name: str) -> JobId:
     return JobId(str(uuid.uuid5(uuid.NAMESPACE_URL, f"jobctrl-selector-test:{name}")))
 
 
+def _job_id(url: str) -> JobId:
+    return JobId(str(uuid.uuid5(uuid.NAMESPACE_URL, url)))
+
+
 def _seed_selector_job(
     conn: sqlite3.Connection,
     name: str,
     fit_score: int = 9,
 ) -> JobId:
-    job_id = _selector_job_id(name)
-    conn.execute(
-        "INSERT INTO jobs "
-        "(tenant_id, job_id, url, title, site, full_description, fit_score, discovered_at) "
-        "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-        (
-            LOCAL_TENANT,
-            job_id,
-            f"https://example.com/{name}",
-            "Engineer",
-            "Acme",
-            "desc",
-            fit_score,
-            "2024-01-01T00:00:00+00:00",
-        ),
-    )
-    conn.commit()
-    return job_id
+    url = f"https://example.com/{name}"
+    _seed_job(conn, url, fit_score)
+    return _job_id(url)
 
 
 def _make_resume_artifact(path: str = "/tmp/r.txt") -> Artifact:
@@ -420,7 +437,7 @@ def test_get_stats_untailored_eligible_excludes_materials_tailored(
 ) -> None:
     """Once a job is tailored via materials, ``untailored_eligible`` drops it."""
     tailored_job_id = _seed_selector_job(conn, "tailored")
-    pending_job_id = _seed_selector_job(conn, "pending")
+    _seed_selector_job(conn, "pending")
     repo = SqliteMaterialsRepository(conn)
     repo.save(
         MaterialsSetFactory.initial(
@@ -434,28 +451,6 @@ def test_get_stats_untailored_eligible_excludes_materials_tailored(
             updated_at="2024-01-02T00:00:00+00:00",
         )
     )
-    # Need a score row so the score-side filter is satisfied for both jobs.
-    from jobctrl.domain.scoring import (
-        FitScore,
-        JobScore,
-        MatchedKeywords,
-        ScoreBreakdown,
-    )
-    from jobctrl.infrastructure.scoring import SqliteScoreRepository
-
-    score_repo = SqliteScoreRepository(conn)
-    for job_id in (tailored_job_id, pending_job_id):
-        score_repo.save(
-            JobScore.initial(
-                tenant_id=LOCAL_TENANT,
-                job_id=job_id,
-                fit_score=FitScore.create(9),
-                breakdown=ScoreBreakdown(reasoning="ok"),
-                matched_keywords=MatchedKeywords.from_iterable(["python"]),
-                scored_at="2024-01-02T00:00:00+00:00",
-            )
-        )
-
     stats = get_stats(conn)
     assert stats["untailored_eligible"] == 1
 
@@ -591,7 +586,7 @@ def test_reset_tailor_clears_rejected_attempt_artifacts(
     repo.save(
         MaterialsSetFactory.initial(
             tenant_id=LOCAL_TENANT,
-            job_id=JobId(url),
+            job_id=_job_id(url),
             created_at="2024-01-01T00:00:00+00:00",
         ).with_resume_attempt(
             _make_resume_artifact(),
@@ -600,17 +595,19 @@ def test_reset_tailor_clears_rejected_attempt_artifacts(
             updated_at="2024-01-02T00:00:00+00:00",
         )
     )
-    ensure_job_stage_rows(conn, url, discovered_at="2024-01-01T00:00:00+00:00")
+    ensure_job_stage_rows(
+        conn, _job_id(url), tenant_id=LOCAL_TENANT, discovered_at="2024-01-01T00:00:00+00:00"
+    )
 
-    reset_job_stage(conn, url, "tailor")
+    reset_job_stage(conn, url, "tailor", tenant_id=LOCAL_TENANT)
 
     pending_after = {row["url"] for row in get_jobs_by_stage(conn=conn, stage="pending_tailor", min_score=7)}
     assert url in pending_after
 
     # Materials artifacts for the latest generation must be gone.
     artifact_count = conn.execute(
-        "SELECT COUNT(*) FROM job_materials_artifacts WHERE job_url = ?",
-        (url,),
+        "SELECT COUNT(*) FROM job_materials_artifacts WHERE tenant_id = ? AND job_id = ?",
+        (LOCAL_TENANT, _job_id(url)),
     ).fetchone()[0]
     assert artifact_count == 0
 
@@ -626,7 +623,7 @@ def test_reset_tailor_preserves_approved_materials_until_replacement(
     repo.save(
         MaterialsSetFactory.initial(
             tenant_id=LOCAL_TENANT,
-            job_id=JobId(url),
+            job_id=_job_id(url),
             created_at="2024-01-01T00:00:00+00:00",
         ).with_resume_attempt(
             _make_resume_artifact(),
@@ -635,15 +632,17 @@ def test_reset_tailor_preserves_approved_materials_until_replacement(
             updated_at="2024-01-02T00:00:00+00:00",
         )
     )
-    ensure_job_stage_rows(conn, url, discovered_at="2024-01-01T00:00:00+00:00")
+    ensure_job_stage_rows(
+        conn, _job_id(url), tenant_id=LOCAL_TENANT, discovered_at="2024-01-01T00:00:00+00:00"
+    )
 
-    reset_job_stage(conn, url, "tailor")
+    reset_job_stage(conn, url, "tailor", tenant_id=LOCAL_TENANT)
 
     pending_after = {row["url"] for row in get_jobs_by_stage(conn=conn, stage="pending_tailor", min_score=7)}
     assert url not in pending_after
     artifact_count = conn.execute(
-        "SELECT COUNT(*) FROM job_materials_artifacts WHERE job_url = ?",
-        (url,),
+        "SELECT COUNT(*) FROM job_materials_artifacts WHERE tenant_id = ? AND job_id = ?",
+        (LOCAL_TENANT, _job_id(url)),
     ).fetchone()[0]
     assert artifact_count == 1
 
@@ -656,7 +655,7 @@ def test_reset_cover_clears_only_failed_cover_artifacts(conn: sqlite3.Connection
     repo = SqliteMaterialsRepository(conn)
     materials = MaterialsSetFactory.initial(
         tenant_id=LOCAL_TENANT,
-        job_id=JobId(url),
+        job_id=_job_id(url),
         created_at="2024-01-01T00:00:00+00:00",
     ).with_resume_attempt(
         _make_resume_artifact(),
@@ -669,13 +668,15 @@ def test_reset_cover_clears_only_failed_cover_artifacts(conn: sqlite3.Connection
         updated_at="2024-01-03T00:00:00+00:00",
     )
     repo.save(materials)
-    ensure_job_stage_rows(conn, url, discovered_at="2024-01-01T00:00:00+00:00")
+    ensure_job_stage_rows(
+        conn, _job_id(url), tenant_id=LOCAL_TENANT, discovered_at="2024-01-01T00:00:00+00:00"
+    )
 
-    reset_job_stage(conn, url, "cover")
+    reset_job_stage(conn, url, "cover", tenant_id=LOCAL_TENANT)
 
     rows = conn.execute(
-        "SELECT artifact_type FROM job_materials_artifacts WHERE job_url = ?",
-        (url,),
+        "SELECT artifact_type FROM job_materials_artifacts WHERE tenant_id = ? AND job_id = ?",
+        (LOCAL_TENANT, _job_id(url)),
     ).fetchall()
     types = {row[0] for row in rows}
     assert "tailored_resume" in types
@@ -692,7 +693,7 @@ def test_reset_cover_preserves_approved_cover_until_replacement(
     repo = SqliteMaterialsRepository(conn)
     materials = MaterialsSetFactory.initial(
         tenant_id=LOCAL_TENANT,
-        job_id=JobId(url),
+        job_id=_job_id(url),
         created_at="2024-01-01T00:00:00+00:00",
     ).with_resume_attempt(
         _make_resume_artifact(),
@@ -705,13 +706,15 @@ def test_reset_cover_preserves_approved_cover_until_replacement(
         updated_at="2024-01-03T00:00:00+00:00",
     )
     repo.save(materials)
-    ensure_job_stage_rows(conn, url, discovered_at="2024-01-01T00:00:00+00:00")
+    ensure_job_stage_rows(
+        conn, _job_id(url), tenant_id=LOCAL_TENANT, discovered_at="2024-01-01T00:00:00+00:00"
+    )
 
-    reset_job_stage(conn, url, "cover")
+    reset_job_stage(conn, url, "cover", tenant_id=LOCAL_TENANT)
 
     rows = conn.execute(
-        "SELECT artifact_type FROM job_materials_artifacts WHERE job_url = ?",
-        (url,),
+        "SELECT artifact_type FROM job_materials_artifacts WHERE tenant_id = ? AND job_id = ?",
+        (LOCAL_TENANT, _job_id(url)),
     ).fetchall()
     types = {row[0] for row in rows}
     assert "tailored_resume" in types
@@ -740,24 +743,31 @@ def test_acquire_job_picks_up_materials_only_tailored_jobs(tmp_path) -> None:
     conn = init_db(db_path)
     try:
         url = "https://example.com/job"
+        job_id = _job_id(url)
         conn.execute(
-            "INSERT INTO jobs (url, title, site, application_url, "
-            "full_description, discovered_at) VALUES (?, ?, ?, ?, ?, ?)",
+            "INSERT INTO jobs (tenant_id, job_id, url, title, site, discovered_at) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
             (
+                LOCAL_TENANT,
+                job_id,
                 url,
                 "Engineer",
                 "Acme",
-                "https://example.com/apply",
-                "desc",
                 "2024-01-01T00:00:00+00:00",
             ),
+        )
+        conn.execute(
+            "INSERT INTO job_enrichments "
+            "(tenant_id, job_id, current_status, full_description, application_url, updated_at) "
+            "VALUES (?, ?, 'enriched', 'desc', 'https://example.com/apply', ?)",
+            (LOCAL_TENANT, job_id, "2024-01-01T00:00:00+00:00"),
         )
         conn.commit()
         # Score the job (apply requires fit_score >= min_score).
         SqliteScoreRepository(conn).save(
             JobScore.initial(
                 tenant_id=LOCAL_TENANT,
-                job_id=JobId(url),
+                job_id=job_id,
                 fit_score=FitScore.create(9),
                 breakdown=ScoreBreakdown(reasoning="ok"),
                 matched_keywords=MatchedKeywords.from_iterable(["python"]),
@@ -768,7 +778,7 @@ def test_acquire_job_picks_up_materials_only_tailored_jobs(tmp_path) -> None:
         SqliteMaterialsRepository(conn).save(
             MaterialsSetFactory.initial(
                 tenant_id=LOCAL_TENANT,
-                job_id=JobId(url),
+                job_id=job_id,
                 created_at="2024-01-01T00:00:00+00:00",
             ).with_resume_attempt(
                 _make_resume_artifact("/tmp/materials-resume.txt"),
@@ -781,7 +791,8 @@ def test_acquire_job_picks_up_materials_only_tailored_jobs(tmp_path) -> None:
             )
         )
         legacy_path = conn.execute(
-            "SELECT tailored_resume_path FROM jobs WHERE url = ?", (url,)
+            "SELECT tailored_resume_path FROM jobs WHERE tenant_id = ? AND job_id = ?",
+            (LOCAL_TENANT, job_id),
         ).fetchone()[0]
         assert legacy_path is None  # confirm no legacy write happened
 
@@ -816,23 +827,30 @@ def test_acquire_job_excludes_materials_only_text_resume_without_pdf(tmp_path) -
     conn = init_db(db_path)
     try:
         url = "https://example.com/job"
+        job_id = _job_id(url)
         conn.execute(
-            "INSERT INTO jobs (url, title, site, application_url, "
-            "full_description, discovered_at) VALUES (?, ?, ?, ?, ?, ?)",
+            "INSERT INTO jobs (tenant_id, job_id, url, title, site, discovered_at) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
             (
+                LOCAL_TENANT,
+                job_id,
                 url,
                 "Engineer",
                 "Acme",
-                "https://example.com/apply",
-                "desc",
                 "2024-01-01T00:00:00+00:00",
             ),
+        )
+        conn.execute(
+            "INSERT INTO job_enrichments "
+            "(tenant_id, job_id, current_status, full_description, application_url, updated_at) "
+            "VALUES (?, ?, 'enriched', 'desc', 'https://example.com/apply', ?)",
+            (LOCAL_TENANT, job_id, "2024-01-01T00:00:00+00:00"),
         )
         conn.commit()
         SqliteScoreRepository(conn).save(
             JobScore.initial(
                 tenant_id=LOCAL_TENANT,
-                job_id=JobId(url),
+                job_id=job_id,
                 fit_score=FitScore.create(9),
                 breakdown=ScoreBreakdown(reasoning="ok"),
                 matched_keywords=MatchedKeywords.from_iterable(["python"]),
@@ -842,7 +860,7 @@ def test_acquire_job_excludes_materials_only_text_resume_without_pdf(tmp_path) -
         SqliteMaterialsRepository(conn).save(
             MaterialsSetFactory.initial(
                 tenant_id=LOCAL_TENANT,
-                job_id=JobId(url),
+                job_id=job_id,
                 created_at="2024-01-01T00:00:00+00:00",
             ).with_resume_attempt(
                 _make_resume_artifact("/tmp/materials-resume.txt"),

--- a/workers/automation/tests/test_score_queue_selectors.py
+++ b/workers/automation/tests/test_score_queue_selectors.py
@@ -1,7 +1,8 @@
-"""Round-1 review B1 + B2 regression: worker queue selectors and stats
-must read the canonical fit score from ``job_scores`` (the new write
-target) and not from the legacy ``jobs.fit_score`` column (which is left
-NULL on the new path).
+"""Exact-v7 regressions for worker score queues and dashboard stats.
+
+Worker queue selectors and stats must read canonical scores from
+``job_scores`` by tenant-scoped JobId. Deprecated score columns on ``jobs``
+are not a runtime fallback.
 
 Without these fixes:
 
@@ -14,9 +15,8 @@ Without these fixes:
     ``score_distribution`` / ``untailored_eligible`` counts — dashboard
     funnel goes wrong.
 
-Each test seeds a job, scores it through ``ScoreRepository.save`` (so the
-legacy column stays NULL), and asserts the selector / stat reflects the
-new score.
+Each test seeds exact-v7 canonical rows, scores through
+``ScoreRepository.save``, and asserts the selector or stat reflects the score.
 """
 
 from __future__ import annotations
@@ -32,7 +32,7 @@ from jobctrl.database import (
     get_stats,
     init_db,
 )
-from jobctrl.domain.identifiers import JobId
+from jobctrl.domain.identifiers import JobId, generate_job_id
 from jobctrl.domain.scoring import (
     EligibilityAssessment,
     FitScore,
@@ -50,44 +50,65 @@ def conn(tmp_path: Path) -> sqlite3.Connection:
     return init_db(tmp_path / "jobctrl.db")
 
 
-def _seed_enriched_job(conn: sqlite3.Connection, url: str) -> None:
+def _seed_enriched_job(conn: sqlite3.Connection, url: str) -> JobId:
+    job_id = generate_job_id()
     conn.execute(
-        "INSERT INTO jobs (url, title, site, full_description, discovered_at) "
-        "VALUES (?, ?, ?, ?, ?)",
-        (url, "Engineer", "Acme", "Need Python.", "2024-01-01T00:00:00+00:00"),
+        "INSERT INTO jobs (tenant_id, job_id, url, title, site, discovered_at) "
+        "VALUES (?, ?, ?, ?, ?, ?)",
+        (
+            str(LOCAL_TENANT),
+            str(job_id),
+            url,
+            "Engineer",
+            "Acme",
+            "2024-01-01T00:00:00+00:00",
+        ),
+    )
+    conn.execute(
+        """
+        INSERT INTO job_enrichments (
+            tenant_id, job_id, current_status, full_description, updated_at
+        ) VALUES (?, ?, 'enriched', 'Need Python.', ?)
+        """,
+        (str(LOCAL_TENANT), str(job_id), "2024-01-01T00:00:00+00:00"),
     )
     conn.commit()
+    return job_id
 
 
-def _mark_closed(conn: sqlite3.Connection, url: str, state: str = "removed") -> None:
+def _mark_closed(
+    conn: sqlite3.Connection,
+    job_id: JobId,
+    state: str = "removed",
+) -> None:
     conn.execute(
         """
         INSERT INTO posting_snapshot_sets (
-            tenant_id, job_url, snapshot_set_json, latest_snapshot_version,
+            tenant_id, job_id, snapshot_set_json, latest_snapshot_version,
             latest_active_state, updated_at
         ) VALUES (?, ?, '{}', 0, ?, ?)
-        ON CONFLICT(tenant_id, job_url) DO UPDATE SET
+        ON CONFLICT(tenant_id, job_id) DO UPDATE SET
             latest_active_state = excluded.latest_active_state,
             updated_at = excluded.updated_at
         """,
-        (str(LOCAL_TENANT), url, state, utc_now()),
+        (str(LOCAL_TENANT), str(job_id), state, utc_now()),
     )
     conn.commit()
 
 
 def _save_score(
     conn: sqlite3.Connection,
-    url: str,
+    job_id: JobId,
     fit: int = 8,
     *,
     eligibility: EligibilityAssessment | None = None,
 ) -> None:
-    """Save a JobScore through the new repository — leaves jobs.fit_score NULL."""
+    """Save a canonical JobScore through the Scoring repository."""
     repo = SqliteScoreRepository(conn)
     repo.save(
         JobScore.initial(
             tenant_id=LOCAL_TENANT,
-            job_id=JobId(url),
+            job_id=job_id,
             fit_score=FitScore.create(fit),
             breakdown=ScoreBreakdown(reasoning="ok", eligibility=eligibility or EligibilityAssessment()),
             matched_keywords=MatchedKeywords.from_iterable(["python"]),
@@ -96,18 +117,65 @@ def _save_score(
     )
 
 
-def _insert_active_score_staleness_marker(conn: sqlite3.Connection, url: str) -> None:
+def _insert_active_score_staleness_marker(
+    conn: sqlite3.Connection,
+    job_id: JobId,
+) -> None:
     conn.execute(
         """
         INSERT INTO job_score_staleness (
-            tenant_id, job_url, stale_reason,
+            tenant_id, job_id, stale_reason,
             old_policy_id, old_policy_version,
             new_policy_id, new_policy_version,
             marked_at, resolved, resolved_at, resolved_by_score_version
         ) VALUES (?, ?, 'scoring_policy_changed', 'local:scoring-policy-v1', 1,
                   'local:scoring-policy-v2', 2, ?, 0, NULL, NULL)
         """,
-        (str(LOCAL_TENANT), url, datetime.now(timezone.utc).isoformat()),
+        (str(LOCAL_TENANT), str(job_id), datetime.now(timezone.utc).isoformat()),
+    )
+    conn.commit()
+
+
+def _seed_approved_tailored_resume(
+    conn: sqlite3.Connection,
+    job_id: JobId,
+) -> None:
+    created_at = "2024-01-02T00:00:00+00:00"
+    conn.execute(
+        """
+        INSERT INTO job_materials (
+            tenant_id, job_id, generation, status, created_at, updated_at
+        ) VALUES (?, ?, 1, 'approved', ?, ?)
+        """,
+        (str(LOCAL_TENANT), str(job_id), created_at, created_at),
+    )
+    conn.executemany(
+        """
+        INSERT INTO job_materials_artifacts (
+            tenant_id, job_id, generation, artifact_type, artifact_id,
+            status, path, render_format, created_at
+        ) VALUES (?, ?, 1, ?, ?, 'approved', ?, ?, ?)
+        """,
+        [
+            (
+                str(LOCAL_TENANT),
+                str(job_id),
+                "tailored_resume",
+                f"{job_id}:tailored-resume",
+                f"/tmp/{job_id}-tailored.txt",
+                "text",
+                created_at,
+            ),
+            (
+                str(LOCAL_TENANT),
+                str(job_id),
+                "resume_pdf",
+                f"{job_id}:resume-pdf",
+                f"/tmp/{job_id}-resume.pdf",
+                "latex_pdf",
+                created_at,
+            ),
+        ],
     )
     conn.commit()
 
@@ -121,23 +189,24 @@ def test_pending_score_excludes_jobs_already_in_job_scores(
     conn: sqlite3.Connection,
 ) -> None:
     url = "https://example.com/job/scored"
-    _seed_enriched_job(conn, url)
+    job_id = _seed_enriched_job(conn, url)
 
     # Pre-condition: the job is pending_score.
     pending_before = get_jobs_by_stage(conn=conn, stage="pending_score")
-    assert {row["url"] for row in pending_before} == {url}
+    assert {row["job_id"] for row in pending_before} == {job_id}
 
     # Action: persist a score through the new repository.
-    _save_score(conn, url, fit=8)
+    _save_score(conn, job_id, fit=8)
 
     # Post-condition: the job is no longer pending_score.
     pending_after = get_jobs_by_stage(conn=conn, stage="pending_score")
     assert pending_after == []
 
-    # And the legacy column is still NULL — proves the selector is
-    # reading the canonical job_scores row, not jobs.fit_score.
-    legacy = conn.execute("SELECT fit_score FROM jobs WHERE url=?", (url,)).fetchone()
-    assert legacy["fit_score"] is None
+    deprecated = conn.execute(
+        "SELECT fit_score FROM jobs WHERE tenant_id = ? AND job_id = ?",
+        (str(LOCAL_TENANT), str(job_id)),
+    ).fetchone()
+    assert deprecated["fit_score"] is None
 
 
 def test_pending_score_excludes_jobs_at_attempt_cap(
@@ -147,14 +216,23 @@ def test_pending_score_excludes_jobs_at_attempt_cap(
     pending_score — otherwise a permanently-failing job re-bills the LLM
     on every batch forever. Mirrors the tailor / cover ``< 5`` cap."""
     url = "https://example.com/job/score-capped"
-    _seed_enriched_job(conn, url)
-    ensure_job_stage_rows(conn, url)
+    job_id = _seed_enriched_job(conn, url)
+    ensure_job_stage_rows(conn, job_id)
     set_stage_state(
-        conn, url, "score", "running",
-        started_at="2024-01-02T00:00:00+00:00", validate_transition=False,
+        conn,
+        job_id,
+        "score",
+        "running",
+        started_at="2024-01-02T00:00:00+00:00",
+        validate_transition=False,
     )
     set_stage_state(
-        conn, url, "score", "failed", attempt_count=5, validate_transition=False,
+        conn,
+        job_id,
+        "score",
+        "failed",
+        attempt_count=5,
+        validate_transition=False,
     )
 
     assert get_jobs_by_stage(conn=conn, stage="pending_score") == []
@@ -165,18 +243,27 @@ def test_pending_score_includes_jobs_under_attempt_cap(
 ) -> None:
     """A job with fewer than 5 score attempts is still eligible."""
     url = "https://example.com/job/score-under-cap"
-    _seed_enriched_job(conn, url)
-    ensure_job_stage_rows(conn, url)
+    job_id = _seed_enriched_job(conn, url)
+    ensure_job_stage_rows(conn, job_id)
     set_stage_state(
-        conn, url, "score", "running",
-        started_at="2024-01-02T00:00:00+00:00", validate_transition=False,
+        conn,
+        job_id,
+        "score",
+        "running",
+        started_at="2024-01-02T00:00:00+00:00",
+        validate_transition=False,
     )
     set_stage_state(
-        conn, url, "score", "failed", attempt_count=4, validate_transition=False,
+        conn,
+        job_id,
+        "score",
+        "failed",
+        attempt_count=4,
+        validate_transition=False,
     )
 
-    urls = {row["url"] for row in get_jobs_by_stage(conn=conn, stage="pending_score")}
-    assert url in urls
+    job_ids = {row["job_id"] for row in get_jobs_by_stage(conn=conn, stage="pending_score")}
+    assert job_id in job_ids
 
 
 def test_count_pending_score_uses_same_attempt_cap_as_selector(
@@ -188,14 +275,23 @@ def test_count_pending_score_uses_same_attempt_cap_as_selector(
     capped_url = "https://example.com/job/count-score-capped"
     eligible_url = "https://example.com/job/count-score-under-cap"
     for url, attempts in ((capped_url, 5), (eligible_url, 4)):
-        _seed_enriched_job(conn, url)
-        ensure_job_stage_rows(conn, url)
+        job_id = _seed_enriched_job(conn, url)
+        ensure_job_stage_rows(conn, job_id)
         set_stage_state(
-            conn, url, "score", "running",
-            started_at="2024-01-02T00:00:00+00:00", validate_transition=False,
+            conn,
+            job_id,
+            "score",
+            "running",
+            started_at="2024-01-02T00:00:00+00:00",
+            validate_transition=False,
         )
         set_stage_state(
-            conn, url, "score", "failed", attempt_count=attempts, validate_transition=False,
+            conn,
+            job_id,
+            "score",
+            "failed",
+            attempt_count=attempts,
+            validate_transition=False,
         )
 
     monkeypatch.setattr(pipeline_runner, "get_connection", lambda: conn)
@@ -211,16 +307,17 @@ def test_closed_postings_are_excluded_from_score_and_tailor_queues(
 
     score_url = "https://example.com/job/closed-score"
     tailor_url = "https://example.com/job/closed-tailor"
-    _seed_enriched_job(conn, score_url)
-    _seed_enriched_job(conn, tailor_url)
-    _save_score(conn, tailor_url, fit=8)
-    _mark_closed(conn, score_url)
-    _mark_closed(conn, tailor_url)
+    score_job_id = _seed_enriched_job(conn, score_url)
+    tailor_job_id = _seed_enriched_job(conn, tailor_url)
+    _save_score(conn, tailor_job_id, fit=8)
+    _mark_closed(conn, score_job_id)
+    _mark_closed(conn, tailor_job_id)
     monkeypatch.setattr(pipeline_runner, "get_connection", lambda: conn)
 
-    assert {row["url"] for row in get_jobs_by_stage(conn=conn, stage="pending_score")} == set()
+    assert get_jobs_by_stage(conn=conn, stage="pending_score") == []
     assert {
-        row["url"] for row in get_jobs_by_stage(conn=conn, stage="pending_tailor", min_score=7)
+        row["job_id"]
+        for row in get_jobs_by_stage(conn=conn, stage="pending_tailor", min_score=7)
     } == set()
     assert pipeline._count_pending("score") == 0
     assert pipeline._count_pending("tailor", min_score=7) == 0
@@ -230,71 +327,63 @@ def test_pending_tailor_includes_jobs_scored_through_repository(
     conn: sqlite3.Connection,
 ) -> None:
     url = "https://example.com/job/ready-to-tailor"
-    _seed_enriched_job(conn, url)
-    _save_score(conn, url, fit=8)
+    job_id = _seed_enriched_job(conn, url)
+    _save_score(conn, job_id, fit=8)
 
-    # The new selector must find the job under pending_tailor even though
-    # jobs.fit_score is NULL — the COALESCE picks up the canonical
-    # job_scores row.
     pending = get_jobs_by_stage(conn=conn, stage="pending_tailor", min_score=7)
-    urls = {row["url"] for row in pending}
-    assert url in urls
+    job_ids = {row["job_id"] for row in pending}
+    assert job_id in job_ids
 
 
 def test_pending_tailor_excludes_score_five_even_when_threshold_is_lowered(
     conn: sqlite3.Connection,
-) -> None:
+    ) -> None:
     low_url = "https://example.com/job/low-fit-tailor"
     ok_url = "https://example.com/job/minimum-fit-tailor"
-    _seed_enriched_job(conn, low_url)
-    _seed_enriched_job(conn, ok_url)
-    _save_score(conn, low_url, fit=5)
-    _save_score(conn, ok_url, fit=6)
+    low_job_id = _seed_enriched_job(conn, low_url)
+    ok_job_id = _seed_enriched_job(conn, ok_url)
+    _save_score(conn, low_job_id, fit=5)
+    _save_score(conn, ok_job_id, fit=6)
 
     pending = get_jobs_by_stage(conn=conn, stage="pending_tailor", min_score=5)
-    urls = {row["url"] for row in pending}
+    job_ids = {row["job_id"] for row in pending}
 
-    assert low_url not in urls
-    assert ok_url in urls
+    assert low_job_id not in job_ids
+    assert ok_job_id in job_ids
 
 
 def test_pending_tailor_excludes_high_score_blocked_jobs(
     conn: sqlite3.Connection,
-) -> None:
+    ) -> None:
     url_allowed = "https://example.com/job/allowed-tailor"
     url_blocked = "https://example.com/job/blocked-tailor"
-    _seed_enriched_job(conn, url_allowed)
-    _seed_enriched_job(conn, url_blocked)
-    _save_score(conn, url_allowed, fit=8)
+    allowed_job_id = _seed_enriched_job(conn, url_allowed)
+    blocked_job_id = _seed_enriched_job(conn, url_blocked)
+    _save_score(conn, allowed_job_id, fit=8)
     _save_score(
         conn,
-        url_blocked,
+        blocked_job_id,
         fit=9,
         eligibility=EligibilityAssessment(status="blocked", hard_blockers=("No sponsorship.",)),
     )
 
     pending = get_jobs_by_stage(conn=conn, stage="pending_tailor", min_score=7)
-    urls = {row["url"] for row in pending}
-    assert url_allowed in urls
-    assert url_blocked not in urls
+    job_ids = {row["job_id"] for row in pending}
+    assert allowed_job_id in job_ids
+    assert blocked_job_id not in job_ids
 
 
 def test_pending_cover_includes_jobs_scored_through_repository(
     conn: sqlite3.Connection,
 ) -> None:
     url = "https://example.com/job/ready-to-cover"
-    _seed_enriched_job(conn, url)
-    _save_score(conn, url, fit=9)
-    # Cover stage requires a tailored resume.
-    conn.execute(
-        "UPDATE jobs SET tailored_resume_path=?, tailored_at=? WHERE url=?",
-        ("/tmp/tailored.txt", "2024-01-02T00:00:00+00:00", url),
-    )
-    conn.commit()
+    job_id = _seed_enriched_job(conn, url)
+    _save_score(conn, job_id, fit=9)
+    _seed_approved_tailored_resume(conn, job_id)
 
     pending = get_jobs_by_stage(conn=conn, stage="pending_cover", min_score=7)
-    urls = {row["url"] for row in pending}
-    assert url in urls
+    job_ids = {row["job_id"] for row in pending}
+    assert job_id in job_ids
 
 
 def test_closed_postings_are_excluded_from_cover_queue(
@@ -304,47 +393,38 @@ def test_closed_postings_are_excluded_from_cover_queue(
     from jobctrl.pipeline import runner as pipeline_runner
 
     url = "https://example.com/job/closed-cover"
-    _seed_enriched_job(conn, url)
-    _save_score(conn, url, fit=9)
-    conn.execute(
-        "UPDATE jobs SET tailored_resume_path=?, tailored_at=? WHERE url=?",
-        ("/tmp/tailored.txt", "2024-01-02T00:00:00+00:00", url),
-    )
-    _mark_closed(conn, url)
+    job_id = _seed_enriched_job(conn, url)
+    _save_score(conn, job_id, fit=9)
+    _seed_approved_tailored_resume(conn, job_id)
+    _mark_closed(conn, job_id)
     monkeypatch.setattr(pipeline_runner, "get_connection", lambda: conn)
 
     pending_cover = get_jobs_by_stage(conn=conn, stage="pending_cover", min_score=7)
-    assert {row["url"] for row in pending_cover} == set()
+    assert pending_cover == []
     assert pipeline._count_pending("cover", min_score=7) == 0
 
 
 def test_pending_cover_excludes_high_score_blocked_jobs(
     conn: sqlite3.Connection,
-) -> None:
+    ) -> None:
     url_allowed = "https://example.com/job/allowed-cover"
     url_blocked = "https://example.com/job/blocked-cover"
-    _seed_enriched_job(conn, url_allowed)
-    _seed_enriched_job(conn, url_blocked)
-    _save_score(conn, url_allowed, fit=8)
+    allowed_job_id = _seed_enriched_job(conn, url_allowed)
+    blocked_job_id = _seed_enriched_job(conn, url_blocked)
+    _save_score(conn, allowed_job_id, fit=8)
     _save_score(
         conn,
-        url_blocked,
+        blocked_job_id,
         fit=9,
         eligibility=EligibilityAssessment(status="eligible", hard_blockers=("Below minimum salary.",)),
     )
-    conn.executemany(
-        "UPDATE jobs SET tailored_resume_path=?, tailored_at=? WHERE url=?",
-        [
-            ("/tmp/allowed-tailored.txt", "2024-01-02T00:00:00+00:00", url_allowed),
-            ("/tmp/blocked-tailored.txt", "2024-01-02T00:00:00+00:00", url_blocked),
-        ],
-    )
-    conn.commit()
+    _seed_approved_tailored_resume(conn, allowed_job_id)
+    _seed_approved_tailored_resume(conn, blocked_job_id)
 
     pending = get_jobs_by_stage(conn=conn, stage="pending_cover", min_score=7)
-    urls = {row["url"] for row in pending}
-    assert url_allowed in urls
-    assert url_blocked not in urls
+    job_ids = {row["job_id"] for row in pending}
+    assert allowed_job_id in job_ids
+    assert blocked_job_id not in job_ids
 
 
 @pytest.mark.parametrize("stage", ["pending_tailor", "pending_cover"])
@@ -363,35 +443,30 @@ def test_downstream_materials_selectors_exclude_non_current_scores(
     active_marker: bool,
 ) -> None:
     url = f"https://example.com/job/non-current-{stage}-{score_state}-{active_marker}"
-    _seed_enriched_job(conn, url)
-    _save_score(conn, url, fit=9)
-    ensure_job_stage_rows(conn, url)
-    set_stage_state(conn, url, "score", score_state, validate_transition=False)
+    job_id = _seed_enriched_job(conn, url)
+    _save_score(conn, job_id, fit=9)
+    ensure_job_stage_rows(conn, job_id)
+    set_stage_state(conn, job_id, "score", score_state, validate_transition=False)
     if active_marker:
-        _insert_active_score_staleness_marker(conn, url)
+        _insert_active_score_staleness_marker(conn, job_id)
     if stage == "pending_cover":
-        conn.execute(
-            "UPDATE jobs SET tailored_resume_path=?, tailored_at=? WHERE url=?",
-            ("/tmp/tailored.txt", "2024-01-02T00:00:00+00:00", url),
-        )
-        conn.commit()
+        _seed_approved_tailored_resume(conn, job_id)
 
     pending = get_jobs_by_stage(conn=conn, stage=stage, min_score=7)
-    urls = {row["url"] for row in pending}
-    assert url not in urls
+    job_ids = {row["job_id"] for row in pending}
+    assert job_id not in job_ids
 
 
 def test_get_jobs_by_stage_returns_canonical_score_in_dict(
     conn: sqlite3.Connection,
 ) -> None:
-    """Returned dicts surface the canonical fit_score so legacy callers
-    that read ``job["fit_score"]`` see the new value (not NULL)."""
+    """Returned selector records expose the canonical score value."""
     url = "https://example.com/job/dict"
-    _seed_enriched_job(conn, url)
-    _save_score(conn, url, fit=6)
+    job_id = _seed_enriched_job(conn, url)
+    _save_score(conn, job_id, fit=6)
 
     rows = get_jobs_by_stage(conn=conn, stage="enriched")
-    matching = next(row for row in rows if row["url"] == url)
+    matching = next(row for row in rows if row["job_id"] == job_id)
     assert matching["fit_score"] == 6
 
 
@@ -403,9 +478,9 @@ def test_get_jobs_by_stage_returns_canonical_score_in_dict(
 def test_get_stats_counts_repository_scores(conn: sqlite3.Connection) -> None:
     url_scored = "https://example.com/job/has-score"
     url_pending = "https://example.com/job/no-score"
-    _seed_enriched_job(conn, url_scored)
+    scored_job_id = _seed_enriched_job(conn, url_scored)
     _seed_enriched_job(conn, url_pending)
-    _save_score(conn, url_scored, fit=8)
+    _save_score(conn, scored_job_id, fit=8)
 
     stats = get_stats(conn)
     assert stats["scored"] == 1
@@ -419,26 +494,35 @@ def test_get_stats_untailored_eligible_uses_canonical_score(
     conn: sqlite3.Connection,
 ) -> None:
     url = "https://example.com/job/eligible"
-    _seed_enriched_job(conn, url)
-    _save_score(conn, url, fit=9)
+    job_id = _seed_enriched_job(conn, url)
+    _save_score(conn, job_id, fit=9)
 
     stats = get_stats(conn)
     # Eligible = score >= 7, has description, no tailored resume.
     assert stats["untailored_eligible"] == 1
 
 
-def test_get_stats_falls_back_to_legacy_column(conn: sqlite3.Connection) -> None:
-    """Pre-Phase-5 rows that only exist in ``jobs.fit_score`` should
-    still be counted (the COALESCE picks them up)."""
-    url = "https://example.com/job/legacy"
-    _seed_enriched_job(conn, url)
-    conn.execute("UPDATE jobs SET fit_score=?, scored_at=? WHERE url=?", (5, "2023-01-01", url))
+def test_get_stats_ignores_deprecated_jobs_score_columns(
+    conn: sqlite3.Connection,
+) -> None:
+    """Exact-v7 runtime never treats deprecated job columns as score state."""
+    url = "https://example.com/job/deprecated-score-column"
+    job_id = _seed_enriched_job(conn, url)
+    conn.execute(
+        """
+        UPDATE jobs
+           SET fit_score = ?, scored_at = ?
+         WHERE tenant_id = ? AND job_id = ?
+        """,
+        (5, "2023-01-01", str(LOCAL_TENANT), str(job_id)),
+    )
     conn.commit()
 
     stats = get_stats(conn)
-    assert stats["scored"] == 1
+    assert stats["scored"] == 0
+    assert stats["unscored"] == 1
     distribution = dict(stats["score_distribution"])
-    assert distribution.get(5) == 1
+    assert 5 not in distribution
 
 
 # ---------------------------------------------------------------------------
@@ -456,11 +540,11 @@ def test_pipeline_count_pending_score_excludes_repository_rows(
     from jobctrl.pipeline import runner as pipeline_runner
 
     url = "https://example.com/job/pipeline"
-    _seed_enriched_job(conn, url)
+    job_id = _seed_enriched_job(conn, url)
     monkeypatch.setattr(pipeline_runner, "get_connection", lambda: conn)
 
     assert pipeline._count_pending("score") == 1
-    _save_score(conn, url, fit=8)
+    _save_score(conn, job_id, fit=8)
     assert pipeline._count_pending("score") == 0
 
 
@@ -471,8 +555,8 @@ def test_pipeline_count_pending_tailor_picks_repository_scores(
     from jobctrl.pipeline import runner as pipeline_runner
 
     url = "https://example.com/job/pipeline-tailor"
-    _seed_enriched_job(conn, url)
-    _save_score(conn, url, fit=8)
+    job_id = _seed_enriched_job(conn, url)
+    _save_score(conn, job_id, fit=8)
     monkeypatch.setattr(pipeline_runner, "get_connection", lambda: conn)
 
     assert pipeline._count_pending("tailor", min_score=7) == 1
@@ -485,10 +569,10 @@ def test_pipeline_count_pending_tailor_excludes_pending_rescore(
     from jobctrl.pipeline import runner as pipeline_runner
 
     url = "https://example.com/job/pipeline-tailor-pending-rescore"
-    _seed_enriched_job(conn, url)
-    _save_score(conn, url, fit=8)
-    ensure_job_stage_rows(conn, url)
-    set_stage_state(conn, url, "score", "pending", validate_transition=False)
+    job_id = _seed_enriched_job(conn, url)
+    _save_score(conn, job_id, fit=8)
+    ensure_job_stage_rows(conn, job_id)
+    set_stage_state(conn, job_id, "score", "pending", validate_transition=False)
     monkeypatch.setattr(pipeline_runner, "get_connection", lambda: conn)
 
     assert pipeline._count_pending("tailor", min_score=7) == 0


### PR DESCRIPTION
## Summary
- migrate apply queue selector fixtures to canonical tenant-scoped JobIds
- migrate materials selector, stats, and count fixtures to exact schema v7
- preserve canonical material-path projection coverage

## Why
The one-shot v6 to v7 cutover intentionally rejects URL-only job rows. These focused fixtures must exercise the same exact schema as the local runtime.

## Validation
- 9 apply selector cases passed
- 14 materials selector/stat/count cases passed
- focused Ruff checks passed
- git diff --check passed
- independent review: PASS (0 findings after restoring material-path coverage)

## Stack
- Depends on #626
- Acquire/reset runtime fixture migration remains in the next bounded implementation slices