### PR TITLE
test: stabilize Jobs saved-view interaction

### DIFF
--- a/apps/web/src/views/jobs/JobsView.test.tsx
+++ b/apps/web/src/views/jobs/JobsView.test.tsx
@@ -810,7 +810,7 @@ describe("<JobsView> bulk delete integration", () => {
     expect(rowForTitle(applyJob.title)).toHaveClass(
       "data-grid-row-tone-warning",
     );
-  });
+  }, 15_000);
 
   it("hydrates active saved table view filters when the jobs view remounts", async () => {
     const vonageJob: JobSummary = {


### PR DESCRIPTION
## Summary

- give the interaction-heavy Jobs saved-view regression a scoped 15-second timeout
- keep production behavior and the global Vitest timeout unchanged
- address the reproduced TypeScript CI failure from PR #700 in a new child above PR #701

## Root cause

The test passes in about one second alone, but exceeded the default five-second timeout under the 324-file web suite on GitHub Actions.

## Validation

- focused Node 22 JobsView Vitest: 1 passed, 29 skipped
- git diff --check passed
- independent SOL review: Gate PASS, no findings