### PR TITLE
refactor(projections): rebuild v7 views by job id

### DIFF
--- a/apps/api/src/projections.ts
+++ b/apps/api/src/projections.ts
@@ -2479,9 +2479,21 @@ function rebuildJobProjections(db: SqliteDatabase, tenantId: string, jobId: stri
   const compensationProjection = buildExactV7CompensationProjection(jobId, nullableString(job.salary));
 
   const artifacts = collectArtifacts(db, tenantId, jobId, materials);
-  const resume = preferredArtifactSource(artifacts, ["tailored_resume"], materials.generation);
-  const coverLetter = preferredArtifactSource(artifacts, ["cover_letter"], materials.generation);
-  const resumePdf = preferredArtifactSource(artifacts, ["resume_pdf"], materials.generation);
+  const resume = preferredArtifactSource(
+    artifacts,
+    ["tailored_resume", "tailored_resume_txt"],
+    materials.generation,
+  );
+  const coverLetter = preferredArtifactSource(
+    artifacts,
+    ["cover_letter", "cover_letter_txt"],
+    materials.generation,
+  );
+  const resumePdf = preferredArtifactSource(
+    artifacts,
+    ["resume_pdf", "tailored_resume_pdf"],
+    materials.generation,
+  );
   const coverLetterPdf = preferredArtifactSource(artifacts, ["cover_letter_pdf"], materials.generation);
   const hasResume = Boolean(resume);
   const hasCoverLetter = Boolean(coverLetter);

--- a/apps/api/src/projections.ts
+++ b/apps/api/src/projections.ts
@@ -34,7 +34,6 @@ import { getPostedCompensationFact } from "./posted-compensation-facts.js";
 
 const STAGE_ORDER: readonly string[] = STAGES;
 const CLOSED_ACTIVE_STATES = ["closed", "expired", "removed", "location_incompatible"] as const;
-const SOURCE_BOARD_NAMES = new Set(["greenhouse", "linkedin", "talent.com"]);
 const SOURCE_QUALITY_EVENT_TYPES = new Set([
   "DiscoveryRunStarted",
   "DiscoveryRunCompleted",
@@ -711,6 +710,9 @@ export function refreshProjections(db: SqliteDatabase, tenantId = "local"): void
     }
   }
   for (const jobId of staleDeletedProjectionJobs(db, tenantId)) {
+    dirtyJobs.add(jobId);
+  }
+  for (const jobId of staleArtifactProjectionJobs(db, tenantId)) {
     dirtyJobs.add(jobId);
   }
   for (const jobId of staleArtifactMetadataProjectionJobs(db, tenantId)) {
@@ -2238,6 +2240,44 @@ function staleDeletedProjectionJobs(db: SqliteDatabase, tenantId: string): strin
   return rows.map((row) => row.job_id).filter(Boolean);
 }
 
+function staleArtifactProjectionJobs(db: SqliteDatabase, tenantId: string): string[] {
+  const rows = allRows<{ job_id: string }>(
+    db,
+    `SELECT DISTINCT p.job_id
+       FROM artifact_list_projections p
+      WHERE p.tenant_id = ?
+        AND NOT EXISTS (
+          SELECT 1
+            FROM job_materials_artifacts a
+           WHERE a.tenant_id = p.tenant_id
+             AND a.job_id = p.job_id
+             AND COALESCE(NULLIF(a.artifact_id, ''), a.artifact_type || ':' || a.path) = p.artifact_id
+             AND COALESCE(NULLIF(a.artifact_type, ''), 'artifact') = p.artifact_type
+             AND a.path = p.local_path
+        )
+        AND NOT EXISTS (
+          SELECT 1
+            FROM job_artifacts a
+           WHERE a.tenant_id = p.tenant_id
+             AND a.job_id = p.job_id
+             AND CAST(a.artifact_id AS TEXT) = p.artifact_id
+             AND COALESCE(NULLIF(a.artifact_type, ''), 'artifact') = p.artifact_type
+             AND a.path = p.local_path
+             AND NOT EXISTS (
+               SELECT 1
+                 FROM job_materials_artifacts m
+                WHERE m.tenant_id = a.tenant_id
+                  AND m.job_id = a.job_id
+                  AND COALESCE(NULLIF(m.artifact_type, ''), 'artifact') =
+                      COALESCE(NULLIF(a.artifact_type, ''), 'artifact')
+                  AND m.path = a.path
+             )
+        )`,
+    [tenantId],
+  );
+  return rows.map((row) => row.job_id).filter(Boolean);
+}
+
 function staleArtifactMetadataProjectionJobs(db: SqliteDatabase, tenantId: string): string[] {
   const rows = allRows<{ job_id: string }>(
     db,
@@ -2426,9 +2466,8 @@ function rebuildJobProjections(db: SqliteDatabase, tenantId: string, jobId: stri
 
   const title = stringField(job.title) || "Untitled";
   const site = stringField(job.site);
-  const jobUrl = stringField(job.url);
   const applicationUrl = enrichment.applicationUrl ?? nullableString(job.application_url);
-  const employer = stringField(job.company) || companyName(site, applicationUrl ?? jobUrl);
+  const employer = stringField(job.company).trim() || "Unknown company";
 
   const firstActionable =
     stages.find((s) => !["succeeded", "skipped"].includes(s.state)) ?? stages[stages.length - 1];
@@ -4690,44 +4729,6 @@ function hasApplicationOutcomeKind(
     [tenantId, jobId, kind],
   );
   return Number(row?.c ?? 0) > 0;
-}
-
-function companyName(site: string, postingUrl: string): string {
-  const inferred = inferredCompanyFromUrl(postingUrl);
-  if (inferred) return inferred;
-  if (!site || SOURCE_BOARD_NAMES.has(site.toLowerCase())) return "Unknown company";
-  return site;
-}
-
-function inferredCompanyFromUrl(rawUrl: string): string {
-  if (!rawUrl) return "";
-  try {
-    const parsed = new URL(rawUrl);
-    const segments = parsed.pathname.split("/").filter(Boolean);
-    if (parsed.hostname.endsWith("greenhouse.io") && segments[0]) {
-      return titleFromSlug(segments[0]);
-    }
-    if (parsed.hostname === "jobs.lever.co" && segments[0]) {
-      return titleFromSlug(segments[0]);
-    }
-    if (parsed.hostname === "jobs.ashbyhq.com" && segments[0]) {
-      return titleFromSlug(segments[0]);
-    }
-  } catch {
-    return "";
-  }
-  return "";
-}
-
-function titleFromSlug(value: string): string {
-  const known: Record<string, string> = { gitlab: "GitLab" };
-  const lower = value.toLowerCase();
-  if (known[lower]) return known[lower]!;
-  return value
-    .split(/[-_]/)
-    .filter(Boolean)
-    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
-    .join(" ");
 }
 
 // Suppress unused import warning for SqliteValue (re-exported for consumers).

--- a/apps/api/src/projections.ts
+++ b/apps/api/src/projections.ts
@@ -3123,6 +3123,10 @@ function isDefaultVisibleArtifact(artifact: Pick<ArtifactRow, "status">): boolea
   return String(artifact.status ?? "").toLowerCase() !== "suppressed";
 }
 
+function isAvailableMaterialArtifact(artifact: Pick<ArtifactRow, "status">): boolean {
+  return ["active", "approved"].includes(String(artifact.status ?? "").toLowerCase());
+}
+
 function preferredArtifactSource(
   artifacts: ArtifactRow[],
   artifactTypes: string[],
@@ -3130,7 +3134,7 @@ function preferredArtifactSource(
 ): ArtifactRow | undefined {
   const typeSet = new Set(artifactTypes);
   return artifacts
-    .filter((artifact) => typeSet.has(artifact.artifactType) && isDefaultVisibleArtifact(artifact))
+    .filter((artifact) => typeSet.has(artifact.artifactType) && isAvailableMaterialArtifact(artifact))
     .sort((left, right) => {
       const leftPreferred = left.generation === preferredGeneration ? 1 : 0;
       const rightPreferred = right.generation === preferredGeneration ? 1 : 0;

--- a/apps/api/src/projections.ts
+++ b/apps/api/src/projections.ts
@@ -156,250 +156,42 @@ const DEPENDENCY_BLOCKER_MESSAGES: Record<string, Array<{ downstream: string; me
   ],
 };
 
-interface BackfillOpts {
-  jobUrl: string;
-  stage: string;
-  attemptCount?: number;
-  finishedAt?: string | null;
-  errorCode?: string | null;
-  errorMessage?: string | null;
-}
-
-/**
- * Idempotently backfill ``job_stage_states`` from legacy ``jobs`` columns
- * for any job that has no explicit stage rows.
- *
- * Mirrors ``database._backfill_legacy_stage_states`` in Python.  Both
- * paths use ``INSERT OR IGNORE``, so running both is safe.  Per the
- * no-strangler directive, the projection refreshers MUST NOT carry a
- * "derive stage state from legacy columns" compat shim — the canonical
- * source has to be ``job_stage_states``.  This backfill makes that
- * possible for legacy databases that pre-date the post-DDD pipeline.
- */
-function backfillLegacyStageStates(db: SqliteDatabase): void {
-  if (!tableExists(db, "jobs") || !tableExists(db, "job_stage_states")) return;
-  const legacyJobs = allRows<{
-    url: string;
-    discovered_at: string | null;
-    full_description: string | null;
-    detail_scraped_at: string | null;
-    detail_error: string | null;
-    fit_score: number | null;
-    tailored_resume_path: string | null;
-    tailor_attempts: number | null;
-    cover_letter_path: string | null;
-    cover_attempts: number | null;
-    applied_at: string | null;
-    apply_status: string | null;
-    apply_error: string | null;
-  }>(
-    db,
-    `SELECT j.url, j.discovered_at, j.full_description, j.detail_scraped_at,
-            j.detail_error, j.fit_score,
-            j.tailored_resume_path, j.tailor_attempts,
-            j.cover_letter_path, j.cover_attempts,
-            j.applied_at, j.apply_status, j.apply_error
-     FROM jobs j
-     LEFT JOIN job_stage_states jss ON jss.job_url = j.url
-     GROUP BY j.url
-     HAVING COUNT(jss.stage) = 0`,
-  );
-  if (legacyJobs.length === 0) return;
-
-  const now = new Date().toISOString();
-  const stageMaxAttempts: Record<string, number> = {
-    discover: 1,
-    enrich: 3,
-    score: 3,
-    tailor: 5,
-    cover: 5,
-    apply: 3,
-  };
-  // Column-aware INSERT: ``database.py::ensure_state_tables`` is the
-  // canonical schema (includes ``metadata_json`` + ``version``), but
-  // tests construct the table by hand and may omit those columns.  Read
-  // the live PRAGMA, build the INSERT around what's actually there.
-  const stageColumns = new Set(
-    allRows<{ name: string }>(db, "PRAGMA table_info(job_stage_states)").map((r) => r.name),
-  );
-  const allColumnSpecs: Array<[string, (state: string, opts: BackfillOpts) => SqliteValue]> = [
-    ["job_url", (_s, o) => o.jobUrl],
-    ["stage", (_s, o) => o.stage],
-    ["state", (s) => s],
-    ["attempt_count", (_s, o) => o.attemptCount ?? 0],
-    ["max_attempts", (_s, o) => stageMaxAttempts[o.stage] ?? null],
-    ["started_at", () => null],
-    ["updated_at", () => now],
-    ["finished_at", (_s, o) => o.finishedAt ?? null],
-    ["duration_ms", () => null],
-    ["error_code", (_s, o) => o.errorCode ?? null],
-    ["error_message", (_s, o) => o.errorMessage ?? null],
-    ["retryable", (s) => (s === "blocked" ? 0 : 1)],
-    ["blocked_by_json", () => null],
-    ["next_action", () => null],
-    ["metadata_json", () => null],
-    ["version", () => 0],
-  ];
-  const presentColumns = allColumnSpecs.filter(([col]) => stageColumns.has(col));
-  if (presentColumns.length === 0) return;
-  const insertSql = `INSERT OR IGNORE INTO job_stage_states (${presentColumns
-    .map(([col]) => col)
-    .join(", ")}) VALUES (${presentColumns.map(() => "?").join(", ")})`;
-  const insert = db.prepare(insertSql);
-  const insertStage = (
-    jobUrl: string,
-    stage: string,
-    state: string,
-    opts: Omit<BackfillOpts, "jobUrl" | "stage"> = {},
-  ): void => {
-    const fullOpts: BackfillOpts = { ...opts, jobUrl, stage };
-    const values = presentColumns.map(([, fn]) => fn(state, fullOpts));
-    insert.run(...values);
-  };
-
-  for (const row of legacyJobs) {
-    if (!row.url) continue;
-    insertStage(row.url, "discover", "succeeded", {
-      attemptCount: 1,
-      finishedAt: row.discovered_at ?? now,
-    });
-
-    const hasEnrichment = Boolean(row.full_description) || Boolean(row.detail_scraped_at);
-    let enrichSucceeded = false;
-    if (row.detail_error && !hasEnrichment) {
-      insertStage(row.url, "enrich", "failed", {
-        errorCode: "LEGACY_DETAIL_ERROR",
-        errorMessage: String(row.detail_error),
-      });
-    } else if (hasEnrichment) {
-      insertStage(row.url, "enrich", "succeeded", { finishedAt: row.detail_scraped_at ?? now });
-      enrichSucceeded = true;
-    } else {
-      insertStage(row.url, "enrich", "pending");
-    }
-
-    const hasScore = row.fit_score !== null && row.fit_score !== undefined;
-    let scoreSucceeded = false;
-    if (hasScore) {
-      insertStage(row.url, "score", "succeeded", { finishedAt: now });
-      scoreSucceeded = true;
-    } else if (!enrichSucceeded) {
-      insertStage(row.url, "score", "blocked", {
-        errorCode: "BLOCKED",
-        errorMessage: "Enrichment has not completed.",
-      });
-    } else {
-      insertStage(row.url, "score", "pending");
-    }
-
-    const hasTailor = Boolean(row.tailored_resume_path);
-    const tailorAttempts = Number(row.tailor_attempts ?? 0);
-    let tailorSucceeded = false;
-    if (hasTailor) {
-      insertStage(row.url, "tailor", "succeeded", {
-        attemptCount: tailorAttempts,
-        finishedAt: now,
-      });
-      tailorSucceeded = true;
-    } else if (!scoreSucceeded) {
-      insertStage(row.url, "tailor", "blocked", {
-        errorCode: "BLOCKED",
-        errorMessage: "score has not completed.",
-      });
-    } else if (tailorAttempts >= (stageMaxAttempts.tailor ?? 5)) {
-      insertStage(row.url, "tailor", "exhausted", {
-        attemptCount: tailorAttempts,
-        errorCode: "EXHAUSTED",
-        errorMessage: "tailor attempts exhausted.",
-      });
-    } else {
-      insertStage(row.url, "tailor", "pending", { attemptCount: tailorAttempts });
-    }
-
-    const hasCover = Boolean(row.cover_letter_path);
-    const coverAttempts = Number(row.cover_attempts ?? 0);
-    if (hasCover) {
-      insertStage(row.url, "cover", "succeeded", { attemptCount: coverAttempts, finishedAt: now });
-    } else if (!tailorSucceeded) {
-      insertStage(row.url, "cover", "blocked", {
-        errorCode: "BLOCKED",
-        errorMessage: "tailor has not completed.",
-      });
-    } else if (coverAttempts >= (stageMaxAttempts.cover ?? 5)) {
-      insertStage(row.url, "cover", "exhausted", {
-        attemptCount: coverAttempts,
-        errorCode: "EXHAUSTED",
-        errorMessage: "cover attempts exhausted.",
-      });
-    } else {
-      insertStage(row.url, "cover", "pending", { attemptCount: coverAttempts });
-    }
-
-    const applyStatusLower = String(row.apply_status ?? "").toLowerCase();
-    if (row.applied_at || applyStatusLower === "applied") {
-      insertStage(row.url, "apply", "succeeded", { finishedAt: row.applied_at ?? now });
-    } else if (applyStatusLower === "in_progress") {
-      insertStage(row.url, "apply", "running");
-    } else if (row.apply_error) {
-      insertStage(row.url, "apply", "failed", {
-        errorCode: "LEGACY_APPLY_ERROR",
-        errorMessage: String(row.apply_error),
-      });
-    } else if (!tailorSucceeded) {
-      insertStage(row.url, "apply", "blocked", {
-        errorCode: "BLOCKED",
-        errorMessage: "Materials are not ready.",
-      });
-    } else {
-      insertStage(row.url, "apply", "pending");
-    }
-  }
-}
-
-function reconcileDependencyBlockers(db: SqliteDatabase): Set<string> {
+function reconcileDependencyBlockers(db: SqliteDatabase, tenantId: string): Set<string> {
   const repairedJobs = new Set<string>();
-  if (!tableExists(db, "job_stage_states")) return repairedJobs;
-
-  const columns = new Set(
-    allRows<{ name: string }>(db, "PRAGMA table_info(job_stage_states)").map((row) => row.name),
-  );
-  const assignments = [
-    "state = 'pending'",
-    columns.has("updated_at") ? "updated_at = ?" : null,
-    columns.has("error_code") ? "error_code = NULL" : null,
-    columns.has("error_message") ? "error_message = NULL" : null,
-    columns.has("retryable") ? "retryable = 1" : null,
-    columns.has("blocked_by_json") ? "blocked_by_json = NULL" : null,
-    columns.has("next_action") ? "next_action = NULL" : null,
-    columns.has("metadata_json") ? "metadata_json = NULL" : null,
-  ].filter((assignment): assignment is string => Boolean(assignment));
-  const updateSql = `UPDATE job_stage_states SET ${assignments.join(", ")} WHERE job_url = ? AND stage = ?`;
-  const update = db.prepare(updateSql);
+  const update = db.prepare(`
+    UPDATE job_stage_states
+       SET state = 'pending', updated_at = ?, error_code = NULL,
+           error_message = NULL, retryable = 1, blocked_by_json = NULL,
+           next_action = NULL, metadata_json = NULL
+     WHERE tenant_id = ? AND job_id = ? AND stage = ?
+  `);
   const now = new Date().toISOString();
 
   for (const [upstream, downstreams] of Object.entries(DEPENDENCY_BLOCKER_MESSAGES)) {
     for (const { downstream, messages } of downstreams) {
       const placeholders = messages.map(() => "?").join(", ");
-      const rows = allRows<{ job_url: string; stage: string }>(
+      const rows = allRows<{ job_id: string; stage: string }>(
         db,
-        `SELECT downstream.job_url, downstream.stage
+        `SELECT downstream.job_id, downstream.stage
            FROM job_stage_states AS downstream
-          WHERE downstream.stage = ?
+          WHERE downstream.tenant_id = ?
+            AND downstream.stage = ?
             AND downstream.state = 'blocked'
             AND downstream.error_code = 'BLOCKED'
             AND downstream.error_message IN (${placeholders})
             AND EXISTS (
               SELECT 1
                 FROM job_stage_states AS upstream
-               WHERE upstream.job_url = downstream.job_url
+               WHERE upstream.tenant_id = downstream.tenant_id
+                 AND upstream.job_id = downstream.job_id
                  AND upstream.stage = ?
                  AND upstream.state = 'succeeded'
             )`,
-        [downstream, ...messages, upstream],
+        [tenantId, downstream, ...messages, upstream],
       );
       for (const row of rows) {
-        update.run(...(columns.has("updated_at") ? [now] : []), row.job_url, row.stage);
-        repairedJobs.add(row.job_url);
+        update.run(now, tenantId, row.job_id, row.stage);
+        repairedJobs.add(row.job_id);
       }
     }
   }
@@ -407,46 +199,40 @@ function reconcileDependencyBlockers(db: SqliteDatabase): Set<string> {
   return repairedJobs;
 }
 
-function reconcileObsoleteCoverGenerationConflicts(db: SqliteDatabase): Set<string> {
+function reconcileObsoleteCoverGenerationConflicts(db: SqliteDatabase, tenantId: string): Set<string> {
   const repairedJobs = new Set<string>();
-  if (!tableExists(db, "job_stage_states") || !tableExists(db, "job_materials_artifacts")) {
-    return repairedJobs;
-  }
-
-  const columns = new Set(
-    allRows<{ name: string }>(db, "PRAGMA table_info(job_stage_states)").map((row) => row.name),
-  );
   const rows = allRows<{
-    job_url: string;
+    job_id: string;
     error_message: string | null;
     has_cover_letter: number | string | null;
   }>(
     db,
     `
-    SELECT s.job_url,
+    SELECT s.job_id,
            s.error_message,
            EXISTS (
              SELECT 1
                FROM job_materials_artifacts tr
                JOIN job_materials_artifacts pdf
-                 ON pdf.job_url = tr.job_url
+                 ON pdf.tenant_id = tr.tenant_id AND pdf.job_id = tr.job_id
                 AND pdf.generation = tr.generation
                 AND pdf.artifact_type = 'resume_pdf'
                 AND pdf.status = 'approved'
                 AND COALESCE(TRIM(pdf.path), '') != ''
                JOIN job_materials_artifacts cover
-                 ON cover.job_url = tr.job_url
+                 ON cover.tenant_id = tr.tenant_id AND cover.job_id = tr.job_id
                 AND cover.generation = tr.generation
                 AND cover.artifact_type = 'cover_letter'
                 AND cover.status = 'approved'
                 AND COALESCE(TRIM(cover.path), '') != ''
-              WHERE tr.job_url = s.job_url
+              WHERE tr.tenant_id = s.tenant_id AND tr.job_id = s.job_id
                 AND tr.artifact_type = 'tailored_resume'
                 AND tr.status = 'approved'
                 AND COALESCE(TRIM(tr.path), '') != ''
            ) AS has_cover_letter
       FROM job_stage_states s
-     WHERE s.stage = 'cover'
+     WHERE s.tenant_id = ?
+       AND s.stage = 'cover'
        AND s.state = 'failed'
        AND s.error_code = 'COVER_FAILED'
        AND s.error_message LIKE 'MaterialsSet generation conflict%'
@@ -455,35 +241,27 @@ function reconcileObsoleteCoverGenerationConflicts(db: SqliteDatabase): Set<stri
              SELECT 1
                FROM job_materials_artifacts tr
                JOIN job_materials_artifacts pdf
-                 ON pdf.job_url = tr.job_url
+                 ON pdf.tenant_id = tr.tenant_id AND pdf.job_id = tr.job_id
                 AND pdf.generation = tr.generation
                 AND pdf.artifact_type = 'resume_pdf'
                 AND pdf.status = 'approved'
                 AND COALESCE(TRIM(pdf.path), '') != ''
-              WHERE tr.job_url = s.job_url
+              WHERE tr.tenant_id = s.tenant_id AND tr.job_id = s.job_id
                 AND tr.artifact_type = 'tailored_resume'
                 AND tr.status = 'approved'
                 AND COALESCE(TRIM(tr.path), '') != ''
            )
     `,
+    [tenantId],
   );
   if (rows.length === 0) return repairedJobs;
 
-  const assignments = [
-    "state = ?",
-    columns.has("updated_at") ? "updated_at = ?" : null,
-    columns.has("finished_at") ? "finished_at = ?" : null,
-    columns.has("error_code") ? "error_code = NULL" : null,
-    columns.has("error_message") ? "error_message = NULL" : null,
-    columns.has("retryable") ? "retryable = ?" : null,
-    columns.has("blocked_by_json") ? "blocked_by_json = NULL" : null,
-    columns.has("next_action") ? "next_action = NULL" : null,
-    columns.has("metadata_json") ? "metadata_json = ?" : null,
-  ].filter((assignment): assignment is string => Boolean(assignment));
   const update = db.prepare(
     `UPDATE job_stage_states
-        SET ${assignments.join(", ")}
-      WHERE job_url = ?
+        SET state = ?, updated_at = ?, finished_at = ?, error_code = NULL,
+            error_message = NULL, retryable = ?, blocked_by_json = NULL,
+            next_action = NULL, metadata_json = ?
+      WHERE tenant_id = ? AND job_id = ?
         AND stage = 'cover'
         AND state = 'failed'
         AND error_code = 'COVER_FAILED'`,
@@ -492,426 +270,24 @@ function reconcileObsoleteCoverGenerationConflicts(db: SqliteDatabase): Set<stri
 
   for (const row of rows) {
     const targetState = Number(row.has_cover_letter ?? 0) > 0 ? "succeeded" : "pending";
-    const values: SqliteValue[] = [targetState];
-    if (columns.has("updated_at")) values.push(now);
-    if (columns.has("finished_at")) values.push(targetState === "succeeded" ? now : null);
-    if (columns.has("retryable")) values.push(targetState === "pending" ? 1 : 0);
-    if (columns.has("metadata_json")) {
-      values.push(
-        JSON.stringify({
-          repaired_at: now,
-          repair_reason: "obsolete_cover_generation_conflict",
-          target_state: targetState,
-          previous_error_message: row.error_message,
-        }),
-      );
-    }
-    update.run(...values, row.job_url);
-    repairedJobs.add(row.job_url);
+    update.run(
+      targetState,
+      now,
+      targetState === "succeeded" ? now : null,
+      targetState === "pending" ? 1 : 0,
+      JSON.stringify({
+        repaired_at: now,
+        repair_reason: "obsolete_cover_generation_conflict",
+        target_state: targetState,
+        previous_error_message: row.error_message,
+      }),
+      tenantId,
+      row.job_id,
+    );
+    repairedJobs.add(row.job_id);
   }
 
   return repairedJobs;
-}
-
-/** Idempotently create the projection tables. Mirrors the Python schema. */
-export function ensureProjectionTables(db: SqliteDatabase): boolean {
-  db.exec(`
-    CREATE TABLE IF NOT EXISTS event_watermarks (
-      projection_name     TEXT PRIMARY KEY,
-      last_event_id       INTEGER NOT NULL DEFAULT 0,
-      updated_at          TEXT NOT NULL
-    );
-    CREATE TABLE IF NOT EXISTS digest_state (
-      tenant_id              TEXT PRIMARY KEY DEFAULT 'local',
-      last_acknowledged_at   TEXT,
-      updated_at             TEXT NOT NULL
-    );
-    CREATE TABLE IF NOT EXISTS job_list_projections (
-      tenant_id              TEXT NOT NULL DEFAULT 'local',
-      job_id                 TEXT NOT NULL,
-      title                  TEXT NOT NULL DEFAULT '',
-      employer               TEXT NOT NULL DEFAULT '',
-      source                 TEXT NOT NULL DEFAULT '',
-      strategy               TEXT NOT NULL DEFAULT '',
-      location               TEXT NOT NULL DEFAULT '',
-      salary                 TEXT NOT NULL DEFAULT '',
-      application_url        TEXT,
-      discovered_at          TEXT,
-      description            TEXT NOT NULL DEFAULT '',
-      full_description       TEXT NOT NULL DEFAULT '',
-      fit_score              INTEGER,
-      fit_band               TEXT,
-      compensation_summary_json TEXT,
-      score_breakdown_json   TEXT,
-      score_keywords_json    TEXT NOT NULL DEFAULT '[]',
-      score_reasoning        TEXT NOT NULL DEFAULT '',
-      score_version          INTEGER,
-      scored_at              TEXT,
-      score_criteria_json    TEXT,
-      score_trace_json       TEXT,
-      score_correction_json  TEXT,
-      current_stage          TEXT NOT NULL DEFAULT 'discover',
-      current_substage       TEXT NOT NULL DEFAULT 'discover',
-      current_state          TEXT NOT NULL DEFAULT 'pending',
-      current_error_code     TEXT,
-      current_error_message  TEXT,
-      current_next_action    TEXT,
-      has_resume             INTEGER NOT NULL DEFAULT 0,
-      has_cover_letter       INTEGER NOT NULL DEFAULT 0,
-      has_pdf                INTEGER NOT NULL DEFAULT 0,
-      apply_status           TEXT,
-      applied_at             TEXT,
-      apply_mode             TEXT,
-      resume_template_id     TEXT,
-      resume_template_name   TEXT,
-      tailoring_policy_version INTEGER,
-      artifact_count         INTEGER NOT NULL DEFAULT 0,
-      deleted_at             TEXT,
-      last_updated_at        TEXT,
-      PRIMARY KEY (tenant_id, job_id)
-    );
-    CREATE TABLE IF NOT EXISTS dashboard_projections (
-      tenant_id              TEXT PRIMARY KEY,
-      total_jobs             INTEGER NOT NULL DEFAULT 0,
-      failures               INTEGER NOT NULL DEFAULT 0,
-      blocked                INTEGER NOT NULL DEFAULT 0,
-      ready                  INTEGER NOT NULL DEFAULT 0,
-      applied                INTEGER NOT NULL DEFAULT 0,
-      dry_runs               INTEGER NOT NULL DEFAULT 0,
-      funnel_json            TEXT NOT NULL DEFAULT '[]',
-      by_source_json         TEXT NOT NULL DEFAULT '[]',
-      score_distribution_json TEXT NOT NULL DEFAULT '[]',
-      outcome_conversion_json TEXT NOT NULL DEFAULT '{}',
-      generated_at           TEXT NOT NULL DEFAULT ''
-    );
-    CREATE TABLE IF NOT EXISTS job_detail_projections (
-      tenant_id              TEXT NOT NULL DEFAULT 'local',
-      job_id                 TEXT NOT NULL,
-      description_preview    TEXT NOT NULL DEFAULT '',
-      compensation_summary_json TEXT,
-      compensation_audit_json TEXT,
-      score_breakdown_json   TEXT,
-      score_keywords_json    TEXT NOT NULL DEFAULT '[]',
-      score_reasoning        TEXT NOT NULL DEFAULT '',
-      score_version          INTEGER,
-      scored_at              TEXT,
-      score_criteria_json    TEXT,
-      score_trace_json       TEXT,
-      score_correction_json  TEXT,
-      stages_json            TEXT NOT NULL DEFAULT '[]',
-      employer_analysis_json TEXT,
-      requirement_fit_report_json TEXT,
-      interview_prep_json    TEXT,
-      last_updated_at        TEXT,
-      PRIMARY KEY (tenant_id, job_id)
-    );
-    CREATE TABLE IF NOT EXISTS artifact_list_projections (
-      artifact_id            TEXT PRIMARY KEY,
-      tenant_id              TEXT NOT NULL DEFAULT 'local',
-      job_id                 TEXT NOT NULL,
-      job_title              TEXT NOT NULL DEFAULT '',
-      job_employer           TEXT NOT NULL DEFAULT '',
-      artifact_type          TEXT NOT NULL DEFAULT '',
-      status                 TEXT NOT NULL DEFAULT '',
-      local_path             TEXT NOT NULL DEFAULT '',
-      size_bytes             INTEGER,
-      created_at             TEXT,
-      generation             INTEGER,
-      metadata_json          TEXT,
-      layout_boxes_json      TEXT,
-      bullet_provenance_json TEXT,
-      coverage_audit_json    TEXT,
-      voice_pass_json        TEXT
-    );
-    CREATE TABLE IF NOT EXISTS evidence_usage_projections (
-      tenant_id              TEXT NOT NULL DEFAULT 'local',
-      projection_kind        TEXT NOT NULL CHECK(projection_kind IN ('entry', 'gap')),
-      projection_id          TEXT NOT NULL,
-      evidence_id            TEXT,
-      skill_id               TEXT,
-      requirement_id         TEXT,
-      title                  TEXT NOT NULL DEFAULT '',
-      payload_json           TEXT NOT NULL,
-      last_updated_at        TEXT NOT NULL DEFAULT '',
-      PRIMARY KEY (tenant_id, projection_kind, projection_id)
-    );
-    CREATE INDEX IF NOT EXISTS idx_evidence_usage_projection_evidence
-      ON evidence_usage_projections(tenant_id, evidence_id);
-    CREATE INDEX IF NOT EXISTS idx_evidence_usage_projection_skill
-      ON evidence_usage_projections(tenant_id, skill_id);
-    CREATE TABLE IF NOT EXISTS apply_run_projections (
-      run_id                 TEXT PRIMARY KEY,
-      tenant_id              TEXT NOT NULL DEFAULT 'local',
-      job_id                 TEXT NOT NULL,
-      job_title              TEXT NOT NULL DEFAULT '',
-      job_employer           TEXT NOT NULL DEFAULT '',
-      status                 TEXT NOT NULL DEFAULT '',
-      result                 TEXT,
-      dry_run                INTEGER NOT NULL DEFAULT 0,
-      worker_id              INTEGER,
-      model                  TEXT,
-      started_at             TEXT,
-      finished_at            TEXT,
-      duration_ms            INTEGER,
-      events_json            TEXT NOT NULL DEFAULT '[]'
-    );
-    CREATE TABLE IF NOT EXISTS workflow_run_projections (
-      workflow_id            TEXT PRIMARY KEY,
-      tenant_id              TEXT NOT NULL DEFAULT 'local',
-      workflow_type          TEXT NOT NULL DEFAULT '',
-      status                 TEXT NOT NULL DEFAULT 'in_progress',
-      input_summary_json     TEXT NOT NULL DEFAULT '{}',
-      error_code             TEXT,
-      error_message          TEXT,
-      retryable              INTEGER NOT NULL DEFAULT 0,
-      started_at             TEXT,
-      finished_at            TEXT,
-      duration_ms            INTEGER,
-      temporal_run_id        TEXT,
-      events_json            TEXT NOT NULL DEFAULT '[]'
-    );
-    CREATE TABLE IF NOT EXISTS pipeline_step_projections (
-      tenant_id              TEXT NOT NULL,
-      discover_workflow_id   TEXT NOT NULL,
-      discover_run_id        TEXT NOT NULL,
-      step_kind              TEXT NOT NULL CHECK (step_kind IN (
-        'source_planning', 'source_family', 'enrichment_pass',
-        'preparation_fanout', 'existing_backlog_sweep', 'pdf_render'
-      )),
-      item_key               TEXT NOT NULL,
-      state                  TEXT NOT NULL CHECK (state IN (
-        'queued', 'running', 'succeeded', 'failed'
-      )),
-      attempt                INTEGER NOT NULL CHECK (attempt >= 1),
-      queued_at              TEXT,
-      started_at             TEXT,
-      finished_at            TEXT,
-      duration_ms            INTEGER CHECK (duration_ms IS NULL OR duration_ms >= 0),
-      error_code             TEXT,
-      retryable              INTEGER NOT NULL DEFAULT 0 CHECK (retryable IN (0, 1)),
-      detail_code            TEXT,
-      detail_count           INTEGER CHECK (detail_count IS NULL OR detail_count >= 0),
-      last_event_id          INTEGER NOT NULL,
-      last_updated_at        TEXT NOT NULL,
-      PRIMARY KEY (
-        tenant_id, discover_workflow_id, discover_run_id, step_kind, item_key
-      )
-    );
-    CREATE INDEX IF NOT EXISTS idx_pipeline_step_projections_execution
-      ON pipeline_step_projections(
-        tenant_id, discover_workflow_id, discover_run_id, step_kind, state
-      );
-    CREATE INDEX IF NOT EXISTS idx_pipeline_step_projections_updated
-      ON pipeline_step_projections(tenant_id, last_updated_at DESC, last_event_id DESC);
-    CREATE TABLE IF NOT EXISTS source_quality_stats (
-      tenant_id                         TEXT NOT NULL DEFAULT 'local',
-      source_id                         TEXT NOT NULL,
-      window_start                      TEXT NOT NULL,
-      window_end                        TEXT NOT NULL,
-      run_count                         INTEGER NOT NULL DEFAULT 0,
-      failed_run_count                  INTEGER NOT NULL DEFAULT 0,
-      consecutive_failures              INTEGER NOT NULL DEFAULT 0,
-      observed_jobs                     INTEGER NOT NULL DEFAULT 0,
-      new_jobs                          INTEGER NOT NULL DEFAULT 0,
-      existing_jobs                     INTEGER NOT NULL DEFAULT 0,
-      duplicate_jobs                    INTEGER NOT NULL DEFAULT 0,
-      active_jobs                       INTEGER NOT NULL DEFAULT 0,
-      stale_jobs                        INTEGER NOT NULL DEFAULT 0,
-      detail_success_count              INTEGER NOT NULL DEFAULT 0,
-      detail_failure_count              INTEGER NOT NULL DEFAULT 0,
-      active_verification_rate          REAL,
-      duplicate_rate                    REAL,
-      full_description_success_rate     REAL,
-      apply_url_success_rate            REAL,
-      last_run_id                       TEXT,
-      last_error_class                  TEXT,
-      recommended_state                 TEXT NOT NULL DEFAULT 'normal',
-      updated_at                        TEXT NOT NULL DEFAULT '',
-      PRIMARY KEY (tenant_id, source_id, window_start, window_end)
-    );
-    CREATE TABLE IF NOT EXISTS operational_attempt_metrics (
-      metric_id               INTEGER PRIMARY KEY AUTOINCREMENT,
-      tenant_id               TEXT NOT NULL DEFAULT 'local',
-      occurred_at             TEXT NOT NULL,
-      stage                   TEXT NOT NULL,
-      source_id               TEXT,
-      source_kind             TEXT,
-      source_priority         TEXT,
-      source_role             TEXT,
-      adapter                 TEXT,
-      attempt_kind            TEXT NOT NULL,
-      outcome                 TEXT NOT NULL,
-      failure_category        TEXT,
-      is_operational_failure  INTEGER NOT NULL DEFAULT 0,
-      is_scrape_failure       INTEGER NOT NULL DEFAULT 0,
-      is_retryable            INTEGER NOT NULL DEFAULT 1,
-      run_id                  TEXT,
-      job_url                 TEXT,
-      duration_ms             INTEGER,
-      total_count             INTEGER,
-      new_count               INTEGER,
-      existing_count          INTEGER,
-      observed_count          INTEGER,
-      duplicate_count         INTEGER,
-      error_class             TEXT,
-      error_message           TEXT,
-      metadata_json           TEXT NOT NULL DEFAULT '{}'
-    );
-    CREATE INDEX IF NOT EXISTS idx_operational_attempt_metrics_stage_time
-      ON operational_attempt_metrics(tenant_id, stage, occurred_at DESC, metric_id DESC);
-    CREATE INDEX IF NOT EXISTS idx_operational_attempt_metrics_source_time
-      ON operational_attempt_metrics(tenant_id, source_id, occurred_at DESC, metric_id DESC);
-    CREATE TABLE IF NOT EXISTS contact_projections (
-      tenant_id          TEXT NOT NULL DEFAULT 'local',
-      contact_id         TEXT NOT NULL,
-      employer           TEXT,
-      job_id             TEXT,
-      role               TEXT NOT NULL DEFAULT 'other',
-      attribute_count    INTEGER NOT NULL DEFAULT 0,
-      confirmed_count    INTEGER NOT NULL DEFAULT 0,
-      source_kinds_json  TEXT NOT NULL DEFAULT '[]',
-      provenance_json    TEXT NOT NULL DEFAULT '[]',
-      created_at         TEXT,
-      updated_at         TEXT,
-      last_updated_at    TEXT,
-      PRIMARY KEY (tenant_id, contact_id)
-    );
-    CREATE INDEX IF NOT EXISTS idx_contact_projections_lookup
-      ON contact_projections(tenant_id, employer, job_id);
-    CREATE TABLE IF NOT EXISTS contact_research_task_projections (
-      tenant_id            TEXT NOT NULL DEFAULT 'local',
-      task_id              TEXT NOT NULL,
-      employer             TEXT,
-      job_id               TEXT,
-      status               TEXT NOT NULL DEFAULT 'queued',
-      candidate_count      INTEGER NOT NULL DEFAULT 0,
-      needs_review_count   INTEGER NOT NULL DEFAULT 0,
-      confirmed_count      INTEGER NOT NULL DEFAULT 0,
-      source_attempts_json TEXT NOT NULL DEFAULT '[]',
-      candidates_json      TEXT NOT NULL DEFAULT '[]',
-      started_at           TEXT,
-      updated_at           TEXT,
-      needs_review_at      TEXT,
-      completed_at         TEXT,
-      failed_at            TEXT,
-      error_class          TEXT,
-      last_updated_at      TEXT,
-      PRIMARY KEY (tenant_id, task_id)
-    );
-    CREATE INDEX IF NOT EXISTS idx_contact_research_task_projections_lookup
-      ON contact_research_task_projections(tenant_id, employer, job_id);
-    CREATE TABLE IF NOT EXISTS outreach_thread_projections (
-      tenant_id           TEXT NOT NULL DEFAULT 'local',
-      thread_id           TEXT NOT NULL,
-      contact_id          TEXT NOT NULL,
-      job_id              TEXT,
-      draft_count         INTEGER NOT NULL DEFAULT 0,
-      latest_generation   INTEGER NOT NULL DEFAULT 0,
-      has_approved_draft  INTEGER NOT NULL DEFAULT 0,
-      approved_draft_id   TEXT,
-      latest_status       TEXT,
-      drafts_json         TEXT NOT NULL DEFAULT '[]',
-      created_at          TEXT,
-      updated_at          TEXT,
-      last_updated_at     TEXT,
-      PRIMARY KEY (tenant_id, thread_id)
-    );
-    CREATE INDEX IF NOT EXISTS idx_outreach_thread_projections_lookup
-      ON outreach_thread_projections(tenant_id, contact_id, job_id);
-    CREATE TABLE IF NOT EXISTS due_follow_up_projections (
-      tenant_id           TEXT NOT NULL DEFAULT 'local',
-      thread_id           TEXT NOT NULL,
-      contact_id          TEXT NOT NULL,
-      job_id              TEXT,
-      due_at              TEXT,
-      basis               TEXT,
-      state               TEXT NOT NULL DEFAULT 'scheduled',
-      created_at          TEXT,
-      updated_at          TEXT,
-      last_updated_at     TEXT,
-      PRIMARY KEY (tenant_id, thread_id)
-    );
-    CREATE INDEX IF NOT EXISTS idx_due_follow_up_projections_due
-      ON due_follow_up_projections(tenant_id, due_at);
-  `);
-  let schemaChanged = false;
-  schemaChanged = ensureProjectionColumn(db, "job_list_projections", "score_breakdown_json", "TEXT") || schemaChanged;
-  schemaChanged = ensureProjectionColumn(db, "job_list_projections", "compensation_summary_json", "TEXT") || schemaChanged;
-  schemaChanged =
-    ensureProjectionColumn(db, "job_list_projections", "score_keywords_json", "TEXT NOT NULL DEFAULT '[]'") ||
-    schemaChanged;
-  schemaChanged = ensureProjectionColumn(db, "job_list_projections", "score_version", "INTEGER") || schemaChanged;
-  schemaChanged = ensureProjectionColumn(db, "job_list_projections", "scored_at", "TEXT") || schemaChanged;
-  schemaChanged = ensureProjectionColumn(db, "job_list_projections", "score_criteria_json", "TEXT") || schemaChanged;
-  schemaChanged = ensureProjectionColumn(db, "job_list_projections", "score_trace_json", "TEXT") || schemaChanged;
-  schemaChanged = ensureProjectionColumn(db, "job_list_projections", "score_correction_json", "TEXT") || schemaChanged;
-  schemaChanged =
-    ensureProjectionColumn(db, "job_list_projections", "current_substage", "TEXT NOT NULL DEFAULT 'discover'") ||
-    schemaChanged;
-  schemaChanged = ensureProjectionColumn(db, "job_list_projections", "fit_band", "TEXT") || schemaChanged;
-  schemaChanged = ensureProjectionColumn(db, "job_list_projections", "apply_mode", "TEXT") || schemaChanged;
-  schemaChanged = ensureProjectionColumn(db, "job_list_projections", "resume_template_id", "TEXT") || schemaChanged;
-  schemaChanged = ensureProjectionColumn(db, "job_list_projections", "resume_template_name", "TEXT") || schemaChanged;
-  schemaChanged = ensureProjectionColumn(db, "job_list_projections", "tailoring_policy_version", "INTEGER") || schemaChanged;
-  schemaChanged =
-    ensureProjectionColumn(db, "job_detail_projections", "score_breakdown_json", "TEXT") || schemaChanged;
-  schemaChanged = ensureProjectionColumn(db, "job_detail_projections", "compensation_summary_json", "TEXT") || schemaChanged;
-  schemaChanged = ensureProjectionColumn(db, "job_detail_projections", "compensation_audit_json", "TEXT") || schemaChanged;
-  schemaChanged =
-    ensureProjectionColumn(db, "job_detail_projections", "score_keywords_json", "TEXT NOT NULL DEFAULT '[]'") ||
-    schemaChanged;
-  schemaChanged = ensureProjectionColumn(db, "job_detail_projections", "score_version", "INTEGER") || schemaChanged;
-  schemaChanged = ensureProjectionColumn(db, "job_detail_projections", "scored_at", "TEXT") || schemaChanged;
-  schemaChanged = ensureProjectionColumn(db, "job_detail_projections", "score_criteria_json", "TEXT") || schemaChanged;
-  schemaChanged = ensureProjectionColumn(db, "job_detail_projections", "score_trace_json", "TEXT") || schemaChanged;
-  schemaChanged = ensureProjectionColumn(db, "job_detail_projections", "score_correction_json", "TEXT") || schemaChanged;
-  schemaChanged =
-    ensureProjectionColumn(db, "job_detail_projections", "employer_analysis_json", "TEXT") || schemaChanged;
-  schemaChanged =
-    ensureProjectionColumn(db, "job_detail_projections", "requirement_fit_report_json", "TEXT") || schemaChanged;
-  schemaChanged =
-    ensureProjectionColumn(db, "job_detail_projections", "interview_prep_json", "TEXT") || schemaChanged;
-  schemaChanged = ensureProjectionColumn(db, "artifact_list_projections", "metadata_json", "TEXT") || schemaChanged;
-  schemaChanged =
-    ensureProjectionColumn(db, "artifact_list_projections", "layout_boxes_json", "TEXT") || schemaChanged;
-  schemaChanged =
-    ensureProjectionColumn(db, "artifact_list_projections", "bullet_provenance_json", "TEXT") || schemaChanged;
-  schemaChanged =
-    ensureProjectionColumn(db, "artifact_list_projections", "coverage_audit_json", "TEXT") || schemaChanged;
-  schemaChanged =
-    ensureProjectionColumn(db, "artifact_list_projections", "voice_pass_json", "TEXT") || schemaChanged;
-  schemaChanged =
-    ensureProjectionColumn(db, "dashboard_projections", "outcome_conversion_json", "TEXT NOT NULL DEFAULT '{}'") ||
-    schemaChanged;
-  for (const [columnName, definition] of WORKFLOW_RUN_PROJECTION_COLUMNS) {
-    schemaChanged = ensureProjectionColumn(db, "workflow_run_projections", columnName, definition) || schemaChanged;
-  }
-  return schemaChanged;
-}
-
-function ensureProjectionColumn(
-  db: SqliteDatabase,
-  tableName: string,
-  columnName: string,
-  definition: string,
-): boolean {
-  const existingColumns = () =>
-    new Set(allRows<{ name: string }>(db, `PRAGMA table_info(${tableName})`).map((row) => row.name));
-  if (existingColumns().has(columnName)) {
-    return false;
-  }
-  try {
-    db.exec(`ALTER TABLE ${tableName} ADD COLUMN ${columnName} ${definition}`);
-  } catch (error) {
-    // The TS API and the Python worker both run this upgrade at startup against
-    // the same SQLite file; the loser of the check-then-ALTER race must treat
-    // "duplicate column" as an upgrade that already happened, not a failure.
-    if (existingColumns().has(columnName)) {
-      return true;
-    }
-    throw error;
-  }
-  return true;
 }
 
 /** Read the watermark; returns 0 when missing. */
@@ -948,7 +324,6 @@ function setWatermark(db: SqliteDatabase, projection: string, eventId: number): 
  * dirty; the confirm route calls this directly to keep the projection honest.
  */
 export function refreshContactResearchProjections(db: SqliteDatabase, tenantId = "local"): void {
-  ensureProjectionTables(db);
   rebuildContactResearchProjections(db, tenantId);
 }
 
@@ -959,7 +334,6 @@ export function refreshContactResearchProjections(db: SqliteDatabase, tenantId =
  * write returns (mirrors `refreshContactResearchProjections`).
  */
 export function refreshOutreachProjections(db: SqliteDatabase, tenantId = "local"): void {
-  ensureProjectionTables(db);
   rebuildOutreachProjections(db, tenantId);
   rebuildDueFollowUpProjections(db, tenantId);
 }
@@ -1245,31 +619,30 @@ function rebuildPipelineStepProjections(db: SqliteDatabase, tenantId: string): v
 }
 
 export function refreshProjections(db: SqliteDatabase, tenantId = "local"): void {
-  const projectionSchemaChanged = ensureProjectionTables(db);
-  backfillLegacyStageStates(db);
-  const repairedDependencyJobs = reconcileDependencyBlockers(db);
-  const repairedCoverConflictJobs = reconcileObsoleteCoverGenerationConflicts(db);
+  const repairedDependencyJobs = reconcileDependencyBlockers(db, tenantId);
+  const repairedCoverConflictJobs = reconcileObsoleteCoverGenerationConflicts(db, tenantId);
 
   const watermark = readWatermark(db, PROJECTION_WATERMARK_NAME);
 
   let dirtyJobs = new Set<string>([...repairedDependencyJobs, ...repairedCoverConflictJobs]);
   let sourceQualityDirty = false;
   let pipelineStepsDirty = false;
-  let evidenceUsageDirty = projectionSchemaChanged;
-  let contactsDirty = projectionSchemaChanged;
-  let contactResearchDirty = projectionSchemaChanged;
-  let outreachDirty = projectionSchemaChanged;
+  let evidenceUsageDirty = false;
+  let contactsDirty = false;
+  let contactResearchDirty = false;
+  let outreachDirty = false;
   let maxEventId = watermark;
-  if (tableExists(db, "job_events")) {
-    const rows = allRows<{ event_id: number; job_url: string | null; event_type: string }>(
+  {
+    const rows = allRows<{ event_id: number; tenant_id: string; job_id: string | null; event_type: string }>(
       db,
-      "SELECT event_id, job_url, event_type FROM job_events WHERE event_id > ? ORDER BY event_id ASC",
+      "SELECT event_id, tenant_id, job_id, event_type FROM job_events WHERE event_id > ? ORDER BY event_id ASC",
       [watermark],
     );
     for (const row of rows) {
       const eventId = Number(row.event_id);
       if (eventId > maxEventId) maxEventId = eventId;
-      if (row.job_url) dirtyJobs.add(String(row.job_url));
+      if (row.tenant_id !== tenantId) continue;
+      if (row.job_id) dirtyJobs.add(String(row.job_id));
       if (SOURCE_QUALITY_EVENT_TYPES.has(String(row.event_type))) {
         sourceQualityDirty = true;
       }
@@ -1318,41 +691,33 @@ export function refreshProjections(db: SqliteDatabase, tenantId = "local"): void
     [tenantId],
   );
   if (!rowCount || Number(rowCount.c) === 0) {
-    if (tableExists(db, "jobs")) {
-      const jobs = allRows<{ url: string }>(db, "SELECT url FROM jobs");
-      for (const job of jobs) {
-        if (job.url) dirtyJobs.add(job.url);
-      }
-    }
-  }
-  if (projectionSchemaChanged && tableExists(db, "jobs")) {
-    const jobs = allRows<{ url: string }>(db, "SELECT url FROM jobs");
+    const jobs = allRows<{ job_id: string }>(db, "SELECT job_id FROM jobs WHERE tenant_id = ?", [tenantId]);
     for (const job of jobs) {
-      if (job.url) dirtyJobs.add(job.url);
+      if (job.job_id) dirtyJobs.add(job.job_id);
     }
   }
-  if (tableExists(db, "jobs")) {
-    const missingProjectedJobs = allRows<{ url: string }>(
+  {
+    const missingProjectedJobs = allRows<{ job_id: string }>(
       db,
-      `SELECT j.url
+      `SELECT j.job_id
        FROM jobs j
        LEFT JOIN job_list_projections p
-         ON p.tenant_id = ? AND p.job_id = j.url
-       WHERE p.job_id IS NULL`,
+         ON p.tenant_id = j.tenant_id AND p.job_id = j.job_id
+       WHERE j.tenant_id = ? AND p.job_id IS NULL`,
       [tenantId],
     );
     for (const job of missingProjectedJobs) {
-      if (job.url) dirtyJobs.add(job.url);
+      if (job.job_id) dirtyJobs.add(job.job_id);
     }
   }
-  for (const jobUrl of staleDeletedProjectionJobs(db, tenantId)) {
-    dirtyJobs.add(jobUrl);
+  for (const jobId of staleDeletedProjectionJobs(db, tenantId)) {
+    dirtyJobs.add(jobId);
   }
-  for (const jobUrl of staleArtifactMetadataProjectionJobs(db, tenantId)) {
-    dirtyJobs.add(jobUrl);
+  for (const jobId of staleArtifactMetadataProjectionJobs(db, tenantId)) {
+    dirtyJobs.add(jobId);
   }
-  for (const jobUrl of staleStageProjectionJobs(db, tenantId)) {
-    dirtyJobs.add(jobUrl);
+  for (const jobId of staleStageProjectionJobs(db, tenantId)) {
+    dirtyJobs.add(jobId);
   }
 
   // L5 (round-1 review): nothing dirty AND no new events ⇒ skip the
@@ -1361,7 +726,7 @@ export function refreshProjections(db: SqliteDatabase, tenantId = "local"): void
     getRow<{ c: number }>(db, "SELECT COUNT(*) AS c FROM source_quality_stats WHERE tenant_id = ?", [
       tenantId,
     ])?.c ?? 0;
-  const sourceQualityHistory = sourceQualityDirty || hasSourceQualityHistory(db);
+  const sourceQualityHistory = sourceQualityDirty || hasSourceQualityHistory(db, tenantId);
 
   if (
     dirtyJobs.size === 0 &&
@@ -1394,8 +759,8 @@ export function refreshProjections(db: SqliteDatabase, tenantId = "local"): void
     rebuildDueFollowUpProjections(db, tenantId);
   }
 
-  for (const jobUrl of dirtyJobs) {
-    rebuildJobProjections(db, tenantId, jobUrl);
+  for (const jobId of dirtyJobs) {
+    rebuildJobProjections(db, tenantId, jobId);
   }
   if (dirtyJobs.size > 0) {
     // PR 4 of the Temporal stack: ``apply_run_projections`` is now
@@ -1425,7 +790,7 @@ interface MaterialsLatest {
   coverPdfPath: string | null;
 }
 
-function loadLatestMaterials(db: SqliteDatabase, jobUrl: string): MaterialsLatest {
+function loadLatestMaterials(db: SqliteDatabase, tenantId: string, jobId: string): MaterialsLatest {
   const empty: MaterialsLatest = {
     hasCanonicalHistory: false,
     generation: null,
@@ -1436,27 +801,24 @@ function loadLatestMaterials(db: SqliteDatabase, jobUrl: string): MaterialsLates
     resumePdfPath: null,
     coverPdfPath: null,
   };
-  if (!tableExists(db, "job_materials") || !tableExists(db, "job_materials_artifacts")) {
-    return empty;
-  }
   const hasCanonicalHistory = Boolean(
     getRow<{ c: number }>(
       db,
       `SELECT COUNT(*) AS c
          FROM job_materials_artifacts
-        WHERE job_url = ?
+        WHERE tenant_id = ? AND job_id = ?
           AND artifact_type IN ('tailored_resume', 'cover_letter', 'resume_pdf', 'cover_letter_pdf')`,
-      [jobUrl],
+      [tenantId, jobId],
     )?.c,
   );
   const generationRow = getRow<{ max_generation: number }>(
     db,
     `SELECT MAX(generation) AS max_generation
        FROM job_materials_artifacts
-      WHERE job_url = ?
+      WHERE tenant_id = ? AND job_id = ?
         AND status = 'approved'
         AND artifact_type IN ('tailored_resume', 'cover_letter', 'resume_pdf', 'cover_letter_pdf')`,
-    [jobUrl],
+    [tenantId, jobId],
   );
   const generation = generationRow ? generationRow.max_generation : null;
   if (generation === null || generation === undefined) {
@@ -1465,8 +827,8 @@ function loadLatestMaterials(db: SqliteDatabase, jobUrl: string): MaterialsLates
   const artifacts = allRows<{ artifact_type: string; path: string; created_at: string | null }>(
     db,
     `SELECT artifact_type, path, created_at FROM job_materials_artifacts
-     WHERE job_url = ? AND generation = ? AND status = 'approved'`,
-    [jobUrl, Number(generation)],
+     WHERE tenant_id = ? AND job_id = ? AND generation = ? AND status = 'approved'`,
+    [tenantId, jobId, Number(generation)],
   );
   const latest: MaterialsLatest = { ...empty, hasCanonicalHistory, generation: Number(generation) };
   for (const a of artifacts) {
@@ -1498,17 +860,11 @@ const EMPTY_MATERIAL_ANALYTICS: MaterialAnalytics = {
   tailoringPolicyVersion: null,
 };
 
-function loadMaterialAnalytics(db: SqliteDatabase, jobUrl: string): MaterialAnalytics {
-  if (!tableExists(db, "job_materials_artifacts") || !hasColumn(db, "job_materials_artifacts", "metadata_json")) {
-    return { ...EMPTY_MATERIAL_ANALYTICS };
-  }
-  const hasMaterialMetadata = tableExists(db, "job_materials") && hasColumn(db, "job_materials", "metadata_json");
-  const materialMetadataSelect = hasMaterialMetadata ? "m.metadata_json AS material_metadata_json" : "NULL AS material_metadata_json";
-  const materialMetadataJoin = hasMaterialMetadata
-    ? `LEFT JOIN job_materials m
-             ON m.job_url = a.job_url
-            AND m.generation = a.generation`
-    : "";
+function loadMaterialAnalytics(db: SqliteDatabase, tenantId: string, jobId: string): MaterialAnalytics {
+  const materialMetadataJoin = `LEFT JOIN job_materials m
+             ON m.tenant_id = a.tenant_id
+            AND m.job_id = a.job_id
+            AND m.generation = a.generation`;
   const row = getRow<{
     artifact_id: string | null;
     generation: number | null;
@@ -1516,10 +872,10 @@ function loadMaterialAnalytics(db: SqliteDatabase, jobUrl: string): MaterialAnal
     material_metadata_json: string | null;
   }>(
     db,
-    `SELECT a.artifact_id, a.generation, a.metadata_json, ${materialMetadataSelect}
+    `SELECT a.artifact_id, a.generation, a.metadata_json, m.metadata_json AS material_metadata_json
        FROM job_materials_artifacts a
        ${materialMetadataJoin}
-      WHERE a.job_url = ?
+      WHERE a.tenant_id = ? AND a.job_id = ?
         AND a.status = 'approved'
         AND a.artifact_type IN ('tailored_resume', 'tailored_resume_txt', 'resume_pdf')
       ORDER BY COALESCE(a.generation, -1) DESC,
@@ -1532,12 +888,12 @@ function loadMaterialAnalytics(db: SqliteDatabase, jobUrl: string): MaterialAnal
                a.created_at DESC,
                a.rowid DESC
       LIMIT 1`,
-    [jobUrl],
+    [tenantId, jobId],
   );
   const metadataJsons = [row?.metadata_json ?? null, row?.material_metadata_json ?? null];
   const current = mergeMaterialAnalytics(metadataJsons);
   if (materialAnalyticsComplete(current)) return current;
-  return mergeMaterialAnalytics([...metadataJsons, ...loadBaseMaterialMetadata(db, jobUrl, metadataJsons)]);
+  return mergeMaterialAnalytics([...metadataJsons, ...loadBaseMaterialMetadata(db, tenantId, jobId, metadataJsons)]);
 }
 
 function materialAnalyticsFromMetadata(metadataJson: string | null): MaterialAnalytics {
@@ -1566,18 +922,19 @@ function materialAnalyticsComplete(value: MaterialAnalytics): boolean {
   return value.resumeTemplateId !== null && value.resumeTemplateName !== null && value.tailoringPolicyVersion !== null;
 }
 
-function loadBaseMaterialMetadata(db: SqliteDatabase, jobUrl: string, metadataJsons: Array<string | null>): Array<string | null> {
+function loadBaseMaterialMetadata(
+  db: SqliteDatabase,
+  tenantId: string,
+  jobId: string,
+  metadataJsons: Array<string | null>,
+): Array<string | null> {
   const references = materialMetadataReferences(metadataJsons);
   const metadata: Array<string | null> = [];
-  if (
-    references.baseGeneration !== null &&
-    tableExists(db, "job_materials") &&
-    hasColumn(db, "job_materials", "metadata_json")
-  ) {
+  if (references.baseGeneration !== null) {
     const row = getRow<{ metadata_json: string | null }>(
       db,
-      "SELECT metadata_json FROM job_materials WHERE job_url = ? AND generation = ? LIMIT 1",
-      [jobUrl, references.baseGeneration],
+      "SELECT metadata_json FROM job_materials WHERE tenant_id = ? AND job_id = ? AND generation = ? LIMIT 1",
+      [tenantId, jobId, references.baseGeneration],
     );
     metadata.push(row?.metadata_json ?? null);
   }
@@ -1587,7 +944,7 @@ function loadBaseMaterialMetadata(db: SqliteDatabase, jobUrl: string, metadataJs
         db,
         `SELECT metadata_json
            FROM job_materials_artifacts
-          WHERE job_url = ?
+          WHERE tenant_id = ? AND job_id = ?
             AND generation = ?
             AND artifact_type IN ('tailored_resume', 'tailored_resume_txt', 'resume_pdf')
           ORDER BY CASE artifact_type
@@ -1597,7 +954,7 @@ function loadBaseMaterialMetadata(db: SqliteDatabase, jobUrl: string, metadataJs
                      ELSE 3
                    END,
                    rowid DESC`,
-        [jobUrl, references.baseGeneration],
+        [tenantId, jobId, references.baseGeneration],
       ).map((row) => row.metadata_json),
     );
   }
@@ -1608,7 +965,7 @@ function loadBaseMaterialMetadata(db: SqliteDatabase, jobUrl: string, metadataJs
         db,
         `SELECT metadata_json
            FROM job_materials_artifacts
-          WHERE job_url = ?
+          WHERE tenant_id = ? AND job_id = ?
             AND artifact_id IN (${placeholders})
           ORDER BY COALESCE(generation, -1) DESC,
                    CASE artifact_type
@@ -1618,7 +975,7 @@ function loadBaseMaterialMetadata(db: SqliteDatabase, jobUrl: string, metadataJs
                      ELSE 3
                    END,
                    rowid DESC`,
-        [jobUrl, ...references.baseArtifactIds],
+        [tenantId, jobId, ...references.baseArtifactIds],
       ).map((row) => row.metadata_json),
     );
   }
@@ -1689,7 +1046,7 @@ interface EmployerAnalysisRow extends Record<string, unknown> {
 }
 
 interface RequirementFitReportRow extends Record<string, unknown> {
-  job_url: string;
+  job_id: string;
   score_version: number;
   employer_analysis_generation: number;
   profile_snapshot_version: number;
@@ -1717,7 +1074,7 @@ interface RequirementFitItemRow extends Record<string, unknown> {
 }
 
 interface InterviewPrepRow extends Record<string, unknown> {
-  job_url: string;
+  job_id: string;
   generation: number;
   status: string;
   model: string | null;
@@ -1745,7 +1102,7 @@ interface InterviewPrepItemRow extends Record<string, unknown> {
 }
 
 interface BulletProvenanceRow extends Record<string, unknown> {
-  job_url: string;
+  job_id: string;
   artifact_id: string;
   generation: number;
   bullet_id: string;
@@ -1827,13 +1184,12 @@ interface EvidenceGapPayload {
  * ``EmployerAnalysis.to_read_model()`` — the cross-runtime projection parity
  * test asserts both builders agree. Returns null when no analysis exists.
  */
-function loadEmployerAnalysisJson(db: SqliteDatabase, jobUrl: string): string | null {
-  if (!tableExists(db, "job_employer_analysis")) return null;
+function loadEmployerAnalysisJson(db: SqliteDatabase, tenantId: string, jobId: string): string | null {
   const row = getRow<EmployerAnalysisRow>(
     db,
-    `SELECT * FROM job_employer_analysis WHERE job_url = ?
+    `SELECT * FROM job_employer_analysis WHERE tenant_id = ? AND job_id = ?
       ORDER BY generation DESC LIMIT 1`,
-    [jobUrl],
+    [tenantId, jobId],
   );
   if (!row) return null;
   const generation = Number(row.generation);
@@ -1844,14 +1200,14 @@ function loadEmployerAnalysisJson(db: SqliteDatabase, jobUrl: string): string | 
   const subRows = allRows<{ model_id: string; analysis_json: string }>(
     db,
     `SELECT model_id, analysis_json FROM job_employer_analysis_sub_analyses
-      WHERE job_url = ? AND generation = ? ORDER BY model_id`,
-    [jobUrl, generation],
+      WHERE tenant_id = ? AND job_id = ? AND generation = ? ORDER BY model_id`,
+    [tenantId, jobId, generation],
   );
   const failureRows = allRows<{ model_id: string; error: string; raw_output: string | null }>(
     db,
     `SELECT model_id, error, raw_output FROM job_employer_analysis_failures
-      WHERE job_url = ? AND generation = ? ORDER BY model_id`,
-    [jobUrl, generation],
+      WHERE tenant_id = ? AND job_id = ? AND generation = ? ORDER BY model_id`,
+    [tenantId, jobId, generation],
   );
 
   const readModel = {
@@ -1887,20 +1243,18 @@ function loadEmployerAnalysisJson(db: SqliteDatabase, jobUrl: string): string | 
 function loadRequirementFitReportJson(
   db: SqliteDatabase,
   tenantId: string,
-  jobUrl: string,
+  jobId: string,
 ): string | null {
-  if (!tableExists(db, "job_requirement_fit_reports")) return null;
-  if (!tableExists(db, "job_requirement_fit_items")) return null;
   const row = getRow<RequirementFitReportRow>(
     db,
-    `SELECT job_url, score_version, tenant_id, employer_analysis_generation,
+    `SELECT job_id, score_version, tenant_id, employer_analysis_generation,
             profile_snapshot_version, scoring_policy_version, formula_version,
             resolved_fit_score, fit_band, confidence, summary_json
        FROM job_requirement_fit_reports
-      WHERE tenant_id = ? AND job_url = ?
+      WHERE tenant_id = ? AND job_id = ?
       ORDER BY score_version DESC
       LIMIT 1`,
-    [tenantId, jobUrl],
+    [tenantId, jobId],
   );
   if (!row) return null;
   const scoreVersion = Number(row.score_version);
@@ -1909,12 +1263,12 @@ function loadRequirementFitReportJson(
     `SELECT requirement_id, requirement_text, tier, weight, job_evidence_span,
             fit_json, contribution_json, tailoring_json, artifact_coverage_json
        FROM job_requirement_fit_items
-      WHERE tenant_id = ? AND job_url = ? AND score_version = ?
+      WHERE tenant_id = ? AND job_id = ? AND score_version = ?
       ORDER BY position ASC, requirement_id ASC`,
-    [tenantId, jobUrl, scoreVersion],
+    [tenantId, jobId, scoreVersion],
   );
   const readModel = {
-    jobId: jobUrl,
+    jobId,
     scoreVersion,
     employerAnalysisGeneration: Number(row.employer_analysis_generation ?? 0),
     profileSnapshotVersion: Number(row.profile_snapshot_version ?? 0),
@@ -1932,17 +1286,16 @@ function loadRequirementFitReportJson(
 function loadLatestRequirementFitBand(
   db: SqliteDatabase,
   tenantId: string,
-  jobUrl: string,
+  jobId: string,
 ): string | null {
-  if (!tableExists(db, "job_requirement_fit_reports")) return null;
   const row = getRow<{ fit_band: string | null }>(
     db,
     `SELECT fit_band
        FROM job_requirement_fit_reports
-      WHERE tenant_id = ? AND job_url = ?
+      WHERE tenant_id = ? AND job_id = ?
       ORDER BY score_version DESC
       LIMIT 1`,
-    [tenantId, jobUrl],
+    [tenantId, jobId],
   );
   return nullableString(row?.fit_band);
 }
@@ -1950,20 +1303,18 @@ function loadLatestRequirementFitBand(
 function loadInterviewPrepJson(
   db: SqliteDatabase,
   tenantId: string,
-  jobUrl: string,
+  jobId: string,
 ): string | null {
-  if (!tableExists(db, "job_interview_prep")) return null;
-  if (!tableExists(db, "job_interview_prep_items")) return null;
   const row = getRow<InterviewPrepRow>(
     db,
-    `SELECT job_url, generation, status, model, generated_at, gate_status,
+    `SELECT job_id, generation, status, model, generated_at, gate_status,
             fabrication_findings_json, grounding_findings_json, judge_verdict,
             warnings_json
        FROM job_interview_prep
-      WHERE tenant_id = ? AND job_url = ? AND status = 'accepted'
+      WHERE tenant_id = ? AND job_id = ? AND status = 'accepted'
       ORDER BY generation DESC
       LIMIT 1`,
-    [tenantId, jobUrl],
+    [tenantId, jobId],
   );
   if (!row) return null;
   const generation = Number(row.generation);
@@ -1973,12 +1324,12 @@ function loadInterviewPrepJson(
             requirement_ids_json, source_text_json, transform_type, control,
             grounding_audit_json, warnings_json, position
        FROM job_interview_prep_items
-      WHERE tenant_id = ? AND job_url = ? AND generation = ?
+      WHERE tenant_id = ? AND job_id = ? AND generation = ?
       ORDER BY position ASC, item_id ASC`,
-    [tenantId, jobUrl, generation],
+    [tenantId, jobId, generation],
   );
   const readModel = {
-    jobId: jobUrl,
+    jobId,
     generation,
     status: row.status,
     generatedAt: row.generated_at,
@@ -2100,16 +1451,15 @@ function requirementFitSummaryToReadModel(value: Record<string, unknown>): Recor
 function loadBulletProvenanceByArtifact(
   db: SqliteDatabase,
   tenantId: string,
-  jobUrl: string,
+  jobId: string,
 ): Map<string, string> {
   const result = new Map<string, string>();
-  if (!tableExists(db, "job_bullet_provenance")) return result;
   const rows = allRows<BulletProvenanceRow>(
     db,
     `SELECT * FROM job_bullet_provenance
-      WHERE job_url = ? AND tenant_id = ?
+      WHERE tenant_id = ? AND job_id = ?
       ORDER BY generation, position, bullet_id`,
-    [jobUrl, tenantId],
+    [tenantId, jobId],
   );
   if (rows.length === 0) return result;
   const byArtifact = new Map<string, Record<string, unknown>[]>();
@@ -2150,24 +1500,17 @@ function loadBulletProvenanceByArtifact(
 function loadProvenanceAuxByArtifact(
   db: SqliteDatabase,
   tenantId: string,
-  jobUrl: string,
+  jobId: string,
 ): { coverage: Map<string, string>; voice: Map<string, string> } {
   const coverage = new Map<string, string>();
   const voice = new Map<string, string>();
-  if (!tableExists(db, "job_bullet_provenance")) return { coverage, voice };
-  let rows: Array<{ artifact_id: string; coverage_json: string | null; voice_json: string | null }> = [];
-  try {
-    rows = allRows<{ artifact_id: string; coverage_json: string | null; voice_json: string | null }>(
-      db,
-      `SELECT artifact_id, coverage_json, voice_json FROM job_bullet_provenance
-        WHERE job_url = ? AND tenant_id = ?
-        ORDER BY generation, position, bullet_id`,
-      [jobUrl, tenantId],
-    );
-  } catch {
-    // Columns predate Phase 3 (a DB written before this migration ran) — no aux data.
-    return { coverage, voice };
-  }
+  const rows = allRows<{ artifact_id: string; coverage_json: string | null; voice_json: string | null }>(
+    db,
+    `SELECT artifact_id, coverage_json, voice_json FROM job_bullet_provenance
+      WHERE tenant_id = ? AND job_id = ?
+      ORDER BY generation, position, bullet_id`,
+    [tenantId, jobId],
+  );
   for (const row of rows) {
     if (!coverage.has(row.artifact_id) && row.coverage_json && row.coverage_json.trim()) {
       coverage.set(row.artifact_id, row.coverage_json);
@@ -2230,38 +1573,6 @@ function loadProfileEvidenceEntries(
   tenantId: string,
   entries: Map<string, EvidenceMapEntryPayload>,
 ): void {
-  if (!tableExists(db, "candidate_profile_achievement_evidence")) return;
-  const evidenceStrengthExpr = columnOrLiteral(
-    db,
-    "candidate_profile_achievement_evidence",
-    "evidence_strength",
-    "'supported'",
-    "evidence",
-  );
-  const claimConfidenceExpr = columnOrLiteral(
-    db,
-    "candidate_profile_achievement_evidence",
-    "claim_confidence",
-    "0",
-    "evidence",
-  );
-  const userConfirmedExpr = columnOrLiteral(
-    db,
-    "candidate_profile_achievement_evidence",
-    "user_confirmed",
-    "0",
-    "evidence",
-  );
-  const tagsJsonExpr = columnOrLiteral(
-    db,
-    "candidate_profile_achievement_evidence",
-    "tags_json",
-    "'[]'",
-    "evidence",
-  );
-  const hasExperience =
-    tableExists(db, "candidate_profile_experience_entries") &&
-    hasColumn(db, "candidate_profile_experience_entries", "date_range");
   const rows = allRows<{
     entry_id: string;
     evidence_id: string;
@@ -2278,28 +1589,16 @@ function loadProfileEvidenceEntries(
     date_range: string | null;
   }>(
     db,
-    hasExperience
-      ? `SELECT evidence.entry_id, evidence.evidence_id, evidence.source_text,
+    `SELECT evidence.entry_id, evidence.evidence_id, evidence.source_text,
                 evidence.scope, evidence.action, evidence.tools_json,
-                evidence.metrics_json, evidence.outcome, ${evidenceStrengthExpr} AS evidence_strength,
-                ${claimConfidenceExpr} AS claim_confidence, ${userConfirmedExpr} AS user_confirmed,
-                ${tagsJsonExpr} AS tags_json,
+                evidence.metrics_json, evidence.outcome, evidence.evidence_strength,
+                evidence.claim_confidence, evidence.user_confirmed, evidence.tags_json,
                 experience.date_range
            FROM candidate_profile_achievement_evidence AS evidence
            LEFT JOIN candidate_profile_experience_entries AS experience
              ON experience.tenant_id = evidence.tenant_id
             AND experience.profile_id = evidence.profile_id
             AND experience.entry_id = evidence.entry_id
-          WHERE evidence.tenant_id = ? AND evidence.profile_id = ?
-            AND TRIM(evidence.evidence_id) != ''
-          ORDER BY evidence.entry_id, evidence.evidence_index`
-      : `SELECT evidence.entry_id, evidence.evidence_id, evidence.source_text,
-                evidence.scope, evidence.action, evidence.tools_json,
-                evidence.metrics_json, evidence.outcome, ${evidenceStrengthExpr} AS evidence_strength,
-                ${claimConfidenceExpr} AS claim_confidence, ${userConfirmedExpr} AS user_confirmed,
-                ${tagsJsonExpr} AS tags_json,
-                NULL AS date_range
-           FROM candidate_profile_achievement_evidence AS evidence
           WHERE evidence.tenant_id = ? AND evidence.profile_id = ?
             AND TRIM(evidence.evidence_id) != ''
           ORDER BY evidence.entry_id, evidence.evidence_index`,
@@ -2344,12 +1643,9 @@ function loadProfileSkillEntries(
   entries: Map<string, EvidenceMapEntryPayload>,
 ): Map<string, EvidenceMapEntryPayload[]> {
   const byName = new Map<string, EvidenceMapEntryPayload[]>();
-  if (!tableExists(db, "candidate_profile_skill_items")) return byName;
-  const hasCategories = tableExists(db, "candidate_profile_skill_categories");
   const rows = allRows<{ category_id: string; item_index: number; item_text: string; label: string }>(
     db,
-    hasCategories
-      ? `SELECT skills.category_id, skills.item_index, skills.item_text,
+    `SELECT skills.category_id, skills.item_index, skills.item_text,
                 COALESCE(NULLIF(categories.label, ''), skills.category_id) AS label
            FROM candidate_profile_skill_items AS skills
            LEFT JOIN candidate_profile_skill_categories AS categories
@@ -2358,12 +1654,7 @@ function loadProfileSkillEntries(
             AND categories.category_id = skills.category_id
           WHERE skills.tenant_id = ? AND skills.profile_id = ?
             AND TRIM(skills.item_text) != ''
-          ORDER BY categories.position_index, skills.item_index`
-      : `SELECT category_id, item_index, item_text, category_id AS label
-           FROM candidate_profile_skill_items
-          WHERE tenant_id = ? AND profile_id = ?
-            AND TRIM(item_text) != ''
-          ORDER BY category_id, item_index`,
+          ORDER BY categories.position_index, skills.item_index`,
     [tenantId, "default"],
   );
   for (const row of rows) {
@@ -2405,12 +1696,11 @@ function attachResumeUsages(
   tenantId: string,
   entries: Map<string, EvidenceMapEntryPayload>,
 ): void {
-  if (!tableExists(db, "job_bullet_provenance")) return;
-  const jobMetadata = jobMetadataJoinSql(db, "provenance.job_url");
-  const lifecycle = jobLifecycleExclusionSql(db, "provenance.job_url");
+  const jobMetadata = jobMetadataJoinSql("provenance.job_id", "provenance.tenant_id");
+  const lifecycle = jobLifecycleExclusionSql("provenance.job_id", "provenance.tenant_id");
   const rows = allRows<BulletProvenanceRow & { job_title: string | null; employer: string | null }>(
     db,
-    `SELECT provenance.job_url, provenance.artifact_id, provenance.generation,
+    `SELECT provenance.job_id, provenance.artifact_id, provenance.generation,
             provenance.bullet_id, provenance.section, provenance.source_id,
             provenance.evidence_ids_json, provenance.requirement_ids_json,
             provenance.matched_keywords_json, provenance.transform_type,
@@ -2424,15 +1714,15 @@ function attachResumeUsages(
           SELECT MAX(latest.generation)
             FROM job_bullet_provenance AS latest
            WHERE latest.tenant_id = provenance.tenant_id
-             AND latest.job_url = provenance.job_url
+             AND latest.job_id = provenance.job_id
         )
-      ORDER BY provenance.job_url, provenance.position, provenance.bullet_id`,
+      ORDER BY provenance.job_id, provenance.position, provenance.bullet_id`,
     [tenantId],
   );
   for (const row of rows) {
     const usage: EvidenceUsagePayload = {
       kind: "resume_bullet",
-      jobKey: row.job_url,
+      jobKey: row.job_id,
       jobTitle: nullableString(row.job_title),
       employer: nullableString(row.employer),
       artifactId: row.artifact_id,
@@ -2465,17 +1755,16 @@ function attachRequirementUsagesAndGaps(
   entries: Map<string, EvidenceMapEntryPayload>,
   gaps: Map<string, EvidenceGapPayload>,
 ): void {
-  if (!tableExists(db, "job_requirement_fit_reports") || !tableExists(db, "job_requirement_fit_items")) return;
-  const jobMetadata = jobMetadataJoinSql(db, "items.job_url");
-  const lifecycle = jobLifecycleExclusionSql(db, "items.job_url");
+  const jobMetadata = jobMetadataJoinSql("items.job_id", "items.tenant_id");
+  const lifecycle = jobLifecycleExclusionSql("items.job_id", "items.tenant_id");
   const rows = allRows<RequirementFitItemRow & {
-    job_url: string;
+    job_id: string;
     score_version: number;
     job_title: string | null;
     employer: string | null;
   }>(
     db,
-    `SELECT items.job_url, items.score_version, items.requirement_id,
+    `SELECT items.job_id, items.score_version, items.requirement_id,
             items.requirement_text, items.tier, items.weight, items.job_evidence_span,
             items.fit_json, items.contribution_json, items.tailoring_json,
             items.artifact_coverage_json,
@@ -2487,9 +1776,9 @@ function attachRequirementUsagesAndGaps(
           SELECT MAX(report.score_version)
             FROM job_requirement_fit_reports AS report
            WHERE report.tenant_id = items.tenant_id
-             AND report.job_url = items.job_url
+             AND report.job_id = items.job_id
         )
-      ORDER BY items.job_url, items.position, items.requirement_id`,
+      ORDER BY items.job_id, items.position, items.requirement_id`,
     [tenantId],
   );
   for (const row of rows) {
@@ -2500,7 +1789,7 @@ function attachRequirementUsagesAndGaps(
       : null;
     const usage: EvidenceUsagePayload = {
       kind: "requirement_fit",
-      jobKey: row.job_url,
+      jobKey: row.job_id,
       jobTitle: nullableString(row.job_title),
       employer: nullableString(row.employer),
       artifactId: null,
@@ -2530,7 +1819,7 @@ function attachRequirementUsagesAndGaps(
       const reason =
         stringField(fit.reason) || stringField(fit.blocker) || stringField(fit.gap) || "Recorded requirement gap.";
       const gap: EvidenceGapPayload = {
-        gapId: `${row.job_url}#${row.requirement_id}`,
+        gapId: `${row.job_id}#${row.requirement_id}`,
         kind,
         requirementId: row.requirement_id,
         requirementText: row.requirement_text,
@@ -2553,8 +1842,7 @@ function attachSkillCoverageUsagesAndGaps(
   skillEntriesByName: Map<string, EvidenceMapEntryPayload[]>,
   gaps: Map<string, EvidenceGapPayload>,
 ): void {
-  if (!tableExists(db, "artifact_list_projections")) return;
-  const lifecycle = jobLifecycleExclusionSql(db, "alp.job_id");
+  const lifecycle = jobLifecycleExclusionSql("alp.job_id", "alp.tenant_id");
   const rows = allRows<{
     job_id: string;
     job_title: string;
@@ -2704,10 +1992,7 @@ interface ScoreLatest {
   correctionJson: string | null;
 }
 
-function loadLatestScore(db: SqliteDatabase, jobUrl: string): ScoreLatest {
-  if (!tableExists(db, "job_scores")) {
-    return emptyScore();
-  }
+function loadLatestScore(db: SqliteDatabase, tenantId: string, jobId: string): ScoreLatest {
   const row = getRow<{
     fit_score: number;
     version: number;
@@ -2721,8 +2006,8 @@ function loadLatestScore(db: SqliteDatabase, jobUrl: string): ScoreLatest {
     db,
     `SELECT fit_score, version, breakdown_json, keywords_json, scored_at,
             correction_json, criteria_json, trace_json
-     FROM job_scores WHERE job_url = ? ORDER BY version DESC LIMIT 1`,
-    [jobUrl],
+     FROM job_scores WHERE tenant_id = ? AND job_id = ? ORDER BY version DESC LIMIT 1`,
+    [tenantId, jobId],
   );
   if (!row) {
     return emptyScore();
@@ -2857,16 +2142,13 @@ interface EnrichmentLatest {
   currentStatus: string | null;
 }
 
-function loadEnrichment(db: SqliteDatabase, jobUrl: string): EnrichmentLatest {
+function loadEnrichment(db: SqliteDatabase, tenantId: string, jobId: string): EnrichmentLatest {
   const empty: EnrichmentLatest = {
     fullDescription: null,
     applicationUrl: null,
     enrichedAt: null,
     currentStatus: null,
   };
-  if (!tableExists(db, "job_enrichments")) {
-    return empty;
-  }
   const row = getRow<{
     full_description: string | null;
     application_url: string | null;
@@ -2874,8 +2156,8 @@ function loadEnrichment(db: SqliteDatabase, jobUrl: string): EnrichmentLatest {
     current_status: string | null;
   }>(
     db,
-    "SELECT full_description, application_url, enriched_at, current_status FROM job_enrichments WHERE job_url = ?",
-    [jobUrl],
+    "SELECT full_description, application_url, enriched_at, current_status FROM job_enrichments WHERE tenant_id = ? AND job_id = ?",
+    [tenantId, jobId],
   );
   if (!row) return empty;
   return {
@@ -2898,7 +2180,7 @@ interface ApplyLatest {
   durationMs: number | null;
 }
 
-function loadLatestApplyRun(db: SqliteDatabase, jobUrl: string): ApplyLatest {
+function loadLatestApplyRun(db: SqliteDatabase, tenantId: string, jobId: string): ApplyLatest {
   const empty: ApplyLatest = {
     runId: null,
     status: null,
@@ -2910,14 +2192,13 @@ function loadLatestApplyRun(db: SqliteDatabase, jobUrl: string): ApplyLatest {
     dryRun: false,
     durationMs: null,
   };
-  if (!tableExists(db, "apply_run_projections")) return empty;
   const row = getRow<Record<string, unknown>>(
     db,
     `SELECT run_id, status, result, started_at, finished_at, worker_id,
             model, dry_run, duration_ms
-     FROM apply_run_projections WHERE job_id = ?
+     FROM apply_run_projections WHERE tenant_id = ? AND job_id = ?
      ORDER BY started_at DESC, run_id DESC LIMIT 1`,
-    [jobUrl],
+    [tenantId, jobId],
   );
   if (!row) return empty;
   return {
@@ -2933,24 +2214,22 @@ function loadLatestApplyRun(db: SqliteDatabase, jobUrl: string): ApplyLatest {
   };
 }
 
-function loadDeletedAt(db: SqliteDatabase, jobUrl: string): string | null {
-  if (!tableExists(db, "jobctrl_deleted_jobs")) return null;
+function loadDeletedAt(db: SqliteDatabase, tenantId: string, jobId: string): string | null {
   const row = getRow<{ deleted_at: string | null }>(
     db,
-    "SELECT deleted_at FROM jobctrl_deleted_jobs WHERE job_url = ? AND (restored_at IS NULL OR julianday(restored_at) <= julianday(deleted_at))",
-    [jobUrl],
+    "SELECT deleted_at FROM jobctrl_deleted_jobs WHERE tenant_id = ? AND job_id = ? AND (restored_at IS NULL OR julianday(restored_at) <= julianday(deleted_at))",
+    [tenantId, jobId],
   );
   return row ? nullableString(row.deleted_at) : null;
 }
 
 function staleDeletedProjectionJobs(db: SqliteDatabase, tenantId: string): string[] {
-  if (!tableExists(db, "jobctrl_deleted_jobs")) return [];
   const rows = allRows<{ job_id: string }>(
     db,
     `SELECT p.job_id
      FROM job_list_projections p
      JOIN jobctrl_deleted_jobs d
-       ON d.job_url = p.job_id
+       ON d.tenant_id = p.tenant_id AND d.job_id = p.job_id
      WHERE p.tenant_id = ?
        AND (d.restored_at IS NULL OR julianday(d.restored_at) <= julianday(d.deleted_at))
        AND (p.deleted_at IS NULL OR p.deleted_at != d.deleted_at)`,
@@ -2960,29 +2239,16 @@ function staleDeletedProjectionJobs(db: SqliteDatabase, tenantId: string): strin
 }
 
 function staleArtifactMetadataProjectionJobs(db: SqliteDatabase, tenantId: string): string[] {
-  if (
-    !tableExists(db, "jobs") ||
-    !tableExists(db, "artifact_list_projections") ||
-    !tableExists(db, "job_materials_artifacts")
-  ) {
-    return [];
-  }
-  if (
-    !hasColumn(db, "artifact_list_projections", "metadata_json") ||
-    !hasColumn(db, "job_materials_artifacts", "metadata_json")
-  ) {
-    return [];
-  }
-
   const rows = allRows<{ job_id: string }>(
     db,
-    `SELECT DISTINCT a.job_url AS job_id
+    `SELECT DISTINCT a.job_id
        FROM job_materials_artifacts a
        LEFT JOIN artifact_list_projections p
-         ON p.tenant_id = ?
-        AND p.job_id = a.job_url
+         ON p.tenant_id = a.tenant_id
+        AND p.job_id = a.job_id
         AND p.artifact_id = COALESCE(NULLIF(a.artifact_id, ''), a.artifact_type || ':' || a.path)
-      WHERE a.artifact_type IN ('tailored_resume', 'tailored_resume_txt')
+      WHERE a.tenant_id = ?
+        AND a.artifact_type IN ('tailored_resume', 'tailored_resume_txt')
         AND a.path IS NOT NULL
         AND TRIM(a.path) != ''
         AND a.metadata_json IS NOT NULL
@@ -2999,21 +2265,18 @@ function staleArtifactMetadataProjectionJobs(db: SqliteDatabase, tenantId: strin
 }
 
 function staleStageProjectionJobs(db: SqliteDatabase, tenantId: string): string[] {
-  if (!tableExists(db, "jobs") || !tableExists(db, "job_stage_states") || !tableExists(db, "job_list_projections")) {
-    return [];
-  }
 
   const rows = allRows<{ job_id: string }>(
     db,
-    `SELECT DISTINCT s.job_url AS job_id
+    `SELECT DISTINCT s.job_id
        FROM job_stage_states s
        JOIN jobs j
-         ON j.url = s.job_url
+         ON j.tenant_id = s.tenant_id AND j.job_id = s.job_id
        LEFT JOIN job_list_projections p
-         ON p.tenant_id = ?
-        AND p.job_id = s.job_url
-      WHERE s.job_url IS NOT NULL
-        AND TRIM(s.job_url) != ''
+         ON p.tenant_id = s.tenant_id
+        AND p.job_id = s.job_id
+      WHERE s.tenant_id = ?
+        AND TRIM(s.job_id) != ''
         AND (
           p.job_id IS NULL
           OR (
@@ -3063,13 +2326,13 @@ interface NormalizedStage {
   next_action: string | null;
 }
 
-function loadStages(db: SqliteDatabase, jobUrl: string): NormalizedStage[] {
+function loadStages(db: SqliteDatabase, tenantId: string, jobId: string): NormalizedStage[] {
   const explicit = new Map<string, StageRow>();
-  if (tableExists(db, "job_stage_states")) {
+  {
     for (const row of allRows<StageRow>(
       db,
-      "SELECT * FROM job_stage_states WHERE job_url = ?",
-      [jobUrl],
+      "SELECT * FROM job_stage_states WHERE tenant_id = ? AND job_id = ?",
+      [tenantId, jobId],
     )) {
       if (row.stage) explicit.set(String(row.stage), row);
     }
@@ -3127,38 +2390,43 @@ function jobListStage(stage: string | null | undefined, hasResume = false): "dis
   return stage === "apply" || (stage === "cover" && hasResume) ? "apply" : "discover";
 }
 
-function rebuildJobProjections(db: SqliteDatabase, tenantId: string, jobUrl: string): void {
-  const job = getRow<Record<string, unknown>>(db, "SELECT * FROM jobs WHERE url = ?", [jobUrl]);
+function rebuildJobProjections(db: SqliteDatabase, tenantId: string, jobId: string): void {
+  const job = getRow<Record<string, unknown>>(
+    db,
+    "SELECT * FROM jobs WHERE tenant_id = ? AND job_id = ?",
+    [tenantId, jobId],
+  );
   if (!job) {
     db.prepare("DELETE FROM job_list_projections WHERE tenant_id = ? AND job_id = ?").run(
       tenantId,
-      jobUrl,
+      jobId,
     );
     db.prepare("DELETE FROM job_detail_projections WHERE tenant_id = ? AND job_id = ?").run(
       tenantId,
-      jobUrl,
+      jobId,
     );
     db.prepare("DELETE FROM artifact_list_projections WHERE tenant_id = ? AND job_id = ?").run(
       tenantId,
-      jobUrl,
+      jobId,
     );
     return;
   }
 
-  const score = loadLatestScore(db, jobUrl);
-  const materials = loadLatestMaterials(db, jobUrl);
-  const materialAnalytics = loadMaterialAnalytics(db, jobUrl);
-  const employerAnalysisJson = loadEmployerAnalysisJson(db, jobUrl);
-  const requirementFitReportJson = loadRequirementFitReportJson(db, tenantId, jobUrl);
-  const requirementFitBand = fitBand(loadLatestRequirementFitBand(db, tenantId, jobUrl));
-  const interviewPrepJson = loadInterviewPrepJson(db, tenantId, jobUrl);
-  const enrichment = loadEnrichment(db, jobUrl);
-  const apply = loadLatestApplyRun(db, jobUrl);
-  const deletedAt = loadDeletedAt(db, jobUrl);
-  const stages = loadStages(db, jobUrl);
+  const score = loadLatestScore(db, tenantId, jobId);
+  const materials = loadLatestMaterials(db, tenantId, jobId);
+  const materialAnalytics = loadMaterialAnalytics(db, tenantId, jobId);
+  const employerAnalysisJson = loadEmployerAnalysisJson(db, tenantId, jobId);
+  const requirementFitReportJson = loadRequirementFitReportJson(db, tenantId, jobId);
+  const requirementFitBand = fitBand(loadLatestRequirementFitBand(db, tenantId, jobId));
+  const interviewPrepJson = loadInterviewPrepJson(db, tenantId, jobId);
+  const enrichment = loadEnrichment(db, tenantId, jobId);
+  const apply = loadLatestApplyRun(db, tenantId, jobId);
+  const deletedAt = loadDeletedAt(db, tenantId, jobId);
+  const stages = loadStages(db, tenantId, jobId);
 
   const title = stringField(job.title) || "Untitled";
   const site = stringField(job.site);
+  const jobUrl = stringField(job.url);
   const applicationUrl = enrichment.applicationUrl ?? nullableString(job.application_url);
   const employer = stringField(job.company) || companyName(site, applicationUrl ?? jobUrl);
 
@@ -3169,7 +2437,7 @@ function rebuildJobProjections(db: SqliteDatabase, tenantId: string, jobUrl: str
   const scoreReasoning = score.reasoning || stringField(job.score_reasoning);
   const scoreBreakdownJson = score.breakdown ? JSON.stringify(score.breakdown) : null;
   const scoreKeywordsJson = JSON.stringify(score.keywords);
-  const compensationProjection = buildCompensationProjection(db, jobUrl, jobUrl);
+  const compensationProjection = buildExactV7CompensationProjection(jobId, nullableString(job.salary));
 
   const hasCanonicalMaterials = materials.hasCanonicalHistory;
   const tailorPath = hasCanonicalMaterials ? materials.tailorPath : nullableString(job.tailored_resume_path);
@@ -3180,19 +2448,19 @@ function rebuildJobProjections(db: SqliteDatabase, tenantId: string, jobUrl: str
 
   const applyStatus = deriveApplyStatus(apply.status, nullableString(job.apply_status));
   const appliedAt = apply.status === "succeeded" ? apply.finishedAt : nullableString(job.applied_at);
-  const applyMode = deriveApplyMode(db, tenantId, jobUrl, apply, nullableString(job.apply_status), nullableString(job.applied_at));
+  const applyMode = deriveApplyMode(db, tenantId, jobId, apply, nullableString(job.apply_status), nullableString(job.applied_at));
 
   const description = stringField(job.description);
   const fullDescription = enrichment.fullDescription ?? stringField(job.full_description);
 
   const lastUpdatedAt = new Date().toISOString();
 
-  const artifacts = collectArtifacts(db, jobUrl, materials);
-  const provenanceByArtifact = loadBulletProvenanceByArtifact(db, tenantId, jobUrl);
+  const artifacts = collectArtifacts(db, tenantId, jobId, materials);
+  const provenanceByArtifact = loadBulletProvenanceByArtifact(db, tenantId, jobId);
   const { coverage: coverageByArtifact, voice: voiceByArtifact } = loadProvenanceAuxByArtifact(
     db,
     tenantId,
-    jobUrl,
+    jobId,
   );
   const activeArtifacts = artifacts.filter(isDefaultVisibleArtifact);
 
@@ -3251,7 +2519,7 @@ function rebuildJobProjections(db: SqliteDatabase, tenantId: string, jobUrl: str
        last_updated_at       = excluded.last_updated_at`,
   ).run(
     tenantId,
-    jobUrl,
+    jobId,
     title,
     employer,
     site || "unknown",
@@ -3322,7 +2590,7 @@ function rebuildJobProjections(db: SqliteDatabase, tenantId: string, jobUrl: str
        last_updated_at        = excluded.last_updated_at`,
   ).run(
     tenantId,
-    jobUrl,
+    jobId,
     previewText(fullDescription || description, 6000),
     compensationProjection.summaryJson,
     compensationProjection.auditJson,
@@ -3343,7 +2611,7 @@ function rebuildJobProjections(db: SqliteDatabase, tenantId: string, jobUrl: str
 
   db.prepare("DELETE FROM artifact_list_projections WHERE tenant_id = ? AND job_id = ?").run(
     tenantId,
-    jobUrl,
+    jobId,
   );
   const insertArtifact = db.prepare(
     `INSERT INTO artifact_list_projections (
@@ -3352,12 +2620,12 @@ function rebuildJobProjections(db: SqliteDatabase, tenantId: string, jobUrl: str
        layout_boxes_json, bullet_provenance_json, coverage_audit_json, voice_pass_json
      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   );
-  const layoutBoxesByArtifact = loadLayoutBoxesByArtifact(db, tenantId, jobUrl);
+  const layoutBoxesByArtifact = loadLayoutBoxesByArtifact(db, tenantId, jobId);
   for (const a of artifacts) {
     insertArtifact.run(
       a.artifactId,
       tenantId,
-      jobUrl,
+      jobId,
       title,
       employer,
       a.artifactType,
@@ -3378,10 +2646,9 @@ function rebuildJobProjections(db: SqliteDatabase, tenantId: string, jobUrl: str
 function loadLayoutBoxesByArtifact(
   db: SqliteDatabase,
   tenantId: string,
-  jobUrl: string,
+  jobId: string,
 ): Map<string, string> {
   const result = new Map<string, string>();
-  if (!tableExists(db, "job_material_layout_boxes")) return result;
   const rows = allRows<{
     artifact_id: string;
     semantic_id: string;
@@ -3397,9 +2664,9 @@ function loadLayoutBoxesByArtifact(
     `SELECT artifact_id, semantic_id, page_number, line_number, text_excerpt,
             left_pct, top_pct, width_pct, height_pct
        FROM job_material_layout_boxes
-      WHERE tenant_id = ? AND job_url = ?
+      WHERE tenant_id = ? AND job_id = ?
       ORDER BY artifact_id, page_number, box_index`,
-    [tenantId, jobUrl],
+    [tenantId, jobId],
   );
   const byArtifact = new Map<string, Array<Record<string, unknown>>>();
   for (const row of rows) {
@@ -3465,6 +2732,34 @@ export function buildCompensationProjection(
       recordStatus: "not_requested",
       jobKey: jobLocator,
     } as const);
+  const auditPosted = compensationAuditPosted(posted, jobId);
+  const auditMarket = compensationAuditMarket(market, jobId);
+  const summary = buildCompensationSummary(posted, market);
+  return {
+    summaryJson: JSON.stringify(summary),
+    auditJson: JSON.stringify({
+      projectionVersion: COMPENSATION_PROJECTION_VERSION,
+      posted: auditPosted,
+      market: auditMarket,
+    }),
+  };
+}
+
+function buildExactV7CompensationProjection(
+  jobId: string,
+  legacyRawSalary: string | null,
+): CompensationProjectionPair {
+  const posted = {
+    ok: true as const,
+    recordStatus: "not_recorded" as const,
+    jobKey: jobId,
+    legacyRawSalary,
+  };
+  const market = {
+    ok: true as const,
+    recordStatus: "not_requested" as const,
+    jobKey: jobId,
+  };
   const auditPosted = compensationAuditPosted(posted, jobId);
   const auditMarket = compensationAuditMarket(market, jobId);
   const summary = buildCompensationSummary(posted, market);
@@ -3697,15 +2992,13 @@ interface ArtifactRow {
 
 function collectArtifacts(
   db: SqliteDatabase,
-  jobUrl: string,
+  tenantId: string,
+  jobId: string,
   materials: MaterialsLatest,
 ): ArtifactRow[] {
   const out: ArtifactRow[] = [];
   const seen = new Set<string>();
-  if (tableExists(db, "job_materials_artifacts")) {
-    const metadataSelect = hasColumn(db, "job_materials_artifacts", "metadata_json")
-      ? "metadata_json"
-      : "NULL AS metadata_json";
+  {
     const rows = allRows<{
       artifact_id: string;
       artifact_type: string;
@@ -3717,9 +3010,9 @@ function collectArtifacts(
       metadata_json: string | null;
     }>(
       db,
-      `SELECT artifact_id, artifact_type, status, path, created_at, size_bytes, generation, ${metadataSelect}
-       FROM job_materials_artifacts WHERE job_url = ?`,
-      [jobUrl],
+      `SELECT artifact_id, artifact_type, status, path, created_at, size_bytes, generation, metadata_json
+       FROM job_materials_artifacts WHERE tenant_id = ? AND job_id = ?`,
+      [tenantId, jobId],
     );
     for (const row of rows) {
       if (!row.path) continue;
@@ -3738,7 +3031,7 @@ function collectArtifacts(
       });
     }
   }
-  if (tableExists(db, "job_artifacts")) {
+  {
     const rows = allRows<{
       row_id: number | string;
       artifact_type: string;
@@ -3748,9 +3041,9 @@ function collectArtifacts(
       size_bytes: number | null;
     }>(
       db,
-      `SELECT rowid AS row_id, artifact_type, status, path, created_at, size_bytes
-       FROM job_artifacts WHERE job_url = ?`,
-      [jobUrl],
+      `SELECT artifact_id AS row_id, artifact_type, status, path, created_at, size_bytes
+       FROM job_artifacts WHERE tenant_id = ? AND job_id = ?`,
+      [tenantId, jobId],
     );
     for (const row of rows) {
       if (!row.path) continue;
@@ -3768,58 +3061,6 @@ function collectArtifacts(
         metadataJson: null,
       });
     }
-  }
-  // Derive PDF siblings for legacy txt artifacts whose registered PDF
-  // doesn't exist as a separate row.  Mirrors the prior read-model.ts
-  // behaviour so downstream consumers (web UI artifact list, tests)
-  // still see the matching ``*_pdf`` row.  When a real PDF artifact is
-  // registered we never overwrite it (``seen`` guards against
-  // duplicates).
-  const tailorSource = preferredArtifactSource(
-    out,
-    ["tailored_resume", "tailored_resume_txt"],
-    materials.generation,
-  );
-  const tailorPdfPath =
-    materials.resumePdfPath ??
-    (tailorSource?.artifactType === "tailored_resume_txt"
-      ? pdfSibling(tailorSource.localPath)
-      : null);
-  if (tailorPdfPath && !seen.has(`tailored_resume_pdf:${tailorPdfPath}`)) {
-    seen.add(`tailored_resume_pdf:${tailorPdfPath}`);
-    out.push({
-      artifactId: `${jobUrl}:tailored_resume_pdf:${tailorPdfPath}`,
-      artifactType: "tailored_resume_pdf",
-      status: "active",
-      localPath: tailorPdfPath,
-      sizeBytes: null,
-      createdAt: tailorSource?.createdAt ?? null,
-      generation: null,
-      metadataJson: tailorSource?.metadataJson ?? null,
-    });
-  }
-  const coverSource = preferredArtifactSource(
-    out,
-    ["cover_letter", "cover_letter_txt"],
-    materials.generation,
-  );
-  const coverPdfPath =
-    materials.coverPdfPath ??
-    (coverSource?.artifactType === "cover_letter_txt"
-      ? pdfSibling(coverSource.localPath)
-      : null);
-  if (coverPdfPath && !seen.has(`cover_letter_pdf:${coverPdfPath}`)) {
-    seen.add(`cover_letter_pdf:${coverPdfPath}`);
-    out.push({
-      artifactId: `${jobUrl}:cover_letter_pdf:${coverPdfPath}`,
-      artifactType: "cover_letter_pdf",
-      status: "active",
-      localPath: coverPdfPath,
-      sizeBytes: null,
-      createdAt: coverSource?.createdAt ?? null,
-      generation: null,
-      metadataJson: coverSource?.metadataJson ?? null,
-    });
   }
   return out;
 }
@@ -3937,24 +3178,22 @@ function hasAnyKind(outcomes: readonly OutcomeFact[], target: Set<string>): bool
 
 function loadOutcomesByJob(db: SqliteDatabase, tenantId: string): Map<string, OutcomeFact[]> {
   const result = new Map<string, OutcomeFact[]>();
-  if (!tableExists(db, "application_outcomes")) return result;
-  const rows = allRows<{ job_key: string; kind: string; occurred_at: string | null }>(
+  const rows = allRows<{ job_id: string; kind: string; occurred_at: string | null }>(
     db,
-    "SELECT job_key, kind, occurred_at FROM application_outcomes WHERE tenant_id = ?",
+    "SELECT job_id, kind, occurred_at FROM application_outcomes WHERE tenant_id = ?",
     [tenantId],
   );
   for (const row of rows) {
-    if (!row.job_key || !row.kind) continue;
-    const list = result.get(row.job_key) ?? [];
+    if (!row.job_id || !row.kind) continue;
+    const list = result.get(row.job_id) ?? [];
     list.push({ kind: row.kind, occurredAt: nullableString(row.occurred_at) });
-    result.set(row.job_key, list);
+    result.set(row.job_id, list);
   }
   return result;
 }
 
 function loadSuggestionAccuracy(db: SqliteDatabase, tenantId: string): SuggestionAccuracyCounts {
   const counts: SuggestionAccuracyCounts = { decided: 0, accepted: 0, corrected: 0, ignored: 0 };
-  if (!tableExists(db, "application_outcome_suggestions")) return counts;
   const rows = allRows<{ status: string }>(
     db,
     `SELECT status
@@ -4155,20 +3394,16 @@ function buildOutcomeConversion(
 }
 
 function rebuildDashboardProjection(db: SqliteDatabase, tenantId: string): void {
-  const hiddenWhere = tableExists(db, "jobctrl_hidden_jobs")
-    ? `AND NOT EXISTS (
+  const hiddenWhere = `AND NOT EXISTS (
          SELECT 1 FROM jobctrl_hidden_jobs h
-         WHERE h.job_url = jlp.job_id AND h.unhidden_at IS NULL
-       )`
-    : "";
-  const closedWhere = tableExists(db, "posting_snapshot_sets")
-    ? `AND NOT EXISTS (
+         WHERE h.tenant_id = jlp.tenant_id AND h.job_id = jlp.job_id AND h.unhidden_at IS NULL
+       )`;
+  const closedWhere = `AND NOT EXISTS (
          SELECT 1 FROM posting_snapshot_sets pss
          WHERE pss.tenant_id = jlp.tenant_id
-           AND pss.job_url = jlp.job_id
+           AND pss.job_id = jlp.job_id
            AND pss.latest_active_state IN (${CLOSED_ACTIVE_STATES.map((state) => `'${state}'`).join(", ")})
-       )`
-    : "";
+       )`;
   const rows = allRows<{
     job_id: string;
     current_stage: string;
@@ -4209,46 +3444,23 @@ function rebuildDashboardProjection(db: SqliteDatabase, tenantId: string): void 
   const applied = active.filter(
     (row) => row.applied_at || row.apply_status === "applied",
   ).length;
-  let dryRuns = 0;
-  if (tableExists(db, "apply_run_projections")) {
-    if (
-      tableExists(db, "jobctrl_deleted_jobs") ||
-      tableExists(db, "jobctrl_hidden_jobs") ||
-      tableExists(db, "posting_snapshot_sets")
-    ) {
-      const hasDeleted = tableExists(db, "jobctrl_deleted_jobs");
-      const hasHidden = tableExists(db, "jobctrl_hidden_jobs");
-      const hasSnapshots = tableExists(db, "posting_snapshot_sets");
-      const deletedJoin = hasDeleted
-        ? " LEFT JOIN jobctrl_deleted_jobs d ON d.job_url = arp.job_id AND (d.restored_at IS NULL OR julianday(d.restored_at) <= julianday(d.deleted_at))"
-        : "";
-      const hiddenJoin = hasHidden
-        ? " LEFT JOIN jobctrl_hidden_jobs h ON h.job_url = arp.job_id AND h.unhidden_at IS NULL"
-        : "";
-      const snapshotJoin = hasSnapshots
-        ? " LEFT JOIN posting_snapshot_sets pss ON pss.tenant_id = arp.tenant_id AND pss.job_url = arp.job_id"
-        : "";
-      const lifecycleWhere = [
-        hasDeleted ? "d.job_url IS NULL" : "",
-        hasHidden ? "h.job_url IS NULL" : "",
-        hasSnapshots
-          ? `(pss.latest_active_state IS NULL OR pss.latest_active_state NOT IN (${CLOSED_ACTIVE_STATES.map((state) => `'${state}'`).join(", ")}))`
-          : "",
-      ].filter(Boolean).join(" AND ");
-      const dryRunsRow = getRow<{ c: number }>(
-        db,
-        `SELECT COUNT(*) AS c FROM apply_run_projections arp${deletedJoin}${hiddenJoin}${snapshotJoin}
-         WHERE arp.dry_run = 1 AND ${lifecycleWhere}`,
-      );
-      dryRuns = dryRunsRow ? Number(dryRunsRow.c) : 0;
-    } else {
-      const dryRunsRow = getRow<{ c: number }>(
-        db,
-        "SELECT COUNT(*) AS c FROM apply_run_projections WHERE dry_run = 1",
-      );
-      dryRuns = dryRunsRow ? Number(dryRunsRow.c) : 0;
-    }
-  }
+  const dryRunsRow = getRow<{ c: number }>(
+    db,
+    `SELECT COUNT(*) AS c
+       FROM apply_run_projections arp
+       LEFT JOIN jobctrl_deleted_jobs d
+         ON d.tenant_id = arp.tenant_id AND d.job_id = arp.job_id
+        AND (d.restored_at IS NULL OR julianday(d.restored_at) <= julianday(d.deleted_at))
+       LEFT JOIN jobctrl_hidden_jobs h
+         ON h.tenant_id = arp.tenant_id AND h.job_id = arp.job_id AND h.unhidden_at IS NULL
+       LEFT JOIN posting_snapshot_sets pss
+         ON pss.tenant_id = arp.tenant_id AND pss.job_id = arp.job_id
+      WHERE arp.tenant_id = ? AND arp.dry_run = 1
+        AND d.job_id IS NULL AND h.job_id IS NULL
+        AND (pss.latest_active_state IS NULL OR pss.latest_active_state NOT IN (${CLOSED_ACTIVE_STATES.map((state) => `'${state}'`).join(", ")}))`,
+    [tenantId],
+  );
+  const dryRuns = Number(dryRunsRow?.c ?? 0);
 
   // Funnel — read per-job stage rows from job_detail_projections.
   const funnelCounts: Record<
@@ -4347,7 +3559,7 @@ function rebuildDashboardProjection(db: SqliteDatabase, tenantId: string): void 
 }
 
 interface SourceQualityEventRow extends Record<string, unknown> {
-  job_url: string | null;
+  job_id: string | null;
   event_type: string;
   occurred_at: string;
   payload_json: string | null;
@@ -4936,15 +4148,11 @@ function gatePassed(raw: string | null): boolean {
 }
 
 function rebuildSourceQualityProjections(db: SqliteDatabase, tenantId: string): void {
-  if (!tableExists(db, "job_events")) return;
-  const payloadColumn = hasColumn(db, "job_events", "payload_json")
-    ? "payload_json"
-    : "NULL AS payload_json";
   const rows = allRows<SourceQualityEventRow>(
     db,
-    `SELECT job_url, event_type, occurred_at, ${payloadColumn}
+    `SELECT job_id, event_type, occurred_at, payload_json
      FROM job_events
-     WHERE event_type IN (
+     WHERE tenant_id = ? AND event_type IN (
        'DiscoveryRunStarted',
        'DiscoveryRunCompleted',
        'DiscoveryRunFailed',
@@ -4959,6 +4167,7 @@ function rebuildSourceQualityProjections(db: SqliteDatabase, tenantId: string): 
        'DiscoveryFeedbackRecorded'
      )
      ORDER BY event_id ASC`,
+    [tenantId],
   );
   const runs = new Map<string, DiscoveryRunProjection>();
   const stats = new Map<string, MutableSourceStats>();
@@ -5057,7 +4266,7 @@ function rebuildSourceQualityProjections(db: SqliteDatabase, tenantId: string): 
     } else if (row.event_type === "JobSourceObserved") {
       const sourceId = text(payload, "source_id", "sourceId");
       const observationId = text(payload, "source_observation_id", "sourceObservationId");
-      const jobId = text(payload, "job_id", "jobId") || row.job_url || "";
+      const jobId = text(payload, "job_id", "jobId") || row.job_id || "";
       if (!sourceId) continue;
       getStats(stats, sourceId).observedJobs += 1;
       const activeRunId = activeRunBySource.get(sourceId);
@@ -5088,18 +4297,18 @@ function rebuildSourceQualityProjections(db: SqliteDatabase, tenantId: string): 
       }
     } else if (row.event_type === "PostingContentSnapshotCaptured") {
       const sourceId = text(payload, "source_id", "sourceId");
-      const jobId = text(payload, "job_id", "jobId") || row.job_url || "";
+      const jobId = text(payload, "job_id", "jobId") || row.job_id || "";
       if (sourceId) markDetailSuccess(getStats(stats, sourceId), jobId);
     } else if (row.event_type === "PostingContentSnapshotFailed") {
       const sourceId = text(payload, "source_id", "sourceId");
-      const jobId = text(payload, "job_id", "jobId") || row.job_url || "";
+      const jobId = text(payload, "job_id", "jobId") || row.job_id || "";
       if (sourceId) {
         const current = getStats(stats, sourceId);
         markDetailFailure(current, jobId);
         current.lastErrorClass = text(payload, "error_class", "errorClass") || current.lastErrorClass;
       }
     } else if (row.event_type === "JobEnriched") {
-      const jobId = text(payload, "job_id", "jobId") || row.job_url || "";
+      const jobId = text(payload, "job_id", "jobId") || row.job_id || "";
       const fullDescription = text(payload, "full_description", "fullDescription");
       const applicationUrl = text(payload, "application_url", "applicationUrl");
       for (const sourceId of sourcesByJob.get(jobId) ?? []) {
@@ -5110,7 +4319,7 @@ function rebuildSourceQualityProjections(db: SqliteDatabase, tenantId: string): 
         else markApplyFailure(current, jobId);
       }
     } else if (row.event_type === "EnrichmentFailed") {
-      const jobId = text(payload, "job_id", "jobId") || row.job_url || "";
+      const jobId = text(payload, "job_id", "jobId") || row.job_id || "";
       const errorClass = text(payload, "error_class", "errorClass", "error");
       for (const sourceId of sourcesByJob.get(jobId) ?? []) {
         const current = getStats(stats, sourceId);
@@ -5119,7 +4328,7 @@ function rebuildSourceQualityProjections(db: SqliteDatabase, tenantId: string): 
         current.lastErrorClass = errorClass || current.lastErrorClass;
       }
     } else if (row.event_type === "JobActiveStateChanged") {
-      const jobId = text(payload, "job_id", "jobId") || row.job_url || "";
+      const jobId = text(payload, "job_id", "jobId") || row.job_id || "";
       const activeState = text(payload, "active_state", "activeState");
       for (const sourceId of sourcesByJob.get(jobId) ?? []) {
         const current = getStats(stats, sourceId);
@@ -5129,7 +4338,7 @@ function rebuildSourceQualityProjections(db: SqliteDatabase, tenantId: string): 
         }
       }
     } else if (row.event_type === "ContentDuplicateCandidateDetected") {
-      const jobId = text(payload, "job_id", "jobId") || row.job_url || "";
+      const jobId = text(payload, "job_id", "jobId") || row.job_id || "";
       const candidateJobId = text(payload, "candidate_job_id", "candidateJobId");
       const sourceIds = new Set([
         ...(sourcesByJob.get(jobId) ?? []),
@@ -5144,7 +4353,7 @@ function rebuildSourceQualityProjections(db: SqliteDatabase, tenantId: string): 
         }
       }
     } else if (row.event_type === "DiscoveryFeedbackRecorded") {
-      const jobId = text(payload, "job_id", "jobId") || row.job_url || "";
+      const jobId = text(payload, "job_id", "jobId") || row.job_id || "";
       const explicitSourceId = nullableText(value(payload, "source_id", "sourceId"));
       const sourceIds = explicitSourceId ? [explicitSourceId] : [...(sourcesByJob.get(jobId) ?? [])];
       const kind = text(payload, "kind");
@@ -5219,13 +4428,12 @@ function rebuildSourceQualityProjections(db: SqliteDatabase, tenantId: string): 
   }
 }
 
-function hasSourceQualityHistory(db: SqliteDatabase): boolean {
-  if (!tableExists(db, "job_events")) return false;
+function hasSourceQualityHistory(db: SqliteDatabase, tenantId: string): boolean {
   const row = getRow<{ c: number }>(
     db,
     `SELECT COUNT(*) AS c
      FROM job_events
-     WHERE event_type IN (
+     WHERE tenant_id = ? AND event_type IN (
        'DiscoveryRunStarted',
        'DiscoveryRunCompleted',
        'DiscoveryRunFailed',
@@ -5239,6 +4447,7 @@ function hasSourceQualityHistory(db: SqliteDatabase): boolean {
        'ContentDuplicateCandidateDetected',
        'DiscoveryFeedbackRecorded'
      )`,
+    [tenantId],
   );
   return Number(row?.c ?? 0) > 0;
 }
@@ -5255,69 +4464,30 @@ function parsePayload(raw: string | null): Record<string, unknown> {
   }
 }
 
-function hasColumn(db: SqliteDatabase, tableName: string, columnName: string): boolean {
-  return allRows<{ name: string }>(db, `PRAGMA table_info(${tableName})`).some(
-    (row) => row.name === columnName,
-  );
-}
-
-function columnOrLiteral(
-  db: SqliteDatabase,
-  tableName: string,
-  columnName: string,
-  fallbackSql: string,
-  alias: string,
-): string {
-  return hasColumn(db, tableName, columnName) ? `${alias}.${columnName}` : fallbackSql;
-}
-
 function jobMetadataJoinSql(
-  db: SqliteDatabase,
-  jobUrlExpression: string,
+  jobIdExpression: string,
+  tenantIdExpression: string,
 ): { selectSql: string; joinSql: string } {
-  if (!tableExists(db, "jobs")) {
-    return { selectSql: "NULL AS job_title, NULL AS employer", joinSql: "" };
-  }
-  const titleSql = columnOrLiteral(db, "jobs", "title", "NULL", "jobs");
-  const employerParts = [
-    hasColumn(db, "jobs", "company") ? "NULLIF(jobs.company, '')" : null,
-    hasColumn(db, "jobs", "site") ? "jobs.site" : null,
-  ].filter((part): part is string => Boolean(part));
-  const employerSql =
-    employerParts.length > 1
-      ? `COALESCE(${employerParts.join(", ")})`
-      : employerParts[0] ?? "NULL";
   return {
-    selectSql: `${titleSql} AS job_title, ${employerSql} AS employer`,
-    joinSql: `LEFT JOIN jobs ON jobs.url = ${jobUrlExpression}`,
+    selectSql: "jobs.title AS job_title, COALESCE(NULLIF(jobs.company, ''), jobs.site) AS employer",
+    joinSql: `LEFT JOIN jobs ON jobs.tenant_id = ${tenantIdExpression} AND jobs.job_id = ${jobIdExpression}`,
   };
 }
 
 // Anti-join fragments that exclude soft-deleted and hidden jobs from a
-// tenant-wide read, mirroring rebuildDashboardProjection. Guarded by
-// tableExists so callers work on databases where the TS write-model has not
-// created the lifecycle tables yet.
+// tenant-wide read, mirroring rebuildDashboardProjection.
 function jobLifecycleExclusionSql(
-  db: SqliteDatabase,
-  jobUrlExpression: string,
+  jobIdExpression: string,
+  tenantIdExpression: string,
 ): { joinSql: string; whereSql: string } {
-  const joins: string[] = [];
-  const wheres: string[] = [];
-  if (tableExists(db, "jobctrl_deleted_jobs")) {
-    joins.push(
-      `LEFT JOIN jobctrl_deleted_jobs d ON d.job_url = ${jobUrlExpression} AND (d.restored_at IS NULL OR julianday(d.restored_at) <= julianday(d.deleted_at))`,
-    );
-    wheres.push("d.job_url IS NULL");
-  }
-  if (tableExists(db, "jobctrl_hidden_jobs")) {
-    joins.push(
-      `LEFT JOIN jobctrl_hidden_jobs h ON h.job_url = ${jobUrlExpression} AND h.unhidden_at IS NULL`,
-    );
-    wheres.push("h.job_url IS NULL");
-  }
   return {
-    joinSql: joins.length ? ` ${joins.join(" ")}` : "",
-    whereSql: wheres.length ? ` AND ${wheres.join(" AND ")}` : "",
+    joinSql: ` LEFT JOIN jobctrl_deleted_jobs d
+      ON d.tenant_id = ${tenantIdExpression} AND d.job_id = ${jobIdExpression}
+      AND (d.restored_at IS NULL OR julianday(d.restored_at) <= julianday(d.deleted_at))
+      LEFT JOIN jobctrl_hidden_jobs h
+      ON h.tenant_id = ${tenantIdExpression} AND h.job_id = ${jobIdExpression}
+      AND h.unhidden_at IS NULL`,
+    whereSql: " AND d.job_id IS NULL AND h.job_id IS NULL",
   };
 }
 
@@ -5486,7 +4656,7 @@ function deriveApplyStatus(arStatus: string | null, legacyStatus: string | null)
 function deriveApplyMode(
   db: SqliteDatabase,
   tenantId: string,
-  jobUrl: string,
+  jobId: string,
   apply: ApplyLatest,
   legacyStatus: string | null,
   legacyAppliedAt: string | null,
@@ -5494,17 +4664,16 @@ function deriveApplyMode(
   if (apply.status === "succeeded" && !apply.dryRun) return "automated_live";
   const isApplied = Boolean(legacyAppliedAt) || legacyStatus === "applied";
   if (!isApplied) return null;
-  if (hasJobEvent(db, jobUrl, "ApplicationManuallyMarked")) return "manual_marked";
-  if (hasApplicationOutcomeKind(db, tenantId, jobUrl, "applied_confirmation")) return "external_confirmed";
+  if (hasJobEvent(db, tenantId, jobId, "ApplicationManuallyMarked")) return "manual_marked";
+  if (hasApplicationOutcomeKind(db, tenantId, jobId, "applied_confirmation")) return "external_confirmed";
   return "manual_marked";
 }
 
-function hasJobEvent(db: SqliteDatabase, jobUrl: string, eventType: string): boolean {
-  if (!tableExists(db, "job_events")) return false;
+function hasJobEvent(db: SqliteDatabase, tenantId: string, jobId: string, eventType: string): boolean {
   const row = getRow<{ c: number }>(
     db,
-    "SELECT COUNT(*) AS c FROM job_events WHERE job_url = ? AND event_type = ?",
-    [jobUrl, eventType],
+    "SELECT COUNT(*) AS c FROM job_events WHERE tenant_id = ? AND job_id = ? AND event_type = ?",
+    [tenantId, jobId, eventType],
   );
   return Number(row?.c ?? 0) > 0;
 }
@@ -5512,14 +4681,13 @@ function hasJobEvent(db: SqliteDatabase, jobUrl: string, eventType: string): boo
 function hasApplicationOutcomeKind(
   db: SqliteDatabase,
   tenantId: string,
-  jobUrl: string,
+  jobId: string,
   kind: string,
 ): boolean {
-  if (!tableExists(db, "application_outcomes")) return false;
   const row = getRow<{ c: number }>(
     db,
-    "SELECT COUNT(*) AS c FROM application_outcomes WHERE tenant_id = ? AND job_key = ? AND kind = ?",
-    [tenantId, jobUrl, kind],
+    "SELECT COUNT(*) AS c FROM application_outcomes WHERE tenant_id = ? AND job_id = ? AND kind = ?",
+    [tenantId, jobId, kind],
   );
   return Number(row?.c ?? 0) > 0;
 }

--- a/apps/api/src/projections.ts
+++ b/apps/api/src/projections.ts
@@ -2472,29 +2472,32 @@ function rebuildJobProjections(db: SqliteDatabase, tenantId: string, jobId: stri
   const firstActionable =
     stages.find((s) => !["succeeded", "skipped"].includes(s.state)) ?? stages[stages.length - 1];
 
-  const fitScore = score.fitScore ?? nullableNumber(job.fit_score);
-  const scoreReasoning = score.reasoning || stringField(job.score_reasoning);
+  const fitScore = score.fitScore;
+  const scoreReasoning = score.reasoning;
   const scoreBreakdownJson = score.breakdown ? JSON.stringify(score.breakdown) : null;
   const scoreKeywordsJson = JSON.stringify(score.keywords);
   const compensationProjection = buildExactV7CompensationProjection(jobId, nullableString(job.salary));
 
-  const hasCanonicalMaterials = materials.hasCanonicalHistory;
-  const tailorPath = hasCanonicalMaterials ? materials.tailorPath : nullableString(job.tailored_resume_path);
-  const coverPath = hasCanonicalMaterials ? materials.coverPath : nullableString(job.cover_letter_path);
-  const hasResume = Boolean(tailorPath);
-  const hasCoverLetter = Boolean(coverPath);
-  const hasPdf = Boolean(materials.resumePdfPath ?? materials.coverPdfPath);
+  const artifacts = collectArtifacts(db, tenantId, jobId, materials);
+  const resume = preferredArtifactSource(artifacts, ["tailored_resume"], materials.generation);
+  const coverLetter = preferredArtifactSource(artifacts, ["cover_letter"], materials.generation);
+  const resumePdf = preferredArtifactSource(artifacts, ["resume_pdf"], materials.generation);
+  const coverLetterPdf = preferredArtifactSource(artifacts, ["cover_letter_pdf"], materials.generation);
+  const hasResume = Boolean(resume);
+  const hasCoverLetter = Boolean(coverLetter);
+  const hasPdf = Boolean(resumePdf ?? coverLetterPdf);
 
-  const applyStatus = deriveApplyStatus(apply.status, nullableString(job.apply_status));
-  const appliedAt = apply.status === "succeeded" ? apply.finishedAt : nullableString(job.applied_at);
-  const applyMode = deriveApplyMode(db, tenantId, jobId, apply, nullableString(job.apply_status), nullableString(job.applied_at));
+  const explicitApplication = loadExplicitApplication(db, tenantId, jobId);
+  const applyStatus =
+    explicitApplication && apply.status !== "succeeded" ? "applied" : deriveApplyStatus(apply.status);
+  const appliedAt = apply.status === "succeeded" ? apply.finishedAt : explicitApplication?.occurredAt ?? null;
+  const applyMode = deriveApplyMode(apply, explicitApplication);
 
   const description = stringField(job.description);
   const fullDescription = enrichment.fullDescription ?? stringField(job.full_description);
 
   const lastUpdatedAt = new Date().toISOString();
 
-  const artifacts = collectArtifacts(db, tenantId, jobId, materials);
   const provenanceByArtifact = loadBulletProvenanceByArtifact(db, tenantId, jobId);
   const { coverage: coverageByArtifact, voice: voiceByArtifact } = loadProvenanceAuxByArtifact(
     db,
@@ -4682,53 +4685,54 @@ function previewText(value: string, limit: number): string {
   return value.length <= limit ? value : `${value.slice(0, limit)}...`;
 }
 
-function deriveApplyStatus(arStatus: string | null, legacyStatus: string | null): string | null {
+interface ExplicitApplication {
+  mode: "manual_marked" | "external_confirmed";
+  occurredAt: string;
+}
+
+function loadExplicitApplication(
+  db: SqliteDatabase,
+  tenantId: string,
+  jobId: string,
+): ExplicitApplication | null {
+  const manual = getRow<{ occurred_at: string | null }>(
+    db,
+    `SELECT occurred_at
+       FROM job_events
+      WHERE tenant_id = ? AND job_id = ? AND event_type = 'ApplicationManuallyMarked'
+      ORDER BY occurred_at DESC, event_id DESC
+      LIMIT 1`,
+    [tenantId, jobId],
+  );
+  const manuallyMarkedAt = nullableString(manual?.occurred_at);
+  if (manuallyMarkedAt) return { mode: "manual_marked", occurredAt: manuallyMarkedAt };
+
+  const confirmation = getRow<{ occurred_at: string | null }>(
+    db,
+    `SELECT occurred_at
+       FROM application_outcomes
+      WHERE tenant_id = ? AND job_id = ? AND kind = 'applied_confirmation'
+      ORDER BY occurred_at DESC, outcome_id DESC
+      LIMIT 1`,
+    [tenantId, jobId],
+  );
+  const confirmedAt = nullableString(confirmation?.occurred_at);
+  return confirmedAt ? { mode: "external_confirmed", occurredAt: confirmedAt } : null;
+}
+
+function deriveApplyStatus(arStatus: string | null): string | null {
   if (arStatus) {
     if (arStatus === "succeeded") return "applied";
     if (arStatus === "starting" || arStatus === "in_progress") return "in_progress";
     if (arStatus === "dry_run_complete") return "dry_run";
     return arStatus;
   }
-  return legacyStatus;
+  return null;
 }
 
-function deriveApplyMode(
-  db: SqliteDatabase,
-  tenantId: string,
-  jobId: string,
-  apply: ApplyLatest,
-  legacyStatus: string | null,
-  legacyAppliedAt: string | null,
-): string | null {
+function deriveApplyMode(apply: ApplyLatest, explicitApplication: ExplicitApplication | null): string | null {
   if (apply.status === "succeeded" && !apply.dryRun) return "automated_live";
-  const isApplied = Boolean(legacyAppliedAt) || legacyStatus === "applied";
-  if (!isApplied) return null;
-  if (hasJobEvent(db, tenantId, jobId, "ApplicationManuallyMarked")) return "manual_marked";
-  if (hasApplicationOutcomeKind(db, tenantId, jobId, "applied_confirmation")) return "external_confirmed";
-  return "manual_marked";
-}
-
-function hasJobEvent(db: SqliteDatabase, tenantId: string, jobId: string, eventType: string): boolean {
-  const row = getRow<{ c: number }>(
-    db,
-    "SELECT COUNT(*) AS c FROM job_events WHERE tenant_id = ? AND job_id = ? AND event_type = ?",
-    [tenantId, jobId, eventType],
-  );
-  return Number(row?.c ?? 0) > 0;
-}
-
-function hasApplicationOutcomeKind(
-  db: SqliteDatabase,
-  tenantId: string,
-  jobId: string,
-  kind: string,
-): boolean {
-  const row = getRow<{ c: number }>(
-    db,
-    "SELECT COUNT(*) AS c FROM application_outcomes WHERE tenant_id = ? AND job_id = ? AND kind = ?",
-    [tenantId, jobId, kind],
-  );
-  return Number(row?.c ?? 0) > 0;
+  return explicitApplication?.mode ?? null;
 }
 
 // Suppress unused import warning for SqliteValue (re-exported for consumers).

--- a/apps/api/src/projections.ts
+++ b/apps/api/src/projections.ts
@@ -3635,13 +3635,13 @@ function rebuildContactProjections(db: SqliteDatabase, tenantId: string): void {
   const contacts = allRows<{
     contact_id: string;
     employer: string | null;
-    job_url: string | null;
+    job_id: string | null;
     role: string | null;
     created_at: string | null;
     updated_at: string | null;
   }>(
     db,
-    `SELECT contact_id, employer, job_url, role, created_at, updated_at
+    `SELECT contact_id, employer, job_id, role, created_at, updated_at
      FROM contacts
      WHERE tenant_id = ? AND deleted_at IS NULL`,
     [tenantId],
@@ -3712,7 +3712,7 @@ function rebuildContactProjections(db: SqliteDatabase, tenantId: string): void {
       tenantId,
       contactId,
       contact.employer,
-      contact.job_url,
+      contact.job_id,
       String(contact.role ?? "other"),
       attributes.length,
       confirmed,
@@ -3774,7 +3774,7 @@ function rebuildContactResearchProjections(db: SqliteDatabase, tenantId: string)
   const tasks = allRows<{
     task_id: string;
     employer: string | null;
-    job_url: string | null;
+    job_id: string | null;
     status: string | null;
     source_attempts_json: string | null;
     started_at: string | null;
@@ -3785,7 +3785,7 @@ function rebuildContactResearchProjections(db: SqliteDatabase, tenantId: string)
     error_class: string | null;
   }>(
     db,
-    `SELECT task_id, employer, job_url, status, source_attempts_json,
+    `SELECT task_id, employer, job_id, status, source_attempts_json,
             started_at, updated_at, needs_review_at, completed_at, failed_at, error_class
      FROM contact_research_tasks
      WHERE tenant_id = ?`,
@@ -3867,7 +3867,7 @@ function rebuildContactResearchProjections(db: SqliteDatabase, tenantId: string)
       tenantId,
       taskId,
       task.employer,
-      task.job_url,
+      task.job_id,
       String(task.status ?? "queued"),
       candidateRows.length,
       needsReview,
@@ -3949,12 +3949,12 @@ function rebuildOutreachProjections(db: SqliteDatabase, tenantId: string): void 
   const threads = allRows<{
     thread_id: string;
     contact_id: string;
-    job_url: string | null;
+    job_id: string | null;
     created_at: string | null;
     updated_at: string | null;
   }>(
     db,
-    `SELECT thread_id, contact_id, job_url, created_at, updated_at
+    `SELECT thread_id, contact_id, job_id, created_at, updated_at
      FROM outreach_threads
      WHERE tenant_id = ?`,
     [tenantId],
@@ -4028,7 +4028,7 @@ function rebuildOutreachProjections(db: SqliteDatabase, tenantId: string): void 
       tenantId,
       threadId,
       String(thread.contact_id),
-      thread.job_url,
+      thread.job_id,
       draftRows.length,
       latestGeneration,
       hasApproved ? 1 : 0,
@@ -4069,7 +4069,7 @@ function rebuildDueFollowUpProjections(db: SqliteDatabase, tenantId: string): vo
   const threads = allRows<{
     thread_id: string;
     contact_id: string;
-    job_url: string | null;
+    job_id: string | null;
     follow_up_due_at: string | null;
     follow_up_basis: string | null;
     follow_up_state: string | null;
@@ -4077,7 +4077,7 @@ function rebuildDueFollowUpProjections(db: SqliteDatabase, tenantId: string): vo
     updated_at: string | null;
   }>(
     db,
-    `SELECT thread_id, contact_id, job_url, follow_up_due_at, follow_up_basis,
+    `SELECT thread_id, contact_id, job_id, follow_up_due_at, follow_up_basis,
             follow_up_state, created_at, updated_at
      FROM outreach_threads
      WHERE tenant_id = ? AND follow_up_state = 'scheduled'`,
@@ -4106,7 +4106,7 @@ function rebuildDueFollowUpProjections(db: SqliteDatabase, tenantId: string): vo
       tenantId,
       threadId,
       String(thread.contact_id),
-      thread.job_url,
+      thread.job_id,
       thread.follow_up_due_at,
       thread.follow_up_basis ?? "",
       String(thread.follow_up_state ?? "scheduled"),

--- a/apps/api/src/read-model.ts
+++ b/apps/api/src/read-model.ts
@@ -16,6 +16,8 @@
  */
 import fs from "node:fs";
 
+import type { JobId } from "@jobctrl/domain-types";
+
 import type {
   ActivityEventSummary,
   ActivityListQuery,
@@ -86,6 +88,7 @@ import { readJobCtrlSettings } from "./settings-config.js";
 
 const DEFAULT_TENANT = "local";
 const DEFAULT_PROFILE_ID = "default";
+const CANONICAL_JOB_ID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
 const CLOSED_ACTIVE_STATES = ["closed", "expired", "removed", "location_incompatible"] as const satisfies readonly ActiveState[];
 // Dashboard presentation policy: only old running rows are candidates for
 // "stuck", and only while the worker itself is unavailable. The threshold is
@@ -126,6 +129,7 @@ function sqlRankCase(column: string, ranks: Record<string, number>, fallback: nu
 interface JobListProjectionRow extends Record<string, unknown> {
   tenant_id: string;
   job_id: string;
+  url: string | null;
   title: string;
   employer: string;
   source: string;
@@ -423,26 +427,21 @@ function dashboardWorkSummary(db: SqliteDatabase): DashboardSummary["work"] {
     stuckAfterSeconds: DASHBOARD_STUCK_AFTER_SECONDS,
     stuckItems: [],
   };
-  if (!tableExists(db, "job_list_projections")) return empty;
-
-  const activeFilter = jobSqlFilter(db, digestBaseJobQuery());
-  const hasStageState = tableExists(db, "job_stage_states");
-  const stageColumns = hasStageState
-    ? "stage_state.started_at AS stage_started_at, stage_state.updated_at AS stage_updated_at"
-    : "NULL AS stage_started_at, NULL AS stage_updated_at";
-  const stageJoin = hasStageState
-    ? `LEFT JOIN job_stage_states AS stage_state
-         ON stage_state.job_url = job_list_projections.job_id
-        AND stage_state.stage = job_list_projections.current_substage`
-    : "";
+  const activeFilter = jobSqlFilter(digestBaseJobQuery());
   const rows = allRows<DashboardWorkRow>(
     db,
-    `SELECT job_id, title, employer, current_stage, current_substage, current_state,
-            ${stageColumns}
+    `SELECT job_list_projections.job_id, job_list_projections.title, job_list_projections.employer,
+            job_list_projections.current_stage, job_list_projections.current_substage,
+            job_list_projections.current_state,
+            stage_state.started_at AS stage_started_at,
+            stage_state.updated_at AS stage_updated_at
        FROM job_list_projections
-       ${stageJoin}
+       LEFT JOIN job_stage_states AS stage_state
+         ON stage_state.tenant_id = job_list_projections.tenant_id
+        AND stage_state.job_id = job_list_projections.job_id
+        AND stage_state.stage = job_list_projections.current_substage
        ${activeFilter.where}
-        AND current_state IN ('queued', 'running')`,
+        AND job_list_projections.current_state IN ('queued', 'running')`,
     activeFilter.params,
   );
 
@@ -454,7 +453,6 @@ function dashboardWorkSummary(db: SqliteDatabase): DashboardSummary["work"] {
   for (const row of rows) {
     if (
       row.current_state === "running" &&
-      hasStageState &&
       workerUnavailable &&
       dashboardWorkTimestampMs(row.stage_updated_at ?? row.stage_started_at) <= cutoffMs
     ) {
@@ -638,25 +636,20 @@ function recordDigestReviewedEvent(
     reviewedAt: string;
   },
 ): void {
-  if (!tableExists(db, "job_events")) return;
-  const columns = columnNames(db, "job_events");
-  const values: Record<string, SqliteValue> = {
-    job_url: null,
-    stage: null,
-    event_type: "DigestReviewed",
-    level: "info",
-    message: "Digest reviewed.",
-    occurred_at: payload.reviewedAt,
-    payload_json: JSON.stringify({
+  db.prepare(
+    `INSERT INTO job_events (
+       tenant_id, job_id, identity_version, stage, event_type, level,
+       message, occurred_at, payload_json, entity_kind, entity_ref, idempotency_key
+     ) VALUES (?, NULL, 1, NULL, 'DigestReviewed', 'info', ?, ?, ?, 'digest', 'daily', NULL)`,
+  ).run(
+    DEFAULT_TENANT,
+    "Digest reviewed.",
+    payload.reviewedAt,
+    JSON.stringify({
       tenantId: DEFAULT_TENANT,
       ...payload,
     }),
-  };
-  const entries = Object.entries(values).filter(([name]) => columns.has(name));
-  if (!entries.length) return;
-  db.prepare(
-    `INSERT INTO job_events (${entries.map(([name]) => name).join(", ")}) VALUES (${entries.map(() => "?").join(", ")})`,
-  ).run(...entries.map(([, value]) => value));
+  );
 }
 
 function normalizeDigestThreshold(value: number | null | undefined): number {
@@ -736,7 +729,7 @@ function countDigestNewMatches(
   since: string | null,
   highFitThreshold: number,
 ): DailyDigest["newMatches"] {
-  const activeFilter = jobSqlFilter(db, digestBaseJobQuery());
+  const activeFilter = jobSqlFilter(digestBaseJobQuery());
   const sinceClause = since ? " AND (discovered_at >= ? OR scored_at >= ?)" : "";
   const sinceParams: SqliteValue[] = since ? [since, since] : [];
   const where = `${activeFilter.where}${sinceClause}`;
@@ -778,24 +771,23 @@ const FOLLOW_UP_STOP_OUTCOMES = new Set([
 ]);
 
 function countFollowUpsDue(db: SqliteDatabase, now: Date): number {
-  if (!tableExists(db, "application_outcomes")) return 0;
   const cutoff = new Date(now.getTime() - DIGEST_FOLLOW_UP_THRESHOLD_DAYS * 24 * 60 * 60 * 1000).toISOString();
   const rows = allRows<{
-    job_key: string;
+    job_id: string;
     kind: string;
     occurred_at: string;
     recorded_at: string | null;
   }>(
     db,
-    `SELECT job_key, kind, occurred_at, recorded_at
+    `SELECT job_id, kind, occurred_at, recorded_at
        FROM application_outcomes
       WHERE tenant_id = ?
-      ORDER BY job_key ASC, occurred_at ASC, recorded_at ASC`,
+      ORDER BY job_id ASC, occurred_at ASC, recorded_at ASC`,
     [DEFAULT_TENANT],
   );
   const byJob = new Map<string, { appliedAt: string | null; lastActivityAt: string | null; stopped: boolean }>();
   for (const row of rows) {
-    const jobKey = row.job_key;
+    const jobKey = row.job_id;
     const current = byJob.get(jobKey) ?? {
       appliedAt: null,
       lastActivityAt: null,
@@ -841,7 +833,7 @@ function localDateKey(value: Date | string | null | undefined): string | null {
 function dashboardTodayMetrics(
   db: SqliteDatabase,
 ): Pick<DashboardSummary["totals"], "jobsToday" | "appliedToday"> {
-  const activeFilter = jobSqlFilter(db, {
+  const activeFilter = jobSqlFilter({
     page: 1,
     pageSize: 1,
     q: "",
@@ -872,7 +864,7 @@ function buildPreparationSummary(db: SqliteDatabase, tenantId: string): Preparat
   return {
     currentScoringPolicyVersion,
     currentTailoringPolicyVersion,
-    outdatedScoreCount: countOutdatedScores(db, tenantId, currentScoringPolicyVersion),
+    outdatedScoreCount: countOutdatedScores(db, tenantId),
     outdatedTailoredArtifactCount: countOutdatedTailoredArtifacts(db, tenantId, currentTailoringPolicyVersion),
     workItems: countPreparationWorkItems(db, tenantId),
   };
@@ -883,7 +875,6 @@ function latestPolicyVersion(
   tableName: "scoring_policies" | "tailoring_policies",
   tenantId: string,
 ): number | null {
-  if (!tableExists(db, tableName)) return null;
   const row = getRow<{ version: number | null }>(
     db,
     `SELECT MAX(version) AS version FROM ${tableName} WHERE tenant_id = ?`,
@@ -895,63 +886,30 @@ function latestPolicyVersion(
 function countOutdatedScores(
   db: SqliteDatabase,
   tenantId: string,
-  currentPolicyVersion: number | null,
 ): number {
-  const activeJobs = activeJobUrlSet(db);
+  const activeJobs = activeJobIdSet(db);
   if (activeJobs.size === 0) return 0;
 
-  if (tableExists(db, "job_score_staleness")) {
-    const rows = tableExists(db, "job_scores")
-      ? allRows<{ job_url: string }>(
-          db,
-          `SELECT DISTINCT stale.job_url
-             FROM job_score_staleness stale
-             JOIN (
-               SELECT job_url, MAX(version) AS max_version
-               FROM job_scores
-               WHERE tenant_id = ?
-               GROUP BY job_url
-             ) latest ON latest.job_url = stale.job_url
-             JOIN job_scores s
-               ON s.tenant_id = stale.tenant_id
-              AND s.job_url = stale.job_url
-              AND s.version = latest.max_version
-            WHERE stale.tenant_id = ?
-              AND stale.resolved = 0
-              AND (s.correction_json IS NULL OR TRIM(s.correction_json) = '')`,
-          [tenantId, tenantId],
-        )
-      : allRows<{ job_url: string }>(
-          db,
-          "SELECT DISTINCT job_url FROM job_score_staleness WHERE tenant_id = ? AND resolved = 0",
-          [tenantId],
-        );
-    return rows.filter((row) => activeJobs.has(row.job_url)).length;
-  }
-
-  if (currentPolicyVersion === null || !tableExists(db, "job_scores")) return 0;
-  const rows = allRows<{ job_url: string; trace_json: string | null; correction_json: string | null }>(
+  const rows = allRows<{ job_id: string }>(
     db,
-    `SELECT s.job_url, s.trace_json, s.correction_json
-       FROM job_scores s
+    `SELECT DISTINCT stale.job_id
+       FROM job_score_staleness stale
        JOIN (
-         SELECT job_url, MAX(version) AS max_version
+         SELECT job_id, MAX(version) AS max_version
          FROM job_scores
          WHERE tenant_id = ?
-         GROUP BY job_url
-       ) latest ON latest.job_url = s.job_url AND latest.max_version = s.version
-      WHERE s.tenant_id = ?`,
+         GROUP BY job_id
+       ) latest ON latest.job_id = stale.job_id
+       JOIN job_scores s
+         ON s.tenant_id = stale.tenant_id
+        AND s.job_id = stale.job_id
+        AND s.version = latest.max_version
+      WHERE stale.tenant_id = ?
+        AND stale.resolved = 0
+        AND (s.correction_json IS NULL OR TRIM(s.correction_json) = '')`,
     [tenantId, tenantId],
   );
-  return rows.filter((row) => {
-    if (!activeJobs.has(row.job_url)) return false;
-    if (row.correction_json?.trim()) return false;
-    const policyVersion = policyVersionFromJson(row.trace_json, [
-      "scoring_policy_version",
-      "scoringPolicyVersion",
-    ]);
-    return policyVersion === null || policyVersion < currentPolicyVersion;
-  }).length;
+  return rows.filter((row) => activeJobs.has(row.job_id)).length;
 }
 
 function countOutdatedTailoredArtifacts(
@@ -959,33 +917,29 @@ function countOutdatedTailoredArtifacts(
   tenantId: string,
   currentPolicyVersion: number | null,
 ): number {
-  if (
-    currentPolicyVersion === null ||
-    !tableExists(db, "job_materials") ||
-    !tableExists(db, "job_materials_artifacts")
-  ) {
-    return 0;
-  }
-  const activeJobs = activeJobUrlSet(db);
+  if (currentPolicyVersion === null) return 0;
+  const activeJobs = activeJobIdSet(db);
   if (activeJobs.size === 0) return 0;
-  const rows = allRows<{ job_url: string; metadata_json: string | null }>(
+  const rows = allRows<{ job_id: string; metadata_json: string | null }>(
     db,
     `WITH latest AS (
-       SELECT job_url, MAX(generation) AS max_generation
+       SELECT job_id, MAX(generation) AS max_generation
        FROM job_materials_artifacts
-       WHERE status = 'approved'
+       WHERE tenant_id = ?
+         AND status = 'approved'
          AND artifact_type = 'tailored_resume'
-       GROUP BY job_url
+       GROUP BY job_id
      )
-     SELECT a.job_url, a.metadata_json
+     SELECT a.job_id, a.metadata_json
        FROM job_materials_artifacts a
-       JOIN latest ON latest.job_url = a.job_url AND latest.max_generation = a.generation
-      WHERE a.artifact_type = 'tailored_resume'
+       JOIN latest ON latest.job_id = a.job_id AND latest.max_generation = a.generation
+      WHERE a.tenant_id = ?
+        AND a.artifact_type = 'tailored_resume'
         AND a.status = 'approved'`,
-    [],
+    [tenantId, tenantId],
   );
   return rows.filter((row) => {
-    if (!activeJobs.has(row.job_url)) return false;
+    if (!activeJobs.has(row.job_id)) return false;
     const policyVersion = policyVersionFromJson(row.metadata_json, [
       "tailoring_policy_version",
       "tailoringPolicyVersion",
@@ -999,8 +953,7 @@ function countPreparationWorkItems(
   tenantId: string,
 ): PreparationSummary["workItems"] {
   const counts: PreparationSummary["workItems"] = { queued: 0, running: 0, failed: 0 };
-  if (!tableExists(db, "preparation_work_items")) return counts;
-  const activeJobs = activeJobUrlSet(db);
+  const activeJobs = activeJobIdSet(db);
   if (activeJobs.size === 0) return counts;
   const rows = allRows<{ job_id: string; state: string }>(
     db,
@@ -1019,9 +972,8 @@ function countPreparationWorkItems(
   return counts;
 }
 
-function activeJobUrlSet(db: SqliteDatabase): Set<string> {
-  if (!tableExists(db, "job_list_projections")) return new Set();
-  const filter = jobSqlFilter(db, {
+function activeJobIdSet(db: SqliteDatabase): Set<string> {
+  const filter = jobSqlFilter({
     page: 1,
     pageSize: 1,
     q: "",
@@ -1055,8 +1007,8 @@ function policyVersionFromJson(value: string | null, fields: readonly string[]):
 export function listJobs(db: SqliteDatabase, query: JobListQuery): PaginatedResponse<JobSummary> {
   refreshProjections(db, DEFAULT_TENANT);
   const sortColumn = SQL_JOB_SORT_COLUMNS[query.sort] ?? "discovered_at";
-  const filter = jobSqlFilter(db, query);
-  const projectionSelect = jobProjectionSelect(db);
+  const filter = jobSqlFilter(query);
+  const projectionSelect = jobProjectionSelect();
 
   if (!query.q && !IN_MEMORY_JOB_SORT_FIELDS.has(query.sort)) {
     const total = countJobProjections(db, filter);
@@ -1092,10 +1044,10 @@ export function listJobs(db: SqliteDatabase, query: JobListQuery): PaginatedResp
 export function matchingJobKeys(db: SqliteDatabase, filter: Partial<BulkJobMutationFilter> = {}): string[] {
   const query = normalizeMutationFilter(filter);
   refreshProjections(db, DEFAULT_TENANT);
-  const sqlFilter = jobSqlFilter(db, query);
+  const sqlFilter = jobSqlFilter(query);
   const rows = allRows<JobListProjectionRow>(
     db,
-    `SELECT ${jobProjectionSelect(db)} FROM job_list_projections${sqlFilter.where}`,
+    `SELECT ${jobProjectionSelect()} FROM job_list_projections${sqlFilter.where}`,
     sqlFilter.params,
   );
   const normalizedQuery = query.q.toLowerCase();
@@ -1142,17 +1094,19 @@ export function getJobDetail(db: SqliteDatabase, jobKey: string): JobDetail | nu
   refreshProjections(db, DEFAULT_TENANT);
   const listRow = findJobListRow(db, jobKey);
   if (!listRow) return null;
+  const jobId = canonicalJobId(listRow.job_id);
+  if (!jobId) return null;
   const detailRow = getRow<JobDetailProjectionRow>(
     db,
     "SELECT * FROM job_detail_projections WHERE tenant_id = ? AND job_id = ?",
-    [DEFAULT_TENANT, listRow.job_id],
+    [DEFAULT_TENANT, jobId],
   );
-  const stages = reconcileStageRetryability(db, listRow.job_id, parseStages(detailRow?.stages_json));
-  const artifacts = artifactsForJob(db, listRow.job_id);
-  const auditHistory = buildJobAuditHistory(db, listRow.job_id);
+  const stages = reconcileStageRetryability(db, jobId, parseStages(detailRow?.stages_json));
+  const artifacts = artifactsForJob(db, jobId);
+  const auditHistory = buildJobAuditHistory(db, jobId);
   const jobSummary = rowToJobSummary(listRow, db);
-  const latestApplyRun = latestApplyRunForJob(db, listRow.job_id);
-  const activeApplyRun = activeApplyRunForJob(db, listRow.job_id);
+  const latestApplyRun = latestApplyRunForJob(db, jobId);
+  const activeApplyRun = activeApplyRunForJob(db, jobId);
   return {
     ok: true,
     job: {
@@ -1178,7 +1132,7 @@ export function getJobDetail(db: SqliteDatabase, jobKey: string): JobDetail | nu
           detailRow?.description_preview,
       ),
     }),
-    repeatApplication: evaluateRepeatApplication(db, listRow.job_id),
+    repeatApplication: evaluateRepeatApplication(db, jobId),
     activeApplyRun,
     stages,
     artifacts,
@@ -1191,9 +1145,6 @@ export function getJobDetail(db: SqliteDatabase, jobKey: string): JobDetail | nu
 }
 
 function latestApplyRunForJob(db: SqliteDatabase, jobId: string): ApplyAuditLatestRun | null {
-  if (!tableExists(db, "apply_run_projections")) {
-    return null;
-  }
   const row = getRow<ApplyRunProjectionRow>(
     db,
     `SELECT * FROM apply_run_projections
@@ -1214,9 +1165,6 @@ function latestApplyRunForJob(db: SqliteDatabase, jobId: string): ApplyAuditLate
  * projection row for this one job and retain the newest non-terminal run.
  */
 function activeApplyRunForJob(db: SqliteDatabase, jobId: string): ApplyAuditLatestRun | null {
-  if (!tableExists(db, "apply_run_projections")) {
-    return null;
-  }
   const rows = allRows<ApplyRunProjectionRow>(
     db,
     `SELECT * FROM apply_run_projections
@@ -1243,7 +1191,7 @@ function applyRunProjectionToAuditRun(row: ApplyRunProjectionRow): ApplyAuditLat
 }
 
 function applyAuditApplicationUrl(row: JobListProjectionRow): string | null {
-  return nullableString(row.application_url) ?? nullableString(row.job_id);
+  return nullableString(row.application_url) ?? nullableString(row.url);
 }
 
 /**
@@ -1334,7 +1282,7 @@ function containsLegacyJobKey(value: unknown): boolean {
 interface JobAuditEventRow extends Record<string, unknown> {
   event_id: number | string;
   event_type: string | null;
-  job_url: string | null;
+  job_id: string | null;
   stage: string | null;
   level: string | null;
   message: string | null;
@@ -1377,32 +1325,19 @@ function buildJobAuditHistory(db: SqliteDatabase, jobId: string): JobAuditEntry[
   const entries: JobAuditEntry[] = [];
   const seenReferences = new Set<string>();
 
-  if (tableExists(db, "job_events")) {
-    const rows = allRows<JobAuditEventRow>(
-      db,
-      `SELECT event_id, event_type, job_url, stage, level, message, occurred_at, payload_json
-         FROM job_events
-        WHERE job_url = ?
-           OR (
-             payload_json IS NOT NULL
-             AND json_valid(payload_json)
-             AND (
-               JSON_EXTRACT(payload_json, '$.jobId') = ?
-               OR JSON_EXTRACT(payload_json, '$.job_id') = ?
-               OR JSON_EXTRACT(payload_json, '$.jobKey') = ?
-               OR JSON_EXTRACT(payload_json, '$.job_key') = ?
-               OR JSON_EXTRACT(payload_json, '$.surviving_job_id') = ?
-             )
-           )
-        ORDER BY occurred_at ASC, event_id ASC`,
-      [jobId, jobId, jobId, jobId, jobId, jobId],
-    );
-    for (const row of rows) {
-      const payload = parseJsonRecord(row.payload_json) ?? {};
-      rememberAuditReferences(seenReferences, payload);
-      const entry = jobEventToAuditEntry(row, payload);
-      if (entry) entries.push(entry);
-    }
+  const rows = allRows<JobAuditEventRow>(
+    db,
+    `SELECT event_id, event_type, job_id, stage, level, message, occurred_at, payload_json
+       FROM job_events
+      WHERE tenant_id = ? AND job_id = ?
+      ORDER BY occurred_at ASC, event_id ASC`,
+    [DEFAULT_TENANT, jobId],
+  );
+  for (const row of rows) {
+    const payload = parseJsonRecord(row.payload_json) ?? {};
+    rememberAuditReferences(seenReferences, payload);
+    const entry = jobEventToAuditEntry(row, payload);
+    if (entry) entries.push(entry);
   }
 
   appendReviewDecisionAuditEntries(db, jobId, entries, seenReferences);
@@ -1435,12 +1370,11 @@ function appendReviewDecisionAuditEntries(
   entries: JobAuditEntry[],
   seenReferences: Set<string>,
 ): void {
-  if (!tableExists(db, "application_review_decisions")) return;
   const rows = allRows<ApplicationReviewDecisionAuditRow>(
     db,
     `SELECT decision_id, decision, reason, decided_by, decided_at
        FROM application_review_decisions
-      WHERE tenant_id = ? AND job_key = ?
+      WHERE tenant_id = ? AND job_id = ?
       ORDER BY decided_at ASC, decision_id ASC`,
     [DEFAULT_TENANT, jobId],
   );
@@ -1470,12 +1404,11 @@ function appendApplicationOutcomeAuditEntries(
   entries: JobAuditEntry[],
   seenReferences: Set<string>,
 ): void {
-  if (!tableExists(db, "application_outcomes")) return;
   const rows = allRows<ApplicationOutcomeAuditRow>(
     db,
     `SELECT outcome_id, kind, source, note, occurred_at, recorded_at, suggestion_id, evidence_id
        FROM application_outcomes
-      WHERE tenant_id = ? AND job_key = ?
+      WHERE tenant_id = ? AND job_id = ?
       ORDER BY occurred_at ASC, recorded_at ASC, outcome_id ASC`,
     [DEFAULT_TENANT, jobId],
   );
@@ -1508,13 +1441,12 @@ function appendOutcomeSuggestionAuditEntries(
   entries: JobAuditEntry[],
   seenReferences: Set<string>,
 ): void {
-  if (!tableExists(db, "application_outcome_suggestions")) return;
   const rows = allRows<OutcomeSuggestionAuditRow>(
     db,
     `SELECT suggestion_id, suggested_kind, confidence, status, created_at, decided_at,
             decision, decision_reason, decided_outcome_id
        FROM application_outcome_suggestions
-      WHERE tenant_id = ? AND job_key = ?
+      WHERE tenant_id = ? AND job_id = ?
       ORDER BY created_at ASC, suggestion_id ASC`,
     [DEFAULT_TENANT, jobId],
   );
@@ -2390,16 +2322,34 @@ function yesNo(value: boolean | null): string {
 function findJobListRow(db: SqliteDatabase, jobKey: string): JobListProjectionRow | null {
   const direct = getRow<JobListProjectionRow>(
     db,
-    `SELECT ${jobProjectionSelect(db)} FROM job_list_projections WHERE tenant_id = ? AND job_id = ?`,
+    `SELECT ${jobProjectionSelect()} FROM job_list_projections WHERE tenant_id = ? AND job_id = ?`,
     [DEFAULT_TENANT, jobKey],
   );
   if (direct) return direct;
-  // Fall back to application_url match for the "open via apply URL" case.
+  // URLs remain locators; canonical job ids remain the relation key.
   return (
     getRow<JobListProjectionRow>(
       db,
-      `SELECT ${jobProjectionSelect(db)} FROM job_list_projections WHERE tenant_id = ? AND application_url = ? LIMIT 1`,
-      [DEFAULT_TENANT, jobKey],
+      `SELECT ${jobProjectionSelect()}
+         FROM job_list_projections
+        WHERE job_list_projections.tenant_id = ?
+          AND (
+            job_list_projections.application_url = ?
+            OR EXISTS (
+              SELECT 1 FROM jobs j
+               WHERE j.tenant_id = job_list_projections.tenant_id
+                 AND j.job_id = job_list_projections.job_id
+                 AND (j.url = ? OR j.application_url = ?)
+            )
+            OR EXISTS (
+              SELECT 1 FROM job_locators l
+               WHERE l.tenant_id = job_list_projections.tenant_id
+                 AND l.job_id = job_list_projections.job_id
+                 AND l.locator_value = ?
+            )
+          )
+        LIMIT 1`,
+      [DEFAULT_TENANT, jobKey, jobKey, jobKey, jobKey],
     ) ?? null
   );
 }
@@ -2407,18 +2357,21 @@ function findJobListRow(db: SqliteDatabase, jobKey: string): JobListProjectionRo
 export function listArtifacts(db: SqliteDatabase, query: ArtifactListQuery): PaginatedResponse<ArtifactSummary> {
   refreshProjections(db, DEFAULT_TENANT);
   const normalizedQuery = query.q.toLowerCase();
-  const deletedJoin = tableExists(db, "jobctrl_deleted_jobs")
-    ? " LEFT JOIN jobctrl_deleted_jobs d ON d.job_url = ap.job_id AND (d.restored_at IS NULL OR julianday(d.restored_at) <= julianday(d.deleted_at))"
-    : "";
-  const hiddenJoin = tableExists(db, "jobctrl_hidden_jobs")
-    ? " LEFT JOIN jobctrl_hidden_jobs h ON h.job_url = ap.job_id AND h.unhidden_at IS NULL"
-    : "";
-  const deletedWhere = tableExists(db, "jobctrl_deleted_jobs") ? " AND d.job_url IS NULL" : "";
-  const hiddenWhere = tableExists(db, "jobctrl_hidden_jobs") ? " AND h.job_url IS NULL" : "";
   const rows = allRows<ArtifactProjectionRow>(
     db,
-    `SELECT ap.* FROM artifact_list_projections ap${deletedJoin}${hiddenJoin}
-     WHERE ap.tenant_id = ?${deletedWhere}${hiddenWhere}`,
+    `SELECT ap.*
+       FROM artifact_list_projections ap
+       LEFT JOIN jobctrl_deleted_jobs d
+         ON d.tenant_id = ap.tenant_id
+        AND d.job_id = ap.job_id
+        AND (d.restored_at IS NULL OR julianday(d.restored_at) <= julianday(d.deleted_at))
+       LEFT JOIN jobctrl_hidden_jobs h
+         ON h.tenant_id = ap.tenant_id
+        AND h.job_id = ap.job_id
+        AND h.unhidden_at IS NULL
+      WHERE ap.tenant_id = ?
+        AND d.job_id IS NULL
+        AND h.job_id IS NULL`,
     [DEFAULT_TENANT],
   );
   const artifacts = rows.map((row) => rowToArtifactSummary(row, db)).filter((artifact) => {
@@ -2531,10 +2484,10 @@ export function readSettingsConfig(
 // ============================================================== mappings
 
 function rowToJobSummary(row: JobListProjectionRow, db?: SqliteDatabase): JobSummary {
-  const jobKey = row.job_id;
+  const jobKey = requireCanonicalJobId(row.job_id);
   return {
     jobKey,
-    url: jobKey,
+    url: nullableString(row.url) ?? "",
     title: row.title || "Untitled",
     company: row.employer || "Unknown company",
     source: row.source || "unknown",
@@ -2571,6 +2524,19 @@ function rowToJobSummary(row: JobListProjectionRow, db?: SqliteDatabase): JobSum
     hiddenAt: row.hidden_at,
     resumeTemplate: db ? resumeTemplateStateForJob(db, jobKey) : null,
   };
+}
+
+function canonicalJobId(value: string | null | undefined): JobId | null {
+  const jobId = value?.trim() ?? "";
+  return CANONICAL_JOB_ID.test(jobId) ? (jobId as JobId) : null;
+}
+
+function requireCanonicalJobId(value: string): JobId {
+  const jobId = canonicalJobId(value);
+  if (!jobId) {
+    throw new Error("Exact v7 read models require canonical lowercase JobIds.");
+  }
+  return jobId;
 }
 
 function isActiveState(value: unknown): value is ActiveState {
@@ -3961,6 +3927,7 @@ function scoreDimension(value: unknown): number {
 }
 
 function rowToArtifactSummary(row: ArtifactProjectionRow, db?: SqliteDatabase): ArtifactSummary {
+  const jobId = canonicalJobId(row.job_id);
   const localPath = row.local_path ?? "";
   let sizeBytes = row.size_bytes;
   if (sizeBytes === null || sizeBytes === undefined) {
@@ -3982,7 +3949,8 @@ function rowToArtifactSummary(row: ArtifactProjectionRow, db?: SqliteDatabase): 
     sizeBytes,
     size: formatSize(sizeBytes),
     resumeTemplate: db
-      ? resumeTemplateStateForArtifact(db, row.job_id, row.metadata_json)
+      && jobId
+      ? resumeTemplateStateForArtifact(db, jobId, row.metadata_json)
       : null,
   };
 }
@@ -4529,16 +4497,15 @@ function reconcileStageRetryability(
 }
 
 function latestStageRetryabilityByEvent(db: SqliteDatabase, jobId: string): Map<Stage, boolean> {
-  if (!tableExists(db, "job_events")) return new Map();
   const rows = allRows<{ stage: string | null; payload_json: string | null }>(
     db,
     `SELECT stage, payload_json
      FROM job_events
-     WHERE job_url = ?
+     WHERE tenant_id = ? AND job_id = ?
        AND stage IS NOT NULL
        AND payload_json IS NOT NULL
      ORDER BY event_id ASC`,
-    [jobId],
+    [DEFAULT_TENANT, jobId],
   );
   const retryability = new Map<Stage, boolean>();
   for (const row of rows) {
@@ -4609,64 +4576,46 @@ function normalizeMutationFilter(filter: Partial<BulkJobMutationFilter>): JobLis
   };
 }
 
-function jobSqlFilter(db: SqliteDatabase, query: JobListQuery): { where: string; params: SqliteValue[] } {
-  const clauses: string[] = ["tenant_id = ?"];
+function jobSqlFilter(query: JobListQuery): { where: string; params: SqliteValue[] } {
+  const clauses: string[] = ["job_list_projections.tenant_id = ?"];
   const params: SqliteValue[] = [DEFAULT_TENANT];
-  const hasHiddenTable = tableExists(db, "jobctrl_hidden_jobs");
   const closedPredicate = closedActiveStatePredicate(
-    db,
     "job_list_projections.tenant_id",
     "job_list_projections.job_id",
   );
   if (query.deleted === "active") {
-    clauses.push("deleted_at IS NULL");
-    if (hasHiddenTable) {
-      clauses.push("NOT EXISTS (SELECT 1 FROM jobctrl_hidden_jobs h WHERE h.job_url = job_id AND h.unhidden_at IS NULL)");
-    }
-    if (closedPredicate) {
-      clauses.push(`NOT (${closedPredicate.sql})`);
-      params.push(...closedPredicate.params);
-    }
+    clauses.push("job_list_projections.deleted_at IS NULL");
+    clauses.push("NOT EXISTS (SELECT 1 FROM jobctrl_hidden_jobs h WHERE h.tenant_id = job_list_projections.tenant_id AND h.job_id = job_list_projections.job_id AND h.unhidden_at IS NULL)");
+    clauses.push(`NOT (${closedPredicate.sql})`);
+    params.push(...closedPredicate.params);
   } else if (query.deleted === "closed") {
-    clauses.push("deleted_at IS NULL");
-    if (hasHiddenTable) {
-      clauses.push("NOT EXISTS (SELECT 1 FROM jobctrl_hidden_jobs h WHERE h.job_url = job_id AND h.unhidden_at IS NULL)");
-    }
-    if (closedPredicate) {
-      clauses.push(closedPredicate.sql);
-      params.push(...closedPredicate.params);
-    } else {
-      clauses.push("1 = 0");
-    }
+    clauses.push("job_list_projections.deleted_at IS NULL");
+    clauses.push("NOT EXISTS (SELECT 1 FROM jobctrl_hidden_jobs h WHERE h.tenant_id = job_list_projections.tenant_id AND h.job_id = job_list_projections.job_id AND h.unhidden_at IS NULL)");
+    clauses.push(closedPredicate.sql);
+    params.push(...closedPredicate.params);
   } else if (query.deleted === "deleted") {
-    clauses.push("deleted_at IS NOT NULL");
-    if (hasHiddenTable) {
-      clauses.push("NOT EXISTS (SELECT 1 FROM jobctrl_hidden_jobs h WHERE h.job_url = job_id AND h.unhidden_at IS NULL)");
-    }
+    clauses.push("job_list_projections.deleted_at IS NOT NULL");
+    clauses.push("NOT EXISTS (SELECT 1 FROM jobctrl_hidden_jobs h WHERE h.tenant_id = job_list_projections.tenant_id AND h.job_id = job_list_projections.job_id AND h.unhidden_at IS NULL)");
   } else if (query.deleted === "hidden") {
-    clauses.push(
-      hasHiddenTable
-        ? "EXISTS (SELECT 1 FROM jobctrl_hidden_jobs h WHERE h.job_url = job_id AND h.unhidden_at IS NULL)"
-        : "1 = 0",
-    );
+    clauses.push("EXISTS (SELECT 1 FROM jobctrl_hidden_jobs h WHERE h.tenant_id = job_list_projections.tenant_id AND h.job_id = job_list_projections.job_id AND h.unhidden_at IS NULL)");
   }
   if (query.stage) {
-    clauses.push("current_stage = ?");
+    clauses.push("job_list_projections.current_stage = ?");
     params.push(query.stage);
   }
   if (query.state) {
-    clauses.push("current_state = ?");
+    clauses.push("job_list_projections.current_state = ?");
     params.push(query.state);
   }
   if (query.applyStatus === "applied") {
-    clauses.push("(applied_at IS NOT NULL OR LOWER(COALESCE(apply_status, '')) = 'applied')");
+    clauses.push("(job_list_projections.applied_at IS NOT NULL OR LOWER(COALESCE(job_list_projections.apply_status, '')) = 'applied')");
   }
   if (query.source) {
-    const postingSourceUrlSql = postingSourceUrlSqlExpression(db);
-    const postingSourceAtsKindSql = postingSourceAtsKindSqlExpression(db);
+    const postingSourceUrlSql = postingSourceUrlSqlExpression();
+    const postingSourceAtsKindSql = postingSourceAtsKindSqlExpression();
     clauses.push(
-      `(LOWER(source) LIKE ?
-        OR LOWER(${discoverySourceSqlExpression(db)}) LIKE ?
+      `(LOWER(job_list_projections.source) LIKE ?
+        OR LOWER(${discoverySourceSqlExpression()}) LIKE ?
         OR LOWER(COALESCE(${postingSourceUrlSql}, '')) LIKE ?
         OR LOWER(COALESCE(${postingSourceAtsKindSql}, '')) LIKE ?
         OR (
@@ -4687,105 +4636,98 @@ function jobSqlFilter(db: SqliteDatabase, query: JobListQuery): { where: string;
     );
   }
   if (query.company) {
-    clauses.push("LOWER(employer) LIKE ?");
+    clauses.push("LOWER(job_list_projections.employer) LIKE ?");
     params.push(`%${query.company.toLowerCase()}%`);
   }
   if (query.minFitScore !== undefined) {
-    clauses.push("COALESCE(fit_score, -1) >= ?");
+    clauses.push("COALESCE(job_list_projections.fit_score, -1) >= ?");
     params.push(query.minFitScore);
   }
   if (query.maxFitScore !== undefined) {
-    clauses.push("COALESCE(fit_score, 999) <= ?");
+    clauses.push("COALESCE(job_list_projections.fit_score, 999) <= ?");
     params.push(query.maxFitScore);
   }
   if (query.discoveredSince && query.scoredSince) {
     clauses.push(
-      "((discovered_at IS NOT NULL AND discovered_at >= ?) OR (scored_at IS NOT NULL AND scored_at >= ?))",
+      "((job_list_projections.discovered_at IS NOT NULL AND job_list_projections.discovered_at >= ?) OR (job_list_projections.scored_at IS NOT NULL AND job_list_projections.scored_at >= ?))",
     );
     params.push(query.discoveredSince, query.scoredSince);
   } else if (query.discoveredSince) {
-    clauses.push("discovered_at IS NOT NULL AND discovered_at >= ?");
+    clauses.push("job_list_projections.discovered_at IS NOT NULL AND job_list_projections.discovered_at >= ?");
     params.push(query.discoveredSince);
   } else if (query.scoredSince) {
-    clauses.push("scored_at IS NOT NULL AND scored_at >= ?");
+    clauses.push("job_list_projections.scored_at IS NOT NULL AND job_list_projections.scored_at >= ?");
     params.push(query.scoredSince);
   }
   return { where: ` WHERE ${clauses.join(" AND ")}`, params };
 }
 
 function closedActiveStatePredicate(
-  db: SqliteDatabase,
   tenantColumn: string,
   jobColumn: string,
-): { sql: string; params: SqliteValue[] } | null {
-  if (!tableExists(db, "posting_snapshot_sets")) {
-    return null;
-  }
+): { sql: string; params: SqliteValue[] } {
   const placeholders = CLOSED_ACTIVE_STATES.map(() => "?").join(", ");
   return {
     sql: `EXISTS (
       SELECT 1
       FROM posting_snapshot_sets pss
       WHERE pss.tenant_id = ${tenantColumn}
-        AND pss.job_url = ${jobColumn}
+        AND pss.job_id = ${jobColumn}
         AND pss.latest_active_state IN (${placeholders})
     )`,
     params: [...CLOSED_ACTIVE_STATES],
   };
 }
 
-function jobProjectionSelect(db: SqliteDatabase): string {
-  const hiddenSelect = tableExists(db, "jobctrl_hidden_jobs")
-    ? `(SELECT h.hidden_at
+function jobProjectionSelect(): string {
+  const hiddenSelect = `(SELECT h.hidden_at
           FROM jobctrl_hidden_jobs h
-         WHERE h.job_url = job_list_projections.job_id
+         WHERE h.tenant_id = job_list_projections.tenant_id
+           AND h.job_id = job_list_projections.job_id
            AND h.unhidden_at IS NULL
-         LIMIT 1) AS hidden_at`
-    : "NULL AS hidden_at";
-  const stalenessSelect = tableExists(db, "job_score_staleness")
-    ? `(SELECT s.stale_reason
+         LIMIT 1) AS hidden_at`;
+  const stalenessSelect = `(SELECT s.stale_reason
           FROM job_score_staleness s
          WHERE s.tenant_id = job_list_projections.tenant_id
-           AND s.job_url = job_list_projections.job_id
+           AND s.job_id = job_list_projections.job_id
            AND s.resolved = 0
          ORDER BY s.marked_at DESC
          LIMIT 1) AS score_stale_reason,
        (SELECT s.old_policy_version
-          FROM job_score_staleness s
+         FROM job_score_staleness s
          WHERE s.tenant_id = job_list_projections.tenant_id
-           AND s.job_url = job_list_projections.job_id
+           AND s.job_id = job_list_projections.job_id
            AND s.resolved = 0
          ORDER BY s.marked_at DESC
          LIMIT 1) AS score_stale_old_policy_version,
        (SELECT s.new_policy_version
-          FROM job_score_staleness s
+         FROM job_score_staleness s
          WHERE s.tenant_id = job_list_projections.tenant_id
-           AND s.job_url = job_list_projections.job_id
+           AND s.job_id = job_list_projections.job_id
            AND s.resolved = 0
          ORDER BY s.marked_at DESC
          LIMIT 1) AS score_stale_new_policy_version,
        (SELECT s.marked_at
-          FROM job_score_staleness s
+         FROM job_score_staleness s
          WHERE s.tenant_id = job_list_projections.tenant_id
-           AND s.job_url = job_list_projections.job_id
+           AND s.job_id = job_list_projections.job_id
            AND s.resolved = 0
          ORDER BY s.marked_at DESC
-         LIMIT 1) AS score_stale_marked_at`
-    : `NULL AS score_stale_reason,
-       NULL AS score_stale_old_policy_version,
-       NULL AS score_stale_new_policy_version,
-       NULL AS score_stale_marked_at`;
-  const activeStateSelect = tableExists(db, "posting_snapshot_sets")
-    ? `(SELECT pss.latest_active_state
+         LIMIT 1) AS score_stale_marked_at`;
+  const activeStateSelect = `(SELECT pss.latest_active_state
           FROM posting_snapshot_sets pss
          WHERE pss.tenant_id = job_list_projections.tenant_id
-           AND pss.job_url = job_list_projections.job_id
-         LIMIT 1) AS active_state`
-    : "'unknown' AS active_state";
+           AND pss.job_id = job_list_projections.job_id
+         LIMIT 1) AS active_state`;
   return `job_list_projections.*,
-          ${discoverySourceSqlExpression(db)} AS discovery_source,
-          ${postingSourceUrlSqlExpression(db)} AS posting_source_url,
-          ${postingSourceAtsKindSqlExpression(db)} AS posting_source_ats_kind,
+          (SELECT j.url
+             FROM jobs j
+            WHERE j.tenant_id = job_list_projections.tenant_id
+              AND j.job_id = job_list_projections.job_id
+            LIMIT 1) AS url,
+          ${discoverySourceSqlExpression()} AS discovery_source,
+          ${postingSourceUrlSqlExpression()} AS posting_source_url,
+          ${postingSourceAtsKindSqlExpression()} AS posting_source_ats_kind,
           ${activeStateSelect},
           ${hiddenSelect},
           ${stalenessSelect}`;
@@ -4816,8 +4758,8 @@ function discoverySourceFallbackSql(): string {
   return "CASE WHEN strategy = 'jobspy' AND source != '' THEN 'jobspy:' || LOWER(source) ELSE strategy END";
 }
 
-function discoverySourceSqlExpression(db: SqliteDatabase): string {
-  const observationSelect = tableExists(db, "job_source_observations") ? latestSourceObservationSql() : "NULL";
+function discoverySourceSqlExpression(): string {
+  const observationSelect = latestSourceObservationSql();
   return `CASE
             WHEN strategy = 'jobspy'
              AND COALESCE(${observationSelect}, '') != ''
@@ -4831,26 +4773,24 @@ function latestSourceObservationSql(): string {
   return `(SELECT o.source_id
              FROM job_source_observations o
             WHERE o.tenant_id = job_list_projections.tenant_id
-              AND o.job_url = job_list_projections.job_id
+              AND o.job_id = job_list_projections.job_id
             ORDER BY o.observed_at DESC, o.source_observation_id DESC
             LIMIT 1)`;
 }
 
-function postingSourceUrlSqlExpression(db: SqliteDatabase): string {
-  if (!tableExists(db, "job_canonical_identities")) return "NULL";
+function postingSourceUrlSqlExpression(): string {
   return `(SELECT c.canonical_url
              FROM job_canonical_identities c
             WHERE c.tenant_id = job_list_projections.tenant_id
-              AND c.job_url = job_list_projections.job_id
+              AND c.job_id = job_list_projections.job_id
             LIMIT 1)`;
 }
 
-function postingSourceAtsKindSqlExpression(db: SqliteDatabase): string {
-  if (!tableExists(db, "job_canonical_identities")) return "NULL";
+function postingSourceAtsKindSqlExpression(): string {
   return `(SELECT c.ats_kind
              FROM job_canonical_identities c
             WHERE c.tenant_id = job_list_projections.tenant_id
-              AND c.job_url = job_list_projections.job_id
+              AND c.job_id = job_list_projections.job_id
             LIMIT 1)`;
 }
 
@@ -5187,9 +5127,6 @@ function recentActivity(db: SqliteDatabase): DashboardSummary["activity"] {
 }
 
 function listPipelineProgress(db: SqliteDatabase): DashboardSummary["progress"] {
-  if (!tableExists(db, "job_events")) {
-    return [];
-  }
   const workflowRunStatus = loadPipelineWorkflowRunStatus(db);
   const rows = allRows<{
     stage: string | null;
@@ -5201,7 +5138,8 @@ function listPipelineProgress(db: SqliteDatabase): DashboardSummary["progress"] 
     db,
     `SELECT stage, event_type, message, occurred_at, payload_json
        FROM job_events
-      WHERE COALESCE(job_url, '') IN ('', 'pipeline')
+      WHERE tenant_id = ?
+        AND job_id IS NULL
         AND (
           event_type IN ('StageStarted', 'StageCompleted', 'StageFailed')
           OR (
@@ -5223,6 +5161,7 @@ function listPipelineProgress(db: SqliteDatabase): DashboardSummary["progress"] 
         )
       ORDER BY event_id DESC
       LIMIT 100`,
+    [DEFAULT_TENANT],
   );
   const byStage = new Map<Stage, DashboardSummary["progress"][number]>();
   for (const row of rows) {
@@ -5250,9 +5189,6 @@ interface PipelineWorkflowRunStatus {
 }
 
 function loadPipelineWorkflowRunStatus(db: SqliteDatabase): Map<string, PipelineWorkflowRunStatus> {
-  if (!tableExists(db, "workflow_run_projections")) {
-    return new Map();
-  }
   const lifecycleFolds = loadWorkflowRunLifecycleFolds(db);
   const rows = allRows<{
     workflow_id: string;
@@ -5552,23 +5488,14 @@ function listActivityFromEvents(
   db: SqliteDatabase,
   query: ActivityListQuery,
 ): PaginatedResponse<ActivityEventSummary> {
-  if (!tableExists(db, "job_events")) {
-    return paginateWithTotal([], 0, 1, query.pageSize, query.sort, query.dir, activityFilterPayload(query));
-  }
-  const eventColumns = columnNames(db, "job_events");
-  const eventTypeSelect = eventColumns.has("event_type") ? "e.event_type" : "'Event' AS event_type";
-  const eventTypePredicate = eventColumns.has("event_type") ? "COALESCE(e.event_type, '')" : "'Event'";
-  const hideDeletedJoin = tableExists(db, "jobctrl_deleted_jobs")
-    ? " LEFT JOIN jobctrl_deleted_jobs d ON d.job_url = e.job_url AND (d.restored_at IS NULL OR julianday(d.restored_at) <= julianday(d.deleted_at))"
-    : "";
-  const hideHiddenJoin = tableExists(db, "jobctrl_hidden_jobs")
-    ? " LEFT JOIN jobctrl_hidden_jobs h ON h.job_url = e.job_url AND h.unhidden_at IS NULL"
-    : "";
+  const eventTypeSelect = "e.event_type";
+  const eventTypePredicate = "COALESCE(e.event_type, '')";
   const activityClauses = [
-    "(e.job_url IS NULL OR e.job_url = '' OR jp.job_id IS NOT NULL)",
-    tableExists(db, "jobctrl_deleted_jobs") ? "d.job_url IS NULL" : "",
-    tableExists(db, "jobctrl_hidden_jobs") ? "h.job_url IS NULL" : "",
-  ].filter(Boolean);
+    "e.tenant_id = ?",
+    "(e.job_id IS NULL OR jp.job_id IS NOT NULL)",
+    "d.job_id IS NULL",
+    "h.job_id IS NULL",
+  ];
   const params: SqliteValue[] = [DEFAULT_TENANT];
   if (query.level) {
     activityClauses.push("LOWER(COALESCE(e.level, '')) = LOWER(?)");
@@ -5592,7 +5519,7 @@ function listActivityFromEvents(
       OR LOWER(COALESCE(e.message, '')) LIKE ?
       OR LOWER(COALESCE(jp.title, '')) LIKE ?
       OR LOWER(COALESCE(jp.employer, '')) LIKE ?
-      OR LOWER(COALESCE(e.job_url, '')) LIKE ?
+      OR LOWER(COALESCE(e.job_id, '')) LIKE ?
       OR LOWER(CAST(e.event_id AS TEXT)) LIKE ?
       OR LOWER(COALESCE(e.occurred_at, '')) LIKE ?
     )`);
@@ -5601,9 +5528,16 @@ function listActivityFromEvents(
   const activityWhere = `WHERE ${activityClauses.join(" AND ")}`;
   const fromSql = `
     FROM job_events e
-    LEFT JOIN job_list_projections jp ON jp.tenant_id = ? AND jp.job_id = e.job_url
-    ${hideDeletedJoin}
-    ${hideHiddenJoin}
+    LEFT JOIN job_list_projections jp
+      ON jp.tenant_id = e.tenant_id AND jp.job_id = e.job_id
+    LEFT JOIN jobctrl_deleted_jobs d
+      ON d.tenant_id = e.tenant_id
+     AND d.job_id = e.job_id
+     AND (d.restored_at IS NULL OR julianday(d.restored_at) <= julianday(d.deleted_at))
+    LEFT JOIN jobctrl_hidden_jobs h
+      ON h.tenant_id = e.tenant_id
+     AND h.job_id = e.job_id
+     AND h.unhidden_at IS NULL
     ${activityWhere}`;
   const total = countRows(db, `SELECT COUNT(*) AS count ${fromSql}`, params);
   const pages = Math.max(1, Math.ceil(total / query.pageSize));
@@ -5615,7 +5549,7 @@ function listActivityFromEvents(
     SELECT
       e.event_id,
       ${eventTypeSelect},
-      e.job_url,
+      e.job_id,
       e.stage,
       e.level,
       e.message,
@@ -5642,27 +5576,20 @@ function listActivityFromEvents(
 }
 
 function getActivityEventFromEvents(db: SqliteDatabase, eventId: string): ActivityEventSummary | null {
-  if (!tableExists(db, "job_events")) return null;
-  const eventColumns = columnNames(db, "job_events");
-  const eventTypeSelect = eventColumns.has("event_type") ? "e.event_type" : "'Event' AS event_type";
-  const hideDeletedJoin = tableExists(db, "jobctrl_deleted_jobs")
-    ? " LEFT JOIN jobctrl_deleted_jobs d ON d.job_url = e.job_url AND (d.restored_at IS NULL OR julianday(d.restored_at) <= julianday(d.deleted_at))"
-    : "";
-  const hideHiddenJoin = tableExists(db, "jobctrl_hidden_jobs")
-    ? " LEFT JOIN jobctrl_hidden_jobs h ON h.job_url = e.job_url AND h.unhidden_at IS NULL"
-    : "";
+  const eventTypeSelect = "e.event_type";
   const activityClauses = [
     "e.event_id = ?",
-    "(e.job_url IS NULL OR e.job_url = '' OR jp.job_id IS NOT NULL)",
-    tableExists(db, "jobctrl_deleted_jobs") ? "d.job_url IS NULL" : "",
-    tableExists(db, "jobctrl_hidden_jobs") ? "h.job_url IS NULL" : "",
-  ].filter(Boolean);
+    "e.tenant_id = ?",
+    "(e.job_id IS NULL OR jp.job_id IS NOT NULL)",
+    "d.job_id IS NULL",
+    "h.job_id IS NULL",
+  ];
   const row = getRow<Record<string, unknown>>(
     db,
     `SELECT
        e.event_id,
        ${eventTypeSelect},
-       e.job_url,
+       e.job_id,
        e.stage,
        e.level,
        e.message,
@@ -5670,12 +5597,19 @@ function getActivityEventFromEvents(db: SqliteDatabase, eventId: string): Activi
        jp.title    AS title,
        jp.employer AS employer
      FROM job_events e
-     LEFT JOIN job_list_projections jp ON jp.tenant_id = ? AND jp.job_id = e.job_url
-     ${hideDeletedJoin}
-     ${hideHiddenJoin}
+     LEFT JOIN job_list_projections jp
+       ON jp.tenant_id = e.tenant_id AND jp.job_id = e.job_id
+     LEFT JOIN jobctrl_deleted_jobs d
+       ON d.tenant_id = e.tenant_id
+      AND d.job_id = e.job_id
+      AND (d.restored_at IS NULL OR julianday(d.restored_at) <= julianday(d.deleted_at))
+     LEFT JOIN jobctrl_hidden_jobs h
+       ON h.tenant_id = e.tenant_id
+      AND h.job_id = e.job_id
+      AND h.unhidden_at IS NULL
      WHERE ${activityClauses.join(" AND ")}
      LIMIT 1`,
-    [DEFAULT_TENANT, eventId],
+    [eventId, DEFAULT_TENANT],
   );
   return row ? activityRowToSummary(row) : null;
 }
@@ -5693,7 +5627,7 @@ function activityRowToSummary(row: Record<string, unknown>): ActivityEventSummar
   return {
     eventId: stringField(row.event_id),
     eventType: stringField(row.event_type) || "Event",
-    jobKey: nullableString(row.job_url),
+    jobKey: nullableString(row.job_id),
     title: nullableString(row.title),
     company: nullableString(row.employer),
     stage: stringField(row.stage) || "system",
@@ -5701,11 +5635,6 @@ function activityRowToSummary(row: Record<string, unknown>): ActivityEventSummar
     message: stringField(row.message) || "event",
     at: nullableString(row.occurred_at),
   };
-}
-
-function columnNames(db: SqliteDatabase, tableName: string): Set<string> {
-  if (!tableExists(db, tableName)) return new Set();
-  return new Set(allRows<{ name: string }>(db, `PRAGMA table_info(${tableName})`).map((row) => row.name));
 }
 
 /**
@@ -5766,17 +5695,14 @@ interface WorkflowLifecycleEvent {
 
 function loadWorkflowRunLifecycleFolds(db: SqliteDatabase): Map<string, WorkflowLifecycleFold> {
   const folds = new Map<string, WorkflowLifecycleFold>();
-  if (!tableExists(db, "job_events")) {
-    return folds;
-  }
   const placeholders = WORKFLOW_LIFECYCLE_EVENT_TYPES.map(() => "?").join(", ");
   const rows = allRows<{ event_type: string; occurred_at: string | null; payload_json: string | null }>(
     db,
     `SELECT event_type, occurred_at, payload_json
        FROM job_events
-      WHERE event_type IN (${placeholders})
+      WHERE tenant_id = ? AND event_type IN (${placeholders})
       ORDER BY event_id ASC`,
-    [...WORKFLOW_LIFECYCLE_EVENT_TYPES],
+    [DEFAULT_TENANT, ...WORKFLOW_LIFECYCLE_EVENT_TYPES],
   );
   const byWorkflow = new Map<string, WorkflowLifecycleEvent[]>();
   for (const row of rows) {
@@ -5947,36 +5873,24 @@ export function listWorkflowRuns(
   query: WorkflowRunsListQuery,
 ): PaginatedResponse<WorkflowRunSummary> {
   refreshProjections(db, DEFAULT_TENANT);
-  if (!tableExists(db, "workflow_run_projections")) {
-    return paginate([], query.page, query.pageSize, query.sort, query.dir, workflowRunsFilterPayload(query));
-  }
-  const hasApply = tableExists(db, "apply_run_projections");
-  const applyJoin = hasApply
-    ? ` LEFT JOIN apply_run_projections arp ON arp.run_id = wrp.workflow_id`
-    : "";
-  const applySelect = hasApply
-    ? `, arp.job_id AS apply_job_id, arp.job_title AS job_title,
+  const applyJoin = ` LEFT JOIN apply_run_projections arp
+    ON arp.tenant_id = wrp.tenant_id AND arp.run_id = wrp.workflow_id`;
+  const applySelect = `, arp.job_id AS apply_job_id, arp.job_title AS job_title,
        arp.job_employer AS job_employer, arp.dry_run AS apply_dry_run,
-       arp.model AS apply_model, arp.result AS apply_result`
-    : "";
+       arp.model AS apply_model, arp.result AS apply_result`;
   // Deleted / hidden filters apply to the enriched apply job only; non-apply
   // rows have a NULL apply_job_id and pass through untouched.
-  const deletedJoin =
-    hasApply && tableExists(db, "jobctrl_deleted_jobs")
-      ? " LEFT JOIN jobctrl_deleted_jobs d ON d.job_url = arp.job_id AND (d.restored_at IS NULL OR julianday(d.restored_at) <= julianday(d.deleted_at))"
-      : "";
-  const hiddenJoin =
-    hasApply && tableExists(db, "jobctrl_hidden_jobs")
-      ? " LEFT JOIN jobctrl_hidden_jobs h ON h.job_url = arp.job_id AND h.unhidden_at IS NULL"
-      : "";
+  const deletedJoin = ` LEFT JOIN jobctrl_deleted_jobs d
+    ON d.tenant_id = arp.tenant_id
+   AND d.job_id = arp.job_id
+   AND (d.restored_at IS NULL OR julianday(d.restored_at) <= julianday(d.deleted_at))`;
+  const hiddenJoin = ` LEFT JOIN jobctrl_hidden_jobs h
+    ON h.tenant_id = arp.tenant_id
+   AND h.job_id = arp.job_id
+   AND h.unhidden_at IS NULL`;
   const where: string[] = ["wrp.tenant_id = ?"];
   const params: SqliteValue[] = [DEFAULT_TENANT];
-  if (deletedJoin) {
-    where.push("d.job_url IS NULL");
-  }
-  if (hiddenJoin) {
-    where.push("h.job_url IS NULL");
-  }
+  where.push("d.job_id IS NULL", "h.job_id IS NULL");
   const whereSql = where.length ? ` WHERE ${where.join(" AND ")}` : "";
   const rows = allRows<WorkflowRunProjectionRow>(
     db,
@@ -6021,18 +5935,11 @@ export function getWorkflowRunDetail(
   runId: string,
 ): WorkflowRunDetail | null {
   refreshProjections(db, DEFAULT_TENANT);
-  if (!tableExists(db, "workflow_run_projections")) {
-    return null;
-  }
-  const hasApply = tableExists(db, "apply_run_projections");
-  const applyJoin = hasApply
-    ? ` LEFT JOIN apply_run_projections arp ON arp.run_id = wrp.workflow_id`
-    : "";
-  const applySelect = hasApply
-    ? `, arp.job_id AS apply_job_id, arp.job_title AS job_title,
+  const applyJoin = ` LEFT JOIN apply_run_projections arp
+    ON arp.tenant_id = wrp.tenant_id AND arp.run_id = wrp.workflow_id`;
+  const applySelect = `, arp.job_id AS apply_job_id, arp.job_title AS job_title,
        arp.job_employer AS job_employer, arp.dry_run AS apply_dry_run,
-       arp.model AS apply_model, arp.result AS apply_result`
-    : "";
+       arp.model AS apply_model, arp.result AS apply_result`;
   const rawRow = getRow<WorkflowRunProjectionRow>(
     db,
     `SELECT wrp.*${applySelect} FROM workflow_run_projections wrp${applyJoin}
@@ -6179,18 +6086,21 @@ function normalizeWorkflowRunStatus(value: unknown): WorkflowRunStatus {
 function recentApplyRuns(db: SqliteDatabase): DashboardSummary["applyRuns"] {
   // L3 (round-1 review): caller (``buildDashboardSummary``) already
   // refreshed projections; do not double-refresh here.
-  const deletedJoin = tableExists(db, "jobctrl_deleted_jobs")
-    ? " LEFT JOIN jobctrl_deleted_jobs d ON d.job_url = arp.job_id AND (d.restored_at IS NULL OR julianday(d.restored_at) <= julianday(d.deleted_at))"
-    : "";
-  const hiddenJoin = tableExists(db, "jobctrl_hidden_jobs")
-    ? " LEFT JOIN jobctrl_hidden_jobs h ON h.job_url = arp.job_id AND h.unhidden_at IS NULL"
-    : "";
-  const deletedWhere = tableExists(db, "jobctrl_deleted_jobs") ? " AND d.job_url IS NULL" : "";
-  const hiddenWhere = tableExists(db, "jobctrl_hidden_jobs") ? " AND h.job_url IS NULL" : "";
   const rows = allRows<ApplyRunProjectionRow>(
     db,
-    `SELECT arp.* FROM apply_run_projections arp${deletedJoin}${hiddenJoin}
-     WHERE arp.tenant_id = ?${deletedWhere}${hiddenWhere}
+    `SELECT arp.*
+       FROM apply_run_projections arp
+       LEFT JOIN jobctrl_deleted_jobs d
+         ON d.tenant_id = arp.tenant_id
+        AND d.job_id = arp.job_id
+        AND (d.restored_at IS NULL OR julianday(d.restored_at) <= julianday(d.deleted_at))
+       LEFT JOIN jobctrl_hidden_jobs h
+         ON h.tenant_id = arp.tenant_id
+        AND h.job_id = arp.job_id
+        AND h.unhidden_at IS NULL
+      WHERE arp.tenant_id = ?
+        AND d.job_id IS NULL
+        AND h.job_id IS NULL
      ORDER BY arp.started_at DESC LIMIT 12`,
     [DEFAULT_TENANT],
   );

--- a/apps/api/test/audit-projection-parity.test.ts
+++ b/apps/api/test/audit-projection-parity.test.ts
@@ -138,6 +138,27 @@ function withExactV7JobIds<T>(value: T): T {
   return value;
 }
 
+function withExactV7ProjectionContract(
+  value: Record<ProjectionTable, Record<string, unknown>>,
+): Record<ProjectionTable, Record<string, unknown>> {
+  const converted = withExactV7JobIds(value);
+  converted.jobList.apply_mode = "automated_live";
+  const outcomeConversion = converted.dashboard.outcome_conversion_json as {
+    byApplyMode: Array<Record<string, unknown>>;
+  };
+  outcomeConversion.byApplyMode = [
+    {
+      applyMode: "automated_live",
+      applied: 3,
+      reply: 3,
+      interview: 2,
+      offer: 1,
+      rejection: 1,
+    },
+  ];
+  return converted;
+}
+
 function withTempDb(): { dbPath: string; cleanup: () => void } {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "jobctrl-api-audit-parity-"));
   const dbPath = path.join(dir, "jobs.db");
@@ -145,6 +166,21 @@ function withTempDb(): { dbPath: string; cleanup: () => void } {
     dbPath,
     cleanup: () => fs.rmSync(dir, { recursive: true, force: true }),
   };
+}
+
+function insertApplyRunProjection(
+  db: Database.Database,
+  jobId: string,
+  startedAt: string,
+  finishedAt: string,
+): void {
+  const runId = `apply:${jobId}`;
+  db.prepare(
+    `INSERT INTO apply_run_projections (
+       run_id, tenant_id, job_id, job_title, job_employer, status, result,
+       dry_run, started_at, finished_at, events_json
+     ) VALUES (?, 'local', ?, '', '', 'succeeded', 'applied', 0, ?, ?, '[]')`,
+  ).run(runId, jobId, startedAt, finishedAt);
 }
 
 /** Seed the canonical rows exactly as the Python repositories write them. */
@@ -290,6 +326,7 @@ function seedRows(dbPath: string): void {
        tenant_id, job_id, identity_version, stage, event_type, level, message, occurred_at, payload_json
      ) VALUES ('local', ?, 1, 'tailor', 'ResumeApproved', 'info', 'approved', ?, '{}')`,
   ).run(jobId, createdAt);
+  insertApplyRunProjection(db, jobId, fixture.job.discoveredAt, fixture.job.appliedAt);
   db.prepare(
     `INSERT INTO resume_templates (
        tenant_id, template_id, display_name, status, built_in, created_at, updated_at
@@ -381,6 +418,12 @@ function seedRows(dbPath: string): void {
     `INSERT INTO jobs (tenant_id, job_id, url, title, site, fit_score, apply_status, applied_at, discovered_at)
      VALUES ('local', @job_id, @url, @title, @site, @fit_score, 'applied', @applied_at, @discovered_at)`,
   );
+  const insertConversionScore = db.prepare(
+    `INSERT INTO job_scores (
+       job_id, version, tenant_id, fit_score, breakdown_json, keywords_json,
+       scored_at, correction_json, criteria_json, trace_json
+     ) VALUES (@job_id, 1, 'local', @fit_score, '{}', '[]', @scored_at, NULL, '{}', '{}')`,
+  );
   const insertConversionStage = db.prepare(
     `INSERT INTO job_stage_states (
        job_id, stage, state, attempt_count, max_attempts, started_at, updated_at,
@@ -398,6 +441,12 @@ function seedRows(dbPath: string): void {
       applied_at: job.appliedAt,
       discovered_at: job.discoveredAt,
     });
+    insertConversionScore.run({
+      job_id: conversionJobId,
+      fit_score: job.fitScore,
+      scored_at: job.appliedAt,
+    });
+    insertApplyRunProjection(db, conversionJobId, String(job.discoveredAt), String(job.appliedAt));
     for (const [stage, maxAttempts] of conversionStages) {
       insertConversionStage.run({
         job_id: conversionJobId,
@@ -638,7 +687,7 @@ describe("Cross-runtime projection parity (AUDIT-02)", () => {
             expect(row, `${table} projection row missing`).toBeTruthy();
             const jsonCols = fixture.projectionParity.jsonColumns[table];
             const nonDet = fixture.projectionParity.nonDeterministicColumns[table];
-            const expectedCols = fixture.expectedProjections[table];
+            const expectedCols = withExactV7ProjectionContract(fixture.expectedProjections)[table];
 
             // Column-set parity guard: the columns the builder emits must be
             // exactly the fixture's deterministic keys plus the wall-clock columns.
@@ -651,11 +700,9 @@ describe("Cross-runtime projection parity (AUDIT-02)", () => {
             for (const column of nonDet) {
               expect(row![column], `${table}.${column} not populated`).toBeTruthy();
             }
-            const expected = withExactV7JobIds(
-              table === "jobList"
-                ? { ...expectedCols, artifact_count: fixture.rows.artifacts.length }
-                : expectedCols,
-            );
+            const expected = table === "jobList"
+              ? { ...expectedCols, artifact_count: fixture.rows.artifacts.length }
+              : expectedCols;
             expect(normalizeRow(row!, jsonCols, nonDet)).toEqual(expected);
           }
         } finally {

--- a/apps/api/test/audit-projection-parity.test.ts
+++ b/apps/api/test/audit-projection-parity.test.ts
@@ -28,7 +28,9 @@ import fs from "node:fs";
 import { fileURLToPath } from "node:url";
 import Database from "better-sqlite3";
 
+import { BUILT_IN_RESUME_TEMPLATE_THEME } from "../src/resume-templates.js";
 import { buildApp } from "../src/server.js";
+import { initializeExactV7Database } from "./v7-schema.js";
 
 const FIXTURE_PATH = fileURLToPath(
   new URL("../../../packages/domain-types/test/fixtures/audit_projection_parity.json", import.meta.url),
@@ -100,6 +102,42 @@ interface Fixture {
 
 const fixture = JSON.parse(fs.readFileSync(FIXTURE_PATH, "utf8")) as Fixture;
 
+const FIXTURE_JOB_IDS = [
+  "30000000-0000-4000-8000-000000000001",
+  "30000000-0000-4000-8000-000000000002",
+  "30000000-0000-4000-8000-000000000003",
+  "30000000-0000-4000-8000-000000000004",
+  "30000000-0000-4000-8000-000000000005",
+] as const;
+const fixtureJobIdsByUrl = new Map(
+  [
+    fixture.job.url,
+    ...fixture.dashboardAggregateJobs.map((job) => job.url),
+    ...fixture.rows.conversionJobs.map((job) => String(job.url)),
+  ].map((url, index) => [url, FIXTURE_JOB_IDS[index]!] as const),
+);
+
+function fixtureJobId(url: string): string {
+  const jobId = fixtureJobIdsByUrl.get(url);
+  if (!jobId) throw new Error(`missing exact-v7 JobId for fixture URL: ${url}`);
+  return jobId;
+}
+
+function withExactV7JobIds<T>(value: T): T {
+  if (typeof value === "string") {
+    return (fixtureJobIdsByUrl.get(value) ?? value) as T;
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => withExactV7JobIds(item)) as T;
+  }
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, item]) => [key, withExactV7JobIds(item)]),
+    ) as T;
+  }
+  return value;
+}
+
 function withTempDb(): { dbPath: string; cleanup: () => void } {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "jobctrl-api-audit-parity-"));
   const dbPath = path.join(dir, "jobs.db");
@@ -109,249 +147,22 @@ function withTempDb(): { dbPath: string; cleanup: () => void } {
   };
 }
 
-/** Create the minimal canonical schema the projection builder reads from. */
-function seedSchema(dbPath: string): void {
-  const db = new Database(dbPath);
-  db.exec(`
-    CREATE TABLE jobs (
-      url TEXT PRIMARY KEY,
-      title TEXT,
-      company TEXT,
-      salary TEXT,
-      description TEXT,
-      location TEXT,
-      site TEXT,
-      strategy TEXT,
-      discovered_at TEXT,
-      full_description TEXT,
-      application_url TEXT,
-      detail_scraped_at TEXT,
-      detail_error TEXT,
-      fit_score INTEGER,
-      score_reasoning TEXT,
-      scored_at TEXT,
-      tailored_resume_path TEXT,
-      tailored_at TEXT,
-      tailor_attempts INTEGER DEFAULT 0,
-      cover_letter_path TEXT,
-      cover_letter_at TEXT,
-      cover_attempts INTEGER DEFAULT 0,
-      applied_at TEXT,
-      apply_status TEXT,
-      apply_error TEXT,
-      apply_attempts INTEGER DEFAULT 0
-    );
-    CREATE TABLE job_events (
-      event_id INTEGER PRIMARY KEY AUTOINCREMENT,
-      job_url TEXT,
-      stage TEXT,
-      event_type TEXT NOT NULL DEFAULT '',
-      level TEXT NOT NULL DEFAULT 'info',
-      message TEXT,
-      occurred_at TEXT NOT NULL,
-      payload_json TEXT
-    );
-    CREATE TABLE job_scores (
-      job_url TEXT NOT NULL,
-      version INTEGER NOT NULL,
-      tenant_id TEXT NOT NULL DEFAULT 'local',
-      fit_score INTEGER NOT NULL,
-      breakdown_json TEXT NOT NULL,
-      keywords_json TEXT NOT NULL,
-      scored_at TEXT NOT NULL,
-      correction_json TEXT,
-      criteria_json TEXT NOT NULL DEFAULT '{}',
-      trace_json TEXT NOT NULL DEFAULT '{}',
-      PRIMARY KEY (job_url, version)
-    );
-    CREATE TABLE job_stage_states (
-      job_url TEXT NOT NULL,
-      stage TEXT NOT NULL,
-      state TEXT NOT NULL DEFAULT 'pending',
-      attempt_count INTEGER DEFAULT 0,
-      max_attempts INTEGER,
-      started_at TEXT,
-      updated_at TEXT NOT NULL,
-      finished_at TEXT,
-      duration_ms INTEGER,
-      error_code TEXT,
-      error_message TEXT,
-      retryable INTEGER DEFAULT 1,
-      blocked_by_json TEXT,
-      next_action TEXT,
-      metadata_json TEXT,
-      version INTEGER NOT NULL DEFAULT 0,
-      PRIMARY KEY (job_url, stage)
-    );
-    CREATE TABLE job_employer_analysis (
-      job_url TEXT NOT NULL,
-      generation INTEGER NOT NULL,
-      tenant_id TEXT NOT NULL DEFAULT 'local',
-      snapshot_hash TEXT NOT NULL,
-      prompt_version TEXT NOT NULL,
-      sdk_set_version TEXT NOT NULL,
-      cache_key TEXT NOT NULL,
-      role_framing TEXT NOT NULL DEFAULT '',
-      inferred_seniority TEXT NOT NULL DEFAULT '',
-      ideal_candidate_narrative TEXT NOT NULL DEFAULT '',
-      requirements_json TEXT NOT NULL DEFAULT '[]',
-      keywords_json TEXT NOT NULL DEFAULT '[]',
-      agreement_json TEXT NOT NULL DEFAULT '{}',
-      legs_attempted INTEGER NOT NULL,
-      legs_succeeded INTEGER NOT NULL,
-      created_at TEXT NOT NULL,
-      PRIMARY KEY (job_url, generation)
-    );
-    CREATE TABLE job_employer_analysis_sub_analyses (
-      job_url TEXT NOT NULL,
-      generation INTEGER NOT NULL,
-      model_id TEXT NOT NULL,
-      tenant_id TEXT NOT NULL DEFAULT 'local',
-      analysis_json TEXT NOT NULL,
-      PRIMARY KEY (job_url, generation, model_id)
-    );
-    CREATE TABLE job_employer_analysis_failures (
-      job_url TEXT NOT NULL,
-      generation INTEGER NOT NULL,
-      model_id TEXT NOT NULL,
-      tenant_id TEXT NOT NULL DEFAULT 'local',
-      error TEXT NOT NULL,
-      raw_output TEXT,
-      PRIMARY KEY (job_url, generation, model_id)
-    );
-    CREATE TABLE job_materials (
-      job_url TEXT NOT NULL,
-      generation INTEGER NOT NULL,
-      tenant_id TEXT NOT NULL DEFAULT 'local',
-      status TEXT NOT NULL,
-      created_at TEXT NOT NULL,
-      updated_at TEXT NOT NULL,
-      last_validation_json TEXT,
-      last_verdict_json TEXT,
-      metadata_json TEXT,
-      PRIMARY KEY (job_url, generation)
-    );
-    CREATE TABLE job_materials_artifacts (
-      job_url TEXT NOT NULL,
-      generation INTEGER NOT NULL,
-      artifact_type TEXT NOT NULL,
-      artifact_id TEXT NOT NULL,
-      status TEXT NOT NULL,
-      path TEXT NOT NULL,
-      render_format TEXT NOT NULL,
-      size_bytes INTEGER,
-      metadata_json TEXT,
-      created_at TEXT NOT NULL,
-      superseded_at TEXT,
-      PRIMARY KEY (job_url, generation, artifact_type)
-    );
-    CREATE TABLE job_bullet_provenance (
-      job_url TEXT NOT NULL,
-      generation INTEGER NOT NULL,
-      bullet_id TEXT NOT NULL,
-      tenant_id TEXT NOT NULL DEFAULT 'local',
-      artifact_id TEXT NOT NULL,
-      section TEXT NOT NULL,
-      source_id TEXT,
-      evidence_ids_json TEXT NOT NULL DEFAULT '[]',
-      requirement_ids_json TEXT NOT NULL DEFAULT '[]',
-      matched_keywords_json TEXT NOT NULL DEFAULT '[]',
-      transform_type TEXT NOT NULL,
-      control TEXT NOT NULL,
-      rationale TEXT NOT NULL DEFAULT '',
-      generated_text TEXT NOT NULL,
-      position INTEGER NOT NULL DEFAULT 0,
-      created_at TEXT NOT NULL,
-      coverage_json TEXT,
-      voice_json TEXT,
-      PRIMARY KEY (job_url, generation, bullet_id)
-    );
-    CREATE TABLE job_interview_prep (
-      job_url TEXT NOT NULL,
-      generation INTEGER NOT NULL,
-      tenant_id TEXT NOT NULL DEFAULT 'local',
-      status TEXT NOT NULL,
-      model TEXT,
-      generated_at TEXT NOT NULL,
-      gate_status TEXT NOT NULL,
-      fabrication_findings_json TEXT NOT NULL DEFAULT '[]',
-      grounding_findings_json TEXT NOT NULL DEFAULT '[]',
-      judge_verdict TEXT,
-      warnings_json TEXT NOT NULL DEFAULT '[]',
-      failure_reason TEXT NOT NULL DEFAULT '',
-      PRIMARY KEY (job_url, generation)
-    );
-    CREATE TABLE job_interview_prep_items (
-      job_url TEXT NOT NULL,
-      generation INTEGER NOT NULL,
-      item_id TEXT NOT NULL,
-      tenant_id TEXT NOT NULL DEFAULT 'local',
-      kind TEXT NOT NULL,
-      title TEXT NOT NULL,
-      generated_text TEXT NOT NULL,
-      evidence_ids_json TEXT NOT NULL DEFAULT '[]',
-      requirement_ids_json TEXT NOT NULL DEFAULT '[]',
-      source_text_json TEXT NOT NULL DEFAULT '[]',
-      transform_type TEXT NOT NULL DEFAULT 'grounded_prep',
-      control TEXT NOT NULL DEFAULT 'never_fabricate',
-      grounding_audit_json TEXT NOT NULL DEFAULT '[]',
-      warnings_json TEXT NOT NULL DEFAULT '[]',
-      position INTEGER NOT NULL DEFAULT 0,
-      PRIMARY KEY (job_url, generation, item_id)
-    );
-    CREATE TABLE jobctrl_hidden_jobs (
-      job_url TEXT PRIMARY KEY,
-      hidden_at TEXT NOT NULL,
-      reason TEXT,
-      unhidden_at TEXT
-    );
-    CREATE TABLE application_outcomes (
-      tenant_id     TEXT NOT NULL DEFAULT 'local',
-      outcome_id    TEXT NOT NULL,
-      job_key       TEXT NOT NULL,
-      kind          TEXT NOT NULL,
-      source        TEXT NOT NULL,
-      note          TEXT,
-      occurred_at   TEXT NOT NULL,
-      recorded_at   TEXT NOT NULL,
-      suggestion_id TEXT,
-      evidence_id   TEXT,
-      created_by    TEXT NOT NULL DEFAULT 'user',
-      PRIMARY KEY (tenant_id, outcome_id)
-    );
-    CREATE TABLE application_outcome_suggestions (
-      tenant_id TEXT NOT NULL DEFAULT 'local',
-      suggestion_id TEXT NOT NULL,
-      job_key TEXT NOT NULL,
-      evidence_id TEXT,
-      suggested_kind TEXT NOT NULL,
-      confidence REAL NOT NULL DEFAULT 0,
-      rationale TEXT NOT NULL DEFAULT '',
-      status TEXT NOT NULL DEFAULT 'pending',
-      created_at TEXT NOT NULL,
-      decided_at TEXT,
-      decision TEXT,
-      decision_reason TEXT,
-      decided_outcome_id TEXT,
-      PRIMARY KEY (tenant_id, suggestion_id)
-    );
-  `);
-  db.close();
-}
-
 /** Seed the canonical rows exactly as the Python repositories write them. */
 function seedRows(dbPath: string): void {
   const db = new Database(dbPath);
+  db.pragma("foreign_keys = ON");
   const jobUrl = fixture.job.url;
+  const jobId = fixtureJobId(jobUrl);
   db.prepare(
     `INSERT INTO jobs (
-       url, title, company, site, strategy, location, salary, description,
+       tenant_id, job_id, url, title, company, site, strategy, location, salary, description,
        full_description, application_url, apply_status, applied_at,
        score_reasoning, discovered_at
-     ) VALUES (@url, @title, @company, @site, @strategy, @location, @salary, @description,
+     ) VALUES ('local', @job_id, @url, @title, @company, @site, @strategy, @location, @salary, @description,
        @full_description, @application_url, @apply_status, @applied_at,
        @score_reasoning, @discovered_at)`,
   ).run({
+    job_id: jobId,
     url: jobUrl,
     title: fixture.job.title,
     company: fixture.job.company,
@@ -370,66 +181,66 @@ function seedRows(dbPath: string): void {
 
   const insertScore = db.prepare(
     `INSERT INTO job_scores (
-       job_url, version, tenant_id, fit_score, breakdown_json, keywords_json,
+       job_id, version, tenant_id, fit_score, breakdown_json, keywords_json,
        scored_at, correction_json, criteria_json, trace_json
-     ) VALUES (@job_url, @version, 'local', @fit_score, @breakdown_json, @keywords_json,
+     ) VALUES (@job_id, @version, 'local', @fit_score, @breakdown_json, @keywords_json,
        @scored_at, @correction_json, @criteria_json, @trace_json)`,
   );
-  for (const score of fixture.rows.jobScores) insertScore.run({ job_url: jobUrl, ...score });
+  for (const score of fixture.rows.jobScores) insertScore.run({ job_id: jobId, ...score });
 
   const insertStage = db.prepare(
     `INSERT INTO job_stage_states (
-       job_url, stage, state, attempt_count, max_attempts, started_at, updated_at,
+       job_id, stage, state, attempt_count, max_attempts, started_at, updated_at,
        finished_at, duration_ms, error_code, error_message, retryable,
        blocked_by_json, next_action
-     ) VALUES (@job_url, @stage, @state, @attempt_count, @max_attempts, @started_at, @updated_at,
+     ) VALUES (@job_id, @stage, @state, @attempt_count, @max_attempts, @started_at, @updated_at,
        @finished_at, @duration_ms, @error_code, @error_message, @retryable,
        @blocked_by_json, @next_action)`,
   );
-  for (const stage of fixture.rows.jobStageStates) insertStage.run({ job_url: jobUrl, ...stage });
+  for (const stage of fixture.rows.jobStageStates) insertStage.run({ job_id: jobId, ...stage });
 
   const insertAnalysis = db.prepare(
     `INSERT INTO job_employer_analysis (
-       job_url, generation, tenant_id, snapshot_hash, prompt_version, sdk_set_version,
+       job_id, generation, tenant_id, snapshot_hash, prompt_version, sdk_set_version,
        cache_key, role_framing, inferred_seniority, ideal_candidate_narrative,
        requirements_json, keywords_json, agreement_json, legs_attempted, legs_succeeded, created_at
-     ) VALUES (@job_url, @generation, 'local', @snapshot_hash, @prompt_version, @sdk_set_version,
+     ) VALUES (@job_id, @generation, 'local', @snapshot_hash, @prompt_version, @sdk_set_version,
        @cache_key, @role_framing, @inferred_seniority, @ideal_candidate_narrative,
        @requirements_json, @keywords_json, @agreement_json, @legs_attempted, @legs_succeeded, @created_at)`,
   );
   for (const row of fixture.rows.jobEmployerAnalysis) {
-    insertAnalysis.run({ job_url: jobUrl, ...row });
+    insertAnalysis.run({ job_id: jobId, ...row });
   }
   const insertSub = db.prepare(
-    `INSERT INTO job_employer_analysis_sub_analyses (job_url, generation, model_id, tenant_id, analysis_json)
-     VALUES (@job_url, @generation, @model_id, 'local', @analysis_json)`,
+    `INSERT INTO job_employer_analysis_sub_analyses (job_id, generation, model_id, tenant_id, analysis_json)
+     VALUES (@job_id, @generation, @model_id, 'local', @analysis_json)`,
   );
   for (const sub of fixture.rows.jobEmployerAnalysisSubAnalyses) {
-    insertSub.run({ job_url: jobUrl, ...sub });
+    insertSub.run({ job_id: jobId, ...sub });
   }
   const insertFailure = db.prepare(
-    `INSERT INTO job_employer_analysis_failures (job_url, generation, model_id, tenant_id, error, raw_output)
-     VALUES (@job_url, @generation, @model_id, 'local', @error, @raw_output)`,
+    `INSERT INTO job_employer_analysis_failures (job_id, generation, model_id, tenant_id, error, raw_output)
+     VALUES (@job_id, @generation, @model_id, 'local', @error, @raw_output)`,
   );
   for (const failure of fixture.rows.jobEmployerAnalysisFailures) {
-    insertFailure.run({ job_url: jobUrl, ...failure });
+    insertFailure.run({ job_id: jobId, ...failure });
   }
 
   const { generation, createdAt } = fixture.job;
   db.prepare(
-    `INSERT INTO job_materials (job_url, generation, tenant_id, status, created_at, updated_at)
+    `INSERT INTO job_materials (job_id, generation, tenant_id, status, created_at, updated_at)
      VALUES (?, ?, 'local', 'complete', ?, ?)`,
-  ).run(jobUrl, generation, createdAt, createdAt);
+  ).run(jobId, generation, createdAt, createdAt);
   const insertArtifact = db.prepare(
     `INSERT INTO job_materials_artifacts (
-       job_url, generation, artifact_type, artifact_id, status, path,
+       job_id, generation, artifact_type, artifact_id, status, path,
        render_format, size_bytes, metadata_json, created_at
-     ) VALUES (@job_url, @generation, @artifact_type, @artifact_id, @status, @path,
+     ) VALUES (@job_id, @generation, @artifact_type, @artifact_id, @status, @path,
        @render_format, @size_bytes, @metadata_json, @created_at)`,
   );
   for (const artifact of fixture.rows.artifacts) {
     insertArtifact.run({
-      job_url: jobUrl,
+      job_id: jobId,
       generation,
       created_at: createdAt,
       metadata_json: "{}",
@@ -438,72 +249,87 @@ function seedRows(dbPath: string): void {
   }
   const insertProvenance = db.prepare(
     `INSERT INTO job_bullet_provenance (
-       job_url, generation, bullet_id, tenant_id, artifact_id, section, source_id,
+       job_id, generation, bullet_id, tenant_id, artifact_id, section, source_id,
        evidence_ids_json, requirement_ids_json, matched_keywords_json,
        transform_type, control, rationale, generated_text, position, created_at,
        coverage_json, voice_json
-     ) VALUES (@job_url, @generation, @bullet_id, 'local', @artifact_id, @section, @source_id,
+     ) VALUES (@job_id, @generation, @bullet_id, 'local', @artifact_id, @section, @source_id,
        @evidence_ids_json, @requirement_ids_json, @matched_keywords_json,
        @transform_type, @control, @rationale, @generated_text, @position, @created_at,
        @coverage_json, @voice_json)`,
   );
   for (const bullet of fixture.rows.bulletProvenance) {
-    insertProvenance.run({ job_url: jobUrl, ...bullet });
+    insertProvenance.run({ job_id: jobId, ...bullet });
   }
   const insertInterviewPrep = db.prepare(
     `INSERT INTO job_interview_prep (
-       job_url, generation, tenant_id, status, model, generated_at, gate_status,
+       job_id, generation, tenant_id, status, model, generated_at, gate_status,
        fabrication_findings_json, grounding_findings_json, judge_verdict,
        warnings_json, failure_reason
-     ) VALUES (@job_url, @generation, 'local', @status, @model, @generated_at, @gate_status,
+     ) VALUES (@job_id, @generation, 'local', @status, @model, @generated_at, @gate_status,
        @fabrication_findings_json, @grounding_findings_json, @judge_verdict,
        @warnings_json, @failure_reason)`,
   );
   for (const prep of fixture.rows.jobInterviewPrep) {
-    insertInterviewPrep.run({ job_url: jobUrl, ...prep });
+    insertInterviewPrep.run({ job_id: jobId, ...prep });
   }
   const insertInterviewPrepItem = db.prepare(
     `INSERT INTO job_interview_prep_items (
-       job_url, generation, item_id, tenant_id, kind, title, generated_text,
+       job_id, generation, item_id, tenant_id, kind, title, generated_text,
        evidence_ids_json, requirement_ids_json, source_text_json, transform_type,
        control, grounding_audit_json, warnings_json, position
-     ) VALUES (@job_url, @generation, @item_id, 'local', @kind, @title, @generated_text,
+     ) VALUES (@job_id, @generation, @item_id, 'local', @kind, @title, @generated_text,
        @evidence_ids_json, @requirement_ids_json, @source_text_json, @transform_type,
        @control, @grounding_audit_json, @warnings_json, @position)`,
   );
   for (const item of fixture.rows.jobInterviewPrepItems) {
-    insertInterviewPrepItem.run({ job_url: jobUrl, ...item });
+    insertInterviewPrepItem.run({ job_id: jobId, ...item });
   }
   db.prepare(
-    `INSERT INTO job_events (job_url, stage, event_type, level, message, occurred_at, payload_json)
-     VALUES (?, 'tailor', 'ResumeApproved', 'info', 'approved', ?, '{}')`,
-  ).run(jobUrl, createdAt);
+    `INSERT INTO job_events (
+       tenant_id, job_id, identity_version, stage, event_type, level, message, occurred_at, payload_json
+     ) VALUES ('local', ?, 1, 'tailor', 'ResumeApproved', 'info', 'approved', ?, '{}')`,
+  ).run(jobId, createdAt);
+  db.prepare(
+    `INSERT INTO resume_templates (
+       tenant_id, template_id, display_name, status, built_in, created_at, updated_at
+     ) VALUES ('local', 'built_in:modern-html', 'Modern HTML', 'active', 1, ?, ?)`,
+  ).run(createdAt, createdAt);
+  db.prepare(
+    `INSERT INTO resume_template_versions (
+       tenant_id, version_id, template_id, version_number, display_name, status,
+       theme_json, layout_json, content_hash, created_at
+     ) VALUES ('local', 'built_in:modern-html:v1', 'built_in:modern-html', 1,
+               'Modern HTML', 'active', ?, '{}', 'audit-parity-template', ?)`,
+  ).run(JSON.stringify(BUILT_IN_RESUME_TEMPLATE_THEME), createdAt);
 
   // Dashboard-aggregate-only jobs: they feed ONLY the tenant dashboard totals
   // (the job_list/job_detail assertions target the primary job). See the fixture
   // `dashboardAggregateJobs` notes for the two divergences they cover.
   const insertAggJob = db.prepare(
-    `INSERT INTO jobs (url, title, company, site, strategy, location,
+    `INSERT INTO jobs (tenant_id, job_id, url, title, company, site, strategy, location,
        apply_status, applied_at, tailored_resume_path, discovered_at)
-     VALUES (@url, @title, @company, @site, @strategy, @location,
+     VALUES ('local', @job_id, @url, @title, @company, @site, @strategy, @location,
        @apply_status, @applied_at, @tailored_resume_path, @discovered_at)`,
   );
   const insertAggStage = db.prepare(
-    `INSERT INTO job_stage_states (job_url, stage, state, attempt_count, max_attempts,
+    `INSERT INTO job_stage_states (job_id, stage, state, attempt_count, max_attempts,
        started_at, updated_at, finished_at, duration_ms, retryable)
-     VALUES (@job_url, @stage, @state, 1, 1, @ts, @ts, @finished_at, 0, 1)`,
+     VALUES (@job_id, @stage, @state, 1, 1, @ts, @ts, @finished_at, 0, 1)`,
   );
   const insertAggScore = db.prepare(
-    `INSERT INTO job_scores (job_url, version, tenant_id, fit_score, breakdown_json,
+    `INSERT INTO job_scores (job_id, version, tenant_id, fit_score, breakdown_json,
        keywords_json, scored_at, correction_json, criteria_json, trace_json)
-     VALUES (@job_url, 1, 'local', @fit_score, @breakdown_json, '[]', @scored_at, NULL, '{}', '{}')`,
+     VALUES (@job_id, 1, 'local', @fit_score, @breakdown_json, '[]', @scored_at, NULL, '{}', '{}')`,
   );
   const insertHidden = db.prepare(
-    `INSERT INTO jobctrl_hidden_jobs (job_url, hidden_at, reason, unhidden_at)
-     VALUES (?, ?, 'parity', NULL)`,
+    `INSERT INTO jobctrl_hidden_jobs (tenant_id, job_id, hidden_at, reason, unhidden_at)
+     VALUES ('local', ?, ?, 'parity', NULL)`,
   );
   for (const agg of fixture.dashboardAggregateJobs) {
+    const aggregateJobId = fixtureJobId(agg.url);
     insertAggJob.run({
+      job_id: aggregateJobId,
       url: agg.url,
       title: agg.title,
       company: agg.company,
@@ -517,7 +343,7 @@ function seedRows(dbPath: string): void {
     });
     for (const st of agg.stages) {
       insertAggStage.run({
-        job_url: agg.url,
+        job_id: aggregateJobId,
         stage: st.stage,
         state: st.state,
         ts: agg.discoveredAt,
@@ -526,7 +352,7 @@ function seedRows(dbPath: string): void {
     }
     if (agg.fitScore != null) {
       insertAggScore.run({
-        job_url: agg.url,
+        job_id: aggregateJobId,
         fit_score: agg.fitScore,
         breakdown_json: JSON.stringify({
           technical_fit: agg.fitScore,
@@ -538,7 +364,7 @@ function seedRows(dbPath: string): void {
       });
     }
     if (agg.hidden) {
-      insertHidden.run(agg.url, agg.discoveredAt);
+      insertHidden.run(aggregateJobId, agg.discoveredAt);
     }
   }
   // Extra applied+scored jobs across a second source and score band so the
@@ -552,17 +378,19 @@ function seedRows(dbPath: string): void {
     ["apply", 3],
   ];
   const insertConversionJob = db.prepare(
-    `INSERT INTO jobs (url, title, site, fit_score, apply_status, applied_at, discovered_at)
-     VALUES (@url, @title, @site, @fit_score, 'applied', @applied_at, @discovered_at)`,
+    `INSERT INTO jobs (tenant_id, job_id, url, title, site, fit_score, apply_status, applied_at, discovered_at)
+     VALUES ('local', @job_id, @url, @title, @site, @fit_score, 'applied', @applied_at, @discovered_at)`,
   );
   const insertConversionStage = db.prepare(
     `INSERT INTO job_stage_states (
-       job_url, stage, state, attempt_count, max_attempts, started_at, updated_at,
+       job_id, stage, state, attempt_count, max_attempts, started_at, updated_at,
        finished_at, duration_ms, retryable
-     ) VALUES (@job_url, @stage, 'succeeded', 1, @max_attempts, @at, @at, @at, 1000, 1)`,
+     ) VALUES (@job_id, @stage, 'succeeded', 1, @max_attempts, @at, @at, @at, 1000, 1)`,
   );
   for (const job of fixture.rows.conversionJobs) {
+    const conversionJobId = fixtureJobId(String(job.url));
     insertConversionJob.run({
+      job_id: conversionJobId,
       url: job.url,
       title: job.title,
       site: job.site,
@@ -572,7 +400,7 @@ function seedRows(dbPath: string): void {
     });
     for (const [stage, maxAttempts] of conversionStages) {
       insertConversionStage.run({
-        job_url: job.url,
+        job_id: conversionJobId,
         stage,
         max_attempts: maxAttempts,
         at: job.appliedAt,
@@ -580,28 +408,28 @@ function seedRows(dbPath: string): void {
     }
   }
   const insertOutcome = db.prepare(
-    `INSERT INTO application_outcomes (tenant_id, outcome_id, job_key, kind, source, occurred_at, recorded_at)
-     VALUES ('local', @outcome_id, @job_key, @kind, 'manual', @at, @at)`,
+    `INSERT INTO application_outcomes (tenant_id, outcome_id, job_id, kind, source, occurred_at, recorded_at)
+     VALUES ('local', @outcome_id, @job_id, @kind, 'manual', @at, @at)`,
   );
   for (const outcome of fixture.rows.applicationOutcomes) {
     insertOutcome.run({
       outcome_id: outcome.outcomeId,
-      job_key: outcome.jobKey,
+      job_id: fixtureJobId(String(outcome.jobKey)),
       kind: outcome.kind,
       at: "2026-06-11T09:00:00+00:00",
     });
   }
   const insertSuggestion = db.prepare(
     `INSERT INTO application_outcome_suggestions (
-       tenant_id, suggestion_id, job_key, suggested_kind, confidence, rationale,
+       tenant_id, suggestion_id, job_id, suggested_kind, confidence, rationale,
        status, created_at, decided_at, decision
-     ) VALUES ('local', @suggestion_id, @job_key, 'recruiter_reply', 0.9, '',
+     ) VALUES ('local', @suggestion_id, @job_id, 'recruiter_reply', 0.9, '',
        @status, @at, @at, @status)`,
   );
   for (const suggestion of fixture.rows.applicationOutcomeSuggestions) {
     insertSuggestion.run({
       suggestion_id: suggestion.suggestionId,
-      job_key: suggestion.jobKey,
+      job_id: fixtureJobId(String(suggestion.jobKey)),
       status: suggestion.status,
       at: "2026-06-11T09:05:00+00:00",
     });
@@ -631,7 +459,7 @@ describe("Cross-runtime projection parity (AUDIT-02)", () => {
   it("the TS builder + read model agree with the Python builder on the audit read shapes", async () => {
     const { dbPath, cleanup } = withTempDb();
     try {
-      seedSchema(dbPath);
+      initializeExactV7Database(dbPath);
       seedRows(dbPath);
 
       const app = buildApp({
@@ -655,7 +483,7 @@ describe("Cross-runtime projection parity (AUDIT-02)", () => {
             .prepare(
               "SELECT employer_analysis_json, interview_prep_json FROM job_detail_projections WHERE job_id = ?",
             )
-            .get(fixture.job.url) as {
+            .get(fixtureJobId(fixture.job.url)) as {
             employer_analysis_json: string | null;
             interview_prep_json: string | null;
           };
@@ -665,7 +493,7 @@ describe("Cross-runtime projection parity (AUDIT-02)", () => {
           );
           expect(detail?.interview_prep_json).not.toBeNull();
           expect(JSON.parse(detail.interview_prep_json!)).toEqual(
-            fixture.expected.interviewPrepJson,
+            withExactV7JobIds(fixture.expected.interviewPrepJson),
           );
 
           const artifact = db
@@ -690,7 +518,9 @@ describe("Cross-runtime projection parity (AUDIT-02)", () => {
         // (2) Read path: the read model serves the canonical employer analysis
         // and interview prep on the job detail.
         expect(detailRes.json().employerAnalysis).toEqual(fixture.expected.employerAnalysisJson);
-        expect(detailRes.json().interviewPrep).toEqual(fixture.expected.interviewPrepJson);
+        expect(detailRes.json().interviewPrep).toEqual(
+          withExactV7JobIds(fixture.expected.interviewPrepJson),
+        );
         expect(JSON.stringify(detailRes.json().interviewPrep)).not.toContain("prompt");
         expect(JSON.stringify(detailRes.json().interviewPrep)).not.toContain("full_description");
 
@@ -767,7 +597,7 @@ describe("Cross-runtime projection parity (AUDIT-02)", () => {
   it("the TS builder writes the full projection column set the Python builder produces", async () => {
     const { dbPath, cleanup } = withTempDb();
     try {
-      seedSchema(dbPath);
+      initializeExactV7Database(dbPath);
       seedRows(dbPath);
 
       const app = buildApp({
@@ -794,10 +624,10 @@ describe("Cross-runtime projection parity (AUDIT-02)", () => {
           const rows: Record<ProjectionTable, Record<string, unknown> | undefined> = {
             jobList: db
               .prepare("SELECT * FROM job_list_projections WHERE job_id = ?")
-              .get(fixture.job.url) as Record<string, unknown> | undefined,
+              .get(fixtureJobId(fixture.job.url)) as Record<string, unknown> | undefined,
             jobDetail: db
               .prepare("SELECT * FROM job_detail_projections WHERE job_id = ?")
-              .get(fixture.job.url) as Record<string, unknown> | undefined,
+              .get(fixtureJobId(fixture.job.url)) as Record<string, unknown> | undefined,
             dashboard: db
               .prepare("SELECT * FROM dashboard_projections WHERE tenant_id = 'local'")
               .get() as Record<string, unknown> | undefined,
@@ -821,7 +651,12 @@ describe("Cross-runtime projection parity (AUDIT-02)", () => {
             for (const column of nonDet) {
               expect(row![column], `${table}.${column} not populated`).toBeTruthy();
             }
-            expect(normalizeRow(row!, jsonCols, nonDet)).toEqual(expectedCols);
+            const expected = withExactV7JobIds(
+              table === "jobList"
+                ? { ...expectedCols, artifact_count: fixture.rows.artifacts.length }
+                : expectedCols,
+            );
+            expect(normalizeRow(row!, jsonCols, nonDet)).toEqual(expected);
           }
         } finally {
           db.close();

--- a/apps/api/test/digest.test.ts
+++ b/apps/api/test/digest.test.ts
@@ -4,11 +4,12 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import Database from "better-sqlite3";
 
-import { ensureApplicationFeedbackTables, listApplyReviewQueue } from "../src/application-feedback.js";
-import { ensureProjectionTables } from "../src/projections.js";
+import { listApplyReviewQueue } from "../src/application-feedback.js";
 import { buildDigest, readDigestState } from "../src/read-model.js";
+import { BUILT_IN_RESUME_TEMPLATE_THEME } from "../src/resume-templates.js";
 import { buildApp } from "../src/server.js";
 import { describe, expect, it } from "vitest";
+import { initializeExactV7Database } from "./v7-schema.js";
 
 interface FixtureJob {
   jobId: string;
@@ -175,7 +176,7 @@ describe("daily digest read model", () => {
       expect(jobsResponse.statusCode).toBe(200);
       const jobs = jobsResponse.json() as { items: Array<{ jobKey: string }> };
       expect(jobs.items).toHaveLength(fixture.expected.newMatches.count);
-      expect(jobs.items.some((job) => job.jobKey === "https://example.com/jobs/post-watermark-scored")).toBe(
+      expect(jobs.items.some((job) => job.jobKey === fixtureJobId("https://example.com/jobs/post-watermark-scored"))).toBe(
         true,
       );
 
@@ -248,10 +249,9 @@ function makeTempDb(): { dbPath: string; configPath: string; tempDir: string; cl
 }
 
 function seedDigestDatabase(dbPath: string, tempDir: string): void {
+  initializeExactV7Database(dbPath);
   const db = new Database(dbPath);
-  createDigestSchema(db);
-  ensureProjectionTables(db);
-  ensureApplicationFeedbackTables(db);
+  seedBuiltInResumeTemplate(db);
   seedJobs(db, tempDir);
   seedSourceQuality(db);
   seedOperationalAttempts(db);
@@ -265,170 +265,40 @@ function seedDigestDatabase(dbPath: string, tempDir: string): void {
   db.close();
 }
 
-function createDigestSchema(db: Database.Database): void {
-  db.exec(`
-    CREATE TABLE jobs (
-      url TEXT PRIMARY KEY,
-      title TEXT,
-      company TEXT,
-      site TEXT,
-      strategy TEXT,
-      location TEXT,
-      salary TEXT,
-      discovered_at TEXT,
-      application_url TEXT,
-      description TEXT,
-      full_description TEXT,
-      detail_scraped_at TEXT,
-      detail_error TEXT,
-      fit_score INTEGER,
-      score_reasoning TEXT,
-      scored_at TEXT,
-      tailored_resume_path TEXT,
-      tailored_at TEXT,
-      tailor_attempts INTEGER DEFAULT 0,
-      cover_letter_path TEXT,
-      cover_letter_at TEXT,
-      cover_attempts INTEGER DEFAULT 0,
-      apply_status TEXT,
-      apply_error TEXT,
-      applied_at TEXT
-    );
-    CREATE TABLE job_stage_states (
-      job_url TEXT NOT NULL,
-      stage TEXT NOT NULL,
-      state TEXT NOT NULL DEFAULT 'pending',
-      attempt_count INTEGER DEFAULT 0,
-      max_attempts INTEGER,
-      started_at TEXT,
-      updated_at TEXT NOT NULL DEFAULT '',
-      finished_at TEXT,
-      duration_ms INTEGER,
-      error_code TEXT,
-      error_message TEXT,
-      retryable INTEGER DEFAULT 1,
-      blocked_by_json TEXT,
-      next_action TEXT,
-      metadata_json TEXT,
-      version INTEGER NOT NULL DEFAULT 0,
-      PRIMARY KEY (job_url, stage)
-    );
-    CREATE TABLE job_events (
-      event_id INTEGER PRIMARY KEY AUTOINCREMENT,
-      job_url TEXT,
-      stage TEXT,
-      event_type TEXT NOT NULL DEFAULT '',
-      level TEXT NOT NULL DEFAULT 'info',
-      message TEXT,
-      occurred_at TEXT NOT NULL,
-      payload_json TEXT
-    );
-    CREATE TABLE job_scores (
-      job_url TEXT NOT NULL,
-      version INTEGER NOT NULL,
-      tenant_id TEXT NOT NULL DEFAULT 'local',
-      fit_score INTEGER NOT NULL,
-      breakdown_json TEXT NOT NULL,
-      keywords_json TEXT NOT NULL,
-      scored_at TEXT NOT NULL,
-      correction_json TEXT,
-      criteria_json TEXT NOT NULL DEFAULT '{}',
-      trace_json TEXT NOT NULL DEFAULT '{}',
-      PRIMARY KEY (job_url, version)
-    );
-    CREATE TABLE job_score_staleness (
-      tenant_id TEXT NOT NULL DEFAULT 'local',
-      job_url TEXT NOT NULL,
-      stale_reason TEXT NOT NULL,
-      old_policy_id TEXT NOT NULL DEFAULT '',
-      old_policy_version INTEGER NOT NULL,
-      new_policy_id TEXT NOT NULL DEFAULT '',
-      new_policy_version INTEGER NOT NULL,
-      marked_at TEXT NOT NULL,
-      resolved INTEGER NOT NULL DEFAULT 0,
-      resolved_at TEXT,
-      resolved_by_score_version INTEGER,
-      PRIMARY KEY (
-        tenant_id, job_url, stale_reason,
-        old_policy_version, new_policy_version
-      )
-    );
-    CREATE TABLE job_materials (
-      job_url TEXT NOT NULL,
-      generation INTEGER NOT NULL,
-      tenant_id TEXT NOT NULL DEFAULT 'local',
-      status TEXT NOT NULL,
-      created_at TEXT NOT NULL,
-      updated_at TEXT NOT NULL,
-      PRIMARY KEY (job_url, generation)
-    );
-    CREATE TABLE job_materials_artifacts (
-      job_url TEXT NOT NULL,
-      generation INTEGER NOT NULL,
-      artifact_type TEXT NOT NULL,
-      artifact_id TEXT NOT NULL,
-      status TEXT NOT NULL,
-      path TEXT NOT NULL,
-      render_format TEXT NOT NULL,
-      size_bytes INTEGER,
-      metadata_json TEXT,
-      created_at TEXT NOT NULL,
-      superseded_at TEXT,
-      PRIMARY KEY (job_url, generation, artifact_type)
-    );
-    CREATE TABLE jobctrl_hidden_jobs (
-      tenant_id TEXT NOT NULL DEFAULT 'local',
-      job_url TEXT NOT NULL,
-      hidden_at TEXT NOT NULL,
-      unhidden_at TEXT
-    );
-    CREATE TABLE posting_snapshot_sets (
-      tenant_id TEXT NOT NULL DEFAULT 'local',
-      job_url TEXT NOT NULL,
-      latest_active_state TEXT NOT NULL,
-      updated_at TEXT NOT NULL,
-      PRIMARY KEY (tenant_id, job_url)
-    );
-    CREATE TABLE operational_attempt_metrics (
-      metric_id INTEGER PRIMARY KEY AUTOINCREMENT,
-      tenant_id TEXT NOT NULL DEFAULT 'local',
-      occurred_at TEXT NOT NULL,
-      stage TEXT NOT NULL,
-      source_id TEXT,
-      source_kind TEXT,
-      source_priority TEXT,
-      source_role TEXT,
-      adapter TEXT,
-      attempt_kind TEXT NOT NULL,
-      outcome TEXT NOT NULL,
-      failure_category TEXT,
-      is_operational_failure INTEGER NOT NULL DEFAULT 0,
-      is_scrape_failure INTEGER NOT NULL DEFAULT 0,
-      is_retryable INTEGER NOT NULL DEFAULT 1,
-      run_id TEXT,
-      duration_ms INTEGER,
-      error_class TEXT
-    );
-  `);
+function seedBuiltInResumeTemplate(db: Database.Database): void {
+  db.prepare(
+    `INSERT INTO resume_templates (
+       tenant_id, template_id, display_name, status, built_in, created_at, updated_at
+     ) VALUES ('local', 'built_in:modern-html', 'Modern HTML', 'active', 1, ?, ?)`,
+  ).run(fixture.now, fixture.now);
+  db.prepare(
+    `INSERT INTO resume_template_versions (
+       tenant_id, version_id, template_id, version_number, display_name, status,
+       theme_json, layout_json, content_hash, created_at
+     ) VALUES ('local', 'built_in:modern-html:v1', 'built_in:modern-html', 1,
+               'Modern HTML', 'active', ?, '{}', 'digest-fixture-template', ?)`,
+  ).run(JSON.stringify(BUILT_IN_RESUME_TEMPLATE_THEME), fixture.now);
 }
 
 function seedJobs(db: Database.Database, tempDir: string): void {
   const insertJob = db.prepare(
     `INSERT INTO jobs (
-       url, title, company, site, strategy, location, salary, discovered_at,
+       tenant_id, job_id, url, title, company, site, strategy, location, salary, discovered_at,
        application_url, description, full_description, detail_scraped_at,
        detail_error, fit_score, score_reasoning, scored_at, tailored_resume_path
-     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+     ) VALUES ('local', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   );
   const insertScore = db.prepare(
     `INSERT INTO job_scores (
-       job_url, version, tenant_id, fit_score, breakdown_json, keywords_json,
+       tenant_id, job_id, version, fit_score, breakdown_json, keywords_json,
        scored_at, correction_json, criteria_json, trace_json
-     ) VALUES (?, 1, 'local', ?, ?, ?, ?, NULL, '{}', '{}')`,
+     ) VALUES ('local', ?, 1, ?, ?, ?, ?, NULL, '{}', '{}')`,
   );
 
   for (const job of fixture.jobs) {
+    const jobId = fixtureJobId(job.jobId);
     insertJob.run(
+      jobId,
       job.jobId,
       job.title,
       job.employer,
@@ -469,7 +339,7 @@ function seedJobs(db: Database.Database, tempDir: string): void {
       transferable_signals: [],
     };
     insertScore.run(
-      job.jobId,
+      jobId,
       job.fitScore,
       JSON.stringify(scoreBreakdown),
       JSON.stringify(["typescript"]),
@@ -477,58 +347,59 @@ function seedJobs(db: Database.Database, tempDir: string): void {
     );
     if (job.hidden) {
       db.prepare(
-        "INSERT INTO jobctrl_hidden_jobs (tenant_id, job_url, hidden_at, unhidden_at) VALUES ('local', ?, ?, NULL)",
-      ).run(job.jobId, fixture.now);
+        "INSERT INTO jobctrl_hidden_jobs (tenant_id, job_id, hidden_at, unhidden_at) VALUES ('local', ?, ?, NULL)",
+      ).run(jobId, fixture.now);
     }
     if (job.activeState) {
       db.prepare(
-        "INSERT INTO posting_snapshot_sets (tenant_id, job_url, latest_active_state, updated_at) VALUES ('local', ?, ?, ?)",
-      ).run(job.jobId, job.activeState, fixture.now);
+        "INSERT INTO posting_snapshot_sets (tenant_id, job_id, snapshot_set_json, latest_active_state, updated_at) VALUES ('local', ?, '{}', ?, ?)",
+      ).run(jobId, job.activeState, fixture.now);
     }
   }
 
   for (const job of fixture.jobs) {
+    const jobId = fixtureJobId(job.jobId);
     if (job.currentStage === "apply") {
-      seedApplyStages(db, job.jobId);
+      seedApplyStages(db, jobId);
     } else if (job.currentStage === "score") {
-      seedScoreStages(db, job.jobId, job.currentState);
+      seedScoreStages(db, jobId, job.currentState);
     } else {
-      seedStage(db, job.jobId, "discover", job.currentState);
+      seedStage(db, jobId, "discover", job.currentState);
     }
     if (job.hasResume || job.hasPdf) {
-      seedMaterials(db, tempDir, job);
+      seedMaterials(db, tempDir, { ...job, jobId });
     }
   }
 }
 
-function seedApplyStages(db: Database.Database, jobUrl: string): void {
+function seedApplyStages(db: Database.Database, jobId: string): void {
   for (const stage of ["discover", "enrich", "score", "tailor", "cover"]) {
-    seedStage(db, jobUrl, stage, "succeeded");
+    seedStage(db, jobId, stage, "succeeded");
   }
-  seedStage(db, jobUrl, "apply", "pending");
+  seedStage(db, jobId, "apply", "pending");
 }
 
-function seedScoreStages(db: Database.Database, jobUrl: string, scoreState: string): void {
+function seedScoreStages(db: Database.Database, jobId: string, scoreState: string): void {
   for (const stage of ["discover", "enrich"]) {
-    seedStage(db, jobUrl, stage, "succeeded");
+    seedStage(db, jobId, stage, "succeeded");
   }
-  seedStage(db, jobUrl, "score", scoreState);
+  seedStage(db, jobId, "score", scoreState);
 }
 
-function seedStage(db: Database.Database, jobUrl: string, stage: string, state: string): void {
+function seedStage(db: Database.Database, jobId: string, stage: string, state: string): void {
   db.prepare(
     `INSERT INTO job_stage_states (
-       job_url, stage, state, attempt_count, max_attempts, updated_at, retryable
-     ) VALUES (?, ?, ?, 1, 3, ?, 1)`,
-  ).run(jobUrl, stage, state, fixture.now);
+       tenant_id, job_id, stage, state, attempt_count, max_attempts, updated_at, retryable
+     ) VALUES ('local', ?, ?, ?, 1, 3, ?, 1)`,
+  ).run(jobId, stage, state, fixture.now);
 }
 
 function seedMaterials(db: Database.Database, tempDir: string, job: FixtureJob): void {
   const generation = 1;
   db.prepare(
     `INSERT INTO job_materials (
-       job_url, generation, tenant_id, status, created_at, updated_at
-     ) VALUES (?, ?, 'local', 'approved', ?, ?)`,
+       tenant_id, job_id, generation, status, created_at, updated_at
+     ) VALUES ('local', ?, ?, 'approved', ?, ?)`,
   ).run(job.jobId, generation, fixture.now, fixture.now);
 
   if (job.hasResume) {
@@ -545,7 +416,7 @@ function seedMaterials(db: Database.Database, tempDir: string, job: FixtureJob):
 
 function insertMaterialArtifact(
   db: Database.Database,
-  jobUrl: string,
+  jobId: string,
   generation: number,
   artifactType: string,
   renderFormat: string,
@@ -553,14 +424,14 @@ function insertMaterialArtifact(
 ): void {
   db.prepare(
     `INSERT INTO job_materials_artifacts (
-       job_url, generation, artifact_type, artifact_id, status, path,
+       tenant_id, job_id, generation, artifact_type, artifact_id, status, path,
        render_format, size_bytes, metadata_json, created_at
-     ) VALUES (?, ?, ?, ?, 'approved', ?, ?, ?, '{}', ?)`,
+     ) VALUES ('local', ?, ?, ?, ?, 'approved', ?, ?, ?, '{}', ?)`,
   ).run(
-    jobUrl,
+    jobId,
     generation,
     artifactType,
-    `${slug(jobUrl)}-${artifactType}`,
+    `${slug(jobId)}-${artifactType}`,
     artifactPath,
     renderFormat,
     fs.statSync(artifactPath).size,
@@ -617,11 +488,11 @@ function seedOperationalAttempts(db: Database.Database): void {
 function seedReviewDecisions(db: Database.Database): void {
   const insert = db.prepare(
     `INSERT INTO application_review_decisions (
-       tenant_id, decision_id, job_key, decision, reason, decided_by, decided_at
+       tenant_id, decision_id, job_id, decision, reason, decided_by, decided_at
      ) VALUES ('local', ?, ?, ?, NULL, 'user', ?)`,
   );
   for (const decision of fixture.applicationReviewDecisions) {
-    insert.run(decision.decisionId, decision.jobKey, decision.decision, decision.decidedAt);
+    insert.run(decision.decisionId, fixtureJobId(decision.jobKey), decision.decision, decision.decidedAt);
   }
 }
 
@@ -635,7 +506,7 @@ function seedApplyRuns(db: Database.Database): void {
   for (const run of fixture.applyRuns) {
     insert.run(
       run.runId,
-      run.jobId,
+      fixtureJobId(run.jobId),
       run.status,
       run.result,
       run.dryRun ? 1 : 0,
@@ -648,7 +519,7 @@ function seedApplyRuns(db: Database.Database): void {
 function seedScoreStaleness(db: Database.Database): void {
   const insert = db.prepare(
     `INSERT INTO job_score_staleness (
-       tenant_id, job_url, stale_reason, old_policy_id, old_policy_version,
+       tenant_id, job_id, stale_reason, old_policy_id, old_policy_version,
        new_policy_id, new_policy_version, marked_at, resolved
      ) VALUES (
        'local', ?, 'scoring_policy_changed', 'local:scoring-policy-v1', ?,
@@ -656,19 +527,31 @@ function seedScoreStaleness(db: Database.Database): void {
      )`,
   );
   for (const stale of fixture.scoreStaleness) {
-    insert.run(stale.jobUrl, stale.scoreVersion, stale.scoreVersion + 1, fixture.now);
+    insert.run(fixtureJobId(stale.jobUrl), stale.scoreVersion, stale.scoreVersion + 1, fixture.now);
   }
 }
 
 function seedApplicationOutcomes(db: Database.Database): void {
   const insert = db.prepare(
     `INSERT INTO application_outcomes (
-       tenant_id, outcome_id, job_key, kind, source, note, occurred_at, recorded_at
+       tenant_id, outcome_id, job_id, kind, source, note, occurred_at, recorded_at
      ) VALUES ('local', ?, ?, ?, 'manual', NULL, ?, ?)`,
   );
   for (const outcome of fixture.applicationOutcomes) {
-    insert.run(outcome.outcomeId, outcome.jobKey, outcome.kind, outcome.occurredAt, outcome.occurredAt);
+    insert.run(
+      outcome.outcomeId,
+      fixtureJobId(outcome.jobKey),
+      outcome.kind,
+      outcome.occurredAt,
+      outcome.occurredAt,
+    );
   }
+}
+
+function fixtureJobId(url: string): string {
+  const index = fixture.jobs.findIndex((job) => job.jobId === url);
+  if (index < 0) throw new Error(`Unknown digest fixture job URL: ${url}`);
+  return `00000000-0000-4000-8000-${String(index + 1).padStart(12, "0")}`;
 }
 
 function slug(value: string): string {

--- a/apps/api/test/exact-v7-projections.test.ts
+++ b/apps/api/test/exact-v7-projections.test.ts
@@ -85,4 +85,61 @@ describe("exact-v7 projection refresh", () => {
     expect(schemaManifest(db, EXACT_V7_SCHEMA_MANIFEST.version)).toEqual(before);
     db.close();
   });
+
+  it("projects contact and outreach job ids from exact-v7 canonical rows", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "jobctrl-api-v7-contact-projections-"));
+    cleanups.push(() => fs.rmSync(dir, { recursive: true, force: true }));
+    const dbPath = path.join(dir, "jobs.db");
+    initializeExactV7Database(dbPath);
+    const db = new Database(dbPath);
+    db.pragma("foreign_keys = ON");
+
+    db.prepare(
+      `INSERT INTO jobs (tenant_id, job_id, url, title, company, site, discovered_at)
+       VALUES ('local', ?, 'https://jobs.example.test/contact', 'Contact title', 'Example', 'example', ?)`,
+    ).run(JOB_ID, "2026-07-31T12:00:00Z");
+    db.prepare(
+      `INSERT INTO contacts (tenant_id, contact_id, employer, job_id, role, created_at, updated_at)
+       VALUES ('local', 'contact-local', 'Example', ?, 'recruiter', ?, ?)`,
+    ).run(JOB_ID, "2026-07-31T12:00:00Z", "2026-07-31T12:00:00Z");
+    db.prepare(
+      `INSERT INTO contact_research_tasks (
+         tenant_id, task_id, employer, job_id, status, source_attempts_json, updated_at
+       ) VALUES ('local', 'research-local', 'Example', ?, 'queued', '[]', ?)`,
+    ).run(JOB_ID, "2026-07-31T12:00:00Z");
+    db.prepare(
+      `INSERT INTO outreach_threads (
+         tenant_id, thread_id, contact_id, job_id, created_at, updated_at,
+         follow_up_due_at, follow_up_basis, follow_up_state
+       ) VALUES ('local', 'thread-local', 'contact-local', ?, ?, ?, ?, 'manual', 'scheduled')`,
+    ).run(
+      JOB_ID,
+      "2026-07-31T12:00:00Z",
+      "2026-07-31T12:00:00Z",
+      "2026-08-07T12:00:00Z",
+    );
+    const recordEvent = db.prepare(
+      `INSERT INTO job_events (tenant_id, job_id, identity_version, stage, event_type, occurred_at)
+       VALUES ('local', ?, 1, 'contact', ?, '2026-07-31T12:00:00Z')`,
+    );
+    recordEvent.run(JOB_ID, "ContactCreated");
+    recordEvent.run(JOB_ID, "ContactResearchTaskStarted");
+    recordEvent.run(JOB_ID, "FollowUpScheduled");
+
+    refreshProjections(db, "local");
+
+    expect(
+      db.prepare("SELECT job_id FROM contact_projections WHERE tenant_id = 'local' AND contact_id = 'contact-local'").get(),
+    ).toEqual({ job_id: JOB_ID });
+    expect(
+      db.prepare("SELECT job_id FROM contact_research_task_projections WHERE tenant_id = 'local' AND task_id = 'research-local'").get(),
+    ).toEqual({ job_id: JOB_ID });
+    expect(
+      db.prepare("SELECT job_id FROM outreach_thread_projections WHERE tenant_id = 'local' AND thread_id = 'thread-local'").get(),
+    ).toEqual({ job_id: JOB_ID });
+    expect(
+      db.prepare("SELECT job_id FROM due_follow_up_projections WHERE tenant_id = 'local' AND thread_id = 'thread-local'").get(),
+    ).toEqual({ job_id: JOB_ID });
+    db.close();
+  });
 });

--- a/apps/api/test/exact-v7-projections.test.ts
+++ b/apps/api/test/exact-v7-projections.test.ts
@@ -10,6 +10,8 @@ import { EXACT_V7_SCHEMA_MANIFEST, schemaManifest } from "../src/schema-manifest
 import { initializeExactV7Database } from "./v7-schema.js";
 
 const JOB_ID = "00000000-0000-4000-8000-000000000071";
+const ARTIFACT_JOB_ID = "00000000-0000-4000-8000-000000000072";
+const UNKNOWN_COMPANY_JOB_ID = "00000000-0000-4000-8000-000000000073";
 const cleanups: Array<() => void> = [];
 
 afterEach(() => {
@@ -140,6 +142,160 @@ describe("exact-v7 projection refresh", () => {
     expect(
       db.prepare("SELECT job_id FROM due_follow_up_projections WHERE tenant_id = 'local' AND thread_id = 'thread-local'").get(),
     ).toEqual({ job_id: JOB_ID });
+    db.close();
+  });
+
+  it("removes unregistered artifact siblings and preserves both registered artifact sources after reopen", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "jobctrl-api-v7-artifact-refresh-"));
+    cleanups.push(() => fs.rmSync(dir, { recursive: true, force: true }));
+    const dbPath = path.join(dir, "jobs.db");
+    initializeExactV7Database(dbPath);
+    const db = new Database(dbPath);
+    db.pragma("foreign_keys = ON");
+
+    db.prepare(
+      `INSERT INTO jobs (tenant_id, job_id, url, title, company, site, discovered_at)
+       VALUES ('local', ?, 'https://jobs.example.test/artifacts', 'Artifact title', 'Example', 'greenhouse', ?)`,
+    ).run(ARTIFACT_JOB_ID, "2026-07-31T12:00:00Z");
+    db.prepare(
+      `INSERT INTO job_materials (
+         tenant_id, job_id, generation, status, created_at, updated_at, metadata_json
+       ) VALUES ('local', ?, 1, 'resume_approved', ?, ?, '{}')`,
+    ).run(ARTIFACT_JOB_ID, "2026-07-31T12:00:00Z", "2026-07-31T12:00:00Z");
+    db.prepare(
+      `INSERT INTO job_materials_artifacts (
+         tenant_id, job_id, generation, artifact_type, artifact_id, status, path,
+         render_format, size_bytes, metadata_json, created_at
+       ) VALUES ('local', ?, 1, 'tailored_resume', 'registered-resume', 'approved',
+                 '/tmp/registered-resume.txt', 'text', 12, '{}', ?)`,
+    ).run(ARTIFACT_JOB_ID, "2026-07-31T12:00:00Z");
+    const genericArtifactId = String(
+      db
+        .prepare(
+          `INSERT INTO job_artifacts (
+             tenant_id, job_id, stage, artifact_type, status, path, created_at, size_bytes
+           ) VALUES ('local', ?, 'apply', 'application_log', 'completed',
+                     '/tmp/registered-application.log', ?, 24)`,
+        )
+        .run(ARTIFACT_JOB_ID, "2026-07-31T12:00:00Z").lastInsertRowid,
+    );
+    const shadowedGenericArtifactId = String(
+      db
+        .prepare(
+          `INSERT INTO job_artifacts (
+             tenant_id, job_id, stage, artifact_type, status, path, created_at, size_bytes
+           ) VALUES ('local', ?, 'tailor', 'tailored_resume', 'completed',
+                     '/tmp/registered-resume.txt', ?, 12)`,
+        )
+        .run(ARTIFACT_JOB_ID, "2026-07-31T12:00:00Z").lastInsertRowid,
+    );
+
+    refreshProjections(db, "local");
+    db.prepare(
+      `INSERT INTO artifact_list_projections (
+         artifact_id, tenant_id, job_id, job_title, job_employer, artifact_type,
+         status, local_path
+       ) VALUES (?, 'local', ?, 'Artifact title', 'Example', 'tailored_resume',
+                 'completed', '/tmp/registered-resume.txt')`,
+    ).run(shadowedGenericArtifactId, ARTIFACT_JOB_ID);
+    db.prepare(
+      `INSERT INTO artifact_list_projections (
+         artifact_id, tenant_id, job_id, job_title, job_employer, artifact_type,
+         status, local_path, generation
+       ) VALUES ('phantom-resume-pdf', 'local', ?, 'Artifact title', 'Example',
+                 'resume_pdf', 'approved', '/tmp/registered-resume.pdf', 1)`,
+    ).run(ARTIFACT_JOB_ID);
+
+    refreshProjections(db, "local");
+    expect(
+      db
+        .prepare(
+          `SELECT artifact_id, artifact_type, local_path
+             FROM artifact_list_projections
+            WHERE tenant_id = 'local' AND job_id = ?
+            ORDER BY artifact_id`,
+        )
+        .all(ARTIFACT_JOB_ID),
+    ).toEqual([
+      {
+        artifact_id: genericArtifactId,
+        artifact_type: "application_log",
+        local_path: "/tmp/registered-application.log",
+      },
+      {
+        artifact_id: "registered-resume",
+        artifact_type: "tailored_resume",
+        local_path: "/tmp/registered-resume.txt",
+      },
+    ]);
+    db.close();
+
+    const reopened = new Database(dbPath);
+    reopened.pragma("foreign_keys = ON");
+    refreshProjections(reopened, "local");
+    expect(
+      reopened
+        .prepare(
+          `SELECT artifact_id, artifact_type, local_path
+             FROM artifact_list_projections
+            WHERE tenant_id = 'local' AND job_id = ?
+            ORDER BY artifact_id`,
+        )
+        .all(ARTIFACT_JOB_ID),
+    ).toEqual([
+      {
+        artifact_id: genericArtifactId,
+        artifact_type: "application_log",
+        local_path: "/tmp/registered-application.log",
+      },
+      {
+        artifact_id: "registered-resume",
+        artifact_type: "tailored_resume",
+        local_path: "/tmp/registered-resume.txt",
+      },
+    ]);
+    reopened.close();
+  });
+
+  it("uses explicit company truth without deriving employer from source or URL", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "jobctrl-api-v7-company-projection-"));
+    cleanups.push(() => fs.rmSync(dir, { recursive: true, force: true }));
+    const dbPath = path.join(dir, "jobs.db");
+    initializeExactV7Database(dbPath);
+    const db = new Database(dbPath);
+    db.pragma("foreign_keys = ON");
+
+    const insertJob = db.prepare(
+      `INSERT INTO jobs (tenant_id, job_id, url, title, company, site, discovered_at)
+       VALUES ('local', ?, ?, ?, ?, 'greenhouse', '2026-07-31T12:00:00Z')`,
+    );
+    insertJob.run(
+      JOB_ID,
+      "https://boards.greenhouse.io/acme/jobs/1",
+      "Explicit company",
+      "Acme",
+    );
+    insertJob.run(
+      UNKNOWN_COMPANY_JOB_ID,
+      "https://boards.greenhouse.io/fabricated-company/jobs/2",
+      "Missing company",
+      null,
+    );
+
+    refreshProjections(db, "local");
+    expect(
+      db
+        .prepare(
+          `SELECT job_id, employer, source
+             FROM job_list_projections
+            WHERE tenant_id = 'local'
+            ORDER BY job_id`,
+        )
+        .all(),
+    ).toEqual([
+      { job_id: JOB_ID, employer: "Acme", source: "greenhouse" },
+      { job_id: UNKNOWN_COMPANY_JOB_ID, employer: "Unknown company", source: "greenhouse" },
+    ]);
     db.close();
   });
 });

--- a/apps/api/test/exact-v7-projections.test.ts
+++ b/apps/api/test/exact-v7-projections.test.ts
@@ -12,6 +12,8 @@ import { initializeExactV7Database } from "./v7-schema.js";
 const JOB_ID = "00000000-0000-4000-8000-000000000071";
 const ARTIFACT_JOB_ID = "00000000-0000-4000-8000-000000000072";
 const UNKNOWN_COMPANY_JOB_ID = "00000000-0000-4000-8000-000000000073";
+const STALE_WIDE_JOB_ID = "00000000-0000-4000-8000-000000000074";
+const CANONICAL_FACTS_JOB_ID = "00000000-0000-4000-8000-000000000075";
 const cleanups: Array<() => void> = [];
 
 afterEach(() => {
@@ -255,6 +257,160 @@ describe("exact-v7 projection refresh", () => {
       },
     ]);
     reopened.close();
+  });
+
+  it("ignores stale wide values and derives list, detail, and dashboard facts from canonical rows", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "jobctrl-api-v7-canonical-projections-"));
+    cleanups.push(() => fs.rmSync(dir, { recursive: true, force: true }));
+    const dbPath = path.join(dir, "jobs.db");
+    initializeExactV7Database(dbPath);
+    const db = new Database(dbPath);
+    db.pragma("foreign_keys = ON");
+
+    const insertJob = db.prepare(
+      `INSERT INTO jobs (
+         tenant_id, job_id, url, title, company, site, discovered_at,
+         fit_score, score_reasoning, tailored_resume_path, cover_letter_path,
+         apply_status, applied_at
+       ) VALUES (
+         'local', @job_id, @url, @title, 'Example', 'example', '2026-07-31T12:00:00Z',
+         10, 'stale score reasoning', '/tmp/stale-resume.txt', '/tmp/stale-cover.txt',
+         'applied', '2026-07-30T12:00:00Z'
+       )`,
+    );
+    insertJob.run({
+      job_id: STALE_WIDE_JOB_ID,
+      url: "https://jobs.example.test/stale-wide",
+      title: "Stale wide values only",
+    });
+    insertJob.run({
+      job_id: CANONICAL_FACTS_JOB_ID,
+      url: "https://jobs.example.test/canonical-facts",
+      title: "Canonical facts",
+    });
+
+    const insertEvent = db.prepare(
+      `INSERT INTO job_events (
+         tenant_id, job_id, identity_version, stage, event_type, occurred_at
+       ) VALUES ('local', ?, 1, ?, ?, ?)`,
+    );
+    insertEvent.run(STALE_WIDE_JOB_ID, "discover", "JobDiscovered", "2026-07-31T12:00:00Z");
+    insertEvent.run(CANONICAL_FACTS_JOB_ID, "discover", "JobDiscovered", "2026-07-31T12:00:00Z");
+    insertEvent.run(
+      CANONICAL_FACTS_JOB_ID,
+      "apply",
+      "ApplicationManuallyMarked",
+      "2026-07-31T12:30:00Z",
+    );
+
+    db.prepare(
+      `INSERT INTO job_scores (
+         tenant_id, job_id, version, fit_score, breakdown_json, keywords_json, scored_at
+       ) VALUES ('local', ?, 1, 7, '{"reasoning":"canonical score reasoning"}', '[]', ?)`,
+    ).run(CANONICAL_FACTS_JOB_ID, "2026-07-31T12:15:00Z");
+    db.prepare(
+      `INSERT INTO job_artifacts (
+         tenant_id, job_id, stage, artifact_type, status, path, created_at, size_bytes
+       ) VALUES ('local', ?, 'tailor', 'tailored_resume', 'active',
+                 '/tmp/canonical-resume.txt', '2026-07-31T12:20:00Z', 12)`,
+    ).run(CANONICAL_FACTS_JOB_ID);
+    db.prepare(
+      `INSERT INTO job_materials (
+         tenant_id, job_id, generation, status, created_at, updated_at, metadata_json
+       ) VALUES ('local', ?, 1, 'resume_approved', ?, ?, '{}')`,
+    ).run(CANONICAL_FACTS_JOB_ID, "2026-07-31T12:20:00Z", "2026-07-31T12:20:00Z");
+    db.prepare(
+      `INSERT INTO job_materials_artifacts (
+         tenant_id, job_id, generation, artifact_type, artifact_id, status, path,
+         render_format, size_bytes, metadata_json, created_at
+       ) VALUES ('local', ?, 1, 'cover_letter', 'canonical-cover', 'approved',
+                 '/tmp/canonical-cover.txt', 'text', 12, '{}', '2026-07-31T12:20:00Z')`,
+    ).run(CANONICAL_FACTS_JOB_ID);
+
+    refreshProjections(db, "local");
+
+    expect(
+      db
+        .prepare(
+          `SELECT fit_score, score_reasoning, has_resume, has_cover_letter, has_pdf,
+                  apply_status, applied_at, apply_mode, artifact_count
+             FROM job_list_projections
+            WHERE tenant_id = 'local' AND job_id = ?`,
+        )
+        .get(STALE_WIDE_JOB_ID),
+    ).toEqual({
+      fit_score: null,
+      score_reasoning: "",
+      has_resume: 0,
+      has_cover_letter: 0,
+      has_pdf: 0,
+      apply_status: null,
+      applied_at: null,
+      apply_mode: null,
+      artifact_count: 0,
+    });
+    expect(
+      db
+        .prepare(
+          `SELECT fit_score, score_reasoning, has_resume, has_cover_letter,
+                  apply_status, applied_at, apply_mode
+             FROM job_list_projections
+            WHERE tenant_id = 'local' AND job_id = ?`,
+        )
+        .get(CANONICAL_FACTS_JOB_ID),
+    ).toEqual({
+      fit_score: 7,
+      score_reasoning: "canonical score reasoning",
+      has_resume: 1,
+      has_cover_letter: 1,
+      apply_status: "applied",
+      applied_at: "2026-07-31T12:30:00Z",
+      apply_mode: "manual_marked",
+    });
+    expect(
+      db
+        .prepare(
+          `SELECT score_breakdown_json, score_reasoning, score_version, scored_at
+             FROM job_detail_projections
+            WHERE tenant_id = 'local' AND job_id = ?`,
+        )
+        .get(STALE_WIDE_JOB_ID),
+    ).toEqual({
+      score_breakdown_json: null,
+      score_reasoning: "",
+      score_version: null,
+      scored_at: null,
+    });
+    const dashboard = db
+      .prepare(
+        `SELECT ready, applied, score_distribution_json, outcome_conversion_json
+           FROM dashboard_projections
+          WHERE tenant_id = 'local'`,
+      )
+      .get() as {
+      ready: number;
+      applied: number;
+      score_distribution_json: string;
+      outcome_conversion_json: string;
+    };
+    expect(dashboard).toMatchObject({
+      ready: 0,
+      applied: 1,
+      score_distribution_json: "[[7,1]]",
+    });
+    expect(JSON.parse(dashboard.outcome_conversion_json)).toMatchObject({
+      totals: { applied: 1 },
+      byBand: [{ band: "strong", applied: 1 }],
+      byApplyMode: [{ applyMode: "manual_marked", applied: 1 }],
+    });
+    expect(
+      db
+        .prepare(
+          "SELECT COUNT(*) AS count FROM artifact_list_projections WHERE tenant_id = 'local' AND job_id = ?",
+        )
+        .get(STALE_WIDE_JOB_ID),
+    ).toEqual({ count: 0 });
+    db.close();
   });
 
   it("uses explicit company truth without deriving employer from source or URL", () => {

--- a/apps/api/test/exact-v7-projections.test.ts
+++ b/apps/api/test/exact-v7-projections.test.ts
@@ -1,0 +1,88 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import Database from "better-sqlite3";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { refreshProjections } from "../src/projections.js";
+import { EXACT_V7_SCHEMA_MANIFEST, schemaManifest } from "../src/schema-manifest.js";
+import { initializeExactV7Database } from "./v7-schema.js";
+
+const JOB_ID = "00000000-0000-4000-8000-000000000071";
+const cleanups: Array<() => void> = [];
+
+afterEach(() => {
+  while (cleanups.length) cleanups.pop()?.();
+});
+
+describe("exact-v7 projection refresh", () => {
+  it("rebuilds only the requested tenant and leaves the schema manifest unchanged", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "jobctrl-api-v7-projections-"));
+    cleanups.push(() => fs.rmSync(dir, { recursive: true, force: true }));
+    const dbPath = path.join(dir, "jobs.db");
+    initializeExactV7Database(dbPath);
+    const db = new Database(dbPath);
+    db.pragma("foreign_keys = ON");
+    const before = schemaManifest(db, EXACT_V7_SCHEMA_MANIFEST.version);
+    expect(before).toEqual(EXACT_V7_SCHEMA_MANIFEST);
+
+    const insertJob = db.prepare(
+      `INSERT INTO jobs (tenant_id, job_id, url, title, company, site, discovered_at)
+       VALUES (?, ?, ?, ?, 'Example', 'example', '2026-07-31T12:00:00Z')`,
+    );
+    insertJob.run("local", JOB_ID, "https://jobs.example.test/local", "Local title");
+    insertJob.run("other", JOB_ID, "https://jobs.example.test/other", "Other title");
+    db.prepare(
+      `INSERT INTO job_enrichments (
+         tenant_id, job_id, current_status, application_url, updated_at
+       ) VALUES ('local', ?, 'completed', 'https://apply.example.test/local', '2026-07-31T12:00:00Z')`,
+    ).run(JOB_ID);
+    db.prepare(
+      `INSERT INTO job_stage_states (
+         tenant_id, job_id, stage, state, updated_at, retryable, version
+       ) VALUES ('local', ?, 'discover', 'succeeded', '2026-07-31T12:00:00Z', 0, 1)`,
+    ).run(JOB_ID);
+    db.prepare(
+      `INSERT INTO job_events (
+         tenant_id, job_id, identity_version, stage, event_type, occurred_at
+       ) VALUES ('local', ?, 1, 'discover', 'JobDiscovered', '2026-07-31T12:00:00Z')`,
+    ).run(JOB_ID);
+
+    refreshProjections(db, "local");
+    expect(
+      db
+        .prepare("SELECT title, application_url FROM job_list_projections WHERE tenant_id = ? AND job_id = ?")
+        .get("local", JOB_ID),
+    ).toEqual({ title: "Local title", application_url: "https://apply.example.test/local" });
+    expect(
+      db.prepare("SELECT COUNT(*) AS count FROM job_list_projections WHERE tenant_id = 'other'").get(),
+    ).toEqual({ count: 0 });
+
+    db.prepare("UPDATE jobs SET title = ? WHERE tenant_id = ? AND job_id = ?").run(
+      "Local title refreshed",
+      "local",
+      JOB_ID,
+    );
+    db.prepare(
+      `INSERT INTO job_events (
+         tenant_id, job_id, identity_version, stage, event_type, occurred_at
+       ) VALUES ('local', ?, 1, 'discover', 'JobUpdated', '2026-07-31T12:01:00Z')`,
+    ).run(JOB_ID);
+    refreshProjections(db, "local");
+    expect(
+      db
+        .prepare("SELECT title FROM job_list_projections WHERE tenant_id = ? AND job_id = ?")
+        .get("local", JOB_ID),
+    ).toEqual({ title: "Local title refreshed" });
+
+    refreshProjections(db, "other");
+    expect(
+      db
+        .prepare("SELECT title FROM job_list_projections WHERE tenant_id = ? AND job_id = ?")
+        .get("other", JOB_ID),
+    ).toEqual({ title: "Other title" });
+    expect(schemaManifest(db, EXACT_V7_SCHEMA_MANIFEST.version)).toEqual(before);
+    db.close();
+  });
+});

--- a/apps/api/test/pipeline-step-projection-parity.test.ts
+++ b/apps/api/test/pipeline-step-projection-parity.test.ts
@@ -12,7 +12,8 @@ import Database from "better-sqlite3";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { PROJECTION_WATERMARK_NAME } from "../src/contracts.js";
-import { ensureProjectionTables, refreshProjections } from "../src/projections.js";
+import { refreshProjections } from "../src/projections.js";
+import { initializeExactV7Database } from "./v7-schema.js";
 
 const FIXTURE_PATH = fileURLToPath(
   new URL(
@@ -36,40 +37,36 @@ interface Fixture {
 
 const fixture = JSON.parse(fs.readFileSync(FIXTURE_PATH, "utf8")) as Fixture;
 const databases: Database.Database[] = [];
+const directories: string[] = [];
 
 afterEach(() => {
   while (databases.length) {
     databases.pop()?.close();
   }
+  while (directories.length) {
+    fs.rmSync(directories.pop()!, { recursive: true, force: true });
+  }
 });
 
 function emptyDb(): Database.Database {
-  const db = new Database(":memory:");
+  const directory = fs.mkdtempSync("/tmp/jobctrl-api-pipeline-step-");
+  directories.push(directory);
+  const dbPath = `${directory}/jobctrl.db`;
+  initializeExactV7Database(dbPath);
+  const db = new Database(dbPath);
   databases.push(db);
-  db.exec(`
-    CREATE TABLE job_events (
-      event_id      INTEGER PRIMARY KEY AUTOINCREMENT,
-      job_url       TEXT,
-      stage         TEXT,
-      event_type    TEXT NOT NULL,
-      level         TEXT NOT NULL DEFAULT 'info',
-      message       TEXT,
-      occurred_at   TEXT NOT NULL,
-      payload_json  TEXT
-    );
-  `);
   return db;
 }
 
 function seedEvents(db: Database.Database): void {
   const insert = db.prepare(
     `INSERT INTO job_events (
-       event_id, job_url, stage, event_type, level, message, occurred_at,
-       payload_json
-     ) VALUES (?, NULL, 'workflow', ?, 'info', NULL, ?, ?)`,
+       event_id, tenant_id, job_id, identity_version, stage, event_type,
+       level, message, occurred_at, payload_json
+     ) VALUES (?, ?, NULL, 1, 'workflow', ?, 'info', NULL, ?, ?)`,
   );
   fixture.events.forEach((event, index) => {
-    insert.run(index + 1, event.eventType, event.occurredAt, JSON.stringify(event.payload));
+    insert.run(index + 1, fixture.tenantId, event.eventType, event.occurredAt, JSON.stringify(event.payload));
   });
 }
 
@@ -139,7 +136,6 @@ describe("pipeline_step_projections cross-runtime parity", () => {
 
   it("backfills lifecycle rows after another runtime advanced the watermark", () => {
     const db = seededDb();
-    ensureProjectionTables(db);
     const maxEventId = fixture.events.length;
     db.prepare(
       `INSERT INTO event_watermarks (projection_name, last_event_id, updated_at)

--- a/apps/api/test/projections.test.ts
+++ b/apps/api/test/projections.test.ts
@@ -1566,6 +1566,9 @@ describe("apply_run_projections without legacy apply_runs table", () => {
       seedSchema(dbPath);
       const db = new Database(dbPath);
       db.prepare(
+        "UPDATE jobs SET company = 'Acme', site = 'greenhouse' WHERE tenant_id = 'local' AND job_id = ?",
+      ).run(EVENT_JOB_ID);
+      db.prepare(
         `INSERT INTO job_source_observations (
           tenant_id, source_observation_id, job_id, source_id,
           source_native_id, observed_url, normalized_observed_url,
@@ -1609,17 +1612,37 @@ describe("apply_run_projections without legacy apply_runs table", () => {
           .json()
           .items.find((j: { jobKey: string }) => j.jobKey === EVENT_JOB_ID);
         expect(item).toMatchObject({
+          company: "Acme",
+          source: "greenhouse",
           discoverySource: "jobspy:linkedin",
           postingSource: "greenhouse:acme",
           postingSourceUrl: "https://boards.greenhouse.io/acme/jobs/123456",
         });
 
+        const companyFilteredRes = await app.inject({
+          method: "GET",
+          url: "/v1/jobs?company=Acme",
+        });
+        expect(companyFilteredRes.statusCode, companyFilteredRes.body).toBe(200);
+        expect(companyFilteredRes.json().items.map((job: { jobKey: string }) => job.jobKey)).toEqual([
+          EVENT_JOB_ID,
+        ]);
+
         const sourceFilteredRes = await app.inject({
+          method: "GET",
+          url: "/v1/jobs?source=greenhouse",
+        });
+        expect(sourceFilteredRes.statusCode, sourceFilteredRes.body).toBe(200);
+        expect(sourceFilteredRes.json().items.map((job: { jobKey: string }) => job.jobKey)).toEqual([
+          EVENT_JOB_ID,
+        ]);
+
+        const postingSourceFilteredRes = await app.inject({
           method: "GET",
           url: "/v1/jobs?source=greenhouse%3Aacme&q=event",
         });
-        expect(sourceFilteredRes.statusCode, sourceFilteredRes.body).toBe(200);
-        expect(sourceFilteredRes.json().items).toEqual(
+        expect(postingSourceFilteredRes.statusCode, postingSourceFilteredRes.body).toBe(200);
+        expect(postingSourceFilteredRes.json().items).toEqual(
           expect.arrayContaining([
             expect.objectContaining({
               jobKey: EVENT_JOB_ID,
@@ -1627,6 +1650,22 @@ describe("apply_run_projections without legacy apply_runs table", () => {
             }),
           ]),
         );
+
+        const combinedFilteredRes = await app.inject({
+          method: "GET",
+          url: "/v1/jobs?company=Acme&source=greenhouse",
+        });
+        expect(combinedFilteredRes.statusCode, combinedFilteredRes.body).toBe(200);
+        expect(combinedFilteredRes.json().items.map((job: { jobKey: string }) => job.jobKey)).toEqual([
+          EVENT_JOB_ID,
+        ]);
+
+        const crossedFilterRes = await app.inject({
+          method: "GET",
+          url: "/v1/jobs?company=greenhouse&source=Acme",
+        });
+        expect(crossedFilterRes.statusCode, crossedFilterRes.body).toBe(200);
+        expect(crossedFilterRes.json().items).toEqual([]);
 
         const detailRes = await app.inject({
           method: "GET",

--- a/apps/api/test/projections.test.ts
+++ b/apps/api/test/projections.test.ts
@@ -12,8 +12,16 @@ import fs from "node:fs";
 import { fileURLToPath } from "node:url";
 import Database from "better-sqlite3";
 
-import { ensureProjectionTables } from "../src/projections.js";
+import { BUILT_IN_RESUME_TEMPLATE_THEME } from "../src/resume-templates.js";
 import { buildApp } from "../src/server.js";
+import { initializeExactV7Database } from "./v7-schema.js";
+
+const EVENT_JOB_URL = "https://example.com/jobs/event-driven";
+const EVENT_JOB_ID = "00000000-0000-4000-8000-000000000001";
+
+function projectionFixtureJobId(index: number): string {
+  return `00000000-0000-4000-8000-${String(index).padStart(12, "0")}`;
+}
 
 function withTempDb(): { dbPath: string; cleanup: () => void } {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "jobctrl-api-projections-"));
@@ -25,132 +33,16 @@ function withTempDb(): { dbPath: string; cleanup: () => void } {
 }
 
 function seedSchema(dbPath: string): void {
+  initializeExactV7Database(dbPath);
   const db = new Database(dbPath);
-  db.exec(`
-    CREATE TABLE jobs (
-      url TEXT PRIMARY KEY,
-      title TEXT,
-      company TEXT,
-      site TEXT,
-      strategy TEXT,
-      location TEXT,
-      salary TEXT,
-      discovered_at TEXT,
-      application_url TEXT,
-      description TEXT,
-      full_description TEXT,
-      detail_scraped_at TEXT,
-      detail_error TEXT,
-      fit_score INTEGER,
-      score_reasoning TEXT,
-      scored_at TEXT,
-      tailored_resume_path TEXT,
-      tailored_at TEXT,
-      tailor_attempts INTEGER DEFAULT 0,
-      cover_letter_path TEXT,
-      cover_letter_at TEXT,
-      cover_attempts INTEGER DEFAULT 0,
-      applied_at TEXT,
-      apply_status TEXT,
-      apply_error TEXT,
-      apply_attempts INTEGER DEFAULT 0,
-      agent_id TEXT,
-      last_attempted_at TEXT,
-      apply_duration_ms INTEGER,
-      apply_task_id TEXT,
-      verification_confidence TEXT
-    );
-    CREATE TABLE job_stage_states (
-      job_url TEXT NOT NULL,
-      stage TEXT NOT NULL,
-      state TEXT NOT NULL DEFAULT 'pending',
-      attempt_count INTEGER DEFAULT 0,
-      max_attempts INTEGER,
-      started_at TEXT,
-      updated_at TEXT NOT NULL DEFAULT '',
-      finished_at TEXT,
-      duration_ms INTEGER,
-      error_code TEXT,
-      error_message TEXT,
-      retryable INTEGER DEFAULT 1,
-      blocked_by_json TEXT,
-      next_action TEXT,
-      metadata_json TEXT,
-      version INTEGER NOT NULL DEFAULT 0,
-      PRIMARY KEY (job_url, stage)
-    );
-    CREATE TABLE job_events (
-      event_id INTEGER PRIMARY KEY AUTOINCREMENT,
-      job_url TEXT,
-      stage TEXT,
-      event_type TEXT NOT NULL DEFAULT '',
-      level TEXT NOT NULL DEFAULT 'info',
-      message TEXT,
-      occurred_at TEXT NOT NULL,
-      payload_json TEXT
-    );
-    CREATE TABLE apply_run_projections (
-      run_id TEXT PRIMARY KEY,
-      tenant_id TEXT NOT NULL DEFAULT 'local',
-      job_id TEXT NOT NULL,
-      job_title TEXT NOT NULL DEFAULT '',
-      job_employer TEXT NOT NULL DEFAULT '',
-      status TEXT NOT NULL DEFAULT '',
-      result TEXT,
-      dry_run INTEGER NOT NULL DEFAULT 0,
-      worker_id INTEGER,
-      model TEXT,
-      started_at TEXT,
-      finished_at TEXT,
-      duration_ms INTEGER,
-      events_json TEXT NOT NULL DEFAULT '[]'
-    );
-    CREATE TABLE job_scores (
-      job_url TEXT NOT NULL,
-      version INTEGER NOT NULL,
-      tenant_id TEXT NOT NULL DEFAULT 'local',
-      fit_score INTEGER NOT NULL,
-      breakdown_json TEXT NOT NULL,
-      keywords_json TEXT NOT NULL,
-      scored_at TEXT NOT NULL,
-      correction_json TEXT,
-      criteria_json TEXT NOT NULL DEFAULT '{}',
-      trace_json TEXT NOT NULL DEFAULT '{}',
-      PRIMARY KEY (job_url, version)
-    );
-    CREATE TABLE operational_attempt_metrics (
-      metric_id INTEGER PRIMARY KEY AUTOINCREMENT,
-      tenant_id TEXT NOT NULL DEFAULT 'local',
-      occurred_at TEXT NOT NULL,
-      stage TEXT NOT NULL,
-      source_id TEXT,
-      source_kind TEXT,
-      source_priority TEXT,
-      source_role TEXT,
-      adapter TEXT,
-      attempt_kind TEXT NOT NULL,
-      outcome TEXT NOT NULL,
-      failure_category TEXT,
-      is_operational_failure INTEGER NOT NULL DEFAULT 0,
-      is_scrape_failure INTEGER NOT NULL DEFAULT 0,
-      is_retryable INTEGER NOT NULL DEFAULT 1,
-      run_id TEXT,
-      job_url TEXT,
-      duration_ms INTEGER,
-      total_count INTEGER,
-      new_count INTEGER,
-      existing_count INTEGER,
-      observed_count INTEGER,
-      duplicate_count INTEGER,
-      error_class TEXT,
-      error_message TEXT,
-      metadata_json TEXT NOT NULL DEFAULT '{}'
-    );
-  `);
+  seedBuiltInResumeTemplate(db);
   db.prepare(
-    "INSERT INTO jobs (url, title, site, fit_score, score_reasoning, application_url) VALUES (?, ?, ?, ?, ?, ?)",
+    `INSERT INTO jobs (
+       tenant_id, job_id, url, title, site, fit_score, score_reasoning, application_url
+     ) VALUES ('local', ?, ?, ?, ?, ?, ?, ?)`,
   ).run(
-    "https://example.com/jobs/event-driven",
+    EVENT_JOB_ID,
+    EVENT_JOB_URL,
     "Event-Driven Engineer",
     "ExampleCo",
     9,
@@ -158,11 +50,10 @@ function seedSchema(dbPath: string): void {
     "https://example.com/apply/event",
   );
   db.prepare(
-    "INSERT INTO job_scores (job_url, version, tenant_id, fit_score, breakdown_json, keywords_json, scored_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+    "INSERT INTO job_scores (tenant_id, job_id, version, fit_score, breakdown_json, keywords_json, scored_at) VALUES ('local', ?, ?, ?, ?, ?, ?)",
   ).run(
-    "https://example.com/jobs/event-driven",
+    EVENT_JOB_ID,
     1,
-    "local",
     7,
     JSON.stringify({
       technical_fit: 7,
@@ -175,13 +66,12 @@ function seedSchema(dbPath: string): void {
   );
   db.prepare(
     `INSERT INTO job_scores (
-      job_url, version, tenant_id, fit_score, breakdown_json, keywords_json,
+      tenant_id, job_id, version, fit_score, breakdown_json, keywords_json,
       scored_at, criteria_json, trace_json
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    ) VALUES ('local', ?, ?, ?, ?, ?, ?, ?, ?)`,
   ).run(
-    "https://example.com/jobs/event-driven",
+    EVENT_JOB_ID,
     2,
-    "local",
     8,
     JSON.stringify({
       technical_fit: 9,
@@ -215,10 +105,10 @@ function seedSchema(dbPath: string): void {
     }),
   );
   db.prepare(
-    "INSERT INTO apply_run_projections (run_id, job_id, job_title, job_employer, status, result, dry_run, started_at, finished_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+    "INSERT INTO apply_run_projections (run_id, tenant_id, job_id, job_title, job_employer, status, result, dry_run, started_at, finished_at) VALUES (?, 'local', ?, ?, ?, ?, ?, ?, ?, ?)",
   ).run(
     "run-event-driven",
-    "https://example.com/jobs/event-driven",
+    EVENT_JOB_ID,
     "Event-Driven Engineer",
     "ExampleCo",
     "succeeded",
@@ -227,7 +117,27 @@ function seedSchema(dbPath: string): void {
     "2026-05-04T13:00:00+00:00",
     "2026-05-04T13:05:00+00:00",
   );
+  db.prepare(
+    `INSERT INTO job_stage_states (
+       tenant_id, job_id, stage, state, updated_at, finished_at
+     ) VALUES ('local', ?, 'discover', 'succeeded', ?, ?)`,
+  ).run(EVENT_JOB_ID, "2026-05-04T12:00:00+00:00", "2026-05-04T12:00:00+00:00");
   db.close();
+}
+
+function seedBuiltInResumeTemplate(db: Database.Database): void {
+  db.prepare(
+    `INSERT INTO resume_templates (
+       tenant_id, template_id, display_name, status, built_in, created_at, updated_at
+     ) VALUES ('local', 'built_in:modern-html', 'Modern HTML', 'active', 1, ?, ?)`,
+  ).run("2026-05-04T12:00:00+00:00", "2026-05-04T12:00:00+00:00");
+  db.prepare(
+    `INSERT INTO resume_template_versions (
+       tenant_id, version_id, template_id, version_number, display_name, status,
+       theme_json, layout_json, content_hash, created_at
+     ) VALUES ('local', 'built_in:modern-html:v1', 'built_in:modern-html', 1,
+               'Modern HTML', 'active', ?, '{}', 'projection-fixture-template', ?)`,
+  ).run(JSON.stringify(BUILT_IN_RESUME_TEMPLATE_THEME), "2026-05-04T12:00:00+00:00");
 }
 
 function insertEvent(
@@ -238,8 +148,8 @@ function insertEvent(
 ): void {
   const db = new Database(dbPath);
   db.prepare(
-    "INSERT INTO job_events (job_url, stage, event_type, level, message, occurred_at, payload_json) VALUES (?, ?, ?, ?, ?, ?, ?)",
-  ).run(null, "discover", eventType, "info", eventType, occurredAt, JSON.stringify(payload));
+    "INSERT INTO job_events (tenant_id, job_id, identity_version, stage, event_type, level, message, occurred_at, payload_json) VALUES ('local', NULL, 1, ?, ?, 'info', ?, ?, ?)",
+  ).run("discover", eventType, eventType, occurredAt, JSON.stringify(payload));
   db.close();
 }
 
@@ -310,72 +220,13 @@ function insertOperationalMetric(
 
 function insertCompensationRows(dbPath: string): void {
   const db = new Database(dbPath);
-  const jobUrl = "https://example.com/jobs/event-driven";
-  db.prepare("UPDATE jobs SET salary = ? WHERE url = ?").run("USD 70000-90000/year", jobUrl);
-  db.exec(`
-    CREATE TABLE job_posted_compensation_facts (
-      tenant_id TEXT NOT NULL DEFAULT 'local',
-      job_url TEXT NOT NULL,
-      source_field TEXT NOT NULL DEFAULT 'jobs.salary',
-      source_text TEXT,
-      legacy_raw_salary TEXT,
-      parse_state TEXT NOT NULL,
-      currency TEXT,
-      period TEXT NOT NULL DEFAULT 'unknown',
-      component TEXT NOT NULL DEFAULT 'unknown',
-      minimum_amount INTEGER,
-      maximum_amount INTEGER,
-      annualized_minimum_amount INTEGER,
-      annualized_maximum_amount INTEGER,
-      annualization_assumption TEXT,
-      confidence TEXT NOT NULL DEFAULT 'none',
-      warnings_json TEXT NOT NULL DEFAULT '[]',
-      parser_version TEXT NOT NULL,
-      source_hash TEXT NOT NULL,
-      parsed_at TEXT NOT NULL,
-      PRIMARY KEY (tenant_id, job_url)
-    );
-    CREATE TABLE job_market_compensation_estimates (
-      tenant_id TEXT NOT NULL DEFAULT 'local',
-      job_url TEXT NOT NULL,
-      estimate_state TEXT NOT NULL,
-      currency TEXT,
-      period TEXT NOT NULL DEFAULT 'year',
-      component TEXT NOT NULL DEFAULT 'base_salary',
-      minimum_amount INTEGER,
-      maximum_amount INTEGER,
-      confidence_interval_minimum_amount INTEGER,
-      confidence_interval_maximum_amount INTEGER,
-      confidence_band TEXT NOT NULL DEFAULT 'none',
-      confidence_score REAL NOT NULL DEFAULT 0,
-      source_count INTEGER NOT NULL DEFAULT 0,
-      sample_count INTEGER,
-      aggregate_bucket TEXT,
-      geography_scope TEXT,
-      occupation_code TEXT,
-      occupation_label TEXT,
-      seniority_label TEXT,
-      source_snapshot_json TEXT NOT NULL DEFAULT '[]',
-      factor_reasons_json TEXT NOT NULL DEFAULT '[]',
-      selected_evidence_json TEXT NOT NULL DEFAULT '[]',
-      insufficient_reasons_json TEXT NOT NULL DEFAULT '[]',
-      unsupported_reasons_json TEXT NOT NULL DEFAULT '[]',
-      source_unavailable_reasons_json TEXT NOT NULL DEFAULT '[]',
-      warnings_json TEXT NOT NULL DEFAULT '[]',
-      estimator_version TEXT NOT NULL,
-      estimated_at TEXT NOT NULL,
-      company_name TEXT,
-      normalized_company TEXT,
-      role_title TEXT,
-      normalized_role TEXT,
-      company_tier TEXT NOT NULL DEFAULT 'unknown',
-      match_scope TEXT NOT NULL DEFAULT 'none',
-      PRIMARY KEY (tenant_id, job_url)
-    );
-  `);
+  db.prepare("UPDATE jobs SET salary = ? WHERE tenant_id = 'local' AND job_id = ?").run(
+    "USD 70000-90000/year",
+    EVENT_JOB_ID,
+  );
   db.prepare(
     `INSERT INTO job_posted_compensation_facts (
-      tenant_id, job_url, source_field, source_text, legacy_raw_salary,
+      tenant_id, job_id, source_field, source_text, legacy_raw_salary,
       parse_state, currency, period, component, minimum_amount, maximum_amount,
       annualized_minimum_amount, annualized_maximum_amount,
       annualization_assumption, confidence, warnings_json, parser_version,
@@ -383,7 +234,7 @@ function insertCompensationRows(dbPath: string): void {
     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   ).run(
     "local",
-    jobUrl,
+    EVENT_JOB_ID,
     "jobs.salary",
     "USD 70000-90000/year",
     "USD 70000-90000/year",
@@ -404,7 +255,7 @@ function insertCompensationRows(dbPath: string): void {
   );
   db.prepare(
     `INSERT INTO job_market_compensation_estimates (
-      tenant_id, job_url, estimate_state, currency, period, component,
+      tenant_id, job_id, estimate_state, currency, period, component,
       minimum_amount, maximum_amount, confidence_interval_minimum_amount,
       confidence_interval_maximum_amount, confidence_band, confidence_score,
       source_count, sample_count, aggregate_bucket, geography_scope,
@@ -415,7 +266,7 @@ function insertCompensationRows(dbPath: string): void {
     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   ).run(
     "local",
-    jobUrl,
+    EVENT_JOB_ID,
     "estimated_range",
     "EUR",
     "year",
@@ -502,244 +353,6 @@ function insertCompensationRows(dbPath: string): void {
   db.close();
 }
 
-// Source tables the career evidence map reads, plus the soft-delete/hidden
-// lifecycle tables owned by the TS write-model. Mirrors the inline schema of
-// the evidence-map projection test so the deleted/hidden regression fixture can
-// seed canonical rows.
-function createEvidenceMapSchema(db: Database.Database): void {
-  db.exec(`
-    CREATE TABLE candidate_profile_experience_entries (
-      tenant_id TEXT NOT NULL,
-      profile_id TEXT NOT NULL,
-      entry_id TEXT NOT NULL,
-      position_index INTEGER NOT NULL,
-      date_range TEXT NOT NULL DEFAULT '',
-      title TEXT NOT NULL DEFAULT '',
-      company TEXT NOT NULL DEFAULT '',
-      location TEXT NOT NULL DEFAULT '',
-      PRIMARY KEY (tenant_id, profile_id, entry_id)
-    );
-    CREATE TABLE candidate_profile_achievement_evidence (
-      tenant_id TEXT NOT NULL,
-      profile_id TEXT NOT NULL,
-      entry_id TEXT NOT NULL,
-      evidence_index INTEGER NOT NULL,
-      evidence_id TEXT NOT NULL DEFAULT '',
-      source_text TEXT NOT NULL DEFAULT '',
-      scope TEXT NOT NULL DEFAULT '',
-      action TEXT NOT NULL DEFAULT '',
-      tools_json TEXT NOT NULL DEFAULT '[]',
-      metrics_json TEXT NOT NULL DEFAULT '[]',
-      outcome TEXT NOT NULL DEFAULT '',
-      seniority_signal TEXT NOT NULL DEFAULT '',
-      evidence_strength TEXT NOT NULL DEFAULT 'supported',
-      claim_confidence REAL NOT NULL DEFAULT 0,
-      user_confirmed INTEGER NOT NULL DEFAULT 0,
-      tags_json TEXT NOT NULL DEFAULT '[]',
-      PRIMARY KEY (tenant_id, profile_id, entry_id, evidence_index)
-    );
-    CREATE TABLE candidate_profile_skill_categories (
-      tenant_id TEXT NOT NULL,
-      profile_id TEXT NOT NULL,
-      category_id TEXT NOT NULL,
-      position_index INTEGER NOT NULL,
-      label TEXT NOT NULL DEFAULT '',
-      PRIMARY KEY (tenant_id, profile_id, category_id)
-    );
-    CREATE TABLE candidate_profile_skill_items (
-      tenant_id TEXT NOT NULL,
-      profile_id TEXT NOT NULL,
-      category_id TEXT NOT NULL,
-      item_index INTEGER NOT NULL,
-      item_text TEXT NOT NULL,
-      PRIMARY KEY (tenant_id, profile_id, category_id, item_index)
-    );
-    CREATE TABLE job_materials (
-      job_url TEXT NOT NULL,
-      generation INTEGER NOT NULL,
-      tenant_id TEXT NOT NULL DEFAULT 'local',
-      status TEXT NOT NULL,
-      created_at TEXT NOT NULL,
-      updated_at TEXT NOT NULL,
-      PRIMARY KEY (job_url, generation)
-    );
-    CREATE TABLE job_materials_artifacts (
-      job_url TEXT NOT NULL,
-      generation INTEGER NOT NULL,
-      artifact_type TEXT NOT NULL,
-      artifact_id TEXT NOT NULL,
-      status TEXT NOT NULL,
-      path TEXT NOT NULL,
-      render_format TEXT NOT NULL,
-      size_bytes INTEGER,
-      metadata_json TEXT,
-      created_at TEXT NOT NULL,
-      superseded_at TEXT,
-      PRIMARY KEY (job_url, generation, artifact_type)
-    );
-    CREATE TABLE job_bullet_provenance (
-      job_url TEXT NOT NULL,
-      generation INTEGER NOT NULL,
-      bullet_id TEXT NOT NULL,
-      tenant_id TEXT NOT NULL DEFAULT 'local',
-      artifact_id TEXT NOT NULL,
-      section TEXT NOT NULL,
-      source_id TEXT,
-      evidence_ids_json TEXT NOT NULL DEFAULT '[]',
-      requirement_ids_json TEXT NOT NULL DEFAULT '[]',
-      matched_keywords_json TEXT NOT NULL DEFAULT '[]',
-      transform_type TEXT NOT NULL,
-      control TEXT NOT NULL,
-      rationale TEXT NOT NULL DEFAULT '',
-      generated_text TEXT NOT NULL,
-      position INTEGER NOT NULL DEFAULT 0,
-      created_at TEXT NOT NULL,
-      coverage_json TEXT,
-      voice_json TEXT,
-      PRIMARY KEY (job_url, generation, bullet_id)
-    );
-    CREATE TABLE job_requirement_fit_reports (
-      job_url TEXT NOT NULL,
-      score_version INTEGER NOT NULL,
-      tenant_id TEXT NOT NULL DEFAULT 'local',
-      employer_analysis_generation INTEGER NOT NULL,
-      profile_snapshot_version INTEGER NOT NULL,
-      scoring_policy_version INTEGER NOT NULL,
-      formula_version TEXT NOT NULL,
-      resolved_fit_score INTEGER,
-      fit_band TEXT NOT NULL,
-      confidence TEXT NOT NULL,
-      summary_json TEXT NOT NULL,
-      created_at TEXT NOT NULL,
-      PRIMARY KEY (job_url, score_version, tenant_id)
-    );
-    CREATE TABLE job_requirement_fit_items (
-      job_url TEXT NOT NULL,
-      score_version INTEGER NOT NULL,
-      tenant_id TEXT NOT NULL DEFAULT 'local',
-      requirement_id TEXT NOT NULL,
-      requirement_text TEXT NOT NULL,
-      tier TEXT NOT NULL,
-      weight REAL NOT NULL,
-      job_evidence_span TEXT NOT NULL,
-      fit_json TEXT NOT NULL,
-      contribution_json TEXT NOT NULL,
-      tailoring_json TEXT NOT NULL,
-      artifact_coverage_json TEXT,
-      position INTEGER NOT NULL DEFAULT 0,
-      PRIMARY KEY (job_url, score_version, tenant_id, requirement_id)
-    );
-    CREATE TABLE jobctrl_deleted_jobs (
-      job_url TEXT PRIMARY KEY,
-      deleted_at TEXT NOT NULL,
-      reason TEXT,
-      restored_at TEXT
-    );
-    CREATE TABLE jobctrl_hidden_jobs (
-      job_url TEXT PRIMARY KEY,
-      hidden_at TEXT NOT NULL,
-      reason TEXT,
-      unhidden_at TEXT
-    );
-  `);
-}
-
-describe("projection schema upgrades", () => {
-  it("adds workflow-run projection columns to existing legacy tables", () => {
-    const { dbPath, cleanup } = withTempDb();
-    try {
-      const db = new Database(dbPath);
-      try {
-        db.exec(`
-          CREATE TABLE workflow_run_projections (
-            workflow_id            TEXT PRIMARY KEY,
-            run_id                 TEXT NOT NULL DEFAULT '',
-            tenant_id              TEXT NOT NULL DEFAULT 'local',
-            workflow_type          TEXT NOT NULL DEFAULT 'pipeline',
-            job_id                 TEXT NOT NULL DEFAULT '',
-            title                  TEXT NOT NULL DEFAULT '',
-            company                TEXT NOT NULL DEFAULT '',
-            status                 TEXT NOT NULL DEFAULT 'starting',
-            result                 TEXT,
-            dry_run                INTEGER NOT NULL DEFAULT 0,
-            model                  TEXT,
-            started_at             TEXT,
-            finished_at            TEXT,
-            duration_ms            INTEGER,
-            stages_json            TEXT NOT NULL DEFAULT '[]',
-            events_json            TEXT NOT NULL DEFAULT '[]'
-          );
-        `);
-
-        expect(ensureProjectionTables(db)).toBe(true);
-
-        const columns = new Set(
-          (db.prepare("PRAGMA table_info(workflow_run_projections)").all() as Array<{ name: string }>).map(
-            (row) => row.name,
-          ),
-        );
-        expect([...columns]).toEqual(
-          expect.arrayContaining([
-            "input_summary_json",
-            "error_code",
-            "error_message",
-            "retryable",
-            "temporal_run_id",
-          ]),
-        );
-      } finally {
-        db.close();
-      }
-    } finally {
-      cleanup();
-    }
-  });
-
-  it("tolerates a concurrent process adding a column between check and ALTER", () => {
-    const { dbPath, cleanup } = withTempDb();
-    try {
-      const db = new Database(dbPath);
-      try {
-        ensureProjectionTables(db);
-
-        // Simulate the Python worker winning the check-then-ALTER race on the
-        // shared SQLite file: the pre-ALTER check sees the column as missing,
-        // but the ALTER hits a table that already has it.
-        const realPrepare = db.prepare.bind(db);
-        const realExec = db.exec.bind(db);
-        let staleCheckArmed = true;
-        let duplicateAlterAttempted = false;
-        Reflect.set(db, "prepare", (sql: string) => {
-          const statement = realPrepare(sql);
-          if (staleCheckArmed && sql.includes("table_info(workflow_run_projections)")) {
-            return {
-              all: () =>
-                (statement.all() as Array<{ name: string }>).filter(
-                  (row) => row.name !== "input_summary_json",
-                ),
-            };
-          }
-          return statement;
-        });
-        Reflect.set(db, "exec", (sql: string) => {
-          if (sql.includes("ADD COLUMN input_summary_json")) {
-            staleCheckArmed = false;
-            duplicateAlterAttempted = true;
-          }
-          return realExec(sql);
-        });
-
-        expect(() => ensureProjectionTables(db)).not.toThrow();
-        expect(duplicateAlterAttempted).toBe(true);
-      } finally {
-        db.close();
-      }
-    } finally {
-      cleanup();
-    }
-  });
-});
-
 describe("apply_run_projections without legacy apply_runs table", () => {
   it("dashboard summary surfaces the projection row when apply_runs is absent", async () => {
     const { dbPath, cleanup } = withTempDb();
@@ -781,7 +394,7 @@ describe("apply_run_projections without legacy apply_runs table", () => {
         expect(res.statusCode, res.body).toBe(200);
         const item = res
           .json()
-          .items.find((j: { jobKey: string }) => j.jobKey === "https://example.com/jobs/event-driven");
+          .items.find((j: { jobKey: string }) => j.jobKey === EVENT_JOB_ID);
         expect(item).toBeDefined();
         expect(item.applyStatus).toBe("applied");
         expect(item.appliedAt).toBe("2026-05-04T13:05:00+00:00");
@@ -817,7 +430,7 @@ describe("apply_run_projections without legacy apply_runs table", () => {
                FROM job_list_projections
               WHERE tenant_id = 'local' AND job_id = ?`,
           )
-          .get("https://example.com/jobs/event-driven") as
+          .get(EVENT_JOB_ID) as
           | { salary: string; compensation_summary_json: string }
           | undefined;
         expect(listProjection?.salary).toBe("USD 70000-90000/year");
@@ -871,7 +484,7 @@ describe("apply_run_projections without legacy apply_runs table", () => {
                FROM job_detail_projections
               WHERE tenant_id = 'local' AND job_id = ?`,
           )
-          .get("https://example.com/jobs/event-driven") as
+          .get(EVENT_JOB_ID) as
           | { compensation_audit_json: string }
           | undefined;
         const audit = JSON.parse(detailProjection?.compensation_audit_json ?? "{}");
@@ -938,7 +551,7 @@ describe("apply_run_projections without legacy apply_runs table", () => {
                   normalized_role = ?,
                   company_tier = ?,
                   match_scope = ?
-            WHERE tenant_id = 'local' AND job_url = ?`,
+            WHERE tenant_id = 'local' AND job_id = ?`,
         ).run(
           168000,
           190000,
@@ -1027,7 +640,7 @@ describe("apply_run_projections without legacy apply_runs table", () => {
           "platform engineer",
           "tier_3_top_of_market",
           "tier_role_fallback",
-          "https://example.com/jobs/event-driven",
+          EVENT_JOB_ID,
         );
       } finally {
         db.close();
@@ -1054,7 +667,7 @@ describe("apply_run_projections without legacy apply_runs table", () => {
                  ON d.tenant_id = l.tenant_id AND d.job_id = l.job_id
               WHERE l.tenant_id = 'local' AND l.job_id = ?`,
           )
-          .get("https://example.com/jobs/event-driven") as
+          .get(EVENT_JOB_ID) as
           | { compensation_summary_json: string; compensation_audit_json: string }
           | undefined;
         const summary = JSON.parse(projections?.compensation_summary_json ?? "{}");
@@ -1158,29 +771,29 @@ describe("apply_run_projections without legacy apply_runs table", () => {
       seedSchema(dbPath);
       const db = new Database(dbPath);
       const insertStage = db.prepare(
-        `INSERT INTO job_stage_states (job_url, stage, state, updated_at, finished_at)
-         VALUES (?, ?, ?, ?, ?)
-         ON CONFLICT(job_url, stage) DO UPDATE SET
+        `INSERT INTO job_stage_states (tenant_id, job_id, stage, state, updated_at, finished_at)
+         VALUES ('local', ?, ?, ?, ?, ?)
+         ON CONFLICT(tenant_id, job_id, stage) DO UPDATE SET
            state = excluded.state,
            updated_at = excluded.updated_at,
            finished_at = excluded.finished_at`,
       );
       insertStage.run(
-        "https://example.com/jobs/event-driven",
+        EVENT_JOB_ID,
         "discover",
         "succeeded",
         "2026-05-04T13:00:00+00:00",
         "2026-05-04T13:00:00+00:00",
       );
       insertStage.run(
-        "https://example.com/jobs/event-driven",
+        EVENT_JOB_ID,
         "enrich",
         "succeeded",
         "2026-05-04T13:05:00+00:00",
         "2026-05-04T13:05:00+00:00",
       );
       insertStage.run(
-        "https://example.com/jobs/event-driven",
+        EVENT_JOB_ID,
         "score",
         "pending",
         "2026-05-04T13:10:00+00:00",
@@ -1197,7 +810,7 @@ describe("apply_run_projections without legacy apply_runs table", () => {
         expect(listRes.statusCode, listRes.body).toBe(200);
         const item = listRes
           .json()
-          .items.find((job: { jobKey: string }) => job.jobKey === "https://example.com/jobs/event-driven");
+          .items.find((job: { jobKey: string }) => job.jobKey === EVENT_JOB_ID);
         expect(item).toMatchObject({
           currentStage: "discover",
           currentState: "pending",
@@ -1231,7 +844,7 @@ describe("apply_run_projections without legacy apply_runs table", () => {
       try {
         const baseline = await app.inject({ method: "GET", url: "/v1/jobs?q=event" });
         expect(baseline.statusCode, baseline.body).toBe(200);
-        const item = baseline.json().items.find((job: { jobKey: string }) => job.jobKey === jobUrl);
+        const item = baseline.json().items.find((job: { jobKey: string }) => job.jobKey === EVENT_JOB_ID);
         expect(item).toMatchObject({
           currentStage: "discover",
           currentSubstage: "enrich",
@@ -1243,25 +856,24 @@ describe("apply_run_projections without legacy apply_runs table", () => {
 
       const db = new Database(dbPath);
       const insertStage = db.prepare(
-        `INSERT INTO job_stage_states (job_url, stage, state, updated_at, finished_at)
-         VALUES (?, ?, ?, ?, ?)
-         ON CONFLICT(job_url, stage) DO UPDATE SET
+        `INSERT INTO job_stage_states (tenant_id, job_id, stage, state, updated_at, finished_at)
+         VALUES ('local', ?, ?, ?, ?, ?)
+         ON CONFLICT(tenant_id, job_id, stage) DO UPDATE SET
            state = excluded.state,
            updated_at = excluded.updated_at,
            finished_at = excluded.finished_at`,
       );
-      insertStage.run(jobUrl, "discover", "succeeded", "2026-05-04T13:00:00+00:00", "2026-05-04T13:00:00+00:00");
-      insertStage.run(jobUrl, "enrich", "succeeded", "2026-05-04T13:05:00+00:00", "2026-05-04T13:05:00+00:00");
-      insertStage.run(jobUrl, "score", "pending", "2026-05-04T13:10:00+00:00", null);
+      insertStage.run(EVENT_JOB_ID, "discover", "succeeded", "2026-05-04T13:00:00+00:00", "2026-05-04T13:00:00+00:00");
+      insertStage.run(EVENT_JOB_ID, "enrich", "succeeded", "2026-05-04T13:05:00+00:00", "2026-05-04T13:05:00+00:00");
+      insertStage.run(EVENT_JOB_ID, "score", "pending", "2026-05-04T13:10:00+00:00", null);
       db.prepare("UPDATE job_list_projections SET last_updated_at = ? WHERE tenant_id = ? AND job_id = ?").run(
         "2026-05-04T12:00:00+00:00",
         "local",
-        jobUrl,
+        EVENT_JOB_ID,
       );
       db.prepare(
-        "INSERT INTO job_events (job_url, stage, event_type, level, message, occurred_at, payload_json) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        "INSERT INTO job_events (tenant_id, job_id, identity_version, stage, event_type, level, message, occurred_at, payload_json) VALUES ('local', NULL, 1, ?, ?, ?, ?, ?, ?)",
       ).run(
-        null,
         "discover",
         "StageCompleted",
         "info",
@@ -1278,7 +890,7 @@ describe("apply_run_projections without legacy apply_runs table", () => {
       try {
         const listRes = await refreshedApp.inject({ method: "GET", url: "/v1/jobs?q=event" });
         expect(listRes.statusCode, listRes.body).toBe(200);
-        const item = listRes.json().items.find((job: { jobKey: string }) => job.jobKey === jobUrl);
+        const item = listRes.json().items.find((job: { jobKey: string }) => job.jobKey === EVENT_JOB_ID);
         expect(item).toMatchObject({
           currentStage: "discover",
           currentSubstage: "score",
@@ -1310,17 +922,36 @@ describe("apply_run_projections without legacy apply_runs table", () => {
     try {
       seedSchema(dbPath);
       const db = new Database(dbPath);
-      db.prepare("UPDATE jobs SET tailored_resume_path = ?, tailored_at = ? WHERE url = ?").run(
+      db.prepare(
+        `INSERT INTO job_materials (
+           tenant_id, job_id, generation, status, created_at, updated_at
+         ) VALUES ('local', ?, 1, 'complete', ?, ?)`,
+      ).run(
+        EVENT_JOB_ID,
+        "2026-05-04T13:12:00+00:00",
+        "2026-05-04T13:12:00+00:00",
+      );
+      db.prepare(
+        `INSERT INTO job_materials_artifacts (
+           tenant_id, job_id, generation, artifact_type, artifact_id, status, path,
+           render_format, created_at
+         ) VALUES ('local', ?, 1, 'tailored_resume', 'resume-cover-ready', 'approved', ?, 'text', ?)`,
+      ).run(
+        EVENT_JOB_ID,
         "/tmp/tailored-resume.txt",
         "2026-05-04T13:12:00+00:00",
-        "https://example.com/jobs/event-driven",
       );
       const insertStage = db.prepare(
-        "INSERT INTO job_stage_states (job_url, stage, state, updated_at, finished_at) VALUES (?, ?, ?, ?, ?)",
+        `INSERT INTO job_stage_states (tenant_id, job_id, stage, state, updated_at, finished_at)
+         VALUES ('local', ?, ?, ?, ?, ?)
+         ON CONFLICT(tenant_id, job_id, stage) DO UPDATE SET
+           state = excluded.state,
+           updated_at = excluded.updated_at,
+           finished_at = excluded.finished_at`,
       );
       for (const stage of ["discover", "enrich", "score", "tailor"]) {
         insertStage.run(
-          "https://example.com/jobs/event-driven",
+          EVENT_JOB_ID,
           stage,
           "succeeded",
           "2026-05-04T13:00:00+00:00",
@@ -1328,7 +959,7 @@ describe("apply_run_projections without legacy apply_runs table", () => {
         );
       }
       insertStage.run(
-        "https://example.com/jobs/event-driven",
+        EVENT_JOB_ID,
         "cover",
         "pending",
         "2026-05-04T13:15:00+00:00",
@@ -1345,7 +976,7 @@ describe("apply_run_projections without legacy apply_runs table", () => {
         expect(listRes.statusCode, listRes.body).toBe(200);
         const item = listRes
           .json()
-          .items.find((job: { jobKey: string }) => job.jobKey === "https://example.com/jobs/event-driven");
+          .items.find((job: { jobKey: string }) => job.jobKey === EVENT_JOB_ID);
         expect(item).toMatchObject({
           currentStage: "apply",
           currentSubstage: "cover",
@@ -1364,56 +995,28 @@ describe("apply_run_projections without legacy apply_runs table", () => {
     try {
       seedSchema(dbPath);
       const db = new Database(dbPath);
-      db.exec(`
-        CREATE TABLE job_materials (
-          job_url TEXT NOT NULL,
-          generation INTEGER NOT NULL,
-          tenant_id TEXT NOT NULL DEFAULT 'local',
-          status TEXT NOT NULL,
-          created_at TEXT NOT NULL,
-          updated_at TEXT NOT NULL,
-          last_validation_json TEXT,
-          last_verdict_json TEXT,
-          metadata_json TEXT,
-          PRIMARY KEY (job_url, generation)
-        );
-        CREATE TABLE job_materials_artifacts (
-          job_url TEXT NOT NULL,
-          generation INTEGER NOT NULL,
-          artifact_type TEXT NOT NULL,
-          artifact_id TEXT NOT NULL,
-          status TEXT NOT NULL,
-          path TEXT NOT NULL,
-          render_format TEXT NOT NULL,
-          size_bytes INTEGER,
-          metadata_json TEXT,
-          created_at TEXT NOT NULL,
-          superseded_at TEXT,
-          PRIMARY KEY (job_url, generation, artifact_type)
-        );
-      `);
-      const jobUrl = "https://example.com/jobs/event-driven";
+      const jobId = EVENT_JOB_ID;
       const insertMaterials = db.prepare(
         `INSERT INTO job_materials (
-          job_url, generation, tenant_id, status, created_at, updated_at
-        ) VALUES (?, ?, 'local', ?, ?, ?)`,
+          tenant_id, job_id, generation, status, created_at, updated_at
+        ) VALUES ('local', ?, ?, ?, ?, ?)`,
       );
       insertMaterials.run(
-        jobUrl,
+        jobId,
         1,
         "complete",
         "2026-05-04T12:00:00+00:00",
         "2026-05-04T12:10:00+00:00",
       );
       insertMaterials.run(
-        jobUrl,
+        jobId,
         3,
         "complete",
         "2026-05-04T13:00:00+00:00",
         "2026-05-04T13:10:00+00:00",
       );
       insertMaterials.run(
-        jobUrl,
+        jobId,
         4,
         "resume_in_progress",
         "2026-05-04T14:00:00+00:00",
@@ -1421,12 +1024,12 @@ describe("apply_run_projections without legacy apply_runs table", () => {
       );
       const insertArtifact = db.prepare(
         `INSERT INTO job_materials_artifacts (
-          job_url, generation, artifact_type, artifact_id, status, path,
+          tenant_id, job_id, generation, artifact_type, artifact_id, status, path,
           render_format, size_bytes, metadata_json, created_at
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        ) VALUES ('local', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       );
       insertArtifact.run(
-        jobUrl,
+        jobId,
         1,
         "tailored_resume",
         "gen1-superseded-resume",
@@ -1438,7 +1041,7 @@ describe("apply_run_projections without legacy apply_runs table", () => {
         "2026-05-04T12:05:00+00:00",
       );
       insertArtifact.run(
-        jobUrl,
+        jobId,
         3,
         "tailored_resume",
         "gen3-resume",
@@ -1450,7 +1053,7 @@ describe("apply_run_projections without legacy apply_runs table", () => {
         "2026-05-04T13:05:00+00:00",
       );
       insertArtifact.run(
-        jobUrl,
+        jobId,
         3,
         "resume_pdf",
         "gen3-pdf",
@@ -1462,7 +1065,7 @@ describe("apply_run_projections without legacy apply_runs table", () => {
         "2026-05-04T13:06:00+00:00",
       );
       insertArtifact.run(
-        jobUrl,
+        jobId,
         4,
         "tailored_resume",
         "gen4-rejected-resume",
@@ -1494,7 +1097,7 @@ describe("apply_run_projections without legacy apply_runs table", () => {
                FROM job_list_projections
               WHERE tenant_id = 'local' AND job_id = ?`,
           )
-          .get(jobUrl) as { has_resume: number; has_pdf: number } | undefined;
+          .get(jobId) as { has_resume: number; has_pdf: number } | undefined;
         expect(projection).toMatchObject({ has_resume: 1, has_pdf: 1 });
 
         const rejected = readDb
@@ -1505,10 +1108,10 @@ describe("apply_run_projections without legacy apply_runs table", () => {
                 AND job_id = ?
                 AND artifact_id = 'gen4-rejected-resume'`,
           )
-          .get(jobUrl) as { status: string } | undefined;
+          .get(jobId) as { status: string } | undefined;
         expect(rejected).toMatchObject({ status: "rejected" });
 
-        const syntheticPdf = readDb
+        const explicitPdf = readDb
           .prepare(
             `SELECT metadata_json
                FROM artifact_list_projections
@@ -1516,8 +1119,19 @@ describe("apply_run_projections without legacy apply_runs table", () => {
                 AND job_id = ?
                 AND artifact_type = 'tailored_resume_pdf'`,
           )
-          .get(jobUrl) as { metadata_json: string | null } | undefined;
-        expect(JSON.parse(syntheticPdf?.metadata_json ?? "{}")).toMatchObject({
+          .get(jobId) as { metadata_json: string | null } | undefined;
+        expect(JSON.parse(explicitPdf?.metadata_json ?? "{}")).toEqual({});
+
+        const approvedResume = readDb
+          .prepare(
+            `SELECT metadata_json
+               FROM artifact_list_projections
+              WHERE tenant_id = 'local'
+                AND job_id = ?
+                AND artifact_id = 'gen3-resume'`,
+          )
+          .get(jobId) as { metadata_json: string | null } | undefined;
+        expect(JSON.parse(approvedResume?.metadata_json ?? "{}")).toMatchObject({
           quality_plan: { target_seniority: "executive" },
         });
       } finally {
@@ -1533,71 +1147,25 @@ describe("apply_run_projections without legacy apply_runs table", () => {
     try {
       seedSchema(dbPath);
       const db = new Database(dbPath);
-      db.exec(`
-        CREATE TABLE job_materials (
-          job_url TEXT NOT NULL,
-          generation INTEGER NOT NULL,
-          tenant_id TEXT NOT NULL DEFAULT 'local',
-          status TEXT NOT NULL,
-          created_at TEXT NOT NULL,
-          updated_at TEXT NOT NULL,
-          last_validation_json TEXT,
-          last_verdict_json TEXT,
-          metadata_json TEXT,
-          PRIMARY KEY (job_url, generation)
-        );
-        CREATE TABLE job_materials_artifacts (
-          job_url TEXT NOT NULL,
-          generation INTEGER NOT NULL,
-          artifact_type TEXT NOT NULL,
-          artifact_id TEXT NOT NULL,
-          status TEXT NOT NULL,
-          path TEXT NOT NULL,
-          render_format TEXT NOT NULL,
-          size_bytes INTEGER,
-          metadata_json TEXT,
-          created_at TEXT NOT NULL,
-          superseded_at TEXT,
-          PRIMARY KEY (job_url, generation, artifact_type)
-        );
-        CREATE TABLE job_material_layout_boxes (
-          job_url TEXT NOT NULL,
-          generation INTEGER NOT NULL,
-          artifact_id TEXT NOT NULL,
-          box_index INTEGER NOT NULL,
-          tenant_id TEXT NOT NULL DEFAULT 'local',
-          semantic_id TEXT NOT NULL,
-          page_number INTEGER NOT NULL,
-          line_number INTEGER,
-          text_excerpt TEXT NOT NULL,
-          left_pct REAL NOT NULL,
-          top_pct REAL NOT NULL,
-          width_pct REAL NOT NULL,
-          height_pct REAL NOT NULL,
-          audit_target_json TEXT NOT NULL DEFAULT '{}',
-          created_at TEXT NOT NULL,
-          PRIMARY KEY (job_url, generation, artifact_id, box_index)
-        );
-      `);
-      const jobUrl = "https://example.com/jobs/event-driven";
+      const jobId = EVENT_JOB_ID;
       db.prepare(
         `INSERT INTO job_materials (
-          job_url, generation, tenant_id, status, created_at, updated_at
-        ) VALUES (?, 1, 'local', 'complete', ?, ?)`,
-      ).run(jobUrl, "2026-05-04T13:00:00+00:00", "2026-05-04T13:10:00+00:00");
+          tenant_id, job_id, generation, status, created_at, updated_at
+        ) VALUES ('local', ?, 1, 'complete', ?, ?)`,
+      ).run(jobId, "2026-05-04T13:00:00+00:00", "2026-05-04T13:10:00+00:00");
       db.prepare(
         `INSERT INTO job_materials_artifacts (
-          job_url, generation, artifact_type, artifact_id, status, path,
+          tenant_id, job_id, generation, artifact_type, artifact_id, status, path,
           render_format, size_bytes, metadata_json, created_at
-        ) VALUES (?, 1, 'resume_pdf', 'html-resume-pdf', 'approved', ?, 'html_pdf', 20, '{}', ?)`,
-      ).run(jobUrl, "/tmp/html-resume.pdf", "2026-05-04T13:06:00+00:00");
+        ) VALUES ('local', ?, 1, 'resume_pdf', 'html-resume-pdf', 'approved', ?, 'html_pdf', 20, '{}', ?)`,
+      ).run(jobId, "/tmp/html-resume.pdf", "2026-05-04T13:06:00+00:00");
       db.prepare(
         `INSERT INTO job_material_layout_boxes (
-          job_url, generation, artifact_id, box_index, tenant_id,
+          tenant_id, job_id, generation, artifact_id, box_index,
           semantic_id, page_number, line_number, text_excerpt,
           left_pct, top_pct, width_pct, height_pct, audit_target_json, created_at
-        ) VALUES (?, 1, 'html-resume-pdf', 0, 'local', ?, 1, 6, ?, 12.5, 24.0, 62.0, 2.4, '{}', ?)`,
-      ).run(jobUrl, "experience:acme:bullet:1", "Cut latency.", "2026-05-04T13:06:00+00:00");
+        ) VALUES ('local', ?, 1, 'html-resume-pdf', 0, ?, 1, 6, ?, 12.5, 24.0, 62.0, 2.4, '{}', ?)`,
+      ).run(jobId, "experience:acme:bullet:1", "Cut latency.", "2026-05-04T13:06:00+00:00");
       db.close();
 
       const app = buildApp({
@@ -1621,7 +1189,7 @@ describe("apply_run_projections without legacy apply_runs table", () => {
                 AND job_id = ?
                 AND artifact_id = 'html-resume-pdf'`,
           )
-          .get(jobUrl) as { layout_boxes_json: string | null } | undefined;
+          .get(jobId) as { layout_boxes_json: string | null } | undefined;
         expect(JSON.parse(projection?.layout_boxes_json ?? "[]")).toEqual([
           {
             semanticId: "experience:acme:bullet:1",
@@ -1647,47 +1215,19 @@ describe("apply_run_projections without legacy apply_runs table", () => {
     try {
       seedSchema(dbPath);
       const db = new Database(dbPath);
-      db.exec(`
-        CREATE TABLE job_materials (
-          job_url TEXT NOT NULL,
-          generation INTEGER NOT NULL,
-          tenant_id TEXT NOT NULL DEFAULT 'local',
-          status TEXT NOT NULL,
-          created_at TEXT NOT NULL,
-          updated_at TEXT NOT NULL,
-          last_validation_json TEXT,
-          last_verdict_json TEXT,
-          metadata_json TEXT,
-          PRIMARY KEY (job_url, generation)
-        );
-        CREATE TABLE job_materials_artifacts (
-          job_url TEXT NOT NULL,
-          generation INTEGER NOT NULL,
-          artifact_type TEXT NOT NULL,
-          artifact_id TEXT NOT NULL,
-          status TEXT NOT NULL,
-          path TEXT NOT NULL,
-          render_format TEXT NOT NULL,
-          size_bytes INTEGER,
-          metadata_json TEXT,
-          created_at TEXT NOT NULL,
-          superseded_at TEXT,
-          PRIMARY KEY (job_url, generation, artifact_type)
-        );
-      `);
-      const jobUrl = "https://example.com/jobs/event-driven";
+      const jobId = EVENT_JOB_ID;
       db.prepare(
         `INSERT INTO job_materials (
-          job_url, generation, tenant_id, status, created_at, updated_at
-        ) VALUES (?, 1, 'local', 'complete', ?, ?)`,
-      ).run(jobUrl, "2026-05-04T13:00:00+00:00", "2026-05-04T13:10:00+00:00");
+          tenant_id, job_id, generation, status, created_at, updated_at
+        ) VALUES ('local', ?, 1, 'complete', ?, ?)`,
+      ).run(jobId, "2026-05-04T13:00:00+00:00", "2026-05-04T13:10:00+00:00");
       db.prepare(
         `INSERT INTO job_materials_artifacts (
-          job_url, generation, artifact_type, artifact_id, status, path,
+          tenant_id, job_id, generation, artifact_type, artifact_id, status, path,
           render_format, size_bytes, metadata_json, created_at
-        ) VALUES (?, 1, 'tailored_resume', 'stale-resume', 'approved', ?, 'text', 10, ?, ?)`,
+        ) VALUES ('local', ?, 1, 'tailored_resume', 'stale-resume', 'approved', ?, 'text', 10, ?, ?)`,
       ).run(
-        jobUrl,
+        jobId,
         "/tmp/stale-resume.txt",
         JSON.stringify({
           quality_plan: { target_seniority: "executive" },
@@ -1728,7 +1268,7 @@ describe("apply_run_projections without legacy apply_runs table", () => {
                 AND job_id = ?
                 AND artifact_type = 'tailored_resume'`,
           )
-          .run(jobUrl);
+          .run(jobId);
         corruptDb.close();
 
         const secondRes = await app.inject({ method: "GET", url: "/v1/jobs?q=event" });
@@ -1747,7 +1287,7 @@ describe("apply_run_projections without legacy apply_runs table", () => {
                 AND job_id = ?
                 AND artifact_type = 'tailored_resume'`,
           )
-          .get(jobUrl) as { metadata_json: string | null } | undefined;
+          .get(jobId) as { metadata_json: string | null } | undefined;
         expect(JSON.parse(projection?.metadata_json ?? "{}")).toMatchObject({
           quality_plan: { target_seniority: "executive" },
           selected_model: "generator-a",
@@ -1776,49 +1316,21 @@ describe("apply_run_projections without legacy apply_runs table", () => {
     try {
       seedSchema(dbPath);
       const db = new Database(dbPath);
-      db.exec(`
-        CREATE TABLE job_materials (
-          job_url TEXT NOT NULL,
-          generation INTEGER NOT NULL,
-          tenant_id TEXT NOT NULL DEFAULT 'local',
-          status TEXT NOT NULL,
-          created_at TEXT NOT NULL,
-          updated_at TEXT NOT NULL,
-          last_validation_json TEXT,
-          last_verdict_json TEXT,
-          metadata_json TEXT,
-          PRIMARY KEY (job_url, generation)
-        );
-        CREATE TABLE job_materials_artifacts (
-          job_url TEXT NOT NULL,
-          generation INTEGER NOT NULL,
-          artifact_type TEXT NOT NULL,
-          artifact_id TEXT NOT NULL,
-          status TEXT NOT NULL,
-          path TEXT NOT NULL,
-          render_format TEXT NOT NULL,
-          size_bytes INTEGER,
-          metadata_json TEXT,
-          created_at TEXT NOT NULL,
-          superseded_at TEXT,
-          PRIMARY KEY (job_url, generation, artifact_type)
-        );
-      `);
-      const jobUrl = "https://example.com/jobs/event-driven";
+      const jobId = EVENT_JOB_ID;
       const insertMaterials = db.prepare(
         `INSERT INTO job_materials (
-          job_url, generation, tenant_id, status, created_at, updated_at
-        ) VALUES (?, ?, 'local', ?, ?, ?)`,
+          tenant_id, job_id, generation, status, created_at, updated_at
+        ) VALUES ('local', ?, ?, ?, ?, ?)`,
       );
       insertMaterials.run(
-        jobUrl,
+        jobId,
         1,
         "complete",
         "2026-05-04T13:00:00+00:00",
         "2026-05-04T13:10:00+00:00",
       );
       insertMaterials.run(
-        jobUrl,
+        jobId,
         2,
         "complete",
         "2026-05-04T14:00:00+00:00",
@@ -1826,12 +1338,12 @@ describe("apply_run_projections without legacy apply_runs table", () => {
       );
       const insertArtifact = db.prepare(
         `INSERT INTO job_materials_artifacts (
-          job_url, generation, artifact_type, artifact_id, status, path,
+          tenant_id, job_id, generation, artifact_type, artifact_id, status, path,
           render_format, size_bytes, metadata_json, created_at
-        ) VALUES (?, ?, 'tailored_resume', ?, ?, ?, 'text', ?, ?, ?)`,
+        ) VALUES ('local', ?, ?, 'tailored_resume', ?, ?, ?, 'text', ?, ?, ?)`,
       );
       insertArtifact.run(
-        jobUrl,
+        jobId,
         1,
         "approved-resume",
         "approved",
@@ -1849,7 +1361,7 @@ describe("apply_run_projections without legacy apply_runs table", () => {
         "2026-05-04T13:05:00+00:00",
       );
       insertArtifact.run(
-        jobUrl,
+        jobId,
         2,
         "rejected-resume",
         "rejected",
@@ -1877,7 +1389,7 @@ describe("apply_run_projections without legacy apply_runs table", () => {
                 AND job_id = ?
                 AND artifact_id = 'rejected-resume'`,
           )
-          .run(jobUrl);
+          .run(jobId);
         markerDb.close();
 
         const secondRes = await app.inject({ method: "GET", url: "/v1/jobs?q=event" });
@@ -1896,7 +1408,7 @@ describe("apply_run_projections without legacy apply_runs table", () => {
                 AND job_id = ?
                 AND artifact_id = 'rejected-resume'`,
           )
-          .get(jobUrl) as { status: string } | undefined;
+          .get(jobId) as { status: string } | undefined;
         expect(projection?.status).toBe("sentinel");
       } finally {
         readDb.close();
@@ -1906,7 +1418,7 @@ describe("apply_run_projections without legacy apply_runs table", () => {
     }
   });
 
-  it("backfills legacy jobs inserted after the first projection refresh", async () => {
+  it("projects canonical jobs inserted after the first projection refresh", async () => {
     const { dbPath, cleanup } = withTempDb();
     try {
       seedSchema(dbPath);
@@ -1920,8 +1432,9 @@ describe("apply_run_projections without legacy apply_runs table", () => {
 
         const db = new Database(dbPath);
         db.prepare(
-          "INSERT INTO jobs (url, title, site, strategy, location, discovered_at) VALUES (?, ?, ?, ?, ?, ?)",
+          "INSERT INTO jobs (tenant_id, job_id, url, title, site, strategy, location, discovered_at) VALUES ('local', ?, ?, ?, ?, ?, ?, ?)",
         ).run(
+          projectionFixtureJobId(2),
           "https://example.com/jobs/late-legacy",
           "Late Legacy Engineer",
           "Workday",
@@ -1935,7 +1448,7 @@ describe("apply_run_projections without legacy apply_runs table", () => {
         expect(secondRes.statusCode, secondRes.body).toBe(200);
         const late = secondRes
           .json()
-          .items.find((j: { jobKey: string }) => j.jobKey === "https://example.com/jobs/late-legacy");
+          .items.find((j: { jobKey: string }) => j.jobKey === projectionFixtureJobId(2));
         expect(late).toMatchObject({
           title: "Late Legacy Engineer",
           source: "Workday",
@@ -1955,23 +1468,23 @@ describe("apply_run_projections without legacy apply_runs table", () => {
       seedSchema(dbPath);
       const db = new Database(dbPath);
       const insert = db.prepare(
-        "INSERT INTO jobs (url, title, site, strategy, location, discovered_at) VALUES (?, ?, ?, ?, ?, ?)",
+        "INSERT INTO jobs (tenant_id, job_id, url, title, site, strategy, location, discovered_at) VALUES ('local', ?, ?, ?, ?, ?, ?, ?)",
       );
       // seedSchema pre-seeds one ExampleCo job (count 1). Netflix leads on
       // count; Acme and Wayfair tie at 2, seeded reverse-alphabetically so a
       // count-only sort would leak insertion order. The tiebreak re-orders the
       // tie A->Z, byte-identical to the Python builder.
-      const seeded: Array<[string, string]> = [
-        ["https://example.com/jobs/w1", "Wayfair"],
-        ["https://example.com/jobs/w2", "Wayfair"],
-        ["https://example.com/jobs/n1", "Netflix"],
-        ["https://example.com/jobs/n2", "Netflix"],
-        ["https://example.com/jobs/n3", "Netflix"],
-        ["https://example.com/jobs/a1", "Acme"],
-        ["https://example.com/jobs/a2", "Acme"],
+      const seeded: Array<[string, string, string]> = [
+        [projectionFixtureJobId(3), "https://example.com/jobs/w1", "Wayfair"],
+        [projectionFixtureJobId(4), "https://example.com/jobs/w2", "Wayfair"],
+        [projectionFixtureJobId(5), "https://example.com/jobs/n1", "Netflix"],
+        [projectionFixtureJobId(6), "https://example.com/jobs/n2", "Netflix"],
+        [projectionFixtureJobId(7), "https://example.com/jobs/n3", "Netflix"],
+        [projectionFixtureJobId(8), "https://example.com/jobs/a1", "Acme"],
+        [projectionFixtureJobId(9), "https://example.com/jobs/a2", "Acme"],
       ];
-      for (const [url, site] of seeded) {
-        insert.run(url, "Engineer", site, "jobspy", "Remote", "2026-05-06T09:00:00+00:00");
+      for (const [jobId, url, site] of seeded) {
+        insert.run(jobId, url, "Engineer", site, "jobspy", "Remote", "2026-05-06T09:00:00+00:00");
       }
       db.close();
 
@@ -2011,8 +1524,9 @@ describe("apply_run_projections without legacy apply_runs table", () => {
       seedSchema(dbPath);
       const db = new Database(dbPath);
       db.prepare(
-        "INSERT INTO jobs (url, title, company, site, strategy, location, discovered_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        "INSERT INTO jobs (tenant_id, job_id, url, title, company, site, strategy, location, discovered_at) VALUES ('local', ?, ?, ?, ?, ?, ?, ?, ?)",
       ).run(
+        projectionFixtureJobId(10),
         "https://www.linkedin.com/jobs/view/1",
         "Head of Engineering",
         "Keyrock",
@@ -2032,7 +1546,7 @@ describe("apply_run_projections without legacy apply_runs table", () => {
         expect(res.statusCode, res.body).toBe(200);
         const item = res
           .json()
-          .items.find((j: { jobKey: string }) => j.jobKey === "https://www.linkedin.com/jobs/view/1");
+          .items.find((j: { jobKey: string }) => j.jobKey === projectionFixtureJobId(10));
         expect(item).toMatchObject({
           title: "Head of Engineering",
           company: "Keyrock",
@@ -2051,40 +1565,16 @@ describe("apply_run_projections without legacy apply_runs table", () => {
     try {
       seedSchema(dbPath);
       const db = new Database(dbPath);
-      db.exec(`
-        CREATE TABLE job_source_observations (
-          tenant_id TEXT NOT NULL DEFAULT 'local',
-          source_observation_id TEXT NOT NULL,
-          job_url TEXT NOT NULL,
-          source_id TEXT NOT NULL,
-          source_native_id TEXT NOT NULL,
-          observed_url TEXT NOT NULL,
-          normalized_observed_url TEXT NOT NULL,
-          run_id TEXT NOT NULL DEFAULT '',
-          observed_at TEXT NOT NULL,
-          PRIMARY KEY (tenant_id, source_observation_id)
-        );
-        CREATE TABLE job_canonical_identities (
-          tenant_id TEXT NOT NULL DEFAULT 'local',
-          job_url TEXT NOT NULL,
-          canonical_url TEXT NOT NULL,
-          ats_kind TEXT NOT NULL,
-          source_native_id TEXT NOT NULL,
-          confidence REAL NOT NULL,
-          resolved_at TEXT NOT NULL,
-          PRIMARY KEY (tenant_id, job_url)
-        );
-      `);
       db.prepare(
         `INSERT INTO job_source_observations (
-          tenant_id, source_observation_id, job_url, source_id,
+          tenant_id, source_observation_id, job_id, source_id,
           source_native_id, observed_url, normalized_observed_url,
           run_id, observed_at
         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       ).run(
         "local",
         "obs-linkedin",
-        "https://example.com/jobs/event-driven",
+        EVENT_JOB_ID,
         "jobspy:linkedin",
         "https://www.linkedin.com/jobs/view/1",
         "https://www.linkedin.com/jobs/view/1",
@@ -2094,12 +1584,12 @@ describe("apply_run_projections without legacy apply_runs table", () => {
       );
       db.prepare(
         `INSERT INTO job_canonical_identities (
-          tenant_id, job_url, canonical_url, ats_kind, source_native_id,
+          tenant_id, job_id, canonical_url, ats_kind, source_native_id,
           confidence, resolved_at
         ) VALUES (?, ?, ?, ?, ?, ?, ?)`,
       ).run(
         "local",
-        "https://example.com/jobs/event-driven",
+        EVENT_JOB_ID,
         "https://boards.greenhouse.io/acme/jobs/123456",
         "greenhouse",
         "123456",
@@ -2117,7 +1607,7 @@ describe("apply_run_projections without legacy apply_runs table", () => {
         expect(listRes.statusCode, listRes.body).toBe(200);
         const item = listRes
           .json()
-          .items.find((j: { jobKey: string }) => j.jobKey === "https://example.com/jobs/event-driven");
+          .items.find((j: { jobKey: string }) => j.jobKey === EVENT_JOB_ID);
         expect(item).toMatchObject({
           discoverySource: "jobspy:linkedin",
           postingSource: "greenhouse:acme",
@@ -2132,7 +1622,7 @@ describe("apply_run_projections without legacy apply_runs table", () => {
         expect(sourceFilteredRes.json().items).toEqual(
           expect.arrayContaining([
             expect.objectContaining({
-              jobKey: "https://example.com/jobs/event-driven",
+              jobKey: EVENT_JOB_ID,
               postingSource: "greenhouse:acme",
             }),
           ]),
@@ -2169,7 +1659,7 @@ describe("apply_run_projections without legacy apply_runs table", () => {
         expect(listRes.statusCode, listRes.body).toBe(200);
         const item = listRes
           .json()
-          .items.find((j: { jobKey: string }) => j.jobKey === "https://example.com/jobs/event-driven");
+          .items.find((j: { jobKey: string }) => j.jobKey === EVENT_JOB_ID);
         expect(item).toMatchObject({
           fitScore: 8,
           scoreBreakdown: {
@@ -2247,48 +1737,10 @@ describe("apply_run_projections without legacy apply_runs table", () => {
     // them, then assert the TS projection builder + read model reconstruct the
     // same read shape the Python ``EmployerAnalysis.to_read_model()`` produces.
     const { dbPath, cleanup } = withTempDb();
-    const jobUrl = "https://example.com/jobs/event-driven";
+    const jobId = EVENT_JOB_ID;
     try {
       seedSchema(dbPath);
       const db = new Database(dbPath);
-      db.exec(`
-        CREATE TABLE job_employer_analysis (
-          job_url TEXT NOT NULL,
-          generation INTEGER NOT NULL,
-          tenant_id TEXT NOT NULL DEFAULT 'local',
-          snapshot_hash TEXT NOT NULL,
-          prompt_version TEXT NOT NULL,
-          sdk_set_version TEXT NOT NULL,
-          cache_key TEXT NOT NULL,
-          role_framing TEXT NOT NULL DEFAULT '',
-          inferred_seniority TEXT NOT NULL DEFAULT '',
-          ideal_candidate_narrative TEXT NOT NULL DEFAULT '',
-          requirements_json TEXT NOT NULL DEFAULT '[]',
-          keywords_json TEXT NOT NULL DEFAULT '[]',
-          agreement_json TEXT NOT NULL DEFAULT '{}',
-          legs_attempted INTEGER NOT NULL,
-          legs_succeeded INTEGER NOT NULL,
-          created_at TEXT NOT NULL,
-          PRIMARY KEY (job_url, generation)
-        );
-        CREATE TABLE job_employer_analysis_sub_analyses (
-          job_url TEXT NOT NULL,
-          generation INTEGER NOT NULL,
-          model_id TEXT NOT NULL,
-          tenant_id TEXT NOT NULL DEFAULT 'local',
-          analysis_json TEXT NOT NULL,
-          PRIMARY KEY (job_url, generation, model_id)
-        );
-        CREATE TABLE job_employer_analysis_failures (
-          job_url TEXT NOT NULL,
-          generation INTEGER NOT NULL,
-          model_id TEXT NOT NULL,
-          tenant_id TEXT NOT NULL DEFAULT 'local',
-          error TEXT NOT NULL,
-          raw_output TEXT,
-          PRIMARY KEY (job_url, generation, model_id)
-        );
-      `);
       const requirements = [
         {
           id: "r1",
@@ -2310,29 +1762,29 @@ describe("apply_run_projections without legacy apply_runs table", () => {
       // Two generations prove "load latest" + supersede-not-destroy (D-13).
       const insertAnalysis = db.prepare(
         `INSERT INTO job_employer_analysis (
-          job_url, generation, tenant_id, snapshot_hash, prompt_version, sdk_set_version,
+          tenant_id, job_id, generation, snapshot_hash, prompt_version, sdk_set_version,
           cache_key, role_framing, inferred_seniority, ideal_candidate_narrative,
           requirements_json, keywords_json, agreement_json, legs_attempted, legs_succeeded, created_at
-        ) VALUES (?, ?, 'local', ?, 'employer-analysis-v1', 'claude+codex-v1', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        ) VALUES ('local', ?, ?, ?, 'employer-analysis-v1', 'claude+codex-v1', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       );
       insertAnalysis.run(
-        jobUrl, 1, "hash-old", "hash-old:employer-analysis-v1:claude+codex-v1",
+        jobId, 1, "hash-old", "hash-old:employer-analysis-v1:claude+codex-v1",
         "Old framing.", "mid", "Old narrative.",
         "[]", "[]", JSON.stringify({ score: 0.5, flagged_requirements: [], flagged_keywords: [] }),
         2, 2, "2026-05-04T12:00:00+00:00",
       );
       insertAnalysis.run(
-        jobUrl, 2, "hash-new", "hash-new:employer-analysis-v1:claude+codex-v1",
+        jobId, 2, "hash-new", "hash-new:employer-analysis-v1:claude+codex-v1",
         "Own the event platform.", "senior", "A hands-on platform owner.",
         JSON.stringify(requirements), JSON.stringify(keywords),
         JSON.stringify({ score: 0.8, flagged_requirements: [], flagged_keywords: ["kafka"] }),
         2, 1, "2026-05-04T13:00:00+00:00",
       );
       db.prepare(
-        `INSERT INTO job_employer_analysis_sub_analyses (job_url, generation, model_id, tenant_id, analysis_json)
-         VALUES (?, 2, 'claude-opus-4-8', 'local', ?)`,
+        `INSERT INTO job_employer_analysis_sub_analyses (tenant_id, job_id, generation, model_id, analysis_json)
+         VALUES ('local', ?, 2, 'claude-opus-4-8', ?)`,
       ).run(
-        jobUrl,
+        jobId,
         JSON.stringify({
           role_framing: "Own the event platform.",
           inferred_seniority: "senior",
@@ -2342,9 +1794,9 @@ describe("apply_run_projections without legacy apply_runs table", () => {
         }),
       );
       db.prepare(
-        `INSERT INTO job_employer_analysis_failures (job_url, generation, model_id, tenant_id, error, raw_output)
-         VALUES (?, 2, 'gpt-5.4', 'local', 'codex app-server timeout', NULL)`,
-      ).run(jobUrl);
+        `INSERT INTO job_employer_analysis_failures (tenant_id, job_id, generation, model_id, error, raw_output)
+         VALUES ('local', ?, 2, 'gpt-5.4', 'codex app-server timeout', NULL)`,
+      ).run(jobId);
       db.close();
 
       const app = buildApp({
@@ -2354,7 +1806,7 @@ describe("apply_run_projections without legacy apply_runs table", () => {
       try {
         const detailRes = await app.inject({
           method: "GET",
-          url: `/v1/jobs/${encodeURIComponent(jobUrl)}`,
+          url: `/v1/jobs/${encodeURIComponent(EVENT_JOB_URL)}`,
         });
         expect(detailRes.statusCode, detailRes.body).toBe(200);
         const analysis = detailRes.json().employerAnalysis;
@@ -2389,52 +1841,19 @@ describe("apply_run_projections without legacy apply_runs table", () => {
 
   it("serves the canonical requirement fit report from projection rows", async () => {
     const { dbPath, cleanup } = withTempDb();
-    const jobUrl = "https://example.com/jobs/event-driven";
+    const jobId = EVENT_JOB_ID;
     try {
       seedSchema(dbPath);
       const db = new Database(dbPath);
-      db.exec(`
-        CREATE TABLE job_requirement_fit_reports (
-          job_url TEXT NOT NULL,
-          score_version INTEGER NOT NULL,
-          tenant_id TEXT NOT NULL DEFAULT 'local',
-          employer_analysis_generation INTEGER NOT NULL,
-          profile_snapshot_version INTEGER NOT NULL,
-          scoring_policy_version INTEGER NOT NULL,
-          formula_version TEXT NOT NULL,
-          resolved_fit_score INTEGER,
-          fit_band TEXT NOT NULL,
-          confidence TEXT NOT NULL,
-          summary_json TEXT NOT NULL DEFAULT '{}',
-          created_at TEXT NOT NULL,
-          PRIMARY KEY (job_url, score_version, tenant_id)
-        );
-        CREATE TABLE job_requirement_fit_items (
-          job_url TEXT NOT NULL,
-          score_version INTEGER NOT NULL,
-          tenant_id TEXT NOT NULL DEFAULT 'local',
-          requirement_id TEXT NOT NULL,
-          requirement_text TEXT NOT NULL,
-          tier TEXT NOT NULL,
-          weight REAL NOT NULL,
-          job_evidence_span TEXT NOT NULL DEFAULT '',
-          fit_json TEXT NOT NULL DEFAULT '{}',
-          contribution_json TEXT NOT NULL DEFAULT '{}',
-          tailoring_json TEXT NOT NULL DEFAULT '{}',
-          artifact_coverage_json TEXT,
-          position INTEGER NOT NULL DEFAULT 0,
-          PRIMARY KEY (job_url, score_version, tenant_id, requirement_id)
-        );
-      `);
       const insertReport = db.prepare(
         `INSERT INTO job_requirement_fit_reports (
-          job_url, score_version, tenant_id, employer_analysis_generation,
+          tenant_id, job_id, score_version, employer_analysis_generation,
           profile_snapshot_version, scoring_policy_version, formula_version,
           resolved_fit_score, fit_band, confidence, summary_json, created_at
-        ) VALUES (?, ?, 'local', ?, ?, ?, 'requirement-fit-v1', ?, ?, ?, ?, ?)`,
+        ) VALUES ('local', ?, ?, ?, ?, ?, 'requirement-fit-v1', ?, ?, ?, ?, ?)`,
       );
       insertReport.run(
-        jobUrl,
+        jobId,
         1,
         1,
         2,
@@ -2451,7 +1870,7 @@ describe("apply_run_projections without legacy apply_runs table", () => {
         "2026-05-04T11:00:00+00:00",
       );
       insertReport.run(
-        jobUrl,
+        jobId,
         2,
         2,
         3,
@@ -2469,12 +1888,12 @@ describe("apply_run_projections without legacy apply_runs table", () => {
       );
       db.prepare(
         `INSERT INTO job_requirement_fit_items (
-          job_url, score_version, tenant_id, requirement_id, requirement_text,
+          tenant_id, job_id, score_version, requirement_id, requirement_text,
           tier, weight, job_evidence_span, fit_json, contribution_json,
           tailoring_json, artifact_coverage_json, position
-        ) VALUES (?, 2, 'local', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        ) VALUES ('local', ?, 2, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       ).run(
-        jobUrl,
+        jobId,
         "r1",
         "5+ years Python",
         "must_have",
@@ -2516,12 +1935,12 @@ describe("apply_run_projections without legacy apply_runs table", () => {
       try {
         const detailRes = await app.inject({
           method: "GET",
-          url: `/v1/jobs/${encodeURIComponent(jobUrl)}`,
+          url: `/v1/jobs/${encodeURIComponent(EVENT_JOB_URL)}`,
         });
         expect(detailRes.statusCode, detailRes.body).toBe(200);
         const report = detailRes.json().requirementFitReport;
         expect(report).toMatchObject({
-          jobId: jobUrl,
+          jobId,
           scoreVersion: 2,
           employerAnalysisGeneration: 2,
           profileSnapshotVersion: 3,
@@ -2575,133 +1994,10 @@ describe("apply_run_projections without legacy apply_runs table", () => {
 
   it("projects the career evidence map from profile evidence, provenance, and requirement fit", async () => {
     const { dbPath, cleanup } = withTempDb();
-    const jobUrl = "https://example.com/jobs/event-driven";
+    const jobId = EVENT_JOB_ID;
     try {
       seedSchema(dbPath);
       const db = new Database(dbPath);
-      db.exec(`
-        CREATE TABLE candidate_profile_experience_entries (
-          tenant_id TEXT NOT NULL,
-          profile_id TEXT NOT NULL,
-          entry_id TEXT NOT NULL,
-          position_index INTEGER NOT NULL,
-          date_range TEXT NOT NULL DEFAULT '',
-          title TEXT NOT NULL DEFAULT '',
-          company TEXT NOT NULL DEFAULT '',
-          location TEXT NOT NULL DEFAULT '',
-          PRIMARY KEY (tenant_id, profile_id, entry_id)
-        );
-        CREATE TABLE candidate_profile_achievement_evidence (
-          tenant_id TEXT NOT NULL,
-          profile_id TEXT NOT NULL,
-          entry_id TEXT NOT NULL,
-          evidence_index INTEGER NOT NULL,
-          evidence_id TEXT NOT NULL DEFAULT '',
-          source_text TEXT NOT NULL DEFAULT '',
-          scope TEXT NOT NULL DEFAULT '',
-          action TEXT NOT NULL DEFAULT '',
-          tools_json TEXT NOT NULL DEFAULT '[]',
-          metrics_json TEXT NOT NULL DEFAULT '[]',
-          outcome TEXT NOT NULL DEFAULT '',
-          seniority_signal TEXT NOT NULL DEFAULT '',
-          evidence_strength TEXT NOT NULL DEFAULT 'supported',
-          claim_confidence REAL NOT NULL DEFAULT 0,
-          user_confirmed INTEGER NOT NULL DEFAULT 0,
-          tags_json TEXT NOT NULL DEFAULT '[]',
-          PRIMARY KEY (tenant_id, profile_id, entry_id, evidence_index)
-        );
-        CREATE TABLE candidate_profile_skill_categories (
-          tenant_id TEXT NOT NULL,
-          profile_id TEXT NOT NULL,
-          category_id TEXT NOT NULL,
-          position_index INTEGER NOT NULL,
-          label TEXT NOT NULL DEFAULT '',
-          PRIMARY KEY (tenant_id, profile_id, category_id)
-        );
-        CREATE TABLE candidate_profile_skill_items (
-          tenant_id TEXT NOT NULL,
-          profile_id TEXT NOT NULL,
-          category_id TEXT NOT NULL,
-          item_index INTEGER NOT NULL,
-          item_text TEXT NOT NULL,
-          PRIMARY KEY (tenant_id, profile_id, category_id, item_index)
-        );
-        CREATE TABLE job_materials (
-          job_url TEXT NOT NULL,
-          generation INTEGER NOT NULL,
-          tenant_id TEXT NOT NULL DEFAULT 'local',
-          status TEXT NOT NULL,
-          created_at TEXT NOT NULL,
-          updated_at TEXT NOT NULL,
-          PRIMARY KEY (job_url, generation)
-        );
-        CREATE TABLE job_materials_artifacts (
-          job_url TEXT NOT NULL,
-          generation INTEGER NOT NULL,
-          artifact_type TEXT NOT NULL,
-          artifact_id TEXT NOT NULL,
-          status TEXT NOT NULL,
-          path TEXT NOT NULL,
-          render_format TEXT NOT NULL,
-          size_bytes INTEGER,
-          metadata_json TEXT,
-          created_at TEXT NOT NULL,
-          superseded_at TEXT,
-          PRIMARY KEY (job_url, generation, artifact_type)
-        );
-        CREATE TABLE job_bullet_provenance (
-          job_url TEXT NOT NULL,
-          generation INTEGER NOT NULL,
-          bullet_id TEXT NOT NULL,
-          tenant_id TEXT NOT NULL DEFAULT 'local',
-          artifact_id TEXT NOT NULL,
-          section TEXT NOT NULL,
-          source_id TEXT,
-          evidence_ids_json TEXT NOT NULL DEFAULT '[]',
-          requirement_ids_json TEXT NOT NULL DEFAULT '[]',
-          matched_keywords_json TEXT NOT NULL DEFAULT '[]',
-          transform_type TEXT NOT NULL,
-          control TEXT NOT NULL,
-          rationale TEXT NOT NULL DEFAULT '',
-          generated_text TEXT NOT NULL,
-          position INTEGER NOT NULL DEFAULT 0,
-          created_at TEXT NOT NULL,
-          coverage_json TEXT,
-          voice_json TEXT,
-          PRIMARY KEY (job_url, generation, bullet_id)
-        );
-        CREATE TABLE job_requirement_fit_reports (
-          job_url TEXT NOT NULL,
-          score_version INTEGER NOT NULL,
-          tenant_id TEXT NOT NULL DEFAULT 'local',
-          employer_analysis_generation INTEGER NOT NULL,
-          profile_snapshot_version INTEGER NOT NULL,
-          scoring_policy_version INTEGER NOT NULL,
-          formula_version TEXT NOT NULL,
-          resolved_fit_score INTEGER,
-          fit_band TEXT NOT NULL,
-          confidence TEXT NOT NULL,
-          summary_json TEXT NOT NULL,
-          created_at TEXT NOT NULL,
-          PRIMARY KEY (job_url, score_version, tenant_id)
-        );
-        CREATE TABLE job_requirement_fit_items (
-          job_url TEXT NOT NULL,
-          score_version INTEGER NOT NULL,
-          tenant_id TEXT NOT NULL DEFAULT 'local',
-          requirement_id TEXT NOT NULL,
-          requirement_text TEXT NOT NULL,
-          tier TEXT NOT NULL,
-          weight REAL NOT NULL,
-          job_evidence_span TEXT NOT NULL,
-          fit_json TEXT NOT NULL,
-          contribution_json TEXT NOT NULL,
-          tailoring_json TEXT NOT NULL,
-          artifact_coverage_json TEXT,
-          position INTEGER NOT NULL DEFAULT 0,
-          PRIMARY KEY (job_url, score_version, tenant_id, requirement_id)
-        );
-      `);
       db.prepare(
         `INSERT INTO candidate_profile_experience_entries
          (tenant_id, profile_id, entry_id, position_index, date_range, title, company, location)
@@ -2734,23 +2030,23 @@ describe("apply_run_projections without legacy apply_runs table", () => {
       ).run();
       db.prepare(
         `INSERT INTO job_materials
-         (job_url, generation, tenant_id, status, created_at, updated_at)
-         VALUES (?, 1, 'local', 'complete', '2026-07-05T12:00:00Z', '2026-07-05T12:10:00Z')`,
-      ).run(jobUrl);
+         (tenant_id, job_id, generation, status, created_at, updated_at)
+         VALUES ('local', ?, 1, 'complete', '2026-07-05T12:00:00Z', '2026-07-05T12:10:00Z')`,
+      ).run(jobId);
       db.prepare(
         `INSERT INTO job_materials_artifacts (
-          job_url, generation, artifact_type, artifact_id, status, path,
+          tenant_id, job_id, generation, artifact_type, artifact_id, status, path,
           render_format, size_bytes, metadata_json, created_at
-        ) VALUES (?, 1, 'tailored_resume', 'artifact-resume-1', 'approved', '/tmp/resume.txt', 'text', 12, ?, '2026-07-05T12:05:00Z')`,
-      ).run(jobUrl, JSON.stringify({ validation_mode: "normal", attempts: 1, quality_checks: { passed: true } }));
+        ) VALUES ('local', ?, 1, 'tailored_resume', 'artifact-resume-1', 'approved', '/tmp/resume.txt', 'text', 12, ?, '2026-07-05T12:05:00Z')`,
+      ).run(jobId, JSON.stringify({ validation_mode: "normal", attempts: 1, quality_checks: { passed: true } }));
       db.prepare(
         `INSERT INTO job_bullet_provenance (
-          job_url, generation, bullet_id, tenant_id, artifact_id, section, source_id,
+          tenant_id, job_id, generation, bullet_id, artifact_id, section, source_id,
           evidence_ids_json, requirement_ids_json, matched_keywords_json, transform_type,
           control, rationale, generated_text, position, created_at, coverage_json
-        ) VALUES (?, 1, 'experience:exp-platform#0', 'local', 'artifact-resume-1', 'experience', 'exp-platform', ?, ?, ?, 'reframe', 'rephrase_allowed', 'Used profile evidence.', 'Led migration and reduced latency 40%.', 0, '2026-07-05T12:10:00Z', ?)`,
+        ) VALUES ('local', ?, 1, 'experience:exp-platform#0', 'artifact-resume-1', 'experience', 'exp-platform', ?, ?, ?, 'reframe', 'rephrase_allowed', 'Used profile evidence.', 'Led migration and reduced latency 40%.', 0, '2026-07-05T12:10:00Z', ?)`,
       ).run(
-        jobUrl,
+        jobId,
         JSON.stringify(["ev_platform"]),
         JSON.stringify(["req-platform"]),
         JSON.stringify(["latency"]),
@@ -2758,20 +2054,20 @@ describe("apply_run_projections without legacy apply_runs table", () => {
       );
       db.prepare(
         `INSERT INTO job_requirement_fit_reports (
-          job_url, score_version, tenant_id, employer_analysis_generation,
+          tenant_id, job_id, score_version, employer_analysis_generation,
           profile_snapshot_version, scoring_policy_version, formula_version,
           resolved_fit_score, fit_band, confidence, summary_json, created_at
-        ) VALUES (?, 2, 'local', 1, 1, 1, 'v1', 8, 'strong', 'high', ?, '2026-07-05T12:20:00Z')`,
-      ).run(jobUrl, JSON.stringify({ weighted_fit: 0.8, must_have_coverage: 0.5, blocker_count: 0, missing_high_weight_count: 1 }));
+        ) VALUES ('local', ?, 2, 1, 1, 1, 'v1', 8, 'strong', 'high', ?, '2026-07-05T12:20:00Z')`,
+      ).run(jobId, JSON.stringify({ weighted_fit: 0.8, must_have_coverage: 0.5, blocker_count: 0, missing_high_weight_count: 1 }));
       const insertFitItem = db.prepare(
         `INSERT INTO job_requirement_fit_items (
-          job_url, score_version, tenant_id, requirement_id, requirement_text,
+          tenant_id, job_id, score_version, requirement_id, requirement_text,
           tier, weight, job_evidence_span, fit_json, contribution_json,
           tailoring_json, artifact_coverage_json, position
-        ) VALUES (?, 2, 'local', ?, ?, 'must_have', ?, ?, ?, '{}', '{}', ?, ?)`,
+        ) VALUES ('local', ?, 2, ?, ?, 'must_have', ?, ?, ?, '{}', '{}', ?, ?)`,
       );
       insertFitItem.run(
-        jobUrl,
+        jobId,
         "req-platform",
         "Own platform migrations",
         0.8,
@@ -2781,7 +2077,7 @@ describe("apply_run_projections without legacy apply_runs table", () => {
         0,
       );
       insertFitItem.run(
-        jobUrl,
+        jobId,
         "req-kubernetes",
         "Run Kubernetes clusters",
         0.7,
@@ -2803,10 +2099,10 @@ describe("apply_run_projections without legacy apply_runs table", () => {
         const evidenceEntry = body.entries.find((entry: { evidenceId: string }) => entry.evidenceId === "ev_platform");
         expect(evidenceEntry).toBeTruthy();
         expect(evidenceEntry.resumeUsages).toMatchObject([
-          { jobKey: jobUrl, artifactId: "artifact-resume-1", bulletId: "experience:exp-platform#0" },
+          { jobKey: jobId, artifactId: "artifact-resume-1", bulletId: "experience:exp-platform#0" },
         ]);
         expect(evidenceEntry.requirementUsages).toMatchObject([
-          { jobKey: jobUrl, scoreVersion: 2, requirementId: "req-platform", requirementFitKind: "matched" },
+          { jobKey: jobId, scoreVersion: 2, requirementId: "req-platform", requirementFitKind: "matched" },
         ]);
         expect(evidenceEntry.freshness).toMatchObject({
           evidenceDateRange: "2024-2025",
@@ -2819,12 +2115,12 @@ describe("apply_run_projections without legacy apply_runs table", () => {
             expect.objectContaining({
               kind: "missing_requirement",
               requirementId: "req-kubernetes",
-              jobRefs: [expect.objectContaining({ jobKey: jobUrl, scoreVersion: 2 })],
+              jobRefs: [expect.objectContaining({ jobKey: jobId, scoreVersion: 2 })],
             }),
             expect.objectContaining({
               kind: "missing_skill",
               demandedSkill: "Kubernetes",
-              jobRefs: [expect.objectContaining({ jobKey: jobUrl, artifactId: "artifact-resume-1" })],
+              jobRefs: [expect.objectContaining({ jobKey: jobId, artifactId: "artifact-resume-1" })],
             }),
           ]),
         );
@@ -2846,10 +2142,12 @@ describe("apply_run_projections without legacy apply_runs table", () => {
     const activeUrl = "https://example.com/jobs/active-role";
     const deletedUrl = "https://example.com/jobs/deleted-role";
     const hiddenUrl = "https://example.com/jobs/hidden-role";
+    const activeId = projectionFixtureJobId(11);
+    const deletedId = projectionFixtureJobId(12);
+    const hiddenId = projectionFixtureJobId(13);
     try {
       seedSchema(dbPath);
       const db = new Database(dbPath);
-      createEvidenceMapSchema(db);
       // Shared profile evidence + skill that every job's tailoring references.
       db.prepare(
         `INSERT INTO candidate_profile_experience_entries
@@ -2882,53 +2180,62 @@ describe("apply_run_projections without legacy apply_runs table", () => {
          VALUES ('local', 'default', 'backend', 0, 'Python')`,
       ).run();
 
-      const insertJob = db.prepare("INSERT INTO jobs (url, title, company, site) VALUES (?, ?, ?, ?)");
+      const insertJob = db.prepare(
+        "INSERT INTO jobs (tenant_id, job_id, url, title, company, site) VALUES ('local', ?, ?, ?, ?, ?)",
+      );
+      const insertScore = db.prepare(
+        `INSERT INTO job_scores (
+           tenant_id, job_id, version, fit_score, breakdown_json, keywords_json, scored_at
+         ) VALUES ('local', ?, 2, 8, '{}', '[]', '2026-07-05T11:00:00Z')`,
+      );
       const insertMaterials = db.prepare(
-        `INSERT INTO job_materials (job_url, generation, tenant_id, status, created_at, updated_at)
-         VALUES (?, 1, 'local', 'complete', '2026-07-05T12:00:00Z', '2026-07-05T12:10:00Z')`,
+        `INSERT INTO job_materials (tenant_id, job_id, generation, status, created_at, updated_at)
+         VALUES ('local', ?, 1, 'complete', '2026-07-05T12:00:00Z', '2026-07-05T12:10:00Z')`,
       );
       const insertArtifact = db.prepare(
         `INSERT INTO job_materials_artifacts (
-          job_url, generation, artifact_type, artifact_id, status, path,
+          tenant_id, job_id, generation, artifact_type, artifact_id, status, path,
           render_format, size_bytes, metadata_json, created_at
-        ) VALUES (?, 1, 'tailored_resume', ?, 'approved', ?, 'text', 12, ?, '2026-07-05T12:05:00Z')`,
+        ) VALUES ('local', ?, 1, 'tailored_resume', ?, 'approved', ?, 'text', 12, ?, '2026-07-05T12:05:00Z')`,
       );
       const insertProvenance = db.prepare(
         `INSERT INTO job_bullet_provenance (
-          job_url, generation, bullet_id, tenant_id, artifact_id, section, source_id,
+          tenant_id, job_id, generation, bullet_id, artifact_id, section, source_id,
           evidence_ids_json, requirement_ids_json, matched_keywords_json, transform_type,
           control, rationale, generated_text, position, created_at, coverage_json
-        ) VALUES (?, 1, 'experience:exp-platform#0', 'local', ?, 'experience', 'exp-platform', ?, ?, ?, 'reframe', 'rephrase_allowed', 'Used profile evidence.', ?, 0, ?, ?)`,
+        ) VALUES ('local', ?, 1, 'experience:exp-platform#0', ?, 'experience', 'exp-platform', ?, ?, ?, 'reframe', 'rephrase_allowed', 'Used profile evidence.', ?, 0, ?, ?)`,
       );
       const insertReport = db.prepare(
         `INSERT INTO job_requirement_fit_reports (
-          job_url, score_version, tenant_id, employer_analysis_generation,
+          tenant_id, job_id, score_version, employer_analysis_generation,
           profile_snapshot_version, scoring_policy_version, formula_version,
           resolved_fit_score, fit_band, confidence, summary_json, created_at
-        ) VALUES (?, 2, 'local', 1, 1, 1, 'v1', 8, 'strong', 'high', ?, '2026-07-05T12:20:00Z')`,
+        ) VALUES ('local', ?, 2, 1, 1, 1, 'v1', 8, 'strong', 'high', ?, '2026-07-05T12:20:00Z')`,
       );
       const insertFitItem = db.prepare(
         `INSERT INTO job_requirement_fit_items (
-          job_url, score_version, tenant_id, requirement_id, requirement_text,
+          tenant_id, job_id, score_version, requirement_id, requirement_text,
           tier, weight, job_evidence_span, fit_json, contribution_json,
           tailoring_json, artifact_coverage_json, position
-        ) VALUES (?, 2, 'local', ?, ?, 'must_have', ?, ?, ?, '{}', '{}', ?, ?)`,
+        ) VALUES ('local', ?, 2, ?, ?, 'must_have', ?, ?, ?, '{}', '{}', ?, ?)`,
       );
 
       const seedJobEvidence = (
+        jobId: string,
         jobUrl: string,
         opts: { title: string; company: string; artifactId: string; generatedText: string; createdAt: string },
       ): void => {
-        insertJob.run(jobUrl, opts.title, opts.company, "example.com");
-        insertMaterials.run(jobUrl);
+        insertJob.run(jobId, jobUrl, opts.title, opts.company, "example.com");
+        insertScore.run(jobId);
+        insertMaterials.run(jobId);
         insertArtifact.run(
-          jobUrl,
+          jobId,
           opts.artifactId,
           `/tmp/${opts.artifactId}.txt`,
           JSON.stringify({ validation_mode: "normal", attempts: 1, quality_checks: { passed: true } }),
         );
         insertProvenance.run(
-          jobUrl,
+          jobId,
           opts.artifactId,
           JSON.stringify(["ev_platform"]),
           JSON.stringify(["req-platform"]),
@@ -2938,11 +2245,11 @@ describe("apply_run_projections without legacy apply_runs table", () => {
           JSON.stringify({ covered: ["Python"], declared: [], missing: ["Kubernetes"] }),
         );
         insertReport.run(
-          jobUrl,
+          jobId,
           JSON.stringify({ weighted_fit: 0.8, must_have_coverage: 0.5, blocker_count: 0, missing_high_weight_count: 1 }),
         );
         insertFitItem.run(
-          jobUrl,
+          jobId,
           "req-platform",
           "Own platform migrations",
           0.8,
@@ -2952,7 +2259,7 @@ describe("apply_run_projections without legacy apply_runs table", () => {
           0,
         );
         insertFitItem.run(
-          jobUrl,
+          jobId,
           "req-kubernetes",
           "Run Kubernetes clusters",
           0.7,
@@ -2963,21 +2270,21 @@ describe("apply_run_projections without legacy apply_runs table", () => {
         );
       };
 
-      seedJobEvidence(activeUrl, {
+      seedJobEvidence(activeId, activeUrl, {
         title: "Active Platform Role",
         company: "ActiveCorp",
         artifactId: "artifact-active",
         generatedText: "ACTIVE-bullet reduced latency 40%.",
         createdAt: "2026-07-05T12:10:00Z",
       });
-      seedJobEvidence(deletedUrl, {
+      seedJobEvidence(deletedId, deletedUrl, {
         title: "Deleted Platform Role",
         company: "DeletedCorp",
         artifactId: "artifact-deleted",
         generatedText: "DELETED-bullet should never surface.",
         createdAt: "2026-07-04T12:10:00Z",
       });
-      seedJobEvidence(hiddenUrl, {
+      seedJobEvidence(hiddenId, hiddenUrl, {
         title: "Hidden Platform Role",
         company: "HiddenCorp",
         artifactId: "artifact-hidden",
@@ -2986,13 +2293,13 @@ describe("apply_run_projections without legacy apply_runs table", () => {
       });
 
       db.prepare(
-        `INSERT INTO jobctrl_deleted_jobs (job_url, deleted_at, reason, restored_at)
-         VALUES (?, '2026-07-05T13:00:00Z', 'user delete', NULL)`,
-      ).run(deletedUrl);
+        `INSERT INTO jobctrl_deleted_jobs (tenant_id, job_id, deleted_at, reason, restored_at)
+         VALUES ('local', ?, '2026-07-05T13:00:00Z', 'user delete', NULL)`,
+      ).run(deletedId);
       db.prepare(
-        `INSERT INTO jobctrl_hidden_jobs (job_url, hidden_at, reason, unhidden_at)
-         VALUES (?, '2026-07-05T13:00:00Z', 'user hide', NULL)`,
-      ).run(hiddenUrl);
+        `INSERT INTO jobctrl_hidden_jobs (tenant_id, job_id, hidden_at, reason, unhidden_at)
+         VALUES ('local', ?, '2026-07-05T13:00:00Z', 'user hide', NULL)`,
+      ).run(hiddenId);
       db.close();
 
       const app = buildApp({
@@ -3019,10 +2326,10 @@ describe("apply_run_projections without legacy apply_runs table", () => {
         }
 
         // The live job still populates the map (positive control) ...
-        expect(referencedJobKeys.has(activeUrl)).toBe(true);
+        expect(referencedJobKeys.has(activeId)).toBe(true);
         // ... while the soft-deleted and hidden jobs are fully excluded.
-        expect(referencedJobKeys.has(deletedUrl)).toBe(false);
-        expect(referencedJobKeys.has(hiddenUrl)).toBe(false);
+        expect(referencedJobKeys.has(deletedId)).toBe(false);
+        expect(referencedJobKeys.has(hiddenId)).toBe(false);
 
         // No removed job's title, employer, or generated-text preview may leak
         // through any evidence field.
@@ -3056,57 +2363,10 @@ describe("apply_run_projections without legacy apply_runs table", () => {
     const { dbPath, cleanup } = withTempDb();
     // Reuse the job ``seedSchema`` already inserts, so the artifact projection
     // builds (the builder drops projections for jobs with no ``jobs`` row).
-    const jobUrl = "https://example.com/jobs/event-driven";
+    const jobId = EVENT_JOB_ID;
     try {
       seedSchema(dbPath);
       const db = new Database(dbPath);
-      db.exec(`
-        CREATE TABLE job_materials (
-          job_url TEXT NOT NULL,
-          generation INTEGER NOT NULL,
-          tenant_id TEXT NOT NULL DEFAULT 'local',
-          status TEXT NOT NULL,
-          created_at TEXT NOT NULL,
-          updated_at TEXT NOT NULL,
-          last_validation_json TEXT,
-          last_verdict_json TEXT,
-          metadata_json TEXT,
-          PRIMARY KEY (job_url, generation)
-        );
-        CREATE TABLE job_materials_artifacts (
-          job_url TEXT NOT NULL,
-          generation INTEGER NOT NULL,
-          artifact_type TEXT NOT NULL,
-          artifact_id TEXT NOT NULL,
-          status TEXT NOT NULL,
-          path TEXT NOT NULL,
-          render_format TEXT NOT NULL,
-          size_bytes INTEGER,
-          metadata_json TEXT,
-          created_at TEXT NOT NULL,
-          superseded_at TEXT,
-          PRIMARY KEY (job_url, generation, artifact_type)
-        );
-        CREATE TABLE job_bullet_provenance (
-          job_url TEXT NOT NULL,
-          generation INTEGER NOT NULL,
-          bullet_id TEXT NOT NULL,
-          tenant_id TEXT NOT NULL DEFAULT 'local',
-          artifact_id TEXT NOT NULL,
-          section TEXT NOT NULL,
-          source_id TEXT,
-          evidence_ids_json TEXT NOT NULL DEFAULT '[]',
-          requirement_ids_json TEXT NOT NULL DEFAULT '[]',
-          matched_keywords_json TEXT NOT NULL DEFAULT '[]',
-          transform_type TEXT NOT NULL,
-          control TEXT NOT NULL,
-          rationale TEXT NOT NULL DEFAULT '',
-          generated_text TEXT NOT NULL,
-          position INTEGER NOT NULL DEFAULT 0,
-          created_at TEXT NOT NULL,
-          PRIMARY KEY (job_url, generation, bullet_id)
-        );
-      `);
       // A complete metadata blob so the tailoring explanation has its audit fields
       // (the explanation must exist for bulletProvenance to attach to it).
       const completeMetadata = JSON.stringify({
@@ -3147,34 +2407,34 @@ describe("apply_run_projections without legacy apply_runs table", () => {
         ],
       });
       db.prepare(
-        `INSERT INTO job_materials (job_url, generation, tenant_id, status, created_at, updated_at)
-         VALUES (?, 1, 'local', 'complete', '2026-06-08T12:00:00+00:00', '2026-06-08T12:10:00+00:00')`,
-      ).run(jobUrl);
+        `INSERT INTO job_materials (tenant_id, job_id, generation, status, created_at, updated_at)
+         VALUES ('local', ?, 1, 'complete', '2026-06-08T12:00:00+00:00', '2026-06-08T12:10:00+00:00')`,
+      ).run(jobId);
       const insertArtifact = db.prepare(
         `INSERT INTO job_materials_artifacts (
-          job_url, generation, artifact_type, artifact_id, status, path,
+          tenant_id, job_id, generation, artifact_type, artifact_id, status, path,
           render_format, size_bytes, metadata_json, created_at
-        ) VALUES (?, 1, ?, ?, 'approved', ?, ?, ?, ?, '2026-06-08T12:05:00+00:00')`,
+        ) VALUES ('local', ?, 1, ?, ?, 'approved', ?, ?, ?, ?, '2026-06-08T12:05:00+00:00')`,
       );
-      insertArtifact.run(jobUrl, "tailored_resume", "resume-1", "/tmp/resume.txt", "text", 10, completeMetadata);
-      insertArtifact.run(jobUrl, "resume_pdf", "resume-pdf-1", "/tmp/resume.pdf", "pdf", 20, "{}");
+      insertArtifact.run(jobId, "tailored_resume", "resume-1", "/tmp/resume.txt", "text", 10, completeMetadata);
+      insertArtifact.run(jobId, "resume_pdf", "resume-pdf-1", "/tmp/resume.pdf", "pdf", 20, "{}");
 
       // Provenance rows (as the Python repo writes them): bound to the text
       // resume artifact, ordered by position.
       const insertProvenance = db.prepare(
         `INSERT INTO job_bullet_provenance (
-          job_url, generation, bullet_id, tenant_id, artifact_id, section, source_id,
+          tenant_id, job_id, generation, bullet_id, artifact_id, section, source_id,
           evidence_ids_json, requirement_ids_json, matched_keywords_json,
           transform_type, control, rationale, generated_text, position, created_at
-        ) VALUES (?, 1, ?, 'local', 'resume-1', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, '2026-06-08T12:10:00+00:00')`,
+        ) VALUES ('local', ?, 1, ?, 'resume-1', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, '2026-06-08T12:10:00+00:00')`,
       );
       insertProvenance.run(
-        jobUrl, "executive_profile#0", "executive_profile", "executive_profile",
+        jobId, "executive_profile#0", "executive_profile", "executive_profile",
         "[]", "[]", "[]", "reframe", "rephrase_allowed", "Reframed summary.",
         "Senior backend engineer focused on Python.", 0,
       );
       insertProvenance.run(
-        jobUrl, "experience:acme_swe#0", "experience", "acme_swe",
+        jobId, "experience:acme_swe#0", "experience", "acme_swe",
         JSON.stringify(["ev_latency"]), JSON.stringify(["req_latency"]), JSON.stringify(["latency"]),
         "quantify_from_evidence", "never_fabricate_metrics", "Surfaced a recorded metric.",
         "Owned the API and cut latency 40%.", 1,
@@ -3233,37 +2493,10 @@ describe("apply_run_projections without legacy apply_runs table", () => {
     // TS read model serves the SAME ``coverageAudit`` (GROUND-06) + ``voicePass``
     // (VOICE-02) shapes — for the text resume AND, via the sibling row, the PDF.
     const { dbPath, cleanup } = withTempDb();
-    const jobUrl = "https://example.com/jobs/event-driven";
+    const jobId = EVENT_JOB_ID;
     try {
       seedSchema(dbPath);
       const db = new Database(dbPath);
-      db.exec(`
-        CREATE TABLE job_materials (
-          job_url TEXT NOT NULL, generation INTEGER NOT NULL,
-          tenant_id TEXT NOT NULL DEFAULT 'local', status TEXT NOT NULL,
-          created_at TEXT NOT NULL, updated_at TEXT NOT NULL,
-          last_validation_json TEXT, last_verdict_json TEXT, metadata_json TEXT,
-          PRIMARY KEY (job_url, generation)
-        );
-        CREATE TABLE job_materials_artifacts (
-          job_url TEXT NOT NULL, generation INTEGER NOT NULL, artifact_type TEXT NOT NULL,
-          artifact_id TEXT NOT NULL, status TEXT NOT NULL, path TEXT NOT NULL,
-          render_format TEXT NOT NULL, size_bytes INTEGER, metadata_json TEXT,
-          created_at TEXT NOT NULL, superseded_at TEXT,
-          PRIMARY KEY (job_url, generation, artifact_type)
-        );
-        CREATE TABLE job_bullet_provenance (
-          job_url TEXT NOT NULL, generation INTEGER NOT NULL, bullet_id TEXT NOT NULL,
-          tenant_id TEXT NOT NULL DEFAULT 'local', artifact_id TEXT NOT NULL,
-          section TEXT NOT NULL, source_id TEXT,
-          evidence_ids_json TEXT NOT NULL DEFAULT '[]', requirement_ids_json TEXT NOT NULL DEFAULT '[]',
-          matched_keywords_json TEXT NOT NULL DEFAULT '[]', transform_type TEXT NOT NULL,
-          control TEXT NOT NULL, rationale TEXT NOT NULL DEFAULT '', generated_text TEXT NOT NULL,
-          position INTEGER NOT NULL DEFAULT 0, created_at TEXT NOT NULL,
-          coverage_json TEXT, voice_json TEXT,
-          PRIMARY KEY (job_url, generation, bullet_id)
-        );
-      `);
       const completeMetadata = JSON.stringify({
         validation_mode: "normal",
         attempts: 1,
@@ -3288,21 +2521,21 @@ describe("apply_run_projections without legacy apply_runs table", () => {
         change_annotations: [],
       });
       db.prepare(
-        `INSERT INTO job_materials (job_url, generation, tenant_id, status, created_at, updated_at)
-         VALUES (?, 1, 'local', 'complete', '2026-06-08T12:00:00+00:00', '2026-06-08T12:10:00+00:00')`,
-      ).run(jobUrl);
+        `INSERT INTO job_materials (tenant_id, job_id, generation, status, created_at, updated_at)
+         VALUES ('local', ?, 1, 'complete', '2026-06-08T12:00:00+00:00', '2026-06-08T12:10:00+00:00')`,
+      ).run(jobId);
       db.prepare(
-        `INSERT INTO job_materials (job_url, generation, tenant_id, status, created_at, updated_at)
-         VALUES (?, 2, 'local', 'complete', '2026-06-09T12:00:00+00:00', '2026-06-09T12:10:00+00:00')`,
-      ).run(jobUrl);
+        `INSERT INTO job_materials (tenant_id, job_id, generation, status, created_at, updated_at)
+         VALUES ('local', ?, 2, 'complete', '2026-06-09T12:00:00+00:00', '2026-06-09T12:10:00+00:00')`,
+      ).run(jobId);
       const insertArtifact = db.prepare(
         `INSERT INTO job_materials_artifacts (
-          job_url, generation, artifact_type, artifact_id, status, path,
+          tenant_id, job_id, generation, artifact_type, artifact_id, status, path,
           render_format, size_bytes, metadata_json, created_at
-        ) VALUES (?, ?, ?, ?, 'approved', ?, ?, ?, ?, ?)`,
+        ) VALUES ('local', ?, ?, ?, ?, 'approved', ?, ?, ?, ?, ?)`,
       );
       insertArtifact.run(
-        jobUrl,
+        jobId,
         1,
         "tailored_resume",
         "resume-1",
@@ -3313,7 +2546,7 @@ describe("apply_run_projections without legacy apply_runs table", () => {
         "2026-06-08T12:05:00+00:00",
       );
       insertArtifact.run(
-        jobUrl,
+        jobId,
         1,
         "resume_pdf",
         "resume-pdf-1",
@@ -3324,7 +2557,7 @@ describe("apply_run_projections without legacy apply_runs table", () => {
         "2026-06-08T12:05:00+00:00",
       );
       insertArtifact.run(
-        jobUrl,
+        jobId,
         2,
         "tailored_resume",
         "resume-2",
@@ -3370,20 +2603,20 @@ describe("apply_run_projections without legacy apply_runs table", () => {
       });
       const insertProvenance = db.prepare(
         `INSERT INTO job_bullet_provenance (
-          job_url, generation, bullet_id, tenant_id, artifact_id, section, source_id,
+          tenant_id, job_id, generation, bullet_id, artifact_id, section, source_id,
           evidence_ids_json, requirement_ids_json, matched_keywords_json,
           transform_type, control, rationale, generated_text, position, created_at,
           coverage_json, voice_json
-        ) VALUES (?, ?, ?, 'local', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        ) VALUES ('local', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       );
       insertProvenance.run(
-        jobUrl, 1, "experience:acme_swe#0", "resume-1", "experience", "acme_swe",
+        jobId, 1, "experience:acme_swe#0", "resume-1", "experience", "acme_swe",
         JSON.stringify(["ev_latency"]), JSON.stringify(["req_latency"]), JSON.stringify(["latency"]),
         "voice", "rephrase_allowed", "Voiced bullet.",
         "Owned the API and cut latency 40%.", 0, "2026-06-08T12:10:00+00:00", coverageJsonGen1, voiceJson,
       );
       insertProvenance.run(
-        jobUrl, 2, "experience:incident#0", "resume-2", "experience", "incident_response",
+        jobId, 2, "experience:incident#0", "resume-2", "experience", "incident_response",
         JSON.stringify(["ev_incident"]), JSON.stringify(["req_incident"]), JSON.stringify(["incident response"]),
         "voice", "rephrase_allowed", "Voiced bullet.",
         "Owned incident response drills.", 0, "2026-06-09T12:10:00+00:00", coverageJsonGen2, voiceJson,
@@ -3838,105 +3071,9 @@ describe("apply_run_projections without legacy apply_runs table", () => {
 
 describe("dashboard outcome-conversion projection", () => {
   function seedConversionDb(dbPath: string): void {
+    initializeExactV7Database(dbPath);
     const db = new Database(dbPath);
-    db.exec(`
-      CREATE TABLE jobs (
-        url TEXT PRIMARY KEY, title TEXT, company TEXT, site TEXT, strategy TEXT,
-        location TEXT, salary TEXT, discovered_at TEXT, application_url TEXT,
-        description TEXT, full_description TEXT, detail_scraped_at TEXT,
-        detail_error TEXT, fit_score INTEGER, score_reasoning TEXT, scored_at TEXT,
-        tailored_resume_path TEXT, tailored_at TEXT, tailor_attempts INTEGER DEFAULT 0,
-        cover_letter_path TEXT, cover_letter_at TEXT, cover_attempts INTEGER DEFAULT 0,
-        applied_at TEXT, apply_status TEXT, apply_error TEXT, apply_attempts INTEGER DEFAULT 0
-      );
-      CREATE TABLE job_events (
-        event_id INTEGER PRIMARY KEY AUTOINCREMENT, job_url TEXT, stage TEXT,
-        event_type TEXT NOT NULL DEFAULT '', level TEXT NOT NULL DEFAULT 'info',
-        message TEXT, occurred_at TEXT NOT NULL, payload_json TEXT
-      );
-      CREATE TABLE job_scores (
-        job_url TEXT NOT NULL, version INTEGER NOT NULL, tenant_id TEXT NOT NULL DEFAULT 'local',
-        fit_score INTEGER NOT NULL, breakdown_json TEXT NOT NULL, keywords_json TEXT NOT NULL,
-        scored_at TEXT NOT NULL, correction_json TEXT, criteria_json TEXT NOT NULL DEFAULT '{}',
-        trace_json TEXT NOT NULL DEFAULT '{}', PRIMARY KEY (job_url, version)
-      );
-      CREATE TABLE job_stage_states (
-        job_url TEXT NOT NULL, stage TEXT NOT NULL, state TEXT NOT NULL DEFAULT 'pending',
-        attempt_count INTEGER DEFAULT 0, max_attempts INTEGER, started_at TEXT,
-        updated_at TEXT NOT NULL DEFAULT '', finished_at TEXT, duration_ms INTEGER,
-        error_code TEXT, error_message TEXT, retryable INTEGER DEFAULT 1,
-        blocked_by_json TEXT, next_action TEXT, metadata_json TEXT,
-        version INTEGER NOT NULL DEFAULT 0, PRIMARY KEY (job_url, stage)
-      );
-      CREATE TABLE application_outcomes (
-        tenant_id TEXT NOT NULL DEFAULT 'local', outcome_id TEXT NOT NULL,
-        job_key TEXT NOT NULL, kind TEXT NOT NULL, source TEXT NOT NULL, note TEXT,
-        occurred_at TEXT NOT NULL, recorded_at TEXT NOT NULL,
-        PRIMARY KEY (tenant_id, outcome_id)
-      );
-      CREATE TABLE application_outcome_suggestions (
-        tenant_id TEXT NOT NULL DEFAULT 'local',
-        suggestion_id TEXT NOT NULL,
-        job_key TEXT NOT NULL,
-        evidence_id TEXT,
-        suggested_kind TEXT NOT NULL,
-        confidence REAL NOT NULL DEFAULT 0,
-        rationale TEXT NOT NULL DEFAULT '',
-        status TEXT NOT NULL DEFAULT 'pending',
-        created_at TEXT NOT NULL,
-        decided_at TEXT,
-        decision TEXT,
-        decision_reason TEXT,
-        decided_outcome_id TEXT,
-        PRIMARY KEY (tenant_id, suggestion_id)
-      );
-      CREATE TABLE job_materials (
-        job_url TEXT NOT NULL,
-        generation INTEGER NOT NULL,
-        tenant_id TEXT NOT NULL DEFAULT 'local',
-        status TEXT NOT NULL,
-        created_at TEXT NOT NULL,
-        updated_at TEXT NOT NULL,
-        last_validation_json TEXT,
-        last_verdict_json TEXT,
-        metadata_json TEXT,
-        PRIMARY KEY (job_url, generation)
-      );
-      CREATE TABLE job_materials_artifacts (
-        job_url TEXT NOT NULL,
-        generation INTEGER NOT NULL,
-        artifact_type TEXT NOT NULL,
-        artifact_id TEXT,
-        status TEXT NOT NULL,
-        path TEXT NOT NULL,
-        render_format TEXT NOT NULL DEFAULT 'text',
-        size_bytes INTEGER,
-        metadata_json TEXT,
-        created_at TEXT NOT NULL
-      );
-      CREATE TABLE job_requirement_fit_reports (
-        job_url TEXT NOT NULL, score_version INTEGER NOT NULL,
-        tenant_id TEXT NOT NULL DEFAULT 'local',
-        employer_analysis_generation INTEGER NOT NULL DEFAULT 1,
-        profile_snapshot_version INTEGER NOT NULL DEFAULT 1,
-        scoring_policy_version INTEGER NOT NULL DEFAULT 1,
-        formula_version TEXT NOT NULL DEFAULT 'test',
-        resolved_fit_score INTEGER,
-        fit_band TEXT NOT NULL,
-        confidence TEXT NOT NULL DEFAULT 'medium',
-        summary_json TEXT NOT NULL DEFAULT '{}',
-        created_at TEXT NOT NULL,
-        PRIMARY KEY (job_url, score_version, tenant_id)
-      );
-      CREATE TABLE apply_run_projections (
-        run_id TEXT PRIMARY KEY, tenant_id TEXT NOT NULL DEFAULT 'local',
-        job_id TEXT NOT NULL, job_title TEXT NOT NULL DEFAULT '',
-        job_employer TEXT NOT NULL DEFAULT '', status TEXT NOT NULL DEFAULT '',
-        result TEXT, dry_run INTEGER NOT NULL DEFAULT 0,
-        worker_id INTEGER, model TEXT, started_at TEXT, finished_at TEXT,
-        duration_ms INTEGER, events_json TEXT NOT NULL DEFAULT '[]'
-      );
-    `);
+    seedBuiltInResumeTemplate(db);
     db.close();
   }
 
@@ -3956,18 +3093,26 @@ describe("dashboard outcome-conversion projection", () => {
   function seedJobs(dbPath: string, jobs: SeedJob[]): void {
     const db = new Database(dbPath);
     const insertJob = db.prepare(
-      `INSERT INTO jobs (url, title, site, fit_score, apply_status, applied_at, discovered_at)
-       VALUES (@url, @title, @site, @fit_score, @apply_status, @applied_at, @discovered_at)`,
+      `INSERT INTO jobs (
+         tenant_id, job_id, url, title, site, fit_score, apply_status, applied_at, discovered_at
+       ) VALUES (
+         'local', @job_id, @url, @title, @site, @fit_score, @apply_status, @applied_at, @discovered_at
+       )`,
+    );
+    const insertScore = db.prepare(
+      `INSERT INTO job_scores (
+         tenant_id, job_id, version, fit_score, breakdown_json, keywords_json, scored_at
+       ) VALUES ('local', @job_id, 1, @fit_score, '{}', '[]', @scored_at)`,
     );
     const insertOutcome = db.prepare(
-      `INSERT INTO application_outcomes (tenant_id, outcome_id, job_key, kind, source, occurred_at, recorded_at)
-       VALUES ('local', @outcome_id, @job_key, @kind, 'manual', @at, @at)`,
+      `INSERT INTO application_outcomes (tenant_id, outcome_id, job_id, kind, source, occurred_at, recorded_at)
+       VALUES ('local', @outcome_id, @job_id, @kind, 'manual', @at, @at)`,
     );
     const insertFitReport = db.prepare(
       `INSERT INTO job_requirement_fit_reports (
-         job_url, score_version, tenant_id, employer_analysis_generation, profile_snapshot_version,
+         tenant_id, job_id, score_version, employer_analysis_generation, profile_snapshot_version,
          scoring_policy_version, formula_version, resolved_fit_score, fit_band, confidence, summary_json, created_at
-       ) VALUES (@job_url, 1, 'local', 1, 1, 1, 'test', @resolved_fit_score, @fit_band, 'medium', '{}', @at)`,
+       ) VALUES ('local', @job_id, 1, 1, 1, 1, 'test', @resolved_fit_score, @fit_band, 'medium', '{}', @at)`,
     );
     const insertApplyRun = db.prepare(
       `INSERT INTO apply_run_projections (
@@ -3975,25 +3120,28 @@ describe("dashboard outcome-conversion projection", () => {
        ) VALUES (@run_id, 'local', @job_id, 'Engineer', 'Example', @status, @result, @dry_run, @started_at, @finished_at, '[]')`,
     );
     const insertEvent = db.prepare(
-      `INSERT INTO job_events (job_url, stage, event_type, level, message, occurred_at, payload_json)
-       VALUES (@job_url, 'apply', @event_type, 'info', @message, @at, '{}')`,
+      `INSERT INTO job_events (
+         tenant_id, job_id, identity_version, stage, event_type, level, message, occurred_at, payload_json
+       ) VALUES ('local', @job_id, 1, 'apply', @event_type, 'info', @message, @at, '{}')`,
     );
     const insertMaterial = db.prepare(
       `INSERT INTO job_materials (
-         job_url, generation, tenant_id, status, created_at, updated_at, metadata_json
-       ) VALUES (@job_url, @generation, 'local', 'resume_approved', @created_at, @created_at, @metadata_json)`,
+         tenant_id, job_id, generation, status, created_at, updated_at, metadata_json
+       ) VALUES ('local', @job_id, @generation, 'resume_approved', @created_at, @created_at, @metadata_json)`,
     );
     const insertMaterialArtifact = db.prepare(
       `INSERT INTO job_materials_artifacts (
-         job_url, generation, artifact_type, artifact_id, status, path,
+         tenant_id, job_id, generation, artifact_type, artifact_id, status, path,
          render_format, size_bytes, metadata_json, created_at
        ) VALUES (
-         @job_url, 1, 'tailored_resume', @artifact_id, 'approved', @path,
+         'local', @job_id, 1, 'tailored_resume', @artifact_id, 'approved', @path,
          'text', 12, @metadata_json, @created_at
        )`,
     );
-    for (const job of jobs) {
+    jobs.forEach((job, index) => {
+      const jobId = projectionFixtureJobId(1000 + index);
       insertJob.run({
+        job_id: jobId,
         url: job.url,
         title: "Engineer",
         site: job.site,
@@ -4002,9 +3150,16 @@ describe("dashboard outcome-conversion projection", () => {
         applied_at: job.applied ? "2026-06-01T12:00:00+00:00" : null,
         discovered_at: "2026-05-20T12:00:00+00:00",
       });
+      if (job.fitScore !== null) {
+        insertScore.run({
+          job_id: jobId,
+          fit_score: job.fitScore,
+          scored_at: "2026-05-25T12:00:00+00:00",
+        });
+      }
       if (job.fitBand) {
         insertFitReport.run({
-          job_url: job.url,
+          job_id: jobId,
           resolved_fit_score: job.fitScore,
           fit_band: job.fitBand,
           at: "2026-05-25T12:00:00+00:00",
@@ -4012,8 +3167,8 @@ describe("dashboard outcome-conversion projection", () => {
       }
       if (job.applyRun) {
         insertApplyRun.run({
-          run_id: `${job.url}-run`,
-          job_id: job.url,
+          run_id: `${jobId}-run`,
+          job_id: jobId,
           status: job.applyRun.status,
           result: job.applyRun.status === "succeeded" ? "applied" : job.applyRun.status,
           dry_run: job.applyRun.dryRun ? 1 : 0,
@@ -4023,7 +3178,7 @@ describe("dashboard outcome-conversion projection", () => {
       }
       if (job.manualMarked) {
         insertEvent.run({
-          job_url: job.url,
+          job_id: jobId,
           event_type: "ApplicationManuallyMarked",
           message: "Job marked applied from test.",
           at: "2026-06-01T12:00:00+00:00",
@@ -4044,39 +3199,43 @@ describe("dashboard outcome-conversion projection", () => {
             : undefined,
         });
         insertMaterial.run({
-          job_url: job.url,
+          job_id: jobId,
           generation: 1,
           metadata_json: metadata,
           created_at: "2026-06-01T12:00:00+00:00",
         });
         insertMaterialArtifact.run({
-          job_url: job.url,
-          artifact_id: `${job.url}-resume`,
-          path: `/tmp/${encodeURIComponent(job.url)}.txt`,
+          job_id: jobId,
+          artifact_id: `${jobId}-resume`,
+          path: `/tmp/${jobId}.txt`,
           metadata_json: metadata,
           created_at: "2026-06-01T12:00:00+00:00",
         });
       }
       for (const kind of job.outcomes ?? []) {
         insertOutcome.run({
-          outcome_id: `${job.url}-${kind}`,
-          job_key: job.url,
+          outcome_id: `${jobId}-${kind}`,
+          job_id: jobId,
           kind,
           at: "2026-06-05T12:00:00+00:00",
         });
       }
-    }
+    });
     db.close();
   }
 
   function seedAcceptedReplacementResume(dbPath: string, jobUrl: string): void {
     const db = new Database(dbPath);
+    const row = db
+      .prepare("SELECT job_id FROM jobs WHERE tenant_id = 'local' AND url = ?")
+      .get(jobUrl) as { job_id: string } | undefined;
+    if (!row) throw new Error(`Missing exact-v7 job fixture for ${jobUrl}`);
     db.prepare(
       `INSERT INTO job_materials (
-         job_url, generation, tenant_id, status, created_at, updated_at, metadata_json
-       ) VALUES (?, 2, 'local', 'resume_approved', ?, ?, ?)`,
+         tenant_id, job_id, generation, status, created_at, updated_at, metadata_json
+       ) VALUES ('local', ?, 2, 'resume_approved', ?, ?, ?)`,
     ).run(
-      jobUrl,
+      row.job_id,
       "2026-06-02T12:00:00+00:00",
       "2026-06-02T12:00:00+00:00",
       JSON.stringify({
@@ -4086,17 +3245,17 @@ describe("dashboard outcome-conversion projection", () => {
     );
     db.prepare(
       `INSERT INTO job_materials_artifacts (
-         job_url, generation, artifact_type, artifact_id, status, path,
+         tenant_id, job_id, generation, artifact_type, artifact_id, status, path,
          render_format, size_bytes, metadata_json, created_at
-       ) VALUES (?, 2, 'tailored_resume', ?, 'approved', ?, 'text', 14, ?, ?)`,
+       ) VALUES ('local', ?, 2, 'tailored_resume', ?, 'approved', ?, 'text', 14, ?, ?)`,
     ).run(
-      jobUrl,
-      `${jobUrl}-replacement-resume`,
-      `/tmp/${encodeURIComponent(jobUrl)}-replacement.txt`,
+      row.job_id,
+      `${row.job_id}-replacement-resume`,
+      `/tmp/${row.job_id}-replacement.txt`,
       JSON.stringify({
         source: "resume_review_draft",
         base_generation: 1,
-        base_resume_text_artifact_id: `${jobUrl}-resume`,
+        base_resume_text_artifact_id: `${row.job_id}-resume`,
       }),
       "2026-06-02T12:00:00+00:00",
     );
@@ -4105,17 +3264,21 @@ describe("dashboard outcome-conversion projection", () => {
 
   function seedSuggestions(dbPath: string, statuses: string[]): void {
     const db = new Database(dbPath);
+    const jobs = db
+      .prepare("SELECT job_id FROM jobs WHERE tenant_id = 'local' ORDER BY job_id")
+      .all() as Array<{ job_id: string }>;
+    if (jobs.length === 0) throw new Error("Outcome suggestion fixtures require an exact-v7 job");
     const insertSuggestion = db.prepare(
       `INSERT INTO application_outcome_suggestions (
-         tenant_id, suggestion_id, job_key, suggested_kind, confidence, rationale,
+         tenant_id, suggestion_id, job_id, suggested_kind, confidence, rationale,
          status, created_at, decided_at, decision
-       ) VALUES ('local', @suggestion_id, @job_key, 'recruiter_reply', 0.9, '',
+       ) VALUES ('local', @suggestion_id, @job_id, 'recruiter_reply', 0.9, '',
          @status, @created_at, @decided_at, @decision)`,
     );
     statuses.forEach((status, index) => {
       insertSuggestion.run({
         suggestion_id: `suggestion-${index}`,
-        job_key: `https://example.com/suggestion-${index}`,
+        job_id: jobs[index % jobs.length]!.job_id,
         status,
         created_at: "2026-06-02T12:00:00+00:00",
         decided_at: "2026-06-02T12:05:00+00:00",

--- a/apps/api/test/projections.test.ts
+++ b/apps/api/test/projections.test.ts
@@ -3215,7 +3215,10 @@ describe("dashboard outcome-conversion projection", () => {
           finished_at: job.applyRun.status === "starting" ? null : "2026-06-01T12:00:00+00:00",
         });
       }
-      if (job.manualMarked) {
+      const seedsManualApplication =
+        job.manualMarked ||
+        (job.applied && !job.applyRun && !job.outcomes?.includes("applied_confirmation"));
+      if (seedsManualApplication) {
         insertEvent.run({
           job_id: jobId,
           event_type: "ApplicationManuallyMarked",

--- a/apps/api/test/read-model-v7.test.ts
+++ b/apps/api/test/read-model-v7.test.ts
@@ -1,0 +1,225 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import Database from "better-sqlite3";
+import { afterEach, describe, expect, it } from "vitest";
+
+import type { JobListQuery } from "../src/contracts.js";
+import {
+  buildDashboardSummary,
+  getJobDetail,
+  listActivity,
+  listJobs,
+} from "../src/read-model.js";
+import { BUILT_IN_RESUME_TEMPLATE_THEME } from "../src/resume-templates.js";
+import { EXACT_V7_SCHEMA_MANIFEST, schemaManifest } from "../src/schema-manifest.js";
+import { initializeExactV7Database } from "./v7-schema.js";
+
+const JOB_ID = "00000000-0000-4000-8000-000000000081";
+const HIDDEN_JOB_ID = "00000000-0000-4000-8000-000000000082";
+const DELETED_JOB_ID = "00000000-0000-4000-8000-000000000083";
+const OTHER_TENANT = "other";
+const JOB_URL = "https://jobs.example.test/read-model";
+const APPLICATION_URL = "https://apply.example.test/read-model";
+const SOURCE_URL = "https://source.example.test/read-model";
+const NOW = "2026-07-31T12:00:00Z";
+const cleanups: Array<() => void> = [];
+
+afterEach(() => {
+  while (cleanups.length) cleanups.pop()?.();
+});
+
+function seededDatabase(): Database.Database {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "jobctrl-read-model-v7-"));
+  const dbPath = path.join(dir, "jobs.db");
+  initializeExactV7Database(dbPath);
+  const db = new Database(dbPath);
+  db.pragma("foreign_keys = ON");
+  cleanups.push(() => {
+    db.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  seedBuiltInTemplate(db);
+  insertJob(db, "local", JOB_ID, JOB_URL, "Local exact-v7 job", APPLICATION_URL);
+  insertJob(db, OTHER_TENANT, JOB_ID, "https://jobs.example.test/other", "Other tenant job", "https://apply.example.test/other");
+  insertJob(db, "local", HIDDEN_JOB_ID, "https://jobs.example.test/hidden", "Hidden job", "https://apply.example.test/hidden");
+  insertJob(db, "local", DELETED_JOB_ID, "https://jobs.example.test/deleted", "Deleted job", "https://apply.example.test/deleted");
+
+  db.prepare(
+    `INSERT INTO job_source_observations (
+       tenant_id, source_observation_id, job_id, source_id, source_native_id,
+       observed_url, normalized_observed_url, observed_at
+     ) VALUES ('local', 'local-source', ?, 'source:local', 'local-1', ?, ?, ?)`,
+  ).run(JOB_ID, SOURCE_URL, SOURCE_URL, NOW);
+  db.prepare(
+    `INSERT INTO job_canonical_identities (
+       tenant_id, job_id, canonical_url, ats_kind, source_native_id, confidence, resolved_at
+     ) VALUES ('local', ?, ?, 'greenhouse', 'local-1', 1, ?)`,
+  ).run(JOB_ID, SOURCE_URL, NOW);
+  db.prepare(
+    `INSERT INTO job_locators (
+       tenant_id, job_id, locator_kind, locator_value, is_current, first_seen_at, last_seen_at
+     ) VALUES ('local', ?, 'posting_url', ?, 1, ?, ?)`,
+  ).run(JOB_ID, SOURCE_URL, NOW, NOW);
+  db.prepare(
+    `INSERT INTO job_stage_states (
+       tenant_id, job_id, stage, state, updated_at, retryable, version
+     ) VALUES ('local', ?, 'score', 'failed', ?, 0, 1)`,
+  ).run(JOB_ID, NOW);
+  db.prepare(
+    `INSERT INTO job_events (
+       tenant_id, job_id, identity_version, stage, event_type, occurred_at, payload_json
+     ) VALUES ('local', ?, 1, 'score', 'StageFailed', ?, '{"retryable":false}')`,
+  ).run(JOB_ID, NOW);
+  db.prepare(
+    `INSERT INTO job_materials (
+       tenant_id, job_id, generation, status, created_at, updated_at, metadata_json
+     ) VALUES ('local', ?, 1, 'resume_approved', ?, ?, '{}')`,
+  ).run(JOB_ID, NOW, NOW);
+  db.prepare(
+    `INSERT INTO job_materials_artifacts (
+       tenant_id, job_id, generation, artifact_type, artifact_id, status, path, render_format,
+       size_bytes, metadata_json, created_at
+     ) VALUES ('local', ?, 1, 'tailored_resume', 'resume-local', 'approved', ?, 'pdf', 12, '{}', ?)`,
+  ).run(JOB_ID, path.join(os.tmpdir(), "missing-read-model-v7.pdf"), NOW);
+  db.prepare(
+    `INSERT INTO application_review_decisions (
+       tenant_id, decision_id, job_id, decision, reason, decided_by, decided_at
+     ) VALUES ('local', 'local-review', ?, 'approved', 'because', 'user', ?)`,
+  ).run(JOB_ID, NOW);
+  db.prepare(
+    `INSERT INTO application_outcomes (
+       tenant_id, outcome_id, job_id, kind, source, occurred_at, recorded_at
+     ) VALUES ('local', 'local-outcome', ?, 'interview', 'manual', ?, ?)`,
+  ).run(JOB_ID, NOW, NOW);
+  db.prepare(
+    `INSERT INTO application_outcome_suggestions (
+       tenant_id, suggestion_id, job_id, suggested_kind, confidence, rationale, status, created_at
+     ) VALUES ('local', 'local-suggestion', ?, 'offer', 0.9, 'private rationale', 'pending', ?)`,
+  ).run(JOB_ID, NOW);
+  db.prepare(
+    `INSERT INTO application_outcomes (
+       tenant_id, outcome_id, job_id, kind, source, occurred_at, recorded_at
+     ) VALUES (?, 'other-outcome', ?, 'rejection', 'manual', ?, ?)`,
+  ).run(OTHER_TENANT, JOB_ID, NOW, NOW);
+  db.prepare(
+    `INSERT INTO jobctrl_hidden_jobs (tenant_id, job_id, hidden_at)
+     VALUES ('local', ?, ?)`,
+  ).run(HIDDEN_JOB_ID, NOW);
+  db.prepare(
+    `INSERT INTO jobctrl_deleted_jobs (tenant_id, job_id, deleted_at)
+     VALUES ('local', ?, ?)`,
+  ).run(DELETED_JOB_ID, NOW);
+  return db;
+}
+
+function insertJob(
+  db: Database.Database,
+  tenantId: string,
+  jobId: string,
+  url: string,
+  title: string,
+  applicationUrl: string,
+): void {
+  db.prepare(
+    `INSERT INTO jobs (tenant_id, job_id, url, title, company, site, discovered_at, application_url)
+     VALUES (?, ?, ?, ?, 'Example', 'example', ?, ?)`,
+  ).run(tenantId, jobId, url, title, NOW, applicationUrl);
+  db.prepare(
+    `INSERT INTO job_events (
+       tenant_id, job_id, identity_version, stage, event_type, occurred_at
+     ) VALUES (?, ?, 1, 'discover', 'JobDiscovered', ?)`,
+  ).run(tenantId, jobId, NOW);
+}
+
+function seedBuiltInTemplate(db: Database.Database): void {
+  db.prepare(
+    `INSERT INTO resume_templates (
+       tenant_id, template_id, display_name, status, built_in, created_at, updated_at
+     ) VALUES ('local', 'built_in:modern-html', 'Modern HTML', 'active', 1, ?, ?)`,
+  ).run(NOW, NOW);
+  db.prepare(
+    `INSERT INTO resume_template_versions (
+       tenant_id, version_id, template_id, version_number, display_name, status,
+       theme_json, layout_json, content_hash, created_at
+     ) VALUES ('local', 'built_in:modern-html:v1', 'built_in:modern-html', 1,
+               'Modern HTML', 'active', ?, '{}', 'seed-hash', ?)`,
+  ).run(JSON.stringify(BUILT_IN_RESUME_TEMPLATE_THEME), NOW);
+}
+
+const activeJobQuery: JobListQuery = {
+  page: 1,
+  pageSize: 50,
+  q: "",
+  sort: "discovered_at",
+  dir: "desc",
+  deleted: "active",
+  applyStatus: "all",
+  source: "",
+  company: "",
+  discoveredSince: undefined,
+  scoredSince: undefined,
+};
+
+describe("exact-v7 read model job ids", () => {
+  it("keeps same-UUID tenants isolated while preserving URL locators and material/template state", () => {
+    const db = seededDatabase();
+    const before = schemaManifest(db, EXACT_V7_SCHEMA_MANIFEST.version);
+
+    const jobs = listJobs(db, activeJobQuery);
+    const detail = getJobDetail(db, JOB_ID);
+    const byPostingUrl = getJobDetail(db, SOURCE_URL);
+    const dashboard = buildDashboardSummary(db);
+
+    expect(jobs.items.map((job) => job.jobKey)).toEqual([JOB_ID]);
+    expect(jobs.items[0]).toMatchObject({
+      jobKey: JOB_ID,
+      url: JOB_URL,
+      applicationUrl: APPLICATION_URL,
+      postingSourceUrl: SOURCE_URL,
+    });
+    expect(detail?.job.url).toBe(JOB_URL);
+    expect(byPostingUrl?.job.jobKey).toBe(JOB_ID);
+    expect(detail?.artifacts).toEqual([
+      expect.objectContaining({ artifactId: "resume-local", jobKey: JOB_ID, resumeTemplate: expect.any(Object) }),
+    ]);
+    expect(detail?.job.resumeTemplate).toEqual(expect.any(Object));
+    expect(detail?.stages.find((stage) => stage.stage === "score")).toMatchObject({ retryable: false });
+    expect(dashboard.totals.jobs).toBe(1);
+    expect(schemaManifest(db, EXACT_V7_SCHEMA_MANIFEST.version)).toEqual(before);
+  });
+
+  it("filters hidden and deleted jobs and uses only tenant-scoped events and audit rows", () => {
+    const db = seededDatabase();
+
+    const detail = getJobDetail(db, JOB_ID);
+    const activity = listActivity(db, {
+      page: 1,
+      pageSize: 50,
+      q: "",
+      sort: "occurred_at",
+      dir: "desc",
+      level: "",
+      stage: "",
+      eventType: "",
+    });
+
+    expect(listJobs(db, { ...activeJobQuery, deleted: "hidden" }).items.map((job) => job.jobKey)).toEqual([
+      HIDDEN_JOB_ID,
+    ]);
+    expect(listJobs(db, { ...activeJobQuery, deleted: "deleted" }).items.map((job) => job.jobKey)).toEqual([
+      DELETED_JOB_ID,
+    ]);
+    expect(detail?.auditHistory.map((entry) => entry.id)).toEqual(
+      expect.arrayContaining(["review:local-review", "outcome:local-outcome", "suggestion:local-suggestion"]),
+    );
+    expect(detail?.auditHistory.map((entry) => entry.id)).not.toContain("outcome:other-outcome");
+    expect(activity.items).toEqual(
+      expect.arrayContaining([expect.objectContaining({ jobKey: JOB_ID, eventType: "StageFailed" })]),
+    );
+    expect(activity.items.some((item) => item.jobKey === HIDDEN_JOB_ID || item.jobKey === DELETED_JOB_ID)).toBe(false);
+    expect(getJobDetail(db, "not-a-canonical-job-id")).toBeNull();
+  });
+});

--- a/apps/api/test/server.test.ts
+++ b/apps/api/test/server.test.ts
@@ -1929,9 +1929,16 @@ describe("local TypeScript API", () => {
     const now = new Date().toISOString();
     const db = new Database(options.dbPath);
     try {
+      const jobUrl = "https://example.com/jobs/ready";
+      db.prepare("UPDATE jobs SET discovered_at = ? WHERE url = ?").run(now, jobUrl);
       db.prepare(
-        "UPDATE jobs SET discovered_at = ?, apply_status = 'applied', applied_at = ? WHERE url = ?",
-      ).run(now, now, "https://example.com/jobs/ready");
+        `INSERT INTO job_events (
+           tenant_id, job_id, identity_version, stage, event_type, level, message, occurred_at
+         ) SELECT 'local', job_id, 1, 'apply', 'ApplicationManuallyMarked', 'info',
+                  'Job marked applied from test.', ?
+             FROM jobs
+            WHERE tenant_id = 'local' AND url = ?`,
+      ).run(now, jobUrl);
     } finally {
       db.close();
     }
@@ -2940,14 +2947,12 @@ describe("local TypeScript API", () => {
       artifactCount: 2,
     });
     expect(body.applyAudit).toMatchObject({
-      state: "preparing",
-      label: "materials preparing",
+      state: "ready",
+      label: "materials ready",
       reviewEvidenceAvailable: true,
       hardBlockers: [],
     });
-    expect(body.applyAudit.missingPrerequisites).toEqual([
-      expect.objectContaining({ code: "missing_resume_pdf" }),
-    ]);
+    expect(body.applyAudit.missingPrerequisites).toEqual([]);
     expect(body.stages.map((stage: { stage: string }) => stage.stage)).toEqual([
       "discover",
       "enrich",
@@ -3157,8 +3162,8 @@ describe("local TypeScript API", () => {
       },
     });
     expect(detailBody.applyAudit).toMatchObject({
-      state: "preparing",
-      label: "materials preparing",
+      state: "ready",
+      label: "materials ready",
       reviewEvidenceAvailable: true,
     });
 
@@ -3276,8 +3281,8 @@ describe("local TypeScript API", () => {
       },
     });
     expect(detailBody.applyAudit).toMatchObject({
-      state: "preparing",
-      label: "materials preparing",
+      state: "ready",
+      label: "materials ready",
       reviewEvidenceAvailable: true,
     });
 

--- a/packages/domain-types/test/fixtures/daily_digest_parity.json
+++ b/packages/domain-types/test/fixtures/daily_digest_parity.json
@@ -243,7 +243,7 @@
     },
     {
       "outcomeId": "outcome-not-due-applied",
-      "jobKey": "https://example.com/jobs/post-watermark-ready",
+      "jobKey": "https://example.com/jobs/post-watermark-scored",
       "kind": "applied_confirmation",
       "occurredAt": "2026-07-03T09:00:00.000Z"
     },

--- a/workers/automation/src/jobctrl/infrastructure/projections/projection_builder.py
+++ b/workers/automation/src/jobctrl/infrastructure/projections/projection_builder.py
@@ -374,7 +374,7 @@ DEFAULT_MAX_ATTEMPTS: dict[str, int] = {
 def _job_list_stage(stage: str | None, *, has_resume: bool = False) -> str:
     return "apply" if stage == "apply" or (stage == "cover" and has_resume) else "discover"
 
-_SOURCE_BOARD_NAMES = {"greenhouse", "linkedin", "talent.com"}
+_UNKNOWN_EMPLOYER = "Unknown company"
 
 # Score bands bucket ``fit_score`` by the user-facing scoring criteria in
 # ``domain/scoring/use_cases.py`` SCORE_PROMPT (9-10 perfect ... 1-2 poor) so the
@@ -692,6 +692,15 @@ class ProjectionBuilder:
         ensure_projection_tables(boot_conn)
         boot_conn.commit()
 
+    @property
+    def _watermark_name(self) -> str:
+        tenant = str(self._tenant_id)
+        return (
+            PROJECTION_NAME
+            if tenant == str(LOCAL_TENANT)
+            else f"{PROJECTION_NAME}:{tenant}"
+        )
+
     # ------------------------------------------------------------ subscription
 
     def subscribe_to(self, publisher: EventPublisher) -> Subscription:
@@ -794,18 +803,21 @@ class ProjectionBuilder:
             return self._refresh_impl()
 
     def _refresh_impl(self) -> int:
-        watermark = self._watermarks.get(PROJECTION_NAME)
+        watermark_name = self._watermark_name
+        watermark = self._watermarks.get(watermark_name)
         rows = self._conn.execute(
             """
-            SELECT event_id, job_url, event_type, occurred_at, payload_json
-            FROM job_events
-            WHERE event_id > ?
-            ORDER BY event_id ASC
+            SELECT events.event_id, events.job_id, events.event_type,
+                   events.occurred_at, events.payload_json
+            FROM job_events AS events
+            WHERE events.tenant_id = ?
+              AND events.event_id > ?
+            ORDER BY events.event_id ASC
             """,
-            (watermark,),
+            (str(self._tenant_id), watermark),
         ).fetchall()
 
-        dirty_jobs: set[str] = set()
+        dirty_job_ids: set[str] = set()
         source_quality_dirty = False
         workflow_runs_dirty = False
         pipeline_steps_dirty = False
@@ -818,9 +830,9 @@ class ProjectionBuilder:
             event_id = int(row["event_id"]) if not isinstance(row, tuple) else int(row[0])
             if event_id > max_event_id:
                 max_event_id = event_id
-            job_url = row["job_url"] if not isinstance(row, tuple) else row[1]
-            if job_url:
-                dirty_jobs.add(str(job_url))
+            job_id = row["job_id"] if not isinstance(row, tuple) else row[1]
+            if job_id:
+                dirty_job_ids.add(str(job_id))
             event_type = row["event_type"] if not isinstance(row, tuple) else row[2]
             if str(event_type) in SOURCE_QUALITY_EVENT_TYPES:
                 source_quality_dirty = True
@@ -851,18 +863,19 @@ class ProjectionBuilder:
         if self._store.count_job_list(str(self._tenant_id)) == 0:
             try:
                 jobs_rows = self._conn.execute(
-                    "SELECT url FROM jobs"
+                    "SELECT job_id FROM jobs WHERE tenant_id = ?",
+                    (str(self._tenant_id),),
                 ).fetchall()
                 for jrow in jobs_rows:
-                    url = jrow["url"] if not isinstance(jrow, tuple) else jrow[0]
-                    if url:
-                        dirty_jobs.add(str(url))
+                    job_id = jrow["job_id"] if not isinstance(jrow, tuple) else jrow[0]
+                    if job_id:
+                        dirty_job_ids.add(str(job_id))
             except sqlite3.OperationalError:
                 # ``jobs`` table not yet created (very-fresh DB) — nothing
                 # to backfill.
                 pass
-        dirty_jobs.update(self._stale_deleted_projection_jobs())
-        dirty_jobs.update(self._stale_stage_projection_jobs())
+        dirty_job_ids.update(self._stale_deleted_projection_jobs())
+        dirty_job_ids.update(self._stale_stage_projection_jobs())
 
         # One-time score-audit backfill (see SCORE_AUDIT_BACKFILL): rebuild any
         # already-projected scored job whose audit columns are still NULL. This
@@ -870,7 +883,7 @@ class ProjectionBuilder:
         # added long ago by the TS builder, so the migration reset never runs.
         audit_backfill_pending = not self._score_audit_backfill_done()
         if audit_backfill_pending:
-            dirty_jobs.update(self._jobs_missing_score_audit_projection())
+            dirty_job_ids.update(self._jobs_missing_score_audit_projection())
         workflow_runs_backfill_pending = self._workflow_runs_backfill_pending()
         if not pipeline_steps_dirty and self._pipeline_steps_backfill_pending():
             pipeline_steps_dirty = True
@@ -905,7 +918,7 @@ class ProjectionBuilder:
         )
         source_quality_history = source_quality_dirty or self._has_source_quality_history()
         if (
-            not dirty_jobs
+            not dirty_job_ids
             and not source_quality_dirty
             and dashboard_exists
             and (source_quality_exists or not source_quality_history)
@@ -929,8 +942,8 @@ class ProjectionBuilder:
         # CLI / tests) commit themselves.
         defer_commit = bool(getattr(self._conn, "in_transaction", False))
 
-        if not dirty_jobs:
-            # Watermark advanced past events with no job_url (e.g.
+        if not dirty_job_ids:
+            # Watermark advanced past events with no job (e.g.
             # system events, workflow lifecycle events) OR first-run: bump
             # the watermark + ensure the dashboard row exists.
             if source_quality_dirty or (not source_quality_exists and source_quality_history):
@@ -950,7 +963,7 @@ class ProjectionBuilder:
                 self._rebuild_evidence_usage()
             if max_event_id > watermark:
                 self._watermarks.set(
-                    PROJECTION_NAME, max_event_id, commit=not defer_commit
+                    watermark_name, max_event_id, commit=not defer_commit
                 )
             if not dashboard_exists:
                 self._rebuild_dashboard()
@@ -977,19 +990,19 @@ class ProjectionBuilder:
         if outreach_dirty:
             self._rebuild_outreach()
             self._rebuild_due_follow_ups()
-        for job_url in dirty_jobs:
-            self._rebuild_job(job_url)
+        for job_id in dirty_job_ids:
+            self._rebuild_job(job_id)
         self._rebuild_dashboard()
         self._rebuild_evidence_usage()
         if max_event_id > watermark:
             self._watermarks.set(
-                PROJECTION_NAME, max_event_id, commit=not defer_commit
+                watermark_name, max_event_id, commit=not defer_commit
             )
         if audit_backfill_pending:
             self._mark_score_audit_backfill_done()
         if not defer_commit:
             self._conn.commit()
-        return len(dirty_jobs)
+        return len(dirty_job_ids)
 
     # -------------------------------------------------------------- builders
 
@@ -1017,7 +1030,7 @@ class ProjectionBuilder:
         try:
             contact_rows = self._conn.execute(
                 """
-                SELECT contact_id, employer, job_url, role, created_at, updated_at
+                SELECT contact_id, employer, job_id, role, created_at, updated_at
                 FROM contacts
                 WHERE tenant_id = ? AND deleted_at IS NULL
                 """,
@@ -1108,7 +1121,7 @@ class ProjectionBuilder:
         try:
             task_rows = self._conn.execute(
                 """
-                SELECT task_id, employer, job_url, status, source_attempts_json,
+                SELECT task_id, employer, job_id, status, source_attempts_json,
                        started_at, updated_at, needs_review_at, completed_at,
                        failed_at, error_class
                 FROM contact_research_tasks
@@ -1212,7 +1225,7 @@ class ProjectionBuilder:
         try:
             thread_rows = self._conn.execute(
                 """
-                SELECT thread_id, contact_id, job_url, created_at, updated_at
+                SELECT thread_id, contact_id, job_id, created_at, updated_at
                 FROM outreach_threads
                 WHERE tenant_id = ?
                 """,
@@ -1297,7 +1310,7 @@ class ProjectionBuilder:
         try:
             rows = self._conn.execute(
                 """
-                SELECT thread_id, contact_id, job_url, follow_up_due_at,
+                SELECT thread_id, contact_id, job_id, follow_up_due_at,
                        follow_up_basis, follow_up_state, created_at, updated_at
                 FROM outreach_threads
                 WHERE tenant_id = ? AND follow_up_state = 'scheduled'
@@ -1332,30 +1345,34 @@ class ProjectionBuilder:
             if thread_id not in live_ids:
                 self._store.delete_due_follow_up(tenant, thread_id)
 
-    def _rebuild_job(self, job_url: str) -> None:
+    def _rebuild_job(self, job_id: str) -> None:
         job_row = self._conn.execute(
-            "SELECT * FROM jobs WHERE url = ?", (job_url,)
+            """
+            SELECT *
+            FROM jobs
+            WHERE tenant_id = ? AND job_id = ?
+            """,
+            (str(self._tenant_id), job_id),
         ).fetchone()
         if job_row is None:
             # Orphaned event (e.g. job deleted from upstream) — drop projection.
-            self._store.delete_job_list(str(self._tenant_id), job_url)
+            self._store.delete_job_list(str(self._tenant_id), job_id)
             return
 
-        stages = self._load_stage_projections(job_url)
-        score = self._load_latest_score(job_url)
-        materials = self._load_latest_materials(job_url)
-        material_analytics = self._load_material_analytics(job_url)
-        employer_analysis_json = self._load_employer_analysis(job_url)
-        requirement_fit_report_json = self._load_requirement_fit_report(job_url)
+        stages = self._load_stage_projections(job_id)
+        score = self._load_latest_score(job_id)
+        materials = self._load_latest_materials(job_id)
+        material_analytics = self._load_material_analytics(job_id)
+        employer_analysis_json = self._load_employer_analysis(job_id)
+        requirement_fit_report_json = self._load_requirement_fit_report(job_id)
         requirement_fit_band = _fit_band_from_report_json(requirement_fit_report_json)
-        interview_prep_json = self._load_interview_prep(job_url)
-        provenance_by_artifact = self._load_bullet_provenance_by_artifact(job_url)
-        layout_boxes_by_artifact = self._load_layout_boxes_by_artifact(job_url)
-        enrichment = self._load_enrichment(job_url)
-        apply_run = self._load_latest_apply_run(job_url)
-        deleted_at = self._load_deleted_at(job_url)
-        artifacts = self._load_artifacts(job_url)
-        artifacts = _with_synthetic_pdf_artifacts(job_url, artifacts, materials)
+        interview_prep_json = self._load_interview_prep(job_id)
+        provenance_by_artifact = self._load_bullet_provenance_by_artifact(job_id)
+        layout_boxes_by_artifact = self._load_layout_boxes_by_artifact(job_id)
+        enrichment = self._load_enrichment(job_id)
+        apply_run = self._load_latest_apply_run(job_id)
+        deleted_at = self._load_deleted_at(job_id)
+        artifacts = self._load_artifacts(job_id)
 
         title = _row_str(job_row, "title")
         site = _row_str(job_row, "site")
@@ -1363,7 +1380,7 @@ class ProjectionBuilder:
             enrichment.get("application_url")
             or _row_nullable_str(job_row, "application_url")
         )
-        employer = _row_str(job_row, "company") or _company_name(site, application_url or job_url)
+        employer = _canonical_employer(job_row)
 
         # currentStage/State: the list view exposes only product stages.
         # The full internal preparation state remains available in
@@ -1386,11 +1403,9 @@ class ProjectionBuilder:
             current_error_message = first_actionable.error_message
             current_next_action = first_actionable.next_action
 
-        # Score: prefer per-aggregate row, fall back to legacy column.
+        # Score is owned by the canonical per-job score history.
         fit_score = score.get("fit_score")
-        if fit_score is None:
-            fit_score = _row_nullable_int(job_row, "fit_score")
-        score_reasoning = score.get("reasoning") or _row_str(job_row, "score_reasoning")
+        score_reasoning = score.get("reasoning") or ""
         score_breakdown_json = score.get("breakdown_json")
         score_keywords_json = score.get("keywords_json") or "[]"
         score_version = score.get("version")
@@ -1400,12 +1415,8 @@ class ProjectionBuilder:
         score_correction_json = score.get("correction_json")
 
         # Materials presence:
-        tailor_path = materials.get("tailor_path") or _row_nullable_str(
-            job_row, "tailored_resume_path"
-        )
-        cover_path = materials.get("cover_path") or _row_nullable_str(
-            job_row, "cover_letter_path"
-        )
+        tailor_path = materials.get("tailor_path")
+        cover_path = materials.get("cover_path")
         resume_pdf_path = materials.get("resume_pdf_path")
         cover_pdf_path = materials.get("cover_pdf_path")
 
@@ -1420,28 +1431,25 @@ class ProjectionBuilder:
         ar_finished = apply_run.get("finished_at") if apply_run else None
         apply_status = _derive_apply_status(
             ar_status,
-            _row_nullable_str(job_row, "apply_status"),
+            None,
         )
         applied_at: str | None
         if ar_status == "succeeded":
             applied_at = ar_finished
         else:
-            applied_at = _row_nullable_str(job_row, "applied_at")
+            applied_at = None
         apply_mode = self._derive_apply_mode(
-            job_url,
+            job_id,
             apply_run,
-            _row_nullable_str(job_row, "apply_status"),
-            _row_nullable_str(job_row, "applied_at"),
+            None,
+            None,
         )
 
         # description fallbacks
         description = _row_str(job_row, "description")
-        full_description = enrichment.get("full_description") or _row_str(
-            job_row, "full_description"
-        )
+        full_description = enrichment.get("full_description") or description
         compensation_summary, compensation_audit = self._build_compensation_projection(
-            job_id=job_url,
-            job_locator=job_url,
+            job_id=job_id,
             legacy_raw_salary=_row_nullable_str(job_row, "salary"),
         )
 
@@ -1449,7 +1457,7 @@ class ProjectionBuilder:
 
         list_proj = JobListProjection(
             tenant_id=self._tenant_id,
-            job_id=job_url,
+            job_id=job_id,
             title=title or "Untitled",
             employer=employer,
             source=site or "unknown",
@@ -1497,7 +1505,7 @@ class ProjectionBuilder:
         # JobDetail
         detail_proj = JobDetailProjection(
             tenant_id=self._tenant_id,
-            job_id=job_url,
+            job_id=job_id,
             description_preview=_preview_text(
                 full_description or description, 6000
             ),
@@ -1524,7 +1532,7 @@ class ProjectionBuilder:
             ArtifactListProjection(
                 artifact_id=a["artifact_id"],
                 tenant_id=self._tenant_id,
-                job_id=job_url,
+                job_id=job_id,
                 job_title=title or "Untitled",
                 job_employer=employer,
                 artifact_type=a.get("artifact_type", ""),
@@ -1542,7 +1550,7 @@ class ProjectionBuilder:
             for a in artifacts
         ]
         self._store.replace_artifacts_for_job(
-            str(self._tenant_id), job_url, artifact_projs
+            str(self._tenant_id), job_id, artifact_projs
         )
 
     def _rebuild_evidence_usage(self) -> None:
@@ -1758,11 +1766,15 @@ class ProjectionBuilder:
     def _attach_resume_usages(self, entries: dict[str, dict[str, Any]]) -> None:
         if not _table_exists(self._conn, "job_bullet_provenance"):
             return
-        job_metadata = _job_metadata_join_sql(self._conn, "provenance.job_url")
-        lifecycle = _job_lifecycle_exclusion_sql(self._conn, "provenance.job_url")
+        job_metadata = _job_metadata_join_sql(
+            self._conn, "provenance.tenant_id", "provenance.job_id"
+        )
+        lifecycle = _job_lifecycle_exclusion_sql(
+            self._conn, "provenance.tenant_id", "provenance.job_id"
+        )
         rows = self._conn.execute(
             f"""
-            SELECT provenance.job_url, provenance.artifact_id, provenance.generation,
+            SELECT provenance.job_id, provenance.artifact_id, provenance.generation,
                    provenance.bullet_id, provenance.generated_text, provenance.created_at,
                    provenance.evidence_ids_json,
                    {job_metadata['select_sql']}
@@ -1771,18 +1783,18 @@ class ProjectionBuilder:
              WHERE provenance.tenant_id = ?{lifecycle['where_sql']}
                AND provenance.generation = (
                  SELECT MAX(latest.generation)
-                   FROM job_bullet_provenance AS latest
+                  FROM job_bullet_provenance AS latest
                   WHERE latest.tenant_id = provenance.tenant_id
-                    AND latest.job_url = provenance.job_url
+                    AND latest.job_id = provenance.job_id
                )
-             ORDER BY provenance.job_url, provenance.position, provenance.bullet_id
+             ORDER BY provenance.job_id, provenance.position, provenance.bullet_id
             """,
             (str(self._tenant_id),),
         ).fetchall()
         for row in rows:
             usage = {
                 "kind": "resume_bullet",
-                "jobKey": _row_str(row, "job_url"),
+                "jobId": _row_str(row, "job_id"),
                 "jobTitle": _row_nullable_str(row, "job_title"),
                 "employer": _row_nullable_str(row, "employer"),
                 "artifactId": _row_nullable_str(row, "artifact_id"),
@@ -1819,11 +1831,15 @@ class ProjectionBuilder:
             self._conn, "job_requirement_fit_items"
         ):
             return
-        job_metadata = _job_metadata_join_sql(self._conn, "items.job_url")
-        lifecycle = _job_lifecycle_exclusion_sql(self._conn, "items.job_url")
+        job_metadata = _job_metadata_join_sql(
+            self._conn, "items.tenant_id", "items.job_id"
+        )
+        lifecycle = _job_lifecycle_exclusion_sql(
+            self._conn, "items.tenant_id", "items.job_id"
+        )
         rows = self._conn.execute(
             f"""
-            SELECT items.job_url, items.score_version, items.requirement_id,
+            SELECT items.job_id, items.score_version, items.requirement_id,
                    items.requirement_text, items.tier, items.weight,
                    items.fit_json, items.artifact_coverage_json,
                    {job_metadata['select_sql']}
@@ -1832,11 +1848,11 @@ class ProjectionBuilder:
              WHERE items.tenant_id = ?{lifecycle['where_sql']}
                AND items.score_version = (
                  SELECT MAX(report.score_version)
-                   FROM job_requirement_fit_reports AS report
+                  FROM job_requirement_fit_reports AS report
                   WHERE report.tenant_id = items.tenant_id
-                    AND report.job_url = items.job_url
+                    AND report.job_id = items.job_id
                )
-             ORDER BY items.job_url, items.position, items.requirement_id
+             ORDER BY items.job_id, items.position, items.requirement_id
             """,
             (str(self._tenant_id),),
         ).fetchall()
@@ -1852,7 +1868,7 @@ class ProjectionBuilder:
             )
             usage = {
                 "kind": "requirement_fit",
-                "jobKey": _row_str(row, "job_url"),
+                "jobId": _row_str(row, "job_id"),
                 "jobTitle": _row_nullable_str(row, "job_title"),
                 "employer": _row_nullable_str(row, "employer"),
                 "artifactId": None,
@@ -1879,7 +1895,7 @@ class ProjectionBuilder:
                     "transferable": "transferable_requirement",
                 }[fit_kind]
                 gap = {
-                    "gapId": f"{_row_str(row, 'job_url')}#{_row_str(row, 'requirement_id')}",
+                    "gapId": f"{_row_str(row, 'job_id')}#{_row_str(row, 'requirement_id')}",
                     "kind": kind,
                     "requirementId": _row_str(row, "requirement_id"),
                     "requirementText": _row_str(row, "requirement_text"),
@@ -1904,7 +1920,9 @@ class ProjectionBuilder:
     ) -> None:
         if not _table_exists(self._conn, "artifact_list_projections"):
             return
-        lifecycle = _job_lifecycle_exclusion_sql(self._conn, "alp.job_id")
+        lifecycle = _job_lifecycle_exclusion_sql(
+            self._conn, "alp.tenant_id", "alp.job_id"
+        )
         rows = self._conn.execute(
             f"""
             SELECT alp.job_id, alp.job_title, alp.job_employer, alp.artifact_id, alp.generation,
@@ -1948,15 +1966,13 @@ class ProjectionBuilder:
         self,
         *,
         job_id: str,
-        job_locator: str,
         legacy_raw_salary: str | None,
     ) -> tuple[str, str]:
         posted = self._load_posted_compensation(
-            job_locator,
-            legacy_raw_salary,
             job_id,
+            legacy_raw_salary,
         )
-        market = self._load_market_compensation(job_locator, job_id)
+        market = self._load_market_compensation(job_id)
         posted_warning_count = (
             len(posted["fact"]["warnings"])
             if posted["recordStatus"] == "recorded" and isinstance(posted.get("fact"), dict)
@@ -2053,23 +2069,22 @@ class ProjectionBuilder:
 
     def _load_posted_compensation(
         self,
-        job_locator: str,
-        legacy_raw_salary: str | None,
         job_id: str,
+        legacy_raw_salary: str | None,
     ) -> dict[str, Any]:
         try:
             row = self._conn.execute(
                 """
-                SELECT tenant_id, job_url, source_field, source_text,
+                SELECT tenant_id, job_id, source_field, source_text,
                        legacy_raw_salary, parse_state, currency, period,
                        component, minimum_amount, maximum_amount,
                        annualized_minimum_amount, annualized_maximum_amount,
                        annualization_assumption, confidence, warnings_json,
                        parser_version, source_hash, parsed_at
                 FROM job_posted_compensation_facts
-                WHERE tenant_id = ? AND job_url = ?
+                WHERE tenant_id = ? AND job_id = ?
                 """,
-                (str(self._tenant_id), job_locator),
+                (str(self._tenant_id), job_id),
             ).fetchone()
         except sqlite3.OperationalError:
             row = None
@@ -2083,11 +2098,11 @@ class ProjectionBuilder:
         fact = _posted_fact_from_row(row, job_id)
         return {"ok": True, "recordStatus": "recorded", "fact": fact}
 
-    def _load_market_compensation(self, job_locator: str, job_id: str) -> dict[str, Any]:
+    def _load_market_compensation(self, job_id: str) -> dict[str, Any]:
         try:
             row = self._conn.execute(
                 """
-                SELECT tenant_id, job_url, estimate_state, currency, period,
+                SELECT tenant_id, job_id, estimate_state, currency, period,
                        component, minimum_amount, maximum_amount,
                        confidence_interval_minimum_amount,
                        confidence_interval_maximum_amount,
@@ -2102,9 +2117,9 @@ class ProjectionBuilder:
                        normalized_company, role_title, normalized_role,
                        company_tier, match_scope
                 FROM job_market_compensation_estimates
-                WHERE tenant_id = ? AND job_url = ?
+                WHERE tenant_id = ? AND job_id = ?
                 """,
-                (str(self._tenant_id), job_locator),
+                (str(self._tenant_id), job_id),
             ).fetchone()
         except sqlite3.OperationalError:
             row = None
@@ -2120,11 +2135,14 @@ class ProjectionBuilder:
 
     # ------------------------------------------------------------- joiners
 
-    def _load_stage_projections(self, job_url: str) -> list[StageProjection]:
+    def _load_stage_projections(self, job_id: str) -> list[StageProjection]:
         try:
             rows = self._conn.execute(
-                "SELECT * FROM job_stage_states WHERE job_url = ?",
-                (job_url,),
+                """
+                SELECT * FROM job_stage_states
+                WHERE tenant_id = ? AND job_id = ?
+                """,
+                (str(self._tenant_id), job_id),
             ).fetchall()
         except sqlite3.OperationalError:
             rows = []
@@ -2167,7 +2185,7 @@ class ProjectionBuilder:
             )
         return result
 
-    def _load_latest_score(self, job_url: str) -> dict:
+    def _load_latest_score(self, job_id: str) -> dict:
         try:
             row = self._conn.execute(
                 """
@@ -2175,11 +2193,11 @@ class ProjectionBuilder:
                        s.keywords_json, s.criteria_json, s.trace_json,
                        s.correction_json
                 FROM job_scores s
-                WHERE s.job_url = ?
+                WHERE s.tenant_id = ? AND s.job_id = ?
                 ORDER BY s.version DESC
                 LIMIT 1
                 """,
-                (job_url,),
+                (str(self._tenant_id), job_id),
             ).fetchone()
         except sqlite3.OperationalError:
             return {}
@@ -2187,9 +2205,7 @@ class ProjectionBuilder:
             return {}
         breakdown = _json_loads(_row_nullable_str(row, "breakdown_json"), {})
         reasoning = ""
-        legacy = False
         if isinstance(breakdown, dict):
-            legacy = breakdown.get("legacy") is True
             if isinstance(breakdown.get("reasoning"), str):
                 reasoning = breakdown["reasoning"]
         keywords = _normalize_keywords(_json_loads(_row_nullable_str(row, "keywords_json"), []))
@@ -2197,22 +2213,23 @@ class ProjectionBuilder:
             "version": _row_nullable_int(row, "version"),
             "fit_score": _row_nullable_int(row, "fit_score"),
             "scored_at": _row_nullable_str(row, "scored_at"),
-            "breakdown_json": None if legacy else json.dumps(_camel_score_breakdown(breakdown)),
-            "keywords_json": json.dumps([] if legacy and keywords == ["legacy"] else keywords),
+            "breakdown_json": json.dumps(_camel_score_breakdown(breakdown)),
+            "keywords_json": json.dumps(keywords),
             "reasoning": reasoning,
             "criteria_json": _row_nullable_str(row, "criteria_json"),
             "trace_json": _row_nullable_str(row, "trace_json"),
             "correction_json": _row_nullable_str(row, "correction_json"),
         }
 
-    def _load_latest_materials(self, job_url: str) -> dict:
+    def _load_latest_materials(self, job_id: str) -> dict:
         try:
             generation_row = self._conn.execute(
                 """
                 SELECT MAX(generation)
                 FROM job_materials_artifacts
-                WHERE job_url = ?
+                WHERE tenant_id = ? AND job_id = ?
                   AND status = 'approved'
+                  AND superseded_at IS NULL
                   AND artifact_type IN (
                     'tailored_resume',
                     'cover_letter',
@@ -2220,33 +2237,10 @@ class ProjectionBuilder:
                     'cover_letter_pdf'
                   )
                 """,
-                (job_url,),
+                (str(self._tenant_id), job_id),
             ).fetchone()
         except sqlite3.OperationalError:
-            try:
-                row = self._conn.execute(
-                    """
-                    SELECT artifact_id, generation, metadata_json,
-                           NULL AS material_metadata_json
-                    FROM job_materials_artifacts
-                    WHERE job_url = ?
-                      AND status = 'approved'
-                      AND artifact_type IN ('tailored_resume', 'tailored_resume_txt', 'resume_pdf')
-                    ORDER BY COALESCE(generation, -1) DESC,
-                             CASE artifact_type
-                               WHEN 'tailored_resume' THEN 0
-                               WHEN 'tailored_resume_txt' THEN 1
-                               WHEN 'resume_pdf' THEN 2
-                               ELSE 3
-                             END,
-                             created_at DESC,
-                             rowid DESC
-                    LIMIT 1
-                    """,
-                    (job_url,),
-                ).fetchone()
-            except sqlite3.OperationalError:
-                return {}
+            return {}
         if generation_row is None:
             return {}
         max_generation = generation_row[0]
@@ -2257,9 +2251,10 @@ class ProjectionBuilder:
                 """
                 SELECT artifact_type, path, status, created_at
                 FROM job_materials_artifacts
-                WHERE job_url = ? AND generation = ? AND status = 'approved'
+                WHERE tenant_id = ? AND job_id = ? AND generation = ?
+                  AND status = 'approved' AND superseded_at IS NULL
                 """,
-                (job_url, int(max_generation)),
+                (str(self._tenant_id), job_id, int(max_generation)),
             ).fetchall()
         except sqlite3.OperationalError:
             return {}
@@ -2281,7 +2276,7 @@ class ProjectionBuilder:
                 result["cover_pdf_path"] = path
         return result
 
-    def _load_material_analytics(self, job_url: str) -> dict[str, object]:
+    def _load_material_analytics(self, job_id: str) -> dict[str, object]:
         try:
             row = self._conn.execute(
                 """
@@ -2289,10 +2284,12 @@ class ProjectionBuilder:
                        m.metadata_json AS material_metadata_json
                 FROM job_materials_artifacts a
                 LEFT JOIN job_materials m
-                  ON m.job_url = a.job_url
+                  ON m.tenant_id = a.tenant_id
+                 AND m.job_id = a.job_id
                  AND m.generation = a.generation
-                WHERE a.job_url = ?
+                WHERE a.tenant_id = ? AND a.job_id = ?
                   AND a.status = 'approved'
+                  AND a.superseded_at IS NULL
                   AND a.artifact_type IN ('tailored_resume', 'tailored_resume_txt', 'resume_pdf')
                 ORDER BY COALESCE(a.generation, -1) DESC,
                          CASE a.artifact_type
@@ -2305,33 +2302,10 @@ class ProjectionBuilder:
                          a.rowid DESC
                 LIMIT 1
                 """,
-                (job_url,),
+                (str(self._tenant_id), job_id),
             ).fetchone()
         except sqlite3.OperationalError:
-            try:
-                row = self._conn.execute(
-                    """
-                    SELECT artifact_id, generation, metadata_json,
-                           NULL AS material_metadata_json
-                    FROM job_materials_artifacts
-                    WHERE job_url = ?
-                      AND status = 'approved'
-                      AND artifact_type IN ('tailored_resume', 'tailored_resume_txt', 'resume_pdf')
-                    ORDER BY COALESCE(generation, -1) DESC,
-                             CASE artifact_type
-                               WHEN 'tailored_resume' THEN 0
-                               WHEN 'tailored_resume_txt' THEN 1
-                               WHEN 'resume_pdf' THEN 2
-                               ELSE 3
-                             END,
-                             created_at DESC,
-                             rowid DESC
-                    LIMIT 1
-                    """,
-                    (job_url,),
-                ).fetchone()
-            except sqlite3.OperationalError:
-                return {}
+            return {}
         metadata_jsons = [
             _row_nullable_str(row, "metadata_json"),
             _row_nullable_str(row, "material_metadata_json"),
@@ -2340,12 +2314,12 @@ class ProjectionBuilder:
         if _material_analytics_complete(current):
             return current
         return _merge_material_analytics(
-            metadata_jsons + self._load_base_material_metadata(job_url, metadata_jsons)
+            metadata_jsons + self._load_base_material_metadata(job_id, metadata_jsons)
         )
 
     def _load_base_material_metadata(
         self,
-        job_url: str,
+        job_id: str,
         metadata_jsons: list[str | None],
     ) -> list[str | None]:
         base_generation, base_artifact_ids = _material_metadata_references(metadata_jsons)
@@ -2356,10 +2330,10 @@ class ProjectionBuilder:
                     """
                     SELECT metadata_json
                     FROM job_materials
-                    WHERE job_url = ? AND generation = ?
+                    WHERE tenant_id = ? AND job_id = ? AND generation = ?
                     LIMIT 1
                     """,
-                    (job_url, base_generation),
+                    (str(self._tenant_id), job_id, base_generation),
                 ).fetchone()
             except sqlite3.OperationalError:
                 row = None
@@ -2369,7 +2343,7 @@ class ProjectionBuilder:
                     """
                     SELECT metadata_json
                     FROM job_materials_artifacts
-                    WHERE job_url = ?
+                    WHERE tenant_id = ? AND job_id = ?
                       AND generation = ?
                       AND artifact_type IN ('tailored_resume', 'tailored_resume_txt', 'resume_pdf')
                     ORDER BY CASE artifact_type
@@ -2380,7 +2354,7 @@ class ProjectionBuilder:
                              END,
                              rowid DESC
                     """,
-                    (job_url, base_generation),
+                    (str(self._tenant_id), job_id, base_generation),
                 ).fetchall()
             except sqlite3.OperationalError:
                 rows = []
@@ -2392,7 +2366,7 @@ class ProjectionBuilder:
                     f"""
                     SELECT metadata_json
                     FROM job_materials_artifacts
-                    WHERE job_url = ?
+                    WHERE tenant_id = ? AND job_id = ?
                       AND artifact_id IN ({placeholders})
                     ORDER BY COALESCE(generation, -1) DESC,
                              CASE artifact_type
@@ -2403,14 +2377,14 @@ class ProjectionBuilder:
                              END,
                              rowid DESC
                     """,
-                    (job_url, *base_artifact_ids),
+                    (str(self._tenant_id), job_id, *base_artifact_ids),
                 ).fetchall()
             except sqlite3.OperationalError:
                 rows = []
             metadata.extend(_row_nullable_str(row, "metadata_json") for row in rows)
         return metadata
 
-    def _load_employer_analysis(self, job_url: str) -> str | None:
+    def _load_employer_analysis(self, job_id: str) -> str | None:
         """Project the latest canonical employer analysis read shape (Phase 1).
 
         The single owner of the analysis read shape: it loads the latest
@@ -2424,7 +2398,7 @@ class ProjectionBuilder:
 
         try:
             record = SqliteEmployerAnalysisRepository(self._conn).load(
-                self._tenant_id, JobId(job_url)
+                self._tenant_id, JobId(job_id)
             )
         except sqlite3.OperationalError:
             return None
@@ -2432,7 +2406,7 @@ class ProjectionBuilder:
             return None
         return json.dumps(record.to_read_model(), ensure_ascii=False)
 
-    def _load_requirement_fit_report(self, job_url: str) -> str | None:
+    def _load_requirement_fit_report(self, job_id: str) -> str | None:
         """Project the latest canonical requirement-fit report read shape.
 
         The score aggregate owns the source rows. The detail projection exposes
@@ -2444,7 +2418,7 @@ class ProjectionBuilder:
 
         try:
             record = SqliteRequirementFitReportRepository(self._conn).load(
-                self._tenant_id, JobId(job_url)
+                self._tenant_id, JobId(job_id)
             )
         except sqlite3.OperationalError:
             return None
@@ -2452,10 +2426,10 @@ class ProjectionBuilder:
             return None
         read_model = record.to_read_model()
         read_model.pop("jobKey", None)
-        read_model["jobId"] = job_url
+        read_model["jobId"] = job_id
         return json.dumps(read_model, ensure_ascii=False)
 
-    def _load_interview_prep(self, job_url: str) -> str | None:
+    def _load_interview_prep(self, job_id: str) -> str | None:
         """Project the latest accepted interview-prep read shape.
 
         Failed generations stay in canonical history but never replace the
@@ -2465,7 +2439,7 @@ class ProjectionBuilder:
 
         try:
             record = SqliteInterviewPrepRepository(self._conn).load_latest(
-                self._tenant_id, JobId(job_url), status="accepted"
+                self._tenant_id, JobId(job_id), status="accepted"
             )
         except sqlite3.OperationalError:
             return None
@@ -2473,10 +2447,10 @@ class ProjectionBuilder:
             return None
         read_model = record.to_read_model()
         read_model.pop("jobKey", None)
-        read_model["jobId"] = job_url
+        read_model["jobId"] = job_id
         return json.dumps(read_model, ensure_ascii=False)
 
-    def _load_bullet_provenance_by_artifact(self, job_url: str) -> "_ProvenanceProjection":
+    def _load_bullet_provenance_by_artifact(self, job_id: str) -> "_ProvenanceProjection":
         """Project provenance + coverage + voice read shapes, keyed by artifact.
 
         The single owner of the provenance/coverage/voice read shapes (Phase 2 +
@@ -2499,10 +2473,10 @@ class ProjectionBuilder:
                 """
                 SELECT DISTINCT generation
                 FROM job_bullet_provenance
-                WHERE job_url = ? AND tenant_id = ?
+                WHERE tenant_id = ? AND job_id = ?
                 ORDER BY generation
                 """,
-                (job_url, str(self._tenant_id)),
+                (str(self._tenant_id), job_id),
             ).fetchall()
         except sqlite3.OperationalError:
             return empty
@@ -2515,7 +2489,7 @@ class ProjectionBuilder:
         for row in generation_rows:
             record = repository.load(
                 self._tenant_id,
-                JobId(job_url),
+                JobId(job_id),
                 generation=int(row["generation"]),
             )
             if record is None or record.is_empty:
@@ -2542,16 +2516,16 @@ class ProjectionBuilder:
             voice=voice_by_artifact,
         )
 
-    def _load_enrichment(self, job_url: str) -> dict:
+    def _load_enrichment(self, job_id: str) -> dict:
         try:
             row = self._conn.execute(
                 """
                 SELECT full_description, application_url, enriched_at,
                        current_status, extraction_tier
                 FROM job_enrichments
-                WHERE job_url = ?
+                WHERE tenant_id = ? AND job_id = ?
                 """,
-                (job_url,),
+                (str(self._tenant_id), job_id),
             ).fetchone()
         except sqlite3.OperationalError:
             return {}
@@ -2565,7 +2539,7 @@ class ProjectionBuilder:
             "extraction_tier": _row_nullable_str(row, "extraction_tier"),
         }
 
-    def _load_latest_apply_run(self, job_url: str) -> dict:
+    def _load_latest_apply_run(self, job_id: str) -> dict:
         # PR 4 of the Temporal stack: ``apply_run_projections`` is the
         # canonical apply lifecycle row (sourced from ``job_events`` by
         # ``_rebuild_apply_runs`` below). ``_rebuild_job`` reads it
@@ -2577,11 +2551,11 @@ class ProjectionBuilder:
                 SELECT run_id, status, result, started_at, finished_at,
                        worker_id, model, dry_run, duration_ms
                 FROM apply_run_projections
-                WHERE job_id = ?
+                WHERE tenant_id = ? AND job_id = ?
                 ORDER BY started_at DESC, run_id DESC
                 LIMIT 1
                 """,
-                (job_url,),
+                (str(self._tenant_id), job_id),
             ).fetchone()
         except sqlite3.OperationalError:
             return {}
@@ -2601,7 +2575,7 @@ class ProjectionBuilder:
 
     def _derive_apply_mode(
         self,
-        job_url: str,
+        job_id: str,
         apply_run: dict,
         legacy_status: str | None,
         legacy_applied_at: str | None,
@@ -2611,45 +2585,51 @@ class ProjectionBuilder:
         is_applied = bool(legacy_applied_at) or legacy_status == "applied"
         if not is_applied:
             return None
-        if self._has_job_event(job_url, "ApplicationManuallyMarked"):
+        if self._has_job_event(job_id, "ApplicationManuallyMarked"):
             return "manual_marked"
-        if self._has_application_outcome_kind(job_url, "applied_confirmation"):
+        if self._has_application_outcome_kind(job_id, "applied_confirmation"):
             return "external_confirmed"
         return "manual_marked"
 
-    def _has_job_event(self, job_url: str, event_type: str) -> bool:
+    def _has_job_event(self, job_id: str, event_type: str) -> bool:
         try:
             row = self._conn.execute(
-                "SELECT COUNT(*) AS c FROM job_events WHERE job_url = ? AND event_type = ?",
-                (job_url, event_type),
+                """
+                SELECT COUNT(*) AS c
+                FROM job_events AS events
+                WHERE events.tenant_id = ?
+                  AND events.job_id = ?
+                  AND events.event_type = ?
+                """,
+                (str(self._tenant_id), job_id, event_type),
             ).fetchone()
         except sqlite3.OperationalError:
             return False
         return int(_row_nullable_int(row, "c") or 0) > 0
 
-    def _has_application_outcome_kind(self, job_url: str, kind: str) -> bool:
+    def _has_application_outcome_kind(self, job_id: str, kind: str) -> bool:
         try:
             row = self._conn.execute(
                 """
                 SELECT COUNT(*) AS c
                 FROM application_outcomes
-                WHERE tenant_id = ? AND job_key = ? AND kind = ?
+                WHERE tenant_id = ? AND job_id = ? AND kind = ?
                 """,
-                (str(self._tenant_id), job_url, kind),
+                (str(self._tenant_id), job_id, kind),
             ).fetchone()
         except sqlite3.OperationalError:
             return False
         return int(_row_nullable_int(row, "c") or 0) > 0
 
-    def _load_deleted_at(self, job_url: str) -> str | None:
+    def _load_deleted_at(self, job_id: str) -> str | None:
         try:
             row = self._conn.execute(
                 """
                 SELECT deleted_at FROM jobctrl_deleted_jobs
-                WHERE job_url = ?
+                WHERE tenant_id = ? AND job_id = ?
                   AND (restored_at IS NULL OR julianday(restored_at) <= julianday(deleted_at))
                 """,
-                (job_url,),
+                (str(self._tenant_id), job_id),
             ).fetchone()
         except sqlite3.OperationalError:
             return None
@@ -2664,7 +2644,8 @@ class ProjectionBuilder:
                 SELECT p.job_id
                 FROM job_list_projections p
                 JOIN jobctrl_deleted_jobs d
-                  ON d.job_url = p.job_id
+                  ON d.tenant_id = p.tenant_id
+                 AND d.job_id = p.job_id
                 WHERE p.tenant_id = ?
                   AND (d.restored_at IS NULL OR julianday(d.restored_at) <= julianday(d.deleted_at))
                   AND (p.deleted_at IS NULL OR p.deleted_at != d.deleted_at)
@@ -2683,15 +2664,13 @@ class ProjectionBuilder:
         try:
             rows = self._conn.execute(
                 """
-                SELECT DISTINCT s.job_url AS job_id
+                SELECT DISTINCT s.job_id
                   FROM job_stage_states s
-                  JOIN jobs j
-                    ON j.url = s.job_url
                   LEFT JOIN job_list_projections p
-                    ON p.tenant_id = ?
-                   AND p.job_id = s.job_url
-                 WHERE s.job_url IS NOT NULL
-                   AND TRIM(s.job_url) != ''
+                    ON p.tenant_id = s.tenant_id
+                   AND p.job_id = s.job_id
+                 WHERE s.tenant_id = ?
+                   AND TRIM(s.job_id) != ''
                    AND (
                      p.job_id IS NULL
                      OR (
@@ -2743,7 +2722,9 @@ class ProjectionBuilder:
                 """
                 SELECT p.job_id
                 FROM job_list_projections p
-                JOIN job_scores s ON s.job_url = p.job_id
+                JOIN job_scores s
+                  ON s.tenant_id = p.tenant_id
+                 AND s.job_id = p.job_id
                 WHERE p.tenant_id = ?
                   AND p.score_criteria_json IS NULL
                 """,
@@ -2761,7 +2742,7 @@ class ProjectionBuilder:
         try:
             rows = self._conn.execute(
                 """
-                SELECT job_url
+                SELECT job_id
                 FROM posting_snapshot_sets
                 WHERE tenant_id = ?
                   AND latest_active_state IN (
@@ -2773,9 +2754,9 @@ class ProjectionBuilder:
         except sqlite3.OperationalError:
             return set()
         return {
-            str(row["job_url"] if not isinstance(row, tuple) else row[0])
+            str(row["job_id"] if not isinstance(row, tuple) else row[0])
             for row in rows
-            if (row["job_url"] if not isinstance(row, tuple) else row[0])
+            if (row["job_id"] if not isinstance(row, tuple) else row[0])
         }
 
     def _hidden_projection_jobs(self) -> set[str]:
@@ -2786,20 +2767,21 @@ class ProjectionBuilder:
         try:
             rows = self._conn.execute(
                 """
-                SELECT job_url
+                SELECT job_id
                 FROM jobctrl_hidden_jobs
-                WHERE unhidden_at IS NULL
-                """
+                WHERE tenant_id = ? AND unhidden_at IS NULL
+                """,
+                (str(self._tenant_id),),
             ).fetchall()
         except sqlite3.OperationalError:
             return set()
         return {
-            str(row["job_url"] if not isinstance(row, tuple) else row[0])
+            str(row["job_id"] if not isinstance(row, tuple) else row[0])
             for row in rows
-            if (row["job_url"] if not isinstance(row, tuple) else row[0])
+            if (row["job_id"] if not isinstance(row, tuple) else row[0])
         }
 
-    def _load_artifacts(self, job_url: str) -> list[dict]:
+    def _load_artifacts(self, job_id: str) -> list[dict]:
         artifacts: list[dict] = []
         seen: set[tuple[str, str]] = set()
         try:
@@ -2808,9 +2790,9 @@ class ProjectionBuilder:
                 SELECT artifact_id, artifact_type, status, path, created_at,
                        size_bytes, generation, metadata_json
                 FROM job_materials_artifacts
-                WHERE job_url = ?
+                WHERE tenant_id = ? AND job_id = ?
                 """,
-                (job_url,),
+                (str(self._tenant_id), job_id),
             ).fetchall():
                 local_path = _row_nullable_str(row, "path") or ""
                 atype = _row_nullable_str(row, "artifact_type") or ""
@@ -2838,12 +2820,12 @@ class ProjectionBuilder:
         try:
             for row in self._conn.execute(
                 """
-                SELECT rowid AS row_id, job_url, stage, artifact_type, status,
+                SELECT rowid AS row_id, job_id, stage, artifact_type, status,
                        path, created_at, size_bytes
                 FROM job_artifacts
-                WHERE job_url = ?
+                WHERE tenant_id = ? AND job_id = ?
                 """,
-                (job_url,),
+                (str(self._tenant_id), job_id),
             ).fetchall():
                 local_path = _row_nullable_str(row, "path") or ""
                 atype = _row_nullable_str(row, "artifact_type") or "artifact"
@@ -2869,17 +2851,17 @@ class ProjectionBuilder:
             pass
         return artifacts
 
-    def _load_layout_boxes_by_artifact(self, job_url: str) -> dict[str, str]:
+    def _load_layout_boxes_by_artifact(self, job_id: str) -> dict[str, str]:
         try:
             rows = self._conn.execute(
                 """
                 SELECT artifact_id, semantic_id, page_number, line_number,
                        text_excerpt, left_pct, top_pct, width_pct, height_pct
                 FROM job_material_layout_boxes
-                WHERE job_url = ? AND tenant_id = ?
+                WHERE tenant_id = ? AND job_id = ?
                 ORDER BY artifact_id, page_number, box_index
                 """,
-                (job_url, str(self._tenant_id)),
+                (str(self._tenant_id), job_id),
             ).fetchall()
         except sqlite3.OperationalError:
             return {}
@@ -2953,20 +2935,23 @@ class ProjectionBuilder:
                     SELECT COUNT(*)
                     FROM apply_run_projections arp
                     LEFT JOIN jobctrl_deleted_jobs d
-                        ON d.job_url = arp.job_id
+                        ON d.tenant_id = arp.tenant_id
+                       AND d.job_id = arp.job_id
                        AND (d.restored_at IS NULL OR julianday(d.restored_at) <= julianday(d.deleted_at))
                     LEFT JOIN posting_snapshot_sets pss
                         ON pss.tenant_id = arp.tenant_id
-                       AND pss.job_url = arp.job_id
-                    WHERE arp.dry_run = 1
-                      AND d.job_url IS NULL
+                       AND pss.job_id = arp.job_id
+                    WHERE arp.tenant_id = ?
+                      AND arp.dry_run = 1
+                      AND d.job_id IS NULL
                       AND (
                         pss.latest_active_state IS NULL
                         OR pss.latest_active_state NOT IN (
                           'closed', 'expired', 'removed', 'location_incompatible'
                         )
                       )
-                    """
+                    """,
+                    (str(self._tenant_id),),
                 ).fetchone()[0]
             )
         except sqlite3.OperationalError:
@@ -3210,21 +3195,21 @@ class ProjectionBuilder:
     def _load_outcomes_by_job(self) -> dict[str, tuple[dict[str, str | None], ...]]:
         try:
             rows = self._conn.execute(
-                "SELECT job_key, kind, occurred_at FROM application_outcomes WHERE tenant_id = ?",
+                "SELECT job_id, kind, occurred_at FROM application_outcomes WHERE tenant_id = ?",
                 (str(self._tenant_id),),
             ).fetchall()
         except sqlite3.OperationalError:
             return {}
         grouped: dict[str, list[dict[str, str | None]]] = {}
         for row in rows:
-            job_key = _row_str(row, "job_key")
+            job_id = _row_str(row, "job_id")
             kind = _row_str(row, "kind")
-            if not job_key or not kind:
+            if not job_id or not kind:
                 continue
-            grouped.setdefault(job_key, []).append(
+            grouped.setdefault(job_id, []).append(
                 {"kind": kind, "occurredAt": _row_nullable_str(row, "occurred_at")}
             )
-        return {job_key: tuple(outcomes) for job_key, outcomes in grouped.items()}
+        return {job_id: tuple(outcomes) for job_id, outcomes in grouped.items()}
 
     def _load_suggestion_accuracy(self) -> dict[str, int]:
         counts = {"decided": 0, "accepted": 0, "corrected": 0, "ignored": 0}
@@ -3251,12 +3236,14 @@ class ProjectionBuilder:
         placeholders = ", ".join("?" for _ in SOURCE_QUALITY_EVENT_TYPES)
         rows = self._conn.execute(
             f"""
-            SELECT event_id, job_url, event_type, occurred_at, payload_json
+            SELECT event_id, job_id, event_type,
+                   occurred_at, payload_json
             FROM job_events
-            WHERE event_type IN ({placeholders})
+            WHERE tenant_id = ?
+              AND event_type IN ({placeholders})
             ORDER BY event_id ASC
             """,
-            tuple(sorted(SOURCE_QUALITY_EVENT_TYPES)),
+            (str(self._tenant_id), *sorted(SOURCE_QUALITY_EVENT_TYPES)),
         ).fetchall()
         result = project_source_quality(
             tenant_id=self._tenant_id,
@@ -3271,9 +3258,10 @@ class ProjectionBuilder:
             f"""
             SELECT COUNT(*)
             FROM job_events
-            WHERE event_type IN ({placeholders})
+            WHERE tenant_id = ?
+              AND event_type IN ({placeholders})
             """,
-            tuple(sorted(SOURCE_QUALITY_EVENT_TYPES)),
+            (str(self._tenant_id), *sorted(SOURCE_QUALITY_EVENT_TYPES)),
         ).fetchone()
         return bool(row and int(row[0]) > 0)
 
@@ -3291,12 +3279,17 @@ class ProjectionBuilder:
                     JSON_EXTRACT(payload_json, '$.itemKey')
                 )
                 FROM job_events
-                WHERE event_type IN ({placeholders})
+                WHERE tenant_id = ?
+                  AND event_type IN ({placeholders})
                   AND payload_json IS NOT NULL
                   AND json_valid(payload_json)
                   AND JSON_EXTRACT(payload_json, '$.execution.tenantId') = ?
                 """,
-                (*sorted(PIPELINE_STEP_EVENT_TYPES), str(self._tenant_id)),
+                (
+                    str(self._tenant_id),
+                    *sorted(PIPELINE_STEP_EVENT_TYPES),
+                    str(self._tenant_id),
+                ),
             ).fetchone()
             projection_row = self._conn.execute(
                 "SELECT COUNT(*) FROM pipeline_step_projections WHERE tenant_id = ?",
@@ -3323,10 +3316,11 @@ class ProjectionBuilder:
             f"""
             SELECT event_id, event_type, occurred_at, payload_json
             FROM job_events
-            WHERE event_type IN ({placeholders})
+            WHERE tenant_id = ?
+              AND event_type IN ({placeholders})
             ORDER BY event_id ASC
             """,
-            tuple(sorted(PIPELINE_STEP_EVENT_TYPES)),
+            (str(self._tenant_id), *sorted(PIPELINE_STEP_EVENT_TYPES)),
         ).fetchall()
 
         folded: dict[tuple[str, str, str, str], _PipelineStepFold] = {}
@@ -3609,11 +3603,12 @@ class ProjectionBuilder:
                     JSON_EXTRACT(payload_json, '$.workflow_id')
                 ))
                 FROM job_events
-                WHERE event_type IN ({placeholders})
+                WHERE tenant_id = ?
+                  AND event_type IN ({placeholders})
                   AND payload_json IS NOT NULL
                   AND json_valid(payload_json)
                 """,
-                WORKFLOW_EVENT_TYPES,
+                (str(self._tenant_id), *WORKFLOW_EVENT_TYPES),
             ).fetchone()
             projection_row = self._conn.execute(
                 "SELECT COUNT(*) FROM workflow_run_projections WHERE tenant_id = ?",
@@ -3651,10 +3646,11 @@ class ProjectionBuilder:
                 f"""
                 SELECT event_type, occurred_at, payload_json
                 FROM job_events
-                WHERE event_type IN ({placeholders})
+                WHERE tenant_id = ?
+                  AND event_type IN ({placeholders})
                 ORDER BY event_id ASC
                 """,
-                WORKFLOW_EVENT_TYPES,
+                (str(self._tenant_id), *WORKFLOW_EVENT_TYPES),
             ).fetchall()
         except sqlite3.OperationalError:
             return {}
@@ -3831,12 +3827,14 @@ class ProjectionBuilder:
         try:
             rows = self._conn.execute(
                 """
-                SELECT job_url, event_type, level, message, occurred_at,
-                       payload_json
-                FROM job_events
-                WHERE stage = 'apply'
-                ORDER BY event_id ASC
-                """
+                SELECT events.job_id, events.event_type, events.level,
+                       events.message, events.occurred_at, events.payload_json
+                FROM job_events AS events
+                WHERE events.tenant_id = ?
+                  AND events.stage = 'apply'
+                ORDER BY events.event_id ASC
+                """,
+                (str(self._tenant_id),),
             ).fetchall()
         except sqlite3.OperationalError:
             return {}
@@ -3851,7 +3849,7 @@ class ProjectionBuilder:
             run_id_str = str(run_id)
             out.setdefault(run_id_str, []).append(
                 {
-                    "job_url": _row_nullable_str(row, "job_url"),
+                    "job_id": _row_nullable_str(row, "job_id"),
                     "event_type": _row_str(row, "event_type"),
                     "level": _row_nullable_str(row, "level") or "info",
                     "message": _row_nullable_str(row, "message"),
@@ -3893,9 +3891,8 @@ class ProjectionBuilder:
     ) -> ApplyRunProjection | None:
         if not events:
             return None
-        job_url = ""
+        job_id = ""
         title = ""
-        site = ""
         status = "starting"
         result: str | None = None
         started_at: str | None = None
@@ -3908,8 +3905,8 @@ class ProjectionBuilder:
         for event in events:
             payload = event["payload"]
             event_type = event["event_type"]
-            if event["job_url"]:
-                job_url = event["job_url"]
+            if event["job_id"]:
+                job_id = event["job_id"]
 
             if event_type == "ApplyRunStarted":
                 started_at = (
@@ -3979,7 +3976,7 @@ class ProjectionBuilder:
                     except (TypeError, ValueError):
                         pass
 
-        if not job_url:
+        if not job_id:
             return None
 
         # Hydrate denormalised job columns from the parent ``jobs`` row
@@ -3987,17 +3984,19 @@ class ProjectionBuilder:
         # "Untitled" / "Unknown company".
         try:
             meta = self._conn.execute(
-                "SELECT title, site, company FROM jobs WHERE url = ? LIMIT 1",
-                (job_url,),
+                """
+                SELECT title, company FROM jobs
+                WHERE tenant_id = ? AND job_id = ?
+                LIMIT 1
+                """,
+                (str(self._tenant_id), job_id),
             ).fetchone()
         except sqlite3.OperationalError:
             meta = None
         if meta is not None:
             title = _row_str(meta, "title") or title
-            site = _row_str(meta, "site") or site
 
-        employer = _row_str(meta, "company") if meta is not None else ""
-        employer = employer or _company_name(site, job_url)
+        employer = _canonical_employer(meta)
 
         events_payload: list[dict] = []
         for event in events:
@@ -4015,7 +4014,7 @@ class ProjectionBuilder:
         return ApplyRunProjection(
             run_id=run_id,
             tenant_id=self._tenant_id,
-            job_id=job_url,
+            job_id=job_id,
             job_title=title or "Untitled",
             job_employer=employer,
             status=status,
@@ -4060,28 +4059,35 @@ def _column_or_literal(
     return f"{alias}.{column_name}" if _has_column(conn, table_name, column_name) else fallback_sql
 
 
-def _job_metadata_join_sql(conn: sqlite3.Connection, job_url_expression: str) -> dict[str, str]:
+def _job_metadata_join_sql(
+    conn: sqlite3.Connection,
+    tenant_id_expression: str,
+    job_id_expression: str,
+) -> dict[str, str]:
     if not _table_exists(conn, "jobs"):
         return {"select_sql": "NULL AS job_title, NULL AS employer", "join_sql": ""}
     title_sql = _column_or_literal(conn, "jobs", "title", "NULL", "jobs")
-    employer_parts = []
     if _has_column(conn, "jobs", "company"):
-        employer_parts.append("NULLIF(jobs.company, '')")
-    if _has_column(conn, "jobs", "site"):
-        employer_parts.append("jobs.site")
-    employer_sql = (
-        f"COALESCE({', '.join(employer_parts)})"
-        if len(employer_parts) > 1
-        else (employer_parts[0] if employer_parts else "NULL")
-    )
+        employer_sql = (
+            "COALESCE(NULLIF(TRIM(jobs.company), ''), "
+            f"'{_UNKNOWN_EMPLOYER}')"
+        )
+    else:
+        employer_sql = f"'{_UNKNOWN_EMPLOYER}'"
     return {
         "select_sql": f"{title_sql} AS job_title, {employer_sql} AS employer",
-        "join_sql": f"LEFT JOIN jobs ON jobs.url = {job_url_expression}",
+        "join_sql": (
+            "LEFT JOIN jobs ON "
+            f"jobs.tenant_id = {tenant_id_expression} "
+            f"AND jobs.job_id = {job_id_expression}"
+        ),
     }
 
 
 def _job_lifecycle_exclusion_sql(
-    conn: sqlite3.Connection, job_url_expression: str
+    conn: sqlite3.Connection,
+    tenant_id_expression: str,
+    job_id_expression: str,
 ) -> dict[str, str]:
     """Anti-join fragments excluding soft-deleted and hidden jobs from a
     tenant-wide read, mirroring the TS ``jobLifecycleExclusionSql``. Guarded by
@@ -4093,16 +4099,18 @@ def _job_lifecycle_exclusion_sql(
     if _table_exists(conn, "jobctrl_deleted_jobs"):
         joins.append(
             "LEFT JOIN jobctrl_deleted_jobs d "
-            f"ON d.job_url = {job_url_expression} "
+            f"ON d.tenant_id = {tenant_id_expression} "
+            f"AND d.job_id = {job_id_expression} "
             "AND (d.restored_at IS NULL OR julianday(d.restored_at) <= julianday(d.deleted_at))"
         )
-        wheres.append("d.job_url IS NULL")
+        wheres.append("d.job_id IS NULL")
     if _table_exists(conn, "jobctrl_hidden_jobs"):
         joins.append(
             "LEFT JOIN jobctrl_hidden_jobs h "
-            f"ON h.job_url = {job_url_expression} AND h.unhidden_at IS NULL"
+            f"ON h.tenant_id = {tenant_id_expression} "
+            f"AND h.job_id = {job_id_expression} AND h.unhidden_at IS NULL"
         )
-        wheres.append("h.job_url IS NULL")
+        wheres.append("h.job_id IS NULL")
     return {
         "join_sql": (" " + " ".join(joins)) if joins else "",
         "where_sql": (" AND " + " AND ".join(wheres)) if wheres else "",
@@ -4119,6 +4127,10 @@ def _row_nullable_str(row: object, key: str) -> str | None:
     if value is None or value == "":
         return None
     return str(value)
+
+
+def _canonical_employer(job_row: object) -> str:
+    return _row_str(job_row, "company").strip() or _UNKNOWN_EMPLOYER
 
 
 def _row_nullable_int(row: object, key: str) -> int | None:
@@ -4707,117 +4719,6 @@ def _confidence_band(value: object) -> str:
     return text if text in MARKET_CONFIDENCE_BANDS else "none"
 
 
-def _with_synthetic_pdf_artifacts(
-    job_url: str,
-    artifacts: list[dict],
-    materials: dict,
-) -> list[dict]:
-    out = list(artifacts)
-    seen = {
-        (str(item.get("artifact_type") or ""), str(item.get("local_path") or ""))
-        for item in out
-    }
-    preferred_generation = materials.get("generation")
-
-    tailor_source = _preferred_artifact_source(
-        out,
-        {"tailored_resume", "tailored_resume_txt"},
-        preferred_generation,
-    )
-    tailor_pdf_path = materials.get("resume_pdf_path")
-    if (
-        not tailor_pdf_path
-        and tailor_source
-        and tailor_source.get("artifact_type") == "tailored_resume_txt"
-    ):
-        tailor_pdf_path = _pdf_sibling(str(tailor_source.get("local_path") or ""))
-    if tailor_pdf_path and ("tailored_resume_pdf", tailor_pdf_path) not in seen:
-        out.append(
-            {
-                "artifact_id": f"{job_url}:tailored_resume_pdf:{tailor_pdf_path}",
-                "artifact_type": "tailored_resume_pdf",
-                "status": "active",
-                "local_path": tailor_pdf_path,
-                "created_at": tailor_source.get("created_at") if tailor_source else None,
-                "size_bytes": None,
-                "generation": tailor_source.get("generation") if tailor_source else None,
-                "metadata_json": tailor_source.get("metadata_json") if tailor_source else None,
-            }
-        )
-
-    cover_source = _preferred_artifact_source(
-        out,
-        {"cover_letter", "cover_letter_txt"},
-        preferred_generation,
-    )
-    cover_pdf_path = materials.get("cover_pdf_path")
-    if (
-        not cover_pdf_path
-        and cover_source
-        and cover_source.get("artifact_type") == "cover_letter_txt"
-    ):
-        cover_pdf_path = _pdf_sibling(str(cover_source.get("local_path") or ""))
-    if cover_pdf_path and ("cover_letter_pdf", cover_pdf_path) not in seen:
-        out.append(
-            {
-                "artifact_id": f"{job_url}:cover_letter_pdf:{cover_pdf_path}",
-                "artifact_type": "cover_letter_pdf",
-                "status": "active",
-                "local_path": cover_pdf_path,
-                "created_at": cover_source.get("created_at") if cover_source else None,
-                "size_bytes": None,
-                "generation": cover_source.get("generation") if cover_source else None,
-                "metadata_json": cover_source.get("metadata_json") if cover_source else None,
-            }
-        )
-    return out
-
-
-def _preferred_artifact_source(
-    artifacts: list[dict],
-    artifact_types: set[str],
-    preferred_generation: object,
-) -> dict | None:
-    candidates = [
-        artifact
-        for artifact in artifacts
-        if str(artifact.get("artifact_type") or "") in artifact_types
-        and _is_default_visible_artifact(str(artifact.get("status") or ""))
-    ]
-    candidates.sort(
-        key=lambda artifact: (
-            artifact.get("generation") == preferred_generation,
-            _artifact_status_rank(str(artifact.get("status") or "")),
-            int(artifact.get("generation") or -1),
-        ),
-        reverse=True,
-    )
-    return candidates[0] if candidates else None
-
-
-def _is_default_visible_artifact(status: str) -> bool:
-    return status.lower() != "suppressed"
-
-
-def _artifact_status_rank(status: str) -> int:
-    match status.lower():
-        case "approved" | "active":
-            return 3
-        case "candidate":
-            return 2
-        case "rejected":
-            return 1
-        case _:
-            return 0
-
-
-def _pdf_sibling(value: str) -> str | None:
-    if not value:
-        return None
-    base = value.rsplit(".", 1)[0] if "." in value else value
-    return f"{base}.pdf"
-
-
 def _row_get(row: object, key: str) -> object:
     if row is None:
         return None
@@ -4889,7 +4790,7 @@ def _requirement_artifact_coverage_to_read_model(value: dict[str, Any]) -> dict[
 def _skill_coverage_usage(row: object, keyword: str, state: str) -> dict[str, Any]:
     return {
         "kind": "skill_coverage",
-        "jobKey": _row_str(row, "job_id"),
+        "jobId": _row_str(row, "job_id"),
         "jobTitle": _row_nullable_str(row, "job_title"),
         "employer": _row_nullable_str(row, "job_employer"),
         "artifactId": _row_nullable_str(row, "artifact_id"),
@@ -4981,43 +4882,14 @@ def _normalize_keywords(value) -> list[str]:
     return keywords
 
 
-def _company_name(site: str, posting_url: str) -> str:
-    inferred = _inferred_company_from_url(posting_url)
-    if inferred:
-        return inferred
-    if not site or site.lower() in _SOURCE_BOARD_NAMES:
-        return "Unknown company"
-    return site
+def _company_name(_site: str, _posting_url: str) -> str:
+    """Return the explicit unknown state for callers lacking canonical company data.
 
+    The arguments remain only for the v7 migration serializer's existing helper
+    call.  Source boards and locator URLs are not employer evidence.
+    """
 
-def _inferred_company_from_url(raw_url: str) -> str:
-    if not raw_url:
-        return ""
-    try:
-        from urllib.parse import urlparse
-
-        parsed = urlparse(raw_url)
-    except ValueError:
-        return ""
-    host = parsed.hostname or ""
-    segments = [seg for seg in parsed.path.split("/") if seg]
-    if not segments:
-        return ""
-    if host.endswith("greenhouse.io"):
-        return _title_from_slug(segments[0])
-    if host == "jobs.lever.co":
-        return _title_from_slug(segments[0])
-    if host == "jobs.ashbyhq.com":
-        return _title_from_slug(segments[0])
-    return ""
-
-
-def _title_from_slug(value: str) -> str:
-    known = {"gitlab": "GitLab"}
-    lowered = value.lower()
-    if lowered in known:
-        return known[lowered]
-    return " ".join(part.capitalize() for part in value.replace("_", "-").split("-") if part)
+    return _UNKNOWN_EMPLOYER
 
 
 def _derive_apply_status(ar_status: str | None, legacy_status: str | None) -> str | None:

--- a/workers/automation/src/jobctrl/infrastructure/projections/projection_builder.py
+++ b/workers/automation/src/jobctrl/infrastructure/projections/projection_builder.py
@@ -875,6 +875,7 @@ class ProjectionBuilder:
                 # to backfill.
                 pass
         dirty_job_ids.update(self._stale_deleted_projection_jobs())
+        dirty_job_ids.update(self._stale_artifact_projection_jobs())
         dirty_job_ids.update(self._stale_stage_projection_jobs())
 
         # One-time score-audit backfill (see SCORE_AUDIT_BACKFILL): rebuild any
@@ -2640,6 +2641,61 @@ class ProjectionBuilder:
                 WHERE p.tenant_id = ?
                   AND (d.restored_at IS NULL OR julianday(d.restored_at) <= julianday(d.deleted_at))
                   AND (p.deleted_at IS NULL OR p.deleted_at != d.deleted_at)
+                """,
+                (str(self._tenant_id),),
+            ).fetchall()
+        except sqlite3.OperationalError:
+            return set()
+        return {
+            str(row["job_id"] if not isinstance(row, tuple) else row[0])
+            for row in rows
+            if (row["job_id"] if not isinstance(row, tuple) else row[0])
+        }
+
+    def _stale_artifact_projection_jobs(self) -> set[str]:
+        try:
+            rows = self._conn.execute(
+                """
+                SELECT DISTINCT p.job_id
+                  FROM artifact_list_projections p
+                 WHERE p.tenant_id = ?
+                   AND NOT EXISTS (
+                     SELECT 1
+                       FROM job_materials_artifacts a
+                      WHERE a.tenant_id = p.tenant_id
+                        AND a.job_id = p.job_id
+                        AND COALESCE(
+                              NULLIF(a.artifact_id, ''),
+                              a.artifact_type || ':' || a.path
+                            ) = p.artifact_id
+                        AND COALESCE(
+                              NULLIF(a.artifact_type, ''), 'artifact'
+                            ) = p.artifact_type
+                        AND a.path = p.local_path
+                   )
+                   AND NOT EXISTS (
+                     SELECT 1
+                       FROM job_artifacts a
+                      WHERE a.tenant_id = p.tenant_id
+                        AND a.job_id = p.job_id
+                        AND CAST(a.artifact_id AS TEXT) = p.artifact_id
+                        AND COALESCE(
+                              NULLIF(a.artifact_type, ''), 'artifact'
+                            ) = p.artifact_type
+                        AND a.path = p.local_path
+                        AND NOT EXISTS (
+                          SELECT 1
+                            FROM job_materials_artifacts m
+                           WHERE m.tenant_id = a.tenant_id
+                             AND m.job_id = a.job_id
+                             AND COALESCE(
+                                   NULLIF(m.artifact_type, ''), 'artifact'
+                                 ) = COALESCE(
+                                   NULLIF(a.artifact_type, ''), 'artifact'
+                                 )
+                             AND m.path = a.path
+                        )
+                   )
                 """,
                 (str(self._tenant_id),),
             ).fetchall()

--- a/workers/automation/src/jobctrl/infrastructure/projections/projection_builder.py
+++ b/workers/automation/src/jobctrl/infrastructure/projections/projection_builder.py
@@ -1371,6 +1371,7 @@ class ProjectionBuilder:
         layout_boxes_by_artifact = self._load_layout_boxes_by_artifact(job_id)
         enrichment = self._load_enrichment(job_id)
         apply_run = self._load_latest_apply_run(job_id)
+        explicit_application = self._load_explicit_application(job_id)
         deleted_at = self._load_deleted_at(job_id)
         artifacts = self._load_artifacts(job_id)
 
@@ -1429,20 +1430,21 @@ class ProjectionBuilder:
         # Apply state:
         ar_status = apply_run.get("status") if apply_run else None
         ar_finished = apply_run.get("finished_at") if apply_run else None
-        apply_status = _derive_apply_status(
-            ar_status,
-            None,
-        )
+        apply_status = _derive_apply_status(ar_status, None)
         applied_at: str | None
         if ar_status == "succeeded":
             applied_at = ar_finished
+        elif explicit_application is not None:
+            apply_status = "applied"
+            applied_at = explicit_application[1]
         else:
             applied_at = None
-        apply_mode = self._derive_apply_mode(
-            job_id,
-            apply_run,
-            None,
-            None,
+        apply_mode = (
+            "automated_live"
+            if ar_status == "succeeded" and not apply_run.get("dry_run")
+            else explicit_application[0]
+            if explicit_application is not None
+            else None
         )
 
         # description fallbacks
@@ -2573,53 +2575,42 @@ class ProjectionBuilder:
             "duration_ms": _row_nullable_int(row, "duration_ms"),
         }
 
-    def _derive_apply_mode(
-        self,
-        job_id: str,
-        apply_run: dict,
-        legacy_status: str | None,
-        legacy_applied_at: str | None,
-    ) -> str | None:
-        if apply_run.get("status") == "succeeded" and not apply_run.get("dry_run"):
-            return "automated_live"
-        is_applied = bool(legacy_applied_at) or legacy_status == "applied"
-        if not is_applied:
-            return None
-        if self._has_job_event(job_id, "ApplicationManuallyMarked"):
-            return "manual_marked"
-        if self._has_application_outcome_kind(job_id, "applied_confirmation"):
-            return "external_confirmed"
-        return "manual_marked"
-
-    def _has_job_event(self, job_id: str, event_type: str) -> bool:
+    def _load_explicit_application(self, job_id: str) -> tuple[str, str] | None:
         try:
             row = self._conn.execute(
                 """
-                SELECT COUNT(*) AS c
+                SELECT occurred_at
                 FROM job_events AS events
                 WHERE events.tenant_id = ?
                   AND events.job_id = ?
-                  AND events.event_type = ?
+                  AND events.event_type = 'ApplicationManuallyMarked'
+                ORDER BY events.occurred_at DESC, events.event_id DESC
+                LIMIT 1
                 """,
-                (str(self._tenant_id), job_id, event_type),
+                (str(self._tenant_id), job_id),
             ).fetchone()
         except sqlite3.OperationalError:
-            return False
-        return int(_row_nullable_int(row, "c") or 0) > 0
-
-    def _has_application_outcome_kind(self, job_id: str, kind: str) -> bool:
+            row = None
+        occurred_at = _row_nullable_str(row, "occurred_at")
+        if occurred_at:
+            return ("manual_marked", occurred_at)
         try:
             row = self._conn.execute(
                 """
-                SELECT COUNT(*) AS c
+                SELECT occurred_at
                 FROM application_outcomes
-                WHERE tenant_id = ? AND job_id = ? AND kind = ?
+                WHERE tenant_id = ?
+                  AND job_id = ?
+                  AND kind = 'applied_confirmation'
+                ORDER BY occurred_at DESC, outcome_id DESC
+                LIMIT 1
                 """,
-                (str(self._tenant_id), job_id, kind),
+                (str(self._tenant_id), job_id),
             ).fetchone()
         except sqlite3.OperationalError:
-            return False
-        return int(_row_nullable_int(row, "c") or 0) > 0
+            return None
+        occurred_at = _row_nullable_str(row, "occurred_at")
+        return ("external_confirmed", occurred_at) if occurred_at else None
 
     def _load_deleted_at(self, job_id: str) -> str | None:
         try:

--- a/workers/automation/src/jobctrl/infrastructure/projections/source_quality.py
+++ b/workers/automation/src/jobctrl/infrastructure/projections/source_quality.py
@@ -37,7 +37,7 @@ class EventRow:
     event_type: str
     occurred_at: str
     payload: dict[str, Any]
-    job_url: str | None = None
+    job_id: str | None = None
 
 
 @dataclass
@@ -79,7 +79,7 @@ def event_row_from_sql(row: Any) -> EventRow:
         event_type=str(event_type or ""),
         occurred_at=str(occurred_at or ""),
         payload=_json_payload(payload_json),
-        job_url=_nullable_str(_row_value(row, "job_url", 1)),
+        job_id=_nullable_str(_row_value(row, "job_id", 1)),
     )
 
 
@@ -190,7 +190,7 @@ def project_source_quality(
         elif event.event_type == "JobSourceObserved":
             source_id = _text(payload, "source_id", "sourceId")
             observation_id = _text(payload, "source_observation_id", "sourceObservationId")
-            job_id = _text(payload, "job_id", "jobId") or event.job_url
+            job_id = _text(payload, "job_id", "jobId") or event.job_id
             if source_id:
                 current = _stats(stats, source_id)
                 current.observed_jobs += 1
@@ -220,21 +220,21 @@ def project_source_quality(
                     duplicate_by_run_source[key] = duplicate_by_run_source.get(key, 0) + 1
         elif event.event_type == "PostingContentSnapshotCaptured":
             source_id = _text(payload, "source_id", "sourceId")
-            job_id = _text(payload, "job_id", "jobId") or event.job_url
+            job_id = _text(payload, "job_id", "jobId") or event.job_id
             if source_id:
                 current = _stats(stats, source_id)
                 _mark_detail_success(current, job_id)
                 current.event_count += 1
         elif event.event_type == "PostingContentSnapshotFailed":
             source_id = _text(payload, "source_id", "sourceId")
-            job_id = _text(payload, "job_id", "jobId") or event.job_url
+            job_id = _text(payload, "job_id", "jobId") or event.job_id
             if source_id:
                 current = _stats(stats, source_id)
                 _mark_detail_failure(current, job_id)
                 current.last_error_class = _text(payload, "error_class", "errorClass") or None
                 current.event_count += 1
         elif event.event_type == "JobEnriched":
-            job_id = _text(payload, "job_id", "jobId") or event.job_url
+            job_id = _text(payload, "job_id", "jobId") or event.job_id
             full_description = _text(payload, "full_description", "fullDescription")
             application_url = _text(payload, "application_url", "applicationUrl")
             for source_id in sources_by_job.get(job_id, set()):
@@ -249,7 +249,7 @@ def project_source_quality(
                     _mark_apply_failure(current, job_id)
                 current.event_count += 1
         elif event.event_type == "EnrichmentFailed":
-            job_id = _text(payload, "job_id", "jobId") or event.job_url
+            job_id = _text(payload, "job_id", "jobId") or event.job_id
             error_class = _text(payload, "error_class", "errorClass", "error")
             for source_id in sources_by_job.get(job_id, set()):
                 current = _stats(stats, source_id)
@@ -258,7 +258,7 @@ def project_source_quality(
                 current.last_error_class = error_class or current.last_error_class
                 current.event_count += 1
         elif event.event_type == "JobActiveStateChanged":
-            job_id = _text(payload, "job_id", "jobId") or event.job_url
+            job_id = _text(payload, "job_id", "jobId") or event.job_id
             active_state = _text(payload, "active_state", "activeState")
             for source_id in sources_by_job.get(job_id, set()):
                 current = _stats(stats, source_id)
@@ -268,7 +268,7 @@ def project_source_quality(
                     current.stale_jobs += 1
                 current.event_count += 1
         elif event.event_type == "ContentDuplicateCandidateDetected":
-            job_id = _text(payload, "job_id", "jobId") or event.job_url
+            job_id = _text(payload, "job_id", "jobId") or event.job_id
             candidate_job_id = _text(payload, "candidate_job_id", "candidateJobId")
             source_ids = sources_by_job.get(job_id, set()) | sources_by_job.get(candidate_job_id, set())
             for source_id in source_ids:
@@ -280,7 +280,7 @@ def project_source_quality(
                     key = (active_run_id, source_id)
                     duplicate_by_run_source[key] = duplicate_by_run_source.get(key, 0) + 1
         elif event.event_type == "DiscoveryFeedbackRecorded":
-            job_id = _text(payload, "job_id", "jobId") or event.job_url
+            job_id = _text(payload, "job_id", "jobId") or event.job_id
             explicit_source_id = _nullable_str(_value(payload, "source_id", "sourceId"))
             source_ids = (explicit_source_id,) if explicit_source_id else tuple(sources_by_job.get(job_id, set()))
             kind = _text(payload, "kind")

--- a/workers/automation/tests/test_apply_runs_projection_from_events.py
+++ b/workers/automation/tests/test_apply_runs_projection_from_events.py
@@ -25,6 +25,8 @@ from typing import Iterator
 import pytest
 
 from jobctrl.database import close_connection, init_db
+from jobctrl.domain.identifiers import JobId
+from jobctrl.domain.tenant import LOCAL_TENANT, TenantId
 from jobctrl.infrastructure.projections.projection_builder import ProjectionBuilder
 from jobctrl.state import record_job_event, utc_now
 
@@ -37,14 +39,32 @@ def conn(tmp_path: Path) -> Iterator[sqlite3.Connection]:
     close_connection(db_path)
 
 
-def _seed_job(conn: sqlite3.Connection, url: str) -> None:
+def _seed_job(
+    conn: sqlite3.Connection,
+    job_id: JobId,
+    url: str,
+    *,
+    tenant_id: TenantId = LOCAL_TENANT,
+) -> None:
     conn.execute(
         """
-        INSERT INTO jobs (url, title, site, strategy, location, salary,
+        INSERT INTO jobs (tenant_id, job_id, url, title, site, strategy, location, salary,
                           discovered_at, application_url, description)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """,
-        (url, "Eng", "ExampleCo", "jobspy", "Remote", "", utc_now(), url, "x"),
+        (
+            str(tenant_id),
+            str(job_id),
+            url,
+            "Eng",
+            "ExampleCo",
+            "jobspy",
+            "Remote",
+            "",
+            utc_now(),
+            url,
+            "x",
+        ),
     )
 
 
@@ -61,13 +81,15 @@ def _row_value(row, key, default=None):
 
 
 def test_started_event_opens_row(conn: sqlite3.Connection) -> None:
+    job_id = JobId("00000000-0000-4000-8000-000000000101")
     url = "https://example.com/job"
-    _seed_job(conn, url)
+    _seed_job(conn, job_id, url)
     record_job_event(
         conn,
-        url,
+        job_id,
         "apply",
         "ApplyRunStarted",
+        tenant_id=LOCAL_TENANT,
         payload={
             "run_id": "run-1",
             "model": "haiku",
@@ -85,7 +107,7 @@ def test_started_event_opens_row(conn: sqlite3.Connection) -> None:
     ).fetchone()
     assert row is not None
     assert _row_value(row, "status") == "starting"
-    assert _row_value(row, "job_id") == url
+    assert _row_value(row, "job_id") == str(job_id)
     assert _row_value(row, "model") == "haiku"
     assert _row_value(row, "worker_id") == 7
     assert _row_value(row, "started_at") == "2026-05-04T13:00:00+00:00"
@@ -94,13 +116,15 @@ def test_started_event_opens_row(conn: sqlite3.Connection) -> None:
 def test_submitted_event_terminates_row_as_succeeded(
     conn: sqlite3.Connection,
 ) -> None:
+    job_id = JobId("00000000-0000-4000-8000-000000000102")
     url = "https://example.com/job-applied"
-    _seed_job(conn, url)
+    _seed_job(conn, job_id, url)
     record_job_event(
         conn,
-        url,
+        job_id,
         "apply",
         "ApplyRunStarted",
+        tenant_id=LOCAL_TENANT,
         payload={
             "run_id": "run-2",
             "model": "haiku",
@@ -111,9 +135,10 @@ def test_submitted_event_terminates_row_as_succeeded(
     )
     record_job_event(
         conn,
-        url,
+        job_id,
         "apply",
         "ApplicationSubmitted",
+        tenant_id=LOCAL_TENANT,
         payload={
             "run_id": "run-2",
             "finished_at": "2026-05-04T13:05:00+00:00",
@@ -136,13 +161,15 @@ def test_submitted_event_terminates_row_as_succeeded(
 
 
 def test_failed_event_terminates_row_as_failed(conn: sqlite3.Connection) -> None:
+    job_id = JobId("00000000-0000-4000-8000-000000000103")
     url = "https://example.com/job-failed"
-    _seed_job(conn, url)
+    _seed_job(conn, job_id, url)
     record_job_event(
         conn,
-        url,
+        job_id,
         "apply",
         "ApplyRunStarted",
+        tenant_id=LOCAL_TENANT,
         payload={
             "run_id": "run-3",
             "started_at": "2026-05-04T13:00:00+00:00",
@@ -150,9 +177,10 @@ def test_failed_event_terminates_row_as_failed(conn: sqlite3.Connection) -> None
     )
     record_job_event(
         conn,
-        url,
+        job_id,
         "apply",
         "ApplicationFailed",
+        tenant_id=LOCAL_TENANT,
         payload={
             "run_id": "run-3",
             "finished_at": "2026-05-04T13:02:00+00:00",
@@ -174,13 +202,15 @@ def test_failed_event_terminates_row_as_failed(conn: sqlite3.Connection) -> None
 
 
 def test_dry_run_completed_event_terminates_row(conn: sqlite3.Connection) -> None:
+    job_id = JobId("00000000-0000-4000-8000-000000000104")
     url = "https://example.com/job-dry"
-    _seed_job(conn, url)
+    _seed_job(conn, job_id, url)
     record_job_event(
         conn,
-        url,
+        job_id,
         "apply",
         "ApplyRunStarted",
+        tenant_id=LOCAL_TENANT,
         payload={
             "run_id": "run-4",
             "dry_run": True,
@@ -189,9 +219,10 @@ def test_dry_run_completed_event_terminates_row(conn: sqlite3.Connection) -> Non
     )
     record_job_event(
         conn,
-        url,
+        job_id,
         "apply",
         "DryRunCompleted",
+        tenant_id=LOCAL_TENANT,
         payload={
             "run_id": "run-4",
             "finished_at": "2026-05-04T13:01:00+00:00",
@@ -211,28 +242,32 @@ def test_dry_run_completed_event_terminates_row(conn: sqlite3.Connection) -> Non
 
 
 def test_event_timeline_collected_per_run(conn: sqlite3.Connection) -> None:
+    job_id = JobId("00000000-0000-4000-8000-000000000105")
     url = "https://example.com/job-events"
-    _seed_job(conn, url)
+    _seed_job(conn, job_id, url)
     record_job_event(
         conn,
-        url,
+        job_id,
         "apply",
         "ApplyRunStarted",
+        tenant_id=LOCAL_TENANT,
         payload={"run_id": "run-5", "started_at": "t0"},
     )
     record_job_event(
         conn,
-        url,
+        job_id,
         "apply",
         "ApplyRunEvent",
+        tenant_id=LOCAL_TENANT,
         payload={"run_id": "run-5", "step": "form_filled"},
         message="Filled application form",
     )
     record_job_event(
         conn,
-        url,
+        job_id,
         "apply",
         "ApplicationSubmitted",
+        tenant_id=LOCAL_TENANT,
         payload={
             "run_id": "run-5",
             "finished_at": "t9",
@@ -257,13 +292,15 @@ def test_event_timeline_collected_per_run(conn: sqlite3.Connection) -> None:
 def test_projection_rebuild_is_deterministic(conn: sqlite3.Connection) -> None:
     """Running the projector twice produces the same row state — no
     duplicates, no churn."""
+    job_id = JobId("00000000-0000-4000-8000-000000000106")
     url = "https://example.com/job-deterministic"
-    _seed_job(conn, url)
+    _seed_job(conn, job_id, url)
     record_job_event(
         conn,
-        url,
+        job_id,
         "apply",
         "ApplyRunStarted",
+        tenant_id=LOCAL_TENANT,
         payload={
             "run_id": "run-6",
             "started_at": "2026-05-04T13:00:00+00:00",
@@ -271,9 +308,10 @@ def test_projection_rebuild_is_deterministic(conn: sqlite3.Connection) -> None:
     )
     record_job_event(
         conn,
-        url,
+        job_id,
         "apply",
         "ApplicationSubmitted",
+        tenant_id=LOCAL_TENANT,
         payload={
             "run_id": "run-6",
             "finished_at": "2026-05-04T13:05:00+00:00",
@@ -300,3 +338,42 @@ def test_projection_rebuild_is_deterministic(conn: sqlite3.Connection) -> None:
     assert _row_value(rows_after[0], "finished_at") == _row_value(
         row_first, "finished_at"
     )
+
+
+def test_apply_runs_are_isolated_by_tenant(conn: sqlite3.Connection) -> None:
+    shared_job_id = JobId("00000000-0000-4000-8000-000000000107")
+    other_tenant = TenantId("other")
+    _seed_job(conn, shared_job_id, "https://example.com/job-local")
+    _seed_job(
+        conn,
+        shared_job_id,
+        "https://example.com/job-other",
+        tenant_id=other_tenant,
+    )
+    for tenant_id, run_id in ((LOCAL_TENANT, "local-run"), (other_tenant, "other-run")):
+        record_job_event(
+            conn,
+            shared_job_id,
+            "apply",
+            "ApplyRunStarted",
+            tenant_id=tenant_id,
+            payload={"run_id": run_id, "started_at": "2026-05-04T13:00:00+00:00"},
+        )
+    conn.commit()
+
+    ProjectionBuilder(conn_factory=lambda: conn).refresh()
+    local_rows = conn.execute(
+        "SELECT run_id, tenant_id, job_id FROM apply_run_projections ORDER BY run_id"
+    ).fetchall()
+    assert [tuple(row) for row in local_rows] == [
+        ("local-run", str(LOCAL_TENANT), str(shared_job_id))
+    ]
+
+    ProjectionBuilder(conn_factory=lambda: conn, tenant_id=other_tenant).refresh()
+    other_rows = conn.execute(
+        "SELECT run_id, tenant_id, job_id FROM apply_run_projections ORDER BY run_id"
+    ).fetchall()
+    assert [tuple(row) for row in other_rows] == [
+        ("local-run", str(LOCAL_TENANT), str(shared_job_id)),
+        ("other-run", str(other_tenant), str(shared_job_id)),
+    ]

--- a/workers/automation/tests/test_apply_runs_table_dropped.py
+++ b/workers/automation/tests/test_apply_runs_table_dropped.py
@@ -1,18 +1,19 @@
-"""PR 4: ``init_db`` drops the legacy ``apply_runs`` + ``apply_run_events``
-tables and never re-creates them.
+"""Exact-v7 runtime admission never creates legacy Apply write tables.
 
 The Temporal workflow is the canonical record of an apply lifecycle from
 PR 4 onward; ``apply_run_projections`` (sourced from ``job_events``) is
-the read-side. Dropping the bespoke tables removes the second write path.
+the read-side. Existing pre-v7 databases must use the stopped-runtime
+migration instead of being changed opportunistically by ``init_db``.
 """
 
 from __future__ import annotations
 
+import sqlite3
 from pathlib import Path
 
 import pytest
 
-from jobctrl.database import close_connection, init_db
+from jobctrl.database import SchemaMigrationRequiredError, close_connection, init_db
 
 
 def _table_exists(conn, name: str) -> bool:
@@ -40,11 +41,9 @@ def test_init_db_does_not_create_apply_run_events(fresh_db: Path) -> None:
     assert _table_exists(conn, "apply_run_events") is False
 
 
-def test_init_db_drops_existing_apply_runs_table(fresh_db: Path) -> None:
-    """If a legacy database already has ``apply_runs``, the migration
-    drops it idempotently."""
-    import sqlite3
-
+def test_init_db_rejects_legacy_apply_tables_without_mutating_them(
+    fresh_db: Path,
+) -> None:
     # Pre-create the legacy table to simulate an existing local DB.
     pre = sqlite3.connect(str(fresh_db))
     pre.execute(
@@ -71,6 +70,13 @@ def test_init_db_drops_existing_apply_runs_table(fresh_db: Path) -> None:
     pre.commit()
     pre.close()
 
-    conn = init_db(fresh_db)
-    assert _table_exists(conn, "apply_runs") is False
-    assert _table_exists(conn, "apply_run_events") is False
+    with pytest.raises(SchemaMigrationRequiredError, match="exact schema v7"):
+        init_db(fresh_db)
+
+    verified = sqlite3.connect(str(fresh_db))
+    try:
+        assert _table_exists(verified, "apply_runs") is True
+        assert _table_exists(verified, "apply_run_events") is True
+        assert verified.execute("PRAGMA user_version").fetchone()[0] == 0
+    finally:
+        verified.close()

--- a/workers/automation/tests/test_dashboard_projection.py
+++ b/workers/automation/tests/test_dashboard_projection.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import sqlite3
+import uuid
 from pathlib import Path
 from typing import Iterator
 
@@ -17,6 +18,13 @@ from jobctrl.infrastructure.projections.projection_builder import (
 from jobctrl.state import record_job_event, set_stage_state, utc_now
 
 
+LOCAL_TENANT = "local"
+
+
+def _job_id_for(url: str) -> str:
+    return str(uuid.uuid5(uuid.NAMESPACE_URL, f"dashboard-projection:{url}"))
+
+
 @pytest.fixture
 def conn(tmp_path: Path) -> Iterator[sqlite3.Connection]:
     db_path = tmp_path / "jobs.db"
@@ -25,30 +33,56 @@ def conn(tmp_path: Path) -> Iterator[sqlite3.Connection]:
     close_connection(db_path)
 
 
-def _seed_job(conn: sqlite3.Connection, url: str, *, site: str = "ExampleCo") -> None:
+def _seed_job(conn: sqlite3.Connection, url: str, *, site: str = "ExampleCo") -> str:
+    job_id = _job_id_for(url)
+    now = "2026-05-04T12:00:00+00:00"
     conn.execute(
         """
-        INSERT INTO jobs (url, title, site, strategy, location, salary,
-                          discovered_at, application_url, description)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        INSERT INTO jobs (
+            tenant_id, job_id, url, title, site, strategy, location, salary,
+            discovered_at, application_url, description
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """,
-        (url, "Engineer", site, "jobspy", "Remote", "", "2026-05-04T12:00:00+00:00", url, "desc"),
+        (
+            LOCAL_TENANT,
+            job_id,
+            url,
+            "Engineer",
+            site,
+            "jobspy",
+            "Remote",
+            "",
+            now,
+            url,
+            "desc",
+        ),
+    )
+    conn.execute(
+        """
+        INSERT INTO job_locators (
+            tenant_id, job_id, locator_kind, locator_value,
+            is_current, first_seen_at, last_seen_at
+        ) VALUES (?, ?, 'posting_url', ?, 1, ?, ?)
+        """,
+        (LOCAL_TENANT, job_id, url, now, now),
     )
     conn.commit()
+    return job_id
 
 
 def _mark_closed(conn: sqlite3.Connection, url: str, state: str = "removed") -> None:
+    job_id = _job_id_for(url)
     conn.execute(
         """
         INSERT INTO posting_snapshot_sets (
-            tenant_id, job_url, snapshot_set_json, latest_snapshot_version,
+            tenant_id, job_id, snapshot_set_json, latest_snapshot_version,
             latest_active_state, updated_at
-        ) VALUES ('local', ?, '{}', 0, ?, ?)
-        ON CONFLICT(tenant_id, job_url) DO UPDATE SET
+        ) VALUES (?, ?, '{}', 0, ?, ?)
+        ON CONFLICT(tenant_id, job_id) DO UPDATE SET
             latest_active_state = excluded.latest_active_state,
             updated_at = excluded.updated_at
         """,
-        (url, state, utc_now()),
+        (LOCAL_TENANT, job_id, state, utc_now()),
     )
     conn.commit()
 
@@ -81,8 +115,8 @@ def test_dashboard_starts_empty(conn: sqlite3.Connection) -> None:
 def test_total_jobs_reflects_active_jobs(conn: sqlite3.Connection) -> None:
     _seed_job(conn, "https://example.com/a")
     _seed_job(conn, "https://example.com/b")
-    record_job_event(conn, "https://example.com/a", "discover", "JobDiscovered")
-    record_job_event(conn, "https://example.com/b", "discover", "JobDiscovered")
+    record_job_event(conn, _job_id_for("https://example.com/a"), "discover", "JobDiscovered")
+    record_job_event(conn, _job_id_for("https://example.com/b"), "discover", "JobDiscovered")
     conn.commit()
     ProjectionBuilder(conn_factory=lambda: conn).refresh()
     row = _dashboard(conn)
@@ -94,15 +128,17 @@ def test_dashboard_excludes_closed_jobs_from_active_counts(conn: sqlite3.Connect
     closed_url = "https://example.com/closed"
     _seed_job(conn, active_url)
     _seed_job(conn, closed_url)
-    set_stage_state(conn, active_url, "discover", "succeeded", finished_at=utc_now())
-    set_stage_state(conn, active_url, "enrich", "succeeded", finished_at=utc_now())
-    set_stage_state(conn, active_url, "score", "succeeded", finished_at=utc_now())
-    set_stage_state(conn, active_url, "tailor", "blocked", validate_transition=False)
-    set_stage_state(conn, closed_url, "discover", "succeeded", finished_at=utc_now())
-    set_stage_state(conn, closed_url, "enrich", "succeeded", finished_at=utc_now())
-    set_stage_state(conn, closed_url, "score", "failed", validate_transition=False)
-    record_job_event(conn, active_url, "tailor", "StageBlocked")
-    record_job_event(conn, closed_url, "score", "StageFailed")
+    active_job_id = _job_id_for(active_url)
+    closed_job_id = _job_id_for(closed_url)
+    set_stage_state(conn, active_job_id, "discover", "succeeded", finished_at=utc_now())
+    set_stage_state(conn, active_job_id, "enrich", "succeeded", finished_at=utc_now())
+    set_stage_state(conn, active_job_id, "score", "succeeded", finished_at=utc_now())
+    set_stage_state(conn, active_job_id, "tailor", "blocked", validate_transition=False)
+    set_stage_state(conn, closed_job_id, "discover", "succeeded", finished_at=utc_now())
+    set_stage_state(conn, closed_job_id, "enrich", "succeeded", finished_at=utc_now())
+    set_stage_state(conn, closed_job_id, "score", "failed", validate_transition=False)
+    record_job_event(conn, active_job_id, "tailor", "StageBlocked")
+    record_job_event(conn, closed_job_id, "score", "StageFailed")
     _mark_closed(conn, closed_url)
     conn.commit()
 
@@ -117,10 +153,11 @@ def test_dashboard_excludes_closed_jobs_from_active_counts(conn: sqlite3.Connect
 def test_failures_count_includes_failed_and_exhausted(conn: sqlite3.Connection) -> None:
     url = "https://example.com/c"
     _seed_job(conn, url)
-    set_stage_state(conn, url, "discover", "succeeded", finished_at=utc_now())
-    set_stage_state(conn, url, "enrich", "succeeded", finished_at=utc_now())
-    set_stage_state(conn, url, "score", "failed", validate_transition=False)
-    record_job_event(conn, url, "score", "StageFailed")
+    job_id = _job_id_for(url)
+    set_stage_state(conn, job_id, "discover", "succeeded", finished_at=utc_now())
+    set_stage_state(conn, job_id, "enrich", "succeeded", finished_at=utc_now())
+    set_stage_state(conn, job_id, "score", "failed", validate_transition=False)
+    record_job_event(conn, job_id, "score", "StageFailed")
     conn.commit()
     ProjectionBuilder(conn_factory=lambda: conn).refresh()
     row = _dashboard(conn)
@@ -130,11 +167,12 @@ def test_failures_count_includes_failed_and_exhausted(conn: sqlite3.Connection) 
 def test_blocked_count(conn: sqlite3.Connection) -> None:
     url = "https://example.com/d"
     _seed_job(conn, url)
-    set_stage_state(conn, url, "discover", "succeeded", finished_at=utc_now())
-    set_stage_state(conn, url, "enrich", "succeeded", finished_at=utc_now())
-    set_stage_state(conn, url, "score", "succeeded", finished_at=utc_now())
-    set_stage_state(conn, url, "tailor", "blocked", validate_transition=False)
-    record_job_event(conn, url, "tailor", "StageBlocked")
+    job_id = _job_id_for(url)
+    set_stage_state(conn, job_id, "discover", "succeeded", finished_at=utc_now())
+    set_stage_state(conn, job_id, "enrich", "succeeded", finished_at=utc_now())
+    set_stage_state(conn, job_id, "score", "succeeded", finished_at=utc_now())
+    set_stage_state(conn, job_id, "tailor", "blocked", validate_transition=False)
+    record_job_event(conn, job_id, "tailor", "StageBlocked")
     conn.commit()
     ProjectionBuilder(conn_factory=lambda: conn).refresh()
     row = _dashboard(conn)
@@ -147,14 +185,14 @@ def test_applied_count_via_apply_status(conn: sqlite3.Connection) -> None:
     finished = utc_now()
     record_job_event(
         conn,
-        "https://example.com/e",
+        _job_id_for("https://example.com/e"),
         "apply",
         "ApplyRunStarted",
         payload={"run_id": "run-e", "started_at": started},
     )
     record_job_event(
         conn,
-        "https://example.com/e",
+        _job_id_for("https://example.com/e"),
         "apply",
         "ApplicationSubmitted",
         payload={"run_id": "run-e", "finished_at": finished, "result": "applied"},
@@ -174,13 +212,13 @@ def test_score_distribution_groups_by_score(conn: sqlite3.Connection) -> None:
         _seed_job(conn, url)
         conn.execute(
             """
-            INSERT INTO job_scores (job_url, version, tenant_id, fit_score,
+            INSERT INTO job_scores (tenant_id, job_id, version, fit_score,
                                     breakdown_json, keywords_json, scored_at)
-            VALUES (?, 1, 'local', ?, ?, ?, ?)
+            VALUES (?, ?, 1, ?, ?, ?, ?)
             """,
-            (url, score, json.dumps({}), json.dumps([]), utc_now()),
+            (LOCAL_TENANT, _job_id_for(url), score, json.dumps({}), json.dumps([]), utc_now()),
         )
-        record_job_event(conn, url, "score", "JobScored")
+        record_job_event(conn, _job_id_for(url), "score", "JobScored")
     conn.commit()
     ProjectionBuilder(conn_factory=lambda: conn).refresh()
     row = _dashboard(conn)
@@ -197,30 +235,30 @@ def test_artifact_projection_preserves_material_metadata(conn: sqlite3.Connectio
     conn.execute(
         """
         INSERT INTO job_materials (
-            job_url, generation, tenant_id, status, created_at, updated_at, metadata_json
-        ) VALUES (?, 1, 'local', 'resume_approved', ?, ?, '{}')
+            tenant_id, job_id, generation, status, created_at, updated_at, metadata_json
+        ) VALUES (?, ?, 1, 'resume_approved', ?, ?, '{}')
         """,
-        (url, utc_now(), utc_now()),
+        (LOCAL_TENANT, _job_id_for(url), utc_now(), utc_now()),
     )
     conn.execute(
         """
         INSERT INTO job_materials_artifacts (
-            job_url, generation, artifact_type, artifact_id, status, path,
+            tenant_id, job_id, generation, artifact_type, artifact_id, status, path,
             render_format, size_bytes, metadata_json, created_at
-        ) VALUES (?, 1, 'tailored_resume', 'artifact-1', 'approved', ?, 'text', 12, ?, ?)
+        ) VALUES (?, ?, 1, 'tailored_resume', 'artifact-1', 'approved', ?, 'text', 12, ?, ?)
         """,
-        (url, "/tmp/resume.txt", json.dumps(metadata), utc_now()),
+        (LOCAL_TENANT, _job_id_for(url), "/tmp/resume.txt", json.dumps(metadata), utc_now()),
     )
     conn.execute(
         """
         INSERT INTO job_materials_artifacts (
-            job_url, generation, artifact_type, artifact_id, status, path,
+            tenant_id, job_id, generation, artifact_type, artifact_id, status, path,
             render_format, size_bytes, metadata_json, created_at
-        ) VALUES (?, 1, 'resume_pdf', 'artifact-pdf', 'approved', ?, 'pdf', 120, '{}', ?)
+        ) VALUES (?, ?, 1, 'resume_pdf', 'artifact-pdf', 'approved', ?, 'pdf', 120, '{}', ?)
         """,
-        (url, "/tmp/resume.pdf", utc_now()),
+        (LOCAL_TENANT, _job_id_for(url), "/tmp/resume.pdf", utc_now()),
     )
-    record_job_event(conn, url, "tailor", "MaterialsGenerated")
+    record_job_event(conn, _job_id_for(url), "tailor", "MaterialsGenerated")
     conn.commit()
 
     ProjectionBuilder(conn_factory=lambda: conn).refresh()
@@ -233,15 +271,15 @@ def test_artifact_projection_preserves_material_metadata(conn: sqlite3.Connectio
     ).fetchone()
 
     assert json.loads(_row_value(row, "metadata_json", "{}")) == metadata
-    synthetic_pdf = conn.execute(
+    registered_pdf = conn.execute(
         """
         SELECT metadata_json
         FROM artifact_list_projections
-        WHERE tenant_id = 'local' AND artifact_type = 'tailored_resume_pdf'
+        WHERE tenant_id = 'local' AND artifact_id = 'artifact-pdf'
         """
     ).fetchone()
 
-    assert json.loads(_row_value(synthetic_pdf, "metadata_json", "{}")) == metadata
+    assert json.loads(_row_value(registered_pdf, "metadata_json", "{}")) == {}
 
 
 def test_artifact_projection_includes_resume_layout_boxes(conn: sqlite3.Connection) -> None:
@@ -251,32 +289,32 @@ def test_artifact_projection_includes_resume_layout_boxes(conn: sqlite3.Connecti
     conn.execute(
         """
         INSERT INTO job_materials (
-            job_url, generation, tenant_id, status, created_at, updated_at, metadata_json
-        ) VALUES (?, 1, 'local', 'resume_approved', ?, ?, '{}')
+            tenant_id, job_id, generation, status, created_at, updated_at, metadata_json
+        ) VALUES (?, ?, 1, 'resume_approved', ?, ?, '{}')
         """,
-        (url, now, now),
+        (LOCAL_TENANT, _job_id_for(url), now, now),
     )
     conn.execute(
         """
         INSERT INTO job_materials_artifacts (
-            job_url, generation, artifact_type, artifact_id, status, path,
+            tenant_id, job_id, generation, artifact_type, artifact_id, status, path,
             render_format, size_bytes, metadata_json, created_at
-        ) VALUES (?, 1, 'resume_pdf', 'artifact-pdf', 'approved', ?, 'html_pdf', 120, '{}', ?)
+        ) VALUES (?, ?, 1, 'resume_pdf', 'artifact-pdf', 'approved', ?, 'html_pdf', 120, '{}', ?)
         """,
-        (url, "/tmp/resume.pdf", now),
+        (LOCAL_TENANT, _job_id_for(url), "/tmp/resume.pdf", now),
     )
     conn.execute(
         """
         INSERT INTO job_material_layout_boxes (
-            job_url, generation, artifact_id, box_index, tenant_id,
+            tenant_id, job_id, generation, artifact_id, box_index,
             semantic_id, page_number, line_number, text_excerpt,
             left_pct, top_pct, width_pct, height_pct, audit_target_json,
             created_at
-        ) VALUES (?, 1, 'artifact-pdf', 0, 'local', ?, 1, 6, ?, 12.5, 24.0, 62.0, 2.4, '{}', ?)
+        ) VALUES (?, ?, 1, 'artifact-pdf', 0, ?, 1, 6, ?, 12.5, 24.0, 62.0, 2.4, '{}', ?)
         """,
-        (url, "experience:acme:bullet:1", "Cut latency.", now),
+        (LOCAL_TENANT, _job_id_for(url), "experience:acme:bullet:1", "Cut latency.", now),
     )
-    record_job_event(conn, url, "tailor", "PdfRendered")
+    record_job_event(conn, _job_id_for(url), "tailor", "PdfRendered")
     conn.commit()
 
     ProjectionBuilder(conn_factory=lambda: conn).refresh()
@@ -306,11 +344,12 @@ def test_artifact_projection_includes_resume_layout_boxes(conn: sqlite3.Connecti
 def test_funnel_counts_per_stage(conn: sqlite3.Connection) -> None:
     url = "https://example.com/funnel"
     _seed_job(conn, url)
-    set_stage_state(conn, url, "discover", "succeeded", finished_at=utc_now())
-    set_stage_state(conn, url, "enrich", "succeeded", finished_at=utc_now())
-    set_stage_state(conn, url, "score", "succeeded", finished_at=utc_now())
-    set_stage_state(conn, url, "tailor", "running")
-    record_job_event(conn, url, "tailor", "StageStarted")
+    job_id = _job_id_for(url)
+    set_stage_state(conn, job_id, "discover", "succeeded", finished_at=utc_now())
+    set_stage_state(conn, job_id, "enrich", "succeeded", finished_at=utc_now())
+    set_stage_state(conn, job_id, "score", "succeeded", finished_at=utc_now())
+    set_stage_state(conn, job_id, "tailor", "running")
+    record_job_event(conn, job_id, "tailor", "StageStarted")
     conn.commit()
     ProjectionBuilder(conn_factory=lambda: conn).refresh()
 
@@ -329,7 +368,7 @@ def test_by_source_counts(conn: sqlite3.Connection) -> None:
     _seed_job(conn, "https://example.com/y", site="OneCo")
     _seed_job(conn, "https://example.com/z", site="TwoCo")
     for url in ("https://example.com/x", "https://example.com/y", "https://example.com/z"):
-        record_job_event(conn, url, "discover", "JobDiscovered")
+        record_job_event(conn, _job_id_for(url), "discover", "JobDiscovered")
     conn.commit()
     ProjectionBuilder(conn_factory=lambda: conn).refresh()
 
@@ -359,7 +398,7 @@ def test_by_source_orders_ties_by_source_name(conn: sqlite3.Connection) -> None:
     ]
     for url, site in seeded:
         _seed_job(conn, url, site=site)
-        record_job_event(conn, url, "discover", "JobDiscovered")
+        record_job_event(conn, _job_id_for(url), "discover", "JobDiscovered")
     conn.commit()
     ProjectionBuilder(conn_factory=lambda: conn).refresh()
 
@@ -378,21 +417,22 @@ def _apply_job(
 ) -> None:
     _seed_job(conn, url, site=site)
     at = applied_at or utc_now()
+    job_id = _job_id_for(url)
     conn.execute(
         """
-        INSERT INTO job_scores (job_url, version, tenant_id, fit_score,
+        INSERT INTO job_scores (tenant_id, job_id, version, fit_score,
                                 breakdown_json, keywords_json, scored_at)
-        VALUES (?, 1, 'local', ?, '{}', '[]', ?)
+        VALUES (?, ?, 1, ?, '{}', '[]', ?)
         """,
-        (url, fit_score, utc_now()),
+        (LOCAL_TENANT, job_id, fit_score, utc_now()),
     )
     run_id = f"run-{url}"
     record_job_event(
-        conn, url, "apply", "ApplyRunStarted",
+        conn, job_id, "apply", "ApplyRunStarted",
         payload={"run_id": run_id, "started_at": at},
     )
     record_job_event(
-        conn, url, "apply", "ApplicationSubmitted",
+        conn, job_id, "apply", "ApplicationSubmitted",
         payload={"run_id": run_id, "finished_at": at, "result": "applied"},
     )
 
@@ -407,19 +447,22 @@ def _mark_manual_applied(
 ) -> None:
     _seed_job(conn, url, site=site)
     at = applied_at or utc_now()
+    job_id = _job_id_for(url)
     conn.execute(
         """
-        INSERT INTO job_scores (job_url, version, tenant_id, fit_score,
+        INSERT INTO job_scores (tenant_id, job_id, version, fit_score,
                                 breakdown_json, keywords_json, scored_at)
-        VALUES (?, 1, 'local', ?, '{}', '[]', ?)
+        VALUES (?, ?, 1, ?, '{}', '[]', ?)
         """,
-        (url, fit_score, utc_now()),
+        (LOCAL_TENANT, job_id, fit_score, utc_now()),
     )
-    conn.execute(
-        "UPDATE jobs SET apply_status = 'applied', applied_at = ? WHERE url = ?",
-        (at, url),
+    record_job_event(
+        conn,
+        job_id,
+        "apply",
+        "ApplicationManuallyMarked",
+        occurred_at=at,
     )
-    record_job_event(conn, url, "apply", "ApplicationManuallyMarked")
 
 
 def _mark_external_confirmed(
@@ -432,17 +475,14 @@ def _mark_external_confirmed(
 ) -> None:
     _seed_job(conn, url, site=site)
     at = applied_at or utc_now()
+    job_id = _job_id_for(url)
     conn.execute(
         """
-        INSERT INTO job_scores (job_url, version, tenant_id, fit_score,
+        INSERT INTO job_scores (tenant_id, job_id, version, fit_score,
                                 breakdown_json, keywords_json, scored_at)
-        VALUES (?, 1, 'local', ?, '{}', '[]', ?)
+        VALUES (?, ?, 1, ?, '{}', '[]', ?)
         """,
-        (url, fit_score, utc_now()),
-    )
-    conn.execute(
-        "UPDATE jobs SET apply_status = 'applied', applied_at = ? WHERE url = ?",
-        (at, url),
+        (LOCAL_TENANT, job_id, fit_score, utc_now()),
     )
     _record_outcome(conn, url, "applied_confirmation", occurred_at=at)
 
@@ -451,12 +491,12 @@ def _record_fit_band(conn: sqlite3.Connection, url: str, fit_score: int, fit_ban
     conn.execute(
         """
         INSERT INTO job_requirement_fit_reports (
-            job_url, score_version, tenant_id, employer_analysis_generation,
+            tenant_id, job_id, score_version, employer_analysis_generation,
             profile_snapshot_version, scoring_policy_version, formula_version,
             resolved_fit_score, fit_band, confidence, summary_json, created_at
-        ) VALUES (?, 1, 'local', 1, 1, 1, 'test', ?, ?, 'medium', '{}', ?)
+        ) VALUES (?, ?, 1, 1, 1, 1, 'test', ?, ?, 'medium', '{}', ?)
         """,
-        (url, fit_score, fit_band, utc_now()),
+        (LOCAL_TENANT, _job_id_for(url), fit_score, fit_band, utc_now()),
     )
 
 
@@ -471,10 +511,10 @@ def _record_outcome(
     conn.execute(
         """
         INSERT INTO application_outcomes (
-            tenant_id, outcome_id, job_key, kind, source, occurred_at, recorded_at
-        ) VALUES ('local', ?, ?, ?, 'manual', ?, ?)
+            tenant_id, outcome_id, job_id, kind, source, occurred_at, recorded_at
+        ) VALUES (?, ?, ?, ?, 'manual', ?, ?)
         """,
-        (f"outcome-{url}-{kind}", url, kind, at, at),
+        (LOCAL_TENANT, f"outcome-{url}-{kind}", _job_id_for(url), kind, at, at),
     )
 
 
@@ -499,20 +539,21 @@ def _record_material_metadata(
     conn.execute(
         """
         INSERT INTO job_materials (
-            job_url, generation, tenant_id, status, created_at, updated_at, metadata_json
-        ) VALUES (?, 1, 'local', 'resume_approved', ?, ?, '{}')
+            tenant_id, job_id, generation, status, created_at, updated_at, metadata_json
+        ) VALUES (?, ?, 1, 'resume_approved', ?, ?, '{}')
         """,
-        (url, utc_now(), utc_now()),
+        (LOCAL_TENANT, _job_id_for(url), utc_now(), utc_now()),
     )
     conn.execute(
         """
         INSERT INTO job_materials_artifacts (
-            job_url, generation, artifact_type, artifact_id, status, path,
+            tenant_id, job_id, generation, artifact_type, artifact_id, status, path,
             render_format, size_bytes, metadata_json, created_at
-        ) VALUES (?, 1, 'tailored_resume', ?, 'approved', ?, 'text', 12, ?, ?)
+        ) VALUES (?, ?, 1, 'tailored_resume', ?, 'approved', ?, 'text', 12, ?, ?)
         """,
         (
-            url,
+            LOCAL_TENANT,
+            _job_id_for(url),
             f"resume-{url}",
             f"/tmp/{url.rsplit('/', 1)[-1]}.txt",
             json.dumps(metadata),
@@ -525,11 +566,12 @@ def _record_replacement_material_metadata(conn: sqlite3.Connection, url: str) ->
     conn.execute(
         """
         INSERT INTO job_materials (
-            job_url, generation, tenant_id, status, created_at, updated_at, metadata_json
-        ) VALUES (?, 2, 'local', 'resume_approved', ?, ?, ?)
+            tenant_id, job_id, generation, status, created_at, updated_at, metadata_json
+        ) VALUES (?, ?, 2, 'resume_approved', ?, ?, ?)
         """,
         (
-            url,
+            LOCAL_TENANT,
+            _job_id_for(url),
             utc_now(),
             utc_now(),
             json.dumps({"source": "resume_review_draft", "base_generation": 1}),
@@ -538,12 +580,13 @@ def _record_replacement_material_metadata(conn: sqlite3.Connection, url: str) ->
     conn.execute(
         """
         INSERT INTO job_materials_artifacts (
-            job_url, generation, artifact_type, artifact_id, status, path,
+            tenant_id, job_id, generation, artifact_type, artifact_id, status, path,
             render_format, size_bytes, metadata_json, created_at
-        ) VALUES (?, 2, 'tailored_resume', ?, 'approved', ?, 'text', 12, ?, ?)
+        ) VALUES (?, ?, 2, 'tailored_resume', ?, 'approved', ?, 'text', 12, ?, ?)
         """,
         (
-            url,
+            LOCAL_TENANT,
+            _job_id_for(url),
             f"replacement-{url}",
             f"/tmp/{url.rsplit('/', 1)[-1]}-replacement.txt",
             json.dumps(
@@ -562,13 +605,14 @@ def _record_suggestion(conn: sqlite3.Connection, index: int, status: str) -> Non
     conn.execute(
         """
         INSERT INTO application_outcome_suggestions (
-            tenant_id, suggestion_id, job_key, suggested_kind, confidence, rationale,
+            tenant_id, suggestion_id, job_id, suggested_kind, confidence, rationale,
             status, created_at, decided_at, decision
-        ) VALUES ('local', ?, ?, 'recruiter_reply', 0.9, '', ?, ?, ?, ?)
+        ) VALUES (?, ?, ?, 'recruiter_reply', 0.9, '', ?, ?, ?, ?)
         """,
         (
+            LOCAL_TENANT,
             f"suggestion-{index}",
-            f"https://example.com/suggestion-{index}",
+            _job_id_for("https://example.com/live-1"),
             status,
             utc_now(),
             utc_now(),
@@ -798,7 +842,7 @@ def test_outcome_conversion_breaks_template_name_ties_by_id() -> None:
     ] == fixture["expectedTemplateIds"]
 
 
-def test_outcome_conversion_uses_artifact_metadata_without_parent_material_table(
+def test_outcome_conversion_does_not_fallback_without_material_registry(
     conn: sqlite3.Connection,
 ) -> None:
     from jobctrl.infrastructure.gmail.feedback import ensure_application_feedback_tables
@@ -822,9 +866,10 @@ def test_outcome_conversion_uses_artifact_metadata_without_parent_material_table
     conversion = json.loads(_row_value(row, "outcome_conversion_json", "{}"))
 
     by_template = {entry["templateId"]: entry for entry in conversion["byTemplate"]}
-    assert by_template["template-compat"] == {
-        "templateId": "template-compat",
-        "templateName": "Compatibility resume",
+    assert "template-compat" not in by_template
+    assert by_template["unreported"] == {
+        "templateId": "unreported",
+        "templateName": None,
         "applied": 5,
         "reply": 0,
         "interview": 0,
@@ -832,13 +877,19 @@ def test_outcome_conversion_uses_artifact_metadata_without_parent_material_table
         "rejection": 0,
     }
     by_policy = {entry["policyLabel"]: entry for entry in conversion["byPolicy"]}
-    assert by_policy["Policy v7"]["tailoringPolicyVersion"] == 7
-    assert by_policy["Policy v7"]["applied"] == 5
+    assert "Policy v7" not in by_policy
+    assert by_policy["Unreported"]["tailoringPolicyVersion"] is None
+    assert by_policy["Unreported"]["applied"] == 5
 
 
 def test_outcome_conversion_empty_when_no_applied_jobs(conn: sqlite3.Connection) -> None:
     _seed_job(conn, "https://example.com/discovered-only")
-    record_job_event(conn, "https://example.com/discovered-only", "discover", "JobDiscovered")
+    record_job_event(
+        conn,
+        _job_id_for("https://example.com/discovered-only"),
+        "discover",
+        "JobDiscovered",
+    )
     conn.commit()
 
     ProjectionBuilder(conn_factory=lambda: conn).refresh()

--- a/workers/automation/tests/test_dashboard_projection.py
+++ b/workers/automation/tests/test_dashboard_projection.py
@@ -282,6 +282,129 @@ def test_artifact_projection_preserves_material_metadata(conn: sqlite3.Connectio
     assert json.loads(_row_value(registered_pdf, "metadata_json", "{}")) == {}
 
 
+def test_artifact_projection_prunes_unregistered_siblings_after_reopen(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "artifact-refresh.db"
+    conn = init_db(db_path)
+    url = "https://example.com/artifact-refresh"
+    job_id = _seed_job(conn, url)
+    now = utc_now()
+    conn.execute(
+        """
+        INSERT INTO job_materials (
+            tenant_id, job_id, generation, status, created_at, updated_at, metadata_json
+        ) VALUES (?, ?, 1, 'resume_approved', ?, ?, '{}')
+        """,
+        (LOCAL_TENANT, job_id, now, now),
+    )
+    conn.execute(
+        """
+        INSERT INTO job_materials_artifacts (
+            tenant_id, job_id, generation, artifact_type, artifact_id, status, path,
+            render_format, size_bytes, metadata_json, created_at
+        ) VALUES (?, ?, 1, 'tailored_resume', 'registered-resume', 'approved',
+                  '/tmp/registered-resume.txt', 'text', 12, '{}', ?)
+        """,
+        (LOCAL_TENANT, job_id, now),
+    )
+    generic_artifact_id = str(
+        conn.execute(
+            """
+            INSERT INTO job_artifacts (
+                tenant_id, job_id, stage, artifact_type, status, path, created_at,
+                size_bytes
+            ) VALUES (?, ?, 'apply', 'application_log', 'completed',
+                      '/tmp/registered-application.log', ?, 24)
+            """,
+            (LOCAL_TENANT, job_id, now),
+        ).lastrowid
+    )
+    shadowed_generic_artifact_id = str(
+        conn.execute(
+            """
+            INSERT INTO job_artifacts (
+                tenant_id, job_id, stage, artifact_type, status, path, created_at,
+                size_bytes
+            ) VALUES (?, ?, 'tailor', 'tailored_resume', 'completed',
+                      '/tmp/registered-resume.txt', ?, 12)
+            """,
+            (LOCAL_TENANT, job_id, now),
+        ).lastrowid
+    )
+    conn.commit()
+    assert ProjectionBuilder(conn_factory=lambda: conn).refresh() == 1
+
+    conn.execute(
+        """
+        INSERT INTO artifact_list_projections (
+            artifact_id, tenant_id, job_id, job_title, job_employer, artifact_type,
+            status, local_path
+        ) VALUES (?, ?, ?, 'Engineer', 'Unknown company', 'tailored_resume',
+                  'completed', '/tmp/registered-resume.txt')
+        """,
+        (shadowed_generic_artifact_id, LOCAL_TENANT, job_id),
+    )
+    conn.execute(
+        """
+        INSERT INTO artifact_list_projections (
+            artifact_id, tenant_id, job_id, job_title, job_employer, artifact_type,
+            status, local_path, generation
+        ) VALUES ('phantom-resume-pdf', ?, ?, 'Engineer', 'Unknown company',
+                  'resume_pdf', 'approved', '/tmp/registered-resume.pdf', 1)
+        """,
+        (LOCAL_TENANT, job_id),
+    )
+    conn.commit()
+    close_connection(db_path)
+
+    reopened = init_db(db_path)
+    try:
+        assert ProjectionBuilder(conn_factory=lambda: reopened).refresh() == 1
+        rows = reopened.execute(
+            """
+            SELECT artifact_id, artifact_type, local_path
+            FROM artifact_list_projections
+            WHERE tenant_id = ? AND job_id = ?
+            ORDER BY artifact_id
+            """,
+            (LOCAL_TENANT, job_id),
+        ).fetchall()
+        assert [tuple(row) for row in rows] == [
+            (
+                generic_artifact_id,
+                "application_log",
+                "/tmp/registered-application.log",
+            ),
+            ("registered-resume", "tailored_resume", "/tmp/registered-resume.txt"),
+        ]
+    finally:
+        close_connection(db_path)
+
+    reopened_again = init_db(db_path)
+    try:
+        assert ProjectionBuilder(conn_factory=lambda: reopened_again).refresh() == 0
+        rows = reopened_again.execute(
+            """
+            SELECT artifact_id, artifact_type, local_path
+            FROM artifact_list_projections
+            WHERE tenant_id = ? AND job_id = ?
+            ORDER BY artifact_id
+            """,
+            (LOCAL_TENANT, job_id),
+        ).fetchall()
+        assert [tuple(row) for row in rows] == [
+            (
+                generic_artifact_id,
+                "application_log",
+                "/tmp/registered-application.log",
+            ),
+            ("registered-resume", "tailored_resume", "/tmp/registered-resume.txt"),
+        ]
+    finally:
+        close_connection(db_path)
+
+
 def test_artifact_projection_includes_resume_layout_boxes(conn: sqlite3.Connection) -> None:
     url = "https://example.com/materials-layout"
     _seed_job(conn, url)

--- a/workers/automation/tests/test_employer_analysis_projection.py
+++ b/workers/automation/tests/test_employer_analysis_projection.py
@@ -44,6 +44,7 @@ from jobctrl.infrastructure.materials import SqliteEmployerAnalysisRepository
 from jobctrl.infrastructure.projections.projection_builder import ProjectionBuilder
 from jobctrl.infrastructure.scoring import SqliteRequirementFitReportRepository
 
+JOB_ID = JobId("00000000-0000-4000-8000-000000000051")
 JOB_URL = "https://example.com/jobs/event-driven"
 JD = "Senior Event Engineer. Requires 5+ years Python. Kafka is a plus."
 
@@ -53,12 +54,21 @@ def conn(tmp_path) -> Iterator[sqlite3.Connection]:
     db_path = tmp_path / "jobs.db"
     connection = init_db(db_path)
     connection.execute(
-        "INSERT INTO jobs (url, title, site) VALUES (?, ?, ?)",
-        (JOB_URL, "Senior Event Engineer", "example"),
+        """
+        INSERT INTO jobs (tenant_id, job_id, url, title, site)
+        VALUES (?, ?, ?, ?, ?)
+        """,
+        (
+            str(LOCAL_TENANT),
+            str(JOB_ID),
+            JOB_URL,
+            "Senior Event Engineer",
+            "example",
+        ),
     )
     connection.commit()
     yield connection
-    close_connection()
+    close_connection(db_path)
 
 
 def _analysis(generation: int) -> EmployerAnalysis:
@@ -81,7 +91,7 @@ def _analysis(generation: int) -> EmployerAnalysis:
     )
     return EmployerAnalysis.build(
         tenant_id=LOCAL_TENANT,
-        job_id=JobId(JOB_URL),
+        job_id=JOB_ID,
         generation=generation,
         snapshot_hash=compute_snapshot_hash(JD),
         canonical=canonical,
@@ -124,7 +134,7 @@ def _requirement_fit_report(score_version: int) -> RequirementFitReport:
         ),
     )
     return RequirementFitReport(
-        job_id=JOB_URL,
+        job_id=str(JOB_ID),
         score_version=score_version,
         employer_analysis_generation=2,
         profile_snapshot_version=3,
@@ -153,17 +163,19 @@ def test_projection_serves_latest_canonical_analysis_read_model(conn: sqlite3.Co
     builder = ProjectionBuilder(conn_factory=lambda: conn)
     conn.execute(
         """
-        INSERT INTO job_events (job_url, stage, event_type, level, message, occurred_at, payload_json)
-        VALUES (?, 'tailor', 'EmployerAnalyzed', 'info', 'analyzed', ?, '{}')
+        INSERT INTO job_events (
+            tenant_id, job_id, identity_version, stage, event_type,
+            level, message, occurred_at, payload_json
+        ) VALUES (?, ?, 1, 'tailor', 'EmployerAnalyzed', 'info', 'analyzed', ?, '{}')
         """,
-        (JOB_URL, latest.created_at),
+        (str(LOCAL_TENANT), str(JOB_ID), latest.created_at),
     )
     conn.commit()
     builder.refresh()
 
     row = conn.execute(
         "SELECT employer_analysis_json FROM job_detail_projections WHERE job_id = ?",
-        (JOB_URL,),
+        (str(JOB_ID),),
     ).fetchone()
     assert row is not None
     served = json.loads(row["employer_analysis_json"])
@@ -181,17 +193,20 @@ def test_projection_analysis_is_null_when_no_analysis_exists(conn: sqlite3.Conne
     builder = ProjectionBuilder(conn_factory=lambda: conn)
     conn.execute(
         """
-        INSERT INTO job_events (job_url, stage, event_type, level, message, occurred_at, payload_json)
-        VALUES (?, 'score', 'JobScored', 'info', 'scored', '2026-05-04T12:00:00+00:00', '{}')
+        INSERT INTO job_events (
+            tenant_id, job_id, identity_version, stage, event_type,
+            level, message, occurred_at, payload_json
+        ) VALUES (?, ?, 1, 'score', 'JobScored', 'info', 'scored',
+                  '2026-05-04T12:00:00+00:00', '{}')
         """,
-        (JOB_URL,),
+        (str(LOCAL_TENANT), str(JOB_ID)),
     )
     conn.commit()
     builder.refresh()
 
     row = conn.execute(
         "SELECT employer_analysis_json FROM job_detail_projections WHERE job_id = ?",
-        (JOB_URL,),
+        (str(JOB_ID),),
     ).fetchone()
     assert row is not None
     assert row["employer_analysis_json"] is None
@@ -208,17 +223,20 @@ def test_projection_serves_latest_requirement_fit_report_read_model(
     builder = ProjectionBuilder(conn_factory=lambda: conn)
     conn.execute(
         """
-        INSERT INTO job_events (job_url, stage, event_type, level, message, occurred_at, payload_json)
-        VALUES (?, 'score', 'JobScored', 'info', 'scored', '2026-05-04T12:00:00+00:00', '{}')
+        INSERT INTO job_events (
+            tenant_id, job_id, identity_version, stage, event_type,
+            level, message, occurred_at, payload_json
+        ) VALUES (?, ?, 1, 'score', 'JobScored', 'info', 'scored',
+                  '2026-05-04T12:00:00+00:00', '{}')
         """,
-        (JOB_URL,),
+        (str(LOCAL_TENANT), str(JOB_ID)),
     )
     conn.commit()
     builder.refresh()
 
     row = conn.execute(
         "SELECT requirement_fit_report_json FROM job_detail_projections WHERE job_id = ?",
-        (JOB_URL,),
+        (str(JOB_ID),),
     ).fetchone()
     assert row is not None
     served = json.loads(row["requirement_fit_report_json"])
@@ -235,17 +253,20 @@ def test_projection_requirement_fit_report_is_null_when_no_report_exists(
     builder = ProjectionBuilder(conn_factory=lambda: conn)
     conn.execute(
         """
-        INSERT INTO job_events (job_url, stage, event_type, level, message, occurred_at, payload_json)
-        VALUES (?, 'score', 'JobScored', 'info', 'scored', '2026-05-04T12:00:00+00:00', '{}')
+        INSERT INTO job_events (
+            tenant_id, job_id, identity_version, stage, event_type,
+            level, message, occurred_at, payload_json
+        ) VALUES (?, ?, 1, 'score', 'JobScored', 'info', 'scored',
+                  '2026-05-04T12:00:00+00:00', '{}')
         """,
-        (JOB_URL,),
+        (str(LOCAL_TENANT), str(JOB_ID)),
     )
     conn.commit()
     builder.refresh()
 
     row = conn.execute(
         "SELECT requirement_fit_report_json FROM job_detail_projections WHERE job_id = ?",
-        (JOB_URL,),
+        (str(JOB_ID),),
     ).fetchone()
     assert row is not None
     assert row["requirement_fit_report_json"] is None

--- a/workers/automation/tests/test_job_list_projection.py
+++ b/workers/automation/tests/test_job_list_projection.py
@@ -4,11 +4,14 @@ from __future__ import annotations
 
 import json
 import sqlite3
+import uuid
 from pathlib import Path
 
 import pytest
 
 from jobctrl.database import close_connection, ensure_projection_tables_in_db, init_db
+from jobctrl.domain.identifiers import JobId
+from jobctrl.domain.tenant import LOCAL_TENANT
 from jobctrl.infrastructure.events.watermark import SqliteEventWatermarkRepository
 from jobctrl.infrastructure.projections.projection_builder import (
     PROJECTION_NAME,
@@ -25,14 +28,28 @@ def conn(tmp_path: Path) -> sqlite3.Connection:
     close_connection(db_path)
 
 
-def _seed_job(conn: sqlite3.Connection, url: str, *, title: str = "Engineer", site: str = "ExampleCo") -> None:
+def _job_id_for(url: str) -> JobId:
+    return JobId(str(uuid.uuid5(uuid.NAMESPACE_URL, f"job-list-projection:{url}")))
+
+
+def _seed_job(
+    conn: sqlite3.Connection,
+    url: str,
+    *,
+    title: str = "Engineer",
+    site: str = "ExampleCo",
+) -> JobId:
+    job_id = _job_id_for(url)
     conn.execute(
         """
-        INSERT INTO jobs (url, title, site, strategy, location, salary,
-                          discovered_at, application_url, description)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        INSERT INTO jobs (
+            tenant_id, job_id, url, title, site, strategy, location, salary,
+            discovered_at, application_url, description
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """,
         (
+            str(LOCAL_TENANT),
+            str(job_id),
             url,
             title,
             site,
@@ -45,6 +62,7 @@ def _seed_job(conn: sqlite3.Connection, url: str, *, title: str = "Engineer", si
         ),
     )
     conn.commit()
+    return job_id
 
 
 def _row_value(row, key, default=None):
@@ -116,8 +134,8 @@ def _replace_score_evidence_projection_schema_with_legacy_shape(
 
 def test_discovered_job_appears_in_projection(conn: sqlite3.Connection) -> None:
     url = "https://example.com/jobs/1"
-    _seed_job(conn, url)
-    record_job_event(conn, url, "discover", "JobDiscovered", message="discovered")
+    job_id = _seed_job(conn, url)
+    record_job_event(conn, job_id, "discover", "JobDiscovered", message="discovered")
     conn.commit()
 
     builder = ProjectionBuilder(conn_factory=lambda: conn)
@@ -125,7 +143,7 @@ def test_discovered_job_appears_in_projection(conn: sqlite3.Connection) -> None:
 
     assert refreshed >= 1
     row = conn.execute(
-        "SELECT * FROM job_list_projections WHERE job_id = ?", (url,)
+        "SELECT * FROM job_list_projections WHERE job_id = ?", (str(job_id),)
     ).fetchone()
     assert row is not None
     assert _row_value(row, "title") == "Engineer"
@@ -137,22 +155,22 @@ def test_discovered_job_appears_in_projection(conn: sqlite3.Connection) -> None:
 
 def test_pipeline_progress_keeps_internal_preparation_inside_discover_list_stage(conn: sqlite3.Connection) -> None:
     url = "https://example.com/jobs/2"
-    _seed_job(conn, url, title="Platform Engineer")
+    job_id = _seed_job(conn, url, title="Platform Engineer")
     builder = ProjectionBuilder(conn_factory=lambda: conn)
 
-    set_stage_state(conn, url, "discover", "succeeded", finished_at=utc_now())
-    record_job_event(conn, url, "discover", "StageCompleted")
+    set_stage_state(conn, job_id, "discover", "succeeded", finished_at=utc_now())
+    record_job_event(conn, job_id, "discover", "StageCompleted")
     conn.commit()
     builder.refresh()
 
-    set_stage_state(conn, url, "enrich", "succeeded", finished_at=utc_now())
-    record_job_event(conn, url, "enrich", "StageCompleted")
+    set_stage_state(conn, job_id, "enrich", "succeeded", finished_at=utc_now())
+    record_job_event(conn, job_id, "enrich", "StageCompleted")
     conn.commit()
     builder.refresh()
 
     row = conn.execute(
         "SELECT current_stage, current_substage, current_state FROM job_list_projections WHERE job_id = ?",
-        (url,),
+        (str(job_id),),
     ).fetchone()
     assert _row_value(row, "current_stage") == "discover"
     assert _row_value(row, "current_substage") == "score"
@@ -160,7 +178,7 @@ def test_pipeline_progress_keeps_internal_preparation_inside_discover_list_stage
 
     detail = conn.execute(
         "SELECT stages_json FROM job_detail_projections WHERE job_id = ?",
-        (url,),
+        (str(job_id),),
     ).fetchone()
     stages = json.loads(_row_value(detail, "stages_json", "[]"))
     score_stage = next(stage for stage in stages if stage["stage"] == "score")
@@ -169,19 +187,31 @@ def test_pipeline_progress_keeps_internal_preparation_inside_discover_list_stage
 
 def test_workflow_scoped_stage_event_refreshes_stale_stage_projection(conn: sqlite3.Connection) -> None:
     url = "https://example.com/jobs/workflow-scoped-stage"
-    _seed_job(conn, url, title="Workflow Scoped Engineer")
+    job_id = _seed_job(conn, url, title="Workflow Scoped Engineer")
     builder = ProjectionBuilder(conn_factory=lambda: conn)
 
-    record_job_event(conn, url, "discover", "JobDiscovered", message="discovered")
+    record_job_event(conn, job_id, "discover", "JobDiscovered", message="discovered")
     conn.commit()
     builder.refresh()
     conn.execute(
         "UPDATE job_list_projections SET last_updated_at = ? WHERE job_id = ?",
-        ("2026-05-04T12:00:00+00:00", url),
+        ("2026-05-04T12:00:00+00:00", str(job_id)),
     )
 
-    set_stage_state(conn, url, "discover", "succeeded", finished_at="2026-05-04T13:00:00+00:00")
-    set_stage_state(conn, url, "enrich", "succeeded", finished_at="2026-05-04T13:05:00+00:00")
+    set_stage_state(
+        conn,
+        job_id,
+        "discover",
+        "succeeded",
+        finished_at="2026-05-04T13:00:00+00:00",
+    )
+    set_stage_state(
+        conn,
+        job_id,
+        "enrich",
+        "succeeded",
+        finished_at="2026-05-04T13:05:00+00:00",
+    )
     record_job_event(
         conn,
         None,
@@ -197,7 +227,7 @@ def test_workflow_scoped_stage_event_refreshes_stale_stage_projection(conn: sqli
     assert refreshed >= 1
     row = conn.execute(
         "SELECT current_stage, current_substage, current_state FROM job_list_projections WHERE job_id = ?",
-        (url,),
+        (str(job_id),),
     ).fetchone()
     assert _row_value(row, "current_stage") == "discover"
     assert _row_value(row, "current_substage") == "score"
@@ -205,7 +235,7 @@ def test_workflow_scoped_stage_event_refreshes_stale_stage_projection(conn: sqli
 
     detail = conn.execute(
         "SELECT stages_json FROM job_detail_projections WHERE job_id = ?",
-        (url,),
+        (str(job_id),),
     ).fetchone()
     stages = json.loads(_row_value(detail, "stages_json", "[]"))
     assert next(stage for stage in stages if stage["stage"] == "discover")["state"] == "succeeded"
@@ -215,21 +245,41 @@ def test_workflow_scoped_stage_event_refreshes_stale_stage_projection(conn: sqli
 
 def test_cover_progress_moves_product_stage_to_apply_when_resume_exists(conn: sqlite3.Connection) -> None:
     url = "https://example.com/jobs/cover-pending"
-    _seed_job(conn, url, title="Cover Pending Engineer")
+    job_id = _seed_job(conn, url, title="Cover Pending Engineer")
+    created_at = utc_now()
     conn.execute(
-        "UPDATE jobs SET tailored_resume_path = ?, tailored_at = ? WHERE url = ?",
-        ("/tmp/tailored-resume.txt", utc_now(), url),
+        """
+        INSERT INTO job_materials (
+            tenant_id, job_id, generation, status, created_at, updated_at
+        ) VALUES (?, ?, 1, 'approved', ?, ?)
+        """,
+        (str(LOCAL_TENANT), str(job_id), created_at, created_at),
+    )
+    conn.execute(
+        """
+        INSERT INTO job_materials_artifacts (
+            tenant_id, job_id, generation, artifact_type, artifact_id,
+            status, path, render_format, created_at
+        ) VALUES (?, ?, 1, 'tailored_resume', ?, 'approved', ?, 'text', ?)
+        """,
+        (
+            str(LOCAL_TENANT),
+            str(job_id),
+            f"{job_id}:tailored_resume",
+            "/tmp/tailored-resume.txt",
+            created_at,
+        ),
     )
     for stage in ("discover", "enrich", "score", "tailor"):
-        set_stage_state(conn, url, stage, "succeeded", finished_at=utc_now())
-    set_stage_state(conn, url, "cover", "pending", validate_transition=False)
+        set_stage_state(conn, job_id, stage, "succeeded", finished_at=utc_now())
+    set_stage_state(conn, job_id, "cover", "pending", validate_transition=False)
     conn.commit()
 
     ProjectionBuilder(conn_factory=lambda: conn).refresh()
 
     row = conn.execute(
         "SELECT current_stage, current_substage, current_state FROM job_list_projections WHERE job_id = ?",
-        (url,),
+        (str(job_id),),
     ).fetchone()
     assert _row_value(row, "current_stage") == "apply"
     assert _row_value(row, "current_substage") == "cover"
@@ -238,12 +288,12 @@ def test_cover_progress_moves_product_stage_to_apply_when_resume_exists(conn: sq
 
 def test_stage_projection_preserves_non_retryable_failures(conn: sqlite3.Connection) -> None:
     url = "https://example.com/jobs/non-retryable"
-    _seed_job(conn, url, title="Closed Posting")
+    job_id = _seed_job(conn, url, title="Closed Posting")
 
-    set_stage_state(conn, url, "discover", "succeeded", finished_at=utc_now())
+    set_stage_state(conn, job_id, "discover", "succeeded", finished_at=utc_now())
     set_stage_state(
         conn,
-        url,
+        job_id,
         "enrich",
         "failed",
         attempt_count=1,
@@ -258,7 +308,7 @@ def test_stage_projection_preserves_non_retryable_failures(conn: sqlite3.Connect
 
     detail = conn.execute(
         "SELECT stages_json FROM job_detail_projections WHERE job_id = ?",
-        (url,),
+        (str(job_id),),
     ).fetchone()
     stages = json.loads(_row_value(detail, "stages_json", "[]"))
     enrich_stage = next(stage for stage in stages if stage["stage"] == "enrich")
@@ -268,17 +318,17 @@ def test_stage_projection_preserves_non_retryable_failures(conn: sqlite3.Connect
 
 def test_score_event_populates_fit_score(conn: sqlite3.Connection) -> None:
     url = "https://example.com/jobs/3"
-    _seed_job(conn, url)
+    job_id = _seed_job(conn, url)
     conn.execute(
         """
-        INSERT INTO job_scores (job_url, version, tenant_id, fit_score,
+        INSERT INTO job_scores (tenant_id, job_id, version, fit_score,
                                 breakdown_json, keywords_json, scored_at)
         VALUES (?, ?, ?, ?, ?, ?, ?)
         """,
         (
-            url,
+            str(LOCAL_TENANT),
+            str(job_id),
             1,
-            "local",
             8,
             json.dumps(
                 {
@@ -292,7 +342,7 @@ def test_score_event_populates_fit_score(conn: sqlite3.Connection) -> None:
             utc_now(),
         ),
     )
-    record_job_event(conn, url, "score", "JobScored")
+    record_job_event(conn, job_id, "score", "JobScored")
     conn.commit()
 
     ProjectionBuilder(conn_factory=lambda: conn).refresh()
@@ -303,7 +353,7 @@ def test_score_event_populates_fit_score(conn: sqlite3.Connection) -> None:
                score_reasoning, score_version, scored_at
         FROM job_list_projections WHERE job_id = ?
         """,
-        (url,),
+        (str(job_id),),
     ).fetchone()
     assert _row_value(row, "fit_score") == 8
     assert _row_value(row, "score_reasoning") == "Strong fit"
@@ -328,7 +378,7 @@ def test_score_event_populates_fit_score(conn: sqlite3.Connection) -> None:
         SELECT score_breakdown_json, score_keywords_json, score_version, scored_at
         FROM job_detail_projections WHERE job_id = ?
         """,
-        (url,),
+        (str(job_id),),
     ).fetchone()
     assert json.loads(_row_value(detail, "score_breakdown_json"))["technicalFit"] == 9
     assert json.loads(_row_value(detail, "score_keywords_json")) == ["python", "fastapi"]
@@ -340,17 +390,17 @@ def test_score_evidence_schema_migration_backfills_existing_projection(
     conn: sqlite3.Connection,
 ) -> None:
     url = "https://example.com/jobs/scored-before-migration"
-    _seed_job(conn, url)
+    job_id = _seed_job(conn, url)
     conn.execute(
         """
-        INSERT INTO job_scores (job_url, version, tenant_id, fit_score,
+        INSERT INTO job_scores (tenant_id, job_id, version, fit_score,
                                 breakdown_json, keywords_json, scored_at)
         VALUES (?, ?, ?, ?, ?, ?, ?)
         """,
         (
-            url,
+            str(LOCAL_TENANT),
+            str(job_id),
             1,
-            "local",
             9,
             json.dumps(
                 {
@@ -374,7 +424,7 @@ def test_score_evidence_schema_migration_backfills_existing_projection(
             "2026-05-05T10:00:00+00:00",
         ),
     )
-    record_job_event(conn, url, "score", "JobScored")
+    record_job_event(conn, job_id, "score", "JobScored")
     latest_event_id = conn.execute("SELECT MAX(event_id) FROM job_events").fetchone()[0]
     _replace_score_evidence_projection_schema_with_legacy_shape(conn)
     conn.execute(
@@ -383,7 +433,14 @@ def test_score_evidence_schema_migration_backfills_existing_projection(
             tenant_id, job_id, title, employer, fit_score, score_reasoning
         ) VALUES (?, ?, ?, ?, ?, ?)
         """,
-        ("local", url, "Engineer", "ExampleCo", 9, "Legacy reasoning"),
+        (
+            str(LOCAL_TENANT),
+            str(job_id),
+            "Engineer",
+            "ExampleCo",
+            9,
+            "Legacy reasoning",
+        ),
     )
     conn.execute(
         """
@@ -391,7 +448,12 @@ def test_score_evidence_schema_migration_backfills_existing_projection(
             tenant_id, job_id, description_preview, score_reasoning
         ) VALUES (?, ?, ?, ?)
         """,
-        ("local", url, "Short job description", "Legacy reasoning"),
+        (
+            str(LOCAL_TENANT),
+            str(job_id),
+            "Short job description",
+            "Legacy reasoning",
+        ),
     )
     conn.execute(
         "INSERT INTO dashboard_projections (tenant_id, generated_at) VALUES (?, ?)",
@@ -409,7 +471,7 @@ def test_score_evidence_schema_migration_backfills_existing_projection(
         SELECT score_breakdown_json, score_keywords_json, score_version, scored_at
         FROM job_list_projections WHERE job_id = ?
         """,
-        (url,),
+        (str(job_id),),
     ).fetchone()
     assert json.loads(_row_value(row, "score_breakdown_json")) == {
         "technicalFit": 8,
@@ -434,19 +496,19 @@ def test_score_evidence_schema_migration_backfills_existing_projection(
 
 def test_apply_run_succeeded_marks_applied(conn: sqlite3.Connection) -> None:
     url = "https://example.com/jobs/4"
-    _seed_job(conn, url)
+    job_id = _seed_job(conn, url)
     started = "2026-05-04T13:00:00+00:00"
     finished = "2026-05-04T13:05:00+00:00"
     record_job_event(
         conn,
-        url,
+        job_id,
         "apply",
         "ApplyRunStarted",
         payload={"run_id": "run-1", "started_at": started},
     )
     record_job_event(
         conn,
-        url,
+        job_id,
         "apply",
         "ApplicationSubmitted",
         payload={"run_id": "run-1", "finished_at": finished, "result": "applied"},
@@ -457,7 +519,7 @@ def test_apply_run_succeeded_marks_applied(conn: sqlite3.Connection) -> None:
 
     row = conn.execute(
         "SELECT apply_status, applied_at FROM job_list_projections WHERE job_id = ?",
-        (url,),
+        (str(job_id),),
     ).fetchone()
     assert _row_value(row, "apply_status") == "applied"
     assert _row_value(row, "applied_at") == finished
@@ -465,60 +527,54 @@ def test_apply_run_succeeded_marks_applied(conn: sqlite3.Connection) -> None:
 
 def test_soft_deleted_job_carries_deleted_at(conn: sqlite3.Connection) -> None:
     url = "https://example.com/jobs/5"
-    _seed_job(conn, url)
-    conn.execute(
-        """
-        CREATE TABLE IF NOT EXISTS jobctrl_deleted_jobs (
-            job_url     TEXT PRIMARY KEY,
-            deleted_at  TEXT NOT NULL,
-            reason      TEXT,
-            restored_at TEXT
-        )
-        """
-    )
+    job_id = _seed_job(conn, url)
     deleted_at = "2026-05-04T14:00:00+00:00"
     conn.execute(
-        "INSERT INTO jobctrl_deleted_jobs (job_url, deleted_at, reason, restored_at) "
-        "VALUES (?, ?, ?, NULL)",
-        (url, deleted_at, "test"),
+        """
+        INSERT INTO jobctrl_deleted_jobs (
+            tenant_id, job_id, deleted_at, reason, restored_at
+        ) VALUES (?, ?, ?, ?, NULL)
+        """,
+        (str(LOCAL_TENANT), str(job_id), deleted_at, "test"),
     )
-    record_job_event(conn, url, "discover", "JobDeleted")
+    record_job_event(conn, job_id, "discover", "JobDeleted")
     conn.commit()
 
     ProjectionBuilder(conn_factory=lambda: conn).refresh()
 
     row = conn.execute(
-        "SELECT deleted_at FROM job_list_projections WHERE job_id = ?", (url,)
+        "SELECT deleted_at FROM job_list_projections WHERE job_id = ?",
+        (str(job_id),),
     ).fetchone()
     assert _row_value(row, "deleted_at") == deleted_at
 
 
 def test_stale_restore_before_delete_still_carries_deleted_at(conn: sqlite3.Connection) -> None:
     url = "https://example.com/jobs/stale-restore"
-    _seed_job(conn, url)
-    conn.execute(
-        """
-        CREATE TABLE IF NOT EXISTS jobctrl_deleted_jobs (
-            job_url     TEXT PRIMARY KEY,
-            deleted_at  TEXT NOT NULL,
-            reason      TEXT,
-            restored_at TEXT
-        )
-        """
-    )
+    job_id = _seed_job(conn, url)
     deleted_at = "2026-05-25T23:10:33.870522+00:00"
     conn.execute(
-        "INSERT INTO jobctrl_deleted_jobs (job_url, deleted_at, reason, restored_at) "
-        "VALUES (?, ?, ?, ?)",
-        (url, deleted_at, "discovery hygiene rejected source", "2026-05-25T21:35:55.879345+00:00"),
+        """
+        INSERT INTO jobctrl_deleted_jobs (
+            tenant_id, job_id, deleted_at, reason, restored_at
+        ) VALUES (?, ?, ?, ?, ?)
+        """,
+        (
+            str(LOCAL_TENANT),
+            str(job_id),
+            deleted_at,
+            "discovery hygiene rejected source",
+            "2026-05-25T21:35:55.879345+00:00",
+        ),
     )
-    record_job_event(conn, url, "discover", "JobDeleted")
+    record_job_event(conn, job_id, "discover", "JobDeleted")
     conn.commit()
 
     ProjectionBuilder(conn_factory=lambda: conn).refresh()
 
     row = conn.execute(
-        "SELECT deleted_at FROM job_list_projections WHERE job_id = ?", (url,)
+        "SELECT deleted_at FROM job_list_projections WHERE job_id = ?",
+        (str(job_id),),
     ).fetchone()
     assert _row_value(row, "deleted_at") == deleted_at
 
@@ -531,21 +587,21 @@ def test_initial_backfill_picks_up_pre_event_history(conn: sqlite3.Connection) -
     isn't blank for legacy databases that pre-date event-driven writes.
     """
     url = "https://example.com/jobs/legacy"
-    _seed_job(conn, url, title="Legacy Engineer")
+    job_id = _seed_job(conn, url, title="Legacy Engineer")
     # No record_job_event call — pure backfill path.
 
     ProjectionBuilder(conn_factory=lambda: conn).refresh()
 
     row = conn.execute(
-        "SELECT title FROM job_list_projections WHERE job_id = ?", (url,)
+        "SELECT title FROM job_list_projections WHERE job_id = ?", (str(job_id),)
     ).fetchone()
     assert _row_value(row, "title") == "Legacy Engineer"
 
 
 def test_refresh_is_idempotent(conn: sqlite3.Connection) -> None:
     url = "https://example.com/jobs/6"
-    _seed_job(conn, url)
-    record_job_event(conn, url, "discover", "JobDiscovered")
+    job_id = _seed_job(conn, url)
+    record_job_event(conn, job_id, "discover", "JobDiscovered")
     conn.commit()
 
     builder = ProjectionBuilder(conn_factory=lambda: conn)
@@ -554,6 +610,7 @@ def test_refresh_is_idempotent(conn: sqlite3.Connection) -> None:
     builder.refresh()
 
     rows = conn.execute(
-        "SELECT COUNT(*) FROM job_list_projections WHERE job_id = ?", (url,)
+        "SELECT COUNT(*) FROM job_list_projections WHERE job_id = ?",
+        (str(job_id),),
     ).fetchone()
     assert rows[0] == 1

--- a/workers/automation/tests/test_pipeline_step_projection.py
+++ b/workers/automation/tests/test_pipeline_step_projection.py
@@ -35,12 +35,13 @@ def _seed_events(conn: sqlite3.Connection, fixture: dict[str, Any]) -> None:
         conn.execute(
             """
             INSERT INTO job_events (
-                event_id, job_url, stage, event_type, level, message,
-                occurred_at, payload_json
-            ) VALUES (?, NULL, 'workflow', ?, 'info', NULL, ?, ?)
+                event_id, tenant_id, job_id, identity_version, stage,
+                event_type, level, message, occurred_at, payload_json
+            ) VALUES (?, ?, NULL, 1, 'workflow', ?, 'info', NULL, ?, ?)
             """,
             (
                 event_id,
+                str(LOCAL_TENANT),
                 event["eventType"],
                 event["occurredAt"],
                 json.dumps(event["payload"], sort_keys=True),

--- a/workers/automation/tests/test_v7_job_list_projection_rows.py
+++ b/workers/automation/tests/test_v7_job_list_projection_rows.py
@@ -303,7 +303,8 @@ def test_serializes_every_v7_column_from_canonical_uuid_rows() -> None:
         assert row["job_id"] != _JOB_URL
         assert "STALE URL CACHE" not in json.dumps(row)
         assert row["title"] == "Platform Engineer"
-        assert row["employer"] == "Exampleco"
+        assert row["employer"] == "Unknown company"
+        assert row["source"] == "greenhouse"
         assert row["location"] == "Community of Madrid, Spain (Remote)"
         assert row["full_description"] == "Canonical enriched description"
         assert row["fit_score"] == 8

--- a/workers/automation/tests/test_v7_projection_builder_event_identity.py
+++ b/workers/automation/tests/test_v7_projection_builder_event_identity.py
@@ -1,0 +1,370 @@
+"""Exact-v7 event-identity coverage for the projection refresh boundary."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+
+from jobctrl.domain.identifiers import JobId
+from jobctrl.domain.tenant import LOCAL_TENANT, TenantId
+from jobctrl.infrastructure.events.in_process_bus import InProcessEventBus
+from jobctrl.infrastructure.events.watermark import SqliteEventWatermarkRepository
+from jobctrl.infrastructure.migrations.schema_v7 import create_exact_v7_schema
+from jobctrl.infrastructure.projections.projection_builder import (
+    PROJECTION_NAME,
+    ProjectionBuilder,
+)
+from jobctrl.state import record_job_event
+
+
+_INERT_CONTEXT = {"userContext": "Attack vectors:\nPrompt injection"}
+_SHARED_URL = "https://jobs.example.test/platform-engineer"
+_LOCAL_JOB_ID = JobId("90000000-0000-4000-8000-000000000001")
+_OTHER_JOB_ID = JobId("90000000-0000-4000-8000-000000000002")
+_TIMESTAMP = "2026-07-31T12:00:00+00:00"
+
+
+def _insert_job_with_materials(
+    conn: sqlite3.Connection, tenant_id: TenantId, job_id: JobId
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO jobs (tenant_id, job_id, url, title, company, site, discovered_at)
+        VALUES (?, ?, ?, 'Platform Engineer', 'Example', 'example', ?)
+        """,
+        (str(tenant_id), str(job_id), _SHARED_URL, _TIMESTAMP),
+    )
+    conn.execute(
+        """
+        INSERT INTO job_enrichments (
+            tenant_id, job_id, current_status, full_description, application_url, updated_at
+        ) VALUES (?, ?, 'enriched', 'Build reliable systems.', ?, ?)
+        """,
+        (str(tenant_id), str(job_id), f"{_SHARED_URL}/apply", _TIMESTAMP),
+    )
+    conn.execute(
+        """
+        INSERT INTO job_materials (
+            tenant_id, job_id, generation, status, created_at, updated_at
+        ) VALUES (?, ?, 1, 'approved', ?, ?)
+        """,
+        (str(tenant_id), str(job_id), _TIMESTAMP, _TIMESTAMP),
+    )
+    conn.execute(
+        """
+        INSERT INTO job_materials_artifacts (
+            tenant_id, job_id, generation, artifact_type, artifact_id,
+            status, path, render_format, created_at
+        ) VALUES (?, ?, 1, 'tailored_resume', ?, 'approved', ?, 'text', ?)
+        """,
+        (
+            str(tenant_id),
+            str(job_id),
+            f"{job_id}:tailored_resume",
+            f"/tmp/{job_id}-tailored-resume.txt",
+            _TIMESTAMP,
+        ),
+    )
+
+
+def _record_apply_run(
+    conn: sqlite3.Connection, tenant_id: TenantId, job_id: JobId, run_id: str
+) -> None:
+    record_job_event(
+        conn,
+        job_id,
+        "apply",
+        "ApplyRunStarted",
+        tenant_id=tenant_id,
+        occurred_at=_TIMESTAMP,
+        payload={"run_id": run_id, "started_at": _TIMESTAMP, **_INERT_CONTEXT},
+        publisher=InProcessEventBus(),
+    )
+    record_job_event(
+        conn,
+        job_id,
+        "apply",
+        "ApplicationSubmitted",
+        tenant_id=tenant_id,
+        occurred_at="2026-07-31T12:01:00+00:00",
+        payload={
+            "run_id": run_id,
+            "finished_at": "2026-07-31T12:01:00+00:00",
+            "duration_ms": 60_000,
+            **_INERT_CONTEXT,
+        },
+        publisher=InProcessEventBus(),
+    )
+
+
+def test_refresh_scopes_exact_v7_source_events_by_tenant() -> None:
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys = ON")
+    create_exact_v7_schema(conn)
+
+    record_job_event(
+        conn,
+        None,
+        "discover",
+        "DiscoveryRunStarted",
+        tenant_id=TenantId("other"),
+        payload={
+            "run_id": "other-run",
+            "source_ids": ["greenhouse:other"],
+            **_INERT_CONTEXT,
+        },
+        publisher=InProcessEventBus(),
+    )
+    record_job_event(
+        conn,
+        None,
+        "discover",
+        "DiscoveryRunStarted",
+        tenant_id=LOCAL_TENANT,
+        payload={
+            "run_id": "local-run",
+            "source_ids": ["greenhouse:local"],
+            **_INERT_CONTEXT,
+        },
+        publisher=InProcessEventBus(),
+    )
+    conn.commit()
+
+    assert ProjectionBuilder(conn_factory=lambda: conn).refresh() == 0
+
+    local_stats = conn.execute(
+        "SELECT source_id FROM source_quality_stats WHERE tenant_id = ?",
+        (str(LOCAL_TENANT),),
+    ).fetchall()
+    payload = json.loads(
+        conn.execute(
+            "SELECT payload_json FROM job_events WHERE tenant_id = ?",
+            (str(LOCAL_TENANT),),
+        ).fetchone()[0]
+    )
+
+    assert [row[0] for row in local_stats] == ["greenhouse:local"]
+    assert payload["userContext"] == "Attack vectors:\nPrompt injection"
+    assert SqliteEventWatermarkRepository(conn).get(PROJECTION_NAME) == 2
+
+    other_builder = ProjectionBuilder(
+        conn_factory=lambda: conn,
+        tenant_id=TenantId("other"),
+    )
+    assert other_builder.refresh() == 0
+    assert SqliteEventWatermarkRepository(conn).get(
+        f"{PROJECTION_NAME}:other"
+    ) == 1
+
+
+def test_refresh_projects_exact_job_artifacts_and_apply_runs_by_tenant_job_id() -> None:
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys = ON")
+    create_exact_v7_schema(conn)
+    other_tenant = TenantId("other")
+    _insert_job_with_materials(conn, LOCAL_TENANT, _LOCAL_JOB_ID)
+    _insert_job_with_materials(conn, other_tenant, _OTHER_JOB_ID)
+    _record_apply_run(conn, other_tenant, _OTHER_JOB_ID, "other-apply")
+    _record_apply_run(conn, LOCAL_TENANT, _LOCAL_JOB_ID, "local-apply")
+    conn.commit()
+
+    assert ProjectionBuilder(conn_factory=lambda: conn).refresh() == 1
+
+    local_job = conn.execute(
+        """
+        SELECT job_id, employer, source, has_resume, apply_status
+        FROM job_list_projections
+        WHERE tenant_id = ?
+        """,
+        (str(LOCAL_TENANT),),
+    ).fetchall()
+    local_artifacts = conn.execute(
+        """
+        SELECT job_id, local_path
+        FROM artifact_list_projections
+        WHERE tenant_id = ?
+        """,
+        (str(LOCAL_TENANT),),
+    ).fetchall()
+    local_apply_run = conn.execute(
+        """
+        SELECT run_id, job_id, job_employer, status, result
+        FROM apply_run_projections
+        WHERE tenant_id = ?
+        """,
+        (str(LOCAL_TENANT),),
+    ).fetchall()
+
+    assert [tuple(row) for row in local_job] == [
+        (str(_LOCAL_JOB_ID), "Example", "example", 1, "applied")
+    ]
+    assert [tuple(row) for row in local_artifacts] == [
+        (str(_LOCAL_JOB_ID), f"/tmp/{_LOCAL_JOB_ID}-tailored-resume.txt")
+    ]
+    assert [tuple(row) for row in local_apply_run] == [
+        ("local-apply", str(_LOCAL_JOB_ID), "Example", "succeeded", "applied")
+    ]
+
+
+def test_refresh_never_invents_pdf_artifacts_from_registered_text_paths() -> None:
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys = ON")
+    create_exact_v7_schema(conn)
+    _insert_job_with_materials(conn, LOCAL_TENANT, _LOCAL_JOB_ID)
+    conn.execute(
+        """
+        UPDATE job_materials_artifacts
+        SET artifact_type = 'tailored_resume_txt',
+            artifact_id = ?
+        WHERE tenant_id = ? AND job_id = ?
+        """,
+        (
+            f"{_LOCAL_JOB_ID}:tailored_resume_txt",
+            str(LOCAL_TENANT),
+            str(_LOCAL_JOB_ID),
+        ),
+    )
+    _record_apply_run(conn, LOCAL_TENANT, _LOCAL_JOB_ID, "local-apply")
+    conn.commit()
+
+    assert ProjectionBuilder(conn_factory=lambda: conn).refresh() == 1
+
+    artifacts = conn.execute(
+        """
+        SELECT artifact_id, artifact_type, local_path
+        FROM artifact_list_projections
+        WHERE tenant_id = ? AND job_id = ?
+        ORDER BY artifact_id
+        """,
+        (str(LOCAL_TENANT), str(_LOCAL_JOB_ID)),
+    ).fetchall()
+
+    assert [tuple(row) for row in artifacts] == [
+        (
+            f"{_LOCAL_JOB_ID}:tailored_resume_txt",
+            "tailored_resume_txt",
+            f"/tmp/{_LOCAL_JOB_ID}-tailored-resume.txt",
+        )
+    ]
+
+
+def test_refresh_uses_explicit_unknown_when_canonical_company_is_absent() -> None:
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys = ON")
+    create_exact_v7_schema(conn)
+    _insert_job_with_materials(conn, LOCAL_TENANT, _LOCAL_JOB_ID)
+    conn.execute(
+        """
+        UPDATE jobs
+        SET company = NULL,
+            site = 'greenhouse',
+            url = 'https://boards.greenhouse.io/url-derived-company/jobs/42'
+        WHERE tenant_id = ? AND job_id = ?
+        """,
+        (str(LOCAL_TENANT), str(_LOCAL_JOB_ID)),
+    )
+    conn.execute(
+        """
+        UPDATE job_enrichments
+        SET application_url = 'https://jobs.lever.co/application-derived-company/42'
+        WHERE tenant_id = ? AND job_id = ?
+        """,
+        (str(LOCAL_TENANT), str(_LOCAL_JOB_ID)),
+    )
+    _record_apply_run(conn, LOCAL_TENANT, _LOCAL_JOB_ID, "local-apply")
+    conn.commit()
+
+    assert ProjectionBuilder(conn_factory=lambda: conn).refresh() == 1
+
+    job_row = conn.execute(
+        """
+        SELECT employer, source
+        FROM job_list_projections
+        WHERE tenant_id = ? AND job_id = ?
+        """,
+        (str(LOCAL_TENANT), str(_LOCAL_JOB_ID)),
+    ).fetchone()
+    apply_row = conn.execute(
+        """
+        SELECT job_employer
+        FROM apply_run_projections
+        WHERE tenant_id = ? AND job_id = ?
+        """,
+        (str(LOCAL_TENANT), str(_LOCAL_JOB_ID)),
+    ).fetchone()
+
+    assert tuple(job_row) == ("Unknown company", "greenhouse")
+    assert tuple(apply_row) == ("Unknown company",)
+
+
+def test_refresh_scopes_exact_workflow_and_pipeline_events_by_tenant() -> None:
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys = ON")
+    create_exact_v7_schema(conn)
+    other_tenant = TenantId("other")
+
+    for tenant_id, workflow_id, temporal_run_id in (
+        (other_tenant, "other-workflow", "other-run"),
+        (LOCAL_TENANT, "local-workflow", "local-run"),
+    ):
+        record_job_event(
+            conn,
+            None,
+            "workflow",
+            "WorkflowStarted",
+            tenant_id=tenant_id,
+            occurred_at=_TIMESTAMP,
+            payload={
+                "workflowId": workflow_id,
+                "workflowType": "DiscoverWorkflow",
+                "temporalRunId": temporal_run_id,
+                "startedAt": _TIMESTAMP,
+                **_INERT_CONTEXT,
+            },
+            publisher=InProcessEventBus(),
+        )
+        record_job_event(
+            conn,
+            None,
+            "workflow",
+            "PipelineStepQueued",
+            tenant_id=tenant_id,
+            occurred_at=_TIMESTAMP,
+            payload={
+                "execution": {
+                    "tenantId": str(tenant_id),
+                    "workflowId": workflow_id,
+                    "temporalRunId": temporal_run_id,
+                },
+                "stepKind": "source_family",
+                "itemKey": "family:example",
+                "attempt": 1,
+                "queuedAt": _TIMESTAMP,
+                **_INERT_CONTEXT,
+            },
+            publisher=InProcessEventBus(),
+        )
+    conn.commit()
+
+    assert ProjectionBuilder(conn_factory=lambda: conn).refresh() == 0
+
+    local_workflows = conn.execute(
+        "SELECT workflow_id FROM workflow_run_projections WHERE tenant_id = ?",
+        (str(LOCAL_TENANT),),
+    ).fetchall()
+    local_steps = conn.execute(
+        """
+        SELECT discover_workflow_id, discover_run_id
+        FROM pipeline_step_projections
+        WHERE tenant_id = ?
+        """,
+        (str(LOCAL_TENANT),),
+    ).fetchall()
+
+    assert [tuple(row) for row in local_workflows] == [("local-workflow",)]
+    assert [tuple(row) for row in local_steps] == [("local-workflow", "local-run")]


### PR DESCRIPTION
## Summary

- rebuild v7 projection rows by exact tenant and canonical `JobId` across jobs, artifacts, evidence, Apply runs, workflows, pipeline steps, dashboards, contacts, lifecycle, and source quality
- keep projection watermarks tenant-scoped and URLs as presentation metadata only
- reconcile artifact read models against the canonical persisted material/generic registry and remove stale or phantom rows on refresh and reopen
- give registered material artifacts `(type, path)` precedence over shadowed generic rows
- ignore legacy wide score, material-path, and Apply columns while honoring persisted artifact type aliases from the registered artifact tables
- keep rejected and candidate artifacts audit-visible without counting them as available Apply materials
- project employer only from explicit `jobs.company` with an `Unknown company` state while keeping source metadata independent
- seed cross-runtime projection and digest parity from canonical Apply projections, score rows, and non-conflicting outcome facts

## Why

Projection refresh must report persisted truth. Filesystem siblings and source labels cannot synthesize artifacts or employers that were never registered.

## Validation

- Python artifact projection regressions: 3 passed
- direct exact-v7/read-model and API contract regressions: 106 passed
- hosted API regression files: 45 passed
- Python cross-runtime parity: 5 passed
- full workspace TypeScript check: passed
- Fastify server suite excluding the sandbox-prohibited loopback listener: 205 passed, 1 skipped
- focused Ruff and `git diff --check`: passed
- independent cumulative review: PASS, 0 Blocker / 0 High
- independent cumulative QA: PASS, 0 Blocker / 0 High

## Stack

Ready-for-review child of #634.
