### PR TITLE
fix(discovery): persist manual captures by JobId

### DIFF
--- a/workers/automation/src/jobctrl/discovery/manual_capture_workflow.py
+++ b/workers/automation/src/jobctrl/discovery/manual_capture_workflow.py
@@ -169,7 +169,7 @@ def _capture_row(
         SELECT tenant_id, item_id, originating_url, source_id, status,
                imported_at, capture_mode, captured_url, content_sha256,
                content_length, note, future_manual_action_required,
-               retry_context_json, job_key
+               retry_context_json, job_id
         FROM manual_capture_queue
         WHERE tenant_id = ? AND item_id = ?
         LIMIT 1
@@ -184,6 +184,8 @@ def _validated_imported_result(
     row: sqlite3.Row,
     content: str,
 ) -> ManualCaptureImportActivityOutput:
+    from jobctrl.domain.identifiers import canonical_job_id
+
     imported_at = _non_empty(row["imported_at"])
     originating_url = _non_empty(row["originating_url"])
     expected_url = payload.captured_url or originating_url
@@ -196,7 +198,6 @@ def _validated_imported_result(
     _compare(mismatches, "tenant_id", row["tenant_id"], payload.tenant_id)
     _compare(mismatches, "item_id", row["item_id"], payload.item_id)
     _compare(mismatches, "captured_url", row["captured_url"], expected_url)
-    _compare(mismatches, "job_key", row["job_key"], expected_url)
     _compare(mismatches, "content_sha256", row["content_sha256"], expected_hash)
     _compare(mismatches, "content_length", row["content_length"], len(content))
     _compare(mismatches, "capture_mode", row["capture_mode"], capture.capture_mode)
@@ -209,6 +210,11 @@ def _validated_imported_result(
     )
     if not imported_at:
         mismatches.append("imported_at")
+    job_id = _non_empty(row["job_id"])
+    try:
+        canonical_job_id(job_id)
+    except ValueError:
+        mismatches.append("job_id")
     if not isinstance(provenance, dict):
         mismatches.append("manual_capture_provenance")
     else:
@@ -234,7 +240,7 @@ def _validated_imported_result(
     return ManualCaptureImportActivityOutput(
         status="succeeded",
         item_id=_non_empty(row["item_id"]),
-        job_id=_non_empty(row["job_key"]),
+        job_id=job_id,
         imported_at=imported_at,
         retry_context=retry_context,
     )

--- a/workers/automation/src/jobctrl/infrastructure/discovery/production_wiring.py
+++ b/workers/automation/src/jobctrl/infrastructure/discovery/production_wiring.py
@@ -999,7 +999,6 @@ def import_manual_capture_item(
     tenant_id: TenantId = LOCAL_TENANT,
 ) -> ManualCaptureImportOutcome:
     """Import one queued manual capture through Discovery + Enrichment."""
-    ensure_worker_discovery_tables(conn)
     row = conn.execute(
         """
         SELECT item_id, originating_url, source_id, reason, retry_context_json
@@ -1034,8 +1033,9 @@ def import_manual_capture_item(
     if isinstance(extension_version, str) and extension_version.strip():
         retry_context["manual_capture_provenance"]["extension_version"] = extension_version.strip()
 
+    repository = SqliteJobRepository(conn)
     use_case = DiscoverJobsUseCase(
-        repository=SqliteJobRepository(conn),
+        repository=repository,
         publisher=DurableJobEventPublisher(conn, stage="discover"),
     )
     posting = _manual_capture_posting(
@@ -1050,6 +1050,10 @@ def import_manual_capture_item(
         postings=(posting,),
         run_id=f"manual-capture:{capture.item_id}",
     )
+    identity = repository.resolve_by_posting_url(tenant_id, posting.posting_url)
+    if identity is None:
+        raise RuntimeError("Manual capture import did not persist a canonical JobId")
+    job_id = identity.job_id
 
     snapshot_use_case = _manual_capture_snapshot_use_case(
         conn,
@@ -1058,7 +1062,7 @@ def import_manual_capture_item(
     )
     outcome = snapshot_use_case.execute(
         tenant_id=tenant_id,
-        job_id=JobId(captured_url),
+        job_id=job_id,
         url=captured_url,
         source_id=str(source_id),
         policy_id="user_mediated_capture",
@@ -1070,7 +1074,8 @@ def import_manual_capture_item(
     if outcome.ok and quarantine_reason and quarantine_reason != QuarantineReason.NONE.value:
         _upsert_quarantine_entry(
             conn,
-            job_id=captured_url,
+            tenant_id=tenant_id,
+            job_id=job_id,
             source_id=str(source_id),
             reason=quarantine_reason,
             confidence=None,
@@ -1093,7 +1098,7 @@ def import_manual_capture_item(
              note = ?,
              future_manual_action_required = ?,
              retry_context_json = ?,
-             job_key = ?
+             job_id = ?
          WHERE tenant_id = ? AND item_id = ?
         """,
         (
@@ -1105,7 +1110,7 @@ def import_manual_capture_item(
             capture.note,
             1 if capture.future_manual_action_required else 0,
             json.dumps(retry_context, sort_keys=True),
-            captured_url,
+            str(job_id),
             str(tenant_id),
             capture.item_id,
         ),
@@ -1113,7 +1118,7 @@ def import_manual_capture_item(
     conn.commit()
     return ManualCaptureImportOutcome(
         item_id=capture.item_id,
-        job_id=captured_url,
+        job_id=str(job_id),
         snapshot_version=outcome.captured_snapshot_version,
         promoted_to_job_enrichment=outcome.promoted_to_job_enrichment,
         quarantine_reason=quarantine_reason,
@@ -2074,7 +2079,8 @@ def manual_capture_content(capture: ManualCaptureImport) -> str:
 def _upsert_quarantine_entry(
     conn: sqlite3.Connection,
     *,
-    job_id: str,
+    tenant_id: TenantId,
+    job_id: JobId,
     source_id: str,
     reason: str,
     confidence: float | None,
@@ -2087,11 +2093,11 @@ def _upsert_quarantine_entry(
     conn.execute(
         """
         INSERT INTO discovery_quarantine_entries (
-            tenant_id, job_id, job_key, title, company, source_id, posting_url,
+            tenant_id, job_id, title, company, source_id, posting_url,
             reason, confidence, snapshot_version, captured_at, notice_text,
             status
-        ) VALUES (?, ?, ?, ?, '', ?, ?, ?, ?, ?, ?, ?, 'pending')
-        ON CONFLICT(tenant_id, job_key) DO UPDATE SET
+        ) VALUES (?, ?, ?, '', ?, ?, ?, ?, ?, ?, ?, 'pending')
+        ON CONFLICT(tenant_id, job_id) DO UPDATE SET
             title = excluded.title,
             source_id = excluded.source_id,
             posting_url = excluded.posting_url,
@@ -2103,9 +2109,8 @@ def _upsert_quarantine_entry(
             status = excluded.status
         """,
         (
-            str(LOCAL_TENANT),
-            job_id,
-            job_id,
+            str(tenant_id),
+            str(job_id),
             title,
             source_id,
             posting_url,

--- a/workers/automation/tests/test_manual_capture_workflow.py
+++ b/workers/automation/tests/test_manual_capture_workflow.py
@@ -37,6 +37,7 @@ from jobctrl.workflow_specs import build_manual_capture_import_workflow_spec
 
 
 _CAPTURE_URL = "https://example.test/jobs/staff-engineer"
+_MANUAL_JOB_ID = "00000000-0000-4000-8000-000000000042"
 _CAPTURE_HTML = """
 <html>
   <head>
@@ -77,7 +78,7 @@ async def _successful_manual_capture_import(
     return ManualCaptureImportActivityOutput(
         status="succeeded",
         item_id=payload.item_id,
-        job_id=_CAPTURE_URL,
+        job_id=_MANUAL_JOB_ID,
         imported_at="2026-07-10T10:00:00+00:00",
         retry_context={
             "manual_capture_provenance": {
@@ -125,7 +126,12 @@ def _pending_payload(item_id: str = "manual-1") -> ManualCaptureImportWorkflowIn
     )
 
 
-def _seed_pending(db_path: Path, *, item_id: str = "manual-1"):
+def _seed_pending(
+    db_path: Path,
+    *,
+    tenant_id: str = "local",
+    item_id: str = "manual-1",
+):
     conn = init_db(db_path)
     conn.execute(
         """
@@ -135,7 +141,7 @@ def _seed_pending(db_path: Path, *, item_id: str = "manual-1"):
         ) VALUES (?, ?, ?, ?, ?, ?, ?, 'pending')
         """,
         (
-            "local",
+            tenant_id,
             item_id,
             _CAPTURE_URL,
             "manual:test",
@@ -162,7 +168,7 @@ def _isolate_runtime(
     return str(tmp_path), str(db_path)
 
 
-def test_activity_reconstructs_exact_result_after_import_commit(tmp_path: Path) -> None:
+def test_activity_imports_and_replays_against_exact_v7_schema(tmp_path: Path) -> None:
     db_path = tmp_path / "jobctrl.db"
     conn = _seed_pending(db_path)
     payload = _pending_payload()
@@ -172,35 +178,73 @@ def test_activity_reconstructs_exact_result_after_import_commit(tmp_path: Path) 
             "SELECT COUNT(*) FROM job_events"
         ).fetchone()[0]
         snapshot_version_before_replay = conn.execute(
-            "SELECT latest_snapshot_version FROM posting_snapshot_sets WHERE job_url = ?",
-            (_CAPTURE_URL,),
+            "SELECT latest_snapshot_version FROM posting_snapshot_sets WHERE tenant_id = ? AND job_id = ?",
+            ("local", first.job_id),
         ).fetchone()[0]
         replay = execute_manual_capture_import(payload, conn=conn)
         events_after_replay = conn.execute(
             "SELECT COUNT(*) FROM job_events"
         ).fetchone()[0]
         snapshot_version_after_replay = conn.execute(
-            "SELECT latest_snapshot_version FROM posting_snapshot_sets WHERE job_url = ?",
-            (_CAPTURE_URL,),
+            "SELECT latest_snapshot_version FROM posting_snapshot_sets WHERE tenant_id = ? AND job_id = ?",
+            ("local", first.job_id),
         ).fetchone()[0]
         row = conn.execute(
-            "SELECT status, content_sha256, imported_at FROM manual_capture_queue "
+            "SELECT status, job_id, captured_url, content_sha256, imported_at FROM manual_capture_queue "
             "WHERE tenant_id = 'local' AND item_id = 'manual-1'"
         ).fetchone()
+        columns = {
+            column["name"] for column in conn.execute("PRAGMA table_info(manual_capture_queue)")
+        }
     finally:
         close_connection(db_path)
 
     assert replay == first
     assert first.status == "succeeded"
     assert first.item_id == "manual-1"
-    assert first.job_id == _CAPTURE_URL
+    assert uuid.UUID(first.job_id).version == 4
     assert first.imported_at == row["imported_at"]
     assert row["status"] == "imported"
+    assert row["job_id"] == first.job_id
+    assert row["captured_url"] == _CAPTURE_URL
+    assert "job_key" not in columns
     assert row["content_sha256"] == hashlib.sha256(
         _CAPTURE_HTML.encode("utf-8")
     ).hexdigest()
     assert events_after_replay == events_before_replay
     assert snapshot_version_after_replay == snapshot_version_before_replay
+
+
+def test_activity_scopes_same_capture_to_tenant_canonical_job_ids(tmp_path: Path) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    conn = _seed_pending(db_path, tenant_id="local")
+    _seed_pending(db_path, tenant_id="other")
+    local_payload = _pending_payload()
+    other_payload = replace(local_payload, tenant_id="other")
+    try:
+        local_first = execute_manual_capture_import(local_payload, conn=conn)
+        other_first = execute_manual_capture_import(other_payload, conn=conn)
+        local_replay = execute_manual_capture_import(local_payload, conn=conn)
+        rows = conn.execute(
+            """
+            SELECT queue.tenant_id, queue.job_id, jobs.url
+            FROM manual_capture_queue queue
+            JOIN jobs
+              ON jobs.tenant_id = queue.tenant_id
+             AND jobs.job_id = queue.job_id
+            WHERE queue.item_id = ?
+            ORDER BY queue.tenant_id
+            """,
+            (local_payload.item_id,),
+        ).fetchall()
+    finally:
+        close_connection(db_path)
+
+    assert local_replay == local_first
+    assert local_first.job_id != other_first.job_id
+    assert {row["tenant_id"] for row in rows} == {"local", "other"}
+    assert {row["job_id"] for row in rows} == {local_first.job_id, other_first.job_id}
+    assert {row["url"] for row in rows} == {_CAPTURE_URL}
 
 
 @pytest.mark.parametrize(
@@ -356,7 +400,7 @@ def test_jsonrpc_handler_awaits_manual_capture_workflow_result() -> None:
     result_payload = {
         "status": "succeeded",
         "item_id": "manual-1",
-        "job_id": _CAPTURE_URL,
+        "job_id": _MANUAL_JOB_ID,
         "imported_at": "2026-07-10T10:00:00+00:00",
         "retry_context": {"manual_capture_provenance": {"source_kind": "user_mediated_capture"}},
         "error": None,


### PR DESCRIPTION
## Summary

-

## Validation

-

## Checklist

- [ ] External contributor commits include a DCO `Signed-off-by:` trailer (`git commit -s`).
- [ ] I ran the relevant local checks and listed them above. Heavy CI runs automatically for ordinary same-repository pull requests and cumulative stack heads, but not public forks; maintainers run manual workflows or local validation for fork contributions after review.
- [ ] I did not include secrets, private profile data, resumes, generated application materials, raw logs, browser profiles, SQLite databases, or local paths.