### PR TITLE
feat(api): inspect learning recommendation evidence

### DIFF
--- a/apps/api/src/learning-recommendations.ts
+++ b/apps/api/src/learning-recommendations.ts
@@ -1,5 +1,8 @@
 import {
+  LearningRecommendationEvidenceListResponseSchema,
   LearningRecommendationListResponseSchema,
+  type LearningRecommendationEvidenceListQuery,
+  type LearningRecommendationEvidenceListResponse,
   type LearningRecommendationListQuery,
   type LearningRecommendationListResponse,
 } from "./contracts.js";
@@ -32,6 +35,15 @@ interface RecommendationSummaryRow extends Record<string, unknown> {
   supporting_evidence_count: number;
   contradicting_evidence_count: number;
   tombstone_count: number;
+}
+
+interface RecommendationEvidenceLinkRow extends Record<string, unknown> {
+  signal_id: string;
+  evidence_role: "supporting" | "contradicting";
+  source_kind: "tailoring_feedback_signal";
+  source_revision: number;
+  job_id: string;
+  recorded_at: string;
 }
 
 export function listLearningRecommendations(
@@ -131,4 +143,81 @@ function listLearningRecommendationsInSnapshot(
     total,
     totalPages: total === 0 ? 0 : Math.ceil(total / query.pageSize),
   });
+}
+
+export function listLearningRecommendationEvidence(
+  db: SqliteDatabase,
+  recommendationId: string,
+  query: LearningRecommendationEvidenceListQuery,
+): LearningRecommendationEvidenceListResponse | null {
+  return db.transaction(() => {
+    const recommendation = getRow<{ recommendation_id: string }>(
+      db,
+      `SELECT recommendation_id
+         FROM learning_recommendations
+        WHERE tenant_id = ?
+          AND recommendation_id = ?`,
+      [DEFAULT_TENANT, recommendationId],
+    );
+    if (!recommendation) {
+      return null;
+    }
+
+    const total = Number(
+      getRow<{ count: number }>(
+        db,
+        `SELECT COUNT(*) AS count
+           FROM learning_recommendation_evidence AS evidence
+           JOIN learning_recommendation_evidence_jobs AS evidence_job
+             ON evidence_job.tenant_id = evidence.tenant_id
+            AND evidence_job.recommendation_id = evidence.recommendation_id
+            AND evidence_job.signal_id = evidence.signal_id
+          WHERE evidence.tenant_id = ?
+            AND evidence.recommendation_id = ?`,
+        [DEFAULT_TENANT, recommendationId],
+      )?.count ?? 0,
+    );
+    const offset = (query.page - 1) * query.pageSize;
+    const rows = allRows<RecommendationEvidenceLinkRow>(
+      db,
+      `SELECT evidence.signal_id,
+              evidence.evidence_role,
+              evidence.source_kind,
+              evidence.source_revision,
+              evidence_job.job_id,
+              evidence.recorded_at
+         FROM learning_recommendation_evidence AS evidence
+         JOIN learning_recommendation_evidence_jobs AS evidence_job
+           ON evidence_job.tenant_id = evidence.tenant_id
+          AND evidence_job.recommendation_id = evidence.recommendation_id
+          AND evidence_job.signal_id = evidence.signal_id
+        WHERE evidence.tenant_id = ?
+          AND evidence.recommendation_id = ?
+        ORDER BY CASE evidence.evidence_role
+                   WHEN 'supporting' THEN 0
+                   ELSE 1
+                 END,
+                 evidence.recorded_at ASC,
+                 evidence.signal_id ASC,
+                 evidence_job.job_id ASC
+        LIMIT ? OFFSET ?`,
+      [DEFAULT_TENANT, recommendationId, query.pageSize, offset],
+    );
+    return LearningRecommendationEvidenceListResponseSchema.parse({
+      ok: true,
+      recommendationId,
+      evidence: rows.map((row) => ({
+        signalId: row.signal_id,
+        evidenceRole: row.evidence_role,
+        sourceKind: row.source_kind,
+        sourceRevision: Number(row.source_revision),
+        jobId: row.job_id,
+        recordedAt: row.recorded_at,
+      })),
+      page: query.page,
+      pageSize: query.pageSize,
+      total,
+      totalPages: total === 0 ? 0 : Math.ceil(total / query.pageSize),
+    });
+  })();
 }

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -45,6 +45,8 @@ import {
   EnsureCurrentResumeMaterialsRequestSchema,
   JobResumeTemplateAssignmentRequestSchema,
   JobListQuerySchema,
+  LearningRecommendationEvidenceListQuerySchema,
+  LearningRecommendationIdSchema,
   LearningRecommendationListQuerySchema,
   JsonRpcErrorCodes,
   JsonRpcRequestSchema,
@@ -240,7 +242,10 @@ import {
   readSettingsConfig,
 } from "./read-model.js";
 import { buildPipelineOperationsSnapshot } from "./pipeline-operations.js";
-import { listLearningRecommendations } from "./learning-recommendations.js";
+import {
+  listLearningRecommendationEvidence,
+  listLearningRecommendations,
+} from "./learning-recommendations.js";
 import { refreshProjections } from "./projections.js";
 import { createResumeHtmlPdfRenderer, type ResumeHtmlPdfRenderer } from "./resume-pdf-render.js";
 import {
@@ -580,6 +585,31 @@ export function buildApp(options: BuildAppOptions): FastifyInstance {
         LearningRecommendationListQuerySchema.parse(request.query),
       ),
     ),
+  );
+
+  app.get<{ Params: { recommendationId: string } }>(
+    "/v1/learning/recommendations/:recommendationId/evidence",
+    async (request, reply) => {
+      const parsedRecommendationId = LearningRecommendationIdSchema.safeParse(
+        decodeRouteParam(request.params.recommendationId),
+      );
+      if (!parsedRecommendationId.success) {
+        void reply.code(400);
+        return { ok: false, error: "invalid_learning_recommendation_id" };
+      }
+      return withDb(reply, options.dbPath, (db) => {
+        const response = listLearningRecommendationEvidence(
+          db,
+          parsedRecommendationId.data,
+          LearningRecommendationEvidenceListQuerySchema.parse(request.query),
+        );
+        if (!response) {
+          void reply.code(404);
+          return { ok: false, error: "learning_recommendation_not_found" };
+        }
+        return response;
+      });
+    },
   );
 
   app.get("/v1/digest", async (_request, reply) =>

--- a/apps/api/test/server.test.ts
+++ b/apps/api/test/server.test.ts
@@ -9,6 +9,7 @@ import {
   CREDENTIAL_VALUE_MAX_LENGTH,
   CredentialKeys,
   JsonRpcErrorCodes,
+  LearningRecommendationEvidenceListResponseSchema,
   LearningRecommendationListResponseSchema,
   PipelineOperationsSnapshotSchema,
   ProviderConfigurationKeys,
@@ -2536,6 +2537,166 @@ describe("local TypeScript API", () => {
       expect.objectContaining({ method: "GET" }),
     );
     fetchMock.mockRestore();
+    const unchanged = new Database(options.dbPath);
+    expect(learningAuditSnapshot(unchanged)).toBe(auditBefore);
+    unchanged.close();
+    await app.close();
+  });
+
+  it("serves paginated recommendation evidence links without source content", async () => {
+    const recommendationId = `learning-recommendation:${"a".repeat(64)}`;
+    const otherTenantRecommendationId = `learning-recommendation:${"b".repeat(64)}`;
+    const db = new Database(options.dbPath);
+    insertLearningRecommendationFixture(db, {
+      tenantId: "local",
+      recommendationId,
+      tombstoned: false,
+    });
+    insertLearningRecommendationFixture(db, {
+      tenantId: "other",
+      recommendationId: otherTenantRecommendationId,
+      tombstoned: false,
+    });
+    const auditBefore = learningAuditSnapshot(db);
+    db.close();
+
+    const app = buildApp(options);
+    const firstResponse = await app.inject({
+      method: "GET",
+      url: `/v1/learning/recommendations/${encodeURIComponent(recommendationId)}/evidence?page=1&pageSize=3`,
+    });
+
+    expect(firstResponse.statusCode, firstResponse.body).toBe(200);
+    const firstPage = LearningRecommendationEvidenceListResponseSchema.parse(
+      firstResponse.json(),
+    );
+    expect(firstPage).toMatchObject({
+      recommendationId,
+      page: 1,
+      pageSize: 3,
+      total: 4,
+      totalPages: 2,
+    });
+    expect(firstPage.evidence).toEqual([
+      {
+        signalId: "signal-local-1",
+        evidenceRole: "supporting",
+        sourceKind: "tailoring_feedback_signal",
+        sourceRevision: 1,
+        jobId: "11111111-1111-4111-8111-111111111111",
+        recordedAt: "2026-08-01T10:00:01.000Z",
+      },
+      {
+        signalId: "signal-local-2",
+        evidenceRole: "supporting",
+        sourceKind: "tailoring_feedback_signal",
+        sourceRevision: 2,
+        jobId: "11111111-1111-4111-8111-111111111111",
+        recordedAt: "2026-08-01T10:00:02.000Z",
+      },
+      {
+        signalId: "signal-local-3",
+        evidenceRole: "supporting",
+        sourceKind: "tailoring_feedback_signal",
+        sourceRevision: 3,
+        jobId: "22222222-2222-4222-8222-222222222222",
+        recordedAt: "2026-08-01T10:00:03.000Z",
+      },
+    ]);
+    expect(firstResponse.body).not.toContain(
+      "private resume, prompt, note, and job description",
+    );
+    expect(firstResponse.body).not.toContain("source-local-1");
+
+    const secondResponse = await app.inject({
+      method: "GET",
+      url: `/v1/learning/recommendations/${encodeURIComponent(recommendationId)}/evidence?page=2&pageSize=3`,
+    });
+    expect(secondResponse.statusCode, secondResponse.body).toBe(200);
+    const secondPage = LearningRecommendationEvidenceListResponseSchema.parse(
+      secondResponse.json(),
+    );
+    expect(secondPage.evidence).toEqual([
+      {
+        signalId: "contradiction-local",
+        evidenceRole: "contradicting",
+        sourceKind: "tailoring_feedback_signal",
+        sourceRevision: 4,
+        jobId: "33333333-3333-4333-8333-333333333333",
+        recordedAt: "2026-08-01T10:00:04.000Z",
+      },
+    ]);
+    expect(secondResponse.body).not.toContain(
+      "private resume, prompt, note, and job description",
+    );
+
+    const otherTenant = await app.inject({
+      method: "GET",
+      url: `/v1/learning/recommendations/${encodeURIComponent(otherTenantRecommendationId)}/evidence`,
+    });
+    expect(otherTenant.statusCode, otherTenant.body).toBe(404);
+    expect(otherTenant.json()).toEqual({
+      ok: false,
+      error: "learning_recommendation_not_found",
+    });
+    const invalid = await app.inject({
+      method: "GET",
+      url: `/v1/learning/recommendations/${encodeURIComponent("https://jobs.example/not-an-id")}/evidence`,
+    });
+    expect(invalid.statusCode, invalid.body).toBe(400);
+    expect(invalid.json()).toEqual({
+      ok: false,
+      error: "invalid_learning_recommendation_id",
+    });
+    expect(() =>
+      LearningRecommendationEvidenceListResponseSchema.parse({
+        ...firstPage,
+        evidence: [
+          {
+            ...firstPage.evidence[0],
+            signalId: "private free text",
+          },
+        ],
+      }),
+    ).toThrow();
+    expect(() =>
+      LearningRecommendationEvidenceListResponseSchema.parse({
+        ...firstPage,
+        evidence: [
+          {
+            ...firstPage.evidence[0],
+            jobId: "AAAAAAAA-AAAA-4AAA-8AAA-AAAAAAAAAAAA",
+          },
+        ],
+      }),
+    ).toThrow();
+    expect(() =>
+      LearningRecommendationEvidenceListResponseSchema.parse({
+        ...firstPage,
+        evidence: [
+          {
+            ...firstPage.evidence[0],
+            jobId: "https://jobs.example/url-is-not-a-job-id",
+          },
+        ],
+      }),
+    ).toThrow();
+
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(firstResponse.body, { status: 200, statusText: "OK" }),
+    );
+    await expect(
+      createJobCtrlApiClient().learningRecommendationEvidence(recommendationId, {
+        page: 1,
+        pageSize: 3,
+      }),
+    ).resolves.toEqual(firstPage);
+    expect(fetchMock).toHaveBeenCalledWith(
+      `http://127.0.0.1:8766/v1/learning/recommendations/${encodeURIComponent(recommendationId)}/evidence?page=1&pageSize=3`,
+      expect.objectContaining({ method: "GET" }),
+    );
+    fetchMock.mockRestore();
+
     const unchanged = new Database(options.dbPath);
     expect(learningAuditSnapshot(unchanged)).toBe(auditBefore);
     unchanged.close();

--- a/packages/api-client/src/client.ts
+++ b/packages/api-client/src/client.ts
@@ -83,6 +83,8 @@ import type {
   JobDetail,
   JobApplicationOutcomeListResponse,
   JobListQuery,
+  LearningRecommendationEvidenceListQuery,
+  LearningRecommendationEvidenceListResponse,
   LearningRecommendationListResponse,
   LearningRecommendationListQuery,
   JobMutationResponse,
@@ -156,7 +158,10 @@ import type {
   WorkflowRunSummary,
   WorkflowRunsListQuery,
 } from "@jobctrl/contracts";
-import { LearningRecommendationListResponseSchema } from "@jobctrl/contracts";
+import {
+  LearningRecommendationEvidenceListResponseSchema,
+  LearningRecommendationListResponseSchema,
+} from "@jobctrl/contracts";
 
 type QueryValue = boolean | number | string | null | undefined;
 const DEFAULT_NODE_BASE_URL = "http://127.0.0.1:8766";
@@ -253,6 +258,18 @@ export class JobCtrlApiClient {
   ): Promise<LearningRecommendationListResponse> {
     return LearningRecommendationListResponseSchema.parse(
       await this.get("/v1/learning/recommendations", query),
+    );
+  }
+
+  async learningRecommendationEvidence(
+    recommendationId: string,
+    query: Partial<LearningRecommendationEvidenceListQuery> = {},
+  ): Promise<LearningRecommendationEvidenceListResponse> {
+    return LearningRecommendationEvidenceListResponseSchema.parse(
+      await this.get(
+        `/v1/learning/recommendations/${encodeURIComponent(recommendationId)}/evidence`,
+        query,
+      ),
     );
   }
 

--- a/packages/contracts/src/schemas.ts
+++ b/packages/contracts/src/schemas.ts
@@ -2183,9 +2183,21 @@ export const ScoringKeywordAggregationResponseSchema = z
   .strict();
 export type ScoringKeywordAggregationResponse = z.infer<typeof ScoringKeywordAggregationResponseSchema>;
 
-const LearningRecommendationIdSchema = z
+export const LearningRecommendationIdSchema = z
   .string()
   .regex(/^learning-recommendation:[a-f0-9]{64}$/);
+
+const LearningEvidenceIdentifierSchema = z
+  .string()
+  .min(1)
+  .max(200)
+  .regex(/^[A-Za-z0-9_.:-]+$/);
+
+const LearningEvidenceJobIdSchema = z
+  .string()
+  .regex(
+    /^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/,
+  );
 
 export const LearningRecommendationListQuerySchema = z
   .object({
@@ -2251,6 +2263,45 @@ export const LearningRecommendationListResponseSchema = z
   );
 export type LearningRecommendationListResponse = z.infer<
   typeof LearningRecommendationListResponseSchema
+>;
+
+export const LearningRecommendationEvidenceListQuerySchema =
+  LearningRecommendationListQuerySchema;
+export type LearningRecommendationEvidenceListQuery = z.infer<
+  typeof LearningRecommendationEvidenceListQuerySchema
+>;
+
+export const LearningRecommendationEvidenceLinkSchema = z
+  .object({
+    signalId: LearningEvidenceIdentifierSchema,
+    evidenceRole: z.enum(["supporting", "contradicting"]),
+    sourceKind: z.literal("tailoring_feedback_signal"),
+    sourceRevision: z.number().int().positive(),
+    jobId: LearningEvidenceJobIdSchema,
+    recordedAt: IsoTimestampSchema,
+  })
+  .strict();
+export type LearningRecommendationEvidenceLink = z.infer<
+  typeof LearningRecommendationEvidenceLinkSchema
+>;
+
+export const LearningRecommendationEvidenceListResponseSchema = z
+  .object({
+    ok: z.literal(true),
+    recommendationId: LearningRecommendationIdSchema,
+    evidence: z.array(LearningRecommendationEvidenceLinkSchema).max(100),
+    page: z.number().int().min(1),
+    pageSize: z.number().int().min(1).max(100),
+    total: z.number().int().nonnegative(),
+    totalPages: z.number().int().nonnegative(),
+  })
+  .strict()
+  .refine(
+    (value) => value.evidence.length <= value.pageSize,
+    "Recommendation evidence page exceeds its declared page size.",
+  );
+export type LearningRecommendationEvidenceListResponse = z.infer<
+  typeof LearningRecommendationEvidenceListResponseSchema
 >;
 
 export const ArtifactListQuerySchema = z


### PR DESCRIPTION
## Summary

- add a separately paginated, tenant-scoped evidence-link endpoint for one pending learning recommendation
- expose supporting and contradicting signal IDs, structured source kind/revision, canonical JobIds, and recorded timestamps
- omit persisted source IDs and all raw source content while validating the response at both server and client boundaries

## Why

Recommendation review needs inspectable provenance without returning unbounded nested arrays or privacy-sensitive source material. This child endpoint pages the canonical evidence-to-job links at a maximum of 100 records, uses one SQLite read snapshot, and performs no writes or policy activation.

## Validation

- `/Users/eloibarti/.nvm/versions/node/v22.21.1/bin/pnpm --filter @jobctrl/api exec vitest run test/server.test.ts -t "serves paginated recommendation evidence links without source content"`
- `/Users/eloibarti/.nvm/versions/node/v22.21.1/bin/pnpm --filter @jobctrl/api check`
- `/Users/eloibarti/.nvm/versions/node/v22.21.1/bin/pnpm --filter @jobctrl/contracts check`
- `/Users/eloibarti/.nvm/versions/node/v22.21.1/bin/pnpm --filter @jobctrl/api-client check`
- `git diff --check`

Canonical product documentation remains deferred to the final PR in the approved unreleased stack. Recommendation review and policy activation remain separate child PRs.

Stacked on #681.
