### PR TITLE
refactor(contact-research): use exact v7 job ids

### DIFF
--- a/apps/api/src/contact-research.ts
+++ b/apps/api/src/contact-research.ts
@@ -31,53 +31,14 @@ import type {
   ResearchTaskStatus,
 } from "./contracts.js";
 import { CONTACT_ROLES } from "@jobctrl/domain-types";
-import { ensureContactTables, getContactDetail } from "./contacts.js";
-import { allRows, getRow, tableExists, type SqliteDatabase, type SqliteValue } from "./db.js";
-import { refreshContactResearchProjections, refreshProjections } from "./projections.js";
+import { getContactDetail } from "./contacts.js";
+import { allRows, getRow, type SqliteDatabase, type SqliteValue } from "./db.js";
 
 const TENANT_ID = "local";
+const CANONICAL_JOB_ID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
 
 export class ContactResearchNotFoundError extends Error {}
 export class ContactResearchInputError extends Error {}
-
-export function ensureContactResearchTables(db: SqliteDatabase): void {
-  ensureContactTables(db);
-  db.exec(`
-    CREATE TABLE IF NOT EXISTS contact_research_tasks (
-      tenant_id            TEXT NOT NULL DEFAULT 'local',
-      task_id              TEXT NOT NULL,
-      employer             TEXT,
-      job_url              TEXT,
-      status               TEXT NOT NULL DEFAULT 'queued',
-      source_attempts_json TEXT NOT NULL DEFAULT '[]',
-      started_at           TEXT,
-      updated_at           TEXT NOT NULL,
-      needs_review_at      TEXT,
-      completed_at         TEXT,
-      failed_at            TEXT,
-      error_class          TEXT,
-      PRIMARY KEY (tenant_id, task_id)
-    );
-    CREATE TABLE IF NOT EXISTS contact_candidates (
-      tenant_id            TEXT NOT NULL DEFAULT 'local',
-      candidate_id         TEXT NOT NULL,
-      task_id              TEXT NOT NULL,
-      role                 TEXT NOT NULL DEFAULT 'other',
-      attributes_json      TEXT,
-      source_kind          TEXT NOT NULL,
-      source_ref           TEXT NOT NULL,
-      capture_method       TEXT NOT NULL,
-      confidence           REAL NOT NULL DEFAULT 0,
-      status               TEXT NOT NULL DEFAULT 'needs_review',
-      proposed_at          TEXT NOT NULL,
-      confirmed_contact_id TEXT,
-      confirmed_at         TEXT,
-      PRIMARY KEY (tenant_id, candidate_id)
-    );
-    CREATE INDEX IF NOT EXISTS idx_contact_candidates_task
-      ON contact_candidates(tenant_id, task_id, status);
-  `);
-}
 
 // ---------------------------------------------------------------------------
 // Reads (projection-backed list; canonical join for candidate values)
@@ -103,8 +64,7 @@ export function listResearchTasks(
   db: SqliteDatabase,
   query: ContactResearchListQuery = { jobId: "", employer: "" },
 ): ContactResearchTaskSummary[] {
-  ensureContactResearchTables(db);
-  refreshProjections(db, TENANT_ID);
+  refreshContactResearchTaskProjections(db, TENANT_ID);
   const filters: string[] = ["tenant_id = ?"];
   const params: SqliteValue[] = [TENANT_ID];
   const jobId = (query.jobId ?? "").trim();
@@ -130,8 +90,7 @@ export function getResearchTaskDetail(
   db: SqliteDatabase,
   taskId: string,
 ): ContactResearchTaskDetail | null {
-  ensureContactResearchTables(db);
-  refreshProjections(db, TENANT_ID);
+  refreshContactResearchTaskProjections(db, TENANT_ID);
   const task = loadTaskRow(db, taskId);
   if (!task) {
     return null;
@@ -154,16 +113,16 @@ export function createQueuedResearchTask(
   db: SqliteDatabase,
   input: { taskId: string; employer: string | null; jobId: string | null },
 ): ContactResearchTaskSummary {
-  ensureContactResearchTables(db);
+  const jobId = canonicalJobId(input.jobId);
   const now = new Date().toISOString();
   db.prepare(
     `INSERT INTO contact_research_tasks (
-       tenant_id, task_id, employer, job_url, status, source_attempts_json, started_at, updated_at
+       tenant_id, task_id, employer, job_id, status, source_attempts_json, started_at, updated_at
      ) VALUES (?, ?, ?, ?, 'queued', '[]', ?, ?)
      ON CONFLICT(tenant_id, task_id) DO NOTHING`,
-  ).run(TENANT_ID, input.taskId, input.employer, input.jobId, now, now);
+  ).run(TENANT_ID, input.taskId, input.employer, jobId, now, now);
   recordEvent(db, {
-    jobUrl: input.jobId,
+    jobId,
     eventType: "ContactResearchTaskStarted",
     entityKind: "contact_research",
     entityRef: input.taskId,
@@ -171,18 +130,18 @@ export function createQueuedResearchTask(
       tenantId: TENANT_ID,
       taskId: input.taskId,
       employer: input.employer,
-      jobId: input.jobId,
+      jobId,
       startedAt: now,
     },
   });
-  refreshContactResearchProjections(db, TENANT_ID);
+  refreshContactResearchTaskProjections(db, TENANT_ID);
   const task = loadTaskRow(db, input.taskId);
   return task
     ? taskSummaryFromCanonical(task, [])
     : ({
         taskId: input.taskId,
         employer: input.employer,
-        jobId: input.jobId,
+        jobId,
         status: "queued",
         candidateCount: 0,
         needsReviewCount: 0,
@@ -206,7 +165,6 @@ export function confirmContactCandidate(
   candidateId: string,
   role?: ContactRole,
 ): ConfirmContactCandidateResponse {
-  ensureContactResearchTables(db);
   const task = loadTaskRow(db, taskId);
   if (!task) {
     throw new ContactResearchNotFoundError(`Research task ${taskId} not found`);
@@ -228,11 +186,11 @@ export function confirmContactCandidate(
   const attributes = parseCandidateAttributes(candidate.attributes_json);
   const contactRole = role ?? normalizeRole(candidate.role);
   const employer = task.employer ?? null;
-  const jobId = task.job_url ?? null;
+  const jobId = task.job_id ?? null;
 
   const transaction = db.transaction(() => {
     db.prepare(
-      `INSERT INTO contacts (tenant_id, contact_id, employer, job_url, role, created_at, updated_at, deleted_at)
+      `INSERT INTO contacts (tenant_id, contact_id, employer, job_id, role, created_at, updated_at, deleted_at)
        VALUES (?, ?, ?, ?, ?, ?, ?, NULL)`,
     ).run(TENANT_ID, contactId, employer, jobId, contactRole, now, now);
     const insertAttr = db.prepare(
@@ -242,7 +200,7 @@ export function confirmContactCandidate(
        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?)`,
     );
     recordEvent(db, {
-      jobUrl: jobId,
+      jobId,
       eventType: "ContactCreated",
       entityKind: "contact",
       entityRef: contactId,
@@ -263,7 +221,7 @@ export function confirmContactCandidate(
         now,
       );
       recordEvent(db, {
-        jobUrl: jobId,
+        jobId,
         eventType: "ContactAttributeRecorded",
         entityKind: "contact",
         entityRef: contactId,
@@ -304,7 +262,7 @@ export function confirmContactCandidate(
         "UPDATE contact_research_tasks SET status = 'completed', completed_at = ?, updated_at = ? WHERE tenant_id = ? AND task_id = ?",
       ).run(now, now, TENANT_ID, taskId);
       recordEvent(db, {
-        jobUrl: jobId,
+        jobId,
         eventType: "ContactResearchTaskCompleted",
         entityKind: "contact_research",
         entityRef: taskId,
@@ -318,8 +276,7 @@ export function confirmContactCandidate(
   });
   transaction();
 
-  refreshProjections(db, TENANT_ID);
-  refreshContactResearchProjections(db, TENANT_ID);
+  refreshContactResearchTaskProjections(db, TENANT_ID);
 
   const contact = getContactDetail(db, contactId);
   if (!contact) {
@@ -335,6 +292,114 @@ export function confirmContactCandidate(
   } satisfies ConfirmContactCandidateResponse;
 }
 
+/** Materialise research summaries directly from exact-v7 canonical rows. */
+export function refreshContactResearchTaskProjections(
+  db: SqliteDatabase,
+  tenantId = TENANT_ID,
+): void {
+  const tasks = allRows<TaskRow>(
+    db,
+    `SELECT task_id, employer, job_id, status, source_attempts_json,
+            started_at, updated_at, needs_review_at, completed_at, failed_at, error_class
+     FROM contact_research_tasks
+     WHERE tenant_id = ?`,
+    [tenantId],
+  );
+  const liveIds = new Set<string>();
+  const upsert = db.prepare(
+    `INSERT INTO contact_research_task_projections (
+       tenant_id, task_id, employer, job_id, status,
+       candidate_count, needs_review_count, confirmed_count,
+       source_attempts_json, candidates_json, started_at, updated_at,
+       needs_review_at, completed_at, failed_at, error_class, last_updated_at
+     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+     ON CONFLICT(tenant_id, task_id) DO UPDATE SET
+       employer             = excluded.employer,
+       job_id               = excluded.job_id,
+       status               = excluded.status,
+       candidate_count      = excluded.candidate_count,
+       needs_review_count   = excluded.needs_review_count,
+       confirmed_count      = excluded.confirmed_count,
+       source_attempts_json = excluded.source_attempts_json,
+       candidates_json      = excluded.candidates_json,
+       started_at           = excluded.started_at,
+       updated_at           = excluded.updated_at,
+       needs_review_at      = excluded.needs_review_at,
+       completed_at         = excluded.completed_at,
+       failed_at            = excluded.failed_at,
+       error_class          = excluded.error_class,
+       last_updated_at      = excluded.last_updated_at`,
+  );
+  for (const task of tasks) {
+    const taskId = String(task.task_id);
+    liveIds.add(taskId);
+    const candidateRows = allRows<CandidateRow>(
+      db,
+      `SELECT candidate_id, task_id, role, attributes_json, source_kind, source_ref,
+              capture_method, confidence, status, proposed_at, confirmed_contact_id, confirmed_at
+       FROM contact_candidates
+       WHERE tenant_id = ? AND task_id = ?
+       ORDER BY proposed_at ASC, candidate_id ASC`,
+      [tenantId, taskId],
+    );
+    let needsReview = 0;
+    let confirmed = 0;
+    const candidates = candidateRows.map((candidate) => {
+      const status = String(candidate.status ?? "needs_review");
+      if (status === "needs_review") {
+        needsReview += 1;
+      } else if (status === "confirmed") {
+        confirmed += 1;
+      }
+      return {
+        candidateId: String(candidate.candidate_id),
+        role: String(candidate.role ?? "other"),
+        sourceKind: String(candidate.source_kind),
+        sourceRef: String(candidate.source_ref),
+        captureMethod: String(candidate.capture_method ?? "llm_assisted"),
+        confidence: Number(candidate.confidence ?? 0),
+        status,
+        proposedAt: String(candidate.proposed_at ?? ""),
+        confirmedContactId: candidate.confirmed_contact_id ?? null,
+        confirmedAt: candidate.confirmed_at ?? null,
+        attributeKinds: projectionAttributeKinds(candidate.attributes_json),
+      };
+    });
+    upsert.run(
+      tenantId,
+      taskId,
+      task.employer,
+      task.job_id,
+      String(task.status ?? "queued"),
+      candidateRows.length,
+      needsReview,
+      confirmed,
+      JSON.stringify(parseJsonArray(task.source_attempts_json)),
+      JSON.stringify(candidates),
+      task.started_at,
+      task.updated_at,
+      task.needs_review_at,
+      task.completed_at,
+      task.failed_at,
+      task.error_class,
+      task.updated_at,
+    );
+  }
+  const existing = allRows<{ task_id: string }>(
+    db,
+    "SELECT task_id FROM contact_research_task_projections WHERE tenant_id = ?",
+    [tenantId],
+  );
+  const drop = db.prepare(
+    "DELETE FROM contact_research_task_projections WHERE tenant_id = ? AND task_id = ?",
+  );
+  for (const row of existing) {
+    if (!liveIds.has(String(row.task_id))) {
+      drop.run(tenantId, String(row.task_id));
+    }
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Internals
 // ---------------------------------------------------------------------------
@@ -342,7 +407,7 @@ export function confirmContactCandidate(
 type TaskRow = {
   task_id: string;
   employer: string | null;
-  job_url: string | null;
+  job_id: string | null;
   status: string | null;
   source_attempts_json: string | null;
   started_at: string | null;
@@ -431,7 +496,7 @@ function taskSummaryFromCanonical(
   return {
     taskId: String(task.task_id),
     employer: task.employer ?? null,
-    jobId: task.job_url ?? null,
+    jobId: task.job_id ?? null,
     status: normalizeStatus(task.status),
     candidateCount: candidates.length,
     needsReviewCount: candidates.filter((candidate) => candidate.status === "needs_review").length,
@@ -498,6 +563,30 @@ function parseJsonArray(raw: string | null): unknown[] {
   }
 }
 
+function projectionAttributeKinds(attributesJson: string | null): string[] {
+  const kinds: string[] = [];
+  for (const item of parseJsonArray(attributesJson)) {
+    if (item && typeof item === "object" && !Array.isArray(item)) {
+      const kind = String((item as Record<string, unknown>).kind ?? "").trim();
+      if (kind) {
+        kinds.push(kind);
+      }
+    }
+  }
+  return kinds;
+}
+
+function canonicalJobId(value: string | null | undefined): string | null {
+  const trimmed = (value ?? "").trim();
+  if (!trimmed) {
+    return null;
+  }
+  if (!CANONICAL_JOB_ID.test(trimmed)) {
+    throw new ContactResearchInputError("jobId must be a canonical UUID");
+  }
+  return trimmed;
+}
+
 function normalizeRole(value: string | null | undefined): ContactRole {
   const text = (value ?? "").trim().toLowerCase();
   return (CONTACT_ROLES as readonly string[]).includes(text) ? (text as ContactRole) : "other";
@@ -518,33 +607,25 @@ function normalizeCandidateStatus(value: string | null | undefined): CandidateSt
 function recordEvent(
   db: SqliteDatabase,
   event: {
-    jobUrl: string | null;
+    jobId: string | null;
     eventType: string;
     entityKind: string;
     entityRef: string;
     payload: Record<string, unknown>;
   },
 ): void {
-  if (!tableExists(db, "job_events")) {
-    return;
-  }
-  const columns = new Set(
-    allRows<{ name: string }>(db, "PRAGMA table_info(job_events)").map((row) => row.name),
-  );
-  const values: Record<string, SqliteValue> = {
-    job_url: event.jobUrl,
-    stage: null,
-    event_type: event.eventType,
-    level: "info",
-    occurred_at: new Date().toISOString(),
-    payload_json: JSON.stringify(event.payload),
-    entity_kind: event.entityKind,
-    entity_ref: event.entityRef,
-  };
-  const entries = Object.entries(values).filter(([name]) => columns.has(name));
   db.prepare(
-    `INSERT INTO job_events (${entries.map(([name]) => name).join(", ")}) VALUES (${entries
-      .map(() => "?")
-      .join(", ")})`,
-  ).run(...entries.map(([, value]) => value));
+    `INSERT INTO job_events (
+       tenant_id, job_id, identity_version, stage, event_type, level,
+       message, occurred_at, payload_json, entity_kind, entity_ref, idempotency_key
+     ) VALUES (?, ?, 1, NULL, ?, 'info', NULL, ?, ?, ?, ?, NULL)`,
+  ).run(
+    TENANT_ID,
+    event.jobId,
+    event.eventType,
+    new Date().toISOString(),
+    JSON.stringify(event.payload),
+    event.entityKind,
+    event.entityRef,
+  );
 }

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -2669,12 +2669,17 @@ export function buildApp(options: BuildAppOptions): FastifyInstance {
   // against the conservative opt-in allowlist (INV-3). Candidates land
   // needs_review and require an explicit confirm command (INV-4). No send
   // transport exists on any of these routes (INV-1).
-  app.get("/v1/contacts/research", async (request, reply) =>
-    withDb(reply, options.dbPath, (db) => ({
+  app.get("/v1/contacts/research", async (request, reply) => {
+    const query = ContactResearchListQuerySchema.safeParse(request.query);
+    if (!query.success) {
+      void reply.code(400);
+      return { ok: false, error: "invalid_contact_research_query" };
+    }
+    return withDb(reply, options.dbPath, (db) => ({
       ok: true,
-      items: listResearchTasks(db, ContactResearchListQuerySchema.parse(request.query)),
-    })),
-  );
+      items: listResearchTasks(db, query.data),
+    }));
+  });
 
   app.get<{ Params: { taskId: string } }>(
     "/v1/contacts/research/:taskId",
@@ -2707,12 +2712,21 @@ export function buildApp(options: BuildAppOptions): FastifyInstance {
       label: source.label,
     }));
     return withWritableDb(reply, options.dbPath, async (db) => {
+      const jobUrl = jobId
+        ? (db
+            .prepare("SELECT url FROM jobs WHERE tenant_id = ? AND job_id = ?")
+            .get("local", jobId) as { url: string } | undefined)?.url ?? null
+        : null;
+      if (jobId && !jobUrl) {
+        void reply.code(404);
+        return { ok: false, error: "contact_research_job_not_found" };
+      }
       createQueuedResearchTask(db, { taskId, employer, jobId });
       const started = await contactResearchStarter(
         {
           taskId,
           employer,
-          jobUrl: jobId,
+          jobUrl,
           sources,
           ...(body.llmModel ? { llmModel: body.llmModel } : {}),
         },

--- a/apps/api/test/contact-research-projection-parity.test.ts
+++ b/apps/api/test/contact-research-projection-parity.test.ts
@@ -1,13 +1,7 @@
 /**
- * Cross-runtime parity for ``contact_research_task_projections`` (R6 Phase 2).
- *
- * The TS half of the TS<->Python drift guard. The Python half lives at
- * ``workers/automation/tests/test_contact_research_projection_parity.py``. Both
- * load the SAME shared fixture, seed the SAME canonical
- * ``contact_research_tasks`` / ``contact_candidates`` rows, run their OWN
- * projection refresh, and assert the resulting projection rows equal the
- * fixture's ``expected`` block. It also asserts no candidate VALUE leaks into the
- * projection (sensitivity rule, plan §6).
+ * Cross-runtime exact-v7 parity for ``contact_research_task_projections``.
+ * The Python half reads the same fixture and lives at
+ * ``workers/automation/tests/test_contact_research_projection_parity.py``.
  */
 import fs from "node:fs";
 import os from "node:os";
@@ -16,8 +10,8 @@ import { fileURLToPath } from "node:url";
 import Database from "better-sqlite3";
 import { afterEach, describe, expect, it } from "vitest";
 
-import { ensureContactResearchTables } from "../src/contact-research.js";
-import { refreshProjections } from "../src/projections.js";
+import { refreshContactResearchTaskProjections } from "../src/contact-research.js";
+import { initializeExactV7Database } from "./v7-schema.js";
 
 const FIXTURE_PATH = fileURLToPath(
   new URL(
@@ -26,12 +20,17 @@ const FIXTURE_PATH = fileURLToPath(
   ),
 );
 
-interface Fixture {
+interface TenantFixture {
   tenantId: string;
+  jobs: Array<{ jobId: string; url: string }>;
   tasks: Array<Record<string, unknown>>;
   candidates: Array<Record<string, unknown>>;
-  sensitiveValues: string[];
   expected: Array<Record<string, unknown>>;
+}
+
+interface Fixture {
+  tenants: TenantFixture[];
+  sensitiveValues: string[];
 }
 
 const fixture = JSON.parse(fs.readFileSync(FIXTURE_PATH, "utf8")) as Fixture;
@@ -45,34 +44,24 @@ afterEach(() => {
 
 function seededDb(): Database.Database {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "jobctrl-research-parity-"));
-  const db = new Database(path.join(dir, "jobs.db"));
+  const dbPath = path.join(dir, "jobs.db");
+  initializeExactV7Database(dbPath);
+  const db = new Database(dbPath);
+  db.pragma("foreign_keys = ON");
   cleanups.push(() => {
     db.close();
     fs.rmSync(dir, { recursive: true, force: true });
   });
-  ensureContactResearchTables(db);
+  const insertJob = db.prepare(
+    `INSERT INTO jobs (tenant_id, job_id, url, title, discovered_at)
+     VALUES (?, ?, ?, 'Fixture job', '2026-07-31T12:00:00Z')`,
+  );
   const insertTask = db.prepare(
     `INSERT INTO contact_research_tasks (
-       tenant_id, task_id, employer, job_url, status, source_attempts_json,
+       tenant_id, task_id, employer, job_id, status, source_attempts_json,
        started_at, updated_at, needs_review_at, completed_at, failed_at, error_class
      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   );
-  for (const task of fixture.tasks) {
-    insertTask.run(
-      fixture.tenantId,
-      task.taskId,
-      task.employer,
-      task.jobUrl,
-      task.status,
-      JSON.stringify(task.sourceAttempts ?? []),
-      task.startedAt,
-      task.updatedAt,
-      task.needsReviewAt,
-      task.completedAt,
-      task.failedAt,
-      task.errorClass,
-    );
-  }
   const insertCandidate = db.prepare(
     `INSERT INTO contact_candidates (
        tenant_id, candidate_id, task_id, role, attributes_json,
@@ -80,22 +69,43 @@ function seededDb(): Database.Database {
        proposed_at, confirmed_contact_id, confirmed_at
      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   );
-  for (const candidate of fixture.candidates) {
-    insertCandidate.run(
-      fixture.tenantId,
-      candidate.candidateId,
-      candidate.taskId,
-      candidate.role,
-      JSON.stringify(candidate.attributes ?? []),
-      candidate.sourceKind,
-      candidate.sourceRef,
-      candidate.captureMethod,
-      candidate.confidence,
-      candidate.status,
-      candidate.proposedAt,
-      candidate.confirmedContactId,
-      candidate.confirmedAt,
-    );
+  for (const tenant of fixture.tenants) {
+    for (const job of tenant.jobs) {
+      insertJob.run(tenant.tenantId, job.jobId, job.url);
+    }
+    for (const task of tenant.tasks) {
+      insertTask.run(
+        tenant.tenantId,
+        task.taskId,
+        task.employer,
+        task.jobId,
+        task.status,
+        JSON.stringify(task.sourceAttempts ?? []),
+        task.startedAt,
+        task.updatedAt,
+        task.needsReviewAt,
+        task.completedAt,
+        task.failedAt,
+        task.errorClass,
+      );
+    }
+    for (const candidate of tenant.candidates) {
+      insertCandidate.run(
+        tenant.tenantId,
+        candidate.candidateId,
+        candidate.taskId,
+        candidate.role,
+        JSON.stringify(candidate.attributes ?? []),
+        candidate.sourceKind,
+        candidate.sourceRef,
+        candidate.captureMethod,
+        candidate.confidence,
+        candidate.status,
+        candidate.proposedAt,
+        candidate.confirmedContactId,
+        candidate.confirmedAt,
+      );
+    }
   }
   return db;
 }
@@ -120,30 +130,48 @@ function normalize(row: Record<string, unknown>): Record<string, unknown> {
   };
 }
 
-describe("contact_research_task_projections cross-runtime parity", () => {
-  it("materialises the projection from canonical rows matching the shared fixture", () => {
-    const db = seededDb();
-    refreshProjections(db, fixture.tenantId);
-    const rows = db
-      .prepare("SELECT * FROM contact_research_task_projections WHERE tenant_id = ?")
-      .all(fixture.tenantId) as Array<Record<string, unknown>>;
+function expectedFor(tenant: TenantFixture): Array<Record<string, unknown>> {
+  return [...tenant.expected].sort((a, b) => String(a.taskId).localeCompare(String(b.taskId)));
+}
 
-    const projected = rows
-      .map(normalize)
-      .sort((a, b) => String(a.taskId).localeCompare(String(b.taskId)));
-    const expected = [...fixture.expected].sort((a, b) =>
-      String(a.taskId).localeCompare(String(b.taskId)),
-    );
-    expect(projected).toEqual(expected);
+function projectedFor(db: Database.Database, tenant: TenantFixture): Array<Record<string, unknown>> {
+  return (db
+    .prepare("SELECT * FROM contact_research_task_projections WHERE tenant_id = ?")
+    .all(tenant.tenantId) as Array<Record<string, unknown>>)
+    .map(normalize)
+    .sort((a, b) => String(a.taskId).localeCompare(String(b.taskId)));
+}
+
+describe("contact_research_task_projections cross-runtime parity", () => {
+  it("materialises exact-v7 projections from the shared fixture", () => {
+    const db = seededDb();
+    for (const tenant of fixture.tenants) {
+      refreshContactResearchTaskProjections(db, tenant.tenantId);
+      expect(projectedFor(db, tenant)).toEqual(expectedFor(tenant));
+    }
   });
 
-  it("never persists a candidate value into the projection (sensitivity)", () => {
+  it("isolates the same canonical JobId across tenants", () => {
     const db = seededDb();
-    refreshProjections(db, fixture.tenantId);
-    const rows = db
-      .prepare("SELECT * FROM contact_research_task_projections WHERE tenant_id = ?")
-      .all(fixture.tenantId) as Array<Record<string, unknown>>;
-    const serialized = JSON.stringify(rows);
+    const [local, other] = fixture.tenants;
+    expect(local).toBeDefined();
+    expect(other).toBeDefined();
+    refreshContactResearchTaskProjections(db, local!.tenantId);
+    expect(projectedFor(db, local!)).toEqual(expectedFor(local!));
+    expect(projectedFor(db, other!)).toEqual([]);
+    refreshContactResearchTaskProjections(db, other!.tenantId);
+    expect(projectedFor(db, other!)).toEqual(expectedFor(other!));
+    expect(projectedFor(db, local!)).toEqual(expectedFor(local!));
+  });
+
+  it("never persists a candidate value into projections", () => {
+    const db = seededDb();
+    for (const tenant of fixture.tenants) {
+      refreshContactResearchTaskProjections(db, tenant.tenantId);
+    }
+    const serialized = JSON.stringify(
+      db.prepare("SELECT * FROM contact_research_task_projections ORDER BY tenant_id, task_id").all(),
+    );
     for (const secret of fixture.sensitiveValues) {
       expect(serialized).not.toContain(secret);
     }

--- a/apps/api/test/contact-research.test.ts
+++ b/apps/api/test/contact-research.test.ts
@@ -19,13 +19,16 @@ import type {
   ContactResearchDetailResponse,
   ContactResearchListResponse,
 } from "../src/contracts.js";
-import { ensureContactResearchTables } from "../src/contact-research.js";
 import type { ContactResearchStarter } from "../src/local-actions.js";
 import { buildApp } from "../src/server.js";
+import { initializeExactV7Database } from "./v7-schema.js";
 
 const SECRET_NAME = "Dana Hiring-Manager";
 const SECRET_EMAIL = "dana@acme.example";
 const TEAM_URL = "https://acme.example/team";
+const JOB_ID_ONE = "00000000-0000-4000-8000-000000000021";
+const JOB_ID_TWO = "00000000-0000-4000-8000-000000000022";
+const JOB_URL_ONE = "https://jobs.example.test/research-one";
 
 const cleanups: Array<() => void> = [];
 afterEach(() => {
@@ -37,23 +40,15 @@ afterEach(() => {
 function withTempApp(starter?: ContactResearchStarter) {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "jobctrl-api-research-"));
   const dbPath = path.join(dir, "jobs.db");
+  initializeExactV7Database(dbPath);
   const db = new Database(dbPath);
-  db.exec(`
-    CREATE TABLE jobs (url TEXT PRIMARY KEY, title TEXT);
-    CREATE TABLE job_events (
-      event_id     INTEGER PRIMARY KEY AUTOINCREMENT,
-      job_url      TEXT,
-      stage        TEXT,
-      event_type   TEXT NOT NULL,
-      level        TEXT NOT NULL DEFAULT 'info',
-      message      TEXT,
-      occurred_at  TEXT NOT NULL,
-      payload_json TEXT,
-      entity_kind  TEXT,
-      entity_ref   TEXT
-    );
-  `);
-  ensureContactResearchTables(db);
+  db.pragma("foreign_keys = ON");
+  const insertJob = db.prepare(
+    `INSERT INTO jobs (tenant_id, job_id, url, title, discovered_at)
+     VALUES ('local', ?, ?, 'Fixture job', '2026-07-31T12:00:00Z')`,
+  );
+  insertJob.run(JOB_ID_ONE, JOB_URL_ONE);
+  insertJob.run(JOB_ID_TWO, "https://jobs.example.test/research-two");
   db.close();
   const app = buildApp({
     dbPath,
@@ -71,11 +66,12 @@ function seedNeedsReviewTask(dbPath: string): { taskId: string; candidateId: str
   const candidateId = "cand-seed";
   db.prepare(
     `INSERT INTO contact_research_tasks (
-       tenant_id, task_id, employer, job_url, status, source_attempts_json,
+       tenant_id, task_id, employer, job_id, status, source_attempts_json,
        started_at, updated_at, needs_review_at
-     ) VALUES ('local', ?, 'Acme', 'https://job/1', 'needs_review', ?, ?, ?, ?)`,
+     ) VALUES ('local', ?, 'Acme', ?, 'needs_review', ?, ?, ?, ?)`,
   ).run(
     taskId,
+    JOB_ID_ONE,
     JSON.stringify([
       {
         sourceKind: "public_web_page",
@@ -123,6 +119,25 @@ function eventTypes(dbPath: string): string[] {
   return rows.map((row) => row.event_type);
 }
 
+function researchEvents(dbPath: string): Array<{
+  tenant_id: string;
+  job_id: string | null;
+  identity_version: number;
+  event_type: string;
+}> {
+  const db = new Database(dbPath);
+  const rows = db
+    .prepare("SELECT tenant_id, job_id, identity_version, event_type FROM job_events")
+    .all() as Array<{
+    tenant_id: string;
+    job_id: string | null;
+    identity_version: number;
+    event_type: string;
+  }>;
+  db.close();
+  return rows;
+}
+
 function eventPayloadBlob(dbPath: string): string {
   const db = new Database(dbPath);
   const rows = db.prepare("SELECT payload_json FROM job_events").all() as Array<{
@@ -147,6 +162,7 @@ describe("contact research API", () => {
       url: "/v1/contacts/research",
       payload: {
         employer: "Acme",
+        jobId: JOB_ID_ONE,
         sources: [{ category: "public_web_page", url: TEAM_URL }],
       },
     });
@@ -157,6 +173,7 @@ describe("contact research API", () => {
     expect(starter).toHaveBeenCalledTimes(1);
     const input = starter.mock.calls[0]![0];
     expect(input.taskId).toBe(body.taskId);
+    expect(input.jobUrl).toBe(JOB_URL_ONE);
     expect(input.sources).toEqual([{ category: "public_web_page", url: TEAM_URL, label: "" }]);
 
     // The queued task is readable immediately and emitted a start event.
@@ -165,8 +182,15 @@ describe("contact research API", () => {
     ).json() as ContactResearchListResponse;
     expect(list.items).toHaveLength(1);
     expect(list.items[0]!.taskId).toBe(body.taskId);
+    expect(list.items[0]!.jobId).toBe(JOB_ID_ONE);
     expect(list.items[0]!.status).toBe("queued");
     expect(eventTypes(dbPath)).toContain("ContactResearchTaskStarted");
+    expect(researchEvents(dbPath)).toContainEqual({
+      tenant_id: "local",
+      job_id: JOB_ID_ONE,
+      identity_version: 1,
+      event_type: "ContactResearchTaskStarted",
+    });
   });
 
   it("rejects a run scoped to neither employer nor jobId", async () => {
@@ -182,6 +206,43 @@ describe("contact research API", () => {
       payload: { sources: [] },
     });
     expect(res.statusCode).toBe(400);
+  });
+
+  it("rejects a URL-shaped JobId before research rows or events are written", async () => {
+    const { app, dbPath } = withTempApp(async () => ({
+      runId: null,
+      workflowId: null,
+      firstExecutionRunId: null,
+      status: "queued",
+    }));
+    const res = await app.inject({
+      method: "POST",
+      url: "/v1/contacts/research",
+      payload: { employer: "Acme", jobId: "https://jobs.example.test/not-an-id" },
+    });
+    expect(res.statusCode).toBe(400);
+    const db = new Database(dbPath, { readonly: true });
+    expect(
+      (db.prepare("SELECT COUNT(*) AS count FROM contact_research_tasks").get() as { count: number })
+        .count,
+    ).toBe(0);
+    expect((db.prepare("SELECT COUNT(*) AS count FROM job_events").get() as { count: number }).count).toBe(0);
+    db.close();
+  });
+
+  it("rejects noncanonical JobId list filters before opening the database", async () => {
+    const { app } = withTempApp();
+    for (const jobId of [
+      "ABCDEFAB-CDEF-4ABC-8DEF-ABCDEFABCDEF",
+      "https://jobs.example.test/not-an-id",
+    ]) {
+      const res = await app.inject({
+        method: "GET",
+        url: `/v1/contacts/research?jobId=${encodeURIComponent(jobId)}`,
+      });
+      expect(res.statusCode).toBe(400);
+      expect(res.json()).toEqual({ ok: false, error: "invalid_contact_research_query" });
+    }
   });
 
   it("renders each candidate's attributes with provenance and the source attempts (INV-2)", async () => {

--- a/apps/api/test/qa-seed.ts
+++ b/apps/api/test/qa-seed.ts
@@ -302,6 +302,7 @@ export function seedQaDatabase(dbPath: string, options: QaSeedOptions = {}): voi
 
   seedPipelineOperations(db, dbPath);
   seedContacts(db);
+  seedContactResearch(db);
   if (options.includeDocumentationAnalytics) {
     seedOutcomeAnalytics(db);
   }
@@ -1273,6 +1274,23 @@ function seedContacts(db: Database.Database): void {
   ] as const) {
     insertAttribute.run(attributeId, contactId, kind, JSON.stringify(value), QA_NOW);
   }
+}
+
+function seedContactResearch(db: Database.Database): void {
+  db.prepare(
+    `INSERT INTO contact_research_tasks (
+       tenant_id, task_id, employer, job_id, status, source_attempts_json,
+       started_at, updated_at
+     ) VALUES ('local', ?, 'GitLab', ?, 'queued', '[]', ?, ?)`,
+  ).run("qa-contact-research-platform", QA_PLATFORM_JOB_ID, QA_NOW, QA_NOW);
+  db.prepare(
+    `INSERT INTO contact_research_task_projections (
+       tenant_id, task_id, employer, job_id, status,
+       candidate_count, needs_review_count, confirmed_count,
+       source_attempts_json, candidates_json, started_at, updated_at,
+       needs_review_at, completed_at, failed_at, error_class, last_updated_at
+     ) VALUES ('local', ?, 'GitLab', ?, 'queued', 0, 0, 0, '[]', '[]', ?, ?, NULL, NULL, NULL, NULL, ?)`,
+  ).run("qa-contact-research-platform", QA_PLATFORM_JOB_ID, QA_NOW, QA_NOW, QA_NOW);
 }
 
 function seedOutcomeAnalytics(db: Database.Database): void {

--- a/packages/contracts/src/schemas.ts
+++ b/packages/contracts/src/schemas.ts
@@ -5476,7 +5476,6 @@ export const ContactAttributeInputSchema = z
 export type ContactAttributeInput = z.infer<typeof ContactAttributeInputSchema>;
 
 const contactEmployerField = z.string().trim().min(1).max(200).nullish();
-const contactJobIdField = z.string().trim().min(1).max(2000).nullish();
 const contactApiJobIdField = z
   .string()
   .trim()
@@ -5664,7 +5663,7 @@ export type ContactResearchSourceRequest = z.infer<typeof ContactResearchSourceR
 export const RunContactResearchRequestSchema = z
   .object({
     employer: contactEmployerField,
-    jobId: contactJobIdField,
+    jobId: contactApiJobIdField,
     sources: z.array(ContactResearchSourceRequestSchema).max(25).default([]),
     llmModel: z.string().trim().min(1).max(120).optional(),
   })
@@ -5677,7 +5676,7 @@ export type RunContactResearchRequest = z.infer<typeof RunContactResearchRequest
 
 export const ContactResearchListQuerySchema = z
   .object({
-    jobId: optionalText,
+    jobId: contactApiJobIdField,
     employer: optionalText,
   })
   .strict();

--- a/packages/domain-types/test/fixtures/contact_research_projection_parity.json
+++ b/packages/domain-types/test/fixtures/contact_research_projection_parity.json
@@ -1,128 +1,102 @@
 {
-  "tenantId": "local",
-  "tasks": [
+  "_comment": "Cross-runtime exact-v7 parity fixture for contact_research_task_projections. TypeScript and Python seed each tenant's canonical jobs, research tasks, and candidates directly, then refresh only that tenant's research projection. URLs are source provenance; jobId is the tenant-scoped root identity.",
+  "tenants": [
     {
-      "taskId": "task-a",
-      "employer": "Acme",
-      "jobUrl": "https://job/1",
-      "status": "needs_review",
-      "sourceAttempts": [
+      "tenantId": "local",
+      "jobs": [
         {
-          "sourceKind": "public_web_page",
-          "sourceRef": "https://acme.example/team",
-          "outcome": "allowed",
-          "attemptedAt": "2026-07-06T00:00:00Z",
-          "detail": "proposed:1"
+          "jobId": "11111111-1111-4111-8111-111111111111",
+          "url": "https://job/1"
         },
         {
-          "sourceKind": "public_web_page",
-          "sourceRef": "https://acme.example/login",
-          "outcome": "manual_capture_required",
-          "attemptedAt": "2026-07-06T00:00:01Z",
-          "detail": "login_required"
+          "jobId": "22222222-2222-4222-8222-222222222222",
+          "url": "https://job/2"
         }
       ],
-      "startedAt": "2026-07-06T00:00:00Z",
-      "updatedAt": "2026-07-06T00:00:02Z",
-      "needsReviewAt": "2026-07-06T00:00:02Z",
-      "completedAt": null,
-      "failedAt": null,
-      "errorClass": null
-    },
-    {
-      "taskId": "task-b",
-      "employer": null,
-      "jobUrl": "https://job/2",
-      "status": "failed",
-      "sourceAttempts": [
+      "tasks": [
         {
-          "sourceKind": "public_web_page",
-          "sourceRef": "https://beta.example/people",
-          "outcome": "rate_limited",
-          "attemptedAt": "2026-07-06T00:01:00Z",
-          "detail": ""
-        }
-      ],
-      "startedAt": "2026-07-06T00:01:00Z",
-      "updatedAt": "2026-07-06T00:01:01Z",
-      "needsReviewAt": null,
-      "completedAt": null,
-      "failedAt": "2026-07-06T00:01:01Z",
-      "errorClass": "contact_research_activity_failed"
-    }
-  ],
-  "candidates": [
-    {
-      "candidateId": "cand-a",
-      "taskId": "task-a",
-      "role": "hiring_manager",
-      "attributes": [
-        {
-          "attributeId": "attr-a",
-          "kind": "name",
-          "value": "Dana Hiring-Manager",
-          "provenance": {
-            "source_kind": "public_web_page",
-            "source_ref": "https://acme.example/team",
-            "capture_method": "llm_assisted",
-            "captured_at": "2026-07-06T00:00:00Z",
-            "confidence": 0.8,
-            "user_confirmed": false
-          }
+          "taskId": "task-a",
+          "employer": "Acme",
+          "jobId": "11111111-1111-4111-8111-111111111111",
+          "status": "needs_review",
+          "sourceAttempts": [
+            {
+              "sourceKind": "public_web_page",
+              "sourceRef": "https://acme.example/team",
+              "outcome": "allowed",
+              "attemptedAt": "2026-07-06T00:00:00Z",
+              "detail": "proposed:1"
+            },
+            {
+              "sourceKind": "public_web_page",
+              "sourceRef": "https://acme.example/login",
+              "outcome": "manual_capture_required",
+              "attemptedAt": "2026-07-06T00:00:01Z",
+              "detail": "login_required"
+            }
+          ],
+          "startedAt": "2026-07-06T00:00:00Z",
+          "updatedAt": "2026-07-06T00:00:02Z",
+          "needsReviewAt": "2026-07-06T00:00:02Z",
+          "completedAt": null,
+          "failedAt": null,
+          "errorClass": null
         },
         {
-          "attributeId": "attr-b",
-          "kind": "email",
-          "value": "dana@acme.example",
-          "provenance": {
-            "source_kind": "public_web_page",
-            "source_ref": "https://acme.example/team",
-            "capture_method": "llm_assisted",
-            "captured_at": "2026-07-06T00:00:00Z",
-            "confidence": 0.8,
-            "user_confirmed": false
-          }
-        }
-      ],
-      "sourceKind": "public_web_page",
-      "sourceRef": "https://acme.example/team",
-      "captureMethod": "llm_assisted",
-      "confidence": 0.8,
-      "status": "needs_review",
-      "proposedAt": "2026-07-06T00:00:00Z",
-      "confirmedContactId": null,
-      "confirmedAt": null
-    }
-  ],
-  "expected": [
-    {
-      "taskId": "task-a",
-      "employer": "Acme",
-      "jobId": "https://job/1",
-      "status": "needs_review",
-      "candidateCount": 1,
-      "needsReviewCount": 1,
-      "confirmedCount": 0,
-      "sourceAttempts": [
-        {
-          "sourceKind": "public_web_page",
-          "sourceRef": "https://acme.example/team",
-          "outcome": "allowed",
-          "attemptedAt": "2026-07-06T00:00:00Z",
-          "detail": "proposed:1"
-        },
-        {
-          "sourceKind": "public_web_page",
-          "sourceRef": "https://acme.example/login",
-          "outcome": "manual_capture_required",
-          "attemptedAt": "2026-07-06T00:00:01Z",
-          "detail": "login_required"
+          "taskId": "task-b",
+          "employer": null,
+          "jobId": "22222222-2222-4222-8222-222222222222",
+          "status": "failed",
+          "sourceAttempts": [
+            {
+              "sourceKind": "public_web_page",
+              "sourceRef": "https://beta.example/people",
+              "outcome": "rate_limited",
+              "attemptedAt": "2026-07-06T00:01:00Z",
+              "detail": ""
+            }
+          ],
+          "startedAt": "2026-07-06T00:01:00Z",
+          "updatedAt": "2026-07-06T00:01:01Z",
+          "needsReviewAt": null,
+          "completedAt": null,
+          "failedAt": "2026-07-06T00:01:01Z",
+          "errorClass": "contact_research_activity_failed"
         }
       ],
       "candidates": [
         {
           "candidateId": "cand-a",
+          "taskId": "task-a",
           "role": "hiring_manager",
+          "attributes": [
+            {
+              "attributeId": "attr-a",
+              "kind": "name",
+              "value": "Dana Hiring-Manager",
+              "provenance": {
+                "source_kind": "public_web_page",
+                "source_ref": "https://acme.example/team",
+                "capture_method": "llm_assisted",
+                "captured_at": "2026-07-06T00:00:00Z",
+                "confidence": 0.8,
+                "user_confirmed": false
+              }
+            },
+            {
+              "attributeId": "attr-b",
+              "kind": "email",
+              "value": "dana@acme.example",
+              "provenance": {
+                "source_kind": "public_web_page",
+                "source_ref": "https://acme.example/team",
+                "capture_method": "llm_assisted",
+                "captured_at": "2026-07-06T00:00:00Z",
+                "confidence": 0.8,
+                "user_confirmed": false
+              }
+            }
+          ],
           "sourceKind": "public_web_page",
           "sourceRef": "https://acme.example/team",
           "captureMethod": "llm_assisted",
@@ -130,41 +104,126 @@
           "status": "needs_review",
           "proposedAt": "2026-07-06T00:00:00Z",
           "confirmedContactId": null,
-          "confirmedAt": null,
-          "attributeKinds": ["name", "email"]
+          "confirmedAt": null
         }
       ],
-      "startedAt": "2026-07-06T00:00:00Z",
-      "updatedAt": "2026-07-06T00:00:02Z",
-      "needsReviewAt": "2026-07-06T00:00:02Z",
-      "completedAt": null,
-      "failedAt": null,
-      "errorClass": null
+      "expected": [
+        {
+          "taskId": "task-a",
+          "employer": "Acme",
+          "jobId": "11111111-1111-4111-8111-111111111111",
+          "status": "needs_review",
+          "candidateCount": 1,
+          "needsReviewCount": 1,
+          "confirmedCount": 0,
+          "sourceAttempts": [
+            {
+              "sourceKind": "public_web_page",
+              "sourceRef": "https://acme.example/team",
+              "outcome": "allowed",
+              "attemptedAt": "2026-07-06T00:00:00Z",
+              "detail": "proposed:1"
+            },
+            {
+              "sourceKind": "public_web_page",
+              "sourceRef": "https://acme.example/login",
+              "outcome": "manual_capture_required",
+              "attemptedAt": "2026-07-06T00:00:01Z",
+              "detail": "login_required"
+            }
+          ],
+          "candidates": [
+            {
+              "candidateId": "cand-a",
+              "role": "hiring_manager",
+              "sourceKind": "public_web_page",
+              "sourceRef": "https://acme.example/team",
+              "captureMethod": "llm_assisted",
+              "confidence": 0.8,
+              "status": "needs_review",
+              "proposedAt": "2026-07-06T00:00:00Z",
+              "confirmedContactId": null,
+              "confirmedAt": null,
+              "attributeKinds": ["name", "email"]
+            }
+          ],
+          "startedAt": "2026-07-06T00:00:00Z",
+          "updatedAt": "2026-07-06T00:00:02Z",
+          "needsReviewAt": "2026-07-06T00:00:02Z",
+          "completedAt": null,
+          "failedAt": null,
+          "errorClass": null
+        },
+        {
+          "taskId": "task-b",
+          "employer": null,
+          "jobId": "22222222-2222-4222-8222-222222222222",
+          "status": "failed",
+          "candidateCount": 0,
+          "needsReviewCount": 0,
+          "confirmedCount": 0,
+          "sourceAttempts": [
+            {
+              "sourceKind": "public_web_page",
+              "sourceRef": "https://beta.example/people",
+              "outcome": "rate_limited",
+              "attemptedAt": "2026-07-06T00:01:00Z",
+              "detail": ""
+            }
+          ],
+          "candidates": [],
+          "startedAt": "2026-07-06T00:01:00Z",
+          "updatedAt": "2026-07-06T00:01:01Z",
+          "needsReviewAt": null,
+          "completedAt": null,
+          "failedAt": "2026-07-06T00:01:01Z",
+          "errorClass": "contact_research_activity_failed"
+        }
+      ]
     },
     {
-      "taskId": "task-b",
-      "employer": null,
-      "jobId": "https://job/2",
-      "status": "failed",
-      "candidateCount": 0,
-      "needsReviewCount": 0,
-      "confirmedCount": 0,
-      "sourceAttempts": [
+      "tenantId": "other",
+      "jobs": [
         {
-          "sourceKind": "public_web_page",
-          "sourceRef": "https://beta.example/people",
-          "outcome": "rate_limited",
-          "attemptedAt": "2026-07-06T00:01:00Z",
-          "detail": ""
+          "jobId": "11111111-1111-4111-8111-111111111111",
+          "url": "https://other.example/jobs/one"
+        }
+      ],
+      "tasks": [
+        {
+          "taskId": "task-other",
+          "employer": "Other Corp",
+          "jobId": "11111111-1111-4111-8111-111111111111",
+          "status": "queued",
+          "sourceAttempts": [],
+          "startedAt": "2026-07-07T00:00:00Z",
+          "updatedAt": "2026-07-07T00:00:00Z",
+          "needsReviewAt": null,
+          "completedAt": null,
+          "failedAt": null,
+          "errorClass": null
         }
       ],
       "candidates": [],
-      "startedAt": "2026-07-06T00:01:00Z",
-      "updatedAt": "2026-07-06T00:01:01Z",
-      "needsReviewAt": null,
-      "completedAt": null,
-      "failedAt": "2026-07-06T00:01:01Z",
-      "errorClass": "contact_research_activity_failed"
+      "expected": [
+        {
+          "taskId": "task-other",
+          "employer": "Other Corp",
+          "jobId": "11111111-1111-4111-8111-111111111111",
+          "status": "queued",
+          "candidateCount": 0,
+          "needsReviewCount": 0,
+          "confirmedCount": 0,
+          "sourceAttempts": [],
+          "candidates": [],
+          "startedAt": "2026-07-07T00:00:00Z",
+          "updatedAt": "2026-07-07T00:00:00Z",
+          "needsReviewAt": null,
+          "completedAt": null,
+          "failedAt": null,
+          "errorClass": null
+        }
+      ]
     }
   ],
   "sensitiveValues": ["Dana Hiring-Manager", "dana@acme.example"]

--- a/workers/automation/tests/test_contact_research_projection_parity.py
+++ b/workers/automation/tests/test_contact_research_projection_parity.py
@@ -1,9 +1,4 @@
-"""Exact-v7 coverage for ``contact_research_task_projections`` (R6 Phase 2).
-
-The shared parity fixture remains on the legacy TypeScript projection contract.
-This test derives a local exact-v7 fixture using canonical JobIds, then asserts
-the projection rows and the sensitive-value boundary.
-"""
+"""Cross-runtime exact-v7 coverage for ``contact_research_task_projections``."""
 
 from __future__ import annotations
 
@@ -12,9 +7,9 @@ import sqlite3
 from pathlib import Path
 from typing import Any
 
-from jobctrl.database import init_db
-from jobctrl.domain.tenant import LOCAL_TENANT
+from jobctrl.domain.tenant import TenantId
 from jobctrl.infrastructure.events.in_process_bus import InProcessEventBus
+from jobctrl.infrastructure.migrations.schema_v7 import create_exact_v7_schema
 from jobctrl.infrastructure.projections.projection_builder import ProjectionBuilder
 from jobctrl.infrastructure.projections.sqlite_projection_store import SqliteProjectionStore
 
@@ -22,36 +17,19 @@ _FIXTURE = (
     Path(__file__).resolve().parents[3]
     / "packages/domain-types/test/fixtures/contact_research_projection_parity.json"
 )
-_V7_JOB_IDS = {
-    "https://job/1": "11111111-1111-4111-8111-111111111111",
-    "https://job/2": "22222222-2222-4222-8222-222222222222",
-}
 
 
-def _exact_v7_fixture() -> dict[str, Any]:
-    fixture = json.loads(_FIXTURE.read_text())
-    for task in fixture["tasks"]:
-        job_url = task.pop("jobUrl")
-        task["jobId"] = _V7_JOB_IDS[job_url] if job_url else None
-    for expected in fixture["expected"]:
-        job_url = expected.get("jobId")
-        expected["jobId"] = _V7_JOB_IDS[job_url] if job_url else None
-    return fixture
-
-
-def _seed_canonical(conn: sqlite3.Connection, fixture: dict[str, Any]) -> None:
-    tenant = fixture["tenantId"]
-    for task in fixture["tasks"]:
-        if task["jobId"] is None:
-            continue
+def _seed_canonical(conn: sqlite3.Connection, tenant: dict[str, Any]) -> None:
+    tenant_id = tenant["tenantId"]
+    for job in tenant["jobs"]:
         conn.execute(
             """
             INSERT INTO jobs (tenant_id, job_id, url, title, discovered_at)
             VALUES (?, ?, ?, 'Fixture job', '2026-07-31T12:00:00Z')
             """,
-            (tenant, task["jobId"], f"https://fixtures.example/{task['taskId']}"),
+            (tenant_id, job["jobId"], job["url"]),
         )
-    for task in fixture["tasks"]:
+    for task in tenant["tasks"]:
         conn.execute(
             """
             INSERT INTO contact_research_tasks (
@@ -60,7 +38,7 @@ def _seed_canonical(conn: sqlite3.Connection, fixture: dict[str, Any]) -> None:
             ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
-                tenant,
+                tenant_id,
                 task["taskId"],
                 task["employer"],
                 task["jobId"],
@@ -74,7 +52,7 @@ def _seed_canonical(conn: sqlite3.Connection, fixture: dict[str, Any]) -> None:
                 task["errorClass"],
             ),
         )
-    for candidate in fixture["candidates"]:
+    for candidate in tenant["candidates"]:
         conn.execute(
             """
             INSERT INTO contact_candidates (
@@ -84,7 +62,7 @@ def _seed_canonical(conn: sqlite3.Connection, fixture: dict[str, Any]) -> None:
             ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
-                tenant,
+                tenant_id,
                 candidate["candidateId"],
                 candidate["taskId"],
                 candidate["role"],
@@ -99,7 +77,6 @@ def _seed_canonical(conn: sqlite3.Connection, fixture: dict[str, Any]) -> None:
                 candidate["confirmedAt"],
             ),
         )
-    conn.commit()
 
 
 def _normalize(row: sqlite3.Row) -> dict[str, Any]:
@@ -122,23 +99,38 @@ def _normalize(row: sqlite3.Row) -> dict[str, Any]:
     }
 
 
-def test_contact_research_projection_exact_v7_fixture(tmp_path: Path) -> None:
-    fixture = _exact_v7_fixture()
-    conn = init_db(tmp_path / "jobctrl.db")
-    conn.row_factory = sqlite3.Row
-    _seed_canonical(conn, fixture)
-
-    builder = ProjectionBuilder(conn_factory=lambda: conn, tenant_id=LOCAL_TENANT)
+def _projected(conn: sqlite3.Connection, tenant: dict[str, Any]) -> list[dict[str, Any]]:
+    tenant_id = TenantId(tenant["tenantId"])
+    builder = ProjectionBuilder(conn_factory=lambda: conn, tenant_id=tenant_id)
     builder.subscribe_to(InProcessEventBus())
     builder.refresh()
+    rows = SqliteProjectionStore(conn).fetch_contact_research_tasks(str(tenant_id))
+    return sorted((_normalize(row) for row in rows), key=lambda item: item["taskId"])
 
-    rows = SqliteProjectionStore(conn).fetch_contact_research_tasks("local")
-    projected = sorted((_normalize(row) for row in rows), key=lambda item: item["taskId"])
-    expected = sorted(fixture["expected"], key=lambda item: item["taskId"])
-    assert projected == expected
+
+def _expected(tenant: dict[str, Any]) -> list[dict[str, Any]]:
+    return sorted(tenant["expected"], key=lambda item: item["taskId"])
+
+
+def test_contact_research_projection_exact_v7_fixture_is_tenant_scoped() -> None:
+    fixture = json.loads(_FIXTURE.read_text())
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys = ON")
+    create_exact_v7_schema(conn)
+    for tenant in fixture["tenants"]:
+        _seed_canonical(conn, tenant)
+
+    local, other = fixture["tenants"]
+    assert _projected(conn, local) == _expected(local)
+    assert SqliteProjectionStore(conn).fetch_contact_research_tasks(other["tenantId"]) == []
+    assert _projected(conn, other) == _expected(other)
+    assert _projected(conn, local) == _expected(local)
 
     projection_text = " ".join(
-        " ".join(str(value) for value in tuple(row)) for row in rows
+        " ".join(str(value) for value in tuple(row))
+        for row in SqliteProjectionStore(conn).fetch_contact_research_tasks(local["tenantId"])
+        + SqliteProjectionStore(conn).fetch_contact_research_tasks(other["tenantId"])
     )
     for secret in fixture["sensitiveValues"]:
         assert secret not in projection_text


### PR DESCRIPTION
## Summary

-

## Validation

-

## Checklist

- [ ] External contributor commits include a DCO `Signed-off-by:` trailer (`git commit -s`).
- [ ] I ran the relevant local checks and listed them above. Heavy CI runs automatically for ordinary same-repository pull requests and cumulative stack heads, but not public forks; maintainers run manual workflows or local validation for fork contributions after review.
- [ ] I did not include secrets, private profile data, resumes, generated application materials, raw logs, browser profiles, SQLite databases, or local paths.