### PR TITLE
refactor(contacts): use canonical job ids for research

### DIFF
--- a/workers/automation/src/jobctrl/contact/activities.py
+++ b/workers/automation/src/jobctrl/contact/activities.py
@@ -19,6 +19,7 @@ from temporalio import activity
 from temporalio.exceptions import ApplicationError
 
 from jobctrl.domain.errors import JobCtrlError, to_application_error
+from jobctrl.domain.identifiers import JobId, canonical_job_id
 from jobctrl.model_defaults import DEFAULT_PIPELINE_LLM_MODEL_SPEC
 
 
@@ -36,11 +37,15 @@ class RunContactResearchActivityInput:
     tenant_id: str
     task_id: str
     employer: str | None = None
-    job_url: str | None = None
+    job_id: JobId | None = None
     sources: tuple[ResearchSourceInput, ...] = ()
     llm_model: str = DEFAULT_PIPELINE_LLM_MODEL_SPEC
     expected_app_dir: str | None = None
     expected_db_path: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.job_id is not None:
+            object.__setattr__(self, "job_id", canonical_job_id(str(self.job_id)))
 
 
 @dataclass(frozen=True)
@@ -109,6 +114,7 @@ def _run_contact_research(
 
     conn = get_connection()
     tenant = TenantId(payload.tenant_id or LOCAL_TENANT)
+    job_id = canonical_job_id(str(payload.job_id)) if payload.job_id is not None else None
 
     # Per-source opt-in (resolved decision 3): the allowlist is exactly the hosts
     # the user explicitly provided — nothing is discovered or fetched autonomously.
@@ -139,12 +145,17 @@ def _run_contact_research(
     task = use_case.execute(
         tenant,
         task_id=payload.task_id,
-        link=ContactLink(employer=payload.employer or None, job_id=payload.job_url or None),
+        link=ContactLink(employer=payload.employer or None, job_id=job_id),
         sources=specs,
         model=payload.llm_model,
     )
 
-    activity.heartbeat({"status": task.status.value})
+    activity.heartbeat(
+        {
+            "status": task.status.value,
+            **({"jobId": str(job_id)} if job_id is not None else {}),
+        }
+    )
     ProjectionBuilder(conn_factory=lambda: conn, tenant_id=tenant).refresh()
     return RunContactResearchActivityOutput(
         task_id=task.task_id,

--- a/workers/automation/src/jobctrl/contact/workflow.py
+++ b/workers/automation/src/jobctrl/contact/workflow.py
@@ -1,6 +1,6 @@
 """Temporal workflow for one supervised contact-research run.
 
-Deterministic id ``contact-research-{task_id}``. Modelled on
+Deterministic id ``contact-research-{tenant_id}-{task_id}``. Modelled on
 ``InterviewPrepWorkflow``: emit lifecycle, run the shared LLM spend preflight
 (§5.4 — the existing ``check_spend_budget`` activity + ``dailyBudgetUsd``; no
 second spend system), then the single research activity that fetches only
@@ -15,6 +15,8 @@ from dataclasses import dataclass
 
 from temporalio import workflow
 from temporalio.exceptions import ActivityError, ApplicationError, CancelledError
+
+from jobctrl.domain.identifiers import JobId, canonical_job_id
 
 with workflow.unsafe.imports_passed_through():
     from jobctrl.contact.activities import (
@@ -41,11 +43,15 @@ class ContactResearchWorkflowInput:
     tenant_id: str
     task_id: str
     employer: str | None = None
-    job_url: str | None = None
+    job_id: JobId | None = None
     sources: tuple[ResearchSourceInput, ...] = ()
     llm_model: str = DEFAULT_PIPELINE_LLM_MODEL_SPEC
     expected_app_dir: str | None = None
     expected_db_path: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.job_id is not None:
+            object.__setattr__(self, "job_id", canonical_job_id(str(self.job_id)))
 
 
 @dataclass(frozen=True)
@@ -58,8 +64,8 @@ class ContactResearchWorkflowResult:
     error_code: str | None = None
 
 
-def contact_research_workflow_id(task_id: str) -> str:
-    return f"contact-research-{task_id}"
+def contact_research_workflow_id(tenant_id: str, task_id: str) -> str:
+    return f"contact-research-{tenant_id}-{task_id}"
 
 
 @workflow.defn(name="ContactResearchWorkflow")
@@ -77,7 +83,7 @@ class ContactResearchWorkflow:
             input_summary={
                 "taskId": payload.task_id,
                 "employer": payload.employer,
-                "jobUrl": payload.job_url,
+                "jobId": str(payload.job_id) if payload.job_id is not None else None,
                 "sourceCount": len(payload.sources),
             },
             started_at=started_at,
@@ -98,7 +104,7 @@ class ContactResearchWorkflow:
                     tenant_id=payload.tenant_id,
                     task_id=payload.task_id,
                     employer=payload.employer,
-                    job_url=payload.job_url,
+                    job_id=payload.job_id,
                     sources=payload.sources,
                     llm_model=payload.llm_model,
                     expected_app_dir=payload.expected_app_dir,

--- a/workers/automation/src/jobctrl/domain/contact/use_cases.py
+++ b/workers/automation/src/jobctrl/domain/contact/use_cases.py
@@ -45,7 +45,7 @@ _CSV_ATTRIBUTE_COLUMNS: dict[str, str] = {
 
 _CSV_ROLE_COLUMNS = ("role",)
 _CSV_EMPLOYER_COLUMNS = ("employer", "company")
-_CSV_JOB_COLUMNS = ("job_id", "jobid", "job_url", "joburl")
+_CSV_JOB_COLUMNS = ("job_id", "jobid")
 
 
 class ContactInputError(ValueError):

--- a/workers/automation/src/jobctrl/domain/contact/value_objects.py
+++ b/workers/automation/src/jobctrl/domain/contact/value_objects.py
@@ -18,6 +18,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from enum import Enum
 
+from jobctrl.domain.identifiers import JobId, canonical_job_id
+
 
 class ContactRole(str, Enum):
     """The role a contact plays for a company/application."""
@@ -122,15 +124,18 @@ class ContactLink:
     """
 
     employer: str | None = None
-    job_id: str | None = None
+    job_id: JobId | None = None
 
     def __post_init__(self) -> None:
         employer = (self.employer or "").strip()
-        job_id = (self.job_id or "").strip()
+        raw_job_id = self.job_id
+        job_id = canonical_job_id(str(raw_job_id)) if raw_job_id else None
         if not employer and not job_id:
             raise ValueError(
                 "ContactLink must reference at least one of {employer, job_id}"
             )
+        if raw_job_id is not None:
+            object.__setattr__(self, "job_id", job_id)
 
 
 @dataclass(frozen=True)

--- a/workers/automation/src/jobctrl/domain/ports/contact.py
+++ b/workers/automation/src/jobctrl/domain/ports/contact.py
@@ -22,7 +22,7 @@ from typing import Protocol
 from jobctrl.domain.contact.aggregate import Contact
 from jobctrl.domain.contact.outreach import OutreachThread
 from jobctrl.domain.contact.research import ContactResearchTask
-from jobctrl.domain.identifiers import ContactId
+from jobctrl.domain.identifiers import ContactId, JobId
 from jobctrl.domain.tenant import TenantId
 
 __all__ = [
@@ -46,7 +46,7 @@ class ContactRepository(Protocol):
     def list_for_tenant(self, tenant_id: TenantId) -> list[Contact]:
         """Return all non-deleted contacts for the tenant."""
 
-    def list_for_job(self, tenant_id: TenantId, job_id: str) -> list[Contact]:
+    def list_for_job(self, tenant_id: TenantId, job_id: JobId) -> list[Contact]:
         """Return non-deleted contacts linked to a specific application."""
 
     def list_for_employer(self, tenant_id: TenantId, employer: str) -> list[Contact]:

--- a/workers/automation/src/jobctrl/infrastructure/contact/research_repository.py
+++ b/workers/automation/src/jobctrl/infrastructure/contact/research_repository.py
@@ -10,7 +10,7 @@ persisted ONLY in ``contact_candidates.attributes_json``. Event payloads written
 to ``job_events`` carry ids, kinds, provenance metadata, confidence, outcomes,
 and timestamps — never a value or a fetched page body. Research events carry
 honest identity via ``entity_kind='contact_research'`` / ``entity_ref=<task_id>``;
-application-linked tasks additionally key on the job's ``job_url``.
+application-linked tasks additionally key on the canonical ``job_id``.
 """
 
 from __future__ import annotations
@@ -19,7 +19,6 @@ import json
 import logging
 import sqlite3
 
-from jobctrl.database import ensure_contact_tables
 from jobctrl.domain.contact.research import (
     CandidateStatus,
     ContactCandidate,
@@ -33,6 +32,7 @@ from jobctrl.domain.contact.value_objects import (
     ContactLink,
     ContactRole,
 )
+from jobctrl.domain.identifiers import JobId
 from jobctrl.domain.ports.events import EventPublisher
 from jobctrl.domain.tenant import TenantId
 from jobctrl.state import record_job_event
@@ -46,7 +46,6 @@ class SqliteContactResearchTaskRepository:
     def __init__(self, conn: sqlite3.Connection, *, publisher: EventPublisher) -> None:
         self._conn = conn
         self._publisher = publisher
-        ensure_contact_tables(self._conn)
 
     # ------------------------------------------------------------------ load
 
@@ -74,7 +73,7 @@ class SqliteContactResearchTaskRepository:
         return ContactResearchTask(
             tenant_id=tenant_id,
             task_id=str(row["task_id"]),
-            link=ContactLink(employer=row["employer"], job_id=row["job_url"]),
+            link=ContactLink(employer=row["employer"], job_id=row["job_id"]),
             status=_status(row["status"]),
             candidates=self._load_candidates(tenant_id, str(row["task_id"])),
             source_attempts=_decode_attempts(row["source_attempts_json"]),
@@ -147,12 +146,12 @@ class SqliteContactResearchTaskRepository:
             self._conn.execute(
                 """
                 INSERT INTO contact_research_tasks (
-                    tenant_id, task_id, employer, job_url, status, source_attempts_json,
+                    tenant_id, task_id, employer, job_id, status, source_attempts_json,
                     started_at, updated_at, needs_review_at, completed_at, failed_at, error_class
                 ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 ON CONFLICT(tenant_id, task_id) DO UPDATE SET
                     employer             = excluded.employer,
-                    job_url              = excluded.job_url,
+                    job_id               = excluded.job_id,
                     status               = excluded.status,
                     source_attempts_json = excluded.source_attempts_json,
                     started_at           = excluded.started_at,
@@ -217,12 +216,13 @@ class SqliteContactResearchTaskRepository:
     ) -> None:
         tenant = str(tenant_id)
         task_id = str(task.task_id)
-        job_url = task.link.job_id or None
+        job_id = task.link.job_id
         previous_status = previous.status if previous is not None else None
 
         if previous is None:
             self._record(
-                job_url,
+                tenant_id,
+                job_id,
                 task_id,
                 "ContactResearchTaskStarted",
                 "Contact research started.",
@@ -243,7 +243,8 @@ class SqliteContactResearchTaskRepository:
                 if candidate.candidate_id in known:
                     continue
                 self._record(
-                    job_url,
+                    tenant_id,
+                    job_id,
                     task_id,
                     "ContactCandidateProposed",
                     "Contact candidate proposed for review.",
@@ -260,7 +261,8 @@ class SqliteContactResearchTaskRepository:
                     },
                 )
             self._record(
-                job_url,
+                tenant_id,
+                job_id,
                 task_id,
                 "ContactResearchTaskNeedsReview",
                 "Contact research needs review.",
@@ -277,7 +279,8 @@ class SqliteContactResearchTaskRepository:
             and previous_status is not ResearchTaskStatus.COMPLETED
         ):
             self._record(
-                job_url,
+                tenant_id,
+                job_id,
                 task_id,
                 "ContactResearchTaskCompleted",
                 "Contact research completed.",
@@ -294,7 +297,8 @@ class SqliteContactResearchTaskRepository:
             and previous_status is not ResearchTaskStatus.FAILED
         ):
             self._record(
-                job_url,
+                tenant_id,
+                job_id,
                 task_id,
                 "ContactResearchTaskFailed",
                 "Contact research failed.",
@@ -309,7 +313,8 @@ class SqliteContactResearchTaskRepository:
 
     def _record(
         self,
-        job_url: str | None,
+        tenant_id: TenantId,
+        job_id: JobId | None,
         task_id: str,
         event_type: str,
         message: str,
@@ -317,9 +322,10 @@ class SqliteContactResearchTaskRepository:
     ) -> None:
         record_job_event(
             self._conn,
-            job_url,
+            job_id,
             None,
             event_type,
+            tenant_id=tenant_id,
             message=message,
             payload=payload,
             publisher=self._publisher,

--- a/workers/automation/src/jobctrl/infrastructure/contact/sqlite_repository.py
+++ b/workers/automation/src/jobctrl/infrastructure/contact/sqlite_repository.py
@@ -12,7 +12,7 @@ Event payloads written to ``job_events`` carry only identifiers, kinds,
 provenance metadata, and timestamps — never a value. Contact-only events (no
 application link) carry honest identity via ``entity_kind='contact'`` /
 ``entity_ref=<contact_id>`` (schema v2). Application-linked events additionally
-key on the job's ``job_url`` so they surface in the job's audit history.
+key on the canonical ``job_id`` so they surface in the job's audit history.
 """
 
 from __future__ import annotations
@@ -21,7 +21,6 @@ import json
 import logging
 import sqlite3
 
-from jobctrl.database import ensure_contact_tables
 from jobctrl.domain.contact.aggregate import Contact
 from jobctrl.domain.contact.value_objects import (
     ContactAttribute,
@@ -29,7 +28,7 @@ from jobctrl.domain.contact.value_objects import (
     ContactLink,
     ContactRole,
 )
-from jobctrl.domain.identifiers import ContactId
+from jobctrl.domain.identifiers import ContactId, JobId, canonical_job_id
 from jobctrl.domain.ports.events import EventPublisher
 from jobctrl.domain.tenant import TenantId
 from jobctrl.state import record_job_event, utc_now
@@ -43,7 +42,6 @@ class SqliteContactRepository:
     def __init__(self, conn: sqlite3.Connection, *, publisher: EventPublisher) -> None:
         self._conn = conn
         self._publisher = publisher
-        ensure_contact_tables(self._conn)
 
     # ------------------------------------------------------------------
     # Load
@@ -61,8 +59,9 @@ class SqliteContactRepository:
     def list_for_tenant(self, tenant_id: TenantId) -> list[Contact]:
         return self._list(tenant_id, "", ())
 
-    def list_for_job(self, tenant_id: TenantId, job_id: str) -> list[Contact]:
-        return self._list(tenant_id, "AND job_url = ?", (job_id,))
+    def list_for_job(self, tenant_id: TenantId, job_id: JobId) -> list[Contact]:
+        stable_job_id = canonical_job_id(str(job_id))
+        return self._list(tenant_id, "AND job_id = ?", (str(stable_job_id),))
 
     def list_for_employer(self, tenant_id: TenantId, employer: str) -> list[Contact]:
         return self._list(tenant_id, "AND employer = ?", (employer,))
@@ -84,7 +83,7 @@ class SqliteContactRepository:
         return Contact(
             tenant_id=tenant_id,
             contact_id=ContactId(str(row["contact_id"])),
-            link=ContactLink(employer=row["employer"], job_id=row["job_url"]),
+            link=ContactLink(employer=row["employer"], job_id=row["job_id"]),
             role=_role(row["role"]),
             attributes=self._load_attributes(tenant_id, str(row["contact_id"])),
             created_at=str(row["created_at"] or ""),
@@ -143,12 +142,12 @@ class SqliteContactRepository:
             self._conn.execute(
                 """
                 INSERT INTO contacts (
-                    tenant_id, contact_id, employer, job_url, role,
+                    tenant_id, contact_id, employer, job_id, role,
                     created_at, updated_at, deleted_at
                 ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
                 ON CONFLICT(tenant_id, contact_id) DO UPDATE SET
                     employer = excluded.employer,
-                    job_url = excluded.job_url,
+                    job_id = excluded.job_id,
                     role = excluded.role,
                     updated_at = excluded.updated_at,
                     deleted_at = excluded.deleted_at
@@ -194,6 +193,9 @@ class SqliteContactRepository:
                 )
 
     def delete(self, tenant_id: TenantId, contact_id: ContactId, *, reason: str = "") -> bool:
+        contact = self.load(tenant_id, contact_id)
+        if contact is None:
+            return False
         deleted_at = utc_now()
         cursor = self._conn.execute(
             """
@@ -207,9 +209,10 @@ class SqliteContactRepository:
         try:
             record_job_event(
                 self._conn,
-                None,
+                contact.link.job_id,
                 None,
                 "ContactDeleted",
+                tenant_id=tenant_id,
                 message="Contact deleted.",
                 payload={
                     "tenantId": str(tenant_id),
@@ -235,11 +238,12 @@ class SqliteContactRepository:
     ) -> None:
         tenant = str(tenant_id)
         contact_id = str(contact.contact_id)
-        job_url = contact.link.job_id or None
+        job_id = contact.link.job_id
 
         if previous is None:
             self._record(
-                job_url,
+                tenant_id,
+                job_id,
                 "ContactCreated",
                 "Contact created.",
                 {
@@ -256,7 +260,8 @@ class SqliteContactRepository:
         else:
             changed = _changed_fields(previous, contact)
             self._record(
-                job_url,
+                tenant_id,
+                job_id,
                 "ContactUpdated",
                 "Contact updated.",
                 {
@@ -275,7 +280,8 @@ class SqliteContactRepository:
         for attribute in new_attributes:
             provenance = attribute.provenance
             self._record(
-                job_url,
+                tenant_id,
+                job_id,
                 "ContactAttributeRecorded",
                 "Contact fact recorded.",
                 {
@@ -295,7 +301,8 @@ class SqliteContactRepository:
 
     def _record(
         self,
-        job_url: str | None,
+        tenant_id: TenantId,
+        job_id: JobId | None,
         event_type: str,
         message: str,
         payload: dict[str, object],
@@ -303,9 +310,10 @@ class SqliteContactRepository:
     ) -> None:
         record_job_event(
             self._conn,
-            job_url,
+            job_id,
             None,
             event_type,
+            tenant_id=tenant_id,
             message=message,
             payload=payload,
             publisher=self._publisher,

--- a/workers/automation/src/jobctrl/infrastructure/rpc/handlers.py
+++ b/workers/automation/src/jobctrl/infrastructure/rpc/handlers.py
@@ -645,7 +645,23 @@ def run_contact_research(params: dict[str, Any]) -> WorkflowStartSpec:
     require an explicit user confirmation before becoming stored facts (INV-4).
     """
     try:
-        return build_contact_research_workflow_spec(params)
+        if "jobId" in params:
+            raise invalid_params("run_contact_research accepts jobUrl only at the RPC boundary")
+        tenant_id = TenantId(_tenant_id(params))
+        job_url = str(params.get("jobUrl") or "").strip()
+        spec_params = dict(params)
+        spec_params.pop("jobUrl", None)
+        spec_params["tenantId"] = str(tenant_id)
+        if job_url:
+            job_id = _job_id(
+                _load_current_job(
+                    get_connection(),
+                    tenant_id=tenant_id,
+                    job_url=job_url,
+                )
+            )
+            spec_params["jobId"] = str(job_id)
+        return build_contact_research_workflow_spec(spec_params)
     except ValueError as exc:
         raise invalid_params(str(exc)) from exc
 

--- a/workers/automation/src/jobctrl/workflow_specs.py
+++ b/workers/automation/src/jobctrl/workflow_specs.py
@@ -270,15 +270,20 @@ def build_contact_research_workflow_spec(params: dict[str, Any]) -> WorkflowStar
     """Build the spec for a supervised ``ContactResearchWorkflow`` run.
 
     The caller (TS API) supplies a fresh ``taskId`` so it can return it and the
-    UI can poll the task immediately. At least one of ``employer`` / ``jobUrl``
+    UI can poll the task immediately. At least one of ``employer`` / ``jobId``
     is required (a task must be scoped to a company or an application).
     """
     tenant_id = _tenant_id(params)
+    if "jobUrl" in params:
+        raise ValueError(
+            "contact research requires jobId; jobUrl is only a locator at the RPC boundary"
+        )
     task_id = str(_require(params, "taskId"))
     employer = str(params.get("employer") or "").strip() or None
-    job_url = str(params.get("jobUrl") or "").strip() or None
-    if not employer and not job_url:
-        raise ValueError("provide at least one of employer or jobUrl")
+    raw_job_id = params.get("jobId")
+    job_id = canonical_job_id(str(raw_job_id)) if raw_job_id not in (None, "") else None
+    if not employer and job_id is None:
+        raise ValueError("provide at least one of employer or jobId")
     raw_sources = params.get("sources") or []
     if not isinstance(raw_sources, list):
         raise ValueError("sources must be an array")
@@ -295,7 +300,7 @@ def build_contact_research_workflow_spec(params: dict[str, Any]) -> WorkflowStar
         tenant_id=tenant_id,
         task_id=task_id,
         employer=employer,
-        job_url=job_url,
+        job_id=job_id,
         sources=sources,
         llm_model=str(params.get("llmModel") or DEFAULT_PIPELINE_LLM_MODEL_SPEC),
         expected_app_dir=params.get("expectedAppDir"),
@@ -304,7 +309,7 @@ def build_contact_research_workflow_spec(params: dict[str, Any]) -> WorkflowStar
     return WorkflowStartSpec(
         workflow=ContactResearchWorkflow,
         args=(payload,),
-        workflow_id=contact_research_workflow_id(task_id),
+        workflow_id=contact_research_workflow_id(tenant_id, task_id),
     )
 
 

--- a/workers/automation/tests/test_contact_aggregate.py
+++ b/workers/automation/tests/test_contact_aggregate.py
@@ -14,6 +14,8 @@ from jobctrl.domain.contact.value_objects import (
 from jobctrl.domain.identifiers import ContactId
 from jobctrl.domain.tenant import LOCAL_TENANT
 
+_JOB_ID = "11111111-1111-4111-8111-111111111111"
+
 
 def _provenance() -> ContactFactProvenance:
     return ContactFactProvenance(
@@ -40,7 +42,9 @@ def test_contact_links_to_at_least_one_of_employer_or_job() -> None:
 
     # Either alone is valid.
     assert ContactLink(employer="Acme").employer == "Acme"
-    assert ContactLink(job_id="https://job/1").job_id == "https://job/1"
+    assert ContactLink(job_id=_JOB_ID).job_id == _JOB_ID
+    with pytest.raises(ValueError, match="canonical UUID"):
+        ContactLink(job_id="https://job/1")
 
 
 def test_contact_attribute_requires_provenance() -> None:
@@ -52,7 +56,7 @@ def test_contact_is_valid_with_link_and_provenanced_attributes() -> None:
     contact = Contact.create(
         tenant_id=LOCAL_TENANT,
         contact_id=ContactId("contact-1"),
-        link=ContactLink(employer="Acme", job_id="https://job/1"),
+        link=ContactLink(employer="Acme", job_id=_JOB_ID),
         role=ContactRole.RECRUITER,
         attributes=(_attribute("name", "Jane Recruiter"),),
         created_at="2026-07-01T00:00:00Z",

--- a/workers/automation/tests/test_contact_projection_parity.py
+++ b/workers/automation/tests/test_contact_projection_parity.py
@@ -1,12 +1,8 @@
-"""Cross-runtime parity for ``contact_projections`` (R6 Phase 1).
+"""Exact-v7 coverage for ``contact_projections`` (R6 Phase 1).
 
-The Python half of the TS<->Python drift guard. The TS half lives at
-``apps/api/test/contact-projection-parity.test.ts``. Both load the SAME shared
-fixture (``packages/domain-types/test/fixtures/contact_projection_parity.json``),
-seed the SAME canonical ``contacts`` / ``contact_attributes`` rows, run their OWN
-projection refresh, and assert the resulting ``contact_projections`` rows equal
-the fixture's ``expected`` block (JSON columns compared parsed). It also asserts
-no attribute VALUE leaks into the projection (sensitivity rule, plan §6).
+The shared parity fixture remains on the legacy TypeScript projection contract.
+This test derives a local exact-v7 fixture using canonical JobIds, then asserts
+the resulting ``contact_projections`` rows and the sensitive-value boundary.
 """
 
 from __future__ import annotations
@@ -28,15 +24,39 @@ _FIXTURE = (
     Path(__file__).resolve().parents[3]
     / "packages/domain-types/test/fixtures/contact_projection_parity.json"
 )
+_V7_JOB_IDS = {
+    "https://boards.example.com/acme/eng-1": "11111111-1111-4111-8111-111111111111",
+}
+
+
+def _exact_v7_fixture() -> dict[str, Any]:
+    fixture = json.loads(_FIXTURE.read_text())
+    for contact in fixture["contacts"]:
+        job_url = contact.pop("jobUrl")
+        contact["jobId"] = _V7_JOB_IDS[job_url] if job_url else None
+    for expected in fixture["expected"]:
+        job_url = expected.get("jobId")
+        expected["jobId"] = _V7_JOB_IDS[job_url] if job_url else None
+    return fixture
 
 
 def _seed_canonical(conn: sqlite3.Connection, fixture: dict[str, Any]) -> None:
     tenant = fixture["tenantId"]
     for contact in fixture["contacts"]:
+        if contact["jobId"] is None:
+            continue
+        conn.execute(
+            """
+            INSERT INTO jobs (tenant_id, job_id, url, title, discovered_at)
+            VALUES (?, ?, ?, 'Fixture job', '2026-07-31T12:00:00Z')
+            """,
+            (tenant, contact["jobId"], f"https://fixtures.example/{contact['contactId']}"),
+        )
+    for contact in fixture["contacts"]:
         conn.execute(
             """
             INSERT INTO contacts (
-                tenant_id, contact_id, employer, job_url, role,
+                tenant_id, contact_id, employer, job_id, role,
                 created_at, updated_at, deleted_at
             ) VALUES (?, ?, ?, ?, ?, ?, ?, NULL)
             """,
@@ -44,7 +64,7 @@ def _seed_canonical(conn: sqlite3.Connection, fixture: dict[str, Any]) -> None:
                 tenant,
                 contact["contactId"],
                 contact["employer"],
-                contact["jobUrl"],
+                contact["jobId"],
                 contact["role"],
                 contact["createdAt"],
                 contact["updatedAt"],
@@ -91,8 +111,8 @@ def _normalize(row: sqlite3.Row) -> dict[str, Any]:
     }
 
 
-def test_contact_projection_parity(tmp_path: Path) -> None:
-    fixture = json.loads(_FIXTURE.read_text())
+def test_contact_projection_exact_v7_fixture(tmp_path: Path) -> None:
+    fixture = _exact_v7_fixture()
     conn = init_db(tmp_path / "jobctrl.db")
     conn.row_factory = sqlite3.Row
     _seed_canonical(conn, fixture)

--- a/workers/automation/tests/test_contact_repository.py
+++ b/workers/automation/tests/test_contact_repository.py
@@ -22,6 +22,7 @@ from jobctrl.domain.contact import (
     ImportContactsUseCase,
     UpdateContactUseCase,
 )
+from jobctrl.domain.identifiers import JobId
 from jobctrl.domain.tenant import LOCAL_TENANT
 from jobctrl.infrastructure.contact.sqlite_repository import SqliteContactRepository
 from jobctrl.infrastructure.events.in_process_bus import InProcessEventBus
@@ -32,11 +33,24 @@ from jobctrl.infrastructure.projections.sqlite_projection_store import (
 
 _SECRET_NAME = "Jane Recruiter"
 _SECRET_EMAIL = "jane@acme.example"
+_JOB_ID = JobId("11111111-1111-4111-8111-111111111111")
+_OTHER_JOB_ID = JobId("22222222-2222-4222-8222-222222222222")
 
 
 def _setup(tmp_path: Path) -> tuple[SqliteContactRepository, sqlite3.Connection]:
     conn = init_db(tmp_path / "jobctrl.db")
     conn.row_factory = sqlite3.Row
+    conn.executemany(
+        """
+        INSERT INTO jobs (tenant_id, job_id, url, title, discovered_at)
+        VALUES ('local', ?, ?, 'Test job', '2026-07-31T12:00:00Z')
+        """,
+        [
+            (_JOB_ID, "https://jobs.example/one"),
+            (_OTHER_JOB_ID, "https://jobs.example/two"),
+        ],
+    )
+    conn.commit()
     bus = InProcessEventBus()
     ProjectionBuilder(conn_factory=lambda: conn, tenant_id=LOCAL_TENANT).subscribe_to(bus)
     return SqliteContactRepository(conn, publisher=bus), conn
@@ -46,7 +60,7 @@ def test_create_persists_canonical_and_projects_with_provenance(tmp_path: Path) 
     repo, conn = _setup(tmp_path)
     contact = CreateContactUseCase(repo).execute(
         LOCAL_TENANT,
-        link=ContactLink(employer="Acme", job_id="https://job/1"),
+        link=ContactLink(employer="Acme", job_id=_JOB_ID),
         role=ContactRole.RECRUITER,
         attributes=[
             AttributeInput("name", _SECRET_NAME),
@@ -74,7 +88,7 @@ def test_values_never_leak_into_events_or_projection(tmp_path: Path) -> None:
     repo, conn = _setup(tmp_path)
     CreateContactUseCase(repo).execute(
         LOCAL_TENANT,
-        link=ContactLink(employer="Acme", job_id="https://job/1"),
+        link=ContactLink(employer="Acme", job_id=_JOB_ID),
         role=ContactRole.RECRUITER,
         attributes=[
             AttributeInput("name", _SECRET_NAME),
@@ -136,16 +150,17 @@ def test_soft_delete_drops_projection_and_hides_from_load(tmp_path: Path) -> Non
     repo, conn = _setup(tmp_path)
     contact = CreateContactUseCase(repo).execute(
         LOCAL_TENANT,
-        link=ContactLink(employer="Acme"),
+        link=ContactLink(employer="Acme", job_id=_JOB_ID),
         attributes=[AttributeInput("name", _SECRET_NAME)],
     )
     assert DeleteContactUseCase(repo).execute(LOCAL_TENANT, contact.contact_id, reason="dup")
     assert repo.load(LOCAL_TENANT, contact.contact_id) is None
     assert SqliteProjectionStore(conn).fetch_contacts("local") == []
-    deleted_events = conn.execute(
-        "SELECT COUNT(*) FROM job_events WHERE event_type = 'ContactDeleted'"
-    ).fetchone()[0]
-    assert deleted_events == 1
+    deleted_event = conn.execute(
+        "SELECT tenant_id, job_id, payload_json FROM job_events WHERE event_type = 'ContactDeleted'"
+    ).fetchone()
+    assert tuple(deleted_event[:2]) == (str(LOCAL_TENANT), _JOB_ID)
+    assert json.loads(deleted_event["payload_json"])["jobId"] == _JOB_ID
 
 
 def test_csv_import_tags_provenance_and_skips_linkless_rows(tmp_path: Path) -> None:
@@ -218,13 +233,13 @@ def test_list_for_job_filters_by_application(tmp_path: Path) -> None:
     repo, _ = _setup(tmp_path)
     CreateContactUseCase(repo).execute(
         LOCAL_TENANT,
-        link=ContactLink(employer="Acme", job_id="https://job/1"),
+        link=ContactLink(employer="Acme", job_id=_JOB_ID),
         attributes=[AttributeInput("name", "A")],
     )
     CreateContactUseCase(repo).execute(
         LOCAL_TENANT,
-        link=ContactLink(employer="Acme", job_id="https://job/2"),
+        link=ContactLink(employer="Acme", job_id=_OTHER_JOB_ID),
         attributes=[AttributeInput("name", "B")],
     )
-    assert len(repo.list_for_job(LOCAL_TENANT, "https://job/1")) == 1
+    assert len(repo.list_for_job(LOCAL_TENANT, _JOB_ID)) == 1
     assert len(repo.list_for_tenant(LOCAL_TENANT)) == 2

--- a/workers/automation/tests/test_contact_research_projection_parity.py
+++ b/workers/automation/tests/test_contact_research_projection_parity.py
@@ -1,12 +1,8 @@
-"""Cross-runtime parity for ``contact_research_task_projections`` (R6 Phase 2).
+"""Exact-v7 coverage for ``contact_research_task_projections`` (R6 Phase 2).
 
-The Python half of the TS<->Python drift guard. The TS half lives at
-``apps/api/test/contact-research-projection-parity.test.ts``. Both load the SAME
-shared fixture, seed the SAME canonical ``contact_research_tasks`` /
-``contact_candidates`` rows, run their OWN projection refresh, and assert the
-resulting projection rows equal the fixture's ``expected`` block (JSON columns
-compared parsed). It also asserts no candidate VALUE leaks into the projection
-(sensitivity rule, plan §6).
+The shared parity fixture remains on the legacy TypeScript projection contract.
+This test derives a local exact-v7 fixture using canonical JobIds, then asserts
+the projection rows and the sensitive-value boundary.
 """
 
 from __future__ import annotations
@@ -26,15 +22,40 @@ _FIXTURE = (
     Path(__file__).resolve().parents[3]
     / "packages/domain-types/test/fixtures/contact_research_projection_parity.json"
 )
+_V7_JOB_IDS = {
+    "https://job/1": "11111111-1111-4111-8111-111111111111",
+    "https://job/2": "22222222-2222-4222-8222-222222222222",
+}
+
+
+def _exact_v7_fixture() -> dict[str, Any]:
+    fixture = json.loads(_FIXTURE.read_text())
+    for task in fixture["tasks"]:
+        job_url = task.pop("jobUrl")
+        task["jobId"] = _V7_JOB_IDS[job_url] if job_url else None
+    for expected in fixture["expected"]:
+        job_url = expected.get("jobId")
+        expected["jobId"] = _V7_JOB_IDS[job_url] if job_url else None
+    return fixture
 
 
 def _seed_canonical(conn: sqlite3.Connection, fixture: dict[str, Any]) -> None:
     tenant = fixture["tenantId"]
     for task in fixture["tasks"]:
+        if task["jobId"] is None:
+            continue
+        conn.execute(
+            """
+            INSERT INTO jobs (tenant_id, job_id, url, title, discovered_at)
+            VALUES (?, ?, ?, 'Fixture job', '2026-07-31T12:00:00Z')
+            """,
+            (tenant, task["jobId"], f"https://fixtures.example/{task['taskId']}"),
+        )
+    for task in fixture["tasks"]:
         conn.execute(
             """
             INSERT INTO contact_research_tasks (
-                tenant_id, task_id, employer, job_url, status, source_attempts_json,
+                tenant_id, task_id, employer, job_id, status, source_attempts_json,
                 started_at, updated_at, needs_review_at, completed_at, failed_at, error_class
             ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
@@ -42,7 +63,7 @@ def _seed_canonical(conn: sqlite3.Connection, fixture: dict[str, Any]) -> None:
                 tenant,
                 task["taskId"],
                 task["employer"],
-                task["jobUrl"],
+                task["jobId"],
                 task["status"],
                 json.dumps(task["sourceAttempts"]),
                 task["startedAt"],
@@ -101,8 +122,8 @@ def _normalize(row: sqlite3.Row) -> dict[str, Any]:
     }
 
 
-def test_contact_research_projection_parity(tmp_path: Path) -> None:
-    fixture = json.loads(_FIXTURE.read_text())
+def test_contact_research_projection_exact_v7_fixture(tmp_path: Path) -> None:
+    fixture = _exact_v7_fixture()
     conn = init_db(tmp_path / "jobctrl.db")
     conn.row_factory = sqlite3.Row
     _seed_canonical(conn, fixture)

--- a/workers/automation/tests/test_contact_research_workflow.py
+++ b/workers/automation/tests/test_contact_research_workflow.py
@@ -9,6 +9,7 @@ and the LLM spend preflight is the existing shared one (§5.4 — no second syst
 
 from __future__ import annotations
 
+import json
 import sqlite3
 import urllib.error
 from email.message import Message
@@ -31,7 +32,7 @@ from jobctrl.domain.contact import (
 )
 from jobctrl.domain.ports.contact import ResearchPageFetch
 from jobctrl.domain.ports.llm import LlmMessage, LlmPort
-from jobctrl.domain.tenant import LOCAL_TENANT
+from jobctrl.domain.tenant import LOCAL_TENANT, TenantId
 from jobctrl.infrastructure.contact import (
     GatewayContactResearchFetcher,
     SqliteContactRepository,
@@ -44,6 +45,7 @@ _HOST = "acme.example"
 _TEAM_URL = f"https://{_HOST}/team"
 _SECRET_NAME = "Dana Hiring-Manager"
 _SECRET_EMAIL = "dana@acme.example"
+_JOB_ID = "11111111-1111-4111-8111-111111111111"
 
 
 class _FakeFetcher:
@@ -96,6 +98,7 @@ def _setup(tmp_path: Path):
 
     conn = init_db(tmp_path / "jobctrl.db")
     conn.row_factory = sqlite3.Row
+    _seed_job(conn, LOCAL_TENANT, _JOB_ID, "https://jobs.example/contact-research")
     bus = InProcessEventBus()
     ProjectionBuilder(conn_factory=lambda: conn, tenant_id=LOCAL_TENANT).subscribe_to(bus)
     research_repo = SqliteContactResearchTaskRepository(conn, publisher=bus)
@@ -103,7 +106,27 @@ def _setup(tmp_path: Path):
     return conn, research_repo, contact_repo
 
 
-def _run_use_case(research_repo, *, fetcher, llm, sources, allowlist=(_HOST,)):
+def _seed_job(conn: sqlite3.Connection, tenant_id: TenantId, job_id: str, url: str) -> None:
+    conn.execute(
+        """
+        INSERT INTO jobs (tenant_id, job_id, url, title, discovered_at)
+        VALUES (?, ?, ?, 'Test job', '2026-07-31T12:00:00Z')
+        """,
+        (str(tenant_id), job_id, url),
+    )
+    conn.commit()
+
+
+def _run_use_case(
+    research_repo,
+    *,
+    fetcher,
+    llm,
+    sources,
+    allowlist=(_HOST,),
+    tenant_id: TenantId = LOCAL_TENANT,
+    task_id: str = "task-1",
+):
     policy = ContactResearchSourcePolicy(domain_allowlist=allowlist)
     use_case = RunContactResearchUseCase(
         repository=research_repo,
@@ -113,9 +136,9 @@ def _run_use_case(research_repo, *, fetcher, llm, sources, allowlist=(_HOST,)):
         new_id=_counter(),
     )
     return use_case.execute(
-        LOCAL_TENANT,
-        task_id="task-1",
-        link=ContactLink(employer="Acme", job_id="https://job/1"),
+        tenant_id,
+        task_id=task_id,
+        link=ContactLink(employer="Acme", job_id=_JOB_ID),
         sources=sources,
     )
 
@@ -255,6 +278,42 @@ def test_candidate_values_never_leak_into_events(tmp_path: Path) -> None:
         "SELECT COUNT(*) FROM job_events WHERE event_type = 'ContactCandidateProposed'"
     ).fetchone()[0]
     assert proposed == 1
+
+
+def test_research_task_events_preserve_tenant_and_canonical_job_id(tmp_path: Path) -> None:
+    conn, research_repo, _contact_repo = _setup(tmp_path)
+    tenant_a = TenantId("tenant-a")
+    tenant_b = TenantId("tenant-b")
+    _seed_job(conn, tenant_a, _JOB_ID, "https://jobs.example/tenant-a")
+    _seed_job(conn, tenant_b, _JOB_ID, "https://jobs.example/tenant-b")
+
+    for tenant_id in (tenant_a, tenant_b):
+        _run_use_case(
+            research_repo,
+            tenant_id=tenant_id,
+            task_id="same-task-id",
+            fetcher=_FakeFetcher(
+                ResearchPageFetch(outcome=ResearchSourceOutcome.ALLOWED.value, text="team page body")
+            ),
+            llm=_FakeLlm([]),
+            sources=(ResearchSourceSpec(category="public_web_page", url=_TEAM_URL),),
+        )
+
+    rows = conn.execute(
+        """
+        SELECT tenant_id, job_id, payload_json
+        FROM job_events
+        WHERE event_type = 'ContactResearchTaskStarted'
+        ORDER BY tenant_id
+        """
+    ).fetchall()
+    assert [(row["tenant_id"], row["job_id"]) for row in rows] == [
+        (str(tenant_a), _JOB_ID),
+        (str(tenant_b), _JOB_ID),
+    ]
+    assert all(json.loads(row["payload_json"])["jobId"] == _JOB_ID for row in rows)
+    assert research_repo.load(tenant_a, "same-task-id") is not None
+    assert research_repo.load(tenant_b, "same-task-id") is not None
 
 
 def test_workflow_reuses_the_shared_spend_preflight() -> None:
@@ -502,7 +561,7 @@ def test_private_redirect_body_never_reaches_llm_prompt(tmp_path: Path) -> None:
     task = use_case.execute(
         LOCAL_TENANT,
         task_id="task-1",
-        link=ContactLink(employer="Acme", job_id="https://job/1"),
+        link=ContactLink(employer="Acme", job_id=_JOB_ID),
         sources=(ResearchSourceSpec(category="public_web_page", url=_TEAM_URL),),
     )
 

--- a/workers/automation/tests/test_jsonrpc_handlers.py
+++ b/workers/automation/tests/test_jsonrpc_handlers.py
@@ -14,6 +14,8 @@ from temporalio.common import WorkflowIDConflictPolicy
 
 from jobctrl.apply.workflow import ApplyWorkflow, ApplyWorkflowInput
 from jobctrl.database import close_connection, get_connection, init_db
+from jobctrl.contact.activities import ResearchSourceInput, RunContactResearchActivityInput
+from jobctrl.contact.workflow import ContactResearchWorkflow, ContactResearchWorkflowInput
 from jobctrl.discovery.workflow import DiscoverWorkflow, DiscoverWorkflowInput
 from jobctrl.domain.compensation import ReportedCompensationObservation
 from jobctrl.domain.interview import INTERVIEW_PREP_ITEM_KINDS, INTERVIEW_PREP_STATUSES
@@ -45,6 +47,7 @@ from jobctrl.preparation.workflow import JobPreparationInput, JobPreparationWork
 from jobctrl.profile.workflow import ProfileImportWorkflow, ProfileImportWorkflowInput
 from jobctrl.scoring import activities as scoring_activities_mod
 from jobctrl.scoring.activities import ScoreActivityInput, score_activity
+from jobctrl.workflow_specs import build_contact_research_workflow_spec
 
 
 class _StubHandle:
@@ -129,6 +132,7 @@ def test_default_handlers_are_registered(monkeypatch) -> None:
         "retailor_current_policy",
         "refresh_compensation",
         "generate_interview_prep",
+        "run_contact_research",
         "apply",
         "profile_import",
         "provider_status",
@@ -301,6 +305,121 @@ def test_generate_interview_prep_starts_user_triggered_workflow(tmp_db: Path) ->
     assert second is not None
     assert len(seen) == 2
     assert seen[1].workflow_id == seen[0].workflow_id
+
+
+def test_contact_research_resolves_job_url_only_at_rpc_boundary(tmp_db: Path) -> None:
+    seen: list[WorkflowStartSpec] = []
+    job_url = "https://example.com/job/contact-research"
+    source_url = "https://example.com/people"
+    job_id = _test_job_id(job_url)
+    _seed_job(tmp_db, job_url)
+
+    async def starter(spec: WorkflowStartSpec) -> _StubHandle:
+        seen.append(spec)
+        return _StubHandle("contact-research-wf", "contact-research-run")
+
+    server = JsonRpcServer(workflow_starter=starter)
+    register_default_handlers(server, canceler=_stub_canceler)
+
+    response = server.dispatch(
+        JsonRpcRequest(
+            method="run_contact_research",
+            params={
+                "tenantId": "local",
+                "taskId": "contact-task-1",
+                "employer": "Example",
+                "jobUrl": job_url,
+                "sources": [
+                    {
+                        "category": "public_web_page",
+                        "url": source_url,
+                        "label": "People",
+                    }
+                ],
+            },
+            id=1,
+        )
+    )
+
+    assert response is not None
+    assert "error" not in response.to_dict()
+    assert len(seen) == 1
+    assert seen[0].workflow is ContactResearchWorkflow
+    assert seen[0].workflow_id == "contact-research-local-contact-task-1"
+    (payload,) = seen[0].args
+    assert payload == ContactResearchWorkflowInput(
+        tenant_id="local",
+        task_id="contact-task-1",
+        employer="Example",
+        job_id=job_id,
+        sources=(
+            ResearchSourceInput(
+                category="public_web_page",
+                url=source_url,
+                label="People",
+            ),
+        ),
+    )
+    assert not hasattr(payload, "job_url")
+
+    second = server.dispatch(
+        JsonRpcRequest(
+            method="run_contact_research",
+            params={
+                "tenantId": "local",
+                "taskId": "contact-task-1",
+                "employer": "Example",
+                "jobUrl": job_url,
+            },
+            id=2,
+        )
+    )
+    assert second is not None
+    assert seen[1].workflow_id == seen[0].workflow_id
+
+    rejected = server.dispatch(
+        JsonRpcRequest(
+            method="run_contact_research",
+            params={
+                "tenantId": "local",
+                "taskId": "contact-task-2",
+                "jobId": str(job_id),
+            },
+            id=3,
+        )
+    )
+    assert rejected is not None
+    assert rejected.to_dict()["error"]["code"] == INVALID_PARAMS
+    assert "jobUrl only at the RPC boundary" in rejected.to_dict()["error"]["message"]
+
+    with pytest.raises(ValueError, match="canonical UUID"):
+        build_contact_research_workflow_spec(
+            {
+                "tenantId": "local",
+                "taskId": "contact-task-2",
+                "jobId": job_url,
+            }
+        )
+
+    tenant_a_spec = build_contact_research_workflow_spec(
+        {"tenantId": "tenant-a", "taskId": "same-task-id", "jobId": str(job_id)}
+    )
+    tenant_b_spec = build_contact_research_workflow_spec(
+        {"tenantId": "tenant-b", "taskId": "same-task-id", "jobId": str(job_id)}
+    )
+    assert tenant_a_spec.workflow_id == "contact-research-tenant-a-same-task-id"
+    assert tenant_b_spec.workflow_id == "contact-research-tenant-b-same-task-id"
+
+
+def test_contact_research_direct_inputs_require_canonical_job_ids() -> None:
+    for input_type in (ContactResearchWorkflowInput, RunContactResearchActivityInput):
+        with pytest.raises(ValueError, match="canonical UUID"):
+            input_type(
+                tenant_id="local",
+                task_id="contact-task-direct",
+                employer="Example",
+                job_id="https://example.com/job/contact-research",
+            )
 
 
 def test_interview_prep_has_no_live_assistance_surface() -> None:


### PR DESCRIPTION
## Summary

-

## Validation

-

## Checklist

- [ ] External contributor commits include a DCO `Signed-off-by:` trailer (`git commit -s`).
- [ ] I ran the relevant local checks and listed them above. Heavy CI runs automatically for ordinary same-repository pull requests and cumulative stack heads, but not public forks; maintainers run manual workflows or local validation for fork contributions after review.
- [ ] I did not include secrets, private profile data, resumes, generated application materials, raw logs, browser profiles, SQLite databases, or local paths.