### PR TITLE
feat(api): expose tailoring policy revision history

### DIFF
--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -50,6 +50,7 @@ import {
   LearningRecommendationListQuerySchema,
   LearningRecommendationReviewRequestSchema,
   LearningRecommendationReviewResponseSchema,
+  TailoringPolicyRevisionListQuerySchema,
   JsonRpcErrorCodes,
   JsonRpcRequestSchema,
   MarkJobActionRequestSchema,
@@ -250,6 +251,7 @@ import {
   listLearningRecommendationEvidence,
   listLearningRecommendations,
 } from "./learning-recommendations.js";
+import { listTailoringPolicyRevisions } from "./tailoring-policy-revisions.js";
 import { refreshProjections } from "./projections.js";
 import { createResumeHtmlPdfRenderer, type ResumeHtmlPdfRenderer } from "./resume-pdf-render.js";
 import {
@@ -587,6 +589,15 @@ export function buildApp(options: BuildAppOptions): FastifyInstance {
       listLearningRecommendations(
         db,
         LearningRecommendationListQuerySchema.parse(request.query),
+      ),
+    ),
+  );
+
+  app.get("/v1/learning/policies/materials", async (request, reply) =>
+    withDb(reply, options.dbPath, (db) =>
+      listTailoringPolicyRevisions(
+        db,
+        TailoringPolicyRevisionListQuerySchema.parse(request.query),
       ),
     ),
   );

--- a/apps/api/src/tailoring-policy-revisions.ts
+++ b/apps/api/src/tailoring-policy-revisions.ts
@@ -1,0 +1,115 @@
+import {
+  TailoringPolicyRevisionListResponseSchema,
+  type TailoringPolicyRevisionListQuery,
+  type TailoringPolicyRevisionListResponse,
+} from "./contracts.js";
+import { allRows, getRow, type SqliteDatabase } from "./db.js";
+
+const DEFAULT_TENANT = "local";
+
+interface TailoringPolicyRevisionRow extends Record<string, unknown> {
+  version: number;
+  runtime_settings_json: string;
+  rollback_of_version: number | null;
+  rollback_reason: string;
+  created_at: string;
+  source_review_id: string | null;
+  source_recommendation_id: string | null;
+  current_version: number;
+}
+
+export function listTailoringPolicyRevisions(
+  db: SqliteDatabase,
+  query: TailoringPolicyRevisionListQuery,
+): TailoringPolicyRevisionListResponse {
+  return db.transaction(() => {
+    const total = Number(
+      getRow<{ count: number }>(
+        db,
+        `SELECT COUNT(*) AS count
+           FROM tailoring_policies
+          WHERE tenant_id = ?`,
+        [DEFAULT_TENANT],
+      )?.count ?? 0,
+    );
+    const offset = (query.page - 1) * query.pageSize;
+    const rows = allRows<TailoringPolicyRevisionRow>(
+      db,
+      `SELECT policy.version,
+              policy.runtime_settings_json,
+              policy.rollback_of_version,
+              policy.rollback_reason,
+              policy.created_at,
+              review.review_id AS source_review_id,
+              review.recommendation_id AS source_recommendation_id,
+              (
+                SELECT MAX(current_policy.version)
+                FROM tailoring_policies AS current_policy
+                WHERE current_policy.tenant_id = policy.tenant_id
+              ) AS current_version
+         FROM tailoring_policies AS policy
+         LEFT JOIN learning_recommendation_reviews AS review
+           ON review.tenant_id = policy.tenant_id
+          AND review.context = 'materials'
+          AND review.policy_kind = 'tailoring_rule'
+          AND review.policy_version = policy.version
+          AND review.decision = 'accepted'
+        WHERE policy.tenant_id = ?
+        ORDER BY policy.version DESC
+        LIMIT ? OFFSET ?`,
+      [DEFAULT_TENANT, query.pageSize, offset],
+    );
+
+    return TailoringPolicyRevisionListResponseSchema.parse({
+      ok: true,
+      revisions: rows.map((row) => ({
+        context: "materials",
+        policyKind: "tailoring_rule",
+        version: Number(row.version),
+        status: Number(row.version) === Number(row.current_version) ? "current" : "superseded",
+        learnedRules: learnedRules(row.runtime_settings_json),
+        sourceReviewId: row.source_review_id,
+        sourceRecommendationId: row.source_recommendation_id,
+        rollbackOfVersion:
+          row.rollback_of_version === null ? null : Number(row.rollback_of_version),
+        rollbackReasonCode:
+          row.rollback_of_version === null
+            ? null
+            : row.rollback_reason === "user_requested"
+              ? "user_requested"
+              : "historical_or_unspecified",
+        createdAt: row.created_at,
+      })),
+      page: query.page,
+      pageSize: query.pageSize,
+      total,
+      totalPages: total === 0 ? 0 : Math.ceil(total / query.pageSize),
+    });
+  })();
+}
+
+function learnedRules(rawRuntimeSettings: string): Array<{
+  ruleKey: string;
+  ruleValue: unknown;
+}> {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(rawRuntimeSettings || "{}");
+  } catch {
+    throw new Error("Tailoring policy runtime settings are not valid JSON.");
+  }
+  if (!isRecord(parsed)) {
+    throw new Error("Tailoring policy runtime settings must be an object.");
+  }
+  const rawRules = parsed.learned_tailoring_rules ?? {};
+  if (!isRecord(rawRules)) {
+    throw new Error("Learned tailoring policy rules must be an object.");
+  }
+  return Object.entries(rawRules)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([ruleKey, ruleValue]) => ({ ruleKey, ruleValue }));
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/apps/api/test/server.test.ts
+++ b/apps/api/test/server.test.ts
@@ -12,6 +12,7 @@ import {
   LearningRecommendationEvidenceListResponseSchema,
   LearningRecommendationListResponseSchema,
   LearningRecommendationReviewResponseSchema,
+  TailoringPolicyRevisionListResponseSchema,
   PipelineOperationsSnapshotSchema,
   ProviderConfigurationKeys,
   RpcMethods,
@@ -2541,6 +2542,145 @@ describe("local TypeScript API", () => {
     fetchMock.mockRestore();
     const unchanged = new Database(options.dbPath);
     expect(learningAuditSnapshot(unchanged)).toBe(auditBefore);
+    unchanged.close();
+    await app.close();
+  });
+
+  it("serves privacy-bounded tailoring policy revision history", async () => {
+    const recommendationId = `learning-recommendation:${"a".repeat(64)}`;
+    const reviewId = `learning-recommendation-review:${"b".repeat(64)}`;
+    const db = new Database(options.dbPath);
+    insertLearningRecommendationFixture(db, {
+      tenantId: "local",
+      recommendationId,
+      tombstoned: false,
+    });
+    insertTailoringPolicyFixture(db, {
+      tenantId: "local",
+      version: 1,
+      learnedRules: {},
+      createdAt: "2026-08-01T10:00:00Z",
+    });
+    insertTailoringPolicyFixture(db, {
+      tenantId: "local",
+      version: 2,
+      learnedRules: { fact_handling: "require_source_match" },
+      createdAt: "2026-08-01T11:00:00Z",
+    });
+    db.prepare(
+      `INSERT INTO learning_recommendation_reviews (
+         tenant_id, review_id, recommendation_id, revision, decision,
+         context, policy_kind, policy_version, reviewed_at
+       ) VALUES ('local', ?, ?, 1, 'accepted', 'materials', 'tailoring_rule', 2, ?)`,
+    ).run(reviewId, recommendationId, "2026-08-01T11:00:00Z");
+    insertTailoringPolicyFixture(db, {
+      tenantId: "local",
+      version: 3,
+      learnedRules: {},
+      rollbackOfVersion: 1,
+      rollbackReason: "private historical rollback narrative",
+      createdAt: "2026-08-01T11:30:00Z",
+    });
+    insertTailoringPolicyFixture(db, {
+      tenantId: "local",
+      version: 4,
+      learnedRules: {},
+      rollbackOfVersion: 1,
+      rollbackReason: "user_requested",
+      createdAt: "2026-08-01T12:00:00Z",
+    });
+    insertTailoringPolicyFixture(db, {
+      tenantId: "other",
+      version: 1,
+      learnedRules: { provenance_policy: "require_direct_evidence" },
+      createdAt: "2026-08-01T10:00:00Z",
+    });
+    const before = JSON.stringify(
+      db.prepare("SELECT * FROM tailoring_policies ORDER BY tenant_id, version").all(),
+    );
+    db.close();
+
+    const app = buildApp(options);
+    const response = await app.inject({
+      method: "GET",
+      url: "/v1/learning/policies/materials?page=1&pageSize=4",
+    });
+
+    expect(response.statusCode, response.body).toBe(200);
+    const parsed = TailoringPolicyRevisionListResponseSchema.parse(response.json());
+    expect(parsed).toMatchObject({ page: 1, pageSize: 4, total: 4, totalPages: 1 });
+    expect(parsed.revisions).toEqual([
+      {
+        context: "materials",
+        policyKind: "tailoring_rule",
+        version: 4,
+        status: "current",
+        learnedRules: [],
+        sourceReviewId: null,
+        sourceRecommendationId: null,
+        rollbackOfVersion: 1,
+        rollbackReasonCode: "user_requested",
+        createdAt: "2026-08-01T12:00:00.000Z",
+      },
+      {
+        context: "materials",
+        policyKind: "tailoring_rule",
+        version: 3,
+        status: "superseded",
+        learnedRules: [],
+        sourceReviewId: null,
+        sourceRecommendationId: null,
+        rollbackOfVersion: 1,
+        rollbackReasonCode: "historical_or_unspecified",
+        createdAt: "2026-08-01T11:30:00.000Z",
+      },
+      {
+        context: "materials",
+        policyKind: "tailoring_rule",
+        version: 2,
+        status: "superseded",
+        learnedRules: [{ ruleKey: "fact_handling", ruleValue: "require_source_match" }],
+        sourceReviewId: reviewId,
+        sourceRecommendationId: recommendationId,
+        rollbackOfVersion: null,
+        rollbackReasonCode: null,
+        createdAt: "2026-08-01T11:00:00.000Z",
+      },
+      {
+        context: "materials",
+        policyKind: "tailoring_rule",
+        version: 1,
+        status: "superseded",
+        learnedRules: [],
+        sourceReviewId: null,
+        sourceRecommendationId: null,
+        rollbackOfVersion: null,
+        rollbackReasonCode: null,
+        createdAt: "2026-08-01T10:00:00.000Z",
+      },
+    ]);
+    expect(response.body).not.toContain("sha256:private-prompt");
+    expect(response.body).not.toContain("require_direct_evidence");
+    expect(response.body).not.toContain("private historical rollback narrative");
+
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(response.body, { status: 200, statusText: "OK" }),
+    );
+    await expect(
+      createJobCtrlApiClient().tailoringPolicyRevisions({ page: 1, pageSize: 4 }),
+    ).resolves.toEqual(parsed);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://127.0.0.1:8766/v1/learning/policies/materials?page=1&pageSize=4",
+      expect.objectContaining({ method: "GET" }),
+    );
+    fetchMock.mockRestore();
+
+    const unchanged = new Database(options.dbPath);
+    expect(
+      JSON.stringify(
+        unchanged.prepare("SELECT * FROM tailoring_policies ORDER BY tenant_id, version").all(),
+      ),
+    ).toBe(before);
     unchanged.close();
     await app.close();
   });
@@ -10766,6 +10906,43 @@ function insertLearningRecommendationFixture(
       );
     }
   })();
+}
+
+function insertTailoringPolicyFixture(
+  db: Database.Database,
+  options: {
+    tenantId: string;
+    version: number;
+    learnedRules: Record<string, string>;
+    createdAt: string;
+    rollbackOfVersion?: number;
+    rollbackReason?: string;
+  },
+): void {
+  db.prepare(
+    `INSERT INTO tailoring_policies (
+       tenant_id, version, prompt_version, schema_version, judge_schema_version,
+       prompt_fingerprint, config_fingerprint, profile_policy_fingerprint,
+       custom_prompt_fingerprint, generator_settings_json, judge_settings_json,
+       runtime_settings_json, rollback_of_version, rollback_reason, created_at,
+       created_from_event_id
+     ) VALUES (?, ?, 'tailor.v2', 'resume.v1', 'judge.v1', ?, ?, ?, ?, '{}', '{}',
+               ?, ?, ?, ?, NULL)`,
+  ).run(
+    options.tenantId,
+    options.version,
+    "sha256:private-prompt",
+    `sha256:config-${options.version}`,
+    "sha256:private-profile",
+    "sha256:private-custom",
+    JSON.stringify({
+      validation_mode: "normal",
+      learned_tailoring_rules: options.learnedRules,
+    }),
+    options.rollbackOfVersion ?? null,
+    options.rollbackReason ?? "",
+    options.createdAt,
+  );
 }
 
 function learningAuditSnapshot(db: Database.Database): string {

--- a/packages/api-client/src/client.ts
+++ b/packages/api-client/src/client.ts
@@ -89,6 +89,8 @@ import type {
   LearningRecommendationListQuery,
   LearningRecommendationReviewRequest,
   LearningRecommendationReviewResponse,
+  TailoringPolicyRevisionListQuery,
+  TailoringPolicyRevisionListResponse,
   JobMutationResponse,
   JobSummary,
   MarkJobActionRequest,
@@ -164,6 +166,7 @@ import {
   LearningRecommendationEvidenceListResponseSchema,
   LearningRecommendationListResponseSchema,
   LearningRecommendationReviewResponseSchema,
+  TailoringPolicyRevisionListResponseSchema,
 } from "@jobctrl/contracts";
 
 type QueryValue = boolean | number | string | null | undefined;
@@ -285,6 +288,14 @@ export class JobCtrlApiClient {
         `/v1/learning/recommendations/${encodeURIComponent(recommendationId)}/reviews`,
         body,
       ),
+    );
+  }
+
+  async tailoringPolicyRevisions(
+    query: Partial<TailoringPolicyRevisionListQuery> = {},
+  ): Promise<TailoringPolicyRevisionListResponse> {
+    return TailoringPolicyRevisionListResponseSchema.parse(
+      await this.get("/v1/learning/policies/materials", query),
     );
   }
 

--- a/packages/contracts/src/schemas.ts
+++ b/packages/contracts/src/schemas.ts
@@ -2263,6 +2263,93 @@ export type LearningRecommendationListQuery = z.infer<
   typeof LearningRecommendationListQuerySchema
 >;
 
+export const TailoringPolicyRevisionListQuerySchema = LearningRecommendationListQuerySchema;
+export type TailoringPolicyRevisionListQuery = z.infer<
+  typeof TailoringPolicyRevisionListQuerySchema
+>;
+
+export const TailoringPolicyLearnedRuleSchema = z.discriminatedUnion("ruleKey", [
+  z
+    .object({
+      ruleKey: z.literal("style_guidance"),
+      ruleValue: z.literal("preserve_user_edit_pattern"),
+    })
+    .strict(),
+  z
+    .object({
+      ruleKey: z.literal("fact_handling"),
+      ruleValue: z.literal("require_source_match"),
+    })
+    .strict(),
+  z
+    .object({
+      ruleKey: z.literal("claim_policy"),
+      ruleValue: z.literal("omit_unsupported_claims"),
+    })
+    .strict(),
+  z
+    .object({
+      ruleKey: z.literal("keyword_strategy"),
+      ruleValue: z.literal("use_supported_terms_only"),
+    })
+    .strict(),
+  z
+    .object({
+      ruleKey: z.literal("provenance_policy"),
+      ruleValue: z.literal("require_direct_evidence"),
+    })
+    .strict(),
+]);
+export type TailoringPolicyLearnedRule = z.infer<typeof TailoringPolicyLearnedRuleSchema>;
+
+export const TailoringPolicyRevisionSummarySchema = z
+  .object({
+    context: z.literal("materials"),
+    policyKind: z.literal("tailoring_rule"),
+    version: z.number().int().positive(),
+    status: z.enum(["current", "superseded"]),
+    learnedRules: z.array(TailoringPolicyLearnedRuleSchema).max(5),
+    sourceReviewId: LearningRecommendationReviewIdSchema.nullable(),
+    sourceRecommendationId: LearningRecommendationIdSchema.nullable(),
+    rollbackOfVersion: z.number().int().positive().nullable(),
+    rollbackReasonCode: z.enum(["user_requested", "historical_or_unspecified"]).nullable(),
+    createdAt: IsoTimestampSchema,
+  })
+  .strict()
+  .refine(
+    (value) => (value.sourceReviewId === null) === (value.sourceRecommendationId === null),
+    "Policy recommendation and review provenance must be present together.",
+  )
+  .refine(
+    (value) => (value.rollbackOfVersion === null) === (value.rollbackReasonCode === null),
+    "Policy rollback version and reason must be present together.",
+  );
+export type TailoringPolicyRevisionSummary = z.infer<
+  typeof TailoringPolicyRevisionSummarySchema
+>;
+
+export const TailoringPolicyRevisionListResponseSchema = z
+  .object({
+    ok: z.literal(true),
+    revisions: z.array(TailoringPolicyRevisionSummarySchema).max(100),
+    page: z.number().int().min(1),
+    pageSize: z.number().int().min(1).max(100),
+    total: z.number().int().nonnegative(),
+    totalPages: z.number().int().nonnegative(),
+  })
+  .strict()
+  .refine(
+    (value) => value.revisions.length <= value.pageSize,
+    "Policy revision page exceeds its declared page size.",
+  )
+  .refine(
+    (value) => value.revisions.filter((revision) => revision.status === "current").length <= 1,
+    "Policy revision page contains multiple current revisions.",
+  );
+export type TailoringPolicyRevisionListResponse = z.infer<
+  typeof TailoringPolicyRevisionListResponseSchema
+>;
+
 export const LearningRecommendationSummarySchema = z
   .object({
     recommendationId: LearningRecommendationIdSchema,


### PR DESCRIPTION
## Summary

- add a paginated read-only Materials policy revision history endpoint
- expose explicit context ownership, current/superseded status, allowlisted learned rules, recommendation/review provenance, and structured rollback metadata
- add the typed API client method and strict shared contracts

## Privacy and integrity

- query count, rows, provenance, and current-version selection inside one SQLite snapshot
- scope every read to the local tenant
- exclude prompt/config/profile fingerprints and raw runtime settings
- redact unknown historical rollback narratives to a structured historical/unspecified code
- reject non-allowlisted learned rule pairs at the response contract boundary

## Validation

- contracts, API client, and API TypeScript checks
- focused Node 22 API route/client regression (1 passed; 218 unrelated skipped)
- `git diff --check`
- independent review: PASS, no findings