### PR TITLE
feat(web): patch workflow run lifecycle details

### DIFF
--- a/apps/web/src/contexts/operations/invalidation-router.test.ts
+++ b/apps/web/src/contexts/operations/invalidation-router.test.ts
@@ -433,16 +433,19 @@ const expectedInvalidations: Record<DomainEventUnion["eventType"], ExpectedKeys>
   WorkflowStarted: [
     workflowRunsKeys.lists(LOCAL_TENANT),
     workflowRunsKeys.detail(LOCAL_TENANT, WORKFLOW_ID),
+    dashboardKeys.summary(LOCAL_TENANT),
     pipelineKeys.operations(LOCAL_TENANT),
   ],
   WorkflowCompleted: [
     workflowRunsKeys.lists(LOCAL_TENANT),
     workflowRunsKeys.detail(LOCAL_TENANT, WORKFLOW_ID),
+    dashboardKeys.summary(LOCAL_TENANT),
     pipelineKeys.operations(LOCAL_TENANT),
   ],
   WorkflowFailed: [
     workflowRunsKeys.lists(LOCAL_TENANT),
     workflowRunsKeys.detail(LOCAL_TENANT, WORKFLOW_ID),
+    dashboardKeys.summary(LOCAL_TENANT),
     pipelineKeys.operations(LOCAL_TENANT),
   ],
   WorkflowCanceled: [
@@ -455,11 +458,13 @@ const expectedInvalidations: Record<DomainEventUnion["eventType"], ExpectedKeys>
   WorkflowTimedOut: [
     workflowRunsKeys.lists(LOCAL_TENANT),
     workflowRunsKeys.detail(LOCAL_TENANT, WORKFLOW_ID),
+    dashboardKeys.summary(LOCAL_TENANT),
     pipelineKeys.operations(LOCAL_TENANT),
   ],
   WorkflowTerminated: [
     workflowRunsKeys.lists(LOCAL_TENANT),
     workflowRunsKeys.detail(LOCAL_TENANT, WORKFLOW_ID),
+    dashboardKeys.summary(LOCAL_TENANT),
     pipelineKeys.operations(LOCAL_TENANT),
   ],
   ContactCreated: [outreachKeys.contactLists(LOCAL_TENANT)],

--- a/apps/web/src/contexts/operations/realtimePatches.ts
+++ b/apps/web/src/contexts/operations/realtimePatches.ts
@@ -1,9 +1,29 @@
 import type {
+  WorkflowCanceled,
+  WorkflowCompleted,
+  WorkflowFailed,
+  WorkflowStarted,
+  WorkflowTerminated,
+  WorkflowTimedOut,
+} from "@jobctrl/domain-types";
+
+import type {
   ArtifactDetail,
   ArtifactSummary,
   JobDetail,
   JobSummary,
+  WorkflowRunDetail,
 } from "./types.js";
+
+export type WorkflowLifecycleEvent =
+  | WorkflowStarted
+  | WorkflowCompleted
+  | WorkflowFailed
+  | WorkflowCanceled
+  | WorkflowTimedOut
+  | WorkflowTerminated;
+
+const ACTIVE_WORKFLOW_STATUSES = new Set(["starting", "in_progress"]);
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -72,4 +92,109 @@ export function patchResumeApproved(
     return changed ? { ...detail, artifacts } : current;
   }
   return current;
+}
+
+function workflowEventTimestamp(event: WorkflowLifecycleEvent): string | null {
+  if (typeof event.occurredAt === "string" && event.occurredAt.length > 0) {
+    return event.occurredAt;
+  }
+  return event.eventType === "WorkflowStarted"
+    ? event.payload.startedAt
+    : event.payload.finishedAt;
+}
+
+function workflowEventMessage(event: WorkflowLifecycleEvent): string | null {
+  if (event.eventType === "WorkflowCompleted" || event.eventType === "WorkflowStarted") {
+    return null;
+  }
+  return event.payload.errorMessage || null;
+}
+
+export function patchWorkflowRunDetail(
+  current: unknown,
+  event: WorkflowLifecycleEvent,
+): unknown {
+  if (!isRecord(current) || current.workflowId !== event.payload.workflowId) {
+    return current;
+  }
+  const detail = current as unknown as WorkflowRunDetail;
+  const occurredAt = workflowEventTimestamp(event);
+  const message = workflowEventMessage(event);
+  const timelineEvent = {
+    eventType: event.eventType,
+    occurredAt,
+    status: event.payload.status,
+    message,
+  };
+  const duplicate = detail.events.some(
+    (entry) =>
+      entry.eventType === timelineEvent.eventType
+      && entry.occurredAt === timelineEvent.occurredAt
+      && entry.status === timelineEvent.status
+      && entry.message === timelineEvent.message,
+  );
+  const base = {
+    ...detail,
+    workflowType: event.payload.workflowType,
+    status: event.payload.status,
+    temporalRunId: event.payload.temporalRunId,
+    events: duplicate ? detail.events : [...detail.events, timelineEvent],
+  };
+  if (!event.payload.temporalRunId) {
+    return { ...detail, events: base.events };
+  }
+  if (event.eventType === "WorkflowStarted") {
+    const recoveredMissingHistory =
+      detail.status === "terminated"
+      && detail.errorCode === "reconciled_not_found"
+      && event.payload.recoveredFromMissingHistory === true
+      && Boolean(event.payload.temporalRunId)
+      && event.payload.temporalRunId === detail.temporalRunId;
+    const startsNewExecution =
+      Boolean(event.payload.temporalRunId)
+      && Boolean(detail.temporalRunId)
+      && event.payload.temporalRunId !== detail.temporalRunId;
+    if (
+      !ACTIVE_WORKFLOW_STATUSES.has(detail.status)
+      && !recoveredMissingHistory
+      && !startsNewExecution
+    ) {
+      return { ...detail, events: base.events };
+    }
+    return {
+      ...base,
+      inputSummary: event.payload.inputSummary,
+      startedAt: event.payload.startedAt ?? occurredAt ?? detail.startedAt,
+      finishedAt: null,
+      durationMs: null,
+      errorCode: null,
+      errorMessage: null,
+      retryable: false,
+      result: null,
+    };
+  }
+  const executionMismatch =
+    !detail.temporalRunId
+    || event.payload.temporalRunId !== detail.temporalRunId;
+  if (!ACTIVE_WORKFLOW_STATUSES.has(detail.status) || executionMismatch) {
+    return { ...detail, events: base.events };
+  }
+  if (event.eventType === "WorkflowCompleted") {
+    return {
+      ...base,
+      finishedAt: event.payload.finishedAt ?? occurredAt ?? detail.finishedAt,
+      durationMs: event.payload.durationMs ?? detail.durationMs,
+      errorCode: null,
+      errorMessage: null,
+      retryable: false,
+    };
+  }
+  return {
+    ...base,
+    finishedAt: event.payload.finishedAt ?? occurredAt ?? detail.finishedAt,
+    durationMs: event.payload.durationMs ?? detail.durationMs,
+    errorCode: event.payload.errorCode || null,
+    errorMessage: event.payload.errorMessage || null,
+    retryable: event.eventType === "WorkflowFailed" ? event.payload.retryable : false,
+  };
 }

--- a/apps/web/src/contexts/operations/workflowRealtimePatches.test.ts
+++ b/apps/web/src/contexts/operations/workflowRealtimePatches.test.ts
@@ -1,0 +1,262 @@
+import {
+  LOCAL_TENANT,
+  createWorkflowCanceled,
+  createWorkflowCompleted,
+  createWorkflowFailed,
+  createWorkflowStarted,
+  type TenantId,
+} from "@jobctrl/domain-types";
+import { QueryClient } from "@tanstack/react-query";
+import { describe, expect, it } from "vitest";
+
+import {
+  makeWorkflowRunDetail,
+  makeWorkflowRunsPage,
+  sampleDashboardSummary,
+  sampleWorkflowRun,
+} from "../../test/fixtures/projections.js";
+import { dashboardKeys } from "./dashboardKeys.js";
+import { invalidationRouter } from "./invalidation-router.js";
+import {
+  patchWorkflowRunDetail,
+} from "./realtimePatches.js";
+import { workflowRunsKeys } from "./workflowRunsKeys.js";
+
+const NOW = "2026-08-01T15:00:00Z";
+const OTHER_TENANT = "other" as TenantId;
+
+describe("workflow realtime cache patches", () => {
+  it("terminalizes an open run detail and appends one inspectable timeline event", () => {
+    const current = makeWorkflowRunDetail({
+      workflowId: "run-1",
+      runId: "run-1",
+      status: "in_progress",
+      finishedAt: null,
+      durationMs: null,
+      errorCode: "old_error",
+      errorMessage: "old message",
+      retryable: true,
+      events: [],
+    });
+    const event = createWorkflowCompleted(LOCAL_TENANT, {
+      workflowId: "run-1",
+      workflowType: "JobPipelineWorkflow",
+      status: "succeeded",
+      finishedAt: NOW,
+      durationMs: 42_000,
+      temporalRunId: "temporal-run-1",
+    });
+
+    const wireEvent = {
+      eventType: event.eventType,
+      tenantId: event.tenantId,
+      payload: event.payload,
+    } as typeof event;
+    const patched = patchWorkflowRunDetail(current, wireEvent) as typeof current;
+    expect(patched).toMatchObject({
+      status: "succeeded",
+      finishedAt: NOW,
+      durationMs: 42_000,
+      errorCode: null,
+      errorMessage: null,
+      retryable: false,
+    });
+    expect(patched.events).toEqual([
+      {
+        eventType: "WorkflowCompleted",
+        occurredAt: NOW,
+        status: "succeeded",
+        message: null,
+      },
+    ]);
+    const replayed = patchWorkflowRunDetail(patched, wireEvent) as typeof patched;
+    expect(replayed.events).toHaveLength(1);
+  });
+
+  it("keeps the first terminal result when a later terminal event races it", () => {
+    const current = makeWorkflowRunDetail({
+      status: "succeeded",
+      finishedAt: NOW,
+      durationMs: 10_000,
+      errorCode: null,
+      errorMessage: null,
+      retryable: false,
+      events: [],
+    });
+    const lateFailure = createWorkflowFailed(LOCAL_TENANT, {
+      workflowId: current.workflowId,
+      workflowType: current.workflowType,
+      status: "failed",
+      errorCode: "late_failure",
+      errorMessage: "late failure must not replace success",
+      retryable: true,
+      finishedAt: "2026-08-01T15:01:00Z",
+      durationMs: 11_000,
+      temporalRunId: current.temporalRunId,
+    });
+
+    const patched = patchWorkflowRunDetail(current, lateFailure) as typeof current;
+    expect(patched).toMatchObject({
+      status: "succeeded",
+      finishedAt: NOW,
+      durationMs: 10_000,
+      errorCode: null,
+      errorMessage: null,
+      retryable: false,
+    });
+    expect(patched.events.at(-1)?.eventType).toBe("WorkflowFailed");
+  });
+
+  it("does not patch state for a missing or superseded Temporal execution id", () => {
+    const current = makeWorkflowRunDetail({
+      status: "in_progress",
+      temporalRunId: "temporal-current",
+      finishedAt: null,
+      durationMs: null,
+      errorCode: null,
+      errorMessage: null,
+      retryable: false,
+      events: [],
+    });
+    const missingIdentity = createWorkflowFailed(LOCAL_TENANT, {
+      workflowId: current.workflowId,
+      workflowType: current.workflowType,
+      status: "failed",
+      errorCode: "missing_identity",
+      errorMessage: "identity unavailable",
+      retryable: true,
+      finishedAt: NOW,
+      durationMs: 5_000,
+      temporalRunId: null,
+    });
+    const superseded = createWorkflowFailed(LOCAL_TENANT, {
+      ...missingIdentity.payload,
+      errorCode: "late_old_run",
+      temporalRunId: "temporal-old",
+    });
+
+    const afterMissing = patchWorkflowRunDetail(current, missingIdentity) as typeof current;
+    const afterSuperseded = patchWorkflowRunDetail(current, superseded) as typeof current;
+    const unidentifiedCurrent = patchWorkflowRunDetail(
+      { ...current, temporalRunId: null },
+      superseded,
+    ) as typeof current;
+    for (const patched of [afterMissing, afterSuperseded, unidentifiedCurrent]) {
+      expect(patched).toMatchObject({
+        status: "in_progress",
+        finishedAt: null,
+        durationMs: null,
+        errorCode: null,
+        errorMessage: null,
+        retryable: false,
+      });
+      expect(patched.events).toHaveLength(1);
+    }
+    expect(afterMissing.temporalRunId).toBe("temporal-current");
+    expect(afterSuperseded.temporalRunId).toBe("temporal-current");
+    expect(unidentifiedCurrent.temporalRunId).toBeNull();
+  });
+
+  it("reopens recovered workflow state without retaining terminal failure fields", () => {
+    const current = makeWorkflowRunDetail({
+      status: "terminated",
+      errorCode: "reconciled_not_found",
+      errorMessage: "history temporarily unavailable",
+      retryable: false,
+    });
+    const event = createWorkflowStarted(LOCAL_TENANT, {
+      workflowId: current.workflowId,
+      workflowType: current.workflowType,
+      status: "in_progress",
+      inputSummary: { stages: ["discover", "score"] },
+      startedAt: NOW,
+      temporalRunId: "temporal-recovered",
+      recoveredFromMissingHistory: true,
+    });
+
+    const patched = patchWorkflowRunDetail(current, event) as typeof current;
+    expect(patched).toMatchObject({
+      status: "in_progress",
+      inputSummary: { stages: ["discover", "score"] },
+      startedAt: NOW,
+      finishedAt: null,
+      durationMs: null,
+      errorCode: null,
+      errorMessage: null,
+      retryable: false,
+      temporalRunId: "temporal-recovered",
+    });
+  });
+
+  it("patches exact tenant details while preserving filtered run-list context", () => {
+    const queryClient = new QueryClient();
+    const workflowId = sampleWorkflowRun.workflowId;
+    const listKey = workflowRunsKeys.list(LOCAL_TENANT, {
+      page: 3,
+      status: "in_progress",
+      sort: "started_at",
+      dir: "desc",
+    });
+    const listBefore = makeWorkflowRunsPage([sampleWorkflowRun]);
+    const detailBefore = makeWorkflowRunDetail({
+      workflowId,
+      runId: workflowId,
+      workflowType: sampleWorkflowRun.workflowType,
+      status: "in_progress",
+      errorCode: null,
+      errorMessage: null,
+      retryable: false,
+      temporalRunId: "temporal-apply-run-1",
+      finishedAt: null,
+      durationMs: null,
+      events: [],
+    });
+    const dashboardBefore = {
+      ...sampleDashboardSummary,
+      applyRuns: sampleDashboardSummary.applyRuns.map((run, index) =>
+        index === 0 ? { ...run, runId: workflowId, status: "in_progress" } : run,
+      ),
+    };
+    queryClient.setQueryData(listKey, listBefore);
+    queryClient.setQueryData(
+      workflowRunsKeys.detail(LOCAL_TENANT, workflowId),
+      detailBefore,
+    );
+    queryClient.setQueryData(
+      workflowRunsKeys.detail(OTHER_TENANT, workflowId),
+      detailBefore,
+    );
+    queryClient.setQueryData(dashboardKeys.summary(LOCAL_TENANT), dashboardBefore);
+
+    const event = createWorkflowCanceled(LOCAL_TENANT, {
+      workflowId,
+      workflowType: "ApplyWorkflow",
+      status: "canceled",
+      errorCode: "",
+      errorMessage: "",
+      finishedAt: NOW,
+      durationMs: 7_000,
+      temporalRunId: "temporal-apply-run-1",
+    });
+    invalidationRouter.handle(event, queryClient);
+
+    expect(queryClient.getQueryData(listKey)).toBe(listBefore);
+    expect(queryClient.getQueryState(listKey)?.isInvalidated).toBe(true);
+    expect(
+      queryClient.getQueryData<ReturnType<typeof makeWorkflowRunDetail>>(
+        workflowRunsKeys.detail(LOCAL_TENANT, workflowId),
+      )?.status,
+    ).toBe("canceled");
+    expect(
+      queryClient.getQueryData<ReturnType<typeof makeWorkflowRunDetail>>(
+        workflowRunsKeys.detail(OTHER_TENANT, workflowId),
+      )?.status,
+    ).toBe("in_progress");
+    expect(queryClient.getQueryData(dashboardKeys.summary(LOCAL_TENANT))).toBe(
+      dashboardBefore,
+    );
+    expect(
+      queryClient.getQueryState(dashboardKeys.summary(LOCAL_TENANT))?.isInvalidated,
+    ).toBe(true);
+  });
+});

--- a/apps/web/src/contexts/pipeline/handlers.ts
+++ b/apps/web/src/contexts/pipeline/handlers.ts
@@ -28,8 +28,13 @@ import { artifactsKeys } from "../operations/artifactsKeys.js";
 import { applyReviewKeys } from "../operations/applyReviewKeys.js";
 import { dashboardKeys } from "../operations/dashboardKeys.js";
 import { digestKeys } from "../operations/digestKeys.js";
-import { invalidate, type InvalidationItem } from "../operations/invalidation-router.js";
+import {
+  invalidate,
+  patchQuery,
+  type InvalidationItem,
+} from "../operations/invalidation-router.js";
 import { jobsKeys } from "../operations/jobsKeys.js";
+import { patchWorkflowRunDetail } from "../operations/realtimePatches.js";
 import { workflowRunsKeys } from "../operations/workflowRunsKeys.js";
 import { pipelineKeys } from "./queryKeys.js";
 
@@ -168,8 +173,16 @@ type WorkflowLifecycleEvent =
 const workflowLifecycleHandler = (
   event: WorkflowLifecycleEvent,
 ): readonly InvalidationItem[] => [
+  // Lifecycle payloads own status/timing/error fields for an existing run.
+  // Lists can cross status filters and dashboard rows may be absent, so both
+  // families retain tenant-bounded invalidation after the immediate patch.
+  patchQuery(
+    workflowRunsKeys.detail(event.tenantId, event.payload.workflowId),
+    (current) => patchWorkflowRunDetail(current, event),
+  ),
   invalidate(workflowRunsKeys.lists(event.tenantId)),
   invalidate(workflowRunsKeys.detail(event.tenantId, event.payload.workflowId)),
+  invalidate(dashboardKeys.summary(event.tenantId)),
   pipelineOperationsInvalidation(event.tenantId),
 ];
 
@@ -181,7 +194,6 @@ export const workflowCanceledHandler = (
 ): readonly InvalidationItem[] => [
   ...workflowLifecycleHandler(event),
   invalidate(applyReviewKeys.queue(event.tenantId)),
-  invalidate(dashboardKeys.summary(event.tenantId)),
 ];
 export const workflowTimedOutHandler = workflowLifecycleHandler;
 export const workflowTerminatedHandler = workflowLifecycleHandler;


### PR DESCRIPTION
## Summary

- patch matching open workflow-run details from lifecycle SSE events
- preserve first-terminal-wins and reject missing or superseded Temporal execution identity
- append replay-safe inspectable timeline entries without synthesizing run rows
- preserve filtered workflow lists and use bounded dashboard invalidation when identity is insufficient

## Why

Workflow lifecycle events carry enough data to update an already-cached run detail only when the current and incoming Temporal execution identities are known and match. Workflow lists can cross status filters, and dashboard apply-run rows do not carry `temporalRunId`, so those surfaces must reconcile through tenant-bounded invalidation instead of a speculative patch.

## Validation

- `git diff --check`
- web TypeScript check
- focused workflow realtime, SSE/provider, and exhaustive invalidation-router suites: 212/212 passed
- independent review: PASS, 0 Blocker / 0 High / 0 Medium / 0 Low
- independent QA: PASS, 0 Blocker / 0 High / 0 Medium / 0 Low

Browser rendering remains deferred to the final Objective 5 UI-state regression child. This is a ready child PR in stack #660 and does not rewrite any prior branch.
