### PR TITLE
feat(api): record explicit learning contradictions

### DIFF
--- a/apps/api/src/resume-review-drafts.ts
+++ b/apps/api/src/resume-review-drafts.ts
@@ -180,6 +180,7 @@ interface TailoringFeedbackSignalReviewRow extends Record<string, unknown> {
 interface TailoringFeedbackSignalIdentityRow extends Record<string, unknown> {
   signal_id: string;
   signal_kind: string;
+  job_id: string;
 }
 
 export class TailoringFeedbackReviewInputError extends Error {
@@ -638,7 +639,7 @@ export function reviewResumeFeedbackSignal(
   const tx = db.transaction(() => {
     const signal = getRow<TailoringFeedbackSignalIdentityRow>(
       db,
-      `SELECT signal_id, signal_kind
+      `SELECT signal_id, signal_kind, job_id
          FROM tailoring_feedback_signals
         WHERE tenant_id = ? AND signal_id = ?`,
       [DEFAULT_TENANT, signalId],
@@ -651,6 +652,8 @@ export function reviewResumeFeedbackSignal(
     const expectedRule = TAILORING_FEEDBACK_RULE_ALLOWLIST[signalKind];
     const ruleKey = request.decision === "accepted" ? request.ruleKey : null;
     const ruleValue = request.decision === "accepted" ? request.ruleValue : null;
+    const contradictsSignalIds =
+      request.decision === "accepted" ? request.contradictsSignalIds : [];
     if (
       request.decision === "accepted"
       && (ruleKey !== expectedRule.ruleKey || ruleValue !== expectedRule.ruleValue)
@@ -676,9 +679,16 @@ export function reviewResumeFeedbackSignal(
       && latest.rule_key === ruleKey
       && latest.rule_value === ruleValue
       && latest.allowlist_version === TAILORING_FEEDBACK_RULE_ALLOWLIST_VERSION
+      && arraysEqual(
+        contradictionSignalIdsForReview(db, latest.signal_id, latest.revision),
+        contradictsSignalIds,
+      )
     ) {
       projectLatestTailoringFeedbackDecision(db, signalId, request.decision, latest.reviewed_at);
-      return { ok: true as const, review: tailoringFeedbackReviewFromRow(latest) };
+      return {
+        ok: true as const,
+        review: tailoringFeedbackReviewFromRow(db, latest),
+      };
     }
 
     const reviewId = `tailoring_feedback_review_${crypto.randomUUID()}`;
@@ -701,6 +711,16 @@ export function reviewResumeFeedbackSignal(
       TAILORING_FEEDBACK_RULE_ALLOWLIST_VERSION,
       reviewedAt,
     );
+    if (request.decision === "accepted") {
+      insertTailoringFeedbackContradictions(
+        db,
+        signalId,
+        revision,
+        signal.job_id,
+        contradictsSignalIds,
+        reviewedAt,
+      );
+    }
     projectLatestTailoringFeedbackDecision(db, signalId, request.decision, reviewedAt);
 
     const review = getRow<TailoringFeedbackSignalReviewRow>(
@@ -714,7 +734,10 @@ export function reviewResumeFeedbackSignal(
     if (!review) {
       throw new Error("Tailoring feedback review was not persisted.");
     }
-    return { ok: true as const, review: tailoringFeedbackReviewFromRow(review) };
+    return {
+      ok: true as const,
+      review: tailoringFeedbackReviewFromRow(db, review),
+    };
   });
   return tx();
 }
@@ -733,6 +756,7 @@ function projectLatestTailoringFeedbackDecision(
 }
 
 function tailoringFeedbackReviewFromRow(
+  db: SqliteDatabase,
   row: TailoringFeedbackSignalReviewRow,
 ): TailoringFeedbackSignalReview {
   const signalKind = feedbackSignalKind(row.signal_kind);
@@ -759,8 +783,158 @@ function tailoringFeedbackReviewFromRow(
     ruleKey: decision === "accepted" ? expectedRule.ruleKey : null,
     ruleValue: decision === "accepted" ? expectedRule.ruleValue : null,
     allowlistVersion: TAILORING_FEEDBACK_RULE_ALLOWLIST_VERSION,
+    contradictsSignalIds:
+      decision === "accepted"
+        ? contradictionSignalIdsForReview(db, row.signal_id, row.revision)
+        : [],
     reviewedAt: row.reviewed_at,
   };
+}
+
+function insertTailoringFeedbackContradictions(
+  db: SqliteDatabase,
+  signalId: string,
+  revision: number,
+  signalJobId: string,
+  contradictsSignalIds: string[],
+  recordedAt: string,
+): void {
+  const currentLearningSignalId = tailoringLearningSignalId(signalId, revision);
+  for (const targetId of contradictsSignalIds) {
+    if (targetId === currentLearningSignalId) {
+      throw new TailoringFeedbackReviewInputError(
+        "A tailoring feedback signal cannot contradict itself.",
+      );
+    }
+    const target = parseTailoringLearningSignalId(targetId);
+    const targetReview = getRow<{
+      revision: number;
+      decision: string;
+      job_id: string;
+    }>(
+      db,
+      `SELECT review.revision, review.decision, source.job_id
+         FROM tailoring_feedback_signal_reviews AS review
+         JOIN tailoring_feedback_signals AS source
+           ON source.tenant_id = review.tenant_id
+          AND source.signal_id = review.signal_id
+        WHERE review.tenant_id = ? AND review.signal_id = ?
+        ORDER BY review.revision DESC
+        LIMIT 1`,
+      [DEFAULT_TENANT, target.signalId],
+    );
+    if (
+      !targetReview
+      || targetReview.decision !== "accepted"
+      || Number(targetReview.revision) !== target.revision
+    ) {
+      throw new TailoringFeedbackReviewInputError(
+        `Contradicting signal ${targetId} is not a current accepted review.`,
+      );
+    }
+    const endpoints = [
+      { signalId, revision, jobId: signalJobId },
+      {
+        signalId: target.signalId,
+        revision: target.revision,
+        jobId: targetReview.job_id,
+      },
+    ].sort((left, right) =>
+      left.signalId === right.signalId
+        ? left.revision - right.revision
+        : left.signalId.localeCompare(right.signalId),
+    );
+    const [left, right] = endpoints;
+    if (!left || !right) {
+      throw new Error("Tailoring feedback contradiction endpoints are missing.");
+    }
+    const contradictionId = `tailoring-feedback-contradiction:${stableHash([
+      DEFAULT_TENANT,
+      left.signalId,
+      left.revision,
+      right.signalId,
+      right.revision,
+    ])}`;
+    db.prepare(
+      `INSERT OR IGNORE INTO tailoring_feedback_signal_contradictions (
+         tenant_id, contradiction_id, signal_id, signal_revision, signal_job_id,
+         contradicting_signal_id, contradicting_signal_revision,
+         contradicting_signal_job_id, recorded_at
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    ).run(
+      DEFAULT_TENANT,
+      contradictionId,
+      left.signalId,
+      left.revision,
+      left.jobId,
+      right.signalId,
+      right.revision,
+      right.jobId,
+      recordedAt,
+    );
+  }
+}
+
+function contradictionSignalIdsForReview(
+  db: SqliteDatabase,
+  signalId: string,
+  revision: number,
+): string[] {
+  return allRows<{
+    signal_id: string;
+    signal_revision: number;
+    contradicting_signal_id: string;
+    contradicting_signal_revision: number;
+  }>(
+    db,
+    `SELECT signal_id, signal_revision,
+            contradicting_signal_id, contradicting_signal_revision
+       FROM tailoring_feedback_signal_contradictions
+      WHERE tenant_id = ?
+        AND ((signal_id = ? AND signal_revision = ?)
+          OR (contradicting_signal_id = ? AND contradicting_signal_revision = ?))
+      ORDER BY contradiction_id`,
+    [DEFAULT_TENANT, signalId, revision, signalId, revision],
+  )
+    .map((row) =>
+      row.signal_id === signalId && Number(row.signal_revision) === revision
+        ? tailoringLearningSignalId(
+            row.contradicting_signal_id,
+            Number(row.contradicting_signal_revision),
+          )
+        : tailoringLearningSignalId(row.signal_id, Number(row.signal_revision)),
+    )
+    .sort();
+}
+
+function parseTailoringLearningSignalId(value: string): {
+  signalId: string;
+  revision: number;
+} {
+  const prefix = "tailoring-feedback:";
+  const separator = value.lastIndexOf(":");
+  const signalId = value.slice(prefix.length, separator);
+  const revision = Number(value.slice(separator + 1));
+  if (
+    !value.startsWith(prefix)
+    || separator <= prefix.length
+    || !signalId
+    || !Number.isSafeInteger(revision)
+    || revision < 1
+  ) {
+    throw new TailoringFeedbackReviewInputError(
+      "Contradicting signal IDs must be canonical learning signal IDs.",
+    );
+  }
+  return { signalId, revision };
+}
+
+function tailoringLearningSignalId(signalId: string, revision: number): string {
+  return `tailoring-feedback:${signalId}:${revision}`;
+}
+
+function arraysEqual(left: readonly string[], right: readonly string[]): boolean {
+  return left.length === right.length && left.every((value, index) => value === right[index]);
 }
 
 function requireExistingJobId(db: SqliteDatabase, jobLocator: string): string {

--- a/apps/api/test/resume-review-drafts.test.ts
+++ b/apps/api/test/resume-review-drafts.test.ts
@@ -393,9 +393,11 @@ describe("resume review draft API", () => {
       ruleKey: "fact_handling",
       ruleValue: "require_source_match",
       allowlistVersion: 1,
+      contradictsSignalIds: [],
     });
     expect(Object.keys(acceptedResponse.json().review).sort()).toEqual([
       "allowlistVersion",
+      "contradictsSignalIds",
       "decision",
       "reviewId",
       "reviewedAt",
@@ -431,8 +433,8 @@ describe("resume review draft API", () => {
       decision: "rejected",
       ruleKey: null,
       ruleValue: null,
+      contradictsSignalIds: [],
     });
-
     const db = new Database(options.dbPath);
     try {
       const reviews = db
@@ -464,6 +466,128 @@ describe("resume review draft API", () => {
       db.close();
     }
 
+    await app.close();
+  });
+
+  it("records only explicit structured contradiction links between accepted reviews", async () => {
+    const privateSource = "private contradiction rationale must not leave the source row";
+    const app = buildApp(options);
+    const createResponse = await app.inject({
+      method: "POST",
+      url: `/v1/jobs/${encodeURIComponent(JOB_KEY)}/resume-review/draft`,
+      payload: {},
+    });
+    const draftId = createResponse.json().draft.draftId as string;
+    const db = new Database(options.dbPath);
+    try {
+      for (const signalId of ["signal-one", "signal-two", "signal-three"]) {
+        db.prepare(
+          `INSERT INTO tailoring_feedback_signals (
+             tenant_id, signal_id, job_id, draft_id, source_kind, source_id,
+             signal_kind, status, summary, created_at
+           ) VALUES (
+             'local', ?, ?, ?, 'comment_reply', ?, 'factual_correction',
+             'candidate', ?, ?
+           )`,
+        ).run(signalId, JOB_ID, draftId, `source-${signalId}`, privateSource, NOW);
+      }
+    } finally {
+      db.close();
+    }
+
+    const first = await app.inject({
+      method: "POST",
+      url: "/v1/resume-review/feedback-signals/signal-one/reviews",
+      payload: {
+        decision: "accepted",
+        ruleKey: "fact_handling",
+        ruleValue: "require_source_match",
+      },
+    });
+    expect(first.statusCode, first.body).toBe(200);
+    expect(first.json().review.contradictsSignalIds).toEqual([]);
+
+    const firstLearningSignalId = "tailoring-feedback:signal-one:1";
+    const secondPayload = {
+      decision: "accepted",
+      ruleKey: "fact_handling",
+      ruleValue: "require_source_match",
+      contradictsSignalIds: [firstLearningSignalId],
+    } as const;
+    const second = await app.inject({
+      method: "POST",
+      url: "/v1/resume-review/feedback-signals/signal-two/reviews",
+      payload: secondPayload,
+    });
+    expect(second.statusCode, second.body).toBe(200);
+    expect(second.json().review.contradictsSignalIds).toEqual([
+      firstLearningSignalId,
+    ]);
+    expect(second.body).not.toContain(privateSource);
+
+    const replay = await app.inject({
+      method: "POST",
+      url: "/v1/resume-review/feedback-signals/signal-two/reviews",
+      payload: secondPayload,
+    });
+    expect(replay.statusCode, replay.body).toBe(200);
+    expect(replay.json().review).toEqual(second.json().review);
+
+    const invalidTarget = await app.inject({
+      method: "POST",
+      url: "/v1/resume-review/feedback-signals/signal-three/reviews",
+      payload: {
+        decision: "accepted",
+        ruleKey: "fact_handling",
+        ruleValue: "require_source_match",
+        contradictsSignalIds: ["tailoring-feedback:missing-signal:1"],
+      },
+    });
+    expect(invalidTarget.statusCode, invalidTarget.body).toBe(400);
+    expect(invalidTarget.json()).toMatchObject({
+      ok: false,
+      error: "invalid_tailoring_feedback_review",
+    });
+
+    const persisted = new Database(options.dbPath);
+    try {
+      expect(
+        persisted
+          .prepare(
+            `SELECT signal_id, signal_revision, contradicting_signal_id,
+                    contradicting_signal_revision
+               FROM tailoring_feedback_signal_contradictions`,
+          )
+          .all(),
+      ).toEqual([
+        {
+          signal_id: "signal-one",
+          signal_revision: 1,
+          contradicting_signal_id: "signal-two",
+          contradicting_signal_revision: 1,
+        },
+      ]);
+      expect(
+        persisted
+          .prepare(
+            `SELECT COUNT(*) AS count
+               FROM tailoring_feedback_signal_reviews
+              WHERE signal_id = 'signal-two'`,
+          )
+          .get(),
+      ).toEqual({ count: 1 });
+      expect(
+        persisted
+          .prepare(
+            `SELECT COUNT(*) AS count
+               FROM tailoring_feedback_signal_reviews
+              WHERE signal_id = 'signal-three'`,
+          )
+          .get(),
+      ).toEqual({ count: 0 });
+    } finally {
+      persisted.close();
+    }
     await app.close();
   });
 

--- a/packages/contracts/src/schemas.ts
+++ b/packages/contracts/src/schemas.ts
@@ -1143,6 +1143,7 @@ export interface TailoringFeedbackSignalReview {
   ruleKey: TailoringFeedbackRuleKey | null;
   ruleValue: TailoringFeedbackRuleValue | null;
   allowlistVersion: typeof TAILORING_FEEDBACK_RULE_ALLOWLIST_VERSION;
+  contradictsSignalIds: string[];
   reviewedAt: string;
 }
 
@@ -1316,12 +1317,23 @@ export interface ResumeReviewFeedbackListResponse {
   feedbackSignals: TailoringFeedbackSignal[];
 }
 
+const TailoringLearningSignalIdSchema = z
+  .string()
+  .min(1)
+  .max(240)
+  .regex(/^tailoring-feedback:[A-Za-z0-9_.:-]+:[1-9][0-9]*$/);
+
 export const TailoringFeedbackSignalReviewRequestSchema = z.discriminatedUnion("decision", [
   z
     .object({
       decision: z.literal("accepted"),
       ruleKey: z.enum(TAILORING_FEEDBACK_RULE_KEYS),
       ruleValue: z.enum(TAILORING_FEEDBACK_RULE_VALUES),
+      contradictsSignalIds: z
+        .array(TailoringLearningSignalIdSchema)
+        .max(100)
+        .default([])
+        .transform((values) => [...new Set(values)].sort()),
     })
     .strict(),
   z.object({ decision: z.literal("rejected") }).strict(),


### PR DESCRIPTION
## Summary

- accept only bounded canonical `contradictsSignalIds` on accepted tailoring-feedback reviews
- validate every contradiction target as the current accepted source revision and append a deterministic structured ledger link
- return only structured contradiction IDs while keeping private source text out of the API

## Why

The learning flow needs an explicit user-controlled contradiction authority. This child PR records that authority at review time without inferring conflict from notes, generated text, or model output, and without changing any policy behavior.

## Validation

- `resume-review-drafts.test.ts`: 13 passed in the isolated child state
- API TypeScript check: passed
- contracts TypeScript check: passed
- `git diff --check`: passed
- independent cumulative review: PASS, zero findings
- independent cumulative QA: PASS, zero findings

Canonical product documentation remains deferred to the final PR in the approved unreleased stack.
