### PR TITLE
feat(api): add preparation run job context

### DIFF
--- a/apps/api/src/read-model.ts
+++ b/apps/api/src/read-model.ts
@@ -278,6 +278,11 @@ interface WorkflowRunProjectionRow extends Record<string, unknown> {
   apply_dry_run?: number | null;
   apply_model?: string | null;
   apply_result?: string | null;
+  // Preparation enrichment (LEFT JOIN job_list_projections) — resolved only
+  // from the canonical JobId recorded in input_summary_json.
+  related_job_id?: string | null;
+  related_job_title?: string | null;
+  related_job_employer?: string | null;
 }
 
 interface SourceQualityProjectionRow extends Record<string, unknown> {
@@ -5916,11 +5921,11 @@ function applyWorkflowLifecycleFold(
  * in one list, then re-folds each row's lifecycle from `job_events` (see
  * `loadWorkflowRunLifecycleFolds`) so a stale terminal outcome from a superseded
  * execution never leaks onto a run the current execution has restarted.
- * Apply rows are enriched with job context via a LEFT JOIN to
- * `apply_run_projections` (the apply-specific detail projection); non-apply
- * rows show their workflow type instead of a job title. The `runId` equals
- * the Temporal `workflow_id`, so the Temporal Web UI deep-link uses it
- * verbatim.
+ * Apply rows are enriched with job context via `apply_run_projections` (the
+ * apply-specific detail projection). Preparation rows resolve the canonical
+ * JobId in their input summary against the tenant-scoped job read model. The
+ * `runId` equals the Temporal `workflow_id`, so the Temporal Web UI deep-link
+ * uses it verbatim.
  */
 export function listWorkflowRuns(
   db: SqliteDatabase,
@@ -5932,15 +5937,25 @@ export function listWorkflowRuns(
   const applySelect = `, arp.job_id AS apply_job_id, arp.job_title AS job_title,
        arp.job_employer AS job_employer, arp.dry_run AS apply_dry_run,
        arp.model AS apply_model, arp.result AS apply_result`;
-  // Deleted / hidden filters apply to the enriched apply job only; non-apply
-  // rows have a NULL apply_job_id and pass through untouched.
+  const relatedJobJoin = ` LEFT JOIN job_list_projections rjp
+    ON wrp.workflow_type = 'JobPreparationWorkflow'
+   AND rjp.tenant_id = wrp.tenant_id
+   AND rjp.job_id = CASE
+     WHEN json_valid(wrp.input_summary_json)
+     THEN json_extract(wrp.input_summary_json, '$.jobId')
+     ELSE NULL
+   END`;
+  const relatedJobSelect = `, rjp.job_id AS related_job_id,
+       rjp.title AS related_job_title, rjp.employer AS related_job_employer`;
+  // Deleted / hidden filters apply to any run with canonical job context;
+  // Discover and other job-independent rows pass through untouched.
   const deletedJoin = ` LEFT JOIN jobctrl_deleted_jobs d
-    ON d.tenant_id = arp.tenant_id
-   AND d.job_id = arp.job_id
+    ON d.tenant_id = wrp.tenant_id
+   AND d.job_id = COALESCE(arp.job_id, rjp.job_id)
    AND (d.restored_at IS NULL OR julianday(d.restored_at) <= julianday(d.deleted_at))`;
   const hiddenJoin = ` LEFT JOIN jobctrl_hidden_jobs h
-    ON h.tenant_id = arp.tenant_id
-   AND h.job_id = arp.job_id
+    ON h.tenant_id = wrp.tenant_id
+   AND h.job_id = COALESCE(arp.job_id, rjp.job_id)
    AND h.unhidden_at IS NULL`;
   const where: string[] = ["wrp.tenant_id = ?"];
   const params: SqliteValue[] = [DEFAULT_TENANT];
@@ -5948,7 +5963,7 @@ export function listWorkflowRuns(
   const whereSql = where.length ? ` WHERE ${where.join(" AND ")}` : "";
   const rows = allRows<WorkflowRunProjectionRow>(
     db,
-    `SELECT wrp.*${applySelect} FROM workflow_run_projections wrp${applyJoin}${deletedJoin}${hiddenJoin}${whereSql}
+    `SELECT wrp.*${applySelect}${relatedJobSelect} FROM workflow_run_projections wrp${applyJoin}${relatedJobJoin}${deletedJoin}${hiddenJoin}${whereSql}
      ORDER BY wrp.started_at DESC, wrp.workflow_id DESC`,
     params,
   );
@@ -5979,10 +5994,10 @@ function workflowRunsFilterPayload(query: WorkflowRunsListQuery): Record<string,
 
 /**
  * Workflow run detail (Temporal loop closure — P0). Reads one
- * `workflow_run_projections` row (enriched with apply job context when the
- * run is an apply workflow) and returns the full `WorkflowRunDetail` shape,
- * including the folded lifecycle timeline. Returns `null` when the run id is
- * unknown.
+ * `workflow_run_projections` row (enriched with canonical job context when the
+ * run is an apply or preparation workflow) and returns the full
+ * `WorkflowRunDetail` shape, including the folded lifecycle timeline. Returns
+ * `null` when the run id is unknown.
  */
 export function getWorkflowRunDetail(
   db: SqliteDatabase,
@@ -5994,9 +6009,19 @@ export function getWorkflowRunDetail(
   const applySelect = `, arp.job_id AS apply_job_id, arp.job_title AS job_title,
        arp.job_employer AS job_employer, arp.dry_run AS apply_dry_run,
        arp.model AS apply_model, arp.result AS apply_result`;
+  const relatedJobJoin = ` LEFT JOIN job_list_projections rjp
+    ON wrp.workflow_type = 'JobPreparationWorkflow'
+   AND rjp.tenant_id = wrp.tenant_id
+   AND rjp.job_id = CASE
+     WHEN json_valid(wrp.input_summary_json)
+     THEN json_extract(wrp.input_summary_json, '$.jobId')
+     ELSE NULL
+   END`;
+  const relatedJobSelect = `, rjp.job_id AS related_job_id,
+       rjp.title AS related_job_title, rjp.employer AS related_job_employer`;
   const rawRow = getRow<WorkflowRunProjectionRow>(
     db,
-    `SELECT wrp.*${applySelect} FROM workflow_run_projections wrp${applyJoin}
+    `SELECT wrp.*${applySelect}${relatedJobSelect} FROM workflow_run_projections wrp${applyJoin}${relatedJobJoin}
      WHERE wrp.tenant_id = ? AND wrp.workflow_id = ?`,
     [DEFAULT_TENANT, runId],
   );
@@ -6089,9 +6114,12 @@ function rowToWorkflowRunSummary(row: WorkflowRunProjectionRow): WorkflowRunSumm
     workflowType === "ApplyWorkflow" &&
     (inputSummary.autoApplyLoop === true || inputSummary.auto_apply_loop === true) &&
     inputSummary.continuous === true;
-  // Apply rows carry job context via the LEFT JOIN; non-apply rows have a
-  // NULL apply_job_id and surface their workflow type instead of a job title.
+  // Apply context remains authoritative for apply runs. Preparation context
+  // comes only from the canonical JobId join; job-independent runs continue to
+  // surface their workflow type.
   const hasApplyJob = Boolean(stringField(row.apply_job_id));
+  const jobKey = stringField(row.apply_job_id) || stringField(row.related_job_id);
+  const hasJob = Boolean(jobKey);
   const dryRun = hasApplyJob
     ? Boolean(row.apply_dry_run)
     : inputSummaryDryRun(inputSummary);
@@ -6099,14 +6127,17 @@ function rowToWorkflowRunSummary(row: WorkflowRunProjectionRow): WorkflowRunSumm
     workflowId,
     runId: workflowId,
     workflowType,
-    jobKey: stringField(row.apply_job_id),
+    jobKey,
     title:
       (isStandingApplyLoop ? "Standing apply loop" : "") ||
       stringField(row.job_title) ||
-      (hasApplyJob ? "Untitled" : workflowType || "Workflow run"),
+      stringField(row.related_job_title) ||
+      (hasJob ? "Untitled" : workflowType || "Workflow run"),
     company:
       (isStandingApplyLoop ? "Auto apply" : "") ||
-      stringField(row.job_employer) || (hasApplyJob ? "Unknown company" : ""),
+      stringField(row.job_employer) ||
+      stringField(row.related_job_employer) ||
+      (hasJob ? "Unknown company" : ""),
     status: normalizeWorkflowRunStatus(row.status),
     result: nullableString(row.apply_result),
     dryRun,

--- a/apps/api/test/server.test.ts
+++ b/apps/api/test/server.test.ts
@@ -5199,6 +5199,104 @@ describe("local TypeScript API", () => {
     }
   });
 
+  it("enriches preparation workflow list and detail from its canonical tenant-scoped JobId", async () => {
+    const jobId = jobIdFor("https://example.com/jobs/ready");
+    const db = new Database(options.dbPath);
+    db.prepare(
+      `INSERT INTO job_list_projections (tenant_id, job_id, title, employer)
+       VALUES (?, ?, ?, ?)`,
+    ).run("other", jobId, "Wrong tenant title", "Wrong tenant employer");
+    insertDiscoverWorkflowRunRow(db, {
+      workflowId: "prepare-local",
+      workflowType: "JobPreparationWorkflow",
+      status: "succeeded",
+      inputSummary: { jobId, dryRun: true, steps: ["tailor", "cover"] },
+      startedAt: "2026-04-29T10:26:00+00:00",
+      finishedAt: "2026-04-29T10:27:00+00:00",
+      durationMs: 60_000,
+      temporalRunId: "temporal-prepare-run",
+      eventsJson: JSON.stringify([
+        {
+          eventType: "WorkflowStarted",
+          occurredAt: "2026-04-29T10:26:00+00:00",
+          status: "in_progress",
+          message: null,
+        },
+        {
+          eventType: "WorkflowCompleted",
+          occurredAt: "2026-04-29T10:27:00+00:00",
+          status: "succeeded",
+          message: null,
+        },
+      ]),
+    });
+    insertDiscoverWorkflowRunRow(db, {
+      workflowId: "prepare-url-shaped",
+      workflowType: "JobPreparationWorkflow",
+      status: "queued",
+      inputSummary: { jobId: "https://example.com/jobs/ready" },
+      startedAt: "2026-04-29T10:25:00+00:00",
+    });
+    insertDiscoverWorkflowRunRow(db, {
+      workflowId: "discover-with-job-id",
+      status: "queued",
+      inputSummary: { jobId },
+      startedAt: "2026-04-29T10:24:00+00:00",
+    });
+    db.close();
+
+    const app = buildApp(options);
+    try {
+      const listResponse = await app.inject({ method: "GET", url: "/v1/workflow-runs" });
+      expect(listResponse.statusCode, listResponse.body).toBe(200);
+      const summary = listResponse
+        .json()
+        .items.find((item: { workflowId: string }) => item.workflowId === "prepare-local");
+      expect(summary).toMatchObject({
+        workflowId: "prepare-local",
+        workflowType: "JobPreparationWorkflow",
+        jobKey: jobId,
+        title: "Platform Engineer",
+        company: "ExampleCo",
+        status: "succeeded",
+        dryRun: true,
+      });
+      const urlShapedSummary = listResponse
+        .json()
+        .items.find((item: { workflowId: string }) => item.workflowId === "prepare-url-shaped");
+      expect(urlShapedSummary).toMatchObject({
+        jobKey: "",
+        title: "JobPreparationWorkflow",
+        company: "",
+      });
+      const discoverSummary = listResponse
+        .json()
+        .items.find((item: { workflowId: string }) => item.workflowId === "discover-with-job-id");
+      expect(discoverSummary).toMatchObject({
+        jobKey: "",
+        title: "DiscoverWorkflow",
+        company: "",
+      });
+
+      const detailResponse = await app.inject({ method: "GET", url: "/v1/workflow-runs/prepare-local" });
+      expect(detailResponse.statusCode, detailResponse.body).toBe(200);
+      expect(detailResponse.json()).toMatchObject({
+        workflowId: "prepare-local",
+        workflowType: "JobPreparationWorkflow",
+        jobKey: jobId,
+        title: "Platform Engineer",
+        company: "ExampleCo",
+        inputSummary: { jobId, dryRun: true, steps: ["tailor", "cover"] },
+        events: [
+          { eventType: "WorkflowStarted", status: "in_progress" },
+          { eventType: "WorkflowCompleted", status: "succeeded" },
+        ],
+      });
+    } finally {
+      await app.close();
+    }
+  });
+
   it("surfaces the standing auto-apply loop as an operations workflow run", async () => {
     const db = new Database(options.dbPath);
     db.prepare(


### PR DESCRIPTION
## Summary

- enrich `JobPreparationWorkflow` list and detail rows from the tenant-scoped canonical `JobId` recorded in the workflow input summary
- preserve Apply projection ownership and keep Discover runs job-independent
- reject URL-shaped pseudo-identities and prevent cross-tenant job context leakage

## Validation

- `corepack pnpm --filter @jobctrl/api check`
- `corepack pnpm --filter @jobctrl/api exec vitest run test/server.test.ts` (210 passed)
- focused preparation, Apply, Discover, tenant-isolation, and URL-shaped identity regressions
- independent review: PASS (0 findings)
- independent QA: PASS (0 findings)

## Checklist

- [x] External contributor commits include a DCO `Signed-off-by:` trailer, when applicable.
- [x] I ran the relevant local checks and listed them above.
- [x] I did not include secrets, private profile data, resumes, generated application materials, raw logs, browser profiles, SQLite databases, or local paths.
