### PR TITLE
feat(api): review learning recommendations

### DIFF
--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -48,6 +48,8 @@ import {
   LearningRecommendationEvidenceListQuerySchema,
   LearningRecommendationIdSchema,
   LearningRecommendationListQuerySchema,
+  LearningRecommendationReviewRequestSchema,
+  LearningRecommendationReviewResponseSchema,
   JsonRpcErrorCodes,
   JsonRpcRequestSchema,
   MarkJobActionRequestSchema,
@@ -70,6 +72,8 @@ import {
   RunJobStageRequestSchema,
   RoleMatchFeedbackDecisionSchema,
   RetailorJobRequestSchema,
+  ReviewLearningRecommendationResultSchema,
+  RpcMethods,
   ResumeTemplateDefaultSelectionRequestSchema,
   ResumeTemplateVersionSaveRequestSchema,
   ResumeCommentReplyRequestSchema,
@@ -609,6 +613,54 @@ export function buildApp(options: BuildAppOptions): FastifyInstance {
         }
         return response;
       });
+    },
+  );
+
+  app.post<{ Params: { recommendationId: string } }>(
+    "/v1/learning/recommendations/:recommendationId/reviews",
+    async (request, reply) => {
+      const parsedRecommendationId = LearningRecommendationIdSchema.safeParse(
+        decodeRouteParam(request.params.recommendationId),
+      );
+      if (!parsedRecommendationId.success) {
+        void reply.code(400);
+        return { ok: false, error: "invalid_learning_recommendation_id" };
+      }
+      const body = parseBody(reply, LearningRecommendationReviewRequestSchema, request.body ?? {});
+      if (!body) {
+        return undefined;
+      }
+
+      let response;
+      try {
+        response = await providerDispatcher.call(RpcMethods.ReviewLearningRecommendation, {
+          tenantId: "local",
+          recommendationId: parsedRecommendationId.data,
+          decision: body.decision,
+          expectedAppDir: appDir,
+          expectedDbPath: options.dbPath,
+        });
+      } catch {
+        return learningRecommendationReviewFailure(reply, 503);
+      }
+
+      if (response.error) {
+        return learningRecommendationReviewFailure(
+          reply,
+          response.error.code === JsonRpcErrorCodes.InvalidParams ? 409 : 502,
+        );
+      }
+
+      const parsedResult = ReviewLearningRecommendationResultSchema.safeParse(response.result);
+      if (
+        !parsedResult.success ||
+        parsedResult.data.recommendationId !== parsedRecommendationId.data ||
+        parsedResult.data.decision !== body.decision
+      ) {
+        return learningRecommendationReviewFailure(reply, 502);
+      }
+      const { status: _status, ...review } = parsedResult.data;
+      return LearningRecommendationReviewResponseSchema.parse({ ok: true, ...review });
     },
   );
 
@@ -3296,6 +3348,15 @@ function providerOperationError(
   message: string,
 ) {
   return { ok: false as const, error, message };
+}
+
+function learningRecommendationReviewFailure(reply: FastifyReply, statusCode: 409 | 502 | 503) {
+  void reply.code(statusCode);
+  return {
+    ok: false as const,
+    error: "learning_recommendation_review_failed" as const,
+    message: "The learning recommendation review could not be completed.",
+  };
 }
 
 async function dispatchProviderModelCatalog(

--- a/apps/api/test/rpc-contracts.test.ts
+++ b/apps/api/test/rpc-contracts.test.ts
@@ -19,6 +19,8 @@ import {
   ProviderModelCatalogResultSchema,
   RederiveLearningRecommendationsParamsSchema,
   RederiveLearningRecommendationsResultSchema,
+  ReviewLearningRecommendationParamsSchema,
+  ReviewLearningRecommendationResultSchema,
   RefreshCompensationParamsSchema,
   RefreshCompensationResultSchema,
   RescoreJobParamsSchema,
@@ -73,6 +75,80 @@ describe("learning recommendation derivation RPC contract", () => {
         status: "succeeded",
         recommendationCount: 1,
         recommendationIds: ["private free text"],
+      }),
+    ).toThrow();
+  });
+});
+
+describe("learning recommendation review RPC contract", () => {
+  it("registers runtime-scoped review params and couples decision to policy effect", () => {
+    const recommendationId = `learning-recommendation:${"a".repeat(64)}`;
+    const reviewId = `learning-recommendation-review:${"b".repeat(64)}`;
+    expect(RpcMethods.ReviewLearningRecommendation).toBe("review_learning_recommendation");
+    expect(
+      ReviewLearningRecommendationParamsSchema.parse({
+        recommendationId,
+        decision: "accepted",
+        expectedAppDir: "/tmp/jobctrl",
+        expectedDbPath: "/tmp/jobctrl/jobctrl.db",
+      }),
+    ).toEqual({
+      tenantId: "local",
+      recommendationId,
+      decision: "accepted",
+      expectedAppDir: "/tmp/jobctrl",
+      expectedDbPath: "/tmp/jobctrl/jobctrl.db",
+    });
+    expect(
+      ReviewLearningRecommendationResultSchema.parse({
+        status: "succeeded",
+        reviewId,
+        recommendationId,
+        revision: 1,
+        decision: "accepted",
+        context: "materials",
+        policyKind: "tailoring_rule",
+        policyVersion: 2,
+        reviewedAt: "2026-08-01T12:34:56+00:00",
+      }),
+    ).toMatchObject({
+      reviewId,
+      recommendationId,
+      decision: "accepted",
+      policyVersion: 2,
+      reviewedAt: "2026-08-01T12:34:56.000Z",
+    });
+    expect(() =>
+      ReviewLearningRecommendationParamsSchema.parse({
+        recommendationId,
+        decision: "accepted",
+        unexpected: true,
+      }),
+    ).toThrow();
+    expect(() =>
+      ReviewLearningRecommendationResultSchema.parse({
+        status: "succeeded",
+        reviewId,
+        recommendationId,
+        revision: 1,
+        decision: "accepted",
+        context: "materials",
+        policyKind: "tailoring_rule",
+        policyVersion: null,
+        reviewedAt: "2026-08-01T12:34:56Z",
+      }),
+    ).toThrow();
+    expect(() =>
+      ReviewLearningRecommendationResultSchema.parse({
+        status: "succeeded",
+        reviewId,
+        recommendationId,
+        revision: 1,
+        decision: "rejected",
+        context: "materials",
+        policyKind: "tailoring_rule",
+        policyVersion: 2,
+        reviewedAt: "2026-08-01T12:34:56Z",
       }),
     ).toThrow();
   });

--- a/apps/api/test/server.test.ts
+++ b/apps/api/test/server.test.ts
@@ -11,8 +11,10 @@ import {
   JsonRpcErrorCodes,
   LearningRecommendationEvidenceListResponseSchema,
   LearningRecommendationListResponseSchema,
+  LearningRecommendationReviewResponseSchema,
   PipelineOperationsSnapshotSchema,
   ProviderConfigurationKeys,
+  RpcMethods,
   ScoringKeywordAggregationResponseSchema,
   SecretCredentialKeys,
   type ActionCommandPayload,
@@ -2700,6 +2702,221 @@ describe("local TypeScript API", () => {
     const unchanged = new Database(options.dbPath);
     expect(learningAuditSnapshot(unchanged)).toBe(auditBefore);
     unchanged.close();
+    await app.close();
+  });
+
+  it("reviews learning recommendations through the runtime-scoped RPC boundary", async () => {
+    const recommendationId = `learning-recommendation:${"a".repeat(64)}`;
+    const acceptedReviewId = `learning-recommendation-review:${"b".repeat(64)}`;
+    const rejectedReviewId = `learning-recommendation-review:${"c".repeat(64)}`;
+    const call = vi.fn<JsonRpcDispatcher["call"]>(async (_method, params) => ({
+      jsonrpc: "2.0" as const,
+      id: 1,
+      result:
+        params.decision === "accepted"
+          ? {
+              status: "succeeded",
+              reviewId: acceptedReviewId,
+              recommendationId,
+              revision: 1,
+              decision: "accepted",
+              context: "materials",
+              policyKind: "tailoring_rule",
+              policyVersion: 2,
+              reviewedAt: "2026-08-01T12:34:56+00:00",
+            }
+          : {
+              status: "succeeded",
+              reviewId: rejectedReviewId,
+              recommendationId,
+              revision: 2,
+              decision: "rejected",
+              context: "materials",
+              policyKind: "tailoring_rule",
+              policyVersion: null,
+              reviewedAt: "2026-08-01T12:35:56Z",
+            },
+    }));
+    const app = buildApp({
+      ...options,
+      providerDispatcher: { call, close: vi.fn(async () => undefined) },
+    });
+
+    const accepted = await app.inject({
+      method: "POST",
+      url: `/v1/learning/recommendations/${recommendationId}/reviews`,
+      payload: { decision: "accepted" },
+    });
+    expect(accepted.statusCode, accepted.body).toBe(200);
+    const acceptedReview = LearningRecommendationReviewResponseSchema.parse(accepted.json());
+    expect(acceptedReview).toMatchObject({
+      reviewId: acceptedReviewId,
+      recommendationId,
+      decision: "accepted",
+      policyVersion: 2,
+      reviewedAt: "2026-08-01T12:34:56.000Z",
+    });
+    expect(call).toHaveBeenCalledWith(RpcMethods.ReviewLearningRecommendation, {
+      tenantId: "local",
+      recommendationId,
+      decision: "accepted",
+      expectedAppDir: tempDir,
+      expectedDbPath: options.dbPath,
+    });
+
+    const rejected = await app.inject({
+      method: "POST",
+      url: `/v1/learning/recommendations/${recommendationId}/reviews`,
+      payload: { decision: "rejected" },
+    });
+    expect(rejected.statusCode, rejected.body).toBe(200);
+    expect(LearningRecommendationReviewResponseSchema.parse(rejected.json())).toMatchObject({
+      reviewId: rejectedReviewId,
+      recommendationId,
+      decision: "rejected",
+      policyVersion: null,
+      reviewedAt: "2026-08-01T12:35:56.000Z",
+    });
+    await app.close();
+
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify(acceptedReview), { status: 200, statusText: "OK" }),
+    );
+    await expect(
+      createJobCtrlApiClient().reviewLearningRecommendation(recommendationId, {
+        decision: "accepted",
+      }),
+    ).resolves.toEqual(acceptedReview);
+    expect(fetchMock).toHaveBeenCalledWith(
+      `http://127.0.0.1:8766/v1/learning/recommendations/${encodeURIComponent(recommendationId)}/reviews`,
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ decision: "accepted" }),
+      }),
+    );
+    fetchMock.mockRestore();
+  });
+
+  it("rejects invalid learning review input before dispatch", async () => {
+    const call = vi.fn<JsonRpcDispatcher["call"]>(async () => {
+      throw new Error("review RPC must not be called");
+    });
+    const app = buildApp({
+      ...options,
+      providerDispatcher: { call, close: vi.fn(async () => undefined) },
+    });
+
+    const invalidId = await app.inject({
+      method: "POST",
+      url: "/v1/learning/recommendations/not-a-canonical-recommendation/reviews",
+      payload: { decision: "accepted" },
+    });
+    const invalidDecision = await app.inject({
+      method: "POST",
+      url: `/v1/learning/recommendations/learning-recommendation:${"a".repeat(64)}/reviews`,
+      payload: { decision: "deferred" },
+    });
+
+    expect(invalidId.statusCode, invalidId.body).toBe(400);
+    expect(invalidId.json()).toEqual({ ok: false, error: "invalid_learning_recommendation_id" });
+    expect(invalidDecision.statusCode).toBe(400);
+    expect(call).not.toHaveBeenCalled();
+    await app.close();
+  });
+
+  it("sanitizes learning review worker failures", async () => {
+    const recommendationId = `learning-recommendation:${"a".repeat(64)}`;
+    const marker = "private-worker-detail-must-not-appear";
+    const cases = [
+      {
+        statusCode: 409,
+        response: {
+          jsonrpc: "2.0" as const,
+          id: 1,
+          error: { code: JsonRpcErrorCodes.InvalidParams, message: marker, data: { marker } },
+        },
+      },
+      {
+        statusCode: 502,
+        response: {
+          jsonrpc: "2.0" as const,
+          id: 1,
+          error: { code: JsonRpcErrorCodes.InternalError, message: marker, data: { marker } },
+        },
+      },
+      {
+        statusCode: 502,
+        response: {
+          jsonrpc: "2.0" as const,
+          id: 1,
+          result: { status: "succeeded", privateDetail: marker },
+        },
+      },
+      { statusCode: 503, error: new Error(marker) },
+    ] as const;
+
+    for (const failure of cases) {
+      const call = vi.fn<JsonRpcDispatcher["call"]>(async () => {
+        if ("error" in failure) {
+          throw failure.error;
+        }
+        return failure.response;
+      });
+      const app = buildApp({
+        ...options,
+        providerDispatcher: { call, close: vi.fn(async () => undefined) },
+      });
+      const response = await app.inject({
+        method: "POST",
+        url: `/v1/learning/recommendations/${recommendationId}/reviews`,
+        payload: { decision: "accepted" },
+      });
+
+      expect(response.statusCode, response.body).toBe(failure.statusCode);
+      expect(response.json()).toEqual({
+        ok: false,
+        error: "learning_recommendation_review_failed",
+        message: "The learning recommendation review could not be completed.",
+      });
+      expect(response.body).not.toContain(marker);
+      await app.close();
+    }
+  });
+
+  it("sanitizes an impossible calendar date in a learning recommendation review result", async () => {
+    const recommendationId = `learning-recommendation:${"a".repeat(64)}`;
+    const call = vi.fn<JsonRpcDispatcher["call"]>(async () => ({
+      jsonrpc: "2.0" as const,
+      id: 1,
+      result: {
+        status: "succeeded",
+        reviewId: `learning-recommendation-review:${"b".repeat(64)}`,
+        recommendationId,
+        revision: 1,
+        decision: "accepted",
+        context: "materials",
+        policyKind: "tailoring_rule",
+        policyVersion: 2,
+        reviewedAt: "2026-02-31T12:34:56+00:00",
+      },
+    }));
+    const app = buildApp({
+      ...options,
+      providerDispatcher: { call, close: vi.fn(async () => undefined) },
+    });
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/v1/learning/recommendations/${recommendationId}/reviews`,
+      payload: { decision: "accepted" },
+    });
+
+    expect(response.statusCode, response.body).toBe(502);
+    expect(response.json()).toEqual({
+      ok: false,
+      error: "learning_recommendation_review_failed",
+      message: "The learning recommendation review could not be completed.",
+    });
     await app.close();
   });
 

--- a/packages/api-client/src/client.ts
+++ b/packages/api-client/src/client.ts
@@ -87,6 +87,8 @@ import type {
   LearningRecommendationEvidenceListResponse,
   LearningRecommendationListResponse,
   LearningRecommendationListQuery,
+  LearningRecommendationReviewRequest,
+  LearningRecommendationReviewResponse,
   JobMutationResponse,
   JobSummary,
   MarkJobActionRequest,
@@ -161,6 +163,7 @@ import type {
 import {
   LearningRecommendationEvidenceListResponseSchema,
   LearningRecommendationListResponseSchema,
+  LearningRecommendationReviewResponseSchema,
 } from "@jobctrl/contracts";
 
 type QueryValue = boolean | number | string | null | undefined;
@@ -269,6 +272,18 @@ export class JobCtrlApiClient {
       await this.get(
         `/v1/learning/recommendations/${encodeURIComponent(recommendationId)}/evidence`,
         query,
+      ),
+    );
+  }
+
+  async reviewLearningRecommendation(
+    recommendationId: string,
+    body: LearningRecommendationReviewRequest,
+  ): Promise<LearningRecommendationReviewResponse> {
+    return LearningRecommendationReviewResponseSchema.parse(
+      await this.post(
+        `/v1/learning/recommendations/${encodeURIComponent(recommendationId)}/reviews`,
+        body,
       ),
     );
   }

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -9,6 +9,8 @@ import { z } from "zod";
 
 import {
   DEFAULT_PIPELINE_LLM_MODEL,
+  LearningRecommendationIdSchema,
+  LearningRecommendationReviewIdSchema,
   MANUAL_CAPTURE_MODE_VALUES,
   STAGES,
 } from "./schemas.js";
@@ -87,6 +89,7 @@ export const RpcMethods = {
   BrowserCapabilityDisable: "browser_capability_disable",
   BrowserProfileCopy: "browser_profile_copy",
   RederiveLearningRecommendations: "rederive_learning_recommendations",
+  ReviewLearningRecommendation: "review_learning_recommendation",
 } as const;
 export type RpcMethod = (typeof RpcMethods)[keyof typeof RpcMethods];
 
@@ -499,6 +502,90 @@ export const RederiveLearningRecommendationsResultSchema = z
   );
 export type RederiveLearningRecommendationsResult = z.infer<
   typeof RederiveLearningRecommendationsResultSchema
+>;
+
+export const ReviewLearningRecommendationParamsSchema = z
+  .object({
+    tenantId: TenantParam,
+    expectedAppDir: z.string().trim().min(1).optional(),
+    expectedDbPath: z.string().trim().min(1).optional(),
+    recommendationId: LearningRecommendationIdSchema,
+    decision: z.enum(["accepted", "rejected"]),
+  })
+  .strict();
+export type ReviewLearningRecommendationParams = z.infer<
+  typeof ReviewLearningRecommendationParamsSchema
+>;
+
+const WorkerUtcTimestampPattern = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.\d{1,6})?(?:Z|\+00:00)$/;
+
+function isValidWorkerUtcTimestamp(value: string): boolean {
+  const match = WorkerUtcTimestampPattern.exec(value);
+  if (!match) {
+    return false;
+  }
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const hour = Number(match[4]);
+  const minute = Number(match[5]);
+  const second = Number(match[6]);
+  if (month < 1 || month > 12 || hour > 23 || minute > 59 || second > 59) {
+    return false;
+  }
+  const daysInMonth = [
+    31,
+    year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0) ? 29 : 28,
+    31,
+    30,
+    31,
+    30,
+    31,
+    31,
+    30,
+    31,
+    30,
+    31,
+  ][month - 1] ?? 0;
+  return day >= 1 && day <= daysInMonth;
+}
+
+const WorkerUtcTimestampSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(80)
+  .regex(
+    WorkerUtcTimestampPattern,
+    "Expected an ISO-8601 UTC timestamp.",
+  )
+  .refine(isValidWorkerUtcTimestamp, "Expected a valid UTC timestamp.")
+  .transform((value) => new Date(value).toISOString());
+
+const ReviewLearningRecommendationResultBaseSchema = z
+  .object({
+    status: z.literal("succeeded"),
+    reviewId: LearningRecommendationReviewIdSchema,
+    recommendationId: LearningRecommendationIdSchema,
+    revision: z.number().int().positive(),
+    context: z.literal("materials"),
+    policyKind: z.literal("tailoring_rule"),
+    reviewedAt: WorkerUtcTimestampSchema,
+  })
+  .strict();
+
+export const ReviewLearningRecommendationResultSchema = z.discriminatedUnion("decision", [
+  ReviewLearningRecommendationResultBaseSchema.extend({
+    decision: z.literal("accepted"),
+    policyVersion: z.number().int().positive(),
+  }),
+  ReviewLearningRecommendationResultBaseSchema.extend({
+    decision: z.literal("rejected"),
+    policyVersion: z.null(),
+  }),
+]);
+export type ReviewLearningRecommendationResult = z.infer<
+  typeof ReviewLearningRecommendationResultSchema
 >;
 
 export const ProfileImportParamsSchema = z

--- a/packages/contracts/src/schemas.ts
+++ b/packages/contracts/src/schemas.ts
@@ -2199,6 +2199,44 @@ export const LearningRecommendationIdSchema = z
   .string()
   .regex(/^learning-recommendation:[a-f0-9]{64}$/);
 
+export const LearningRecommendationReviewIdSchema = z
+  .string()
+  .regex(/^learning-recommendation-review:[a-f0-9]{64}$/);
+
+export const LearningRecommendationReviewRequestSchema = z.discriminatedUnion("decision", [
+  z.object({ decision: z.literal("accepted") }).strict(),
+  z.object({ decision: z.literal("rejected") }).strict(),
+]);
+export type LearningRecommendationReviewRequest = z.infer<
+  typeof LearningRecommendationReviewRequestSchema
+>;
+
+const LearningRecommendationReviewResponseBaseSchema = z
+  .object({
+    ok: z.literal(true),
+    reviewId: LearningRecommendationReviewIdSchema,
+    recommendationId: LearningRecommendationIdSchema,
+    revision: z.number().int().positive(),
+    context: z.literal("materials"),
+    policyKind: z.literal("tailoring_rule"),
+    reviewedAt: IsoTimestampSchema,
+  })
+  .strict();
+
+export const LearningRecommendationReviewResponseSchema = z.discriminatedUnion("decision", [
+  LearningRecommendationReviewResponseBaseSchema.extend({
+    decision: z.literal("accepted"),
+    policyVersion: z.number().int().positive(),
+  }),
+  LearningRecommendationReviewResponseBaseSchema.extend({
+    decision: z.literal("rejected"),
+    policyVersion: z.null(),
+  }),
+]);
+export type LearningRecommendationReviewResponse = z.infer<
+  typeof LearningRecommendationReviewResponseSchema
+>;
+
 const LearningEvidenceIdentifierSchema = z
   .string()
   .min(1)


### PR DESCRIPTION
## Summary
- expose accepted and rejected learning-recommendation reviews through the typed RPC, REST, and API-client boundaries
- preserve tenant and runtime identity parameters while keeping policy mutation in the Python Materials owner
- validate policy-version coupling and strict UTC worker timestamps
- sanitize worker conflicts, malformed results, and transport failures

## Validation
- Node 22 contracts typecheck: passed
- Node 22 API client typecheck: passed
- Node 22 API typecheck: passed
- focused RPC/API tests: 5 passed, 251 skipped
- git diff --check: passed
- independent SOL review: PASS, zero findings
- independent SOL QA: PASS, zero findings

Ready for review. Stacked on #691. Cumulative live product QA remains deferred to the final stack top.