### PR TITLE
test(discovery): align exact v7 runtime fixtures

### DIFF
--- a/workers/automation/tests/test_browser_capabilities.py
+++ b/workers/automation/tests/test_browser_capabilities.py
@@ -7,6 +7,7 @@ import os
 import stat
 import sys
 import threading
+import uuid
 from contextlib import contextmanager
 from pathlib import Path
 
@@ -266,7 +267,13 @@ def test_standing_apply_loop_rechecks_capability_before_the_next_candidate(
 
     def acquire(*_args, **_kwargs):
         candidates.append("claimed")
-        return {"url": "https://example.com/job", "title": "Engineer", "site": "Example"}
+        return {
+            "job_id": str(uuid.uuid4()),
+            "tenant_id": "local",
+            "url": "https://example.com/job",
+            "title": "Engineer",
+            "site": "Example",
+        }
 
     monkeypatch.setattr(browser_capabilities, "require_system_browser_capability", check_capability)
     monkeypatch.setattr(launcher, "acquire_job", acquire)

--- a/workers/automation/tests/test_browser_ua_propagation.py
+++ b/workers/automation/tests/test_browser_ua_propagation.py
@@ -22,6 +22,8 @@ import pytest
 
 from jobctrl.database import close_connection, init_db
 from jobctrl.discovery import smartextract
+from jobctrl.domain.identifiers import generate_job_id
+from jobctrl.domain.tenant import LOCAL_TENANT
 from jobctrl.domain.discovery.source_registry import (
     ENRICHMENT_CRAWL_POLICY,
     SMART_EXTRACT_EXPERIMENTAL_POLICY,
@@ -278,12 +280,35 @@ def test_enrichment_batch_context_uses_owner_overridden_ua(
     url = "https://example.test/jobs/1"
     try:
         conn.execute(
-            "INSERT INTO jobs (url, title, site, discovered_at) VALUES (?, ?, ?, ?)",
-            (url, "Engineer", "RemoteOK", "2026-01-01T00:00:00+00:00"),
+            """
+            INSERT INTO jobs (tenant_id, job_id, url, title, site, discovered_at)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (
+                str(LOCAL_TENANT),
+                str(generate_job_id()),
+                url,
+                "Engineer",
+                "RemoteOK",
+                "2026-01-01T00:00:00+00:00",
+            ),
+        )
+        job_id = conn.execute(
+            "SELECT job_id FROM jobs WHERE tenant_id = ? AND url = ?",
+            (str(LOCAL_TENANT), url),
+        ).fetchone()[0]
+        conn.execute(
+            """
+            INSERT INTO job_locators (
+                tenant_id, job_id, locator_kind, locator_value, is_current,
+                first_seen_at, last_seen_at, retired_at
+            ) VALUES (?, ?, 'posting_url', ?, 1, ?, ?, NULL)
+            """,
+            (str(LOCAL_TENANT), job_id, url, "2026-01-01T00:00:00+00:00", "2026-01-01T00:00:00+00:00"),
         )
         conn.commit()
 
-        detail.scrape_site_batch(conn, "RemoteOK", [(url, "Role")], gateway=gateway)
+        detail.scrape_site_batch(conn, "RemoteOK", [(job_id, "Role")], gateway=gateway)
 
         expected = _expected_ua()
         assert gateway.user_agent == expected

--- a/workers/automation/tests/test_discovery_execution_lineage.py
+++ b/workers/automation/tests/test_discovery_execution_lineage.py
@@ -19,7 +19,7 @@ from jobctrl.domain.enrichment import (
     FullDescription,
     JobEnrichment,
 )
-from jobctrl.domain.identifiers import JobId
+from jobctrl.domain.identifiers import JobId, generate_job_id
 from jobctrl.domain.tenant import LOCAL_TENANT
 from jobctrl.discovery.activities import (
     DiscoveryEnrichmentActivityInput,
@@ -50,12 +50,42 @@ def _execution(run_id: str, *, workflow_id: str = "discover-local") -> Discovery
 
 def _insert_job(conn: sqlite3.Connection, suffix: str) -> str:
     job_url = f"https://example.com/jobs/{suffix}"
+    job_id = generate_job_id()
     conn.execute(
-        "INSERT INTO jobs (url, title, discovered_at) VALUES (?, ?, ?)",
-        (job_url, f"Job {suffix}", "2026-07-14T08:00:00+00:00"),
+        """
+        INSERT INTO jobs (tenant_id, job_id, url, title, discovered_at)
+        VALUES (?, ?, ?, ?, ?)
+        """,
+        (str(LOCAL_TENANT), str(job_id), job_url, f"Job {suffix}", "2026-07-14T08:00:00+00:00"),
     )
     conn.commit()
     return job_url
+
+
+def _job_id(conn: sqlite3.Connection, job_url: str) -> JobId:
+    row = conn.execute(
+        "SELECT job_id FROM jobs WHERE tenant_id = ? AND url = ?",
+        (str(LOCAL_TENANT), job_url),
+    ).fetchone()
+    assert row is not None
+    return JobId(str(row["job_id"]))
+
+
+def _set_score(conn: sqlite3.Connection, job_url: str, score: int) -> None:
+    conn.execute(
+        """
+        INSERT INTO job_scores (
+            tenant_id, job_id, version, fit_score, breakdown_json, keywords_json,
+            scored_at, criteria_json, trace_json
+        ) VALUES (?, ?, 1, ?, '{}', '[]', ?, '{}', '{}')
+        """,
+        (
+            str(LOCAL_TENANT),
+            _job_id(conn, job_url),
+            score,
+            "2026-07-14T08:00:00+00:00",
+        ),
+    )
 
 
 def _mark_enriched(conn: sqlite3.Connection, job_url: str) -> None:
@@ -63,7 +93,7 @@ def _mark_enriched(conn: sqlite3.Connection, job_url: str) -> None:
     enrichment = (
         JobEnrichment.empty(
             tenant_id=LOCAL_TENANT,
-            job_id=JobId(job_url),
+            job_id=_job_id(conn, job_url),
             updated_at=timestamp,
         )
         .start_attempt(
@@ -98,7 +128,7 @@ def test_execution_ref_is_serializable_across_every_discovery_handoff() -> None:
     )
     preparation = JobPreparationInput(
         tenant_id=str(LOCAL_TENANT),
-        job_url="https://example.com/jobs/serialized",
+        job_id=generate_job_id(),
         steps=["score"],
         target_version="1",
         idempotency_key="preparation:serialized",
@@ -136,7 +166,7 @@ def test_source_observation_retry_links_once_without_rewriting_first_link(
 
     repository.attach_source_observation(
         LOCAL_TENANT,
-        JobId(job_url),
+        _job_id(conn, job_url),
         JobSourceObservation(
             source_observation_id="observation-1",
             source_id="jobspy:indeed",
@@ -148,7 +178,7 @@ def test_source_observation_retry_links_once_without_rewriting_first_link(
     )
     repository.attach_source_observation(
         LOCAL_TENANT,
-        JobId(job_url),
+        _job_id(conn, job_url),
         JobSourceObservation(
             source_observation_id="observation-2",
             source_id="jobspy:indeed",
@@ -159,7 +189,7 @@ def test_source_observation_retry_links_once_without_rewriting_first_link(
         ),
     )
 
-    lineage = SqliteDiscoveryExecutionRepository(conn).get(execution, job_url)
+    lineage = SqliteDiscoveryExecutionRepository(conn).get(execution, _job_id(conn, job_url))
     assert lineage is not None
     assert lineage.source_run_id == "source-run-original"
     assert lineage.linked_at == "2026-07-14T09:00:00+00:00"
@@ -168,8 +198,8 @@ def test_source_observation_retry_links_once_without_rewriting_first_link(
     # The source observation remains mutable metadata and is intentionally not
     # the authority for the immutable execution link above.
     source_row = conn.execute(
-        "SELECT run_id, observed_at FROM job_source_observations WHERE job_url = ?",
-        (job_url,),
+        "SELECT run_id, observed_at FROM job_source_observations WHERE job_id = ?",
+        (_job_id(conn, job_url),),
     ).fetchone()
     assert tuple(source_row) == ("source-run-retry", "2026-07-14T09:05:00+00:00")
 
@@ -184,7 +214,7 @@ def test_later_temporal_run_inserts_history_instead_of_reusing_membership(
 
     repository.link_job(
         first,
-        job_url,
+        _job_id(conn, job_url),
         cohort_kind="observed_this_run",
         source_family="workday",
         source_run_id="source-old",
@@ -192,15 +222,15 @@ def test_later_temporal_run_inserts_history_instead_of_reusing_membership(
     )
     repository.link_job(
         second,
-        job_url,
+        _job_id(conn, job_url),
         cohort_kind="observed_this_run",
         source_family="ats_api",
         source_run_id="source-new",
         linked_at="2026-07-14T09:00:00+00:00",
     )
 
-    first_membership = repository.get(first, job_url)
-    second_membership = repository.get(second, job_url)
+    first_membership = repository.get(first, _job_id(conn, job_url))
+    second_membership = repository.get(second, _job_id(conn, job_url))
     assert first_membership is not None
     assert second_membership is not None
     assert first_membership.source_run_id == "source-old"
@@ -217,20 +247,20 @@ def test_observed_promotion_wins_transactionally_without_double_count(
 
     repository.link_job(
         execution,
-        job_url,
+        _job_id(conn, job_url),
         cohort_kind="existing_backlog",
         linked_at="2026-07-14T08:55:00+00:00",
     )
     repository.set_work_plan(
         execution,
-        job_url,
+        _job_id(conn, job_url),
         state="planned",
         required_steps=["tailor", "cover", "pdf"],
         preparation_workflow_id="prep-backlog-job",
     )
     promoted = repository.link_job(
         execution,
-        job_url,
+        _job_id(conn, job_url),
         cohort_kind="observed_this_run",
         source_family="jobspy",
         source_run_id="source-current",
@@ -238,7 +268,7 @@ def test_observed_promotion_wins_transactionally_without_double_count(
     )
     attempted_reverse = repository.link_job(
         execution,
-        job_url,
+        _job_id(conn, job_url),
         cohort_kind="existing_backlog",
         linked_at="2026-07-14T09:10:00+00:00",
     )
@@ -260,23 +290,24 @@ def test_promoted_job_keeps_existing_plan_instead_of_starting_parallel_work(
     job_url = _insert_job(conn, "promoted-plan")
     execution = _execution("temporal-run-promoted-plan")
     repository = SqliteDiscoveryExecutionRepository(conn)
-    repository.link_job(execution, job_url, cohort_kind="existing_backlog")
+    repository.link_job(execution, _job_id(conn, job_url), cohort_kind="existing_backlog")
     repository.set_work_plan(
         execution,
-        job_url,
+        _job_id(conn, job_url),
         state="planned",
         required_steps=["tailor", "cover", "pdf"],
         preparation_workflow_id="prep-existing-plan",
     )
     repository.link_job(
         execution,
-        job_url,
+        _job_id(conn, job_url),
         cohort_kind="observed_this_run",
         source_family="jobspy",
         source_run_id="source-current",
     )
     replacement = preparation_pipeline.PreparationTarget(
-        job_url=job_url,
+        tenant_id=LOCAL_TENANT,
+        job_id=_job_id(conn, job_url),
         idempotency_key="replacement-plan",
         target_version="4",
         steps=["score", "tailor", "cover", "pdf"],
@@ -300,7 +331,7 @@ def test_promoted_job_keeps_existing_plan_instead_of_starting_parallel_work(
         discovery_execution=execution,
     )
 
-    membership = repository.get(execution, job_url)
+    membership = repository.get(execution, _job_id(conn, job_url))
     assert membership is not None
     assert membership.cohort_kind == "observed_this_run"
     assert membership.preparation_workflow_id == "prep-existing-plan"
@@ -318,11 +349,11 @@ def test_pre_run_selection_can_form_an_existing_backlog_only_cohort(
     second_url = _insert_job(conn, "backlog-b")
 
     for job_url in (first_url, second_url):
-        repository.link_job(execution, job_url, cohort_kind="existing_backlog")
+        repository.link_job(execution, _job_id(conn, job_url), cohort_kind="existing_backlog")
 
     memberships = repository.list_for_execution(execution)
-    assert [membership.job_url for membership in memberships] == sorted(
-        [first_url, second_url]
+    assert [str(membership.job_id) for membership in memberships] == sorted(
+        [str(_job_id(conn, first_url)), str(_job_id(conn, second_url))]
     )
     assert {membership.cohort_kind for membership in memberships} == {"existing_backlog"}
 
@@ -334,7 +365,8 @@ def test_pre_run_fanout_links_selected_target_and_propagates_lineage(
     execution = _execution("temporal-run-pre-run-sweep")
     job_url = _insert_job(conn, "selected-backlog")
     target = preparation_pipeline.PreparationTarget(
-        job_url=job_url,
+        tenant_id=LOCAL_TENANT,
+        job_id=_job_id(conn, job_url),
         idempotency_key="preparation:selected-backlog",
         target_version="3",
         steps=["tailor", "cover", "pdf"],
@@ -359,7 +391,7 @@ def test_pre_run_fanout_links_selected_target_and_propagates_lineage(
         discovery_cohort_kind="existing_backlog",
     )
 
-    membership = SqliteDiscoveryExecutionRepository(conn).get(execution, job_url)
+    membership = SqliteDiscoveryExecutionRepository(conn).get(execution, _job_id(conn, job_url))
     assert membership is not None
     assert membership.cohort_kind == "existing_backlog"
     assert membership.work_plan_state == "planned"
@@ -377,12 +409,12 @@ def test_terminal_fanout_decides_every_unselected_observed_membership(
     repository = SqliteDiscoveryExecutionRepository(conn)
     below_threshold_url = _insert_job(conn, "below-threshold")
     unresolved_url = _insert_job(conn, "unresolved")
-    conn.execute("UPDATE jobs SET fit_score = 4 WHERE url = ?", (below_threshold_url,))
+    _set_score(conn, below_threshold_url, 4)
     conn.commit()
     for job_url in (below_threshold_url, unresolved_url):
         repository.link_job(
             execution,
-            job_url,
+            _job_id(conn, job_url),
             cohort_kind="observed_this_run",
             source_family="jobspy",
             source_run_id="source-terminal",
@@ -402,8 +434,8 @@ def test_terminal_fanout_decides_every_unselected_observed_membership(
         finalize_observed_work_plans=True,
     )
 
-    below_threshold = repository.get(execution, below_threshold_url)
-    unresolved = repository.get(execution, unresolved_url)
+    below_threshold = repository.get(execution, _job_id(conn, below_threshold_url))
+    unresolved = repository.get(execution, _job_id(conn, unresolved_url))
     assert below_threshold is not None
     assert below_threshold.work_plan_state == "not_eligible"
     assert below_threshold.work_plan_reason == "score_below_threshold"
@@ -425,23 +457,13 @@ def test_terminal_fanout_honors_deleted_job_tombstone_when_table_exists(
     repository = SqliteDiscoveryExecutionRepository(conn)
     job_url = _insert_job(conn, "deleted")
     conn.execute(
-        """
-        CREATE TABLE jobctrl_deleted_jobs (
-            job_url TEXT PRIMARY KEY,
-            deleted_at TEXT NOT NULL,
-            reason TEXT,
-            restored_at TEXT
-        )
-        """
-    )
-    conn.execute(
-        "INSERT INTO jobctrl_deleted_jobs (job_url, deleted_at) VALUES (?, ?)",
-        (job_url, "2026-07-14T09:00:00+00:00"),
+        "INSERT INTO jobctrl_deleted_jobs (tenant_id, job_id, deleted_at) VALUES (?, ?, ?)",
+        (str(LOCAL_TENANT), _job_id(conn, job_url), "2026-07-14T09:00:00+00:00"),
     )
     conn.commit()
     repository.link_job(
         execution,
-        job_url,
+        _job_id(conn, job_url),
         cohort_kind="observed_this_run",
         source_family="jobspy",
         source_run_id="source-terminal",
@@ -460,7 +482,7 @@ def test_terminal_fanout_honors_deleted_job_tombstone_when_table_exists(
         finalize_observed_work_plans=True,
     )
 
-    membership = repository.get(execution, job_url)
+    membership = repository.get(execution, _job_id(conn, job_url))
     assert membership is not None
     assert membership.work_plan_state == "not_eligible"
     assert membership.work_plan_reason == "job_not_actionable"
@@ -478,13 +500,13 @@ def test_terminal_fanout_keeps_unobserved_pending_score_in_existing_backlog(
     ineligible_url = _insert_job(conn, "observed-ineligible")
     _mark_enriched(conn, observed_url)
     _mark_enriched(conn, backlog_url)
-    conn.execute("UPDATE jobs SET fit_score = 4 WHERE url = ?", (ineligible_url,))
+    _set_score(conn, ineligible_url, 4)
     conn.commit()
 
     for job_url in (observed_url, ineligible_url):
         repository.link_job(
             execution,
-            job_url,
+            _job_id(conn, job_url),
             cohort_kind="observed_this_run",
             source_family="jobspy",
             source_run_id="source-current",
@@ -506,23 +528,23 @@ def test_terminal_fanout_keeps_unobserved_pending_score_in_existing_backlog(
     )
 
     memberships = {
-        membership.job_url: membership
+        str(membership.job_id): membership
         for membership in repository.list_for_execution(execution)
     }
     assert result["started"] == {"job_preparation": 2}
-    assert memberships[observed_url].cohort_kind == "observed_this_run"
-    assert memberships[observed_url].work_plan_state == "planned"
-    assert memberships[backlog_url].cohort_kind == "existing_backlog"
-    assert memberships[backlog_url].source_family is None
-    assert memberships[backlog_url].source_run_id is None
-    assert memberships[backlog_url].work_plan_state == "planned"
-    assert memberships[ineligible_url].work_plan_state == "not_eligible"
-    assert memberships[ineligible_url].work_plan_reason == "score_below_threshold"
+    assert memberships[str(_job_id(conn, observed_url))].cohort_kind == "observed_this_run"
+    assert memberships[str(_job_id(conn, observed_url))].work_plan_state == "planned"
+    assert memberships[str(_job_id(conn, backlog_url))].cohort_kind == "existing_backlog"
+    assert memberships[str(_job_id(conn, backlog_url))].source_family is None
+    assert memberships[str(_job_id(conn, backlog_url))].source_run_id is None
+    assert memberships[str(_job_id(conn, backlog_url))].work_plan_state == "planned"
+    assert memberships[str(_job_id(conn, ineligible_url))].work_plan_state == "not_eligible"
+    assert memberships[str(_job_id(conn, ineligible_url))].work_plan_reason == "score_below_threshold"
     assert {
-        payload.job_url: payload.discovery_cohort_kind for payload in started_inputs
+        str(payload.job_id): payload.discovery_cohort_kind for payload in started_inputs
     } == {
-        observed_url: "observed_this_run",
-        backlog_url: "existing_backlog",
+        str(_job_id(conn, observed_url)): "observed_this_run",
+        str(_job_id(conn, backlog_url)): "existing_backlog",
     }
     assert all(
         membership.work_plan_state != "failed"
@@ -539,7 +561,7 @@ def test_derivation_failure_marks_pending_observed_membership_failed(
     repository = SqliteDiscoveryExecutionRepository(conn)
     repository.link_job(
         execution,
-        job_url,
+        _job_id(conn, job_url),
         cohort_kind="observed_this_run",
         source_family="ats_api",
         source_run_id="source-failure",
@@ -561,7 +583,7 @@ def test_derivation_failure_marks_pending_observed_membership_failed(
             discovery_execution=execution,
         )
 
-    membership = repository.get(execution, job_url)
+    membership = repository.get(execution, _job_id(conn, job_url))
     assert membership is not None
     assert membership.work_plan_state == "failed"
     assert membership.work_plan_reason == "target_derivation_failed"
@@ -577,13 +599,14 @@ def test_planning_failure_marks_pending_observed_membership_failed(
     repository = SqliteDiscoveryExecutionRepository(conn)
     repository.link_job(
         execution,
-        job_url,
+        _job_id(conn, job_url),
         cohort_kind="observed_this_run",
         source_family="workday",
         source_run_id="source-planning-failure",
     )
     target = preparation_pipeline.PreparationTarget(
-        job_url=job_url,
+        tenant_id=LOCAL_TENANT,
+        job_id=_job_id(conn, job_url),
         idempotency_key="preparation:planning-failure",
         target_version="2",
         steps=["score", "tailor", "cover", "pdf"],
@@ -610,7 +633,7 @@ def test_planning_failure_marks_pending_observed_membership_failed(
             discovery_execution=execution,
         )
 
-    membership = repository.get(execution, job_url)
+    membership = repository.get(execution, _job_id(conn, job_url))
     assert membership is not None
     assert membership.work_plan_state == "failed"
     assert membership.work_plan_reason == "work_plan_persistence_failed"
@@ -627,7 +650,7 @@ def test_pending_and_failed_work_plans_are_never_reported_as_no_work(
 
     pending = repository.link_job(
         execution,
-        failed_url,
+        _job_id(conn, failed_url),
         cohort_kind="observed_this_run",
         source_family="ats_api",
         source_run_id="source-plan",
@@ -638,7 +661,7 @@ def test_pending_and_failed_work_plans_are_never_reported_as_no_work(
 
     failed = repository.set_work_plan(
         execution,
-        failed_url,
+        _job_id(conn, failed_url),
         state="failed",
         reason="target_derivation_failed",
     )
@@ -648,14 +671,14 @@ def test_pending_and_failed_work_plans_are_never_reported_as_no_work(
 
     planned = repository.set_work_plan(
         execution,
-        failed_url,
+        _job_id(conn, failed_url),
         state="planned",
         required_steps=["pdf", "score", "tailor", "cover", "score"],
         preparation_workflow_id="prep-recovered-plan",
     )
     retried = repository.set_work_plan(
         execution,
-        failed_url,
+        _job_id(conn, failed_url),
         state="planned",
         required_steps=["score", "tailor", "cover", "pdf"],
         preparation_workflow_id="prep-recovered-plan",
@@ -666,14 +689,14 @@ def test_pending_and_failed_work_plans_are_never_reported_as_no_work(
 
     repository.link_job(
         execution,
-        excluded_url,
+        _job_id(conn, excluded_url),
         cohort_kind="observed_this_run",
         source_family="workday",
         source_run_id="source-plan",
     )
     excluded = repository.set_work_plan(
         execution,
-        excluded_url,
+        _job_id(conn, excluded_url),
         state="not_eligible",
         reason="no_preparation_required",
     )

--- a/workers/automation/tests/test_discovery_search_units.py
+++ b/workers/automation/tests/test_discovery_search_units.py
@@ -6,7 +6,7 @@ import pandas as pd
 import pytest
 from jobstreaming import CheckpointConflictError, SearchCheckpoint, build_search_request
 
-from jobctrl.database import SCHEMA_VERSION, close_connection, init_db
+from jobctrl.database import SchemaMigrationRequiredError, close_connection, init_db
 from jobctrl.domain.discovery import (
     AtsKind,
     CanonicalJobIdentity,
@@ -19,7 +19,7 @@ from jobctrl.domain.discovery import (
 )
 from jobctrl.domain.discovery.execution import DiscoveryExecutionRef
 from jobctrl.domain.discovery.search_units import DiscoverySearchSpec
-from jobctrl.domain.identifiers import JobId
+from jobctrl.domain.identifiers import JobId, generate_job_id
 from jobctrl.domain.tenant import LOCAL_TENANT
 from jobctrl.discovery.jobspy import store_jobspy_results
 from jobctrl.infrastructure.compensation import SqlitePostedCompensationRepository
@@ -38,6 +38,15 @@ def _execution() -> DiscoveryExecutionRef:
         workflow_id="discover-local",
         temporal_run_id="temporal-run-1",
     )
+
+
+def _job_id_for_url(conn, job_url: str) -> JobId:
+    row = conn.execute(
+        "SELECT job_id FROM jobs WHERE tenant_id = ? AND url = ?",
+        (str(LOCAL_TENANT), job_url),
+    ).fetchone()
+    assert row is not None
+    return JobId(str(row["job_id"]))
 
 
 def _spec(*, query: str = "Director of Engineering") -> DiscoverySearchSpec:
@@ -250,7 +259,7 @@ def test_unacknowledged_cursor_reset_intent_does_not_clear_on_reclaim(
     assert repository.checkpoint_store(next_attempt).load() is None
 
 
-def test_v4_search_unit_tables_migrate_consumption_ordering(
+def test_v4_search_unit_tables_require_an_explicit_v7_upgrade(
     tmp_path: Path,
 ) -> None:
     db_path = tmp_path / "v4-jobctrl.db"
@@ -266,29 +275,8 @@ def test_v4_search_unit_tables_migrate_consumption_ordering(
     conn.commit()
     close_connection(db_path)
 
-    migrated = init_db(db_path)
-    try:
-        columns = {
-            str(row[1])
-            for row in migrated.execute(
-                "PRAGMA table_info(discovery_search_units)"
-            ).fetchall()
-        }
-        assert "reset_checkpoint_after_revision" in columns
-        assert migrated.execute(
-            """
-            SELECT COUNT(*)
-              FROM sqlite_master
-             WHERE type = 'table'
-               AND name = 'discovery_search_unit_filtered_events'
-            """
-        ).fetchone()[0] == 1
-        # ``user_version`` guards the complete database shape, so reopening a
-        # v4 fixture must advance to the current schema rather than pinning
-        # this search-unit migration to its historical v5 release.
-        assert migrated.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_VERSION
-    finally:
-        close_connection(db_path)
+    with pytest.raises(SchemaMigrationRequiredError, match="exact schema v7"):
+        init_db(db_path)
 
 
 def test_execution_attempt_watermark_fences_old_owner_from_pending_unit(
@@ -400,7 +388,7 @@ def test_job_write_and_new_receipt_share_the_fenced_repository_path(search_db) -
     discovered_at = "2026-07-17T10:00:00+00:00"
     job = Job.discover(
         tenant_id=LOCAL_TENANT,
-        job_id=JobId("https://example.test/jobs/1"),
+        job_id=generate_job_id(),
         posting_url=PostingUrl(value="https://example.test/jobs/1"),
         source=Source(board="indeed"),
         employer=Employer.unknown(),
@@ -437,7 +425,7 @@ def test_job_write_and_new_receipt_share_the_fenced_repository_path(search_db) -
     )
     stale_job = Job.discover(
         tenant_id=LOCAL_TENANT,
-        job_id=JobId("https://example.test/jobs/stale"),
+        job_id=generate_job_id(),
         posting_url=PostingUrl(value="https://example.test/jobs/stale"),
         source=Source(board="indeed"),
         employer=Employer.unknown(),
@@ -514,10 +502,10 @@ def test_jobspy_storage_records_new_receipt_once_across_replay(search_db) -> Non
             """
             SELECT event_type, COUNT(*)
               FROM job_events
-             WHERE job_url = ?
+             WHERE job_id = ?
              GROUP BY event_type
             """,
-            ("https://example.test/jobs/jobstreaming-1",),
+            (_job_id_for_url(search_db, "https://example.test/jobs/jobstreaming-1"),),
         ).fetchall()
     }
     replay = store_jobspy_results(
@@ -538,10 +526,10 @@ def test_jobspy_storage_records_new_receipt_once_across_replay(search_db) -> Non
             """
             SELECT event_type, COUNT(*)
               FROM job_events
-             WHERE job_url = ?
+             WHERE job_id = ?
              GROUP BY event_type
             """,
-            ("https://example.test/jobs/jobstreaming-1",),
+            (_job_id_for_url(search_db, "https://example.test/jobs/jobstreaming-1"),),
         ).fetchall()
     }
     assert replay_events == first_events
@@ -550,10 +538,10 @@ def test_jobspy_storage_records_new_receipt_once_across_replay(search_db) -> Non
         """
         SELECT COUNT(*)
           FROM job_events
-         WHERE job_url = ?
+         WHERE job_id = ?
            AND idempotency_key LIKE 'jobstreaming:%'
         """,
-        ("https://example.test/jobs/jobstreaming-1",),
+        (_job_id_for_url(search_db, "https://example.test/jobs/jobstreaming-1"),),
     ).fetchone()[0] == sum(first_events.values())
     assert search_units.execution_counts(execution) == {
         "accepted": 1,
@@ -630,8 +618,11 @@ def test_mid_event_supersession_is_fenced_and_retry_repairs_audit_rows(
     )
     assert (
         search_db.execute(
-            "SELECT COUNT(*) FROM job_canonical_identities WHERE job_url = ?",
-            ("https://example.test/jobs/mid-event",),
+            """
+            SELECT COUNT(*) FROM job_canonical_identities
+            WHERE job_id = (SELECT job_id FROM jobs WHERE tenant_id = ? AND url = ?)
+            """,
+            (str(LOCAL_TENANT), "https://example.test/jobs/mid-event"),
         ).fetchone()[0]
         == 1
     )
@@ -670,22 +661,31 @@ def test_mid_event_supersession_is_fenced_and_retry_repairs_audit_rows(
     assert resumed == (0, 1)
     assert (
         search_db.execute(
-            "SELECT COUNT(*) FROM job_canonical_identities WHERE job_url = ?",
-            ("https://example.test/jobs/mid-event",),
+            """
+            SELECT COUNT(*) FROM job_canonical_identities
+            WHERE job_id = (SELECT job_id FROM jobs WHERE tenant_id = ? AND url = ?)
+            """,
+            (str(LOCAL_TENANT), "https://example.test/jobs/mid-event"),
         ).fetchone()[0]
         == 1
     )
     assert (
         search_db.execute(
-            "SELECT COUNT(*) FROM job_source_observations WHERE job_url = ?",
-            ("https://example.test/jobs/mid-event",),
+            """
+            SELECT COUNT(*) FROM job_source_observations
+            WHERE job_id = (SELECT job_id FROM jobs WHERE tenant_id = ? AND url = ?)
+            """,
+            (str(LOCAL_TENANT), "https://example.test/jobs/mid-event"),
         ).fetchone()[0]
         == 1
     )
     assert (
         search_db.execute(
-            "SELECT COUNT(*) FROM job_events WHERE job_url = ?",
-            ("https://example.test/jobs/mid-event",),
+            """
+            SELECT COUNT(*) FROM job_events
+            WHERE job_id = (SELECT job_id FROM jobs WHERE tenant_id = ? AND url = ?)
+            """,
+            (str(LOCAL_TENANT), "https://example.test/jobs/mid-event"),
         ).fetchone()[0]
         == 4
     )
@@ -698,13 +698,14 @@ def test_mid_event_supersession_is_fenced_and_retry_repairs_audit_rows(
 
 def test_compensation_event_rechecks_fence_after_fact_commit(search_db) -> None:
     job_url = "https://example.test/jobs/compensation-fence"
+    job_id = generate_job_id()
     search_db.execute(
         """
-        INSERT INTO jobs (url, title, salary, description, location, site, strategy)
-        VALUES (?, 'Director of Engineering', 'EUR 150000/year',
+        INSERT INTO jobs (tenant_id, job_id, url, title, salary, description, location, site, strategy)
+        VALUES (?, ?, ?, 'Director of Engineering', 'EUR 150000/year',
                 'Lead engineering.', 'Barcelona, Spain', 'indeed', 'jobspy')
         """,
-        (job_url,),
+        (str(LOCAL_TENANT), str(job_id), job_url),
     )
     search_db.commit()
     search_units = SqliteDiscoverySearchUnitRepository(search_db)
@@ -723,7 +724,7 @@ def test_compensation_event_rechecks_fence_after_fact_commit(search_db) -> None:
 
     with pytest.raises(StaleDiscoverySearchUnitLease):
         compensation.parse_and_save_job_salary(
-            job_url,
+            job_id,
             "EUR 150000/year",
             parsed_at="2026-07-17T10:00:00+00:00",
             event_idempotency_key="jobstreaming:test:CompensationFactsUpdated",
@@ -732,22 +733,22 @@ def test_compensation_event_rechecks_fence_after_fact_commit(search_db) -> None:
 
     assert (
         search_db.execute(
-            "SELECT COUNT(*) FROM job_posted_compensation_facts WHERE job_url = ?",
-            (job_url,),
+            "SELECT COUNT(*) FROM job_posted_compensation_facts WHERE tenant_id = ? AND job_id = ?",
+            (str(LOCAL_TENANT), job_id),
         ).fetchone()[0]
         == 1
     )
     assert (
         search_db.execute(
-            "SELECT COUNT(*) FROM job_events WHERE job_url = ?",
-            (job_url,),
+            "SELECT COUNT(*) FROM job_events WHERE tenant_id = ? AND job_id = ?",
+            (str(LOCAL_TENANT), job_id),
         ).fetchone()[0]
         == 0
     )
     assert reclaimed
 
     compensation.parse_and_save_job_salary(
-        job_url,
+        job_id,
         "EUR 150000/year",
         parsed_at="2026-07-17T10:01:00+00:00",
         event_idempotency_key="jobstreaming:test:CompensationFactsUpdated",
@@ -755,8 +756,8 @@ def test_compensation_event_rechecks_fence_after_fact_commit(search_db) -> None:
     )
     assert (
         search_db.execute(
-            "SELECT COUNT(*) FROM job_events WHERE job_url = ?",
-            (job_url,),
+            "SELECT COUNT(*) FROM job_events WHERE tenant_id = ? AND job_id = ?",
+            (str(LOCAL_TENANT), job_id),
         ).fetchone()[0]
         == 1
     )

--- a/workers/automation/tests/test_enrichment_politeness_gate.py
+++ b/workers/automation/tests/test_enrichment_politeness_gate.py
@@ -23,6 +23,8 @@ from typing import Iterator
 import pytest
 
 from jobctrl.database import close_connection, init_db
+from jobctrl.domain.identifiers import JobId, generate_job_id
+from jobctrl.domain.tenant import LOCAL_TENANT
 from jobctrl.enrichment import detail
 from jobctrl.enrichment.detail import scrape_detail_page, scrape_site_batch
 from jobctrl.infrastructure.network import (
@@ -51,33 +53,65 @@ def _allow_test_url_safety(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def _seed_pending(conn: sqlite3.Connection, url: str, site: str = "RemoteOK") -> None:
+    job_id = generate_job_id()
     conn.execute(
-        "INSERT INTO jobs (url, title, site, discovered_at) VALUES (?, ?, ?, ?)",
-        (url, "Engineer", site, "2026-01-01T00:00:00+00:00"),
+        """
+        INSERT INTO jobs (tenant_id, job_id, url, title, site, discovered_at)
+        VALUES (?, ?, ?, ?, ?, ?)
+        """,
+        (str(LOCAL_TENANT), str(job_id), url, "Engineer", site, "2026-01-01T00:00:00+00:00"),
+    )
+    conn.execute(
+        """
+        INSERT INTO job_locators (
+            tenant_id, job_id, locator_kind, locator_value, is_current,
+            first_seen_at, last_seen_at, retired_at
+        ) VALUES (?, ?, 'posting_url', ?, 1, ?, ?, NULL)
+        """,
+        (
+            str(LOCAL_TENANT),
+            str(job_id),
+            url,
+            "2026-01-01T00:00:00+00:00",
+            "2026-01-01T00:00:00+00:00",
+        ),
     )
     conn.commit()
+
+
+def _job_id(conn: sqlite3.Connection, url: str) -> JobId:
+    row = conn.execute(
+        "SELECT job_id FROM jobs WHERE tenant_id = ? AND url = ?",
+        (str(LOCAL_TENANT), url),
+    ).fetchone()
+    assert row is not None
+    return JobId(str(row["job_id"]))
 
 
 def _enrich_stage(conn: sqlite3.Connection, url: str) -> sqlite3.Row:
     conn.row_factory = sqlite3.Row
     return conn.execute(
-        "SELECT state, error_code, next_action FROM job_stage_states WHERE job_url = ? AND stage = 'enrich'",
-        (url,),
+        "SELECT state, error_code, next_action FROM job_stage_states WHERE job_id = ? AND stage = 'enrich'",
+        (_job_id(conn, url),),
     ).fetchone()
 
 
 def _blocked_metric(conn: sqlite3.Connection, url: str) -> sqlite3.Row | None:
     conn.row_factory = sqlite3.Row
+    source = conn.execute("SELECT site FROM jobs WHERE url = ?", (url,)).fetchone()
+    assert source is not None
     return conn.execute(
         "SELECT outcome, failure_category, is_scrape_failure, is_operational_failure, stage, source_id "
-        "FROM operational_attempt_metrics WHERE job_url = ? AND outcome = 'blocked'",
-        (url,),
+        "FROM operational_attempt_metrics "
+        "WHERE stage = 'enrich' AND source_id = ? AND outcome = 'blocked' "
+        "ORDER BY metric_id DESC LIMIT 1",
+        (source[0],),
     ).fetchone()
 
 
 def _enrichment_status(conn: sqlite3.Connection, url: str) -> str | None:
     row = conn.execute(
-        "SELECT current_status FROM job_enrichments WHERE job_url = ?", (url,)
+        "SELECT current_status FROM job_enrichments WHERE job_id = ?", (_job_id(conn, url),)
     ).fetchone()
     return None if row is None else row[0]
 
@@ -256,7 +290,7 @@ def test_robots_disallowed_job_never_navigates_and_folds_blocked(
                 robots=RobotsCache(opener=public_loopback_opener()),
                 rate_limiter=no_sleep_limiter(),
             )
-            stats = scrape_site_batch(conn, "RemoteOK", [(url, "Role")], gateway=gateway)
+            stats = scrape_site_batch(conn, "RemoteOK", [(_job_id(conn, url), "Role")], gateway=gateway)
 
             # The invariant: a disallowed page is NEVER navigated.
             assert spy.goto_calls == []
@@ -277,8 +311,8 @@ def test_robots_disallowed_job_never_navigates_and_folds_blocked(
             assert metric["stage"] == "enrich"
 
             event = conn.execute(
-                "SELECT event_type, level FROM job_events WHERE job_url = ? AND event_type = 'StageBlocked'",
-                (url,),
+                "SELECT event_type, level FROM job_events WHERE job_id = ? AND event_type = 'StageBlocked'",
+                (_job_id(conn, url),),
             ).fetchone()
             assert event is not None
 
@@ -310,7 +344,7 @@ def test_budget_exhausted_defers_job_without_navigation(
         assert exhausted.try_consume(1) is True  # drain to zero
 
         stats = scrape_site_batch(
-            conn, "RemoteOK", [(url, "Role")], gateway=offline_gateway(), run_budget=exhausted
+            conn, "RemoteOK", [(_job_id(conn, url), "Role")], gateway=offline_gateway(), run_budget=exhausted
         )
 
         assert spy.goto_calls == []
@@ -341,7 +375,7 @@ def test_run_budget_decrements_per_navigation_and_stops_batch(
         stats = scrape_site_batch(
             conn,
             "RemoteOK",
-            [(u, "Role") for u in urls],
+            [(_job_id(conn, u), "Role") for u in urls],
             gateway=offline_gateway(),
             run_budget=budget,
         )
@@ -424,7 +458,7 @@ def test_authenticated_linkedin_session_skips_robots_but_keeps_budget(
         stats = scrape_site_batch(
             conn,
             "linkedin",
-            [(url, "Role")],
+            [(_job_id(conn, url), "Role")],
             gateway=offline_gateway(robots=DenyAllRobots()),
         )
 
@@ -458,7 +492,7 @@ def test_non_linkedin_url_with_linkedin_substring_uses_anonymous_context(
         monkeypatch.setattr(detail, "LinkedInApplyUrlResolver", _resolver_factory)
         monkeypatch.setattr(detail, "sync_playwright", lambda: anonymous_playwright)
 
-        stats = scrape_site_batch(conn, "linkedin", [(url, "Role")], gateway=offline_gateway())
+        stats = scrape_site_batch(conn, "linkedin", [(_job_id(conn, url), "Role")], gateway=offline_gateway())
 
         assert authenticated_constructed == []
         assert anonymous_playwright.goto_calls == [url]
@@ -493,7 +527,10 @@ def test_mixed_linkedin_batch_does_not_reuse_authenticated_page_for_other_hosts(
         stats = scrape_site_batch(
             conn,
             "linkedin",
-            [(linkedin_url, "LinkedIn role"), (non_linkedin_url, "Spoofed role")],
+            [
+                (_job_id(conn, linkedin_url), "LinkedIn role"),
+                (_job_id(conn, non_linkedin_url), "Spoofed role"),
+            ],
             gateway=offline_gateway(),
         )
 
@@ -628,7 +665,7 @@ def test_robots_blocked_job_re_enriches_after_robots_allows(
 
         # Run 1 — robots disallows: folded blocked, zero navigation, je pending.
         blocked = scrape_site_batch(
-            conn, "RemoteOK", [(url, "Role")], gateway=offline_gateway(robots=DenyAllRobots())
+            conn, "RemoteOK", [(_job_id(conn, url), "Role")], gateway=offline_gateway(robots=DenyAllRobots())
         )
         assert blocked["blocked"] == 1
         assert spy.goto_calls == []
@@ -638,7 +675,7 @@ def test_robots_blocked_job_re_enriches_after_robots_allows(
         # ``error == 0`` is the direct proof the Blocked->Running ValueError path
         # (which would have recorded ENRICH_INTERNAL_ERROR) never fired.
         allowed = scrape_site_batch(
-            conn, "RemoteOK", [(url, "Role")], gateway=offline_gateway(robots=AllowAllRobots())
+            conn, "RemoteOK", [(_job_id(conn, url), "Role")], gateway=offline_gateway(robots=AllowAllRobots())
         )
         assert allowed["processed"] == 1
         assert allowed["error"] == 0
@@ -652,9 +689,9 @@ def test_robots_blocked_job_re_enriches_after_robots_allows(
         # The unblock is auditable — exactly one StageReset event marks the
         # robots re-evaluation of the previously blocked job.
         reset_events = conn.execute(
-            "SELECT COUNT(*) FROM job_events WHERE job_url = ? AND stage = 'enrich' "
+            "SELECT COUNT(*) FROM job_events WHERE job_id = ? AND stage = 'enrich' "
             "AND event_type = 'StageReset'",
-            (url,),
+            (_job_id(conn, url),),
         ).fetchone()[0]
         assert reset_events == 1
     finally:
@@ -684,7 +721,7 @@ def test_repeatedly_robots_blocked_job_stays_blocked_never_failed(
             stats = scrape_site_batch(
                 conn,
                 "RemoteOK",
-                [(url, "Role")],
+                [(_job_id(conn, url), "Role")],
                 gateway=offline_gateway(robots=DenyAllRobots()),
             )
             assert stats["blocked"] == 1

--- a/workers/automation/tests/test_enrichment_quarantine_gating.py
+++ b/workers/automation/tests/test_enrichment_quarantine_gating.py
@@ -39,7 +39,7 @@ from jobctrl.domain.enrichment import (
     SnapshotConfidence,
     SnapshotDescriptionHash,
 )
-from jobctrl.domain.identifiers import JobId
+from jobctrl.domain.identifiers import JobId, generate_job_id
 from jobctrl.domain.materials import (
     Artifact,
     ArtifactType,
@@ -72,19 +72,49 @@ def conn(tmp_path: Path) -> sqlite3.Connection:
 
 
 def _seed_enriched_job(conn: sqlite3.Connection, url: str) -> None:
+    job_id = generate_job_id()
     conn.execute(
-        "INSERT INTO jobs (url, title, site, full_description, discovered_at) "
-        "VALUES (?, ?, ?, ?, ?)",
-        (url, "Engineer", "Acme", _DESCRIPTION, "2024-01-01T00:00:00+00:00"),
+        """
+        INSERT INTO jobs (tenant_id, job_id, url, title, site, discovered_at)
+        VALUES (?, ?, ?, ?, ?, ?)
+        """,
+        (str(LOCAL_TENANT), str(job_id), url, "Engineer", "Acme", "2024-01-01T00:00:00+00:00"),
+    )
+    conn.execute(
+        """
+        INSERT INTO job_locators (
+            tenant_id, job_id, locator_kind, locator_value, is_current,
+            first_seen_at, last_seen_at, retired_at
+        ) VALUES (?, ?, 'posting_url', ?, 1, ?, ?, NULL)
+        """,
+        (str(LOCAL_TENANT), str(job_id), url, NOW, NOW),
+    )
+    conn.execute(
+        """
+        INSERT INTO job_enrichments (
+            tenant_id, job_id, current_status, full_description, application_url,
+            enriched_at, extraction_tier, attempts_json, updated_at
+        ) VALUES (?, ?, 'enriched', ?, NULL, ?, 'css_selectors', '[]', ?)
+        """,
+        (str(LOCAL_TENANT), str(job_id), _DESCRIPTION, NOW, NOW),
     )
     conn.commit()
+
+
+def _job_id(conn: sqlite3.Connection, url: str) -> JobId:
+    row = conn.execute(
+        "SELECT job_id FROM jobs WHERE tenant_id = ? AND url = ?",
+        (str(LOCAL_TENANT), url),
+    ).fetchone()
+    assert row is not None
+    return JobId(str(row["job_id"]))
 
 
 def _save_score(conn: sqlite3.Connection, url: str, fit: int = 9) -> None:
     SqliteScoreRepository(conn).save(
         JobScore.initial(
             tenant_id=LOCAL_TENANT,
-            job_id=JobId(url),
+            job_id=_job_id(conn, url),
             fit_score=FitScore.create(fit),
             breakdown=ScoreBreakdown(reasoning="ok", eligibility=EligibilityAssessment()),
             matched_keywords=MatchedKeywords.from_iterable(["python"]),
@@ -104,7 +134,7 @@ def _record_snapshot(
 ) -> None:
     repo = SqlitePostingSnapshotSetRepository(conn)
     snapshot_set = PostingSnapshotSet.empty(
-        tenant_id=LOCAL_TENANT, job_id=JobId(url), updated_at=NOW
+        tenant_id=LOCAL_TENANT, job_id=_job_id(conn, url), updated_at=NOW
     )
     snapshot_set, _ = snapshot_set.record_snapshot(
         source_id="acme",
@@ -129,7 +159,7 @@ def _add_approved_resume_with_pdf(conn: sqlite3.Connection, url: str) -> None:
     SqliteMaterialsRepository(conn).save(
         MaterialsSetFactory.initial(
             tenant_id=LOCAL_TENANT,
-            job_id=JobId(url),
+            job_id=_job_id(conn, url),
             created_at="2024-01-01T00:00:00+00:00",
         )
         .with_resume_attempt(
@@ -289,8 +319,8 @@ def test_repository_persists_latest_confidence_and_quarantine(
 
     row = conn.execute(
         "SELECT latest_confidence, latest_quarantine_reason "
-        "FROM posting_snapshot_sets WHERE job_url = ?",
-        (url,),
+        "FROM posting_snapshot_sets WHERE tenant_id = ? AND job_id = ?",
+        (str(LOCAL_TENANT), _job_id(conn, url)),
     ).fetchone()
     assert row["latest_confidence"] == "low"
     assert row["latest_quarantine_reason"] == "low_confidence_extraction"
@@ -356,6 +386,7 @@ def test_snapshot_captured_event_records_confidence_and_quarantine(
     }
     _record_posting_snapshot_from_cascade(
         conn,
+        job_id=_job_id(conn, url),
         url=url,
         source_id="acme",
         title="Engineer",
@@ -397,8 +428,9 @@ def test_no_snapshot_backlog_job_is_never_gated_from_any_selector(
     _seed_enriched_job(conn, tailored)
     _save_score(conn, tailored, fit=9)
     conn.execute(
-        "UPDATE jobs SET application_url = 'https://apply.example/backlog' WHERE url = ?",
-        (tailored,),
+        "UPDATE job_enrichments SET application_url = 'https://apply.example/backlog' "
+        "WHERE tenant_id = ? AND job_id = ?",
+        (str(LOCAL_TENANT), _job_id(conn, tailored)),
     )
     conn.commit()
     _add_approved_resume_with_pdf(conn, tailored)
@@ -444,7 +476,7 @@ def test_reenrichment_to_high_self_heals_a_quarantined_job_into_tailoring(
 
     # Re-enrich: append a fresh confident snapshot to the same aggregate.
     repo = SqlitePostingSnapshotSetRepository(conn)
-    snapshot_set = repo.load(LOCAL_TENANT, JobId(url))
+    snapshot_set = repo.load(LOCAL_TENANT, _job_id(conn, url))
     assert snapshot_set is not None
     snapshot_set, _ = snapshot_set.record_snapshot(
         source_id="acme",

--- a/workers/automation/tests/test_event_publication.py
+++ b/workers/automation/tests/test_event_publication.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 
 from jobctrl.database import close_connection, init_db
+from jobctrl.domain.identifiers import generate_job_id
 from jobctrl.domain.tenant import LOCAL_TENANT
 from jobctrl.infrastructure.events.in_process_bus import InProcessEventBus
 from jobctrl.state import record_job_event
@@ -16,9 +17,10 @@ def test_record_job_event_publishes_through_bus(tmp_path: Path) -> None:
     bus.subscribe(None, received.append)
 
     try:
+        job_id = generate_job_id()
         record_job_event(
             conn,
-            "https://example.com/job/1",
+            job_id,
             "score",
             "StageCompleted",
             message="Fit score 9/10",
@@ -37,7 +39,7 @@ def test_record_job_event_publishes_through_bus(tmp_path: Path) -> None:
         event = received[0]
         assert event.event_type == "StageCompleted"
         assert event.tenant_id == LOCAL_TENANT
-        assert event.payload["job_url"] == "https://example.com/job/1"
+        assert event.payload["jobId"] == str(job_id)
         assert event.payload["stage"] == "score"
         assert event.payload["score"] == 9
         assert event.payload["message"] == "Fit score 9/10"
@@ -50,9 +52,10 @@ def test_record_job_event_without_publisher_only_persists(tmp_path: Path) -> Non
     conn = init_db(db_path)
 
     try:
+        job_id = generate_job_id()
         record_job_event(
             conn,
-            "https://example.com/job/2",
+            job_id,
             "enrich",
             "StageStarted",
             message="Enrichment started",
@@ -75,9 +78,10 @@ def test_record_job_event_typed_subscriber_only_receives_match(tmp_path: Path) -
     bus.subscribe("StageCompleted", completed.append)
 
     try:
-        record_job_event(conn, "u", "score", "StageStarted", publisher=bus)
-        record_job_event(conn, "u", "score", "StageCompleted", publisher=bus)
-        record_job_event(conn, "u", "score", "StageFailed", publisher=bus)
+        job_id = generate_job_id()
+        record_job_event(conn, job_id, "score", "StageStarted", publisher=bus)
+        record_job_event(conn, job_id, "score", "StageCompleted", publisher=bus)
+        record_job_event(conn, job_id, "score", "StageFailed", publisher=bus)
         conn.commit()
     finally:
         close_connection(db_path)

--- a/workers/automation/tests/test_event_type_migration.py
+++ b/workers/automation/tests/test_event_type_migration.py
@@ -10,29 +10,36 @@ from __future__ import annotations
 from pathlib import Path
 
 from jobctrl.database import close_connection, ensure_state_tables, init_db
+from jobctrl.domain.identifiers import generate_job_id
+from jobctrl.domain.tenant import LOCAL_TENANT
 
 
 def test_migration_renames_legacy_snake_case_event_types(tmp_path: Path) -> None:
     db_path = tmp_path / "jobs.db"
     conn = init_db(db_path)
     try:
+        job_id = generate_job_id()
         # Seed historical rows that pre-date the PascalCase rip-and-replace.
         conn.executemany(
-            "INSERT INTO job_events (job_url, stage, event_type, occurred_at) VALUES (?, ?, ?, ?)",
+            """
+            INSERT INTO job_events (
+                tenant_id, job_id, identity_version, stage, event_type, level, occurred_at
+            ) VALUES (?, ?, 1, ?, ?, 'info', ?)
+            """,
             [
-                ("u1", "score", "stage_succeeded", "t0"),
-                ("u1", "tailor", "stage_failed", "t1"),
-                ("u1", "apply", "mark_skipped", "t2"),
-                ("u1", "apply", "cancel_requested", "t3"),
-                ("u1", "apply", "lock_released", "t4"),
-                ("u1", "apply", "action_started", "t5"),
-                ("u1", "apply", "action_succeeded", "t6"),
-                ("u1", "apply", "action_failed", "t7"),
-                ("u1", "apply", "dry_run_completed", "t8"),
-                ("u1", "score", "retry_requested", "t9"),
-                ("u1", "score", "mark_applied", "t10"),
+                (str(LOCAL_TENANT), str(job_id), "score", "stage_succeeded", "t0"),
+                (str(LOCAL_TENANT), str(job_id), "tailor", "stage_failed", "t1"),
+                (str(LOCAL_TENANT), str(job_id), "apply", "mark_skipped", "t2"),
+                (str(LOCAL_TENANT), str(job_id), "apply", "cancel_requested", "t3"),
+                (str(LOCAL_TENANT), str(job_id), "apply", "lock_released", "t4"),
+                (str(LOCAL_TENANT), str(job_id), "apply", "action_started", "t5"),
+                (str(LOCAL_TENANT), str(job_id), "apply", "action_succeeded", "t6"),
+                (str(LOCAL_TENANT), str(job_id), "apply", "action_failed", "t7"),
+                (str(LOCAL_TENANT), str(job_id), "apply", "dry_run_completed", "t8"),
+                (str(LOCAL_TENANT), str(job_id), "score", "retry_requested", "t9"),
+                (str(LOCAL_TENANT), str(job_id), "score", "mark_applied", "t10"),
                 # Already-PascalCase rows must pass through unchanged.
-                ("u1", "score", "StageCompleted", "t11"),
+                (str(LOCAL_TENANT), str(job_id), "score", "StageCompleted", "t11"),
             ],
         )
         conn.commit()
@@ -64,9 +71,14 @@ def test_migration_is_idempotent(tmp_path: Path) -> None:
     db_path = tmp_path / "jobs.db"
     conn = init_db(db_path)
     try:
+        job_id = generate_job_id()
         conn.execute(
-            "INSERT INTO job_events (job_url, stage, event_type, occurred_at) VALUES (?, ?, ?, ?)",
-            ("u1", "score", "stage_succeeded", "t0"),
+            """
+            INSERT INTO job_events (
+                tenant_id, job_id, identity_version, stage, event_type, level, occurred_at
+            ) VALUES (?, ?, 1, ?, ?, 'info', ?)
+            """,
+            (str(LOCAL_TENANT), str(job_id), "score", "stage_succeeded", "t0"),
         )
         conn.commit()
 

--- a/workers/automation/tests/test_linkedin_authenticated_enrichment_retry.py
+++ b/workers/automation/tests/test_linkedin_authenticated_enrichment_retry.py
@@ -14,7 +14,7 @@ from jobctrl.domain.enrichment import (
     FullDescription,
     JobEnrichment,
 )
-from jobctrl.domain.identifiers import JobId
+from jobctrl.domain.identifiers import JobId, generate_job_id
 from jobctrl.domain.tenant import LOCAL_TENANT
 from jobctrl.enrichment.detail import (
     _MAX_AUTHENTICATED_LINKEDIN_RETRY_ATTEMPTS,
@@ -72,11 +72,33 @@ class _RecoveryResolver:
 
 
 def _seed_discovered(conn: sqlite3.Connection, url: str, site: str) -> None:
+    job_id = generate_job_id()
     conn.execute(
-        "INSERT INTO jobs (url, title, site, discovered_at) VALUES (?, ?, ?, ?)",
-        (url, "Engineer", site, "2026-01-01T00:00:00+00:00"),
+        """
+        INSERT INTO jobs (tenant_id, job_id, url, title, site, discovered_at)
+        VALUES (?, ?, ?, ?, ?, ?)
+        """,
+        (str(LOCAL_TENANT), str(job_id), url, "Engineer", site, "2026-01-01T00:00:00+00:00"),
+    )
+    conn.execute(
+        """
+        INSERT INTO job_locators (
+            tenant_id, job_id, locator_kind, locator_value, is_current,
+            first_seen_at, last_seen_at, retired_at
+        ) VALUES (?, ?, 'posting_url', ?, 1, ?, ?, NULL)
+        """,
+        (str(LOCAL_TENANT), str(job_id), url, "2026-01-01T00:00:00+00:00", "2026-01-01T00:00:00+00:00"),
     )
     conn.commit()
+
+
+def _job_id(conn: sqlite3.Connection, url: str) -> JobId:
+    row = conn.execute(
+        "SELECT job_id FROM jobs WHERE tenant_id = ? AND url = ?",
+        (str(LOCAL_TENANT), url),
+    ).fetchone()
+    assert row is not None
+    return JobId(str(row["job_id"]))
 
 
 def _save_enriched(
@@ -90,7 +112,7 @@ def _save_enriched(
     now = datetime.now(timezone.utc).isoformat()
     aggregate = JobEnrichment.empty(
         tenant_id=LOCAL_TENANT,
-        job_id=JobId(url),
+        job_id=_job_id(conn, url),
         updated_at=now,
     )
     for attempt_index in range(attempts):
@@ -121,7 +143,7 @@ def _save_failed(
     now = datetime.now(timezone.utc).isoformat()
     aggregate = JobEnrichment.empty(
         tenant_id=LOCAL_TENANT,
-        job_id=JobId(url),
+        job_id=_job_id(conn, url),
         updated_at=now,
     )
     for attempt_index in range(attempts):
@@ -233,15 +255,15 @@ def test_retry_candidates_reset_failed_rows_and_preserve_enriched(
 
     assert reset_count == 1
     repo = SqliteEnrichmentRepository(conn)
-    missing = repo.load(LOCAL_TENANT, JobId(missing_url))
+    missing = repo.load(LOCAL_TENANT, _job_id(conn, missing_url))
     assert missing is not None
     assert missing.is_enriched
     assert missing.full_description is not None
     assert missing.full_description.text == "A complete LinkedIn description"
     assert missing.application_url is None
-    assert repo.load(LOCAL_TENANT, JobId(failed_url)).is_pending  # type: ignore[union-attr]
-    assert repo.load(LOCAL_TENANT, JobId(has_apply_url)).is_enriched  # type: ignore[union-attr]
-    assert repo.load(LOCAL_TENANT, JobId(indeed_url)).is_enriched  # type: ignore[union-attr]
+    assert repo.load(LOCAL_TENANT, _job_id(conn, failed_url)).is_pending  # type: ignore[union-attr]
+    assert repo.load(LOCAL_TENANT, _job_id(conn, has_apply_url)).is_enriched  # type: ignore[union-attr]
+    assert repo.load(LOCAL_TENANT, _job_id(conn, indeed_url)).is_enriched  # type: ignore[union-attr]
 
 
 def test_enriched_missing_apply_url_preserves_description_on_failed_recovery(
@@ -262,7 +284,7 @@ def test_enriched_missing_apply_url_preserves_description_on_failed_recovery(
     assert resolver.calls == [url]
     assert resolver.closed is True
     repo = SqliteEnrichmentRepository(conn)
-    aggregate = repo.load(LOCAL_TENANT, JobId(url))
+    aggregate = repo.load(LOCAL_TENANT, _job_id(conn, url))
     assert aggregate is not None
     assert aggregate.is_enriched
     assert aggregate.full_description is not None
@@ -289,7 +311,7 @@ def test_enriched_missing_apply_url_preserves_description_when_resolver_raises(
 
     assert reset_count == 0
     repo = SqliteEnrichmentRepository(conn)
-    aggregate = repo.load(LOCAL_TENANT, JobId(url))
+    aggregate = repo.load(LOCAL_TENANT, _job_id(conn, url))
     assert aggregate is not None
     assert aggregate.is_enriched
     assert aggregate.full_description is not None
@@ -315,7 +337,7 @@ def test_enriched_missing_apply_url_backfills_on_successful_recovery(
     assert reset_count == 0
     assert resolver.calls == [url]
     repo = SqliteEnrichmentRepository(conn)
-    aggregate = repo.load(LOCAL_TENANT, JobId(url))
+    aggregate = repo.load(LOCAL_TENANT, _job_id(conn, url))
     assert aggregate is not None
     assert aggregate.is_enriched
     assert aggregate.full_description is not None
@@ -344,7 +366,7 @@ def test_enriched_missing_apply_url_recovery_is_bounded_across_runs(
     # reached (initial enrichment attempt + N-1 recovery passes), never forever.
     assert len(resolver.calls) == _MAX_AUTHENTICATED_LINKEDIN_RETRY_ATTEMPTS - 1
     repo = SqliteEnrichmentRepository(conn)
-    aggregate = repo.load(LOCAL_TENANT, JobId(url))
+    aggregate = repo.load(LOCAL_TENANT, _job_id(conn, url))
     assert aggregate is not None
     assert aggregate.attempt_count == _MAX_AUTHENTICATED_LINKEDIN_RETRY_ATTEMPTS
     # Description preserved intact across every run.
@@ -372,7 +394,7 @@ def test_failed_row_still_reset_for_authenticated_retry(
     # Non-enriched rows never touch the apply-URL resolver.
     assert resolver.calls == []
     repo = SqliteEnrichmentRepository(conn)
-    aggregate = repo.load(LOCAL_TENANT, JobId(url))
+    aggregate = repo.load(LOCAL_TENANT, _job_id(conn, url))
     assert aggregate is not None
     assert aggregate.is_pending
 
@@ -391,8 +413,8 @@ def test_retry_candidates_skip_nonretryable_and_exhausted_rows(
 
     assert reset_count == 0
     repo = SqliteEnrichmentRepository(conn)
-    assert repo.load(LOCAL_TENANT, JobId(nonretryable_url)).is_failed  # type: ignore[union-attr]
-    assert repo.load(LOCAL_TENANT, JobId(exhausted_url)).is_enriched  # type: ignore[union-attr]
+    assert repo.load(LOCAL_TENANT, _job_id(conn, nonretryable_url)).is_failed  # type: ignore[union-attr]
+    assert repo.load(LOCAL_TENANT, _job_id(conn, exhausted_url)).is_enriched  # type: ignore[union-attr]
 
 
 def test_recovery_pass_navigation_consumes_run_budget(
@@ -445,7 +467,7 @@ def test_recovery_pass_defers_when_run_budget_exhausted(
     assert resolver.calls == []
     assert reset_count == 0
     repo = SqliteEnrichmentRepository(conn)
-    aggregate = repo.load(LOCAL_TENANT, JobId(url))
+    aggregate = repo.load(LOCAL_TENANT, _job_id(conn, url))
     assert aggregate is not None
     assert aggregate.is_enriched
     assert aggregate.application_url is None
@@ -454,8 +476,8 @@ def test_recovery_pass_defers_when_run_budget_exhausted(
     # The deferral is a first-class budget-exhausted outcome, not a scrape error.
     row = conn.execute(
         "SELECT failure_category, is_scrape_failure FROM operational_attempt_metrics "
-        "WHERE job_url = ? AND outcome = 'blocked'",
-        (url,),
+        "WHERE stage = 'enrich' AND source_id = 'linkedin' AND outcome = 'blocked' "
+        "ORDER BY metric_id DESC LIMIT 1",
     ).fetchone()
     assert row is not None
     assert row[0] == "budget_exhausted"

--- a/workers/automation/tests/test_stage_runner_thread_safety.py
+++ b/workers/automation/tests/test_stage_runner_thread_safety.py
@@ -25,6 +25,7 @@ from pathlib import Path
 import pytest
 
 from jobctrl.database import get_connection, init_db
+from jobctrl.domain.identifiers import generate_job_id
 from jobctrl.infrastructure.materials import SqliteMaterialsRepository
 from jobctrl.infrastructure.profile import factory as profile_factory
 from jobctrl.state import set_stage_state, ensure_job_stage_rows
@@ -110,26 +111,26 @@ def test_failed_to_running_transition_skips_validation(
     bypass so a reverted runner doesn't silently start crashing in
     production."""
 
-    url = "https://example.com/job/1"
-    ensure_job_stage_rows(db, url, discovered_at="2026-01-01T00:00:00+00:00")
+    job_id = generate_job_id()
+    ensure_job_stage_rows(db, job_id, discovered_at="2026-01-01T00:00:00+00:00")
     # Seed the row in 'failed' state via the validation bypass — the
     # canonical state machine doesn't permit pending -> failed directly,
     # but for this test we just need the row to BE in failed state to
     # exercise the fix.
     set_stage_state(
-        db, url, "tailor", "failed",
+        db, job_id, "tailor", "failed",
         error_message="prior run died",
         validate_transition=False,
     )
 
     # Strict path: Failed -> Running must be rejected by the canonical table.
     with pytest.raises(ValueError, match="Invalid state transition"):
-        set_stage_state(db, url, "tailor", "running")
+        set_stage_state(db, job_id, "tailor", "running")
 
     # Bypass path: runners pass validate_transition=False and survive.
-    set_stage_state(db, url, "tailor", "running", validate_transition=False)
+    set_stage_state(db, job_id, "tailor", "running", validate_transition=False)
     row = db.execute(
-        "SELECT state FROM job_stage_states WHERE job_url = ? AND stage = ?",
-        (url, "tailor"),
+        "SELECT state FROM job_stage_states WHERE job_id = ? AND stage = ?",
+        (job_id, "tailor"),
     ).fetchone()
     assert row["state"] == "running"


### PR DESCRIPTION
## Summary

- migrate the remaining discovery/runtime fixtures to tenant-scoped canonical `JobId` values
- update exact-v7 event, enrichment, browser, and lineage test seams
- keep JobStreaming behavior unchanged; this PR is fixture compatibility only
- serve as the current cumulative top for the rebuilt Step 3 stack

## Validation

- cumulative Step 3 Python suite: 185 passed
- cumulative focused API RPC/projection suite: 106 passed
- hosted-failure API regression files: 45 passed
- Python cross-runtime projection/digest parity: 5 passed
- Fastify server suite excluding the sandbox-prohibited loopback listener: 205 passed, 1 skipped
- full workspace TypeScript check: passed
- focused Ruff and `git diff --check`: passed
- independent cumulative review: PASS, 0 Blocker / 0 High / 0 Medium / 0 Low
- independent cumulative QA: PASS, 0 Blocker / 0 High / 0 Medium / 0 Low

Hosted top-only CI will revalidate the clean pushed stack. Canonical documentation and the final cumulative Tier 3 release gate remain deferred to the final roadmap PR.
