### PR TITLE
feat(storage): add learning recommendation records

### DIFF
--- a/apps/api/src/schema-manifest.ts
+++ b/apps/api/src/schema-manifest.ts
@@ -14,9 +14,9 @@ export type SchemaManifest = {
 // a different schema.
 export const EXACT_V7_SCHEMA_MANIFEST: SchemaManifest = {
   version: 7,
-  objectCount: 205,
-  tableCount: 103,
-  fingerprint: "265cdabf5e7631e0c51b9a05e53b797d7a0f2c19d37d049e15acb2d141a9509c",
+  objectCount: 226,
+  tableCount: 107,
+  fingerprint: "b80552dd38f1bdfcd75b95c09054f80a1169c609610ce4975edb837dd76808c8",
 };
 
 type SqliteMasterRow = [type: string, name: string, tableName: string, sql: string];

--- a/apps/api/test/schema-version-guard.test.ts
+++ b/apps/api/test/schema-version-guard.test.ts
@@ -142,14 +142,14 @@ describe("schema version guard at DB open", () => {
     const pythonManifest = fs.readFileSync(pythonManifestPath, "utf8");
 
     expect(pythonManifest).toContain("version=7,");
-    expect(pythonManifest).toContain("object_count=205,");
-    expect(pythonManifest).toContain("table_count=103,");
+    expect(pythonManifest).toContain("object_count=226,");
+    expect(pythonManifest).toContain("table_count=107,");
     expect(pythonManifest).toContain(`fingerprint=\"${EXACT_V7_SCHEMA_MANIFEST.fingerprint}\",`);
     expect(EXACT_V7_SCHEMA_MANIFEST).toEqual({
       version: SUPPORTED_SCHEMA_VERSION,
-      objectCount: 205,
-      tableCount: 103,
-      fingerprint: "265cdabf5e7631e0c51b9a05e53b797d7a0f2c19d37d049e15acb2d141a9509c",
+      objectCount: 226,
+      tableCount: 107,
+      fingerprint: "b80552dd38f1bdfcd75b95c09054f80a1169c609610ce4975edb837dd76808c8",
     });
   });
 });

--- a/apps/api/vitest.config.ts
+++ b/apps/api/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    testTimeout: 15_000,
+  },
+});

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
     conditions: ["development", "browser"],
   },
   test: {
+    testTimeout: 10_000,
     environment: "jsdom",
     globals: true,
     setupFiles: ["./src/test/setup.ts"],

--- a/workers/automation/src/jobctrl/infrastructure/migrations/schema_manifest.py
+++ b/workers/automation/src/jobctrl/infrastructure/migrations/schema_manifest.py
@@ -23,9 +23,9 @@ class SchemaManifest:
 # semantically meaningful and must never normalize to the same fingerprint.
 EXACT_V7_MANIFEST = SchemaManifest(
     version=7,
-    object_count=205,
-    table_count=103,
-    fingerprint="265cdabf5e7631e0c51b9a05e53b797d7a0f2c19d37d049e15acb2d141a9509c",
+    object_count=226,
+    table_count=107,
+    fingerprint="b80552dd38f1bdfcd75b95c09054f80a1169c609610ce4975edb837dd76808c8",
 )
 
 

--- a/workers/automation/src/jobctrl/infrastructure/migrations/schema_v7.sql
+++ b/workers/automation/src/jobctrl/infrastructure/migrations/schema_v7.sql
@@ -1800,6 +1800,214 @@ CREATE TABLE tailoring_feedback_signals (
       FOREIGN KEY (tenant_id, job_id)
         REFERENCES jobs(tenant_id, job_id) ON DELETE CASCADE
     );
+CREATE TABLE learning_recommendations (
+      tenant_id                 TEXT NOT NULL DEFAULT 'local',
+      recommendation_id         TEXT NOT NULL,
+      derivation_version        INTEGER NOT NULL CHECK(derivation_version > 0),
+      evaluation_fixture_version INTEGER NOT NULL CHECK(evaluation_fixture_version > 0),
+      context                   TEXT NOT NULL CHECK(context = 'materials'),
+      policy_kind               TEXT NOT NULL CHECK(policy_kind = 'tailoring_rule'),
+      signal_kind               TEXT NOT NULL CHECK(signal_kind IN (
+        'style_preference',
+        'factual_correction',
+        'claim_policy_correction',
+        'keyword_strategy',
+        'provenance_dispute'
+      )),
+      rule_key                  TEXT NOT NULL CHECK(
+        length(rule_key) BETWEEN 1 AND 80
+        AND rule_key NOT GLOB '*[^a-z0-9_]*'
+      ),
+      rule_value                TEXT NOT NULL CHECK(
+        length(rule_value) BETWEEN 1 AND 160
+        AND rule_value NOT GLOB '*[^a-z0-9_]*'
+      ),
+      allowlist_version         INTEGER NOT NULL CHECK(allowlist_version > 0),
+      status                    TEXT NOT NULL DEFAULT 'pending' CHECK(status = 'pending'),
+      observed_signal_count     INTEGER NOT NULL,
+      observed_job_count        INTEGER NOT NULL,
+      minimum_signal_count      INTEGER NOT NULL CHECK(minimum_signal_count >= 3),
+      minimum_job_count         INTEGER NOT NULL CHECK(minimum_job_count >= 2),
+      confidence_limit          TEXT NOT NULL CHECK(
+        confidence_limit = 'sample_gated_no_population_inference'
+      ),
+      input_fingerprint         TEXT NOT NULL CHECK(
+        length(input_fingerprint) = 64
+        AND input_fingerprint NOT GLOB '*[^a-f0-9]*'
+      ),
+      derived_at                TEXT NOT NULL,
+      PRIMARY KEY (tenant_id, recommendation_id),
+      UNIQUE (tenant_id, derivation_version, input_fingerprint),
+      CHECK(observed_signal_count >= minimum_signal_count),
+      CHECK(observed_job_count >= minimum_job_count)
+    );
+CREATE TRIGGER prevent_learning_recommendation_update
+BEFORE UPDATE ON learning_recommendations
+BEGIN
+  SELECT RAISE(ABORT, 'learning recommendations are append-only');
+END;
+CREATE TRIGGER prevent_learning_recommendation_delete
+BEFORE DELETE ON learning_recommendations
+BEGIN
+  SELECT RAISE(ABORT, 'learning recommendations are append-only');
+END;
+CREATE TRIGGER validate_learning_recommendation_counts
+BEFORE INSERT ON learning_recommendations
+BEGIN
+  SELECT CASE WHEN (
+    SELECT COUNT(*)
+    FROM learning_recommendation_evidence
+    WHERE tenant_id = NEW.tenant_id
+      AND recommendation_id = NEW.recommendation_id
+      AND evidence_role = 'supporting'
+  ) != NEW.observed_signal_count
+  THEN RAISE(ABORT, 'learning recommendation supporting signal count mismatch') END;
+  SELECT CASE WHEN (
+    SELECT COUNT(*)
+    FROM learning_recommendation_jobs
+    WHERE tenant_id = NEW.tenant_id
+      AND recommendation_id = NEW.recommendation_id
+  ) != NEW.observed_job_count
+  THEN RAISE(ABORT, 'learning recommendation job count mismatch') END;
+END;
+CREATE TABLE learning_recommendation_evidence (
+      tenant_id         TEXT NOT NULL DEFAULT 'local',
+      recommendation_id TEXT NOT NULL,
+      signal_id         TEXT NOT NULL,
+      evidence_role     TEXT NOT NULL CHECK(evidence_role IN ('supporting', 'contradicting')),
+      source_kind       TEXT NOT NULL CHECK(source_kind = 'tailoring_feedback_signal'),
+      source_id         TEXT NOT NULL,
+      source_revision   INTEGER NOT NULL CHECK(source_revision > 0),
+      recorded_at       TEXT NOT NULL,
+      PRIMARY KEY (tenant_id, recommendation_id, signal_id),
+      FOREIGN KEY (tenant_id, recommendation_id)
+        REFERENCES learning_recommendations(tenant_id, recommendation_id)
+        ON DELETE RESTRICT
+        DEFERRABLE INITIALLY DEFERRED
+    );
+CREATE TRIGGER prevent_learning_recommendation_evidence_after_seal
+BEFORE INSERT ON learning_recommendation_evidence
+WHEN EXISTS (
+  SELECT 1 FROM learning_recommendations
+  WHERE tenant_id = NEW.tenant_id
+    AND recommendation_id = NEW.recommendation_id
+)
+BEGIN
+  SELECT RAISE(ABORT, 'learning recommendation evidence is sealed');
+END;
+CREATE TRIGGER prevent_learning_recommendation_evidence_update
+BEFORE UPDATE ON learning_recommendation_evidence
+BEGIN
+  SELECT RAISE(ABORT, 'learning recommendation evidence is append-only');
+END;
+CREATE TRIGGER prevent_learning_recommendation_evidence_delete
+BEFORE DELETE ON learning_recommendation_evidence
+BEGIN
+  SELECT RAISE(ABORT, 'learning recommendation evidence is append-only');
+END;
+CREATE TABLE learning_recommendation_jobs (
+      tenant_id         TEXT NOT NULL DEFAULT 'local',
+      recommendation_id TEXT NOT NULL,
+      job_id            TEXT NOT NULL CHECK(
+        length(job_id) = 36
+        AND substr(job_id, 9, 1) = '-'
+        AND substr(job_id, 14, 1) = '-'
+        AND substr(job_id, 19, 1) = '-'
+        AND substr(job_id, 24, 1) = '-'
+        AND replace(job_id, '-', '') NOT GLOB '*[^a-f0-9]*'
+      ),
+      PRIMARY KEY (tenant_id, recommendation_id, job_id),
+      FOREIGN KEY (tenant_id, recommendation_id)
+        REFERENCES learning_recommendations(tenant_id, recommendation_id)
+        ON DELETE RESTRICT
+        DEFERRABLE INITIALLY DEFERRED
+    );
+CREATE TRIGGER prevent_learning_recommendation_job_after_seal
+BEFORE INSERT ON learning_recommendation_jobs
+WHEN EXISTS (
+  SELECT 1 FROM learning_recommendations
+  WHERE tenant_id = NEW.tenant_id
+    AND recommendation_id = NEW.recommendation_id
+)
+BEGIN
+  SELECT RAISE(ABORT, 'learning recommendation jobs are sealed');
+END;
+CREATE TRIGGER prevent_learning_recommendation_job_update
+BEFORE UPDATE ON learning_recommendation_jobs
+BEGIN
+  SELECT RAISE(ABORT, 'learning recommendation jobs are append-only');
+END;
+CREATE TRIGGER prevent_learning_recommendation_job_delete
+BEFORE DELETE ON learning_recommendation_jobs
+BEGIN
+  SELECT RAISE(ABORT, 'learning recommendation jobs are append-only');
+END;
+CREATE TABLE learning_recommendation_tombstones (
+      tenant_id                    TEXT NOT NULL DEFAULT 'local',
+      tombstone_id                 TEXT NOT NULL,
+      recommendation_id            TEXT NOT NULL,
+      affected_signal_id           TEXT NOT NULL,
+      affected_source_revision     INTEGER NOT NULL CHECK(affected_source_revision > 0),
+      reason_code                  TEXT NOT NULL CHECK(reason_code IN (
+        'source_corrected',
+        'source_deleted',
+        'learning_cleared',
+        'derivation_superseded'
+      )),
+      derivation_version           INTEGER NOT NULL CHECK(derivation_version > 0),
+      tombstoned_at                TEXT NOT NULL,
+      rederived_at                 TEXT NOT NULL,
+      replacement_recommendation_id TEXT,
+      PRIMARY KEY (tenant_id, tombstone_id),
+      UNIQUE (
+        tenant_id,
+        recommendation_id,
+        affected_signal_id,
+        affected_source_revision,
+        reason_code,
+        derivation_version
+      ),
+      FOREIGN KEY (tenant_id, recommendation_id)
+        REFERENCES learning_recommendations(tenant_id, recommendation_id)
+        ON DELETE RESTRICT,
+      FOREIGN KEY (tenant_id, replacement_recommendation_id)
+        REFERENCES learning_recommendations(tenant_id, recommendation_id)
+        ON DELETE RESTRICT,
+      CHECK(
+        replacement_recommendation_id IS NULL
+        OR replacement_recommendation_id != recommendation_id
+      )
+    );
+CREATE TRIGGER prevent_learning_recommendation_tombstone_collision
+BEFORE INSERT ON learning_recommendation_tombstones
+WHEN EXISTS (
+  SELECT 1
+  FROM learning_recommendation_tombstones
+  WHERE tenant_id = NEW.tenant_id
+    AND (
+      tombstone_id = NEW.tombstone_id
+      OR (
+        recommendation_id = NEW.recommendation_id
+        AND affected_signal_id = NEW.affected_signal_id
+        AND affected_source_revision = NEW.affected_source_revision
+        AND reason_code = NEW.reason_code
+        AND derivation_version = NEW.derivation_version
+      )
+    )
+)
+BEGIN
+  SELECT RAISE(ABORT, 'learning recommendation tombstones are append-only');
+END;
+CREATE TRIGGER prevent_learning_recommendation_tombstone_update
+BEFORE UPDATE ON learning_recommendation_tombstones
+BEGIN
+  SELECT RAISE(ABORT, 'learning recommendation tombstones are append-only');
+END;
+CREATE TRIGGER prevent_learning_recommendation_tombstone_delete
+BEFORE DELETE ON learning_recommendation_tombstones
+BEGIN
+  SELECT RAISE(ABORT, 'learning recommendation tombstones are append-only');
+END;
 CREATE INDEX idx_application_email_evidence_job
             ON application_email_evidence(
                 tenant_id,
@@ -2162,6 +2370,24 @@ CREATE INDEX idx_tailoring_feedback_signal_reviews_signal
       ON tailoring_feedback_signal_reviews(tenant_id, signal_id, revision DESC);
 CREATE INDEX idx_tailoring_feedback_signal_reviews_decision
       ON tailoring_feedback_signal_reviews(tenant_id, decision, reviewed_at DESC);
+CREATE INDEX idx_learning_recommendations_tenant_derived
+      ON learning_recommendations(tenant_id, derived_at DESC, recommendation_id);
+CREATE INDEX idx_learning_recommendation_evidence_signal
+      ON learning_recommendation_evidence(tenant_id, signal_id, evidence_role);
+CREATE INDEX idx_learning_recommendation_jobs_job
+      ON learning_recommendation_jobs(tenant_id, job_id, recommendation_id);
+CREATE INDEX idx_learning_recommendation_tombstones_recommendation
+      ON learning_recommendation_tombstones(
+        tenant_id,
+        recommendation_id,
+        tombstoned_at DESC
+      );
+CREATE INDEX idx_learning_recommendation_tombstones_signal
+      ON learning_recommendation_tombstones(
+        tenant_id,
+        affected_signal_id,
+        tombstoned_at DESC
+      );
 CREATE INDEX idx_workflow_run_projections_tenant_started
         ON workflow_run_projections(tenant_id, started_at DESC, workflow_id DESC)
         ;

--- a/workers/automation/src/jobctrl/infrastructure/migrations/v6_to_v7_plan.py
+++ b/workers/automation/src/jobctrl/infrastructure/migrations/v6_to_v7_plan.py
@@ -234,13 +234,21 @@ def _table_plans() -> dict[str, TablePlan]:
         source_exists=False,
         source_required=False,
     )
-    # Structured tailoring reviews are append-only exact-v7 audit facts. The
-    # v6 source has only raw candidate signals, so no review row is inferred.
-    plans["tailoring_feedback_signal_reviews"] = TablePlan(
-        TableDisposition.DIRECT_COPY,
-        source_exists=False,
-        source_required=False,
-    )
+    # Reviewed tailoring facts and derived recommendation audit records exist
+    # only in exact v7. The v6 source cannot imply review, recommendation, job
+    # evidence, or tombstone rows, so all begin empty after cutover.
+    for table in (
+        "learning_recommendation_evidence",
+        "learning_recommendation_jobs",
+        "learning_recommendation_tombstones",
+        "learning_recommendations",
+        "tailoring_feedback_signal_reviews",
+    ):
+        plans[table] = TablePlan(
+            TableDisposition.DIRECT_COPY,
+            source_exists=False,
+            source_required=False,
+        )
     plans["discovery_run_projections"] = TablePlan(
         TableDisposition.RETIRED,
         target_exists=False,
@@ -397,6 +405,7 @@ _TARGET_JOB_ID_COLUMNS: Final = frozenset(
         ("job_duplicate_links", "surviving_job_id"),
         ("job_events", "job_id"),
         ("job_locators", "job_id"),
+        ("learning_recommendation_jobs", "job_id"),
         ("job_score_keywords", "job_id"),
         ("jobs", "job_id"),
     }
@@ -506,6 +515,10 @@ _DECLARED_COLUMNS: Final[Mapping[str, frozenset[str]]] = _column_manifest(
         "jobctrl_hidden_jobs": "job_url tenant_id job_id hidden_at reason unhidden_at",
         "jobs": "url title company salary description location site strategy discovered_at full_description application_url detail_scraped_at detail_error fit_score score_reasoning scored_at tailored_resume_path tailored_at tailor_attempts cover_letter_path cover_letter_at cover_attempts applied_at apply_status apply_error apply_attempts agent_id last_attempted_at apply_duration_ms apply_task_id verification_confidence tenant_id job_id",
         "llm_spend": "day input_tokens output_tokens estimated_usd",
+        "learning_recommendation_evidence": "tenant_id recommendation_id signal_id evidence_role source_kind source_id source_revision recorded_at",
+        "learning_recommendation_jobs": "tenant_id recommendation_id job_id",
+        "learning_recommendation_tombstones": "tenant_id tombstone_id recommendation_id affected_signal_id affected_source_revision reason_code derivation_version tombstoned_at rederived_at replacement_recommendation_id",
+        "learning_recommendations": "tenant_id recommendation_id derivation_version evaluation_fixture_version context policy_kind signal_kind rule_key rule_value allowlist_version status observed_signal_count observed_job_count minimum_signal_count minimum_job_count confidence_limit input_fingerprint derived_at",
         "manual_capture_queue": "tenant_id item_id originating_url source_id reason retry_context_json required_at status imported_at dismissed_at capture_mode captured_url content_sha256 content_length note future_manual_action_required job_key job_id",
         "operational_attempt_metrics": "metric_id tenant_id occurred_at stage source_id source_kind source_priority source_role adapter attempt_kind outcome failure_category is_operational_failure is_scrape_failure is_retryable run_id job_url job_id duration_ms total_count new_count existing_count observed_count duplicate_count error_class error_message metadata_json",
         "outreach_drafts": "tenant_id draft_id thread_id generation kind status body_text gate_results_json provenance_json created_at approved_at rejected_at reason",

--- a/workers/automation/tests/test_exact_v7_schema.py
+++ b/workers/automation/tests/test_exact_v7_schema.py
@@ -31,6 +31,10 @@ from jobctrl.infrastructure import runtime_identity
 _CROSS_RUNTIME_DURABLE_TABLES = {
     "discovery_execution_recoveries",
     "jobctrl_hidden_jobs",
+    "learning_recommendation_evidence",
+    "learning_recommendation_jobs",
+    "learning_recommendation_tombstones",
+    "learning_recommendations",
     "role_match_feedback_suggestions",
     "resume_review_comment_replies",
     "resume_review_comment_threads",
@@ -620,6 +624,334 @@ def test_tailoring_feedback_reviews_are_structured_append_only_facts(
         "idx_tailoring_feedback_signal_reviews_signal",
         "idx_tailoring_feedback_signal_reviews_decision",
     } <= indexes
+    close_connection(db_path)
+
+
+def test_learning_recommendation_storage_is_structured_append_only_and_private(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    conn = init_db(db_path)
+    conn.execute("PRAGMA foreign_keys = ON")
+    insert_recommendation = """
+        INSERT INTO learning_recommendations (
+            tenant_id, recommendation_id, derivation_version,
+            evaluation_fixture_version, context, policy_kind, signal_kind,
+            rule_key, rule_value, allowlist_version, status,
+            observed_signal_count, observed_job_count, minimum_signal_count,
+            minimum_job_count, confidence_limit, input_fingerprint, derived_at
+        ) VALUES (
+            'local', ?, 1, 1, 'materials', 'tailoring_rule',
+            'factual_correction', ?, ?, 1, 'pending', ?, ?, 3, 2,
+            'sample_gated_no_population_inference', ?, ?
+        )
+    """
+    for index in range(1, 4):
+        conn.execute(
+            """
+            INSERT INTO learning_recommendation_evidence (
+                tenant_id, recommendation_id, signal_id, evidence_role,
+                source_kind, source_id, source_revision, recorded_at
+            ) VALUES (
+                'local', 'recommendation-1', ?, 'supporting',
+                'tailoring_feedback_signal', ?, ?, ?
+            )
+            """,
+            (
+                f"signal-{index}",
+                f"source-signal-{index}",
+                index,
+                f"2026-08-01T00:00:0{index}Z",
+            ),
+        )
+    for job_id in (
+        "11111111-1111-4111-8111-111111111111",
+        "22222222-2222-4222-8222-222222222222",
+    ):
+        conn.execute(
+            """
+            INSERT INTO learning_recommendation_jobs (
+                tenant_id, recommendation_id, job_id
+            ) VALUES ('local', 'recommendation-1', ?)
+            """,
+            (job_id,),
+        )
+    conn.execute(
+        insert_recommendation,
+        (
+            "recommendation-1",
+            "fact_handling",
+            "require_source_match",
+            3,
+            2,
+            "a" * 64,
+            "2026-08-01T01:00:00Z",
+        ),
+    )
+    conn.execute(
+        """
+        INSERT INTO learning_recommendation_tombstones (
+            tenant_id, tombstone_id, recommendation_id, affected_signal_id,
+            affected_source_revision, reason_code, derivation_version,
+            tombstoned_at, rederived_at, replacement_recommendation_id
+        ) VALUES (
+            'local', 'tombstone-1', 'recommendation-1', 'signal-1', 1,
+            'source_corrected', 1, ?, ?, NULL
+        )
+        """,
+        ("2026-08-01T02:00:00Z", "2026-08-01T02:00:01Z"),
+    )
+    conn.commit()
+
+    with pytest.raises(sqlite3.IntegrityError, match="supporting signal count mismatch"):
+        conn.execute(
+            insert_recommendation,
+            (
+                "recommendation-missing-evidence",
+                "fact_handling",
+                "require_source_match",
+                3,
+                2,
+                "c" * 64,
+                "2026-08-01T03:00:00Z",
+            ),
+        )
+
+    for recommendation_id, rule_key, rule_value, signal_count, job_count, match in (
+        (
+            "recommendation-too-few-signals",
+            "fact_handling",
+            "require_source_match",
+            2,
+            2,
+            "observed_signal_count",
+        ),
+        (
+            "recommendation-one-job",
+            "fact_handling",
+            "require_source_match",
+            3,
+            1,
+            "observed_job_count",
+        ),
+        (
+            "recommendation-free-text",
+            "free text",
+            "require_source_match",
+            3,
+            2,
+            "rule_key",
+        ),
+        (
+            "recommendation-free-value",
+            "fact_handling",
+            "free text",
+            3,
+            2,
+            "rule_value",
+        ),
+    ):
+        conn.execute("SAVEPOINT invalid_recommendation")
+        for index in range(1, signal_count + 1):
+            conn.execute(
+                """
+                INSERT INTO learning_recommendation_evidence (
+                    tenant_id, recommendation_id, signal_id, evidence_role,
+                    source_kind, source_id, source_revision, recorded_at
+                ) VALUES (
+                    'local', ?, ?, 'supporting',
+                    'tailoring_feedback_signal', ?, ?, ?
+                )
+                """,
+                (
+                    recommendation_id,
+                    f"{recommendation_id}-signal-{index}",
+                    f"{recommendation_id}-source-{index}",
+                    index,
+                    f"2026-08-01T03:00:0{index}Z",
+                ),
+            )
+        for index in range(1, job_count + 1):
+            conn.execute(
+                """
+                INSERT INTO learning_recommendation_jobs (
+                    tenant_id, recommendation_id, job_id
+                ) VALUES ('local', ?, ?)
+                """,
+                (
+                    recommendation_id,
+                    f"00000000-0000-4000-8000-{index:012d}",
+                ),
+            )
+        with pytest.raises(sqlite3.IntegrityError, match=match):
+            conn.execute(
+                insert_recommendation,
+                (
+                    recommendation_id,
+                    rule_key,
+                    rule_value,
+                    signal_count,
+                    job_count,
+                    "b" * 64,
+                    "2026-08-01T03:00:00Z",
+                ),
+            )
+        conn.execute("ROLLBACK TO invalid_recommendation")
+        conn.execute("RELEASE invalid_recommendation")
+
+    with pytest.raises(sqlite3.IntegrityError, match="evidence is sealed"):
+        conn.execute(
+            """
+            INSERT INTO learning_recommendation_evidence (
+                tenant_id, recommendation_id, signal_id, evidence_role,
+                source_kind, source_id, source_revision, recorded_at
+            ) VALUES (
+                'local', 'recommendation-1', 'signal-late', 'supporting',
+                'tailoring_feedback_signal', 'source-late', 4, ?
+            )
+            """,
+            ("2026-08-01T03:00:00Z",),
+        )
+    with pytest.raises(sqlite3.IntegrityError, match="jobs are sealed"):
+        conn.execute(
+            """
+            INSERT INTO learning_recommendation_jobs (
+                tenant_id, recommendation_id, job_id
+            ) VALUES (
+                'local', 'recommendation-1',
+                '33333333-3333-4333-8333-333333333333'
+            )
+            """
+        )
+    with pytest.raises(sqlite3.IntegrityError):
+        conn.execute(
+            """
+            INSERT INTO learning_recommendation_jobs (
+                tenant_id, recommendation_id, job_id
+            ) VALUES (
+                'local', 'missing-recommendation',
+                'https://jobs.example/not-a-job-id'
+            )
+            """
+        )
+
+    conn.execute(
+        """
+        INSERT INTO learning_recommendation_evidence (
+            tenant_id, recommendation_id, signal_id, evidence_role,
+            source_kind, source_id, source_revision, recorded_at
+        ) VALUES (
+            'local', 'missing-recommendation', 'signal-orphan', 'supporting',
+            'tailoring_feedback_signal', 'source-orphan', 1, ?
+        )
+        """,
+        ("2026-08-01T03:00:00Z",),
+    )
+    with pytest.raises(sqlite3.IntegrityError):
+        conn.commit()
+    conn.rollback()
+    with pytest.raises(sqlite3.IntegrityError):
+        conn.execute(
+            """
+            INSERT INTO learning_recommendation_tombstones (
+                tenant_id, tombstone_id, recommendation_id, affected_signal_id,
+                affected_source_revision, reason_code, derivation_version,
+                tombstoned_at, rederived_at, replacement_recommendation_id
+            ) VALUES (
+                'local', 'tombstone-self', 'recommendation-1', 'signal-2', 2,
+                'source_deleted', 1, ?, ?, 'recommendation-1'
+            )
+            """,
+            ("2026-08-01T03:00:00Z", "2026-08-01T03:00:01Z"),
+        )
+
+    tombstone_before = tuple(
+        conn.execute(
+            """
+            SELECT tombstone_id, reason_code, tombstoned_at, rederived_at
+            FROM learning_recommendation_tombstones
+            WHERE tenant_id = 'local' AND tombstone_id = 'tombstone-1'
+            """
+        ).fetchone()
+    )
+    with pytest.raises(sqlite3.IntegrityError, match="append-only"):
+        conn.execute(
+            """
+            INSERT OR REPLACE INTO learning_recommendation_tombstones (
+                tenant_id, tombstone_id, recommendation_id, affected_signal_id,
+                affected_source_revision, reason_code, derivation_version,
+                tombstoned_at, rederived_at, replacement_recommendation_id
+            ) VALUES (
+                'local', 'tombstone-1', 'recommendation-1', 'signal-1', 1,
+                'source_deleted', 1, ?, ?, NULL
+            )
+            """,
+            ("2026-08-01T04:00:00Z", "2026-08-01T04:00:01Z"),
+        )
+    with pytest.raises(sqlite3.IntegrityError, match="append-only"):
+        conn.execute(
+            """
+            INSERT OR REPLACE INTO learning_recommendation_tombstones (
+                tenant_id, tombstone_id, recommendation_id, affected_signal_id,
+                affected_source_revision, reason_code, derivation_version,
+                tombstoned_at, rederived_at, replacement_recommendation_id
+            ) VALUES (
+                'local', 'tombstone-duplicate', 'recommendation-1', 'signal-1', 1,
+                'source_corrected', 1, ?, ?, NULL
+            )
+            """,
+            ("2026-08-01T04:00:00Z", "2026-08-01T04:00:01Z"),
+        )
+    assert tuple(
+        conn.execute(
+            """
+            SELECT tombstone_id, reason_code, tombstoned_at, rederived_at
+            FROM learning_recommendation_tombstones
+            WHERE tenant_id = 'local' AND tombstone_id = 'tombstone-1'
+            """
+        ).fetchone()
+    ) == tombstone_before
+
+    append_only_mutations = (
+        "UPDATE learning_recommendations SET derived_at = derived_at WHERE recommendation_id = 'recommendation-1'",
+        "DELETE FROM learning_recommendation_evidence WHERE recommendation_id = 'recommendation-1'",
+        "UPDATE learning_recommendation_jobs SET job_id = job_id WHERE recommendation_id = 'recommendation-1'",
+        "DELETE FROM learning_recommendation_tombstones WHERE tombstone_id = 'tombstone-1'",
+    )
+    for statement in append_only_mutations:
+        with pytest.raises(sqlite3.IntegrityError, match="append-only"):
+            conn.execute(statement)
+
+    forbidden_fragments = {
+        "artifact",
+        "body",
+        "description",
+        "mail",
+        "note",
+        "path",
+        "prompt",
+        "resume",
+        "summary",
+        "text",
+    }
+    for table in (
+        "learning_recommendations",
+        "learning_recommendation_evidence",
+        "learning_recommendation_jobs",
+        "learning_recommendation_tombstones",
+    ):
+        columns = {
+            str(column[1])
+            for column in conn.execute(f"PRAGMA table_info({table})").fetchall()
+        }
+        assert not {
+            column
+            for column in columns
+            if column in forbidden_fragments
+            or any(column.endswith(f"_{fragment}") for fragment in forbidden_fragments)
+        }
+
+    assert conn.execute("PRAGMA foreign_key_check").fetchone() is None
     close_connection(db_path)
 
 

--- a/workers/automation/tests/test_v6_to_v7_plan.py
+++ b/workers/automation/tests/test_v6_to_v7_plan.py
@@ -167,6 +167,22 @@ def test_identity_locator_and_sequence_roles_are_not_inferred_from_names() -> No
         classify_column("tailoring_feedback_signal_reviews", "signal_id", "target")
         is ColumnRole.PRESERVE
     )
+    for table in (
+        "learning_recommendation_evidence",
+        "learning_recommendation_jobs",
+        "learning_recommendation_tombstones",
+        "learning_recommendations",
+    ):
+        assert not table_plan(table).source_exists
+        assert table_plan(table).disposition is TableDisposition.DIRECT_COPY
+    assert (
+        classify_column("learning_recommendation_jobs", "job_id", "target")
+        is ColumnRole.JOB_ID
+    )
+    assert (
+        classify_column("learning_recommendation_evidence", "signal_id", "target")
+        is ColumnRole.PRESERVE
+    )
     assert (
         table_plan("dashboard_projections").disposition
         is TableDisposition.STRUCTURED_REWRITE


### PR DESCRIPTION
## Summary

- add exact-v7 append-only tables for pending learning recommendations, structured evidence, canonical job references, and re-derivation tombstones
- seal evidence and job associations before a recommendation record validates its threshold counts
- preserve audit references across source/job deletion without admitting URL-shaped JobIds or raw content columns
- classify every new relation as target-only so v6 migration never infers recommendations or tombstones

## Why

Deterministic recommendations need durable provenance and re-derivation history before an API can expose them. This schema-only child establishes those data-integrity and privacy boundaries without runtime DDL, backfilled recommendations, policy mutation, or a compatibility path.

## Validation

- `PYTHONPATH=workers/automation/src /Users/eloibarti/Github/JobHunter/workers/automation/.venv/bin/pytest workers/automation/tests/test_exact_v7_schema.py workers/automation/tests/test_v6_to_v7_plan.py workers/automation/tests/test_v6_to_v7_candidate.py workers/automation/tests/test_schema_v7_packaging.py`
- `/Users/eloibarti/.nvm/versions/node/v22.21.1/bin/pnpm --filter @jobctrl/api exec vitest run test/schema-version-guard.test.ts`
- `/Users/eloibarti/.nvm/versions/node/v22.21.1/bin/pnpm --filter @jobctrl/api check`
- `PYTHONPATH=workers/automation/src /Users/eloibarti/Github/JobHunter/workers/automation/.venv/bin/ruff check workers/automation/src/jobctrl/infrastructure/migrations/schema_manifest.py workers/automation/src/jobctrl/infrastructure/migrations/v6_to_v7_plan.py workers/automation/tests/test_exact_v7_schema.py workers/automation/tests/test_v6_to_v7_plan.py`
- `git diff --check`

Canonical product documentation remains deferred to the final PR in the approved unreleased stack.

Stacked on #676.
