### PR TITLE
test(demo): update capability manifest counts

### DIFF
--- a/apps/web/src/demo/DemoLocalCommandExecutor.test.ts
+++ b/apps/web/src/demo/DemoLocalCommandExecutor.test.ts
@@ -229,7 +229,7 @@ const LOCAL_CASES = [
 ] as const satisfies readonly LocalCase[];
 
 describe("DemoLocalCommandExecutor", () => {
-  it("keeps the 128-member capability manifest exhaustive with exact class counts", () => {
+  it("keeps the 131-member capability manifest exhaustive with exact class counts", () => {
     const counts = Object.values(DEMO_CAPABILITY_MANIFEST).reduce<Record<string, number>>(
       (result, capability) => {
         result[capability.class] = (result[capability.class] ?? 0) + 1;
@@ -237,12 +237,12 @@ describe("DemoLocalCommandExecutor", () => {
       },
       {},
     );
-    expect(Object.keys(DEMO_CAPABILITY_MANIFEST)).toHaveLength(128);
+    expect(Object.keys(DEMO_CAPABILITY_MANIFEST)).toHaveLength(131);
     expect(counts).toEqual({
       browser_local: 92,
       simulated_async: 4,
       rehearsed_external: 4,
-      unavailable: 28,
+      unavailable: 31,
     });
   });
 

--- a/apps/web/src/demo/demo-seed.test.ts
+++ b/apps/web/src/demo/demo-seed.test.ts
@@ -18,7 +18,7 @@ const CONTOSO_GENERATION_ONE_ARTIFACT_IDS = [
 
 describe("canonical public demo seed", () => {
   it("has a complete classified API capability manifest", () => {
-    expect(Object.keys(DEMO_CAPABILITY_MANIFEST)).toHaveLength(128);
+    expect(Object.keys(DEMO_CAPABILITY_MANIFEST)).toHaveLength(131);
     expect(Object.values(DEMO_CAPABILITY_MANIFEST).every((entry) => entry.reason.length > 0)).toBe(true);
   });
 


### PR DESCRIPTION
## Summary

- update the exhaustive demo capability manifest total for the three learning-review API methods added by the parent PR
- classify the added methods in the existing unavailable capability count
- keep the canonical demo-seed assertion aligned with the manifest

## Why

The parent PR intentionally exposes three learning-review client methods as unavailable in demo mode. The runtime manifest was correct, but two exact-count assertions still expected the previous 128-member contract and failed the remote TypeScript suite.

## Validation

- `pnpm --filter @jobctrl/web exec vitest run src/demo/DemoLocalCommandExecutor.test.ts src/demo/demo-seed.test.ts` (35 passed)
- `pnpm --filter @jobctrl/web check`
- `git diff --check`
- independent review: PASS, no findings