### PR TITLE
fix: synchronize exact v7 schema manifests

### DIFF
--- a/apps/api/test/schema-version-guard.test.ts
+++ b/apps/api/test/schema-version-guard.test.ts
@@ -149,7 +149,7 @@ describe("schema version guard at DB open", () => {
       version: SUPPORTED_SCHEMA_VERSION,
       objectCount: 242,
       tableCount: 110,
-      fingerprint: "55d88c87aaf9bec6c8686ee0e40dba31ca19aaaa5767042f9376f5e2756fecfd",
+      fingerprint: "775312f0ec2640a2a87889602886c90e21a49e06fffc53cf26c435856247da97",
     });
   });
 });


### PR DESCRIPTION
## What changed

- synchronize the TypeScript exact-v7 schema fingerprint with the canonical SQL and Python manifest
- update the schema-version guard expectation for the same canonical fingerprint

## Why

The terminal-review trigger changed the canonical schema fingerprint, but the TypeScript runtime still required the prior hash. Fresh exact-v7 databases were therefore rejected by API and launcher reopen checks.

## Validation

- Node 22 API Vitest: 3 files, 53 tests passed
- focused native launcher v6-to-v7 reopen test: passed
- git diff --check

This ready child resolves the #706 TypeScript and Darwin launcher CI failures.