### PR TITLE
feat(web): unify workflow run cancellation

### DIFF
--- a/apps/web/src/contexts/pipeline/components/CancelWorkflowRunButton.test.tsx
+++ b/apps/web/src/contexts/pipeline/components/CancelWorkflowRunButton.test.tsx
@@ -1,4 +1,5 @@
-import { screen, waitFor } from "@testing-library/react";
+import type { ActionRunResponse } from "@jobctrl/contracts";
+import { screen } from "@testing-library/react";
 import { userEvent } from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
@@ -6,23 +7,28 @@ import { renderWithProviders } from "../../../test/render.js";
 import { buildTestPorts } from "../../../test/testPorts.js";
 import { CancelWorkflowRunButton } from "./CancelWorkflowRunButton.js";
 
-describe("<CancelWorkflowRunButton>", () => {
-  it("stops propagation and cancels the workflow run", async () => {
-    const user = userEvent.setup();
-    const cancelWorkflowRun = vi.fn(async (runId: string) => ({
-      ok: true as const,
-      runId,
-      actionId: runId,
-      action: "cancel" as const,
-      status: "cancel_requested",
-      jobKey: "pipeline",
-      command: { action: "cancel" as const, jobKey: "pipeline", runId },
-    }));
-    const parentClick = vi.fn();
+function cancelResponse(runId: string, status: string): ActionRunResponse {
+  return {
+    ok: true,
+    runId,
+    actionId: runId,
+    action: "cancel",
+    status,
+    jobKey: "pipeline",
+    command: { action: "cancel", jobKey: "pipeline", runId },
+  };
+}
 
+describe("<CancelWorkflowRunButton>", () => {
+  it("stops propagation and surfaces an accepted cancellation", async () => {
+    const user = userEvent.setup();
+    const cancelWorkflowRun = vi.fn(async (runId: string) =>
+      cancelResponse(runId, "canceling"),
+    );
+    const parentClick = vi.fn();
     renderWithProviders(
       <div onClick={parentClick}>
-        <CancelWorkflowRunButton runId="workflow-run-1" label="Stop" />
+        <CancelWorkflowRunButton runId="workflow-run-1" />
       </div>,
       { ports: buildTestPorts({ api: { cancelWorkflowRun } }) },
     );
@@ -32,10 +38,69 @@ describe("<CancelWorkflowRunButton>", () => {
     });
     expect(button).toHaveAttribute("data-slot", "button");
     expect(button).toHaveAttribute("data-typography", "control");
-
     await user.click(button);
 
-    await waitFor(() => expect(cancelWorkflowRun).toHaveBeenCalledWith("workflow-run-1"));
+    expect(await screen.findByText("Cancellation requested")).toBeDisabled();
+    expect(cancelWorkflowRun).toHaveBeenCalledWith("workflow-run-1");
     expect(parentClick).not.toHaveBeenCalled();
+  });
+
+  it("surfaces an already-terminal cancellation result", async () => {
+    const user = userEvent.setup();
+    const cancelWorkflowRun = vi.fn(async (runId: string) =>
+      cancelResponse(runId, "already_terminal"),
+    );
+    renderWithProviders(<CancelWorkflowRunButton runId="workflow-run-1" />, {
+      ports: buildTestPorts({ api: { cancelWorkflowRun } }),
+    });
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Stop workflow run workflow-run-1",
+      }),
+    );
+
+    expect(await screen.findByText("Already finished")).toBeDisabled();
+  });
+
+  it("keeps cancellation retryable when the worker is unavailable", async () => {
+    const user = userEvent.setup();
+    const cancelWorkflowRun = vi.fn(async () => {
+      throw new Error("JobCtrl worker is unavailable.");
+    });
+    renderWithProviders(<CancelWorkflowRunButton runId="workflow-run-1" />, {
+      ports: buildTestPorts({ api: { cancelWorkflowRun } }),
+    });
+
+    const button = screen.getByRole("button", {
+      name: "Stop workflow run workflow-run-1",
+    });
+    await user.click(button);
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "JobCtrl worker is unavailable.",
+    );
+    expect(button).toBeEnabled();
+  });
+
+  it("keeps a transport-successful worker failure retryable and visible", async () => {
+    const user = userEvent.setup();
+    const cancelWorkflowRun = vi.fn(async (runId: string) => ({
+      ...cancelResponse(runId, "failed"),
+      message: "Temporal cancellation failed.",
+    }));
+    renderWithProviders(<CancelWorkflowRunButton runId="workflow-run-1" />, {
+      ports: buildTestPorts({ api: { cancelWorkflowRun } }),
+    });
+
+    const button = screen.getByRole("button", {
+      name: "Stop workflow run workflow-run-1",
+    });
+    await user.click(button);
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Temporal cancellation failed.",
+    );
+    expect(button).toBeEnabled();
   });
 });

--- a/apps/web/src/contexts/pipeline/components/CancelWorkflowRunButton.tsx
+++ b/apps/web/src/contexts/pipeline/components/CancelWorkflowRunButton.tsx
@@ -18,21 +18,41 @@ export function CancelWorkflowRunButton({
 }: CancelWorkflowRunButtonProps): JSX.Element {
   const cancelRun = useCancelWorkflowRunMutation();
   const isPending = cancelRun.isPending;
+  const cancellationAccepted = cancelRun.data?.status === "canceling";
+  const alreadyTerminal = cancelRun.data?.status === "already_terminal";
+  const responseError =
+    cancelRun.isSuccess && !cancellationAccepted && !alreadyTerminal
+      ? cancelRun.data.message || `Cancellation failed (${cancelRun.data.status}).`
+      : null;
+  const buttonLabel = isPending
+    ? "Stopping"
+    : cancellationAccepted
+      ? "Cancellation requested"
+      : alreadyTerminal
+        ? "Already finished"
+        : label;
   return (
-    <Button
-      type="button"
-      {...(className ? { className } : {})}
-      variant="destructive"
-      size="sm"
-      disabled={isPending}
-      aria-label={ariaLabel ?? `Stop workflow run ${runId}`}
-      title="Stop workflow run"
-      onClick={(event) => {
-        event.stopPropagation();
-        cancelRun.mutate({ runId });
-      }}
-    >
-      {isPending ? "Stopping" : label}
-    </Button>
+    <span className="workflow-cancel-action">
+      <Button
+        type="button"
+        {...(className ? { className } : {})}
+        variant="destructive"
+        size="sm"
+        disabled={isPending || cancellationAccepted || alreadyTerminal}
+        aria-label={ariaLabel ?? `Stop workflow run ${runId}`}
+        title="Stop workflow run"
+        onClick={(event) => {
+          event.stopPropagation();
+          cancelRun.mutate({ runId });
+        }}
+      >
+        {buttonLabel}
+      </Button>
+      {cancelRun.isError || responseError ? (
+        <small data-typography="metadata" role="alert">
+          {cancelRun.isError ? cancelRun.error.message : responseError}
+        </small>
+      ) : null}
+    </span>
   );
 }

--- a/apps/web/src/contexts/pipeline/hooks/useCancelWorkflowRunMutation.test.ts
+++ b/apps/web/src/contexts/pipeline/hooks/useCancelWorkflowRunMutation.test.ts
@@ -17,7 +17,7 @@ describe("useCancelWorkflowRunMutation", () => {
       runId,
       actionId: runId,
       action: "cancel" as const,
-      status: "cancel_requested",
+      status: "canceling",
       jobKey: "pipeline",
       command: { action: "cancel" as const, jobKey: "pipeline", runId },
     }));
@@ -34,6 +34,9 @@ describe("useCancelWorkflowRunMutation", () => {
     expect(cancelWorkflowRun).toHaveBeenCalledWith("workflow-run-1");
     expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: workflowRunsKeys.lists(LOCAL_TENANT),
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: workflowRunsKeys.details(LOCAL_TENANT),
     });
     expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: dashboardKeys.summary(LOCAL_TENANT),

--- a/apps/web/src/contexts/pipeline/hooks/useCancelWorkflowRunMutation.ts
+++ b/apps/web/src/contexts/pipeline/hooks/useCancelWorkflowRunMutation.ts
@@ -24,6 +24,7 @@ export function useCancelWorkflowRunMutation(): UseMutationResult<
     onSettled: async () => {
       await Promise.all([
         queryClient.invalidateQueries({ queryKey: workflowRunsKeys.lists(tenantId) }),
+        queryClient.invalidateQueries({ queryKey: workflowRunsKeys.details(tenantId) }),
         queryClient.invalidateQueries({ queryKey: dashboardKeys.summary(tenantId) }),
         queryClient.invalidateQueries({ queryKey: pipelineKeys.operations(tenantId) }),
       ]);

--- a/apps/web/src/views/runs/RunsView.tsx
+++ b/apps/web/src/views/runs/RunsView.tsx
@@ -13,10 +13,6 @@ import { PageHead } from "../../shared/ui/page-head.js";
 import { RunsFilterBar } from "./RunsFilterBar.js";
 import { RunsTable } from "./RunsTable.js";
 
-// TODO(temporal): the JSON-RPC `cancel_run` handler + `CancelRunParamsSchema`
-// already exist (PR 3 fixer). Wiring an in-row "Cancel running workflow"
-// button is out of scope for PR 5 and lands in a follow-up.
-
 function workflowRunsInput(search: RunsSearch): WorkflowRunsListInput {
   return {
     page: search.page,

--- a/apps/web/src/views/runs/WorkflowRunDrawer.test.tsx
+++ b/apps/web/src/views/runs/WorkflowRunDrawer.test.tsx
@@ -176,4 +176,71 @@ describe("<WorkflowRunDrawer>", () => {
       "Reconstructed from the run failure record",
     );
   });
+
+  it("cancels an active run from the detail workspace and refreshes its detail", async () => {
+    const user = userEvent.setup();
+    const workflowRun = vi.fn(async () =>
+      makeWorkflowRunDetail({
+        status: "in_progress",
+        errorCode: null,
+        errorMessage: null,
+        retryable: false,
+        finishedAt: null,
+        durationMs: null,
+        events: [],
+      }),
+    );
+    const cancelWorkflowRun = vi.fn(async (runId: string) => ({
+      ok: true as const,
+      runId,
+      actionId: runId,
+      action: "cancel" as const,
+      status: "canceling",
+      jobKey: "pipeline",
+      command: { action: "cancel" as const, jobKey: "pipeline", runId },
+    }));
+    const ports = buildTestPorts({ api: { workflowRun, cancelWorkflowRun } });
+    const harness = buildProviderHarness({ ports });
+    const router = buildRouter();
+    render(<RouterProvider router={router} />, { wrapper: harness.Wrapper });
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: "Stop workflow run run-pipeline-1",
+      }),
+    );
+
+    expect(await screen.findByText("Cancellation requested")).toBeDisabled();
+    expect(cancelWorkflowRun).toHaveBeenCalledWith("run-pipeline-1");
+    expect(workflowRun).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps a terminal workflow result inspectable without a stop action", async () => {
+    const workflowRun = vi.fn(async () =>
+      makeWorkflowRunDetail({
+        status: "canceled",
+        result: "Canceled by user",
+        errorCode: null,
+        errorMessage: null,
+        retryable: false,
+      }),
+    );
+    const ports = buildTestPorts({ api: { workflowRun } });
+    const harness = buildProviderHarness({ ports });
+    const router = buildRouter();
+    render(<RouterProvider router={router} />, { wrapper: harness.Wrapper });
+
+    const workspace = await screen.findByRole("article", {
+      name: "Workflow run details",
+    });
+    const details = within(workspace)
+      .getByRole("heading", { level: 2, name: "Run details" })
+      .closest("section");
+    expect(details).not.toBeNull();
+    expect(within(details!).getByText("Result")).toBeInTheDocument();
+    expect(within(details!).getByText("Canceled by user")).toBeInTheDocument();
+    expect(
+      within(workspace).queryByRole("button", { name: /Stop workflow run/ }),
+    ).not.toBeInTheDocument();
+  });
 });

--- a/apps/web/src/views/runs/WorkflowRunDrawer.tsx
+++ b/apps/web/src/views/runs/WorkflowRunDrawer.tsx
@@ -15,6 +15,7 @@ import type {
   WorkflowRunDetail,
   WorkflowRunTimelineEvent,
 } from "../../contexts/operations/types.js";
+import { CancelWorkflowRunButton } from "../../contexts/pipeline/components/CancelWorkflowRunButton.js";
 import { formatDateTime } from "../../shared/lib/formatters.js";
 import { usePorts } from "../../shared/providers/PortsProvider.js";
 import { Button, buttonVariants } from "../../shared/ui/button.js";
@@ -164,16 +165,12 @@ function RunActions({ run }: { readonly run: WorkflowRunDetail }) {
         </Link>
       ) : null}
       {ACTIVE_RUN_STATUSES.has(run.status) ? (
-        <Link
-          className={buttonVariants({
-            className: "workflow-run-actions__primary",
-            size: "sm",
-          })}
-          data-typography="control"
-          to="/pipelines"
-        >
-          Open pipeline controls
-        </Link>
+        <CancelWorkflowRunButton
+          ariaLabel={`Stop workflow run ${run.workflowId}`}
+          className="workflow-run-actions__primary"
+          label="Stop run"
+          runId={run.runId}
+        />
       ) : null}
       <a
         aria-label={`Open workflow ${run.workflowId} in Temporal Web UI`}
@@ -271,6 +268,12 @@ function RunMetadata({ run }: { readonly run: WorkflowRunDetail }) {
           <dt data-typography="label">Duration</dt>
           <dd data-typography="body">{formatDuration(run.durationMs)}</dd>
         </div>
+        {run.result ? (
+          <div>
+            <dt data-typography="label">Result</dt>
+            <dd data-typography="body">{run.result}</dd>
+          </div>
+        ) : null}
       </dl>
     </RunSection>
   );


### PR DESCRIPTION
## Summary

- reuse the context-owned cancellation mutation from both workflow-run rows and the detail workspace
- distinguish canceling, already-terminal, worker-unavailable, and transport-successful failure results without synthesizing terminal workflow state
- refresh tenant-scoped workflow list/detail, dashboard, and pipeline queries after cancellation while keeping terminal results inspectable

## Validation

- `corepack pnpm --filter @jobctrl/web check`
- `corepack pnpm --filter @jobctrl/web build`
- four focused Vitest suites (17 passed)
- Storybook production build
- independent review: PASS (0 findings)
- independent QA: PASS (0 findings)

## Checklist

- [x] External contributor commits include a DCO `Signed-off-by:` trailer, when applicable.
- [x] I ran the relevant local checks and listed them above.
- [x] I did not include secrets, private profile data, resumes, generated application materials, raw logs, browser profiles, SQLite databases, or local paths.
