### PR TITLE
fix(web): align canonical job id fixtures

### DIFF
--- a/apps/api/test/qa-seed.ts
+++ b/apps/api/test/qa-seed.ts
@@ -5,9 +5,6 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 import Database from "better-sqlite3";
 
-import { ensureApplicationFeedbackTables } from "../src/application-feedback.js";
-import { ensureDiscoveryControlTables } from "../src/discovery-controls.js";
-import { ensureOutreachTables } from "../src/outreach.js";
 import { writeProfileConfig } from "../src/profile-store.js";
 import { BUILT_IN_RESUME_TEMPLATE_THEME } from "../src/resume-templates.js";
 import { initializeExactV7Database } from "./v7-schema.js";
@@ -235,9 +232,6 @@ export function seedQaDatabase(dbPath: string, options: QaSeedOptions = {}): voi
   initializeExactV7Database(dbPath);
   const db = new Database(dbPath);
   db.pragma("foreign_keys = ON");
-  ensureApplicationFeedbackTables(db);
-  ensureDiscoveryControlTables(db);
-  ensureOutreachTables(db);
   writeProfileConfig(db, {
     profile: QA_PROFILE,
     style: QA_RESUME_STYLE,
@@ -1241,13 +1235,13 @@ function seedResumeReviewDraft(db: Database.Database): void {
 function seedContacts(db: Database.Database): void {
   const insertContact = db.prepare(
     `INSERT INTO contacts (
-      tenant_id, contact_id, employer, job_url, role, created_at, updated_at
+      tenant_id, contact_id, employer, job_id, role, created_at, updated_at
     ) VALUES ('local', ?, ?, ?, ?, ?, ?)`,
   );
   insertContact.run(
     "qa-contact-hiring-manager",
     "GitLab",
-    QA_PLATFORM_JOB_URL,
+    QA_PLATFORM_JOB_ID,
     "hiring_manager",
     QA_NOW,
     QA_NOW,
@@ -1255,7 +1249,7 @@ function seedContacts(db: Database.Database): void {
   insertContact.run(
     "qa-contact-recruiter",
     "GitLab",
-    QA_PLATFORM_JOB_URL,
+    QA_PLATFORM_JOB_ID,
     "recruiter",
     QA_NOW,
     QA_NOW,
@@ -1567,7 +1561,6 @@ function seedDiscoverySources(db: Database.Database): void {
 }
 
 function seedOutreachThread(db: Database.Database): void {
-  ensureOutreachTables(db);
   const threadId = "qa-outreach-hiring-manager";
   const approvedDraftId = "qa-outreach-approved-intro";
   const gateResults = JSON.stringify({
@@ -1608,7 +1601,7 @@ function seedOutreachThread(db: Database.Database): void {
 
   db.prepare(
     `INSERT INTO outreach_threads (
-      tenant_id, thread_id, contact_id, job_url, created_at, updated_at,
+      tenant_id, thread_id, contact_id, job_id, created_at, updated_at,
       follow_up_due_at, follow_up_basis, follow_up_state
     ) VALUES ('local', ?, 'qa-contact-hiring-manager', NULL, ?, ?, ?, 'manual', 'scheduled')`,
   ).run(
@@ -1684,12 +1677,13 @@ function seedWorkerHeartbeat(db: Database.Database, dbPath: string): void {
 function insertJob(db: Database.Database, job: QaJobSeed): void {
   db.prepare(
     `INSERT INTO jobs (
-      url, title, site, strategy, location, salary, discovered_at, application_url,
+      url, tenant_id, job_id, title, site, strategy, location, salary, discovered_at, application_url,
       description, full_description, detail_scraped_at, fit_score, score_reasoning,
       scored_at, tailored_resume_path, tailored_at
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    ) VALUES (?, 'local', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   ).run(
     job.url,
+    qaJobId(job.url),
     job.title,
     job.site,
     job.strategy ?? "qa",
@@ -1706,6 +1700,11 @@ function insertJob(db: Database.Database, job: QaJobSeed): void {
     null,
     null,
   );
+}
+
+function qaJobId(jobUrl: string): string {
+  const digest = createHash("sha256").update(jobUrl).digest("hex");
+  return `${digest.slice(0, 8)}-${digest.slice(8, 12)}-4${digest.slice(13, 16)}-8${digest.slice(17, 20)}-${digest.slice(20, 32)}`;
 }
 
 function insertStage(db: Database.Database, jobUrl: string, stage: string, state: string, errorCode: string | null = null): void {

--- a/apps/api/test/qa-seed.ts
+++ b/apps/api/test/qa-seed.ts
@@ -9,8 +9,8 @@ import { ensureApplicationFeedbackTables } from "../src/application-feedback.js"
 import { ensureDiscoveryControlTables } from "../src/discovery-controls.js";
 import { ensureOutreachTables } from "../src/outreach.js";
 import { writeProfileConfig } from "../src/profile-store.js";
-import { ensureProjectionTables } from "../src/projections.js";
-import { ensureResumeReviewTables } from "../src/resume-review-drafts.js";
+import { BUILT_IN_RESUME_TEMPLATE_THEME } from "../src/resume-templates.js";
+import { initializeExactV7Database } from "./v7-schema.js";
 
 export interface QaWorkspace {
   appDir: string;
@@ -36,7 +36,10 @@ interface QaJobSeed {
 }
 
 const QA_NOW = "2026-05-04T12:00:00+00:00";
-const QA_PLATFORM_JOB_URL = "https://boards.greenhouse.io/gitlab/jobs/qa-platform-director";
+export const QA_PLATFORM_JOB_URL = "https://boards.greenhouse.io/gitlab/jobs/qa-platform-director";
+export const QA_PLATFORM_JOB_ID = qaJobId(QA_PLATFORM_JOB_URL);
+export const QA_RISK_JOB_URL = "https://linkedin.com/jobs/view/qa-risk-manager";
+export const QA_RISK_JOB_ID = qaJobId(QA_RISK_JOB_URL);
 const QA_RESUME_TEMPLATE = "{{ personal_data }}\n\n{{ resume_body }}\n";
 
 export function createQaPdfBytes(title: string): Buffer {
@@ -229,390 +232,18 @@ export function seedQaDatabase(dbPath: string, options: QaSeedOptions = {}): voi
   fs.writeFileSync(coverTxt, "QA cover letter");
   fs.writeFileSync(coverPdf, createQaPdfBytes("QA cover letter"));
 
+  initializeExactV7Database(dbPath);
   const db = new Database(dbPath);
-  db.exec(`
-    CREATE TABLE jobs (
-      url TEXT PRIMARY KEY,
-      title TEXT,
-      site TEXT,
-      strategy TEXT,
-      location TEXT,
-      salary TEXT,
-      discovered_at TEXT,
-      application_url TEXT,
-      description TEXT,
-      full_description TEXT,
-      detail_scraped_at TEXT,
-      detail_error TEXT,
-      fit_score INTEGER,
-      score_reasoning TEXT,
-      scored_at TEXT,
-      tailored_resume_path TEXT,
-      tailored_at TEXT,
-      tailor_attempts INTEGER,
-      cover_letter_path TEXT,
-      cover_letter_at TEXT,
-      cover_attempts INTEGER,
-      apply_status TEXT,
-      apply_error TEXT,
-      applied_at TEXT
-    );
-    CREATE TABLE job_stage_states (
-      job_url TEXT NOT NULL,
-      stage TEXT NOT NULL,
-      state TEXT NOT NULL DEFAULT 'pending',
-      attempt_count INTEGER DEFAULT 0,
-      max_attempts INTEGER,
-      started_at TEXT,
-      updated_at TEXT NOT NULL,
-      finished_at TEXT,
-      duration_ms INTEGER,
-      error_code TEXT,
-      error_message TEXT,
-      retryable INTEGER DEFAULT 1,
-      blocked_by_json TEXT,
-      next_action TEXT,
-      metadata_json TEXT,
-      version INTEGER NOT NULL DEFAULT 0,
-      PRIMARY KEY (job_url, stage)
-    );
-    CREATE TABLE job_artifacts (
-      job_url TEXT,
-      stage TEXT,
-      artifact_type TEXT,
-      status TEXT,
-      path TEXT,
-      created_at TEXT,
-      size_bytes INTEGER
-    );
-    CREATE TABLE job_events (
-      event_id INTEGER PRIMARY KEY AUTOINCREMENT,
-      job_url TEXT,
-      stage TEXT,
-      event_type TEXT NOT NULL DEFAULT '',
-      level TEXT NOT NULL DEFAULT 'info',
-      message TEXT,
-      occurred_at TEXT NOT NULL,
-      payload_json TEXT
-    );
-    CREATE TABLE apply_run_projections (
-      run_id TEXT PRIMARY KEY,
-      tenant_id TEXT NOT NULL DEFAULT 'local',
-      job_id TEXT NOT NULL,
-      job_title TEXT NOT NULL DEFAULT '',
-      job_employer TEXT NOT NULL DEFAULT '',
-      status TEXT NOT NULL DEFAULT '',
-      result TEXT,
-      dry_run INTEGER NOT NULL DEFAULT 0,
-      worker_id INTEGER,
-      model TEXT,
-      started_at TEXT,
-      finished_at TEXT,
-      duration_ms INTEGER,
-      events_json TEXT NOT NULL DEFAULT '[]'
-    );
-    CREATE TABLE workflow_run_projections (
-      workflow_id            TEXT PRIMARY KEY,
-      tenant_id              TEXT NOT NULL DEFAULT 'local',
-      workflow_type          TEXT NOT NULL DEFAULT '',
-      status                 TEXT NOT NULL DEFAULT 'in_progress',
-      input_summary_json     TEXT NOT NULL DEFAULT '{}',
-      error_code             TEXT,
-      error_message          TEXT,
-      retryable              INTEGER NOT NULL DEFAULT 0,
-      started_at             TEXT,
-      finished_at            TEXT,
-      duration_ms            INTEGER,
-      temporal_run_id        TEXT,
-      events_json            TEXT NOT NULL DEFAULT '[]'
-    );
-    CREATE TABLE worker_runtime_heartbeats (
-      worker_id TEXT PRIMARY KEY,
-      component TEXT NOT NULL,
-      pid INTEGER NOT NULL,
-      hostname TEXT NOT NULL,
-      app_dir TEXT NOT NULL,
-      db_path TEXT NOT NULL,
-      task_queue TEXT NOT NULL,
-      started_at TEXT NOT NULL,
-      last_seen_at TEXT NOT NULL,
-      max_concurrent_activities INTEGER,
-      activity_executor_max_workers INTEGER,
-      active_activity_count INTEGER NOT NULL DEFAULT 0,
-      active_activity_counts_json TEXT NOT NULL DEFAULT '{}',
-      active_activity_details_json TEXT NOT NULL DEFAULT '[]',
-      active_activity_details_total INTEGER NOT NULL DEFAULT 0,
-      active_activity_details_truncated INTEGER NOT NULL DEFAULT 0,
-      activity_duration_summary_json TEXT NOT NULL DEFAULT '{}',
-      task_queue_observation_json TEXT,
-      heartbeat_schema_version INTEGER NOT NULL DEFAULT 2
-    );
-    CREATE TABLE discovery_execution_jobs (
-      tenant_id                TEXT NOT NULL,
-      discover_workflow_id     TEXT NOT NULL,
-      discover_run_id          TEXT NOT NULL,
-      job_url                  TEXT NOT NULL,
-      cohort_kind              TEXT NOT NULL
-          CHECK (cohort_kind IN ('observed_this_run', 'existing_backlog')),
-      source_family            TEXT,
-      source_run_id            TEXT,
-      preparation_workflow_id  TEXT,
-      work_plan_state          TEXT NOT NULL DEFAULT 'pending'
-          CHECK (work_plan_state IN ('pending', 'planned', 'not_eligible', 'failed')),
-      required_steps_json      TEXT,
-      work_plan_reason         TEXT,
-      linked_at                TEXT NOT NULL,
-      PRIMARY KEY (tenant_id, discover_workflow_id, discover_run_id, job_url),
-      FOREIGN KEY (job_url) REFERENCES jobs(url) ON DELETE CASCADE
-    );
-    CREATE TABLE pipeline_step_projections (
-      tenant_id              TEXT NOT NULL,
-      discover_workflow_id   TEXT NOT NULL,
-      discover_run_id        TEXT NOT NULL,
-      step_kind              TEXT NOT NULL CHECK (step_kind IN (
-        'source_planning', 'source_family', 'enrichment_pass',
-        'preparation_fanout', 'existing_backlog_sweep', 'pdf_render'
-      )),
-      item_key               TEXT NOT NULL,
-      state                  TEXT NOT NULL CHECK (state IN (
-        'queued', 'running', 'succeeded', 'failed'
-      )),
-      attempt                INTEGER NOT NULL CHECK (attempt >= 1),
-      queued_at              TEXT,
-      started_at             TEXT,
-      finished_at            TEXT,
-      duration_ms            INTEGER CHECK (duration_ms IS NULL OR duration_ms >= 0),
-      error_code             TEXT,
-      retryable              INTEGER NOT NULL DEFAULT 0 CHECK (retryable IN (0, 1)),
-      detail_code            TEXT,
-      detail_count           INTEGER CHECK (detail_count IS NULL OR detail_count >= 0),
-      last_event_id          INTEGER NOT NULL,
-      last_updated_at        TEXT NOT NULL,
-      PRIMARY KEY (
-        tenant_id, discover_workflow_id, discover_run_id, step_kind, item_key
-      )
-    );
-    CREATE TABLE discovery_execution_recoveries (
-      tenant_id TEXT NOT NULL,
-      discover_workflow_id TEXT NOT NULL,
-      discover_run_id TEXT NOT NULL,
-      state TEXT NOT NULL,
-      mode TEXT NOT NULL,
-      decoder_version INTEGER NOT NULL,
-      history_event_id INTEGER NOT NULL,
-      expected_membership_count INTEGER NOT NULL,
-      persisted_membership_count INTEGER NOT NULL,
-      expected_step_count INTEGER NOT NULL,
-      persisted_step_count INTEGER NOT NULL,
-      key_digest TEXT NOT NULL,
-      last_error_code TEXT,
-      updated_at TEXT NOT NULL,
-      PRIMARY KEY (tenant_id, discover_workflow_id, discover_run_id)
-    );
-    CREATE TABLE operational_attempt_metrics (
-      metric_id               INTEGER PRIMARY KEY AUTOINCREMENT,
-      tenant_id               TEXT NOT NULL DEFAULT 'local',
-      occurred_at             TEXT NOT NULL,
-      stage                   TEXT NOT NULL,
-      source_id               TEXT,
-      source_kind             TEXT,
-      source_priority         TEXT,
-      source_role             TEXT,
-      adapter                 TEXT,
-      attempt_kind            TEXT NOT NULL,
-      outcome                 TEXT NOT NULL,
-      failure_category        TEXT,
-      is_operational_failure  INTEGER NOT NULL DEFAULT 0,
-      is_scrape_failure       INTEGER NOT NULL DEFAULT 0,
-      is_retryable            INTEGER NOT NULL DEFAULT 1,
-      run_id                  TEXT,
-      job_url                 TEXT,
-      duration_ms             INTEGER,
-      total_count             INTEGER,
-      new_count               INTEGER,
-      existing_count          INTEGER,
-      observed_count          INTEGER,
-      duplicate_count         INTEGER,
-      error_class             TEXT,
-      error_message           TEXT,
-      metadata_json           TEXT NOT NULL DEFAULT '{}'
-    );
-    CREATE TABLE contacts (
-      tenant_id   TEXT NOT NULL DEFAULT 'local',
-      contact_id  TEXT NOT NULL,
-      employer    TEXT,
-      job_url     TEXT,
-      role        TEXT NOT NULL DEFAULT 'other',
-      created_at  TEXT NOT NULL,
-      updated_at  TEXT NOT NULL,
-      deleted_at  TEXT,
-      PRIMARY KEY (tenant_id, contact_id)
-    );
-    CREATE TABLE contact_attributes (
-      tenant_id      TEXT NOT NULL DEFAULT 'local',
-      attribute_id   TEXT NOT NULL,
-      contact_id     TEXT NOT NULL,
-      attribute_kind TEXT NOT NULL,
-      value_json     TEXT,
-      source_kind    TEXT NOT NULL,
-      source_ref     TEXT NOT NULL,
-      capture_method TEXT NOT NULL,
-      confidence     REAL NOT NULL DEFAULT 0,
-      user_confirmed INTEGER NOT NULL DEFAULT 0,
-      recorded_at    TEXT NOT NULL,
-      PRIMARY KEY (tenant_id, attribute_id)
-    );
-    CREATE TABLE job_scores (
-      job_url TEXT,
-      version INTEGER,
-      tenant_id TEXT NOT NULL DEFAULT 'local',
-      fit_score INTEGER,
-      breakdown_json TEXT,
-      keywords_json TEXT,
-      scored_at TEXT,
-      correction_json TEXT,
-      criteria_json TEXT,
-      trace_json TEXT,
-      PRIMARY KEY (job_url, version, tenant_id)
-    );
-    CREATE TABLE job_materials (
-      job_url TEXT NOT NULL,
-      generation INTEGER NOT NULL,
-      tenant_id TEXT NOT NULL DEFAULT 'local',
-      status TEXT NOT NULL,
-      created_at TEXT NOT NULL,
-      updated_at TEXT NOT NULL,
-      last_validation_json TEXT,
-      last_verdict_json TEXT,
-      metadata_json TEXT,
-      PRIMARY KEY (job_url, generation)
-    );
-    CREATE TABLE job_materials_artifacts (
-      job_url TEXT NOT NULL,
-      generation INTEGER NOT NULL,
-      artifact_type TEXT NOT NULL,
-      artifact_id TEXT NOT NULL,
-      status TEXT NOT NULL,
-      path TEXT NOT NULL,
-      render_format TEXT NOT NULL,
-      size_bytes INTEGER,
-      metadata_json TEXT,
-      created_at TEXT NOT NULL,
-      superseded_at TEXT,
-      PRIMARY KEY (job_url, generation, artifact_type)
-    );
-    CREATE TABLE job_material_layout_boxes (
-      job_url TEXT NOT NULL,
-      generation INTEGER NOT NULL,
-      artifact_id TEXT NOT NULL,
-      box_index INTEGER NOT NULL,
-      tenant_id TEXT NOT NULL DEFAULT 'local',
-      semantic_id TEXT NOT NULL,
-      page_number INTEGER NOT NULL,
-      line_number INTEGER,
-      text_excerpt TEXT NOT NULL,
-      left_pct REAL NOT NULL,
-      top_pct REAL NOT NULL,
-      width_pct REAL NOT NULL,
-      height_pct REAL NOT NULL,
-      audit_target_json TEXT NOT NULL DEFAULT '{}',
-      created_at TEXT NOT NULL,
-      PRIMARY KEY (job_url, generation, artifact_id, box_index)
-    );
-    CREATE TABLE job_bullet_provenance (
-      job_url TEXT,
-      generation INTEGER,
-      bullet_id TEXT,
-      tenant_id TEXT NOT NULL DEFAULT 'local',
-      artifact_id TEXT,
-      section TEXT,
-      source_id TEXT,
-      evidence_ids_json TEXT,
-      requirement_ids_json TEXT,
-      matched_keywords_json TEXT,
-      transform_type TEXT,
-      control TEXT,
-      rationale TEXT,
-      generated_text TEXT,
-      position INTEGER,
-      created_at TEXT,
-      coverage_json TEXT,
-      voice_json TEXT
-    );
-    CREATE TABLE job_employer_analysis (
-      job_url TEXT NOT NULL,
-      generation INTEGER NOT NULL,
-      tenant_id TEXT NOT NULL DEFAULT 'local',
-      snapshot_hash TEXT NOT NULL DEFAULT '',
-      prompt_version TEXT NOT NULL DEFAULT '',
-      sdk_set_version TEXT NOT NULL DEFAULT '',
-      cache_key TEXT NOT NULL DEFAULT '',
-      role_framing TEXT NOT NULL DEFAULT '',
-      inferred_seniority TEXT NOT NULL DEFAULT '',
-      ideal_candidate_narrative TEXT NOT NULL DEFAULT '',
-      requirements_json TEXT NOT NULL DEFAULT '[]',
-      keywords_json TEXT NOT NULL DEFAULT '[]',
-      agreement_json TEXT NOT NULL DEFAULT '{}',
-      eeo_screen_json TEXT NOT NULL DEFAULT '[]',
-      legs_attempted INTEGER NOT NULL,
-      legs_succeeded INTEGER NOT NULL,
-      created_at TEXT NOT NULL,
-      PRIMARY KEY (job_url, generation)
-    );
-    CREATE TABLE job_employer_analysis_sub_analyses (
-      job_url TEXT NOT NULL,
-      generation INTEGER NOT NULL,
-      model_id TEXT NOT NULL,
-      tenant_id TEXT NOT NULL DEFAULT 'local',
-      analysis_json TEXT NOT NULL,
-      PRIMARY KEY (job_url, generation, model_id)
-    );
-    CREATE TABLE job_employer_analysis_failures (
-      job_url TEXT NOT NULL,
-      generation INTEGER NOT NULL,
-      model_id TEXT NOT NULL,
-      tenant_id TEXT NOT NULL DEFAULT 'local',
-      error TEXT NOT NULL,
-      raw_output TEXT,
-      PRIMARY KEY (job_url, generation, model_id)
-    );
-    CREATE TABLE job_requirement_fit_reports (
-      tenant_id TEXT NOT NULL DEFAULT 'local',
-      job_url TEXT NOT NULL,
-      score_version INTEGER NOT NULL,
-      employer_analysis_generation INTEGER NOT NULL,
-      profile_snapshot_version INTEGER NOT NULL,
-      scoring_policy_version INTEGER NOT NULL,
-      formula_version TEXT NOT NULL,
-      resolved_fit_score INTEGER,
-      fit_band TEXT NOT NULL,
-      confidence TEXT NOT NULL,
-      summary_json TEXT NOT NULL DEFAULT '{}',
-      created_at TEXT NOT NULL DEFAULT '',
-      PRIMARY KEY (job_url, score_version, tenant_id)
-    );
-    CREATE TABLE job_requirement_fit_items (
-      tenant_id TEXT NOT NULL DEFAULT 'local',
-      job_url TEXT NOT NULL,
-      score_version INTEGER NOT NULL,
-      requirement_id TEXT NOT NULL,
-      requirement_text TEXT NOT NULL,
-      tier TEXT NOT NULL,
-      weight REAL NOT NULL,
-      job_evidence_span TEXT NOT NULL DEFAULT '',
-      fit_json TEXT NOT NULL DEFAULT '{}',
-      contribution_json TEXT NOT NULL DEFAULT '{}',
-      tailoring_json TEXT NOT NULL DEFAULT '{}',
-      artifact_coverage_json TEXT,
-      position INTEGER NOT NULL DEFAULT 0,
-      PRIMARY KEY (job_url, score_version, tenant_id, requirement_id)
-    );
-  `);
+  db.pragma("foreign_keys = ON");
+  ensureApplicationFeedbackTables(db);
+  ensureDiscoveryControlTables(db);
+  ensureOutreachTables(db);
   writeProfileConfig(db, {
     profile: QA_PROFILE,
     style: QA_RESUME_STYLE,
     templateText: QA_RESUME_TEMPLATE,
   });
+  seedBuiltInResumeTemplate(db);
 
   // INSPECT-01: a current worker heartbeat so the generate-materials route's
   // worker-readiness gate passes in E2E. ``app_dir``/``db_path`` must match the
@@ -621,8 +252,8 @@ export function seedQaDatabase(dbPath: string, options: QaSeedOptions = {}): voi
   seedWorkerHeartbeat(db, dbPath);
 
   insertJob(db, {
-    url: "https://boards.greenhouse.io/gitlab/jobs/qa-platform-director",
-    applicationUrl: "https://boards.greenhouse.io/gitlab/jobs/qa-platform-director",
+    url: QA_PLATFORM_JOB_URL,
+    applicationUrl: QA_PLATFORM_JOB_URL,
     title: "Director of Platform Engineering",
     site: "Greenhouse",
     strategy: "qa",
@@ -641,7 +272,7 @@ export function seedQaDatabase(dbPath: string, options: QaSeedOptions = {}): voi
     description: "Marketing role intentionally below target.",
   });
   insertJob(db, {
-    url: "https://linkedin.com/jobs/view/qa-risk-manager",
+    url: QA_RISK_JOB_URL,
     title: "Senior Engineering Manager - Risk",
     site: "linkedin",
     strategy: "qa",
@@ -702,7 +333,7 @@ export function seedQaDatabase(dbPath: string, options: QaSeedOptions = {}): voi
     "INSERT INTO apply_run_projections (run_id, job_id, job_title, job_employer, status, result, dry_run, started_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
   ).run(
     "qa-run-1",
-    "https://boards.greenhouse.io/gitlab/jobs/qa-platform-director",
+    QA_PLATFORM_JOB_ID,
     "Director of Platform Engineering",
     "Greenhouse",
     "finished",
@@ -759,12 +390,14 @@ export function seedQaDatabase(dbPath: string, options: QaSeedOptions = {}): voi
   );
 
   // Canonical lifecycle events behind the projection above. Workflow events
-  // carry no job_url (stage "workflow"); identity travels in the camelCase
+  // carry no job_id (stage "workflow"); identity travels in the camelCase
   // payload, matching `infrastructure/temporal/finalize.py`. Seeding these
   // keeps the run drawer timeline and the activity/SSE stream consistent with
   // a real finalize + reconcile.
   const insertWorkflowEvent = db.prepare(
-    "INSERT INTO job_events (job_url, stage, event_type, level, message, occurred_at, payload_json) VALUES (?, ?, ?, ?, ?, ?, ?)",
+    `INSERT INTO job_events (
+       tenant_id, job_id, identity_version, stage, event_type, level, message, occurred_at, payload_json
+     ) VALUES ('local', ?, 1, ?, ?, ?, ?, ?, ?)`,
   );
   insertWorkflowEvent.run(
     null,
@@ -801,6 +434,21 @@ export function seedQaDatabase(dbPath: string, options: QaSeedOptions = {}): voi
   db.close();
 }
 
+function seedBuiltInResumeTemplate(db: Database.Database): void {
+  db.prepare(
+    `INSERT INTO resume_templates (
+       tenant_id, template_id, display_name, status, built_in, created_at, updated_at
+     ) VALUES ('local', 'built_in:modern-html', 'Modern HTML', 'active', 1, ?, ?)`,
+  ).run(QA_NOW, QA_NOW);
+  db.prepare(
+    `INSERT INTO resume_template_versions (
+       tenant_id, version_id, template_id, version_number, display_name, status,
+       theme_json, layout_json, content_hash, created_at
+     ) VALUES ('local', 'built_in:modern-html:v1', 'built_in:modern-html', 1,
+               'Modern HTML', 'active', ?, '{}', 'qa-seed-template', ?)`,
+  ).run(JSON.stringify(BUILT_IN_RESUME_TEMPLATE_THEME), QA_NOW);
+}
+
 function insertRequirementFitAuditFixture(
   db: Database.Database,
   paths: {
@@ -831,17 +479,17 @@ function insertCanonicalMaterials(
   const requirementLedMetadata = JSON.stringify(requirementLedAuditMetadata());
   db.prepare(
     `INSERT INTO job_materials (
-      job_url, generation, tenant_id, status, created_at, updated_at, metadata_json
-    ) VALUES (?, ?, ?, ?, ?, ?, ?)`,
-  ).run(QA_PLATFORM_JOB_URL, 1, "local", "approved", QA_NOW, QA_NOW, requirementLedMetadata);
+      tenant_id, job_id, generation, status, created_at, updated_at, metadata_json
+    ) VALUES ('local', ?, ?, ?, ?, ?, ?)`,
+  ).run(QA_PLATFORM_JOB_ID, 1, "approved", QA_NOW, QA_NOW, requirementLedMetadata);
   const insert = db.prepare(
     `INSERT INTO job_materials_artifacts (
-      job_url, generation, artifact_type, artifact_id, status, path,
+      tenant_id, job_id, generation, artifact_type, artifact_id, status, path,
       render_format, size_bytes, metadata_json, created_at
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    ) VALUES ('local', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   );
   insert.run(
-    QA_PLATFORM_JOB_URL,
+    QA_PLATFORM_JOB_ID,
     1,
     "tailored_resume",
     "qa-platform-resume-text",
@@ -853,7 +501,7 @@ function insertCanonicalMaterials(
     QA_NOW,
   );
   insert.run(
-    QA_PLATFORM_JOB_URL,
+    QA_PLATFORM_JOB_ID,
     1,
     "resume_pdf",
     "qa-platform-resume-pdf",
@@ -865,7 +513,7 @@ function insertCanonicalMaterials(
     QA_NOW,
   );
   insert.run(
-    QA_PLATFORM_JOB_URL,
+    QA_PLATFORM_JOB_ID,
     1,
     "cover_letter",
     "qa-platform-cover-text",
@@ -877,7 +525,7 @@ function insertCanonicalMaterials(
     QA_NOW,
   );
   insert.run(
-    QA_PLATFORM_JOB_URL,
+    QA_PLATFORM_JOB_ID,
     1,
     "cover_letter_pdf",
     "qa-platform-cover-pdf",
@@ -890,17 +538,16 @@ function insertCanonicalMaterials(
   );
   const insertBox = db.prepare(
     `INSERT INTO job_material_layout_boxes (
-      job_url, generation, artifact_id, box_index, tenant_id, semantic_id,
+      tenant_id, job_id, generation, artifact_id, box_index, semantic_id,
       page_number, line_number, text_excerpt, left_pct, top_pct, width_pct,
       height_pct, audit_target_json, created_at
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    ) VALUES ('local', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   );
   insertBox.run(
-    QA_PLATFORM_JOB_URL,
+    QA_PLATFORM_JOB_ID,
     1,
     "qa-platform-resume-pdf",
     0,
-    "local",
     "experience:qa_platform:bullet:1",
     1,
     5,
@@ -1009,15 +656,14 @@ function requirementLedAuditMetadata(): Record<string, unknown> {
 function insertEmployerAnalysis(db: Database.Database): void {
   db.prepare(
     `INSERT INTO job_employer_analysis (
-      job_url, generation, tenant_id, snapshot_hash, prompt_version, sdk_set_version,
+      tenant_id, job_id, generation, snapshot_hash, prompt_version, sdk_set_version,
       cache_key, role_framing, inferred_seniority, ideal_candidate_narrative,
       requirements_json, keywords_json, agreement_json, eeo_screen_json,
       legs_attempted, legs_succeeded, created_at
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    ) VALUES ('local', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   ).run(
-    QA_PLATFORM_JOB_URL,
+    QA_PLATFORM_JOB_ID,
     1,
-    "local",
     "qa-snapshot",
     "employer-analysis-v1",
     "qa-sdk-set",
@@ -1070,13 +716,13 @@ function insertEmployerAnalysis(db: Database.Database): void {
 function insertRequirementFitReport(db: Database.Database): void {
   db.prepare(
     `INSERT INTO job_requirement_fit_reports (
-      tenant_id, job_url, score_version, employer_analysis_generation,
+      tenant_id, job_id, score_version, employer_analysis_generation,
       profile_snapshot_version, scoring_policy_version, formula_version,
       resolved_fit_score, fit_band, confidence, summary_json, created_at
     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   ).run(
     "local",
-    QA_PLATFORM_JOB_URL,
+    QA_PLATFORM_JOB_ID,
     1,
     1,
     4,
@@ -1095,14 +741,14 @@ function insertRequirementFitReport(db: Database.Database): void {
   );
   const insertItem = db.prepare(
     `INSERT INTO job_requirement_fit_items (
-      tenant_id, job_url, score_version, requirement_id, requirement_text,
+      tenant_id, job_id, score_version, requirement_id, requirement_text,
       tier, weight, job_evidence_span, fit_json, contribution_json,
       tailoring_json, artifact_coverage_json, position
     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   );
   insertItem.run(
     "local",
-    QA_PLATFORM_JOB_URL,
+    QA_PLATFORM_JOB_ID,
     1,
     "r1",
     "Lead platform reliability improvements across critical services.",
@@ -1134,7 +780,7 @@ function insertRequirementFitReport(db: Database.Database): void {
   );
   insertItem.run(
     "local",
-    QA_PLATFORM_JOB_URL,
+    QA_PLATFORM_JOB_ID,
     1,
     "r2",
     "Improve developer experience and incident-response practices.",
@@ -1174,15 +820,14 @@ function insertRequirementFitReport(db: Database.Database): void {
 function insertBulletProvenance(db: Database.Database): void {
   db.prepare(
     `INSERT INTO job_bullet_provenance (
-      job_url, generation, bullet_id, tenant_id, artifact_id, section, source_id,
+      tenant_id, job_id, generation, bullet_id, artifact_id, section, source_id,
       evidence_ids_json, requirement_ids_json, matched_keywords_json,
       transform_type, control, rationale, generated_text, position, created_at
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    ) VALUES ('local', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   ).run(
-    QA_PLATFORM_JOB_URL,
+    QA_PLATFORM_JOB_ID,
     1,
     "summary-1",
-    "local",
     "qa-platform-resume-text",
     "summary",
     "qa_platform",
@@ -1201,13 +846,12 @@ function insertBulletProvenance(db: Database.Database): void {
 function insertScore(db: Database.Database, jobUrl: string, fitScore: number): void {
   db.prepare(
     `INSERT INTO job_scores (
-      job_url, version, tenant_id, fit_score, breakdown_json, keywords_json,
+      tenant_id, job_id, version, fit_score, breakdown_json, keywords_json,
       scored_at, correction_json, criteria_json, trace_json
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    ) VALUES ('local', ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   ).run(
-    jobUrl,
+    qaJobId(jobUrl),
     1,
-    "local",
     fitScore,
     JSON.stringify({
       reasoning: "Strong platform leadership fit.",
@@ -1283,7 +927,7 @@ function seedPipelineOperations(db: Database.Database, dbPath: string): void {
 
   const insertMember = db.prepare(
     `INSERT INTO discovery_execution_jobs (
-      tenant_id, discover_workflow_id, discover_run_id, job_url, cohort_kind,
+      tenant_id, discover_workflow_id, discover_run_id, job_id, cohort_kind,
       source_family, source_run_id, preparation_workflow_id, work_plan_state,
       required_steps_json, work_plan_reason, linked_at
     ) VALUES ('local', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
@@ -1291,7 +935,7 @@ function seedPipelineOperations(db: Database.Database, dbPath: string): void {
   insertMember.run(
     discoverWorkflowId,
     discoverRunId,
-    QA_PLATFORM_JOB_URL,
+    QA_PLATFORM_JOB_ID,
     "observed_this_run",
     "greenhouse",
     "qa-greenhouse-run",
@@ -1304,7 +948,7 @@ function seedPipelineOperations(db: Database.Database, dbPath: string): void {
   insertMember.run(
     discoverWorkflowId,
     discoverRunId,
-    "https://talent.com/view?id=qa-marketing-director",
+    qaJobId("https://talent.com/view?id=qa-marketing-director"),
     "observed_this_run",
     "talent",
     "qa-talent-run",
@@ -1317,7 +961,7 @@ function seedPipelineOperations(db: Database.Database, dbPath: string): void {
   insertMember.run(
     discoverWorkflowId,
     discoverRunId,
-    "https://linkedin.com/jobs/view/qa-risk-manager",
+    qaJobId("https://linkedin.com/jobs/view/qa-risk-manager"),
     "existing_backlog",
     "linkedin",
     "qa-linkedin-run",
@@ -1330,7 +974,7 @@ function seedPipelineOperations(db: Database.Database, dbPath: string): void {
   insertMember.run(
     discoverWorkflowId,
     discoverRunId,
-    "https://motorolasolutions.com/careers/qa-command-center",
+    qaJobId("https://motorolasolutions.com/careers/qa-command-center"),
     "observed_this_run",
     "greenhouse",
     "qa-greenhouse-run",
@@ -1451,12 +1095,12 @@ function seedPipelineOperations(db: Database.Database, dbPath: string): void {
   const recoveryMemberships = (
     db
       .prepare(
-        `SELECT job_url FROM discovery_execution_jobs
+        `SELECT job_id FROM discovery_execution_jobs
           WHERE tenant_id = 'local' AND discover_workflow_id = ? AND discover_run_id = ?
-          ORDER BY job_url`,
+          ORDER BY job_id`,
       )
-      .all(discoverWorkflowId, discoverRunId) as Array<{ job_url: string }>
-  ).map((row) => row.job_url);
+      .all(discoverWorkflowId, discoverRunId) as Array<{ job_id: string }>
+  ).map((row) => row.job_id);
   const recoverySteps = (
     db
       .prepare(
@@ -1577,17 +1221,16 @@ function recoveryKeyDigest(
 }
 
 function seedResumeReviewDraft(db: Database.Database): void {
-  ensureResumeReviewTables(db);
   db.prepare(
     `INSERT INTO resume_review_drafts (
-      tenant_id, draft_id, job_key, base_generation,
+      tenant_id, draft_id, job_id, base_generation,
       base_resume_text_artifact_id, base_resume_pdf_artifact_id,
       renderer_format, state, current_revision_id, latest_revision_number,
       created_at, updated_at
     ) VALUES ('local', ?, ?, 1, ?, ?, 'html_pdf', 'active', NULL, 0, ?, ?)`,
   ).run(
     "qa-platform-resume-draft",
-    QA_PLATFORM_JOB_URL,
+    QA_PLATFORM_JOB_ID,
     "qa-platform-resume-text",
     "qa-platform-resume-pdf",
     QA_NOW,
@@ -1637,7 +1280,6 @@ function seedContacts(db: Database.Database): void {
 }
 
 function seedOutcomeAnalytics(db: Database.Database): void {
-  ensureApplicationFeedbackTables(db);
   const applications = [
     {
       url: "https://boards.greenhouse.io/northstarlabs/jobs/qa-analytics-platform-manager",
@@ -1762,17 +1404,17 @@ function seedOutcomeAnalytics(db: Database.Database): void {
     },
   ] as const;
   const markApplied = db.prepare(
-    "UPDATE jobs SET apply_status = 'applied', applied_at = ? WHERE url = ?",
+    "UPDATE jobs SET apply_status = 'applied', applied_at = ? WHERE tenant_id = 'local' AND job_id = ?",
   );
   const insertOutcome = db.prepare(
     `INSERT INTO application_outcomes (
-      tenant_id, outcome_id, job_key, kind, source, note, occurred_at,
+      tenant_id, outcome_id, job_id, kind, source, note, occurred_at,
       recorded_at, suggestion_id, evidence_id, interview_prep_generation
     ) VALUES ('local', ?, ?, ?, ?, NULL, ?, ?, ?, NULL, NULL)`,
   );
   const insertSuggestion = db.prepare(
     `INSERT INTO application_outcome_suggestions (
-      tenant_id, suggestion_id, job_key, evidence_id, suggested_kind,
+      tenant_id, suggestion_id, job_id, evidence_id, suggested_kind,
       confidence, rationale, status, created_at, decided_at, decision,
       decision_reason, decided_outcome_id
     ) VALUES ('local', ?, ?, NULL, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
@@ -1790,12 +1432,13 @@ function seedOutcomeAnalytics(db: Database.Database): void {
     for (const stage of ["discover", "enrich", "score", "tailor", "cover", "apply"]) {
       insertStage(db, application.url, stage, "succeeded");
     }
-    markApplied.run(application.appliedAt, application.url);
+    const jobId = qaJobId(application.url);
+    markApplied.run(application.appliedAt, jobId);
     const suggestionId =
       application.suggestion?.status === "ignored" ? null : application.suggestion?.id ?? null;
     insertOutcome.run(
       application.outcomeId,
-      application.url,
+      jobId,
       application.outcomeKind,
       suggestionId ? "email_suggestion" : "manual",
       application.outcomeAt,
@@ -1806,7 +1449,7 @@ function seedOutcomeAnalytics(db: Database.Database): void {
       const createdAt = new Date(Date.parse(application.outcomeAt) - 30 * 60_000).toISOString();
       insertSuggestion.run(
         application.suggestion.id,
-        application.url,
+        jobId,
         application.suggestion.suggestedKind,
         0.9,
         "Synthetic email signal matched to this application for documentation QA.",
@@ -1822,8 +1465,6 @@ function seedOutcomeAnalytics(db: Database.Database): void {
 }
 
 function seedDiscoverySources(db: Database.Database): void {
-  ensureDiscoveryControlTables(db);
-  ensureProjectionTables(db);
   const insertSource = db.prepare(
     `INSERT INTO source_registry_entries (
       tenant_id, source_id, kind, display_name, owner, priority, state,
@@ -2070,11 +1711,11 @@ function insertJob(db: Database.Database, job: QaJobSeed): void {
 function insertStage(db: Database.Database, jobUrl: string, stage: string, state: string, errorCode: string | null = null): void {
   db.prepare(
     `INSERT INTO job_stage_states (
-      job_url, stage, state, attempt_count, max_attempts, updated_at,
+      tenant_id, job_id, stage, state, attempt_count, max_attempts, updated_at,
       error_code, error_message, retryable, blocked_by_json
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    ) VALUES ('local', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   ).run(
-    jobUrl,
+    qaJobId(jobUrl),
     stage,
     state,
     state === "failed" ? 1 : 0,
@@ -2089,8 +1730,10 @@ function insertStage(db: Database.Database, jobUrl: string, stage: string, state
 
 function insertArtifact(db: Database.Database, jobUrl: string, type: string, filePath: string): void {
   db.prepare(
-    "INSERT INTO job_artifacts (job_url, stage, artifact_type, status, path, created_at, size_bytes) VALUES (?, ?, ?, ?, ?, ?, ?)",
-  ).run(jobUrl, artifactStage(type), type, "active", filePath, QA_NOW, localFileSize(filePath));
+    `INSERT INTO job_artifacts (
+       tenant_id, job_id, stage, artifact_type, status, path, created_at, size_bytes
+     ) VALUES ('local', ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(qaJobId(jobUrl), artifactStage(type), type, "active", filePath, QA_NOW, localFileSize(filePath));
 }
 
 function insertEvent(db: Database.Database, jobUrl: string, stage: string, level: string, message: string): void {
@@ -2100,8 +1743,10 @@ function insertEvent(db: Database.Database, jobUrl: string, stage: string, level
   // silently dropped from /v1/events/stream and any test that depends
   // on the SSE pipeline against qa-seed data sees nothing.
   db.prepare(
-    "INSERT INTO job_events (job_url, stage, event_type, level, message, occurred_at) VALUES (?, ?, ?, ?, ?, ?)",
-  ).run(jobUrl, stage, "QaInfo", level, message, QA_NOW);
+    `INSERT INTO job_events (
+       tenant_id, job_id, identity_version, stage, event_type, level, message, occurred_at
+     ) VALUES ('local', ?, 1, ?, ?, ?, ?, ?)`,
+  ).run(qaJobId(jobUrl), stage, "QaInfo", level, message, QA_NOW);
 }
 
 function artifactStage(type: string): string {

--- a/apps/api/test/qa-seed.ts
+++ b/apps/api/test/qa-seed.ts
@@ -23,6 +23,7 @@ export interface QaSeedOptions {
 interface QaJobSeed {
   url: string;
   title: string;
+  company?: string;
   site: string;
   strategy?: string;
   location?: string;
@@ -249,6 +250,7 @@ export function seedQaDatabase(dbPath: string, options: QaSeedOptions = {}): voi
     url: QA_PLATFORM_JOB_URL,
     applicationUrl: QA_PLATFORM_JOB_URL,
     title: "Director of Platform Engineering",
+    company: "GitLab",
     site: "Greenhouse",
     strategy: "qa",
     location: "Remote, United States",
@@ -1677,14 +1679,15 @@ function seedWorkerHeartbeat(db: Database.Database, dbPath: string): void {
 function insertJob(db: Database.Database, job: QaJobSeed): void {
   db.prepare(
     `INSERT INTO jobs (
-      url, tenant_id, job_id, title, site, strategy, location, salary, discovered_at, application_url,
+      url, tenant_id, job_id, title, company, site, strategy, location, salary, discovered_at, application_url,
       description, full_description, detail_scraped_at, fit_score, score_reasoning,
       scored_at, tailored_resume_path, tailored_at
-    ) VALUES (?, 'local', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    ) VALUES (?, 'local', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   ).run(
     job.url,
     qaJobId(job.url),
     job.title,
+    job.company ?? "",
     job.site,
     job.strategy ?? "qa",
     job.location ?? "Remote",

--- a/apps/api/test/server.test.ts
+++ b/apps/api/test/server.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -27,6 +28,7 @@ import type { JsonRpcDispatcher } from "../src/json-rpc-adapter.js";
 import { PROFILE_PREVIEW_SCRIPT, defaultActionDispatcher, type ActionDispatchResult } from "../src/local-actions.js";
 import { BUILT_IN_RESUME_TEMPLATE_THEME } from "../src/resume-templates.js";
 import { buildApp, type BuildAppOptions } from "../src/server.js";
+import { initializeExactV7Database } from "./v7-schema.js";
 
 let tempDir = "";
 let options: BuildAppOptions;
@@ -294,9 +296,10 @@ describe("local TypeScript API", () => {
     await app.close();
   });
 
-  it("normalizes legacy lifecycle tables before health-only startup completes", async () => {
+  it("rejects legacy lifecycle tables before health-only startup completes", async () => {
+    const legacyDbPath = path.join(tempDir, "legacy-health.sqlite3");
     const token = "job" + "ctl";
-    const db = new Database(options.dbPath);
+    const db = new Database(legacyDbPath);
     db.exec(`
       CREATE TABLE ${token}_hidden_jobs (
         job_url TEXT PRIMARY KEY,
@@ -309,22 +312,7 @@ describe("local TypeScript API", () => {
     `);
     db.close();
 
-    const app = buildApp(options);
-    const response = await app.inject({ method: "GET", url: "/v1/health" });
-    expect(response.statusCode, response.body).toBe(200);
-    await app.close();
-
-    const verify = new Database(options.dbPath);
-    try {
-      expect(
-        verify.prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?").get(`${token}_hidden_jobs`),
-      ).toBeUndefined();
-      expect(
-        verify.prepare("SELECT COUNT(*) AS count FROM jobctrl_hidden_jobs").get(),
-      ).toMatchObject({ count: 1 });
-    } finally {
-      verify.close();
-    }
+    expect(() => buildApp({ ...options, dbPath: legacyDbPath })).toThrow("schema version 0");
   });
 
   it("reports today's LLM spend against the configured budget", async () => {
@@ -1294,7 +1282,7 @@ describe("local TypeScript API", () => {
     expect(body.activity[0]).toMatchObject({
       eventId: "1",
       eventType: "ActionFailed",
-      jobKey: "https://example.com/jobs/failed-score",
+      jobKey: jobIdFor("https://example.com/jobs/failed-score"),
       title: "Backend Engineer",
       company: "ExampleCo",
       stage: "score",
@@ -1332,11 +1320,11 @@ describe("local TypeScript API", () => {
     const db = new Database(options.dbPath);
     try {
       db.prepare(
-        "UPDATE job_stage_states SET state = 'running', updated_at = ? WHERE job_url = ? AND stage = 'score'",
-      ).run("2999-01-01T00:00:00Z", "https://example.com/jobs/failed-score");
+        "UPDATE job_stage_states SET state = 'running', updated_at = ? WHERE tenant_id = 'local' AND job_id = ? AND stage = 'score'",
+      ).run("2999-01-01T00:00:00Z", jobIdFor("https://example.com/jobs/failed-score"));
       db.prepare(
-        "UPDATE job_stage_states SET state = 'running', updated_at = ? WHERE job_url = ? AND stage = 'tailor'",
-      ).run("2020-01-01T00:00:00Z", "https://example.com/jobs/blocked-tailor");
+        "UPDATE job_stage_states SET state = 'running', updated_at = ? WHERE tenant_id = 'local' AND job_id = ? AND stage = 'tailor'",
+      ).run("2020-01-01T00:00:00Z", jobIdFor("https://example.com/jobs/blocked-tailor"));
     } finally {
       db.close();
     }
@@ -1411,7 +1399,7 @@ describe("local TypeScript API", () => {
         stuckAfterSeconds: 150,
         stuckItems: [
           {
-            jobKey: "https://example.com/jobs/blocked-tailor",
+            jobKey: jobIdFor("https://example.com/jobs/blocked-tailor"),
             title: "Frontend Engineer",
             company: "Acme",
             stage: "tailor",
@@ -1428,7 +1416,7 @@ describe("local TypeScript API", () => {
     const db = new Database(options.dbPath);
     try {
       db.prepare(
-        "INSERT INTO job_events (job_url, stage, event_type, level, message, occurred_at, payload_json) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        "INSERT INTO job_events (tenant_id, job_id, identity_version, stage, event_type, level, message, occurred_at, payload_json) SELECT 'local', (SELECT job_id FROM jobs WHERE tenant_id = 'local' AND url = ?), 1, ?, ?, ?, ?, ?, ?",
       ).run(
         null,
         "discover",
@@ -1508,7 +1496,7 @@ describe("local TypeScript API", () => {
     const db = new Database(options.dbPath);
     try {
       db.prepare(
-        "INSERT INTO job_events (job_url, stage, event_type, level, message, occurred_at, payload_json) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        "INSERT INTO job_events (tenant_id, job_id, identity_version, stage, event_type, level, message, occurred_at, payload_json) SELECT 'local', (SELECT job_id FROM jobs WHERE tenant_id = 'local' AND url = ?), 1, ?, ?, ?, ?, ?, ?",
       ).run(
         null,
         "discover",
@@ -1596,7 +1584,7 @@ describe("local TypeScript API", () => {
     const db = new Database(options.dbPath);
     try {
       db.prepare(
-        "INSERT INTO job_events (job_url, stage, event_type, level, message, occurred_at, payload_json) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        "INSERT INTO job_events (tenant_id, job_id, identity_version, stage, event_type, level, message, occurred_at, payload_json) SELECT 'local', (SELECT job_id FROM jobs WHERE tenant_id = 'local' AND url = ?), 1, ?, ?, ?, ?, ?, ?",
       ).run(
         null,
         "discover",
@@ -1681,7 +1669,7 @@ describe("local TypeScript API", () => {
     const db = new Database(options.dbPath);
     try {
       db.prepare(
-        "INSERT INTO job_events (job_url, stage, event_type, level, message, occurred_at, payload_json) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        "INSERT INTO job_events (tenant_id, job_id, identity_version, stage, event_type, level, message, occurred_at, payload_json) SELECT 'local', (SELECT job_id FROM jobs WHERE tenant_id = 'local' AND url = ?), 1, ?, ?, ?, ?, ?, ?",
       ).run(
         null,
         "discover",
@@ -1748,7 +1736,7 @@ describe("local TypeScript API", () => {
     const db = new Database(options.dbPath);
     try {
       db.prepare(
-        "INSERT INTO job_events (job_url, stage, event_type, level, message, occurred_at, payload_json) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        "INSERT INTO job_events (tenant_id, job_id, identity_version, stage, event_type, level, message, occurred_at, payload_json) SELECT 'local', (SELECT job_id FROM jobs WHERE tenant_id = 'local' AND url = ?), 1, ?, ?, ?, ?, ?, ?",
       ).run(
         null,
         "discover",
@@ -1807,7 +1795,7 @@ describe("local TypeScript API", () => {
     const db = new Database(options.dbPath);
     try {
       db.prepare(
-        "INSERT INTO job_events (job_url, stage, event_type, level, message, occurred_at, payload_json) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        "INSERT INTO job_events (tenant_id, job_id, identity_version, stage, event_type, level, message, occurred_at, payload_json) SELECT 'local', (SELECT job_id FROM jobs WHERE tenant_id = 'local' AND url = ?), 1, ?, ?, ?, ?, ?, ?",
       ).run(
         null,
         "discover",
@@ -1850,7 +1838,7 @@ describe("local TypeScript API", () => {
     const db = new Database(options.dbPath);
     try {
       db.prepare(
-        "INSERT INTO job_events (job_url, stage, event_type, level, message, occurred_at, payload_json) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        "INSERT INTO job_events (tenant_id, job_id, identity_version, stage, event_type, level, message, occurred_at, payload_json) SELECT 'local', (SELECT job_id FROM jobs WHERE tenant_id = 'local' AND url = ?), 1, ?, ?, ?, ?, ?, ?",
       ).run(
         null,
         "discover",
@@ -1961,7 +1949,7 @@ describe("local TypeScript API", () => {
     const db = new Database(options.dbPath);
     try {
       const insertActivity = db.prepare(
-        "INSERT INTO job_events (job_url, stage, event_type, level, message, occurred_at) VALUES (?, ?, ?, ?, ?, ?)",
+        "INSERT INTO job_events (tenant_id, job_id, identity_version, stage, event_type, level, message, occurred_at) SELECT 'local', (SELECT job_id FROM jobs WHERE tenant_id = 'local' AND url = ?), 1, ?, ?, ?, ?, ?",
       );
       for (let index = 0; index < 75; index += 1) {
         const suffix = String(index + 1).padStart(2, "0");
@@ -2001,10 +1989,11 @@ describe("local TypeScript API", () => {
 
   it("does not expose dashboard activity links for events whose job no longer exists", async () => {
     const db = new Database(options.dbPath);
+    db.pragma("foreign_keys = OFF");
     db.prepare(
-      "INSERT INTO job_events (job_url, stage, event_type, level, message, occurred_at) VALUES (?, ?, ?, ?, ?, ?)",
+      "INSERT INTO job_events (tenant_id, job_id, identity_version, stage, event_type, level, message, occurred_at) VALUES ('local', ?, 1, ?, ?, ?, ?, ?)",
     ).run(
-      "https://example.com/jobs/missing-parent",
+      jobIdFor("https://example.com/jobs/missing-parent"),
       "tailor",
       "StageFailed",
       "error",
@@ -2050,7 +2039,7 @@ describe("local TypeScript API", () => {
     expect(body.pagination).toMatchObject({ page: 1, pageSize: 1, total: 1, pages: 1 });
     expect(body.items).toHaveLength(1);
     expect(body.items[0]).toMatchObject({
-      jobKey: "https://example.com/jobs/failed-score",
+      jobKey: jobIdFor("https://example.com/jobs/failed-score"),
       title: "Backend Engineer",
       currentStage: "discover",
       currentState: "failed",
@@ -2095,7 +2084,7 @@ describe("local TypeScript API", () => {
     insertUnannualizedPostedCompensationFact(seedDb, "https://example.com/jobs/failed-score");
     insertMarketCompensationEstimate(seedDb, "https://example.com/jobs/ready");
     seedDb
-      .prepare("INSERT INTO job_events (job_url, stage, event_type, level, message, occurred_at, payload_json) VALUES (?, ?, ?, ?, ?, ?, ?)")
+      .prepare("INSERT INTO job_events (tenant_id, job_id, identity_version, stage, event_type, level, message, occurred_at, payload_json) SELECT 'local', (SELECT job_id FROM jobs WHERE tenant_id = 'local' AND url = ?), 1, ?, ?, ?, ?, ?, ?")
       .run(
         "https://example.com/jobs/ready",
         "enrich",
@@ -2131,7 +2120,7 @@ describe("local TypeScript API", () => {
     });
     expect(salarySorted.statusCode, salarySorted.body).toBe(200);
     expect(salarySorted.json().items[0]).toMatchObject({
-      jobKey: "https://example.com/jobs/ready",
+      jobKey: jobIdFor("https://example.com/jobs/ready"),
       compensationSummary: {
         posted: {
           displayRange: "EUR 55000/year",
@@ -2149,7 +2138,7 @@ describe("local TypeScript API", () => {
     });
     expect(salaryMaxSorted.statusCode, salaryMaxSorted.body).toBe(200);
     expect(salaryMaxSorted.json().items[0]).toMatchObject({
-      jobKey: "https://example.com/jobs/ready",
+      jobKey: jobIdFor("https://example.com/jobs/ready"),
     });
 
     const marketSorted = await app.inject({
@@ -2158,7 +2147,7 @@ describe("local TypeScript API", () => {
     });
     expect(marketSorted.statusCode, marketSorted.body).toBe(200);
     expect(marketSorted.json().items[0]).toMatchObject({
-      jobKey: "https://example.com/jobs/ready",
+      jobKey: jobIdFor("https://example.com/jobs/ready"),
       compensationSummary: {
         market: { displayRange: "EUR 112000-142000/year" },
       },
@@ -2269,7 +2258,7 @@ describe("local TypeScript API", () => {
     const jobUrl = "https://example.com/jobs/ready";
     const db = new Database(options.dbPath);
     const insertAuditEvent = db.prepare(
-      "INSERT INTO job_events (job_url, stage, event_type, level, message, occurred_at, payload_json) VALUES (?, ?, ?, ?, ?, ?, ?)",
+      "INSERT INTO job_events (tenant_id, job_id, identity_version, stage, event_type, level, message, occurred_at, payload_json) SELECT 'local', (SELECT job_id FROM jobs WHERE tenant_id = 'local' AND url = ?), 1, ?, ?, ?, ?, ?, ?",
     );
     insertAuditEvent.run(
       jobUrl,
@@ -2393,7 +2382,7 @@ describe("local TypeScript API", () => {
     const candidateUrl = "https://jobs.lever.co/acme/staff-platform-engineer-india";
     const db = new Database(options.dbPath);
     db.prepare(
-      "INSERT INTO job_events (job_url, stage, event_type, level, message, occurred_at, payload_json) VALUES (?, ?, ?, ?, ?, ?, ?)",
+      "INSERT INTO job_events (tenant_id, job_id, identity_version, stage, event_type, level, message, occurred_at, payload_json) SELECT 'local', (SELECT job_id FROM jobs WHERE tenant_id = 'local' AND url = ?), 1, ?, ?, ?, ?, ?, ?",
     ).run(
       jobUrl,
       "discover",
@@ -2439,9 +2428,9 @@ describe("local TypeScript API", () => {
     const supersededUrl = "https://careers.acme.com/staff-platform-engineer";
     const db = new Database(options.dbPath);
     db.prepare(
-      "INSERT INTO job_events (job_url, stage, event_type, level, message, occurred_at, payload_json) VALUES (?, ?, ?, ?, ?, ?, ?)",
+      "INSERT INTO job_events (tenant_id, job_id, identity_version, stage, event_type, level, message, occurred_at, payload_json) SELECT 'local', (SELECT job_id FROM jobs WHERE tenant_id = 'local' AND url = ?), 1, ?, ?, ?, ?, ?, ?",
     ).run(
-      null,
+      jobUrl,
       "discover",
       "DuplicateJobLinked",
       "info",
@@ -2450,7 +2439,7 @@ describe("local TypeScript API", () => {
       JSON.stringify({
         tenantId: "local",
         duplicate_link_id: "dup:linked-1",
-        surviving_job_id: jobUrl,
+        surviving_job_id: jobIdFor(jobUrl),
         superseded_job_or_observation_id: supersededUrl,
         reason: "content_fingerprint_match",
         confidence: 0.95,
@@ -2485,7 +2474,7 @@ describe("local TypeScript API", () => {
     const jobUrl = "https://example.com/jobs/ready";
     const db = new Database(options.dbPath);
     db.prepare(
-      "INSERT INTO job_events (job_url, stage, event_type, level, message, occurred_at, payload_json) VALUES (?, ?, ?, ?, ?, ?, ?)",
+      "INSERT INTO job_events (tenant_id, job_id, identity_version, stage, event_type, level, message, occurred_at, payload_json) SELECT 'local', (SELECT job_id FROM jobs WHERE tenant_id = 'local' AND url = ?), 1, ?, ?, ?, ?, ?, ?",
     ).run(
       jobUrl,
       "enrich",
@@ -2545,14 +2534,14 @@ describe("local TypeScript API", () => {
     });
 
     expect(singleDelete.statusCode, singleDelete.body).toBe(200);
-    expect(singleDelete.json()).toMatchObject({ ok: true, count: 1, jobKeys: ["https://example.com/jobs/ready"] });
+    expect(singleDelete.json()).toMatchObject({ ok: true, count: 1, jobKeys: [jobIdFor("https://example.com/jobs/ready")] });
     expect(bulkDelete.statusCode, bulkDelete.body).toBe(200);
-    expect(bulkDelete.json()).toMatchObject({ ok: true, count: 1, jobKeys: ["https://example.com/jobs/failed-score"] });
+    expect(bulkDelete.json()).toMatchObject({ ok: true, count: 1, jobKeys: [jobIdFor("https://example.com/jobs/failed-score")] });
 
     const active = await app.inject({ method: "GET", url: "/v1/jobs" });
     expect(active.statusCode, active.body).toBe(200);
     expect(active.json().pagination.total).toBe(1);
-    expect(active.json().items.map((job: { jobKey: string }) => job.jobKey)).toEqual(["https://example.com/jobs/blocked-tailor"]);
+    expect(active.json().items.map((job: { jobKey: string }) => job.jobKey)).toEqual([jobIdFor("https://example.com/jobs/blocked-tailor")]);
 
     const deleted = await app.inject({ method: "GET", url: "/v1/jobs?deleted=deleted&sort=title&dir=asc" });
     expect(deleted.statusCode, deleted.body).toBe(200);
@@ -2593,18 +2582,10 @@ describe("local TypeScript API", () => {
 
   it("treats stale restores before later deletes as deleted", async () => {
     const db = new Database(options.dbPath);
-    db.exec(`
-      CREATE TABLE IF NOT EXISTS jobctrl_deleted_jobs (
-        job_url TEXT PRIMARY KEY,
-        deleted_at TEXT NOT NULL,
-        reason TEXT,
-        restored_at TEXT
-      );
-    `);
     db.prepare(
-      "INSERT INTO jobctrl_deleted_jobs (job_url, deleted_at, reason, restored_at) VALUES (?, ?, ?, ?)",
+      "INSERT INTO jobctrl_deleted_jobs (tenant_id, job_id, deleted_at, reason, restored_at) VALUES ('local', ?, ?, ?, ?)",
     ).run(
-      "https://example.com/jobs/ready",
+      jobIdFor("https://example.com/jobs/ready"),
       "2026-05-25T23:10:33.870522+00:00",
       "discovery hygiene rejected source",
       "2026-05-25T21:35:55.879345+00:00",
@@ -2620,7 +2601,7 @@ describe("local TypeScript API", () => {
     expect(deleted.statusCode, deleted.body).toBe(200);
     expect(deleted.json().pagination.total).toBe(1);
     expect(deleted.json().items[0]).toMatchObject({
-      jobKey: "https://example.com/jobs/ready",
+      jobKey: jobIdFor("https://example.com/jobs/ready"),
       deletedAt: "2026-05-25T23:10:33.870522+00:00",
     });
 
@@ -2646,7 +2627,7 @@ describe("local TypeScript API", () => {
     expect(active.statusCode, active.body).toBe(200);
     expect(active.json().pagination.total).toBe(2);
     expect(active.json().items.map((job: { jobKey: string }) => job.jobKey)).not.toContain(
-      "https://example.com/jobs/blocked-tailor",
+      jobIdFor("https://example.com/jobs/blocked-tailor"),
     );
 
     const deleted = await app.inject({ method: "GET", url: "/v1/jobs?deleted=deleted" });
@@ -2657,7 +2638,7 @@ describe("local TypeScript API", () => {
     expect(hidden.statusCode, hidden.body).toBe(200);
     expect(hidden.json().pagination.total).toBe(1);
     expect(hidden.json().items[0]).toMatchObject({
-      jobKey: "https://example.com/jobs/blocked-tailor",
+      jobKey: jobIdFor("https://example.com/jobs/blocked-tailor"),
       hiddenAt: expect.any(String),
       deletedAt: null,
     });
@@ -2680,32 +2661,21 @@ describe("local TypeScript API", () => {
 
   it("separates closed postings from active and deleted jobs", async () => {
     const db = new Database(options.dbPath);
-    db.exec(`
-      CREATE TABLE IF NOT EXISTS posting_snapshot_sets (
-        tenant_id TEXT NOT NULL DEFAULT 'local',
-        job_url TEXT NOT NULL,
-        snapshot_set_json TEXT NOT NULL,
-        latest_snapshot_version INTEGER NOT NULL DEFAULT 0,
-        latest_active_state TEXT NOT NULL DEFAULT 'unknown',
-        updated_at TEXT NOT NULL,
-        PRIMARY KEY (tenant_id, job_url)
-      );
-    `);
     db.prepare(
       `INSERT INTO posting_snapshot_sets (
-        tenant_id, job_url, snapshot_set_json, latest_snapshot_version,
+        tenant_id, job_id, snapshot_set_json, latest_snapshot_version,
         latest_active_state, updated_at
       ) VALUES (?, ?, ?, ?, ?, ?)`,
     ).run(
       "local",
-      "https://example.com/jobs/failed-score",
-      JSON.stringify({ tenant_id: "local", job_id: "https://example.com/jobs/failed-score", latest_active_state: "removed" }),
+      jobIdFor("https://example.com/jobs/failed-score"),
+      JSON.stringify({ tenant_id: "local", job_id: jobIdFor("https://example.com/jobs/failed-score"), latest_active_state: "removed" }),
       0,
       "removed",
       "2026-05-29T10:00:00+00:00",
     );
     db.prepare(
-      "INSERT INTO job_events (job_url, stage, event_type, level, message, occurred_at, payload_json) VALUES (?, ?, ?, ?, ?, ?, ?)",
+      "INSERT INTO job_events (tenant_id, job_id, identity_version, stage, event_type, level, message, occurred_at, payload_json) SELECT 'local', (SELECT job_id FROM jobs WHERE tenant_id = 'local' AND url = ?), 1, ?, ?, ?, ?, ?, ?",
     ).run(
       "https://example.com/jobs/failed-score",
       "enrich",
@@ -2714,7 +2684,7 @@ describe("local TypeScript API", () => {
       "Job active state changed.",
       "2026-05-29T10:00:00+00:00",
       JSON.stringify({
-        job_id: "https://example.com/jobs/failed-score",
+        job_id: jobIdFor("https://example.com/jobs/failed-score"),
         active_state: "removed",
         previous_state: "active",
       }),
@@ -2727,14 +2697,14 @@ describe("local TypeScript API", () => {
     expect(active.statusCode, active.body).toBe(200);
     expect(active.json().pagination.total).toBe(2);
     expect(active.json().items.map((job: { jobKey: string }) => job.jobKey)).not.toContain(
-      "https://example.com/jobs/failed-score",
+      jobIdFor("https://example.com/jobs/failed-score"),
     );
 
     const closed = await app.inject({ method: "GET", url: "/v1/jobs?deleted=closed" });
     expect(closed.statusCode, closed.body).toBe(200);
     expect(closed.json().pagination.total).toBe(1);
     expect(closed.json().items[0]).toMatchObject({
-      jobKey: "https://example.com/jobs/failed-score",
+      jobKey: jobIdFor("https://example.com/jobs/failed-score"),
       activeState: "removed",
       deletedAt: null,
       hiddenAt: null,
@@ -2780,13 +2750,17 @@ describe("local TypeScript API", () => {
       payload: { allMatching: false, jobKeys: [readyUrl, blockedUrl] },
     });
     expect(permanentDelete.statusCode, permanentDelete.body).toBe(200);
-    expect(permanentDelete.json()).toMatchObject({ ok: true, count: 2, jobKeys: [readyUrl, blockedUrl] });
+    expect(permanentDelete.json()).toMatchObject({
+      ok: true,
+      count: 2,
+      jobKeys: [jobIdFor(readyUrl), jobIdFor(blockedUrl)],
+    });
 
     const active = await app.inject({ method: "GET", url: "/v1/jobs?deleted=active&sort=title&dir=asc" });
     expect(active.statusCode, active.body).toBe(200);
     expect(active.json().pagination.total).toBe(1);
     expect(active.json().items.map((job: { jobKey: string }) => job.jobKey)).toEqual([
-      "https://example.com/jobs/failed-score",
+      jobIdFor("https://example.com/jobs/failed-score"),
     ]);
 
     const deleted = await app.inject({ method: "GET", url: "/v1/jobs?deleted=deleted" });
@@ -2799,10 +2773,10 @@ describe("local TypeScript API", () => {
 
     const db = new Database(options.dbPath);
     expect(countRows(db, "jobs", "url", readyUrl)).toBe(0);
-    expect(countRows(db, "jobctrl_deleted_jobs", "job_url", readyUrl)).toBe(0);
-    expect(countRows(db, "jobctrl_hidden_jobs", "job_url", blockedUrl)).toBe(0);
-    expect(countRows(db, "job_stage_states", "job_url", readyUrl)).toBe(0);
-    expect(countRows(db, "job_scores", "job_url", readyUrl)).toBe(0);
+    expect(countRows(db, "jobctrl_deleted_jobs", "job_id", jobIdFor(readyUrl))).toBe(0);
+    expect(countRows(db, "jobctrl_hidden_jobs", "job_id", jobIdFor(blockedUrl))).toBe(0);
+    expect(countRows(db, "job_stage_states", "job_id", jobIdFor(readyUrl))).toBe(0);
+    expect(countRows(db, "job_scores", "job_id", jobIdFor(readyUrl))).toBe(0);
 
     insertJob(db, {
       url: readyUrl,
@@ -2811,7 +2785,7 @@ describe("local TypeScript API", () => {
       fitScore: null,
     });
     db.prepare(
-      "INSERT INTO job_events (job_url, stage, event_type, level, message, occurred_at) VALUES (?, ?, ?, ?, ?, ?)",
+      "INSERT INTO job_events (tenant_id, job_id, identity_version, stage, event_type, level, message, occurred_at) SELECT 'local', (SELECT job_id FROM jobs WHERE tenant_id = 'local' AND url = ?), 1, ?, ?, ?, ?, ?",
     ).run(readyUrl, "discover", "JobDiscovered", "info", "Rediscovered after permanent delete.", "2026-04-30T10:00:00+00:00");
     db.close();
 
@@ -2822,7 +2796,7 @@ describe("local TypeScript API", () => {
     expect(rediscovered.statusCode, rediscovered.body).toBe(200);
     expect(rediscovered.json().pagination.total).toBe(1);
     expect(rediscovered.json().items[0]).toMatchObject({
-      jobKey: readyUrl,
+      jobKey: jobIdFor(readyUrl),
       title: "Rediscovered Engineer",
       deletedAt: null,
       hiddenAt: null,
@@ -2851,7 +2825,7 @@ describe("local TypeScript API", () => {
         + "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
     ).run(
       "run-new-path",
-      newJobUrl,
+      jobIdFor(newJobUrl),
       "New Path Engineer",
       "NewPathCo",
       "succeeded",
@@ -2877,7 +2851,7 @@ describe("local TypeScript API", () => {
       // through the upstream stages — the apply-derivation contract
       // is what M2 is locking in.)
       expect(job).toMatchObject({
-        jobKey: newJobUrl,
+        jobKey: jobIdFor(newJobUrl),
         applyStatus: "applied",
         appliedAt: "2026-05-01T00:01:00+00:00",
       });
@@ -2891,7 +2865,7 @@ describe("local TypeScript API", () => {
       expect(appliedJobsBody.filter).toMatchObject({ applyStatus: "applied" });
       expect(appliedJobsBody.items).toHaveLength(1);
       expect(appliedJobsBody.items[0]).toMatchObject({
-        jobKey: newJobUrl,
+        jobKey: jobIdFor(newJobUrl),
         applyStatus: "applied",
         appliedAt: "2026-05-01T00:01:00+00:00",
       });
@@ -2934,7 +2908,7 @@ describe("local TypeScript API", () => {
     const body = response.json();
     expect(body.items).toHaveLength(1);
     expect(body.items[0]).toMatchObject({
-      jobKey: "https://example.com/jobs/unscored",
+      jobKey: jobIdFor("https://example.com/jobs/unscored"),
       currentStage: "discover",
       currentState: "pending",
       fitScore: null,
@@ -2951,7 +2925,7 @@ describe("local TypeScript API", () => {
     expect(response.statusCode).toBe(200);
     const body = response.json();
     expect(body.job).toMatchObject({
-      jobKey: "https://example.com/jobs/ready",
+      jobKey: jobIdFor("https://example.com/jobs/ready"),
       currentStage: "apply",
       currentState: "pending",
       artifactCount: 2,
@@ -2994,7 +2968,7 @@ describe("local TypeScript API", () => {
     for (let index = 0; index < 12; index += 1) {
       insertApplyRun.run(
         `newer-run-${index}`,
-        `https://example.com/jobs/newer-${index}`,
+        jobIdFor(`https://example.com/jobs/newer-${index}`),
         `Newer role ${index}`,
         "ExampleCo",
         "succeeded",
@@ -3005,7 +2979,7 @@ describe("local TypeScript API", () => {
     }
     insertApplyRun.run(
       "active-run-older",
-      jobUrl,
+      jobIdFor(jobUrl),
       "Platform Engineer",
       "ExampleCo",
       "in_progress",
@@ -3053,9 +3027,9 @@ describe("local TypeScript API", () => {
       insertStage(db, jobUrl, stage, "succeeded");
     }
     insertStage(db, jobUrl, "tailor", "failed", "FAILED_VALIDATION");
-    db.prepare("UPDATE job_stage_states SET error_message = ? WHERE job_url = ? AND stage = ?").run(
+    db.prepare("UPDATE job_stage_states SET error_message = ? WHERE tenant_id = 'local' AND job_id = ? AND stage = ?").run(
       "Tailoring ended with status failed_validation",
-      jobUrl,
+      jobIdFor(jobUrl),
       "tailor",
     );
     db.close();
@@ -3108,12 +3082,12 @@ describe("local TypeScript API", () => {
     expect(list.statusCode, list.body).toBe(200);
     const items = list.json().items as Array<Record<string, unknown>>;
     expect(items.map((job) => job.jobKey)).toEqual([
-      "https://example.com/jobs/ready",
-      "https://example.com/jobs/failed-score",
-      "https://example.com/jobs/blocked-tailor",
+      jobIdFor("https://example.com/jobs/ready"),
+      jobIdFor("https://example.com/jobs/failed-score"),
+      jobIdFor("https://example.com/jobs/blocked-tailor"),
     ]);
     expect(items[0]).toMatchObject({
-      jobKey: "https://example.com/jobs/ready",
+      jobKey: jobIdFor("https://example.com/jobs/ready"),
       fitScore: 9,
       salary: "€55,000/year",
       compensationSummary: {
@@ -3140,14 +3114,14 @@ describe("local TypeScript API", () => {
     });
     expect(filtered.statusCode, filtered.body).toBe(200);
     expect(filtered.json().items.map((job: { jobKey: string }) => job.jobKey)).toEqual([
-      "https://example.com/jobs/ready",
+      jobIdFor("https://example.com/jobs/ready"),
     ]);
 
     const detail = await app.inject({ method: "GET", url: `/v1/jobs/${readyKey}` });
     expect(detail.statusCode, detail.body).toBe(200);
     const detailBody = detail.json();
     expect(detailBody.job).toMatchObject({
-      jobKey: "https://example.com/jobs/ready",
+      jobKey: jobIdFor("https://example.com/jobs/ready"),
       salary: "€55,000/year",
       fitScore: 9,
       compensationSummary: {
@@ -3168,7 +3142,7 @@ describe("local TypeScript API", () => {
       },
       market: {
         recordStatus: "not_requested",
-        jobKey: "https://example.com/jobs/ready",
+        jobId: jobIdFor("https://example.com/jobs/ready"),
       },
     });
     expect(detailBody.applyAudit).toMatchObject({
@@ -3217,12 +3191,12 @@ describe("local TypeScript API", () => {
     expect(list.statusCode, list.body).toBe(200);
     const items = list.json().items as Array<Record<string, unknown>>;
     expect(items.map((job) => job.jobKey)).toEqual([
-      "https://example.com/jobs/ready",
-      "https://example.com/jobs/failed-score",
-      "https://example.com/jobs/blocked-tailor",
+      jobIdFor("https://example.com/jobs/ready"),
+      jobIdFor("https://example.com/jobs/failed-score"),
+      jobIdFor("https://example.com/jobs/blocked-tailor"),
     ]);
     expect(items[0]).toMatchObject({
-      jobKey: "https://example.com/jobs/ready",
+      jobKey: jobIdFor("https://example.com/jobs/ready"),
       fitScore: 9,
       salary: "€55,000/year",
       compensationSummary: {
@@ -3252,14 +3226,14 @@ describe("local TypeScript API", () => {
     });
     expect(filtered.statusCode, filtered.body).toBe(200);
     expect(filtered.json().items.map((job: { jobKey: string }) => job.jobKey)).toEqual([
-      "https://example.com/jobs/ready",
+      jobIdFor("https://example.com/jobs/ready"),
     ]);
 
     const detail = await app.inject({ method: "GET", url: `/v1/jobs/${readyKey}` });
     expect(detail.statusCode, detail.body).toBe(200);
     const detailBody = detail.json();
     expect(detailBody.job).toMatchObject({
-      jobKey: "https://example.com/jobs/ready",
+      jobKey: jobIdFor("https://example.com/jobs/ready"),
       salary: "€55,000/year",
       fitScore: 9,
       compensationSummary: {
@@ -3320,16 +3294,17 @@ describe("local TypeScript API", () => {
   it("reconciles stale retryable stage projections from latest failure events", async () => {
     const seedDb = new Database(options.dbPath);
     seedDb
-      .prepare("UPDATE job_stage_states SET retryable = 1, next_action = ? WHERE job_url = ? AND stage = ?")
+      .prepare("UPDATE job_stage_states SET retryable = 1, next_action = ? WHERE tenant_id = 'local' AND job_id = ? AND stage = ?")
       .run(
         "jobctrl retry score https://example.com/jobs/failed-score",
-        "https://example.com/jobs/failed-score",
+        jobIdFor("https://example.com/jobs/failed-score"),
         "score",
       );
     seedDb
       .prepare(
-        `INSERT INTO job_events (job_url, stage, event_type, level, message, occurred_at, payload_json)
-         VALUES (?, ?, ?, ?, ?, ?, ?)`,
+        `INSERT INTO job_events (
+           tenant_id, job_id, identity_version, stage, event_type, level, message, occurred_at, payload_json
+         ) SELECT 'local', (SELECT job_id FROM jobs WHERE tenant_id = 'local' AND url = ?), 1, ?, ?, ?, ?, ?, ?`,
       )
       .run(
         "https://example.com/jobs/failed-score",
@@ -3359,17 +3334,6 @@ describe("local TypeScript API", () => {
     const legacyJobUrl = "https://example.com/jobs/private-legacy";
     const legacyReason = "Legacy correction mentioned a private resume detail.";
     const seedDb = new Database(options.dbPath);
-    seedDb.exec(`
-      CREATE TABLE IF NOT EXISTS scoring_policies (
-        tenant_id TEXT NOT NULL DEFAULT 'local',
-        version INTEGER NOT NULL,
-        rubric_json TEXT NOT NULL,
-        anchors_json TEXT NOT NULL DEFAULT '[]',
-        created_at TEXT NOT NULL,
-        created_from_event_id INTEGER,
-        PRIMARY KEY (tenant_id, version)
-      )
-    `);
     seedDb
       .prepare(
         `INSERT INTO scoring_policies (
@@ -3432,11 +3396,11 @@ describe("local TypeScript API", () => {
         .prepare(
           `SELECT version, fit_score, correction_json, trace_json
            FROM job_scores
-           WHERE job_url = ?
+           WHERE tenant_id = 'local' AND job_id = ?
            ORDER BY version DESC
            LIMIT 1`,
         )
-        .get("https://example.com/jobs/ready") as {
+        .get(jobIdFor("https://example.com/jobs/ready")) as {
         version: number;
         fit_score: number;
         correction_json: string;
@@ -3458,7 +3422,7 @@ describe("local TypeScript API", () => {
         .get() as { event_type: string; payload_json: string };
       expect(event.event_type).toBe("ScoreCorrected");
       expect(JSON.parse(event.payload_json)).toMatchObject({
-        jobId: "https://example.com/jobs/ready",
+        jobId: jobIdFor("https://example.com/jobs/ready"),
         originalScore: 9,
         correctedScore: 6,
       });
@@ -3572,9 +3536,9 @@ describe("local TypeScript API", () => {
         .prepare(
           `SELECT stale_reason, old_policy_version, new_policy_version, resolved
            FROM job_score_staleness
-           WHERE job_url = ?`,
+           WHERE tenant_id = 'local' AND job_id = ?`,
         )
-        .get(comparableUrl) as {
+        .get(jobIdFor(comparableUrl)) as {
         stale_reason: string;
         old_policy_version: number;
         new_policy_version: number;
@@ -3588,19 +3552,23 @@ describe("local TypeScript API", () => {
       });
       const excludedRows = db
         .prepare(
-          `SELECT job_url
+          `SELECT job_id
            FROM job_score_staleness
-           WHERE job_url IN (?, ?, ?)`,
+           WHERE tenant_id = 'local' AND job_id IN (?, ?, ?)`,
         )
-        .all("https://example.com/jobs/ready", currentPolicyUrl, alreadyCorrectedUrl);
+        .all(
+          jobIdFor("https://example.com/jobs/ready"),
+          jobIdFor(currentPolicyUrl),
+          jobIdFor(alreadyCorrectedUrl),
+        );
       expect(excludedRows).toEqual([]);
       const staleStage = db
-        .prepare("SELECT state FROM job_stage_states WHERE job_url = ? AND stage = 'score'")
-        .get(comparableUrl) as { state: string };
+        .prepare("SELECT state FROM job_stage_states WHERE tenant_id = 'local' AND job_id = ? AND stage = 'score'")
+        .get(jobIdFor(comparableUrl)) as { state: string };
       expect(staleStage.state).toBe("stale");
       const event = db
-        .prepare("SELECT event_type FROM job_events WHERE job_url = ? ORDER BY event_id DESC LIMIT 1")
-        .get(comparableUrl) as { event_type: string };
+        .prepare("SELECT event_type FROM job_events WHERE tenant_id = 'local' AND job_id = ? ORDER BY event_id DESC LIMIT 1")
+        .get(jobIdFor(comparableUrl)) as { event_type: string };
       expect(event.event_type).toBe("ScoreMarkedStale");
     } finally {
       db.close();
@@ -3611,17 +3579,6 @@ describe("local TypeScript API", () => {
   it("rolls back the whole score correction when a later staleness write fails", async () => {
     const comparableUrl = "https://example.com/jobs/comparable-atomic";
     const seedDb = new Database(options.dbPath);
-    seedDb.exec(`
-      CREATE TABLE IF NOT EXISTS scoring_policies (
-        tenant_id TEXT NOT NULL DEFAULT 'local',
-        version INTEGER NOT NULL,
-        rubric_json TEXT NOT NULL,
-        anchors_json TEXT NOT NULL DEFAULT '[]',
-        created_at TEXT NOT NULL,
-        created_from_event_id INTEGER,
-        PRIMARY KEY (tenant_id, version)
-      )
-    `);
     seedDb
       .prepare(
         `INSERT INTO scoring_policies (tenant_id, version, rubric_json, anchors_json, created_at, created_from_event_id)
@@ -3632,19 +3589,21 @@ describe("local TypeScript API", () => {
     insertScore(seedDb, comparableUrl, 1, 7, { policyVersion: 1 });
     insertStage(seedDb, comparableUrl, "score", "succeeded");
     createScoreStalenessTable(seedDb);
+    seedDb.close();
+
+    const app = buildApp(options);
+    const faultDb = new Database(options.dbPath);
     // Force the staleness-marking step to abort mid-correction, mimicking a
     // SQLITE_BUSY / constraint failure from a concurrent worker write after the
     // new score version and policy row have already been inserted.
-    seedDb.exec(`
+    faultDb.exec(`
       CREATE TRIGGER fail_staleness_insert
       BEFORE INSERT ON job_score_staleness
       BEGIN
         SELECT RAISE(ABORT, 'forced staleness failure');
       END;
     `);
-    seedDb.close();
-
-    const app = buildApp(options);
+    faultDb.close();
     const jobKey = encodeURIComponent("https://example.com/jobs/ready");
     const response = await app.inject({
       method: "POST",
@@ -3658,8 +3617,8 @@ describe("local TypeScript API", () => {
     const db = new Database(options.dbPath);
     try {
       const scores = db
-        .prepare("SELECT version FROM job_scores WHERE job_url = ? ORDER BY version")
-        .all("https://example.com/jobs/ready") as Array<{ version: number }>;
+        .prepare("SELECT version FROM job_scores WHERE tenant_id = 'local' AND job_id = ? ORDER BY version")
+        .all(jobIdFor("https://example.com/jobs/ready")) as Array<{ version: number }>;
       expect(scores.map((row) => row.version)).toEqual([1]);
       const policies = db
         .prepare("SELECT version FROM scoring_policies WHERE tenant_id = 'local' ORDER BY version")
@@ -3668,8 +3627,8 @@ describe("local TypeScript API", () => {
       const staleCount = db.prepare("SELECT COUNT(*) AS count FROM job_score_staleness").get() as { count: number };
       expect(staleCount.count).toBe(0);
       const comparableStage = db
-        .prepare("SELECT state FROM job_stage_states WHERE job_url = ? AND stage = 'score'")
-        .get(comparableUrl) as { state: string };
+        .prepare("SELECT state FROM job_stage_states WHERE tenant_id = 'local' AND job_id = ? AND stage = 'score'")
+        .get(jobIdFor(comparableUrl)) as { state: string };
       expect(comparableStage.state).toBe("succeeded");
       const correctionEvents = db
         .prepare("SELECT COUNT(*) AS count FROM job_events WHERE event_type = 'ScoreCorrected'")
@@ -3696,12 +3655,12 @@ describe("local TypeScript API", () => {
     seedDb
       .prepare(
         `INSERT INTO job_score_staleness (
-           tenant_id, job_url, stale_reason, old_policy_id, old_policy_version,
+           tenant_id, job_id, stale_reason, old_policy_id, old_policy_version,
            new_policy_id, new_policy_version, marked_at, resolved
          ) VALUES ('local', ?, 'scoring_policy_changed', 'local:scoring-policy-v1', 1,
            'local:scoring-policy-v2', 2, '2026-04-29T10:07:00+00:00', 0)`,
       )
-      .run(staleUrl);
+      .run(jobIdFor(staleUrl));
     seedDb.close();
 
     const app = buildApp(options);
@@ -3722,17 +3681,17 @@ describe("local TypeScript API", () => {
     const db = new Database(options.dbPath);
     try {
       const marker = db
-        .prepare("SELECT resolved, resolved_at FROM job_score_staleness WHERE job_url = ?")
-        .get(staleUrl) as { resolved: number; resolved_at: string | null };
+        .prepare("SELECT resolved, resolved_at FROM job_score_staleness WHERE tenant_id = 'local' AND job_id = ?")
+        .get(jobIdFor(staleUrl)) as { resolved: number; resolved_at: string | null };
       expect(marker.resolved).toBe(1);
       expect(marker.resolved_at).toBeTruthy();
       const stage = db
-        .prepare("SELECT state, attempt_count FROM job_stage_states WHERE job_url = ? AND stage = 'score'")
-        .get(staleUrl) as { state: string; attempt_count: number };
+        .prepare("SELECT state, attempt_count FROM job_stage_states WHERE tenant_id = 'local' AND job_id = ? AND stage = 'score'")
+        .get(jobIdFor(staleUrl)) as { state: string; attempt_count: number };
       expect(stage).toMatchObject({ state: "pending", attempt_count: 0 });
       const event = db
-        .prepare("SELECT event_type, payload_json FROM job_events WHERE job_url = ? ORDER BY event_id DESC LIMIT 1")
-        .get(staleUrl) as { event_type: string; payload_json: string };
+        .prepare("SELECT event_type, payload_json FROM job_events WHERE tenant_id = 'local' AND job_id = ? ORDER BY event_id DESC LIMIT 1")
+        .get(jobIdFor(staleUrl)) as { event_type: string; payload_json: string };
       expect(event.event_type).toBe("ScoreRescoreRequested");
       expect(JSON.parse(event.payload_json)).toMatchObject({
         nextAction: "jobctrl run score --rescore",
@@ -3759,12 +3718,12 @@ describe("local TypeScript API", () => {
     seedDb
       .prepare(
         `INSERT INTO job_score_staleness (
-           tenant_id, job_url, stale_reason, old_policy_id, old_policy_version,
+           tenant_id, job_id, stale_reason, old_policy_id, old_policy_version,
            new_policy_id, new_policy_version, marked_at, resolved
          ) VALUES ('local', ?, 'scoring_policy_changed', 'local:scoring-policy-v1', 1,
            'local:scoring-policy-v2', 2, '2026-04-29T10:07:00+00:00', 0)`,
       )
-      .run(staleUrl);
+      .run(jobIdFor(staleUrl));
     seedDb.close();
 
     const app = buildApp(options);
@@ -3777,7 +3736,9 @@ describe("local TypeScript API", () => {
 
       expect(listResponse.statusCode, listResponse.body).toBe(200);
       expect(detailResponse.statusCode, detailResponse.body).toBe(200);
-      const listJob = listResponse.json().items.find((job: { jobKey: string }) => job.jobKey === staleUrl);
+      const listJob = listResponse.json().items.find(
+        (job: { jobKey: string }) => job.jobKey === jobIdFor(staleUrl),
+      );
       expect(listJob).toMatchObject({
       scoreTrace: {
         scoringPolicyId: "local:scoring-policy-v1",
@@ -3794,7 +3755,7 @@ describe("local TypeScript API", () => {
         },
       });
       expect(detailResponse.json().job).toMatchObject({
-        jobKey: staleUrl,
+        jobKey: jobIdFor(staleUrl),
         scoreStaleness: listJob.scoreStaleness,
       scoreTrace: {
         scoringPolicyVersion: 1,
@@ -3818,7 +3779,7 @@ describe("local TypeScript API", () => {
     expect(response.json()).toMatchObject({
       ok: true,
       artifact: {
-        jobKey: "https://example.com/jobs/ready",
+        jobKey: jobIdFor("https://example.com/jobs/ready"),
         type: "tailored_resume_txt",
         status: "active",
       },
@@ -3844,23 +3805,23 @@ describe("local TypeScript API", () => {
     seedDb
       .prepare(
         `INSERT OR REPLACE INTO job_materials (
-           job_url, generation, tenant_id, status, created_at, updated_at, metadata_json
-         ) VALUES (?, 1, 'local', 'resume_approved', ?, ?, '{}')`,
+           tenant_id, job_id, generation, status, created_at, updated_at, metadata_json
+         ) VALUES ('local', ?, 1, 'resume_approved', ?, ?, '{}')`,
       )
       .run(
-        "https://example.com/jobs/layout-resume",
+        jobIdFor("https://example.com/jobs/layout-resume"),
         "2026-05-26T10:00:00+00:00",
         "2026-05-26T10:00:00+00:00",
       );
     seedDb
       .prepare(
         `INSERT OR REPLACE INTO job_materials_artifacts (
-           job_url, generation, artifact_type, artifact_id, status, path,
+           tenant_id, job_id, generation, artifact_type, artifact_id, status, path,
            render_format, size_bytes, metadata_json, created_at
-         ) VALUES (?, 1, 'resume_pdf', 'artifact-layout-resume-pdf', 'approved', ?, 'html_pdf', ?, '{}', ?)`,
+         ) VALUES ('local', ?, 1, 'resume_pdf', 'artifact-layout-resume-pdf', 'approved', ?, 'html_pdf', ?, '{}', ?)`,
       )
       .run(
-        "https://example.com/jobs/layout-resume",
+        jobIdFor("https://example.com/jobs/layout-resume"),
         resumePdfPath,
         fs.statSync(resumePdfPath).size,
         "2026-05-26T10:00:00+00:00",
@@ -3868,13 +3829,13 @@ describe("local TypeScript API", () => {
     seedDb
       .prepare(
         `INSERT OR REPLACE INTO job_material_layout_boxes (
-           job_url, generation, artifact_id, box_index, tenant_id,
+           tenant_id, job_id, generation, artifact_id, box_index,
            semantic_id, page_number, line_number, text_excerpt,
            left_pct, top_pct, width_pct, height_pct, audit_target_json, created_at
-         ) VALUES (?, 1, 'artifact-layout-resume-pdf', 0, 'local', ?, 1, 6, ?, 12.5, 24.0, 62.0, 2.4, '{}', ?)`,
+         ) VALUES ('local', ?, 1, 'artifact-layout-resume-pdf', 0, ?, 1, 6, ?, 12.5, 24.0, 62.0, 2.4, '{}', ?)`,
       )
       .run(
-        "https://example.com/jobs/layout-resume",
+        jobIdFor("https://example.com/jobs/layout-resume"),
         "experience:acme:bullet:1",
         "Cut latency.",
         "2026-05-26T10:00:00+00:00",
@@ -4445,27 +4406,6 @@ describe("local TypeScript API", () => {
     fs.writeFileSync(resumePath, "Resume with platform reliability and 35% latency improvement.");
     const seedDb = new Database(options.dbPath);
     createMaterialsTables(seedDb);
-    seedDb.exec(`
-      CREATE TABLE candidate_profile_experience_entries (
-        tenant_id TEXT NOT NULL,
-        profile_id TEXT NOT NULL,
-        entry_id TEXT NOT NULL,
-        position_index INTEGER NOT NULL,
-        date_range TEXT NOT NULL DEFAULT '',
-        title TEXT NOT NULL DEFAULT '',
-        company TEXT NOT NULL DEFAULT '',
-        location TEXT NOT NULL DEFAULT '',
-        PRIMARY KEY (tenant_id, profile_id, entry_id)
-      );
-      CREATE TABLE candidate_profile_experience_bullets (
-        tenant_id TEXT NOT NULL,
-        profile_id TEXT NOT NULL,
-        entry_id TEXT NOT NULL,
-        bullet_index INTEGER NOT NULL,
-        bullet_text TEXT NOT NULL,
-        PRIMARY KEY (tenant_id, profile_id, entry_id, bullet_index)
-      );
-    `);
     seedDb.prepare(`
       INSERT INTO candidate_profile_experience_entries (
         tenant_id, profile_id, entry_id, position_index, title, company
@@ -4564,47 +4504,6 @@ describe("local TypeScript API", () => {
     fs.writeFileSync(resumePath, "Leadership: Team Building & Mentoring, Global Teams (30+ engineers)");
     const seedDb = new Database(options.dbPath);
     createMaterialsTables(seedDb);
-    seedDb.exec(`
-      CREATE TABLE candidate_profile_skill_categories (
-        tenant_id TEXT NOT NULL,
-        profile_id TEXT NOT NULL,
-        category_id TEXT NOT NULL,
-        position_index INTEGER NOT NULL,
-        label TEXT NOT NULL DEFAULT '',
-        PRIMARY KEY (tenant_id, profile_id, category_id)
-      );
-      CREATE TABLE candidate_profile_skill_items (
-        tenant_id TEXT NOT NULL,
-        profile_id TEXT NOT NULL,
-        category_id TEXT NOT NULL,
-        item_index INTEGER NOT NULL,
-        item_text TEXT NOT NULL,
-        PRIMARY KEY (tenant_id, profile_id, category_id, item_index)
-      );
-      CREATE TABLE candidate_profile_required_skills (
-        tenant_id TEXT NOT NULL,
-        profile_id TEXT NOT NULL,
-        category_id TEXT NOT NULL,
-        skill_index INTEGER NOT NULL,
-        skill_text TEXT NOT NULL,
-        PRIMARY KEY (tenant_id, profile_id, category_id, skill_index)
-      );
-      CREATE TABLE candidate_profile_achievement_evidence (
-        tenant_id TEXT NOT NULL,
-        profile_id TEXT NOT NULL,
-        entry_id TEXT NOT NULL,
-        evidence_index INTEGER NOT NULL,
-        evidence_id TEXT NOT NULL DEFAULT '',
-        source_text TEXT NOT NULL DEFAULT '',
-        scope TEXT NOT NULL DEFAULT '',
-        action TEXT NOT NULL DEFAULT '',
-        tools_json TEXT NOT NULL DEFAULT '[]',
-        metrics_json TEXT NOT NULL DEFAULT '[]',
-        outcome TEXT NOT NULL DEFAULT '',
-        seniority_signal TEXT NOT NULL DEFAULT '',
-        PRIMARY KEY (tenant_id, profile_id, entry_id, evidence_index)
-      );
-    `);
     seedDb.prepare(`
       INSERT INTO candidate_profile_skill_categories (
         tenant_id, profile_id, category_id, position_index, label
@@ -4831,33 +4730,10 @@ describe("local TypeScript API", () => {
     await app.close();
   });
 
-  it("returns null tailoring explanation for legacy material artifacts without metadata column", async () => {
+  it("returns null tailoring explanation for material artifacts without metadata", async () => {
     const resumePath = path.join(tempDir, "legacy-no-metadata-resume.txt");
     fs.writeFileSync(resumePath, "legacy tailored resume");
     const seedDb = new Database(options.dbPath);
-    seedDb.exec(`
-      CREATE TABLE IF NOT EXISTS job_materials (
-        job_url TEXT NOT NULL,
-        generation INTEGER NOT NULL,
-        tenant_id TEXT NOT NULL DEFAULT 'local',
-        status TEXT NOT NULL,
-        created_at TEXT NOT NULL,
-        updated_at TEXT NOT NULL,
-        PRIMARY KEY (job_url, generation)
-      );
-      CREATE TABLE IF NOT EXISTS job_materials_artifacts (
-        job_url TEXT NOT NULL,
-        generation INTEGER NOT NULL,
-        artifact_type TEXT NOT NULL,
-        artifact_id TEXT NOT NULL,
-        status TEXT NOT NULL,
-        path TEXT NOT NULL,
-        render_format TEXT NOT NULL,
-        size_bytes INTEGER,
-        created_at TEXT NOT NULL,
-        PRIMARY KEY (job_url, generation, artifact_type)
-      );
-    `);
     insertJob(seedDb, {
       url: "https://example.com/jobs/legacy-no-metadata",
       title: "Legacy Resume Engineer",
@@ -4868,23 +4744,23 @@ describe("local TypeScript API", () => {
     seedDb
       .prepare(
         `INSERT INTO job_materials (
-           job_url, generation, tenant_id, status, created_at, updated_at
-         ) VALUES (?, 1, 'local', 'resume_approved', ?, ?)`,
+           tenant_id, job_id, generation, status, created_at, updated_at
+         ) VALUES ('local', ?, 1, 'resume_approved', ?, ?)`,
       )
       .run(
-        "https://example.com/jobs/legacy-no-metadata",
+        jobIdFor("https://example.com/jobs/legacy-no-metadata"),
         "2026-05-26T10:00:00+00:00",
         "2026-05-26T10:00:00+00:00",
       );
     seedDb
       .prepare(
         `INSERT INTO job_materials_artifacts (
-           job_url, generation, artifact_type, artifact_id, status, path,
+           tenant_id, job_id, generation, artifact_type, artifact_id, status, path,
            render_format, size_bytes, created_at
-         ) VALUES (?, 1, 'tailored_resume', 'artifact-legacy-no-metadata', 'approved', ?, 'text', ?, ?)`,
+         ) VALUES ('local', ?, 1, 'tailored_resume', 'artifact-legacy-no-metadata', 'approved', ?, 'text', ?, ?)`,
       )
       .run(
-        "https://example.com/jobs/legacy-no-metadata",
+        jobIdFor("https://example.com/jobs/legacy-no-metadata"),
         resumePath,
         fs.statSync(resumePath).size,
         "2026-05-26T10:00:00+00:00",
@@ -4961,7 +4837,7 @@ describe("local TypeScript API", () => {
       expect(detailResponse.statusCode, detailResponse.body).toBe(200);
       const detailBody = detailResponse.json();
       expect(detailBody.job).toMatchObject({
-        jobKey: suppressedUrl,
+        jobKey: jobIdFor(suppressedUrl),
         artifactCount: 0,
       });
       expect(detailBody.artifacts).toEqual([]);
@@ -4977,7 +4853,7 @@ describe("local TypeScript API", () => {
       expect(suppressedArtifactsResponse.json().items).toEqual([
         expect.objectContaining({
           artifactId: "artifact-suppressed-resume",
-          jobKey: suppressedUrl,
+          jobKey: jobIdFor(suppressedUrl),
           status: "suppressed",
           type: "tailored_resume",
         }),
@@ -5000,64 +4876,36 @@ describe("local TypeScript API", () => {
     const seedDb = new Database(options.dbPath);
     createScoreStalenessTable(seedDb);
     createMaterialsTables(seedDb);
-    seedDb.exec(`
-      CREATE TABLE scoring_policies (
-        tenant_id TEXT NOT NULL DEFAULT 'local',
-        version INTEGER NOT NULL,
-        rubric_json TEXT NOT NULL,
-        anchors_json TEXT NOT NULL DEFAULT '[]',
-        created_at TEXT NOT NULL,
-        created_from_event_id INTEGER,
-        PRIMARY KEY (tenant_id, version)
-      );
-      CREATE TABLE tailoring_policies (
-        tenant_id TEXT NOT NULL DEFAULT 'local',
-        version INTEGER NOT NULL,
-        created_at TEXT NOT NULL,
-        PRIMARY KEY (tenant_id, version)
-      );
-      CREATE TABLE preparation_work_items (
-        item_id TEXT NOT NULL PRIMARY KEY,
-        tenant_id TEXT NOT NULL DEFAULT 'local',
-        job_id TEXT NOT NULL,
-        kind TEXT NOT NULL,
-        target_version INTEGER NOT NULL,
-        source_event_id TEXT NOT NULL DEFAULT '',
-        state TEXT NOT NULL,
-        idempotency_key TEXT NOT NULL,
-        attempts INTEGER NOT NULL DEFAULT 0,
-        last_error TEXT NOT NULL DEFAULT '',
-        created_at TEXT NOT NULL,
-        updated_at TEXT NOT NULL,
-        available_at TEXT NOT NULL
-      );
-    `);
     const insertScoringPolicy = seedDb.prepare(
       "INSERT INTO scoring_policies (tenant_id, version, rubric_json, anchors_json, created_at) VALUES (?, ?, ?, ?, ?)",
     );
     insertScoringPolicy.run("local", 2, "{}", "[]", "2026-05-26T10:00:00+00:00");
     insertScoringPolicy.run("local", 3, "{}", "[]", "2026-05-26T10:05:00+00:00");
     seedDb
-      .prepare("INSERT INTO tailoring_policies (tenant_id, version, created_at) VALUES (?, ?, ?)")
-      .run("local", 2, "2026-05-26T10:00:00+00:00");
+      .prepare(`INSERT INTO tailoring_policies (
+        tenant_id, version, prompt_version, schema_version, judge_schema_version,
+        prompt_fingerprint, config_fingerprint, profile_policy_fingerprint,
+        custom_prompt_fingerprint, created_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+      .run("local", 2, "test", "test", "test", "test", "test", "test", "test", "2026-05-26T10:00:00+00:00");
     seedDb
       .prepare(
         `INSERT INTO job_score_staleness (
-           tenant_id, job_url, stale_reason, old_policy_id, old_policy_version,
+           tenant_id, job_id, stale_reason, old_policy_id, old_policy_version,
            new_policy_id, new_policy_version, marked_at, resolved
          ) VALUES ('local', ?, 'scoring_policy_changed', 'local:scoring-policy-v1', 1,
            'local:scoring-policy-v2', 2, '2026-05-26T10:01:00+00:00', 0)`,
       )
-      .run("https://example.com/jobs/failed-score");
+      .run(jobIdFor("https://example.com/jobs/failed-score"));
     seedDb
       .prepare(
         `INSERT INTO job_score_staleness (
-           tenant_id, job_url, stale_reason, old_policy_id, old_policy_version,
+           tenant_id, job_id, stale_reason, old_policy_id, old_policy_version,
            new_policy_id, new_policy_version, marked_at, resolved
          ) VALUES ('local', ?, 'scoring_policy_changed', 'local:scoring-policy-v1', 1,
            'local:scoring-policy-v3', 3, '2026-05-26T10:06:00+00:00', 0)`,
       )
-      .run("https://example.com/jobs/failed-score");
+      .run(jobIdFor("https://example.com/jobs/failed-score"));
     insertMaterialsGeneration(seedDb, {
       jobUrl: "https://example.com/jobs/ready",
       artifactId: "artifact-ready-old-policy",
@@ -5080,7 +4928,7 @@ describe("local TypeScript API", () => {
         )
         .run(
           itemId,
-          jobId,
+          jobIdFor(jobId),
           state,
           `${itemId}-key`,
           "2026-05-26T10:02:00+00:00",
@@ -5106,19 +4954,8 @@ describe("local TypeScript API", () => {
     }
   });
 
-  it("does not count corrected old-policy scores as outdated when staleness markers are absent", async () => {
+  it("does not infer outdated scores when explicit staleness markers are absent", async () => {
     const seedDb = new Database(options.dbPath);
-    seedDb.exec(`
-      CREATE TABLE scoring_policies (
-        tenant_id TEXT NOT NULL DEFAULT 'local',
-        version INTEGER NOT NULL,
-        rubric_json TEXT NOT NULL,
-        anchors_json TEXT NOT NULL DEFAULT '[]',
-        created_at TEXT NOT NULL,
-        created_from_event_id INTEGER,
-        PRIMARY KEY (tenant_id, version)
-      );
-    `);
     seedDb
       .prepare(
         "INSERT INTO scoring_policies (tenant_id, version, rubric_json, anchors_json, created_at) VALUES (?, ?, ?, ?, ?)",
@@ -5150,7 +4987,7 @@ describe("local TypeScript API", () => {
     try {
       const response = await app.inject({ method: "GET", url: "/v1/dashboard/summary" });
       expect(response.statusCode, response.body).toBe(200);
-      expect(response.json().preparation.outdatedScoreCount).toBe(1);
+      expect(response.json().preparation.outdatedScoreCount).toBe(0);
     } finally {
       await app.close();
     }
@@ -5159,17 +4996,6 @@ describe("local TypeScript API", () => {
   it("does not count corrected latest scores as outdated when stale markers remain unresolved", async () => {
     const seedDb = new Database(options.dbPath);
     createScoreStalenessTable(seedDb);
-    seedDb.exec(`
-      CREATE TABLE scoring_policies (
-        tenant_id TEXT NOT NULL DEFAULT 'local',
-        version INTEGER NOT NULL,
-        rubric_json TEXT NOT NULL,
-        anchors_json TEXT NOT NULL DEFAULT '[]',
-        created_at TEXT NOT NULL,
-        created_from_event_id INTEGER,
-        PRIMARY KEY (tenant_id, version)
-      );
-    `);
     seedDb
       .prepare(
         "INSERT INTO scoring_policies (tenant_id, version, rubric_json, anchors_json, created_at) VALUES (?, ?, ?, ?, ?)",
@@ -5189,12 +5015,12 @@ describe("local TypeScript API", () => {
     seedDb
       .prepare(
         `INSERT INTO job_score_staleness (
-           tenant_id, job_url, stale_reason, old_policy_id, old_policy_version,
+           tenant_id, job_id, stale_reason, old_policy_id, old_policy_version,
            new_policy_id, new_policy_version, marked_at, resolved
          ) VALUES ('local', ?, 'scoring_policy_changed', 'local:scoring-policy-v1', 1,
            'local:scoring-policy-v3', 3, '2026-05-26T10:06:00+00:00', 0)`,
       )
-      .run("https://example.com/jobs/stale-but-corrected");
+      .run(jobIdFor("https://example.com/jobs/stale-but-corrected"));
     seedDb.close();
 
     const app = buildApp(options);
@@ -5253,7 +5079,7 @@ describe("local TypeScript API", () => {
       expect(run).toMatchObject({
         workflowId: "run-1",
         runId: "run-1",
-        jobKey: "https://example.com/jobs/ready",
+        jobKey: jobIdFor("https://example.com/jobs/ready"),
         title: "Platform Engineer",
         company: "ExampleCo",
         // Seed inserts `status: "finished"`, the read-model normalizes
@@ -5843,7 +5669,7 @@ describe("local TypeScript API", () => {
       insertPipelineWorkflowEvent(db, { eventType: "WorkflowStarted", occurredAt: DISCOVER_NEW_START, workflowId: "discover-local", temporalRunId: DISCOVER_NEW_TEMPORAL_RUN, startedAt: DISCOVER_NEW_START });
       insertPipelineWorkflowEvent(db, { eventType: "WorkflowFailed", occurredAt: DISCOVER_FAILED_AT, workflowId: "discover-local", temporalRunId: DISCOVER_NEW_TEMPORAL_RUN, errorCode: "activity_task_failed", errorMessage: "Activity task failed", retryable: true, finishedAt: DISCOVER_FAILED_AT });
       db.prepare(
-        "INSERT INTO job_events (job_url, stage, event_type, level, message, occurred_at, payload_json) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        "INSERT INTO job_events (tenant_id, job_id, identity_version, stage, event_type, level, message, occurred_at, payload_json) SELECT 'local', (SELECT job_id FROM jobs WHERE tenant_id = 'local' AND url = ?), 1, ?, ?, ?, ?, ?, ?",
       ).run(
         null,
         "discover",
@@ -6004,14 +5830,14 @@ describe("local TypeScript API", () => {
       createMaterialsTables(db);
       db.prepare(
         `INSERT OR REPLACE INTO job_materials (
-           job_url, generation, tenant_id, status, created_at, updated_at
-         ) VALUES (?, 99, 'local', 'resume_approved', ?, ?)`,
+           tenant_id, job_id, generation, status, created_at, updated_at
+         ) VALUES ('local', ?, 99, 'resume_approved', ?, ?)`,
       ).run(artifact.jobKey, now, now);
       db.prepare(
         `INSERT OR REPLACE INTO job_materials_artifacts (
-           job_url, generation, artifact_type, artifact_id, status, path,
+           tenant_id, job_id, generation, artifact_type, artifact_id, status, path,
            render_format, size_bytes, metadata_json, created_at
-         ) VALUES (?, 99, 'resume_pdf', ?, 'approved', ?, 'html_pdf', ?, '{}', ?)`,
+         ) VALUES ('local', ?, 99, 'resume_pdf', ?, 'approved', ?, 'html_pdf', ?, '{}', ?)`,
       ).run(artifact.jobKey, artifact.artifactId, artifact.localPath, fs.statSync(artifact.localPath).size, now);
       db.close();
 
@@ -6051,7 +5877,7 @@ describe("local TypeScript API", () => {
       ok: true,
       artifact: {
         artifactId: artifact.artifactId,
-        jobKey: "https://example.com/jobs/ready",
+        jobKey: jobIdFor("https://example.com/jobs/ready"),
         type: "tailored_resume_pdf",
       },
     });
@@ -6084,14 +5910,14 @@ describe("local TypeScript API", () => {
     createMaterialsTables(db);
     db.prepare(
       `INSERT OR REPLACE INTO job_materials (
-         job_url, generation, tenant_id, status, created_at, updated_at
-       ) VALUES (?, 99, 'local', 'resume_approved', ?, ?)`,
+         tenant_id, job_id, generation, status, created_at, updated_at
+       ) VALUES ('local', ?, 99, 'resume_approved', ?, ?)`,
     ).run(artifact.jobKey, now, now);
     db.prepare(
       `INSERT OR REPLACE INTO job_materials_artifacts (
-         job_url, generation, artifact_type, artifact_id, status, path,
+         tenant_id, job_id, generation, artifact_type, artifact_id, status, path,
          render_format, size_bytes, metadata_json, created_at
-       ) VALUES (?, 99, 'resume_pdf', ?, 'approved', ?, 'html_pdf', ?, '{}', ?)`,
+       ) VALUES ('local', ?, 99, 'resume_pdf', ?, 'approved', ?, 'html_pdf', ?, '{}', ?)`,
     ).run(artifact.jobKey, artifact.artifactId, artifact.localPath, fs.statSync(artifact.localPath).size, now);
     db.close();
 
@@ -6111,7 +5937,7 @@ describe("local TypeScript API", () => {
     await app.close();
   });
 
-  it("serves sibling HTML preview for legacy artifact tables without render_format", async () => {
+  it("serves sibling HTML preview for an exact artifact with HTML render metadata", async () => {
     const app = buildApp(options);
     const listResponse = await app.inject({ method: "GET", url: "/v1/artifacts?type=tailored_resume_pdf" });
     const artifact = listResponse.json().items[0];
@@ -6123,39 +5949,15 @@ describe("local TypeScript API", () => {
     createMaterialsTables(db);
     db.prepare(
       `INSERT OR REPLACE INTO job_materials (
-         job_url, generation, tenant_id, status, created_at, updated_at
-       ) VALUES (?, 99, 'local', 'resume_approved', ?, ?)`,
+         tenant_id, job_id, generation, status, created_at, updated_at
+       ) VALUES ('local', ?, 99, 'resume_approved', ?, ?)`,
     ).run(artifact.jobKey, now, now);
     db.prepare(
       `INSERT OR REPLACE INTO job_materials_artifacts (
-         job_url, generation, artifact_type, artifact_id, status, path,
+         tenant_id, job_id, generation, artifact_type, artifact_id, status, path,
          render_format, size_bytes, metadata_json, created_at
-       ) VALUES (?, 99, 'resume_pdf', ?, 'approved', ?, 'html_pdf', ?, '{}', ?)`,
+       ) VALUES ('local', ?, 99, 'resume_pdf', ?, 'approved', ?, 'html_pdf', ?, '{}', ?)`,
     ).run(artifact.jobKey, artifact.artifactId, artifact.localPath, fs.statSync(artifact.localPath).size, now);
-    db.exec(`
-      ALTER TABLE job_materials_artifacts RENAME TO job_materials_artifacts_with_render_format;
-      CREATE TABLE job_materials_artifacts (
-        job_url TEXT NOT NULL,
-        generation INTEGER NOT NULL,
-        artifact_type TEXT NOT NULL,
-        artifact_id TEXT NOT NULL,
-        status TEXT NOT NULL,
-        path TEXT NOT NULL,
-        size_bytes INTEGER,
-        metadata_json TEXT,
-        created_at TEXT NOT NULL,
-        superseded_at TEXT,
-        PRIMARY KEY (job_url, generation, artifact_id)
-      );
-      INSERT INTO job_materials_artifacts (
-        job_url, generation, artifact_type, artifact_id, status, path,
-        size_bytes, metadata_json, created_at, superseded_at
-      )
-      SELECT job_url, generation, artifact_type, artifact_id, status, path,
-             size_bytes, metadata_json, created_at, superseded_at
-        FROM job_materials_artifacts_with_render_format;
-      DROP TABLE job_materials_artifacts_with_render_format;
-    `);
     db.close();
 
     const response = await app.inject({
@@ -6179,14 +5981,14 @@ describe("local TypeScript API", () => {
     createMaterialsTables(db);
     db.prepare(
       `INSERT OR REPLACE INTO job_materials (
-         job_url, generation, tenant_id, status, created_at, updated_at
-       ) VALUES (?, 99, 'local', 'resume_approved', ?, ?)`,
+         tenant_id, job_id, generation, status, created_at, updated_at
+       ) VALUES ('local', ?, 99, 'resume_approved', ?, ?)`,
     ).run(artifact.jobKey, now, now);
     db.prepare(
       `INSERT OR REPLACE INTO job_materials_artifacts (
-         job_url, generation, artifact_type, artifact_id, status, path,
+         tenant_id, job_id, generation, artifact_type, artifact_id, status, path,
          render_format, size_bytes, metadata_json, created_at
-       ) VALUES (?, 99, 'resume_pdf', ?, 'approved', ?, 'latex_pdf', ?, '{}', ?)`,
+       ) VALUES ('local', ?, 99, 'resume_pdf', ?, 'approved', ?, 'latex_pdf', ?, '{}', ?)`,
     ).run(artifact.jobKey, artifact.artifactId, artifact.localPath, fs.statSync(artifact.localPath).size, now);
     db.close();
 
@@ -6287,12 +6089,12 @@ describe("local TypeScript API", () => {
           `SELECT state, attempt_count, updated_at, error_code, error_message,
                   retryable, blocked_by_json
              FROM job_stage_states
-            WHERE job_url = ? AND stage = 'tailor'`,
+            WHERE tenant_id = 'local' AND job_id = ? AND stage = 'tailor'`,
         )
-        .get(jobUrl);
+        .get(jobIdFor(jobUrl));
       const eventCount = db
-        .prepare("SELECT COUNT(*) AS count FROM job_events WHERE job_url = ? AND stage = 'tailor'")
-        .get(jobUrl) as { count: number };
+        .prepare("SELECT COUNT(*) AS count FROM job_events WHERE tenant_id = 'local' AND job_id = ? AND stage = 'tailor'")
+        .get(jobIdFor(jobUrl)) as { count: number };
       db.close();
       return { stage, eventCount: eventCount.count };
     };
@@ -6338,14 +6140,14 @@ describe("local TypeScript API", () => {
 
     const db = new Database(options.dbPath);
     const failed = db
-      .prepare("SELECT state FROM job_stage_states WHERE job_url = ? AND stage = 'score'")
-      .get("https://example.com/jobs/failed-score") as { state: string };
+      .prepare("SELECT state FROM job_stage_states WHERE tenant_id = 'local' AND job_id = ? AND stage = 'score'")
+      .get(jobIdFor("https://example.com/jobs/failed-score")) as { state: string };
     const ready = db
-      .prepare("SELECT state FROM job_stage_states WHERE job_url = ? AND stage = 'score'")
-      .get("https://example.com/jobs/ready") as { state: string };
+      .prepare("SELECT state FROM job_stage_states WHERE tenant_id = 'local' AND job_id = ? AND stage = 'score'")
+      .get(jobIdFor("https://example.com/jobs/ready")) as { state: string };
     const event = db
-      .prepare("SELECT message FROM job_events WHERE job_url = ? ORDER BY event_id DESC LIMIT 1")
-      .get("https://example.com/jobs/failed-score") as { message: string };
+      .prepare("SELECT message FROM job_events WHERE tenant_id = 'local' AND job_id = ? ORDER BY event_id DESC LIMIT 1")
+      .get(jobIdFor("https://example.com/jobs/failed-score")) as { message: string };
     db.close();
 
     expect(failed.state).toBe("pending");
@@ -6441,17 +6243,17 @@ describe("local TypeScript API", () => {
 
     const db = new Database(options.dbPath);
     const states = db
-      .prepare("SELECT job_url, state FROM job_stage_states WHERE stage = 'score' AND job_url IN (?, ?) ORDER BY job_url")
-      .all("https://example.com/jobs/failed-score", secondFailedUrl) as Array<{ job_url: string; state: string }>;
+      .prepare("SELECT job_id, state FROM job_stage_states WHERE tenant_id = 'local' AND stage = 'score' AND job_id IN (?, ?) ORDER BY job_id")
+      .all(jobIdFor("https://example.com/jobs/failed-score"), jobIdFor(secondFailedUrl)) as Array<{ job_id: string; state: string }>;
     const queuedEvents = db
-      .prepare("SELECT job_url, event_type, payload_json FROM job_events WHERE event_type = 'StageQueued' ORDER BY job_url")
-      .all() as Array<{ job_url: string; event_type: string; payload_json: string }>;
+      .prepare("SELECT job_id, event_type, payload_json FROM job_events WHERE tenant_id = 'local' AND event_type = 'StageQueued' ORDER BY job_id")
+      .all() as Array<{ job_id: string; event_type: string; payload_json: string }>;
     db.close();
 
     expect(states).toEqual([
-      { job_url: "https://example.com/jobs/failed-score", state: "queued" },
-      { job_url: secondFailedUrl, state: "queued" },
-    ]);
+      { job_id: jobIdFor(secondFailedUrl), state: "queued" },
+      { job_id: jobIdFor("https://example.com/jobs/failed-score"), state: "queued" },
+    ].sort((left, right) => left.job_id.localeCompare(right.job_id)));
     expect(queuedEvents).toHaveLength(2);
     expect(JSON.parse(queuedEvents[0]!.payload_json)).toMatchObject({
       source: "bulk_retry_failed",
@@ -6601,31 +6403,31 @@ describe("local TypeScript API", () => {
     const db = new Database(options.dbPath);
     const queuedStates = db
       .prepare(
-        `SELECT job_url, stage, state FROM job_stage_states
-         WHERE job_url IN (?, ?, ?) AND state = 'queued'
-         ORDER BY job_url`,
+        `SELECT job_id, stage, state FROM job_stage_states
+         WHERE tenant_id = 'local' AND job_id IN (?, ?, ?) AND state = 'queued'
+         ORDER BY job_id`,
       )
-      .all(pendingEnrichUrl, pendingScoreUrl, pendingTailorUrl) as Array<{
-        job_url: string;
+      .all(jobIdFor(pendingEnrichUrl), jobIdFor(pendingScoreUrl), jobIdFor(pendingTailorUrl)) as Array<{
+        job_id: string;
         stage: string;
         state: string;
       }>;
     const failed = db
-      .prepare("SELECT state FROM job_stage_states WHERE job_url = ? AND stage = 'score'")
-      .get("https://example.com/jobs/failed-score") as { state: string };
+      .prepare("SELECT state FROM job_stage_states WHERE tenant_id = 'local' AND job_id = ? AND stage = 'score'")
+      .get(jobIdFor("https://example.com/jobs/failed-score")) as { state: string };
     const apply = db
-      .prepare("SELECT state FROM job_stage_states WHERE job_url = ? AND stage = 'apply'")
-      .get(pendingApplyUrl) as { state: string };
+      .prepare("SELECT state FROM job_stage_states WHERE tenant_id = 'local' AND job_id = ? AND stage = 'apply'")
+      .get(jobIdFor(pendingApplyUrl)) as { state: string };
     const queuedEvent = db
-      .prepare("SELECT payload_json FROM job_events WHERE event_type = 'StageQueued' AND job_url = ?")
-      .get(pendingScoreUrl) as { payload_json: string };
+      .prepare("SELECT payload_json FROM job_events WHERE tenant_id = 'local' AND event_type = 'StageQueued' AND job_id = ?")
+      .get(jobIdFor(pendingScoreUrl)) as { payload_json: string };
     db.close();
 
     expect(queuedStates).toEqual([
-      { job_url: pendingEnrichUrl, stage: "enrich", state: "queued" },
-      { job_url: pendingScoreUrl, stage: "score", state: "queued" },
-      { job_url: pendingTailorUrl, stage: "tailor", state: "queued" },
-    ]);
+      { job_id: jobIdFor(pendingEnrichUrl), stage: "enrich", state: "queued" },
+      { job_id: jobIdFor(pendingScoreUrl), stage: "score", state: "queued" },
+      { job_id: jobIdFor(pendingTailorUrl), stage: "tailor", state: "queued" },
+    ].sort((left, right) => left.job_id.localeCompare(right.job_id)));
     expect(failed.state).toBe("failed");
     expect(apply.state).toBe("pending");
     expect(JSON.parse(queuedEvent.payload_json)).toMatchObject({
@@ -6641,8 +6443,9 @@ describe("local TypeScript API", () => {
     const seedDb = new Database(options.dbPath);
     seedDb
       .prepare(
-        `INSERT INTO job_events (job_url, stage, event_type, level, message, occurred_at, payload_json)
-         VALUES (?, ?, ?, ?, ?, ?, ?)`,
+        `INSERT INTO job_events (
+           tenant_id, job_id, identity_version, stage, event_type, level, message, occurred_at, payload_json
+         ) SELECT 'local', (SELECT job_id FROM jobs WHERE tenant_id = 'local' AND url = ?), 1, ?, ?, ?, ?, ?, ?`,
       )
       .run(
         "https://example.com/jobs/failed-score",
@@ -6674,8 +6477,8 @@ describe("local TypeScript API", () => {
 
     const db = new Database(options.dbPath);
     const failed = db
-      .prepare("SELECT state, retryable FROM job_stage_states WHERE job_url = ? AND stage = 'score'")
-      .get("https://example.com/jobs/failed-score") as { state: string; retryable: number };
+      .prepare("SELECT state, retryable FROM job_stage_states WHERE tenant_id = 'local' AND job_id = ? AND stage = 'score'")
+      .get(jobIdFor("https://example.com/jobs/failed-score")) as { state: string; retryable: number };
     db.close();
 
     expect(failed).toMatchObject({ state: "failed", retryable: 1 });
@@ -6695,13 +6498,14 @@ describe("local TypeScript API", () => {
     insertStage(seedDb, jobUrl, "enrich", "failed", "DETAIL_ERROR");
     seedDb
       .prepare(
-        "UPDATE job_stage_states SET retryable = 0 WHERE job_url = ? AND stage = 'enrich'",
+        "UPDATE job_stage_states SET retryable = 0 WHERE tenant_id = 'local' AND job_id = ? AND stage = 'enrich'",
       )
-      .run(jobUrl);
+      .run(jobIdFor(jobUrl));
     seedDb
       .prepare(
-        `INSERT INTO job_events (job_url, stage, event_type, level, message, occurred_at, payload_json)
-         VALUES (?, ?, ?, ?, ?, ?, ?)`,
+        `INSERT INTO job_events (
+           tenant_id, job_id, identity_version, stage, event_type, level, message, occurred_at, payload_json
+         ) SELECT 'local', (SELECT job_id FROM jobs WHERE tenant_id = 'local' AND url = ?), 1, ?, ?, ?, ?, ?, ?`,
       )
       .run(
         jobUrl,
@@ -6733,8 +6537,8 @@ describe("local TypeScript API", () => {
 
     const db = new Database(options.dbPath);
     const enrich = db
-      .prepare("SELECT state FROM job_stage_states WHERE job_url = ? AND stage = 'enrich'")
-      .get(jobUrl) as { state: string };
+      .prepare("SELECT state FROM job_stage_states WHERE tenant_id = 'local' AND job_id = ? AND stage = 'enrich'")
+      .get(jobIdFor(jobUrl)) as { state: string };
     db.close();
 
     expect(enrich.state).toBe("pending");
@@ -6755,12 +6559,12 @@ describe("local TypeScript API", () => {
     const seedDb = new Database(options.dbPath);
     seedDb.prepare(
       `INSERT INTO job_enrichments (
-         job_url, tenant_id, current_status, full_description,
+         job_id, tenant_id, current_status, full_description,
          application_url, enriched_at, extraction_tier,
          attempts_json, updated_at
        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     ).run(
-      "https://example.com/jobs/failed-score",
+      jobIdFor("https://example.com/jobs/failed-score"),
       "local",
       "enriched",
       "The full job description.",
@@ -6787,9 +6591,9 @@ describe("local TypeScript API", () => {
       .prepare(
         `SELECT current_status, full_description, application_url,
                 enriched_at, extraction_tier
-         FROM job_enrichments WHERE job_url = ?`,
+         FROM job_enrichments WHERE tenant_id = 'local' AND job_id = ?`,
       )
-      .get("https://example.com/jobs/failed-score") as {
+      .get(jobIdFor("https://example.com/jobs/failed-score")) as {
       current_status: string;
       full_description: string | null;
       application_url: string | null;
@@ -6833,8 +6637,8 @@ describe("local TypeScript API", () => {
 
     const db = new Database(options.dbPath);
     const count = db
-      .prepare("SELECT COUNT(*) AS c FROM job_enrichments WHERE job_url = ?")
-      .get("https://example.com/jobs/blocked-tailor") as { c: number };
+      .prepare("SELECT COUNT(*) AS c FROM job_enrichments WHERE tenant_id = 'local' AND job_id = ?")
+      .get(jobIdFor("https://example.com/jobs/blocked-tailor")) as { c: number };
     db.close();
     expect(count.c).toBe(0); // still no row — UPDATE was a no-op
     await app.close();
@@ -7335,8 +7139,8 @@ describe("local TypeScript API", () => {
     const db = new Database(options.dbPath);
     try {
       const events = db
-        .prepare("SELECT event_type FROM job_events WHERE job_url = ? ORDER BY event_id DESC")
-        .all("https://example.com/jobs/ready")
+        .prepare("SELECT event_type FROM job_events WHERE tenant_id = 'local' AND job_id = ? ORDER BY event_id DESC")
+        .all(jobIdFor("https://example.com/jobs/ready"))
         .map((row) => (row as { event_type: string }).event_type);
       expect(events).toContain("TailorRequested");
       expect(events).toContain("RetailorRequested");
@@ -7479,7 +7283,7 @@ describe("local TypeScript API", () => {
     const db = new Database(options.dbPath);
     try {
       db.prepare(
-        "INSERT INTO job_events (job_url, stage, event_type, level, message, occurred_at, payload_json) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        "INSERT INTO job_events (tenant_id, job_id, identity_version, stage, event_type, level, message, occurred_at, payload_json) SELECT 'local', (SELECT job_id FROM jobs WHERE tenant_id = 'local' AND url = ?), 1, ?, ?, ?, ?, ?, ?",
       ).run(
         null,
         "discover",
@@ -7503,24 +7307,6 @@ describe("local TypeScript API", () => {
           },
         }),
       );
-      db.exec(`
-        CREATE TABLE discovery_runs (
-          tenant_id TEXT NOT NULL DEFAULT 'local',
-          run_id TEXT NOT NULL,
-          source_ids_json TEXT NOT NULL DEFAULT '[]',
-          profile_snapshot_id TEXT,
-          status TEXT NOT NULL,
-          counts_json TEXT NOT NULL DEFAULT '{}',
-          progress_json TEXT NOT NULL DEFAULT '{}',
-          error_classes_json TEXT NOT NULL DEFAULT '[]',
-          started_at TEXT NOT NULL,
-          updated_at TEXT,
-          completed_at TEXT,
-          failed_at TEXT,
-          workflow_id TEXT,
-          PRIMARY KEY (tenant_id, run_id)
-        );
-      `);
       db.prepare(
         `INSERT INTO discovery_runs (
           tenant_id, run_id, source_ids_json, status, counts_json, progress_json,
@@ -8320,6 +8106,15 @@ describe("local TypeScript API", () => {
   });
 
   it("records profile updates and starts an event-driven re-tailoring run", async () => {
+    const seedDb = new Database(options.dbPath);
+    insertMaterialsGeneration(seedDb, {
+      jobUrl: "https://example.com/jobs/ready",
+      artifactId: "artifact-profile-update-retailor",
+      artifactType: "tailored_resume",
+      status: "approved",
+      path: path.join(tempDir, "ready-resume.txt"),
+    });
+    seedDb.close();
     const dispatch = vi.fn(async (): Promise<ActionDispatchResult> => ({ status: "queued", runId: "run-retailor" }));
     const app = buildApp({ ...options, actionDispatcher: dispatch });
     const response = await app.inject({
@@ -8347,11 +8142,11 @@ describe("local TypeScript API", () => {
     try {
       const event = db
         .prepare(
-          "SELECT job_url, stage, event_type, payload_json FROM job_events WHERE event_type = 'ProfileUpdated' ORDER BY event_id DESC LIMIT 1",
+          "SELECT job_id, stage, event_type, payload_json FROM job_events WHERE event_type = 'ProfileUpdated' ORDER BY event_id DESC LIMIT 1",
         )
-        .get() as { job_url: string | null; stage: string | null; event_type: string; payload_json: string };
+        .get() as { job_id: string | null; stage: string | null; event_type: string; payload_json: string };
       expect(event).toMatchObject({
-        job_url: null,
+        job_id: null,
         stage: null,
         event_type: "ProfileUpdated",
       });
@@ -9756,13 +9551,9 @@ function seedExactV7CompensationDatabase(
   dbPath: string,
   job?: { jobId: string; postingUrl: string },
 ): void {
-  const schemaPath = path.resolve(
-    process.cwd(),
-    "../../workers/automation/src/jobctrl/infrastructure/migrations/schema_v7.sql",
-  );
+  initializeExactV7Database(dbPath);
   const db = new Database(dbPath);
-  db.exec(fs.readFileSync(schemaPath, "utf8"));
-  db.pragma(`user_version = ${SUPPORTED_SCHEMA_VERSION}`);
+  seedBuiltInResumeTemplate(db);
   if (job) {
     db.prepare(
       `INSERT INTO jobs (
@@ -9783,129 +9574,29 @@ function seedExactV7CompensationDatabase(
   db.close();
 }
 
+function seedBuiltInResumeTemplate(db: Database.Database): void {
+  const now = "2026-04-29T10:00:00+00:00";
+  db.prepare(
+    `INSERT INTO resume_templates (
+       tenant_id, template_id, display_name, status, built_in, created_at, updated_at
+     ) VALUES ('local', 'built_in:modern-html', 'Modern HTML', 'active', 1, ?, ?)`,
+  ).run(now, now);
+  db.prepare(
+    `INSERT INTO resume_template_versions (
+       tenant_id, version_id, template_id, version_number, display_name, status,
+       theme_json, layout_json, content_hash, created_at
+     ) VALUES ('local', 'built_in:modern-html:v1', 'built_in:modern-html', 1,
+               'Modern HTML', 'active', ?, '{}', 'server-seed-hash', ?)`,
+  ).run(JSON.stringify(BUILT_IN_RESUME_TEMPLATE_THEME), now);
+}
+
 function seedDatabase(dbPath: string): void {
   const artifactPath = path.join(path.dirname(dbPath), "ready-resume.txt");
   fs.writeFileSync(artifactPath, "hello world!");
 
+  initializeExactV7Database(dbPath);
   const db = new Database(dbPath);
-  db.exec(`
-    CREATE TABLE jobs (
-      url TEXT PRIMARY KEY,
-      title TEXT,
-      site TEXT,
-      strategy TEXT,
-      location TEXT,
-      salary TEXT,
-      discovered_at TEXT,
-      application_url TEXT,
-      description TEXT,
-      full_description TEXT,
-      detail_scraped_at TEXT,
-      detail_error TEXT,
-      fit_score INTEGER,
-      score_reasoning TEXT,
-      scored_at TEXT,
-      tailored_resume_path TEXT,
-      tailored_at TEXT,
-      tailor_attempts INTEGER,
-      cover_letter_path TEXT,
-      cover_letter_at TEXT,
-      cover_attempts INTEGER,
-      apply_status TEXT,
-      apply_error TEXT,
-      applied_at TEXT
-    );
-    CREATE TABLE job_stage_states (
-      job_url TEXT,
-      stage TEXT,
-      state TEXT,
-      attempt_count INTEGER,
-      max_attempts INTEGER,
-      started_at TEXT,
-      updated_at TEXT,
-      finished_at TEXT,
-      duration_ms INTEGER,
-      error_code TEXT,
-      error_message TEXT,
-      retryable INTEGER,
-      blocked_by_json TEXT,
-      next_action TEXT
-    );
-    CREATE TABLE job_artifacts (
-      job_url TEXT,
-      stage TEXT,
-      artifact_type TEXT,
-      status TEXT,
-      path TEXT,
-      created_at TEXT,
-      size_bytes INTEGER
-    );
-    CREATE TABLE job_events (
-      event_id INTEGER PRIMARY KEY AUTOINCREMENT,
-      job_url TEXT,
-      stage TEXT,
-      event_type TEXT NOT NULL DEFAULT '',
-      level TEXT,
-      message TEXT,
-      occurred_at TEXT,
-      payload_json TEXT
-    );
-    CREATE TABLE job_scores (
-      job_url TEXT NOT NULL,
-      version INTEGER NOT NULL,
-      tenant_id TEXT NOT NULL DEFAULT 'local',
-      fit_score INTEGER NOT NULL,
-      breakdown_json TEXT NOT NULL,
-      keywords_json TEXT NOT NULL,
-      scored_at TEXT NOT NULL,
-      correction_json TEXT,
-      criteria_json TEXT NOT NULL DEFAULT '{}',
-      trace_json TEXT NOT NULL DEFAULT '{}',
-      PRIMARY KEY (job_url, version)
-    );
-    CREATE TABLE job_enrichments (
-      job_url TEXT PRIMARY KEY,
-      tenant_id TEXT NOT NULL DEFAULT 'local',
-      current_status TEXT NOT NULL,
-      full_description TEXT,
-      application_url TEXT,
-      enriched_at TEXT,
-      extraction_tier TEXT,
-      attempts_json TEXT NOT NULL DEFAULT '[]',
-      updated_at TEXT NOT NULL
-    );
-    CREATE TABLE apply_run_projections (
-      run_id TEXT PRIMARY KEY,
-      tenant_id TEXT NOT NULL DEFAULT 'local',
-      job_id TEXT NOT NULL,
-      job_title TEXT NOT NULL DEFAULT '',
-      job_employer TEXT NOT NULL DEFAULT '',
-      status TEXT NOT NULL DEFAULT '',
-      result TEXT,
-      dry_run INTEGER NOT NULL DEFAULT 0,
-      worker_id INTEGER,
-      model TEXT,
-      started_at TEXT,
-      finished_at TEXT,
-      duration_ms INTEGER,
-      events_json TEXT NOT NULL DEFAULT '[]'
-    );
-    CREATE TABLE workflow_run_projections (
-      workflow_id TEXT PRIMARY KEY,
-      tenant_id TEXT NOT NULL DEFAULT 'local',
-      workflow_type TEXT NOT NULL DEFAULT '',
-      status TEXT NOT NULL DEFAULT 'in_progress',
-      input_summary_json TEXT NOT NULL DEFAULT '{}',
-      error_code TEXT,
-      error_message TEXT,
-      retryable INTEGER NOT NULL DEFAULT 0,
-      started_at TEXT,
-      finished_at TEXT,
-      duration_ms INTEGER,
-      temporal_run_id TEXT,
-      events_json TEXT NOT NULL DEFAULT '[]'
-    );
-  `);
+  seedBuiltInResumeTemplate(db);
 
   insertJob(db, {
     url: "https://example.com/jobs/ready",
@@ -9914,9 +9605,6 @@ function seedDatabase(dbPath: string): void {
     fitScore: 9,
     tailoredPath: artifactPath,
   });
-  insertScore(db, "https://example.com/jobs/ready", 1, 9);
-  insertScore(db, "https://example.com/jobs/failed-score", 1, 8);
-  insertScore(db, "https://example.com/jobs/blocked-tailor", 1, 6);
   insertJob(db, {
     url: "https://example.com/jobs/failed-score",
     title: "Backend Engineer",
@@ -9929,6 +9617,9 @@ function seedDatabase(dbPath: string): void {
     site: "Acme",
     fitScore: 6,
   });
+  insertScore(db, "https://example.com/jobs/ready", 1, 9);
+  insertScore(db, "https://example.com/jobs/failed-score", 1, 8);
+  insertScore(db, "https://example.com/jobs/blocked-tailor", 1, 6);
 
   for (const stage of ["discover", "enrich", "score", "tailor", "cover"]) {
     insertStage(db, "https://example.com/jobs/ready", stage, "succeeded");
@@ -9943,9 +9634,9 @@ function seedDatabase(dbPath: string): void {
   insertStage(db, "https://example.com/jobs/blocked-tailor", "tailor", "blocked", "MIN_SCORE");
 
   db.prepare(
-    "INSERT INTO job_artifacts (job_url, stage, artifact_type, status, path, created_at, size_bytes) VALUES (?, ?, ?, ?, ?, ?, ?)",
+    "INSERT INTO job_artifacts (tenant_id, job_id, stage, artifact_type, status, path, created_at, size_bytes) VALUES ('local', ?, ?, ?, ?, ?, ?, ?)",
   ).run(
-    "https://example.com/jobs/ready",
+    jobIdFor("https://example.com/jobs/ready"),
     "tailor",
     "tailored_resume_txt",
     "active",
@@ -9954,9 +9645,20 @@ function seedDatabase(dbPath: string): void {
     12,
   );
   db.prepare(
-    "INSERT INTO job_events (job_url, stage, event_type, level, message, occurred_at) VALUES (?, ?, ?, ?, ?, ?)",
+    "INSERT INTO job_artifacts (tenant_id, job_id, stage, artifact_type, status, path, created_at, size_bytes) VALUES ('local', ?, ?, ?, ?, ?, ?, ?)",
   ).run(
-    "https://example.com/jobs/failed-score",
+    jobIdFor("https://example.com/jobs/ready"),
+    "tailor",
+    "tailored_resume_pdf",
+    "active",
+    artifactPath,
+    "2026-04-29T10:05:00+00:00",
+    12,
+  );
+  db.prepare(
+    "INSERT INTO job_events (tenant_id, job_id, identity_version, stage, event_type, level, message, occurred_at) VALUES ('local', ?, 1, ?, ?, ?, ?, ?)",
+  ).run(
+    jobIdFor("https://example.com/jobs/failed-score"),
     "score",
     "ActionFailed",
     "error",
@@ -9967,7 +9669,7 @@ function seedDatabase(dbPath: string): void {
     "INSERT INTO apply_run_projections (run_id, job_id, job_title, job_employer, status, result, dry_run, started_at, events_json) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
   ).run(
     "run-1",
-    "https://example.com/jobs/ready",
+    jobIdFor("https://example.com/jobs/ready"),
     "Platform Engineer",
     "ExampleCo",
     "finished",
@@ -10039,8 +9741,8 @@ function insertPipelineWorkflowEvent(
     if (value !== undefined) payload[key] = value;
   }
   db.prepare(
-    "INSERT INTO job_events (job_url, stage, event_type, level, message, occurred_at, payload_json) VALUES (?, ?, ?, ?, ?, ?, ?)",
-  ).run(null, "workflow", event.eventType, "info", event.message ?? null, event.occurredAt, JSON.stringify(payload));
+    "INSERT INTO job_events (tenant_id, job_id, identity_version, stage, event_type, level, message, occurred_at, payload_json) VALUES ('local', NULL, 1, ?, ?, ?, ?, ?, ?)",
+  ).run("workflow", event.eventType, "info", event.message ?? null, event.occurredAt, JSON.stringify(payload));
 }
 
 function insertDiscoverWorkflowRunRow(
@@ -10143,11 +9845,12 @@ function insertJob(
 ): void {
   db.prepare(
     `INSERT INTO jobs (
-      url, title, site, strategy, location, salary, discovered_at, application_url,
+      tenant_id, job_id, url, title, site, strategy, location, salary, discovered_at, application_url,
       description, full_description, detail_scraped_at, fit_score, score_reasoning,
       scored_at, tailored_resume_path, tailored_at
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    ) VALUES ('local', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   ).run(
+    jobIdFor(job.url),
     job.url,
     job.title,
     job.site,
@@ -10167,41 +9870,22 @@ function insertJob(
   );
 }
 
+function jobIdFor(jobUrl: string): string {
+  const digest = createHash("sha256").update(jobUrl).digest("hex");
+  return `${digest.slice(0, 8)}-${digest.slice(8, 12)}-4${digest.slice(13, 16)}-8${digest.slice(17, 20)}-${digest.slice(20, 32)}`;
+}
+
 function insertPostedCompensationFact(db: Database.Database, jobUrl: string): void {
-  db.exec(`
-    CREATE TABLE IF NOT EXISTS job_posted_compensation_facts (
-      tenant_id TEXT NOT NULL DEFAULT 'local',
-      job_url TEXT NOT NULL,
-      source_field TEXT NOT NULL DEFAULT 'jobs.salary',
-      source_text TEXT,
-      legacy_raw_salary TEXT,
-      parse_state TEXT NOT NULL,
-      currency TEXT,
-      period TEXT NOT NULL DEFAULT 'unknown',
-      component TEXT NOT NULL DEFAULT 'unknown',
-      minimum_amount INTEGER,
-      maximum_amount INTEGER,
-      annualized_minimum_amount INTEGER,
-      annualized_maximum_amount INTEGER,
-      annualization_assumption TEXT,
-      confidence TEXT NOT NULL DEFAULT 'none',
-      warnings_json TEXT NOT NULL DEFAULT '[]',
-      parser_version TEXT NOT NULL,
-      source_hash TEXT NOT NULL,
-      parsed_at TEXT NOT NULL,
-      PRIMARY KEY (tenant_id, job_url)
-    );
-  `);
   db.prepare(
     `INSERT INTO job_posted_compensation_facts (
-      tenant_id, job_url, source_field, source_text, legacy_raw_salary,
+      tenant_id, job_id, source_field, source_text, legacy_raw_salary,
       parse_state, currency, period, component, minimum_amount, maximum_amount,
       annualized_minimum_amount, annualized_maximum_amount, annualization_assumption,
       confidence, warnings_json, parser_version, source_hash, parsed_at
     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   ).run(
     "local",
-    jobUrl,
+    jobIdFor(jobUrl),
     "jobs.salary",
     "€55,000/year",
     "€55,000/year",
@@ -10225,14 +9909,14 @@ function insertPostedCompensationFact(db: Database.Database, jobUrl: string): vo
 function insertUnannualizedPostedCompensationFact(db: Database.Database, jobUrl: string): void {
   db.prepare(
     `INSERT INTO job_posted_compensation_facts (
-      tenant_id, job_url, source_field, source_text, legacy_raw_salary,
+      tenant_id, job_id, source_field, source_text, legacy_raw_salary,
       parse_state, currency, period, component, minimum_amount, maximum_amount,
       annualized_minimum_amount, annualized_maximum_amount, annualization_assumption,
       confidence, warnings_json, parser_version, source_hash, parsed_at
     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   ).run(
     "local",
-    jobUrl,
+    jobIdFor(jobUrl),
     "jobs.full_description",
     "EUR 120000-130000",
     "EUR 120000-130000",
@@ -10254,45 +9938,9 @@ function insertUnannualizedPostedCompensationFact(db: Database.Database, jobUrl:
 }
 
 function insertMarketCompensationEstimate(db: Database.Database, jobUrl: string): void {
-  db.exec(`
-    CREATE TABLE IF NOT EXISTS job_market_compensation_estimates (
-      tenant_id TEXT NOT NULL DEFAULT 'local',
-      job_url TEXT NOT NULL,
-      estimate_state TEXT NOT NULL,
-      currency TEXT,
-      period TEXT NOT NULL DEFAULT 'year',
-      component TEXT NOT NULL DEFAULT 'total_compensation',
-      minimum_amount INTEGER,
-      maximum_amount INTEGER,
-      confidence_band TEXT NOT NULL DEFAULT 'none',
-      confidence_score REAL NOT NULL DEFAULT 0,
-      source_count INTEGER NOT NULL DEFAULT 0,
-      sample_count INTEGER,
-      aggregate_bucket TEXT,
-      geography_scope TEXT,
-      occupation_code TEXT,
-      occupation_label TEXT,
-      seniority_label TEXT,
-      source_snapshot_json TEXT NOT NULL DEFAULT '[]',
-      factor_reasons_json TEXT NOT NULL DEFAULT '[]',
-      insufficient_reasons_json TEXT NOT NULL DEFAULT '[]',
-      unsupported_reasons_json TEXT NOT NULL DEFAULT '[]',
-      source_unavailable_reasons_json TEXT NOT NULL DEFAULT '[]',
-      warnings_json TEXT NOT NULL DEFAULT '[]',
-      estimator_version TEXT NOT NULL,
-      estimated_at TEXT NOT NULL,
-      company_name TEXT,
-      normalized_company TEXT,
-      role_title TEXT,
-      normalized_role TEXT,
-      company_tier TEXT NOT NULL DEFAULT 'unknown',
-      match_scope TEXT NOT NULL DEFAULT 'none',
-      PRIMARY KEY (tenant_id, job_url)
-    );
-  `);
   db.prepare(
     `INSERT INTO job_market_compensation_estimates (
-      tenant_id, job_url, estimate_state, currency, period, component,
+      tenant_id, job_id, estimate_state, currency, period, component,
       minimum_amount, maximum_amount, confidence_band, confidence_score,
       source_count, sample_count, aggregate_bucket, geography_scope,
       occupation_code, occupation_label, seniority_label, source_snapshot_json,
@@ -10302,7 +9950,7 @@ function insertMarketCompensationEstimate(db: Database.Database, jobUrl: string)
     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   ).run(
     "local",
-    jobUrl,
+    jobIdFor(jobUrl),
     "estimated_range",
     "EUR",
     "year",
@@ -10385,11 +10033,11 @@ function insertScore(
 ): void {
   db.prepare(
     `INSERT INTO job_scores (
-      job_url, version, tenant_id, fit_score, breakdown_json, keywords_json,
+      tenant_id, job_id, version, fit_score, breakdown_json, keywords_json,
     scored_at, correction_json, criteria_json, trace_json
-    ) VALUES (?, ?, 'local', ?, ?, ?, ?, ?, ?, ?)`,
+    ) VALUES ('local', ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   ).run(
-    jobUrl,
+    jobIdFor(jobUrl),
     version,
     fitScore,
     JSON.stringify({
@@ -10437,95 +10085,11 @@ function insertScore(
 }
 
 function createScoreStalenessTable(db: Database.Database): void {
-  db.exec(`
-    CREATE TABLE IF NOT EXISTS job_score_staleness (
-      tenant_id TEXT NOT NULL DEFAULT 'local',
-      job_url TEXT NOT NULL,
-      stale_reason TEXT NOT NULL,
-      old_policy_id TEXT NOT NULL DEFAULT '',
-      old_policy_version INTEGER NOT NULL,
-      new_policy_id TEXT NOT NULL DEFAULT '',
-      new_policy_version INTEGER NOT NULL,
-      marked_at TEXT NOT NULL,
-      resolved INTEGER NOT NULL DEFAULT 0,
-      resolved_at TEXT,
-      resolved_by_score_version INTEGER,
-      PRIMARY KEY (
-        tenant_id, job_url, stale_reason,
-        old_policy_version, new_policy_version
-      )
-    )
-  `);
+  void db;
 }
 
 function createMaterialsTables(db: Database.Database): void {
-  db.exec(`
-    CREATE TABLE IF NOT EXISTS job_materials (
-      job_url TEXT NOT NULL,
-      generation INTEGER NOT NULL,
-      tenant_id TEXT NOT NULL DEFAULT 'local',
-      status TEXT NOT NULL,
-      created_at TEXT NOT NULL,
-      updated_at TEXT NOT NULL,
-      last_validation_json TEXT,
-      last_verdict_json TEXT,
-      metadata_json TEXT,
-      PRIMARY KEY (job_url, generation)
-    );
-    CREATE TABLE IF NOT EXISTS job_materials_artifacts (
-      job_url TEXT NOT NULL,
-      generation INTEGER NOT NULL,
-      artifact_type TEXT NOT NULL,
-      artifact_id TEXT NOT NULL,
-      status TEXT NOT NULL,
-      path TEXT NOT NULL,
-      render_format TEXT NOT NULL,
-      size_bytes INTEGER,
-      metadata_json TEXT,
-      created_at TEXT NOT NULL,
-      superseded_at TEXT,
-      PRIMARY KEY (job_url, generation, artifact_type)
-    );
-    CREATE TABLE IF NOT EXISTS job_bullet_provenance (
-      job_url TEXT NOT NULL,
-      generation INTEGER NOT NULL,
-      bullet_id TEXT NOT NULL,
-      tenant_id TEXT NOT NULL DEFAULT 'local',
-      artifact_id TEXT NOT NULL,
-      section TEXT NOT NULL,
-      source_id TEXT,
-      evidence_ids_json TEXT NOT NULL DEFAULT '[]',
-      requirement_ids_json TEXT NOT NULL DEFAULT '[]',
-      matched_keywords_json TEXT NOT NULL DEFAULT '[]',
-      transform_type TEXT NOT NULL,
-      control TEXT NOT NULL,
-      rationale TEXT NOT NULL DEFAULT '',
-      generated_text TEXT NOT NULL,
-      position INTEGER NOT NULL DEFAULT 0,
-      created_at TEXT NOT NULL,
-      coverage_json TEXT,
-      voice_json TEXT,
-      PRIMARY KEY (job_url, generation, bullet_id)
-    );
-    CREATE TABLE IF NOT EXISTS job_material_layout_boxes (
-      job_url TEXT NOT NULL,
-      generation INTEGER NOT NULL,
-      artifact_id TEXT NOT NULL,
-      box_index INTEGER NOT NULL,
-      tenant_id TEXT NOT NULL DEFAULT 'local',
-      semantic_id TEXT NOT NULL,
-      page_number INTEGER NOT NULL,
-      line_number INTEGER,
-      text_excerpt TEXT NOT NULL,
-      left_pct REAL NOT NULL,
-      top_pct REAL NOT NULL,
-      width_pct REAL NOT NULL,
-      height_pct REAL NOT NULL,
-      audit_target_json TEXT NOT NULL DEFAULT '{}',
-      created_at TEXT NOT NULL,
-      PRIMARY KEY (job_url, generation, artifact_id, box_index)
-    );
-  `);
+  void db;
 }
 
 /**
@@ -10558,13 +10122,13 @@ function insertBulletProvenanceRow(
 ): void {
   db.prepare(
     `INSERT OR REPLACE INTO job_bullet_provenance (
-       job_url, generation, bullet_id, tenant_id, artifact_id, section, source_id,
+       tenant_id, job_id, generation, bullet_id, artifact_id, section, source_id,
        evidence_ids_json, requirement_ids_json, matched_keywords_json,
        transform_type, control, rationale, generated_text, position, created_at,
        coverage_json, voice_json
-     ) VALUES (?, ?, ?, 'local', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+     ) VALUES ('local', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   ).run(
-    row.jobUrl,
+    jobIdFor(row.jobUrl),
     row.generation ?? 1,
     row.bulletId,
     row.artifactId,
@@ -10713,10 +10277,10 @@ function insertMaterialsGeneration(
 ): void {
   db.prepare(
     `INSERT OR REPLACE INTO job_materials (
-       job_url, generation, tenant_id, status, created_at, updated_at, metadata_json
-     ) VALUES (?, 1, 'local', ?, ?, ?, ?)`,
+       tenant_id, job_id, generation, status, created_at, updated_at, metadata_json
+     ) VALUES ('local', ?, 1, ?, ?, ?, ?)`,
   ).run(
-    artifact.jobUrl,
+    jobIdFor(artifact.jobUrl),
     artifact.status === "suppressed" ? "suppressed" : "resume_approved",
     "2026-05-26T10:00:00+00:00",
     "2026-05-26T10:00:00+00:00",
@@ -10724,11 +10288,11 @@ function insertMaterialsGeneration(
   );
   db.prepare(
     `INSERT OR REPLACE INTO job_materials_artifacts (
-       job_url, generation, artifact_type, artifact_id, status, path,
+       tenant_id, job_id, generation, artifact_type, artifact_id, status, path,
        render_format, size_bytes, metadata_json, created_at
-     ) VALUES (?, 1, ?, ?, ?, ?, 'text', ?, ?, ?)`,
+     ) VALUES ('local', ?, 1, ?, ?, ?, ?, 'text', ?, ?, ?)`,
   ).run(
-    artifact.jobUrl,
+    jobIdFor(artifact.jobUrl),
     artifact.artifactType,
     artifact.artifactId,
     artifact.status,
@@ -10748,11 +10312,11 @@ function insertStage(
 ): void {
   db.prepare(
     `INSERT INTO job_stage_states (
-      job_url, stage, state, attempt_count, max_attempts, updated_at,
+      tenant_id, job_id, stage, state, attempt_count, max_attempts, updated_at,
       error_code, error_message, retryable, blocked_by_json
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    ) VALUES ('local', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   ).run(
-    jobUrl,
+    jobIdFor(jobUrl),
     stage,
     state,
     state === "failed" ? 1 : 0,

--- a/apps/api/test/server.test.ts
+++ b/apps/api/test/server.test.ts
@@ -6072,7 +6072,10 @@ describe("local TypeScript API", () => {
       message: string;
     };
     db.close();
-    expect(job).toMatchObject({ fit_score: null, scored_at: null });
+    expect(job).toMatchObject({
+      fit_score: 8,
+      scored_at: "2026-04-29T10:02:00+00:00",
+    });
     expect(event).toMatchObject({ stage: "score", level: "info", message: "Retry reset requested for score" });
 
     await app.close();
@@ -6600,7 +6603,8 @@ describe("local TypeScript API", () => {
       enriched_at: string | null;
       extraction_tier: string | null;
     };
-    // Sanity: legacy columns are also nulled (existing behavior).
+    // Retired wide columns remain untouched; exact-v7 state lives in the
+    // canonical enrichment aggregate and stage rows.
     const legacyJob = db
       .prepare(
         "SELECT detail_scraped_at, detail_error FROM jobs WHERE url = ?",
@@ -6616,7 +6620,7 @@ describe("local TypeScript API", () => {
     expect(enrichment.application_url).toBeNull();
     expect(enrichment.enriched_at).toBeNull();
     expect(enrichment.extraction_tier).toBeNull();
-    expect(legacyJob.detail_scraped_at).toBeNull();
+    expect(legacyJob.detail_scraped_at).toBe("2026-04-29T10:01:00+00:00");
     expect(legacyJob.detail_error).toBeNull();
 
     await app.close();
@@ -6624,8 +6628,8 @@ describe("local TypeScript API", () => {
 
   it("retry-enrich is a no-op when no job_enrichments row exists", async () => {
     // Confirm ``resetEnrichmentAggregate`` doesn't crash when the
-    // aggregate row was never written (job in legacy-only state). The
-    // legacy column reset still fires; the JE update is a 0-row UPDATE.
+    // aggregate row was never written. Exact-v7 reset is a 0-row aggregate
+    // update and never falls back to retired wide job columns.
     const app = buildApp(options);
     const jobKey = encodeURIComponent("https://example.com/jobs/blocked-tailor");
     const response = await app.inject({

--- a/apps/api/test/worker-runtime-telemetry.test.ts
+++ b/apps/api/test/worker-runtime-telemetry.test.ts
@@ -5,6 +5,7 @@ import Database from "better-sqlite3";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { readWorkerRuntimeTelemetry } from "../src/worker-runtime-telemetry.js";
+import { initializeExactV7Database } from "./v7-schema.js";
 
 const fixtures: Fixture[] = [];
 
@@ -254,30 +255,8 @@ interface Fixture {
 function createFixture(): Fixture {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "jobctrl-worker-runtime-"));
   const dbPath = path.join(directory, "jobctrl.db");
+  initializeExactV7Database(dbPath);
   const db = new Database(dbPath);
-  db.exec(`
-    CREATE TABLE worker_runtime_heartbeats (
-      worker_id TEXT PRIMARY KEY,
-      component TEXT NOT NULL,
-      pid INTEGER NOT NULL,
-      hostname TEXT NOT NULL,
-      app_dir TEXT NOT NULL,
-      db_path TEXT NOT NULL,
-      task_queue TEXT NOT NULL,
-      started_at TEXT NOT NULL,
-      last_seen_at TEXT NOT NULL,
-      max_concurrent_activities INTEGER,
-      activity_executor_max_workers INTEGER,
-      active_activity_count INTEGER NOT NULL DEFAULT 0,
-      active_activity_counts_json TEXT NOT NULL DEFAULT '{}',
-      active_activity_details_json TEXT NOT NULL DEFAULT '[]',
-      active_activity_details_total INTEGER NOT NULL DEFAULT 0,
-      active_activity_details_truncated INTEGER NOT NULL DEFAULT 0,
-      activity_duration_summary_json TEXT NOT NULL DEFAULT '{}',
-      task_queue_observation_json TEXT,
-      heartbeat_schema_version INTEGER NOT NULL DEFAULT 2
-    )
-  `);
   const fixture = { directory, dbPath, db };
   fixtures.push(fixture);
   return fixture;

--- a/apps/web/e2e/demo-workspace-tests/demo-workspace.spec.ts
+++ b/apps/web/e2e/demo-workspace-tests/demo-workspace.spec.ts
@@ -702,7 +702,9 @@ scenarioTest("Demo guide shortcuts navigate through seeded surfaces and confirm 
   await expect(guide).toContainText("Every record and action in this demo is simulated and synthetic");
 
   await guide.getByRole("link", { name: "Inspect synthetic scoring evidence" }).click();
-  await expect(page).toHaveURL(/\/jobs\/job-northwind-platform(?:\?|$)/);
+  await expect(page).toHaveURL(
+    /\/jobs\/6e2f4a10-20be-4d5f-98a4-a4bb9a877a35(?:\?|$)/,
+  );
   await expect(page.getByText("Preparation diagnostics", { exact: false })).toBeVisible();
   await expect(page.getByRole("article", { name: "Job details" })).toBeVisible();
 
@@ -713,7 +715,9 @@ scenarioTest("Demo guide shortcuts navigate through seeded surfaces and confirm 
 
   await openGuide.click();
   await guide.getByRole("link", { name: "Open simulated Apply Review and dry run" }).click();
-  await expect(page).toHaveURL(/\/apply-review\?jobKey=job-northwind-platform(?:&|$)/);
+  await expect(page).toHaveURL(
+    /\/apply-review\?jobKey=6e2f4a10-20be-4d5f-98a4-a4bb9a877a35(?:&|$)/,
+  );
   await expect(page.getByRole("heading", { name: "Application review" })).toBeVisible();
 
   await openGuide.click();
@@ -784,7 +788,12 @@ scenarioTest("every P2 product route and seeded deep link renders populated acro
   const routes = [
     ["/dashboard", "Dashboard", "3 jobs"],
     ["/jobs", "Jobs", "Platform systems lead"],
-    ["/jobs/job-northwind-platform", "Job details", "Preparation diagnostics", "article"],
+    [
+      "/jobs/6e2f4a10-20be-4d5f-98a4-a4bb9a877a35",
+      "Job details",
+      "Preparation diagnostics",
+      "article",
+    ],
     ["/evidence-map", "Career evidence map", "Delivery improvement evidence"],
     ["/artifacts", "Artifacts", "Platform systems lead"],
     [
@@ -794,7 +803,7 @@ scenarioTest("every P2 product route and seeded deep link renders populated acro
       "article",
     ],
     [
-      "/apply-review?jobKey=job-northwind-platform",
+      "/apply-review?jobKey=6e2f4a10-20be-4d5f-98a4-a4bb9a877a35",
       "Application review",
       "Materials ready",
     ],
@@ -1033,8 +1042,8 @@ scenarioTest("score correction is browser-local, cross-tab visible, reload durab
 
   const second = await context.newPage();
   await Promise.all([
-    page.goto("/jobs/job-northwind-platform"),
-    second.goto("/jobs/job-northwind-platform"),
+    page.goto("/jobs/6e2f4a10-20be-4d5f-98a4-a4bb9a877a35"),
+    second.goto("/jobs/6e2f4a10-20be-4d5f-98a4-a4bb9a877a35"),
   ]);
   await expect(page.getByText("8/10", { exact: true })).toBeVisible();
   await expect(second.getByText("8/10", { exact: true })).toBeVisible();

--- a/apps/web/e2e/demo-workspace-tests/demo-workspace.spec.ts
+++ b/apps/web/e2e/demo-workspace-tests/demo-workspace.spec.ts
@@ -18,7 +18,7 @@ const MODULE_URLS = {
   eventStream: "/src/demo/workspace/DemoWorkspaceEventStreamAdapter.ts",
 } as const;
 const STATIC_HOST = "/demo/source-preview.html";
-const CURRENT_DEMO_SEED_VERSION = "2026-07-12.2";
+const CURRENT_DEMO_SEED_VERSION = "2026-07-31.1";
 const GOOGLE_TAG_ORIGIN = "https://www.googletagmanager.com";
 const GOOGLE_TAG_MEASUREMENT_ID = "G-6MJGD17JN0";
 
@@ -1134,7 +1134,7 @@ scenarioTest("an older seed refreshes once and clears generated browser state", 
     await workspace.mutate((draft) => {
       (draft as unknown as { schemaVersion: number }).schemaVersion = 3;
       (draft as unknown as { seedVersion: string }).seedVersion =
-        "2026-07-11.1";
+        "2026-07-12.2";
       (draft.state as { title: string }).title =
         "Mutated previous synthetic seed";
     });

--- a/apps/web/e2e/fixtures/e2e-state.ts
+++ b/apps/web/e2e/fixtures/e2e-state.ts
@@ -6,6 +6,9 @@ interface E2eState {
   workspace?: { dbPath?: string };
 }
 
+/** Canonical ID emitted for QA_PLATFORM_JOB_URL by the exact-v7 QA seed. */
+export const QA_PLATFORM_JOB_ID = "abaf847c-43cd-40ad-8dc3-76685694ff29";
+
 export function e2eStateFilePath(): string {
   const configured = process.env["JOBCTRL_E2E_STATE_FILE"];
   if (!configured) {

--- a/apps/web/e2e/tests/dry-run.spec.ts
+++ b/apps/web/e2e/tests/dry-run.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from "@playwright/test";
 import Database from "better-sqlite3";
 
-import { loadE2eDbPath } from "../fixtures/e2e-state.js";
+import { loadE2eDbPath, QA_PLATFORM_JOB_ID } from "../fixtures/e2e-state.js";
 
 test("Dry-run apply: seed JobScored event → activity feed reflects new event", async ({
   page,
@@ -19,10 +19,11 @@ test("Dry-run apply: seed JobScored event → activity feed reflects new event",
   const db = new Database(dbPath);
   try {
     db.prepare(
-      `INSERT INTO job_events (job_url, stage, event_type, level, message, occurred_at, payload_json)
-       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      `INSERT INTO job_events (
+         tenant_id, job_id, identity_version, stage, event_type, level, message, occurred_at, payload_json
+       ) VALUES ('local', ?, 1, ?, ?, ?, ?, ?, ?)`,
     ).run(
-      "https://boards.greenhouse.io/gitlab/jobs/qa-platform-director",
+      QA_PLATFORM_JOB_ID,
       "score",
       "JobScored",
       "info",
@@ -30,7 +31,7 @@ test("Dry-run apply: seed JobScored event → activity feed reflects new event",
       occurredAt,
       JSON.stringify({
         tenantId: "local",
-        jobId: "https://boards.greenhouse.io/gitlab/jobs/qa-platform-director",
+        jobId: QA_PLATFORM_JOB_ID,
         fitScore: 9,
         breakdown: {},
         keywords: ["platform"],

--- a/apps/web/e2e/tests/interview-prep.spec.ts
+++ b/apps/web/e2e/tests/interview-prep.spec.ts
@@ -1,9 +1,7 @@
 import { test, expect } from "@playwright/test";
 import Database from "better-sqlite3";
 
-import { loadE2eDbPath } from "../fixtures/e2e-state.js";
-
-const JOB_URL = "https://boards.greenhouse.io/gitlab/jobs/qa-platform-director";
+import { loadE2eDbPath, QA_PLATFORM_JOB_ID } from "../fixtures/e2e-state.js";
 
 function refreshWorkerHeartbeat(dbPath: string): void {
   const db = new Database(dbPath);
@@ -17,72 +15,38 @@ function refreshWorkerHeartbeat(dbPath: string): void {
 function seedAcceptedPrep(dbPath: string, occurredAt: string): void {
   const db = new Database(dbPath);
   try {
-    db.exec(`
-      CREATE TABLE IF NOT EXISTS job_interview_prep (
-        job_url TEXT NOT NULL,
-        generation INTEGER NOT NULL,
-        tenant_id TEXT NOT NULL DEFAULT 'local',
-        status TEXT NOT NULL,
-        model TEXT,
-        generated_at TEXT NOT NULL,
-        gate_status TEXT NOT NULL,
-        fabrication_findings_json TEXT NOT NULL DEFAULT '[]',
-        grounding_findings_json TEXT NOT NULL DEFAULT '[]',
-        judge_verdict TEXT,
-        warnings_json TEXT NOT NULL DEFAULT '[]',
-        failure_reason TEXT NOT NULL DEFAULT '',
-        PRIMARY KEY (job_url, generation)
-      );
-      CREATE TABLE IF NOT EXISTS job_interview_prep_items (
-        job_url TEXT NOT NULL,
-        generation INTEGER NOT NULL,
-        item_id TEXT NOT NULL,
-        tenant_id TEXT NOT NULL DEFAULT 'local',
-        kind TEXT NOT NULL,
-        title TEXT NOT NULL,
-        generated_text TEXT NOT NULL,
-        evidence_ids_json TEXT NOT NULL DEFAULT '[]',
-        requirement_ids_json TEXT NOT NULL DEFAULT '[]',
-        source_text_json TEXT NOT NULL DEFAULT '[]',
-        transform_type TEXT NOT NULL DEFAULT 'grounded_prep',
-        control TEXT NOT NULL DEFAULT 'never_fabricate',
-        grounding_audit_json TEXT NOT NULL DEFAULT '[]',
-        warnings_json TEXT NOT NULL DEFAULT '[]',
-        position INTEGER NOT NULL DEFAULT 0,
-        PRIMARY KEY (job_url, generation, item_id)
-      );
-    `);
     db.prepare(
       `INSERT INTO job_interview_prep (
-         job_url, generation, tenant_id, status, model, generated_at, gate_status,
+         tenant_id, job_id, generation, status, model, generated_at, gate_status,
          fabrication_findings_json, grounding_findings_json, judge_verdict,
          warnings_json, failure_reason
-       ) VALUES (?, 1, 'local', 'accepted', 'e2e-stub', ?, 'passed', '[]', '[]', 'grounded', '[]', '')
-       ON CONFLICT(job_url, generation) DO UPDATE SET
+       ) VALUES ('local', ?, 1, 'accepted', 'e2e-stub', ?, 'passed', '[]', '[]', 'grounded', '[]', '')
+       ON CONFLICT(tenant_id, job_id, generation) DO UPDATE SET
          status = excluded.status,
          model = excluded.model,
          generated_at = excluded.generated_at,
          gate_status = excluded.gate_status,
          judge_verdict = excluded.judge_verdict`,
-    ).run(JOB_URL, occurredAt);
+    ).run(QA_PLATFORM_JOB_ID, occurredAt);
     db.prepare(
       `INSERT INTO job_interview_prep_items (
-         job_url, generation, item_id, tenant_id, kind, title, generated_text,
+         tenant_id, job_id, generation, item_id, kind, title, generated_text,
          evidence_ids_json, requirement_ids_json, source_text_json, transform_type,
          control, grounding_audit_json, warnings_json, position
-       ) VALUES (?, 1, 'prep-e2e-star', 'local', 'star_draft', 'Platform ownership story',
+       ) VALUES ('local', ?, 1, 'prep-e2e-star', 'star_draft', 'Platform ownership story',
          'Use the platform ownership story to answer systems and team-enablement questions.',
          '["ev-platform"]', '["r1"]', '["Owned the developer platform across product teams."]',
          'grounded_prep', 'never_fabricate', '["ev-platform supports the STAR draft."]', '[]', 0)
-       ON CONFLICT(job_url, generation, item_id) DO UPDATE SET
+       ON CONFLICT(tenant_id, job_id, generation, item_id) DO UPDATE SET
          title = excluded.title,
          generated_text = excluded.generated_text`,
-    ).run(JOB_URL);
+    ).run(QA_PLATFORM_JOB_ID);
     db.prepare(
-      `INSERT INTO job_events (job_url, stage, event_type, level, message, occurred_at, payload_json)
-       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      `INSERT INTO job_events (
+         tenant_id, job_id, identity_version, stage, event_type, level, message, occurred_at, payload_json
+       ) VALUES ('local', ?, 1, ?, ?, ?, ?, ?, ?)`,
     ).run(
-      JOB_URL,
+      QA_PLATFORM_JOB_ID,
       "interview_prep",
       "InterviewPrepGenerated",
       "info",
@@ -90,7 +54,7 @@ function seedAcceptedPrep(dbPath: string, occurredAt: string): void {
       occurredAt,
       JSON.stringify({
         tenantId: "local",
-        jobId: JOB_URL,
+        jobId: QA_PLATFORM_JOB_ID,
         generation: 1,
         status: "accepted",
       }),

--- a/apps/web/e2e/tests/jobs-drawer.spec.ts
+++ b/apps/web/e2e/tests/jobs-drawer.spec.ts
@@ -1,11 +1,11 @@
 import Database from "better-sqlite3";
 import { test, expect, type Locator, type Page } from "@playwright/test";
 
+import { QA_PLATFORM_JOB_ID } from "../fixtures/e2e-state.js";
+
 const FILTER_PARAMS =
   "stage=all&state=all&deleted=active&sort=fit_score&dir=desc&page=1&pageSize=50";
 const PLATFORM_JOB_TITLE = "Director of Platform Engineering";
-const PLATFORM_JOB_URL =
-  "https://boards.greenhouse.io/gitlab/jobs/qa-platform-director";
 // Pending-preparation pickup is an existing non-apply Jobs behavior; Phase 22 blocks apply/material/Gmail/destructive paths.
 const PROHIBITED_PRODUCT_PATH_REQUESTS = [
   /\/v1\/jobs\/.+\/actions\/apply$/i,
@@ -50,76 +50,19 @@ function seedSyntheticCompensationData(): void {
   }
   const db = new Database(dbPath);
   try {
-    db.exec(`
-      CREATE TABLE IF NOT EXISTS job_posted_compensation_facts (
-        tenant_id TEXT NOT NULL DEFAULT 'local',
-        job_url TEXT NOT NULL,
-        source_field TEXT NOT NULL DEFAULT 'jobs.salary',
-        source_text TEXT,
-        legacy_raw_salary TEXT,
-        parse_state TEXT NOT NULL,
-        currency TEXT,
-        period TEXT NOT NULL DEFAULT 'unknown',
-        component TEXT NOT NULL DEFAULT 'unknown',
-        minimum_amount INTEGER,
-        maximum_amount INTEGER,
-        annualized_minimum_amount INTEGER,
-        annualized_maximum_amount INTEGER,
-        annualization_assumption TEXT,
-        confidence TEXT NOT NULL DEFAULT 'none',
-        warnings_json TEXT NOT NULL DEFAULT '[]',
-        parser_version TEXT NOT NULL,
-        source_hash TEXT NOT NULL,
-        parsed_at TEXT NOT NULL,
-        PRIMARY KEY (tenant_id, job_url)
-      );
-      CREATE TABLE IF NOT EXISTS job_market_compensation_estimates (
-        tenant_id TEXT NOT NULL DEFAULT 'local',
-        job_url TEXT NOT NULL,
-        estimate_state TEXT NOT NULL,
-        currency TEXT,
-        period TEXT NOT NULL DEFAULT 'year',
-        component TEXT NOT NULL DEFAULT 'total_compensation',
-        minimum_amount INTEGER,
-        maximum_amount INTEGER,
-        confidence_band TEXT NOT NULL DEFAULT 'none',
-        confidence_score REAL NOT NULL DEFAULT 0,
-        source_count INTEGER NOT NULL DEFAULT 0,
-        sample_count INTEGER,
-        aggregate_bucket TEXT,
-        geography_scope TEXT,
-        occupation_code TEXT,
-        occupation_label TEXT,
-        seniority_label TEXT,
-        source_snapshot_json TEXT NOT NULL DEFAULT '[]',
-        factor_reasons_json TEXT NOT NULL DEFAULT '[]',
-        insufficient_reasons_json TEXT NOT NULL DEFAULT '[]',
-        unsupported_reasons_json TEXT NOT NULL DEFAULT '[]',
-        source_unavailable_reasons_json TEXT NOT NULL DEFAULT '[]',
-        warnings_json TEXT NOT NULL DEFAULT '[]',
-        estimator_version TEXT NOT NULL,
-        estimated_at TEXT NOT NULL,
-        company_name TEXT,
-        normalized_company TEXT,
-        role_title TEXT,
-        normalized_role TEXT,
-        company_tier TEXT NOT NULL DEFAULT 'unknown',
-        match_scope TEXT NOT NULL DEFAULT 'none',
-        PRIMARY KEY (tenant_id, job_url)
-      );
-    `);
-    db.prepare("UPDATE jobs SET salary = ? WHERE url = ?").run(
+    db.prepare("UPDATE jobs SET salary = ? WHERE tenant_id = ? AND job_id = ?").run(
       "€55,000/year",
-      PLATFORM_JOB_URL,
+      "local",
+      QA_PLATFORM_JOB_ID,
     );
     db.prepare(
       `INSERT INTO job_posted_compensation_facts (
-        tenant_id, job_url, source_field, source_text, legacy_raw_salary,
+        tenant_id, job_id, source_field, source_text, legacy_raw_salary,
         parse_state, currency, period, component, minimum_amount, maximum_amount,
         annualized_minimum_amount, annualized_maximum_amount, annualization_assumption,
         confidence, warnings_json, parser_version, source_hash, parsed_at
       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-      ON CONFLICT(tenant_id, job_url) DO UPDATE SET
+      ON CONFLICT(tenant_id, job_id) DO UPDATE SET
         source_text = excluded.source_text,
         legacy_raw_salary = excluded.legacy_raw_salary,
         parse_state = excluded.parse_state,
@@ -138,7 +81,7 @@ function seedSyntheticCompensationData(): void {
         parsed_at = excluded.parsed_at`,
     ).run(
       "local",
-      PLATFORM_JOB_URL,
+      QA_PLATFORM_JOB_ID,
       "jobs.salary",
       "€55,000/year",
       "€55,000/year",
@@ -159,7 +102,7 @@ function seedSyntheticCompensationData(): void {
     );
     db.prepare(
       `INSERT INTO job_market_compensation_estimates (
-        tenant_id, job_url, estimate_state, currency, period, component,
+        tenant_id, job_id, estimate_state, currency, period, component,
         minimum_amount, maximum_amount, confidence_band, confidence_score,
         source_count, sample_count, aggregate_bucket, geography_scope,
         occupation_code, occupation_label, seniority_label, source_snapshot_json,
@@ -167,7 +110,7 @@ function seedSyntheticCompensationData(): void {
         source_unavailable_reasons_json, warnings_json, estimator_version, estimated_at,
         company_name, normalized_company, role_title, normalized_role, company_tier, match_scope
       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-      ON CONFLICT(tenant_id, job_url) DO UPDATE SET
+      ON CONFLICT(tenant_id, job_id) DO UPDATE SET
         estimate_state = excluded.estimate_state,
         currency = excluded.currency,
         period = excluded.period,
@@ -193,7 +136,7 @@ function seedSyntheticCompensationData(): void {
         match_scope = excluded.match_scope`,
     ).run(
       "local",
-      PLATFORM_JOB_URL,
+      QA_PLATFORM_JOB_ID,
       "estimated_range",
       "EUR",
       "year",
@@ -262,10 +205,10 @@ function seedSyntheticCompensationData(): void {
        WHERE tenant_id = ? AND profile_id = ?`,
     ).run("EUR", "75000", profileUpdatedAt, "local", "default");
     db.prepare(
-      `INSERT INTO job_events (job_url, stage, event_type, level, message, occurred_at, payload_json)
-       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      `INSERT INTO job_events (
+         tenant_id, job_id, identity_version, stage, event_type, level, message, occurred_at, payload_json
+       ) VALUES ('local', NULL, 1, ?, ?, ?, ?, ?, ?)`,
     ).run(
-      null,
       "profile",
       "ProfileUpdated",
       "info",
@@ -279,10 +222,11 @@ function seedSyntheticCompensationData(): void {
     );
     const compensationUpdatedAt = new Date().toISOString();
     db.prepare(
-      `INSERT INTO job_events (job_url, stage, event_type, level, message, occurred_at, payload_json)
-       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      `INSERT INTO job_events (
+         tenant_id, job_id, identity_version, stage, event_type, level, message, occurred_at, payload_json
+       ) VALUES ('local', ?, 1, ?, ?, ?, ?, ?, ?)`,
     ).run(
-      PLATFORM_JOB_URL,
+      QA_PLATFORM_JOB_ID,
       "compensation",
       "CompensationFactsUpdated",
       "info",
@@ -290,7 +234,7 @@ function seedSyntheticCompensationData(): void {
       compensationUpdatedAt,
       JSON.stringify({
         tenantId: "local",
-        jobId: PLATFORM_JOB_URL,
+        jobId: QA_PLATFORM_JOB_ID,
         changedSections: ["posted", "market"],
         postedRecordStatus: "recorded",
         postedParseState: "parsed_range",

--- a/apps/web/e2e/tests/materials.spec.ts
+++ b/apps/web/e2e/tests/materials.spec.ts
@@ -1,9 +1,7 @@
 import { test, expect } from "@playwright/test";
 import Database from "better-sqlite3";
 
-import { loadE2eDbPath } from "../fixtures/e2e-state.js";
-
-const JOB_URL = "https://boards.greenhouse.io/gitlab/jobs/qa-platform-director";
+import { loadE2eDbPath, QA_PLATFORM_JOB_ID } from "../fixtures/e2e-state.js";
 
 // The seeded worker heartbeat is written once at global-setup; the suite runs
 // serially and can exceed the 45s staleness window before this spec runs. Refresh
@@ -71,10 +69,11 @@ test("Generate materials: button enabled → dispatch queued → ResumeApproved 
   const db = new Database(dbPath);
   try {
     db.prepare(
-      `INSERT INTO job_events (job_url, stage, event_type, level, message, occurred_at, payload_json)
-       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      `INSERT INTO job_events (
+         tenant_id, job_id, identity_version, stage, event_type, level, message, occurred_at, payload_json
+       ) VALUES ('local', ?, 1, ?, ?, ?, ?, ?, ?)`,
     ).run(
-      JOB_URL,
+      QA_PLATFORM_JOB_ID,
       "tailor",
       "ResumeApproved",
       "info",
@@ -82,7 +81,7 @@ test("Generate materials: button enabled → dispatch queued → ResumeApproved 
       occurredAt,
       JSON.stringify({
         tenantId: "local",
-        jobId: JOB_URL,
+        jobId: QA_PLATFORM_JOB_ID,
         artifactId: "qa-e2e-resume",
         generation: 2,
         approvedAt: occurredAt,

--- a/apps/web/e2e/tests/outreach.spec.ts
+++ b/apps/web/e2e/tests/outreach.spec.ts
@@ -1,9 +1,8 @@
 import { expect, test } from "@playwright/test";
 import Database from "better-sqlite3";
 
-import { loadE2eDbPath } from "../fixtures/e2e-state.js";
+import { loadE2eDbPath, QA_PLATFORM_JOB_ID } from "../fixtures/e2e-state.js";
 
-const JOB_URL = "https://boards.greenhouse.io/gitlab/jobs/qa-platform-director";
 const CONTACT_ID = "contact-e2e-outreach";
 const CONTACT_THREAD_ID = "thread-e2e-contact";
 const DUE_THREAD_ID = "thread-e2e-due";
@@ -28,155 +27,6 @@ function tableExists(db: Database.Database, table: string): boolean {
     .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?")
     .get(table);
   return Boolean(row);
-}
-
-function ensureColumn(
-  db: Database.Database,
-  table: string,
-  column: string,
-  definition: string,
-): void {
-  const columns = new Set(
-    (
-      db.prepare(`PRAGMA table_info(${table})`).all() as Array<{ name: string }>
-    ).map((row) => row.name),
-  );
-  if (!columns.has(column)) {
-    db.exec(`ALTER TABLE ${table} ADD COLUMN ${column} ${definition}`);
-  }
-}
-
-function ensureOutreachSeedTables(db: Database.Database): void {
-  db.exec(`
-    CREATE TABLE IF NOT EXISTS contacts (
-      tenant_id   TEXT NOT NULL DEFAULT 'local',
-      contact_id  TEXT NOT NULL,
-      employer    TEXT,
-      job_url     TEXT,
-      role        TEXT NOT NULL DEFAULT 'other',
-      created_at  TEXT NOT NULL,
-      updated_at  TEXT NOT NULL,
-      deleted_at  TEXT,
-      PRIMARY KEY (tenant_id, contact_id)
-    );
-    CREATE TABLE IF NOT EXISTS contact_attributes (
-      tenant_id      TEXT NOT NULL DEFAULT 'local',
-      attribute_id   TEXT NOT NULL,
-      contact_id     TEXT NOT NULL,
-      attribute_kind TEXT NOT NULL,
-      value_json     TEXT,
-      source_kind    TEXT NOT NULL,
-      source_ref     TEXT NOT NULL,
-      capture_method TEXT NOT NULL,
-      confidence     REAL NOT NULL DEFAULT 0,
-      user_confirmed INTEGER NOT NULL DEFAULT 0,
-      recorded_at    TEXT NOT NULL,
-      PRIMARY KEY (tenant_id, attribute_id)
-    );
-    CREATE TABLE IF NOT EXISTS contact_research_tasks (
-      tenant_id            TEXT NOT NULL DEFAULT 'local',
-      task_id              TEXT NOT NULL,
-      employer             TEXT,
-      job_url              TEXT,
-      status               TEXT NOT NULL DEFAULT 'queued',
-      source_attempts_json TEXT NOT NULL DEFAULT '[]',
-      started_at           TEXT,
-      updated_at           TEXT NOT NULL,
-      needs_review_at      TEXT,
-      completed_at         TEXT,
-      failed_at            TEXT,
-      error_class          TEXT,
-      PRIMARY KEY (tenant_id, task_id)
-    );
-    CREATE TABLE IF NOT EXISTS contact_candidates (
-      tenant_id            TEXT NOT NULL DEFAULT 'local',
-      candidate_id         TEXT NOT NULL,
-      task_id              TEXT NOT NULL,
-      role                 TEXT NOT NULL DEFAULT 'other',
-      attributes_json      TEXT,
-      source_kind          TEXT NOT NULL,
-      source_ref           TEXT NOT NULL,
-      capture_method       TEXT NOT NULL,
-      confidence           REAL NOT NULL DEFAULT 0,
-      status               TEXT NOT NULL DEFAULT 'needs_review',
-      proposed_at          TEXT NOT NULL,
-      confirmed_contact_id TEXT,
-      confirmed_at         TEXT,
-      PRIMARY KEY (tenant_id, candidate_id)
-    );
-    CREATE TABLE IF NOT EXISTS outreach_threads (
-      tenant_id        TEXT NOT NULL DEFAULT 'local',
-      thread_id        TEXT NOT NULL,
-      contact_id       TEXT NOT NULL,
-      job_url          TEXT,
-      created_at       TEXT NOT NULL,
-      updated_at       TEXT NOT NULL,
-      follow_up_due_at TEXT,
-      follow_up_basis  TEXT,
-      follow_up_state  TEXT NOT NULL DEFAULT 'none',
-      PRIMARY KEY (tenant_id, thread_id)
-    );
-    CREATE TABLE IF NOT EXISTS outreach_drafts (
-      tenant_id         TEXT NOT NULL DEFAULT 'local',
-      draft_id          TEXT NOT NULL,
-      thread_id         TEXT NOT NULL,
-      generation        INTEGER NOT NULL DEFAULT 1,
-      kind              TEXT NOT NULL,
-      status            TEXT NOT NULL DEFAULT 'candidate',
-      body_text         TEXT,
-      gate_results_json TEXT,
-      provenance_json   TEXT,
-      created_at        TEXT NOT NULL,
-      approved_at       TEXT,
-      rejected_at       TEXT,
-      reason            TEXT,
-      PRIMARY KEY (tenant_id, draft_id)
-    );
-    CREATE TABLE IF NOT EXISTS outreach_send_logs (
-      tenant_id        TEXT NOT NULL DEFAULT 'local',
-      send_log_id      TEXT NOT NULL,
-      thread_id        TEXT NOT NULL,
-      draft_id         TEXT NOT NULL,
-      channel          TEXT NOT NULL,
-      sent_at          TEXT NOT NULL,
-      logged_at        TEXT NOT NULL,
-      PRIMARY KEY (tenant_id, send_log_id)
-    );
-    CREATE TABLE IF NOT EXISTS application_outcomes (
-      tenant_id     TEXT NOT NULL DEFAULT 'local',
-      outcome_id    TEXT NOT NULL,
-      job_key       TEXT NOT NULL,
-      kind          TEXT NOT NULL,
-      source        TEXT NOT NULL,
-      note          TEXT,
-      occurred_at   TEXT NOT NULL,
-      recorded_at   TEXT NOT NULL,
-      suggestion_id TEXT,
-      evidence_id   TEXT,
-      interview_prep_generation INTEGER,
-      created_by    TEXT NOT NULL DEFAULT 'user',
-      PRIMARY KEY (tenant_id, outcome_id)
-    );
-  `);
-  ensureColumn(db, "application_outcomes", "note", "TEXT");
-  ensureColumn(db, "application_outcomes", "suggestion_id", "TEXT");
-  ensureColumn(db, "application_outcomes", "evidence_id", "TEXT");
-  ensureColumn(
-    db,
-    "application_outcomes",
-    "interview_prep_generation",
-    "INTEGER",
-  );
-  ensureColumn(
-    db,
-    "application_outcomes",
-    "created_by",
-    "TEXT NOT NULL DEFAULT 'user'",
-  );
-  if (tableExists(db, "job_events")) {
-    ensureColumn(db, "job_events", "entity_kind", "TEXT");
-    ensureColumn(db, "job_events", "entity_ref", "TEXT");
-  }
 }
 
 function resetOutreachSeed(db: Database.Database): void {
@@ -223,14 +73,13 @@ function resetOutreachSeed(db: Database.Database): void {
 function seedOutreachPlanner(dbPath: string): void {
   const db = new Database(dbPath);
   try {
-    ensureOutreachSeedTables(db);
     resetOutreachSeed(db);
 
     db.prepare(
       `INSERT INTO contacts (
-         tenant_id, contact_id, employer, job_url, role, created_at, updated_at, deleted_at
+         tenant_id, contact_id, employer, job_id, role, created_at, updated_at, deleted_at
        ) VALUES ('local', ?, 'GitLab', ?, 'recruiter', ?, ?, NULL)`,
-    ).run(CONTACT_ID, JOB_URL, NOW, NOW);
+    ).run(CONTACT_ID, QA_PLATFORM_JOB_ID, NOW, NOW);
     const insertAttribute = db.prepare(
       `INSERT INTO contact_attributes (
          tenant_id, attribute_id, contact_id, attribute_kind, value_json,
@@ -261,12 +110,12 @@ function seedOutreachPlanner(dbPath: string): void {
 
     db.prepare(
       `INSERT INTO contact_research_tasks (
-         tenant_id, task_id, employer, job_url, status, source_attempts_json,
+         tenant_id, task_id, employer, job_id, status, source_attempts_json,
          started_at, updated_at, needs_review_at, completed_at, failed_at, error_class
        ) VALUES ('local', ?, 'GitLab', ?, 'needs_review', ?, ?, ?, ?, NULL, NULL, NULL)`,
     ).run(
       TASK_ID,
-      JOB_URL,
+      QA_PLATFORM_JOB_ID,
       JSON.stringify([
         {
           sourceKind: "public_web_page",
@@ -329,7 +178,7 @@ function seedOutreachPlanner(dbPath: string): void {
 
     const insertThread = db.prepare(
       `INSERT INTO outreach_threads (
-         tenant_id, thread_id, contact_id, job_url, created_at, updated_at,
+         tenant_id, thread_id, contact_id, job_id, created_at, updated_at,
          follow_up_due_at, follow_up_basis, follow_up_state
        ) VALUES ('local', ?, ?, ?, ?, ?, ?, ?, ?)`,
     );
@@ -346,7 +195,7 @@ function seedOutreachPlanner(dbPath: string): void {
     insertThread.run(
       DUE_THREAD_ID,
       CONTACT_ID,
-      JOB_URL,
+      QA_PLATFORM_JOB_ID,
       NOW,
       NOW,
       PAST_DUE_AT,
@@ -356,7 +205,7 @@ function seedOutreachPlanner(dbPath: string): void {
     insertThread.run(
       FUTURE_THREAD_ID,
       CONTACT_ID,
-      JOB_URL,
+      QA_PLATFORM_JOB_ID,
       NOW,
       NOW,
       FUTURE_DUE_AT,
@@ -455,11 +304,11 @@ function seedOutreachPlanner(dbPath: string): void {
     ).run(CONTACT_THREAD_ID, NOW);
     db.prepare(
       `INSERT INTO application_outcomes (
-         tenant_id, outcome_id, job_key, kind, source, note, occurred_at, recorded_at,
+         tenant_id, outcome_id, job_id, kind, source, note, occurred_at, recorded_at,
          suggestion_id, evidence_id, interview_prep_generation, created_by
        ) VALUES ('local', 'outcome-e2e-outreach', ?, 'applied_confirmation', 'e2e_seed',
          NULL, '2026-07-01T12:00:00.000Z', ?, NULL, NULL, NULL, 'e2e')`,
-    ).run(JOB_URL, NOW);
+    ).run(QA_PLATFORM_JOB_ID, NOW);
 
     // This fixture writes canonical rows directly. Clear the derived read
     // models so the next public API read rematerializes every outreach surface

--- a/apps/web/e2e/tests/repeat-application.spec.ts
+++ b/apps/web/e2e/tests/repeat-application.spec.ts
@@ -6,12 +6,15 @@ import Database from "better-sqlite3";
 
 import {
   loadE2eDbPath,
+  QA_PLATFORM_JOB_ID,
   refreshE2eWorkerHeartbeat,
 } from "../fixtures/e2e-state.js";
 
 const TARGET = "https://boards.greenhouse.io/gitlab/jobs/qa-platform-director";
 const PRIOR = "https://alternate.example.test/gitlab/qa-platform-director";
 const CANONICAL = "https://boards.greenhouse.io/gitlab/jobs/qa-platform-director-canonical";
+const TARGET_JOB_ID = QA_PLATFORM_JOB_ID;
+const PRIOR_JOB_ID = "10000000-0000-4000-8000-000000000045";
 const CONFIRMED_AT = "2026-07-20T08:00:00.000Z";
 type DatabaseRow = Record<string, unknown>;
 type RepeatApplicationTable =
@@ -29,10 +32,10 @@ function repeatApplicationTablesExist(db: Database.Database): boolean {
 
 function clearRepeatApplicationState(db: Database.Database): void {
   db.prepare(
-    "DELETE FROM application_repeat_override_consumptions WHERE override_id IN (SELECT override_id FROM application_repeat_overrides WHERE target_job_key = ?)",
-  ).run(TARGET);
-  db.prepare("DELETE FROM application_repeat_audit WHERE target_job_key = ?").run(TARGET);
-  db.prepare("DELETE FROM application_repeat_overrides WHERE target_job_key = ?").run(TARGET);
+    "DELETE FROM application_repeat_override_consumptions WHERE override_id IN (SELECT override_id FROM application_repeat_overrides WHERE target_job_id = ?)",
+  ).run(TARGET_JOB_ID);
+  db.prepare("DELETE FROM application_repeat_audit WHERE target_job_id = ?").run(TARGET_JOB_ID);
+  db.prepare("DELETE FROM application_repeat_overrides WHERE target_job_id = ?").run(TARGET_JOB_ID);
 }
 
 function restoreRows(
@@ -55,81 +58,83 @@ test("repeat application block and reasoned override reach only the simulated su
 }) => {
   const dbPath = loadE2eDbPath();
   const db = new Database(dbPath);
-  const hadCanonicalIdentityTable = Boolean(
-    db
-      .prepare("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?")
-      .get("job_canonical_identities"),
-  );
-  db.exec(`
-    CREATE TABLE IF NOT EXISTS job_canonical_identities (
-      tenant_id TEXT NOT NULL DEFAULT 'local',
-      job_url TEXT NOT NULL,
-      canonical_url TEXT NOT NULL,
-      ats_kind TEXT NOT NULL,
-      source_native_id TEXT NOT NULL,
-      confidence REAL NOT NULL,
-      resolved_at TEXT NOT NULL,
-      PRIMARY KEY (tenant_id, job_url),
-      FOREIGN KEY (job_url) REFERENCES jobs(url) ON DELETE CASCADE
+  const originalIdentity = db
+    .prepare(
+      "SELECT * FROM job_canonical_identities WHERE tenant_id = 'local' AND job_id = ?",
     )
-  `);
-  const originalIdentity = hadCanonicalIdentityTable
-    ? (db
-        .prepare(
-          "SELECT * FROM job_canonical_identities WHERE tenant_id = 'local' AND job_url = ?",
-        )
-        .get(TARGET) as Record<string, unknown> | undefined)
-    : undefined;
+    .get(TARGET_JOB_ID) as Record<string, unknown> | undefined;
   const originalApplyStage = db
-    .prepare("SELECT * FROM job_stage_states WHERE job_url = ? AND stage = 'apply'")
-    .get(TARGET) as Record<string, unknown> | undefined;
+    .prepare("SELECT * FROM job_stage_states WHERE tenant_id = 'local' AND job_id = ? AND stage = 'apply'")
+    .get(TARGET_JOB_ID) as Record<string, unknown> | undefined;
   const hasRepeatApplicationTables = repeatApplicationTablesExist(db);
   const originalRepeatOverrides = hasRepeatApplicationTables
     ? (db
         .prepare(
-          "SELECT * FROM application_repeat_overrides WHERE tenant_id = 'local' AND target_job_key = ?",
+          "SELECT * FROM application_repeat_overrides WHERE tenant_id = 'local' AND target_job_id = ?",
         )
-        .all(TARGET) as Array<Record<string, unknown>>)
+        .all(TARGET_JOB_ID) as Array<Record<string, unknown>>)
     : [];
   const originalRepeatOverrideConsumptions = hasRepeatApplicationTables
     ? (db
         .prepare(
           `SELECT c.*
              FROM application_repeat_override_consumptions c
-             JOIN application_repeat_overrides o
-               ON o.tenant_id = c.tenant_id AND o.override_id = c.override_id
-            WHERE o.tenant_id = 'local' AND o.target_job_key = ?`,
+            JOIN application_repeat_overrides o
+              ON o.tenant_id = c.tenant_id AND o.override_id = c.override_id
+            WHERE o.tenant_id = 'local' AND o.target_job_id = ?`,
         )
-        .all(TARGET) as Array<Record<string, unknown>>)
+        .all(TARGET_JOB_ID) as Array<Record<string, unknown>>)
     : [];
   const originalRepeatAudit = hasRepeatApplicationTables
     ? (db
         .prepare(
-          "SELECT * FROM application_repeat_audit WHERE tenant_id = 'local' AND target_job_key = ?",
+          "SELECT * FROM application_repeat_audit WHERE tenant_id = 'local' AND target_job_id = ?",
         )
-        .all(TARGET) as Array<Record<string, unknown>>)
+        .all(TARGET_JOB_ID) as Array<Record<string, unknown>>)
     : [];
-  let originalTargetApplication: Record<string, unknown> | undefined;
-
+  const originalTargetConfirmedEvents = db
+    .prepare(
+      `SELECT event_id, event_type FROM job_events
+        WHERE tenant_id = 'local' AND job_id = ?
+          AND event_type IN ('ApplicationSubmitted', 'ApplicationManuallyMarked')`,
+    )
+    .all(TARGET_JOB_ID) as Array<{ event_id: number; event_type: string }>;
+  const originalTargetAppliedOutcomes = db
+    .prepare(
+      `SELECT outcome_id, kind FROM application_outcomes
+        WHERE tenant_id = 'local' AND job_id = ? AND kind = 'applied_confirmation'`,
+    )
+    .all(TARGET_JOB_ID) as Array<{ outcome_id: string; kind: string }>;
+  let originalTargetJob: Record<string, unknown> | undefined;
   try {
     if (hasRepeatApplicationTables) clearRepeatApplicationState(db);
-    const target = db.prepare("SELECT * FROM jobs WHERE url = ?").get(TARGET) as Record<
+    const target = db.prepare("SELECT * FROM jobs WHERE tenant_id = 'local' AND job_id = ?").get(TARGET_JOB_ID) as Record<
       string,
       unknown
     >;
     if (!target) throw new Error("QA target job is missing");
-    originalTargetApplication = {
-      apply_status: target.apply_status,
-      applied_at: target.applied_at,
-    };
-    db.prepare("UPDATE jobs SET apply_status = 'applied', applied_at = ? WHERE url = ?").run(
-      CONFIRMED_AT,
-      TARGET,
+    originalTargetJob = target;
+    db.prepare(
+      `UPDATE job_events SET event_type = 'RepeatApplicationFixtureSuppressed'
+        WHERE tenant_id = 'local' AND job_id = ?
+          AND event_type IN ('ApplicationSubmitted', 'ApplicationManuallyMarked')`,
+    ).run(TARGET_JOB_ID);
+    db.prepare(
+      `UPDATE application_outcomes SET kind = 'unknown'
+        WHERE tenant_id = 'local' AND job_id = ? AND kind = 'applied_confirmation'`,
+    ).run(TARGET_JOB_ID);
+    db.prepare(
+      `UPDATE jobs SET company = 'GitLab', apply_status = NULL, applied_at = NULL
+        WHERE tenant_id = 'local' AND job_id = ?`,
+    ).run(
+      TARGET_JOB_ID,
     );
     const prior: Record<string, unknown> = {
       ...target,
+      job_id: PRIOR_JOB_ID,
       url: PRIOR,
       application_url: `${PRIOR}/apply`,
+      company: "GitLab",
       apply_status: "applied",
       applied_at: CONFIRMED_AT,
     };
@@ -140,44 +145,29 @@ test("repeat application block and reasoned override reach only the simulated su
     ).run(...columns.map((column) => prior[column]));
     db.prepare(
       `INSERT INTO job_events
-       (job_url, stage, event_type, level, message, occurred_at, payload_json)
-       VALUES (?, 'apply', 'ApplicationSubmitted', 'info',
+       (tenant_id, job_id, identity_version, stage, event_type, level, message, occurred_at, payload_json)
+       VALUES ('local', ?, 1, 'apply', 'ApplicationSubmitted', 'info',
                'Simulated prior application confirmation', ?, ?)`,
-    ).run(PRIOR, CONFIRMED_AT, JSON.stringify({ run_id: "e2e-prior-run" }));
-    const targetProjection = db
-      .prepare("SELECT * FROM job_list_projections WHERE tenant_id = 'local' AND job_id = ?")
-      .get(TARGET) as Record<string, unknown> | undefined;
-    if (targetProjection) {
-      const priorProjection: Record<string, unknown> = {
-        ...targetProjection,
-        job_id: PRIOR,
-      };
-      const columns = Object.keys(priorProjection);
-      db.prepare(
-        `INSERT OR REPLACE INTO job_list_projections
-         (${columns.map((column) => `"${column}"`).join(", ")})
-         VALUES (${columns.map(() => "?").join(", ")})`,
-      ).run(...columns.map((column) => priorProjection[column]));
-    }
+    ).run(PRIOR_JOB_ID, CONFIRMED_AT, JSON.stringify({ run_id: "e2e-prior-run" }));
     const identity = db.prepare(
       `INSERT OR REPLACE INTO job_canonical_identities
-       (tenant_id, job_url, canonical_url, ats_kind, source_native_id, confidence, resolved_at)
+       (tenant_id, job_id, canonical_url, ats_kind, source_native_id, confidence, resolved_at)
        VALUES ('local', ?, ?, 'greenhouse', 'qa-platform-director', 1, ?)`,
     );
-    identity.run(TARGET, CANONICAL, CONFIRMED_AT);
-    identity.run(PRIOR, CANONICAL, CONFIRMED_AT);
+    identity.run(TARGET_JOB_ID, CANONICAL, CONFIRMED_AT);
+    identity.run(PRIOR_JOB_ID, CANONICAL, CONFIRMED_AT);
 
-    await page.goto(`/apply-review?jobKey=${encodeURIComponent(TARGET)}`);
+    await page.goto(`/apply-review?jobKey=${encodeURIComponent(TARGET_JOB_ID)}`);
     await expect(page.getByText("Repeat application blocked", { exact: true })).toBeVisible();
     await expect(
       page.getByText("matching canonical ATS identity", { exact: true }),
     ).toBeVisible();
     const priorApplicationLink = page.getByRole("link", {
-      name: `Inspect prior application: ${PRIOR}`,
+      name: `Inspect prior application: ${PRIOR_JOB_ID}`,
     });
     await expect(priorApplicationLink).toHaveAttribute(
       "href",
-      `/jobs/${encodeURIComponent(PRIOR)}`,
+      `/jobs/${encodeURIComponent(PRIOR_JOB_ID)}`,
     );
     await expect(page.getByRole("button", { name: /Authorize live submit/i })).toBeDisabled();
     const trustedMutationHeaders = {
@@ -186,16 +176,27 @@ test("repeat application block and reasoned override reach only the simulated su
     };
 
     const blocked = await request.post(
-      `/v1/jobs/${encodeURIComponent(TARGET)}/actions/apply`,
+      `/v1/jobs/${encodeURIComponent(TARGET_JOB_ID)}/actions/apply`,
       { data: { dryRun: false }, headers: trustedMutationHeaders },
     );
     expect(blocked.status()).toBe(409);
     expect(await blocked.json()).toMatchObject({ error: "repeat_application_blocked" });
+    await expect(page.getByLabel("Reason for another live attempt")).toHaveCount(0);
+    await expect(page.getByRole("button", { name: "Confirm one live attempt" })).toHaveCount(0);
+
+    db.prepare(
+      "DELETE FROM job_canonical_identities WHERE tenant_id = 'local' AND job_id IN (?, ?)",
+    ).run(TARGET_JOB_ID, PRIOR_JOB_ID);
+    await page.reload();
+    await expect(
+      page.getByText("Review prior application before live submit", { exact: true }),
+    ).toBeVisible();
+    await expect(page.getByText("same employer and equivalent role", { exact: true })).toBeVisible();
 
     await page.getByLabel("Reason for another live attempt").fill(
       "The prior application was withdrawn before review; this retry is intentional.",
     );
-    await page.getByRole("radio", { name: `Confirm prior application: ${PRIOR}` }).check();
+    await page.getByRole("radio", { name: `Confirm prior application: ${PRIOR_JOB_ID}` }).check();
     await page.getByRole("button", { name: "Confirm one live attempt" }).click();
     await expect(
       page.getByText("Repeat application confirmation recorded", { exact: true }),
@@ -213,7 +214,7 @@ test("repeat application block and reasoned override reach only the simulated su
     // the seeded heartbeat's freshness window before reaching this request.
     refreshE2eWorkerHeartbeat();
     const acceptedBySimulation = await request.post(
-      `/v1/jobs/${encodeURIComponent(TARGET)}/actions/apply`,
+      `/v1/jobs/${encodeURIComponent(TARGET_JOB_ID)}/actions/apply`,
       { data: { dryRun: false }, headers: trustedMutationHeaders },
     );
     expect(acceptedBySimulation.status()).toBe(202);
@@ -231,7 +232,7 @@ from jobctrl.apply.launcher import acquire_job
 from jobctrl.database import get_connection, init_db
 from jobctrl.state import set_stage_state
 
-target = sys.argv[1]
+target_job_id = sys.argv[1]
 init_db()
 run_ctx = {
     "dry_run": False,
@@ -239,7 +240,7 @@ run_ctx = {
     "workflow_id": "e2e-repeat-application",
 }
 job = acquire_job(
-    target_url=target,
+    target_job_id=target_job_id,
     worker_id=91,
     run_ctx=run_ctx,
     approval_required=False,
@@ -247,13 +248,13 @@ job = acquire_job(
 if job is None:
     raise SystemExit("authoritative worker claim was refused unexpectedly")
 conn = get_connection()
-set_stage_state(conn, target, "apply", "pending", validate_transition=False)
+set_stage_state(conn, target_job_id, "apply", "pending", validate_transition=False)
 conn.commit()
 print(job["url"])
 `;
     const workerOutput = execFileSync(
       pythonExecutable,
-      ["-c", workerClaimScript, TARGET],
+      ["-c", workerClaimScript, TARGET_JOB_ID],
       {
         cwd: repositoryRoot,
         encoding: "utf8",
@@ -272,7 +273,7 @@ print(job["url"])
     await expect(page.getByRole("button", { name: /Authorize live submit/i })).toBeDisabled();
 
     const refusedAfterConsumption = await request.post(
-      `/v1/jobs/${encodeURIComponent(TARGET)}/actions/apply`,
+      `/v1/jobs/${encodeURIComponent(TARGET_JOB_ID)}/actions/apply`,
       { data: { dryRun: false }, headers: trustedMutationHeaders },
     );
     expect(refusedAfterConsumption.status()).toBe(409);
@@ -282,36 +283,45 @@ print(job["url"])
 
     const override = db
       .prepare(
-        `SELECT override_id, target_job_key, prior_job_key, evidence_fingerprint, reason, confirmed_by, confirmed_at
+        `SELECT override_id, target_job_id, prior_job_id, evidence_fingerprint, reason, confirmed_by, confirmed_at
            FROM application_repeat_overrides
-          WHERE tenant_id = 'local' AND target_job_key = ?
+          WHERE tenant_id = 'local' AND target_job_id = ?
           ORDER BY confirmed_at DESC LIMIT 1`,
       )
-      .get(TARGET) as Record<string, unknown>;
+      .get(TARGET_JOB_ID) as Record<string, unknown>;
     expect(override).toMatchObject({
-      target_job_key: TARGET,
-      prior_job_key: PRIOR,
+      target_job_id: TARGET_JOB_ID,
+      prior_job_id: PRIOR_JOB_ID,
       confirmed_by: "user",
     });
     expect(String(override.reason)).toContain("withdrawn before review");
+    expect(
+      db
+        .prepare(
+          `SELECT COUNT(*) AS count
+             FROM application_repeat_audit
+            WHERE tenant_id = 'local' AND target_job_id = ? AND action = 'blocked'`,
+        )
+        .get(TARGET_JOB_ID),
+    ).toMatchObject({ count: 1 });
     const auditRows = db
       .prepare(
         `SELECT action, evidence_fingerprint, override_id
            FROM application_repeat_audit
           WHERE tenant_id = 'local'
-            AND target_job_key = ?
+            AND target_job_id = ?
             AND evidence_fingerprint = ?
-            AND action IN ('blocked', 'override_recorded', 'override_consumed')
+            AND action IN ('confirmation_required', 'override_recorded', 'override_consumed')
           ORDER BY CASE action
-            WHEN 'blocked' THEN 1
+            WHEN 'confirmation_required' THEN 1
             WHEN 'override_recorded' THEN 2
             WHEN 'override_consumed' THEN 3
           END`,
       )
-      .all(TARGET, override.evidence_fingerprint) as Array<Record<string, unknown>>;
+      .all(TARGET_JOB_ID, override.evidence_fingerprint) as Array<Record<string, unknown>>;
     expect(auditRows).toEqual([
       {
-        action: "blocked",
+        action: "confirmation_required",
         evidence_fingerprint: override.evidence_fingerprint,
         override_id: null,
       },
@@ -344,15 +354,15 @@ print(job["url"])
       db
         .prepare(
           `SELECT COUNT(*) AS count FROM job_events
-            WHERE job_url = ? AND event_type = 'ApplicationSubmitted'`,
+            WHERE tenant_id = 'local' AND job_id = ? AND event_type = 'ApplicationSubmitted'`,
         )
-        .get(TARGET),
+        .get(TARGET_JOB_ID),
     ).toMatchObject({ count: 0 });
   } finally {
     db.prepare(
-      "DELETE FROM job_events WHERE job_url = ? AND payload_json LIKE '%e2e-worker-repeat-claim%'",
-    ).run(TARGET);
-    db.prepare("DELETE FROM job_stage_states WHERE job_url = ? AND stage = 'apply'").run(TARGET);
+      "DELETE FROM job_events WHERE tenant_id = 'local' AND job_id = ? AND payload_json LIKE '%e2e-worker-repeat-claim%'",
+    ).run(TARGET_JOB_ID);
+    db.prepare("DELETE FROM job_stage_states WHERE tenant_id = 'local' AND job_id = ? AND stage = 'apply'").run(TARGET_JOB_ID);
     if (originalApplyStage) {
       const columns = Object.keys(originalApplyStage);
       db.prepare(
@@ -371,8 +381,8 @@ print(job["url"])
       restoreRows(db, "application_repeat_audit", originalRepeatAudit);
     }
     db.prepare(
-      "DELETE FROM job_canonical_identities WHERE tenant_id = 'local' AND job_url IN (?, ?)",
-    ).run(TARGET, PRIOR);
+      "DELETE FROM job_canonical_identities WHERE tenant_id = 'local' AND job_id IN (?, ?)",
+    ).run(TARGET_JOB_ID, PRIOR_JOB_ID);
     if (originalIdentity) {
       const columns = Object.keys(originalIdentity);
       db.prepare(
@@ -380,19 +390,32 @@ print(job["url"])
          VALUES (${columns.map(() => "?").join(", ")})`,
       ).run(...columns.map((column) => originalIdentity[column]));
     }
-    if (!hadCanonicalIdentityTable) {
-      db.exec("DROP TABLE job_canonical_identities");
-    }
-    db.prepare("DELETE FROM job_events WHERE job_url = ?").run(PRIOR);
+    db.prepare("DELETE FROM job_events WHERE tenant_id = 'local' AND job_id = ?").run(PRIOR_JOB_ID);
     db.prepare("DELETE FROM job_list_projections WHERE tenant_id = 'local' AND job_id = ?").run(
-      PRIOR,
+      PRIOR_JOB_ID,
     );
-    db.prepare("DELETE FROM jobs WHERE url = ?").run(PRIOR);
-    if (originalTargetApplication) {
-      db.prepare("UPDATE jobs SET apply_status = ?, applied_at = ? WHERE url = ?").run(
-        originalTargetApplication.apply_status,
-        originalTargetApplication.applied_at,
-        TARGET,
+    db.prepare("DELETE FROM jobs WHERE tenant_id = 'local' AND job_id = ?").run(PRIOR_JOB_ID);
+    if (originalTargetJob) {
+      db.prepare(
+        `UPDATE jobs SET company = ?, apply_status = ?, applied_at = ?
+          WHERE tenant_id = 'local' AND job_id = ?`,
+      ).run(
+        originalTargetJob.company,
+        originalTargetJob.apply_status,
+        originalTargetJob.applied_at,
+        TARGET_JOB_ID,
+      );
+    }
+    for (const event of originalTargetConfirmedEvents) {
+      db.prepare("UPDATE job_events SET event_type = ? WHERE event_id = ?").run(
+        event.event_type,
+        event.event_id,
+      );
+    }
+    for (const outcome of originalTargetAppliedOutcomes) {
+      db.prepare("UPDATE application_outcomes SET kind = ? WHERE outcome_id = ?").run(
+        outcome.kind,
+        outcome.outcome_id,
       );
     }
     db.close();

--- a/apps/web/e2e/tests/route-visual-qa.spec.ts
+++ b/apps/web/e2e/tests/route-visual-qa.spec.ts
@@ -1,6 +1,7 @@
 import { expect, type Locator, type Page, test } from "@playwright/test";
 import type { ApplyReviewQueueResponse } from "@jobctrl/contracts";
 
+import { QA_PLATFORM_JOB_ID } from "../fixtures/e2e-state.js";
 import {
   makeApplyAudit,
   makeJobsPage,
@@ -2318,7 +2319,7 @@ test("Apply Review requirement-fit card has visual regression coverage", async (
 }) => {
   await installDeterministicRequirementFitScrollbars(page);
   await page.goto(
-    `/apply-review?jobKey=${encodeURIComponent(REQUIREMENT_FIT_JOB_URL)}`,
+    `/apply-review?jobKey=${encodeURIComponent(QA_PLATFORM_JOB_ID)}`,
   );
   const selectedApplication = page.locator(".apply-review-selected");
   await expect(selectedApplication).toBeVisible({ timeout: 30_000 });

--- a/apps/web/src/contexts/enrichment/components/CompensationEvidence.tsx
+++ b/apps/web/src/contexts/enrichment/components/CompensationEvidence.tsx
@@ -2,16 +2,16 @@ import { IconRefresh } from "@tabler/icons-react";
 import { type FormEvent, useState } from "react";
 import type {
   JobCompensationAudit,
+  JobCompensationAuditMarketEstimate,
+  JobCompensationAuditPostedFact,
   JobCompensationSummary,
   JobMarketCompensationSummary,
   JobPostedCompensationSummary,
-  MarketCompensationEstimate,
   MarketCompensationEvidenceRow,
   MarketCompensationFactor,
   MarketCompensationReason,
   MarketCompensationSourceSnapshot,
   MarketCompensationWarning,
-  PostedCompensationFact,
   PostedCompensationWarning,
 } from "@jobctrl/contracts";
 
@@ -370,7 +370,7 @@ function ReasonList({
   );
 }
 
-function MarketReasonLists({ estimate }: { readonly estimate: MarketCompensationEstimate }) {
+function MarketReasonLists({ estimate }: { readonly estimate: JobCompensationAuditMarketEstimate }) {
   if (estimate.estimateState === "unsupported") {
     return <ReasonList title="Unsupported reasons" reasons={estimate.unsupportedReasons} />;
   }
@@ -475,7 +475,7 @@ function PostedPanel({
   fact,
 }: {
   readonly posted: JobPostedCompensationSummary;
-  readonly fact: PostedCompensationFact | null;
+  readonly fact: JobCompensationAuditPostedFact | null;
 }) {
   return (
     <article className="compensation-panel">
@@ -504,7 +504,7 @@ function MarketPanel({
   estimate,
 }: {
   readonly market: JobMarketCompensationSummary;
-  readonly estimate: MarketCompensationEstimate | null;
+  readonly estimate: JobCompensationAuditMarketEstimate | null;
 }) {
   const score = estimate ? formatPercent(estimate.confidenceScore) : formatPercent(market.confidenceScore);
   return (

--- a/apps/web/src/demo/DemoApiClientAdapter.test.ts
+++ b/apps/web/src/demo/DemoApiClientAdapter.test.ts
@@ -136,11 +136,13 @@ const READ_CASES = [
   ["applyReviewQueue", (api: ApiClientPort) => api.applyReviewQueue()],
   [
     "resumeReviewDraft",
-    (api: ApiClientPort) => api.resumeReviewDraft("job-northwind-platform"),
+    (api: ApiClientPort) =>
+      api.resumeReviewDraft("6e2f4a10-20be-4d5f-98a4-a4bb9a877a35"),
   ],
   [
     "resumeReviewFeedback",
-    (api: ApiClientPort) => api.resumeReviewFeedback("job-northwind-platform"),
+    (api: ApiClientPort) =>
+      api.resumeReviewFeedback("6e2f4a10-20be-4d5f-98a4-a4bb9a877a35"),
   ],
   ["resumeTemplates", (api: ApiClientPort) => api.resumeTemplates()],
   [
@@ -151,10 +153,14 @@ const READ_CASES = [
   [
     "jobApplicationOutcomes",
     (api: ApiClientPort) =>
-      api.jobApplicationOutcomes("job-northwind-platform"),
+      api.jobApplicationOutcomes("6e2f4a10-20be-4d5f-98a4-a4bb9a877a35"),
   ],
   ["jobs", (api: ApiClientPort) => api.jobs()],
-  ["job", (api: ApiClientPort) => api.job("job-northwind-platform")],
+  [
+    "job",
+    (api: ApiClientPort) =>
+      api.job("6e2f4a10-20be-4d5f-98a4-a4bb9a877a35"),
+  ],
   ["evidenceMap", (api: ApiClientPort) => api.evidenceMap()],
   ["workflowRuns", (api: ApiClientPort) => api.workflowRuns()],
   [
@@ -270,12 +276,15 @@ describe("DemoApiClientAdapter", () => {
     expect((await adapter.jobs()).items[0]!.title).not.toBe("caller mutation");
 
     await repository.mutate((draft) => {
-      draft.state.readModel.jobs.details["job-northwind-platform"]!.job.title =
-        "authoritative update";
+      draft.state.readModel.jobs.details[
+        "6e2f4a10-20be-4d5f-98a4-a4bb9a877a35"
+      ]!.job.title = "authoritative update";
     });
-    expect((await adapter.job("job-northwind-platform")).job.title).toBe(
-      "authoritative update",
-    );
+    expect(
+      (
+        await adapter.job("6e2f4a10-20be-4d5f-98a4-a4bb9a877a35")
+      ).job.title,
+    ).toBe("authoritative update");
   });
 
   it("resolves synchronous previews only from current repository authority", async () => {
@@ -705,7 +714,7 @@ describe("DemoApiClientAdapter", () => {
 
     await expect(
       adapter.listContacts({
-        jobId: "job-northwind-platform",
+        jobId: "6e2f4a10-20be-4d5f-98a4-a4bb9a877a35",
         employer: "Northwind Workshop",
       }),
     ).resolves.toMatchObject({
@@ -715,7 +724,9 @@ describe("DemoApiClientAdapter", () => {
       adapter.listContacts({ employer: "northwind workshop" }),
     ).resolves.toEqual({ ok: true, items: [] });
     await expect(
-      adapter.researchTasks({ jobId: "job-northwind-platform" }),
+      adapter.researchTasks({
+        jobId: "6e2f4a10-20be-4d5f-98a4-a4bb9a877a35",
+      }),
     ).resolves.toMatchObject({
       items: [{ taskId: "research-demo-hiring-partner" }],
     });
@@ -805,7 +816,7 @@ describe("DemoApiClientAdapter", () => {
   it("resolves every seeded dynamic detail and returns stable 404 errors for unknown IDs", async () => {
     const { adapter } = await createAdapter();
     for (const jobKey of [
-      "job-northwind-platform",
+      "6e2f4a10-20be-4d5f-98a4-a4bb9a877a35",
       "job-contoso-reliability",
       "job-fabrikam-systems",
     ]) {

--- a/apps/web/src/demo/DemoExternalRehearsalExecutor.test.ts
+++ b/apps/web/src/demo/DemoExternalRehearsalExecutor.test.ts
@@ -14,7 +14,7 @@ import {
 } from "./workspace/index.js";
 
 const NOW = "2026-07-11T12:00:00.000Z";
-const JOB = "job-northwind-platform";
+const JOB = "6e2f4a10-20be-4d5f-98a4-a4bb9a877a35";
 const ARTIFACT = "artifact-tailored-resume";
 
 afterEach(() => {

--- a/apps/web/src/demo/DemoLocalCommandExecutor.test.ts
+++ b/apps/web/src/demo/DemoLocalCommandExecutor.test.ts
@@ -40,7 +40,7 @@ type LocalCase = readonly [
   (api: ApiClientPort, repository: DemoWorkspaceRepository) => Promise<unknown>,
 ];
 
-const JOB = "job-northwind-platform";
+const JOB = "6e2f4a10-20be-4d5f-98a4-a4bb9a877a35";
 const BULK = { jobKeys: [JOB], allMatching: false };
 
 const ACTION_RESPONSE_KEYS = [

--- a/apps/web/src/demo/DemoLocalCommandExecutor.ts
+++ b/apps/web/src/demo/DemoLocalCommandExecutor.ts
@@ -455,7 +455,11 @@ export class DemoLocalCommandExecutor {
         );
         draft.state.readModel.discovery.manualCapture.items =
           draft.state.readModel.discovery.manualCapture.items.filter((candidate) => candidate.itemId !== itemId);
-        const baseDetail = structuredClone(draft.state.readModel.jobs.details["job-northwind-platform"]!);
+        const baseDetail = structuredClone(
+          draft.state.readModel.jobs.details[
+            "6e2f4a10-20be-4d5f-98a4-a4bb9a877a35"
+          ]!,
+        );
         const importedJob = {
           ...structuredClone(baseDetail.job),
           jobKey,

--- a/apps/web/src/demo/DemoScenarioEngine.test.ts
+++ b/apps/web/src/demo/DemoScenarioEngine.test.ts
@@ -175,21 +175,21 @@ describe("DemoScenarioEngine", () => {
   it("returns production-shaped results for every simulated-async operation", async () => {
     const cases = [
       { name: "renderResumeReviewDraft", delay: 600, invoke: (engine: DemoScenarioEngine) => engine.execute("renderResumeReviewDraft", ["draft-tailored-resume", {}]) },
-      { name: "ensureCurrentResumeMaterials", delay: 750, invoke: (engine: DemoScenarioEngine) => engine.execute("ensureCurrentResumeMaterials", ["job-northwind-platform", { force: true }]) },
+      { name: "ensureCurrentResumeMaterials", delay: 750, invoke: (engine: DemoScenarioEngine) => engine.execute("ensureCurrentResumeMaterials", ["6e2f4a10-20be-4d5f-98a4-a4bb9a877a35", { force: true }]) },
       { name: "retryFailedJobs", delay: 0, invoke: (engine: DemoScenarioEngine) => engine.execute("retryFailedJobs", [{ jobKeys: ["job-contoso-reliability"], allMatching: false, runAfter: false, workers: 1, minScore: 7, validationMode: "normal", dryRun: false, llmModel: "simulated" }]) },
       { name: "runPendingPreparation", delay: 0, invoke: (engine: DemoScenarioEngine) => engine.execute("runPendingPreparation", [{ jobKeys: ["job-contoso-reliability"], allMatching: false, workers: 1, minScore: 7, validationMode: "normal", dryRun: false, llmModel: "simulated" }]) },
       { name: "rescoreJob", delay: 550, invoke: (engine: DemoScenarioEngine) => engine.execute("rescoreJob", ["job-fabrikam-systems", {}]) },
       { name: "rescoreJobsNotOnCurrentScoringPolicy", delay: 700, invoke: (engine: DemoScenarioEngine) => engine.execute("rescoreJobsNotOnCurrentScoringPolicy", [{ limit: 100, jobKeys: ["job-fabrikam-systems"], dryRun: false }]) },
-      { name: "retailorJob", delay: 850, invoke: (engine: DemoScenarioEngine) => engine.execute("retailorJob", ["job-northwind-platform", {}]) },
-      { name: "tailorJob", delay: 850, invoke: (engine: DemoScenarioEngine) => engine.execute("tailorJob", ["job-northwind-platform", {}]) },
-      { name: "retailorCurrentPolicy", delay: 900, invoke: (engine: DemoScenarioEngine) => engine.execute("retailorCurrentPolicy", [{ limit: 100, jobKeys: ["job-northwind-platform"], dryRun: false, suppressExistingArtifacts: true, tailorModels: [] }]) },
+      { name: "retailorJob", delay: 850, invoke: (engine: DemoScenarioEngine) => engine.execute("retailorJob", ["6e2f4a10-20be-4d5f-98a4-a4bb9a877a35", {}]) },
+      { name: "tailorJob", delay: 850, invoke: (engine: DemoScenarioEngine) => engine.execute("tailorJob", ["6e2f4a10-20be-4d5f-98a4-a4bb9a877a35", {}]) },
+      { name: "retailorCurrentPolicy", delay: 900, invoke: (engine: DemoScenarioEngine) => engine.execute("retailorCurrentPolicy", [{ limit: 100, jobKeys: ["6e2f4a10-20be-4d5f-98a4-a4bb9a877a35"], dryRun: false, suppressExistingArtifacts: true, tailorModels: [] }]) },
       { name: "runPipelineStages", delay: 650, invoke: (engine: DemoScenarioEngine) => engine.execute("runPipelineStages", [{ stages: ["discover"], limit: 25, workers: 1, minScore: 7, validationMode: "normal", dryRun: true, rescore: false, retailor: false, headless: false, model: "default", llmModel: "simulated", tailorModels: [], continuous: false }]) },
-      { name: "generateOutreachDraft", delay: 700, invoke: (engine: DemoScenarioEngine) => engine.execute("generateOutreachDraft", ["contact-demo-hiring-partner", { jobId: "job-northwind-platform", kind: "intro_request" }]) },
+      { name: "generateOutreachDraft", delay: 700, invoke: (engine: DemoScenarioEngine) => engine.execute("generateOutreachDraft", ["contact-demo-hiring-partner", { jobId: "6e2f4a10-20be-4d5f-98a4-a4bb9a877a35", kind: "intro_request" }]) },
       { name: "reviseOutreachDraft", delay: 700, invoke: (engine: DemoScenarioEngine) => engine.execute("reviseOutreachDraft", ["thread-demo", { editedBodyText: "Bounded revision." }]) },
       { name: "retryStage", delay: 650, invoke: (engine: DemoScenarioEngine) => engine.execute("retryStage", ["job-fabrikam-systems", { stage: "score", resetAttempts: false, runAfter: true, dryRun: false }]) },
       { name: "runJobStage", delay: 650, invoke: (engine: DemoScenarioEngine) => engine.execute("runJobStage", ["job-fabrikam-systems", { stage: "score", dryRun: false, limit: 1, workers: 1, minScore: 7, validationMode: "normal", llmModel: "simulated" }]) },
-      { name: "generateMaterials", delay: 850, invoke: (engine: DemoScenarioEngine) => engine.execute("generateMaterials", ["job-northwind-platform", { stages: ["tailor"], dryRun: false, limit: 1 }]) },
-      { name: "generateInterviewPrep", delay: 800, invoke: (engine: DemoScenarioEngine) => engine.execute("generateInterviewPrep", ["job-northwind-platform", {}]) },
+      { name: "generateMaterials", delay: 850, invoke: (engine: DemoScenarioEngine) => engine.execute("generateMaterials", ["6e2f4a10-20be-4d5f-98a4-a4bb9a877a35", { stages: ["tailor"], dryRun: false, limit: 1 }]) },
+      { name: "generateInterviewPrep", delay: 800, invoke: (engine: DemoScenarioEngine) => engine.execute("generateInterviewPrep", ["6e2f4a10-20be-4d5f-98a4-a4bb9a877a35", {}]) },
     ] as const;
 
     expect(cases.map((entry) => entry.name)).toEqual([
@@ -296,7 +296,7 @@ describe("DemoScenarioEngine", () => {
     const initialRevision = (await fixture.repository.snapshot()).revision;
     await expect(
       fixture.engine.execute("ensureCurrentResumeMaterials", [
-        "job-northwind-platform",
+        "6e2f4a10-20be-4d5f-98a4-a4bb9a877a35",
         { force: false },
       ]),
     ).resolves.toMatchObject({ status: "not_required", generation: 1 });

--- a/apps/web/src/demo/DemoScenarioEngine.ts
+++ b/apps/web/src/demo/DemoScenarioEngine.ts
@@ -927,7 +927,7 @@ function applyInterviewProjection(
   if (!template) return;
   target.interviewPrep = {
     ...structuredClone(template),
-    jobKey,
+    jobId: jobKey,
     generation: (target.interviewPrep?.generation ?? 0) + 1,
     generatedAt: now,
     model: "simulated",

--- a/apps/web/src/demo/consent/DemoTelemetryAdapter.test.ts
+++ b/apps/web/src/demo/consent/DemoTelemetryAdapter.test.ts
@@ -54,7 +54,9 @@ describe("DemoTelemetryAdapter", () => {
       referrer: () => "https://jobctrl.dev/private?query=value",
     });
 
-    adapter.sessionStarted("/jobs/job-northwind-platform?secret=value");
+    adapter.sessionStarted(
+      "/jobs/6e2f4a10-20be-4d5f-98a4-a4bb9a877a35?secret=value",
+    );
     adapter.routeViewed("/artifacts/artifact-tailored-resume");
     await Promise.resolve();
     const bodies = fetcher.mock.calls.map((call) => String(call[1]?.body));

--- a/apps/web/src/demo/contracts.ts
+++ b/apps/web/src/demo/contracts.ts
@@ -254,7 +254,7 @@ export interface DemoReadModel {
 
 export interface DemoSeedValue {
   readonly schemaVersion: 1;
-  readonly seedVersion: "2026-07-12.2";
+  readonly seedVersion: "2026-07-31.1";
   readonly title: string;
   readonly artifacts: DemoArtifacts;
   readonly readModel: DemoReadModel;

--- a/apps/web/src/demo/demo-seed.test.ts
+++ b/apps/web/src/demo/demo-seed.test.ts
@@ -24,7 +24,7 @@ describe("canonical public demo seed", () => {
 
   it("is deterministic, immutable by type, and covers the required lifecycle arms", () => {
     expect(() => assertDemoSeedInvariants(DEMO_SEED)).not.toThrow();
-    expect(demoSeedDigest(DEMO_SEED)).toBe("fnv1a-53eb35c5");
+    expect(demoSeedDigest(DEMO_SEED)).toBe("fnv1a-9182aa0d");
     expect(demoSeedDigest({ b: 2, a: ["seed", true] })).toBe(demoSeedDigest({ a: ["seed", true], b: 2 }));
   });
 

--- a/apps/web/src/demo/demo-seed.test.ts
+++ b/apps/web/src/demo/demo-seed.test.ts
@@ -24,7 +24,7 @@ describe("canonical public demo seed", () => {
 
   it("is deterministic, immutable by type, and covers the required lifecycle arms", () => {
     expect(() => assertDemoSeedInvariants(DEMO_SEED)).not.toThrow();
-    expect(demoSeedDigest(DEMO_SEED)).toBe("fnv1a-9182aa0d");
+    expect(demoSeedDigest(DEMO_SEED)).toBe("fnv1a-3e6d6ec9");
     expect(demoSeedDigest({ b: 2, a: ["seed", true] })).toBe(demoSeedDigest({ a: ["seed", true], b: 2 }));
   });
 

--- a/apps/web/src/demo/guide/DemoGuide.test.tsx
+++ b/apps/web/src/demo/guide/DemoGuide.test.tsx
@@ -118,7 +118,10 @@ describe("<DemoGuide>", () => {
     );
     expect(
       screen.getByRole("link", { name: "Inspect synthetic scoring evidence" }),
-    ).toHaveAttribute("href", "/jobs/job-northwind-platform");
+    ).toHaveAttribute(
+      "href",
+      "/jobs/6e2f4a10-20be-4d5f-98a4-a4bb9a877a35",
+    );
     expect(
       screen.getByRole("link", { name: "Review synthetic tailored materials" }),
     ).toHaveAttribute("href", "/artifacts/artifact-tailored-resume");
@@ -126,7 +129,10 @@ describe("<DemoGuide>", () => {
       screen.getByRole("link", {
         name: "Open simulated Apply Review and dry run",
       }),
-    ).toHaveAttribute("href", "/apply-review?jobKey=job-northwind-platform");
+    ).toHaveAttribute(
+      "href",
+      "/apply-review?jobKey=6e2f4a10-20be-4d5f-98a4-a4bb9a877a35",
+    );
     expect(
       screen.getByRole("link", { name: "See simulated run history" }),
     ).toHaveAttribute("href", "/runs");
@@ -136,7 +142,7 @@ describe("<DemoGuide>", () => {
     );
     await waitFor(() => {
       expect(router.state.location.pathname).toBe(
-        "/jobs/job-northwind-platform",
+        "/jobs/6e2f4a10-20be-4d5f-98a4-a4bb9a877a35",
       );
     });
     expect((ports.telemetry as FakeTelemetryPort).event).toHaveBeenCalledWith(

--- a/apps/web/src/demo/guide/DemoGuide.tsx
+++ b/apps/web/src/demo/guide/DemoGuide.tsx
@@ -23,7 +23,7 @@ import {
 } from "../../shared/ui/dialog.js";
 
 const GUIDE_STATE_KEY = "demo.guide.state";
-const DEMO_JOB_ID = "job-northwind-platform";
+const DEMO_JOB_ID = "6e2f4a10-20be-4d5f-98a4-a4bb9a877a35";
 const DEMO_ARTIFACT_ID = "artifact-tailored-resume";
 
 type DemoGuideFeature = "scoring" | "materials" | "apply_review" | "pipeline";

--- a/apps/web/src/demo/purgeDemoJobProjections.test.ts
+++ b/apps/web/src/demo/purgeDemoJobProjections.test.ts
@@ -12,7 +12,7 @@ import {
   type DemoWorkspaceSnapshot,
 } from "./workspace/index.js";
 
-const JOB = "job-northwind-platform";
+const JOB = "6e2f4a10-20be-4d5f-98a4-a4bb9a877a35";
 const OTHER_JOB = "job-contoso-reliability";
 const JOB_URL = "demo-job:northwind-platform";
 const NOW = "2026-07-11T12:00:00.000Z";

--- a/apps/web/src/demo/read-model.ts
+++ b/apps/web/src/demo/read-model.ts
@@ -240,7 +240,7 @@ const clearRepeatApplication = {
 } satisfies DemoReadModel["apply"]["queue"]["items"][number]["repeatApplication"];
 
 const interviewPrep = {
-  jobKey: job.jobKey,
+  jobId: job.jobKey,
   generation: 1,
   status: "accepted",
   generatedAt: at("2026-07-10T10:00:00.000Z"),

--- a/apps/web/src/demo/read-model.ts
+++ b/apps/web/src/demo/read-model.ts
@@ -11,7 +11,7 @@ const REFERENCE_TIME_MS = Date.parse(REFERENCE_TIME);
 const at = (value: string) => demoTimestamp(Math.round((Date.parse(value) - REFERENCE_TIME_MS) / 60_000));
 
 const job = {
-  jobKey: "job-northwind-platform",
+  jobKey: "6e2f4a10-20be-4d5f-98a4-a4bb9a877a35",
   url: "demo-job:northwind-platform",
   title: "Platform systems lead",
   company: "Northwind Workshop",

--- a/apps/web/src/demo/seed.ts
+++ b/apps/web/src/demo/seed.ts
@@ -29,7 +29,7 @@ const demoSeed = {
     ],
     jobs: [
       {
-        id: "job-northwind-platform",
+        id: "6e2f4a10-20be-4d5f-98a4-a4bb9a877a35",
         title: "Platform systems lead",
         state: "accepted",
         at: minutes(-1440),

--- a/apps/web/src/demo/seed.ts
+++ b/apps/web/src/demo/seed.ts
@@ -6,7 +6,7 @@ const minutes = (offsetMinutes: number) => ({ offsetMinutes }) as const;
 
 const demoSeed = {
   schemaVersion: 1,
-  seedVersion: "2026-07-12.2",
+  seedVersion: "2026-07-31.1",
   title: "JobCtrl product tour",
   artifacts: DEMO_ARTIFACTS,
   readModel: DEMO_READ_MODEL,

--- a/apps/web/src/demo/workspace/DemoReceiptHistory.test.tsx
+++ b/apps/web/src/demo/workspace/DemoReceiptHistory.test.tsx
@@ -63,7 +63,7 @@ describe("<DemoReceiptHistory>", () => {
             didNotDo: "No test application was submitted.",
             operation: "applyJob",
             entityType: "job",
-            entityId: "job-northwind-platform",
+            entityId: "6e2f4a10-20be-4d5f-98a4-a4bb9a877a35",
           });
       });
     });

--- a/apps/web/src/demo/workspace/DemoWorkspaceRepository.test.ts
+++ b/apps/web/src/demo/workspace/DemoWorkspaceRepository.test.ts
@@ -387,7 +387,7 @@ describe("DemoWorkspaceRepository", () => {
     const staleSnapshot: DemoWorkspaceSnapshot = {
       ...baseline.snapshot,
       schemaVersion: 3,
-      seedVersion: "2026-07-11.1",
+      seedVersion: "2026-07-12.2",
       workspaceId: "workspace-stale-seed",
       resetCount: 2,
       resetEpoch: 4,

--- a/apps/web/src/demo/workspace/DemoWorkspaceRepository.ts
+++ b/apps/web/src/demo/workspace/DemoWorkspaceRepository.ts
@@ -1002,7 +1002,11 @@ function workspaceUpgrade(
   return null;
 }
 
-const REFRESHABLE_DEMO_SEED_VERSIONS = new Set(["2026-07-11.1", "2026-07-12.1"]);
+const REFRESHABLE_DEMO_SEED_VERSIONS = new Set([
+  "2026-07-11.1",
+  "2026-07-12.1",
+  "2026-07-12.2",
+]);
 
 /** Only reviewed legacy fixtures may be destructively replaced. */
 function classifyDemoSeedVersion(

--- a/apps/web/src/test/fixtures/materials-inspector.ts
+++ b/apps/web/src/test/fixtures/materials-inspector.ts
@@ -112,7 +112,7 @@ export const emptyEmployerAnalysis: EmployerAnalysis = {
 };
 
 export const populatedRequirementFitReport: RequirementFitReport = {
-  jobKey: "job-1",
+  jobId: "job-1",
   scoreVersion: 4,
   employerAnalysisGeneration: populatedEmployerAnalysis.generation,
   profileSnapshotVersion: 7,

--- a/apps/web/src/test/fixtures/projections.ts
+++ b/apps/web/src/test/fixtures/projections.ts
@@ -142,7 +142,7 @@ export const sampleCompensationAudit: JobCompensationAudit = {
     recordStatus: "recorded",
     fact: {
       tenantId: "local",
-      jobKey: "job-2",
+      jobId: "job-2",
       sourceField: "salary",
       legacyRawSalary: "EUR 70000-90000/year",
       sourceText: "EUR 70000-90000/year",
@@ -167,7 +167,7 @@ export const sampleCompensationAudit: JobCompensationAudit = {
     recordStatus: "recorded",
     estimate: {
       tenantId: "local",
-      jobKey: "job-2",
+      jobId: "job-2",
       estimateState: "estimated_range",
       confidenceBand: "medium",
       confidenceScore: 0.82,
@@ -822,7 +822,7 @@ export const sampleJobAuditHistory: JobAuditEntry[] = [
 ];
 
 export const sampleInterviewPrep: InterviewPrep = {
-  jobKey: sampleJob.jobKey,
+  jobId: sampleJob.jobKey,
   generation: 1,
   status: "accepted",
   generatedAt: "2026-05-03T09:30:00Z",

--- a/apps/web/src/views/apply-review/ApplyReviewView.test.tsx
+++ b/apps/web/src/views/apply-review/ApplyReviewView.test.tsx
@@ -1097,7 +1097,7 @@ describe("<ApplyReviewView>", () => {
       items: [
         {
           ...sampleApplyReviewQueue.items[0]!,
-          jobKey: "job-northwind-platform",
+          jobKey: "6e2f4a10-20be-4d5f-98a4-a4bb9a877a35",
           title: "Platform systems lead",
           company: "Northwind Workshop",
         },

--- a/apps/web/test/types/evidenceInterviewContracts.test-d.ts
+++ b/apps/web/test/types/evidenceInterviewContracts.test-d.ts
@@ -35,7 +35,7 @@ test("interview-prep contracts expose generated prep only, never live session st
   }>();
 
   expectTypeOf<InterviewPrep>().toMatchTypeOf<{
-    jobKey: string;
+    jobId: string;
     generation: number;
     status: InterviewPrepStatus;
     items: InterviewPrepItem[];


### PR DESCRIPTION
## Summary

- align compensation audit, interview prep, and requirement-fit consumers with canonical `jobId` contracts
- update synthetic demo projections and fixtures without adding compatibility aliases
- persist the QA platform employer explicitly so exact-v7 artifact projections remain truthful
- advance the demo seed revision and prove safe refresh from the immediate predecessor

## Validation

- full workspace TypeScript check
- 76 focused web/demo tests
- 13 type-contract assertions
- production web build
- targeted Chromium predecessor-seed refresh
- cumulative hosted API regression files: 45 passed
- independent review: PASS, no findings
- independent QA: PASS, no Blocker/High/Medium findings

## Stack

Ready-for-review child of #639 in GitHub Stack #632.
