### PR TITLE
feat(learning): rederive corrected recommendations

### DIFF
--- a/workers/automation/src/jobctrl/domain/operations/__init__.py
+++ b/workers/automation/src/jobctrl/domain/operations/__init__.py
@@ -44,6 +44,7 @@ from jobctrl.domain.operations.feedback import (
 )
 from jobctrl.domain.operations.learning import (
     LearningRecommendation,
+    LearningSourceChange,
     RecommendationEvidenceRef,
     TAILORING_RECOMMENDATION_DERIVATION_VERSION,
     TAILORING_RECOMMENDATION_EVALUATION_FIXTURE_VERSION,
@@ -71,6 +72,7 @@ __all__ = [
     "JobDetailProjection",
     "JobListProjection",
     "LearningRecommendation",
+    "LearningSourceChange",
     "RecommendationEvidenceRef",
     "RoleMatchApprovalFeedbackSignal",
     "ScoreCorrectionDirection",

--- a/workers/automation/src/jobctrl/domain/operations/learning.py
+++ b/workers/automation/src/jobctrl/domain/operations/learning.py
@@ -28,6 +28,36 @@ TAILORING_RECOMMENDATION_MIN_JOB_COUNT = 2
 
 
 @dataclass(frozen=True, kw_only=True)
+class LearningSourceChange:
+    """Explicit accepted-signal correction or deletion requiring re-derivation."""
+
+    tenant_id: TenantId
+    previous_signal_id: str
+    source_id: str
+    source_revision: int
+    reason_code: Literal["source_corrected", "source_deleted"]
+    changed_at: str
+    source_kind: Literal["tailoring_feedback_signal"] = field(
+        default="tailoring_feedback_signal", init=False
+    )
+
+    def __post_init__(self) -> None:
+        if not str(self.tenant_id).strip():
+            raise ValueError("tenant_id must not be empty")
+        for name, value in (
+            ("previous_signal_id", self.previous_signal_id),
+            ("source_id", self.source_id),
+            ("changed_at", self.changed_at),
+        ):
+            if not value.strip():
+                raise ValueError(f"{name} must not be empty")
+        if self.source_revision < 1:
+            raise ValueError("source_revision must be positive")
+        if self.reason_code not in {"source_corrected", "source_deleted"}:
+            raise ValueError("unsupported learning source change reason")
+
+
+@dataclass(frozen=True, kw_only=True)
 class TailoringRuleEffect:
     """Closed, allowlisted Materials policy effect proposed by learning."""
 
@@ -319,6 +349,7 @@ def _recommendation_id(
 
 __all__ = [
     "LearningRecommendation",
+    "LearningSourceChange",
     "RecommendationEvidenceRef",
     "TAILORING_RECOMMENDATION_DERIVATION_VERSION",
     "TAILORING_RECOMMENDATION_EVALUATION_FIXTURE_VERSION",

--- a/workers/automation/src/jobctrl/infrastructure/learning/sqlite_repository.py
+++ b/workers/automation/src/jobctrl/infrastructure/learning/sqlite_repository.py
@@ -2,16 +2,29 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from datetime import datetime
+import hashlib
+import json
 import sqlite3
 
 from jobctrl.domain.operations.learning import (
     LearningRecommendation,
+    LearningSourceChange,
     RecommendationEvidenceRef,
+    TailoringContradictionEvidence,
+    TailoringRecommendationScope,
+    derive_tailoring_recommendations,
+)
+from jobctrl.domain.operations.feedback import TailoringFeedbackSignal
+from jobctrl.domain.tenant import TenantId
+from jobctrl.infrastructure.projections.sqlite_feedback_signals import (
+    SqliteFeedbackSignalReader,
 )
 
 
 _SAVEPOINT = "append_learning_recommendation"
+_REDERIVE_SAVEPOINT = "rederive_learning_recommendations"
 _RECOMMENDATION_PREFIX = "learning-recommendation:"
 
 
@@ -166,6 +179,204 @@ class SqliteLearningRecommendationRepository:
             raise
         self._finish(owns_transaction)
         return True
+
+    def rederive_tailoring(
+        self,
+        tenant_id: TenantId,
+        *,
+        source_changes: tuple[LearningSourceChange, ...],
+        rederived_at: str,
+        contradictions: Mapping[
+            TailoringRecommendationScope, TailoringContradictionEvidence
+        ]
+        | None = None,
+        contradicting_evidence: Mapping[
+            TailoringRecommendationScope,
+            tuple[RecommendationEvidenceRef, ...],
+        ]
+        | None = None,
+    ) -> tuple[LearningRecommendation, ...]:
+        """Recompute pending proposals and tombstone changed source history."""
+
+        if not str(tenant_id).strip():
+            raise ValueError("tenant_id must not be empty")
+        rederived_at = _structured_timestamp(rederived_at, name="rederived_at")
+        contradiction_ledger = contradictions or {}
+        contradiction_refs = contradicting_evidence or {}
+        owns_transaction = not self._conn.in_transaction
+        if owns_transaction:
+            self._conn.execute("BEGIN IMMEDIATE")
+        else:
+            self._conn.execute(f"SAVEPOINT {_REDERIVE_SAVEPOINT}")
+        try:
+            signals = SqliteFeedbackSignalReader(self._conn).list_accepted(tenant_id)
+            tailoring_signals = tuple(
+                signal
+                for signal in signals
+                if isinstance(signal, TailoringFeedbackSignal)
+            )
+            self._validate_source_changes(
+                tenant_id,
+                source_changes=source_changes,
+                current_signals=tailoring_signals,
+            )
+            recommendations = derive_tailoring_recommendations(
+                tailoring_signals,
+                contradictions=contradiction_ledger,
+            )
+            for recommendation in recommendations:
+                self.append_pending(
+                    recommendation,
+                    contradicting_evidence=contradiction_refs.get(
+                        recommendation.scope, ()
+                    ),
+                    derived_at=rederived_at,
+                )
+            for change in source_changes:
+                self._append_source_change_tombstones(
+                    change,
+                    recommendations=recommendations,
+                    rederived_at=rederived_at,
+                )
+        except BaseException:
+            if owns_transaction:
+                self._conn.rollback()
+            else:
+                self._conn.execute(f"ROLLBACK TO SAVEPOINT {_REDERIVE_SAVEPOINT}")
+                self._conn.execute(f"RELEASE SAVEPOINT {_REDERIVE_SAVEPOINT}")
+            raise
+        if owns_transaction:
+            self._conn.commit()
+        else:
+            self._conn.execute(f"RELEASE SAVEPOINT {_REDERIVE_SAVEPOINT}")
+        return recommendations
+
+    def _validate_source_changes(
+        self,
+        tenant_id: TenantId,
+        *,
+        source_changes: tuple[LearningSourceChange, ...],
+        current_signals: tuple[TailoringFeedbackSignal, ...],
+    ) -> None:
+        current_by_source: dict[str, TailoringFeedbackSignal] = {}
+        for signal in current_signals:
+            existing = current_by_source.get(signal.source_id)
+            if existing is not None and existing != signal:
+                raise ValueError("one tailoring source has conflicting current signals")
+            current_by_source[signal.source_id] = signal
+        identities: set[tuple[str, int, str]] = set()
+        for change in source_changes:
+            if change.tenant_id != tenant_id:
+                raise ValueError("learning source change must belong to its tenant")
+            _structured_identifier(change.previous_signal_id, name="previous_signal_id")
+            _structured_identifier(change.source_id, name="source_id")
+            _structured_timestamp(change.changed_at, name="changed_at")
+            expected_signal_id = (
+                f"tailoring-feedback:{change.source_id}:{change.source_revision}"
+            )
+            if change.previous_signal_id != expected_signal_id:
+                raise ValueError("learning source change identity is not canonical")
+            identity = (change.source_id, change.source_revision, change.reason_code)
+            if identity in identities:
+                raise ValueError("learning source changes must be unique")
+            identities.add(identity)
+            current = current_by_source.get(change.source_id)
+            if change.reason_code == "source_corrected":
+                if current is None or current.source_revision <= change.source_revision:
+                    raise ValueError(
+                        "source correction requires a newer accepted revision"
+                    )
+            elif current is not None:
+                raise ValueError("source deletion requires no current accepted revision")
+
+    def _append_source_change_tombstones(
+        self,
+        change: LearningSourceChange,
+        *,
+        recommendations: tuple[LearningRecommendation, ...],
+        rederived_at: str,
+    ) -> None:
+        rows = self._conn.execute(
+            """
+            SELECT recommendation.recommendation_id,
+                   recommendation.derivation_version,
+                   recommendation.signal_kind,
+                   recommendation.rule_key,
+                   recommendation.rule_value,
+                   recommendation.allowlist_version,
+                   evidence.signal_id,
+                   evidence.source_revision
+            FROM learning_recommendations AS recommendation
+            JOIN learning_recommendation_evidence AS evidence
+              ON evidence.tenant_id = recommendation.tenant_id
+             AND evidence.recommendation_id = recommendation.recommendation_id
+            WHERE recommendation.tenant_id = ?
+              AND evidence.source_kind = ?
+              AND evidence.source_id = ?
+              AND evidence.source_revision = ?
+              AND evidence.signal_id = ?
+            ORDER BY recommendation.recommendation_id
+            """,
+            (
+                str(change.tenant_id),
+                change.source_kind,
+                change.source_id,
+                change.source_revision,
+                change.previous_signal_id,
+            ),
+        ).fetchall()
+        for row in rows:
+            recommendation_id = str(row[0])
+            derivation_version = int(row[1])
+            replacement_id = _replacement_recommendation_id(
+                row,
+                recommendations=recommendations,
+                change=change,
+            )
+            business_key = (
+                str(change.tenant_id),
+                recommendation_id,
+                change.previous_signal_id,
+                change.source_revision,
+                change.reason_code,
+                derivation_version,
+            )
+            if self._conn.execute(
+                """
+                SELECT 1
+                FROM learning_recommendation_tombstones
+                WHERE tenant_id = ?
+                  AND recommendation_id = ?
+                  AND affected_signal_id = ?
+                  AND affected_source_revision = ?
+                  AND reason_code = ?
+                  AND derivation_version = ?
+                """,
+                business_key,
+            ).fetchone() is not None:
+                continue
+            self._conn.execute(
+                """
+                INSERT INTO learning_recommendation_tombstones (
+                    tenant_id, tombstone_id, recommendation_id,
+                    affected_signal_id, affected_source_revision, reason_code,
+                    derivation_version, tombstoned_at, rederived_at,
+                    replacement_recommendation_id
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    str(change.tenant_id),
+                    _tombstone_id(business_key),
+                    recommendation_id,
+                    change.previous_signal_id,
+                    change.source_revision,
+                    change.reason_code,
+                    derivation_version,
+                    change.changed_at,
+                    rederived_at,
+                    replacement_id,
+                ),
+            )
 
     def _existing_rows(
         self,
@@ -351,6 +562,43 @@ def _evidence_job_rows(
             )
         )
     )
+
+
+def _replacement_recommendation_id(
+    persisted_row: sqlite3.Row | tuple[object, ...],
+    *,
+    recommendations: tuple[LearningRecommendation, ...],
+    change: LearningSourceChange,
+) -> str | None:
+    persisted_effect = (
+        str(persisted_row[2]),
+        str(persisted_row[3]),
+        str(persisted_row[4]),
+        int(persisted_row[5]),
+    )
+    for recommendation in recommendations:
+        effect = recommendation.proposed_effect
+        if (
+            effect.signal_kind,
+            effect.rule_key,
+            effect.rule_value,
+            effect.allowlist_version,
+        ) != persisted_effect:
+            continue
+        if change.reason_code == "source_corrected" and not any(
+            evidence.source_id == change.source_id
+            and evidence.source_revision > change.source_revision
+            for evidence in recommendation.evidence
+        ):
+            continue
+        return recommendation.recommendation_id
+    return None
+
+
+def _tombstone_id(business_key: tuple[object, ...]) -> str:
+    payload = json.dumps(business_key, separators=(",", ":"), ensure_ascii=True)
+    fingerprint = hashlib.sha256(payload.encode("utf-8")).hexdigest()
+    return f"learning-recommendation-tombstone:{fingerprint}"
 
 
 __all__ = [

--- a/workers/automation/tests/test_sqlite_learning_recommendations.py
+++ b/workers/automation/tests/test_sqlite_learning_recommendations.py
@@ -9,6 +9,7 @@ from jobctrl.database import close_connection, init_db
 from jobctrl.domain.identifiers import JobId, canonical_job_id
 from jobctrl.domain.operations.feedback import TailoringFeedbackSignal
 from jobctrl.domain.operations.learning import (
+    LearningSourceChange,
     RecommendationEvidenceRef,
     TailoringContradictionEvidence,
     TailoringRecommendationScope,
@@ -313,6 +314,239 @@ def test_reused_deterministic_identity_cannot_change_persisted_facts(
     close_connection(db_path)
 
 
+def test_source_correction_tombstones_and_rederives_with_replacement(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    conn = init_db(db_path)
+    _seed_tailoring_sources(conn)
+    conn.commit()
+    repository = SqliteLearningRecommendationRepository(conn)
+
+    original = repository.rederive_tailoring(
+        _TENANT_A,
+        source_changes=(),
+        rederived_at="2026-08-01T11:00:00Z",
+    )[0]
+    _insert_tailoring_review(
+        conn,
+        signal_id="tailoring-1",
+        revision=2,
+        decision="accepted",
+        reviewed_at="2026-08-01T11:30:00Z",
+    )
+    conn.commit()
+    change = LearningSourceChange(
+        tenant_id=_TENANT_A,
+        previous_signal_id="tailoring-feedback:tailoring-1:1",
+        source_id="tailoring-1",
+        source_revision=1,
+        reason_code="source_corrected",
+        changed_at="2026-08-01T11:30:00Z",
+    )
+
+    rederived = repository.rederive_tailoring(
+        _TENANT_A,
+        source_changes=(change,),
+        rederived_at="2026-08-01T11:31:00Z",
+    )
+
+    assert len(rederived) == 1
+    replacement = rederived[0]
+    assert replacement.recommendation_id != original.recommendation_id
+    assert any(
+        evidence.source_id == "tailoring-1" and evidence.source_revision == 2
+        for evidence in replacement.evidence
+    )
+    assert tuple(
+        conn.execute(
+            """
+            SELECT recommendation_id, affected_signal_id,
+                   affected_source_revision, reason_code,
+                   replacement_recommendation_id, tombstoned_at, rederived_at
+            FROM learning_recommendation_tombstones
+            """
+        ).fetchone()
+    ) == (
+        original.recommendation_id,
+        "tailoring-feedback:tailoring-1:1",
+        1,
+        "source_corrected",
+        replacement.recommendation_id,
+        "2026-08-01T11:30:00Z",
+        "2026-08-01T11:31:00Z",
+    )
+    assert conn.execute("SELECT COUNT(*) FROM learning_recommendations").fetchone()[0] == 2
+    learning_dump = "\n".join(
+        repr(tuple(row))
+        for table in (
+            "learning_recommendations",
+            "learning_recommendation_evidence",
+            "learning_recommendation_evidence_jobs",
+            "learning_recommendation_jobs",
+            "learning_recommendation_tombstones",
+        )
+        for row in conn.execute(f"SELECT * FROM {table}").fetchall()
+    )
+    for forbidden in (
+        "private edit",
+        "resume",
+        "prompt",
+        "job description",
+        "private-delta",
+    ):
+        assert forbidden not in learning_dump
+
+    replayed = repository.rederive_tailoring(
+        _TENANT_A,
+        source_changes=(change,),
+        rederived_at="2026-08-01T11:32:00Z",
+    )
+    assert replayed == rederived
+    assert conn.execute(
+        "SELECT COUNT(*) FROM learning_recommendation_tombstones"
+    ).fetchone()[0] == 1
+    close_connection(db_path)
+
+
+def test_source_deletion_tombstones_without_inventing_a_replacement(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    conn = init_db(db_path)
+    _seed_tailoring_sources(conn)
+    conn.commit()
+    repository = SqliteLearningRecommendationRepository(conn)
+    original = repository.rederive_tailoring(
+        _TENANT_A,
+        source_changes=(),
+        rederived_at="2026-08-01T11:00:00Z",
+    )[0]
+    _insert_tailoring_review(
+        conn,
+        signal_id="tailoring-1",
+        revision=2,
+        decision="rejected",
+        reviewed_at="2026-08-01T11:30:00Z",
+    )
+    conn.commit()
+
+    assert repository.rederive_tailoring(
+        _TENANT_A,
+        source_changes=(
+            LearningSourceChange(
+                tenant_id=_TENANT_A,
+                previous_signal_id="tailoring-feedback:tailoring-1:1",
+                source_id="tailoring-1",
+                source_revision=1,
+                reason_code="source_deleted",
+                changed_at="2026-08-01T11:30:00Z",
+            ),
+        ),
+        rederived_at="2026-08-01T11:31:00Z",
+    ) == ()
+    assert tuple(
+        conn.execute(
+            """
+            SELECT recommendation_id, reason_code,
+                   replacement_recommendation_id
+            FROM learning_recommendation_tombstones
+            """
+        ).fetchone()
+    ) == (original.recommendation_id, "source_deleted", None)
+    assert conn.execute("SELECT COUNT(*) FROM learning_recommendations").fetchone()[0] == 1
+    close_connection(db_path)
+
+
+def test_source_change_validation_rolls_back_before_audit_mutation(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    conn = init_db(db_path)
+    _seed_tailoring_sources(conn)
+    conn.commit()
+    repository = SqliteLearningRecommendationRepository(conn)
+    repository.rederive_tailoring(
+        _TENANT_A,
+        source_changes=(),
+        rederived_at="2026-08-01T11:00:00Z",
+    )
+
+    with pytest.raises(ValueError, match="no current accepted revision"):
+        repository.rederive_tailoring(
+            _TENANT_A,
+            source_changes=(
+                LearningSourceChange(
+                    tenant_id=_TENANT_A,
+                    previous_signal_id="tailoring-feedback:tailoring-1:1",
+                    source_id="tailoring-1",
+                    source_revision=1,
+                    reason_code="source_deleted",
+                    changed_at="2026-08-01T11:30:00Z",
+                ),
+            ),
+            rederived_at="2026-08-01T11:31:00Z",
+        )
+    assert conn.execute(
+        "SELECT COUNT(*) FROM learning_recommendation_tombstones"
+    ).fetchone()[0] == 0
+    assert conn.execute("SELECT COUNT(*) FROM learning_recommendations").fetchone()[0] == 1
+    close_connection(db_path)
+
+
+def test_multiple_source_changes_each_append_a_tombstone(tmp_path: Path) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    conn = init_db(db_path)
+    _seed_tailoring_sources(conn)
+    conn.commit()
+    repository = SqliteLearningRecommendationRepository(conn)
+    repository.rederive_tailoring(
+        _TENANT_A,
+        source_changes=(),
+        rederived_at="2026-08-01T11:00:00Z",
+    )
+    for signal_id in ("tailoring-1", "tailoring-2"):
+        _insert_tailoring_review(
+            conn,
+            signal_id=signal_id,
+            revision=2,
+            decision="rejected",
+            reviewed_at="2026-08-01T11:30:00Z",
+        )
+    conn.commit()
+
+    changes = tuple(
+        LearningSourceChange(
+            tenant_id=_TENANT_A,
+            previous_signal_id=f"tailoring-feedback:{signal_id}:1",
+            source_id=signal_id,
+            source_revision=1,
+            reason_code="source_deleted",
+            changed_at="2026-08-01T11:30:00Z",
+        )
+        for signal_id in ("tailoring-1", "tailoring-2")
+    )
+    assert repository.rederive_tailoring(
+        _TENANT_A,
+        source_changes=changes,
+        rederived_at="2026-08-01T11:31:00Z",
+    ) == ()
+    assert [
+        str(row[0])
+        for row in conn.execute(
+            """
+            SELECT affected_signal_id
+            FROM learning_recommendation_tombstones
+            ORDER BY affected_signal_id
+            """
+        ).fetchall()
+    ] == [
+        "tailoring-feedback:tailoring-1:1",
+        "tailoring-feedback:tailoring-2:1",
+    ]
+    close_connection(db_path)
+
+
 def _recommendation(tenant_id: TenantId):
     return derive_tailoring_recommendations(
         _signals(tenant_id),
@@ -357,4 +591,87 @@ def _signal(
         rule_key="fact_handling",
         rule_value="require_source_match",
         allowlist_version=1,
+    )
+
+
+def _seed_tailoring_sources(conn) -> None:
+    for index, job_id in enumerate((_JOB_A, _JOB_B), start=1):
+        conn.execute(
+            "INSERT INTO jobs (tenant_id, job_id, url) VALUES (?, ?, ?)",
+            ("tenant-a", job_id, f"https://jobs.example.test/{index}"),
+        )
+    for index, job_id in enumerate((_JOB_A, _JOB_A, _JOB_B), start=1):
+        signal_id = f"tailoring-{index}"
+        draft_id = f"draft-{index}"
+        conn.execute(
+            """
+            INSERT INTO resume_review_drafts (
+                tenant_id, draft_id, job_id, base_generation, renderer_format,
+                state, latest_revision_number, created_at, updated_at
+            ) VALUES (?, ?, ?, 1, 'text', 'active', 0, ?, ?)
+            """,
+            (
+                "tenant-a",
+                draft_id,
+                job_id,
+                "2026-08-01T10:00:00Z",
+                "2026-08-01T10:00:00Z",
+            ),
+        )
+        conn.execute(
+            """
+            INSERT INTO tailoring_feedback_signals (
+                tenant_id, signal_id, job_id, draft_id, source_kind, source_id,
+                signal_kind, status, summary, created_at, reviewed_at
+            ) VALUES (
+                'tenant-a', ?, ?, ?, 'edit_delta', ?,
+                'factual_correction', 'accepted', ?, ?, ?
+            )
+            """,
+            (
+                signal_id,
+                job_id,
+                draft_id,
+                f"private-delta-{index}",
+                "private edit, resume, prompt, and job description",
+                "2026-08-01T10:00:00Z",
+                "2026-08-01T10:00:00Z",
+            ),
+        )
+        _insert_tailoring_review(
+            conn,
+            signal_id=signal_id,
+            revision=1,
+            decision="accepted",
+            reviewed_at=f"2026-08-01T10:00:0{index}Z",
+        )
+
+
+def _insert_tailoring_review(
+    conn,
+    *,
+    signal_id: str,
+    revision: int,
+    decision: str,
+    reviewed_at: str,
+) -> None:
+    accepted = decision == "accepted"
+    conn.execute(
+        """
+        INSERT INTO tailoring_feedback_signal_reviews (
+            tenant_id, review_id, signal_id, revision, decision, signal_kind,
+            rule_key, rule_value, allowlist_version, reviewed_at
+        ) VALUES (
+            'tenant-a', ?, ?, ?, ?, 'factual_correction', ?, ?, 1, ?
+        )
+        """,
+        (
+            f"review-{signal_id}-{revision}",
+            signal_id,
+            revision,
+            decision,
+            "fact_handling" if accepted else None,
+            "require_source_match" if accepted else None,
+            reviewed_at,
+        ),
     )


### PR DESCRIPTION
## Summary

- re-read accepted tenant-scoped tailoring signals and deterministically derive pending recommendations in one SQLite transaction
- validate explicit source-correction/deletion claims against the current accepted revision before mutating audit history
- append source tombstones without erasing prior recommendations and link a truthful replacement only when the threshold still derives one
- make repeated re-derivation idempotent while preserving caller-owned transaction rollback

## Why

Accepted feedback corrections and deletions must invalidate stale pending proposals without rewriting history. This child wires the exact-v7 reader, pure derivation kernel, pending writer, and append-only tombstone ledger together. It does not expose an API/UI, activate policy, or change ranking.

## Validation

- `PYTHONPATH=workers/automation/src /Users/eloibarti/Github/JobHunter/workers/automation/.venv/bin/pytest workers/automation/tests/test_sqlite_learning_recommendations.py workers/automation/tests/test_learning_recommendations.py workers/automation/tests/test_feedback_signal_reader.py workers/automation/tests/test_exact_v7_schema.py::test_learning_recommendation_storage_is_structured_append_only_and_private workers/automation/tests/test_exact_v7_schema.py::test_learning_recommendation_job_provenance_constraints_fail_closed -q`
- `/Users/eloibarti/Github/JobHunter/workers/automation/.venv/bin/ruff check workers/automation/src/jobctrl/domain/operations/learning.py workers/automation/src/jobctrl/domain/operations/__init__.py workers/automation/src/jobctrl/infrastructure/learning/sqlite_repository.py workers/automation/tests/test_sqlite_learning_recommendations.py`
- `git diff --check`

Canonical product documentation remains deferred to the final PR in the approved unreleased stack. Contradiction-trigger wiring and read APIs remain separate child PRs.

Stacked on #679.
