### PR TITLE
docs(agents): reuse task validation agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,6 +93,11 @@ and explain any intentional stacked deferral in the PR body.
 - **Subagent spawning:** Use subagents only for genuinely independent work or
   for the review/QA gates required by the validation tiers below. Do not add
   coordination overhead to work that is faster to complete directly.
+  Within one task, create at most one agent of each required type/role and
+  reuse that agent via follow-up turns for related work, fixes, and reruns.
+  Replace an agent only when it is unavailable/terminated or the new work is
+  genuinely a different task; never use a replacement to obtain another
+  opinion or avoid continuity.
 
 ### Root-Cause And Auditability Discipline
 
@@ -179,9 +184,9 @@ gate across the whole stack. A phase that changes an active high-risk path or is
 released independently follows its normal tier immediately.
 
 Run independent gates once after implementation and focused verification. Rerun
-a failed gate after addressing its Blocker/High findings; do not repeat passing
-gates for cosmetic edits or unresolved Medium/Low observations unless the edit
-could affect the verified behavior.
+a failed gate with the same reviewer/QA agent after addressing its Blocker/High
+findings; do not repeat passing gates for cosmetic edits or unresolved Medium/
+Low observations unless the edit could affect the verified behavior.
 
 Before calling work done:
 


### PR DESCRIPTION
## Summary

- require one reusable agent per role within a task
- require related fixes and validation reruns to use follow-up turns on that agent
- allow replacement only when the prior agent is unavailable or the work is genuinely a different task
- require failed independent gates to rerun with the same reviewer or QA agent

## Why

The existing rules limited when subagents should be used but did not constrain their lifecycle. Reusing one agent per role preserves context and avoids coordination overhead from repeated replacements.

## Validation

- `git diff --check`
- inspected the exact `AGENTS.md` diff

This is a Tier 0 editorial workflow change with no runtime effect.
