### PR TITLE
fix(sse): separate transport and domain timestamps

### DIFF
--- a/apps/api/src/event-stream.ts
+++ b/apps/api/src/event-stream.ts
@@ -285,18 +285,18 @@ function writeEventRow(reply: FastifyReply, row: EventRow): void {
   if (eventType.length === 0) {
     return;
   }
-  const payload = canonicalSsePayload(row);
-  if (payload === null) {
+  const envelope = canonicalSseEnvelope(row);
+  if (envelope === null) {
     return;
   }
-  const dataLine = formatDataField(JSON.stringify(payload));
+  const dataLine = formatDataField(JSON.stringify(envelope));
   writeRaw(
     reply,
     `id: ${row.event_id}\nevent: ${eventType}\n${dataLine}\n\n`,
   );
 }
 
-function canonicalSsePayload(row: EventRow): Record<string, unknown> | null {
+function canonicalSseEnvelope(row: EventRow): Record<string, unknown> | null {
   let payload: unknown;
   try {
     payload = JSON.parse(row.payload_json ?? "{}");
@@ -310,6 +310,9 @@ function canonicalSsePayload(row: EventRow): Record<string, unknown> | null {
   if (legacyJobAliases.some((key) => Object.hasOwn(payload, key))) {
     return null;
   }
+  if (Object.hasOwn(payload, "occurred_at")) {
+    return null;
+  }
   if (payload.tenantId !== undefined && payload.tenantId !== row.tenant_id) {
     return null;
   }
@@ -317,12 +320,21 @@ function canonicalSsePayload(row: EventRow): Record<string, unknown> | null {
     if (Object.hasOwn(payload, "jobId")) {
       return null;
     }
-    return { ...payload, tenantId: row.tenant_id };
+    return {
+      tenantId: row.tenant_id,
+      occurredAt: row.occurred_at,
+      payload: { ...payload, tenantId: row.tenant_id },
+    };
   }
   if (payload.jobId !== undefined && payload.jobId !== row.job_id) {
     return null;
   }
-  return { ...payload, tenantId: row.tenant_id, jobId: row.job_id };
+  return {
+    tenantId: row.tenant_id,
+    jobId: row.job_id,
+    occurredAt: row.occurred_at,
+    payload: { ...payload, tenantId: row.tenant_id, jobId: row.job_id },
+  };
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/apps/api/test/server.test.ts
+++ b/apps/api/test/server.test.ts
@@ -668,6 +668,35 @@ describe("local TypeScript API", () => {
       occurredAt,
       JSON.stringify({ tenantId: "local", jobKey: jobUrl }),
     );
+    insertEvent.run(
+      "local",
+      jobId,
+      "score",
+      "StageReset",
+      occurredAt,
+      JSON.stringify({
+        tenantId: "local",
+        occurred_at: "2026-04-29T10:29:00+00:00",
+        postingUrl: "https://example.com/jobs/legacy-timestamp",
+      }),
+    );
+    const outcomeOccurredAt = "2026-04-01T09:00:00+00:00";
+    insertEvent.run(
+      "local",
+      jobId,
+      "apply",
+      "ApplicationOutcomeRecorded",
+      occurredAt,
+      JSON.stringify({
+        tenantId: "local",
+        jobId,
+        outcomeId: "outcome-historical",
+        kind: "interview",
+        source: "manual",
+        occurredAt: outcomeOccurredAt,
+        notePresent: false,
+      }),
+    );
     const canonical = insertEvent.run(
       "local",
       jobId,
@@ -698,8 +727,13 @@ describe("local TypeScript API", () => {
     expect(streamed).toContain(`\"tenantId\":\"local\"`);
     expect(streamed).toContain(`\"jobId\":\"${jobId}\"`);
     expect(streamed).toContain(`\"postingUrl\":\"${jobUrl}\"`);
+    expect(streamed).toContain(`\"occurredAt\":\"${occurredAt}\"`);
+    expect(streamed).toContain("event: ApplicationOutcomeRecorded");
+    expect(streamed).toContain("outcome-historical");
+    expect(streamed).toContain(`\"occurredAt\":\"${outcomeOccurredAt}\"`);
     expect(streamed).not.toContain("event: ProfileUpdated");
     expect(streamed).not.toContain("\"jobKey\"");
+    expect(streamed).not.toContain("legacy-timestamp");
     await reader.cancel();
     db.close();
     await app.close();

--- a/apps/web/src/contexts/operations/sse-integration.test.ts
+++ b/apps/web/src/contexts/operations/sse-integration.test.ts
@@ -47,7 +47,15 @@ describe("SSE integration (frames → parser → invalidation router) — full p
     it(`parses an SSE frame for ${eventType} and routes it through the invalidation router`, () => {
       const event = eventByType[eventType];
       const wire = buildFrameText([
-        { id: "42", event: eventType, data: JSON.stringify(event.payload) },
+        {
+          id: "42",
+          event: eventType,
+          data: JSON.stringify({
+            tenantId: event.tenantId,
+            occurredAt: event.occurredAt,
+            payload: event.payload,
+          }),
+        },
       ]);
       const [frame] = parseSse(wire);
       expect(frame, `expected one parsed frame for ${eventType}`).toBeDefined();
@@ -58,6 +66,7 @@ describe("SSE integration (frames → parser → invalidation router) — full p
         return;
       }
       expect(result.envelope.eventType).toBe(eventType);
+      expect(result.envelope.occurredAt).toBe(event.occurredAt);
 
       const queryClient = new QueryClient();
       if (eventType === "ApplyRunEventRecorded") {
@@ -73,7 +82,7 @@ describe("SSE integration (frames → parser → invalidation router) — full p
           {
             eventType,
             tenantId: result.envelope.tenantId,
-            occurredAt: event.occurredAt,
+            occurredAt: result.envelope.occurredAt,
             payload: result.envelope.payload,
           } as never,
           queryClient,

--- a/apps/web/src/shared/adapters/local/SseEventStreamAdapter.test.ts
+++ b/apps/web/src/shared/adapters/local/SseEventStreamAdapter.test.ts
@@ -106,12 +106,13 @@ describe("SseEventStreamAdapter", () => {
     expect(streamUrl.searchParams.get("tenantId")).toBe(tenantId);
 
     const payload = { tenantId, jobId: "job-1", fitScore: 91 };
-    source.emit("JobScored", JSON.stringify(payload));
+    source.emit("JobScored", encodeEnvelope(payload));
 
     expect(handler).toHaveBeenCalledOnce();
     expect(handler).toHaveBeenCalledWith({
       eventType: "JobScored",
       tenantId,
+      occurredAt: null,
       payload,
     });
   });
@@ -135,7 +136,7 @@ describe("SseEventStreamAdapter", () => {
       expect(handler).not.toHaveBeenCalled();
 
       const payload = { tenantId: LOCAL_TENANT, jobId: "job-1" };
-      source.emit("JobScored", JSON.stringify(payload));
+      source.emit("JobScored", encodeEnvelope(payload));
       expect(handler).toHaveBeenCalledOnce();
     },
   );
@@ -153,12 +154,12 @@ describe("SseEventStreamAdapter", () => {
 
     expect(source.listenerCount("JobScored")).toBe(1);
     offRemovedEvent();
-    source.emit("JobScored", JSON.stringify({ jobId: "job-1" }));
+    source.emit("JobScored", encodeEnvelope({ jobId: "job-1" }));
     expect(removedEventHandler).not.toHaveBeenCalled();
     expect(activeEventHandler).toHaveBeenCalledOnce();
 
     offActiveEvent();
-    source.emit("JobScored", JSON.stringify({ jobId: "job-2" }));
+    source.emit("JobScored", encodeEnvelope({ jobId: "job-2" }));
     expect(activeEventHandler).toHaveBeenCalledOnce();
     expect(source.listenerCount("JobScored")).toBe(1);
 
@@ -197,7 +198,7 @@ describe("SseEventStreamAdapter", () => {
     expect(FakeEventSource.instances).toHaveLength(1);
     expect(source.listenerCount("JobScored")).toBe(1);
 
-    source.emit("JobScored", JSON.stringify({ jobId: "job-1" }));
+    source.emit("JobScored", encodeEnvelope({ jobId: "job-1" }));
     expect(handler).toHaveBeenCalledOnce();
     expect(statuses.mock.calls.map(([status]) => status)).toEqual([
       "open",
@@ -246,7 +247,7 @@ describe("SseEventStreamAdapter", () => {
     expect(subscription.status).toBe("closed");
     expect(adapter.status).toBe("closed");
 
-    source.emit("JobScored", JSON.stringify({ jobId: "job-1" }));
+    source.emit("JobScored", encodeEnvelope({ jobId: "job-1" }));
     source.emit("heartbeat");
     source.emit("open");
     expect(eventHandler).not.toHaveBeenCalled();
@@ -269,3 +270,10 @@ describe("SseEventStreamAdapter", () => {
     expect(() => subscription.close()).not.toThrow();
   });
 });
+
+function encodeEnvelope(payload: Record<string, unknown>): string {
+  const tenantId = typeof payload["tenantId"] === "string"
+    ? payload["tenantId"]
+    : LOCAL_TENANT;
+  return JSON.stringify({ tenantId, occurredAt: null, payload });
+}

--- a/apps/web/src/shared/ports/EventStreamPort.ts
+++ b/apps/web/src/shared/ports/EventStreamPort.ts
@@ -5,6 +5,7 @@ export type EventStreamStatus = "connecting" | "open" | "closed";
 export interface DomainEventEnvelope {
   readonly eventType: string;
   readonly tenantId: TenantId;
+  readonly occurredAt?: string | null;
   readonly payload: unknown;
 }
 

--- a/apps/web/src/shared/ports/lib/parseDomainEvent.test.ts
+++ b/apps/web/src/shared/ports/lib/parseDomainEvent.test.ts
@@ -8,7 +8,7 @@ describe("parseDomainEvent", () => {
   for (const eventType of DOMAIN_EVENT_TYPES) {
     it(`round-trips JSON → parsed → envelope for ${eventType}`, () => {
       const event = eventByType[eventType];
-      const data = JSON.stringify(event.payload);
+      const data = encodeEnvelope(event.payload);
       const result = parseDomainEvent({ eventType, data });
       expect(result.ok).toBe(true);
       if (result.ok) {
@@ -21,7 +21,10 @@ describe("parseDomainEvent", () => {
   it("uses the explicit tenantId from the payload when present", () => {
     const result = parseDomainEvent({
       eventType: "JobScored",
-      data: JSON.stringify({ tenantId: "alice", jobId: "job-1" }),
+      data: encodeEnvelope(
+        { tenantId: "alice", jobId: "job-1" },
+        { tenantId: "alice" },
+      ),
     });
     expect(result.ok).toBe(true);
     if (result.ok) {
@@ -29,10 +32,32 @@ describe("parseDomainEvent", () => {
     }
   });
 
+  it("separates the authoritative event timestamp from the domain timestamp", () => {
+    const eventOccurredAt = "2026-08-01T15:30:00Z";
+    const outcomeOccurredAt = "2026-07-01T09:00:00Z";
+    const result = parseDomainEvent({
+      eventType: "ApplicationOutcomeRecorded",
+      data: encodeEnvelope(
+        {
+          tenantId: "local",
+          jobId: "job-1",
+          outcomeId: "outcome-1",
+          occurredAt: outcomeOccurredAt,
+        },
+        { occurredAt: eventOccurredAt },
+      ),
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.envelope.occurredAt).toBe(eventOccurredAt);
+      expect(result.envelope.payload).toMatchObject({ occurredAt: outcomeOccurredAt });
+    }
+  });
+
   it("falls back to LOCAL_TENANT when the payload omits tenantId", () => {
     const result = parseDomainEvent({
       eventType: "JobScored",
-      data: JSON.stringify({ jobId: "job-1" }),
+      data: JSON.stringify({ occurredAt: null, payload: { jobId: "job-1" } }),
     });
     expect(result.ok).toBe(true);
     if (result.ok) {
@@ -41,7 +66,7 @@ describe("parseDomainEvent", () => {
   });
 
   it("rejects unknown event types", () => {
-    const result = parseDomainEvent({ eventType: "MysteryEvent", data: "{}" });
+    const result = parseDomainEvent({ eventType: "MysteryEvent", data: encodeEnvelope({}) });
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.reason).toBe("unknown-event-type");
@@ -71,4 +96,30 @@ describe("parseDomainEvent", () => {
       expect(result.reason).toBe("non-object-payload");
     }
   });
+
+  it("rejects the legacy flat payload shape", () => {
+    const result = parseDomainEvent({
+      eventType: "JobScored",
+      data: JSON.stringify({ tenantId: "local", jobId: "job-1" }),
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe("non-object-payload");
+    }
+  });
 });
+
+function encodeEnvelope(
+  payload: object,
+  metadata: { tenantId?: string | undefined; occurredAt?: string | null } = {},
+): string {
+  const payloadRecord = payload as Record<string, unknown>;
+  const tenantId = metadata.tenantId === undefined
+    ? (typeof payloadRecord["tenantId"] === "string" ? payloadRecord["tenantId"] : LOCAL_TENANT)
+    : metadata.tenantId;
+  return JSON.stringify({
+    ...(tenantId === undefined ? {} : { tenantId }),
+    occurredAt: metadata.occurredAt ?? null,
+    payload,
+  });
+}

--- a/apps/web/src/shared/ports/lib/parseDomainEvent.ts
+++ b/apps/web/src/shared/ports/lib/parseDomainEvent.ts
@@ -35,12 +35,17 @@ export function parseDomainEvent(frame: ParsedFrame): ParseDomainEventResult {
   if (!isRecord(parsed)) {
     return { ok: false, reason: "non-object-payload", eventType: frame.eventType };
   }
+  const payload = parsed["payload"];
+  if (!isRecord(payload)) {
+    return { ok: false, reason: "non-object-payload", eventType: frame.eventType };
+  }
   return {
     ok: true,
     envelope: {
       eventType: frame.eventType,
       tenantId: readTenantId(parsed),
-      payload: parsed,
+      occurredAt: readOccurredAt(parsed),
+      payload,
     },
   };
 }
@@ -54,4 +59,9 @@ function readTenantId(payload: Record<string, unknown>): TenantId {
   return typeof candidate === "string" && candidate.length > 0
     ? (candidate as TenantId)
     : LOCAL_TENANT;
+}
+
+function readOccurredAt(payload: Record<string, unknown>): string | null {
+  const candidate = payload["occurredAt"];
+  return typeof candidate === "string" && candidate.length > 0 ? candidate : null;
 }


### PR DESCRIPTION
## Summary

- wrap each SSE data frame in a canonical transport envelope whose tenant, JobId, and event timestamp come from persisted event columns
- keep the nested domain payload intact, including business timestamps such as historical application outcome time
- reject legacy identity aliases, snake-case event timestamps, and legacy flat client frames instead of adding compatibility fallbacks
- route the authoritative event-row timestamp through the web event envelope and exhaustive realtime registry

## Why

Realtime workflow timelines need the persisted event timestamp, but domain payloads can legitimately own a different timestamp. Keeping transport metadata outside the domain payload prevents historical application outcomes from being overwritten or silently dropped.

## Validation

- API TypeScript check
- web TypeScript check
- API server suite: 212 passed
- web parser, adapter, provider, and exhaustive SSE router suites: 220 passed
- parser regression after legacy-flat rejection: 107 passed
- independent review: PASS, no findings
- independent QA: PASS, 222 focused realtime checks passed with no findings
- git diff --check

## Stack

- ready child above #670
- canonical API/SSE documentation remains intentionally deferred to the final roadmap PR, when the unreleased stack contract is complete
