### PR TITLE
fix(api): enforce exact v7 runtime writes

### DIFF
--- a/apps/api/src/db.ts
+++ b/apps/api/src/db.ts
@@ -63,6 +63,9 @@ export function openReadOnlyDatabase(dbPath: string): SqliteDatabase {
 export function openDatabase(dbPath: string): SqliteDatabase {
   const db = new Database(dbPath, { fileMustExist: true });
   assertExactSchemaVersion(db);
+  // Exact-v7 permanent deletion relies on the sealed schema's cascade and
+  // RESTRICT constraints. SQLite enables those constraints per connection.
+  db.pragma("foreign_keys = ON");
   // L4 (round-1 review): now that read endpoints write (projection
   // refresh) and the worker process also writes to the same
   // ``*_projections`` tables + watermark, SQLite contention is more

--- a/apps/api/src/profile-events.ts
+++ b/apps/api/src/profile-events.ts
@@ -10,7 +10,7 @@ import {
   type ActionCommandPayload,
   type ProfileUpdateRequest,
 } from "./contracts.js";
-import { allRows, getRow, tableExists, type SqliteDatabase, type SqliteValue } from "./db.js";
+import { getRow, type SqliteDatabase } from "./db.js";
 import type { ActionDispatchContext, ActionDispatcher } from "./local-actions.js";
 
 export function profileChangedSections(request: ProfileUpdateRequest): string[] {
@@ -32,46 +32,14 @@ export function shouldRetailorForProfileUpdate(request: ProfileUpdateRequest): b
 }
 
 export function hasRetailorableResumes(db: SqliteDatabase): boolean {
-  if (tableExists(db, "job_materials_artifacts")) {
-    const row = getRow<{ count: number }>(
-      db,
-      `SELECT COUNT(*) AS count
-       FROM job_materials_artifacts
-       WHERE artifact_type = 'tailored_resume'
-         AND status = 'approved'`,
-    );
-    if (Number(row?.count ?? 0) > 0) {
-      return true;
-    }
-  }
-
-  if (tableExists(db, "jobs")) {
-    const row = getRow<{ count: number }>(
-      db,
-      `SELECT COUNT(*) AS count
-       FROM jobs
-       WHERE tailored_resume_path IS NOT NULL
-         AND tailored_resume_path != ''`,
-    );
-    if (Number(row?.count ?? 0) > 0) {
-      return true;
-    }
-  }
-
-  if (tableExists(db, "job_artifacts")) {
-    const row = getRow<{ count: number }>(
-      db,
-      `SELECT COUNT(*) AS count
-       FROM job_artifacts
-       WHERE artifact_type IN ('tailored_resume', 'tailored_resume_txt')
-         AND status IN ('active', 'approved')`,
-    );
-    if (Number(row?.count ?? 0) > 0) {
-      return true;
-    }
-  }
-
-  return false;
+  const row = getRow<{ count: number }>(
+    db,
+    `SELECT COUNT(*) AS count
+     FROM job_materials_artifacts
+     WHERE artifact_type = 'tailored_resume'
+       AND status = 'approved'`,
+  );
+  return Number(row?.count ?? 0) > 0;
 }
 
 export function recordProfileUpdatedEvent(
@@ -79,9 +47,6 @@ export function recordProfileUpdatedEvent(
   changedSections: readonly string[],
   occurredAt = new Date().toISOString(),
 ): ProfileUpdated | null {
-  if (!tableExists(db, "job_events")) {
-    return null;
-  }
   const event = {
     ...createProfileUpdated(LOCAL_TENANT, {
       changedSections,
@@ -117,33 +82,19 @@ export async function handleProfileUpdatedEvent(
 }
 
 function insertProfileEvent(db: SqliteDatabase, event: ProfileUpdated): void {
-  const columns = columnNames(db, "job_events");
-  const values: Record<string, SqliteValue> = {
-    job_url: null,
-    stage: null,
-    event_type: event.eventType,
-    level: "info",
-    message: "Candidate profile updated.",
-    occurred_at: event.occurredAt,
-    payload_json: JSON.stringify({
+  db.prepare(
+    `INSERT INTO job_events (
+       tenant_id, job_id, identity_version, stage, event_type, level,
+       message, occurred_at, payload_json
+     ) VALUES (?, NULL, 1, NULL, ?, 'info', ?, ?, ?)`,
+  ).run(
+    event.tenantId,
+    event.eventType,
+    "Candidate profile updated.",
+    event.occurredAt,
+    JSON.stringify({
       tenantId: event.tenantId,
       ...event.payload,
     }),
-  };
-  const entries = Object.entries(values).filter(([name]) => columns.has(name));
-  if (entries.length === 0) {
-    return;
-  }
-  db.prepare(
-    `INSERT INTO job_events (${entries.map(([name]) => name).join(", ")}) VALUES (${entries
-      .map(() => "?")
-      .join(", ")})`,
-  ).run(...entries.map(([, value]) => value));
-}
-
-function columnNames(db: SqliteDatabase, tableName: string): Set<string> {
-  if (!tableExists(db, tableName)) {
-    return new Set();
-  }
-  return new Set(allRows<{ name: string }>(db, `PRAGMA table_info(${tableName})`).map((row) => row.name));
+  );
 }

--- a/apps/api/src/profile-store.ts
+++ b/apps/api/src/profile-store.ts
@@ -374,43 +374,6 @@ export function ensureProfileTables(db: SqliteDatabase): void {
     CREATE INDEX IF NOT EXISTS idx_candidate_profile_skill_order
       ON candidate_profile_skill_categories(tenant_id, profile_id, position_index);
   `);
-  ensureCandidateProfileColumns(db);
-}
-
-const CANDIDATE_PROFILE_COLUMN_MIGRATIONS: Record<string, string> = {
-  experience_target_track: "TEXT NOT NULL DEFAULT ''",
-  experience_target_seniority_floor: "TEXT NOT NULL DEFAULT ''",
-  experience_target_functions: "TEXT NOT NULL DEFAULT ''",
-  experience_target_specializations: "TEXT NOT NULL DEFAULT ''",
-  experience_target_locations: "TEXT NOT NULL DEFAULT ''",
-  experience_target_work_models: "TEXT NOT NULL DEFAULT ''",
-  tailoring_claim_mode: "TEXT NOT NULL DEFAULT 'evidence_reframing'",
-  tailoring_auto_approvable_claim_modes_json: "TEXT NOT NULL DEFAULT '[\"verified_only\",\"evidence_reframing\"]'",
-  tailoring_allow_adjacent_achievement_drafts: "INTEGER NOT NULL DEFAULT 0",
-  revision_min_fit_score: "INTEGER NOT NULL DEFAULT 8",
-  revision_must_have_coverage: "REAL NOT NULL DEFAULT 0.85",
-  revision_max_attempts: "INTEGER NOT NULL DEFAULT 1",
-  application_attestation_age_18_plus: "INTEGER DEFAULT NULL",
-  application_attestation_background_check_consent: "INTEGER DEFAULT NULL",
-  application_attestation_felony_conviction: "INTEGER DEFAULT NULL",
-  application_attestation_previously_worked_at_employer: "INTEGER DEFAULT NULL",
-  application_attestation_additional_json: "TEXT NOT NULL DEFAULT '{}'",
-  application_preference_how_heard: "TEXT NOT NULL DEFAULT ''",
-};
-
-function ensureCandidateProfileColumns(db: SqliteDatabase): void {
-  const existingColumns = new Set(
-    (db.prepare("PRAGMA table_info(candidate_profiles)").all() as Array<{ name: string }>).map(
-      (column) => column.name,
-    ),
-  );
-
-  for (const [column, definition] of Object.entries(CANDIDATE_PROFILE_COLUMN_MIGRATIONS)) {
-    if (!existingColumns.has(column)) {
-      db.exec(`ALTER TABLE candidate_profiles ADD COLUMN ${column} ${definition}`);
-    }
-  }
-
   backfillAchievementEvidenceFromBullets(db);
 }
 

--- a/apps/api/src/projections.ts
+++ b/apps/api/src/projections.ts
@@ -1570,6 +1570,19 @@ function rebuildEvidenceUsageProjection(db: SqliteDatabase, tenantId: string): v
   }
 }
 
+/**
+ * Rebuild the tenant-wide projections affected by a permanent Job deletion.
+ *
+ * The delete command removes the target's projections and cascades its events,
+ * so resetting the shared event watermark would replay unrelated tenants. The
+ * remaining local rows are already canonical; these two projections can be
+ * rebuilt directly and transactionally with the delete command instead.
+ */
+export function rebuildTenantDeleteProjections(db: SqliteDatabase, tenantId: string): void {
+  rebuildDashboardProjection(db, tenantId);
+  rebuildEvidenceUsageProjection(db, tenantId);
+}
+
 function loadProfileEvidenceEntries(
   db: SqliteDatabase,
   tenantId: string,

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -3671,16 +3671,15 @@ function preparationPickupEligibility(
   stage: Stage,
   minScore: number,
 ): PreparationPickupEligibility {
-  if (!tableExists(db, "job_list_projections")) {
-    return ineligiblePickup("projection_unavailable", "Preparation pickup is waiting for job projections.");
+  const jobId = resolveJobId(db, "local", jobUrl);
+  if (!jobId) {
+    return ineligiblePickup("job_not_found", "Job is no longer available for preparation pickup.");
   }
-  const staleScoreSelect = tableExists(db, "job_score_staleness")
-    ? `(SELECT COUNT(*)
+  const staleScoreSelect = `(SELECT COUNT(*)
         FROM job_score_staleness stale
         WHERE stale.tenant_id = 'local'
-          AND stale.job_url = jobs.url
-          AND stale.resolved = 0)`
-    : "0";
+          AND stale.job_id = jobs.job_id
+          AND stale.resolved = 0)`;
   const row = db
     .prepare(
       `SELECT
@@ -3698,15 +3697,19 @@ function preparationPickupEligibility(
          ${staleScoreSelect} AS unresolved_stale_scores
        FROM jobs
        LEFT JOIN job_list_projections projections
-         ON projections.tenant_id = 'local' AND projections.job_id = jobs.url
+         ON projections.tenant_id = jobs.tenant_id AND projections.job_id = jobs.job_id
        LEFT JOIN job_stage_states stage_state
-         ON stage_state.job_url = jobs.url AND stage_state.stage = ?
+         ON stage_state.tenant_id = jobs.tenant_id
+        AND stage_state.job_id = jobs.job_id
+        AND stage_state.stage = ?
        LEFT JOIN job_stage_states score_state
-         ON score_state.job_url = jobs.url AND score_state.stage = 'score'
-       WHERE jobs.url = ?
+         ON score_state.tenant_id = jobs.tenant_id
+        AND score_state.job_id = jobs.job_id
+        AND score_state.stage = 'score'
+       WHERE jobs.tenant_id = 'local' AND jobs.job_id = ?
        LIMIT 1`,
     )
-    .get(stage, jobUrl) as PreparationPickupRow | undefined;
+    .get(stage, jobId) as PreparationPickupRow | undefined;
   if (!row) {
     return ineligiblePickup("job_not_found", "Job is no longer available for preparation pickup.");
   }

--- a/apps/api/src/write-model.ts
+++ b/apps/api/src/write-model.ts
@@ -193,6 +193,9 @@ function resetResolvedJobStage(
   // so even though we _call_ isValidTransition (via validateStageTransition)
   // when the gate is opt-in, this entry-point bypasses §8.5 — the user is
   // explicitly forcing the stage back to pending.
+  if (stage === "enrich") {
+    resetEnrichmentAggregate(db, LOCAL_TENANT, job.jobId);
+  }
   const stageOptions: Parameters<typeof upsertStageStateById>[5] = {
     retryable: true,
     clearTiming: true,
@@ -756,50 +759,6 @@ export function writeSettingsConfig(
   return readSettingsConfig(paths);
 }
 
-function updateLegacyJobColumnsForReset(
-  db: SqliteDatabase,
-  jobUrl: string,
-  stage: Stage,
-  resetAttempts: boolean,
-): void {
-  const updates: Record<string, SqliteValue> = {};
-  if (stage === "enrich") {
-    updates.detail_error = null;
-    updates.detail_scraped_at = null;
-    // Phase 7 (S-26 round-1 review B2): the new ``job_enrichments``
-    // table is the canonical source of "is this job enriched". Without
-    // resetting its row the worker's ``_ENRICHMENT_PENDING`` predicate
-    // permanently excludes the job and the API-driven retry-enrich
-    // silently no-ops. Mirror of Python's ``_reset_enrichment_aggregate``.
-    resetEnrichmentAggregate(db, jobUrl);
-  } else if (stage === "score") {
-    updates.fit_score = null;
-    updates.score_reasoning = null;
-    updates.scored_at = null;
-  } else if (stage === "tailor") {
-    updates.tailored_resume_path = null;
-    updates.tailored_at = null;
-    if (resetAttempts) {
-      updates.tailor_attempts = 0;
-    }
-  } else if (stage === "cover") {
-    updates.cover_letter_path = null;
-    updates.cover_letter_at = null;
-    if (resetAttempts) {
-      updates.cover_attempts = 0;
-    }
-  } else if (stage === "apply") {
-    updates.apply_status = null;
-    updates.apply_error = null;
-    updates.agent_id = null;
-    updates.apply_task_id = null;
-    if (resetAttempts) {
-      updates.apply_attempts = 0;
-    }
-  }
-  updateExistingJobColumns(db, jobUrl, updates);
-}
-
 /**
  * Phase 7 (S-26 round-1 review B2): reset the ``job_enrichments`` row
  * for one job back to the ``pending`` lifecycle state.
@@ -815,7 +774,7 @@ function updateLegacyJobColumnsForReset(
  * only clears the success-side fields plus rolls ``current_status``
  * back to ``pending``. Idempotent — safe to call when no row exists.
  */
-function resetEnrichmentAggregate(db: SqliteDatabase, jobUrl: string): void {
+function resetEnrichmentAggregate(db: SqliteDatabase, tenantId: string, jobId: string): void {
   if (!tableExists(db, "job_enrichments")) {
     return;
   }
@@ -828,8 +787,8 @@ function resetEnrichmentAggregate(db: SqliteDatabase, jobUrl: string): void {
            enriched_at = NULL,
            extraction_tier = NULL,
            updated_at = ?
-     WHERE job_url = ?`,
-  ).run(now, jobUrl);
+     WHERE tenant_id = ? AND job_id = ?`,
+  ).run(now, tenantId, jobId);
 }
 
 function mutableJobKeys(db: SqliteDatabase, request: BulkJobMutationRequest): string[] {
@@ -1364,16 +1323,6 @@ function appendCorrectionHistory(
     ...trace,
     correction_history: [...history.filter(isRecord), correction],
   };
-}
-
-function updateExistingJobColumns(db: SqliteDatabase, jobUrl: string, updates: Record<string, SqliteValue>): void {
-  const names = columnNames(db, "jobs");
-  const entries = Object.entries(updates).filter(([name]) => names.has(name));
-  if (!entries.length) {
-    return;
-  }
-  const assignments = entries.map(([name]) => `${name} = ?`).join(", ");
-  db.prepare(`UPDATE jobs SET ${assignments} WHERE url = ?`).run(...entries.map(([, value]) => value), jobUrl);
 }
 
 function parseObjectOrDefault(text: string): Record<string, unknown> {

--- a/apps/api/src/write-model.ts
+++ b/apps/api/src/write-model.ts
@@ -15,7 +15,7 @@ import type {
   StageState,
   StageSummary,
 } from "./contracts.js";
-import { PROJECTION_WATERMARK_NAME, STAGES } from "./contracts.js";
+import { STAGES } from "./contracts.js";
 import {
   isValidTransition,
   deserializeStageStateKind,
@@ -24,6 +24,7 @@ import {
 import { allRows, getRow, tableExists, type SqliteDatabase, type SqliteValue } from "./db.js";
 import { matchingJobKeys, readSettingsConfig } from "./read-model.js";
 import { updateConfigObject } from "./config-file.js";
+import { rebuildTenantDeleteProjections } from "./projections.js";
 
 export class InputError extends Error {}
 
@@ -567,23 +568,23 @@ export function softDeleteJob(db: SqliteDatabase, jobKey: string, request: Delet
 }
 
 export function softDeleteJobs(db: SqliteDatabase, request: BulkJobMutationRequest): JobMutationResponse {
-  ensureDeletedJobsTable(db);
   const deletedAt = new Date().toISOString();
-  const jobKeys = mutableJobKeys(db, request);
+  const jobs = mutableResolvedJobs(db, request);
   const statement = db.prepare(`
-    INSERT INTO jobctrl_deleted_jobs (job_url, deleted_at, reason, restored_at)
-    VALUES (?, ?, ?, NULL)
-    ON CONFLICT(job_url) DO UPDATE SET
+    INSERT INTO jobctrl_deleted_jobs (tenant_id, job_id, deleted_at, reason, restored_at)
+    VALUES ('local', ?, ?, ?, NULL)
+    ON CONFLICT(tenant_id, job_id) DO UPDATE SET
       deleted_at = excluded.deleted_at,
       reason = excluded.reason,
       restored_at = NULL
   `);
-  const transaction = db.transaction((keys: string[]) => {
-    for (const jobUrl of keys) {
-      statement.run(jobUrl, deletedAt, request.reason ?? null);
-      recordActionEvent(db, {
-        jobUrl,
-        stage: currentMutableStage(db, jobUrl),
+  const transaction = db.transaction((resolvedJobs: readonly ResolvedJobIdentity[]) => {
+    for (const job of resolvedJobs) {
+      statement.run(job.jobId, deletedAt, request.reason ?? null);
+      recordActionEventById(db, {
+        tenantId: LOCAL_TENANT,
+        jobId: job.jobId,
+        stage: currentMutableStageById(db, LOCAL_TENANT, job.jobId),
         eventType: "JobDeleted",
         level: "info",
         message: "Job soft-deleted from the local API.",
@@ -591,8 +592,8 @@ export function softDeleteJobs(db: SqliteDatabase, request: BulkJobMutationReque
       });
     }
   });
-  transaction(jobKeys);
-  return { ok: true, count: jobKeys.length, jobKeys };
+  transaction(jobs);
+  return { ok: true, count: jobs.length, jobKeys: jobs.map((job) => job.jobId) };
 }
 
 export function restoreJob(db: SqliteDatabase, jobKey: string): JobMutationResponse {
@@ -600,18 +601,22 @@ export function restoreJob(db: SqliteDatabase, jobKey: string): JobMutationRespo
 }
 
 export function restoreJobs(db: SqliteDatabase, request: BulkJobMutationRequest): JobMutationResponse {
-  ensureDeletedJobsTable(db);
   const restoredAt = new Date().toISOString();
-  const jobKeys = mutableJobKeys(db, request);
+  const jobs = mutableResolvedJobs(db, request);
   const statement = db.prepare(
-    "UPDATE jobctrl_deleted_jobs SET restored_at = ? WHERE job_url = ? AND (restored_at IS NULL OR julianday(restored_at) <= julianday(deleted_at))",
+    `UPDATE jobctrl_deleted_jobs
+        SET restored_at = ?
+      WHERE tenant_id = 'local'
+        AND job_id = ?
+        AND (restored_at IS NULL OR julianday(restored_at) <= julianday(deleted_at))`,
   );
-  const transaction = db.transaction((keys: string[]) => {
-    for (const jobUrl of keys) {
-      statement.run(restoredAt, jobUrl);
-      recordActionEvent(db, {
-        jobUrl,
-        stage: currentMutableStage(db, jobUrl),
+  const transaction = db.transaction((resolvedJobs: readonly ResolvedJobIdentity[]) => {
+    for (const job of resolvedJobs) {
+      statement.run(restoredAt, job.jobId);
+      recordActionEventById(db, {
+        tenantId: LOCAL_TENANT,
+        jobId: job.jobId,
+        stage: currentMutableStageById(db, LOCAL_TENANT, job.jobId),
         eventType: "JobRestored",
         level: "info",
         message: "Job restored from deleted jobs.",
@@ -619,8 +624,8 @@ export function restoreJobs(db: SqliteDatabase, request: BulkJobMutationRequest)
       });
     }
   });
-  transaction(jobKeys);
-  return { ok: true, count: jobKeys.length, jobKeys };
+  transaction(jobs);
+  return { ok: true, count: jobs.length, jobKeys: jobs.map((job) => job.jobId) };
 }
 
 export function hideJob(db: SqliteDatabase, jobKey: string, request: DeleteJobRequest = {}): JobMutationResponse {
@@ -628,23 +633,23 @@ export function hideJob(db: SqliteDatabase, jobKey: string, request: DeleteJobRe
 }
 
 export function hideJobs(db: SqliteDatabase, request: BulkJobMutationRequest): JobMutationResponse {
-  ensureHiddenJobsTable(db);
   const hiddenAt = new Date().toISOString();
-  const jobKeys = mutableJobKeys(db, request);
+  const jobs = mutableResolvedJobs(db, request);
   const statement = db.prepare(`
-    INSERT INTO jobctrl_hidden_jobs (job_url, hidden_at, reason, unhidden_at)
-    VALUES (?, ?, ?, NULL)
-    ON CONFLICT(job_url) DO UPDATE SET
+    INSERT INTO jobctrl_hidden_jobs (tenant_id, job_id, hidden_at, reason, unhidden_at)
+    VALUES ('local', ?, ?, ?, NULL)
+    ON CONFLICT(tenant_id, job_id) DO UPDATE SET
       hidden_at = excluded.hidden_at,
       reason = excluded.reason,
       unhidden_at = NULL
   `);
-  const transaction = db.transaction((keys: string[]) => {
-    for (const jobUrl of keys) {
-      statement.run(jobUrl, hiddenAt, request.reason ?? null);
-      recordActionEvent(db, {
-        jobUrl,
-        stage: currentMutableStage(db, jobUrl),
+  const transaction = db.transaction((resolvedJobs: readonly ResolvedJobIdentity[]) => {
+    for (const job of resolvedJobs) {
+      statement.run(job.jobId, hiddenAt, request.reason ?? null);
+      recordActionEventById(db, {
+        tenantId: LOCAL_TENANT,
+        jobId: job.jobId,
+        stage: currentMutableStageById(db, LOCAL_TENANT, job.jobId),
         eventType: "JobHidden",
         level: "info",
         message: "Job hidden from the local API.",
@@ -652,8 +657,8 @@ export function hideJobs(db: SqliteDatabase, request: BulkJobMutationRequest): J
       });
     }
   });
-  transaction(jobKeys);
-  return { ok: true, count: jobKeys.length, jobKeys };
+  transaction(jobs);
+  return { ok: true, count: jobs.length, jobKeys: jobs.map((job) => job.jobId) };
 }
 
 export function unhideJob(db: SqliteDatabase, jobKey: string): JobMutationResponse {
@@ -661,16 +666,18 @@ export function unhideJob(db: SqliteDatabase, jobKey: string): JobMutationRespon
 }
 
 export function unhideJobs(db: SqliteDatabase, request: BulkJobMutationRequest): JobMutationResponse {
-  ensureHiddenJobsTable(db);
   const unhiddenAt = new Date().toISOString();
-  const jobKeys = mutableJobKeys(db, request);
-  const statement = db.prepare("UPDATE jobctrl_hidden_jobs SET unhidden_at = ? WHERE job_url = ? AND unhidden_at IS NULL");
-  const transaction = db.transaction((keys: string[]) => {
-    for (const jobUrl of keys) {
-      statement.run(unhiddenAt, jobUrl);
-      recordActionEvent(db, {
-        jobUrl,
-        stage: currentMutableStage(db, jobUrl),
+  const jobs = mutableResolvedJobs(db, request);
+  const statement = db.prepare(
+    "UPDATE jobctrl_hidden_jobs SET unhidden_at = ? WHERE tenant_id = 'local' AND job_id = ? AND unhidden_at IS NULL",
+  );
+  const transaction = db.transaction((resolvedJobs: readonly ResolvedJobIdentity[]) => {
+    for (const job of resolvedJobs) {
+      statement.run(unhiddenAt, job.jobId);
+      recordActionEventById(db, {
+        tenantId: LOCAL_TENANT,
+        jobId: job.jobId,
+        stage: currentMutableStageById(db, LOCAL_TENANT, job.jobId),
         eventType: "JobUnhidden",
         level: "info",
         message: "Job unhidden from hidden jobs.",
@@ -678,8 +685,8 @@ export function unhideJobs(db: SqliteDatabase, request: BulkJobMutationRequest):
       });
     }
   });
-  transaction(jobKeys);
-  return { ok: true, count: jobKeys.length, jobKeys };
+  transaction(jobs);
+  return { ok: true, count: jobs.length, jobKeys: jobs.map((job) => job.jobId) };
 }
 
 export function permanentlyDeleteJob(db: SqliteDatabase, jobKey: string): JobMutationResponse {
@@ -687,15 +694,24 @@ export function permanentlyDeleteJob(db: SqliteDatabase, jobKey: string): JobMut
 }
 
 export function permanentlyDeleteJobs(db: SqliteDatabase, request: BulkJobMutationRequest): JobMutationResponse {
-  const jobKeys = mutableJobKeys(db, request);
-  const transaction = db.transaction((keys: string[]) => {
-    for (const jobUrl of keys) {
-      purgeJobRows(db, jobUrl);
+  const tenantId = LOCAL_TENANT;
+  const jobs = mutableResolvedJobs(db, request);
+  // The v7 schema deliberately delegates deletion of the job-owned graph to
+  // its foreign-key cascades. This command is also callable without the API
+  // connection wrapper, so enable the constraint engine at the command
+  // boundary before starting the transaction.
+  db.pragma("foreign_keys = ON");
+  if (db.pragma("foreign_keys", { simple: true }) !== 1) {
+    throw new Error("Permanent delete requires SQLite foreign-key enforcement.");
+  }
+  const transaction = db.transaction((resolvedJobs: readonly ResolvedJobIdentity[]) => {
+    for (const job of resolvedJobs) {
+      purgeJobRows(db, tenantId, job.jobId);
     }
-    invalidateOperationsProjections(db);
+    invalidateOperationsProjections(db, tenantId);
   });
-  transaction(jobKeys);
-  return { ok: true, count: jobKeys.length, jobKeys };
+  transaction(jobs);
+  return { ok: true, count: jobs.length, jobKeys: jobs.map((job) => job.jobId) };
 }
 
 export function writeSettingsConfig(
@@ -816,30 +832,6 @@ function resetEnrichmentAggregate(db: SqliteDatabase, jobUrl: string): void {
   ).run(now, jobUrl);
 }
 
-function ensureDeletedJobsTable(db: SqliteDatabase): void {
-  db.prepare(
-    `CREATE TABLE IF NOT EXISTS jobctrl_deleted_jobs (
-      job_url TEXT PRIMARY KEY,
-      deleted_at TEXT NOT NULL,
-      reason TEXT,
-      restored_at TEXT,
-      FOREIGN KEY(job_url) REFERENCES jobs(url)
-    )`,
-  ).run();
-}
-
-function ensureHiddenJobsTable(db: SqliteDatabase): void {
-  db.prepare(
-    `CREATE TABLE IF NOT EXISTS jobctrl_hidden_jobs (
-      job_url TEXT PRIMARY KEY,
-      hidden_at TEXT NOT NULL,
-      reason TEXT,
-      unhidden_at TEXT,
-      FOREIGN KEY(job_url) REFERENCES jobs(url)
-    )`,
-  ).run();
-}
-
 function mutableJobKeys(db: SqliteDatabase, request: BulkJobMutationRequest): string[] {
   if (request.allMatching) {
     return uniqueJobKeys(matchingJobKeys(db, request.filter ?? {}));
@@ -860,49 +852,230 @@ function uniqueJobKeys(jobKeys: string[]): string[] {
   return Array.from(new Set(jobKeys.map((jobKey) => jobKey.trim()).filter(Boolean)));
 }
 
-function purgeJobRows(db: SqliteDatabase, jobUrl: string): void {
-  deleteWhere(db, "jobctrl_deleted_jobs", "job_url = ?", [jobUrl]);
-  deleteWhere(db, "jobctrl_hidden_jobs", "job_url = ?", [jobUrl]);
-  deleteWhere(db, "job_stage_states", "job_url = ?", [jobUrl]);
-  deleteWhere(db, "job_events", "job_url = ?", [jobUrl]);
-  deleteWhere(db, "job_artifacts", "job_url = ?", [jobUrl]);
-  deleteWhere(db, "job_scores", "job_url = ?", [jobUrl]);
-  deleteWhere(db, "job_score_staleness", "job_url = ?", [jobUrl]);
-  deleteWhere(db, "job_materials_artifacts", "job_url = ?", [jobUrl]);
-  deleteWhere(db, "job_materials", "job_url = ?", [jobUrl]);
-  deleteWhere(db, "job_enrichments", "job_url = ?", [jobUrl]);
-  deleteWhere(db, "job_source_observations", "job_url = ?", [jobUrl]);
-  deleteWhere(db, "job_canonical_identities", "job_url = ?", [jobUrl]);
-  deleteWhere(db, "job_duplicate_links", "surviving_job_id = ? OR superseded_job_or_observation_id = ?", [
-    jobUrl,
-    jobUrl,
-  ]);
-  deleteWhere(db, "apply_run_projections", "job_id = ?", [jobUrl]);
-  deleteWhere(db, "artifact_list_projections", "job_id = ?", [jobUrl]);
-  deleteWhere(db, "job_detail_projections", "job_id = ?", [jobUrl]);
-  deleteWhere(db, "job_list_projections", "job_id = ?", [jobUrl]);
-  deleteWhere(db, "discovery_quarantine_entries", "job_id = ? OR job_key = ? OR posting_url = ?", [
-    jobUrl,
-    jobUrl,
-    jobUrl,
-  ]);
-  deleteWhere(db, "discovery_feedback", "job_key = ?", [jobUrl]);
-  deleteWhere(db, "jobs", "url = ?", [jobUrl]);
-}
+function purgeJobRows(db: SqliteDatabase, tenantId: string, jobId: string): void {
+  const locatorValues = jobLocatorValues(db, tenantId, jobId);
+  const repeatOverrideIds = affectedRepeatOverrideIds(db, tenantId, jobId);
 
-function invalidateOperationsProjections(db: SqliteDatabase): void {
-  deleteWhere(db, "job_list_projections", "1 = 1", []);
-  deleteWhere(db, "job_detail_projections", "1 = 1", []);
-  deleteWhere(db, "artifact_list_projections", "1 = 1", []);
-  deleteWhere(db, "dashboard_projections", "1 = 1", []);
-  deleteWhere(db, "event_watermarks", "projection_name = ?", [PROJECTION_WATERMARK_NAME]);
-}
+  detachIndependentJobEvents(db, tenantId, jobId);
+  detachIndependentJobReferences(db, tenantId, jobId);
+  purgeRepeatApplicationEdges(db, tenantId, jobId, repeatOverrideIds);
 
-function deleteWhere(db: SqliteDatabase, tableName: string, whereSql: string, params: SqliteValue[]): void {
-  if (!tableExists(db, tableName)) {
-    return;
+  // These tables deliberately do not have job foreign keys because they are
+  // rebuildable projections. Apply/artifact projections are job-scoped and
+  // must disappear with the permanent-delete boundary.
+  for (const tableName of [
+    "apply_run_projections",
+    "artifact_list_projections",
+    "job_detail_projections",
+    "job_list_projections",
+  ]) {
+    deleteExactV7Rows(db, tableName, "tenant_id = ? AND job_id = ?", [tenantId, jobId]);
   }
+
+  // A link can retain the deleted aggregate as a non-FK superseded target.
+  // Remove both forms so a later observation is not suppressed as a duplicate.
+  deleteExactV7Rows(
+    db,
+    "job_duplicate_links",
+    "tenant_id = ? AND (surviving_job_id = ? OR superseded_job_or_observation_id = ?)",
+    [tenantId, jobId, jobId],
+  );
+  for (const locatorValue of locatorValues) {
+    deleteExactV7Rows(
+      db,
+      "job_rejected_duplicate_links",
+      "tenant_id = ? AND candidate_url = ?",
+      [tenantId, locatorValue],
+    );
+  }
+
+  // The root deletion clears locators, delete/hide tombstones, events, and
+  // every job-owned child through the exact-v7 ON DELETE CASCADE graph.
+  deleteExactV7Rows(db, "jobs", "tenant_id = ? AND job_id = ?", [tenantId, jobId]);
+}
+
+function jobLocatorValues(db: SqliteDatabase, tenantId: string, jobId: string): string[] {
+  const values = new Set<string>();
+  const job = getRow<{ url: string | null; application_url: string | null }>(
+    db,
+    "SELECT url, application_url FROM jobs WHERE tenant_id = ? AND job_id = ?",
+    [tenantId, jobId],
+  );
+  for (const value of [job?.url, job?.application_url]) {
+    if (value?.trim()) values.add(value);
+  }
+  for (const row of allRows<{ locator_value: string }>(
+    db,
+    "SELECT locator_value FROM job_locators WHERE tenant_id = ? AND job_id = ?",
+    [tenantId, jobId],
+  )) {
+    if (row.locator_value.trim()) values.add(row.locator_value);
+  }
+  for (const row of allRows<{ canonical_url: string }>(
+    db,
+    "SELECT canonical_url FROM job_canonical_identities WHERE tenant_id = ? AND job_id = ?",
+    [tenantId, jobId],
+  )) {
+    if (row.canonical_url.trim()) values.add(row.canonical_url);
+  }
+  for (const row of allRows<{ observed_url: string; normalized_observed_url: string }>(
+    db,
+    `SELECT observed_url, normalized_observed_url
+       FROM job_source_observations
+      WHERE tenant_id = ? AND job_id = ?`,
+    [tenantId, jobId],
+  )) {
+    if (row.observed_url.trim()) values.add(row.observed_url);
+    if (row.normalized_observed_url.trim()) values.add(row.normalized_observed_url);
+  }
+  return [...values];
+}
+
+function affectedRepeatOverrideIds(db: SqliteDatabase, tenantId: string, jobId: string): string[] {
+  return allRows<{ override_id: string }>(
+    db,
+    `SELECT override_id
+       FROM application_repeat_overrides
+      WHERE tenant_id = ? AND (target_job_id = ? OR prior_job_id = ?)`,
+    [tenantId, jobId, jobId],
+  ).map((row) => row.override_id);
+}
+
+function purgeRepeatApplicationEdges(
+  db: SqliteDatabase,
+  tenantId: string,
+  jobId: string,
+  overrideIds: string[],
+): void {
+  // A repeat override is a cross-job decision. Its consumption table has no
+  // foreign key, so capture the affected override ids before the root's
+  // cascade removes the overrides themselves.
+  for (const overrideId of overrideIds) {
+    deleteExactV7Rows(
+      db,
+      "application_repeat_override_consumptions",
+      "tenant_id = ? AND override_id = ?",
+      [tenantId, overrideId],
+    );
+    deleteExactV7Rows(
+      db,
+      "application_repeat_audit",
+      "tenant_id = ? AND override_id = ?",
+      [tenantId, overrideId],
+    );
+  }
+  // Audit rows may reference the deleted Job as a prior match only in their
+  // evidence payload, while retaining a different target Job aggregate. Parse
+  // the JSON and match exact scalar values: substring search could erase an
+  // unrelated user note that merely happens to contain the same text.
+  for (const auditId of repeatAuditIdsReferencingJob(db, tenantId, jobId)) {
+    deleteExactV7Rows(db, "application_repeat_audit", "tenant_id = ? AND audit_id = ?", [tenantId, auditId]);
+  }
+}
+
+function repeatAuditIdsReferencingJob(db: SqliteDatabase, tenantId: string, jobId: string): string[] {
+  return allRows<{ audit_id: string; target_job_id: string; evidence_json: string }>(
+    db,
+    `SELECT audit_id, target_job_id, evidence_json
+       FROM application_repeat_audit
+      WHERE tenant_id = ?`,
+    [tenantId],
+  )
+    .filter((row) => row.target_job_id === jobId || repeatAuditEvidenceReferencesPriorJob(row.evidence_json, jobId))
+    .map((row) => row.audit_id);
+}
+
+function repeatAuditEvidenceReferencesPriorJob(json: string, expectedJobId: string): boolean {
+  try {
+    const matches = JSON.parse(json) as unknown;
+    return Array.isArray(matches) && matches.some((match) => priorApplicationJobId(match) === expectedJobId);
+  } catch {
+    return false;
+  }
+}
+
+function priorApplicationJobId(value: unknown): string | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const priorApplication = (value as Record<string, unknown>).priorApplication;
+  if (!priorApplication || typeof priorApplication !== "object" || Array.isArray(priorApplication)) return null;
+  const jobId = (priorApplication as Record<string, unknown>).jobId;
+  return typeof jobId === "string" ? jobId : null;
+}
+
+function detachIndependentJobEvents(db: SqliteDatabase, tenantId: string, jobId: string): void {
+  const events = allRows<{ event_id: number; payload_json: string | null }>(
+    db,
+    `SELECT event_id, payload_json
+       FROM job_events
+      WHERE tenant_id = ?
+        AND job_id = ?
+        AND entity_kind IN ('contact', 'contact_research', 'outreach')`,
+    [tenantId, jobId],
+  );
+  const update = db.prepare(
+    `UPDATE job_events
+        SET job_id = NULL, payload_json = ?
+      WHERE tenant_id = ?
+        AND event_id = ?
+        AND entity_kind IN ('contact', 'contact_research', 'outreach')`,
+  );
+  for (const event of events) {
+    update.run(scrubTopLevelEventJobId(event.payload_json, jobId), tenantId, event.event_id);
+  }
+}
+
+function scrubTopLevelEventJobId(payloadJson: string | null, jobId: string): string | null {
+  if (!payloadJson) return payloadJson;
+  try {
+    const payload = JSON.parse(payloadJson) as unknown;
+    if (!payload || typeof payload !== "object" || Array.isArray(payload)) return payloadJson;
+    const values = payload as Record<string, unknown>;
+    if (values.jobId !== jobId) return payloadJson;
+    const { jobId: _jobId, ...withoutJobId } = values;
+    return JSON.stringify(withoutJobId);
+  } catch {
+    return payloadJson;
+  }
+}
+
+function detachIndependentJobReferences(db: SqliteDatabase, tenantId: string, jobId: string): void {
+  // Contact, research, outreach, and operational records own their own
+  // lifecycles. Their nullable job reference is deliberately RESTRICT rather
+  // than a job-owned cascade: permanent deletion removes the Job aggregate,
+  // not user-entered contact history or operational evidence.
+  for (const tableName of [
+    "contacts",
+    "contact_research_tasks",
+    "outreach_threads",
+    "operational_attempt_metrics",
+    "contact_projections",
+    "contact_research_task_projections",
+    "outreach_thread_projections",
+    "due_follow_up_projections",
+  ]) {
+    updateExactV7Rows(db, tableName, "job_id = NULL", "tenant_id = ? AND job_id = ?", [tenantId, jobId]);
+  }
+}
+
+function invalidateOperationsProjections(db: SqliteDatabase, tenantId: string): void {
+  // Target rows were removed before the root deletion. Rebuild the two
+  // tenant-wide projections synchronously instead of resetting the shared
+  // event watermark and replaying unrelated tenants' event histories.
+  rebuildTenantDeleteProjections(db, tenantId);
+}
+
+function deleteExactV7Rows(db: SqliteDatabase, tableName: string, whereSql: string, params: SqliteValue[]): void {
   db.prepare(`DELETE FROM ${tableName} WHERE ${whereSql}`).run(...params);
+}
+
+function updateExactV7Rows(
+  db: SqliteDatabase,
+  tableName: string,
+  setSql: string,
+  whereSql: string,
+  params: SqliteValue[],
+): void {
+  db.prepare(`UPDATE ${tableName} SET ${setSql} WHERE ${whereSql}`).run(...params);
 }
 
 function ensureJobScoresTable(db: SqliteDatabase): void {

--- a/apps/api/test/permanent-delete-v7.test.ts
+++ b/apps/api/test/permanent-delete-v7.test.ts
@@ -1,0 +1,383 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import type Database from "better-sqlite3";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { openDatabase } from "../src/db.js";
+import { rebuildTenantDeleteProjections } from "../src/projections.js";
+import { schemaManifest, EXACT_V7_SCHEMA_MANIFEST } from "../src/schema-manifest.js";
+import { permanentlyDeleteJob } from "../src/write-model.js";
+import { initializeExactV7Database } from "./v7-schema.js";
+
+const JOB_ID = "00000000-0000-4000-8000-0000000000d1";
+const ANCHOR_JOB_ID = "00000000-0000-4000-8000-0000000000d2";
+const REDISCOVERED_JOB_ID = "00000000-0000-4000-8000-0000000000d3";
+const OTHER_TENANT = "other";
+const JOB_URL = "https://jobs.example.test/permanent-delete";
+const SOURCE_URL = "https://source.example.test/permanent-delete";
+const NOW = "2026-07-31T15:00:00Z";
+const cleanups: Array<() => void> = [];
+
+afterEach(() => {
+  while (cleanups.length) cleanups.pop()?.();
+});
+
+function exactDatabase(): Database.Database {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "jobctrl-permanent-delete-v7-"));
+  const dbPath = path.join(dir, "jobs.db");
+  initializeExactV7Database(dbPath);
+  const db = openDatabase(dbPath);
+  cleanups.push(() => {
+    db.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+  return db;
+}
+
+function insertJob(db: Database.Database, tenantId: string, jobId: string, url: string): void {
+  db.prepare(
+    `INSERT INTO jobs (tenant_id, job_id, url, title, company, site, discovered_at, application_url)
+     VALUES (?, ?, ?, ?, 'Example', 'example', ?, ?)`,
+  ).run(tenantId, jobId, url, `Job ${jobId.slice(-3)}`, NOW, `${url}/apply`);
+}
+
+function countRows(db: Database.Database, tableName: string, whereSql: string, params: unknown[] = []): number {
+  const row = db.prepare(`SELECT COUNT(*) AS count FROM ${tableName} WHERE ${whereSql}`).get(...params) as {
+    count: number;
+  };
+  return Number(row.count);
+}
+
+function rowSnapshot(db: Database.Database, tableName: string, whereSql: string, params: unknown[] = []): unknown[] {
+  return db.prepare(`SELECT * FROM ${tableName} WHERE ${whereSql} ORDER BY rowid`).all(...params);
+}
+
+function seedExactV7DeleteGraph(db: Database.Database): void {
+  insertJob(db, "local", JOB_ID, JOB_URL);
+  insertJob(db, "local", ANCHOR_JOB_ID, "https://jobs.example.test/permanent-delete-anchor");
+  insertJob(db, OTHER_TENANT, JOB_ID, "https://jobs.example.test/permanent-delete-other");
+
+  const insertLocator = db.prepare(
+    `INSERT INTO job_locators (
+       tenant_id, job_id, locator_kind, locator_value, is_current, first_seen_at, last_seen_at
+     ) VALUES (?, ?, ?, ?, 1, ?, ?)`,
+  );
+  insertLocator.run("local", JOB_ID, "posting_url", JOB_URL, NOW, NOW);
+  insertLocator.run(OTHER_TENANT, JOB_ID, "posting_url", "https://jobs.example.test/permanent-delete-other", NOW, NOW);
+  db.prepare(
+    `INSERT INTO job_canonical_identities (
+       tenant_id, job_id, canonical_url, ats_kind, source_native_id, confidence, resolved_at
+     ) VALUES ('local', ?, ?, 'greenhouse', 'permanent-delete', 1, ?)`,
+  ).run(JOB_ID, SOURCE_URL, NOW);
+  db.prepare(
+    `INSERT INTO job_source_observations (
+       tenant_id, source_observation_id, job_id, source_id, source_native_id,
+       observed_url, normalized_observed_url, observed_at
+     ) VALUES ('local', 'source-observation-1', ?, 'example', 'permanent-delete', ?, ?, ?)`,
+  ).run(JOB_ID, SOURCE_URL, SOURCE_URL, NOW);
+
+  db.prepare(
+    `INSERT INTO jobctrl_deleted_jobs (tenant_id, job_id, deleted_at, reason)
+     VALUES ('local', ?, ?, 'test tombstone')`,
+  ).run(JOB_ID, NOW);
+  db.prepare(
+    `INSERT INTO jobctrl_hidden_jobs (tenant_id, job_id, hidden_at, reason)
+     VALUES ('local', ?, ?, 'test suppression')`,
+  ).run(JOB_ID, NOW);
+  db.prepare(
+    `INSERT INTO job_stage_states (tenant_id, job_id, stage, state, updated_at)
+     VALUES ('local', ?, 'apply', 'failed', ?)`,
+  ).run(JOB_ID, NOW);
+  db.prepare(
+    `INSERT INTO job_events (tenant_id, job_id, identity_version, stage, event_type, occurred_at)
+     VALUES ('local', ?, 1, 'apply', 'StageFailed', ?)`,
+  ).run(JOB_ID, NOW);
+  const insertIndependentEvent = db.prepare(
+    `INSERT INTO job_events (
+       tenant_id, job_id, identity_version, stage, event_type, occurred_at,
+       payload_json, entity_kind, entity_ref
+     ) VALUES ('local', ?, 1, NULL, ?, ?, ?, ?, ?)`,
+  );
+  insertIndependentEvent.run(
+    JOB_ID,
+    "ContactTimelineRecorded",
+    NOW,
+    JSON.stringify({ jobId: JOB_ID, nested: { jobId: JOB_ID }, note: "contact audit" }),
+    "contact",
+    "contact-1",
+  );
+  insertIndependentEvent.run(
+    JOB_ID,
+    "ContactResearchCompleted",
+    NOW,
+    JSON.stringify({ jobId: JOB_ID, taskId: "research-1", note: "research audit" }),
+    "contact_research",
+    "research-1",
+  );
+  insertIndependentEvent.run(
+    JOB_ID,
+    "OutreachDrafted",
+    NOW,
+    JSON.stringify({ jobId: ANCHOR_JOB_ID, threadId: "thread-1", note: "outreach audit" }),
+    "outreach",
+    "thread-1",
+  );
+  db.prepare(
+    `INSERT INTO application_email_evidence (
+       tenant_id, evidence_id, job_id, provider, provider_message_id, to_addresses_json, linked_at, body_text
+     ) VALUES ('local', 'private-email', ?, 'gmail', 'msg-private', '[]', ?, 'private email body')`,
+  ).run(JOB_ID, NOW);
+  db.prepare(
+    `INSERT INTO application_outcomes (
+       tenant_id, outcome_id, job_id, kind, source, note, occurred_at, recorded_at
+     ) VALUES ('local', 'private-outcome', ?, 'interview', 'manual', 'private outcome note', ?, ?)`,
+  ).run(JOB_ID, NOW, NOW);
+  db.prepare(
+    `INSERT INTO job_materials (
+       tenant_id, job_id, generation, status, created_at, updated_at, metadata_json
+     ) VALUES ('local', ?, 1, 'resume_approved', ?, ?, '{"private":true}')`,
+  ).run(JOB_ID, NOW, NOW);
+  db.prepare(
+    `INSERT INTO job_materials_artifacts (
+       tenant_id, job_id, generation, artifact_type, artifact_id, status, path, render_format, metadata_json, created_at
+     ) VALUES ('local', ?, 1, 'tailored_resume', 'private-artifact', 'approved', '/private/resume.pdf', 'pdf', '{}', ?)`,
+  ).run(JOB_ID, NOW);
+
+  db.prepare(
+    `INSERT INTO job_duplicate_links (
+       tenant_id, duplicate_link_id, surviving_job_id, superseded_job_or_observation_id, reason, confidence, linked_at
+     ) VALUES ('local', 'target-survives', ?, 'old-observation', 'same posting', 1, ?)`,
+  ).run(JOB_ID, NOW);
+  db.prepare(
+    `INSERT INTO job_duplicate_links (
+       tenant_id, duplicate_link_id, surviving_job_id, superseded_job_or_observation_id, reason, confidence, linked_at
+     ) VALUES ('local', 'target-superseded', ?, ?, 'same posting', 1, ?)`,
+  ).run(ANCHOR_JOB_ID, JOB_ID, NOW);
+  db.prepare(
+    `INSERT INTO job_rejected_duplicate_links (
+       tenant_id, owner_job_id, candidate_url, reason, rejected_at
+     ) VALUES ('local', ?, ?, 'rejected candidate', ?)`,
+  ).run(ANCHOR_JOB_ID, SOURCE_URL, NOW);
+
+  db.prepare(
+    `INSERT INTO application_repeat_overrides (
+       tenant_id, override_id, target_job_id, prior_job_id, relationship,
+       evidence_fingerprint, evidence_json, reason, confirmed_by, confirmed_at
+     ) VALUES ('local', 'repeat-cross', ?, ?, 'same employer', 'repeat-fingerprint', ?, 'test', 'user', ?)`,
+  ).run(ANCHOR_JOB_ID, JOB_ID, JSON.stringify({ priorJobId: JOB_ID }), NOW);
+  db.prepare(
+    `INSERT INTO application_repeat_override_consumptions (tenant_id, override_id, run_id, consumed_at)
+     VALUES ('local', 'repeat-cross', 'repeat-run', ?)`,
+  ).run(NOW);
+  db.prepare(
+    `INSERT INTO application_repeat_audit (
+       tenant_id, audit_id, audit_key, target_job_id, action, evidence_fingerprint,
+       evidence_json, override_id, actor, occurred_at
+     ) VALUES ('local', 'repeat-audit', 'repeat-audit-key', ?, 'override_confirmed',
+               'repeat-fingerprint', ?, 'repeat-cross', 'user', ?)`,
+  ).run(ANCHOR_JOB_ID, JSON.stringify([{ priorApplication: { jobId: JOB_ID } }]), NOW);
+  db.prepare(
+    `INSERT INTO application_repeat_audit (
+       tenant_id, audit_id, audit_key, target_job_id, action, evidence_fingerprint,
+       evidence_json, override_id, actor, occurred_at
+     ) VALUES ('local', 'repeat-audit-payload', 'repeat-audit-payload-key', ?, 'blocked',
+               'repeat-payload', ?, NULL, 'system', ?)`,
+  ).run(
+    ANCHOR_JOB_ID,
+    JSON.stringify([{ priorApplication: { jobId: JOB_ID, title: "Previous role" } }]),
+    NOW,
+  );
+  db.prepare(
+    `INSERT INTO application_repeat_audit (
+       tenant_id, audit_id, audit_key, target_job_id, action, evidence_fingerprint,
+       evidence_json, override_id, actor, occurred_at
+     ) VALUES ('local', 'repeat-audit-near-match', 'repeat-audit-near-match-key', ?, 'allowed',
+               'repeat-near-match', ?, NULL, 'system', ?)`,
+  ).run(
+    ANCHOR_JOB_ID,
+    JSON.stringify([{ priorApplication: { jobId: ANCHOR_JOB_ID, title: JOB_ID }, note: JOB_ID }]),
+    NOW,
+  );
+
+  db.prepare(
+    `INSERT INTO contacts (tenant_id, contact_id, employer, job_id, role, created_at, updated_at)
+     VALUES ('local', 'contact-1', 'Example', ?, 'recruiter', ?, ?)`,
+  ).run(JOB_ID, NOW, NOW);
+  db.prepare(
+    `INSERT INTO contact_attributes (
+       tenant_id, attribute_id, contact_id, attribute_kind, source_kind, source_ref, capture_method, recorded_at
+     ) VALUES ('local', 'attribute-1', 'contact-1', 'email', 'user_entered', 'manual', 'manual', ?)`,
+  ).run(NOW);
+  db.prepare(
+    `INSERT INTO contact_research_tasks (
+       tenant_id, task_id, employer, job_id, status, source_attempts_json, updated_at
+     ) VALUES ('local', 'research-1', 'Example', ?, 'completed', '[]', ?)`,
+  ).run(JOB_ID, NOW);
+  db.prepare(
+    `INSERT INTO contact_candidates (
+       tenant_id, candidate_id, task_id, source_kind, source_ref, capture_method, proposed_at
+     ) VALUES ('local', 'candidate-1', 'research-1', 'public_web_page', 'https://example.test', 'manual', ?)`,
+  ).run(NOW);
+  db.prepare(
+    `INSERT INTO outreach_threads (tenant_id, thread_id, contact_id, job_id, created_at, updated_at)
+     VALUES ('local', 'thread-1', 'contact-1', ?, ?, ?)`,
+  ).run(JOB_ID, NOW, NOW);
+  db.prepare(
+    `INSERT INTO outreach_drafts (tenant_id, draft_id, thread_id, kind, body_text, created_at)
+     VALUES ('local', 'draft-1', 'thread-1', 'initial', 'reviewable draft', ?)`,
+  ).run(NOW);
+  db.prepare(
+    `INSERT INTO outreach_send_logs (tenant_id, send_log_id, thread_id, draft_id, channel, sent_at, logged_at)
+     VALUES ('local', 'send-1', 'thread-1', 'draft-1', 'email', ?, ?)`,
+  ).run(NOW, NOW);
+  db.prepare(
+    `INSERT INTO operational_attempt_metrics (tenant_id, occurred_at, stage, attempt_kind, outcome, job_id)
+     VALUES ('local', ?, 'discover', 'fetch', 'succeeded', ?)`,
+  ).run(NOW, JOB_ID);
+
+  for (const [tableName, idColumn, idValue] of [
+    ["contact_projections", "contact_id", "contact-1"],
+    ["contact_research_task_projections", "task_id", "research-1"],
+  ] as const) {
+    db.prepare(`INSERT INTO ${tableName} (tenant_id, ${idColumn}, job_id) VALUES ('local', ?, ?)`).run(idValue, JOB_ID);
+  }
+  for (const tableName of ["outreach_thread_projections", "due_follow_up_projections"]) {
+    db.prepare(`INSERT INTO ${tableName} (tenant_id, thread_id, contact_id, job_id) VALUES ('local', 'thread-1', 'contact-1', ?)`).run(JOB_ID);
+  }
+
+  db.prepare(`INSERT INTO apply_run_projections (run_id, tenant_id, job_id) VALUES ('apply-target', 'local', ?)`).run(JOB_ID);
+  db.prepare(`INSERT INTO artifact_list_projections (artifact_id, tenant_id, job_id) VALUES ('artifact-target', 'local', ?)`).run(JOB_ID);
+  db.prepare(`INSERT INTO job_list_projections (tenant_id, job_id) VALUES ('local', ?), ('local', ?)`).run(JOB_ID, ANCHOR_JOB_ID);
+  db.prepare(`INSERT INTO job_detail_projections (tenant_id, job_id) VALUES ('local', ?), ('local', ?)`).run(JOB_ID, ANCHOR_JOB_ID);
+  db.prepare(`INSERT INTO evidence_usage_projections (tenant_id, projection_kind, projection_id, title, payload_json)
+              VALUES ('local', 'entry', 'stale-target', 'stale target', '{}'), (?, 'entry', 'other-evidence', 'other evidence', '{}')`).run(OTHER_TENANT);
+  db.prepare(`INSERT INTO dashboard_projections (tenant_id, total_jobs, generated_at) VALUES ('local', 2, ?), (?, 1, ?)`).run(NOW, OTHER_TENANT, NOW);
+  db.prepare(`INSERT INTO event_watermarks (projection_name, last_event_id, updated_at) VALUES ('operations_projections', 999, ?)`).run(NOW);
+}
+
+describe("exact-v7 permanent job deletion", () => {
+  it("purges only the local Job aggregate, preserves independent history, and permits rediscovery", () => {
+    const db = exactDatabase();
+    seedExactV7DeleteGraph(db);
+    const manifestBefore = schemaManifest(db, EXACT_V7_SCHEMA_MANIFEST.version);
+    const otherJobsBefore = rowSnapshot(db, "jobs", "tenant_id = ? AND job_id = ?", [OTHER_TENANT, JOB_ID]);
+    const otherLocatorsBefore = rowSnapshot(db, "job_locators", "tenant_id = ? AND job_id = ?", [OTHER_TENANT, JOB_ID]);
+    const otherEvidenceBefore = rowSnapshot(db, "evidence_usage_projections", "tenant_id = ?", [OTHER_TENANT]);
+    const otherDashboardBefore = rowSnapshot(db, "dashboard_projections", "tenant_id = ?", [OTHER_TENANT]);
+
+    expect(db.pragma("foreign_keys", { simple: true })).toBe(1);
+    expect(permanentlyDeleteJob(db, JOB_URL)).toEqual({ ok: true, count: 1, jobKeys: [JOB_ID] });
+
+    for (const tableName of [
+      "jobs",
+      "job_locators",
+      "jobctrl_deleted_jobs",
+      "jobctrl_hidden_jobs",
+      "job_stage_states",
+      "job_materials",
+      "job_materials_artifacts",
+      "application_email_evidence",
+      "application_outcomes",
+      "apply_run_projections",
+      "artifact_list_projections",
+      "job_detail_projections",
+      "job_list_projections",
+    ]) {
+      expect(countRows(db, tableName, "tenant_id = ? AND job_id = ?", ["local", JOB_ID])).toBe(0);
+    }
+    expect(countRows(db, "job_events", "tenant_id = ? AND job_id = ?", ["local", JOB_ID])).toBe(0);
+    const detachedEvents = db.prepare(
+      `SELECT job_id, event_type, payload_json, entity_kind, entity_ref
+         FROM job_events
+        WHERE tenant_id = 'local'
+          AND entity_kind IN ('contact', 'contact_research', 'outreach')
+        ORDER BY entity_kind`,
+    ).all() as Array<{
+      job_id: string | null;
+      event_type: string;
+      payload_json: string | null;
+      entity_kind: string;
+      entity_ref: string | null;
+    }>;
+    expect(detachedEvents).toEqual([
+      expect.objectContaining({
+        job_id: null,
+        event_type: "ContactTimelineRecorded",
+        entity_kind: "contact",
+        entity_ref: "contact-1",
+      }),
+      expect.objectContaining({
+        job_id: null,
+        event_type: "ContactResearchCompleted",
+        entity_kind: "contact_research",
+        entity_ref: "research-1",
+      }),
+      expect.objectContaining({
+        job_id: null,
+        event_type: "OutreachDrafted",
+        entity_kind: "outreach",
+        entity_ref: "thread-1",
+      }),
+    ]);
+    expect(JSON.parse(detachedEvents[0]!.payload_json!)).toEqual({ nested: { jobId: JOB_ID }, note: "contact audit" });
+    expect(JSON.parse(detachedEvents[1]!.payload_json!)).toEqual({ taskId: "research-1", note: "research audit" });
+    expect(JSON.parse(detachedEvents[2]!.payload_json!)).toEqual({
+      jobId: ANCHOR_JOB_ID,
+      threadId: "thread-1",
+      note: "outreach audit",
+    });
+    expect(countRows(db, "job_duplicate_links", "tenant_id = ? AND (surviving_job_id = ? OR superseded_job_or_observation_id = ?)", ["local", JOB_ID, JOB_ID])).toBe(0);
+    expect(countRows(db, "job_rejected_duplicate_links", "tenant_id = ? AND candidate_url = ?", ["local", SOURCE_URL])).toBe(0);
+    expect(countRows(db, "application_repeat_override_consumptions", "tenant_id = ? AND override_id = ?", ["local", "repeat-cross"])).toBe(0);
+    expect(countRows(db, "application_repeat_audit", "tenant_id = ? AND audit_id = ?", ["local", "repeat-audit"])).toBe(0);
+    expect(countRows(db, "application_repeat_audit", "tenant_id = ? AND audit_id = ?", ["local", "repeat-audit-payload"])).toBe(0);
+    expect(countRows(db, "application_repeat_audit", "tenant_id = ? AND audit_id = ?", ["local", "repeat-audit-near-match"])).toBe(1);
+
+    for (const tableName of ["contacts", "contact_research_tasks", "outreach_threads", "operational_attempt_metrics"]) {
+      expect(rowSnapshot(db, tableName, "tenant_id = 'local'")).toEqual(
+        expect.arrayContaining([expect.objectContaining({ job_id: null })]),
+      );
+    }
+    for (const tableName of [
+      "contact_projections",
+      "contact_research_task_projections",
+      "outreach_thread_projections",
+      "due_follow_up_projections",
+    ]) {
+      expect(rowSnapshot(db, tableName, "tenant_id = 'local'")).toEqual(
+        expect.arrayContaining([expect.objectContaining({ job_id: null })]),
+      );
+    }
+    for (const tableName of ["contact_attributes", "contact_candidates", "outreach_drafts", "outreach_send_logs"]) {
+      expect(countRows(db, tableName, "tenant_id = 'local'")).toBe(1);
+    }
+
+    expect(db.prepare("SELECT total_jobs FROM dashboard_projections WHERE tenant_id = 'local'").get()).toEqual({ total_jobs: 1 });
+    expect(countRows(db, "evidence_usage_projections", "tenant_id = 'local'")).toBe(0);
+    expect(rowSnapshot(db, "event_watermarks", "projection_name = 'operations_projections'")).toEqual([
+      expect.objectContaining({ last_event_id: 999 }),
+    ]);
+    expect(db.prepare("PRAGMA foreign_key_check").all()).toEqual([]);
+    expect(schemaManifest(db, EXACT_V7_SCHEMA_MANIFEST.version)).toEqual(manifestBefore);
+
+    expect(rowSnapshot(db, "jobs", "tenant_id = ? AND job_id = ?", [OTHER_TENANT, JOB_ID])).toEqual(otherJobsBefore);
+    expect(rowSnapshot(db, "job_locators", "tenant_id = ? AND job_id = ?", [OTHER_TENANT, JOB_ID])).toEqual(otherLocatorsBefore);
+    expect(rowSnapshot(db, "evidence_usage_projections", "tenant_id = ?", [OTHER_TENANT])).toEqual(otherEvidenceBefore);
+    expect(rowSnapshot(db, "dashboard_projections", "tenant_id = ?", [OTHER_TENANT])).toEqual(otherDashboardBefore);
+
+    insertJob(db, "local", REDISCOVERED_JOB_ID, JOB_URL);
+    db.prepare(
+      `INSERT INTO job_locators (
+         tenant_id, job_id, locator_kind, locator_value, is_current, first_seen_at, last_seen_at
+       ) VALUES ('local', ?, 'posting_url', ?, 1, ?, ?)`,
+    ).run(REDISCOVERED_JOB_ID, SOURCE_URL, NOW, NOW);
+    expect(db.prepare("SELECT job_id FROM jobs WHERE tenant_id = 'local' AND url = ?").get(JOB_URL)).toEqual({
+      job_id: REDISCOVERED_JOB_ID,
+    });
+
+    rebuildTenantDeleteProjections(db, "local");
+    expect(db.prepare("SELECT total_jobs FROM dashboard_projections WHERE tenant_id = 'local'").get()).toEqual({ total_jobs: 1 });
+  });
+});

--- a/apps/api/test/profile-events-v7.test.ts
+++ b/apps/api/test/profile-events-v7.test.ts
@@ -1,0 +1,86 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import Database from "better-sqlite3";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { hasRetailorableResumes, recordProfileUpdatedEvent } from "../src/profile-events.js";
+import { initializeExactV7Database } from "./v7-schema.js";
+
+const JOB_ID = "00000000-0000-4000-8000-000000000091";
+const NOW = "2026-07-31T13:00:00Z";
+const cleanups: Array<() => void> = [];
+
+afterEach(() => {
+  while (cleanups.length) cleanups.pop()?.();
+});
+
+function exactDatabase(): Database.Database {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "jobctrl-profile-events-v7-"));
+  const dbPath = path.join(dir, "jobs.db");
+  initializeExactV7Database(dbPath);
+  const db = new Database(dbPath);
+  db.pragma("foreign_keys = ON");
+  cleanups.push(() => {
+    db.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+  return db;
+}
+
+describe("exact-v7 profile events", () => {
+  it("records canonical profile events and detects only approved canonical resumes", () => {
+    const db = exactDatabase();
+
+    expect(hasRetailorableResumes(db)).toBe(false);
+    db.prepare(
+      `INSERT INTO jobs (tenant_id, job_id, url, tailored_resume_path)
+       VALUES ('local', ?, 'https://example.com/jobs/profile-events', '/legacy/resume.pdf')`,
+    ).run(JOB_ID);
+    expect(hasRetailorableResumes(db)).toBe(false);
+
+    db.prepare(
+      `INSERT INTO job_materials (
+         tenant_id, job_id, generation, status, created_at, updated_at, metadata_json
+       ) VALUES ('local', ?, 1, 'resume_approved', ?, ?, '{}')`,
+    ).run(JOB_ID, NOW, NOW);
+    db.prepare(
+      `INSERT INTO job_materials_artifacts (
+         tenant_id, job_id, generation, artifact_type, artifact_id, status,
+         path, render_format, metadata_json, created_at
+       ) VALUES ('local', ?, 1, 'tailored_resume', 'profile-resume', 'approved',
+                 '/canonical/resume.pdf', 'pdf', '{}', ?)`,
+    ).run(JOB_ID, NOW);
+    expect(hasRetailorableResumes(db)).toBe(true);
+
+    const event = recordProfileUpdatedEvent(db, ["resume", "preferences"], NOW);
+    expect(event).toMatchObject({ tenantId: "local", eventType: "ProfileUpdated" });
+    const row = db
+      .prepare(
+        `SELECT tenant_id, job_id, identity_version, stage, event_type, payload_json
+           FROM job_events
+          WHERE event_type = 'ProfileUpdated'`,
+      )
+      .get() as {
+      tenant_id: string;
+      job_id: string | null;
+      identity_version: number;
+      stage: string | null;
+      event_type: string;
+      payload_json: string;
+    };
+    expect(row).toMatchObject({
+      tenant_id: "local",
+      job_id: null,
+      identity_version: 1,
+      stage: null,
+      event_type: "ProfileUpdated",
+    });
+    expect(JSON.parse(row.payload_json)).toMatchObject({
+      tenantId: "local",
+      changedSections: ["resume", "preferences"],
+    });
+    expect(JSON.stringify(row)).not.toContain("job_url");
+  });
+});

--- a/apps/api/test/qa-workflow.test.ts
+++ b/apps/api/test/qa-workflow.test.ts
@@ -11,7 +11,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { CredentialStore } from "../src/credentials.js";
 import { buildApp, type BuildAppOptions } from "../src/server.js";
-import { createQaWorkspace, removeQaWorkspace, type QaWorkspace } from "./qa-seed.js";
+import {
+  createQaWorkspace,
+  QA_PLATFORM_JOB_ID,
+  QA_RISK_JOB_ID,
+  removeQaWorkspace,
+  type QaWorkspace,
+} from "./qa-seed.js";
 
 const LOOPBACK_HEADERS = { origin: "http://127.0.0.1:5173" };
 
@@ -65,7 +71,7 @@ describe("seeded local QA workflow", () => {
     expect(deleteFailed.statusCode, deleteFailed.body).toBe(200);
     expect(deleteFailed.json()).toMatchObject({
       count: 1,
-      jobKeys: ["https://linkedin.com/jobs/view/qa-risk-manager"],
+      jobKeys: [QA_RISK_JOB_ID],
     });
 
     const activeRisk = await app.inject({ method: "GET", url: "/v1/jobs?deleted=active&q=risk" });
@@ -111,7 +117,7 @@ describe("seeded local QA workflow", () => {
     expect(artifacts.json().pagination.total).toBe(8);
     const gitlabArtifacts = artifacts
       .json()
-      .items.filter((artifact: { jobKey: string }) => artifact.jobKey === "https://boards.greenhouse.io/gitlab/jobs/qa-platform-director");
+      .items.filter((artifact: { jobKey: string }) => artifact.jobKey === QA_PLATFORM_JOB_ID);
     expect(gitlabArtifacts).toHaveLength(7);
     expect(gitlabArtifacts.map((artifact: { type: string }) => artifact.type).sort()).toEqual(
       expect.arrayContaining([
@@ -162,13 +168,13 @@ describe("seeded local QA workflow", () => {
     const artifactsAfterDelete = await app.inject({ method: "GET", url: "/v1/artifacts?pageSize=20" });
     expect(artifactsAfterDelete.statusCode, artifactsAfterDelete.body).toBe(200);
     expect(artifactsAfterDelete.json().items.map((artifact: { jobKey: string }) => artifact.jobKey)).not.toContain(
-      "https://boards.greenhouse.io/gitlab/jobs/qa-platform-director",
+      QA_PLATFORM_JOB_ID,
     );
 
     const dashboardAfterDelete = await app.inject({ method: "GET", url: "/v1/dashboard/summary" });
     expect(dashboardAfterDelete.statusCode, dashboardAfterDelete.body).toBe(200);
     expect(dashboardAfterDelete.json().applyRuns.map((run: { jobKey: string }) => run.jobKey)).not.toContain(
-      "https://boards.greenhouse.io/gitlab/jobs/qa-platform-director",
+      QA_PLATFORM_JOB_ID,
     );
 
     await app.close();

--- a/apps/api/test/read-model-v7.test.ts
+++ b/apps/api/test/read-model-v7.test.ts
@@ -14,6 +14,7 @@ import {
 } from "../src/read-model.js";
 import { BUILT_IN_RESUME_TEMPLATE_THEME } from "../src/resume-templates.js";
 import { EXACT_V7_SCHEMA_MANIFEST, schemaManifest } from "../src/schema-manifest.js";
+import { hideJob, restoreJob, softDeleteJob, unhideJob } from "../src/write-model.js";
 import { initializeExactV7Database } from "./v7-schema.js";
 
 const JOB_ID = "00000000-0000-4000-8000-000000000081";
@@ -221,5 +222,65 @@ describe("exact-v7 read model job ids", () => {
     );
     expect(activity.items.some((item) => item.jobKey === HIDDEN_JOB_ID || item.jobKey === DELETED_JOB_ID)).toBe(false);
     expect(getJobDetail(db, "not-a-canonical-job-id")).toBeNull();
+  });
+
+  it("resolves URL locators once and writes reversible lifecycle state with canonical job ids", () => {
+    const db = seededDatabase();
+
+    expect(softDeleteJob(db, JOB_URL, { reason: "not relevant" })).toMatchObject({
+      ok: true,
+      count: 1,
+      jobKeys: [JOB_ID],
+    });
+    expect(
+      db.prepare("SELECT tenant_id, job_id, reason, restored_at FROM jobctrl_deleted_jobs WHERE tenant_id = 'local' AND job_id = ?").get(JOB_ID),
+    ).toMatchObject({ tenant_id: "local", job_id: JOB_ID, reason: "not relevant", restored_at: null });
+    expect(
+      db.prepare("SELECT COUNT(*) AS count FROM jobctrl_deleted_jobs WHERE tenant_id = ? AND job_id = ?").get(OTHER_TENANT, JOB_ID),
+    ).toMatchObject({ count: 0 });
+
+    expect(restoreJob(db, APPLICATION_URL)).toMatchObject({ ok: true, count: 1, jobKeys: [JOB_ID] });
+    expect(
+      db.prepare("SELECT restored_at FROM jobctrl_deleted_jobs WHERE tenant_id = 'local' AND job_id = ?").get(JOB_ID),
+    ).toMatchObject({ restored_at: expect.any(String) });
+
+    expect(hideJob(db, SOURCE_URL, { reason: "later" })).toMatchObject({
+      ok: true,
+      count: 1,
+      jobKeys: [JOB_ID],
+    });
+    expect(unhideJob(db, JOB_ID)).toMatchObject({ ok: true, count: 1, jobKeys: [JOB_ID] });
+    expect(
+      db.prepare("SELECT unhidden_at FROM jobctrl_hidden_jobs WHERE tenant_id = 'local' AND job_id = ?").get(JOB_ID),
+    ).toMatchObject({ unhidden_at: expect.any(String) });
+
+    const lifecycleEvents = db
+      .prepare(
+        `SELECT tenant_id, job_id, identity_version, event_type, payload_json
+           FROM job_events
+          WHERE tenant_id = 'local'
+            AND job_id = ?
+            AND event_type IN ('JobDeleted', 'JobRestored', 'JobHidden', 'JobUnhidden')
+          ORDER BY event_id`,
+      )
+      .all(JOB_ID) as Array<{
+        tenant_id: string;
+        job_id: string;
+        identity_version: number;
+        event_type: string;
+        payload_json: string;
+      }>;
+    expect(lifecycleEvents.map((event) => event.event_type)).toEqual([
+      "JobDeleted",
+      "JobRestored",
+      "JobHidden",
+      "JobUnhidden",
+    ]);
+    expect(lifecycleEvents.every((event) => event.tenant_id === "local" && event.job_id === JOB_ID)).toBe(true);
+    expect(lifecycleEvents.every((event) => event.identity_version === 1)).toBe(true);
+    expect(lifecycleEvents.map((event) => JSON.parse(event.payload_json))).toEqual(
+      expect.arrayContaining([expect.objectContaining({ tenantId: "local", jobId: JOB_ID })]),
+    );
+    expect(JSON.stringify(lifecycleEvents)).not.toContain("job_url");
   });
 });

--- a/apps/api/test/write-model-cancel.test.ts
+++ b/apps/api/test/write-model-cancel.test.ts
@@ -5,12 +5,14 @@ import path from "node:path";
 import Database from "better-sqlite3";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-import { cancelJobAction, markJobApplied, markJobSkipped } from "../src/write-model.js";
+import type { Stage } from "../src/contracts.js";
+import { cancelJobAction, markJobApplied, markJobSkipped, resetJobStage } from "../src/write-model.js";
 import { initializeExactV7Database } from "./v7-schema.js";
 
 const JOB_URL = "https://example.com/jobs/ready";
 const JOB_ID = "10000000-0000-4000-8000-000000000001";
 const TENANT_ID = "local";
+const RETIRED_AT = "2025-01-01T00:00:00Z";
 
 describe("cancelJobAction", () => {
   let directory: string;
@@ -22,8 +24,30 @@ describe("cancelJobAction", () => {
     initializeExactV7Database(dbPath);
     db = new Database(dbPath);
     db.prepare(
-      "INSERT INTO jobs (tenant_id, job_id, url, application_url) VALUES (?, ?, ?, ?)",
-    ).run(TENANT_ID, JOB_ID, JOB_URL, `${JOB_URL}/apply`);
+      `INSERT INTO jobs (
+         tenant_id, job_id, url, application_url,
+         detail_scraped_at, detail_error,
+         fit_score, score_reasoning, scored_at,
+         tailored_resume_path, tailored_at, tailor_attempts,
+         cover_letter_path, cover_letter_at, cover_attempts,
+         applied_at, apply_status, apply_error, apply_attempts,
+         agent_id, apply_task_id
+       ) VALUES (?, ?, ?, ?, ?, 'retired-detail-error', 10, 'retired-score', ?,
+                 '/tmp/retired-resume.txt', ?, 4,
+                 '/tmp/retired-cover.txt', ?, 3,
+                 ?, 'retired-status', 'retired-apply-error', 2,
+                 'retired-agent', 'retired-task')`,
+    ).run(
+      TENANT_ID,
+      JOB_ID,
+      JOB_URL,
+      `${JOB_URL}/apply`,
+      RETIRED_AT,
+      RETIRED_AT,
+      RETIRED_AT,
+      RETIRED_AT,
+      RETIRED_AT,
+    );
     db.prepare(
       `INSERT INTO job_locators (
          tenant_id, job_id, locator_kind, locator_value, is_current,
@@ -90,6 +114,7 @@ describe("cancelJobAction", () => {
     ["applied", markJobApplied, "succeeded", "ApplicationManuallyMarked"],
     ["skipped", markJobSkipped, "skipped", "StageSkipped"],
   ] as const)("persists a manually %s result only in the canonical aggregate", (_label, action, state, eventType) => {
+    const retiredBefore = retiredJobState();
     const result = action(db, JOB_URL, { reason: "confirmed by user" });
 
     expect(result.jobUrl).toBe(JOB_URL);
@@ -113,5 +138,79 @@ describe("cancelJobAction", () => {
       jobId: JOB_ID,
       reason: "confirmed by user",
     });
+    expect(retiredJobState()).toEqual(retiredBefore);
   });
+
+  it.each(["score", "tailor", "cover", "apply"] as const)(
+    "resets %s through canonical stage state without writing retired jobs columns",
+    (stage) => {
+      insertStage(stage, "failed", 3);
+      const retiredBefore = retiredJobState();
+
+      const result = resetJobStage(db, JOB_URL, stage, { resetAttempts: true });
+
+      expect(result.stage).toMatchObject({ state: "pending", attemptCount: 0 });
+      expect(retiredJobState()).toEqual(retiredBefore);
+      expect(eventCount("StageReset")).toBe(1);
+    },
+  );
+
+  it("resets enrichment only through the canonical aggregate", () => {
+    insertStage("enrich", "failed", 2);
+    db.prepare(
+      `INSERT INTO job_enrichments (
+         tenant_id, job_id, current_status, full_description,
+         application_url, enriched_at, extraction_tier, updated_at
+       ) VALUES (?, ?, 'enriched', 'canonical description', ?, ?, 'json_ld', ?)`,
+    ).run(TENANT_ID, JOB_ID, `${JOB_URL}/canonical-apply`, RETIRED_AT, RETIRED_AT);
+    const retiredBefore = retiredJobState();
+
+    const result = resetJobStage(db, JOB_URL, "enrich", { resetAttempts: true });
+    const enrichment = db.prepare(
+      `SELECT current_status, full_description, application_url,
+              enriched_at, extraction_tier
+         FROM job_enrichments
+        WHERE tenant_id = ? AND job_id = ?`,
+    ).get(TENANT_ID, JOB_ID);
+
+    expect(result.stage).toMatchObject({ state: "pending", attemptCount: 0 });
+    expect(enrichment).toEqual({
+      current_status: "pending",
+      full_description: null,
+      application_url: null,
+      enriched_at: null,
+      extraction_tier: null,
+    });
+    expect(retiredJobState()).toEqual(retiredBefore);
+    expect(eventCount("StageReset")).toBe(1);
+  });
+
+  function insertStage(stage: Stage, state: string, attemptCount: number): void {
+    db.prepare(
+      `INSERT INTO job_stage_states (
+         tenant_id, job_id, stage, state, attempt_count, updated_at, retryable
+       ) VALUES (?, ?, ?, ?, ?, ?, 1)`,
+    ).run(TENANT_ID, JOB_ID, stage, state, attemptCount, RETIRED_AT);
+  }
+
+  function eventCount(eventType: string): number {
+    const row = db.prepare(
+      `SELECT COUNT(*) AS count FROM job_events
+       WHERE tenant_id = ? AND job_id = ? AND event_type = ?`,
+    ).get(TENANT_ID, JOB_ID, eventType) as { count: number };
+    return row.count;
+  }
+
+  function retiredJobState(): Record<string, unknown> {
+    return db.prepare(
+      `SELECT detail_scraped_at, detail_error,
+              fit_score, score_reasoning, scored_at,
+              tailored_resume_path, tailored_at, tailor_attempts,
+              cover_letter_path, cover_letter_at, cover_attempts,
+              applied_at, apply_status, apply_error, apply_attempts,
+              agent_id, apply_task_id
+         FROM jobs
+        WHERE tenant_id = ? AND job_id = ?`,
+    ).get(TENANT_ID, JOB_ID) as Record<string, unknown>;
+  }
 });

--- a/workers/automation/src/jobctrl/database.py
+++ b/workers/automation/src/jobctrl/database.py
@@ -1047,7 +1047,6 @@ def ensure_profile_tables(conn: sqlite3.Connection | None = None) -> list[str]:
         ON candidate_profile_skill_categories(tenant_id, profile_id, position_index)
         """
     )
-    _ensure_candidate_profile_columns(conn)
     conn.commit()
     return [
         "candidate_profiles",
@@ -1064,29 +1063,6 @@ def ensure_profile_tables(conn: sqlite3.Connection | None = None) -> list[str]:
         "candidate_profile_required_skills",
         "candidate_profile_resume_constraint_metrics",
     ]
-
-
-_PROFILE_COLUMN_MIGRATIONS: dict[str, str] = {
-    "experience_target_track": "TEXT NOT NULL DEFAULT ''",
-    "experience_target_seniority_floor": "TEXT NOT NULL DEFAULT ''",
-    "experience_target_functions": "TEXT NOT NULL DEFAULT ''",
-    "experience_target_specializations": "TEXT NOT NULL DEFAULT ''",
-    "experience_target_locations": "TEXT NOT NULL DEFAULT ''",
-    "experience_target_work_models": "TEXT NOT NULL DEFAULT ''",
-    "tailoring_claim_mode": "TEXT NOT NULL DEFAULT 'evidence_reframing'",
-    "tailoring_auto_approvable_claim_modes_json": "TEXT NOT NULL DEFAULT '[\"verified_only\",\"evidence_reframing\"]'",
-    "tailoring_allow_adjacent_achievement_drafts": "INTEGER NOT NULL DEFAULT 0",
-    "revision_min_fit_score": "INTEGER NOT NULL DEFAULT 8",
-    "revision_must_have_coverage": "REAL NOT NULL DEFAULT 0.85",
-    "revision_max_attempts": "INTEGER NOT NULL DEFAULT 1",
-}
-
-
-def _ensure_candidate_profile_columns(conn: sqlite3.Connection) -> None:
-    existing_cols = {row[1] for row in conn.execute("PRAGMA table_info(candidate_profiles)").fetchall()}
-    for column, definition in _PROFILE_COLUMN_MIGRATIONS.items():
-        if column not in existing_cols:
-            conn.execute(f"ALTER TABLE candidate_profiles ADD COLUMN {column} {definition}")
 
 
 def ensure_score_tables(conn: sqlite3.Connection | None = None) -> list[str]:

--- a/workers/automation/tests/test_sqlite_profile_repository.py
+++ b/workers/automation/tests/test_sqlite_profile_repository.py
@@ -109,6 +109,35 @@ def test_profile_schema_is_normalized_without_blob_escape_hatch(tmp_path):
     assert root_columns.isdisjoint(forbidden)
 
 
+def test_profile_schema_initializer_does_not_repair_partial_legacy_table(tmp_path):
+    conn = sqlite3.connect(tmp_path / "legacy-profile.db")
+    conn.row_factory = sqlite3.Row
+    conn.execute(
+        """
+        CREATE TABLE candidate_profiles (
+            tenant_id TEXT NOT NULL DEFAULT 'local',
+            profile_id TEXT NOT NULL DEFAULT 'default',
+            updated_at TEXT NOT NULL,
+            PRIMARY KEY (tenant_id, profile_id)
+        )
+        """
+    )
+    statements: list[str] = []
+    conn.set_trace_callback(statements.append)
+
+    ensure_profile_tables(conn)
+
+    root_columns = {
+        row["name"] for row in conn.execute("PRAGMA table_info(candidate_profiles)")
+    }
+    assert "experience_target_track" not in root_columns
+    assert not any(
+        statement.lstrip().upper().startswith("ALTER TABLE CANDIDATE_PROFILES")
+        for statement in statements
+    )
+    conn.close()
+
+
 def test_save_and_load_round_trips_profile_through_relational_rows(tmp_path):
     repo, conn, events = _new_repo(tmp_path)
 


### PR DESCRIPTION
## Summary

- enforce tenant-scoped JobId writes for delete, hide, restore, permanent-delete, and preparation pickup lifecycle paths
- preserve exact-v7 foreign-key deletion semantics and rebuild only the affected tenant projections
- remove profile schema-repair and retired `jobs` lifecycle write fallbacks so malformed schemas fail at the owning boundary
- keep manual Apply actions and retry resets canonical while preserving terminal cancellation results and idempotent events
- add exact-v7 regressions for permanent deletion, profile admission, lifecycle resets, and server pickup eligibility

## Why

This child closes the remaining known production runtime-write fallbacks after #643. URLs remain external locators; persisted lifecycle state is owned by `(tenant_id, job_id)` and the exact local v7 schema.

## Validation

- 13 focused TypeScript files: 133 tests passed
- focused preparation-pickup server cases: 4 passed
- API and contracts TypeScript checks passed under Node 22
- focused Python groups: 42 + 16 + 8 + 7 tests passed
- focused Ruff checks and `git diff --check` passed
- independent Step 1 review: PASS, 0 Blocker / 0 High
- reviewer notes deferred to their later mapped objectives: 2 Medium (starting-state cancellation; bulk locator alias deduplication), 1 Low (two-generation reset fixture depth)

## Stack

Ready-for-review child of #643 in GitHub Stack #632.

