### PR TITLE
fix(ci): run checks on stacked pull requests

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,5 +9,5 @@
 ## Checklist
 
 - [ ] External contributor commits include a DCO `Signed-off-by:` trailer (`git commit -s`).
-- [ ] I ran the relevant local checks and listed them above. Heavy CI does not run automatically on public pull requests; maintainers run manual workflows or local validation after review.
+- [ ] I ran the relevant local checks and listed them above. Heavy CI runs automatically for same-repository pull requests, but not public forks; maintainers run manual workflows or local validation for fork contributions after review.
 - [ ] I did not include secrets, private profile data, resumes, generated application materials, raw logs, browser profiles, SQLite databases, or local paths.

--- a/.github/workflows/docs-site.yml
+++ b/.github/workflows/docs-site.yml
@@ -10,6 +10,15 @@ on:
       - "scripts/check-install-asset.mjs"
       - "scripts/get"
       - ".github/workflows/docs-site.yml"
+  pull_request:
+    branches: ["main"]
+    paths:
+      - "docs/**"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "scripts/check-install-asset.mjs"
+      - "scripts/get"
+      - ".github/workflows/docs-site.yml"
   workflow_dispatch:
 
 permissions:
@@ -17,6 +26,7 @@ permissions:
 
 jobs:
   build:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     name: Build (dead-link gate)
     runs-on: ubuntu-latest
 

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -8,15 +8,27 @@ on:
       - "scripts/**"
       - "pyproject.toml"
       - ".github/workflows/python.yml"
+  pull_request:
+    branches: ["main"]
+    paths:
+      - "workers/**"
+      - "scripts/**"
+      - "pyproject.toml"
+      - ".github/workflows/python.yml"
   workflow_dispatch:
 
 jobs:
   python:
+    # Same-repository stacks are trusted to run hosted CI; public forks retain
+    # the maintainer-reviewed manual validation path documented in CONTRIBUTING.
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     name: Python (workers/automation)
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11", "3.12", "3.13"]
+        # Every matching stack layer gets the 3.11 correctness lane. The top
+        # layer contains the cumulative stack and also exercises compatibility.
+        python-version: ${{ fromJSON(github.event_name == 'pull_request' && github.event.pull_request.stack != null && github.event.pull_request.stack.position != github.event.pull_request.stack.size && '["3.11"]' || '["3.11","3.12","3.13"]') }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -3,10 +3,13 @@ name: Release Privacy Gate
 on:
   push:
     branches: ["main"]
+  pull_request:
+    branches: ["main"]
   workflow_dispatch:
 
 jobs:
   release-check:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     name: Release check
     runs-on: ubuntu-latest
 

--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -10,10 +10,22 @@ on:
       - "package.json"
       - "pnpm-workspace.yaml"
       - ".github/workflows/typescript.yml"
+  pull_request:
+    branches: ["main"]
+    paths:
+      - "apps/**"
+      - "packages/**"
+      - "pnpm-lock.yaml"
+      - "package.json"
+      - "pnpm-workspace.yaml"
+      - ".github/workflows/typescript.yml"
   workflow_dispatch:
 
 jobs:
   typescript:
+    # Same-repository stacks are trusted to run hosted CI; public forks retain
+    # the maintainer-reviewed manual validation path documented in CONTRIBUTING.
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     name: TypeScript (apps + packages)
     runs-on: ubuntu-latest
 
@@ -31,11 +43,13 @@ jobs:
           cache: pnpm
 
       - name: Set up Python
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.stack == null || github.event.pull_request.stack.position == github.event.pull_request.stack.size }}
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
 
       - name: Install uv
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.stack == null || github.event.pull_request.stack.position == github.event.pull_request.stack.size }}
         run: python -m pip install uv
 
       - name: Install dependencies
@@ -56,17 +70,24 @@ jobs:
       - name: Build web
         run: pnpm --filter @jobctrl/web build
 
+      # Browser and Storybook suites exercise the cumulative top layer. The
+      # null guard keeps full coverage for ordinary, non-stack pull requests.
       - name: Build web storybook
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.stack == null || github.event.pull_request.stack.position == github.event.pull_request.stack.size }}
         run: pnpm --filter @jobctrl/web storybook:build
 
       - name: Install Playwright Chromium
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.stack == null || github.event.pull_request.stack.position == github.event.pull_request.stack.size }}
         run: pnpm --filter @jobctrl/web exec playwright install --with-deps chromium
 
       - name: Install Python Playwright Chromium
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.stack == null || github.event.pull_request.stack.position == github.event.pull_request.stack.size }}
         run: uv --project workers/automation run playwright install chromium
 
       - name: Test web e2e
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.stack == null || github.event.pull_request.stack.position == github.event.pull_request.stack.size }}
         run: pnpm --filter @jobctrl/web e2e
 
       - name: Test web storybook
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.stack == null || github.event.pull_request.stack.position == github.event.pull_request.stack.size }}
         run: pnpm --filter @jobctrl/web storybook:test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,9 +46,13 @@ JOBCTRL_DIR=/tmp/jobctrl-qa corepack pnpm dev
   unreleased stack, update canonical docs in the final PR and run QA afterward.
 - Do not commit local user data, `.env` files, resumes, PDFs, logs, browser
   profiles, SQLite databases, or generated application materials.
-- Heavy CI workflows do not run automatically on public pull requests. Run the
-  relevant local validation before opening a PR; maintainers run manual
-  workflows or local checks after reviewing the change.
+- Heavy CI workflows run automatically for same-repository pull requests, but
+  not for pull requests from public forks. Run the relevant local validation
+  before opening a PR; maintainers run manual workflows or local checks for
+  fork contributions after reviewing the change.
+- GitHub Stacks run matching correctness checks on every layer. Python
+  compatibility lanes and the browser/Storybook suites run on the top layer,
+  whose head contains the cumulative stack.
 
 ## Developer Certificate of Origin Sign-Off
 

--- a/scripts/stacked-ci-workflows.test.mjs
+++ b/scripts/stacked-ci-workflows.test.mjs
@@ -1,0 +1,184 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+const rubyYamlToJson = String.raw`
+document = YAML.safe_load(
+  File.read(ARGV.fetch(0)),
+  permitted_classes: [],
+  permitted_symbols: [],
+  aliases: false,
+)
+events = document.delete("on") || document.delete(true)
+document["on"] = events
+puts JSON.generate(document)
+`;
+
+const parseWorkflow = async (name) => {
+  const path = fileURLToPath(
+    new URL(`../.github/workflows/${name}.yml`, import.meta.url),
+  );
+  const { stdout } = await execFileAsync(
+    "ruby",
+    ["-ryaml", "-rjson", "-e", rubyYamlToJson, path],
+    { maxBuffer: 1024 * 1024 },
+  );
+  return JSON.parse(stdout);
+};
+
+const sameRepositoryPullRequest =
+  "github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository";
+const topOfStack =
+  "github.event_name != 'pull_request' || github.event.pull_request.stack == null || github.event.pull_request.stack.position == github.event.pull_request.stack.size";
+
+const findStep = (job, name) => {
+  const step = job.steps.find((candidate) => candidate.name === name);
+  assert.ok(step, `missing ${name} step`);
+  return step;
+};
+
+test("same-repository pull requests targeting main admit correctness workflows", async () => {
+  const specs = [
+    { workflowName: "python", jobName: "python", pathFiltered: true },
+    { workflowName: "typescript", jobName: "typescript", pathFiltered: true },
+    { workflowName: "docs-site", jobName: "build", pathFiltered: true },
+    { workflowName: "release-check", jobName: "release-check", pathFiltered: false },
+  ];
+
+  for (const spec of specs) {
+    const workflow = await parseWorkflow(spec.workflowName);
+    assert.deepEqual(
+      workflow.on.pull_request.branches,
+      ["main"],
+      `${spec.workflowName} must admit every GitHub Stack layer as targeting main`,
+    );
+    assert.equal(
+      workflow.jobs[spec.jobName].if,
+      `\${{ ${sameRepositoryPullRequest} }}`,
+      `${spec.workflowName} must continue to reject untrusted fork execution`,
+    );
+    if (spec.pathFiltered) {
+      assert.deepEqual(
+        workflow.on.pull_request.paths,
+        workflow.on.push.paths,
+        `${spec.workflowName} must use the same paths for stack PRs and main pushes`,
+      );
+    } else {
+      assert.equal(workflow.on.pull_request.paths, undefined);
+    }
+  }
+});
+
+test("stack metadata gates only cumulative Python compatibility lanes", async () => {
+  const workflow = await parseWorkflow("python");
+  const job = workflow.jobs.python;
+  const matrix =
+    "fromJSON(github.event_name == 'pull_request' && github.event.pull_request.stack != null && github.event.pull_request.stack.position != github.event.pull_request.stack.size && '[\"3.11\"]' || '[\"3.11\",\"3.12\",\"3.13\"]')";
+
+  assert.equal(job.strategy.matrix["python-version"], `\${{ ${matrix} }}`);
+  for (const requiredStep of ["Lint", "Release scan", "Test", "Build package"]) {
+    assert.equal(
+      findStep(job, requiredStep).if,
+      undefined,
+      `${requiredStep} must run in the Python 3.11 correctness lane on every matching stack PR`,
+    );
+  }
+});
+
+test("stack metadata gates only cumulative TypeScript browser suites", async () => {
+  const workflow = await parseWorkflow("typescript");
+  const job = workflow.jobs.typescript;
+
+  for (const requiredStep of ["Check", "Test", "Test web", "Test web types", "Build web"]) {
+    assert.equal(
+      findStep(job, requiredStep).if,
+      undefined,
+      `${requiredStep} must run on every matching stack PR`,
+    );
+  }
+
+  for (const cumulativeStep of [
+    "Set up Python",
+    "Install uv",
+    "Build web storybook",
+    "Install Playwright Chromium",
+    "Install Python Playwright Chromium",
+    "Test web e2e",
+    "Test web storybook",
+  ]) {
+    assert.equal(
+      findStep(job, cumulativeStep).if,
+      `\${{ ${topOfStack} }}`,
+      `${cumulativeStep} must use the null-safe top-of-stack guard`,
+    );
+  }
+});
+
+test("stack routing keeps per-layer correctness and cumulative top coverage", () => {
+  const routes = [
+    {
+      name: "push",
+      eventName: "push",
+      trusted: true,
+      stack: null,
+      expectedPython: ["3.11", "3.12", "3.13"],
+      expectedCumulative: true,
+    },
+    {
+      name: "ordinary same-repository pull request",
+      eventName: "pull_request",
+      trusted: true,
+      stack: null,
+      expectedPython: ["3.11", "3.12", "3.13"],
+      expectedCumulative: true,
+    },
+    {
+      name: "lower stack layer",
+      eventName: "pull_request",
+      trusted: true,
+      stack: { position: 2, size: 3 },
+      expectedPython: ["3.11"],
+      expectedCumulative: false,
+    },
+    {
+      name: "top stack layer",
+      eventName: "pull_request",
+      trusted: true,
+      stack: { position: 3, size: 3 },
+      expectedPython: ["3.11", "3.12", "3.13"],
+      expectedCumulative: true,
+    },
+    {
+      name: "public fork pull request",
+      eventName: "pull_request",
+      trusted: false,
+      stack: null,
+      expectedPython: [],
+      expectedCumulative: false,
+    },
+  ];
+
+  for (const route of routes) {
+    const admitted = route.eventName !== "pull_request" || route.trusted;
+    const isLowerStackLayer =
+      route.eventName === "pull_request" &&
+      route.stack !== null &&
+      route.stack.position !== route.stack.size;
+    const pythonVersions = admitted
+      ? isLowerStackLayer
+        ? ["3.11"]
+        : ["3.11", "3.12", "3.13"]
+      : [];
+    const cumulative =
+      admitted &&
+      (route.eventName !== "pull_request" ||
+        route.stack === null ||
+        route.stack.position === route.stack.size);
+
+    assert.deepEqual(pythonVersions, route.expectedPython, route.name);
+    assert.equal(cumulative, route.expectedCumulative, route.name);
+  }
+});


### PR DESCRIPTION
## Summary

- run Python, TypeScript, docs, and release-privacy correctness checks for same-repository pull requests targeting main, including every matching GitHub Stack layer
- keep public fork heavy CI gated while running Python compatibility and browser/Storybook suites only on the cumulative top stack layer
- add a parsed workflow contract and routing truth table, and align contributor guidance

## Root cause

The open-source intake policy removed pull_request triggers from the heavyweight workflows without distinguishing public forks from trusted same-repository branches. GitHub therefore never created those workflow runs for stack layers. GitHub Stacks evaluate every pull request as targeting the stack base, so main-targeted pull_request triggers restore per-layer admission; null-safe stack metadata limits only cumulative work.

Reference: https://docs.github.com/en/pull-requests/how-tos/merge-and-close-pull-requests/optimizing-ci-for-stacked-pull-requests

## Validation

- corepack pnpm scripts:test (138 passed)
- node scripts/check-python-workflow-contract.mjs
- corepack pnpm --filter @jobctrl/api exec vitest run test/typescript-ci-workflow-contract.test.ts (1 passed)
- go run github.com/rhysd/actionlint/cmd/actionlint@latest
- Ruby YAML parse of all workflows
- git diff --check
- independent review: Gate PASS, 0 Blocker, 0 High

## Live verification

After merge, rebase GitHub Stack #632 onto the new main and confirm fresh Actions jobs on at least one non-bottom layer.