### PR TITLE
refactor(pipeline): select current-policy jobs by canonical id

### DIFF
--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -305,7 +305,6 @@ import {
   restoreJobs,
   resolveJobId,
   resetStaleScoresForRescore,
-  resolveJobId,
   resolveJobUrl,
   softDeleteJob,
   softDeleteJobs,

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -305,6 +305,7 @@ import {
   restoreJobs,
   resolveJobId,
   resetStaleScoresForRescore,
+  resolveJobId,
   resolveJobUrl,
   softDeleteJob,
   softDeleteJobs,
@@ -1423,8 +1424,8 @@ export function buildApp(options: BuildAppOptions): FastifyInstance {
         return undefined;
       }
       const outcome = await withWritableDb(reply, options.dbPath, async (db) => {
-        const jobUrl = resolveExistingJob(reply, db, decodeRouteParam(request.params.jobKey));
-        if (!jobUrl) {
+        const jobId = resolveExistingJobId(reply, db, decodeRouteParam(request.params.jobKey));
+        if (!jobId) {
           return { ok: false, error: "job_not_found" };
         }
         const jobId = requireJobId(db, jobUrl);
@@ -1736,8 +1737,8 @@ export function buildApp(options: BuildAppOptions): FastifyInstance {
         return undefined;
       }
       const outcome = await withWritableDb(reply, options.dbPath, async (db) => {
-        const jobUrl = resolveExistingJob(reply, db, decodeRouteParam(request.params.jobKey));
-        if (!jobUrl) {
+        const jobId = resolveExistingJobId(reply, db, decodeRouteParam(request.params.jobKey));
+        if (!jobId) {
           return { ok: false, error: "job_not_found" };
         }
         const jobId = requireJobId(db, jobUrl);
@@ -1755,7 +1756,7 @@ export function buildApp(options: BuildAppOptions): FastifyInstance {
           command.tailorJudgeMinScore = body.tailorJudgeMinScore;
         }
         insertJobEvent(db, {
-          jobUrl,
+          jobUrl: jobId,
           stage: "tailor",
           eventType: "RetailorRequested",
           level: "info",
@@ -4310,6 +4311,19 @@ function resolveExistingJob(
     return null;
   }
   return jobUrl;
+}
+
+function resolveExistingJobId(
+  reply: { code: (statusCode: number) => unknown },
+  db: ReturnType<typeof openDatabase>,
+  jobKey: string,
+): string | null {
+  const jobId = resolveJobId(db, "local", jobKey);
+  if (!jobId) {
+    void reply.code(404);
+    return null;
+  }
+  return jobId;
 }
 
 function decodeBase64Pdf(value: string): Buffer {

--- a/apps/api/test/server.test.ts
+++ b/apps/api/test/server.test.ts
@@ -7263,7 +7263,8 @@ describe("local TypeScript API", () => {
       1,
       expect.objectContaining({
         action: "rescore_job",
-        jobKey: "https://example.com/jobs/ready",
+        jobKey: jobIdFor("https://example.com/jobs/ready"),
+        jobId: jobIdFor("https://example.com/jobs/ready"),
         dryRun: true,
         reason: "policy refresh",
       }),
@@ -7294,7 +7295,8 @@ describe("local TypeScript API", () => {
       4,
       expect.objectContaining({
         action: "retailor_job",
-        jobKey: "https://example.com/jobs/ready",
+        jobKey: jobIdFor("https://example.com/jobs/ready"),
+        jobId: jobIdFor("https://example.com/jobs/ready"),
         dryRun: true,
         suppressExistingArtifacts: false,
         tailorModels: ["gemini:test"],

--- a/workers/automation/src/jobctrl/infrastructure/rpc/handlers.py
+++ b/workers/automation/src/jobctrl/infrastructure/rpc/handlers.py
@@ -239,7 +239,8 @@ def _stage_list(params: dict[str, Any]) -> list[str]:
 
 def run_stage(params: dict[str, Any]) -> WorkflowStartSpec:
     try:
-        return build_run_stage_workflow_spec(_legacy_workflow_locator_params(params))
+        _reject_job_url_params(params)
+        return build_run_stage_workflow_spec(params)
     except ValueError as exc:
         raise invalid_params(str(exc)) from exc
 
@@ -565,27 +566,22 @@ def _pipeline_workflow_spec(
     suppress_existing_artifacts: bool = False,
     allow_low_fit_override: bool = False,
 ) -> WorkflowStartSpec:
-    tenant_id = TenantId(_tenant_id(params))
-    conn = get_connection()
-    selected_job_ids = (job_id,) if job_id is not None else job_ids
-    job_urls = _load_current_job_urls_by_id(
-        conn,
-        tenant_id=tenant_id,
-        job_ids=selected_job_ids,
-    )
-    return build_pipeline_workflow_spec(
-        params,
-        stages=stages,
-        limit=limit,
-        rescore=rescore,
-        retailor=retailor,
-        job_url=job_urls[0] if job_id is not None else None,
-        job_urls=job_urls if job_id is None else (),
-        score_current_policy_only=score_current_policy_only,
-        tailor_current_policy_only=tailor_current_policy_only,
-        suppress_existing_artifacts=suppress_existing_artifacts,
-        allow_low_fit_override=allow_low_fit_override,
-    )
+    try:
+        return build_pipeline_workflow_spec(
+            params,
+            stages=stages,
+            limit=limit,
+            rescore=rescore,
+            retailor=retailor,
+            job_id=job_id,
+            job_ids=job_ids,
+            score_current_policy_only=score_current_policy_only,
+            tailor_current_policy_only=tailor_current_policy_only,
+            suppress_existing_artifacts=suppress_existing_artifacts,
+            allow_low_fit_override=allow_low_fit_override,
+        )
+    except ValueError as exc:
+        raise invalid_params(str(exc)) from exc
 
 
 def profile_import(params: dict[str, Any]) -> WorkflowStartSpec:

--- a/workers/automation/src/jobctrl/materials/activities.py
+++ b/workers/automation/src/jobctrl/materials/activities.py
@@ -38,7 +38,7 @@ class TailorActivityInput:
     validation_mode: str = "normal"
     dry_run: bool = False
     retailor: bool = False
-    job_urls: tuple[str, ...] = ()
+    job_ids: tuple[JobId, ...] = ()
     current_policy_only: bool = False
     suppress_existing_artifacts: bool = False
     allow_low_fit_override: bool = False
@@ -47,6 +47,9 @@ class TailorActivityInput:
     tailor_judge_min_score: float | None = None
     llm_model: str = DEFAULT_PIPELINE_LLM_MODEL_SPEC
     workflow_id: str | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "job_ids", _canonical_job_ids(self.job_ids))
 
 
 @dataclass(frozen=True)
@@ -116,7 +119,7 @@ async def tailor_activity(payload: TailorActivityInput) -> TailorActivityOutput:
                 stages=list(result["stages"]),
             )
 
-        if payload.job_urls:
+        if payload.job_ids:
             result = await run_blocking_with_heartbeat(
                 lambda: _run_selected_tailoring(payload, cancel_event=cancel_event),
                 starting_message="selected tailor starting",
@@ -143,8 +146,8 @@ async def tailor_activity(payload: TailorActivityInput) -> TailorActivityOutput:
                         "status": "ok",
                         "elapsed": 0.0,
                         "dry_run": True,
-                        "selectedJobUrls": [],
-                        "approvedJobUrls": [],
+                        "selectedJobIds": [],
+                        "approvedJobIds": [],
                     }
                 ],
             )
@@ -203,16 +206,16 @@ def _run_current_policy_tailoring(
     cancel_event: threading.Event | None = None,
 ) -> dict[str, Any]:
     from jobctrl.database import get_connection
-    from jobctrl.pipeline.current_policy_selectors import tailoring_current_policy_job_urls
+    from jobctrl.pipeline.current_policy_selectors import tailoring_current_policy_job_ids
 
-    urls = tailoring_current_policy_job_urls(
+    job_ids = tailoring_current_policy_job_ids(
         get_connection(),
         tenant_id=payload.tenant_id,
         min_score=payload.min_score,
         limit=payload.limit,
-        job_urls=payload.job_urls,
+        job_ids=payload.job_ids,
     )
-    return _run_selected_tailoring(replace(payload, job_urls=urls, limit=0), cancel_event=cancel_event)
+    return _run_selected_tailoring(replace(payload, job_ids=job_ids, limit=0), cancel_event=cancel_event)
 
 
 def _run_selected_tailoring(
@@ -221,9 +224,9 @@ def _run_selected_tailoring(
     cancel_event: threading.Event | None = None,
 ) -> dict[str, Any]:
     from jobctrl.domain.tenant import TenantId
-    from jobctrl.scoring.tailor import tailor_job_by_url
+    from jobctrl.scoring.tailor import tailor_job_by_id
 
-    urls = _limited_job_urls(payload.job_urls, payload.limit)
+    job_ids = _limited_job_ids(payload.job_ids, payload.limit)
     if payload.dry_run:
         return {
             "status": "ok",
@@ -234,25 +237,25 @@ def _run_selected_tailoring(
                     "stage": "tailor",
                     "status": "ok",
                     "elapsed": 0.0,
-                    "selected": len(urls),
+                    "selected": len(job_ids),
                     "dry_run": True,
-                    "selectedJobUrls": list(urls),
-                    "approvedJobUrls": [],
+                    "selectedJobIds": list(job_ids),
+                    "approvedJobIds": [],
                 }
             ],
         }
 
     t0 = time.time()
     approved = 0
-    approved_urls: list[str] = []
+    approved_job_ids: list[JobId] = []
     skipped = 0
     failed = 0
     errors: dict[str, str] = {}
-    for url in urls:
+    for job_id in job_ids:
         if cancel_event is not None and cancel_event.is_set():
             raise LlmTransientError("tailor activity canceled")
-        result = tailor_job_by_url(
-            url,
+        result = tailor_job_by_id(
+            job_id,
             min_score=payload.min_score,
             validation_mode=payload.validation_mode,
             workers=payload.workers,
@@ -268,12 +271,12 @@ def _run_selected_tailoring(
         status = str(result.get("status") or "error")
         if status == "approved":
             approved += 1
-            approved_urls.append(url)
+            approved_job_ids.append(job_id)
         elif status in {"skipped", "not_eligible"}:
             skipped += 1
         else:
             failed += 1
-            errors[url] = str(result.get("error") or f"Tailoring ended with status {status}")
+            errors[str(job_id)] = str(result.get("error") or f"Tailoring ended with status {status}")
 
     elapsed = time.time() - t0
     status = "failed" if errors else "ok"
@@ -286,10 +289,10 @@ def _run_selected_tailoring(
                 "stage": "tailor",
                 "status": status,
                 "elapsed": elapsed,
-                "selected": len(urls),
+                "selected": len(job_ids),
                 "approved": approved,
-                "selectedJobUrls": list(urls),
-                "approvedJobUrls": approved_urls,
+                "selectedJobIds": list(job_ids),
+                "approvedJobIds": approved_job_ids,
                 "skipped": skipped,
                 "failed": failed,
             }
@@ -297,11 +300,15 @@ def _run_selected_tailoring(
     }
 
 
-def _limited_job_urls(job_urls: tuple[str, ...], limit: int) -> tuple[str, ...]:
-    unique = tuple(dict.fromkeys(url for url in job_urls if url))
+def _limited_job_ids(job_ids: tuple[JobId, ...], limit: int) -> tuple[JobId, ...]:
+    unique = tuple(dict.fromkeys(job_ids))
     if limit > 0:
         return unique[:limit]
     return unique
+
+
+def _canonical_job_ids(job_ids: tuple[JobId, ...]) -> tuple[JobId, ...]:
+    return tuple(dict.fromkeys(canonical_job_id(str(job_id)) for job_id in job_ids))
 
 
 @activity.defn(name="tailor_job")
@@ -369,9 +376,12 @@ class CoverActivityInput:
     limit: int = 0
     validation_mode: str = "normal"
     dry_run: bool = False
-    job_urls: tuple[str, ...] = ()
+    job_ids: tuple[JobId, ...] = ()
     llm_model: str = DEFAULT_PIPELINE_LLM_MODEL_SPEC
     workflow_id: str | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "job_ids", _canonical_job_ids(self.job_ids))
 
 
 @dataclass(frozen=True)
@@ -444,7 +454,7 @@ async def cover_activity(payload: CoverActivityInput) -> CoverActivityOutput:
 
     cancel_event = threading.Event()
     try:
-        if payload.job_urls:
+        if payload.job_ids:
             result = await run_blocking_with_heartbeat(
                 lambda: _run_selected_cover(payload, cancel_event=cancel_event),
                 starting_message="selected cover starting",
@@ -524,9 +534,9 @@ def _run_selected_cover(
     cancel_event: threading.Event | None = None,
 ) -> dict[str, Any]:
     from jobctrl.domain.tenant import TenantId
-    from jobctrl.scoring.cover_letter import cover_letter_by_url
+    from jobctrl.scoring.cover_letter import cover_letter_by_id
 
-    urls = _limited_job_urls(payload.job_urls, payload.limit)
+    job_ids = _limited_job_ids(payload.job_ids, payload.limit)
     if payload.dry_run:
         return {
             "status": "ok",
@@ -537,7 +547,7 @@ def _run_selected_cover(
                     "stage": "cover",
                     "status": "ok",
                     "elapsed": 0.0,
-                    "selected": len(urls),
+                    "selected": len(job_ids),
                     "dry_run": True,
                 }
             ],
@@ -549,11 +559,11 @@ def _run_selected_cover(
     failed = 0
     errors: dict[str, str] = {}
     results: list[dict[str, Any]] = []
-    for url in urls:
+    for job_id in job_ids:
         if cancel_event is not None and cancel_event.is_set():
             raise LlmTransientError("cover activity canceled")
-        result = cover_letter_by_url(
-            url,
+        result = cover_letter_by_id(
+            job_id,
             min_score=payload.min_score,
             validation_mode=payload.validation_mode,
             llm_model=payload.llm_model,
@@ -567,7 +577,7 @@ def _run_selected_cover(
             skipped += 1
         else:
             failed += 1
-            errors[url] = str(result.get("error") or f"Cover ended with status {result_status}")
+            errors[str(job_id)] = str(result.get("error") or f"Cover ended with status {result_status}")
     elapsed = time.time() - t0
     status = "failed" if errors else "ok"
     return {
@@ -579,7 +589,7 @@ def _run_selected_cover(
                 "stage": "cover",
                 "status": status,
                 "elapsed": elapsed,
-                "selected": len(urls),
+                "selected": len(job_ids),
                 "generated": generated,
                 "skipped": skipped,
                 "failed": failed,

--- a/workers/automation/src/jobctrl/pipeline/current_policy_selectors.py
+++ b/workers/automation/src/jobctrl/pipeline/current_policy_selectors.py
@@ -24,31 +24,30 @@ def scoring_current_policy_job_urls(
     current_version = _current_scoring_policy_version(conn, tenant_id)
     requested = _clean_job_urls(job_urls)
     requested_sql, requested_params = _requested_filter("j.url", requested)
-    active_sql = _active_job_filter(conn, "j.url")
+    active_sql = _active_job_filter("j.tenant_id", "j.job_id")
     limit_sql, limit_params = _limit_filter(limit)
 
     rows = conn.execute(
         f"""
         SELECT j.url
         FROM jobs j
-        LEFT JOIN job_enrichments je ON je.job_url = j.url
-        LEFT JOIN (
-            SELECT s.job_url, s.trace_json, s.correction_json
-            FROM job_scores s
-            INNER JOIN (
-                SELECT job_url, MAX(version) AS max_version
-                FROM job_scores
-                WHERE tenant_id = ?
-                GROUP BY job_url
-            ) latest
-              ON latest.job_url = s.job_url AND latest.max_version = s.version
-            WHERE s.tenant_id = ?
-        ) latest_score ON latest_score.job_url = j.url
-        WHERE COALESCE(je.full_description, j.full_description) IS NOT NULL
+        JOIN job_enrichments je
+          ON je.tenant_id = j.tenant_id AND je.job_id = j.job_id
+        LEFT JOIN job_scores latest_score
+          ON latest_score.tenant_id = j.tenant_id
+         AND latest_score.job_id = j.job_id
+         AND latest_score.version = (
+            SELECT MAX(candidate.version)
+            FROM job_scores candidate
+            WHERE candidate.tenant_id = j.tenant_id
+              AND candidate.job_id = j.job_id
+         )
+        WHERE j.tenant_id = ?
+          AND je.full_description IS NOT NULL
           {active_sql}
           {requested_sql}
           AND (
-            latest_score.job_url IS NULL
+            latest_score.job_id IS NULL
             OR (
               (latest_score.correction_json IS NULL OR TRIM(latest_score.correction_json) = '')
               AND {_score_policy_version_expr("latest_score.trace_json")} != ?
@@ -57,7 +56,7 @@ def scoring_current_policy_job_urls(
         ORDER BY j.discovered_at DESC
         {limit_sql}
         """,
-        (tenant_id, tenant_id, *requested_params, current_version, *limit_params),
+        (tenant_id, *requested_params, current_version, *limit_params),
     ).fetchall()
     return tuple(str(row[0]) for row in rows if row[0])
 
@@ -76,89 +75,76 @@ def tailoring_current_policy_job_urls(
     current_version = _current_tailoring_policy_version(conn, tenant_id)
     requested = _clean_job_urls(job_urls)
     requested_sql, requested_params = _requested_filter("j.url", requested)
-    active_sql = _active_job_filter(conn, "j.url")
+    active_sql = _active_job_filter("j.tenant_id", "j.job_id")
     limit_sql, limit_params = _limit_filter(limit)
     effective_tailor_path = (
-        "((lm.materials_job_url IS NOT NULL AND lm.tailored_resume_path IS NOT NULL "
-        "AND lm.tailored_resume_path != '') "
-        "OR (lm.materials_job_url IS NULL AND j.tailored_resume_path IS NOT NULL "
-        "AND j.tailored_resume_path != ''))"
+        "(tailored_resume.job_id IS NOT NULL "
+        "AND tailored_resume.path IS NOT NULL "
+        "AND tailored_resume.path != '')"
     )
 
     rows = conn.execute(
         f"""
         SELECT j.url
         FROM jobs j
-        LEFT JOIN job_enrichments je ON je.job_url = j.url
-        LEFT JOIN (
-            SELECT s.job_url, s.fit_score, s.breakdown_json
-            FROM job_scores s
-            INNER JOIN (
-                SELECT job_url, MAX(version) AS max_version
-                FROM job_scores
-                WHERE tenant_id = ?
-                GROUP BY job_url
-            ) latest
-              ON latest.job_url = s.job_url AND latest.max_version = s.version
-            WHERE s.tenant_id = ?
-        ) latest_score ON latest_score.job_url = j.url
-        LEFT JOIN (
-            SELECT job_url AS stale_job_url
-            FROM job_score_staleness
-            WHERE tenant_id = ? AND resolved = 0
-            GROUP BY job_url
-        ) stale_score ON stale_score.stale_job_url = j.url
+        JOIN job_enrichments je
+          ON je.tenant_id = j.tenant_id AND je.job_id = j.job_id
+        LEFT JOIN job_scores latest_score
+          ON latest_score.tenant_id = j.tenant_id
+         AND latest_score.job_id = j.job_id
+         AND latest_score.version = (
+            SELECT MAX(candidate.version)
+            FROM job_scores candidate
+            WHERE candidate.tenant_id = j.tenant_id
+              AND candidate.job_id = j.job_id
+         )
         LEFT JOIN job_stage_states score_state
-          ON score_state.job_url = j.url AND score_state.stage = 'score'
+          ON score_state.tenant_id = j.tenant_id
+         AND score_state.job_id = j.job_id
+         AND score_state.stage = 'score'
         LEFT JOIN job_stage_states tailor_state
-          ON tailor_state.job_url = j.url AND tailor_state.stage = 'tailor'
-        LEFT JOIN (
-            SELECT m.job_url AS materials_job_url, tr.path AS tailored_resume_path,
-                   tr.metadata_json AS tailored_resume_metadata
-            FROM job_materials m
-            INNER JOIN (
-                SELECT job_url, MAX(generation) AS max_generation
-                FROM job_materials
-                WHERE tenant_id = ?
-                GROUP BY job_url
-            ) latest
-              ON latest.job_url = m.job_url AND latest.max_generation = m.generation
-            LEFT JOIN job_materials_artifacts tr
-              ON tr.job_url = m.job_url
-             AND tr.generation = m.generation
-             AND tr.artifact_type = 'tailored_resume'
-             AND tr.status = 'approved'
-             AND tr.superseded_at IS NULL
-            WHERE m.tenant_id = ?
-        ) lm ON lm.materials_job_url = j.url
-        WHERE COALESCE(je.full_description, j.full_description) IS NOT NULL
+          ON tailor_state.tenant_id = j.tenant_id
+         AND tailor_state.job_id = j.job_id
+         AND tailor_state.stage = 'tailor'
+        LEFT JOIN job_materials_artifacts tailored_resume
+          ON tailored_resume.tenant_id = j.tenant_id
+         AND tailored_resume.job_id = j.job_id
+         AND tailored_resume.generation = (
+            SELECT MAX(candidate.generation)
+            FROM job_materials_artifacts candidate
+            WHERE candidate.tenant_id = j.tenant_id
+              AND candidate.job_id = j.job_id
+              AND candidate.artifact_type = 'tailored_resume'
+              AND candidate.status = 'approved'
+              AND candidate.superseded_at IS NULL
+         )
+         AND tailored_resume.artifact_type = 'tailored_resume'
+         AND tailored_resume.status = 'approved'
+         AND tailored_resume.superseded_at IS NULL
+        WHERE j.tenant_id = ?
+          AND je.full_description IS NOT NULL
           {active_sql}
           {requested_sql}
-          AND COALESCE(latest_score.fit_score, j.fit_score) >= ?
+          AND latest_score.fit_score >= ?
           AND {_score_eligible_expr("latest_score.breakdown_json")}
-          AND stale_score.stale_job_url IS NULL
-          AND (
-            score_state.state IS NULL
-            OR score_state.state = 'succeeded'
-            OR (latest_score.fit_score IS NULL AND score_state.state != 'stale')
+          AND NOT EXISTS (
+            SELECT 1
+            FROM job_score_staleness stale_score
+            WHERE stale_score.tenant_id = j.tenant_id
+              AND stale_score.job_id = j.job_id
+              AND stale_score.resolved = 0
           )
+          AND (score_state.state IS NULL OR score_state.state = 'succeeded')
           AND (tailor_state.state IS NULL OR tailor_state.state != 'exhausted')
-          AND (
-            {effective_tailor_path}
-            OR COALESCE(tailor_state.attempt_count, j.tailor_attempts, 0) < 5
-          )
+          AND COALESCE(tailor_state.attempt_count, 0) < 5
           AND (
             NOT {effective_tailor_path}
-            OR {_tailoring_policy_version_expr("lm.tailored_resume_metadata")} != ?
+            OR {_tailoring_policy_version_expr("tailored_resume.metadata_json")} != ?
           )
-        ORDER BY COALESCE(latest_score.fit_score, j.fit_score) DESC, j.discovered_at DESC
+        ORDER BY latest_score.fit_score DESC, j.discovered_at DESC
         {limit_sql}
         """,
         (
-            tenant_id,
-            tenant_id,
-            tenant_id,
-            tenant_id,
             tenant_id,
             *requested_params,
             min_score,
@@ -187,33 +173,32 @@ def _current_tailoring_policy_version(conn: sqlite3.Connection, tenant_id: str) 
     return _positive_int(row[0] if row else None, default=1)
 
 
-def _active_job_filter(conn: sqlite3.Connection, job_url_expr: str) -> str:
-    clauses: list[str] = []
-    if _table_exists(conn, "jobctrl_deleted_jobs"):
-        clauses.append(
-            "NOT EXISTS ("
-            "SELECT 1 FROM jobctrl_deleted_jobs d "
-            f"WHERE d.job_url = {job_url_expr} "
-            "AND (d.restored_at IS NULL OR julianday(d.restored_at) <= julianday(d.deleted_at))"
-            ")"
+def _active_job_filter(tenant_id_expr: str, job_id_expr: str) -> str:
+    return f"""
+        AND NOT EXISTS (
+            SELECT 1 FROM jobctrl_deleted_jobs deleted
+            WHERE deleted.tenant_id = {tenant_id_expr}
+              AND deleted.job_id = {job_id_expr}
+              AND (
+                deleted.restored_at IS NULL
+                OR julianday(deleted.restored_at) <= julianday(deleted.deleted_at)
+              )
         )
-    if _table_exists(conn, "jobctrl_hidden_jobs"):
-        clauses.append(
-            "NOT EXISTS ("
-            "SELECT 1 FROM jobctrl_hidden_jobs h "
-            f"WHERE h.job_url = {job_url_expr} AND h.unhidden_at IS NULL"
-            ")"
+        AND NOT EXISTS (
+            SELECT 1 FROM jobctrl_hidden_jobs hidden
+            WHERE hidden.tenant_id = {tenant_id_expr}
+              AND hidden.job_id = {job_id_expr}
+              AND hidden.unhidden_at IS NULL
         )
-    if _table_exists(conn, "posting_snapshot_sets"):
-        clauses.append(
-            "NOT EXISTS ("
-            "SELECT 1 FROM posting_snapshot_sets pss "
-            f"WHERE pss.tenant_id = 'local' AND pss.job_url = {job_url_expr} "
-            "AND pss.latest_active_state IN "
-            "('closed', 'expired', 'removed', 'location_incompatible')"
-            ")"
+        AND NOT EXISTS (
+            SELECT 1 FROM posting_snapshot_sets snapshots
+            WHERE snapshots.tenant_id = {tenant_id_expr}
+              AND snapshots.job_id = {job_id_expr}
+              AND snapshots.latest_active_state IN (
+                'closed', 'expired', 'removed', 'location_incompatible'
+              )
         )
-    return "".join(f" AND {clause}" for clause in clauses)
+    """
 
 
 def _requested_filter(column: str, job_urls: tuple[str, ...]) -> tuple[str, tuple[str, ...]]:
@@ -231,14 +216,6 @@ def _limit_filter(limit: int) -> tuple[str, tuple[int, ...]]:
 
 def _clean_job_urls(job_urls: tuple[str, ...]) -> tuple[str, ...]:
     return tuple(dict.fromkeys(url.strip() for url in job_urls if url and url.strip()))
-
-
-def _table_exists(conn: sqlite3.Connection, name: str) -> bool:
-    row = conn.execute(
-        "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?",
-        (name,),
-    ).fetchone()
-    return row is not None
 
 
 def _score_policy_version_expr(json_expr: str) -> str:

--- a/workers/automation/src/jobctrl/pipeline/current_policy_selectors.py
+++ b/workers/automation/src/jobctrl/pipeline/current_policy_selectors.py
@@ -10,26 +10,27 @@ from jobctrl.database import (
     ensure_scoring_policy_tables,
     ensure_tailoring_policy_tables,
 )
+from jobctrl.domain.identifiers import JobId, canonical_job_id
 
 
-def scoring_current_policy_job_urls(
+def scoring_current_policy_job_ids(
     conn: sqlite3.Connection,
     *,
     tenant_id: str,
     limit: int = 0,
-    job_urls: tuple[str, ...] = (),
-) -> tuple[str, ...]:
+    job_ids: tuple[JobId, ...] = (),
+) -> tuple[JobId, ...]:
     """Return active enriched jobs missing a current-policy score."""
 
     current_version = _current_scoring_policy_version(conn, tenant_id)
-    requested = _clean_job_urls(job_urls)
-    requested_sql, requested_params = _requested_filter("j.url", requested)
+    requested = _clean_job_ids(job_ids)
+    requested_sql, requested_params = _requested_filter("j.job_id", requested)
     active_sql = _active_job_filter("j.tenant_id", "j.job_id")
     limit_sql, limit_params = _limit_filter(limit)
 
     rows = conn.execute(
         f"""
-        SELECT j.url
+        SELECT j.job_id
         FROM jobs j
         JOIN job_enrichments je
           ON je.tenant_id = j.tenant_id AND je.job_id = j.job_id
@@ -58,23 +59,23 @@ def scoring_current_policy_job_urls(
         """,
         (tenant_id, *requested_params, current_version, *limit_params),
     ).fetchall()
-    return tuple(str(row[0]) for row in rows if row[0])
+    return tuple(canonical_job_id(str(row[0])) for row in rows if row[0])
 
 
-def tailoring_current_policy_job_urls(
+def tailoring_current_policy_job_ids(
     conn: sqlite3.Connection,
     *,
     tenant_id: str,
     min_score: int = 7,
     limit: int = 0,
-    job_urls: tuple[str, ...] = (),
-) -> tuple[str, ...]:
+    job_ids: tuple[JobId, ...] = (),
+) -> tuple[JobId, ...]:
     """Return active eligible jobs missing a current-policy tailored artifact."""
 
     min_score = effective_tailoring_min_score(min_score)
     current_version = _current_tailoring_policy_version(conn, tenant_id)
-    requested = _clean_job_urls(job_urls)
-    requested_sql, requested_params = _requested_filter("j.url", requested)
+    requested = _clean_job_ids(job_ids)
+    requested_sql, requested_params = _requested_filter("j.job_id", requested)
     active_sql = _active_job_filter("j.tenant_id", "j.job_id")
     limit_sql, limit_params = _limit_filter(limit)
     effective_tailor_path = (
@@ -85,7 +86,7 @@ def tailoring_current_policy_job_urls(
 
     rows = conn.execute(
         f"""
-        SELECT j.url
+        SELECT j.job_id
         FROM jobs j
         JOIN job_enrichments je
           ON je.tenant_id = j.tenant_id AND je.job_id = j.job_id
@@ -152,7 +153,7 @@ def tailoring_current_policy_job_urls(
             *limit_params,
         ),
     ).fetchall()
-    return tuple(str(row[0]) for row in rows if row[0])
+    return tuple(canonical_job_id(str(row[0])) for row in rows if row[0])
 
 
 def _current_scoring_policy_version(conn: sqlite3.Connection, tenant_id: str) -> int:
@@ -201,11 +202,11 @@ def _active_job_filter(tenant_id_expr: str, job_id_expr: str) -> str:
     """
 
 
-def _requested_filter(column: str, job_urls: tuple[str, ...]) -> tuple[str, tuple[str, ...]]:
-    if not job_urls:
+def _requested_filter(column: str, job_ids: tuple[JobId, ...]) -> tuple[str, tuple[JobId, ...]]:
+    if not job_ids:
         return "", ()
-    placeholders = ", ".join("?" for _ in job_urls)
-    return f" AND {column} IN ({placeholders})", job_urls
+    placeholders = ", ".join("?" for _ in job_ids)
+    return f" AND {column} IN ({placeholders})", job_ids
 
 
 def _limit_filter(limit: int) -> tuple[str, tuple[int, ...]]:
@@ -214,8 +215,8 @@ def _limit_filter(limit: int) -> tuple[str, tuple[int, ...]]:
     return "", ()
 
 
-def _clean_job_urls(job_urls: tuple[str, ...]) -> tuple[str, ...]:
-    return tuple(dict.fromkeys(url.strip() for url in job_urls if url and url.strip()))
+def _clean_job_ids(job_ids: tuple[JobId, ...]) -> tuple[JobId, ...]:
+    return tuple(dict.fromkeys(canonical_job_id(str(job_id)) for job_id in job_ids))
 
 
 def _score_policy_version_expr(json_expr: str) -> str:

--- a/workers/automation/src/jobctrl/pipeline/workflow.py
+++ b/workers/automation/src/jobctrl/pipeline/workflow.py
@@ -15,6 +15,7 @@ from jobctrl.domain.identifiers import JobId, canonical_job_id
 with workflow.unsafe.imports_passed_through():
     from jobctrl.apply.workflow import ApplyWorkflow, ApplyWorkflowInput
     from jobctrl.discovery.workflow import DiscoverWorkflow, DiscoverWorkflowInput
+    from jobctrl.domain.identifiers import JobId, canonical_job_id
     from jobctrl.infrastructure.temporal.finalize import (
         emit_workflow_outcome,
         emit_workflow_started,
@@ -42,8 +43,8 @@ class JobPipelineWorkflowInput:
     """Input for ``JobPipelineWorkflow``.
 
     Drives the requested stage list in batch mode against eligible jobs in the
-    local DB. Preparation stages can also be constrained to ``job_url`` /
-    ``job_urls`` for retry-continuation flows, while discovery remains a
+    local DB. Preparation stages can also be constrained to ``job_id`` /
+    ``job_ids`` for retry-continuation flows, while discovery remains a
     batch/source-oriented stage.
 
     The apply step is delegated to ``ApplyWorkflow`` as a child workflow so
@@ -65,9 +66,8 @@ class JobPipelineWorkflowInput:
     tailor_models: tuple[str, ...] = ()
     tailor_judge_model: str | None = None
     tailor_judge_min_score: float | None = None
-    job_url: str | None = None
-    job_urls: tuple[str, ...] = ()
-    apply_job_id: JobId | None = None
+    job_id: JobId | None = None
+    job_ids: tuple[JobId, ...] = ()
     apply_selector_keys: tuple[str, ...] = ()
     source_ids: tuple[str, ...] = ()
     score_current_policy_only: bool = False
@@ -80,12 +80,9 @@ class JobPipelineWorkflowInput:
     continuous: bool = False
 
     def __post_init__(self) -> None:
-        if self.apply_job_id is not None:
-            object.__setattr__(
-                self,
-                "apply_job_id",
-                canonical_job_id(str(self.apply_job_id)),
-            )
+        if self.job_id is not None:
+            object.__setattr__(self, "job_id", canonical_job_id(str(self.job_id)))
+        object.__setattr__(self, "job_ids", _canonical_job_ids(self.job_ids))
 
 
 @dataclass(frozen=True)
@@ -215,16 +212,16 @@ class JobPipelineWorkflow:
         failed: list[str] = []
         failure: str | None = None
         error_code: str | None = None
-        derived_cover_job_urls: tuple[str, ...] | None = None
+        derived_cover_job_ids: tuple[JobId, ...] | None = None
 
         for stage in payload.stages:
             stage_payload = payload
-            if stage == "cover" and derived_cover_job_urls is not None and not _has_selected_job_scope(payload):
-                if not derived_cover_job_urls:
+            if stage == "cover" and derived_cover_job_ids is not None and not _has_selected_job_scope(payload):
+                if not derived_cover_job_ids:
                     completed.append(stage)
-                    derived_cover_job_urls = None
+                    derived_cover_job_ids = None
                     continue
-                stage_payload = replace(payload, job_urls=derived_cover_job_urls, limit=0)
+                stage_payload = replace(payload, job_ids=derived_cover_job_ids, limit=0)
 
             try:
                 result = await _execute_stage(stage, stage_payload)
@@ -245,9 +242,9 @@ class JobPipelineWorkflow:
 
             completed.append(stage)
             if stage == "tailor" and not _has_selected_job_scope(payload):
-                derived_cover_job_urls = _approved_tailor_job_urls(result)
+                derived_cover_job_ids = _approved_tailor_job_ids(result)
             elif stage != "cover":
-                derived_cover_job_urls = None
+                derived_cover_job_ids = None
 
         return JobPipelineWorkflowResult(
             stages_completed=completed,
@@ -289,7 +286,7 @@ async def _execute_stage(stage: str, payload: JobPipelineWorkflowInput) -> Any:
                 workers=payload.workers,
                 limit=payload.limit,
                 dry_run=payload.dry_run,
-                job_urls=_selected_job_urls(payload),
+                job_ids=_selected_job_ids(payload),
                 workflow_id=workflow_id,
             ),
             start_to_close_timeout=_DEFAULT_TIMEOUT,
@@ -307,7 +304,7 @@ async def _execute_stage(stage: str, payload: JobPipelineWorkflowInput) -> Any:
                 limit=payload.limit,
                 dry_run=payload.dry_run,
                 rescore=payload.rescore,
-                job_urls=_selected_job_urls(payload),
+                job_ids=_selected_job_ids(payload),
                 current_policy_only=payload.score_current_policy_only,
                 llm_model=payload.llm_model,
                 workflow_id=workflow_id,
@@ -329,7 +326,7 @@ async def _execute_stage(stage: str, payload: JobPipelineWorkflowInput) -> Any:
                 validation_mode=payload.validation_mode,
                 dry_run=payload.dry_run,
                 retailor=payload.retailor,
-                job_urls=_selected_job_urls(payload),
+                job_ids=_selected_job_ids(payload),
                 current_policy_only=payload.tailor_current_policy_only,
                 suppress_existing_artifacts=payload.suppress_existing_artifacts,
                 allow_low_fit_override=payload.allow_low_fit_override,
@@ -354,7 +351,7 @@ async def _execute_stage(stage: str, payload: JobPipelineWorkflowInput) -> Any:
                 limit=payload.limit,
                 validation_mode=payload.validation_mode,
                 dry_run=payload.dry_run,
-                job_urls=_selected_job_urls(payload),
+                job_ids=_selected_job_ids(payload),
                 llm_model=payload.llm_model,
                 workflow_id=workflow_id,
             ),
@@ -406,7 +403,8 @@ def _pipeline_input_summary(payload: JobPipelineWorkflowInput) -> dict[str, Any]
         "stages": list(payload.stages),
         "dryRun": payload.dry_run,
         "limit": payload.limit,
-        "jobUrl": payload.job_url,
+        "jobId": str(payload.job_id) if payload.job_id is not None else None,
+        "jobIds": [str(job_id) for job_id in payload.job_ids],
     }
 
 
@@ -437,29 +435,28 @@ def _activity_error_was_cancelled(exc: ActivityError) -> bool:
     return False
 
 
-def _selected_job_urls(payload: JobPipelineWorkflowInput) -> tuple[str, ...]:
-    if payload.job_urls:
-        return payload.job_urls
-    if payload.job_url:
-        return (payload.job_url,)
+def _selected_job_ids(payload: JobPipelineWorkflowInput) -> tuple[JobId, ...]:
+    if payload.job_ids:
+        return payload.job_ids
+    if payload.job_id is not None:
+        return (payload.job_id,)
     return ()
 
 
 def _has_selected_job_scope(payload: JobPipelineWorkflowInput) -> bool:
-    return bool(payload.job_url or payload.job_urls)
+    return payload.job_id is not None or bool(payload.job_ids)
 
 
 def _apply_child_job_id(payload: JobPipelineWorkflowInput) -> JobId | None:
     """Validate the preserved selector shape before starting an Apply child."""
 
     selector_keys = tuple(payload.apply_selector_keys)
-    legacy_scope_present = payload.job_url is not None or bool(payload.job_urls)
     if not selector_keys:
-        if payload.apply_job_id is None and not legacy_scope_present:
+        if payload.job_id is None and not payload.job_ids:
             return None
     elif selector_keys == ("jobId",):
-        if payload.apply_job_id is not None and not legacy_scope_present:
-            return canonical_job_id(str(payload.apply_job_id))
+        if payload.job_id is not None and not payload.job_ids:
+            return canonical_job_id(str(payload.job_id))
 
     raise ApplicationError(
         "apply accepts only a canonical jobId; omit all selector keys for batch apply",
@@ -467,7 +464,7 @@ def _apply_child_job_id(payload: JobPipelineWorkflowInput) -> JobId | None:
     )
 
 
-def _approved_tailor_job_urls(result: Any) -> tuple[str, ...] | None:
+def _approved_tailor_job_ids(result: Any) -> tuple[JobId, ...] | None:
     stages = _result_value(result, "stages")
     if not isinstance(stages, list):
         return None
@@ -476,13 +473,17 @@ def _approved_tailor_job_urls(result: Any) -> tuple[str, ...] | None:
             continue
         if stage_result.get("stage") != "tailor":
             continue
-        if "approvedJobUrls" not in stage_result:
+        if "approvedJobIds" not in stage_result:
             return None
-        raw_urls = stage_result.get("approvedJobUrls")
-        if not isinstance(raw_urls, list):
+        raw_job_ids = stage_result.get("approvedJobIds")
+        if not isinstance(raw_job_ids, list):
             return ()
-        return tuple(dict.fromkeys(str(url) for url in raw_urls if str(url)))
+        return _canonical_job_ids(tuple(canonical_job_id(str(job_id)) for job_id in raw_job_ids))
     return None
+
+
+def _canonical_job_ids(job_ids: tuple[JobId, ...]) -> tuple[JobId, ...]:
+    return tuple(dict.fromkeys(canonical_job_id(str(job_id)) for job_id in job_ids))
 
 
 _SUCCESS_STAGE_STATUSES = frozenset({"ok", "partial", "skipped"})

--- a/workers/automation/src/jobctrl/scoring/activities.py
+++ b/workers/automation/src/jobctrl/scoring/activities.py
@@ -26,10 +26,13 @@ class ScoreActivityInput:
     workers: int = 1
     dry_run: bool = False
     rescore: bool = False
-    job_urls: tuple[str, ...] = ()
+    job_ids: tuple[JobId, ...] = ()
     current_policy_only: bool = False
     llm_model: str = DEFAULT_PIPELINE_LLM_MODEL_SPEC
     workflow_id: str | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "job_ids", _canonical_job_ids(self.job_ids))
 
 
 @dataclass(frozen=True)
@@ -90,7 +93,7 @@ async def score_activity(payload: ScoreActivityInput) -> ScoreActivityOutput:
                 stages=list(result["stages"]),
             )
 
-        if payload.job_urls:
+        if payload.job_ids:
             result = await run_blocking_with_heartbeat(
                 lambda: _run_selected_scores(payload, cancel_event=cancel_event),
                 starting_message="selected score starting",
@@ -170,15 +173,15 @@ def _run_current_policy_scores(
     cancel_event: threading.Event | None = None,
 ) -> dict[str, Any]:
     from jobctrl.database import get_connection
-    from jobctrl.pipeline.current_policy_selectors import scoring_current_policy_job_urls
+    from jobctrl.pipeline.current_policy_selectors import scoring_current_policy_job_ids
 
-    urls = scoring_current_policy_job_urls(
+    job_ids = scoring_current_policy_job_ids(
         get_connection(),
         tenant_id=payload.tenant_id,
         limit=payload.limit,
-        job_urls=payload.job_urls,
+        job_ids=payload.job_ids,
     )
-    return _run_selected_scores(replace(payload, job_urls=urls, limit=0), cancel_event=cancel_event)
+    return _run_selected_scores(replace(payload, job_ids=job_ids, limit=0), cancel_event=cancel_event)
 
 
 def _run_selected_scores(
@@ -187,9 +190,9 @@ def _run_selected_scores(
     cancel_event: threading.Event | None = None,
 ) -> dict[str, Any]:
     from jobctrl.domain.tenant import TenantId
-    from jobctrl.scoring.scorer import score_job_by_url
+    from jobctrl.scoring.scorer import score_job_by_id
 
-    urls = _limited_job_urls(payload.job_urls, payload.limit)
+    job_ids = _limited_job_ids(payload.job_ids, payload.limit)
     if payload.dry_run:
         return {
             "status": "ok",
@@ -200,7 +203,7 @@ def _run_selected_scores(
                     "stage": "score",
                     "status": "ok",
                     "elapsed": 0.0,
-                    "selected": len(urls),
+                    "selected": len(job_ids),
                     "dry_run": True,
                 }
             ],
@@ -210,31 +213,31 @@ def _run_selected_scores(
     errors: dict[str, str] = {}
     scored = 0
 
-    def score_one(url: str):
+    def score_one(job_id: JobId):
         if cancel_event is not None and cancel_event.is_set():
             raise LlmTransientError("score activity canceled")
-        return url, score_job_by_url(
-            url,
+        return job_id, score_job_by_id(
+            job_id,
             tenant_id=TenantId(payload.tenant_id),
             rescore=payload.rescore,
             llm_model=payload.llm_model,
         )
 
     worker_count = max(1, int(payload.workers or 1))
-    if worker_count == 1 or len(urls) <= 1:
-        results = [score_one(url) for url in urls]
+    if worker_count == 1 or len(job_ids) <= 1:
+        results = [score_one(job_id) for job_id in job_ids]
     else:
         with ThreadPoolExecutor(max_workers=worker_count) as executor:
-            futures = [executor.submit(score_one, url) for url in urls]
+            futures = [executor.submit(score_one, job_id) for job_id in job_ids]
             results = [future.result() for future in as_completed(futures)]
 
-    for url, outcome in results:
+    for job_id, outcome in results:
         if cancel_event is not None and cancel_event.is_set():
             raise LlmTransientError("score activity canceled")
         if outcome.ok:
             scored += 1
         else:
-            errors[url] = outcome.error or "Scoring failed"
+            errors[str(job_id)] = outcome.error or "Scoring failed"
 
     elapsed = time.time() - t0
     status = "failed" if errors else "ok"
@@ -247,18 +250,22 @@ def _run_selected_scores(
                 "stage": "score",
                 "status": status,
                 "elapsed": elapsed,
-                "selected": len(urls),
+                "selected": len(job_ids),
                 "scored": scored,
             }
         ],
     }
 
 
-def _limited_job_urls(job_urls: tuple[str, ...], limit: int) -> tuple[str, ...]:
-    unique = tuple(dict.fromkeys(url for url in job_urls if url))
+def _limited_job_ids(job_ids: tuple[JobId, ...], limit: int) -> tuple[JobId, ...]:
+    unique = tuple(dict.fromkeys(job_ids))
     if limit > 0:
         return unique[:limit]
     return unique
+
+
+def _canonical_job_ids(job_ids: tuple[JobId, ...]) -> tuple[JobId, ...]:
+    return tuple(dict.fromkeys(canonical_job_id(str(job_id)) for job_id in job_ids))
 
 
 _SUCCESS_STATUSES = {"ok", "partial", "skipped", "already_done"}

--- a/workers/automation/src/jobctrl/workflow_specs.py
+++ b/workers/automation/src/jobctrl/workflow_specs.py
@@ -305,7 +305,7 @@ def build_contact_research_workflow_spec(params: dict[str, Any]) -> WorkflowStar
 
 
 def build_single_job_workflow_spec(
-    url: str,
+    job_id: str,
     *,
     do_tailor: bool = True,
     do_apply: bool = True,
@@ -329,7 +329,7 @@ def build_single_job_workflow_spec(
             "expectedAppDir": expected_app_dir,
             "expectedDbPath": expected_db_path,
             "stages": stages,
-            "jobUrl": url,
+            "jobId": job_id,
             "validationMode": validation_mode,
             "model": model,
             "headless": headless,

--- a/workers/automation/src/jobctrl/workflow_specs.py
+++ b/workers/automation/src/jobctrl/workflow_specs.py
@@ -20,7 +20,7 @@ from jobctrl.discovery.workflow import (
     discover_workflow_id,
 )
 from jobctrl.domain.discovery.source_registry import ManualCaptureMode
-from jobctrl.domain.identifiers import canonical_job_id
+from jobctrl.domain.identifiers import JobId, canonical_job_id
 from jobctrl.domain.rpc.messages import WorkflowStartSpec
 from jobctrl.domain.tenant import LOCAL_TENANT
 from jobctrl.interview.workflow import InterviewPrepWorkflow, InterviewPrepWorkflowInput
@@ -77,6 +77,7 @@ def build_run_stage_workflow_spec(params: dict[str, Any]) -> WorkflowStartSpec:
             args=(payload,),
             workflow_id=discover_workflow_id(tenant_id),
         )
+    _reject_legacy_pipeline_job_urls(params)
     payload = JobPipelineWorkflowInput(
         tenant_id=tenant_id,
         expected_app_dir=params.get("expectedAppDir"),
@@ -91,10 +92,15 @@ def build_run_stage_workflow_spec(params: dict[str, Any]) -> WorkflowStartSpec:
         retailor=bool(params.get("retailor", False)),
         tailor_models=tuple(str(item) for item in (params.get("tailorModels") or ())),
         tailor_judge_model=str(params["tailorJudgeModel"]) if params.get("tailorJudgeModel") else None,
-        tailor_judge_min_score=(float(raw_judge_min_score) if raw_judge_min_score is not None else None),
-        job_url=params.get("jobUrl") if params.get("jobUrl") else None,
-        job_urls=_job_urls(params),
-        apply_job_id=apply_selector.job_id if apply_selector else None,
+        tailor_judge_min_score=(
+            float(raw_judge_min_score) if raw_judge_min_score is not None else None
+        ),
+        job_id=(
+            apply_selector.job_id
+            if apply_selector is not None
+            else _optional_job_id(params, "jobId")
+        ),
+        job_ids=() if apply_selector is not None else _job_ids(params),
         apply_selector_keys=apply_selector.keys if apply_selector else (),
         source_ids=_source_ids(params),
         headless=bool(params.get("headless", False)),
@@ -112,16 +118,21 @@ def build_pipeline_workflow_spec(
     limit: int,
     rescore: bool = False,
     retailor: bool = False,
-    job_url: str | None = None,
-    job_urls: tuple[str, ...] = (),
+    job_id: JobId | None = None,
+    job_ids: tuple[JobId, ...] = (),
     score_current_policy_only: bool = False,
     tailor_current_policy_only: bool = False,
     suppress_existing_artifacts: bool = False,
     allow_low_fit_override: bool = False,
 ) -> WorkflowStartSpec:
-    apply_selector = _apply_selector(params, job_url=job_url, job_urls=job_urls) if "apply" in stages else None
+    apply_selector = (
+        _apply_selector(params, job_id=job_id, job_ids=job_ids)
+        if "apply" in stages
+        else None
+    )
     if "apply" in stages:
         _require_auto_apply_browser_capability()
+    _reject_legacy_pipeline_job_urls(params)
     tenant_id = _tenant_id(params)
     raw_judge_min_score = params.get("tailorJudgeMinScore")
     payload = JobPipelineWorkflowInput(
@@ -138,10 +149,11 @@ def build_pipeline_workflow_spec(
         retailor=retailor,
         tailor_models=tuple(str(item) for item in (params.get("tailorModels") or ())),
         tailor_judge_model=str(params["tailorJudgeModel"]) if params.get("tailorJudgeModel") else None,
-        tailor_judge_min_score=(float(raw_judge_min_score) if raw_judge_min_score is not None else None),
-        job_url=job_url,
-        job_urls=job_urls,
-        apply_job_id=apply_selector.job_id if apply_selector else None,
+        tailor_judge_min_score=(
+            float(raw_judge_min_score) if raw_judge_min_score is not None else None
+        ),
+        job_id=apply_selector.job_id if apply_selector is not None else job_id,
+        job_ids=() if apply_selector is not None else job_ids,
         apply_selector_keys=apply_selector.keys if apply_selector else (),
         score_current_policy_only=score_current_policy_only,
         tailor_current_policy_only=tailor_current_policy_only,
@@ -170,7 +182,11 @@ def build_apply_workflow_spec(params: dict[str, Any]) -> WorkflowStartSpec:
         continuous=bool(params.get("continuous", False)),
         approval_required=bool(params.get("applyApprovalRequired", True)),
     )
-    workflow_id = apply_workflow_id(tenant_id, str(selector.job_id)) if selector.job_id is not None else None
+    workflow_id = (
+        apply_workflow_id(tenant_id, str(selector.job_id))
+        if selector.job_id is not None
+        else None
+    )
     return WorkflowStartSpec(workflow=ApplyWorkflow, args=(payload,), workflow_id=workflow_id)
 
 
@@ -179,14 +195,14 @@ class _ApplySelector:
     """The only selector shape permitted to start an Apply workflow."""
 
     keys: tuple[str, ...] = ()
-    job_id: str | None = None
+    job_id: JobId | None = None
 
 
 def _apply_selector(
     params: dict[str, Any],
     *,
-    job_url: str | None = None,
-    job_urls: tuple[str, ...] = (),
+    job_id: JobId | None = None,
+    job_ids: tuple[JobId, ...] = (),
 ) -> _ApplySelector:
     """Preserve selector key presence so invalid scopes cannot become batch Apply.
 
@@ -196,20 +212,29 @@ def _apply_selector(
     """
 
     keys = tuple(key for key in _APPLY_SELECTOR_KEYS if key in params)
-    if job_url is not None and "jobUrl" not in keys:
-        keys += ("jobUrl",)
-    if job_urls and "jobUrls" not in keys:
-        keys += ("jobUrls",)
+    if job_id is not None and "jobId" not in keys:
+        keys += ("jobId",)
+    if job_ids and "jobIds" not in keys:
+        keys += ("jobIds",)
 
     if not keys:
         return _ApplySelector()
     if keys != ("jobId",):
-        raise ValueError("apply accepts only a canonical jobId; omit all selector keys for batch apply")
+        raise ValueError(
+            "apply accepts only a canonical jobId; omit all selector keys for batch apply"
+        )
 
-    raw_job_id = params["jobId"]
+    raw_job_id = job_id if job_id is not None else params["jobId"]
     if not isinstance(raw_job_id, str) or not raw_job_id.strip():
         raise ValueError("apply jobId must be a non-empty canonical UUID")
-    return _ApplySelector(keys=keys, job_id=canonical_job_id(raw_job_id))
+    selected_job_id = canonical_job_id(raw_job_id)
+    if job_id is not None and "jobId" in params:
+        supplied_job_id = params["jobId"]
+        if not isinstance(supplied_job_id, str) or not supplied_job_id.strip():
+            raise ValueError("apply jobId must be a non-empty canonical UUID")
+        if canonical_job_id(supplied_job_id) != selected_job_id:
+            raise ValueError("conflicting apply jobId selectors")
+    return _ApplySelector(keys=keys, job_id=selected_job_id)
 
 
 def _require_auto_apply_browser_capability() -> None:
@@ -477,13 +502,25 @@ def _stage_list(params: dict[str, Any]) -> list[str]:
     return [stage for stage in _WORKFLOW_STAGE_ORDER if stage in unique]
 
 
-def _job_urls(params: dict[str, Any]) -> tuple[str, ...]:
-    raw = params.get("jobUrls") or ()
+def _job_ids(params: dict[str, Any]) -> tuple[JobId, ...]:
+    raw = params.get("jobIds") or ()
     if not raw:
         return ()
     if not isinstance(raw, list):
-        raise ValueError("jobUrls must be an array")
-    return tuple(str(item).strip() for item in raw if str(item).strip())
+        raise ValueError("jobIds must be an array")
+    return tuple(dict.fromkeys(canonical_job_id(str(item)) for item in raw))
+
+
+def _optional_job_id(params: dict[str, Any], name: str) -> JobId | None:
+    value = params.get(name)
+    if value is None or value == "":
+        return None
+    return canonical_job_id(str(value))
+
+
+def _reject_legacy_pipeline_job_urls(params: dict[str, Any]) -> None:
+    if "jobUrl" in params or "jobUrls" in params:
+        raise ValueError("pipeline job selection requires jobId or jobIds")
 
 
 def _source_ids(params: dict[str, Any]) -> tuple[str, ...]:

--- a/workers/automation/tests/test_apply_regressions.py
+++ b/workers/automation/tests/test_apply_regressions.py
@@ -1038,11 +1038,11 @@ def test_single_job_starts_temporal_workflow_spec(tmp_path, monkeypatch):
     monkeypatch.setattr("jobctrl.workflow_specs.start_workflow_spec_and_wait_sync", fake_start)
     monkeypatch.setattr(runner_module, "get_connection", lambda: conn)
 
-    result = runner_module.run_single_job(url, do_tailor=True, do_apply=False)
+    result = runner_module.run_single_job(url, do_tailor=True, do_apply=True)
 
     payload = specs[0].args[0]
-    assert payload.job_url == job_id
-    assert payload.stages == ["enrich", "score", "tailor", "cover"]
+    assert str(payload.job_id) == job_id
+    assert payload.stages == ["enrich", "score", "tailor", "cover", "apply"]
     assert payload.expected_app_dir == str(app_dir)
     assert payload.expected_db_path == str(db_path)
     assert result["url"] == url

--- a/workers/automation/tests/test_jsonrpc_handlers.py
+++ b/workers/automation/tests/test_jsonrpc_handlers.py
@@ -1929,11 +1929,34 @@ def test_current_policy_score_activity_skips_current_policy_scores(
     outdated_url = "https://example.com/job/outdated-score"
     corrected_url = "https://example.com/job/corrected-score"
     missing_url = "https://example.com/job/missing-score"
-    for url in (current_url, outdated_url, corrected_url, missing_url):
-        _seed_enriched_job(conn, url)
-    _seed_score(conn, current_url, policy_version=2)
-    _seed_score(conn, outdated_url, policy_version=1)
-    _seed_score(conn, corrected_url, policy_version=1, correction={"fit_score": 9})
+    job_ids = {
+        url: _seed_v7_current_locator(
+            conn,
+            tenant_id=TenantId("local"),
+            job_url=url,
+        )
+        for url in (current_url, outdated_url, corrected_url, missing_url)
+    }
+    _seed_v7_score(conn, job_ids[current_url], policy_version=2)
+    _seed_v7_score(conn, job_ids[outdated_url], policy_version=1)
+    _seed_v7_score(
+        conn,
+        job_ids[corrected_url],
+        policy_version=1,
+        correction={"fit_score": 9},
+    )
+    _seed_v7_current_locator(
+        conn,
+        tenant_id=TenantId("other"),
+        job_url=missing_url,
+        job_id=job_ids[missing_url],
+    )
+    _seed_v7_score(
+        conn,
+        job_ids[missing_url],
+        tenant_id=TenantId("other"),
+        policy_version=2,
+    )
 
     calls: list[str] = []
 
@@ -2032,13 +2055,66 @@ def test_current_policy_tailor_activity_skips_current_policy_artifacts(
     outdated_url = "https://example.com/job/outdated-tailor"
     missing_url = "https://example.com/job/missing-tailor"
     low_fit_url = "https://example.com/job/low-fit-tailor"
-    for url in (current_url, outdated_url, missing_url):
-        _seed_enriched_job(conn, url)
-        _seed_score(conn, url, policy_version=2, fit_score=9)
-    _seed_enriched_job(conn, low_fit_url)
-    _seed_score(conn, low_fit_url, policy_version=2, fit_score=5)
-    _seed_tailored_artifact(conn, current_url, policy_version=2)
-    _seed_tailored_artifact(conn, outdated_url, policy_version=1)
+    exhausted_url = "https://example.com/job/exhausted-tailor"
+    job_ids = {
+        url: _seed_v7_current_locator(
+            conn,
+            tenant_id=TenantId("local"),
+            job_url=url,
+        )
+        for url in (
+            current_url,
+            outdated_url,
+            missing_url,
+            low_fit_url,
+            exhausted_url,
+        )
+    }
+    for url in (current_url, outdated_url, missing_url, exhausted_url):
+        _seed_v7_score(conn, job_ids[url], policy_version=2, fit_score=9)
+    _seed_v7_score(conn, job_ids[low_fit_url], policy_version=2, fit_score=5)
+    _seed_v7_tailored_artifact(
+        conn,
+        job_ids[current_url],
+        policy_version=2,
+    )
+    _seed_v7_tailored_artifact(
+        conn,
+        job_ids[outdated_url],
+        policy_version=1,
+    )
+    _seed_v7_rejected_tailoring_generation(conn, job_ids[current_url], generation=2)
+    _seed_v7_rejected_tailoring_generation(conn, job_ids[outdated_url], generation=2)
+    _seed_v7_tailored_artifact(
+        conn,
+        job_ids[exhausted_url],
+        policy_version=1,
+    )
+    _seed_v7_tailor_stage(
+        conn,
+        job_ids[exhausted_url],
+        state="failed",
+        attempt_count=5,
+    )
+    _seed_v7_current_locator(
+        conn,
+        tenant_id=TenantId("other"),
+        job_url=missing_url,
+        job_id=job_ids[missing_url],
+    )
+    _seed_v7_score(
+        conn,
+        job_ids[missing_url],
+        tenant_id=TenantId("other"),
+        policy_version=2,
+        fit_score=9,
+    )
+    _seed_v7_tailored_artifact(
+        conn,
+        job_ids[missing_url],
+        tenant_id=TenantId("other"),
+        policy_version=2,
+    )
 
     calls: list[tuple[str, dict[str, object]]] = []
 
@@ -2212,6 +2288,43 @@ def _seed_scoring_policy(conn, *, version: int) -> None:
     conn.commit()
 
 
+def _seed_v7_score(
+    conn,
+    job_id: JobId,
+    *,
+    tenant_id: TenantId = TenantId("local"),
+    policy_version: int,
+    fit_score: int = 8,
+    correction: dict[str, object] | None = None,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO job_scores (
+            tenant_id, job_id, version, fit_score, breakdown_json, keywords_json,
+            scored_at, correction_json, criteria_json, trace_json
+        ) VALUES (?, ?, 1, ?, ?, '[]', '2026-07-30T10:02:00+00:00',
+                  ?, '{}', ?)
+        """,
+        (
+            str(tenant_id),
+            str(job_id),
+            fit_score,
+            json.dumps(
+                {
+                    "reasoning": "ok",
+                    "eligibility": {
+                        "status": "eligible",
+                        "hard_blockers": [],
+                    },
+                }
+            ),
+            json.dumps(correction) if correction is not None else None,
+            json.dumps({"scoring_policy_version": policy_version}),
+        ),
+    )
+    conn.commit()
+
+
 def _seed_tailoring_policy(conn, *, version: int) -> None:
     conn.execute(
         """
@@ -2226,6 +2339,102 @@ def _seed_tailoring_policy(conn, *, version: int) -> None:
             '{}', '{}', '{}', NULL, '', '2026-05-26T10:00:00+00:00', NULL)
         """,
         (version,),
+    )
+    conn.commit()
+
+
+def _seed_v7_tailored_artifact(
+    conn,
+    job_id: JobId,
+    *,
+    tenant_id: TenantId = TenantId("local"),
+    policy_version: int,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO job_materials (
+            tenant_id, job_id, generation, status, created_at, updated_at,
+            metadata_json
+        ) VALUES (?, ?, 1, 'resume_approved',
+                  '2026-07-30T10:03:00+00:00',
+                  '2026-07-30T10:03:00+00:00', '{}')
+        """,
+        (str(tenant_id), str(job_id)),
+    )
+    conn.execute(
+        """
+        INSERT INTO job_materials_artifacts (
+            tenant_id, job_id, generation, artifact_type, artifact_id, status,
+            path, render_format, size_bytes, metadata_json, created_at,
+            superseded_at
+        ) VALUES (?, ?, 1, 'tailored_resume', ?, 'approved', ?, 'text', 12, ?,
+                  '2026-07-30T10:03:00+00:00', NULL)
+        """,
+        (
+            str(tenant_id),
+            str(job_id),
+            f"artifact-{policy_version}-{job_id}",
+            f"/tmp/{job_id}.txt",
+            json.dumps({"tailoring_policy_version": policy_version}),
+        ),
+    )
+    conn.commit()
+
+
+def _seed_v7_rejected_tailoring_generation(
+    conn,
+    job_id: JobId,
+    *,
+    tenant_id: TenantId = TenantId("local"),
+    generation: int,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO job_materials (
+            tenant_id, job_id, generation, status, created_at, updated_at,
+            metadata_json
+        ) VALUES (?, ?, ?, 'resume_rejected',
+                  '2026-07-30T10:04:00+00:00',
+                  '2026-07-30T10:04:00+00:00', '{}')
+        """,
+        (str(tenant_id), str(job_id), generation),
+    )
+    conn.execute(
+        """
+        INSERT INTO job_materials_artifacts (
+            tenant_id, job_id, generation, artifact_type, artifact_id, status,
+            path, render_format, size_bytes, metadata_json, created_at,
+            superseded_at
+        ) VALUES (?, ?, ?, 'tailored_resume', ?, 'rejected', ?, 'text', 12, '{}',
+                  '2026-07-30T10:04:00+00:00', NULL)
+        """,
+        (
+            str(tenant_id),
+            str(job_id),
+            generation,
+            f"artifact-rejected-{generation}-{job_id}",
+            f"/tmp/{job_id}-rejected-{generation}.txt",
+        ),
+    )
+    conn.commit()
+
+
+def _seed_v7_tailor_stage(
+    conn,
+    job_id: JobId,
+    *,
+    tenant_id: TenantId = TenantId("local"),
+    state: str,
+    attempt_count: int,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO job_stage_states (
+            tenant_id, job_id, stage, state, attempt_count, max_attempts,
+            updated_at, retryable
+        ) VALUES (?, ?, 'tailor', ?, ?, 5, '2026-07-30T10:05:00+00:00', 1)
+        """,
+        (str(tenant_id), str(job_id), state, attempt_count),
     )
     conn.commit()
 

--- a/workers/automation/tests/test_jsonrpc_handlers.py
+++ b/workers/automation/tests/test_jsonrpc_handlers.py
@@ -886,11 +886,11 @@ def test_run_stage_starts_job_pipeline_workflow(tmp_db: Path) -> None:
     seen: list[WorkflowStartSpec] = []
     selected_jobs = (
         (
-            JobId("20000000-0000-4000-8000-000000000021"),
+            JobId("20000000-0000-4000-8000-000000000001"),
             "https://example.com/job/score-a",
         ),
         (
-            JobId("20000000-0000-4000-8000-000000000022"),
+            JobId("20000000-0000-4000-8000-000000000002"),
             "https://example.com/job/score-b",
         ),
     )
@@ -949,9 +949,9 @@ def test_run_stage_starts_job_pipeline_workflow(tmp_db: Path) -> None:
         expected_app_dir="/tmp/jobctrl",
         expected_db_path="/tmp/jobctrl/jobctrl.db",
         stages=["score", "tailor"],
-        job_urls=(
-            "https://example.com/job/score-a",
-            "https://example.com/job/score-b",
+        job_ids=(
+            JobId("20000000-0000-4000-8000-000000000001"),
+            JobId("20000000-0000-4000-8000-000000000002"),
         ),
         min_score=8,
         workers=2,
@@ -965,6 +965,52 @@ def test_run_stage_starts_job_pipeline_workflow(tmp_db: Path) -> None:
         tailor_judge_min_score=0.9,
         llm_model=DEFAULT_PIPELINE_LLM_MODEL_SPEC,
     )
+
+
+def test_run_stage_rejects_noncanonical_job_ids() -> None:
+    server = _server()
+
+    response = server.dispatch(
+        JsonRpcRequest(
+            method="run_stage",
+            params={
+                "tenantId": "local",
+                "stage": "score",
+                "jobIds": ["https://example.com/jobs/not-an-id"],
+            },
+            id=1,
+        )
+    )
+
+    assert response is not None
+    assert response.to_dict()["error"]["code"] == INVALID_PARAMS
+
+
+@pytest.mark.parametrize(
+    ("method", "params"),
+    [
+        ("run_stage", {"stage": "score", "jobUrl": "https://example.com/jobs/legacy"}),
+        (
+            "rescore_jobs_not_on_current_scoring_policy",
+            {"jobUrls": ["https://example.com/jobs/legacy"]},
+        ),
+        (
+            "retailor_current_policy",
+            {"jobUrls": ["https://example.com/jobs/legacy"]},
+        ),
+    ],
+)
+def test_pipeline_rpc_rejects_legacy_url_selection_fields(
+    method: str,
+    params: dict[str, object],
+) -> None:
+    response = _server().dispatch(JsonRpcRequest(method=method, params=params, id=1))
+
+    assert response is not None
+    body = response.to_dict()
+    assert body["error"]["code"] == INVALID_PARAMS
+    assert "not supported" in body["error"]["message"]
+    assert "jobId" in body["error"]["message"]
 
 
 def test_run_stage_preserves_selected_discovery_source_ids(tmp_db: Path) -> None:
@@ -1066,8 +1112,8 @@ def test_run_stage_preserves_omitted_tailor_judge_threshold(tmp_db: Path) -> Non
                 "expectedDbPath": "/tmp/jobctrl/jobctrl.db",
                 "limit": 10,
                 "jobIds": [
-                    "20000000-0000-4000-8000-000000000002",
                     "20000000-0000-4000-8000-000000000003",
+                    "20000000-0000-4000-8000-000000000004",
                 ],
                 "dryRun": False,
             },
@@ -1076,10 +1122,10 @@ def test_run_stage_preserves_omitted_tailor_judge_threshold(tmp_db: Path) -> Non
                 "limit": 10,
                 "rescore": True,
                 "retailor": False,
-                "job_url": None,
-                "job_urls": (
-                    "https://example.com/job/score-a",
-                    "https://example.com/job/score-b",
+                "job_id": None,
+                "job_ids": (
+                    JobId("20000000-0000-4000-8000-000000000003"),
+                    JobId("20000000-0000-4000-8000-000000000004"),
                 ),
                 "score_current_policy_only": True,
                 "dry_run": False,
@@ -1154,8 +1200,8 @@ def test_run_stage_preserves_omitted_tailor_judge_threshold(tmp_db: Path) -> Non
                 "expectedDbPath": "/tmp/jobctrl/jobctrl.db",
                 "limit": 5,
                 "jobIds": [
-                    "20000000-0000-4000-8000-000000000011",
-                    "20000000-0000-4000-8000-000000000012",
+                    "20000000-0000-4000-8000-000000000005",
+                    "20000000-0000-4000-8000-000000000006",
                 ],
                 "dryRun": False,
                 "suppressExistingArtifacts": True,
@@ -1165,10 +1211,10 @@ def test_run_stage_preserves_omitted_tailor_judge_threshold(tmp_db: Path) -> Non
                 "limit": 5,
                 "rescore": False,
                 "retailor": True,
-                "job_url": None,
-                "job_urls": (
-                    "https://example.com/job/tailor-a",
-                    "https://example.com/job/tailor-b",
+                "job_id": None,
+                "job_ids": (
+                    JobId("20000000-0000-4000-8000-000000000005"),
+                    JobId("20000000-0000-4000-8000-000000000006"),
                 ),
                 "tailor_current_policy_only": True,
                 "dry_run": False,
@@ -1182,15 +1228,15 @@ def test_run_stage_preserves_omitted_tailor_judge_threshold(tmp_db: Path) -> Non
                 "expectedAppDir": "/tmp/jobctrl",
                 "expectedDbPath": "/tmp/jobctrl/jobctrl.db",
                 "limit": 5,
-                "jobIds": ["20000000-0000-4000-8000-000000000011"],
+                "jobIds": ["20000000-0000-4000-8000-000000000007"],
             },
             {
                 "stages": ["tailor", "cover"],
                 "limit": 5,
                 "rescore": False,
                 "retailor": True,
-                "job_url": None,
-                "job_urls": ("https://example.com/job/tailor-a",),
+                "job_id": None,
+                "job_ids": (JobId("20000000-0000-4000-8000-000000000007"),),
                 "tailor_current_policy_only": True,
                 "dry_run": False,
                 "suppress_existing_artifacts": False,
@@ -1218,18 +1264,6 @@ def test_current_policy_maintenance_methods_start_pipeline_workflows(
             job_url=f"https://example.com/job/{method}-{job_id}",
             job_id=job_id,
         )
-    else:
-        for job_id, job_url in zip(
-            params["jobIds"],
-            expected_payload["job_urls"],
-            strict=True,
-        ):
-            _seed_v7_current_locator(
-                get_connection(tmp_db),
-                tenant_id=TenantId("local"),
-                job_url=str(job_url),
-                job_id=JobId(str(job_id)),
-            )
 
     server = JsonRpcServer(workflow_starter=starter)
     register_default_handlers(server, canceler=_stub_canceler)
@@ -1403,7 +1437,7 @@ def test_v7_job_id_workflow_targets_are_loaded_directly_and_tenant_scoped(
         ),
     ],
 )
-def test_v7_direct_preparation_identity_requires_one_canonical_job_id(
+def test_current_policy_job_handlers_require_a_canonical_job_id(
     tmp_db: Path,
     method: str,
     params: dict[str, object],
@@ -1415,6 +1449,26 @@ def test_v7_direct_preparation_identity_requires_one_canonical_job_id(
     body = response.to_dict()
     assert body["error"]["code"] == INVALID_PARAMS
     assert expected_message in body["error"]["message"]
+
+
+@pytest.mark.parametrize("method", ("rescore_job", "retailor_job"))
+def test_current_policy_job_handlers_reject_legacy_url_fields(method: str) -> None:
+    response = _server().dispatch(
+        JsonRpcRequest(
+            method=method,
+            params={
+                "tenantId": "local",
+                "jobId": "20000000-0000-4000-8000-000000000001",
+                "jobUrl": "https://example.com/jobs/legacy",
+            },
+            id=1,
+        )
+    )
+
+    assert response is not None
+    body = response.to_dict()
+    assert body["error"]["code"] == INVALID_PARAMS
+    assert "jobUrl is not supported" in body["error"]["message"]
 
 
 @pytest.mark.parametrize(
@@ -1660,7 +1714,7 @@ def test_retailor_job_duplicate_dispatch_uses_existing_workflow_without_duplicat
         job_url=job_url,
     )
     _seed_tailoring_policy(conn, version=3)
-    _seed_tailored_artifact(conn, job_url, policy_version=3)
+    _seed_tailored_artifact(conn, job_id, policy_version=3)
     before = conn.execute(
         """
         SELECT COUNT(*), COUNT(DISTINCT artifact_id)
@@ -1713,7 +1767,7 @@ def test_retailor_job_duplicate_dispatch_uses_existing_workflow_without_duplicat
 
 
 @pytest.mark.asyncio
-async def test_pipeline_workflow_preserves_selected_job_urls_in_activity_inputs(monkeypatch) -> None:
+async def test_pipeline_workflow_preserves_selected_job_ids_in_activity_inputs(monkeypatch) -> None:
     captured: list[tuple[object, object]] = []
     child_workflows: list[tuple[object, object, dict[str, object]]] = []
 
@@ -1747,7 +1801,7 @@ async def test_pipeline_workflow_preserves_selected_job_urls_in_activity_inputs(
         JobPipelineWorkflowInput(
             tenant_id="local",
             stages=["score"],
-            job_url="https://example.com/job/score-one",
+            job_id=JobId("30000000-0000-4000-8000-000000000001"),
             rescore=True,
         ),
     )
@@ -1756,9 +1810,9 @@ async def test_pipeline_workflow_preserves_selected_job_urls_in_activity_inputs(
         JobPipelineWorkflowInput(
             tenant_id="local",
             stages=["score"],
-            job_urls=(
-                "https://example.com/job/score-a",
-                "https://example.com/job/score-b",
+            job_ids=(
+                JobId("30000000-0000-4000-8000-000000000002"),
+                JobId("30000000-0000-4000-8000-000000000003"),
             ),
             rescore=True,
         ),
@@ -1768,7 +1822,7 @@ async def test_pipeline_workflow_preserves_selected_job_urls_in_activity_inputs(
         JobPipelineWorkflowInput(
             tenant_id="local",
             stages=["tailor"],
-            job_url="https://example.com/job/tailor-one",
+            job_id=JobId("30000000-0000-4000-8000-000000000004"),
             retailor=True,
             suppress_existing_artifacts=False,
         ),
@@ -1778,9 +1832,9 @@ async def test_pipeline_workflow_preserves_selected_job_urls_in_activity_inputs(
         JobPipelineWorkflowInput(
             tenant_id="local",
             stages=["tailor"],
-            job_urls=(
-                "https://example.com/job/tailor-a",
-                "https://example.com/job/tailor-b",
+            job_ids=(
+                JobId("30000000-0000-4000-8000-000000000005"),
+                JobId("30000000-0000-4000-8000-000000000006"),
             ),
             retailor=True,
             suppress_existing_artifacts=True,
@@ -1791,7 +1845,7 @@ async def test_pipeline_workflow_preserves_selected_job_urls_in_activity_inputs(
         JobPipelineWorkflowInput(
             tenant_id="local",
             stages=["cover"],
-            job_url="https://example.com/job/cover-one",
+            job_id=JobId("30000000-0000-4000-8000-000000000007"),
         ),
     )
 
@@ -1803,45 +1857,45 @@ async def test_pipeline_workflow_preserves_selected_job_urls_in_activity_inputs(
     assert len(captured) == 5
     assert captured[0][0] is score_activity
     assert isinstance(captured[0][1], ScoreActivityInput)
-    assert captured[0][1].job_urls == ("https://example.com/job/score-one",)
+    assert captured[0][1].job_ids == (JobId("30000000-0000-4000-8000-000000000001"),)
     assert captured[1][0] is score_activity
     assert isinstance(captured[1][1], ScoreActivityInput)
-    assert captured[1][1].job_urls == (
-        "https://example.com/job/score-a",
-        "https://example.com/job/score-b",
+    assert captured[1][1].job_ids == (
+        JobId("30000000-0000-4000-8000-000000000002"),
+        JobId("30000000-0000-4000-8000-000000000003"),
     )
     assert captured[2][0] is tailor_activity
     assert isinstance(captured[2][1], TailorActivityInput)
-    assert captured[2][1].job_urls == ("https://example.com/job/tailor-one",)
+    assert captured[2][1].job_ids == (JobId("30000000-0000-4000-8000-000000000004"),)
     assert captured[2][1].suppress_existing_artifacts is False
     assert captured[3][0] is tailor_activity
     assert isinstance(captured[3][1], TailorActivityInput)
-    assert captured[3][1].job_urls == (
-        "https://example.com/job/tailor-a",
-        "https://example.com/job/tailor-b",
+    assert captured[3][1].job_ids == (
+        JobId("30000000-0000-4000-8000-000000000005"),
+        JobId("30000000-0000-4000-8000-000000000006"),
     )
     assert captured[3][1].suppress_existing_artifacts is True
     assert captured[4][0] is cover_activity
     assert isinstance(captured[4][1], CoverActivityInput)
-    assert captured[4][1].job_urls == ("https://example.com/job/cover-one",)
+    assert captured[4][1].job_ids == (JobId("30000000-0000-4000-8000-000000000007"),)
 
 
-def test_selected_score_activity_runs_only_requested_urls(monkeypatch) -> None:
-    calls: list[tuple[str, dict[str, object]]] = []
+def test_selected_score_activity_runs_only_requested_job_ids(monkeypatch) -> None:
+    calls: list[tuple[JobId, dict[str, object]]] = []
 
-    def fake_score_job_by_url(url: str, **kwargs: object) -> SimpleNamespace:
-        calls.append((url, kwargs))
+    def fake_score_job_by_id(job_id: JobId, **kwargs: object) -> SimpleNamespace:
+        calls.append((job_id, kwargs))
         return SimpleNamespace(ok=True, error=None)
 
-    monkeypatch.setattr("jobctrl.scoring.scorer.score_job_by_url", fake_score_job_by_url)
+    monkeypatch.setattr("jobctrl.scoring.scorer.score_job_by_id", fake_score_job_by_id)
 
     result = scoring_activities_mod._run_selected_scores(
         ScoreActivityInput(
             tenant_id="local",
-            job_urls=(
-                "https://example.com/job/score-a",
-                "https://example.com/job/score-b",
-                "https://example.com/job/score-a",
+            job_ids=(
+                JobId("40000000-0000-4000-8000-000000000001"),
+                JobId("40000000-0000-4000-8000-000000000002"),
+                JobId("40000000-0000-4000-8000-000000000001"),
             ),
             limit=2,
             rescore=True,
@@ -1849,20 +1903,20 @@ def test_selected_score_activity_runs_only_requested_urls(monkeypatch) -> None:
         )
     )
 
-    assert [url for url, _kwargs in calls] == [
-        "https://example.com/job/score-a",
-        "https://example.com/job/score-b",
+    assert [job_id for job_id, _kwargs in calls] == [
+        JobId("40000000-0000-4000-8000-000000000001"),
+        JobId("40000000-0000-4000-8000-000000000002"),
     ]
-    assert all(call_kwargs["rescore"] is True for _url, call_kwargs in calls)
-    assert all(call_kwargs["llm_model"] == "local:score" for _url, call_kwargs in calls)
+    assert all(call_kwargs["rescore"] is True for _job_id, call_kwargs in calls)
+    assert all(call_kwargs["llm_model"] == "local:score" for _job_id, call_kwargs in calls)
     assert result["errors"] == {}
     assert result["stages"][0]["selected"] == 2
     assert result["stages"][0]["scored"] == 2
 
 
 def test_selected_score_activity_uses_requested_workers(monkeypatch) -> None:
-    calls: list[str] = []
-    submitted: list[str] = []
+    calls: list[JobId] = []
+    submitted: list[JobId] = []
     executor_workers: list[int] = []
 
     class FakeFuture:
@@ -1882,25 +1936,25 @@ def test_selected_score_activity_uses_requested_workers(monkeypatch) -> None:
         def __exit__(self, *_args: object) -> None:
             return None
 
-        def submit(self, fn, url: str):  # noqa: ANN001 - test double mirrors concurrent.futures
-            submitted.append(url)
-            return FakeFuture(fn(url))
+        def submit(self, fn, job_id: JobId):  # noqa: ANN001 - test double mirrors concurrent.futures
+            submitted.append(job_id)
+            return FakeFuture(fn(job_id))
 
-    def fake_score_job_by_url(url: str, **_kwargs: object) -> SimpleNamespace:
-        calls.append(url)
+    def fake_score_job_by_id(job_id: JobId, **_kwargs: object) -> SimpleNamespace:
+        calls.append(job_id)
         return SimpleNamespace(ok=True, error=None)
 
-    monkeypatch.setattr("jobctrl.scoring.scorer.score_job_by_url", fake_score_job_by_url)
+    monkeypatch.setattr("jobctrl.scoring.scorer.score_job_by_id", fake_score_job_by_id)
     monkeypatch.setattr(scoring_activities_mod, "ThreadPoolExecutor", RecordingExecutor)
     monkeypatch.setattr(scoring_activities_mod, "as_completed", lambda futures: futures)
 
     result = scoring_activities_mod._run_selected_scores(
         ScoreActivityInput(
             tenant_id="local",
-            job_urls=(
-                "https://example.com/job/score-a",
-                "https://example.com/job/score-b",
-                "https://example.com/job/score-c",
+            job_ids=(
+                JobId("40000000-0000-4000-8000-000000000003"),
+                JobId("40000000-0000-4000-8000-000000000004"),
+                JobId("40000000-0000-4000-8000-000000000005"),
             ),
             workers=3,
             llm_model="local:score",
@@ -1909,9 +1963,9 @@ def test_selected_score_activity_uses_requested_workers(monkeypatch) -> None:
 
     assert executor_workers == [3]
     assert submitted == [
-        "https://example.com/job/score-a",
-        "https://example.com/job/score-b",
-        "https://example.com/job/score-c",
+        JobId("40000000-0000-4000-8000-000000000003"),
+        JobId("40000000-0000-4000-8000-000000000004"),
+        JobId("40000000-0000-4000-8000-000000000005"),
     ]
     assert calls == submitted
     assert result["errors"] == {}
@@ -1958,14 +2012,14 @@ def test_current_policy_score_activity_skips_current_policy_scores(
         policy_version=2,
     )
 
-    calls: list[str] = []
+    calls: list[JobId] = []
 
-    def fake_score_job_by_url(url: str, **_kwargs: object) -> SimpleNamespace:
-        calls.append(url)
+    def fake_score_job_by_id(job_id: JobId, **_kwargs: object) -> SimpleNamespace:
+        calls.append(job_id)
         return SimpleNamespace(ok=True, error=None)
 
     monkeypatch.setattr("jobctrl.database.get_connection", lambda: get_connection(tmp_db))
-    monkeypatch.setattr("jobctrl.scoring.scorer.score_job_by_url", fake_score_job_by_url)
+    monkeypatch.setattr("jobctrl.scoring.scorer.score_job_by_id", fake_score_job_by_id)
 
     result = scoring_activities_mod._run_current_policy_scores(
         ScoreActivityInput(
@@ -1976,7 +2030,7 @@ def test_current_policy_score_activity_skips_current_policy_scores(
         )
     )
 
-    assert set(calls) == {missing_url, outdated_url}
+    assert set(calls) == {job_ids[missing_url], job_ids[outdated_url]}
     assert result["stages"][0]["selected"] == 2
     assert result["stages"][0]["scored"] == 2
 
@@ -1986,31 +2040,31 @@ def test_current_policy_score_activity_skips_current_policy_scores(
             tenant_id="local",
             limit=10,
             rescore=True,
-            job_urls=(current_url, outdated_url, corrected_url),
+            job_ids=(job_ids[current_url], job_ids[outdated_url], job_ids[corrected_url]),
             current_policy_only=True,
         )
     )
 
-    assert calls == [outdated_url]
+    assert calls == [job_ids[outdated_url]]
     assert result["stages"][0]["selected"] == 1
 
 
-def test_selected_tailor_activity_runs_only_requested_urls(monkeypatch) -> None:
-    calls: list[tuple[str, dict[str, object]]] = []
+def test_selected_tailor_activity_runs_only_requested_job_ids(monkeypatch) -> None:
+    calls: list[tuple[JobId, dict[str, object]]] = []
 
-    def fake_tailor_job_by_url(url: str, **kwargs: object) -> dict[str, object]:
-        calls.append((url, kwargs))
+    def fake_tailor_job_by_id(job_id: JobId, **kwargs: object) -> dict[str, object]:
+        calls.append((job_id, kwargs))
         return {"status": "approved"}
 
-    monkeypatch.setattr("jobctrl.scoring.tailor.tailor_job_by_url", fake_tailor_job_by_url)
+    monkeypatch.setattr("jobctrl.scoring.tailor.tailor_job_by_id", fake_tailor_job_by_id)
 
     result = materials_activities_mod._run_selected_tailoring(
         TailorActivityInput(
             tenant_id="local",
-            job_urls=(
-                "https://example.com/job/tailor-a",
-                "https://example.com/job/tailor-b",
-                "https://example.com/job/tailor-a",
+            job_ids=(
+                JobId("50000000-0000-4000-8000-000000000001"),
+                JobId("50000000-0000-4000-8000-000000000002"),
+                JobId("50000000-0000-4000-8000-000000000001"),
             ),
             limit=2,
             min_score=8,
@@ -2024,24 +2078,24 @@ def test_selected_tailor_activity_runs_only_requested_urls(monkeypatch) -> None:
         )
     )
 
-    assert [url for url, _kwargs in calls] == [
-        "https://example.com/job/tailor-a",
-        "https://example.com/job/tailor-b",
+    assert [job_id for job_id, _kwargs in calls] == [
+        JobId("50000000-0000-4000-8000-000000000001"),
+        JobId("50000000-0000-4000-8000-000000000002"),
     ]
-    assert all(call_kwargs["retailor"] is True for _url, call_kwargs in calls)
-    assert all(call_kwargs["suppress_existing_artifacts"] is True for _url, call_kwargs in calls)
-    assert all(call_kwargs["min_score"] == 8 for _url, call_kwargs in calls)
-    assert all(call_kwargs["tailor_models"] == ("local:tailor",) for _url, call_kwargs in calls)
+    assert all(call_kwargs["retailor"] is True for _job_id, call_kwargs in calls)
+    assert all(call_kwargs["suppress_existing_artifacts"] is True for _job_id, call_kwargs in calls)
+    assert all(call_kwargs["min_score"] == 8 for _job_id, call_kwargs in calls)
+    assert all(call_kwargs["tailor_models"] == ("local:tailor",) for _job_id, call_kwargs in calls)
     assert result["errors"] == {}
     assert result["stages"][0]["selected"] == 2
     assert result["stages"][0]["approved"] == 2
-    assert result["stages"][0]["selectedJobUrls"] == [
-        "https://example.com/job/tailor-a",
-        "https://example.com/job/tailor-b",
+    assert result["stages"][0]["selectedJobIds"] == [
+        JobId("50000000-0000-4000-8000-000000000001"),
+        JobId("50000000-0000-4000-8000-000000000002"),
     ]
-    assert result["stages"][0]["approvedJobUrls"] == [
-        "https://example.com/job/tailor-a",
-        "https://example.com/job/tailor-b",
+    assert result["stages"][0]["approvedJobIds"] == [
+        JobId("50000000-0000-4000-8000-000000000001"),
+        JobId("50000000-0000-4000-8000-000000000002"),
     ]
 
 
@@ -2116,14 +2170,14 @@ def test_current_policy_tailor_activity_skips_current_policy_artifacts(
         policy_version=2,
     )
 
-    calls: list[tuple[str, dict[str, object]]] = []
+    calls: list[tuple[JobId, dict[str, object]]] = []
 
-    def fake_tailor_job_by_url(url: str, **kwargs: object) -> dict[str, object]:
-        calls.append((url, kwargs))
+    def fake_tailor_job_by_id(job_id: JobId, **kwargs: object) -> dict[str, object]:
+        calls.append((job_id, kwargs))
         return {"status": "approved"}
 
     monkeypatch.setattr("jobctrl.database.get_connection", lambda: get_connection(tmp_db))
-    monkeypatch.setattr("jobctrl.scoring.tailor.tailor_job_by_url", fake_tailor_job_by_url)
+    monkeypatch.setattr("jobctrl.scoring.tailor.tailor_job_by_id", fake_tailor_job_by_id)
 
     result = materials_activities_mod._run_current_policy_tailoring(
         TailorActivityInput(
@@ -2136,11 +2190,11 @@ def test_current_policy_tailor_activity_skips_current_policy_artifacts(
         )
     )
 
-    assert {url for url, _kwargs in calls} == {missing_url, outdated_url}
-    assert all(kwargs["suppress_existing_artifacts"] is True for _url, kwargs in calls)
+    assert {job_id for job_id, _kwargs in calls} == {job_ids[missing_url], job_ids[outdated_url]}
+    assert all(kwargs["suppress_existing_artifacts"] is True for _job_id, kwargs in calls)
     assert result["stages"][0]["selected"] == 2
     assert result["stages"][0]["approved"] == 2
-    assert set(result["stages"][0]["approvedJobUrls"]) == {missing_url, outdated_url}
+    assert set(result["stages"][0]["approvedJobIds"]) == {job_ids[missing_url], job_ids[outdated_url]}
 
     calls.clear()
     result = materials_activities_mod._run_current_policy_tailoring(
@@ -2149,13 +2203,13 @@ def test_current_policy_tailor_activity_skips_current_policy_artifacts(
             min_score=7,
             limit=10,
             retailor=True,
-            job_urls=(current_url, outdated_url),
+            job_ids=(job_ids[current_url], job_ids[outdated_url]),
             current_policy_only=True,
             suppress_existing_artifacts=False,
         )
     )
 
-    assert [url for url, _kwargs in calls] == [outdated_url]
+    assert [job_id for job_id, _kwargs in calls] == [job_ids[outdated_url]]
     assert calls[0][1]["suppress_existing_artifacts"] is False
     assert result["stages"][0]["selected"] == 1
 
@@ -2471,13 +2525,7 @@ def _seed_score(
     conn.commit()
 
 
-def _seed_tailored_artifact(conn, url: str, *, policy_version: int) -> None:
-    job = conn.execute(
-        "SELECT job_id FROM jobs WHERE tenant_id = 'local' AND url = ?",
-        (url,),
-    ).fetchone()
-    assert job is not None
-    job_id = str(job["job_id"])
+def _seed_tailored_artifact(conn, job_id: JobId, *, policy_version: int) -> None:
     conn.execute(
         """
         INSERT INTO job_materials (
@@ -2497,8 +2545,8 @@ def _seed_tailored_artifact(conn, url: str, *, policy_version: int) -> None:
         """,
         (
             job_id,
-            f"artifact-{policy_version}-{url.rsplit('/', 1)[-1]}",
-            f"/tmp/{url.rsplit('/', 1)[-1]}.txt",
+            f"artifact-{policy_version}-{job_id}",
+            f"/tmp/{job_id}.txt",
             json.dumps({"tailoring_policy_version": policy_version}),
         ),
     )

--- a/workers/automation/tests/test_workflow_job_pipeline.py
+++ b/workers/automation/tests/test_workflow_job_pipeline.py
@@ -29,6 +29,7 @@ from jobctrl.discovery.activities import (
 )
 from jobctrl.discovery.workflow import DiscoverWorkflow
 from jobctrl.enrichment.activities import enrich_activity
+from jobctrl.domain.identifiers import JobId
 from jobctrl.infrastructure.temporal.finalize import (
     record_workflow_outcome,
     record_workflow_started,
@@ -257,7 +258,7 @@ async def test_pipeline_workflow_preserves_canonical_apply_target():
                     JobPipelineWorkflowInput(
                         tenant_id="local",
                         stages=["apply"],
-                        apply_job_id=_APPLY_JOB_ID,
+                        job_id=_APPLY_JOB_ID,
                         apply_selector_keys=("jobId",),
                         dry_run=True,
                     ),
@@ -326,7 +327,9 @@ def test_pipeline_apply_spec_boundaries_reject_present_unsupported_or_empty_sele
     selector: dict[str, object],
 ) -> None:
     with pytest.raises(ValueError, match="apply (accepts|jobId)"):
-        build_run_stage_workflow_spec({"tenantId": "local", "stage": "apply", **selector})
+        build_run_stage_workflow_spec(
+            {"tenantId": "local", "stage": "apply", **selector}
+        )
     with pytest.raises(ValueError, match="apply (accepts|jobId)"):
         build_pipeline_workflow_spec(
             {"tenantId": "local", **selector},
@@ -339,7 +342,7 @@ def test_pipeline_apply_spec_boundaries_preserve_batch_and_canonical_target() ->
     batch = build_run_stage_workflow_spec({"tenantId": "local", "stage": "apply"})
     (batch_payload,) = batch.args
     assert batch_payload.apply_selector_keys == ()
-    assert batch_payload.apply_job_id is None
+    assert batch_payload.job_id is None
 
     targeted = build_pipeline_workflow_spec(
         {"tenantId": "local", "jobId": _APPLY_JOB_ID},
@@ -348,15 +351,15 @@ def test_pipeline_apply_spec_boundaries_preserve_batch_and_canonical_target() ->
     )
     (targeted_payload,) = targeted.args
     assert targeted_payload.apply_selector_keys == ("jobId",)
-    assert targeted_payload.apply_job_id == _APPLY_JOB_ID
+    assert targeted_payload.job_id == _APPLY_JOB_ID
 
 
 @pytest.mark.parametrize(
     "selector_kwargs",
     [
-        {"job_url": "https://example.test/job"},
-        {"job_url": ""},
-        {"job_urls": ("https://example.test/job",)},
+        {"jobUrl": "https://example.test/job"},
+        {"jobUrl": ""},
+        {"jobUrls": ["https://example.test/job"]},
     ],
 )
 def test_pipeline_apply_spec_rejects_direct_legacy_scope_arguments(
@@ -364,10 +367,9 @@ def test_pipeline_apply_spec_rejects_direct_legacy_scope_arguments(
 ) -> None:
     with pytest.raises(ValueError, match="apply accepts only a canonical jobId"):
         build_pipeline_workflow_spec(
-            {"tenantId": "local"},
+            {"tenantId": "local", **selector_kwargs},
             stages=["apply"],
             limit=1,
-            **selector_kwargs,
         )
 
 
@@ -516,21 +518,21 @@ async def test_pipeline_workflow_forwards_validation_mode_to_tailor_and_cover():
 @pytest.mark.asyncio
 async def test_job_scoped_tailor_continuation_runs_cover_for_same_job_after_success():
     queue = f"pipeline-tailor-cover-{uuid.uuid4()}"
-    job_url = "https://example.com/job/manual-tailor"
-    tailored_urls: list[str] = []
-    cover_urls: list[str] = []
+    job_id = JobId("10000000-0000-4000-8000-000000000001")
+    tailored_job_ids: list[JobId] = []
+    cover_job_ids: list[JobId] = []
 
-    def fake_tailor_job_by_url(url: str, **_kwargs):
-        tailored_urls.append(url)
+    def fake_tailor_job_by_id(selected_job_id: JobId, **_kwargs):
+        tailored_job_ids.append(selected_job_id)
         return {"status": "approved"}
 
-    def fake_cover_letter_by_url(url: str, **_kwargs):
-        cover_urls.append(url)
+    def fake_cover_letter_by_id(selected_job_id: JobId, **_kwargs):
+        cover_job_ids.append(selected_job_id)
         return {"status": "ok", "generated": 1, "errors": 0, "elapsed": 0.01}
 
     with (
-        patch("jobctrl.scoring.tailor.tailor_job_by_url", side_effect=fake_tailor_job_by_url),
-        patch("jobctrl.scoring.cover_letter.cover_letter_by_url", side_effect=fake_cover_letter_by_url),
+        patch("jobctrl.scoring.tailor.tailor_job_by_id", side_effect=fake_tailor_job_by_id),
+        patch("jobctrl.scoring.cover_letter.cover_letter_by_id", side_effect=fake_cover_letter_by_id),
     ):
         async with await WorkflowEnvironment.start_time_skipping() as env:
             async with Worker(
@@ -545,7 +547,7 @@ async def test_job_scoped_tailor_continuation_runs_cover_for_same_job_after_succ
                     JobPipelineWorkflowInput(
                         tenant_id="local",
                         stages=["tailor", "cover"],
-                        job_url=job_url,
+                        job_id=job_id,
                         limit=1,
                     ),
                     id=f"pipeline-tailor-cover-wf-{uuid.uuid4()}",
@@ -554,29 +556,29 @@ async def test_job_scoped_tailor_continuation_runs_cover_for_same_job_after_succ
 
     assert result.stages_completed == ["tailor", "cover"]
     assert result.stages_failed == []
-    assert tailored_urls == [job_url]
-    assert cover_urls == [job_url]
+    assert tailored_job_ids == [job_id]
+    assert cover_job_ids == [job_id]
 
 
 @pytest.mark.asyncio
 async def test_current_policy_tailor_continuation_covers_only_approved_jobs():
     queue = f"pipeline-current-policy-tailor-cover-{uuid.uuid4()}"
-    selected_url = "https://example.com/job/current-policy-selected"
-    unrelated_pending_cover_url = "https://example.com/job/unrelated-pending-cover"
-    tailored_urls: list[str] = []
-    cover_urls: list[str] = []
+    selected_job_id = JobId("10000000-0000-4000-8000-000000000002")
+    unrelated_pending_cover_job_id = JobId("10000000-0000-4000-8000-000000000003")
+    tailored_job_ids: list[JobId] = []
+    cover_job_ids: list[JobId] = []
 
-    def fake_current_policy_urls(_conn, **kwargs):
+    def fake_current_policy_job_ids(_conn, **kwargs):
         assert kwargs["limit"] == 1
-        return (selected_url,)
+        return (selected_job_id,)
 
-    def fake_tailor_job_by_url(url: str, **_kwargs):
-        tailored_urls.append(url)
+    def fake_tailor_job_by_id(job_id: JobId, **_kwargs):
+        tailored_job_ids.append(job_id)
         return {"status": "approved"}
 
-    def fake_cover_letter_by_url(url: str, **_kwargs):
-        cover_urls.append(url)
-        assert url != unrelated_pending_cover_url
+    def fake_cover_letter_by_id(job_id: JobId, **_kwargs):
+        cover_job_ids.append(job_id)
+        assert job_id != unrelated_pending_cover_job_id
         return {"status": "ok", "generated": 1, "errors": 0, "elapsed": 0.01}
 
     with (
@@ -585,12 +587,9 @@ async def test_current_policy_tailor_continuation_covers_only_approved_jobs():
         # dummy), so stub the finalize writer — the finalize wiring itself is
         # covered by test_workflow_finalize.py.
         patch("jobctrl.infrastructure.temporal.finalize._emit"),
-        patch(
-            "jobctrl.pipeline.current_policy_selectors.tailoring_current_policy_job_urls",
-            side_effect=fake_current_policy_urls,
-        ),
-        patch("jobctrl.scoring.tailor.tailor_job_by_url", side_effect=fake_tailor_job_by_url),
-        patch("jobctrl.scoring.cover_letter.cover_letter_by_url", side_effect=fake_cover_letter_by_url),
+        patch("jobctrl.pipeline.current_policy_selectors.tailoring_current_policy_job_ids", side_effect=fake_current_policy_job_ids),
+        patch("jobctrl.scoring.tailor.tailor_job_by_id", side_effect=fake_tailor_job_by_id),
+        patch("jobctrl.scoring.cover_letter.cover_letter_by_id", side_effect=fake_cover_letter_by_id),
     ):
         async with await WorkflowEnvironment.start_time_skipping() as env:
             async with Worker(
@@ -615,8 +614,8 @@ async def test_current_policy_tailor_continuation_covers_only_approved_jobs():
 
     assert result.stages_completed == ["tailor", "cover"]
     assert result.stages_failed == []
-    assert tailored_urls == [selected_url]
-    assert cover_urls == [selected_url]
+    assert tailored_job_ids == [selected_job_id]
+    assert cover_job_ids == [selected_job_id]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- select current-policy scoring and tailoring candidates by exact tenant and canonical job identity
- remove legacy job-column fallbacks from the maintenance selectors
- preserve the newest approved tailored artifact when a later generation is rejected
- stop re-selecting tailoring work after the canonical attempt limit

## Validation
- focused current-policy pytest: 10 passed
- exact-v7 schema pytest: 14 passed
- Ruff on changed Python files
- independent review: PASS, 0 Blocker / 0 High / 0 Medium / 0 Low
- independent QA: PASS, 0 Blocker / 0 High

## Stack
Ready-for-review child of #628 in GitHub Stack #632.