### PR TITLE
feat(learning): persist pending recommendations

### DIFF
--- a/workers/automation/src/jobctrl/domain/operations/learning.py
+++ b/workers/automation/src/jobctrl/domain/operations/learning.py
@@ -66,6 +66,7 @@ class TailoringRecommendationScope:
 class RecommendationEvidenceRef:
     """Non-sensitive provenance copied from an accepted signal value."""
 
+    tenant_id: TenantId
     signal_id: str
     source_kind: Literal["tailoring_feedback_signal"]
     source_id: str
@@ -74,6 +75,8 @@ class RecommendationEvidenceRef:
     recorded_at: str
 
     def __post_init__(self) -> None:
+        if not str(self.tenant_id).strip():
+            raise ValueError("tenant_id must not be empty")
         for name, value in (
             ("signal_id", self.signal_id),
             ("source_id", self.source_id),
@@ -157,6 +160,10 @@ class LearningRecommendation:
             self.supporting_signal_ids
         ):
             raise ValueError("recommendation evidence must match supporting signal IDs")
+        if any(
+            evidence.tenant_id != self.scope.tenant_id for evidence in self.evidence
+        ):
+            raise ValueError("recommendation evidence must belong to its tenant")
         if len(set(self.job_ids)) != len(self.job_ids):
             raise ValueError("recommendation job IDs must be unique")
         if self.observed_job_count != len(self.job_ids):
@@ -238,6 +245,7 @@ def derive_tailoring_recommendations(
 
         evidence = tuple(
             RecommendationEvidenceRef(
+                tenant_id=signal.tenant_id,
                 signal_id=signal.signal_id,
                 source_kind=signal.source_kind,
                 source_id=signal.source_id,

--- a/workers/automation/src/jobctrl/domain/ports/learning.py
+++ b/workers/automation/src/jobctrl/domain/ports/learning.py
@@ -1,0 +1,27 @@
+"""Persistence port for pending learning recommendations."""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from jobctrl.domain.operations.learning import (
+    LearningRecommendation,
+    RecommendationEvidenceRef,
+)
+
+
+class LearningRecommendationWriter(Protocol):
+    """Append deterministic pending recommendations without activating policy."""
+
+    def append_pending(
+        self,
+        recommendation: LearningRecommendation,
+        *,
+        contradicting_evidence: tuple[RecommendationEvidenceRef, ...] = (),
+        derived_at: str,
+    ) -> bool:
+        """Persist one immutable recommendation, returning whether it was new."""
+        ...
+
+
+__all__ = ["LearningRecommendationWriter"]

--- a/workers/automation/src/jobctrl/infrastructure/learning/__init__.py
+++ b/workers/automation/src/jobctrl/infrastructure/learning/__init__.py
@@ -1,0 +1,11 @@
+"""Infrastructure adapters for privacy-safe learning recommendations."""
+
+from jobctrl.infrastructure.learning.sqlite_repository import (
+    LearningRecommendationConflict,
+    SqliteLearningRecommendationRepository,
+)
+
+__all__ = [
+    "LearningRecommendationConflict",
+    "SqliteLearningRecommendationRepository",
+]

--- a/workers/automation/src/jobctrl/infrastructure/learning/sqlite_repository.py
+++ b/workers/automation/src/jobctrl/infrastructure/learning/sqlite_repository.py
@@ -1,0 +1,359 @@
+"""Exact-v7 SQLite persistence for pending learning recommendations."""
+
+from __future__ import annotations
+
+from datetime import datetime
+import sqlite3
+
+from jobctrl.domain.operations.learning import (
+    LearningRecommendation,
+    RecommendationEvidenceRef,
+)
+
+
+_SAVEPOINT = "append_learning_recommendation"
+_RECOMMENDATION_PREFIX = "learning-recommendation:"
+
+
+class LearningRecommendationConflict(RuntimeError):
+    """Raised when persisted audit facts disagree with a deterministic identity."""
+
+
+class SqliteLearningRecommendationRepository:
+    """Append immutable pending recommendations to the exact-v7 ledger."""
+
+    def __init__(self, conn: sqlite3.Connection) -> None:
+        self._conn = conn
+
+    def append_pending(
+        self,
+        recommendation: LearningRecommendation,
+        *,
+        contradicting_evidence: tuple[RecommendationEvidenceRef, ...] = (),
+        derived_at: str,
+    ) -> bool:
+        """Atomically append one proposal and its privacy-safe provenance.
+
+        Repeating the same deterministic recommendation is a no-op. A reused
+        identity with different facts fails closed instead of overwriting the
+        append-only audit record. This method never writes effective policy.
+        """
+
+        derived_at = _structured_timestamp(derived_at, name="derived_at")
+        contradiction_by_id = {
+            evidence.signal_id: evidence for evidence in contradicting_evidence
+        }
+        if len(contradiction_by_id) != len(contradicting_evidence):
+            raise ValueError("contradicting evidence signal IDs must be unique")
+        if tuple(sorted(contradiction_by_id)) != tuple(
+            sorted(recommendation.contradicting_signal_ids)
+        ):
+            raise ValueError(
+                "contradicting evidence must match recommendation contradiction IDs"
+            )
+        if set(recommendation.supporting_signal_ids) & set(contradiction_by_id):
+            raise ValueError("one signal cannot support and contradict a recommendation")
+        for evidence in (*recommendation.evidence, *contradicting_evidence):
+            if evidence.tenant_id != recommendation.scope.tenant_id:
+                raise ValueError("recommendation evidence must belong to its tenant")
+            _structured_identifier(evidence.signal_id, name="signal_id")
+            _structured_identifier(evidence.source_id, name="source_id")
+            _structured_timestamp(evidence.recorded_at, name="recorded_at")
+
+        fingerprint = _input_fingerprint(recommendation.recommendation_id)
+        expected_main = _main_row(recommendation, fingerprint)
+        expected_evidence = _evidence_rows(
+            recommendation,
+            contradicting_evidence=contradicting_evidence,
+        )
+        expected_evidence_jobs = _evidence_job_rows(
+            recommendation,
+            contradicting_evidence=contradicting_evidence,
+        )
+        expected_jobs = tuple(sorted(str(job_id) for job_id in recommendation.job_ids))
+
+        owns_transaction = not self._conn.in_transaction
+        if owns_transaction:
+            self._conn.execute("BEGIN IMMEDIATE")
+        else:
+            self._conn.execute(f"SAVEPOINT {_SAVEPOINT}")
+        try:
+            existing = self._existing_rows(recommendation)
+            if existing is not None:
+                if existing != (
+                    expected_main,
+                    expected_evidence,
+                    expected_evidence_jobs,
+                    expected_jobs,
+                ):
+                    raise LearningRecommendationConflict(
+                        "persisted learning recommendation conflicts with deterministic facts"
+                    )
+                self._finish(owns_transaction)
+                return False
+
+            tenant_id = str(recommendation.scope.tenant_id)
+            self._conn.executemany(
+                """
+                INSERT INTO learning_recommendation_evidence (
+                    tenant_id, recommendation_id, signal_id, evidence_role,
+                    source_kind, source_id, source_revision, recorded_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    (
+                        tenant_id,
+                        recommendation.recommendation_id,
+                        signal_id,
+                        role,
+                        source_kind,
+                        source_id,
+                        source_revision,
+                        recorded_at,
+                    )
+                    for (
+                        signal_id,
+                        role,
+                        source_kind,
+                        source_id,
+                        source_revision,
+                        recorded_at,
+                    ) in expected_evidence
+                ),
+            )
+            self._conn.executemany(
+                """
+                INSERT INTO learning_recommendation_evidence_jobs (
+                    tenant_id, recommendation_id, signal_id, job_id
+                ) VALUES (?, ?, ?, ?)
+                """,
+                (
+                    (
+                        tenant_id,
+                        recommendation.recommendation_id,
+                        signal_id,
+                        job_id,
+                    )
+                    for signal_id, job_id in expected_evidence_jobs
+                ),
+            )
+            self._conn.executemany(
+                """
+                INSERT INTO learning_recommendation_jobs (
+                    tenant_id, recommendation_id, job_id
+                ) VALUES (?, ?, ?)
+                """,
+                (
+                    (tenant_id, recommendation.recommendation_id, job_id)
+                    for job_id in expected_jobs
+                ),
+            )
+            self._conn.execute(
+                """
+                INSERT INTO learning_recommendations (
+                    tenant_id, recommendation_id, derivation_version,
+                    evaluation_fixture_version, context, policy_kind,
+                    signal_kind, rule_key, rule_value, allowlist_version,
+                    status, observed_signal_count, observed_job_count,
+                    minimum_signal_count, minimum_job_count, confidence_limit,
+                    input_fingerprint, derived_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (*expected_main, derived_at),
+            )
+        except BaseException:
+            self._rollback(owns_transaction)
+            raise
+        self._finish(owns_transaction)
+        return True
+
+    def _existing_rows(
+        self,
+        recommendation: LearningRecommendation,
+    ) -> (
+        tuple[
+            tuple[object, ...],
+            tuple[tuple[object, ...], ...],
+            tuple[tuple[str, str], ...],
+            tuple[str, ...],
+        ]
+        | None
+    ):
+        tenant_id = str(recommendation.scope.tenant_id)
+        identity = (tenant_id, recommendation.recommendation_id)
+        main = self._conn.execute(
+            """
+            SELECT tenant_id, recommendation_id, derivation_version,
+                   evaluation_fixture_version, context, policy_kind,
+                   signal_kind, rule_key, rule_value, allowlist_version,
+                   status, observed_signal_count, observed_job_count,
+                   minimum_signal_count, minimum_job_count, confidence_limit,
+                   input_fingerprint
+            FROM learning_recommendations
+            WHERE tenant_id = ? AND recommendation_id = ?
+            """,
+            identity,
+        ).fetchone()
+        if main is None:
+            return None
+        evidence = self._conn.execute(
+            """
+            SELECT signal_id, evidence_role, source_kind, source_id,
+                   source_revision, recorded_at
+            FROM learning_recommendation_evidence
+            WHERE tenant_id = ? AND recommendation_id = ?
+            ORDER BY evidence_role, signal_id
+            """,
+            identity,
+        ).fetchall()
+        evidence_jobs = self._conn.execute(
+            """
+            SELECT signal_id, job_id
+            FROM learning_recommendation_evidence_jobs
+            WHERE tenant_id = ? AND recommendation_id = ?
+            ORDER BY signal_id, job_id
+            """,
+            identity,
+        ).fetchall()
+        jobs = self._conn.execute(
+            """
+            SELECT job_id
+            FROM learning_recommendation_jobs
+            WHERE tenant_id = ? AND recommendation_id = ?
+            ORDER BY job_id
+            """,
+            identity,
+        ).fetchall()
+        return (
+            tuple(main),
+            tuple(tuple(row) for row in evidence),
+            tuple((str(row[0]), str(row[1])) for row in evidence_jobs),
+            tuple(str(row[0]) for row in jobs),
+        )
+
+    def _finish(self, owns_transaction: bool) -> None:
+        if owns_transaction:
+            self._conn.commit()
+        else:
+            self._conn.execute(f"RELEASE SAVEPOINT {_SAVEPOINT}")
+
+    def _rollback(self, owns_transaction: bool) -> None:
+        if owns_transaction:
+            self._conn.rollback()
+        else:
+            self._conn.execute(f"ROLLBACK TO SAVEPOINT {_SAVEPOINT}")
+            self._conn.execute(f"RELEASE SAVEPOINT {_SAVEPOINT}")
+
+
+def _input_fingerprint(recommendation_id: str) -> str:
+    if not recommendation_id.startswith(_RECOMMENDATION_PREFIX):
+        raise ValueError("recommendation_id must contain a deterministic fingerprint")
+    fingerprint = recommendation_id.removeprefix(_RECOMMENDATION_PREFIX)
+    if len(fingerprint) != 64 or any(character not in "0123456789abcdef" for character in fingerprint):
+        raise ValueError("recommendation_id must contain a deterministic fingerprint")
+    return fingerprint
+
+
+def _structured_identifier(value: str, *, name: str) -> str:
+    if not 1 <= len(value) <= 200 or any(
+        not (character.isascii() and (character.isalnum() or character in "-_.:"))
+        for character in value
+    ):
+        raise ValueError(f"{name} must be a bounded structured identifier")
+    return value
+
+
+def _structured_timestamp(value: str, *, name: str) -> str:
+    text = value.strip()
+    if not text or len(text) > 40:
+        raise ValueError(f"{name} must be a bounded timezone-aware ISO timestamp")
+    try:
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ValueError(
+            f"{name} must be a bounded timezone-aware ISO timestamp"
+        ) from exc
+    if parsed.tzinfo is None:
+        raise ValueError(f"{name} must be a bounded timezone-aware ISO timestamp")
+    return text
+
+
+def _main_row(
+    recommendation: LearningRecommendation,
+    fingerprint: str,
+) -> tuple[object, ...]:
+    effect = recommendation.proposed_effect
+    return (
+        str(recommendation.scope.tenant_id),
+        recommendation.recommendation_id,
+        recommendation.derivation_version,
+        recommendation.evaluation_fixture_version,
+        recommendation.scope.context,
+        recommendation.scope.policy_kind,
+        effect.signal_kind,
+        effect.rule_key,
+        effect.rule_value,
+        effect.allowlist_version,
+        recommendation.status,
+        recommendation.observed_signal_count,
+        recommendation.observed_job_count,
+        recommendation.minimum_signal_count,
+        recommendation.minimum_job_count,
+        recommendation.confidence_limit,
+        fingerprint,
+    )
+
+
+def _evidence_rows(
+    recommendation: LearningRecommendation,
+    *,
+    contradicting_evidence: tuple[RecommendationEvidenceRef, ...],
+) -> tuple[tuple[object, ...], ...]:
+    rows = [
+        (
+            evidence.signal_id,
+            "supporting",
+            evidence.source_kind,
+            evidence.source_id,
+            evidence.source_revision,
+            evidence.recorded_at,
+        )
+        for evidence in recommendation.evidence
+    ]
+    rows.extend(
+        (
+            evidence.signal_id,
+            "contradicting",
+            evidence.source_kind,
+            evidence.source_id,
+            evidence.source_revision,
+            evidence.recorded_at,
+        )
+        for evidence in contradicting_evidence
+    )
+    return tuple(sorted(rows, key=lambda row: (str(row[1]), str(row[0]))))
+
+
+def _evidence_job_rows(
+    recommendation: LearningRecommendation,
+    *,
+    contradicting_evidence: tuple[RecommendationEvidenceRef, ...],
+) -> tuple[tuple[str, str], ...]:
+    return tuple(
+        sorted(
+            (
+                (evidence.signal_id, str(job_id))
+                for evidence in (
+                    *recommendation.evidence,
+                    *contradicting_evidence,
+                )
+                for job_id in evidence.job_ids
+            )
+        )
+    )
+
+
+__all__ = [
+    "LearningRecommendationConflict",
+    "SqliteLearningRecommendationRepository",
+]

--- a/workers/automation/tests/test_sqlite_learning_recommendations.py
+++ b/workers/automation/tests/test_sqlite_learning_recommendations.py
@@ -1,0 +1,360 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from jobctrl.database import close_connection, init_db
+from jobctrl.domain.identifiers import JobId, canonical_job_id
+from jobctrl.domain.operations.feedback import TailoringFeedbackSignal
+from jobctrl.domain.operations.learning import (
+    RecommendationEvidenceRef,
+    TailoringContradictionEvidence,
+    TailoringRecommendationScope,
+    TailoringRuleEffect,
+    derive_tailoring_recommendations,
+)
+from jobctrl.domain.tenant import TenantId
+from jobctrl.infrastructure.learning.sqlite_repository import (
+    LearningRecommendationConflict,
+    SqliteLearningRecommendationRepository,
+)
+
+
+_TENANT_A = TenantId("tenant-a")
+_TENANT_B = TenantId("tenant-b")
+_JOB_A = canonical_job_id("10000000-0000-4000-8000-000000000001")
+_JOB_B = canonical_job_id("10000000-0000-4000-8000-000000000002")
+_JOB_C = canonical_job_id("10000000-0000-4000-8000-000000000003")
+
+
+def test_append_pending_is_atomic_structured_and_idempotent(tmp_path: Path) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    conn = init_db(db_path)
+    recommendation = _recommendation(_TENANT_A)
+    repository = SqliteLearningRecommendationRepository(conn)
+
+    assert repository.append_pending(
+        recommendation,
+        derived_at="2026-08-01T10:01:00Z",
+    )
+    assert not repository.append_pending(
+        recommendation,
+        derived_at="2026-08-01T10:02:00Z",
+    )
+
+    row = conn.execute(
+        """
+        SELECT tenant_id, recommendation_id, context, policy_kind, signal_kind,
+               rule_key, rule_value, status, observed_signal_count,
+               observed_job_count, input_fingerprint, derived_at
+        FROM learning_recommendations
+        """
+    ).fetchone()
+    assert tuple(row) == (
+        "tenant-a",
+        recommendation.recommendation_id,
+        "materials",
+        "tailoring_rule",
+        "factual_correction",
+        "fact_handling",
+        "require_source_match",
+        "pending",
+        3,
+        2,
+        recommendation.recommendation_id.removeprefix("learning-recommendation:"),
+        "2026-08-01T10:01:00Z",
+    )
+    assert [
+        tuple(item)
+        for item in conn.execute(
+            """
+            SELECT signal_id, evidence_role, source_kind, source_id,
+                   source_revision, recorded_at
+            FROM learning_recommendation_evidence
+            ORDER BY signal_id
+            """
+        ).fetchall()
+    ] == [
+        (
+            f"signal-{index}",
+            "supporting",
+            "tailoring_feedback_signal",
+            f"source-{index}",
+            index,
+            f"2026-08-01T10:00:0{index}Z",
+        )
+        for index in range(1, 4)
+    ]
+    assert [
+        str(item[0])
+        for item in conn.execute(
+            "SELECT job_id FROM learning_recommendation_jobs ORDER BY job_id"
+        ).fetchall()
+    ] == [_JOB_A, _JOB_B]
+    assert [
+        tuple(item)
+        for item in conn.execute(
+            """
+            SELECT signal_id, job_id
+            FROM learning_recommendation_evidence_jobs
+            ORDER BY signal_id, job_id
+            """
+        ).fetchall()
+    ] == [
+        ("signal-1", _JOB_A),
+        ("signal-2", _JOB_A),
+        ("signal-3", _JOB_B),
+    ]
+    assert conn.execute("PRAGMA foreign_key_check").fetchone() is None
+    close_connection(db_path)
+
+
+def test_resolved_contradiction_requires_truthful_provenance(tmp_path: Path) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    conn = init_db(db_path)
+    contradiction_id = "contradiction-1"
+    recommendation = derive_tailoring_recommendations(
+        _signals(_TENANT_A),
+        contradictions={
+            _scope(_TENANT_A): TailoringContradictionEvidence(
+                signal_ids=(contradiction_id,),
+                unresolved_signal_ids=(),
+            )
+        },
+    )[0]
+    repository = SqliteLearningRecommendationRepository(conn)
+
+    with pytest.raises(ValueError, match="must match"):
+        repository.append_pending(
+            recommendation,
+            derived_at="2026-08-01T10:01:00Z",
+        )
+    assert conn.execute("SELECT COUNT(*) FROM learning_recommendations").fetchone()[0] == 0
+
+    contradiction = RecommendationEvidenceRef(
+        tenant_id=_TENANT_A,
+        signal_id=contradiction_id,
+        source_kind="tailoring_feedback_signal",
+        source_id="source-contradiction-1",
+        source_revision=4,
+        job_ids=(_JOB_B,),
+        recorded_at="2026-08-01T10:00:04Z",
+    )
+    assert repository.append_pending(
+        recommendation,
+        contradicting_evidence=(contradiction,),
+        derived_at="2026-08-01T10:01:00Z",
+    )
+    assert [
+        tuple(row)
+        for row in conn.execute(
+            """
+            SELECT signal_id, evidence_role, source_id, source_revision
+            FROM learning_recommendation_evidence
+            ORDER BY evidence_role, signal_id
+            """
+        ).fetchall()
+    ] == [
+        ("contradiction-1", "contradicting", "source-contradiction-1", 4),
+        ("signal-1", "supporting", "source-1", 1),
+        ("signal-2", "supporting", "source-2", 2),
+        ("signal-3", "supporting", "source-3", 3),
+    ]
+    assert conn.execute(
+        """
+        SELECT job_id
+        FROM learning_recommendation_evidence_jobs
+        WHERE signal_id = 'contradiction-1'
+        """
+    ).fetchone()[0] == _JOB_B
+
+    with pytest.raises(LearningRecommendationConflict, match="conflicts"):
+        repository.append_pending(
+            recommendation,
+            contradicting_evidence=(replace(contradiction, job_ids=(_JOB_C,)),),
+            derived_at="2026-08-01T10:02:00Z",
+        )
+    with pytest.raises(ValueError, match="belong to its tenant"):
+        repository.append_pending(
+            recommendation,
+            contradicting_evidence=(
+                replace(contradiction, tenant_id=_TENANT_B),
+            ),
+            derived_at="2026-08-01T10:02:00Z",
+        )
+    close_connection(db_path)
+
+
+def test_pending_append_respects_outer_rollback_and_tenant_isolation(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    conn = init_db(db_path)
+    repository = SqliteLearningRecommendationRepository(conn)
+
+    conn.execute("BEGIN")
+    assert repository.append_pending(
+        _recommendation(_TENANT_A),
+        derived_at="2026-08-01T10:01:00Z",
+    )
+    conn.rollback()
+    assert conn.execute("SELECT COUNT(*) FROM learning_recommendations").fetchone()[0] == 0
+
+    assert repository.append_pending(
+        _recommendation(_TENANT_A),
+        derived_at="2026-08-01T10:01:00Z",
+    )
+    assert repository.append_pending(
+        _recommendation(_TENANT_B),
+        derived_at="2026-08-01T10:01:00Z",
+    )
+    assert [
+        tuple(row)
+        for row in conn.execute(
+            """
+            SELECT tenant_id, COUNT(*)
+            FROM learning_recommendations
+            GROUP BY tenant_id
+            ORDER BY tenant_id
+            """
+        ).fetchall()
+    ] == [("tenant-a", 1), ("tenant-b", 1)]
+    close_connection(db_path)
+
+
+@pytest.mark.parametrize(
+    ("derived_at", "source_id", "match"),
+    [
+        ("private prompt and mail body", "source-safe", "derived_at"),
+        (
+            "2026-08-01T10:01:00Z",
+            "private resume text /Users/private/resume.pdf",
+            "source_id",
+        ),
+    ],
+)
+def test_unstructured_private_values_are_rejected_before_writes(
+    tmp_path: Path,
+    derived_at: str,
+    source_id: str,
+    match: str,
+) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    conn = init_db(db_path)
+    recommendation = derive_tailoring_recommendations(
+        _signals(_TENANT_A),
+        contradictions={
+            _scope(_TENANT_A): TailoringContradictionEvidence(
+                signal_ids=("contradiction-1",),
+                unresolved_signal_ids=(),
+            )
+        },
+    )[0]
+    contradiction = RecommendationEvidenceRef(
+        tenant_id=_TENANT_A,
+        signal_id="contradiction-1",
+        source_kind="tailoring_feedback_signal",
+        source_id=source_id,
+        source_revision=4,
+        job_ids=(_JOB_B,),
+        recorded_at="2026-08-01T10:00:04Z",
+    )
+
+    with pytest.raises(ValueError, match=match):
+        SqliteLearningRecommendationRepository(conn).append_pending(
+            recommendation,
+            contradicting_evidence=(contradiction,),
+            derived_at=derived_at,
+        )
+    for table in (
+        "learning_recommendations",
+        "learning_recommendation_evidence",
+        "learning_recommendation_jobs",
+    ):
+        assert conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0] == 0
+    close_connection(db_path)
+
+
+def test_reused_deterministic_identity_cannot_change_persisted_facts(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    conn = init_db(db_path)
+    repository = SqliteLearningRecommendationRepository(conn)
+    original = _recommendation(_TENANT_A)
+    repository.append_pending(original, derived_at="2026-08-01T10:01:00Z")
+
+    different_effect = TailoringRuleEffect(
+        signal_kind="style_preference",
+        rule_key="style_guidance",
+        rule_value="preserve_user_edit_pattern",
+        allowlist_version=1,
+    )
+    conflicting = replace(
+        original,
+        recommendation_id=original.recommendation_id,
+        scope=TailoringRecommendationScope(
+            tenant_id=_TENANT_A,
+            proposed_effect=different_effect,
+        ),
+        proposed_effect=different_effect,
+    )
+
+    with pytest.raises(LearningRecommendationConflict, match="conflicts"):
+        repository.append_pending(
+            conflicting,
+            derived_at="2026-08-01T10:02:00Z",
+        )
+    assert conn.execute(
+        "SELECT rule_key FROM learning_recommendations"
+    ).fetchone()[0] == "fact_handling"
+    close_connection(db_path)
+
+
+def _recommendation(tenant_id: TenantId):
+    return derive_tailoring_recommendations(
+        _signals(tenant_id),
+        contradictions={},
+    )[0]
+
+
+def _signals(tenant_id: TenantId) -> tuple[TailoringFeedbackSignal, ...]:
+    return (
+        _signal("signal-1", _JOB_A, 1, tenant_id),
+        _signal("signal-2", _JOB_A, 2, tenant_id),
+        _signal("signal-3", _JOB_B, 3, tenant_id),
+    )
+
+
+def _scope(tenant_id: TenantId) -> TailoringRecommendationScope:
+    return TailoringRecommendationScope(
+        tenant_id=tenant_id,
+        proposed_effect=TailoringRuleEffect(
+            signal_kind="factual_correction",
+            rule_key="fact_handling",
+            rule_value="require_source_match",
+            allowlist_version=1,
+        ),
+    )
+
+
+def _signal(
+    signal_id: str,
+    job_id: JobId,
+    revision: int,
+    tenant_id: TenantId,
+) -> TailoringFeedbackSignal:
+    return TailoringFeedbackSignal(
+        signal_id=signal_id,
+        tenant_id=tenant_id,
+        job_id=job_id,
+        source_id=f"source-{revision}",
+        source_revision=revision,
+        recorded_at=f"2026-08-01T10:00:0{revision}Z",
+        signal_kind="factual_correction",
+        rule_key="fact_handling",
+        rule_value="require_source_match",
+        allowlist_version=1,
+    )


### PR DESCRIPTION
## Summary

- append deterministic pending learning recommendations and their canonical evidence/job associations atomically
- carry tenant identity in every evidence reference and reject cross-tenant attribution before writes
- make identical derivation replay a no-op while rejecting changed source, revision, or job provenance for the same identity
- require truthful structured provenance for resolved contradictions and reject unstructured private values

## Why

The pure derivation kernel and exact-v7 ledger need a narrow persistence boundary before correction/deletion re-derivation and read APIs can be wired. This writer persists all supporting and contradiction provenance introduced by #678, while writing only immutable pending proposals. It does not activate policy, change ranking, or create schema at runtime.

## Validation

- `PYTHONPATH=workers/automation/src /Users/eloibarti/Github/JobHunter/workers/automation/.venv/bin/pytest workers/automation/tests/test_sqlite_learning_recommendations.py workers/automation/tests/test_learning_recommendations.py workers/automation/tests/test_feedback_signal_reader.py workers/automation/tests/test_exact_v7_schema.py::test_learning_recommendation_storage_is_structured_append_only_and_private -q`
- `/Users/eloibarti/Github/JobHunter/workers/automation/.venv/bin/ruff check workers/automation/src/jobctrl/domain/operations/learning.py workers/automation/src/jobctrl/domain/ports/learning.py workers/automation/src/jobctrl/infrastructure/learning/__init__.py workers/automation/src/jobctrl/infrastructure/learning/sqlite_repository.py workers/automation/tests/test_sqlite_learning_recommendations.py`
- `git diff --check`

Canonical product documentation remains deferred to the final PR in the approved unreleased stack. Re-derivation/tombstones and read APIs remain separate child PRs.

Stacked on #678.
