### PR TITLE
feat(storage): migrate versioned scoring keywords

### DIFF
--- a/apps/api/src/schema-manifest.ts
+++ b/apps/api/src/schema-manifest.ts
@@ -14,9 +14,9 @@ export type SchemaManifest = {
 // a different schema.
 export const EXACT_V7_SCHEMA_MANIFEST: SchemaManifest = {
   version: 7,
-  objectCount: 197,
-  tableCount: 101,
-  fingerprint: "b24a3c1c366b40a8acf3b27f4eb237ef63e52d7ebc55166b7df58970afbd0d80",
+  objectCount: 199,
+  tableCount: 102,
+  fingerprint: "515fbe3685b850638bbf0900fa99f2dc6faf46b2ae480b152a2fb5ff972d68f4",
 };
 
 type SqliteMasterRow = [type: string, name: string, tableName: string, sql: string];

--- a/apps/api/test/schema-version-guard.test.ts
+++ b/apps/api/test/schema-version-guard.test.ts
@@ -142,14 +142,14 @@ describe("schema version guard at DB open", () => {
     const pythonManifest = fs.readFileSync(pythonManifestPath, "utf8");
 
     expect(pythonManifest).toContain("version=7,");
-    expect(pythonManifest).toContain("object_count=197,");
-    expect(pythonManifest).toContain("table_count=101,");
+    expect(pythonManifest).toContain("object_count=199,");
+    expect(pythonManifest).toContain("table_count=102,");
     expect(pythonManifest).toContain(`fingerprint=\"${EXACT_V7_SCHEMA_MANIFEST.fingerprint}\",`);
     expect(EXACT_V7_SCHEMA_MANIFEST).toEqual({
       version: SUPPORTED_SCHEMA_VERSION,
-      objectCount: 197,
-      tableCount: 101,
-      fingerprint: "b24a3c1c366b40a8acf3b27f4eb237ef63e52d7ebc55166b7df58970afbd0d80",
+      objectCount: 199,
+      tableCount: 102,
+      fingerprint: "515fbe3685b850638bbf0900fa99f2dc6faf46b2ae480b152a2fb5ff972d68f4",
     });
   });
 });

--- a/workers/automation/src/jobctrl/infrastructure/migrations/schema_manifest.py
+++ b/workers/automation/src/jobctrl/infrastructure/migrations/schema_manifest.py
@@ -23,9 +23,9 @@ class SchemaManifest:
 # semantically meaningful and must never normalize to the same fingerprint.
 EXACT_V7_MANIFEST = SchemaManifest(
     version=7,
-    object_count=197,
-    table_count=101,
-    fingerprint="b24a3c1c366b40a8acf3b27f4eb237ef63e52d7ebc55166b7df58970afbd0d80",
+    object_count=199,
+    table_count=102,
+    fingerprint="515fbe3685b850638bbf0900fa99f2dc6faf46b2ae480b152a2fb5ff972d68f4",
 )
 
 

--- a/workers/automation/src/jobctrl/infrastructure/migrations/schema_v7.sql
+++ b/workers/automation/src/jobctrl/infrastructure/migrations/schema_v7.sql
@@ -1160,6 +1160,24 @@ CREATE TABLE "job_resume_template_assignments" (
             FOREIGN KEY (tenant_id, job_id)
                 REFERENCES jobs(tenant_id, job_id) ON DELETE CASCADE
         );
+CREATE TABLE "job_score_keywords" (
+            tenant_id          TEXT NOT NULL DEFAULT 'local',
+            job_id             TEXT NOT NULL,
+            score_version      INTEGER NOT NULL CHECK(score_version > 0),
+            normalized_keyword TEXT NOT NULL
+                CHECK(length(trim(normalized_keyword)) > 0),
+            display_keyword    TEXT NOT NULL
+                CHECK(length(trim(display_keyword)) > 0),
+            position           INTEGER NOT NULL CHECK(position >= 0),
+            PRIMARY KEY (
+                tenant_id, job_id, score_version, normalized_keyword
+            ),
+            UNIQUE (tenant_id, job_id, score_version, position),
+            FOREIGN KEY (tenant_id, job_id, score_version)
+                REFERENCES "job_scores"(
+                    tenant_id, job_id, version
+                ) ON DELETE CASCADE
+        );
 CREATE TABLE "job_score_staleness" (
             tenant_id                 TEXT NOT NULL DEFAULT 'local',
             job_id                   TEXT NOT NULL,
@@ -1979,6 +1997,11 @@ CREATE INDEX idx_job_posted_compensation_parse_state
 CREATE INDEX idx_job_resume_template_assignments_template
         ON job_resume_template_assignments(
             tenant_id, template_id, version_id
+        )
+        ;
+CREATE INDEX idx_job_score_keywords_tenant_normalized
+        ON job_score_keywords(
+            tenant_id, normalized_keyword, job_id, score_version
         )
         ;
 CREATE INDEX idx_job_score_staleness_job

--- a/workers/automation/src/jobctrl/infrastructure/migrations/v6_to_v7_plan.py
+++ b/workers/automation/src/jobctrl/infrastructure/migrations/v6_to_v7_plan.py
@@ -226,6 +226,14 @@ def _table_plans() -> dict[str, TablePlan]:
         source_exists=False,
         source_required=False,
     )
+    # Scoring keywords are derived solely from each migrated job_scores row.
+    # They had no v6 relation to copy, so one dedicated owner prevents
+    # duplicate or unnormalized rows from a broad scalar copy.
+    plans["job_score_keywords"] = TablePlan(
+        TableDisposition.STRUCTURED_REWRITE,
+        source_exists=False,
+        source_required=False,
+    )
     plans["discovery_run_projections"] = TablePlan(
         TableDisposition.RETIRED,
         target_exists=False,
@@ -382,6 +390,7 @@ _TARGET_JOB_ID_COLUMNS: Final = frozenset(
         ("job_duplicate_links", "surviving_job_id"),
         ("job_events", "job_id"),
         ("job_locators", "job_id"),
+        ("job_score_keywords", "job_id"),
         ("jobs", "job_id"),
     }
 )
@@ -481,6 +490,7 @@ _DECLARED_COLUMNS: Final[Mapping[str, frozenset[str]]] = _column_manifest(
         "job_requirement_fit_items": "job_url tenant_id job_id score_version requirement_id requirement_text tier weight job_evidence_span fit_json contribution_json tailoring_json artifact_coverage_json position",
         "job_requirement_fit_reports": "job_url tenant_id job_id score_version employer_analysis_generation profile_snapshot_version scoring_policy_version formula_version resolved_fit_score fit_band confidence summary_json created_at",
         "job_resume_template_assignments": "tenant_id job_url job_id template_id version_id updated_at",
+        "job_score_keywords": "tenant_id job_id score_version normalized_keyword display_keyword position",
         "job_score_staleness": "tenant_id job_url job_id stale_reason old_policy_id old_policy_version new_policy_id new_policy_version marked_at resolved resolved_at resolved_by_score_version",
         "job_scores": "job_url tenant_id job_id version fit_score breakdown_json keywords_json scored_at correction_json criteria_json trace_json",
         "job_source_observations": "tenant_id source_observation_id job_url job_id source_id source_native_id observed_url normalized_observed_url run_id observed_at",
@@ -606,6 +616,7 @@ _TARGET_ONLY_COLUMNS: Final[Mapping[str, frozenset[str]]] = _column_manifest(
         "job_requirement_fit_items": "job_id",
         "job_requirement_fit_reports": "job_id",
         "job_resume_template_assignments": "job_id",
+        "job_score_keywords": "job_id",
         "job_score_staleness": "job_id",
         "job_scores": "job_id",
         "job_source_observations": "job_id",

--- a/workers/automation/src/jobctrl/infrastructure/migrations/v6_to_v7_population_steps.py
+++ b/workers/automation/src/jobctrl/infrastructure/migrations/v6_to_v7_population_steps.py
@@ -48,6 +48,9 @@ from jobctrl.infrastructure.migrations.v6_to_v7_plan import (
     TableDisposition,
 )
 from jobctrl.infrastructure.migrations.v6_to_v7_root import copy_root_jobs
+from jobctrl.infrastructure.migrations.v6_to_v7_score_keywords import (
+    copy_score_keywords,
+)
 from jobctrl.infrastructure.migrations.v6_to_v7_work_items import (
     copy_structured_work_items,
 )
@@ -104,6 +107,13 @@ CANDIDATE_POPULATION_STEPS: Final[tuple[CandidatePopulationStep, ...]] = (
         depends_on=("root",),
         writer=copy_direct_and_scalar_tables,
         argument_profile=CandidatePopulationArgumentProfile.PLAIN,
+    ),
+    CandidatePopulationStep(
+        step_id="score_keywords",
+        owned_tables=frozenset({"job_score_keywords"}),
+        depends_on=("direct_scalar",),
+        writer=copy_score_keywords,
+        argument_profile=CandidatePopulationArgumentProfile.JOB_IDS,
     ),
     CandidatePopulationStep(
         step_id="duplicate_links",

--- a/workers/automation/src/jobctrl/infrastructure/migrations/v6_to_v7_score_keywords.py
+++ b/workers/automation/src/jobctrl/infrastructure/migrations/v6_to_v7_score_keywords.py
@@ -1,0 +1,247 @@
+"""Populate the exact-v7 normalized keyword relation from migrated scores."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import unicodedata
+from dataclasses import dataclass
+from typing import Final
+
+from jobctrl.infrastructure.migrations.schema_manifest import (
+    EXACT_V7_MANIFEST,
+    assert_exact_manifest,
+)
+from jobctrl.infrastructure.migrations.v6_to_v7_copy import (
+    CandidateCopyError,
+    JobIdMap,
+    build_job_id_map,
+)
+from jobctrl.infrastructure.migrations.v6_to_v7_preflight import (
+    assert_v6_migration_preflight,
+)
+
+
+_SAVEPOINT: Final = "v6_score_keyword_copy"
+
+
+class CandidateScoreKeywordError(RuntimeError):
+    """Raised when score keyword migration cannot preserve the score contract."""
+
+
+@dataclass(frozen=True)
+class ScoreKeywordPopulationResult:
+    """Metadata-only receipt for the one score-keyword population owner."""
+
+    migrated_score_versions: int
+    copied_keywords: int
+
+
+def copy_score_keywords(
+    source: sqlite3.Connection,
+    candidate: sqlite3.Connection,
+    *,
+    job_ids: JobIdMap,
+) -> ScoreKeywordPopulationResult:
+    """Populate normalized keywords after ``job_scores`` receives stable JobIds.
+
+    Each v6 JSON string array is normalized with NFKC, whitespace collapse,
+    and casefold lookup. Blank values are dropped; duplicate lookup keys retain
+    the first normalized display text and receive contiguous positions.
+    """
+    assert_v6_migration_preflight(source)
+    assert_exact_manifest(candidate, EXACT_V7_MANIFEST)
+    _assert_empty(candidate)
+    _assert_job_id_map(source, candidate, job_ids)
+
+    source_rows = source.execute(
+        """
+        SELECT job_url, tenant_id, version, keywords_json
+        FROM job_scores
+        ORDER BY tenant_id, job_url, version
+        """
+    ).fetchall()
+    target_score_ids = _target_score_ids(candidate)
+    keyword_rows: list[tuple[str, str, int, str, str, int]] = []
+    migrated_score_ids: set[tuple[str, str, int]] = set()
+
+    candidate.execute(f"SAVEPOINT {_SAVEPOINT}")
+    try:
+        for source_row in source_rows:
+            tenant_id, job_id, score_version, keywords_json = _source_score_row(
+                source_row,
+                job_ids,
+            )
+            score_id = (tenant_id, job_id, score_version)
+            if score_id in migrated_score_ids:
+                raise CandidateScoreKeywordError(
+                    "source score identities are not unique"
+                )
+            migrated_score_ids.add(score_id)
+            for normalized, display, position in _normalized_keywords(keywords_json):
+                keyword_rows.append(
+                    (
+                        tenant_id,
+                        job_id,
+                        score_version,
+                        normalized,
+                        display,
+                        position,
+                    )
+                )
+
+        if migrated_score_ids != target_score_ids:
+            raise CandidateScoreKeywordError(
+                "migrated score identities do not match the candidate"
+            )
+        if keyword_rows:
+            candidate.executemany(
+                """
+                INSERT INTO job_score_keywords (
+                    tenant_id, job_id, score_version, normalized_keyword,
+                    display_keyword, position
+                ) VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                keyword_rows,
+            )
+        _assert_populated(candidate, keyword_rows)
+        candidate.execute(f"RELEASE SAVEPOINT {_SAVEPOINT}")
+    except BaseException:
+        candidate.execute(f"ROLLBACK TO SAVEPOINT {_SAVEPOINT}")
+        candidate.execute(f"RELEASE SAVEPOINT {_SAVEPOINT}")
+        raise
+
+    return ScoreKeywordPopulationResult(
+        migrated_score_versions=len(migrated_score_ids),
+        copied_keywords=len(keyword_rows),
+    )
+
+
+def _assert_empty(candidate: sqlite3.Connection) -> None:
+    if _table_count(candidate, "job_score_keywords"):
+        raise CandidateScoreKeywordError(
+            "candidate score keyword table must be empty"
+        )
+
+
+def _assert_job_id_map(
+    source: sqlite3.Connection,
+    candidate: sqlite3.Connection,
+    job_ids: JobIdMap,
+) -> None:
+    try:
+        expected = build_job_id_map(source, candidate)
+    except CandidateCopyError:
+        raise CandidateScoreKeywordError(
+            "candidate JobId mapping is invalid for score keywords"
+        ) from None
+    if job_ids != expected:
+        raise CandidateScoreKeywordError(
+            "score keyword population received a mismatched JobId map"
+        )
+
+
+def _source_score_row(
+    row: tuple[object, ...],
+    job_ids: JobIdMap,
+) -> tuple[str, str, int, object]:
+    locator, tenant, version, keywords_json = row
+    tenant_id = str(tenant or "").strip()
+    if not tenant_id:
+        raise CandidateScoreKeywordError("source score has an empty tenant")
+    if isinstance(version, bool) or not isinstance(version, int) or version <= 0:
+        raise CandidateScoreKeywordError("source score has an invalid version")
+    try:
+        job_id = job_ids.resolve(tenant_id=tenant_id, locator=locator)
+    except CandidateCopyError:
+        raise CandidateScoreKeywordError(
+            "source score cannot resolve to a canonical JobId"
+        ) from None
+    if job_id is None:
+        raise CandidateScoreKeywordError(
+            "source score cannot resolve to a canonical JobId"
+        )
+    return tenant_id, job_id, version, keywords_json
+
+
+def _normalized_keywords(keywords_json: object) -> tuple[tuple[str, str, int], ...]:
+    if not isinstance(keywords_json, str):
+        raise CandidateScoreKeywordError("source score keywords must be JSON text")
+    try:
+        values = json.loads(keywords_json)
+    except json.JSONDecodeError:
+        raise CandidateScoreKeywordError(
+            "source score keywords are not valid JSON"
+        ) from None
+    if not isinstance(values, list) or any(
+        not isinstance(value, str) for value in values
+    ):
+        raise CandidateScoreKeywordError(
+            "source score keywords must be a JSON string array"
+        )
+
+    normalized: list[tuple[str, str, int]] = []
+    seen: set[str] = set()
+    for value in values:
+        display = " ".join(unicodedata.normalize("NFKC", value).split())
+        if not display:
+            continue
+        lookup = display.casefold()
+        if lookup in seen:
+            continue
+        seen.add(lookup)
+        normalized.append((lookup, display, len(normalized)))
+    return tuple(normalized)
+
+
+def _target_score_ids(candidate: sqlite3.Connection) -> set[tuple[str, str, int]]:
+    return {
+        (str(tenant), str(job_id), int(version))
+        for tenant, job_id, version in candidate.execute(
+            """
+            SELECT tenant_id, job_id, version
+            FROM job_scores
+            ORDER BY tenant_id, job_id, version
+            """
+        ).fetchall()
+    }
+
+
+def _assert_populated(
+    candidate: sqlite3.Connection,
+    expected_rows: list[tuple[str, str, int, str, str, int]],
+) -> None:
+    rows = [
+        tuple(row)
+        for row in candidate.execute(
+            """
+            SELECT tenant_id, job_id, score_version, normalized_keyword,
+                   display_keyword, position
+            FROM job_score_keywords
+            ORDER BY tenant_id, job_id, score_version, position
+            """
+        ).fetchall()
+    ]
+    expected = sorted(
+        expected_rows,
+        key=lambda row: (row[0], row[1], row[2], row[5]),
+    )
+    if rows != expected:
+        raise CandidateScoreKeywordError(
+            "candidate score keywords differ from normalized source values"
+        )
+    if candidate.execute("PRAGMA foreign_key_check").fetchall():
+        raise CandidateScoreKeywordError(
+            "candidate score keywords have foreign-key violations"
+        )
+
+
+def _table_count(candidate: sqlite3.Connection, table: str) -> int:
+    return int(candidate.execute(f'SELECT COUNT(*) FROM "{table}"').fetchone()[0])
+
+
+__all__ = [
+    "CandidateScoreKeywordError",
+    "ScoreKeywordPopulationResult",
+    "copy_score_keywords",
+]

--- a/workers/automation/tests/test_exact_v7_schema.py
+++ b/workers/automation/tests/test_exact_v7_schema.py
@@ -353,6 +353,141 @@ def test_job_purge_cascades_private_resume_review_rows(tmp_path: Path) -> None:
     close_connection(db_path)
 
 
+def test_job_score_keywords_exact_schema_contract(tmp_path: Path) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    conn = init_db(db_path)
+    conn.execute("PRAGMA foreign_keys = ON")
+    job_id = "11111111-1111-4111-8111-111111111111"
+    conn.execute(
+        "INSERT INTO jobs (tenant_id, job_id, url) VALUES (?, ?, ?)",
+        ("local", job_id, "https://jobs.example/1"),
+    )
+    conn.execute(
+        """
+        INSERT INTO job_scores (
+            tenant_id, job_id, version, fit_score, breakdown_json,
+            keywords_json, scored_at
+        ) VALUES (?, ?, 1, 8, '{}', '[]', ?)
+        """,
+        ("local", job_id, "2026-08-01T00:00:00Z"),
+    )
+    conn.execute(
+        """
+        INSERT INTO job_score_keywords (
+            tenant_id, job_id, score_version, normalized_keyword,
+            display_keyword, position
+        ) VALUES (?, ?, 1, 'python', 'Python', 0)
+        """,
+        ("local", job_id),
+    )
+    conn.commit()
+
+    columns = conn.execute("PRAGMA table_info(job_score_keywords)").fetchall()
+    assert tuple(str(column[1]) for column in columns) == (
+        "tenant_id",
+        "job_id",
+        "score_version",
+        "normalized_keyword",
+        "display_keyword",
+        "position",
+    )
+    assert tuple(
+        str(column[1]) for column in columns if int(column[5])
+    ) == ("tenant_id", "job_id", "score_version", "normalized_keyword")
+
+    foreign_keys = conn.execute(
+        "PRAGMA foreign_key_list(job_score_keywords)"
+    ).fetchall()
+    score_foreign_keys = [foreign_key for foreign_key in foreign_keys if foreign_key[2] == "job_scores"]
+    assert {(foreign_key[3], foreign_key[4]) for foreign_key in score_foreign_keys} == {
+        ("tenant_id", "tenant_id"),
+        ("job_id", "job_id"),
+        ("score_version", "version"),
+    }
+    assert {foreign_key[6] for foreign_key in score_foreign_keys} == {"CASCADE"}
+
+    with pytest.raises(sqlite3.IntegrityError):
+        conn.execute(
+            """
+            INSERT INTO job_score_keywords (
+                tenant_id, job_id, score_version, normalized_keyword,
+                display_keyword, position
+            ) VALUES (?, ?, 1, 'python', 'PYTHON', 1)
+            """,
+            ("local", job_id),
+        )
+    with pytest.raises(sqlite3.IntegrityError):
+        conn.execute(
+            """
+            INSERT INTO job_score_keywords (
+                tenant_id, job_id, score_version, normalized_keyword,
+                display_keyword, position
+            ) VALUES (?, ?, 1, 'python', 'Python', 0)
+            """,
+            ("other-tenant", job_id),
+        )
+    with pytest.raises(sqlite3.IntegrityError):
+        conn.execute(
+            """
+            INSERT INTO job_score_keywords (
+                tenant_id, job_id, score_version, normalized_keyword,
+                display_keyword, position
+            ) VALUES (?, ?, 1, '   ', 'SQL', 1)
+            """,
+            ("local", job_id),
+        )
+    with pytest.raises(sqlite3.IntegrityError):
+        conn.execute(
+            """
+            INSERT INTO job_score_keywords (
+                tenant_id, job_id, score_version, normalized_keyword,
+                display_keyword, position
+            ) VALUES (?, ?, 1, 'sql', '', 1)
+            """,
+            ("local", job_id),
+        )
+    with pytest.raises(sqlite3.IntegrityError):
+        conn.execute(
+            """
+            INSERT INTO job_score_keywords (
+                tenant_id, job_id, score_version, normalized_keyword,
+                display_keyword, position
+            ) VALUES (?, ?, 1, 'sql', 'SQL', 0)
+            """,
+            ("local", job_id),
+        )
+    with pytest.raises(sqlite3.IntegrityError):
+        conn.execute(
+            """
+            INSERT INTO job_score_keywords (
+                tenant_id, job_id, score_version, normalized_keyword,
+                display_keyword, position
+            ) VALUES (?, ?, 1, 'sql', 'SQL', -1)
+            """,
+            ("local", job_id),
+        )
+
+    indexes = {
+        str(index[1]): index
+        for index in conn.execute("PRAGMA index_list(job_score_keywords)")
+    }
+    assert indexes["idx_job_score_keywords_tenant_normalized"][2] == 0
+    assert tuple(
+        str(column[2])
+        for column in conn.execute(
+            "PRAGMA index_info(idx_job_score_keywords_tenant_normalized)"
+        )
+    ) == ("tenant_id", "normalized_keyword", "job_id", "score_version")
+
+    conn.execute(
+        "DELETE FROM job_scores WHERE tenant_id = ? AND job_id = ? AND version = 1",
+        ("local", job_id),
+    )
+    assert conn.execute("SELECT COUNT(*) FROM job_score_keywords").fetchone()[0] == 0
+    assert conn.execute("PRAGMA foreign_key_check").fetchone() is None
+    close_connection(db_path)
+
+
 def test_incomplete_v6_is_rejected_before_any_write(tmp_path: Path) -> None:
     db_path = tmp_path / "jobctrl.db"
     _create_incomplete_v6_database(db_path)

--- a/workers/automation/tests/test_v6_to_v7_candidate.py
+++ b/workers/automation/tests/test_v6_to_v7_candidate.py
@@ -37,6 +37,7 @@ _SOURCE_TITLE = "Shipped V6 fixture"
 _STEP_IDS = (
     "root",
     "direct_scalar",
+    "score_keywords",
     "duplicate_links",
     "events",
     "work_items",

--- a/workers/automation/tests/test_v6_to_v7_plan.py
+++ b/workers/automation/tests/test_v6_to_v7_plan.py
@@ -149,6 +149,16 @@ def test_identity_locator_and_sequence_roles_are_not_inferred_from_names() -> No
     )
     assert table_plan("job_locators").disposition is TableDisposition.STRUCTURED_REWRITE
     assert (
+        table_plan("job_score_keywords").disposition
+        is TableDisposition.STRUCTURED_REWRITE
+    )
+    assert not table_plan("job_score_keywords").source_exists
+    assert classify_column("job_score_keywords", "job_id", "source") is None
+    assert (
+        classify_column("job_score_keywords", "job_id", "target")
+        is ColumnRole.JOB_ID
+    )
+    assert (
         table_plan("dashboard_projections").disposition
         is TableDisposition.STRUCTURED_REWRITE
     )

--- a/workers/automation/tests/test_v6_to_v7_population_steps.py
+++ b/workers/automation/tests/test_v6_to_v7_population_steps.py
@@ -49,6 +49,9 @@ from jobctrl.infrastructure.migrations.v6_to_v7_population_steps import (
     CandidatePopulationArgumentProfile,
 )
 from jobctrl.infrastructure.migrations.v6_to_v7_root import copy_root_jobs
+from jobctrl.infrastructure.migrations.v6_to_v7_score_keywords import (
+    copy_score_keywords,
+)
 from jobctrl.infrastructure.migrations.v6_to_v7_work_items import (
     copy_structured_work_items,
 )
@@ -94,7 +97,7 @@ def test_direct_scalar_and_structured_ownership_match_the_migration_plan() -> No
         if step.step_id != "direct_scalar"
         for table in step.owned_tables
     } == structured_tables
-    assert len(structured_tables) == 18
+    assert len(structured_tables) == 19
 
 
 def test_population_step_ids_and_owners_are_exact() -> None:
@@ -111,6 +114,7 @@ def test_population_step_ids_and_owners_are_exact() -> None:
     assert tuple(step.step_id for step in CANDIDATE_POPULATION_STEPS) == (
         "root",
         "direct_scalar",
+        "score_keywords",
         "duplicate_links",
         "events",
         "work_items",
@@ -127,6 +131,7 @@ def test_population_step_ids_and_owners_are_exact() -> None:
     assert {step.step_id: step.owned_tables for step in CANDIDATE_POPULATION_STEPS} == {
         "root": {"jobs", "job_locators"},
         "direct_scalar": direct_scalar_tables,
+        "score_keywords": {"job_score_keywords"},
         "duplicate_links": {"job_duplicate_links"},
         "events": {"job_events"},
         "work_items": {"discovery_quarantine_entries", "preparation_work_items"},
@@ -177,6 +182,7 @@ def test_population_writers_and_argument_profiles_match_exact_signatures() -> No
     expected_writers = (
         copy_root_jobs,
         copy_direct_and_scalar_tables,
+        copy_score_keywords,
         copy_duplicate_links,
         copy_job_events,
         copy_structured_work_items,

--- a/workers/automation/tests/test_v6_to_v7_score_keywords.py
+++ b/workers/automation/tests/test_v6_to_v7_score_keywords.py
@@ -1,0 +1,239 @@
+"""Focused contracts for the stopped-runtime score-keyword migration owner."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from collections.abc import Callable, Iterator
+from pathlib import Path
+
+import pytest
+
+from jobctrl.infrastructure.migrations.schema_manifest import schema_dump
+from jobctrl.infrastructure.migrations.v6_to_v7_candidate import (
+    candidate_logical_digest,
+    populate_v7_candidate,
+)
+from jobctrl.infrastructure.migrations.v6_to_v7_score_keywords import (
+    CandidateScoreKeywordError,
+)
+from jobctrl.infrastructure.migrations.v6_to_v7_verify import (
+    verify_and_stamp_v7_candidate,
+    verify_v7_candidate,
+)
+from tests.v6_migration_fixture import create_shipped_v6_database
+
+
+_MIGRATION_AT = "2026-08-01T12:00:00+00:00"
+_JOB_ID = "00000000-0000-4000-8000-000000000001"
+_SOURCE_URL = "https://jobs.example/shipped-v6"
+
+
+def _allocator(*values: str) -> Callable[[], str]:
+    allocated: Iterator[str] = iter(values)
+    return allocated.__next__
+
+
+def _connections(
+    tmp_path: Path,
+    *,
+    name: str,
+) -> tuple[sqlite3.Connection, sqlite3.Connection, Path]:
+    source_path = tmp_path / f"{name}-source.db"
+    candidate_path = tmp_path / f"{name}-candidate.db"
+    create_shipped_v6_database(source_path)
+    source = sqlite3.connect(source_path)
+    candidate = sqlite3.connect(candidate_path)
+    source.execute("PRAGMA foreign_keys = ON")
+    candidate.execute("PRAGMA foreign_keys = ON")
+    return source, candidate, candidate_path
+
+
+def _insert_scores(source: sqlite3.Connection) -> None:
+    source.executemany(
+        """
+        INSERT INTO job_scores (
+            job_url, version, tenant_id, fit_score, breakdown_json,
+            keywords_json, scored_at
+        ) VALUES (?, ?, 'local', 8, '{}', ?, ?)
+        """,
+        (
+            (
+                _SOURCE_URL,
+                1,
+                json.dumps(
+                    [
+                        "  Python  ",
+                        "\u3000Ｐｙｔｈｏｎ\t",
+                        "Data   Science",
+                        " data science ",
+                        "\u00a0",
+                        "\t",
+                        "Straße",
+                        "STRASSE",
+                    ]
+                ),
+                _MIGRATION_AT,
+            ),
+            (
+                _SOURCE_URL,
+                2,
+                json.dumps(["Cloud\tInfrastructure", "   "]),
+                _MIGRATION_AT,
+            ),
+        ),
+    )
+    source.commit()
+
+
+def _keyword_rows(candidate: sqlite3.Connection) -> list[tuple[object, ...]]:
+    return [
+        tuple(row)
+        for row in candidate.execute(
+            """
+            SELECT tenant_id, job_id, score_version, normalized_keyword,
+                   display_keyword, position
+            FROM job_score_keywords
+            ORDER BY tenant_id, job_id, score_version, position
+            """
+        ).fetchall()
+    ]
+
+
+def _raw_candidate_dump(candidate: sqlite3.Connection) -> tuple[object, ...]:
+    return (
+        schema_dump(candidate),
+        tuple(candidate.iterdump()),
+        candidate.execute("PRAGMA user_version").fetchone(),
+    )
+
+
+def test_score_keyword_population_normalizes_each_version_and_reopens(
+    tmp_path: Path,
+) -> None:
+    source, candidate, candidate_path = _connections(tmp_path, name="normalize")
+    try:
+        _insert_scores(source)
+
+        population = populate_v7_candidate(
+            source,
+            candidate,
+            migration_at=_MIGRATION_AT,
+            job_id_factory=_allocator(_JOB_ID),
+        )
+
+        assert _keyword_rows(candidate) == [
+            ("local", _JOB_ID, 1, "python", "Python", 0),
+            ("local", _JOB_ID, 1, "data science", "Data Science", 1),
+            ("local", _JOB_ID, 1, "strasse", "Straße", 2),
+            (
+                "local",
+                _JOB_ID,
+                2,
+                "cloud infrastructure",
+                "Cloud Infrastructure",
+                0,
+            ),
+        ]
+        assert dict(population.table_row_counts)["job_score_keywords"] == 4
+        assert verify_v7_candidate(source, candidate, population).table_row_counts == (
+            population.table_row_counts
+        )
+        assert verify_and_stamp_v7_candidate(
+            source,
+            candidate,
+            population,
+        ).user_version == 7
+        candidate.commit()
+        candidate.close()
+        candidate = sqlite3.connect(candidate_path)
+
+        assert candidate.execute("PRAGMA user_version").fetchone() == (7,)
+        assert _keyword_rows(candidate)[-1] == (
+            "local",
+            _JOB_ID,
+            2,
+            "cloud infrastructure",
+            "Cloud Infrastructure",
+            0,
+        )
+    finally:
+        source.close()
+        candidate.close()
+
+
+def test_score_keyword_step_rolls_back_and_retries_with_the_same_digest(
+    tmp_path: Path,
+) -> None:
+    source, candidate, _ = _connections(tmp_path, name="retry")
+    reference_source, reference, _ = _connections(tmp_path, name="reference")
+    try:
+        _insert_scores(source)
+        _insert_scores(reference_source)
+        before = _raw_candidate_dump(candidate)
+
+        def fail_after_score_keywords(step_id: str) -> None:
+            if step_id == "score_keywords":
+                raise RuntimeError("forced score keyword failure")
+
+        with pytest.raises(RuntimeError, match="forced score keyword failure"):
+            populate_v7_candidate(
+                source,
+                candidate,
+                migration_at=_MIGRATION_AT,
+                job_id_factory=_allocator(_JOB_ID),
+                _after_step=fail_after_score_keywords,
+            )
+        assert _raw_candidate_dump(candidate) == before
+
+        retried = populate_v7_candidate(
+            source,
+            candidate,
+            migration_at=_MIGRATION_AT,
+            job_id_factory=_allocator(_JOB_ID),
+        )
+        expected = populate_v7_candidate(
+            reference_source,
+            reference,
+            migration_at=_MIGRATION_AT,
+            job_id_factory=_allocator(_JOB_ID),
+        )
+
+        assert retried == expected
+        assert candidate_logical_digest(candidate) == expected.candidate_digest
+        assert _keyword_rows(candidate) == _keyword_rows(reference)
+    finally:
+        source.close()
+        candidate.close()
+        reference_source.close()
+        reference.close()
+
+
+def test_score_keyword_population_rejects_malformed_json_without_leaving_rows(
+    tmp_path: Path,
+) -> None:
+    source, candidate, _ = _connections(tmp_path, name="malformed")
+    try:
+        source.execute(
+            """
+            INSERT INTO job_scores (
+                job_url, version, tenant_id, fit_score, breakdown_json,
+                keywords_json, scored_at
+            ) VALUES (?, 1, 'local', 8, '{}', '{', ?)
+            """,
+            (_SOURCE_URL, _MIGRATION_AT),
+        )
+        source.commit()
+        before = _raw_candidate_dump(candidate)
+
+        with pytest.raises(CandidateScoreKeywordError):
+            populate_v7_candidate(
+                source,
+                candidate,
+                migration_at=_MIGRATION_AT,
+                job_id_factory=_allocator(_JOB_ID),
+            )
+        assert _raw_candidate_dump(candidate) == before
+    finally:
+        source.close()
+        candidate.close()


### PR DESCRIPTION
## Summary

- add canonical `job_score_keywords` rows keyed by tenant, `JobId`, score version, and normalized keyword
- preserve display text and deterministic keyword order while rejecting duplicate normalized terms or positions within one score version
- cascade keyword history with its owning score version and add the tenant-scoped normalized lookup index used by later filter and aggregation queries
- populate the relation during the stopped-runtime v6-to-v7 cutover using deterministic NFKC, collapsed-whitespace, and casefold normalization
- give the new relation one migration owner with atomic rollback/retry, version preservation, malformed-input rejection, reopen, and digest verification
- refresh the Python and TypeScript exact-v7 manifests and cover the relation, constraints, foreign key, cascade, and index contract

## Why

Scoring keywords must be queryable from persisted versioned facts without parsing free-text reasoning or mixing stale score versions. Exact-v7 schema and stopped-runtime migration population form one data-integrity unit; atomic runtime writers and API/client behavior follow in separate stacked PRs.

## Validation

- focused exact-v7 schema, packaging, migration inventory/population/verification, rollback/retry, and keyword normalization tests: 58 passed
- API schema-manifest guard: 13 passed
- API typecheck: passed
- full worker Ruff: passed
- `git diff --check`: passed
- independent Tier 3 groundwork review: PASS, 0 Blocker / 0 High / 0 Medium / 0 Low

Product QA is deferred because this contract-only PR exposes no executable user path. The first API/client child will run focused product QA, and the final roadmap PR retains the cumulative Tier 3 gate.

## Stack

Ready-for-review child of #658.
