### PR TITLE
docs: document JobId v7 roadmap contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,10 @@ evidence, qualifications, and the complete capability matrix.
   by default and uses the configured cron only after you enable it.
 - Enrich postings with full descriptions, canonical posting URLs, and apply
   URLs.
+- Keep each job under one tenant-scoped, immutable `JobId`. Posting and
+  application URLs are locators resolved only at explicit capture/import/API
+  boundaries, so a URL change cannot detach scores, materials, outcomes, or
+  workflow history. Source and employer remain separate persisted facts.
 - Fetch politely: anonymous discovery/enrichment requests route through one
   gateway that honors `robots.txt`, paces each host, bounds each run's request
   budget, and sends an honest `User-Agent` that never impersonates a browser.
@@ -185,6 +189,9 @@ evidence, qualifications, and the complete capability matrix.
   reflow into labelled cards at narrower widths.
 - Score jobs as an applicant-side triage aid with auditable evidence — never
   employer-side screening.
+- Persist normalized scoring keywords per score version. The jobs API filters
+  by the canonical normalized key, while `/v1/scoring/keywords` exposes the
+  current-version aggregation used by typed clients.
 - Generate tailored resumes, cover letters, PDFs, and review artifacts.
 - Triage jobs through the real **Active**, **Deleted**, and **Hidden** queues.
   The default Active view keeps source and warning columns available but hidden,
@@ -212,6 +219,15 @@ evidence, qualifications, and the complete capability matrix.
   remains before offering to set up a replacement run; setup never starts work
   by itself. Runs keeps the durable workflow history; Jobs and route-level
   detail workspaces keep record-specific evidence and actions adjacent.
+- Inspect Discover, preparation, and Apply through the same Runs vocabulary,
+  timeline, terminal-state rules, and cancellation control. Repeated cancel
+  requests are harmless, and an already-terminal result remains inspectable.
+- Review privacy-bounded learning recommendations on the Dashboard. JobCtrl
+  derives them only from explicit reviewed signals, requires compatible
+  evidence across jobs, and changes Materials behavior only after you accept a
+  recommendation. Tailoring policy history is versioned, superseded revisions
+  remain inspectable, and restore creates a new append-only revision without
+  re-scoring jobs or replacing artifacts.
 - Keep recruiter, hiring-manager, and referrer contact records per company or
   application, each fact carrying its provenance, with CSV import. Draft
   truthful, reviewable outreach messages under the same anti-fabrication gates
@@ -456,6 +472,14 @@ invoke the same Python command through the checkout as described in
 This writes `~/.jobctrl/backups/jobctrl-<timestamp>.db` via SQLite
 `VACUUM INTO` and never deletes anything (`--output <path>` to choose a
 target).
+
+The native v7 update performs its own paired migration safeguard. For an
+admitted v6 installation it stops and quiesces JobCtrl, backs up both
+`jobctrl.db` and bundled Temporal state, builds and verifies the JobId-keyed v7
+candidate in one transaction, then activates the verified pair. Any failed
+build, verification, or activation restores the previous pair. The API and
+worker run exact v7 only; there is no mixed-version, dual-write, or permanent
+fallback runtime.
 
 <details>
 <summary><b>Restore steps</b></summary>

--- a/docs/api/complete-contract.md
+++ b/docs/api/complete-contract.md
@@ -39,6 +39,7 @@ need:
 | [Profile and preferences](#profile-and-preferences) | Reading and writing the candidate profile, autosave, and the Preferences / Discovery / Settings control split. |
 | [Artifacts and tailoring audit](#artifacts-and-tailoring-audit) | Read-model projections, artifact preview/open routes, resume templates, and canonical tailoring evidence. |
 | [Jobs read model and lifecycle](#jobs-read-model-and-lifecycle) | Score evidence, requirement-fit, career evidence map, audit history, list filters, and delete / hide / restore routes. |
+| [Feedback learning and policy history](#feedback-learning-and-policy-history) | Normalized scoring-keyword aggregation, privacy-safe recommendations and evidence, explicit review, Materials policy history, and append-only rollback. |
 | [Dashboard, analytics, and operational metrics](#dashboard-analytics-and-operational-metrics) | `GET /v1/dashboard/summary`, `GET /v1/analytics/outcomes`, source health, and operational attempt counters. |
 | [Pipeline operations snapshot](#pipeline-operations-snapshot) | `GET /v1/pipeline/operations`: immutable Discover execution lineage, scoped backlog, orchestration steps, runtime capacity, active work, task-queue observations, and typed ETA. |
 | [Discovery controls](#discovery-controls) | Source registry, locator / quarantine / manual-capture queues, and feedback endpoints. |
@@ -270,6 +271,44 @@ record, so rediscovery can add the same posting again later.
 `POST /v1/jobs/bulk-retry-failed` accepts the same selected-job or
 all-matching bulk mutation body and resets each active failed or exhausted job's
 failed stage to `pending`; non-failed selected jobs are ignored.
+
+## Feedback learning and policy history
+
+`GET /v1/scoring/keywords` returns `{ ok: true, keywords }`. Each item contains
+`normalizedKeyword`, `displayKeyword`, the positive current `scoreVersion`, and
+positive `jobCount`. `GET /v1/jobs?normalizedScoreKeyword=<key>` performs an
+exact match against that normalized key on each job's current score version;
+historical score keywords are not mixed into either result.
+
+`GET /v1/learning/recommendations?page=<n>&pageSize=<1..100>` returns a
+paginated list of pending Materials `tailoring_rule` recommendations. Each
+summary exposes only an allowlisted rule key/value, derivation and evaluation
+fixture versions, signal kind, threshold/observed counts, bounded
+supporting/contradicting/tombstone counts, the explicit
+`sample_gated_no_population_inference` confidence limit, and timestamps. It
+never exposes feedback free text, raw notes, resumes, job descriptions, prompts,
+mail bodies, or model output.
+
+`GET /v1/learning/recommendations/:recommendationId/evidence` returns paginated
+structured evidence links: signal ID, supporting/contradicting role, source
+revision, stable JobId, and recorded time. An invalid canonical recommendation
+ID returns `400`; an unknown tenant-scoped recommendation returns `404`.
+
+`POST /v1/learning/recommendations/:recommendationId/reviews` accepts exactly
+`{ decision: "accepted" | "rejected" }`. Acceptance creates a new versioned
+Materials tailoring-policy revision and returns its positive `policyVersion`.
+Rejection records the review and returns `policyVersion: null`; it changes no
+policy. Replayed/conflicting/stale review attempts return a bounded error rather
+than applying behavior twice.
+
+`GET /v1/learning/policies/materials?page=<n>&pageSize=<1..100>` returns
+allowlisted current/superseded revision summaries: version, learned rules,
+recommendation/review provenance when present, rollback provenance when
+present, and creation time. `POST /v1/learning/policies/materials/rollbacks`
+accepts `{ targetVersion: <positive integer> }` and appends a new current
+revision with `rollbackOfVersion` and `rollbackReasonCode: "user_requested"`.
+The exact structured replay is idempotent. Neither review nor rollback starts
+scoring, tailoring, Apply, workflow, or artifact work.
 
 ## Dashboard, analytics, and operational metrics
 
@@ -708,7 +747,9 @@ invalidation router uses the event to refresh job list/detail queries.
 `/v1/workflow-runs` reads the unified `workflow_run_projections` table (the
 Python-sole-writer projection folded from the `Workflow*` lifecycle events) and
 projects each row to a `WorkflowRunSummary` across **all** workflow types —
-pipeline orchestrator, apply, and future workflows. Apply rows are enriched with
+Discover, job preparation, Apply, and future workflows. Those workflow families
+share one status vocabulary, ordered timeline, terminal-state interpretation,
+and cancellation boundary. Apply rows are enriched with
 job context (title/company/dry-run/model) via a LEFT JOIN to
 `apply_run_projections`; non-apply rows surface their `workflowType` instead of a
 job title. The `runId` equals the Temporal workflow id, so the web Workflow Runs
@@ -726,6 +767,11 @@ status, input summary, failure cause (`errorCode` / `errorMessage` /
 `POST /v1/workflow-runs/:runId/actions/cancel` dispatches a worker-backed
 `cancel_run` request for in-flight workflow IDs that are not tied to a concrete
 job row, such as global Discover or Apply runs started from the Pipelines tab.
+The command is cooperative, asynchronous, and idempotent. Repeating it cannot
+replace an already-terminal Apply result or emit another cancellation
+transition. Whether cancellation wins or loses its race with completion, the
+terminal result and folded timeline remain inspectable through the same detail
+route.
 `GET /v1/dashboard/summary` also carries recent apply-run timeline summaries
 from `apply_run_projections.events_json` (`type`, `level`, `message`, `at`) so
 the run detail workspace renders persisted history without exposing raw event
@@ -1077,8 +1123,8 @@ configuration choose the active model.
 `POST /v1/jobs/:jobKey/actions/run-stage` starts one job-scoped preparation
 pickup without resetting stage state. It accepts the internal preparation
 stages `enrich`, `score`, `tailor`, and `cover`, rejects product-stage starts
-such as `apply`, resolves the route key to the canonical job URL, checks worker
-readiness, and dispatches `run_stage` for the remaining preparation sequence
+such as `apply`, resolves the route key at the API boundary to the stable JobId,
+checks worker readiness, and dispatches `run_stage` for the remaining preparation sequence
 from the requested substage. Before dispatch, the route refreshes projections
 and checks that the requested substage is still pending and observably eligible;
 known-ineligible rows return `status: "not_eligible"` without starting worker
@@ -1090,7 +1136,7 @@ fanout.
   matching jobs. It does not reset stages. It selects the first eligible pending
   preparation substage per job (`enrich`, `score`, `tailor`, or `cover`),
   groups those jobs by substage, and dispatches bounded `run_stage` workflows
-  with selected job URLs and the requested worker count. Known-ineligible,
+  with selected JobIds and the requested worker count. Known-ineligible,
   failed, exhausted, already-complete, low-fit, and `apply`-pending rows are
   ignored. The Jobs toolbar exposes this as `continue pending prep` so pending
   preparation backlogs are not dependent on page-local pickup.
@@ -1510,6 +1556,15 @@ the browser's native `EventSource`. Per
 single realtime channel from the worker / API write-side to the frontend's
 TanStack Query cache; the frontend's `InvalidationRouter` translates each
 `DomainEvent` into the right `invalidateQueries` / `setQueryData` calls.
+
+`setQueryData` is used only when the tenant-scoped event contains enough
+canonical fields for an exact truthful patch: active job detail,
+already-registered artifact detail, workflow-run detail, or an ordered Apply-run
+event. Filtered/list membership, dashboards, incomplete payloads, and uncertain
+artifact registration use bounded tenant-scoped invalidation. Cache
+reconciliation does not reset view-owned filters, selection, pagination, or
+scroll state and never synthesizes an artifact that is absent from persisted
+registration.
 
 ### Request
 

--- a/docs/api/jobs-and-materials.md
+++ b/docs/api/jobs-and-materials.md
@@ -13,12 +13,36 @@ For field-level schemas and every route variant, use the
 | Route family | What it exposes |
 | --- | --- |
 | `GET /v1/jobs` and `GET /v1/jobs/:jobKey` | List/detail projections, stage state, score summary, and audit links. |
+| `GET /v1/scoring/keywords` | Current projected score-version keyword aggregation with canonical normalized keys. |
 | `GET /v1/evidence-map` | Canonical career evidence used by scoring and materials. |
 | `POST /v1/jobs/:key/score-correction` | A new score version plus explicit correction rationale. |
 | Job hide/restore/delete routes | Reversible lifecycle commands, plus a separate permanent-delete boundary. |
 
 List and detail endpoints read projection rows. They do not recompute scores,
 parse salary text, or replay events during a request.
+
+`jobKey` is the tenant-scoped stable `JobId`, not a posting URL. User/import
+boundaries may resolve a URL to that ID explicitly, but internal job routes and
+foreign references remain ID-shaped. `GET /v1/jobs` accepts
+`normalizedScoreKeyword` using the exact key returned by
+`GET /v1/scoring/keywords`; current filtering never mixes historical score
+versions into the result.
+
+## Feedback Learning And Materials Policy
+
+| Route | Purpose |
+| --- | --- |
+| `GET /v1/learning/recommendations` | Paginated pending/inactive recommendation summaries with sample gates and safe counts. |
+| `GET /v1/learning/recommendations/:recommendationId/evidence` | Bounded structured supporting and contradicting references without source free text. |
+| `POST /v1/learning/recommendations/:recommendationId/reviews` | Explicitly accept or reject one current recommendation. |
+| `GET /v1/learning/policies/materials` | Paginated current and superseded tailoring-policy revisions with allowlisted provenance. |
+| `POST /v1/learning/policies/materials/rollbacks` | Append a `user_requested` revision restoring one earlier version. |
+
+Acceptance creates one versioned Materials policy revision; rejection writes a
+review but does not change policy. Rollback is append-only and idempotent for
+the same structured request. None of these routes starts scoring, tailoring,
+Apply, or artifact work. Errors and historical metadata are sanitized before
+they cross the browser boundary.
 
 ## Artifacts And Resume Templates
 

--- a/docs/api/operations-and-events.md
+++ b/docs/api/operations-and-events.md
@@ -165,14 +165,22 @@ and task-queue observations are runtime telemetry, not domain events.
 /v1/workflow-runs/:runId` returns the projection-backed detail and timeline.
 `POST /v1/workflow-runs/:runId/actions/cancel` requests Temporal cancellation.
 
+Discover, job preparation, and Apply use this same history contract: one status
+vocabulary, ordered lifecycle timeline, terminal-state interpretation, and
+cancellation boundary. Product views may present different workflow details,
+but they do not maintain separate run-state rules.
+
 The list accepts an exact `workflowType`, inclusive UTC `startedSince`, and
 exclusive UTC `startedBefore` in addition to status, sorting, and pagination.
 Filtering happens after lifecycle folding and before pagination, so restarted
 executions use their canonical projected start time and returned totals cover
 the complete filtered result rather than only the current page.
 
-Cancellation is cooperative and asynchronous: the accepted request is not the
-same thing as observing the terminal canceled state.
+Cancellation is cooperative, asynchronous, and idempotent: accepting a request
+is not the same thing as observing terminal `canceled`, and repeating the
+request cannot overwrite an already-terminal result or emit duplicate
+cancellation transitions. Terminal results remain inspectable through the same
+run detail after cancellation wins or loses the race with completion.
 
 ## Health And JSON-RPC
 
@@ -197,6 +205,15 @@ Event IDs support reconnect replay; keepalives preserve quiet connections. See
 the [frontend realtime design](../architecture/frontend/realtime.md) for cache
 behavior and the [complete SSE contract](complete-contract.md#server-sent-events-—-get-v1eventsstream)
 for framing and precedence rules.
+
+The browser patches a tenant-scoped cache row only when the event carries
+enough canonical data to do so truthfully. That includes active job detail,
+already-registered artifact detail, workflow-run detail, and ordered Apply-run
+events. List membership, filtered views, dashboards, missing payload fields,
+and uncertain artifact registration use bounded tenant-scoped invalidation
+instead. Realtime reconciliation preserves view-owned filters, selection,
+pagination, and scroll position; it never inserts a phantom artifact merely
+because a generation event arrived.
 
 ## Implementation Map
 

--- a/docs/architecture/frontend/realtime.md
+++ b/docs/architecture/frontend/realtime.md
@@ -198,58 +198,39 @@ manages the subscription lifecycle.
 
 ## 7.4 The Invalidation Router
 
-A pure function that maps `DomainEvent → Set<QueryKey>`. The router lives
-in `contexts/operations/invalidation-router.ts`. Each backend event type
-has a registered handler:
+A pure function maps each `DomainEvent` to tenant-scoped invalidation or exact
+patch instructions. The router lives in
+`contexts/operations/invalidation-router.ts`; each backend event type has a
+registered aggregate-owned handler:
 
 ```ts
-const handlers: Record<DomainEventType, InvalidationHandler> = {
-  JobDiscovered: ({ tenantId }) => [
-    jobsKeys.lists(tenantId),
-    dashboardKeys.summary(tenantId),
-  ],
-  JobScored: ({ tenantId, jobId }) => [
-    jobsKeys.detail(tenantId, jobId),
-    jobsKeys.lists(tenantId),
-    dashboardKeys.summary(tenantId),
-  ],
-  ResumeApproved: ({ tenantId, jobId }) => [
-    jobsKeys.detail(tenantId, jobId),
-    jobsKeys.lists(tenantId),
-    artifactsKeys.lists(tenantId),
-    dashboardKeys.summary(tenantId),
-  ],
-  ApplyRunEventRecorded: ({ tenantId, runId, event }) => {
-    // Specialized: append to in-memory list rather than invalidate.
-    return [{ kind: "apply-run-event", tenantId, runId, event }];
-  },
-  PipelineStepStarted: ({ tenantId, execution }) => [
-    workflowRunsKeys.detail(tenantId, execution.workflowId),
-    workflowRunsKeys.lists(tenantId),
-    pipelineKeys.operations(tenantId),
-  ],
-  // ... one entry per DomainEventUnion variant
-};
+export const jobActiveStateChangedHandler = (event) => [
+  patchQuery(jobsKeys.detail(event.tenantId, event.payload.jobId),
+    (current) => patchJobActiveState(current, event.payload)),
+  invalidate(jobsKeys.lists(event.tenantId)),
+  invalidate(dashboardKeys.summary(event.tenantId)),
+];
 
-export function handleEvent(event: DomainEvent, qc: QueryClient): void {
-  const out = handlers[event.eventType](event.payload);
-  for (const item of out) {
-    if ("kind" in item && item.kind === "apply-run-event") {
-      qc.setQueryData(applyRunsKeys.detail(item.tenantId, item.runId), (old) =>
-        appendApplyRunEvent(old, item.event),
-      );
-    } else {
-      qc.invalidateQueries({ queryKey: item });
-    }
-  }
-}
+export const resumeApprovedHandler = (event) => [
+  patchQuery(jobsKeys.detail(event.tenantId, event.payload.jobId),
+    (current) => patchResumeApproved(current, event.payload)),
+  patchQuery(artifactsKeys.detail(event.tenantId, event.payload.artifactId),
+    (current) => patchResumeApproved(current, event.payload)),
+  invalidate(jobsKeys.lists(event.tenantId)),
+  invalidate(artifactsKeys.lists(event.tenantId)),
+];
+
+// Workflow lifecycle handlers patch the existing detail, then invalidate the
+// list/dashboard reads whose membership or aggregation may have changed.
+// ApplyRunEventRecorded remains a direct ordered append.
 ```
 
 In practice the per-event handler functions are authored in each aggregate
 context's `handlers.ts` (seven files: `discovery`, `enrichment`, `profile`,
 `scoring`, `materials`, `apply`, `pipeline`) and registered centrally in
-`invalidation-router.ts`, which exports `invalidate`, `patchApplyRunEvent`,
-and `useInvalidationRouter`. The illustration above inlines them for
+`invalidation-router.ts`, which exports `invalidate`, `patchQuery`,
+`patchApplyRunEvent`, and `useInvalidationRouter`. The illustration above
+inlines representative handlers for
 clarity; Operations itself has no `handlers.ts`.
 
 **Why a router and not per-context subscriptions:**
@@ -277,10 +258,8 @@ Two layers, both required:
    is no Zod schema to read `.options` from) and asserts a handler is
    registered for each. This is the *backstop* that catches the case where a
    developer adds a stub handler `() => []` (TS-passing, behaviorally wrong).
-   It runs in the web Vitest suite, which is **not yet CI-gated** (tracked in
-   `docs/backlog.md`); the compile-time check in (1) — run in CI via
-   `pnpm -r check` — is the CI-enforced guard, and this parity test is its
-   local runtime backstop.
+   The web Vitest suite runs in TypeScript CI; the compile-time check and
+   runtime parity test are both required.
 
 The pattern mirrors the backend's `scripts/check-domain-type-parity.py`
 (per `architecture.md`'s verification-commands section). A new event on
@@ -294,26 +273,34 @@ Two patterns exist; both have a place:
 
 | Pattern | When to use | Example event |
 |---|---|---|
-| `queryClient.invalidateQueries({ queryKey })` | **Default.** Use whenever the event indicates "the projection changed; the next render should re-fetch." | `JobScored` → invalidate `jobsKeys.detail` and `jobsKeys.lists`. |
-| `queryClient.setQueryData(queryKey, updater)` | **Optimization for high-frequency events** where re-fetching would be wasteful. Use when the event payload contains exactly the data needed to patch the cache. | `ApplyRunEventRecorded` → append to the in-memory event list of the active apply-run query. |
+| `queryClient.invalidateQueries({ queryKey })` | Use when the payload is incomplete, list/filter membership can change, a dashboard aggregate changed, or no exact registered row is known. Keep the key tenant-scoped and no broader than the affected resource family. | `JobScored` → invalidate job list/detail and dashboard projections. |
+| `queryClient.setQueriesData` / `setQueryData` | Use immediately when the event contains the canonical fields needed for a truthful patch of an existing cache row. Pair it with bounded invalidation when another view needs membership/refilter/aggregate reconciliation. | Active job detail, registered artifact approval, workflow detail, and ordered Apply-run append. |
 
-**Why default to `invalidate`:**
+**Why invalidation remains necessary:**
 
 - **Single source of truth.** The projection on the server is canonical;
   the cache always reconciles to it.
 - **No hand-rolled merge bugs.** Patching cache shape by hand introduces
   mismatch between the patched value and what a fresh fetch would return.
-- **Simple, mechanical.** Each new event type is a one-line handler.
+- **Membership safety.** Events cannot insert rows into filtered or paginated
+  lists without the complete projection and filter context.
 
-**Why `setQueryData` for `ApplyRunEventRecorded` specifically:**
+**Exact patch rules:**
 
-- **Volume.** During an apply run, several events per second arrive over
-  the course of minutes. Re-fetching the apply-run detail per event
-  saturates the API for no benefit.
-- **Append-only semantics.** The event payload is exactly the new event to
-  append. Patching is trivially correct.
-- **Reconciliation backstop.** When the apply-run route workspace is left and
-  revisited, it re-fetches, naturally reconciling with any drift.
+- `JobActiveStateChanged` patches an open job detail immediately; job lists and
+  Dashboard invalidate because active-state filters and aggregates can change.
+- `ResumeApproved` changes status only on an artifact already present in an
+  open job/artifact detail. It never creates a missing artifact; list pages
+  invalidate so persisted registration and filtering remain authoritative.
+- `Workflow*` lifecycle events patch the matching run detail by exact workflow
+  identity and append a deduplicated timeline entry. Run lists, Dashboard, and
+  operations invalidate because status membership and aggregation can change.
+- `ApplyRunEventRecorded` directly appends its complete ordered event. This
+  high-frequency path avoids a refetch per event; a later read still provides
+  reconciliation.
+
+The router never resets component-owned filters, selection, pagination, or
+scroll position. A query update changes data under the existing view state.
 
 ### Runtime snapshot polling complements SSE
 

--- a/docs/architecture/pipeline/envelope.md
+++ b/docs/architecture/pipeline/envelope.md
@@ -113,7 +113,7 @@ and Temporal run ID. Source-run IDs are deliberately excluded.
 That exact reference is carried through planning, source families,
 reconciliation, preparation fan-out, child `JobPreparationWorkflow` input, and
 PDF rendering. `discovery_execution_jobs` stores one membership per execution
-and canonical job URL. Its cohort is `observed_this_run` or
+and stable JobId. Its cohort is `observed_this_run` or
 `existing_backlog`; a later source observation may promote a swept membership
 to current, but cannot duplicate or demote it. A work plan remains explicitly
 `pending` until it becomes `planned`, `not_eligible`, or `failed`; a missing

--- a/docs/architecture/pipeline/operations.md
+++ b/docs/architecture/pipeline/operations.md
@@ -142,7 +142,7 @@ identity once and creates an immutable `DiscoveryExecutionRef`:
 The run ID is required because the deterministic workflow ID can be started
 again. Source-run IDs are observation details, not execution identity. Every
 linked job is persisted in `discovery_execution_jobs`, keyed by that exact
-execution plus canonical job URL, with one of two cohorts:
+execution plus stable JobId, with one of two cohorts:
 
 - `observed_this_run` — a source in this execution observed the job;
 - `existing_backlog` — the execution deliberately swept pre-existing eligible

--- a/docs/architecture/storage.md
+++ b/docs/architecture/storage.md
@@ -55,8 +55,11 @@ flowchart LR
     MATERIALS -->|writes| FILES
 ```
 
-Within the job-owned families, one `jobs` row (keyed by posting URL) is the hub:
-stage state, events, scores, analysis, materials, and apply records hang off it.
+Within the job-owned families, one `jobs` row keyed by `(tenant_id, job_id)` is
+the hub: stage state, events, scores, analysis, materials, and Apply records
+hang off the stable tenant-scoped `JobId`. A posting URL is an external locator
+with a tenant-scoped uniqueness constraint, not an internal primary or foreign
+key. Employer and Source observations are stored as independent facts.
 
 The remaining tables group by owner:
 
@@ -65,10 +68,12 @@ The remaining tables group by owner:
 | Candidate Profile | `candidate_profiles` plus 12 `candidate_profile_*` child tables (experience, bullets, skills, education, achievement evidence, required-content sets, resume constraint metrics) |
 | Resume templates | `resume_templates`, `resume_template_versions`, `resume_template_defaults`, `resume_template_refresh_attempts`, `job_resume_template_assignments` |
 | Compensation | `job_posted_compensation_facts`, `job_market_compensation_estimates` |
+| Scoring | `job_scores`, versioned/indexed `job_score_keywords`, `scoring_policies`, `job_score_staleness` |
 | Read-model projections | `job_list_projections`, `job_detail_projections`, `dashboard_projections`, `apply_run_projections`, `workflow_run_projections`, `pipeline_step_projections`, `artifact_list_projections`, `event_watermarks`, `digest_state` |
 | Discovery & preparation | `discovery_runs`, `discovery_execution_jobs`, `discovery_search_units`, `discovery_search_unit_jobs`, `discovery_search_unit_filtered_events`, `discovery_settings`, `discovery_feedback`, `discovery_quarantine_entries`, `job_canonical_identities`, `job_source_observations`, `job_duplicate_links`, legacy `preparation_work_items`, `manual_capture_queue`, `posting_snapshot_sets`, `source_registry_entries`, `source_locator_candidates` |
 | Apply review, repeat protection, and outcomes | `application_review_decisions`, `application_repeat_overrides`, `application_repeat_override_consumptions`, `application_repeat_audit`, `application_outcomes`, `application_email_evidence`, `application_outcome_suggestions` |
-| Policies & operations | `tailoring_policies`, `llm_spend`, `job_score_staleness`, `worker_runtime_heartbeats`, `jobctrl_deleted_jobs` |
+| Explicit-feedback learning | `tailoring_feedback_signals`, `tailoring_feedback_signal_reviews`, `tailoring_feedback_signal_contradictions`, `learning_recommendations`, `learning_recommendation_evidence`, `learning_recommendation_evidence_jobs`, `learning_recommendation_jobs`, `learning_recommendation_reviews`, `learning_recommendation_tombstones` |
+| Policies & operations | `tailoring_policies`, `llm_spend`, `worker_runtime_heartbeats`, `jobctrl_deleted_jobs` |
 
 SQLite in `~/.jobctrl/jobctrl.db` is the local source of truth for jobs,
 stage states, events, artifacts, normalized Candidate Profile data, profile
@@ -82,11 +87,30 @@ licensed-feed coverage policy. Public Levels.fyi Markdown needs no credential.
 Credentials, feed paths/URLs, feed contents, and provider payloads do not belong
 in the settings file.
 
-### Repeat-application authority and migration
+### Exact v7 identity cutover
+
+Schema v7 is an exact runtime contract. The native lifecycle upgrades an
+admitted v6 installation only while the application is stopped: it quiesces
+the local runtime, creates a paired backup of `jobctrl.db` and Temporal state,
+builds an isolated candidate, and runs the v6-to-v7 rewrite in one SQLite
+transaction. URL-rooted job rows and foreign references are mapped to stable
+tenant-scoped JobIds; immutable historical events are upcast only as part of
+that migration.
+
+Activation happens only after schema, row/reference, projection, and paired
+state verification succeeds. The verified candidate replaces the live pair
+atomically. Any failed build, verification, or activation restores the paired
+backup and leaves the previous version runnable. There is no mixed-version
+runtime, rolling deployment, dual-write path, or permanent compatibility
+layer: the TypeScript API and Python worker accept exact v7 and reject direct
+v6 operation. Runtime projections read registered persisted artifacts only and
+do not reconstruct legacy URL-shaped fallback rows.
+
+### Repeat-application authority retained in v7
 
 Historical application facts remain owned by the existing job events, reviewed
-outcomes, and compatible applied status. Schema version 6 adds only three
-decision/audit tables; it does not backfill, reinterpret, or update those facts:
+outcomes, and compatible applied status. The three repeat-decision/audit tables
+introduced in schema v6 are retained in v7 without reinterpreting those facts:
 
 - `application_repeat_overrides` stores the target, selected prior job,
   relationship, immutable evidence snapshot and SHA-256 fingerprint, reason,
@@ -101,10 +125,9 @@ decision/audit tables; it does not backfill, reinterpret, or update those facts:
 The evaluator reads canonical job/source identity and accepted
 `job_duplicate_links`, then joins only confirmed application facts. Pending
 suggestions, notes, dry runs, failed attempts, and intent checkpoints are not
-promoted into history. Existing databases advance additively from version 5 to
-6 while their prior application rows and events remain byte-for-byte unchanged.
-Both the TypeScript API and Python worker can create the new tables
-idempotently, and both reject a database created by a newer schema version.
+promoted into history. The v6-to-v7 migration copies these exact application
+facts into the JobId-keyed schema and verifies their references before
+activation.
 
 For a live run, the Python launcher opens `BEGIN IMMEDIATE`, recomputes the
 current evidence, performs the existing active-run and approval checks, and
@@ -159,8 +182,8 @@ those projection columns only; it does not parse raw salary text on read.
 ### Discovery lineage and operations state
 
 `discovery_execution_jobs` is the durable execution-membership authority. Its
-primary identity is tenant + Discover workflow ID + Temporal run ID + canonical
-job URL. It stores `observed_this_run` or `existing_backlog`, the first safe
+primary identity is tenant + Discover workflow ID + Temporal run ID + stable
+JobId. It stores `observed_this_run` or `existing_backlog`, the first safe
 source metadata, explicit work-plan state, immutable required steps when
 planned, a bounded reason for not-eligible/failed plans, and the preparation
 workflow ID. Link writes are idempotent; a swept job can be promoted when this
@@ -176,7 +199,7 @@ that must be reached by acknowledging the provider error; reclaim cannot clear
 the cursor before that revision is durable.
 
 `discovery_search_unit_jobs` is the idempotent acceptance-receipt set keyed by
-execution, unit, and canonical job URL. The job/source/event writes and receipt
+execution, unit, and stable JobId. The job/source/event writes and receipt
 commit before provider acknowledgement. Durable new/existing counts and the
 run-wide result limit are derived from these receipts, so replay cannot count a
 posting twice. A newer activity attempt reclaims only `running`/`pending` units

--- a/docs/local-reliability-qa.md
+++ b/docs/local-reliability-qa.md
@@ -76,6 +76,61 @@ and accepted-artifact preservation. The
 [Regression Catalog](developer/qa/regression-catalog.md) explains which layer
 proves each class of invariant; the complete page maps every risk to exact tests.
 
+### Stable JobId v7 and explicit-feedback cumulative gate
+
+Run this gate on the final stack tip with disposable SQLite fixtures only. Do
+not point it at `~/.jobctrl/jobctrl.db`, a real Temporal store, or any live
+application target. The Python commands deliberately use the fixed project
+virtual environment directly so validation does not rewrite lock metadata.
+
+```bash
+PYTHONPATH=workers/automation/src workers/automation/.venv/bin/pytest -q \
+  workers/automation/tests/test_v6_to_v7_*.py \
+  workers/automation/tests/test_exact_v7_*.py \
+  workers/automation/tests/test_detail_projection_job_id_contract.py \
+  workers/automation/tests/test_jobstreaming_gateway.py \
+  workers/automation/tests/test_jobstreaming_resumable_discovery.py \
+  workers/automation/tests/test_learning_recommendations.py \
+  workers/automation/tests/test_sqlite_learning_recommendations.py \
+  workers/automation/tests/test_rpc_learning_recommendations.py \
+  workers/automation/tests/test_tailoring_policy_revisions.py \
+  workers/automation/tests/test_scoring_eval_feedback.py
+workers/automation/.venv/bin/ruff check workers/automation/src workers/automation/tests
+
+corepack pnpm --filter @jobctrl/api exec vitest run \
+  test/exact-v7-projections.test.ts \
+  test/read-model-v7.test.ts \
+  test/application-feedback-v7.test.ts \
+  test/write-model-cancel.test.ts \
+  test/server.test.ts
+corepack pnpm --filter @jobctrl/web exec vitest run \
+  src/contexts/operations/realtimePatches.test.ts \
+  src/contexts/operations/workflowRealtimePatches.test.ts \
+  src/contexts/operations/invalidation-router.test.ts \
+  src/contexts/apply/components/CancelApplyButton.test.tsx \
+  src/contexts/apply/hooks/useCancelApplyMutation.test.ts \
+  src/contexts/materials/components/LearningRecommendationReviewPanel.test.tsx \
+  src/contexts/materials/components/TailoringPolicyHistoryPanel.test.tsx
+corepack pnpm web:test-d
+go -C launcher test ./internal/launcher
+corepack pnpm check
+corepack pnpm test
+corepack pnpm docs:build
+git diff --check
+```
+
+The product path must then verify in the disposable/demo workspace that Runs
+shows the shared Discover/preparation/Apply timeline; repeated cancellation
+does not overwrite a terminal result; targeted events update an open job,
+registered artifact, and workflow detail without resetting filters, selection,
+pagination, or scroll; and Dashboard supports recommendation evidence,
+accept/reject, policy history, and explicit append-only restore. After
+acceptance, explicitly re-score/re-tailor synthetic work and verify the prior
+score and accepted artifact remain unchanged until those commands are invoked.
+The gate must also prove that no feedback decision or restore automatically
+starts scoring, tailoring, Apply, or artifact work. Do not perform a real
+application submission or mutate a real user database during this QA.
+
 ### Repeat-application prevention
 
 Use disposable SQLite fixtures and the simulated web dispatch boundary; never

--- a/docs/local-ts-api.md
+++ b/docs/local-ts-api.md
@@ -16,8 +16,9 @@ when implementing or debugging a specific endpoint.
   not completed.
 - Synchronous reads and commands return `200 OK`; invalid input, unavailable
   workers, and start failures return an error instead of a misleading `202`.
-- Browser updates arrive through `GET /v1/events/stream`, then TanStack Query
-  refetches the affected projections.
+- Browser updates arrive through `GET /v1/events/stream`; TanStack Query exact-
+  patches truthful detail payloads and boundedly refetches affected projections
+  when membership, aggregation, or missing event data requires reconciliation.
 - Credentials are handled through the local credential boundary, never through
   ordinary settings payloads.
 
@@ -36,6 +37,7 @@ when implementing or debugging a specific endpoint.
 | --- | --- | --- |
 | Profile and configuration | `/v1/profile`, `/v1/settings`, `/v1/credentials`, `/v1/providers/models`, `/v1/discovery/settings`, `/v1/browser-capabilities`, `/v1/extension/pairing-token` | Synchronous reads and validated patches |
 | Jobs and evidence | `/v1/jobs`, `/v1/jobs/:jobKey`, `/v1/evidence-map`, `/v1/artifacts` | Projection-backed reads |
+| Scoring keywords and feedback learning | `/v1/scoring/keywords`, `/v1/learning/recommendations`, `/v1/learning/policies/materials` | Current score-version aggregation plus explicit review and versioned policy history |
 | Review and outcomes | `/v1/apply/review-queue`, `/v1/jobs/:jobKey/apply-review/decision`, `/v1/jobs/:jobKey/repeat-application/override`, `/v1/outcomes` | Explicit review commands plus read models |
 | Workflow operations | `/v1/pipeline/actions/run-stage`, `/v1/pipeline/operations`, `/v1/workflow-runs`, `/v1/health` | `202` for accepted asynchronous work; `200` for projection-backed and runtime-backed reads/sync commands |
 | Realtime | `/v1/events/stream` | Server-Sent Events with replay and reconnect support |
@@ -60,6 +62,23 @@ field.
 The jobs list and detail routes read stable projections. Lifecycle changes—hide,
 restore, delete, score correction, stage retry, and per-job actions—are explicit
 commands. See [Jobs & Materials](api/jobs-and-materials.md).
+
+Internal list/detail identity is the tenant-scoped stable `JobId`; posting URLs
+are locators resolved only at explicit import or API boundaries. Employer and
+Source remain independent facts. `GET /v1/scoring/keywords` aggregates indexed,
+normalized keywords from the current score version, and `GET /v1/jobs` accepts
+an exact `normalizedScoreKeyword` filter using those returned keys.
+
+## Feedback Learning And Policy History
+
+`GET /v1/learning/recommendations` and its evidence route expose only bounded,
+privacy-safe derived evidence. The review route requires an explicit accepted
+or rejected decision. Acceptance creates a versioned Materials policy revision;
+rejection changes no policy. `GET /v1/learning/policies/materials` exposes the
+allowlisted current/superseded history, while the rollback route appends a new
+user-requested revision that restores an earlier version. These routes never
+start scoring, tailoring, Apply, or artifact work. See
+[Jobs & Materials](api/jobs-and-materials.md#feedback-learning-and-materials-policy).
 
 ## Dashboard, Analytics, And Operational Metrics
 
@@ -96,6 +115,11 @@ an exact `workflowType` match, inclusive `startedSince`, and exclusive
 `startedBefore`. Timestamp bounds must be UTC ISO-8601 timestamps; malformed
 optional filter values are ignored. The list response echoes the effective
 filters in its `filter` object (`null` when an optional filter is inactive).
+
+Discover, job preparation, and Apply share the same statuses, lifecycle
+timeline, terminal-state rules, and cancellation command. Cancellation is
+cooperative and idempotent: repeated requests do not replace terminal results
+or emit duplicate cancellation transitions.
 
 ## Profile Resume Preview
 

--- a/docs/user/enrichment-and-extraction.md
+++ b/docs/user/enrichment-and-extraction.md
@@ -6,6 +6,12 @@ state, and a provenance-bearing content snapshot. Extraction is the controlled
 work used to obtain those facts from an API, posting page, browser render, or
 user-mediated capture.
 
+Every accepted job receives one system-generated `JobId` inside its tenant.
+Posting and application URLs remain external locators: changing a URL does not
+change identity or detach the job's score, materials, stages, outcomes, events,
+or workflow references. URL resolution happens only at explicit API, import,
+capture, or migration boundaries.
+
 ## How A Lead Becomes A Usable Snapshot
 
 Enrichment separates “we found a listing” from “we have enough trustworthy
@@ -82,6 +88,9 @@ Several records participate, but they do not own the same fact:
 - **Discovery owns intake and identity:** source observations, canonical job
   identity, deduplication, source-native identifiers, manual capture, and the
   source registry.
+- **Employer and source are independent facts:** Employer identifies the
+  hiring organization; Source identifies where JobCtrl observed the posting.
+  Neither is guessed from the other or from a URL during projection reads.
 - **Enrichment owns posting detail:** fetch attempts, full description,
   application URL, content snapshots, extraction provenance, confidence, and
   active-state verification.
@@ -91,8 +100,10 @@ Several records participate, but they do not own the same fact:
 - **Operations owns the read projection:** list/detail pages read projection
   rows. A `GET` does not fetch the posting again or repair missing enrichment.
 
-Canonical job/enrichment rows and `posting_snapshot_sets` live in
-`jobctrl.db`. Events explain what changed, while projections make the latest
+Canonical job/enrichment rows are keyed by `(tenant_id, job_id)` in
+`jobctrl.db`; posting URLs are unique locators rather than primary or foreign
+keys. `posting_snapshot_sets` and source observations retain their own
+provenance. Events explain what changed, while projections make the latest
 accepted state efficient to read. Raw captured content is not copied into broad
 event payloads.
 

--- a/docs/user/materials-and-tailoring.md
+++ b/docs/user/materials-and-tailoring.md
@@ -109,6 +109,25 @@ Review its linked profile and requirement evidence before relying on it; the
 current maturity boundary is described in
 [Daily Workflow → Generate Interview Prep](normal-flows.md).
 
+## Policy History And Rollback
+
+The Dashboard's **Learning recommendations** card is a review boundary, not an
+automatic tuning loop. Accepting a pending, active recommendation appends a new
+Materials tailoring-policy revision linked to its recommendation and review;
+rejecting it leaves the current revision unchanged. Recommendations whose
+source evidence was tombstoned are inactive and cannot be accepted until they
+are deterministically re-derived.
+
+**Tailoring policy history** lists every current and superseded revision,
+allowlisted learned rule, safe recommendation/review reference, restore
+provenance, and creation time. Restoring a superseded version appends the next
+version with `user_requested` provenance; it never edits or deletes the target
+or current row. Acceptance and restore affect future tailoring-policy
+resolution only. They do not re-score jobs, re-tailor existing materials,
+replace accepted artifacts, alter the Candidate Profile, or change Apply
+decisions. Use the normal explicit re-tailor action when you want existing work
+to adopt the current policy.
+
 ## Source Of Truth And Ownership
 
 The inputs have intentionally different authority:
@@ -159,6 +178,10 @@ the local-file boundary.
    supersedes the prior active generation while preserving history. If a live
    threshold or blocker makes materials ineligible, JobCtrl soft-suppresses
    them from active/Apply surfaces rather than deleting the audit record.
+8. **Review policy changes separately.** Compatible accepted feedback may
+   produce a pending recommendation. Acceptance or restore appends a policy
+   revision, while rejection or a failed restore leaves the current revision
+   and all generated artifacts unchanged.
 
 The same preservation rule applies to stored interview prep and outreach draft
 generations: a failed replacement does not destroy the last accepted record.
@@ -168,7 +191,7 @@ generations: a failed replacement does not destroy the last accepted record.
 | Layer | Pointer |
 | --- | --- |
 | User workflow | [Daily Workflow → Generate And Inspect Materials](normal-flows.md) and [Apply → Materials And Resume Rendering](apply.md#materials-and-resume-rendering). |
-| HTTP contract | Artifact list/detail/preview routes, `/v1/resume-templates`, and per-job generate/re-tailor actions; see [Jobs & Materials API](../api/jobs-and-materials.md) and the [complete artifacts contract](../api/complete-contract.md#artifacts-and-tailoring-audit). Apply Review routes are owned by [Apply](apply.md). |
+| HTTP contract | Artifact list/detail/preview routes, `/v1/resume-templates`, per-job generate/re-tailor actions, and `/v1/learning/recommendations` plus `/v1/learning/policies/materials`; see [Jobs & Materials API](../api/jobs-and-materials.md) and the [complete learning contract](../api/complete-contract.md#feedback-learning-and-policy-history). Apply Review routes are owned by [Apply](apply.md). |
 | Worker implementation | `workers/automation/src/jobctrl/domain/materials/`, the `tailor.py` and `cover_letter.py` paths in `workers/automation/src/jobctrl/scoring/`, and `workers/automation/src/jobctrl/infrastructure/materials/`. |
 | API and web implementation | In `apps/api/src/`: `resume-review-drafts.ts`, `resume-templates.ts`, and `read-model.ts`; in the web app: `apps/web/src/contexts/materials/`, `apps/web/src/views/artifacts/`, and `apps/web/src/views/apply-review/`. |
 | Deep architecture | [Employer Analysis & Materials Audit](../architecture/materials.md), [Tailoring Contract](../architecture/tailoring.md), and [Stage Walkthrough → Tailor](../architecture/pipeline/stages.md#tailor). |

--- a/docs/user/normal-flows.md
+++ b/docs/user/normal-flows.md
@@ -527,7 +527,8 @@ is on the [Security](security.md) page.
 
 Useful web app views:
 
-- Dashboard for high-level counts and source health.
+- Dashboard for high-level counts, source health, pending learning
+  recommendations, and the versioned Materials policy history.
 - Pipelines for the selected execution, execution sweep, unrelated global
   backlog, source-family intake, reconciliation, stage outcomes, capacity,
   approximate task-queue pressure, ETA, freshness, and active work.
@@ -536,7 +537,9 @@ Useful web app views:
   application outcome rows and projections only; groups below the minimum
   sample count stay count-only.
 - Jobs for triage and the bookmarkable Job Detail workspace.
-- Runs for workflow history and route-level run timelines.
+- Runs for the shared Discover, preparation, and Apply history, using one status
+  vocabulary, terminal-state contract, cancellation control, and route-level
+  timeline.
 - Evidence for profile-evidence reuse, generated-material usage, and gaps.
 - Artifacts for generated files and same-job artifact comparisons.
 - Apply Review for approval and resume edits.
@@ -566,8 +569,16 @@ you pass `--acknowledge`, which marks the displayed digest as reviewed.
 
 </WorkflowSurfacePanel>
 
+A cancel request is cooperative and asynchronous. Repeating it is harmless;
+the projected run remains inspectable and an already completed, failed,
+canceled, timed-out, or terminated result is never overwritten by a synthetic
+canceled state. The same contract applies whether cancellation starts in
+Pipelines or Runs.
+
 [Outcomes & Feedback](outcomes-and-feedback.md) explains which application and
-interview facts become canonical outcomes and how analytics read them.
+interview facts become canonical outcomes, how analytics read them, and how
+explicit reviewed feedback can produce a pending recommendation without
+changing behavior automatically.
 
 ## 11. Keep Contacts (Optional)
 

--- a/docs/user/outcomes-and-feedback.md
+++ b/docs/user/outcomes-and-feedback.md
@@ -4,7 +4,9 @@ An application outcome is a reviewed local record of what happened after you
 applied, such as a reply, interview, rejection, offer, withdrawal, or no
 response. Feedback includes your manual corrections and bounded suggestions
 from linked evidence; it improves the audit trail and analytics without
-changing scoring, ranking, thresholds, or Apply eligibility.
+changing scoring, ranking, thresholds, or Apply eligibility on its own. An
+owning policy changes only through an explicit score correction, approved role
+rule, or accepted learning recommendation.
 
 ## How Email Becomes An Outcome Suggestion
 
@@ -47,6 +49,32 @@ it does not ask a model to read the inbox and decide what happened.
 
 This keeps private mail access narrow and preserves the difference between a
 machine suggestion, a reviewed lifecycle fact, and descriptive analytics.
+
+## Explicit Feedback Learning
+
+Operations exposes one privacy-bounded `FeedbackSignal` union over explicit
+score corrections, recorded Discovery feedback, approved role-match
+suggestions, and accepted structured tailoring feedback. These records carry
+canonical IDs, revisions, timestamps, closed rule codes, and non-sensitive
+evidence references. They never copy raw notes, resume or job-description text,
+prompts, model output, mail bodies, credentials, or local paths.
+
+The first derived recommendation type is a closed Materials tailoring-rule
+revision. JobCtrl creates a pending recommendation only when at least three
+compatible accepted tailoring signals span at least two jobs, no unresolved
+contradiction remains, and the derivation version has a passing deterministic
+evaluation fixture. Application outcomes may support later evaluation, but an
+outcome cannot create or prove a policy improvement by itself. Score
+corrections and approved role rules already passed an explicit user decision,
+so their owning Scoring or Discovery history does not require a second review.
+
+The Dashboard shows the pending recommendation, observed-versus-required
+sample counts, confidence limit, allowlist/derivation versions, and bounded
+evidence IDs. Accept creates a new context-owned Materials policy revision;
+reject leaves the current policy unchanged. Neither action re-scores jobs,
+re-tailors artifacts, changes Apply eligibility, or rewrites history. Corrected,
+deleted, or tombstoned source signals trigger deterministic re-derivation while
+preserving earlier reviews and accepted policy revisions.
 
 ## What You Can See And Control
 
@@ -95,6 +123,9 @@ Both may appear in the same job audit timeline without sharing ownership.
 - **Analytics** is a read model over canonical outcomes and accepted material
   metadata. It cannot write back to a score, policy, profile, discovery query,
   or application decision.
+- **Learning recommendations** remain separate from canonical feedback sources.
+  Their evidence and contradictions are reproducible, and no recommendation
+  changes behavior before explicit acceptance creates an owning revision.
 
 The job detail audit history is allow-listed explanatory history, not a raw
 event dump. It intentionally excludes private notes, mail bodies, local paths,
@@ -123,16 +154,18 @@ and debug payloads.
 4. The suggestion decision remains available for accuracy reporting, while the
    reviewed outcome becomes the job's lifecycle fact.
 
-Outcome feedback does not retrain a model or automatically adjust a scoring
-policy in the current product. Score corrections have their own explicit
-lifecycle under [Scoring](scoring-and-employer-analysis.md).
+Outcome feedback does not retrain a model or automatically adjust a scoring or
+tailoring policy. Score corrections have their own explicit lifecycle under
+[Scoring](scoring-and-employer-analysis.md); accepted tailoring recommendations
+and rollback are documented under
+[Materials & Tailoring](materials-and-tailoring.md#policy-history-and-rollback).
 
 ## Implementation And API Pointers
 
 | Layer | Pointer |
 | --- | --- |
 | User surfaces | `/jobs/:jobId`, `/dashboard`, and `/analytics`; the practical monitoring loop is in [Daily Workflow → Inspect Progress](normal-flows.md). |
-| HTTP contract | `GET /v1/outcomes`, per-job outcome reads/writes, suggestion decisions, `POST /v1/outcomes/gmail/scan`, and `GET /v1/analytics/outcomes`; see [Jobs & Materials API](../api/jobs-and-materials.md#apply-review-and-outcomes) and the [complete outcomes contract](../api/complete-contract.md#apply-review-and-outcomes). |
+| HTTP contract | `GET /v1/outcomes`, per-job outcome reads/writes, suggestion decisions, `POST /v1/outcomes/gmail/scan`, `GET /v1/analytics/outcomes`, and the `/v1/learning/*` review/history routes; see [Jobs & Materials API](../api/jobs-and-materials.md) and the [complete contract](../api/complete-contract.md#feedback-learning-and-policy-history). |
 | API implementation | Outcome routes and projections are composed in `apps/api/src/server.ts`, `apps/api/src/read-model.ts`, and `apps/api/src/projections.ts`. |
 | Web implementation | `apps/web/src/contexts/apply/components/ApplicationOutcomes.tsx`, Operations outcome hooks/keys, `views/dashboard/`, and `views/analytics/`. |
 | Deep architecture | [Apply Feedback & Projections](../architecture/read-model.md#apply-review-and-outcome-feedback) and its [sensitive projection boundaries](../architecture/read-model.md#evidence-analytics-and-compensation). |

--- a/docs/user/scoring-and-employer-analysis.md
+++ b/docs/user/scoring-and-employer-analysis.md
@@ -99,6 +99,18 @@ applies the same score bands.
   reviewed score version and a calibration anchor. An explicit re-score runs
   the current policy again against the current canonical inputs.
 
+### Indexed Scoring Keywords
+
+Each score version stores its keywords in a normalized, indexed relation keyed
+by tenant, job, and score version. Historical versions remain auditable, but
+Jobs filtering and `GET /v1/scoring/keywords` use only the score version that
+the current projection renders. The aggregation returns both the canonical
+normalized key and a display spelling with its score version and job count.
+
+`GET /v1/jobs?normalizedScoreKeyword=...` accepts the exact canonical key from
+that aggregation. Normalization is owned by persistence, including Unicode
+case-folding; clients do not guess or re-normalize display text.
+
 ## What You Can See And Control
 
 Scoring runs inside Discover preparation. Review it on the current product
@@ -152,6 +164,10 @@ reason to correct or investigate it.
   newer policy.
 - **Operations owns display projections.** Jobs reads expose persisted analysis
   and score evidence. They do not call a model or recompute a score on request.
+- **Explicit feedback remains history until an owning policy says otherwise.**
+  Score corrections and their anchors are auditable inputs, but Apply candidate
+  acquisition does not apply a second feedback-based rank adjustment or let an
+  unaccepted learning recommendation reorder jobs.
 
 The model may extract structured evidence and propose fit. The final persisted
 decision is resolved through the versioned scoring policy, so a raw model
@@ -183,7 +199,7 @@ not for an employer ranking people.
 | Layer | Pointer |
 | --- | --- |
 | User workflow | [Daily Workflow → Review Jobs](normal-flows.md) and [Discovery → Employer Analysis Perspectives](discovery.md#employer-analysis-perspectives). |
-| HTTP contract | Jobs list/detail reads, `POST /v1/jobs/:key/score-correction`, per-job current-policy re-score, and bulk/stale-score actions; see [Jobs & Materials API](../api/jobs-and-materials.md#jobs-and-evidence) and the [complete lifecycle contract](../api/complete-contract.md#jobs-read-model-and-lifecycle). |
+| HTTP contract | Jobs list/detail reads, `GET /v1/scoring/keywords`, `POST /v1/jobs/:key/score-correction`, per-job current-policy re-score, and bulk/stale-score actions; see [Jobs & Materials API](../api/jobs-and-materials.md#jobs-and-evidence) and the [complete lifecycle contract](../api/complete-contract.md#jobs-read-model-and-lifecycle). |
 | Worker implementation | `workers/automation/src/jobctrl/scoring/` (`employer_analysis.py`, `scorer.py`) and `workers/automation/src/jobctrl/domain/scoring/`; canonical analysis gates and persistence live under `workers/automation/src/jobctrl/domain/materials/analysis*` and `workers/automation/src/jobctrl/infrastructure/materials/employer_analysis_repository.py`. |
 | Product components | `apps/web/src/contexts/scoring/`, `apps/web/src/contexts/materials/components/EmployerAnalysisPanel.tsx`, and the Jobs detail/triage views. |
 | Deep architecture | [Scoring](../architecture/scoring.md), [Materials → Canonical Employer Analysis](../architecture/materials.md#canonical-employer-analysis), and [Stage Walkthrough → Score](../architecture/pipeline/stages.md#score). |


### PR DESCRIPTION
## Summary

- document the exact v6-to-v7 JobId cutover, paired rollback, and exact-v7 runtime boundary
- document shared workflow history and cancellation plus tenant-scoped realtime cache reconciliation
- document current-version scoring keywords and explicit feedback recommendation, policy, and rollback behavior
- add the final cumulative high-risk validation checklist without declaring the roadmap complete

## Validation

- Node 22.21.1 docs build passed
- 9,651 emitted documentation references resolved
- documentation redirects passed
- git diff --check passed
- independent review: Gate PASS; three Medium wording/QA corrections are being delivered in a separate child PR above this one

## Safety

- documentation only
- no user database, application, profile, artifact, or submission path was exercised