### PR TITLE
fix(outreach): project canonical job ids

### DIFF
--- a/apps/api/src/outreach.ts
+++ b/apps/api/src/outreach.ts
@@ -35,8 +35,8 @@ import {
   OUTREACH_DRAFT_STATUSES,
   OUTREACH_SEND_CHANNELS,
 } from "./contracts.js";
-import { allRows, getRow, tableExists, type SqliteDatabase, type SqliteValue } from "./db.js";
-import { refreshOutreachProjections, refreshProjections } from "./projections.js";
+import { allRows, getRow, tableExists, type SqliteDatabase } from "./db.js";
+import { refreshOutreachProjections } from "./projections.js";
 
 // Conservative follow-up cadence (plan §16 res. 5), mirrored from the Python
 // domain (``FIRST_FOLLOW_UP_DAYS`` / ``SUBSEQUENT_NUDGE_DAYS``). Surfaced-only,
@@ -46,59 +46,11 @@ const SUBSEQUENT_NUDGE_DAYS = 14;
 
 const TENANT_ID = "local";
 const OUTREACH_SEND_CHANNEL_SET = new Set<string>(OUTREACH_SEND_CHANNELS);
+const CANONICAL_JOB_ID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
 
 export class OutreachNotFoundError extends Error {}
 export class OutreachInputError extends Error {}
 export class OutreachDraftGatesNotPassedError extends Error {}
-
-export function ensureOutreachTables(db: SqliteDatabase): void {
-  db.exec(`
-    CREATE TABLE IF NOT EXISTS outreach_threads (
-      tenant_id        TEXT NOT NULL DEFAULT 'local',
-      thread_id        TEXT NOT NULL,
-      contact_id       TEXT NOT NULL,
-      job_url          TEXT,
-      created_at       TEXT NOT NULL,
-      updated_at       TEXT NOT NULL,
-      follow_up_due_at TEXT,
-      follow_up_basis  TEXT,
-      follow_up_state  TEXT NOT NULL DEFAULT 'none',
-      PRIMARY KEY (tenant_id, thread_id)
-    );
-    CREATE TABLE IF NOT EXISTS outreach_drafts (
-      tenant_id         TEXT NOT NULL DEFAULT 'local',
-      draft_id          TEXT NOT NULL,
-      thread_id         TEXT NOT NULL,
-      generation        INTEGER NOT NULL DEFAULT 1,
-      kind              TEXT NOT NULL,
-      status            TEXT NOT NULL DEFAULT 'candidate',
-      body_text         TEXT,
-      gate_results_json TEXT,
-      provenance_json   TEXT,
-      created_at        TEXT NOT NULL,
-      approved_at       TEXT,
-      rejected_at       TEXT,
-      reason            TEXT,
-      PRIMARY KEY (tenant_id, draft_id)
-    );
-    CREATE TABLE IF NOT EXISTS outreach_send_logs (
-      tenant_id        TEXT NOT NULL DEFAULT 'local',
-      send_log_id      TEXT NOT NULL,
-      thread_id        TEXT NOT NULL,
-      draft_id         TEXT NOT NULL,
-      channel          TEXT NOT NULL,
-      sent_at          TEXT NOT NULL,
-      logged_at        TEXT NOT NULL,
-      PRIMARY KEY (tenant_id, send_log_id)
-    );
-    CREATE INDEX IF NOT EXISTS idx_outreach_threads_contact
-      ON outreach_threads(tenant_id, contact_id);
-    CREATE INDEX IF NOT EXISTS idx_outreach_drafts_thread
-      ON outreach_drafts(tenant_id, thread_id, generation DESC);
-    CREATE INDEX IF NOT EXISTS idx_outreach_send_logs_thread
-      ON outreach_send_logs(tenant_id, thread_id);
-  `);
-}
 
 // ---------------------------------------------------------------------------
 // Reads (canonical join — the thread summary + every generation's full content)
@@ -109,9 +61,9 @@ export function getOutreachThreadForContact(
   contactId: string,
   jobId?: string | null,
 ): OutreachThreadDetail | null {
-  ensureOutreachTables(db);
-  refreshProjections(db, TENANT_ID);
-  const thread = loadThreadForContact(db, contactId, jobId ?? null);
+  const stableJobId = canonicalJobId(jobId);
+  refreshOutreachProjections(db, TENANT_ID);
+  const thread = loadThreadForContact(db, contactId, stableJobId);
   return thread ? buildThreadDetail(db, thread) : null;
 }
 
@@ -119,8 +71,7 @@ export function getOutreachThreadDetail(
   db: SqliteDatabase,
   threadId: string,
 ): OutreachThreadDetail | null {
-  ensureOutreachTables(db);
-  refreshProjections(db, TENANT_ID);
+  refreshOutreachProjections(db, TENANT_ID);
   const thread = loadThreadRow(db, threadId);
   return thread ? buildThreadDetail(db, thread) : null;
 }
@@ -131,8 +82,8 @@ export function findOutreachThreadIdForContact(
   contactId: string,
   jobId?: string | null,
 ): string | null {
-  ensureOutreachTables(db);
-  const thread = loadThreadForContact(db, contactId, jobId ?? null);
+  const stableJobId = canonicalJobId(jobId);
+  const thread = loadThreadForContact(db, contactId, stableJobId);
   return thread ? String(thread.thread_id) : null;
 }
 
@@ -145,7 +96,6 @@ export function approveOutreachDraft(
   threadId: string,
   draftId: string,
 ): OutreachThreadDetail {
-  ensureOutreachTables(db);
   const thread = loadThreadRow(db, threadId);
   if (!thread) {
     throw new OutreachNotFoundError(`Outreach thread ${threadId} not found`);
@@ -166,7 +116,7 @@ export function approveOutreachDraft(
   }
 
   const now = new Date().toISOString();
-  const jobUrl = thread.job_url ?? null;
+  const jobId = thread.job_id ?? null;
   const transaction = db.transaction(() => {
     // Supersede the prior approved draft (if any). This is internal generation
     // bookkeeping — it emits no event, exactly like the Python repository.
@@ -182,7 +132,7 @@ export function approveOutreachDraft(
       `UPDATE outreach_threads SET updated_at = ? WHERE tenant_id = ? AND thread_id = ?`,
     ).run(now, TENANT_ID, threadId);
     recordEvent(db, {
-      jobUrl,
+      jobId,
       eventType: "OutreachDraftApproved",
       threadId,
       payload: {
@@ -196,7 +146,6 @@ export function approveOutreachDraft(
   });
   transaction();
 
-  refreshProjections(db, TENANT_ID);
   refreshOutreachProjections(db, TENANT_ID);
   return buildThreadDetail(db, loadThreadRow(db, threadId) ?? thread);
 }
@@ -207,7 +156,6 @@ export function rejectOutreachDraft(
   draftId: string,
   reason = "",
 ): OutreachThreadDetail {
-  ensureOutreachTables(db);
   const thread = loadThreadRow(db, threadId);
   if (!thread) {
     throw new OutreachNotFoundError(`Outreach thread ${threadId} not found`);
@@ -223,7 +171,7 @@ export function rejectOutreachDraft(
   }
 
   const now = new Date().toISOString();
-  const jobUrl = thread.job_url ?? null;
+  const jobId = thread.job_id ?? null;
   const transaction = db.transaction(() => {
     db.prepare(
       `UPDATE outreach_drafts SET status = 'rejected', rejected_at = ?, reason = ?
@@ -233,7 +181,7 @@ export function rejectOutreachDraft(
       `UPDATE outreach_threads SET updated_at = ? WHERE tenant_id = ? AND thread_id = ?`,
     ).run(now, TENANT_ID, threadId);
     recordEvent(db, {
-      jobUrl,
+      jobId,
       eventType: "OutreachDraftRejected",
       threadId,
       payload: {
@@ -247,7 +195,6 @@ export function rejectOutreachDraft(
   });
   transaction();
 
-  refreshProjections(db, TENANT_ID);
   refreshOutreachProjections(db, TENANT_ID);
   return buildThreadDetail(db, loadThreadRow(db, threadId) ?? thread);
 }
@@ -269,7 +216,6 @@ export function logOutreachSend(
   channel: string,
   sentAt: string,
 ): OutreachThreadDetail {
-  ensureOutreachTables(db);
   const thread = loadThreadRow(db, threadId);
   if (!thread) {
     throw new OutreachNotFoundError(`Outreach thread ${threadId} not found`);
@@ -295,7 +241,7 @@ export function logOutreachSend(
 
   const now = new Date().toISOString();
   const sendLogId = randomUUID();
-  const jobUrl = thread.job_url ?? null;
+  const jobId = thread.job_id ?? null;
   const transaction = db.transaction(() => {
     db.prepare(
       `INSERT INTO outreach_send_logs (
@@ -306,7 +252,7 @@ export function logOutreachSend(
       `UPDATE outreach_threads SET updated_at = ? WHERE tenant_id = ? AND thread_id = ?`,
     ).run(now, TENANT_ID, threadId);
     recordEvent(db, {
-      jobUrl,
+      jobId,
       eventType: "OutreachSendLogged",
       threadId,
       payload: {
@@ -321,7 +267,6 @@ export function logOutreachSend(
   });
   transaction();
 
-  refreshProjections(db, TENANT_ID);
   refreshOutreachProjections(db, TENANT_ID);
   return buildThreadDetail(db, loadThreadRow(db, threadId) ?? thread);
 }
@@ -335,7 +280,6 @@ export function scheduleOutreachFollowUp(
     hasLoggedReply?: boolean;
   } = {},
 ): OutreachThreadDetail {
-  ensureOutreachTables(db);
   const thread = loadThreadRow(db, threadId);
   if (!thread) {
     throw new OutreachNotFoundError(`Outreach thread ${threadId} not found`);
@@ -360,7 +304,7 @@ export function scheduleOutreachFollowUp(
   basis = basis || "manual";
 
   const now = new Date().toISOString();
-  const jobUrl = thread.job_url ?? null;
+  const jobId = thread.job_id ?? null;
   const transaction = db.transaction(() => {
     db.prepare(
       `UPDATE outreach_threads
@@ -368,13 +312,13 @@ export function scheduleOutreachFollowUp(
        WHERE tenant_id = ? AND thread_id = ?`,
     ).run(dueAt, basis, now, TENANT_ID, threadId);
     recordEvent(db, {
-      jobUrl,
+      jobId,
       eventType: "FollowUpScheduled",
       threadId,
       payload: {
         tenantId: TENANT_ID,
         threadId,
-        jobId: jobUrl,
+        jobId,
         dueAt,
         basis,
         scheduledAt: now,
@@ -383,7 +327,6 @@ export function scheduleOutreachFollowUp(
   });
   transaction();
 
-  refreshProjections(db, TENANT_ID);
   refreshOutreachProjections(db, TENANT_ID);
   return buildThreadDetail(db, loadThreadRow(db, threadId) ?? thread);
 }
@@ -419,7 +362,6 @@ function transitionFollowUp(
     buildPayload: (now: string) => Record<string, unknown>;
   },
 ): OutreachThreadDetail {
-  ensureOutreachTables(db);
   const thread = loadThreadRow(db, threadId);
   if (!thread) {
     throw new OutreachNotFoundError(`Outreach thread ${threadId} not found`);
@@ -428,14 +370,14 @@ function transitionFollowUp(
     throw new OutreachInputError(`Outreach thread ${threadId} has no scheduled follow-up`);
   }
   const now = new Date().toISOString();
-  const jobUrl = thread.job_url ?? null;
+  const jobId = thread.job_id ?? null;
   const transaction = db.transaction(() => {
     db.prepare(
       `UPDATE outreach_threads SET follow_up_state = ?, updated_at = ?
        WHERE tenant_id = ? AND thread_id = ?`,
     ).run(spec.to, now, TENANT_ID, threadId);
     recordEvent(db, {
-      jobUrl,
+      jobId,
       eventType: spec.eventType,
       threadId,
       payload: spec.buildPayload(now),
@@ -443,7 +385,6 @@ function transitionFollowUp(
   });
   transaction();
 
-  refreshProjections(db, TENANT_ID);
   refreshOutreachProjections(db, TENANT_ID);
   return buildThreadDetail(db, loadThreadRow(db, threadId) ?? thread);
 }
@@ -454,8 +395,6 @@ function transitionFollowUp(
  * never an action. Only follow-ups whose date has arrived are returned.
  */
 export function getDueFollowUps(db: SqliteDatabase, now: Date = new Date()): DueFollowUpSummary[] {
-  ensureOutreachTables(db);
-  refreshProjections(db, TENANT_ID);
   refreshOutreachProjections(db, TENANT_ID);
   if (!tableExists(db, "due_follow_up_projections")) {
     return [];
@@ -520,8 +459,8 @@ function deriveFollowUpDueAt(opts: {
 }
 
 function latestApplicationSubmittedAt(db: SqliteDatabase, thread: ThreadRow): string {
-  const jobUrl = (thread.job_url ?? "").trim();
-  if (!jobUrl) {
+  const jobId = thread.job_id ?? "";
+  if (!jobId) {
     return "";
   }
   if (tableExists(db, "application_outcomes")) {
@@ -529,10 +468,10 @@ function latestApplicationSubmittedAt(db: SqliteDatabase, thread: ThreadRow): st
       db,
       `SELECT occurred_at
        FROM application_outcomes
-       WHERE tenant_id = ? AND job_key = ? AND kind = 'applied_confirmation'
+       WHERE tenant_id = ? AND job_id = ? AND kind = 'applied_confirmation'
        ORDER BY occurred_at DESC, recorded_at DESC
        LIMIT 1`,
-      [TENANT_ID, jobUrl],
+      [TENANT_ID, jobId],
     );
     if (outcome?.occurred_at) {
       return outcome.occurred_at;
@@ -543,10 +482,10 @@ function latestApplicationSubmittedAt(db: SqliteDatabase, thread: ThreadRow): st
       db,
       `SELECT occurred_at
        FROM job_events
-       WHERE job_url = ? AND event_type = 'ApplicationSubmitted'
+       WHERE tenant_id = ? AND job_id = ? AND event_type = 'ApplicationSubmitted'
        ORDER BY occurred_at DESC
        LIMIT 1`,
-      [jobUrl],
+      [TENANT_ID, jobId],
     );
     if (submitted?.occurred_at) {
       return submitted.occurred_at;
@@ -567,7 +506,7 @@ function addCalendarDays(iso: string, days: number): string {
 type ThreadRow = {
   thread_id: string;
   contact_id: string;
-  job_url: string | null;
+  job_id: string | null;
   created_at: string | null;
   updated_at: string | null;
   follow_up_due_at: string | null;
@@ -585,7 +524,7 @@ type SendLogRow = {
 };
 
 const THREAD_COLUMNS =
-  "thread_id, contact_id, job_url, created_at, updated_at, " +
+  "thread_id, contact_id, job_id, created_at, updated_at, " +
   "follow_up_due_at, follow_up_basis, follow_up_state";
 
 type DraftRow = {
@@ -631,7 +570,7 @@ function loadThreadForContact(
     return (
       getRow<ThreadRow>(
         db,
-        `SELECT ${THREAD_COLUMNS} FROM outreach_threads WHERE tenant_id = ? AND contact_id = ? AND job_url = ?`,
+        `SELECT ${THREAD_COLUMNS} FROM outreach_threads WHERE tenant_id = ? AND contact_id = ? AND job_id = ?`,
         [TENANT_ID, contactId, job],
       ) ?? null
     );
@@ -639,7 +578,7 @@ function loadThreadForContact(
   return (
     getRow<ThreadRow>(
       db,
-      `SELECT ${THREAD_COLUMNS} FROM outreach_threads WHERE tenant_id = ? AND contact_id = ? AND job_url IS NULL`,
+      `SELECT ${THREAD_COLUMNS} FROM outreach_threads WHERE tenant_id = ? AND contact_id = ? AND job_id IS NULL`,
       [TENANT_ID, contactId],
     ) ?? null
   );
@@ -729,7 +668,7 @@ function summarize(thread: ThreadRow, drafts: OutreachDraftDto[]): OutreachThrea
   return {
     threadId: String(thread.thread_id),
     contactId: String(thread.contact_id),
-    jobId: thread.job_url ?? null,
+    jobId: thread.job_id ?? null,
     draftCount: drafts.length,
     latestGeneration,
     hasApprovedDraft,
@@ -823,32 +762,39 @@ function normalizeStatus(value: string | null | undefined): OutreachDraftStatus 
 function recordEvent(
   db: SqliteDatabase,
   event: {
-    jobUrl: string | null;
+    jobId: string | null;
     eventType: string;
     threadId: string;
     payload: Record<string, unknown>;
   },
 ): void {
-  if (!tableExists(db, "job_events")) {
-    return;
-  }
-  const columns = new Set(
-    allRows<{ name: string }>(db, "PRAGMA table_info(job_events)").map((row) => row.name),
-  );
-  const values: Record<string, SqliteValue> = {
-    job_url: event.jobUrl,
-    stage: null,
-    event_type: event.eventType,
-    level: "info",
-    occurred_at: new Date().toISOString(),
-    payload_json: JSON.stringify(event.payload),
-    entity_kind: "outreach",
-    entity_ref: event.threadId,
-  };
-  const entries = Object.entries(values).filter(([name]) => columns.has(name));
   db.prepare(
-    `INSERT INTO job_events (${entries.map(([name]) => name).join(", ")}) VALUES (${entries
-      .map(() => "?")
-      .join(", ")})`,
-  ).run(...entries.map(([, value]) => value));
+    `INSERT INTO job_events (
+       tenant_id, job_id, identity_version, stage, event_type, level,
+       message, occurred_at, payload_json, entity_kind, entity_ref, idempotency_key
+     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    TENANT_ID,
+    event.jobId,
+    1,
+    null,
+    event.eventType,
+    "info",
+    null,
+    new Date().toISOString(),
+    JSON.stringify(event.payload),
+    "outreach",
+    event.threadId,
+    null,
+  );
+}
+
+function canonicalJobId(value: string | null | undefined): string | null {
+  if (value == null) {
+    return null;
+  }
+  if (!CANONICAL_JOB_ID.test(value)) {
+    throw new OutreachInputError("jobId must be a canonical UUID");
+  }
+  return value;
 }

--- a/apps/api/test/due-follow-up-projection-parity.test.ts
+++ b/apps/api/test/due-follow-up-projection-parity.test.ts
@@ -15,8 +15,8 @@ import { fileURLToPath } from "node:url";
 import Database from "better-sqlite3";
 import { afterEach, describe, expect, it } from "vitest";
 
-import { ensureOutreachTables } from "../src/outreach.js";
-import { refreshProjections } from "../src/projections.js";
+import { refreshOutreachProjections } from "../src/projections.js";
+import { initializeExactV7Database } from "./v7-schema.js";
 
 const FIXTURE_PATH = fileURLToPath(
   new URL(
@@ -42,24 +42,32 @@ afterEach(() => {
 
 function seededDb(): Database.Database {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "jobctrl-due-followup-parity-"));
-  const db = new Database(path.join(dir, "jobs.db"));
+  const dbPath = path.join(dir, "jobs.db");
+  initializeExactV7Database(dbPath);
+  const db = new Database(dbPath);
   cleanups.push(() => {
     db.close();
     fs.rmSync(dir, { recursive: true, force: true });
   });
-  ensureOutreachTables(db);
+  const insertJob = db.prepare(
+    `INSERT INTO jobs (tenant_id, job_id, url) VALUES (?, ?, ?)`,
+  );
   const insertThread = db.prepare(
     `INSERT INTO outreach_threads (
-       tenant_id, thread_id, contact_id, job_url, created_at, updated_at,
+       tenant_id, thread_id, contact_id, job_id, created_at, updated_at,
        follow_up_due_at, follow_up_basis, follow_up_state
      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   );
   for (const thread of fixture.threads) {
+    if (thread.jobId) {
+      const jobId = String(thread.jobId);
+      insertJob.run(fixture.tenantId, jobId, `https://example.test/jobs/${jobId}`);
+    }
     insertThread.run(
       fixture.tenantId,
       thread.threadId,
       thread.contactId,
-      thread.jobUrl,
+      thread.jobId,
       thread.createdAt,
       thread.updatedAt,
       thread.followUpDueAt,
@@ -87,7 +95,7 @@ function normalize(row: Record<string, unknown>): Record<string, unknown> {
 describe("due_follow_up_projections cross-runtime parity", () => {
   it("materialises only scheduled follow-ups matching the shared fixture", () => {
     const db = seededDb();
-    refreshProjections(db, fixture.tenantId);
+    refreshOutreachProjections(db, fixture.tenantId);
     const rows = db
       .prepare("SELECT * FROM due_follow_up_projections WHERE tenant_id = ?")
       .all(fixture.tenantId) as Array<Record<string, unknown>>;
@@ -103,13 +111,13 @@ describe("due_follow_up_projections cross-runtime parity", () => {
 
   it("is idempotent across repeated refreshes", () => {
     const db = seededDb();
-    refreshProjections(db, fixture.tenantId);
+    refreshOutreachProjections(db, fixture.tenantId);
     const first = (
       db
         .prepare("SELECT * FROM due_follow_up_projections WHERE tenant_id = ?")
         .all(fixture.tenantId) as Array<Record<string, unknown>>
     ).map(normalize);
-    refreshProjections(db, fixture.tenantId);
+    refreshOutreachProjections(db, fixture.tenantId);
     const second = (
       db
         .prepare("SELECT * FROM due_follow_up_projections WHERE tenant_id = ?")

--- a/apps/api/test/outreach-projection-parity.test.ts
+++ b/apps/api/test/outreach-projection-parity.test.ts
@@ -16,8 +16,8 @@ import { fileURLToPath } from "node:url";
 import Database from "better-sqlite3";
 import { afterEach, describe, expect, it } from "vitest";
 
-import { ensureOutreachTables } from "../src/outreach.js";
-import { refreshProjections } from "../src/projections.js";
+import { refreshOutreachProjections } from "../src/projections.js";
+import { initializeExactV7Database } from "./v7-schema.js";
 
 const FIXTURE_PATH = fileURLToPath(
   new URL(
@@ -45,23 +45,31 @@ afterEach(() => {
 
 function seededDb(): Database.Database {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "jobctrl-outreach-parity-"));
-  const db = new Database(path.join(dir, "jobs.db"));
+  const dbPath = path.join(dir, "jobs.db");
+  initializeExactV7Database(dbPath);
+  const db = new Database(dbPath);
   cleanups.push(() => {
     db.close();
     fs.rmSync(dir, { recursive: true, force: true });
   });
-  ensureOutreachTables(db);
+  const insertJob = db.prepare(
+    `INSERT INTO jobs (tenant_id, job_id, url) VALUES (?, ?, ?)`,
+  );
   const insertThread = db.prepare(
     `INSERT INTO outreach_threads (
-       tenant_id, thread_id, contact_id, job_url, created_at, updated_at
+       tenant_id, thread_id, contact_id, job_id, created_at, updated_at
      ) VALUES (?, ?, ?, ?, ?, ?)`,
   );
   for (const thread of fixture.threads) {
+    if (thread.jobId) {
+      const jobId = String(thread.jobId);
+      insertJob.run(fixture.tenantId, jobId, `https://example.test/jobs/${jobId}`);
+    }
     insertThread.run(
       fixture.tenantId,
       thread.threadId,
       thread.contactId,
-      thread.jobUrl,
+      thread.jobId,
       thread.createdAt,
       thread.updatedAt,
     );
@@ -112,7 +120,7 @@ function normalize(row: Record<string, unknown>): Record<string, unknown> {
 describe("outreach_thread_projections cross-runtime parity", () => {
   it("materialises the projection from canonical rows matching the shared fixture", () => {
     const db = seededDb();
-    refreshProjections(db, fixture.tenantId);
+    refreshOutreachProjections(db, fixture.tenantId);
     const rows = db
       .prepare("SELECT * FROM outreach_thread_projections WHERE tenant_id = ?")
       .all(fixture.tenantId) as Array<Record<string, unknown>>;
@@ -128,7 +136,7 @@ describe("outreach_thread_projections cross-runtime parity", () => {
 
   it("never persists a draft body, gate internal, or rationale into the projection", () => {
     const db = seededDb();
-    refreshProjections(db, fixture.tenantId);
+    refreshOutreachProjections(db, fixture.tenantId);
     const rows = db
       .prepare("SELECT * FROM outreach_thread_projections WHERE tenant_id = ?")
       .all(fixture.tenantId) as Array<Record<string, unknown>>;
@@ -136,5 +144,33 @@ describe("outreach_thread_projections cross-runtime parity", () => {
     for (const secret of fixture.sensitiveValues) {
       expect(serialized).not.toContain(secret);
     }
+  });
+
+  it("keeps the same canonical JobId isolated by tenant", () => {
+    const db = seededDb();
+    const jobId = String(fixture.threads[0]!.jobId);
+    db.prepare(`INSERT INTO jobs (tenant_id, job_id, url) VALUES (?, ?, ?)`).run(
+      "other",
+      jobId,
+      `https://example.test/jobs/${jobId}`,
+    );
+    db.prepare(
+      `INSERT INTO outreach_threads (
+         tenant_id, thread_id, contact_id, job_id, created_at, updated_at
+       ) VALUES (?, ?, ?, ?, ?, ?)`,
+    ).run("other", "thread-a", "contact-other", jobId, "2026-07-07T00:00:00Z", "2026-07-07T00:00:00Z");
+
+    refreshOutreachProjections(db, fixture.tenantId);
+    refreshOutreachProjections(db, "other");
+
+    expect(
+      db
+        .prepare("SELECT tenant_id, contact_id, job_id FROM outreach_thread_projections ORDER BY tenant_id, thread_id")
+        .all(),
+    ).toEqual([
+      { tenant_id: "local", contact_id: "contact-a", job_id: jobId },
+      { tenant_id: "local", contact_id: "contact-b", job_id: null },
+      { tenant_id: "other", contact_id: "contact-other", job_id: jobId },
+    ]);
   });
 });

--- a/apps/api/test/outreach.test.ts
+++ b/apps/api/test/outreach.test.ts
@@ -16,12 +16,13 @@ import Database from "better-sqlite3";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { OutreachDraftGateResults, OutreachThreadDetail } from "../src/contracts.js";
-import { ensureOutreachTables } from "../src/outreach.js";
 import type { OutreachDraftGenerator } from "../src/local-actions.js";
 import { buildApp } from "../src/server.js";
+import { initializeExactV7Database } from "./v7-schema.js";
 
 const SECRET_BODY = "Hi Dana, I boosted revenue 40% and would love to connect.";
 const SECRET_RATIONALE = "Grounded in the confirmed employer attribute.";
+const JOB_ID = "00000000-0000-4000-8000-000000000003";
 
 const PASSING_GATE: OutreachDraftGateResults = {
   passed: true,
@@ -51,34 +52,7 @@ afterEach(() => {
 function withTempApp(generator?: OutreachDraftGenerator) {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "jobctrl-api-outreach-"));
   const dbPath = path.join(dir, "jobs.db");
-  const db = new Database(dbPath);
-  db.exec(`
-    CREATE TABLE jobs (url TEXT PRIMARY KEY, title TEXT);
-    CREATE TABLE job_events (
-      event_id     INTEGER PRIMARY KEY AUTOINCREMENT,
-      job_url      TEXT,
-      stage        TEXT,
-      event_type   TEXT NOT NULL,
-      level        TEXT NOT NULL DEFAULT 'info',
-      message      TEXT,
-      occurred_at  TEXT NOT NULL,
-      payload_json TEXT,
-      entity_kind  TEXT,
-      entity_ref   TEXT
-    );
-    CREATE TABLE application_outcomes (
-      tenant_id     TEXT NOT NULL DEFAULT 'local',
-      outcome_id    TEXT NOT NULL,
-      job_key       TEXT NOT NULL,
-      kind          TEXT NOT NULL,
-      source        TEXT NOT NULL,
-      occurred_at   TEXT NOT NULL,
-      recorded_at   TEXT NOT NULL,
-      PRIMARY KEY (tenant_id, outcome_id)
-    );
-  `);
-  ensureOutreachTables(db);
-  db.close();
+  initializeExactV7Database(dbPath);
   const app = buildApp({
     dbPath,
     configPath: path.join(dir, "config.json"),
@@ -91,13 +65,18 @@ function withTempApp(generator?: OutreachDraftGenerator) {
 
 function seedThread(
   dbPath: string,
-  input: { threadId: string; contactId: string; jobUrl: string | null },
+  input: { threadId: string; contactId: string; jobId: string | null },
 ): void {
   const db = new Database(dbPath);
+  if (input.jobId) {
+    db.prepare(
+      `INSERT OR IGNORE INTO jobs (tenant_id, job_id, url) VALUES ('local', ?, ?)`,
+    ).run(input.jobId, `https://posting.example/${input.jobId}`);
+  }
   db.prepare(
-    `INSERT INTO outreach_threads (tenant_id, thread_id, contact_id, job_url, created_at, updated_at)
+    `INSERT INTO outreach_threads (tenant_id, thread_id, contact_id, job_id, created_at, updated_at)
      VALUES ('local', ?, ?, ?, ?, ?)`,
-  ).run(input.threadId, input.contactId, input.jobUrl, "2026-07-06T00:00:00Z", "2026-07-06T00:00:00Z");
+  ).run(input.threadId, input.contactId, input.jobId, "2026-07-06T00:00:00Z", "2026-07-06T00:00:00Z");
   db.close();
 }
 
@@ -136,13 +115,13 @@ function seedDraft(
   db.close();
 }
 
-function seedSubmittedOutcome(dbPath: string, jobKey: string, occurredAt: string): void {
+function seedSubmittedOutcome(dbPath: string, jobId: string, occurredAt: string): void {
   const db = new Database(dbPath);
   db.prepare(
     `INSERT INTO application_outcomes (
-     tenant_id, outcome_id, job_key, kind, source, occurred_at, recorded_at
+     tenant_id, outcome_id, job_id, kind, source, occurred_at, recorded_at
      ) VALUES ('local', ?, ?, 'applied_confirmation', 'manual', ?, ?)`,
-  ).run(`outcome-${jobKey}`, jobKey, occurredAt, "2026-07-06T00:00:00Z");
+  ).run(`outcome-${jobId}`, jobId, occurredAt, "2026-07-06T00:00:00Z");
   db.close();
 }
 
@@ -194,7 +173,7 @@ describe("outreach API", () => {
 
   it("maps gateResults + provenance + body from canonical rows on read", async () => {
     const { app, dbPath } = withTempApp();
-    seedThread(dbPath, { threadId: "thread-r", contactId: "contact-r", jobUrl: "https://job/9" });
+    seedThread(dbPath, { threadId: "thread-r", contactId: "contact-r", jobId: JOB_ID });
     seedDraft(dbPath, {
       draftId: "draft-r1",
       threadId: "thread-r",
@@ -214,7 +193,7 @@ describe("outreach API", () => {
 
     const res = await app.inject({
       method: "GET",
-      url: "/v1/contacts/contact-r/outreach?jobId=https%3A%2F%2Fjob%2F9",
+      url: `/v1/contacts/contact-r/outreach?jobId=${JOB_ID}`,
     });
     expect(res.statusCode).toBe(200);
     const thread = (res.json() as ThreadResponse).thread!;
@@ -232,7 +211,7 @@ describe("outreach API", () => {
 
   it("BLOCKS approval with 409/draft_gates_not_passed when the persisted gate did not pass (INV-5)", async () => {
     const { app, dbPath } = withTempApp();
-    seedThread(dbPath, { threadId: "thread-g", contactId: "contact-g", jobUrl: null });
+    seedThread(dbPath, { threadId: "thread-g", contactId: "contact-g", jobId: null });
     seedDraft(dbPath, { draftId: "draft-g1", threadId: "thread-g", generation: 1, gate: FAILING_GATE });
 
     const res = await app.inject({
@@ -251,7 +230,7 @@ describe("outreach API", () => {
 
   it("approves a gate-passing candidate and supersedes the prior approved generation", async () => {
     const { app, dbPath } = withTempApp();
-    seedThread(dbPath, { threadId: "thread-a", contactId: "contact-a", jobUrl: "https://job/1" });
+    seedThread(dbPath, { threadId: "thread-a", contactId: "contact-a", jobId: JOB_ID });
     seedDraft(dbPath, {
       draftId: "draft-a1",
       threadId: "thread-a",
@@ -278,7 +257,7 @@ describe("outreach API", () => {
 
   it("rejects a candidate but never touches an approved draft (INV-5)", async () => {
     const { app, dbPath } = withTempApp();
-    seedThread(dbPath, { threadId: "thread-j", contactId: "contact-j", jobUrl: null });
+    seedThread(dbPath, { threadId: "thread-j", contactId: "contact-j", jobId: null });
     seedDraft(dbPath, {
       draftId: "draft-j1",
       threadId: "thread-j",
@@ -327,7 +306,7 @@ describe("outreach API", () => {
 
   it("returns 404 approving a draft that does not exist", async () => {
     const { app, dbPath } = withTempApp();
-    seedThread(dbPath, { threadId: "thread-n", contactId: "contact-n", jobUrl: null });
+    seedThread(dbPath, { threadId: "thread-n", contactId: "contact-n", jobId: null });
     const res = await app.inject({
       method: "POST",
       url: "/v1/outreach/threads/thread-n/drafts/missing/approve",
@@ -338,7 +317,7 @@ describe("outreach API", () => {
 
   it("reflects the thread lifecycle in the outreach_thread_projections row without leaking bodies", async () => {
     const { app, dbPath } = withTempApp();
-    seedThread(dbPath, { threadId: "thread-p", contactId: "contact-p", jobUrl: "https://job/2" });
+    seedThread(dbPath, { threadId: "thread-p", contactId: "contact-p", jobId: JOB_ID });
     seedDraft(dbPath, {
       draftId: "draft-p1",
       threadId: "thread-p",
@@ -372,8 +351,13 @@ describe("outreach API", () => {
     const generator = vi.fn<OutreachDraftGenerator>(async (input, _context) => {
       // Simulate the worker (a separate process) persisting a gated candidate draft.
       const db = new Database(dbPathRef.current);
+      if (input.jobId) {
+        db.prepare(
+          `INSERT INTO jobs (tenant_id, job_id, url) VALUES ('local', ?, ?)`,
+        ).run(input.jobId, `https://posting.example/${input.jobId}`);
+      }
       db.prepare(
-        `INSERT INTO outreach_threads (tenant_id, thread_id, contact_id, job_url, created_at, updated_at)
+        `INSERT INTO outreach_threads (tenant_id, thread_id, contact_id, job_id, created_at, updated_at)
          VALUES ('local', ?, ?, ?, ?, ?)
          ON CONFLICT(tenant_id, thread_id) DO NOTHING`,
       ).run(input.threadId, input.contactId ?? "", input.jobId ?? null, "2026-07-06T02:00:00Z", "2026-07-06T02:00:00Z");
@@ -401,7 +385,7 @@ describe("outreach API", () => {
     const res = await app.inject({
       method: "POST",
       url: "/v1/contacts/contact-gen/outreach/drafts",
-      payload: { jobId: "https://job/3", kind: "intro_request" },
+      payload: { jobId: JOB_ID, kind: "intro_request" },
     });
     expect(res.statusCode).toBe(200);
     const thread = (res.json() as ThreadResponse).thread!;
@@ -410,8 +394,26 @@ describe("outreach API", () => {
     expect(generator).toHaveBeenCalledTimes(1);
     const input = generator.mock.calls[0]![0];
     expect(input.contactId).toBe("contact-gen");
-    expect(input.jobId).toBe("https://job/3");
+    expect(input.jobId).toBe(JOB_ID);
     expect(input.threadId).toBeTruthy();
+  });
+
+  it("rejects a URL-shaped outreach JobId before the worker, writes, or events", async () => {
+    const generator = vi.fn<OutreachDraftGenerator>();
+    const { app, dbPath } = withTempApp(generator);
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/v1/contacts/contact-invalid/outreach/drafts",
+      payload: { jobId: "https://jobs.example/invalid" },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(generator).not.toHaveBeenCalled();
+    const db = new Database(dbPath);
+    expect(db.prepare("SELECT COUNT(*) AS count FROM outreach_threads").get()).toEqual({ count: 0 });
+    expect(db.prepare("SELECT COUNT(*) AS count FROM job_events").get()).toEqual({ count: 0 });
+    db.close();
   });
 
   it("revises an existing thread through the injected generator with the edited body", async () => {
@@ -441,7 +443,7 @@ describe("outreach API", () => {
     });
     const { app, dbPath } = withTempApp(generator);
     dbPathRef.current = dbPath;
-    seedThread(dbPath, { threadId: "thread-e", contactId: "contact-e", jobUrl: null });
+    seedThread(dbPath, { threadId: "thread-e", contactId: "contact-e", jobId: null });
     seedDraft(dbPath, { draftId: "draft-e1", threadId: "thread-e", generation: 1, gate: PASSING_GATE });
 
     const res = await app.inject({
@@ -459,7 +461,7 @@ describe("outreach API", () => {
 
   it("exposes no send transport on any outreach route (INV-1)", async () => {
     const { app, dbPath } = withTempApp();
-    seedThread(dbPath, { threadId: "thread-s", contactId: "contact-s", jobUrl: null });
+    seedThread(dbPath, { threadId: "thread-s", contactId: "contact-s", jobId: null });
     seedDraft(dbPath, { draftId: "draft-s1", threadId: "thread-s", generation: 1, gate: PASSING_GATE });
     const res = await app.inject({
       method: "POST",
@@ -472,7 +474,7 @@ describe("outreach API", () => {
 
   it("records a user-attested send over an approved draft and marks the thread sent (INV-1)", async () => {
     const { app, dbPath } = withTempApp();
-    seedThread(dbPath, { threadId: "thread-send", contactId: "contact-send", jobUrl: "https://job/7" });
+    seedThread(dbPath, { threadId: "thread-send", contactId: "contact-send", jobId: JOB_ID });
     seedDraft(dbPath, {
       draftId: "draft-send",
       threadId: "thread-send",
@@ -507,7 +509,7 @@ describe("outreach API", () => {
 
   it("rejects address-shaped send channels before they can enter logs or events", async () => {
     const { app, dbPath } = withTempApp();
-    seedThread(dbPath, { threadId: "thread-channel", contactId: "contact-channel", jobUrl: null });
+    seedThread(dbPath, { threadId: "thread-channel", contactId: "contact-channel", jobId: null });
     seedDraft(dbPath, {
       draftId: "draft-channel",
       threadId: "thread-channel",
@@ -533,7 +535,7 @@ describe("outreach API", () => {
 
   it("refuses to log a send over a non-approved draft and leaves the thread unsent (INV-1)", async () => {
     const { app, dbPath } = withTempApp();
-    seedThread(dbPath, { threadId: "thread-c", contactId: "contact-c", jobUrl: null });
+    seedThread(dbPath, { threadId: "thread-c", contactId: "contact-c", jobId: null });
     seedDraft(dbPath, { draftId: "draft-c1", threadId: "thread-c", generation: 1, gate: PASSING_GATE });
 
     const res = await app.inject({
@@ -550,9 +552,9 @@ describe("outreach API", () => {
 
   it("schedules a follow-up from the canonical application outcome, then completes it", async () => {
     const { app, dbPath } = withTempApp();
-    seedThread(dbPath, { threadId: "thread-f", contactId: "contact-f", jobUrl: "https://job/8" });
+    seedThread(dbPath, { threadId: "thread-f", contactId: "contact-f", jobId: JOB_ID });
     seedDraft(dbPath, { draftId: "draft-f1", threadId: "thread-f", generation: 1, gate: PASSING_GATE });
-    seedSubmittedOutcome(dbPath, "https://job/8", "2026-07-01T00:00:00+00:00");
+    seedSubmittedOutcome(dbPath, JOB_ID, "2026-07-01T00:00:00+00:00");
 
     const scheduled = await app.inject({
       method: "POST",
@@ -577,9 +579,9 @@ describe("outreach API", () => {
 
   it("surfaces only arrived follow-ups in the due-follow-ups read model", async () => {
     const { app, dbPath } = withTempApp();
-    seedThread(dbPath, { threadId: "thread-due", contactId: "contact-due", jobUrl: "https://job/due" });
+    seedThread(dbPath, { threadId: "thread-due", contactId: "contact-due", jobId: JOB_ID });
     seedDraft(dbPath, { draftId: "d-due", threadId: "thread-due", generation: 1, gate: PASSING_GATE });
-    seedThread(dbPath, { threadId: "thread-upcoming", contactId: "contact-up", jobUrl: null });
+    seedThread(dbPath, { threadId: "thread-upcoming", contactId: "contact-up", jobId: null });
     seedDraft(dbPath, { draftId: "d-up", threadId: "thread-upcoming", generation: 1, gate: PASSING_GATE });
 
     await app.inject({
@@ -602,7 +604,7 @@ describe("outreach API", () => {
 
   it("dismisses a scheduled follow-up and drops it from the due list", async () => {
     const { app, dbPath } = withTempApp();
-    seedThread(dbPath, { threadId: "thread-dis", contactId: "contact-dis", jobUrl: null });
+    seedThread(dbPath, { threadId: "thread-dis", contactId: "contact-dis", jobId: null });
     seedDraft(dbPath, { draftId: "d-dis", threadId: "thread-dis", generation: 1, gate: PASSING_GATE });
     await app.inject({
       method: "POST",
@@ -624,7 +626,7 @@ describe("outreach API", () => {
 
   it("cannot complete or dismiss a follow-up that was never scheduled", async () => {
     const { app, dbPath } = withTempApp();
-    seedThread(dbPath, { threadId: "thread-ns", contactId: "contact-ns", jobUrl: null });
+    seedThread(dbPath, { threadId: "thread-ns", contactId: "contact-ns", jobId: null });
     const res = await app.inject({
       method: "POST",
       url: "/v1/outreach/threads/thread-ns/follow-up/complete",

--- a/packages/contracts/src/schemas.ts
+++ b/packages/contracts/src/schemas.ts
@@ -5477,6 +5477,14 @@ export type ContactAttributeInput = z.infer<typeof ContactAttributeInputSchema>;
 
 const contactEmployerField = z.string().trim().min(1).max(200).nullish();
 const contactJobIdField = z.string().trim().min(1).max(2000).nullish();
+const outreachJobIdField = z
+  .string()
+  .trim()
+  .uuid()
+  .refine((value) => value === value.toLowerCase(), {
+    message: "jobId must be a canonical UUID",
+  })
+  .nullish();
 
 export const ContactCreateRequestSchema = z
   .object({
@@ -5804,7 +5812,7 @@ export interface OutreachThreadDetail extends OutreachThreadSummary {
 
 export const GenerateOutreachDraftRequestSchema = z
   .object({
-    jobId: contactJobIdField,
+    jobId: outreachJobIdField,
     kind: OutreachDraftKindSchema.optional(),
     applicationRole: z.string().trim().max(200).optional(),
     llmModel: z.string().trim().min(1).max(120).optional(),
@@ -5832,7 +5840,7 @@ export type RejectOutreachDraftRequest = z.infer<typeof RejectOutreachDraftReque
 export const OutreachThreadQuerySchema = z
   .object({
     contactId: optionalText,
-    jobId: optionalText,
+    jobId: outreachJobIdField,
   })
   .strict();
 export type OutreachThreadQuery = z.infer<typeof OutreachThreadQuerySchema>;

--- a/packages/domain-types/test/fixtures/due_follow_up_projection_parity.json
+++ b/packages/domain-types/test/fixtures/due_follow_up_projection_parity.json
@@ -4,7 +4,7 @@
     {
       "threadId": "thread-due",
       "contactId": "contact-1",
-      "jobUrl": "https://example.com/job/1",
+      "jobId": "00000000-0000-4000-8000-000000000002",
       "createdAt": "2026-07-01T00:00:00+00:00",
       "updatedAt": "2026-07-02T00:00:00+00:00",
       "followUpDueAt": "2026-07-09T00:00:00+00:00",
@@ -14,7 +14,7 @@
     {
       "threadId": "thread-completed",
       "contactId": "contact-2",
-      "jobUrl": null,
+      "jobId": null,
       "createdAt": "2026-07-01T00:00:00+00:00",
       "updatedAt": "2026-07-03T00:00:00+00:00",
       "followUpDueAt": "2026-07-05T00:00:00+00:00",
@@ -24,7 +24,7 @@
     {
       "threadId": "thread-none",
       "contactId": "contact-3",
-      "jobUrl": null,
+      "jobId": null,
       "createdAt": "2026-07-01T00:00:00+00:00",
       "updatedAt": "2026-07-01T00:00:00+00:00",
       "followUpDueAt": null,
@@ -36,7 +36,7 @@
     {
       "threadId": "thread-due",
       "contactId": "contact-1",
-      "jobId": "https://example.com/job/1",
+      "jobId": "00000000-0000-4000-8000-000000000002",
       "dueAt": "2026-07-09T00:00:00+00:00",
       "basis": "application_submitted",
       "state": "scheduled",

--- a/packages/domain-types/test/fixtures/outreach_thread_projection_parity.json
+++ b/packages/domain-types/test/fixtures/outreach_thread_projection_parity.json
@@ -4,14 +4,14 @@
     {
       "threadId": "thread-a",
       "contactId": "contact-a",
-      "jobUrl": "https://job/1",
+      "jobId": "00000000-0000-4000-8000-000000000001",
       "createdAt": "2026-07-06T00:00:00Z",
       "updatedAt": "2026-07-06T00:00:02Z"
     },
     {
       "threadId": "thread-b",
       "contactId": "contact-b",
-      "jobUrl": null,
+      "jobId": null,
       "createdAt": "2026-07-06T01:00:00Z",
       "updatedAt": "2026-07-06T01:05:00Z"
     }
@@ -112,7 +112,7 @@
     {
       "threadId": "thread-a",
       "contactId": "contact-a",
-      "jobId": "https://job/1",
+      "jobId": "00000000-0000-4000-8000-000000000001",
       "draftCount": 1,
       "latestGeneration": 1,
       "hasApprovedDraft": false,

--- a/workers/automation/tests/test_due_follow_up_projection_parity.py
+++ b/workers/automation/tests/test_due_follow_up_projection_parity.py
@@ -34,10 +34,16 @@ _FIXTURE = (
 def _seed_canonical(conn: sqlite3.Connection, fixture: dict[str, Any]) -> None:
     tenant = fixture["tenantId"]
     for thread in fixture["threads"]:
+        job_id = thread["jobId"]
+        if job_id is not None:
+            conn.execute(
+                "INSERT INTO jobs (tenant_id, job_id, url) VALUES (?, ?, ?)",
+                (tenant, job_id, f"https://example.test/jobs/{job_id}"),
+            )
         conn.execute(
             """
             INSERT INTO outreach_threads (
-                tenant_id, thread_id, contact_id, job_url, created_at, updated_at,
+                tenant_id, thread_id, contact_id, job_id, created_at, updated_at,
                 follow_up_due_at, follow_up_basis, follow_up_state
             ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
@@ -45,7 +51,7 @@ def _seed_canonical(conn: sqlite3.Connection, fixture: dict[str, Any]) -> None:
                 tenant,
                 thread["threadId"],
                 thread["contactId"],
-                thread["jobUrl"],
+                job_id,
                 thread["createdAt"],
                 thread["updatedAt"],
                 thread["followUpDueAt"],

--- a/workers/automation/tests/test_outreach_projection_parity.py
+++ b/workers/automation/tests/test_outreach_projection_parity.py
@@ -32,17 +32,23 @@ _FIXTURE = (
 def _seed_canonical(conn: sqlite3.Connection, fixture: dict[str, Any]) -> None:
     tenant = fixture["tenantId"]
     for thread in fixture["threads"]:
+        job_id = thread["jobId"]
+        if job_id is not None:
+            conn.execute(
+                "INSERT INTO jobs (tenant_id, job_id, url) VALUES (?, ?, ?)",
+                (tenant, job_id, f"https://example.test/jobs/{job_id}"),
+            )
         conn.execute(
             """
             INSERT INTO outreach_threads (
-                tenant_id, thread_id, contact_id, job_url, created_at, updated_at
+                tenant_id, thread_id, contact_id, job_id, created_at, updated_at
             ) VALUES (?, ?, ?, ?, ?, ?)
             """,
             (
                 tenant,
                 thread["threadId"],
                 thread["contactId"],
-                thread["jobUrl"],
+                job_id,
                 thread["createdAt"],
                 thread["updatedAt"],
             ),


### PR DESCRIPTION
## Summary

-

## Validation

-

## Checklist

- [ ] External contributor commits include a DCO `Signed-off-by:` trailer (`git commit -s`).
- [ ] I ran the relevant local checks and listed them above. Heavy CI runs automatically for ordinary same-repository pull requests and cumulative stack heads, but not public forks; maintainers run manual workflows or local validation for fork contributions after review.
- [ ] I did not include secrets, private profile data, resumes, generated application materials, raw logs, browser profiles, SQLite databases, or local paths.