### PR TITLE
refactor(contacts): use exact v7 job ids

### DIFF
--- a/apps/api/src/contacts.ts
+++ b/apps/api/src/contacts.ts
@@ -33,11 +33,12 @@ import type {
   ContactUpdateRequest,
 } from "./contracts.js";
 import { CONTACT_ROLES } from "@jobctrl/domain-types";
-import { allRows, getRow, tableExists, type SqliteDatabase, type SqliteValue } from "./db.js";
-import { refreshProjections } from "./projections.js";
+import { allRows, getRow, type SqliteDatabase, type SqliteValue } from "./db.js";
+import { refreshContactProjections } from "./projections.js";
 
 const TENANT_ID = "local";
 const USER_ENTERED_REF = "user_entered";
+const CANONICAL_JOB_ID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
 
 export class ContactInputError extends Error {}
 export class ContactNotFoundError extends Error {}
@@ -56,38 +57,12 @@ interface AttributeSeed {
   value: string;
 }
 
-export function ensureContactTables(db: SqliteDatabase): void {
-  db.exec(`
-    CREATE TABLE IF NOT EXISTS contacts (
-      tenant_id   TEXT NOT NULL DEFAULT 'local',
-      contact_id  TEXT NOT NULL,
-      employer    TEXT,
-      job_url     TEXT,
-      role        TEXT NOT NULL DEFAULT 'other',
-      created_at  TEXT NOT NULL,
-      updated_at  TEXT NOT NULL,
-      deleted_at  TEXT,
-      PRIMARY KEY (tenant_id, contact_id)
-    );
-    CREATE TABLE IF NOT EXISTS contact_attributes (
-      tenant_id      TEXT NOT NULL DEFAULT 'local',
-      attribute_id   TEXT NOT NULL,
-      contact_id     TEXT NOT NULL,
-      attribute_kind TEXT NOT NULL,
-      value_json     TEXT,
-      source_kind    TEXT NOT NULL,
-      source_ref     TEXT NOT NULL,
-      capture_method TEXT NOT NULL,
-      confidence     REAL NOT NULL DEFAULT 0,
-      user_confirmed INTEGER NOT NULL DEFAULT 0,
-      recorded_at    TEXT NOT NULL,
-      PRIMARY KEY (tenant_id, attribute_id)
-    );
-    CREATE INDEX IF NOT EXISTS idx_contacts_lookup ON contacts(tenant_id, employer, job_url);
-    CREATE INDEX IF NOT EXISTS idx_contact_attributes_contact
-      ON contact_attributes(tenant_id, contact_id);
-  `);
-}
+/**
+ * Retained as an exact-v7 no-op for the deferred contact-research module.
+ * The stopped-runtime migration owns table creation and API admission verifies
+ * the complete v7 manifest before this module is called.
+ */
+export function ensureContactTables(_db: SqliteDatabase): void {}
 
 // ---------------------------------------------------------------------------
 // Reads
@@ -97,8 +72,7 @@ export function listContacts(
   db: SqliteDatabase,
   query: ContactListQuery = { jobId: "", employer: "" },
 ): ContactSummary[] {
-  ensureContactTables(db);
-  refreshProjections(db, TENANT_ID);
+  refreshContactProjections(db, TENANT_ID);
   const filters: string[] = ["tenant_id = ?"];
   const params: SqliteValue[] = [TENANT_ID];
   const jobId = (query.jobId ?? "").trim();
@@ -121,8 +95,7 @@ export function listContacts(
 }
 
 export function getContactDetail(db: SqliteDatabase, contactId: string): ContactDetail | null {
-  ensureContactTables(db);
-  refreshProjections(db, TENANT_ID);
+  refreshContactProjections(db, TENANT_ID);
   const row = getRow<ContactProjectionRow>(
     db,
     "SELECT * FROM contact_projections WHERE tenant_id = ? AND contact_id = ?",
@@ -157,9 +130,8 @@ function requireContactDetail(db: SqliteDatabase, contactId: string): ContactDet
 // ---------------------------------------------------------------------------
 
 export function createContact(db: SqliteDatabase, request: ContactCreateRequest): ContactDetail {
-  ensureContactTables(db);
   const employer = normalizeLink(request.employer);
-  const jobId = normalizeLink(request.jobId);
+  const jobId = canonicalJobId(request.jobId);
   if (!employer && !jobId) {
     throw new ContactInputError("A contact must link to at least one of employer or jobId.");
   }
@@ -177,7 +149,7 @@ export function createContact(db: SqliteDatabase, request: ContactCreateRequest)
     insertContactRow(db, { contactId, employer, jobId, role: request.role, createdAt: now, updatedAt: now });
     insertAttributes(db, contactId, attributes, provenance, now);
     recordContactEvent(db, {
-      jobUrl: jobId,
+      jobId,
       eventType: "ContactCreated",
       contactId,
       payload: {
@@ -202,7 +174,6 @@ export function updateContact(
   contactId: string,
   request: ContactUpdateRequest,
 ): ContactDetail {
-  ensureContactTables(db);
   const existing = getRow<ContactRow>(
     db,
     "SELECT * FROM contacts WHERE tenant_id = ? AND contact_id = ? AND deleted_at IS NULL",
@@ -213,7 +184,7 @@ export function updateContact(
   }
   const employer =
     request.employer !== undefined ? normalizeLink(request.employer) : existing.employer ?? null;
-  const jobId = request.jobId !== undefined ? normalizeLink(request.jobId) : existing.job_url ?? null;
+  const jobId = request.jobId !== undefined ? canonicalJobId(request.jobId) : existing.job_id ?? null;
   if (!employer && !jobId) {
     throw new ContactInputError("A contact must link to at least one of employer or jobId.");
   }
@@ -235,7 +206,7 @@ export function updateContact(
     request.attributes !== undefined ? seedAttributes(request.attributes) : null;
   const transaction = db.transaction(() => {
     db.prepare(
-      `UPDATE contacts SET employer = ?, job_url = ?, role = ?, updated_at = ?
+      `UPDATE contacts SET employer = ?, job_id = ?, role = ?, updated_at = ?
        WHERE tenant_id = ? AND contact_id = ?`,
     ).run(employer, jobId, role, now, TENANT_ID, contactId);
     if (nextAttributes !== null) {
@@ -279,7 +250,7 @@ export function updateContact(
       insertAttributeRows(db, contactId, rows);
     }
     recordContactEvent(db, {
-      jobUrl: jobId,
+      jobId,
       eventType: "ContactUpdated",
       contactId,
       payload: { tenantId: TENANT_ID, contactId, changedFields: changed, updatedAt: now },
@@ -301,7 +272,6 @@ export function deleteContact(
   contactId: string,
   reason = "",
 ): ContactDeleteResponse {
-  ensureContactTables(db);
   const deletedAt = new Date().toISOString();
   const result = db
     .prepare(
@@ -313,12 +283,12 @@ export function deleteContact(
     throw new ContactNotFoundError(`Contact ${contactId} not found`);
   }
   recordContactEvent(db, {
-    jobUrl: null,
+    jobId: null,
     eventType: "ContactDeleted",
     contactId,
     payload: { tenantId: TENANT_ID, contactId, reason, deletedAt },
   });
-  refreshProjections(db, TENANT_ID);
+  refreshContactProjections(db, TENANT_ID);
   return { ok: true, contactId, deletedAt };
 }
 
@@ -326,7 +296,6 @@ export function importContacts(
   db: SqliteDatabase,
   request: ContactImportRequest,
 ): ContactImportResponse {
-  ensureContactTables(db);
   const filename = request.filename.trim() || "import.csv";
   const now = new Date().toISOString();
   const provenance: ProvenanceSeed = {
@@ -343,7 +312,7 @@ export function importContacts(
   const transaction = db.transaction(() => {
     for (const row of rows) {
       const employer = normalizeLink(firstColumn(row, EMPLOYER_COLUMNS));
-      const jobId = normalizeLink(firstColumn(row, JOB_COLUMNS));
+      const jobId = canonicalJobId(firstColumn(row, JOB_COLUMNS));
       if (!employer && !jobId) {
         skipped += 1;
         continue;
@@ -354,7 +323,7 @@ export function importContacts(
       insertContactRow(db, { contactId, employer, jobId, role, createdAt: now, updatedAt: now });
       insertAttributes(db, contactId, attributes, provenance, now);
       recordContactEvent(db, {
-        jobUrl: jobId,
+        jobId,
         eventType: "ContactCreated",
         contactId,
         payload: { tenantId: TENANT_ID, contactId, employer, jobId, role, createdAt: now },
@@ -367,7 +336,7 @@ export function importContacts(
     }
   });
   transaction();
-  refreshProjections(db, TENANT_ID);
+  refreshContactProjections(db, TENANT_ID);
   return { ok: true, imported, skipped, contactIds };
 }
 
@@ -378,7 +347,7 @@ export function importContacts(
 type ContactRow = {
   contact_id: string;
   employer: string | null;
-  job_url: string | null;
+  job_id: string | null;
   role: string | null;
   created_at: string | null;
   updated_at: string | null;
@@ -422,7 +391,7 @@ const ATTRIBUTE_COLUMNS: Record<string, string> = {
   notes: "note",
 };
 const EMPLOYER_COLUMNS = ["employer", "company"] as const;
-const JOB_COLUMNS = ["job_id", "jobid", "job_url", "joburl"] as const;
+const JOB_COLUMNS = ["job_id", "jobid"] as const;
 
 function toSummary(db: SqliteDatabase, row: ContactProjectionRow): ContactSummary {
   const attributeCount = Number(row.attribute_count ?? 0);
@@ -494,7 +463,7 @@ function insertContactRow(
   },
 ): void {
   db.prepare(
-    `INSERT INTO contacts (tenant_id, contact_id, employer, job_url, role, created_at, updated_at, deleted_at)
+    `INSERT INTO contacts (tenant_id, contact_id, employer, job_id, role, created_at, updated_at, deleted_at)
      VALUES (?, ?, ?, ?, ?, ?, ?, NULL)`,
   ).run(TENANT_ID, input.contactId, input.employer, input.jobId, input.role, input.createdAt, input.updatedAt);
 }
@@ -554,13 +523,13 @@ function insertAttributes(
 function recordAttributeEvent(
   db: SqliteDatabase,
   contactId: string,
-  jobUrl: string | null,
+  jobId: string | null,
   attribute: AttributeSeed,
   provenance: ProvenanceSeed,
   recordedAt: string,
 ): void {
   recordContactEvent(db, {
-    jobUrl,
+    jobId,
     eventType: "ContactAttributeRecorded",
     contactId,
     payload: {
@@ -581,34 +550,25 @@ function recordAttributeEvent(
 function recordContactEvent(
   db: SqliteDatabase,
   event: {
-    jobUrl: string | null;
+    jobId: string | null;
     eventType: string;
     contactId: string;
     payload: Record<string, unknown>;
   },
 ): void {
-  if (!tableExists(db, "job_events")) {
-    return;
-  }
-  const columns = new Set(
-    allRows<{ name: string }>(db, "PRAGMA table_info(job_events)").map((row) => row.name),
-  );
-  const values: Record<string, SqliteValue> = {
-    job_url: event.jobUrl,
-    stage: null,
-    event_type: event.eventType,
-    level: "info",
-    occurred_at: new Date().toISOString(),
-    payload_json: JSON.stringify(event.payload),
-    entity_kind: "contact",
-    entity_ref: event.contactId,
-  };
-  const entries = Object.entries(values).filter(([name]) => columns.has(name));
   db.prepare(
-    `INSERT INTO job_events (${entries.map(([name]) => name).join(", ")}) VALUES (${entries
-      .map(() => "?")
-      .join(", ")})`,
-  ).run(...entries.map(([, value]) => value));
+    `INSERT INTO job_events (
+       tenant_id, job_id, identity_version, stage, event_type, level,
+       message, occurred_at, payload_json, entity_kind, entity_ref, idempotency_key
+     ) VALUES (?, ?, 1, NULL, ?, 'info', NULL, ?, ?, 'contact', ?, NULL)`,
+  ).run(
+    TENANT_ID,
+    event.jobId,
+    event.eventType,
+    new Date().toISOString(),
+    JSON.stringify(event.payload),
+    event.contactId,
+  );
 }
 
 function seedAttributes(inputs: ContactAttributeInput[]): AttributeSeed[] {
@@ -646,7 +606,7 @@ function changedFields(
   if ((existing.employer ?? null) !== next.employer) {
     changed.push("employer");
   }
-  if ((existing.job_url ?? null) !== next.jobId) {
+  if ((existing.job_id ?? null) !== next.jobId) {
     changed.push("jobId");
   }
   if (attributesReplaced) {
@@ -668,6 +628,17 @@ function firstColumn(row: Record<string, string>, columns: readonly string[]): s
 function normalizeLink(value: string | null | undefined): string | null {
   const trimmed = (value ?? "").trim();
   return trimmed.length > 0 ? trimmed : null;
+}
+
+function canonicalJobId(value: string | null | undefined): string | null {
+  const trimmed = (value ?? "").trim();
+  if (!trimmed) {
+    return null;
+  }
+  if (!CANONICAL_JOB_ID.test(trimmed)) {
+    throw new ContactInputError("jobId must be a canonical UUID");
+  }
+  return trimmed;
 }
 
 function normalizeRole(value: string | null | undefined): ContactRole {

--- a/apps/api/src/projections.ts
+++ b/apps/api/src/projections.ts
@@ -310,12 +310,11 @@ function setWatermark(db: SqliteDatabase, projection: string, eventId: number): 
   ).run(projection, eventId, new Date().toISOString());
 }
 
-/**
- * Refresh the projections from canonical state, advancing the
- * shared watermark.  Called at the top of every read-model query so
- * dashboards, lists, and detail views always reflect the latest
- * worker writes (which also bump ``job_events``).
- */
+/** Force-rebuild contact summaries from exact-v7 canonical contact rows. */
+export function refreshContactProjections(db: SqliteDatabase, tenantId = "local"): void {
+  rebuildContactProjections(db, tenantId);
+}
+
 /**
  * Force-rebuild the research-task read model from canonical rows. Confirming a
  * candidate that leaves other candidates awaiting review advances no research
@@ -617,6 +616,12 @@ function rebuildPipelineStepProjections(db: SqliteDatabase, tenantId: string): v
   replace();
 }
 
+/**
+ * Refresh the projections from canonical state, advancing the
+ * shared watermark.  Called at the top of every read-model query so
+ * dashboards, lists, and detail views always reflect the latest
+ * worker writes (which also bump ``job_events``).
+ */
 export function refreshProjections(db: SqliteDatabase, tenantId = "local"): void {
   const repairedDependencyJobs = reconcileDependencyBlockers(db, tenantId);
   const repairedCoverConflictJobs = reconcileObsoleteCoverGenerationConflicts(db, tenantId);
@@ -3672,9 +3677,6 @@ function contactsBackfillPending(db: SqliteDatabase, tenantId: string): boolean 
  * the Python ``ProjectionBuilder._rebuild_contacts`` for cross-runtime parity.
  */
 function rebuildContactProjections(db: SqliteDatabase, tenantId: string): void {
-  if (!tableExists(db, "contacts") || !tableExists(db, "contact_attributes")) {
-    return;
-  }
   const contacts = allRows<{
     contact_id: string;
     employer: string | null;

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -2562,12 +2562,17 @@ export function buildApp(options: BuildAppOptions): FastifyInstance {
 
   // Contact & Outreach (R6 Phase 1). Reads project provenance for every fact
   // (INV-2); writes never expose a send transport (INV-1).
-  app.get("/v1/contacts", async (request, reply) =>
-    withDb(reply, options.dbPath, (db) => ({
+  app.get("/v1/contacts", async (request, reply) => {
+    const query = ContactListQuerySchema.safeParse(request.query);
+    if (!query.success) {
+      void reply.code(400);
+      return { ok: false, error: "invalid_contact_query" };
+    }
+    return withDb(reply, options.dbPath, (db) => ({
       ok: true,
-      items: listContacts(db, ContactListQuerySchema.parse(request.query)),
-    })),
-  );
+      items: listContacts(db, query.data),
+    }));
+  });
 
   app.get<{ Params: { contactId: string } }>("/v1/contacts/:contactId", async (request, reply) =>
     withDb(reply, options.dbPath, (db) => {

--- a/apps/api/test/contact-projection-parity.test.ts
+++ b/apps/api/test/contact-projection-parity.test.ts
@@ -1,13 +1,7 @@
 /**
- * Cross-runtime parity for ``contact_projections`` (R6 Phase 1).
- *
- * The TS half of the TS<->Python drift guard. The Python half lives at
- * ``workers/automation/tests/test_contact_projection_parity.py``. Both load the
- * SAME shared fixture, seed the SAME canonical ``contacts`` /
- * ``contact_attributes`` rows, run their OWN projection refresh, and assert the
- * resulting ``contact_projections`` rows equal the fixture's ``expected`` block
- * (JSON columns compared parsed). It also asserts no attribute VALUE leaks into
- * the projection (sensitivity rule, plan §6).
+ * Cross-runtime exact-v7 parity for ``contact_projections``. The Python half
+ * reads the same fixture and lives at
+ * ``workers/automation/tests/test_contact_projection_parity.py``.
  */
 import fs from "node:fs";
 import os from "node:os";
@@ -16,19 +10,20 @@ import { fileURLToPath } from "node:url";
 import Database from "better-sqlite3";
 import { afterEach, describe, expect, it } from "vitest";
 
-import { ensureContactTables } from "../src/contacts.js";
-import { refreshProjections } from "../src/projections.js";
+import { refreshContactProjections } from "../src/projections.js";
+import { initializeExactV7Database } from "./v7-schema.js";
 
 const FIXTURE_PATH = fileURLToPath(
   new URL("../../../packages/domain-types/test/fixtures/contact_projection_parity.json", import.meta.url),
 );
 
-interface Fixture {
+interface TenantFixture {
   tenantId: string;
+  jobs: Array<{ jobId: string; url: string }>;
   contacts: Array<{
     contactId: string;
     employer: string | null;
-    jobUrl: string | null;
+    jobId: string | null;
     role: string;
     createdAt: string;
     updatedAt: string;
@@ -45,8 +40,12 @@ interface Fixture {
     userConfirmed: boolean;
     recordedAt: string;
   }>;
-  sensitiveValues: string[];
   expected: Array<Record<string, unknown>>;
+}
+
+interface Fixture {
+  tenants: TenantFixture[];
+  sensitiveValues: string[];
 }
 
 const fixture = JSON.parse(fs.readFileSync(FIXTURE_PATH, "utf8")) as Fixture;
@@ -60,47 +59,58 @@ afterEach(() => {
 
 function seededDb(): Database.Database {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "jobctrl-contact-parity-"));
-  const db = new Database(path.join(dir, "jobs.db"));
+  const dbPath = path.join(dir, "jobs.db");
+  initializeExactV7Database(dbPath);
+  const db = new Database(dbPath);
+  db.pragma("foreign_keys = ON");
   cleanups.push(() => {
     db.close();
     fs.rmSync(dir, { recursive: true, force: true });
   });
-  ensureContactTables(db);
+  const insertJob = db.prepare(
+    `INSERT INTO jobs (tenant_id, job_id, url, title, discovered_at)
+     VALUES (?, ?, ?, 'Fixture job', '2026-07-31T12:00:00Z')`,
+  );
   const insertContact = db.prepare(
-    `INSERT INTO contacts (tenant_id, contact_id, employer, job_url, role, created_at, updated_at, deleted_at)
+    `INSERT INTO contacts (tenant_id, contact_id, employer, job_id, role, created_at, updated_at, deleted_at)
      VALUES (?, ?, ?, ?, ?, ?, ?, NULL)`,
   );
-  for (const contact of fixture.contacts) {
-    insertContact.run(
-      fixture.tenantId,
-      contact.contactId,
-      contact.employer,
-      contact.jobUrl,
-      contact.role,
-      contact.createdAt,
-      contact.updatedAt,
-    );
-  }
   const insertAttribute = db.prepare(
     `INSERT INTO contact_attributes (
        tenant_id, attribute_id, contact_id, attribute_kind, value_json,
        source_kind, source_ref, capture_method, confidence, user_confirmed, recorded_at
      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   );
-  for (const attribute of fixture.attributes) {
-    insertAttribute.run(
-      fixture.tenantId,
-      attribute.attributeId,
-      attribute.contactId,
-      attribute.kind,
-      JSON.stringify(attribute.value),
-      attribute.sourceKind,
-      attribute.sourceRef,
-      attribute.captureMethod,
-      attribute.confidence,
-      attribute.userConfirmed ? 1 : 0,
-      attribute.recordedAt,
-    );
+  for (const tenant of fixture.tenants) {
+    for (const job of tenant.jobs) {
+      insertJob.run(tenant.tenantId, job.jobId, job.url);
+    }
+    for (const contact of tenant.contacts) {
+      insertContact.run(
+        tenant.tenantId,
+        contact.contactId,
+        contact.employer,
+        contact.jobId,
+        contact.role,
+        contact.createdAt,
+        contact.updatedAt,
+      );
+    }
+    for (const attribute of tenant.attributes) {
+      insertAttribute.run(
+        tenant.tenantId,
+        attribute.attributeId,
+        attribute.contactId,
+        attribute.kind,
+        JSON.stringify(attribute.value),
+        attribute.sourceKind,
+        attribute.sourceRef,
+        attribute.captureMethod,
+        attribute.confidence,
+        attribute.userConfirmed ? 1 : 0,
+        attribute.recordedAt,
+      );
+    }
   }
   return db;
 }
@@ -120,30 +130,48 @@ function normalize(row: Record<string, unknown>): Record<string, unknown> {
   };
 }
 
-describe("contact_projections cross-runtime parity", () => {
-  it("materialises the projection from canonical rows matching the shared fixture", () => {
-    const db = seededDb();
-    refreshProjections(db, fixture.tenantId);
-    const rows = db
-      .prepare("SELECT * FROM contact_projections WHERE tenant_id = ?")
-      .all(fixture.tenantId) as Array<Record<string, unknown>>;
+function expectedFor(tenant: TenantFixture): Array<Record<string, unknown>> {
+  return [...tenant.expected].sort((a, b) => String(a.contactId).localeCompare(String(b.contactId)));
+}
 
-    const projected = rows
-      .map(normalize)
-      .sort((a, b) => String(a.contactId).localeCompare(String(b.contactId)));
-    const expected = [...fixture.expected].sort((a, b) =>
-      String(a.contactId).localeCompare(String(b.contactId)),
-    );
-    expect(projected).toEqual(expected);
+function projectedFor(db: Database.Database, tenant: TenantFixture): Array<Record<string, unknown>> {
+  return (db
+    .prepare("SELECT * FROM contact_projections WHERE tenant_id = ?")
+    .all(tenant.tenantId) as Array<Record<string, unknown>>)
+    .map(normalize)
+    .sort((a, b) => String(a.contactId).localeCompare(String(b.contactId)));
+}
+
+describe("contact_projections cross-runtime parity", () => {
+  it("materialises the exact-v7 projections from the shared fixture", () => {
+    const db = seededDb();
+    for (const tenant of fixture.tenants) {
+      refreshContactProjections(db, tenant.tenantId);
+      expect(projectedFor(db, tenant)).toEqual(expectedFor(tenant));
+    }
   });
 
-  it("never persists an attribute value into the projection (sensitivity)", () => {
+  it("isolates the same canonical JobId across tenants", () => {
     const db = seededDb();
-    refreshProjections(db, fixture.tenantId);
-    const rows = db
-      .prepare("SELECT * FROM contact_projections WHERE tenant_id = ?")
-      .all(fixture.tenantId) as Array<Record<string, unknown>>;
-    const serialized = JSON.stringify(rows);
+    const [local, other] = fixture.tenants;
+    expect(local).toBeDefined();
+    expect(other).toBeDefined();
+    refreshContactProjections(db, local!.tenantId);
+    expect(projectedFor(db, local!)).toEqual(expectedFor(local!));
+    expect(projectedFor(db, other!)).toEqual([]);
+    refreshContactProjections(db, other!.tenantId);
+    expect(projectedFor(db, other!)).toEqual(expectedFor(other!));
+    expect(projectedFor(db, local!)).toEqual(expectedFor(local!));
+  });
+
+  it("never persists an attribute value into projections", () => {
+    const db = seededDb();
+    for (const tenant of fixture.tenants) {
+      refreshContactProjections(db, tenant.tenantId);
+    }
+    const serialized = JSON.stringify(
+      db.prepare("SELECT * FROM contact_projections ORDER BY tenant_id, contact_id").all(),
+    );
     for (const secret of fixture.sensitiveValues) {
       expect(serialized).not.toContain(secret);
     }

--- a/apps/api/test/contacts.test.ts
+++ b/apps/api/test/contacts.test.ts
@@ -10,9 +10,12 @@ import type {
   ContactSummary,
 } from "../src/contracts.js";
 import { buildApp } from "../src/server.js";
+import { initializeExactV7Database } from "./v7-schema.js";
 
 const SECRET_NAME = "Jane Recruiter";
 const SECRET_EMAIL = "jane@acme.example";
+const JOB_ID_ONE = "00000000-0000-4000-8000-000000000011";
+const JOB_ID_TWO = "00000000-0000-4000-8000-000000000012";
 
 const cleanups: Array<() => void> = [];
 
@@ -25,22 +28,15 @@ afterEach(() => {
 function withTempApp() {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "jobctrl-api-contacts-"));
   const dbPath = path.join(dir, "jobs.db");
+  initializeExactV7Database(dbPath);
   const db = new Database(dbPath);
-  db.exec(`
-    CREATE TABLE jobs (url TEXT PRIMARY KEY, title TEXT);
-    CREATE TABLE job_events (
-      event_id     INTEGER PRIMARY KEY AUTOINCREMENT,
-      job_url      TEXT,
-      stage        TEXT,
-      event_type   TEXT NOT NULL,
-      level        TEXT NOT NULL DEFAULT 'info',
-      message      TEXT,
-      occurred_at  TEXT NOT NULL,
-      payload_json TEXT,
-      entity_kind  TEXT,
-      entity_ref   TEXT
-    );
-  `);
+  db.pragma("foreign_keys = ON");
+  const insertJob = db.prepare(
+    `INSERT INTO jobs (tenant_id, job_id, url, title, discovered_at)
+     VALUES ('local', ?, ?, 'Fixture job', '2026-07-31T12:00:00Z')`,
+  );
+  insertJob.run(JOB_ID_ONE, "https://jobs.example.test/one");
+  insertJob.run(JOB_ID_TWO, "https://jobs.example.test/two");
   db.close();
   const app = buildApp({ dbPath, configPath: path.join(dir, "config.json") });
   cleanups.push(() => fs.rmSync(dir, { recursive: true, force: true }));
@@ -62,7 +58,7 @@ describe("contacts API", () => {
     const { statusCode, contact } = await createContact(app, {
       role: "recruiter",
       employer: "Acme",
-      jobId: "https://job/1",
+      jobId: JOB_ID_ONE,
       attributes: [
         { kind: "name", value: SECRET_NAME },
         { kind: "email", value: SECRET_EMAIL },
@@ -98,12 +94,24 @@ describe("contacts API", () => {
 
   it("filters the list by application (jobId)", async () => {
     const { app } = withTempApp();
-    await createContact(app, { employer: "Acme", jobId: "https://job/1", attributes: [{ kind: "name", value: "A" }] });
-    await createContact(app, { employer: "Acme", jobId: "https://job/2", attributes: [{ kind: "name", value: "B" }] });
-    const res = await app.inject({ method: "GET", url: "/v1/contacts?jobId=https://job/1" });
+    await createContact(app, { employer: "Acme", jobId: JOB_ID_ONE, attributes: [{ kind: "name", value: "A" }] });
+    await createContact(app, { employer: "Acme", jobId: JOB_ID_TWO, attributes: [{ kind: "name", value: "B" }] });
+    const res = await app.inject({ method: "GET", url: `/v1/contacts?jobId=${JOB_ID_ONE}` });
     const items = (res.json() as { items: ContactSummary[] }).items;
     expect(items).toHaveLength(1);
-    expect(items[0]?.jobId).toBe("https://job/1");
+    expect(items[0]?.jobId).toBe(JOB_ID_ONE);
+  });
+
+  it("rejects noncanonical JobId list filters before opening the database", async () => {
+    const { app } = withTempApp();
+    for (const jobId of [
+      "ABCDEFAB-CDEF-4ABC-8DEF-ABCDEFABCDEF",
+      "https://jobs.example.test/not-an-id",
+    ]) {
+      const res = await app.inject({ method: "GET", url: `/v1/contacts?jobId=${encodeURIComponent(jobId)}` });
+      expect(res.statusCode).toBe(400);
+      expect(res.json()).toEqual({ ok: false, error: "invalid_contact_query" });
+    }
   });
 
   it("never leaks attribute values into job_events payloads (sensitivity)", async () => {
@@ -116,7 +124,12 @@ describe("contacts API", () => {
       ],
     });
     const db = new Database(dbPath, { readonly: true });
-    const rows = db.prepare("SELECT event_type, payload_json, entity_kind, entity_ref FROM job_events").all() as Array<{
+    const rows = db.prepare(
+      "SELECT tenant_id, job_id, identity_version, event_type, payload_json, entity_kind, entity_ref FROM job_events",
+    ).all() as Array<{
+      tenant_id: string;
+      job_id: string | null;
+      identity_version: number;
       event_type: string;
       payload_json: string;
       entity_kind: string;
@@ -126,6 +139,8 @@ describe("contacts API", () => {
     expect(rows.length).toBeGreaterThan(0);
     expect(rows.map((row) => row.event_type)).toContain("ContactCreated");
     for (const row of rows) {
+      expect(row.tenant_id).toBe("local");
+      expect(row.identity_version).toBe(1);
       expect(row.entity_kind).toBe("contact");
       expect(row.entity_ref).not.toBe("");
       expect(row.payload_json).not.toContain(SECRET_NAME);
@@ -141,6 +156,20 @@ describe("contacts API", () => {
       payload: { attributes: [{ kind: "name", value: "Nobody" }] },
     });
     expect(res.statusCode).toBe(400);
+  });
+
+  it("rejects a URL-shaped JobId before contacts or events are written", async () => {
+    const { app, dbPath } = withTempApp();
+    const res = await app.inject({
+      method: "POST",
+      url: "/v1/contacts",
+      payload: { employer: "Acme", jobId: "https://jobs.example.test/not-an-id" },
+    });
+    expect(res.statusCode).toBe(400);
+    const db = new Database(dbPath, { readonly: true });
+    expect((db.prepare("SELECT COUNT(*) AS count FROM contacts").get() as { count: number }).count).toBe(0);
+    expect((db.prepare("SELECT COUNT(*) AS count FROM job_events").get() as { count: number }).count).toBe(0);
+    db.close();
   });
 
   it("updates role and re-projects", async () => {

--- a/packages/contracts/src/schemas.ts
+++ b/packages/contracts/src/schemas.ts
@@ -5477,6 +5477,14 @@ export type ContactAttributeInput = z.infer<typeof ContactAttributeInputSchema>;
 
 const contactEmployerField = z.string().trim().min(1).max(200).nullish();
 const contactJobIdField = z.string().trim().min(1).max(2000).nullish();
+const contactApiJobIdField = z
+  .string()
+  .trim()
+  .uuid()
+  .refine((value) => value === value.toLowerCase(), {
+    message: "jobId must be a canonical UUID",
+  })
+  .nullish();
 const outreachJobIdField = z
   .string()
   .trim()
@@ -5490,7 +5498,7 @@ export const ContactCreateRequestSchema = z
   .object({
     role: ContactRoleSchema.default("other"),
     employer: contactEmployerField,
-    jobId: contactJobIdField,
+    jobId: contactApiJobIdField,
     attributes: z.array(ContactAttributeInputSchema).max(50).default([]),
   })
   .strict()
@@ -5504,7 +5512,7 @@ export const ContactUpdateRequestSchema = z
   .object({
     role: ContactRoleSchema.optional(),
     employer: contactEmployerField,
-    jobId: contactJobIdField,
+    jobId: contactApiJobIdField,
     attributes: z.array(ContactAttributeInputSchema).max(50).optional(),
   })
   .strict();
@@ -5520,7 +5528,7 @@ export type ContactImportRequest = z.infer<typeof ContactImportRequestSchema>;
 
 export const ContactListQuerySchema = z
   .object({
-    jobId: optionalText,
+    jobId: contactApiJobIdField,
     employer: optionalText,
   })
   .strict();

--- a/packages/domain-types/test/fixtures/contact_projection_parity.json
+++ b/packages/domain-types/test/fixtures/contact_projection_parity.json
@@ -1,76 +1,38 @@
 {
-  "_comment": "Cross-runtime parity fixture for contact_projections (R6 Phase 1). Python half: workers/automation/tests/test_contact_projection_parity.py. TS half: apps/api/test/contact-projection-parity.test.ts. Both seed the SAME canonical contacts + contact_attributes rows, run their OWN projection refresh, and assert the resulting contact_projections rows equal `expected` (JSON columns compared parsed). `attributes[].value` seeds canonical value_json and MUST NOT appear anywhere in the projection (sensitivity rule, plan §6).",
-  "tenantId": "local",
-  "contacts": [
+  "_comment": "Cross-runtime exact-v7 parity fixture for contact_projections. The TypeScript and Python tests seed each tenant's canonical jobs, contacts, and contact_attributes directly from this fixture, then refresh only that tenant's contact projection. URLs are job locator data; jobId is the tenant-scoped root identity.",
+  "tenants": [
     {
-      "contactId": "contact-1",
-      "employer": "Acme Corp",
-      "jobUrl": "https://boards.example.com/acme/eng-1",
-      "role": "recruiter",
-      "createdAt": "2026-07-01T00:00:00.000Z",
-      "updatedAt": "2026-07-02T00:00:00.000Z"
-    },
-    {
-      "contactId": "contact-2",
-      "employer": "Globex",
-      "jobUrl": null,
-      "role": "hiring_manager",
-      "createdAt": "2026-07-03T00:00:00.000Z",
-      "updatedAt": "2026-07-03T00:00:00.000Z"
-    }
-  ],
-  "attributes": [
-    {
-      "attributeId": "attr-1",
-      "contactId": "contact-1",
-      "kind": "name",
-      "value": "Jane Recruiter",
-      "sourceKind": "user_entered",
-      "sourceRef": "user_entered",
-      "captureMethod": "manual",
-      "confidence": 1.0,
-      "userConfirmed": true,
-      "recordedAt": "2026-07-01T00:00:00.000Z"
-    },
-    {
-      "attributeId": "attr-2",
-      "contactId": "contact-1",
-      "kind": "email",
-      "value": "jane@acme.example",
-      "sourceKind": "user_entered",
-      "sourceRef": "user_entered",
-      "captureMethod": "manual",
-      "confidence": 1.0,
-      "userConfirmed": true,
-      "recordedAt": "2026-07-01T00:00:01.000Z"
-    },
-    {
-      "attributeId": "attr-3",
-      "contactId": "contact-2",
-      "kind": "name",
-      "value": "Bob Manager",
-      "sourceKind": "user_imported_list",
-      "sourceRef": "referrals.csv",
-      "captureMethod": "manual",
-      "confidence": 1.0,
-      "userConfirmed": false,
-      "recordedAt": "2026-07-03T00:00:00.000Z"
-    }
-  ],
-  "sensitiveValues": ["Jane Recruiter", "jane@acme.example", "Bob Manager"],
-  "expected": [
-    {
-      "contactId": "contact-1",
-      "employer": "Acme Corp",
-      "jobId": "https://boards.example.com/acme/eng-1",
-      "role": "recruiter",
-      "attributeCount": 2,
-      "confirmedCount": 2,
-      "sourceKinds": ["user_entered"],
-      "provenance": [
+      "tenantId": "local",
+      "jobs": [
+        {
+          "jobId": "11111111-1111-4111-8111-111111111111",
+          "url": "https://boards.example.com/acme/eng-1"
+        }
+      ],
+      "contacts": [
+        {
+          "contactId": "contact-1",
+          "employer": "Acme Corp",
+          "jobId": "11111111-1111-4111-8111-111111111111",
+          "role": "recruiter",
+          "createdAt": "2026-07-01T00:00:00.000Z",
+          "updatedAt": "2026-07-02T00:00:00.000Z"
+        },
+        {
+          "contactId": "contact-2",
+          "employer": "Globex",
+          "jobId": null,
+          "role": "hiring_manager",
+          "createdAt": "2026-07-03T00:00:00.000Z",
+          "updatedAt": "2026-07-03T00:00:00.000Z"
+        }
+      ],
+      "attributes": [
         {
           "attributeId": "attr-1",
-          "attributeKind": "name",
+          "contactId": "contact-1",
+          "kind": "name",
+          "value": "Jane Recruiter",
           "sourceKind": "user_entered",
           "sourceRef": "user_entered",
           "captureMethod": "manual",
@@ -80,30 +42,21 @@
         },
         {
           "attributeId": "attr-2",
-          "attributeKind": "email",
+          "contactId": "contact-1",
+          "kind": "email",
+          "value": "jane@acme.example",
           "sourceKind": "user_entered",
           "sourceRef": "user_entered",
           "captureMethod": "manual",
           "confidence": 1.0,
           "userConfirmed": true,
           "recordedAt": "2026-07-01T00:00:01.000Z"
-        }
-      ],
-      "createdAt": "2026-07-01T00:00:00.000Z",
-      "updatedAt": "2026-07-02T00:00:00.000Z"
-    },
-    {
-      "contactId": "contact-2",
-      "employer": "Globex",
-      "jobId": null,
-      "role": "hiring_manager",
-      "attributeCount": 1,
-      "confirmedCount": 0,
-      "sourceKinds": ["user_imported_list"],
-      "provenance": [
+        },
         {
           "attributeId": "attr-3",
-          "attributeKind": "name",
+          "contactId": "contact-2",
+          "kind": "name",
+          "value": "Bob Manager",
           "sourceKind": "user_imported_list",
           "sourceRef": "referrals.csv",
           "captureMethod": "manual",
@@ -112,8 +65,123 @@
           "recordedAt": "2026-07-03T00:00:00.000Z"
         }
       ],
-      "createdAt": "2026-07-03T00:00:00.000Z",
-      "updatedAt": "2026-07-03T00:00:00.000Z"
+      "expected": [
+        {
+          "contactId": "contact-1",
+          "employer": "Acme Corp",
+          "jobId": "11111111-1111-4111-8111-111111111111",
+          "role": "recruiter",
+          "attributeCount": 2,
+          "confirmedCount": 2,
+          "sourceKinds": ["user_entered"],
+          "provenance": [
+            {
+              "attributeId": "attr-1",
+              "attributeKind": "name",
+              "sourceKind": "user_entered",
+              "sourceRef": "user_entered",
+              "captureMethod": "manual",
+              "confidence": 1.0,
+              "userConfirmed": true,
+              "recordedAt": "2026-07-01T00:00:00.000Z"
+            },
+            {
+              "attributeId": "attr-2",
+              "attributeKind": "email",
+              "sourceKind": "user_entered",
+              "sourceRef": "user_entered",
+              "captureMethod": "manual",
+              "confidence": 1.0,
+              "userConfirmed": true,
+              "recordedAt": "2026-07-01T00:00:01.000Z"
+            }
+          ],
+          "createdAt": "2026-07-01T00:00:00.000Z",
+          "updatedAt": "2026-07-02T00:00:00.000Z"
+        },
+        {
+          "contactId": "contact-2",
+          "employer": "Globex",
+          "jobId": null,
+          "role": "hiring_manager",
+          "attributeCount": 1,
+          "confirmedCount": 0,
+          "sourceKinds": ["user_imported_list"],
+          "provenance": [
+            {
+              "attributeId": "attr-3",
+              "attributeKind": "name",
+              "sourceKind": "user_imported_list",
+              "sourceRef": "referrals.csv",
+              "captureMethod": "manual",
+              "confidence": 1.0,
+              "userConfirmed": false,
+              "recordedAt": "2026-07-03T00:00:00.000Z"
+            }
+          ],
+          "createdAt": "2026-07-03T00:00:00.000Z",
+          "updatedAt": "2026-07-03T00:00:00.000Z"
+        }
+      ]
+    },
+    {
+      "tenantId": "other",
+      "jobs": [
+        {
+          "jobId": "11111111-1111-4111-8111-111111111111",
+          "url": "https://boards.example.com/acme/eng-1"
+        }
+      ],
+      "contacts": [
+        {
+          "contactId": "contact-other-1",
+          "employer": "Other Corp",
+          "jobId": "11111111-1111-4111-8111-111111111111",
+          "role": "referrer",
+          "createdAt": "2026-07-04T00:00:00.000Z",
+          "updatedAt": "2026-07-04T00:00:00.000Z"
+        }
+      ],
+      "attributes": [
+        {
+          "attributeId": "attr-other-1",
+          "contactId": "contact-other-1",
+          "kind": "name",
+          "value": "Other Contact",
+          "sourceKind": "user_entered",
+          "sourceRef": "user_entered",
+          "captureMethod": "manual",
+          "confidence": 1.0,
+          "userConfirmed": true,
+          "recordedAt": "2026-07-04T00:00:00.000Z"
+        }
+      ],
+      "expected": [
+        {
+          "contactId": "contact-other-1",
+          "employer": "Other Corp",
+          "jobId": "11111111-1111-4111-8111-111111111111",
+          "role": "referrer",
+          "attributeCount": 1,
+          "confirmedCount": 1,
+          "sourceKinds": ["user_entered"],
+          "provenance": [
+            {
+              "attributeId": "attr-other-1",
+              "attributeKind": "name",
+              "sourceKind": "user_entered",
+              "sourceRef": "user_entered",
+              "captureMethod": "manual",
+              "confidence": 1.0,
+              "userConfirmed": true,
+              "recordedAt": "2026-07-04T00:00:00.000Z"
+            }
+          ],
+          "createdAt": "2026-07-04T00:00:00.000Z",
+          "updatedAt": "2026-07-04T00:00:00.000Z"
+        }
+      ]
     }
-  ]
+  ],
+  "sensitiveValues": ["Jane Recruiter", "jane@acme.example", "Bob Manager", "Other Contact"]
 }

--- a/workers/automation/tests/test_contact_projection_parity.py
+++ b/workers/automation/tests/test_contact_projection_parity.py
@@ -1,9 +1,4 @@
-"""Exact-v7 coverage for ``contact_projections`` (R6 Phase 1).
-
-The shared parity fixture remains on the legacy TypeScript projection contract.
-This test derives a local exact-v7 fixture using canonical JobIds, then asserts
-the resulting ``contact_projections`` rows and the sensitive-value boundary.
-"""
+"""Cross-runtime exact-v7 coverage for ``contact_projections``."""
 
 from __future__ import annotations
 
@@ -12,9 +7,9 @@ import sqlite3
 from pathlib import Path
 from typing import Any
 
-from jobctrl.database import init_db
-from jobctrl.domain.tenant import LOCAL_TENANT
+from jobctrl.domain.tenant import TenantId
 from jobctrl.infrastructure.events.in_process_bus import InProcessEventBus
+from jobctrl.infrastructure.migrations.schema_v7 import create_exact_v7_schema
 from jobctrl.infrastructure.projections.projection_builder import ProjectionBuilder
 from jobctrl.infrastructure.projections.sqlite_projection_store import (
     SqliteProjectionStore,
@@ -24,35 +19,19 @@ _FIXTURE = (
     Path(__file__).resolve().parents[3]
     / "packages/domain-types/test/fixtures/contact_projection_parity.json"
 )
-_V7_JOB_IDS = {
-    "https://boards.example.com/acme/eng-1": "11111111-1111-4111-8111-111111111111",
-}
 
 
-def _exact_v7_fixture() -> dict[str, Any]:
-    fixture = json.loads(_FIXTURE.read_text())
-    for contact in fixture["contacts"]:
-        job_url = contact.pop("jobUrl")
-        contact["jobId"] = _V7_JOB_IDS[job_url] if job_url else None
-    for expected in fixture["expected"]:
-        job_url = expected.get("jobId")
-        expected["jobId"] = _V7_JOB_IDS[job_url] if job_url else None
-    return fixture
-
-
-def _seed_canonical(conn: sqlite3.Connection, fixture: dict[str, Any]) -> None:
-    tenant = fixture["tenantId"]
-    for contact in fixture["contacts"]:
-        if contact["jobId"] is None:
-            continue
+def _seed_canonical(conn: sqlite3.Connection, tenant: dict[str, Any]) -> None:
+    tenant_id = tenant["tenantId"]
+    for job in tenant["jobs"]:
         conn.execute(
             """
             INSERT INTO jobs (tenant_id, job_id, url, title, discovered_at)
             VALUES (?, ?, ?, 'Fixture job', '2026-07-31T12:00:00Z')
             """,
-            (tenant, contact["jobId"], f"https://fixtures.example/{contact['contactId']}"),
+            (tenant_id, job["jobId"], job["url"]),
         )
-    for contact in fixture["contacts"]:
+    for contact in tenant["contacts"]:
         conn.execute(
             """
             INSERT INTO contacts (
@@ -61,7 +40,7 @@ def _seed_canonical(conn: sqlite3.Connection, fixture: dict[str, Any]) -> None:
             ) VALUES (?, ?, ?, ?, ?, ?, ?, NULL)
             """,
             (
-                tenant,
+                tenant_id,
                 contact["contactId"],
                 contact["employer"],
                 contact["jobId"],
@@ -70,7 +49,7 @@ def _seed_canonical(conn: sqlite3.Connection, fixture: dict[str, Any]) -> None:
                 contact["updatedAt"],
             ),
         )
-    for attribute in fixture["attributes"]:
+    for attribute in tenant["attributes"]:
         conn.execute(
             """
             INSERT INTO contact_attributes (
@@ -80,7 +59,7 @@ def _seed_canonical(conn: sqlite3.Connection, fixture: dict[str, Any]) -> None:
             ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
-                tenant,
+                tenant_id,
                 attribute["attributeId"],
                 attribute["contactId"],
                 attribute["kind"],
@@ -111,23 +90,38 @@ def _normalize(row: sqlite3.Row) -> dict[str, Any]:
     }
 
 
-def test_contact_projection_exact_v7_fixture(tmp_path: Path) -> None:
-    fixture = _exact_v7_fixture()
-    conn = init_db(tmp_path / "jobctrl.db")
-    conn.row_factory = sqlite3.Row
-    _seed_canonical(conn, fixture)
-
-    builder = ProjectionBuilder(conn_factory=lambda: conn, tenant_id=LOCAL_TENANT)
+def _projected(conn: sqlite3.Connection, tenant: dict[str, Any]) -> list[dict[str, Any]]:
+    tenant_id = TenantId(tenant["tenantId"])
+    builder = ProjectionBuilder(conn_factory=lambda: conn, tenant_id=tenant_id)
     builder.subscribe_to(InProcessEventBus())
     builder.refresh()
+    rows = SqliteProjectionStore(conn).fetch_contacts(str(tenant_id))
+    return sorted((_normalize(row) for row in rows), key=lambda item: item["contactId"])
 
-    rows = SqliteProjectionStore(conn).fetch_contacts("local")
-    projected = sorted((_normalize(row) for row in rows), key=lambda item: item["contactId"])
-    expected = sorted(fixture["expected"], key=lambda item: item["contactId"])
-    assert projected == expected
+
+def _expected(tenant: dict[str, Any]) -> list[dict[str, Any]]:
+    return sorted(tenant["expected"], key=lambda item: item["contactId"])
+
+
+def test_contact_projection_exact_v7_fixture_is_tenant_scoped() -> None:
+    fixture = json.loads(_FIXTURE.read_text())
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys = ON")
+    create_exact_v7_schema(conn)
+    for tenant in fixture["tenants"]:
+        _seed_canonical(conn, tenant)
+
+    local, other = fixture["tenants"]
+    assert _projected(conn, local) == _expected(local)
+    assert SqliteProjectionStore(conn).fetch_contacts(other["tenantId"]) == []
+    assert _projected(conn, other) == _expected(other)
+    assert _projected(conn, local) == _expected(local)
 
     projection_text = " ".join(
-        " ".join(str(value) for value in tuple(row)) for row in rows
+        " ".join(str(value) for value in tuple(row))
+        for row in SqliteProjectionStore(conn).fetch_contacts(local["tenantId"])
+        + SqliteProjectionStore(conn).fetch_contacts(other["tenantId"])
     )
     for secret in fixture["sensitiveValues"]:
         assert secret not in projection_text


### PR DESCRIPTION
## Summary

-

## Validation

-

## Checklist

- [ ] External contributor commits include a DCO `Signed-off-by:` trailer (`git commit -s`).
- [ ] I ran the relevant local checks and listed them above. Heavy CI runs automatically for ordinary same-repository pull requests and cumulative stack heads, but not public forks; maintainers run manual workflows or local validation for fork contributions after review.
- [ ] I did not include secrets, private profile data, resumes, generated application materials, raw logs, browser profiles, SQLite databases, or local paths.