### PR TITLE
feat(storage): preserve learning evidence jobs

### DIFF
--- a/apps/api/src/schema-manifest.ts
+++ b/apps/api/src/schema-manifest.ts
@@ -14,9 +14,9 @@ export type SchemaManifest = {
 // a different schema.
 export const EXACT_V7_SCHEMA_MANIFEST: SchemaManifest = {
   version: 7,
-  objectCount: 226,
-  tableCount: 107,
-  fingerprint: "b80552dd38f1bdfcd75b95c09054f80a1169c609610ce4975edb837dd76808c8",
+  objectCount: 231,
+  tableCount: 108,
+  fingerprint: "8b2179d91d202bf43c5463ceb7f34313a0c75f296b20335ee4364cfa8d2e78bd",
 };
 
 type SqliteMasterRow = [type: string, name: string, tableName: string, sql: string];

--- a/apps/api/test/schema-version-guard.test.ts
+++ b/apps/api/test/schema-version-guard.test.ts
@@ -142,14 +142,14 @@ describe("schema version guard at DB open", () => {
     const pythonManifest = fs.readFileSync(pythonManifestPath, "utf8");
 
     expect(pythonManifest).toContain("version=7,");
-    expect(pythonManifest).toContain("object_count=226,");
-    expect(pythonManifest).toContain("table_count=107,");
+    expect(pythonManifest).toContain("object_count=231,");
+    expect(pythonManifest).toContain("table_count=108,");
     expect(pythonManifest).toContain(`fingerprint=\"${EXACT_V7_SCHEMA_MANIFEST.fingerprint}\",`);
     expect(EXACT_V7_SCHEMA_MANIFEST).toEqual({
       version: SUPPORTED_SCHEMA_VERSION,
-      objectCount: 226,
-      tableCount: 107,
-      fingerprint: "b80552dd38f1bdfcd75b95c09054f80a1169c609610ce4975edb837dd76808c8",
+      objectCount: 231,
+      tableCount: 108,
+      fingerprint: "8b2179d91d202bf43c5463ceb7f34313a0c75f296b20335ee4364cfa8d2e78bd",
     });
   });
 });

--- a/workers/automation/src/jobctrl/infrastructure/migrations/schema_manifest.py
+++ b/workers/automation/src/jobctrl/infrastructure/migrations/schema_manifest.py
@@ -23,9 +23,9 @@ class SchemaManifest:
 # semantically meaningful and must never normalize to the same fingerprint.
 EXACT_V7_MANIFEST = SchemaManifest(
     version=7,
-    object_count=226,
-    table_count=107,
-    fingerprint="b80552dd38f1bdfcd75b95c09054f80a1169c609610ce4975edb837dd76808c8",
+    object_count=231,
+    table_count=108,
+    fingerprint="8b2179d91d202bf43c5463ceb7f34313a0c75f296b20335ee4364cfa8d2e78bd",
 )
 
 

--- a/workers/automation/src/jobctrl/infrastructure/migrations/schema_v7.sql
+++ b/workers/automation/src/jobctrl/infrastructure/migrations/schema_v7.sql
@@ -1869,6 +1869,55 @@ BEGIN
       AND recommendation_id = NEW.recommendation_id
   ) != NEW.observed_job_count
   THEN RAISE(ABORT, 'learning recommendation job count mismatch') END;
+  SELECT CASE WHEN EXISTS (
+    SELECT 1
+    FROM learning_recommendation_evidence AS evidence
+    WHERE evidence.tenant_id = NEW.tenant_id
+      AND evidence.recommendation_id = NEW.recommendation_id
+      AND NOT EXISTS (
+        SELECT 1
+        FROM learning_recommendation_evidence_jobs AS evidence_job
+        WHERE evidence_job.tenant_id = evidence.tenant_id
+          AND evidence_job.recommendation_id = evidence.recommendation_id
+          AND evidence_job.signal_id = evidence.signal_id
+      )
+  ) THEN RAISE(ABORT, 'learning recommendation evidence job provenance missing') END;
+  SELECT CASE WHEN EXISTS (
+    SELECT 1
+    FROM learning_recommendation_evidence AS evidence
+    JOIN learning_recommendation_evidence_jobs AS evidence_job
+      ON evidence_job.tenant_id = evidence.tenant_id
+     AND evidence_job.recommendation_id = evidence.recommendation_id
+     AND evidence_job.signal_id = evidence.signal_id
+    WHERE evidence.tenant_id = NEW.tenant_id
+      AND evidence.recommendation_id = NEW.recommendation_id
+      AND evidence.evidence_role = 'supporting'
+      AND NOT EXISTS (
+        SELECT 1
+        FROM learning_recommendation_jobs AS recommendation_job
+        WHERE recommendation_job.tenant_id = evidence_job.tenant_id
+          AND recommendation_job.recommendation_id = evidence_job.recommendation_id
+          AND recommendation_job.job_id = evidence_job.job_id
+      )
+  ) THEN RAISE(ABORT, 'learning recommendation supporting evidence job mismatch') END;
+  SELECT CASE WHEN EXISTS (
+    SELECT 1
+    FROM learning_recommendation_jobs AS recommendation_job
+    WHERE recommendation_job.tenant_id = NEW.tenant_id
+      AND recommendation_job.recommendation_id = NEW.recommendation_id
+      AND NOT EXISTS (
+        SELECT 1
+        FROM learning_recommendation_evidence_jobs AS evidence_job
+        JOIN learning_recommendation_evidence AS evidence
+          ON evidence.tenant_id = evidence_job.tenant_id
+         AND evidence.recommendation_id = evidence_job.recommendation_id
+         AND evidence.signal_id = evidence_job.signal_id
+        WHERE evidence_job.tenant_id = recommendation_job.tenant_id
+          AND evidence_job.recommendation_id = recommendation_job.recommendation_id
+          AND evidence_job.job_id = recommendation_job.job_id
+          AND evidence.evidence_role = 'supporting'
+      )
+  ) THEN RAISE(ABORT, 'learning recommendation job lacks supporting evidence') END;
 END;
 CREATE TABLE learning_recommendation_evidence (
       tenant_id         TEXT NOT NULL DEFAULT 'local',
@@ -1904,6 +1953,48 @@ CREATE TRIGGER prevent_learning_recommendation_evidence_delete
 BEFORE DELETE ON learning_recommendation_evidence
 BEGIN
   SELECT RAISE(ABORT, 'learning recommendation evidence is append-only');
+END;
+CREATE TABLE learning_recommendation_evidence_jobs (
+      tenant_id         TEXT NOT NULL DEFAULT 'local',
+      recommendation_id TEXT NOT NULL,
+      signal_id         TEXT NOT NULL,
+      job_id            TEXT NOT NULL CHECK(
+        length(job_id) = 36
+        AND substr(job_id, 9, 1) = '-'
+        AND substr(job_id, 14, 1) = '-'
+        AND substr(job_id, 19, 1) = '-'
+        AND substr(job_id, 24, 1) = '-'
+        AND replace(job_id, '-', '') NOT GLOB '*[^a-f0-9]*'
+      ),
+      PRIMARY KEY (tenant_id, recommendation_id, signal_id, job_id),
+      FOREIGN KEY (tenant_id, recommendation_id, signal_id)
+        REFERENCES learning_recommendation_evidence(
+          tenant_id,
+          recommendation_id,
+          signal_id
+        )
+        ON DELETE RESTRICT
+        DEFERRABLE INITIALLY DEFERRED
+    );
+CREATE TRIGGER prevent_learning_recommendation_evidence_job_after_seal
+BEFORE INSERT ON learning_recommendation_evidence_jobs
+WHEN EXISTS (
+  SELECT 1 FROM learning_recommendations
+  WHERE tenant_id = NEW.tenant_id
+    AND recommendation_id = NEW.recommendation_id
+)
+BEGIN
+  SELECT RAISE(ABORT, 'learning recommendation evidence jobs are sealed');
+END;
+CREATE TRIGGER prevent_learning_recommendation_evidence_job_update
+BEFORE UPDATE ON learning_recommendation_evidence_jobs
+BEGIN
+  SELECT RAISE(ABORT, 'learning recommendation evidence jobs are append-only');
+END;
+CREATE TRIGGER prevent_learning_recommendation_evidence_job_delete
+BEFORE DELETE ON learning_recommendation_evidence_jobs
+BEGIN
+  SELECT RAISE(ABORT, 'learning recommendation evidence jobs are append-only');
 END;
 CREATE TABLE learning_recommendation_jobs (
       tenant_id         TEXT NOT NULL DEFAULT 'local',
@@ -2374,6 +2465,13 @@ CREATE INDEX idx_learning_recommendations_tenant_derived
       ON learning_recommendations(tenant_id, derived_at DESC, recommendation_id);
 CREATE INDEX idx_learning_recommendation_evidence_signal
       ON learning_recommendation_evidence(tenant_id, signal_id, evidence_role);
+CREATE INDEX idx_learning_recommendation_evidence_jobs_job
+      ON learning_recommendation_evidence_jobs(
+        tenant_id,
+        job_id,
+        recommendation_id,
+        signal_id
+      );
 CREATE INDEX idx_learning_recommendation_jobs_job
       ON learning_recommendation_jobs(tenant_id, job_id, recommendation_id);
 CREATE INDEX idx_learning_recommendation_tombstones_recommendation

--- a/workers/automation/src/jobctrl/infrastructure/migrations/v6_to_v7_plan.py
+++ b/workers/automation/src/jobctrl/infrastructure/migrations/v6_to_v7_plan.py
@@ -239,6 +239,7 @@ def _table_plans() -> dict[str, TablePlan]:
     # evidence, or tombstone rows, so all begin empty after cutover.
     for table in (
         "learning_recommendation_evidence",
+        "learning_recommendation_evidence_jobs",
         "learning_recommendation_jobs",
         "learning_recommendation_tombstones",
         "learning_recommendations",
@@ -405,6 +406,7 @@ _TARGET_JOB_ID_COLUMNS: Final = frozenset(
         ("job_duplicate_links", "surviving_job_id"),
         ("job_events", "job_id"),
         ("job_locators", "job_id"),
+        ("learning_recommendation_evidence_jobs", "job_id"),
         ("learning_recommendation_jobs", "job_id"),
         ("job_score_keywords", "job_id"),
         ("jobs", "job_id"),
@@ -516,6 +518,7 @@ _DECLARED_COLUMNS: Final[Mapping[str, frozenset[str]]] = _column_manifest(
         "jobs": "url title company salary description location site strategy discovered_at full_description application_url detail_scraped_at detail_error fit_score score_reasoning scored_at tailored_resume_path tailored_at tailor_attempts cover_letter_path cover_letter_at cover_attempts applied_at apply_status apply_error apply_attempts agent_id last_attempted_at apply_duration_ms apply_task_id verification_confidence tenant_id job_id",
         "llm_spend": "day input_tokens output_tokens estimated_usd",
         "learning_recommendation_evidence": "tenant_id recommendation_id signal_id evidence_role source_kind source_id source_revision recorded_at",
+        "learning_recommendation_evidence_jobs": "tenant_id recommendation_id signal_id job_id",
         "learning_recommendation_jobs": "tenant_id recommendation_id job_id",
         "learning_recommendation_tombstones": "tenant_id tombstone_id recommendation_id affected_signal_id affected_source_revision reason_code derivation_version tombstoned_at rederived_at replacement_recommendation_id",
         "learning_recommendations": "tenant_id recommendation_id derivation_version evaluation_fixture_version context policy_kind signal_kind rule_key rule_value allowlist_version status observed_signal_count observed_job_count minimum_signal_count minimum_job_count confidence_limit input_fingerprint derived_at",

--- a/workers/automation/tests/test_exact_v7_schema.py
+++ b/workers/automation/tests/test_exact_v7_schema.py
@@ -32,6 +32,7 @@ _CROSS_RUNTIME_DURABLE_TABLES = {
     "discovery_execution_recoveries",
     "jobctrl_hidden_jobs",
     "learning_recommendation_evidence",
+    "learning_recommendation_evidence_jobs",
     "learning_recommendation_jobs",
     "learning_recommendation_tombstones",
     "learning_recommendations",
@@ -646,6 +647,10 @@ def test_learning_recommendation_storage_is_structured_append_only_and_private(
             'sample_gated_no_population_inference', ?, ?
         )
     """
+    job_ids = (
+        "11111111-1111-4111-8111-111111111111",
+        "22222222-2222-4222-8222-222222222222",
+    )
     for index in range(1, 4):
         conn.execute(
             """
@@ -664,10 +669,15 @@ def test_learning_recommendation_storage_is_structured_append_only_and_private(
                 f"2026-08-01T00:00:0{index}Z",
             ),
         )
-    for job_id in (
-        "11111111-1111-4111-8111-111111111111",
-        "22222222-2222-4222-8222-222222222222",
-    ):
+        conn.execute(
+            """
+            INSERT INTO learning_recommendation_evidence_jobs (
+                tenant_id, recommendation_id, signal_id, job_id
+            ) VALUES ('local', 'recommendation-1', ?, ?)
+            """,
+            (f"signal-{index}", job_ids[min(index - 1, 1)]),
+        )
+    for job_id in job_ids:
         conn.execute(
             """
             INSERT INTO learning_recommendation_jobs (
@@ -676,6 +686,28 @@ def test_learning_recommendation_storage_is_structured_append_only_and_private(
             """,
             (job_id,),
         )
+    conn.execute(
+        """
+        INSERT INTO learning_recommendation_evidence (
+            tenant_id, recommendation_id, signal_id, evidence_role,
+            source_kind, source_id, source_revision, recorded_at
+        ) VALUES (
+            'local', 'recommendation-1', 'contradiction-1', 'contradicting',
+            'tailoring_feedback_signal', 'source-contradiction-1', 4, ?
+        )
+        """,
+        ("2026-08-01T00:00:04Z",),
+    )
+    conn.execute(
+        """
+        INSERT INTO learning_recommendation_evidence_jobs (
+            tenant_id, recommendation_id, signal_id, job_id
+        ) VALUES (
+            'local', 'recommendation-1', 'contradiction-1',
+            '33333333-3333-4333-8333-333333333333'
+        )
+        """
+    )
     conn.execute(
         insert_recommendation,
         (
@@ -702,6 +734,26 @@ def test_learning_recommendation_storage_is_structured_append_only_and_private(
         ("2026-08-01T02:00:00Z", "2026-08-01T02:00:01Z"),
     )
     conn.commit()
+    assert tuple(
+        conn.execute(
+            """
+            SELECT evidence.evidence_role, evidence_job.signal_id,
+                   evidence_job.job_id
+            FROM learning_recommendation_evidence_jobs AS evidence_job
+            JOIN learning_recommendation_evidence AS evidence
+              ON evidence.tenant_id = evidence_job.tenant_id
+             AND evidence.recommendation_id = evidence_job.recommendation_id
+             AND evidence.signal_id = evidence_job.signal_id
+            WHERE evidence_job.tenant_id = 'local'
+              AND evidence_job.recommendation_id = 'recommendation-1'
+              AND evidence_job.signal_id = 'contradiction-1'
+            """
+        ).fetchone()
+    ) == (
+        "contradicting",
+        "contradiction-1",
+        "33333333-3333-4333-8333-333333333333",
+    )
 
     with pytest.raises(sqlite3.IntegrityError, match="supporting signal count mismatch"):
         conn.execute(
@@ -771,6 +823,18 @@ def test_learning_recommendation_storage_is_structured_append_only_and_private(
                     f"2026-08-01T03:00:0{index}Z",
                 ),
             )
+            conn.execute(
+                """
+                INSERT INTO learning_recommendation_evidence_jobs (
+                    tenant_id, recommendation_id, signal_id, job_id
+                ) VALUES ('local', ?, ?, ?)
+                """,
+                (
+                    recommendation_id,
+                    f"{recommendation_id}-signal-{index}",
+                    f"00000000-0000-4000-8000-{min(index, job_count):012d}",
+                ),
+            )
         for index in range(1, job_count + 1):
             conn.execute(
                 """
@@ -823,6 +887,17 @@ def test_learning_recommendation_storage_is_structured_append_only_and_private(
             )
             """
         )
+    with pytest.raises(sqlite3.IntegrityError, match="evidence jobs are sealed"):
+        conn.execute(
+            """
+            INSERT INTO learning_recommendation_evidence_jobs (
+                tenant_id, recommendation_id, signal_id, job_id
+            ) VALUES (
+                'local', 'recommendation-1', 'signal-1',
+                '33333333-3333-4333-8333-333333333333'
+            )
+            """
+        )
     with pytest.raises(sqlite3.IntegrityError):
         conn.execute(
             """
@@ -830,6 +905,17 @@ def test_learning_recommendation_storage_is_structured_append_only_and_private(
                 tenant_id, recommendation_id, job_id
             ) VALUES (
                 'local', 'missing-recommendation',
+                'https://jobs.example/not-a-job-id'
+            )
+            """
+        )
+    with pytest.raises(sqlite3.IntegrityError):
+        conn.execute(
+            """
+            INSERT INTO learning_recommendation_evidence_jobs (
+                tenant_id, recommendation_id, signal_id, job_id
+            ) VALUES (
+                'local', 'missing-recommendation', 'signal-orphan',
                 'https://jobs.example/not-a-job-id'
             )
             """
@@ -915,6 +1001,7 @@ def test_learning_recommendation_storage_is_structured_append_only_and_private(
     append_only_mutations = (
         "UPDATE learning_recommendations SET derived_at = derived_at WHERE recommendation_id = 'recommendation-1'",
         "DELETE FROM learning_recommendation_evidence WHERE recommendation_id = 'recommendation-1'",
+        "UPDATE learning_recommendation_evidence_jobs SET job_id = job_id WHERE recommendation_id = 'recommendation-1'",
         "UPDATE learning_recommendation_jobs SET job_id = job_id WHERE recommendation_id = 'recommendation-1'",
         "DELETE FROM learning_recommendation_tombstones WHERE tombstone_id = 'tombstone-1'",
     )
@@ -937,6 +1024,7 @@ def test_learning_recommendation_storage_is_structured_append_only_and_private(
     for table in (
         "learning_recommendations",
         "learning_recommendation_evidence",
+        "learning_recommendation_evidence_jobs",
         "learning_recommendation_jobs",
         "learning_recommendation_tombstones",
     ):
@@ -951,6 +1039,105 @@ def test_learning_recommendation_storage_is_structured_append_only_and_private(
             or any(column.endswith(f"_{fragment}") for fragment in forbidden_fragments)
         }
 
+    assert conn.execute("PRAGMA foreign_key_check").fetchone() is None
+    close_connection(db_path)
+
+
+def test_learning_recommendation_job_provenance_constraints_fail_closed(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    conn = init_db(db_path)
+    insert_recommendation = """
+        INSERT INTO learning_recommendations (
+            tenant_id, recommendation_id, derivation_version,
+            evaluation_fixture_version, context, policy_kind, signal_kind,
+            rule_key, rule_value, allowlist_version, status,
+            observed_signal_count, observed_job_count, minimum_signal_count,
+            minimum_job_count, confidence_limit, input_fingerprint, derived_at
+        ) VALUES (
+            'local', ?, 1, 1, 'materials', 'tailoring_rule',
+            'factual_correction', 'fact_handling', 'require_source_match',
+            1, 'pending', 3, 2, 3, 2,
+            'sample_gated_no_population_inference', ?, ?
+        )
+    """
+    job_ids = (
+        "11111111-1111-4111-8111-111111111111",
+        "22222222-2222-4222-8222-222222222222",
+        "33333333-3333-4333-8333-333333333333",
+    )
+    cases = (
+        (
+            "missing-provenance",
+            (job_ids[0], job_ids[1], None),
+            "evidence job provenance missing",
+        ),
+        (
+            "supporting-mismatch",
+            (job_ids[0], job_ids[1], job_ids[2]),
+            "supporting evidence job mismatch",
+        ),
+        (
+            "unsupported-threshold-job",
+            (job_ids[0], job_ids[0], job_ids[0]),
+            "job lacks supporting evidence",
+        ),
+    )
+    for recommendation_id, evidence_job_ids, match in cases:
+        conn.execute("SAVEPOINT invalid_evidence_jobs")
+        for index in range(1, 4):
+            signal_id = f"{recommendation_id}-signal-{index}"
+            conn.execute(
+                """
+                INSERT INTO learning_recommendation_evidence (
+                    tenant_id, recommendation_id, signal_id, evidence_role,
+                    source_kind, source_id, source_revision, recorded_at
+                ) VALUES (
+                    'local', ?, ?, 'supporting',
+                    'tailoring_feedback_signal', ?, ?, ?
+                )
+                """,
+                (
+                    recommendation_id,
+                    signal_id,
+                    f"{recommendation_id}-source-{index}",
+                    index,
+                    f"2026-08-01T05:00:0{index}Z",
+                ),
+            )
+            evidence_job_id = evidence_job_ids[index - 1]
+            if evidence_job_id is not None:
+                conn.execute(
+                    """
+                    INSERT INTO learning_recommendation_evidence_jobs (
+                        tenant_id, recommendation_id, signal_id, job_id
+                    ) VALUES ('local', ?, ?, ?)
+                    """,
+                    (recommendation_id, signal_id, evidence_job_id),
+                )
+        for job_id in job_ids[:2]:
+            conn.execute(
+                """
+                INSERT INTO learning_recommendation_jobs (
+                    tenant_id, recommendation_id, job_id
+                ) VALUES ('local', ?, ?)
+                """,
+                (recommendation_id, job_id),
+            )
+        with pytest.raises(sqlite3.IntegrityError, match=match):
+            conn.execute(
+                insert_recommendation,
+                (
+                    recommendation_id,
+                    str(len(recommendation_id)).zfill(64),
+                    "2026-08-01T05:01:00Z",
+                ),
+            )
+        conn.execute("ROLLBACK TO invalid_evidence_jobs")
+        conn.execute("RELEASE invalid_evidence_jobs")
+
+    assert conn.execute("SELECT COUNT(*) FROM learning_recommendations").fetchone()[0] == 0
     assert conn.execute("PRAGMA foreign_key_check").fetchone() is None
     close_connection(db_path)
 

--- a/workers/automation/tests/test_v6_to_v7_plan.py
+++ b/workers/automation/tests/test_v6_to_v7_plan.py
@@ -169,6 +169,7 @@ def test_identity_locator_and_sequence_roles_are_not_inferred_from_names() -> No
     )
     for table in (
         "learning_recommendation_evidence",
+        "learning_recommendation_evidence_jobs",
         "learning_recommendation_jobs",
         "learning_recommendation_tombstones",
         "learning_recommendations",
@@ -177,6 +178,12 @@ def test_identity_locator_and_sequence_roles_are_not_inferred_from_names() -> No
         assert table_plan(table).disposition is TableDisposition.DIRECT_COPY
     assert (
         classify_column("learning_recommendation_jobs", "job_id", "target")
+        is ColumnRole.JOB_ID
+    )
+    assert (
+        classify_column(
+            "learning_recommendation_evidence_jobs", "job_id", "target"
+        )
         is ColumnRole.JOB_ID
     )
     assert (


### PR DESCRIPTION
## Summary

- add an immutable tenant-scoped evidence-to-JobId association for learning recommendations
- preserve canonical job provenance for both supporting and contradicting evidence without counting contradiction jobs toward the support threshold
- seal evidence job associations with the recommendation and enforce that supporting evidence exactly accounts for its threshold job set
- classify the relation as empty exact-v7 target-only state so v6 migration never infers learning data

## Why

Recommendation evidence already preserves source ID and revision, but contradiction provenance also needs its canonical job association to prevent later replay from re-attributing the same source to a different job. This schema-only child closes that audit-integrity boundary before the executable writer is published.

## Validation

- `PYTHONPATH=workers/automation/src /Users/eloibarti/Github/JobHunter/workers/automation/.venv/bin/pytest workers/automation/tests/test_sqlite_learning_recommendations.py workers/automation/tests/test_learning_recommendations.py workers/automation/tests/test_feedback_signal_reader.py workers/automation/tests/test_exact_v7_schema.py::test_learning_recommendation_storage_is_structured_append_only_and_private -q`
- `/Users/eloibarti/Github/JobHunter/workers/automation/.venv/bin/ruff check workers/automation/src/jobctrl/domain/ports/learning.py workers/automation/src/jobctrl/infrastructure/learning/__init__.py workers/automation/src/jobctrl/infrastructure/learning/sqlite_repository.py workers/automation/tests/test_sqlite_learning_recommendations.py`
- `git diff --check`

Canonical product documentation remains deferred to the final PR in the approved unreleased stack. Runtime persistence and re-derivation remain separate child PRs.

Stacked on #677.
