### PR TITLE
feat(api): list learning recommendation summaries

### DIFF
--- a/apps/api/src/learning-recommendations.ts
+++ b/apps/api/src/learning-recommendations.ts
@@ -1,0 +1,134 @@
+import {
+  LearningRecommendationListResponseSchema,
+  type LearningRecommendationListQuery,
+  type LearningRecommendationListResponse,
+} from "./contracts.js";
+import { getRow, allRows, type SqliteDatabase } from "./db.js";
+
+const DEFAULT_TENANT = "local";
+
+interface RecommendationSummaryRow extends Record<string, unknown> {
+  recommendation_id: string;
+  derivation_version: number;
+  evaluation_fixture_version: number;
+  context: "materials";
+  policy_kind: "tailoring_rule";
+  signal_kind:
+    | "style_preference"
+    | "factual_correction"
+    | "claim_policy_correction"
+    | "keyword_strategy"
+    | "provenance_dispute";
+  rule_key: string;
+  rule_value: string;
+  allowlist_version: number;
+  status: "pending";
+  observed_signal_count: number;
+  observed_job_count: number;
+  minimum_signal_count: number;
+  minimum_job_count: number;
+  confidence_limit: "sample_gated_no_population_inference";
+  derived_at: string;
+  supporting_evidence_count: number;
+  contradicting_evidence_count: number;
+  tombstone_count: number;
+}
+
+export function listLearningRecommendations(
+  db: SqliteDatabase,
+  query: LearningRecommendationListQuery,
+): LearningRecommendationListResponse {
+  return db.transaction(() =>
+    listLearningRecommendationsInSnapshot(db, query),
+  )();
+}
+
+function listLearningRecommendationsInSnapshot(
+  db: SqliteDatabase,
+  query: LearningRecommendationListQuery,
+): LearningRecommendationListResponse {
+  const total = Number(
+    getRow<{ count: number }>(
+      db,
+      `SELECT COUNT(*) AS count
+         FROM learning_recommendations
+        WHERE tenant_id = ?`,
+      [DEFAULT_TENANT],
+    )?.count ?? 0,
+  );
+  const offset = (query.page - 1) * query.pageSize;
+  const rows = allRows<RecommendationSummaryRow>(
+    db,
+    `SELECT recommendation.recommendation_id,
+            recommendation.derivation_version,
+            recommendation.evaluation_fixture_version,
+            recommendation.context,
+            recommendation.policy_kind,
+            recommendation.signal_kind,
+            recommendation.rule_key,
+            recommendation.rule_value,
+            recommendation.allowlist_version,
+            recommendation.status,
+            recommendation.observed_signal_count,
+            recommendation.observed_job_count,
+            recommendation.minimum_signal_count,
+            recommendation.minimum_job_count,
+            recommendation.confidence_limit,
+            recommendation.derived_at,
+            (
+              SELECT COUNT(*)
+              FROM learning_recommendation_evidence AS evidence
+              WHERE evidence.tenant_id = recommendation.tenant_id
+                AND evidence.recommendation_id = recommendation.recommendation_id
+                AND evidence.evidence_role = 'supporting'
+            ) AS supporting_evidence_count,
+            (
+              SELECT COUNT(*)
+              FROM learning_recommendation_evidence AS evidence
+              WHERE evidence.tenant_id = recommendation.tenant_id
+                AND evidence.recommendation_id = recommendation.recommendation_id
+                AND evidence.evidence_role = 'contradicting'
+            ) AS contradicting_evidence_count,
+            (
+              SELECT COUNT(*)
+              FROM learning_recommendation_tombstones AS tombstone
+              WHERE tombstone.tenant_id = recommendation.tenant_id
+                AND tombstone.recommendation_id = recommendation.recommendation_id
+            ) AS tombstone_count
+       FROM learning_recommendations AS recommendation
+      WHERE recommendation.tenant_id = ?
+      ORDER BY recommendation.derived_at DESC,
+               recommendation.recommendation_id ASC
+      LIMIT ? OFFSET ?`,
+    [DEFAULT_TENANT, query.pageSize, offset],
+  );
+  return LearningRecommendationListResponseSchema.parse({
+    ok: true,
+    recommendations: rows.map((row) => ({
+      recommendationId: row.recommendation_id,
+      derivationVersion: Number(row.derivation_version),
+      evaluationFixtureVersion: Number(row.evaluation_fixture_version),
+      context: row.context,
+      policyKind: row.policy_kind,
+      signalKind: row.signal_kind,
+      ruleKey: row.rule_key,
+      ruleValue: row.rule_value,
+      allowlistVersion: Number(row.allowlist_version),
+      status: row.status,
+      active: Number(row.tombstone_count) === 0,
+      observedSignalCount: Number(row.observed_signal_count),
+      observedJobCount: Number(row.observed_job_count),
+      minimumSignalCount: Number(row.minimum_signal_count),
+      minimumJobCount: Number(row.minimum_job_count),
+      confidenceLimit: row.confidence_limit,
+      supportingEvidenceCount: Number(row.supporting_evidence_count),
+      contradictingEvidenceCount: Number(row.contradicting_evidence_count),
+      tombstoneCount: Number(row.tombstone_count),
+      derivedAt: row.derived_at,
+    })),
+    page: query.page,
+    pageSize: query.pageSize,
+    total,
+    totalPages: total === 0 ? 0 : Math.ceil(total / query.pageSize),
+  });
+}

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -45,6 +45,7 @@ import {
   EnsureCurrentResumeMaterialsRequestSchema,
   JobResumeTemplateAssignmentRequestSchema,
   JobListQuerySchema,
+  LearningRecommendationListQuerySchema,
   JsonRpcErrorCodes,
   JsonRpcRequestSchema,
   MarkJobActionRequestSchema,
@@ -239,6 +240,7 @@ import {
   readSettingsConfig,
 } from "./read-model.js";
 import { buildPipelineOperationsSnapshot } from "./pipeline-operations.js";
+import { listLearningRecommendations } from "./learning-recommendations.js";
 import { refreshProjections } from "./projections.js";
 import { createResumeHtmlPdfRenderer, type ResumeHtmlPdfRenderer } from "./resume-pdf-render.js";
 import {
@@ -569,6 +571,15 @@ export function buildApp(options: BuildAppOptions): FastifyInstance {
 
   app.get("/v1/scoring/keywords", async (_request, reply) =>
     withDb(reply, options.dbPath, (db) => listScoringKeywords(db)),
+  );
+
+  app.get("/v1/learning/recommendations", async (request, reply) =>
+    withDb(reply, options.dbPath, (db) =>
+      listLearningRecommendations(
+        db,
+        LearningRecommendationListQuerySchema.parse(request.query),
+      ),
+    ),
   );
 
   app.get("/v1/digest", async (_request, reply) =>

--- a/apps/api/test/server.test.ts
+++ b/apps/api/test/server.test.ts
@@ -9,6 +9,7 @@ import {
   CREDENTIAL_VALUE_MAX_LENGTH,
   CredentialKeys,
   JsonRpcErrorCodes,
+  LearningRecommendationListResponseSchema,
   PipelineOperationsSnapshotSchema,
   ProviderConfigurationKeys,
   ScoringKeywordAggregationResponseSchema,
@@ -2411,6 +2412,133 @@ describe("local TypeScript API", () => {
       expect.objectContaining({ method: "GET" }),
     );
     fetchMock.mockRestore();
+    await app.close();
+  });
+
+  it("serves tenant-scoped learning recommendations without source content", async () => {
+    const db = new Database(options.dbPath);
+    insertLearningRecommendationFixture(db, {
+      tenantId: "local",
+      recommendationId: `learning-recommendation:${"a".repeat(64)}`,
+      tombstoned: true,
+    });
+    insertLearningRecommendationFixture(db, {
+      tenantId: "local",
+      recommendationId: `learning-recommendation:${"d".repeat(64)}`,
+      tombstoned: false,
+    });
+    insertLearningRecommendationFixture(db, {
+      tenantId: "other",
+      recommendationId: `learning-recommendation:${"b".repeat(64)}`,
+      tombstoned: false,
+    });
+    db.prepare(
+      `INSERT INTO resume_review_drafts (
+         tenant_id, draft_id, job_id, base_generation, renderer_format,
+         state, latest_revision_number, created_at, updated_at
+       ) VALUES ('local', 'private-learning-draft', ?, 1, 'text',
+                 'active', 0, ?, ?)`,
+    ).run(
+      jobIdFor("https://example.com/jobs/ready"),
+      "2026-08-01T09:00:00Z",
+      "2026-08-01T09:00:00Z",
+    );
+    db.prepare(
+      `INSERT INTO tailoring_feedback_signals (
+         tenant_id, signal_id, job_id, draft_id, source_kind, source_id,
+         signal_kind, status, summary, created_at
+       ) VALUES ('local', 'private-learning-signal', ?,
+                 'private-learning-draft', 'edit_delta', 'private-delta',
+                 'factual_correction', 'candidate', ?, ?)`,
+    ).run(
+      jobIdFor("https://example.com/jobs/ready"),
+      "private resume, prompt, note, and job description",
+      "2026-08-01T09:00:00Z",
+    );
+    const auditBefore = learningAuditSnapshot(db);
+    db.close();
+
+    const app = buildApp(options);
+    const response = await app.inject({
+      method: "GET",
+      url: "/v1/learning/recommendations?page=1&pageSize=1",
+    });
+
+    expect(response.statusCode, response.body).toBe(200);
+    const parsed = LearningRecommendationListResponseSchema.parse(response.json());
+    expect(parsed.recommendations).toHaveLength(1);
+    expect(parsed).toMatchObject({ page: 1, pageSize: 1, total: 2, totalPages: 2 });
+    expect(parsed.recommendations[0]).toMatchObject({
+      recommendationId: `learning-recommendation:${"a".repeat(64)}`,
+      context: "materials",
+      policyKind: "tailoring_rule",
+      signalKind: "factual_correction",
+      ruleKey: "fact_handling",
+      ruleValue: "require_source_match",
+      status: "pending",
+      active: false,
+      observedSignalCount: 3,
+      observedJobCount: 2,
+      minimumSignalCount: 3,
+      minimumJobCount: 2,
+      confidenceLimit: "sample_gated_no_population_inference",
+      supportingEvidenceCount: 3,
+      contradictingEvidenceCount: 1,
+      tombstoneCount: 1,
+    });
+    expect(response.body).not.toContain("private resume, prompt, note, and job description");
+    expect(response.body).not.toContain("source-contradiction-local");
+    expect(response.body).not.toContain(`learning-recommendation:${"b".repeat(64)}`);
+    expect(() =>
+      LearningRecommendationListResponseSchema.parse({
+        ...parsed,
+        recommendations: [
+          {
+            ...parsed.recommendations[0],
+            recommendationId: "https://jobs.example/not-a-recommendation-id",
+          },
+        ],
+      }),
+    ).toThrow();
+    expect(() =>
+      LearningRecommendationListResponseSchema.parse({
+        ...parsed,
+        recommendations: [
+          { ...parsed.recommendations[0], ruleKey: "private free text" },
+        ],
+      }),
+    ).toThrow();
+    const secondPage = LearningRecommendationListResponseSchema.parse(
+      (
+        await app.inject({
+          method: "GET",
+          url: "/v1/learning/recommendations?page=2&pageSize=1",
+        })
+      ).json(),
+    );
+    expect(secondPage).toMatchObject({ page: 2, pageSize: 1, total: 2, totalPages: 2 });
+    expect(secondPage.recommendations).toEqual([
+      expect.objectContaining({
+        recommendationId: `learning-recommendation:${"d".repeat(64)}`,
+        active: true,
+        tombstoneCount: 0,
+      }),
+    ]);
+
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(response.body, { status: 200, statusText: "OK" }),
+    );
+    await expect(
+      createJobCtrlApiClient().learningRecommendations({ page: 1, pageSize: 1 }),
+    ).resolves.toEqual(parsed);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://127.0.0.1:8766/v1/learning/recommendations?page=1&pageSize=1",
+      expect.objectContaining({ method: "GET" }),
+    );
+    fetchMock.mockRestore();
+    const unchanged = new Database(options.dbPath);
+    expect(learningAuditSnapshot(unchanged)).toBe(auditBefore);
+    unchanged.close();
     await app.close();
   });
 
@@ -10158,6 +10286,120 @@ function seedBuiltInResumeTemplate(db: Database.Database): void {
      ) VALUES ('local', 'built_in:modern-html:v1', 'built_in:modern-html', 1,
                'Modern HTML', 'active', ?, '{}', 'server-seed-hash', ?)`,
   ).run(JSON.stringify(BUILT_IN_RESUME_TEMPLATE_THEME), now);
+}
+
+function insertLearningRecommendationFixture(
+  db: Database.Database,
+  options: {
+    tenantId: string;
+    recommendationId: string;
+    tombstoned: boolean;
+  },
+): void {
+  const jobIds = [
+    "11111111-1111-4111-8111-111111111111",
+    "22222222-2222-4222-8222-222222222222",
+  ] as const;
+  db.transaction(() => {
+    for (const index of [1, 2, 3] as const) {
+      const signalId = `signal-${options.tenantId}-${index}`;
+      db.prepare(
+        `INSERT INTO learning_recommendation_evidence (
+           tenant_id, recommendation_id, signal_id, evidence_role,
+           source_kind, source_id, source_revision, recorded_at
+         ) VALUES (?, ?, ?, 'supporting', 'tailoring_feedback_signal', ?, ?, ?)`,
+      ).run(
+        options.tenantId,
+        options.recommendationId,
+        signalId,
+        `source-${options.tenantId}-${index}`,
+        index,
+        `2026-08-01T10:00:0${index}Z`,
+      );
+      db.prepare(
+        `INSERT INTO learning_recommendation_evidence_jobs (
+           tenant_id, recommendation_id, signal_id, job_id
+         ) VALUES (?, ?, ?, ?)`,
+      ).run(
+        options.tenantId,
+        options.recommendationId,
+        signalId,
+        index === 3 ? jobIds[1] : jobIds[0],
+      );
+    }
+    const contradictionId = `contradiction-${options.tenantId}`;
+    db.prepare(
+      `INSERT INTO learning_recommendation_evidence (
+         tenant_id, recommendation_id, signal_id, evidence_role,
+         source_kind, source_id, source_revision, recorded_at
+       ) VALUES (?, ?, ?, 'contradicting', 'tailoring_feedback_signal', ?, 4, ?)`,
+    ).run(
+      options.tenantId,
+      options.recommendationId,
+      contradictionId,
+      options.tenantId === "local"
+        ? "private resume, prompt, note, and job description"
+        : `source-${contradictionId}`,
+      "2026-08-01T10:00:04Z",
+    );
+    db.prepare(
+      `INSERT INTO learning_recommendation_evidence_jobs (
+         tenant_id, recommendation_id, signal_id, job_id
+       ) VALUES (?, ?, ?, '33333333-3333-4333-8333-333333333333')`,
+    ).run(options.tenantId, options.recommendationId, contradictionId);
+    for (const jobId of jobIds) {
+      db.prepare(
+        `INSERT INTO learning_recommendation_jobs (
+           tenant_id, recommendation_id, job_id
+         ) VALUES (?, ?, ?)`,
+      ).run(options.tenantId, options.recommendationId, jobId);
+    }
+    db.prepare(
+      `INSERT INTO learning_recommendations (
+         tenant_id, recommendation_id, derivation_version,
+         evaluation_fixture_version, context, policy_kind, signal_kind,
+         rule_key, rule_value, allowlist_version, status,
+         observed_signal_count, observed_job_count, minimum_signal_count,
+         minimum_job_count, confidence_limit, input_fingerprint, derived_at
+       ) VALUES (
+         ?, ?, 1, 1, 'materials', 'tailoring_rule', 'factual_correction',
+         'fact_handling', 'require_source_match', 1, 'pending', 3, 2, 3, 2,
+         'sample_gated_no_population_inference', ?, '2026-08-01T10:01:00Z'
+       )`,
+    ).run(
+      options.tenantId,
+      options.recommendationId,
+      options.recommendationId.replace("learning-recommendation:", ""),
+    );
+    if (options.tombstoned) {
+      db.prepare(
+        `INSERT INTO learning_recommendation_tombstones (
+           tenant_id, tombstone_id, recommendation_id, affected_signal_id,
+           affected_source_revision, reason_code, derivation_version,
+           tombstoned_at, rederived_at, replacement_recommendation_id
+         ) VALUES (?, ?, ?, ?, 1, 'source_deleted', 1, ?, ?, NULL)`,
+      ).run(
+        options.tenantId,
+        `learning-recommendation-tombstone:${"c".repeat(64)}`,
+        options.recommendationId,
+        `signal-${options.tenantId}-1`,
+        "2026-08-01T10:02:00Z",
+        "2026-08-01T10:02:01Z",
+      );
+    }
+  })();
+}
+
+function learningAuditSnapshot(db: Database.Database): string {
+  return JSON.stringify(
+    [
+      "learning_recommendations",
+      "learning_recommendation_evidence",
+      "learning_recommendation_evidence_jobs",
+      "learning_recommendation_jobs",
+      "learning_recommendation_tombstones",
+    ].map((table) => [table, db.prepare(`SELECT * FROM ${table} ORDER BY rowid`).all()]),
+  );
 }
 
 function seedDatabase(dbPath: string): void {

--- a/packages/api-client/src/client.ts
+++ b/packages/api-client/src/client.ts
@@ -83,6 +83,8 @@ import type {
   JobDetail,
   JobApplicationOutcomeListResponse,
   JobListQuery,
+  LearningRecommendationListResponse,
+  LearningRecommendationListQuery,
   JobMutationResponse,
   JobSummary,
   MarkJobActionRequest,
@@ -154,6 +156,7 @@ import type {
   WorkflowRunSummary,
   WorkflowRunsListQuery,
 } from "@jobctrl/contracts";
+import { LearningRecommendationListResponseSchema } from "@jobctrl/contracts";
 
 type QueryValue = boolean | number | string | null | undefined;
 const DEFAULT_NODE_BASE_URL = "http://127.0.0.1:8766";
@@ -243,6 +246,14 @@ export class JobCtrlApiClient {
 
   scoringKeywords(): Promise<ScoringKeywordAggregationResponse> {
     return this.get("/v1/scoring/keywords");
+  }
+
+  async learningRecommendations(
+    query: Partial<LearningRecommendationListQuery> = {},
+  ): Promise<LearningRecommendationListResponse> {
+    return LearningRecommendationListResponseSchema.parse(
+      await this.get("/v1/learning/recommendations", query),
+    );
   }
 
   digest(): Promise<DailyDigest> {

--- a/packages/contracts/src/schemas.ts
+++ b/packages/contracts/src/schemas.ts
@@ -2183,6 +2183,76 @@ export const ScoringKeywordAggregationResponseSchema = z
   .strict();
 export type ScoringKeywordAggregationResponse = z.infer<typeof ScoringKeywordAggregationResponseSchema>;
 
+const LearningRecommendationIdSchema = z
+  .string()
+  .regex(/^learning-recommendation:[a-f0-9]{64}$/);
+
+export const LearningRecommendationListQuerySchema = z
+  .object({
+    page: z.coerce.number().int().min(1).default(1).catch(1),
+    pageSize: z.coerce.number().int().min(1).max(100).optional().catch(undefined),
+    page_size: z.coerce.number().int().min(1).max(100).optional().catch(undefined),
+  })
+  .transform((value) => ({
+    page: value.page,
+    pageSize: value.pageSize ?? value.page_size ?? 50,
+  }));
+export type LearningRecommendationListQuery = z.infer<
+  typeof LearningRecommendationListQuerySchema
+>;
+
+export const LearningRecommendationSummarySchema = z
+  .object({
+    recommendationId: LearningRecommendationIdSchema,
+    derivationVersion: z.number().int().positive(),
+    evaluationFixtureVersion: z.number().int().positive(),
+    context: z.literal("materials"),
+    policyKind: z.literal("tailoring_rule"),
+    signalKind: z.enum([
+      "style_preference",
+      "factual_correction",
+      "claim_policy_correction",
+      "keyword_strategy",
+      "provenance_dispute",
+    ]),
+    ruleKey: z.string().min(1).max(80).regex(/^[a-z0-9_]+$/),
+    ruleValue: z.string().min(1).max(160).regex(/^[a-z0-9_]+$/),
+    allowlistVersion: z.number().int().positive(),
+    status: z.literal("pending"),
+    active: z.boolean(),
+    observedSignalCount: z.number().int().min(3),
+    observedJobCount: z.number().int().min(2),
+    minimumSignalCount: z.number().int().min(3),
+    minimumJobCount: z.number().int().min(2),
+    confidenceLimit: z.literal("sample_gated_no_population_inference"),
+    supportingEvidenceCount: z.number().int().min(3),
+    contradictingEvidenceCount: z.number().int().nonnegative(),
+    tombstoneCount: z.number().int().nonnegative(),
+    derivedAt: IsoTimestampSchema,
+  })
+  .strict();
+export type LearningRecommendationSummary = z.infer<
+  typeof LearningRecommendationSummarySchema
+>;
+
+export const LearningRecommendationListResponseSchema = z
+  .object({
+    ok: z.literal(true),
+    recommendations: z.array(LearningRecommendationSummarySchema).max(100),
+    page: z.number().int().min(1),
+    pageSize: z.number().int().min(1).max(100),
+    total: z.number().int().nonnegative(),
+    totalPages: z.number().int().nonnegative(),
+  })
+  .strict()
+  .refine(
+    (value) => value.recommendations.length <= value.pageSize,
+    "Recommendation page exceeds its declared page size.",
+  );
+export type LearningRecommendationListResponse = z.infer<
+  typeof LearningRecommendationListResponseSchema
+>;
+
 export const ArtifactListQuerySchema = z
   .object({
     page: z.coerce.number().int().min(1).default(1).catch(1),


### PR DESCRIPTION
## Summary

- expose tenant-scoped learning recommendation history through a bounded, paginated read-only API contract
- return structured proposed effects, thresholds, sample limits, and supporting/contradicting/tombstone counts without source identifiers or raw evidence
- mark tombstoned recommendations inactive without rewriting their pending audit record
- runtime-validate both server and client responses and cover adversarial persisted private evidence

## Why

Pending recommendations need a bounded discovery contract before separately paginated evidence detail, explicit review, and policy revision can be added. This endpoint caps each SQL page at 100 summaries and never returns source IDs, raw notes, resumes, job descriptions, prompts, mail, or source bodies. It performs no writes and cannot activate policy.

## Validation

- `/Users/eloibarti/.nvm/versions/node/v22.21.1/bin/pnpm --filter @jobctrl/api exec vitest run test/server.test.ts -t "serves tenant-scoped learning recommendations without source content"`
- `/Users/eloibarti/.nvm/versions/node/v22.21.1/bin/pnpm --filter @jobctrl/api check`
- `/Users/eloibarti/.nvm/versions/node/v22.21.1/bin/pnpm --filter @jobctrl/contracts check`
- `/Users/eloibarti/.nvm/versions/node/v22.21.1/bin/pnpm --filter @jobctrl/api-client check`
- `git diff --check`

Canonical product documentation remains deferred to the final PR in the approved unreleased stack. Paginated evidence detail, explicit review, and policy activation remain separate child PRs.

Stacked on #680.
