### PR TITLE
feat(api): expose canonical scoring keywords

### DIFF
--- a/apps/api/src/read-model.ts
+++ b/apps/api/src/read-model.ts
@@ -53,6 +53,7 @@ import type {
   ProfileShape,
   RequirementFitReport,
   ScoreBreakdown,
+  ScoringKeywordAggregationResponse,
   SettingsResponse,
   Stage,
   StageState,
@@ -1039,6 +1040,45 @@ export function listJobs(db: SqliteDatabase, query: JobListQuery): PaginatedResp
     .filter((job) => !query.q || filterJob(job, query, normalizedQuery));
   filtered.sort((left, right) => compareJobs(left, right, query.sort, query.dir));
   return paginate(filtered, query.page, query.pageSize, query.sort, query.dir, jobFilterPayload(query));
+}
+
+/**
+ * Aggregate only keywords belonging to the score version rendered by the
+ * current job-list projection. Historical score versions stay auditable but
+ * must not affect current filtering or rollups.
+ */
+export function listScoringKeywords(db: SqliteDatabase): ScoringKeywordAggregationResponse {
+  refreshProjections(db, DEFAULT_TENANT);
+  const rows = allRows<{
+    normalized_keyword: string;
+    display_keyword: string;
+    score_version: number;
+    job_count: number;
+  }>(
+    db,
+    `SELECT keywords.normalized_keyword,
+            MIN(keywords.display_keyword) AS display_keyword,
+            keywords.score_version,
+            COUNT(DISTINCT projections.job_id) AS job_count
+       FROM job_score_keywords AS keywords
+       INNER JOIN job_list_projections AS projections
+         ON projections.tenant_id = keywords.tenant_id
+        AND projections.job_id = keywords.job_id
+        AND projections.score_version = keywords.score_version
+      WHERE keywords.tenant_id = ?
+      GROUP BY keywords.normalized_keyword, keywords.score_version
+      ORDER BY keywords.normalized_keyword ASC, keywords.score_version ASC, display_keyword ASC`,
+    [DEFAULT_TENANT],
+  );
+  return {
+    ok: true,
+    keywords: rows.map((row) => ({
+      normalizedKeyword: row.normalized_keyword,
+      displayKeyword: row.display_keyword,
+      scoreVersion: Number(row.score_version),
+      jobCount: Number(row.job_count),
+    })),
+  };
 }
 
 export function matchingJobKeys(db: SqliteDatabase, filter: Partial<BulkJobMutationFilter> = {}): string[] {
@@ -4639,6 +4679,19 @@ function jobSqlFilter(query: JobListQuery): { where: string; params: SqliteValue
     clauses.push("LOWER(job_list_projections.employer) LIKE ?");
     params.push(`%${query.company.toLowerCase()}%`);
   }
+  if (query.normalizedScoreKeyword) {
+    // This is the exact canonical key returned by listScoringKeywords. Do not
+    // re-normalize it in TypeScript: persistence owns Unicode casefolding.
+    clauses.push(`EXISTS (
+      SELECT 1
+        FROM job_score_keywords AS keywords INDEXED BY idx_job_score_keywords_tenant_normalized
+       WHERE keywords.tenant_id = job_list_projections.tenant_id
+         AND keywords.job_id = job_list_projections.job_id
+         AND keywords.score_version = job_list_projections.score_version
+         AND keywords.normalized_keyword = ?
+    )`);
+    params.push(query.normalizedScoreKeyword);
+  }
   if (query.minFitScore !== undefined) {
     clauses.push("COALESCE(job_list_projections.fit_score, -1) >= ?");
     params.push(query.minFitScore);
@@ -4801,6 +4854,7 @@ function jobFilterPayload(query: JobListQuery): Record<string, unknown> {
     state: query.state ?? "",
     source: query.source,
     company: query.company,
+    normalizedScoreKeyword: query.normalizedScoreKeyword ?? "",
     applyStatus: query.applyStatus,
     minFitScore: query.minFitScore ?? null,
     maxFitScore: query.maxFitScore ?? null,

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -230,6 +230,7 @@ import {
   listArtifacts,
   listEvidenceMap,
   listJobs,
+  listScoringKeywords,
   matchingJobKeys,
   listWorkflowRuns,
   getWorkflowRunDetail,
@@ -560,6 +561,10 @@ export function buildApp(options: BuildAppOptions): FastifyInstance {
 
   app.get("/v1/analytics/outcomes", async (_request, reply) =>
     withDb(reply, options.dbPath, (db) => buildOutcomeAnalyticsSummary(db)),
+  );
+
+  app.get("/v1/scoring/keywords", async (_request, reply) =>
+    withDb(reply, options.dbPath, (db) => listScoringKeywords(db)),
   );
 
   app.get("/v1/digest", async (_request, reply) =>

--- a/apps/api/test/read-model-v7.test.ts
+++ b/apps/api/test/read-model-v7.test.ts
@@ -11,6 +11,7 @@ import {
   getJobDetail,
   listActivity,
   listJobs,
+  listScoringKeywords,
 } from "../src/read-model.js";
 import { BUILT_IN_RESUME_TEMPLATE_THEME } from "../src/resume-templates.js";
 import { EXACT_V7_SCHEMA_MANIFEST, schemaManifest } from "../src/schema-manifest.js";
@@ -20,6 +21,7 @@ import { initializeExactV7Database } from "./v7-schema.js";
 const JOB_ID = "00000000-0000-4000-8000-000000000081";
 const HIDDEN_JOB_ID = "00000000-0000-4000-8000-000000000082";
 const DELETED_JOB_ID = "00000000-0000-4000-8000-000000000083";
+const KEYWORD_JOB_ID = "00000000-0000-4000-8000-000000000084";
 const OTHER_TENANT = "other";
 const JOB_URL = "https://jobs.example.test/read-model";
 const APPLICATION_URL = "https://apply.example.test/read-model";
@@ -135,6 +137,28 @@ function insertJob(
   ).run(tenantId, jobId, NOW);
 }
 
+function insertScoreWithKeywords(
+  db: Database.Database,
+  tenantId: string,
+  jobId: string,
+  version: number,
+  keywords: Array<{ normalized: string; display: string }>,
+): void {
+  db.prepare(
+    `INSERT INTO job_scores (
+       tenant_id, job_id, version, fit_score, breakdown_json, keywords_json, scored_at
+     ) VALUES (?, ?, ?, 8, '{}', '[]', ?)`,
+  ).run(tenantId, jobId, version, NOW);
+  const insertKeyword = db.prepare(
+    `INSERT INTO job_score_keywords (
+       tenant_id, job_id, score_version, normalized_keyword, display_keyword, position
+     ) VALUES (?, ?, ?, ?, ?, ?)`,
+  );
+  keywords.forEach((keyword, position) => {
+    insertKeyword.run(tenantId, jobId, version, keyword.normalized, keyword.display, position);
+  });
+}
+
 function seedBuiltInTemplate(db: Database.Database): void {
   db.prepare(
     `INSERT INTO resume_templates (
@@ -222,6 +246,111 @@ describe("exact-v7 read model job ids", () => {
     );
     expect(activity.items.some((item) => item.jobKey === HIDDEN_JOB_ID || item.jobKey === DELETED_JOB_ID)).toBe(false);
     expect(getJobDetail(db, "not-a-canonical-job-id")).toBeNull();
+  });
+
+  it("filters and aggregates only projection-visible normalized score keywords", () => {
+    const db = seededDatabase();
+    insertJob(
+      db,
+      "local",
+      KEYWORD_JOB_ID,
+      "https://jobs.example.test/keyword-second",
+      "Second keyword job",
+      "https://apply.example.test/keyword-second",
+    );
+    insertScoreWithKeywords(db, "local", JOB_ID, 1, [
+      { normalized: "legacy-only", display: "Legacy only" },
+    ]);
+    insertScoreWithKeywords(db, "local", JOB_ID, 2, [
+      { normalized: "strasse", display: "Straße" },
+      { normalized: "react", display: "React" },
+      { normalized: "ι\u0308\u0301", display: "ΐ" },
+    ]);
+    insertScoreWithKeywords(db, "local", KEYWORD_JOB_ID, 2, [
+      { normalized: "cloud", display: "Cloud" },
+      { normalized: "react", display: "react" },
+    ]);
+    insertScoreWithKeywords(db, OTHER_TENANT, JOB_ID, 1, [
+      { normalized: "strasse", display: "Other tenant Straße" },
+    ]);
+    db.prepare(
+      `INSERT INTO job_score_staleness (
+         tenant_id, job_id, stale_reason, old_policy_version, new_policy_version, marked_at
+       ) VALUES ('local', ?, 'scoring_policy_changed', 1, 2, ?)`,
+    ).run(JOB_ID, NOW);
+
+    const strasseMatches = listJobs(db, { ...activeJobQuery, normalizedScoreKeyword: "strasse" });
+    const displayTextMatches = listJobs(db, { ...activeJobQuery, normalizedScoreKeyword: "Straße" });
+    const canonicalGreekMatches = listJobs(db, {
+      ...activeJobQuery,
+      normalizedScoreKeyword: "ι\u0308\u0301",
+    });
+    const displayGreekMatches = listJobs(db, { ...activeJobQuery, normalizedScoreKeyword: "ΐ" });
+    const legacyMatches = listJobs(db, { ...activeJobQuery, normalizedScoreKeyword: "legacy-only" });
+    const aggregated = listScoringKeywords(db);
+    const queryPlan = db
+      .prepare(
+        `EXPLAIN QUERY PLAN
+         SELECT job_list_projections.job_id
+           FROM job_list_projections
+          WHERE job_list_projections.tenant_id = ?
+            AND EXISTS (
+              SELECT 1
+                FROM job_score_keywords AS keywords INDEXED BY idx_job_score_keywords_tenant_normalized
+               WHERE keywords.tenant_id = job_list_projections.tenant_id
+                 AND keywords.job_id = job_list_projections.job_id
+                 AND keywords.score_version = job_list_projections.score_version
+                 AND keywords.normalized_keyword = ?
+            )`,
+      )
+      .all("local", "strasse") as Array<{ detail: string }>;
+    const aggregationPlan = db
+      .prepare(
+        `EXPLAIN QUERY PLAN
+         SELECT keywords.normalized_keyword,
+                MIN(keywords.display_keyword) AS display_keyword,
+                keywords.score_version,
+                COUNT(DISTINCT projections.job_id) AS job_count
+           FROM job_score_keywords AS keywords
+           INNER JOIN job_list_projections AS projections
+             ON projections.tenant_id = keywords.tenant_id
+            AND projections.job_id = keywords.job_id
+            AND projections.score_version = keywords.score_version
+          WHERE keywords.tenant_id = ?
+          GROUP BY keywords.normalized_keyword, keywords.score_version`,
+      )
+      .all("local") as Array<{ detail: string }>;
+
+    expect(strasseMatches.items).toEqual([
+      expect.objectContaining({
+        jobKey: JOB_ID,
+        scoreVersion: 2,
+        scoreStaleness: expect.objectContaining({ isStale: true, staleReason: "scoring_policy_changed" }),
+      }),
+    ]);
+    expect(displayTextMatches.items).toEqual([]);
+    expect(canonicalGreekMatches.items.map((job) => job.jobKey)).toEqual([JOB_ID]);
+    expect(displayGreekMatches.items).toEqual([]);
+    expect(legacyMatches.items).toEqual([]);
+    expect(queryPlan.map((row) => row.detail)).toContainEqual(
+      expect.stringContaining("idx_job_score_keywords_tenant_normalized"),
+    );
+    expect(aggregationPlan.map((row) => row.detail)).toContainEqual(
+      expect.stringContaining("idx_job_score_keywords_tenant_normalized"),
+    );
+    expect(aggregated).toEqual({
+      ok: true,
+      keywords: [
+        { normalizedKeyword: "cloud", displayKeyword: "Cloud", scoreVersion: 2, jobCount: 1 },
+        { normalizedKeyword: "react", displayKeyword: "React", scoreVersion: 2, jobCount: 2 },
+        { normalizedKeyword: "strasse", displayKeyword: "Straße", scoreVersion: 2, jobCount: 1 },
+        { normalizedKeyword: "ι\u0308\u0301", displayKeyword: "ΐ", scoreVersion: 2, jobCount: 1 },
+      ],
+    });
+  });
+
+  it("returns an empty keyword aggregation when no visible score has keywords", () => {
+    expect(listScoringKeywords(seededDatabase())).toEqual({ ok: true, keywords: [] });
   });
 
   it("resolves URL locators once and writes reversible lifecycle state with canonical job ids", () => {

--- a/apps/api/test/server.test.ts
+++ b/apps/api/test/server.test.ts
@@ -11,6 +11,7 @@ import {
   JsonRpcErrorCodes,
   PipelineOperationsSnapshotSchema,
   ProviderConfigurationKeys,
+  ScoringKeywordAggregationResponseSchema,
   SecretCredentialKeys,
   type ActionCommandPayload,
   type CredentialBatchOperation,
@@ -2153,6 +2154,99 @@ describe("local TypeScript API", () => {
       },
     });
 
+    await app.close();
+  });
+
+  it("serves projection-visible normalized scoring keyword filters and rollups", async () => {
+    const longNormalizedKeyword = "x".repeat(241);
+    const formatBoundaryKeyword = "\uFEFFkeyword";
+    const db = new Database(options.dbPath);
+    insertScoreKeyword(db, "https://example.com/jobs/ready", 1, "legacy-only", "Legacy only", 0);
+    insertScore(db, "https://example.com/jobs/ready", 2, 9, { keywords: ["ignored JSON keyword"] });
+    insertScoreKeyword(db, "https://example.com/jobs/ready", 2, "strasse", "Straße", 0);
+    insertScoreKeyword(
+      db,
+      "https://example.com/jobs/ready",
+      2,
+      longNormalizedKeyword,
+      longNormalizedKeyword,
+      1,
+    );
+    insertScoreKeyword(
+      db,
+      "https://example.com/jobs/ready",
+      2,
+      formatBoundaryKeyword,
+      formatBoundaryKeyword,
+      2,
+    );
+    insertScoreKeyword(db, "https://example.com/jobs/failed-score", 1, "cloud", "Cloud", 0);
+    db.prepare(
+      `INSERT INTO job_score_staleness (
+         tenant_id, job_id, stale_reason, old_policy_version, new_policy_version, marked_at
+       ) VALUES ('local', ?, 'scoring_policy_changed', 1, 2, ?)`,
+    ).run(jobIdFor("https://example.com/jobs/ready"), "2026-04-29T10:03:00+00:00");
+    db.close();
+
+    const app = buildApp(options);
+    const filtered = await app.inject({
+      method: "GET",
+      url: "/v1/jobs?normalizedScoreKeyword=strasse",
+    });
+    const aggregated = await app.inject({ method: "GET", url: "/v1/scoring/keywords" });
+    const longKeywordFiltered = await app.inject({
+      method: "GET",
+      url: `/v1/jobs?normalizedScoreKeyword=${encodeURIComponent(longNormalizedKeyword)}`,
+    });
+    const formatBoundaryFiltered = await app.inject({
+      method: "GET",
+      url: `/v1/jobs?normalizedScoreKeyword=${encodeURIComponent(formatBoundaryKeyword)}`,
+    });
+
+    expect(filtered.statusCode, filtered.body).toBe(200);
+    expect(filtered.json().items).toEqual([
+      expect.objectContaining({
+        jobKey: jobIdFor("https://example.com/jobs/ready"),
+        scoreVersion: 2,
+        scoreStaleness: expect.objectContaining({ isStale: true, staleReason: "scoring_policy_changed" }),
+      }),
+    ]);
+    expect(longKeywordFiltered.json().items.map((job: { jobKey: string }) => job.jobKey)).toEqual([
+      jobIdFor("https://example.com/jobs/ready"),
+    ]);
+    expect(formatBoundaryFiltered.json().items.map((job: { jobKey: string }) => job.jobKey)).toEqual([
+      jobIdFor("https://example.com/jobs/ready"),
+    ]);
+    expect(ScoringKeywordAggregationResponseSchema.parse(aggregated.json())).toEqual({
+      ok: true,
+      keywords: [
+        { normalizedKeyword: "cloud", displayKeyword: "Cloud", scoreVersion: 1, jobCount: 1 },
+        { normalizedKeyword: "strasse", displayKeyword: "Straße", scoreVersion: 2, jobCount: 1 },
+        {
+          normalizedKeyword: longNormalizedKeyword,
+          displayKeyword: longNormalizedKeyword,
+          scoreVersion: 2,
+          jobCount: 1,
+        },
+        {
+          normalizedKeyword: formatBoundaryKeyword,
+          displayKeyword: formatBoundaryKeyword,
+          scoreVersion: 2,
+          jobCount: 1,
+        },
+      ],
+    });
+
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(aggregated.body, { status: 200, statusText: "OK" }),
+    );
+    const clientKeywords = await createJobCtrlApiClient().scoringKeywords();
+    expect(clientKeywords).toEqual(ScoringKeywordAggregationResponseSchema.parse(aggregated.json()));
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://127.0.0.1:8766/v1/scoring/keywords",
+      expect.objectContaining({ method: "GET" }),
+    );
+    fetchMock.mockRestore();
     await app.close();
   });
 
@@ -10111,6 +10205,21 @@ function insertScore(
       correction_history: [],
     }),
   );
+}
+
+function insertScoreKeyword(
+  db: Database.Database,
+  jobUrl: string,
+  scoreVersion: number,
+  normalizedKeyword: string,
+  displayKeyword: string,
+  position: number,
+): void {
+  db.prepare(
+    `INSERT INTO job_score_keywords (
+       tenant_id, job_id, score_version, normalized_keyword, display_keyword, position
+     ) VALUES ('local', ?, ?, ?, ?, ?)`,
+  ).run(jobIdFor(jobUrl), scoreVersion, normalizedKeyword, displayKeyword, position);
 }
 
 function createScoreStalenessTable(db: Database.Database): void {

--- a/packages/api-client/src/client.ts
+++ b/packages/api-client/src/client.ts
@@ -115,6 +115,7 @@ import type {
   RoleMatchFeedbackListResponse,
   RescoreJobRequest,
   RetailorJobRequest,
+  ScoringKeywordAggregationResponse,
   ResumeTemplateDefaultSelectionRequest,
   ResumeTemplateDefaultSelectionResponse,
   ResumeTemplateDetailResponse,
@@ -236,6 +237,10 @@ export class JobCtrlApiClient {
 
   outcomeAnalytics(): Promise<OutcomeAnalyticsSummary> {
     return this.get("/v1/analytics/outcomes");
+  }
+
+  scoringKeywords(): Promise<ScoringKeywordAggregationResponse> {
+    return this.get("/v1/scoring/keywords");
   }
 
   digest(): Promise<DailyDigest> {

--- a/packages/contracts/src/schemas.ts
+++ b/packages/contracts/src/schemas.ts
@@ -2071,6 +2071,7 @@ export const JobListQuerySchema = z
     applyStatus: z.enum(JOB_APPLY_STATUS_FILTERS).default("all").catch("all"),
     source: optionalText,
     company: optionalText,
+    normalizedScoreKeyword: z.string().min(1).optional(),
     minFitScore: optionalNumber,
     maxFitScore: optionalNumber,
     discoveredSince: IsoTimestampSchema.optional().catch(undefined),
@@ -2086,6 +2087,24 @@ export const JobListQuerySchema = z
   }));
 
 export type JobListQuery = z.infer<typeof JobListQuerySchema>;
+
+export const ScoringKeywordAggregationItemSchema = z
+  .object({
+    normalizedKeyword: z.string().min(1),
+    displayKeyword: z.string().min(1),
+    scoreVersion: z.number().int().positive(),
+    jobCount: z.number().int().positive(),
+  })
+  .strict();
+export type ScoringKeywordAggregationItem = z.infer<typeof ScoringKeywordAggregationItemSchema>;
+
+export const ScoringKeywordAggregationResponseSchema = z
+  .object({
+    ok: z.literal(true),
+    keywords: z.array(ScoringKeywordAggregationItemSchema),
+  })
+  .strict();
+export type ScoringKeywordAggregationResponse = z.infer<typeof ScoringKeywordAggregationResponseSchema>;
 
 export const ArtifactListQuerySchema = z
   .object({


### PR DESCRIPTION
## Summary

- add a typed `normalizedScoreKeyword` job-list filter backed by the indexed canonical keyword relation
- constrain filtering and aggregation to each tenant-scoped job projection's currently visible score version
- expose deterministic keyword rollups with display text, score-version provenance, and job counts at `GET /v1/scoring/keywords`
- add a typed client method plus exact-v7 route, tenant, staleness, Unicode-boundary, empty-result, and query-plan regressions

## Validation

- Node 22 `corepack pnpm --filter @jobctrl/api exec vitest run test/read-model-v7.test.ts test/server.test.ts` — 212 passed
- Node 22 contracts, API, and API-client TypeScript checks — passed
- `git diff --check` — passed
- independent product review — `Gate: PASS` (0 findings)
- independent product QA — `Gate: PASS` (0 findings)

## Stack

- child of #662
- intermediate API/client slice; canonical docs and cumulative Tier 3 QA remain deferred to the final roadmap PR
