### PR TITLE
docs: correct v7 review and QA semantics

### DIFF
--- a/docs/api/complete-contract.md
+++ b/docs/api/complete-contract.md
@@ -298,8 +298,9 @@ ID returns `400`; an unknown tenant-scoped recommendation returns `404`.
 `{ decision: "accepted" | "rejected" }`. Acceptance creates a new versioned
 Materials tailoring-policy revision and returns its positive `policyVersion`.
 Rejection records the review and returns `policyVersion: null`; it changes no
-policy. Replayed/conflicting/stale review attempts return a bounded error rather
-than applying behavior twice.
+policy. An identical structured replay returns the same idempotent success;
+conflicting or stale review attempts return a bounded error rather than
+applying behavior twice.
 
 `GET /v1/learning/policies/materials?page=<n>&pageSize=<1..100>` returns
 allowlisted current/superseded revision summaries: version, learned rules,

--- a/docs/api/jobs-and-materials.md
+++ b/docs/api/jobs-and-materials.md
@@ -21,9 +21,11 @@ For field-level schemas and every route variant, use the
 List and detail endpoints read projection rows. They do not recompute scores,
 parse salary text, or replay events during a request.
 
-`jobKey` is the tenant-scoped stable `JobId`, not a posting URL. User/import
-boundaries may resolve a URL to that ID explicitly, but internal job routes and
-foreign references remain ID-shaped. `GET /v1/jobs` accepts
+`jobKey` resolves at the browser API boundary to the tenant-scoped stable
+`JobId`. Canonical clients send that ID; the explicit API/import boundary may
+also accept a posting or application URL as an external locator and resolve it
+to the same ID. Internal command payloads and foreign references remain
+ID-shaped. `GET /v1/jobs` accepts
 `normalizedScoreKeyword` using the exact key returned by
 `GET /v1/scoring/keywords`; current filtering never mixes historical score
 versions into the result.

--- a/docs/local-reliability-qa.md
+++ b/docs/local-reliability-qa.md
@@ -119,8 +119,8 @@ corepack pnpm docs:build
 git diff --check
 ```
 
-The product path must then verify in the disposable/demo workspace that Runs
-shows the shared Discover/preparation/Apply timeline; repeated cancellation
+The product path must then verify in a disposable seeded API/web workspace that
+Runs shows the shared Discover/preparation/Apply timeline; repeated cancellation
 does not overwrite a terminal result; targeted events update an open job,
 registered artifact, and workflow detail without resetting filters, selection,
 pagination, or scroll; and Dashboard supports recommendation evidence,
@@ -130,6 +130,11 @@ score and accepted artifact remain unchanged until those commands are invoked.
 The gate must also prove that no feedback decision or restore automatically
 starts scoring, tailoring, Apply, or artifact work. Do not perform a real
 application submission or mutate a real user database during this QA.
+
+The browser-local public demo may cover realtime state preservation, but its
+learning capabilities are intentionally unavailable. Recommendation review,
+policy acceptance/rejection, and rollback must therefore run through the seeded
+non-demo local API/web fixture.
 
 ### Repeat-application prevention
 


### PR DESCRIPTION
## Summary

- document identical recommendation-review replay as idempotent success
- clarify that URL locators may be resolved only at explicit API/import boundaries while internal identity remains JobId
- move learning-policy product QA to the seeded non-demo API/web fixture because public demo capabilities are intentionally unavailable

## Validation

- Node 22.21.1 docs build passed
- 9,651 emitted documentation references resolved
- documentation redirects passed
- git diff --check passed

## Review provenance

These corrections resolve all three Medium findings from the SOL review of PR #701. No Blocker or High findings were reported.