### PR TITLE
refactor(contact-research): dispatch canonical job ids

### DIFF
--- a/apps/api/src/local-actions.ts
+++ b/apps/api/src/local-actions.ts
@@ -200,7 +200,7 @@ export const defaultActionDispatcher: ActionDispatcher = createActionDispatcher(
 export interface ContactResearchStartInput {
   taskId: string;
   employer: string | null;
-  jobUrl: string | null;
+  jobId: string | null;
   sources: { category: string; url: string; label: string }[];
   llmModel?: string;
 }
@@ -220,16 +220,17 @@ export type ContactResearchStarter = (
 /** Start a supervised research run on the Python worker via JSON-RPC / Temporal. */
 export function createContactResearchStarter(
   pythonRuntime: PythonRuntimeCommandResolver = defaultSourcePythonRuntime,
+  dispatcherFactory: JsonRpcDispatcherFactory = createRuntimeJsonRpcDispatcherFactory(pythonRuntime),
 ): ContactResearchStarter {
   return async (input, context) => {
-    const rpc = getDefaultJsonRpcDispatcher({ appDir: context.appDir, pythonRuntime });
+    const rpc = dispatcherFactory(context);
     const response = await rpc.call("run_contact_research", {
       tenantId: "local",
       expectedAppDir: context.appDir,
       expectedDbPath: context.dbPath,
       taskId: input.taskId,
       ...(input.employer ? { employer: input.employer } : {}),
-      ...(input.jobUrl ? { jobUrl: input.jobUrl } : {}),
+      ...(input.jobId ? { jobId: input.jobId } : {}),
       sources: input.sources,
       llmModel: input.llmModel ?? DEFAULT_PIPELINE_LLM_MODEL,
     });

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -2712,12 +2712,12 @@ export function buildApp(options: BuildAppOptions): FastifyInstance {
       label: source.label,
     }));
     return withWritableDb(reply, options.dbPath, async (db) => {
-      const jobUrl = jobId
+      const storedJobId = jobId
         ? (db
-            .prepare("SELECT url FROM jobs WHERE tenant_id = ? AND job_id = ?")
-            .get("local", jobId) as { url: string } | undefined)?.url ?? null
+            .prepare("SELECT job_id FROM jobs WHERE tenant_id = ? AND job_id = ?")
+            .get("local", jobId) as { job_id: string } | undefined)?.job_id ?? null
         : null;
-      if (jobId && !jobUrl) {
+      if (jobId && !storedJobId) {
         void reply.code(404);
         return { ok: false, error: "contact_research_job_not_found" };
       }
@@ -2726,7 +2726,7 @@ export function buildApp(options: BuildAppOptions): FastifyInstance {
         {
           taskId,
           employer,
-          jobUrl,
+          jobId,
           sources,
           ...(body.llmModel ? { llmModel: body.llmModel } : {}),
         },

--- a/apps/api/test/contact-research.test.ts
+++ b/apps/api/test/contact-research.test.ts
@@ -173,7 +173,7 @@ describe("contact research API", () => {
     expect(starter).toHaveBeenCalledTimes(1);
     const input = starter.mock.calls[0]![0];
     expect(input.taskId).toBe(body.taskId);
-    expect(input.jobUrl).toBe(JOB_URL_ONE);
+    expect(input.jobId).toBe(JOB_ID_ONE);
     expect(input.sources).toEqual([{ category: "public_web_page", url: TEAM_URL, label: "" }]);
 
     // The queued task is readable immediately and emitted a start event.
@@ -221,6 +221,30 @@ describe("contact research API", () => {
       payload: { employer: "Acme", jobId: "https://jobs.example.test/not-an-id" },
     });
     expect(res.statusCode).toBe(400);
+    const db = new Database(dbPath, { readonly: true });
+    expect(
+      (db.prepare("SELECT COUNT(*) AS count FROM contact_research_tasks").get() as { count: number })
+        .count,
+    ).toBe(0);
+    expect((db.prepare("SELECT COUNT(*) AS count FROM job_events").get() as { count: number }).count).toBe(0);
+    db.close();
+  });
+
+  it("rejects an unknown canonical JobId before dispatch", async () => {
+    const starter = vi.fn<ContactResearchStarter>();
+    const { app, dbPath } = withTempApp(starter);
+    const res = await app.inject({
+      method: "POST",
+      url: "/v1/contacts/research",
+      payload: {
+        employer: "Acme",
+        jobId: "00000000-0000-4000-8000-000000000099",
+        sources: [{ category: "public_web_page", url: TEAM_URL }],
+      },
+    });
+    expect(res.statusCode).toBe(404);
+    expect(res.json()).toEqual({ ok: false, error: "contact_research_job_not_found" });
+    expect(starter).not.toHaveBeenCalled();
     const db = new Database(dbPath, { readonly: true });
     expect(
       (db.prepare("SELECT COUNT(*) AS count FROM contact_research_tasks").get() as { count: number })

--- a/apps/api/test/json-rpc-adapter.test.ts
+++ b/apps/api/test/json-rpc-adapter.test.ts
@@ -15,6 +15,7 @@ import { DEFAULT_PIPELINE_LLM_MODEL, PIPELINE_ACTION_JOB_KEY, type ActionCommand
 import {
   buildActionResponse,
   createActionDispatcher,
+  createContactResearchStarter,
   type ActionDispatchResult,
   type JsonRpcDispatcherFactory,
 } from "../src/local-actions.js";
@@ -47,6 +48,67 @@ class FakeDispatcher implements JsonRpcDispatcher {
     /* no-op */
   }
 }
+
+describe("createContactResearchStarter (JSON-RPC adapter)", () => {
+  it("dispatches only the canonical JobId to the worker", async () => {
+    const fake = new FakeDispatcher();
+    fake.setResponse({
+      jsonrpc: "2.0",
+      id: 1,
+      result: {
+        runId: "run-contact",
+        workflowId: "contact-research-task-1",
+        firstExecutionRunId: "run-contact",
+      },
+    });
+    const factory = vi.fn<JsonRpcDispatcherFactory>(() => fake);
+    const starter = createContactResearchStarter(undefined, factory);
+
+    const result = await starter(
+      {
+        taskId: "task-1",
+        employer: "Acme",
+        jobId: CANONICAL_JOB_ID,
+        sources: [
+          {
+            category: "public_web_page",
+            url: "https://example.com/team",
+            label: "Team",
+          },
+        ],
+      },
+      { appDir: "/tmp", dbPath: "/tmp/jobctrl.db" },
+    );
+
+    expect(fake.calls).toEqual([
+      {
+        method: "run_contact_research",
+        params: {
+          tenantId: "local",
+          expectedAppDir: "/tmp",
+          expectedDbPath: "/tmp/jobctrl.db",
+          taskId: "task-1",
+          employer: "Acme",
+          jobId: CANONICAL_JOB_ID,
+          sources: [
+            {
+              category: "public_web_page",
+              url: "https://example.com/team",
+              label: "Team",
+            },
+          ],
+          llmModel: DEFAULT_PIPELINE_LLM_MODEL,
+        },
+      },
+    ]);
+    expect(result).toEqual({
+      runId: "run-contact",
+      workflowId: "contact-research-task-1",
+      firstExecutionRunId: "run-contact",
+      status: "queued",
+    });
+  });
+});
 
 describe("createActionDispatcher (JSON-RPC adapter)", () => {
   it("maps an apply action to the apply RPC method", async () => {

--- a/apps/api/test/rpc-contracts.test.ts
+++ b/apps/api/test/rpc-contracts.test.ts
@@ -24,6 +24,7 @@ import {
   RetailorCurrentPolicyParamsSchema,
   RetailorJobParamsSchema,
   RpcMethods,
+  RunContactResearchParamsSchema,
   RunStageParamsSchema,
   SettingsUpdateRequestSchema,
   TailorJobParamsSchema,
@@ -208,6 +209,55 @@ describe("manual_capture_import RPC contract", () => {
       item_id: "manual-1",
       job_id: "https://example.test/jobs/1",
     });
+  });
+});
+
+describe("run_contact_research RPC contract", () => {
+  it("registers canonical job-scoped research", () => {
+    expect(RpcMethods.RunContactResearch).toBe("run_contact_research");
+    expect(
+      RunContactResearchParamsSchema.parse({
+        taskId: "contact-research-1",
+        jobId: CANONICAL_JOB_ID,
+      }),
+    ).toMatchObject({
+      tenantId: "local",
+      taskId: "contact-research-1",
+      jobId: CANONICAL_JOB_ID,
+    });
+  });
+
+  it("accepts an employer-scoped research request", () => {
+    expect(
+      RunContactResearchParamsSchema.parse({
+        taskId: "contact-research-1",
+        employer: "Acme",
+      }),
+    ).toMatchObject({
+      tenantId: "local",
+      employer: "Acme",
+    });
+  });
+
+  it("rejects URL-shaped job IDs and legacy job URLs", () => {
+    expect(() =>
+      RunContactResearchParamsSchema.parse({
+        taskId: "contact-research-1",
+        jobId: "https://example.test/jobs/1",
+      }),
+    ).toThrow();
+    expect(() =>
+      RunContactResearchParamsSchema.parse({
+        taskId: "contact-research-1",
+        jobUrl: "https://example.test/jobs/1",
+      }),
+    ).toThrow();
+  });
+
+  it("rejects research requests without an employer or job ID", () => {
+    expect(() =>
+      RunContactResearchParamsSchema.parse({ taskId: "contact-research-1" }),
+    ).toThrow();
   });
 });
 

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -335,13 +335,13 @@ export const RunContactResearchParamsSchema = z
     expectedDbPath: z.string().trim().min(1).optional(),
     taskId: z.string().trim().min(1).max(200),
     employer: z.string().trim().min(1).max(200).nullish(),
-    jobUrl: z.string().trim().min(1).max(2000).nullish(),
+    jobId: CanonicalJobIdParam.optional(),
     sources: z.array(ContactResearchSourceInputSchema).max(25).default([]),
     llmModel: z.string().trim().min(1).max(120).default(DEFAULT_PIPELINE_LLM_MODEL),
   })
   .strict()
-  .refine((params) => Boolean(params.employer) || Boolean(params.jobUrl), {
-    message: "provide at least one of employer or jobUrl",
+  .refine((params) => Boolean(params.employer) || Boolean(params.jobId), {
+    message: "provide at least one of employer or jobId",
     path: ["employer"],
   });
 export type RunContactResearchParams = z.infer<typeof RunContactResearchParamsSchema>;

--- a/workers/automation/src/jobctrl/infrastructure/rpc/handlers.py
+++ b/workers/automation/src/jobctrl/infrastructure/rpc/handlers.py
@@ -645,19 +645,19 @@ def run_contact_research(params: dict[str, Any]) -> WorkflowStartSpec:
     require an explicit user confirmation before becoming stored facts (INV-4).
     """
     try:
-        if "jobId" in params:
-            raise invalid_params("run_contact_research accepts jobUrl only at the RPC boundary")
+        _reject_job_url_params(params)
+        if "jobIds" in params:
+            raise invalid_params("jobIds is not supported by contact research; use jobId")
         tenant_id = TenantId(_tenant_id(params))
-        job_url = str(params.get("jobUrl") or "").strip()
         spec_params = dict(params)
-        spec_params.pop("jobUrl", None)
         spec_params["tenantId"] = str(tenant_id)
-        if job_url:
+        if "jobId" in params:
+            requested_job_id = _required_job_id(params)
             job_id = _job_id(
-                _load_current_job(
+                _load_current_job_by_id(
                     get_connection(),
                     tenant_id=tenant_id,
-                    job_url=job_url,
+                    job_id=requested_job_id,
                 )
             )
             spec_params["jobId"] = str(job_id)

--- a/workers/automation/tests/test_jsonrpc_handlers.py
+++ b/workers/automation/tests/test_jsonrpc_handlers.py
@@ -307,7 +307,7 @@ def test_generate_interview_prep_starts_user_triggered_workflow(tmp_db: Path) ->
     assert seen[1].workflow_id == seen[0].workflow_id
 
 
-def test_contact_research_resolves_job_url_only_at_rpc_boundary(tmp_db: Path) -> None:
+def test_contact_research_accepts_only_job_id_at_rpc_boundary(tmp_db: Path) -> None:
     seen: list[WorkflowStartSpec] = []
     job_url = "https://example.com/job/contact-research"
     source_url = "https://example.com/people"
@@ -328,7 +328,7 @@ def test_contact_research_resolves_job_url_only_at_rpc_boundary(tmp_db: Path) ->
                 "tenantId": "local",
                 "taskId": "contact-task-1",
                 "employer": "Example",
-                "jobUrl": job_url,
+                "jobId": str(job_id),
                 "sources": [
                     {
                         "category": "public_web_page",
@@ -369,7 +369,7 @@ def test_contact_research_resolves_job_url_only_at_rpc_boundary(tmp_db: Path) ->
                 "tenantId": "local",
                 "taskId": "contact-task-1",
                 "employer": "Example",
-                "jobUrl": job_url,
+                "jobId": str(job_id),
             },
             id=2,
         )
@@ -383,14 +383,14 @@ def test_contact_research_resolves_job_url_only_at_rpc_boundary(tmp_db: Path) ->
             params={
                 "tenantId": "local",
                 "taskId": "contact-task-2",
-                "jobId": str(job_id),
+                "jobUrl": job_url,
             },
             id=3,
         )
     )
     assert rejected is not None
     assert rejected.to_dict()["error"]["code"] == INVALID_PARAMS
-    assert "jobUrl only at the RPC boundary" in rejected.to_dict()["error"]["message"]
+    assert "jobUrl is not supported" in rejected.to_dict()["error"]["message"]
 
     with pytest.raises(ValueError, match="canonical UUID"):
         build_contact_research_workflow_spec(
@@ -1719,7 +1719,7 @@ def test_v7_apply_preserves_global_and_explicit_job_semantics(
 
 @pytest.mark.parametrize(
     "method",
-    ("tailor_job", "analyze_job", "generate_interview_prep"),
+    ("tailor_job", "analyze_job", "generate_interview_prep", "run_contact_research"),
 )
 def test_v7_canonical_job_ids_reject_unknown_and_deleted_jobs(
     tmp_db: Path,


### PR DESCRIPTION
## Summary

- resolve contact-research job locators in the TypeScript API and dispatch only canonical `jobId`
- expose canonical lowercase UUID `jobId` in the shared RPC contract and reject legacy `jobUrl` or URL-shaped IDs
- validate the canonical Job against the tenant-scoped current-job read model before starting research
- reject URL and plural selectors at the Python JSON-RPC boundary
- preserve employer-only research while making job-scoped workflow input and durable events `JobId`-based
- retain the supervised, needs-review-only contact research safety contract

## Why

The TypeScript starter already dispatches canonical identity. The Python boundary must accept that contract directly rather than expecting a removed URL lookup helper.

## Validation

- Python JSON-RPC handler suite: 79 passed
- TypeScript adapter and RPC contract suites: 60 passed
- focused contact-research Fastify regressions: 3 passed
- cumulative Step 3 Python suite: 185 passed
- cumulative focused API RPC/projection suite: 106 passed
- API typecheck: passed
- independent cumulative review: PASS, 0 Blocker / 0 High
- independent cumulative QA: PASS, 0 Blocker / 0 High

## Stack

Ready-for-review child of #653.
