### PR TITLE
feat(storage): add explicit learning contradiction ledger

### DIFF
--- a/apps/api/src/schema-manifest.ts
+++ b/apps/api/src/schema-manifest.ts
@@ -14,9 +14,9 @@ export type SchemaManifest = {
 // a different schema.
 export const EXACT_V7_SCHEMA_MANIFEST: SchemaManifest = {
   version: 7,
-  objectCount: 231,
-  tableCount: 108,
-  fingerprint: "8b2179d91d202bf43c5463ceb7f34313a0c75f296b20335ee4364cfa8d2e78bd",
+  objectCount: 236,
+  tableCount: 109,
+  fingerprint: "3b6ad22091d895ef141917e080df86b02dc21c56a1f9ffe3b70da3c9db6edad8",
 };
 
 type SqliteMasterRow = [type: string, name: string, tableName: string, sql: string];

--- a/apps/api/test/schema-version-guard.test.ts
+++ b/apps/api/test/schema-version-guard.test.ts
@@ -142,14 +142,14 @@ describe("schema version guard at DB open", () => {
     const pythonManifest = fs.readFileSync(pythonManifestPath, "utf8");
 
     expect(pythonManifest).toContain("version=7,");
-    expect(pythonManifest).toContain("object_count=231,");
-    expect(pythonManifest).toContain("table_count=108,");
+    expect(pythonManifest).toContain("object_count=236,");
+    expect(pythonManifest).toContain("table_count=109,");
     expect(pythonManifest).toContain(`fingerprint=\"${EXACT_V7_SCHEMA_MANIFEST.fingerprint}\",`);
     expect(EXACT_V7_SCHEMA_MANIFEST).toEqual({
       version: SUPPORTED_SCHEMA_VERSION,
-      objectCount: 231,
-      tableCount: 108,
-      fingerprint: "8b2179d91d202bf43c5463ceb7f34313a0c75f296b20335ee4364cfa8d2e78bd",
+      objectCount: 236,
+      tableCount: 109,
+      fingerprint: "3b6ad22091d895ef141917e080df86b02dc21c56a1f9ffe3b70da3c9db6edad8",
     });
   });
 });

--- a/workers/automation/src/jobctrl/infrastructure/migrations/schema_manifest.py
+++ b/workers/automation/src/jobctrl/infrastructure/migrations/schema_manifest.py
@@ -23,9 +23,9 @@ class SchemaManifest:
 # semantically meaningful and must never normalize to the same fingerprint.
 EXACT_V7_MANIFEST = SchemaManifest(
     version=7,
-    object_count=231,
-    table_count=108,
-    fingerprint="8b2179d91d202bf43c5463ceb7f34313a0c75f296b20335ee4364cfa8d2e78bd",
+    object_count=236,
+    table_count=109,
+    fingerprint="3b6ad22091d895ef141917e080df86b02dc21c56a1f9ffe3b70da3c9db6edad8",
 )
 
 

--- a/workers/automation/src/jobctrl/infrastructure/migrations/schema_v7.sql
+++ b/workers/automation/src/jobctrl/infrastructure/migrations/schema_v7.sql
@@ -1776,6 +1776,67 @@ BEFORE DELETE ON tailoring_feedback_signal_reviews
 BEGIN
   SELECT RAISE(ABORT, 'tailoring feedback reviews are append-only');
 END;
+CREATE TABLE tailoring_feedback_signal_contradictions (
+      tenant_id                    TEXT NOT NULL DEFAULT 'local',
+      contradiction_id            TEXT NOT NULL,
+      signal_id                    TEXT NOT NULL,
+      signal_revision              INTEGER NOT NULL CHECK(signal_revision > 0),
+      signal_job_id                TEXT NOT NULL CHECK(
+        length(signal_job_id) = 36
+        AND substr(signal_job_id, 9, 1) = '-'
+        AND substr(signal_job_id, 14, 1) = '-'
+        AND substr(signal_job_id, 19, 1) = '-'
+        AND substr(signal_job_id, 24, 1) = '-'
+        AND replace(signal_job_id, '-', '') NOT GLOB '*[^a-f0-9]*'
+      ),
+      contradicting_signal_id      TEXT NOT NULL,
+      contradicting_signal_revision INTEGER NOT NULL CHECK(
+        contradicting_signal_revision > 0
+      ),
+      contradicting_signal_job_id  TEXT NOT NULL CHECK(
+        length(contradicting_signal_job_id) = 36
+        AND substr(contradicting_signal_job_id, 9, 1) = '-'
+        AND substr(contradicting_signal_job_id, 14, 1) = '-'
+        AND substr(contradicting_signal_job_id, 19, 1) = '-'
+        AND substr(contradicting_signal_job_id, 24, 1) = '-'
+        AND replace(contradicting_signal_job_id, '-', '') NOT GLOB '*[^a-f0-9]*'
+      ),
+      recorded_at                  TEXT NOT NULL,
+      PRIMARY KEY (tenant_id, contradiction_id),
+      UNIQUE (
+        tenant_id,
+        signal_id,
+        signal_revision,
+        contradicting_signal_id,
+        contradicting_signal_revision
+      ),
+      FOREIGN KEY (tenant_id, signal_id, signal_revision)
+        REFERENCES tailoring_feedback_signal_reviews(tenant_id, signal_id, revision)
+        ON DELETE RESTRICT,
+      FOREIGN KEY (
+        tenant_id,
+        contradicting_signal_id,
+        contradicting_signal_revision
+      ) REFERENCES tailoring_feedback_signal_reviews(tenant_id, signal_id, revision)
+        ON DELETE RESTRICT,
+      CHECK (
+        signal_id < contradicting_signal_id
+        OR (
+          signal_id = contradicting_signal_id
+          AND signal_revision < contradicting_signal_revision
+        )
+      )
+    );
+CREATE TRIGGER prevent_tailoring_feedback_signal_contradiction_update
+BEFORE UPDATE ON tailoring_feedback_signal_contradictions
+BEGIN
+  SELECT RAISE(ABORT, 'tailoring feedback contradictions are append-only');
+END;
+CREATE TRIGGER prevent_tailoring_feedback_signal_contradiction_delete
+BEFORE DELETE ON tailoring_feedback_signal_contradictions
+BEGIN
+  SELECT RAISE(ABORT, 'tailoring feedback contradictions are append-only');
+END;
 CREATE TABLE tailoring_feedback_signals (
       tenant_id         TEXT NOT NULL DEFAULT 'local',
       signal_id         TEXT NOT NULL,
@@ -2461,6 +2522,18 @@ CREATE INDEX idx_tailoring_feedback_signal_reviews_signal
       ON tailoring_feedback_signal_reviews(tenant_id, signal_id, revision DESC);
 CREATE INDEX idx_tailoring_feedback_signal_reviews_decision
       ON tailoring_feedback_signal_reviews(tenant_id, decision, reviewed_at DESC);
+CREATE INDEX idx_tailoring_feedback_signal_contradictions_signal
+      ON tailoring_feedback_signal_contradictions(
+        tenant_id,
+        signal_id,
+        signal_revision
+      );
+CREATE INDEX idx_tailoring_feedback_signal_contradictions_other
+      ON tailoring_feedback_signal_contradictions(
+        tenant_id,
+        contradicting_signal_id,
+        contradicting_signal_revision
+      );
 CREATE INDEX idx_learning_recommendations_tenant_derived
       ON learning_recommendations(tenant_id, derived_at DESC, recommendation_id);
 CREATE INDEX idx_learning_recommendation_evidence_signal

--- a/workers/automation/src/jobctrl/infrastructure/migrations/v6_to_v7_plan.py
+++ b/workers/automation/src/jobctrl/infrastructure/migrations/v6_to_v7_plan.py
@@ -243,6 +243,7 @@ def _table_plans() -> dict[str, TablePlan]:
         "learning_recommendation_jobs",
         "learning_recommendation_tombstones",
         "learning_recommendations",
+        "tailoring_feedback_signal_contradictions",
         "tailoring_feedback_signal_reviews",
     ):
         plans[table] = TablePlan(
@@ -547,6 +548,7 @@ _DECLARED_COLUMNS: Final[Mapping[str, frozenset[str]]] = _column_manifest(
         "source_quality_stats": "tenant_id source_id window_start window_end run_count failed_run_count consecutive_failures observed_jobs new_jobs existing_jobs duplicate_jobs active_jobs stale_jobs detail_success_count detail_failure_count active_verification_rate duplicate_rate full_description_success_rate apply_url_success_rate last_run_id last_error_class recommended_state updated_at",
         "source_registry_entries": "tenant_id source_id kind display_name owner priority state policy_id seed_url created_at updated_at",
         "tailoring_feedback_signals": "tenant_id signal_id job_key job_id draft_id draft_revision_id source_kind source_id signal_kind status summary section semantic_id created_at reviewed_at",
+        "tailoring_feedback_signal_contradictions": "tenant_id contradiction_id signal_id signal_revision signal_job_id contradicting_signal_id contradicting_signal_revision contradicting_signal_job_id recorded_at",
         "tailoring_feedback_signal_reviews": "tenant_id review_id signal_id revision decision signal_kind rule_key rule_value allowlist_version reviewed_at",
         "tailoring_policies": "tenant_id version prompt_version schema_version judge_schema_version prompt_fingerprint config_fingerprint profile_policy_fingerprint custom_prompt_fingerprint generator_settings_json judge_settings_json runtime_settings_json rollback_of_version rollback_reason created_at created_from_event_id",
         "worker_runtime_heartbeats": "worker_id component pid hostname app_dir db_path task_queue started_at last_seen_at max_concurrent_activities activity_executor_max_workers active_activity_count active_activity_counts_json active_activity_details_json active_activity_details_total active_activity_details_truncated activity_duration_summary_json task_queue_observation_json heartbeat_schema_version",

--- a/workers/automation/tests/test_exact_v7_schema.py
+++ b/workers/automation/tests/test_exact_v7_schema.py
@@ -43,6 +43,7 @@ _CROSS_RUNTIME_DURABLE_TABLES = {
     "resume_review_drafts",
     "resume_review_edit_deltas",
     "tailoring_feedback_signals",
+    "tailoring_feedback_signal_contradictions",
     "tailoring_feedback_signal_reviews",
     "worker_runtime_heartbeats",
 }
@@ -537,6 +538,75 @@ def test_tailoring_feedback_reviews_are_structured_append_only_facts(
         """,
         ("2026-08-01T00:02:00Z",),
     )
+    conn.execute(
+        """
+        INSERT INTO tailoring_feedback_signals (
+            tenant_id, signal_id, job_id, draft_id, source_kind, source_id,
+            signal_kind, status, summary, created_at
+        ) VALUES (
+            'local', 'signal-2', ?, 'draft-1', 'comment_reply', 'reply-2',
+            'factual_correction', 'candidate', 'private contradiction text', ?
+        )
+        """,
+        (job_id, "2026-08-01T00:01:30Z"),
+    )
+    conn.execute(
+        """
+        INSERT INTO tailoring_feedback_signal_reviews (
+            tenant_id, review_id, signal_id, revision, decision, signal_kind,
+            rule_key, rule_value, allowlist_version, reviewed_at
+        ) VALUES (
+            'local', 'review-2', 'signal-2', 1, 'accepted',
+            'factual_correction', 'fact_handling', 'require_source_match', 1, ?
+        )
+        """,
+        ("2026-08-01T00:02:30Z",),
+    )
+    conn.execute(
+        """
+        INSERT INTO tailoring_feedback_signal_contradictions (
+            tenant_id, contradiction_id, signal_id, signal_revision,
+            signal_job_id, contradicting_signal_id,
+            contradicting_signal_revision, contradicting_signal_job_id,
+            recorded_at
+        ) VALUES (
+            'local', 'contradiction-1', 'signal-1', 1, ?,
+            'signal-2', 1, ?, '2026-08-01T00:03:00Z'
+        )
+        """,
+        (job_id, job_id),
+    )
+
+    with pytest.raises(sqlite3.IntegrityError):
+        conn.execute(
+            """
+            INSERT INTO tailoring_feedback_signal_contradictions (
+                tenant_id, contradiction_id, signal_id, signal_revision,
+                signal_job_id, contradicting_signal_id,
+                contradicting_signal_revision, contradicting_signal_job_id,
+                recorded_at
+            ) VALUES (
+                'local', 'contradiction-reversed', 'signal-2', 1, ?,
+                'signal-1', 1, ?, '2026-08-01T00:03:00Z'
+            )
+            """,
+            (job_id, job_id),
+        )
+    with pytest.raises(sqlite3.IntegrityError, match="append-only"):
+        conn.execute(
+            """
+            UPDATE tailoring_feedback_signal_contradictions
+            SET recorded_at = '2026-08-01T00:04:00Z'
+            WHERE contradiction_id = 'contradiction-1'
+            """
+        )
+    with pytest.raises(sqlite3.IntegrityError, match="append-only"):
+        conn.execute(
+            """
+            DELETE FROM tailoring_feedback_signal_contradictions
+            WHERE contradiction_id = 'contradiction-1'
+            """
+        )
 
     with pytest.raises(sqlite3.IntegrityError):
         conn.execute(
@@ -612,9 +682,16 @@ def test_tailoring_feedback_reviews_are_structured_append_only_facts(
     assert [
         tuple(row)
         for row in conn.execute(
-            "SELECT decision, rule_key, rule_value FROM tailoring_feedback_signal_reviews"
+            """
+            SELECT decision, rule_key, rule_value
+            FROM tailoring_feedback_signal_reviews
+            ORDER BY review_id
+            """
         ).fetchall()
-    ] == [("accepted", "fact_handling", "require_source_match")]
+    ] == [
+        ("accepted", "fact_handling", "require_source_match"),
+        ("accepted", "fact_handling", "require_source_match"),
+    ]
     assert conn.execute("PRAGMA foreign_key_check").fetchone() is None
 
     indexes = {
@@ -625,6 +702,16 @@ def test_tailoring_feedback_reviews_are_structured_append_only_facts(
         "idx_tailoring_feedback_signal_reviews_signal",
         "idx_tailoring_feedback_signal_reviews_decision",
     } <= indexes
+    contradiction_indexes = {
+        str(index[1])
+        for index in conn.execute(
+            "PRAGMA index_list(tailoring_feedback_signal_contradictions)"
+        )
+    }
+    assert {
+        "idx_tailoring_feedback_signal_contradictions_signal",
+        "idx_tailoring_feedback_signal_contradictions_other",
+    } <= contradiction_indexes
     close_connection(db_path)
 
 

--- a/workers/automation/tests/test_v6_to_v7_plan.py
+++ b/workers/automation/tests/test_v6_to_v7_plan.py
@@ -167,6 +167,11 @@ def test_identity_locator_and_sequence_roles_are_not_inferred_from_names() -> No
         classify_column("tailoring_feedback_signal_reviews", "signal_id", "target")
         is ColumnRole.PRESERVE
     )
+    assert not table_plan("tailoring_feedback_signal_contradictions").source_exists
+    assert (
+        table_plan("tailoring_feedback_signal_contradictions").disposition
+        is TableDisposition.DIRECT_COPY
+    )
     for table in (
         "learning_recommendation_evidence",
         "learning_recommendation_evidence_jobs",


### PR DESCRIPTION
## Summary

- add an append-only exact-v7 ledger for explicit contradictions between accepted tailoring-feedback revisions
- retain canonical JobIds and both signal revisions so contradiction provenance survives later source changes
- update the Python and TypeScript schema manifests plus migration-plan guards

## Why

Learning recommendations must block on unresolved contradictions without inferring conflict from private text or unreviewed model output. This child PR adds only the structured persistence boundary required by the later review and derivation slices.

## Validation

- fixed-environment Python schema and migration tests
- TypeScript schema-version guard tests on Node 22
- Ruff on touched Python files
- `git diff --check`
- independent review: PASS, zero findings
- independent QA on the cumulative behavior: PASS, zero findings

Canonical product documentation remains deferred to the final PR in the approved unreleased stack.
