### PR TITLE
feat(learning): derive thresholded tailoring recommendations

### DIFF
--- a/workers/automation/src/jobctrl/domain/operations/__init__.py
+++ b/workers/automation/src/jobctrl/domain/operations/__init__.py
@@ -42,6 +42,18 @@ from jobctrl.domain.operations.feedback import (
     TailoringFeedbackSignal,
     TailoringFeedbackSignalKind,
 )
+from jobctrl.domain.operations.learning import (
+    LearningRecommendation,
+    RecommendationEvidenceRef,
+    TAILORING_RECOMMENDATION_DERIVATION_VERSION,
+    TAILORING_RECOMMENDATION_EVALUATION_FIXTURE_VERSION,
+    TAILORING_RECOMMENDATION_MIN_JOB_COUNT,
+    TAILORING_RECOMMENDATION_MIN_SIGNAL_COUNT,
+    TailoringContradictionEvidence,
+    TailoringRecommendationScope,
+    TailoringRuleEffect,
+    derive_tailoring_recommendations,
+)
 
 __all__ = [
     "ApplyRunProjection",
@@ -58,14 +70,24 @@ __all__ = [
     "FeedbackSignal",
     "JobDetailProjection",
     "JobListProjection",
+    "LearningRecommendation",
+    "RecommendationEvidenceRef",
     "RoleMatchApprovalFeedbackSignal",
     "ScoreCorrectionDirection",
     "ScoreCorrectionFeedbackSignal",
     "TAILORING_FEEDBACK_RULE_ALLOWLIST",
     "TAILORING_FEEDBACK_RULE_ALLOWLIST_VERSION",
+    "TAILORING_RECOMMENDATION_DERIVATION_VERSION",
+    "TAILORING_RECOMMENDATION_EVALUATION_FIXTURE_VERSION",
+    "TAILORING_RECOMMENDATION_MIN_JOB_COUNT",
+    "TAILORING_RECOMMENDATION_MIN_SIGNAL_COUNT",
     "StageProjection",
     "TailoringFeedbackRuleKey",
     "TailoringFeedbackRuleValue",
     "TailoringFeedbackSignal",
     "TailoringFeedbackSignalKind",
+    "TailoringContradictionEvidence",
+    "TailoringRecommendationScope",
+    "TailoringRuleEffect",
+    "derive_tailoring_recommendations",
 ]

--- a/workers/automation/src/jobctrl/domain/operations/learning.py
+++ b/workers/automation/src/jobctrl/domain/operations/learning.py
@@ -1,0 +1,323 @@
+"""Deterministic, non-executable learning recommendation derivation."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass, field
+import hashlib
+import json
+from typing import Literal
+
+from jobctrl.domain.identifiers import JobId
+from jobctrl.domain.operations.feedback import (
+    FeedbackSignal,
+    TAILORING_FEEDBACK_RULE_ALLOWLIST,
+    TAILORING_FEEDBACK_RULE_ALLOWLIST_VERSION,
+    TailoringFeedbackRuleKey,
+    TailoringFeedbackRuleValue,
+    TailoringFeedbackSignal,
+    TailoringFeedbackSignalKind,
+)
+from jobctrl.domain.tenant import TenantId
+
+
+TAILORING_RECOMMENDATION_DERIVATION_VERSION = 1
+TAILORING_RECOMMENDATION_EVALUATION_FIXTURE_VERSION = 1
+TAILORING_RECOMMENDATION_MIN_SIGNAL_COUNT = 3
+TAILORING_RECOMMENDATION_MIN_JOB_COUNT = 2
+
+
+@dataclass(frozen=True, kw_only=True)
+class TailoringRuleEffect:
+    """Closed, allowlisted Materials policy effect proposed by learning."""
+
+    signal_kind: TailoringFeedbackSignalKind
+    rule_key: TailoringFeedbackRuleKey
+    rule_value: TailoringFeedbackRuleValue
+    allowlist_version: int
+
+    def __post_init__(self) -> None:
+        if self.allowlist_version != TAILORING_FEEDBACK_RULE_ALLOWLIST_VERSION:
+            raise ValueError("unsupported tailoring feedback rule allowlist version")
+        if TAILORING_FEEDBACK_RULE_ALLOWLIST[self.signal_kind] != (
+            self.rule_key,
+            self.rule_value,
+        ):
+            raise ValueError("tailoring recommendation effect is not allowlisted")
+
+
+@dataclass(frozen=True, kw_only=True)
+class TailoringRecommendationScope:
+    """Tenant-owned Materials scope used for grouping and contradiction lookup."""
+
+    tenant_id: TenantId
+    proposed_effect: TailoringRuleEffect
+    context: Literal["materials"] = field(default="materials", init=False)
+    policy_kind: Literal["tailoring_rule"] = field(
+        default="tailoring_rule", init=False
+    )
+
+    def __post_init__(self) -> None:
+        if not str(self.tenant_id).strip():
+            raise ValueError("tenant_id must not be empty")
+
+
+@dataclass(frozen=True, kw_only=True)
+class RecommendationEvidenceRef:
+    """Non-sensitive provenance copied from an accepted signal value."""
+
+    signal_id: str
+    source_kind: Literal["tailoring_feedback_signal"]
+    source_id: str
+    source_revision: int
+    job_ids: tuple[JobId, ...]
+    recorded_at: str
+
+    def __post_init__(self) -> None:
+        for name, value in (
+            ("signal_id", self.signal_id),
+            ("source_id", self.source_id),
+            ("recorded_at", self.recorded_at),
+        ):
+            if not value.strip():
+                raise ValueError(f"{name} must not be empty")
+        if self.source_revision < 1:
+            raise ValueError("source_revision must be positive")
+        if not self.job_ids or len(set(self.job_ids)) != len(self.job_ids):
+            raise ValueError("evidence requires unique canonical job IDs")
+
+
+@dataclass(frozen=True, kw_only=True)
+class TailoringContradictionEvidence:
+    """Canonical contradiction IDs and the unresolved subset for one scope."""
+
+    signal_ids: tuple[str, ...]
+    unresolved_signal_ids: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        if any(not signal_id.strip() for signal_id in self.signal_ids):
+            raise ValueError("contradiction signal IDs must not be empty")
+        if len(set(self.signal_ids)) != len(self.signal_ids):
+            raise ValueError("contradiction signal IDs must be unique")
+        if len(set(self.unresolved_signal_ids)) != len(
+            self.unresolved_signal_ids
+        ):
+            raise ValueError("unresolved contradiction signal IDs must be unique")
+        if not set(self.unresolved_signal_ids).issubset(self.signal_ids):
+            raise ValueError("unresolved contradiction IDs must be recorded")
+
+
+@dataclass(frozen=True, kw_only=True)
+class LearningRecommendation:
+    """Pending proposal that cannot change behavior before explicit acceptance."""
+
+    recommendation_id: str
+    scope: TailoringRecommendationScope
+    proposed_effect: TailoringRuleEffect
+    derivation_version: int
+    evaluation_fixture_version: int
+    supporting_signal_ids: tuple[str, ...]
+    contradicting_signal_ids: tuple[str, ...]
+    evidence: tuple[RecommendationEvidenceRef, ...]
+    job_ids: tuple[JobId, ...]
+    observed_signal_count: int
+    observed_job_count: int
+    minimum_signal_count: int = field(
+        default=TAILORING_RECOMMENDATION_MIN_SIGNAL_COUNT, init=False
+    )
+    minimum_job_count: int = field(
+        default=TAILORING_RECOMMENDATION_MIN_JOB_COUNT, init=False
+    )
+    confidence_limit: Literal["sample_gated_no_population_inference"] = field(
+        default="sample_gated_no_population_inference", init=False
+    )
+    status: Literal["pending"] = field(default="pending", init=False)
+
+    def __post_init__(self) -> None:
+        if not self.recommendation_id.strip():
+            raise ValueError("recommendation_id must not be empty")
+        if self.scope.proposed_effect != self.proposed_effect:
+            raise ValueError("recommendation scope and proposed effect must match")
+        if self.derivation_version != TAILORING_RECOMMENDATION_DERIVATION_VERSION:
+            raise ValueError("recommendation derivation version is not gated")
+        if (
+            self.evaluation_fixture_version
+            != TAILORING_RECOMMENDATION_EVALUATION_FIXTURE_VERSION
+        ):
+            raise ValueError("recommendation evaluation fixture version is not gated")
+        if len(set(self.supporting_signal_ids)) != len(self.supporting_signal_ids):
+            raise ValueError("supporting signal IDs must be unique")
+        if len(set(self.contradicting_signal_ids)) != len(
+            self.contradicting_signal_ids
+        ):
+            raise ValueError("contradicting signal IDs must be unique")
+        if self.observed_signal_count != len(self.supporting_signal_ids):
+            raise ValueError("observed signal count must match supporting signal IDs")
+        if tuple(evidence.signal_id for evidence in self.evidence) != (
+            self.supporting_signal_ids
+        ):
+            raise ValueError("recommendation evidence must match supporting signal IDs")
+        if len(set(self.job_ids)) != len(self.job_ids):
+            raise ValueError("recommendation job IDs must be unique")
+        if self.observed_job_count != len(self.job_ids):
+            raise ValueError("observed job count must match canonical job IDs")
+        if self.observed_signal_count < self.minimum_signal_count:
+            raise ValueError("recommendation does not meet the signal threshold")
+        if self.observed_job_count < self.minimum_job_count:
+            raise ValueError("recommendation does not meet the cross-job threshold")
+        if set(self.supporting_signal_ids) & set(self.contradicting_signal_ids):
+            raise ValueError("one signal cannot support and contradict a recommendation")
+
+
+def derive_tailoring_recommendations(
+    signals: Iterable[FeedbackSignal],
+    *,
+    contradictions: Mapping[
+        TailoringRecommendationScope, TailoringContradictionEvidence
+    ],
+    derivation_version: int = TAILORING_RECOMMENDATION_DERIVATION_VERSION,
+) -> tuple[LearningRecommendation, ...]:
+    """Derive stable pending proposals from explicit accepted tailoring facts.
+
+    Contradiction inputs contain non-sensitive signal IDs resolved by the
+    owning ledger. Any unresolved ID suppresses the candidate entirely.
+    """
+
+    if derivation_version != TAILORING_RECOMMENDATION_DERIVATION_VERSION:
+        raise ValueError("derivation version has no passing evaluation fixture")
+
+    unique_signals: dict[tuple[TenantId, str], TailoringFeedbackSignal] = {}
+    for signal in signals:
+        if not isinstance(signal, TailoringFeedbackSignal):
+            continue
+        identity = (signal.tenant_id, signal.signal_id)
+        existing = unique_signals.get(identity)
+        if existing is not None and existing != signal:
+            raise ValueError("one tailoring signal ID has conflicting accepted facts")
+        unique_signals[identity] = signal
+
+    grouped: dict[TailoringRecommendationScope, list[TailoringFeedbackSignal]] = {}
+    for signal in unique_signals.values():
+        effect = TailoringRuleEffect(
+            signal_kind=signal.signal_kind,
+            rule_key=signal.rule_key,
+            rule_value=signal.rule_value,
+            allowlist_version=signal.allowlist_version,
+        )
+        scope = TailoringRecommendationScope(
+            tenant_id=signal.tenant_id,
+            proposed_effect=effect,
+        )
+        grouped.setdefault(scope, []).append(signal)
+
+    recommendations: list[LearningRecommendation] = []
+    for scope, scoped_signals in grouped.items():
+        support = tuple(sorted(scoped_signals, key=lambda signal: signal.signal_id))
+        job_ids = tuple(sorted({job_id for signal in support for job_id in signal.job_ids}))
+        if len(support) < TAILORING_RECOMMENDATION_MIN_SIGNAL_COUNT:
+            continue
+        if len(job_ids) < TAILORING_RECOMMENDATION_MIN_JOB_COUNT:
+            continue
+
+        contradiction_evidence = contradictions.get(scope)
+        contradiction_ids = (
+            tuple(sorted(contradiction_evidence.signal_ids))
+            if contradiction_evidence
+            else ()
+        )
+        unresolved_ids = (
+            contradiction_evidence.unresolved_signal_ids
+            if contradiction_evidence
+            else ()
+        )
+        support_ids = tuple(signal.signal_id for signal in support)
+        if set(support_ids) & set(contradiction_ids):
+            raise ValueError("one signal cannot support and contradict a recommendation")
+        if unresolved_ids:
+            continue
+
+        evidence = tuple(
+            RecommendationEvidenceRef(
+                signal_id=signal.signal_id,
+                source_kind=signal.source_kind,
+                source_id=signal.source_id,
+                source_revision=signal.source_revision,
+                job_ids=signal.job_ids,
+                recorded_at=signal.recorded_at,
+            )
+            for signal in support
+        )
+        recommendations.append(
+            LearningRecommendation(
+                recommendation_id=_recommendation_id(
+                    scope,
+                    derivation_version,
+                    support,
+                    contradiction_ids,
+                ),
+                scope=scope,
+                proposed_effect=scope.proposed_effect,
+                derivation_version=derivation_version,
+                evaluation_fixture_version=(
+                    TAILORING_RECOMMENDATION_EVALUATION_FIXTURE_VERSION
+                ),
+                supporting_signal_ids=support_ids,
+                contradicting_signal_ids=contradiction_ids,
+                evidence=evidence,
+                job_ids=job_ids,
+                observed_signal_count=len(support_ids),
+                observed_job_count=len(job_ids),
+            )
+        )
+
+    return tuple(
+        sorted(
+            recommendations,
+            key=lambda recommendation: recommendation.recommendation_id,
+        )
+    )
+
+
+def _recommendation_id(
+    scope: TailoringRecommendationScope,
+    derivation_version: int,
+    supporting_signals: tuple[TailoringFeedbackSignal, ...],
+    contradicting_signal_ids: tuple[str, ...],
+) -> str:
+    payload = json.dumps(
+        {
+            "allowlistVersion": scope.proposed_effect.allowlist_version,
+            "contradictingSignalIds": contradicting_signal_ids,
+            "derivationVersion": derivation_version,
+            "ruleKey": scope.proposed_effect.rule_key,
+            "ruleValue": scope.proposed_effect.rule_value,
+            "signalKind": scope.proposed_effect.signal_kind,
+            "supportingEvidence": [
+                {
+                    "jobIds": signal.job_ids,
+                    "signalId": signal.signal_id,
+                    "sourceId": signal.source_id,
+                    "sourceRevision": signal.source_revision,
+                }
+                for signal in supporting_signals
+            ],
+            "tenantId": str(scope.tenant_id),
+        },
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    return f"learning-recommendation:{hashlib.sha256(payload.encode('utf-8')).hexdigest()}"
+
+
+__all__ = [
+    "LearningRecommendation",
+    "RecommendationEvidenceRef",
+    "TAILORING_RECOMMENDATION_DERIVATION_VERSION",
+    "TAILORING_RECOMMENDATION_EVALUATION_FIXTURE_VERSION",
+    "TAILORING_RECOMMENDATION_MIN_JOB_COUNT",
+    "TAILORING_RECOMMENDATION_MIN_SIGNAL_COUNT",
+    "TailoringContradictionEvidence",
+    "TailoringRecommendationScope",
+    "TailoringRuleEffect",
+    "derive_tailoring_recommendations",
+]

--- a/workers/automation/tests/test_feedback_signal_reader.py
+++ b/workers/automation/tests/test_feedback_signal_reader.py
@@ -12,6 +12,7 @@ from jobctrl.domain.operations.feedback import (
     ScoreCorrectionFeedbackSignal,
     TailoringFeedbackSignal,
 )
+from jobctrl.domain.operations.learning import derive_tailoring_recommendations
 from jobctrl.domain.tenant import LOCAL_TENANT, TenantId
 from jobctrl.infrastructure.projections.sqlite_feedback_signals import (
     SqliteFeedbackSignalReader,
@@ -146,6 +147,34 @@ def test_latest_tailoring_review_must_be_accepted(tmp_path: Path) -> None:
     conn.commit()
 
     assert SqliteFeedbackSignalReader(conn).list_accepted(LOCAL_TENANT) == ()
+
+    close_connection(tmp_path / "jobctrl.db")
+
+
+def test_reviewed_tailoring_signals_feed_thresholded_recommendation_derivation(
+    tmp_path: Path,
+) -> None:
+    conn = _exact_v7_connection(tmp_path)
+    _seed_jobs(conn)
+    _seed_tailoring_feedback(
+        conn, tenant_id="local", job_id=_JOB_A, signal_id="tailoring-signal-1"
+    )
+    _seed_tailoring_feedback(
+        conn, tenant_id="local", job_id=_JOB_A, signal_id="tailoring-signal-2"
+    )
+    _seed_tailoring_feedback(
+        conn, tenant_id="local", job_id=_JOB_B, signal_id="tailoring-signal-3"
+    )
+    conn.commit()
+
+    recommendation = derive_tailoring_recommendations(
+        SqliteFeedbackSignalReader(conn).list_accepted(LOCAL_TENANT),
+        contradictions={},
+    )[0]
+
+    assert recommendation.observed_signal_count == 3
+    assert recommendation.job_ids == (_JOB_A, _JOB_B)
+    assert recommendation.status == "pending"
 
     close_connection(tmp_path / "jobctrl.db")
 

--- a/workers/automation/tests/test_learning_recommendations.py
+++ b/workers/automation/tests/test_learning_recommendations.py
@@ -1,0 +1,280 @@
+from __future__ import annotations
+
+from dataclasses import asdict
+import json
+
+import pytest
+
+from jobctrl.domain.identifiers import canonical_job_id
+from jobctrl.domain.operations.feedback import (
+    ScoreCorrectionFeedbackSignal,
+    TailoringFeedbackSignal,
+)
+from jobctrl.domain.operations.learning import (
+    TAILORING_RECOMMENDATION_DERIVATION_VERSION,
+    TailoringContradictionEvidence,
+    TailoringRecommendationScope,
+    TailoringRuleEffect,
+    derive_tailoring_recommendations,
+)
+from jobctrl.domain.tenant import TenantId
+
+
+_TENANT = TenantId("tenant-a")
+_JOB_A = canonical_job_id("10000000-0000-4000-8000-000000000001")
+_JOB_B = canonical_job_id("10000000-0000-4000-8000-000000000002")
+_PRIVATE_SENTINELS = (
+    "private edit text",
+    "private generated resume",
+    "private job description",
+    "private prompt",
+    "private mail body",
+    "/Users/private/resume.pdf",
+)
+
+
+def test_three_compatible_signals_across_two_jobs_derive_one_pending_proposal() -> None:
+    signals = (
+        _signal("signal-3", _JOB_B, 3),
+        _signal("signal-1", _JOB_A, 1),
+        _signal("signal-2", _JOB_A, 2),
+    )
+
+    recommendations = derive_tailoring_recommendations(signals, contradictions={})
+
+    assert len(recommendations) == 1
+    recommendation = recommendations[0]
+    assert recommendation.status == "pending"
+    assert recommendation.derivation_version == TAILORING_RECOMMENDATION_DERIVATION_VERSION
+    assert recommendation.evaluation_fixture_version == 1
+    assert recommendation.supporting_signal_ids == ("signal-1", "signal-2", "signal-3")
+    assert recommendation.contradicting_signal_ids == ()
+    assert recommendation.job_ids == (_JOB_A, _JOB_B)
+    assert recommendation.observed_signal_count == 3
+    assert recommendation.observed_job_count == 2
+    assert recommendation.minimum_signal_count == 3
+    assert recommendation.minimum_job_count == 2
+    assert recommendation.confidence_limit == "sample_gated_no_population_inference"
+    assert recommendation.proposed_effect == _scope().proposed_effect
+    assert [evidence.source_id for evidence in recommendation.evidence] == [
+        "source-signal-1",
+        "source-signal-2",
+        "source-signal-3",
+    ]
+
+
+@pytest.mark.parametrize(
+    "signal_specs",
+    [
+        (("signal-1", _JOB_A, 1), ("signal-2", _JOB_B, 2)),
+        (
+            ("signal-1", _JOB_A, 1),
+            ("signal-2", _JOB_A, 2),
+            ("signal-3", _JOB_A, 3),
+        ),
+    ],
+    ids=("insufficient-signals", "single-job-concentration"),
+)
+def test_thresholds_fail_closed(
+    signal_specs: tuple[tuple[str, str, int], ...],
+) -> None:
+    signals = tuple(_signal(*spec) for spec in signal_specs)
+    assert derive_tailoring_recommendations(signals, contradictions={}) == ()
+
+
+def test_duplicate_inputs_are_deduplicated_and_order_independent() -> None:
+    signal_1 = _signal("signal-1", _JOB_A, 1)
+    signal_2 = _signal("signal-2", _JOB_A, 2)
+    signal_3 = _signal("signal-3", _JOB_B, 3)
+
+    forward = derive_tailoring_recommendations(
+        (signal_1, signal_2, signal_3), contradictions={}
+    )
+    reordered = derive_tailoring_recommendations(
+        (signal_3, signal_1, signal_2, signal_1, signal_3),
+        contradictions={},
+    )
+
+    assert reordered == forward
+    assert reordered[0].observed_signal_count == 3
+
+
+def test_canonical_subject_correction_changes_the_derivation_identity() -> None:
+    original = derive_tailoring_recommendations(
+        (
+            _signal("signal-1", _JOB_A, 1),
+            _signal("signal-2", _JOB_A, 2),
+            _signal("signal-3", _JOB_B, 3),
+        ),
+        contradictions={},
+    )[0]
+    corrected = derive_tailoring_recommendations(
+        (
+            _signal("signal-1", _JOB_B, 1),
+            _signal("signal-2", _JOB_A, 2),
+            _signal("signal-3", _JOB_B, 3),
+        ),
+        contradictions={},
+    )[0]
+
+    assert corrected.supporting_signal_ids == original.supporting_signal_ids
+    assert corrected.recommendation_id != original.recommendation_id
+
+
+def test_tenants_never_share_thresholds_or_recommendation_identity() -> None:
+    tenant_b = TenantId("tenant-b")
+    tenant_a_signals = (
+        _signal("signal-1", _JOB_A, 1),
+        _signal("signal-2", _JOB_B, 2),
+    )
+    tenant_b_signals = (
+        _signal("signal-1", _JOB_A, 1, tenant_id=tenant_b),
+        _signal("signal-2", _JOB_A, 2, tenant_id=tenant_b),
+        _signal("signal-3", _JOB_B, 3, tenant_id=tenant_b),
+    )
+
+    assert (
+        derive_tailoring_recommendations(
+            (*tenant_a_signals, tenant_b_signals[0]), contradictions={}
+        )
+        == ()
+    )
+
+    recommendations = derive_tailoring_recommendations(
+        (*tenant_a_signals, _signal("signal-3", _JOB_A, 3), *tenant_b_signals),
+        contradictions={},
+    )
+    by_tenant = {
+        recommendation.scope.tenant_id: recommendation
+        for recommendation in recommendations
+    }
+    assert set(by_tenant) == {_TENANT, tenant_b}
+    assert by_tenant[_TENANT].recommendation_id != by_tenant[tenant_b].recommendation_id
+
+
+def test_conflicting_duplicate_signal_identity_is_rejected() -> None:
+    with pytest.raises(ValueError, match="conflicting accepted facts"):
+        derive_tailoring_recommendations(
+            (
+                _signal("signal-1", _JOB_A, 1),
+                _signal("signal-1", _JOB_B, 1),
+            ),
+            contradictions={},
+        )
+
+
+def test_unresolved_contradiction_blocks_derivation_but_resolved_history_is_recorded() -> None:
+    signals = (
+        _signal("signal-1", _JOB_A, 1),
+        _signal("signal-2", _JOB_A, 2),
+        _signal("signal-3", _JOB_B, 3),
+    )
+    unresolved = {
+        _scope(): TailoringContradictionEvidence(
+            signal_ids=("contradiction-2", "contradiction-1"),
+            unresolved_signal_ids=("contradiction-1",),
+        )
+    }
+
+    assert (
+        derive_tailoring_recommendations(
+            signals,
+            contradictions=unresolved,
+        )
+        == ()
+    )
+
+    resolved = derive_tailoring_recommendations(
+        signals,
+        contradictions={
+            _scope(): TailoringContradictionEvidence(
+                signal_ids=("contradiction-2", "contradiction-1"),
+                unresolved_signal_ids=(),
+            )
+        },
+    )
+    assert resolved[0].contradicting_signal_ids == (
+        "contradiction-1",
+        "contradiction-2",
+    )
+
+
+def test_unregistered_derivation_version_is_rejected_until_its_fixture_exists() -> None:
+    with pytest.raises(ValueError, match="no passing evaluation fixture"):
+        derive_tailoring_recommendations(
+            (
+                _signal("signal-1", _JOB_A, 1),
+                _signal("signal-2", _JOB_A, 2),
+                _signal("signal-3", _JOB_B, 3),
+            ),
+            contradictions={},
+            derivation_version=TAILORING_RECOMMENDATION_DERIVATION_VERSION + 1,
+        )
+
+
+def test_recommendation_contains_no_private_source_content() -> None:
+    recommendation = derive_tailoring_recommendations(
+        (
+            _signal("signal-1", _JOB_A, 1),
+            _signal("signal-2", _JOB_A, 2),
+            _signal("signal-3", _JOB_B, 3),
+        ),
+        contradictions={},
+    )[0]
+    serialized = json.dumps(asdict(recommendation), sort_keys=True)
+
+    for sentinel in _PRIVATE_SENTINELS:
+        assert sentinel not in serialized
+    assert "summary" not in serialized
+    assert "application_outcome" not in serialized
+    assert "raw" not in serialized
+
+
+def test_empty_or_non_tailoring_input_cannot_create_a_recommendation() -> None:
+    assert derive_tailoring_recommendations((), contradictions={}) == ()
+    score_correction = ScoreCorrectionFeedbackSignal(
+        signal_id="score-correction",
+        tenant_id=_TENANT,
+        job_id=_JOB_A,
+        source_id="score-source",
+        source_revision=2,
+        recorded_at="2026-08-01T10:00:00Z",
+        original_fit_score=4,
+        corrected_fit_score=8,
+    )
+    assert derive_tailoring_recommendations(
+        (score_correction,), contradictions={}
+    ) == ()
+
+
+def _scope() -> TailoringRecommendationScope:
+    return TailoringRecommendationScope(
+        tenant_id=_TENANT,
+        proposed_effect=TailoringRuleEffect(
+            signal_kind="factual_correction",
+            rule_key="fact_handling",
+            rule_value="require_source_match",
+            allowlist_version=1,
+        ),
+    )
+
+
+def _signal(
+    signal_id: str,
+    job_id: str,
+    revision: int,
+    *,
+    tenant_id: TenantId = _TENANT,
+) -> TailoringFeedbackSignal:
+    return TailoringFeedbackSignal(
+        signal_id=signal_id,
+        tenant_id=tenant_id,
+        job_id=canonical_job_id(job_id),
+        source_id=f"source-{signal_id}",
+        source_revision=revision,
+        recorded_at=f"2026-08-01T10:00:0{revision}Z",
+        signal_kind="factual_correction",
+        rule_key="fact_handling",
+        rule_value="require_source_match",
+        allowlist_version=1,
+    )


### PR DESCRIPTION
## Summary

- add a pure, deterministic derivation kernel for pending tailoring-rule recommendations
- require three unique compatible accepted signals across at least two canonical jobs
- require an explicit contradiction ledger input and suppress candidates with unresolved contradictions
- hash versioned structured provenance into stable recommendation identities without persisting or applying behavior

## Why

Reviewed feedback must remain non-executable until a recommendation passes deterministic thresholds and is explicitly accepted in a later policy-revision flow. This child establishes that fail-closed domain boundary without adding storage, API behavior, ranking changes, or policy mutation.

## Validation

- `PYTHONPATH=workers/automation/src /Users/eloibarti/Github/JobHunter/workers/automation/.venv/bin/pytest workers/automation/tests/test_learning_recommendations.py workers/automation/tests/test_feedback_signal_reader.py workers/automation/tests/test_scoring_eval_feedback.py`
- `PYTHONPATH=workers/automation/src /Users/eloibarti/Github/JobHunter/workers/automation/.venv/bin/ruff check workers/automation/src/jobctrl/domain/operations/__init__.py workers/automation/src/jobctrl/domain/operations/learning.py workers/automation/tests/test_learning_recommendations.py workers/automation/tests/test_feedback_signal_reader.py`
- `git diff --check`

Canonical product documentation remains deferred to the final PR in the approved unreleased stack.

Stacked on #675.
