### PR TITLE
fix(ci): reserve product suites for stack top

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,5 +9,5 @@
 ## Checklist
 
 - [ ] External contributor commits include a DCO `Signed-off-by:` trailer (`git commit -s`).
-- [ ] I ran the relevant local checks and listed them above. Heavy CI runs automatically for same-repository pull requests, but not public forks; maintainers run manual workflows or local validation for fork contributions after review.
+- [ ] I ran the relevant local checks and listed them above. Heavy CI runs automatically for ordinary same-repository pull requests and cumulative stack heads, but not public forks; maintainers run manual workflows or local validation for fork contributions after review.
 - [ ] I did not include secrets, private profile data, resumes, generated application materials, raw logs, browser profiles, SQLite databases, or local paths.

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -75,6 +75,9 @@ jobs:
           fi
 
       - name: Test
+        # Approved stack layers can be intentionally non-installable review
+        # slices. Exercise the product suite only on a cumulative head.
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.stack == null || github.event.pull_request.stack.position == github.event.pull_request.stack.size }}
         run: pytest workers/automation/tests -v
 
       - name: Build package

--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -58,16 +58,23 @@ jobs:
       - name: Check
         run: pnpm -r check
 
+      # Product suites and builds require the cumulative stack. Lower layers
+      # retain dependency installation and static workspace checks as fast
+      # admission checks.
       - name: Test
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.stack == null || github.event.pull_request.stack.position == github.event.pull_request.stack.size }}
         run: pnpm --filter @jobctrl/api test
 
       - name: Test web
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.stack == null || github.event.pull_request.stack.position == github.event.pull_request.stack.size }}
         run: pnpm --filter @jobctrl/web test
 
       - name: Test web types
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.stack == null || github.event.pull_request.stack.position == github.event.pull_request.stack.size }}
         run: pnpm --filter @jobctrl/web test-d
 
       - name: Build web
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.stack == null || github.event.pull_request.stack.position == github.event.pull_request.stack.size }}
         run: pnpm --filter @jobctrl/web build
 
       # Browser and Storybook suites exercise the cumulative top layer. The

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,9 +50,10 @@ JOBCTRL_DIR=/tmp/jobctrl-qa corepack pnpm dev
   not for pull requests from public forks. Run the relevant local validation
   before opening a PR; maintainers run manual workflows or local checks for
   fork contributions after reviewing the change.
-- GitHub Stacks run matching correctness checks on every layer. Python
-  compatibility lanes and the browser/Storybook suites run on the top layer,
-  whose head contains the cumulative stack.
+- GitHub Stacks run matching fast admission and static checks on every layer.
+  Those checks include the Python sdist/wheel smoke build. Product test suites,
+  Python compatibility lanes, cumulative web builds, and the browser/Storybook
+  suites run on the top layer, whose head contains the cumulative stack.
 
 ## Developer Certificate of Origin Sign-Off
 

--- a/scripts/stacked-ci-workflows.test.mjs
+++ b/scripts/stacked-ci-workflows.test.mjs
@@ -72,37 +72,49 @@ test("same-repository pull requests targeting main admit correctness workflows",
   }
 });
 
-test("stack metadata gates only cumulative Python compatibility lanes", async () => {
+test("stack metadata gates cumulative Python product coverage", async () => {
   const workflow = await parseWorkflow("python");
   const job = workflow.jobs.python;
   const matrix =
     "fromJSON(github.event_name == 'pull_request' && github.event.pull_request.stack != null && github.event.pull_request.stack.position != github.event.pull_request.stack.size && '[\"3.11\"]' || '[\"3.11\",\"3.12\",\"3.13\"]')";
 
   assert.equal(job.strategy.matrix["python-version"], `\${{ ${matrix} }}`);
-  for (const requiredStep of ["Lint", "Release scan", "Test", "Build package"]) {
+  for (const admissionStep of [
+    "Lint",
+    "Release scan",
+    "Validate Python workflow contract",
+    "Build package",
+  ]) {
     assert.equal(
-      findStep(job, requiredStep).if,
+      findStep(job, admissionStep).if,
       undefined,
-      `${requiredStep} must run in the Python 3.11 correctness lane on every matching stack PR`,
+      `${admissionStep} must run as a fast Python 3.11 admission check on every matching stack PR`,
     );
   }
+  assert.equal(
+    findStep(job, "Test").if,
+    `\${{ ${topOfStack} }}`,
+    "the Python product suite must use the null-safe top-of-stack guard",
+  );
 });
 
-test("stack metadata gates only cumulative TypeScript browser suites", async () => {
+test("stack metadata gates cumulative TypeScript product suites", async () => {
   const workflow = await parseWorkflow("typescript");
   const job = workflow.jobs.typescript;
 
-  for (const requiredStep of ["Check", "Test", "Test web", "Test web types", "Build web"]) {
-    assert.equal(
-      findStep(job, requiredStep).if,
-      undefined,
-      `${requiredStep} must run on every matching stack PR`,
-    );
-  }
+  assert.equal(
+    findStep(job, "Check").if,
+    undefined,
+    "the static workspace check must run on every matching stack PR",
+  );
 
   for (const cumulativeStep of [
     "Set up Python",
     "Install uv",
+    "Test",
+    "Test web",
+    "Test web types",
+    "Build web",
     "Build web storybook",
     "Install Playwright Chromium",
     "Install Python Playwright Chromium",


### PR DESCRIPTION
## Summary
- keep fast Python and TypeScript admission/static checks on every matching same-repository stack layer
- reserve full Python pytest, TypeScript product suites, web builds, Playwright, and Storybook for ordinary pull requests and the cumulative stack top
- encode the routing policy in schema-aware workflow tests and contributor guidance

## Why
The first live 66-PR stack fan-out proved that approved intermediate review slices can be intentionally non-installable. Running cumulative product suites on every slice produced hundreds of expected partial-cutover failures and unnecessary hosted-runner load. The stack top still receives the full matrix and all product/browser suites.

## Validation
- `corepack pnpm scripts:test` — 138 passed
- `node --test scripts/stacked-ci-workflows.test.mjs` — 4 passed
- `node scripts/check-python-workflow-contract.mjs` — passed
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest` — passed
- Ruby Psych parse of all workflow YAML — passed
- `git diff --check` — passed
- independent review — Gate: PASS, 0 Blocker/High/Medium