### PR TITLE
refactor(apply): persist results by canonical id

### DIFF
--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -1857,7 +1857,11 @@ export function buildApp(options: BuildAppOptions): FastifyInstance {
       if (body.runId) {
         command.runId = body.runId;
       }
-      return { command, stage: canceled.stage };
+      return {
+        command,
+        stage: canceled.stage,
+        cancelRequested: canceled.cancelRequested,
+      };
     });
     if ("ok" in writeOutcome) {
       return writeOutcome;
@@ -1867,9 +1871,13 @@ export function buildApp(options: BuildAppOptions): FastifyInstance {
     // cancellation signal. Without this, the SQLite event-flip succeeds
     // but the workflow keeps polling Chrome and the stage row drifts
     // back to running on the next worker_loop cycle.
-    const { command: cancelCommand, stage: cancelStage } = writeOutcome;
+    const {
+      command: cancelCommand,
+      stage: cancelStage,
+      cancelRequested,
+    } = writeOutcome;
     const runId = cancelCommand.runId;
-    if (runId) {
+    if (runId && cancelRequested) {
       try {
         await actionDispatcher(cancelCommand, actionContext);
       } catch (err) {
@@ -1881,7 +1889,10 @@ export function buildApp(options: BuildAppOptions): FastifyInstance {
     }
     return buildActionResponse(
       cancelCommand,
-      { status: "cancel_requested" },
+      {
+        status: cancelRequested ? "cancel_requested" : "already_terminal",
+        ...(runId ? { runId } : {}),
+      },
       { stage: cancelStage },
     );
   });

--- a/apps/api/src/write-model.ts
+++ b/apps/api/src/write-model.ts
@@ -52,6 +52,15 @@ interface ResolvedJobIdentity {
   readonly jobUrl: string;
 }
 
+const IMMUTABLE_CANCEL_STATES: ReadonlySet<StageState> = new Set([
+  "succeeded",
+  "failed",
+  "skipped",
+  "exhausted",
+  "needs_verification",
+  "canceled",
+]);
+
 const DEFAULT_SCORING_RUBRIC_VERSION = "default-scoring-rubric-v1";
 const DEFAULT_SCORING_DIMENSIONS = [
   { name: "technical_fit", weight: 0.45 },
@@ -358,18 +367,25 @@ export function markJobSkipped(
   return { jobUrl, stage: getStageState(db, jobUrl, "apply") };
 }
 
-export function cancelJobAction(db: SqliteDatabase, jobKey: string, runId = ""): { jobUrl: string; stage: StageSummary } {
+export function cancelJobAction(
+  db: SqliteDatabase,
+  jobKey: string,
+  runId = "",
+): { jobUrl: string; stage: StageSummary; cancelRequested: boolean } {
   const jobUrl = resolveJobUrl(db, jobKey);
   if (!jobUrl) {
     throw new InputError("Job not found.");
   }
   const stage = currentMutableStage(db, jobUrl);
-  // Manual cancel — admin override, bypasses §8.5.  Cancel from any state is
-  // permitted when the user explicitly requests it from the UI.
+  const current = getStageState(db, jobUrl, stage);
+  if (IMMUTABLE_CANCEL_STATES.has(current.state)) {
+    return { jobUrl, stage: current, cancelRequested: false };
+  }
+  // Cancellation is a normal state-machine transition. Only queued/running
+  // work may enter Canceled; terminal results remain inspectable and immutable.
   upsertStageState(db, jobUrl, stage, "canceled", {
     retryable: true,
     finishedAt: new Date().toISOString(),
-    skipValidation: true,
   });
   recordActionEvent(db, {
     jobUrl,
@@ -381,7 +397,7 @@ export function cancelJobAction(db: SqliteDatabase, jobKey: string, runId = ""):
     message: "Cancel requested from the local API.",
     payload: { run_id: runId },
   });
-  return { jobUrl, stage: getStageState(db, jobUrl, stage) };
+  return { jobUrl, stage: getStageState(db, jobUrl, stage), cancelRequested: true };
 }
 
 export function correctScore(
@@ -1429,7 +1445,6 @@ function cleanJsonRecord(value: Record<string, unknown>): Record<string, unknown
  *   - `resetJobStage`        — user retry, mirrors Python `reset_job_stage`
  *   - `markJobApplied`       — user assertion "I applied externally"
  *   - `markJobSkipped`       — user assertion "skip this one"
- *   - `cancelJobAction`      — user-initiated cancel from any state
  *   - `resetStaleScoresForRescore` — explicit stale-score rescore request
  *
  * **Automated pipeline writes (Phase 9 / S-34 onward) MUST NOT pass
@@ -1449,7 +1464,7 @@ function upsertStageState(
     retryable?: boolean;
     /**
      * S-12: skip the §8.5 validation gate. Admin overrides (manual
-     * mark-applied, mark-skipped, cancel, reset) set this to mirror
+     * mark-applied, mark-skipped, reset) set this to mirror
      * Python's `set_stage_state(... validate_transition=False)` —
      * see `state.py::reset_job_stage`. Automated/normal writes leave
      * this `false` (default) and pay the cost of the gate.

--- a/apps/api/src/write-model.ts
+++ b/apps/api/src/write-model.ts
@@ -302,25 +302,21 @@ export function markJobApplied(
   jobKey: string,
   request: MarkJobActionRequest,
 ): { jobUrl: string; stage: StageSummary } {
-  const jobUrl = resolveJobUrl(db, jobKey);
-  if (!jobUrl) {
+  const job = resolveJobIdentity(db, LOCAL_TENANT, jobKey);
+  if (!job) {
     throw new InputError("Job not found.");
   }
   // Manual mark-applied — admin override, bypasses §8.5 (parity with the
   // Python JSON-RPC `mark_applied` handler).  The user is asserting they
   // applied externally; we trust them.
-  updateExistingJobColumns(db, jobUrl, {
-    apply_status: "applied",
-    apply_error: null,
-    applied_at: new Date().toISOString(),
-  });
-  upsertStageState(db, jobUrl, "apply", "succeeded", {
+  upsertStageStateById(db, LOCAL_TENANT, job.jobId, "apply", "succeeded", {
     retryable: false,
     finishedAt: new Date().toISOString(),
     skipValidation: true,
   });
-  recordActionEvent(db, {
-    jobUrl,
+  recordActionEventById(db, {
+    tenantId: LOCAL_TENANT,
+    jobId: job.jobId,
     stage: "apply",
     // H1 (round-1 review): align with the Python JSON-RPC handler
     // (`infrastructure/rpc/handlers.py::mark_applied`) which writes the
@@ -330,7 +326,10 @@ export function markJobApplied(
     message: "Job marked applied from the local API.",
     payload: { reason: request.reason ?? "" },
   });
-  return { jobUrl, stage: getStageState(db, jobUrl, "apply") };
+  return {
+    jobUrl: job.jobUrl,
+    stage: getStageStateById(db, LOCAL_TENANT, job.jobId, "apply"),
+  };
 }
 
 export function markJobSkipped(
@@ -338,23 +337,20 @@ export function markJobSkipped(
   jobKey: string,
   request: MarkJobActionRequest,
 ): { jobUrl: string; stage: StageSummary } {
-  const jobUrl = resolveJobUrl(db, jobKey);
-  if (!jobUrl) {
+  const job = resolveJobIdentity(db, LOCAL_TENANT, jobKey);
+  if (!job) {
     throw new InputError("Job not found.");
   }
   // Manual mark-skipped — admin override, bypasses §8.5 (parity with
   // Python's `mark_skipped` JSON-RPC handler).
-  updateExistingJobColumns(db, jobUrl, {
-    apply_status: "skipped",
-    apply_error: null,
-  });
-  upsertStageState(db, jobUrl, "apply", "skipped", {
+  upsertStageStateById(db, LOCAL_TENANT, job.jobId, "apply", "skipped", {
     retryable: false,
     finishedAt: new Date().toISOString(),
     skipValidation: true,
   });
-  recordActionEvent(db, {
-    jobUrl,
+  recordActionEventById(db, {
+    tenantId: LOCAL_TENANT,
+    jobId: job.jobId,
     stage: "apply",
     // H1 (round-1 review): align with domain catalog — `StageSkipped`
     // already exists in `domain/events/orchestration.py`.  The Python RPC
@@ -364,7 +360,10 @@ export function markJobSkipped(
     message: "Job marked skipped from the local API.",
     payload: { reason: request.reason ?? "" },
   });
-  return { jobUrl, stage: getStageState(db, jobUrl, "apply") };
+  return {
+    jobUrl: job.jobUrl,
+    stage: getStageStateById(db, LOCAL_TENANT, job.jobId, "apply"),
+  };
 }
 
 export function cancelJobAction(
@@ -372,23 +371,24 @@ export function cancelJobAction(
   jobKey: string,
   runId = "",
 ): { jobUrl: string; stage: StageSummary; cancelRequested: boolean } {
-  const jobUrl = resolveJobUrl(db, jobKey);
-  if (!jobUrl) {
+  const job = resolveJobIdentity(db, LOCAL_TENANT, jobKey);
+  if (!job) {
     throw new InputError("Job not found.");
   }
-  const stage = currentMutableStage(db, jobUrl);
-  const current = getStageState(db, jobUrl, stage);
+  const stage = currentMutableStageById(db, LOCAL_TENANT, job.jobId);
+  const current = getStageStateById(db, LOCAL_TENANT, job.jobId, stage);
   if (IMMUTABLE_CANCEL_STATES.has(current.state)) {
-    return { jobUrl, stage: current, cancelRequested: false };
+    return { jobUrl: job.jobUrl, stage: current, cancelRequested: false };
   }
   // Cancellation is a normal state-machine transition. Only queued/running
   // work may enter Canceled; terminal results remain inspectable and immutable.
-  upsertStageState(db, jobUrl, stage, "canceled", {
+  upsertStageStateById(db, LOCAL_TENANT, job.jobId, stage, "canceled", {
     retryable: true,
     finishedAt: new Date().toISOString(),
   });
-  recordActionEvent(db, {
-    jobUrl,
+  recordActionEventById(db, {
+    tenantId: LOCAL_TENANT,
+    jobId: job.jobId,
     stage,
     // Canonical `StageCanceled` catalog event (see
     // `domain/events/orchestration.py`).
@@ -397,7 +397,11 @@ export function cancelJobAction(
     message: "Cancel requested from the local API.",
     payload: { run_id: runId },
   });
-  return { jobUrl, stage: getStageState(db, jobUrl, stage), cancelRequested: true };
+  return {
+    jobUrl: job.jobUrl,
+    stage: getStageStateById(db, LOCAL_TENANT, job.jobId, stage),
+    cancelRequested: true,
+  };
 }
 
 export function correctScore(
@@ -1753,6 +1757,19 @@ function getStageStateById(db: SqliteDatabase, tenantId: string, jobId: string, 
     blockedBy: parseStringArray(nullableString(row.blocked_by_json)),
     nextAction: nullableString(row.next_action),
   };
+}
+
+function currentMutableStageById(db: SqliteDatabase, tenantId: string, jobId: string): Stage {
+  const rows = allRows<Record<string, unknown>>(
+    db,
+    "SELECT stage, state FROM job_stage_states WHERE tenant_id = ? AND job_id = ? ORDER BY rowid",
+    [tenantId, jobId],
+  );
+  const active = rows.find((row) => ["queued", "running"].includes(String(row.state ?? "")));
+  if (active && STAGES.includes(active.stage as Stage)) {
+    return active.stage as Stage;
+  }
+  return "apply";
 }
 
 function currentFailedStageById(db: SqliteDatabase, tenantId: string, jobId: string): Stage | null {

--- a/apps/api/test/write-model-cancel.test.ts
+++ b/apps/api/test/write-model-cancel.test.ts
@@ -1,0 +1,81 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import Database from "better-sqlite3";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { cancelJobAction } from "../src/write-model.js";
+import { initializeExactV7Database } from "./v7-schema.js";
+
+const JOB_ID = "11111111-1111-4111-8111-111111111111";
+const JOB_URL = "https://example.com/jobs/ready";
+
+describe("cancelJobAction", () => {
+  let directory: string;
+  let db: Database.Database;
+
+  beforeEach(() => {
+    directory = fs.mkdtempSync(path.join(os.tmpdir(), "jobctrl-cancel-action-"));
+    const dbPath = path.join(directory, "jobctrl.db");
+    initializeExactV7Database(dbPath);
+    db = new Database(dbPath);
+    db.prepare(
+      "INSERT INTO jobs (tenant_id, job_id, url, application_url) VALUES ('local', ?, ?, ?)",
+    ).run(JOB_ID, JOB_URL, `${JOB_URL}/apply`);
+    db.prepare(
+      `INSERT INTO job_locators (
+         tenant_id, job_id, locator_kind, locator_value, is_current,
+         first_seen_at, last_seen_at
+       ) VALUES ('local', ?, 'posting_url', ?, 1, ?, ?)`,
+    ).run(JOB_ID, JOB_URL, "2026-07-31T12:00:00+00:00", "2026-07-31T12:00:00+00:00");
+  });
+
+  afterEach(() => {
+    db.close();
+    fs.rmSync(directory, { recursive: true, force: true });
+  });
+
+  it("records a running-stage cancellation only once", () => {
+    db.prepare(
+      `INSERT INTO job_stage_states (
+         tenant_id, job_id, stage, state, attempt_count, updated_at
+       ) VALUES ('local', ?, 'apply', 'running', 1, ?)`,
+    ).run(JOB_ID, "2026-07-31T12:00:00+00:00");
+
+    const first = cancelJobAction(db, JOB_URL, "apply-run-1");
+    const second = cancelJobAction(db, JOB_URL, "apply-run-1");
+
+    expect(first.cancelRequested).toBe(true);
+    expect(first.stage.state).toBe("canceled");
+    expect(second.cancelRequested).toBe(false);
+    expect(second.stage.state).toBe("canceled");
+    const events = db
+      .prepare(
+        `SELECT COUNT(*) AS count FROM job_events
+         WHERE tenant_id = 'local' AND job_id = ? AND event_type = 'StageCanceled'`,
+      )
+      .get(JOB_ID) as { count: number };
+    expect(events.count).toBe(1);
+  });
+
+  it("preserves an already-terminal Apply result", () => {
+    db.prepare(
+      `INSERT INTO job_stage_states (
+         tenant_id, job_id, stage, state, attempt_count, updated_at
+       ) VALUES ('local', ?, 'apply', 'succeeded', 1, ?)`,
+    ).run(JOB_ID, "2026-07-31T12:00:00+00:00");
+
+    const result = cancelJobAction(db, JOB_URL, "apply-run-terminal");
+
+    expect(result.cancelRequested).toBe(false);
+    expect(result.stage.state).toBe("succeeded");
+    const events = db
+      .prepare(
+        `SELECT COUNT(*) AS count FROM job_events
+         WHERE tenant_id = 'local' AND job_id = ? AND event_type = 'StageCanceled'`,
+      )
+      .get(JOB_ID) as { count: number };
+    expect(events.count).toBe(0);
+  });
+});

--- a/apps/api/test/write-model-cancel.test.ts
+++ b/apps/api/test/write-model-cancel.test.ts
@@ -5,11 +5,12 @@ import path from "node:path";
 import Database from "better-sqlite3";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-import { cancelJobAction } from "../src/write-model.js";
+import { cancelJobAction, markJobApplied, markJobSkipped } from "../src/write-model.js";
 import { initializeExactV7Database } from "./v7-schema.js";
 
-const JOB_ID = "11111111-1111-4111-8111-111111111111";
 const JOB_URL = "https://example.com/jobs/ready";
+const JOB_ID = "10000000-0000-4000-8000-000000000001";
+const TENANT_ID = "local";
 
 describe("cancelJobAction", () => {
   let directory: string;
@@ -21,14 +22,20 @@ describe("cancelJobAction", () => {
     initializeExactV7Database(dbPath);
     db = new Database(dbPath);
     db.prepare(
-      "INSERT INTO jobs (tenant_id, job_id, url, application_url) VALUES ('local', ?, ?, ?)",
-    ).run(JOB_ID, JOB_URL, `${JOB_URL}/apply`);
+      "INSERT INTO jobs (tenant_id, job_id, url, application_url) VALUES (?, ?, ?, ?)",
+    ).run(TENANT_ID, JOB_ID, JOB_URL, `${JOB_URL}/apply`);
     db.prepare(
       `INSERT INTO job_locators (
          tenant_id, job_id, locator_kind, locator_value, is_current,
          first_seen_at, last_seen_at
-       ) VALUES ('local', ?, 'posting_url', ?, 1, ?, ?)`,
-    ).run(JOB_ID, JOB_URL, "2026-07-31T12:00:00+00:00", "2026-07-31T12:00:00+00:00");
+       ) VALUES (?, ?, 'posting_url', ?, 1, ?, ?)`,
+    ).run(
+      TENANT_ID,
+      JOB_ID,
+      JOB_URL,
+      "2026-07-31T12:00:00+00:00",
+      "2026-07-31T12:00:00+00:00",
+    );
   });
 
   afterEach(() => {
@@ -40,8 +47,8 @@ describe("cancelJobAction", () => {
     db.prepare(
       `INSERT INTO job_stage_states (
          tenant_id, job_id, stage, state, attempt_count, updated_at
-       ) VALUES ('local', ?, 'apply', 'running', 1, ?)`,
-    ).run(JOB_ID, "2026-07-31T12:00:00+00:00");
+       ) VALUES (?, ?, 'apply', 'running', 1, ?)`,
+    ).run(TENANT_ID, JOB_ID, "2026-07-31T12:00:00+00:00");
 
     const first = cancelJobAction(db, JOB_URL, "apply-run-1");
     const second = cancelJobAction(db, JOB_URL, "apply-run-1");
@@ -53,9 +60,9 @@ describe("cancelJobAction", () => {
     const events = db
       .prepare(
         `SELECT COUNT(*) AS count FROM job_events
-         WHERE tenant_id = 'local' AND job_id = ? AND event_type = 'StageCanceled'`,
+         WHERE tenant_id = ? AND job_id = ? AND event_type = 'StageCanceled'`,
       )
-      .get(JOB_ID) as { count: number };
+      .get(TENANT_ID, JOB_ID) as { count: number };
     expect(events.count).toBe(1);
   });
 
@@ -63,8 +70,8 @@ describe("cancelJobAction", () => {
     db.prepare(
       `INSERT INTO job_stage_states (
          tenant_id, job_id, stage, state, attempt_count, updated_at
-       ) VALUES ('local', ?, 'apply', 'succeeded', 1, ?)`,
-    ).run(JOB_ID, "2026-07-31T12:00:00+00:00");
+       ) VALUES (?, ?, 'apply', 'succeeded', 1, ?)`,
+    ).run(TENANT_ID, JOB_ID, "2026-07-31T12:00:00+00:00");
 
     const result = cancelJobAction(db, JOB_URL, "apply-run-terminal");
 
@@ -73,9 +80,38 @@ describe("cancelJobAction", () => {
     const events = db
       .prepare(
         `SELECT COUNT(*) AS count FROM job_events
-         WHERE tenant_id = 'local' AND job_id = ? AND event_type = 'StageCanceled'`,
+         WHERE tenant_id = ? AND job_id = ? AND event_type = 'StageCanceled'`,
       )
-      .get(JOB_ID) as { count: number };
+      .get(TENANT_ID, JOB_ID) as { count: number };
     expect(events.count).toBe(0);
+  });
+
+  it.each([
+    ["applied", markJobApplied, "succeeded", "ApplicationManuallyMarked"],
+    ["skipped", markJobSkipped, "skipped", "StageSkipped"],
+  ] as const)("persists a manually %s result only in the canonical aggregate", (_label, action, state, eventType) => {
+    const result = action(db, JOB_URL, { reason: "confirmed by user" });
+
+    expect(result.jobUrl).toBe(JOB_URL);
+    expect(result.stage.state).toBe(state);
+    const stageRow = db
+      .prepare(
+        `SELECT state FROM job_stage_states
+         WHERE tenant_id = ? AND job_id = ? AND stage = 'apply'`,
+      )
+      .get(TENANT_ID, JOB_ID) as { state: string };
+    expect(stageRow.state).toBe(state);
+    const event = db
+      .prepare(
+        `SELECT event_type, payload_json FROM job_events
+         WHERE tenant_id = ? AND job_id = ? ORDER BY event_id DESC LIMIT 1`,
+      )
+      .get(TENANT_ID, JOB_ID) as { event_type: string; payload_json: string };
+    expect(event.event_type).toBe(eventType);
+    expect(JSON.parse(event.payload_json)).toMatchObject({
+      tenantId: TENANT_ID,
+      jobId: JOB_ID,
+      reason: "confirmed by user",
+    });
   });
 });

--- a/workers/automation/src/jobctrl/apply/launcher.py
+++ b/workers/automation/src/jobctrl/apply/launcher.py
@@ -1117,6 +1117,63 @@ def mark_result(
     stable_tenant_id = TenantId(
         str(tenant_id or (run_ctx.get("tenant_id") if run_ctx else None) or LOCAL_TENANT)
     )
+    run_id = (
+        task_id
+        or (run_ctx.get("run_id") if run_ctx else None)
+        or new_apply_run_id()
+    )
+    current_state = conn.execute(
+        """
+        SELECT state
+        FROM job_stage_states
+        WHERE tenant_id = ? AND job_id = ? AND stage = 'apply'
+        """,
+        (str(stable_tenant_id), str(stable_job_id)),
+    ).fetchone()
+    immutable_states = {
+        "succeeded",
+        "failed",
+        "skipped",
+        "exhausted",
+        "needs_verification",
+        "canceled",
+    }
+    state_value = (
+        str(current_state["state"])
+        if current_state is not None and hasattr(current_state, "keys")
+        else str(current_state[0])
+        if current_state is not None
+        else ""
+    )
+    requested_terminal_event = (
+        "ApplicationSubmitted"
+        if status == "applied"
+        else "DryRunCompleted"
+        if status == "dry_run"
+        else "ApplicationFailed"
+    )
+    terminal_event_types = {
+        event_type
+        for event_type in {
+            "ApplicationSubmitted",
+            "ApplicationFailed",
+            "DryRunCompleted",
+            "ApplyManualSkip",
+            "StageCanceled",
+        }
+        if _has_apply_event(
+            conn,
+            tenant_id=stable_tenant_id,
+            job_id=stable_job_id,
+            run_id=str(run_id),
+            event_types={event_type},
+        )
+    }
+    if state_value in immutable_states or (
+        terminal_event_types
+        and terminal_event_types != {requested_terminal_event}
+    ):
+        return
     posting_url = _posting_url_for_job_id(
         conn,
         tenant_id=stable_tenant_id,
@@ -1128,7 +1185,6 @@ def mark_result(
         tenant_id=stable_tenant_id,
     )
 
-    run_id = task_id or (run_ctx.get("run_id") if run_ctx else None) or new_apply_run_id()
     worker_id = run_ctx.get("worker_id") if run_ctx else None
     model = run_ctx.get("model") if run_ctx else None
     dry_run = bool(run_ctx.get("dry_run")) if run_ctx else False
@@ -1143,10 +1199,9 @@ def mark_result(
     )
 
     if status == "applied":
-        # Launcher owns lock-release policy: if a competing process raced
-        # the row out of `running` (orphan rescue, mark-skipped, etc.) we
-        # still want to record this completion. Skip canonical validation;
-        # the launcher is the writer.
+        # The terminal guard above protects results written by cancellation,
+        # recovery, or manual action. The launcher still owns the normal
+        # Running -> Succeeded write for this active run.
         set_stage_state(
             conn,
             stable_job_id,

--- a/workers/automation/src/jobctrl/apply/launcher.py
+++ b/workers/automation/src/jobctrl/apply/launcher.py
@@ -1058,34 +1058,6 @@ def _posting_url_for_job_id(
     return str(row[0] or "") or None
 
 
-def _has_apply_event_for_job_id(
-    conn,
-    *,
-    tenant_id: TenantId,
-    job_id: JobId,
-    run_id: str,
-    event_types: set[str],
-) -> bool:
-    placeholders = ",".join("?" for _ in event_types)
-    rows = conn.execute(
-        f"""
-        SELECT payload_json FROM job_events
-        WHERE tenant_id = ? AND job_id = ?
-          AND stage = 'apply' AND event_type IN ({placeholders})
-        """,
-        (str(tenant_id), str(job_id), *event_types),
-    ).fetchall()
-    for row in rows:
-        payload_json = row["payload_json"] if hasattr(row, "keys") else row[0]
-        try:
-            payload = json.loads(payload_json or "{}")
-        except (TypeError, ValueError):
-            continue
-        if isinstance(payload, dict) and str(payload.get("run_id") or "") == run_id:
-            return True
-    return False
-
-
 def _record_apply_terminal_event_once(
     conn,
     *,
@@ -1097,7 +1069,7 @@ def _record_apply_terminal_event_once(
     message: str,
     payload: dict[str, Any],
 ) -> None:
-    if _has_apply_event_for_job_id(
+    if _has_apply_event(
         conn,
         tenant_id=tenant_id,
         job_id=job_id,
@@ -1142,7 +1114,9 @@ def mark_result(
     conn = get_connection()
     now = _utc_now()
     stable_job_id = canonical_job_id(str(job_id))
-    stable_tenant_id = TenantId(str(tenant_id or (run_ctx.get("tenant_id") if run_ctx else None) or LOCAL_TENANT))
+    stable_tenant_id = TenantId(
+        str(tenant_id or (run_ctx.get("tenant_id") if run_ctx else None) or LOCAL_TENANT)
+    )
     posting_url = _posting_url_for_job_id(
         conn,
         tenant_id=stable_tenant_id,
@@ -1158,12 +1132,14 @@ def mark_result(
     worker_id = run_ctx.get("worker_id") if run_ctx else None
     model = run_ctx.get("model") if run_ctx else None
     dry_run = bool(run_ctx.get("dry_run")) if run_ctx else False
-    submit_intent_recorded = status not in {"applied", "dry_run"} and _has_apply_event_for_job_id(
-        conn,
-        tenant_id=stable_tenant_id,
-        job_id=stable_job_id,
-        run_id=str(run_id),
-        event_types={"ApplySubmitIntended"},
+    submit_intent_recorded = (
+        status not in {"applied", "dry_run"}
+        and _has_apply_submit_intent(
+            conn,
+            tenant_id=stable_tenant_id,
+            job_id=stable_job_id,
+            run_id=str(run_id),
+        )
     )
 
     if status == "applied":
@@ -1218,7 +1194,9 @@ def mark_result(
             error_code="DRY_RUN",
             error_message="Dry run completed without submitting.",
             retryable=True,
-            next_action=f"jobctrl apply --url {posting_url}" if posting_url else None,
+            next_action=(
+                f"jobctrl apply --url {posting_url}" if posting_url else None
+            ),
             validate_transition=False,
         )
         _record_apply_terminal_event_once(
@@ -1330,8 +1308,13 @@ def mark_result(
     conn.commit()
 
 
-def _latest_apply_run_started_run_id(conn, url: str) -> str | None:
-    """Look up the run_id of the most recent ``ApplyRunStarted`` event for ``url``.
+def _latest_apply_run_started_run_id(
+    conn,
+    *,
+    tenant_id: TenantId,
+    job_id: JobId,
+) -> str | None:
+    """Look up the latest ``ApplyRunStarted`` run id for one aggregate.
 
     Used by orphan rescue (and any caller without a ``run_ctx``) to
     close the SAME run row instead of minting a phantom new uuid that
@@ -1339,9 +1322,10 @@ def _latest_apply_run_started_run_id(conn, url: str) -> str | None:
     """
     row = conn.execute(
         "SELECT payload_json FROM job_events "
-        "WHERE job_url = ? AND stage = 'apply' AND event_type = 'ApplyRunStarted' "
+        "WHERE tenant_id = ? AND job_id = ? "
+        "AND stage = 'apply' AND event_type = 'ApplyRunStarted' "
         "ORDER BY event_id DESC LIMIT 1",
-        (url,),
+        (str(tenant_id), str(canonical_job_id(str(job_id)))),
     ).fetchone()
     if row is None:
         return None
@@ -1367,11 +1351,13 @@ def release_lock(
     """Record that launcher cleanup ran without making retry decisions."""
     conn = get_connection()
     stable_job_id = canonical_job_id(str(job_id))
-    stable_tenant_id = TenantId(str(tenant_id or (run_ctx.get("tenant_id") if run_ctx else None) or LOCAL_TENANT))
+    stable_tenant_id = TenantId(
+        str(tenant_id or (run_ctx.get("tenant_id") if run_ctx else None) or LOCAL_TENANT)
+    )
     ctx_run_id = run_ctx.get("run_id") if run_ctx else None
     run_id = (
         ctx_run_id
-        or _latest_apply_run_started_run_id_for_job_id(
+        or _latest_apply_run_started_run_id(
             conn,
             tenant_id=stable_tenant_id,
             job_id=stable_job_id,
@@ -1390,43 +1376,22 @@ def release_lock(
     conn.commit()
 
 
-def _latest_apply_run_started_run_id_for_job_id(
-    conn,
-    *,
-    tenant_id: TenantId,
-    job_id: JobId,
-) -> str | None:
-    row = conn.execute(
-        "SELECT payload_json FROM job_events "
-        "WHERE tenant_id = ? AND job_id = ? "
-        "AND stage = 'apply' AND event_type = 'ApplyRunStarted' "
-        "ORDER BY event_id DESC LIMIT 1",
-        (str(tenant_id), str(job_id)),
-    ).fetchone()
-    if row is None:
-        return None
-    payload_json = row["payload_json"] if not isinstance(row, tuple) else row[0]
-    try:
-        payload = json.loads(payload_json)
-    except (TypeError, ValueError):
-        return None
-    if not isinstance(payload, dict):
-        return None
-    run_id = payload.get("run_id")
-    return str(run_id) if run_id else None
-
-
 def recover_ambiguous_running_apply(console: Console | None = None) -> int:
     """Recover apply rows inherited from a prior dead workflow/activity."""
     try:
         conn = get_connection()
         rows = conn.execute(
-            "SELECT tenant_id, job_id FROM job_stage_states WHERE stage = 'apply' AND state = 'running'"
+            "SELECT tenant_id, job_id FROM job_stage_states "
+            "WHERE stage = 'apply' AND state = 'running'"
         ).fetchall()
         recovered = 0
         for row in rows:
-            tenant_id = TenantId(str(row["tenant_id"] if hasattr(row, "keys") else row[0]))
-            job_id = canonical_job_id(str(row["job_id"] if hasattr(row, "keys") else row[1]))
+            tenant_id = TenantId(
+                str(row["tenant_id"] if hasattr(row, "keys") else row[0])
+            )
+            job_id = canonical_job_id(
+                str(row["job_id"] if hasattr(row, "keys") else row[1])
+            )
             posting_url = _posting_url_for_job_id(
                 conn,
                 tenant_id=tenant_id,
@@ -1477,7 +1442,11 @@ def recover_ambiguous_running_apply(console: Console | None = None) -> int:
                         "apply",
                         "pending",
                         tenant_id=tenant_id,
-                        next_action=(f"jobctrl apply --url {posting_url}" if posting_url else None),
+                        next_action=(
+                            f"jobctrl apply --url {posting_url}"
+                            if posting_url
+                            else None
+                        ),
                         validate_transition=False,
                     )
                 recovered += 1
@@ -1535,7 +1504,8 @@ def _workflow_terminal_or_gone(
         return True
     try:
         row = conn.execute(
-            "SELECT status FROM workflow_run_projections WHERE tenant_id = ? AND workflow_id = ? LIMIT 1",
+            "SELECT status FROM workflow_run_projections "
+            "WHERE tenant_id = ? AND workflow_id = ? LIMIT 1",
             (str(tenant_id), workflow_id),
         ).fetchone()
     except Exception:  # noqa: BLE001
@@ -1693,8 +1663,12 @@ def reset_failed() -> int:
     ).fetchall()
     count = 0
     for row in rows:
-        tenant_id = TenantId(str(row["tenant_id"] if hasattr(row, "keys") else row[0]))
-        job_id = canonical_job_id(str(row["job_id"] if hasattr(row, "keys") else row[1]))
+        tenant_id = TenantId(
+            str(row["tenant_id"] if hasattr(row, "keys") else row[0])
+        )
+        job_id = canonical_job_id(
+            str(row["job_id"] if hasattr(row, "keys") else row[1])
+        )
         posting_url = _posting_url_for_job_id(
             conn,
             tenant_id=tenant_id,
@@ -1729,7 +1703,11 @@ def reset_failed() -> int:
                 attempt_count=0,
                 error_code=None,
                 error_message=None,
-                next_action=(f"jobctrl apply --url {posting_url}" if posting_url else None),
+                next_action=(
+                    f"jobctrl apply --url {posting_url}"
+                    if posting_url
+                    else None
+                ),
                 validate_transition=False,
             )
             count += 1
@@ -1783,7 +1761,11 @@ def _load_job_for_prompt(
           AND {_NOT_CLOSED_ACTIVE_STATE}
         LIMIT 1
         """,
-        (str(tenant_id), str(canonical_job_id(str(job_id))), min_score),
+        (
+            str(tenant_id),
+            str(canonical_job_id(str(job_id))),
+            min_score,
+        ),
     ).fetchone()
     return _row_to_job_dict(row) if row is not None else None
 

--- a/workers/automation/src/jobctrl/domain/apply/use_cases.py
+++ b/workers/automation/src/jobctrl/domain/apply/use_cases.py
@@ -53,7 +53,7 @@ from jobctrl.domain.events import (
     create_apply_run_event_recorded,
     create_apply_run_started,
 )
-from jobctrl.domain.identifiers import JobId
+from jobctrl.domain.identifiers import JobId, canonical_job_id
 from jobctrl.domain.ports.apply import (
     ApplyRunRepository,
     AutonomousAgentPort,
@@ -172,6 +172,8 @@ class SubmitApplicationUseCase:
         launcher loads once per process. ``worker_id`` / ``cdp_port``
         identify the browser slot.
         """
+        job_id = canonical_job_id(str(job.get("job_id") or ""))
+
         # 1. Eligibility check — pure data inspection, never raises
         attempt_count = int(job.get("apply_attempts") or 0)
         eligibility = self._eligibility.check(job=job, attempts=attempt_count)
@@ -184,7 +186,7 @@ class SubmitApplicationUseCase:
             return SubmitApplicationOutcome(
                 apply_run=_skipped_aggregate(
                     tenant_id=tenant_id,
-                    job_id=JobId(str(job.get("url") or "")),
+                    job_id=job_id,
                     run_id=run_id or new_apply_run_id(),
                     reason=eligibility.reason,
                     started_at=_utc_now(),
@@ -218,7 +220,7 @@ class SubmitApplicationUseCase:
             started_at = _utc_now()
             apply_run = _blocked_aggregate(
                 tenant_id=tenant_id,
-                job_id=JobId(str(job.get("url") or "")),
+                job_id=job_id,
                 run_id=run_id,
                 reason=reason,
                 blocked_url=apply_target_url,
@@ -241,7 +243,6 @@ class SubmitApplicationUseCase:
 
         # 3. Construct the aggregate in the starting state
         run_id = run_id or new_apply_run_id()
-        job_id = JobId(str(job.get("url") or ""))
         apply_run = ApplyRun.start(
             tenant_id=tenant_id,
             run_id=run_id,

--- a/workers/automation/src/jobctrl/state.py
+++ b/workers/automation/src/jobctrl/state.py
@@ -824,30 +824,34 @@ def record_job_event(
 
 def record_job_artifact(
     conn,
-    job_url: str,
+    job_id: JobId,
     stage: str,
     artifact_type: str,
     path: str | Path,
     *,
+    tenant_id: TenantId = LOCAL_TENANT,
     status: str = "active",
     created_at: str | None = None,
     metadata: dict[str, Any] | None = None,
 ) -> None:
     """Record or update one artifact with provenance."""
+    stable_job_id = canonical_job_id(str(job_id))
     path_str = str(path)
     conn.execute(
         """
         INSERT INTO job_artifacts (
-            job_url, stage, artifact_type, status, path, created_at, size_bytes, metadata_json
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-        ON CONFLICT(job_url, stage, artifact_type, path) DO UPDATE SET
+            tenant_id, job_id, stage, artifact_type, status, path,
+            created_at, size_bytes, metadata_json
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(tenant_id, job_id, stage, artifact_type, path) DO UPDATE SET
             status = excluded.status,
             created_at = excluded.created_at,
             size_bytes = excluded.size_bytes,
             metadata_json = excluded.metadata_json
         """,
         (
-            job_url,
+            str(tenant_id),
+            str(stable_job_id),
             stage,
             artifact_type,
             status,

--- a/workers/automation/tests/test_apply_use_cases.py
+++ b/workers/automation/tests/test_apply_use_cases.py
@@ -194,6 +194,7 @@ def _build_use_case(repo, *, agent_result=None, publisher=None) -> SubmitApplica
 
 def _ready_job():
     return {
+        "job_id": "90000000-0000-4000-8000-000000000041",
         "url": "https://example.com/job",
         "application_url": "https://example.com/apply",
         "tailored_resume_path": "/tmp/resume.txt",

--- a/workers/automation/tests/test_exact_v7_apply_acquire_job_identity.py
+++ b/workers/automation/tests/test_exact_v7_apply_acquire_job_identity.py
@@ -718,6 +718,132 @@ def test_dry_run_completion_binds_to_exact_v7_job(
     assert payload["application_url"] == f"{SHARED_URL}/apply"
 
 
+def test_late_apply_completion_does_not_overwrite_cancellation(
+    conn: sqlite3.Connection,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _insert_ready_job(conn, LOCAL_TENANT, LOCAL_JOB_ID)
+    conn.execute(
+        """
+        INSERT INTO job_stage_states (
+            tenant_id, job_id, stage, state, attempt_count, updated_at
+        ) VALUES (?, ?, 'apply', 'canceled', 1, ?)
+        """,
+        (LOCAL_TENANT, LOCAL_JOB_ID, TIMESTAMP),
+    )
+    conn.execute(
+        """
+        INSERT INTO job_events (
+            tenant_id, job_id, identity_version, stage, event_type,
+            occurred_at, payload_json
+        ) VALUES (?, ?, 1, 'apply', 'StageCanceled', ?, ?)
+        """,
+        (
+            LOCAL_TENANT,
+            LOCAL_JOB_ID,
+            TIMESTAMP,
+            json.dumps({"run_id": "apply-run-canceled"}),
+        ),
+    )
+    conn.commit()
+    monkeypatch.setattr("jobctrl.apply.launcher.get_connection", lambda: conn)
+
+    mark_result(
+        JobId(LOCAL_JOB_ID),
+        "applied",
+        run_ctx={"run_id": "apply-run-canceled", "tenant_id": LOCAL_TENANT},
+        tenant_id=TenantId(LOCAL_TENANT),
+    )
+
+    state = conn.execute(
+        """
+        SELECT state FROM job_stage_states
+        WHERE tenant_id = ? AND job_id = ? AND stage = 'apply'
+        """,
+        (LOCAL_TENANT, LOCAL_JOB_ID),
+    ).fetchone()
+    assert state is not None
+    assert state["state"] == "canceled"
+    assert conn.execute(
+        """
+        SELECT COUNT(*) FROM job_events
+        WHERE tenant_id = ? AND job_id = ?
+          AND event_type = 'ApplicationSubmitted'
+        """,
+        (LOCAL_TENANT, LOCAL_JOB_ID),
+    ).fetchone()[0] == 0
+
+
+def test_matching_terminal_event_reconciles_running_state_without_duplication(
+    conn: sqlite3.Connection,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _insert_ready_job(conn, LOCAL_TENANT, LOCAL_JOB_ID)
+    conn.execute(
+        """
+        INSERT INTO job_stage_states (
+            tenant_id, job_id, stage, state, attempt_count, updated_at
+        ) VALUES (?, ?, 'apply', 'running', 1, ?)
+        """,
+        (LOCAL_TENANT, LOCAL_JOB_ID, TIMESTAMP),
+    )
+    conn.execute(
+        """
+        INSERT INTO job_events (
+            tenant_id, job_id, identity_version, stage, event_type,
+            occurred_at, payload_json
+        ) VALUES (?, ?, 1, 'apply', 'DryRunCompleted', ?, ?)
+        """,
+        (
+            LOCAL_TENANT,
+            LOCAL_JOB_ID,
+            TIMESTAMP,
+            json.dumps(
+                {
+                    "run_id": "dry-run-reconcile",
+                    "result": "dry_run_complete",
+                    "dry_run": True,
+                    "materials_generation": 1,
+                    "profile_version": 3,
+                    "application_url": f"{SHARED_URL}/apply",
+                }
+            ),
+        ),
+    )
+    conn.commit()
+    monkeypatch.setattr("jobctrl.apply.launcher.get_connection", lambda: conn)
+
+    mark_result(
+        JobId(LOCAL_JOB_ID),
+        "dry_run",
+        run_ctx={
+            "run_id": "dry-run-reconcile",
+            "tenant_id": LOCAL_TENANT,
+            "materials_generation": 1,
+            "profile_version": 3,
+            "application_url": f"{SHARED_URL}/apply",
+        },
+        tenant_id=TenantId(LOCAL_TENANT),
+    )
+
+    state = conn.execute(
+        """
+        SELECT state FROM job_stage_states
+        WHERE tenant_id = ? AND job_id = ? AND stage = 'apply'
+        """,
+        (LOCAL_TENANT, LOCAL_JOB_ID),
+    ).fetchone()
+    assert state["state"] == "skipped"
+    assert conn.execute(
+        """
+        SELECT COUNT(*) FROM job_events
+        WHERE tenant_id = ? AND job_id = ?
+          AND event_type = 'DryRunCompleted'
+        """,
+        (LOCAL_TENANT, LOCAL_JOB_ID),
+    ).fetchone()[0] == 1
+
+
 def _record_submitted_application(
     conn: sqlite3.Connection,
     tenant_id: str,


### PR DESCRIPTION
## Summary

- persist Apply aggregates, terminal results, events, stage state, and artifacts by exact tenant and canonical JobId
- resolve posting URLs once at CLI and targeted-claim boundaries while retaining URLs only for navigation and human-facing retry commands
- make cancellation idempotent, preserve already-terminal Apply results, and emit at most one cancellation event
- persist manual applied/skipped results only in canonical stage state and events
- prevent duplicate terminal events when the saga repository and launcher finalize the same run

## Validation

- focused exact-v7 Apply and cancellation regressions passed
- cumulative TypeScript Step 1 matrix: 133 passed
- focused Python Apply/repeat-prevention tests passed
- Ruff and `git diff --check` passed
- independent Step 1 review: PASS, 0 Blocker / 0 High

## Stack

Ready-for-review child of #633 in GitHub Stack #632.

