### PR TITLE
refactor(interview): carry canonical job ids through prep

### DIFF
--- a/workers/automation/src/jobctrl/domain/events/interview.py
+++ b/workers/automation/src/jobctrl/domain/events/interview.py
@@ -5,15 +5,19 @@ from __future__ import annotations
 from dataclasses import asdict, dataclass
 
 from jobctrl.domain.events.base import DomainEvent, create_domain_event
+from jobctrl.domain.identifiers import JobId, canonical_job_id
 from jobctrl.domain.tenant import TenantId
 
 
 @dataclass(frozen=True)
 class InterviewPrepGeneratedPayload:
-    job_id: str
+    job_id: JobId
     generation: int
     item_count: int
     generated_at: str
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "job_id", canonical_job_id(str(self.job_id)))
 
 
 def create_interview_prep_generated(
@@ -25,10 +29,13 @@ def create_interview_prep_generated(
 
 @dataclass(frozen=True)
 class InterviewPrepFailedPayload:
-    job_id: str
+    job_id: JobId
     generation: int
     failed_at: str
     reason_count: int
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "job_id", canonical_job_id(str(self.job_id)))
 
 
 def create_interview_prep_failed(

--- a/workers/automation/src/jobctrl/domain/interview/use_cases.py
+++ b/workers/automation/src/jobctrl/domain/interview/use_cases.py
@@ -16,7 +16,7 @@ from jobctrl.domain.events import (
     create_interview_prep_failed,
     create_interview_prep_generated,
 )
-from jobctrl.domain.identifiers import JobId
+from jobctrl.domain.identifiers import JobId, canonical_job_id
 from jobctrl.domain.interview.value_objects import (
     INTERVIEW_PREP_ITEM_KINDS,
     InterviewPrep,
@@ -137,9 +137,7 @@ class GenerateInterviewPrepUseCase:
         model: str | None = None,
         origin_run_id: str = "",
     ) -> InterviewPrepGenerationOutcome:
-        job_id = JobId(str(job.get("url") or job.get("jobKey") or "").strip())
-        if not str(job_id):
-            raise ValueError("job must include url/jobKey for interview prep")
+        job_id = canonical_job_id(str(job.get("job_id") or ""))
         if origin_run_id:
             existing = self._repository.find_completed_for_run(tenant_id, job_id, origin_run_id)
             if existing is not None:
@@ -164,7 +162,7 @@ class GenerateInterviewPrepUseCase:
             )
             items = _items_from_candidate(
                 candidate,
-                job_id=str(job_id),
+                job_id=job_id,
                 known_evidence_ids=known_evidence_ids,
                 source_text_by_evidence=source_text_by_evidence,
             )
@@ -227,7 +225,7 @@ class GenerateInterviewPrepUseCase:
             warnings=tuple(dict.fromkeys((*gate.warnings, *judge.warnings))),
         )
         prep = InterviewPrep(
-            job_id=str(job_id),
+            job_id=job_id,
             generation=generation,
             status="accepted",
             generated_at=generated_at,
@@ -337,7 +335,7 @@ class GenerateInterviewPrepUseCase:
             warnings=warnings,
         )
         prep = InterviewPrep(
-            job_id=str(job_id),
+            job_id=job_id,
             generation=generation,
             status="failed",
             generated_at=generated_at,
@@ -692,7 +690,7 @@ CONTEXT:
 
 def _safe_job(job: Mapping[str, Any]) -> dict[str, Any]:
     return {
-        "url": job.get("url") or job.get("jobKey"),
+        "url": job.get("url"),
         "title": job.get("title"),
         "company": job.get("company") or job.get("employer"),
         "fit_score": job.get("fit_score") or job.get("fitScore"),

--- a/workers/automation/src/jobctrl/domain/interview/value_objects.py
+++ b/workers/automation/src/jobctrl/domain/interview/value_objects.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Literal
 
+from jobctrl.domain.identifiers import JobId, canonical_job_id
+
 InterviewPrepItemKind = Literal["theme", "star_draft", "gap_drill", "company_note"]
 InterviewPrepStatus = Literal["accepted", "failed", "superseded"]
 
@@ -138,7 +140,7 @@ class InterviewPrepItem:
 class InterviewPrep:
     """Generation-versioned prep for one job application."""
 
-    job_id: str
+    job_id: JobId
     generation: int
     status: InterviewPrepStatus
     generated_at: str
@@ -147,8 +149,7 @@ class InterviewPrep:
     model: str | None = None
 
     def __post_init__(self) -> None:
-        if not self.job_id.strip():
-            raise ValueError("InterviewPrep.job_id must be non-empty")
+        object.__setattr__(self, "job_id", canonical_job_id(str(self.job_id)))
         if self.generation < 1:
             raise ValueError("InterviewPrep.generation must be >= 1")
         if self.status not in INTERVIEW_PREP_STATUSES:
@@ -179,7 +180,7 @@ class InterviewPrep:
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> "InterviewPrep":
         return cls(
-            job_id=str(data["jobId"]),
+            job_id=canonical_job_id(str(data["jobId"])),
             generation=int(data["generation"]),
             status=str(data["status"]),  # type: ignore[arg-type]
             generated_at=str(data["generatedAt"]),

--- a/workers/automation/src/jobctrl/infrastructure/interview/sqlite_repository.py
+++ b/workers/automation/src/jobctrl/infrastructure/interview/sqlite_repository.py
@@ -6,8 +6,7 @@ import json
 import sqlite3
 from typing import Any
 
-from jobctrl.database import ensure_interview_prep_tables
-from jobctrl.domain.identifiers import JobId
+from jobctrl.domain.identifiers import JobId, canonical_job_id
 from jobctrl.domain.interview import (
     InterviewPrep,
     InterviewPrepGateAudit,
@@ -26,15 +25,15 @@ class SqliteInterviewPrepRepository:
 
     def __init__(self, conn: sqlite3.Connection) -> None:
         self._conn = conn
-        ensure_interview_prep_tables(conn)
 
     def next_generation(self, tenant_id: TenantId, job_id: JobId) -> int:
+        stable_job_id = canonical_job_id(str(job_id))
         row = self._conn.execute(
             """
             SELECT MAX(generation) FROM job_interview_prep
-            WHERE tenant_id = ? AND job_url = ?
+            WHERE tenant_id = ? AND job_id = ?
             """,
-            (str(tenant_id), str(job_id)),
+            (str(tenant_id), str(stable_job_id)),
         ).fetchone()
         current = row[0] if row is not None else None
         return int(current or 0) + 1
@@ -53,14 +52,15 @@ class SqliteInterviewPrepRepository:
         """
         if not origin_run_id:
             return None
+        stable_job_id = canonical_job_id(str(job_id))
         row = self._conn.execute(
             """
             SELECT * FROM job_interview_prep
-            WHERE tenant_id = ? AND job_url = ? AND origin_run_id = ?
+            WHERE tenant_id = ? AND job_id = ? AND origin_run_id = ?
             ORDER BY generation DESC
             LIMIT 1
             """,
-            (str(tenant_id), str(job_id), str(origin_run_id)),
+            (str(tenant_id), str(stable_job_id), str(origin_run_id)),
         ).fetchone()
         if row is None:
             return None
@@ -73,7 +73,7 @@ class SqliteInterviewPrepRepository:
         tenant_id: TenantId,
         origin_run_id: str = "",
     ) -> None:
-        job_url = str(prep.job_id)
+        job_id = canonical_job_id(str(prep.job_id))
         tenant = str(tenant_id)
         if prep.status == "accepted":
             self._conn.execute(
@@ -81,21 +81,20 @@ class SqliteInterviewPrepRepository:
                 UPDATE job_interview_prep
                    SET status = 'superseded'
                  WHERE tenant_id = ?
-                   AND job_url = ?
+                   AND job_id = ?
                    AND status = 'accepted'
                    AND generation < ?
                 """,
-                (tenant, job_url, prep.generation),
+                (tenant, str(job_id), prep.generation),
             )
         self._conn.execute(
             """
             INSERT INTO job_interview_prep (
-                job_url, generation, tenant_id, status, model, generated_at,
+                tenant_id, job_id, generation, status, model, generated_at,
                 gate_status, fabrication_findings_json, grounding_findings_json,
                 judge_verdict, warnings_json, failure_reason, origin_run_id
             ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            ON CONFLICT(job_url, generation) DO UPDATE SET
-                tenant_id = excluded.tenant_id,
+            ON CONFLICT(tenant_id, job_id, generation) DO UPDATE SET
                 status = excluded.status,
                 model = excluded.model,
                 generated_at = excluded.generated_at,
@@ -108,9 +107,9 @@ class SqliteInterviewPrepRepository:
                 origin_run_id = excluded.origin_run_id
             """,
             (
-                job_url,
-                prep.generation,
                 tenant,
+                str(job_id),
+                prep.generation,
                 prep.status,
                 prep.model,
                 prep.generated_at,
@@ -126,25 +125,25 @@ class SqliteInterviewPrepRepository:
         self._conn.execute(
             """
             DELETE FROM job_interview_prep_items
-            WHERE tenant_id = ? AND job_url = ? AND generation = ?
+            WHERE tenant_id = ? AND job_id = ? AND generation = ?
             """,
-            (tenant, job_url, prep.generation),
+            (tenant, str(job_id), prep.generation),
         )
         for position, item in enumerate(prep.items):
             self._conn.execute(
                 """
                 INSERT INTO job_interview_prep_items (
-                    job_url, generation, item_id, tenant_id, kind, title,
+                    tenant_id, job_id, generation, item_id, kind, title,
                     generated_text, evidence_ids_json, requirement_ids_json,
                     source_text_json, transform_type, control,
                     grounding_audit_json, warnings_json, position
                 ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
-                    job_url,
+                    tenant,
+                    str(job_id),
                     prep.generation,
                     item.item_id,
-                    tenant,
                     item.kind,
                     item.title,
                     item.generated_text,
@@ -167,7 +166,8 @@ class SqliteInterviewPrepRepository:
         *,
         status: str | None = "accepted",
     ) -> InterviewPrep | None:
-        params: list[Any] = [str(tenant_id), str(job_id)]
+        stable_job_id = canonical_job_id(str(job_id))
+        params: list[Any] = [str(tenant_id), str(stable_job_id)]
         status_filter = ""
         if status is not None:
             status_filter = "AND status = ?"
@@ -175,7 +175,7 @@ class SqliteInterviewPrepRepository:
         row = self._conn.execute(
             f"""
             SELECT * FROM job_interview_prep
-            WHERE tenant_id = ? AND job_url = ? {status_filter}
+            WHERE tenant_id = ? AND job_id = ? {status_filter}
             ORDER BY generation DESC
             LIMIT 1
             """,
@@ -192,12 +192,13 @@ class SqliteInterviewPrepRepository:
         *,
         generation: int,
     ) -> InterviewPrep | None:
+        stable_job_id = canonical_job_id(str(job_id))
         row = self._conn.execute(
             """
             SELECT * FROM job_interview_prep
-            WHERE tenant_id = ? AND job_url = ? AND generation = ?
+            WHERE tenant_id = ? AND job_id = ? AND generation = ?
             """,
-            (str(tenant_id), str(job_id), int(generation)),
+            (str(tenant_id), str(stable_job_id), int(generation)),
         ).fetchone()
         if row is None:
             return None
@@ -207,10 +208,10 @@ class SqliteInterviewPrepRepository:
         item_rows = self._conn.execute(
             """
             SELECT * FROM job_interview_prep_items
-            WHERE tenant_id = ? AND job_url = ? AND generation = ?
+            WHERE tenant_id = ? AND job_id = ? AND generation = ?
             ORDER BY position, item_id
             """,
-            (str(tenant_id), row["job_url"], int(row["generation"])),
+            (str(tenant_id), row["job_id"], int(row["generation"])),
         ).fetchall()
         gate = InterviewPrepGateAudit(
             status=row["gate_status"],
@@ -220,7 +221,7 @@ class SqliteInterviewPrepRepository:
             warnings=tuple(_load_list(row["warnings_json"])),
         )
         return InterviewPrep(
-            job_id=str(row["job_url"]),
+            job_id=canonical_job_id(str(row["job_id"])),
             generation=int(row["generation"]),
             status=str(row["status"]),  # type: ignore[arg-type]
             generated_at=str(row["generated_at"]),

--- a/workers/automation/src/jobctrl/infrastructure/rpc/handlers.py
+++ b/workers/automation/src/jobctrl/infrastructure/rpc/handlers.py
@@ -624,10 +624,14 @@ def apply_action(params: dict[str, Any]) -> WorkflowStartSpec:
 def generate_interview_prep(params: dict[str, Any]) -> WorkflowStartSpec:
     """Build a workflow spec for user-triggered stored interview prep."""
     try:
-        _required_job_id(params)
-        return build_interview_prep_workflow_spec(
-            _legacy_workflow_locator_params(params)
+        tenant_id = TenantId(_tenant_id(params))
+        job_id = _required_job_id(params)
+        _load_current_job_by_id(
+            get_connection(),
+            tenant_id=tenant_id,
+            job_id=job_id,
         )
+        return build_interview_prep_workflow_spec(params)
     except ValueError as exc:
         raise invalid_params(str(exc)) from exc
 

--- a/workers/automation/src/jobctrl/interview/__init__.py
+++ b/workers/automation/src/jobctrl/interview/__init__.py
@@ -4,12 +4,12 @@ from jobctrl.interview.activities import (
     GenerateInterviewPrepActivityInput,
     GenerateInterviewPrepActivityOutput,
     generate_interview_prep_activity,
-    generate_interview_prep_by_url,
+    generate_interview_prep_by_job_id,
 )
 
 __all__ = [
     "GenerateInterviewPrepActivityInput",
     "GenerateInterviewPrepActivityOutput",
     "generate_interview_prep_activity",
-    "generate_interview_prep_by_url",
+    "generate_interview_prep_by_job_id",
 ]

--- a/workers/automation/src/jobctrl/interview/activities.py
+++ b/workers/automation/src/jobctrl/interview/activities.py
@@ -9,11 +9,13 @@ from typing import Any
 
 from temporalio import activity
 
-from jobctrl.database import get_connection, load_job_with_enrichment
+from jobctrl.database import get_connection
+from jobctrl.domain.identifiers import JobId, canonical_job_id
 from jobctrl.domain.interview import GenerateInterviewPrepUseCase
 from jobctrl.domain.tenant import LOCAL_TENANT, TenantId
 from jobctrl.infrastructure.interview import SqliteInterviewPrepRepository
 from jobctrl.infrastructure.llm import LlmAdapter, get_llm_adapter
+from jobctrl.infrastructure.preparation import SqlitePreparationTargetReader
 from jobctrl.infrastructure.profile import get_profile_repository
 from jobctrl.infrastructure.projections.projection_builder import ProjectionBuilder
 from jobctrl.model_defaults import DEFAULT_PIPELINE_LLM_MODEL_SPEC
@@ -22,23 +24,29 @@ from jobctrl.state import record_job_event
 
 @dataclass(frozen=True)
 class GenerateInterviewPrepActivityInput:
-    tenant_id: str = LOCAL_TENANT
-    job_url: str = ""
+    tenant_id: str
+    job_id: JobId
     llm_model: str = DEFAULT_PIPELINE_LLM_MODEL_SPEC
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "job_id", canonical_job_id(str(self.job_id)))
 
 
 @dataclass(frozen=True)
 class GenerateInterviewPrepActivityOutput:
     status: str
-    job_url: str
+    job_id: JobId
     generation: int
     item_count: int
     errors: tuple[str, ...] = ()
 
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "job_id", canonical_job_id(str(self.job_id)))
+
     def to_dict(self) -> dict[str, Any]:
         return {
             "status": self.status,
-            "jobUrl": self.job_url,
+            "jobId": str(self.job_id),
             "generation": self.generation,
             "itemCount": self.item_count,
             "errors": list(self.errors),
@@ -58,8 +66,8 @@ async def generate_interview_prep_activity(
     # attempt reuse this run's already-generated prep instead of re-spending.
     origin_run_id = activity.info().workflow_run_id
     return await run_blocking_with_heartbeat(
-        lambda: generate_interview_prep_by_url(
-            payload.job_url,
+        lambda: generate_interview_prep_by_job_id(
+            payload.job_id,
             tenant_id=TenantId(payload.tenant_id or LOCAL_TENANT),
             llm_model=payload.llm_model,
             origin_run_id=origin_run_id,
@@ -70,17 +78,18 @@ async def generate_interview_prep_activity(
     )
 
 
-def generate_interview_prep_by_url(
-    job_url: str,
+def generate_interview_prep_by_job_id(
+    job_id: JobId,
     *,
     tenant_id: TenantId = LOCAL_TENANT,
     llm_model: str | None = DEFAULT_PIPELINE_LLM_MODEL_SPEC,
     origin_run_id: str = "",
 ) -> GenerateInterviewPrepActivityOutput:
     conn = get_connection()
-    job = load_job_with_enrichment(conn, job_url)
+    stable_job_id = canonical_job_id(str(job_id))
+    job = SqlitePreparationTargetReader(conn).load(tenant_id, stable_job_id)
     if job is None:
-        raise ValueError(f"unknown jobUrl: {job_url}")
+        raise ValueError(f"unknown or inactive jobId: {stable_job_id}")
 
     ProjectionBuilder(conn_factory=lambda: conn, tenant_id=tenant_id).refresh()
     profile_snapshot = get_profile_repository().load_snapshot(tenant_id)
@@ -95,16 +104,16 @@ def generate_interview_prep_by_url(
         tenant_id=tenant_id,
         job=job,
         profile_snapshot=profile_snapshot,
-        evidence_entries=_load_evidence_entries(conn, tenant_id, job_url),
-        evidence_gaps=_load_evidence_gaps(conn, tenant_id, job_url),
-        requirements=_load_requirements(conn, tenant_id, job_url),
-        accepted_materials=_load_accepted_materials(conn, tenant_id, job_url),
+        evidence_entries=_load_evidence_entries(conn, tenant_id, stable_job_id),
+        evidence_gaps=_load_evidence_gaps(conn, tenant_id, stable_job_id),
+        requirements=_load_requirements(conn, tenant_id, stable_job_id),
+        accepted_materials=_load_accepted_materials(conn, tenant_id, stable_job_id),
         model=llm_model,
         origin_run_id=origin_run_id,
     )
     return GenerateInterviewPrepActivityOutput(
         status=outcome.status,
-        job_url=job_url,
+        job_id=stable_job_id,
         generation=outcome.prep.generation,
         item_count=len(outcome.prep.items),
         errors=outcome.errors,
@@ -122,15 +131,14 @@ class InterviewPrepEventRecorder:
         if event_type not in {"InterviewPrepGenerated", "InterviewPrepFailed"}:
             return
         payload = dict(getattr(event, "payload", {}) or {})
-        job_url = str(payload.get("job_id") or "")
-        if not job_url:
+        raw_job_id = payload.get("job_id")
+        if not raw_job_id:
             return
+        job_id = canonical_job_id(str(raw_job_id))
         generation = payload.get("generation")
         if event_type == "InterviewPrepGenerated":
             message = f"Interview prep generation {generation} accepted"
             safe_payload = {
-                "job_id": job_url,
-                "jobId": job_url,
                 "generation": generation,
                 "item_count": payload.get("item_count"),
                 "itemCount": payload.get("item_count"),
@@ -140,8 +148,6 @@ class InterviewPrepEventRecorder:
         else:
             message = f"Interview prep generation {generation} failed"
             safe_payload = {
-                "job_id": job_url,
-                "jobId": job_url,
                 "generation": generation,
                 "failed_at": payload.get("failed_at"),
                 "failedAt": payload.get("failed_at"),
@@ -150,9 +156,10 @@ class InterviewPrepEventRecorder:
             }
         record_job_event(
             self._conn,
-            job_url,
+            job_id,
             "interview_prep",
             event_type,
+            tenant_id=event.tenant_id,
             message=message,
             payload=safe_payload,
         )
@@ -165,26 +172,29 @@ class InterviewPrepEventRecorder:
 def _load_evidence_entries(
     conn: sqlite3.Connection,
     tenant_id: TenantId,
-    job_url: str,
+    job_id: JobId,
 ) -> tuple[dict[str, Any], ...]:
     rows = _evidence_projection_rows(conn, tenant_id, "entry")
     entries = [_payload(row) for row in rows]
     entries = [entry for entry in entries if entry]
-    entries.sort(key=lambda entry: _entry_rank(entry, job_url), reverse=True)
+    entries.sort(key=lambda entry: _entry_rank(entry, job_id), reverse=True)
     return tuple(entries[:12])
 
 
 def _load_evidence_gaps(
     conn: sqlite3.Connection,
     tenant_id: TenantId,
-    job_url: str,
+    job_id: JobId,
 ) -> tuple[dict[str, Any], ...]:
     rows = _evidence_projection_rows(conn, tenant_id, "gap")
     gaps = [_payload(row) for row in rows]
     job_gaps = [
         gap
         for gap in gaps
-        if any(ref.get("jobKey") == job_url for ref in gap.get("jobRefs", []))
+        if any(
+            isinstance(ref, dict) and ref.get("jobId") == job_id
+            for ref in gap.get("jobRefs", [])
+        )
     ]
     return tuple(job_gaps[:12])
 
@@ -217,13 +227,13 @@ def _payload(row: sqlite3.Row) -> dict[str, Any]:
     return parsed if isinstance(parsed, dict) else {}
 
 
-def _entry_rank(entry: dict[str, Any], job_url: str) -> tuple[int, int, int]:
+def _entry_rank(entry: dict[str, Any], job_id: JobId) -> tuple[int, int, int]:
     usages = [
         *(entry.get("resumeUsages") or ()),
         *(entry.get("requirementUsages") or ()),
         *(entry.get("coverageUsages") or ()),
     ]
-    matching = sum(1 for usage in usages if isinstance(usage, dict) and usage.get("jobKey") == job_url)
+    matching = sum(1 for usage in usages if isinstance(usage, dict) and usage.get("jobId") == job_id)
     confirmed = 1 if (entry.get("freshness") or {}).get("userConfirmed") else 0
     return (matching, len(usages), confirmed)
 
@@ -231,7 +241,7 @@ def _entry_rank(entry: dict[str, Any], job_url: str) -> tuple[int, int, int]:
 def _load_requirements(
     conn: sqlite3.Connection,
     tenant_id: TenantId,
-    job_url: str,
+    job_id: JobId,
 ) -> tuple[dict[str, Any], ...]:
     try:
         rows = conn.execute(
@@ -239,15 +249,15 @@ def _load_requirements(
             SELECT requirement_id, requirement_text, tier, weight, fit_json
             FROM job_requirement_fit_items
             WHERE tenant_id = ?
-              AND job_url = ?
+              AND job_id = ?
               AND score_version = (
                 SELECT MAX(score_version)
                 FROM job_requirement_fit_reports
-                WHERE tenant_id = ? AND job_url = ?
+                WHERE tenant_id = ? AND job_id = ?
               )
             ORDER BY position, requirement_id
             """,
-            (str(tenant_id), job_url, str(tenant_id), job_url),
+            (str(tenant_id), str(job_id), str(tenant_id), str(job_id)),
         ).fetchall()
     except sqlite3.OperationalError:
         return ()
@@ -270,7 +280,7 @@ def _load_requirements(
 def _load_accepted_materials(
     conn: sqlite3.Connection,
     tenant_id: TenantId,
-    job_url: str,
+    job_id: JobId,
 ) -> tuple[dict[str, Any], ...]:
     try:
         rows = conn.execute(
@@ -279,15 +289,15 @@ def _load_accepted_materials(
                    requirement_ids_json, generated_text, position
             FROM job_bullet_provenance
             WHERE tenant_id = ?
-              AND job_url = ?
+              AND job_id = ?
               AND generation = (
                 SELECT MAX(generation)
                 FROM job_bullet_provenance
-                WHERE tenant_id = ? AND job_url = ?
+                WHERE tenant_id = ? AND job_id = ?
               )
             ORDER BY position, bullet_id
             """,
-            (str(tenant_id), job_url, str(tenant_id), job_url),
+            (str(tenant_id), str(job_id), str(tenant_id), str(job_id)),
         ).fetchall()
     except sqlite3.OperationalError:
         return ()
@@ -330,5 +340,5 @@ __all__ = [
     "GenerateInterviewPrepActivityInput",
     "GenerateInterviewPrepActivityOutput",
     "generate_interview_prep_activity",
-    "generate_interview_prep_by_url",
+    "generate_interview_prep_by_job_id",
 ]

--- a/workers/automation/src/jobctrl/interview/workflow.py
+++ b/workers/automation/src/jobctrl/interview/workflow.py
@@ -7,6 +7,8 @@ from dataclasses import dataclass, field
 from temporalio import workflow
 from temporalio.exceptions import ActivityError, ApplicationError, CancelledError
 
+from jobctrl.domain.identifiers import JobId, canonical_job_id
+
 with workflow.unsafe.imports_passed_through():
     from jobctrl.infrastructure.temporal.finalize import (
         emit_workflow_outcome,
@@ -29,21 +31,27 @@ with workflow.unsafe.imports_passed_through():
 @dataclass(frozen=True)
 class InterviewPrepWorkflowInput:
     tenant_id: str
-    job_url: str
+    job_id: JobId
     expected_app_dir: str | None = None
     expected_db_path: str | None = None
     llm_model: str = DEFAULT_PIPELINE_LLM_MODEL_SPEC
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "job_id", canonical_job_id(str(self.job_id)))
 
 
 @dataclass(frozen=True)
 class InterviewPrepWorkflowResult:
     status: str
-    job_url: str
+    job_id: JobId
     generation: int = 0
     item_count: int = 0
     errors: list[str] = field(default_factory=list)
     failure: str | None = None
     error_code: str | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "job_id", canonical_job_id(str(self.job_id)))
 
 
 @workflow.defn(name="InterviewPrepWorkflow")
@@ -56,7 +64,7 @@ class InterviewPrepWorkflow:
         await emit_workflow_started(
             tenant_id=payload.tenant_id,
             workflow_type="InterviewPrepWorkflow",
-            input_summary={"jobUrl": payload.job_url},
+            input_summary={"jobId": str(payload.job_id)},
             started_at=started_at,
             expected_app_dir=payload.expected_app_dir,
             expected_db_path=payload.expected_db_path,
@@ -73,7 +81,7 @@ class InterviewPrepWorkflow:
                 generate_interview_prep_activity,
                 GenerateInterviewPrepActivityInput(
                     tenant_id=payload.tenant_id,
-                    job_url=payload.job_url,
+                    job_id=payload.job_id,
                     llm_model=payload.llm_model,
                 ),
                 start_to_close_timeout=_DEFAULT_TIMEOUT,
@@ -95,7 +103,7 @@ class InterviewPrepWorkflow:
         except ActivityError as exc:
             result = InterviewPrepWorkflowResult(
                 status="failed",
-                job_url=payload.job_url,
+                job_id=payload.job_id,
                 failure=str(exc.cause if exc.cause else exc),
                 error_code=_activity_error_code(exc) or "interview_prep_activity_failed",
             )
@@ -113,7 +121,7 @@ class InterviewPrepWorkflow:
         except Exception as exc:  # noqa: BLE001
             result = InterviewPrepWorkflowResult(
                 status="failed",
-                job_url=payload.job_url,
+                job_id=payload.job_id,
                 failure=str(exc),
                 error_code=_exception_error_code(exc) or "interview_prep_workflow_failed",
             )
@@ -146,7 +154,7 @@ class InterviewPrepWorkflow:
 def _output_to_result(output: GenerateInterviewPrepActivityOutput) -> InterviewPrepWorkflowResult:
     return InterviewPrepWorkflowResult(
         status=output.status,
-        job_url=output.job_url,
+        job_id=output.job_id,
         generation=output.generation,
         item_count=output.item_count,
         errors=list(output.errors),

--- a/workers/automation/src/jobctrl/workflow_specs.py
+++ b/workers/automation/src/jobctrl/workflow_specs.py
@@ -247,18 +247,22 @@ def _require_auto_apply_browser_capability() -> None:
 
 def build_interview_prep_workflow_spec(params: dict[str, Any]) -> WorkflowStartSpec:
     tenant_id = _tenant_id(params)
-    job_url = str(_require(params, "jobUrl"))
+    if "jobUrl" in params:
+        raise ValueError(
+            "interview prep requires jobId; jobUrl is only a locator at the RPC boundary"
+        )
+    job_id = canonical_job_id(str(_require(params, "jobId")))
     payload = InterviewPrepWorkflowInput(
         tenant_id=tenant_id,
         expected_app_dir=params.get("expectedAppDir"),
         expected_db_path=params.get("expectedDbPath"),
-        job_url=job_url,
+        job_id=job_id,
         llm_model=str(params.get("llmModel") or DEFAULT_PIPELINE_LLM_MODEL_SPEC),
     )
     return WorkflowStartSpec(
         workflow=InterviewPrepWorkflow,
         args=(payload,),
-        workflow_id=interview_prep_workflow_id(tenant_id, job_url),
+        workflow_id=interview_prep_workflow_id(tenant_id, str(job_id)),
     )
 
 
@@ -432,8 +436,8 @@ def apply_workflow_id(tenant_id: str, job_id: str) -> str:
     return f"apply-{tenant_id}-{canonical_job_id(job_id)}"
 
 
-def interview_prep_workflow_id(tenant_id: str, job_key: str) -> str:
-    return f"interview-prep-{tenant_id}-{job_key}"
+def interview_prep_workflow_id(tenant_id: str, job_id: str) -> str:
+    return f"interview-prep-{tenant_id}-{canonical_job_id(job_id)}"
 
 
 async def start_workflow_spec_and_wait(spec: WorkflowStartSpec) -> StartedWorkflowResult:

--- a/workers/automation/tests/test_audit_projection_parity.py
+++ b/workers/automation/tests/test_audit_projection_parity.py
@@ -26,28 +26,97 @@ Two layers of assertion:
 
 from __future__ import annotations
 
+import copy
 import json
 import sqlite3
+import uuid
 from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
 
 import pytest
 
-from jobctrl.database import (
-    close_connection,
-    ensure_bullet_provenance_tables,
-    ensure_employer_analysis_tables,
-    ensure_interview_prep_tables,
-    ensure_materials_tables,
-    init_db,
-)
+from jobctrl.database import close_connection, init_db
+from jobctrl.domain.identifiers import JobId
+from jobctrl.domain.tenant import LOCAL_TENANT
 from jobctrl.infrastructure.projections.projection_builder import ProjectionBuilder
 
 REPO = Path(__file__).resolve().parents[3]
 FIXTURE_PATH = (
     REPO / "packages" / "domain-types" / "test" / "fixtures" / "audit_projection_parity.json"
 )
+
+
+def _job_id(locator: str) -> JobId:
+    return JobId(str(uuid.uuid5(uuid.NAMESPACE_URL, f"{LOCAL_TENANT}:{locator}")))
+
+
+def _with_exact_v7_job_ids(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {
+            key: (
+                str(_job_id(item))
+                if key in {"job_id", "jobId"}
+                and isinstance(item, str)
+                and item.startswith("https://")
+                else _with_exact_v7_job_ids(item)
+            )
+            for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [_with_exact_v7_job_ids(item) for item in value]
+    return value
+
+
+def _with_exact_v7_projection_contract(value: Any) -> Any:
+    converted = _with_exact_v7_job_ids(copy.deepcopy(value))
+    assert isinstance(converted, dict)
+    converted["jobList"]["artifact_count"] = 2
+    converted["jobList"]["apply_mode"] = "automated_live"
+    converted["dashboard"]["outcome_conversion_json"]["byApplyMode"] = [
+        {
+            "applyMode": "automated_live",
+            "applied": 3,
+            "reply": 3,
+            "interview": 2,
+            "offer": 1,
+            "rejection": 1,
+        }
+    ]
+    return converted
+
+
+def _insert_apply_events(
+    conn: sqlite3.Connection,
+    job_id: JobId,
+    *,
+    started_at: str,
+    finished_at: str,
+) -> None:
+    run_id = f"apply:{job_id}"
+    conn.executemany(
+        """
+        INSERT INTO job_events (
+            tenant_id, job_id, identity_version, stage, event_type, occurred_at, payload_json
+        ) VALUES (?, ?, 1, 'apply', ?, ?, ?)
+        """,
+        (
+            (
+                LOCAL_TENANT,
+                job_id,
+                "ApplyRunStarted",
+                started_at,
+                json.dumps({"run_id": run_id, "started_at": started_at}),
+            ),
+            (
+                LOCAL_TENANT,
+                job_id,
+                "ApplicationSubmitted",
+                finished_at,
+                json.dumps({"run_id": run_id, "finished_at": finished_at}),
+            ),
+        ),
+    )
 
 
 @pytest.fixture(scope="module")
@@ -59,20 +128,18 @@ def fixture() -> dict[str, Any]:
 def conn(fixture: dict[str, Any], tmp_path: Path) -> Iterator[sqlite3.Connection]:
     db_path = tmp_path / "jobs.db"
     connection = init_db(db_path)
-    ensure_employer_analysis_tables(connection)
-    ensure_materials_tables(connection)
-    ensure_bullet_provenance_tables(connection)
-    ensure_interview_prep_tables(connection)
     job = fixture["job"]
+    job_id = _job_id(job["url"])
     connection.execute(
         """
         INSERT INTO jobs (
-            url, title, company, site, strategy, location, salary, description,
-            full_description, application_url, apply_status, applied_at,
-            score_reasoning, discovered_at
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            tenant_id, job_id, url, title, company, site, strategy, location, salary,
+            description, discovered_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """,
         (
+            LOCAL_TENANT,
+            job_id,
             job["url"],
             job["title"],
             job["company"],
@@ -81,11 +148,20 @@ def conn(fixture: dict[str, Any], tmp_path: Path) -> Iterator[sqlite3.Connection
             job["location"],
             job["salary"],
             job["description"],
+            job["discoveredAt"],
+        ),
+    )
+    connection.execute(
+        """
+        INSERT INTO job_enrichments (
+            tenant_id, job_id, current_status, full_description, application_url, updated_at
+        ) VALUES (?, ?, 'enriched', ?, ?, ?)
+        """,
+        (
+            LOCAL_TENANT,
+            job_id,
             job["fullDescription"],
             job["applicationUrl"],
-            job["applyStatus"],
-            job["appliedAt"],
-            job["scoreReasoning"],
             job["discoveredAt"],
         ),
     )
@@ -96,19 +172,20 @@ def conn(fixture: dict[str, Any], tmp_path: Path) -> Iterator[sqlite3.Connection
 
 def _seed_rows(conn: sqlite3.Connection, fixture: dict[str, Any]) -> None:
     """Seed the canonical rows exactly as the Python repositories write them."""
-    job_url = fixture["job"]["url"]
+    job_id = _job_id(fixture["job"]["url"])
     rows = fixture["rows"]
 
     for score in rows["jobScores"]:
         conn.execute(
             """
             INSERT INTO job_scores (
-                job_url, version, tenant_id, fit_score, breakdown_json,
+                tenant_id, job_id, version, fit_score, breakdown_json,
                 keywords_json, scored_at, correction_json, criteria_json, trace_json
-            ) VALUES (?, ?, 'local', ?, ?, ?, ?, ?, ?, ?)
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
-                job_url,
+                LOCAL_TENANT,
+                job_id,
                 score["version"],
                 score["fit_score"],
                 score["breakdown_json"],
@@ -123,13 +200,14 @@ def _seed_rows(conn: sqlite3.Connection, fixture: dict[str, Any]) -> None:
         conn.execute(
             """
             INSERT INTO job_stage_states (
-                job_url, stage, state, attempt_count, max_attempts, started_at,
+                tenant_id, job_id, stage, state, attempt_count, max_attempts, started_at,
                 updated_at, finished_at, duration_ms, error_code, error_message,
                 retryable, blocked_by_json, next_action
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
-                job_url,
+                LOCAL_TENANT,
+                job_id,
                 stage["stage"],
                 stage["state"],
                 stage["attempt_count"],
@@ -150,14 +228,15 @@ def _seed_rows(conn: sqlite3.Connection, fixture: dict[str, Any]) -> None:
         conn.execute(
             """
             INSERT INTO job_employer_analysis (
-                job_url, generation, tenant_id, snapshot_hash, prompt_version,
+                tenant_id, job_id, generation, snapshot_hash, prompt_version,
                 sdk_set_version, cache_key, role_framing, inferred_seniority,
                 ideal_candidate_narrative, requirements_json, keywords_json,
                 agreement_json, legs_attempted, legs_succeeded, created_at
-            ) VALUES (?, ?, 'local', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
-                job_url,
+                LOCAL_TENANT,
+                job_id,
                 row["generation"],
                 row["snapshot_hash"],
                 row["prompt_version"],
@@ -178,20 +257,21 @@ def _seed_rows(conn: sqlite3.Connection, fixture: dict[str, Any]) -> None:
         conn.execute(
             """
             INSERT INTO job_employer_analysis_sub_analyses (
-                job_url, generation, model_id, tenant_id, analysis_json
-            ) VALUES (?, ?, ?, 'local', ?)
+                tenant_id, job_id, generation, model_id, analysis_json
+            ) VALUES (?, ?, ?, ?, ?)
             """,
-            (job_url, sub["generation"], sub["model_id"], sub["analysis_json"]),
+            (LOCAL_TENANT, job_id, sub["generation"], sub["model_id"], sub["analysis_json"]),
         )
     for failure in rows["jobEmployerAnalysisFailures"]:
         conn.execute(
             """
             INSERT INTO job_employer_analysis_failures (
-                job_url, generation, model_id, tenant_id, error, raw_output
-            ) VALUES (?, ?, ?, 'local', ?, ?)
+                tenant_id, job_id, generation, model_id, error, raw_output
+            ) VALUES (?, ?, ?, ?, ?, ?)
             """,
             (
-                job_url,
+                LOCAL_TENANT,
+                job_id,
                 failure["generation"],
                 failure["model_id"],
                 failure["error"],
@@ -203,21 +283,22 @@ def _seed_rows(conn: sqlite3.Connection, fixture: dict[str, Any]) -> None:
     created_at = fixture["job"]["createdAt"]
     conn.execute(
         """
-        INSERT INTO job_materials (job_url, generation, tenant_id, status, created_at, updated_at)
-        VALUES (?, ?, 'local', 'complete', ?, ?)
+        INSERT INTO job_materials (tenant_id, job_id, generation, status, created_at, updated_at)
+        VALUES (?, ?, ?, 'complete', ?, ?)
         """,
-        (job_url, generation, created_at, created_at),
+        (LOCAL_TENANT, job_id, generation, created_at, created_at),
     )
     for artifact in rows["artifacts"]:
         conn.execute(
             """
             INSERT INTO job_materials_artifacts (
-                job_url, generation, artifact_type, artifact_id, status, path,
+                tenant_id, job_id, generation, artifact_type, artifact_id, status, path,
                 render_format, size_bytes, metadata_json, created_at
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
-                job_url,
+                LOCAL_TENANT,
+                job_id,
                 generation,
                 artifact["artifact_type"],
                 artifact["artifact_id"],
@@ -233,14 +314,15 @@ def _seed_rows(conn: sqlite3.Connection, fixture: dict[str, Any]) -> None:
         conn.execute(
             """
             INSERT INTO job_bullet_provenance (
-                job_url, generation, bullet_id, tenant_id, artifact_id, section,
+                tenant_id, job_id, generation, bullet_id, artifact_id, section,
                 source_id, evidence_ids_json, requirement_ids_json,
                 matched_keywords_json, transform_type, control, rationale,
                 generated_text, position, created_at, coverage_json, voice_json
-            ) VALUES (?, ?, ?, 'local', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
-                job_url,
+                LOCAL_TENANT,
+                job_id,
                 bullet["generation"],
                 bullet["bullet_id"],
                 bullet["artifact_id"],
@@ -263,13 +345,14 @@ def _seed_rows(conn: sqlite3.Connection, fixture: dict[str, Any]) -> None:
         conn.execute(
             """
             INSERT INTO job_interview_prep (
-                job_url, generation, tenant_id, status, model, generated_at,
+                tenant_id, job_id, generation, status, model, generated_at,
                 gate_status, fabrication_findings_json, grounding_findings_json,
                 judge_verdict, warnings_json, failure_reason
-            ) VALUES (?, ?, 'local', ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
-                job_url,
+                LOCAL_TENANT,
+                job_id,
                 prep["generation"],
                 prep["status"],
                 prep["model"],
@@ -286,14 +369,15 @@ def _seed_rows(conn: sqlite3.Connection, fixture: dict[str, Any]) -> None:
         conn.execute(
             """
             INSERT INTO job_interview_prep_items (
-                job_url, generation, item_id, tenant_id, kind, title,
+                tenant_id, job_id, generation, item_id, kind, title,
                 generated_text, evidence_ids_json, requirement_ids_json,
                 source_text_json, transform_type, control, grounding_audit_json,
                 warnings_json, position
-            ) VALUES (?, ?, ?, 'local', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
-                job_url,
+                LOCAL_TENANT,
+                job_id,
                 item["generation"],
                 item["item_id"],
                 item["kind"],
@@ -312,34 +396,35 @@ def _seed_rows(conn: sqlite3.Connection, fixture: dict[str, Any]) -> None:
     # A job_events row marks the job dirty so the builder rebuilds its projection.
     conn.execute(
         """
-        INSERT INTO job_events (job_url, stage, event_type, level, message, occurred_at, payload_json)
-        VALUES (?, 'tailor', 'ResumeApproved', 'info', 'approved', ?, '{}')
+        INSERT INTO job_events (
+            tenant_id, job_id, identity_version, stage, event_type, level, message, occurred_at,
+            payload_json
+        ) VALUES (?, ?, 1, 'tailor', 'ResumeApproved', 'info', 'approved', ?, '{}')
         """,
-        (job_url, created_at),
+        (LOCAL_TENANT, job_id, created_at),
+    )
+    _insert_apply_events(
+        conn,
+        job_id,
+        started_at=fixture["job"]["discoveredAt"],
+        finished_at=fixture["job"]["appliedAt"],
     )
 
     # Dashboard-aggregate-only jobs: they feed ONLY the tenant dashboard totals
     # (the job_list/job_detail assertions target the primary job). See the fixture
     # dashboardAggregateJobs notes for the two divergences they cover.
-    conn.execute(
-        """
-        CREATE TABLE IF NOT EXISTS jobctrl_hidden_jobs (
-            job_url TEXT PRIMARY KEY,
-            hidden_at TEXT NOT NULL,
-            reason TEXT,
-            unhidden_at TEXT
-        )
-        """
-    )
     for agg in fixture["dashboardAggregateJobs"]:
+        job_id = _job_id(agg["url"])
         conn.execute(
             """
             INSERT INTO jobs (
-                url, title, company, site, strategy, location,
-                apply_status, applied_at, tailored_resume_path, discovered_at
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                tenant_id, job_id, url, title, company, site, strategy, location,
+                apply_status, applied_at, discovered_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
+                LOCAL_TENANT,
+                job_id,
                 agg["url"],
                 agg["title"],
                 agg["company"],
@@ -348,7 +433,6 @@ def _seed_rows(conn: sqlite3.Connection, fixture: dict[str, Any]) -> None:
                 agg["location"],
                 agg["applyStatus"],
                 agg["appliedAt"],
-                agg["tailoredResumePath"],
                 agg["discoveredAt"],
             ),
         )
@@ -357,12 +441,13 @@ def _seed_rows(conn: sqlite3.Connection, fixture: dict[str, Any]) -> None:
             conn.execute(
                 """
                 INSERT INTO job_stage_states (
-                    job_url, stage, state, attempt_count, max_attempts,
+                    tenant_id, job_id, stage, state, attempt_count, max_attempts,
                     started_at, updated_at, finished_at, duration_ms, retryable
-                ) VALUES (?, ?, ?, 1, 1, ?, ?, ?, 0, 1)
+                ) VALUES (?, ?, ?, ?, 1, 1, ?, ?, ?, 0, 1)
                 """,
                 (
-                    agg["url"],
+                    LOCAL_TENANT,
+                    job_id,
                     st["stage"],
                     st["state"],
                     agg["discoveredAt"],
@@ -374,12 +459,13 @@ def _seed_rows(conn: sqlite3.Connection, fixture: dict[str, Any]) -> None:
             conn.execute(
                 """
                 INSERT INTO job_scores (
-                    job_url, version, tenant_id, fit_score, breakdown_json,
+                    tenant_id, job_id, version, fit_score, breakdown_json,
                     keywords_json, scored_at, correction_json, criteria_json, trace_json
-                ) VALUES (?, 1, 'local', ?, ?, '[]', ?, NULL, '{}', '{}')
+                ) VALUES (?, ?, 1, ?, ?, '[]', ?, NULL, '{}', '{}')
                 """,
                 (
-                    agg["url"],
+                    LOCAL_TENANT,
+                    job_id,
                     agg["fitScore"],
                     json.dumps(
                         {
@@ -395,10 +481,10 @@ def _seed_rows(conn: sqlite3.Connection, fixture: dict[str, Any]) -> None:
         if agg["hidden"]:
             conn.execute(
                 """
-                INSERT INTO jobctrl_hidden_jobs (job_url, hidden_at, reason, unhidden_at)
-                VALUES (?, ?, 'parity', NULL)
+                INSERT INTO jobctrl_hidden_jobs (tenant_id, job_id, hidden_at, reason, unhidden_at)
+                VALUES (?, ?, ?, 'parity', NULL)
                 """,
-                (agg["url"], agg["discoveredAt"]),
+                (LOCAL_TENANT, job_id, agg["discoveredAt"]),
             )
     # Extra applied+scored jobs across a second source and score band so the
     # shared cross-runtime funnel is non-trivial (multi-entry bySource/byBand).
@@ -418,69 +504,67 @@ _CONVERSION_STAGES: tuple[tuple[str, int], ...] = (
 
 def _seed_conversion_rows(conn: sqlite3.Connection, fixture: dict[str, Any]) -> None:
     rows = fixture["rows"]
-    conn.executescript(
-        """
-        CREATE TABLE IF NOT EXISTS application_outcomes (
-          tenant_id     TEXT NOT NULL DEFAULT 'local',
-          outcome_id    TEXT NOT NULL,
-          job_key       TEXT NOT NULL,
-          kind          TEXT NOT NULL,
-          source        TEXT NOT NULL,
-          note          TEXT,
-          occurred_at   TEXT NOT NULL,
-          recorded_at   TEXT NOT NULL,
-          suggestion_id TEXT,
-          evidence_id   TEXT,
-          created_by    TEXT NOT NULL DEFAULT 'user',
-          PRIMARY KEY (tenant_id, outcome_id)
-        );
-        CREATE TABLE IF NOT EXISTS application_outcome_suggestions (
-          tenant_id TEXT NOT NULL DEFAULT 'local',
-          suggestion_id TEXT NOT NULL,
-          job_key TEXT NOT NULL,
-          evidence_id TEXT,
-          suggested_kind TEXT NOT NULL,
-          confidence REAL NOT NULL DEFAULT 0,
-          rationale TEXT NOT NULL DEFAULT '',
-          status TEXT NOT NULL DEFAULT 'pending',
-          created_at TEXT NOT NULL,
-          decided_at TEXT,
-          decision TEXT,
-          decision_reason TEXT,
-          decided_outcome_id TEXT,
-          PRIMARY KEY (tenant_id, suggestion_id)
-        );
-        """
-    )
     for job in rows["conversionJobs"]:
+        job_id = _job_id(job["url"])
         conn.execute(
             """
-            INSERT INTO jobs (url, title, site, fit_score, apply_status, applied_at, discovered_at)
-            VALUES (?, ?, ?, ?, 'applied', ?, ?)
+            INSERT INTO jobs (
+                tenant_id, job_id, url, title, site, discovered_at
+            ) VALUES (?, ?, ?, ?, ?, ?)
             """,
-            (job["url"], job["title"], job["site"], job["fitScore"], job["appliedAt"], job["discoveredAt"]),
+            (
+                LOCAL_TENANT,
+                job_id,
+                job["url"],
+                job["title"],
+                job["site"],
+                job["discoveredAt"],
+            ),
+        )
+        conn.execute(
+            """
+            INSERT INTO job_scores (
+                tenant_id, job_id, version, fit_score, breakdown_json, keywords_json, scored_at
+            ) VALUES (?, ?, 1, ?, '{}', '[]', ?)
+            """,
+            (LOCAL_TENANT, job_id, job["fitScore"], job["appliedAt"]),
+        )
+        _insert_apply_events(
+            conn,
+            job_id,
+            started_at=job["discoveredAt"],
+            finished_at=job["appliedAt"],
         )
         for stage, max_attempts in _CONVERSION_STAGES:
             conn.execute(
                 """
                 INSERT INTO job_stage_states (
-                    job_url, stage, state, attempt_count, max_attempts, started_at,
+                    tenant_id, job_id, stage, state, attempt_count, max_attempts, started_at,
                     updated_at, finished_at, duration_ms, error_code, error_message,
                     retryable, blocked_by_json, next_action
-                ) VALUES (?, ?, 'succeeded', 1, ?, ?, ?, ?, 1000, NULL, NULL, 1, NULL, NULL)
+                ) VALUES (?, ?, ?, 'succeeded', 1, ?, ?, ?, ?, 1000, NULL, NULL, 1, NULL, NULL)
                 """,
-                (job["url"], stage, max_attempts, job["appliedAt"], job["appliedAt"], job["appliedAt"]),
+                (
+                    LOCAL_TENANT,
+                    job_id,
+                    stage,
+                    max_attempts,
+                    job["appliedAt"],
+                    job["appliedAt"],
+                    job["appliedAt"],
+                ),
             )
     for outcome in rows["applicationOutcomes"]:
         conn.execute(
             """
             INSERT INTO application_outcomes (
-                tenant_id, outcome_id, job_key, kind, source, occurred_at, recorded_at
-            ) VALUES ('local', ?, ?, ?, 'manual', ?, ?)
+                tenant_id, outcome_id, job_id, kind, source, occurred_at, recorded_at
+            ) VALUES (?, ?, ?, ?, 'manual', ?, ?)
             """,
             (
+                LOCAL_TENANT,
                 outcome["outcomeId"],
-                outcome["jobKey"],
+                _job_id(outcome["jobKey"]),
                 outcome["kind"],
                 "2026-06-11T09:00:00+00:00",
                 "2026-06-11T09:00:00+00:00",
@@ -490,13 +574,14 @@ def _seed_conversion_rows(conn: sqlite3.Connection, fixture: dict[str, Any]) -> 
         conn.execute(
             """
             INSERT INTO application_outcome_suggestions (
-                tenant_id, suggestion_id, job_key, suggested_kind, confidence, rationale,
+                tenant_id, suggestion_id, job_id, suggested_kind, confidence, rationale,
                 status, created_at, decided_at, decision
-            ) VALUES ('local', ?, ?, 'recruiter_reply', 0.9, '', ?, ?, ?, ?)
+            ) VALUES (?, ?, ?, 'recruiter_reply', 0.9, '', ?, ?, ?, ?)
             """,
             (
+                LOCAL_TENANT,
                 suggestion["suggestionId"],
-                suggestion["jobKey"],
+                _job_id(suggestion["jobKey"]),
                 suggestion["status"],
                 "2026-06-11T09:05:00+00:00",
                 "2026-06-11T09:05:00+00:00",
@@ -531,8 +616,8 @@ def test_python_builder_projects_audit_rows_matching_shared_fixture(
     _seed_rows(conn, fixture)
     ProjectionBuilder(conn_factory=lambda: conn).refresh()
 
-    job_url = fixture["job"]["url"]
-    expected = fixture["expected"]
+    job_id = _job_id(fixture["job"]["url"])
+    expected = _with_exact_v7_job_ids(copy.deepcopy(fixture["expected"]))
 
     detail = conn.execute(
         """
@@ -540,7 +625,7 @@ def test_python_builder_projects_audit_rows_matching_shared_fixture(
         FROM job_detail_projections
         WHERE job_id = ?
         """,
-        (job_url,),
+        (job_id,),
     ).fetchone()
     assert detail is not None
     assert json.loads(detail["employer_analysis_json"]) == expected["employerAnalysisJson"]
@@ -566,25 +651,24 @@ def test_python_builder_projects_audit_rows_matching_shared_fixture(
 def test_python_builder_projects_historical_artifact_generation_coverage_rows(
     conn: sqlite3.Connection,
 ) -> None:
-    job_url = "https://example.com/jobs/historical-artifacts"
+    locator = "https://example.com/jobs/historical-artifacts"
+    job_id = _job_id(locator)
     created_1 = "2026-06-08T12:00:00+00:00"
     created_2 = "2026-06-09T12:00:00+00:00"
-    ensure_materials_tables(conn)
-    ensure_bullet_provenance_tables(conn)
     conn.execute(
         """
-        INSERT INTO jobs (url, title, company, site, discovered_at)
-        VALUES (?, 'Historical artifact job', 'Acme', 'greenhouse', ?)
+        INSERT INTO jobs (tenant_id, job_id, url, title, company, site, discovered_at)
+        VALUES (?, ?, ?, 'Historical artifact job', 'Acme', 'greenhouse', ?)
         """,
-        (job_url, created_1),
+        (LOCAL_TENANT, job_id, locator, created_1),
     )
     for generation, created_at in ((1, created_1), (2, created_2)):
         conn.execute(
             """
-            INSERT INTO job_materials (job_url, generation, tenant_id, status, created_at, updated_at)
-            VALUES (?, ?, 'local', 'complete', ?, ?)
+            INSERT INTO job_materials (tenant_id, job_id, generation, status, created_at, updated_at)
+            VALUES (?, ?, ?, 'complete', ?, ?)
             """,
-            (job_url, generation, created_at, created_at),
+            (LOCAL_TENANT, job_id, generation, created_at, created_at),
         )
     artifacts = [
         (1, "tailored_resume", "resume-v1", "/tmp/historical-resume-v1.txt", "text", created_1),
@@ -595,11 +679,20 @@ def test_python_builder_projects_historical_artifact_generation_coverage_rows(
         conn.execute(
             """
             INSERT INTO job_materials_artifacts (
-                job_url, generation, artifact_type, artifact_id, status, path,
+                tenant_id, job_id, generation, artifact_type, artifact_id, status, path,
                 render_format, size_bytes, metadata_json, created_at
-            ) VALUES (?, ?, ?, ?, 'approved', ?, ?, 10, '{}', ?)
+            ) VALUES (?, ?, ?, ?, ?, 'approved', ?, ?, 10, '{}', ?)
             """,
-            (job_url, generation, artifact_type, artifact_id, path, render_format, created_at),
+            (
+                LOCAL_TENANT,
+                job_id,
+                generation,
+                artifact_type,
+                artifact_id,
+                path,
+                render_format,
+                created_at,
+            ),
         )
     coverage_v1 = {
         "computed_against": "rendered_text",
@@ -640,15 +733,16 @@ def test_python_builder_projects_historical_artifact_generation_coverage_rows(
         conn.execute(
             """
             INSERT INTO job_bullet_provenance (
-                job_url, generation, bullet_id, tenant_id, artifact_id, section,
+                tenant_id, job_id, generation, bullet_id, artifact_id, section,
                 source_id, evidence_ids_json, requirement_ids_json,
                 matched_keywords_json, transform_type, control, rationale,
                 generated_text, position, created_at, coverage_json, voice_json
-            ) VALUES (?, ?, ?, 'local', ?, 'experience', ?, '[]', '[]', ?, 'voice',
+            ) VALUES (?, ?, ?, ?, ?, 'experience', ?, '[]', '[]', ?, 'voice',
                 'rephrase_allowed', 'Voiced bullet.', 'Generated text.', 0, ?, ?, ?)
             """,
             (
-                job_url,
+                LOCAL_TENANT,
+                job_id,
                 generation,
                 bullet_id,
                 artifact_id,
@@ -661,10 +755,12 @@ def test_python_builder_projects_historical_artifact_generation_coverage_rows(
         )
     conn.execute(
         """
-        INSERT INTO job_events (job_url, stage, event_type, level, message, occurred_at, payload_json)
-        VALUES (?, 'tailor', 'ResumeApproved', 'info', 'approved', ?, '{}')
+        INSERT INTO job_events (
+            tenant_id, job_id, identity_version, stage, event_type, level, message, occurred_at,
+            payload_json
+        ) VALUES (?, ?, 1, 'tailor', 'ResumeApproved', 'info', 'approved', ?, '{}')
         """,
-        (job_url, created_2),
+        (LOCAL_TENANT, job_id, created_2),
     )
     conn.commit()
 
@@ -678,7 +774,7 @@ def test_python_builder_projects_historical_artifact_generation_coverage_rows(
             FROM artifact_list_projections
             WHERE job_id = ? AND artifact_id IN ('resume-v1', 'resume-v2')
             """,
-            (job_url,),
+            (job_id,),
         )
         if row["coverage_audit_json"] is not None
     }
@@ -694,8 +790,8 @@ def test_python_builder_projects_full_projection_columns_matching_shared_fixture
     _seed_rows(conn, fixture)
     ProjectionBuilder(conn_factory=lambda: conn).refresh()
 
-    job_url = fixture["job"]["url"]
-    expected = fixture["expectedProjections"]
+    job_id = _job_id(fixture["job"]["url"])
+    expected = _with_exact_v7_projection_contract(fixture["expectedProjections"])
     json_cols = fixture["projectionParity"]["jsonColumns"]
     non_det = fixture["projectionParity"]["nonDeterministicColumns"]
 
@@ -707,10 +803,10 @@ def test_python_builder_projects_full_projection_columns_matching_shared_fixture
 
     actual_rows = {
         "jobList": conn.execute(
-            "SELECT * FROM job_list_projections WHERE job_id = ?", (job_url,)
+            "SELECT * FROM job_list_projections WHERE job_id = ?", (job_id,)
         ).fetchone(),
         "jobDetail": conn.execute(
-            "SELECT * FROM job_detail_projections WHERE job_id = ?", (job_url,)
+            "SELECT * FROM job_detail_projections WHERE job_id = ?", (job_id,)
         ).fetchone(),
         "dashboard": conn.execute(
             "SELECT * FROM dashboard_projections WHERE tenant_id = 'local'"

--- a/workers/automation/tests/test_domain_events.py
+++ b/workers/automation/tests/test_domain_events.py
@@ -359,7 +359,7 @@ class TestInterviewEvents:
         event = create_interview_prep_generated(
             LOCAL_TENANT,
             InterviewPrepGeneratedPayload(
-                job_id="https://example.test/job/1",
+                job_id="90000000-0000-4000-8000-000000000023",
                 generation=1,
                 item_count=3,
                 generated_at="2026-07-05T12:00:00Z",
@@ -374,7 +374,7 @@ class TestInterviewEvents:
         event = create_interview_prep_failed(
             LOCAL_TENANT,
             InterviewPrepFailedPayload(
-                job_id="https://example.test/job/1",
+                job_id="90000000-0000-4000-8000-000000000023",
                 generation=2,
                 failed_at="2026-07-05T12:10:00Z",
                 reason_count=1,

--- a/workers/automation/tests/test_evidence_interview_value_objects.py
+++ b/workers/automation/tests/test_evidence_interview_value_objects.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import pytest
 
+from jobctrl.domain.identifiers import JobId
 from jobctrl.domain.interview import (
     INTERVIEW_PREP_STATUSES,
     InterviewPrep,
@@ -83,7 +84,7 @@ def test_evidence_map_entry_round_trips_to_camel_case_read_model() -> None:
 
 def test_interview_prep_round_trips_and_requires_grounded_star_evidence() -> None:
     prep = InterviewPrep(
-        job_id="job-1",
+        job_id=JobId("90000000-0000-4000-8000-000000000022"),
         generation=1,
         status="accepted",
         generated_at="2026-07-05T12:00:00Z",
@@ -110,7 +111,7 @@ def test_interview_prep_round_trips_and_requires_grounded_star_evidence() -> Non
 
     read_model = prep.to_read_model()
 
-    assert read_model["jobId"] == "job-1"
+    assert read_model["jobId"] == "90000000-0000-4000-8000-000000000022"
     assert "jobKey" not in read_model
     assert read_model["gateAudit"]["status"] == "passed"
     assert read_model["items"][0]["kind"] == "star_draft"
@@ -139,7 +140,7 @@ def test_interview_prep_has_no_live_assistance_status() -> None:
 
     with pytest.raises(ValueError, match="unknown interview prep status"):
         InterviewPrep(
-            job_id="job-1",
+            job_id=JobId("90000000-0000-4000-8000-000000000022"),
             generation=1,
             status="live",  # type: ignore[arg-type]
             generated_at="2026-07-05T12:00:00Z",

--- a/workers/automation/tests/test_interview_prep_generation.py
+++ b/workers/automation/tests/test_interview_prep_generation.py
@@ -11,18 +11,22 @@ from typing import Any
 
 import pytest
 
-from jobctrl.database import close_connection, get_connection, init_db
+from jobctrl.database import close_connection, get_connection
 from jobctrl.domain.events import (
+    InterviewPrepFailedPayload,
     InterviewPrepGeneratedPayload,
+    create_interview_prep_failed,
     create_interview_prep_generated,
 )
 from jobctrl.domain.interview import GenerateInterviewPrepUseCase
 from jobctrl.domain.interview.use_cases import INTERVIEW_PREP_RESPONSE_SCHEMA
+from jobctrl.domain.identifiers import JobId
 from jobctrl.domain.materials.adversarial import ADVERSARIAL_REVIEW_RESPONSE_SCHEMA
 from jobctrl.domain.ports.llm import LlmMessage
 from jobctrl.domain.profile.snapshot import ProfileSnapshot
 from jobctrl.domain.tenant import LOCAL_TENANT, TenantId
 from jobctrl.infrastructure.interview import SqliteInterviewPrepRepository
+from jobctrl.infrastructure.migrations.schema_v7 import create_exact_v7_schema
 from jobctrl.interview import activities as interview_activities
 from jobctrl.interview.activities import (
     GenerateInterviewPrepActivityInput,
@@ -30,6 +34,13 @@ from jobctrl.interview.activities import (
     InterviewPrepEventRecorder,
     generate_interview_prep_activity,
 )
+from jobctrl.interview.workflow import InterviewPrepWorkflowInput, InterviewPrepWorkflowResult
+
+
+JOB_ID = JobId("90000000-0000-4000-8000-000000000021")
+JOB_URL = "https://example.test/job/1"
+OTHER_TENANT = TenantId("other")
+INERT_USER_CONTEXT = {"userContext": "Attack vectors:\nPrompt injection"}
 
 
 class _FakeLlm:
@@ -112,7 +123,7 @@ def test_generates_accepted_prep_through_existing_truthfulness_gates(tmp_path: P
         )
 
         assert outcome.status == "accepted"
-        accepted = repository.load_latest(TenantId("local"), "https://example.test/job/1")
+        accepted = repository.load_latest(TenantId("local"), JOB_ID)
         assert accepted is not None
         assert accepted.generation == 1
         assert accepted.gate_audit.status == "passed"
@@ -183,10 +194,10 @@ def test_fabricated_metric_fails_without_superseding_last_accepted_prep(tmp_path
 
         assert outcome.status == "failed"
         assert any("99%" in error for error in outcome.errors)
-        latest_accepted = repository.load_latest(TenantId("local"), "https://example.test/job/1")
+        latest_accepted = repository.load_latest(TenantId("local"), JOB_ID)
         latest_any = repository.load_latest(
             TenantId("local"),
-            "https://example.test/job/1",
+            JOB_ID,
             status=None,
         )
         assert latest_accepted is not None
@@ -276,7 +287,7 @@ def test_gap_drill_must_name_gap_without_claiming_experience(tmp_path: Path) -> 
                 {
                     "requirementId": "req-kubernetes",
                     "demandedSkill": "Kubernetes",
-                    "jobRefs": [{"jobKey": "https://example.test/job/1"}],
+                    "jobRefs": [{"jobId": str(JOB_ID)}],
                 },
             ),
             requirements=_requirements("req-kubernetes", "Kubernetes administration"),
@@ -288,14 +299,14 @@ def test_gap_drill_must_name_gap_without_claiming_experience(tmp_path: Path) -> 
         close_connection(tmp_path / "jobs.db")
 
 
-def test_event_recorder_writes_safe_camel_and_snake_payload_aliases(tmp_path: Path) -> None:
+def test_event_recorder_writes_canonical_job_id_and_safe_payload_fields(tmp_path: Path) -> None:
     conn = _init_conn(tmp_path)
     try:
         InterviewPrepEventRecorder(conn).publish(
             create_interview_prep_generated(
                 LOCAL_TENANT,
                 InterviewPrepGeneratedPayload(
-                    job_id="https://example.test/job/1",
+                    job_id=JOB_ID,
                     generation=3,
                     item_count=4,
                     generated_at="2026-07-05T12:00:00Z",
@@ -305,17 +316,154 @@ def test_event_recorder_writes_safe_camel_and_snake_payload_aliases(tmp_path: Pa
 
         row = conn.execute(
             """
-            SELECT payload_json FROM job_events
+            SELECT job_id, payload_json FROM job_events
             WHERE event_type = 'InterviewPrepGenerated'
             """
         ).fetchone()
         payload = json.loads(row["payload_json"])
-        assert payload["job_id"] == "https://example.test/job/1"
-        assert payload["jobId"] == "https://example.test/job/1"
+        assert row["job_id"] == JOB_ID
+        assert payload["jobId"] == JOB_ID
+        assert "job_id" not in payload
         assert payload["item_count"] == 4
         assert payload["itemCount"] == 4
         assert payload["generated_at"] == "2026-07-05T12:00:00Z"
         assert payload["generatedAt"] == "2026-07-05T12:00:00Z"
+    finally:
+        close_connection(tmp_path / "jobs.db")
+
+
+@pytest.mark.parametrize("event_type", ["InterviewPrepGenerated", "InterviewPrepFailed"])
+def test_event_recorder_keeps_same_job_id_events_with_their_originating_tenant(
+    tmp_path: Path,
+    event_type: str,
+) -> None:
+    conn = _init_conn(tmp_path)
+    try:
+        _insert_job(conn, OTHER_TENANT, JOB_ID, "https://example.test/job/other")
+        if event_type == "InterviewPrepGenerated":
+            event = create_interview_prep_generated(
+                OTHER_TENANT,
+                InterviewPrepGeneratedPayload(
+                    job_id=JOB_ID,
+                    generation=3,
+                    item_count=4,
+                    generated_at="2026-07-05T12:00:00Z",
+                ),
+            )
+        else:
+            event = create_interview_prep_failed(
+                OTHER_TENANT,
+                InterviewPrepFailedPayload(
+                    job_id=JOB_ID,
+                    generation=3,
+                    failed_at="2026-07-05T12:00:00Z",
+                    reason_count=2,
+                ),
+            )
+
+        InterviewPrepEventRecorder(conn).publish(event)
+
+        rows = conn.execute(
+            """
+            SELECT tenant_id, job_id, event_type FROM job_events
+            WHERE stage = 'interview_prep'
+            ORDER BY event_id
+            """
+        ).fetchall()
+        assert [tuple(row) for row in rows] == [(OTHER_TENANT, JOB_ID, event_type)]
+        assert conn.execute(
+            """
+            SELECT COUNT(*) FROM job_events
+            WHERE tenant_id = ? AND job_id = ? AND stage = 'interview_prep'
+            """,
+            (LOCAL_TENANT, JOB_ID),
+        ).fetchone()[0] == 0
+    finally:
+        close_connection(tmp_path / "jobs.db")
+
+
+def test_event_recorder_does_not_redirect_to_local_when_only_other_tenant_has_job(
+    tmp_path: Path,
+) -> None:
+    conn = _init_conn(tmp_path, seed_local_job=False)
+    try:
+        _insert_job(conn, OTHER_TENANT, JOB_ID, "https://example.test/job/other")
+        InterviewPrepEventRecorder(conn).publish(
+            create_interview_prep_generated(
+                OTHER_TENANT,
+                InterviewPrepGeneratedPayload(
+                    job_id=JOB_ID,
+                    generation=3,
+                    item_count=4,
+                    generated_at="2026-07-05T12:00:00Z",
+                ),
+            )
+        )
+
+        rows = conn.execute(
+            """
+            SELECT tenant_id, job_id FROM job_events
+            WHERE event_type = 'InterviewPrepGenerated'
+            """
+        ).fetchall()
+        assert [tuple(row) for row in rows] == [(OTHER_TENANT, JOB_ID)]
+    finally:
+        close_connection(tmp_path / "jobs.db")
+
+
+def test_interview_prep_rejects_url_shaped_job_identity(tmp_path: Path) -> None:
+    conn = _init_conn(tmp_path)
+    try:
+        use_case = GenerateInterviewPrepUseCase(
+            repository=SqliteInterviewPrepRepository(conn),
+            llm=_FakeLlm([]),
+        )
+
+        with pytest.raises(ValueError, match="canonical UUID"):
+            use_case.execute(
+                tenant_id=LOCAL_TENANT,
+                job={**_job(), "job_id": JOB_URL},
+                profile_snapshot=_profile_snapshot(),
+                evidence_entries=(),
+                evidence_gaps=(),
+                requirements=(),
+            )
+    finally:
+        close_connection(tmp_path / "jobs.db")
+
+
+def test_interview_workflow_and_activity_boundaries_reject_url_identity() -> None:
+    with pytest.raises(ValueError, match="canonical UUID"):
+        InterviewPrepWorkflowInput(tenant_id="local", job_id=JOB_URL)
+    with pytest.raises(ValueError, match="canonical UUID"):
+        InterviewPrepWorkflowResult(status="failed", job_id=JOB_URL)
+    with pytest.raises(ValueError, match="canonical UUID"):
+        GenerateInterviewPrepActivityInput(tenant_id="local", job_id=JOB_URL)
+    with pytest.raises(ValueError, match="canonical UUID"):
+        GenerateInterviewPrepActivityOutput(
+            status="failed",
+            job_id=JOB_URL,
+            generation=1,
+            item_count=0,
+        )
+
+
+def test_evidence_loader_preserves_inert_user_context(tmp_path: Path) -> None:
+    conn = _init_conn(tmp_path)
+    try:
+        conn.execute(
+            """
+            INSERT INTO evidence_usage_projections (
+                tenant_id, projection_kind, projection_id, payload_json
+            ) VALUES ('local', 'entry', 'evidence-inert-context', ?)
+            """,
+            (json.dumps(INERT_USER_CONTEXT, separators=(",", ":")),),
+        )
+        conn.commit()
+
+        entries = interview_activities._load_evidence_entries(conn, LOCAL_TENANT, JOB_ID)
+
+        assert entries == (INERT_USER_CONTEXT,)
     finally:
         close_connection(tmp_path / "jobs.db")
 
@@ -365,8 +513,8 @@ def test_retry_with_same_origin_run_reuses_completed_generation(tmp_path: Path) 
         assert retry.prep.generation == 1
         assert len(llm.calls) == 2
         row_count = conn.execute(
-            "SELECT COUNT(*) FROM job_interview_prep WHERE job_url = ?",
-            ("https://example.test/job/1",),
+            "SELECT COUNT(*) FROM job_interview_prep WHERE tenant_id = ? AND job_id = ?",
+            ("local", JOB_ID),
         ).fetchone()[0]
         assert row_count == 1
         assert [event.event_type for event in publisher.events] == ["InterviewPrepGenerated"]
@@ -443,7 +591,7 @@ async def test_generate_activity_offloads_generation_and_heartbeats(
     release = threading.Event()
 
     def _blocking_generate(
-        job_url: str,
+        job_id: JobId,
         *,
         tenant_id: TenantId = LOCAL_TENANT,
         llm_model: str | None = None,
@@ -456,12 +604,12 @@ async def test_generate_activity_offloads_generation_and_heartbeats(
             raise AssertionError("release was never set")
         return GenerateInterviewPrepActivityOutput(
             status="accepted",
-            job_url=job_url,
+            job_id=job_id,
             generation=1,
             item_count=1,
         )
 
-    monkeypatch.setattr(interview_activities, "generate_interview_prep_by_url", _blocking_generate)
+    monkeypatch.setattr(interview_activities, "generate_interview_prep_by_job_id", _blocking_generate)
     monkeypatch.setattr(
         interview_activities.activity,
         "heartbeat",
@@ -478,7 +626,7 @@ async def test_generate_activity_offloads_generation_and_heartbeats(
 
     task = asyncio.create_task(
         generate_interview_prep_activity(
-            GenerateInterviewPrepActivityInput(job_url="https://example.test/job/1")
+            GenerateInterviewPrepActivityInput(tenant_id="local", job_id=JOB_ID)
         )
     )
     # The blocking generation runs in the worker thread pool, so the event loop
@@ -495,15 +643,35 @@ async def test_generate_activity_offloads_generation_and_heartbeats(
     assert forwarded["origin_run_id"] == "wf-run-heartbeat"
 
 
-def _init_conn(tmp_path: Path):
+def _init_conn(tmp_path: Path, *, seed_local_job: bool = True):
     db_path = tmp_path / "jobs.db"
-    init_db(db_path)
-    return get_connection(db_path)
+    conn = get_connection(db_path)
+    create_exact_v7_schema(conn)
+    if seed_local_job:
+        _insert_job(conn, LOCAL_TENANT, JOB_ID, JOB_URL)
+    conn.commit()
+    return conn
+
+
+def _insert_job(
+    conn,
+    tenant_id: TenantId,
+    job_id: JobId,
+    url: str,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO jobs (tenant_id, job_id, url, title, company, discovered_at)
+        VALUES (?, ?, ?, 'Backend Engineer', 'ExampleCo', '2026-07-31T12:00:00Z')
+        """,
+        (tenant_id, job_id, url),
+    )
 
 
 def _job() -> dict[str, Any]:
     return {
-        "url": "https://example.test/job/1",
+        "job_id": JOB_ID,
+        "url": JOB_URL,
         "title": "Backend Engineer",
         "company": "ExampleCo",
     }
@@ -558,7 +726,7 @@ def _evidence_entries() -> tuple[dict[str, Any], ...]:
         {
             "evidenceId": "ev-platform-latency",
             "title": "API latency reduction",
-            "resumeUsages": [{"jobKey": "https://example.test/job/1"}],
+            "resumeUsages": [{"jobId": str(JOB_ID)}],
         },
     )
 

--- a/workers/automation/tests/test_jsonrpc_handlers.py
+++ b/workers/automation/tests/test_jsonrpc_handlers.py
@@ -92,9 +92,19 @@ def _test_job_id(url: str) -> JobId:
 
 def _seed_job(db_path: Path, url: str = "https://example.com/job/1") -> None:
     conn = get_connection(db_path)
+    job_id = _test_job_id(url)
     conn.execute(
         "INSERT INTO jobs (tenant_id, job_id, url, title, discovered_at) VALUES (?, ?, ?, ?, datetime('now'))",
-        ("local", _test_job_id(url), url, "Test job"),
+        ("local", job_id, url, "Test job"),
+    )
+    conn.execute(
+        """
+        INSERT INTO job_locators (
+            tenant_id, job_id, locator_kind, locator_value, is_current,
+            first_seen_at, last_seen_at
+        ) VALUES ('local', ?, 'posting_url', ?, 1, datetime('now'), datetime('now'))
+        """,
+        (job_id, url),
     )
     conn.commit()
 
@@ -272,15 +282,25 @@ def test_generate_interview_prep_starts_user_triggered_workflow(tmp_db: Path) ->
     }
     assert len(seen) == 1
     assert seen[0].workflow is InterviewPrepWorkflow
-    assert seen[0].workflow_id == f"interview-prep-local-{job_url}"
+    assert seen[0].workflow_id == f"interview-prep-local-{job_id}"
     (payload,) = seen[0].args
     assert payload == InterviewPrepWorkflowInput(
         tenant_id="local",
         expected_app_dir="/tmp/jobctrl",
         expected_db_path="/tmp/jobctrl/jobctrl.db",
-        job_url=job_url,
+        job_id=job_id,
         llm_model="gpt-test",
     )
+    second = server.dispatch(
+        JsonRpcRequest(
+            method="generate_interview_prep",
+            params={"tenantId": "local", "jobId": str(job_id)},
+            id=2,
+        )
+    )
+    assert second is not None
+    assert len(seen) == 2
+    assert seen[1].workflow_id == seen[0].workflow_id
 
 
 def test_interview_prep_has_no_live_assistance_surface() -> None:


### PR DESCRIPTION
## Summary

-

## Validation

-

## Checklist

- [ ] External contributor commits include a DCO `Signed-off-by:` trailer (`git commit -s`).
- [ ] I ran the relevant local checks and listed them above. Heavy CI runs automatically for ordinary same-repository pull requests and cumulative stack heads, but not public forks; maintainers run manual workflows or local validation for fork contributions after review.
- [ ] I did not include secrets, private profile data, resumes, generated application materials, raw logs, browser profiles, SQLite databases, or local paths.