### PR TITLE
fix(ci): admit stacked pull request checks

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -9,19 +9,13 @@ on:
       - "pyproject.toml"
       - ".github/workflows/python.yml"
   pull_request:
-    branches: ["main"]
-    paths:
-      - "workers/**"
-      - "scripts/**"
-      - "pyproject.toml"
-      - ".github/workflows/python.yml"
   workflow_dispatch:
 
 jobs:
   python:
-    # Same-repository stacks are trusted to run hosted CI; public forks retain
-    # the maintainer-reviewed manual validation path documented in CONTRIBUTING.
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+    # Run hosted dependencies and product tests only for the trusted cumulative
+    # head. Lower stack layers retain their no-cost skipped check record.
+    if: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && (github.event_name != 'pull_request' || github.event.pull_request.stack == null || github.event.pull_request.stack.position == github.event.pull_request.stack.size) }}
     name: Python (workers/automation)
     runs-on: ubuntu-latest
     strategy:
@@ -29,9 +23,7 @@ jobs:
       # every supported Python version owns an independent product result.
       fail-fast: false
       matrix:
-        # Every matching stack layer gets the 3.11 correctness lane. The top
-        # layer contains the cumulative stack and also exercises compatibility.
-        python-version: ${{ fromJSON(github.event_name == 'pull_request' && github.event.pull_request.stack != null && github.event.pull_request.stack.position != github.event.pull_request.stack.size && '["3.11"]' || '["3.11","3.12","3.13"]') }}
+        python-version: ["3.11", "3.12", "3.13"]
 
     steps:
       - name: Checkout
@@ -41,6 +33,8 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: workers/automation/pyproject.toml
 
       - name: Install dependencies
         run: pip install -e "workers/automation[dev,providers]"
@@ -78,9 +72,6 @@ jobs:
           fi
 
       - name: Test
-        # Approved stack layers can be intentionally non-installable review
-        # slices. Exercise the product suite only on a cumulative head.
-        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.stack == null || github.event.pull_request.stack.position == github.event.pull_request.stack.size }}
         run: pytest workers/automation/tests -v
 
       - name: Build package

--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -11,21 +11,13 @@ on:
       - "pnpm-workspace.yaml"
       - ".github/workflows/typescript.yml"
   pull_request:
-    branches: ["main"]
-    paths:
-      - "apps/**"
-      - "packages/**"
-      - "pnpm-lock.yaml"
-      - "package.json"
-      - "pnpm-workspace.yaml"
-      - ".github/workflows/typescript.yml"
   workflow_dispatch:
 
 jobs:
   typescript:
-    # Same-repository stacks are trusted to run hosted CI; public forks retain
-    # the maintainer-reviewed manual validation path documented in CONTRIBUTING.
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+    # Run hosted dependencies and product tests only for the trusted cumulative
+    # head. Lower stack layers retain their no-cost skipped check record.
+    if: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && (github.event_name != 'pull_request' || github.event.pull_request.stack == null || github.event.pull_request.stack.position == github.event.pull_request.stack.size) }}
     name: TypeScript (apps + packages)
     runs-on: ubuntu-latest
 
@@ -43,13 +35,11 @@ jobs:
           cache: pnpm
 
       - name: Set up Python
-        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.stack == null || github.event.pull_request.stack.position == github.event.pull_request.stack.size }}
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
 
       - name: Install uv
-        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.stack == null || github.event.pull_request.stack.position == github.event.pull_request.stack.size }}
         run: python -m pip install uv
 
       - name: Install dependencies
@@ -58,43 +48,29 @@ jobs:
       - name: Check
         run: pnpm -r check
 
-      # Product suites and builds require the cumulative stack. Lower layers
-      # retain dependency installation and static workspace checks as fast
-      # admission checks.
       - name: Test
-        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.stack == null || github.event.pull_request.stack.position == github.event.pull_request.stack.size }}
         run: pnpm --filter @jobctrl/api test
 
       - name: Test web
-        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.stack == null || github.event.pull_request.stack.position == github.event.pull_request.stack.size }}
         run: pnpm --filter @jobctrl/web test
 
       - name: Test web types
-        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.stack == null || github.event.pull_request.stack.position == github.event.pull_request.stack.size }}
         run: pnpm --filter @jobctrl/web test-d
 
       - name: Build web
-        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.stack == null || github.event.pull_request.stack.position == github.event.pull_request.stack.size }}
         run: pnpm --filter @jobctrl/web build
 
-      # Browser and Storybook suites exercise the cumulative top layer. The
-      # null guard keeps full coverage for ordinary, non-stack pull requests.
       - name: Build web storybook
-        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.stack == null || github.event.pull_request.stack.position == github.event.pull_request.stack.size }}
         run: pnpm --filter @jobctrl/web storybook:build
 
       - name: Install Playwright Chromium
-        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.stack == null || github.event.pull_request.stack.position == github.event.pull_request.stack.size }}
         run: pnpm --filter @jobctrl/web exec playwright install --with-deps chromium
 
       - name: Install Python Playwright Chromium
-        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.stack == null || github.event.pull_request.stack.position == github.event.pull_request.stack.size }}
         run: uv --project workers/automation run playwright install chromium
 
       - name: Test web e2e
-        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.stack == null || github.event.pull_request.stack.position == github.event.pull_request.stack.size }}
         run: pnpm --filter @jobctrl/web e2e
 
       - name: Test web storybook
-        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.stack == null || github.event.pull_request.stack.position == github.event.pull_request.stack.size }}
         run: pnpm --filter @jobctrl/web storybook:test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,10 +50,10 @@ JOBCTRL_DIR=/tmp/jobctrl-qa corepack pnpm dev
   not for pull requests from public forks. Run the relevant local validation
   before opening a PR; maintainers run manual workflows or local checks for
   fork contributions after reviewing the change.
-- GitHub Stacks run matching fast admission and static checks on every layer.
-  Those checks include the Python sdist/wheel smoke build. Product test suites,
-  Python compatibility lanes, cumulative web builds, and the browser/Storybook
-  suites run on the top layer, whose head contains the cumulative stack.
+- GitHub Stacks leave dependency-heavy Python and TypeScript jobs skipped on
+  non-top layers. The cumulative top layer runs the full Python compatibility
+  matrix, packages, web builds, product tests, and browser/Storybook suites.
+  Use targeted local validation while reviewing a lower layer.
 
 ## Developer Certificate of Origin Sign-Off
 

--- a/scripts/stacked-ci-workflows.test.mjs
+++ b/scripts/stacked-ci-workflows.test.mjs
@@ -33,6 +33,7 @@ const sameRepositoryPullRequest =
   "github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository";
 const topOfStack =
   "github.event_name != 'pull_request' || github.event.pull_request.stack == null || github.event.pull_request.stack.position == github.event.pull_request.stack.size";
+const trustedTopOfStack = `(${sameRepositoryPullRequest}) && (${topOfStack})`;
 
 const findStep = (job, name) => {
   const step = job.steps.find((candidate) => candidate.name === name);
@@ -40,67 +41,58 @@ const findStep = (job, name) => {
   return step;
 };
 
-test("same-repository pull requests targeting main admit correctness workflows", async () => {
+test("stacked pull requests always instantiate the Python and TypeScript admission workflows", async () => {
   const specs = [
-    { workflowName: "python", jobName: "python", pathFiltered: true },
-    { workflowName: "typescript", jobName: "typescript", pathFiltered: true },
-    { workflowName: "docs-site", jobName: "build", pathFiltered: true },
-    { workflowName: "release-check", jobName: "release-check", pathFiltered: false },
+    { workflowName: "python", jobName: "python" },
+    { workflowName: "typescript", jobName: "typescript" },
   ];
 
   for (const spec of specs) {
     const workflow = await parseWorkflow(spec.workflowName);
-    assert.deepEqual(
-      workflow.on.pull_request.branches,
-      ["main"],
-      `${spec.workflowName} must admit every GitHub Stack layer as targeting main`,
+    assert.equal(
+      workflow.on.pull_request,
+      null,
+      `${spec.workflowName} must not suppress stacked PRs by their direct base branch or changed paths`,
     );
     assert.equal(
       workflow.jobs[spec.jobName].if,
-      `\${{ ${sameRepositoryPullRequest} }}`,
-      `${spec.workflowName} must continue to reject untrusted fork execution`,
+      `\${{ ${trustedTopOfStack} }}`,
+      `${spec.workflowName} must run hosted dependencies only on a trusted cumulative head`,
     );
-    if (spec.pathFiltered) {
-      assert.deepEqual(
-        workflow.on.pull_request.paths,
-        workflow.on.push.paths,
-        `${spec.workflowName} must use the same paths for stack PRs and main pushes`,
-      );
-    } else {
-      assert.equal(workflow.on.pull_request.paths, undefined);
-    }
   }
 });
 
 test("stack metadata gates cumulative Python product coverage", async () => {
   const workflow = await parseWorkflow("python");
   const job = workflow.jobs.python;
-  const matrix =
-    "fromJSON(github.event_name == 'pull_request' && github.event.pull_request.stack != null && github.event.pull_request.stack.position != github.event.pull_request.stack.size && '[\"3.11\"]' || '[\"3.11\",\"3.12\",\"3.13\"]')";
-
   assert.equal(
     job.strategy["fail-fast"],
     false,
     "one Python compatibility failure must not cancel the remaining top lanes",
   );
-  assert.equal(job.strategy.matrix["python-version"], `\${{ ${matrix} }}`);
-  for (const admissionStep of [
+  assert.deepEqual(job.strategy.matrix["python-version"], ["3.11", "3.12", "3.13"]);
+  assert.deepEqual(
+    findStep(job, "Set up Python ${{ matrix.python-version }}").with,
+    {
+      "python-version": "${{ matrix.python-version }}",
+      cache: "pip",
+      "cache-dependency-path": "workers/automation/pyproject.toml",
+    },
+    "the full Python lane must reuse pip downloads across top runs",
+  );
+  for (const productStep of [
     "Lint",
     "Release scan",
     "Validate Python workflow contract",
+    "Test",
     "Build package",
   ]) {
     assert.equal(
-      findStep(job, admissionStep).if,
+      findStep(job, productStep).if,
       undefined,
-      `${admissionStep} must run as a fast Python 3.11 admission check on every matching stack PR`,
+      `${productStep} must run when the trusted-top Python job is admitted`,
     );
   }
-  assert.equal(
-    findStep(job, "Test").if,
-    `\${{ ${topOfStack} }}`,
-    "the Python product suite must use the null-safe top-of-stack guard",
-  );
 });
 
 test("stack metadata gates cumulative TypeScript product suites", async () => {
@@ -108,12 +100,13 @@ test("stack metadata gates cumulative TypeScript product suites", async () => {
   const job = workflow.jobs.typescript;
 
   assert.equal(
-    findStep(job, "Check").if,
-    undefined,
-    "the static workspace check must run on every matching stack PR",
+    findStep(job, "Set up Node").with.cache,
+    "pnpm",
+    "the full TypeScript lane must reuse the pnpm store across top runs",
   );
 
-  for (const cumulativeStep of [
+  for (const productStep of [
+    "Check",
     "Set up Python",
     "Install uv",
     "Test",
@@ -127,9 +120,9 @@ test("stack metadata gates cumulative TypeScript product suites", async () => {
     "Test web storybook",
   ]) {
     assert.equal(
-      findStep(job, cumulativeStep).if,
-      `\${{ ${topOfStack} }}`,
-      `${cumulativeStep} must use the null-safe top-of-stack guard`,
+      findStep(job, productStep).if,
+      undefined,
+      `${productStep} must run when the trusted-top TypeScript job is admitted`,
     );
   }
 });
@@ -157,7 +150,7 @@ test("stack routing keeps per-layer correctness and cumulative top coverage", ()
       eventName: "pull_request",
       trusted: true,
       stack: { position: 2, size: 3 },
-      expectedPython: ["3.11"],
+      expectedPython: [],
       expectedCumulative: false,
     },
     {
@@ -179,21 +172,15 @@ test("stack routing keeps per-layer correctness and cumulative top coverage", ()
   ];
 
   for (const route of routes) {
-    const admitted = route.eventName !== "pull_request" || route.trusted;
-    const isLowerStackLayer =
-      route.eventName === "pull_request" &&
-      route.stack !== null &&
-      route.stack.position !== route.stack.size;
-    const pythonVersions = admitted
-      ? isLowerStackLayer
-        ? ["3.11"]
-        : ["3.11", "3.12", "3.13"]
-      : [];
-    const cumulative =
-      admitted &&
+    const admitted =
+      (route.eventName !== "pull_request" || route.trusted) &&
       (route.eventName !== "pull_request" ||
         route.stack === null ||
         route.stack.position === route.stack.size);
+    const pythonVersions = admitted
+      ? ["3.11", "3.12", "3.13"]
+      : [];
+    const cumulative = admitted;
 
     assert.deepEqual(pythonVersions, route.expectedPython, route.name);
     assert.equal(cumulative, route.expectedCumulative, route.name);


### PR DESCRIPTION
## Summary

- always instantiate the Python and TypeScript pull-request workflows so every
  same-repository stack layer reaches job-level routing
- run hosted Python and TypeScript dependencies, matrices, builds, and product
  suites only on the cumulative stack top; lower layers receive skipped
  Python/TypeScript job records and retain the no-cost DCO admission
- cache Python dependency downloads through `actions/setup-python`, preserve
  the existing pnpm cache for full TypeScript runs, and document the routing
  policy for contributors

## Root cause

The two workflows filtered `pull_request` events by both `branches: [main]`
and changed paths. A stacked pull request can have a direct stack base and a
diff outside those filters, so GitHub never created the workflow run and its
job-level stack routing could not execute. The unfiltered PR triggers follow
the [GitHub Stacks CI guidance](https://docs.github.com/en/pull-requests/how-tos/merge-and-close-pull-requests/optimizing-ci-for-stacked-pull-requests).

The same-repository guard remains unchanged, so public forks still do not run
hosted CI automatically. The cumulative-top guard prevents lower stack layers
from starting any dependency-heavy Python or TypeScript runner work.

## Validation

- `node --test scripts/stacked-ci-workflows.test.mjs` -- 4 passed
- `node scripts/check-python-workflow-contract.mjs` -- passed
- `corepack pnpm docs:build` -- passed; 9,649 links resolved
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest` -- passed
- Ruby Psych parse of `.github/workflows/*.yml` -- passed
- `git diff --check` -- passed
- `corepack pnpm scripts:test` -- 136 passed; two
  `capture-docs-screenshots` confinement tests failed only from the temporary
  worktree path, while the same focused test passed on clean `main`
