### PR TITLE
fix(materials): preserve learning review transaction

### DIFF
--- a/workers/automation/src/jobctrl/infrastructure/materials/sqlite_repository.py
+++ b/workers/automation/src/jobctrl/infrastructure/materials/sqlite_repository.py
@@ -974,6 +974,11 @@ class SqliteLearningRecommendationReviewRepository:
         if not reviewed_at:
             raise LearningRecommendationReviewError("reviewed_at must not be empty")
 
+        policy_repository = (
+            SqliteTailoringPolicyRepository(self._conn)
+            if decision == "accepted"
+            else None
+        )
         self._conn.execute("BEGIN IMMEDIATE")
         try:
             recommendation = self._conn.execute(
@@ -1046,7 +1051,7 @@ class SqliteLearningRecommendationReviewRepository:
                         _row_value(recommendation, "allowlist_version", 3)
                     ),
                 )
-                policy_repository = SqliteTailoringPolicyRepository(self._conn)
+                assert policy_repository is not None
                 current = policy_repository.get_current(tenant_id)
                 if current is None:
                     raise LearningRecommendationReviewError(

--- a/workers/automation/tests/test_sqlite_learning_recommendations.py
+++ b/workers/automation/tests/test_sqlite_learning_recommendations.py
@@ -24,6 +24,7 @@ from jobctrl.infrastructure.learning.sqlite_repository import (
     LearningRecommendationConflict,
     SqliteLearningRecommendationRepository,
 )
+from jobctrl.infrastructure.materials import sqlite_repository as materials_sqlite_repository
 from jobctrl.infrastructure.materials import (
     LearningRecommendationReviewError,
     SqliteLearningRecommendationReviewRepository,
@@ -892,7 +893,21 @@ def test_review_fails_closed_without_current_policy_or_for_tombstone(
     close_connection(db_path)
 
 
-def test_concurrent_accepts_serialize_and_preserve_both_rules(tmp_path: Path) -> None:
+def test_concurrent_accepts_serialize_and_preserve_both_rules(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    original_ensure = materials_sqlite_repository.ensure_tailoring_policy_tables
+
+    def ensure_before_immediate_transaction(conn):
+        assert not conn.in_transaction
+        return original_ensure(conn)
+
+    monkeypatch.setattr(
+        materials_sqlite_repository,
+        "ensure_tailoring_policy_tables",
+        ensure_before_immediate_transaction,
+    )
     db_path = tmp_path / "jobctrl.db"
     setup_conn = init_db(db_path)
     recommendations = (


### PR DESCRIPTION
## Summary
- construct the tailoring policy repository before opening the immediate review transaction
- keep policy reads, version allocation, policy insertion, and review insertion under one SQLite write lock
- make the concurrency regression fail if schema setup commits inside the transaction

## Why
Concurrent accepted recommendations could both allocate the same policy version because repository schema setup committed after BEGIN IMMEDIATE. Python 3.11 and 3.13 CI exposed the resulting unique-key failure.

## Validation
- focused learning-review tests: 2 passed
- concurrent acceptance regression: 10 consecutive passes
- Ruff on both changed files: passed
- git diff --check: passed
- independent review: PASS, zero findings

Ready for review. Stacked on #690.