### PR TITLE
refactor(enrichment): persist aggregates by canonical job id

### DIFF
--- a/workers/automation/src/jobctrl/discovery/activities.py
+++ b/workers/automation/src/jobctrl/discovery/activities.py
@@ -16,6 +16,7 @@ from jobctrl.domain.discovery.execution import (
 )
 from jobctrl.domain.errors import JobCtrlError, to_application_error
 from jobctrl.domain.events.operations import PipelineStepDetailCode, PipelineStepKind
+from jobctrl.domain.identifiers import JobId
 from jobctrl.infrastructure.temporal.pipeline_step_lifecycle import (
     PipelineStepScope,
     begin_pipeline_step_attempt,
@@ -367,7 +368,7 @@ async def discovery_enrichment_activity(
 
 def _build_per_job_handoff(
     payload: DiscoveryEnrichmentActivityInput,
-) -> Callable[[str], None] | None:
+) -> Callable[[JobId], None] | None:
     """Build the R9 Phase 2 per-job preparation handoff, or ``None`` when off.
 
     The returned callback is fired by the enrichment worker as each job reaches
@@ -385,10 +386,10 @@ def _build_per_job_handoff(
 
     handoff_lock = threading.Lock()
 
-    def _handoff(job_url: str) -> None:
+    def _handoff(job_id: JobId) -> None:
         with handoff_lock:
             start_job_preparation_workflow(
-                job_url,
+                job_id,
                 min_score=payload.min_score,
                 workers=payload.workers,
                 validation_mode=payload.validation_mode,

--- a/workers/automation/src/jobctrl/enrichment/activities.py
+++ b/workers/automation/src/jobctrl/enrichment/activities.py
@@ -10,20 +10,23 @@ from typing import Any
 from temporalio import activity
 
 from jobctrl.domain.errors import JobCtrlError, TransientNetworkError, to_application_error
+from jobctrl.domain.identifiers import JobId, canonical_job_id
 
 
 @dataclass(frozen=True)
 class EnrichActivityInput:
-    # ``tenant_id`` is currently informational; runners read from
-    # ``LOCAL_TENANT`` until tenant scoping lands.
+    # Tenant scope travels with selected canonical job identifiers.
     tenant_id: str
     expected_app_dir: str | None = None
     expected_db_path: str | None = None
     limit: int = 0
     workers: int = 1
     dry_run: bool = False
-    job_urls: tuple[str, ...] = ()
+    job_ids: tuple[JobId, ...] = ()
     workflow_id: str | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "job_ids", _canonical_job_ids(self.job_ids))
 
 
 @dataclass(frozen=True)
@@ -50,7 +53,7 @@ async def enrich_activity(payload: EnrichActivityInput) -> EnrichActivityOutput:
 
     cancel_event = threading.Event()
     try:
-        if payload.job_urls:
+        if payload.job_ids:
             result = await run_blocking_with_heartbeat(
                 lambda: _run_selected_enrichment(payload, cancel_event=cancel_event),
                 starting_message="selected enrich starting",
@@ -134,7 +137,7 @@ def _run_selected_enrichment(
     from jobctrl.database import get_connection
     from jobctrl.enrichment.detail import _run_detail_scraper
 
-    urls = _limited_job_urls(payload.job_urls, payload.limit)
+    job_ids = _limited_job_ids(payload.job_ids, payload.limit)
     if payload.dry_run:
         return {
             "status": "ok",
@@ -145,21 +148,23 @@ def _run_selected_enrichment(
                     "stage": "enrich",
                     "status": "ok",
                     "elapsed": 0.0,
-                    "selected": len(urls),
+                    "selected": len(job_ids),
                     "dry_run": True,
                 }
             ],
         }
 
+    conn = get_connection()
     t0 = time.time()
     scraper_kwargs: dict[str, Any] = {
         "max_per_site": payload.limit or None,
         "workers": payload.workers,
-        "job_urls": urls,
+        "tenant_id": payload.tenant_id,
+        "job_ids": job_ids,
     }
     if cancel_event is not None:
         scraper_kwargs["cancel_event"] = cancel_event
-    stats = _run_detail_scraper(get_connection(), **scraper_kwargs)
+    stats = _run_detail_scraper(conn, **scraper_kwargs)
     elapsed = time.time() - t0
     errors = (
         {"enrich": f"{stats.get('error', 0)} enrichment error(s)"}
@@ -176,18 +181,22 @@ def _run_selected_enrichment(
                 "stage": "enrich",
                 "status": status,
                 "elapsed": elapsed,
-                "selected": len(urls),
+                "selected": len(job_ids),
                 **stats,
             }
         ],
     }
 
 
-def _limited_job_urls(job_urls: tuple[str, ...], limit: int) -> tuple[str, ...]:
-    unique = tuple(dict.fromkeys(url for url in job_urls if url))
+def _limited_job_ids(job_ids: tuple[JobId, ...], limit: int) -> tuple[JobId, ...]:
+    unique = tuple(dict.fromkeys(job_ids))
     if limit > 0:
         return unique[:limit]
     return unique
+
+
+def _canonical_job_ids(job_ids: tuple[JobId, ...]) -> tuple[JobId, ...]:
+    return tuple(dict.fromkeys(canonical_job_id(str(job_id)) for job_id in job_ids))
 
 
 _SUCCESS_STATUSES = {"ok", "partial", "skipped", "already_done"}

--- a/workers/automation/src/jobctrl/enrichment/detail.py
+++ b/workers/automation/src/jobctrl/enrichment/detail.py
@@ -63,7 +63,6 @@ from jobctrl.domain.enrichment.value_objects import (
     ApplicationUrl,
     FullDescription,
 )
-from jobctrl.domain.discovery.value_objects import PostingUrl
 from jobctrl.domain.identifiers import JobId, canonical_job_id
 from jobctrl.domain.errors import ConfigurationError, TransientNetworkError
 from jobctrl.domain.tenant import LOCAL_TENANT, TenantId
@@ -175,17 +174,6 @@ SKIP_DETAIL_SITES = {"glassdoor", "google", "Workopolis"}
 # Module-level proxy config (set from CLI or caller)
 _PROXY_CONFIG: ProxyConfig | None = None
 _MAX_AUTHENTICATED_LINKEDIN_RETRY_ATTEMPTS = 3
-
-
-def _resolve_current_enrichment_job_id(conn: sqlite3.Connection, url: str) -> JobId:
-    """Resolve the external posting locator before enrichment persistence."""
-    identity = SqliteJobIdentityResolver(conn).resolve_current_by_posting_url(
-        LOCAL_TENANT,
-        PostingUrl(value=url),
-    )
-    if identity is None:
-        raise ValueError(f"no current JobId for enrichment locator: {url}")
-    return canonical_job_id(str(identity.job_id))
 
 
 def set_proxy(proxy_str: str | None) -> None:
@@ -606,16 +594,19 @@ def _detail_failure_retryable(cascade_result: dict) -> bool:
 
 
 def _discovery_description_fallback(
-    conn: sqlite3.Connection, url: str
+    conn: sqlite3.Connection,
+    job_id: JobId,
+    *,
+    tenant_id: TenantId = LOCAL_TENANT,
 ) -> tuple[str | None, str | None]:
     """Return discovery-owned content that is usable as enrichment fallback."""
     row = conn.execute(
         """
         SELECT full_description, description, application_url
         FROM jobs
-        WHERE url = ?
+        WHERE tenant_id = ? AND job_id = ?
         """,
-        (url,),
+        (str(tenant_id), str(job_id)),
     ).fetchone()
     if row is None:
         return None, None
@@ -636,7 +627,11 @@ def _discovery_description_fallback(
 
 
 def _apply_discovery_description_fallback(
-    conn: sqlite3.Connection, url: str, cascade_result: dict
+    conn: sqlite3.Connection,
+    job_id: JobId,
+    cascade_result: dict,
+    *,
+    tenant_id: TenantId = LOCAL_TENANT,
 ) -> dict:
     """Promote discovery content when a live detail scrape finds no description."""
     if str(cascade_result.get("full_description") or "").strip():
@@ -644,7 +639,11 @@ def _apply_discovery_description_fallback(
     if cascade_result.get("status") not in {"error", "partial"}:
         return cascade_result
 
-    description, application_url = _discovery_description_fallback(conn, url)
+    description, application_url = _discovery_description_fallback(
+        conn,
+        job_id,
+        tenant_id=tenant_id,
+    )
     if not description:
         return cascade_result
 
@@ -771,6 +770,8 @@ def _record_enrich_robots_blocked(
     job_id: JobId,
     url: str,
     decision: PolitenessDecision,
+    *,
+    tenant_id: TenantId = LOCAL_TENANT,
 ) -> None:
     """Fold a robots-disallowed navigation into the enrichment lifecycle.
 
@@ -791,7 +792,7 @@ def _record_enrich_robots_blocked(
 
     finished_at = utc_now()
     message = decision.reason or "robots.txt disallows automated fetch of this URL"
-    ensure_job_stage_rows(conn, job_id)
+    ensure_job_stage_rows(conn, job_id, tenant_id=tenant_id)
     set_stage_state(
         conn,
         job_id,
@@ -804,6 +805,7 @@ def _record_enrich_robots_blocked(
         finished_at=finished_at,
         metadata={"reason": "robots_disallowed", "politenessOutcome": decision.outcome.value},
         validate_transition=False,
+        tenant_id=tenant_id,
     )
     record_job_event(
         conn,
@@ -818,11 +820,17 @@ def _record_enrich_robots_blocked(
             "politenessOutcome": decision.outcome.value,
             "retryable": True,
         },
+        tenant_id=tenant_id,
     )
     conn.commit()
 
 
-def _unblock_enrich_stage_if_blocked(conn: sqlite3.Connection, job_id: JobId) -> None:
+def _unblock_enrich_stage_if_blocked(
+    conn: sqlite3.Connection,
+    job_id: JobId,
+    *,
+    tenant_id: TenantId = LOCAL_TENANT,
+) -> None:
     """Unblock a previously robots-blocked enrich stage before re-enrichment.
 
     A robots-disallowed job folds into ``enrich = blocked`` (see
@@ -843,14 +851,14 @@ def _unblock_enrich_stage_if_blocked(conn: sqlite3.Connection, job_id: JobId) ->
         SELECT state FROM job_stage_states
         WHERE tenant_id = ? AND job_id = ? AND stage = 'enrich'
         """,
-        (str(LOCAL_TENANT), str(job_id)),
+        (str(tenant_id), str(job_id)),
     ).fetchone()
     if row is None:
         return
     current = row[0] if not isinstance(row, dict) else row["state"]
     if current != "blocked":
         return
-    set_stage_state(conn, job_id, "enrich", "pending")
+    set_stage_state(conn, job_id, "enrich", "pending", tenant_id=tenant_id)
     record_job_event(
         conn,
         job_id,
@@ -858,6 +866,7 @@ def _unblock_enrich_stage_if_blocked(conn: sqlite3.Connection, job_id: JobId) ->
         "StageReset",
         message="Re-evaluating robots for a previously robots-blocked job",
         payload={"reason": "robots_recheck", "previousState": "blocked"},
+        tenant_id=tenant_id,
     )
 
 
@@ -865,9 +874,12 @@ def _record_enrich_politeness_deferral(
     conn: sqlite3.Connection,
     repo: SqliteEnrichmentRepository,
     aggregate: JobEnrichment,
+    job_id: JobId,
     url: str,
     started_at: str,
     cascade_result: dict,
+    *,
+    tenant_id: TenantId = LOCAL_TENANT,
 ) -> None:
     """Fold a mid-flight budget block (peek allowed, guard denied) as a deferral.
 
@@ -886,7 +898,7 @@ def _record_enrich_politeness_deferral(
     repo.save(failed)
     set_stage_state(
         conn,
-        aggregate.job_id,
+        job_id,
         "enrich",
         "failed",
         attempt_count=failed.attempt_count,
@@ -896,10 +908,11 @@ def _record_enrich_politeness_deferral(
         error_message=error.message,
         retryable=True,
         next_action=f"jobctrl retry enrich {url}",
+        tenant_id=tenant_id,
     )
     record_job_event(
         conn,
-        aggregate.job_id,
+        job_id,
         "enrich",
         "StageFailed",
         level="warning",
@@ -909,6 +922,7 @@ def _record_enrich_politeness_deferral(
             "retryable": True,
             "politenessOutcome": cascade_result.get("politeness_outcome"),
         },
+        tenant_id=tenant_id,
     )
 
 
@@ -917,6 +931,8 @@ def _record_enrich_job_failure(
     job_id: JobId,
     url: str,
     exc: Exception,
+    *,
+    tenant_id: TenantId = LOCAL_TENANT,
 ) -> None:
     """Record a single job's unexpected enrichment failure without aborting the batch.
 
@@ -929,7 +945,13 @@ def _record_enrich_job_failure(
         from jobctrl.state import record_job_event, set_stage_state, utc_now
 
         finished_at = utc_now()
-        _record_enrich_aggregate_failure(conn, job_id, message, finished_at=finished_at)
+        _record_enrich_aggregate_failure(
+            conn,
+            job_id,
+            message,
+            finished_at=finished_at,
+            tenant_id=tenant_id,
+        )
         set_stage_state(
             conn,
             job_id,
@@ -940,6 +962,7 @@ def _record_enrich_job_failure(
             retryable=True,
             finished_at=finished_at,
             validate_transition=False,
+            tenant_id=tenant_id,
         )
         record_job_event(
             conn,
@@ -953,6 +976,7 @@ def _record_enrich_job_failure(
                 "errorMessage": message,
                 "retryable": True,
             },
+            tenant_id=tenant_id,
         )
         conn.commit()
     except Exception:
@@ -965,10 +989,11 @@ def _record_enrich_aggregate_failure(
     message: str,
     *,
     finished_at: str,
+    tenant_id: TenantId = LOCAL_TENANT,
 ) -> None:
     """Persist the canonical failed JobEnrichment attempt for an isolated crash."""
     repo = SqliteEnrichmentRepository(conn)
-    existing = repo.load(LOCAL_TENANT, job_id)
+    existing = repo.load(tenant_id, job_id)
     if existing is not None and existing.is_enriched:
         # Do not destroy an accepted enrichment artifact from a later audit-only
         # failure path. The stage event below still preserves the crash.
@@ -980,7 +1005,7 @@ def _record_enrich_aggregate_failure(
         retryable=True,
     )
     aggregate = existing or JobEnrichment.empty(
-        tenant_id=LOCAL_TENANT,
+        tenant_id=tenant_id,
         job_id=job_id,
         updated_at=finished_at,
     )
@@ -998,13 +1023,14 @@ def _record_enrich_aggregate_failure(
 def scrape_site_batch(
     conn: sqlite3.Connection | None,
     site: str,
-    jobs: list[tuple],
+    jobs: list[tuple[JobId, str]],
     max_jobs: int | None = None,
     cancel_event: threading.Event | None = None,
     *,
+    tenant_id: TenantId = LOCAL_TENANT,
     gateway: PolitenessGateway | None = None,
     run_budget: RunBudgetCounter | None = None,
-    on_job_enriched: Callable[[str], None] | None = None,
+    on_job_enriched: Callable[[JobId], None] | None = None,
 ) -> dict:
     """Process all jobs for one site using a shared browser context.
 
@@ -1035,16 +1061,18 @@ def scrape_site_batch(
         "tiers": {1: 0, 2: 0, 3: 0},
     }
 
-    if max_jobs:
-        jobs = jobs[:max_jobs]
-
-    if not jobs:
-        return stats
-
     own_conn = conn is None
     if own_conn:
         conn = init_db()
     assert conn is not None
+
+    # Selected enrichment carries aggregate identities only. Resolve the URL
+    # immediately before the outbound fetch, after all persistence decisions.
+    targets = [(canonical_job_id(str(job_id)), title) for job_id, title in jobs]
+    if max_jobs:
+        targets = targets[:max_jobs]
+    if not targets:
+        return stats
 
     if run_budget is None:
         run_budget = _new_enrichment_budget()
@@ -1057,48 +1085,12 @@ def scrape_site_batch(
             resolver: LinkedInApplyUrlResolver | None = None
             authenticated_page = None
             anonymous_page = None
-            if linkedin_apply_resolver_enabled() and any(
-                _is_linkedin_job(site, job[0]) for job in jobs
-            ):
-                # Owner-scoped authenticated context: present the real logged-in
-                # browser identity (user_agent=None), never the bot UA, matching
-                # _default_linkedin_apply_resolver_factory (D1/D3, see module top).
-                resolver = LinkedInApplyUrlResolver(
-                    proxy=_PROXY_CONFIG,
-                    user_agent=None,
-                    playwright=p,
-                )
-                try:
-                    resolver.start()
-                    authenticated_page = resolver.new_page()
-                    log.info(
-                        "LinkedIn authenticated browser enabled for %d enrichment job(s)",
-                        sum(1 for job in jobs if _is_linkedin_job(site, job[0])),
-                    )
-                except Exception as exc:  # noqa: BLE001 - fallback to static browser
-                    log.warning(
-                        "LinkedIn authenticated browser unavailable; falling back to unauthenticated enrichment: %s",
-                        exc,
-                    )
-                    resolver.close()
-                    resolver = None
-
             # The authenticated LinkedIn context is the owner's logged-in
             # session, so robots.txt is an owner decision there (D1/D3) — pace +
             # budget it, but do not enforce an anonymous robots verdict on the
             # owner's own LinkedIn account. Anonymous rows keep the normal
             # gateway and never share the authenticated browser/profile.
             owner_authenticated_session: PolitenessSession | None = None
-            if resolver is not None and authenticated_page is not None:
-                owner_authenticated_session = _enrichment_session(
-                    PolitenessGateway(
-                        robots=_OwnerAuthenticatedRobots(),
-                        rate_limiter=get_shared_rate_limiter(),
-                    ),
-                    run_budget,
-                    conn,
-                    site=site,
-                )
             anonymous_gateway = gateway or PolitenessGateway()
             anonymous_session = _enrichment_session(
                 anonymous_gateway,
@@ -1120,6 +1112,36 @@ def scrape_site_batch(
                 return anonymous_page
 
             def _page_and_session_for(url: str) -> tuple[object, PolitenessSession, object | None]:
+                nonlocal resolver, authenticated_page, owner_authenticated_session
+                if (
+                    resolver is None
+                    and linkedin_apply_resolver_enabled()
+                    and _is_linkedin_job(site, url)
+                ):
+                    candidate = LinkedInApplyUrlResolver(
+                        proxy=_PROXY_CONFIG,
+                        user_agent=None,
+                        playwright=p,
+                    )
+                    try:
+                        candidate.start()
+                        resolver = candidate
+                        authenticated_page = candidate.new_page()
+                        owner_authenticated_session = _enrichment_session(
+                            PolitenessGateway(
+                                robots=_OwnerAuthenticatedRobots(),
+                                rate_limiter=get_shared_rate_limiter(),
+                            ),
+                            run_budget,
+                            conn,
+                            site=site,
+                        )
+                    except Exception as exc:  # noqa: BLE001 - anonymous fallback
+                        log.warning(
+                            "LinkedIn authenticated browser unavailable; falling back to unauthenticated enrichment: %s",
+                            exc,
+                        )
+                        candidate.close()
                 if (
                     resolver is not None
                     and authenticated_page is not None
@@ -1129,14 +1151,14 @@ def scrape_site_batch(
                     return authenticated_page, owner_authenticated_session, resolver
                 return _ensure_anonymous_page(), anonymous_session, None
 
-            for i, (url, title) in enumerate(jobs):
+            for i, (job_id, title) in enumerate(targets):
                 if cancel_event is not None and cancel_event.is_set():
                     raise TransientNetworkError("enrichment canceled")
                 log.info(
                     "[%d/%d] %s",
                     i + 1,
-                    len(jobs),
-                    title[:50] if title else url[:50],
+                    len(targets),
+                    title[:50] if title else str(job_id),
                 )
 
                 from jobctrl.state import (
@@ -1146,20 +1168,13 @@ def scrape_site_batch(
                     utc_now,
                 )
 
-                try:
-                    job_id = _resolve_current_enrichment_job_id(conn, url)
-                except ValueError:
-                    log.error("Skipping enrichment without a current JobId: %s", url)
-                    stats["error"] += 1
-                    continue
-
                 # Already-enriched rows need no navigation — reaffirm and skip
                 # before the gate so a robots change can't relabel finished work.
-                aggregate = repo.load(LOCAL_TENANT, job_id)
+                aggregate = repo.load(tenant_id, job_id)
                 if aggregate is not None and aggregate.is_enriched:
                     stats["processed"] += 1
                     stats["ok"] += 1
-                    ensure_job_stage_rows(conn, job_id)
+                    ensure_job_stage_rows(conn, job_id, tenant_id=tenant_id)
                     set_stage_state(
                         conn,
                         job_id,
@@ -1168,10 +1183,16 @@ def scrape_site_batch(
                         attempt_count=aggregate.attempt_count,
                         finished_at=utc_now(),
                         validate_transition=False,
+                        tenant_id=tenant_id,
                     )
                     conn.commit()
                     continue
 
+                identity = SqliteJobIdentityResolver(conn).resolve_by_job_id(tenant_id, job_id)
+                if identity is None:
+                    log.warning("Skipping enrichment for unresolved job id %s", job_id)
+                    continue
+                url = identity.posting_url.value
                 page, session, active_resolver = _page_and_session_for(url)
 
                 # R10 pre-navigation gate (peek). A block folds into the lifecycle
@@ -1184,33 +1205,47 @@ def scrape_site_batch(
                     if gate.outcome is PolitenessOutcome.BUDGET_EXHAUSTED:
                         log.warning(
                             "Enrichment request budget exhausted; deferring %d remaining %s job(s) to a future run",
-                            len(jobs) - i,
+                            len(targets) - i,
                             site,
                         )
                         break
-                    _record_enrich_robots_blocked(conn, job_id, url, gate)
+                    _record_enrich_robots_blocked(
+                        conn,
+                        job_id,
+                        url,
+                        gate,
+                        tenant_id=tenant_id,
+                    )
                     stats["blocked"] += 1
                     continue
 
                 try:
                     started_at = utc_now()
-                    ensure_job_stage_rows(conn, job_id)
+                    ensure_job_stage_rows(conn, job_id, tenant_id=tenant_id)
                     # A previously robots-blocked job re-enters here once robots
                     # allows again; Unblock (Blocked->Pending) before the running
                     # transition, which has no Blocked->Running edge and would
                     # otherwise strand the job as ENRICH_INTERNAL_ERROR.
-                    _unblock_enrich_stage_if_blocked(conn, job_id)
-                    set_stage_state(conn, job_id, "enrich", "running", started_at=started_at)
+                    _unblock_enrich_stage_if_blocked(conn, job_id, tenant_id=tenant_id)
+                    set_stage_state(
+                        conn,
+                        job_id,
+                        "enrich",
+                        "running",
+                        started_at=started_at,
+                        tenant_id=tenant_id,
+                    )
                     record_job_event(
                         conn,
                         job_id,
                         "enrich",
                         "StageStarted",
                         message="Enrichment started",
+                        tenant_id=tenant_id,
                     )
 
                     aggregate = aggregate or JobEnrichment.empty(
-                        tenant_id=LOCAL_TENANT,
+                        tenant_id=tenant_id,
                         job_id=job_id,
                         updated_at=started_at,
                     )
@@ -1220,7 +1255,10 @@ def scrape_site_batch(
                     )
 
                     cascade_result = _apply_discovery_description_fallback(
-                        conn, url, scrape_detail_page(page, url, session=session)
+                        conn,
+                        job_id,
+                        scrape_detail_page(page, url, session=session),
+                        tenant_id=tenant_id,
                     )
                     if (
                         cascade_result.get("status") == "blocked"
@@ -1228,7 +1266,14 @@ def scrape_site_batch(
                     ):
                         # Rare parallel race: budget drained between peek + guard.
                         _record_enrich_politeness_deferral(
-                            conn, repo, aggregate, url, started_at, cascade_result
+                            conn,
+                            repo,
+                            aggregate,
+                            job_id,
+                            url,
+                            started_at,
+                            cascade_result,
+                            tenant_id=tenant_id,
                         )
                         conn.commit()
                         break
@@ -1310,6 +1355,7 @@ def scrape_site_batch(
                             title=title or "",
                             cascade_result=cascade_result,
                             captured_at=finished_at,
+                            tenant_id=tenant_id,
                         )
                         set_stage_state(
                             conn,
@@ -1320,6 +1366,7 @@ def scrape_site_batch(
                             started_at=started_at,
                             finished_at=finished_at,
                             metadata=stage_metadata or None,
+                            tenant_id=tenant_id,
                         )
                         completed_payload = {
                             "tier": tier,
@@ -1352,6 +1399,7 @@ def scrape_site_batch(
                             "StageCompleted",
                             message=f"Enrichment {status}: {desc_len} description chars",
                             payload=completed_payload,
+                            tenant_id=tenant_id,
                         )
                     elif status == "inactive":
                         stats["error"] += 1
@@ -1363,6 +1411,7 @@ def scrape_site_batch(
                             title=title or "",
                             cascade_result=cascade_result,
                             captured_at=finished_at,
+                            tenant_id=tenant_id,
                         )
                         err = EnrichmentError(
                             code="POSTING_INACTIVE",
@@ -1384,6 +1433,7 @@ def scrape_site_batch(
                             error_code="POSTING_INACTIVE",
                             error_message=err.message,
                             retryable=False,
+                            tenant_id=tenant_id,
                         )
                         record_job_event(
                             conn,
@@ -1416,6 +1466,7 @@ def scrape_site_batch(
                                 "httpStatus": cascade_result.get("http_status"),
                                 "http_status": cascade_result.get("http_status"),
                             },
+                            tenant_id=tenant_id,
                         )
                     else:
                         stats["error"] += 1
@@ -1446,6 +1497,7 @@ def scrape_site_batch(
                             error_message=err.message,
                             retryable=retryable,
                             next_action=f"jobctrl retry enrich {url}" if retryable else None,
+                            tenant_id=tenant_id,
                         )
                         record_job_event(
                             conn,
@@ -1480,6 +1532,7 @@ def scrape_site_batch(
                                 "httpStatus": cascade_result.get("http_status"),
                                 "http_status": cascade_result.get("http_status"),
                             },
+                            tenant_id=tenant_id,
                         )
                         _record_posting_snapshot_failure_from_cascade(
                             conn,
@@ -1488,6 +1541,7 @@ def scrape_site_batch(
                             source_id=site or "enrichment",
                             cascade_result=cascade_result,
                             failed_at=finished_at,
+                            tenant_id=tenant_id,
                         )
 
                     conn.commit()
@@ -1502,7 +1556,7 @@ def scrape_site_batch(
                         and desc_len > 0
                     ):
                         try:
-                            on_job_enriched(url)
+                            on_job_enriched(job_id)
                         except Exception:  # noqa: BLE001 - handoff is best-effort
                             log.warning(
                                 "Per-job preparation handoff failed for %s", url, exc_info=True
@@ -1512,7 +1566,13 @@ def scrape_site_batch(
                 except Exception as exc:
                     log.exception("Enrichment job failed: %s", url)
                     stats["error"] += 1
-                    _record_enrich_job_failure(conn, job_id, url, exc)
+                    _record_enrich_job_failure(
+                        conn,
+                        job_id,
+                        url,
+                        exc,
+                        tenant_id=tenant_id,
+                    )
 
                 # No inter-job sleep: the shared host limiter (inside the gate)
                 # now paces each host by min-interval + concurrency across threads.
@@ -1540,28 +1600,30 @@ def _tier_from_legacy(tier_num: int | None) -> ExtractionTier:
 def _record_posting_snapshot_from_cascade(
     conn: sqlite3.Connection,
     *,
+    job_id: JobId,
     url: str,
-    job_id: JobId | None = None,
     source_id: str,
     title: str,
     cascade_result: dict,
     captured_at: str,
+    tenant_id: TenantId = LOCAL_TENANT,
 ) -> None:
     """Persist ``PostingSnapshotSet`` history from the existing enrich path."""
     description = str(cascade_result.get("full_description") or "")
     if not description.strip():
         return
-    job_id = (
-        _resolve_current_enrichment_job_id(conn, url)
-        if job_id is None
-        else canonical_job_id(str(job_id))
+    stable_job_id = canonical_job_id(str(job_id))
+    resolved_source_id = _source_id_for_enriched_job(
+        conn,
+        stable_job_id,
+        fallback=source_id,
+        tenant_id=tenant_id,
     )
-    resolved_source_id = _source_id_for_enriched_job(conn, job_id, fallback=source_id)
     try:
         repo = SqlitePostingSnapshotSetRepository(conn)
-        snapshot_set = repo.load(LOCAL_TENANT, job_id) or PostingSnapshotSet.empty(
-            tenant_id=LOCAL_TENANT,
-            job_id=job_id,
+        snapshot_set = repo.load(tenant_id, stable_job_id) or PostingSnapshotSet.empty(
+            tenant_id=tenant_id,
+            job_id=stable_job_id,
             updated_at=captured_at,
         )
         previous_active = snapshot_set.latest_active_state
@@ -1609,16 +1671,16 @@ def _record_posting_snapshot_from_cascade(
 
         record_job_event(
             conn,
-            job_id,
+            stable_job_id,
             "enrich",
             "PostingContentSnapshotCaptured",
             message="Posting content snapshot captured.",
             payload={
-                "tenantId": str(LOCAL_TENANT),
+                "tenantId": str(tenant_id),
                 "snapshot_version": snapshot.snapshot_version,
                 "snapshotVersion": snapshot.snapshot_version,
-                "snapshot_ref": f"{job_id}:{snapshot.snapshot_version}",
-                "snapshotRef": f"{job_id}:{snapshot.snapshot_version}",
+                "snapshot_ref": f"{stable_job_id}:{snapshot.snapshot_version}",
+                "snapshotRef": f"{stable_job_id}:{snapshot.snapshot_version}",
                 "source_id": resolved_source_id,
                 "sourceId": resolved_source_id,
                 "extraction_tier": tier.value,
@@ -1632,17 +1694,18 @@ def _record_posting_snapshot_from_cascade(
             },
             occurred_at=captured_at,
             entity_kind="posting_snapshot",
-            entity_ref=f"{job_id}:{snapshot.snapshot_version}",
+            entity_ref=f"{stable_job_id}:{snapshot.snapshot_version}",
+            tenant_id=tenant_id,
         )
         if previous_active is not active_state:
             record_job_event(
                 conn,
-                job_id,
+                stable_job_id,
                 "enrich",
                 "JobActiveStateChanged",
                 message="Job active state changed.",
                 payload={
-                    "tenantId": str(LOCAL_TENANT),
+                    "tenantId": str(tenant_id),
                     "active_state": active_state.value,
                     "activeState": active_state.value,
                     "previous_state": previous_active.value,
@@ -1653,6 +1716,7 @@ def _record_posting_snapshot_from_cascade(
                     "verifiedAt": captured_at,
                 },
                 occurred_at=captured_at,
+                tenant_id=tenant_id,
             )
         if quarantine_reason is not QuarantineReason.NONE:
             ensure_discovery_control_tables(conn)
@@ -1675,8 +1739,8 @@ def _record_posting_snapshot_from_cascade(
                     status = excluded.status
                 """,
                 (
-                    str(LOCAL_TENANT),
-                    str(job_id),
+                    str(tenant_id),
+                    str(stable_job_id),
                     title,
                     resolved_source_id,
                     url,
@@ -1695,28 +1759,30 @@ def _record_posting_snapshot_from_cascade(
 def _record_posting_snapshot_failure_from_cascade(
     conn: sqlite3.Connection,
     *,
+    job_id: JobId,
     url: str,
-    job_id: JobId | None = None,
     source_id: str,
     cascade_result: dict,
     failed_at: str,
+    tenant_id: TenantId = LOCAL_TENANT,
 ) -> None:
     """Persist verified active-state failures from the existing enrich path."""
     active_state = ActiveState.from_optional(cascade_result.get("active_state"))
     verification_method = str(cascade_result.get("verification_method") or "")
     if active_state is None or verification_method == "unknown":
         return
-    job_id = (
-        _resolve_current_enrichment_job_id(conn, url)
-        if job_id is None
-        else canonical_job_id(str(job_id))
+    stable_job_id = canonical_job_id(str(job_id))
+    resolved_source_id = _source_id_for_enriched_job(
+        conn,
+        stable_job_id,
+        fallback=source_id,
+        tenant_id=tenant_id,
     )
-    resolved_source_id = _source_id_for_enriched_job(conn, job_id, fallback=source_id)
     try:
         repo = SqlitePostingSnapshotSetRepository(conn)
-        snapshot_set = repo.load(LOCAL_TENANT, job_id) or PostingSnapshotSet.empty(
-            tenant_id=LOCAL_TENANT,
-            job_id=job_id,
+        snapshot_set = repo.load(tenant_id, stable_job_id) or PostingSnapshotSet.empty(
+            tenant_id=tenant_id,
+            job_id=stable_job_id,
             updated_at=failed_at,
         )
         error_class = str(cascade_result.get("error") or "DETAIL_ERROR")[:120]
@@ -1738,12 +1804,12 @@ def _record_posting_snapshot_failure_from_cascade(
 
         record_job_event(
             conn,
-            job_id,
+            stable_job_id,
             "enrich",
             "PostingContentSnapshotFailed",
             message="Posting content snapshot failed.",
             payload={
-                "tenantId": str(LOCAL_TENANT),
+                "tenantId": str(tenant_id),
                 "source_id": resolved_source_id,
                 "sourceId": resolved_source_id,
                 "error_class": error_class,
@@ -1771,16 +1837,17 @@ def _record_posting_snapshot_failure_from_cascade(
                 "failedAt": failed_at,
             },
             occurred_at=failed_at,
+            tenant_id=tenant_id,
         )
         if previous_active is not None:
             record_job_event(
                 conn,
-                job_id,
+                stable_job_id,
                 "enrich",
                 "JobActiveStateChanged",
                 message="Job active state changed.",
                 payload={
-                    "tenantId": str(LOCAL_TENANT),
+                    "tenantId": str(tenant_id),
                     "active_state": active_state.value,
                     "activeState": active_state.value,
                     "previous_state": previous_active.value,
@@ -1791,6 +1858,7 @@ def _record_posting_snapshot_failure_from_cascade(
                     "verifiedAt": failed_at,
                 },
                 occurred_at=failed_at,
+                tenant_id=tenant_id,
             )
     except Exception:
         log.exception("Failed to persist PostingSnapshotSet failure for %s", url)
@@ -1801,6 +1869,7 @@ def _source_id_for_enriched_job(
     job_id: JobId,
     *,
     fallback: str,
+    tenant_id: TenantId = LOCAL_TENANT,
 ) -> str:
     """Return the discovery source id for an enriched job when available."""
     row = conn.execute(
@@ -1811,7 +1880,7 @@ def _source_id_for_enriched_job(
         ORDER BY observed_at DESC, source_observation_id DESC
         LIMIT 1
         """,
-        (str(LOCAL_TENANT), str(job_id)),
+        (str(tenant_id), str(job_id)),
     ).fetchone()
     if row is None:
         return fallback
@@ -1865,7 +1934,6 @@ def _default_linkedin_apply_resolver_factory() -> LinkedInApplyUrlResolver:
 def _reset_authenticated_linkedin_retry_candidates(
     conn: sqlite3.Connection,
     *,
-    job_urls: tuple[str, ...] = (),
     limit: int | None = None,
     resolver_factory: Callable[[], object] | None = None,
     run_budget: RunBudgetCounter | None = None,
@@ -1912,18 +1980,11 @@ def _reset_authenticated_linkedin_retry_candidates(
             site="linkedin",
         )
 
-    selected_urls = tuple(dict.fromkeys(url for url in job_urls if url))
     where = [
         "lower(COALESCE(j.site, '')) = 'linkedin'",
         "e.current_status IN ('failed', 'enriched')",
         "(e.current_status = 'failed' OR e.application_url IS NULL OR e.application_url = '')",
     ]
-    params: list[object] = []
-    if selected_urls:
-        placeholders = ", ".join("?" for _ in selected_urls)
-        where.append(f"j.url IN ({placeholders})")
-        params.extend(selected_urls)
-
     rows = conn.execute(
         f"""
         SELECT j.tenant_id, j.job_id, j.url,
@@ -1934,7 +1995,6 @@ def _reset_authenticated_linkedin_retry_candidates(
         WHERE {' AND '.join(where)}
         ORDER BY e.updated_at DESC
         """,
-        params,
     ).fetchall()
 
     from jobctrl.state import (
@@ -2152,10 +2212,11 @@ def _run_detail_scraper(
     sites: list[str] | None = None,
     max_per_site: int | None = None,
     workers: int = 1,
-    job_urls: tuple[str, ...] = (),
+    job_ids: tuple[JobId, ...] = (),
+    tenant_id: str | TenantId = LOCAL_TENANT,
     cancel_event: threading.Event | None = None,
     reset_linkedin_candidates: bool = True,
-    on_job_enriched: Callable[[str], None] | None = None,
+    on_job_enriched: Callable[[JobId], None] | None = None,
 ) -> dict:
     """Group pending jobs by site and process each batch.
 
@@ -2171,30 +2232,34 @@ def _run_detail_scraper(
     # is the aggregate's status alone. The legacy
     # ``detail_scraped_at IS NULL`` gate was redundant AND blocked the
     # post-``reset_job_stage("enrich")`` re-pickup.
+    stable_tenant_id = TenantId(str(tenant_id))
     where_parts = [db_module._ENRICHMENT_PENDING, skip_filter]
-    params: list[str] = []
-    selected_urls = tuple(dict.fromkeys(url for url in job_urls if url))
-    if selected_urls:
-        placeholders = ", ".join("?" for _ in selected_urls)
-        where_parts.append(f"jobs.url IN ({placeholders})")
-        params.extend(selected_urls)
+    params: list[object] = []
+    selected_job_ids = tuple(
+        dict.fromkeys(canonical_job_id(str(job_id)) for job_id in job_ids)
+    )
+    if selected_job_ids:
+        placeholders = ", ".join("?" for _ in selected_job_ids)
+        where_parts.append("jobs.tenant_id = ?")
+        where_parts.append(f"jobs.job_id IN ({placeholders})")
+        params.append(str(stable_tenant_id))
+        params.extend(str(job_id) for job_id in selected_job_ids)
 
     # One run budget spans the whole enrichment run: the authenticated LinkedIn
     # recovery pre-pass below and every site batch share it, so the per-run
     # navigation budget bounds them all together.
     run_budget = _new_enrichment_budget()
 
-    if reset_linkedin_candidates:
+    if reset_linkedin_candidates and not selected_job_ids:
         _reset_authenticated_linkedin_retry_candidates(
             conn,
-            job_urls=selected_urls,
             limit=max_per_site,
             resolver_factory=_default_linkedin_apply_resolver_factory,
             run_budget=run_budget,
         )
 
     rows = conn.execute(
-        f"SELECT jobs.url, jobs.title, jobs.site FROM jobs {db_module._ENRICHMENT_JOIN} "
+        f"SELECT jobs.job_id, jobs.title, jobs.site FROM jobs {db_module._ENRICHMENT_JOIN} "
         f"WHERE {' AND '.join(where_parts)} "
         "ORDER BY jobs.site",
         params,
@@ -2206,10 +2271,10 @@ def _run_detail_scraper(
 
     site_jobs: dict[str, list[tuple]] = {}
     for row in rows:
-        url, title, site = row[0], row[1], row[2]
+        job_id, title, site = canonical_job_id(str(row[0])), row[1], row[2]
         if sites and site not in sites:
             continue
-        site_jobs.setdefault(site, []).append((url, title))
+        site_jobs.setdefault(site, []).append((job_id, title))
 
     log.info("Pending: %d jobs across %d sites (workers=%d)", len(rows), len(site_jobs), workers)
     for site, jobs in site_jobs.items():
@@ -2268,6 +2333,7 @@ def _run_detail_scraper(
                     site,
                     jobs,
                     max_jobs=max_per_site,
+                    tenant_id=stable_tenant_id,
                     gateway=gateway,
                     run_budget=run_budget,
                     on_job_enriched=on_job_enriched,
@@ -2279,6 +2345,7 @@ def _run_detail_scraper(
                     jobs,
                     max_jobs=max_per_site,
                     cancel_event=cancel_event,
+                    tenant_id=stable_tenant_id,
                     gateway=gateway,
                     run_budget=run_budget,
                     on_job_enriched=on_job_enriched,
@@ -2323,6 +2390,7 @@ def _run_detail_scraper(
                         site,
                         jobs,
                         max_jobs=max_per_site,
+                        tenant_id=stable_tenant_id,
                         gateway=gateway,
                         run_budget=run_budget,
                         on_job_enriched=on_job_enriched,
@@ -2334,6 +2402,7 @@ def _run_detail_scraper(
                         jobs,
                         max_jobs=max_per_site,
                         cancel_event=cancel_event,
+                        tenant_id=stable_tenant_id,
                         gateway=gateway,
                         run_budget=run_budget,
                         on_job_enriched=on_job_enriched,
@@ -2426,7 +2495,7 @@ def stream_detail(
             # ``_ENRICHMENT_PENDING`` so all three call sites use the
             # same signal.
             rows = conn.execute(
-                f"SELECT jobs.url, jobs.title, jobs.site FROM jobs {db_module._ENRICHMENT_JOIN} "
+                f"SELECT jobs.job_id, jobs.title, jobs.site FROM jobs {db_module._ENRICHMENT_JOIN} "
                 f"WHERE {db_module._ENRICHMENT_PENDING} "
                 f"AND {skip_filter} "
                 "ORDER BY jobs.site LIMIT 200"
@@ -2435,8 +2504,8 @@ def stream_detail(
             if rows:
                 site_jobs: dict[str, list[tuple]] = {}
                 for row in rows:
-                    url, title, site = row[0], row[1], row[2]
-                    site_jobs.setdefault(site, []).append((url, title))
+                    job_id, title, site = canonical_job_id(str(row[0])), row[1], row[2]
+                    site_jobs.setdefault(site, []).append((job_id, title))
 
                 # One shared gateway + per-cycle run budget across this poll's
                 # site batches (a poll cycle is the streaming "run").
@@ -2483,7 +2552,7 @@ def run_enrichment(
     workers: int = 1,
     cancel_event: threading.Event | None = None,
     reset_linkedin_candidates: bool = True,
-    on_job_enriched: Callable[[str], None] | None = None,
+    on_job_enriched: Callable[[JobId], None] | None = None,
 ) -> dict:
     """Main entry point for detail page enrichment.
 

--- a/workers/automation/src/jobctrl/enrichment/detail.py
+++ b/workers/automation/src/jobctrl/enrichment/detail.py
@@ -63,9 +63,9 @@ from jobctrl.domain.enrichment.value_objects import (
     ApplicationUrl,
     FullDescription,
 )
-from jobctrl.domain.identifiers import JobId
+from jobctrl.domain.identifiers import JobId, canonical_job_id
 from jobctrl.domain.errors import ConfigurationError, TransientNetworkError
-from jobctrl.domain.tenant import LOCAL_TENANT
+from jobctrl.domain.tenant import LOCAL_TENANT, TenantId
 from jobctrl.infrastructure.enrichment import SqliteEnrichmentRepository
 from jobctrl.infrastructure.enrichment.sqlite_repository import (
     SqlitePostingSnapshotSetRepository,
@@ -1884,9 +1884,11 @@ def _reset_authenticated_linkedin_retry_candidates(
 
     rows = conn.execute(
         f"""
-        SELECT j.url, e.current_status, e.application_url, e.attempts_json
+        SELECT j.tenant_id, j.job_id, j.url,
+               e.current_status, e.application_url, e.attempts_json
         FROM jobs j
-        JOIN job_enrichments e ON e.job_url = j.url
+        JOIN job_enrichments e
+          ON e.tenant_id = j.tenant_id AND e.job_id = j.job_id
         WHERE {' AND '.join(where)}
         ORDER BY e.updated_at DESC
         """,
@@ -1908,15 +1910,21 @@ def _reset_authenticated_linkedin_retry_candidates(
     try:
         for row in rows:
             try:
-                attempts_json = row["attempts_json"] if isinstance(row, sqlite3.Row) else row[3]
+                attempts_json = row["attempts_json"] if isinstance(row, sqlite3.Row) else row[5]
                 if _attempt_count_from_json(attempts_json) >= _MAX_AUTHENTICATED_LINKEDIN_RETRY_ATTEMPTS:
                     continue
-                current_status = row["current_status"] if isinstance(row, sqlite3.Row) else row[1]
+                current_status = row["current_status"] if isinstance(row, sqlite3.Row) else row[3]
                 if str(current_status) == "failed" and not _last_failed_attempt_retryable(attempts_json):
                     continue
-                url = str(row["url"] if isinstance(row, sqlite3.Row) else row[0])
+                tenant_id = TenantId(
+                    str(row["tenant_id"] if isinstance(row, sqlite3.Row) else row[0])
+                )
+                job_id = canonical_job_id(
+                    str(row["job_id"] if isinstance(row, sqlite3.Row) else row[1])
+                )
+                url = str(row["url"] if isinstance(row, sqlite3.Row) else row[2])
                 now = utc_now()
-                aggregate = repo.load(LOCAL_TENANT, JobId(url))
+                aggregate = repo.load(tenant_id, job_id)
                 if aggregate is None:
                     continue
 
@@ -1973,9 +1981,10 @@ def _reset_authenticated_linkedin_retry_candidates(
                     )
                     record_job_event(
                         conn,
-                        url,
+                        job_id,
                         "enrich",
                         "StageProgress",
+                        tenant_id=tenant_id,
                         message=(
                             "LinkedIn authenticated apply URL recovered"
                             if recovered is not None
@@ -2001,23 +2010,21 @@ def _reset_authenticated_linkedin_retry_candidates(
                     continue
 
                 repo.save(aggregate.reset(reset_at=now))
-                conn.execute(
-                    "UPDATE jobs SET detail_error = NULL, detail_scraped_at = NULL WHERE url = ?",
-                    (url,),
-                )
-                ensure_job_stage_rows(conn, url)
+                ensure_job_stage_rows(conn, job_id, tenant_id=tenant_id)
                 set_stage_state(
                     conn,
-                    url,
+                    job_id,
                     "enrich",
                     "pending",
+                    tenant_id=tenant_id,
                     validate_transition=False,
                 )
                 record_job_event(
                     conn,
-                    url,
+                    job_id,
                     "enrich",
                     "StageReset",
+                    tenant_id=tenant_id,
                     message="LinkedIn authenticated enrichment retry queued",
                     payload={
                         "reason": "linkedin_authenticated_apply_url",

--- a/workers/automation/src/jobctrl/enrichment/detail.py
+++ b/workers/automation/src/jobctrl/enrichment/detail.py
@@ -2322,34 +2322,44 @@ def _run_detail_scraper(
     gateway = PolitenessGateway()
 
     if workers > 1 and len(order) > 1:
+        database_path = next(
+            str(row[2])
+            for row in conn.execute("PRAGMA database_list").fetchall()
+            if str(row[1]) == "main"
+        )
+
         def _scrape_site(site: str) -> dict:
             if cancel_event is not None and cancel_event.is_set():
                 raise TransientNetworkError("enrichment canceled")
             jobs = site_jobs[site]
             log.info("%s -- %d jobs", site, len(jobs))
-            if cancel_event is None:
-                stats = scrape_site_batch(
-                    None,
-                    site,
-                    jobs,
-                    max_jobs=max_per_site,
-                    tenant_id=stable_tenant_id,
-                    gateway=gateway,
-                    run_budget=run_budget,
-                    on_job_enriched=on_job_enriched,
-                )
-            else:
-                stats = scrape_site_batch(
-                    None,
-                    site,
-                    jobs,
-                    max_jobs=max_per_site,
-                    cancel_event=cancel_event,
-                    tenant_id=stable_tenant_id,
-                    gateway=gateway,
-                    run_budget=run_budget,
-                    on_job_enriched=on_job_enriched,
-                )
+            thread_conn = db_module.get_connection(database_path)
+            try:
+                if cancel_event is None:
+                    stats = scrape_site_batch(
+                        thread_conn,
+                        site,
+                        jobs,
+                        max_jobs=max_per_site,
+                        tenant_id=stable_tenant_id,
+                        gateway=gateway,
+                        run_budget=run_budget,
+                        on_job_enriched=on_job_enriched,
+                    )
+                else:
+                    stats = scrape_site_batch(
+                        thread_conn,
+                        site,
+                        jobs,
+                        max_jobs=max_per_site,
+                        cancel_event=cancel_event,
+                        tenant_id=stable_tenant_id,
+                        gateway=gateway,
+                        run_budget=run_budget,
+                        on_job_enriched=on_job_enriched,
+                    )
+            finally:
+                db_module.close_connection(database_path)
             log.info(
                 "%s summary: %d ok, %d partial, %d error | T1=%d T2=%d T3=%d",
                 site,

--- a/workers/automation/src/jobctrl/enrichment/detail.py
+++ b/workers/automation/src/jobctrl/enrichment/detail.py
@@ -63,10 +63,12 @@ from jobctrl.domain.enrichment.value_objects import (
     ApplicationUrl,
     FullDescription,
 )
+from jobctrl.domain.discovery.value_objects import PostingUrl
 from jobctrl.domain.identifiers import JobId, canonical_job_id
 from jobctrl.domain.errors import ConfigurationError, TransientNetworkError
 from jobctrl.domain.tenant import LOCAL_TENANT, TenantId
 from jobctrl.infrastructure.enrichment import SqliteEnrichmentRepository
+from jobctrl.infrastructure.discovery.sqlite_identity_resolver import SqliteJobIdentityResolver
 from jobctrl.infrastructure.enrichment.sqlite_repository import (
     SqlitePostingSnapshotSetRepository,
 )
@@ -173,6 +175,17 @@ SKIP_DETAIL_SITES = {"glassdoor", "google", "Workopolis"}
 # Module-level proxy config (set from CLI or caller)
 _PROXY_CONFIG: ProxyConfig | None = None
 _MAX_AUTHENTICATED_LINKEDIN_RETRY_ATTEMPTS = 3
+
+
+def _resolve_current_enrichment_job_id(conn: sqlite3.Connection, url: str) -> JobId:
+    """Resolve the external posting locator before enrichment persistence."""
+    identity = SqliteJobIdentityResolver(conn).resolve_current_by_posting_url(
+        LOCAL_TENANT,
+        PostingUrl(value=url),
+    )
+    if identity is None:
+        raise ValueError(f"no current JobId for enrichment locator: {url}")
+    return canonical_job_id(str(identity.job_id))
 
 
 def set_proxy(proxy_str: str | None) -> None:
@@ -754,7 +767,10 @@ def _make_llm_extractor() -> LlmExtractor:
 
 
 def _record_enrich_robots_blocked(
-    conn: sqlite3.Connection, url: str, decision: PolitenessDecision
+    conn: sqlite3.Connection,
+    job_id: JobId,
+    url: str,
+    decision: PolitenessDecision,
 ) -> None:
     """Fold a robots-disallowed navigation into the enrichment lifecycle.
 
@@ -775,10 +791,10 @@ def _record_enrich_robots_blocked(
 
     finished_at = utc_now()
     message = decision.reason or "robots.txt disallows automated fetch of this URL"
-    ensure_job_stage_rows(conn, url)
+    ensure_job_stage_rows(conn, job_id)
     set_stage_state(
         conn,
-        url,
+        job_id,
         "enrich",
         "blocked",
         error_code="ENRICH_ROBOTS_DISALLOWED",
@@ -791,7 +807,7 @@ def _record_enrich_robots_blocked(
     )
     record_job_event(
         conn,
-        url,
+        job_id,
         "enrich",
         "StageBlocked",
         level="warning",
@@ -806,7 +822,7 @@ def _record_enrich_robots_blocked(
     conn.commit()
 
 
-def _unblock_enrich_stage_if_blocked(conn: sqlite3.Connection, url: str) -> None:
+def _unblock_enrich_stage_if_blocked(conn: sqlite3.Connection, job_id: JobId) -> None:
     """Unblock a previously robots-blocked enrich stage before re-enrichment.
 
     A robots-disallowed job folds into ``enrich = blocked`` (see
@@ -823,18 +839,21 @@ def _unblock_enrich_stage_if_blocked(conn: sqlite3.Connection, url: str) -> None
     from jobctrl.state import record_job_event, set_stage_state
 
     row = conn.execute(
-        "SELECT state FROM job_stage_states WHERE job_url = ? AND stage = 'enrich'",
-        (url,),
+        """
+        SELECT state FROM job_stage_states
+        WHERE tenant_id = ? AND job_id = ? AND stage = 'enrich'
+        """,
+        (str(LOCAL_TENANT), str(job_id)),
     ).fetchone()
     if row is None:
         return
     current = row[0] if not isinstance(row, dict) else row["state"]
     if current != "blocked":
         return
-    set_stage_state(conn, url, "enrich", "pending")
+    set_stage_state(conn, job_id, "enrich", "pending")
     record_job_event(
         conn,
-        url,
+        job_id,
         "enrich",
         "StageReset",
         message="Re-evaluating robots for a previously robots-blocked job",
@@ -867,7 +886,7 @@ def _record_enrich_politeness_deferral(
     repo.save(failed)
     set_stage_state(
         conn,
-        url,
+        aggregate.job_id,
         "enrich",
         "failed",
         attempt_count=failed.attempt_count,
@@ -880,7 +899,7 @@ def _record_enrich_politeness_deferral(
     )
     record_job_event(
         conn,
-        url,
+        aggregate.job_id,
         "enrich",
         "StageFailed",
         level="warning",
@@ -893,7 +912,12 @@ def _record_enrich_politeness_deferral(
     )
 
 
-def _record_enrich_job_failure(conn: sqlite3.Connection, url: str, exc: Exception) -> None:
+def _record_enrich_job_failure(
+    conn: sqlite3.Connection,
+    job_id: JobId,
+    url: str,
+    exc: Exception,
+) -> None:
     """Record a single job's unexpected enrichment failure without aborting the batch.
 
     ``validate_transition=False`` because the failure-recording path must never
@@ -905,10 +929,10 @@ def _record_enrich_job_failure(conn: sqlite3.Connection, url: str, exc: Exceptio
         from jobctrl.state import record_job_event, set_stage_state, utc_now
 
         finished_at = utc_now()
-        _record_enrich_aggregate_failure(conn, url, message, finished_at=finished_at)
+        _record_enrich_aggregate_failure(conn, job_id, message, finished_at=finished_at)
         set_stage_state(
             conn,
-            url,
+            job_id,
             "enrich",
             "failed",
             error_code="ENRICH_INTERNAL_ERROR",
@@ -919,7 +943,7 @@ def _record_enrich_job_failure(conn: sqlite3.Connection, url: str, exc: Exceptio
         )
         record_job_event(
             conn,
-            url,
+            job_id,
             "enrich",
             "StageFailed",
             level="error",
@@ -937,14 +961,14 @@ def _record_enrich_job_failure(conn: sqlite3.Connection, url: str, exc: Exceptio
 
 def _record_enrich_aggregate_failure(
     conn: sqlite3.Connection,
-    url: str,
+    job_id: JobId,
     message: str,
     *,
     finished_at: str,
 ) -> None:
     """Persist the canonical failed JobEnrichment attempt for an isolated crash."""
     repo = SqliteEnrichmentRepository(conn)
-    existing = repo.load(LOCAL_TENANT, JobId(url))
+    existing = repo.load(LOCAL_TENANT, job_id)
     if existing is not None and existing.is_enriched:
         # Do not destroy an accepted enrichment artifact from a later audit-only
         # failure path. The stage event below still preserves the crash.
@@ -957,7 +981,7 @@ def _record_enrich_aggregate_failure(
     )
     aggregate = existing or JobEnrichment.empty(
         tenant_id=LOCAL_TENANT,
-        job_id=JobId(url),
+        job_id=job_id,
         updated_at=finished_at,
     )
     running = (
@@ -1122,16 +1146,23 @@ def scrape_site_batch(
                     utc_now,
                 )
 
+                try:
+                    job_id = _resolve_current_enrichment_job_id(conn, url)
+                except ValueError:
+                    log.error("Skipping enrichment without a current JobId: %s", url)
+                    stats["error"] += 1
+                    continue
+
                 # Already-enriched rows need no navigation — reaffirm and skip
                 # before the gate so a robots change can't relabel finished work.
-                aggregate = repo.load(LOCAL_TENANT, JobId(url))
+                aggregate = repo.load(LOCAL_TENANT, job_id)
                 if aggregate is not None and aggregate.is_enriched:
                     stats["processed"] += 1
                     stats["ok"] += 1
-                    ensure_job_stage_rows(conn, url)
+                    ensure_job_stage_rows(conn, job_id)
                     set_stage_state(
                         conn,
-                        url,
+                        job_id,
                         "enrich",
                         "succeeded",
                         attempt_count=aggregate.attempt_count,
@@ -1157,24 +1188,30 @@ def scrape_site_batch(
                             site,
                         )
                         break
-                    _record_enrich_robots_blocked(conn, url, gate)
+                    _record_enrich_robots_blocked(conn, job_id, url, gate)
                     stats["blocked"] += 1
                     continue
 
                 try:
                     started_at = utc_now()
-                    ensure_job_stage_rows(conn, url)
+                    ensure_job_stage_rows(conn, job_id)
                     # A previously robots-blocked job re-enters here once robots
                     # allows again; Unblock (Blocked->Pending) before the running
                     # transition, which has no Blocked->Running edge and would
                     # otherwise strand the job as ENRICH_INTERNAL_ERROR.
-                    _unblock_enrich_stage_if_blocked(conn, url)
-                    set_stage_state(conn, url, "enrich", "running", started_at=started_at)
-                    record_job_event(conn, url, "enrich", "StageStarted", message="Enrichment started")
+                    _unblock_enrich_stage_if_blocked(conn, job_id)
+                    set_stage_state(conn, job_id, "enrich", "running", started_at=started_at)
+                    record_job_event(
+                        conn,
+                        job_id,
+                        "enrich",
+                        "StageStarted",
+                        message="Enrichment started",
+                    )
 
                     aggregate = aggregate or JobEnrichment.empty(
                         tenant_id=LOCAL_TENANT,
-                        job_id=JobId(url),
+                        job_id=job_id,
                         updated_at=started_at,
                     )
                     aggregate = aggregate.start_attempt(
@@ -1267,6 +1304,7 @@ def scrape_site_batch(
                         repo.save(succeeded)
                         _record_posting_snapshot_from_cascade(
                             conn,
+                            job_id=job_id,
                             url=url,
                             source_id=site or "enrichment",
                             title=title or "",
@@ -1275,7 +1313,7 @@ def scrape_site_batch(
                         )
                         set_stage_state(
                             conn,
-                            url,
+                            job_id,
                             "enrich",
                             "succeeded",
                             attempt_count=succeeded.attempt_count,
@@ -1309,7 +1347,7 @@ def scrape_site_batch(
                             )
                         record_job_event(
                             conn,
-                            url,
+                            job_id,
                             "enrich",
                             "StageCompleted",
                             message=f"Enrichment {status}: {desc_len} description chars",
@@ -1319,6 +1357,7 @@ def scrape_site_batch(
                         stats["error"] += 1
                         _record_posting_snapshot_from_cascade(
                             conn,
+                            job_id=job_id,
                             url=url,
                             source_id=site or "enrichment",
                             title=title or "",
@@ -1336,7 +1375,7 @@ def scrape_site_batch(
                         repo.save(failed)
                         set_stage_state(
                             conn,
-                            url,
+                            job_id,
                             "enrich",
                             "failed",
                             attempt_count=failed.attempt_count,
@@ -1348,7 +1387,7 @@ def scrape_site_batch(
                         )
                         record_job_event(
                             conn,
-                            url,
+                            job_id,
                             "enrich",
                             "StageFailed",
                             level="info",
@@ -1397,7 +1436,7 @@ def scrape_site_batch(
                         repo.save(failed)
                         set_stage_state(
                             conn,
-                            url,
+                            job_id,
                             "enrich",
                             "failed",
                             attempt_count=failed.attempt_count,
@@ -1410,7 +1449,7 @@ def scrape_site_batch(
                         )
                         record_job_event(
                             conn,
-                            url,
+                            job_id,
                             "enrich",
                             "StageFailed",
                             level="error",
@@ -1444,6 +1483,7 @@ def scrape_site_batch(
                         )
                         _record_posting_snapshot_failure_from_cascade(
                             conn,
+                            job_id=job_id,
                             url=url,
                             source_id=site or "enrichment",
                             cascade_result=cascade_result,
@@ -1472,7 +1512,7 @@ def scrape_site_batch(
                 except Exception as exc:
                     log.exception("Enrichment job failed: %s", url)
                     stats["error"] += 1
-                    _record_enrich_job_failure(conn, url, exc)
+                    _record_enrich_job_failure(conn, job_id, url, exc)
 
                 # No inter-job sleep: the shared host limiter (inside the gate)
                 # now paces each host by min-interval + concurrency across threads.
@@ -1501,6 +1541,7 @@ def _record_posting_snapshot_from_cascade(
     conn: sqlite3.Connection,
     *,
     url: str,
+    job_id: JobId | None = None,
     source_id: str,
     title: str,
     cascade_result: dict,
@@ -1510,12 +1551,17 @@ def _record_posting_snapshot_from_cascade(
     description = str(cascade_result.get("full_description") or "")
     if not description.strip():
         return
-    resolved_source_id = _source_id_for_enriched_job(conn, url, fallback=source_id)
+    job_id = (
+        _resolve_current_enrichment_job_id(conn, url)
+        if job_id is None
+        else canonical_job_id(str(job_id))
+    )
+    resolved_source_id = _source_id_for_enriched_job(conn, job_id, fallback=source_id)
     try:
         repo = SqlitePostingSnapshotSetRepository(conn)
-        snapshot_set = repo.load(LOCAL_TENANT, JobId(url)) or PostingSnapshotSet.empty(
+        snapshot_set = repo.load(LOCAL_TENANT, job_id) or PostingSnapshotSet.empty(
             tenant_id=LOCAL_TENANT,
-            job_id=JobId(url),
+            job_id=job_id,
             updated_at=captured_at,
         )
         previous_active = snapshot_set.latest_active_state
@@ -1563,18 +1609,16 @@ def _record_posting_snapshot_from_cascade(
 
         record_job_event(
             conn,
-            url,
+            job_id,
             "enrich",
             "PostingContentSnapshotCaptured",
             message="Posting content snapshot captured.",
             payload={
                 "tenantId": str(LOCAL_TENANT),
-                "job_id": url,
-                "jobId": url,
                 "snapshot_version": snapshot.snapshot_version,
                 "snapshotVersion": snapshot.snapshot_version,
-                "snapshot_ref": f"{url}:{snapshot.snapshot_version}",
-                "snapshotRef": f"{url}:{snapshot.snapshot_version}",
+                "snapshot_ref": f"{job_id}:{snapshot.snapshot_version}",
+                "snapshotRef": f"{job_id}:{snapshot.snapshot_version}",
                 "source_id": resolved_source_id,
                 "sourceId": resolved_source_id,
                 "extraction_tier": tier.value,
@@ -1587,18 +1631,18 @@ def _record_posting_snapshot_from_cascade(
                 "capturedAt": captured_at,
             },
             occurred_at=captured_at,
+            entity_kind="posting_snapshot",
+            entity_ref=f"{job_id}:{snapshot.snapshot_version}",
         )
         if previous_active is not active_state:
             record_job_event(
                 conn,
-                url,
+                job_id,
                 "enrich",
                 "JobActiveStateChanged",
                 message="Job active state changed.",
                 payload={
                     "tenantId": str(LOCAL_TENANT),
-                    "job_id": url,
-                    "jobId": url,
                     "active_state": active_state.value,
                     "activeState": active_state.value,
                     "previous_state": previous_active.value,
@@ -1615,11 +1659,11 @@ def _record_posting_snapshot_from_cascade(
             conn.execute(
                 """
                 INSERT INTO discovery_quarantine_entries (
-                    tenant_id, job_id, job_key, title, company, source_id,
+                    tenant_id, job_id, title, company, source_id,
                     posting_url, reason, confidence, snapshot_version,
                     captured_at, notice_text, status
-                ) VALUES (?, ?, ?, ?, '', ?, ?, ?, ?, ?, ?, ?, 'pending')
-                ON CONFLICT(tenant_id, job_key) DO UPDATE SET
+                ) VALUES (?, ?, ?, '', ?, ?, ?, ?, ?, ?, ?, 'pending')
+                ON CONFLICT(tenant_id, job_id) DO UPDATE SET
                     title = excluded.title,
                     source_id = excluded.source_id,
                     posting_url = excluded.posting_url,
@@ -1632,8 +1676,7 @@ def _record_posting_snapshot_from_cascade(
                 """,
                 (
                     str(LOCAL_TENANT),
-                    url,
-                    url,
+                    str(job_id),
                     title,
                     resolved_source_id,
                     url,
@@ -1653,6 +1696,7 @@ def _record_posting_snapshot_failure_from_cascade(
     conn: sqlite3.Connection,
     *,
     url: str,
+    job_id: JobId | None = None,
     source_id: str,
     cascade_result: dict,
     failed_at: str,
@@ -1662,12 +1706,17 @@ def _record_posting_snapshot_failure_from_cascade(
     verification_method = str(cascade_result.get("verification_method") or "")
     if active_state is None or verification_method == "unknown":
         return
-    resolved_source_id = _source_id_for_enriched_job(conn, url, fallback=source_id)
+    job_id = (
+        _resolve_current_enrichment_job_id(conn, url)
+        if job_id is None
+        else canonical_job_id(str(job_id))
+    )
+    resolved_source_id = _source_id_for_enriched_job(conn, job_id, fallback=source_id)
     try:
         repo = SqlitePostingSnapshotSetRepository(conn)
-        snapshot_set = repo.load(LOCAL_TENANT, JobId(url)) or PostingSnapshotSet.empty(
+        snapshot_set = repo.load(LOCAL_TENANT, job_id) or PostingSnapshotSet.empty(
             tenant_id=LOCAL_TENANT,
-            job_id=JobId(url),
+            job_id=job_id,
             updated_at=failed_at,
         )
         error_class = str(cascade_result.get("error") or "DETAIL_ERROR")[:120]
@@ -1689,14 +1738,12 @@ def _record_posting_snapshot_failure_from_cascade(
 
         record_job_event(
             conn,
-            url,
+            job_id,
             "enrich",
             "PostingContentSnapshotFailed",
             message="Posting content snapshot failed.",
             payload={
                 "tenantId": str(LOCAL_TENANT),
-                "job_id": url,
-                "jobId": url,
                 "source_id": resolved_source_id,
                 "sourceId": resolved_source_id,
                 "error_class": error_class,
@@ -1728,14 +1775,12 @@ def _record_posting_snapshot_failure_from_cascade(
         if previous_active is not None:
             record_job_event(
                 conn,
-                url,
+                job_id,
                 "enrich",
                 "JobActiveStateChanged",
                 message="Job active state changed.",
                 payload={
                     "tenantId": str(LOCAL_TENANT),
-                    "job_id": url,
-                    "jobId": url,
                     "active_state": active_state.value,
                     "activeState": active_state.value,
                     "previous_state": previous_active.value,
@@ -1753,24 +1798,21 @@ def _record_posting_snapshot_failure_from_cascade(
 
 def _source_id_for_enriched_job(
     conn: sqlite3.Connection,
-    job_url: str,
+    job_id: JobId,
     *,
     fallback: str,
 ) -> str:
     """Return the discovery source id for an enriched job when available."""
-    try:
-        row = conn.execute(
-            """
-            SELECT source_id
-            FROM job_source_observations
-            WHERE tenant_id = ? AND job_url = ?
-            ORDER BY observed_at DESC, source_observation_id DESC
-            LIMIT 1
-            """,
-            (str(LOCAL_TENANT), job_url),
-        ).fetchone()
-    except sqlite3.OperationalError:
-        return fallback
+    row = conn.execute(
+        """
+        SELECT source_id
+        FROM job_source_observations
+        WHERE tenant_id = ? AND job_id = ?
+        ORDER BY observed_at DESC, source_observation_id DESC
+        LIMIT 1
+        """,
+        (str(LOCAL_TENANT), str(job_id)),
+    ).fetchone()
     if row is None:
         return fallback
     source_id = str(row[0] or "").strip()

--- a/workers/automation/src/jobctrl/infrastructure/enrichment/sqlite_repository.py
+++ b/workers/automation/src/jobctrl/infrastructure/enrichment/sqlite_repository.py
@@ -1,10 +1,9 @@
 """SqliteEnrichmentRepository — local-mode adapter for the Enrichment context.
 
 Persists ``JobEnrichment`` aggregates to the ``job_enrichments`` table
-created by ``database.ensure_enrichment_tables``. The aggregate identity
-is ``(tenant_id, job_id)`` and the table primary key is ``job_url``;
-local mode collapses ``JobId`` onto the legacy ``jobs.url`` per the
-migration plan §8 (deferred narrowing).
+created by the exact-v7 schema. The aggregate identity and table primary
+key are both ``(tenant_id, job_id)``. Posting URLs remain locators on the
+Job aggregate; they are never used as enrichment identity.
 
 The repository is an upsert on every save — versioning is per-attempt
 inside the aggregate's ``attempts_json`` blob, not per-row.
@@ -43,7 +42,7 @@ from jobctrl.domain.enrichment.value_objects import (
     ExtractionTier,
     FullDescription,
 )
-from jobctrl.domain.identifiers import JobId
+from jobctrl.domain.identifiers import JobId, canonical_job_id
 from jobctrl.domain.tenant import LOCAL_TENANT, TenantId
 
 
@@ -64,20 +63,21 @@ class SqliteEnrichmentRepository:
     # ------------------------------------------------------------------
 
     def load(self, tenant_id: TenantId, job_id: JobId) -> JobEnrichment | None:
+        stable_job_id = canonical_job_id(str(job_id))
         row = self._conn.execute(
             """
-            SELECT job_url, tenant_id, current_status, full_description,
+            SELECT tenant_id, job_id, current_status, full_description,
                    application_url, enriched_at, extraction_tier,
                    attempts_json, updated_at
             FROM job_enrichments
-            WHERE job_url = ? AND tenant_id = ?
+            WHERE tenant_id = ? AND job_id = ?
             LIMIT 1
             """,
-            (str(job_id), str(tenant_id)),
+            (str(tenant_id), str(stable_job_id)),
         ).fetchone()
         if row is None:
             return None
-        return self._row_to_enrichment(row, tenant_id)
+        return self._row_to_enrichment(row)
 
     def list_pending(self, tenant_id: TenantId, *, limit: int = 0) -> list[JobId]:
         """Return job_ids whose enrichment is `pending`.
@@ -94,22 +94,23 @@ class SqliteEnrichmentRepository:
         """
         params: list[Any] = [str(tenant_id)]
         sql = (
-            "SELECT j.url FROM jobs j "
+            "SELECT j.job_id FROM jobs j "
             "LEFT JOIN job_enrichments e "
-            "  ON e.job_url = j.url AND e.tenant_id = ? "
-            "WHERE e.job_url IS NULL OR e.current_status = 'pending' "
+            "  ON e.tenant_id = j.tenant_id AND e.job_id = j.job_id "
+            "WHERE j.tenant_id = ? "
+            "  AND (e.job_id IS NULL OR e.current_status = 'pending') "
             "ORDER BY j.discovered_at DESC NULLS LAST"
         )
         if limit > 0:
             sql += " LIMIT ?"
             params.append(limit)
         rows = self._conn.execute(sql, params).fetchall()
-        return [JobId(row[0]) for row in rows if row[0]]
+        return [canonical_job_id(str(row[0])) for row in rows if row[0]]
 
     def list_failed(self, tenant_id: TenantId, *, limit: int = 0) -> list[JobEnrichment]:
         params: list[Any] = [str(tenant_id)]
         sql = (
-            "SELECT job_url, tenant_id, current_status, full_description, "
+            "SELECT tenant_id, job_id, current_status, full_description, "
             "application_url, enriched_at, extraction_tier, attempts_json, "
             "updated_at "
             "FROM job_enrichments "
@@ -120,13 +121,14 @@ class SqliteEnrichmentRepository:
             sql += " LIMIT ?"
             params.append(limit)
         rows = self._conn.execute(sql, params).fetchall()
-        return [self._row_to_enrichment(row, tenant_id) for row in rows]
+        return [self._row_to_enrichment(row) for row in rows]
 
     # ------------------------------------------------------------------
     # Write
     # ------------------------------------------------------------------
 
     def save(self, enrichment: JobEnrichment) -> None:
+        job_id = canonical_job_id(str(enrichment.job_id))
         attempts_json = json.dumps(
             [a.to_dict() for a in enrichment.attempts],
             sort_keys=True,
@@ -134,12 +136,11 @@ class SqliteEnrichmentRepository:
         self._conn.execute(
             """
             INSERT INTO job_enrichments (
-                job_url, tenant_id, current_status, full_description,
+                tenant_id, job_id, current_status, full_description,
                 application_url, enriched_at, extraction_tier,
                 attempts_json, updated_at
             ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-            ON CONFLICT(job_url) DO UPDATE SET
-                tenant_id = excluded.tenant_id,
+            ON CONFLICT(tenant_id, job_id) DO UPDATE SET
                 current_status = excluded.current_status,
                 full_description = excluded.full_description,
                 application_url = excluded.application_url,
@@ -149,8 +150,8 @@ class SqliteEnrichmentRepository:
                 updated_at = excluded.updated_at
             """,
             (
-                str(enrichment.job_id),
                 str(enrichment.tenant_id),
+                str(job_id),
                 enrichment.current_status,
                 (
                     enrichment.full_description.text
@@ -179,9 +180,10 @@ class SqliteEnrichmentRepository:
     # ------------------------------------------------------------------
 
     @staticmethod
-    def _row_to_enrichment(row: Any, tenant_id: TenantId | None = None) -> JobEnrichment:
+    def _row_to_enrichment(row: Any) -> JobEnrichment:
         if isinstance(row, sqlite3.Row):
-            job_url = row["job_url"]
+            tenant_id = row["tenant_id"]
+            job_id = row["job_id"]
             current_status = row["current_status"]
             full_description = row["full_description"]
             application_url = row["application_url"]
@@ -191,8 +193,8 @@ class SqliteEnrichmentRepository:
             updated_at = row["updated_at"]
         else:
             (
-                job_url,
-                _tenant,
+                tenant_id,
+                job_id,
                 current_status,
                 full_description,
                 application_url,
@@ -209,8 +211,8 @@ class SqliteEnrichmentRepository:
         # break the aggregate's __post_init__ and we want the load path
         # to surface that as a clear error rather than a silent rewrite.
         return JobEnrichment(
-            tenant_id=tenant_id or LOCAL_TENANT,
-            job_id=JobId(str(job_url)),
+            tenant_id=TenantId(str(tenant_id)),
+            job_id=canonical_job_id(str(job_id)),
             current_status=str(current_status or EnrichmentLifecycle.PENDING),
             attempts=attempts,
             full_description=(

--- a/workers/automation/src/jobctrl/infrastructure/enrichment/sqlite_repository.py
+++ b/workers/automation/src/jobctrl/infrastructure/enrichment/sqlite_repository.py
@@ -234,14 +234,15 @@ class SqlitePostingSnapshotSetRepository:
         self._conn = conn
 
     def load(self, tenant_id: TenantId, job_id: JobId) -> PostingSnapshotSet | None:
+        stable_job_id = canonical_job_id(str(job_id))
         row = self._conn.execute(
             """
             SELECT snapshot_set_json
             FROM posting_snapshot_sets
-            WHERE tenant_id = ? AND job_url = ?
+            WHERE tenant_id = ? AND job_id = ?
             LIMIT 1
             """,
-            (str(tenant_id), str(job_id)),
+            (str(tenant_id), str(stable_job_id)),
         ).fetchone()
         if row is None:
             return None
@@ -254,11 +255,11 @@ class SqlitePostingSnapshotSetRepository:
         self._conn.execute(
             """
             INSERT INTO posting_snapshot_sets (
-                tenant_id, job_url, snapshot_set_json, latest_snapshot_version,
+                tenant_id, job_id, snapshot_set_json, latest_snapshot_version,
                 latest_active_state, latest_confidence, latest_quarantine_reason,
                 updated_at
             ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-            ON CONFLICT(tenant_id, job_url) DO UPDATE SET
+            ON CONFLICT(tenant_id, job_id) DO UPDATE SET
                 snapshot_set_json = excluded.snapshot_set_json,
                 latest_snapshot_version = excluded.latest_snapshot_version,
                 latest_active_state = excluded.latest_active_state,
@@ -287,7 +288,7 @@ class SqlitePostingSnapshotSetRepository:
     ) -> list[DedupeIndexEntry]:
         rows = self._conn.execute(
             """
-            SELECT job_url, snapshot_set_json
+            SELECT job_id, snapshot_set_json
             FROM posting_snapshot_sets
             WHERE tenant_id = ?
             ORDER BY updated_at DESC
@@ -296,8 +297,8 @@ class SqlitePostingSnapshotSetRepository:
         ).fetchall()
         entries: list[DedupeIndexEntry] = []
         for row in rows:
-            job_url = row["job_url"] if isinstance(row, sqlite3.Row) else row[0]
-            if exclude_job_id is not None and str(job_url) == str(exclude_job_id):
+            job_id = row["job_id"] if isinstance(row, sqlite3.Row) else row[0]
+            if exclude_job_id is not None and str(job_id) == str(exclude_job_id):
                 continue
             raw_json = row["snapshot_set_json"] if isinstance(row, sqlite3.Row) else row[1]
             data = json.loads(raw_json) if raw_json else {}
@@ -317,7 +318,7 @@ class SqlitePostingSnapshotSetRepository:
 
 def _snapshot_set_from_dict(data: dict[str, Any]) -> PostingSnapshotSet:
     tenant_id = TenantId(str(data.get("tenant_id") or LOCAL_TENANT))
-    job_id = JobId(str(data.get("job_id") or ""))
+    job_id = canonical_job_id(str(data.get("job_id") or ""))
     snapshots = tuple(
         _snapshot_from_dict(item)
         for item in data.get("snapshots", [])

--- a/workers/automation/src/jobctrl/pipeline/runner.py
+++ b/workers/automation/src/jobctrl/pipeline/runner.py
@@ -31,6 +31,7 @@ from jobctrl.domain.discovery.scheduler import (
 from jobctrl.domain.discovery.execution import DiscoveryExecutionRef
 from jobctrl.domain.discovery.source_registry import SourceKind, SourcePriority, SourceState
 from jobctrl.domain.errors import LlmTransientError, SourceUnavailableError, TransientNetworkError
+from jobctrl.domain.identifiers import JobId
 from jobctrl.domain.tenant import LOCAL_TENANT
 from jobctrl.infrastructure.discovery.sqlite_run_repository import (
     SqliteDiscoveryRunRepository,
@@ -1666,7 +1667,7 @@ def run_discovery_enrichment_stage(
     cancel_event: threading.Event | None = None,
     progress_completed: int = 0,
     progress_total: int = 0,
-    on_job_enriched: Callable[[str], None] | None = None,
+    on_job_enriched: Callable[[JobId], None] | None = None,
 ) -> dict[str, Any]:
     emit_progress = progress_total > 0
     if emit_progress:
@@ -2306,7 +2307,7 @@ def _run_enrich(
     limit: int = 0,
     cancel_event: threading.Event | None = None,
     reset_linkedin_candidates: bool = True,
-    on_job_enriched: Callable[[str], None] | None = None,
+    on_job_enriched: Callable[[JobId], None] | None = None,
 ) -> dict:
     """Stage: Detail enrichment — scrape full descriptions and apply URLs."""
     if cancel_event is not None and cancel_event.is_set():
@@ -2666,7 +2667,7 @@ def _run_discovery_enrichment_until_idle(
     workers: int,
     limit: int,
     cancel_event: threading.Event | None = None,
-    on_job_enriched: Callable[[str], None] | None = None,
+    on_job_enriched: Callable[[JobId], None] | None = None,
 ) -> None:
     """Drain the detail-enrichment queue while discovery is still producing jobs.
 

--- a/workers/automation/tests/test_activity_enrich.py
+++ b/workers/automation/tests/test_activity_enrich.py
@@ -11,11 +11,15 @@ from temporalio import workflow
 from temporalio.testing import WorkflowEnvironment
 from temporalio.worker import UnsandboxedWorkflowRunner, Worker
 
+from jobctrl.database import close_connection, init_db
+from jobctrl.domain.identifiers import JobId
+from jobctrl.enrichment import activities as enrichment_activities_mod
 from jobctrl.enrichment.activities import (
     EnrichActivityInput,
     EnrichActivityOutput,
     enrich_activity,
 )
+from .politeness_helpers import offline_gateway
 
 
 @workflow.defn(name="EnrichHarness")
@@ -60,3 +64,119 @@ async def test_enrich_activity_invokes_observed_enrich_core():
     assert kwargs["mode"] == "workflow"
     assert output.status == "ok"
     assert output.elapsed == pytest.approx(0.2)
+
+
+def test_selected_enrichment_uses_only_the_requested_v7_job_id_at_fetch_boundary(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    from jobctrl.enrichment import detail
+
+    db_path = tmp_path / "jobctrl.db"
+    conn = init_db(db_path)
+    job_id = JobId("60000000-0000-4000-8000-000000000001")
+    unrelated_job_id = JobId("60000000-0000-4000-8000-000000000002")
+    local_url = "https://local.example/jobs/one"
+    unrelated_url = "https://local.example/jobs/two"
+    for current_job_id, url in ((job_id, local_url), (unrelated_job_id, unrelated_url)):
+        conn.execute(
+            "INSERT INTO jobs (tenant_id, job_id, url, title, site) VALUES ('local', ?, ?, 'Test job', 'RemoteOK')",
+            (current_job_id, url),
+        )
+        conn.execute(
+            """
+            INSERT INTO job_locators (
+                tenant_id, job_id, locator_kind, locator_value, is_current,
+                first_seen_at, last_seen_at, retired_at
+            ) VALUES (?, ?, 'posting_url', ?, 1, '2026-07-31T10:00:00+00:00',
+                      '2026-07-31T10:00:00+00:00', NULL)
+            """,
+            ("local", current_job_id, url),
+        )
+    conn.commit()
+
+    class _FakeBrowser:
+        def new_context(self, **_kwargs):
+            return self
+
+        def new_page(self):
+            return object()
+
+        def close(self) -> None:
+            return None
+
+    class _FakePlaywright:
+        class chromium:  # noqa: N801 - mirrors Playwright's public attribute
+            @staticmethod
+            def launch(**_kwargs):
+                return _FakeBrowser()
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args) -> None:
+            return None
+
+    fetched_urls: list[str] = []
+
+    def fake_scrape_detail_page(_page, url, *, session):
+        fetched_urls.append(url)
+        return {
+            "status": "ok",
+            "tier_used": 1,
+            "full_description": "Build reliable systems with Python and TypeScript. " * 8,
+            "application_url": "https://apply.example/jobs/one",
+            "elapsed": 0.1,
+            "active_state": "active",
+            "verification_method": "fixture",
+            "http_status": 200,
+        }
+
+    monkeypatch.setattr("jobctrl.database.get_connection", lambda: conn)
+    monkeypatch.setattr(detail, "sync_playwright", lambda: _FakePlaywright())
+    monkeypatch.setattr(detail, "PolitenessGateway", lambda: offline_gateway())
+    monkeypatch.setattr(detail, "scrape_detail_page", fake_scrape_detail_page)
+
+    result = enrichment_activities_mod._run_selected_enrichment(
+        EnrichActivityInput(tenant_id="local", job_ids=(job_id,))
+    )
+
+    assert fetched_urls == [local_url]
+    assert result["stages"][0]["selected"] == 1
+    assert conn.execute(
+        "SELECT current_status FROM job_enrichments WHERE tenant_id = 'local' AND job_id = ?",
+        (job_id,),
+    ).fetchone()[0] == "enriched"
+    assert conn.execute(
+        "SELECT COUNT(*) FROM job_enrichments WHERE tenant_id = 'local' AND job_id = ?",
+        (unrelated_job_id,),
+    ).fetchone()[0] == 0
+
+    missing_job_id = JobId("60000000-0000-4000-8000-000000000003")
+    missing_result = enrichment_activities_mod._run_selected_enrichment(
+        EnrichActivityInput(tenant_id="local", job_ids=(missing_job_id,))
+    )
+
+    assert missing_result["stages"][0]["processed"] == 0
+    assert fetched_urls == [local_url]
+    assert conn.execute(
+        "SELECT COUNT(*) FROM job_enrichments WHERE tenant_id = 'local' AND job_id = ?",
+        (unrelated_job_id,),
+    ).fetchone()[0] == 0
+    close_connection(db_path)
+
+
+def test_scrape_site_batch_rejects_legacy_url_targets(tmp_path) -> None:
+    from jobctrl.enrichment import detail
+
+    db_path = tmp_path / "jobctrl.db"
+    conn = init_db(db_path)
+    try:
+        with pytest.raises(ValueError, match="canonical UUID"):
+            detail.scrape_site_batch(
+                conn,
+                "RemoteOK",
+                [(JobId("https://example.test/jobs/legacy"), "Legacy target")],
+            )
+    finally:
+        close_connection(db_path)

--- a/workers/automation/tests/test_discover_reliability.py
+++ b/workers/automation/tests/test_discover_reliability.py
@@ -12,6 +12,7 @@ import json
 import sqlite3
 import threading
 from pathlib import Path
+from uuid import NAMESPACE_URL, uuid5
 
 import pytest
 from temporalio.exceptions import ApplicationError
@@ -26,6 +27,8 @@ from jobctrl.discovery.activities import (
     _stage_failure_error,
 )
 from jobctrl.domain.errors import ConfigurationError, TransientNetworkError
+from jobctrl.domain.identifiers import JobId
+from jobctrl.domain.tenant import LOCAL_TENANT
 from jobctrl.enrichment import detail
 from jobctrl.pipeline import runner
 
@@ -67,12 +70,28 @@ class _FakePlaywright:
         return None
 
 
-def _seed_pending(conn: sqlite3.Connection, url: str, site: str) -> None:
+def _seed_pending(conn: sqlite3.Connection, url: str, site: str) -> JobId:
+    job_id = JobId(str(uuid5(NAMESPACE_URL, url)))
+    discovered_at = "2026-01-01T00:00:00+00:00"
     conn.execute(
-        "INSERT INTO jobs (url, title, site, discovered_at) VALUES (?, ?, ?, ?)",
-        (url, "Engineer", site, "2026-01-01T00:00:00+00:00"),
+        "INSERT INTO jobs (tenant_id, job_id, url, title, site, discovered_at) "
+        "VALUES (?, ?, ?, ?, ?, ?)",
+        (
+            str(LOCAL_TENANT),
+            str(job_id),
+            url,
+            "Engineer",
+            site,
+            discovered_at,
+        ),
+    )
+    conn.execute(
+        "INSERT INTO job_locators (tenant_id, job_id, locator_kind, locator_value, "
+        "is_current, first_seen_at, last_seen_at) VALUES (?, ?, 'posting_url', ?, 1, ?, ?)",
+        (str(LOCAL_TENANT), str(job_id), url, discovered_at, discovered_at),
     )
     conn.commit()
+    return job_id
 
 
 # ---------------------------------------------------------------------------
@@ -476,8 +495,8 @@ def test_scrape_site_batch_isolates_single_job_failure(
     bad_url = "https://remoteok.com/bad"
     good_url = "https://remoteok.com/good"
     try:
-        _seed_pending(conn, bad_url, "RemoteOK")
-        _seed_pending(conn, good_url, "RemoteOK")
+        bad_job_id = _seed_pending(conn, bad_url, "RemoteOK")
+        good_job_id = _seed_pending(conn, good_url, "RemoteOK")
 
         monkeypatch.setattr(detail, "sync_playwright", lambda: _FakePlaywright())
 
@@ -501,7 +520,7 @@ def test_scrape_site_batch_isolates_single_job_failure(
         stats = detail.scrape_site_batch(
             conn,
             "RemoteOK",
-            [(bad_url, "Bad"), (good_url, "Good")],
+            [(bad_job_id, "Bad"), (good_job_id, "Good")],
             gateway=offline_gateway(),
         )
 
@@ -509,8 +528,9 @@ def test_scrape_site_batch_isolates_single_job_failure(
         assert stats["ok"] == 1
 
         bad_state = conn.execute(
-            "SELECT state, error_code FROM job_stage_states WHERE job_url = ? AND stage = 'enrich'",
-            (bad_url,),
+            "SELECT state, error_code FROM job_stage_states "
+            "WHERE tenant_id = ? AND job_id = ? AND stage = 'enrich'",
+            (str(LOCAL_TENANT), str(bad_job_id)),
         ).fetchone()
         assert bad_state["state"] == "failed"
         assert bad_state["error_code"] == "ENRICH_INTERNAL_ERROR"
@@ -519,9 +539,9 @@ def test_scrape_site_batch_isolates_single_job_failure(
             """
             SELECT current_status, attempts_json
             FROM job_enrichments
-            WHERE job_url = ?
+            WHERE tenant_id = ? AND job_id = ?
             """,
-            (bad_url,),
+            (str(LOCAL_TENANT), str(bad_job_id)),
         ).fetchone()
         assert bad_enrichment["current_status"] == "failed"
         attempts = json.loads(bad_enrichment["attempts_json"])
@@ -533,19 +553,20 @@ def test_scrape_site_batch_isolates_single_job_failure(
             """
             SELECT payload_json
             FROM job_events
-            WHERE job_url = ? AND event_type = 'StageFailed'
+            WHERE tenant_id = ? AND job_id = ? AND event_type = 'StageFailed'
             ORDER BY event_id DESC
             LIMIT 1
             """,
-            (bad_url,),
+            (str(LOCAL_TENANT), str(bad_job_id)),
         ).fetchone()
         payload = json.loads(bad_event["payload_json"])
         assert payload["errorCode"] == "ENRICH_INTERNAL_ERROR"
         assert payload["retryable"] is True
 
         good = conn.execute(
-            "SELECT current_status FROM job_enrichments WHERE job_url = ?",
-            (good_url,),
+            "SELECT current_status FROM job_enrichments "
+            "WHERE tenant_id = ? AND job_id = ?",
+            (str(LOCAL_TENANT), str(good_job_id)),
         ).fetchone()
         assert good["current_status"] == "enriched"
     finally:
@@ -566,9 +587,9 @@ def test_scrape_site_batch_hands_off_each_job_as_it_is_enriched(
     second = "https://remoteok.com/second"
     events: list[tuple[str, str]] = []
     try:
-        _seed_pending(conn, first, "RemoteOK")
-        _seed_pending(conn, bad, "RemoteOK")
-        _seed_pending(conn, second, "RemoteOK")
+        first_job_id = _seed_pending(conn, first, "RemoteOK")
+        bad_job_id = _seed_pending(conn, bad, "RemoteOK")
+        second_job_id = _seed_pending(conn, second, "RemoteOK")
 
         monkeypatch.setattr(detail, "sync_playwright", lambda: _FakePlaywright())
 
@@ -599,13 +620,13 @@ def test_scrape_site_batch_hands_off_each_job_as_it_is_enriched(
 
         monkeypatch.setattr(detail, "scrape_detail_page", fake_scrape)
 
-        def on_job_enriched(url: str) -> None:
-            events.append(("handoff", url))
+        def on_job_enriched(job_id: JobId) -> None:
+            events.append(("handoff", str(job_id)))
 
         detail.scrape_site_batch(
             conn,
             "RemoteOK",
-            [(first, "First"), (bad, "Bad"), (second, "Second")],
+            [(first_job_id, "First"), (bad_job_id, "Bad"), (second_job_id, "Second")],
             gateway=offline_gateway(),
             on_job_enriched=on_job_enriched,
         )
@@ -614,10 +635,10 @@ def test_scrape_site_batch_hands_off_each_job_as_it_is_enriched(
         # the next job is scraped. The failed job produces no handoff.
         assert events == [
             ("scrape", first),
-            ("handoff", first),
+            ("handoff", str(first_job_id)),
             ("scrape", bad),
             ("scrape", second),
-            ("handoff", second),
+            ("handoff", str(second_job_id)),
         ]
     finally:
         close_connection(db_path)
@@ -632,7 +653,7 @@ def test_scrape_site_batch_handoff_error_does_not_break_enrichment(
     conn = init_db(db_path)
     url = "https://remoteok.com/job"
     try:
-        _seed_pending(conn, url, "RemoteOK")
+        job_id = _seed_pending(conn, url, "RemoteOK")
         monkeypatch.setattr(detail, "sync_playwright", lambda: _FakePlaywright())
         monkeypatch.setattr(
             detail,
@@ -650,13 +671,13 @@ def test_scrape_site_batch_handoff_error_does_not_break_enrichment(
             },
         )
 
-        def exploding_handoff(_url: str) -> None:
+        def exploding_handoff(_job_id: JobId) -> None:
             raise RuntimeError("temporal unreachable")
 
         stats = detail.scrape_site_batch(
             conn,
             "RemoteOK",
-            [(url, "Job")],
+            [(job_id, "Job")],
             gateway=offline_gateway(),
             on_job_enriched=exploding_handoff,
         )
@@ -664,8 +685,9 @@ def test_scrape_site_batch_handoff_error_does_not_break_enrichment(
         assert stats["ok"] == 1
         assert stats["error"] == 0
         state = conn.execute(
-            "SELECT state FROM job_stage_states WHERE job_url = ? AND stage = 'enrich'",
-            (url,),
+            "SELECT state FROM job_stage_states "
+            "WHERE tenant_id = ? AND job_id = ? AND stage = 'enrich'",
+            (str(LOCAL_TENANT), str(job_id)),
         ).fetchone()
         assert state["state"] == "succeeded"
     finally:

--- a/workers/automation/tests/test_enrichment_detail_staleness.py
+++ b/workers/automation/tests/test_enrichment_detail_staleness.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import sqlite3
 from pathlib import Path
 
 import pytest
@@ -13,7 +14,9 @@ from jobctrl.enrichment import detail
 from jobctrl.enrichment.detail import (
     _detail_failure_retryable,
     _record_posting_snapshot_from_cascade,
+    _record_posting_snapshot_failure_from_cascade,
     _reset_authenticated_linkedin_retry_candidates,
+    _source_id_for_enriched_job,
     scrape_detail_page,
 )
 from jobctrl.infrastructure.enrichment import SqliteEnrichmentRepository
@@ -173,6 +176,33 @@ def test_verified_inactive_detail_failure_is_not_retryable() -> None:
     ) is False
 
 
+def test_source_lookup_only_falls_back_for_missing_exact_v7_observation() -> None:
+    conn = sqlite3.connect(":memory:")
+    job_id = canonical_job_id("d06861be-e8d5-46dd-aa30-2d78dc12c96a")
+    try:
+        conn.execute(
+            """
+            CREATE TABLE job_source_observations (
+                tenant_id TEXT NOT NULL,
+                job_id TEXT NOT NULL,
+                source_id TEXT,
+                observed_at TEXT,
+                source_observation_id TEXT
+            )
+            """
+        )
+        assert _source_id_for_enriched_job(conn, job_id, fallback="enrichment") == "enrichment"
+
+        conn.execute("DROP TABLE job_source_observations")
+        conn.execute(
+            "CREATE TABLE job_source_observations (tenant_id TEXT NOT NULL, source_id TEXT)"
+        )
+        with pytest.raises(sqlite3.OperationalError, match="no such column: job_id"):
+            _source_id_for_enriched_job(conn, job_id, fallback="enrichment")
+    finally:
+        conn.close()
+
+
 def test_authenticated_linkedin_retry_resets_only_exact_v7_aggregate(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -272,6 +302,87 @@ def test_authenticated_linkedin_retry_resets_only_exact_v7_aggregate(
         payload = json.loads(event["payload_json"])
         assert payload["jobId"] == str(job_id)
         assert "jobUrl" not in payload
+    finally:
+        close_connection(db_path)
+
+
+def test_scrape_site_batch_resolves_url_once_before_exact_v7_writes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    db_path = tmp_path / "jobs.db"
+    conn = init_db(db_path)
+    job_id = canonical_job_id("790fd73f-2fbe-44d7-b9a4-163040e69d89")
+    job_url = "https://www.linkedin.com/jobs/view/4375576106"
+    try:
+        _seed_current_job(conn, job_id=job_id, url=job_url, title="Director")
+        resolved_urls: list[str] = []
+        resolve_current_job_id = detail._resolve_current_enrichment_job_id
+
+        def resolve_once(current_conn, url: str):
+            resolved_urls.append(url)
+            return resolve_current_job_id(current_conn, url)
+
+        monkeypatch.setenv("JOBCTRL_LINKEDIN_APPLY_RESOLVER", "0")
+        monkeypatch.setattr(detail, "sync_playwright", lambda: _FakePlaywright())
+        monkeypatch.setattr(detail, "_resolve_current_enrichment_job_id", resolve_once)
+        monkeypatch.setattr(
+            detail,
+            "scrape_detail_page",
+            lambda _page, _url, session=None: {
+                "status": "ok",
+                "tier_used": 1,
+                "full_description": _long_description(),
+                "application_url": f"{job_url}/apply",
+                "elapsed": 1.0,
+                "active_state": "active",
+                "verification_method": "json_ld",
+            },
+        )
+
+        stats = detail.scrape_site_batch(
+            conn, "linkedin", [(job_url, "Director")], gateway=offline_gateway()
+        )
+
+        aggregate = SqliteEnrichmentRepository(conn).load(LOCAL_TENANT, job_id)
+        snapshot = conn.execute(
+            """
+            SELECT job_id FROM posting_snapshot_sets
+            WHERE tenant_id = ? AND job_id = ?
+            """,
+            (str(LOCAL_TENANT), str(job_id)),
+        ).fetchone()
+        stage = conn.execute(
+            """
+            SELECT job_id, state FROM job_stage_states
+            WHERE tenant_id = ? AND job_id = ? AND stage = 'enrich'
+            """,
+            (str(LOCAL_TENANT), str(job_id)),
+        ).fetchone()
+        event = conn.execute(
+            """
+            SELECT job_id, payload_json FROM job_events
+            WHERE tenant_id = ? AND job_id = ? AND event_type = 'StageCompleted'
+            ORDER BY event_id DESC LIMIT 1
+            """,
+            (str(LOCAL_TENANT), str(job_id)),
+        ).fetchone()
+
+        assert stats == {
+            "processed": 1,
+            "ok": 1,
+            "partial": 0,
+            "error": 0,
+            "blocked": 0,
+            "tiers": {1: 1, 2: 0, 3: 0},
+        }
+        assert aggregate is not None and aggregate.is_enriched
+        assert aggregate.job_id == job_id
+        assert resolved_urls == [job_url]
+        assert snapshot is not None and snapshot["job_id"] == str(job_id)
+        assert stage is not None and stage["job_id"] == str(job_id)
+        assert stage["state"] == "succeeded"
+        assert event is not None and event["job_id"] == str(job_id)
+        assert json.loads(event["payload_json"])["jobId"] == str(job_id)
     finally:
         close_connection(db_path)
 
@@ -415,20 +526,48 @@ def test_selected_enrichment_filters_retry_to_requested_job(monkeypatch: pytest.
     ]
 
 
-def test_inactive_cascade_snapshot_persists_closed_state(tmp_path: Path) -> None:
+def _seed_current_job(
+    conn, *, job_id, url: str, title: str = "Closed engineering role"
+) -> None:
+    discovered_at = "2026-05-29T10:00:00+00:00"
+    conn.execute(
+        """
+        INSERT INTO jobs (tenant_id, job_id, url, title, company, site, discovered_at)
+        VALUES (?, ?, ?, ?, 'Example', 'example', ?)
+        """,
+        (str(LOCAL_TENANT), str(job_id), url, title, discovered_at),
+    )
+    conn.execute(
+        """
+        INSERT INTO job_locators (
+            tenant_id, job_id, locator_kind, locator_value,
+            is_current, first_seen_at, last_seen_at
+        ) VALUES (?, ?, 'posting_url', ?, 1, ?, ?)
+        """,
+        (str(LOCAL_TENANT), str(job_id), url, discovered_at, discovered_at),
+    )
+    conn.commit()
+
+
+def test_inactive_cascade_snapshot_uses_current_job_id_and_keeps_url_as_locator(
+    tmp_path: Path,
+) -> None:
     db_path = tmp_path / "jobs.db"
     conn = init_db(db_path)
+    job_id = canonical_job_id("43c31e55-7ac4-4e5f-afbe-7612180ef829")
+    url = "https://example.com/jobs/closed"
     try:
+        _seed_current_job(conn, job_id=job_id, url=url)
         _record_posting_snapshot_from_cascade(
             conn,
-            url="https://example.com/jobs/closed",
+            url=url,
             source_id="jobspy",
             title="Closed engineering role",
             cascade_result={
                 "status": "inactive",
                 "tier_used": 1,
                 "full_description": _long_description(),
-                "application_url": "https://example.com/jobs/closed/apply",
+                "application_url": None,
                 "active_state": "closed",
                 "verification_method": "closed_marker",
             },
@@ -437,23 +576,97 @@ def test_inactive_cascade_snapshot_persists_closed_state(tmp_path: Path) -> None
 
         snapshot_set = conn.execute(
             """
-            SELECT latest_active_state
+            SELECT job_id, latest_active_state
             FROM posting_snapshot_sets
-            WHERE tenant_id = 'local' AND job_url = ?
+            WHERE tenant_id = 'local' AND job_id = ?
             """,
-            ("https://example.com/jobs/closed",),
+            (str(job_id),),
         ).fetchone()
         event = conn.execute(
             """
-            SELECT payload_json
+            SELECT job_id, payload_json, entity_ref
             FROM job_events
-            WHERE event_type = 'JobActiveStateChanged'
+            WHERE event_type = 'PostingContentSnapshotCaptured'
             ORDER BY event_id DESC
             LIMIT 1
             """
         ).fetchone()
 
+        quarantine = conn.execute(
+            """
+            SELECT job_id, posting_url
+            FROM discovery_quarantine_entries
+            WHERE tenant_id = 'local' AND job_id = ?
+            """,
+            (str(job_id),),
+        ).fetchone()
+
+        assert snapshot_set["job_id"] == str(job_id)
         assert snapshot_set["latest_active_state"] == "closed"
-        assert json.loads(event["payload_json"])["active_state"] == "closed"
+        assert event["job_id"] == str(job_id)
+        payload = json.loads(event["payload_json"])
+        assert payload["jobId"] == str(job_id)
+        assert payload["snapshotRef"] == f"{job_id}:1"
+        assert event["entity_ref"] == f"{job_id}:1"
+        assert quarantine is not None
+        assert quarantine["job_id"] == str(job_id)
+        assert quarantine["posting_url"] == url
+        assert "job_url" not in {
+            row["name"] for row in conn.execute("PRAGMA table_info(posting_snapshot_sets)")
+        }
+        assert "job_key" not in {
+            row["name"]
+            for row in conn.execute("PRAGMA table_info(discovery_quarantine_entries)")
+        }
+    finally:
+        close_connection(db_path)
+
+
+def test_snapshot_failure_uses_current_job_id_for_state_and_events(tmp_path: Path) -> None:
+    db_path = tmp_path / "jobs.db"
+    conn = init_db(db_path)
+    job_id = canonical_job_id("9796a7ae-a520-4d7d-af21-c5474743e580")
+    url = "https://example.com/jobs/removed"
+    try:
+        _seed_current_job(conn, job_id=job_id, url=url)
+        _record_posting_snapshot_failure_from_cascade(
+            conn,
+            url=url,
+            source_id="jobspy",
+            cascade_result={
+                "status": "inactive",
+                "error": "posting removed",
+                "tier_used": 1,
+                "active_state": "removed",
+                "verification_method": "http_status",
+                "http_status": 404,
+            },
+            failed_at="2026-05-29T12:00:00+00:00",
+        )
+
+        snapshot_set = conn.execute(
+            """
+            SELECT job_id, latest_active_state
+            FROM posting_snapshot_sets
+            WHERE tenant_id = 'local' AND job_id = ?
+            """,
+            (str(job_id),),
+        ).fetchone()
+        event = conn.execute(
+            """
+            SELECT job_id, payload_json
+            FROM job_events
+            WHERE event_type = 'PostingContentSnapshotFailed'
+            ORDER BY event_id DESC
+            LIMIT 1
+            """
+        ).fetchone()
+
+        assert snapshot_set is not None
+        assert snapshot_set["job_id"] == str(job_id)
+        assert snapshot_set["latest_active_state"] == "removed"
+        assert event is not None
+        assert event["job_id"] == str(job_id)
+        assert json.loads(event["payload_json"])["jobId"] == str(job_id)
     finally:
         close_connection(db_path)

--- a/workers/automation/tests/test_enrichment_detail_staleness.py
+++ b/workers/automation/tests/test_enrichment_detail_staleness.py
@@ -6,12 +6,17 @@ from pathlib import Path
 import pytest
 
 from jobctrl.database import close_connection, init_db
+from jobctrl.domain.enrichment import EnrichmentError, ExtractionTier, JobEnrichment
+from jobctrl.domain.identifiers import canonical_job_id
+from jobctrl.domain.tenant import LOCAL_TENANT
 from jobctrl.enrichment import detail
 from jobctrl.enrichment.detail import (
     _detail_failure_retryable,
     _record_posting_snapshot_from_cascade,
+    _reset_authenticated_linkedin_retry_candidates,
     scrape_detail_page,
 )
+from jobctrl.infrastructure.enrichment import SqliteEnrichmentRepository
 from jobctrl.infrastructure.network import PublicUrlDecision
 
 from .politeness_helpers import offline_gateway, offline_session
@@ -166,6 +171,109 @@ def test_verified_inactive_detail_failure_is_not_retryable() -> None:
             "verification_method": "http_status",
         }
     ) is False
+
+
+def test_authenticated_linkedin_retry_resets_only_exact_v7_aggregate(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    db_path = tmp_path / "jobs.db"
+    conn = init_db(db_path)
+    job_id = canonical_job_id("d7ac9089-caf0-4eb9-82fb-f56b168e9707")
+    job_url = "https://www.linkedin.com/jobs/view/4375576106"
+    try:
+        conn.execute(
+            """
+            INSERT INTO jobs (
+                tenant_id, job_id, url, title, site, discovered_at,
+                detail_error, detail_scraped_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                str(LOCAL_TENANT),
+                str(job_id),
+                job_url,
+                "Director of Engineering",
+                "linkedin",
+                "2026-06-04T15:55:20+00:00",
+                "legacy error must remain untouched",
+                "2026-06-04T16:00:00+00:00",
+            ),
+        )
+        conn.execute(
+            """
+            INSERT INTO job_locators (
+                tenant_id, job_id, locator_kind, locator_value,
+                is_current, first_seen_at, last_seen_at
+            ) VALUES (?, ?, 'posting_url', ?, 1, ?, ?)
+            """,
+            (
+                str(LOCAL_TENANT),
+                str(job_id),
+                job_url,
+                "2026-06-04T15:55:20+00:00",
+                "2026-06-04T15:55:20+00:00",
+            ),
+        )
+        failed = (
+            JobEnrichment.empty(
+                tenant_id=LOCAL_TENANT,
+                job_id=job_id,
+                updated_at="2026-06-04T16:00:00+00:00",
+            )
+            .start_attempt(
+                extraction_tier=ExtractionTier.CSS_SELECTORS,
+                started_at="2026-06-04T16:00:00+00:00",
+            )
+            .fail_attempt(
+                error=EnrichmentError(
+                    code="DETAIL_ERROR",
+                    message="login wall",
+                    retryable=True,
+                ),
+                finished_at="2026-06-04T16:00:01+00:00",
+            )
+        )
+        repo = SqliteEnrichmentRepository(conn)
+        repo.save(failed)
+
+        monkeypatch.setattr(detail, "linkedin_apply_resolver_enabled", lambda: True)
+
+        reset_count = _reset_authenticated_linkedin_retry_candidates(
+            conn,
+            job_urls=(job_url,),
+            session=offline_session(conn, site="linkedin"),
+        )
+
+        assert reset_count == 1
+        reset = repo.load(LOCAL_TENANT, job_id)
+        assert reset is not None and reset.is_pending
+        assert reset.attempt_count == 1
+        legacy_row = conn.execute(
+            "SELECT detail_error, detail_scraped_at FROM jobs "
+            "WHERE tenant_id = ? AND job_id = ?",
+            (str(LOCAL_TENANT), str(job_id)),
+        ).fetchone()
+        assert tuple(legacy_row) == (
+            "legacy error must remain untouched",
+            "2026-06-04T16:00:00+00:00",
+        )
+        stage = conn.execute(
+            "SELECT state FROM job_stage_states "
+            "WHERE tenant_id = ? AND job_id = ? AND stage = 'enrich'",
+            (str(LOCAL_TENANT), str(job_id)),
+        ).fetchone()
+        assert stage is not None and stage["state"] == "pending"
+        event = conn.execute(
+            "SELECT job_id, payload_json FROM job_events "
+            "WHERE tenant_id = ? AND event_type = 'StageReset'",
+            (str(LOCAL_TENANT),),
+        ).fetchone()
+        assert event is not None and event["job_id"] == str(job_id)
+        payload = json.loads(event["payload_json"])
+        assert payload["jobId"] == str(job_id)
+        assert "jobUrl" not in payload
+    finally:
+        close_connection(db_path)
 
 
 def test_scrape_site_batch_uses_discovery_description_when_detail_extracts_no_data(

--- a/workers/automation/tests/test_enrichment_detail_staleness.py
+++ b/workers/automation/tests/test_enrichment_detail_staleness.py
@@ -8,7 +8,7 @@ import pytest
 
 from jobctrl.database import close_connection, init_db
 from jobctrl.domain.enrichment import EnrichmentError, ExtractionTier, JobEnrichment
-from jobctrl.domain.identifiers import canonical_job_id
+from jobctrl.domain.identifiers import JobId, canonical_job_id
 from jobctrl.domain.tenant import LOCAL_TENANT
 from jobctrl.enrichment import detail
 from jobctrl.enrichment.detail import (
@@ -270,7 +270,6 @@ def test_authenticated_linkedin_retry_resets_only_exact_v7_aggregate(
 
         reset_count = _reset_authenticated_linkedin_retry_candidates(
             conn,
-            job_urls=(job_url,),
             session=offline_session(conn, site="linkedin"),
         )
 
@@ -315,20 +314,14 @@ def test_scrape_site_batch_resolves_url_once_before_exact_v7_writes(
     job_url = "https://www.linkedin.com/jobs/view/4375576106"
     try:
         _seed_current_job(conn, job_id=job_id, url=job_url, title="Director")
-        resolved_urls: list[str] = []
-        resolve_current_job_id = detail._resolve_current_enrichment_job_id
-
-        def resolve_once(current_conn, url: str):
-            resolved_urls.append(url)
-            return resolve_current_job_id(current_conn, url)
+        fetched_urls: list[str] = []
 
         monkeypatch.setenv("JOBCTRL_LINKEDIN_APPLY_RESOLVER", "0")
         monkeypatch.setattr(detail, "sync_playwright", lambda: _FakePlaywright())
-        monkeypatch.setattr(detail, "_resolve_current_enrichment_job_id", resolve_once)
         monkeypatch.setattr(
             detail,
             "scrape_detail_page",
-            lambda _page, _url, session=None: {
+            lambda _page, _url, session=None: fetched_urls.append(_url) or {
                 "status": "ok",
                 "tier_used": 1,
                 "full_description": _long_description(),
@@ -340,7 +333,11 @@ def test_scrape_site_batch_resolves_url_once_before_exact_v7_writes(
         )
 
         stats = detail.scrape_site_batch(
-            conn, "linkedin", [(job_url, "Director")], gateway=offline_gateway()
+            conn,
+            "linkedin",
+            [(job_id, "Director")],
+            tenant_id=LOCAL_TENANT,
+            gateway=offline_gateway(),
         )
 
         aggregate = SqliteEnrichmentRepository(conn).load(LOCAL_TENANT, job_id)
@@ -377,7 +374,7 @@ def test_scrape_site_batch_resolves_url_once_before_exact_v7_writes(
         }
         assert aggregate is not None and aggregate.is_enriched
         assert aggregate.job_id == job_id
-        assert resolved_urls == [job_url]
+        assert fetched_urls == [job_url]
         assert snapshot is not None and snapshot["job_id"] == str(job_id)
         assert stage is not None and stage["job_id"] == str(job_id)
         assert stage["state"] == "succeeded"
@@ -392,17 +389,21 @@ def test_scrape_site_batch_uses_discovery_description_when_detail_extracts_no_da
 ) -> None:
     db_path = tmp_path / "jobs.db"
     conn = init_db(db_path)
+    tenant_id = "local"
+    job_id = JobId("60000000-0000-4000-8000-000000000011")
     job_url = "https://www.linkedin.com/jobs/view/4375576106"
     description = _long_description()
     try:
         conn.execute(
             """
             INSERT INTO jobs (
-                url, title, description, full_description, location, site,
-                strategy, discovered_at, application_url, company
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                tenant_id, job_id, url, title, description, full_description,
+                location, site, strategy, discovered_at, application_url, company
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
+                tenant_id,
+                str(job_id),
                 job_url,
                 "Director of Engineering",
                 description,
@@ -413,6 +414,21 @@ def test_scrape_site_batch_uses_discovery_description_when_detail_extracts_no_da
                 "2026-06-04T15:55:20+00:00",
                 None,
                 "Checkatrade",
+            ),
+        )
+        conn.execute(
+            """
+            INSERT INTO job_locators (
+                tenant_id, job_id, locator_kind, locator_value, is_current,
+                first_seen_at, last_seen_at, retired_at
+            ) VALUES (?, ?, 'posting_url', ?, 1, ?, ?, NULL)
+            """,
+            (
+                tenant_id,
+                str(job_id),
+                job_url,
+                "2026-06-04T15:55:20+00:00",
+                "2026-06-04T15:55:20+00:00",
             ),
         )
         conn.commit()
@@ -438,7 +454,11 @@ def test_scrape_site_batch_uses_discovery_description_when_detail_extracts_no_da
         )
 
         stats = detail.scrape_site_batch(
-            conn, "linkedin", [(job_url, "Director")], gateway=offline_gateway()
+            conn,
+            "linkedin",
+            [(job_id, "Director")],
+            tenant_id=tenant_id,
+            gateway=offline_gateway(),
         )
 
         assert stats["processed"] == 1
@@ -449,9 +469,9 @@ def test_scrape_site_batch_uses_discovery_description_when_detail_extracts_no_da
             """
             SELECT current_status, full_description, attempts_json
             FROM job_enrichments
-            WHERE job_url = ?
+            WHERE tenant_id = ? AND job_id = ?
             """,
-            (job_url,),
+            (tenant_id, str(job_id)),
         ).fetchone()
         assert enrichment["current_status"] == "enriched"
         assert enrichment["full_description"] == description.strip()
@@ -462,9 +482,9 @@ def test_scrape_site_batch_uses_discovery_description_when_detail_extracts_no_da
             """
             SELECT state, metadata_json
             FROM job_stage_states
-            WHERE job_url = ? AND stage = 'enrich'
+            WHERE tenant_id = ? AND job_id = ? AND stage = 'enrich'
             """,
-            (job_url,),
+            (tenant_id, str(job_id)),
         ).fetchone()
         assert stage["state"] == "succeeded"
         assert json.loads(stage["metadata_json"]) == {
@@ -477,11 +497,11 @@ def test_scrape_site_batch_uses_discovery_description_when_detail_extracts_no_da
             """
             SELECT payload_json
             FROM job_events
-            WHERE job_url = ? AND event_type = 'StageCompleted'
+            WHERE tenant_id = ? AND job_id = ? AND event_type = 'StageCompleted'
             ORDER BY event_id DESC
             LIMIT 1
             """,
-            (job_url,),
+            (tenant_id, str(job_id)),
         ).fetchone()
         payload = json.loads(event["payload_json"])
         assert payload["fallbackSource"] == "discovery"
@@ -507,10 +527,9 @@ def test_selected_enrichment_filters_retry_to_requested_job(monkeypatch: pytest.
     result = _run_selected_enrichment(
         EnrichActivityInput(
             tenant_id="local",
-            job_urls=(
-                "https://example.com/jobs/selected",
-                "https://example.com/jobs/selected",
-                "",
+            job_ids=(
+                JobId("60000000-0000-4000-8000-000000000010"),
+                JobId("60000000-0000-4000-8000-000000000010"),
             ),
             limit=1,
         )
@@ -521,7 +540,8 @@ def test_selected_enrichment_filters_retry_to_requested_job(monkeypatch: pytest.
         {
             "max_per_site": 1,
             "workers": 1,
-            "job_urls": ("https://example.com/jobs/selected",),
+            "tenant_id": "local",
+            "job_ids": (JobId("60000000-0000-4000-8000-000000000010"),),
         }
     ]
 
@@ -560,6 +580,7 @@ def test_inactive_cascade_snapshot_uses_current_job_id_and_keeps_url_as_locator(
         _seed_current_job(conn, job_id=job_id, url=url)
         _record_posting_snapshot_from_cascade(
             conn,
+            job_id=job_id,
             url=url,
             source_id="jobspy",
             title="Closed engineering role",
@@ -631,6 +652,7 @@ def test_snapshot_failure_uses_current_job_id_for_state_and_events(tmp_path: Pat
         _seed_current_job(conn, job_id=job_id, url=url)
         _record_posting_snapshot_failure_from_cascade(
             conn,
+            job_id=job_id,
             url=url,
             source_id="jobspy",
             cascade_result={

--- a/workers/automation/tests/test_enrichment_queue_selectors.py
+++ b/workers/automation/tests/test_enrichment_queue_selectors.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import sqlite3
 from datetime import datetime, timezone
 from pathlib import Path
+from uuid import NAMESPACE_URL, uuid5
 
 import pytest
 
@@ -39,7 +40,7 @@ from jobctrl.domain.enrichment import (
     FullDescription,
     JobEnrichment,
 )
-from jobctrl.domain.identifiers import JobId
+from jobctrl.domain.identifiers import JobId, canonical_job_id
 from jobctrl.domain.tenant import LOCAL_TENANT
 from jobctrl.infrastructure.enrichment import SqliteEnrichmentRepository
 from jobctrl.state import utc_now
@@ -50,34 +51,48 @@ def conn(tmp_path: Path) -> sqlite3.Connection:
     return init_db(tmp_path / "jobctrl.db")
 
 
-def _seed_discovered(conn: sqlite3.Connection, url: str) -> None:
+def _seed_discovered(conn: sqlite3.Connection, url: str) -> JobId:
     """Insert a discovered Job row WITHOUT any legacy enrichment columns."""
+    job_id = canonical_job_id(str(uuid5(NAMESPACE_URL, f"{LOCAL_TENANT}:{url}")))
+    discovered_at = "2024-01-01T00:00:00+00:00"
     conn.execute(
-        "INSERT INTO jobs (url, title, site, discovered_at) VALUES (?, ?, ?, ?)",
-        (url, "Engineer", "Acme", "2024-01-01T00:00:00+00:00"),
+        """
+        INSERT INTO jobs (tenant_id, job_id, url, title, site, discovered_at)
+        VALUES (?, ?, ?, ?, ?, ?)
+        """,
+        (str(LOCAL_TENANT), str(job_id), url, "Engineer", "Acme", discovered_at),
+    )
+    conn.execute(
+        """
+        INSERT INTO job_locators (
+            tenant_id, job_id, locator_kind, locator_value,
+            is_current, first_seen_at, last_seen_at
+        ) VALUES (?, ?, 'posting_url', ?, 1, ?, ?)
+        """,
+        (str(LOCAL_TENANT), str(job_id), url, discovered_at, discovered_at),
     )
     conn.commit()
+    return job_id
 
 
-def _mark_closed(conn: sqlite3.Connection, url: str, state: str = "removed") -> None:
+def _mark_closed(conn: sqlite3.Connection, job_id: JobId, state: str = "removed") -> None:
     conn.execute(
         """
         INSERT INTO posting_snapshot_sets (
-            tenant_id, job_url, snapshot_set_json, latest_snapshot_version,
-            latest_active_state, updated_at
-        ) VALUES (?, ?, '{}', 0, ?, ?)
-        ON CONFLICT(tenant_id, job_url) DO UPDATE SET
+            tenant_id, job_id, snapshot_set_json, latest_active_state, updated_at
+        ) VALUES (?, ?, '{}', ?, ?)
+        ON CONFLICT(tenant_id, job_id) DO UPDATE SET
             latest_active_state = excluded.latest_active_state,
             updated_at = excluded.updated_at
         """,
-        (str(LOCAL_TENANT), url, state, utc_now()),
+        (str(LOCAL_TENANT), str(job_id), state, utc_now()),
     )
     conn.commit()
 
 
 def _save_enriched(
     conn: sqlite3.Connection,
-    url: str,
+    job_id: JobId,
     *,
     description: str = "Real description from repository",
     apply_url: str = "https://apply",
@@ -87,7 +102,7 @@ def _save_enriched(
     agg = (
         JobEnrichment.empty(
             tenant_id=LOCAL_TENANT,
-            job_id=JobId(url),
+            job_id=job_id,
             updated_at=datetime.now(timezone.utc).isoformat(),
         )
         .start_attempt(
@@ -104,12 +119,12 @@ def _save_enriched(
     repo.save(agg)
 
 
-def _save_failed(conn: sqlite3.Connection, url: str) -> None:
+def _save_failed(conn: sqlite3.Connection, job_id: JobId) -> None:
     repo = SqliteEnrichmentRepository(conn)
     agg = (
         JobEnrichment.empty(
             tenant_id=LOCAL_TENANT,
-            job_id=JobId(url),
+            job_id=job_id,
             updated_at="t0",
         )
         .start_attempt(extraction_tier=ExtractionTier.JSON_LD, started_at="t0")
@@ -121,6 +136,49 @@ def _save_failed(conn: sqlite3.Connection, url: str) -> None:
     repo.save(agg)
 
 
+def _save_score(conn: sqlite3.Connection, job_id: JobId, fit_score: int) -> None:
+    conn.execute(
+        """
+        INSERT INTO job_scores (
+            tenant_id, job_id, version, fit_score, breakdown_json,
+            keywords_json, scored_at
+        ) VALUES (?, ?, 1, ?, '{}', '[]', ?)
+        """,
+        (str(LOCAL_TENANT), str(job_id), fit_score, utc_now()),
+    )
+    conn.commit()
+
+
+def _save_approved_resume_with_pdf(conn: sqlite3.Connection, job_id: JobId) -> None:
+    created_at = utc_now()
+    conn.execute(
+        """
+        INSERT INTO job_materials (
+            tenant_id, job_id, generation, status, created_at, updated_at
+        ) VALUES (?, ?, 1, 'approved', ?, ?)
+        """,
+        (str(LOCAL_TENANT), str(job_id), created_at, created_at),
+    )
+    for artifact_type in ("tailored_resume", "resume_pdf"):
+        conn.execute(
+            """
+            INSERT INTO job_materials_artifacts (
+                tenant_id, job_id, generation, artifact_type, artifact_id,
+                status, path, render_format, created_at
+            ) VALUES (?, ?, 1, ?, ?, 'approved', ?, 'text', ?)
+            """,
+            (
+                str(LOCAL_TENANT),
+                str(job_id),
+                artifact_type,
+                f"{job_id}:{artifact_type}",
+                f"/tmp/{job_id}-{artifact_type}",
+                created_at,
+            ),
+        )
+    conn.commit()
+
+
 # ---------------------------------------------------------------------------
 # Queue selectors
 # ---------------------------------------------------------------------------
@@ -130,9 +188,9 @@ def test_pending_detail_excludes_jobs_with_enrichment_row(conn: sqlite3.Connecti
     """A job whose enrichment landed in job_enrichments should NOT be
     re-picked by ``pending_detail``. Without the new join the selector
     would loop forever because ``jobs.detail_scraped_at`` is NULL."""
-    _seed_discovered(conn, "https://example.com/jobs/1")
+    enriched_job_id = _seed_discovered(conn, "https://example.com/jobs/1")
     _seed_discovered(conn, "https://example.com/jobs/2")
-    _save_enriched(conn, "https://example.com/jobs/1")
+    _save_enriched(conn, enriched_job_id)
 
     rows = get_jobs_by_stage(conn, "pending_detail")
     urls = {row["url"] for row in rows}
@@ -147,11 +205,11 @@ def test_closed_postings_are_excluded_from_enrichment_queues(
 
     pending_url = "https://example.com/jobs/closed-pending-detail"
     enriched_url = "https://example.com/jobs/closed-enriched"
-    _seed_discovered(conn, pending_url)
-    _seed_discovered(conn, enriched_url)
-    _save_enriched(conn, enriched_url)
-    _mark_closed(conn, pending_url)
-    _mark_closed(conn, enriched_url)
+    pending_job_id = _seed_discovered(conn, pending_url)
+    enriched_job_id = _seed_discovered(conn, enriched_url)
+    _save_enriched(conn, enriched_job_id)
+    _mark_closed(conn, pending_job_id)
+    _mark_closed(conn, enriched_job_id)
     monkeypatch.setattr(pipeline_runner, "get_connection", lambda: conn)
 
     assert {row["url"] for row in get_jobs_by_stage(conn, "pending_detail")} == set()
@@ -164,17 +222,17 @@ def test_closed_postings_are_excluded_from_enrichment_queues(
 def test_pending_score_includes_jobs_enriched_via_repository(conn: sqlite3.Connection) -> None:
     """``pending_score`` must read through ``_EFFECTIVE_FULL_DESCRIPTION``
     so newly-enriched jobs appear immediately."""
-    _seed_discovered(conn, "https://example.com/jobs/1")
-    _save_enriched(conn, "https://example.com/jobs/1")
+    job_id = _seed_discovered(conn, "https://example.com/jobs/1")
+    _save_enriched(conn, job_id)
     rows = get_jobs_by_stage(conn, "pending_score")
     assert len(rows) == 1
     assert rows[0]["url"] == "https://example.com/jobs/1"
 
 
 def test_enriched_selector_returns_jobs_enriched_via_repository(conn: sqlite3.Connection) -> None:
-    _seed_discovered(conn, "https://example.com/jobs/1")
+    enriched_job_id = _seed_discovered(conn, "https://example.com/jobs/1")
     _seed_discovered(conn, "https://example.com/jobs/2")
-    _save_enriched(conn, "https://example.com/jobs/1")
+    _save_enriched(conn, enriched_job_id)
     rows = get_jobs_by_stage(conn, "enriched")
     assert {row["url"] for row in rows} == {"https://example.com/jobs/1"}
 
@@ -185,10 +243,10 @@ def test_jobs_by_stage_promotes_je_columns_into_legacy_slots(
     """Legacy consumers reading ``row["full_description"]`` /
     ``row["application_url"]`` / ``row["detail_scraped_at"]`` should
     see the canonical values from ``job_enrichments``."""
-    _seed_discovered(conn, "https://example.com/jobs/1")
+    job_id = _seed_discovered(conn, "https://example.com/jobs/1")
     _save_enriched(
         conn,
-        "https://example.com/jobs/1",
+        job_id,
         description="From repository write",
         apply_url="https://example.com/apply",
     )
@@ -205,17 +263,17 @@ def test_jobs_by_stage_promotes_je_columns_into_legacy_slots(
 
 
 def test_stats_pending_detail_reads_through_enrichment_join(conn: sqlite3.Connection) -> None:
-    _seed_discovered(conn, "https://example.com/jobs/1")
+    enriched_job_id = _seed_discovered(conn, "https://example.com/jobs/1")
     _seed_discovered(conn, "https://example.com/jobs/2")
-    _save_enriched(conn, "https://example.com/jobs/1")
+    _save_enriched(conn, enriched_job_id)
     stats = get_stats(conn)
     assert stats["pending_detail"] == 1  # only jobs/2
     assert stats["with_description"] == 1
 
 
 def test_stats_detail_errors_reads_failed_status(conn: sqlite3.Connection) -> None:
-    _seed_discovered(conn, "https://example.com/jobs/1")
-    _save_failed(conn, "https://example.com/jobs/1")
+    job_id = _seed_discovered(conn, "https://example.com/jobs/1")
+    _save_failed(conn, job_id)
     stats = get_stats(conn)
     assert stats["detail_errors"] >= 1
 
@@ -223,14 +281,10 @@ def test_stats_detail_errors_reads_failed_status(conn: sqlite3.Connection) -> No
 def test_pending_apply_reads_through_application_url_join(conn: sqlite3.Connection) -> None:
     """The ``pending_apply`` selector requires application_url; the new
     enrichment join must surface it from ``job_enrichments``."""
-    _seed_discovered(conn, "https://example.com/jobs/1")
-    _save_enriched(conn, "https://example.com/jobs/1")
-    # Materialise a tailored resume so pending_apply unblocks
-    conn.execute(
-        "UPDATE jobs SET tailored_resume_path = ?, fit_score = 8 WHERE url = ?",
-        ("/tmp/foo.tex", "https://example.com/jobs/1"),
-    )
-    conn.commit()
+    job_id = _seed_discovered(conn, "https://example.com/jobs/1")
+    _save_enriched(conn, job_id)
+    _save_score(conn, job_id, 8)
+    _save_approved_resume_with_pdf(conn, job_id)
     rows = get_jobs_by_stage(conn, "pending_apply")
     assert len(rows) == 1
     assert rows[0]["application_url"] == "https://apply"
@@ -252,19 +306,19 @@ def test_reset_job_stage_enrich_clears_job_enrichments_aggregate(
     from jobctrl.state import reset_job_stage
 
     url = "https://example.com/jobs/RESET"
-    _seed_discovered(conn, url)
-    _save_enriched(conn, url)
+    job_id = _seed_discovered(conn, url)
+    _save_enriched(conn, job_id)
 
     # Sanity check: the row IS enriched after the save.
     repo = SqliteEnrichmentRepository(conn)
-    loaded = repo.load(LOCAL_TENANT, JobId(url))
+    loaded = repo.load(LOCAL_TENANT, job_id)
     assert loaded is not None and loaded.is_enriched
 
     # The reset call clears the aggregate (B1 fix).
     reset_job_stage(conn, url, "enrich", reset_attempts=True)
 
     # Aggregate is now pending — terminal-state fields cleared.
-    after_reset = repo.load(LOCAL_TENANT, JobId(url))
+    after_reset = repo.load(LOCAL_TENANT, job_id)
     assert after_reset is not None
     assert after_reset.is_pending
     assert after_reset.full_description is None
@@ -309,9 +363,9 @@ def test_pending_sql_enrich_excludes_new_path_enriched_jobs(
     of the count."""
     from jobctrl.pipeline import _PENDING_SQL
 
-    _seed_discovered(conn, "https://example.com/jobs/A")
+    enriched_job_id = _seed_discovered(conn, "https://example.com/jobs/A")
     _seed_discovered(conn, "https://example.com/jobs/B")
-    _save_enriched(conn, "https://example.com/jobs/A")
+    _save_enriched(conn, enriched_job_id)
 
     pending_count = conn.execute(_PENDING_SQL["enrich"]).fetchone()[0]
     assert pending_count == 1  # only B is pending
@@ -328,20 +382,25 @@ def test_pending_detail_excludes_legacy_stage_succeeded_without_aggregate(
 
     legacy_url = "https://example.com/jobs/LEGACY"
     pending_url = "https://example.com/jobs/PENDING"
-    _seed_discovered(conn, legacy_url)
+    legacy_job_id = _seed_discovered(conn, legacy_url)
     _seed_discovered(conn, pending_url)
     conn.execute(
         """
         UPDATE jobs
         SET full_description = ?, detail_scraped_at = ?
-        WHERE url = ?
+        WHERE tenant_id = ? AND job_id = ?
         """,
-        ("Legacy description", "2024-01-02T00:00:00+00:00", legacy_url),
+        (
+            "Legacy description",
+            "2024-01-02T00:00:00+00:00",
+            str(LOCAL_TENANT),
+            str(legacy_job_id),
+        ),
     )
-    ensure_job_stage_rows(conn, legacy_url)
+    ensure_job_stage_rows(conn, legacy_job_id)
     set_stage_state(
         conn,
-        legacy_url,
+        legacy_job_id,
         "enrich",
         "succeeded",
         finished_at="2024-01-02T00:00:00+00:00",
@@ -363,20 +422,25 @@ def test_run_detail_scraper_skips_legacy_stage_succeeded_without_aggregate(
 
     legacy_url = "https://example.com/jobs/LEGACY-RUNNER"
     pending_url = "https://example.com/jobs/PENDING-RUNNER"
-    _seed_discovered(conn, legacy_url)
-    _seed_discovered(conn, pending_url)
+    legacy_job_id = _seed_discovered(conn, legacy_url)
+    pending_job_id = _seed_discovered(conn, pending_url)
     conn.execute(
         """
         UPDATE jobs
         SET full_description = ?, detail_scraped_at = ?
-        WHERE url = ?
+        WHERE tenant_id = ? AND job_id = ?
         """,
-        ("Legacy description", "2024-01-02T00:00:00+00:00", legacy_url),
+        (
+            "Legacy description",
+            "2024-01-02T00:00:00+00:00",
+            str(LOCAL_TENANT),
+            str(legacy_job_id),
+        ),
     )
-    ensure_job_stage_rows(conn, legacy_url)
+    ensure_job_stage_rows(conn, legacy_job_id)
     set_stage_state(
         conn,
-        legacy_url,
+        legacy_job_id,
         "enrich",
         "succeeded",
         finished_at="2024-01-02T00:00:00+00:00",
@@ -402,7 +466,7 @@ def test_run_detail_scraper_skips_legacy_stage_succeeded_without_aggregate(
 
     detail._run_detail_scraper(conn, max_per_site=1, workers=1)
 
-    assert batches == [[(pending_url, "Engineer")]]
+    assert batches == [[(str(pending_job_id), "Engineer")]]
 
 
 def test_pending_sql_score_includes_new_path_enriched_jobs(
@@ -414,8 +478,8 @@ def test_pending_sql_score_includes_new_path_enriched_jobs(
     the new path and the count stays at 0 forever."""
     from jobctrl.pipeline import _PENDING_SQL
 
-    _seed_discovered(conn, "https://example.com/jobs/A")
-    _save_enriched(conn, "https://example.com/jobs/A")
+    job_id = _seed_discovered(conn, "https://example.com/jobs/A")
+    _save_enriched(conn, job_id)
 
     pending_score = conn.execute(_PENDING_SQL["score"]).fetchone()[0]
     assert pending_score == 1
@@ -426,18 +490,14 @@ def test_pending_sql_tailor_sees_new_path_enriched_scored_jobs(
 ) -> None:
     """The ``tailor`` predicate also reads
     ``_EFFECTIVE_FULL_DESCRIPTION`` — a job enriched via the repository
-    AND scored via the legacy column should surface for tailoring."""
+    AND scored via the canonical aggregate should surface for tailoring."""
     from jobctrl.pipeline import _PENDING_SQL
 
-    _seed_discovered(conn, "https://example.com/jobs/A")
-    _save_enriched(conn, "https://example.com/jobs/A")
-    # Score via the legacy column (so we exercise the ENRICHMENT join
-    # alone — the score join is tested separately).
-    conn.execute(
-        "UPDATE jobs SET fit_score = 9 WHERE url = ?",
-        ("https://example.com/jobs/A",),
-    )
-    conn.commit()
+    job_id = _seed_discovered(conn, "https://example.com/jobs/A")
+    _save_enriched(conn, job_id)
+    # Score through the canonical aggregate so this test isolates the
+    # enrichment join; score-join behavior is covered separately.
+    _save_score(conn, job_id, 9)
 
     pending_tailor = conn.execute(_PENDING_SQL["tailor"], (7,)).fetchone()[0]
     assert pending_tailor == 1

--- a/workers/automation/tests/test_enrichment_repository.py
+++ b/workers/automation/tests/test_enrichment_repository.py
@@ -1,341 +1,333 @@
-"""Phase 7 / S-26: SqliteEnrichmentRepository round-trip + backfill + queue.
+"""Exact-v7 persistence contract for ``SqliteEnrichmentRepository``.
 
-Pin the repository's contract: round-trip JobEnrichment aggregates,
-list_pending sees jobs without an enrichment row, list_failed surfaces
-the failed aggregates, and the legacy backfill produces the right shape.
+Enrichment aggregates are identified solely by ``(tenant_id, job_id)``.
+Posting URLs are inserted only as current job locators so this suite catches
+any accidental regression to URL-shaped persistence identity.
 """
 
 from __future__ import annotations
 
-import json
 import sqlite3
+import uuid
 
 import pytest
 
 from jobctrl.database import init_db
 from jobctrl.domain.enrichment import (
     ApplicationUrl,
+    EnrichmentError,
     ExtractionTier,
     FullDescription,
     JobEnrichment,
 )
-from jobctrl.domain.identifiers import JobId
-from jobctrl.domain.tenant import LOCAL_TENANT
+from jobctrl.domain.identifiers import JobId, canonical_job_id
+from jobctrl.domain.tenant import LOCAL_TENANT, TenantId
 from jobctrl.infrastructure.enrichment import SqliteEnrichmentRepository
+
+
+OTHER_TENANT = TenantId("other")
+SHARED_URL = "https://example.test/jobs/shared"
 
 
 @pytest.fixture
 def conn(tmp_path) -> sqlite3.Connection:
-    db_path = tmp_path / "jobctrl.db"
-    return init_db(db_path)
+    return init_db(tmp_path / "jobctrl.db")
 
 
-def _insert_job(conn: sqlite3.Connection, url: str, **legacy_cols) -> None:
-    """Insert a discovery row with optional legacy enrichment columns."""
-    base_cols = ["url", "title", "site", "discovered_at"]
-    base_vals = [url, legacy_cols.pop("title", "Some title"), "greenhouse", "2026-05-01T00:00:00+00:00"]
-    cols = list(base_cols)
-    vals: list = list(base_vals)
-    for k, v in legacy_cols.items():
-        cols.append(k)
-        vals.append(v)
-    placeholders = ", ".join(["?"] * len(cols))
+def _job_id(*, tenant_id: TenantId, url: str) -> JobId:
+    return canonical_job_id(str(uuid.uuid5(uuid.NAMESPACE_URL, f"{tenant_id}:{url}")))
+
+
+def _insert_job(
+    conn: sqlite3.Connection,
+    *,
+    tenant_id: TenantId,
+    job_id: JobId,
+    url: str,
+    discovered_at: str = "2026-07-31T12:00:00+00:00",
+) -> None:
     conn.execute(
-        f"INSERT INTO jobs ({', '.join(cols)}) VALUES ({placeholders})",
-        vals,
+        """
+        INSERT INTO jobs (tenant_id, job_id, url, title, company, site, discovered_at)
+        VALUES (?, ?, ?, 'Platform Engineer', 'Example', 'example', ?)
+        """,
+        (str(tenant_id), str(job_id), url, discovered_at),
+    )
+    conn.execute(
+        """
+        INSERT INTO job_locators (
+            tenant_id, job_id, locator_kind, locator_value,
+            is_current, first_seen_at, last_seen_at
+        ) VALUES (?, ?, 'posting_url', ?, 1, ?, ?)
+        """,
+        (str(tenant_id), str(job_id), url, discovered_at, discovered_at),
     )
     conn.commit()
 
 
-def _make_enriched(url: str = "https://example.com/jobs/1") -> JobEnrichment:
-    agg = JobEnrichment.empty(
+def _enriched(
+    *,
+    tenant_id: TenantId,
+    job_id: JobId,
+    description: str = "The full description",
+) -> JobEnrichment:
+    return (
+        JobEnrichment.empty(tenant_id=tenant_id, job_id=job_id, updated_at="t0")
+        .start_attempt(extraction_tier=ExtractionTier.JSON_LD, started_at="t0")
+        .succeed_attempt(
+            full_description=FullDescription(text=description),
+            application_url=ApplicationUrl(value="https://example.test/apply"),
+            extraction_tier=ExtractionTier.JSON_LD,
+            finished_at="t1",
+        )
+    )
+
+
+def _failed(*, tenant_id: TenantId, job_id: JobId) -> JobEnrichment:
+    return (
+        JobEnrichment.empty(tenant_id=tenant_id, job_id=job_id, updated_at="t0")
+        .start_attempt(extraction_tier=ExtractionTier.CSS_SELECTORS, started_at="t0")
+        .fail_attempt(
+            error=EnrichmentError(code="HTTP_404", message="gone", retryable=False),
+            finished_at="t1",
+        )
+    )
+
+
+def test_save_then_load_round_trips_exact_tenant_job_identity(
+    conn: sqlite3.Connection,
+) -> None:
+    job_id = _job_id(tenant_id=LOCAL_TENANT, url="https://example.test/jobs/1")
+    _insert_job(
+        conn,
         tenant_id=LOCAL_TENANT,
-        job_id=JobId(url),
-        updated_at="t0",
+        job_id=job_id,
+        url="https://example.test/jobs/1",
     )
-    agg = agg.start_attempt(extraction_tier=ExtractionTier.JSON_LD, started_at="t0")
-    return agg.succeed_attempt(
-        full_description=FullDescription(text="The full description"),
-        application_url=ApplicationUrl(value="https://example.com/apply"),
-        extraction_tier=ExtractionTier.JSON_LD,
-        finished_at="t1",
-    )
-
-
-def test_save_then_load_round_trips(conn: sqlite3.Connection) -> None:
-    _insert_job(conn, "https://example.com/jobs/1")
     repo = SqliteEnrichmentRepository(conn)
-    original = _make_enriched()
-    repo.save(original)
+    original = _enriched(tenant_id=LOCAL_TENANT, job_id=job_id)
 
-    loaded = repo.load(LOCAL_TENANT, original.job_id)
+    repo.save(original)
+    loaded = repo.load(LOCAL_TENANT, job_id)
+
     assert loaded is not None
+    assert loaded.tenant_id == LOCAL_TENANT
+    assert loaded.job_id == job_id
     assert loaded.is_enriched
     assert loaded.full_description is not None
     assert loaded.full_description.text == "The full description"
     assert loaded.application_url is not None
-    assert loaded.application_url.value == "https://example.com/apply"
+    assert loaded.application_url.value == "https://example.test/apply"
     assert loaded.extraction_tier is ExtractionTier.JSON_LD
     assert loaded.attempt_count == 1
 
 
-def test_save_upserts_on_repeated_save(conn: sqlite3.Connection) -> None:
-    _insert_job(conn, "https://example.com/jobs/1")
+def test_save_upserts_only_the_same_tenant_job_pair(conn: sqlite3.Connection) -> None:
+    job_id = _job_id(tenant_id=LOCAL_TENANT, url="https://example.test/jobs/1")
+    _insert_job(
+        conn,
+        tenant_id=LOCAL_TENANT,
+        job_id=job_id,
+        url="https://example.test/jobs/1",
+    )
     repo = SqliteEnrichmentRepository(conn)
-    repo.save(_make_enriched())
+    repo.save(_enriched(tenant_id=LOCAL_TENANT, job_id=job_id))
 
-    # Reset + new attempt cycle ⇒ failed
-    from jobctrl.domain.enrichment import EnrichmentError
+    repo.save(_failed(tenant_id=LOCAL_TENANT, job_id=job_id))
 
-    failed = (
-        _make_enriched()
-        .reset(reset_at="t2")
+    assert conn.execute(
+        "SELECT COUNT(*) FROM job_enrichments WHERE tenant_id = ? AND job_id = ?",
+        (str(LOCAL_TENANT), str(job_id)),
+    ).fetchone()[0] == 1
+    loaded = repo.load(LOCAL_TENANT, job_id)
+    assert loaded is not None
+    assert loaded.is_failed
+    assert loaded.attempt_count == 1
+
+
+def test_save_after_reset_round_trips_the_full_attempt_history(
+    conn: sqlite3.Connection,
+) -> None:
+    job_id = _job_id(tenant_id=LOCAL_TENANT, url="https://example.test/jobs/retry")
+    _insert_job(
+        conn,
+        tenant_id=LOCAL_TENANT,
+        job_id=job_id,
+        url="https://example.test/jobs/retry",
+    )
+    repo = SqliteEnrichmentRepository(conn)
+    initial = _enriched(tenant_id=LOCAL_TENANT, job_id=job_id)
+    retried = (
+        initial.reset(reset_at="t2")
         .start_attempt(extraction_tier=ExtractionTier.CSS_SELECTORS, started_at="t3")
         .fail_attempt(
-            error=EnrichmentError(code="HTTP_404", message="gone", retryable=False),
+            error=EnrichmentError(code="HTTP_503", message="retry later", retryable=True),
             finished_at="t4",
         )
     )
-    repo.save(failed)
 
-    loaded = repo.load(LOCAL_TENANT, failed.job_id)
+    repo.save(initial)
+    repo.save(retried)
+
+    loaded = repo.load(LOCAL_TENANT, job_id)
     assert loaded is not None
     assert loaded.is_failed
-    assert loaded.attempt_count == 2  # the prior succeeded + the new failed
+    assert loaded.attempt_count == 2
+    assert [attempt.extraction_tier for attempt in loaded.attempts] == [
+        ExtractionTier.JSON_LD,
+        ExtractionTier.CSS_SELECTORS,
+    ]
+    assert loaded.attempts[0].succeeded
+    assert loaded.attempts[1].failed
+    assert loaded.attempts[1].error is not None
+    assert loaded.attempts[1].error.code == "HTTP_503"
 
 
-def test_load_returns_none_for_unknown_job(conn: sqlite3.Connection) -> None:
+def test_repository_rejects_url_shaped_job_identity(conn: sqlite3.Connection) -> None:
     repo = SqliteEnrichmentRepository(conn)
-    assert repo.load(LOCAL_TENANT, JobId("https://nope/")) is None
+    invalid_job_id = JobId("https://example.test/jobs/not-an-id")
+
+    with pytest.raises(ValueError, match="canonical UUID"):
+        repo.load(LOCAL_TENANT, invalid_job_id)
+    with pytest.raises(ValueError, match="canonical UUID"):
+        repo.save(
+            JobEnrichment.empty(
+                tenant_id=LOCAL_TENANT,
+                job_id=invalid_job_id,
+                updated_at="t0",
+            )
+        )
 
 
-def test_list_pending_includes_jobs_with_no_enrichment(conn: sqlite3.Connection) -> None:
-    _insert_job(conn, "https://example.com/jobs/A")
-    _insert_job(conn, "https://example.com/jobs/B")
-    repo = SqliteEnrichmentRepository(conn)
-    # Save an enrichment for A only
-    repo.save(_make_enriched("https://example.com/jobs/A"))
-    pending = repo.list_pending(LOCAL_TENANT)
-    assert pending == [JobId("https://example.com/jobs/B")]
-
-
-def test_list_pending_includes_jobs_with_pending_status(conn: sqlite3.Connection) -> None:
-    _insert_job(conn, "https://example.com/jobs/A")
-    repo = SqliteEnrichmentRepository(conn)
-    pending_agg = JobEnrichment.empty(
+def test_list_pending_uses_tenant_scoped_job_ids(conn: sqlite3.Connection) -> None:
+    enriched_id = _job_id(tenant_id=LOCAL_TENANT, url="https://example.test/jobs/enriched")
+    missing_id = _job_id(tenant_id=LOCAL_TENANT, url="https://example.test/jobs/missing")
+    pending_id = _job_id(tenant_id=LOCAL_TENANT, url="https://example.test/jobs/pending")
+    other_id = _job_id(tenant_id=OTHER_TENANT, url="https://example.test/jobs/other")
+    _insert_job(
+        conn,
         tenant_id=LOCAL_TENANT,
-        job_id=JobId("https://example.com/jobs/A"),
-        updated_at="t0",
+        job_id=enriched_id,
+        url="https://example.test/jobs/enriched",
     )
-    repo.save(pending_agg)
-    pending = repo.list_pending(LOCAL_TENANT)
-    assert pending == [JobId("https://example.com/jobs/A")]
-
-
-def test_list_pending_excludes_running_and_failed(conn: sqlite3.Connection) -> None:
-    """Running attempts are in flight; failed aggregates wait for explicit retry."""
-    _insert_job(conn, "https://example.com/jobs/R")
-    _insert_job(conn, "https://example.com/jobs/F")
+    _insert_job(
+        conn,
+        tenant_id=LOCAL_TENANT,
+        job_id=missing_id,
+        url="https://example.test/jobs/missing",
+    )
+    _insert_job(
+        conn,
+        tenant_id=LOCAL_TENANT,
+        job_id=pending_id,
+        url="https://example.test/jobs/pending",
+    )
+    _insert_job(
+        conn,
+        tenant_id=OTHER_TENANT,
+        job_id=other_id,
+        url="https://example.test/jobs/other",
+    )
     repo = SqliteEnrichmentRepository(conn)
-    running = JobEnrichment.empty(
-        tenant_id=LOCAL_TENANT, job_id=JobId("https://example.com/jobs/R"), updated_at="t0"
-    ).start_attempt(extraction_tier=ExtractionTier.JSON_LD, started_at="t0")
-    repo.save(running)
-
-    from jobctrl.domain.enrichment import EnrichmentError
-
-    failed = (
+    repo.save(_enriched(tenant_id=LOCAL_TENANT, job_id=enriched_id))
+    repo.save(
         JobEnrichment.empty(
-            tenant_id=LOCAL_TENANT, job_id=JobId("https://example.com/jobs/F"), updated_at="t0"
-        )
-        .start_attempt(extraction_tier=ExtractionTier.JSON_LD, started_at="t0")
-        .fail_attempt(
-            error=EnrichmentError(code="x", message="x", retryable=True),
-            finished_at="t1",
+            tenant_id=LOCAL_TENANT,
+            job_id=pending_id,
+            updated_at="t0",
         )
     )
-    repo.save(failed)
+
+    assert set(repo.list_pending(LOCAL_TENANT)) == {missing_id, pending_id}
+    assert repo.list_pending(OTHER_TENANT) == [other_id]
+
+
+def test_list_pending_excludes_running_and_failed_aggregates(
+    conn: sqlite3.Connection,
+) -> None:
+    running_id = _job_id(tenant_id=LOCAL_TENANT, url="https://example.test/jobs/running")
+    failed_id = _job_id(tenant_id=LOCAL_TENANT, url="https://example.test/jobs/failed")
+    for job_id, url in (
+        (running_id, "https://example.test/jobs/running"),
+        (failed_id, "https://example.test/jobs/failed"),
+    ):
+        _insert_job(conn, tenant_id=LOCAL_TENANT, job_id=job_id, url=url)
+    repo = SqliteEnrichmentRepository(conn)
+    repo.save(
+        JobEnrichment.empty(
+            tenant_id=LOCAL_TENANT,
+            job_id=running_id,
+            updated_at="t0",
+        ).start_attempt(extraction_tier=ExtractionTier.JSON_LD, started_at="t0")
+    )
+    repo.save(_failed(tenant_id=LOCAL_TENANT, job_id=failed_id))
 
     assert repo.list_pending(LOCAL_TENANT) == []
 
 
-def test_list_failed_returns_full_aggregates(conn: sqlite3.Connection) -> None:
-    _insert_job(conn, "https://example.com/jobs/F")
-    repo = SqliteEnrichmentRepository(conn)
-    from jobctrl.domain.enrichment import EnrichmentError
-
-    failed = (
-        JobEnrichment.empty(
-            tenant_id=LOCAL_TENANT, job_id=JobId("https://example.com/jobs/F"), updated_at="t0"
-        )
-        .start_attempt(extraction_tier=ExtractionTier.LLM_ASSISTED, started_at="t0")
-        .fail_attempt(
-            error=EnrichmentError(code="LLM_500", message="bad", retryable=True),
-            finished_at="t1",
-        )
+def test_list_failed_returns_aggregate_with_canonical_identity(
+    conn: sqlite3.Connection,
+) -> None:
+    job_id = _job_id(tenant_id=LOCAL_TENANT, url="https://example.test/jobs/failed")
+    _insert_job(
+        conn,
+        tenant_id=LOCAL_TENANT,
+        job_id=job_id,
+        url="https://example.test/jobs/failed",
     )
-    repo.save(failed)
+    repo = SqliteEnrichmentRepository(conn)
+    repo.save(_failed(tenant_id=LOCAL_TENANT, job_id=job_id))
 
     failures = repo.list_failed(LOCAL_TENANT)
+
     assert len(failures) == 1
+    assert failures[0].tenant_id == LOCAL_TENANT
+    assert failures[0].job_id == job_id
     assert failures[0].is_failed
     assert failures[0].last_attempt is not None
     assert failures[0].last_attempt.error is not None
-    assert failures[0].last_attempt.error.code == "LLM_500"
+    assert failures[0].last_attempt.error.code == "HTTP_404"
 
 
-# ---------------------------------------------------------------------------
-# Backfill — verifies ensure_enrichment_tables's idempotent migration
-# ---------------------------------------------------------------------------
-
-
-def test_backfill_idempotent_when_table_already_populated(tmp_path) -> None:
-    """Re-running the migration on an existing DB must not duplicate rows."""
-    db_path = tmp_path / "jobctrl.db"
-    conn = init_db(db_path)
-    _insert_job(conn, "https://example.com/jobs/1", full_description="Legacy desc")
-    repo = SqliteEnrichmentRepository(conn)
-    repo.save(_make_enriched("https://example.com/jobs/1"))
-
-    # The table now has at least one row, so subsequent calls are no-ops.
-    rows_before = conn.execute("SELECT COUNT(*) FROM job_enrichments").fetchone()[0]
-    from jobctrl.database import ensure_enrichment_tables
-
-    # Insert a NEW legacy row that WOULD be backfilled if the migration
-    # fired — and confirm it doesn't, because the table is already
-    # populated.
+def test_shared_url_never_crosses_tenant_job_identity_on_save_load_or_update(
+    conn: sqlite3.Connection,
+) -> None:
+    local_job_id = _job_id(tenant_id=LOCAL_TENANT, url=SHARED_URL)
+    other_job_id = _job_id(tenant_id=OTHER_TENANT, url=SHARED_URL)
     _insert_job(
         conn,
-        "https://example.com/jobs/2",
-        full_description="Another legacy desc",
+        tenant_id=LOCAL_TENANT,
+        job_id=local_job_id,
+        url=SHARED_URL,
     )
-    ensure_enrichment_tables(conn)
-    rows_after = conn.execute("SELECT COUNT(*) FROM job_enrichments").fetchone()[0]
-    assert rows_before == rows_after
-
-
-def test_backfill_creates_enriched_rows_from_legacy_columns(tmp_path) -> None:
-    """A legacy job with full_description should backfill as ``enriched``."""
-    db_path = tmp_path / "jobctrl.db"
-    # Insert legacy data BEFORE init_db runs the backfill
-    conn = sqlite3.connect(str(db_path))
-    conn.execute("PRAGMA journal_mode=WAL")
-    conn.row_factory = sqlite3.Row
-    conn.execute(
-        """
-        CREATE TABLE jobs (
-            url TEXT PRIMARY KEY,
-            title TEXT,
-            site TEXT,
-            discovered_at TEXT,
-            full_description TEXT,
-            application_url TEXT,
-            detail_scraped_at TEXT,
-            detail_error TEXT
-        )
-        """
-    )
-    conn.execute(
-        "INSERT INTO jobs (url, title, site, discovered_at, full_description, "
-        "application_url, detail_scraped_at) "
-        "VALUES (?, ?, ?, ?, ?, ?, ?)",
-        (
-            "https://example.com/jobs/1",
-            "Senior Engineer",
-            "greenhouse",
-            "2026-04-01T00:00:00+00:00",
-            "The legacy full description",
-            "https://example.com/apply",
-            "2026-04-02T00:00:00+00:00",
-        ),
-    )
-    conn.commit()
-    conn.close()
-
-    # Now run init_db — it should backfill the existing legacy row
-    conn = init_db(db_path)
-    repo = SqliteEnrichmentRepository(conn)
-    loaded = repo.load(LOCAL_TENANT, JobId("https://example.com/jobs/1"))
-    assert loaded is not None
-    assert loaded.is_enriched
-    assert loaded.full_description is not None
-    assert loaded.full_description.text == "The legacy full description"
-    assert loaded.application_url is not None
-    assert loaded.application_url.value == "https://example.com/apply"
-    # Backfilled attempt is recorded as a succeeded css_selectors attempt
-    assert loaded.attempt_count == 1
-    assert loaded.last_attempt is not None
-    assert loaded.last_attempt.succeeded
-    # The attempts_json carries the "backfilled": true flag
-    raw = conn.execute(
-        "SELECT attempts_json FROM job_enrichments WHERE job_url = ?",
-        ("https://example.com/jobs/1",),
-    ).fetchone()
-    payload = json.loads(raw[0])
-    assert payload[0]["backfilled"] is True
-
-
-def test_backfill_creates_failed_row_for_legacy_error(tmp_path) -> None:
-    db_path = tmp_path / "jobctrl.db"
-    conn = sqlite3.connect(str(db_path))
-    conn.row_factory = sqlite3.Row
-    conn.execute(
-        """
-        CREATE TABLE jobs (
-            url TEXT PRIMARY KEY,
-            title TEXT,
-            site TEXT,
-            discovered_at TEXT,
-            full_description TEXT,
-            application_url TEXT,
-            detail_scraped_at TEXT,
-            detail_error TEXT
-        )
-        """
-    )
-    conn.execute(
-        "INSERT INTO jobs (url, title, site, discovered_at, detail_error) "
-        "VALUES (?, ?, ?, ?, ?)",
-        (
-            "https://example.com/jobs/2",
-            "Foo",
-            "greenhouse",
-            "2026-04-01T00:00:00+00:00",
-            "HTTP 404",
-        ),
-    )
-    conn.commit()
-    conn.close()
-
-    conn = init_db(db_path)
-    repo = SqliteEnrichmentRepository(conn)
-    loaded = repo.load(LOCAL_TENANT, JobId("https://example.com/jobs/2"))
-    assert loaded is not None
-    assert loaded.is_failed
-    assert loaded.last_attempt is not None
-    assert loaded.last_attempt.failed
-    assert loaded.last_attempt.error is not None
-    assert "HTTP 404" in loaded.last_attempt.error.message
-
-
-def test_backfill_does_not_fire_when_table_has_rows(tmp_path) -> None:
-    """Idempotent backfill: subsequent runs against new legacy data are no-ops."""
-    db_path = tmp_path / "jobctrl.db"
-    conn = init_db(db_path)
-    _insert_job(conn, "https://example.com/jobs/A")
-    repo = SqliteEnrichmentRepository(conn)
-    repo.save(_make_enriched("https://example.com/jobs/A"))
-
-    # Now insert a NEW legacy-only row and re-run ensure_enrichment_tables
     _insert_job(
         conn,
-        "https://example.com/jobs/B",
-        full_description="Legacy desc",
-        detail_scraped_at="2026-04-01T00:00:00+00:00",
+        tenant_id=OTHER_TENANT,
+        job_id=other_job_id,
+        url=SHARED_URL,
     )
-    from jobctrl.database import ensure_enrichment_tables
+    repo = SqliteEnrichmentRepository(conn)
+    repo.save(
+        _enriched(
+            tenant_id=LOCAL_TENANT,
+            job_id=local_job_id,
+            description="local description",
+        )
+    )
+    repo.save(
+        _enriched(
+            tenant_id=OTHER_TENANT,
+            job_id=other_job_id,
+            description="other description",
+        )
+    )
 
-    ensure_enrichment_tables(conn)
+    repo.save(_failed(tenant_id=LOCAL_TENANT, job_id=local_job_id))
 
-    # B was NOT backfilled because the table already had A
-    assert repo.load(LOCAL_TENANT, JobId("https://example.com/jobs/B")) is None
+    local = repo.load(LOCAL_TENANT, local_job_id)
+    other = repo.load(OTHER_TENANT, other_job_id)
+    assert local is not None and local.is_failed
+    assert other is not None and other.is_enriched
+    assert other.full_description is not None
+    assert other.full_description.text == "other description"
+    assert repo.load(LOCAL_TENANT, other_job_id) is None

--- a/workers/automation/tests/test_enrichment_repository.py
+++ b/workers/automation/tests/test_enrichment_repository.py
@@ -19,10 +19,14 @@ from jobctrl.domain.enrichment import (
     ExtractionTier,
     FullDescription,
     JobEnrichment,
+    PostingSnapshotSet,
 )
 from jobctrl.domain.identifiers import JobId, canonical_job_id
 from jobctrl.domain.tenant import LOCAL_TENANT, TenantId
 from jobctrl.infrastructure.enrichment import SqliteEnrichmentRepository
+from jobctrl.infrastructure.enrichment.sqlite_repository import (
+    SqlitePostingSnapshotSetRepository,
+)
 
 
 OTHER_TENANT = TenantId("other")
@@ -197,6 +201,38 @@ def test_repository_rejects_url_shaped_job_identity(conn: sqlite3.Connection) ->
                 updated_at="t0",
             )
         )
+
+
+def test_snapshot_set_repository_uses_tenant_scoped_job_id(
+    conn: sqlite3.Connection,
+) -> None:
+    url = "https://example.test/jobs/snapshot"
+    job_id = _job_id(tenant_id=LOCAL_TENANT, url=url)
+    _insert_job(conn, tenant_id=LOCAL_TENANT, job_id=job_id, url=url)
+    repo = SqlitePostingSnapshotSetRepository(conn)
+    snapshot_set = PostingSnapshotSet.empty(
+        tenant_id=LOCAL_TENANT,
+        job_id=job_id,
+        updated_at="2026-07-31T12:00:00+00:00",
+    )
+
+    repo.save(snapshot_set)
+
+    loaded = repo.load(LOCAL_TENANT, job_id)
+    row = conn.execute(
+        """
+        SELECT job_id
+        FROM posting_snapshot_sets
+        WHERE tenant_id = ? AND job_id = ?
+        """,
+        (str(LOCAL_TENANT), str(job_id)),
+    ).fetchone()
+
+    assert loaded == snapshot_set
+    assert row is not None and row["job_id"] == str(job_id)
+    assert "job_url" not in {
+        column["name"] for column in conn.execute("PRAGMA table_info(posting_snapshot_sets)")
+    }
 
 
 def test_list_pending_uses_tenant_scoped_job_ids(conn: sqlite3.Connection) -> None:


### PR DESCRIPTION
## Summary

- persist enrichment aggregates and posting snapshot sets by exact tenant and canonical UUID JobId
- resolve posting URLs once before enrichment persistence while retaining them only as external locators
- key source lookup, stage state, events, quarantine rows, and snapshot references by JobId
- fail on malformed exact-v7 observation schema instead of silently using a legacy fallback
- preserve retry history, persisted-pending selection, and composite upsert behavior

## Validation

- focused enrichment correction suite: 14 passed
- cumulative selected enrichment and JobStreaming identity regressions: 7 passed
- focused Ruff checks and `git diff --check` passed
- independent Step 1 review: PASS, 0 Blocker / 0 High

## Stack

Ready-for-review child of #635 in GitHub Stack #632.

