### PR TITLE
feat(storage): add tailoring feedback reviews

### DIFF
--- a/apps/api/src/schema-manifest.ts
+++ b/apps/api/src/schema-manifest.ts
@@ -14,9 +14,9 @@ export type SchemaManifest = {
 // a different schema.
 export const EXACT_V7_SCHEMA_MANIFEST: SchemaManifest = {
   version: 7,
-  objectCount: 199,
-  tableCount: 102,
-  fingerprint: "515fbe3685b850638bbf0900fa99f2dc6faf46b2ae480b152a2fb5ff972d68f4",
+  objectCount: 205,
+  tableCount: 103,
+  fingerprint: "265cdabf5e7631e0c51b9a05e53b797d7a0f2c19d37d049e15acb2d141a9509c",
 };
 
 type SqliteMasterRow = [type: string, name: string, tableName: string, sql: string];

--- a/apps/api/test/schema-version-guard.test.ts
+++ b/apps/api/test/schema-version-guard.test.ts
@@ -142,14 +142,14 @@ describe("schema version guard at DB open", () => {
     const pythonManifest = fs.readFileSync(pythonManifestPath, "utf8");
 
     expect(pythonManifest).toContain("version=7,");
-    expect(pythonManifest).toContain("object_count=199,");
-    expect(pythonManifest).toContain("table_count=102,");
+    expect(pythonManifest).toContain("object_count=205,");
+    expect(pythonManifest).toContain("table_count=103,");
     expect(pythonManifest).toContain(`fingerprint=\"${EXACT_V7_SCHEMA_MANIFEST.fingerprint}\",`);
     expect(EXACT_V7_SCHEMA_MANIFEST).toEqual({
       version: SUPPORTED_SCHEMA_VERSION,
-      objectCount: 199,
-      tableCount: 102,
-      fingerprint: "515fbe3685b850638bbf0900fa99f2dc6faf46b2ae480b152a2fb5ff972d68f4",
+      objectCount: 205,
+      tableCount: 103,
+      fingerprint: "265cdabf5e7631e0c51b9a05e53b797d7a0f2c19d37d049e15acb2d141a9509c",
     });
   });
 });

--- a/workers/automation/src/jobctrl/infrastructure/migrations/schema_manifest.py
+++ b/workers/automation/src/jobctrl/infrastructure/migrations/schema_manifest.py
@@ -23,9 +23,9 @@ class SchemaManifest:
 # semantically meaningful and must never normalize to the same fingerprint.
 EXACT_V7_MANIFEST = SchemaManifest(
     version=7,
-    object_count=199,
-    table_count=102,
-    fingerprint="515fbe3685b850638bbf0900fa99f2dc6faf46b2ae480b152a2fb5ff972d68f4",
+    object_count=205,
+    table_count=103,
+    fingerprint="265cdabf5e7631e0c51b9a05e53b797d7a0f2c19d37d049e15acb2d141a9509c",
 )
 
 

--- a/workers/automation/src/jobctrl/infrastructure/migrations/schema_v7.sql
+++ b/workers/automation/src/jobctrl/infrastructure/migrations/schema_v7.sql
@@ -1720,10 +1720,62 @@ CREATE TABLE resume_review_comment_replies (
       FOREIGN KEY (tenant_id, thread_id)
         REFERENCES resume_review_comment_threads(tenant_id, thread_id)
         ON DELETE CASCADE,
-      FOREIGN KEY (tenant_id, draft_revision_id)
+        FOREIGN KEY (tenant_id, draft_revision_id)
         REFERENCES resume_review_draft_revisions(tenant_id, revision_id)
         ON DELETE CASCADE
     );
+CREATE TABLE tailoring_feedback_signal_reviews (
+      tenant_id        TEXT NOT NULL DEFAULT 'local',
+      review_id        TEXT NOT NULL,
+      signal_id        TEXT NOT NULL,
+      revision         INTEGER NOT NULL CHECK(revision > 0),
+      decision         TEXT NOT NULL CHECK(decision IN ('accepted', 'rejected')),
+      signal_kind      TEXT NOT NULL CHECK(signal_kind IN (
+        'style_preference',
+        'factual_correction',
+        'claim_policy_correction',
+        'keyword_strategy',
+        'provenance_dispute'
+      )),
+      rule_key         TEXT,
+      rule_value       TEXT,
+      allowlist_version INTEGER NOT NULL CHECK(allowlist_version > 0),
+      reviewed_at      TEXT NOT NULL,
+      PRIMARY KEY (tenant_id, review_id),
+      UNIQUE (tenant_id, signal_id, revision),
+      CHECK (
+        (decision = 'accepted'
+          AND rule_key IS NOT NULL
+          AND length(rule_key) BETWEEN 1 AND 80
+          AND rule_key NOT GLOB '*[^a-z0-9_]*'
+          AND rule_value IS NOT NULL
+          AND length(rule_value) BETWEEN 1 AND 160
+          AND rule_value NOT GLOB '*[^a-z0-9_]*')
+        OR
+        (decision = 'rejected' AND rule_key IS NULL AND rule_value IS NULL)
+      )
+    );
+CREATE TRIGGER validate_tailoring_feedback_signal_review_source
+BEFORE INSERT ON tailoring_feedback_signal_reviews
+BEGIN
+  SELECT CASE WHEN NOT EXISTS (
+    SELECT 1
+    FROM tailoring_feedback_signals
+    WHERE tenant_id = NEW.tenant_id
+      AND signal_id = NEW.signal_id
+      AND signal_kind = NEW.signal_kind
+  ) THEN RAISE(ABORT, 'tailoring feedback review source mismatch') END;
+END;
+CREATE TRIGGER prevent_tailoring_feedback_signal_review_update
+BEFORE UPDATE ON tailoring_feedback_signal_reviews
+BEGIN
+  SELECT RAISE(ABORT, 'tailoring feedback reviews are append-only');
+END;
+CREATE TRIGGER prevent_tailoring_feedback_signal_review_delete
+BEFORE DELETE ON tailoring_feedback_signal_reviews
+BEGIN
+  SELECT RAISE(ABORT, 'tailoring feedback reviews are append-only');
+END;
 CREATE TABLE tailoring_feedback_signals (
       tenant_id         TEXT NOT NULL DEFAULT 'local',
       signal_id         TEXT NOT NULL,
@@ -2106,6 +2158,10 @@ CREATE INDEX idx_tailoring_feedback_signals_draft
       ON tailoring_feedback_signals(tenant_id, draft_id, created_at DESC);
 CREATE INDEX idx_tailoring_feedback_signals_job
       ON tailoring_feedback_signals(tenant_id, job_id, created_at DESC);
+CREATE INDEX idx_tailoring_feedback_signal_reviews_signal
+      ON tailoring_feedback_signal_reviews(tenant_id, signal_id, revision DESC);
+CREATE INDEX idx_tailoring_feedback_signal_reviews_decision
+      ON tailoring_feedback_signal_reviews(tenant_id, decision, reviewed_at DESC);
 CREATE INDEX idx_workflow_run_projections_tenant_started
         ON workflow_run_projections(tenant_id, started_at DESC, workflow_id DESC)
         ;

--- a/workers/automation/src/jobctrl/infrastructure/migrations/v6_to_v7_plan.py
+++ b/workers/automation/src/jobctrl/infrastructure/migrations/v6_to_v7_plan.py
@@ -234,6 +234,13 @@ def _table_plans() -> dict[str, TablePlan]:
         source_exists=False,
         source_required=False,
     )
+    # Structured tailoring reviews are append-only exact-v7 audit facts. The
+    # v6 source has only raw candidate signals, so no review row is inferred.
+    plans["tailoring_feedback_signal_reviews"] = TablePlan(
+        TableDisposition.DIRECT_COPY,
+        source_exists=False,
+        source_required=False,
+    )
     plans["discovery_run_projections"] = TablePlan(
         TableDisposition.RETIRED,
         target_exists=False,
@@ -524,6 +531,7 @@ _DECLARED_COLUMNS: Final[Mapping[str, frozenset[str]]] = _column_manifest(
         "source_quality_stats": "tenant_id source_id window_start window_end run_count failed_run_count consecutive_failures observed_jobs new_jobs existing_jobs duplicate_jobs active_jobs stale_jobs detail_success_count detail_failure_count active_verification_rate duplicate_rate full_description_success_rate apply_url_success_rate last_run_id last_error_class recommended_state updated_at",
         "source_registry_entries": "tenant_id source_id kind display_name owner priority state policy_id seed_url created_at updated_at",
         "tailoring_feedback_signals": "tenant_id signal_id job_key job_id draft_id draft_revision_id source_kind source_id signal_kind status summary section semantic_id created_at reviewed_at",
+        "tailoring_feedback_signal_reviews": "tenant_id review_id signal_id revision decision signal_kind rule_key rule_value allowlist_version reviewed_at",
         "tailoring_policies": "tenant_id version prompt_version schema_version judge_schema_version prompt_fingerprint config_fingerprint profile_policy_fingerprint custom_prompt_fingerprint generator_settings_json judge_settings_json runtime_settings_json rollback_of_version rollback_reason created_at created_from_event_id",
         "worker_runtime_heartbeats": "worker_id component pid hostname app_dir db_path task_queue started_at last_seen_at max_concurrent_activities activity_executor_max_workers active_activity_count active_activity_counts_json active_activity_details_json active_activity_details_total active_activity_details_truncated activity_duration_summary_json task_queue_observation_json heartbeat_schema_version",
         "workflow_run_projections": "workflow_id tenant_id workflow_type status input_summary_json error_code error_message retryable started_at finished_at duration_ms temporal_run_id events_json",

--- a/workers/automation/tests/test_exact_v7_schema.py
+++ b/workers/automation/tests/test_exact_v7_schema.py
@@ -38,6 +38,7 @@ _CROSS_RUNTIME_DURABLE_TABLES = {
     "resume_review_drafts",
     "resume_review_edit_deltas",
     "tailoring_feedback_signals",
+    "tailoring_feedback_signal_reviews",
     "worker_runtime_heartbeats",
 }
 
@@ -485,6 +486,140 @@ def test_job_score_keywords_exact_schema_contract(tmp_path: Path) -> None:
     )
     assert conn.execute("SELECT COUNT(*) FROM job_score_keywords").fetchone()[0] == 0
     assert conn.execute("PRAGMA foreign_key_check").fetchone() is None
+    close_connection(db_path)
+
+
+def test_tailoring_feedback_reviews_are_structured_append_only_facts(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    conn = init_db(db_path)
+    conn.execute("PRAGMA foreign_keys = ON")
+    job_id = "11111111-1111-4111-8111-111111111112"
+    conn.execute(
+        "INSERT INTO jobs (tenant_id, job_id, url) VALUES (?, ?, ?)",
+        ("local", job_id, "https://jobs.example/feedback-review"),
+    )
+    conn.execute(
+        """
+        INSERT INTO resume_review_drafts (
+            tenant_id, draft_id, job_id, base_generation, created_at, updated_at
+        ) VALUES ('local', 'draft-1', ?, 1, ?, ?)
+        """,
+        (job_id, "2026-08-01T00:00:00Z", "2026-08-01T00:00:00Z"),
+    )
+    conn.execute(
+        """
+        INSERT INTO tailoring_feedback_signals (
+            tenant_id, signal_id, job_id, draft_id, source_kind, source_id,
+            signal_kind, status, summary, created_at
+        ) VALUES (
+            'local', 'signal-1', ?, 'draft-1', 'edit_delta', 'delta-1',
+            'factual_correction', 'candidate', 'private source text', ?
+        )
+        """,
+        (job_id, "2026-08-01T00:01:00Z"),
+    )
+    conn.execute(
+        """
+        INSERT INTO tailoring_feedback_signal_reviews (
+            tenant_id, review_id, signal_id, revision, decision, signal_kind,
+            rule_key, rule_value, allowlist_version, reviewed_at
+        ) VALUES (
+            'local', 'review-1', 'signal-1', 1, 'accepted',
+            'factual_correction', 'fact_handling', 'require_source_match', 1, ?
+        )
+        """,
+        ("2026-08-01T00:02:00Z",),
+    )
+
+    with pytest.raises(sqlite3.IntegrityError):
+        conn.execute(
+            """
+            INSERT INTO tailoring_feedback_signal_reviews (
+                tenant_id, review_id, signal_id, revision, decision, signal_kind,
+                rule_key, rule_value, allowlist_version, reviewed_at
+            ) VALUES (
+                'local', 'review-duplicate', 'signal-1', 1, 'rejected',
+                'factual_correction', NULL, NULL, 1, ?
+            )
+            """,
+            ("2026-08-01T00:03:00Z",),
+        )
+    with pytest.raises(sqlite3.IntegrityError, match="source mismatch"):
+        conn.execute(
+            """
+            INSERT INTO tailoring_feedback_signal_reviews (
+                tenant_id, review_id, signal_id, revision, decision, signal_kind,
+                rule_key, rule_value, allowlist_version, reviewed_at
+            ) VALUES (
+                'local', 'review-kind-mismatch', 'signal-1', 2, 'accepted',
+                'style_preference', 'resume_style', 'concise', 1, ?
+            )
+            """,
+            ("2026-08-01T00:03:00Z",),
+        )
+    for rule_key, rule_value in (
+        (None, None),
+        ("free text", "require_source_match"),
+        ("fact_handling", "free text"),
+    ):
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute(
+                """
+                INSERT INTO tailoring_feedback_signal_reviews (
+                    tenant_id, review_id, signal_id, revision, decision,
+                    signal_kind, rule_key, rule_value, allowlist_version,
+                    reviewed_at
+                ) VALUES (
+                    'local', ?, 'signal-1', ?, 'accepted',
+                    'factual_correction', ?, ?, 1, ?
+                )
+                """,
+                (
+                    f"review-invalid-{rule_key}-{rule_value}",
+                    10 + len(str(rule_key)),
+                    rule_key,
+                    rule_value,
+                    "2026-08-01T00:04:00Z",
+                ),
+            )
+
+    with pytest.raises(sqlite3.IntegrityError, match="append-only"):
+        conn.execute(
+            """
+            UPDATE tailoring_feedback_signal_reviews
+            SET rule_value = 'silently_changed'
+            WHERE tenant_id = 'local' AND review_id = 'review-1'
+            """
+        )
+    with pytest.raises(sqlite3.IntegrityError, match="append-only"):
+        conn.execute(
+            """
+            DELETE FROM tailoring_feedback_signal_reviews
+            WHERE tenant_id = 'local' AND review_id = 'review-1'
+            """
+        )
+
+    conn.execute(
+        "DELETE FROM tailoring_feedback_signals WHERE tenant_id = 'local' AND signal_id = 'signal-1'"
+    )
+    assert [
+        tuple(row)
+        for row in conn.execute(
+            "SELECT decision, rule_key, rule_value FROM tailoring_feedback_signal_reviews"
+        ).fetchall()
+    ] == [("accepted", "fact_handling", "require_source_match")]
+    assert conn.execute("PRAGMA foreign_key_check").fetchone() is None
+
+    indexes = {
+        str(index[1])
+        for index in conn.execute("PRAGMA index_list(tailoring_feedback_signal_reviews)")
+    }
+    assert {
+        "idx_tailoring_feedback_signal_reviews_signal",
+        "idx_tailoring_feedback_signal_reviews_decision",
+    } <= indexes
     close_connection(db_path)
 
 

--- a/workers/automation/tests/test_v6_to_v7_plan.py
+++ b/workers/automation/tests/test_v6_to_v7_plan.py
@@ -158,6 +158,15 @@ def test_identity_locator_and_sequence_roles_are_not_inferred_from_names() -> No
         classify_column("job_score_keywords", "job_id", "target")
         is ColumnRole.JOB_ID
     )
+    assert not table_plan("tailoring_feedback_signal_reviews").source_exists
+    assert (
+        table_plan("tailoring_feedback_signal_reviews").disposition
+        is TableDisposition.DIRECT_COPY
+    )
+    assert (
+        classify_column("tailoring_feedback_signal_reviews", "signal_id", "target")
+        is ColumnRole.PRESERVE
+    )
     assert (
         table_plan("dashboard_projections").disposition
         is TableDisposition.STRUCTURED_REWRITE


### PR DESCRIPTION
## Summary

- add an exact-v7 append-only tailoring feedback review relation without creating another database version
- represent accepted and rejected review decisions as revisioned structured code facts with an explicit allowlist version
- require accepted reviews to carry lowercase allowlisted rule tokens and rejected reviews to carry no proposed rule
- validate the source signal tenant and signal kind at insert time while retaining the privacy-safe review audit after raw source deletion
- declare the new relation as target-only in the stopped-runtime v6-to-v7 population plan so migration never infers acceptance from raw candidate feedback

## Validation

- exact schema, unstamped candidate, population ownership, and packaged schema matrix: 30 passed
- TypeScript schema-version guard: 13 passed
- TypeScript API check: passed
- fixed-environment Ruff on touched Python files: passed
- git diff --check: passed
- independent review: Gate PASS, no findings

## Stack

This is a ready schema-groundwork child above #673. It changes the single exact-v7 release schema in place; it does not add runtime DDL, a schema-version fork, a review API, recommendation derivation, or policy behavior. The next child adds the explicit allowlisted review operation and the accepted Materials signal adapter.
