### PR TITLE
fix(ci): let Python matrix lanes finish

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -25,6 +25,9 @@ jobs:
     name: Python (workers/automation)
     runs-on: ubuntu-latest
     strategy:
+      # A failure in one top compatibility lane must not cancel the others;
+      # every supported Python version owns an independent product result.
+      fail-fast: false
       matrix:
         # Every matching stack layer gets the 3.11 correctness lane. The top
         # layer contains the cumulative stack and also exercises compatibility.

--- a/scripts/stacked-ci-workflows.test.mjs
+++ b/scripts/stacked-ci-workflows.test.mjs
@@ -78,6 +78,11 @@ test("stack metadata gates cumulative Python product coverage", async () => {
   const matrix =
     "fromJSON(github.event_name == 'pull_request' && github.event.pull_request.stack != null && github.event.pull_request.stack.position != github.event.pull_request.stack.size && '[\"3.11\"]' || '[\"3.11\",\"3.12\",\"3.13\"]')";
 
+  assert.equal(
+    job.strategy["fail-fast"],
+    false,
+    "one Python compatibility failure must not cancel the remaining top lanes",
+  );
   assert.equal(job.strategy.matrix["python-version"], `\${{ ${matrix} }}`);
   for (const admissionStep of [
     "Lint",


### PR DESCRIPTION
## Summary
- disable Python matrix fail-fast so every top/non-stack compatibility lane reaches its own terminal result
- assert the parsed workflow strategy in the schema-aware stacked-CI contract

## Why
The live top-stack run proved all three Python lanes entered pytest, but GitHub cancelled 3.12 and 3.13 after 3.11 failed. The cumulative top must execute every supported-version suite even when one lane exposes a product defect.

## Validation
- `corepack pnpm scripts:test` — 138 passed
- `node --test scripts/stacked-ci-workflows.test.mjs` — 4 passed
- `node scripts/check-python-workflow-contract.mjs` — passed
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest` — passed
- `git diff --check` — passed
- independent review — Gate: PASS, 0 findings