### PR TITLE
feat(web): add learning recommendation review panel

### DIFF
--- a/apps/web/src/contexts/materials/components/LearningRecommendationReviewPanel.test.tsx
+++ b/apps/web/src/contexts/materials/components/LearningRecommendationReviewPanel.test.tsx
@@ -1,0 +1,223 @@
+import type {
+  LearningRecommendationListResponse,
+  LearningRecommendationReviewRequest,
+  LearningRecommendationReviewResponse,
+} from "@jobctrl/contracts";
+import { act, screen, waitFor, within } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import { axe } from "jest-axe";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  sampleLearningRecommendation,
+  sampleLearningRecommendationEvidence,
+  sampleLearningRecommendationList,
+  sampleSecondLearningRecommendation,
+} from "../../../test/fixtures/learning.js";
+import { renderWithProviders } from "../../../test/render.js";
+import { buildTestPorts } from "../../../test/testPorts.js";
+import { LearningRecommendationReviewPanel } from "./LearningRecommendationReviewPanel.js";
+
+function reviewResponse(
+  recommendationId: string,
+  decision: LearningRecommendationReviewRequest["decision"],
+): LearningRecommendationReviewResponse {
+  const base = {
+    ok: true as const,
+    reviewId: `learning-recommendation-review:${
+      decision === "accepted" ? "c".repeat(64) : "d".repeat(64)
+    }`,
+    recommendationId,
+    revision: 1,
+    decision,
+    context: "materials" as const,
+    policyKind: "tailoring_rule" as const,
+    reviewedAt: "2026-08-01T12:05:00.000Z",
+  };
+  return decision === "accepted"
+    ? { ...base, decision, policyVersion: 2 }
+    : { ...base, decision, policyVersion: null };
+}
+
+describe("LearningRecommendationReviewPanel", () => {
+  it("has no axe violations with pending recommendations", async () => {
+    const view = renderWithProviders(<LearningRecommendationReviewPanel />, {
+      ports: buildTestPorts({
+        api: {
+          learningRecommendations: vi.fn(async () => sampleLearningRecommendationList),
+        },
+      }),
+    });
+
+    await screen.findByText("style_guidance → preserve_user_edit_pattern");
+    expect(await axe(view.container)).toHaveNoViolations();
+  });
+
+  it("defers and exposes only bounded evidence after explicit inspection", async () => {
+    const user = userEvent.setup();
+    const learningRecommendations = vi.fn(async () => sampleLearningRecommendationList);
+    const learningRecommendationEvidence = vi.fn(async () => sampleLearningRecommendationEvidence);
+    renderWithProviders(<LearningRecommendationReviewPanel />, {
+      ports: buildTestPorts({ api: { learningRecommendations, learningRecommendationEvidence } }),
+    });
+
+    expect(
+      await screen.findByText("style_guidance → preserve_user_edit_pattern"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getAllByText(/3 of 3 required accepted signals across 2 of 2 required jobs/i),
+    ).toHaveLength(2);
+    expect(screen.getByText(/3 supporting · 1 contradicting · 0 tombstones/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/sample-gated recommendation only/i)).not.toHaveLength(0);
+    expect(learningRecommendationEvidence).not.toHaveBeenCalled();
+
+    await user.click(
+      screen.getByRole("button", {
+        name: /inspect evidence for style_guidance → preserve_user_edit_pattern/i,
+      }),
+    );
+
+    const evidence = await screen.findByRole("list", {
+      name: /evidence for style_guidance → preserve_user_edit_pattern/i,
+    });
+    expect(within(evidence).getByText("tailoring-signal-supporting-1")).toBeInTheDocument();
+    expect(within(evidence).getByText("tailoring-signal-contradicting-1")).toBeInTheDocument();
+    expect(within(evidence).getByText("contradicting")).toBeInTheDocument();
+    expect(learningRecommendationEvidence).toHaveBeenCalledWith(
+      sampleLearningRecommendation.recommendationId,
+      { page: 1, pageSize: 100 },
+    );
+  });
+
+  it("accepts and rejects without triggering rescore or re-tailor work", async () => {
+    const user = userEvent.setup();
+    let current = [...sampleLearningRecommendationList.recommendations];
+    const learningRecommendations = vi.fn(async (): Promise<LearningRecommendationListResponse> => ({
+      ...sampleLearningRecommendationList,
+      recommendations: current,
+      total: current.length,
+      totalPages: current.length ? 1 : 0,
+    }));
+    const reviewLearningRecommendation = vi.fn(
+      async (recommendationId: string, body: LearningRecommendationReviewRequest) => {
+        current = current.filter((item) => item.recommendationId !== recommendationId);
+        return reviewResponse(recommendationId, body.decision);
+      },
+    );
+    const rescoreJob = vi.fn();
+    const retailorJob = vi.fn();
+    renderWithProviders(<LearningRecommendationReviewPanel />, {
+      ports: buildTestPorts({
+        api: { learningRecommendations, reviewLearningRecommendation, rescoreJob, retailorJob },
+      }),
+    });
+
+    await screen.findByText("style_guidance → preserve_user_edit_pattern");
+    await user.click(
+      screen.getByRole("button", {
+        name: /accept learning recommendation style_guidance → preserve_user_edit_pattern/i,
+      }),
+    );
+    await waitFor(() =>
+      expect(reviewLearningRecommendation).toHaveBeenCalledWith(
+        sampleLearningRecommendation.recommendationId,
+        { decision: "accepted" },
+      ),
+    );
+    await waitFor(() =>
+      expect(screen.queryByText("style_guidance → preserve_user_edit_pattern")).not.toBeInTheDocument(),
+    );
+
+    await user.click(
+      screen.getByRole("button", {
+        name: /reject learning recommendation fact_handling → require_source_match/i,
+      }),
+    );
+    await waitFor(() =>
+      expect(reviewLearningRecommendation).toHaveBeenCalledWith(
+        sampleSecondLearningRecommendation.recommendationId,
+        { decision: "rejected" },
+      ),
+    );
+    expect(rescoreJob).not.toHaveBeenCalled();
+    expect(retailorJob).not.toHaveBeenCalled();
+  });
+
+  it("restores the recommendation and surfaces a sanitized review error", async () => {
+    const user = userEvent.setup();
+    let rejectReview: ((error: Error) => void) | undefined;
+    const learningRecommendations = vi.fn(async (): Promise<LearningRecommendationListResponse> => ({
+      ...sampleLearningRecommendationList,
+      recommendations: [sampleLearningRecommendation],
+      total: 1,
+      totalPages: 1,
+    }));
+    const reviewLearningRecommendation = vi.fn(
+      () =>
+        new Promise<LearningRecommendationReviewResponse>((_resolve, reject) => {
+          rejectReview = reject;
+        }),
+    );
+    renderWithProviders(<LearningRecommendationReviewPanel />, {
+      ports: buildTestPorts({ api: { learningRecommendations, reviewLearningRecommendation } }),
+    });
+
+    await screen.findByText("style_guidance → preserve_user_edit_pattern");
+    await user.click(
+      screen.getByRole("button", {
+        name: /reject learning recommendation style_guidance → preserve_user_edit_pattern/i,
+      }),
+    );
+    expect(await screen.findByText("No learning recommendations to review.")).toBeInTheDocument();
+    act(() => rejectReview?.(new Error("The learning recommendation review could not be completed.")));
+
+    expect(await screen.findByText("Recommendation review failed")).toBeInTheDocument();
+    expect(
+      await screen.findByText("style_guidance → preserve_user_edit_pattern"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("The learning recommendation review could not be completed."),
+    ).toBeInTheDocument();
+  });
+
+  it("marks tombstoned recommendations inactive and prevents guaranteed-failing reviews", async () => {
+    const reviewLearningRecommendation = vi.fn();
+    renderWithProviders(<LearningRecommendationReviewPanel />, {
+      ports: buildTestPorts({
+        api: {
+          learningRecommendations: vi.fn(async () => ({
+            ...sampleLearningRecommendationList,
+            recommendations: [
+              {
+                ...sampleLearningRecommendation,
+                active: false,
+                tombstoneCount: 1,
+              },
+            ],
+            total: 1,
+          })),
+          reviewLearningRecommendation,
+        },
+      }),
+    });
+
+    await screen.findByText("style_guidance → preserve_user_edit_pattern");
+    expect(screen.getByText("1 review item")).toBeInTheDocument();
+    expect(screen.queryByText(/1 pending/i)).not.toBeInTheDocument();
+    expect(screen.getByText("Inactive")).toBeInTheDocument();
+    expect(
+      screen.getByText(/source evidence was tombstoned, so this recommendation must be re-derived/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", {
+        name: /accept learning recommendation style_guidance → preserve_user_edit_pattern/i,
+      }),
+    ).toBeDisabled();
+    expect(
+      screen.getByRole("button", {
+        name: /reject learning recommendation style_guidance → preserve_user_edit_pattern/i,
+      }),
+    ).toBeDisabled();
+    expect(reviewLearningRecommendation).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/contexts/materials/components/LearningRecommendationReviewPanel.tsx
+++ b/apps/web/src/contexts/materials/components/LearningRecommendationReviewPanel.tsx
@@ -1,0 +1,206 @@
+import { IconAlertTriangle } from "@tabler/icons-react";
+import type { LearningRecommendationSummary } from "@jobctrl/contracts";
+import { useState } from "react";
+
+import {
+  useLearningRecommendationEvidenceQuery,
+  useLearningRecommendationsQuery,
+} from "../../operations/index.js";
+import { formatDateTime } from "../../../shared/lib/formatters.js";
+import { Alert, AlertDescription, AlertTitle } from "../../../shared/ui/alert.js";
+import { Button } from "../../../shared/ui/button.js";
+import { CardHeader } from "../../../shared/ui/card-header.js";
+import { Empty } from "../../../shared/ui/empty.js";
+import { StatusBadge } from "../../../shared/ui/status-badge.js";
+import { useReviewLearningRecommendationMutation } from "../hooks/useReviewLearningRecommendationMutation.js";
+
+export function LearningRecommendationReviewPanel() {
+  const recommendations = useLearningRecommendationsQuery();
+  const review = useReviewLearningRecommendationMutation();
+  const readError = recommendations.error instanceof Error ? recommendations.error.message : null;
+  const reviewError = review.error instanceof Error ? review.error.message : null;
+  const pending = recommendations.data?.recommendations ?? [];
+
+  return (
+    <section className="card col-span-full learning-review-panel">
+      <CardHeader
+        title="Learning recommendations"
+        meta={
+          recommendations.data
+            ? `${recommendations.data.total} review item${recommendations.data.total === 1 ? "" : "s"}`
+            : "loading"
+        }
+      />
+      {readError ? (
+        <Alert variant="destructive">
+          <IconAlertTriangle aria-hidden="true" />
+          <AlertTitle>Learning recommendations unavailable</AlertTitle>
+          <AlertDescription>{readError}</AlertDescription>
+        </Alert>
+      ) : null}
+      {reviewError ? (
+        <Alert variant="destructive">
+          <IconAlertTriangle aria-hidden="true" />
+          <AlertTitle>Recommendation review failed</AlertTitle>
+          <AlertDescription>{reviewError}</AlertDescription>
+        </Alert>
+      ) : null}
+      {recommendations.isFetching && !recommendations.data ? (
+        <Empty title="Loading learning recommendations." />
+      ) : null}
+      {recommendations.data && pending.length === 0 ? (
+        <Empty title="No learning recommendations to review." />
+      ) : null}
+      {pending.length ? (
+        <div className="learning-recommendations" aria-label="Learning recommendations">
+          {pending.map((recommendation) => (
+            <LearningRecommendationCard
+              key={recommendation.recommendationId}
+              recommendation={recommendation}
+              disabled={review.isPending}
+              onReview={(decision) => {
+                review.reset();
+                review.mutate({ recommendationId: recommendation.recommendationId, decision });
+              }}
+            />
+          ))}
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
+function LearningRecommendationCard({
+  recommendation,
+  disabled,
+  onReview,
+}: {
+  readonly recommendation: LearningRecommendationSummary;
+  readonly disabled: boolean;
+  readonly onReview: (decision: "accepted" | "rejected") => void;
+}) {
+  const [evidenceOpen, setEvidenceOpen] = useState(false);
+  const evidence = useLearningRecommendationEvidenceQuery(
+    recommendation.recommendationId,
+    { page: 1, pageSize: 100 },
+    evidenceOpen,
+  );
+  const evidenceError = evidence.error instanceof Error ? evidence.error.message : null;
+  const effect = `${recommendation.ruleKey} → ${recommendation.ruleValue}`;
+  const titleId = `learning-recommendation-${recommendation.recommendationId}-title`;
+  const reviewable = recommendation.active && recommendation.tombstoneCount === 0;
+
+  return (
+    <article className="learning-recommendation-card" aria-labelledby={titleId}>
+      <header className="learning-recommendation-head">
+        <span>
+          <b id={titleId}>{effect}</b>
+          <span className="meta">
+            {recommendation.signalKind.replaceAll("_", " ")} · derived {formatDateTime(recommendation.derivedAt)}
+          </span>
+        </span>
+        <StatusBadge tone={reviewable ? "info" : "warn"}>
+          {reviewable ? "Pending" : "Inactive"}
+        </StatusBadge>
+      </header>
+
+      <dl className="learning-recommendation-facts">
+        <div>
+          <dt>Sample</dt>
+          <dd>
+            {recommendation.observedSignalCount} of {recommendation.minimumSignalCount} required
+            accepted signals across {recommendation.observedJobCount} of{" "}
+            {recommendation.minimumJobCount} required jobs
+          </dd>
+        </div>
+        <div>
+          <dt>Evidence</dt>
+          <dd>
+            {recommendation.supportingEvidenceCount} supporting ·{" "}
+            {recommendation.contradictingEvidenceCount} contradicting ·{" "}
+            {recommendation.tombstoneCount} tombstones
+          </dd>
+        </div>
+        <div>
+          <dt>Versions</dt>
+          <dd>
+            derivation {recommendation.derivationVersion} · fixture{" "}
+            {recommendation.evaluationFixtureVersion} · allowlist{" "}
+            {recommendation.allowlistVersion}
+          </dd>
+        </div>
+      </dl>
+      <p className="meta">
+        Sample-gated recommendation only; it does not claim a population-wide improvement.
+      </p>
+      {!reviewable ? (
+        <p className="meta" role="status">
+          {recommendation.tombstoneCount > 0
+            ? "Review unavailable: source evidence was tombstoned, so this recommendation must be re-derived."
+            : "Review unavailable: this recommendation is no longer active."}
+        </p>
+      ) : null}
+
+      <div className="row-actions">
+        <Button
+          type="button"
+          size="sm"
+          variant="outline"
+          aria-expanded={evidenceOpen}
+          aria-label={`${evidenceOpen ? "Hide" : "Inspect"} evidence for ${effect}`}
+          onClick={() => setEvidenceOpen((open) => !open)}
+        >
+          {evidenceOpen ? "Hide evidence" : "Inspect evidence"}
+        </Button>
+        <Button
+          type="button"
+          size="sm"
+          disabled={disabled || !reviewable}
+          aria-label={`Accept learning recommendation ${effect}`}
+          onClick={() => onReview("accepted")}
+        >
+          Accept
+        </Button>
+        <Button
+          type="button"
+          size="sm"
+          variant="outline"
+          disabled={disabled || !reviewable}
+          aria-label={`Reject learning recommendation ${effect}`}
+          onClick={() => onReview("rejected")}
+        >
+          Reject
+        </Button>
+      </div>
+
+      {evidenceOpen ? (
+        <div className="learning-recommendation-evidence">
+          {evidence.isFetching && !evidence.data ? <Empty title="Loading evidence." /> : null}
+          {evidenceError ? (
+            <Alert variant="destructive">
+              <IconAlertTriangle aria-hidden="true" />
+              <AlertTitle>Recommendation evidence unavailable</AlertTitle>
+              <AlertDescription>{evidenceError}</AlertDescription>
+            </Alert>
+          ) : null}
+          {evidence.data?.evidence.length === 0 ? <Empty title="No evidence links available." /> : null}
+          {evidence.data?.evidence.length ? (
+            <ul aria-label={`Evidence for ${effect}`}>
+              {evidence.data.evidence.map((link) => (
+                <li key={`${link.signalId}:${link.sourceRevision}`}>
+                  <StatusBadge tone={link.evidenceRole === "contradicting" ? "warn" : "info"}>
+                    {link.evidenceRole}
+                  </StatusBadge>
+                  <span>{link.signalId}</span>
+                  <span className="meta">
+                    revision {link.sourceRevision} · job {link.jobId} · {formatDateTime(link.recordedAt)}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          ) : null}
+        </div>
+      ) : null}
+    </article>
+  );
+}

--- a/apps/web/src/contexts/materials/index.ts
+++ b/apps/web/src/contexts/materials/index.ts
@@ -36,6 +36,7 @@ export {
   EmployerAnalysisPanel,
   type EmployerAnalysisPanelProps,
 } from "./components/EmployerAnalysisPanel.js";
+export { LearningRecommendationReviewPanel } from "./components/LearningRecommendationReviewPanel.js";
 export {
   ArtifactTypeBadge,
   type ArtifactTypeBadgeProps,

--- a/apps/web/src/contexts/operations/hooks/useLearningRecommendationsQuery.test.ts
+++ b/apps/web/src/contexts/operations/hooks/useLearningRecommendationsQuery.test.ts
@@ -58,4 +58,26 @@ describe("learning recommendation queries", () => {
       pageSize: 25,
     });
   });
+
+  it("defers evidence reads until inspection is enabled", async () => {
+    const learningRecommendationEvidence = vi.fn(async () => evidenceList);
+    const { result, rerender } = renderHookWithProviders(
+      ({ enabled }: { enabled: boolean }) =>
+        useLearningRecommendationEvidenceQuery(
+          recommendationId,
+          { page: 1, pageSize: 25 },
+          enabled,
+        ),
+      {
+        initialProps: { enabled: false },
+        ports: buildTestPorts({ api: { learningRecommendationEvidence } }),
+      },
+    );
+
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(learningRecommendationEvidence).not.toHaveBeenCalled();
+    rerender({ enabled: true });
+    await waitFor(() => expect(result.current.data).toBe(evidenceList));
+    expect(learningRecommendationEvidence).toHaveBeenCalledTimes(1);
+  });
 });

--- a/apps/web/src/contexts/operations/hooks/useLearningRecommendationsQuery.ts
+++ b/apps/web/src/contexts/operations/hooks/useLearningRecommendationsQuery.ts
@@ -26,11 +26,13 @@ export function useLearningRecommendationsQuery(
 export function useLearningRecommendationEvidenceQuery(
   recommendationId: string,
   input: Partial<LearningRecommendationEvidenceListQuery> = DEFAULT_PAGE,
+  enabled = true,
 ): UseQueryResult<LearningRecommendationEvidenceListResponse> {
   const tenantId = useTenantId();
   const { api } = usePorts();
   return useQuery({
     queryKey: learningKeys.evidenceList(tenantId, recommendationId, input),
     queryFn: () => api.learningRecommendationEvidence(recommendationId, input),
+    enabled,
   });
 }

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -3756,6 +3756,79 @@ input[type="radio"] {
   overflow-wrap: anywhere;
 }
 
+.learning-recommendations {
+  display: grid;
+  gap: 10px;
+  padding: 12px 16px;
+}
+
+.learning-recommendation-card {
+  display: grid;
+  gap: 10px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--card);
+  padding: 12px;
+}
+
+.learning-recommendation-head {
+  display: flex;
+  min-width: 0;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.learning-recommendation-head > span:first-child {
+  display: grid;
+  min-width: 0;
+  gap: 2px;
+}
+
+.learning-recommendation-facts {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 8px 16px;
+  margin: 0;
+}
+
+.learning-recommendation-facts div {
+  display: grid;
+  gap: 2px;
+}
+
+.learning-recommendation-facts dt {
+  color: var(--muted-foreground);
+  font-size: var(--jh-type-caption-size);
+}
+
+.learning-recommendation-facts dd {
+  margin: 0;
+}
+
+.learning-recommendation-card p,
+.learning-recommendation-evidence ul {
+  margin: 0;
+}
+
+.learning-recommendation-evidence ul {
+  display: grid;
+  gap: 8px;
+  padding: 0;
+  list-style: none;
+}
+
+.learning-recommendation-evidence li {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 2px 10px;
+  overflow-wrap: anywhere;
+}
+
+.learning-recommendation-evidence li .meta {
+  grid-column: 2;
+}
+
 .discovery-control-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));

--- a/apps/web/src/test/fixtures/learning.ts
+++ b/apps/web/src/test/fixtures/learning.ts
@@ -1,0 +1,74 @@
+import type {
+  LearningRecommendationEvidenceListResponse,
+  LearningRecommendationListResponse,
+  LearningRecommendationSummary,
+} from "@jobctrl/contracts";
+
+export const sampleLearningRecommendation: LearningRecommendationSummary = {
+  recommendationId: `learning-recommendation:${"a".repeat(64)}`,
+  derivationVersion: 1,
+  evaluationFixtureVersion: 1,
+  context: "materials",
+  policyKind: "tailoring_rule",
+  signalKind: "style_preference",
+  ruleKey: "style_guidance",
+  ruleValue: "preserve_user_edit_pattern",
+  allowlistVersion: 1,
+  status: "pending",
+  active: true,
+  observedSignalCount: 3,
+  observedJobCount: 2,
+  minimumSignalCount: 3,
+  minimumJobCount: 2,
+  confidenceLimit: "sample_gated_no_population_inference",
+  supportingEvidenceCount: 3,
+  contradictingEvidenceCount: 1,
+  tombstoneCount: 0,
+  derivedAt: "2026-08-01T12:00:00.000Z",
+};
+
+export const sampleSecondLearningRecommendation: LearningRecommendationSummary = {
+  ...sampleLearningRecommendation,
+  recommendationId: `learning-recommendation:${"b".repeat(64)}`,
+  signalKind: "factual_correction",
+  ruleKey: "fact_handling",
+  ruleValue: "require_source_match",
+  contradictingEvidenceCount: 0,
+  derivedAt: "2026-08-01T12:01:00.000Z",
+};
+
+export const sampleLearningRecommendationList: LearningRecommendationListResponse = {
+  ok: true,
+  recommendations: [sampleLearningRecommendation, sampleSecondLearningRecommendation],
+  page: 1,
+  pageSize: 50,
+  total: 2,
+  totalPages: 1,
+};
+
+export const sampleLearningRecommendationEvidence: LearningRecommendationEvidenceListResponse = {
+  ok: true,
+  recommendationId: sampleLearningRecommendation.recommendationId,
+  evidence: [
+    {
+      signalId: "tailoring-signal-supporting-1",
+      evidenceRole: "supporting",
+      sourceKind: "tailoring_feedback_signal",
+      sourceRevision: 2,
+      jobId: "11111111-1111-4111-8111-111111111111",
+      recordedAt: "2026-08-01T10:00:00.000Z",
+    },
+    {
+      signalId: "tailoring-signal-contradicting-1",
+      evidenceRole: "contradicting",
+      sourceKind: "tailoring_feedback_signal",
+      sourceRevision: 1,
+      jobId: "22222222-2222-4222-8222-222222222222",
+      recordedAt: "2026-08-01T10:05:00.000Z",
+    },
+  ],
+  page: 1,
+  pageSize: 100,
+  total: 2,
+  totalPages: 1,
+};

--- a/apps/web/src/test/msw/handlers.ts
+++ b/apps/web/src/test/msw/handlers.ts
@@ -29,6 +29,10 @@ import {
   makeOutreachThreadResponse,
 } from "../fixtures/outreach.js";
 import {
+  sampleLearningRecommendationEvidence,
+  sampleLearningRecommendationList,
+} from "../fixtures/learning.js";
+import {
   makeArtifactDetail,
   makeArtifactTailoringExplanation,
   makeActivityPage,
@@ -260,6 +264,34 @@ export const handlers = [
   http.get("*/v1/health", () => HttpResponse.json(sampleHealthResponse)),
   http.get("*/v1/dashboard/summary", () => HttpResponse.json(sampleDashboardSummary)),
   http.get("*/v1/analytics/outcomes", () => HttpResponse.json(sampleOutcomeAnalyticsSummary)),
+  http.get("*/v1/learning/recommendations", () =>
+    HttpResponse.json(sampleLearningRecommendationList),
+  ),
+  http.get("*/v1/learning/recommendations/:recommendationId/evidence", ({ params }) =>
+    HttpResponse.json({
+      ...sampleLearningRecommendationEvidence,
+      recommendationId: String(params["recommendationId"]),
+    }),
+  ),
+  http.post(
+    "*/v1/learning/recommendations/:recommendationId/reviews",
+    async ({ params, request }) => {
+      const body = (await request.json()) as { decision: "accepted" | "rejected" };
+      return HttpResponse.json({
+        ok: true,
+        reviewId: `learning-recommendation-review:${
+          body.decision === "accepted" ? "c".repeat(64) : "d".repeat(64)
+        }`,
+        recommendationId: String(params["recommendationId"]),
+        revision: 1,
+        decision: body.decision,
+        context: "materials",
+        policyKind: "tailoring_rule",
+        policyVersion: body.decision === "accepted" ? 2 : null,
+        reviewedAt: "2026-08-01T12:05:00.000Z",
+      });
+    },
+  ),
   http.get("*/v1/digest", () => HttpResponse.json(sampleDailyDigest)),
   http.post("*/v1/digest/acknowledge", async ({ request }) => {
     const body = (await request.json().catch(() => ({}))) as { acknowledgedAt?: string };

--- a/apps/web/src/views/dashboard/DashboardView.test.tsx
+++ b/apps/web/src/views/dashboard/DashboardView.test.tsx
@@ -27,6 +27,9 @@ describe("DashboardView", () => {
     expect(screen.getByText("Job scored 8/10")).toBeInTheDocument();
     expect(await screen.findByRole("heading", { name: "Daily digest" })).toBeInTheDocument();
     expect(await screen.findByRole("heading", { name: "Outcome suggestions" })).toBeInTheDocument();
+    expect(
+      await screen.findByRole("heading", { name: "Learning recommendations" }),
+    ).toBeInTheDocument();
     expect(screen.getByText("Recruiter reply indicates an interview request.")).toBeInTheDocument();
     expect(screen.getByText("stuck").querySelector("svg")).toHaveClass("tabler-icon-ban");
     expect(screen.getByText("in progress").querySelector("svg")).toHaveClass("tabler-icon-clock");

--- a/apps/web/src/views/dashboard/DashboardView.tsx
+++ b/apps/web/src/views/dashboard/DashboardView.tsx
@@ -1,6 +1,7 @@
 import { IconAlertTriangle } from "@tabler/icons-react";
 
 import { OutcomeSuggestionsPanel } from "../../contexts/apply/components/ApplicationOutcomes.js";
+import { LearningRecommendationReviewPanel } from "../../contexts/materials/index.js";
 import { useApplicationOutcomesQuery } from "../../contexts/operations/hooks/useApplicationOutcomesQuery.js";
 import { useDashboardSummaryQuery } from "../../contexts/operations/hooks/useDashboardSummaryQuery.js";
 import { useWorkflowRunsListQuery } from "../../contexts/operations/hooks/useWorkflowRunsListQuery.js";
@@ -78,6 +79,7 @@ export function DashboardView() {
             />
             <RecentActivityCard summary={summary} />
             <ApplyRunsCard summary={summary} />
+            <LearningRecommendationReviewPanel />
             <section className="card col-span-full">
               <CardHeader
                 title="Outcome suggestions"


### PR DESCRIPTION
## Summary

- add a Materials-owned dashboard panel for pending learning recommendations
- show allowlisted rule effects, observed-versus-required thresholds, provenance versions, bounded evidence counts, and confidence limits
- load privacy-safe evidence only after explicit inspection
- accept or reject through the existing optimistic mutation with exact rollback on failure
- mark tombstoned or inactive recommendations as unavailable for review instead of dispatching guaranteed-failing commands

## Boundaries

- does not expose raw notes, resumes, job descriptions, prompts, mail bodies, or model output
- does not trigger rescoring, re-tailoring, Apply work, or other workflow mutations
- cumulative browser and high-risk product QA remains deferred to the final Objective 7 stack head

## Validation

- `pnpm --filter @jobctrl/web exec vitest run src/contexts/materials/components/LearningRecommendationReviewPanel.test.tsx src/contexts/operations/hooks/useLearningRecommendationsQuery.test.ts src/views/dashboard/DashboardView.test.tsx` (13 passed)
- `pnpm --filter @jobctrl/web check`
- `pnpm --filter @jobctrl/web build`
- `git diff --check`
- independent review: PASS, no Blocker/High/Medium findings; one wording Low corrected before publication