### PR TITLE
feat(materials): apply accepted learning rules

### DIFF
--- a/workers/automation/src/jobctrl/domain/materials/__init__.py
+++ b/workers/automation/src/jobctrl/domain/materials/__init__.py
@@ -18,7 +18,11 @@ from jobctrl.domain.materials.aggregate import (
     MaterialsSetFactory,
 )
 from jobctrl.domain.materials.entities import Artifact
-from jobctrl.domain.materials.policy import TailoringPolicy
+from jobctrl.domain.materials.policy import (
+    LearnedTailoringRules,
+    TailoringPolicy,
+    TailoringPolicyChangedError,
+)
 from jobctrl.domain.materials.value_objects import (
     ArtifactStatus,
     ArtifactType,
@@ -34,9 +38,11 @@ __all__ = [
     "ArtifactType",
     "JudgeVerdict",
     "LlmModelSpec",
+    "LearnedTailoringRules",
     "MaterialsSet",
     "MaterialsSetFactory",
     "RenderFormat",
     "TailoringPolicy",
+    "TailoringPolicyChangedError",
     "ValidationResult",
 ]

--- a/workers/automation/src/jobctrl/domain/materials/policy.py
+++ b/workers/automation/src/jobctrl/domain/materials/policy.py
@@ -8,6 +8,7 @@ from collections.abc import Mapping as MappingABC
 from dataclasses import dataclass, field
 from typing import Any
 
+from jobctrl.domain.operations.feedback import TAILORING_FEEDBACK_RULE_ALLOWLIST
 from jobctrl.domain.tenant import LOCAL_TENANT, TenantId
 
 DEFAULT_TAILORING_POLICY_VERSION = 1
@@ -16,6 +17,74 @@ REQUIREMENT_LED_TAILORING_POLICY_VERSION = 2
 DEFAULT_REQUIREMENT_LED_MIN_FIT_SCORE = 8
 DEFAULT_REQUIREMENT_LED_MUST_HAVE_COVERAGE = 0.85
 DEFAULT_REQUIREMENT_LED_MAX_REVISION_ATTEMPTS = 1
+
+_LEARNED_TAILORING_RULES_RUNTIME_KEY = "learned_tailoring_rules"
+_LEARNED_TAILORING_RULE_PAIRS = frozenset(TAILORING_FEEDBACK_RULE_ALLOWLIST.values())
+_LEARNED_TAILORING_RULE_PROMPTS = {
+    "style_guidance": "Preserve the user's reviewed edit pattern and writing-style choices.",
+    "fact_handling": "Require every factual claim to match canonical source evidence.",
+    "claim_policy": "Omit claims that are not verified or explicitly confirmed.",
+    "keyword_strategy": "Use target-job terms only when supported by canonical profile evidence.",
+    "provenance_policy": "Require direct traceable evidence for every generated claim.",
+}
+
+
+class TailoringPolicyChangedError(RuntimeError):
+    """Raised before artifact persistence when the policy snapshot advanced."""
+
+
+@dataclass(frozen=True)
+class LearnedTailoringRules:
+    """Closed, privacy-safe Materials rules accepted from recommendations."""
+
+    rules: tuple[tuple[str, str], ...] = ()
+
+    def __post_init__(self) -> None:
+        normalized = tuple(
+            sorted(
+                (str(rule_key or "").strip(), str(rule_value or "").strip())
+                for rule_key, rule_value in self.rules
+            )
+        )
+        if len({rule_key for rule_key, _ in normalized}) != len(normalized):
+            raise ValueError("learned tailoring rule keys must be unique")
+        invalid = [pair for pair in normalized if pair not in _LEARNED_TAILORING_RULE_PAIRS]
+        if invalid:
+            raise ValueError("learned tailoring rules must match the versioned allowlist")
+        object.__setattr__(self, "rules", normalized)
+
+    @classmethod
+    def from_mapping(cls, value: MappingABC[str, Any] | None) -> "LearnedTailoringRules":
+        if value is None:
+            return cls()
+        if not isinstance(value, MappingABC):
+            raise ValueError("learned tailoring rules must be an object")
+        return cls(tuple((str(key), str(item)) for key, item in value.items()))
+
+    @classmethod
+    def from_runtime_settings(
+        cls,
+        runtime_settings: MappingABC[str, Any] | None,
+    ) -> "LearnedTailoringRules":
+        settings = runtime_settings or {}
+        raw = settings.get(_LEARNED_TAILORING_RULES_RUNTIME_KEY, {})
+        if not isinstance(raw, MappingABC):
+            raise ValueError("learned tailoring rules must be an object")
+        return cls.from_mapping(raw)
+
+    def with_rule(self, rule_key: str, rule_value: str) -> "LearnedTailoringRules":
+        updated = self.to_dict()
+        updated[str(rule_key or "").strip()] = str(rule_value or "").strip()
+        return type(self).from_mapping(updated)
+
+    def to_dict(self) -> dict[str, str]:
+        return dict(self.rules)
+
+    def prompt_lines(self) -> tuple[str, ...]:
+        return tuple(
+            f"- {rule_key}={rule_value}: {_LEARNED_TAILORING_RULE_PROMPTS[rule_key]}"
+            for rule_key, rule_value in self.rules
+        )
 
 
 @dataclass(frozen=True)
@@ -387,6 +456,64 @@ class TailoringPolicy:
     def policy_id(self) -> str:
         return f"{self.tenant_id}:tailoring-policy-v{self.version}"
 
+    @property
+    def learned_tailoring_rules(self) -> LearnedTailoringRules:
+        return LearnedTailoringRules.from_runtime_settings(self.runtime_settings)
+
+    def with_learned_tailoring_rules(
+        self,
+        rules: LearnedTailoringRules,
+        *,
+        version: int | None = None,
+        created_at: str | None = None,
+        rollback_of_version: int | None = None,
+        rollback_reason: str = "",
+    ) -> "TailoringPolicy":
+        runtime_settings = dict(self.runtime_settings)
+        runtime_settings[_LEARNED_TAILORING_RULES_RUNTIME_KEY] = rules.to_dict()
+        return type(self)(
+            tenant_id=self.tenant_id,
+            version=self.version if version is None else version,
+            prompt_version=self.prompt_version,
+            schema_version=self.schema_version,
+            judge_schema_version=self.judge_schema_version,
+            prompt_fingerprint=self.prompt_fingerprint,
+            config_fingerprint=_configuration_fingerprint(
+                prompt_version=self.prompt_version,
+                schema_version=self.schema_version,
+                judge_schema_version=self.judge_schema_version,
+                prompt_fingerprint=self.prompt_fingerprint,
+                profile_policy_fingerprint=self.profile_policy_fingerprint,
+                custom_prompt_fingerprint=self.custom_prompt_fingerprint,
+                generator_settings=self.generator_settings,
+                judge_settings=self.judge_settings,
+                runtime_settings=runtime_settings,
+            ),
+            profile_policy_fingerprint=self.profile_policy_fingerprint,
+            custom_prompt_fingerprint=self.custom_prompt_fingerprint,
+            generator_settings=self.generator_settings,
+            judge_settings=self.judge_settings,
+            runtime_settings=runtime_settings,
+            rollback_of_version=rollback_of_version,
+            rollback_reason=rollback_reason,
+            created_at=self.created_at if created_at is None else created_at,
+            created_from_event_id=self.created_from_event_id,
+        )
+
+    def with_learned_tailoring_rule(
+        self,
+        *,
+        rule_key: str,
+        rule_value: str,
+        version: int,
+        created_at: str,
+    ) -> "TailoringPolicy":
+        return self.with_learned_tailoring_rules(
+            self.learned_tailoring_rules.with_rule(rule_key, rule_value),
+            version=version,
+            created_at=created_at,
+        )
+
     @classmethod
     def from_runtime(
         cls,
@@ -411,18 +538,16 @@ class TailoringPolicy:
         generator = _clean_mapping(generator_settings or {})
         judge = _clean_mapping(judge_settings or {})
         runtime = _clean_mapping(runtime_settings or {})
-        config_fingerprint = fingerprint_value(
-            {
-                "prompt_version": prompt_version,
-                "schema_version": schema_version,
-                "judge_schema_version": judge_schema_version,
-                "prompt_fingerprint": prompt_fingerprint,
-                "profile_policy_fingerprint": profile_fingerprint,
-                "custom_prompt_fingerprint": custom_fingerprint,
-                "generator_settings": generator,
-                "judge_settings": judge,
-                "runtime_settings": runtime,
-            }
+        config_fingerprint = _configuration_fingerprint(
+            prompt_version=prompt_version,
+            schema_version=schema_version,
+            judge_schema_version=judge_schema_version,
+            prompt_fingerprint=prompt_fingerprint,
+            profile_policy_fingerprint=profile_fingerprint,
+            custom_prompt_fingerprint=custom_fingerprint,
+            generator_settings=generator,
+            judge_settings=judge,
+            runtime_settings=runtime,
         )
         return cls(
             tenant_id=tenant_id,
@@ -495,7 +620,35 @@ class TailoringPolicy:
             "config_fingerprint": self.config_fingerprint,
             "profile_policy_fingerprint": self.profile_policy_fingerprint,
             "custom_prompt_fingerprint": self.custom_prompt_fingerprint,
+            "learned_tailoring_rules": self.learned_tailoring_rules.to_dict(),
         }
+
+
+def _configuration_fingerprint(
+    *,
+    prompt_version: str,
+    schema_version: str,
+    judge_schema_version: str,
+    prompt_fingerprint: str,
+    profile_policy_fingerprint: str,
+    custom_prompt_fingerprint: str,
+    generator_settings: MappingABC[str, Any],
+    judge_settings: MappingABC[str, Any],
+    runtime_settings: MappingABC[str, Any],
+) -> str:
+    return fingerprint_value(
+        {
+            "prompt_version": prompt_version,
+            "schema_version": schema_version,
+            "judge_schema_version": judge_schema_version,
+            "prompt_fingerprint": prompt_fingerprint,
+            "profile_policy_fingerprint": profile_policy_fingerprint,
+            "custom_prompt_fingerprint": custom_prompt_fingerprint,
+            "generator_settings": generator_settings,
+            "judge_settings": judge_settings,
+            "runtime_settings": runtime_settings,
+        }
+    )
 
 
 def fingerprint_value(value: Any) -> str:
@@ -536,10 +689,12 @@ __all__ = [
     "DEFAULT_REQUIREMENT_LED_REVISION_GATES",
     "AutoApprovalPolicy",
     "GenerationPermissions",
+    "LearnedTailoringRules",
     "RequiredContentPins",
     "RequirementLedTailoringControls",
     "RevisionGatePolicy",
     "TailoringPolicy",
+    "TailoringPolicyChangedError",
     "WritingStylePolicy",
     "adapt_requirement_led_controls",
     "fingerprint_value",

--- a/workers/automation/src/jobctrl/domain/materials/use_cases.py
+++ b/workers/automation/src/jobctrl/domain/materials/use_cases.py
@@ -88,7 +88,7 @@ from jobctrl.domain.materials.fabrication_detector import (
     scan_prose_skill_fabrications,
     scan_resume_bullets,
 )
-from jobctrl.domain.materials.policy import TailoringPolicy
+from jobctrl.domain.materials.policy import LearnedTailoringRules, TailoringPolicy
 from jobctrl.domain.materials.provenance import BulletProvenance, BulletProvenanceSet
 from jobctrl.domain.materials.provenance_builder import (
     ProvenanceBindingError,
@@ -1075,6 +1075,7 @@ def build_master_tailor_prompt(
     snapshot: ProfileSnapshot,
     *,
     tailoring_plan: TailoringPlan | None = None,
+    learned_tailoring_rules: LearnedTailoringRules | None = None,
 ) -> str:
     """Build the master-resume tailoring prompt from the snapshot."""
     profile = snapshot.as_dict()
@@ -1154,6 +1155,14 @@ def build_master_tailor_prompt(
     quality_plan_block = (
         "\n" + tailoring_plan.to_prompt_context() + "\n"
         if tailoring_plan is not None
+        else ""
+    )
+    learned_rule_lines = (learned_tailoring_rules or LearnedTailoringRules()).prompt_lines()
+    learned_rule_block = (
+        "\nACCEPTED LEARNING RULES FOR FUTURE MATERIALS:\n"
+        + "\n".join(learned_rule_lines)
+        + "\n"
+        if learned_rule_lines
         else ""
     )
 
@@ -1238,6 +1247,7 @@ MASTER SKILL CATEGORIES:
 
 TAILORING POLICY:
 {chr(10).join(policy_lines)}
+{learned_rule_block}
 
 WRITING STYLE:
 {chr(10).join(style_lines)}
@@ -1624,12 +1634,35 @@ class TailorResumeUseCase:
             prior_generation = None
             materials = previous
 
+        current_policy = (
+            self._policy_repository.get_current(tenant_id)
+            if self._policy_repository is not None
+            else None
+        )
+        learned_tailoring_rules = (
+            current_policy.learned_tailoring_rules
+            if current_policy is not None
+            else LearnedTailoringRules()
+        )
+        tailoring_plan = build_tailoring_plan(
+            profile_snapshot.as_dict(),
+            job,
+            employer_analysis=employer_analysis,
+            requirement_fit_report=requirement_fit_report,
+        )
+        tailor_prompt_base = build_master_tailor_prompt(
+            profile_snapshot,
+            tailoring_plan=tailoring_plan,
+            learned_tailoring_rules=learned_tailoring_rules,
+        )
         report, parsed_payload, validation, verdict = self._run_attempts(
             job=job,
             profile_snapshot=profile_snapshot,
             validation_mode=validation_mode,
             employer_analysis=employer_analysis,
             requirement_fit_report=requirement_fit_report,
+            tailoring_plan=tailoring_plan,
+            tailor_prompt_base=tailor_prompt_base,
         )
         attempts = report["attempts"]
 
@@ -1677,6 +1710,15 @@ class TailorResumeUseCase:
                 warnings=validation.warnings,
             )
 
+        tailoring_policy = self._resolve_tailoring_policy(
+            profile_snapshot=profile_snapshot,
+            prompt_text=tailor_prompt_base,
+            validation_mode=validation_mode,
+            tenant_id=tenant_id,
+            learned_tailoring_rules=learned_tailoring_rules,
+            expected_current_version=0 if current_policy is None else current_policy.version,
+        )
+
         # Assemble the rendered resume text from the FINAL (voiced) payload so the
         # shipped text == the audited text == the provenance ``generated_text``.
         tailored_text = self._assembler.assemble_resume_text(final_payload, profile_snapshot)
@@ -1695,12 +1737,6 @@ class TailorResumeUseCase:
             size_bytes = None
 
         judge_record = self._judge_record(verdict)
-        tailoring_policy = self._resolve_tailoring_policy(
-            profile_snapshot=profile_snapshot,
-            report=report,
-            validation_mode=validation_mode,
-            tenant_id=tenant_id,
-        )
         resume_template = _resolve_effective_resume_template(
             self._repository,
             tenant_id,
@@ -1992,6 +2028,8 @@ class TailorResumeUseCase:
         validation_mode: str,
         employer_analysis: EmployerAnalysis,
         requirement_fit_report: "RequirementFitReport | None" = None,
+        tailoring_plan: TailoringPlan,
+        tailor_prompt_base: str,
     ) -> tuple[dict, dict | None, ValidationResult, JudgeVerdict | None]:
         """Run the LLM ⇒ validate ⇒ judge attempt loop.
 
@@ -1999,16 +2037,6 @@ class TailorResumeUseCase:
         payload (or ``None`` if every attempt failed to parse) + the last
         :class:`ValidationResult` and :class:`JudgeVerdict`.
         """
-        tailoring_plan = build_tailoring_plan(
-            profile_snapshot.as_dict(),
-            job,
-            employer_analysis=employer_analysis,
-            requirement_fit_report=requirement_fit_report,
-        )
-        tailor_prompt_base = build_master_tailor_prompt(
-            profile_snapshot,
-            tailoring_plan=tailoring_plan,
-        )
         model_policy = self._llm_policy
         report: dict = {
             "attempts": 0,
@@ -2271,18 +2299,23 @@ class TailorResumeUseCase:
         self,
         *,
         profile_snapshot: ProfileSnapshot,
-        report: dict,
+        prompt_text: str,
         validation_mode: str,
         tenant_id: TenantId,
+        learned_tailoring_rules: LearnedTailoringRules,
+        expected_current_version: int,
     ) -> TailoringPolicy:
         profile = profile_snapshot.as_dict()
+        runtime_settings: dict[str, Any] = {"validation_mode": validation_mode}
+        if learned_tailoring_rules.rules:
+            runtime_settings["learned_tailoring_rules"] = learned_tailoring_rules.to_dict()
         candidate = TailoringPolicy.from_runtime(
             tenant_id=tenant_id,
             version=1,
             prompt_version=TAILORING_PROMPT_VERSION,
             schema_version=TAILORING_SCHEMA_VERSION,
             judge_schema_version=TAILORING_JUDGE_SCHEMA_VERSION,
-            prompt_text=str(report.get("system_prompt") or ""),
+            prompt_text=prompt_text,
             profile_policy=get_tailoring_policy(profile),
             custom_prompt=get_custom_tailoring_prompt(profile),
             generator_settings={
@@ -2297,12 +2330,15 @@ class TailorResumeUseCase:
                 "max_tokens": self._llm_policy.judge_max_tokens,
                 "min_score": self._llm_policy.judge_min_score,
             },
-            runtime_settings={"validation_mode": validation_mode},
+            runtime_settings=runtime_settings,
             created_at=_utc_now(),
         )
         if self._policy_repository is None:
             return candidate
-        return self._policy_repository.resolve_current(candidate)
+        return self._policy_repository.resolve_current(
+            candidate,
+            expected_current_version=expected_current_version,
+        )
 
     def _run_candidate(
         self,

--- a/workers/automation/src/jobctrl/domain/ports/materials.py
+++ b/workers/automation/src/jobctrl/domain/ports/materials.py
@@ -199,8 +199,13 @@ class TailoringPolicyRepository(Protocol):
         """Persist a tailoring policy version."""
         ...
 
-    def resolve_current(self, candidate: TailoringPolicy) -> TailoringPolicy:
-        """Return current policy, creating a new version when config changed."""
+    def resolve_current(
+        self,
+        candidate: TailoringPolicy,
+        *,
+        expected_current_version: int | None = None,
+    ) -> TailoringPolicy:
+        """Resolve the candidate only if the pre-generation snapshot is current."""
         ...
 
 

--- a/workers/automation/src/jobctrl/infrastructure/materials/sqlite_repository.py
+++ b/workers/automation/src/jobctrl/infrastructure/materials/sqlite_repository.py
@@ -27,7 +27,7 @@ from jobctrl.database import effective_tailoring_min_score, ensure_tailoring_pol
 from jobctrl.domain.identifiers import JobId, canonical_job_id
 from jobctrl.domain.materials.aggregate import MaterialsSet
 from jobctrl.domain.materials.entities import Artifact
-from jobctrl.domain.materials.policy import TailoringPolicy
+from jobctrl.domain.materials.policy import TailoringPolicy, TailoringPolicyChangedError
 from jobctrl.domain.materials.value_objects import (
     ArtifactStatus,
     ArtifactType,
@@ -999,10 +999,28 @@ class SqliteTailoringPolicyRepository:
             ),
         )
 
-    def resolve_current(self, candidate: TailoringPolicy) -> TailoringPolicy:
+    def resolve_current(
+        self,
+        candidate: TailoringPolicy,
+        *,
+        expected_current_version: int | None = None,
+    ) -> TailoringPolicy:
         self._conn.execute("BEGIN IMMEDIATE")
         try:
             current = self.get_current(candidate.tenant_id)
+            actual_current_version = 0 if current is None else current.version
+            if (
+                expected_current_version is not None
+                and actual_current_version != expected_current_version
+            ):
+                raise TailoringPolicyChangedError(
+                    "tailoring policy advanced before artifact persistence"
+                )
+            if current is not None and current.learned_tailoring_rules.rules:
+                candidate = candidate.with_learned_tailoring_rules(
+                    current.learned_tailoring_rules,
+                    created_at=candidate.created_at,
+                )
             if current is not None and current.same_config_as(candidate):
                 self._conn.commit()
                 return current

--- a/workers/automation/tests/test_materials_repository.py
+++ b/workers/automation/tests/test_materials_repository.py
@@ -29,7 +29,11 @@ from jobctrl.domain.materials import (
     RenderFormat,
     ValidationResult,
 )
-from jobctrl.domain.materials.policy import TailoringPolicy
+from jobctrl.domain.materials.policy import (
+    LearnedTailoringRules,
+    TailoringPolicy,
+    TailoringPolicyChangedError,
+)
 from jobctrl.domain.tenant import LOCAL_TENANT
 from jobctrl.infrastructure.materials import (
     MaterialsGenerationConflict,
@@ -843,6 +847,70 @@ def _policy(*, fingerprint: str = "sha256:a", version: int = 1) -> TailoringPoli
         runtime_settings={"validation_mode": "normal"},
         created_at="2026-05-26T00:00:00+00:00",
     )
+
+
+@pytest.mark.parametrize(
+    ("rule_key", "rule_value"),
+    [
+        ("style_guidance", "preserve_user_edit_pattern"),
+        ("fact_handling", "require_source_match"),
+        ("claim_policy", "omit_unsupported_claims"),
+        ("keyword_strategy", "use_supported_terms_only"),
+        ("provenance_policy", "require_direct_evidence"),
+    ],
+)
+def test_learned_tailoring_rules_accept_only_closed_pairs(
+    rule_key: str,
+    rule_value: str,
+) -> None:
+    rules = LearnedTailoringRules.from_mapping({rule_key: rule_value})
+    assert rules.to_dict() == {rule_key: rule_value}
+    assert f"{rule_key}={rule_value}" in rules.prompt_lines()[0]
+
+
+def test_learned_tailoring_rules_fail_closed_and_fingerprint_canonically() -> None:
+    with pytest.raises(ValueError, match="versioned allowlist"):
+        LearnedTailoringRules.from_mapping({"fact_handling": "private free text"})
+
+    left = LearnedTailoringRules.from_mapping(
+        {
+            "provenance_policy": "require_direct_evidence",
+            "fact_handling": "require_source_match",
+        }
+    )
+    right = LearnedTailoringRules.from_mapping(
+        {
+            "fact_handling": "require_source_match",
+            "provenance_policy": "require_direct_evidence",
+        }
+    )
+    left_policy = _policy().with_learned_tailoring_rules(left)
+    right_policy = _policy().with_learned_tailoring_rules(right)
+    assert left_policy.runtime_settings == right_policy.runtime_settings
+    assert left_policy.config_fingerprint == right_policy.config_fingerprint
+
+
+def test_tailoring_policy_repository_carries_learned_rules_forward(
+    conn: sqlite3.Connection,
+) -> None:
+    repo = SqliteTailoringPolicyRepository(conn)
+    learned = LearnedTailoringRules.from_mapping(
+        {"fact_handling": "require_source_match"}
+    )
+    first = repo.resolve_current(_policy().with_learned_tailoring_rules(learned))
+
+    second = repo.resolve_current(
+        _policy(fingerprint="sha256:new-runtime"),
+        expected_current_version=first.version,
+    )
+
+    assert second.version == first.version + 1
+    assert second.learned_tailoring_rules == learned
+    with pytest.raises(TailoringPolicyChangedError):
+        repo.resolve_current(
+            _policy(fingerprint="sha256:stale"),
+            expected_current_version=first.version,
+        )
 
 
 def test_tailoring_policy_repository_reuses_same_config(conn: sqlite3.Connection) -> None:

--- a/workers/automation/tests/test_tailor_retailor.py
+++ b/workers/automation/tests/test_tailor_retailor.py
@@ -19,7 +19,8 @@ from jobctrl.domain.materials import (
     RenderFormat,
     ValidationResult,
 )
-from jobctrl.domain.materials.use_cases import TailorOutcome
+from jobctrl.domain.materials.policy import LearnedTailoringRules
+from jobctrl.domain.materials.use_cases import TailorOutcome, build_master_tailor_prompt
 from jobctrl.domain.profile.aggregate import Profile
 from jobctrl.domain.profile.snapshot import ProfileSnapshot
 from jobctrl.domain.tenant import LOCAL_TENANT
@@ -743,13 +744,30 @@ def test_tailor_prompt_includes_writing_style_and_custom_guidance():
     }
 
     snapshot = ProfileSnapshot.from_profile(Profile.from_dict(LOCAL_TENANT, profile))
-    prompt = _build_master_tailor_prompt(snapshot)
+    prompt = build_master_tailor_prompt(
+        snapshot,
+        learned_tailoring_rules=LearnedTailoringRules.from_mapping(
+            {
+                "style_guidance": "preserve_user_edit_pattern",
+                "fact_handling": "require_source_match",
+                "claim_policy": "omit_unsupported_claims",
+                "keyword_strategy": "use_supported_terms_only",
+                "provenance_policy": "require_direct_evidence",
+            }
+        ),
+    )
 
     assert "WRITING STYLE:" in prompt
     assert "- Tone: technical" in prompt
     assert "- Bullet standards: impact, technical_depth, leadership" in prompt
     assert "USER ADDITIONAL TAILORING PROMPT:" in prompt
     assert "Use concise platform leadership language." in prompt
+    assert "ACCEPTED LEARNING RULES FOR FUTURE MATERIALS:" in prompt
+    assert "style_guidance=preserve_user_edit_pattern" in prompt
+    assert "fact_handling=require_source_match" in prompt
+    assert "claim_policy=omit_unsupported_claims" in prompt
+    assert "keyword_strategy=use_supported_terms_only" in prompt
+    assert "provenance_policy=require_direct_evidence" in prompt
 
 
 def test_tailor_prompt_treats_target_job_as_context_not_evidence():


### PR DESCRIPTION
## Summary

- model accepted learning output as a closed, canonical set of typed tailoring rules
- carry learned rules forward through the authoritative Materials policy and include them in deterministic prompt construction and artifact audit metadata
- reject stale policy snapshots before artifact persistence so concurrent policy changes cannot produce an artifact under mismatched rules

## Why

Learning recommendations must not affect behavior until a later explicit acceptance command creates a Materials-owned policy revision. This child provides the typed runtime consumption boundary that command will target, without adding review decisions or mutating policy from the learning context.

## Validation

- `PYTHONPATH=workers/automation/src /Users/eloibarti/Github/JobHunter/workers/automation/.venv/bin/pytest workers/automation/tests/test_materials_repository.py workers/automation/tests/test_tailor_retailor.py -q` (52 passed)
- focused Materials use-case and requirement-led tailoring suites (88 passed)
- focused learning recommendation and feedback reader suites (17 passed)
- Ruff on all changed Python files
- `git diff --check`
- independent review: PASS, no findings

Canonical product documentation remains deferred to the final PR in the approved unreleased stack.
