### PR TITLE
feat(scoring): persist normalized keyword rows

### DIFF
--- a/workers/automation/src/jobctrl/infrastructure/migrations/v6_to_v7_score_keywords.py
+++ b/workers/automation/src/jobctrl/infrastructure/migrations/v6_to_v7_score_keywords.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 
 import json
 import sqlite3
-import unicodedata
 from dataclasses import dataclass
 from typing import Final
 
+from jobctrl.infrastructure.scoring.keyword_normalization import canonicalize_keywords
 from jobctrl.infrastructure.migrations.schema_manifest import (
     EXACT_V7_MANIFEST,
     assert_exact_manifest,
@@ -180,18 +180,7 @@ def _normalized_keywords(keywords_json: object) -> tuple[tuple[str, str, int], .
             "source score keywords must be a JSON string array"
         )
 
-    normalized: list[tuple[str, str, int]] = []
-    seen: set[str] = set()
-    for value in values:
-        display = " ".join(unicodedata.normalize("NFKC", value).split())
-        if not display:
-            continue
-        lookup = display.casefold()
-        if lookup in seen:
-            continue
-        seen.add(lookup)
-        normalized.append((lookup, display, len(normalized)))
-    return tuple(normalized)
+    return canonicalize_keywords(values)
 
 
 def _target_score_ids(candidate: sqlite3.Connection) -> set[tuple[str, str, int]]:

--- a/workers/automation/src/jobctrl/infrastructure/scoring/keyword_normalization.py
+++ b/workers/automation/src/jobctrl/infrastructure/scoring/keyword_normalization.py
@@ -1,0 +1,34 @@
+"""Deterministic canonicalization for persisted score keywords."""
+
+from __future__ import annotations
+
+import unicodedata
+from collections.abc import Iterable
+from typing import TypeAlias
+
+
+NormalizedKeyword: TypeAlias = tuple[str, str, int]
+
+
+def canonicalize_keywords(values: Iterable[str]) -> tuple[NormalizedKeyword, ...]:
+    """Normalize score keywords while retaining their first display spelling.
+
+    NFKC normalization and whitespace collapse form the stored display value.
+    Its casefolded form is the lookup key. Duplicate lookup keys are omitted
+    after their first appearance so persisted positions stay contiguous.
+    """
+    normalized: list[NormalizedKeyword] = []
+    seen: set[str] = set()
+    for value in values:
+        display = " ".join(unicodedata.normalize("NFKC", value).split())
+        if not display:
+            continue
+        lookup = display.casefold()
+        if lookup in seen:
+            continue
+        seen.add(lookup)
+        normalized.append((lookup, display, len(normalized)))
+    return tuple(normalized)
+
+
+__all__ = ["NormalizedKeyword", "canonicalize_keywords"]

--- a/workers/automation/src/jobctrl/infrastructure/scoring/sqlite_repository.py
+++ b/workers/automation/src/jobctrl/infrastructure/scoring/sqlite_repository.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 import json
 import sqlite3
 from datetime import datetime, timezone
-from typing import Any
+from typing import Any, Final
 
 from jobctrl.database import ensure_scoring_policy_tables
 from jobctrl.domain.identifiers import JobId, canonical_job_id
@@ -38,7 +38,11 @@ from jobctrl.domain.scoring.value_objects import (
     ScoringCriteria,
 )
 from jobctrl.domain.tenant import TenantId
+from jobctrl.infrastructure.scoring.keyword_normalization import canonicalize_keywords
 from jobctrl.state import record_job_event, set_stage_state
+
+
+_SCORE_SAVEPOINT: Final = "score_with_keywords"
 
 
 class ScoreVersionConflict(ValueError):
@@ -141,7 +145,7 @@ class SqliteScoreStalenessRepository:
         self._conn.commit()
         return marked
 
-    def resolve_for_score(self, score: JobScore) -> int:
+    def resolve_for_score(self, score: JobScore, *, commit: bool = True) -> int:
         """Resolve markers satisfied by a fresh, non-corrected score version."""
         if score.correction is not None or score.trace.scoring_policy_version <= 0:
             return 0
@@ -179,7 +183,8 @@ class SqliteScoreStalenessRepository:
                     "scoringPolicyVersion": score.trace.scoring_policy_version,
                 },
             )
-        self._conn.commit()
+        if commit:
+            self._conn.commit()
         return int(result.rowcount)
 
     def reset_for_rescore(
@@ -619,45 +624,73 @@ class SqliteScoreRepository:
 
     def save(self, score: JobScore) -> None:
         job_id = canonical_job_id(str(score.job_id))
-        latest = self._conn.execute(
-            "SELECT COALESCE(MAX(version), 0) AS v FROM job_scores "
-            "WHERE tenant_id = ? AND job_id = ?",
-            (str(score.tenant_id), str(job_id)),
-        ).fetchone()
-        current_max = int(latest[0] if latest else 0)
-        expected = current_max + 1
-        if score.version != expected:
-            raise ScoreVersionConflict(
-                job_id=score.job_id,
-                attempted=score.version,
-                expected=expected,
-            )
+        self._conn.execute(f"SAVEPOINT {_SCORE_SAVEPOINT}")
+        try:
+            latest = self._conn.execute(
+                "SELECT COALESCE(MAX(version), 0) AS v FROM job_scores "
+                "WHERE tenant_id = ? AND job_id = ?",
+                (str(score.tenant_id), str(job_id)),
+            ).fetchone()
+            current_max = int(latest[0] if latest else 0)
+            expected = current_max + 1
+            if score.version != expected:
+                raise ScoreVersionConflict(
+                    job_id=score.job_id,
+                    attempted=score.version,
+                    expected=expected,
+                )
 
-        self._conn.execute(
-            """
-            INSERT INTO job_scores (
-                tenant_id, job_id, version, fit_score, breakdown_json,
-                keywords_json, scored_at, correction_json, criteria_json, trace_json
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            """,
-            (
-                str(score.tenant_id),
-                str(job_id),
-                score.version,
-                score.fit_score.value,
-                json.dumps(score.breakdown.to_dict(), sort_keys=True),
-                json.dumps(score.matched_keywords.to_list()),
-                score.scored_at,
+            self._conn.execute(
+                """
+                INSERT INTO job_scores (
+                    tenant_id, job_id, version, fit_score, breakdown_json,
+                    keywords_json, scored_at, correction_json, criteria_json, trace_json
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
                 (
-                    json.dumps(score.correction.to_dict(), sort_keys=True)
-                    if score.correction
-                    else None
+                    str(score.tenant_id),
+                    str(job_id),
+                    score.version,
+                    score.fit_score.value,
+                    json.dumps(score.breakdown.to_dict(), sort_keys=True),
+                    json.dumps(score.matched_keywords.to_list()),
+                    score.scored_at,
+                    (
+                        json.dumps(score.correction.to_dict(), sort_keys=True)
+                        if score.correction
+                        else None
+                    ),
+                    json.dumps(score.criteria.to_dict(), sort_keys=True),
+                    json.dumps(score.trace.to_dict(), sort_keys=True),
                 ),
-                json.dumps(score.criteria.to_dict(), sort_keys=True),
-                json.dumps(score.trace.to_dict(), sort_keys=True),
-            ),
-        )
-        self._staleness.resolve_for_score(score)
+            )
+            self._conn.executemany(
+                """
+                INSERT INTO job_score_keywords (
+                    tenant_id, job_id, score_version, normalized_keyword,
+                    display_keyword, position
+                ) VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    (
+                        str(score.tenant_id),
+                        str(job_id),
+                        score.version,
+                        normalized_keyword,
+                        display_keyword,
+                        position,
+                    )
+                    for normalized_keyword, display_keyword, position in canonicalize_keywords(
+                        score.matched_keywords.values
+                    )
+                ),
+            )
+            self._staleness.resolve_for_score(score, commit=False)
+        except BaseException:
+            self._conn.execute(f"ROLLBACK TO SAVEPOINT {_SCORE_SAVEPOINT}")
+            self._conn.execute(f"RELEASE SAVEPOINT {_SCORE_SAVEPOINT}")
+            raise
+        self._conn.execute(f"RELEASE SAVEPOINT {_SCORE_SAVEPOINT}")
         self._conn.commit()
 
     # ------------------------------------------------------------------

--- a/workers/automation/tests/test_score_repository.py
+++ b/workers/automation/tests/test_score_repository.py
@@ -34,6 +34,7 @@ from jobctrl.infrastructure.scoring import (
     SqliteScoreStalenessRepository,
     SqliteScoringPolicyRepository,
 )
+from jobctrl.infrastructure.scoring.keyword_normalization import canonicalize_keywords
 from jobctrl.infrastructure.scoring.sqlite_repository import ScoreVersionConflict
 
 
@@ -102,6 +103,7 @@ def _build_score(
     tenant_id: TenantId = LOCAL_TENANT,
     version: int = 1,
     fit: int = 7,
+    keywords: tuple[str, ...] = ("python", "fastapi"),
     trace: ScoreTrace | None = None,
     correction: ScoreCorrection | None = None,
 ) -> JobScore:
@@ -111,11 +113,25 @@ def _build_score(
         version=version,
         fit_score=FitScore.create(fit),
         breakdown=ScoreBreakdown(technical_fit=8, experience_fit=6, role_fit=7, reasoning="ok"),
-        matched_keywords=MatchedKeywords.from_iterable(["python", "fastapi"]),
+        matched_keywords=MatchedKeywords(values=keywords),
         scored_at=datetime.now(timezone.utc).isoformat(),
         trace=trace or ScoreTrace(),
         correction=correction,
     )
+
+
+def _score_keyword_rows(conn: sqlite3.Connection) -> list[tuple[object, ...]]:
+    return [
+        tuple(row)
+        for row in conn.execute(
+            """
+            SELECT tenant_id, job_id, score_version, normalized_keyword,
+                   display_keyword, position
+            FROM job_score_keywords
+            ORDER BY tenant_id, job_id, score_version, position
+            """
+        ).fetchall()
+    ]
 
 
 def _requirement_assessment(
@@ -243,6 +259,53 @@ def test_score_round_trip_uses_canonical_job_id_distinct_from_posting_url(
     assert tuple(row) == (str(LOCAL_TENANT), str(job_id))
 
 
+def test_canonicalize_score_keywords_preserves_first_display_and_positions() -> None:
+    assert canonicalize_keywords(
+        (
+            "  Python  ",
+            "\u3000Ｐｙｔｈｏｎ\t",
+            "Data   Science",
+            " data science ",
+            "\u00a0",
+            "\t",
+            "Straße",
+            "STRASSE",
+        )
+    ) == (
+        ("python", "Python", 0),
+        ("data science", "Data Science", 1),
+        ("strasse", "Straße", 2),
+    )
+
+
+def test_save_writes_complete_normalized_keyword_rows(conn: sqlite3.Connection) -> None:
+    job_id = _seed_job(
+        conn,
+        job_id=_job_id(20),
+        url="https://example.com/jobs/keyword-rows",
+    )
+
+    SqliteScoreRepository(conn).save(
+        _build_score(
+            job_id,
+            keywords=(
+                "  Python  ",
+                "\u3000Ｐｙｔｈｏｎ\t",
+                "Data   Science",
+                "data science",
+                "Straße",
+                "STRASSE",
+            ),
+        )
+    )
+
+    assert _score_keyword_rows(conn) == [
+        (str(LOCAL_TENANT), str(job_id), 1, "python", "Python", 0),
+        (str(LOCAL_TENANT), str(job_id), 1, "data science", "Data Science", 1),
+        (str(LOCAL_TENANT), str(job_id), 1, "strasse", "Straße", 2),
+    ]
+
+
 def test_score_round_trip_preserves_criteria_and_trace(conn: sqlite3.Connection) -> None:
     job_id = _seed_job(
         conn,
@@ -367,6 +430,12 @@ def test_score_repository_scopes_same_job_id_by_tenant(conn: sqlite3.Connection)
     assert other_score.fit_score.value == 9
     assert [(score.tenant_id, score.job_id) for score in local_range] == [
         (LOCAL_TENANT, job_id)
+    ]
+    assert _score_keyword_rows(conn) == [
+        (str(LOCAL_TENANT), str(job_id), 1, "python", "python", 0),
+        (str(LOCAL_TENANT), str(job_id), 1, "fastapi", "fastapi", 1),
+        (str(other_tenant), str(job_id), 1, "python", "python", 0),
+        (str(other_tenant), str(job_id), 1, "fastapi", "fastapi", 1),
     ]
 
 
@@ -521,14 +590,18 @@ def test_save_increments_version(conn: sqlite3.Connection) -> None:
         url="https://example.com/jobs/versioning",
     )
     repo = SqliteScoreRepository(conn)
-    repo.save(_build_score(job_id, version=1, fit=7))
-    repo.save(_build_score(job_id, version=2, fit=9))
+    repo.save(_build_score(job_id, version=1, fit=7, keywords=("Python",)))
+    repo.save(_build_score(job_id, version=2, fit=9, keywords=("FastAPI",)))
 
     latest = repo.load(LOCAL_TENANT, job_id)
 
     assert latest is not None
     assert latest.version == 2
     assert latest.fit_score.value == 9
+    assert _score_keyword_rows(conn) == [
+        (str(LOCAL_TENANT), str(job_id), 1, "python", "Python", 0),
+        (str(LOCAL_TENANT), str(job_id), 2, "fastapi", "FastAPI", 0),
+    ]
 
 
 def test_save_rejects_version_skip_and_replay(conn: sqlite3.Connection) -> None:
@@ -539,6 +612,10 @@ def test_save_rejects_version_skip_and_replay(conn: sqlite3.Connection) -> None:
     )
     repo = SqliteScoreRepository(conn)
     repo.save(_build_score(job_id, version=1, fit=7))
+    before_scores = conn.execute(
+        "SELECT tenant_id, job_id, version, fit_score FROM job_scores"
+    ).fetchall()
+    before_keywords = _score_keyword_rows(conn)
 
     with pytest.raises(ScoreVersionConflict) as excinfo:
         repo.save(_build_score(job_id, version=3, fit=8))
@@ -546,6 +623,33 @@ def test_save_rejects_version_skip_and_replay(conn: sqlite3.Connection) -> None:
         repo.save(_build_score(job_id, version=1, fit=8))
 
     assert excinfo.value.expected == 2
+    assert conn.execute(
+        "SELECT tenant_id, job_id, version, fit_score FROM job_scores"
+    ).fetchall() == before_scores
+    assert _score_keyword_rows(conn) == before_keywords
+
+
+def test_save_rolls_back_score_and_keyword_rows_after_downstream_failure(
+    conn: sqlite3.Connection,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    job_id = _seed_job(
+        conn,
+        job_id=_job_id(21),
+        url="https://example.com/jobs/keyword-rollback",
+    )
+    repo = SqliteScoreRepository(conn)
+
+    def fail_after_score_write(_: JobScore, *, commit: bool) -> int:
+        raise RuntimeError("forced score downstream failure")
+
+    monkeypatch.setattr(repo._staleness, "resolve_for_score", fail_after_score_write)
+
+    with pytest.raises(RuntimeError, match="forced score downstream failure"):
+        repo.save(_build_score(job_id))
+
+    assert conn.execute("SELECT COUNT(*) FROM job_scores").fetchone()[0] == 0
+    assert _score_keyword_rows(conn) == []
 
 
 def test_list_pending_reads_canonical_enrichment_content_with_tenant_isolation(


### PR DESCRIPTION
## Summary

- share one deterministic NFKC, whitespace-collapse, and casefold keyword canonicalizer between migration and runtime writes
- persist each score version and its normalized keyword rows atomically under the same tenant-scoped `JobId`
- preserve prior score versions while rejecting replays and version skips without partial writes
- cover tenant isolation, display spelling, normalized positions, and rollback after downstream failure

## Validation

- `PYTHONPATH=workers/automation/src /Users/eloibarti/Github/JobHunter/workers/automation/.venv/bin/pytest workers/automation/tests/test_score_repository.py workers/automation/tests/test_v6_to_v7_score_keywords.py -q` — 24 passed
- `/Users/eloibarti/Github/JobHunter/workers/automation/.venv/bin/ruff check workers/automation/src/jobctrl/infrastructure/scoring/keyword_normalization.py workers/automation/src/jobctrl/infrastructure/migrations/v6_to_v7_score_keywords.py workers/automation/src/jobctrl/infrastructure/scoring/sqlite_repository.py workers/automation/tests/test_score_repository.py` — passed
- `git diff --check` — passed
- independent Tier 3 groundwork review — `Gate: PASS` (0 Blocker, High, Medium, or Low findings)

## Stack

- child of #661
- intermediate persistence slice; API/client product-path QA remains deferred to the next child PR
