### PR TITLE
feat(api): review tailoring feedback signals

### DIFF
--- a/apps/api/src/resume-review-drafts.ts
+++ b/apps/api/src/resume-review-drafts.ts
@@ -27,7 +27,14 @@ import type {
   ResumeReviewEditKind,
   TailoringFeedbackSignal,
   TailoringFeedbackSignalKind,
+  TailoringFeedbackSignalReview,
+  TailoringFeedbackSignalReviewRequest,
+  TailoringFeedbackSignalReviewResponse,
   TailoringFeedbackSourceKind,
+} from "./contracts.js";
+import {
+  TAILORING_FEEDBACK_RULE_ALLOWLIST,
+  TAILORING_FEEDBACK_RULE_ALLOWLIST_VERSION,
 } from "./contracts.js";
 import { allRows, getRow, type SqliteDatabase } from "./db.js";
 import { defaultResumeHtmlPdfRenderer, type ResumeHtmlPdfRenderer } from "./resume-pdf-render.js";
@@ -156,6 +163,30 @@ interface TailoringFeedbackSignalRow extends Record<string, unknown> {
   semantic_id: string | null;
   created_at: string;
   reviewed_at: string | null;
+}
+
+interface TailoringFeedbackSignalReviewRow extends Record<string, unknown> {
+  review_id: string;
+  signal_id: string;
+  revision: number;
+  decision: string;
+  signal_kind: string;
+  rule_key: string | null;
+  rule_value: string | null;
+  allowlist_version: number;
+  reviewed_at: string;
+}
+
+interface TailoringFeedbackSignalIdentityRow extends Record<string, unknown> {
+  signal_id: string;
+  signal_kind: string;
+}
+
+export class TailoringFeedbackReviewInputError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "TailoringFeedbackReviewInputError";
+  }
 }
 
 interface MaterialArtifactRow extends Record<string, unknown> {
@@ -596,6 +627,139 @@ export function listResumeReviewFeedback(
     ok: true,
     jobKey: jobId,
     feedbackSignals: feedbackSignalsForJob(db, jobId),
+  };
+}
+
+export function reviewResumeFeedbackSignal(
+  db: SqliteDatabase,
+  signalId: string,
+  request: TailoringFeedbackSignalReviewRequest,
+): TailoringFeedbackSignalReviewResponse {
+  const tx = db.transaction(() => {
+    const signal = getRow<TailoringFeedbackSignalIdentityRow>(
+      db,
+      `SELECT signal_id, signal_kind
+         FROM tailoring_feedback_signals
+        WHERE tenant_id = ? AND signal_id = ?`,
+      [DEFAULT_TENANT, signalId],
+    );
+    if (!signal) {
+      throw new InputError(`Tailoring feedback signal not found: ${signalId}`);
+    }
+
+    const signalKind = feedbackSignalKind(signal.signal_kind);
+    const expectedRule = TAILORING_FEEDBACK_RULE_ALLOWLIST[signalKind];
+    const ruleKey = request.decision === "accepted" ? request.ruleKey : null;
+    const ruleValue = request.decision === "accepted" ? request.ruleValue : null;
+    if (
+      request.decision === "accepted"
+      && (ruleKey !== expectedRule.ruleKey || ruleValue !== expectedRule.ruleValue)
+    ) {
+      throw new TailoringFeedbackReviewInputError(
+        `Rule ${ruleKey}/${ruleValue} is not allowed for ${signalKind}.`,
+      );
+    }
+
+    const latest = getRow<TailoringFeedbackSignalReviewRow>(
+      db,
+      `SELECT review_id, signal_id, revision, decision, signal_kind,
+              rule_key, rule_value, allowlist_version, reviewed_at
+         FROM tailoring_feedback_signal_reviews
+        WHERE tenant_id = ? AND signal_id = ?
+        ORDER BY revision DESC
+        LIMIT 1`,
+      [DEFAULT_TENANT, signalId],
+    );
+    if (
+      latest
+      && latest.decision === request.decision
+      && latest.rule_key === ruleKey
+      && latest.rule_value === ruleValue
+      && latest.allowlist_version === TAILORING_FEEDBACK_RULE_ALLOWLIST_VERSION
+    ) {
+      projectLatestTailoringFeedbackDecision(db, signalId, request.decision, latest.reviewed_at);
+      return { ok: true as const, review: tailoringFeedbackReviewFromRow(latest) };
+    }
+
+    const reviewId = `tailoring_feedback_review_${crypto.randomUUID()}`;
+    const revision = (latest?.revision ?? 0) + 1;
+    const reviewedAt = new Date().toISOString();
+    db.prepare(
+      `INSERT INTO tailoring_feedback_signal_reviews (
+         tenant_id, review_id, signal_id, revision, decision, signal_kind,
+         rule_key, rule_value, allowlist_version, reviewed_at
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    ).run(
+      DEFAULT_TENANT,
+      reviewId,
+      signalId,
+      revision,
+      request.decision,
+      signalKind,
+      ruleKey,
+      ruleValue,
+      TAILORING_FEEDBACK_RULE_ALLOWLIST_VERSION,
+      reviewedAt,
+    );
+    projectLatestTailoringFeedbackDecision(db, signalId, request.decision, reviewedAt);
+
+    const review = getRow<TailoringFeedbackSignalReviewRow>(
+      db,
+      `SELECT review_id, signal_id, revision, decision, signal_kind,
+              rule_key, rule_value, allowlist_version, reviewed_at
+         FROM tailoring_feedback_signal_reviews
+        WHERE tenant_id = ? AND review_id = ?`,
+      [DEFAULT_TENANT, reviewId],
+    );
+    if (!review) {
+      throw new Error("Tailoring feedback review was not persisted.");
+    }
+    return { ok: true as const, review: tailoringFeedbackReviewFromRow(review) };
+  });
+  return tx();
+}
+
+function projectLatestTailoringFeedbackDecision(
+  db: SqliteDatabase,
+  signalId: string,
+  decision: "accepted" | "rejected",
+  reviewedAt: string,
+): void {
+  db.prepare(
+    `UPDATE tailoring_feedback_signals
+        SET status = ?, reviewed_at = ?
+      WHERE tenant_id = ? AND signal_id = ?`,
+  ).run(decision, reviewedAt, DEFAULT_TENANT, signalId);
+}
+
+function tailoringFeedbackReviewFromRow(
+  row: TailoringFeedbackSignalReviewRow,
+): TailoringFeedbackSignalReview {
+  const signalKind = feedbackSignalKind(row.signal_kind);
+  const expectedRule = TAILORING_FEEDBACK_RULE_ALLOWLIST[signalKind];
+  const decision = row.decision === "accepted" ? "accepted" : row.decision === "rejected" ? "rejected" : null;
+  if (!decision || row.allowlist_version !== TAILORING_FEEDBACK_RULE_ALLOWLIST_VERSION) {
+    throw new Error("Tailoring feedback review has an unsupported decision or allowlist version.");
+  }
+  if (
+    decision === "accepted"
+    && (row.rule_key !== expectedRule.ruleKey || row.rule_value !== expectedRule.ruleValue)
+  ) {
+    throw new Error("Tailoring feedback review contains a non-allowlisted rule.");
+  }
+  if (decision === "rejected" && (row.rule_key !== null || row.rule_value !== null)) {
+    throw new Error("Rejected tailoring feedback review contains a rule.");
+  }
+  return {
+    reviewId: row.review_id,
+    signalId: row.signal_id,
+    revision: row.revision,
+    decision,
+    signalKind,
+    ruleKey: decision === "accepted" ? expectedRule.ruleKey : null,
+    ruleValue: decision === "accepted" ? expectedRule.ruleValue : null,
+    allowlistVersion: TAILORING_FEEDBACK_RULE_ALLOWLIST_VERSION,
+    reviewedAt: row.reviewed_at,
   };
 }
 

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -74,6 +74,7 @@ import {
   ResumeReviewDraftCreateRequestSchema,
   ResumeReviewDraftRenderRequestSchema,
   ResumeReviewDraftRevisionSaveRequestSchema,
+  TailoringFeedbackSignalReviewRequestSchema,
   RunPipelineStagesRequestSchema,
   SettingsUpdateRequestSchema,
   type ExtensionCapabilityTokenResponse,
@@ -248,10 +249,12 @@ import {
   createOrLoadResumeReviewDraft,
   getResumeReviewDraftForJob,
   listResumeReviewFeedback,
+  reviewResumeFeedbackSignal,
   replyToResumeReviewComment,
   renderResumeReviewDraft,
   saveResumeReviewDraftRevision,
   seedResumeReviewCommentThreads,
+  TailoringFeedbackReviewInputError,
 } from "./resume-review-drafts.js";
 import {
   createResumeTemplateVersion,
@@ -1050,6 +1053,23 @@ export function buildApp(options: BuildAppOptions): FastifyInstance {
       withDb(reply, options.dbPath, (db) =>
         listResumeReviewFeedback(db, decodeRouteParam(request.params.jobKey)),
       ),
+  );
+
+  app.post<{ Params: { signalId: string } }>(
+    "/v1/resume-review/feedback-signals/:signalId/reviews",
+    async (request, reply) => {
+      const body = parseBody(
+        reply,
+        TailoringFeedbackSignalReviewRequestSchema,
+        request.body ?? {},
+      );
+      if (!body) {
+        return undefined;
+      }
+      return withWritableDb(reply, options.dbPath, (db) =>
+        reviewResumeFeedbackSignal(db, decodeRouteParam(request.params.signalId), body),
+      );
+    },
   );
 
   app.post<{ Params: { draftId: string } }>(
@@ -3965,6 +3985,14 @@ async function withWritableDb<T>(
       return {
         ok: false,
         error: "role_match_feedback_decision_conflict",
+        message: error.message,
+      };
+    }
+    if (error instanceof TailoringFeedbackReviewInputError) {
+      void reply.code(400);
+      return {
+        ok: false,
+        error: "invalid_tailoring_feedback_review",
         message: error.message,
       };
     }

--- a/apps/api/test/resume-review-drafts.test.ts
+++ b/apps/api/test/resume-review-drafts.test.ts
@@ -333,6 +333,140 @@ describe("resume review draft API", () => {
     await app.close();
   });
 
+  it("reviews tailoring feedback through the versioned allowlist without exposing source text", async () => {
+    const privateSource = "private source text must never enter the review response";
+    const app = buildApp(options);
+    const createResponse = await app.inject({
+      method: "POST",
+      url: `/v1/jobs/${encodeURIComponent(JOB_KEY)}/resume-review/draft`,
+      payload: {},
+    });
+    const draftId = createResponse.json().draft.draftId as string;
+    const revisionResponse = await app.inject({
+      method: "POST",
+      url: `/v1/resume-review/drafts/${encodeURIComponent(draftId)}/revisions`,
+      payload: {
+        editedText: "Led 4 platform reliability projects.",
+        editDeltas: [
+          {
+            kind: "replace_text",
+            section: "experience",
+            beforeText: `Led 3 projects. ${privateSource}`,
+            afterText: "Led 4 platform reliability projects.",
+          },
+        ],
+      },
+    });
+    expect(revisionResponse.statusCode, revisionResponse.body).toBe(200);
+    const signalId = revisionResponse.json().draft.feedbackSignals[0].signalId as string;
+
+    const invalidResponse = await app.inject({
+      method: "POST",
+      url: `/v1/resume-review/feedback-signals/${encodeURIComponent(signalId)}/reviews`,
+      payload: {
+        decision: "accepted",
+        ruleKey: "style_guidance",
+        ruleValue: "preserve_user_edit_pattern",
+      },
+    });
+    expect(invalidResponse.statusCode, invalidResponse.body).toBe(400);
+    expect(invalidResponse.json()).toMatchObject({
+      ok: false,
+      error: "invalid_tailoring_feedback_review",
+    });
+
+    const acceptedResponse = await app.inject({
+      method: "POST",
+      url: `/v1/resume-review/feedback-signals/${encodeURIComponent(signalId)}/reviews`,
+      payload: {
+        decision: "accepted",
+        ruleKey: "fact_handling",
+        ruleValue: "require_source_match",
+      },
+    });
+    expect(acceptedResponse.statusCode, acceptedResponse.body).toBe(200);
+    expect(acceptedResponse.json().review).toMatchObject({
+      signalId,
+      revision: 1,
+      decision: "accepted",
+      signalKind: "factual_correction",
+      ruleKey: "fact_handling",
+      ruleValue: "require_source_match",
+      allowlistVersion: 1,
+    });
+    expect(Object.keys(acceptedResponse.json().review).sort()).toEqual([
+      "allowlistVersion",
+      "decision",
+      "reviewId",
+      "reviewedAt",
+      "revision",
+      "ruleKey",
+      "ruleValue",
+      "signalId",
+      "signalKind",
+    ]);
+    expect(JSON.stringify(acceptedResponse.json())).not.toContain(privateSource);
+
+    const repeatedResponse = await app.inject({
+      method: "POST",
+      url: `/v1/resume-review/feedback-signals/${encodeURIComponent(signalId)}/reviews`,
+      payload: {
+        decision: "accepted",
+        ruleKey: "fact_handling",
+        ruleValue: "require_source_match",
+      },
+    });
+    expect(repeatedResponse.statusCode, repeatedResponse.body).toBe(200);
+    expect(repeatedResponse.json().review).toEqual(acceptedResponse.json().review);
+
+    const rejectedResponse = await app.inject({
+      method: "POST",
+      url: `/v1/resume-review/feedback-signals/${encodeURIComponent(signalId)}/reviews`,
+      payload: { decision: "rejected" },
+    });
+    expect(rejectedResponse.statusCode, rejectedResponse.body).toBe(200);
+    expect(rejectedResponse.json().review).toMatchObject({
+      signalId,
+      revision: 2,
+      decision: "rejected",
+      ruleKey: null,
+      ruleValue: null,
+    });
+
+    const db = new Database(options.dbPath);
+    try {
+      const reviews = db
+        .prepare(
+          `SELECT revision, decision, rule_key, rule_value
+             FROM tailoring_feedback_signal_reviews
+            WHERE tenant_id = 'local' AND signal_id = ?
+            ORDER BY revision`,
+        )
+        .all(signalId);
+      expect(reviews).toEqual([
+        {
+          revision: 1,
+          decision: "accepted",
+          rule_key: "fact_handling",
+          rule_value: "require_source_match",
+        },
+        { revision: 2, decision: "rejected", rule_key: null, rule_value: null },
+      ]);
+      expect(
+        db
+          .prepare(
+            `SELECT status FROM tailoring_feedback_signals
+              WHERE tenant_id = 'local' AND signal_id = ?`,
+          )
+          .get(signalId),
+      ).toEqual({ status: "rejected" });
+    } finally {
+      db.close();
+    }
+
+    await app.close();
+  });
+
   it("persists comment replies as safe feedback without changing approved artifacts", async () => {
     const app = buildApp(options);
     const createResponse = await app.inject({

--- a/packages/api-client/src/client.ts
+++ b/packages/api-client/src/client.ts
@@ -133,6 +133,8 @@ import type {
   ResumeReviewDraftRevisionResponse,
   ResumeReviewDraftRevisionSaveRequest,
   ResumeReviewFeedbackListResponse,
+  TailoringFeedbackSignalReviewRequest,
+  TailoringFeedbackSignalReviewResponse,
   TailorJobRequest,
   RetryStageRequest,
   RunJobStageRequest,
@@ -508,6 +510,16 @@ export class JobCtrlApiClient {
   ): Promise<ResumeReviewFeedbackListResponse> {
     return this.get(
       `/v1/jobs/${encodeURIComponent(jobKey)}/resume-review/feedback`,
+    );
+  }
+
+  reviewResumeFeedbackSignal(
+    signalId: string,
+    body: TailoringFeedbackSignalReviewRequest,
+  ): Promise<TailoringFeedbackSignalReviewResponse> {
+    return this.post(
+      `/v1/resume-review/feedback-signals/${encodeURIComponent(signalId)}/reviews`,
+      body,
     );
   }
 

--- a/packages/contracts/src/schemas.ts
+++ b/packages/contracts/src/schemas.ts
@@ -1005,6 +1005,50 @@ export const TAILORING_FEEDBACK_SIGNAL_KINDS = [
 ] as const;
 export type TailoringFeedbackSignalKind = (typeof TAILORING_FEEDBACK_SIGNAL_KINDS)[number];
 
+export const TAILORING_FEEDBACK_RULE_ALLOWLIST_VERSION = 1 as const;
+export const TAILORING_FEEDBACK_RULE_KEYS = [
+  "style_guidance",
+  "fact_handling",
+  "claim_policy",
+  "keyword_strategy",
+  "provenance_policy",
+] as const;
+export type TailoringFeedbackRuleKey = (typeof TAILORING_FEEDBACK_RULE_KEYS)[number];
+export const TAILORING_FEEDBACK_RULE_VALUES = [
+  "preserve_user_edit_pattern",
+  "require_source_match",
+  "omit_unsupported_claims",
+  "use_supported_terms_only",
+  "require_direct_evidence",
+] as const;
+export type TailoringFeedbackRuleValue = (typeof TAILORING_FEEDBACK_RULE_VALUES)[number];
+
+export const TAILORING_FEEDBACK_RULE_ALLOWLIST = {
+  style_preference: {
+    ruleKey: "style_guidance",
+    ruleValue: "preserve_user_edit_pattern",
+  },
+  factual_correction: {
+    ruleKey: "fact_handling",
+    ruleValue: "require_source_match",
+  },
+  claim_policy_correction: {
+    ruleKey: "claim_policy",
+    ruleValue: "omit_unsupported_claims",
+  },
+  keyword_strategy: {
+    ruleKey: "keyword_strategy",
+    ruleValue: "use_supported_terms_only",
+  },
+  provenance_dispute: {
+    ruleKey: "provenance_policy",
+    ruleValue: "require_direct_evidence",
+  },
+} as const satisfies Record<
+  TailoringFeedbackSignalKind,
+  { readonly ruleKey: TailoringFeedbackRuleKey; readonly ruleValue: TailoringFeedbackRuleValue }
+>;
+
 export const TAILORING_FEEDBACK_SIGNAL_STATUSES = [
   "candidate",
   "accepted",
@@ -1086,6 +1130,20 @@ export interface TailoringFeedbackSignal {
   semanticId: string | null;
   createdAt: string;
   reviewedAt: string | null;
+}
+
+export type TailoringFeedbackReviewDecision = "accepted" | "rejected";
+
+export interface TailoringFeedbackSignalReview {
+  reviewId: string;
+  signalId: string;
+  revision: number;
+  decision: TailoringFeedbackReviewDecision;
+  signalKind: TailoringFeedbackSignalKind;
+  ruleKey: TailoringFeedbackRuleKey | null;
+  ruleValue: TailoringFeedbackRuleValue | null;
+  allowlistVersion: typeof TAILORING_FEEDBACK_RULE_ALLOWLIST_VERSION;
+  reviewedAt: string;
 }
 
 export interface ResumeReviewDraft {
@@ -1256,6 +1314,25 @@ export interface ResumeReviewFeedbackListResponse {
   ok: true;
   jobKey: string;
   feedbackSignals: TailoringFeedbackSignal[];
+}
+
+export const TailoringFeedbackSignalReviewRequestSchema = z.discriminatedUnion("decision", [
+  z
+    .object({
+      decision: z.literal("accepted"),
+      ruleKey: z.enum(TAILORING_FEEDBACK_RULE_KEYS),
+      ruleValue: z.enum(TAILORING_FEEDBACK_RULE_VALUES),
+    })
+    .strict(),
+  z.object({ decision: z.literal("rejected") }).strict(),
+]);
+export type TailoringFeedbackSignalReviewRequest = z.infer<
+  typeof TailoringFeedbackSignalReviewRequestSchema
+>;
+
+export interface TailoringFeedbackSignalReviewResponse {
+  ok: true;
+  review: TailoringFeedbackSignalReview;
 }
 
 export const APPLICATION_OUTCOME_KINDS = [

--- a/workers/automation/src/jobctrl/domain/operations/__init__.py
+++ b/workers/automation/src/jobctrl/domain/operations/__init__.py
@@ -35,6 +35,12 @@ from jobctrl.domain.operations.feedback import (
     RoleMatchApprovalFeedbackSignal,
     ScoreCorrectionDirection,
     ScoreCorrectionFeedbackSignal,
+    TAILORING_FEEDBACK_RULE_ALLOWLIST,
+    TAILORING_FEEDBACK_RULE_ALLOWLIST_VERSION,
+    TailoringFeedbackRuleKey,
+    TailoringFeedbackRuleValue,
+    TailoringFeedbackSignal,
+    TailoringFeedbackSignalKind,
 )
 
 __all__ = [
@@ -55,5 +61,11 @@ __all__ = [
     "RoleMatchApprovalFeedbackSignal",
     "ScoreCorrectionDirection",
     "ScoreCorrectionFeedbackSignal",
+    "TAILORING_FEEDBACK_RULE_ALLOWLIST",
+    "TAILORING_FEEDBACK_RULE_ALLOWLIST_VERSION",
     "StageProjection",
+    "TailoringFeedbackRuleKey",
+    "TailoringFeedbackRuleValue",
+    "TailoringFeedbackSignal",
+    "TailoringFeedbackSignalKind",
 ]

--- a/workers/automation/src/jobctrl/domain/operations/feedback.py
+++ b/workers/automation/src/jobctrl/domain/operations/feedback.py
@@ -8,7 +8,8 @@ policy or copy private rationale, notes, job text, or model output.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Literal, TypeAlias
+from types import MappingProxyType
+from typing import Literal, Mapping, TypeAlias
 
 from jobctrl.domain.identifiers import JobId
 from jobctrl.domain.tenant import TenantId
@@ -27,6 +28,39 @@ DiscoveryFeedbackKind: TypeAlias = Literal[
     "irrelevant",
 ]
 ScoreCorrectionDirection: TypeAlias = Literal["increase", "decrease", "unchanged"]
+TailoringFeedbackSignalKind: TypeAlias = Literal[
+    "style_preference",
+    "factual_correction",
+    "claim_policy_correction",
+    "keyword_strategy",
+    "provenance_dispute",
+]
+TailoringFeedbackRuleKey: TypeAlias = Literal[
+    "style_guidance",
+    "fact_handling",
+    "claim_policy",
+    "keyword_strategy",
+    "provenance_policy",
+]
+TailoringFeedbackRuleValue: TypeAlias = Literal[
+    "preserve_user_edit_pattern",
+    "require_source_match",
+    "omit_unsupported_claims",
+    "use_supported_terms_only",
+    "require_direct_evidence",
+]
+
+TAILORING_FEEDBACK_RULE_ALLOWLIST_VERSION = 1
+TAILORING_FEEDBACK_RULE_ALLOWLIST: Mapping[
+    TailoringFeedbackSignalKind,
+    tuple[TailoringFeedbackRuleKey, TailoringFeedbackRuleValue],
+] = MappingProxyType({
+    "style_preference": ("style_guidance", "preserve_user_edit_pattern"),
+    "factual_correction": ("fact_handling", "require_source_match"),
+    "claim_policy_correction": ("claim_policy", "omit_unsupported_claims"),
+    "keyword_strategy": ("keyword_strategy", "use_supported_terms_only"),
+    "provenance_dispute": ("provenance_policy", "require_direct_evidence"),
+})
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -141,10 +175,54 @@ class RoleMatchApprovalFeedbackSignal:
         for source_id in self.source_ids:
             _require_nonempty("source_id", source_id)
 
+
+@dataclass(frozen=True, kw_only=True)
+class TailoringFeedbackSignal:
+    """One explicitly accepted tailoring rule without its private source text."""
+
+    signal_id: str
+    tenant_id: TenantId
+    job_id: JobId
+    source_id: str
+    source_revision: int
+    recorded_at: str
+    signal_kind: TailoringFeedbackSignalKind
+    rule_key: TailoringFeedbackRuleKey
+    rule_value: TailoringFeedbackRuleValue
+    allowlist_version: int
+    context: Literal["materials"] = field(default="materials", init=False)
+    kind: Literal["tailoring_feedback"] = field(
+        default="tailoring_feedback", init=False
+    )
+    source_kind: Literal["tailoring_feedback_signal"] = field(
+        default="tailoring_feedback_signal", init=False
+    )
+    source_action: Literal["accepted"] = field(default="accepted", init=False)
+
+    def __post_init__(self) -> None:
+        _require_nonempty("signal_id", self.signal_id)
+        _require_nonempty("source_id", self.source_id)
+        _require_nonempty("recorded_at", self.recorded_at)
+        if self.source_revision < 1:
+            raise ValueError("source_revision must be positive")
+        if self.allowlist_version != TAILORING_FEEDBACK_RULE_ALLOWLIST_VERSION:
+            raise ValueError("unsupported tailoring feedback rule allowlist version")
+        if TAILORING_FEEDBACK_RULE_ALLOWLIST[self.signal_kind] != (
+            self.rule_key,
+            self.rule_value,
+        ):
+            raise ValueError("tailoring feedback rule is not allowlisted for its kind")
+
+    @property
+    def job_ids(self) -> tuple[JobId, ...]:
+        return (self.job_id,)
+
+
 FeedbackSignal: TypeAlias = (
     ScoreCorrectionFeedbackSignal
     | DiscoveryFeedbackSignal
     | RoleMatchApprovalFeedbackSignal
+    | TailoringFeedbackSignal
 )
 
 
@@ -160,4 +238,10 @@ __all__ = [
     "RoleMatchApprovalFeedbackSignal",
     "ScoreCorrectionDirection",
     "ScoreCorrectionFeedbackSignal",
+    "TAILORING_FEEDBACK_RULE_ALLOWLIST",
+    "TAILORING_FEEDBACK_RULE_ALLOWLIST_VERSION",
+    "TailoringFeedbackRuleKey",
+    "TailoringFeedbackRuleValue",
+    "TailoringFeedbackSignal",
+    "TailoringFeedbackSignalKind",
 ]

--- a/workers/automation/src/jobctrl/infrastructure/projections/sqlite_feedback_signals.py
+++ b/workers/automation/src/jobctrl/infrastructure/projections/sqlite_feedback_signals.py
@@ -13,6 +13,11 @@ from jobctrl.domain.operations.feedback import (
     FeedbackSignal,
     RoleMatchApprovalFeedbackSignal,
     ScoreCorrectionFeedbackSignal,
+    TAILORING_FEEDBACK_RULE_ALLOWLIST_VERSION,
+    TailoringFeedbackRuleKey,
+    TailoringFeedbackRuleValue,
+    TailoringFeedbackSignal,
+    TailoringFeedbackSignalKind,
 )
 from jobctrl.domain.tenant import TenantId
 
@@ -44,6 +49,7 @@ class SqliteFeedbackSignalReader:
         signals.extend(self._score_corrections(tenant_id))
         signals.extend(self._discovery_feedback(tenant_id))
         signals.extend(self._approved_role_matches(tenant_id))
+        signals.extend(self._accepted_tailoring_feedback(tenant_id))
         return tuple(sorted(signals, key=lambda signal: (signal.recorded_at, signal.signal_id)))
 
     def _score_corrections(
@@ -215,6 +221,76 @@ class SqliteFeedbackSignalReader:
             if source_id and source_id not in grouped[suggestion_id]:
                 grouped[suggestion_id].append(source_id)
         return {key: tuple(values) for key, values in grouped.items()}
+
+    def _accepted_tailoring_feedback(self, tenant_id: TenantId) -> tuple[TailoringFeedbackSignal, ...]:
+        rows = self._conn.execute(
+            """
+            WITH latest_reviews AS (
+                SELECT review.signal_id, review.revision, review.decision,
+                       review.signal_kind, review.rule_key, review.rule_value,
+                       review.allowlist_version, review.reviewed_at,
+                       ROW_NUMBER() OVER (
+                           PARTITION BY review.tenant_id, review.signal_id
+                           ORDER BY review.revision DESC
+                       ) AS latest_rank
+                FROM tailoring_feedback_signal_reviews AS review
+                WHERE review.tenant_id = ?
+            )
+            SELECT source.signal_id, source.job_id, review.revision,
+                   review.signal_kind, review.rule_key, review.rule_value,
+                   review.allowlist_version, review.reviewed_at
+            FROM latest_reviews AS review
+            JOIN tailoring_feedback_signals AS source
+              ON source.tenant_id = ?
+             AND source.signal_id = review.signal_id
+             AND source.signal_kind = review.signal_kind
+            JOIN jobs AS job
+              ON job.tenant_id = ?
+             AND job.job_id = source.job_id
+            WHERE review.latest_rank = 1
+              AND review.decision = 'accepted'
+              AND review.allowlist_version = ?
+              AND (
+                (review.signal_kind = 'style_preference'
+                  AND review.rule_key = 'style_guidance'
+                  AND review.rule_value = 'preserve_user_edit_pattern')
+                OR (review.signal_kind = 'factual_correction'
+                  AND review.rule_key = 'fact_handling'
+                  AND review.rule_value = 'require_source_match')
+                OR (review.signal_kind = 'claim_policy_correction'
+                  AND review.rule_key = 'claim_policy'
+                  AND review.rule_value = 'omit_unsupported_claims')
+                OR (review.signal_kind = 'keyword_strategy'
+                  AND review.rule_key = 'keyword_strategy'
+                  AND review.rule_value = 'use_supported_terms_only')
+                OR (review.signal_kind = 'provenance_dispute'
+                  AND review.rule_key = 'provenance_policy'
+                  AND review.rule_value = 'require_direct_evidence')
+              )
+            ORDER BY source.signal_id
+            """,
+            (
+                str(tenant_id),
+                str(tenant_id),
+                str(tenant_id),
+                TAILORING_FEEDBACK_RULE_ALLOWLIST_VERSION,
+            ),
+        ).fetchall()
+        return tuple(
+            TailoringFeedbackSignal(
+                signal_id=(f"tailoring-feedback:{row['signal_id']}:{int(row['revision'])}"),
+                tenant_id=tenant_id,
+                job_id=canonical_job_id(str(row["job_id"])),
+                source_id=str(row["signal_id"]),
+                source_revision=int(row["revision"]),
+                recorded_at=str(row["reviewed_at"]),
+                signal_kind=cast(TailoringFeedbackSignalKind, str(row["signal_kind"])),
+                rule_key=cast(TailoringFeedbackRuleKey, str(row["rule_key"])),
+                rule_value=cast(TailoringFeedbackRuleValue, str(row["rule_value"])),
+                allowlist_version=int(row["allowlist_version"]),
+            )
+            for row in rows
+        )
 
 
 def _optional_text(value: Any) -> str | None:

--- a/workers/automation/tests/test_feedback_signal_reader.py
+++ b/workers/automation/tests/test_feedback_signal_reader.py
@@ -10,6 +10,7 @@ from jobctrl.domain.operations.feedback import (
     DiscoveryFeedbackSignal,
     RoleMatchApprovalFeedbackSignal,
     ScoreCorrectionFeedbackSignal,
+    TailoringFeedbackSignal,
 )
 from jobctrl.domain.tenant import LOCAL_TENANT, TenantId
 from jobctrl.infrastructure.projections.sqlite_feedback_signals import (
@@ -31,6 +32,7 @@ _PRIVATE_SENTINELS = (
     "private mail body",
     "/Users/private/resume.pdf",
 )
+_PRIVATE_TAILORING_SUMMARY = "private tailoring edit and generated resume text"
 
 
 def test_reads_only_explicit_reviewed_feedback_as_closed_typed_facts(
@@ -41,6 +43,7 @@ def test_reads_only_explicit_reviewed_feedback_as_closed_typed_facts(
     _seed_score_correction(conn)
     _seed_discovery_feedback(conn)
     _seed_role_suggestions(conn)
+    _seed_tailoring_feedback(conn, tenant_id="local", job_id=_JOB_C)
     conn.commit()
 
     signals = SqliteFeedbackSignalReader(conn).list_accepted(LOCAL_TENANT)
@@ -49,6 +52,7 @@ def test_reads_only_explicit_reviewed_feedback_as_closed_typed_facts(
         ScoreCorrectionFeedbackSignal,
         DiscoveryFeedbackSignal,
         RoleMatchApprovalFeedbackSignal,
+        TailoringFeedbackSignal,
     ]
     score = signals[0]
     assert isinstance(score, ScoreCorrectionFeedbackSignal)
@@ -73,6 +77,16 @@ def test_reads_only_explicit_reviewed_feedback_as_closed_typed_facts(
     assert role.rule_value == "account executive"
     assert role.source_ids == ("source-a", "source-b")
 
+    tailoring = signals[3]
+    assert isinstance(tailoring, TailoringFeedbackSignal)
+    assert tailoring.job_ids == (_JOB_C,)
+    assert tailoring.source_id == "tailoring-signal"
+    assert tailoring.source_revision == 1
+    assert tailoring.signal_kind == "factual_correction"
+    assert tailoring.rule_key == "fact_handling"
+    assert tailoring.rule_value == "require_source_match"
+    assert tailoring.allowlist_version == 1
+
     close_connection(tmp_path / "jobctrl.db")
 
 
@@ -84,14 +98,15 @@ def test_private_source_text_and_outcomes_never_enter_the_signal_union(
     _seed_score_correction(conn)
     _seed_discovery_feedback(conn)
     _seed_role_suggestions(conn)
+    _seed_tailoring_feedback(conn, tenant_id="local", job_id=_JOB_C)
     _seed_outcome_and_mail(conn)
     conn.commit()
 
     signals = SqliteFeedbackSignalReader(conn).list_accepted(LOCAL_TENANT)
     serialized = json.dumps([asdict(signal) for signal in signals], sort_keys=True)
 
-    assert len(signals) == 3
-    for sentinel in _PRIVATE_SENTINELS:
+    assert len(signals) == 4
+    for sentinel in (*_PRIVATE_SENTINELS, _PRIVATE_TAILORING_SUMMARY):
         assert sentinel not in serialized
     assert "application_outcome" not in serialized
     assert "application_email_evidence" not in serialized
@@ -105,6 +120,29 @@ def test_application_outcomes_alone_never_create_a_feedback_signal(
     conn = _exact_v7_connection(tmp_path)
     _seed_jobs(conn)
     _seed_outcome_and_mail(conn)
+    conn.commit()
+
+    assert SqliteFeedbackSignalReader(conn).list_accepted(LOCAL_TENANT) == ()
+
+    close_connection(tmp_path / "jobctrl.db")
+
+
+def test_latest_tailoring_review_must_be_accepted(tmp_path: Path) -> None:
+    conn = _exact_v7_connection(tmp_path)
+    _seed_jobs(conn)
+    _seed_tailoring_feedback(conn, tenant_id="local", job_id=_JOB_C)
+    conn.execute(
+        """
+        INSERT INTO tailoring_feedback_signal_reviews (
+            tenant_id, review_id, signal_id, revision, decision, signal_kind,
+            rule_key, rule_value, allowlist_version, reviewed_at
+        ) VALUES (
+            'local', 'tailoring-review-rejected', 'tailoring-signal', 2,
+            'rejected', 'factual_correction', NULL, NULL, 1,
+            '2026-08-01T12:01:00Z'
+        )
+        """
+    )
     conn.commit()
 
     assert SqliteFeedbackSignalReader(conn).list_accepted(LOCAL_TENANT) == ()
@@ -195,18 +233,36 @@ def test_signal_reads_are_tenant_scoped_and_deterministic(tmp_path: Path) -> Non
             "2026-08-01T09:00:00Z",
         ),
     )
+    _seed_tailoring_feedback(
+        conn,
+        tenant_id="tenant-a",
+        job_id=_JOB_A,
+        signal_id="shared-tailoring-signal",
+        reviewed_at="2026-08-01T10:00:00Z",
+    )
+    _seed_tailoring_feedback(
+        conn,
+        tenant_id="tenant-b",
+        job_id=_JOB_A,
+        signal_id="shared-tailoring-signal",
+        reviewed_at="2026-08-01T10:00:01Z",
+    )
     conn.commit()
 
     reader = SqliteFeedbackSignalReader(conn)
     tenant_a = reader.list_accepted(TenantId("tenant-a"))
     tenant_b = reader.list_accepted(TenantId("tenant-b"))
 
-    assert len(tenant_a) == len(tenant_b) == 1
+    assert len(tenant_a) == len(tenant_b) == 2
     assert tenant_a == reader.list_accepted(TenantId("tenant-a"))
     assert isinstance(tenant_a[0], ScoreCorrectionFeedbackSignal)
     assert isinstance(tenant_b[0], ScoreCorrectionFeedbackSignal)
     assert tenant_a[0].corrected_fit_score == 8
     assert tenant_b[0].corrected_fit_score == 4
+    assert isinstance(tenant_a[1], TailoringFeedbackSignal)
+    assert isinstance(tenant_b[1], TailoringFeedbackSignal)
+    assert tenant_a[1].tenant_id == TenantId("tenant-a")
+    assert tenant_b[1].tenant_id == TenantId("tenant-b")
 
     close_connection(tmp_path / "jobctrl.db")
 
@@ -327,6 +383,58 @@ def _seed_role_suggestions(conn: sqlite3.Connection) -> None:
                 _PRIVATE_SENTINELS[3],
             ),
         )
+
+
+def _seed_tailoring_feedback(
+    conn: sqlite3.Connection,
+    *,
+    tenant_id: str,
+    job_id: str,
+    signal_id: str = "tailoring-signal",
+    reviewed_at: str = "2026-08-01T12:00:00Z",
+) -> None:
+    draft_id = f"tailoring-draft-{tenant_id}-{signal_id}"
+    conn.execute(
+        """
+        INSERT INTO resume_review_drafts (
+            tenant_id, draft_id, job_id, base_generation, renderer_format,
+            state, latest_revision_number, created_at, updated_at
+        ) VALUES (?, ?, ?, 1, 'text', 'active', 0, ?, ?)
+        """,
+        (tenant_id, draft_id, job_id, reviewed_at, reviewed_at),
+    )
+    conn.execute(
+        """
+        INSERT INTO tailoring_feedback_signals (
+            tenant_id, signal_id, job_id, draft_id, source_kind, source_id,
+            signal_kind, status, summary, created_at, reviewed_at
+        ) VALUES (
+            ?, ?, ?, ?, 'edit_delta', 'private-delta',
+            'factual_correction', 'accepted', ?, ?, ?
+        )
+        """,
+        (
+            tenant_id,
+            signal_id,
+            job_id,
+            draft_id,
+            _PRIVATE_TAILORING_SUMMARY,
+            reviewed_at,
+            reviewed_at,
+        ),
+    )
+    conn.execute(
+        """
+        INSERT INTO tailoring_feedback_signal_reviews (
+            tenant_id, review_id, signal_id, revision, decision, signal_kind,
+            rule_key, rule_value, allowlist_version, reviewed_at
+        ) VALUES (
+            ?, ?, ?, 1, 'accepted', 'factual_correction',
+            'fact_handling', 'require_source_match', 1, ?
+        )
+        """,
+        (tenant_id, f"tailoring-review-{tenant_id}-{signal_id}", signal_id, reviewed_at),
+    )
 
 
 def _seed_outcome_and_mail(conn: sqlite3.Connection) -> None:


### PR DESCRIPTION
## Summary

- add a typed review endpoint and client operation for tailoring feedback signals
- constrain accepted reviews to a versioned server-owned rule allowlist and keep review history append-only
- expose only latest accepted structured tailoring facts through the privacy-safe feedback reader
- keep repeated identical decisions idempotent while later decisions append a new revision

## Why

Tailoring edits and comment replies contain private free text that must never become learning input directly. This child makes explicit review the only boundary from those source records into the shared feedback-signal union. It does not derive rules from summaries, generated materials, or model output, and it does not change policy behavior.

## Validation

- `/Users/eloibarti/.nvm/versions/node/v22.21.1/bin/pnpm --filter @jobctrl/contracts check`
- `/Users/eloibarti/.nvm/versions/node/v22.21.1/bin/pnpm --filter @jobctrl/api-client check`
- `/Users/eloibarti/.nvm/versions/node/v22.21.1/bin/pnpm --filter @jobctrl/api check`
- `/Users/eloibarti/.nvm/versions/node/v22.21.1/bin/pnpm --filter @jobctrl/api exec vitest run test/resume-review-drafts.test.ts`
- `PYTHONPATH=workers/automation/src /Users/eloibarti/Github/JobHunter/workers/automation/.venv/bin/pytest workers/automation/tests/test_feedback_signal_reader.py workers/automation/tests/test_scoring_eval_feedback.py`
- `PYTHONPATH=workers/automation/src /Users/eloibarti/Github/JobHunter/workers/automation/.venv/bin/ruff check workers/automation/src/jobctrl/domain/operations/__init__.py workers/automation/src/jobctrl/domain/operations/feedback.py workers/automation/src/jobctrl/infrastructure/projections/sqlite_feedback_signals.py workers/automation/tests/test_feedback_signal_reader.py`
- `git diff --check`

Canonical product and API documentation remains deferred to the final PR in the approved unreleased stack.

Stacked on #674.
