### PR TITLE
feat(storage): add learning recommendation review ledger

### DIFF
--- a/apps/api/src/schema-manifest.ts
+++ b/apps/api/src/schema-manifest.ts
@@ -14,9 +14,9 @@ export type SchemaManifest = {
 // a different schema.
 export const EXACT_V7_SCHEMA_MANIFEST: SchemaManifest = {
   version: 7,
-  objectCount: 236,
-  tableCount: 109,
-  fingerprint: "3b6ad22091d895ef141917e080df86b02dc21c56a1f9ffe3b70da3c9db6edad8",
+  objectCount: 242,
+  tableCount: 110,
+  fingerprint: "55d88c87aaf9bec6c8686ee0e40dba31ca19aaaa5767042f9376f5e2756fecfd",
 };
 
 type SqliteMasterRow = [type: string, name: string, tableName: string, sql: string];

--- a/apps/api/test/schema-version-guard.test.ts
+++ b/apps/api/test/schema-version-guard.test.ts
@@ -142,14 +142,14 @@ describe("schema version guard at DB open", () => {
     const pythonManifest = fs.readFileSync(pythonManifestPath, "utf8");
 
     expect(pythonManifest).toContain("version=7,");
-    expect(pythonManifest).toContain("object_count=236,");
-    expect(pythonManifest).toContain("table_count=109,");
+    expect(pythonManifest).toContain("object_count=242,");
+    expect(pythonManifest).toContain("table_count=110,");
     expect(pythonManifest).toContain(`fingerprint=\"${EXACT_V7_SCHEMA_MANIFEST.fingerprint}\",`);
     expect(EXACT_V7_SCHEMA_MANIFEST).toEqual({
       version: SUPPORTED_SCHEMA_VERSION,
-      objectCount: 236,
-      tableCount: 109,
-      fingerprint: "3b6ad22091d895ef141917e080df86b02dc21c56a1f9ffe3b70da3c9db6edad8",
+      objectCount: 242,
+      tableCount: 110,
+      fingerprint: "55d88c87aaf9bec6c8686ee0e40dba31ca19aaaa5767042f9376f5e2756fecfd",
     });
   });
 });

--- a/workers/automation/src/jobctrl/infrastructure/migrations/schema_manifest.py
+++ b/workers/automation/src/jobctrl/infrastructure/migrations/schema_manifest.py
@@ -23,9 +23,9 @@ class SchemaManifest:
 # semantically meaningful and must never normalize to the same fingerprint.
 EXACT_V7_MANIFEST = SchemaManifest(
     version=7,
-    object_count=236,
-    table_count=109,
-    fingerprint="3b6ad22091d895ef141917e080df86b02dc21c56a1f9ffe3b70da3c9db6edad8",
+    object_count=242,
+    table_count=110,
+    fingerprint="55d88c87aaf9bec6c8686ee0e40dba31ca19aaaa5767042f9376f5e2756fecfd",
 )
 
 

--- a/workers/automation/src/jobctrl/infrastructure/migrations/schema_v7.sql
+++ b/workers/automation/src/jobctrl/infrastructure/migrations/schema_v7.sql
@@ -1912,6 +1912,101 @@ BEFORE DELETE ON learning_recommendations
 BEGIN
   SELECT RAISE(ABORT, 'learning recommendations are append-only');
 END;
+CREATE TABLE learning_recommendation_reviews (
+      tenant_id         TEXT NOT NULL DEFAULT 'local',
+      review_id         TEXT NOT NULL,
+      recommendation_id TEXT NOT NULL,
+      revision          INTEGER NOT NULL CHECK(revision > 0),
+      decision          TEXT NOT NULL CHECK(decision IN ('accepted', 'rejected')),
+      context           TEXT NOT NULL CHECK(context = 'materials'),
+      policy_kind       TEXT NOT NULL CHECK(policy_kind = 'tailoring_rule'),
+      policy_version    INTEGER,
+      reviewed_at       TEXT NOT NULL,
+      PRIMARY KEY (tenant_id, review_id),
+      UNIQUE (tenant_id, recommendation_id, revision),
+      UNIQUE (tenant_id, recommendation_id, decision),
+      UNIQUE (tenant_id, context, policy_kind, policy_version),
+      FOREIGN KEY (tenant_id, recommendation_id)
+        REFERENCES learning_recommendations(tenant_id, recommendation_id)
+        ON DELETE RESTRICT,
+      FOREIGN KEY (tenant_id, policy_version)
+        REFERENCES tailoring_policies(tenant_id, version)
+        ON DELETE RESTRICT,
+      CHECK(
+        (decision = 'accepted' AND policy_version IS NOT NULL AND policy_version > 0)
+        OR (decision = 'rejected' AND policy_version IS NULL)
+      )
+    );
+CREATE TRIGGER prevent_learning_recommendation_review_collision
+BEFORE INSERT ON learning_recommendation_reviews
+WHEN EXISTS (
+  SELECT 1
+  FROM learning_recommendation_reviews
+  WHERE tenant_id = NEW.tenant_id
+    AND (
+      review_id = NEW.review_id
+      OR (
+        recommendation_id = NEW.recommendation_id
+        AND (
+          revision = NEW.revision
+          OR decision = NEW.decision
+          OR decision = 'accepted'
+        )
+      )
+      OR (
+        NEW.policy_version IS NOT NULL
+        AND context = NEW.context
+        AND policy_kind = NEW.policy_kind
+        AND policy_version = NEW.policy_version
+      )
+    )
+)
+BEGIN
+  SELECT RAISE(ABORT, 'learning recommendation reviews are append-only');
+END;
+CREATE TRIGGER validate_learning_recommendation_review_revision
+BEFORE INSERT ON learning_recommendation_reviews
+WHEN NOT EXISTS (
+  SELECT 1
+  FROM learning_recommendation_reviews
+  WHERE tenant_id = NEW.tenant_id
+    AND (
+      review_id = NEW.review_id
+      OR (
+        recommendation_id = NEW.recommendation_id
+        AND (
+          revision = NEW.revision
+          OR decision = NEW.decision
+          OR decision = 'accepted'
+        )
+      )
+      OR (
+        NEW.policy_version IS NOT NULL
+        AND context = NEW.context
+        AND policy_kind = NEW.policy_kind
+        AND policy_version = NEW.policy_version
+      )
+    )
+)
+AND NEW.revision != COALESCE((
+  SELECT MAX(revision) + 1
+  FROM learning_recommendation_reviews
+  WHERE tenant_id = NEW.tenant_id
+    AND recommendation_id = NEW.recommendation_id
+), 1)
+BEGIN
+  SELECT RAISE(ABORT, 'learning recommendation review revision must be contiguous');
+END;
+CREATE TRIGGER prevent_learning_recommendation_review_update
+BEFORE UPDATE ON learning_recommendation_reviews
+BEGIN
+  SELECT RAISE(ABORT, 'learning recommendation reviews are append-only');
+END;
+CREATE TRIGGER prevent_learning_recommendation_review_delete
+BEFORE DELETE ON learning_recommendation_reviews
+BEGIN
+  SELECT RAISE(ABORT, 'learning recommendation reviews are append-only');
+END;
 CREATE TRIGGER validate_learning_recommendation_counts
 BEFORE INSERT ON learning_recommendations
 BEGIN
@@ -2536,6 +2631,12 @@ CREATE INDEX idx_tailoring_feedback_signal_contradictions_other
       );
 CREATE INDEX idx_learning_recommendations_tenant_derived
       ON learning_recommendations(tenant_id, derived_at DESC, recommendation_id);
+CREATE INDEX idx_learning_recommendation_reviews_tenant_reviewed
+      ON learning_recommendation_reviews(
+        tenant_id,
+        reviewed_at DESC,
+        review_id
+      );
 CREATE INDEX idx_learning_recommendation_evidence_signal
       ON learning_recommendation_evidence(tenant_id, signal_id, evidence_role);
 CREATE INDEX idx_learning_recommendation_evidence_jobs_job

--- a/workers/automation/src/jobctrl/infrastructure/migrations/v6_to_v7_plan.py
+++ b/workers/automation/src/jobctrl/infrastructure/migrations/v6_to_v7_plan.py
@@ -236,8 +236,9 @@ def _table_plans() -> dict[str, TablePlan]:
     )
     # Reviewed tailoring facts and derived recommendation audit records exist
     # only in exact v7. The v6 source cannot imply review, recommendation, job
-    # evidence, or tombstone rows, so all begin empty after cutover.
+    # evidence, decision, or tombstone rows, so all begin empty after cutover.
     for table in (
+        "learning_recommendation_reviews",
         "learning_recommendation_evidence",
         "learning_recommendation_evidence_jobs",
         "learning_recommendation_jobs",
@@ -518,6 +519,7 @@ _DECLARED_COLUMNS: Final[Mapping[str, frozenset[str]]] = _column_manifest(
         "jobctrl_hidden_jobs": "job_url tenant_id job_id hidden_at reason unhidden_at",
         "jobs": "url title company salary description location site strategy discovered_at full_description application_url detail_scraped_at detail_error fit_score score_reasoning scored_at tailored_resume_path tailored_at tailor_attempts cover_letter_path cover_letter_at cover_attempts applied_at apply_status apply_error apply_attempts agent_id last_attempted_at apply_duration_ms apply_task_id verification_confidence tenant_id job_id",
         "llm_spend": "day input_tokens output_tokens estimated_usd",
+        "learning_recommendation_reviews": "tenant_id review_id recommendation_id revision decision context policy_kind policy_version reviewed_at",
         "learning_recommendation_evidence": "tenant_id recommendation_id signal_id evidence_role source_kind source_id source_revision recorded_at",
         "learning_recommendation_evidence_jobs": "tenant_id recommendation_id signal_id job_id",
         "learning_recommendation_jobs": "tenant_id recommendation_id job_id",

--- a/workers/automation/tests/test_exact_v7_schema.py
+++ b/workers/automation/tests/test_exact_v7_schema.py
@@ -31,6 +31,7 @@ from jobctrl.infrastructure import runtime_identity
 _CROSS_RUNTIME_DURABLE_TABLES = {
     "discovery_execution_recoveries",
     "jobctrl_hidden_jobs",
+    "learning_recommendation_reviews",
     "learning_recommendation_evidence",
     "learning_recommendation_evidence_jobs",
     "learning_recommendation_jobs",
@@ -715,6 +716,71 @@ def test_tailoring_feedback_reviews_are_structured_append_only_facts(
     close_connection(db_path)
 
 
+def _insert_learning_recommendation_fixture(
+    conn: sqlite3.Connection,
+    recommendation_id: str,
+    fingerprint_character: str,
+) -> None:
+    job_ids = (
+        "11111111-1111-4111-8111-111111111111",
+        "22222222-2222-4222-8222-222222222222",
+    )
+    for index in range(1, 4):
+        signal_id = f"{recommendation_id}-signal-{index}"
+        conn.execute(
+            """
+            INSERT INTO learning_recommendation_evidence (
+                tenant_id, recommendation_id, signal_id, evidence_role,
+                source_kind, source_id, source_revision, recorded_at
+            ) VALUES (
+                'local', ?, ?, 'supporting',
+                'tailoring_feedback_signal', ?, ?, ?
+            )
+            """,
+            (
+                recommendation_id,
+                signal_id,
+                f"source-{signal_id}",
+                index,
+                f"2026-08-01T00:00:0{index}Z",
+            ),
+        )
+        conn.execute(
+            """
+            INSERT INTO learning_recommendation_evidence_jobs (
+                tenant_id, recommendation_id, signal_id, job_id
+            ) VALUES ('local', ?, ?, ?)
+            """,
+            (recommendation_id, signal_id, job_ids[min(index - 1, 1)]),
+        )
+    for job_id in job_ids:
+        conn.execute(
+            """
+            INSERT INTO learning_recommendation_jobs (
+                tenant_id, recommendation_id, job_id
+            ) VALUES ('local', ?, ?)
+            """,
+            (recommendation_id, job_id),
+        )
+    conn.execute(
+        """
+        INSERT INTO learning_recommendations (
+            tenant_id, recommendation_id, derivation_version,
+            evaluation_fixture_version, context, policy_kind, signal_kind,
+            rule_key, rule_value, allowlist_version, status,
+            observed_signal_count, observed_job_count, minimum_signal_count,
+            minimum_job_count, confidence_limit, input_fingerprint, derived_at
+        ) VALUES (
+            'local', ?, 1, 1, 'materials', 'tailoring_rule',
+            'factual_correction', 'fact_handling', 'require_source_match',
+            1, 'pending', 3, 2, 3, 2,
+            'sample_gated_no_population_inference', ?, '2026-08-01T01:00:00Z'
+        )
+        """,
+        (recommendation_id, fingerprint_character * 64),
+    )
+
+
 def test_learning_recommendation_storage_is_structured_append_only_and_private(
     tmp_path: Path,
 ) -> None:
@@ -1109,6 +1175,7 @@ def test_learning_recommendation_storage_is_structured_append_only_and_private(
         "text",
     }
     for table in (
+        "learning_recommendation_reviews",
         "learning_recommendations",
         "learning_recommendation_evidence",
         "learning_recommendation_evidence_jobs",
@@ -1125,6 +1192,169 @@ def test_learning_recommendation_storage_is_structured_append_only_and_private(
             if column in forbidden_fragments
             or any(column.endswith(f"_{fragment}") for fragment in forbidden_fragments)
         }
+
+    assert conn.execute("PRAGMA foreign_key_check").fetchone() is None
+    close_connection(db_path)
+
+
+def test_learning_recommendation_reviews_are_append_only_and_policy_linked(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    conn = init_db(db_path)
+    conn.execute("PRAGMA foreign_keys = ON")
+    for recommendation_id, fingerprint in (
+        ("recommendation-rejected", "d"),
+        ("recommendation-accepted", "e"),
+        ("recommendation-later-accepted", "f"),
+    ):
+        _insert_learning_recommendation_fixture(
+            conn,
+            recommendation_id,
+            fingerprint,
+        )
+    conn.execute(
+        """
+        INSERT INTO tailoring_policies (
+            tenant_id, version, prompt_version, schema_version,
+            judge_schema_version, prompt_fingerprint, config_fingerprint,
+            profile_policy_fingerprint, custom_prompt_fingerprint,
+            generator_settings_json, judge_settings_json,
+            runtime_settings_json, rollback_of_version, rollback_reason,
+            created_at, created_from_event_id
+        ) VALUES (
+            'local', 1, 'prompt-v1', 'schema-v1', 'judge-v1',
+            'prompt-fingerprint', 'config-fingerprint',
+            'profile-fingerprint', 'custom-fingerprint',
+            '{}', '{}', '{}', NULL, '', '2026-08-01T02:00:00Z', NULL
+        )
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO tailoring_policies (
+            tenant_id, version, prompt_version, schema_version,
+            judge_schema_version, prompt_fingerprint, config_fingerprint,
+            profile_policy_fingerprint, custom_prompt_fingerprint,
+            generator_settings_json, judge_settings_json,
+            runtime_settings_json, rollback_of_version, rollback_reason,
+            created_at, created_from_event_id
+        ) VALUES (
+            'local', 2, 'prompt-v1', 'schema-v1', 'judge-v1',
+            'prompt-fingerprint', 'config-fingerprint-2',
+            'profile-fingerprint', 'custom-fingerprint',
+            '{}', '{}', '{}', NULL, '', '2026-08-01T02:00:01Z', NULL
+        )
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO learning_recommendation_reviews (
+            tenant_id, review_id, recommendation_id, revision, decision,
+            context, policy_kind, policy_version, reviewed_at
+        ) VALUES (
+            'local', 'review-rejected', 'recommendation-rejected', 1,
+            'rejected', 'materials', 'tailoring_rule', NULL,
+            '2026-08-01T02:01:00Z'
+        )
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO learning_recommendation_reviews (
+            tenant_id, review_id, recommendation_id, revision, decision,
+            context, policy_kind, policy_version, reviewed_at
+        ) VALUES (
+            'local', 'review-accepted', 'recommendation-accepted', 1,
+            'accepted', 'materials', 'tailoring_rule', 1,
+            '2026-08-01T02:02:00Z'
+        )
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO learning_recommendation_reviews (
+            tenant_id, review_id, recommendation_id, revision, decision,
+            context, policy_kind, policy_version, reviewed_at
+        ) VALUES (
+            'local', 'review-later-rejected', 'recommendation-later-accepted', 1,
+            'rejected', 'materials', 'tailoring_rule', NULL,
+            '2026-08-01T02:03:00Z'
+        )
+        """
+    )
+
+    with pytest.raises(sqlite3.IntegrityError, match="append-only"):
+        conn.execute(
+            """
+            INSERT OR REPLACE INTO learning_recommendation_reviews (
+                tenant_id, review_id, recommendation_id, revision, decision,
+                context, policy_kind, policy_version, reviewed_at
+            ) VALUES (
+                'local', 'review-rejected', 'recommendation-rejected', 1,
+                'rejected', 'materials', 'tailoring_rule', NULL,
+                '2026-08-01T03:00:00Z'
+            )
+            """
+        )
+    with pytest.raises(sqlite3.IntegrityError, match="contiguous"):
+        conn.execute(
+            """
+            INSERT INTO learning_recommendation_reviews (
+                tenant_id, review_id, recommendation_id, revision, decision,
+                context, policy_kind, policy_version, reviewed_at
+            ) VALUES (
+                'local', 'review-later-accepted-gap',
+                'recommendation-later-accepted', 3, 'accepted',
+                'materials', 'tailoring_rule', 2, '2026-08-01T03:01:00Z'
+            )
+            """
+        )
+    conn.execute(
+        """
+        INSERT INTO learning_recommendation_reviews (
+            tenant_id, review_id, recommendation_id, revision, decision,
+            context, policy_kind, policy_version, reviewed_at
+        ) VALUES (
+            'local', 'review-later-accepted',
+            'recommendation-later-accepted', 2, 'accepted',
+            'materials', 'tailoring_rule', 2, '2026-08-01T03:02:00Z'
+        )
+        """
+    )
+    with pytest.raises(sqlite3.IntegrityError, match="append-only"):
+        conn.execute(
+            """
+            INSERT INTO learning_recommendation_reviews (
+                tenant_id, review_id, recommendation_id, revision, decision,
+                context, policy_kind, policy_version, reviewed_at
+            ) VALUES (
+                'local', 'review-after-accepted',
+                'recommendation-later-accepted', 3, 'rejected',
+                'materials', 'tailoring_rule', NULL, '2026-08-01T03:03:00Z'
+            )
+            """
+        )
+    for decision, policy_version in (("accepted", None), ("rejected", 1)):
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute(
+                """
+                INSERT INTO learning_recommendation_reviews (
+                    tenant_id, review_id, recommendation_id, revision, decision,
+                    context, policy_kind, policy_version, reviewed_at
+                ) VALUES (
+                    'local', ?, 'recommendation-rejected', 2, ?,
+                    'materials', 'tailoring_rule', ?, '2026-08-01T04:00:00Z'
+                )
+                """,
+                (f"review-invalid-{decision}", decision, policy_version),
+            )
+    for statement in (
+        "UPDATE learning_recommendation_reviews SET reviewed_at = reviewed_at WHERE review_id = 'review-rejected'",
+        "DELETE FROM learning_recommendation_reviews WHERE review_id = 'review-accepted'",
+    ):
+        with pytest.raises(sqlite3.IntegrityError, match="append-only"):
+            conn.execute(statement)
 
     assert conn.execute("PRAGMA foreign_key_check").fetchone() is None
     close_connection(db_path)

--- a/workers/automation/tests/test_v6_to_v7_plan.py
+++ b/workers/automation/tests/test_v6_to_v7_plan.py
@@ -173,6 +173,7 @@ def test_identity_locator_and_sequence_roles_are_not_inferred_from_names() -> No
         is TableDisposition.DIRECT_COPY
     )
     for table in (
+        "learning_recommendation_reviews",
         "learning_recommendation_evidence",
         "learning_recommendation_evidence_jobs",
         "learning_recommendation_jobs",


### PR DESCRIPTION
## Summary

- add a privacy-safe append-only review ledger for learning recommendations
- keep immutable recommendations as pending proposals and record accepted/rejected review facts separately
- require accepted reviews to reference a tenant-scoped Materials tailoring-policy version while rejected reviews reference none
- enforce contiguous review revisions, reject-then-accept history, no post-accept review, and collision-safe immutable rows

## Why

Recommendation review needs an auditable storage boundary before an executable acceptance path can be exposed. This child adds only that exact-v7 boundary; it does not add an endpoint or mutate effective policy.

## Validation

- exact-v7 schema and migration-plan tests: 25 passed
- TypeScript schema-version guards: 13 passed
- Ruff on touched Python files: passed
- `git diff --check`: passed
- independent review: PASS, zero findings

Product QA is deferred to the first executable accept/reject child. Canonical product documentation remains deferred to the final PR in the approved unreleased stack.
