### PR TITLE
feat(learning): review recommendations atomically

### DIFF
--- a/workers/automation/src/jobctrl/domain/operations/learning.py
+++ b/workers/automation/src/jobctrl/domain/operations/learning.py
@@ -26,6 +26,8 @@ TAILORING_RECOMMENDATION_EVALUATION_FIXTURE_VERSION = 1
 TAILORING_RECOMMENDATION_MIN_SIGNAL_COUNT = 3
 TAILORING_RECOMMENDATION_MIN_JOB_COUNT = 2
 
+LearningRecommendationDecision = Literal["accepted", "rejected"]
+
 
 @dataclass(frozen=True, kw_only=True)
 class LearningSourceChange:
@@ -206,6 +208,43 @@ class LearningRecommendation:
             raise ValueError("one signal cannot support and contradict a recommendation")
 
 
+@dataclass(frozen=True, kw_only=True)
+class LearningRecommendationReview:
+    """Append-only explicit decision linked to the owning Materials policy."""
+
+    tenant_id: TenantId
+    review_id: str
+    recommendation_id: str
+    revision: int
+    decision: LearningRecommendationDecision
+    policy_version: int | None
+    reviewed_at: str
+    context: Literal["materials"] = field(default="materials", init=False)
+    policy_kind: Literal["tailoring_rule"] = field(
+        default="tailoring_rule", init=False
+    )
+
+    def __post_init__(self) -> None:
+        if not str(self.tenant_id).strip():
+            raise ValueError("tenant_id must not be empty")
+        for name, value in (
+            ("review_id", self.review_id),
+            ("recommendation_id", self.recommendation_id),
+            ("reviewed_at", self.reviewed_at),
+        ):
+            if not value.strip():
+                raise ValueError(f"{name} must not be empty")
+        if self.revision < 1:
+            raise ValueError("review revision must be positive")
+        if self.decision not in {"accepted", "rejected"}:
+            raise ValueError("unsupported learning recommendation decision")
+        if self.decision == "accepted":
+            if self.policy_version is None or self.policy_version < 1:
+                raise ValueError("accepted review requires a policy version")
+        elif self.policy_version is not None:
+            raise ValueError("rejected review cannot change policy")
+
+
 def derive_tailoring_recommendations(
     signals: Iterable[FeedbackSignal],
     *,
@@ -348,6 +387,8 @@ def _recommendation_id(
 
 
 __all__ = [
+    "LearningRecommendationDecision",
+    "LearningRecommendationReview",
     "LearningRecommendation",
     "LearningSourceChange",
     "RecommendationEvidenceRef",

--- a/workers/automation/src/jobctrl/domain/ports/materials.py
+++ b/workers/automation/src/jobctrl/domain/ports/materials.py
@@ -33,6 +33,10 @@ from jobctrl.domain.materials.value_objects import (
     RenderFormat,
 )
 from jobctrl.domain.materials.voice import VoiceRequest, VoiceResult
+from jobctrl.domain.operations.learning import (
+    LearningRecommendationDecision,
+    LearningRecommendationReview,
+)
 from jobctrl.domain.tenant import TenantId
 
 
@@ -206,6 +210,21 @@ class TailoringPolicyRepository(Protocol):
         expected_current_version: int | None = None,
     ) -> TailoringPolicy:
         """Resolve the candidate only if the pre-generation snapshot is current."""
+        ...
+
+
+class LearningRecommendationReviewer(Protocol):
+    """Materials-owned boundary for explicit recommendation decisions."""
+
+    def review(
+        self,
+        tenant_id: TenantId,
+        *,
+        recommendation_id: str,
+        decision: LearningRecommendationDecision,
+        reviewed_at: str,
+    ) -> LearningRecommendationReview:
+        """Append a decision and its policy revision atomically."""
         ...
 
 

--- a/workers/automation/src/jobctrl/infrastructure/materials/__init__.py
+++ b/workers/automation/src/jobctrl/infrastructure/materials/__init__.py
@@ -24,7 +24,9 @@ from jobctrl.infrastructure.materials.playwright_html_pdf import (
     PlaywrightHtmlPdfAdapter,
 )
 from jobctrl.infrastructure.materials.sqlite_repository import (
+    LearningRecommendationReviewError,
     MaterialsGenerationConflict,
+    SqliteLearningRecommendationReviewRepository,
     SqliteMaterialsRepository,
     SqliteTailoringPolicyRepository,
 )
@@ -32,10 +34,12 @@ from jobctrl.infrastructure.materials.unit_of_work import SqliteUnitOfWork
 
 __all__ = [
     "HtmlResumePdfAdapter",
+    "LearningRecommendationReviewError",
     "MaterialsGenerationConflict",
     "PlaywrightHtmlPdfAdapter",
     "SqliteBulletProvenanceRepository",
     "SqliteEmployerAnalysisRepository",
+    "SqliteLearningRecommendationReviewRepository",
     "SqliteMaterialsRepository",
     "SqliteTailoringPolicyRepository",
     "SqliteUnitOfWork",

--- a/workers/automation/src/jobctrl/infrastructure/materials/sqlite_repository.py
+++ b/workers/automation/src/jobctrl/infrastructure/materials/sqlite_repository.py
@@ -17,6 +17,7 @@ See ddd-target.md §7.1 / §7.2 (per-aggregate repository, schema decoupling).
 
 from __future__ import annotations
 
+import hashlib
 import json
 import math
 import sqlite3
@@ -28,6 +29,11 @@ from jobctrl.domain.identifiers import JobId, canonical_job_id
 from jobctrl.domain.materials.aggregate import MaterialsSet
 from jobctrl.domain.materials.entities import Artifact
 from jobctrl.domain.materials.policy import TailoringPolicy, TailoringPolicyChangedError
+from jobctrl.domain.operations.learning import (
+    LearningRecommendationDecision,
+    LearningRecommendationReview,
+    TailoringRuleEffect,
+)
 from jobctrl.domain.materials.value_objects import (
     ArtifactStatus,
     ArtifactType,
@@ -62,6 +68,10 @@ class MaterialsGenerationConflict(ValueError):
             f"MaterialsSet generation conflict for job_id={job_id!r}: "
             f"got generation={attempted}, expected existing generation or next generation={expected}"
         )
+
+
+class LearningRecommendationReviewError(ValueError):
+    """Raised when an explicit recommendation decision cannot be applied."""
 
 
 # ---------------------------------------------------------------------------
@@ -936,6 +946,175 @@ def _bounded_float(value: Any) -> float | None:
     return min(100.0, parsed)
 
 
+class SqliteLearningRecommendationReviewRepository:
+    """Atomically link explicit decisions to Materials policy revisions."""
+
+    def __init__(self, conn: sqlite3.Connection) -> None:
+        self._conn = conn
+        ensure_tailoring_policy_tables(conn)
+
+    def review(
+        self,
+        tenant_id: TenantId,
+        *,
+        recommendation_id: str,
+        decision: LearningRecommendationDecision,
+        reviewed_at: str,
+    ) -> LearningRecommendationReview:
+        recommendation_id = str(recommendation_id or "").strip()
+        reviewed_at = str(reviewed_at or "").strip()
+        if not recommendation_id:
+            raise LearningRecommendationReviewError(
+                "recommendation_id must not be empty"
+            )
+        if decision not in {"accepted", "rejected"}:
+            raise LearningRecommendationReviewError(
+                "decision must be accepted or rejected"
+            )
+        if not reviewed_at:
+            raise LearningRecommendationReviewError("reviewed_at must not be empty")
+
+        self._conn.execute("BEGIN IMMEDIATE")
+        try:
+            recommendation = self._conn.execute(
+                """
+                SELECT signal_kind, rule_key, rule_value, allowlist_version
+                FROM learning_recommendations
+                WHERE tenant_id = ? AND recommendation_id = ?
+                """,
+                (str(tenant_id), recommendation_id),
+            ).fetchone()
+            if recommendation is None:
+                raise LearningRecommendationReviewError(
+                    "learning recommendation does not exist for tenant"
+                )
+
+            prior_reviews = tuple(
+                self._review_from_row(row)
+                for row in self._conn.execute(
+                    """
+                    SELECT tenant_id, review_id, recommendation_id, revision,
+                           decision, policy_version, reviewed_at
+                    FROM learning_recommendation_reviews
+                    WHERE tenant_id = ? AND recommendation_id = ?
+                    ORDER BY revision
+                    """,
+                    (str(tenant_id), recommendation_id),
+                ).fetchall()
+            )
+            accepted = next(
+                (review for review in prior_reviews if review.decision == "accepted"),
+                None,
+            )
+            if accepted is not None:
+                if decision == "accepted":
+                    self._conn.commit()
+                    return accepted
+                raise LearningRecommendationReviewError(
+                    "accepted learning recommendation is terminal"
+                )
+            replay = next(
+                (review for review in prior_reviews if review.decision == decision),
+                None,
+            )
+            if replay is not None:
+                self._conn.commit()
+                return replay
+
+            tombstoned = self._conn.execute(
+                """
+                SELECT 1
+                FROM learning_recommendation_tombstones
+                WHERE tenant_id = ? AND recommendation_id = ?
+                LIMIT 1
+                """,
+                (str(tenant_id), recommendation_id),
+            ).fetchone()
+            if tombstoned is not None:
+                raise LearningRecommendationReviewError(
+                    "tombstoned learning recommendation cannot be reviewed"
+                )
+
+            revision = len(prior_reviews) + 1
+            policy_version: int | None = None
+            if decision == "accepted":
+                effect = TailoringRuleEffect(
+                    signal_kind=str(_row_value(recommendation, "signal_kind", 0)),
+                    rule_key=str(_row_value(recommendation, "rule_key", 1)),
+                    rule_value=str(_row_value(recommendation, "rule_value", 2)),
+                    allowlist_version=int(
+                        _row_value(recommendation, "allowlist_version", 3)
+                    ),
+                )
+                policy_repository = SqliteTailoringPolicyRepository(self._conn)
+                current = policy_repository.get_current(tenant_id)
+                if current is None:
+                    raise LearningRecommendationReviewError(
+                        "acceptance requires an initialized tailoring policy"
+                    )
+                policy = current.with_learned_tailoring_rule(
+                    rule_key=effect.rule_key,
+                    rule_value=effect.rule_value,
+                    version=current.version + 1,
+                    created_at=reviewed_at,
+                )
+                policy_repository._insert(policy)
+                policy_version = policy.version
+
+            review = LearningRecommendationReview(
+                tenant_id=tenant_id,
+                review_id=_learning_recommendation_review_id(
+                    tenant_id=tenant_id,
+                    recommendation_id=recommendation_id,
+                    decision=decision,
+                ),
+                recommendation_id=recommendation_id,
+                revision=revision,
+                decision=decision,
+                policy_version=policy_version,
+                reviewed_at=reviewed_at,
+            )
+            self._conn.execute(
+                """
+                INSERT INTO learning_recommendation_reviews (
+                    tenant_id, review_id, recommendation_id, revision,
+                    decision, context, policy_kind, policy_version, reviewed_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    str(review.tenant_id),
+                    review.review_id,
+                    review.recommendation_id,
+                    review.revision,
+                    review.decision,
+                    review.context,
+                    review.policy_kind,
+                    review.policy_version,
+                    review.reviewed_at,
+                ),
+            )
+            self._conn.commit()
+            return review
+        except Exception:
+            self._conn.rollback()
+            raise
+
+    @staticmethod
+    def _review_from_row(row: Any) -> LearningRecommendationReview:
+        raw_policy_version = _row_value(row, "policy_version", 5)
+        return LearningRecommendationReview(
+            tenant_id=TenantId(str(_row_value(row, "tenant_id", 0))),
+            review_id=str(_row_value(row, "review_id", 1)),
+            recommendation_id=str(_row_value(row, "recommendation_id", 2)),
+            revision=int(_row_value(row, "revision", 3)),
+            decision=str(_row_value(row, "decision", 4)),
+            policy_version=(
+                None if raw_policy_version is None else int(raw_policy_version)
+            ),
+            reviewed_at=str(_row_value(row, "reviewed_at", 6)),
+        )
+
+
 class SqliteTailoringPolicyRepository:
     """SQLite-backed current policy adapter for the Materials context."""
 
@@ -1077,6 +1256,16 @@ def _row_value(row: Any, name: str, index: int) -> Any:
     if isinstance(row, sqlite3.Row):
         return row[name]
     return row[index]
+
+
+def _learning_recommendation_review_id(
+    *,
+    tenant_id: TenantId,
+    recommendation_id: str,
+    decision: LearningRecommendationDecision,
+) -> str:
+    payload = f"{tenant_id}\0{recommendation_id}\0{decision}".encode()
+    return f"learning-recommendation-review:{hashlib.sha256(payload).hexdigest()}"
 
 
 def _utc_now() -> str:

--- a/workers/automation/src/jobctrl/infrastructure/rpc/handlers.py
+++ b/workers/automation/src/jobctrl/infrastructure/rpc/handlers.py
@@ -32,6 +32,10 @@ from jobctrl.infrastructure.preparation import SqlitePreparationTargetReader
 from jobctrl.infrastructure.learning.sqlite_repository import (
     SqliteLearningRecommendationRepository,
 )
+from jobctrl.infrastructure.materials import (
+    LearningRecommendationReviewError,
+    SqliteLearningRecommendationReviewRepository,
+)
 from jobctrl.infrastructure.rpc.server import JsonRpcServer, invalid_params
 from jobctrl.infrastructure.rpc.workflow_starter import WorkflowCanceler
 from jobctrl.infrastructure.runtime_identity import assert_expected_runtime
@@ -821,6 +825,42 @@ def rederive_learning_recommendations(params: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def review_learning_recommendation(params: dict[str, Any]) -> dict[str, Any]:
+    """Record one explicit recommendation decision and its policy effect."""
+
+    tenant_id = TenantId(_tenant_id(params))
+    recommendation_id = str(_require(params, "recommendationId")).strip()
+    decision = str(_require(params, "decision")).strip()
+    if decision not in {"accepted", "rejected"}:
+        raise invalid_params("decision must be accepted or rejected")
+    assert_expected_runtime(
+        expected_app_dir=params.get("expectedAppDir"),
+        expected_db_path=params.get("expectedDbPath"),
+    )
+    try:
+        review = SqliteLearningRecommendationReviewRepository(
+            get_connection()
+        ).review(
+            tenant_id,
+            recommendation_id=recommendation_id,
+            decision=decision,
+            reviewed_at=datetime.now(UTC).isoformat(),
+        )
+    except LearningRecommendationReviewError as exc:
+        raise invalid_params(str(exc)) from exc
+    return {
+        "status": "succeeded",
+        "reviewId": review.review_id,
+        "recommendationId": review.recommendation_id,
+        "revision": review.revision,
+        "decision": review.decision,
+        "context": review.context,
+        "policyKind": review.policy_kind,
+        "policyVersion": review.policy_version,
+        "reviewedAt": review.reviewed_at,
+    }
+
+
 # ---------------------------------------------------------------------------
 # Registration
 # ---------------------------------------------------------------------------
@@ -854,6 +894,11 @@ def register_default_handlers(server: JsonRpcServer, *, canceler: WorkflowCancel
     server.register(
         "rederive_learning_recommendations",
         rederive_learning_recommendations,
+        mode="sync",
+    )
+    server.register(
+        "review_learning_recommendation",
+        review_learning_recommendation,
         mode="sync",
     )
     server.register("refresh_compensation", refresh_compensation, mode="workflow")

--- a/workers/automation/tests/test_rpc_learning_recommendations.py
+++ b/workers/automation/tests/test_rpc_learning_recommendations.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 from pathlib import Path
 
 from jobctrl.database import close_connection, init_db
-from jobctrl.domain.rpc.messages import JsonRpcRequest
+from jobctrl.domain.materials.policy import TailoringPolicy
+from jobctrl.domain.rpc.messages import INVALID_PARAMS, JsonRpcRequest
+from jobctrl.domain.tenant import LOCAL_TENANT
+from jobctrl.infrastructure.materials import SqliteTailoringPolicyRepository
 from jobctrl.infrastructure.rpc import handlers as handlers_mod
 from jobctrl.infrastructure.rpc.handlers import register_default_handlers
 from jobctrl.infrastructure.rpc.server import JsonRpcServer
@@ -25,6 +28,149 @@ def test_review_trigger_derives_once_and_replays_idempotently(
 ) -> None:
     db_path = tmp_path / "jobctrl.db"
     conn = init_db(db_path)
+    _seed_recommendation_sources(conn)
+    monkeypatch.setattr(handlers_mod, "get_connection", lambda: conn)
+    server = JsonRpcServer(workflow_starter=_stub_starter)
+    register_default_handlers(server, canceler=_stub_canceler)
+
+    first = server.dispatch(
+        JsonRpcRequest(
+            method="rederive_learning_recommendations",
+            params={"tenantId": "local"},
+            id=1,
+        )
+    )
+    replay = server.dispatch(
+        JsonRpcRequest(
+            method="rederive_learning_recommendations",
+            params={"tenantId": "local"},
+            id=2,
+        )
+    )
+
+    assert first is not None
+    assert replay is not None
+    first_result = first.to_dict()["result"]
+    replay_result = replay.to_dict()["result"]
+    assert first_result["status"] == "succeeded"
+    assert first_result["recommendationCount"] == 1
+    assert replay_result["recommendationIds"] == first_result["recommendationIds"]
+    assert conn.execute("SELECT COUNT(*) FROM learning_recommendations").fetchone()[0] == 1
+    assert conn.execute(
+        "SELECT COUNT(*) FROM learning_recommendation_evidence"
+    ).fetchone()[0] == 3
+    assert conn.execute(
+        "SELECT COUNT(*) FROM learning_recommendation_jobs"
+    ).fetchone()[0] == 2
+    learning_dump = "\n".join(
+        repr(tuple(row))
+        for table in (
+            "learning_recommendations",
+            "learning_recommendation_evidence",
+            "learning_recommendation_evidence_jobs",
+            "learning_recommendation_jobs",
+        )
+        for row in conn.execute(f"SELECT * FROM {table}").fetchall()
+    )
+    assert "private source text" not in learning_dump
+    assert "private-delta" not in learning_dump
+    close_connection(db_path)
+
+
+def test_explicit_review_accepts_atomically_and_replays(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    conn = init_db(db_path)
+    _seed_recommendation_sources(conn)
+    monkeypatch.setattr(handlers_mod, "get_connection", lambda: conn)
+    server = JsonRpcServer(workflow_starter=_stub_starter)
+    register_default_handlers(server, canceler=_stub_canceler)
+    derived = server.dispatch(
+        JsonRpcRequest(
+            method="rederive_learning_recommendations",
+            params={"tenantId": "local"},
+            id=1,
+        )
+    )
+    assert derived is not None
+    recommendation_id = derived.to_dict()["result"]["recommendationIds"][0]
+    policy_repository = SqliteTailoringPolicyRepository(conn)
+    policy_repository.save(_tailoring_policy())
+    runtime_expectations: list[dict[str, str | None]] = []
+    monkeypatch.setattr(
+        handlers_mod,
+        "assert_expected_runtime",
+        lambda **kwargs: runtime_expectations.append(kwargs),
+    )
+    params = {
+        "tenantId": "local",
+        "recommendationId": recommendation_id,
+        "decision": "accepted",
+        "expectedAppDir": "/tmp/jobctrl",
+        "expectedDbPath": "/tmp/jobctrl/jobctrl.db",
+    }
+
+    first = server.dispatch(
+        JsonRpcRequest(
+            method="review_learning_recommendation",
+            params=params,
+            id=2,
+        )
+    )
+    replay = server.dispatch(
+        JsonRpcRequest(
+            method="review_learning_recommendation",
+            params=params,
+            id=3,
+        )
+    )
+
+    assert first is not None
+    assert replay is not None
+    first_result = first.to_dict()["result"]
+    replay_result = replay.to_dict()["result"]
+    assert first_result["decision"] == "accepted"
+    assert first_result["policyVersion"] == 2
+    assert replay_result["reviewId"] == first_result["reviewId"]
+    assert replay_result["policyVersion"] == first_result["policyVersion"]
+    assert runtime_expectations == [
+        {
+            "expected_app_dir": "/tmp/jobctrl",
+            "expected_db_path": "/tmp/jobctrl/jobctrl.db",
+        },
+        {
+            "expected_app_dir": "/tmp/jobctrl",
+            "expected_db_path": "/tmp/jobctrl/jobctrl.db",
+        },
+    ]
+    current = policy_repository.get_current(LOCAL_TENANT)
+    assert current is not None
+    assert current.learned_tailoring_rules.to_dict() == {
+        "fact_handling": "require_source_match"
+    }
+    assert conn.execute(
+        "SELECT COUNT(*) FROM learning_recommendation_reviews"
+    ).fetchone()[0] == 1
+    assert conn.execute("SELECT COUNT(*) FROM tailoring_policies").fetchone()[0] == 2
+
+    rejected = server.dispatch(
+        JsonRpcRequest(
+            method="review_learning_recommendation",
+            params={**params, "decision": "rejected"},
+            id=4,
+        )
+    )
+    assert rejected is not None
+    assert rejected.to_dict()["error"]["code"] == INVALID_PARAMS
+    assert conn.execute(
+        "SELECT COUNT(*) FROM learning_recommendation_reviews"
+    ).fetchone()[0] == 1
+    close_connection(db_path)
+
+
+def _seed_recommendation_sources(conn) -> None:
     job_ids = (
         "11111111-1111-4111-8111-111111111111",
         "22222222-2222-4222-8222-222222222222",
@@ -84,49 +230,21 @@ def test_review_trigger_derives_once_and_replays_idempotently(
             (f"review-{index}", signal_id, f"2026-08-01T10:00:0{index}Z"),
         )
     conn.commit()
-    monkeypatch.setattr(handlers_mod, "get_connection", lambda: conn)
-    server = JsonRpcServer(workflow_starter=_stub_starter)
-    register_default_handlers(server, canceler=_stub_canceler)
 
-    first = server.dispatch(
-        JsonRpcRequest(
-            method="rederive_learning_recommendations",
-            params={"tenantId": "local"},
-            id=1,
-        )
-    )
-    replay = server.dispatch(
-        JsonRpcRequest(
-            method="rederive_learning_recommendations",
-            params={"tenantId": "local"},
-            id=2,
-        )
-    )
 
-    assert first is not None
-    assert replay is not None
-    first_result = first.to_dict()["result"]
-    replay_result = replay.to_dict()["result"]
-    assert first_result["status"] == "succeeded"
-    assert first_result["recommendationCount"] == 1
-    assert replay_result["recommendationIds"] == first_result["recommendationIds"]
-    assert conn.execute("SELECT COUNT(*) FROM learning_recommendations").fetchone()[0] == 1
-    assert conn.execute(
-        "SELECT COUNT(*) FROM learning_recommendation_evidence"
-    ).fetchone()[0] == 3
-    assert conn.execute(
-        "SELECT COUNT(*) FROM learning_recommendation_jobs"
-    ).fetchone()[0] == 2
-    learning_dump = "\n".join(
-        repr(tuple(row))
-        for table in (
-            "learning_recommendations",
-            "learning_recommendation_evidence",
-            "learning_recommendation_evidence_jobs",
-            "learning_recommendation_jobs",
-        )
-        for row in conn.execute(f"SELECT * FROM {table}").fetchall()
+def _tailoring_policy() -> TailoringPolicy:
+    return TailoringPolicy(
+        tenant_id=LOCAL_TENANT,
+        version=1,
+        prompt_version="tailor.v2.quality-gated",
+        schema_version="tailored-resume.v1",
+        judge_schema_version="tailor-judge.v1",
+        prompt_fingerprint="sha256:prompt",
+        config_fingerprint="sha256:config",
+        profile_policy_fingerprint="sha256:profile",
+        custom_prompt_fingerprint="sha256:custom",
+        generator_settings={"candidate_models": ["local:draft"]},
+        judge_settings={"judge_model": "local:judge", "min_score": 0.82},
+        runtime_settings={"validation_mode": "normal"},
+        created_at="2026-08-01T10:00:00Z",
     )
-    assert "private source text" not in learning_dump
-    assert "private-delta" not in learning_dump
-    close_connection(db_path)

--- a/workers/automation/tests/test_sqlite_learning_recommendations.py
+++ b/workers/automation/tests/test_sqlite_learning_recommendations.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
 from dataclasses import replace
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
+import threading
 
 import pytest
 
-from jobctrl.database import close_connection, init_db
+from jobctrl.database import close_connection, get_connection, init_db
 from jobctrl.domain.identifiers import JobId, canonical_job_id
+from jobctrl.domain.materials.policy import TailoringPolicy
 from jobctrl.domain.operations.feedback import TailoringFeedbackSignal
 from jobctrl.domain.operations.learning import (
     LearningSourceChange,
@@ -20,6 +23,11 @@ from jobctrl.domain.tenant import TenantId
 from jobctrl.infrastructure.learning.sqlite_repository import (
     LearningRecommendationConflict,
     SqliteLearningRecommendationRepository,
+)
+from jobctrl.infrastructure.materials import (
+    LearningRecommendationReviewError,
+    SqliteLearningRecommendationReviewRepository,
+    SqliteTailoringPolicyRepository,
 )
 
 
@@ -744,11 +752,273 @@ def test_multiple_source_changes_each_append_a_tombstone(tmp_path: Path) -> None
     close_connection(db_path)
 
 
+def test_review_rejects_without_policy_then_accepts_once(tmp_path: Path) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    conn = init_db(db_path)
+    recommendation = _recommendation(_TENANT_A)
+    SqliteLearningRecommendationRepository(conn).append_pending(
+        recommendation,
+        derived_at="2026-08-01T10:01:00Z",
+    )
+    policy_repository = SqliteTailoringPolicyRepository(conn)
+    original_policy = _tailoring_policy(_TENANT_A)
+    policy_repository.save(original_policy)
+    reviewer = SqliteLearningRecommendationReviewRepository(conn)
+
+    rejected = reviewer.review(
+        _TENANT_A,
+        recommendation_id=recommendation.recommendation_id,
+        decision="rejected",
+        reviewed_at="2026-08-01T11:00:00Z",
+    )
+    rejected_replay = reviewer.review(
+        _TENANT_A,
+        recommendation_id=recommendation.recommendation_id,
+        decision="rejected",
+        reviewed_at="2026-08-01T11:01:00Z",
+    )
+
+    assert rejected == rejected_replay
+    assert rejected.revision == 1
+    assert rejected.policy_version is None
+    assert policy_repository.get_current(_TENANT_A) == original_policy
+
+    accepted = reviewer.review(
+        _TENANT_A,
+        recommendation_id=recommendation.recommendation_id,
+        decision="accepted",
+        reviewed_at="2026-08-01T11:02:00Z",
+    )
+    accepted_replay = reviewer.review(
+        _TENANT_A,
+        recommendation_id=recommendation.recommendation_id,
+        decision="accepted",
+        reviewed_at="2026-08-01T11:03:00Z",
+    )
+
+    assert accepted == accepted_replay
+    assert accepted.revision == 2
+    assert accepted.policy_version == 2
+    assert policy_repository.get_current(_TENANT_A).learned_tailoring_rules.to_dict() == {
+        "fact_handling": "require_source_match"
+    }
+    assert conn.execute(
+        "SELECT COUNT(*) FROM learning_recommendation_reviews"
+    ).fetchone()[0] == 2
+    assert conn.execute("SELECT COUNT(*) FROM tailoring_policies").fetchone()[0] == 2
+    with pytest.raises(
+        LearningRecommendationReviewError,
+        match="terminal",
+    ):
+        reviewer.review(
+            _TENANT_A,
+            recommendation_id=recommendation.recommendation_id,
+            decision="rejected",
+            reviewed_at="2026-08-01T11:04:00Z",
+        )
+    close_connection(db_path)
+
+
+def test_review_fails_closed_without_current_policy_or_for_tombstone(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    conn = init_db(db_path)
+    recommendation = _recommendation(_TENANT_A)
+    SqliteLearningRecommendationRepository(conn).append_pending(
+        recommendation,
+        derived_at="2026-08-01T10:01:00Z",
+    )
+    reviewer = SqliteLearningRecommendationReviewRepository(conn)
+
+    with pytest.raises(
+        LearningRecommendationReviewError,
+        match="initialized tailoring policy",
+    ):
+        reviewer.review(
+            _TENANT_A,
+            recommendation_id=recommendation.recommendation_id,
+            decision="accepted",
+            reviewed_at="2026-08-01T11:00:00Z",
+        )
+    with pytest.raises(
+        LearningRecommendationReviewError,
+        match="does not exist for tenant",
+    ):
+        reviewer.review(
+            _TENANT_B,
+            recommendation_id=recommendation.recommendation_id,
+            decision="accepted",
+            reviewed_at="2026-08-01T11:00:00Z",
+        )
+    assert conn.execute(
+        "SELECT COUNT(*) FROM learning_recommendation_reviews"
+    ).fetchone()[0] == 0
+    assert conn.execute("SELECT COUNT(*) FROM tailoring_policies").fetchone()[0] == 0
+
+    SqliteTailoringPolicyRepository(conn).save(_tailoring_policy(_TENANT_A))
+    evidence = recommendation.evidence[0]
+    conn.execute(
+        """
+        INSERT INTO learning_recommendation_tombstones (
+            tenant_id, tombstone_id, recommendation_id, affected_signal_id,
+            affected_source_revision, reason_code, derivation_version,
+            tombstoned_at, rederived_at, replacement_recommendation_id
+        ) VALUES (?, ?, ?, ?, ?, 'source_deleted', 1, ?, ?, NULL)
+        """,
+        (
+            str(_TENANT_A),
+            "tombstone-review-fixture",
+            recommendation.recommendation_id,
+            evidence.signal_id,
+            evidence.source_revision,
+            "2026-08-01T11:01:00Z",
+            "2026-08-01T11:01:00Z",
+        ),
+    )
+    conn.commit()
+
+    with pytest.raises(LearningRecommendationReviewError, match="tombstoned"):
+        reviewer.review(
+            _TENANT_A,
+            recommendation_id=recommendation.recommendation_id,
+            decision="accepted",
+            reviewed_at="2026-08-01T11:02:00Z",
+        )
+    assert conn.execute(
+        "SELECT COUNT(*) FROM learning_recommendation_reviews"
+    ).fetchone()[0] == 0
+    assert conn.execute("SELECT COUNT(*) FROM tailoring_policies").fetchone()[0] == 1
+    close_connection(db_path)
+
+
+def test_concurrent_accepts_serialize_and_preserve_both_rules(tmp_path: Path) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    setup_conn = init_db(db_path)
+    recommendations = (
+        _recommendation(_TENANT_A),
+        _recommendation_for_effect(
+            _TENANT_A,
+            signal_kind="style_preference",
+            rule_key="style_guidance",
+            rule_value="preserve_user_edit_pattern",
+        ),
+    )
+    recommendation_repository = SqliteLearningRecommendationRepository(setup_conn)
+    for recommendation in recommendations:
+        recommendation_repository.append_pending(
+            recommendation,
+            derived_at="2026-08-01T10:01:00Z",
+        )
+    SqliteTailoringPolicyRepository(setup_conn).save(_tailoring_policy(_TENANT_A))
+    close_connection(db_path)
+    start = threading.Event()
+
+    def accept(recommendation_id: str):
+        conn = get_connection(db_path)
+        try:
+            start.wait(timeout=5)
+            return SqliteLearningRecommendationReviewRepository(conn).review(
+                _TENANT_A,
+                recommendation_id=recommendation_id,
+                decision="accepted",
+                reviewed_at="2026-08-01T11:00:00Z",
+            )
+        finally:
+            close_connection(db_path)
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        futures = [
+            executor.submit(accept, recommendation.recommendation_id)
+            for recommendation in recommendations
+        ]
+        start.set()
+        reviews = [future.result(timeout=10) for future in futures]
+
+    assert sorted(review.policy_version for review in reviews) == [2, 3]
+    check_conn = get_connection(db_path)
+    try:
+        current = SqliteTailoringPolicyRepository(check_conn).get_current(_TENANT_A)
+        assert current is not None
+        assert current.learned_tailoring_rules.to_dict() == {
+            "fact_handling": "require_source_match",
+            "style_guidance": "preserve_user_edit_pattern",
+        }
+        assert check_conn.execute(
+            "SELECT COUNT(*) FROM learning_recommendation_reviews"
+        ).fetchone()[0] == 2
+        assert check_conn.execute(
+            "SELECT COUNT(*) FROM tailoring_policies"
+        ).fetchone()[0] == 3
+    finally:
+        close_connection(db_path)
+
+
 def _recommendation(tenant_id: TenantId):
     return derive_tailoring_recommendations(
         _signals(tenant_id),
         contradictions={},
     )[0]
+
+
+def _recommendation_for_effect(
+    tenant_id: TenantId,
+    *,
+    signal_kind: str,
+    rule_key: str,
+    rule_value: str,
+):
+    scope = TailoringRecommendationScope(
+        tenant_id=tenant_id,
+        proposed_effect=TailoringRuleEffect(
+            signal_kind=signal_kind,
+            rule_key=rule_key,
+            rule_value=rule_value,
+            allowlist_version=1,
+        ),
+    )
+    signals = tuple(
+        TailoringFeedbackSignal(
+            signal_id=f"{signal_kind}-signal-{index}",
+            tenant_id=tenant_id,
+            job_id=job_id,
+            source_id=f"{signal_kind}-source-{index}",
+            source_revision=index,
+            recorded_at=f"2026-08-01T10:00:0{index}Z",
+            signal_kind=signal_kind,
+            rule_key=rule_key,
+            rule_value=rule_value,
+            allowlist_version=1,
+        )
+        for index, job_id in enumerate((_JOB_A, _JOB_A, _JOB_B), start=1)
+    )
+    return derive_tailoring_recommendations(
+        signals,
+        contradictions={
+            scope: TailoringContradictionEvidence(
+                signal_ids=(),
+                unresolved_signal_ids=(),
+            )
+        },
+    )[0]
+
+
+def _tailoring_policy(tenant_id: TenantId) -> TailoringPolicy:
+    return TailoringPolicy(
+        tenant_id=tenant_id,
+        version=1,
+        prompt_version="tailor.v2.quality-gated",
+        schema_version="tailored-resume.v1",
+        judge_schema_version="tailor-judge.v1",
+        prompt_fingerprint="sha256:prompt",
+        config_fingerprint="sha256:config",
+        profile_policy_fingerprint="sha256:profile",
+        custom_prompt_fingerprint="sha256:custom",
+        generator_settings={"candidate_models": ["local:draft"]},
+        judge_settings={"judge_model": "local:judge", "min_score": 0.82},
+        runtime_settings={"validation_mode": "normal"},
+        created_at="2026-08-01T10:00:00Z",
+    )
 
 
 def _signals(tenant_id: TenantId) -> tuple[TailoringFeedbackSignal, ...]:


### PR DESCRIPTION
## Summary

- add a synchronous, runtime-identity-guarded command for explicit learning recommendation acceptance and rejection
- serialize decision writes with `BEGIN IMMEDIATE` so acceptance appends one Materials policy revision and its linked review atomically
- keep rejection policy-neutral and make duplicate decisions idempotent while preserving reject-then-accept and terminal acceptance semantics
- fail closed for missing, cross-tenant, tombstoned, uninitialized, or non-allowlisted recommendations

## Why

Recommendations must remain non-executable until the user explicitly accepts them. This child adds the owning transaction boundary without introducing a second policy authority: `tailoring_policies` remains canonical, and the append-only review ledger records the decision and accepted policy version.

## Validation

- repository, synchronous RPC, and Materials regressions: 52 passed
- learning derivation and exact-v7 schema regressions: 30 passed
- wider JSON-RPC handler suite: 79 passed
- Ruff on all seven changed Python files
- `git diff --check`
- independent Tier 3 review: PASS, no findings
- independent Tier 3 QA: PASS, no findings; includes injected review-insert rollback failure, runtime-identity ordering, concurrent accepts, tombstones, tenant isolation, and decision replay

This child intentionally has no REST or web surface. Canonical product documentation and cumulative product-path QA remain deferred to later children in the approved unreleased stack.
