### PR TITLE
fix(api): preserve workflow terminal cancellation state

### DIFF
--- a/apps/api/src/local-actions.ts
+++ b/apps/api/src/local-actions.ts
@@ -156,6 +156,16 @@ export function createActionDispatcher(
         result: response.error.data,
       };
     }
+    if (rpcCall.method === "cancel_run") {
+      const rpcRunId = isRecord(response.result) && typeof response.result.runId === "string"
+        ? response.result.runId
+        : command.runId;
+      return {
+        status: extractStatus(response.result) ?? "canceling",
+        ...(rpcRunId ? { runId: rpcRunId } : {}),
+        result: response.result,
+      };
+    }
     const workflowStart = extractWorkflowStart(response.result);
     if (hasWorkflowStart(workflowStart)) {
       const result: ActionDispatchResult = {

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -1999,19 +1999,34 @@ export function buildApp(options: BuildAppOptions): FastifyInstance {
 
   app.post<{ Params: { runId: string } }>("/v1/workflow-runs/:runId/actions/cancel", async (request, reply) => {
     const runId = decodeRouteParam(request.params.runId);
+    const run = withDb(reply, options.dbPath, (db) => getWorkflowRunDetail(db, runId));
+    if (run && "ok" in run) {
+      return run;
+    }
+    if (!run) {
+      void reply.code(404);
+      return { ok: false, error: "workflow_run_not_found" };
+    }
+    const command: ActionCommandPayload = {
+      action: "cancel" as const,
+      jobKey: run.jobKey || PIPELINE_ACTION_JOB_KEY,
+      runId,
+    };
+    if (run.status !== "starting" && run.status !== "in_progress") {
+      return buildActionResponse(command, {
+        status: "already_terminal",
+        runId,
+        result: {
+          status: run.status,
+          result: run.result,
+        },
+      });
+    }
     const workerReady = requireWorkerReady(reply, options.dbPath, requireHealthyWorkerForActions);
     if (!workerReady) {
       return undefined;
     }
-    const command: ActionCommandPayload = {
-      action: "cancel" as const,
-      jobKey: PIPELINE_ACTION_JOB_KEY,
-      runId,
-    };
     const dispatch = await actionDispatcher(command, actionContext);
-    if (dispatch.status !== "failed") {
-      recordPipelineWorkflowCancelRequested(options.dbPath, runId);
-    }
     return buildActionResponse(command, dispatch);
   });
 
@@ -4025,117 +4040,6 @@ function recordPipelineWorkflowStarted(
   });
 }
 
-function recordPipelineWorkflowCancelRequested(dbPath: string, workflowId: string): void {
-  if (!databaseExists(dbPath)) return;
-  let db: ApiDb | null = null;
-  try {
-    db = openDatabase(dbPath);
-    const latest = latestPipelineWorkflowEvent(db, workflowId);
-    if (!latest) return;
-    const payload = parseJsonRecord(latest.payload_json);
-    const progress = isRecord(payload.progress) ? payload.progress : {};
-    const stage = isStage(latest.stage) ? latest.stage : isStage(payload.stage) ? payload.stage : null;
-    if (!stage) return;
-    const sourceRunId = textValue(payload.runId ?? payload.run_id);
-    const message = `${labelForStage(stage)} canceled`;
-    const now = new Date().toISOString();
-    const progressPayload = {
-      completed: numberValue(progress.completed ?? progress.progressCompleted) ?? 0,
-      total: numberValue(progress.total ?? progress.progressTotal) ?? 1,
-      percent: numberValue(progress.percent ?? progress.progressPercent) ?? 0,
-      currentStep: textValue(progress.currentStep ?? progress.current_step) || null,
-      status: "failed",
-      message,
-      ...(isRecord(progress.sourceProgress)
-        ? { sourceProgress: progress.sourceProgress }
-        : isRecord(progress.source_progress)
-          ? { sourceProgress: progress.source_progress }
-          : {}),
-    };
-    insertJobEvent(db, {
-      jobUrl: null,
-      stage,
-      eventType: "StageFailed",
-      level: "warn",
-      message,
-      payload: {
-        tenantId: "local",
-        jobId: PIPELINE_ACTION_JOB_KEY,
-        stage,
-        workflowId,
-        workflow_id: workflowId,
-        ...(sourceRunId ? { runId: sourceRunId, run_id: sourceRunId } : {}),
-        errorCode: "pipeline_stage_canceled",
-        errorMessage: message,
-        retryable: true,
-        progress: progressPayload,
-      },
-    });
-    if (stage === "discover" && sourceRunId) {
-      insertJobEvent(db, {
-        jobUrl: null,
-        stage,
-        eventType: "DiscoveryRunFailed",
-        level: "warn",
-        message: `Discovery run ${sourceRunId} canceled`,
-        payload: {
-          tenantId: "local",
-          runId: sourceRunId,
-          run_id: sourceRunId,
-          errorClass: "canceled",
-          error_class: "canceled",
-          failedAt: now,
-          failed_at: now,
-          retryable: true,
-        },
-      });
-      markDiscoveryRunCanceled(db, {
-        runId: sourceRunId,
-        workflowId,
-        failedAt: now,
-        progress: progressPayload,
-      });
-    }
-  } catch {
-    // Cancellation should still reach Temporal even if local projection repair fails.
-  } finally {
-    db?.close();
-  }
-}
-
-function markDiscoveryRunCanceled(
-  db: ApiDb,
-  cancellation: {
-    runId: string;
-    workflowId: string;
-    failedAt: string;
-    progress: Record<string, unknown>;
-  },
-): void {
-  if (!tableExists(db, "discovery_runs")) return;
-  const columns = columnNames(db, "discovery_runs");
-  const assignments: string[] = ["status = ?", "error_classes_json = ?", "failed_at = ?"];
-  const values: unknown[] = ["failed", JSON.stringify(["canceled"]), cancellation.failedAt];
-
-  if (columns.has("updated_at")) {
-    assignments.push("updated_at = ?");
-    values.push(cancellation.failedAt);
-  }
-  if (columns.has("progress_json")) {
-    assignments.push("progress_json = ?");
-    values.push(JSON.stringify(cancellation.progress));
-  }
-  if (columns.has("workflow_id")) {
-    assignments.push("workflow_id = COALESCE(workflow_id, ?)");
-    values.push(cancellation.workflowId);
-  }
-
-  values.push(cancellation.runId);
-  db.prepare(`UPDATE discovery_runs SET ${assignments.join(", ")} WHERE run_id = ? AND status = 'running'`).run(
-    ...values,
-  );
-}
-
 function recordPipelineWorkflowEvent(
   dbPath: string,
   event: {
@@ -4182,29 +4086,6 @@ function recordPipelineWorkflowEvent(
   } finally {
     db?.close();
   }
-}
-
-function latestPipelineWorkflowEvent(
-  db: ApiDb,
-  workflowId: string,
-): { stage: string | null; payload_json: string | null } | null {
-  const row = db.prepare(
-    `SELECT stage, payload_json
-       FROM job_events
-      WHERE tenant_id = 'local'
-        AND job_id IS NULL
-        AND payload_json IS NOT NULL
-        AND json_valid(payload_json)
-        AND (
-          JSON_EXTRACT(payload_json, '$.workflowId') = ?
-          OR JSON_EXTRACT(payload_json, '$.workflow_id') = ?
-        )
-      ORDER BY event_id DESC
-      LIMIT 1`,
-  ).get(workflowId, workflowId) as
-    | { stage: string | null; payload_json: string | null }
-    | undefined;
-  return row ?? null;
 }
 
 function insertJobEvent(

--- a/apps/api/test/json-rpc-adapter.test.ts
+++ b/apps/api/test/json-rpc-adapter.test.ts
@@ -111,6 +111,33 @@ describe("createContactResearchStarter (JSON-RPC adapter)", () => {
 });
 
 describe("createActionDispatcher (JSON-RPC adapter)", () => {
+  it("preserves the cancel_run RPC canceling status and run id", async () => {
+    const fake = new FakeDispatcher();
+    fake.setResponse({
+      jsonrpc: "2.0",
+      id: 1,
+      result: { runId: "workflow-run-1", status: "canceling" },
+    });
+    const dispatcher = createActionDispatcher(fake);
+
+    const result = await dispatcher(
+      { action: "cancel", jobKey: PIPELINE_ACTION_JOB_KEY, runId: "workflow-run-1" },
+      { appDir: "/tmp", dbPath: "/tmp/jobctrl.db" },
+    );
+
+    expect(fake.calls).toEqual([
+      {
+        method: "cancel_run",
+        params: { tenantId: "local", runId: "workflow-run-1" },
+      },
+    ]);
+    expect(result).toEqual({
+      status: "canceling",
+      runId: "workflow-run-1",
+      result: { runId: "workflow-run-1", status: "canceling" },
+    });
+  });
+
   it("maps an apply action to the apply RPC method", async () => {
     const fake = new FakeDispatcher();
     const dispatcher = createActionDispatcher(fake);

--- a/apps/api/test/server.test.ts
+++ b/apps/api/test/server.test.ts
@@ -7397,34 +7397,24 @@ describe("local TypeScript API", () => {
     await app.close();
   });
 
-  it("cancels an in-flight workflow run by run id", async () => {
+  it("requests in-flight workflow cancellation idempotently without synthetic terminal events", async () => {
     const db = new Database(options.dbPath);
     try {
-      db.prepare(
-        "INSERT INTO job_events (tenant_id, job_id, identity_version, stage, event_type, level, message, occurred_at, payload_json) SELECT 'local', (SELECT job_id FROM jobs WHERE tenant_id = 'local' AND url = ?), 1, ?, ?, ?, ?, ?, ?",
-      ).run(
-        null,
-        "discover",
-        "StageStarted",
-        "info",
-        "Discover workflow started",
-        "2026-04-29T10:20:00+00:00",
-        JSON.stringify({
-          tenantId: "local",
-          jobId: "pipeline",
-          stage: "discover",
-          runId: "discovery:jobspy:run-1",
-          workflowId: "workflow-run-1",
-          progress: {
-            completed: 0,
-            total: 6,
-            percent: 0,
-            currentStep: "JobSpy",
-            status: "running",
-            message: "JobSpy started",
-          },
-        }),
-      );
+      insertPipelineWorkflowEvent(db, {
+        eventType: "WorkflowStarted",
+        occurredAt: "2026-04-29T10:20:00+00:00",
+        workflowId: "workflow-run-1",
+        temporalRunId: "temporal-run-1",
+        startedAt: "2026-04-29T10:20:00+00:00",
+        inputSummary: { runId: "discovery:jobspy:run-1", stage: "discover" },
+      });
+      insertDiscoverWorkflowRunRow(db, {
+        workflowId: "workflow-run-1",
+        status: "in_progress",
+        startedAt: "2026-04-29T10:20:00+00:00",
+        temporalRunId: "temporal-run-1",
+        inputSummary: { runId: "discovery:jobspy:run-1", stage: "discover" },
+      });
       db.prepare(
         `INSERT INTO discovery_runs (
           tenant_id, run_id, source_ids_json, status, counts_json, progress_json,
@@ -7447,11 +7437,15 @@ describe("local TypeScript API", () => {
     }
     const dispatch = vi.fn(async () => ({
       runId: "workflow-run-1",
-      status: "cancel_requested",
+      status: "canceling",
     }));
     const app = buildApp({ ...options, actionDispatcher: dispatch });
 
     const response = await app.inject({
+      method: "POST",
+      url: "/v1/workflow-runs/workflow-run-1/actions/cancel",
+    });
+    const replay = await app.inject({
       method: "POST",
       url: "/v1/workflow-runs/workflow-run-1/actions/cancel",
     });
@@ -7460,7 +7454,7 @@ describe("local TypeScript API", () => {
     expect(response.json()).toMatchObject({
       ok: true,
       action: "cancel",
-      status: "cancel_requested",
+      status: "canceling",
       jobKey: "pipeline",
       runId: "workflow-run-1",
       command: {
@@ -7469,25 +7463,17 @@ describe("local TypeScript API", () => {
         runId: "workflow-run-1",
       },
     });
-    expect(dispatch).toHaveBeenCalledWith(
+    expect(replay.statusCode, replay.body).toBe(200);
+    expect(replay.json()).toMatchObject({ status: "canceling", runId: "workflow-run-1" });
+    expect(dispatch).toHaveBeenCalledTimes(2);
+    expect(dispatch).toHaveBeenNthCalledWith(
+      1,
       expect.objectContaining({
         action: "cancel",
         jobKey: "pipeline",
         runId: "workflow-run-1",
       }),
       expect.objectContaining({ appDir: tempDir, dbPath: options.dbPath }),
-    );
-
-    const summaryResponse = await app.inject({ method: "GET", url: "/v1/dashboard/summary" });
-    expect(summaryResponse.statusCode, summaryResponse.body).toBe(200);
-    expect(summaryResponse.json().progress).toContainEqual(
-      expect.objectContaining({
-        stage: "discover",
-        status: "failed",
-        runId: "discovery:jobspy:run-1",
-        workflowId: "workflow-run-1",
-        message: "Discover canceled",
-      }),
     );
     const verifyDb = new Database(options.dbPath);
     try {
@@ -7506,19 +7492,108 @@ describe("local TypeScript API", () => {
         | undefined;
       expect(row).toBeDefined();
       expect(row).toMatchObject({
-        status: "failed",
-        failed_at: expect.any(String),
-        updated_at: expect.any(String),
+        status: "running",
+        failed_at: null,
+        updated_at: "2026-04-29T10:20:00+00:00",
       });
-      expect(JSON.parse(row?.error_classes_json ?? "[]")).toEqual(["canceled"]);
-      expect(JSON.parse(row?.progress_json ?? "{}")).toMatchObject({
-        status: "failed",
-        message: "Discover canceled",
-      });
+      expect(JSON.parse(row?.error_classes_json ?? "[]")).toEqual([]);
+      expect(JSON.parse(row?.progress_json ?? "{}")).toEqual({ completed: 0, total: 72, unit: "searches" });
+      const syntheticEvents = verifyDb.prepare(
+        `SELECT COUNT(*) AS count
+           FROM job_events
+          WHERE event_type IN ('StageFailed', 'DiscoveryRunFailed', 'WorkflowCanceled')
+            AND payload_json LIKE '%workflow-run-1%'`,
+      ).get() as { count: number };
+      expect(syntheticEvents.count).toBe(0);
     } finally {
       verifyDb.close();
     }
 
+    await app.close();
+  });
+
+  it("preserves an already-terminal Apply result before the worker gate without writes", async () => {
+    const db = new Database(options.dbPath);
+    const eventCount = (db.prepare("SELECT COUNT(*) AS count FROM job_events").get() as { count: number }).count;
+    db.close();
+    const dispatch = vi.fn(async () => ({ status: "canceling" }));
+    const app = buildApp({
+      ...options,
+      actionDispatcher: dispatch,
+      requireHealthyWorkerForActions: true,
+    });
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/v1/workflow-runs/run-1/actions/cancel",
+    });
+    const detail = await app.inject({ method: "GET", url: "/v1/workflow-runs/run-1" });
+
+    expect(response.statusCode, response.body).toBe(200);
+    expect(response.json()).toMatchObject({
+      status: "already_terminal",
+      jobKey: jobIdFor("https://example.com/jobs/ready"),
+      runId: "run-1",
+      result: { status: "succeeded", result: "succeeded" },
+    });
+    expect(detail.statusCode, detail.body).toBe(200);
+    expect(detail.json()).toMatchObject({
+      runId: "run-1",
+      status: "succeeded",
+      result: "succeeded",
+    });
+    expect(dispatch).not.toHaveBeenCalled();
+    const verifyDb = new Database(options.dbPath);
+    expect((verifyDb.prepare("SELECT COUNT(*) AS count FROM job_events").get() as { count: number }).count).toBe(
+      eventCount,
+    );
+    verifyDb.close();
+    await app.close();
+  });
+
+  it("does not mutate an active workflow when the worker is unavailable and rejects unknown runs", async () => {
+    const db = new Database(options.dbPath);
+    insertPipelineWorkflowEvent(db, {
+      eventType: "WorkflowStarted",
+      occurredAt: "2026-04-29T10:20:00+00:00",
+      workflowId: "workflow-run-unavailable",
+      temporalRunId: "temporal-run-unavailable",
+      startedAt: "2026-04-29T10:20:00+00:00",
+    });
+    insertDiscoverWorkflowRunRow(db, {
+      workflowId: "workflow-run-unavailable",
+      status: "in_progress",
+      startedAt: "2026-04-29T10:20:00+00:00",
+      temporalRunId: "temporal-run-unavailable",
+    });
+    const eventCount = (db.prepare("SELECT COUNT(*) AS count FROM job_events").get() as { count: number }).count;
+    db.close();
+    const dispatch = vi.fn(async () => ({ status: "canceling" }));
+    const app = buildApp({
+      ...options,
+      actionDispatcher: dispatch,
+      requireHealthyWorkerForActions: true,
+    });
+
+    const unavailable = await app.inject({
+      method: "POST",
+      url: "/v1/workflow-runs/workflow-run-unavailable/actions/cancel",
+    });
+    const unknown = await app.inject({
+      method: "POST",
+      url: "/v1/workflow-runs/workflow-run-missing/actions/cancel",
+    });
+
+    expect(unavailable.statusCode, unavailable.body).toBe(503);
+    expect(unavailable.json()).toMatchObject({ ok: false, error: "worker_runtime_unavailable" });
+    expect(unknown.statusCode, unknown.body).toBe(404);
+    expect(unknown.json()).toMatchObject({ ok: false, error: "workflow_run_not_found" });
+    expect(dispatch).not.toHaveBeenCalled();
+    const verifyDb = new Database(options.dbPath);
+    expect((verifyDb.prepare("SELECT COUNT(*) AS count FROM job_events").get() as { count: number }).count).toBe(
+      eventCount,
+    );
+    verifyDb.close();
     await app.close();
   });
 
@@ -9869,6 +9944,8 @@ function insertPipelineWorkflowEvent(
 function insertDiscoverWorkflowRunRow(
   db: Database.Database,
   row: {
+    workflowId?: string;
+    workflowType?: string;
     status: string;
     errorCode?: string | null;
     errorMessage?: string | null;
@@ -9878,6 +9955,7 @@ function insertDiscoverWorkflowRunRow(
     durationMs?: number | null;
     temporalRunId?: string | null;
     eventsJson?: string;
+    inputSummary?: Record<string, unknown>;
   },
 ): void {
   db.prepare(
@@ -9887,11 +9965,11 @@ function insertDiscoverWorkflowRunRow(
        duration_ms, temporal_run_id, events_json
      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   ).run(
-    "discover-local",
+    row.workflowId ?? "discover-local",
     "local",
-    "DiscoverWorkflow",
+    row.workflowType ?? "DiscoverWorkflow",
     row.status,
-    JSON.stringify({ limit: 1000 }),
+    JSON.stringify(row.inputSummary ?? { limit: 1000 }),
     row.errorCode ?? null,
     row.errorMessage ?? null,
     row.retryable ? 1 : 0,


### PR DESCRIPTION
## Summary

- classify workflow-run terminal state before checking worker availability or dispatching cancellation
- preserve already-terminal Apply results and related job context without writing replacement events
- surface the worker's canonical `canceling` RPC result instead of degrading it to `queued`
- remove synthetic `StageFailed` and discovery-failed writes from accepted workflow cancellation
- cover repeat cancellation, terminal Apply, worker-unavailable, unknown-run, and RPC mapping behavior

## Validation

- Node 22 `corepack pnpm --filter @jobctrl/api exec vitest run test/server.test.ts test/json-rpc-adapter.test.ts` — 238 passed
- Node 22 `corepack pnpm --filter @jobctrl/api check` — passed
- `git diff --check` — passed
- independent product review — `Gate: PASS` (0 findings)
- independent product QA — `Gate: PASS` (0 findings)

## Stack

- child of #663
- first workflow-parity slice; shared run context and web drawer parity follow as separate child PRs
