### PR TITLE
refactor(apply): claim jobs by canonical id

### DIFF
--- a/apps/api/src/repeat-application.ts
+++ b/apps/api/src/repeat-application.ts
@@ -17,6 +17,7 @@ import { InputError } from "./write-model.js";
 const DEFAULT_TENANT = "local";
 
 interface JobIdentityRow extends Record<string, unknown> {
+  job_id: string;
   url: string;
   title: string | null;
   company: string | null;
@@ -24,7 +25,7 @@ interface JobIdentityRow extends Record<string, unknown> {
 }
 
 interface ConfirmedFactRow extends Record<string, unknown> {
-  job_key: string;
+  job_id: string;
   fact_kind: RepeatApplicationFactKind;
   fact_id: string;
   confirmed_at: string;
@@ -32,7 +33,7 @@ interface ConfirmedFactRow extends Record<string, unknown> {
 }
 
 interface CanonicalIdentityRow extends Record<string, unknown> {
-  job_url: string;
+  job_id: string;
   canonical_url: string;
   ats_kind: string;
   source_native_id: string;
@@ -46,8 +47,8 @@ interface DuplicateLinkRow extends Record<string, unknown> {
 
 interface OverrideRow extends Record<string, unknown> {
   override_id: string;
-  target_job_key: string;
-  prior_job_key: string;
+  target_job_id: string;
+  prior_job_id: string;
   evidence_fingerprint: string;
   reason: string;
   confirmed_by: string;
@@ -58,82 +59,84 @@ interface OverrideRow extends Record<string, unknown> {
 
 interface AuditRow extends Record<string, unknown> {
   audit_id: string;
-  target_job_key: string;
+  target_job_id: string;
   action: RepeatApplicationAuditEntry["action"];
   evidence_fingerprint: string;
   evidence_json: string;
   override_id: string | null;
-  prior_job_key: string | null;
+  prior_job_id: string | null;
   actor: string;
   reason: string | null;
   occurred_at: string;
 }
 
+type RepeatFingerprintMatch = Omit<RepeatApplicationMatch, "priorApplication"> & {
+  priorApplication: Omit<RepeatApplicationMatch["priorApplication"], "jobId"> & {
+    jobId: string;
+  };
+};
+
 export function ensureRepeatApplicationTables(db: SqliteDatabase): void {
   db.exec(`
     CREATE TABLE IF NOT EXISTS application_repeat_overrides (
-      tenant_id            TEXT NOT NULL DEFAULT 'local',
-      override_id          TEXT NOT NULL,
-      target_job_key       TEXT NOT NULL,
-      prior_job_key        TEXT NOT NULL,
-      relationship         TEXT NOT NULL,
+      tenant_id TEXT NOT NULL DEFAULT 'local',
+      override_id TEXT NOT NULL,
+      target_job_id TEXT NOT NULL,
+      prior_job_id TEXT NOT NULL,
+      relationship TEXT NOT NULL,
       evidence_fingerprint TEXT NOT NULL,
-      evidence_json        TEXT NOT NULL,
-      reason               TEXT NOT NULL,
-      confirmed_by         TEXT NOT NULL,
-      confirmed_at         TEXT NOT NULL,
-      PRIMARY KEY (tenant_id, override_id)
+      evidence_json TEXT NOT NULL,
+      reason TEXT NOT NULL,
+      confirmed_by TEXT NOT NULL,
+      confirmed_at TEXT NOT NULL,
+      PRIMARY KEY (tenant_id, override_id),
+      FOREIGN KEY (tenant_id, target_job_id) REFERENCES jobs(tenant_id, job_id) ON DELETE CASCADE,
+      FOREIGN KEY (tenant_id, prior_job_id) REFERENCES jobs(tenant_id, job_id) ON DELETE CASCADE
     );
     CREATE INDEX IF NOT EXISTS idx_application_repeat_overrides_target
-      ON application_repeat_overrides(tenant_id, target_job_key, confirmed_at DESC);
-
+      ON application_repeat_overrides(tenant_id, target_job_id, confirmed_at DESC);
     CREATE TABLE IF NOT EXISTS application_repeat_override_consumptions (
-      tenant_id    TEXT NOT NULL DEFAULT 'local',
-      override_id  TEXT NOT NULL,
-      run_id       TEXT NOT NULL,
-      consumed_at  TEXT NOT NULL,
+      tenant_id TEXT NOT NULL DEFAULT 'local',
+      override_id TEXT NOT NULL,
+      run_id TEXT NOT NULL,
+      consumed_at TEXT NOT NULL,
       PRIMARY KEY (tenant_id, override_id),
       UNIQUE (tenant_id, run_id)
     );
-
     CREATE TABLE IF NOT EXISTS application_repeat_audit (
-      tenant_id            TEXT NOT NULL DEFAULT 'local',
-      audit_id             TEXT NOT NULL,
-      audit_key            TEXT NOT NULL,
-      target_job_key       TEXT NOT NULL,
-      action               TEXT NOT NULL,
+      tenant_id TEXT NOT NULL DEFAULT 'local',
+      audit_id TEXT NOT NULL,
+      audit_key TEXT NOT NULL,
+      target_job_id TEXT NOT NULL,
+      action TEXT NOT NULL,
       evidence_fingerprint TEXT NOT NULL,
-      evidence_json        TEXT NOT NULL,
-      override_id          TEXT,
-      actor                TEXT NOT NULL,
-      reason               TEXT,
-      occurred_at          TEXT NOT NULL,
+      evidence_json TEXT NOT NULL,
+      override_id TEXT,
+      actor TEXT NOT NULL,
+      reason TEXT,
+      occurred_at TEXT NOT NULL,
       PRIMARY KEY (tenant_id, audit_id),
-      UNIQUE (tenant_id, audit_key)
+      UNIQUE (tenant_id, audit_key),
+      FOREIGN KEY (tenant_id, target_job_id) REFERENCES jobs(tenant_id, job_id) ON DELETE CASCADE
     );
     CREATE INDEX IF NOT EXISTS idx_application_repeat_audit_target
-      ON application_repeat_audit(tenant_id, target_job_key, occurred_at DESC);
+      ON application_repeat_audit(tenant_id, target_job_id, occurred_at DESC);
   `);
 }
 
 export function evaluateRepeatApplication(
   db: SqliteDatabase,
-  targetJobKey: string,
+  targetJobId: string,
   options: { recordAudit?: boolean; evaluatedAt?: string } = {},
 ): RepeatApplicationAssessment {
   ensureRepeatApplicationTables(db);
   const evaluatedAt = options.evaluatedAt ?? new Date().toISOString();
-  const target = jobIdentity(db, targetJobKey);
-  if (!target) {
-    throw new InputError("Job not found.");
-  }
-
-  const confirmedFacts = confirmedApplicationFacts(db);
-  const matches = confirmedFacts
+  const target = jobIdentity(db, targetJobId);
+  if (!target) throw new InputError("Job not found.");
+  const matches = confirmedApplicationFacts(db)
     .map((fact) => relationshipMatch(db, target, fact))
     .filter((match): match is RepeatApplicationMatch => match !== null)
     .sort(compareMatches);
-
   if (!matches.length) {
     return {
       status: "clear",
@@ -142,39 +145,36 @@ export function evaluateRepeatApplication(
       evaluatedAt,
       matches: [],
       override: null,
-      auditTrail: auditTrail(db, targetJobKey),
+      auditTrail: auditTrail(db, targetJobId),
     };
   }
-
-  const evidenceFingerprint = repeatEvidenceFingerprint(targetJobKey, matches);
-  const override = matchingOverride(db, targetJobKey, evidenceFingerprint);
+  const fingerprintMatches = matches.map((match) => {
+    const prior = jobIdentity(db, match.priorApplication.jobId);
+    if (!prior) throw new InputError("Repeat evidence references an unknown prior job.");
+    return { ...match, priorApplication: { ...match.priorApplication, jobId: prior.job_id } };
+  });
+  const evidenceFingerprint = repeatEvidenceFingerprint(target.job_id, fingerprintMatches);
+  const override = matchingOverride(db, targetJobId, evidenceFingerprint);
   const exact = matches.some((match) => match.relationship !== "same_employer_equivalent_role");
-  let status: RepeatApplicationAssessment["status"];
-  let summary: string;
-  if (override && !override.consumedAt) {
-    status = "override_ready";
-    summary = "A reasoned confirmation is recorded for one live attempt against this exact evidence.";
-  } else if (override?.consumedAt) {
-    status = "override_consumed";
-    summary = "The prior confirmation was already used; another live attempt requires a new confirmation.";
-  } else if (exact) {
-    status = "blocked";
-    summary = "A confirmed application to this canonical opening blocks another live submission by default.";
-  } else {
-    status = "confirmation_required";
-    summary = "A confirmed application to the same employer and an equivalent role requires deliberate confirmation.";
-  }
-
+  const status: RepeatApplicationAssessment["status"] = override
+    ? override.consumedAt ? "override_consumed" : "override_ready"
+    : exact ? "blocked" : "confirmation_required";
+  const summary = status === "override_ready"
+    ? "A reasoned confirmation is recorded for one live attempt against this exact evidence."
+    : status === "override_consumed"
+      ? "The prior confirmation was already used; another live attempt requires a new confirmation."
+      : status === "blocked"
+        ? "A confirmed application to this canonical opening blocks another live submission by default."
+        : "A confirmed application to the same employer and an equivalent role requires deliberate confirmation.";
   if (options.recordAudit !== false && (status === "blocked" || status === "confirmation_required")) {
     recordAssessmentAudit(db, {
-      targetJobKey,
+      targetJobId,
       action: status,
       evidenceFingerprint,
       matches,
       occurredAt: evaluatedAt,
     });
   }
-
   return {
     status,
     summary,
@@ -182,18 +182,18 @@ export function evaluateRepeatApplication(
     evaluatedAt,
     matches,
     override,
-    auditTrail: auditTrail(db, targetJobKey),
+    auditTrail: auditTrail(db, targetJobId),
   };
 }
 
 export function recordRepeatApplicationOverride(
   db: SqliteDatabase,
-  targetJobKey: string,
+  targetJobId: string,
   request: RepeatApplicationOverrideRequest,
 ): RepeatApplicationOverrideResponse {
   ensureRepeatApplicationTables(db);
   const transact = db.transaction(() => {
-    const assessment = evaluateRepeatApplication(db, targetJobKey);
+    const assessment = evaluateRepeatApplication(db, targetJobId);
     if (!assessment.evidenceFingerprint || assessment.status === "clear") {
       throw new InputError("repeat_application_confirmation_not_required");
     }
@@ -201,34 +201,24 @@ export function recordRepeatApplicationOverride(
       throw new InputError("repeat_application_evidence_stale");
     }
     const selectedPrior = assessment.matches.find(
-      (match) => match.priorApplication.jobKey === request.priorJobKey,
+      (match) => match.priorApplication.jobId === request.priorJobId,
     );
-    if (!selectedPrior) {
-      throw new InputError("repeat_application_prior_mismatch");
-    }
-
+    if (!selectedPrior) throw new InputError("repeat_application_prior_mismatch");
     const confirmedAt = new Date().toISOString();
     const overrideId = randomUUID();
     db.prepare(
       `INSERT INTO application_repeat_overrides (
-         tenant_id, override_id, target_job_key, prior_job_key, relationship,
+         tenant_id, override_id, target_job_id, prior_job_id, relationship,
          evidence_fingerprint, evidence_json, reason, confirmed_by, confirmed_at
        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     ).run(
-      DEFAULT_TENANT,
-      overrideId,
-      targetJobKey,
-      request.priorJobKey,
-      selectedPrior.relationship,
-      assessment.evidenceFingerprint,
-      JSON.stringify(assessment.matches),
-      request.reason,
-      request.confirmedBy,
-      confirmedAt,
+      DEFAULT_TENANT, overrideId, targetJobId, request.priorJobId, selectedPrior.relationship,
+      assessment.evidenceFingerprint, JSON.stringify(assessment.matches), request.reason,
+      request.confirmedBy, confirmedAt,
     );
     insertAudit(db, {
       auditKey: `override_recorded:${overrideId}`,
-      targetJobKey,
+      targetJobId,
       action: "override_recorded",
       evidenceFingerprint: assessment.evidenceFingerprint,
       evidenceJson: JSON.stringify(assessment.matches),
@@ -237,22 +227,17 @@ export function recordRepeatApplicationOverride(
       reason: request.reason,
       occurredAt: confirmedAt,
     });
-    return evaluateRepeatApplication(db, targetJobKey, {
-      recordAudit: false,
-      evaluatedAt: confirmedAt,
-    });
+    return evaluateRepeatApplication(db, targetJobId, { recordAudit: false, evaluatedAt: confirmedAt });
   });
   return { ok: true, assessment: transact() };
 }
 
 export function assertLiveApplicationMayDispatch(
   db: SqliteDatabase,
-  targetJobKey: string,
+  targetJobId: string,
 ): RepeatApplicationAssessment {
-  const assessment = evaluateRepeatApplication(db, targetJobKey);
-  if (assessment.status === "blocked") {
-    throw new InputError("repeat_application_blocked");
-  }
+  const assessment = evaluateRepeatApplication(db, targetJobId);
+  if (assessment.status === "blocked") throw new InputError("repeat_application_blocked");
   if (assessment.status === "confirmation_required") {
     throw new InputError("repeat_application_confirmation_required");
   }
@@ -263,168 +248,132 @@ export function assertLiveApplicationMayDispatch(
 }
 
 export function repeatEvidenceFingerprint(
-  targetJobKey: string,
-  matches: readonly RepeatApplicationMatch[],
+  targetJobId: string,
+  matches: readonly RepeatFingerprintMatch[],
 ): string {
-  const orderedMatches = [...matches].sort(compareMatches);
+  const canonicalTargetJobId = assertCanonicalJobId(targetJobId, "targetJobId");
+  const validatedMatches = matches.map((match) => {
+    if (!("jobId" in match.priorApplication) || !match.priorApplication.jobId || "jobKey" in match.priorApplication) {
+      throw new InputError("Repeat evidence fingerprint requires canonical priorApplication.jobId.");
+    }
+    return {
+      ...match,
+      priorApplication: {
+        ...match.priorApplication,
+        jobId: assertCanonicalJobId(match.priorApplication.jobId, "priorApplication.jobId"),
+      },
+    };
+  });
   const canonical = {
-    targetJobKey,
-    matches: orderedMatches.map((match) => ({
+    targetJobId: canonicalTargetJobId,
+    matches: validatedMatches.sort(compareMatches).map((match) => ({
       relationship: match.relationship,
       reason: match.reason,
-      priorApplication: match.priorApplication,
+      priorApplication: {
+        jobId: match.priorApplication.jobId,
+        title: match.priorApplication.title,
+        company: match.priorApplication.company,
+        applicationUrl: match.priorApplication.applicationUrl,
+        factKind: match.priorApplication.factKind,
+        factId: match.priorApplication.factId,
+        confirmedAt: match.priorApplication.confirmedAt,
+      },
       identityEvidence: match.identityEvidence,
     })),
   };
   return createHash("sha256").update(JSON.stringify(canonical), "utf8").digest("hex");
 }
 
-function jobIdentity(db: SqliteDatabase, jobKey: string): JobIdentityRow | null {
-  const hasCompanyColumn = columnExists(db, "jobs", "company");
-  const hasJobListProjections = tableExists(db, "job_list_projections");
-  const companyExpression = hasJobListProjections
-    ? `COALESCE(
-        ${hasCompanyColumn ? "NULLIF(j.company, '')" : "NULL"},
-        (SELECT jlp.employer FROM job_list_projections jlp
-         WHERE jlp.tenant_id = ? AND jlp.job_id = j.url LIMIT 1),
-        ''
-      )`
-    : hasCompanyColumn
-      ? "COALESCE(j.company, '')"
-      : "''";
-  const enrichmentExpression = tableExists(db, "job_enrichments")
-    ? `(SELECT je.application_url
-          FROM job_enrichments je
-         WHERE je.job_url = j.url AND je.tenant_id = ?
-         ORDER BY je.updated_at DESC LIMIT 1),`
-    : "";
-  const params = [
-    ...(hasJobListProjections ? [DEFAULT_TENANT] : []),
-    ...(enrichmentExpression ? [DEFAULT_TENANT] : []),
-    jobKey,
-  ];
-  return (
-    getRow<JobIdentityRow>(
-      db,
-      `SELECT j.url, j.title, ${companyExpression} AS company,
-              COALESCE(
-                ${enrichmentExpression}
-                j.application_url,
-                j.url
-              ) AS application_url
-         FROM jobs j
-        WHERE j.url = ?`,
-      params,
-    ) ?? null
-  );
+function assertCanonicalJobId(value: string, field: string): string {
+  if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/.test(value)) {
+    throw new InputError(`${field} must be a canonical UUID.`);
+  }
+  return value;
 }
 
-function columnExists(db: SqliteDatabase, tableName: string, columnName: string): boolean {
-  if (!tableExists(db, tableName)) return false;
-  const quoted = `"${tableName.replaceAll('"', '""')}"`;
-  return allRows<Record<string, unknown>>(db, `PRAGMA table_info(${quoted})`).some(
-    (row) => row.name === columnName,
-  );
+function jobIdentity(db: SqliteDatabase, jobId: string): JobIdentityRow | null {
+  const company = tableExists(db, "job_list_projections")
+    ? "COALESCE(NULLIF(j.company, ''), (SELECT jlp.employer FROM job_list_projections jlp WHERE jlp.tenant_id = ? AND jlp.job_id = j.job_id LIMIT 1), '')"
+    : "COALESCE(j.company, '')";
+  const enrichment = tableExists(db, "job_enrichments")
+    ? `(SELECT je.application_url FROM job_enrichments je WHERE je.tenant_id = ? AND je.job_id = j.job_id ORDER BY je.updated_at DESC LIMIT 1),`
+    : "";
+  const params = [
+    ...(tableExists(db, "job_list_projections") ? [DEFAULT_TENANT] : []),
+    ...(enrichment ? [DEFAULT_TENANT] : []),
+    DEFAULT_TENANT,
+    jobId,
+  ];
+  return getRow<JobIdentityRow>(
+    db,
+    `SELECT j.job_id, j.url, j.title, ${company} AS company,
+            COALESCE(${enrichment} j.application_url, j.url) AS application_url
+       FROM jobs j WHERE j.tenant_id = ? AND j.job_id = ?`,
+    params,
+  ) ?? null;
 }
 
 function confirmedApplicationFacts(db: SqliteDatabase): ConfirmedFactRow[] {
   const facts: ConfirmedFactRow[] = [];
   if (tableExists(db, "job_events")) {
-    facts.push(
-      ...allRows<ConfirmedFactRow>(
-        db,
-        `SELECT job_url AS job_key,
-                CASE event_type
-                  WHEN 'ApplicationSubmitted' THEN 'application_submitted'
-                  ELSE 'application_manually_marked'
-                END AS fact_kind,
-                'event:' || event_id AS fact_id,
-                occurred_at AS confirmed_at,
-                CASE event_type WHEN 'ApplicationSubmitted' THEN 40 ELSE 30 END AS priority
-           FROM job_events
-          WHERE job_url IS NOT NULL
-            AND event_type IN ('ApplicationSubmitted', 'ApplicationManuallyMarked')`,
-      ),
-    );
+    facts.push(...allRows<ConfirmedFactRow>(db, `
+      SELECT job_id, CASE event_type WHEN 'ApplicationSubmitted' THEN 'application_submitted'
+        ELSE 'application_manually_marked' END AS fact_kind,
+        'event:' || event_id AS fact_id, occurred_at AS confirmed_at,
+        CASE event_type WHEN 'ApplicationSubmitted' THEN 40 ELSE 30 END AS priority
+      FROM job_events WHERE tenant_id = ? AND job_id IS NOT NULL
+        AND event_type IN ('ApplicationSubmitted', 'ApplicationManuallyMarked')
+    `, [DEFAULT_TENANT]));
   }
   if (tableExists(db, "application_outcomes")) {
-    facts.push(
-      ...allRows<ConfirmedFactRow>(
-        db,
-        `SELECT job_key,
-                'applied_confirmation' AS fact_kind,
-                'outcome:' || outcome_id AS fact_id,
-                occurred_at AS confirmed_at,
-                20 AS priority
-           FROM application_outcomes
-          WHERE tenant_id = ? AND kind = 'applied_confirmation'`,
-        [DEFAULT_TENANT],
-      ),
-    );
+    facts.push(...allRows<ConfirmedFactRow>(db, `
+      SELECT job_id, 'applied_confirmation' AS fact_kind,
+        'outcome:' || outcome_id AS fact_id, occurred_at AS confirmed_at, 20 AS priority
+      FROM application_outcomes WHERE tenant_id = ? AND kind = 'applied_confirmation'
+    `, [DEFAULT_TENANT]));
   }
-  facts.push(
-    ...allRows<ConfirmedFactRow>(
-      db,
-      `SELECT url AS job_key,
-              'legacy_applied_status' AS fact_kind,
-              'job:' || url AS fact_id,
-              COALESCE(applied_at, discovered_at, '') AS confirmed_at,
-              10 AS priority
-         FROM jobs
-        WHERE LOWER(COALESCE(apply_status, '')) = 'applied'
-          AND COALESCE(applied_at, '') != ''`,
-    ),
-  );
-
+  facts.push(...allRows<ConfirmedFactRow>(db, `
+    SELECT job_id, 'legacy_applied_status' AS fact_kind, 'job:' || job_id AS fact_id,
+      COALESCE(applied_at, discovered_at, '') AS confirmed_at, 10 AS priority
+    FROM jobs WHERE tenant_id = ? AND LOWER(COALESCE(apply_status, '')) = 'applied'
+      AND COALESCE(applied_at, '') != ''
+  `, [DEFAULT_TENANT]));
   const best = new Map<string, ConfirmedFactRow>();
   for (const fact of facts) {
-    const current = best.get(fact.job_key);
-    if (
-      !current ||
-      fact.priority > current.priority ||
-      (fact.priority === current.priority && fact.confirmed_at > current.confirmed_at)
-    ) {
-      best.set(fact.job_key, fact);
+    const current = best.get(fact.job_id);
+    if (!current || fact.priority > current.priority ||
+      (fact.priority === current.priority && fact.confirmed_at > current.confirmed_at)) {
+      best.set(fact.job_id, fact);
     }
   }
   return [...best.values()];
 }
 
-function relationshipMatch(
-  db: SqliteDatabase,
-  target: JobIdentityRow,
-  fact: ConfirmedFactRow,
-): RepeatApplicationMatch | null {
-  const prior = jobIdentity(db, fact.job_key);
+function relationshipMatch(db: SqliteDatabase, target: JobIdentityRow, fact: ConfirmedFactRow): RepeatApplicationMatch | null {
+  const prior = jobIdentity(db, fact.job_id);
   if (!prior) return null;
-
   let relationship: RepeatApplicationRelationship | null = null;
   let reason = "";
   let identityEvidence: string[] = [];
-  if (target.url === prior.url) {
+  if (target.job_id === prior.job_id) {
     relationship = "canonical_job";
     reason = "Both records resolve to the same canonical JobCtrl job.";
-    identityEvidence = [`job:${target.url}`];
+    identityEvidence = [`job:${target.job_id}`];
   } else {
-    const canonical = canonicalIdentityRelationship(db, target.url, prior.url);
+    const canonical = canonicalIdentityRelationship(db, target.job_id, prior.job_id);
+    const duplicate = canonical ? null : acceptedDuplicateRelationship(db, target.job_id, prior.job_id);
     if (canonical) {
       relationship = "canonical_identity";
       reason = "The canonical ATS identity matches the previously applied opening.";
       identityEvidence = canonical;
-    } else {
-      const duplicate = acceptedDuplicateRelationship(db, target.url, prior.url);
-      if (duplicate) {
-        relationship = "accepted_duplicate";
-        reason = "An accepted duplicate link connects this representation to the previously applied opening.";
-        identityEvidence = duplicate;
-      } else if (equivalentEmployerRole(target, prior)) {
-        relationship = "same_employer_equivalent_role";
-        reason = "The employer identity matches exactly and the normalized role titles are materially equivalent.";
-        identityEvidence = [
-          `employer:${normalizeEmployer(target.company)}`,
-          `role:${normalizeRoleTitle(target.title)}`,
-        ];
-      }
+    } else if (duplicate) {
+      relationship = "accepted_duplicate";
+      reason = "An accepted duplicate link connects this representation to the previously applied opening.";
+      identityEvidence = duplicate;
+    } else if (equivalentEmployerRole(target, prior)) {
+      relationship = "same_employer_equivalent_role";
+      reason = "The employer identity matches exactly and the normalized role titles are materially equivalent.";
+      identityEvidence = [`employer:${normalizeEmployer(target.company)}`, `role:${normalizeRoleTitle(target.title)}`];
     }
   }
   if (!relationship) return null;
@@ -432,7 +381,7 @@ function relationshipMatch(
     relationship,
     reason,
     priorApplication: {
-      jobKey: prior.url,
+      jobId: prior.job_id,
       title: prior.title?.trim() || "Untitled role",
       company: prior.company?.trim() || "Unknown company",
       applicationUrl: prior.application_url,
@@ -444,80 +393,40 @@ function relationshipMatch(
   };
 }
 
-function canonicalIdentityRelationship(
-  db: SqliteDatabase,
-  targetJobKey: string,
-  priorJobKey: string,
-): string[] | null {
+function canonicalIdentityRelationship(db: SqliteDatabase, targetJobId: string, priorJobId: string): string[] | null {
   if (!tableExists(db, "job_canonical_identities")) return null;
-  const rows = allRows<CanonicalIdentityRow>(
-    db,
-    `SELECT job_url, canonical_url, ats_kind, source_native_id
-       FROM job_canonical_identities
-      WHERE tenant_id = ? AND job_url IN (?, ?)`,
-    [DEFAULT_TENANT, targetJobKey, priorJobKey],
-  );
-  const target = rows.find((row) => row.job_url === targetJobKey);
-  const prior = rows.find((row) => row.job_url === priorJobKey);
+  const rows = allRows<CanonicalIdentityRow>(db, `
+    SELECT job_id, canonical_url, ats_kind, source_native_id
+    FROM job_canonical_identities WHERE tenant_id = ? AND job_id IN (?, ?)
+  `, [DEFAULT_TENANT, targetJobId, priorJobId]);
+  const target = rows.find((row) => row.job_id === targetJobId);
+  const prior = rows.find((row) => row.job_id === priorJobId);
   if (!target || !prior) return null;
-  if (target.canonical_url && target.canonical_url === prior.canonical_url) {
-    return [`canonical_url:${target.canonical_url}`];
-  }
-  if (
-    target.ats_kind &&
-    target.ats_kind === prior.ats_kind &&
-    target.source_native_id &&
-    target.source_native_id === prior.source_native_id
-  ) {
+  if (target.canonical_url && target.canonical_url === prior.canonical_url) return [`canonical_url:${target.canonical_url}`];
+  if (target.ats_kind === prior.ats_kind && target.source_native_id === prior.source_native_id) {
     return [`ats:${target.ats_kind}`, `native_id:${target.source_native_id}`];
   }
   return null;
 }
 
-function acceptedDuplicateRelationship(
-  db: SqliteDatabase,
-  targetJobKey: string,
-  priorJobKey: string,
-): string[] | null {
+function acceptedDuplicateRelationship(db: SqliteDatabase, targetJobId: string, priorJobId: string): string[] | null {
   if (!tableExists(db, "job_duplicate_links")) return null;
-  const targetAliases = jobAliases(db, targetJobKey);
-  const priorAliases = jobAliases(db, priorJobKey);
-  const links = allRows<DuplicateLinkRow>(
-    db,
-    `SELECT surviving_job_id, superseded_job_or_observation_id, reason
-       FROM job_duplicate_links WHERE tenant_id = ?`,
-    [DEFAULT_TENANT],
-  );
-  const link = links.find(
-    (candidate) =>
-      (targetAliases.has(candidate.surviving_job_id) &&
-        priorAliases.has(candidate.superseded_job_or_observation_id)) ||
-      (priorAliases.has(candidate.surviving_job_id) &&
-        targetAliases.has(candidate.superseded_job_or_observation_id)),
-  );
-  return link
-    ? [
-        `survivor:${link.surviving_job_id}`,
-        `superseded:${link.superseded_job_or_observation_id}`,
-        `link_reason:${link.reason}`,
-      ]
-    : null;
+  const targetAliases = jobAliases(db, targetJobId);
+  const priorAliases = jobAliases(db, priorJobId);
+  const links = allRows<DuplicateLinkRow>(db, `SELECT surviving_job_id, superseded_job_or_observation_id, reason FROM job_duplicate_links WHERE tenant_id = ?`, [DEFAULT_TENANT]);
+  const link = links.find((candidate) =>
+    (targetAliases.has(candidate.surviving_job_id) && priorAliases.has(candidate.superseded_job_or_observation_id)) ||
+    (priorAliases.has(candidate.surviving_job_id) && targetAliases.has(candidate.superseded_job_or_observation_id)));
+  return link ? [`survivor:${link.surviving_job_id}`, `superseded:${link.superseded_job_or_observation_id}`, `link_reason:${link.reason}`] : null;
 }
 
-function jobAliases(db: SqliteDatabase, jobKey: string): Set<string> {
-  const aliases = new Set([jobKey]);
+function jobAliases(db: SqliteDatabase, jobId: string): Set<string> {
+  const aliases = new Set([jobId]);
   if (!tableExists(db, "job_source_observations")) return aliases;
-  const rows = allRows<Record<string, unknown>>(
-    db,
-    `SELECT source_observation_id, observed_url, normalized_observed_url
-       FROM job_source_observations WHERE tenant_id = ? AND job_url = ?`,
-    [DEFAULT_TENANT, jobKey],
-  );
-  for (const row of rows) {
-    for (const value of [row.source_observation_id, row.observed_url, row.normalized_observed_url]) {
-      if (typeof value === "string" && value) aliases.add(value);
-    }
-  }
+  const rows = allRows<Record<string, unknown>>(db, `
+    SELECT source_observation_id FROM job_source_observations WHERE tenant_id = ? AND job_id = ?
+  `, [DEFAULT_TENANT, jobId]);
+  for (const row of rows) if (typeof row.source_observation_id === "string") aliases.add(row.source_observation_id);
   return aliases;
 }
 
@@ -528,161 +437,64 @@ function equivalentEmployerRole(target: JobIdentityRow, prior: JobIdentityRow): 
   const targetRole = normalizeRoleTitle(target.title);
   const priorRole = normalizeRoleTitle(prior.title);
   if (!targetRole || !priorRole) return false;
-  if (targetRole === priorRole) return true;
-  return [...targetRole.split(" ")].sort().join(" ") === [...priorRole.split(" ")].sort().join(" ");
+  return targetRole === priorRole || targetRole.split(" ").sort().join(" ") === priorRole.split(" ").sort().join(" ");
 }
 
 export function normalizeEmployer(value: string | null | undefined): string {
-  const tokens = normalizeTokens(value).filter(Boolean);
-  const legalSuffixes = new Set([
-    "inc", "incorporated", "llc", "ltd", "limited", "corp", "corporation", "plc", "gmbh",
-  ]);
-  while (tokens.length > 1 && legalSuffixes.has(tokens[tokens.length - 1] ?? "")) tokens.pop();
+  const tokens = normalizeTokens(value);
+  const suffixes = new Set(["inc", "incorporated", "llc", "ltd", "limited", "corp", "corporation", "plc", "gmbh"]);
+  while (tokens.length > 1 && suffixes.has(tokens[tokens.length - 1] ?? "")) tokens.pop();
   return tokens.join(" ");
 }
 
 export function normalizeRoleTitle(value: string | null | undefined): string {
-  const aliases: Record<string, string> = {
-    sr: "senior",
-    jr: "junior",
-    eng: "engineer",
-    engr: "engineer",
-    mgr: "manager",
-    dev: "developer",
-    ii: "2",
-    iii: "3",
-    iv: "4",
-  };
+  const aliases: Record<string, string> = { sr: "senior", jr: "junior", eng: "engineer", engr: "engineer", mgr: "manager", dev: "developer", ii: "2", iii: "3", iv: "4" };
   const presentationOnly = new Set(["remote", "hybrid", "onsite", "fulltime"]);
-  return normalizeTokens(value)
-    .map((token) => aliases[token] ?? token)
-    .filter((token) => !presentationOnly.has(token))
-    .join(" ");
+  return normalizeTokens(value).map((token) => aliases[token] ?? token).filter((token) => !presentationOnly.has(token)).join(" ");
 }
 
 function normalizeTokens(value: string | null | undefined): string[] {
-  return String(value ?? "")
-    .normalize("NFKC")
-    .toLocaleLowerCase("en-US")
-    .replace(/&/g, " and ")
-    .replace(/[^a-z0-9]+/g, " ")
-    .trim()
-    .split(/\s+/)
-    .filter(Boolean);
+  return String(value ?? "").normalize("NFKC").toLocaleLowerCase("en-US").replace(/&/g, " and ").replace(/[^a-z0-9]+/g, " ").trim().split(/\s+/).filter(Boolean);
 }
 
-function matchingOverride(
-  db: SqliteDatabase,
-  targetJobKey: string,
-  evidenceFingerprint: string,
-): RepeatApplicationOverride | null {
-  const row = getRow<OverrideRow>(
-    db,
-    `SELECT o.override_id, o.target_job_key, o.prior_job_key,
-            o.evidence_fingerprint, o.reason, o.confirmed_by, o.confirmed_at,
-            c.consumed_at, c.run_id AS consumed_run_id
-       FROM application_repeat_overrides o
-       LEFT JOIN application_repeat_override_consumptions c
-         ON c.tenant_id = o.tenant_id AND c.override_id = o.override_id
-      WHERE o.tenant_id = ? AND o.target_job_key = ? AND o.evidence_fingerprint = ?
-      ORDER BY o.confirmed_at DESC, o.override_id DESC LIMIT 1`,
-    [DEFAULT_TENANT, targetJobKey, evidenceFingerprint],
-  );
-  return row
-    ? {
-        overrideId: row.override_id,
-        targetJobKey: row.target_job_key,
-        priorJobKey: row.prior_job_key,
-        evidenceFingerprint: row.evidence_fingerprint,
-        reason: row.reason,
-        confirmedBy: row.confirmed_by,
-        confirmedAt: row.confirmed_at,
-        consumedAt: row.consumed_at,
-        consumedRunId: row.consumed_run_id,
-      }
-    : null;
+function matchingOverride(db: SqliteDatabase, targetJobId: string, evidenceFingerprint: string): RepeatApplicationOverride | null {
+  const row = getRow<OverrideRow>(db, `
+    SELECT o.override_id, o.target_job_id, o.prior_job_id, o.evidence_fingerprint,
+      o.reason, o.confirmed_by, o.confirmed_at, c.consumed_at, c.run_id AS consumed_run_id
+    FROM application_repeat_overrides o
+    LEFT JOIN application_repeat_override_consumptions c
+      ON c.tenant_id = o.tenant_id AND c.override_id = o.override_id
+    WHERE o.tenant_id = ? AND o.target_job_id = ? AND o.evidence_fingerprint = ?
+    ORDER BY o.confirmed_at DESC, o.override_id DESC LIMIT 1
+  `, [DEFAULT_TENANT, targetJobId, evidenceFingerprint]);
+  return row ? {
+    overrideId: row.override_id, targetJobId: row.target_job_id, priorJobId: row.prior_job_id,
+    evidenceFingerprint: row.evidence_fingerprint, reason: row.reason, confirmedBy: row.confirmed_by,
+    confirmedAt: row.confirmed_at, consumedAt: row.consumed_at, consumedRunId: row.consumed_run_id,
+  } : null;
 }
 
-function recordAssessmentAudit(
-  db: SqliteDatabase,
-  input: {
-    targetJobKey: string;
-    action: "blocked" | "confirmation_required";
-    evidenceFingerprint: string;
-    matches: readonly RepeatApplicationMatch[];
-    occurredAt: string;
-  },
-): void {
-  insertAudit(db, {
-    auditKey: `assessment:${input.targetJobKey}:${input.evidenceFingerprint}:${input.action}`,
-    targetJobKey: input.targetJobKey,
-    action: input.action,
-    evidenceFingerprint: input.evidenceFingerprint,
-    evidenceJson: JSON.stringify(input.matches),
-    overrideId: null,
-    actor: "system",
-    reason: null,
-    occurredAt: input.occurredAt,
-  });
+function recordAssessmentAudit(db: SqliteDatabase, input: { targetJobId: string; action: "blocked" | "confirmation_required"; evidenceFingerprint: string; matches: readonly RepeatApplicationMatch[]; occurredAt: string }): void {
+  insertAudit(db, { auditKey: `assessment:${input.targetJobId}:${input.evidenceFingerprint}:${input.action}`, targetJobId: input.targetJobId, action: input.action, evidenceFingerprint: input.evidenceFingerprint, evidenceJson: JSON.stringify(input.matches), overrideId: null, actor: "system", reason: null, occurredAt: input.occurredAt });
 }
 
-function insertAudit(
-  db: SqliteDatabase,
-  input: {
-    auditKey: string;
-    targetJobKey: string;
-    action: RepeatApplicationAuditEntry["action"];
-    evidenceFingerprint: string;
-    evidenceJson: string;
-    overrideId: string | null;
-    actor: string;
-    reason: string | null;
-    occurredAt: string;
-  },
-): void {
-  db.prepare(
-    `INSERT OR IGNORE INTO application_repeat_audit (
-       tenant_id, audit_id, audit_key, target_job_key, action,
-       evidence_fingerprint, evidence_json, override_id, actor, reason, occurred_at
-     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-  ).run(
-    DEFAULT_TENANT,
-    randomUUID(),
-    input.auditKey,
-    input.targetJobKey,
-    input.action,
-    input.evidenceFingerprint,
-    input.evidenceJson,
-    input.overrideId,
-    input.actor,
-    input.reason,
-    input.occurredAt,
-  );
+function insertAudit(db: SqliteDatabase, input: { auditKey: string; targetJobId: string; action: RepeatApplicationAuditEntry["action"]; evidenceFingerprint: string; evidenceJson: string; overrideId: string | null; actor: string; reason: string | null; occurredAt: string }): void {
+  db.prepare(`INSERT OR IGNORE INTO application_repeat_audit (tenant_id, audit_id, audit_key, target_job_id, action, evidence_fingerprint, evidence_json, override_id, actor, reason, occurred_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`).run(DEFAULT_TENANT, randomUUID(), input.auditKey, input.targetJobId, input.action, input.evidenceFingerprint, input.evidenceJson, input.overrideId, input.actor, input.reason, input.occurredAt);
 }
 
-function auditTrail(db: SqliteDatabase, targetJobKey: string): RepeatApplicationAuditEntry[] {
-  return allRows<AuditRow>(
-    db,
-    `SELECT a.audit_id, a.target_job_key, a.action, a.evidence_fingerprint,
-            a.evidence_json, a.override_id, o.prior_job_key,
-            a.actor, a.reason, a.occurred_at
-       FROM application_repeat_audit a
-       LEFT JOIN application_repeat_overrides o
-         ON o.tenant_id = a.tenant_id AND o.override_id = a.override_id
-      WHERE a.tenant_id = ? AND a.target_job_key = ?
-      ORDER BY a.occurred_at DESC, a.rowid DESC LIMIT 50`,
-    [DEFAULT_TENANT, targetJobKey],
-  ).map((row) => ({
-    auditId: row.audit_id,
-    targetJobKey: row.target_job_key,
-    action: row.action,
-    evidenceFingerprint: row.evidence_fingerprint,
-    evidence: parseEvidenceSnapshot(row.evidence_json),
-    overrideId: row.override_id,
-    priorJobKey: row.prior_job_key,
-    actor: row.actor,
-    reason: row.reason,
-    occurredAt: row.occurred_at,
+function auditTrail(db: SqliteDatabase, targetJobId: string): RepeatApplicationAuditEntry[] {
+  return allRows<AuditRow>(db, `
+    SELECT a.audit_id, a.target_job_id, a.action, a.evidence_fingerprint, a.evidence_json,
+      a.override_id, o.prior_job_id, a.actor, a.reason, a.occurred_at
+    FROM application_repeat_audit a
+    LEFT JOIN application_repeat_overrides o ON o.tenant_id = a.tenant_id AND o.override_id = a.override_id
+    WHERE a.tenant_id = ? AND a.target_job_id = ?
+    ORDER BY a.occurred_at DESC, a.rowid DESC LIMIT 50
+  `, [DEFAULT_TENANT, targetJobId]).map((row) => ({
+    auditId: row.audit_id, targetJobId: row.target_job_id, action: row.action,
+    evidenceFingerprint: row.evidence_fingerprint, evidence: parseEvidenceSnapshot(row.evidence_json),
+    overrideId: row.override_id, priorJobId: row.prior_job_id, actor: row.actor,
+    reason: row.reason, occurredAt: row.occurred_at,
   }));
 }
 
@@ -695,18 +507,9 @@ function parseEvidenceSnapshot(value: string): RepeatApplicationMatch[] {
   }
 }
 
-function compareMatches(left: RepeatApplicationMatch, right: RepeatApplicationMatch): number {
-  const rank: Record<RepeatApplicationRelationship, number> = {
-    canonical_job: 0,
-    canonical_identity: 1,
-    accepted_duplicate: 2,
-    same_employer_equivalent_role: 3,
-  };
-  return (
-    rank[left.relationship] - rank[right.relationship] ||
-    compareUtf8(left.priorApplication.jobKey, right.priorApplication.jobKey) ||
-    compareUtf8(left.priorApplication.factId, right.priorApplication.factId)
-  );
+function compareMatches(left: RepeatApplicationMatch | RepeatFingerprintMatch, right: RepeatApplicationMatch | RepeatFingerprintMatch): number {
+  const rank: Record<RepeatApplicationRelationship, number> = { canonical_job: 0, canonical_identity: 1, accepted_duplicate: 2, same_employer_equivalent_role: 3 };
+  return rank[left.relationship] - rank[right.relationship] || compareUtf8(left.priorApplication.jobId, right.priorApplication.jobId) || compareUtf8(left.priorApplication.factId, right.priorApplication.factId);
 }
 
 function compareUtf8(left: string, right: string): number {

--- a/apps/api/src/repeat-application.ts
+++ b/apps/api/src/repeat-application.ts
@@ -156,9 +156,11 @@ export function evaluateRepeatApplication(
   const evidenceFingerprint = repeatEvidenceFingerprint(target.job_id, fingerprintMatches);
   const override = matchingOverride(db, targetJobId, evidenceFingerprint);
   const exact = matches.some((match) => match.relationship !== "same_employer_equivalent_role");
-  const status: RepeatApplicationAssessment["status"] = override
-    ? override.consumedAt ? "override_consumed" : "override_ready"
-    : exact ? "blocked" : "confirmation_required";
+  const status: RepeatApplicationAssessment["status"] = exact
+    ? "blocked"
+    : override
+      ? override.consumedAt ? "override_consumed" : "override_ready"
+      : "confirmation_required";
   const summary = status === "override_ready"
     ? "A reasoned confirmation is recorded for one live attempt against this exact evidence."
     : status === "override_consumed"
@@ -196,6 +198,9 @@ export function recordRepeatApplicationOverride(
     const assessment = evaluateRepeatApplication(db, targetJobId);
     if (!assessment.evidenceFingerprint || assessment.status === "clear") {
       throw new InputError("repeat_application_confirmation_not_required");
+    }
+    if (assessment.status === "blocked") {
+      throw new InputError("repeat_application_blocked");
     }
     if (assessment.evidenceFingerprint !== request.evidenceFingerprint) {
       throw new InputError("repeat_application_evidence_stale");

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -1818,14 +1818,12 @@ export function buildApp(options: BuildAppOptions): FastifyInstance {
     return withWritableDb(reply, options.dbPath, async (db) => {
       const jobLocator = decodeRouteParam(request.params.jobKey);
       const jobId = resolveJobId(db, "local", jobLocator);
-      const jobUrl = resolveExistingJob(reply, db, jobLocator);
-      if (!jobId || !jobUrl) {
+      if (!jobId) {
         return { ok: false, error: "job_not_found" };
       }
       if (!body.dryRun) {
         assertLiveApplicationMayDispatch(db, jobId);
       }
-      const jobId = requireJobId(db, jobUrl);
       const command: ActionCommandPayload = {
         action: "apply" as const,
         jobKey: jobId,

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -1330,11 +1330,11 @@ export function buildApp(options: BuildAppOptions): FastifyInstance {
         return undefined;
       }
       return withWritableDb(reply, options.dbPath, (db) => {
-        const jobUrl = resolveExistingJob(reply, db, decodeRouteParam(request.params.jobKey));
-        if (!jobUrl) {
+        const jobId = resolveJobId(db, "local", decodeRouteParam(request.params.jobKey));
+        if (!jobId) {
           return { ok: false, error: "job_not_found" };
         }
-        return recordRepeatApplicationOverride(db, jobUrl, body);
+        return recordRepeatApplicationOverride(db, jobId, body);
       });
     },
   );
@@ -1816,12 +1816,14 @@ export function buildApp(options: BuildAppOptions): FastifyInstance {
       return undefined;
     }
     return withWritableDb(reply, options.dbPath, async (db) => {
-      const jobUrl = resolveExistingJob(reply, db, decodeRouteParam(request.params.jobKey));
-      if (!jobUrl) {
+      const jobLocator = decodeRouteParam(request.params.jobKey);
+      const jobId = resolveJobId(db, "local", jobLocator);
+      const jobUrl = resolveExistingJob(reply, db, jobLocator);
+      if (!jobId || !jobUrl) {
         return { ok: false, error: "job_not_found" };
       }
       if (!body.dryRun) {
-        assertLiveApplicationMayDispatch(db, jobUrl);
+        assertLiveApplicationMayDispatch(db, jobId);
       }
       const jobId = requireJobId(db, jobUrl);
       const command: ActionCommandPayload = {

--- a/apps/api/test/repeat-application.test.ts
+++ b/apps/api/test/repeat-application.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { readFileSync } from "node:fs";
 
 import Database from "better-sqlite3";
@@ -15,78 +16,19 @@ import {
 
 const PRIOR = "https://jobs.example.test/prior";
 const TARGET = "https://careers.example.test/target";
+const PRIOR_JOB_ID = "70000000-0000-4000-8000-000000000002";
+const TARGET_JOB_ID = "70000000-0000-4000-8000-000000000001";
 const NOW = "2026-07-20T08:00:00.000Z";
 
 let db: Database.Database;
 
 beforeEach(() => {
   db = new Database(":memory:");
-  db.exec(`
-    CREATE TABLE jobs (
-      url TEXT PRIMARY KEY,
-      title TEXT,
-      company TEXT,
-      application_url TEXT,
-      applied_at TEXT,
-      apply_status TEXT,
-      discovered_at TEXT
-    );
-    CREATE TABLE job_enrichments (
-      job_url TEXT NOT NULL,
-      tenant_id TEXT NOT NULL,
-      application_url TEXT,
-      updated_at TEXT NOT NULL
-    );
-    CREATE TABLE job_list_projections (
-      tenant_id TEXT NOT NULL,
-      job_id TEXT NOT NULL,
-      employer TEXT NOT NULL
-    );
-    CREATE TABLE job_events (
-      event_id INTEGER PRIMARY KEY AUTOINCREMENT,
-      job_url TEXT,
-      event_type TEXT NOT NULL,
-      occurred_at TEXT NOT NULL
-    );
-    CREATE TABLE application_outcomes (
-      tenant_id TEXT NOT NULL,
-      outcome_id TEXT NOT NULL,
-      job_key TEXT NOT NULL,
-      kind TEXT NOT NULL,
-      occurred_at TEXT NOT NULL
-    );
-    CREATE TABLE application_outcome_suggestions (
-      tenant_id TEXT NOT NULL,
-      suggestion_id TEXT NOT NULL,
-      job_key TEXT NOT NULL,
-      suggested_kind TEXT NOT NULL,
-      status TEXT NOT NULL,
-      created_at TEXT NOT NULL
-    );
-    CREATE TABLE job_canonical_identities (
-      tenant_id TEXT NOT NULL,
-      job_url TEXT NOT NULL,
-      canonical_url TEXT NOT NULL,
-      ats_kind TEXT NOT NULL,
-      source_native_id TEXT NOT NULL
-    );
-    CREATE TABLE job_source_observations (
-      tenant_id TEXT NOT NULL,
-      source_observation_id TEXT NOT NULL,
-      job_url TEXT NOT NULL,
-      observed_url TEXT NOT NULL,
-      normalized_observed_url TEXT NOT NULL
-    );
-    CREATE TABLE job_duplicate_links (
-      tenant_id TEXT NOT NULL,
-      duplicate_link_id TEXT NOT NULL,
-      surviving_job_id TEXT NOT NULL,
-      superseded_job_or_observation_id TEXT NOT NULL,
-      reason TEXT NOT NULL,
-      confidence REAL NOT NULL,
-      linked_at TEXT NOT NULL
-    );
-  `);
+  db.exec(readFileSync(new URL(
+    "../../../workers/automation/src/jobctrl/infrastructure/migrations/schema_v7.sql",
+    import.meta.url,
+  ), "utf8"));
+  db.pragma("user_version = 7");
   ensureRepeatApplicationTables(db);
 });
 
@@ -95,17 +37,30 @@ afterEach(() => {
   db.close();
 });
 
+function jobIdFor(url: string): string {
+  if (url === PRIOR) return PRIOR_JOB_ID;
+  if (url === TARGET) return TARGET_JOB_ID;
+  const hex = createHash("sha256").update(`repeat-test:${url}`, "utf8").digest("hex").slice(0, 32);
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-4${hex.slice(13, 16)}-8${hex.slice(17, 20)}-${hex.slice(20)}`;
+}
+
 function insertJob(url: string, title: string, company: string): void {
   db.prepare(
-    `INSERT INTO jobs (url, title, company, application_url, discovered_at)
-     VALUES (?, ?, ?, ?, ?)`,
-  ).run(url, title, company, `${url}/apply`, NOW);
+    `INSERT INTO jobs (tenant_id, job_id, url, title, company, application_url, discovered_at)
+     VALUES ('local', ?, ?, ?, ?, ?, ?)`,
+  ).run(jobIdFor(url), url, title, company, `${url}/apply`, NOW);
+  db.prepare(
+    `INSERT INTO job_enrichments
+       (tenant_id, job_id, current_status, application_url, updated_at)
+     VALUES ('local', ?, 'enriched', ?, ?)`,
+  ).run(jobIdFor(url), `${url}/apply`, NOW);
 }
 
 function confirmPrior(kind: "ApplicationSubmitted" | "ApplicationManuallyMarked" = "ApplicationSubmitted"): void {
   db.prepare(
-    "INSERT INTO job_events (job_url, event_type, occurred_at) VALUES (?, ?, ?)",
-  ).run(PRIOR, kind, NOW);
+    `INSERT INTO job_events (tenant_id, job_id, identity_version, event_type, occurred_at)
+     VALUES ('local', ?, 1, ?, ?)`,
+  ).run(PRIOR_JOB_ID, kind, NOW);
 }
 
 describe("repeat application evidence", () => {
@@ -119,17 +74,71 @@ describe("repeat application evidence", () => {
         "utf8",
       ),
     ) as {
-      targetJobKey: string;
+      targetJobId: string;
       matches: Parameters<typeof repeatEvidenceFingerprint>[1];
       expectedFingerprint: string;
     };
 
-    expect(repeatEvidenceFingerprint(fixture.targetJobKey, fixture.matches)).toBe(
+    expect(repeatEvidenceFingerprint(fixture.targetJobId, fixture.matches)).toBe(
       fixture.expectedFingerprint,
     );
-    expect(repeatEvidenceFingerprint(fixture.targetJobKey, [...fixture.matches].reverse())).toBe(
+    expect(repeatEvidenceFingerprint(fixture.targetJobId, [...fixture.matches].reverse())).toBe(
       fixture.expectedFingerprint,
     );
+  });
+
+  it("rejects legacy locator keys at the fingerprint boundary", () => {
+    const legacyMatch = {
+      relationship: "canonical_identity",
+      reason: "legacy input",
+      priorApplication: {
+        jobKey: PRIOR,
+        title: "Platform Engineer",
+        company: "Acme",
+        applicationUrl: null,
+        factKind: "application_submitted",
+        factId: "event:legacy",
+        confirmedAt: NOW,
+      },
+      identityEvidence: [],
+    } as unknown as Parameters<typeof repeatEvidenceFingerprint>[1][number];
+
+    expect(
+      () =>
+        repeatEvidenceFingerprint("70000000-0000-4000-8000-000000000001", [legacyMatch]),
+    ).toThrow("canonical priorApplication.jobId");
+  });
+
+  it("rejects every shared invalid fingerprint vector", () => {
+    const fixture = JSON.parse(
+      readFileSync(
+        new URL(
+          "../../../packages/domain-types/test/fixtures/repeat_application_fingerprint_parity.json",
+          import.meta.url,
+        ),
+        "utf8",
+      ),
+    ) as {
+      invalidVectors: Array<{
+        targetJobId: string;
+        matches: unknown[];
+        error: string;
+      }>;
+    };
+
+    for (const vector of fixture.invalidVectors) {
+      expect(() =>
+        repeatEvidenceFingerprint(
+          vector.targetJobId,
+          vector.matches as Parameters<typeof repeatEvidenceFingerprint>[1],
+        ),
+      ).toThrow(vector.error);
+    }
+  });
+
+  it("keeps live-dispatch safety on canonical JobIds", () => {
+    insertJob(TARGET, "Platform Engineer", "Acme Inc");
+    expect(assertLiveApplicationMayDispatch(db, TARGET_JOB_ID).status).toBe("clear");
   });
 
   it("blocks alternate URLs with the same canonical ATS identity", () => {
@@ -138,21 +147,21 @@ describe("repeat application evidence", () => {
     confirmPrior();
     const identity = db.prepare(
       `INSERT INTO job_canonical_identities
-       (tenant_id, job_url, canonical_url, ats_kind, source_native_id)
-       VALUES ('local', ?, ?, 'greenhouse', 'gh-123')`,
+       (tenant_id, job_id, canonical_url, ats_kind, source_native_id, confidence, resolved_at)
+       VALUES ('local', ?, ?, 'greenhouse', 'gh-123', 1, ?)`,
     );
-    identity.run(PRIOR, "https://boards.example.test/jobs/123");
-    identity.run(TARGET, "https://boards.example.test/jobs/123");
+    identity.run(PRIOR_JOB_ID, "https://boards.example.test/jobs/123", NOW);
+    identity.run(TARGET_JOB_ID, "https://boards.example.test/jobs/123", NOW);
 
-    const assessment = evaluateRepeatApplication(db, TARGET);
+    const assessment = evaluateRepeatApplication(db, TARGET_JOB_ID);
 
     expect(assessment.status).toBe("blocked");
     expect(assessment.matches[0]).toMatchObject({
       relationship: "canonical_identity",
-      priorApplication: { jobKey: PRIOR, factKind: "application_submitted" },
+      priorApplication: { jobId: PRIOR_JOB_ID, factKind: "application_submitted" },
     });
     expect(assessment.auditTrail[0]?.action).toBe("blocked");
-    expect(() => assertLiveApplicationMayDispatch(db, TARGET)).toThrow(
+    expect(() => assertLiveApplicationMayDispatch(db, TARGET_JOB_ID)).toThrow(
       "repeat_application_blocked",
     );
   });
@@ -163,17 +172,18 @@ describe("repeat application evidence", () => {
     confirmPrior("ApplicationManuallyMarked");
     db.prepare(
       `INSERT INTO job_source_observations
-       (tenant_id, source_observation_id, job_url, observed_url, normalized_observed_url)
-       VALUES ('local', 'prior-observation', ?, ?, ?)`,
-    ).run(PRIOR, `${PRIOR}?source=board`, PRIOR);
+       (tenant_id, source_observation_id, job_id, source_id, source_native_id,
+        observed_url, normalized_observed_url, observed_at)
+       VALUES ('local', 'prior-observation', ?, 'test', 'prior-observation', ?, ?, ?)`,
+    ).run(PRIOR_JOB_ID, `${PRIOR}?source=board`, PRIOR, NOW);
     db.prepare(
       `INSERT INTO job_duplicate_links
        (tenant_id, duplicate_link_id, surviving_job_id,
         superseded_job_or_observation_id, reason, confidence, linked_at)
        VALUES ('local', 'link-1', ?, 'prior-observation', 'accepted_content_identity', 0.99, ?)`,
-    ).run(TARGET, NOW);
+    ).run(TARGET_JOB_ID, NOW);
 
-    expect(evaluateRepeatApplication(db, TARGET)).toMatchObject({
+    expect(evaluateRepeatApplication(db, TARGET_JOB_ID)).toMatchObject({
       status: "blocked",
       matches: [{ relationship: "accepted_duplicate" }],
     });
@@ -184,7 +194,7 @@ describe("repeat application evidence", () => {
     insertJob(TARGET, "Senior Backend Engineer 2 (Remote)", "ACME INC");
     confirmPrior();
 
-    const assessment = evaluateRepeatApplication(db, TARGET);
+    const assessment = evaluateRepeatApplication(db, TARGET_JOB_ID);
 
     expect(assessment.status).toBe("confirmation_required");
     expect(assessment.matches[0]?.relationship).toBe("same_employer_equivalent_role");
@@ -201,10 +211,10 @@ describe("repeat application evidence", () => {
     db.prepare(
       `INSERT INTO job_list_projections (tenant_id, job_id, employer)
        VALUES ('local', ?, 'Acme Inc'), ('local', ?, 'Acme Inc')`,
-    ).run(PRIOR, TARGET);
+    ).run(PRIOR_JOB_ID, TARGET_JOB_ID);
     confirmPrior();
 
-    const assessment = evaluateRepeatApplication(db, TARGET);
+    const assessment = evaluateRepeatApplication(db, TARGET_JOB_ID);
 
     expect(assessment.status).toBe("confirmation_required");
     expect(assessment.matches[0]).toMatchObject({
@@ -222,7 +232,7 @@ describe("repeat application evidence", () => {
     insertJob(TARGET, title, company);
     confirmPrior();
 
-    expect(evaluateRepeatApplication(db, TARGET).status).toBe("clear");
+    expect(evaluateRepeatApplication(db, TARGET_JOB_ID).status).toBe("clear");
   });
 
   it("excludes dry runs, failed attempts, and pending outcome suggestions", () => {
@@ -230,28 +240,28 @@ describe("repeat application evidence", () => {
     insertJob(TARGET, "Senior Backend Engineer", "Acme Inc");
     for (const eventType of ["DryRunCompleted", "ApplicationFailed", "ApplySubmitIntended"]) {
       db.prepare(
-        "INSERT INTO job_events (job_url, event_type, occurred_at) VALUES (?, ?, ?)",
-      ).run(PRIOR, eventType, NOW);
+        "INSERT INTO job_events (tenant_id, job_id, identity_version, event_type, occurred_at) VALUES ('local', ?, 1, ?, ?)",
+      ).run(PRIOR_JOB_ID, eventType, NOW);
     }
     db.prepare(
       `INSERT INTO application_outcome_suggestions
-       (tenant_id, suggestion_id, job_key, suggested_kind, status, created_at)
+       (tenant_id, suggestion_id, job_id, suggested_kind, status, created_at)
        VALUES ('local', 'suggestion-1', ?, 'applied_confirmation', 'pending', ?)`,
-    ).run(PRIOR, NOW);
+    ).run(PRIOR_JOB_ID, NOW);
     db.prepare(
       `INSERT INTO application_outcomes
-       (tenant_id, outcome_id, job_key, kind, occurred_at)
-       VALUES ('local', 'note-like-outcome', ?, 'unknown', ?)`,
-    ).run(PRIOR, NOW);
+       (tenant_id, outcome_id, job_id, kind, source, occurred_at, recorded_at)
+       VALUES ('local', 'note-like-outcome', ?, 'unknown', 'test', ?, ?)`,
+    ).run(PRIOR_JOB_ID, NOW, NOW);
 
-    expect(evaluateRepeatApplication(db, TARGET).status).toBe("clear");
+    expect(evaluateRepeatApplication(db, TARGET_JOB_ID).status).toBe("clear");
 
     db.prepare(
       `INSERT INTO application_outcomes
-       (tenant_id, outcome_id, job_key, kind, occurred_at)
-       VALUES ('local', 'confirmed-application', ?, 'applied_confirmation', ?)`,
-    ).run(PRIOR, NOW);
-    expect(evaluateRepeatApplication(db, TARGET)).toMatchObject({
+       (tenant_id, outcome_id, job_id, kind, source, occurred_at, recorded_at)
+       VALUES ('local', 'confirmed-application', ?, 'applied_confirmation', 'test', ?, ?)`,
+    ).run(PRIOR_JOB_ID, NOW, NOW);
+    expect(evaluateRepeatApplication(db, TARGET_JOB_ID)).toMatchObject({
       status: "confirmation_required",
       matches: [{ priorApplication: { factKind: "applied_confirmation" } }],
     });
@@ -263,11 +273,11 @@ describe("repeat application evidence", () => {
     insertJob(PRIOR, "Senior Backend Engineer", "Acme Inc");
     insertJob(TARGET, "Senior Backend Engineer", "Acme Inc");
     confirmPrior();
-    const initial = evaluateRepeatApplication(db, TARGET);
+    const initial = evaluateRepeatApplication(db, TARGET_JOB_ID);
 
-    const response = recordRepeatApplicationOverride(db, TARGET, {
+    const response = recordRepeatApplicationOverride(db, TARGET_JOB_ID, {
       evidenceFingerprint: initial.evidenceFingerprint!,
-      priorJobKey: PRIOR,
+      priorJobId: PRIOR_JOB_ID,
       reason: "The first record was withdrawn before review.",
       confirmedBy: "qa-user",
     });
@@ -275,8 +285,8 @@ describe("repeat application evidence", () => {
     expect(response.assessment).toMatchObject({
       status: "override_ready",
       override: {
-        targetJobKey: TARGET,
-        priorJobKey: PRIOR,
+        targetJobId: TARGET_JOB_ID,
+        priorJobId: PRIOR_JOB_ID,
         reason: "The first record was withdrawn before review.",
         confirmedBy: "qa-user",
         consumedAt: null,
@@ -294,47 +304,47 @@ describe("repeat application evidence", () => {
     db.prepare(
       "UPDATE application_repeat_audit SET audit_id = ? WHERE action = 'override_recorded'",
     ).run("00000000-0000-0000-0000-000000000000");
-    const ordered = evaluateRepeatApplication(db, TARGET, {
+    const ordered = evaluateRepeatApplication(db, TARGET_JOB_ID, {
       recordAudit: false,
       evaluatedAt: NOW,
     });
     expect(ordered.auditTrail[0]).toMatchObject({
       action: "override_recorded",
-      targetJobKey: TARGET,
-      priorJobKey: PRIOR,
+      targetJobId: TARGET_JOB_ID,
+      priorJobId: PRIOR_JOB_ID,
       evidence: [
         {
           relationship: "same_employer_equivalent_role",
-          priorApplication: { jobKey: PRIOR, factId: "event:1" },
+          priorApplication: { jobId: PRIOR_JOB_ID, factId: "event:1" },
         },
       ],
     });
 
-    db.prepare("UPDATE jobs SET title = 'Engineering Manager' WHERE url = ?").run(TARGET);
-    const cleared = evaluateRepeatApplication(db, TARGET);
+    db.prepare("UPDATE jobs SET title = 'Engineering Manager' WHERE job_id = ?").run(TARGET_JOB_ID);
+    const cleared = evaluateRepeatApplication(db, TARGET_JOB_ID);
     expect(cleared.status).toBe("clear");
     expect(cleared.auditTrail).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           action: "override_recorded",
-          priorJobKey: PRIOR,
+          priorJobId: PRIOR_JOB_ID,
           evidence: expect.arrayContaining([
-            expect.objectContaining({ priorApplication: expect.objectContaining({ jobKey: PRIOR }) }),
+            expect.objectContaining({ priorApplication: expect.objectContaining({ jobId: PRIOR_JOB_ID }) }),
           ]),
         }),
       ]),
     );
-    db.prepare("UPDATE jobs SET title = 'Senior Backend Engineer' WHERE url = ?").run(TARGET);
+    db.prepare("UPDATE jobs SET title = 'Senior Backend Engineer' WHERE job_id = ?").run(TARGET_JOB_ID);
 
     const secondPrior = "https://jobs.example.test/second-prior";
     insertJob(secondPrior, "Senior Backend Engineer", "Acme Inc");
     db.prepare(
-      "INSERT INTO job_events (job_url, event_type, occurred_at) VALUES (?, 'ApplicationSubmitted', ?)",
-    ).run(secondPrior, "2026-07-20T09:00:00.000Z");
+      "INSERT INTO job_events (tenant_id, job_id, identity_version, event_type, occurred_at) VALUES ('local', ?, 1, 'ApplicationSubmitted', ?)",
+    ).run(jobIdFor(secondPrior), "2026-07-20T09:00:00.000Z");
     expect(() =>
-      recordRepeatApplicationOverride(db, TARGET, {
+      recordRepeatApplicationOverride(db, TARGET_JOB_ID, {
         evidenceFingerprint: initial.evidenceFingerprint!,
-        priorJobKey: PRIOR,
+        priorJobId: PRIOR_JOB_ID,
         reason: "Trying to reuse an outdated confirmation.",
         confirmedBy: "qa-user",
       }),

--- a/apps/api/test/repeat-application.test.ts
+++ b/apps/api/test/repeat-application.test.ts
@@ -164,6 +164,19 @@ describe("repeat application evidence", () => {
     expect(() => assertLiveApplicationMayDispatch(db, TARGET_JOB_ID)).toThrow(
       "repeat_application_blocked",
     );
+    expect(() =>
+      recordRepeatApplicationOverride(db, TARGET_JOB_ID, {
+        evidenceFingerprint: assessment.evidenceFingerprint!,
+        priorJobId: PRIOR_JOB_ID,
+        reason: "The first application was withdrawn before review.",
+        confirmedBy: "qa-user",
+      }),
+    ).toThrow("repeat_application_blocked");
+    expect(
+      db.prepare(
+        "SELECT COUNT(*) AS count FROM application_repeat_overrides WHERE tenant_id = 'local' AND target_job_id = ?",
+      ).get(TARGET_JOB_ID),
+    ).toMatchObject({ count: 0 });
   });
 
   it("honors accepted duplicate links, including observation identities", () => {

--- a/apps/web/src/test/msw/handlers.ts
+++ b/apps/web/src/test/msw/handlers.ts
@@ -555,7 +555,7 @@ export const handlers = [
   http.post("*/v1/jobs/:jobKey/repeat-application/override", async ({ params, request }) => {
     const body = (await request.json()) as {
       evidenceFingerprint: string;
-      priorJobKey: string;
+      priorJobId: string;
       reason: string;
       confirmedBy?: string;
     };
@@ -578,8 +578,8 @@ export const handlers = [
         evidenceFingerprint: body.evidenceFingerprint,
         override: {
           overrideId: `repeat-override-${jobKey}`,
-          targetJobKey: jobKey,
-          priorJobKey: body.priorJobKey,
+          targetJobId: jobKey,
+          priorJobId: body.priorJobId,
           evidenceFingerprint: body.evidenceFingerprint,
           reason: body.reason,
           confirmedBy: body.confirmedBy ?? "user",

--- a/apps/web/src/views/apply-review/ApplyReviewView.test.tsx
+++ b/apps/web/src/views/apply-review/ApplyReviewView.test.tsx
@@ -918,10 +918,10 @@ describe("<ApplyReviewView>", () => {
     resolveConfirmation({ ok: true, assessment: repeatApplication });
   });
 
-  it("surfaces stale repeat evidence as a refresh-and-review error", async () => {
+  it("keeps canonical-identity repeats blocked without offering an override", async () => {
     const repeatApplication = makeRepeatApplicationAssessment({
       status: "blocked",
-      summary: "A confirmed application to this canonical opening blocks another live submission by default.",
+      summary: "A confirmed application to this canonical opening blocks another live submission.",
       evidenceFingerprint: "b".repeat(64),
       matches: [
         {
@@ -937,6 +937,50 @@ describe("<ApplyReviewView>", () => {
             confirmedAt: "2026-05-01T10:00:00Z",
           },
           identityEvidence: ["canonical_url:https://example.com/jobs/99"],
+        },
+      ],
+    });
+    const queue = {
+      ...sampleApplyReviewQueue,
+      items: sampleApplyReviewQueue.items.map((item, index) =>
+        index === 0 ? { ...item, repeatApplication } : item,
+      ),
+    };
+
+    renderWithProviders(<ApplyReviewView />, {
+      ports: buildTestPorts({
+        api: {
+          applyReviewQueue: vi.fn(async () => queue),
+        },
+      }),
+    });
+
+    expect(await screen.findByText("Repeat application blocked")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Reason for another live attempt")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Confirm one live attempt" })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Authorize live submit/i })).toBeDisabled();
+    expect(screen.getByRole("button", { name: /Authorize dry run/i })).toBeEnabled();
+  });
+
+  it("surfaces stale repeat evidence as a refresh-and-review error", async () => {
+    const repeatApplication = makeRepeatApplicationAssessment({
+      status: "confirmation_required",
+      summary: "A confirmed application to the same employer and an equivalent role requires deliberate confirmation.",
+      evidenceFingerprint: "b".repeat(64),
+      matches: [
+        {
+          relationship: "same_employer_equivalent_role",
+          reason: "The employer identity matches exactly and the normalized role titles are materially equivalent.",
+          priorApplication: {
+            jobId: "20000000-0000-4000-8000-000000000003",
+            title: "Principal Platform Engineer",
+            company: "Globex",
+            applicationUrl: null,
+            factKind: "application_submitted",
+            factId: "event:99",
+            confirmedAt: "2026-05-01T10:00:00Z",
+          },
+          identityEvidence: ["employer:globex", "role:principal platform engineer"],
         },
       ],
     });

--- a/apps/web/src/views/apply-review/ApplyReviewView.test.tsx
+++ b/apps/web/src/views/apply-review/ApplyReviewView.test.tsx
@@ -812,6 +812,8 @@ const pinnedTailoringExplanation: ArtifactTailoringExplanation = {
 describe("<ApplyReviewView>", () => {
   it("shows inspectable repeat evidence, keeps dry-run authorization available, and records a bound confirmation", async () => {
     const fingerprint = "a".repeat(64);
+    const priorJobId = "20000000-0000-4000-8000-000000000001";
+    const alternatePriorJobId = "20000000-0000-4000-8000-000000000002";
     const repeatApplication = makeRepeatApplicationAssessment({
       status: "confirmation_required",
       summary: "A confirmed application to the same employer and an equivalent role requires deliberate confirmation.",
@@ -821,7 +823,7 @@ describe("<ApplyReviewView>", () => {
           relationship: "same_employer_equivalent_role",
           reason: "The employer identity matches exactly and the normalized role titles are materially equivalent.",
           priorApplication: {
-            jobKey: "https://example.com/jobs/prior-platform",
+            jobId: priorJobId,
             title: "Principal Platform Engineer",
             company: "Globex",
             applicationUrl: "https://example.com/jobs/prior-platform/apply",
@@ -835,7 +837,7 @@ describe("<ApplyReviewView>", () => {
           relationship: "same_employer_equivalent_role",
           reason: "The employer identity matches exactly and the normalized role titles are materially equivalent.",
           priorApplication: {
-            jobKey: "https://alternate.example.test/jobs/prior-platform",
+            jobId: alternatePriorJobId,
             title: "Principal Platform Engineer",
             company: "Globex",
             applicationUrl: "https://alternate.example.test/jobs/prior-platform/apply",
@@ -849,12 +851,12 @@ describe("<ApplyReviewView>", () => {
       auditTrail: [
         {
           auditId: "audit-repeat-1",
-          targetJobKey: sampleApplyReviewQueue.items[0]!.jobKey,
+          targetJobId: "10000000-0000-4000-8000-000000000001",
           action: "confirmation_required",
           evidenceFingerprint: fingerprint,
           evidence: [],
           overrideId: null,
-          priorJobKey: null,
+          priorJobId: null,
           actor: "system",
           reason: null,
           occurredAt: "2026-05-06T06:36:00Z",
@@ -889,10 +891,10 @@ describe("<ApplyReviewView>", () => {
     expect(await screen.findByText("Review prior application before live submit")).toBeInTheDocument();
     expect(screen.getAllByText("worker-confirmed submission", { exact: false })).toHaveLength(2);
     expect(screen.getByRole("link", {
-      name: "Inspect prior application: https://example.com/jobs/prior-platform",
+      name: `Inspect prior application: ${priorJobId}`,
     })).toHaveAttribute(
       "href",
-      `/jobs/${encodeURIComponent("https://example.com/jobs/prior-platform")}`,
+      `/jobs/${encodeURIComponent(priorJobId)}`,
     );
     expect(screen.getByRole("button", { name: /Authorize live submit/i })).toBeDisabled();
     expect(screen.getByRole("button", { name: /Authorize dry run/i })).toBeEnabled();
@@ -903,13 +905,13 @@ describe("<ApplyReviewView>", () => {
     );
     expect(screen.getByRole("button", { name: "Confirm one live attempt" })).toBeDisabled();
     await userEvent.click(screen.getByRole("radio", {
-      name: "Confirm prior application: https://alternate.example.test/jobs/prior-platform",
+      name: `Confirm prior application: ${alternatePriorJobId}`,
     }));
     await userEvent.click(screen.getByRole("button", { name: "Confirm one live attempt" }));
     expect(screen.getByRole("button", { name: "Recording confirmation" })).toBeDisabled();
     expect(confirmRepeatApplication).toHaveBeenCalledWith(queue.items[0]!.jobKey, {
       evidenceFingerprint: fingerprint,
-      priorJobKey: "https://alternate.example.test/jobs/prior-platform",
+      priorJobId: alternatePriorJobId,
       reason: "The first application was withdrawn before review.",
       confirmedBy: "user",
     });
@@ -926,7 +928,7 @@ describe("<ApplyReviewView>", () => {
           relationship: "canonical_identity",
           reason: "The canonical ATS identity matches the previously applied opening.",
           priorApplication: {
-            jobKey: "prior-job",
+            jobId: "20000000-0000-4000-8000-000000000003",
             title: "Principal Platform Engineer",
             company: "Globex",
             applicationUrl: null,
@@ -966,14 +968,14 @@ describe("<ApplyReviewView>", () => {
   });
 
   it("keeps immutable repeat-protection evidence inspectable after the current relation clears", async () => {
-    const jobKey = sampleApplyReviewQueue.items[0]!.jobKey;
-    const priorJobKey = "https://example.com/jobs/prior-platform";
+    const targetJobId = "10000000-0000-4000-8000-000000000001";
+    const priorJobId = "20000000-0000-4000-8000-000000000004";
     const fingerprint = "c".repeat(64);
     const historicalMatch = {
       relationship: "same_employer_equivalent_role" as const,
       reason: "The employer identity matched when the confirmation was recorded.",
       priorApplication: {
-        jobKey: priorJobKey,
+        jobId: priorJobId,
         title: "Principal Platform Engineer",
         company: "Globex",
         applicationUrl: null,
@@ -991,12 +993,12 @@ describe("<ApplyReviewView>", () => {
       auditTrail: [
         {
           auditId: "audit-historical-1",
-          targetJobKey: jobKey,
+          targetJobId,
           action: "override_recorded",
           evidenceFingerprint: fingerprint,
           evidence: [historicalMatch],
           overrideId: "override-historical-1",
-          priorJobKey,
+          priorJobId,
           actor: "user",
           reason: "The first application was withdrawn before review.",
           occurredAt: "2026-05-06T06:36:00Z",
@@ -1020,7 +1022,7 @@ describe("<ApplyReviewView>", () => {
     expect(screen.getByText(/event:historical-42/)).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Inspect selected prior application" })).toHaveAttribute(
       "href",
-      `/jobs/${encodeURIComponent(priorJobKey)}`,
+      `/jobs/${encodeURIComponent(priorJobId)}`,
     );
   });
 

--- a/apps/web/src/views/apply-review/ApplyReviewView.tsx
+++ b/apps/web/src/views/apply-review/ApplyReviewView.tsx
@@ -1363,9 +1363,10 @@ function RepeatApplicationGuardPanel({ item }: { readonly item: ApplyReviewQueue
   const mutation = useRepeatApplicationOverrideMutation();
   const [reason, setReason] = useState("");
   const [selectedPriorJobId, setSelectedPriorJobId] = useState<string | null>(null);
-  const needsConfirmation = ["blocked", "confirmation_required", "override_consumed"].includes(
+  const needsAttention = ["blocked", "confirmation_required", "override_consumed"].includes(
     assessment.status,
   );
+  const canConfirm = ["confirmation_required", "override_consumed"].includes(assessment.status);
   const selectedPrior = assessment.matches.find(
     (match) => match.priorApplication.jobId === selectedPriorJobId,
   ) ?? (assessment.matches.length === 1 ? assessment.matches[0] ?? null : null);
@@ -1382,7 +1383,7 @@ function RepeatApplicationGuardPanel({ item }: { readonly item: ApplyReviewQueue
   const variant = assessment.status === "blocked" ? "destructive" : ["clear", "override_ready"].includes(assessment.status) ? "info" : "warning";
   return (
     <section className="repeat-application-guard" aria-label="Repeat application protection">
-      <Alert variant={variant} role={needsConfirmation ? "alert" : "status"}>
+      <Alert variant={variant} role={needsAttention ? "alert" : "status"}>
         {["clear", "override_ready"].includes(assessment.status) ? (
           <IconShieldCheck aria-hidden="true" />
         ) : (
@@ -1447,7 +1448,7 @@ function RepeatApplicationGuardPanel({ item }: { readonly item: ApplyReviewQueue
         </details>
       ) : null}
 
-      {needsConfirmation && assessment.matches.length > 0 && assessment.evidenceFingerprint ? (
+      {canConfirm && assessment.matches.length > 0 && assessment.evidenceFingerprint ? (
         <div className="repeat-application-confirmation-form">
           <FieldSet>
             <FieldLegend>Select the prior application for this confirmation</FieldLegend>

--- a/apps/web/src/views/apply-review/ApplyReviewView.tsx
+++ b/apps/web/src/views/apply-review/ApplyReviewView.tsx
@@ -1362,17 +1362,17 @@ function RepeatApplicationGuardPanel({ item }: { readonly item: ApplyReviewQueue
   const assessment = item.repeatApplication;
   const mutation = useRepeatApplicationOverrideMutation();
   const [reason, setReason] = useState("");
-  const [selectedPriorJobKey, setSelectedPriorJobKey] = useState<string | null>(null);
+  const [selectedPriorJobId, setSelectedPriorJobId] = useState<string | null>(null);
   const needsConfirmation = ["blocked", "confirmation_required", "override_consumed"].includes(
     assessment.status,
   );
   const selectedPrior = assessment.matches.find(
-    (match) => match.priorApplication.jobKey === selectedPriorJobKey,
+    (match) => match.priorApplication.jobId === selectedPriorJobId,
   ) ?? (assessment.matches.length === 1 ? assessment.matches[0] ?? null : null);
 
   useEffect(() => {
     setReason("");
-    setSelectedPriorJobKey(null);
+    setSelectedPriorJobId(null);
     mutation.reset();
   }, [item.jobKey]); // eslint-disable-line react-hooks/exhaustive-deps
 
@@ -1415,8 +1415,8 @@ function RepeatApplicationGuardPanel({ item }: { readonly item: ApplyReviewQueue
             </p>
             <p className="meta">{match.reason}</p>
             <a
-              href={`/jobs/${encodeURIComponent(match.priorApplication.jobKey)}`}
-              aria-label={`Inspect prior application: ${match.priorApplication.jobKey}`}
+              href={`/jobs/${encodeURIComponent(match.priorApplication.jobId)}`}
+              aria-label={`Inspect prior application: ${match.priorApplication.jobId}`}
             >
               Inspect prior application
             </a>
@@ -1453,8 +1453,8 @@ function RepeatApplicationGuardPanel({ item }: { readonly item: ApplyReviewQueue
             <FieldLegend>Select the prior application for this confirmation</FieldLegend>
             <FieldGroup data-slot="radio-group" className="repeat-application-prior-options">
               {assessment.matches.map((match) => {
-                const priorJobKey = match.priorApplication.jobKey;
-                const controlId = `repeat-application-prior-${encodeURIComponent(item.jobKey)}-${encodeURIComponent(priorJobKey)}`;
+                const priorJobId = match.priorApplication.jobId;
+                const controlId = `repeat-application-prior-${encodeURIComponent(item.jobKey)}-${encodeURIComponent(priorJobId)}`;
                 return (
                   <Field
                     className="repeat-application-prior"
@@ -1462,15 +1462,15 @@ function RepeatApplicationGuardPanel({ item }: { readonly item: ApplyReviewQueue
                     orientation="horizontal"
                   >
                     <Input
-                      checked={selectedPrior?.priorApplication.jobKey === priorJobKey}
+                      checked={selectedPrior?.priorApplication.jobId === priorJobId}
                       id={controlId}
                       name={`repeat-application-prior-${encodeURIComponent(item.jobKey)}`}
-                      onChange={() => setSelectedPriorJobKey(priorJobKey)}
+                      onChange={() => setSelectedPriorJobId(priorJobId)}
                       type="radio"
-                      value={priorJobKey}
+                      value={priorJobId}
                     />
                     <FieldLabel htmlFor={controlId}>
-                      Confirm prior application: {priorJobKey}
+                      Confirm prior application: {priorJobId}
                     </FieldLabel>
                   </Field>
                 );
@@ -1497,7 +1497,7 @@ function RepeatApplicationGuardPanel({ item }: { readonly item: ApplyReviewQueue
                 jobId: item.jobKey,
                 body: {
                   evidenceFingerprint: assessment.evidenceFingerprint!,
-                  priorJobKey: selectedPrior.priorApplication.jobKey,
+                  priorJobId: selectedPrior.priorApplication.jobId,
                   reason: reason.trim(),
                   confirmedBy: "user",
                 },
@@ -1536,22 +1536,22 @@ function RepeatApplicationGuardPanel({ item }: { readonly item: ApplyReviewQueue
                 </p>
                 <details>
                   <summary>Inspect recorded evidence</summary>
-                  {entry.priorJobKey ? (
-                    <a href={`/jobs/${encodeURIComponent(entry.priorJobKey)}`}>
+                  {entry.priorJobId ? (
+                    <a href={`/jobs/${encodeURIComponent(entry.priorJobId)}`}>
                       Inspect selected prior application
                     </a>
                   ) : null}
                   <ul>
                     {entry.evidence.map((match) => (
                       <li key={`${entry.auditId}:${match.relationship}:${match.priorApplication.factId}`}>
-                        <a href={`/jobs/${encodeURIComponent(match.priorApplication.jobKey)}`}>
+                        <a href={`/jobs/${encodeURIComponent(match.priorApplication.jobId)}`}>
                           {match.priorApplication.title}
                         </a>{" "}at {match.priorApplication.company}
                         {" — "}{relationshipLabel(match.relationship)}; {match.reason}; fact {match.priorApplication.factId}
                       </li>
                     ))}
                     <li>evidence fingerprint: {entry.evidenceFingerprint}</li>
-                    <li>target: {entry.targetJobKey}</li>
+                    <li>target: {entry.targetJobId}</li>
                   </ul>
                 </details>
               </li>

--- a/packages/contracts/src/schemas.ts
+++ b/packages/contracts/src/schemas.ts
@@ -385,7 +385,7 @@ export interface ApplyReviewDecisionResponse {
 export const RepeatApplicationOverrideRequestSchema = z
   .object({
     evidenceFingerprint: z.string().regex(/^[a-f0-9]{64}$/),
-    priorJobKey: z.string().trim().min(1).max(2048),
+    priorJobId: z.string().uuid(),
     reason: z.string().trim().min(10).max(400),
     confirmedBy: z.string().trim().min(1).max(120).default("user"),
   })
@@ -820,7 +820,7 @@ export interface RepeatApplicationMatch {
   relationship: RepeatApplicationRelationship;
   reason: string;
   priorApplication: {
-    jobKey: string;
+    jobId: string;
     title: string;
     company: string;
     applicationUrl: string | null;
@@ -833,8 +833,8 @@ export interface RepeatApplicationMatch {
 
 export interface RepeatApplicationOverride {
   overrideId: string;
-  targetJobKey: string;
-  priorJobKey: string;
+  targetJobId: string;
+  priorJobId: string;
   evidenceFingerprint: string;
   reason: string;
   confirmedBy: string;
@@ -845,12 +845,12 @@ export interface RepeatApplicationOverride {
 
 export interface RepeatApplicationAuditEntry {
   auditId: string;
-  targetJobKey: string;
+  targetJobId: string;
   action: "blocked" | "confirmation_required" | "override_recorded" | "override_consumed";
   evidenceFingerprint: string;
   evidence: RepeatApplicationMatch[];
   overrideId: string | null;
-  priorJobKey: string | null;
+  priorJobId: string | null;
   actor: string;
   reason: string | null;
   occurredAt: string;

--- a/packages/domain-types/test/fixtures/repeat_application_fingerprint_parity.json
+++ b/packages/domain-types/test/fixtures/repeat_application_fingerprint_parity.json
@@ -1,11 +1,11 @@
 {
-  "targetJobKey": "https://careers.example.test/Target-role",
+  "targetJobId": "70000000-0000-4000-8000-000000000001",
   "matches": [
     {
       "relationship": "same_employer_equivalent_role",
       "reason": "The employer identity matches exactly and the normalized role titles are materially equivalent.",
       "priorApplication": {
-        "jobKey": "https://jobs.example.test/a-role",
+        "jobId": "70000000-0000-4000-8000-000000000002",
         "title": "Senior Platform Engineer",
         "company": "Acme",
         "applicationUrl": "https://jobs.example.test/a-role/apply",
@@ -22,7 +22,7 @@
       "relationship": "canonical_identity",
       "reason": "The canonical ATS identity matches the previously applied opening.",
       "priorApplication": {
-        "jobKey": "https://jobs.example.test/Å-role",
+        "jobId": "70000000-0000-4000-8000-000000000003",
         "title": "Platform Engineer",
         "company": "Acme",
         "applicationUrl": null,
@@ -38,7 +38,7 @@
       "relationship": "same_employer_equivalent_role",
       "reason": "The employer identity matches exactly and the normalized role titles are materially equivalent.",
       "priorApplication": {
-        "jobKey": "https://jobs.example.test/B-role",
+        "jobId": "70000000-0000-4000-8000-000000000004",
         "title": "Platform Senior Eng",
         "company": "ACME, INC.",
         "applicationUrl": "https://jobs.example.test/B-role/apply",
@@ -52,5 +52,37 @@
       ]
     }
   ],
-  "expectedFingerprint": "b975c68b1b1a6025ea9fdd784bd4bf5e4d703fb05ed74949c5bad2533921d17b"
+  "invalidVectors": [
+    {
+      "name": "URL target identifier",
+      "targetJobId": "https://careers.example.test/target",
+      "matches": [],
+      "error": "canonical UUID"
+    },
+    {
+      "name": "URL prior identifier",
+      "targetJobId": "70000000-0000-4000-8000-000000000001",
+      "matches": [
+        {
+          "priorApplication": {
+            "jobId": "https://jobs.example.test/prior"
+          }
+        }
+      ],
+      "error": "canonical UUID"
+    },
+    {
+      "name": "legacy prior locator key",
+      "targetJobId": "70000000-0000-4000-8000-000000000001",
+      "matches": [
+        {
+          "priorApplication": {
+            "jobKey": "https://jobs.example.test/prior"
+          }
+        }
+      ],
+      "error": "priorApplication.jobId"
+    }
+  ],
+  "expectedFingerprint": "543fc30706d672acce8fb0a0001214f9739e45626cb492a028e88222f66c68df"
 }

--- a/workers/automation/src/jobctrl/actions.py
+++ b/workers/automation/src/jobctrl/actions.py
@@ -30,6 +30,7 @@ from jobctrl.workflow_specs import (
 
 INTERNAL_PIPELINE_ACTION_STAGES: tuple[str, ...] = (*SUPPORTED_STAGE_ORDER, "enrich")
 ACTION_STAGES: tuple[str, ...] = (*INTERNAL_PIPELINE_ACTION_STAGES, "apply", "profile_import")
+_APPLY_JOB_LOCATOR_UNRESOLVED = "apply_job_locator_unresolved"
 
 
 @dataclass(frozen=True)
@@ -97,14 +98,17 @@ def run_local_action(request: LocalActionRequest) -> LocalActionResult:
             error=f"Unknown action stage: {request.stage}",
         )
 
+    apply_job_id: str | None = None
     try:
         _bootstrap_runtime()
+        apply_job_id = _resolve_apply_action_job_id(request)
         _record_action_event(
             request,
             "ActionStarted",
             "info",
             f"{request.stage} action started",
             {"action_id": action_id, "dry_run": request.dry_run},
+            job_id=apply_job_id,
         )
 
         if request.stage == "profile_import" and request.dry_run:
@@ -117,12 +121,22 @@ def run_local_action(request: LocalActionRequest) -> LocalActionResult:
                 ok=True,
                 status="dry_run",
                 result=result,
+                job_id=apply_job_id,
             )
 
-        result = _execute_action(request)
+        result = _execute_action(request, apply_job_id=apply_job_id)
         ok = _action_succeeded(result)
         status = "succeeded" if ok else "failed"
-        return _finish_action(request, action_id, started_at, start, ok=ok, status=status, result=result)
+        return _finish_action(
+            request,
+            action_id,
+            started_at,
+            start,
+            ok=ok,
+            status=status,
+            result=result,
+            job_id=apply_job_id,
+        )
     except Exception as exc:  # noqa: BLE001 - action API must return structured failure
         return _finish_action(
             request,
@@ -134,6 +148,7 @@ def run_local_action(request: LocalActionRequest) -> LocalActionResult:
             result={},
             error=str(exc),
             traceback_text=traceback.format_exc(),
+            job_id=apply_job_id,
         )
 
 
@@ -177,7 +192,11 @@ def _bootstrap_runtime() -> None:
     init_db()
 
 
-def _execute_action(request: LocalActionRequest) -> dict[str, Any]:
+def _execute_action(
+    request: LocalActionRequest,
+    *,
+    apply_job_id: str | None = None,
+) -> dict[str, Any]:
     if request.stage in INTERNAL_PIPELINE_ACTION_STAGES:
         return _start_and_wait(
             build_run_stage_workflow_spec(
@@ -202,7 +221,7 @@ def _execute_action(request: LocalActionRequest) -> dict[str, Any]:
             build_apply_workflow_spec(
                 {
                     "tenantId": "local",
-                    "jobUrl": request.job_url,
+                    **({"jobId": apply_job_id} if apply_job_id else {}),
                     "limit": _effective_apply_limit(request),
                     "minScore": request.min_score,
                     "headless": request.headless,
@@ -266,6 +285,24 @@ def _effective_apply_limit(request: LocalActionRequest) -> int:
     return 0 if request.continuous else max(1, request.limit)
 
 
+def _resolve_apply_action_job_id(request: LocalActionRequest) -> str | None:
+    """Resolve the external apply URL before it reaches canonical event state."""
+    if request.stage != "apply" or not request.job_url:
+        return None
+
+    from jobctrl.domain.discovery.value_objects import PostingUrl
+    from jobctrl.domain.tenant import LOCAL_TENANT
+    from jobctrl.infrastructure.discovery import SqliteJobIdentityResolver
+
+    identity = SqliteJobIdentityResolver(get_connection()).resolve_current_by_posting_url(
+        LOCAL_TENANT,
+        PostingUrl(value=request.job_url),
+    )
+    if identity is None:
+        raise ValueError(_APPLY_JOB_LOCATOR_UNRESOLVED)
+    return str(identity.job_id)
+
+
 def _finish_action(
     request: LocalActionRequest,
     action_id: str,
@@ -277,6 +314,7 @@ def _finish_action(
     result: dict[str, Any],
     error: str | None = None,
     traceback_text: str | None = None,
+    job_id: str | None = None,
 ) -> LocalActionResult:
     finished_at = utc_now()
     duration_ms = int((perf_counter() - start) * 1000)
@@ -291,9 +329,10 @@ def _finish_action(
                 "duration_ms": duration_ms,
                 "error": error,
             },
+            job_id=job_id,
         )
         if request.dry_run:
-            _record_dry_run_metric(request, action_id, duration_ms)
+            _record_dry_run_metric(request, action_id, duration_ms, job_id=job_id)
     except Exception:  # noqa: BLE001 - action results must stay JSON-safe when event logging fails
         pass
     return LocalActionResult(
@@ -318,11 +357,16 @@ def _record_action_event(
     level: str,
     message: str,
     payload: dict[str, Any],
+    *,
+    job_id: str | None = None,
 ) -> None:
     conn = get_connection()
+    event_job_id = job_id
+    if event_job_id is None and request.stage != "apply":
+        event_job_id = request.job_url
     record_job_event(
         conn,
-        request.job_url,
+        event_job_id,
         request.stage,
         event_type,
         level=level,
@@ -332,7 +376,13 @@ def _record_action_event(
     conn.commit()
 
 
-def _record_dry_run_metric(request: LocalActionRequest, action_id: str, duration_ms: int) -> None:
+def _record_dry_run_metric(
+    request: LocalActionRequest,
+    action_id: str,
+    duration_ms: int,
+    *,
+    job_id: str | None = None,
+) -> None:
     conn = get_connection()
     record_operational_attempt_metric(
         conn,
@@ -341,7 +391,7 @@ def _record_dry_run_metric(request: LocalActionRequest, action_id: str, duration
         outcome="dry_run",
         adapter="api",
         run_id=action_id,
-        job_url=request.job_url,
+        job_id=job_id,
         duration_ms=duration_ms,
         metadata={
             "workers": request.workers,

--- a/workers/automation/src/jobctrl/apply/activities.py
+++ b/workers/automation/src/jobctrl/apply/activities.py
@@ -8,15 +8,16 @@ from typing import Any
 from temporalio import activity
 from temporalio.exceptions import ApplicationError
 
+from jobctrl.domain.identifiers import JobId, canonical_job_id
+
 
 @dataclass(frozen=True)
 class ApplyActivityInput:
-    # ``tenant_id`` is currently informational; runners read from
-    # ``LOCAL_TENANT`` until tenant scoping lands.
+    # Every targeted claim is scoped by this tenant and canonical JobId.
     tenant_id: str
     expected_app_dir: str | None = None
     expected_db_path: str | None = None
-    job_url: str | None = None
+    job_id: JobId | None = None
     limit: int = 1
     min_score: int = 7
     model: str = "default"
@@ -29,6 +30,10 @@ class ApplyActivityInput:
     # ``limit``.  Otherwise ``max(1, limit)`` jobs are processed.
     continuous: bool = False
     auto_apply_loop: bool = False
+
+    def __post_init__(self) -> None:
+        if self.job_id is not None:
+            object.__setattr__(self, "job_id", canonical_job_id(str(self.job_id)))
 
 
 @dataclass(frozen=True)
@@ -46,7 +51,7 @@ async def apply_activity(payload: ApplyActivityInput) -> ApplyActivityOutput:
     Exception policy:
 
     - ``CancelledError`` — re-raised so Temporal marks the activity cancelled.
-    - ``LookupError`` (missing job URL or other lookup misses) — wrapped in a
+    - ``LookupError`` (missing JobId or other lookup misses) — wrapped in a
       non-retryable ``ApplicationError`` so the workflow fails fast.
     - Any other exception — re-raised verbatim so Temporal's configured retry
       policy can fire on transient browser / network / executor failures.
@@ -80,19 +85,12 @@ async def apply_activity(payload: ApplyActivityInput) -> ApplyActivityOutput:
         # of one to keep ``limit < 1`` calls from no-oping.
         effective_limit = 0 if payload.continuous else max(1, payload.limit)
         approval_required = read_apply_approval_required(default=payload.approval_required)
-        min_score = (
-            read_min_fit_score(default=payload.min_score)
-            if payload.auto_apply_loop
-            else payload.min_score
-        )
-        workers = (
-            read_apply_concurrency(default=payload.workers)
-            if payload.auto_apply_loop
-            else payload.workers
-        )
+        min_score = read_min_fit_score(default=payload.min_score) if payload.auto_apply_loop else payload.min_score
+        workers = read_apply_concurrency(default=payload.workers) if payload.auto_apply_loop else payload.workers
         return apply_main(
             limit=effective_limit,
-            target_url=payload.job_url,
+            target_job_id=payload.job_id,
+            tenant_id=payload.tenant_id,
             min_score=min_score,
             headless=payload.headless,
             model=payload.model,
@@ -110,7 +108,10 @@ async def apply_activity(payload: ApplyActivityInput) -> ApplyActivityOutput:
             progress_message="apply still running",
             poll_interval=15.0,
             activity_name="apply",
-            job_context={"job_url": payload.job_url or "", "dry_run": payload.dry_run},
+            job_context={
+                "job_id": str(payload.job_id) if payload.job_id is not None else "",
+                "dry_run": payload.dry_run,
+            },
             on_cancel=_signal_launcher_stop,
         )
 
@@ -122,11 +123,9 @@ async def apply_activity(payload: ApplyActivityInput) -> ApplyActivityOutput:
             error=None,
         )
     except LookupError as exc:
-        # Missing job URL or other lookup misses are operator errors;
+        # Missing JobId or other lookup misses are operator errors;
         # do not retry — surface them immediately to the workflow.
-        raise ApplicationError(
-            str(exc), type=type(exc).__name__, non_retryable=True
-        ) from exc
+        raise ApplicationError(str(exc), type=type(exc).__name__, non_retryable=True) from exc
 
 
 def _signal_launcher_stop() -> None:
@@ -136,9 +135,7 @@ def _signal_launcher_stop() -> None:
 
         _stop_event.set()
     except Exception:  # noqa: BLE001 — never let cleanup mask the cancel
-        activity.logger.exception(
-            "apply_activity: failed to set launcher _stop_event during cancel"
-        )
+        activity.logger.exception("apply_activity: failed to set launcher _stop_event during cancel")
 
 
 # Re-exported for the registry; activity decorator metadata is preserved.

--- a/workers/automation/src/jobctrl/apply/launcher.py
+++ b/workers/automation/src/jobctrl/apply/launcher.py
@@ -79,7 +79,6 @@ from jobctrl.database import (
     _SCORE_DOWNSTREAM_STATE_JOIN,
     _SCORE_CURRENT_FOR_DOWNSTREAM,
     _SCORE_ELIGIBLE_FOR_DOWNSTREAM,
-    ensure_application_review_decision_columns,
     get_connection,
 )
 from jobctrl.domain.apply.services import ApplyPromptBuilder
@@ -88,7 +87,10 @@ from jobctrl.domain.apply.repeat_application import (
     evaluate_repeat_application,
 )
 from jobctrl.domain.apply.value_objects import ApplyPrompt, ApplyRunId, new_apply_run_id
+from jobctrl.domain.discovery.value_objects import PostingUrl
 from jobctrl.domain.profile.snapshot import ProfileSnapshot
+from jobctrl.domain.tenant import TenantId
+from jobctrl.infrastructure.discovery import SqliteJobIdentityResolver
 from jobctrl.operational_metrics import record_operational_attempt_metric
 from jobctrl.state import (
     ensure_job_stage_rows,
@@ -136,62 +138,64 @@ def _utc_now() -> str:
 # ---------------------------------------------------------------------------
 
 
-def _has_active_apply(conn, url: str) -> bool:
-    """True when ``job_stage_states.apply.state == 'running'`` for ``url``.
+def _has_active_apply(conn, *, tenant_id: str, job_id: str) -> bool:
+    """True when ``job_stage_states.apply.state == 'running'`` for one JobId.
 
     The §4.6 invariant — at most one in-progress apply per JobId —
     is enforced by checking the canonical stage state row.
     """
     row = conn.execute(
         "SELECT 1 FROM job_stage_states "
-        "WHERE job_url = ? AND stage = 'apply' AND state = 'running' LIMIT 1",
-        (url,),
+        "WHERE tenant_id = ? AND job_id = ? "
+        "AND stage = 'apply' AND state = 'running' LIMIT 1",
+        (tenant_id, job_id),
     ).fetchone()
     return row is not None
 
 
-def _has_succeeded_apply(conn, url: str) -> bool:
-    """True when the canonical apply stage row is succeeded for ``url``."""
+def _has_succeeded_apply(conn, *, tenant_id: str, job_id: str) -> bool:
+    """True when the canonical apply stage row is succeeded for one JobId."""
     row = conn.execute(
         "SELECT 1 FROM job_stage_states "
-        "WHERE job_url = ? AND stage = 'apply' AND state = 'succeeded' LIMIT 1",
-        (url,),
+        "WHERE tenant_id = ? AND job_id = ? "
+        "AND stage = 'apply' AND state = 'succeeded' LIMIT 1",
+        (tenant_id, job_id),
     ).fetchone()
     return row is not None
 
 
-def _has_needs_verification_apply(conn, url: str) -> bool:
-    """True when a live apply is parked for manual verification."""
+def _has_needs_verification_apply(conn, *, tenant_id: str, job_id: str) -> bool:
+    """True when one JobId is parked for manual verification."""
     row = conn.execute(
         "SELECT 1 FROM job_stage_states "
-        "WHERE job_url = ? AND stage = 'apply' AND state = 'needs_verification' LIMIT 1",
-        (url,),
+        "WHERE tenant_id = ? AND job_id = ? "
+        "AND stage = 'apply' AND state = 'needs_verification' LIMIT 1",
+        (tenant_id, job_id),
     ).fetchone()
     return row is not None
 
 
-def _attempt_count_for(conn, url: str) -> int:
+def _attempt_count_for(conn, *, tenant_id: str, job_id: str) -> int:
     """Return the canonical attempt count from ``job_stage_states.apply``."""
     row = conn.execute(
         "SELECT attempt_count FROM job_stage_states "
-        "WHERE job_url = ? AND stage = 'apply' LIMIT 1",
-        (url,),
+        "WHERE tenant_id = ? AND job_id = ? AND stage = 'apply' LIMIT 1",
+        (tenant_id, job_id),
     ).fetchone()
     return int(row[0] or 0) if row else 0
 
 
-def _latest_apply_review_decision(conn, *, tenant_id: str, job_key: str) -> dict[str, Any] | None:
-    ensure_application_review_decision_columns(conn)
+def _latest_apply_review_decision(conn, *, tenant_id: str, job_id: str) -> dict[str, Any] | None:
     row = conn.execute(
         """
         SELECT decision, materials_generation, profile_version, application_url,
                partial_override_run_id, email_recipient, email_attachment_artifact_id
         FROM application_review_decisions
-        WHERE tenant_id = ? AND job_key = ?
+        WHERE tenant_id = ? AND job_id = ?
         ORDER BY decided_at DESC, decision_id DESC
         LIMIT 1
         """,
-        (tenant_id, job_key),
+        (tenant_id, job_id),
     ).fetchone()
     if row is None:
         return None
@@ -206,19 +210,24 @@ def _latest_apply_review_decision(conn, *, tenant_id: str, job_key: str) -> dict
     }
 
 
-def _latest_email_application_candidate(conn, *, job_key: str) -> dict[str, Any] | None:
+def _latest_email_application_candidate(
+    conn,
+    *,
+    tenant_id: str,
+    job_id: str,
+) -> dict[str, Any] | None:
     try:
         row = conn.execute(
             """
             SELECT payload_json
             FROM job_events
-            WHERE job_url = ?
+            WHERE tenant_id = ? AND job_id = ?
               AND stage = 'apply'
               AND event_type = 'EmailApplicationCandidateRecorded'
             ORDER BY occurred_at DESC, event_id DESC
             LIMIT 1
             """,
-            (job_key,),
+            (tenant_id, job_id),
         ).fetchone()
     except Exception:  # noqa: BLE001
         return None
@@ -321,7 +330,8 @@ def _has_run_bound_initial_navigation(
 def _dry_run_evidence_exists(
     conn,
     *,
-    job_key: str,
+    tenant_id: str,
+    job_id: str,
     materials_generation: int,
     profile_version: int,
     application_url: str,
@@ -331,11 +341,12 @@ def _dry_run_evidence_exists(
     rows = conn.execute(
         """
         SELECT payload_json FROM job_events
-        WHERE job_url = ? AND stage = 'apply' AND event_type = 'DryRunCompleted'
+        WHERE tenant_id = ? AND job_id = ?
+          AND stage = 'apply' AND event_type = 'DryRunCompleted'
         ORDER BY event_id DESC
         LIMIT 24
         """,
-        (job_key,),
+        (tenant_id, job_id),
     ).fetchall()
     for row in rows:
         payload = _payload_from_row(row)
@@ -357,11 +368,12 @@ def _dry_run_evidence_exists(
         started_rows = conn.execute(
             """
             SELECT payload_json FROM job_events
-            WHERE job_url = ? AND stage = 'apply' AND event_type = 'ApplyRunStarted'
+            WHERE tenant_id = ? AND job_id = ?
+              AND stage = 'apply' AND event_type = 'ApplyRunStarted'
             ORDER BY event_id DESC
             LIMIT 48
             """,
-            (job_key,),
+            (tenant_id, job_id),
         ).fetchall()
         for started_row in started_rows:
             started_payload = _payload_from_row(started_row)
@@ -527,7 +539,7 @@ def _approval_refusal_reason(
     conn,
     *,
     tenant_id: str,
-    job_key: str,
+    job_id: str,
     materials_generation: Any,
     profile_version: int | None,
     application_url: str,
@@ -535,7 +547,7 @@ def _approval_refusal_reason(
     decision = _latest_apply_review_decision(
         conn,
         tenant_id=tenant_id,
-        job_key=job_key,
+        job_id=job_id,
     )
     if not decision or decision.get("decision") != "approve_submit":
         return "awaiting_approval"
@@ -557,7 +569,11 @@ def _approval_refusal_reason(
         return "approval_stale_profile"
     if str(decision.get("application_url") or "") != application_url:
         return "approval_stale_url"
-    email_candidate = _latest_email_application_candidate(conn, job_key=job_key)
+    email_candidate = _latest_email_application_candidate(
+        conn,
+        tenant_id=tenant_id,
+        job_id=job_id,
+    )
     if email_candidate:
         if (
             str(decision.get("email_recipient") or "").lower()
@@ -568,7 +584,8 @@ def _approval_refusal_reason(
             return "approval_stale_email_candidate"
     if _dry_run_evidence_exists(
         conn,
-        job_key=job_key,
+        tenant_id=tenant_id,
+        job_id=job_id,
         materials_generation=current_materials_generation,
         profile_version=decision_profile_version,
         application_url=application_url,
@@ -579,7 +596,8 @@ def _approval_refusal_reason(
     if partial_override_run_id:
         if _dry_run_evidence_exists(
             conn,
-            job_key=job_key,
+            tenant_id=tenant_id,
+            job_id=job_id,
             materials_generation=current_materials_generation,
             profile_version=decision_profile_version,
             application_url=application_url,
@@ -608,7 +626,9 @@ def _apply_candidate_select_parts() -> tuple[str, str]:
     attempts_subquery = (
         "(SELECT COALESCE(jss_a.attempt_count, 0) "
         "FROM job_stage_states jss_a "
-        "WHERE jss_a.job_url = jobs.url AND jss_a.stage = 'apply' LIMIT 1) AS apply_attempts"
+        "WHERE jss_a.tenant_id = jobs.tenant_id "
+        "AND jss_a.job_id = jobs.job_id "
+        "AND jss_a.stage = 'apply' LIMIT 1) AS apply_attempts"
     )
     columns = (
         f"jobs.tenant_id AS tenant_id, jobs.job_id AS job_id, "
@@ -640,6 +660,7 @@ def acquire_job(
     worker_id: int = 0,
     run_ctx: dict | None = None,
     approval_required: bool = True,
+    tenant_id: str | None = None,
 ) -> dict | None:
     """Atomically acquire the next job to apply to.
 
@@ -653,29 +674,40 @@ def acquire_job(
     conn = get_connection()
     try:
         conn.execute("BEGIN IMMEDIATE")
+        tenant_id = str(
+            tenant_id
+            or (run_ctx.get("tenant_id") if run_ctx else None)
+            or LOCAL_TENANT
+        )
 
         common_columns, common_joins = _apply_candidate_select_parts()
 
         if target_url:
-            like = f"%{target_url.split('?')[0].rstrip('/')}%"
-            target_row = conn.execute(
-                f"""
-                SELECT {common_columns}
-                FROM jobs {common_joins}
-                WHERE (jobs.url = ? OR {_EFFECTIVE_APPLICATION_URL} = ?
-                       OR {_EFFECTIVE_APPLICATION_URL} LIKE ? OR jobs.url LIKE ?)
-                  AND {_READY_TAILORED_RESUME_WITH_PDF}
-                  AND {_SCORE_ELIGIBLE_FOR_DOWNSTREAM}
-                  AND {_SCORE_CURRENT_FOR_DOWNSTREAM}
-                  AND {_NOT_CLOSED_ACTIVE_STATE}
-                LIMIT 1
-                """,
-                (target_url, target_url, like, like),
-            ).fetchone()
+            target_identity = SqliteJobIdentityResolver(conn).resolve_by_posting_url(
+                TenantId(tenant_id),
+                PostingUrl(value=target_url),
+            )
+            target_row = None
+            if target_identity is not None:
+                target_row = conn.execute(
+                    f"""
+                    SELECT {common_columns}
+                    FROM jobs {common_joins}
+                    WHERE jobs.tenant_id = ?
+                      AND jobs.job_id = ?
+                      AND {_READY_TAILORED_RESUME_WITH_PDF}
+                      AND {_SCORE_ELIGIBLE_FOR_DOWNSTREAM}
+                      AND {_SCORE_CURRENT_FOR_DOWNSTREAM}
+                      AND {_NOT_CLOSED_ACTIVE_STATE}
+                    LIMIT 1
+                    """,
+                    (tenant_id, str(target_identity.job_id)),
+                ).fetchone()
             candidate_rows = [target_row] if target_row is not None else []
         else:
             blocked_sites, blocked_patterns = _load_blocked()
             params: list[Any] = [
+                tenant_id,
                 config.DEFAULTS["max_apply_attempts"],
                 min_score,
             ]
@@ -694,18 +726,22 @@ def acquire_job(
                 f"""
                 SELECT {common_columns}
                 FROM jobs {common_joins}
-                WHERE {_READY_TAILORED_RESUME_WITH_PDF}
+                WHERE jobs.tenant_id = ?
+                  AND {_READY_TAILORED_RESUME_WITH_PDF}
                   AND {_EFFECTIVE_APPLY_TARGET_URL} IS NOT NULL
                   AND {_EFFECTIVE_APPLY_TARGET_URL} != ''
                   AND NOT EXISTS (
                       SELECT 1 FROM job_stage_states jss_active
-                      WHERE jss_active.job_url = jobs.url
+                      WHERE jss_active.tenant_id = jobs.tenant_id
+                        AND jss_active.job_id = jobs.job_id
                         AND jss_active.stage = 'apply'
                         AND jss_active.state IN ('running', 'succeeded', 'needs_verification')
                   )
                   AND COALESCE(
                       (SELECT jss_a.attempt_count FROM job_stage_states jss_a
-                       WHERE jss_a.job_url = jobs.url AND jss_a.stage = 'apply'
+                       WHERE jss_a.tenant_id = jobs.tenant_id
+                         AND jss_a.job_id = jobs.job_id
+                         AND jss_a.stage = 'apply'
                        LIMIT 1), 0
                   ) < ?
                   AND {_EFFECTIVE_FIT_SCORE} >= ?
@@ -731,7 +767,11 @@ def acquire_job(
         if not dry_run:
             row = None
             for candidate in candidate_rows:
-                candidate_assessment = evaluate_repeat_application(conn, candidate["url"])
+                candidate_assessment = evaluate_repeat_application(
+                    conn,
+                    tenant_id=tenant_id,
+                    target_job_id=candidate["job_id"],
+                )
                 if candidate_assessment["status"] in {"clear", "override_ready"}:
                     row = candidate
                     repeat_assessment = candidate_assessment
@@ -754,16 +794,18 @@ def acquire_job(
         # Skip manual ATS sites (the agent cannot solve them).
         from jobctrl.config import is_manual_ats
 
+        job_id = str(row["job_id"])
         url = row["url"]
         apply_url = row["application_url"] or url
         if is_manual_ats(apply_url):
             now = _utc_now()
-            ensure_job_stage_rows(conn, url)
+            ensure_job_stage_rows(conn, job_id, tenant_id=tenant_id)
             set_stage_state(
                 conn,
-                url,
+                job_id,
                 "apply",
                 "skipped",
+                tenant_id=tenant_id,
                 finished_at=now,
                 error_code="MANUAL_ATS",
                 error_message="manual ATS",
@@ -772,9 +814,10 @@ def acquire_job(
             run_id = new_apply_run_id()
             record_job_event(
                 conn,
-                url,
+                job_id,
                 "apply",
                 "ApplyManualSkip",
+                tenant_id=tenant_id,
                 level="info",
                 message="manual ATS",
                 payload={
@@ -793,26 +836,26 @@ def acquire_job(
         # Targeted-mode also enforces the no-active + max-attempts
         # invariants (the SELECT above is permissive on target_url so
         # we can surface "no such job" errors clearly).
-        if _has_active_apply(conn, url):
+        if _has_active_apply(conn, tenant_id=tenant_id, job_id=job_id):
             conn.rollback()
             return None
-        if _has_succeeded_apply(conn, url):
+        if _has_succeeded_apply(conn, tenant_id=tenant_id, job_id=job_id):
             conn.rollback()
             return None
-        if _has_needs_verification_apply(conn, url):
+        if _has_needs_verification_apply(conn, tenant_id=tenant_id, job_id=job_id):
             conn.rollback()
             return None
-        attempts = _attempt_count_for(conn, url)
+        attempts = _attempt_count_for(conn, tenant_id=tenant_id, job_id=job_id)
         if attempts >= int(config.DEFAULTS["max_apply_attempts"]):
             conn.rollback()
             return None
         if approval_required and not dry_run:
             refusal_reason = _approval_refusal_reason(
                 conn,
-                tenant_id=LOCAL_TENANT,
-                job_key=url,
+                tenant_id=tenant_id,
+                job_id=job_id,
                 materials_generation=row["materials_generation"],
-                profile_version=_current_profile_version(conn, tenant_id=LOCAL_TENANT),
+                profile_version=_current_profile_version(conn, tenant_id=tenant_id),
                 application_url=apply_url,
             )
             if refusal_reason:
@@ -841,18 +884,19 @@ def acquire_job(
             repeat_override_id = consume_repeat_application_override(
                 conn,
                 repeat_assessment,
-                target_job_key=url,
+                tenant_id=tenant_id,
+                target_job_id=job_id,
                 run_id=str(run_id),
                 consumed_at=now,
             )
-        ensure_job_stage_rows(conn, url)
+        ensure_job_stage_rows(conn, job_id, tenant_id=tenant_id)
         # Reset prior retryable terminal state (failed / exhausted /
         # canceled / skipped) back to pending so the §8.5 state machine accepts
         # the pending → running transition.
         prior_row = conn.execute(
             "SELECT state FROM job_stage_states "
-            "WHERE job_url = ? AND stage = 'apply' LIMIT 1",
-            (url,),
+            "WHERE tenant_id = ? AND job_id = ? AND stage = 'apply' LIMIT 1",
+            (tenant_id, job_id),
         ).fetchone()
         if prior_row is not None and prior_row[0] not in {
             "pending",
@@ -862,24 +906,27 @@ def acquire_job(
         }:
             set_stage_state(
                 conn,
-                url,
+                job_id,
                 "apply",
                 "pending",
+                tenant_id=tenant_id,
                 validate_transition=False,
             )
         set_stage_state(
             conn,
-            url,
+            job_id,
             "apply",
             "running",
+            tenant_id=tenant_id,
             started_at=now,
             attempt_count=attempts + 1,
         )
         record_job_event(
             conn,
-            url,
+            job_id,
             "apply",
             "ApplyRunStarted",
+            tenant_id=tenant_id,
             message="Apply agent acquired job",
             payload={
                 "run_id": str(run_id),
@@ -892,7 +939,7 @@ def acquire_job(
                 "workflow_id": run_ctx.get("workflow_id") if run_ctx else None,
                 "materials_generation": row["materials_generation"],
                 "application_url": apply_url,
-                "profile_version": _current_profile_version(conn, tenant_id=LOCAL_TENANT),
+                "profile_version": _current_profile_version(conn, tenant_id=tenant_id),
                 "repeat_application_override_id": repeat_override_id,
                 "repeat_application_evidence_fingerprint": (
                     repeat_assessment.get("evidenceFingerprint")
@@ -908,9 +955,11 @@ def acquire_job(
             run_ctx.setdefault("worker_id", worker_id)
             run_ctx["materials_generation"] = row["materials_generation"]
             run_ctx["application_url"] = apply_url
+            run_ctx["tenant_id"] = tenant_id
+            run_ctx["job_id"] = job_id
             run_ctx["profile_version"] = _current_profile_version(
                 conn,
-                tenant_id=LOCAL_TENANT,
+                tenant_id=tenant_id,
             )
             run_ctx["repeat_application_override_id"] = repeat_override_id
             run_ctx["repeat_application_evidence_fingerprint"] = (
@@ -922,8 +971,8 @@ def acquire_job(
         job_dict = _row_to_job_dict(row, run_id=run_id)
         decision = _latest_apply_review_decision(
             conn,
-            tenant_id=LOCAL_TENANT,
-            job_key=url,
+            tenant_id=tenant_id,
+            job_id=job_id,
         )
         if decision:
             job_dict["approved_email_recipient"] = str(decision.get("email_recipient") or "")

--- a/workers/automation/src/jobctrl/apply/launcher.py
+++ b/workers/automation/src/jobctrl/apply/launcher.py
@@ -87,15 +87,12 @@ from jobctrl.domain.apply.repeat_application import (
     evaluate_repeat_application,
 )
 from jobctrl.domain.apply.value_objects import ApplyPrompt, ApplyRunId, new_apply_run_id
-from jobctrl.domain.discovery.value_objects import PostingUrl
 from jobctrl.domain.identifiers import JobId, canonical_job_id
 from jobctrl.domain.profile.snapshot import ProfileSnapshot
 from jobctrl.domain.tenant import TenantId
-from jobctrl.infrastructure.discovery import SqliteJobIdentityResolver
 from jobctrl.operational_metrics import record_operational_attempt_metric
 from jobctrl.state import (
     ensure_job_stage_rows,
-    record_job_artifact,
     record_job_event,
     set_stage_state,
 )
@@ -179,8 +176,7 @@ def _has_needs_verification_apply(conn, *, tenant_id: str, job_id: str) -> bool:
 def _attempt_count_for(conn, *, tenant_id: str, job_id: str) -> int:
     """Return the canonical attempt count from ``job_stage_states.apply``."""
     row = conn.execute(
-        "SELECT attempt_count FROM job_stage_states "
-        "WHERE tenant_id = ? AND job_id = ? AND stage = 'apply' LIMIT 1",
+        "SELECT attempt_count FROM job_stage_states WHERE tenant_id = ? AND job_id = ? AND stage = 'apply' LIMIT 1",
         (tenant_id, job_id),
     ).fetchone()
     return int(row[0] or 0) if row else 0
@@ -200,15 +196,19 @@ def _latest_apply_review_decision(conn, *, tenant_id: str, job_id: str) -> dict[
     ).fetchone()
     if row is None:
         return None
-    return dict(row) if hasattr(row, "keys") else {
-        "decision": row[0],
-        "materials_generation": row[1],
-        "profile_version": row[2],
-        "application_url": row[3],
-        "partial_override_run_id": row[4],
-        "email_recipient": row[5],
-        "email_attachment_artifact_id": row[6],
-    }
+    return (
+        dict(row)
+        if hasattr(row, "keys")
+        else {
+            "decision": row[0],
+            "materials_generation": row[1],
+            "profile_version": row[2],
+            "application_url": row[3],
+            "partial_override_run_id": row[4],
+            "email_recipient": row[5],
+            "email_attachment_artifact_id": row[6],
+        }
+    )
 
 
 def _latest_email_application_candidate(
@@ -243,10 +243,7 @@ def _latest_email_application_candidate(
 
 
 def _current_profile_version(conn, *, tenant_id: str = "local") -> int | None:
-    columns = {
-        row[1]
-        for row in conn.execute("PRAGMA table_info(candidate_profiles)").fetchall()
-    }
+    columns = {row[1] for row in conn.execute("PRAGMA table_info(candidate_profiles)").fetchall()}
     if "version" not in columns:
         return None
     row = conn.execute(
@@ -304,17 +301,13 @@ def _has_run_bound_initial_navigation(
     if len(allowed) != 1:
         return False
     try:
-        expected_fingerprint = sha256(
-            canonical_http_url(application_url).encode("utf-8")
-        ).hexdigest()
+        expected_fingerprint = sha256(canonical_http_url(application_url).encode("utf-8")).hexdigest()
     except ValueError:
         return False
     navigation = allowed[0]
     return (
-        str(_payload_value(navigation, "decision") or "")
-        == "run_bound_initial_url"
-        and str(_payload_value(navigation, "grant_id", "grantId") or "")
-        == "initial_application_url"
+        str(_payload_value(navigation, "decision") or "") == "run_bound_initial_url"
+        and str(_payload_value(navigation, "grant_id", "grantId") or "") == "initial_application_url"
         and str(_payload_value(navigation, "method") or "").upper() == "GET"
         and str(
             _payload_value(
@@ -529,10 +522,7 @@ def _dry_run_completion_binding(
     )
     if not isinstance(blocked_channels, list):
         blocked_channels = [str(blocked_channels)]
-    allowed_navigations = (
-        _allowed_navigation_evidence(completion_payload)
-        or _allowed_navigation_evidence(ctx)
-    )
+    allowed_navigations = _allowed_navigation_evidence(completion_payload) or _allowed_navigation_evidence(ctx)
     if not _has_run_bound_initial_navigation(
         {"allowed_navigations": allowed_navigations},
         application_url=application_url,
@@ -543,11 +533,7 @@ def _dry_run_completion_binding(
         "application_url": application_url or None,
         "profile_version": profile_version,
         "coverage": coverage,
-        "blocked_channels": [
-            str(channel)
-            for channel in blocked_channels
-            if channel is not None and str(channel)
-        ],
+        "blocked_channels": [str(channel) for channel in blocked_channels if channel is not None and str(channel)],
         "allowed_navigations": allowed_navigations,
     }
 
@@ -592,11 +578,10 @@ def _approval_refusal_reason(
         job_id=job_id,
     )
     if email_candidate:
-        if (
-            str(decision.get("email_recipient") or "").lower()
-            != str(email_candidate.get("recipient") or "").lower()
-            or str(decision.get("email_attachment_artifact_id") or "")
-            != str(email_candidate.get("attachment_artifact_id") or "")
+        if str(decision.get("email_recipient") or "").lower() != str(
+            email_candidate.get("recipient") or ""
+        ).lower() or str(decision.get("email_attachment_artifact_id") or "") != str(
+            email_candidate.get("attachment_artifact_id") or ""
         ):
             return "approval_stale_email_candidate"
     if _dry_run_evidence_exists(
@@ -672,7 +657,7 @@ def _apply_candidate_select_parts() -> tuple[str, str]:
 
 
 def acquire_job(
-    target_url: str | None = None,
+    target_job_id: JobId | None = None,
     min_score: int = 7,
     worker_id: int = 0,
     run_ctx: dict | None = None,
@@ -691,35 +676,25 @@ def acquire_job(
     conn = get_connection()
     try:
         conn.execute("BEGIN IMMEDIATE")
-        tenant_id = str(
-            tenant_id
-            or (run_ctx.get("tenant_id") if run_ctx else None)
-            or LOCAL_TENANT
-        )
+        tenant_id = str(tenant_id or (run_ctx.get("tenant_id") if run_ctx else None) or LOCAL_TENANT)
 
         common_columns, common_joins = _apply_candidate_select_parts()
 
-        if target_url:
-            target_identity = SqliteJobIdentityResolver(conn).resolve_by_posting_url(
-                TenantId(tenant_id),
-                PostingUrl(value=target_url),
-            )
-            target_row = None
-            if target_identity is not None:
-                target_row = conn.execute(
-                    f"""
-                    SELECT {common_columns}
-                    FROM jobs {common_joins}
-                    WHERE jobs.tenant_id = ?
-                      AND jobs.job_id = ?
-                      AND {_READY_TAILORED_RESUME_WITH_PDF}
-                      AND {_SCORE_ELIGIBLE_FOR_DOWNSTREAM}
-                      AND {_SCORE_CURRENT_FOR_DOWNSTREAM}
-                      AND {_NOT_CLOSED_ACTIVE_STATE}
-                    LIMIT 1
-                    """,
-                    (tenant_id, str(target_identity.job_id)),
-                ).fetchone()
+        if target_job_id is not None:
+            target_row = conn.execute(
+                f"""
+                SELECT {common_columns}
+                FROM jobs {common_joins}
+                WHERE jobs.tenant_id = ?
+                  AND jobs.job_id = ?
+                  AND {_READY_TAILORED_RESUME_WITH_PDF}
+                  AND {_SCORE_ELIGIBLE_FOR_DOWNSTREAM}
+                  AND {_SCORE_CURRENT_FOR_DOWNSTREAM}
+                  AND {_NOT_CLOSED_ACTIVE_STATE}
+                LIMIT 1
+                """,
+                (tenant_id, str(canonical_job_id(str(target_job_id)))),
+            ).fetchone()
             candidate_rows = [target_row] if target_row is not None else []
         else:
             blocked_sites, blocked_patterns = _load_blocked()
@@ -735,9 +710,7 @@ def acquire_job(
                 params.extend(blocked_sites)
             url_clauses = ""
             if blocked_patterns:
-                url_clauses = " ".join(
-                    "AND jobs.url NOT LIKE ?" for _ in blocked_patterns
-                )
+                url_clauses = " ".join("AND jobs.url NOT LIKE ?" for _ in blocked_patterns)
                 params.extend(blocked_patterns)
             rows = conn.execute(
                 f"""
@@ -850,9 +823,7 @@ def acquire_job(
             logger.info("Skipping manual ATS: %s", url[:80])
             return None
 
-        # Targeted-mode also enforces the no-active + max-attempts
-        # invariants (the SELECT above is permissive on target_url so
-        # we can surface "no such job" errors clearly).
+        # Targeted-mode also enforces the no-active + max-attempts invariants.
         if _has_active_apply(conn, tenant_id=tenant_id, job_id=job_id):
             conn.rollback()
             return None
@@ -881,10 +852,7 @@ def acquire_job(
                 # Keep those audit facts even though this candidate cannot be
                 # claimed yet.
                 conn.commit()
-                add_event(
-                    f"[W{worker_id}] Awaiting apply approval "
-                    f"({refusal_reason}) for {(row['title'] or url)[:40]}"
-                )
+                add_event(f"[W{worker_id}] Awaiting apply approval ({refusal_reason}) for {(row['title'] or url)[:40]}")
                 logger.info(
                     "Apply approval required for %s; refusal_reason=%s",
                     url,
@@ -893,9 +861,7 @@ def acquire_job(
                 return None
 
         now = _utc_now()
-        run_id = ApplyRunId(
-            (run_ctx.get("run_id") if run_ctx else None) or new_apply_run_id()
-        )
+        run_id = ApplyRunId((run_ctx.get("run_id") if run_ctx else None) or new_apply_run_id())
         repeat_override_id = None
         if repeat_assessment and repeat_assessment["status"] == "override_ready":
             repeat_override_id = consume_repeat_application_override(
@@ -911,8 +877,7 @@ def acquire_job(
         # canceled / skipped) back to pending so the §8.5 state machine accepts
         # the pending → running transition.
         prior_row = conn.execute(
-            "SELECT state FROM job_stage_states "
-            "WHERE tenant_id = ? AND job_id = ? AND stage = 'apply' LIMIT 1",
+            "SELECT state FROM job_stage_states WHERE tenant_id = ? AND job_id = ? AND stage = 'apply' LIMIT 1",
             (tenant_id, job_id),
         ).fetchone()
         if prior_row is not None and prior_row[0] not in {
@@ -959,9 +924,7 @@ def acquire_job(
                 "profile_version": _current_profile_version(conn, tenant_id=tenant_id),
                 "repeat_application_override_id": repeat_override_id,
                 "repeat_application_evidence_fingerprint": (
-                    repeat_assessment.get("evidenceFingerprint")
-                    if repeat_assessment
-                    else None
+                    repeat_assessment.get("evidenceFingerprint") if repeat_assessment else None
                 ),
             },
         )
@@ -980,9 +943,7 @@ def acquire_job(
             )
             run_ctx["repeat_application_override_id"] = repeat_override_id
             run_ctx["repeat_application_evidence_fingerprint"] = (
-                repeat_assessment.get("evidenceFingerprint")
-                if repeat_assessment
-                else None
+                repeat_assessment.get("evidenceFingerprint") if repeat_assessment else None
             )
 
         job_dict = _row_to_job_dict(row, run_id=run_id)
@@ -993,9 +954,7 @@ def acquire_job(
         )
         if decision:
             job_dict["approved_email_recipient"] = str(decision.get("email_recipient") or "")
-            job_dict["approved_email_attachment_artifact_id"] = str(
-                decision.get("email_attachment_artifact_id") or ""
-            )
+            job_dict["approved_email_attachment_artifact_id"] = str(decision.get("email_attachment_artifact_id") or "")
         return job_dict
     except Exception:
         conn.rollback()
@@ -1017,37 +976,59 @@ def _register_apply_log_artifact(
     if worker_id is None:
         return
     log_path = config.LOG_DIR / f"worker-{int(worker_id)}.log"
-    record_job_artifact(
+    _record_apply_artifact(
         conn,
         job_id,
-        "apply",
-        "apply_log",
-        log_path,
         tenant_id=tenant_id,
+        artifact_type="apply_log",
+        path=log_path,
         status="active",
         created_at=occurred_at,
         metadata={"run_id": str(run_id), "worker_id": int(worker_id)},
     )
 
 
-def _resolve_apply_job_id(
+def _record_apply_artifact(
     conn,
+    job_id: JobId,
     *,
     tenant_id: TenantId,
-    job_id_or_url: JobId | str,
-) -> JobId:
-    """Resolve a legacy URL input once at the launcher boundary."""
-    value = str(job_id_or_url)
+    artifact_type: str,
+    path: Path,
+    status: str = "active",
+    created_at: str | None = None,
+    metadata: dict[str, Any] | None = None,
+) -> None:
+    """Persist an Apply artifact against the exact tenant/job aggregate."""
+
+    stable_job_id = canonical_job_id(str(job_id))
     try:
-        return canonical_job_id(value)
-    except ValueError:
-        identity = SqliteJobIdentityResolver(conn).resolve_by_posting_url(
-            tenant_id,
-            PostingUrl(value=value),
-        )
-        if identity is None:
-            raise ValueError("Job not found.") from None
-        return identity.job_id
+        size_bytes = path.stat().st_size
+    except OSError:
+        size_bytes = None
+    conn.execute(
+        """
+        INSERT INTO job_artifacts (
+            tenant_id, job_id, stage, artifact_type, status, path,
+            created_at, size_bytes, metadata_json
+        ) VALUES (?, ?, 'apply', ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(tenant_id, job_id, stage, artifact_type, path) DO UPDATE SET
+            status = excluded.status,
+            created_at = excluded.created_at,
+            size_bytes = excluded.size_bytes,
+            metadata_json = excluded.metadata_json
+        """,
+        (
+            str(tenant_id),
+            str(stable_job_id),
+            artifact_type,
+            status,
+            str(path),
+            created_at or _utc_now(),
+            size_bytes,
+            json.dumps(metadata or {}, separators=(",", ":"), sort_keys=True),
+        ),
+    )
 
 
 def _posting_url_for_job_id(
@@ -1137,7 +1118,7 @@ def _record_apply_terminal_event_once(
 
 
 def mark_result(
-    url: JobId | str,
+    job_id: JobId,
     status: str,
     error: str | None = None,
     permanent: bool = False,
@@ -1160,14 +1141,8 @@ def mark_result(
     """
     conn = get_connection()
     now = _utc_now()
-    stable_tenant_id = TenantId(
-        str(tenant_id or (run_ctx.get("tenant_id") if run_ctx else None) or LOCAL_TENANT)
-    )
-    stable_job_id = _resolve_apply_job_id(
-        conn,
-        tenant_id=stable_tenant_id,
-        job_id_or_url=url,
-    )
+    stable_job_id = canonical_job_id(str(job_id))
+    stable_tenant_id = TenantId(str(tenant_id or (run_ctx.get("tenant_id") if run_ctx else None) or LOCAL_TENANT))
     posting_url = _posting_url_for_job_id(
         conn,
         tenant_id=stable_tenant_id,
@@ -1179,23 +1154,16 @@ def mark_result(
         tenant_id=stable_tenant_id,
     )
 
-    run_id = (
-        task_id
-        or (run_ctx.get("run_id") if run_ctx else None)
-        or new_apply_run_id()
-    )
+    run_id = task_id or (run_ctx.get("run_id") if run_ctx else None) or new_apply_run_id()
     worker_id = run_ctx.get("worker_id") if run_ctx else None
     model = run_ctx.get("model") if run_ctx else None
     dry_run = bool(run_ctx.get("dry_run")) if run_ctx else False
-    submit_intent_recorded = (
-        status not in {"applied", "dry_run"}
-        and _has_apply_event_for_job_id(
-            conn,
-            tenant_id=stable_tenant_id,
-            job_id=stable_job_id,
-            run_id=str(run_id),
-            event_types={"ApplySubmitIntended"},
-        )
+    submit_intent_recorded = status not in {"applied", "dry_run"} and _has_apply_event_for_job_id(
+        conn,
+        tenant_id=stable_tenant_id,
+        job_id=stable_job_id,
+        run_id=str(run_id),
+        event_types={"ApplySubmitIntended"},
     )
 
     if status == "applied":
@@ -1204,9 +1172,13 @@ def mark_result(
         # still want to record this completion. Skip canonical validation;
         # the launcher is the writer.
         set_stage_state(
-            conn, stable_job_id, "apply", "succeeded",
+            conn,
+            stable_job_id,
+            "apply",
+            "succeeded",
             tenant_id=stable_tenant_id,
-            finished_at=now, duration_ms=duration_ms,
+            finished_at=now,
+            duration_ms=duration_ms,
             validate_transition=False,
         )
         _record_apply_terminal_event_once(
@@ -1284,13 +1256,10 @@ def mark_result(
             duration_ms=duration_ms,
             error_code="APPLY_NEEDS_VERIFICATION",
             error_message=(
-                "Apply reached the submit-intent checkpoint, but the external "
-                f"outcome is ambiguous: {reason}"
+                f"Apply reached the submit-intent checkpoint, but the external outcome is ambiguous: {reason}"
             ),
             retryable=False,
-            next_action=(
-                "Review the employer site or confirmation email before retrying."
-            ),
+            next_action=("Review the employer site or confirmation email before retrying."),
             validate_transition=False,
         )
         _record_apply_terminal_event_once(
@@ -1328,11 +1297,7 @@ def mark_result(
             error_code=str(status).upper(),
             error_message=reason,
             retryable=not permanent,
-            next_action=(
-                f"jobctrl apply --url {posting_url}"
-                if not permanent and posting_url
-                else None
-            ),
+            next_action=(f"jobctrl apply --url {posting_url}" if not permanent and posting_url else None),
             validate_transition=False,
         )
         _record_apply_terminal_event_once(
@@ -1394,21 +1359,15 @@ def _latest_apply_run_started_run_id(conn, url: str) -> str | None:
 
 
 def release_lock(
-    url: JobId | str,
+    job_id: JobId,
     run_ctx: dict | None = None,
     *,
     tenant_id: TenantId | None = None,
 ) -> None:
     """Record that launcher cleanup ran without making retry decisions."""
     conn = get_connection()
-    stable_tenant_id = TenantId(
-        str(tenant_id or (run_ctx.get("tenant_id") if run_ctx else None) or LOCAL_TENANT)
-    )
-    stable_job_id = _resolve_apply_job_id(
-        conn,
-        tenant_id=stable_tenant_id,
-        job_id_or_url=url,
-    )
+    stable_job_id = canonical_job_id(str(job_id))
+    stable_tenant_id = TenantId(str(tenant_id or (run_ctx.get("tenant_id") if run_ctx else None) or LOCAL_TENANT))
     ctx_run_id = run_ctx.get("run_id") if run_ctx else None
     run_id = (
         ctx_run_id
@@ -1462,24 +1421,49 @@ def recover_ambiguous_running_apply(console: Console | None = None) -> int:
     try:
         conn = get_connection()
         rows = conn.execute(
-            "SELECT job_url FROM job_stage_states "
-            "WHERE stage = 'apply' AND state = 'running'"
+            "SELECT tenant_id, job_id FROM job_stage_states WHERE stage = 'apply' AND state = 'running'"
         ).fetchall()
         recovered = 0
         for row in rows:
-            url = str(row["job_url"] if hasattr(row, "keys") else row[0])
+            tenant_id = TenantId(str(row["tenant_id"] if hasattr(row, "keys") else row[0]))
+            job_id = canonical_job_id(str(row["job_id"] if hasattr(row, "keys") else row[1]))
+            posting_url = _posting_url_for_job_id(
+                conn,
+                tenant_id=tenant_id,
+                job_id=job_id,
+            )
             try:
-                run_id, workflow_id = _latest_apply_run_started_identity(conn, url)
-                if not _workflow_terminal_or_gone(conn, workflow_id or run_id):
+                run_id, workflow_id = _latest_apply_run_started_identity(
+                    conn,
+                    tenant_id=tenant_id,
+                    job_id=job_id,
+                )
+                if not _workflow_terminal_or_gone(
+                    conn,
+                    tenant_id=tenant_id,
+                    workflow_id=workflow_id or run_id,
+                ):
                     continue
-                if run_id and _has_apply_submit_intent(conn, url, run_id):
-                    if _has_apply_terminal_result(conn, url, run_id):
+                if run_id:
+                    if _has_apply_terminal_result(
+                        conn,
+                        tenant_id=tenant_id,
+                        job_id=job_id,
+                        run_id=run_id,
+                    ):
                         continue
+                if run_id and _has_apply_submit_intent(
+                    conn,
+                    tenant_id=tenant_id,
+                    job_id=job_id,
+                    run_id=run_id,
+                ):
                     set_stage_state(
                         conn,
-                        url,
+                        job_id,
                         "apply",
                         "needs_verification",
+                        tenant_id=tenant_id,
                         error_code="APPLY_NEEDS_VERIFICATION",
                         error_message="Live apply reached the submit-intent checkpoint without a terminal result.",
                         retryable=False,
@@ -1489,34 +1473,43 @@ def recover_ambiguous_running_apply(console: Console | None = None) -> int:
                 else:
                     set_stage_state(
                         conn,
-                        url,
+                        job_id,
                         "apply",
                         "pending",
-                        next_action=f"jobctrl apply --url {url}",
+                        tenant_id=tenant_id,
+                        next_action=(f"jobctrl apply --url {posting_url}" if posting_url else None),
                         validate_transition=False,
                     )
                 recovered += 1
             except Exception:  # noqa: BLE001
-                logger.exception("Apply recovery failed for %s", url)
+                logger.exception(
+                    "Apply recovery failed for %s/%s",
+                    tenant_id,
+                    job_id,
+                )
                 continue
         if recovered:
             conn.commit()
             if console is not None:
-                console.print(
-                    f"[yellow]Recovered {recovered} ambiguous apply run(s) from prior crash[/yellow]"
-                )
+                console.print(f"[yellow]Recovered {recovered} ambiguous apply run(s) from prior crash[/yellow]")
         return recovered
     except Exception:  # noqa: BLE001
         logger.exception("Apply recovery sweep failed")
         return 0
 
 
-def _latest_apply_run_started_identity(conn, url: str) -> tuple[str | None, str | None]:
+def _latest_apply_run_started_identity(
+    conn,
+    *,
+    tenant_id: TenantId,
+    job_id: JobId,
+) -> tuple[str | None, str | None]:
     row = conn.execute(
         "SELECT payload_json FROM job_events "
-        "WHERE job_url = ? AND stage = 'apply' AND event_type = 'ApplyRunStarted' "
+        "WHERE tenant_id = ? AND job_id = ? "
+        "AND stage = 'apply' AND event_type = 'ApplyRunStarted' "
         "ORDER BY event_id DESC LIMIT 1",
-        (url,),
+        (str(tenant_id), str(canonical_job_id(str(job_id)))),
     ).fetchone()
     if row is None:
         return None, None
@@ -1532,13 +1525,18 @@ def _latest_apply_run_started_identity(conn, url: str) -> tuple[str | None, str 
     return run_id, workflow_id
 
 
-def _workflow_terminal_or_gone(conn, workflow_id: str | None) -> bool:
+def _workflow_terminal_or_gone(
+    conn,
+    *,
+    tenant_id: TenantId,
+    workflow_id: str | None,
+) -> bool:
     if not workflow_id:
         return True
     try:
         row = conn.execute(
-            "SELECT status FROM workflow_run_projections WHERE workflow_id = ? LIMIT 1",
-            (workflow_id,),
+            "SELECT status FROM workflow_run_projections WHERE tenant_id = ? AND workflow_id = ? LIMIT 1",
+            (str(tenant_id), workflow_id),
         ).fetchone()
     except Exception:  # noqa: BLE001
         return True
@@ -1548,27 +1546,63 @@ def _workflow_terminal_or_gone(conn, workflow_id: str | None) -> bool:
     return status in {"succeeded", "failed", "canceled", "timed_out", "terminated"}
 
 
-def _has_apply_submit_intent(conn, url: str, run_id: str) -> bool:
-    return _has_apply_event(conn, url, run_id, {"ApplySubmitIntended"})
-
-
-def _has_apply_terminal_result(conn, url: str, run_id: str) -> bool:
+def _has_apply_submit_intent(
+    conn,
+    *,
+    tenant_id: TenantId,
+    job_id: JobId,
+    run_id: str,
+) -> bool:
     return _has_apply_event(
         conn,
-        url,
-        run_id,
-        {"ApplicationSubmitted", "ApplicationFailed", "DryRunCompleted", "ApplyManualSkip"},
+        tenant_id=tenant_id,
+        job_id=job_id,
+        run_id=run_id,
+        event_types={"ApplySubmitIntended"},
     )
 
 
-def _has_apply_event(conn, url: str, run_id: str, event_types: set[str]) -> bool:
+def _has_apply_terminal_result(
+    conn,
+    *,
+    tenant_id: TenantId,
+    job_id: JobId,
+    run_id: str,
+) -> bool:
+    return _has_apply_event(
+        conn,
+        tenant_id=tenant_id,
+        job_id=job_id,
+        run_id=run_id,
+        event_types={
+            "ApplicationSubmitted",
+            "ApplicationFailed",
+            "DryRunCompleted",
+            "ApplyManualSkip",
+        },
+    )
+
+
+def _has_apply_event(
+    conn,
+    *,
+    tenant_id: TenantId,
+    job_id: JobId,
+    run_id: str,
+    event_types: set[str],
+) -> bool:
     placeholders = ",".join("?" for _ in event_types)
     rows = conn.execute(
         f"""
         SELECT payload_json FROM job_events
-        WHERE job_url = ? AND stage = 'apply' AND event_type IN ({placeholders})
+        WHERE tenant_id = ? AND job_id = ?
+          AND stage = 'apply' AND event_type IN ({placeholders})
         """,
-        (url, *event_types),
+        (
+            str(tenant_id),
+            str(canonical_job_id(str(job_id))),
+            *event_types,
+        ),
     ).fetchall()
     for row in rows:
         payload_json = row["payload_json"] if hasattr(row, "keys") else row[0]
@@ -1588,22 +1622,18 @@ def _has_apply_event(conn, url: str, run_id: str, event_types: set[str]) -> bool
 
 
 def mark_job(
-    url: JobId | str,
+    job_id: JobId,
     status: str,
     reason: str | None = None,
     *,
     tenant_id: TenantId | None = None,
 ) -> None:
     """Manually mark a job's apply status."""
+    stable_job_id = canonical_job_id(str(job_id))
     stable_tenant_id = tenant_id or LOCAL_TENANT
     if status == "applied":
         conn = get_connection()
         now = _utc_now()
-        stable_job_id = _resolve_apply_job_id(
-            conn,
-            tenant_id=stable_tenant_id,
-            job_id_or_url=url,
-        )
         ensure_job_stage_rows(
             conn,
             stable_job_id,
@@ -1636,7 +1666,7 @@ def mark_job(
         conn.commit()
     else:
         mark_result(
-            url,
+            stable_job_id,
             "failed",
             error=reason or "manual",
             permanent=True,
@@ -1657,17 +1687,31 @@ def reset_failed() -> int:
     conn = get_connection()
     rows = conn.execute(
         """
-        SELECT job_url FROM job_stage_states
+        SELECT tenant_id, job_id FROM job_stage_states
         WHERE stage = 'apply' AND state IN ('failed', 'exhausted')
         """
     ).fetchall()
     count = 0
     for row in rows:
-        url = row["job_url"]
+        tenant_id = TenantId(str(row["tenant_id"] if hasattr(row, "keys") else row[0]))
+        job_id = canonical_job_id(str(row["job_id"] if hasattr(row, "keys") else row[1]))
+        posting_url = _posting_url_for_job_id(
+            conn,
+            tenant_id=tenant_id,
+            job_id=job_id,
+        )
         # Skip jobs that already succeeded on a prior run.
-        if _has_succeeded_apply(conn, url):
+        if _has_succeeded_apply(
+            conn,
+            tenant_id=str(tenant_id),
+            job_id=str(job_id),
+        ):
             continue
-        ensure_job_stage_rows(conn, url)
+        ensure_job_stage_rows(
+            conn,
+            job_id,
+            tenant_id=tenant_id,
+        )
         # Per-row try/except so one race-induced failure (e.g., another
         # worker flipped the row to ``running`` between the SELECT and
         # this write) doesn't strand every subsequent row in the batch
@@ -1678,18 +1722,24 @@ def reset_failed() -> int:
         try:
             set_stage_state(
                 conn,
-                url,
+                job_id,
                 "apply",
                 "pending",
+                tenant_id=tenant_id,
                 attempt_count=0,
                 error_code=None,
                 error_message=None,
-                next_action=f"jobctrl apply --url {url}",
+                next_action=(f"jobctrl apply --url {posting_url}" if posting_url else None),
                 validate_transition=False,
             )
             count += 1
         except Exception as exc:  # noqa: BLE001 — keep batch reset alive
-            logger.warning("reset_failed: skipping %s — %s", url, exc)
+            logger.warning(
+                "reset_failed: skipping %s/%s — %s",
+                tenant_id,
+                job_id,
+                exc,
+            )
     conn.commit()
     return count
 
@@ -1712,19 +1762,14 @@ def _load_profile_snapshot() -> ProfileSnapshot:
 
 
 def _load_job_for_prompt(
-    target_url: JobId | str,
-    min_score: int,
+    job_id: JobId,
     *,
     tenant_id: TenantId,
+    min_score: int,
 ) -> dict[str, Any] | None:
     """Read one eligible job without creating an apply attempt or consuming authority."""
 
     conn = get_connection()
-    stable_job_id = _resolve_apply_job_id(
-        conn,
-        tenant_id=tenant_id,
-        job_id_or_url=target_url,
-    )
     common_columns, common_joins = _apply_candidate_select_parts()
     row = conn.execute(
         f"""
@@ -1738,13 +1783,13 @@ def _load_job_for_prompt(
           AND {_NOT_CLOSED_ACTIVE_STATE}
         LIMIT 1
         """,
-        (str(tenant_id), str(stable_job_id), min_score),
+        (str(tenant_id), str(canonical_job_id(str(job_id))), min_score),
     ).fetchone()
     return _row_to_job_dict(row) if row is not None else None
 
 
 def gen_prompt(
-    target_url: JobId | str,
+    job_id: JobId,
     min_score: int = 7,
     model: str = "default",
     worker_id: int = 0,
@@ -1755,9 +1800,9 @@ def gen_prompt(
     """Render an inspection-only dry-run prompt without claiming the job."""
 
     job = _load_job_for_prompt(
-        target_url,
-        min_score,
+        canonical_job_id(str(job_id)),
         tenant_id=tenant_id or LOCAL_TENANT,
+        min_score=min_score,
     )
     if not job:
         return None
@@ -1767,9 +1812,7 @@ def gen_prompt(
 
     decision = validate_public_http_url(apply_url)
     if not decision.allowed:
-        raise ValueError(
-            f"unsafe apply target URL: {decision.reason or 'not a public HTTP(S) destination'}"
-        )
+        raise ValueError(f"unsafe apply target URL: {decision.reason or 'not a public HTTP(S) destination'}")
 
     snapshot = snapshot or _load_profile_snapshot()
     cdp_port = BASE_CDP_PORT + worker_id
@@ -1840,9 +1883,7 @@ def _build_use_case():
         repository=SqliteApplyRunRepository(),
         browser_port=browser_port,
         agent_port=agent_port,
-        eligibility_checker=ApplyEligibilityChecker(
-            max_attempts=int(config.DEFAULTS["max_apply_attempts"])
-        ),
+        eligibility_checker=ApplyEligibilityChecker(max_attempts=int(config.DEFAULTS["max_apply_attempts"])),
         prompt_builder=ApplyPromptBuilder(),
         publisher=get_default_publisher(),
         saga=saga,
@@ -1854,14 +1895,21 @@ class SqliteApplyRunRepository:
     """Persist ``ApplyRun`` aggregate events into the canonical event stream."""
 
     def save(self, run) -> None:
-        job_url = str(getattr(run, "job_id", "") or "")
+        job_id_raw = str(getattr(run, "job_id", "") or "")
         run_id = str(getattr(run, "run_id", "") or "")
-        if not job_url or not run_id:
+        if not job_id_raw or not run_id:
             return
+        job_id = canonical_job_id(job_id_raw)
+        tenant_id = TenantId(str(getattr(run, "tenant_id", "") or LOCAL_TENANT))
 
         conn = get_connection()
         try:
-            seen = _existing_apply_event_ids(conn, job_url, run_id)
+            seen = _existing_apply_event_ids(
+                conn,
+                tenant_id=tenant_id,
+                job_id=job_id,
+                run_id=run_id,
+            )
             for event in list(getattr(run, "events", ()) or ()):
                 event_id = int(getattr(event, "event_id", 0) or 0)
                 if event_id and event_id in seen:
@@ -1875,15 +1923,23 @@ class SqliteApplyRunRepository:
                 payload.setdefault("apply_status", str(getattr(run, "status", "") or ""))
                 record_job_event(
                     conn,
-                    job_url,
+                    job_id,
                     "apply",
                     event_type,
+                    tenant_id=tenant_id,
                     level=str(getattr(event, "level", "info") or "info"),
                     message=getattr(event, "message", None),
                     payload=payload,
                     occurred_at=str(getattr(event, "occurred_at", "") or "") or None,
                 )
-                _persist_agent_artifacts(conn, job_url, run_id, event_type, payload)
+                _persist_agent_artifacts(
+                    conn,
+                    tenant_id=tenant_id,
+                    job_id=job_id,
+                    run_id=run_id,
+                    event_type=event_type,
+                    payload=payload,
+                )
                 if event_id:
                     seen.add(event_id)
             conn.commit()
@@ -1904,13 +1960,20 @@ class SqliteApplyRunRepository:
         return []
 
 
-def _existing_apply_event_ids(conn, job_url: str, run_id: str) -> set[int]:
+def _existing_apply_event_ids(
+    conn,
+    *,
+    tenant_id: TenantId,
+    job_id: JobId,
+    run_id: str,
+) -> set[int]:
     rows = conn.execute(
         """
         SELECT payload_json FROM job_events
-        WHERE job_url = ? AND stage = 'apply' AND payload_json IS NOT NULL
+        WHERE tenant_id = ? AND job_id = ?
+          AND stage = 'apply' AND payload_json IS NOT NULL
         """,
-        (job_url,),
+        (str(tenant_id), str(canonical_job_id(str(job_id)))),
     ).fetchall()
     seen: set[int] = set()
     for row in rows:
@@ -1932,7 +1995,9 @@ def _existing_apply_event_ids(conn, job_url: str, run_id: str) -> set[int]:
 
 def _persist_agent_artifacts(
     conn,
-    job_url: str,
+    *,
+    tenant_id: TenantId,
+    job_id: JobId,
     run_id: str,
     event_type: str,
     payload: dict[str, Any],
@@ -1958,12 +2023,12 @@ def _persist_agent_artifacts(
             ),
             encoding="utf-8",
         )
-        record_job_artifact(
+        _record_apply_artifact(
             conn,
-            job_url,
-            "apply",
-            "apply_dryrun_blocked",
-            blocked_path,
+            job_id,
+            tenant_id=tenant_id,
+            artifact_type="apply_dryrun_blocked",
+            path=blocked_path,
             status="active",
             metadata={
                 "run_id": run_id,
@@ -1980,12 +2045,12 @@ def _persist_agent_artifacts(
     artifact_dir.mkdir(parents=True, exist_ok=True)
     output_path = artifact_dir / f"{safe_run}-agent-output.txt"
     output_path.write_text(raw_output, encoding="utf-8")
-    record_job_artifact(
+    _record_apply_artifact(
         conn,
-        job_url,
-        "apply",
-        "apply_agent_output",
-        output_path,
+        job_id,
+        tenant_id=tenant_id,
+        artifact_type="apply_agent_output",
+        path=output_path,
         status="active",
         metadata={"run_id": run_id},
     )
@@ -1993,16 +2058,15 @@ def _persist_agent_artifacts(
         return
     confirmation_path = artifact_dir / f"{safe_run}-confirmation.html"
     confirmation_path.write_text(
-        "<!doctype html><meta charset=\"utf-8\"><title>Apply confirmation</title>"
-        f"<pre>{html.escape(raw_output)}</pre>",
+        f'<!doctype html><meta charset="utf-8"><title>Apply confirmation</title><pre>{html.escape(raw_output)}</pre>',
         encoding="utf-8",
     )
-    record_job_artifact(
+    _record_apply_artifact(
         conn,
-        job_url,
-        "apply",
-        "apply_confirmation",
-        confirmation_path,
+        job_id,
+        tenant_id=tenant_id,
+        artifact_type="apply_confirmation",
+        path=confirmation_path,
         status="active",
         metadata={"run_id": run_id, "source": "agent_output"},
     )
@@ -2048,6 +2112,8 @@ def run_job(
     dry_run: bool = False,
     run_ctx: dict | None = None,
     snapshot: ProfileSnapshot | None = None,
+    *,
+    tenant_id: TenantId,
 ) -> tuple[str, int]:
     """Spawn a Claude Code session for one job application.
 
@@ -2084,13 +2150,10 @@ def run_job(
         actions=0,
         last_action="starting",
     )
-    add_event(
-        f"[W{worker_id} {run_id[:8]}] Starting: "
-        f"{(job.get('title') or '')[:40]} @ {job.get('site', '')}"
-    )
+    add_event(f"[W{worker_id} {run_id[:8]}] Starting: {(job.get('title') or '')[:40]} @ {job.get('site', '')}")
 
     outcome = use_case.execute(
-        tenant_id=LOCAL_TENANT,
+        tenant_id=tenant_id,
         job=job,
         snapshot=snapshot,
         worker_id=worker_id,
@@ -2165,7 +2228,7 @@ def _is_permanent_failure(result: str) -> bool:
 def worker_loop(
     worker_id: int = 0,
     limit: int = 1,
-    target_url: str | None = None,
+    target_job_id: JobId | None = None,
     min_score: int = 7,
     headless: bool = False,
     model: str = "default",
@@ -2173,6 +2236,7 @@ def worker_loop(
     snapshot: ProfileSnapshot | None = None,
     approval_required: bool = True,
     workflow_id: str | None = None,
+    tenant_id: str | None = None,
 ) -> tuple[int, int]:
     """Run jobs sequentially until ``limit`` is reached or the queue is empty."""
     applied = 0
@@ -2181,6 +2245,7 @@ def worker_loop(
     jobs_done = 0
     empty_polls = 0
     port = BASE_CDP_PORT + worker_id
+    stable_tenant_id = TenantId(str(tenant_id or LOCAL_TENANT))
 
     while not _stop_event.is_set():
         if not continuous and jobs_done >= limit:
@@ -2217,16 +2282,18 @@ def worker_loop(
             "model": model,
             "dry_run": dry_run,
             "workflow_id": workflow_id,
-            "target_url": target_url,
+            "target_job_id": str(target_job_id) if target_job_id is not None else None,
+            "tenant_id": str(stable_tenant_id),
             "min_score": min_score,
             "headless": headless,
         }
         job = acquire_job(
-            target_url=target_url,
+            target_job_id=target_job_id,
             min_score=min_score,
             worker_id=worker_id,
             run_ctx=run_ctx,
             approval_required=approval_required,
+            tenant_id=str(stable_tenant_id),
         )
         if not job:
             if not continuous:
@@ -2234,13 +2301,9 @@ def worker_loop(
                 update_state(worker_id, status="done", last_action="queue empty")
                 break
             empty_polls += 1
-            update_state(
-                worker_id, status="idle", last_action=f"polling ({empty_polls})"
-            )
+            update_state(worker_id, status="idle", last_action=f"polling ({empty_polls})")
             if empty_polls == 1:
-                add_event(
-                    f"[W{worker_id}] Queue empty, polling every {POLL_INTERVAL}s..."
-                )
+                add_event(f"[W{worker_id}] Queue empty, polling every {POLL_INTERVAL}s...")
             if _stop_event.wait(timeout=POLL_INTERVAL):
                 break
             continue
@@ -2257,6 +2320,7 @@ def worker_loop(
                 dry_run=dry_run,
                 run_ctx=run_ctx,
                 snapshot=snapshot,
+                tenant_id=stable_tenant_id,
             )
 
             if result == "skipped":
@@ -2265,10 +2329,7 @@ def worker_loop(
                     run_ctx=run_ctx,
                     tenant_id=job_tenant_id,
                 )
-                add_event(
-                    f"[W{worker_id} {run_ctx['run_id'][:8]}] Skipped: "
-                    f"{(job.get('title') or '')[:30]}"
-                )
+                add_event(f"[W{worker_id} {run_ctx['run_id'][:8]}] Skipped: {(job.get('title') or '')[:30]}")
                 continue
             if result == "applied":
                 mark_result(
@@ -2308,26 +2369,20 @@ def worker_loop(
                     tenant_id=job_tenant_id,
                 )
                 failed += 1
-                update_state(
-                    worker_id, jobs_failed=failed, jobs_done=applied + failed
-                )
+                update_state(worker_id, jobs_failed=failed, jobs_done=applied + failed)
         except KeyboardInterrupt:
             release_lock(
                 job_id,
                 run_ctx=run_ctx,
                 tenant_id=job_tenant_id,
             )
-            add_event(
-                f"[W{worker_id} {run_ctx['run_id'][:8]}] Job skipped (Ctrl+C)"
-            )
+            add_event(f"[W{worker_id} {run_ctx['run_id'][:8]}] Job skipped (Ctrl+C)")
             if _stop_event.is_set():
                 break
             continue
         except Exception as exc:  # noqa: BLE001
             logger.exception("Worker %d launcher error", worker_id)
-            add_event(
-                f"[W{worker_id} {run_ctx['run_id'][:8]}] Launcher error: {str(exc)[:40]}"
-            )
+            add_event(f"[W{worker_id} {run_ctx['run_id'][:8]}] Launcher error: {str(exc)[:40]}")
             release_lock(
                 job_id,
                 run_ctx=run_ctx,
@@ -2337,7 +2392,7 @@ def worker_loop(
             update_state(worker_id, jobs_failed=failed)
 
         jobs_done += 1
-        if target_url:
+        if target_job_id is not None:
             break
 
     update_state(worker_id, run_id="", status="done", last_action="finished")
@@ -2351,7 +2406,8 @@ def worker_loop(
 
 def main(
     limit: int = 1,
-    target_url: str | None = None,
+    target_job_id: JobId | None = None,
+    tenant_id: str | None = None,
     min_score: int = 7,
     headless: bool = False,
     model: str = "default",
@@ -2373,11 +2429,13 @@ def main(
     batch_started = time.time()
     metric_error_class: str | None = None
     metric_error_message: str | None = None
+    stable_tenant_id = TenantId(str(tenant_id or LOCAL_TENANT))
 
     _record_apply_batch_metric(
         outcome="started",
         run_id=batch_run_id,
-        target_url=target_url,
+        tenant_id=stable_tenant_id,
+        job_id=target_job_id,
         dry_run=dry_run,
         workers=workers,
         model=model,
@@ -2405,9 +2463,7 @@ def main(
         init_worker(i)
 
     worker_label = f"{workers} worker{'s' if workers > 1 else ''}"
-    console.print(
-        f"Launching apply pipeline ({mode_label}, {worker_label}, poll every {POLL_INTERVAL}s)..."
-    )
+    console.print(f"Launching apply pipeline ({mode_label}, {worker_label}, poll every {POLL_INTERVAL}s)...")
     console.print("[dim]Ctrl+C = skip current job(s) | Ctrl+C x2 = stop[/dim]")
 
     _ctrl_c_count = 0
@@ -2416,9 +2472,7 @@ def main(
         nonlocal _ctrl_c_count
         _ctrl_c_count += 1
         if _ctrl_c_count == 1:
-            console.print(
-                "\n[yellow]Skipping current job(s)... (Ctrl+C again to STOP)[/yellow]"
-            )
+            console.print("\n[yellow]Skipping current job(s)... (Ctrl+C again to STOP)[/yellow]")
             _kill_claude_processes_for_interrupt()
         else:
             console.print("\n[red bold]STOPPING[/red bold]")
@@ -2446,7 +2500,7 @@ def main(
                 total_applied, total_failed = worker_loop(
                     worker_id=0,
                     limit=effective_limit,
-                    target_url=target_url,
+                    target_job_id=target_job_id,
                     min_score=min_score,
                     headless=headless,
                     model=model,
@@ -2454,26 +2508,23 @@ def main(
                     snapshot=snapshot,
                     approval_required=approval_required,
                     workflow_id=workflow_id,
+                    tenant_id=stable_tenant_id,
                 )
             else:
                 if effective_limit:
                     base = effective_limit // workers
                     extra = effective_limit % workers
-                    limits = [
-                        base + (1 if i < extra else 0) for i in range(workers)
-                    ]
+                    limits = [base + (1 if i < extra else 0) for i in range(workers)]
                 else:
                     limits = [0] * workers
 
-                with ThreadPoolExecutor(
-                    max_workers=workers, thread_name_prefix="apply-worker"
-                ) as executor:
+                with ThreadPoolExecutor(max_workers=workers, thread_name_prefix="apply-worker") as executor:
                     futures = {
                         executor.submit(
                             worker_loop,
                             worker_id=i,
                             limit=limits[i],
-                            target_url=target_url,
+                            target_job_id=target_job_id,
                             min_score=min_score,
                             headless=headless,
                             model=model,
@@ -2481,6 +2532,7 @@ def main(
                             snapshot=snapshot,
                             approval_required=approval_required,
                             workflow_id=workflow_id,
+                            tenant_id=stable_tenant_id,
                         ): i
                         for i in range(workers)
                     }
@@ -2502,10 +2554,7 @@ def main(
             live.update(render_full())
 
         totals = get_totals()
-        console.print(
-            f"\n[bold]Done: {total_applied} applied, {total_failed} failed "
-            f"(${totals['cost']:.3f})[/bold]"
-        )
+        console.print(f"\n[bold]Done: {total_applied} applied, {total_failed} failed (${totals['cost']:.3f})[/bold]")
         console.print(f"Logs: {config.LOG_DIR}")
     except KeyboardInterrupt:
         metric_error_class = "manual_abort_apply"
@@ -2527,7 +2576,8 @@ def main(
         _record_apply_batch_metric(
             outcome=metric_outcome,
             run_id=batch_run_id,
-            target_url=target_url,
+            tenant_id=stable_tenant_id,
+            job_id=target_job_id,
             dry_run=dry_run,
             workers=workers,
             model=model,
@@ -2545,7 +2595,8 @@ def _record_apply_batch_metric(
     *,
     outcome: str,
     run_id: str,
-    target_url: str | None,
+    tenant_id: str | None,
+    job_id: JobId | None,
     dry_run: bool,
     workers: int,
     model: str,
@@ -2564,7 +2615,8 @@ def _record_apply_batch_metric(
             outcome=outcome,
             adapter="browser",
             run_id=run_id,
-            job_url=target_url,
+            tenant_id=tenant_id,
+            job_id=str(canonical_job_id(str(job_id))) if job_id is not None else None,
             duration_ms=duration_ms,
             counts={"total": total_applied + total_failed},
             error_class=error_class,

--- a/workers/automation/src/jobctrl/apply/launcher.py
+++ b/workers/automation/src/jobctrl/apply/launcher.py
@@ -88,6 +88,7 @@ from jobctrl.domain.apply.repeat_application import (
 )
 from jobctrl.domain.apply.value_objects import ApplyPrompt, ApplyRunId, new_apply_run_id
 from jobctrl.domain.discovery.value_objects import PostingUrl
+from jobctrl.domain.identifiers import JobId, canonical_job_id
 from jobctrl.domain.profile.snapshot import ProfileSnapshot
 from jobctrl.domain.tenant import TenantId
 from jobctrl.infrastructure.discovery import SqliteJobIdentityResolver
@@ -417,15 +418,22 @@ def _dry_run_evidence_exists(
     return False
 
 
-def _apply_run_started_payload(conn, *, job_key: str, run_id: str) -> dict[str, Any]:
+def _apply_run_started_payload(
+    conn,
+    *,
+    tenant_id: TenantId,
+    job_id: JobId,
+    run_id: str,
+) -> dict[str, Any]:
     rows = conn.execute(
         """
         SELECT payload_json FROM job_events
-        WHERE job_url = ? AND stage = 'apply' AND event_type = 'ApplyRunStarted'
+        WHERE tenant_id = ? AND job_id = ?
+          AND stage = 'apply' AND event_type = 'ApplyRunStarted'
         ORDER BY event_id DESC
         LIMIT 48
         """,
-        (job_key,),
+        (str(tenant_id), str(canonical_job_id(str(job_id)))),
     ).fetchall()
     for row in rows:
         payload = _payload_from_row(row)
@@ -437,17 +445,19 @@ def _apply_run_started_payload(conn, *, job_key: str, run_id: str) -> dict[str, 
 def _latest_dry_run_completion_payload(
     conn,
     *,
-    job_key: str,
+    tenant_id: TenantId,
+    job_id: JobId,
     run_id: str,
 ) -> dict[str, Any]:
     rows = conn.execute(
         """
         SELECT payload_json FROM job_events
-        WHERE job_url = ? AND stage = 'apply' AND event_type = 'DryRunCompleted'
+        WHERE tenant_id = ? AND job_id = ?
+          AND stage = 'apply' AND event_type = 'DryRunCompleted'
         ORDER BY event_id DESC
         LIMIT 24
         """,
-        (job_key,),
+        (str(tenant_id), str(canonical_job_id(str(job_id)))),
     ).fetchall()
     for row in rows:
         payload = _payload_from_row(row)
@@ -459,15 +469,22 @@ def _latest_dry_run_completion_payload(
 def _dry_run_completion_binding(
     conn,
     *,
-    job_key: str,
+    tenant_id: TenantId,
+    job_id: JobId,
     run_id: str,
     run_ctx: dict | None,
 ) -> dict[str, Any]:
     ctx = run_ctx or {}
-    started_payload = _apply_run_started_payload(conn, job_key=job_key, run_id=run_id)
+    started_payload = _apply_run_started_payload(
+        conn,
+        tenant_id=tenant_id,
+        job_id=job_id,
+        run_id=run_id,
+    )
     completion_payload = _latest_dry_run_completion_payload(
         conn,
-        job_key=job_key,
+        tenant_id=tenant_id,
+        job_id=job_id,
         run_id=run_id,
     )
     materials_generation = _payload_int(ctx, "materials_generation", "materialsGeneration")
@@ -987,8 +1004,9 @@ def acquire_job(
 
 def _register_apply_log_artifact(
     conn,
-    url: str,
+    job_id: JobId,
     *,
+    tenant_id: TenantId,
     worker_id: int | None,
     run_id: str,
     occurred_at: str,
@@ -1001,24 +1019,132 @@ def _register_apply_log_artifact(
     log_path = config.LOG_DIR / f"worker-{int(worker_id)}.log"
     record_job_artifact(
         conn,
-        url,
+        job_id,
         "apply",
         "apply_log",
         log_path,
+        tenant_id=tenant_id,
         status="active",
         created_at=occurred_at,
         metadata={"run_id": str(run_id), "worker_id": int(worker_id)},
     )
 
 
+def _resolve_apply_job_id(
+    conn,
+    *,
+    tenant_id: TenantId,
+    job_id_or_url: JobId | str,
+) -> JobId:
+    """Resolve a legacy URL input once at the launcher boundary."""
+    value = str(job_id_or_url)
+    try:
+        return canonical_job_id(value)
+    except ValueError:
+        identity = SqliteJobIdentityResolver(conn).resolve_by_posting_url(
+            tenant_id,
+            PostingUrl(value=value),
+        )
+        if identity is None:
+            raise ValueError("Job not found.") from None
+        return identity.job_id
+
+
+def _posting_url_for_job_id(
+    conn,
+    *,
+    tenant_id: TenantId,
+    job_id: JobId,
+) -> str | None:
+    row = conn.execute(
+        """
+        SELECT locator_value
+        FROM job_locators
+        WHERE tenant_id = ? AND job_id = ?
+          AND locator_kind = 'posting_url' AND is_current = 1
+        ORDER BY last_seen_at DESC
+        LIMIT 1
+        """,
+        (str(tenant_id), str(job_id)),
+    ).fetchone()
+    if row is None:
+        row = conn.execute(
+            "SELECT url FROM jobs WHERE tenant_id = ? AND job_id = ? LIMIT 1",
+            (str(tenant_id), str(job_id)),
+        ).fetchone()
+    if row is None:
+        return None
+    return str(row[0] or "") or None
+
+
+def _has_apply_event_for_job_id(
+    conn,
+    *,
+    tenant_id: TenantId,
+    job_id: JobId,
+    run_id: str,
+    event_types: set[str],
+) -> bool:
+    placeholders = ",".join("?" for _ in event_types)
+    rows = conn.execute(
+        f"""
+        SELECT payload_json FROM job_events
+        WHERE tenant_id = ? AND job_id = ?
+          AND stage = 'apply' AND event_type IN ({placeholders})
+        """,
+        (str(tenant_id), str(job_id), *event_types),
+    ).fetchall()
+    for row in rows:
+        payload_json = row["payload_json"] if hasattr(row, "keys") else row[0]
+        try:
+            payload = json.loads(payload_json or "{}")
+        except (TypeError, ValueError):
+            continue
+        if isinstance(payload, dict) and str(payload.get("run_id") or "") == run_id:
+            return True
+    return False
+
+
+def _record_apply_terminal_event_once(
+    conn,
+    *,
+    tenant_id: TenantId,
+    job_id: JobId,
+    run_id: str,
+    event_type: str,
+    level: str = "info",
+    message: str,
+    payload: dict[str, Any],
+) -> None:
+    if _has_apply_event_for_job_id(
+        conn,
+        tenant_id=tenant_id,
+        job_id=job_id,
+        run_id=run_id,
+        event_types={event_type},
+    ):
+        return
+    record_job_event(
+        conn,
+        job_id,
+        "apply",
+        event_type,
+        tenant_id=tenant_id,
+        level=level,
+        message=message,
+        payload=payload,
+    )
+
+
 def mark_result(
-    url: str,
+    url: JobId | str,
     status: str,
     error: str | None = None,
     permanent: bool = False,
     duration_ms: int | None = None,
     task_id: str | None = None,
     run_ctx: dict | None = None,
+    tenant_id: TenantId | None = None,
 ) -> None:
     """Update a job's apply outcome.
 
@@ -1034,7 +1160,24 @@ def mark_result(
     """
     conn = get_connection()
     now = _utc_now()
-    ensure_job_stage_rows(conn, url)
+    stable_tenant_id = TenantId(
+        str(tenant_id or (run_ctx.get("tenant_id") if run_ctx else None) or LOCAL_TENANT)
+    )
+    stable_job_id = _resolve_apply_job_id(
+        conn,
+        tenant_id=stable_tenant_id,
+        job_id_or_url=url,
+    )
+    posting_url = _posting_url_for_job_id(
+        conn,
+        tenant_id=stable_tenant_id,
+        job_id=stable_job_id,
+    )
+    ensure_job_stage_rows(
+        conn,
+        stable_job_id,
+        tenant_id=stable_tenant_id,
+    )
 
     run_id = (
         task_id
@@ -1046,7 +1189,13 @@ def mark_result(
     dry_run = bool(run_ctx.get("dry_run")) if run_ctx else False
     submit_intent_recorded = (
         status not in {"applied", "dry_run"}
-        and _has_apply_submit_intent(conn, url, str(run_id))
+        and _has_apply_event_for_job_id(
+            conn,
+            tenant_id=stable_tenant_id,
+            job_id=stable_job_id,
+            run_id=str(run_id),
+            event_types={"ApplySubmitIntended"},
+        )
     )
 
     if status == "applied":
@@ -1055,15 +1204,17 @@ def mark_result(
         # still want to record this completion. Skip canonical validation;
         # the launcher is the writer.
         set_stage_state(
-            conn, url, "apply", "succeeded",
+            conn, stable_job_id, "apply", "succeeded",
+            tenant_id=stable_tenant_id,
             finished_at=now, duration_ms=duration_ms,
             validate_transition=False,
         )
-        record_job_event(
+        _record_apply_terminal_event_once(
             conn,
-            url,
-            "apply",
-            "ApplicationSubmitted",
+            tenant_id=stable_tenant_id,
+            job_id=stable_job_id,
+            run_id=str(run_id),
+            event_type="ApplicationSubmitted",
             message="Application submitted",
             payload={
                 "run_id": str(run_id),
@@ -1077,7 +1228,8 @@ def mark_result(
     elif status == "dry_run":
         binding = _dry_run_completion_binding(
             conn,
-            job_key=url,
+            tenant_id=stable_tenant_id,
+            job_id=stable_job_id,
             run_id=str(run_id),
             run_ctx=run_ctx,
         )
@@ -1085,22 +1237,24 @@ def mark_result(
         # convention (dry-run completed), not in the canonical §8.5 table.
         set_stage_state(
             conn,
-            url,
+            stable_job_id,
             "apply",
             "skipped",
+            tenant_id=stable_tenant_id,
             finished_at=now,
             duration_ms=duration_ms,
             error_code="DRY_RUN",
             error_message="Dry run completed without submitting.",
             retryable=True,
-            next_action=f"jobctrl apply --url {url}",
+            next_action=f"jobctrl apply --url {posting_url}" if posting_url else None,
             validate_transition=False,
         )
-        record_job_event(
+        _record_apply_terminal_event_once(
             conn,
-            url,
-            "apply",
-            "DryRunCompleted",
+            tenant_id=stable_tenant_id,
+            job_id=stable_job_id,
+            run_id=str(run_id),
+            event_type="DryRunCompleted",
             message="Dry run completed without submitting",
             payload={
                 "run_id": str(run_id),
@@ -1122,9 +1276,10 @@ def mark_result(
         reason = (error or "unknown").strip()
         set_stage_state(
             conn,
-            url,
+            stable_job_id,
             "apply",
             "needs_verification",
+            tenant_id=stable_tenant_id,
             finished_at=now,
             duration_ms=duration_ms,
             error_code="APPLY_NEEDS_VERIFICATION",
@@ -1138,11 +1293,12 @@ def mark_result(
             ),
             validate_transition=False,
         )
-        record_job_event(
+        _record_apply_terminal_event_once(
             conn,
-            url,
-            "apply",
-            "ApplicationFailed",
+            tenant_id=stable_tenant_id,
+            job_id=stable_job_id,
+            run_id=str(run_id),
+            event_type="ApplicationFailed",
             level="warn",
             message="Application outcome requires manual verification",
             payload={
@@ -1163,22 +1319,28 @@ def mark_result(
         # the writer is the launcher, transitions are runner-owned.
         set_stage_state(
             conn,
-            url,
+            stable_job_id,
             "apply",
             "failed",
+            tenant_id=stable_tenant_id,
             finished_at=now,
             duration_ms=duration_ms,
             error_code=str(status).upper(),
             error_message=reason,
             retryable=not permanent,
-            next_action=f"jobctrl apply --url {url}" if not permanent else None,
+            next_action=(
+                f"jobctrl apply --url {posting_url}"
+                if not permanent and posting_url
+                else None
+            ),
             validate_transition=False,
         )
-        record_job_event(
+        _record_apply_terminal_event_once(
             conn,
-            url,
-            "apply",
-            "ApplicationFailed",
+            tenant_id=stable_tenant_id,
+            job_id=stable_job_id,
+            run_id=str(run_id),
+            event_type="ApplicationFailed",
             level="error",
             message=reason,
             payload={
@@ -1193,7 +1355,12 @@ def mark_result(
         )
 
     _register_apply_log_artifact(
-        conn, url, worker_id=worker_id, run_id=str(run_id), occurred_at=now
+        conn,
+        stable_job_id,
+        tenant_id=stable_tenant_id,
+        worker_id=worker_id,
+        run_id=str(run_id),
+        occurred_at=now,
     )
     conn.commit()
 
@@ -1226,24 +1393,68 @@ def _latest_apply_run_started_run_id(conn, url: str) -> str | None:
     return str(run_id) if run_id else None
 
 
-def release_lock(url: str, run_ctx: dict | None = None) -> None:
+def release_lock(
+    url: JobId | str,
+    run_ctx: dict | None = None,
+    *,
+    tenant_id: TenantId | None = None,
+) -> None:
     """Record that launcher cleanup ran without making retry decisions."""
     conn = get_connection()
+    stable_tenant_id = TenantId(
+        str(tenant_id or (run_ctx.get("tenant_id") if run_ctx else None) or LOCAL_TENANT)
+    )
+    stable_job_id = _resolve_apply_job_id(
+        conn,
+        tenant_id=stable_tenant_id,
+        job_id_or_url=url,
+    )
     ctx_run_id = run_ctx.get("run_id") if run_ctx else None
     run_id = (
         ctx_run_id
-        or _latest_apply_run_started_run_id(conn, url)
+        or _latest_apply_run_started_run_id_for_job_id(
+            conn,
+            tenant_id=stable_tenant_id,
+            job_id=stable_job_id,
+        )
         or new_apply_run_id()
     )
     record_job_event(
         conn,
-        url,
+        stable_job_id,
         "apply",
         "LockReleased",
+        tenant_id=stable_tenant_id,
         message="Apply lock released",
         payload={"run_id": str(run_id)},
     )
     conn.commit()
+
+
+def _latest_apply_run_started_run_id_for_job_id(
+    conn,
+    *,
+    tenant_id: TenantId,
+    job_id: JobId,
+) -> str | None:
+    row = conn.execute(
+        "SELECT payload_json FROM job_events "
+        "WHERE tenant_id = ? AND job_id = ? "
+        "AND stage = 'apply' AND event_type = 'ApplyRunStarted' "
+        "ORDER BY event_id DESC LIMIT 1",
+        (str(tenant_id), str(job_id)),
+    ).fetchone()
+    if row is None:
+        return None
+    payload_json = row["payload_json"] if not isinstance(row, tuple) else row[0]
+    try:
+        payload = json.loads(payload_json)
+    except (TypeError, ValueError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    run_id = payload.get("run_id")
+    return str(run_id) if run_id else None
 
 
 def recover_ambiguous_running_apply(console: Console | None = None) -> int:
@@ -1376,17 +1587,34 @@ def _has_apply_event(conn, url: str, run_id: str, event_types: set[str]) -> bool
 # ---------------------------------------------------------------------------
 
 
-def mark_job(url: str, status: str, reason: str | None = None) -> None:
+def mark_job(
+    url: JobId | str,
+    status: str,
+    reason: str | None = None,
+    *,
+    tenant_id: TenantId | None = None,
+) -> None:
     """Manually mark a job's apply status."""
+    stable_tenant_id = tenant_id or LOCAL_TENANT
     if status == "applied":
         conn = get_connection()
         now = _utc_now()
-        ensure_job_stage_rows(conn, url)
+        stable_job_id = _resolve_apply_job_id(
+            conn,
+            tenant_id=stable_tenant_id,
+            job_id_or_url=url,
+        )
+        ensure_job_stage_rows(
+            conn,
+            stable_job_id,
+            tenant_id=stable_tenant_id,
+        )
         set_stage_state(
             conn,
-            url,
+            stable_job_id,
             "apply",
             "succeeded",
+            tenant_id=stable_tenant_id,
             finished_at=now,
             duration_ms=0,
             retryable=False,
@@ -1394,9 +1622,10 @@ def mark_job(url: str, status: str, reason: str | None = None) -> None:
         )
         record_job_event(
             conn,
-            url,
+            stable_job_id,
             "apply",
             "ApplicationManuallyMarked",
+            tenant_id=stable_tenant_id,
             message="Job manually marked as applied",
             payload={
                 "reason": reason or "",
@@ -1412,6 +1641,7 @@ def mark_job(url: str, status: str, reason: str | None = None) -> None:
             error=reason or "manual",
             permanent=True,
             duration_ms=0,
+            tenant_id=stable_tenant_id,
         )
 
 
@@ -1481,18 +1711,26 @@ def _load_profile_snapshot() -> ProfileSnapshot:
 # ---------------------------------------------------------------------------
 
 
-def _load_job_for_prompt(target_url: str, min_score: int) -> dict[str, Any] | None:
+def _load_job_for_prompt(
+    target_url: JobId | str,
+    min_score: int,
+    *,
+    tenant_id: TenantId,
+) -> dict[str, Any] | None:
     """Read one eligible job without creating an apply attempt or consuming authority."""
 
     conn = get_connection()
+    stable_job_id = _resolve_apply_job_id(
+        conn,
+        tenant_id=tenant_id,
+        job_id_or_url=target_url,
+    )
     common_columns, common_joins = _apply_candidate_select_parts()
-    like = f"%{target_url.split('?')[0].rstrip('/')}%"
     row = conn.execute(
         f"""
         SELECT {common_columns}
         FROM jobs {common_joins}
-        WHERE (jobs.url = ? OR {_EFFECTIVE_APPLICATION_URL} = ?
-               OR {_EFFECTIVE_APPLICATION_URL} LIKE ? OR jobs.url LIKE ?)
+        WHERE jobs.tenant_id = ? AND jobs.job_id = ?
           AND {_READY_TAILORED_RESUME_WITH_PDF}
           AND {_EFFECTIVE_FIT_SCORE} >= ?
           AND {_SCORE_ELIGIBLE_FOR_DOWNSTREAM}
@@ -1500,21 +1738,27 @@ def _load_job_for_prompt(target_url: str, min_score: int) -> dict[str, Any] | No
           AND {_NOT_CLOSED_ACTIVE_STATE}
         LIMIT 1
         """,
-        (target_url, target_url, like, like, min_score),
+        (str(tenant_id), str(stable_job_id), min_score),
     ).fetchone()
     return _row_to_job_dict(row) if row is not None else None
 
 
 def gen_prompt(
-    target_url: str,
+    target_url: JobId | str,
     min_score: int = 7,
     model: str = "default",
     worker_id: int = 0,
     snapshot: ProfileSnapshot | None = None,
+    *,
+    tenant_id: TenantId | None = None,
 ) -> Path | None:
     """Render an inspection-only dry-run prompt without claiming the job."""
 
-    job = _load_job_for_prompt(target_url, min_score)
+    job = _load_job_for_prompt(
+        target_url,
+        min_score,
+        tenant_id=tenant_id or LOCAL_TENANT,
+    )
     if not job:
         return None
 
@@ -2002,6 +2246,8 @@ def worker_loop(
             continue
 
         empty_polls = 0
+        job_id = canonical_job_id(str(job["job_id"]))
+        job_tenant_id = TenantId(str(job["tenant_id"]))
         try:
             result, duration_ms = run_job(
                 job,
@@ -2014,7 +2260,11 @@ def worker_loop(
             )
 
             if result == "skipped":
-                release_lock(job["url"], run_ctx=run_ctx)
+                release_lock(
+                    job_id,
+                    run_ctx=run_ctx,
+                    tenant_id=job_tenant_id,
+                )
                 add_event(
                     f"[W{worker_id} {run_ctx['run_id'][:8]}] Skipped: "
                     f"{(job.get('title') or '')[:30]}"
@@ -2022,11 +2272,12 @@ def worker_loop(
                 continue
             if result == "applied":
                 mark_result(
-                    job["url"],
+                    job_id,
                     "applied",
                     duration_ms=duration_ms,
                     task_id=run_ctx.get("run_id"),
                     run_ctx=run_ctx,
+                    tenant_id=job_tenant_id,
                 )
                 applied += 1
                 update_state(
@@ -2036,30 +2287,36 @@ def worker_loop(
                 )
             elif result == "dry_run":
                 mark_result(
-                    job["url"],
+                    job_id,
                     "dry_run",
                     duration_ms=duration_ms,
                     task_id=run_ctx.get("run_id"),
                     run_ctx=run_ctx,
+                    tenant_id=job_tenant_id,
                 )
                 update_state(worker_id, jobs_done=applied + failed)
             else:
                 reason = result.split(":", 1)[-1] if ":" in result else result
                 mark_result(
-                    job["url"],
+                    job_id,
                     "failed",
                     reason,
                     permanent=_is_permanent_failure(result),
                     duration_ms=duration_ms,
                     task_id=run_ctx.get("run_id"),
                     run_ctx=run_ctx,
+                    tenant_id=job_tenant_id,
                 )
                 failed += 1
                 update_state(
                     worker_id, jobs_failed=failed, jobs_done=applied + failed
                 )
         except KeyboardInterrupt:
-            release_lock(job["url"], run_ctx=run_ctx)
+            release_lock(
+                job_id,
+                run_ctx=run_ctx,
+                tenant_id=job_tenant_id,
+            )
             add_event(
                 f"[W{worker_id} {run_ctx['run_id'][:8]}] Job skipped (Ctrl+C)"
             )
@@ -2071,7 +2328,11 @@ def worker_loop(
             add_event(
                 f"[W{worker_id} {run_ctx['run_id'][:8]}] Launcher error: {str(exc)[:40]}"
             )
-            release_lock(job["url"], run_ctx=run_ctx)
+            release_lock(
+                job_id,
+                run_ctx=run_ctx,
+                tenant_id=job_tenant_id,
+            )
             failed += 1
             update_state(worker_id, jobs_failed=failed)
 

--- a/workers/automation/src/jobctrl/apply/workflow.py
+++ b/workers/automation/src/jobctrl/apply/workflow.py
@@ -16,6 +16,8 @@ from temporalio import workflow
 from temporalio.common import RetryPolicy
 from temporalio.exceptions import ActivityError, ApplicationError
 
+from jobctrl.domain.identifiers import JobId, canonical_job_id
+
 with workflow.unsafe.imports_passed_through():
     from jobctrl.apply.activities import (
         ApplyActivityInput,
@@ -34,7 +36,7 @@ class ApplyWorkflowInput:
     tenant_id: str
     expected_app_dir: str | None = None
     expected_db_path: str | None = None
-    job_url: str | None = None
+    job_id: JobId | None = None
     dry_run: bool = False
     headless: bool = False
     model: str = "default"
@@ -48,6 +50,10 @@ class ApplyWorkflowInput:
     # Settings-controlled standing loop. The workflow id is deterministic and
     # the activity re-reads apply settings at batch time.
     auto_apply_loop: bool = False
+
+    def __post_init__(self) -> None:
+        if self.job_id is not None:
+            object.__setattr__(self, "job_id", canonical_job_id(str(self.job_id)))
 
 
 @dataclass(frozen=True)
@@ -140,7 +146,7 @@ class ApplyWorkflow:
                     tenant_id=payload.tenant_id,
                     expected_app_dir=payload.expected_app_dir,
                     expected_db_path=payload.expected_db_path,
-                    job_url=payload.job_url,
+                    job_id=payload.job_id,
                     limit=activity_limit,
                     min_score=payload.min_score,
                     model=payload.model,
@@ -151,11 +157,7 @@ class ApplyWorkflow:
                     continuous=False,
                     auto_apply_loop=payload.auto_apply_loop,
                 ),
-                start_to_close_timeout=(
-                    _APPLY_CONTINUOUS_BATCH_TIMEOUT
-                    if payload.continuous
-                    else _APPLY_TIMEOUT
-                ),
+                start_to_close_timeout=(_APPLY_CONTINUOUS_BATCH_TIMEOUT if payload.continuous else _APPLY_TIMEOUT),
                 retry_policy=_APPLY_DRY_RUN_RETRY if payload.dry_run else _APPLY_LIVE_RETRY,
                 heartbeat_timeout=timedelta(seconds=60),
             )
@@ -180,7 +182,7 @@ class ApplyWorkflow:
 def _apply_input_summary(payload: ApplyWorkflowInput) -> dict[str, Any]:
     """Compact, camelCase input summary for the workflow-run read-model."""
     return {
-        "jobUrl": payload.job_url,
+        "jobId": str(payload.job_id) if payload.job_id is not None else None,
         "dryRun": payload.dry_run,
         "continuous": payload.continuous,
         "autoApplyLoop": payload.auto_apply_loop,

--- a/workers/automation/src/jobctrl/cli.py
+++ b/workers/automation/src/jobctrl/cli.py
@@ -139,10 +139,7 @@ def _validate_validation_mode(validation: str) -> str:
     """Validate the tailor/cover validation mode option."""
     valid_modes = ("strict", "normal", "lenient")
     if validation not in valid_modes:
-        console.print(
-            f"[red]Invalid --validation value:[/red] '{validation}'. "
-            f"Choose from: {', '.join(valid_modes)}"
-        )
+        console.print(f"[red]Invalid --validation value:[/red] '{validation}'. Choose from: {', '.join(valid_modes)}")
         raise typer.Exit(code=1)
     return validation
 
@@ -699,10 +696,13 @@ def _run_stage_command(
 # Commands
 # ---------------------------------------------------------------------------
 
+
 @app.callback()
 def main(
     version: bool = typer.Option(
-        False, "--version", "-V",
+        False,
+        "--version",
+        "-V",
         help="Show version and exit.",
         callback=_version_callback,
         is_eager=True,
@@ -818,7 +818,9 @@ def capability_enable(
             default=False,
         )
         if not consent_copy_profile:
-            console.print("[yellow]Browser capability was not enabled because profile-copy consent was not granted.[/yellow]")
+            console.print(
+                "[yellow]Browser capability was not enabled because profile-copy consent was not granted.[/yellow]"
+            )
             raise typer.Exit(code=2)
 
     try:
@@ -857,7 +859,9 @@ def capability_disable(name: str = typer.Argument(..., help="Optional capability
 
 @app.command()
 def action(
-    stage: str = typer.Argument(..., help=f"Action stage. Valid: {', '.join((*VALID_STAGES, 'apply', 'profile_import'))}."),
+    stage: str = typer.Argument(
+        ..., help=f"Action stage. Valid: {', '.join((*VALID_STAGES, 'apply', 'profile_import'))}."
+    ),
     url: Optional[str] = typer.Option(None, "--url", help="Target job URL for targeted actions."),
     limit: int = typer.Option(0, "--limit", help="Maximum records to process. 0 means stage default."),
     workers: int = typer.Option(1, "--workers", "-w", help="Worker count for supported actions."),
@@ -865,9 +869,15 @@ def action(
     validation: str = typer.Option("normal", "--validation", help="Validation mode for material generation."),
     dry_run: bool = typer.Option(False, "--dry-run", help="Return the planned action without executing."),
     pdf_path: Optional[str] = typer.Option(None, "--pdf", help="Resume PDF path for profile_import."),
-    model: str = typer.Option("default", "--model", "-m", help="Apply action model. 'default' uses the local Claude Code default."),
-    tailor_models: str = typer.Option("", "--tailor-models", help="Comma-separated LLM specs for tailor candidate generation."),
-    tailor_judge_model: str = typer.Option("", "--tailor-judge-model", help="Optional LLM spec for the structured tailoring judge."),
+    model: str = typer.Option(
+        "default", "--model", "-m", help="Apply action model. 'default' uses the local Claude Code default."
+    ),
+    tailor_models: str = typer.Option(
+        "", "--tailor-models", help="Comma-separated LLM specs for tailor candidate generation."
+    ),
+    tailor_judge_model: str = typer.Option(
+        "", "--tailor-judge-model", help="Optional LLM spec for the structured tailoring judge."
+    ),
     tailor_judge_min_score: float | None = typer.Option(
         None,
         "--tailor-judge-min-score",
@@ -971,14 +981,8 @@ def setup(
         console.print("[bold]JobCtrl Setup[/bold]")
 
     if not skip_system:
-        rows = (
-            [("Bundled payload", True, str(payload_dir()))]
-            if bundled
-            else _setup_toolchain_rows()
-        )
-        summary["toolchain"] = [
-            {"name": name, "ok": ok, "note": note} for name, ok, note in rows
-        ]
+        rows = [("Bundled payload", True, str(payload_dir()))] if bundled else _setup_toolchain_rows()
+        summary["toolchain"] = [{"name": name, "ok": ok, "note": note} for name, ok, note in rows]
         if not json_output:
             console.print("\n[bold]Toolchain[/bold]")
             for name, ok, note in rows:
@@ -987,15 +991,19 @@ def setup(
 
     commands: list[list[str]] = []
     if not bundled and not skip_dependencies:
-        commands.extend([
-            ["corepack", "pnpm", "install", "--frozen-lockfile"],
-            ["uv", "--project", "workers/automation", "sync", "--extra", "dev"],
-        ])
+        commands.extend(
+            [
+                ["corepack", "pnpm", "install", "--frozen-lockfile"],
+                ["uv", "--project", "workers/automation", "sync", "--extra", "dev"],
+            ]
+        )
     if not bundled and not skip_browsers:
-        commands.extend([
-            ["corepack", "pnpm", "--filter", "@jobctrl/web", "exec", "playwright", "install", "chromium"],
-            ["uv", "--project", "workers/automation", "run", "playwright", "install", "chromium"],
-        ])
+        commands.extend(
+            [
+                ["corepack", "pnpm", "--filter", "@jobctrl/web", "exec", "playwright", "install", "chromium"],
+                ["uv", "--project", "workers/automation", "run", "playwright", "install", "chromium"],
+            ]
+        )
 
     if commands:
         if not json_output:
@@ -1024,11 +1032,13 @@ def setup(
     if not json_output:
         console.print("\n[bold]Analysis Vendor Auth[/bold]")
     for probe in probe_analysis_setup():
-        summary["analysis"].append({
-            "name": probe.name,
-            "ok": probe.ok,
-            "note": probe.note,
-        })
+        summary["analysis"].append(
+            {
+                "name": probe.name,
+                "ok": probe.ok,
+                "note": probe.note,
+            }
+        )
         if not json_output:
             status = "[green]OK[/green]" if probe.ok else "[yellow]WARN[/yellow]"
             console.print(f"  {probe.name:<28} {status}  [dim]{probe.note}[/dim]")
@@ -1047,7 +1057,9 @@ def setup(
             if key.strip():
                 env_updates["ANTHROPIC_API_KEY"] = key.strip()
                 authenticated_legs.append("claude")
-        elif _confirm_setup_action("Skip the Claude analysis leg for now?", yes=yes, non_interactive=non_interactive, default=True):
+        elif _confirm_setup_action(
+            "Skip the Claude analysis leg for now?", yes=yes, non_interactive=non_interactive, default=True
+        ):
             pass
         else:
             authenticated_legs.append("claude")
@@ -1060,11 +1072,15 @@ def setup(
             key = os.environ.get("OPENAI_API_KEY") or os.environ.get("CODEX_API_KEY")
             command: list[str] | None = None
             stdin: str | None = None
-            if key and launch_logins and _confirm_setup_action(
-                "Enroll the current OpenAI key into JobCtrl's Codex CLI home now?",
-                yes=yes,
-                non_interactive=non_interactive,
-                default=False,
+            if (
+                key
+                and launch_logins
+                and _confirm_setup_action(
+                    "Enroll the current OpenAI key into JobCtrl's Codex CLI home now?",
+                    yes=yes,
+                    non_interactive=non_interactive,
+                    default=False,
+                )
             ):
                 command = [str(resolve_codex_binary()), "login", "--with-api-key"]
                 stdin = key + "\n"
@@ -1130,7 +1146,9 @@ def setup(
             if key.strip():
                 env_updates["GEMINI_API_KEY"] = key.strip()
                 authenticated_legs.append("antigravity")
-        elif _confirm_setup_action("Skip the Antigravity analysis leg for now?", yes=yes, non_interactive=non_interactive, default=True):
+        elif _confirm_setup_action(
+            "Skip the Antigravity analysis leg for now?", yes=yes, non_interactive=non_interactive, default=True
+        ):
             pass
         else:
             authenticated_legs.append("antigravity")
@@ -1146,16 +1164,15 @@ def setup(
             authenticated_legs.remove("antigravity")
 
     if authenticated_legs:
-        persisted_legs = [
-            "google" if leg == "antigravity" else leg
-            for leg in authenticated_legs
-        ]
+        persisted_legs = ["google" if leg == "antigravity" else leg for leg in authenticated_legs]
         if not dry_run:
             update_config_file({"analysis_legs": persisted_legs})
         summary["configUpdates"] = ["analysis_legs"]
     elif configured_legs:
         if not json_output:
-            console.print("[yellow]No analysis leg is authenticated; leaving existing leg configuration unchanged.[/yellow]")
+            console.print(
+                "[yellow]No analysis leg is authenticated; leaving existing leg configuration unchanged.[/yellow]"
+            )
     _write_env_updates(get_env_path(), env_updates, dry_run=dry_run, quiet=json_output)
     summary["envUpdates"] = sorted(env_updates)
 
@@ -1165,9 +1182,7 @@ def setup(
     if not core_probe.ok:
         summary["analysisNotReadyReason"] = core_probe.note
         if not json_output:
-            console.print(
-                f"[red]Core AI stages are NOT ready:[/red] {core_probe.note}"
-            )
+            console.print(f"[red]Core AI stages are NOT ready:[/red] {core_probe.note}")
     elif not json_output:
         console.print("[green]Core AI provider ready.[/green]")
 
@@ -1228,11 +1243,7 @@ def provider_pack_install(
 def run(
     stages: Optional[list[str]] = typer.Argument(
         None,
-        help=(
-            "Pipeline stages to run. "
-            f"Valid: {', '.join(VALID_STAGES)}, all. "
-            "Defaults to 'all' if omitted."
-        ),
+        help=(f"Pipeline stages to run. Valid: {', '.join(VALID_STAGES)}, all. Defaults to 'all' if omitted."),
     ),
     min_score: int = typer.Option(7, "--min-score", help="Minimum fit score for tailor/cover stages."),
     workers: int = typer.Option(
@@ -1288,10 +1299,7 @@ def run(
     # Validate stage names
     for s in stage_list:
         if s != "all" and s not in VALID_STAGES:
-            console.print(
-                f"[red]Unknown stage:[/red] '{s}'. "
-                f"Valid stages: {', '.join(VALID_STAGES)}, all"
-            )
+            console.print(f"[red]Unknown stage:[/red] '{s}'. Valid stages: {', '.join(VALID_STAGES)}, all")
             raise typer.Exit(code=1)
 
     # Discovery now drains scoring/tailoring preparation work, so explicit
@@ -1333,7 +1341,9 @@ def run(
 
 @app.command()
 def discover(
-    workers: int = typer.Option(1, "--workers", "-w", help="Parallel threads for discovery backends and detail enrichment."),
+    workers: int = typer.Option(
+        1, "--workers", "-w", help="Parallel threads for discovery backends and detail enrichment."
+    ),
     limit: int = typer.Option(0, "--limit", help="Maximum jobs to discover. 0 means all eligible jobs."),
     dry_run: bool = typer.Option(False, "--dry-run", help="Preview the stage without executing."),
 ) -> None:
@@ -1485,17 +1495,23 @@ def compensation_refresh(
 
 @app.command()
 def apply(
-    limit: Optional[int] = typer.Option(None, "--limit", "-l", help="Max applications to submit (default: all ready jobs)."),
+    limit: Optional[int] = typer.Option(
+        None, "--limit", "-l", help="Max applications to submit (default: all ready jobs)."
+    ),
     workers: int = typer.Option(1, "--workers", "-w", help="Number of parallel browser workers."),
     min_score: int = typer.Option(7, "--min-score", help="Minimum fit score for job selection."),
-    model: str = typer.Option("default", "--model", "-m", help="Claude model name. 'default' uses the local Claude Code default."),
+    model: str = typer.Option(
+        "default", "--model", "-m", help="Claude model name. 'default' uses the local Claude Code default."
+    ),
     continuous: bool = typer.Option(False, "--continuous", "-c", help="Run forever, polling for new jobs."),
     dry_run: bool = typer.Option(False, "--dry-run", help="Preview actions without submitting."),
     headless: bool = typer.Option(False, "--headless", help="Run browsers in headless mode."),
     url: Optional[str] = typer.Option(None, "--url", help="Apply to a specific job URL."),
     gen: bool = typer.Option(False, "--gen", help="Generate an inspection-only dry-run prompt instead of running."),
     mark_applied: Optional[str] = typer.Option(None, "--mark-applied", help="Manually mark a job URL as applied."),
-    mark_failed: Optional[str] = typer.Option(None, "--mark-failed", help="Manually mark a job URL as failed (provide URL)."),
+    mark_failed: Optional[str] = typer.Option(
+        None, "--mark-failed", help="Manually mark a job URL as failed (provide URL)."
+    ),
     fail_reason: Optional[str] = typer.Option(None, "--fail-reason", help="Reason for --mark-failed."),
     reset_failed: bool = typer.Option(False, "--reset-failed", help="Reset all failed jobs for retry."),
 ) -> None:
@@ -1504,25 +1520,48 @@ def apply(
 
     from jobctrl.config import check_tier
     from jobctrl.database import count_ready_to_apply, get_connection
+    from jobctrl.domain.discovery.value_objects import PostingUrl
+    from jobctrl.domain.identifiers import JobId
     from jobctrl.domain.tenant import LOCAL_TENANT
+    from jobctrl.infrastructure.discovery import SqliteJobIdentityResolver
     from jobctrl.infrastructure.profile import get_profile_repository
 
     # --- Utility modes (no Chrome/Claude needed) ---
 
+    def resolve_job_id(posting_url: str) -> JobId:
+        identity = SqliteJobIdentityResolver(get_connection()).resolve_current_by_posting_url(
+            LOCAL_TENANT,
+            PostingUrl(value=posting_url),
+        )
+        if identity is None:
+            raise typer.BadParameter(
+                f"No current job found for URL: {posting_url}",
+                param_hint="--url",
+            )
+        return identity.job_id
+
     if mark_applied:
         from jobctrl.apply.launcher import mark_job
-        mark_job(mark_applied, "applied")
+
+        mark_job(resolve_job_id(mark_applied), "applied", tenant_id=LOCAL_TENANT)
         console.print(f"[green]Marked as applied:[/green] {mark_applied}")
         return
 
     if mark_failed:
         from jobctrl.apply.launcher import mark_job
-        mark_job(mark_failed, "failed", reason=fail_reason)
+
+        mark_job(
+            resolve_job_id(mark_failed),
+            "failed",
+            reason=fail_reason,
+            tenant_id=LOCAL_TENANT,
+        )
         console.print(f"[yellow]Marked as failed:[/yellow] {mark_failed} ({fail_reason or 'manual'})")
         return
 
     if reset_failed:
         from jobctrl.apply.launcher import reset_failed as do_reset
+
         count = do_reset()
         console.print(f"[green]Reset {count} failed job(s) for retry.[/green]")
         return
@@ -1538,10 +1577,7 @@ def apply(
     except FileNotFoundError:
         profile = None
     if profile is None:
-        console.print(
-            "[red]Profile not found.[/red]\n"
-            "Run [bold]jobctrl init[/bold] to create your profile first."
-        )
+        console.print("[red]Profile not found.[/red]\nRun [bold]jobctrl init[/bold] to create your profile first.")
         raise typer.Exit(code=1)
 
     # Check 3: Tailored resumes exist (skip for --gen with --url)
@@ -1562,11 +1598,17 @@ def apply(
 
     if gen:
         from jobctrl.apply.launcher import gen_prompt
+
         target = url or ""
         if not target:
             console.print("[red]--gen requires --url to specify which job.[/red]")
             raise typer.Exit(code=1)
-        prompt_file = gen_prompt(target, min_score=min_score, model=model)
+        prompt_file = gen_prompt(
+            resolve_job_id(target),
+            min_score=min_score,
+            model=model,
+            tenant_id=LOCAL_TENANT,
+        )
         if not prompt_file:
             console.print("[red]No matching job found for that URL.[/red]")
             raise typer.Exit(code=1)
@@ -1585,9 +1627,12 @@ def apply(
     else:
         # Default: apply to all currently ready jobs
         effective_limit = ready
+    target_job_id = resolve_job_id(url) if url else None
 
     console.print("\n[bold blue]Launching Auto-Apply[/bold blue]")
-    console.print(f"  Limit:    {'unlimited' if continuous else f'{effective_limit} (all ready)'  if limit is None else effective_limit}")
+    console.print(
+        f"  Limit:    {'unlimited' if continuous else f'{effective_limit} (all ready)' if limit is None else effective_limit}"
+    )
     console.print(f"  Workers:  {workers}")
     console.print(f"  Model:    {model}")
     console.print(f"  Headless: {headless}")
@@ -1600,7 +1645,7 @@ def apply(
         build_apply_workflow_spec(
             {
                 "tenantId": "local",
-                "jobUrl": url,
+                **({"jobId": str(target_job_id)} if target_job_id else {}),
                 "limit": effective_limit,
                 "minScore": min_score,
                 "headless": headless,
@@ -1616,15 +1661,24 @@ def apply(
 
 @app.command()
 def job(
-    url: str = typer.Argument(..., help="URL of the job to process. Automatically enriched if not already in the database."),
+    url: str = typer.Argument(
+        ..., help="URL of the job to process. Automatically enriched if not already in the database."
+    ),
     tailor_flag: bool = typer.Option(False, "--tailor", "-t", help="Only tailor resume + cover letter (skip apply)."),
-    apply_flag: bool = typer.Option(False, "--apply", "-a", help="Only apply (skip tailoring). Job must already be tailored."),
+    apply_flag: bool = typer.Option(
+        False, "--apply", "-a", help="Only apply (skip tailoring). Job must already be tailored."
+    ),
     validation: str = typer.Option(
         "normal",
         "--validation",
         help="Validation strictness for tailor/cover. strict | normal | lenient.",
     ),
-    model: str = typer.Option("default", "--model", "-m", help="Claude model name for auto-apply. 'default' uses the local Claude Code default."),
+    model: str = typer.Option(
+        "default",
+        "--model",
+        "-m",
+        help="Claude model name for auto-apply. 'default' uses the local Claude Code default.",
+    ),
     headless: bool = typer.Option(False, "--headless", help="Run browser in headless mode."),
     dry_run: bool = typer.Option(False, "--dry-run", help="Preview without executing."),
 ) -> None:
@@ -1653,9 +1707,11 @@ def job(
     # Gate on required tiers
     if do_tailor:
         from jobctrl.config import check_tier
+
         check_tier(2, "resume tailoring")
     if do_apply:
         from jobctrl.config import check_tier
+
         check_tier(3, "auto-apply")
 
     actions = []
@@ -1665,10 +1721,12 @@ def job(
         actions.append("apply")
 
     console.print()
-    console.print(Panel.fit(
-        f"[bold]Single Job[/bold] — {' + '.join(actions)}",
-        border_style="blue",
-    ))
+    console.print(
+        Panel.fit(
+            f"[bold]Single Job[/bold] — {' + '.join(actions)}",
+            border_style="blue",
+        )
+    )
     console.print(f"  URL:        {url}")
     console.print(f"  Validation: {validation}")
     if do_apply:
@@ -1735,9 +1793,7 @@ def digest(
 
     if json_output:
         payload = (
-            {"digest": digest_payload, "acknowledge": acknowledge_payload}
-            if acknowledge_payload
-            else digest_payload
+            {"digest": digest_payload, "acknowledge": acknowledge_payload} if acknowledge_payload else digest_payload
         )
         console.print_json(data=payload)
         return
@@ -1837,9 +1893,7 @@ def _blocked_source_note(blocked_sources: dict[str, Any]) -> str:
     if not isinstance(sources, list) or not sources:
         return "No blocked or failing sources"
     names = [
-        str(_dict(source).get("sourceId") or "")
-        for source in sources[:3]
-        if str(_dict(source).get("sourceId") or "")
+        str(_dict(source).get("sourceId") or "") for source in sources[:3] if str(_dict(source).get("sourceId") or "")
     ]
     extra = len(sources) - len(names)
     if extra > 0:
@@ -1966,13 +2020,13 @@ def retry(
 
     retry_stages = (*VALID_STAGES, "enrich", "apply")
     if stage not in retry_stages:
-        console.print(
-            f"[red]Unknown stage:[/red] '{stage}'. "
-            f"Valid stages: {', '.join(retry_stages)}"
-        )
+        console.print(f"[red]Unknown stage:[/red] '{stage}'. Valid stages: {', '.join(retry_stages)}")
         raise typer.Exit(code=1)
 
     from jobctrl.database import get_connection
+    from jobctrl.domain.discovery.value_objects import PostingUrl
+    from jobctrl.domain.tenant import LOCAL_TENANT
+    from jobctrl.infrastructure.discovery import SqliteJobIdentityResolver
     from jobctrl.state import reset_job_stage
 
     try:
@@ -1984,11 +2038,18 @@ def retry(
     console.print(f"[green]Reset {stage} for retry:[/green] {job_url}")
     if run_after:
         if stage == "apply":
+            identity = SqliteJobIdentityResolver(get_connection()).resolve_current_by_posting_url(
+                LOCAL_TENANT,
+                PostingUrl(value=job_url),
+            )
+            if identity is None:
+                console.print(f"[red]No current job found for URL:[/red] {job_url}")
+                raise typer.Exit(code=1)
             _run_workflow_spec_from_cli(
                 build_apply_workflow_spec(
                     {
                         "tenantId": "local",
-                        "jobUrl": job_url,
+                        "jobId": str(identity.job_id),
                         "limit": 1,
                     }
                 ),
@@ -2063,11 +2124,7 @@ def runs(
         selected = next((run for run in runs if run.get("run_id", "").startswith(run_id)), None)
     else:
         selected = next(
-            (
-                run
-                for run in runs
-                if (run.get("status") or "").upper() in {"FAILED", "ERROR", "IN_PROGRESS", "RUNNING"}
-            ),
+            (run for run in runs if (run.get("status") or "").upper() in {"FAILED", "ERROR", "IN_PROGRESS", "RUNNING"}),
             recent[0],
         )
 
@@ -2220,6 +2277,7 @@ def worker(
         current_runtime_identity,
         write_worker_heartbeat,
     )
+
     queue = task_queue or JOBCTRL_TASK_QUEUE
 
     async def _run() -> None:
@@ -2283,8 +2341,7 @@ def worker(
         )
         if startup_auto_apply.changed:
             console.print(
-                f"[yellow]Auto-apply loop {startup_auto_apply.action}: "
-                f"{startup_auto_apply.workflow_id}.[/yellow]"
+                f"[yellow]Auto-apply loop {startup_auto_apply.action}: {startup_auto_apply.workflow_id}.[/yellow]"
             )
         try:
             await worker.run()
@@ -2317,18 +2374,14 @@ async def _worker_heartbeat_loop(
         await asyncio.sleep(interval_seconds)
         try:
             queue_observation = (
-                await _safe_task_queue_observation(temporal_client, task_queue)
-                if temporal_client is not None
-                else None
+                await _safe_task_queue_observation(temporal_client, task_queue) if temporal_client is not None else None
             )
             _worker_heartbeat_iteration(
                 task_queue,
                 worker_id,
                 worker_started_at=worker_started_at,
                 max_concurrent_activities=max_concurrent_activities,
-                activity_snapshot=(
-                    activity_inventory.snapshot() if activity_inventory is not None else None
-                ),
+                activity_snapshot=(activity_inventory.snapshot() if activity_inventory is not None else None),
                 task_queue_observation=queue_observation,
             )
         except Exception:
@@ -2344,10 +2397,7 @@ async def _worker_heartbeat_loop(
                 log.warning("Workflow-run reconciler iteration failed; will retry", exc_info=True)
             else:
                 if reconciled:
-                    console.print(
-                        f"[yellow]Reconciler updated {reconciled} workflow "
-                        "run(s).[/yellow]"
-                    )
+                    console.print(f"[yellow]Reconciler updated {reconciled} workflow run(s).[/yellow]")
             try:
                 recovered = await _reconcile_legacy_discovery_executions(temporal_client)
             except Exception:
@@ -2358,8 +2408,7 @@ async def _worker_heartbeat_loop(
             else:
                 if recovered:
                     console.print(
-                        f"[yellow]Recovered durable tracking for {recovered} legacy "
-                        "Discover execution(s).[/yellow]"
+                        f"[yellow]Recovered durable tracking for {recovered} legacy Discover execution(s).[/yellow]"
                     )
             try:
                 from jobctrl.apply.auto_apply import reconcile_auto_apply_loop
@@ -2376,10 +2425,7 @@ async def _worker_heartbeat_loop(
                 log.warning("Auto-apply loop reconciler iteration failed; will retry", exc_info=True)
             else:
                 if auto_apply.changed:
-                    console.print(
-                        f"[yellow]Auto-apply loop {auto_apply.action}: "
-                        f"{auto_apply.workflow_id}.[/yellow]"
-                    )
+                    console.print(f"[yellow]Auto-apply loop {auto_apply.action}: {auto_apply.workflow_id}.[/yellow]")
 
 
 def _worker_heartbeat_iteration(
@@ -2556,11 +2602,7 @@ async def _reconcile_legacy_discovery_executions(
                 exc_info=True,
             )
             continue
-        if (
-            result.activities_recovered
-            or result.jobs_linked
-            or result.work_plans_recovered
-        ):
+        if result.activities_recovered or result.jobs_linked or result.work_plans_recovered:
             changed += 1
     return changed
 
@@ -2654,8 +2696,7 @@ async def _reconcile_one_workflow_run(temporal_client: Any, conn, run: dict) -> 
         return False
     temporal_run_id = str(run.get("temporal_run_id") or "") or None
     missing_history_terminal = (
-        str(run.get("status") or "") == "terminated"
-        and str(run.get("error_code") or "") == "reconciled_not_found"
+        str(run.get("status") or "") == "terminated" and str(run.get("error_code") or "") == "reconciled_not_found"
     )
     try:
         handle = temporal_client.get_workflow_handle(
@@ -2838,10 +2879,7 @@ def _record_reconciled_outcome(
             "SELECT status FROM workflow_run_projections WHERE workflow_id = ?",
             (workflow_id,),
         ).fetchone()
-        if (
-            existing is not None
-            and str(existing["status"]) in SqliteProjectionStore.WORKFLOW_TERMINAL_STATUSES
-        ):
+        if existing is not None and str(existing["status"]) in SqliteProjectionStore.WORKFLOW_TERMINAL_STATUSES:
             if own_txn:
                 conn.rollback()
             return
@@ -2932,21 +2970,25 @@ def politeness_doctor_notices(conn, search_cfg: dict) -> list[tuple[str, str, st
     rows: list[tuple[str, str, str]] = []
 
     user_agent = resolve_honest_user_agent().header_value()
-    rows.append((
-        "crawl user-agent",
-        "ok",
-        f"{user_agent} — review before real crawls; edit it in Discovery runtime settings",
-    ))
+    rows.append(
+        (
+            "crawl user-agent",
+            "ok",
+            f"{user_agent} — review before real crawls; edit it in Discovery runtime settings",
+        )
+    )
 
     boards = resolve_jobspy_boards(search_cfg, warn=False)
     active_broad = [board for board in boards if board in _BROAD_BOARDS]
     if active_broad:
-        rows.append((
-            "broad-board discovery",
-            "warn",
-            f"active: {', '.join(active_broad)} — JobStreaming owns their transport; "
-            "only invocation-boundary budget + pacing apply (D3)",
-        ))
+        rows.append(
+            (
+                "broad-board discovery",
+                "warn",
+                f"active: {', '.join(active_broad)} — JobStreaming owns their transport; "
+                "only invocation-boundary budget + pacing apply (D3)",
+            )
+        )
     else:
         rows.append(("broad-board discovery", "ok", "no broad boards active"))
 
@@ -2954,11 +2996,13 @@ def politeness_doctor_notices(conn, search_cfg: dict) -> list[tuple[str, str, st
     if blocked:
         preview = ", ".join(sorted(blocked)[:5])
         extra = "" if len(blocked) <= 5 else f" (+{len(blocked) - 5} more)"
-        rows.append((
-            "robots/rate-limited sources",
-            "warn",
-            f"{len(blocked)} source(s) recently blocked: {preview}{extra}",
-        ))
+        rows.append(
+            (
+                "robots/rate-limited sources",
+                "warn",
+                f"{len(blocked)} source(s) recently blocked: {preview}{extra}",
+            )
+        )
     else:
         rows.append(("robots/rate-limited sources", "ok", "none recently blocked"))
 
@@ -2971,7 +3015,10 @@ def doctor() -> None:
     import os
     import shutil
     from jobctrl.config import (
-        load_env, DB_PATH, RESUME_PATH, RESUME_PDF_PATH,
+        load_env,
+        DB_PATH,
+        RESUME_PATH,
+        RESUME_PDF_PATH,
         load_search_config,
         gmail_mcp_auth_status,
     )
@@ -3056,21 +3103,23 @@ def doctor() -> None:
                 "felony_conviction",
                 "previously_worked_at_employer",
             )
-            missing_attestations = [
-                key for key in required_attestations if attestations.get(key) is None
-            ]
+            missing_attestations = [key for key in required_attestations if attestations.get(key) is None]
             if missing_attestations:
-                results.append((
-                    "application attestations",
-                    warn_mark,
-                    "incomplete; live applies may fail on screening questions",
-                ))
+                results.append(
+                    (
+                        "application attestations",
+                        warn_mark,
+                        "incomplete; live applies may fail on screening questions",
+                    )
+                )
             else:
-                results.append((
-                    "application attestations",
-                    ok_mark,
-                    "typed screening attestations complete",
-                ))
+                results.append(
+                    (
+                        "application attestations",
+                        ok_mark,
+                        "typed screening attestations complete",
+                    )
+                )
     except FileNotFoundError:
         results.append(("candidate profile", fail_mark, "Run 'jobctrl init' to create"))
     except Exception:  # noqa: BLE001 - doctor should report validation problems instead of crashing
@@ -3088,11 +3137,13 @@ def doctor() -> None:
 
     browser_capabilities = {item.id: item for item in list_browser_capabilities()}
     core_browser = browser_capabilities["core-browser"]
-    results.append((
-        "core browser (scraping + PDF)",
-        ok_mark if core_browser.status == "ready" else fail_mark,
-        core_browser.detail,
-    ))
+    results.append(
+        (
+            "core browser (scraping + PDF)",
+            ok_mark if core_browser.status == "ready" else fail_mark,
+            core_browser.detail,
+        )
+    )
     auto_apply_browser = browser_capabilities["auto-apply-browser"]
     linkedin_browser = browser_capabilities["authenticated-linkedin-browser"]
     capability_marks = {
@@ -3103,11 +3154,13 @@ def doctor() -> None:
         "unavailable": fail_mark,
     }
     for capability in (auto_apply_browser, linkedin_browser):
-        results.append((
-            f"{capability.id} capability",
-            capability_marks[capability.status],
-            capability.detail,
-        ))
+        results.append(
+            (
+                f"{capability.id} capability",
+                capability_marks[capability.status],
+                capability.detail,
+            )
+        )
 
     try:
         search_cfg = load_search_config()
@@ -3141,11 +3194,13 @@ def doctor() -> None:
             if _claude_supports_budget_flag(claude_bin, bare=bundled):
                 results.append(("Claude apply budget flag", ok_mark, "--max-budget-usd available"))
             else:
-                results.append((
-                    "Claude apply budget flag",
-                    warn_mark,
-                    "installed Claude runtime does not advertise --max-budget-usd",
-                ))
+                results.append(
+                    (
+                        "Claude apply budget flag",
+                        warn_mark,
+                        "installed Claude runtime does not advertise --max-budget-usd",
+                    )
+                )
         else:
             results.append(("Claude apply runtime", fail_mark, "set JOBCTRL_CLAUDE_BIN or install dependencies"))
     except Exception as exc:  # noqa: BLE001 - doctor is diagnostic
@@ -3169,8 +3224,7 @@ def doctor() -> None:
         if npx_bin:
             results.append(("Node.js (npx)", ok_mark, npx_bin))
         else:
-            results.append(("Node.js (npx)", fail_mark,
-                            "Install Node.js 18+ from nodejs.org (needed for auto-apply)"))
+            results.append(("Node.js (npx)", fail_mark, "Install Node.js 18+ from nodejs.org (needed for auto-apply)"))
 
     # Gmail connector is optional, but apply runs that hit email verification need it
     # to stay browser-independent and finish automatically.
@@ -3178,39 +3232,52 @@ def doctor() -> None:
     if gmail_ok:
         results.append(("Gmail connector auth", ok_mark, gmail_note))
     else:
-        results.append((
-            "Gmail connector auth",
-            warn_mark,
-            f"{gmail_note}; email verification will stop as login_issue and email applications cannot send",
-        ))
+        results.append(
+            (
+                "Gmail connector auth",
+                warn_mark,
+                f"{gmail_note}; email verification will stop as login_issue and email applications cannot send",
+            )
+        )
 
     # CapSolver (optional; the owned solve_captcha tool fails closed when absent)
     capsolver = os.environ.get("CAPSOLVER_API_KEY")
     if capsolver:
-        results.append((
-            "CapSolver API key",
-            "[dim]configured[/dim]",
-            "owned solve_captcha tool can handle supported widgets",
-        ))
+        results.append(
+            (
+                "CapSolver API key",
+                "[dim]configured[/dim]",
+                "owned solve_captcha tool can handle supported widgets",
+            )
+        )
     else:
-        results.append(("CapSolver API key", "[dim]optional[/dim]",
-                        "not required; unsupported or unconfigured CAPTCHA flows fail closed"))
+        results.append(
+            (
+                "CapSolver API key",
+                "[dim]optional[/dim]",
+                "not required; unsupported or unconfigured CAPTCHA flows fail closed",
+            )
+        )
 
     # The gate defaults on. If an operator has explicitly disabled it, make the
     # resulting live-submission posture visible in the same preflight that
     # reports the other preserved automation capabilities.
     if read_apply_approval_required(default=True):
-        results.append((
-            "apply approval gate",
-            ok_mark,
-            "required before eligible live submissions",
-        ))
+        results.append(
+            (
+                "apply approval gate",
+                ok_mark,
+                "required before eligible live submissions",
+            )
+        )
     else:
-        results.append((
-            "apply approval gate",
-            warn_mark,
-            "disabled; eligible live runs may submit without human review",
-        ))
+        results.append(
+            (
+                "apply approval gate",
+                warn_mark,
+                "disabled; eligible live runs may submit without human review",
+            )
+        )
 
     # Temporal dev server (workflow engine)
     from jobctrl.infrastructure.temporal import get_temporal_client
@@ -3222,8 +3289,7 @@ def doctor() -> None:
         asyncio.run(_probe_temporal())
         results.append(("Temporal", ok_mark, "reachable"))
     except (Exception, asyncio.TimeoutError):  # noqa: BLE001 — any failure ⇒ unreachable
-        results.append(("Temporal", fail_mark,
-                        "unreachable (start with: temporal server start-dev)"))
+        results.append(("Temporal", fail_mark, "unreachable (start with: temporal server start-dev)"))
 
     # Langfuse OTLP ingest (observability target)
     # Skip the network probe entirely if LANGFUSE_DISABLE is set — it's the
@@ -3238,11 +3304,13 @@ def doctor() -> None:
         lf_sec = os.environ.get("LANGFUSE_SECRET_KEY", "").strip()
         lf_url = os.environ.get("LANGFUSE_BASE_URL", "").strip().rstrip("/")
         if not (lf_pub and lf_sec and lf_url):
-            results.append((
-                "Langfuse",
-                fail_mark,
-                "MISSING (set LANGFUSE_PUBLIC_KEY/SECRET_KEY/BASE_URL)",
-            ))
+            results.append(
+                (
+                    "Langfuse",
+                    fail_mark,
+                    "MISSING (set LANGFUSE_PUBLIC_KEY/SECRET_KEY/BASE_URL)",
+                )
+            )
         else:
             try:
                 resp = httpx.head(f"{lf_url}/api/public/otel/v1/traces", timeout=2.0)
@@ -3252,11 +3320,13 @@ def doctor() -> None:
                 if resp.status_code < 500:
                     results.append(("Langfuse", ok_mark, "reachable"))
                 else:
-                    results.append((
-                        "Langfuse",
-                        fail_mark,
-                        f"unreachable (status={resp.status_code})",
-                    ))
+                    results.append(
+                        (
+                            "Langfuse",
+                            fail_mark,
+                            f"unreachable (status={resp.status_code})",
+                        )
+                    )
             except Exception:  # noqa: BLE001 — any failure ⇒ unreachable
                 results.append(("Langfuse", fail_mark, "unreachable"))
 
@@ -3292,15 +3362,20 @@ def doctor() -> None:
 
     # Tier summary
     from jobctrl.config import get_tier, TIER_LABELS
+
     tier = get_tier()
     console.print(f"[bold]Current tier: Tier {tier} — {TIER_LABELS[tier]}[/bold]")
 
     if tier == 1:
         console.print("[dim]  → Tier 2 unlocks: scoring, tailoring, cover letters (needs an LLM provider)[/dim]")
-        tier3_tools = "Claude apply runtime + an explicitly enabled auto-apply browser capability" + ("" if bundled else " + Node.js")
+        tier3_tools = "Claude apply runtime + an explicitly enabled auto-apply browser capability" + (
+            "" if bundled else " + Node.js"
+        )
         console.print(f"[dim]  → Tier 3 unlocks: auto-apply (needs {tier3_tools})[/dim]")
     elif tier == 2:
-        tier3_tools = "Claude apply runtime + an explicitly enabled auto-apply browser capability" + ("" if bundled else " + Node.js")
+        tier3_tools = "Claude apply runtime + an explicitly enabled auto-apply browser capability" + (
+            "" if bundled else " + Node.js"
+        )
         console.print(f"[dim]  → Tier 3 unlocks: auto-apply (needs {tier3_tools})[/dim]")
 
     console.print()
@@ -3308,10 +3383,16 @@ def doctor() -> None:
 
 @app.command("migrate-resume-html")
 def migrate_resume_html(
-    dry_run: bool = typer.Option(False, "--dry-run", help="Report matching resume PDFs without writing files or DB rows."),
-    force: bool = typer.Option(False, "--force", help="Refresh already-HTML resume PDFs from their sibling text source."),
+    dry_run: bool = typer.Option(
+        False, "--dry-run", help="Report matching resume PDFs without writing files or DB rows."
+    ),
+    force: bool = typer.Option(
+        False, "--force", help="Refresh already-HTML resume PDFs from their sibling text source."
+    ),
     job_url: Optional[str] = typer.Option(None, "--job-url", help="Limit migration to one job URL."),
-    limit: Optional[int] = typer.Option(None, "--limit", min=1, help="Maximum number of resume PDFs to migrate or refresh."),
+    limit: Optional[int] = typer.Option(
+        None, "--limit", min=1, help="Maximum number of resume PDFs to migrate or refresh."
+    ),
 ) -> None:
     """Migrate or refresh approved resume PDFs as HTML/CSS-rendered artifacts."""
     _bootstrap()

--- a/workers/automation/src/jobctrl/domain/apply/repeat_application.py
+++ b/workers/automation/src/jobctrl/domain/apply/repeat_application.py
@@ -15,7 +15,8 @@ import uuid
 from datetime import datetime, timezone
 from typing import Any
 
-LOCAL_TENANT = "local"
+from jobctrl.domain.identifiers import JobId, canonical_job_id
+from jobctrl.domain.tenant import LOCAL_TENANT, TenantId
 
 _RELATIONSHIP_RANK = {
     "canonical_job": 0,
@@ -68,8 +69,8 @@ def ensure_repeat_application_tables(conn) -> list[str]:
         CREATE TABLE IF NOT EXISTS application_repeat_overrides (
           tenant_id            TEXT NOT NULL DEFAULT 'local',
           override_id          TEXT NOT NULL,
-          target_job_key       TEXT NOT NULL,
-          prior_job_key        TEXT NOT NULL,
+          target_job_id        TEXT NOT NULL,
+          prior_job_id         TEXT NOT NULL,
           relationship         TEXT NOT NULL,
           evidence_fingerprint TEXT NOT NULL,
           evidence_json        TEXT NOT NULL,
@@ -81,7 +82,7 @@ def ensure_repeat_application_tables(conn) -> list[str]:
         """,
         """
         CREATE INDEX IF NOT EXISTS idx_application_repeat_overrides_target
-          ON application_repeat_overrides(tenant_id, target_job_key, confirmed_at DESC)
+          ON application_repeat_overrides(tenant_id, target_job_id, confirmed_at DESC)
         """,
         """
         CREATE TABLE IF NOT EXISTS application_repeat_override_consumptions (
@@ -98,7 +99,7 @@ def ensure_repeat_application_tables(conn) -> list[str]:
           tenant_id            TEXT NOT NULL DEFAULT 'local',
           audit_id             TEXT NOT NULL,
           audit_key            TEXT NOT NULL,
-          target_job_key       TEXT NOT NULL,
+          target_job_id        TEXT NOT NULL,
           action               TEXT NOT NULL,
           evidence_fingerprint TEXT NOT NULL,
           evidence_json        TEXT NOT NULL,
@@ -112,7 +113,7 @@ def ensure_repeat_application_tables(conn) -> list[str]:
         """,
         """
         CREATE INDEX IF NOT EXISTS idx_application_repeat_audit_target
-          ON application_repeat_audit(tenant_id, target_job_key, occurred_at DESC)
+          ON application_repeat_audit(tenant_id, target_job_id, occurred_at DESC)
         """,
     )
     for statement in statements:
@@ -124,23 +125,32 @@ def ensure_repeat_application_tables(conn) -> list[str]:
 
 def evaluate_repeat_application(
     conn,
-    target_job_key: str,
     *,
+    tenant_id: TenantId = LOCAL_TENANT,
+    target_job_id: JobId,
     record_audit: bool = True,
     evaluated_at: str | None = None,
 ) -> dict[str, Any]:
-    """Evaluate confirmed prior applications related to ``target_job_key``."""
+    """Evaluate confirmed prior applications related to one canonical JobId."""
 
     ensure_repeat_application_tables(conn)
     evaluated_at = evaluated_at or _utc_now()
-    target = _job_identity(conn, target_job_key)
+    stable_job_id = canonical_job_id(str(target_job_id))
+    target = _job_identity(conn, tenant_id=tenant_id, job_id=stable_job_id)
     if target is None:
-        raise ValueError(f"job not found: {target_job_key}")
+        raise ValueError(f"job not found: {stable_job_id}")
 
     matches = [
         match
-        for fact in _confirmed_application_facts(conn)
-        if (match := _relationship_match(conn, target, fact)) is not None
+        for fact in _confirmed_application_facts(conn, tenant_id=tenant_id)
+        if (
+            match := _relationship_match(
+                conn,
+                tenant_id=tenant_id,
+                target=target,
+                fact=fact,
+            )
+        ) is not None
     ]
     matches.sort(key=_match_sort_key)
     if not matches:
@@ -151,21 +161,30 @@ def evaluate_repeat_application(
             "evaluatedAt": evaluated_at,
             "matches": [],
             "override": None,
-            "auditTrail": _audit_trail(conn, target_job_key),
+            "auditTrail": _audit_trail(
+                conn,
+                tenant_id=tenant_id,
+                target_job_id=stable_job_id,
+            ),
         }
 
-    fingerprint = repeat_evidence_fingerprint(target_job_key, matches)
-    override = _matching_override(conn, target_job_key, fingerprint)
-    exact = any(match["relationship"] != "same_employer_equivalent_role" for match in matches)
-    if override and override["consumedAt"] is None:
+    fingerprint = repeat_evidence_fingerprint(str(stable_job_id), matches)
+    override = _matching_override(
+        conn,
+        tenant_id=tenant_id,
+        target_job_id=stable_job_id,
+        fingerprint=fingerprint,
+    )
+    hard_block = any(match["relationship"] != "same_employer_equivalent_role" for match in matches)
+    if hard_block:
+        status = "blocked"
+        summary = "A confirmed application to this canonical opening blocks another live submission."
+    elif override and override["consumedAt"] is None:
         status = "override_ready"
         summary = "A reasoned confirmation is recorded for one live attempt against this exact evidence."
     elif override:
         status = "override_consumed"
         summary = "The prior confirmation was already used; another live attempt requires a new confirmation."
-    elif exact:
-        status = "blocked"
-        summary = "A confirmed application to this canonical opening blocks another live submission by default."
     else:
         status = "confirmation_required"
         summary = (
@@ -175,8 +194,9 @@ def evaluate_repeat_application(
     if record_audit and status in {"blocked", "confirmation_required"}:
         _insert_audit(
             conn,
-            audit_key=f"assessment:{target_job_key}:{fingerprint}:{status}",
-            target_job_key=target_job_key,
+            tenant_id=tenant_id,
+            audit_key=f"assessment:{stable_job_id}:{fingerprint}:{status}",
+            target_job_id=stable_job_id,
             action=status,
             evidence_fingerprint=fingerprint,
             evidence_json=_compact_json(matches),
@@ -193,7 +213,11 @@ def evaluate_repeat_application(
         "evaluatedAt": evaluated_at,
         "matches": matches,
         "override": override,
-        "auditTrail": _audit_trail(conn, target_job_key),
+        "auditTrail": _audit_trail(
+            conn,
+            tenant_id=tenant_id,
+            target_job_id=stable_job_id,
+        ),
     }
 
 
@@ -201,7 +225,8 @@ def consume_repeat_application_override(
     conn,
     assessment: dict[str, Any],
     *,
-    target_job_key: str,
+    tenant_id: TenantId = LOCAL_TENANT,
+    target_job_id: JobId,
     run_id: str,
     consumed_at: str,
 ) -> str | None:
@@ -218,12 +243,13 @@ def consume_repeat_application_override(
           tenant_id, override_id, run_id, consumed_at
         ) VALUES (?, ?, ?, ?)
         """,
-        (LOCAL_TENANT, override["overrideId"], run_id, consumed_at),
+        (str(tenant_id), override["overrideId"], run_id, consumed_at),
     )
     _insert_audit(
         conn,
+        tenant_id=tenant_id,
         audit_key=f"override_consumed:{override['overrideId']}",
-        target_job_key=target_job_key,
+        target_job_id=target_job_id,
         action="override_consumed",
         evidence_fingerprint=assessment["evidenceFingerprint"],
         evidence_json=_compact_json(assessment["matches"]),
@@ -236,17 +262,17 @@ def consume_repeat_application_override(
 
 
 def repeat_evidence_fingerprint(
-    target_job_key: str,
+    target_job_id: str,
     matches: list[dict[str, Any]],
 ) -> str:
     canonical = {
-        "targetJobKey": target_job_key,
+        "targetJobId": target_job_id,
         "matches": [
             {
                 "relationship": match["relationship"],
                 "reason": match["reason"],
                 "priorApplication": {
-                    "jobKey": match["priorApplication"]["jobKey"],
+                    "jobId": match["priorApplication"]["jobId"],
                     "title": match["priorApplication"]["title"],
                     "company": match["priorApplication"]["company"],
                     "applicationUrl": match["priorApplication"]["applicationUrl"],
@@ -271,7 +297,7 @@ def _match_sort_key(match: dict[str, Any]) -> tuple[int, bytes, bytes]:
     prior = match["priorApplication"]
     return (
         _RELATIONSHIP_RANK[str(match["relationship"])],
-        str(prior["jobKey"]).encode("utf-8"),
+        str(prior["jobId"]).encode("utf-8"),
         str(prior["factId"]).encode("utf-8"),
     )
 
@@ -296,7 +322,12 @@ def _normalize_tokens(value: str | None) -> list[str]:
     return [token for token in re.sub(r"[^a-z0-9]+", " ", normalized).strip().split() if token]
 
 
-def _job_identity(conn, job_key: str) -> dict[str, Any] | None:
+def _job_identity(
+    conn,
+    *,
+    tenant_id: TenantId,
+    job_id: JobId,
+) -> dict[str, Any] | None:
     company_expression = "j.company"
     company_params: tuple[str, ...] = ()
     if _table_exists(conn, "job_list_projections"):
@@ -304,31 +335,32 @@ def _job_identity(conn, job_key: str) -> dict[str, Any] | None:
             COALESCE(
               NULLIF(j.company, ''),
               (SELECT jlp.employer
-                 FROM job_list_projections jlp
-                WHERE jlp.tenant_id = ? AND jlp.job_id = j.url
+                FROM job_list_projections jlp
+                WHERE jlp.tenant_id = ? AND jlp.job_id = j.job_id
                 LIMIT 1)
             )
         """
-        company_params = (LOCAL_TENANT,)
+        company_params = (str(tenant_id),)
     row = conn.execute(
         f"""
-        SELECT j.url, j.title, {company_expression} AS company,
+        SELECT j.job_id, j.url, j.title, {company_expression} AS company,
                COALESCE(
                  (SELECT je.application_url
                     FROM job_enrichments je
-                   WHERE je.job_url = j.url AND je.tenant_id = ?
+                   WHERE je.tenant_id = ? AND je.job_id = j.job_id
                    ORDER BY je.updated_at DESC LIMIT 1),
                  j.application_url,
                  j.url
                ) AS application_url
          FROM jobs j
-         WHERE j.url = ?
+         WHERE j.tenant_id = ? AND j.job_id = ?
         """,
-        (*company_params, LOCAL_TENANT, job_key),
+        (*company_params, str(tenant_id), str(tenant_id), str(job_id)),
     ).fetchone()
     if row is None:
         return None
     return {
+        "job_id": str(row["job_id"]),
         "url": str(row["url"]),
         "title": str(row["title"] or ""),
         "company": str(row["company"] or ""),
@@ -336,12 +368,16 @@ def _job_identity(conn, job_key: str) -> dict[str, Any] | None:
     }
 
 
-def _confirmed_application_facts(conn) -> list[dict[str, Any]]:
+def _confirmed_application_facts(
+    conn,
+    *,
+    tenant_id: TenantId,
+) -> list[dict[str, Any]]:
     facts: list[dict[str, Any]] = []
     if _table_exists(conn, "job_events"):
         for row in conn.execute(
             """
-            SELECT job_url AS job_key,
+            SELECT job_id,
                    CASE event_type
                      WHEN 'ApplicationSubmitted' THEN 'application_submitted'
                      ELSE 'application_manually_marked'
@@ -350,40 +386,42 @@ def _confirmed_application_facts(conn) -> list[dict[str, Any]]:
                    occurred_at AS confirmed_at,
                    CASE event_type WHEN 'ApplicationSubmitted' THEN 40 ELSE 30 END AS priority
               FROM job_events
-             WHERE job_url IS NOT NULL
+             WHERE tenant_id = ? AND job_id IS NOT NULL
                AND event_type IN ('ApplicationSubmitted', 'ApplicationManuallyMarked')
-            """
+            """,
+            (str(tenant_id),),
         ).fetchall():
             facts.append(dict(row))
     if _table_exists(conn, "application_outcomes"):
         for row in conn.execute(
             """
-            SELECT job_key, 'applied_confirmation' AS fact_kind,
+            SELECT job_id, 'applied_confirmation' AS fact_kind,
                    'outcome:' || outcome_id AS fact_id,
                    occurred_at AS confirmed_at, 20 AS priority
               FROM application_outcomes
              WHERE tenant_id = ? AND kind = 'applied_confirmation'
             """,
-            (LOCAL_TENANT,),
+            (str(tenant_id),),
         ).fetchall():
             facts.append(dict(row))
     for row in conn.execute(
         """
-        SELECT url AS job_key, 'legacy_applied_status' AS fact_kind,
-               'job:' || url AS fact_id,
+        SELECT job_id, 'legacy_applied_status' AS fact_kind,
+               'job:' || job_id AS fact_id,
                COALESCE(applied_at, discovered_at, '') AS confirmed_at,
                10 AS priority
           FROM jobs
-         WHERE LOWER(COALESCE(apply_status, '')) = 'applied'
+         WHERE tenant_id = ? AND LOWER(COALESCE(apply_status, '')) = 'applied'
            AND COALESCE(applied_at, '') != ''
-        """
+        """,
+        (str(tenant_id),),
     ).fetchall():
         facts.append(dict(row))
 
     best: dict[str, dict[str, Any]] = {}
     for fact in facts:
-        job_key = str(fact["job_key"])
-        current = best.get(job_key)
+        job_id = str(fact["job_id"])
+        current = best.get(job_id)
         if (
             current is None
             or int(fact["priority"]) > int(current["priority"])
@@ -392,30 +430,46 @@ def _confirmed_application_facts(conn) -> list[dict[str, Any]]:
                 and str(fact["confirmed_at"]) > str(current["confirmed_at"])
             )
         ):
-            best[job_key] = fact
+            best[job_id] = fact
     return list(best.values())
 
 
 def _relationship_match(
     conn,
+    *,
+    tenant_id: TenantId,
     target: dict[str, Any],
     fact: dict[str, Any],
 ) -> dict[str, Any] | None:
-    prior = _job_identity(conn, str(fact["job_key"]))
+    prior = _job_identity(
+        conn,
+        tenant_id=tenant_id,
+        job_id=canonical_job_id(str(fact["job_id"])),
+    )
     if prior is None:
         return None
     relationship: str | None = None
     reason = ""
     evidence: list[str] = []
-    if target["url"] == prior["url"]:
+    if target["job_id"] == prior["job_id"]:
         relationship = "canonical_job"
         reason = "Both records resolve to the same canonical JobCtrl job."
-        evidence = [f"job:{target['url']}"]
-    elif canonical := _canonical_identity_relationship(conn, target["url"], prior["url"]):
+        evidence = [f"job:{target['job_id']}"]
+    elif canonical := _canonical_identity_relationship(
+        conn,
+        tenant_id=tenant_id,
+        target_job_id=target["job_id"],
+        prior_job_id=prior["job_id"],
+    ):
         relationship = "canonical_identity"
         reason = "The canonical ATS identity matches the previously applied opening."
         evidence = canonical
-    elif duplicate := _accepted_duplicate_relationship(conn, target["url"], prior["url"]):
+    elif duplicate := _accepted_duplicate_relationship(
+        conn,
+        tenant_id=tenant_id,
+        target_job_id=target["job_id"],
+        prior_job_id=prior["job_id"],
+    ):
         relationship = "accepted_duplicate"
         reason = "An accepted duplicate link connects this representation to the previously applied opening."
         evidence = duplicate
@@ -432,7 +486,7 @@ def _relationship_match(
         "relationship": relationship,
         "reason": reason,
         "priorApplication": {
-            "jobKey": prior["url"],
+            "jobId": prior["job_id"],
             "title": prior["title"].strip() or "Untitled role",
             "company": prior["company"].strip() or "Unknown company",
             "applicationUrl": prior["application_url"],
@@ -444,20 +498,26 @@ def _relationship_match(
     }
 
 
-def _canonical_identity_relationship(conn, target_job_key: str, prior_job_key: str) -> list[str] | None:
+def _canonical_identity_relationship(
+    conn,
+    *,
+    tenant_id: TenantId,
+    target_job_id: str,
+    prior_job_id: str,
+) -> list[str] | None:
     if not _table_exists(conn, "job_canonical_identities"):
         return None
     rows = conn.execute(
         """
-        SELECT job_url, canonical_url, ats_kind, source_native_id
+        SELECT job_id, canonical_url, ats_kind, source_native_id
           FROM job_canonical_identities
-         WHERE tenant_id = ? AND job_url IN (?, ?)
+         WHERE tenant_id = ? AND job_id IN (?, ?)
         """,
-        (LOCAL_TENANT, target_job_key, prior_job_key),
+        (str(tenant_id), target_job_id, prior_job_id),
     ).fetchall()
-    identities = {str(row["job_url"]): row for row in rows}
-    target = identities.get(target_job_key)
-    prior = identities.get(prior_job_key)
+    identities = {str(row["job_id"]): row for row in rows}
+    target = identities.get(target_job_id)
+    prior = identities.get(prior_job_id)
     if target is None or prior is None:
         return None
     if target["canonical_url"] and target["canonical_url"] == prior["canonical_url"]:
@@ -472,17 +532,31 @@ def _canonical_identity_relationship(conn, target_job_key: str, prior_job_key: s
     return None
 
 
-def _accepted_duplicate_relationship(conn, target_job_key: str, prior_job_key: str) -> list[str] | None:
+def _accepted_duplicate_relationship(
+    conn,
+    *,
+    tenant_id: TenantId,
+    target_job_id: str,
+    prior_job_id: str,
+) -> list[str] | None:
     if not _table_exists(conn, "job_duplicate_links"):
         return None
-    target_aliases = _job_aliases(conn, target_job_key)
-    prior_aliases = _job_aliases(conn, prior_job_key)
+    target_aliases = _job_aliases(
+        conn,
+        tenant_id=tenant_id,
+        job_id=target_job_id,
+    )
+    prior_aliases = _job_aliases(
+        conn,
+        tenant_id=tenant_id,
+        job_id=prior_job_id,
+    )
     rows = conn.execute(
         """
         SELECT surviving_job_id, superseded_job_or_observation_id, reason
           FROM job_duplicate_links WHERE tenant_id = ?
         """,
-        (LOCAL_TENANT,),
+        (str(tenant_id),),
     ).fetchall()
     for row in rows:
         survivor = str(row["surviving_job_id"])
@@ -498,16 +572,21 @@ def _accepted_duplicate_relationship(conn, target_job_key: str, prior_job_key: s
     return None
 
 
-def _job_aliases(conn, job_key: str) -> set[str]:
-    aliases = {job_key}
+def _job_aliases(
+    conn,
+    *,
+    tenant_id: TenantId,
+    job_id: str,
+) -> set[str]:
+    aliases = {job_id}
     if not _table_exists(conn, "job_source_observations"):
         return aliases
     rows = conn.execute(
         """
-        SELECT source_observation_id, observed_url, normalized_observed_url
-          FROM job_source_observations WHERE tenant_id = ? AND job_url = ?
+        SELECT source_observation_id
+          FROM job_source_observations WHERE tenant_id = ? AND job_id = ?
         """,
-        (LOCAL_TENANT, job_key),
+        (str(tenant_id), job_id),
     ).fetchall()
     for row in rows:
         aliases.update(str(value) for value in row if value)
@@ -525,26 +604,32 @@ def _equivalent_employer_role(target: dict[str, Any], prior: dict[str, Any]) -> 
     return target_role == prior_role or sorted(target_role.split()) == sorted(prior_role.split())
 
 
-def _matching_override(conn, target_job_key: str, fingerprint: str) -> dict[str, Any] | None:
+def _matching_override(
+    conn,
+    *,
+    tenant_id: TenantId,
+    target_job_id: JobId,
+    fingerprint: str,
+) -> dict[str, Any] | None:
     row = conn.execute(
         """
-        SELECT o.override_id, o.target_job_key, o.prior_job_key,
+        SELECT o.override_id, o.target_job_id, o.prior_job_id,
                o.evidence_fingerprint, o.reason, o.confirmed_by, o.confirmed_at,
                c.consumed_at, c.run_id AS consumed_run_id
           FROM application_repeat_overrides o
           LEFT JOIN application_repeat_override_consumptions c
             ON c.tenant_id = o.tenant_id AND c.override_id = o.override_id
-         WHERE o.tenant_id = ? AND o.target_job_key = ? AND o.evidence_fingerprint = ?
+         WHERE o.tenant_id = ? AND o.target_job_id = ? AND o.evidence_fingerprint = ?
          ORDER BY o.confirmed_at DESC, o.override_id DESC LIMIT 1
         """,
-        (LOCAL_TENANT, target_job_key, fingerprint),
+        (str(tenant_id), str(target_job_id), fingerprint),
     ).fetchone()
     if row is None:
         return None
     return {
         "overrideId": str(row["override_id"]),
-        "targetJobKey": str(row["target_job_key"]),
-        "priorJobKey": str(row["prior_job_key"]),
+        "targetJobId": str(row["target_job_id"]),
+        "priorJobId": str(row["prior_job_id"]),
         "evidenceFingerprint": str(row["evidence_fingerprint"]),
         "reason": str(row["reason"]),
         "confirmedBy": str(row["confirmed_by"]),
@@ -557,8 +642,9 @@ def _matching_override(conn, target_job_key: str, fingerprint: str) -> dict[str,
 def _insert_audit(
     conn,
     *,
+    tenant_id: TenantId,
     audit_key: str,
-    target_job_key: str,
+    target_job_id: JobId,
     action: str,
     evidence_fingerprint: str,
     evidence_json: str,
@@ -570,15 +656,15 @@ def _insert_audit(
     conn.execute(
         """
         INSERT OR IGNORE INTO application_repeat_audit (
-          tenant_id, audit_id, audit_key, target_job_key, action,
+          tenant_id, audit_id, audit_key, target_job_id, action,
           evidence_fingerprint, evidence_json, override_id, actor, reason, occurred_at
         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """,
         (
-            LOCAL_TENANT,
+            str(tenant_id),
             str(uuid.uuid4()),
             audit_key,
-            target_job_key,
+            str(target_job_id),
             action,
             evidence_fingerprint,
             evidence_json,
@@ -590,29 +676,34 @@ def _insert_audit(
     )
 
 
-def _audit_trail(conn, target_job_key: str) -> list[dict[str, Any]]:
+def _audit_trail(
+    conn,
+    *,
+    tenant_id: TenantId,
+    target_job_id: JobId,
+) -> list[dict[str, Any]]:
     rows = conn.execute(
         """
-        SELECT a.audit_id, a.target_job_key, a.action, a.evidence_fingerprint,
-               a.evidence_json, a.override_id, o.prior_job_key,
+        SELECT a.audit_id, a.target_job_id, a.action, a.evidence_fingerprint,
+               a.evidence_json, a.override_id, o.prior_job_id,
                a.actor, a.reason, a.occurred_at
           FROM application_repeat_audit a
           LEFT JOIN application_repeat_overrides o
             ON o.tenant_id = a.tenant_id AND o.override_id = a.override_id
-         WHERE a.tenant_id = ? AND a.target_job_key = ?
+         WHERE a.tenant_id = ? AND a.target_job_id = ?
          ORDER BY a.occurred_at DESC, a.rowid DESC LIMIT 50
         """,
-        (LOCAL_TENANT, target_job_key),
+        (str(tenant_id), str(target_job_id)),
     ).fetchall()
     return [
         {
             "auditId": str(row["audit_id"]),
-            "targetJobKey": str(row["target_job_key"]),
+            "targetJobId": str(row["target_job_id"]),
             "action": str(row["action"]),
             "evidenceFingerprint": str(row["evidence_fingerprint"]),
             "evidence": _parse_evidence_snapshot(row["evidence_json"]),
             "overrideId": str(row["override_id"]) if row["override_id"] else None,
-            "priorJobKey": str(row["prior_job_key"]) if row["prior_job_key"] else None,
+            "priorJobId": str(row["prior_job_id"]) if row["prior_job_id"] else None,
             "actor": str(row["actor"]),
             "reason": str(row["reason"]) if row["reason"] else None,
             "occurredAt": str(row["occurred_at"]),

--- a/workers/automation/src/jobctrl/domain/apply/repeat_application.py
+++ b/workers/automation/src/jobctrl/domain/apply/repeat_application.py
@@ -265,8 +265,21 @@ def repeat_evidence_fingerprint(
     target_job_id: str,
     matches: list[dict[str, Any]],
 ) -> str:
+    canonical_target_job_id = str(canonical_job_id(str(target_job_id)))
+    validated_matches: list[dict[str, Any]] = []
+    for match in matches:
+        prior = match.get("priorApplication")
+        if not isinstance(prior, dict) or "jobKey" in prior or "jobId" not in prior:
+            raise ValueError("Repeat evidence fingerprint requires canonical priorApplication.jobId")
+        canonical_prior_job_id = str(canonical_job_id(str(prior["jobId"])))
+        validated_matches.append(
+            {
+                **match,
+                "priorApplication": {**prior, "jobId": canonical_prior_job_id},
+            }
+        )
     canonical = {
-        "targetJobId": target_job_id,
+        "targetJobId": canonical_target_job_id,
         "matches": [
             {
                 "relationship": match["relationship"],
@@ -282,7 +295,7 @@ def repeat_evidence_fingerprint(
                 },
                 "identityEvidence": list(match["identityEvidence"]),
             }
-            for match in sorted(matches, key=_match_sort_key)
+            for match in sorted(validated_matches, key=_match_sort_key)
         ],
     }
     return hashlib.sha256(_compact_json(canonical).encode("utf-8")).hexdigest()

--- a/workers/automation/src/jobctrl/infrastructure/projections/sqlite_projection_store.py
+++ b/workers/automation/src/jobctrl/infrastructure/projections/sqlite_projection_store.py
@@ -396,7 +396,7 @@ def ensure_projection_tables(conn: sqlite3.Connection) -> list[str]:
             is_scrape_failure       INTEGER NOT NULL DEFAULT 0,
             is_retryable            INTEGER NOT NULL DEFAULT 1,
             run_id                  TEXT,
-            job_url                 TEXT,
+            job_id                  TEXT,
             duration_ms             INTEGER,
             total_count             INTEGER,
             new_count               INTEGER,
@@ -405,7 +405,9 @@ def ensure_projection_tables(conn: sqlite3.Connection) -> list[str]:
             duplicate_count         INTEGER,
             error_class             TEXT,
             error_message           TEXT,
-            metadata_json           TEXT NOT NULL DEFAULT '{}'
+            metadata_json           TEXT NOT NULL DEFAULT '{}',
+            FOREIGN KEY (tenant_id, job_id)
+                REFERENCES jobs(tenant_id, job_id) ON DELETE RESTRICT
         )
         """
     )
@@ -536,8 +538,7 @@ def ensure_projection_tables(conn: sqlite3.Connection) -> list[str]:
     score_evidence_schema_changed = False
     for table_name, column_name, definition in SCORE_EVIDENCE_COLUMNS:
         score_evidence_schema_changed = (
-            _ensure_column(conn, table_name, column_name, definition)
-            or score_evidence_schema_changed
+            _ensure_column(conn, table_name, column_name, definition) or score_evidence_schema_changed
         )
     if score_evidence_schema_changed:
         # Projection rows are fully derived; resetting them lets the next

--- a/workers/automation/src/jobctrl/infrastructure/rpc/handlers.py
+++ b/workers/automation/src/jobctrl/infrastructure/rpc/handlers.py
@@ -311,18 +311,10 @@ def retailor_job(params: dict[str, Any]) -> WorkflowStartSpec:
         workers=int(params.get("workers", 1)),
         validation_mode=str(params.get("validationMode", "normal")),
         retailor=True,
-        suppress_existing_artifacts=_bool_param(
-            params, "suppressExistingArtifacts", default=False
-        ),
+        suppress_existing_artifacts=_bool_param(params, "suppressExistingArtifacts", default=False),
         tailor_models=tuple(str(item) for item in (params.get("tailorModels") or ())),
-        tailor_judge_model=(
-            str(params["tailorJudgeModel"])
-            if params.get("tailorJudgeModel")
-            else None
-        ),
-        tailor_judge_min_score=(
-            float(raw_judge_min_score) if raw_judge_min_score is not None else None
-        ),
+        tailor_judge_model=(str(params["tailorJudgeModel"]) if params.get("tailorJudgeModel") else None),
+        tailor_judge_min_score=(float(raw_judge_min_score) if raw_judge_min_score is not None else None),
         llm_model=str(params.get("llmModel") or DEFAULT_PIPELINE_LLM_MODEL_SPEC),
         expected_app_dir=params.get("expectedAppDir"),
         expected_db_path=params.get("expectedDbPath"),
@@ -356,18 +348,10 @@ def tailor_job(params: dict[str, Any]) -> WorkflowStartSpec:
         workers=int(params.get("workers", 1)),
         validation_mode=str(params.get("validationMode", "normal")),
         retailor=False,
-        allow_low_fit_override=_bool_param(
-            params, "allowLowFitOverride", default=True
-        ),
+        allow_low_fit_override=_bool_param(params, "allowLowFitOverride", default=True),
         tailor_models=tuple(str(item) for item in (params.get("tailorModels") or ())),
-        tailor_judge_model=(
-            str(params["tailorJudgeModel"])
-            if params.get("tailorJudgeModel")
-            else None
-        ),
-        tailor_judge_min_score=(
-            float(raw_judge_min_score) if raw_judge_min_score is not None else None
-        ),
+        tailor_judge_model=(str(params["tailorJudgeModel"]) if params.get("tailorJudgeModel") else None),
+        tailor_judge_min_score=(float(raw_judge_min_score) if raw_judge_min_score is not None else None),
         llm_model=str(params.get("llmModel") or DEFAULT_PIPELINE_LLM_MODEL_SPEC),
         expected_app_dir=params.get("expectedAppDir"),
         expected_db_path=params.get("expectedDbPath"),
@@ -461,8 +445,7 @@ def _browser_status_payload(status: Any) -> dict[str, object]:
         "detail": status.detail,
         "mutable": status.id != "core-browser",
         "enabled": status.id == "core-browser" or status.status != "disabled",
-        "profileCopyReady": status.id == "authenticated-linkedin-browser"
-        and status.status == "ready",
+        "profileCopyReady": status.id == "authenticated-linkedin-browser" and status.status == "ready",
     }
 
 
@@ -473,10 +456,7 @@ def _browser_capabilities_payload() -> dict[str, object]:
 
     return {
         "capabilities": [_browser_status_payload(item) for item in list_browser_capabilities()],
-        "detectedBrowsers": [
-            {"id": browser.id, "label": browser.label}
-            for browser in detect_supported_browsers()
-        ],
+        "detectedBrowsers": [{"id": browser.id, "label": browser.label} for browser in detect_supported_browsers()],
     }
 
 
@@ -567,9 +547,7 @@ def retailor_current_policy(params: dict[str, Any]) -> WorkflowStartSpec:
         retailor=True,
         job_ids=_job_ids(params),
         tailor_current_policy_only=True,
-        suppress_existing_artifacts=_bool_param(
-            params, "suppressExistingArtifacts", default=False
-        ),
+        suppress_existing_artifacts=_bool_param(params, "suppressExistingArtifacts", default=False),
     )
 
 
@@ -629,19 +607,20 @@ def manual_capture_import(params: dict[str, Any]) -> WorkflowStartSpec:
 # ---------------------------------------------------------------------------
 
 
-def _apply_workflow_id(tenant_id: str, job_key: str) -> str:
-    """Deterministic ``apply-{tenant}-{jobKey}`` id so a double-click apply for one job
+def _apply_workflow_id(tenant_id: str, job_id: str) -> str:
+    """Deterministic ``apply-{tenant}-{jobId}`` id so a double-click apply for one job
     attaches to the running workflow (USE_EXISTING) instead of double-submitting.
     """
-    return apply_workflow_id(tenant_id, job_key)
+    return apply_workflow_id(tenant_id, job_id)
 
 
 def apply_action(params: dict[str, Any]) -> WorkflowStartSpec:
     """Build a :class:`WorkflowStartSpec` for :class:`ApplyWorkflow`."""
     try:
+        _reject_job_url_params(params)
         if "jobIds" in params:
             raise invalid_params("jobIds is not supported by apply; use jobId")
-        return build_apply_workflow_spec(_legacy_workflow_locator_params(params))
+        return build_apply_workflow_spec(params)
     except ValueError as exc:
         raise invalid_params(str(exc)) from exc
 

--- a/workers/automation/src/jobctrl/operational_metrics.py
+++ b/workers/automation/src/jobctrl/operational_metrics.py
@@ -15,6 +15,7 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any
 
+from jobctrl.domain.identifiers import canonical_job_id
 from jobctrl.domain.tenant import LOCAL_TENANT
 
 
@@ -49,7 +50,7 @@ def ensure_operational_metric_tables(conn: sqlite3.Connection) -> list[str]:
             is_scrape_failure       INTEGER NOT NULL DEFAULT 0,
             is_retryable            INTEGER NOT NULL DEFAULT 1,
             run_id                  TEXT,
-            job_url                 TEXT,
+            job_id                  TEXT,
             duration_ms             INTEGER,
             total_count             INTEGER,
             new_count               INTEGER,
@@ -92,9 +93,7 @@ def classify_failure(
     adapter_lower = (adapter or "").lower()
 
     if normalized_class == "TypeError" and (
-        "lambda" in message_lower
-        or "<lambda>" in normalized_message
-        or "unexpected keyword argument" in message_lower
+        "lambda" in message_lower or "<lambda>" in normalized_message or "unexpected keyword argument" in message_lower
     ):
         return FailureClassification("test_harness", False, False, False)
     if "aborted_for_code_reload" in message_lower or class_lower == "aborted_for_code_reload":
@@ -107,7 +106,8 @@ def classify_failure(
         return FailureClassification(
             "timeout",
             True,
-            stage_lower in SCRAPE_STAGES or adapter_lower in {"browser", "jobspy", "workday", "smartextract", "ats_api"},
+            stage_lower in SCRAPE_STAGES
+            or adapter_lower in {"browser", "jobspy", "workday", "smartextract", "ats_api"},
             True,
         )
     if not normalized_class and not normalized_message:
@@ -132,6 +132,10 @@ def record_operational_attempt_metric(
     source_role: str | None = None,
     adapter: str | None = None,
     run_id: str | None = None,
+    tenant_id: str | None = None,
+    job_id: str | None = None,
+    # Accepted for legacy callers at an explicit locator boundary, but never
+    # persisted in the broad operational read model.
     job_url: str | None = None,
     duration_ms: int | None = None,
     counts: dict[str, Any] | None = None,
@@ -146,6 +150,7 @@ def record_operational_attempt_metric(
 ) -> None:
     ensure_operational_metric_tables(conn)
     counts = counts or {}
+    stable_job_id = canonical_job_id(str(job_id)) if job_id is not None else None
     terminal_failure = outcome in {"failed", "partial_failed"}
     classification = (
         classify_failure(
@@ -163,13 +168,13 @@ def record_operational_attempt_metric(
             tenant_id, occurred_at, stage, source_id, source_kind,
             source_priority, source_role, adapter, attempt_kind, outcome,
             failure_category, is_operational_failure, is_scrape_failure,
-            is_retryable, run_id, job_url, duration_ms, total_count,
+            is_retryable, run_id, job_id, duration_ms, total_count,
             new_count, existing_count, observed_count, duplicate_count,
             error_class, error_message, metadata_json
         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """,
         (
-            str(LOCAL_TENANT),
+            str(tenant_id or LOCAL_TENANT),
             occurred_at or utc_now(),
             stage,
             source_id,
@@ -179,7 +184,9 @@ def record_operational_attempt_metric(
             adapter,
             attempt_kind,
             outcome,
-            failure_category if failure_category is not None else (classification.failure_category if classification else None),
+            failure_category
+            if failure_category is not None
+            else (classification.failure_category if classification else None),
             _bool_int(
                 is_operational_failure
                 if is_operational_failure is not None
@@ -191,12 +198,10 @@ def record_operational_attempt_metric(
                 else (classification.is_scrape_failure if classification else False)
             ),
             _bool_int(
-                is_retryable
-                if is_retryable is not None
-                else (classification.is_retryable if classification else True)
+                is_retryable if is_retryable is not None else (classification.is_retryable if classification else True)
             ),
             run_id,
-            job_url,
+            str(stable_job_id) if stable_job_id is not None else None,
             duration_ms,
             _count(counts, "total"),
             _count(counts, "new_jobs", "newJobs", "new"),
@@ -233,7 +238,6 @@ def _snake_case(value: str) -> str:
     if raw.upper() == raw:
         return "_".join(part.lower() for part in re.split(r"[^A-Za-z0-9]+", raw) if part) or "unknown"
     normalized = "".join(
-        f"_{char.lower()}" if char.isupper() else (char.lower() if char.isalnum() else "_")
-        for char in raw
+        f"_{char.lower()}" if char.isupper() else (char.lower() if char.isalnum() else "_") for char in raw
     )
     return "_".join(part for part in normalized.split("_") if part) or "unknown"

--- a/workers/automation/src/jobctrl/pipeline/runner.py
+++ b/workers/automation/src/jobctrl/pipeline/runner.py
@@ -2816,14 +2816,23 @@ def run_single_job(
 ) -> dict:
     """Start the single-job Temporal workflow path and wait for its result."""
     from jobctrl.config import APP_DIR, DB_PATH
+    from jobctrl.domain.discovery.value_objects import PostingUrl
+    from jobctrl.infrastructure.discovery import SqliteJobIdentityResolver
     from jobctrl.workflow_specs import (
         build_single_job_workflow_spec,
         start_workflow_spec_and_wait_sync,
         workflow_result_to_dict,
     )
 
+    identity = SqliteJobIdentityResolver(get_connection()).resolve_current_by_posting_url(
+        LOCAL_TENANT,
+        PostingUrl(value=url),
+    )
+    if identity is None:
+        raise ValueError(f"No current job found for URL: {url}")
+
     spec = build_single_job_workflow_spec(
-        url,
+        str(identity.job_id),
         do_tailor=do_tailor,
         do_apply=do_apply,
         validation_mode=validation_mode,

--- a/workers/automation/src/jobctrl/pipeline/workflow.py
+++ b/workers/automation/src/jobctrl/pipeline/workflow.py
@@ -10,6 +10,8 @@ from temporalio import workflow
 from temporalio.common import RetryPolicy
 from temporalio.exceptions import ActivityError, ApplicationError, CancelledError
 
+from jobctrl.domain.identifiers import JobId, canonical_job_id
+
 with workflow.unsafe.imports_passed_through():
     from jobctrl.apply.workflow import ApplyWorkflow, ApplyWorkflowInput
     from jobctrl.discovery.workflow import DiscoverWorkflow, DiscoverWorkflowInput
@@ -65,6 +67,8 @@ class JobPipelineWorkflowInput:
     tailor_judge_min_score: float | None = None
     job_url: str | None = None
     job_urls: tuple[str, ...] = ()
+    apply_job_id: JobId | None = None
+    apply_selector_keys: tuple[str, ...] = ()
     source_ids: tuple[str, ...] = ()
     score_current_policy_only: bool = False
     tailor_current_policy_only: bool = False
@@ -74,6 +78,14 @@ class JobPipelineWorkflowInput:
     model: str = "default"
     llm_model: str = DEFAULT_PIPELINE_LLM_MODEL_SPEC
     continuous: bool = False
+
+    def __post_init__(self) -> None:
+        if self.apply_job_id is not None:
+            object.__setattr__(
+                self,
+                "apply_job_id",
+                canonical_job_id(str(self.apply_job_id)),
+            )
 
 
 @dataclass(frozen=True)
@@ -198,9 +210,7 @@ class JobPipelineWorkflow:
             )
         return result
 
-    async def _execute_stages(
-        self, payload: JobPipelineWorkflowInput
-    ) -> JobPipelineWorkflowResult:
+    async def _execute_stages(self, payload: JobPipelineWorkflowInput) -> JobPipelineWorkflowResult:
         completed: list[str] = []
         failed: list[str] = []
         failure: str | None = None
@@ -353,13 +363,14 @@ async def _execute_stage(stage: str, payload: JobPipelineWorkflowInput) -> Any:
             retry_policy=_COVER_RETRY,
         )
     if stage == "apply":
+        apply_job_id = _apply_child_job_id(payload)
         return await workflow.execute_child_workflow(
             ApplyWorkflow.run,
             ApplyWorkflowInput(
                 tenant_id=payload.tenant_id,
                 expected_app_dir=payload.expected_app_dir,
                 expected_db_path=payload.expected_db_path,
-                job_url=payload.job_url,
+                job_id=apply_job_id,
                 dry_run=payload.dry_run,
                 headless=payload.headless,
                 model=payload.model,
@@ -436,6 +447,24 @@ def _selected_job_urls(payload: JobPipelineWorkflowInput) -> tuple[str, ...]:
 
 def _has_selected_job_scope(payload: JobPipelineWorkflowInput) -> bool:
     return bool(payload.job_url or payload.job_urls)
+
+
+def _apply_child_job_id(payload: JobPipelineWorkflowInput) -> JobId | None:
+    """Validate the preserved selector shape before starting an Apply child."""
+
+    selector_keys = tuple(payload.apply_selector_keys)
+    legacy_scope_present = payload.job_url is not None or bool(payload.job_urls)
+    if not selector_keys:
+        if payload.apply_job_id is None and not legacy_scope_present:
+            return None
+    elif selector_keys == ("jobId",):
+        if payload.apply_job_id is not None and not legacy_scope_present:
+            return canonical_job_id(str(payload.apply_job_id))
+
+    raise ApplicationError(
+        "apply accepts only a canonical jobId; omit all selector keys for batch apply",
+        non_retryable=True,
+    )
 
 
 def _approved_tailor_job_urls(result: Any) -> tuple[str, ...] | None:

--- a/workers/automation/src/jobctrl/workflow_specs.py
+++ b/workers/automation/src/jobctrl/workflow_specs.py
@@ -20,6 +20,7 @@ from jobctrl.discovery.workflow import (
     discover_workflow_id,
 )
 from jobctrl.domain.discovery.source_registry import ManualCaptureMode
+from jobctrl.domain.identifiers import canonical_job_id
 from jobctrl.domain.rpc.messages import WorkflowStartSpec
 from jobctrl.domain.tenant import LOCAL_TENANT
 from jobctrl.interview.workflow import InterviewPrepWorkflow, InterviewPrepWorkflowInput
@@ -29,6 +30,7 @@ from jobctrl.pipeline.workflow import JobPipelineWorkflow, JobPipelineWorkflowIn
 
 WORKFLOW_STAGES = {"discover", "enrich", "score", "tailor", "cover", "apply"}
 _WORKFLOW_STAGE_ORDER = ("discover", "enrich", "score", "tailor", "cover", "apply")
+_APPLY_SELECTOR_KEYS = ("jobId", "jobIds", "jobUrl", "jobUrls")
 logger = logging.getLogger(__name__)
 
 
@@ -51,6 +53,7 @@ class StartedWorkflowResult:
 def build_run_stage_workflow_spec(params: dict[str, Any]) -> WorkflowStartSpec:
     tenant_id = _tenant_id(params)
     stages = _stage_list(params)
+    apply_selector = _apply_selector(params) if "apply" in stages else None
     if "apply" in stages:
         _require_auto_apply_browser_capability()
     raw_judge_min_score = params.get("tailorJudgeMinScore")
@@ -65,9 +68,7 @@ def build_run_stage_workflow_spec(params: dict[str, Any]) -> WorkflowStartSpec:
             validation_mode=str(params.get("validationMode", "normal")),
             tailor_models=tuple(str(item) for item in (params.get("tailorModels") or ())),
             tailor_judge_model=str(params["tailorJudgeModel"]) if params.get("tailorJudgeModel") else None,
-            tailor_judge_min_score=(
-                float(raw_judge_min_score) if raw_judge_min_score is not None else None
-            ),
+            tailor_judge_min_score=(float(raw_judge_min_score) if raw_judge_min_score is not None else None),
             source_ids=_source_ids(params),
             llm_model=str(params.get("llmModel") or DEFAULT_PIPELINE_LLM_MODEL_SPEC),
         )
@@ -90,11 +91,11 @@ def build_run_stage_workflow_spec(params: dict[str, Any]) -> WorkflowStartSpec:
         retailor=bool(params.get("retailor", False)),
         tailor_models=tuple(str(item) for item in (params.get("tailorModels") or ())),
         tailor_judge_model=str(params["tailorJudgeModel"]) if params.get("tailorJudgeModel") else None,
-        tailor_judge_min_score=(
-            float(raw_judge_min_score) if raw_judge_min_score is not None else None
-        ),
+        tailor_judge_min_score=(float(raw_judge_min_score) if raw_judge_min_score is not None else None),
         job_url=params.get("jobUrl") if params.get("jobUrl") else None,
         job_urls=_job_urls(params),
+        apply_job_id=apply_selector.job_id if apply_selector else None,
+        apply_selector_keys=apply_selector.keys if apply_selector else (),
         source_ids=_source_ids(params),
         headless=bool(params.get("headless", False)),
         model=str(params.get("model", "default")),
@@ -118,6 +119,7 @@ def build_pipeline_workflow_spec(
     suppress_existing_artifacts: bool = False,
     allow_low_fit_override: bool = False,
 ) -> WorkflowStartSpec:
+    apply_selector = _apply_selector(params, job_url=job_url, job_urls=job_urls) if "apply" in stages else None
     if "apply" in stages:
         _require_auto_apply_browser_capability()
     tenant_id = _tenant_id(params)
@@ -136,11 +138,11 @@ def build_pipeline_workflow_spec(
         retailor=retailor,
         tailor_models=tuple(str(item) for item in (params.get("tailorModels") or ())),
         tailor_judge_model=str(params["tailorJudgeModel"]) if params.get("tailorJudgeModel") else None,
-        tailor_judge_min_score=(
-            float(raw_judge_min_score) if raw_judge_min_score is not None else None
-        ),
+        tailor_judge_min_score=(float(raw_judge_min_score) if raw_judge_min_score is not None else None),
         job_url=job_url,
         job_urls=job_urls,
+        apply_job_id=apply_selector.job_id if apply_selector else None,
+        apply_selector_keys=apply_selector.keys if apply_selector else (),
         score_current_policy_only=score_current_policy_only,
         tailor_current_policy_only=tailor_current_policy_only,
         suppress_existing_artifacts=suppress_existing_artifacts,
@@ -151,14 +153,14 @@ def build_pipeline_workflow_spec(
 
 
 def build_apply_workflow_spec(params: dict[str, Any]) -> WorkflowStartSpec:
-    _require_auto_apply_browser_capability()
     tenant_id = _tenant_id(params)
-    job_url = params.get("jobUrl")
+    selector = _apply_selector(params)
+    _require_auto_apply_browser_capability()
     payload = ApplyWorkflowInput(
         tenant_id=tenant_id,
         expected_app_dir=params.get("expectedAppDir"),
         expected_db_path=params.get("expectedDbPath"),
-        job_url=job_url,
+        job_id=selector.job_id,
         dry_run=bool(params.get("dryRun", False)),
         headless=bool(params.get("headless", False)),
         model=str(params.get("model", "default")),
@@ -168,8 +170,46 @@ def build_apply_workflow_spec(params: dict[str, Any]) -> WorkflowStartSpec:
         continuous=bool(params.get("continuous", False)),
         approval_required=bool(params.get("applyApprovalRequired", True)),
     )
-    workflow_id = apply_workflow_id(tenant_id, str(job_url)) if job_url else None
+    workflow_id = apply_workflow_id(tenant_id, str(selector.job_id)) if selector.job_id is not None else None
     return WorkflowStartSpec(workflow=ApplyWorkflow, args=(payload,), workflow_id=workflow_id)
+
+
+@dataclass(frozen=True)
+class _ApplySelector:
+    """The only selector shape permitted to start an Apply workflow."""
+
+    keys: tuple[str, ...] = ()
+    job_id: str | None = None
+
+
+def _apply_selector(
+    params: dict[str, Any],
+    *,
+    job_url: str | None = None,
+    job_urls: tuple[str, ...] = (),
+) -> _ApplySelector:
+    """Preserve selector key presence so invalid scopes cannot become batch Apply.
+
+    Batch Apply is intentional only when callers supplied none of the known
+    selector keys. A canonical singular ``jobId`` is the sole targeted shape;
+    URL selectors and plural ``jobIds`` cannot safely cross the Apply boundary.
+    """
+
+    keys = tuple(key for key in _APPLY_SELECTOR_KEYS if key in params)
+    if job_url is not None and "jobUrl" not in keys:
+        keys += ("jobUrl",)
+    if job_urls and "jobUrls" not in keys:
+        keys += ("jobUrls",)
+
+    if not keys:
+        return _ApplySelector()
+    if keys != ("jobId",):
+        raise ValueError("apply accepts only a canonical jobId; omit all selector keys for batch apply")
+
+    raw_job_id = params["jobId"]
+    if not isinstance(raw_job_id, str) or not raw_job_id.strip():
+        raise ValueError("apply jobId must be a non-empty canonical UUID")
+    return _ApplySelector(keys=keys, job_id=canonical_job_id(raw_job_id))
 
 
 def _require_auto_apply_browser_capability() -> None:
@@ -294,15 +334,9 @@ def build_compensation_refresh_workflow_spec(params: dict[str, Any]) -> Workflow
         job_url=str(job_url_param) if job_url_param else None,
         limit=int(params.get("limit") or 0),
         include_euro_top_tech=(
-            bool(params["includeEuroTopTech"])
-            if params.get("includeEuroTopTech") is not None
-            else True
+            bool(params["includeEuroTopTech"]) if params.get("includeEuroTopTech") is not None else True
         ),
-        observations_json_path=(
-            str(params["observationsJsonPath"])
-            if params.get("observationsJsonPath")
-            else None
-        ),
+        observations_json_path=(str(params["observationsJsonPath"]) if params.get("observationsJsonPath") else None),
         euro_top_tech_max_pages=int(params.get("euroTopTechMaxPages") or 10),
     )
     return WorkflowStartSpec(workflow=CompensationRefreshWorkflow, args=(payload,))
@@ -346,9 +380,7 @@ def build_manual_capture_import_workflow_spec(
     )
     captured_url = _optional_string(params, "capturedUrl")
     if content_text is None and content_html_base64 is None and captured_url is None:
-        raise ValueError(
-            "one of contentText, contentHtmlBase64, or capturedUrl is required"
-        )
+        raise ValueError("one of contentText, contentHtmlBase64, or capturedUrl is required")
     future_manual_action_required = params.get("futureManualActionRequired", False)
     if not isinstance(future_manual_action_required, bool):
         raise ValueError("futureManualActionRequired must be a boolean")
@@ -371,8 +403,8 @@ def build_manual_capture_import_workflow_spec(
     )
 
 
-def apply_workflow_id(tenant_id: str, job_key: str) -> str:
-    return f"apply-{tenant_id}-{job_key}"
+def apply_workflow_id(tenant_id: str, job_id: str) -> str:
+    return f"apply-{tenant_id}-{canonical_job_id(job_id)}"
 
 
 def interview_prep_workflow_id(tenant_id: str, job_key: str) -> str:

--- a/workers/automation/tests/test_actions.py
+++ b/workers/automation/tests/test_actions.py
@@ -1,3 +1,4 @@
+import json
 from io import StringIO
 from pathlib import Path
 
@@ -11,6 +12,9 @@ from jobctrl.actions import LocalActionRequest, run_local_action
 from jobctrl.cli import app
 from jobctrl.database import close_connection, get_connection, init_db
 from jobctrl.workflow_specs import StartedWorkflowResult, build_run_stage_workflow_spec
+
+APPLY_JOB_ID = "90000000-0000-4000-8000-000000000001"
+APPLY_URL = "https://example.com/job"
 
 
 @pytest.fixture(autouse=True)
@@ -31,6 +35,26 @@ def _started(result: dict | None = None) -> StartedWorkflowResult:
         first_execution_run_id="first-test",
         result=result or {"status": "succeeded"},
     )
+
+
+def _insert_apply_target(conn) -> None:
+    conn.execute(
+        """
+        INSERT INTO jobs (tenant_id, job_id, url, title, company, site, discovered_at)
+        VALUES ('local', ?, ?, 'Platform Engineer', 'Example', 'Example', '2026-07-31T12:00:00+00:00')
+        """,
+        (APPLY_JOB_ID, APPLY_URL),
+    )
+    conn.execute(
+        """
+        INSERT INTO job_locators (
+            tenant_id, job_id, locator_kind, locator_value, is_current,
+            first_seen_at, last_seen_at
+        ) VALUES ('local', ?, 'posting_url', ?, 1, '2026-07-31T12:00:00+00:00', '2026-07-31T12:00:00+00:00')
+        """,
+        (APPLY_JOB_ID, APPLY_URL),
+    )
+    conn.commit()
 
 
 def test_local_stage_action_records_events(tmp_path, monkeypatch):
@@ -111,9 +135,7 @@ def test_tailor_action_fails_when_pipeline_reports_quality_gate_failure(tmp_path
     try:
         result = run_local_action(LocalActionRequest(stage="tailor"))
         conn = get_connection(db_path)
-        failure = conn.execute(
-            "SELECT event_type, level FROM job_events ORDER BY event_id DESC LIMIT 1"
-        ).fetchone()
+        failure = conn.execute("SELECT event_type, level FROM job_events ORDER BY event_id DESC LIMIT 1").fetchone()
 
         assert result.ok is False
         assert result.status == "failed"
@@ -137,7 +159,9 @@ def test_local_action_returns_structured_failure(tmp_path, monkeypatch):
 
     try:
         result = run_local_action(LocalActionRequest(stage="tailor"))
-        failure = conn.execute("SELECT event_type, level, message FROM job_events ORDER BY event_id DESC LIMIT 1").fetchone()
+        failure = conn.execute(
+            "SELECT event_type, level, message FROM job_events ORDER BY event_id DESC LIMIT 1"
+        ).fetchone()
 
         assert result.ok is False
         assert result.status == "failed"
@@ -219,7 +243,8 @@ def test_profile_import_dry_run_returns_plan_without_starting_workflow(monkeypat
 
 def test_apply_action_propagates_failed_count(tmp_path, monkeypatch):
     db_path = Path(tmp_path) / "jobs.db"
-    init_db(db_path)
+    conn = init_db(db_path)
+    _insert_apply_target(conn)
 
     monkeypatch.setattr(actions, "_bootstrap_runtime", lambda: None)
     monkeypatch.setattr(actions, "get_connection", lambda: get_connection(db_path))
@@ -230,7 +255,7 @@ def test_apply_action_propagates_failed_count(tmp_path, monkeypatch):
     )
 
     try:
-        result = run_local_action(LocalActionRequest(stage="apply", job_url="https://example.com/job", limit=1))
+        result = run_local_action(LocalActionRequest(stage="apply", job_url=APPLY_URL, limit=1))
 
         assert result.ok is False
         assert result.status == "failed"
@@ -241,7 +266,8 @@ def test_apply_action_propagates_failed_count(tmp_path, monkeypatch):
 
 def test_apply_action_uses_single_job_default_limit(tmp_path, monkeypatch):
     db_path = Path(tmp_path) / "jobs.db"
-    init_db(db_path)
+    conn = init_db(db_path)
+    _insert_apply_target(conn)
     specs = []
 
     monkeypatch.setattr(actions, "_bootstrap_runtime", lambda: None)
@@ -253,19 +279,59 @@ def test_apply_action_uses_single_job_default_limit(tmp_path, monkeypatch):
     )
 
     try:
-        result = run_local_action(LocalActionRequest(stage="apply", job_url="https://example.com/job"))
+        result = run_local_action(LocalActionRequest(stage="apply", job_url=APPLY_URL))
 
         assert result.ok is True
         payload = specs[0].args[0]
+        assert payload.job_id == APPLY_JOB_ID
         assert payload.limit == 1
         assert payload.continuous is False
+        event_job_ids = [
+            row["job_id"]
+            for row in conn.execute("SELECT job_id FROM job_events WHERE stage = 'apply' ORDER BY event_id")
+        ]
+        assert event_job_ids == [APPLY_JOB_ID, APPLY_JOB_ID]
+    finally:
+        close_connection(db_path)
+
+
+def test_unresolved_apply_locator_records_sanitized_stage_level_failure(tmp_path, monkeypatch):
+    db_path = Path(tmp_path) / "jobs.db"
+    conn = init_db(db_path)
+
+    monkeypatch.setattr(actions, "_bootstrap_runtime", lambda: None)
+    monkeypatch.setattr(actions, "get_connection", lambda: get_connection(db_path))
+
+    try:
+        locator = "https://example.com/missing?private-token=do-not-persist"
+        result = run_local_action(LocalActionRequest(stage="apply", job_url=locator))
+        failure = conn.execute(
+            """
+            SELECT event_type, job_id, level, message, payload_json
+            FROM job_events
+            ORDER BY event_id DESC
+            LIMIT 1
+            """
+        ).fetchone()
+
+        assert result.ok is False
+        assert result.error == "apply_job_locator_unresolved"
+        assert (failure["event_type"], failure["job_id"], failure["level"]) == (
+            "ActionFailed",
+            None,
+            "error",
+        )
+        payload = json.loads(failure["payload_json"])
+        assert payload["error"] == "apply_job_locator_unresolved"
+        assert locator not in f"{failure['message']} {failure['payload_json']}"
     finally:
         close_connection(db_path)
 
 
 def test_action_cli_passes_apply_model_and_headless_options(tmp_path, monkeypatch):
     db_path = Path(tmp_path) / "jobs.db"
-    init_db(db_path)
+    conn = init_db(db_path)
+    _insert_apply_target(conn)
     specs = []
 
     monkeypatch.setattr(actions, "_bootstrap_runtime", lambda: None)
@@ -283,7 +349,7 @@ def test_action_cli_passes_apply_model_and_headless_options(tmp_path, monkeypatc
                 "action",
                 "apply",
                 "--url",
-                "https://example.com/job",
+                APPLY_URL,
                 "--model",
                 "sonnet",
                 "--headless",
@@ -292,6 +358,7 @@ def test_action_cli_passes_apply_model_and_headless_options(tmp_path, monkeypatc
 
         assert result.exit_code == 0
         payload = specs[0].args[0]
+        assert payload.job_id == APPLY_JOB_ID
         assert payload.model == "sonnet"
         assert payload.headless is True
     finally:

--- a/workers/automation/tests/test_activity_apply.py
+++ b/workers/automation/tests/test_activity_apply.py
@@ -21,6 +21,14 @@ from jobctrl.apply.activities import (
 )
 
 
+JOB_ID = "90000000-0000-4000-8000-000000000001"
+
+
+def test_apply_activity_input_rejects_url_shaped_job_id() -> None:
+    with pytest.raises(ValueError, match="canonical UUID"):
+        ApplyActivityInput(tenant_id="local", job_id="https://example.com/job")
+
+
 @pytest.fixture(autouse=True)
 def permit_browser_for_existing_apply_activity_tests(monkeypatch: pytest.MonkeyPatch) -> None:
     """Activity behavior tests run after the separate capability check."""
@@ -66,7 +74,7 @@ async def test_apply_activity_invokes_apply_main_and_returns_ok():
                     _ApplyHarness.run,
                     ApplyActivityInput(
                         tenant_id="local",
-                        job_url="https://example.com/job",
+                        job_id=JOB_ID,
                         limit=2,
                         min_score=8,
                         model="haiku",
@@ -79,7 +87,8 @@ async def test_apply_activity_invokes_apply_main_and_returns_ok():
     apply_main_mock.assert_called_once()
     kwargs = apply_main_mock.call_args.kwargs
     assert kwargs["limit"] == 2
-    assert kwargs["target_url"] == "https://example.com/job"
+    assert kwargs["target_job_id"] == JOB_ID
+    assert kwargs["tenant_id"] == "local"
     assert kwargs["min_score"] == 8
     assert kwargs["headless"] is True
     assert kwargs["model"] == "haiku"

--- a/workers/automation/tests/test_apply_regressions.py
+++ b/workers/automation/tests/test_apply_regressions.py
@@ -31,6 +31,7 @@ from jobctrl.apply.launcher import (
 from jobctrl.apply.dashboard import get_recent_events
 from jobctrl.apply.origins import canonical_http_url
 from jobctrl.database import close_connection, get_connection, init_db
+from jobctrl.domain.tenant import LOCAL_TENANT
 from jobctrl.infrastructure.projections.projection_builder import ProjectionBuilder
 from jobctrl.state import ensure_job_stage_rows, record_job_event, set_stage_state, utc_now
 from jobctrl.workflow_specs import StartedWorkflowResult
@@ -74,9 +75,7 @@ def _insert_ready_job(
     conn.commit()
 
 
-def _insert_single_job_tailor_candidate(
-    conn, *, url: str = "https://example.com/job"
-) -> None:
+def _insert_single_job_tailor_candidate(conn, *, url: str = "https://example.com/job") -> None:
     conn.execute(
         """
         INSERT INTO jobs (
@@ -93,6 +92,15 @@ def _insert_single_job_tailor_candidate(
         ),
     )
     conn.commit()
+
+
+def _target_job_id(conn, url: str = "https://example.com/job") -> str:
+    row = conn.execute(
+        "SELECT job_id FROM jobs WHERE tenant_id = ? AND url = ? LIMIT 1",
+        (LOCAL_TENANT, url),
+    ).fetchone()
+    assert row is not None
+    return str(row["job_id"])
 
 
 def _insert_blocked_score(conn, url: str, *, fit_score: int = 9) -> None:
@@ -124,9 +132,7 @@ def _insert_blocked_score(conn, url: str, *, fit_score: int = 9) -> None:
 
 
 def test_unsafe_url_failure_is_permanent() -> None:
-    assert launcher_module._is_permanent_failure(
-        "failed:unsafe_url: URL host is not a public address: 127.0.0.1"
-    )
+    assert launcher_module._is_permanent_failure("failed:unsafe_url: URL host is not a public address: 127.0.0.1")
 
 
 def _mark_closed(conn: sqlite3.Connection, url: str, state: str = "removed") -> None:
@@ -275,25 +281,20 @@ def test_targeted_apply_takes_canonical_stage_lock(tmp_path, monkeypatch):
     _insert_ready_job(conn)
 
     try:
-        monkeypatch.setattr(
-            "jobctrl.apply.launcher.get_connection", lambda: get_connection(db_path)
-        )
+        monkeypatch.setattr("jobctrl.apply.launcher.get_connection", lambda: get_connection(db_path))
         job = acquire_job(
-            target_url="https://example.com/job",
+            target_job_id=_target_job_id(conn),
             worker_id=1,
             approval_required=False,
         )
         assert job is not None
         assert job["url"] == "https://example.com/job"
         # Legacy column stays NULL on the new path.
-        legacy = conn.execute(
-            "SELECT apply_status FROM jobs WHERE url = ?", (job["url"],)
-        ).fetchone()
+        legacy = conn.execute("SELECT apply_status FROM jobs WHERE url = ?", (job["url"],)).fetchone()
         assert legacy["apply_status"] is None
         # Canonical lock: stage row in 'running'.
         stage = conn.execute(
-            "SELECT state FROM job_stage_states "
-            "WHERE job_url = ? AND stage = 'apply'",
+            "SELECT state FROM job_stage_states WHERE job_url = ? AND stage = 'apply'",
             (job["url"],),
         ).fetchone()
         assert stage is not None
@@ -332,20 +333,15 @@ def test_apply_approval_gate_blocks_live_without_approval(tmp_path, monkeypatch)
     _insert_ready_job(conn)
 
     try:
-        monkeypatch.setattr(
-            "jobctrl.apply.launcher.get_connection", lambda: get_connection(db_path)
-        )
+        monkeypatch.setattr("jobctrl.apply.launcher.get_connection", lambda: get_connection(db_path))
         prior_event_count = len(get_recent_events())
-        assert acquire_job(target_url="https://example.com/job", worker_id=1) is None
+        assert acquire_job(target_job_id=_target_job_id(conn), worker_id=1) is None
         row = conn.execute(
             "SELECT state FROM job_stage_states WHERE job_url = ? AND stage = 'apply'",
             ("https://example.com/job",),
         ).fetchone()
         assert row is None or row["state"] == "pending"
-        assert any(
-            "Awaiting apply approval" in event
-            for event in get_recent_events()[prior_event_count:]
-        )
+        assert any("Awaiting apply approval" in event for event in get_recent_events()[prior_event_count:])
     finally:
         close_connection(db_path)
 
@@ -362,9 +358,7 @@ def test_approval_required_apply_loop_never_runs_browser_for_unapproved_job(
         raise AssertionError("unapproved live job reached browser automation")
 
     try:
-        monkeypatch.setattr(
-            "jobctrl.apply.launcher.get_connection", lambda: get_connection(db_path)
-        )
+        monkeypatch.setattr("jobctrl.apply.launcher.get_connection", lambda: get_connection(db_path))
         monkeypatch.setattr(launcher_module, "run_job", fail_run_job)
 
         applied, failed = worker_loop(
@@ -390,11 +384,9 @@ def test_apply_approval_gate_can_be_disabled_or_bypassed_for_dry_run(tmp_path, m
     _insert_ready_job(conn)
 
     try:
-        monkeypatch.setattr(
-            "jobctrl.apply.launcher.get_connection", lambda: get_connection(db_path)
-        )
+        monkeypatch.setattr("jobctrl.apply.launcher.get_connection", lambda: get_connection(db_path))
         job = acquire_job(
-            target_url="https://example.com/job",
+            target_job_id=_target_job_id(conn),
             worker_id=1,
             approval_required=False,
         )
@@ -403,7 +395,7 @@ def test_apply_approval_gate_can_be_disabled_or_bypassed_for_dry_run(tmp_path, m
         conn.commit()
 
         dry_job = acquire_job(
-            target_url="https://example.com/job",
+            target_job_id=_target_job_id(conn),
             worker_id=1,
             run_ctx={"dry_run": True},
             approval_required=True,
@@ -435,10 +427,8 @@ def test_apply_approval_gate_requires_latest_approve_submit(tmp_path, monkeypatc
     )
 
     try:
-        monkeypatch.setattr(
-            "jobctrl.apply.launcher.get_connection", lambda: get_connection(db_path)
-        )
-        assert acquire_job(target_url="https://example.com/job", worker_id=1) is None
+        monkeypatch.setattr("jobctrl.apply.launcher.get_connection", lambda: get_connection(db_path))
+        assert acquire_job(target_job_id=_target_job_id(conn), worker_id=1) is None
         _insert_review_decision(
             conn,
             decision="approve_submit",
@@ -448,7 +438,7 @@ def test_apply_approval_gate_requires_latest_approve_submit(tmp_path, monkeypatc
             profile_version=1,
             application_url="https://example.com/apply",
         )
-        assert acquire_job(target_url="https://example.com/job", worker_id=1) is not None
+        assert acquire_job(target_job_id=_target_job_id(conn), worker_id=1) is not None
     finally:
         close_connection(db_path)
 
@@ -467,15 +457,10 @@ def test_apply_approval_gate_requires_matching_full_dry_run(tmp_path, monkeypatc
     )
 
     try:
-        monkeypatch.setattr(
-            "jobctrl.apply.launcher.get_connection", lambda: get_connection(db_path)
-        )
+        monkeypatch.setattr("jobctrl.apply.launcher.get_connection", lambda: get_connection(db_path))
         prior_event_count = len(get_recent_events())
-        assert acquire_job(target_url="https://example.com/job", worker_id=1) is None
-        assert any(
-            "awaiting_dry_run" in event
-            for event in get_recent_events()[prior_event_count:]
-        )
+        assert acquire_job(target_job_id=_target_job_id(conn), worker_id=1) is None
+        assert any("awaiting_dry_run" in event for event in get_recent_events()[prior_event_count:])
     finally:
         close_connection(db_path)
 
@@ -487,12 +472,10 @@ def test_normal_dry_run_completion_satisfies_approval_gate(tmp_path, monkeypatch
     _seed_current_apply_binding(conn, coverage=None)
 
     try:
-        monkeypatch.setattr(
-            "jobctrl.apply.launcher.get_connection", lambda: get_connection(db_path)
-        )
+        monkeypatch.setattr("jobctrl.apply.launcher.get_connection", lambda: get_connection(db_path))
         run_ctx: dict = {"dry_run": True}
         dry_run_job = acquire_job(
-            target_url="https://example.com/job",
+            target_job_id=_target_job_id(conn),
             worker_id=1,
             run_ctx=run_ctx,
             approval_required=True,
@@ -509,9 +492,7 @@ def test_normal_dry_run_completion_satisfies_approval_gate(tmp_path, monkeypatch
                 "result": "dry_run_complete",
                 "dry_run": True,
                 "coverage": "full",
-                "allowed_navigations": _run_bound_navigation(
-                    "https://example.com/apply"
-                ),
+                "allowed_navigations": _run_bound_navigation("https://example.com/apply"),
                 "materials_generation": 1,
                 "application_url": "https://example.com/apply",
                 "profile_version": 1,
@@ -533,9 +514,7 @@ def test_normal_dry_run_completion_satisfies_approval_gate(tmp_path, monkeypatch
         assert completion is not None
         payload = json.loads(completion["payload_json"])
         assert payload["coverage"] == "full"
-        assert payload["allowed_navigations"] == _run_bound_navigation(
-            "https://example.com/apply"
-        )
+        assert payload["allowed_navigations"] == _run_bound_navigation("https://example.com/apply")
         assert payload["materials_generation"] == 1
         assert payload["application_url"] == "https://example.com/apply"
 
@@ -549,7 +528,7 @@ def test_normal_dry_run_completion_satisfies_approval_gate(tmp_path, monkeypatch
         )
 
         live_job = acquire_job(
-            target_url="https://example.com/job",
+            target_job_id=_target_job_id(conn),
             worker_id=2,
             approval_required=True,
         )
@@ -568,13 +547,11 @@ def test_full_dry_run_without_navigation_receipt_cannot_satisfy_approval_gate(
     _seed_current_apply_binding(conn, coverage=None)
 
     try:
-        monkeypatch.setattr(
-            "jobctrl.apply.launcher.get_connection", lambda: get_connection(db_path)
-        )
+        monkeypatch.setattr("jobctrl.apply.launcher.get_connection", lambda: get_connection(db_path))
         run_ctx: dict = {"dry_run": True}
         assert (
             acquire_job(
-                target_url="https://example.com/job",
+                target_job_id=_target_job_id(conn),
                 worker_id=1,
                 run_ctx=run_ctx,
                 approval_required=True,
@@ -608,7 +585,7 @@ def test_full_dry_run_without_navigation_receipt_cannot_satisfy_approval_gate(
 
         assert (
             acquire_job(
-                target_url="https://example.com/job",
+                target_job_id=_target_job_id(conn),
                 worker_id=2,
                 approval_required=True,
             )
@@ -621,9 +598,18 @@ def test_full_dry_run_without_navigation_receipt_cannot_satisfy_approval_gate(
 @pytest.mark.parametrize(
     ("decision_bindings", "expected_reason"),
     [
-        ({"materials_generation": 0, "profile_version": 1, "application_url": "https://example.com/apply"}, "approval_stale_materials"),
-        ({"materials_generation": 1, "profile_version": 0, "application_url": "https://example.com/apply"}, "approval_stale_profile"),
-        ({"materials_generation": 1, "profile_version": 1, "application_url": "https://example.com/old-apply"}, "approval_stale_url"),
+        (
+            {"materials_generation": 0, "profile_version": 1, "application_url": "https://example.com/apply"},
+            "approval_stale_materials",
+        ),
+        (
+            {"materials_generation": 1, "profile_version": 0, "application_url": "https://example.com/apply"},
+            "approval_stale_profile",
+        ),
+        (
+            {"materials_generation": 1, "profile_version": 1, "application_url": "https://example.com/old-apply"},
+            "approval_stale_url",
+        ),
     ],
 )
 def test_apply_approval_gate_rejects_stale_bindings(
@@ -639,19 +625,14 @@ def test_apply_approval_gate_rejects_stale_bindings(
     _insert_review_decision(conn, decision="approve_submit", **decision_bindings)
 
     try:
-        monkeypatch.setattr(
-            "jobctrl.apply.launcher.get_connection", lambda: get_connection(db_path)
-        )
+        monkeypatch.setattr("jobctrl.apply.launcher.get_connection", lambda: get_connection(db_path))
         worker_id = {
             "approval_stale_materials": 11,
             "approval_stale_profile": 12,
             "approval_stale_url": 13,
         }[expected_reason]
-        assert acquire_job(target_url="https://example.com/job", worker_id=worker_id) is None
-        assert any(
-            f"[W{worker_id}]" in event and expected_reason in event
-            for event in get_recent_events()
-        )
+        assert acquire_job(target_job_id=_target_job_id(conn), worker_id=worker_id) is None
+        assert any(f"[W{worker_id}]" in event and expected_reason in event for event in get_recent_events())
     finally:
         close_connection(db_path)
 
@@ -671,10 +652,8 @@ def test_apply_approval_gate_accepts_partial_override_bound_to_run(tmp_path, mon
     )
 
     try:
-        monkeypatch.setattr(
-            "jobctrl.apply.launcher.get_connection", lambda: get_connection(db_path)
-        )
-        assert acquire_job(target_url="https://example.com/job", worker_id=1) is not None
+        monkeypatch.setattr("jobctrl.apply.launcher.get_connection", lambda: get_connection(db_path))
+        assert acquire_job(target_job_id=_target_job_id(conn), worker_id=1) is not None
     finally:
         close_connection(db_path)
 
@@ -721,15 +700,10 @@ def test_apply_approval_gate_rejects_dry_run_evidence_for_stale_profile(
     )
 
     try:
-        monkeypatch.setattr(
-            "jobctrl.apply.launcher.get_connection", lambda: get_connection(db_path)
-        )
+        monkeypatch.setattr("jobctrl.apply.launcher.get_connection", lambda: get_connection(db_path))
         worker_id = 21 if coverage == "full" else 22
-        assert acquire_job(target_url="https://example.com/job", worker_id=worker_id) is None
-        assert any(
-            f"[W{worker_id}]" in event and expected_reason in event
-            for event in get_recent_events()
-        )
+        assert acquire_job(target_job_id=_target_job_id(conn), worker_id=worker_id) is None
+        assert any(f"[W{worker_id}]" in event and expected_reason in event for event in get_recent_events())
     finally:
         close_connection(db_path)
 
@@ -782,15 +756,10 @@ def test_apply_approval_gate_rejects_invalid_partial_override(
     )
 
     try:
-        monkeypatch.setattr(
-            "jobctrl.apply.launcher.get_connection", lambda: get_connection(db_path)
-        )
+        monkeypatch.setattr("jobctrl.apply.launcher.get_connection", lambda: get_connection(db_path))
         worker_id = 23 if seed_stale_run else 24
-        assert acquire_job(target_url="https://example.com/job", worker_id=worker_id) is None
-        assert any(
-            f"[W{worker_id}]" in event and "override_evidence_invalid" in event
-            for event in get_recent_events()
-        )
+        assert acquire_job(target_job_id=_target_job_id(conn), worker_id=worker_id) is None
+        assert any(f"[W{worker_id}]" in event and "override_evidence_invalid" in event for event in get_recent_events())
     finally:
         close_connection(db_path)
 
@@ -806,9 +775,7 @@ def test_acquire_job_accepts_posting_url_when_direct_apply_url_missing(tmp_path,
     )
 
     try:
-        monkeypatch.setattr(
-            "jobctrl.apply.launcher.get_connection", lambda: get_connection(db_path)
-        )
+        monkeypatch.setattr("jobctrl.apply.launcher.get_connection", lambda: get_connection(db_path))
         job = acquire_job(worker_id=1, approval_required=False)
         assert job is not None
         assert job["url"] == "https://example.com/posting-only"
@@ -899,9 +866,7 @@ def test_acquire_job_excludes_high_score_blocked_candidates(tmp_path, monkeypatc
     _insert_blocked_score(conn, "https://example.com/blocked", fit_score=10)
 
     try:
-        monkeypatch.setattr(
-            "jobctrl.apply.launcher.get_connection", lambda: get_connection(db_path)
-        )
+        monkeypatch.setattr("jobctrl.apply.launcher.get_connection", lambda: get_connection(db_path))
         job = acquire_job(min_score=7, worker_id=1, approval_required=False)
         assert job is not None
         assert job["url"] == "https://example.com/allowed"
@@ -916,15 +881,16 @@ def test_acquire_job_excludes_closed_candidates(tmp_path, monkeypatch):
     _mark_closed(conn, "https://example.com/closed")
 
     try:
-        monkeypatch.setattr(
-            "jobctrl.apply.launcher.get_connection", lambda: get_connection(db_path)
-        )
+        monkeypatch.setattr("jobctrl.apply.launcher.get_connection", lambda: get_connection(db_path))
         assert acquire_job(min_score=7, worker_id=1, approval_required=False) is None
-        assert acquire_job(
-            target_url="https://example.com/closed",
-            worker_id=1,
-            approval_required=False,
-        ) is None
+        assert (
+            acquire_job(
+                target_job_id=_target_job_id(conn, "https://example.com/closed"),
+                worker_id=1,
+                approval_required=False,
+            )
+            is None
+        )
     finally:
         close_connection(db_path)
 
@@ -936,14 +902,15 @@ def test_targeted_apply_rejects_blocked_candidate(tmp_path, monkeypatch):
     _insert_blocked_score(conn, "https://example.com/blocked", fit_score=10)
 
     try:
-        monkeypatch.setattr(
-            "jobctrl.apply.launcher.get_connection", lambda: get_connection(db_path)
+        monkeypatch.setattr("jobctrl.apply.launcher.get_connection", lambda: get_connection(db_path))
+        assert (
+            acquire_job(
+                target_job_id=_target_job_id(conn, "https://example.com/blocked"),
+                worker_id=1,
+                approval_required=False,
+            )
+            is None
         )
-        assert acquire_job(
-            target_url="https://example.com/blocked",
-            worker_id=1,
-            approval_required=False,
-        ) is None
     finally:
         close_connection(db_path)
 
@@ -1025,11 +992,9 @@ def test_acquire_job_promotes_prior_apply_run_into_row_dict(tmp_path, monkeypatc
     conn.commit()
     ProjectionBuilder(conn_factory=lambda: conn).refresh()
     try:
-        monkeypatch.setattr(
-            "jobctrl.apply.launcher.get_connection", lambda: get_connection(db_path)
-        )
+        monkeypatch.setattr("jobctrl.apply.launcher.get_connection", lambda: get_connection(db_path))
         job = acquire_job(
-            target_url="https://example.com/job",
+            target_job_id=_target_job_id(conn),
             worker_id=1,
             approval_required=False,
         )
@@ -1059,17 +1024,14 @@ def test_acquire_job_finds_new_path_enriched_job(tmp_path, monkeypatch):
     conn = init_db(db_path)
     url = "https://example.com/new-path-job"
     conn.execute(
-        "INSERT INTO jobs (url, title, site, fit_score, tailored_resume_path) "
-        "VALUES (?, ?, ?, ?, ?)",
+        "INSERT INTO jobs (url, title, site, fit_score, tailored_resume_path) VALUES (?, ?, ?, ?, ?)",
         (url, "New Path Engineer", "ExampleCo", 9, "/tmp/resume.txt"),
     )
     conn.commit()
 
     repo = SqliteEnrichmentRepository(conn)
     repo.save(
-        JobEnrichment.empty(
-            tenant_id=LOCAL_TENANT, job_id=JobId(url), updated_at="t0"
-        )
+        JobEnrichment.empty(tenant_id=LOCAL_TENANT, job_id=JobId(url), updated_at="t0")
         .start_attempt(extraction_tier=ExtractionTier.JSON_LD, started_at="t0")
         .succeed_attempt(
             full_description=FullDescription(text="Build distributed systems."),
@@ -1078,16 +1040,12 @@ def test_acquire_job_finds_new_path_enriched_job(tmp_path, monkeypatch):
             finished_at="t1",
         )
     )
-    legacy = conn.execute(
-        "SELECT application_url FROM jobs WHERE url = ?", (url,)
-    ).fetchone()
+    legacy = conn.execute("SELECT application_url FROM jobs WHERE url = ?", (url,)).fetchone()
     assert legacy["application_url"] is None
 
     try:
-        monkeypatch.setattr(
-            "jobctrl.apply.launcher.get_connection", lambda: get_connection(db_path)
-        )
-        job = acquire_job(target_url=url, worker_id=1, approval_required=False)
+        monkeypatch.setattr("jobctrl.apply.launcher.get_connection", lambda: get_connection(db_path))
+        job = acquire_job(target_job_id=_target_job_id(conn, url), worker_id=1, approval_required=False)
         assert job is not None
         assert job["url"] == url
         assert job["application_url"] == "https://example.com/apply-new"
@@ -1106,9 +1064,7 @@ def test_dry_run_result_does_not_mark_job_applied(tmp_path, monkeypatch):
     _insert_ready_job(conn)
 
     try:
-        monkeypatch.setattr(
-            "jobctrl.apply.launcher.get_connection", lambda: get_connection(db_path)
-        )
+        monkeypatch.setattr("jobctrl.apply.launcher.get_connection", lambda: get_connection(db_path))
         mark_result(
             "https://example.com/job",
             "dry_run",
@@ -1122,8 +1078,7 @@ def test_dry_run_result_does_not_mark_job_applied(tmp_path, monkeypatch):
             ("https://example.com/job",),
         ).fetchone()
         state = conn.execute(
-            "SELECT state, error_code FROM job_stage_states "
-            "WHERE job_url = ? AND stage = 'apply'",
+            "SELECT state, error_code FROM job_stage_states WHERE job_url = ? AND stage = 'apply'",
             ("https://example.com/job",),
         ).fetchone()
         # Legacy columns stay NULL on the new write path.
@@ -1134,8 +1089,7 @@ def test_dry_run_result_does_not_mark_job_applied(tmp_path, monkeypatch):
         assert state["error_code"] == "DRY_RUN"
         # Canonical: an apply_run_projections row in dry_run_complete.
         ar = conn.execute(
-            "SELECT run_id, status, dry_run FROM apply_run_projections "
-            "WHERE job_id = ?",
+            "SELECT run_id, status, dry_run FROM apply_run_projections WHERE job_id = ?",
             ("https://example.com/job",),
         ).fetchone()
         assert ar is not None
@@ -1146,9 +1100,7 @@ def test_dry_run_result_does_not_mark_job_applied(tmp_path, monkeypatch):
         close_connection(db_path)
 
 
-def test_acquire_job_then_mark_result_dry_run_completes_end_to_end(
-    tmp_path, monkeypatch
-):
+def test_acquire_job_then_mark_result_dry_run_completes_end_to_end(tmp_path, monkeypatch):
     """Reviewer-reported regression (PR 37 High #1): the production
     sequence ``acquire_job`` (Pending -> Running) then
     ``mark_result("dry_run", ...)`` (Running -> Skipped) used to raise
@@ -1161,12 +1113,10 @@ def test_acquire_job_then_mark_result_dry_run_completes_end_to_end(
     _insert_ready_job(conn)
 
     try:
-        monkeypatch.setattr(
-            "jobctrl.apply.launcher.get_connection", lambda: get_connection(db_path)
-        )
+        monkeypatch.setattr("jobctrl.apply.launcher.get_connection", lambda: get_connection(db_path))
         run_ctx: dict = {}
         job = acquire_job(
-            target_url="https://example.com/job",
+            target_job_id=_target_job_id(conn),
             worker_id=2,
             run_ctx=run_ctx,
             approval_required=False,
@@ -1174,8 +1124,7 @@ def test_acquire_job_then_mark_result_dry_run_completes_end_to_end(
         assert job is not None
         # Sanity: the lock acquired -> Running.
         before = conn.execute(
-            "SELECT state FROM job_stage_states "
-            "WHERE job_url = ? AND stage = 'apply'",
+            "SELECT state FROM job_stage_states WHERE job_url = ? AND stage = 'apply'",
             (job["url"],),
         ).fetchone()
         assert before["state"] == "running"
@@ -1191,8 +1140,7 @@ def test_acquire_job_then_mark_result_dry_run_completes_end_to_end(
         # (a) No exception (we got here).
         # (b) Stage row landed on Skipped.
         after = conn.execute(
-            "SELECT state, error_code FROM job_stage_states "
-            "WHERE job_url = ? AND stage = 'apply'",
+            "SELECT state, error_code FROM job_stage_states WHERE job_url = ? AND stage = 'apply'",
             (job["url"],),
         ).fetchone()
         assert after["state"] == "skipped"
@@ -1202,8 +1150,7 @@ def test_acquire_job_then_mark_result_dry_run_completes_end_to_end(
         # and a sensible terminal status, after refresh.
         ProjectionBuilder(conn_factory=lambda: get_connection(db_path)).refresh()
         ar = conn.execute(
-            "SELECT run_id, status, dry_run FROM apply_run_projections "
-            "WHERE job_id = ?",
+            "SELECT run_id, status, dry_run FROM apply_run_projections WHERE job_id = ?",
             (job["url"],),
         ).fetchone()
         assert ar is not None
@@ -1221,20 +1168,17 @@ def test_release_lock_does_not_rewind_running_row(tmp_path, monkeypatch):
     _insert_ready_job(conn)
 
     try:
-        monkeypatch.setattr(
-            "jobctrl.apply.launcher.get_connection", lambda: get_connection(db_path)
-        )
+        monkeypatch.setattr("jobctrl.apply.launcher.get_connection", lambda: get_connection(db_path))
         run_ctx: dict = {}
         job = acquire_job(
-            target_url="https://example.com/job",
+            target_job_id=_target_job_id(conn),
             worker_id=3,
             run_ctx=run_ctx,
             approval_required=False,
         )
         assert job is not None
         before = conn.execute(
-            "SELECT state FROM job_stage_states "
-            "WHERE job_url = ? AND stage = 'apply'",
+            "SELECT state FROM job_stage_states WHERE job_url = ? AND stage = 'apply'",
             (job["url"],),
         ).fetchone()
         assert before["state"] == "running"
@@ -1242,8 +1186,7 @@ def test_release_lock_does_not_rewind_running_row(tmp_path, monkeypatch):
         release_lock(job["url"], run_ctx=run_ctx)
 
         after = conn.execute(
-            "SELECT state FROM job_stage_states "
-            "WHERE job_url = ? AND stage = 'apply'",
+            "SELECT state FROM job_stage_states WHERE job_url = ? AND stage = 'apply'",
             (job["url"],),
         ).fetchone()
         assert after["state"] == "running"
@@ -1258,14 +1201,12 @@ def test_apply_recovery_rewinds_before_submit_intent(tmp_path, monkeypatch):
     _insert_ready_job(conn)
 
     try:
-        monkeypatch.setattr(
-            "jobctrl.apply.launcher.get_connection", lambda: get_connection(db_path)
-        )
+        monkeypatch.setattr("jobctrl.apply.launcher.get_connection", lambda: get_connection(db_path))
         # 1. Acquire (writes ApplyRunStarted with the canonical run_id +
         #    flips stage to running).
         run_ctx: dict = {}
         job = acquire_job(
-            target_url="https://example.com/job",
+            target_job_id=_target_job_id(conn),
             worker_id=5,
             run_ctx=run_ctx,
             approval_required=False,
@@ -1289,12 +1230,10 @@ def test_apply_recovery_after_submit_intent_needs_verification(tmp_path, monkeyp
     _insert_ready_job(conn)
 
     try:
-        monkeypatch.setattr(
-            "jobctrl.apply.launcher.get_connection", lambda: get_connection(db_path)
-        )
+        monkeypatch.setattr("jobctrl.apply.launcher.get_connection", lambda: get_connection(db_path))
         run_ctx: dict = {"workflow_id": "apply-local-https://example.com/job"}
         job = acquire_job(
-            target_url="https://example.com/job",
+            target_job_id=_target_job_id(conn),
             worker_id=5,
             run_ctx=run_ctx,
             approval_required=False,
@@ -1328,7 +1267,7 @@ def test_apply_recovery_after_submit_intent_needs_verification(tmp_path, monkeyp
         _insert_review_decision(conn, job_key=job["url"], decision="approve_submit")
         assert (
             acquire_job(
-                target_url=job["url"],
+                target_job_id=_target_job_id(conn, job["url"]),
                 worker_id=6,
                 run_ctx={"workflow_id": "apply-targeted-reclaim"},
                 approval_required=True,
@@ -1369,7 +1308,7 @@ def test_failed_result_after_submit_intent_parks_without_reclaim(
         )
         run_ctx: dict = {"workflow_id": "apply-email-send"}
         job = acquire_job(
-            target_url="https://example.com/job",
+            target_job_id=_target_job_id(conn),
             worker_id=5,
             run_ctx=run_ctx,
             approval_required=False,
@@ -1411,7 +1350,7 @@ def test_failed_result_after_submit_intent_parks_without_reclaim(
 
         assert (
             acquire_job(
-                target_url=job["url"],
+                target_job_id=_target_job_id(conn, job["url"]),
                 worker_id=6,
                 run_ctx={"workflow_id": "apply-targeted-reclaim"},
                 approval_required=False,
@@ -1439,6 +1378,7 @@ def test_acquire_job_concurrent_workers_only_one_succeeds(tmp_path, monkeypatch)
     db_path = Path(tmp_path) / "jobs.db"
     conn = init_db(db_path)
     _insert_ready_job(conn)
+    job_id = _target_job_id(conn)
     close_connection(db_path)  # workers create thread-local connections
 
     try:
@@ -1446,9 +1386,7 @@ def test_acquire_job_concurrent_workers_only_one_succeeds(tmp_path, monkeypatch)
         # connection (SQLite forbids sharing across threads).  The
         # ``get_connection`` helper is already thread-local, so the
         # monkeypatch points each thread to the same DB path.
-        monkeypatch.setattr(
-            "jobctrl.apply.launcher.get_connection", lambda: get_connection(db_path)
-        )
+        monkeypatch.setattr("jobctrl.apply.launcher.get_connection", lambda: get_connection(db_path))
 
         results: list[dict | None] = []
         results_lock = threading.Lock()
@@ -1458,7 +1396,7 @@ def test_acquire_job_concurrent_workers_only_one_succeeds(tmp_path, monkeypatch)
             ready.wait()
             try:
                 outcome = acquire_job(
-                    target_url="https://example.com/job",
+                    target_job_id=job_id,
                     worker_id=worker_id,
                     approval_required=False,
                 )
@@ -1483,15 +1421,13 @@ def test_acquire_job_concurrent_workers_only_one_succeeds(tmp_path, monkeypatch)
 
         successes = [r for r in results if r is not None]
         assert len(successes) == 1, (
-            f"expected exactly one acquire to succeed, got {len(successes)} "
-            f"(results={results!r})"
+            f"expected exactly one acquire to succeed, got {len(successes)} (results={results!r})"
         )
 
         # Exactly one ``running`` row in ``job_stage_states.apply``.
         check_conn = get_connection(db_path)
         running_count = check_conn.execute(
-            "SELECT COUNT(*) FROM job_stage_states "
-            "WHERE job_url = ? AND stage = 'apply' AND state = 'running'",
+            "SELECT COUNT(*) FROM job_stage_states WHERE job_url = ? AND stage = 'apply' AND state = 'running'",
             ("https://example.com/job",),
         ).fetchone()[0]
         assert running_count == 1
@@ -1499,9 +1435,7 @@ def test_acquire_job_concurrent_workers_only_one_succeeds(tmp_path, monkeypatch)
         close_connection(db_path)
 
 
-def test_record_job_event_default_publisher_refreshes_apply_run_projections(
-    tmp_path, monkeypatch
-):
+def test_record_job_event_default_publisher_refreshes_apply_run_projections(tmp_path, monkeypatch):
     """Reviewer-reported regression (PR 37 High #4): ``record_job_event``
     used to require the caller to thread a publisher through to fan out
     via the ``InProcessEventBus``; the projection's wildcard subscriber
@@ -1657,8 +1591,7 @@ def test_record_job_event_from_worker_thread_refreshes_projection(
         ar = None
         while _time.monotonic() < deadline:
             ar = bootstrap_conn.execute(
-                "SELECT run_id, status FROM apply_run_projections "
-                "WHERE job_id = ?",
+                "SELECT run_id, status FROM apply_run_projections WHERE job_id = ?",
                 ("https://example.com/job",),
             ).fetchone()
             if ar is not None:
@@ -1666,8 +1599,7 @@ def test_record_job_event_from_worker_thread_refreshes_projection(
             _time.sleep(0.05)
 
         assert ar is not None, (
-            "apply_run_projections row never appeared — "
-            "the wildcard subscriber did not refresh on the worker thread"
+            "apply_run_projections row never appeared — the wildcard subscriber did not refresh on the worker thread"
         )
         assert ar["run_id"] == "from-worker"
         assert ar["status"] == "succeeded"
@@ -1680,9 +1612,7 @@ def test_record_job_event_from_worker_thread_refreshes_projection(
         close_connection(db_path)
 
 
-def test_apply_saga_writes_full_event_timeline_to_job_events(
-    tmp_path, monkeypatch
-):
+def test_apply_saga_writes_full_event_timeline_to_job_events(tmp_path, monkeypatch):
     """Reviewer-reported regression (PR 37 High #3): saga events
     (``SagaStarted`` / ``BrowserLaunched`` / ``AgentStarted`` /
     ``AgentResult`` / per-``AgentEvent``) used to be lost because
@@ -1706,14 +1636,12 @@ def test_apply_saga_writes_full_event_timeline_to_job_events(
     _insert_ready_job(conn)
 
     try:
-        monkeypatch.setattr(
-            "jobctrl.apply.launcher.get_connection", lambda: get_connection(db_path)
-        )
+        monkeypatch.setattr("jobctrl.apply.launcher.get_connection", lambda: get_connection(db_path))
 
         # Seed the launcher-emitted ApplyRunStarted (acquire_job's job).
         run_ctx: dict = {}
         job = acquire_job(
-            target_url="https://example.com/job",
+            target_job_id=_target_job_id(conn),
             worker_id=1,
             run_ctx=run_ctx,
             approval_required=False,
@@ -1905,16 +1833,13 @@ def test_dashboard_dry_runs_excludes_soft_deleted_jobs(tmp_path):
 
         # Soft-delete the second job.
         conn.execute(
-            "INSERT INTO jobctrl_deleted_jobs (job_url, deleted_at) "
-            "VALUES (?, ?)",
+            "INSERT INTO jobctrl_deleted_jobs (job_url, deleted_at) VALUES (?, ?)",
             ("https://example.com/job-deleted", "2026-05-04T13:05:00+00:00"),
         )
         conn.commit()
         ProjectionBuilder(conn_factory=lambda: conn).refresh()
 
-        dash = conn.execute(
-            "SELECT dry_runs FROM dashboard_projections LIMIT 1"
-        ).fetchone()
+        dash = conn.execute("SELECT dry_runs FROM dashboard_projections LIMIT 1").fetchone()
         assert dash is not None
         # Only the live job's dry run is counted.
         assert dash["dry_runs"] == 1

--- a/workers/automation/tests/test_apply_regressions.py
+++ b/workers/automation/tests/test_apply_regressions.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import json
 import sqlite3
 import threading
+import uuid
 from collections import Counter
 from hashlib import sha256
 from pathlib import Path
@@ -31,10 +32,18 @@ from jobctrl.apply.launcher import (
 from jobctrl.apply.dashboard import get_recent_events
 from jobctrl.apply.origins import canonical_http_url
 from jobctrl.database import close_connection, get_connection, init_db
-from jobctrl.domain.tenant import LOCAL_TENANT
 from jobctrl.infrastructure.projections.projection_builder import ProjectionBuilder
 from jobctrl.state import ensure_job_stage_rows, record_job_event, set_stage_state, utc_now
 from jobctrl.workflow_specs import StartedWorkflowResult
+
+
+LOCAL_TENANT = "local"
+
+
+def _job_id_for(url: str) -> str:
+    """Return the deterministic canonical identity for one test locator."""
+
+    return str(uuid.uuid5(uuid.NAMESPACE_URL, f"apply-regression:{url}"))
 
 
 @pytest.fixture(autouse=True)
@@ -53,45 +62,84 @@ def _insert_ready_job(
     *,
     url: str = "https://example.com/job",
     application_url: str | None = "https://example.com/apply",
-) -> None:
+) -> str:
+    job_id = _job_id_for(url)
+    now = "2026-05-04T13:00:00+00:00"
     conn.execute(
         """
         INSERT INTO jobs (
-            url, title, site, full_description, application_url,
-            fit_score, tailored_resume_path, cover_letter_path
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            tenant_id, job_id, url, title, company, site, discovered_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?)
         """,
         (
+            LOCAL_TENANT,
+            job_id,
             url,
             "Platform Engineer",
             "ExampleCo",
-            "Build distributed systems.",
-            application_url,
-            9,
-            "/tmp/resume.txt",
-            "/tmp/cover.txt",
+            "ExampleCo",
+            now,
         ),
     )
-    conn.commit()
-
-
-def _insert_single_job_tailor_candidate(conn, *, url: str = "https://example.com/job") -> None:
     conn.execute(
         """
-        INSERT INTO jobs (
-            url, title, site, full_description, application_url, fit_score
-        ) VALUES (?, ?, ?, ?, ?, ?)
+        INSERT INTO job_locators (
+            tenant_id, job_id, locator_kind, locator_value,
+            is_current, first_seen_at, last_seen_at
+        ) VALUES (?, ?, 'posting_url', ?, 1, ?, ?)
         """,
-        (
-            url,
-            "Platform Engineer",
-            "ExampleCo",
-            "Build distributed systems.",
-            "https://example.com/apply",
-            9,
-        ),
+        (LOCAL_TENANT, job_id, url, now, now),
     )
+    conn.execute(
+        """
+        INSERT INTO job_enrichments (
+            tenant_id, job_id, current_status, full_description, application_url, updated_at
+        ) VALUES (?, ?, 'enriched', 'Build distributed systems.', ?, ?)
+        """,
+        (LOCAL_TENANT, job_id, application_url, now),
+    )
+    conn.execute(
+        """
+        INSERT INTO job_scores (
+            tenant_id, job_id, version, fit_score, breakdown_json, keywords_json, scored_at
+        ) VALUES (?, ?, 1, 9, '{}', '[]', ?)
+        """,
+        (LOCAL_TENANT, job_id, now),
+    )
+    conn.execute(
+        """
+        INSERT INTO job_materials (
+            tenant_id, job_id, generation, status, created_at, updated_at
+        ) VALUES (?, ?, 1, 'approved', ?, ?)
+        """,
+        (LOCAL_TENANT, job_id, now, now),
+    )
+    for artifact_type, artifact_id, path in (
+        ("tailored_resume", "resume-text-1", "/tmp/resume.txt"),
+        ("resume_pdf", "resume-pdf-1", "/tmp/resume.pdf"),
+    ):
+        conn.execute(
+            """
+            INSERT INTO job_materials_artifacts (
+                tenant_id, job_id, generation, artifact_type, artifact_id,
+                status, path, render_format, created_at
+            ) VALUES (?, ?, 1, ?, ?, 'approved', ?, 'text', ?)
+            """,
+            (LOCAL_TENANT, job_id, artifact_type, artifact_id, path, now),
+        )
+    ensure_job_stage_rows(conn, job_id, tenant_id=LOCAL_TENANT)
+    for stage in ("enrich", "score", "tailor"):
+        set_stage_state(
+            conn,
+            job_id,
+            stage,
+            "succeeded",
+            tenant_id=LOCAL_TENANT,
+            finished_at=now,
+            validate_transition=False,
+        )
     conn.commit()
+    return job_id
 
 
 def _target_job_id(conn, url: str = "https://example.com/job") -> str:
@@ -104,15 +152,17 @@ def _target_job_id(conn, url: str = "https://example.com/job") -> str:
 
 
 def _insert_blocked_score(conn, url: str, *, fit_score: int = 9) -> None:
+    job_id = _job_id_for(url)
     conn.execute(
         """
         INSERT INTO job_scores (
-            job_url, version, tenant_id, fit_score, breakdown_json,
+            tenant_id, job_id, version, fit_score, breakdown_json,
             keywords_json, scored_at, correction_json, criteria_json, trace_json
-        ) VALUES (?, 1, 'local', ?, ?, '["python"]', ?, NULL, '{}', '{}')
+        ) VALUES (?, ?, 2, ?, ?, '["python"]', ?, NULL, '{}', '{}')
         """,
         (
-            url,
+            LOCAL_TENANT,
+            job_id,
             fit_score,
             json.dumps(
                 {
@@ -136,17 +186,18 @@ def test_unsafe_url_failure_is_permanent() -> None:
 
 
 def _mark_closed(conn: sqlite3.Connection, url: str, state: str = "removed") -> None:
+    job_id = _job_id_for(url)
     conn.execute(
         """
         INSERT INTO posting_snapshot_sets (
-            tenant_id, job_url, snapshot_set_json, latest_snapshot_version,
+            tenant_id, job_id, snapshot_set_json, latest_snapshot_version,
             latest_active_state, updated_at
-        ) VALUES ('local', ?, '{}', 0, ?, ?)
-        ON CONFLICT(tenant_id, job_url) DO UPDATE SET
+        ) VALUES (?, ?, '{}', 0, ?, ?)
+        ON CONFLICT(tenant_id, job_id) DO UPDATE SET
             latest_active_state = excluded.latest_active_state,
             updated_at = excluded.updated_at
         """,
-        (url, state, utc_now()),
+        (LOCAL_TENANT, job_id, state, utc_now()),
     )
     conn.commit()
 
@@ -154,7 +205,7 @@ def _mark_closed(conn: sqlite3.Connection, url: str, state: str = "removed") -> 
 def _insert_review_decision(
     conn: sqlite3.Connection,
     *,
-    job_key: str = "https://example.com/job",
+    job_id: str | None = None,
     decision: str = "approve_submit",
     decided_at: str = "2026-01-01T00:00:00+00:00",
     decision_id: str | None = None,
@@ -163,16 +214,18 @@ def _insert_review_decision(
     application_url: str | None = None,
     partial_override_run_id: str | None = None,
 ) -> None:
+    stable_job_id = job_id or _job_id_for("https://example.com/job")
     conn.execute(
         """
         INSERT INTO application_review_decisions (
-            tenant_id, decision_id, job_key, decision, reason, decided_by, decided_at,
+            tenant_id, decision_id, job_id, decision, reason, decided_by, decided_at,
             materials_generation, profile_version, application_url, partial_override_run_id
-        ) VALUES ('local', ?, ?, ?, 'test', 'pytest', ?, ?, ?, ?, ?)
+        ) VALUES (?, ?, ?, ?, 'test', 'pytest', ?, ?, ?, ?, ?)
         """,
         (
+            LOCAL_TENANT,
             decision_id or f"decision-{decision}-{decided_at}",
-            job_key,
+            stable_job_id,
             decision,
             decided_at,
             materials_generation,
@@ -187,29 +240,30 @@ def _insert_review_decision(
 def _seed_current_apply_binding(
     conn: sqlite3.Connection,
     *,
-    job_key: str = "https://example.com/job",
+    job_id: str | None = None,
     application_url: str = "https://example.com/apply",
     generation: int = 1,
     profile_version: int = 1,
     coverage: str | None = "full",
     run_id: str = "dry-run-full",
 ) -> None:
+    stable_job_id = job_id or _job_id_for("https://example.com/job")
     now = "2026-01-01T00:00:00+00:00"
     conn.execute(
         """
         INSERT OR REPLACE INTO candidate_profiles (
             tenant_id, profile_id, version, updated_at
-        ) VALUES ('local', 'default', ?, ?)
+        ) VALUES (?, 'default', ?, ?)
         """,
-        (profile_version, now),
+        (LOCAL_TENANT, profile_version, now),
     )
     conn.execute(
         """
         INSERT OR REPLACE INTO job_materials (
-            job_url, generation, tenant_id, status, created_at, updated_at
-        ) VALUES (?, ?, 'local', 'approved', ?, ?)
+            tenant_id, job_id, generation, status, created_at, updated_at
+        ) VALUES (?, ?, ?, 'approved', ?, ?)
         """,
-        (job_key, generation, now, now),
+        (LOCAL_TENANT, stable_job_id, generation, now, now),
     )
     for artifact_type, artifact_id, path in (
         ("tailored_resume", "resume-text-1", "/tmp/resume.txt"),
@@ -218,18 +272,19 @@ def _seed_current_apply_binding(
         conn.execute(
             """
             INSERT OR REPLACE INTO job_materials_artifacts (
-                job_url, generation, artifact_type, artifact_id, status, path,
+                tenant_id, job_id, generation, artifact_type, artifact_id, status, path,
                 render_format, created_at
-            ) VALUES (?, ?, ?, ?, 'approved', ?, 'text', ?)
+            ) VALUES (?, ?, ?, ?, ?, 'approved', ?, 'text', ?)
             """,
-            (job_key, generation, artifact_type, artifact_id, path, now),
+            (LOCAL_TENANT, stable_job_id, generation, artifact_type, artifact_id, path, now),
         )
     if coverage is not None:
         record_job_event(
             conn,
-            job_key,
+            stable_job_id,
             "apply",
             "ApplyRunStarted",
+            tenant_id=LOCAL_TENANT,
             message="Apply dry-run started",
             payload={
                 "run_id": run_id,
@@ -241,9 +296,10 @@ def _seed_current_apply_binding(
         )
         record_job_event(
             conn,
-            job_key,
+            stable_job_id,
             "apply",
             "DryRunCompleted",
+            tenant_id=LOCAL_TENANT,
             message="Dry run completed",
             payload={
                 "run_id": run_id,
@@ -278,7 +334,7 @@ def test_targeted_apply_takes_canonical_stage_lock(tmp_path, monkeypatch):
     Legacy ``jobs.apply_status`` stays NULL."""
     db_path = Path(tmp_path) / "jobs.db"
     conn = init_db(db_path)
-    _insert_ready_job(conn)
+    job_id = _insert_ready_job(conn)
 
     try:
         monkeypatch.setattr("jobctrl.apply.launcher.get_connection", lambda: get_connection(db_path))
@@ -290,21 +346,25 @@ def test_targeted_apply_takes_canonical_stage_lock(tmp_path, monkeypatch):
         assert job is not None
         assert job["url"] == "https://example.com/job"
         # Legacy column stays NULL on the new path.
-        legacy = conn.execute("SELECT apply_status FROM jobs WHERE url = ?", (job["url"],)).fetchone()
+        legacy = conn.execute(
+            "SELECT apply_status FROM jobs WHERE tenant_id = ? AND job_id = ?",
+            (LOCAL_TENANT, job_id),
+        ).fetchone()
         assert legacy["apply_status"] is None
         # Canonical lock: stage row in 'running'.
         stage = conn.execute(
-            "SELECT state FROM job_stage_states WHERE job_url = ? AND stage = 'apply'",
-            (job["url"],),
+            "SELECT state FROM job_stage_states "
+            "WHERE tenant_id = ? AND job_id = ? AND stage = 'apply'",
+            (LOCAL_TENANT, job_id),
         ).fetchone()
         assert stage is not None
         assert stage["state"] == "running"
         # ApplyRunStarted event recorded with the same run_id.
         evt = conn.execute(
             "SELECT payload_json FROM job_events "
-            "WHERE job_url = ? AND event_type = 'ApplyRunStarted' "
+            "WHERE tenant_id = ? AND job_id = ? AND event_type = 'ApplyRunStarted' "
             "ORDER BY event_id DESC LIMIT 1",
-            (job["url"],),
+            (LOCAL_TENANT, job_id),
         ).fetchone()
         assert evt is not None
         import json
@@ -330,15 +390,16 @@ def test_application_review_decisions_table_exists_on_fresh_db(tmp_path):
 def test_apply_approval_gate_blocks_live_without_approval(tmp_path, monkeypatch):
     db_path = Path(tmp_path) / "jobs.db"
     conn = init_db(db_path)
-    _insert_ready_job(conn)
+    job_id = _insert_ready_job(conn)
 
     try:
         monkeypatch.setattr("jobctrl.apply.launcher.get_connection", lambda: get_connection(db_path))
         prior_event_count = len(get_recent_events())
         assert acquire_job(target_job_id=_target_job_id(conn), worker_id=1) is None
         row = conn.execute(
-            "SELECT state FROM job_stage_states WHERE job_url = ? AND stage = 'apply'",
-            ("https://example.com/job",),
+            "SELECT state FROM job_stage_states "
+            "WHERE tenant_id = ? AND job_id = ? AND stage = 'apply'",
+            (LOCAL_TENANT, job_id),
         ).fetchone()
         assert row is None or row["state"] == "pending"
         assert any("Awaiting apply approval" in event for event in get_recent_events()[prior_event_count:])
@@ -352,7 +413,7 @@ def test_approval_required_apply_loop_never_runs_browser_for_unapproved_job(
 ):
     db_path = Path(tmp_path) / "jobs.db"
     conn = init_db(db_path)
-    _insert_ready_job(conn)
+    job_id = _insert_ready_job(conn)
 
     def fail_run_job(*_args, **_kwargs):
         raise AssertionError("unapproved live job reached browser automation")
@@ -370,8 +431,9 @@ def test_approval_required_apply_loop_never_runs_browser_for_unapproved_job(
 
         assert (applied, failed) == (0, 0)
         row = conn.execute(
-            "SELECT state FROM job_stage_states WHERE job_url = ? AND stage = 'apply'",
-            ("https://example.com/job",),
+            "SELECT state FROM job_stage_states "
+            "WHERE tenant_id = ? AND job_id = ? AND stage = 'apply'",
+            (LOCAL_TENANT, job_id),
         ).fetchone()
         assert row is None or row["state"] == "pending"
     finally:
@@ -391,7 +453,14 @@ def test_apply_approval_gate_can_be_disabled_or_bypassed_for_dry_run(tmp_path, m
             approval_required=False,
         )
         assert job is not None
-        set_stage_state(conn, job["url"], "apply", "pending", validate_transition=False)
+        set_stage_state(
+            conn,
+            job["job_id"],
+            "apply",
+            "pending",
+            tenant_id=LOCAL_TENANT,
+            validate_transition=False,
+        )
         conn.commit()
 
         dry_job = acquire_job(
@@ -408,10 +477,11 @@ def test_apply_approval_gate_can_be_disabled_or_bypassed_for_dry_run(tmp_path, m
 def test_apply_approval_gate_requires_latest_approve_submit(tmp_path, monkeypatch):
     db_path = Path(tmp_path) / "jobs.db"
     conn = init_db(db_path)
-    _insert_ready_job(conn)
-    _seed_current_apply_binding(conn)
+    job_id = _insert_ready_job(conn)
+    _seed_current_apply_binding(conn, job_id=job_id)
     _insert_review_decision(
         conn,
+        job_id=job_id,
         decision="approve_submit",
         decided_at="2026-01-01T00:00:00+00:00",
         decision_id="decision-old-approve",
@@ -421,6 +491,7 @@ def test_apply_approval_gate_requires_latest_approve_submit(tmp_path, monkeypatc
     )
     _insert_review_decision(
         conn,
+        job_id=job_id,
         decision="decline",
         decided_at="2026-01-02T00:00:00+00:00",
         decision_id="decision-new-decline",
@@ -431,6 +502,7 @@ def test_apply_approval_gate_requires_latest_approve_submit(tmp_path, monkeypatc
         assert acquire_job(target_job_id=_target_job_id(conn), worker_id=1) is None
         _insert_review_decision(
             conn,
+            job_id=job_id,
             decision="approve_submit",
             decided_at="2026-01-03T00:00:00+00:00",
             decision_id="decision-new-approve",
@@ -446,10 +518,11 @@ def test_apply_approval_gate_requires_latest_approve_submit(tmp_path, monkeypatc
 def test_apply_approval_gate_requires_matching_full_dry_run(tmp_path, monkeypatch):
     db_path = Path(tmp_path) / "jobs.db"
     conn = init_db(db_path)
-    _insert_ready_job(conn)
-    _seed_current_apply_binding(conn, coverage=None)
+    job_id = _insert_ready_job(conn)
+    _seed_current_apply_binding(conn, job_id=job_id, coverage=None)
     _insert_review_decision(
         conn,
+        job_id=job_id,
         decision="approve_submit",
         materials_generation=1,
         profile_version=1,
@@ -468,8 +541,8 @@ def test_apply_approval_gate_requires_matching_full_dry_run(tmp_path, monkeypatc
 def test_normal_dry_run_completion_satisfies_approval_gate(tmp_path, monkeypatch):
     db_path = Path(tmp_path) / "jobs.db"
     conn = init_db(db_path)
-    _insert_ready_job(conn)
-    _seed_current_apply_binding(conn, coverage=None)
+    job_id = _insert_ready_job(conn)
+    _seed_current_apply_binding(conn, job_id=job_id, coverage=None)
 
     try:
         monkeypatch.setattr("jobctrl.apply.launcher.get_connection", lambda: get_connection(db_path))
@@ -483,9 +556,10 @@ def test_normal_dry_run_completion_satisfies_approval_gate(tmp_path, monkeypatch
         assert dry_run_job is not None
         record_job_event(
             conn,
-            "https://example.com/job",
+            dry_run_job["job_id"],
             "apply",
             "DryRunCompleted",
+            tenant_id=LOCAL_TENANT,
             message="Saga dry run completed",
             payload={
                 "run_id": run_ctx["run_id"],
@@ -499,17 +573,18 @@ def test_normal_dry_run_completion_satisfies_approval_gate(tmp_path, monkeypatch
             },
         )
         mark_result(
-            "https://example.com/job",
+            dry_run_job["job_id"],
             "dry_run",
             duration_ms=123,
             task_id=run_ctx["run_id"],
             run_ctx=run_ctx,
+            tenant_id=LOCAL_TENANT,
         )
         completion = conn.execute(
             "SELECT payload_json FROM job_events "
-            "WHERE job_url = ? AND event_type = 'DryRunCompleted' "
+            "WHERE tenant_id = ? AND job_id = ? AND event_type = 'DryRunCompleted' "
             "ORDER BY event_id DESC LIMIT 1",
-            ("https://example.com/job",),
+            (LOCAL_TENANT, job_id),
         ).fetchone()
         assert completion is not None
         payload = json.loads(completion["payload_json"])
@@ -520,6 +595,7 @@ def test_normal_dry_run_completion_satisfies_approval_gate(tmp_path, monkeypatch
 
         _insert_review_decision(
             conn,
+            job_id=job_id,
             decision="approve_submit",
             decided_at="2026-01-02T00:00:00+00:00",
             materials_generation=1,
@@ -543,8 +619,8 @@ def test_full_dry_run_without_navigation_receipt_cannot_satisfy_approval_gate(
 ):
     db_path = Path(tmp_path) / "jobs.db"
     conn = init_db(db_path)
-    _insert_ready_job(conn)
-    _seed_current_apply_binding(conn, coverage=None)
+    job_id = _insert_ready_job(conn)
+    _seed_current_apply_binding(conn, job_id=job_id, coverage=None)
 
     try:
         monkeypatch.setattr("jobctrl.apply.launcher.get_connection", lambda: get_connection(db_path))
@@ -559,23 +635,25 @@ def test_full_dry_run_without_navigation_receipt_cannot_satisfy_approval_gate(
             is not None
         )
         mark_result(
-            "https://example.com/job",
+            job_id,
             "dry_run",
             duration_ms=123,
             task_id=run_ctx["run_id"],
             run_ctx=run_ctx,
+            tenant_id=LOCAL_TENANT,
         )
         completion = conn.execute(
             "SELECT payload_json FROM job_events "
-            "WHERE job_url = ? AND event_type = 'DryRunCompleted' "
+            "WHERE tenant_id = ? AND job_id = ? AND event_type = 'DryRunCompleted' "
             "ORDER BY event_id DESC LIMIT 1",
-            ("https://example.com/job",),
+            (LOCAL_TENANT, job_id),
         ).fetchone()
         assert completion is not None
         assert json.loads(completion["payload_json"])["coverage"] == "partial"
 
         _insert_review_decision(
             conn,
+            job_id=job_id,
             decision="approve_submit",
             decided_at="2026-01-02T00:00:00+00:00",
             materials_generation=1,
@@ -620,9 +698,14 @@ def test_apply_approval_gate_rejects_stale_bindings(
 ):
     db_path = Path(tmp_path) / "jobs.db"
     conn = init_db(db_path)
-    _insert_ready_job(conn)
-    _seed_current_apply_binding(conn)
-    _insert_review_decision(conn, decision="approve_submit", **decision_bindings)
+    job_id = _insert_ready_job(conn)
+    _seed_current_apply_binding(conn, job_id=job_id)
+    _insert_review_decision(
+        conn,
+        job_id=job_id,
+        decision="approve_submit",
+        **decision_bindings,
+    )
 
     try:
         monkeypatch.setattr("jobctrl.apply.launcher.get_connection", lambda: get_connection(db_path))
@@ -640,10 +723,16 @@ def test_apply_approval_gate_rejects_stale_bindings(
 def test_apply_approval_gate_accepts_partial_override_bound_to_run(tmp_path, monkeypatch):
     db_path = Path(tmp_path) / "jobs.db"
     conn = init_db(db_path)
-    _insert_ready_job(conn)
-    _seed_current_apply_binding(conn, coverage="partial", run_id="dry-run-partial")
+    job_id = _insert_ready_job(conn)
+    _seed_current_apply_binding(
+        conn,
+        job_id=job_id,
+        coverage="partial",
+        run_id="dry-run-partial",
+    )
     _insert_review_decision(
         conn,
+        job_id=job_id,
         decision="approve_submit",
         materials_generation=1,
         profile_version=1,
@@ -674,9 +763,10 @@ def test_apply_approval_gate_rejects_dry_run_evidence_for_stale_profile(
 ):
     db_path = Path(tmp_path) / "jobs.db"
     conn = init_db(db_path)
-    _insert_ready_job(conn)
+    job_id = _insert_ready_job(conn)
     _seed_current_apply_binding(
         conn,
+        job_id=job_id,
         coverage=coverage,
         profile_version=1,
         run_id="dry-run-profile-v1",
@@ -692,6 +782,7 @@ def test_apply_approval_gate_rejects_dry_run_evidence_for_stale_profile(
     conn.commit()
     _insert_review_decision(
         conn,
+        job_id=job_id,
         decision="approve_submit",
         materials_generation=1,
         profile_version=2,
@@ -716,14 +807,15 @@ def test_apply_approval_gate_rejects_invalid_partial_override(
 ):
     db_path = Path(tmp_path) / "jobs.db"
     conn = init_db(db_path)
-    _insert_ready_job(conn)
-    _seed_current_apply_binding(conn, coverage=None)
+    job_id = _insert_ready_job(conn)
+    _seed_current_apply_binding(conn, job_id=job_id, coverage=None)
     if seed_stale_run:
         record_job_event(
             conn,
-            "https://example.com/job",
+            job_id,
             "apply",
             "ApplyRunStarted",
+            tenant_id=LOCAL_TENANT,
             message="stale partial dry-run started",
             payload={
                 "run_id": "dry-run-partial",
@@ -735,9 +827,10 @@ def test_apply_approval_gate_rejects_invalid_partial_override(
         )
         record_job_event(
             conn,
-            "https://example.com/job",
+            job_id,
             "apply",
             "DryRunCompleted",
+            tenant_id=LOCAL_TENANT,
             message="stale partial dry-run completed",
             payload={
                 "run_id": "dry-run-partial",
@@ -748,6 +841,7 @@ def test_apply_approval_gate_rejects_invalid_partial_override(
         conn.commit()
     _insert_review_decision(
         conn,
+        job_id=job_id,
         decision="approve_submit",
         materials_generation=1,
         profile_version=1,
@@ -793,6 +887,8 @@ def test_worker_loop_delegates_browser_lifecycle_to_apply_saga(monkeypatch):
     """
 
     job = {
+        "tenant_id": LOCAL_TENANT,
+        "job_id": _job_id_for("https://example.com/job"),
         "url": "https://example.com/job",
         "title": "Platform Engineer",
         "site": "ExampleCo",
@@ -815,8 +911,8 @@ def test_worker_loop_delegates_browser_lifecycle_to_apply_saga(monkeypatch):
     def fake_run_job(*_args, **_kwargs):
         return "dry_run", 10
 
-    def fake_mark_result(url, status, **kwargs):
-        marked["url"] = url
+    def fake_mark_result(job_id, status, **kwargs):
+        marked["job_id"] = job_id
         marked["status"] = status
         marked["duration_ms"] = kwargs.get("duration_ms")
 
@@ -833,7 +929,7 @@ def test_worker_loop_delegates_browser_lifecycle_to_apply_saga(monkeypatch):
 
     assert (applied, failed) == (0, 0)
     assert marked == {
-        "url": "https://example.com/job",
+        "job_id": _job_id_for("https://example.com/job"),
         "status": "dry_run",
         "duration_ms": 10,
     }
@@ -956,23 +1052,25 @@ def test_acquire_job_promotes_prior_apply_run_into_row_dict(tmp_path, monkeypatc
     ``apply_status`` slot."""
     db_path = Path(tmp_path) / "jobs.db"
     conn = init_db(db_path)
-    _insert_ready_job(conn)
+    job_id = _insert_ready_job(conn)
     # Seed prior failed apply via the canonical writer + projector.
-    ensure_job_stage_rows(conn, "https://example.com/job")
+    ensure_job_stage_rows(conn, job_id, tenant_id=LOCAL_TENANT)
     set_stage_state(
         conn,
-        "https://example.com/job",
+        job_id,
         "apply",
         "failed",
+        tenant_id=LOCAL_TENANT,
         finished_at="2026-01-01T00:01:00+00:00",
         attempt_count=1,
         validate_transition=False,
     )
     record_job_event(
         conn,
-        "https://example.com/job",
+        job_id,
         "apply",
         "ApplyRunStarted",
+        tenant_id=LOCAL_TENANT,
         payload={
             "run_id": "run-prior",
             "started_at": "2026-01-01T00:00:00+00:00",
@@ -980,9 +1078,10 @@ def test_acquire_job_promotes_prior_apply_run_into_row_dict(tmp_path, monkeypatc
     )
     record_job_event(
         conn,
-        "https://example.com/job",
+        job_id,
         "apply",
         "ApplicationFailed",
+        tenant_id=LOCAL_TENANT,
         payload={
             "run_id": "run-prior",
             "finished_at": "2026-01-01T00:01:00+00:00",
@@ -1023,15 +1122,13 @@ def test_acquire_job_finds_new_path_enriched_job(tmp_path, monkeypatch):
     db_path = Path(tmp_path) / "jobs.db"
     conn = init_db(db_path)
     url = "https://example.com/new-path-job"
-    conn.execute(
-        "INSERT INTO jobs (url, title, site, fit_score, tailored_resume_path) VALUES (?, ?, ?, ?, ?)",
-        (url, "New Path Engineer", "ExampleCo", 9, "/tmp/resume.txt"),
-    )
-    conn.commit()
+    job_id = _insert_ready_job(conn, url=url, application_url=None)
 
     repo = SqliteEnrichmentRepository(conn)
     repo.save(
-        JobEnrichment.empty(tenant_id=LOCAL_TENANT, job_id=JobId(url), updated_at="t0")
+        JobEnrichment.empty(
+            tenant_id=LOCAL_TENANT, job_id=JobId(job_id), updated_at="t0"
+        )
         .start_attempt(extraction_tier=ExtractionTier.JSON_LD, started_at="t0")
         .succeed_attempt(
             full_description=FullDescription(text="Build distributed systems."),
@@ -1040,7 +1137,10 @@ def test_acquire_job_finds_new_path_enriched_job(tmp_path, monkeypatch):
             finished_at="t1",
         )
     )
-    legacy = conn.execute("SELECT application_url FROM jobs WHERE url = ?", (url,)).fetchone()
+    legacy = conn.execute(
+        "SELECT application_url FROM jobs WHERE tenant_id = ? AND job_id = ?",
+        (LOCAL_TENANT, job_id),
+    ).fetchone()
     assert legacy["application_url"] is None
 
     try:
@@ -1061,25 +1161,28 @@ def test_dry_run_result_does_not_mark_job_applied(tmp_path, monkeypatch):
     """
     db_path = Path(tmp_path) / "jobs.db"
     conn = init_db(db_path)
-    _insert_ready_job(conn)
+    job_id = _insert_ready_job(conn)
 
     try:
         monkeypatch.setattr("jobctrl.apply.launcher.get_connection", lambda: get_connection(db_path))
         mark_result(
-            "https://example.com/job",
+            job_id,
             "dry_run",
             duration_ms=123,
             task_id="run-test",
+            tenant_id=LOCAL_TENANT,
         )
         ProjectionBuilder(conn_factory=lambda: get_connection(db_path)).refresh()
 
         row = conn.execute(
-            "SELECT apply_status, applied_at, apply_task_id FROM jobs WHERE url = ?",
-            ("https://example.com/job",),
+            "SELECT apply_status, applied_at, apply_task_id FROM jobs "
+            "WHERE tenant_id = ? AND job_id = ?",
+            (LOCAL_TENANT, job_id),
         ).fetchone()
         state = conn.execute(
-            "SELECT state, error_code FROM job_stage_states WHERE job_url = ? AND stage = 'apply'",
-            ("https://example.com/job",),
+            "SELECT state, error_code FROM job_stage_states "
+            "WHERE tenant_id = ? AND job_id = ? AND stage = 'apply'",
+            (LOCAL_TENANT, job_id),
         ).fetchone()
         # Legacy columns stay NULL on the new write path.
         assert row["apply_status"] is None
@@ -1089,8 +1192,9 @@ def test_dry_run_result_does_not_mark_job_applied(tmp_path, monkeypatch):
         assert state["error_code"] == "DRY_RUN"
         # Canonical: an apply_run_projections row in dry_run_complete.
         ar = conn.execute(
-            "SELECT run_id, status, dry_run FROM apply_run_projections WHERE job_id = ?",
-            ("https://example.com/job",),
+            "SELECT run_id, status, dry_run FROM apply_run_projections "
+            "WHERE tenant_id = ? AND job_id = ?",
+            (LOCAL_TENANT, job_id),
         ).fetchone()
         assert ar is not None
         assert ar["status"] == "dry_run_complete"
@@ -1124,24 +1228,27 @@ def test_acquire_job_then_mark_result_dry_run_completes_end_to_end(tmp_path, mon
         assert job is not None
         # Sanity: the lock acquired -> Running.
         before = conn.execute(
-            "SELECT state FROM job_stage_states WHERE job_url = ? AND stage = 'apply'",
-            (job["url"],),
+            "SELECT state FROM job_stage_states "
+            "WHERE tenant_id = ? AND job_id = ? AND stage = 'apply'",
+            (LOCAL_TENANT, job["job_id"]),
         ).fetchone()
         assert before["state"] == "running"
 
         # Production sequence -- this used to raise ValueError.
         mark_result(
-            job["url"],
+            job["job_id"],
             "dry_run",
             duration_ms=42,
             run_ctx=run_ctx,
+            tenant_id=LOCAL_TENANT,
         )
 
         # (a) No exception (we got here).
         # (b) Stage row landed on Skipped.
         after = conn.execute(
-            "SELECT state, error_code FROM job_stage_states WHERE job_url = ? AND stage = 'apply'",
-            (job["url"],),
+            "SELECT state, error_code FROM job_stage_states "
+            "WHERE tenant_id = ? AND job_id = ? AND stage = 'apply'",
+            (LOCAL_TENANT, job["job_id"]),
         ).fetchone()
         assert after["state"] == "skipped"
         assert after["error_code"] == "DRY_RUN"
@@ -1150,8 +1257,9 @@ def test_acquire_job_then_mark_result_dry_run_completes_end_to_end(tmp_path, mon
         # and a sensible terminal status, after refresh.
         ProjectionBuilder(conn_factory=lambda: get_connection(db_path)).refresh()
         ar = conn.execute(
-            "SELECT run_id, status, dry_run FROM apply_run_projections WHERE job_id = ?",
-            (job["url"],),
+            "SELECT run_id, status, dry_run FROM apply_run_projections "
+            "WHERE tenant_id = ? AND job_id = ?",
+            (LOCAL_TENANT, job["job_id"]),
         ).fetchone()
         assert ar is not None
         assert ar["run_id"] == run_ctx["run_id"]
@@ -1178,16 +1286,18 @@ def test_release_lock_does_not_rewind_running_row(tmp_path, monkeypatch):
         )
         assert job is not None
         before = conn.execute(
-            "SELECT state FROM job_stage_states WHERE job_url = ? AND stage = 'apply'",
-            (job["url"],),
+            "SELECT state FROM job_stage_states "
+            "WHERE tenant_id = ? AND job_id = ? AND stage = 'apply'",
+            (LOCAL_TENANT, job["job_id"]),
         ).fetchone()
         assert before["state"] == "running"
 
-        release_lock(job["url"], run_ctx=run_ctx)
+        release_lock(job["job_id"], run_ctx=run_ctx, tenant_id=LOCAL_TENANT)
 
         after = conn.execute(
-            "SELECT state FROM job_stage_states WHERE job_url = ? AND stage = 'apply'",
-            (job["url"],),
+            "SELECT state FROM job_stage_states "
+            "WHERE tenant_id = ? AND job_id = ? AND stage = 'apply'",
+            (LOCAL_TENANT, job["job_id"]),
         ).fetchone()
         assert after["state"] == "running"
     finally:
@@ -1215,8 +1325,9 @@ def test_apply_recovery_rewinds_before_submit_intent(tmp_path, monkeypatch):
         recovered = recover_ambiguous_running_apply()
         assert recovered == 1
         row = conn.execute(
-            "SELECT state FROM job_stage_states WHERE job_url = ? AND stage = 'apply'",
-            (job["url"],),
+            "SELECT state FROM job_stage_states "
+            "WHERE tenant_id = ? AND job_id = ? AND stage = 'apply'",
+            (LOCAL_TENANT, job["job_id"]),
         ).fetchone()
         assert row["state"] == "pending"
     finally:
@@ -1241,13 +1352,14 @@ def test_apply_recovery_after_submit_intent_needs_verification(tmp_path, monkeyp
         assert job is not None
         record_job_event(
             conn,
-            job["url"],
+            job["job_id"],
             "apply",
             "ApplySubmitIntended",
+            tenant_id=LOCAL_TENANT,
             message="apply submission intent recorded",
             payload={
-                "tenant_id": "local",
-                "job_key": job["url"],
+                "tenant_id": LOCAL_TENANT,
+                "job_id": job["job_id"],
                 "run_id": run_ctx["run_id"],
                 "material_version": "1",
                 "intended_at": utc_now(),
@@ -1258,13 +1370,18 @@ def test_apply_recovery_after_submit_intent_needs_verification(tmp_path, monkeyp
         recovered = recover_ambiguous_running_apply()
         assert recovered == 1
         row = conn.execute(
-            "SELECT state, error_code FROM job_stage_states WHERE job_url = ? AND stage = 'apply'",
-            (job["url"],),
+            "SELECT state, error_code FROM job_stage_states "
+            "WHERE tenant_id = ? AND job_id = ? AND stage = 'apply'",
+            (LOCAL_TENANT, job["job_id"]),
         ).fetchone()
         assert row["state"] == "needs_verification"
         assert row["error_code"] == "APPLY_NEEDS_VERIFICATION"
 
-        _insert_review_decision(conn, job_key=job["url"], decision="approve_submit")
+        _insert_review_decision(
+            conn,
+            job_id=job["job_id"],
+            decision="approve_submit",
+        )
         assert (
             acquire_job(
                 target_job_id=_target_job_id(conn, job["url"]),
@@ -1283,8 +1400,9 @@ def test_apply_recovery_after_submit_intent_needs_verification(tmp_path, monkeyp
             is None
         )
         parked = conn.execute(
-            "SELECT state FROM job_stage_states WHERE job_url = ? AND stage = 'apply'",
-            (job["url"],),
+            "SELECT state FROM job_stage_states "
+            "WHERE tenant_id = ? AND job_id = ? AND stage = 'apply'",
+            (LOCAL_TENANT, job["job_id"]),
         ).fetchone()
         assert parked["state"] == "needs_verification"
     finally:
@@ -1316,13 +1434,14 @@ def test_failed_result_after_submit_intent_parks_without_reclaim(
         assert job is not None
         record_job_event(
             conn,
-            job["url"],
+            job["job_id"],
             "apply",
             "ApplySubmitIntended",
+            tenant_id=LOCAL_TENANT,
             message="owned email application intent recorded",
             payload={
-                "tenant_id": "local",
-                "job_key": job["url"],
+                "tenant_id": LOCAL_TENANT,
+                "job_id": job["job_id"],
                 "run_id": run_ctx["run_id"],
                 "material_version": "1",
                 "submission_channel": "email",
@@ -1332,16 +1451,18 @@ def test_failed_result_after_submit_intent_parks_without_reclaim(
         conn.commit()
 
         mark_result(
-            job["url"],
+            job["job_id"],
             "failed",
             "email_send_outcome_ambiguous:provider timed out after accepting request",
             run_ctx=run_ctx,
+            tenant_id=LOCAL_TENANT,
         )
 
         row = conn.execute(
             "SELECT state, error_code, retryable, next_action "
-            "FROM job_stage_states WHERE job_url = ? AND stage = 'apply'",
-            (job["url"],),
+            "FROM job_stage_states "
+            "WHERE tenant_id = ? AND job_id = ? AND stage = 'apply'",
+            (LOCAL_TENANT, job["job_id"]),
         ).fetchone()
         assert row["state"] == "needs_verification"
         assert row["error_code"] == "APPLY_NEEDS_VERIFICATION"
@@ -1377,8 +1498,7 @@ def test_acquire_job_concurrent_workers_only_one_succeeds(tmp_path, monkeypatch)
     """
     db_path = Path(tmp_path) / "jobs.db"
     conn = init_db(db_path)
-    _insert_ready_job(conn)
-    job_id = _target_job_id(conn)
+    job_id = _insert_ready_job(conn)
     close_connection(db_path)  # workers create thread-local connections
 
     try:
@@ -1427,8 +1547,10 @@ def test_acquire_job_concurrent_workers_only_one_succeeds(tmp_path, monkeypatch)
         # Exactly one ``running`` row in ``job_stage_states.apply``.
         check_conn = get_connection(db_path)
         running_count = check_conn.execute(
-            "SELECT COUNT(*) FROM job_stage_states WHERE job_url = ? AND stage = 'apply' AND state = 'running'",
-            ("https://example.com/job",),
+            "SELECT COUNT(*) FROM job_stage_states "
+            "WHERE tenant_id = ? AND job_id = ? "
+            "AND stage = 'apply' AND state = 'running'",
+            (LOCAL_TENANT, job_id),
         ).fetchone()[0]
         assert running_count == 1
     finally:
@@ -1454,7 +1576,7 @@ def test_record_job_event_default_publisher_refreshes_apply_run_projections(tmp_
 
     db_path = Path(tmp_path) / "jobs.db"
     conn = init_db(db_path)
-    _insert_ready_job(conn)
+    job_id = _insert_ready_job(conn)
     reset_default_publisher()
     publisher = get_default_publisher()
 
@@ -1468,9 +1590,10 @@ def test_record_job_event_default_publisher_refreshes_apply_run_projections(tmp_
     try:
         record_job_event(
             conn,
-            "https://example.com/job",
+            job_id,
             "apply",
             "ApplyRunStarted",
+            tenant_id=LOCAL_TENANT,
             payload={
                 "run_id": "run-fresh",
                 "started_at": "2026-05-04T13:00:00+00:00",
@@ -1484,9 +1607,10 @@ def test_record_job_event_default_publisher_refreshes_apply_run_projections(tmp_
 
         record_job_event(
             conn,
-            "https://example.com/job",
+            job_id,
             "apply",
             "ApplicationSubmitted",
+            tenant_id=LOCAL_TENANT,
             payload={
                 "run_id": "run-fresh",
                 "result": "applied",
@@ -1497,8 +1621,9 @@ def test_record_job_event_default_publisher_refreshes_apply_run_projections(tmp_
         ProjectionBuilder(conn_factory=lambda: conn).refresh()
 
         ar = conn.execute(
-            "SELECT run_id, status FROM apply_run_projections WHERE job_id = ?",
-            ("https://example.com/job",),
+            "SELECT run_id, status FROM apply_run_projections "
+            "WHERE tenant_id = ? AND job_id = ?",
+            (LOCAL_TENANT, job_id),
         ).fetchone()
         assert ar is not None
         assert ar["run_id"] == "run-fresh"
@@ -1532,7 +1657,7 @@ def test_record_job_event_from_worker_thread_refreshes_projection(
 
     db_path = Path(tmp_path) / "jobs.db"
     bootstrap_conn = init_db(db_path)
-    _insert_ready_job(bootstrap_conn)
+    job_id = _insert_ready_job(bootstrap_conn)
     reset_default_publisher()
 
     # Wire the projection builder on the bootstrap thread the same way
@@ -1551,9 +1676,10 @@ def test_record_job_event_from_worker_thread_refreshes_projection(
             # builder has a complete starting + terminal pair to fold.
             record_job_event(
                 worker_conn,
-                "https://example.com/job",
+                job_id,
                 "apply",
                 "ApplyRunStarted",
+                tenant_id=LOCAL_TENANT,
                 payload={
                     "run_id": "from-worker",
                     "started_at": "2026-05-04T13:00:00+00:00",
@@ -1563,9 +1689,10 @@ def test_record_job_event_from_worker_thread_refreshes_projection(
             )
             record_job_event(
                 worker_conn,
-                "https://example.com/job",
+                job_id,
                 "apply",
                 "ApplicationSubmitted",
+                tenant_id=LOCAL_TENANT,
                 payload={
                     "run_id": "from-worker",
                     "result": "applied",
@@ -1591,8 +1718,9 @@ def test_record_job_event_from_worker_thread_refreshes_projection(
         ar = None
         while _time.monotonic() < deadline:
             ar = bootstrap_conn.execute(
-                "SELECT run_id, status FROM apply_run_projections WHERE job_id = ?",
-                ("https://example.com/job",),
+                "SELECT run_id, status FROM apply_run_projections "
+                "WHERE tenant_id = ? AND job_id = ?",
+                (LOCAL_TENANT, job_id),
             ).fetchone()
             if ar is not None:
                 break
@@ -1656,7 +1784,7 @@ def test_apply_saga_writes_full_event_timeline_to_job_events(tmp_path, monkeypat
         run = ApplyRun.start(
             tenant_id=LOCAL_TENANT,
             run_id=ApplyRunId(run_id),
-            job_id=JobId(job["url"]),
+            job_id=JobId(job["job_id"]),
             started_at="2026-05-04T13:00:00+00:00",
             worker_id=1,
             model="haiku",
@@ -1665,7 +1793,7 @@ def test_apply_saga_writes_full_event_timeline_to_job_events(tmp_path, monkeypat
             attempts=1,
         )
         for event_type, payload in (
-            ("SagaStarted", {"job_id": job["url"], "model": "haiku"}),
+            ("SagaStarted", {"job_id": job["job_id"], "model": "haiku"}),
             ("BrowserLaunched", {"cdp_port": 9222, "pid": 1234}),
             ("AgentStarted", {"model": "haiku"}),
             # Agent-stream events forwarded by the Claude CLI adapter
@@ -1696,17 +1824,19 @@ def test_apply_saga_writes_full_event_timeline_to_job_events(tmp_path, monkeypat
 
         # Mark the terminal applied result via the launcher.
         mark_result(
-            job["url"],
+            job["job_id"],
             "applied",
             duration_ms=60000,
             run_ctx=run_ctx,
+            tenant_id=LOCAL_TENANT,
         )
 
         # The saga's intermediate timeline lands in job_events keyed by run_id.
         events = conn.execute(
             "SELECT event_type, payload_json FROM job_events "
-            "WHERE job_url = ? AND stage = 'apply' ORDER BY event_id ASC",
-            (job["url"],),
+            "WHERE tenant_id = ? AND job_id = ? AND stage = 'apply' "
+            "ORDER BY event_id ASC",
+            (LOCAL_TENANT, job["job_id"]),
         ).fetchall()
         counts = Counter(evt["event_type"] for evt in events)
         recorded: dict[str, dict] = {}
@@ -1779,38 +1909,20 @@ def test_dashboard_dry_runs_excludes_soft_deleted_jobs(tmp_path):
     db_path = Path(tmp_path) / "jobs.db"
     conn = init_db(db_path)
 
-    # ``jobctrl_deleted_jobs`` is created on demand by the discovery
-    # repository.  Create it here so the test seeds a tombstone.
-    conn.execute(
-        """
-        CREATE TABLE IF NOT EXISTS jobctrl_deleted_jobs (
-            job_url TEXT PRIMARY KEY,
-            deleted_at TEXT NOT NULL,
-            reason TEXT,
-            restored_at TEXT,
-            FOREIGN KEY(job_url) REFERENCES jobs(url)
-        )
-        """
-    )
-    conn.commit()
-
     try:
         # Two jobs, both with a dry-run apply lifecycle.
+        job_ids: dict[str, str] = {}
         for url in (
             "https://example.com/job-live",
             "https://example.com/job-deleted",
         ):
-            conn.execute(
-                "INSERT INTO jobs (url, title, site, fit_score, "
-                "tailored_resume_path, application_url) "
-                "VALUES (?, ?, ?, ?, ?, ?)",
-                (url, "Eng", "ExampleCo", 9, "/tmp/r.txt", url),
-            )
+            job_ids[url] = _insert_ready_job(conn, url=url, application_url=url)
             record_job_event(
                 conn,
-                url,
+                job_ids[url],
                 "apply",
                 "ApplyRunStarted",
+                tenant_id=LOCAL_TENANT,
                 payload={
                     "run_id": f"run-{url[-8:]}",
                     "started_at": "2026-05-04T13:00:00+00:00",
@@ -1820,9 +1932,10 @@ def test_dashboard_dry_runs_excludes_soft_deleted_jobs(tmp_path):
             )
             record_job_event(
                 conn,
-                url,
+                job_ids[url],
                 "apply",
                 "DryRunCompleted",
+                tenant_id=LOCAL_TENANT,
                 payload={
                     "run_id": f"run-{url[-8:]}",
                     "result": "dry_run_complete",
@@ -1833,8 +1946,13 @@ def test_dashboard_dry_runs_excludes_soft_deleted_jobs(tmp_path):
 
         # Soft-delete the second job.
         conn.execute(
-            "INSERT INTO jobctrl_deleted_jobs (job_url, deleted_at) VALUES (?, ?)",
-            ("https://example.com/job-deleted", "2026-05-04T13:05:00+00:00"),
+            "INSERT INTO jobctrl_deleted_jobs (tenant_id, job_id, deleted_at) "
+            "VALUES (?, ?, ?)",
+            (
+                LOCAL_TENANT,
+                job_ids["https://example.com/job-deleted"],
+                "2026-05-04T13:05:00+00:00",
+            ),
         )
         conn.commit()
         ProjectionBuilder(conn_factory=lambda: conn).refresh()

--- a/workers/automation/tests/test_apply_regressions.py
+++ b/workers/automation/tests/test_apply_regressions.py
@@ -1018,10 +1018,12 @@ def test_single_job_starts_temporal_workflow_spec(tmp_path, monkeypatch):
     app_dir = Path(tmp_path) / "app"
     db_path = Path(tmp_path) / "jobs.db"
     app_dir.mkdir()
+    conn = init_db(db_path)
 
     monkeypatch.setattr(config_module, "APP_DIR", app_dir)
     monkeypatch.setattr(config_module, "DB_PATH", db_path)
     url = "https://example.com/blocked"
+    job_id = _insert_ready_job(conn, url=url)
     specs = []
 
     def fake_start(spec):
@@ -1034,14 +1036,16 @@ def test_single_job_starts_temporal_workflow_spec(tmp_path, monkeypatch):
         )
 
     monkeypatch.setattr("jobctrl.workflow_specs.start_workflow_spec_and_wait_sync", fake_start)
+    monkeypatch.setattr(runner_module, "get_connection", lambda: conn)
 
     result = runner_module.run_single_job(url, do_tailor=True, do_apply=False)
 
     payload = specs[0].args[0]
-    assert payload.job_url == url
+    assert payload.job_url == job_id
     assert payload.stages == ["enrich", "score", "tailor", "cover"]
     assert payload.expected_app_dir == str(app_dir)
     assert payload.expected_db_path == str(db_path)
+    assert result["url"] == url
     assert result["workflowId"] == "workflow-single"
     assert result["stages_completed"] == ["enrich", "score", "tailor", "cover"]
 

--- a/workers/automation/tests/test_exact_v7_apply_acquire_job_identity.py
+++ b/workers/automation/tests/test_exact_v7_apply_acquire_job_identity.py
@@ -11,10 +11,19 @@ import hashlib
 import json
 import sqlite3
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
-from jobctrl.apply.launcher import _latest_apply_review_decision, acquire_job
+from jobctrl.apply.launcher import (
+    _latest_apply_review_decision,
+    acquire_job,
+    mark_job,
+    mark_result,
+    recover_ambiguous_running_apply,
+    release_lock,
+    worker_loop,
+)
 from jobctrl.apply.origins import canonical_http_url
 from jobctrl.database import init_db
 from jobctrl.domain.apply.repeat_application import (
@@ -22,7 +31,7 @@ from jobctrl.domain.apply.repeat_application import (
     evaluate_repeat_application,
     repeat_evidence_fingerprint,
 )
-from jobctrl.domain.identifiers import canonical_job_id
+from jobctrl.domain.identifiers import JobId, canonical_job_id
 from jobctrl.domain.tenant import TenantId
 
 
@@ -132,9 +141,7 @@ def _insert_approval_with_dry_run(
         """,
         (tenant_id, f"approval-{job_id}", job_id, TIMESTAMP, profile_version, application_url),
     )
-    navigation_fingerprint = hashlib.sha256(
-        canonical_http_url(application_url).encode("utf-8")
-    ).hexdigest()
+    navigation_fingerprint = hashlib.sha256(canonical_http_url(application_url).encode("utf-8")).hexdigest()
     started_payload = {
         "run_id": f"dry-run-{job_id}",
         "materials_generation": 1,
@@ -184,11 +191,14 @@ def test_targeted_acquire_binds_approval_and_profile_to_exact_v7_identity(
     conn.commit()
     monkeypatch.setattr("jobctrl.apply.launcher.get_connection", lambda: conn)
 
-    assert acquire_job(
-        target_url=SHARED_URL,
-        tenant_id=LOCAL_TENANT,
-        approval_required=True,
-    ) is None
+    assert (
+        acquire_job(
+            target_job_id=JobId(LOCAL_JOB_ID),
+            tenant_id=LOCAL_TENANT,
+            approval_required=True,
+        )
+        is None
+    )
 
     _insert_approval_with_dry_run(
         conn,
@@ -200,7 +210,7 @@ def test_targeted_acquire_binds_approval_and_profile_to_exact_v7_identity(
 
     run_ctx: dict[str, object] = {}
     job = acquire_job(
-        target_url=SHARED_URL,
+        target_job_id=JobId(LOCAL_JOB_ID),
         tenant_id=LOCAL_TENANT,
         approval_required=True,
         run_ctx=run_ctx,
@@ -215,27 +225,36 @@ def test_targeted_acquire_binds_approval_and_profile_to_exact_v7_identity(
     assert run_ctx["tenant_id"] == LOCAL_TENANT
     assert run_ctx["job_id"] == LOCAL_JOB_ID
     assert run_ctx["profile_version"] == 1
-    assert conn.execute(
-        """
+    assert (
+        conn.execute(
+            """
         SELECT state FROM job_stage_states
         WHERE tenant_id = ? AND job_id = ? AND stage = 'apply'
         """,
-        (LOCAL_TENANT, LOCAL_JOB_ID),
-    ).fetchone()["state"] == "running"
-    assert conn.execute(
-        """
+            (LOCAL_TENANT, LOCAL_JOB_ID),
+        ).fetchone()["state"]
+        == "running"
+    )
+    assert (
+        conn.execute(
+            """
         SELECT COUNT(*) FROM job_events
         WHERE tenant_id = ? AND job_id = ? AND event_type = 'ApplyRunStarted'
         """,
-        (LOCAL_TENANT, LOCAL_JOB_ID),
-    ).fetchone()[0] == 2
-    assert conn.execute(
-        """
+            (LOCAL_TENANT, LOCAL_JOB_ID),
+        ).fetchone()[0]
+        == 2
+    )
+    assert (
+        conn.execute(
+            """
         SELECT COUNT(*) FROM job_stage_states
         WHERE tenant_id = ? AND job_id = ? AND stage = 'apply'
         """,
-        (OTHER_TENANT, OTHER_JOB_ID),
-    ).fetchone()[0] == 0
+            (OTHER_TENANT, OTHER_JOB_ID),
+        ).fetchone()[0]
+        == 0
+    )
 
 
 def test_approval_lookup_preserves_the_apply_claim_transaction(
@@ -305,27 +324,29 @@ def test_batch_acquire_does_not_cross_tenant_stage_or_repeat_evidence(
     ).fetchone()
     assert state is not None
     assert (state["state"], state["attempt_count"]) == ("running", 1)
-    assert conn.execute(
-        """
+    assert (
+        conn.execute(
+            """
         SELECT COUNT(*) FROM application_repeat_audit
         WHERE tenant_id = ? AND target_job_id = ?
         """,
-        (LOCAL_TENANT, LOCAL_JOB_ID),
-    ).fetchone()[0] == 0
+            (LOCAL_TENANT, LOCAL_JOB_ID),
+        ).fetchone()[0]
+        == 0
+    )
 
 
-def test_targeted_acquire_resolves_retired_alias_without_prefix_collision(
+def test_targeted_acquire_binds_exact_job_id_without_prefix_collision(
     conn: sqlite3.Connection,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    alias = "https://example.test/jobs/123"
     wrong_job_id = "90000000-0000-4000-8000-000000000031"
     target_job_id = "90000000-0000-4000-8000-000000000032"
     _insert_ready_job(
         conn,
         LOCAL_TENANT,
         wrong_job_id,
-        url=f"{alias}-extra",
+        url="https://example.test/jobs/123-extra",
     )
     _insert_ready_job(
         conn,
@@ -333,40 +354,368 @@ def test_targeted_acquire_resolves_retired_alias_without_prefix_collision(
         target_job_id,
         url="https://example.test/jobs/456",
     )
-    conn.execute(
-        """
-        INSERT INTO job_locators (
-            tenant_id, job_id, locator_kind, locator_value,
-            is_current, first_seen_at, last_seen_at, retired_at
-        ) VALUES (?, ?, 'posting_url', ?, 0, ?, ?, ?)
-        """,
-        (LOCAL_TENANT, target_job_id, alias, TIMESTAMP, TIMESTAMP, TIMESTAMP),
-    )
     conn.commit()
     monkeypatch.setattr("jobctrl.apply.launcher.get_connection", lambda: conn)
 
     job = acquire_job(
-        target_url=alias,
+        target_job_id=JobId(target_job_id),
         tenant_id=LOCAL_TENANT,
         approval_required=False,
     )
 
     assert job is not None
     assert job["job_id"] == target_job_id
-    assert conn.execute(
+    assert (
+        conn.execute(
+            """
+        SELECT state FROM job_stage_states
+        WHERE tenant_id = ? AND job_id = ? AND stage = 'apply'
+        """,
+            (LOCAL_TENANT, target_job_id),
+        ).fetchone()["state"]
+        == "running"
+    )
+    assert (
+        conn.execute(
+            """
+        SELECT COUNT(*) FROM job_stage_states
+        WHERE tenant_id = ? AND job_id = ? AND stage = 'apply'
+        """,
+            (LOCAL_TENANT, wrong_job_id),
+        ).fetchone()[0]
+        == 0
+    )
+
+
+def test_targeted_acquire_rejects_a_url_shaped_job_id(
+    conn: sqlite3.Connection,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _insert_ready_job(conn, LOCAL_TENANT, LOCAL_JOB_ID)
+    conn.commit()
+    monkeypatch.setattr("jobctrl.apply.launcher.get_connection", lambda: conn)
+
+    with pytest.raises(ValueError, match="canonical UUID"):
+        acquire_job(
+            target_job_id=JobId(SHARED_URL),
+            tenant_id=LOCAL_TENANT,
+            approval_required=False,
+        )
+
+
+def test_targeted_apply_lifecycle_preserves_other_tenant_job_id(
+    conn: sqlite3.Connection,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _insert_ready_job(conn, OTHER_TENANT, OTHER_JOB_ID)
+    conn.commit()
+    captured: dict[str, object] = {}
+
+    class _UseCase:
+        def execute(self, **kwargs):
+            captured.update(kwargs)
+            return SimpleNamespace(skipped=True)
+
+    monkeypatch.setattr("jobctrl.apply.launcher.get_connection", lambda: conn)
+    monkeypatch.setattr("jobctrl.apply.launcher._build_use_case", _UseCase)
+    monkeypatch.setattr("jobctrl.apply.launcher.reset_worker_dir", lambda _worker_id: tmp_path)
+    monkeypatch.setattr("jobctrl.apply.launcher.add_event", lambda _message: None)
+    monkeypatch.setattr("jobctrl.apply.launcher.update_state", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        "jobctrl.browser_capabilities.require_system_browser_capability",
+        lambda _capability: None,
+    )
+
+    assert worker_loop(
+        target_job_id=JobId(OTHER_JOB_ID),
+        tenant_id=OTHER_TENANT,
+        approval_required=False,
+        dry_run=True,
+        snapshot=object(),
+    ) == (0, 0)
+    assert captured["tenant_id"] == TenantId(OTHER_TENANT)
+    assert captured["job"]["tenant_id"] == OTHER_TENANT
+    assert captured["job"]["job_id"] == OTHER_JOB_ID
+
+    rows = conn.execute(
+        """
+        SELECT tenant_id, job_id, event_type
+        FROM job_events
+        WHERE stage = 'apply'
+        ORDER BY event_id
+        """
+    ).fetchall()
+    assert [tuple(row) for row in rows] == [
+        (OTHER_TENANT, OTHER_JOB_ID, "ApplyRunStarted"),
+        (OTHER_TENANT, OTHER_JOB_ID, "LockReleased"),
+    ]
+
+
+def test_apply_result_release_and_manual_mark_write_exact_v7_identity(
+    conn: sqlite3.Connection,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _insert_ready_job(conn, LOCAL_TENANT, LOCAL_JOB_ID)
+    _insert_ready_job(conn, OTHER_TENANT, OTHER_JOB_ID)
+    for tenant_id, job_id in (
+        (LOCAL_TENANT, LOCAL_JOB_ID),
+        (OTHER_TENANT, OTHER_JOB_ID),
+    ):
+        conn.execute(
+            """
+            INSERT INTO job_stage_states (
+                tenant_id, job_id, stage, state, attempt_count, updated_at
+            ) VALUES (?, ?, 'apply', 'running', 1, ?)
+            """,
+            (tenant_id, job_id, TIMESTAMP),
+        )
+    conn.commit()
+    monkeypatch.setattr("jobctrl.apply.launcher.get_connection", lambda: conn)
+    monkeypatch.setattr("jobctrl.apply.launcher.config.LOG_DIR", tmp_path)
+
+    run_ctx = {
+        "run_id": "local-result-run",
+        "tenant_id": LOCAL_TENANT,
+        "worker_id": 7,
+    }
+    mark_result(
+        JobId(LOCAL_JOB_ID),
+        "applied",
+        run_ctx=run_ctx,
+        tenant_id=TenantId(LOCAL_TENANT),
+    )
+    release_lock(
+        JobId(LOCAL_JOB_ID),
+        run_ctx=run_ctx,
+        tenant_id=TenantId(LOCAL_TENANT),
+    )
+    mark_job(
+        JobId(LOCAL_JOB_ID),
+        "applied",
+        reason="Confirmed outside JobCtrl.",
+        tenant_id=TenantId(LOCAL_TENANT),
+    )
+
+    states = conn.execute(
+        """
+        SELECT tenant_id, state
+        FROM job_stage_states
+        WHERE job_id IN (?, ?) AND stage = 'apply'
+        ORDER BY tenant_id
+        """,
+        (LOCAL_JOB_ID, OTHER_JOB_ID),
+    ).fetchall()
+    assert [(row["tenant_id"], row["state"]) for row in states] == [
+        (LOCAL_TENANT, "succeeded"),
+        (OTHER_TENANT, "running"),
+    ]
+    assert (
+        conn.execute(
+            """
+        SELECT COUNT(*) FROM job_events
+        WHERE tenant_id = ? AND job_id = ?
+          AND event_type IN (
+            'ApplicationSubmitted', 'LockReleased', 'ApplicationManuallyMarked'
+          )
+        """,
+            (LOCAL_TENANT, LOCAL_JOB_ID),
+        ).fetchone()[0]
+        == 3
+    )
+    assert (
+        conn.execute(
+            """
+        SELECT COUNT(*) FROM job_events
+        WHERE tenant_id = ? AND job_id = ?
+          AND event_type IN (
+            'ApplicationSubmitted', 'LockReleased', 'ApplicationManuallyMarked'
+          )
+        """,
+            (OTHER_TENANT, OTHER_JOB_ID),
+        ).fetchone()[0]
+        == 0
+    )
+    artifact = conn.execute(
+        """
+        SELECT tenant_id, job_id, artifact_type
+        FROM job_artifacts
+        WHERE tenant_id = ? AND job_id = ?
+        """,
+        (LOCAL_TENANT, LOCAL_JOB_ID),
+    ).fetchone()
+    assert tuple(artifact) == (LOCAL_TENANT, LOCAL_JOB_ID, "apply_log")
+
+
+def test_apply_recovery_uses_exact_v7_identity_and_preserves_terminal_peer(
+    conn: sqlite3.Connection,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _insert_ready_job(conn, LOCAL_TENANT, LOCAL_JOB_ID)
+    _insert_ready_job(conn, OTHER_TENANT, OTHER_JOB_ID)
+    for tenant_id, job_id, run_id in (
+        (LOCAL_TENANT, LOCAL_JOB_ID, "local-run"),
+        (OTHER_TENANT, OTHER_JOB_ID, "other-run"),
+    ):
+        conn.execute(
+            """
+            INSERT INTO job_stage_states (
+                tenant_id, job_id, stage, state, attempt_count, updated_at
+            ) VALUES (?, ?, 'apply', 'running', 1, ?)
+            """,
+            (tenant_id, job_id, TIMESTAMP),
+        )
+        conn.execute(
+            """
+            INSERT INTO job_events (
+                tenant_id, job_id, identity_version, stage, event_type,
+                occurred_at, payload_json
+            ) VALUES (?, ?, 1, 'apply', 'ApplyRunStarted', ?, ?)
+            """,
+            (tenant_id, job_id, TIMESTAMP, json.dumps({"run_id": run_id})),
+        )
+    conn.execute(
+        """
+        INSERT INTO job_events (
+            tenant_id, job_id, identity_version, stage, event_type,
+            occurred_at, payload_json
+        ) VALUES (?, ?, 1, 'apply', 'ApplySubmitIntended', ?, ?)
+        """,
+        (
+            LOCAL_TENANT,
+            LOCAL_JOB_ID,
+            TIMESTAMP,
+            json.dumps({"run_id": "local-run"}),
+        ),
+    )
+    conn.execute(
+        """
+        INSERT INTO job_events (
+            tenant_id, job_id, identity_version, stage, event_type,
+            occurred_at, payload_json
+        ) VALUES (?, ?, 1, 'apply', 'ApplicationSubmitted', ?, ?)
+        """,
+        (
+            OTHER_TENANT,
+            OTHER_JOB_ID,
+            TIMESTAMP,
+            json.dumps({"run_id": "other-run"}),
+        ),
+    )
+    conn.commit()
+    monkeypatch.setattr("jobctrl.apply.launcher.get_connection", lambda: conn)
+
+    assert recover_ambiguous_running_apply() == 1
+    states = conn.execute(
+        """
+        SELECT tenant_id, state
+        FROM job_stage_states
+        WHERE job_id IN (?, ?) AND stage = 'apply'
+        ORDER BY tenant_id
+        """,
+        (LOCAL_JOB_ID, OTHER_JOB_ID),
+    ).fetchall()
+    assert [(row["tenant_id"], row["state"]) for row in states] == [
+        (LOCAL_TENANT, "needs_verification"),
+        (OTHER_TENANT, "running"),
+    ]
+
+
+def test_dry_run_completion_binds_to_exact_v7_job(
+    conn: sqlite3.Connection,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _insert_ready_job(conn, LOCAL_TENANT, LOCAL_JOB_ID)
+    conn.execute(
+        """
+        INSERT INTO job_stage_states (
+            tenant_id, job_id, stage, state, attempt_count, updated_at
+        ) VALUES (?, ?, 'apply', 'running', 1, ?)
+        """,
+        (LOCAL_TENANT, LOCAL_JOB_ID, TIMESTAMP),
+    )
+    conn.execute(
+        """
+        INSERT INTO job_events (
+            tenant_id, job_id, identity_version, stage, event_type,
+            occurred_at, payload_json
+        ) VALUES (?, ?, 1, 'apply', 'ApplyRunStarted', ?, ?)
+        """,
+        (
+            LOCAL_TENANT,
+            LOCAL_JOB_ID,
+            TIMESTAMP,
+            json.dumps(
+                {
+                    "run_id": "dry-run-1",
+                    "materials_generation": 1,
+                    "profile_version": 3,
+                    "application_url": f"{SHARED_URL}/apply",
+                }
+            ),
+        ),
+    )
+    conn.commit()
+    monkeypatch.setattr("jobctrl.apply.launcher.get_connection", lambda: conn)
+
+    mark_result(
+        JobId(LOCAL_JOB_ID),
+        "dry_run",
+        run_ctx={
+            "run_id": "dry-run-1",
+            "tenant_id": LOCAL_TENANT,
+            "materials_generation": 1,
+            "profile_version": 3,
+            "application_url": f"{SHARED_URL}/apply",
+        },
+        tenant_id=TenantId(LOCAL_TENANT),
+    )
+    mark_result(
+        JobId(LOCAL_JOB_ID),
+        "dry_run",
+        run_ctx={
+            "run_id": "dry-run-1",
+            "tenant_id": LOCAL_TENANT,
+            "materials_generation": 1,
+            "profile_version": 3,
+            "application_url": f"{SHARED_URL}/apply",
+        },
+        tenant_id=TenantId(LOCAL_TENANT),
+    )
+
+    state = conn.execute(
         """
         SELECT state FROM job_stage_states
         WHERE tenant_id = ? AND job_id = ? AND stage = 'apply'
         """,
-        (LOCAL_TENANT, target_job_id),
-    ).fetchone()["state"] == "running"
-    assert conn.execute(
+        (LOCAL_TENANT, LOCAL_JOB_ID),
+    ).fetchone()
+    assert state["state"] == "skipped"
+    event = conn.execute(
         """
-        SELECT COUNT(*) FROM job_stage_states
-        WHERE tenant_id = ? AND job_id = ? AND stage = 'apply'
+        SELECT payload_json FROM job_events
+        WHERE tenant_id = ? AND job_id = ? AND event_type = 'DryRunCompleted'
+        ORDER BY event_id DESC LIMIT 1
         """,
-        (LOCAL_TENANT, wrong_job_id),
-    ).fetchone()[0] == 0
+        (LOCAL_TENANT, LOCAL_JOB_ID),
+    ).fetchone()
+    payload = json.loads(event["payload_json"])
+    assert (
+        conn.execute(
+            """
+        SELECT COUNT(*) FROM job_events
+        WHERE tenant_id = ? AND job_id = ?
+          AND event_type = 'DryRunCompleted'
+        """,
+            (LOCAL_TENANT, LOCAL_JOB_ID),
+        ).fetchone()[0]
+        == 1
+    )
+    assert payload["jobId"] == LOCAL_JOB_ID
+    assert payload["materials_generation"] == 1
+    assert payload["profile_version"] == 3
+    assert payload["application_url"] == f"{SHARED_URL}/apply"
 
 
 def _record_submitted_application(
@@ -472,13 +821,16 @@ def test_repeat_protection_never_overrides_canonical_identity(
             consumed_at=TIMESTAMP,
         )
 
-    assert conn.execute(
-        """
+    assert (
+        conn.execute(
+            """
         SELECT COUNT(*) FROM application_repeat_override_consumptions
         WHERE tenant_id = ? AND override_id = ?
         """,
-        (LOCAL_TENANT, override_id),
-    ).fetchone()[0] == 0
+            (LOCAL_TENANT, override_id),
+        ).fetchone()[0]
+        == 0
+    )
 
 
 def test_repeat_protection_does_not_cross_tenants_with_shared_job_id_and_url(
@@ -496,10 +848,13 @@ def test_repeat_protection_does_not_cross_tenants_with_shared_job_id_and_url(
     )
 
     assert assessment["status"] == "clear"
-    assert conn.execute(
-        """
+    assert (
+        conn.execute(
+            """
         SELECT COUNT(*) FROM application_repeat_audit
         WHERE tenant_id = ? AND target_job_id = ?
         """,
-        (LOCAL_TENANT, LOCAL_JOB_ID),
-    ).fetchone()[0] == 0
+            (LOCAL_TENANT, LOCAL_JOB_ID),
+        ).fetchone()[0]
+        == 0
+    )

--- a/workers/automation/tests/test_exact_v7_apply_acquire_job_identity.py
+++ b/workers/automation/tests/test_exact_v7_apply_acquire_job_identity.py
@@ -1,0 +1,505 @@
+"""Exact-v7 identity regressions for the apply claim boundary.
+
+The apply runtime receives posting URLs only as browser locators. Its durable
+claim, approval, profile, event, and repeat-protection reads must stay scoped
+to the selected ``(tenant_id, job_id)`` aggregate.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from jobctrl.apply.launcher import _latest_apply_review_decision, acquire_job
+from jobctrl.apply.origins import canonical_http_url
+from jobctrl.database import init_db
+from jobctrl.domain.apply.repeat_application import (
+    consume_repeat_application_override,
+    evaluate_repeat_application,
+    repeat_evidence_fingerprint,
+)
+from jobctrl.domain.identifiers import canonical_job_id
+from jobctrl.domain.tenant import TenantId
+
+
+LOCAL_TENANT = "local"
+OTHER_TENANT = "other"
+SHARED_URL = "https://example.test/jobs/shared"
+LOCAL_JOB_ID = "90000000-0000-4000-8000-000000000011"
+OTHER_JOB_ID = "90000000-0000-4000-8000-000000000012"
+TIMESTAMP = "2026-07-31T12:00:00+00:00"
+
+
+@pytest.fixture()
+def conn(tmp_path: Path) -> sqlite3.Connection:
+    return init_db(tmp_path / "jobctrl.db")
+
+
+def _insert_ready_job(
+    conn: sqlite3.Connection,
+    tenant_id: str,
+    job_id: str,
+    *,
+    url: str = SHARED_URL,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO jobs (tenant_id, job_id, url, title, company, site, discovered_at)
+        VALUES (?, ?, ?, 'Platform Engineer', 'Example', 'Example', ?)
+        """,
+        (tenant_id, job_id, url, TIMESTAMP),
+    )
+    conn.execute(
+        """
+        INSERT INTO job_locators (
+            tenant_id, job_id, locator_kind, locator_value,
+            is_current, first_seen_at, last_seen_at
+        ) VALUES (?, ?, 'posting_url', ?, 1, ?, ?)
+        """,
+        (tenant_id, job_id, url, TIMESTAMP, TIMESTAMP),
+    )
+    conn.execute(
+        """
+        INSERT INTO job_enrichments (
+            tenant_id, job_id, current_status, full_description, application_url, updated_at
+        ) VALUES (?, ?, 'enriched', 'Build reliable systems.', ?, ?)
+        """,
+        (tenant_id, job_id, f"{url}/apply", TIMESTAMP),
+    )
+    conn.execute(
+        """
+        INSERT INTO job_scores (
+            tenant_id, job_id, version, fit_score, breakdown_json, keywords_json, scored_at
+        ) VALUES (?, ?, 1, 9, '{}', '[]', ?)
+        """,
+        (tenant_id, job_id, TIMESTAMP),
+    )
+    conn.execute(
+        """
+        INSERT INTO job_materials (
+            tenant_id, job_id, generation, status, created_at, updated_at
+        ) VALUES (?, ?, 1, 'approved', ?, ?)
+        """,
+        (tenant_id, job_id, TIMESTAMP, TIMESTAMP),
+    )
+    for artifact_type in ("tailored_resume", "resume_pdf"):
+        conn.execute(
+            """
+            INSERT INTO job_materials_artifacts (
+                tenant_id, job_id, generation, artifact_type, artifact_id,
+                status, path, render_format, created_at
+            ) VALUES (?, ?, 1, ?, ?, 'approved', ?, 'text', ?)
+            """,
+            (
+                tenant_id,
+                job_id,
+                artifact_type,
+                f"{job_id}:{artifact_type}",
+                f"/tmp/{job_id}-{artifact_type}",
+                TIMESTAMP,
+            ),
+        )
+
+
+def _insert_profile(conn: sqlite3.Connection, tenant_id: str, version: int) -> None:
+    conn.execute(
+        """
+        INSERT INTO candidate_profiles (tenant_id, profile_id, version, updated_at)
+        VALUES (?, 'default', ?, ?)
+        """,
+        (tenant_id, version, TIMESTAMP),
+    )
+
+
+def _insert_approval_with_dry_run(
+    conn: sqlite3.Connection,
+    tenant_id: str,
+    job_id: str,
+    *,
+    profile_version: int,
+) -> None:
+    application_url = f"{SHARED_URL}/apply"
+    conn.execute(
+        """
+        INSERT INTO application_review_decisions (
+            tenant_id, decision_id, job_id, decision, decided_at,
+            materials_generation, profile_version, application_url
+        ) VALUES (?, ?, ?, 'approve_submit', ?, 1, ?, ?)
+        """,
+        (tenant_id, f"approval-{job_id}", job_id, TIMESTAMP, profile_version, application_url),
+    )
+    navigation_fingerprint = hashlib.sha256(
+        canonical_http_url(application_url).encode("utf-8")
+    ).hexdigest()
+    started_payload = {
+        "run_id": f"dry-run-{job_id}",
+        "materials_generation": 1,
+        "profile_version": profile_version,
+        "application_url": application_url,
+    }
+    completed_payload = {
+        **started_payload,
+        "coverage": "full",
+        "allowed_navigations": [
+            {
+                "decision": "run_bound_initial_url",
+                "grant_id": "initial_application_url",
+                "method": "GET",
+                "url_fingerprint": navigation_fingerprint,
+            }
+        ],
+    }
+    for event_type, payload in (
+        ("ApplyRunStarted", started_payload),
+        ("DryRunCompleted", completed_payload),
+    ):
+        conn.execute(
+            """
+            INSERT INTO job_events (
+                tenant_id, job_id, identity_version, stage, event_type, occurred_at, payload_json
+            ) VALUES (?, ?, 1, 'apply', ?, ?, ?)
+            """,
+            (tenant_id, job_id, event_type, TIMESTAMP, json.dumps(payload)),
+        )
+
+
+def test_targeted_acquire_binds_approval_and_profile_to_exact_v7_identity(
+    conn: sqlite3.Connection,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _insert_ready_job(conn, LOCAL_TENANT, LOCAL_JOB_ID)
+    _insert_ready_job(conn, OTHER_TENANT, OTHER_JOB_ID)
+    _insert_profile(conn, LOCAL_TENANT, version=1)
+    _insert_profile(conn, OTHER_TENANT, version=2)
+    _insert_approval_with_dry_run(
+        conn,
+        OTHER_TENANT,
+        OTHER_JOB_ID,
+        profile_version=2,
+    )
+    conn.commit()
+    monkeypatch.setattr("jobctrl.apply.launcher.get_connection", lambda: conn)
+
+    assert acquire_job(
+        target_url=SHARED_URL,
+        tenant_id=LOCAL_TENANT,
+        approval_required=True,
+    ) is None
+
+    _insert_approval_with_dry_run(
+        conn,
+        LOCAL_TENANT,
+        LOCAL_JOB_ID,
+        profile_version=1,
+    )
+    conn.commit()
+
+    run_ctx: dict[str, object] = {}
+    job = acquire_job(
+        target_url=SHARED_URL,
+        tenant_id=LOCAL_TENANT,
+        approval_required=True,
+        run_ctx=run_ctx,
+    )
+
+    assert job is not None
+    assert (job["tenant_id"], job["job_id"], job["url"]) == (
+        LOCAL_TENANT,
+        LOCAL_JOB_ID,
+        SHARED_URL,
+    )
+    assert run_ctx["tenant_id"] == LOCAL_TENANT
+    assert run_ctx["job_id"] == LOCAL_JOB_ID
+    assert run_ctx["profile_version"] == 1
+    assert conn.execute(
+        """
+        SELECT state FROM job_stage_states
+        WHERE tenant_id = ? AND job_id = ? AND stage = 'apply'
+        """,
+        (LOCAL_TENANT, LOCAL_JOB_ID),
+    ).fetchone()["state"] == "running"
+    assert conn.execute(
+        """
+        SELECT COUNT(*) FROM job_events
+        WHERE tenant_id = ? AND job_id = ? AND event_type = 'ApplyRunStarted'
+        """,
+        (LOCAL_TENANT, LOCAL_JOB_ID),
+    ).fetchone()[0] == 2
+    assert conn.execute(
+        """
+        SELECT COUNT(*) FROM job_stage_states
+        WHERE tenant_id = ? AND job_id = ? AND stage = 'apply'
+        """,
+        (OTHER_TENANT, OTHER_JOB_ID),
+    ).fetchone()[0] == 0
+
+
+def test_approval_lookup_preserves_the_apply_claim_transaction(
+    conn: sqlite3.Connection,
+) -> None:
+    _insert_ready_job(conn, LOCAL_TENANT, LOCAL_JOB_ID)
+    _insert_approval_with_dry_run(
+        conn,
+        LOCAL_TENANT,
+        LOCAL_JOB_ID,
+        profile_version=1,
+    )
+    conn.commit()
+    conn.execute("BEGIN IMMEDIATE")
+
+    decision = _latest_apply_review_decision(
+        conn,
+        tenant_id=LOCAL_TENANT,
+        job_id=LOCAL_JOB_ID,
+    )
+
+    assert decision is not None
+    assert decision["decision"] == "approve_submit"
+    assert conn.in_transaction is True
+    conn.rollback()
+
+
+def test_batch_acquire_does_not_cross_tenant_stage_or_repeat_evidence(
+    conn: sqlite3.Connection,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _insert_ready_job(conn, LOCAL_TENANT, LOCAL_JOB_ID)
+    _insert_ready_job(conn, OTHER_TENANT, OTHER_JOB_ID)
+    conn.execute(
+        """
+        INSERT INTO job_stage_states (
+            tenant_id, job_id, stage, state, attempt_count, updated_at
+        ) VALUES (?, ?, 'apply', 'running', 1, ?)
+        """,
+        (OTHER_TENANT, OTHER_JOB_ID, TIMESTAMP),
+    )
+    conn.execute(
+        """
+        INSERT INTO job_events (
+            tenant_id, job_id, identity_version, stage, event_type, occurred_at, payload_json
+        ) VALUES (?, ?, 1, 'apply', 'ApplicationSubmitted', ?, '{}')
+        """,
+        (OTHER_TENANT, OTHER_JOB_ID, TIMESTAMP),
+    )
+    conn.commit()
+    monkeypatch.setattr("jobctrl.apply.launcher.get_connection", lambda: conn)
+
+    job = acquire_job(tenant_id=LOCAL_TENANT, approval_required=False)
+
+    assert job is not None
+    assert (job["tenant_id"], job["job_id"], job["url"]) == (
+        LOCAL_TENANT,
+        LOCAL_JOB_ID,
+        SHARED_URL,
+    )
+    state = conn.execute(
+        """
+        SELECT state, attempt_count FROM job_stage_states
+        WHERE tenant_id = ? AND job_id = ? AND stage = 'apply'
+        """,
+        (LOCAL_TENANT, LOCAL_JOB_ID),
+    ).fetchone()
+    assert state is not None
+    assert (state["state"], state["attempt_count"]) == ("running", 1)
+    assert conn.execute(
+        """
+        SELECT COUNT(*) FROM application_repeat_audit
+        WHERE tenant_id = ? AND target_job_id = ?
+        """,
+        (LOCAL_TENANT, LOCAL_JOB_ID),
+    ).fetchone()[0] == 0
+
+
+def test_targeted_acquire_resolves_retired_alias_without_prefix_collision(
+    conn: sqlite3.Connection,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    alias = "https://example.test/jobs/123"
+    wrong_job_id = "90000000-0000-4000-8000-000000000031"
+    target_job_id = "90000000-0000-4000-8000-000000000032"
+    _insert_ready_job(
+        conn,
+        LOCAL_TENANT,
+        wrong_job_id,
+        url=f"{alias}-extra",
+    )
+    _insert_ready_job(
+        conn,
+        LOCAL_TENANT,
+        target_job_id,
+        url="https://example.test/jobs/456",
+    )
+    conn.execute(
+        """
+        INSERT INTO job_locators (
+            tenant_id, job_id, locator_kind, locator_value,
+            is_current, first_seen_at, last_seen_at, retired_at
+        ) VALUES (?, ?, 'posting_url', ?, 0, ?, ?, ?)
+        """,
+        (LOCAL_TENANT, target_job_id, alias, TIMESTAMP, TIMESTAMP, TIMESTAMP),
+    )
+    conn.commit()
+    monkeypatch.setattr("jobctrl.apply.launcher.get_connection", lambda: conn)
+
+    job = acquire_job(
+        target_url=alias,
+        tenant_id=LOCAL_TENANT,
+        approval_required=False,
+    )
+
+    assert job is not None
+    assert job["job_id"] == target_job_id
+    assert conn.execute(
+        """
+        SELECT state FROM job_stage_states
+        WHERE tenant_id = ? AND job_id = ? AND stage = 'apply'
+        """,
+        (LOCAL_TENANT, target_job_id),
+    ).fetchone()["state"] == "running"
+    assert conn.execute(
+        """
+        SELECT COUNT(*) FROM job_stage_states
+        WHERE tenant_id = ? AND job_id = ? AND stage = 'apply'
+        """,
+        (LOCAL_TENANT, wrong_job_id),
+    ).fetchone()[0] == 0
+
+
+def _record_submitted_application(
+    conn: sqlite3.Connection,
+    tenant_id: str,
+    job_id: str,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO job_events (
+            tenant_id, job_id, identity_version, stage, event_type, occurred_at, payload_json
+        ) VALUES (?, ?, 1, 'apply', 'ApplicationSubmitted', ?, '{}')
+        """,
+        (tenant_id, job_id, TIMESTAMP),
+    )
+
+
+def test_repeat_protection_never_overrides_canonical_identity(
+    conn: sqlite3.Connection,
+) -> None:
+    prior_job_id = "90000000-0000-4000-8000-000000000021"
+    target_job_id = "90000000-0000-4000-8000-000000000022"
+    _insert_ready_job(
+        conn,
+        LOCAL_TENANT,
+        prior_job_id,
+        url="https://example.test/jobs/prior",
+    )
+    _insert_ready_job(
+        conn,
+        LOCAL_TENANT,
+        target_job_id,
+        url="https://example.test/jobs/target",
+    )
+    for job_id in (prior_job_id, target_job_id):
+        conn.execute(
+            """
+            INSERT INTO job_canonical_identities (
+                tenant_id, job_id, canonical_url, ats_kind, source_native_id,
+                confidence, resolved_at
+            ) VALUES (?, ?, 'https://boards.example.test/jobs/123', 'greenhouse',
+                      'gh-123', 1.0, ?)
+            """,
+            (LOCAL_TENANT, job_id, TIMESTAMP),
+        )
+    _record_submitted_application(conn, LOCAL_TENANT, prior_job_id)
+    conn.commit()
+
+    tenant_id = TenantId(LOCAL_TENANT)
+    stable_target_id = canonical_job_id(target_job_id)
+    assessment = evaluate_repeat_application(
+        conn,
+        tenant_id=tenant_id,
+        target_job_id=stable_target_id,
+    )
+
+    assert assessment["status"] == "blocked"
+    assert assessment["matches"][0]["relationship"] == "canonical_identity"
+    assert assessment["matches"][0]["priorApplication"]["jobId"] == prior_job_id
+    assert assessment["evidenceFingerprint"] == repeat_evidence_fingerprint(
+        target_job_id,
+        assessment["matches"],
+    )
+
+    override_id = "repeat-override-v7"
+    conn.execute(
+        """
+        INSERT INTO application_repeat_overrides (
+            tenant_id, override_id, target_job_id, prior_job_id, relationship,
+            evidence_fingerprint, evidence_json, reason, confirmed_by, confirmed_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, 'Prior application was withdrawn.', 'qa-user', ?)
+        """,
+        (
+            LOCAL_TENANT,
+            override_id,
+            target_job_id,
+            prior_job_id,
+            assessment["matches"][0]["relationship"],
+            assessment["evidenceFingerprint"],
+            json.dumps(assessment["matches"], separators=(",", ":")),
+            TIMESTAMP,
+        ),
+    )
+    conn.commit()
+
+    still_blocked = evaluate_repeat_application(
+        conn,
+        tenant_id=tenant_id,
+        target_job_id=stable_target_id,
+        record_audit=False,
+    )
+    assert still_blocked["status"] == "blocked"
+    assert still_blocked["override"]["targetJobId"] == target_job_id
+    assert still_blocked["override"]["priorJobId"] == prior_job_id
+
+    with pytest.raises(ValueError, match="repeat application protection refused: blocked"):
+        consume_repeat_application_override(
+            conn,
+            still_blocked,
+            tenant_id=tenant_id,
+            target_job_id=stable_target_id,
+            run_id="apply-run-v7",
+            consumed_at=TIMESTAMP,
+        )
+
+    assert conn.execute(
+        """
+        SELECT COUNT(*) FROM application_repeat_override_consumptions
+        WHERE tenant_id = ? AND override_id = ?
+        """,
+        (LOCAL_TENANT, override_id),
+    ).fetchone()[0] == 0
+
+
+def test_repeat_protection_does_not_cross_tenants_with_shared_job_id_and_url(
+    conn: sqlite3.Connection,
+) -> None:
+    _insert_ready_job(conn, LOCAL_TENANT, LOCAL_JOB_ID)
+    _insert_ready_job(conn, OTHER_TENANT, LOCAL_JOB_ID)
+    _record_submitted_application(conn, OTHER_TENANT, LOCAL_JOB_ID)
+    conn.commit()
+
+    assessment = evaluate_repeat_application(
+        conn,
+        tenant_id=TenantId(LOCAL_TENANT),
+        target_job_id=canonical_job_id(LOCAL_JOB_ID),
+    )
+
+    assert assessment["status"] == "clear"
+    assert conn.execute(
+        """
+        SELECT COUNT(*) FROM application_repeat_audit
+        WHERE tenant_id = ? AND target_job_id = ?
+        """,
+        (LOCAL_TENANT, LOCAL_JOB_ID),
+    ).fetchone()[0] == 0

--- a/workers/automation/tests/test_materials_queue_selectors.py
+++ b/workers/automation/tests/test_materials_queue_selectors.py
@@ -96,20 +96,20 @@ def _seed_apply_selector_job(
 ) -> tuple[JobId, str]:
     job_id = _seed_selector_job(conn, name)
     url = f"https://example.com/{name}"
-    conn.execute(
+    cursor = conn.execute(
         """
-        INSERT INTO job_enrichments (
-            tenant_id, job_id, current_status, full_description,
-            application_url, updated_at
-        ) VALUES (?, ?, 'enriched', 'desc', ?, ?)
+        UPDATE job_enrichments
+        SET application_url = ?, updated_at = ?
+        WHERE tenant_id = ? AND job_id = ?
         """,
         (
-            LOCAL_TENANT,
-            job_id,
             f"{url}/apply",
             "2024-01-01T00:00:00+00:00",
+            LOCAL_TENANT,
+            job_id,
         ),
     )
+    assert cursor.rowcount == 1
     conn.commit()
     return job_id, url
 
@@ -755,29 +755,10 @@ def test_acquire_job_picks_up_materials_only_tailored_jobs(tmp_path) -> None:
     ``job_materials_artifacts`` (no legacy ``jobs.tailored_resume_path``)."""
     from jobctrl.apply.launcher import acquire_job
     from jobctrl.database import close_connection, get_connection
-    from jobctrl.domain.scoring import (
-        FitScore,
-        JobScore,
-        MatchedKeywords,
-        ScoreBreakdown,
-    )
-    from jobctrl.infrastructure.scoring import SqliteScoreRepository
-
     db_path = tmp_path / "apply.db"
     conn = init_db(db_path)
     try:
         job_id, url = _seed_apply_selector_job(conn, "apply-materials-pdf")
-        # Score the job (apply requires fit_score >= min_score).
-        SqliteScoreRepository(conn).save(
-            JobScore.initial(
-                tenant_id=LOCAL_TENANT,
-                job_id=job_id,
-                fit_score=FitScore.create(9),
-                breakdown=ScoreBreakdown(reasoning="ok"),
-                matched_keywords=MatchedKeywords.from_iterable(["python"]),
-                scored_at="2024-01-02T00:00:00+00:00",
-            )
-        )
         # Tailor via materials (no legacy column write).
         SqliteMaterialsRepository(conn).save(
             MaterialsSetFactory.initial(
@@ -822,28 +803,10 @@ def test_acquire_job_picks_up_materials_only_tailored_jobs(tmp_path) -> None:
 def test_acquire_job_excludes_materials_only_text_resume_without_pdf(tmp_path) -> None:
     from jobctrl.apply.launcher import acquire_job
     from jobctrl.database import close_connection, get_connection
-    from jobctrl.domain.scoring import (
-        FitScore,
-        JobScore,
-        MatchedKeywords,
-        ScoreBreakdown,
-    )
-    from jobctrl.infrastructure.scoring import SqliteScoreRepository
-
     db_path = tmp_path / "apply.db"
     conn = init_db(db_path)
     try:
         job_id, _url = _seed_apply_selector_job(conn, "apply-materials-text-only")
-        SqliteScoreRepository(conn).save(
-            JobScore.initial(
-                tenant_id=LOCAL_TENANT,
-                job_id=job_id,
-                fit_score=FitScore.create(9),
-                breakdown=ScoreBreakdown(reasoning="ok"),
-                matched_keywords=MatchedKeywords.from_iterable(["python"]),
-                scored_at="2024-01-02T00:00:00+00:00",
-            )
-        )
         SqliteMaterialsRepository(conn).save(
             MaterialsSetFactory.initial(
                 tenant_id=LOCAL_TENANT,

--- a/workers/automation/tests/test_materials_queue_selectors.py
+++ b/workers/automation/tests/test_materials_queue_selectors.py
@@ -90,6 +90,30 @@ def _seed_selector_job(
     return _job_id(url)
 
 
+def _seed_apply_selector_job(
+    conn: sqlite3.Connection,
+    name: str,
+) -> tuple[JobId, str]:
+    job_id = _seed_selector_job(conn, name)
+    url = f"https://example.com/{name}"
+    conn.execute(
+        """
+        INSERT INTO job_enrichments (
+            tenant_id, job_id, current_status, full_description,
+            application_url, updated_at
+        ) VALUES (?, ?, 'enriched', 'desc', ?, ?)
+        """,
+        (
+            LOCAL_TENANT,
+            job_id,
+            f"{url}/apply",
+            "2024-01-01T00:00:00+00:00",
+        ),
+    )
+    conn.commit()
+    return job_id, url
+
+
 def _make_resume_artifact(path: str = "/tmp/r.txt") -> Artifact:
     return Artifact.create(
         type=ArtifactType.TAILORED_RESUME,
@@ -742,27 +766,7 @@ def test_acquire_job_picks_up_materials_only_tailored_jobs(tmp_path) -> None:
     db_path = tmp_path / "apply.db"
     conn = init_db(db_path)
     try:
-        url = "https://example.com/job"
-        job_id = _job_id(url)
-        conn.execute(
-            "INSERT INTO jobs (tenant_id, job_id, url, title, site, discovered_at) "
-            "VALUES (?, ?, ?, ?, ?, ?)",
-            (
-                LOCAL_TENANT,
-                job_id,
-                url,
-                "Engineer",
-                "Acme",
-                "2024-01-01T00:00:00+00:00",
-            ),
-        )
-        conn.execute(
-            "INSERT INTO job_enrichments "
-            "(tenant_id, job_id, current_status, full_description, application_url, updated_at) "
-            "VALUES (?, ?, 'enriched', 'desc', 'https://example.com/apply', ?)",
-            (LOCAL_TENANT, job_id, "2024-01-01T00:00:00+00:00"),
-        )
-        conn.commit()
+        job_id, url = _seed_apply_selector_job(conn, "apply-materials-pdf")
         # Score the job (apply requires fit_score >= min_score).
         SqliteScoreRepository(conn).save(
             JobScore.initial(
@@ -791,7 +795,10 @@ def test_acquire_job_picks_up_materials_only_tailored_jobs(tmp_path) -> None:
             )
         )
         legacy_path = conn.execute(
-            "SELECT tailored_resume_path FROM jobs WHERE tenant_id = ? AND job_id = ?",
+            """
+            SELECT tailored_resume_path FROM jobs
+            WHERE tenant_id = ? AND job_id = ?
+            """,
             (LOCAL_TENANT, job_id),
         ).fetchone()[0]
         assert legacy_path is None  # confirm no legacy write happened
@@ -826,27 +833,7 @@ def test_acquire_job_excludes_materials_only_text_resume_without_pdf(tmp_path) -
     db_path = tmp_path / "apply.db"
     conn = init_db(db_path)
     try:
-        url = "https://example.com/job"
-        job_id = _job_id(url)
-        conn.execute(
-            "INSERT INTO jobs (tenant_id, job_id, url, title, site, discovered_at) "
-            "VALUES (?, ?, ?, ?, ?, ?)",
-            (
-                LOCAL_TENANT,
-                job_id,
-                url,
-                "Engineer",
-                "Acme",
-                "2024-01-01T00:00:00+00:00",
-            ),
-        )
-        conn.execute(
-            "INSERT INTO job_enrichments "
-            "(tenant_id, job_id, current_status, full_description, application_url, updated_at) "
-            "VALUES (?, ?, 'enriched', 'desc', 'https://example.com/apply', ?)",
-            (LOCAL_TENANT, job_id, "2024-01-01T00:00:00+00:00"),
-        )
-        conn.commit()
+        job_id, _url = _seed_apply_selector_job(conn, "apply-materials-text-only")
         SqliteScoreRepository(conn).save(
             JobScore.initial(
                 tenant_id=LOCAL_TENANT,

--- a/workers/automation/tests/test_operational_metrics.py
+++ b/workers/automation/tests/test_operational_metrics.py
@@ -108,6 +108,33 @@ def test_record_operational_attempt_metric_is_append_only_and_structured(tmp_pat
         close_connection(db_path)
 
 
+def test_record_operational_attempt_metric_preserves_tenant_and_job_id(tmp_path: Path) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    conn = init_db(db_path)
+    job_id = "90000000-0000-4000-8000-000000000001"
+    conn.execute(
+        """
+        INSERT INTO jobs (tenant_id, job_id, url, title, discovered_at)
+        VALUES ('other', ?, 'https://example.com/job', 'Example', '2026-07-31T00:00:00+00:00')
+        """,
+        (job_id,),
+    )
+    record_operational_attempt_metric(
+        conn,
+        stage="apply",
+        attempt_kind="apply_batch",
+        outcome="started",
+        tenant_id="other",
+        job_id=job_id,
+    )
+    row = conn.execute(
+        "SELECT tenant_id, job_id FROM operational_attempt_metrics ORDER BY metric_id DESC LIMIT 1"
+    ).fetchone()
+    assert (row["tenant_id"], row["job_id"]) == ("other", job_id)
+    assert "job_url" not in row.keys()
+    close_connection(db_path)
+
+
 def test_discovery_source_attempts_model_board_and_canonical_source_roles(monkeypatch) -> None:
     calls: list[dict[str, object]] = []
     sources = (

--- a/workers/automation/tests/test_repeat_application_prevention.py
+++ b/workers/automation/tests/test_repeat_application_prevention.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import sqlite3
 import threading
+import uuid
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -17,18 +18,29 @@ from jobctrl.apply.launcher import (
     release_lock,
     worker_loop,
 )
-from jobctrl.database import SCHEMA_VERSION, close_connection, get_connection, init_db
+from jobctrl.database import close_connection, get_connection, init_db
 from jobctrl.domain.apply.repeat_application import (
     consume_repeat_application_override,
     evaluate_repeat_application,
     repeat_evidence_fingerprint,
 )
 from jobctrl.domain.apply.value_objects import ApplyPrompt
-from jobctrl.state import ensure_job_stage_rows, record_job_event
+from jobctrl.domain.identifiers import JobId
+from jobctrl.domain.tenant import TenantId
+from jobctrl.state import ensure_job_stage_rows, record_job_event, set_stage_state
 
 PRIOR = "https://jobs.example.test/prior"
 TARGET = "https://careers.example.test/target"
 NOW = "2026-07-20T08:00:00+00:00"
+LOCAL_TENANT = TenantId("local")
+
+
+def _job_id_for(url: str) -> JobId:
+    return JobId(str(uuid.uuid5(uuid.NAMESPACE_URL, f"jobctrl-repeat-v7:{url}")))
+
+
+PRIOR_JOB_ID = _job_id_for(PRIOR)
+TARGET_JOB_ID = _job_id_for(TARGET)
 
 
 def _insert_job(
@@ -39,22 +51,47 @@ def _insert_job(
     company: str,
     ready: bool = False,
     fit_score: int = 9,
-) -> None:
+    tenant_id: TenantId = LOCAL_TENANT,
+    job_id: JobId | None = None,
+) -> JobId:
+    stable_job_id = job_id or _job_id_for(url)
     conn.execute(
         """
         INSERT INTO jobs (
-          url, title, company, site, description, full_description,
-          application_url, fit_score, tailored_resume_path, discovered_at
-        ) VALUES (?, ?, ?, 'test', 'Build reliable systems.', 'Build reliable systems.',
-                  ?, ?, ?, ?)
+          tenant_id, job_id, url, title, company, site, description, discovered_at
+        ) VALUES (?, ?, ?, ?, ?, 'test', 'Build reliable systems.', ?)
         """,
         (
+            str(tenant_id),
+            str(stable_job_id),
             url,
             title,
             company,
+            NOW,
+        ),
+    )
+    conn.execute(
+        """
+        INSERT INTO job_locators (
+          tenant_id, job_id, locator_kind, locator_value, is_current,
+          first_seen_at, last_seen_at, retired_at
+        ) VALUES (?, ?, 'posting_url', ?, 1, ?, ?, NULL)
+        """,
+        (str(tenant_id), str(stable_job_id), url, NOW, NOW),
+    )
+    conn.execute(
+        """
+        INSERT INTO job_enrichments (
+          tenant_id, job_id, current_status, full_description,
+          application_url, enriched_at, extraction_tier, updated_at
+        ) VALUES (?, ?, 'enriched', 'Build reliable systems.', ?,
+                  ?, 'high', ?)
+        """,
+        (
+            str(tenant_id),
+            str(stable_job_id),
             f"{url}/apply",
-            fit_score,
-            "/tmp/repeat-resume.txt" if ready else None,
+            NOW,
             NOW,
         ),
     )
@@ -63,17 +100,41 @@ def _insert_job(
             """
             INSERT OR REPLACE INTO candidate_profiles (
               tenant_id, profile_id, version, updated_at
-            ) VALUES ('local', 'default', 1, ?)
+            ) VALUES (?, 'default', 1, ?)
             """,
-            (NOW,),
+            (str(tenant_id), NOW),
+        )
+        conn.execute(
+            """
+            INSERT INTO job_scores (
+              tenant_id, job_id, version, fit_score, breakdown_json,
+              keywords_json, scored_at, correction_json, criteria_json,
+              trace_json
+            ) VALUES (?, ?, 1, ?, ?, '[]', ?, NULL, '{}', '{}')
+            """,
+            (
+                str(tenant_id),
+                str(stable_job_id),
+                fit_score,
+                json.dumps(
+                    {
+                        "reasoning": "eligible",
+                        "eligibility": {
+                            "status": "eligible",
+                            "hard_blockers": [],
+                        },
+                    }
+                ),
+                NOW,
+            ),
         )
         conn.execute(
             """
             INSERT INTO job_materials (
-              job_url, generation, tenant_id, status, created_at, updated_at
-            ) VALUES (?, 1, 'local', 'approved', ?, ?)
+              tenant_id, job_id, generation, status, created_at, updated_at
+            ) VALUES (?, ?, 1, 'approved', ?, ?)
             """,
-            (url, NOW, NOW),
+            (str(tenant_id), str(stable_job_id), NOW, NOW),
         )
         for artifact_type, artifact_id, path in (
             ("tailored_resume", f"resume-{url}", "/tmp/repeat-resume.txt"),
@@ -82,26 +143,35 @@ def _insert_job(
             conn.execute(
                 """
                 INSERT INTO job_materials_artifacts (
-                  job_url, generation, artifact_type, artifact_id, status, path,
-                  render_format, created_at
-                ) VALUES (?, 1, ?, ?, 'approved', ?, 'text', ?)
+                  tenant_id, job_id, generation, artifact_type, artifact_id,
+                  status, path, render_format, created_at
+                ) VALUES (?, ?, 1, ?, ?, 'approved', ?, 'text', ?)
                 """,
-                (url, artifact_type, artifact_id, path, NOW),
+                (
+                    str(tenant_id),
+                    str(stable_job_id),
+                    artifact_type,
+                    artifact_id,
+                    path,
+                    NOW,
+                ),
             )
-        ensure_job_stage_rows(conn, url)
     conn.commit()
+    return stable_job_id
 
 
 def _confirm_application(
     conn: sqlite3.Connection,
-    job_key: str = PRIOR,
+    job_id: JobId = PRIOR_JOB_ID,
     event_type: str = "ApplicationSubmitted",
+    tenant_id: TenantId = LOCAL_TENANT,
 ) -> None:
     record_job_event(
         conn,
-        job_key,
+        job_id,
         "apply",
         event_type,
+        tenant_id=tenant_id,
         occurred_at=NOW,
         payload={"run_id": "prior-run"},
     )
@@ -113,20 +183,22 @@ def _insert_override(
     assessment: dict,
     *,
     override_id: str = "repeat-override-1",
-    target_job_key: str = TARGET,
+    target_job_id: JobId = TARGET_JOB_ID,
+    tenant_id: TenantId = LOCAL_TENANT,
 ) -> None:
     primary = assessment["matches"][0]
     conn.execute(
         """
         INSERT INTO application_repeat_overrides (
-          tenant_id, override_id, target_job_key, prior_job_key, relationship,
+          tenant_id, override_id, target_job_id, prior_job_id, relationship,
           evidence_fingerprint, evidence_json, reason, confirmed_by, confirmed_at
-        ) VALUES ('local', ?, ?, ?, ?, ?, ?, ?, 'qa-user', ?)
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'qa-user', ?)
         """,
         (
+            str(tenant_id),
             override_id,
-            target_job_key,
-            primary["priorApplication"]["jobKey"],
+            str(target_job_id),
+            primary["priorApplication"]["jobId"],
             primary["relationship"],
             assessment["evidenceFingerprint"],
             json.dumps(assessment["matches"], separators=(",", ":")),
@@ -156,6 +228,23 @@ def _seed_equivalent_repeat(db_path: Path) -> sqlite3.Connection:
     return conn
 
 
+def _evaluate(
+    conn: sqlite3.Connection,
+    job_id: JobId = TARGET_JOB_ID,
+    *,
+    tenant_id: TenantId = LOCAL_TENANT,
+    record_audit: bool = True,
+    evaluated_at: str | None = None,
+) -> dict:
+    return evaluate_repeat_application(
+        conn,
+        tenant_id=tenant_id,
+        target_job_id=job_id,
+        record_audit=record_audit,
+        evaluated_at=evaluated_at,
+    )
+
+
 def test_worker_fingerprint_matches_shared_portable_multi_match_fixture() -> None:
     fixture_path = (
         Path(__file__).resolve().parents[3]
@@ -163,11 +252,32 @@ def test_worker_fingerprint_matches_shared_portable_multi_match_fixture() -> Non
     )
     fixture = json.loads(fixture_path.read_text(encoding="utf-8"))
 
-    assert repeat_evidence_fingerprint(fixture["targetJobKey"], fixture["matches"]) == fixture["expectedFingerprint"]
     assert (
-        repeat_evidence_fingerprint(fixture["targetJobKey"], list(reversed(fixture["matches"])))
+        repeat_evidence_fingerprint(
+            fixture["targetJobId"],
+            fixture["matches"],
+        )
         == fixture["expectedFingerprint"]
     )
+    assert (
+        repeat_evidence_fingerprint(
+            fixture["targetJobId"],
+            list(reversed(fixture["matches"])),
+        )
+        == fixture["expectedFingerprint"]
+    )
+
+
+def test_worker_rejects_every_shared_invalid_fingerprint_vector() -> None:
+    fixture_path = (
+        Path(__file__).resolve().parents[3]
+        / "packages/domain-types/test/fixtures/repeat_application_fingerprint_parity.json"
+    )
+    fixture = json.loads(fixture_path.read_text(encoding="utf-8"))
+
+    for vector in fixture["invalidVectors"]:
+        with pytest.raises(ValueError, match=vector["error"]):
+            repeat_evidence_fingerprint(vector["targetJobId"], vector["matches"])
 
 
 def test_exact_canonical_and_accepted_duplicate_identities_block(tmp_path: Path) -> None:
@@ -175,20 +285,20 @@ def test_exact_canonical_and_accepted_duplicate_identities_block(tmp_path: Path)
     _insert_job(conn, url=PRIOR, title="Platform Engineer", company="Acme")
     _insert_job(conn, url=TARGET, title="Different label", company="Different employer")
     _confirm_application(conn)
-    for job_key in (PRIOR, TARGET):
+    for job_id in (PRIOR_JOB_ID, TARGET_JOB_ID):
         conn.execute(
             """
             INSERT INTO job_canonical_identities (
-              tenant_id, job_url, canonical_url, ats_kind, source_native_id,
+              tenant_id, job_id, canonical_url, ats_kind, source_native_id,
               confidence, resolved_at
             ) VALUES ('local', ?, 'https://boards.example.test/jobs/123',
                       'greenhouse', 'gh-123', 1, ?)
             """,
-            (job_key, NOW),
+            (str(job_id), NOW),
         )
     conn.commit()
 
-    exact = evaluate_repeat_application(conn, TARGET)
+    exact = _evaluate(conn)
     assert exact["status"] == "blocked"
     assert exact["matches"][0]["relationship"] == "canonical_identity"
 
@@ -200,11 +310,11 @@ def test_exact_canonical_and_accepted_duplicate_identities_block(tmp_path: Path)
           superseded_job_or_observation_id, reason, confidence, linked_at
         ) VALUES ('local', 'accepted-link', ?, ?, 'accepted_content_identity', 0.99, ?)
         """,
-        (TARGET, PRIOR, NOW),
+        (str(TARGET_JOB_ID), str(PRIOR_JOB_ID), NOW),
     )
     conn.commit()
 
-    linked = evaluate_repeat_application(conn, TARGET)
+    linked = _evaluate(conn)
     assert linked["status"] == "blocked"
     assert linked["matches"][0]["relationship"] == "accepted_duplicate"
 
@@ -213,18 +323,21 @@ def test_projected_employer_preserves_repeat_evidence_when_job_company_is_missin
     conn = init_db(tmp_path / "jobs.db")
     _insert_job(conn, url=PRIOR, title="Senior Backend Engineer", company="")
     _insert_job(conn, url=TARGET, title="Backend Senior Eng", company="", ready=True)
-    conn.execute("UPDATE jobs SET company = NULL")
+    conn.execute(
+        "UPDATE jobs SET company = NULL WHERE tenant_id = ?",
+        (str(LOCAL_TENANT),),
+    )
     conn.execute("DELETE FROM job_list_projections")
     conn.executemany(
         """
         INSERT INTO job_list_projections (tenant_id, job_id, employer)
         VALUES ('local', ?, 'Acme Inc')
         """,
-        [(PRIOR,), (TARGET,)],
+        [(str(PRIOR_JOB_ID),), (str(TARGET_JOB_ID),)],
     )
     _confirm_application(conn)
 
-    assessment = evaluate_repeat_application(conn, TARGET)
+    assessment = _evaluate(conn)
 
     assert assessment["status"] == "confirmation_required"
     match = assessment["matches"][0]
@@ -237,30 +350,44 @@ def test_equivalent_role_requires_confirmation_but_distinct_and_similar_employer
     tmp_path: Path,
 ) -> None:
     conn = _seed_equivalent_repeat(tmp_path / "jobs.db")
-    assert evaluate_repeat_application(conn, TARGET)["status"] == "confirmation_required"
-
-    conn.execute("UPDATE jobs SET title = 'Engineering Manager' WHERE url = ?", (TARGET,))
-    conn.commit()
-    assert evaluate_repeat_application(conn, TARGET)["status"] == "clear"
+    assert _evaluate(conn)["status"] == "confirmation_required"
 
     conn.execute(
-        "UPDATE jobs SET title = 'Senior Backend Engineer', company = 'Acme Health' WHERE url = ?",
-        (TARGET,),
+        """
+        UPDATE jobs SET title = 'Engineering Manager'
+        WHERE tenant_id = ? AND job_id = ?
+        """,
+        (str(LOCAL_TENANT), str(TARGET_JOB_ID)),
     )
     conn.commit()
-    assert evaluate_repeat_application(conn, TARGET)["status"] == "clear"
+    assert _evaluate(conn)["status"] == "clear"
+
+    conn.execute(
+        """
+        UPDATE jobs SET title = 'Senior Backend Engineer', company = 'Acme Health'
+        WHERE tenant_id = ? AND job_id = ?
+        """,
+        (str(LOCAL_TENANT), str(TARGET_JOB_ID)),
+    )
+    conn.commit()
+    assert _evaluate(conn)["status"] == "clear"
 
 
 def test_audit_trail_orders_equal_timestamps_by_sqlite_insertion_order(tmp_path: Path) -> None:
     conn = _seed_equivalent_repeat(tmp_path / "jobs.db")
-    initial = evaluate_repeat_application(conn, TARGET, evaluated_at=NOW)
+    initial = _evaluate(conn, evaluated_at=NOW)
     _insert_override(conn, initial)
-    ready = evaluate_repeat_application(conn, TARGET, record_audit=False, evaluated_at=NOW)
+    ready = _evaluate(
+        conn,
+        record_audit=False,
+        evaluated_at=NOW,
+    )
     assert ready["status"] == "override_ready"
     consume_repeat_application_override(
         conn,
         ready,
-        target_job_key=TARGET,
+        tenant_id=LOCAL_TENANT,
+        target_job_id=TARGET_JOB_ID,
         run_id="equal-timestamp-run",
         consumed_at=NOW,
     )
@@ -275,10 +402,14 @@ def test_audit_trail_orders_equal_timestamps_by_sqlite_insertion_order(tmp_path:
         "UPDATE application_repeat_audit SET audit_id = ? WHERE action = 'override_consumed'",
         ("00000000-0000-0000-0000-000000000000",),
     )
-    ordered = evaluate_repeat_application(conn, TARGET, record_audit=False, evaluated_at=NOW)
+    ordered = _evaluate(
+        conn,
+        record_audit=False,
+        evaluated_at=NOW,
+    )
 
     assert ordered["auditTrail"][0]["action"] == "override_consumed"
-    assert ordered["auditTrail"][0]["priorJobKey"] == PRIOR
+    assert ordered["auditTrail"][0]["priorJobId"] == str(PRIOR_JOB_ID)
 
 
 def test_unconfirmed_sources_do_not_establish_application_history(tmp_path: Path) -> None:
@@ -288,31 +419,24 @@ def test_unconfirmed_sources_do_not_establish_application_history(tmp_path: Path
     for event_type in ("DryRunCompleted", "ApplicationFailed", "ApplySubmitIntended"):
         record_job_event(
             conn,
-            PRIOR,
+            PRIOR_JOB_ID,
             "apply",
             event_type,
+            tenant_id=LOCAL_TENANT,
             occurred_at=NOW,
             payload={"run_id": event_type},
         )
     conn.execute(
         """
-        CREATE TABLE IF NOT EXISTS application_outcome_suggestions (
-          tenant_id TEXT NOT NULL, suggestion_id TEXT NOT NULL, job_key TEXT NOT NULL,
-          suggested_kind TEXT NOT NULL, status TEXT NOT NULL, created_at TEXT NOT NULL
-        )
-        """
-    )
-    conn.execute(
-        """
         INSERT INTO application_outcome_suggestions
-          (tenant_id, suggestion_id, job_key, suggested_kind, status, created_at)
+          (tenant_id, suggestion_id, job_id, suggested_kind, status, created_at)
         VALUES ('local', 'pending-suggestion', ?, 'applied_confirmation', 'pending', ?)
         """,
-        (PRIOR, NOW),
+        (str(PRIOR_JOB_ID), NOW),
     )
     conn.commit()
 
-    assert evaluate_repeat_application(conn, TARGET)["status"] == "clear"
+    assert _evaluate(conn)["status"] == "clear"
 
 
 def test_manual_mark_is_a_user_attested_confirmed_fact_not_a_submission(
@@ -327,19 +451,31 @@ def test_manual_mark_is_a_user_attested_confirmed_fact_not_a_submission(
         "jobctrl.apply.launcher.get_connection", lambda: get_connection(db_path)
     )
 
-    mark_job(PRIOR, "applied", reason="Applied outside JobCtrl.")
+    mark_job(
+        PRIOR_JOB_ID,
+        "applied",
+        reason="Applied outside JobCtrl.",
+        tenant_id=LOCAL_TENANT,
+    )
 
     events = conn.execute(
-        "SELECT event_type, payload_json FROM job_events WHERE job_url = ? ORDER BY event_id",
-        (PRIOR,),
+        """
+        SELECT event_type, payload_json FROM job_events
+        WHERE tenant_id = ? AND job_id = ?
+        ORDER BY event_id
+        """,
+        (str(LOCAL_TENANT), str(PRIOR_JOB_ID)),
     ).fetchall()
     assert [row["event_type"] for row in events] == ["ApplicationManuallyMarked"]
     assert json.loads(events[0]["payload_json"])["source"] == "user_attestation"
     assert conn.execute(
-        "SELECT state FROM job_stage_states WHERE job_url = ? AND stage = 'apply'",
-        (PRIOR,),
+        """
+        SELECT state FROM job_stage_states
+        WHERE tenant_id = ? AND job_id = ? AND stage = 'apply'
+        """,
+        (str(LOCAL_TENANT), str(PRIOR_JOB_ID)),
     ).fetchone()[0] == "succeeded"
-    assessment = evaluate_repeat_application(conn, TARGET)
+    assessment = _evaluate(conn)
     assert assessment["status"] == "confirmation_required"
     assert assessment["matches"][0]["priorApplication"]["factKind"] == (
         "application_manually_marked"
@@ -368,15 +504,23 @@ def test_authoritative_claim_blocks_direct_dispatch_and_repeated_standing_polls(
 
     assert (
         conn.execute(
-            "SELECT COUNT(*) FROM job_events WHERE job_url = ? AND event_type = 'ApplyRunStarted'",
-            (TARGET,),
+            """
+            SELECT COUNT(*) FROM job_events
+            WHERE tenant_id = ? AND job_id = ?
+              AND event_type = 'ApplyRunStarted'
+            """,
+            (str(LOCAL_TENANT), str(TARGET_JOB_ID)),
         ).fetchone()[0]
         == 0
     )
     assert (
         conn.execute(
-            "SELECT COUNT(*) FROM application_repeat_audit WHERE target_job_key = ? AND action = 'confirmation_required'",
-            (TARGET,),
+            """
+            SELECT COUNT(*) FROM application_repeat_audit
+            WHERE tenant_id = ? AND target_job_id = ?
+              AND action = 'confirmation_required'
+            """,
+            (str(LOCAL_TENANT), str(TARGET_JOB_ID)),
         ).fetchone()[0]
         == 1
     )
@@ -388,7 +532,11 @@ def test_authoritative_claim_blocks_direct_dispatch_and_repeated_standing_polls(
         run_ctx={"dry_run": True, "run_id": "safe-dry-run"},
     )
     assert dry_run is not None
-    release_lock(TARGET, run_ctx={"run_id": "safe-dry-run"})
+    release_lock(
+        TARGET_JOB_ID,
+        run_ctx={"run_id": "safe-dry-run"},
+        tenant_id=LOCAL_TENANT,
+    )
 
 
 def test_non_targeted_claim_skips_protected_high_ranked_job_for_distinct_role(
@@ -414,19 +562,31 @@ def test_non_targeted_claim_skips_protected_high_ranked_job_for_distinct_role(
     assert claimed["url"] == clear_job
     assert (
         conn.execute(
-            "SELECT COUNT(*) FROM job_events WHERE job_url = ? AND event_type = 'ApplyRunStarted'",
-            (TARGET,),
+            """
+            SELECT COUNT(*) FROM job_events
+            WHERE tenant_id = ? AND job_id = ?
+              AND event_type = 'ApplyRunStarted'
+            """,
+            (str(LOCAL_TENANT), str(TARGET_JOB_ID)),
         ).fetchone()[0]
         == 0
     )
     assert (
         conn.execute(
-            "SELECT COUNT(*) FROM application_repeat_audit WHERE target_job_key = ? AND action = 'confirmation_required'",
-            (TARGET,),
+            """
+            SELECT COUNT(*) FROM application_repeat_audit
+            WHERE tenant_id = ? AND target_job_id = ?
+              AND action = 'confirmation_required'
+            """,
+            (str(LOCAL_TENANT), str(TARGET_JOB_ID)),
         ).fetchone()[0]
         == 1
     )
-    release_lock(clear_job, run_ctx={"run_id": str(claimed["apply_run_id"])})
+    release_lock(
+        _job_id_for(clear_job),
+        run_ctx={"run_id": str(claimed["apply_run_id"])},
+        tenant_id=LOCAL_TENANT,
+    )
 
 
 def test_protected_queue_audit_survives_lower_candidate_approval_refusal(
@@ -449,8 +609,12 @@ def test_protected_queue_audit_survives_lower_candidate_approval_refusal(
 
     assert acquire_job(worker_id=51, approval_required=True) is None
     assert conn.execute(
-        "SELECT COUNT(*) FROM application_repeat_audit WHERE target_job_key = ? AND action = 'confirmation_required'",
-        (TARGET,),
+        """
+        SELECT COUNT(*) FROM application_repeat_audit
+        WHERE tenant_id = ? AND target_job_id = ?
+          AND action = 'confirmation_required'
+        """,
+        (str(LOCAL_TENANT), str(TARGET_JOB_ID)),
     ).fetchone()[0] == 1
 
 
@@ -496,15 +660,23 @@ def test_standing_loop_skips_protected_candidate_and_processes_distinct_role(
     assert (applied, failed) == (0, 1)
     assert (
         conn.execute(
-            "SELECT COUNT(*) FROM job_events WHERE job_url = ? AND event_type = 'ApplyRunStarted'",
-            (TARGET,),
+            """
+            SELECT COUNT(*) FROM job_events
+            WHERE tenant_id = ? AND job_id = ?
+              AND event_type = 'ApplyRunStarted'
+            """,
+            (str(LOCAL_TENANT), str(TARGET_JOB_ID)),
         ).fetchone()[0]
         == 0
     )
     assert (
         conn.execute(
-            "SELECT COUNT(*) FROM job_events WHERE job_url = ? AND event_type = 'ApplicationFailed'",
-            (clear_job,),
+            """
+            SELECT COUNT(*) FROM job_events
+            WHERE tenant_id = ? AND job_id = ?
+              AND event_type = 'ApplicationFailed'
+            """,
+            (str(LOCAL_TENANT), str(_job_id_for(clear_job))),
         ).fetchone()[0]
         == 1
     )
@@ -536,13 +708,13 @@ def test_worker_batch_uses_unique_attempt_ids_for_two_repeat_overrides(
             ready=True,
             fit_score=fit_score,
         )
-        _confirm_application(conn, prior)
-        assessment = evaluate_repeat_application(conn, target)
+        _confirm_application(conn, _job_id_for(prior))
+        assessment = _evaluate(conn, _job_id_for(target))
         _insert_override(
             conn,
             assessment,
             override_id=f"repeat-batch-override-{index}",
-            target_job_key=target,
+            target_job_id=_job_id_for(target),
         )
 
     monkeypatch.setattr("jobctrl.apply.launcher.get_connection", lambda: get_connection(db_path))
@@ -584,7 +756,7 @@ def test_gen_prompt_is_read_only_and_cannot_consume_repeat_override(
 ) -> None:
     db_path = tmp_path / "jobs.db"
     conn = _seed_equivalent_repeat(db_path)
-    _insert_override(conn, evaluate_repeat_application(conn, TARGET))
+    _insert_override(conn, _evaluate(conn))
     app_dir = tmp_path / "app"
     log_dir = tmp_path / "logs"
     monkeypatch.setattr("jobctrl.apply.launcher.get_connection", lambda: get_connection(db_path))
@@ -611,7 +783,26 @@ def test_gen_prompt_is_read_only_and_cannot_consume_repeat_override(
 
     monkeypatch.setattr("jobctrl.apply.launcher.ApplyPromptBuilder", InspectionBuilder)
 
-    prompt_path = gen_prompt(TARGET, snapshot=object())
+    ensure_job_stage_rows(
+        conn,
+        TARGET_JOB_ID,
+        tenant_id=LOCAL_TENANT,
+    )
+    set_stage_state(
+        conn,
+        TARGET_JOB_ID,
+        "score",
+        "succeeded",
+        tenant_id=LOCAL_TENANT,
+        validate_transition=False,
+    )
+    conn.commit()
+
+    prompt_path = gen_prompt(
+        TARGET_JOB_ID,
+        snapshot=object(),
+        tenant_id=LOCAL_TENANT,
+    )
 
     assert prompt_path is not None
     assert prompt_path.read_text(encoding="utf-8") == ("Inspection-only repeat-application prompt")
@@ -619,15 +810,22 @@ def test_gen_prompt_is_read_only_and_cannot_consume_repeat_override(
     assert conn.execute("SELECT COUNT(*) FROM application_repeat_override_consumptions").fetchone()[0] == 0
     assert (
         conn.execute(
-            "SELECT COUNT(*) FROM job_events WHERE job_url = ? AND event_type = 'ApplyRunStarted'",
-            (TARGET,),
+            """
+            SELECT COUNT(*) FROM job_events
+            WHERE tenant_id = ? AND job_id = ?
+              AND event_type = 'ApplyRunStarted'
+            """,
+            (str(LOCAL_TENANT), str(TARGET_JOB_ID)),
         ).fetchone()[0]
         == 0
     )
     assert (
         conn.execute(
-            "SELECT state FROM job_stage_states WHERE job_url = ? AND stage = 'apply'",
-            (TARGET,),
+            """
+            SELECT state FROM job_stage_states
+            WHERE tenant_id = ? AND job_id = ? AND stage = 'apply'
+            """,
+            (str(LOCAL_TENANT), str(TARGET_JOB_ID)),
         ).fetchone()[0]
         == "pending"
     )
@@ -639,7 +837,7 @@ def test_override_is_consumed_once_under_concurrent_claims(
 ) -> None:
     db_path = tmp_path / "jobs.db"
     conn = _seed_equivalent_repeat(db_path)
-    assessment = evaluate_repeat_application(conn, TARGET)
+    assessment = _evaluate(conn)
     _insert_override(conn, assessment)
     close_connection(db_path)
     monkeypatch.setattr("jobctrl.apply.launcher.get_connection", lambda: get_connection(db_path))
@@ -689,16 +887,16 @@ def test_stale_apply_approval_does_not_consume_repeat_override(
 ) -> None:
     db_path = tmp_path / "jobs.db"
     conn = _seed_equivalent_repeat(db_path)
-    _insert_override(conn, evaluate_repeat_application(conn, TARGET))
+    _insert_override(conn, _evaluate(conn))
     conn.execute(
         """
         INSERT INTO application_review_decisions (
-          tenant_id, decision_id, job_key, decision, reason, decided_by, decided_at,
+          tenant_id, decision_id, job_id, decision, reason, decided_by, decided_at,
           materials_generation, profile_version, application_url
         ) VALUES ('local', 'stale-approval', ?, 'approve_submit', 'test', 'qa', ?,
                   0, 1, ?)
         """,
-        (TARGET, NOW, f"{TARGET}/apply"),
+        (str(TARGET_JOB_ID), NOW, f"{TARGET}/apply"),
     )
     conn.commit()
     monkeypatch.setattr("jobctrl.apply.launcher.get_connection", lambda: get_connection(db_path))
@@ -707,45 +905,55 @@ def test_stale_apply_approval_does_not_consume_repeat_override(
     assert conn.execute("SELECT COUNT(*) FROM application_repeat_override_consumptions").fetchone()[0] == 0
 
 
-def test_schema_v5_migrates_additively_without_changing_application_facts(
+def test_repeat_application_tables_are_exact_v7_and_preserve_application_facts(
     tmp_path: Path,
 ) -> None:
-    db_path = tmp_path / "jobs.db"
-    conn = init_db(db_path)
+    conn = init_db(tmp_path / "jobs.db")
     _insert_job(conn, url=PRIOR, title="Platform Engineer", company="Acme")
     _confirm_application(conn)
-    conn.executescript(
+    facts = conn.execute(
         """
-        DROP TABLE application_repeat_audit;
-        DROP TABLE application_repeat_override_consumptions;
-        DROP TABLE application_repeat_overrides;
-        ALTER TABLE job_stage_states DROP COLUMN metadata_json;
-        PRAGMA user_version = 5;
-        """
-    )
-    before = conn.execute(
-        "SELECT event_type, occurred_at, payload_json FROM job_events WHERE job_url = ?",
-        (PRIOR,),
-    ).fetchall()
-    conn.close()
-
-    migrated = init_db(db_path)
-    after = migrated.execute(
-        "SELECT event_type, occurred_at, payload_json FROM job_events WHERE job_url = ?",
-        (PRIOR,),
+        SELECT tenant_id, job_id, event_type, occurred_at, payload_json
+        FROM job_events
+        WHERE tenant_id = ? AND job_id = ?
+        """,
+        (str(LOCAL_TENANT), str(PRIOR_JOB_ID)),
     ).fetchall()
 
-    assert int(migrated.execute("PRAGMA user_version").fetchone()[0]) == SCHEMA_VERSION == 6
-    assert [tuple(row) for row in after] == [tuple(row) for row in before]
-    assert "metadata_json" in {
-        str(row[1]) for row in migrated.execute("PRAGMA table_info(job_stage_states)").fetchall()
+    assert [tuple(row[:4]) for row in facts] == [
+        (
+            str(LOCAL_TENANT),
+            str(PRIOR_JOB_ID),
+            "ApplicationSubmitted",
+            NOW,
+        )
+    ]
+    assert json.loads(facts[0]["payload_json"]) == {
+        "jobId": str(PRIOR_JOB_ID),
+        "level": "info",
+        "message": "",
+        "run_id": "prior-run",
+        "stage": "apply",
     }
     for table_name in (
         "application_repeat_overrides",
         "application_repeat_override_consumptions",
         "application_repeat_audit",
     ):
-        assert migrated.execute(
+        columns = {
+            str(row[1])
+            for row in conn.execute(
+                f"PRAGMA table_info({table_name})"
+            ).fetchall()
+        }
+        assert "tenant_id" in columns
+        assert conn.execute(
             "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?",
             (table_name,),
         ).fetchone()
+    assert {"target_job_id", "prior_job_id"} <= {
+        str(row[1])
+        for row in conn.execute(
+            "PRAGMA table_info(application_repeat_overrides)"
+        ).fetchall()
+    }

--- a/workers/automation/tests/test_repeat_application_prevention.py
+++ b/workers/automation/tests/test_repeat_application_prevention.py
@@ -43,6 +43,15 @@ PRIOR_JOB_ID = _job_id_for(PRIOR)
 TARGET_JOB_ID = _job_id_for(TARGET)
 
 
+def _target_job_id(conn: sqlite3.Connection, url: str) -> str:
+    row = conn.execute(
+        "SELECT job_id FROM jobs WHERE tenant_id = 'local' AND url = ? LIMIT 1",
+        (url,),
+    ).fetchone()
+    assert row is not None
+    return str(row["job_id"])
+
+
 def _insert_job(
     conn: sqlite3.Connection,
     *,
@@ -447,9 +456,7 @@ def test_manual_mark_is_a_user_attested_confirmed_fact_not_a_submission(
     conn = init_db(db_path)
     _insert_job(conn, url=PRIOR, title="Senior Backend Engineer", company="Acme")
     _insert_job(conn, url=TARGET, title="Senior Backend Engineer", company="Acme")
-    monkeypatch.setattr(
-        "jobctrl.apply.launcher.get_connection", lambda: get_connection(db_path)
-    )
+    monkeypatch.setattr("jobctrl.apply.launcher.get_connection", lambda: get_connection(db_path))
 
     mark_job(
         PRIOR_JOB_ID,
@@ -468,18 +475,19 @@ def test_manual_mark_is_a_user_attested_confirmed_fact_not_a_submission(
     ).fetchall()
     assert [row["event_type"] for row in events] == ["ApplicationManuallyMarked"]
     assert json.loads(events[0]["payload_json"])["source"] == "user_attestation"
-    assert conn.execute(
-        """
+    assert (
+        conn.execute(
+            """
         SELECT state FROM job_stage_states
         WHERE tenant_id = ? AND job_id = ? AND stage = 'apply'
         """,
-        (str(LOCAL_TENANT), str(PRIOR_JOB_ID)),
-    ).fetchone()[0] == "succeeded"
+            (str(LOCAL_TENANT), str(PRIOR_JOB_ID)),
+        ).fetchone()[0]
+        == "succeeded"
+    )
     assessment = _evaluate(conn)
     assert assessment["status"] == "confirmation_required"
-    assert assessment["matches"][0]["priorApplication"]["factKind"] == (
-        "application_manually_marked"
-    )
+    assert assessment["matches"][0]["priorApplication"]["factKind"] == ("application_manually_marked")
 
 
 def test_authoritative_claim_blocks_direct_dispatch_and_repeated_standing_polls(
@@ -492,7 +500,7 @@ def test_authoritative_claim_blocks_direct_dispatch_and_repeated_standing_polls(
 
     assert (
         acquire_job(
-            target_url=TARGET,
+            target_job_id=_target_job_id(conn, TARGET),
             worker_id=1,
             approval_required=False,
             run_ctx={"dry_run": False, "run_id": "direct-bypass"},
@@ -526,7 +534,7 @@ def test_authoritative_claim_blocks_direct_dispatch_and_repeated_standing_polls(
     )
 
     dry_run = acquire_job(
-        target_url=TARGET,
+        target_job_id=_target_job_id(conn, TARGET),
         worker_id=3,
         approval_required=False,
         run_ctx={"dry_run": True, "run_id": "safe-dry-run"},
@@ -603,19 +611,20 @@ def test_protected_queue_audit_survives_lower_candidate_approval_refusal(
         ready=True,
         fit_score=8,
     )
-    monkeypatch.setattr(
-        "jobctrl.apply.launcher.get_connection", lambda: get_connection(db_path)
-    )
+    monkeypatch.setattr("jobctrl.apply.launcher.get_connection", lambda: get_connection(db_path))
 
     assert acquire_job(worker_id=51, approval_required=True) is None
-    assert conn.execute(
-        """
+    assert (
+        conn.execute(
+            """
         SELECT COUNT(*) FROM application_repeat_audit
         WHERE tenant_id = ? AND target_job_id = ?
           AND action = 'confirmation_required'
         """,
-        (str(LOCAL_TENANT), str(TARGET_JOB_ID)),
-    ).fetchone()[0] == 1
+            (str(LOCAL_TENANT), str(TARGET_JOB_ID)),
+        ).fetchone()[0]
+        == 1
+    )
 
 
 def test_standing_loop_skips_protected_candidate_and_processes_distinct_role(
@@ -839,6 +848,7 @@ def test_override_is_consumed_once_under_concurrent_claims(
     conn = _seed_equivalent_repeat(db_path)
     assessment = _evaluate(conn)
     _insert_override(conn, assessment)
+    target_job_id = _target_job_id(conn, TARGET)
     close_connection(db_path)
     monkeypatch.setattr("jobctrl.apply.launcher.get_connection", lambda: get_connection(db_path))
 
@@ -850,7 +860,7 @@ def test_override_is_consumed_once_under_concurrent_claims(
         ready.wait()
         try:
             result = acquire_job(
-                target_url=TARGET,
+                target_job_id=target_job_id,
                 worker_id=worker_id,
                 approval_required=False,
                 run_ctx={"dry_run": False, "run_id": f"concurrent-{worker_id}"},
@@ -901,7 +911,7 @@ def test_stale_apply_approval_does_not_consume_repeat_override(
     conn.commit()
     monkeypatch.setattr("jobctrl.apply.launcher.get_connection", lambda: get_connection(db_path))
 
-    assert acquire_job(target_url=TARGET, worker_id=4, approval_required=True) is None
+    assert acquire_job(target_job_id=_target_job_id(conn, TARGET), worker_id=4, approval_required=True) is None
     assert conn.execute("SELECT COUNT(*) FROM application_repeat_override_consumptions").fetchone()[0] == 0
 
 
@@ -940,20 +950,12 @@ def test_repeat_application_tables_are_exact_v7_and_preserve_application_facts(
         "application_repeat_override_consumptions",
         "application_repeat_audit",
     ):
-        columns = {
-            str(row[1])
-            for row in conn.execute(
-                f"PRAGMA table_info({table_name})"
-            ).fetchall()
-        }
+        columns = {str(row[1]) for row in conn.execute(f"PRAGMA table_info({table_name})").fetchall()}
         assert "tenant_id" in columns
         assert conn.execute(
             "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?",
             (table_name,),
         ).fetchone()
     assert {"target_job_id", "prior_job_id"} <= {
-        str(row[1])
-        for row in conn.execute(
-            "PRAGMA table_info(application_repeat_overrides)"
-        ).fetchall()
+        str(row[1]) for row in conn.execute("PRAGMA table_info(application_repeat_overrides)").fetchall()
     }

--- a/workers/automation/tests/test_rpc_handlers_apply_workflow.py
+++ b/workers/automation/tests/test_rpc_handlers_apply_workflow.py
@@ -175,7 +175,13 @@ def test_apply_handler_forwards_approval_required_flag() -> None:
 def test_apply_handler_rejects_present_unsupported_or_empty_selectors(
     selector: dict[str, object],
 ) -> None:
-    with pytest.raises(ValueError, match="apply (accepts|jobId)"):
+    selector_name = next(iter(selector))
+    expected_message = (
+        r"apply (?:accepts|jobId)"
+        if selector_name == "jobId"
+        else rf"{selector_name} is not supported"
+    )
+    with pytest.raises(ValueError, match=expected_message):
         apply_action({"tenantId": "local", **selector})
 
 

--- a/workers/automation/tests/test_rpc_handlers_apply_workflow.py
+++ b/workers/automation/tests/test_rpc_handlers_apply_workflow.py
@@ -12,6 +12,9 @@ from jobctrl.domain.rpc.messages import JsonRpcRequest, WorkflowStartSpec
 from jobctrl.infrastructure.rpc.handlers import apply_action, register_default_handlers
 from jobctrl.infrastructure.rpc.server import JsonRpcServer
 
+JOB_ID = "90000000-0000-4000-8000-000000000001"
+OTHER_JOB_ID = "90000000-0000-4000-8000-000000000002"
+
 
 @pytest.fixture(autouse=True)
 def permit_browser_for_existing_rpc_spec_tests(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -40,7 +43,7 @@ def test_apply_handler_returns_workflow_start_spec() -> None:
             "tenantId": "local",
             "expectedAppDir": "/tmp/jobctrl",
             "expectedDbPath": "/tmp/jobctrl/jobctrl.db",
-            "jobUrl": "https://example.com/job/1",
+            "jobId": JOB_ID,
             "limit": 2,
             "model": "sonnet",
             "dryRun": True,
@@ -58,7 +61,7 @@ def test_apply_handler_returns_workflow_start_spec() -> None:
         tenant_id="local",
         expected_app_dir="/tmp/jobctrl",
         expected_db_path="/tmp/jobctrl/jobctrl.db",
-        job_url="https://example.com/job/1",
+        job_id=JOB_ID,
         dry_run=True,
         headless=True,
         model="sonnet",
@@ -83,7 +86,7 @@ def test_apply_via_jsonrpc_starts_workflow() -> None:
             method="apply",
             params={
                 "tenantId": "local",
-                "jobUrl": "https://example.com/job/1",
+                "jobId": JOB_ID,
                 "limit": 1,
                 "model": "haiku",
                 "dryRun": False,
@@ -104,7 +107,7 @@ def test_apply_via_jsonrpc_starts_workflow() -> None:
     assert seen[0].workflow is ApplyWorkflow
     (payload,) = seen[0].args
     assert payload.tenant_id == "local"
-    assert payload.job_url == "https://example.com/job/1"
+    assert payload.job_id == JOB_ID
     assert payload.limit == 1
     assert payload.model == "haiku"
 
@@ -129,15 +132,15 @@ def test_apply_handler_continuous_defaults_to_false() -> None:
 
 
 def test_apply_handler_sets_deterministic_workflow_id_for_single_job() -> None:
-    """A single-job apply gets a stable ``apply-{jobKey}`` id so a double-click
+    """A single-job apply gets a stable ``apply-{jobId}`` id so a double-click
     attaches to the running run (USE_EXISTING) instead of double-submitting."""
-    spec_a = apply_action({"tenantId": "local", "jobUrl": "https://example.com/job/1"})
-    spec_b = apply_action({"tenantId": "local", "jobUrl": "https://example.com/job/1"})
-    spec_c = apply_action({"tenantId": "local", "jobUrl": "https://example.com/job/2"})
+    spec_a = apply_action({"tenantId": "local", "jobId": JOB_ID})
+    spec_b = apply_action({"tenantId": "local", "jobId": JOB_ID})
+    spec_c = apply_action({"tenantId": "local", "jobId": OTHER_JOB_ID})
 
     assert spec_a.workflow_id is not None
-    assert spec_a.workflow_id == "apply-local-https://example.com/job/1"
-    # Deterministic: same job URL ⇒ same id; different URL ⇒ different id.
+    assert spec_a.workflow_id == f"apply-local-{JOB_ID}"
+    # Deterministic: same canonical JobId ⇒ same id; different JobId ⇒ different id.
     assert spec_a.workflow_id == spec_b.workflow_id
     assert spec_a.workflow_id != spec_c.workflow_id
 
@@ -149,7 +152,39 @@ def test_apply_handler_forwards_approval_required_flag() -> None:
     assert payload.approval_required is False
 
 
-def test_apply_handler_batch_keeps_uuid_id() -> None:
-    """Batch / continuous apply (no jobUrl) stays on the starter's uuid id."""
+@pytest.mark.parametrize(
+    "selector",
+    [
+        {"jobId": None},
+        {"jobId": ""},
+        {"jobId": "   "},
+        {"jobIds": None},
+        {"jobIds": []},
+        {"jobIds": [JOB_ID]},
+        {"jobUrl": None},
+        {"jobUrl": ""},
+        {"jobUrl": "   "},
+        {"jobUrl": "https://example.test/job"},
+        {"jobUrls": None},
+        {"jobUrls": []},
+        {"jobUrls": [""]},
+        {"jobUrls": ["   "]},
+        {"jobUrls": ["https://example.test/job"]},
+    ],
+)
+def test_apply_handler_rejects_present_unsupported_or_empty_selectors(
+    selector: dict[str, object],
+) -> None:
+    with pytest.raises(ValueError, match="apply (accepts|jobId)"):
+        apply_action({"tenantId": "local", **selector})
+
+
+def test_apply_handler_rejects_noncanonical_job_identity() -> None:
+    with pytest.raises(ValueError, match="canonical UUID"):
+        apply_action({"tenantId": "local", "jobId": JOB_ID.replace("90000000", "9000000a").upper()})
+
+
+def test_apply_handler_batch_keeps_generated_workflow_id() -> None:
+    """Batch / continuous apply (no jobId) stays on the starter's generated id."""
     spec = apply_action({"tenantId": "local", "continuous": True})
     assert spec.workflow_id is None

--- a/workers/automation/tests/test_scoring_eval_feedback.py
+++ b/workers/automation/tests/test_scoring_eval_feedback.py
@@ -214,7 +214,11 @@ def test_acquire_job_does_not_apply_unaccepted_feedback_to_candidate_order(
 
     monkeypatch.setattr(launcher_module, "get_connection", lambda: acquire_conn)
     monkeypatch.setattr(launcher_module, "_load_blocked", lambda: ([], []))
-    monkeypatch.setattr(launcher_module, "ensure_job_stage_rows", lambda *_args: None)
+    monkeypatch.setattr(
+        launcher_module,
+        "ensure_job_stage_rows",
+        lambda *_args, **_kwargs: None,
+    )
     monkeypatch.setattr(launcher_module, "set_stage_state", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(launcher_module, "record_job_event", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(launcher_module, "_current_profile_version", lambda *_args, **_kwargs: 1)

--- a/workers/automation/tests/test_workflow_apply.py
+++ b/workers/automation/tests/test_workflow_apply.py
@@ -28,6 +28,14 @@ from jobctrl.infrastructure.temporal.finalize import (
 from jobctrl.llm import SpendBudgetStatus
 
 
+JOB_ID = "90000000-0000-4000-8000-000000000001"
+
+
+def test_apply_workflow_input_rejects_url_shaped_job_id() -> None:
+    with pytest.raises(ValueError, match="canonical UUID"):
+        ApplyWorkflowInput(tenant_id="local", job_id="https://example.com/job")
+
+
 @pytest.fixture(autouse=True)
 def permit_browser_for_existing_apply_workflow_tests(monkeypatch: pytest.MonkeyPatch) -> None:
     """Workflow retry tests execute after the capability gate has passed."""
@@ -78,7 +86,6 @@ async def test_apply_workflow_returns_ok_when_apply_main_succeeds():
                     ApplyWorkflow.run,
                     ApplyWorkflowInput(
                         tenant_id="local",
-                        job_url="https://example.com/job",
                         min_score=8,
                         limit=3,
                         workers=2,
@@ -120,7 +127,6 @@ async def test_live_apply_workflow_does_not_retry_transient_failures():
                     ApplyWorkflow.run,
                     ApplyWorkflowInput(
                         tenant_id="local",
-                        job_url="https://example.com/job",
                         limit=1,
                     ),
                     id=workflow_id,
@@ -156,7 +162,6 @@ async def test_dry_run_apply_workflow_recovers_when_first_attempt_fails():
                     ApplyWorkflow.run,
                     ApplyWorkflowInput(
                         tenant_id="local",
-                        job_url="https://example.com/job",
                         limit=1,
                         dry_run=True,
                     ),
@@ -190,10 +195,16 @@ async def test_apply_workflow_continuous_batch_is_bounded_and_continues_as_new(m
     )
 
     result = await ApplyWorkflow()._run_apply(
-        ApplyWorkflowInput(tenant_id="local", continuous=True, limit=0)
+        ApplyWorkflowInput(
+            tenant_id="local",
+            job_id=JOB_ID,
+            continuous=True,
+            limit=0,
+        )
     )
 
     assert result.ok is True
+    assert captured["payload"].job_id == JOB_ID
     assert captured["payload"].limit == 25
     assert captured["payload"].continuous is False
     assert captured["timeout"] == timedelta(hours=1)
@@ -292,7 +303,7 @@ async def test_apply_workflow_does_not_retry_lookup_errors():
 
     with patch(
         "jobctrl.apply.launcher.main",
-        side_effect=LookupError("no job URL provided"),
+        side_effect=LookupError("no matching JobId"),
     ) as apply_main_mock:
         async with await WorkflowEnvironment.start_time_skipping() as env:
             async with Worker(
@@ -316,4 +327,4 @@ async def test_apply_workflow_does_not_retry_lookup_errors():
     assert apply_main_mock.call_count == 1
     assert result.ok is False
     assert result.status == "failed"
-    assert "no job URL provided" in (result.error or "")
+    assert "no matching JobId" in (result.error or "")

--- a/workers/automation/tests/test_workflow_job_pipeline.py
+++ b/workers/automation/tests/test_workflow_job_pipeline.py
@@ -47,6 +47,10 @@ from jobctrl.pipeline.workflow import (
 )
 from jobctrl.scoring.activities import score_activity
 from jobctrl.llm import SpendBudgetStatus
+from jobctrl.workflow_specs import (
+    build_pipeline_workflow_spec,
+    build_run_stage_workflow_spec,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -63,6 +67,7 @@ def permit_browser_for_existing_pipeline_workflow_tests(monkeypatch: pytest.Monk
 
 
 _OK_OBSERVED = ({"status": "ok"}, 0.0, "ok")
+_APPLY_JOB_ID = "90000000-0000-4000-8000-000000000001"
 
 
 def test_stage_retry_policies_are_stage_specific():
@@ -220,7 +225,8 @@ async def test_pipeline_workflow_runs_apply_as_child_workflow():
     assert result.stages_failed == []
     assert apply_mock.call_args.kwargs == {
         "limit": 2,
-        "target_url": None,
+        "target_job_id": None,
+        "tenant_id": "local",
         "min_score": 8,
         "headless": True,
         "model": "sonnet",
@@ -230,6 +236,139 @@ async def test_pipeline_workflow_runs_apply_as_child_workflow():
         "workflow_id": f"{workflow_id}-apply",
         "install_signal_handlers": False,
     }
+
+
+@pytest.mark.asyncio
+async def test_pipeline_workflow_preserves_canonical_apply_target():
+    queue = f"pipeline-apply-target-{uuid.uuid4()}"
+    workflow_id = f"pipeline-apply-target-wf-{uuid.uuid4()}"
+
+    with patch("jobctrl.apply.launcher.main", return_value=(0, 0)) as apply_mock:
+        async with await WorkflowEnvironment.start_time_skipping() as env:
+            async with Worker(
+                env.client,
+                task_queue=queue,
+                workflows=[JobPipelineWorkflow, DiscoverWorkflow, ApplyWorkflow],
+                activities=_all_activities(),
+                workflow_runner=UnsandboxedWorkflowRunner(),
+            ):
+                result = await env.client.execute_workflow(
+                    JobPipelineWorkflow.run,
+                    JobPipelineWorkflowInput(
+                        tenant_id="local",
+                        stages=["apply"],
+                        apply_job_id=_APPLY_JOB_ID,
+                        apply_selector_keys=("jobId",),
+                        dry_run=True,
+                    ),
+                    id=workflow_id,
+                    task_queue=queue,
+                )
+
+    assert result.stages_completed == ["apply"]
+    assert apply_mock.call_args.kwargs["target_job_id"] == _APPLY_JOB_ID
+
+
+@pytest.mark.asyncio
+async def test_pipeline_rejects_present_legacy_apply_selector_before_child_start():
+    queue = f"pipeline-apply-selector-{uuid.uuid4()}"
+
+    with patch("jobctrl.apply.launcher.main", return_value=(0, 0)) as apply_mock:
+        async with await WorkflowEnvironment.start_time_skipping() as env:
+            async with Worker(
+                env.client,
+                task_queue=queue,
+                workflows=[JobPipelineWorkflow, DiscoverWorkflow, ApplyWorkflow],
+                activities=_all_activities(),
+                workflow_runner=UnsandboxedWorkflowRunner(),
+            ):
+                with pytest.raises(WorkflowFailureError) as exc_info:
+                    await env.client.execute_workflow(
+                        JobPipelineWorkflow.run,
+                        JobPipelineWorkflowInput(
+                            tenant_id="local",
+                            stages=["apply"],
+                            apply_selector_keys=("jobUrls",),
+                            dry_run=True,
+                        ),
+                        id=f"pipeline-apply-selector-wf-{uuid.uuid4()}",
+                        task_queue=queue,
+                    )
+
+    cause = exc_info.value.cause
+    assert isinstance(cause, ApplicationError)
+    assert cause.non_retryable is True
+    assert "canonical jobId" in str(cause.message)
+    apply_mock.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "selector",
+    [
+        {"jobId": None},
+        {"jobId": ""},
+        {"jobId": "   "},
+        {"jobIds": None},
+        {"jobIds": []},
+        {"jobIds": [_APPLY_JOB_ID]},
+        {"jobUrl": None},
+        {"jobUrl": ""},
+        {"jobUrl": "   "},
+        {"jobUrl": "https://example.test/job"},
+        {"jobUrls": None},
+        {"jobUrls": []},
+        {"jobUrls": [""]},
+        {"jobUrls": ["   "]},
+        {"jobUrls": ["https://example.test/job"]},
+    ],
+)
+def test_pipeline_apply_spec_boundaries_reject_present_unsupported_or_empty_selectors(
+    selector: dict[str, object],
+) -> None:
+    with pytest.raises(ValueError, match="apply (accepts|jobId)"):
+        build_run_stage_workflow_spec({"tenantId": "local", "stage": "apply", **selector})
+    with pytest.raises(ValueError, match="apply (accepts|jobId)"):
+        build_pipeline_workflow_spec(
+            {"tenantId": "local", **selector},
+            stages=["apply"],
+            limit=1,
+        )
+
+
+def test_pipeline_apply_spec_boundaries_preserve_batch_and_canonical_target() -> None:
+    batch = build_run_stage_workflow_spec({"tenantId": "local", "stage": "apply"})
+    (batch_payload,) = batch.args
+    assert batch_payload.apply_selector_keys == ()
+    assert batch_payload.apply_job_id is None
+
+    targeted = build_pipeline_workflow_spec(
+        {"tenantId": "local", "jobId": _APPLY_JOB_ID},
+        stages=["apply"],
+        limit=1,
+    )
+    (targeted_payload,) = targeted.args
+    assert targeted_payload.apply_selector_keys == ("jobId",)
+    assert targeted_payload.apply_job_id == _APPLY_JOB_ID
+
+
+@pytest.mark.parametrize(
+    "selector_kwargs",
+    [
+        {"job_url": "https://example.test/job"},
+        {"job_url": ""},
+        {"job_urls": ("https://example.test/job",)},
+    ],
+)
+def test_pipeline_apply_spec_rejects_direct_legacy_scope_arguments(
+    selector_kwargs: dict[str, object],
+) -> None:
+    with pytest.raises(ValueError, match="apply accepts only a canonical jobId"):
+        build_pipeline_workflow_spec(
+            {"tenantId": "local"},
+            stages=["apply"],
+            limit=1,
+            **selector_kwargs,
+        )
 
 
 @pytest.mark.asyncio
@@ -370,10 +509,7 @@ async def test_pipeline_workflow_forwards_validation_mode_to_tailor_and_cover():
                     task_queue=queue,
                 )
 
-    by_stage = {
-        call.args[0]: call.args[2].get("validation_mode")
-        for call in observed_mock.call_args_list
-    }
+    by_stage = {call.args[0]: call.args[2].get("validation_mode") for call in observed_mock.call_args_list}
     assert by_stage == {"tailor": "lenient", "cover": "lenient"}
 
 
@@ -449,7 +585,10 @@ async def test_current_policy_tailor_continuation_covers_only_approved_jobs():
         # dummy), so stub the finalize writer — the finalize wiring itself is
         # covered by test_workflow_finalize.py.
         patch("jobctrl.infrastructure.temporal.finalize._emit"),
-        patch("jobctrl.pipeline.current_policy_selectors.tailoring_current_policy_job_urls", side_effect=fake_current_policy_urls),
+        patch(
+            "jobctrl.pipeline.current_policy_selectors.tailoring_current_policy_job_urls",
+            side_effect=fake_current_policy_urls,
+        ),
         patch("jobctrl.scoring.tailor.tailor_job_by_url", side_effect=fake_tailor_job_by_url),
         patch("jobctrl.scoring.cover_letter.cover_letter_by_url", side_effect=fake_cover_letter_by_url),
     ):
@@ -513,10 +652,7 @@ async def test_pipeline_workflow_preserves_stage_options():
                     task_queue=queue,
                 )
 
-    by_stage = {
-        call.args[0]: call.args[2]
-        for call in observed_mock.call_args_list
-    }
+    by_stage = {call.args[0]: call.args[2] for call in observed_mock.call_args_list}
     assert "discover" not in by_stage
     assert by_stage["score"]["rescore"] is True
     assert by_stage["tailor"]["min_score"] == 8


### PR DESCRIPTION
## Summary

- claim targeted and batch Apply work by tenant-scoped canonical `JobId`
- resolve a supplied posting locator once, then key approval, profile, stage, event, attempt, dry-run, and repeat-protection state by `(tenant_id, job_id)`
- keep canonical and accepted-duplicate application history as hard, non-overridable submission blocks
- align Repeat Application projections and requests with canonical `jobId`, `priorJobId`, and `targetJobId` fields
- reuse the already-resolved API `JobId` for Apply dispatch without a second URL lookup or duplicate identifier declaration
- keep rejection regressions aligned with selector-specific canonical identity errors

## Why

Apply acquisition previously mixed locator URLs with durable identity. The v7 path must resolve once and keep the live claim transaction, repeat protection, and workflow ID canonical.

## Validation

- focused Apply, selector, feedback, PDF-gate, and Apply Review regressions: passed
- Apply RPC workflow handler suite: 23 passed
- API typecheck: passed
- Fastify Apply route regression: passed
- Fastify server suite excluding the sandbox-prohibited loopback listener: 205 passed, 1 skipped
- independent cumulative review: PASS, 0 Blocker / 0 High
- independent cumulative QA: PASS, 0 Blocker / 0 High

## Stack

Ready-for-review child of #627. Apply result, release, and recovery behavior remain in their existing upstack PRs.
