### PR TITLE
feat(web): patch realtime job and artifact details

### DIFF
--- a/apps/web/src/contexts/enrichment/handlers.ts
+++ b/apps/web/src/contexts/enrichment/handlers.ts
@@ -10,8 +10,13 @@ import type {
 
 import { dashboardKeys } from "../operations/dashboardKeys.js";
 import { discoveryKeys } from "../discovery/queryKeys.js";
-import { invalidate, type InvalidationItem } from "../operations/invalidation-router.js";
+import {
+  invalidate,
+  patchQuery,
+  type InvalidationItem,
+} from "../operations/invalidation-router.js";
 import { jobsKeys } from "../operations/jobsKeys.js";
+import { patchJobActiveState } from "../operations/realtimePatches.js";
 
 export const jobEnrichedHandler = (event: JobEnriched): readonly InvalidationItem[] => [
   invalidate(jobsKeys.lists(event.tenantId)),
@@ -62,6 +67,12 @@ export const postingContentSnapshotFailedHandler = (
 export const jobActiveStateChangedHandler = (
   event: JobActiveStateChanged,
 ): readonly InvalidationItem[] => [
+  // Active state is exact on an open detail. List membership can cross the
+  // active/closed filters, so list reconciliation remains bounded by tenant.
+  patchQuery(
+    jobsKeys.detail(event.tenantId, event.payload.jobId),
+    (current) => patchJobActiveState(current, event.payload),
+  ),
   invalidate(jobsKeys.lists(event.tenantId)),
   invalidate(jobsKeys.detail(event.tenantId, event.payload.jobId)),
   invalidate(discoveryKeys.sourceQuality(event.tenantId)),

--- a/apps/web/src/contexts/materials/handlers.ts
+++ b/apps/web/src/contexts/materials/handlers.ts
@@ -20,13 +20,28 @@ import type {
 import { applyReviewKeys } from "../operations/applyReviewKeys.js";
 import { artifactsKeys } from "../operations/artifactsKeys.js";
 import { dashboardKeys } from "../operations/dashboardKeys.js";
-import { invalidate, type InvalidationItem } from "../operations/invalidation-router.js";
+import {
+  invalidate,
+  patchQuery,
+  type InvalidationItem,
+} from "../operations/invalidation-router.js";
 import { jobsKeys } from "../operations/jobsKeys.js";
+import { patchResumeApproved } from "../operations/realtimePatches.js";
 import { profileKeys } from "../profile/queryKeys.js";
 
 export const resumeApprovedHandler = (
   event: ResumeApproved,
 ): readonly InvalidationItem[] => [
+  // Patch only already-registered detail rows. This event does not carry the
+  // complete artifact summary needed to insert or refilter an artifact page.
+  patchQuery(
+    jobsKeys.detail(event.tenantId, event.payload.jobId),
+    (current) => patchResumeApproved(current, event.payload),
+  ),
+  patchQuery(
+    artifactsKeys.detail(event.tenantId, event.payload.artifactId),
+    (current) => patchResumeApproved(current, event.payload),
+  ),
   invalidate(jobsKeys.detail(event.tenantId, event.payload.jobId)),
   invalidate(jobsKeys.lists(event.tenantId)),
   invalidate(artifactsKeys.lists(event.tenantId)),

--- a/apps/web/src/contexts/operations/invalidation-router.ts
+++ b/apps/web/src/contexts/operations/invalidation-router.ts
@@ -125,6 +125,12 @@ import type { KnownDomainEvent, KnownDomainEventType } from "./types.js";
 export type InvalidationItem =
   | { readonly kind: "invalidate"; readonly queryKey: QueryKey }
   | {
+      readonly kind: "patch-query";
+      readonly queryKey: QueryKey;
+      readonly exact: boolean;
+      readonly updater: (current: unknown) => unknown;
+    }
+  | {
       readonly kind: "apply-run-event-append";
       readonly tenantId: TenantId;
       readonly runId: string;
@@ -138,6 +144,17 @@ export type InvalidationHandler<TEvent extends KnownDomainEvent = KnownDomainEve
 export const invalidate = (queryKey: QueryKey): InvalidationItem => ({
   kind: "invalidate",
   queryKey,
+});
+
+export const patchQuery = (
+  queryKey: QueryKey,
+  updater: (current: unknown) => unknown,
+  exact = true,
+): InvalidationItem => ({
+  kind: "patch-query",
+  queryKey,
+  exact,
+  updater,
 });
 
 export const patchApplyRunEvent = (
@@ -280,6 +297,13 @@ export const invalidationRouter: InvalidationRouter = {
     for (const item of items) {
       if (item.kind === "invalidate") {
         void queryClient.invalidateQueries({ queryKey: item.queryKey });
+        continue;
+      }
+      if (item.kind === "patch-query") {
+        queryClient.setQueriesData(
+          { queryKey: item.queryKey, exact: item.exact },
+          item.updater,
+        );
         continue;
       }
       // High-frequency `ApplyRunEventRecorded` events patch the apply-run

--- a/apps/web/src/contexts/operations/realtimePatches.test.ts
+++ b/apps/web/src/contexts/operations/realtimePatches.test.ts
@@ -1,0 +1,165 @@
+import {
+  LOCAL_TENANT,
+  createJobActiveStateChanged,
+  createResumeApproved,
+  type TenantId,
+} from "@jobctrl/domain-types";
+import { QueryClient } from "@tanstack/react-query";
+import { describe, expect, it } from "vitest";
+
+import {
+  makeArtifactDetail,
+  makeArtifactsPage,
+  makeJobDetail,
+  makeJobsPage,
+  sampleDraftResumeArtifact,
+  sampleJob,
+} from "../../test/fixtures/projections.js";
+import { artifactsKeys } from "./artifactsKeys.js";
+import { invalidationRouter } from "./invalidation-router.js";
+import { jobsKeys } from "./jobsKeys.js";
+import {
+  patchJobActiveState,
+  patchResumeApproved,
+} from "./realtimePatches.js";
+
+const NOW = "2026-08-01T14:00:00Z";
+const OTHER_TENANT = "other" as TenantId;
+
+describe("realtime cache patches", () => {
+  it("patches active state on one cached detail without replacing its audit data", () => {
+    const current = makeJobDetail(sampleJob);
+    const patched = patchJobActiveState(current, {
+      jobId: sampleJob.jobKey,
+      activeState: "closed",
+    }) as typeof current;
+
+    expect(patched.job.activeState).toBe("closed");
+    expect(patched.auditHistory).toBe(current.auditHistory);
+    expect(patched.stages).toBe(current.stages);
+  });
+
+  it("approves only registered cached artifact rows and never synthesizes one", () => {
+    const candidate = { ...sampleDraftResumeArtifact, artifactId: "artifact-1" };
+    const detail = makeArtifactDetail(candidate);
+    const job = makeJobDetail(sampleJob, { artifacts: [candidate] });
+    const payload = { jobId: sampleJob.jobKey, artifactId: candidate.artifactId };
+
+    expect((patchResumeApproved(detail, payload) as typeof detail).artifact.status).toBe(
+      "approved",
+    );
+    expect((patchResumeApproved(job, payload) as typeof job).artifacts[0]?.status).toBe(
+      "approved",
+    );
+
+    const missing = makeArtifactDetail({ ...candidate, artifactId: "artifact-other" });
+    const unchanged = patchResumeApproved(missing, payload) as typeof missing;
+    expect(unchanged).toBe(missing);
+    expect(unchanged.artifact.artifactId).toBe("artifact-other");
+  });
+
+  it("patches tenant-scoped details while preserving filtered list state", () => {
+    const queryClient = new QueryClient();
+    const listKey = jobsKeys.list(LOCAL_TENANT, {
+      page: 3,
+      q: "platform",
+      normalizedScoreKeyword: "kubernetes",
+    });
+    const listBefore = makeJobsPage([sampleJob]);
+    queryClient.setQueryData(listKey, listBefore);
+    queryClient.setQueryData(
+      jobsKeys.detail(LOCAL_TENANT, sampleJob.jobKey),
+      makeJobDetail(sampleJob),
+    );
+    queryClient.setQueryData(
+      jobsKeys.detail(OTHER_TENANT, sampleJob.jobKey),
+      makeJobDetail(sampleJob),
+    );
+
+    invalidationRouter.handle(
+      createJobActiveStateChanged(LOCAL_TENANT, {
+        jobId: sampleJob.jobKey,
+        activeState: "closed",
+        previousState: "active",
+        verificationMethod: "snapshot",
+        verifiedAt: NOW,
+      }),
+      queryClient,
+    );
+
+    const list = queryClient.getQueryData<ReturnType<typeof makeJobsPage>>(listKey);
+    const detail = queryClient.getQueryData<ReturnType<typeof makeJobDetail>>(
+      jobsKeys.detail(LOCAL_TENANT, sampleJob.jobKey),
+    );
+    expect(list?.items[0]?.activeState).toBe("active");
+    expect(list).toBe(listBefore);
+    expect(detail?.job.activeState).toBe("closed");
+    expect(
+      queryClient.getQueryData<ReturnType<typeof makeJobDetail>>(
+        jobsKeys.detail(OTHER_TENANT, sampleJob.jobKey),
+      )?.job.activeState,
+    ).toBe("active");
+    expect(queryClient.getQueryState(listKey)?.isInvalidated).toBe(true);
+  });
+
+  it("routes active-state and approval events through their exact cached records", () => {
+    const queryClient = new QueryClient();
+    const candidate = { ...sampleDraftResumeArtifact, artifactId: "artifact-1" };
+    const jobsListKey = jobsKeys.list(LOCAL_TENANT, { page: 2, deleted: "all" });
+    const artifactsListKey = artifactsKeys.list(LOCAL_TENANT, {
+      page: 2,
+      status: "candidate",
+    });
+    queryClient.setQueryData(jobsListKey, makeJobsPage([sampleJob]));
+    queryClient.setQueryData(
+      jobsKeys.detail(LOCAL_TENANT, sampleJob.jobKey),
+      makeJobDetail(sampleJob, { artifacts: [candidate] }),
+    );
+    queryClient.setQueryData(artifactsListKey, makeArtifactsPage([candidate]));
+    queryClient.setQueryData(
+      artifactsKeys.detail(LOCAL_TENANT, candidate.artifactId),
+      makeArtifactDetail(candidate),
+    );
+
+    invalidationRouter.handle(
+      createJobActiveStateChanged(LOCAL_TENANT, {
+        jobId: sampleJob.jobKey,
+        activeState: "closed",
+        previousState: "active",
+        verificationMethod: "snapshot",
+        verifiedAt: NOW,
+      }),
+      queryClient,
+    );
+    invalidationRouter.handle(
+      createResumeApproved(LOCAL_TENANT, {
+        jobId: sampleJob.jobKey,
+        artifactId: candidate.artifactId,
+        generation: 2,
+        approvedAt: NOW,
+      }),
+      queryClient,
+    );
+
+    expect(
+      queryClient.getQueryData<ReturnType<typeof makeJobsPage>>(jobsListKey)?.items[0]
+        ?.activeState,
+    ).toBe("active");
+    expect(
+      queryClient.getQueryData<ReturnType<typeof makeJobDetail>>(
+        jobsKeys.detail(LOCAL_TENANT, sampleJob.jobKey),
+      )?.artifacts[0]?.status,
+    ).toBe("approved");
+    expect(
+      queryClient.getQueryData<{ items: typeof candidate[] }>(artifactsListKey)?.items[0]
+        ?.status,
+    ).toBe("candidate");
+    expect(
+      queryClient.getQueryData<ReturnType<typeof makeArtifactDetail>>(
+        artifactsKeys.detail(LOCAL_TENANT, candidate.artifactId),
+      )?.artifact.status,
+    ).toBe("approved");
+    expect(queryClient.getQueryState(jobsListKey)?.isInvalidated).toBe(true);
+    expect(queryClient.getQueryState(artifactsListKey)?.isInvalidated).toBe(true);
+  });
+});

--- a/apps/web/src/contexts/operations/realtimePatches.ts
+++ b/apps/web/src/contexts/operations/realtimePatches.ts
@@ -1,0 +1,75 @@
+import type {
+  ArtifactDetail,
+  ArtifactSummary,
+  JobDetail,
+  JobSummary,
+} from "./types.js";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function patchJobDetail(
+  current: unknown,
+  jobId: string,
+  patch: (job: JobSummary) => JobSummary,
+): unknown {
+  if (isRecord(current) && isRecord(current.job) && typeof current.job.jobKey === "string") {
+    const detail = current as unknown as JobDetail;
+    if (detail.job.jobKey !== jobId) {
+      return current;
+    }
+    return {
+      ...detail,
+      job: patch(detail.job),
+    };
+  }
+  return current;
+}
+
+export function patchJobActiveState(
+  current: unknown,
+  payload: { readonly jobId: string; readonly activeState: JobSummary["activeState"] },
+): unknown {
+  return patchJobDetail(current, payload.jobId, (job) => ({
+    ...job,
+    activeState: payload.activeState,
+  }));
+}
+
+function approveArtifact(artifact: ArtifactSummary, artifactId: string): ArtifactSummary {
+  return artifact.artifactId === artifactId ? { ...artifact, status: "approved" } : artifact;
+}
+
+export function patchResumeApproved(
+  current: unknown,
+  payload: { readonly jobId: string; readonly artifactId: string },
+): unknown {
+  if (isRecord(current) && isRecord(current.artifact)) {
+    const detail = current as unknown as ArtifactDetail;
+    const artifact = approveArtifact(detail.artifact, payload.artifactId);
+    if (artifact === detail.artifact) {
+      return current;
+    }
+    return {
+      ...detail,
+      artifact,
+    };
+  }
+  if (
+    isRecord(current)
+    && isRecord(current.job)
+    && current.job.jobKey === payload.jobId
+    && Array.isArray(current.artifacts)
+  ) {
+    const detail = current as unknown as JobDetail;
+    let changed = false;
+    const artifacts = detail.artifacts.map((artifact) => {
+      const next = approveArtifact(artifact, payload.artifactId);
+      changed ||= next !== artifact;
+      return next;
+    });
+    return changed ? { ...detail, artifacts } : current;
+  }
+  return current;
+}


### PR DESCRIPTION
## Summary

- add a reusable exact-query patch action to the realtime invalidation router
- patch active-state changes into the matching open job detail
- patch resume approval only into already-cached job and artifact details
- preserve filtered and paginated list data while tenant-bounded invalidation reconciles incomplete projections

## Why

Realtime events should update values they authoritatively own without synthesizing projection data. Active-state and resume-approval events can truthfully update registered detail rows, but they cannot insert or refilter complete list records. Scoring remains invalidation-only because its event does not carry the full score evidence needed for an atomic detail update.

## Validation

- `git diff --check`
- web TypeScript check
- focused realtime, SSE integration, provider, and exhaustive invalidation-router suites: 207/207 passed
- independent review: PASS, 0 Blocker / 0 High / 0 Medium / 0 Low
- independent QA: PASS, 0 Blocker / 0 High / 0 Medium / 0 Low

Browser rendering remains deferred to the final Objective 5 UI-state regression child. This is a ready child PR in stack #660 and does not rewrite any prior branch.
