### PR TITLE
fix: restore JobId v7 continuation onto main

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,6 +93,11 @@ and explain any intentional stacked deferral in the PR body.
 - **Subagent spawning:** Use subagents only for genuinely independent work or
   for the review/QA gates required by the validation tiers below. Do not add
   coordination overhead to work that is faster to complete directly.
+  Within one task, create at most one agent of each required type/role and
+  reuse that agent via follow-up turns for related work, fixes, and reruns.
+  Replace an agent only when it is unavailable/terminated or the new work is
+  genuinely a different task; never use a replacement to obtain another
+  opinion or avoid continuity.
 
 ### Root-Cause And Auditability Discipline
 
@@ -179,9 +184,9 @@ gate across the whole stack. A phase that changes an active high-risk path or is
 released independently follows its normal tier immediately.
 
 Run independent gates once after implementation and focused verification. Rerun
-a failed gate after addressing its Blocker/High findings; do not repeat passing
-gates for cosmetic edits or unresolved Medium/Low observations unless the edit
-could affect the verified behavior.
+a failed gate with the same reviewer/QA agent after addressing its Blocker/High
+findings; do not repeat passing gates for cosmetic edits or unresolved Medium/
+Low observations unless the edit could affect the verified behavior.
 
 Before calling work done:
 

--- a/README.md
+++ b/README.md
@@ -169,6 +169,10 @@ evidence, qualifications, and the complete capability matrix.
   by default and uses the configured cron only after you enable it.
 - Enrich postings with full descriptions, canonical posting URLs, and apply
   URLs.
+- Keep each job under one tenant-scoped, immutable `JobId`. Posting and
+  application URLs are locators resolved only at explicit capture/import/API
+  boundaries, so a URL change cannot detach scores, materials, outcomes, or
+  workflow history. Source and employer remain separate persisted facts.
 - Fetch politely: anonymous discovery/enrichment requests route through one
   gateway that honors `robots.txt`, paces each host, bounds each run's request
   budget, and sends an honest `User-Agent` that never impersonates a browser.
@@ -185,6 +189,9 @@ evidence, qualifications, and the complete capability matrix.
   reflow into labelled cards at narrower widths.
 - Score jobs as an applicant-side triage aid with auditable evidence — never
   employer-side screening.
+- Persist normalized scoring keywords per score version. The jobs API filters
+  by the canonical normalized key, while `/v1/scoring/keywords` exposes the
+  current-version aggregation used by typed clients.
 - Generate tailored resumes, cover letters, PDFs, and review artifacts.
 - Triage jobs through the real **Active**, **Deleted**, and **Hidden** queues.
   The default Active view keeps source and warning columns available but hidden,
@@ -212,6 +219,15 @@ evidence, qualifications, and the complete capability matrix.
   remains before offering to set up a replacement run; setup never starts work
   by itself. Runs keeps the durable workflow history; Jobs and route-level
   detail workspaces keep record-specific evidence and actions adjacent.
+- Inspect Discover, preparation, and Apply through the same Runs vocabulary,
+  timeline, terminal-state rules, and cancellation control. Repeated cancel
+  requests are harmless, and an already-terminal result remains inspectable.
+- Review privacy-bounded learning recommendations on the Dashboard. JobCtrl
+  derives them only from explicit reviewed signals, requires compatible
+  evidence across jobs, and changes Materials behavior only after you accept a
+  recommendation. Tailoring policy history is versioned, superseded revisions
+  remain inspectable, and restore creates a new append-only revision without
+  re-scoring jobs or replacing artifacts.
 - Keep recruiter, hiring-manager, and referrer contact records per company or
   application, each fact carrying its provenance, with CSV import. Draft
   truthful, reviewable outreach messages under the same anti-fabrication gates
@@ -456,6 +472,14 @@ invoke the same Python command through the checkout as described in
 This writes `~/.jobctrl/backups/jobctrl-<timestamp>.db` via SQLite
 `VACUUM INTO` and never deletes anything (`--output <path>` to choose a
 target).
+
+The native v7 update performs its own paired migration safeguard. For an
+admitted v6 installation it stops and quiesces JobCtrl, backs up both
+`jobctrl.db` and bundled Temporal state, builds and verifies the JobId-keyed v7
+candidate in one transaction, then activates the verified pair. Any failed
+build, verification, or activation restores the previous pair. The API and
+worker run exact v7 only; there is no mixed-version, dual-write, or permanent
+fallback runtime.
 
 <details>
 <summary><b>Restore steps</b></summary>

--- a/apps/api/src/learning-recommendations.ts
+++ b/apps/api/src/learning-recommendations.ts
@@ -1,5 +1,8 @@
 import {
+  LearningRecommendationEvidenceListResponseSchema,
   LearningRecommendationListResponseSchema,
+  type LearningRecommendationEvidenceListQuery,
+  type LearningRecommendationEvidenceListResponse,
   type LearningRecommendationListQuery,
   type LearningRecommendationListResponse,
 } from "./contracts.js";
@@ -32,6 +35,15 @@ interface RecommendationSummaryRow extends Record<string, unknown> {
   supporting_evidence_count: number;
   contradicting_evidence_count: number;
   tombstone_count: number;
+}
+
+interface RecommendationEvidenceLinkRow extends Record<string, unknown> {
+  signal_id: string;
+  evidence_role: "supporting" | "contradicting";
+  source_kind: "tailoring_feedback_signal";
+  source_revision: number;
+  job_id: string;
+  recorded_at: string;
 }
 
 export function listLearningRecommendations(
@@ -131,4 +143,81 @@ function listLearningRecommendationsInSnapshot(
     total,
     totalPages: total === 0 ? 0 : Math.ceil(total / query.pageSize),
   });
+}
+
+export function listLearningRecommendationEvidence(
+  db: SqliteDatabase,
+  recommendationId: string,
+  query: LearningRecommendationEvidenceListQuery,
+): LearningRecommendationEvidenceListResponse | null {
+  return db.transaction(() => {
+    const recommendation = getRow<{ recommendation_id: string }>(
+      db,
+      `SELECT recommendation_id
+         FROM learning_recommendations
+        WHERE tenant_id = ?
+          AND recommendation_id = ?`,
+      [DEFAULT_TENANT, recommendationId],
+    );
+    if (!recommendation) {
+      return null;
+    }
+
+    const total = Number(
+      getRow<{ count: number }>(
+        db,
+        `SELECT COUNT(*) AS count
+           FROM learning_recommendation_evidence AS evidence
+           JOIN learning_recommendation_evidence_jobs AS evidence_job
+             ON evidence_job.tenant_id = evidence.tenant_id
+            AND evidence_job.recommendation_id = evidence.recommendation_id
+            AND evidence_job.signal_id = evidence.signal_id
+          WHERE evidence.tenant_id = ?
+            AND evidence.recommendation_id = ?`,
+        [DEFAULT_TENANT, recommendationId],
+      )?.count ?? 0,
+    );
+    const offset = (query.page - 1) * query.pageSize;
+    const rows = allRows<RecommendationEvidenceLinkRow>(
+      db,
+      `SELECT evidence.signal_id,
+              evidence.evidence_role,
+              evidence.source_kind,
+              evidence.source_revision,
+              evidence_job.job_id,
+              evidence.recorded_at
+         FROM learning_recommendation_evidence AS evidence
+         JOIN learning_recommendation_evidence_jobs AS evidence_job
+           ON evidence_job.tenant_id = evidence.tenant_id
+          AND evidence_job.recommendation_id = evidence.recommendation_id
+          AND evidence_job.signal_id = evidence.signal_id
+        WHERE evidence.tenant_id = ?
+          AND evidence.recommendation_id = ?
+        ORDER BY CASE evidence.evidence_role
+                   WHEN 'supporting' THEN 0
+                   ELSE 1
+                 END,
+                 evidence.recorded_at ASC,
+                 evidence.signal_id ASC,
+                 evidence_job.job_id ASC
+        LIMIT ? OFFSET ?`,
+      [DEFAULT_TENANT, recommendationId, query.pageSize, offset],
+    );
+    return LearningRecommendationEvidenceListResponseSchema.parse({
+      ok: true,
+      recommendationId,
+      evidence: rows.map((row) => ({
+        signalId: row.signal_id,
+        evidenceRole: row.evidence_role,
+        sourceKind: row.source_kind,
+        sourceRevision: Number(row.source_revision),
+        jobId: row.job_id,
+        recordedAt: row.recorded_at,
+      })),
+      page: query.page,
+      pageSize: query.pageSize,
+      total,
+      totalPages: total === 0 ? 0 : Math.ceil(total / query.pageSize),
+    });
+  })();
 }

--- a/apps/api/src/learning-recommendations.ts
+++ b/apps/api/src/learning-recommendations.ts
@@ -1,0 +1,134 @@
+import {
+  LearningRecommendationListResponseSchema,
+  type LearningRecommendationListQuery,
+  type LearningRecommendationListResponse,
+} from "./contracts.js";
+import { getRow, allRows, type SqliteDatabase } from "./db.js";
+
+const DEFAULT_TENANT = "local";
+
+interface RecommendationSummaryRow extends Record<string, unknown> {
+  recommendation_id: string;
+  derivation_version: number;
+  evaluation_fixture_version: number;
+  context: "materials";
+  policy_kind: "tailoring_rule";
+  signal_kind:
+    | "style_preference"
+    | "factual_correction"
+    | "claim_policy_correction"
+    | "keyword_strategy"
+    | "provenance_dispute";
+  rule_key: string;
+  rule_value: string;
+  allowlist_version: number;
+  status: "pending";
+  observed_signal_count: number;
+  observed_job_count: number;
+  minimum_signal_count: number;
+  minimum_job_count: number;
+  confidence_limit: "sample_gated_no_population_inference";
+  derived_at: string;
+  supporting_evidence_count: number;
+  contradicting_evidence_count: number;
+  tombstone_count: number;
+}
+
+export function listLearningRecommendations(
+  db: SqliteDatabase,
+  query: LearningRecommendationListQuery,
+): LearningRecommendationListResponse {
+  return db.transaction(() =>
+    listLearningRecommendationsInSnapshot(db, query),
+  )();
+}
+
+function listLearningRecommendationsInSnapshot(
+  db: SqliteDatabase,
+  query: LearningRecommendationListQuery,
+): LearningRecommendationListResponse {
+  const total = Number(
+    getRow<{ count: number }>(
+      db,
+      `SELECT COUNT(*) AS count
+         FROM learning_recommendations
+        WHERE tenant_id = ?`,
+      [DEFAULT_TENANT],
+    )?.count ?? 0,
+  );
+  const offset = (query.page - 1) * query.pageSize;
+  const rows = allRows<RecommendationSummaryRow>(
+    db,
+    `SELECT recommendation.recommendation_id,
+            recommendation.derivation_version,
+            recommendation.evaluation_fixture_version,
+            recommendation.context,
+            recommendation.policy_kind,
+            recommendation.signal_kind,
+            recommendation.rule_key,
+            recommendation.rule_value,
+            recommendation.allowlist_version,
+            recommendation.status,
+            recommendation.observed_signal_count,
+            recommendation.observed_job_count,
+            recommendation.minimum_signal_count,
+            recommendation.minimum_job_count,
+            recommendation.confidence_limit,
+            recommendation.derived_at,
+            (
+              SELECT COUNT(*)
+              FROM learning_recommendation_evidence AS evidence
+              WHERE evidence.tenant_id = recommendation.tenant_id
+                AND evidence.recommendation_id = recommendation.recommendation_id
+                AND evidence.evidence_role = 'supporting'
+            ) AS supporting_evidence_count,
+            (
+              SELECT COUNT(*)
+              FROM learning_recommendation_evidence AS evidence
+              WHERE evidence.tenant_id = recommendation.tenant_id
+                AND evidence.recommendation_id = recommendation.recommendation_id
+                AND evidence.evidence_role = 'contradicting'
+            ) AS contradicting_evidence_count,
+            (
+              SELECT COUNT(*)
+              FROM learning_recommendation_tombstones AS tombstone
+              WHERE tombstone.tenant_id = recommendation.tenant_id
+                AND tombstone.recommendation_id = recommendation.recommendation_id
+            ) AS tombstone_count
+       FROM learning_recommendations AS recommendation
+      WHERE recommendation.tenant_id = ?
+      ORDER BY recommendation.derived_at DESC,
+               recommendation.recommendation_id ASC
+      LIMIT ? OFFSET ?`,
+    [DEFAULT_TENANT, query.pageSize, offset],
+  );
+  return LearningRecommendationListResponseSchema.parse({
+    ok: true,
+    recommendations: rows.map((row) => ({
+      recommendationId: row.recommendation_id,
+      derivationVersion: Number(row.derivation_version),
+      evaluationFixtureVersion: Number(row.evaluation_fixture_version),
+      context: row.context,
+      policyKind: row.policy_kind,
+      signalKind: row.signal_kind,
+      ruleKey: row.rule_key,
+      ruleValue: row.rule_value,
+      allowlistVersion: Number(row.allowlist_version),
+      status: row.status,
+      active: Number(row.tombstone_count) === 0,
+      observedSignalCount: Number(row.observed_signal_count),
+      observedJobCount: Number(row.observed_job_count),
+      minimumSignalCount: Number(row.minimum_signal_count),
+      minimumJobCount: Number(row.minimum_job_count),
+      confidenceLimit: row.confidence_limit,
+      supportingEvidenceCount: Number(row.supporting_evidence_count),
+      contradictingEvidenceCount: Number(row.contradicting_evidence_count),
+      tombstoneCount: Number(row.tombstone_count),
+      derivedAt: row.derived_at,
+    })),
+    page: query.page,
+    pageSize: query.pageSize,
+    total,
+    totalPages: total === 0 ? 0 : Math.ceil(total / query.pageSize),
+  });
+}

--- a/apps/api/src/learning-recommendations.ts
+++ b/apps/api/src/learning-recommendations.ts
@@ -64,7 +64,14 @@ function listLearningRecommendationsInSnapshot(
       db,
       `SELECT COUNT(*) AS count
          FROM learning_recommendations
-        WHERE tenant_id = ?`,
+        WHERE tenant_id = ?
+          AND NOT EXISTS (
+            SELECT 1
+              FROM learning_recommendation_reviews AS review
+             WHERE review.tenant_id = learning_recommendations.tenant_id
+               AND review.recommendation_id = learning_recommendations.recommendation_id
+               AND review.decision IN ('accepted', 'rejected')
+          )`,
       [DEFAULT_TENANT],
     )?.count ?? 0,
   );
@@ -109,6 +116,13 @@ function listLearningRecommendationsInSnapshot(
             ) AS tombstone_count
        FROM learning_recommendations AS recommendation
       WHERE recommendation.tenant_id = ?
+        AND NOT EXISTS (
+          SELECT 1
+            FROM learning_recommendation_reviews AS review
+           WHERE review.tenant_id = recommendation.tenant_id
+             AND review.recommendation_id = recommendation.recommendation_id
+             AND review.decision IN ('accepted', 'rejected')
+        )
       ORDER BY recommendation.derived_at DESC,
                recommendation.recommendation_id ASC
       LIMIT ? OFFSET ?`,

--- a/apps/api/src/local-actions.ts
+++ b/apps/api/src/local-actions.ts
@@ -25,6 +25,7 @@ import { randomUUID } from "node:crypto";
 import {
   DEFAULT_PIPELINE_LLM_MODEL,
   PIPELINE_ACTION_JOB_KEY,
+  RederiveLearningRecommendationsResultSchema,
   type ActionCommandPayload,
   type ActionRunResponse,
   type ResumeTemplateTheme,
@@ -196,6 +197,12 @@ export function createActionDispatcher(
       const message = status === "failed" ? extractResultMessage(response.result) : null;
       if (message) result.message = message;
       return result;
+    }
+    if (rpcCall.method === "rederive_learning_recommendations") {
+      const result = RederiveLearningRecommendationsResultSchema.parse(
+        response.result,
+      );
+      return { status: result.status, result };
     }
     return {
       status: "queued",
@@ -475,6 +482,16 @@ interface RpcCall {
 }
 
 function mapCommandToRpc(command: ActionCommandPayload, context: ActionDispatchContext): RpcCall | null {
+  if (command.action === "rederive_learning_recommendations") {
+    return {
+      method: "rederive_learning_recommendations",
+      params: {
+        tenantId: "local",
+        expectedAppDir: context.appDir,
+        expectedDbPath: context.dbPath,
+      },
+    };
+  }
   if (command.action === "run_stage") {
     if (!command.stage) return null;
     return { method: "run_stage", params: runStageRpcParams(command, context) };

--- a/apps/api/src/resume-review-drafts.ts
+++ b/apps/api/src/resume-review-drafts.ts
@@ -180,6 +180,7 @@ interface TailoringFeedbackSignalReviewRow extends Record<string, unknown> {
 interface TailoringFeedbackSignalIdentityRow extends Record<string, unknown> {
   signal_id: string;
   signal_kind: string;
+  job_id: string;
 }
 
 export class TailoringFeedbackReviewInputError extends Error {
@@ -638,7 +639,7 @@ export function reviewResumeFeedbackSignal(
   const tx = db.transaction(() => {
     const signal = getRow<TailoringFeedbackSignalIdentityRow>(
       db,
-      `SELECT signal_id, signal_kind
+      `SELECT signal_id, signal_kind, job_id
          FROM tailoring_feedback_signals
         WHERE tenant_id = ? AND signal_id = ?`,
       [DEFAULT_TENANT, signalId],
@@ -651,6 +652,8 @@ export function reviewResumeFeedbackSignal(
     const expectedRule = TAILORING_FEEDBACK_RULE_ALLOWLIST[signalKind];
     const ruleKey = request.decision === "accepted" ? request.ruleKey : null;
     const ruleValue = request.decision === "accepted" ? request.ruleValue : null;
+    const contradictsSignalIds =
+      request.decision === "accepted" ? request.contradictsSignalIds : [];
     if (
       request.decision === "accepted"
       && (ruleKey !== expectedRule.ruleKey || ruleValue !== expectedRule.ruleValue)
@@ -676,9 +679,16 @@ export function reviewResumeFeedbackSignal(
       && latest.rule_key === ruleKey
       && latest.rule_value === ruleValue
       && latest.allowlist_version === TAILORING_FEEDBACK_RULE_ALLOWLIST_VERSION
+      && arraysEqual(
+        contradictionSignalIdsForReview(db, latest.signal_id, latest.revision),
+        contradictsSignalIds,
+      )
     ) {
       projectLatestTailoringFeedbackDecision(db, signalId, request.decision, latest.reviewed_at);
-      return { ok: true as const, review: tailoringFeedbackReviewFromRow(latest) };
+      return {
+        ok: true as const,
+        review: tailoringFeedbackReviewFromRow(db, latest),
+      };
     }
 
     const reviewId = `tailoring_feedback_review_${crypto.randomUUID()}`;
@@ -701,6 +711,16 @@ export function reviewResumeFeedbackSignal(
       TAILORING_FEEDBACK_RULE_ALLOWLIST_VERSION,
       reviewedAt,
     );
+    if (request.decision === "accepted") {
+      insertTailoringFeedbackContradictions(
+        db,
+        signalId,
+        revision,
+        signal.job_id,
+        contradictsSignalIds,
+        reviewedAt,
+      );
+    }
     projectLatestTailoringFeedbackDecision(db, signalId, request.decision, reviewedAt);
 
     const review = getRow<TailoringFeedbackSignalReviewRow>(
@@ -714,7 +734,10 @@ export function reviewResumeFeedbackSignal(
     if (!review) {
       throw new Error("Tailoring feedback review was not persisted.");
     }
-    return { ok: true as const, review: tailoringFeedbackReviewFromRow(review) };
+    return {
+      ok: true as const,
+      review: tailoringFeedbackReviewFromRow(db, review),
+    };
   });
   return tx();
 }
@@ -733,6 +756,7 @@ function projectLatestTailoringFeedbackDecision(
 }
 
 function tailoringFeedbackReviewFromRow(
+  db: SqliteDatabase,
   row: TailoringFeedbackSignalReviewRow,
 ): TailoringFeedbackSignalReview {
   const signalKind = feedbackSignalKind(row.signal_kind);
@@ -759,8 +783,158 @@ function tailoringFeedbackReviewFromRow(
     ruleKey: decision === "accepted" ? expectedRule.ruleKey : null,
     ruleValue: decision === "accepted" ? expectedRule.ruleValue : null,
     allowlistVersion: TAILORING_FEEDBACK_RULE_ALLOWLIST_VERSION,
+    contradictsSignalIds:
+      decision === "accepted"
+        ? contradictionSignalIdsForReview(db, row.signal_id, row.revision)
+        : [],
     reviewedAt: row.reviewed_at,
   };
+}
+
+function insertTailoringFeedbackContradictions(
+  db: SqliteDatabase,
+  signalId: string,
+  revision: number,
+  signalJobId: string,
+  contradictsSignalIds: string[],
+  recordedAt: string,
+): void {
+  const currentLearningSignalId = tailoringLearningSignalId(signalId, revision);
+  for (const targetId of contradictsSignalIds) {
+    if (targetId === currentLearningSignalId) {
+      throw new TailoringFeedbackReviewInputError(
+        "A tailoring feedback signal cannot contradict itself.",
+      );
+    }
+    const target = parseTailoringLearningSignalId(targetId);
+    const targetReview = getRow<{
+      revision: number;
+      decision: string;
+      job_id: string;
+    }>(
+      db,
+      `SELECT review.revision, review.decision, source.job_id
+         FROM tailoring_feedback_signal_reviews AS review
+         JOIN tailoring_feedback_signals AS source
+           ON source.tenant_id = review.tenant_id
+          AND source.signal_id = review.signal_id
+        WHERE review.tenant_id = ? AND review.signal_id = ?
+        ORDER BY review.revision DESC
+        LIMIT 1`,
+      [DEFAULT_TENANT, target.signalId],
+    );
+    if (
+      !targetReview
+      || targetReview.decision !== "accepted"
+      || Number(targetReview.revision) !== target.revision
+    ) {
+      throw new TailoringFeedbackReviewInputError(
+        `Contradicting signal ${targetId} is not a current accepted review.`,
+      );
+    }
+    const endpoints = [
+      { signalId, revision, jobId: signalJobId },
+      {
+        signalId: target.signalId,
+        revision: target.revision,
+        jobId: targetReview.job_id,
+      },
+    ].sort((left, right) =>
+      left.signalId === right.signalId
+        ? left.revision - right.revision
+        : left.signalId.localeCompare(right.signalId),
+    );
+    const [left, right] = endpoints;
+    if (!left || !right) {
+      throw new Error("Tailoring feedback contradiction endpoints are missing.");
+    }
+    const contradictionId = `tailoring-feedback-contradiction:${stableHash([
+      DEFAULT_TENANT,
+      left.signalId,
+      left.revision,
+      right.signalId,
+      right.revision,
+    ])}`;
+    db.prepare(
+      `INSERT OR IGNORE INTO tailoring_feedback_signal_contradictions (
+         tenant_id, contradiction_id, signal_id, signal_revision, signal_job_id,
+         contradicting_signal_id, contradicting_signal_revision,
+         contradicting_signal_job_id, recorded_at
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    ).run(
+      DEFAULT_TENANT,
+      contradictionId,
+      left.signalId,
+      left.revision,
+      left.jobId,
+      right.signalId,
+      right.revision,
+      right.jobId,
+      recordedAt,
+    );
+  }
+}
+
+function contradictionSignalIdsForReview(
+  db: SqliteDatabase,
+  signalId: string,
+  revision: number,
+): string[] {
+  return allRows<{
+    signal_id: string;
+    signal_revision: number;
+    contradicting_signal_id: string;
+    contradicting_signal_revision: number;
+  }>(
+    db,
+    `SELECT signal_id, signal_revision,
+            contradicting_signal_id, contradicting_signal_revision
+       FROM tailoring_feedback_signal_contradictions
+      WHERE tenant_id = ?
+        AND ((signal_id = ? AND signal_revision = ?)
+          OR (contradicting_signal_id = ? AND contradicting_signal_revision = ?))
+      ORDER BY contradiction_id`,
+    [DEFAULT_TENANT, signalId, revision, signalId, revision],
+  )
+    .map((row) =>
+      row.signal_id === signalId && Number(row.signal_revision) === revision
+        ? tailoringLearningSignalId(
+            row.contradicting_signal_id,
+            Number(row.contradicting_signal_revision),
+          )
+        : tailoringLearningSignalId(row.signal_id, Number(row.signal_revision)),
+    )
+    .sort();
+}
+
+function parseTailoringLearningSignalId(value: string): {
+  signalId: string;
+  revision: number;
+} {
+  const prefix = "tailoring-feedback:";
+  const separator = value.lastIndexOf(":");
+  const signalId = value.slice(prefix.length, separator);
+  const revision = Number(value.slice(separator + 1));
+  if (
+    !value.startsWith(prefix)
+    || separator <= prefix.length
+    || !signalId
+    || !Number.isSafeInteger(revision)
+    || revision < 1
+  ) {
+    throw new TailoringFeedbackReviewInputError(
+      "Contradicting signal IDs must be canonical learning signal IDs.",
+    );
+  }
+  return { signalId, revision };
+}
+
+function tailoringLearningSignalId(signalId: string, revision: number): string {
+  return `tailoring-feedback:${signalId}:${revision}`;
+}
+
+function arraysEqual(left: readonly string[], right: readonly string[]): boolean {
+  return left.length === right.length && left.every((value, index) => value === right[index]);
 }
 
 function requireExistingJobId(db: SqliteDatabase, jobLocator: string): string {

--- a/apps/api/src/schema-manifest.ts
+++ b/apps/api/src/schema-manifest.ts
@@ -14,9 +14,9 @@ export type SchemaManifest = {
 // a different schema.
 export const EXACT_V7_SCHEMA_MANIFEST: SchemaManifest = {
   version: 7,
-  objectCount: 236,
-  tableCount: 109,
-  fingerprint: "3b6ad22091d895ef141917e080df86b02dc21c56a1f9ffe3b70da3c9db6edad8",
+  objectCount: 242,
+  tableCount: 110,
+  fingerprint: "55d88c87aaf9bec6c8686ee0e40dba31ca19aaaa5767042f9376f5e2756fecfd",
 };
 
 type SqliteMasterRow = [type: string, name: string, tableName: string, sql: string];

--- a/apps/api/src/schema-manifest.ts
+++ b/apps/api/src/schema-manifest.ts
@@ -16,7 +16,7 @@ export const EXACT_V7_SCHEMA_MANIFEST: SchemaManifest = {
   version: 7,
   objectCount: 242,
   tableCount: 110,
-  fingerprint: "55d88c87aaf9bec6c8686ee0e40dba31ca19aaaa5767042f9376f5e2756fecfd",
+  fingerprint: "775312f0ec2640a2a87889602886c90e21a49e06fffc53cf26c435856247da97",
 };
 
 type SqliteMasterRow = [type: string, name: string, tableName: string, sql: string];

--- a/apps/api/src/schema-manifest.ts
+++ b/apps/api/src/schema-manifest.ts
@@ -14,9 +14,9 @@ export type SchemaManifest = {
 // a different schema.
 export const EXACT_V7_SCHEMA_MANIFEST: SchemaManifest = {
   version: 7,
-  objectCount: 231,
-  tableCount: 108,
-  fingerprint: "8b2179d91d202bf43c5463ceb7f34313a0c75f296b20335ee4364cfa8d2e78bd",
+  objectCount: 236,
+  tableCount: 109,
+  fingerprint: "3b6ad22091d895ef141917e080df86b02dc21c56a1f9ffe3b70da3c9db6edad8",
 };
 
 type SqliteMasterRow = [type: string, name: string, tableName: string, sql: string];

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -50,6 +50,7 @@ import {
   LearningRecommendationListQuerySchema,
   LearningRecommendationReviewRequestSchema,
   LearningRecommendationReviewResponseSchema,
+  TailoringPolicyRevisionListQuerySchema,
   JsonRpcErrorCodes,
   JsonRpcRequestSchema,
   MarkJobActionRequestSchema,
@@ -250,6 +251,7 @@ import {
   listLearningRecommendationEvidence,
   listLearningRecommendations,
 } from "./learning-recommendations.js";
+import { listTailoringPolicyRevisions } from "./tailoring-policy-revisions.js";
 import { refreshProjections } from "./projections.js";
 import { createResumeHtmlPdfRenderer, type ResumeHtmlPdfRenderer } from "./resume-pdf-render.js";
 import {
@@ -587,6 +589,15 @@ export function buildApp(options: BuildAppOptions): FastifyInstance {
       listLearningRecommendations(
         db,
         LearningRecommendationListQuerySchema.parse(request.query),
+      ),
+    ),
+  );
+
+  app.get("/v1/learning/policies/materials", async (request, reply) =>
+    withDb(reply, options.dbPath, (db) =>
+      listTailoringPolicyRevisions(
+        db,
+        TailoringPolicyRevisionListQuerySchema.parse(request.query),
       ),
     ),
   );

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -48,6 +48,8 @@ import {
   LearningRecommendationEvidenceListQuerySchema,
   LearningRecommendationIdSchema,
   LearningRecommendationListQuerySchema,
+  LearningRecommendationReviewRequestSchema,
+  LearningRecommendationReviewResponseSchema,
   JsonRpcErrorCodes,
   JsonRpcRequestSchema,
   MarkJobActionRequestSchema,
@@ -70,6 +72,8 @@ import {
   RunJobStageRequestSchema,
   RoleMatchFeedbackDecisionSchema,
   RetailorJobRequestSchema,
+  ReviewLearningRecommendationResultSchema,
+  RpcMethods,
   ResumeTemplateDefaultSelectionRequestSchema,
   ResumeTemplateVersionSaveRequestSchema,
   ResumeCommentReplyRequestSchema,
@@ -609,6 +613,54 @@ export function buildApp(options: BuildAppOptions): FastifyInstance {
         }
         return response;
       });
+    },
+  );
+
+  app.post<{ Params: { recommendationId: string } }>(
+    "/v1/learning/recommendations/:recommendationId/reviews",
+    async (request, reply) => {
+      const parsedRecommendationId = LearningRecommendationIdSchema.safeParse(
+        decodeRouteParam(request.params.recommendationId),
+      );
+      if (!parsedRecommendationId.success) {
+        void reply.code(400);
+        return { ok: false, error: "invalid_learning_recommendation_id" };
+      }
+      const body = parseBody(reply, LearningRecommendationReviewRequestSchema, request.body ?? {});
+      if (!body) {
+        return undefined;
+      }
+
+      let response;
+      try {
+        response = await providerDispatcher.call(RpcMethods.ReviewLearningRecommendation, {
+          tenantId: "local",
+          recommendationId: parsedRecommendationId.data,
+          decision: body.decision,
+          expectedAppDir: appDir,
+          expectedDbPath: options.dbPath,
+        });
+      } catch {
+        return learningRecommendationReviewFailure(reply, 503);
+      }
+
+      if (response.error) {
+        return learningRecommendationReviewFailure(
+          reply,
+          response.error.code === JsonRpcErrorCodes.InvalidParams ? 409 : 502,
+        );
+      }
+
+      const parsedResult = ReviewLearningRecommendationResultSchema.safeParse(response.result);
+      if (
+        !parsedResult.success ||
+        parsedResult.data.recommendationId !== parsedRecommendationId.data ||
+        parsedResult.data.decision !== body.decision
+      ) {
+        return learningRecommendationReviewFailure(reply, 502);
+      }
+      const { status: _status, ...review } = parsedResult.data;
+      return LearningRecommendationReviewResponseSchema.parse({ ok: true, ...review });
     },
   );
 
@@ -3296,6 +3348,15 @@ function providerOperationError(
   message: string,
 ) {
   return { ok: false as const, error, message };
+}
+
+function learningRecommendationReviewFailure(reply: FastifyReply, statusCode: 409 | 502 | 503) {
+  void reply.code(statusCode);
+  return {
+    ok: false as const,
+    error: "learning_recommendation_review_failed" as const,
+    message: "The learning recommendation review could not be completed.",
+  };
 }
 
 async function dispatchProviderModelCatalog(

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -45,6 +45,8 @@ import {
   EnsureCurrentResumeMaterialsRequestSchema,
   JobResumeTemplateAssignmentRequestSchema,
   JobListQuerySchema,
+  LearningRecommendationEvidenceListQuerySchema,
+  LearningRecommendationIdSchema,
   LearningRecommendationListQuerySchema,
   JsonRpcErrorCodes,
   JsonRpcRequestSchema,
@@ -240,7 +242,10 @@ import {
   readSettingsConfig,
 } from "./read-model.js";
 import { buildPipelineOperationsSnapshot } from "./pipeline-operations.js";
-import { listLearningRecommendations } from "./learning-recommendations.js";
+import {
+  listLearningRecommendationEvidence,
+  listLearningRecommendations,
+} from "./learning-recommendations.js";
 import { refreshProjections } from "./projections.js";
 import { createResumeHtmlPdfRenderer, type ResumeHtmlPdfRenderer } from "./resume-pdf-render.js";
 import {
@@ -580,6 +585,31 @@ export function buildApp(options: BuildAppOptions): FastifyInstance {
         LearningRecommendationListQuerySchema.parse(request.query),
       ),
     ),
+  );
+
+  app.get<{ Params: { recommendationId: string } }>(
+    "/v1/learning/recommendations/:recommendationId/evidence",
+    async (request, reply) => {
+      const parsedRecommendationId = LearningRecommendationIdSchema.safeParse(
+        decodeRouteParam(request.params.recommendationId),
+      );
+      if (!parsedRecommendationId.success) {
+        void reply.code(400);
+        return { ok: false, error: "invalid_learning_recommendation_id" };
+      }
+      return withDb(reply, options.dbPath, (db) => {
+        const response = listLearningRecommendationEvidence(
+          db,
+          parsedRecommendationId.data,
+          LearningRecommendationEvidenceListQuerySchema.parse(request.query),
+        );
+        if (!response) {
+          void reply.code(404);
+          return { ok: false, error: "learning_recommendation_not_found" };
+        }
+        return response;
+      });
+    },
   );
 
   app.get("/v1/digest", async (_request, reply) =>

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -45,6 +45,7 @@ import {
   EnsureCurrentResumeMaterialsRequestSchema,
   JobResumeTemplateAssignmentRequestSchema,
   JobListQuerySchema,
+  LearningRecommendationListQuerySchema,
   JsonRpcErrorCodes,
   JsonRpcRequestSchema,
   MarkJobActionRequestSchema,
@@ -239,6 +240,7 @@ import {
   readSettingsConfig,
 } from "./read-model.js";
 import { buildPipelineOperationsSnapshot } from "./pipeline-operations.js";
+import { listLearningRecommendations } from "./learning-recommendations.js";
 import { refreshProjections } from "./projections.js";
 import { createResumeHtmlPdfRenderer, type ResumeHtmlPdfRenderer } from "./resume-pdf-render.js";
 import {
@@ -569,6 +571,15 @@ export function buildApp(options: BuildAppOptions): FastifyInstance {
 
   app.get("/v1/scoring/keywords", async (_request, reply) =>
     withDb(reply, options.dbPath, (db) => listScoringKeywords(db)),
+  );
+
+  app.get("/v1/learning/recommendations", async (request, reply) =>
+    withDb(reply, options.dbPath, (db) =>
+      listLearningRecommendations(
+        db,
+        LearningRecommendationListQuerySchema.parse(request.query),
+      ),
+    ),
   );
 
   app.get("/v1/digest", async (_request, reply) =>

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -1107,9 +1107,39 @@ export function buildApp(options: BuildAppOptions): FastifyInstance {
       if (!body) {
         return undefined;
       }
-      return withWritableDb(reply, options.dbPath, (db) =>
+      const reviewResponse = await withWritableDb(reply, options.dbPath, (db) =>
         reviewResumeFeedbackSignal(db, decodeRouteParam(request.params.signalId), body),
       );
+      if (!reviewResponse || reviewResponse.ok !== true) {
+        return reviewResponse;
+      }
+      try {
+        const derivation = await actionDispatcher(
+          {
+            action: "rederive_learning_recommendations",
+            jobKey: "learning",
+          },
+          actionContext,
+        );
+        if (derivation.status !== "succeeded") {
+          void reply.code(503);
+          return {
+            ok: false,
+            error: "learning_rederivation_failed",
+            message:
+              "The feedback review was saved, but pending learning recommendations could not be refreshed. Retry the same review.",
+          };
+        }
+      } catch {
+        void reply.code(503);
+        return {
+          ok: false,
+          error: "learning_rederivation_failed",
+          message:
+            "The feedback review was saved, but pending learning recommendations could not be refreshed. Retry the same review.",
+        };
+      }
+      return reviewResponse;
     },
   );
 

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -74,6 +74,7 @@ import {
   RoleMatchFeedbackDecisionSchema,
   RetailorJobRequestSchema,
   ReviewLearningRecommendationResultSchema,
+  RollbackTailoringPolicyResultSchema,
   RpcMethods,
   ResumeTemplateDefaultSelectionRequestSchema,
   ResumeTemplateVersionSaveRequestSchema,
@@ -83,6 +84,8 @@ import {
   ResumeReviewDraftRenderRequestSchema,
   ResumeReviewDraftRevisionSaveRequestSchema,
   TailoringFeedbackSignalReviewRequestSchema,
+  TailoringPolicyRollbackRequestSchema,
+  TailoringPolicyRollbackResponseSchema,
   RunPipelineStagesRequestSchema,
   SettingsUpdateRequestSchema,
   type ExtensionCapabilityTokenResponse,
@@ -601,6 +604,52 @@ export function buildApp(options: BuildAppOptions): FastifyInstance {
       ),
     ),
   );
+
+  app.post("/v1/learning/policies/materials/rollbacks", async (request, reply) => {
+    const body = parseBody(reply, TailoringPolicyRollbackRequestSchema, request.body ?? {});
+    if (!body) {
+      return undefined;
+    }
+
+    let response;
+    try {
+      response = await providerDispatcher.call(RpcMethods.RollbackTailoringPolicy, {
+        tenantId: "local",
+        targetVersion: body.targetVersion,
+        expectedAppDir: appDir,
+        expectedDbPath: options.dbPath,
+      });
+    } catch {
+      return tailoringPolicyRollbackFailure(reply, 503);
+    }
+    if (response.error) {
+      return tailoringPolicyRollbackFailure(
+        reply,
+        response.error.code === JsonRpcErrorCodes.InvalidParams ? 409 : 502,
+      );
+    }
+
+    const parsedResult = RollbackTailoringPolicyResultSchema.safeParse(response.result);
+    if (
+      !parsedResult.success ||
+      parsedResult.data.rollbackOfVersion !== body.targetVersion
+    ) {
+      return tailoringPolicyRollbackFailure(reply, 502);
+    }
+    return TailoringPolicyRollbackResponseSchema.parse({
+      ok: true,
+      context: parsedResult.data.context,
+      policyKind: parsedResult.data.policyKind,
+      version: parsedResult.data.policyVersion,
+      status: "current",
+      learnedRules: parsedResult.data.learnedRules,
+      sourceReviewId: null,
+      sourceRecommendationId: null,
+      rollbackOfVersion: parsedResult.data.rollbackOfVersion,
+      rollbackReasonCode: parsedResult.data.rollbackReasonCode,
+      createdAt: parsedResult.data.rolledBackAt,
+    });
+  });
 
   app.get<{ Params: { recommendationId: string } }>(
     "/v1/learning/recommendations/:recommendationId/evidence",
@@ -3367,6 +3416,15 @@ function learningRecommendationReviewFailure(reply: FastifyReply, statusCode: 40
     ok: false as const,
     error: "learning_recommendation_review_failed" as const,
     message: "The learning recommendation review could not be completed.",
+  };
+}
+
+function tailoringPolicyRollbackFailure(reply: FastifyReply, statusCode: 409 | 502 | 503) {
+  void reply.code(statusCode);
+  return {
+    ok: false as const,
+    error: "tailoring_policy_rollback_failed" as const,
+    message: "The tailoring policy rollback could not be completed.",
   };
 }
 

--- a/apps/api/src/tailoring-policy-revisions.ts
+++ b/apps/api/src/tailoring-policy-revisions.ts
@@ -1,0 +1,115 @@
+import {
+  TailoringPolicyRevisionListResponseSchema,
+  type TailoringPolicyRevisionListQuery,
+  type TailoringPolicyRevisionListResponse,
+} from "./contracts.js";
+import { allRows, getRow, type SqliteDatabase } from "./db.js";
+
+const DEFAULT_TENANT = "local";
+
+interface TailoringPolicyRevisionRow extends Record<string, unknown> {
+  version: number;
+  runtime_settings_json: string;
+  rollback_of_version: number | null;
+  rollback_reason: string;
+  created_at: string;
+  source_review_id: string | null;
+  source_recommendation_id: string | null;
+  current_version: number;
+}
+
+export function listTailoringPolicyRevisions(
+  db: SqliteDatabase,
+  query: TailoringPolicyRevisionListQuery,
+): TailoringPolicyRevisionListResponse {
+  return db.transaction(() => {
+    const total = Number(
+      getRow<{ count: number }>(
+        db,
+        `SELECT COUNT(*) AS count
+           FROM tailoring_policies
+          WHERE tenant_id = ?`,
+        [DEFAULT_TENANT],
+      )?.count ?? 0,
+    );
+    const offset = (query.page - 1) * query.pageSize;
+    const rows = allRows<TailoringPolicyRevisionRow>(
+      db,
+      `SELECT policy.version,
+              policy.runtime_settings_json,
+              policy.rollback_of_version,
+              policy.rollback_reason,
+              policy.created_at,
+              review.review_id AS source_review_id,
+              review.recommendation_id AS source_recommendation_id,
+              (
+                SELECT MAX(current_policy.version)
+                FROM tailoring_policies AS current_policy
+                WHERE current_policy.tenant_id = policy.tenant_id
+              ) AS current_version
+         FROM tailoring_policies AS policy
+         LEFT JOIN learning_recommendation_reviews AS review
+           ON review.tenant_id = policy.tenant_id
+          AND review.context = 'materials'
+          AND review.policy_kind = 'tailoring_rule'
+          AND review.policy_version = policy.version
+          AND review.decision = 'accepted'
+        WHERE policy.tenant_id = ?
+        ORDER BY policy.version DESC
+        LIMIT ? OFFSET ?`,
+      [DEFAULT_TENANT, query.pageSize, offset],
+    );
+
+    return TailoringPolicyRevisionListResponseSchema.parse({
+      ok: true,
+      revisions: rows.map((row) => ({
+        context: "materials",
+        policyKind: "tailoring_rule",
+        version: Number(row.version),
+        status: Number(row.version) === Number(row.current_version) ? "current" : "superseded",
+        learnedRules: learnedRules(row.runtime_settings_json),
+        sourceReviewId: row.source_review_id,
+        sourceRecommendationId: row.source_recommendation_id,
+        rollbackOfVersion:
+          row.rollback_of_version === null ? null : Number(row.rollback_of_version),
+        rollbackReasonCode:
+          row.rollback_of_version === null
+            ? null
+            : row.rollback_reason === "user_requested"
+              ? "user_requested"
+              : "historical_or_unspecified",
+        createdAt: row.created_at,
+      })),
+      page: query.page,
+      pageSize: query.pageSize,
+      total,
+      totalPages: total === 0 ? 0 : Math.ceil(total / query.pageSize),
+    });
+  })();
+}
+
+function learnedRules(rawRuntimeSettings: string): Array<{
+  ruleKey: string;
+  ruleValue: unknown;
+}> {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(rawRuntimeSettings || "{}");
+  } catch {
+    throw new Error("Tailoring policy runtime settings are not valid JSON.");
+  }
+  if (!isRecord(parsed)) {
+    throw new Error("Tailoring policy runtime settings must be an object.");
+  }
+  const rawRules = parsed.learned_tailoring_rules ?? {};
+  if (!isRecord(rawRules)) {
+    throw new Error("Learned tailoring policy rules must be an object.");
+  }
+  return Object.entries(rawRules)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([ruleKey, ruleValue]) => ({ ruleKey, ruleValue }));
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/apps/api/test/json-rpc-adapter.test.ts
+++ b/apps/api/test/json-rpc-adapter.test.ts
@@ -111,6 +111,45 @@ describe("createContactResearchStarter (JSON-RPC adapter)", () => {
 });
 
 describe("createActionDispatcher (JSON-RPC adapter)", () => {
+  it("maps learning rederivation to one runtime-scoped synchronous RPC", async () => {
+    const fake = new FakeDispatcher();
+    const recommendationId = `learning-recommendation:${"a".repeat(64)}`;
+    fake.setResponse({
+      jsonrpc: "2.0",
+      id: 1,
+      result: {
+        status: "succeeded",
+        recommendationCount: 1,
+        recommendationIds: [recommendationId],
+      },
+    });
+    const dispatcher = createActionDispatcher(fake);
+
+    const result = await dispatcher(
+      { action: "rederive_learning_recommendations", jobKey: "learning" },
+      { appDir: "/tmp/jobctrl", dbPath: "/tmp/jobctrl/jobctrl.db" },
+    );
+
+    expect(fake.calls).toEqual([
+      {
+        method: "rederive_learning_recommendations",
+        params: {
+          tenantId: "local",
+          expectedAppDir: "/tmp/jobctrl",
+          expectedDbPath: "/tmp/jobctrl/jobctrl.db",
+        },
+      },
+    ]);
+    expect(result).toEqual({
+      status: "succeeded",
+      result: {
+        status: "succeeded",
+        recommendationCount: 1,
+        recommendationIds: [recommendationId],
+      },
+    });
+  });
+
   it("preserves the cancel_run RPC canceling status and run id", async () => {
     const fake = new FakeDispatcher();
     fake.setResponse({

--- a/apps/api/test/qa-seed.ts
+++ b/apps/api/test/qa-seed.ts
@@ -322,6 +322,7 @@ export function seedQaDatabase(dbPath: string, options: QaSeedOptions = {}): voi
     resumeTxt,
   });
   seedResumeReviewDraft(db);
+  seedLearningPolicyFixture(db);
 
   insertEvent(db, "https://boards.greenhouse.io/gitlab/jobs/qa-platform-director", "apply", "info", "QA apply run queued");
   insertEvent(db, "https://linkedin.com/jobs/view/qa-risk-manager", "score", "error", "QA score action failed");
@@ -1232,6 +1233,229 @@ function seedResumeReviewDraft(db: Database.Database): void {
     "qa-platform-resume-pdf",
     QA_NOW,
     QA_NOW,
+  );
+}
+
+function seedLearningPolicyFixture(db: Database.Database): void {
+  const policyCreatedAt = "2026-05-04T11:00:00.000Z";
+  const styleRecommendationId = `learning-recommendation:${"a".repeat(64)}`;
+  const factualRecommendationId = `learning-recommendation:${"b".repeat(64)}`;
+  const signals = [
+    {
+      signalId: "qa-learning-style-1",
+      jobId: QA_PLATFORM_JOB_ID,
+      draftId: "qa-platform-resume-draft",
+      signalKind: "style_preference",
+      ruleKey: "style_guidance",
+      ruleValue: "preserve_user_edit_pattern",
+      reviewedAt: "2026-05-04T11:01:00.000Z",
+    },
+    {
+      signalId: "qa-learning-style-2",
+      jobId: QA_RISK_JOB_ID,
+      draftId: "qa-risk-resume-draft",
+      signalKind: "style_preference",
+      ruleKey: "style_guidance",
+      ruleValue: "preserve_user_edit_pattern",
+      reviewedAt: "2026-05-04T11:02:00.000Z",
+    },
+    {
+      signalId: "qa-learning-style-3",
+      jobId: QA_PLATFORM_JOB_ID,
+      draftId: "qa-platform-resume-draft",
+      signalKind: "style_preference",
+      ruleKey: "style_guidance",
+      ruleValue: "preserve_user_edit_pattern",
+      reviewedAt: "2026-05-04T11:03:00.000Z",
+    },
+    {
+      signalId: "qa-learning-factual-1",
+      jobId: QA_PLATFORM_JOB_ID,
+      draftId: "qa-platform-resume-draft",
+      signalKind: "factual_correction",
+      ruleKey: "fact_handling",
+      ruleValue: "require_source_match",
+      reviewedAt: "2026-05-04T11:04:00.000Z",
+    },
+    {
+      signalId: "qa-learning-factual-2",
+      jobId: QA_RISK_JOB_ID,
+      draftId: "qa-risk-resume-draft",
+      signalKind: "factual_correction",
+      ruleKey: "fact_handling",
+      ruleValue: "require_source_match",
+      reviewedAt: "2026-05-04T11:05:00.000Z",
+    },
+    {
+      signalId: "qa-learning-factual-3",
+      jobId: QA_RISK_JOB_ID,
+      draftId: "qa-risk-resume-draft",
+      signalKind: "factual_correction",
+      ruleKey: "fact_handling",
+      ruleValue: "require_source_match",
+      reviewedAt: "2026-05-04T11:06:00.000Z",
+    },
+  ] as const;
+
+  db.transaction(() => {
+    db.prepare(
+      `INSERT INTO resume_review_drafts (
+        tenant_id, draft_id, job_id, base_generation, renderer_format,
+        state, latest_revision_number, created_at, updated_at
+      ) VALUES ('local', 'qa-risk-resume-draft', ?, 1, 'text', 'active', 0, ?, ?)`,
+    ).run(QA_RISK_JOB_ID, policyCreatedAt, policyCreatedAt);
+    insertQaTailoringPolicy(db, {
+      version: 1,
+      learnedRules: {},
+      createdAt: policyCreatedAt,
+    });
+
+    const insertSignal = db.prepare(
+      `INSERT INTO tailoring_feedback_signals (
+        tenant_id, signal_id, job_id, draft_id, source_kind, source_id,
+        signal_kind, status, summary, created_at, reviewed_at
+      ) VALUES ('local', ?, ?, ?, 'edit_delta', ?, ?, 'accepted', ?, ?, ?)`,
+    );
+    const insertSignalReview = db.prepare(
+      `INSERT INTO tailoring_feedback_signal_reviews (
+        tenant_id, review_id, signal_id, revision, decision, signal_kind,
+        rule_key, rule_value, allowlist_version, reviewed_at
+      ) VALUES ('local', ?, ?, 1, 'accepted', ?, ?, ?, 1, ?)`,
+    );
+    for (const signal of signals) {
+      insertSignal.run(
+        signal.signalId,
+        signal.jobId,
+        signal.draftId,
+        `qa-source-${signal.signalId}`,
+        signal.signalKind,
+        "Synthetic accepted feedback for learning policy browser QA.",
+        signal.reviewedAt,
+        signal.reviewedAt,
+      );
+      insertSignalReview.run(
+        `qa-learning-review-${signal.signalId}`,
+        signal.signalId,
+        signal.signalKind,
+        signal.ruleKey,
+        signal.ruleValue,
+        signal.reviewedAt,
+      );
+    }
+
+    insertQaLearningRecommendation(db, {
+      recommendationId: styleRecommendationId,
+      signalKind: "style_preference",
+      ruleKey: "style_guidance",
+      ruleValue: "preserve_user_edit_pattern",
+      inputFingerprint: "c".repeat(64),
+      derivedAt: "2026-05-04T11:10:00.000Z",
+      signals: signals.slice(0, 3),
+    });
+    insertQaLearningRecommendation(db, {
+      recommendationId: factualRecommendationId,
+      signalKind: "factual_correction",
+      ruleKey: "fact_handling",
+      ruleValue: "require_source_match",
+      inputFingerprint: "d".repeat(64),
+      derivedAt: "2026-05-04T11:09:00.000Z",
+      signals: signals.slice(3),
+    });
+  })();
+}
+
+function insertQaTailoringPolicy(
+  db: Database.Database,
+  input: {
+    version: number;
+    learnedRules: Record<string, string>;
+    createdAt: string;
+    rollbackOfVersion?: number;
+    rollbackReason?: string;
+  },
+): void {
+  db.prepare(
+    `INSERT INTO tailoring_policies (
+      tenant_id, version, prompt_version, schema_version, judge_schema_version,
+      prompt_fingerprint, config_fingerprint, profile_policy_fingerprint,
+      custom_prompt_fingerprint, generator_settings_json, judge_settings_json,
+      runtime_settings_json, rollback_of_version, rollback_reason, created_at,
+      created_from_event_id
+    ) VALUES ('local', ?, 'tailor.v2', 'resume.v1', 'judge.v1',
+              'qa-prompt', ?, 'qa-profile', 'qa-custom', '{}', '{}', ?, ?, ?, ?, NULL)`,
+  ).run(
+    input.version,
+    `qa-config-${input.version}`,
+    JSON.stringify({ learned_tailoring_rules: input.learnedRules }),
+    input.rollbackOfVersion ?? null,
+    input.rollbackReason ?? "",
+    input.createdAt,
+  );
+}
+
+function insertQaLearningRecommendation(
+  db: Database.Database,
+  input: {
+    recommendationId: string;
+    signalKind: "style_preference" | "factual_correction";
+    ruleKey: "style_guidance" | "fact_handling";
+    ruleValue: "preserve_user_edit_pattern" | "require_source_match";
+    inputFingerprint: string;
+    derivedAt: string;
+    signals: readonly {
+      signalId: string;
+      jobId: string;
+      reviewedAt: string;
+    }[];
+  },
+): void {
+  const insertEvidence = db.prepare(
+    `INSERT INTO learning_recommendation_evidence (
+      tenant_id, recommendation_id, signal_id, evidence_role, source_kind,
+      source_id, source_revision, recorded_at
+    ) VALUES ('local', ?, ?, 'supporting', 'tailoring_feedback_signal', ?, 1, ?)`,
+  );
+  const insertEvidenceJob = db.prepare(
+    `INSERT INTO learning_recommendation_evidence_jobs (
+      tenant_id, recommendation_id, signal_id, job_id
+    ) VALUES ('local', ?, ?, ?)`,
+  );
+  const jobIds = new Set<string>();
+  for (const signal of input.signals) {
+    const evidenceSignalId = `tailoring-feedback:${signal.signalId}:1`;
+    insertEvidence.run(
+      input.recommendationId,
+      evidenceSignalId,
+      signal.signalId,
+      signal.reviewedAt,
+    );
+    insertEvidenceJob.run(input.recommendationId, evidenceSignalId, signal.jobId);
+    jobIds.add(signal.jobId);
+  }
+  const insertJob = db.prepare(
+    `INSERT INTO learning_recommendation_jobs (
+      tenant_id, recommendation_id, job_id
+    ) VALUES ('local', ?, ?)`,
+  );
+  for (const jobId of jobIds) {
+    insertJob.run(input.recommendationId, jobId);
+  }
+  db.prepare(
+    `INSERT INTO learning_recommendations (
+      tenant_id, recommendation_id, derivation_version,
+      evaluation_fixture_version, context, policy_kind, signal_kind,
+      rule_key, rule_value, allowlist_version, status, observed_signal_count,
+      observed_job_count, minimum_signal_count, minimum_job_count,
+      confidence_limit, input_fingerprint, derived_at
+    ) VALUES ('local', ?, 1, 1, 'materials', 'tailoring_rule', ?, ?, ?, 1,
+              'pending', 3, 2, 3, 2, 'sample_gated_no_population_inference', ?, ?)`,
+  ).run(
+    input.recommendationId,
+    input.signalKind,
+    input.ruleKey,
+    input.ruleValue,
+    input.inputFingerprint,
+    input.derivedAt,
   );
 }
 

--- a/apps/api/test/resume-review-drafts.test.ts
+++ b/apps/api/test/resume-review-drafts.test.ts
@@ -34,8 +34,12 @@ beforeEach(() => {
     configPath: path.join(tempDir, "config.json"),
     resumePdfRenderer,
     actionDispatcher: vi.fn(async (): Promise<ActionDispatchResult> => ({
-      status: "queued",
-      runId: "unexpected-run",
+      status: "succeeded",
+      result: {
+        status: "succeeded",
+        recommendationCount: 0,
+        recommendationIds: [],
+      },
     })) as ReturnType<typeof vi.fn> & ActionDispatcher,
   };
   seedDatabase(options.dbPath);
@@ -335,6 +339,35 @@ describe("resume review draft API", () => {
 
   it("reviews tailoring feedback through the versioned allowlist without exposing source text", async () => {
     const privateSource = "private source text must never enter the review response";
+    const decisionsObservedByDerivation: string[] = [];
+    const actionDispatcher = options.actionDispatcher as ReturnType<typeof vi.fn> &
+      ActionDispatcher;
+    actionDispatcher.mockImplementation(
+      async (...[, context]: Parameters<ActionDispatcher>): Promise<ActionDispatchResult> => {
+        const persisted = new Database(context.dbPath);
+        try {
+          const row = persisted
+            .prepare(
+              `SELECT decision
+                 FROM tailoring_feedback_signal_reviews
+                ORDER BY revision DESC
+                LIMIT 1`,
+            )
+            .get() as { decision: string };
+          decisionsObservedByDerivation.push(row.decision);
+        } finally {
+          persisted.close();
+        }
+        return {
+          status: "succeeded",
+          result: {
+            status: "succeeded",
+            recommendationCount: 0,
+            recommendationIds: [],
+          },
+        };
+      },
+    );
     const app = buildApp(options);
     const createResponse = await app.inject({
       method: "POST",
@@ -435,6 +468,18 @@ describe("resume review draft API", () => {
       ruleValue: null,
       contradictsSignalIds: [],
     });
+    expect(options.actionDispatcher).toHaveBeenCalledTimes(3);
+    expect(decisionsObservedByDerivation).toEqual([
+      "accepted",
+      "accepted",
+      "rejected",
+    ]);
+    expect(options.actionDispatcher).toHaveBeenNthCalledWith(
+      1,
+      { action: "rederive_learning_recommendations", jobKey: "learning" },
+      expect.objectContaining({ dbPath: options.dbPath }),
+    );
+
     const db = new Database(options.dbPath);
     try {
       const reviews = db
@@ -588,6 +633,91 @@ describe("resume review draft API", () => {
     } finally {
       persisted.close();
     }
+    await app.close();
+  });
+
+  it("retries idempotent derivation when a saved review refresh initially fails", async () => {
+    const actionDispatcher = options.actionDispatcher as ReturnType<typeof vi.fn> &
+      ActionDispatcher;
+    actionDispatcher
+      .mockResolvedValueOnce({ status: "failed" })
+      .mockResolvedValueOnce({
+        status: "succeeded",
+        result: {
+          status: "succeeded",
+          recommendationCount: 0,
+          recommendationIds: [],
+        },
+      });
+    const app = buildApp(options);
+    const createResponse = await app.inject({
+      method: "POST",
+      url: `/v1/jobs/${encodeURIComponent(JOB_KEY)}/resume-review/draft`,
+      payload: {},
+    });
+    const draftId = createResponse.json().draft.draftId as string;
+    const revisionResponse = await app.inject({
+      method: "POST",
+      url: `/v1/resume-review/drafts/${encodeURIComponent(draftId)}/revisions`,
+      payload: {
+        editedText: "Led 4 platform reliability projects.",
+        editDeltas: [
+          {
+            kind: "replace_text",
+            section: "experience",
+            beforeText: "Led 3 projects.",
+            afterText: "Led 4 platform reliability projects.",
+          },
+        ],
+      },
+    });
+    const signalId = revisionResponse.json().draft.feedbackSignals[0].signalId as string;
+    const payload = {
+      decision: "accepted",
+      ruleKey: "fact_handling",
+      ruleValue: "require_source_match",
+    } as const;
+
+    const failed = await app.inject({
+      method: "POST",
+      url: `/v1/resume-review/feedback-signals/${encodeURIComponent(signalId)}/reviews`,
+      payload,
+    });
+    expect(failed.statusCode, failed.body).toBe(503);
+    expect(failed.json()).toEqual({
+      ok: false,
+      error: "learning_rederivation_failed",
+      message:
+        "The feedback review was saved, but pending learning recommendations could not be refreshed. Retry the same review.",
+    });
+
+    const retried = await app.inject({
+      method: "POST",
+      url: `/v1/resume-review/feedback-signals/${encodeURIComponent(signalId)}/reviews`,
+      payload,
+    });
+    expect(retried.statusCode, retried.body).toBe(200);
+    expect(retried.json().review).toMatchObject({
+      signalId,
+      revision: 1,
+      decision: "accepted",
+      contradictsSignalIds: [],
+    });
+    const persisted = new Database(options.dbPath);
+    try {
+      expect(
+        persisted
+          .prepare(
+            `SELECT COUNT(*) AS count
+               FROM tailoring_feedback_signal_reviews
+              WHERE signal_id = ?`,
+          )
+          .get(signalId),
+      ).toEqual({ count: 1 });
+    } finally {
+      persisted.close();
+    }
+    expect(actionDispatcher).toHaveBeenCalledTimes(2);
     await app.close();
   });
 

--- a/apps/api/test/resume-review-drafts.test.ts
+++ b/apps/api/test/resume-review-drafts.test.ts
@@ -393,9 +393,11 @@ describe("resume review draft API", () => {
       ruleKey: "fact_handling",
       ruleValue: "require_source_match",
       allowlistVersion: 1,
+      contradictsSignalIds: [],
     });
     expect(Object.keys(acceptedResponse.json().review).sort()).toEqual([
       "allowlistVersion",
+      "contradictsSignalIds",
       "decision",
       "reviewId",
       "reviewedAt",
@@ -431,8 +433,8 @@ describe("resume review draft API", () => {
       decision: "rejected",
       ruleKey: null,
       ruleValue: null,
+      contradictsSignalIds: [],
     });
-
     const db = new Database(options.dbPath);
     try {
       const reviews = db
@@ -464,6 +466,128 @@ describe("resume review draft API", () => {
       db.close();
     }
 
+    await app.close();
+  });
+
+  it("records only explicit structured contradiction links between accepted reviews", async () => {
+    const privateSource = "private contradiction rationale must not leave the source row";
+    const app = buildApp(options);
+    const createResponse = await app.inject({
+      method: "POST",
+      url: `/v1/jobs/${encodeURIComponent(JOB_KEY)}/resume-review/draft`,
+      payload: {},
+    });
+    const draftId = createResponse.json().draft.draftId as string;
+    const db = new Database(options.dbPath);
+    try {
+      for (const signalId of ["signal-one", "signal-two", "signal-three"]) {
+        db.prepare(
+          `INSERT INTO tailoring_feedback_signals (
+             tenant_id, signal_id, job_id, draft_id, source_kind, source_id,
+             signal_kind, status, summary, created_at
+           ) VALUES (
+             'local', ?, ?, ?, 'comment_reply', ?, 'factual_correction',
+             'candidate', ?, ?
+           )`,
+        ).run(signalId, JOB_ID, draftId, `source-${signalId}`, privateSource, NOW);
+      }
+    } finally {
+      db.close();
+    }
+
+    const first = await app.inject({
+      method: "POST",
+      url: "/v1/resume-review/feedback-signals/signal-one/reviews",
+      payload: {
+        decision: "accepted",
+        ruleKey: "fact_handling",
+        ruleValue: "require_source_match",
+      },
+    });
+    expect(first.statusCode, first.body).toBe(200);
+    expect(first.json().review.contradictsSignalIds).toEqual([]);
+
+    const firstLearningSignalId = "tailoring-feedback:signal-one:1";
+    const secondPayload = {
+      decision: "accepted",
+      ruleKey: "fact_handling",
+      ruleValue: "require_source_match",
+      contradictsSignalIds: [firstLearningSignalId],
+    } as const;
+    const second = await app.inject({
+      method: "POST",
+      url: "/v1/resume-review/feedback-signals/signal-two/reviews",
+      payload: secondPayload,
+    });
+    expect(second.statusCode, second.body).toBe(200);
+    expect(second.json().review.contradictsSignalIds).toEqual([
+      firstLearningSignalId,
+    ]);
+    expect(second.body).not.toContain(privateSource);
+
+    const replay = await app.inject({
+      method: "POST",
+      url: "/v1/resume-review/feedback-signals/signal-two/reviews",
+      payload: secondPayload,
+    });
+    expect(replay.statusCode, replay.body).toBe(200);
+    expect(replay.json().review).toEqual(second.json().review);
+
+    const invalidTarget = await app.inject({
+      method: "POST",
+      url: "/v1/resume-review/feedback-signals/signal-three/reviews",
+      payload: {
+        decision: "accepted",
+        ruleKey: "fact_handling",
+        ruleValue: "require_source_match",
+        contradictsSignalIds: ["tailoring-feedback:missing-signal:1"],
+      },
+    });
+    expect(invalidTarget.statusCode, invalidTarget.body).toBe(400);
+    expect(invalidTarget.json()).toMatchObject({
+      ok: false,
+      error: "invalid_tailoring_feedback_review",
+    });
+
+    const persisted = new Database(options.dbPath);
+    try {
+      expect(
+        persisted
+          .prepare(
+            `SELECT signal_id, signal_revision, contradicting_signal_id,
+                    contradicting_signal_revision
+               FROM tailoring_feedback_signal_contradictions`,
+          )
+          .all(),
+      ).toEqual([
+        {
+          signal_id: "signal-one",
+          signal_revision: 1,
+          contradicting_signal_id: "signal-two",
+          contradicting_signal_revision: 1,
+        },
+      ]);
+      expect(
+        persisted
+          .prepare(
+            `SELECT COUNT(*) AS count
+               FROM tailoring_feedback_signal_reviews
+              WHERE signal_id = 'signal-two'`,
+          )
+          .get(),
+      ).toEqual({ count: 1 });
+      expect(
+        persisted
+          .prepare(
+            `SELECT COUNT(*) AS count
+               FROM tailoring_feedback_signal_reviews
+              WHERE signal_id = 'signal-three'`,
+          )
+          .get(),
+      ).toEqual({ count: 0 });
+    } finally {
+      persisted.close();
+    }
     await app.close();
   });
 

--- a/apps/api/test/rpc-contracts.test.ts
+++ b/apps/api/test/rpc-contracts.test.ts
@@ -19,6 +19,8 @@ import {
   ProviderModelCatalogResultSchema,
   RederiveLearningRecommendationsParamsSchema,
   RederiveLearningRecommendationsResultSchema,
+  ReviewLearningRecommendationParamsSchema,
+  ReviewLearningRecommendationResultSchema,
   RefreshCompensationParamsSchema,
   RefreshCompensationResultSchema,
   RescoreJobParamsSchema,
@@ -73,6 +75,80 @@ describe("learning recommendation derivation RPC contract", () => {
         status: "succeeded",
         recommendationCount: 1,
         recommendationIds: ["private free text"],
+      }),
+    ).toThrow();
+  });
+});
+
+describe("learning recommendation review RPC contract", () => {
+  it("registers runtime-scoped review params and couples decision to policy effect", () => {
+    const recommendationId = `learning-recommendation:${"a".repeat(64)}`;
+    const reviewId = `learning-recommendation-review:${"b".repeat(64)}`;
+    expect(RpcMethods.ReviewLearningRecommendation).toBe("review_learning_recommendation");
+    expect(
+      ReviewLearningRecommendationParamsSchema.parse({
+        recommendationId,
+        decision: "accepted",
+        expectedAppDir: "/tmp/jobctrl",
+        expectedDbPath: "/tmp/jobctrl/jobctrl.db",
+      }),
+    ).toEqual({
+      tenantId: "local",
+      recommendationId,
+      decision: "accepted",
+      expectedAppDir: "/tmp/jobctrl",
+      expectedDbPath: "/tmp/jobctrl/jobctrl.db",
+    });
+    expect(
+      ReviewLearningRecommendationResultSchema.parse({
+        status: "succeeded",
+        reviewId,
+        recommendationId,
+        revision: 1,
+        decision: "accepted",
+        context: "materials",
+        policyKind: "tailoring_rule",
+        policyVersion: 2,
+        reviewedAt: "2026-08-01T12:34:56+00:00",
+      }),
+    ).toMatchObject({
+      reviewId,
+      recommendationId,
+      decision: "accepted",
+      policyVersion: 2,
+      reviewedAt: "2026-08-01T12:34:56.000Z",
+    });
+    expect(() =>
+      ReviewLearningRecommendationParamsSchema.parse({
+        recommendationId,
+        decision: "accepted",
+        unexpected: true,
+      }),
+    ).toThrow();
+    expect(() =>
+      ReviewLearningRecommendationResultSchema.parse({
+        status: "succeeded",
+        reviewId,
+        recommendationId,
+        revision: 1,
+        decision: "accepted",
+        context: "materials",
+        policyKind: "tailoring_rule",
+        policyVersion: null,
+        reviewedAt: "2026-08-01T12:34:56Z",
+      }),
+    ).toThrow();
+    expect(() =>
+      ReviewLearningRecommendationResultSchema.parse({
+        status: "succeeded",
+        reviewId,
+        recommendationId,
+        revision: 1,
+        decision: "rejected",
+        context: "materials",
+        policyKind: "tailoring_rule",
+        policyVersion: 2,
+        reviewedAt: "2026-08-01T12:34:56Z",
       }),
     ).toThrow();
   });

--- a/apps/api/test/rpc-contracts.test.ts
+++ b/apps/api/test/rpc-contracts.test.ts
@@ -17,6 +17,8 @@ import {
   ManualCaptureImportParamsSchema,
   ManualCaptureImportWorkflowResultSchema,
   ProviderModelCatalogResultSchema,
+  RederiveLearningRecommendationsParamsSchema,
+  RederiveLearningRecommendationsResultSchema,
   RefreshCompensationParamsSchema,
   RefreshCompensationResultSchema,
   RescoreJobParamsSchema,
@@ -31,6 +33,50 @@ import {
 } from "../src/contracts.js";
 
 const CANONICAL_JOB_ID = "11111111-1111-4111-8111-111111111111";
+
+describe("learning recommendation derivation RPC contract", () => {
+  it("registers bounded runtime-scoped request and result shapes", () => {
+    expect(RpcMethods.RederiveLearningRecommendations).toBe(
+      "rederive_learning_recommendations",
+    );
+    expect(
+      RederiveLearningRecommendationsParamsSchema.parse({
+        expectedAppDir: "/tmp/jobctrl",
+        expectedDbPath: "/tmp/jobctrl/jobctrl.db",
+      }),
+    ).toEqual({
+      tenantId: "local",
+      expectedAppDir: "/tmp/jobctrl",
+      expectedDbPath: "/tmp/jobctrl/jobctrl.db",
+    });
+    const recommendationId = `learning-recommendation:${"a".repeat(64)}`;
+    expect(
+      RederiveLearningRecommendationsResultSchema.parse({
+        status: "succeeded",
+        recommendationCount: 1,
+        recommendationIds: [recommendationId],
+      }),
+    ).toEqual({
+      status: "succeeded",
+      recommendationCount: 1,
+      recommendationIds: [recommendationId],
+    });
+    expect(() =>
+      RederiveLearningRecommendationsResultSchema.parse({
+        status: "succeeded",
+        recommendationCount: 0,
+        recommendationIds: [recommendationId],
+      }),
+    ).toThrow();
+    expect(() =>
+      RederiveLearningRecommendationsResultSchema.parse({
+        status: "succeeded",
+        recommendationCount: 1,
+        recommendationIds: ["private free text"],
+      }),
+    ).toThrow();
+  });
+});
 
 describe("cancel_run RPC contract", () => {
   it("registers cancel_run in RpcMethods", () => {

--- a/apps/api/test/rpc-contracts.test.ts
+++ b/apps/api/test/rpc-contracts.test.ts
@@ -21,6 +21,8 @@ import {
   RederiveLearningRecommendationsResultSchema,
   ReviewLearningRecommendationParamsSchema,
   ReviewLearningRecommendationResultSchema,
+  RollbackTailoringPolicyParamsSchema,
+  RollbackTailoringPolicyResultSchema,
   RefreshCompensationParamsSchema,
   RefreshCompensationResultSchema,
   RescoreJobParamsSchema,
@@ -149,6 +151,55 @@ describe("learning recommendation review RPC contract", () => {
         policyKind: "tailoring_rule",
         policyVersion: 2,
         reviewedAt: "2026-08-01T12:34:56Z",
+      }),
+    ).toThrow();
+  });
+});
+
+describe("tailoring policy rollback RPC contract", () => {
+  it("registers a runtime-scoped rollback with closed policy metadata", () => {
+    expect(RpcMethods.RollbackTailoringPolicy).toBe("rollback_tailoring_policy");
+    expect(
+      RollbackTailoringPolicyParamsSchema.parse({
+        targetVersion: 1,
+        expectedAppDir: "/tmp/jobctrl",
+        expectedDbPath: "/tmp/jobctrl/jobctrl.db",
+      }),
+    ).toEqual({
+      tenantId: "local",
+      targetVersion: 1,
+      expectedAppDir: "/tmp/jobctrl",
+      expectedDbPath: "/tmp/jobctrl/jobctrl.db",
+    });
+    expect(
+      RollbackTailoringPolicyResultSchema.parse({
+        status: "succeeded",
+        context: "materials",
+        policyKind: "tailoring_rule",
+        policyVersion: 3,
+        rollbackOfVersion: 1,
+        rollbackReasonCode: "user_requested",
+        learnedRules: [],
+        rolledBackAt: "2026-08-01T12:34:56+00:00",
+      }),
+    ).toMatchObject({
+      policyVersion: 3,
+      rollbackOfVersion: 1,
+      rolledBackAt: "2026-08-01T12:34:56.000Z",
+    });
+    expect(() =>
+      RollbackTailoringPolicyParamsSchema.parse({ targetVersion: 0 }),
+    ).toThrow();
+    expect(() =>
+      RollbackTailoringPolicyResultSchema.parse({
+        status: "succeeded",
+        context: "materials",
+        policyKind: "tailoring_rule",
+        policyVersion: 3,
+        rollbackOfVersion: 1,
+        rollbackReasonCode: "private narrative",
+        learnedRules: [],
+        rolledBackAt: "2026-08-01T12:34:56Z",
       }),
     ).toThrow();
   });

--- a/apps/api/test/schema-version-guard.test.ts
+++ b/apps/api/test/schema-version-guard.test.ts
@@ -142,14 +142,14 @@ describe("schema version guard at DB open", () => {
     const pythonManifest = fs.readFileSync(pythonManifestPath, "utf8");
 
     expect(pythonManifest).toContain("version=7,");
-    expect(pythonManifest).toContain("object_count=231,");
-    expect(pythonManifest).toContain("table_count=108,");
+    expect(pythonManifest).toContain("object_count=236,");
+    expect(pythonManifest).toContain("table_count=109,");
     expect(pythonManifest).toContain(`fingerprint=\"${EXACT_V7_SCHEMA_MANIFEST.fingerprint}\",`);
     expect(EXACT_V7_SCHEMA_MANIFEST).toEqual({
       version: SUPPORTED_SCHEMA_VERSION,
-      objectCount: 231,
-      tableCount: 108,
-      fingerprint: "8b2179d91d202bf43c5463ceb7f34313a0c75f296b20335ee4364cfa8d2e78bd",
+      objectCount: 236,
+      tableCount: 109,
+      fingerprint: "3b6ad22091d895ef141917e080df86b02dc21c56a1f9ffe3b70da3c9db6edad8",
     });
   });
 });

--- a/apps/api/test/schema-version-guard.test.ts
+++ b/apps/api/test/schema-version-guard.test.ts
@@ -142,14 +142,14 @@ describe("schema version guard at DB open", () => {
     const pythonManifest = fs.readFileSync(pythonManifestPath, "utf8");
 
     expect(pythonManifest).toContain("version=7,");
-    expect(pythonManifest).toContain("object_count=236,");
-    expect(pythonManifest).toContain("table_count=109,");
+    expect(pythonManifest).toContain("object_count=242,");
+    expect(pythonManifest).toContain("table_count=110,");
     expect(pythonManifest).toContain(`fingerprint=\"${EXACT_V7_SCHEMA_MANIFEST.fingerprint}\",`);
     expect(EXACT_V7_SCHEMA_MANIFEST).toEqual({
       version: SUPPORTED_SCHEMA_VERSION,
-      objectCount: 236,
-      tableCount: 109,
-      fingerprint: "3b6ad22091d895ef141917e080df86b02dc21c56a1f9ffe3b70da3c9db6edad8",
+      objectCount: 242,
+      tableCount: 110,
+      fingerprint: "55d88c87aaf9bec6c8686ee0e40dba31ca19aaaa5767042f9376f5e2756fecfd",
     });
   });
 });

--- a/apps/api/test/schema-version-guard.test.ts
+++ b/apps/api/test/schema-version-guard.test.ts
@@ -149,7 +149,7 @@ describe("schema version guard at DB open", () => {
       version: SUPPORTED_SCHEMA_VERSION,
       objectCount: 242,
       tableCount: 110,
-      fingerprint: "55d88c87aaf9bec6c8686ee0e40dba31ca19aaaa5767042f9376f5e2756fecfd",
+      fingerprint: "775312f0ec2640a2a87889602886c90e21a49e06fffc53cf26c435856247da97",
     });
   });
 });

--- a/apps/api/test/server.test.ts
+++ b/apps/api/test/server.test.ts
@@ -13,6 +13,7 @@ import {
   LearningRecommendationListResponseSchema,
   LearningRecommendationReviewResponseSchema,
   TailoringPolicyRevisionListResponseSchema,
+  TailoringPolicyRollbackResponseSchema,
   PipelineOperationsSnapshotSchema,
   ProviderConfigurationKeys,
   RpcMethods,
@@ -2683,6 +2684,111 @@ describe("local TypeScript API", () => {
     ).toBe(before);
     unchanged.close();
     await app.close();
+  });
+
+  it("rolls back tailoring policy through the runtime-scoped RPC boundary", async () => {
+    const call = vi.fn<JsonRpcDispatcher["call"]>(async () => ({
+      jsonrpc: "2.0" as const,
+      id: 1,
+      result: {
+        status: "succeeded",
+        context: "materials",
+        policyKind: "tailoring_rule",
+        policyVersion: 3,
+        rollbackOfVersion: 1,
+        rollbackReasonCode: "user_requested",
+        learnedRules: [],
+        rolledBackAt: "2026-08-01T12:34:56+00:00",
+      },
+    }));
+    const app = buildApp({
+      ...options,
+      providerDispatcher: { call, close: vi.fn(async () => undefined) },
+    });
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/v1/learning/policies/materials/rollbacks",
+      payload: { targetVersion: 1 },
+    });
+
+    expect(response.statusCode, response.body).toBe(200);
+    const parsed = TailoringPolicyRollbackResponseSchema.parse(response.json());
+    expect(parsed).toEqual({
+      ok: true,
+      context: "materials",
+      policyKind: "tailoring_rule",
+      version: 3,
+      status: "current",
+      learnedRules: [],
+      sourceReviewId: null,
+      sourceRecommendationId: null,
+      rollbackOfVersion: 1,
+      rollbackReasonCode: "user_requested",
+      createdAt: "2026-08-01T12:34:56.000Z",
+    });
+    expect(call).toHaveBeenCalledWith(RpcMethods.RollbackTailoringPolicy, {
+      tenantId: "local",
+      targetVersion: 1,
+      expectedAppDir: tempDir,
+      expectedDbPath: options.dbPath,
+    });
+
+    const invalid = await app.inject({
+      method: "POST",
+      url: "/v1/learning/policies/materials/rollbacks",
+      payload: { targetVersion: 0 },
+    });
+    expect(invalid.statusCode, invalid.body).toBe(400);
+    expect(call).toHaveBeenCalledTimes(1);
+    await app.close();
+
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(response.body, { status: 200, statusText: "OK" }),
+    );
+    await expect(
+      createJobCtrlApiClient().rollbackTailoringPolicy({ targetVersion: 1 }),
+    ).resolves.toEqual(parsed);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://127.0.0.1:8766/v1/learning/policies/materials/rollbacks",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ targetVersion: 1 }),
+      }),
+    );
+    fetchMock.mockRestore();
+
+    const badCall = vi.fn<JsonRpcDispatcher["call"]>(async () => ({
+      jsonrpc: "2.0" as const,
+      id: 1,
+      result: {
+        status: "succeeded",
+        context: "materials",
+        policyKind: "tailoring_rule",
+        policyVersion: 3,
+        rollbackOfVersion: 1,
+        rollbackReasonCode: "private rollback narrative",
+        learnedRules: [],
+        rolledBackAt: "2026-08-01T12:34:56Z",
+      },
+    }));
+    const badApp = buildApp({
+      ...options,
+      providerDispatcher: { call: badCall, close: vi.fn(async () => undefined) },
+    });
+    const badResponse = await badApp.inject({
+      method: "POST",
+      url: "/v1/learning/policies/materials/rollbacks",
+      payload: { targetVersion: 1 },
+    });
+    expect(badResponse.statusCode, badResponse.body).toBe(502);
+    expect(badResponse.json()).toEqual({
+      ok: false,
+      error: "tailoring_policy_rollback_failed",
+      message: "The tailoring policy rollback could not be completed.",
+    });
+    expect(badResponse.body).not.toContain("private rollback narrative");
+    await badApp.close();
   });
 
   it("serves paginated recommendation evidence links without source content", async () => {

--- a/apps/api/test/server.test.ts
+++ b/apps/api/test/server.test.ts
@@ -2547,6 +2547,100 @@ describe("local TypeScript API", () => {
     await app.close();
   });
 
+  it("excludes terminal learning recommendations from tenant-scoped pages without hiding evidence", async () => {
+    const acceptedRecommendationId = `learning-recommendation:${"a".repeat(64)}`;
+    const rejectedRecommendationId = `learning-recommendation:${"b".repeat(64)}`;
+    const pendingRecommendationId = `learning-recommendation:${"c".repeat(64)}`;
+    const otherTenantRecommendationId = `learning-recommendation:${"d".repeat(64)}`;
+    const db = new Database(options.dbPath);
+    insertLearningRecommendationFixture(db, {
+      tenantId: "local",
+      recommendationId: acceptedRecommendationId,
+      tombstoned: false,
+    });
+    insertLearningRecommendationFixture(db, {
+      tenantId: "local",
+      recommendationId: rejectedRecommendationId,
+      tombstoned: false,
+    });
+    insertLearningRecommendationFixture(db, {
+      tenantId: "local",
+      recommendationId: pendingRecommendationId,
+      tombstoned: false,
+    });
+    insertLearningRecommendationFixture(db, {
+      tenantId: "other",
+      recommendationId: otherTenantRecommendationId,
+      tombstoned: false,
+    });
+    insertTailoringPolicyFixture(db, {
+      tenantId: "local",
+      version: 1,
+      learnedRules: {},
+      createdAt: "2026-08-01T10:00:00Z",
+    });
+    db.prepare(
+      `INSERT INTO learning_recommendation_reviews (
+         tenant_id, review_id, recommendation_id, revision, decision,
+         context, policy_kind, policy_version, reviewed_at
+       ) VALUES ('local', ?, ?, 1, 'accepted', 'materials', 'tailoring_rule', 1, ?)`,
+    ).run(
+      `learning-recommendation-review:${"e".repeat(64)}`,
+      acceptedRecommendationId,
+      "2026-08-01T10:01:00Z",
+    );
+    db.prepare(
+      `INSERT INTO learning_recommendation_reviews (
+         tenant_id, review_id, recommendation_id, revision, decision,
+         context, policy_kind, policy_version, reviewed_at
+       ) VALUES ('local', ?, ?, 1, 'rejected', 'materials', 'tailoring_rule', NULL, ?)`,
+    ).run(
+      `learning-recommendation-review:${"f".repeat(64)}`,
+      rejectedRecommendationId,
+      "2026-08-01T10:02:00Z",
+    );
+    db.close();
+
+    const app = buildApp(options);
+    const firstPage = LearningRecommendationListResponseSchema.parse(
+      (
+        await app.inject({
+          method: "GET",
+          url: "/v1/learning/recommendations?page=1&pageSize=1",
+        })
+      ).json(),
+    );
+    const secondPage = LearningRecommendationListResponseSchema.parse(
+      (
+        await app.inject({
+          method: "GET",
+          url: "/v1/learning/recommendations?page=2&pageSize=1",
+        })
+      ).json(),
+    );
+    const acceptedEvidence = LearningRecommendationEvidenceListResponseSchema.parse(
+      (
+        await app.inject({
+          method: "GET",
+          url: `/v1/learning/recommendations/${encodeURIComponent(acceptedRecommendationId)}/evidence`,
+        })
+      ).json(),
+    );
+
+    expect(firstPage).toMatchObject({ page: 1, pageSize: 1, total: 1, totalPages: 1 });
+    expect(firstPage.recommendations).toEqual([
+      expect.objectContaining({ recommendationId: pendingRecommendationId }),
+    ]);
+    expect(secondPage).toMatchObject({ page: 2, pageSize: 1, total: 1, totalPages: 1 });
+    expect(secondPage.recommendations).toEqual([]);
+    expect(acceptedEvidence).toMatchObject({
+      recommendationId: acceptedRecommendationId,
+      total: 4,
+    });
+
+    await app.close();
+  });
+
   it("serves privacy-bounded tailoring policy revision history", async () => {
     const recommendationId = `learning-recommendation:${"a".repeat(64)}`;
     const reviewId = `learning-recommendation-review:${"b".repeat(64)}`;

--- a/apps/api/test/server.test.ts
+++ b/apps/api/test/server.test.ts
@@ -12,6 +12,7 @@ import {
   LearningRecommendationEvidenceListResponseSchema,
   LearningRecommendationListResponseSchema,
   LearningRecommendationReviewResponseSchema,
+  TailoringPolicyRevisionListResponseSchema,
   PipelineOperationsSnapshotSchema,
   ProviderConfigurationKeys,
   RpcMethods,
@@ -2541,6 +2542,145 @@ describe("local TypeScript API", () => {
     fetchMock.mockRestore();
     const unchanged = new Database(options.dbPath);
     expect(learningAuditSnapshot(unchanged)).toBe(auditBefore);
+    unchanged.close();
+    await app.close();
+  });
+
+  it("serves privacy-bounded tailoring policy revision history", async () => {
+    const recommendationId = `learning-recommendation:${"a".repeat(64)}`;
+    const reviewId = `learning-recommendation-review:${"b".repeat(64)}`;
+    const db = new Database(options.dbPath);
+    insertLearningRecommendationFixture(db, {
+      tenantId: "local",
+      recommendationId,
+      tombstoned: false,
+    });
+    insertTailoringPolicyFixture(db, {
+      tenantId: "local",
+      version: 1,
+      learnedRules: {},
+      createdAt: "2026-08-01T10:00:00Z",
+    });
+    insertTailoringPolicyFixture(db, {
+      tenantId: "local",
+      version: 2,
+      learnedRules: { fact_handling: "require_source_match" },
+      createdAt: "2026-08-01T11:00:00Z",
+    });
+    db.prepare(
+      `INSERT INTO learning_recommendation_reviews (
+         tenant_id, review_id, recommendation_id, revision, decision,
+         context, policy_kind, policy_version, reviewed_at
+       ) VALUES ('local', ?, ?, 1, 'accepted', 'materials', 'tailoring_rule', 2, ?)`,
+    ).run(reviewId, recommendationId, "2026-08-01T11:00:00Z");
+    insertTailoringPolicyFixture(db, {
+      tenantId: "local",
+      version: 3,
+      learnedRules: {},
+      rollbackOfVersion: 1,
+      rollbackReason: "private historical rollback narrative",
+      createdAt: "2026-08-01T11:30:00Z",
+    });
+    insertTailoringPolicyFixture(db, {
+      tenantId: "local",
+      version: 4,
+      learnedRules: {},
+      rollbackOfVersion: 1,
+      rollbackReason: "user_requested",
+      createdAt: "2026-08-01T12:00:00Z",
+    });
+    insertTailoringPolicyFixture(db, {
+      tenantId: "other",
+      version: 1,
+      learnedRules: { provenance_policy: "require_direct_evidence" },
+      createdAt: "2026-08-01T10:00:00Z",
+    });
+    const before = JSON.stringify(
+      db.prepare("SELECT * FROM tailoring_policies ORDER BY tenant_id, version").all(),
+    );
+    db.close();
+
+    const app = buildApp(options);
+    const response = await app.inject({
+      method: "GET",
+      url: "/v1/learning/policies/materials?page=1&pageSize=4",
+    });
+
+    expect(response.statusCode, response.body).toBe(200);
+    const parsed = TailoringPolicyRevisionListResponseSchema.parse(response.json());
+    expect(parsed).toMatchObject({ page: 1, pageSize: 4, total: 4, totalPages: 1 });
+    expect(parsed.revisions).toEqual([
+      {
+        context: "materials",
+        policyKind: "tailoring_rule",
+        version: 4,
+        status: "current",
+        learnedRules: [],
+        sourceReviewId: null,
+        sourceRecommendationId: null,
+        rollbackOfVersion: 1,
+        rollbackReasonCode: "user_requested",
+        createdAt: "2026-08-01T12:00:00.000Z",
+      },
+      {
+        context: "materials",
+        policyKind: "tailoring_rule",
+        version: 3,
+        status: "superseded",
+        learnedRules: [],
+        sourceReviewId: null,
+        sourceRecommendationId: null,
+        rollbackOfVersion: 1,
+        rollbackReasonCode: "historical_or_unspecified",
+        createdAt: "2026-08-01T11:30:00.000Z",
+      },
+      {
+        context: "materials",
+        policyKind: "tailoring_rule",
+        version: 2,
+        status: "superseded",
+        learnedRules: [{ ruleKey: "fact_handling", ruleValue: "require_source_match" }],
+        sourceReviewId: reviewId,
+        sourceRecommendationId: recommendationId,
+        rollbackOfVersion: null,
+        rollbackReasonCode: null,
+        createdAt: "2026-08-01T11:00:00.000Z",
+      },
+      {
+        context: "materials",
+        policyKind: "tailoring_rule",
+        version: 1,
+        status: "superseded",
+        learnedRules: [],
+        sourceReviewId: null,
+        sourceRecommendationId: null,
+        rollbackOfVersion: null,
+        rollbackReasonCode: null,
+        createdAt: "2026-08-01T10:00:00.000Z",
+      },
+    ]);
+    expect(response.body).not.toContain("sha256:private-prompt");
+    expect(response.body).not.toContain("require_direct_evidence");
+    expect(response.body).not.toContain("private historical rollback narrative");
+
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(response.body, { status: 200, statusText: "OK" }),
+    );
+    await expect(
+      createJobCtrlApiClient().tailoringPolicyRevisions({ page: 1, pageSize: 4 }),
+    ).resolves.toEqual(parsed);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://127.0.0.1:8766/v1/learning/policies/materials?page=1&pageSize=4",
+      expect.objectContaining({ method: "GET" }),
+    );
+    fetchMock.mockRestore();
+
+    const unchanged = new Database(options.dbPath);
+    expect(
+      JSON.stringify(
+        unchanged.prepare("SELECT * FROM tailoring_policies ORDER BY tenant_id, version").all(),
+      ),
+    ).toBe(before);
     unchanged.close();
     await app.close();
   });
@@ -10766,6 +10906,43 @@ function insertLearningRecommendationFixture(
       );
     }
   })();
+}
+
+function insertTailoringPolicyFixture(
+  db: Database.Database,
+  options: {
+    tenantId: string;
+    version: number;
+    learnedRules: Record<string, string>;
+    createdAt: string;
+    rollbackOfVersion?: number;
+    rollbackReason?: string;
+  },
+): void {
+  db.prepare(
+    `INSERT INTO tailoring_policies (
+       tenant_id, version, prompt_version, schema_version, judge_schema_version,
+       prompt_fingerprint, config_fingerprint, profile_policy_fingerprint,
+       custom_prompt_fingerprint, generator_settings_json, judge_settings_json,
+       runtime_settings_json, rollback_of_version, rollback_reason, created_at,
+       created_from_event_id
+     ) VALUES (?, ?, 'tailor.v2', 'resume.v1', 'judge.v1', ?, ?, ?, ?, '{}', '{}',
+               ?, ?, ?, ?, NULL)`,
+  ).run(
+    options.tenantId,
+    options.version,
+    "sha256:private-prompt",
+    `sha256:config-${options.version}`,
+    "sha256:private-profile",
+    "sha256:private-custom",
+    JSON.stringify({
+      validation_mode: "normal",
+      learned_tailoring_rules: options.learnedRules,
+    }),
+    options.rollbackOfVersion ?? null,
+    options.rollbackReason ?? "",
+    options.createdAt,
+  );
 }
 
 function learningAuditSnapshot(db: Database.Database): string {

--- a/apps/api/test/server.test.ts
+++ b/apps/api/test/server.test.ts
@@ -11,8 +11,10 @@ import {
   JsonRpcErrorCodes,
   LearningRecommendationEvidenceListResponseSchema,
   LearningRecommendationListResponseSchema,
+  LearningRecommendationReviewResponseSchema,
   PipelineOperationsSnapshotSchema,
   ProviderConfigurationKeys,
+  RpcMethods,
   ScoringKeywordAggregationResponseSchema,
   SecretCredentialKeys,
   type ActionCommandPayload,
@@ -2700,6 +2702,221 @@ describe("local TypeScript API", () => {
     const unchanged = new Database(options.dbPath);
     expect(learningAuditSnapshot(unchanged)).toBe(auditBefore);
     unchanged.close();
+    await app.close();
+  });
+
+  it("reviews learning recommendations through the runtime-scoped RPC boundary", async () => {
+    const recommendationId = `learning-recommendation:${"a".repeat(64)}`;
+    const acceptedReviewId = `learning-recommendation-review:${"b".repeat(64)}`;
+    const rejectedReviewId = `learning-recommendation-review:${"c".repeat(64)}`;
+    const call = vi.fn<JsonRpcDispatcher["call"]>(async (_method, params) => ({
+      jsonrpc: "2.0" as const,
+      id: 1,
+      result:
+        params.decision === "accepted"
+          ? {
+              status: "succeeded",
+              reviewId: acceptedReviewId,
+              recommendationId,
+              revision: 1,
+              decision: "accepted",
+              context: "materials",
+              policyKind: "tailoring_rule",
+              policyVersion: 2,
+              reviewedAt: "2026-08-01T12:34:56+00:00",
+            }
+          : {
+              status: "succeeded",
+              reviewId: rejectedReviewId,
+              recommendationId,
+              revision: 2,
+              decision: "rejected",
+              context: "materials",
+              policyKind: "tailoring_rule",
+              policyVersion: null,
+              reviewedAt: "2026-08-01T12:35:56Z",
+            },
+    }));
+    const app = buildApp({
+      ...options,
+      providerDispatcher: { call, close: vi.fn(async () => undefined) },
+    });
+
+    const accepted = await app.inject({
+      method: "POST",
+      url: `/v1/learning/recommendations/${recommendationId}/reviews`,
+      payload: { decision: "accepted" },
+    });
+    expect(accepted.statusCode, accepted.body).toBe(200);
+    const acceptedReview = LearningRecommendationReviewResponseSchema.parse(accepted.json());
+    expect(acceptedReview).toMatchObject({
+      reviewId: acceptedReviewId,
+      recommendationId,
+      decision: "accepted",
+      policyVersion: 2,
+      reviewedAt: "2026-08-01T12:34:56.000Z",
+    });
+    expect(call).toHaveBeenCalledWith(RpcMethods.ReviewLearningRecommendation, {
+      tenantId: "local",
+      recommendationId,
+      decision: "accepted",
+      expectedAppDir: tempDir,
+      expectedDbPath: options.dbPath,
+    });
+
+    const rejected = await app.inject({
+      method: "POST",
+      url: `/v1/learning/recommendations/${recommendationId}/reviews`,
+      payload: { decision: "rejected" },
+    });
+    expect(rejected.statusCode, rejected.body).toBe(200);
+    expect(LearningRecommendationReviewResponseSchema.parse(rejected.json())).toMatchObject({
+      reviewId: rejectedReviewId,
+      recommendationId,
+      decision: "rejected",
+      policyVersion: null,
+      reviewedAt: "2026-08-01T12:35:56.000Z",
+    });
+    await app.close();
+
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify(acceptedReview), { status: 200, statusText: "OK" }),
+    );
+    await expect(
+      createJobCtrlApiClient().reviewLearningRecommendation(recommendationId, {
+        decision: "accepted",
+      }),
+    ).resolves.toEqual(acceptedReview);
+    expect(fetchMock).toHaveBeenCalledWith(
+      `http://127.0.0.1:8766/v1/learning/recommendations/${encodeURIComponent(recommendationId)}/reviews`,
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ decision: "accepted" }),
+      }),
+    );
+    fetchMock.mockRestore();
+  });
+
+  it("rejects invalid learning review input before dispatch", async () => {
+    const call = vi.fn<JsonRpcDispatcher["call"]>(async () => {
+      throw new Error("review RPC must not be called");
+    });
+    const app = buildApp({
+      ...options,
+      providerDispatcher: { call, close: vi.fn(async () => undefined) },
+    });
+
+    const invalidId = await app.inject({
+      method: "POST",
+      url: "/v1/learning/recommendations/not-a-canonical-recommendation/reviews",
+      payload: { decision: "accepted" },
+    });
+    const invalidDecision = await app.inject({
+      method: "POST",
+      url: `/v1/learning/recommendations/learning-recommendation:${"a".repeat(64)}/reviews`,
+      payload: { decision: "deferred" },
+    });
+
+    expect(invalidId.statusCode, invalidId.body).toBe(400);
+    expect(invalidId.json()).toEqual({ ok: false, error: "invalid_learning_recommendation_id" });
+    expect(invalidDecision.statusCode).toBe(400);
+    expect(call).not.toHaveBeenCalled();
+    await app.close();
+  });
+
+  it("sanitizes learning review worker failures", async () => {
+    const recommendationId = `learning-recommendation:${"a".repeat(64)}`;
+    const marker = "private-worker-detail-must-not-appear";
+    const cases = [
+      {
+        statusCode: 409,
+        response: {
+          jsonrpc: "2.0" as const,
+          id: 1,
+          error: { code: JsonRpcErrorCodes.InvalidParams, message: marker, data: { marker } },
+        },
+      },
+      {
+        statusCode: 502,
+        response: {
+          jsonrpc: "2.0" as const,
+          id: 1,
+          error: { code: JsonRpcErrorCodes.InternalError, message: marker, data: { marker } },
+        },
+      },
+      {
+        statusCode: 502,
+        response: {
+          jsonrpc: "2.0" as const,
+          id: 1,
+          result: { status: "succeeded", privateDetail: marker },
+        },
+      },
+      { statusCode: 503, error: new Error(marker) },
+    ] as const;
+
+    for (const failure of cases) {
+      const call = vi.fn<JsonRpcDispatcher["call"]>(async () => {
+        if ("error" in failure) {
+          throw failure.error;
+        }
+        return failure.response;
+      });
+      const app = buildApp({
+        ...options,
+        providerDispatcher: { call, close: vi.fn(async () => undefined) },
+      });
+      const response = await app.inject({
+        method: "POST",
+        url: `/v1/learning/recommendations/${recommendationId}/reviews`,
+        payload: { decision: "accepted" },
+      });
+
+      expect(response.statusCode, response.body).toBe(failure.statusCode);
+      expect(response.json()).toEqual({
+        ok: false,
+        error: "learning_recommendation_review_failed",
+        message: "The learning recommendation review could not be completed.",
+      });
+      expect(response.body).not.toContain(marker);
+      await app.close();
+    }
+  });
+
+  it("sanitizes an impossible calendar date in a learning recommendation review result", async () => {
+    const recommendationId = `learning-recommendation:${"a".repeat(64)}`;
+    const call = vi.fn<JsonRpcDispatcher["call"]>(async () => ({
+      jsonrpc: "2.0" as const,
+      id: 1,
+      result: {
+        status: "succeeded",
+        reviewId: `learning-recommendation-review:${"b".repeat(64)}`,
+        recommendationId,
+        revision: 1,
+        decision: "accepted",
+        context: "materials",
+        policyKind: "tailoring_rule",
+        policyVersion: 2,
+        reviewedAt: "2026-02-31T12:34:56+00:00",
+      },
+    }));
+    const app = buildApp({
+      ...options,
+      providerDispatcher: { call, close: vi.fn(async () => undefined) },
+    });
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/v1/learning/recommendations/${recommendationId}/reviews`,
+      payload: { decision: "accepted" },
+    });
+
+    expect(response.statusCode, response.body).toBe(502);
+    expect(response.json()).toEqual({
+      ok: false,
+      error: "learning_recommendation_review_failed",
+      message: "The learning recommendation review could not be completed.",
+    });
     await app.close();
   });
 

--- a/apps/api/test/server.test.ts
+++ b/apps/api/test/server.test.ts
@@ -9,6 +9,7 @@ import {
   CREDENTIAL_VALUE_MAX_LENGTH,
   CredentialKeys,
   JsonRpcErrorCodes,
+  LearningRecommendationListResponseSchema,
   PipelineOperationsSnapshotSchema,
   ProviderConfigurationKeys,
   ScoringKeywordAggregationResponseSchema,
@@ -2411,6 +2412,133 @@ describe("local TypeScript API", () => {
       expect.objectContaining({ method: "GET" }),
     );
     fetchMock.mockRestore();
+    await app.close();
+  });
+
+  it("serves tenant-scoped learning recommendations without source content", async () => {
+    const db = new Database(options.dbPath);
+    insertLearningRecommendationFixture(db, {
+      tenantId: "local",
+      recommendationId: `learning-recommendation:${"a".repeat(64)}`,
+      tombstoned: true,
+    });
+    insertLearningRecommendationFixture(db, {
+      tenantId: "local",
+      recommendationId: `learning-recommendation:${"d".repeat(64)}`,
+      tombstoned: false,
+    });
+    insertLearningRecommendationFixture(db, {
+      tenantId: "other",
+      recommendationId: `learning-recommendation:${"b".repeat(64)}`,
+      tombstoned: false,
+    });
+    db.prepare(
+      `INSERT INTO resume_review_drafts (
+         tenant_id, draft_id, job_id, base_generation, renderer_format,
+         state, latest_revision_number, created_at, updated_at
+       ) VALUES ('local', 'private-learning-draft', ?, 1, 'text',
+                 'active', 0, ?, ?)`,
+    ).run(
+      jobIdFor("https://example.com/jobs/ready"),
+      "2026-08-01T09:00:00Z",
+      "2026-08-01T09:00:00Z",
+    );
+    db.prepare(
+      `INSERT INTO tailoring_feedback_signals (
+         tenant_id, signal_id, job_id, draft_id, source_kind, source_id,
+         signal_kind, status, summary, created_at
+       ) VALUES ('local', 'private-learning-signal', ?,
+                 'private-learning-draft', 'edit_delta', 'private-delta',
+                 'factual_correction', 'candidate', ?, ?)`,
+    ).run(
+      jobIdFor("https://example.com/jobs/ready"),
+      "private resume, prompt, note, and job description",
+      "2026-08-01T09:00:00Z",
+    );
+    const auditBefore = learningAuditSnapshot(db);
+    db.close();
+
+    const app = buildApp(options);
+    const response = await app.inject({
+      method: "GET",
+      url: "/v1/learning/recommendations?page=1&pageSize=1",
+    });
+
+    expect(response.statusCode, response.body).toBe(200);
+    const parsed = LearningRecommendationListResponseSchema.parse(response.json());
+    expect(parsed.recommendations).toHaveLength(1);
+    expect(parsed).toMatchObject({ page: 1, pageSize: 1, total: 2, totalPages: 2 });
+    expect(parsed.recommendations[0]).toMatchObject({
+      recommendationId: `learning-recommendation:${"a".repeat(64)}`,
+      context: "materials",
+      policyKind: "tailoring_rule",
+      signalKind: "factual_correction",
+      ruleKey: "fact_handling",
+      ruleValue: "require_source_match",
+      status: "pending",
+      active: false,
+      observedSignalCount: 3,
+      observedJobCount: 2,
+      minimumSignalCount: 3,
+      minimumJobCount: 2,
+      confidenceLimit: "sample_gated_no_population_inference",
+      supportingEvidenceCount: 3,
+      contradictingEvidenceCount: 1,
+      tombstoneCount: 1,
+    });
+    expect(response.body).not.toContain("private resume, prompt, note, and job description");
+    expect(response.body).not.toContain("source-contradiction-local");
+    expect(response.body).not.toContain(`learning-recommendation:${"b".repeat(64)}`);
+    expect(() =>
+      LearningRecommendationListResponseSchema.parse({
+        ...parsed,
+        recommendations: [
+          {
+            ...parsed.recommendations[0],
+            recommendationId: "https://jobs.example/not-a-recommendation-id",
+          },
+        ],
+      }),
+    ).toThrow();
+    expect(() =>
+      LearningRecommendationListResponseSchema.parse({
+        ...parsed,
+        recommendations: [
+          { ...parsed.recommendations[0], ruleKey: "private free text" },
+        ],
+      }),
+    ).toThrow();
+    const secondPage = LearningRecommendationListResponseSchema.parse(
+      (
+        await app.inject({
+          method: "GET",
+          url: "/v1/learning/recommendations?page=2&pageSize=1",
+        })
+      ).json(),
+    );
+    expect(secondPage).toMatchObject({ page: 2, pageSize: 1, total: 2, totalPages: 2 });
+    expect(secondPage.recommendations).toEqual([
+      expect.objectContaining({
+        recommendationId: `learning-recommendation:${"d".repeat(64)}`,
+        active: true,
+        tombstoneCount: 0,
+      }),
+    ]);
+
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(response.body, { status: 200, statusText: "OK" }),
+    );
+    await expect(
+      createJobCtrlApiClient().learningRecommendations({ page: 1, pageSize: 1 }),
+    ).resolves.toEqual(parsed);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://127.0.0.1:8766/v1/learning/recommendations?page=1&pageSize=1",
+      expect.objectContaining({ method: "GET" }),
+    );
+    fetchMock.mockRestore();
+    const unchanged = new Database(options.dbPath);
+    expect(learningAuditSnapshot(unchanged)).toBe(auditBefore);
+    unchanged.close();
     await app.close();
   });
 
@@ -10158,6 +10286,120 @@ function seedBuiltInResumeTemplate(db: Database.Database): void {
      ) VALUES ('local', 'built_in:modern-html:v1', 'built_in:modern-html', 1,
                'Modern HTML', 'active', ?, '{}', 'server-seed-hash', ?)`,
   ).run(JSON.stringify(BUILT_IN_RESUME_TEMPLATE_THEME), now);
+}
+
+function insertLearningRecommendationFixture(
+  db: Database.Database,
+  options: {
+    tenantId: string;
+    recommendationId: string;
+    tombstoned: boolean;
+  },
+): void {
+  const jobIds = [
+    "11111111-1111-4111-8111-111111111111",
+    "22222222-2222-4222-8222-222222222222",
+  ] as const;
+  db.transaction(() => {
+    for (const index of [1, 2, 3] as const) {
+      const signalId = `signal-${options.tenantId}-${index}`;
+      db.prepare(
+        `INSERT INTO learning_recommendation_evidence (
+           tenant_id, recommendation_id, signal_id, evidence_role,
+           source_kind, source_id, source_revision, recorded_at
+         ) VALUES (?, ?, ?, 'supporting', 'tailoring_feedback_signal', ?, ?, ?)`,
+      ).run(
+        options.tenantId,
+        options.recommendationId,
+        signalId,
+        `source-${options.tenantId}-${index}`,
+        index,
+        `2026-08-01T10:00:0${index}Z`,
+      );
+      db.prepare(
+        `INSERT INTO learning_recommendation_evidence_jobs (
+           tenant_id, recommendation_id, signal_id, job_id
+         ) VALUES (?, ?, ?, ?)`,
+      ).run(
+        options.tenantId,
+        options.recommendationId,
+        signalId,
+        index === 3 ? jobIds[1] : jobIds[0],
+      );
+    }
+    const contradictionId = `contradiction-${options.tenantId}`;
+    db.prepare(
+      `INSERT INTO learning_recommendation_evidence (
+         tenant_id, recommendation_id, signal_id, evidence_role,
+         source_kind, source_id, source_revision, recorded_at
+       ) VALUES (?, ?, ?, 'contradicting', 'tailoring_feedback_signal', ?, 4, ?)`,
+    ).run(
+      options.tenantId,
+      options.recommendationId,
+      contradictionId,
+      options.tenantId === "local"
+        ? "private resume, prompt, note, and job description"
+        : `source-${contradictionId}`,
+      "2026-08-01T10:00:04Z",
+    );
+    db.prepare(
+      `INSERT INTO learning_recommendation_evidence_jobs (
+         tenant_id, recommendation_id, signal_id, job_id
+       ) VALUES (?, ?, ?, '33333333-3333-4333-8333-333333333333')`,
+    ).run(options.tenantId, options.recommendationId, contradictionId);
+    for (const jobId of jobIds) {
+      db.prepare(
+        `INSERT INTO learning_recommendation_jobs (
+           tenant_id, recommendation_id, job_id
+         ) VALUES (?, ?, ?)`,
+      ).run(options.tenantId, options.recommendationId, jobId);
+    }
+    db.prepare(
+      `INSERT INTO learning_recommendations (
+         tenant_id, recommendation_id, derivation_version,
+         evaluation_fixture_version, context, policy_kind, signal_kind,
+         rule_key, rule_value, allowlist_version, status,
+         observed_signal_count, observed_job_count, minimum_signal_count,
+         minimum_job_count, confidence_limit, input_fingerprint, derived_at
+       ) VALUES (
+         ?, ?, 1, 1, 'materials', 'tailoring_rule', 'factual_correction',
+         'fact_handling', 'require_source_match', 1, 'pending', 3, 2, 3, 2,
+         'sample_gated_no_population_inference', ?, '2026-08-01T10:01:00Z'
+       )`,
+    ).run(
+      options.tenantId,
+      options.recommendationId,
+      options.recommendationId.replace("learning-recommendation:", ""),
+    );
+    if (options.tombstoned) {
+      db.prepare(
+        `INSERT INTO learning_recommendation_tombstones (
+           tenant_id, tombstone_id, recommendation_id, affected_signal_id,
+           affected_source_revision, reason_code, derivation_version,
+           tombstoned_at, rederived_at, replacement_recommendation_id
+         ) VALUES (?, ?, ?, ?, 1, 'source_deleted', 1, ?, ?, NULL)`,
+      ).run(
+        options.tenantId,
+        `learning-recommendation-tombstone:${"c".repeat(64)}`,
+        options.recommendationId,
+        `signal-${options.tenantId}-1`,
+        "2026-08-01T10:02:00Z",
+        "2026-08-01T10:02:01Z",
+      );
+    }
+  })();
+}
+
+function learningAuditSnapshot(db: Database.Database): string {
+  return JSON.stringify(
+    [
+      "learning_recommendations",
+      "learning_recommendation_evidence",
+      "learning_recommendation_evidence_jobs",
+      "learning_recommendation_jobs",
+      "learning_recommendation_tombstones",
+    ].map((table) => [table, db.prepare(`SELECT * FROM ${table} ORDER BY rowid`).all()]),
+  );
 }
 
 function seedDatabase(dbPath: string): void {

--- a/apps/api/test/server.test.ts
+++ b/apps/api/test/server.test.ts
@@ -9,6 +9,7 @@ import {
   CREDENTIAL_VALUE_MAX_LENGTH,
   CredentialKeys,
   JsonRpcErrorCodes,
+  LearningRecommendationEvidenceListResponseSchema,
   LearningRecommendationListResponseSchema,
   PipelineOperationsSnapshotSchema,
   ProviderConfigurationKeys,
@@ -2536,6 +2537,166 @@ describe("local TypeScript API", () => {
       expect.objectContaining({ method: "GET" }),
     );
     fetchMock.mockRestore();
+    const unchanged = new Database(options.dbPath);
+    expect(learningAuditSnapshot(unchanged)).toBe(auditBefore);
+    unchanged.close();
+    await app.close();
+  });
+
+  it("serves paginated recommendation evidence links without source content", async () => {
+    const recommendationId = `learning-recommendation:${"a".repeat(64)}`;
+    const otherTenantRecommendationId = `learning-recommendation:${"b".repeat(64)}`;
+    const db = new Database(options.dbPath);
+    insertLearningRecommendationFixture(db, {
+      tenantId: "local",
+      recommendationId,
+      tombstoned: false,
+    });
+    insertLearningRecommendationFixture(db, {
+      tenantId: "other",
+      recommendationId: otherTenantRecommendationId,
+      tombstoned: false,
+    });
+    const auditBefore = learningAuditSnapshot(db);
+    db.close();
+
+    const app = buildApp(options);
+    const firstResponse = await app.inject({
+      method: "GET",
+      url: `/v1/learning/recommendations/${encodeURIComponent(recommendationId)}/evidence?page=1&pageSize=3`,
+    });
+
+    expect(firstResponse.statusCode, firstResponse.body).toBe(200);
+    const firstPage = LearningRecommendationEvidenceListResponseSchema.parse(
+      firstResponse.json(),
+    );
+    expect(firstPage).toMatchObject({
+      recommendationId,
+      page: 1,
+      pageSize: 3,
+      total: 4,
+      totalPages: 2,
+    });
+    expect(firstPage.evidence).toEqual([
+      {
+        signalId: "signal-local-1",
+        evidenceRole: "supporting",
+        sourceKind: "tailoring_feedback_signal",
+        sourceRevision: 1,
+        jobId: "11111111-1111-4111-8111-111111111111",
+        recordedAt: "2026-08-01T10:00:01.000Z",
+      },
+      {
+        signalId: "signal-local-2",
+        evidenceRole: "supporting",
+        sourceKind: "tailoring_feedback_signal",
+        sourceRevision: 2,
+        jobId: "11111111-1111-4111-8111-111111111111",
+        recordedAt: "2026-08-01T10:00:02.000Z",
+      },
+      {
+        signalId: "signal-local-3",
+        evidenceRole: "supporting",
+        sourceKind: "tailoring_feedback_signal",
+        sourceRevision: 3,
+        jobId: "22222222-2222-4222-8222-222222222222",
+        recordedAt: "2026-08-01T10:00:03.000Z",
+      },
+    ]);
+    expect(firstResponse.body).not.toContain(
+      "private resume, prompt, note, and job description",
+    );
+    expect(firstResponse.body).not.toContain("source-local-1");
+
+    const secondResponse = await app.inject({
+      method: "GET",
+      url: `/v1/learning/recommendations/${encodeURIComponent(recommendationId)}/evidence?page=2&pageSize=3`,
+    });
+    expect(secondResponse.statusCode, secondResponse.body).toBe(200);
+    const secondPage = LearningRecommendationEvidenceListResponseSchema.parse(
+      secondResponse.json(),
+    );
+    expect(secondPage.evidence).toEqual([
+      {
+        signalId: "contradiction-local",
+        evidenceRole: "contradicting",
+        sourceKind: "tailoring_feedback_signal",
+        sourceRevision: 4,
+        jobId: "33333333-3333-4333-8333-333333333333",
+        recordedAt: "2026-08-01T10:00:04.000Z",
+      },
+    ]);
+    expect(secondResponse.body).not.toContain(
+      "private resume, prompt, note, and job description",
+    );
+
+    const otherTenant = await app.inject({
+      method: "GET",
+      url: `/v1/learning/recommendations/${encodeURIComponent(otherTenantRecommendationId)}/evidence`,
+    });
+    expect(otherTenant.statusCode, otherTenant.body).toBe(404);
+    expect(otherTenant.json()).toEqual({
+      ok: false,
+      error: "learning_recommendation_not_found",
+    });
+    const invalid = await app.inject({
+      method: "GET",
+      url: `/v1/learning/recommendations/${encodeURIComponent("https://jobs.example/not-an-id")}/evidence`,
+    });
+    expect(invalid.statusCode, invalid.body).toBe(400);
+    expect(invalid.json()).toEqual({
+      ok: false,
+      error: "invalid_learning_recommendation_id",
+    });
+    expect(() =>
+      LearningRecommendationEvidenceListResponseSchema.parse({
+        ...firstPage,
+        evidence: [
+          {
+            ...firstPage.evidence[0],
+            signalId: "private free text",
+          },
+        ],
+      }),
+    ).toThrow();
+    expect(() =>
+      LearningRecommendationEvidenceListResponseSchema.parse({
+        ...firstPage,
+        evidence: [
+          {
+            ...firstPage.evidence[0],
+            jobId: "AAAAAAAA-AAAA-4AAA-8AAA-AAAAAAAAAAAA",
+          },
+        ],
+      }),
+    ).toThrow();
+    expect(() =>
+      LearningRecommendationEvidenceListResponseSchema.parse({
+        ...firstPage,
+        evidence: [
+          {
+            ...firstPage.evidence[0],
+            jobId: "https://jobs.example/url-is-not-a-job-id",
+          },
+        ],
+      }),
+    ).toThrow();
+
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(firstResponse.body, { status: 200, statusText: "OK" }),
+    );
+    await expect(
+      createJobCtrlApiClient().learningRecommendationEvidence(recommendationId, {
+        page: 1,
+        pageSize: 3,
+      }),
+    ).resolves.toEqual(firstPage);
+    expect(fetchMock).toHaveBeenCalledWith(
+      `http://127.0.0.1:8766/v1/learning/recommendations/${encodeURIComponent(recommendationId)}/evidence?page=1&pageSize=3`,
+      expect.objectContaining({ method: "GET" }),
+    );
+    fetchMock.mockRestore();
+
     const unchanged = new Database(options.dbPath);
     expect(learningAuditSnapshot(unchanged)).toBe(auditBefore);
     unchanged.close();

--- a/apps/web/e2e/tests/learning-policy.spec.ts
+++ b/apps/web/e2e/tests/learning-policy.spec.ts
@@ -1,0 +1,295 @@
+import { expect, type Page, test } from "@playwright/test";
+import Database from "better-sqlite3";
+
+import { loadE2eDbPath } from "../fixtures/e2e-state.js";
+
+const STYLE_RECOMMENDATION_ID = `learning-recommendation:${"a".repeat(64)}`;
+const FACTUAL_RECOMMENDATION_ID = `learning-recommendation:${"b".repeat(64)}`;
+const ACCEPTED_REVIEW_ID = `learning-recommendation-review:${"c".repeat(64)}`;
+const REJECTED_REVIEW_ID = `learning-recommendation-review:${"d".repeat(64)}`;
+const ACCEPTED_AT = "2026-05-04T11:20:00.000Z";
+const REJECTED_AT = "2026-05-04T11:21:00.000Z";
+const ROLLED_BACK_AT = "2026-05-04T11:22:00.000Z";
+
+test("Dashboard learning review keeps evidence, terminal decisions, and policy rollback auditable", async ({
+  page,
+}) => {
+  const dbPath = loadE2eDbPath();
+  await installDeterministicLearningWrites(page, dbPath);
+
+  const initialRecommendations = page.waitForResponse(
+    (response) =>
+      response.url().includes("/v1/learning/recommendations") &&
+      response.request().method() === "GET",
+  );
+  const initialPolicyHistory = page.waitForResponse(
+    (response) =>
+      response.url().includes("/v1/learning/policies/materials") &&
+      response.request().method() === "GET",
+  );
+  await page.goto("/dashboard");
+  expect((await initialRecommendations).status()).toBe(200);
+  expect((await initialPolicyHistory).status()).toBe(200);
+
+  const recommendations = page.locator(".learning-review-panel");
+  const policyHistory = page.locator(".tailoring-policy-history-panel");
+  const styleRecommendation = recommendations.getByRole("article", {
+    name: "style_guidance → preserve_user_edit_pattern",
+  });
+  const factualRecommendation = recommendations.getByRole("article", {
+    name: "fact_handling → require_source_match",
+  });
+
+  await expect(styleRecommendation).toBeVisible({ timeout: 30_000 });
+  await expect(factualRecommendation).toBeVisible();
+  await expect(
+    styleRecommendation.getByText("3 of 3 required accepted signals across 2 of 2 required jobs"),
+  ).toBeVisible();
+  await expect(policyHistory.getByRole("article", { name: "Version 1" })).toBeVisible();
+  await expect(
+    policyHistory.getByRole("button", { name: "Restore tailoring policy version 1" }),
+  ).toHaveCount(0);
+
+  await styleRecommendation
+    .getByRole("button", { name: "Inspect evidence for style_guidance → preserve_user_edit_pattern" })
+    .click();
+  const evidence = styleRecommendation.getByRole("list", {
+    name: "Evidence for style_guidance → preserve_user_edit_pattern",
+  });
+  await expect(evidence.getByText("tailoring-feedback:qa-learning-style-1:1")).toBeVisible();
+  await expect(
+    evidence.getByText(/revision 1 · job abaf847c-43cd-40ad-8dc3-76685694ff29/i),
+  ).toHaveCount(2);
+  await expect(
+    evidence.getByText(/revision 1 · job 1b34c69a-9c9f-4f67-8bd1-9682a6ff492a/i),
+  ).toHaveCount(1);
+
+  await styleRecommendation
+    .getByRole("button", {
+      name: "Accept learning recommendation style_guidance → preserve_user_edit_pattern",
+    })
+    .click();
+  await expect(styleRecommendation).toHaveCount(0);
+  const acceptedRecommendations = page.waitForResponse(
+    (response) =>
+      response.url().includes("/v1/learning/recommendations") &&
+      response.request().method() === "GET",
+  );
+  const acceptedHistory = page.waitForResponse(
+    (response) =>
+      response.url().includes("/v1/learning/policies/materials") &&
+      response.request().method() === "GET",
+  );
+  await page.reload();
+  expect((await acceptedRecommendations).status()).toBe(200);
+  expect((await acceptedHistory).status()).toBe(200);
+  const acceptedPolicy = policyHistory.getByRole("article", { name: "Version 2" });
+  await expect(acceptedPolicy).toBeVisible();
+  await expect(acceptedPolicy.getByText("Current")).toBeVisible();
+  await expect(
+    acceptedPolicy.getByText(`Accepted recommendation ${STYLE_RECOMMENDATION_ID}`),
+  ).toBeVisible();
+  await expect(acceptedPolicy.getByText(`Review ${ACCEPTED_REVIEW_ID}`)).toBeVisible();
+
+  await factualRecommendation
+    .getByRole("button", {
+      name: "Reject learning recommendation fact_handling → require_source_match",
+    })
+    .click();
+  await expect(factualRecommendation).toHaveCount(0);
+  expect(currentPolicyVersion(dbPath)).toBe(2);
+
+  const rejectedRecommendations = page.waitForResponse(
+    (response) =>
+      response.url().includes("/v1/learning/recommendations") &&
+      response.request().method() === "GET",
+  );
+  const rejectedHistory = page.waitForResponse(
+    (response) =>
+      response.url().includes("/v1/learning/policies/materials") &&
+      response.request().method() === "GET",
+  );
+  await page.reload();
+  expect((await rejectedRecommendations).status()).toBe(200);
+  expect((await rejectedHistory).status()).toBe(200);
+  await expect(recommendations.getByText("No learning recommendations to review.")).toBeVisible();
+  await expect(policyHistory.getByRole("article", { name: "Version 2" })).toBeVisible();
+  await expect(policyHistory.getByRole("article", { name: "Version 3" })).toHaveCount(0);
+
+  const rollbackHistory = page.waitForResponse(
+    (response) =>
+      response.url().includes("/v1/learning/policies/materials") &&
+      response.request().method() === "GET",
+  );
+  await policyHistory
+    .getByRole("button", { name: "Restore tailoring policy version 1" })
+    .click();
+  expect((await rollbackHistory).status()).toBe(200);
+  const rolledBackPolicy = policyHistory.getByRole("article", { name: "Version 3" });
+  await expect(rolledBackPolicy).toBeVisible();
+  await expect(rolledBackPolicy.getByText("Current")).toBeVisible();
+  await expect(rolledBackPolicy.getByText("Restored from version 1")).toBeVisible();
+  await expect(rolledBackPolicy.getByText("Reason: user requested")).toBeVisible();
+  await expect(
+    policyHistory.getByRole("button", { name: "Restore tailoring policy version 3" }),
+  ).toHaveCount(0);
+});
+
+async function installDeterministicLearningWrites(page: Page, dbPath: string): Promise<void> {
+  await page.route("**/v1/learning/recommendations/*/reviews", async (route) => {
+    const request = route.request();
+    const recommendationId = decodeURIComponent(
+      new URL(request.url()).pathname.split("/").at(-2) ?? "",
+    );
+    const body = request.postDataJSON() as { decision?: string };
+    if (recommendationId === STYLE_RECOMMENDATION_ID && body.decision === "accepted") {
+      appendAcceptedRecommendation(dbPath);
+      await route.fulfill({
+        json: {
+          ok: true,
+          reviewId: ACCEPTED_REVIEW_ID,
+          recommendationId,
+          revision: 1,
+          decision: "accepted",
+          context: "materials",
+          policyKind: "tailoring_rule",
+          policyVersion: 2,
+          reviewedAt: ACCEPTED_AT,
+        },
+      });
+      return;
+    }
+    if (recommendationId === FACTUAL_RECOMMENDATION_ID && body.decision === "rejected") {
+      appendRejectedRecommendation(dbPath);
+      await route.fulfill({
+        json: {
+          ok: true,
+          reviewId: REJECTED_REVIEW_ID,
+          recommendationId,
+          revision: 1,
+          decision: "rejected",
+          context: "materials",
+          policyKind: "tailoring_rule",
+          policyVersion: null,
+          reviewedAt: REJECTED_AT,
+        },
+      });
+      return;
+    }
+    throw new Error(`Unexpected learning review request for ${recommendationId}.`);
+  });
+
+  await page.route("**/v1/learning/policies/materials/rollbacks", async (route) => {
+    const body = route.request().postDataJSON() as { targetVersion?: number };
+    if (body.targetVersion !== 1) {
+      throw new Error(`Unexpected tailoring policy rollback target ${body.targetVersion}.`);
+    }
+    appendRollback(dbPath);
+    await route.fulfill({
+      json: {
+        ok: true,
+        context: "materials",
+        policyKind: "tailoring_rule",
+        version: 3,
+        status: "current",
+        learnedRules: [],
+        sourceReviewId: null,
+        sourceRecommendationId: null,
+        rollbackOfVersion: 1,
+        rollbackReasonCode: "user_requested",
+        createdAt: ROLLED_BACK_AT,
+      },
+    });
+  });
+}
+
+function appendAcceptedRecommendation(dbPath: string): void {
+  const db = new Database(dbPath);
+  try {
+    db.transaction(() => {
+      insertPolicy(db, {
+        version: 2,
+        learnedRules: { style_guidance: "preserve_user_edit_pattern" },
+        createdAt: ACCEPTED_AT,
+      });
+      db.prepare(
+        `INSERT INTO learning_recommendation_reviews (
+          tenant_id, review_id, recommendation_id, revision, decision,
+          context, policy_kind, policy_version, reviewed_at
+        ) VALUES ('local', ?, ?, 1, 'accepted', 'materials', 'tailoring_rule', 2, ?)`,
+      ).run(ACCEPTED_REVIEW_ID, STYLE_RECOMMENDATION_ID, ACCEPTED_AT);
+    })();
+  } finally {
+    db.close();
+  }
+}
+
+function appendRejectedRecommendation(dbPath: string): void {
+  const db = new Database(dbPath);
+  try {
+    db.prepare(
+      `INSERT INTO learning_recommendation_reviews (
+        tenant_id, review_id, recommendation_id, revision, decision,
+        context, policy_kind, policy_version, reviewed_at
+      ) VALUES ('local', ?, ?, 1, 'rejected', 'materials', 'tailoring_rule', NULL, ?)`,
+    ).run(REJECTED_REVIEW_ID, FACTUAL_RECOMMENDATION_ID, REJECTED_AT);
+  } finally {
+    db.close();
+  }
+}
+
+function appendRollback(dbPath: string): void {
+  const db = new Database(dbPath);
+  try {
+    insertPolicy(db, {
+      version: 3,
+      learnedRules: {},
+      createdAt: ROLLED_BACK_AT,
+      rollbackOfVersion: 1,
+      rollbackReason: "user_requested",
+    });
+  } finally {
+    db.close();
+  }
+}
+
+function insertPolicy(
+  db: Database.Database,
+  input: {
+    version: number;
+    learnedRules: Record<string, string>;
+    createdAt: string;
+    rollbackOfVersion?: number;
+    rollbackReason?: string;
+  },
+): void {
+  db.prepare(
+    `INSERT INTO tailoring_policies (
+      tenant_id, version, prompt_version, schema_version, judge_schema_version,
+      prompt_fingerprint, config_fingerprint, profile_policy_fingerprint,
+      custom_prompt_fingerprint, generator_settings_json, judge_settings_json,
+      runtime_settings_json, rollback_of_version, rollback_reason, created_at,
+      created_from_event_id
+    ) VALUES ('local', ?, 'tailor.v2', 'resume.v1', 'judge.v1',
+              'qa-prompt', ?, 'qa-profile', 'qa-custom', '{}', '{}', ?, ?, ?, ?, NULL)`,
+  ).run(
+    input.version,
+    `qa-config-${input.version}`,
+    JSON.stringify({ learned_tailoring_rules: input.learnedRules }),
+    input.rollbackOfVersion ?? null,
+    input.rollbackReason ?? "",
+    input.createdAt,
+  );
+}
+
+function currentPolicyVersion(dbPath: string): number {
+  const db = new Database(dbPath, { readonly: true });
+  try {
+    const row = db
+      .prepare("SELECT MAX(version) AS version FROM tailoring_policies WHERE tenant_id = 'local'")
+      .get() as { version: number | null } | undefined;
+    return Number(row?.version);
+  } finally {
+    db.close();
+  }
+}

--- a/apps/web/src/contexts/materials/components/LearningRecommendationReviewPanel.test.tsx
+++ b/apps/web/src/contexts/materials/components/LearningRecommendationReviewPanel.test.tsx
@@ -1,0 +1,223 @@
+import type {
+  LearningRecommendationListResponse,
+  LearningRecommendationReviewRequest,
+  LearningRecommendationReviewResponse,
+} from "@jobctrl/contracts";
+import { act, screen, waitFor, within } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import { axe } from "jest-axe";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  sampleLearningRecommendation,
+  sampleLearningRecommendationEvidence,
+  sampleLearningRecommendationList,
+  sampleSecondLearningRecommendation,
+} from "../../../test/fixtures/learning.js";
+import { renderWithProviders } from "../../../test/render.js";
+import { buildTestPorts } from "../../../test/testPorts.js";
+import { LearningRecommendationReviewPanel } from "./LearningRecommendationReviewPanel.js";
+
+function reviewResponse(
+  recommendationId: string,
+  decision: LearningRecommendationReviewRequest["decision"],
+): LearningRecommendationReviewResponse {
+  const base = {
+    ok: true as const,
+    reviewId: `learning-recommendation-review:${
+      decision === "accepted" ? "c".repeat(64) : "d".repeat(64)
+    }`,
+    recommendationId,
+    revision: 1,
+    decision,
+    context: "materials" as const,
+    policyKind: "tailoring_rule" as const,
+    reviewedAt: "2026-08-01T12:05:00.000Z",
+  };
+  return decision === "accepted"
+    ? { ...base, decision, policyVersion: 2 }
+    : { ...base, decision, policyVersion: null };
+}
+
+describe("LearningRecommendationReviewPanel", () => {
+  it("has no axe violations with pending recommendations", async () => {
+    const view = renderWithProviders(<LearningRecommendationReviewPanel />, {
+      ports: buildTestPorts({
+        api: {
+          learningRecommendations: vi.fn(async () => sampleLearningRecommendationList),
+        },
+      }),
+    });
+
+    await screen.findByText("style_guidance → preserve_user_edit_pattern");
+    expect(await axe(view.container)).toHaveNoViolations();
+  });
+
+  it("defers and exposes only bounded evidence after explicit inspection", async () => {
+    const user = userEvent.setup();
+    const learningRecommendations = vi.fn(async () => sampleLearningRecommendationList);
+    const learningRecommendationEvidence = vi.fn(async () => sampleLearningRecommendationEvidence);
+    renderWithProviders(<LearningRecommendationReviewPanel />, {
+      ports: buildTestPorts({ api: { learningRecommendations, learningRecommendationEvidence } }),
+    });
+
+    expect(
+      await screen.findByText("style_guidance → preserve_user_edit_pattern"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getAllByText(/3 of 3 required accepted signals across 2 of 2 required jobs/i),
+    ).toHaveLength(2);
+    expect(screen.getByText(/3 supporting · 1 contradicting · 0 tombstones/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/sample-gated recommendation only/i)).not.toHaveLength(0);
+    expect(learningRecommendationEvidence).not.toHaveBeenCalled();
+
+    await user.click(
+      screen.getByRole("button", {
+        name: /inspect evidence for style_guidance → preserve_user_edit_pattern/i,
+      }),
+    );
+
+    const evidence = await screen.findByRole("list", {
+      name: /evidence for style_guidance → preserve_user_edit_pattern/i,
+    });
+    expect(within(evidence).getByText("tailoring-signal-supporting-1")).toBeInTheDocument();
+    expect(within(evidence).getByText("tailoring-signal-contradicting-1")).toBeInTheDocument();
+    expect(within(evidence).getByText("contradicting")).toBeInTheDocument();
+    expect(learningRecommendationEvidence).toHaveBeenCalledWith(
+      sampleLearningRecommendation.recommendationId,
+      { page: 1, pageSize: 100 },
+    );
+  });
+
+  it("accepts and rejects without triggering rescore or re-tailor work", async () => {
+    const user = userEvent.setup();
+    let current = [...sampleLearningRecommendationList.recommendations];
+    const learningRecommendations = vi.fn(async (): Promise<LearningRecommendationListResponse> => ({
+      ...sampleLearningRecommendationList,
+      recommendations: current,
+      total: current.length,
+      totalPages: current.length ? 1 : 0,
+    }));
+    const reviewLearningRecommendation = vi.fn(
+      async (recommendationId: string, body: LearningRecommendationReviewRequest) => {
+        current = current.filter((item) => item.recommendationId !== recommendationId);
+        return reviewResponse(recommendationId, body.decision);
+      },
+    );
+    const rescoreJob = vi.fn();
+    const retailorJob = vi.fn();
+    renderWithProviders(<LearningRecommendationReviewPanel />, {
+      ports: buildTestPorts({
+        api: { learningRecommendations, reviewLearningRecommendation, rescoreJob, retailorJob },
+      }),
+    });
+
+    await screen.findByText("style_guidance → preserve_user_edit_pattern");
+    await user.click(
+      screen.getByRole("button", {
+        name: /accept learning recommendation style_guidance → preserve_user_edit_pattern/i,
+      }),
+    );
+    await waitFor(() =>
+      expect(reviewLearningRecommendation).toHaveBeenCalledWith(
+        sampleLearningRecommendation.recommendationId,
+        { decision: "accepted" },
+      ),
+    );
+    await waitFor(() =>
+      expect(screen.queryByText("style_guidance → preserve_user_edit_pattern")).not.toBeInTheDocument(),
+    );
+
+    await user.click(
+      screen.getByRole("button", {
+        name: /reject learning recommendation fact_handling → require_source_match/i,
+      }),
+    );
+    await waitFor(() =>
+      expect(reviewLearningRecommendation).toHaveBeenCalledWith(
+        sampleSecondLearningRecommendation.recommendationId,
+        { decision: "rejected" },
+      ),
+    );
+    expect(rescoreJob).not.toHaveBeenCalled();
+    expect(retailorJob).not.toHaveBeenCalled();
+  });
+
+  it("restores the recommendation and surfaces a sanitized review error", async () => {
+    const user = userEvent.setup();
+    let rejectReview: ((error: Error) => void) | undefined;
+    const learningRecommendations = vi.fn(async (): Promise<LearningRecommendationListResponse> => ({
+      ...sampleLearningRecommendationList,
+      recommendations: [sampleLearningRecommendation],
+      total: 1,
+      totalPages: 1,
+    }));
+    const reviewLearningRecommendation = vi.fn(
+      () =>
+        new Promise<LearningRecommendationReviewResponse>((_resolve, reject) => {
+          rejectReview = reject;
+        }),
+    );
+    renderWithProviders(<LearningRecommendationReviewPanel />, {
+      ports: buildTestPorts({ api: { learningRecommendations, reviewLearningRecommendation } }),
+    });
+
+    await screen.findByText("style_guidance → preserve_user_edit_pattern");
+    await user.click(
+      screen.getByRole("button", {
+        name: /reject learning recommendation style_guidance → preserve_user_edit_pattern/i,
+      }),
+    );
+    expect(await screen.findByText("No learning recommendations to review.")).toBeInTheDocument();
+    act(() => rejectReview?.(new Error("The learning recommendation review could not be completed.")));
+
+    expect(await screen.findByText("Recommendation review failed")).toBeInTheDocument();
+    expect(
+      await screen.findByText("style_guidance → preserve_user_edit_pattern"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("The learning recommendation review could not be completed."),
+    ).toBeInTheDocument();
+  });
+
+  it("marks tombstoned recommendations inactive and prevents guaranteed-failing reviews", async () => {
+    const reviewLearningRecommendation = vi.fn();
+    renderWithProviders(<LearningRecommendationReviewPanel />, {
+      ports: buildTestPorts({
+        api: {
+          learningRecommendations: vi.fn(async () => ({
+            ...sampleLearningRecommendationList,
+            recommendations: [
+              {
+                ...sampleLearningRecommendation,
+                active: false,
+                tombstoneCount: 1,
+              },
+            ],
+            total: 1,
+          })),
+          reviewLearningRecommendation,
+        },
+      }),
+    });
+
+    await screen.findByText("style_guidance → preserve_user_edit_pattern");
+    expect(screen.getByText("1 review item")).toBeInTheDocument();
+    expect(screen.queryByText(/1 pending/i)).not.toBeInTheDocument();
+    expect(screen.getByText("Inactive")).toBeInTheDocument();
+    expect(
+      screen.getByText(/source evidence was tombstoned, so this recommendation must be re-derived/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", {
+        name: /accept learning recommendation style_guidance → preserve_user_edit_pattern/i,
+      }),
+    ).toBeDisabled();
+    expect(
+      screen.getByRole("button", {
+        name: /reject learning recommendation style_guidance → preserve_user_edit_pattern/i,
+      }),
+    ).toBeDisabled();
+    expect(reviewLearningRecommendation).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/contexts/materials/components/LearningRecommendationReviewPanel.tsx
+++ b/apps/web/src/contexts/materials/components/LearningRecommendationReviewPanel.tsx
@@ -1,0 +1,206 @@
+import { IconAlertTriangle } from "@tabler/icons-react";
+import type { LearningRecommendationSummary } from "@jobctrl/contracts";
+import { useState } from "react";
+
+import {
+  useLearningRecommendationEvidenceQuery,
+  useLearningRecommendationsQuery,
+} from "../../operations/index.js";
+import { formatDateTime } from "../../../shared/lib/formatters.js";
+import { Alert, AlertDescription, AlertTitle } from "../../../shared/ui/alert.js";
+import { Button } from "../../../shared/ui/button.js";
+import { CardHeader } from "../../../shared/ui/card-header.js";
+import { Empty } from "../../../shared/ui/empty.js";
+import { StatusBadge } from "../../../shared/ui/status-badge.js";
+import { useReviewLearningRecommendationMutation } from "../hooks/useReviewLearningRecommendationMutation.js";
+
+export function LearningRecommendationReviewPanel() {
+  const recommendations = useLearningRecommendationsQuery();
+  const review = useReviewLearningRecommendationMutation();
+  const readError = recommendations.error instanceof Error ? recommendations.error.message : null;
+  const reviewError = review.error instanceof Error ? review.error.message : null;
+  const pending = recommendations.data?.recommendations ?? [];
+
+  return (
+    <section className="card col-span-full learning-review-panel">
+      <CardHeader
+        title="Learning recommendations"
+        meta={
+          recommendations.data
+            ? `${recommendations.data.total} review item${recommendations.data.total === 1 ? "" : "s"}`
+            : "loading"
+        }
+      />
+      {readError ? (
+        <Alert variant="destructive">
+          <IconAlertTriangle aria-hidden="true" />
+          <AlertTitle>Learning recommendations unavailable</AlertTitle>
+          <AlertDescription>{readError}</AlertDescription>
+        </Alert>
+      ) : null}
+      {reviewError ? (
+        <Alert variant="destructive">
+          <IconAlertTriangle aria-hidden="true" />
+          <AlertTitle>Recommendation review failed</AlertTitle>
+          <AlertDescription>{reviewError}</AlertDescription>
+        </Alert>
+      ) : null}
+      {recommendations.isFetching && !recommendations.data ? (
+        <Empty title="Loading learning recommendations." />
+      ) : null}
+      {recommendations.data && pending.length === 0 ? (
+        <Empty title="No learning recommendations to review." />
+      ) : null}
+      {pending.length ? (
+        <div className="learning-recommendations" aria-label="Learning recommendations">
+          {pending.map((recommendation) => (
+            <LearningRecommendationCard
+              key={recommendation.recommendationId}
+              recommendation={recommendation}
+              disabled={review.isPending}
+              onReview={(decision) => {
+                review.reset();
+                review.mutate({ recommendationId: recommendation.recommendationId, decision });
+              }}
+            />
+          ))}
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
+function LearningRecommendationCard({
+  recommendation,
+  disabled,
+  onReview,
+}: {
+  readonly recommendation: LearningRecommendationSummary;
+  readonly disabled: boolean;
+  readonly onReview: (decision: "accepted" | "rejected") => void;
+}) {
+  const [evidenceOpen, setEvidenceOpen] = useState(false);
+  const evidence = useLearningRecommendationEvidenceQuery(
+    recommendation.recommendationId,
+    { page: 1, pageSize: 100 },
+    evidenceOpen,
+  );
+  const evidenceError = evidence.error instanceof Error ? evidence.error.message : null;
+  const effect = `${recommendation.ruleKey} → ${recommendation.ruleValue}`;
+  const titleId = `learning-recommendation-${recommendation.recommendationId}-title`;
+  const reviewable = recommendation.active && recommendation.tombstoneCount === 0;
+
+  return (
+    <article className="learning-recommendation-card" aria-labelledby={titleId}>
+      <header className="learning-recommendation-head">
+        <span>
+          <b id={titleId}>{effect}</b>
+          <span className="meta">
+            {recommendation.signalKind.replaceAll("_", " ")} · derived {formatDateTime(recommendation.derivedAt)}
+          </span>
+        </span>
+        <StatusBadge tone={reviewable ? "info" : "warn"}>
+          {reviewable ? "Pending" : "Inactive"}
+        </StatusBadge>
+      </header>
+
+      <dl className="learning-recommendation-facts">
+        <div>
+          <dt>Sample</dt>
+          <dd>
+            {recommendation.observedSignalCount} of {recommendation.minimumSignalCount} required
+            accepted signals across {recommendation.observedJobCount} of{" "}
+            {recommendation.minimumJobCount} required jobs
+          </dd>
+        </div>
+        <div>
+          <dt>Evidence</dt>
+          <dd>
+            {recommendation.supportingEvidenceCount} supporting ·{" "}
+            {recommendation.contradictingEvidenceCount} contradicting ·{" "}
+            {recommendation.tombstoneCount} tombstones
+          </dd>
+        </div>
+        <div>
+          <dt>Versions</dt>
+          <dd>
+            derivation {recommendation.derivationVersion} · fixture{" "}
+            {recommendation.evaluationFixtureVersion} · allowlist{" "}
+            {recommendation.allowlistVersion}
+          </dd>
+        </div>
+      </dl>
+      <p className="meta">
+        Sample-gated recommendation only; it does not claim a population-wide improvement.
+      </p>
+      {!reviewable ? (
+        <p className="meta" role="status">
+          {recommendation.tombstoneCount > 0
+            ? "Review unavailable: source evidence was tombstoned, so this recommendation must be re-derived."
+            : "Review unavailable: this recommendation is no longer active."}
+        </p>
+      ) : null}
+
+      <div className="row-actions">
+        <Button
+          type="button"
+          size="sm"
+          variant="outline"
+          aria-expanded={evidenceOpen}
+          aria-label={`${evidenceOpen ? "Hide" : "Inspect"} evidence for ${effect}`}
+          onClick={() => setEvidenceOpen((open) => !open)}
+        >
+          {evidenceOpen ? "Hide evidence" : "Inspect evidence"}
+        </Button>
+        <Button
+          type="button"
+          size="sm"
+          disabled={disabled || !reviewable}
+          aria-label={`Accept learning recommendation ${effect}`}
+          onClick={() => onReview("accepted")}
+        >
+          Accept
+        </Button>
+        <Button
+          type="button"
+          size="sm"
+          variant="outline"
+          disabled={disabled || !reviewable}
+          aria-label={`Reject learning recommendation ${effect}`}
+          onClick={() => onReview("rejected")}
+        >
+          Reject
+        </Button>
+      </div>
+
+      {evidenceOpen ? (
+        <div className="learning-recommendation-evidence">
+          {evidence.isFetching && !evidence.data ? <Empty title="Loading evidence." /> : null}
+          {evidenceError ? (
+            <Alert variant="destructive">
+              <IconAlertTriangle aria-hidden="true" />
+              <AlertTitle>Recommendation evidence unavailable</AlertTitle>
+              <AlertDescription>{evidenceError}</AlertDescription>
+            </Alert>
+          ) : null}
+          {evidence.data?.evidence.length === 0 ? <Empty title="No evidence links available." /> : null}
+          {evidence.data?.evidence.length ? (
+            <ul aria-label={`Evidence for ${effect}`}>
+              {evidence.data.evidence.map((link) => (
+                <li key={`${link.signalId}:${link.sourceRevision}`}>
+                  <StatusBadge tone={link.evidenceRole === "contradicting" ? "warn" : "info"}>
+                    {link.evidenceRole}
+                  </StatusBadge>
+                  <span>{link.signalId}</span>
+                  <span className="meta">
+                    revision {link.sourceRevision} · job {link.jobId} · {formatDateTime(link.recordedAt)}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          ) : null}
+        </div>
+      ) : null}
+    </article>
+  );
+}

--- a/apps/web/src/contexts/materials/components/TailoringPolicyHistoryPanel.test.tsx
+++ b/apps/web/src/contexts/materials/components/TailoringPolicyHistoryPanel.test.tsx
@@ -1,0 +1,167 @@
+import type {
+  TailoringPolicyRevisionListQuery,
+  TailoringPolicyRollbackResponse,
+} from "@jobctrl/contracts";
+import { screen, waitFor, within } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import { axe } from "jest-axe";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  sampleLearningRecommendation,
+  sampleTailoringPolicyRevisionList,
+  sampleTailoringPolicyRollback,
+} from "../../../test/fixtures/learning.js";
+import { renderWithProviders } from "../../../test/render.js";
+import { buildTestPorts } from "../../../test/testPorts.js";
+import { TailoringPolicyHistoryPanel } from "./TailoringPolicyHistoryPanel.js";
+
+describe("TailoringPolicyHistoryPanel", () => {
+  it("renders truthful revision status and auditable provenance without axe violations", async () => {
+    const view = renderWithProviders(<TailoringPolicyHistoryPanel />, {
+      ports: buildTestPorts({
+        api: {
+          tailoringPolicyRevisions: vi.fn(
+            async () => sampleTailoringPolicyRevisionList,
+          ),
+        },
+      }),
+    });
+
+    const current = await screen.findByRole("article", { name: "Version 4" });
+    const learned = screen.getByRole("article", { name: "Version 3" });
+    const configured = screen.getByRole("article", { name: "Version 2" });
+    expect(within(current).getByText("Current")).toBeInTheDocument();
+    expect(
+      within(current).getByText("Restored from version 1"),
+    ).toBeInTheDocument();
+    expect(
+      within(current).getByText("Reason: user requested"),
+    ).toBeInTheDocument();
+    expect(within(learned).getByText("Superseded")).toBeInTheDocument();
+    expect(
+      within(learned).getByText("fact_handling → require_source_match"),
+    ).toBeInTheDocument();
+    expect(
+      within(learned).getByText(
+        `Accepted recommendation ${sampleLearningRecommendation.recommendationId}`,
+      ),
+    ).toBeInTheDocument();
+    expect(
+      within(learned).getByText(/^Review learning-recommendation-review:/),
+    ).toBeInTheDocument();
+    expect(
+      within(configured).getByText(
+        "No recommendation or restore provenance recorded.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", {
+        name: "Restore tailoring policy version 4",
+      }),
+    ).not.toBeInTheDocument();
+    expect(await axe(view.container)).toHaveNoViolations();
+  });
+
+  it("pages through every auditable revision", async () => {
+    const user = userEvent.setup();
+    const tailoringPolicyRevisions = vi.fn(
+      async (input: Partial<TailoringPolicyRevisionListQuery>) => ({
+        ...sampleTailoringPolicyRevisionList,
+        revisions:
+          input.page === 2
+            ? [sampleTailoringPolicyRevisionList.revisions.at(-1)!]
+            : [sampleTailoringPolicyRevisionList.revisions[0]!],
+        page: input.page ?? 1,
+        total: 101,
+        totalPages: 2,
+      }),
+    );
+    renderWithProviders(<TailoringPolicyHistoryPanel />, {
+      ports: buildTestPorts({ api: { tailoringPolicyRevisions } }),
+    });
+
+    await screen.findByRole("article", { name: "Version 4" });
+    expect(screen.getByText("Page 1 of 2")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Next page" }));
+
+    expect(
+      await screen.findByRole("article", { name: "Version 1" }),
+    ).toBeInTheDocument();
+    expect(tailoringPolicyRevisions).toHaveBeenLastCalledWith({
+      page: 2,
+      pageSize: 100,
+    });
+    expect(screen.getByText("Page 2 of 2")).toBeInTheDocument();
+  });
+
+  it("restores an older version without starting scoring, tailoring, or workflow work", async () => {
+    const user = userEvent.setup();
+    const rollbackTailoringPolicy = vi.fn(
+      async (): Promise<TailoringPolicyRollbackResponse> =>
+        sampleTailoringPolicyRollback,
+    );
+    const rescoreJob = vi.fn();
+    const retailorJob = vi.fn();
+    const runPipelineStages = vi.fn();
+    renderWithProviders(<TailoringPolicyHistoryPanel />, {
+      ports: buildTestPorts({
+        api: {
+          tailoringPolicyRevisions: vi.fn(
+            async () => sampleTailoringPolicyRevisionList,
+          ),
+          rollbackTailoringPolicy,
+          rescoreJob,
+          retailorJob,
+          runPipelineStages,
+        },
+      }),
+    });
+
+    await screen.findByRole("article", { name: "Version 1" });
+    await user.click(
+      screen.getByRole("button", {
+        name: "Restore tailoring policy version 1",
+      }),
+    );
+
+    await waitFor(() =>
+      expect(rollbackTailoringPolicy).toHaveBeenCalledWith({
+        targetVersion: 1,
+      }),
+    );
+    expect(rescoreJob).not.toHaveBeenCalled();
+    expect(retailorJob).not.toHaveBeenCalled();
+    expect(runPipelineStages).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a policy restore failure", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<TailoringPolicyHistoryPanel />, {
+      ports: buildTestPorts({
+        api: {
+          tailoringPolicyRevisions: vi.fn(
+            async () => sampleTailoringPolicyRevisionList,
+          ),
+          rollbackTailoringPolicy: vi.fn(async () => {
+            throw new Error("The policy restore could not be completed.");
+          }),
+        },
+      }),
+    });
+
+    await screen.findByRole("article", { name: "Version 2" });
+    await user.click(
+      screen.getByRole("button", {
+        name: "Restore tailoring policy version 2",
+      }),
+    );
+
+    expect(
+      await screen.findByText("Policy restore failed"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("The policy restore could not be completed."),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/contexts/materials/components/TailoringPolicyHistoryPanel.tsx
+++ b/apps/web/src/contexts/materials/components/TailoringPolicyHistoryPanel.tsx
@@ -1,0 +1,213 @@
+import type { TailoringPolicyRevisionSummary } from "@jobctrl/contracts";
+import { IconAlertTriangle } from "@tabler/icons-react";
+import { useState } from "react";
+
+import { formatDateTime } from "../../../shared/lib/formatters.js";
+import {
+  Alert,
+  AlertDescription,
+  AlertTitle,
+} from "../../../shared/ui/alert.js";
+import { Button } from "../../../shared/ui/button.js";
+import { CardHeader } from "../../../shared/ui/card-header.js";
+import { Empty } from "../../../shared/ui/empty.js";
+import { StatusBadge } from "../../../shared/ui/status-badge.js";
+import { useTailoringPolicyRevisionsQuery } from "../../operations/index.js";
+import { useRollbackTailoringPolicyMutation } from "../hooks/useRollbackTailoringPolicyMutation.js";
+
+const HISTORY_PAGE_SIZE = 100;
+
+export function TailoringPolicyHistoryPanel() {
+  const [page, setPage] = useState(1);
+  const history = useTailoringPolicyRevisionsQuery({
+    page,
+    pageSize: HISTORY_PAGE_SIZE,
+  });
+  const rollback = useRollbackTailoringPolicyMutation();
+  const revisions = history.data?.revisions ?? [];
+  const readError =
+    history.error instanceof Error ? history.error.message : null;
+  const rollbackError =
+    rollback.error instanceof Error ? rollback.error.message : null;
+
+  return (
+    <section className="card col-span-full tailoring-policy-history-panel">
+      <CardHeader
+        title="Tailoring policy history"
+        meta={
+          history.data
+            ? `${history.data.total} revision${history.data.total === 1 ? "" : "s"}`
+            : "loading"
+        }
+      />
+      {readError ? (
+        <Alert variant="destructive">
+          <IconAlertTriangle aria-hidden="true" />
+          <AlertTitle>Tailoring policy history unavailable</AlertTitle>
+          <AlertDescription>{readError}</AlertDescription>
+        </Alert>
+      ) : null}
+      {rollbackError ? (
+        <Alert variant="destructive">
+          <IconAlertTriangle aria-hidden="true" />
+          <AlertTitle>Policy restore failed</AlertTitle>
+          <AlertDescription>{rollbackError}</AlertDescription>
+        </Alert>
+      ) : null}
+      {history.isFetching && !history.data ? (
+        <Empty title="Loading policy history." />
+      ) : null}
+      {history.data && revisions.length === 0 ? (
+        <Empty title="No tailoring policy revisions recorded." />
+      ) : null}
+      {revisions.length > 0 ? (
+        <div
+          className="tailoring-policy-revisions"
+          aria-label="Tailoring policy revisions"
+        >
+          {revisions.map((revision) => (
+            <TailoringPolicyRevisionCard
+              key={revision.version}
+              revision={revision}
+              restoring={rollback.isPending}
+              onRestore={(targetVersion) => {
+                rollback.reset();
+                rollback.mutate(targetVersion);
+              }}
+            />
+          ))}
+        </div>
+      ) : null}
+      {history.data && history.data.totalPages > 1 ? (
+        <nav
+          className="row-actions tailoring-policy-pagination"
+          aria-label="Tailoring policy history pages"
+        >
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            disabled={history.isFetching || history.data.page <= 1}
+            onClick={() => setPage((current) => Math.max(1, current - 1))}
+          >
+            Previous page
+          </Button>
+          <span className="meta" aria-live="polite">
+            Page {history.data.page} of {history.data.totalPages}
+          </span>
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            disabled={
+              history.isFetching || history.data.page >= history.data.totalPages
+            }
+            onClick={() => setPage((current) => current + 1)}
+          >
+            Next page
+          </Button>
+        </nav>
+      ) : null}
+    </section>
+  );
+}
+
+function TailoringPolicyRevisionCard({
+  revision,
+  restoring,
+  onRestore,
+}: {
+  readonly revision: TailoringPolicyRevisionSummary;
+  readonly restoring: boolean;
+  readonly onRestore: (targetVersion: number) => void;
+}) {
+  const titleId = `tailoring-policy-version-${revision.version}`;
+  const current = revision.status === "current";
+
+  return (
+    <article
+      className="tailoring-policy-revision-card"
+      aria-labelledby={titleId}
+    >
+      <header className="tailoring-policy-revision-head">
+        <span>
+          <b id={titleId}>Version {revision.version}</b>
+          <span className="meta">
+            Materials tailoring policy · {formatDateTime(revision.createdAt)}
+          </span>
+        </span>
+        <StatusBadge tone={current ? "ok" : "muted"}>
+          {current ? "Current" : "Superseded"}
+        </StatusBadge>
+      </header>
+
+      <dl className="tailoring-policy-revision-facts">
+        <div>
+          <dt>Learned rules</dt>
+          <dd>
+            {revision.learnedRules.length > 0 ? (
+              <ul>
+                {revision.learnedRules.map((rule) => (
+                  <li key={`${rule.ruleKey}:${rule.ruleValue}`}>
+                    {rule.ruleKey} → {rule.ruleValue}
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              "Baseline policy; no accepted learned rules."
+            )}
+          </dd>
+        </div>
+        <div>
+          <dt>Provenance</dt>
+          <dd>{revisionProvenance(revision)}</dd>
+        </div>
+      </dl>
+
+      {!current ? (
+        <div className="row-actions">
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            disabled={restoring}
+            aria-label={`Restore tailoring policy version ${revision.version}`}
+            onClick={() => onRestore(revision.version)}
+          >
+            {restoring ? "Restoring…" : `Restore version ${revision.version}`}
+          </Button>
+        </div>
+      ) : null}
+    </article>
+  );
+}
+
+function revisionProvenance(revision: TailoringPolicyRevisionSummary) {
+  if (revision.sourceReviewId && revision.sourceRecommendationId) {
+    return (
+      <span className="tailoring-policy-provenance">
+        <span>Accepted recommendation {revision.sourceRecommendationId}</span>
+        <span className="meta">Review {revision.sourceReviewId}</span>
+      </span>
+    );
+  }
+  if (revision.rollbackOfVersion && revision.rollbackReasonCode) {
+    return (
+      <span className="tailoring-policy-provenance">
+        <span>Restored from version {revision.rollbackOfVersion}</span>
+        <span className="meta">
+          Reason: {rollbackReason(revision.rollbackReasonCode)}
+        </span>
+      </span>
+    );
+  }
+  return "No recommendation or restore provenance recorded.";
+}
+
+function rollbackReason(
+  reason: NonNullable<TailoringPolicyRevisionSummary["rollbackReasonCode"]>,
+) {
+  return reason === "user_requested"
+    ? "user requested"
+    : "historical or unspecified";
+}

--- a/apps/web/src/contexts/materials/hooks/useReviewLearningRecommendationMutation.test.ts
+++ b/apps/web/src/contexts/materials/hooks/useReviewLearningRecommendationMutation.test.ts
@@ -1,0 +1,157 @@
+import type {
+  LearningRecommendationListResponse,
+  LearningRecommendationReviewResponse,
+  LearningRecommendationSummary,
+} from "@jobctrl/contracts";
+import { LOCAL_TENANT } from "@jobctrl/domain-types";
+import { act, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { renderHookWithProviders } from "../../../test/render.js";
+import { buildTestPorts } from "../../../test/testPorts.js";
+import { learningKeys } from "../../operations/learningKeys.js";
+import { useReviewLearningRecommendationMutation } from "./useReviewLearningRecommendationMutation.js";
+
+const recommendation: LearningRecommendationSummary = {
+  recommendationId: `learning-recommendation:${"a".repeat(64)}`,
+  derivationVersion: 1,
+  evaluationFixtureVersion: 1,
+  context: "materials",
+  policyKind: "tailoring_rule",
+  signalKind: "style_preference",
+  ruleKey: "style_guidance",
+  ruleValue: "preserve_user_edit_pattern",
+  allowlistVersion: 1,
+  status: "pending",
+  active: true,
+  observedSignalCount: 3,
+  observedJobCount: 2,
+  minimumSignalCount: 3,
+  minimumJobCount: 2,
+  confidenceLimit: "sample_gated_no_population_inference",
+  supportingEvidenceCount: 3,
+  contradictingEvidenceCount: 0,
+  tombstoneCount: 0,
+  derivedAt: "2026-08-01T12:00:00.000Z",
+};
+
+const otherRecommendation: LearningRecommendationSummary = {
+  ...recommendation,
+  recommendationId: `learning-recommendation:${"c".repeat(64)}`,
+  ruleKey: "fact_handling",
+  ruleValue: "require_source_match",
+};
+
+const pageOneInput = { page: 1, pageSize: 50 } as const;
+const pageTwoInput = { page: 2, pageSize: 50 } as const;
+const pageOne: LearningRecommendationListResponse = {
+  ok: true,
+  recommendations: [otherRecommendation],
+  page: 1,
+  pageSize: 50,
+  total: 51,
+  totalPages: 2,
+};
+const pageTwo: LearningRecommendationListResponse = {
+  ok: true,
+  recommendations: [recommendation],
+  page: 2,
+  pageSize: 50,
+  total: 51,
+  totalPages: 2,
+};
+
+const accepted: LearningRecommendationReviewResponse = {
+  ok: true,
+  reviewId: `learning-recommendation-review:${"b".repeat(64)}`,
+  recommendationId: recommendation.recommendationId,
+  revision: 1,
+  decision: "accepted",
+  context: "materials",
+  policyKind: "tailoring_rule",
+  policyVersion: 2,
+  reviewedAt: "2026-08-01T12:05:00.000Z",
+};
+
+describe("useReviewLearningRecommendationMutation", () => {
+  it("reviews through the Materials API port and removes the terminal recommendation", async () => {
+    const reviewLearningRecommendation = vi.fn(async () => accepted);
+    const { result, queryClient } = renderHookWithProviders(
+      () => useReviewLearningRecommendationMutation(),
+      { ports: buildTestPorts({ api: { reviewLearningRecommendation } }) },
+    );
+    const pageOneKey = learningKeys.list(LOCAL_TENANT, pageOneInput);
+    const pageTwoKey = learningKeys.list(LOCAL_TENANT, pageTwoInput);
+    queryClient.setQueryData(pageOneKey, pageOne);
+    queryClient.setQueryData(pageTwoKey, pageTwo);
+
+    await act(async () => {
+      await expect(
+        result.current.mutateAsync({
+          recommendationId: recommendation.recommendationId,
+          decision: "accepted",
+        }),
+      ).resolves.toBe(accepted);
+    });
+
+    expect(reviewLearningRecommendation).toHaveBeenCalledWith(recommendation.recommendationId, {
+      decision: "accepted",
+    });
+    expect(queryClient.getQueryData<LearningRecommendationListResponse>(pageOneKey)).toMatchObject({
+      recommendations: [otherRecommendation],
+      total: 50,
+      totalPages: 1,
+    });
+    expect(queryClient.getQueryData<LearningRecommendationListResponse>(pageTwoKey)).toMatchObject({
+      recommendations: [],
+      total: 50,
+      totalPages: 1,
+    });
+  });
+
+  it("restores every optimistic recommendation snapshot when review fails", async () => {
+    let rejectReview: ((error: Error) => void) | undefined;
+    const reviewLearningRecommendation = vi.fn(
+      () =>
+        new Promise<LearningRecommendationReviewResponse>((_resolve, reject) => {
+          rejectReview = reject;
+        }),
+    );
+    const { result, queryClient } = renderHookWithProviders(
+      () => useReviewLearningRecommendationMutation(),
+      { ports: buildTestPorts({ api: { reviewLearningRecommendation } }) },
+    );
+    const pageOneKey = learningKeys.list(LOCAL_TENANT, pageOneInput);
+    const pageTwoKey = learningKeys.list(LOCAL_TENANT, pageTwoInput);
+    queryClient.setQueryData(pageOneKey, pageOne);
+    queryClient.setQueryData(pageTwoKey, pageTwo);
+
+    act(() => {
+      result.current.mutate({
+        recommendationId: recommendation.recommendationId,
+        decision: "rejected",
+      });
+    });
+
+    await waitFor(() =>
+      expect(
+        queryClient.getQueryData<LearningRecommendationListResponse>(pageTwoKey)?.recommendations,
+      ).toEqual([]),
+    );
+    expect(queryClient.getQueryData<LearningRecommendationListResponse>(pageOneKey)).toMatchObject({
+      recommendations: [otherRecommendation],
+      total: 50,
+      totalPages: 1,
+    });
+    act(() => rejectReview?.(new Error("review unavailable")));
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    await waitFor(() =>
+      expect(queryClient.getQueryData<LearningRecommendationListResponse>(pageOneKey)).toEqual(
+        pageOne,
+      ),
+    );
+    expect(queryClient.getQueryData<LearningRecommendationListResponse>(pageTwoKey)).toEqual(
+      pageTwo,
+    );
+  });
+});

--- a/apps/web/src/contexts/materials/hooks/useReviewLearningRecommendationMutation.ts
+++ b/apps/web/src/contexts/materials/hooks/useReviewLearningRecommendationMutation.ts
@@ -1,0 +1,81 @@
+import type {
+  LearningRecommendationListResponse,
+  LearningRecommendationReviewRequest,
+  LearningRecommendationReviewResponse,
+} from "@jobctrl/contracts";
+import {
+  useMutation,
+  useQueryClient,
+  type QueryKey,
+  type UseMutationResult,
+} from "@tanstack/react-query";
+
+import { usePorts } from "../../../shared/providers/PortsProvider.js";
+import { useTenantId } from "../../../shared/providers/TenantProvider.js";
+import { learningKeys } from "../../operations/learningKeys.js";
+
+export interface ReviewLearningRecommendationVariables {
+  readonly recommendationId: string;
+  readonly decision: LearningRecommendationReviewRequest["decision"];
+}
+
+interface ReviewLearningRecommendationContext {
+  readonly snapshots: readonly (readonly [QueryKey, LearningRecommendationListResponse | undefined])[];
+}
+
+export function useReviewLearningRecommendationMutation(): UseMutationResult<
+  LearningRecommendationReviewResponse,
+  Error,
+  ReviewLearningRecommendationVariables,
+  ReviewLearningRecommendationContext
+> {
+  const tenantId = useTenantId();
+  const { api } = usePorts();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ recommendationId, decision }) =>
+      api.reviewLearningRecommendation(recommendationId, { decision }),
+    onMutate: async ({ recommendationId }) => {
+      await queryClient.cancelQueries({ queryKey: learningKeys.lists(tenantId) });
+      const snapshots = queryClient.getQueriesData<LearningRecommendationListResponse>({
+        queryKey: learningKeys.lists(tenantId),
+      });
+      const isCached = snapshots.some(([, snapshot]) =>
+        snapshot?.recommendations.some((item) => item.recommendationId === recommendationId),
+      );
+      for (const [queryKey] of isCached ? snapshots : []) {
+        queryClient.setQueryData<LearningRecommendationListResponse>(queryKey, (current) =>
+          removePendingRecommendation(current, recommendationId),
+        );
+      }
+      return { snapshots };
+    },
+    onError: (_error, _variables, context) => {
+      for (const [queryKey, snapshot] of context?.snapshots ?? []) {
+        queryClient.setQueryData(queryKey, snapshot);
+      }
+    },
+    onSettled: async () => {
+      await queryClient.invalidateQueries({ queryKey: learningKeys.lists(tenantId) });
+    },
+  });
+}
+
+function removePendingRecommendation(
+  current: LearningRecommendationListResponse | undefined,
+  recommendationId: string,
+): LearningRecommendationListResponse | undefined {
+  if (!current) {
+    return current;
+  }
+  const total = Math.max(0, current.total - 1);
+  return {
+    ...current,
+    recommendations: current.recommendations.filter(
+      (item) => item.recommendationId !== recommendationId,
+    ),
+    total,
+    totalPages: total === 0 ? 0 : Math.ceil(total / current.pageSize),
+  };
+}

--- a/apps/web/src/contexts/materials/hooks/useRollbackTailoringPolicyMutation.test.ts
+++ b/apps/web/src/contexts/materials/hooks/useRollbackTailoringPolicyMutation.test.ts
@@ -1,0 +1,125 @@
+import type {
+  TailoringPolicyRevisionListResponse,
+  TailoringPolicyRevisionSummary,
+  TailoringPolicyRollbackResponse,
+} from "@jobctrl/contracts";
+import { LOCAL_TENANT } from "@jobctrl/domain-types";
+import { act, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { renderHookWithProviders } from "../../../test/render.js";
+import { buildTestPorts } from "../../../test/testPorts.js";
+import { learningKeys } from "../../operations/learningKeys.js";
+import { useRollbackTailoringPolicyMutation } from "./useRollbackTailoringPolicyMutation.js";
+
+const original: TailoringPolicyRevisionSummary = {
+  context: "materials",
+  policyKind: "tailoring_rule",
+  version: 1,
+  status: "superseded",
+  learnedRules: [],
+  sourceReviewId: null,
+  sourceRecommendationId: null,
+  rollbackOfVersion: null,
+  rollbackReasonCode: null,
+  createdAt: "2026-08-01T10:00:00.000Z",
+};
+
+const learned: TailoringPolicyRevisionSummary = {
+  ...original,
+  version: 2,
+  status: "current",
+  learnedRules: [{ ruleKey: "fact_handling", ruleValue: "require_source_match" }],
+  sourceReviewId: `learning-recommendation-review:${"b".repeat(64)}`,
+  sourceRecommendationId: `learning-recommendation:${"a".repeat(64)}`,
+  createdAt: "2026-08-01T11:00:00.000Z",
+};
+
+const pageInput = { page: 1, pageSize: 50 } as const;
+const history: TailoringPolicyRevisionListResponse = {
+  ok: true,
+  revisions: [learned, original],
+  page: 1,
+  pageSize: 50,
+  total: 2,
+  totalPages: 1,
+};
+
+const rollback: TailoringPolicyRollbackResponse = {
+  ok: true,
+  context: "materials",
+  policyKind: "tailoring_rule",
+  version: 3,
+  status: "current",
+  learnedRules: [],
+  sourceReviewId: null,
+  sourceRecommendationId: null,
+  rollbackOfVersion: 1,
+  rollbackReasonCode: "user_requested",
+  createdAt: "2026-08-01T12:00:00.000Z",
+};
+
+describe("useRollbackTailoringPolicyMutation", () => {
+  it("patches the cached audit history with the exact rollback response", async () => {
+    const rollbackTailoringPolicy = vi.fn(async () => rollback);
+    const { result, queryClient } = renderHookWithProviders(
+      () => useRollbackTailoringPolicyMutation(),
+      { ports: buildTestPorts({ api: { rollbackTailoringPolicy } }) },
+    );
+    const key = learningKeys.policyRevisionList(LOCAL_TENANT, pageInput);
+    queryClient.setQueryData(key, history);
+
+    await act(async () => {
+      await expect(result.current.mutateAsync(1)).resolves.toBe(rollback);
+    });
+
+    expect(rollbackTailoringPolicy).toHaveBeenCalledWith({ targetVersion: 1 });
+    expect(queryClient.getQueryData<TailoringPolicyRevisionListResponse>(key)).toEqual({
+      ...history,
+      revisions: [
+        {
+          context: rollback.context,
+          policyKind: rollback.policyKind,
+          version: rollback.version,
+          status: rollback.status,
+          learnedRules: rollback.learnedRules,
+          sourceReviewId: null,
+          sourceRecommendationId: null,
+          rollbackOfVersion: rollback.rollbackOfVersion,
+          rollbackReasonCode: rollback.rollbackReasonCode,
+          createdAt: rollback.createdAt,
+        },
+        { ...learned, status: "superseded" },
+        original,
+      ],
+      total: 3,
+      totalPages: 1,
+    });
+  });
+
+  it("restores the exact cached history when rollback fails", async () => {
+    let rejectRollback: ((error: Error) => void) | undefined;
+    const rollbackTailoringPolicy = vi.fn(
+      () =>
+        new Promise<TailoringPolicyRollbackResponse>((_resolve, reject) => {
+          rejectRollback = reject;
+        }),
+    );
+    const { result, queryClient } = renderHookWithProviders(
+      () => useRollbackTailoringPolicyMutation(),
+      { ports: buildTestPorts({ api: { rollbackTailoringPolicy } }) },
+    );
+    const key = learningKeys.policyRevisionList(LOCAL_TENANT, pageInput);
+    queryClient.setQueryData(key, history);
+
+    act(() => result.current.mutate(1));
+    await waitFor(() =>
+      expect(
+        queryClient.getQueryData<TailoringPolicyRevisionListResponse>(key)?.revisions[0],
+      ).toMatchObject({ version: 3, status: "current", rollbackOfVersion: 1 }),
+    );
+    act(() => rejectRollback?.(new Error("rollback unavailable")));
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(queryClient.getQueryData<TailoringPolicyRevisionListResponse>(key)).toEqual(history);
+  });
+});

--- a/apps/web/src/contexts/materials/hooks/useRollbackTailoringPolicyMutation.ts
+++ b/apps/web/src/contexts/materials/hooks/useRollbackTailoringPolicyMutation.ts
@@ -1,0 +1,165 @@
+import type {
+  TailoringPolicyRevisionListResponse,
+  TailoringPolicyRevisionSummary,
+  TailoringPolicyRollbackResponse,
+} from "@jobctrl/contracts";
+import {
+  useMutation,
+  useQueryClient,
+  type QueryKey,
+  type UseMutationResult,
+} from "@tanstack/react-query";
+
+import { usePorts } from "../../../shared/providers/PortsProvider.js";
+import { useTenantId } from "../../../shared/providers/TenantProvider.js";
+import { learningKeys } from "../../operations/learningKeys.js";
+
+interface PolicyRevisionSnapshot {
+  readonly queryKey: QueryKey;
+  readonly data: TailoringPolicyRevisionListResponse | undefined;
+}
+
+interface RollbackTailoringPolicyContext {
+  readonly snapshots: readonly PolicyRevisionSnapshot[];
+  readonly patched: boolean;
+}
+
+export function useRollbackTailoringPolicyMutation(): UseMutationResult<
+  TailoringPolicyRollbackResponse,
+  Error,
+  number,
+  RollbackTailoringPolicyContext
+> {
+  const tenantId = useTenantId();
+  const { api } = usePorts();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (targetVersion) => api.rollbackTailoringPolicy({ targetVersion }),
+    onMutate: async (targetVersion) => {
+      const queryKey = learningKeys.policyRevisions(tenantId);
+      await queryClient.cancelQueries({ queryKey });
+      const snapshots = queryClient
+        .getQueriesData<TailoringPolicyRevisionListResponse>({ queryKey })
+        .map(([cachedKey, data]) => ({ queryKey: cachedKey, data }));
+      const target = snapshots
+        .flatMap(({ data }) => data?.revisions ?? [])
+        .find((revision) => revision.version === targetVersion);
+      const current = snapshots
+        .flatMap(({ data }) => data?.revisions ?? [])
+        .find((revision) => revision.status === "current");
+      const provisional =
+        target && current
+          ? rollbackRevision(target, current.version + 1, new Date().toISOString())
+          : null;
+      const patched = provisional ? patchSnapshots(queryClient, snapshots, provisional) : false;
+      return { snapshots, patched };
+    },
+    onSuccess: (response, _targetVersion, context) => {
+      const revision: TailoringPolicyRevisionSummary = {
+        context: response.context,
+        policyKind: response.policyKind,
+        version: response.version,
+        status: response.status,
+        learnedRules: response.learnedRules,
+        sourceReviewId: response.sourceReviewId,
+        sourceRecommendationId: response.sourceRecommendationId,
+        rollbackOfVersion: response.rollbackOfVersion,
+        rollbackReasonCode: response.rollbackReasonCode,
+        createdAt: response.createdAt,
+      };
+      patchSnapshots(queryClient, context.snapshots, revision);
+    },
+    onError: (_error, _targetVersion, context) => {
+      for (const { queryKey, data } of context?.snapshots ?? []) {
+        queryClient.setQueryData(queryKey, data);
+      }
+    },
+    onSettled: async () => {
+      await queryClient.invalidateQueries({ queryKey: learningKeys.policyRevisions(tenantId) });
+    },
+  });
+}
+
+function rollbackRevision(
+  target: TailoringPolicyRevisionSummary,
+  version: number,
+  createdAt: string,
+): TailoringPolicyRevisionSummary {
+  return {
+    ...target,
+    version,
+    status: "current",
+    sourceReviewId: null,
+    sourceRecommendationId: null,
+    rollbackOfVersion: target.version,
+    rollbackReasonCode: "user_requested",
+    createdAt,
+  };
+}
+
+function patchSnapshots(
+  queryClient: ReturnType<typeof useQueryClient>,
+  snapshots: readonly PolicyRevisionSnapshot[],
+  revision: TailoringPolicyRevisionSummary,
+): boolean {
+  const pages = snapshots
+    .filter(
+      (snapshot): snapshot is PolicyRevisionSnapshot & {
+        data: TailoringPolicyRevisionListResponse;
+      } => snapshot.data !== undefined,
+    )
+    .toSorted((left, right) => left.data.page - right.data.page);
+  if (!isCompleteCache(pages)) {
+    return false;
+  }
+  const firstPage = pages[0];
+  if (!firstPage) {
+    return false;
+  }
+  const pageSize = firstPage.data.pageSize;
+  const prior = pages.flatMap(({ data }) => data.revisions);
+  const revisions = [
+    revision,
+    ...prior
+      .filter((item) => item.version !== revision.version)
+      .map((item) => (item.status === "current" ? { ...item, status: "superseded" as const } : item)),
+  ];
+  const total = prior.some((item) => item.version === revision.version)
+    ? firstPage.data.total
+    : firstPage.data.total + 1;
+  const totalPages = total === 0 ? 0 : Math.ceil(total / pageSize);
+  if (totalPages > pages.length) {
+    return false;
+  }
+  for (const { queryKey, data } of pages) {
+    const offset = (data.page - 1) * pageSize;
+    queryClient.setQueryData<TailoringPolicyRevisionListResponse>(queryKey, {
+      ...data,
+      revisions: revisions.slice(offset, offset + pageSize),
+      total,
+      totalPages,
+    });
+  }
+  return true;
+}
+
+function isCompleteCache(
+  pages: readonly { readonly data: TailoringPolicyRevisionListResponse }[],
+): boolean {
+  if (pages.length === 0 || pages[0]?.data.page !== 1) {
+    return false;
+  }
+  const first = pages[0].data;
+  return (
+    pages.length === first.totalPages &&
+    pages.every(
+      ({ data }, index) =>
+        data.page === index + 1 &&
+        data.pageSize === first.pageSize &&
+        data.total === first.total &&
+        data.totalPages === first.totalPages,
+    ) &&
+    pages.reduce((count, { data }) => count + data.revisions.length, 0) === first.total
+  );
+}

--- a/apps/web/src/contexts/materials/index.ts
+++ b/apps/web/src/contexts/materials/index.ts
@@ -36,6 +36,7 @@ export {
   EmployerAnalysisPanel,
   type EmployerAnalysisPanelProps,
 } from "./components/EmployerAnalysisPanel.js";
+export { LearningRecommendationReviewPanel } from "./components/LearningRecommendationReviewPanel.js";
 export {
   ArtifactTypeBadge,
   type ArtifactTypeBadgeProps,

--- a/apps/web/src/contexts/materials/index.ts
+++ b/apps/web/src/contexts/materials/index.ts
@@ -4,6 +4,10 @@ export { useGenerateMaterialsMutation } from "./hooks/useGenerateMaterialsMutati
 export { useGenerateInterviewPrepMutation } from "./hooks/useGenerateInterviewPrepMutation.js";
 export { useOpenArtifactMutation } from "./hooks/useOpenArtifactMutation.js";
 export {
+  useReviewLearningRecommendationMutation,
+  type ReviewLearningRecommendationVariables,
+} from "./hooks/useReviewLearningRecommendationMutation.js";
+export {
   useRetailorCurrentPolicyMutation,
   useRetailorJobMutation,
   useTailorJobMutation,

--- a/apps/web/src/contexts/materials/index.ts
+++ b/apps/web/src/contexts/materials/index.ts
@@ -7,6 +7,7 @@ export {
   useReviewLearningRecommendationMutation,
   type ReviewLearningRecommendationVariables,
 } from "./hooks/useReviewLearningRecommendationMutation.js";
+export { useRollbackTailoringPolicyMutation } from "./hooks/useRollbackTailoringPolicyMutation.js";
 export {
   useRetailorCurrentPolicyMutation,
   useRetailorJobMutation,

--- a/apps/web/src/contexts/materials/index.ts
+++ b/apps/web/src/contexts/materials/index.ts
@@ -38,6 +38,7 @@ export {
   type EmployerAnalysisPanelProps,
 } from "./components/EmployerAnalysisPanel.js";
 export { LearningRecommendationReviewPanel } from "./components/LearningRecommendationReviewPanel.js";
+export { TailoringPolicyHistoryPanel } from "./components/TailoringPolicyHistoryPanel.js";
 export {
   ArtifactTypeBadge,
   type ArtifactTypeBadgeProps,

--- a/apps/web/src/contexts/operations/hooks/useLearningRecommendationsQuery.test.ts
+++ b/apps/web/src/contexts/operations/hooks/useLearningRecommendationsQuery.test.ts
@@ -58,4 +58,26 @@ describe("learning recommendation queries", () => {
       pageSize: 25,
     });
   });
+
+  it("defers evidence reads until inspection is enabled", async () => {
+    const learningRecommendationEvidence = vi.fn(async () => evidenceList);
+    const { result, rerender } = renderHookWithProviders(
+      ({ enabled }: { enabled: boolean }) =>
+        useLearningRecommendationEvidenceQuery(
+          recommendationId,
+          { page: 1, pageSize: 25 },
+          enabled,
+        ),
+      {
+        initialProps: { enabled: false },
+        ports: buildTestPorts({ api: { learningRecommendationEvidence } }),
+      },
+    );
+
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(learningRecommendationEvidence).not.toHaveBeenCalled();
+    rerender({ enabled: true });
+    await waitFor(() => expect(result.current.data).toBe(evidenceList));
+    expect(learningRecommendationEvidence).toHaveBeenCalledTimes(1);
+  });
 });

--- a/apps/web/src/contexts/operations/hooks/useLearningRecommendationsQuery.test.ts
+++ b/apps/web/src/contexts/operations/hooks/useLearningRecommendationsQuery.test.ts
@@ -1,6 +1,7 @@
 import type {
   LearningRecommendationEvidenceListResponse,
   LearningRecommendationListResponse,
+  TailoringPolicyRevisionListResponse,
 } from "@jobctrl/contracts";
 import { waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
@@ -10,6 +11,7 @@ import { buildTestPorts } from "../../../test/testPorts.js";
 import {
   useLearningRecommendationEvidenceQuery,
   useLearningRecommendationsQuery,
+  useTailoringPolicyRevisionsQuery,
 } from "./useLearningRecommendationsQuery.js";
 
 const recommendationId = `learning-recommendation:${"a".repeat(64)}`;
@@ -27,6 +29,15 @@ const evidenceList: LearningRecommendationEvidenceListResponse = {
   ok: true,
   recommendationId,
   evidence: [],
+  page: 1,
+  pageSize: 25,
+  total: 0,
+  totalPages: 0,
+};
+
+const policyHistory: TailoringPolicyRevisionListResponse = {
+  ok: true,
+  revisions: [],
   page: 1,
   pageSize: 25,
   total: 0,
@@ -79,5 +90,16 @@ describe("learning recommendation queries", () => {
     rerender({ enabled: true });
     await waitFor(() => expect(result.current.data).toBe(evidenceList));
     expect(learningRecommendationEvidence).toHaveBeenCalledTimes(1);
+  });
+
+  it("reads tenant-scoped Materials policy history through the API port", async () => {
+    const tailoringPolicyRevisions = vi.fn(async () => policyHistory);
+    const { result } = renderHookWithProviders(
+      () => useTailoringPolicyRevisionsQuery({ page: 1, pageSize: 25 }),
+      { ports: buildTestPorts({ api: { tailoringPolicyRevisions } }) },
+    );
+
+    await waitFor(() => expect(result.current.data).toBe(policyHistory));
+    expect(tailoringPolicyRevisions).toHaveBeenCalledWith({ page: 1, pageSize: 25 });
   });
 });

--- a/apps/web/src/contexts/operations/hooks/useLearningRecommendationsQuery.test.ts
+++ b/apps/web/src/contexts/operations/hooks/useLearningRecommendationsQuery.test.ts
@@ -1,0 +1,61 @@
+import type {
+  LearningRecommendationEvidenceListResponse,
+  LearningRecommendationListResponse,
+} from "@jobctrl/contracts";
+import { waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { renderHookWithProviders } from "../../../test/render.js";
+import { buildTestPorts } from "../../../test/testPorts.js";
+import {
+  useLearningRecommendationEvidenceQuery,
+  useLearningRecommendationsQuery,
+} from "./useLearningRecommendationsQuery.js";
+
+const recommendationId = `learning-recommendation:${"a".repeat(64)}`;
+
+const recommendationList: LearningRecommendationListResponse = {
+  ok: true,
+  recommendations: [],
+  page: 2,
+  pageSize: 10,
+  total: 0,
+  totalPages: 0,
+};
+
+const evidenceList: LearningRecommendationEvidenceListResponse = {
+  ok: true,
+  recommendationId,
+  evidence: [],
+  page: 1,
+  pageSize: 25,
+  total: 0,
+  totalPages: 0,
+};
+
+describe("learning recommendation queries", () => {
+  it("reads one tenant-scoped recommendation page through the API port", async () => {
+    const learningRecommendations = vi.fn(async () => recommendationList);
+    const { result } = renderHookWithProviders(
+      () => useLearningRecommendationsQuery({ page: 2, pageSize: 10 }),
+      { ports: buildTestPorts({ api: { learningRecommendations } }) },
+    );
+
+    await waitFor(() => expect(result.current.data).toBe(recommendationList));
+    expect(learningRecommendations).toHaveBeenCalledWith({ page: 2, pageSize: 10 });
+  });
+
+  it("reads bounded evidence for one recommendation through the API port", async () => {
+    const learningRecommendationEvidence = vi.fn(async () => evidenceList);
+    const { result } = renderHookWithProviders(
+      () => useLearningRecommendationEvidenceQuery(recommendationId, { page: 1, pageSize: 25 }),
+      { ports: buildTestPorts({ api: { learningRecommendationEvidence } }) },
+    );
+
+    await waitFor(() => expect(result.current.data).toBe(evidenceList));
+    expect(learningRecommendationEvidence).toHaveBeenCalledWith(recommendationId, {
+      page: 1,
+      pageSize: 25,
+    });
+  });
+});

--- a/apps/web/src/contexts/operations/hooks/useLearningRecommendationsQuery.ts
+++ b/apps/web/src/contexts/operations/hooks/useLearningRecommendationsQuery.ts
@@ -3,6 +3,8 @@ import type {
   LearningRecommendationEvidenceListResponse,
   LearningRecommendationListQuery,
   LearningRecommendationListResponse,
+  TailoringPolicyRevisionListQuery,
+  TailoringPolicyRevisionListResponse,
 } from "@jobctrl/contracts";
 import { useQuery, type UseQueryResult } from "@tanstack/react-query";
 
@@ -34,5 +36,16 @@ export function useLearningRecommendationEvidenceQuery(
     queryKey: learningKeys.evidenceList(tenantId, recommendationId, input),
     queryFn: () => api.learningRecommendationEvidence(recommendationId, input),
     enabled,
+  });
+}
+
+export function useTailoringPolicyRevisionsQuery(
+  input: Partial<TailoringPolicyRevisionListQuery> = DEFAULT_PAGE,
+): UseQueryResult<TailoringPolicyRevisionListResponse> {
+  const tenantId = useTenantId();
+  const { api } = usePorts();
+  return useQuery({
+    queryKey: learningKeys.policyRevisionList(tenantId, input),
+    queryFn: () => api.tailoringPolicyRevisions(input),
   });
 }

--- a/apps/web/src/contexts/operations/hooks/useLearningRecommendationsQuery.ts
+++ b/apps/web/src/contexts/operations/hooks/useLearningRecommendationsQuery.ts
@@ -26,11 +26,13 @@ export function useLearningRecommendationsQuery(
 export function useLearningRecommendationEvidenceQuery(
   recommendationId: string,
   input: Partial<LearningRecommendationEvidenceListQuery> = DEFAULT_PAGE,
+  enabled = true,
 ): UseQueryResult<LearningRecommendationEvidenceListResponse> {
   const tenantId = useTenantId();
   const { api } = usePorts();
   return useQuery({
     queryKey: learningKeys.evidenceList(tenantId, recommendationId, input),
     queryFn: () => api.learningRecommendationEvidence(recommendationId, input),
+    enabled,
   });
 }

--- a/apps/web/src/contexts/operations/hooks/useLearningRecommendationsQuery.ts
+++ b/apps/web/src/contexts/operations/hooks/useLearningRecommendationsQuery.ts
@@ -1,0 +1,36 @@
+import type {
+  LearningRecommendationEvidenceListQuery,
+  LearningRecommendationEvidenceListResponse,
+  LearningRecommendationListQuery,
+  LearningRecommendationListResponse,
+} from "@jobctrl/contracts";
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+
+import { usePorts } from "../../../shared/providers/PortsProvider.js";
+import { useTenantId } from "../../../shared/providers/TenantProvider.js";
+import { learningKeys } from "../learningKeys.js";
+
+const DEFAULT_PAGE = { page: 1, pageSize: 50 } as const;
+
+export function useLearningRecommendationsQuery(
+  input: Partial<LearningRecommendationListQuery> = DEFAULT_PAGE,
+): UseQueryResult<LearningRecommendationListResponse> {
+  const tenantId = useTenantId();
+  const { api } = usePorts();
+  return useQuery({
+    queryKey: learningKeys.list(tenantId, input),
+    queryFn: () => api.learningRecommendations(input),
+  });
+}
+
+export function useLearningRecommendationEvidenceQuery(
+  recommendationId: string,
+  input: Partial<LearningRecommendationEvidenceListQuery> = DEFAULT_PAGE,
+): UseQueryResult<LearningRecommendationEvidenceListResponse> {
+  const tenantId = useTenantId();
+  const { api } = usePorts();
+  return useQuery({
+    queryKey: learningKeys.evidenceList(tenantId, recommendationId, input),
+    queryFn: () => api.learningRecommendationEvidence(recommendationId, input),
+  });
+}

--- a/apps/web/src/contexts/operations/index.ts
+++ b/apps/web/src/contexts/operations/index.ts
@@ -133,6 +133,7 @@ export { useJobsListQuery } from "./hooks/useJobsListQuery.js";
 export {
   useLearningRecommendationEvidenceQuery,
   useLearningRecommendationsQuery,
+  useTailoringPolicyRevisionsQuery,
 } from "./hooks/useLearningRecommendationsQuery.js";
 export { usePipelineOperationsQuery } from "./hooks/usePipelineOperationsQuery.js";
 export { useWorkflowRunsListQuery } from "./hooks/useWorkflowRunsListQuery.js";

--- a/apps/web/src/contexts/operations/index.ts
+++ b/apps/web/src/contexts/operations/index.ts
@@ -85,6 +85,7 @@ export { healthKeys } from "./healthKeys.js";
 export { settingsKeys } from "./settingsKeys.js";
 export { browserCapabilityKeys } from "./browserCapabilityKeys.js";
 export { jobsKeys } from "./jobsKeys.js";
+export { learningKeys } from "./learningKeys.js";
 export { outcomesKeys } from "./outcomesKeys.js";
 export { workflowRunsKeys } from "./workflowRunsKeys.js";
 
@@ -129,6 +130,10 @@ export {
 export { useJobApplicationOutcomesQuery } from "./hooks/useJobApplicationOutcomesQuery.js";
 export { useJobDetailQuery } from "./hooks/useJobDetailQuery.js";
 export { useJobsListQuery } from "./hooks/useJobsListQuery.js";
+export {
+  useLearningRecommendationEvidenceQuery,
+  useLearningRecommendationsQuery,
+} from "./hooks/useLearningRecommendationsQuery.js";
 export { usePipelineOperationsQuery } from "./hooks/usePipelineOperationsQuery.js";
 export { useWorkflowRunsListQuery } from "./hooks/useWorkflowRunsListQuery.js";
 

--- a/apps/web/src/contexts/operations/learningKeys.ts
+++ b/apps/web/src/contexts/operations/learningKeys.ts
@@ -1,0 +1,18 @@
+import type {
+  LearningRecommendationEvidenceListQuery,
+  LearningRecommendationListQuery,
+} from "@jobctrl/contracts";
+import type { TenantId } from "@jobctrl/domain-types";
+
+export const learningKeys = {
+  all: (tenantId: TenantId) => ["tenant", tenantId, "operations", "learning"] as const,
+  lists: (tenantId: TenantId) => [...learningKeys.all(tenantId), "recommendations"] as const,
+  list: (tenantId: TenantId, input: Partial<LearningRecommendationListQuery>) =>
+    [...learningKeys.lists(tenantId), input] as const,
+  evidence: (tenantId: TenantId) => [...learningKeys.all(tenantId), "evidence"] as const,
+  evidenceList: (
+    tenantId: TenantId,
+    recommendationId: string,
+    input: Partial<LearningRecommendationEvidenceListQuery>,
+  ) => [...learningKeys.evidence(tenantId), recommendationId, input] as const,
+};

--- a/apps/web/src/contexts/operations/learningKeys.ts
+++ b/apps/web/src/contexts/operations/learningKeys.ts
@@ -1,6 +1,7 @@
 import type {
   LearningRecommendationEvidenceListQuery,
   LearningRecommendationListQuery,
+  TailoringPolicyRevisionListQuery,
 } from "@jobctrl/contracts";
 import type { TenantId } from "@jobctrl/domain-types";
 
@@ -15,4 +16,10 @@ export const learningKeys = {
     recommendationId: string,
     input: Partial<LearningRecommendationEvidenceListQuery>,
   ) => [...learningKeys.evidence(tenantId), recommendationId, input] as const,
+  policyRevisions: (tenantId: TenantId) =>
+    [...learningKeys.all(tenantId), "policies", "materials"] as const,
+  policyRevisionList: (
+    tenantId: TenantId,
+    input: Partial<TailoringPolicyRevisionListQuery>,
+  ) => [...learningKeys.policyRevisions(tenantId), input] as const,
 };

--- a/apps/web/src/contexts/operations/queryKeys.ts
+++ b/apps/web/src/contexts/operations/queryKeys.ts
@@ -11,6 +11,7 @@ export { applyReviewKeys } from "./applyReviewKeys.js";
 export { outcomesKeys } from "./outcomesKeys.js";
 export { workflowRunsKeys } from "./workflowRunsKeys.js";
 export { healthKeys } from "./healthKeys.js";
+export { learningKeys } from "./learningKeys.js";
 export { profileKeys } from "../profile/queryKeys.js";
 export { discoveryKeys } from "../discovery/queryKeys.js";
 export { enrichmentKeys } from "../enrichment/queryKeys.js";

--- a/apps/web/src/demo/DemoApiClientAdapter.ts
+++ b/apps/web/src/demo/DemoApiClientAdapter.ts
@@ -139,6 +139,10 @@ export class DemoApiClientAdapter implements ApiClientPort {
     return this.read((model) => model.analytics.summary);
   }
 
+  learningRecommendations = this.unsupported("learningRecommendations");
+  learningRecommendationEvidence = this.unsupported("learningRecommendationEvidence");
+  reviewLearningRecommendation = this.unsupported("reviewLearningRecommendation");
+
   digest() {
     return this.read((model) => model.dashboard.digest);
   }

--- a/apps/web/src/demo/DemoApiClientAdapter.ts
+++ b/apps/web/src/demo/DemoApiClientAdapter.ts
@@ -142,6 +142,8 @@ export class DemoApiClientAdapter implements ApiClientPort {
   learningRecommendations = this.unsupported("learningRecommendations");
   learningRecommendationEvidence = this.unsupported("learningRecommendationEvidence");
   reviewLearningRecommendation = this.unsupported("reviewLearningRecommendation");
+  tailoringPolicyRevisions = this.unsupported("tailoringPolicyRevisions");
+  rollbackTailoringPolicy = this.unsupported("rollbackTailoringPolicy");
 
   digest() {
     return this.read((model) => model.dashboard.digest);

--- a/apps/web/src/demo/DemoLocalCommandExecutor.test.ts
+++ b/apps/web/src/demo/DemoLocalCommandExecutor.test.ts
@@ -229,7 +229,7 @@ const LOCAL_CASES = [
 ] as const satisfies readonly LocalCase[];
 
 describe("DemoLocalCommandExecutor", () => {
-  it("keeps the 128-member capability manifest exhaustive with exact class counts", () => {
+  it("keeps the 131-member capability manifest exhaustive with exact class counts", () => {
     const counts = Object.values(DEMO_CAPABILITY_MANIFEST).reduce<Record<string, number>>(
       (result, capability) => {
         result[capability.class] = (result[capability.class] ?? 0) + 1;
@@ -237,12 +237,12 @@ describe("DemoLocalCommandExecutor", () => {
       },
       {},
     );
-    expect(Object.keys(DEMO_CAPABILITY_MANIFEST)).toHaveLength(128);
+    expect(Object.keys(DEMO_CAPABILITY_MANIFEST)).toHaveLength(131);
     expect(counts).toEqual({
       browser_local: 92,
       simulated_async: 4,
       rehearsed_external: 4,
-      unavailable: 28,
+      unavailable: 31,
     });
   });
 

--- a/apps/web/src/demo/DemoLocalCommandExecutor.test.ts
+++ b/apps/web/src/demo/DemoLocalCommandExecutor.test.ts
@@ -229,7 +229,7 @@ const LOCAL_CASES = [
 ] as const satisfies readonly LocalCase[];
 
 describe("DemoLocalCommandExecutor", () => {
-  it("keeps the 131-member capability manifest exhaustive with exact class counts", () => {
+  it("keeps the 133-member capability manifest exhaustive with exact class counts", () => {
     const counts = Object.values(DEMO_CAPABILITY_MANIFEST).reduce<Record<string, number>>(
       (result, capability) => {
         result[capability.class] = (result[capability.class] ?? 0) + 1;
@@ -237,12 +237,12 @@ describe("DemoLocalCommandExecutor", () => {
       },
       {},
     );
-    expect(Object.keys(DEMO_CAPABILITY_MANIFEST)).toHaveLength(131);
+    expect(Object.keys(DEMO_CAPABILITY_MANIFEST)).toHaveLength(133);
     expect(counts).toEqual({
       browser_local: 92,
       simulated_async: 4,
       rehearsed_external: 4,
-      unavailable: 31,
+      unavailable: 33,
     });
   });
 

--- a/apps/web/src/demo/capabilities.ts
+++ b/apps/web/src/demo/capabilities.ts
@@ -14,6 +14,15 @@ export const DEMO_CAPABILITY_MANIFEST = {
   dashboardSummary: local("Reads the synthetic dashboard projection."),
   pipelineOperations: unavailable("Pipeline operations telemetry is unavailable in the public demo."),
   outcomeAnalytics: local("Reads synthetic conversion analytics."),
+  learningRecommendations: unavailable(
+    "Learning recommendations require the local audited database.",
+  ),
+  learningRecommendationEvidence: unavailable(
+    "Learning evidence requires the local audited database.",
+  ),
+  reviewLearningRecommendation: unavailable(
+    "Learning recommendation review requires the local audited database.",
+  ),
   digest: local("Reads the synthetic daily digest."),
   acknowledgeDigest: local("Acknowledges a digest only in browser-local state."),
   activity: local("Reads synthetic activity history."),

--- a/apps/web/src/demo/capabilities.ts
+++ b/apps/web/src/demo/capabilities.ts
@@ -23,6 +23,12 @@ export const DEMO_CAPABILITY_MANIFEST = {
   reviewLearningRecommendation: unavailable(
     "Learning recommendation review requires the local audited database.",
   ),
+  tailoringPolicyRevisions: unavailable(
+    "Tailoring policy history requires the local audited database.",
+  ),
+  rollbackTailoringPolicy: unavailable(
+    "Tailoring policy rollback requires the local audited database.",
+  ),
   digest: local("Reads the synthetic daily digest."),
   acknowledgeDigest: local("Acknowledges a digest only in browser-local state."),
   activity: local("Reads synthetic activity history."),

--- a/apps/web/src/demo/demo-seed.test.ts
+++ b/apps/web/src/demo/demo-seed.test.ts
@@ -18,7 +18,7 @@ const CONTOSO_GENERATION_ONE_ARTIFACT_IDS = [
 
 describe("canonical public demo seed", () => {
   it("has a complete classified API capability manifest", () => {
-    expect(Object.keys(DEMO_CAPABILITY_MANIFEST)).toHaveLength(131);
+    expect(Object.keys(DEMO_CAPABILITY_MANIFEST)).toHaveLength(133);
     expect(Object.values(DEMO_CAPABILITY_MANIFEST).every((entry) => entry.reason.length > 0)).toBe(true);
   });
 

--- a/apps/web/src/demo/demo-seed.test.ts
+++ b/apps/web/src/demo/demo-seed.test.ts
@@ -18,7 +18,7 @@ const CONTOSO_GENERATION_ONE_ARTIFACT_IDS = [
 
 describe("canonical public demo seed", () => {
   it("has a complete classified API capability manifest", () => {
-    expect(Object.keys(DEMO_CAPABILITY_MANIFEST)).toHaveLength(128);
+    expect(Object.keys(DEMO_CAPABILITY_MANIFEST)).toHaveLength(131);
     expect(Object.values(DEMO_CAPABILITY_MANIFEST).every((entry) => entry.reason.length > 0)).toBe(true);
   });
 

--- a/apps/web/src/shared/adapters/local/FetchApiClientAdapter.ts
+++ b/apps/web/src/shared/adapters/local/FetchApiClientAdapter.ts
@@ -30,6 +30,21 @@ export class FetchApiClientAdapter implements ApiClientPort {
   outcomeAnalytics() {
     return this.client.outcomeAnalytics();
   }
+  learningRecommendations(query: Parameters<JobCtrlApiClient["learningRecommendations"]>[0] = {}) {
+    return this.client.learningRecommendations(query);
+  }
+  learningRecommendationEvidence(
+    recommendationId: string,
+    query: Parameters<JobCtrlApiClient["learningRecommendationEvidence"]>[1] = {},
+  ) {
+    return this.client.learningRecommendationEvidence(recommendationId, query);
+  }
+  reviewLearningRecommendation(
+    recommendationId: string,
+    body: Parameters<JobCtrlApiClient["reviewLearningRecommendation"]>[1],
+  ) {
+    return this.client.reviewLearningRecommendation(recommendationId, body);
+  }
   digest() {
     return this.client.digest();
   }

--- a/apps/web/src/shared/adapters/local/FetchApiClientAdapter.ts
+++ b/apps/web/src/shared/adapters/local/FetchApiClientAdapter.ts
@@ -45,6 +45,16 @@ export class FetchApiClientAdapter implements ApiClientPort {
   ) {
     return this.client.reviewLearningRecommendation(recommendationId, body);
   }
+  tailoringPolicyRevisions(
+    query: Parameters<JobCtrlApiClient["tailoringPolicyRevisions"]>[0] = {},
+  ) {
+    return this.client.tailoringPolicyRevisions(query);
+  }
+  rollbackTailoringPolicy(
+    body: Parameters<JobCtrlApiClient["rollbackTailoringPolicy"]>[0],
+  ) {
+    return this.client.rollbackTailoringPolicy(body);
+  }
   digest() {
     return this.client.digest();
   }

--- a/apps/web/src/shared/ports/ApiClientPort.ts
+++ b/apps/web/src/shared/ports/ApiClientPort.ts
@@ -83,6 +83,12 @@ import type {
   JobListQuery,
   JobMutationResponse,
   JobSummary,
+  LearningRecommendationEvidenceListQuery,
+  LearningRecommendationEvidenceListResponse,
+  LearningRecommendationListQuery,
+  LearningRecommendationListResponse,
+  LearningRecommendationReviewRequest,
+  LearningRecommendationReviewResponse,
   MarkJobActionRequest,
   ManualCaptureDismissRequest,
   ManualCaptureDismissResponse,
@@ -192,6 +198,17 @@ export interface ApiClientPort {
   dashboardSummary(): Promise<DashboardSummary>;
   pipelineOperations(): Promise<PipelineOperationsSnapshot>;
   outcomeAnalytics(): Promise<OutcomeAnalyticsSummary>;
+  learningRecommendations(
+    query?: Partial<LearningRecommendationListQuery>,
+  ): Promise<LearningRecommendationListResponse>;
+  learningRecommendationEvidence(
+    recommendationId: string,
+    query?: Partial<LearningRecommendationEvidenceListQuery>,
+  ): Promise<LearningRecommendationEvidenceListResponse>;
+  reviewLearningRecommendation(
+    recommendationId: string,
+    body: LearningRecommendationReviewRequest,
+  ): Promise<LearningRecommendationReviewResponse>;
   digest(): Promise<DailyDigest>;
   acknowledgeDigest(body?: DigestAcknowledgeRequest): Promise<DigestAcknowledgeResponse>;
   activity(query?: Partial<ActivityListQuery>): Promise<PaginatedResponse<ActivityEventSummary>>;

--- a/apps/web/src/shared/ports/ApiClientPort.ts
+++ b/apps/web/src/shared/ports/ApiClientPort.ts
@@ -89,6 +89,10 @@ import type {
   LearningRecommendationListResponse,
   LearningRecommendationReviewRequest,
   LearningRecommendationReviewResponse,
+  TailoringPolicyRevisionListQuery,
+  TailoringPolicyRevisionListResponse,
+  TailoringPolicyRollbackRequest,
+  TailoringPolicyRollbackResponse,
   MarkJobActionRequest,
   ManualCaptureDismissRequest,
   ManualCaptureDismissResponse,
@@ -209,6 +213,12 @@ export interface ApiClientPort {
     recommendationId: string,
     body: LearningRecommendationReviewRequest,
   ): Promise<LearningRecommendationReviewResponse>;
+  tailoringPolicyRevisions(
+    query?: Partial<TailoringPolicyRevisionListQuery>,
+  ): Promise<TailoringPolicyRevisionListResponse>;
+  rollbackTailoringPolicy(
+    body: TailoringPolicyRollbackRequest,
+  ): Promise<TailoringPolicyRollbackResponse>;
   digest(): Promise<DailyDigest>;
   acknowledgeDigest(body?: DigestAcknowledgeRequest): Promise<DigestAcknowledgeResponse>;
   activity(query?: Partial<ActivityListQuery>): Promise<PaginatedResponse<ActivityEventSummary>>;

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -3756,6 +3756,79 @@ input[type="radio"] {
   overflow-wrap: anywhere;
 }
 
+.learning-recommendations {
+  display: grid;
+  gap: 10px;
+  padding: 12px 16px;
+}
+
+.learning-recommendation-card {
+  display: grid;
+  gap: 10px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--card);
+  padding: 12px;
+}
+
+.learning-recommendation-head {
+  display: flex;
+  min-width: 0;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.learning-recommendation-head > span:first-child {
+  display: grid;
+  min-width: 0;
+  gap: 2px;
+}
+
+.learning-recommendation-facts {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 8px 16px;
+  margin: 0;
+}
+
+.learning-recommendation-facts div {
+  display: grid;
+  gap: 2px;
+}
+
+.learning-recommendation-facts dt {
+  color: var(--muted-foreground);
+  font-size: var(--jh-type-caption-size);
+}
+
+.learning-recommendation-facts dd {
+  margin: 0;
+}
+
+.learning-recommendation-card p,
+.learning-recommendation-evidence ul {
+  margin: 0;
+}
+
+.learning-recommendation-evidence ul {
+  display: grid;
+  gap: 8px;
+  padding: 0;
+  list-style: none;
+}
+
+.learning-recommendation-evidence li {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 2px 10px;
+  overflow-wrap: anywhere;
+}
+
+.learning-recommendation-evidence li .meta {
+  grid-column: 2;
+}
+
 .discovery-control-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -3829,6 +3829,73 @@ input[type="radio"] {
   grid-column: 2;
 }
 
+.tailoring-policy-revisions {
+  display: grid;
+  gap: 10px;
+  padding: 12px 16px;
+}
+
+.tailoring-policy-revision-card {
+  display: grid;
+  gap: 10px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--card);
+  padding: 12px;
+}
+
+.tailoring-policy-revision-head {
+  display: flex;
+  min-width: 0;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.tailoring-policy-revision-head > span:first-child,
+.tailoring-policy-provenance {
+  display: grid;
+  min-width: 0;
+  gap: 2px;
+  overflow-wrap: anywhere;
+}
+
+.tailoring-policy-revision-facts {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 8px 16px;
+  margin: 0;
+}
+
+.tailoring-policy-revision-facts div {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+}
+
+.tailoring-policy-revision-facts dt {
+  color: var(--muted-foreground);
+  font-size: var(--jh-type-caption-size);
+}
+
+.tailoring-policy-revision-facts dd {
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+
+.tailoring-policy-revision-facts ul {
+  display: grid;
+  gap: 2px;
+  margin: 0;
+  padding-left: 18px;
+}
+
+.tailoring-policy-pagination {
+  display: flex;
+  align-items: center;
+  padding: 0 16px 12px;
+}
+
 .discovery-control-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));

--- a/apps/web/src/test/fixtures/learning.ts
+++ b/apps/web/src/test/fixtures/learning.ts
@@ -2,6 +2,8 @@ import type {
   LearningRecommendationEvidenceListResponse,
   LearningRecommendationListResponse,
   LearningRecommendationSummary,
+  TailoringPolicyRevisionListResponse,
+  TailoringPolicyRollbackResponse,
 } from "@jobctrl/contracts";
 
 export const sampleLearningRecommendation: LearningRecommendationSummary = {
@@ -71,4 +73,76 @@ export const sampleLearningRecommendationEvidence: LearningRecommendationEvidenc
   pageSize: 100,
   total: 2,
   totalPages: 1,
+};
+
+export const sampleTailoringPolicyRevisionList: TailoringPolicyRevisionListResponse = {
+  ok: true,
+  revisions: [
+    {
+      context: "materials",
+      policyKind: "tailoring_rule",
+      version: 4,
+      status: "current",
+      learnedRules: [],
+      sourceReviewId: null,
+      sourceRecommendationId: null,
+      rollbackOfVersion: 1,
+      rollbackReasonCode: "user_requested",
+      createdAt: "2026-08-01T12:15:00.000Z",
+    },
+    {
+      context: "materials",
+      policyKind: "tailoring_rule",
+      version: 3,
+      status: "superseded",
+      learnedRules: [{ ruleKey: "fact_handling", ruleValue: "require_source_match" }],
+      sourceReviewId: `learning-recommendation-review:${"c".repeat(64)}`,
+      sourceRecommendationId: sampleLearningRecommendation.recommendationId,
+      rollbackOfVersion: null,
+      rollbackReasonCode: null,
+      createdAt: "2026-08-01T12:05:00.000Z",
+    },
+    {
+      context: "materials",
+      policyKind: "tailoring_rule",
+      version: 2,
+      status: "superseded",
+      learnedRules: [],
+      sourceReviewId: null,
+      sourceRecommendationId: null,
+      rollbackOfVersion: null,
+      rollbackReasonCode: null,
+      createdAt: "2026-08-01T11:00:00.000Z",
+    },
+    {
+      context: "materials",
+      policyKind: "tailoring_rule",
+      version: 1,
+      status: "superseded",
+      learnedRules: [],
+      sourceReviewId: null,
+      sourceRecommendationId: null,
+      rollbackOfVersion: null,
+      rollbackReasonCode: null,
+      createdAt: "2026-08-01T10:00:00.000Z",
+    },
+  ],
+  page: 1,
+  pageSize: 100,
+  total: 4,
+  totalPages: 1,
+};
+
+export const sampleTailoringPolicyRollback: TailoringPolicyRollbackResponse = {
+  ok: true,
+  context: "materials",
+  policyKind: "tailoring_rule",
+  version: 5,
+  status: "current",
+  learnedRules: [],
+  sourceReviewId: null,
+  sourceRecommendationId: null,
+  rollbackOfVersion: 1,
+  rollbackReasonCode: "user_requested",
+  createdAt: "2026-08-01T12:30:00.000Z",
 };

--- a/apps/web/src/test/fixtures/learning.ts
+++ b/apps/web/src/test/fixtures/learning.ts
@@ -1,0 +1,74 @@
+import type {
+  LearningRecommendationEvidenceListResponse,
+  LearningRecommendationListResponse,
+  LearningRecommendationSummary,
+} from "@jobctrl/contracts";
+
+export const sampleLearningRecommendation: LearningRecommendationSummary = {
+  recommendationId: `learning-recommendation:${"a".repeat(64)}`,
+  derivationVersion: 1,
+  evaluationFixtureVersion: 1,
+  context: "materials",
+  policyKind: "tailoring_rule",
+  signalKind: "style_preference",
+  ruleKey: "style_guidance",
+  ruleValue: "preserve_user_edit_pattern",
+  allowlistVersion: 1,
+  status: "pending",
+  active: true,
+  observedSignalCount: 3,
+  observedJobCount: 2,
+  minimumSignalCount: 3,
+  minimumJobCount: 2,
+  confidenceLimit: "sample_gated_no_population_inference",
+  supportingEvidenceCount: 3,
+  contradictingEvidenceCount: 1,
+  tombstoneCount: 0,
+  derivedAt: "2026-08-01T12:00:00.000Z",
+};
+
+export const sampleSecondLearningRecommendation: LearningRecommendationSummary = {
+  ...sampleLearningRecommendation,
+  recommendationId: `learning-recommendation:${"b".repeat(64)}`,
+  signalKind: "factual_correction",
+  ruleKey: "fact_handling",
+  ruleValue: "require_source_match",
+  contradictingEvidenceCount: 0,
+  derivedAt: "2026-08-01T12:01:00.000Z",
+};
+
+export const sampleLearningRecommendationList: LearningRecommendationListResponse = {
+  ok: true,
+  recommendations: [sampleLearningRecommendation, sampleSecondLearningRecommendation],
+  page: 1,
+  pageSize: 50,
+  total: 2,
+  totalPages: 1,
+};
+
+export const sampleLearningRecommendationEvidence: LearningRecommendationEvidenceListResponse = {
+  ok: true,
+  recommendationId: sampleLearningRecommendation.recommendationId,
+  evidence: [
+    {
+      signalId: "tailoring-signal-supporting-1",
+      evidenceRole: "supporting",
+      sourceKind: "tailoring_feedback_signal",
+      sourceRevision: 2,
+      jobId: "11111111-1111-4111-8111-111111111111",
+      recordedAt: "2026-08-01T10:00:00.000Z",
+    },
+    {
+      signalId: "tailoring-signal-contradicting-1",
+      evidenceRole: "contradicting",
+      sourceKind: "tailoring_feedback_signal",
+      sourceRevision: 1,
+      jobId: "22222222-2222-4222-8222-222222222222",
+      recordedAt: "2026-08-01T10:05:00.000Z",
+    },
+  ],
+  page: 1,
+  pageSize: 100,
+  total: 2,
+  totalPages: 1,
+};

--- a/apps/web/src/test/msw/handlers.ts
+++ b/apps/web/src/test/msw/handlers.ts
@@ -31,6 +31,8 @@ import {
 import {
   sampleLearningRecommendationEvidence,
   sampleLearningRecommendationList,
+  sampleTailoringPolicyRevisionList,
+  sampleTailoringPolicyRollback,
 } from "../fixtures/learning.js";
 import {
   makeArtifactDetail,
@@ -291,6 +293,12 @@ export const handlers = [
         reviewedAt: "2026-08-01T12:05:00.000Z",
       });
     },
+  ),
+  http.get("*/v1/learning/policies/materials", () =>
+    HttpResponse.json(sampleTailoringPolicyRevisionList),
+  ),
+  http.post("*/v1/learning/policies/materials/rollbacks", () =>
+    HttpResponse.json(sampleTailoringPolicyRollback),
   ),
   http.get("*/v1/digest", () => HttpResponse.json(sampleDailyDigest)),
   http.post("*/v1/digest/acknowledge", async ({ request }) => {

--- a/apps/web/src/test/msw/handlers.ts
+++ b/apps/web/src/test/msw/handlers.ts
@@ -29,6 +29,10 @@ import {
   makeOutreachThreadResponse,
 } from "../fixtures/outreach.js";
 import {
+  sampleLearningRecommendationEvidence,
+  sampleLearningRecommendationList,
+} from "../fixtures/learning.js";
+import {
   makeArtifactDetail,
   makeArtifactTailoringExplanation,
   makeActivityPage,
@@ -260,6 +264,34 @@ export const handlers = [
   http.get("*/v1/health", () => HttpResponse.json(sampleHealthResponse)),
   http.get("*/v1/dashboard/summary", () => HttpResponse.json(sampleDashboardSummary)),
   http.get("*/v1/analytics/outcomes", () => HttpResponse.json(sampleOutcomeAnalyticsSummary)),
+  http.get("*/v1/learning/recommendations", () =>
+    HttpResponse.json(sampleLearningRecommendationList),
+  ),
+  http.get("*/v1/learning/recommendations/:recommendationId/evidence", ({ params }) =>
+    HttpResponse.json({
+      ...sampleLearningRecommendationEvidence,
+      recommendationId: String(params["recommendationId"]),
+    }),
+  ),
+  http.post(
+    "*/v1/learning/recommendations/:recommendationId/reviews",
+    async ({ params, request }) => {
+      const body = (await request.json()) as { decision: "accepted" | "rejected" };
+      return HttpResponse.json({
+        ok: true,
+        reviewId: `learning-recommendation-review:${
+          body.decision === "accepted" ? "c".repeat(64) : "d".repeat(64)
+        }`,
+        recommendationId: String(params["recommendationId"]),
+        revision: 1,
+        decision: body.decision,
+        context: "materials",
+        policyKind: "tailoring_rule",
+        policyVersion: body.decision === "accepted" ? 2 : null,
+        reviewedAt: "2026-08-01T12:05:00.000Z",
+      });
+    },
+  ),
   http.get("*/v1/digest", () => HttpResponse.json(sampleDailyDigest)),
   http.post("*/v1/digest/acknowledge", async ({ request }) => {
     const body = (await request.json().catch(() => ({}))) as { acknowledgedAt?: string };

--- a/apps/web/src/views/dashboard/DashboardView.test.tsx
+++ b/apps/web/src/views/dashboard/DashboardView.test.tsx
@@ -30,6 +30,9 @@ describe("DashboardView", () => {
     expect(
       await screen.findByRole("heading", { name: "Learning recommendations" }),
     ).toBeInTheDocument();
+    expect(
+      await screen.findByRole("heading", { name: "Tailoring policy history" }),
+    ).toBeInTheDocument();
     expect(screen.getByText("Recruiter reply indicates an interview request.")).toBeInTheDocument();
     expect(screen.getByText("stuck").querySelector("svg")).toHaveClass("tabler-icon-ban");
     expect(screen.getByText("in progress").querySelector("svg")).toHaveClass("tabler-icon-clock");

--- a/apps/web/src/views/dashboard/DashboardView.test.tsx
+++ b/apps/web/src/views/dashboard/DashboardView.test.tsx
@@ -27,6 +27,9 @@ describe("DashboardView", () => {
     expect(screen.getByText("Job scored 8/10")).toBeInTheDocument();
     expect(await screen.findByRole("heading", { name: "Daily digest" })).toBeInTheDocument();
     expect(await screen.findByRole("heading", { name: "Outcome suggestions" })).toBeInTheDocument();
+    expect(
+      await screen.findByRole("heading", { name: "Learning recommendations" }),
+    ).toBeInTheDocument();
     expect(screen.getByText("Recruiter reply indicates an interview request.")).toBeInTheDocument();
     expect(screen.getByText("stuck").querySelector("svg")).toHaveClass("tabler-icon-ban");
     expect(screen.getByText("in progress").querySelector("svg")).toHaveClass("tabler-icon-clock");

--- a/apps/web/src/views/dashboard/DashboardView.tsx
+++ b/apps/web/src/views/dashboard/DashboardView.tsx
@@ -1,7 +1,10 @@
 import { IconAlertTriangle } from "@tabler/icons-react";
 
 import { OutcomeSuggestionsPanel } from "../../contexts/apply/components/ApplicationOutcomes.js";
-import { LearningRecommendationReviewPanel } from "../../contexts/materials/index.js";
+import {
+  LearningRecommendationReviewPanel,
+  TailoringPolicyHistoryPanel,
+} from "../../contexts/materials/index.js";
 import { useApplicationOutcomesQuery } from "../../contexts/operations/hooks/useApplicationOutcomesQuery.js";
 import { useDashboardSummaryQuery } from "../../contexts/operations/hooks/useDashboardSummaryQuery.js";
 import { useWorkflowRunsListQuery } from "../../contexts/operations/hooks/useWorkflowRunsListQuery.js";
@@ -80,6 +83,7 @@ export function DashboardView() {
             <RecentActivityCard summary={summary} />
             <ApplyRunsCard summary={summary} />
             <LearningRecommendationReviewPanel />
+            <TailoringPolicyHistoryPanel />
             <section className="card col-span-full">
               <CardHeader
                 title="Outcome suggestions"

--- a/apps/web/src/views/dashboard/DashboardView.tsx
+++ b/apps/web/src/views/dashboard/DashboardView.tsx
@@ -1,6 +1,7 @@
 import { IconAlertTriangle } from "@tabler/icons-react";
 
 import { OutcomeSuggestionsPanel } from "../../contexts/apply/components/ApplicationOutcomes.js";
+import { LearningRecommendationReviewPanel } from "../../contexts/materials/index.js";
 import { useApplicationOutcomesQuery } from "../../contexts/operations/hooks/useApplicationOutcomesQuery.js";
 import { useDashboardSummaryQuery } from "../../contexts/operations/hooks/useDashboardSummaryQuery.js";
 import { useWorkflowRunsListQuery } from "../../contexts/operations/hooks/useWorkflowRunsListQuery.js";
@@ -78,6 +79,7 @@ export function DashboardView() {
             />
             <RecentActivityCard summary={summary} />
             <ApplyRunsCard summary={summary} />
+            <LearningRecommendationReviewPanel />
             <section className="card col-span-full">
               <CardHeader
                 title="Outcome suggestions"

--- a/apps/web/src/views/jobs/JobsView.test.tsx
+++ b/apps/web/src/views/jobs/JobsView.test.tsx
@@ -810,7 +810,7 @@ describe("<JobsView> bulk delete integration", () => {
     expect(rowForTitle(applyJob.title)).toHaveClass(
       "data-grid-row-tone-warning",
     );
-  });
+  }, 15_000);
 
   it("hydrates active saved table view filters when the jobs view remounts", async () => {
     const vonageJob: JobSummary = {

--- a/docs/api/complete-contract.md
+++ b/docs/api/complete-contract.md
@@ -39,6 +39,7 @@ need:
 | [Profile and preferences](#profile-and-preferences) | Reading and writing the candidate profile, autosave, and the Preferences / Discovery / Settings control split. |
 | [Artifacts and tailoring audit](#artifacts-and-tailoring-audit) | Read-model projections, artifact preview/open routes, resume templates, and canonical tailoring evidence. |
 | [Jobs read model and lifecycle](#jobs-read-model-and-lifecycle) | Score evidence, requirement-fit, career evidence map, audit history, list filters, and delete / hide / restore routes. |
+| [Feedback learning and policy history](#feedback-learning-and-policy-history) | Normalized scoring-keyword aggregation, privacy-safe recommendations and evidence, explicit review, Materials policy history, and append-only rollback. |
 | [Dashboard, analytics, and operational metrics](#dashboard-analytics-and-operational-metrics) | `GET /v1/dashboard/summary`, `GET /v1/analytics/outcomes`, source health, and operational attempt counters. |
 | [Pipeline operations snapshot](#pipeline-operations-snapshot) | `GET /v1/pipeline/operations`: immutable Discover execution lineage, scoped backlog, orchestration steps, runtime capacity, active work, task-queue observations, and typed ETA. |
 | [Discovery controls](#discovery-controls) | Source registry, locator / quarantine / manual-capture queues, and feedback endpoints. |
@@ -270,6 +271,44 @@ record, so rediscovery can add the same posting again later.
 `POST /v1/jobs/bulk-retry-failed` accepts the same selected-job or
 all-matching bulk mutation body and resets each active failed or exhausted job's
 failed stage to `pending`; non-failed selected jobs are ignored.
+
+## Feedback learning and policy history
+
+`GET /v1/scoring/keywords` returns `{ ok: true, keywords }`. Each item contains
+`normalizedKeyword`, `displayKeyword`, the positive current `scoreVersion`, and
+positive `jobCount`. `GET /v1/jobs?normalizedScoreKeyword=<key>` performs an
+exact match against that normalized key on each job's current score version;
+historical score keywords are not mixed into either result.
+
+`GET /v1/learning/recommendations?page=<n>&pageSize=<1..100>` returns a
+paginated list of pending Materials `tailoring_rule` recommendations. Each
+summary exposes only an allowlisted rule key/value, derivation and evaluation
+fixture versions, signal kind, threshold/observed counts, bounded
+supporting/contradicting/tombstone counts, the explicit
+`sample_gated_no_population_inference` confidence limit, and timestamps. It
+never exposes feedback free text, raw notes, resumes, job descriptions, prompts,
+mail bodies, or model output.
+
+`GET /v1/learning/recommendations/:recommendationId/evidence` returns paginated
+structured evidence links: signal ID, supporting/contradicting role, source
+revision, stable JobId, and recorded time. An invalid canonical recommendation
+ID returns `400`; an unknown tenant-scoped recommendation returns `404`.
+
+`POST /v1/learning/recommendations/:recommendationId/reviews` accepts exactly
+`{ decision: "accepted" | "rejected" }`. Acceptance creates a new versioned
+Materials tailoring-policy revision and returns its positive `policyVersion`.
+Rejection records the review and returns `policyVersion: null`; it changes no
+policy. Replayed/conflicting/stale review attempts return a bounded error rather
+than applying behavior twice.
+
+`GET /v1/learning/policies/materials?page=<n>&pageSize=<1..100>` returns
+allowlisted current/superseded revision summaries: version, learned rules,
+recommendation/review provenance when present, rollback provenance when
+present, and creation time. `POST /v1/learning/policies/materials/rollbacks`
+accepts `{ targetVersion: <positive integer> }` and appends a new current
+revision with `rollbackOfVersion` and `rollbackReasonCode: "user_requested"`.
+The exact structured replay is idempotent. Neither review nor rollback starts
+scoring, tailoring, Apply, workflow, or artifact work.
 
 ## Dashboard, analytics, and operational metrics
 
@@ -708,7 +747,9 @@ invalidation router uses the event to refresh job list/detail queries.
 `/v1/workflow-runs` reads the unified `workflow_run_projections` table (the
 Python-sole-writer projection folded from the `Workflow*` lifecycle events) and
 projects each row to a `WorkflowRunSummary` across **all** workflow types —
-pipeline orchestrator, apply, and future workflows. Apply rows are enriched with
+Discover, job preparation, Apply, and future workflows. Those workflow families
+share one status vocabulary, ordered timeline, terminal-state interpretation,
+and cancellation boundary. Apply rows are enriched with
 job context (title/company/dry-run/model) via a LEFT JOIN to
 `apply_run_projections`; non-apply rows surface their `workflowType` instead of a
 job title. The `runId` equals the Temporal workflow id, so the web Workflow Runs
@@ -726,6 +767,11 @@ status, input summary, failure cause (`errorCode` / `errorMessage` /
 `POST /v1/workflow-runs/:runId/actions/cancel` dispatches a worker-backed
 `cancel_run` request for in-flight workflow IDs that are not tied to a concrete
 job row, such as global Discover or Apply runs started from the Pipelines tab.
+The command is cooperative, asynchronous, and idempotent. Repeating it cannot
+replace an already-terminal Apply result or emit another cancellation
+transition. Whether cancellation wins or loses its race with completion, the
+terminal result and folded timeline remain inspectable through the same detail
+route.
 `GET /v1/dashboard/summary` also carries recent apply-run timeline summaries
 from `apply_run_projections.events_json` (`type`, `level`, `message`, `at`) so
 the run detail workspace renders persisted history without exposing raw event
@@ -1077,8 +1123,8 @@ configuration choose the active model.
 `POST /v1/jobs/:jobKey/actions/run-stage` starts one job-scoped preparation
 pickup without resetting stage state. It accepts the internal preparation
 stages `enrich`, `score`, `tailor`, and `cover`, rejects product-stage starts
-such as `apply`, resolves the route key to the canonical job URL, checks worker
-readiness, and dispatches `run_stage` for the remaining preparation sequence
+such as `apply`, resolves the route key at the API boundary to the stable JobId,
+checks worker readiness, and dispatches `run_stage` for the remaining preparation sequence
 from the requested substage. Before dispatch, the route refreshes projections
 and checks that the requested substage is still pending and observably eligible;
 known-ineligible rows return `status: "not_eligible"` without starting worker
@@ -1090,7 +1136,7 @@ fanout.
   matching jobs. It does not reset stages. It selects the first eligible pending
   preparation substage per job (`enrich`, `score`, `tailor`, or `cover`),
   groups those jobs by substage, and dispatches bounded `run_stage` workflows
-  with selected job URLs and the requested worker count. Known-ineligible,
+  with selected JobIds and the requested worker count. Known-ineligible,
   failed, exhausted, already-complete, low-fit, and `apply`-pending rows are
   ignored. The Jobs toolbar exposes this as `continue pending prep` so pending
   preparation backlogs are not dependent on page-local pickup.
@@ -1510,6 +1556,15 @@ the browser's native `EventSource`. Per
 single realtime channel from the worker / API write-side to the frontend's
 TanStack Query cache; the frontend's `InvalidationRouter` translates each
 `DomainEvent` into the right `invalidateQueries` / `setQueryData` calls.
+
+`setQueryData` is used only when the tenant-scoped event contains enough
+canonical fields for an exact truthful patch: active job detail,
+already-registered artifact detail, workflow-run detail, or an ordered Apply-run
+event. Filtered/list membership, dashboards, incomplete payloads, and uncertain
+artifact registration use bounded tenant-scoped invalidation. Cache
+reconciliation does not reset view-owned filters, selection, pagination, or
+scroll state and never synthesizes an artifact that is absent from persisted
+registration.
 
 ### Request
 

--- a/docs/api/complete-contract.md
+++ b/docs/api/complete-contract.md
@@ -298,8 +298,9 @@ ID returns `400`; an unknown tenant-scoped recommendation returns `404`.
 `{ decision: "accepted" | "rejected" }`. Acceptance creates a new versioned
 Materials tailoring-policy revision and returns its positive `policyVersion`.
 Rejection records the review and returns `policyVersion: null`; it changes no
-policy. Replayed/conflicting/stale review attempts return a bounded error rather
-than applying behavior twice.
+policy. An identical structured replay returns the same idempotent success;
+conflicting or stale review attempts return a bounded error rather than
+applying behavior twice.
 
 `GET /v1/learning/policies/materials?page=<n>&pageSize=<1..100>` returns
 allowlisted current/superseded revision summaries: version, learned rules,

--- a/docs/api/jobs-and-materials.md
+++ b/docs/api/jobs-and-materials.md
@@ -13,12 +13,36 @@ For field-level schemas and every route variant, use the
 | Route family | What it exposes |
 | --- | --- |
 | `GET /v1/jobs` and `GET /v1/jobs/:jobKey` | List/detail projections, stage state, score summary, and audit links. |
+| `GET /v1/scoring/keywords` | Current projected score-version keyword aggregation with canonical normalized keys. |
 | `GET /v1/evidence-map` | Canonical career evidence used by scoring and materials. |
 | `POST /v1/jobs/:key/score-correction` | A new score version plus explicit correction rationale. |
 | Job hide/restore/delete routes | Reversible lifecycle commands, plus a separate permanent-delete boundary. |
 
 List and detail endpoints read projection rows. They do not recompute scores,
 parse salary text, or replay events during a request.
+
+`jobKey` is the tenant-scoped stable `JobId`, not a posting URL. User/import
+boundaries may resolve a URL to that ID explicitly, but internal job routes and
+foreign references remain ID-shaped. `GET /v1/jobs` accepts
+`normalizedScoreKeyword` using the exact key returned by
+`GET /v1/scoring/keywords`; current filtering never mixes historical score
+versions into the result.
+
+## Feedback Learning And Materials Policy
+
+| Route | Purpose |
+| --- | --- |
+| `GET /v1/learning/recommendations` | Paginated pending/inactive recommendation summaries with sample gates and safe counts. |
+| `GET /v1/learning/recommendations/:recommendationId/evidence` | Bounded structured supporting and contradicting references without source free text. |
+| `POST /v1/learning/recommendations/:recommendationId/reviews` | Explicitly accept or reject one current recommendation. |
+| `GET /v1/learning/policies/materials` | Paginated current and superseded tailoring-policy revisions with allowlisted provenance. |
+| `POST /v1/learning/policies/materials/rollbacks` | Append a `user_requested` revision restoring one earlier version. |
+
+Acceptance creates one versioned Materials policy revision; rejection writes a
+review but does not change policy. Rollback is append-only and idempotent for
+the same structured request. None of these routes starts scoring, tailoring,
+Apply, or artifact work. Errors and historical metadata are sanitized before
+they cross the browser boundary.
 
 ## Artifacts And Resume Templates
 

--- a/docs/api/jobs-and-materials.md
+++ b/docs/api/jobs-and-materials.md
@@ -21,9 +21,11 @@ For field-level schemas and every route variant, use the
 List and detail endpoints read projection rows. They do not recompute scores,
 parse salary text, or replay events during a request.
 
-`jobKey` is the tenant-scoped stable `JobId`, not a posting URL. User/import
-boundaries may resolve a URL to that ID explicitly, but internal job routes and
-foreign references remain ID-shaped. `GET /v1/jobs` accepts
+`jobKey` resolves at the browser API boundary to the tenant-scoped stable
+`JobId`. Canonical clients send that ID; the explicit API/import boundary may
+also accept a posting or application URL as an external locator and resolve it
+to the same ID. Internal command payloads and foreign references remain
+ID-shaped. `GET /v1/jobs` accepts
 `normalizedScoreKeyword` using the exact key returned by
 `GET /v1/scoring/keywords`; current filtering never mixes historical score
 versions into the result.

--- a/docs/api/operations-and-events.md
+++ b/docs/api/operations-and-events.md
@@ -165,14 +165,22 @@ and task-queue observations are runtime telemetry, not domain events.
 /v1/workflow-runs/:runId` returns the projection-backed detail and timeline.
 `POST /v1/workflow-runs/:runId/actions/cancel` requests Temporal cancellation.
 
+Discover, job preparation, and Apply use this same history contract: one status
+vocabulary, ordered lifecycle timeline, terminal-state interpretation, and
+cancellation boundary. Product views may present different workflow details,
+but they do not maintain separate run-state rules.
+
 The list accepts an exact `workflowType`, inclusive UTC `startedSince`, and
 exclusive UTC `startedBefore` in addition to status, sorting, and pagination.
 Filtering happens after lifecycle folding and before pagination, so restarted
 executions use their canonical projected start time and returned totals cover
 the complete filtered result rather than only the current page.
 
-Cancellation is cooperative and asynchronous: the accepted request is not the
-same thing as observing the terminal canceled state.
+Cancellation is cooperative, asynchronous, and idempotent: accepting a request
+is not the same thing as observing terminal `canceled`, and repeating the
+request cannot overwrite an already-terminal result or emit duplicate
+cancellation transitions. Terminal results remain inspectable through the same
+run detail after cancellation wins or loses the race with completion.
 
 ## Health And JSON-RPC
 
@@ -197,6 +205,15 @@ Event IDs support reconnect replay; keepalives preserve quiet connections. See
 the [frontend realtime design](../architecture/frontend/realtime.md) for cache
 behavior and the [complete SSE contract](complete-contract.md#server-sent-events-—-get-v1eventsstream)
 for framing and precedence rules.
+
+The browser patches a tenant-scoped cache row only when the event carries
+enough canonical data to do so truthfully. That includes active job detail,
+already-registered artifact detail, workflow-run detail, and ordered Apply-run
+events. List membership, filtered views, dashboards, missing payload fields,
+and uncertain artifact registration use bounded tenant-scoped invalidation
+instead. Realtime reconciliation preserves view-owned filters, selection,
+pagination, and scroll position; it never inserts a phantom artifact merely
+because a generation event arrived.
 
 ## Implementation Map
 

--- a/docs/architecture/frontend/realtime.md
+++ b/docs/architecture/frontend/realtime.md
@@ -198,58 +198,39 @@ manages the subscription lifecycle.
 
 ## 7.4 The Invalidation Router
 
-A pure function that maps `DomainEvent → Set<QueryKey>`. The router lives
-in `contexts/operations/invalidation-router.ts`. Each backend event type
-has a registered handler:
+A pure function maps each `DomainEvent` to tenant-scoped invalidation or exact
+patch instructions. The router lives in
+`contexts/operations/invalidation-router.ts`; each backend event type has a
+registered aggregate-owned handler:
 
 ```ts
-const handlers: Record<DomainEventType, InvalidationHandler> = {
-  JobDiscovered: ({ tenantId }) => [
-    jobsKeys.lists(tenantId),
-    dashboardKeys.summary(tenantId),
-  ],
-  JobScored: ({ tenantId, jobId }) => [
-    jobsKeys.detail(tenantId, jobId),
-    jobsKeys.lists(tenantId),
-    dashboardKeys.summary(tenantId),
-  ],
-  ResumeApproved: ({ tenantId, jobId }) => [
-    jobsKeys.detail(tenantId, jobId),
-    jobsKeys.lists(tenantId),
-    artifactsKeys.lists(tenantId),
-    dashboardKeys.summary(tenantId),
-  ],
-  ApplyRunEventRecorded: ({ tenantId, runId, event }) => {
-    // Specialized: append to in-memory list rather than invalidate.
-    return [{ kind: "apply-run-event", tenantId, runId, event }];
-  },
-  PipelineStepStarted: ({ tenantId, execution }) => [
-    workflowRunsKeys.detail(tenantId, execution.workflowId),
-    workflowRunsKeys.lists(tenantId),
-    pipelineKeys.operations(tenantId),
-  ],
-  // ... one entry per DomainEventUnion variant
-};
+export const jobActiveStateChangedHandler = (event) => [
+  patchQuery(jobsKeys.detail(event.tenantId, event.payload.jobId),
+    (current) => patchJobActiveState(current, event.payload)),
+  invalidate(jobsKeys.lists(event.tenantId)),
+  invalidate(dashboardKeys.summary(event.tenantId)),
+];
 
-export function handleEvent(event: DomainEvent, qc: QueryClient): void {
-  const out = handlers[event.eventType](event.payload);
-  for (const item of out) {
-    if ("kind" in item && item.kind === "apply-run-event") {
-      qc.setQueryData(applyRunsKeys.detail(item.tenantId, item.runId), (old) =>
-        appendApplyRunEvent(old, item.event),
-      );
-    } else {
-      qc.invalidateQueries({ queryKey: item });
-    }
-  }
-}
+export const resumeApprovedHandler = (event) => [
+  patchQuery(jobsKeys.detail(event.tenantId, event.payload.jobId),
+    (current) => patchResumeApproved(current, event.payload)),
+  patchQuery(artifactsKeys.detail(event.tenantId, event.payload.artifactId),
+    (current) => patchResumeApproved(current, event.payload)),
+  invalidate(jobsKeys.lists(event.tenantId)),
+  invalidate(artifactsKeys.lists(event.tenantId)),
+];
+
+// Workflow lifecycle handlers patch the existing detail, then invalidate the
+// list/dashboard reads whose membership or aggregation may have changed.
+// ApplyRunEventRecorded remains a direct ordered append.
 ```
 
 In practice the per-event handler functions are authored in each aggregate
 context's `handlers.ts` (seven files: `discovery`, `enrichment`, `profile`,
 `scoring`, `materials`, `apply`, `pipeline`) and registered centrally in
-`invalidation-router.ts`, which exports `invalidate`, `patchApplyRunEvent`,
-and `useInvalidationRouter`. The illustration above inlines them for
+`invalidation-router.ts`, which exports `invalidate`, `patchQuery`,
+`patchApplyRunEvent`, and `useInvalidationRouter`. The illustration above
+inlines representative handlers for
 clarity; Operations itself has no `handlers.ts`.
 
 **Why a router and not per-context subscriptions:**
@@ -277,10 +258,8 @@ Two layers, both required:
    is no Zod schema to read `.options` from) and asserts a handler is
    registered for each. This is the *backstop* that catches the case where a
    developer adds a stub handler `() => []` (TS-passing, behaviorally wrong).
-   It runs in the web Vitest suite, which is **not yet CI-gated** (tracked in
-   `docs/backlog.md`); the compile-time check in (1) — run in CI via
-   `pnpm -r check` — is the CI-enforced guard, and this parity test is its
-   local runtime backstop.
+   The web Vitest suite runs in TypeScript CI; the compile-time check and
+   runtime parity test are both required.
 
 The pattern mirrors the backend's `scripts/check-domain-type-parity.py`
 (per `architecture.md`'s verification-commands section). A new event on
@@ -294,26 +273,34 @@ Two patterns exist; both have a place:
 
 | Pattern | When to use | Example event |
 |---|---|---|
-| `queryClient.invalidateQueries({ queryKey })` | **Default.** Use whenever the event indicates "the projection changed; the next render should re-fetch." | `JobScored` → invalidate `jobsKeys.detail` and `jobsKeys.lists`. |
-| `queryClient.setQueryData(queryKey, updater)` | **Optimization for high-frequency events** where re-fetching would be wasteful. Use when the event payload contains exactly the data needed to patch the cache. | `ApplyRunEventRecorded` → append to the in-memory event list of the active apply-run query. |
+| `queryClient.invalidateQueries({ queryKey })` | Use when the payload is incomplete, list/filter membership can change, a dashboard aggregate changed, or no exact registered row is known. Keep the key tenant-scoped and no broader than the affected resource family. | `JobScored` → invalidate job list/detail and dashboard projections. |
+| `queryClient.setQueriesData` / `setQueryData` | Use immediately when the event contains the canonical fields needed for a truthful patch of an existing cache row. Pair it with bounded invalidation when another view needs membership/refilter/aggregate reconciliation. | Active job detail, registered artifact approval, workflow detail, and ordered Apply-run append. |
 
-**Why default to `invalidate`:**
+**Why invalidation remains necessary:**
 
 - **Single source of truth.** The projection on the server is canonical;
   the cache always reconciles to it.
 - **No hand-rolled merge bugs.** Patching cache shape by hand introduces
   mismatch between the patched value and what a fresh fetch would return.
-- **Simple, mechanical.** Each new event type is a one-line handler.
+- **Membership safety.** Events cannot insert rows into filtered or paginated
+  lists without the complete projection and filter context.
 
-**Why `setQueryData` for `ApplyRunEventRecorded` specifically:**
+**Exact patch rules:**
 
-- **Volume.** During an apply run, several events per second arrive over
-  the course of minutes. Re-fetching the apply-run detail per event
-  saturates the API for no benefit.
-- **Append-only semantics.** The event payload is exactly the new event to
-  append. Patching is trivially correct.
-- **Reconciliation backstop.** When the apply-run route workspace is left and
-  revisited, it re-fetches, naturally reconciling with any drift.
+- `JobActiveStateChanged` patches an open job detail immediately; job lists and
+  Dashboard invalidate because active-state filters and aggregates can change.
+- `ResumeApproved` changes status only on an artifact already present in an
+  open job/artifact detail. It never creates a missing artifact; list pages
+  invalidate so persisted registration and filtering remain authoritative.
+- `Workflow*` lifecycle events patch the matching run detail by exact workflow
+  identity and append a deduplicated timeline entry. Run lists, Dashboard, and
+  operations invalidate because status membership and aggregation can change.
+- `ApplyRunEventRecorded` directly appends its complete ordered event. This
+  high-frequency path avoids a refetch per event; a later read still provides
+  reconciliation.
+
+The router never resets component-owned filters, selection, pagination, or
+scroll position. A query update changes data under the existing view state.
 
 ### Runtime snapshot polling complements SSE
 

--- a/docs/architecture/pipeline/envelope.md
+++ b/docs/architecture/pipeline/envelope.md
@@ -113,7 +113,7 @@ and Temporal run ID. Source-run IDs are deliberately excluded.
 That exact reference is carried through planning, source families,
 reconciliation, preparation fan-out, child `JobPreparationWorkflow` input, and
 PDF rendering. `discovery_execution_jobs` stores one membership per execution
-and canonical job URL. Its cohort is `observed_this_run` or
+and stable JobId. Its cohort is `observed_this_run` or
 `existing_backlog`; a later source observation may promote a swept membership
 to current, but cannot duplicate or demote it. A work plan remains explicitly
 `pending` until it becomes `planned`, `not_eligible`, or `failed`; a missing

--- a/docs/architecture/pipeline/operations.md
+++ b/docs/architecture/pipeline/operations.md
@@ -142,7 +142,7 @@ identity once and creates an immutable `DiscoveryExecutionRef`:
 The run ID is required because the deterministic workflow ID can be started
 again. Source-run IDs are observation details, not execution identity. Every
 linked job is persisted in `discovery_execution_jobs`, keyed by that exact
-execution plus canonical job URL, with one of two cohorts:
+execution plus stable JobId, with one of two cohorts:
 
 - `observed_this_run` — a source in this execution observed the job;
 - `existing_backlog` — the execution deliberately swept pre-existing eligible

--- a/docs/architecture/storage.md
+++ b/docs/architecture/storage.md
@@ -55,8 +55,11 @@ flowchart LR
     MATERIALS -->|writes| FILES
 ```
 
-Within the job-owned families, one `jobs` row (keyed by posting URL) is the hub:
-stage state, events, scores, analysis, materials, and apply records hang off it.
+Within the job-owned families, one `jobs` row keyed by `(tenant_id, job_id)` is
+the hub: stage state, events, scores, analysis, materials, and Apply records
+hang off the stable tenant-scoped `JobId`. A posting URL is an external locator
+with a tenant-scoped uniqueness constraint, not an internal primary or foreign
+key. Employer and Source observations are stored as independent facts.
 
 The remaining tables group by owner:
 
@@ -65,10 +68,12 @@ The remaining tables group by owner:
 | Candidate Profile | `candidate_profiles` plus 12 `candidate_profile_*` child tables (experience, bullets, skills, education, achievement evidence, required-content sets, resume constraint metrics) |
 | Resume templates | `resume_templates`, `resume_template_versions`, `resume_template_defaults`, `resume_template_refresh_attempts`, `job_resume_template_assignments` |
 | Compensation | `job_posted_compensation_facts`, `job_market_compensation_estimates` |
+| Scoring | `job_scores`, versioned/indexed `job_score_keywords`, `scoring_policies`, `job_score_staleness` |
 | Read-model projections | `job_list_projections`, `job_detail_projections`, `dashboard_projections`, `apply_run_projections`, `workflow_run_projections`, `pipeline_step_projections`, `artifact_list_projections`, `event_watermarks`, `digest_state` |
 | Discovery & preparation | `discovery_runs`, `discovery_execution_jobs`, `discovery_search_units`, `discovery_search_unit_jobs`, `discovery_search_unit_filtered_events`, `discovery_settings`, `discovery_feedback`, `discovery_quarantine_entries`, `job_canonical_identities`, `job_source_observations`, `job_duplicate_links`, legacy `preparation_work_items`, `manual_capture_queue`, `posting_snapshot_sets`, `source_registry_entries`, `source_locator_candidates` |
 | Apply review, repeat protection, and outcomes | `application_review_decisions`, `application_repeat_overrides`, `application_repeat_override_consumptions`, `application_repeat_audit`, `application_outcomes`, `application_email_evidence`, `application_outcome_suggestions` |
-| Policies & operations | `tailoring_policies`, `llm_spend`, `job_score_staleness`, `worker_runtime_heartbeats`, `jobctrl_deleted_jobs` |
+| Explicit-feedback learning | `tailoring_feedback_signals`, `tailoring_feedback_signal_reviews`, `tailoring_feedback_signal_contradictions`, `learning_recommendations`, `learning_recommendation_evidence`, `learning_recommendation_evidence_jobs`, `learning_recommendation_jobs`, `learning_recommendation_reviews`, `learning_recommendation_tombstones` |
+| Policies & operations | `tailoring_policies`, `llm_spend`, `worker_runtime_heartbeats`, `jobctrl_deleted_jobs` |
 
 SQLite in `~/.jobctrl/jobctrl.db` is the local source of truth for jobs,
 stage states, events, artifacts, normalized Candidate Profile data, profile
@@ -82,11 +87,30 @@ licensed-feed coverage policy. Public Levels.fyi Markdown needs no credential.
 Credentials, feed paths/URLs, feed contents, and provider payloads do not belong
 in the settings file.
 
-### Repeat-application authority and migration
+### Exact v7 identity cutover
+
+Schema v7 is an exact runtime contract. The native lifecycle upgrades an
+admitted v6 installation only while the application is stopped: it quiesces
+the local runtime, creates a paired backup of `jobctrl.db` and Temporal state,
+builds an isolated candidate, and runs the v6-to-v7 rewrite in one SQLite
+transaction. URL-rooted job rows and foreign references are mapped to stable
+tenant-scoped JobIds; immutable historical events are upcast only as part of
+that migration.
+
+Activation happens only after schema, row/reference, projection, and paired
+state verification succeeds. The verified candidate replaces the live pair
+atomically. Any failed build, verification, or activation restores the paired
+backup and leaves the previous version runnable. There is no mixed-version
+runtime, rolling deployment, dual-write path, or permanent compatibility
+layer: the TypeScript API and Python worker accept exact v7 and reject direct
+v6 operation. Runtime projections read registered persisted artifacts only and
+do not reconstruct legacy URL-shaped fallback rows.
+
+### Repeat-application authority retained in v7
 
 Historical application facts remain owned by the existing job events, reviewed
-outcomes, and compatible applied status. Schema version 6 adds only three
-decision/audit tables; it does not backfill, reinterpret, or update those facts:
+outcomes, and compatible applied status. The three repeat-decision/audit tables
+introduced in schema v6 are retained in v7 without reinterpreting those facts:
 
 - `application_repeat_overrides` stores the target, selected prior job,
   relationship, immutable evidence snapshot and SHA-256 fingerprint, reason,
@@ -101,10 +125,9 @@ decision/audit tables; it does not backfill, reinterpret, or update those facts:
 The evaluator reads canonical job/source identity and accepted
 `job_duplicate_links`, then joins only confirmed application facts. Pending
 suggestions, notes, dry runs, failed attempts, and intent checkpoints are not
-promoted into history. Existing databases advance additively from version 5 to
-6 while their prior application rows and events remain byte-for-byte unchanged.
-Both the TypeScript API and Python worker can create the new tables
-idempotently, and both reject a database created by a newer schema version.
+promoted into history. The v6-to-v7 migration copies these exact application
+facts into the JobId-keyed schema and verifies their references before
+activation.
 
 For a live run, the Python launcher opens `BEGIN IMMEDIATE`, recomputes the
 current evidence, performs the existing active-run and approval checks, and
@@ -159,8 +182,8 @@ those projection columns only; it does not parse raw salary text on read.
 ### Discovery lineage and operations state
 
 `discovery_execution_jobs` is the durable execution-membership authority. Its
-primary identity is tenant + Discover workflow ID + Temporal run ID + canonical
-job URL. It stores `observed_this_run` or `existing_backlog`, the first safe
+primary identity is tenant + Discover workflow ID + Temporal run ID + stable
+JobId. It stores `observed_this_run` or `existing_backlog`, the first safe
 source metadata, explicit work-plan state, immutable required steps when
 planned, a bounded reason for not-eligible/failed plans, and the preparation
 workflow ID. Link writes are idempotent; a swept job can be promoted when this
@@ -176,7 +199,7 @@ that must be reached by acknowledging the provider error; reclaim cannot clear
 the cursor before that revision is durable.
 
 `discovery_search_unit_jobs` is the idempotent acceptance-receipt set keyed by
-execution, unit, and canonical job URL. The job/source/event writes and receipt
+execution, unit, and stable JobId. The job/source/event writes and receipt
 commit before provider acknowledgement. Durable new/existing counts and the
 run-wide result limit are derived from these receipts, so replay cannot count a
 posting twice. A newer activity attempt reclaims only `running`/`pending` units

--- a/docs/local-reliability-qa.md
+++ b/docs/local-reliability-qa.md
@@ -76,6 +76,61 @@ and accepted-artifact preservation. The
 [Regression Catalog](developer/qa/regression-catalog.md) explains which layer
 proves each class of invariant; the complete page maps every risk to exact tests.
 
+### Stable JobId v7 and explicit-feedback cumulative gate
+
+Run this gate on the final stack tip with disposable SQLite fixtures only. Do
+not point it at `~/.jobctrl/jobctrl.db`, a real Temporal store, or any live
+application target. The Python commands deliberately use the fixed project
+virtual environment directly so validation does not rewrite lock metadata.
+
+```bash
+PYTHONPATH=workers/automation/src workers/automation/.venv/bin/pytest -q \
+  workers/automation/tests/test_v6_to_v7_*.py \
+  workers/automation/tests/test_exact_v7_*.py \
+  workers/automation/tests/test_detail_projection_job_id_contract.py \
+  workers/automation/tests/test_jobstreaming_gateway.py \
+  workers/automation/tests/test_jobstreaming_resumable_discovery.py \
+  workers/automation/tests/test_learning_recommendations.py \
+  workers/automation/tests/test_sqlite_learning_recommendations.py \
+  workers/automation/tests/test_rpc_learning_recommendations.py \
+  workers/automation/tests/test_tailoring_policy_revisions.py \
+  workers/automation/tests/test_scoring_eval_feedback.py
+workers/automation/.venv/bin/ruff check workers/automation/src workers/automation/tests
+
+corepack pnpm --filter @jobctrl/api exec vitest run \
+  test/exact-v7-projections.test.ts \
+  test/read-model-v7.test.ts \
+  test/application-feedback-v7.test.ts \
+  test/write-model-cancel.test.ts \
+  test/server.test.ts
+corepack pnpm --filter @jobctrl/web exec vitest run \
+  src/contexts/operations/realtimePatches.test.ts \
+  src/contexts/operations/workflowRealtimePatches.test.ts \
+  src/contexts/operations/invalidation-router.test.ts \
+  src/contexts/apply/components/CancelApplyButton.test.tsx \
+  src/contexts/apply/hooks/useCancelApplyMutation.test.ts \
+  src/contexts/materials/components/LearningRecommendationReviewPanel.test.tsx \
+  src/contexts/materials/components/TailoringPolicyHistoryPanel.test.tsx
+corepack pnpm web:test-d
+go -C launcher test ./internal/launcher
+corepack pnpm check
+corepack pnpm test
+corepack pnpm docs:build
+git diff --check
+```
+
+The product path must then verify in the disposable/demo workspace that Runs
+shows the shared Discover/preparation/Apply timeline; repeated cancellation
+does not overwrite a terminal result; targeted events update an open job,
+registered artifact, and workflow detail without resetting filters, selection,
+pagination, or scroll; and Dashboard supports recommendation evidence,
+accept/reject, policy history, and explicit append-only restore. After
+acceptance, explicitly re-score/re-tailor synthetic work and verify the prior
+score and accepted artifact remain unchanged until those commands are invoked.
+The gate must also prove that no feedback decision or restore automatically
+starts scoring, tailoring, Apply, or artifact work. Do not perform a real
+application submission or mutate a real user database during this QA.
+
 ### Repeat-application prevention
 
 Use disposable SQLite fixtures and the simulated web dispatch boundary; never

--- a/docs/local-reliability-qa.md
+++ b/docs/local-reliability-qa.md
@@ -119,8 +119,8 @@ corepack pnpm docs:build
 git diff --check
 ```
 
-The product path must then verify in the disposable/demo workspace that Runs
-shows the shared Discover/preparation/Apply timeline; repeated cancellation
+The product path must then verify in a disposable seeded API/web workspace that
+Runs shows the shared Discover/preparation/Apply timeline; repeated cancellation
 does not overwrite a terminal result; targeted events update an open job,
 registered artifact, and workflow detail without resetting filters, selection,
 pagination, or scroll; and Dashboard supports recommendation evidence,
@@ -130,6 +130,11 @@ score and accepted artifact remain unchanged until those commands are invoked.
 The gate must also prove that no feedback decision or restore automatically
 starts scoring, tailoring, Apply, or artifact work. Do not perform a real
 application submission or mutate a real user database during this QA.
+
+The browser-local public demo may cover realtime state preservation, but its
+learning capabilities are intentionally unavailable. Recommendation review,
+policy acceptance/rejection, and rollback must therefore run through the seeded
+non-demo local API/web fixture.
 
 ### Repeat-application prevention
 

--- a/docs/local-ts-api.md
+++ b/docs/local-ts-api.md
@@ -16,8 +16,9 @@ when implementing or debugging a specific endpoint.
   not completed.
 - Synchronous reads and commands return `200 OK`; invalid input, unavailable
   workers, and start failures return an error instead of a misleading `202`.
-- Browser updates arrive through `GET /v1/events/stream`, then TanStack Query
-  refetches the affected projections.
+- Browser updates arrive through `GET /v1/events/stream`; TanStack Query exact-
+  patches truthful detail payloads and boundedly refetches affected projections
+  when membership, aggregation, or missing event data requires reconciliation.
 - Credentials are handled through the local credential boundary, never through
   ordinary settings payloads.
 
@@ -36,6 +37,7 @@ when implementing or debugging a specific endpoint.
 | --- | --- | --- |
 | Profile and configuration | `/v1/profile`, `/v1/settings`, `/v1/credentials`, `/v1/providers/models`, `/v1/discovery/settings`, `/v1/browser-capabilities`, `/v1/extension/pairing-token` | Synchronous reads and validated patches |
 | Jobs and evidence | `/v1/jobs`, `/v1/jobs/:jobKey`, `/v1/evidence-map`, `/v1/artifacts` | Projection-backed reads |
+| Scoring keywords and feedback learning | `/v1/scoring/keywords`, `/v1/learning/recommendations`, `/v1/learning/policies/materials` | Current score-version aggregation plus explicit review and versioned policy history |
 | Review and outcomes | `/v1/apply/review-queue`, `/v1/jobs/:jobKey/apply-review/decision`, `/v1/jobs/:jobKey/repeat-application/override`, `/v1/outcomes` | Explicit review commands plus read models |
 | Workflow operations | `/v1/pipeline/actions/run-stage`, `/v1/pipeline/operations`, `/v1/workflow-runs`, `/v1/health` | `202` for accepted asynchronous work; `200` for projection-backed and runtime-backed reads/sync commands |
 | Realtime | `/v1/events/stream` | Server-Sent Events with replay and reconnect support |
@@ -60,6 +62,23 @@ field.
 The jobs list and detail routes read stable projections. Lifecycle changes—hide,
 restore, delete, score correction, stage retry, and per-job actions—are explicit
 commands. See [Jobs & Materials](api/jobs-and-materials.md).
+
+Internal list/detail identity is the tenant-scoped stable `JobId`; posting URLs
+are locators resolved only at explicit import or API boundaries. Employer and
+Source remain independent facts. `GET /v1/scoring/keywords` aggregates indexed,
+normalized keywords from the current score version, and `GET /v1/jobs` accepts
+an exact `normalizedScoreKeyword` filter using those returned keys.
+
+## Feedback Learning And Policy History
+
+`GET /v1/learning/recommendations` and its evidence route expose only bounded,
+privacy-safe derived evidence. The review route requires an explicit accepted
+or rejected decision. Acceptance creates a versioned Materials policy revision;
+rejection changes no policy. `GET /v1/learning/policies/materials` exposes the
+allowlisted current/superseded history, while the rollback route appends a new
+user-requested revision that restores an earlier version. These routes never
+start scoring, tailoring, Apply, or artifact work. See
+[Jobs & Materials](api/jobs-and-materials.md#feedback-learning-and-materials-policy).
 
 ## Dashboard, Analytics, And Operational Metrics
 
@@ -96,6 +115,11 @@ an exact `workflowType` match, inclusive `startedSince`, and exclusive
 `startedBefore`. Timestamp bounds must be UTC ISO-8601 timestamps; malformed
 optional filter values are ignored. The list response echoes the effective
 filters in its `filter` object (`null` when an optional filter is inactive).
+
+Discover, job preparation, and Apply share the same statuses, lifecycle
+timeline, terminal-state rules, and cancellation command. Cancellation is
+cooperative and idempotent: repeated requests do not replace terminal results
+or emit duplicate cancellation transitions.
 
 ## Profile Resume Preview
 

--- a/docs/user/enrichment-and-extraction.md
+++ b/docs/user/enrichment-and-extraction.md
@@ -6,6 +6,12 @@ state, and a provenance-bearing content snapshot. Extraction is the controlled
 work used to obtain those facts from an API, posting page, browser render, or
 user-mediated capture.
 
+Every accepted job receives one system-generated `JobId` inside its tenant.
+Posting and application URLs remain external locators: changing a URL does not
+change identity or detach the job's score, materials, stages, outcomes, events,
+or workflow references. URL resolution happens only at explicit API, import,
+capture, or migration boundaries.
+
 ## How A Lead Becomes A Usable Snapshot
 
 Enrichment separates “we found a listing” from “we have enough trustworthy
@@ -82,6 +88,9 @@ Several records participate, but they do not own the same fact:
 - **Discovery owns intake and identity:** source observations, canonical job
   identity, deduplication, source-native identifiers, manual capture, and the
   source registry.
+- **Employer and source are independent facts:** Employer identifies the
+  hiring organization; Source identifies where JobCtrl observed the posting.
+  Neither is guessed from the other or from a URL during projection reads.
 - **Enrichment owns posting detail:** fetch attempts, full description,
   application URL, content snapshots, extraction provenance, confidence, and
   active-state verification.
@@ -91,8 +100,10 @@ Several records participate, but they do not own the same fact:
 - **Operations owns the read projection:** list/detail pages read projection
   rows. A `GET` does not fetch the posting again or repair missing enrichment.
 
-Canonical job/enrichment rows and `posting_snapshot_sets` live in
-`jobctrl.db`. Events explain what changed, while projections make the latest
+Canonical job/enrichment rows are keyed by `(tenant_id, job_id)` in
+`jobctrl.db`; posting URLs are unique locators rather than primary or foreign
+keys. `posting_snapshot_sets` and source observations retain their own
+provenance. Events explain what changed, while projections make the latest
 accepted state efficient to read. Raw captured content is not copied into broad
 event payloads.
 

--- a/docs/user/materials-and-tailoring.md
+++ b/docs/user/materials-and-tailoring.md
@@ -109,6 +109,25 @@ Review its linked profile and requirement evidence before relying on it; the
 current maturity boundary is described in
 [Daily Workflow → Generate Interview Prep](normal-flows.md).
 
+## Policy History And Rollback
+
+The Dashboard's **Learning recommendations** card is a review boundary, not an
+automatic tuning loop. Accepting a pending, active recommendation appends a new
+Materials tailoring-policy revision linked to its recommendation and review;
+rejecting it leaves the current revision unchanged. Recommendations whose
+source evidence was tombstoned are inactive and cannot be accepted until they
+are deterministically re-derived.
+
+**Tailoring policy history** lists every current and superseded revision,
+allowlisted learned rule, safe recommendation/review reference, restore
+provenance, and creation time. Restoring a superseded version appends the next
+version with `user_requested` provenance; it never edits or deletes the target
+or current row. Acceptance and restore affect future tailoring-policy
+resolution only. They do not re-score jobs, re-tailor existing materials,
+replace accepted artifacts, alter the Candidate Profile, or change Apply
+decisions. Use the normal explicit re-tailor action when you want existing work
+to adopt the current policy.
+
 ## Source Of Truth And Ownership
 
 The inputs have intentionally different authority:
@@ -159,6 +178,10 @@ the local-file boundary.
    supersedes the prior active generation while preserving history. If a live
    threshold or blocker makes materials ineligible, JobCtrl soft-suppresses
    them from active/Apply surfaces rather than deleting the audit record.
+8. **Review policy changes separately.** Compatible accepted feedback may
+   produce a pending recommendation. Acceptance or restore appends a policy
+   revision, while rejection or a failed restore leaves the current revision
+   and all generated artifacts unchanged.
 
 The same preservation rule applies to stored interview prep and outreach draft
 generations: a failed replacement does not destroy the last accepted record.
@@ -168,7 +191,7 @@ generations: a failed replacement does not destroy the last accepted record.
 | Layer | Pointer |
 | --- | --- |
 | User workflow | [Daily Workflow → Generate And Inspect Materials](normal-flows.md) and [Apply → Materials And Resume Rendering](apply.md#materials-and-resume-rendering). |
-| HTTP contract | Artifact list/detail/preview routes, `/v1/resume-templates`, and per-job generate/re-tailor actions; see [Jobs & Materials API](../api/jobs-and-materials.md) and the [complete artifacts contract](../api/complete-contract.md#artifacts-and-tailoring-audit). Apply Review routes are owned by [Apply](apply.md). |
+| HTTP contract | Artifact list/detail/preview routes, `/v1/resume-templates`, per-job generate/re-tailor actions, and `/v1/learning/recommendations` plus `/v1/learning/policies/materials`; see [Jobs & Materials API](../api/jobs-and-materials.md) and the [complete learning contract](../api/complete-contract.md#feedback-learning-and-policy-history). Apply Review routes are owned by [Apply](apply.md). |
 | Worker implementation | `workers/automation/src/jobctrl/domain/materials/`, the `tailor.py` and `cover_letter.py` paths in `workers/automation/src/jobctrl/scoring/`, and `workers/automation/src/jobctrl/infrastructure/materials/`. |
 | API and web implementation | In `apps/api/src/`: `resume-review-drafts.ts`, `resume-templates.ts`, and `read-model.ts`; in the web app: `apps/web/src/contexts/materials/`, `apps/web/src/views/artifacts/`, and `apps/web/src/views/apply-review/`. |
 | Deep architecture | [Employer Analysis & Materials Audit](../architecture/materials.md), [Tailoring Contract](../architecture/tailoring.md), and [Stage Walkthrough → Tailor](../architecture/pipeline/stages.md#tailor). |

--- a/docs/user/normal-flows.md
+++ b/docs/user/normal-flows.md
@@ -527,7 +527,8 @@ is on the [Security](security.md) page.
 
 Useful web app views:
 
-- Dashboard for high-level counts and source health.
+- Dashboard for high-level counts, source health, pending learning
+  recommendations, and the versioned Materials policy history.
 - Pipelines for the selected execution, execution sweep, unrelated global
   backlog, source-family intake, reconciliation, stage outcomes, capacity,
   approximate task-queue pressure, ETA, freshness, and active work.
@@ -536,7 +537,9 @@ Useful web app views:
   application outcome rows and projections only; groups below the minimum
   sample count stay count-only.
 - Jobs for triage and the bookmarkable Job Detail workspace.
-- Runs for workflow history and route-level run timelines.
+- Runs for the shared Discover, preparation, and Apply history, using one status
+  vocabulary, terminal-state contract, cancellation control, and route-level
+  timeline.
 - Evidence for profile-evidence reuse, generated-material usage, and gaps.
 - Artifacts for generated files and same-job artifact comparisons.
 - Apply Review for approval and resume edits.
@@ -566,8 +569,16 @@ you pass `--acknowledge`, which marks the displayed digest as reviewed.
 
 </WorkflowSurfacePanel>
 
+A cancel request is cooperative and asynchronous. Repeating it is harmless;
+the projected run remains inspectable and an already completed, failed,
+canceled, timed-out, or terminated result is never overwritten by a synthetic
+canceled state. The same contract applies whether cancellation starts in
+Pipelines or Runs.
+
 [Outcomes & Feedback](outcomes-and-feedback.md) explains which application and
-interview facts become canonical outcomes and how analytics read them.
+interview facts become canonical outcomes, how analytics read them, and how
+explicit reviewed feedback can produce a pending recommendation without
+changing behavior automatically.
 
 ## 11. Keep Contacts (Optional)
 

--- a/docs/user/outcomes-and-feedback.md
+++ b/docs/user/outcomes-and-feedback.md
@@ -4,7 +4,9 @@ An application outcome is a reviewed local record of what happened after you
 applied, such as a reply, interview, rejection, offer, withdrawal, or no
 response. Feedback includes your manual corrections and bounded suggestions
 from linked evidence; it improves the audit trail and analytics without
-changing scoring, ranking, thresholds, or Apply eligibility.
+changing scoring, ranking, thresholds, or Apply eligibility on its own. An
+owning policy changes only through an explicit score correction, approved role
+rule, or accepted learning recommendation.
 
 ## How Email Becomes An Outcome Suggestion
 
@@ -47,6 +49,32 @@ it does not ask a model to read the inbox and decide what happened.
 
 This keeps private mail access narrow and preserves the difference between a
 machine suggestion, a reviewed lifecycle fact, and descriptive analytics.
+
+## Explicit Feedback Learning
+
+Operations exposes one privacy-bounded `FeedbackSignal` union over explicit
+score corrections, recorded Discovery feedback, approved role-match
+suggestions, and accepted structured tailoring feedback. These records carry
+canonical IDs, revisions, timestamps, closed rule codes, and non-sensitive
+evidence references. They never copy raw notes, resume or job-description text,
+prompts, model output, mail bodies, credentials, or local paths.
+
+The first derived recommendation type is a closed Materials tailoring-rule
+revision. JobCtrl creates a pending recommendation only when at least three
+compatible accepted tailoring signals span at least two jobs, no unresolved
+contradiction remains, and the derivation version has a passing deterministic
+evaluation fixture. Application outcomes may support later evaluation, but an
+outcome cannot create or prove a policy improvement by itself. Score
+corrections and approved role rules already passed an explicit user decision,
+so their owning Scoring or Discovery history does not require a second review.
+
+The Dashboard shows the pending recommendation, observed-versus-required
+sample counts, confidence limit, allowlist/derivation versions, and bounded
+evidence IDs. Accept creates a new context-owned Materials policy revision;
+reject leaves the current policy unchanged. Neither action re-scores jobs,
+re-tailors artifacts, changes Apply eligibility, or rewrites history. Corrected,
+deleted, or tombstoned source signals trigger deterministic re-derivation while
+preserving earlier reviews and accepted policy revisions.
 
 ## What You Can See And Control
 
@@ -95,6 +123,9 @@ Both may appear in the same job audit timeline without sharing ownership.
 - **Analytics** is a read model over canonical outcomes and accepted material
   metadata. It cannot write back to a score, policy, profile, discovery query,
   or application decision.
+- **Learning recommendations** remain separate from canonical feedback sources.
+  Their evidence and contradictions are reproducible, and no recommendation
+  changes behavior before explicit acceptance creates an owning revision.
 
 The job detail audit history is allow-listed explanatory history, not a raw
 event dump. It intentionally excludes private notes, mail bodies, local paths,
@@ -123,16 +154,18 @@ and debug payloads.
 4. The suggestion decision remains available for accuracy reporting, while the
    reviewed outcome becomes the job's lifecycle fact.
 
-Outcome feedback does not retrain a model or automatically adjust a scoring
-policy in the current product. Score corrections have their own explicit
-lifecycle under [Scoring](scoring-and-employer-analysis.md).
+Outcome feedback does not retrain a model or automatically adjust a scoring or
+tailoring policy. Score corrections have their own explicit lifecycle under
+[Scoring](scoring-and-employer-analysis.md); accepted tailoring recommendations
+and rollback are documented under
+[Materials & Tailoring](materials-and-tailoring.md#policy-history-and-rollback).
 
 ## Implementation And API Pointers
 
 | Layer | Pointer |
 | --- | --- |
 | User surfaces | `/jobs/:jobId`, `/dashboard`, and `/analytics`; the practical monitoring loop is in [Daily Workflow → Inspect Progress](normal-flows.md). |
-| HTTP contract | `GET /v1/outcomes`, per-job outcome reads/writes, suggestion decisions, `POST /v1/outcomes/gmail/scan`, and `GET /v1/analytics/outcomes`; see [Jobs & Materials API](../api/jobs-and-materials.md#apply-review-and-outcomes) and the [complete outcomes contract](../api/complete-contract.md#apply-review-and-outcomes). |
+| HTTP contract | `GET /v1/outcomes`, per-job outcome reads/writes, suggestion decisions, `POST /v1/outcomes/gmail/scan`, `GET /v1/analytics/outcomes`, and the `/v1/learning/*` review/history routes; see [Jobs & Materials API](../api/jobs-and-materials.md) and the [complete contract](../api/complete-contract.md#feedback-learning-and-policy-history). |
 | API implementation | Outcome routes and projections are composed in `apps/api/src/server.ts`, `apps/api/src/read-model.ts`, and `apps/api/src/projections.ts`. |
 | Web implementation | `apps/web/src/contexts/apply/components/ApplicationOutcomes.tsx`, Operations outcome hooks/keys, `views/dashboard/`, and `views/analytics/`. |
 | Deep architecture | [Apply Feedback & Projections](../architecture/read-model.md#apply-review-and-outcome-feedback) and its [sensitive projection boundaries](../architecture/read-model.md#evidence-analytics-and-compensation). |

--- a/docs/user/scoring-and-employer-analysis.md
+++ b/docs/user/scoring-and-employer-analysis.md
@@ -99,6 +99,18 @@ applies the same score bands.
   reviewed score version and a calibration anchor. An explicit re-score runs
   the current policy again against the current canonical inputs.
 
+### Indexed Scoring Keywords
+
+Each score version stores its keywords in a normalized, indexed relation keyed
+by tenant, job, and score version. Historical versions remain auditable, but
+Jobs filtering and `GET /v1/scoring/keywords` use only the score version that
+the current projection renders. The aggregation returns both the canonical
+normalized key and a display spelling with its score version and job count.
+
+`GET /v1/jobs?normalizedScoreKeyword=...` accepts the exact canonical key from
+that aggregation. Normalization is owned by persistence, including Unicode
+case-folding; clients do not guess or re-normalize display text.
+
 ## What You Can See And Control
 
 Scoring runs inside Discover preparation. Review it on the current product
@@ -152,6 +164,10 @@ reason to correct or investigate it.
   newer policy.
 - **Operations owns display projections.** Jobs reads expose persisted analysis
   and score evidence. They do not call a model or recompute a score on request.
+- **Explicit feedback remains history until an owning policy says otherwise.**
+  Score corrections and their anchors are auditable inputs, but Apply candidate
+  acquisition does not apply a second feedback-based rank adjustment or let an
+  unaccepted learning recommendation reorder jobs.
 
 The model may extract structured evidence and propose fit. The final persisted
 decision is resolved through the versioned scoring policy, so a raw model
@@ -183,7 +199,7 @@ not for an employer ranking people.
 | Layer | Pointer |
 | --- | --- |
 | User workflow | [Daily Workflow → Review Jobs](normal-flows.md) and [Discovery → Employer Analysis Perspectives](discovery.md#employer-analysis-perspectives). |
-| HTTP contract | Jobs list/detail reads, `POST /v1/jobs/:key/score-correction`, per-job current-policy re-score, and bulk/stale-score actions; see [Jobs & Materials API](../api/jobs-and-materials.md#jobs-and-evidence) and the [complete lifecycle contract](../api/complete-contract.md#jobs-read-model-and-lifecycle). |
+| HTTP contract | Jobs list/detail reads, `GET /v1/scoring/keywords`, `POST /v1/jobs/:key/score-correction`, per-job current-policy re-score, and bulk/stale-score actions; see [Jobs & Materials API](../api/jobs-and-materials.md#jobs-and-evidence) and the [complete lifecycle contract](../api/complete-contract.md#jobs-read-model-and-lifecycle). |
 | Worker implementation | `workers/automation/src/jobctrl/scoring/` (`employer_analysis.py`, `scorer.py`) and `workers/automation/src/jobctrl/domain/scoring/`; canonical analysis gates and persistence live under `workers/automation/src/jobctrl/domain/materials/analysis*` and `workers/automation/src/jobctrl/infrastructure/materials/employer_analysis_repository.py`. |
 | Product components | `apps/web/src/contexts/scoring/`, `apps/web/src/contexts/materials/components/EmployerAnalysisPanel.tsx`, and the Jobs detail/triage views. |
 | Deep architecture | [Scoring](../architecture/scoring.md), [Materials → Canonical Employer Analysis](../architecture/materials.md#canonical-employer-analysis), and [Stage Walkthrough → Score](../architecture/pipeline/stages.md#score). |

--- a/packages/api-client/src/client.ts
+++ b/packages/api-client/src/client.ts
@@ -83,6 +83,8 @@ import type {
   JobDetail,
   JobApplicationOutcomeListResponse,
   JobListQuery,
+  LearningRecommendationListResponse,
+  LearningRecommendationListQuery,
   JobMutationResponse,
   JobSummary,
   MarkJobActionRequest,
@@ -154,6 +156,7 @@ import type {
   WorkflowRunSummary,
   WorkflowRunsListQuery,
 } from "@jobctrl/contracts";
+import { LearningRecommendationListResponseSchema } from "@jobctrl/contracts";
 
 type QueryValue = boolean | number | string | null | undefined;
 const DEFAULT_NODE_BASE_URL = "http://127.0.0.1:8766";
@@ -243,6 +246,14 @@ export class JobCtrlApiClient {
 
   scoringKeywords(): Promise<ScoringKeywordAggregationResponse> {
     return this.get("/v1/scoring/keywords");
+  }
+
+  async learningRecommendations(
+    query: Partial<LearningRecommendationListQuery> = {},
+  ): Promise<LearningRecommendationListResponse> {
+    return LearningRecommendationListResponseSchema.parse(
+      await this.get("/v1/learning/recommendations", query),
+    );
   }
 
   digest(): Promise<DailyDigest> {

--- a/packages/api-client/src/client.ts
+++ b/packages/api-client/src/client.ts
@@ -91,6 +91,8 @@ import type {
   LearningRecommendationReviewResponse,
   TailoringPolicyRevisionListQuery,
   TailoringPolicyRevisionListResponse,
+  TailoringPolicyRollbackRequest,
+  TailoringPolicyRollbackResponse,
   JobMutationResponse,
   JobSummary,
   MarkJobActionRequest,
@@ -167,6 +169,7 @@ import {
   LearningRecommendationListResponseSchema,
   LearningRecommendationReviewResponseSchema,
   TailoringPolicyRevisionListResponseSchema,
+  TailoringPolicyRollbackResponseSchema,
 } from "@jobctrl/contracts";
 
 type QueryValue = boolean | number | string | null | undefined;
@@ -296,6 +299,14 @@ export class JobCtrlApiClient {
   ): Promise<TailoringPolicyRevisionListResponse> {
     return TailoringPolicyRevisionListResponseSchema.parse(
       await this.get("/v1/learning/policies/materials", query),
+    );
+  }
+
+  async rollbackTailoringPolicy(
+    body: TailoringPolicyRollbackRequest,
+  ): Promise<TailoringPolicyRollbackResponse> {
+    return TailoringPolicyRollbackResponseSchema.parse(
+      await this.post("/v1/learning/policies/materials/rollbacks", body),
     );
   }
 

--- a/packages/api-client/src/client.ts
+++ b/packages/api-client/src/client.ts
@@ -87,6 +87,8 @@ import type {
   LearningRecommendationEvidenceListResponse,
   LearningRecommendationListResponse,
   LearningRecommendationListQuery,
+  LearningRecommendationReviewRequest,
+  LearningRecommendationReviewResponse,
   JobMutationResponse,
   JobSummary,
   MarkJobActionRequest,
@@ -161,6 +163,7 @@ import type {
 import {
   LearningRecommendationEvidenceListResponseSchema,
   LearningRecommendationListResponseSchema,
+  LearningRecommendationReviewResponseSchema,
 } from "@jobctrl/contracts";
 
 type QueryValue = boolean | number | string | null | undefined;
@@ -269,6 +272,18 @@ export class JobCtrlApiClient {
       await this.get(
         `/v1/learning/recommendations/${encodeURIComponent(recommendationId)}/evidence`,
         query,
+      ),
+    );
+  }
+
+  async reviewLearningRecommendation(
+    recommendationId: string,
+    body: LearningRecommendationReviewRequest,
+  ): Promise<LearningRecommendationReviewResponse> {
+    return LearningRecommendationReviewResponseSchema.parse(
+      await this.post(
+        `/v1/learning/recommendations/${encodeURIComponent(recommendationId)}/reviews`,
+        body,
       ),
     );
   }

--- a/packages/api-client/src/client.ts
+++ b/packages/api-client/src/client.ts
@@ -83,6 +83,8 @@ import type {
   JobDetail,
   JobApplicationOutcomeListResponse,
   JobListQuery,
+  LearningRecommendationEvidenceListQuery,
+  LearningRecommendationEvidenceListResponse,
   LearningRecommendationListResponse,
   LearningRecommendationListQuery,
   JobMutationResponse,
@@ -156,7 +158,10 @@ import type {
   WorkflowRunSummary,
   WorkflowRunsListQuery,
 } from "@jobctrl/contracts";
-import { LearningRecommendationListResponseSchema } from "@jobctrl/contracts";
+import {
+  LearningRecommendationEvidenceListResponseSchema,
+  LearningRecommendationListResponseSchema,
+} from "@jobctrl/contracts";
 
 type QueryValue = boolean | number | string | null | undefined;
 const DEFAULT_NODE_BASE_URL = "http://127.0.0.1:8766";
@@ -253,6 +258,18 @@ export class JobCtrlApiClient {
   ): Promise<LearningRecommendationListResponse> {
     return LearningRecommendationListResponseSchema.parse(
       await this.get("/v1/learning/recommendations", query),
+    );
+  }
+
+  async learningRecommendationEvidence(
+    recommendationId: string,
+    query: Partial<LearningRecommendationEvidenceListQuery> = {},
+  ): Promise<LearningRecommendationEvidenceListResponse> {
+    return LearningRecommendationEvidenceListResponseSchema.parse(
+      await this.get(
+        `/v1/learning/recommendations/${encodeURIComponent(recommendationId)}/evidence`,
+        query,
+      ),
     );
   }
 

--- a/packages/api-client/src/client.ts
+++ b/packages/api-client/src/client.ts
@@ -89,6 +89,8 @@ import type {
   LearningRecommendationListQuery,
   LearningRecommendationReviewRequest,
   LearningRecommendationReviewResponse,
+  TailoringPolicyRevisionListQuery,
+  TailoringPolicyRevisionListResponse,
   JobMutationResponse,
   JobSummary,
   MarkJobActionRequest,
@@ -164,6 +166,7 @@ import {
   LearningRecommendationEvidenceListResponseSchema,
   LearningRecommendationListResponseSchema,
   LearningRecommendationReviewResponseSchema,
+  TailoringPolicyRevisionListResponseSchema,
 } from "@jobctrl/contracts";
 
 type QueryValue = boolean | number | string | null | undefined;
@@ -285,6 +288,14 @@ export class JobCtrlApiClient {
         `/v1/learning/recommendations/${encodeURIComponent(recommendationId)}/reviews`,
         body,
       ),
+    );
+  }
+
+  async tailoringPolicyRevisions(
+    query: Partial<TailoringPolicyRevisionListQuery> = {},
+  ): Promise<TailoringPolicyRevisionListResponse> {
+    return TailoringPolicyRevisionListResponseSchema.parse(
+      await this.get("/v1/learning/policies/materials", query),
     );
   }
 

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -86,6 +86,7 @@ export const RpcMethods = {
   BrowserCapabilityEnable: "browser_capability_enable",
   BrowserCapabilityDisable: "browser_capability_disable",
   BrowserProfileCopy: "browser_profile_copy",
+  RederiveLearningRecommendations: "rederive_learning_recommendations",
 } as const;
 export type RpcMethod = (typeof RpcMethods)[keyof typeof RpcMethods];
 
@@ -471,6 +472,34 @@ export const CancelRunResultSchema = z
   })
   .strict();
 export type CancelRunResult = z.infer<typeof CancelRunResultSchema>;
+
+export const RederiveLearningRecommendationsParamsSchema = z
+  .object({
+    tenantId: TenantParam,
+    expectedAppDir: z.string().trim().min(1).optional(),
+    expectedDbPath: z.string().trim().min(1).optional(),
+  })
+  .strict();
+export type RederiveLearningRecommendationsParams = z.infer<
+  typeof RederiveLearningRecommendationsParamsSchema
+>;
+
+export const RederiveLearningRecommendationsResultSchema = z
+  .object({
+    status: z.literal("succeeded"),
+    recommendationCount: z.number().int().nonnegative(),
+    recommendationIds: z
+      .array(z.string().regex(/^learning-recommendation:[a-f0-9]{64}$/))
+      .max(100),
+  })
+  .strict()
+  .refine(
+    (value) => value.recommendationIds.length === value.recommendationCount,
+    "Recommendation count must match recommendation IDs.",
+  );
+export type RederiveLearningRecommendationsResult = z.infer<
+  typeof RederiveLearningRecommendationsResultSchema
+>;
 
 export const ProfileImportParamsSchema = z
   .object({

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -13,6 +13,7 @@ import {
   LearningRecommendationReviewIdSchema,
   MANUAL_CAPTURE_MODE_VALUES,
   STAGES,
+  TailoringPolicyLearnedRuleSchema,
 } from "./schemas.js";
 
 /* ------------------------------------------------------------------ codes */
@@ -90,6 +91,7 @@ export const RpcMethods = {
   BrowserProfileCopy: "browser_profile_copy",
   RederiveLearningRecommendations: "rederive_learning_recommendations",
   ReviewLearningRecommendation: "review_learning_recommendation",
+  RollbackTailoringPolicy: "rollback_tailoring_policy",
 } as const;
 export type RpcMethod = (typeof RpcMethods)[keyof typeof RpcMethods];
 
@@ -586,6 +588,34 @@ export const ReviewLearningRecommendationResultSchema = z.discriminatedUnion("de
 ]);
 export type ReviewLearningRecommendationResult = z.infer<
   typeof ReviewLearningRecommendationResultSchema
+>;
+
+export const RollbackTailoringPolicyParamsSchema = z
+  .object({
+    tenantId: TenantParam,
+    expectedAppDir: z.string().trim().min(1).optional(),
+    expectedDbPath: z.string().trim().min(1).optional(),
+    targetVersion: z.number().int().positive(),
+  })
+  .strict();
+export type RollbackTailoringPolicyParams = z.infer<
+  typeof RollbackTailoringPolicyParamsSchema
+>;
+
+export const RollbackTailoringPolicyResultSchema = z
+  .object({
+    status: z.literal("succeeded"),
+    context: z.literal("materials"),
+    policyKind: z.literal("tailoring_rule"),
+    policyVersion: z.number().int().positive(),
+    rollbackOfVersion: z.number().int().positive(),
+    rollbackReasonCode: z.literal("user_requested"),
+    learnedRules: z.array(TailoringPolicyLearnedRuleSchema).max(5),
+    rolledBackAt: WorkerUtcTimestampSchema,
+  })
+  .strict();
+export type RollbackTailoringPolicyResult = z.infer<
+  typeof RollbackTailoringPolicyResultSchema
 >;
 
 export const ProfileImportParamsSchema = z

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -9,6 +9,8 @@ import { z } from "zod";
 
 import {
   DEFAULT_PIPELINE_LLM_MODEL,
+  LearningRecommendationIdSchema,
+  LearningRecommendationReviewIdSchema,
   MANUAL_CAPTURE_MODE_VALUES,
   STAGES,
 } from "./schemas.js";
@@ -87,6 +89,7 @@ export const RpcMethods = {
   BrowserCapabilityDisable: "browser_capability_disable",
   BrowserProfileCopy: "browser_profile_copy",
   RederiveLearningRecommendations: "rederive_learning_recommendations",
+  ReviewLearningRecommendation: "review_learning_recommendation",
 } as const;
 export type RpcMethod = (typeof RpcMethods)[keyof typeof RpcMethods];
 
@@ -499,6 +502,90 @@ export const RederiveLearningRecommendationsResultSchema = z
   );
 export type RederiveLearningRecommendationsResult = z.infer<
   typeof RederiveLearningRecommendationsResultSchema
+>;
+
+export const ReviewLearningRecommendationParamsSchema = z
+  .object({
+    tenantId: TenantParam,
+    expectedAppDir: z.string().trim().min(1).optional(),
+    expectedDbPath: z.string().trim().min(1).optional(),
+    recommendationId: LearningRecommendationIdSchema,
+    decision: z.enum(["accepted", "rejected"]),
+  })
+  .strict();
+export type ReviewLearningRecommendationParams = z.infer<
+  typeof ReviewLearningRecommendationParamsSchema
+>;
+
+const WorkerUtcTimestampPattern = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.\d{1,6})?(?:Z|\+00:00)$/;
+
+function isValidWorkerUtcTimestamp(value: string): boolean {
+  const match = WorkerUtcTimestampPattern.exec(value);
+  if (!match) {
+    return false;
+  }
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const hour = Number(match[4]);
+  const minute = Number(match[5]);
+  const second = Number(match[6]);
+  if (month < 1 || month > 12 || hour > 23 || minute > 59 || second > 59) {
+    return false;
+  }
+  const daysInMonth = [
+    31,
+    year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0) ? 29 : 28,
+    31,
+    30,
+    31,
+    30,
+    31,
+    31,
+    30,
+    31,
+    30,
+    31,
+  ][month - 1] ?? 0;
+  return day >= 1 && day <= daysInMonth;
+}
+
+const WorkerUtcTimestampSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(80)
+  .regex(
+    WorkerUtcTimestampPattern,
+    "Expected an ISO-8601 UTC timestamp.",
+  )
+  .refine(isValidWorkerUtcTimestamp, "Expected a valid UTC timestamp.")
+  .transform((value) => new Date(value).toISOString());
+
+const ReviewLearningRecommendationResultBaseSchema = z
+  .object({
+    status: z.literal("succeeded"),
+    reviewId: LearningRecommendationReviewIdSchema,
+    recommendationId: LearningRecommendationIdSchema,
+    revision: z.number().int().positive(),
+    context: z.literal("materials"),
+    policyKind: z.literal("tailoring_rule"),
+    reviewedAt: WorkerUtcTimestampSchema,
+  })
+  .strict();
+
+export const ReviewLearningRecommendationResultSchema = z.discriminatedUnion("decision", [
+  ReviewLearningRecommendationResultBaseSchema.extend({
+    decision: z.literal("accepted"),
+    policyVersion: z.number().int().positive(),
+  }),
+  ReviewLearningRecommendationResultBaseSchema.extend({
+    decision: z.literal("rejected"),
+    policyVersion: z.null(),
+  }),
+]);
+export type ReviewLearningRecommendationResult = z.infer<
+  typeof ReviewLearningRecommendationResultSchema
 >;
 
 export const ProfileImportParamsSchema = z

--- a/packages/contracts/src/schemas.ts
+++ b/packages/contracts/src/schemas.ts
@@ -1143,6 +1143,7 @@ export interface TailoringFeedbackSignalReview {
   ruleKey: TailoringFeedbackRuleKey | null;
   ruleValue: TailoringFeedbackRuleValue | null;
   allowlistVersion: typeof TAILORING_FEEDBACK_RULE_ALLOWLIST_VERSION;
+  contradictsSignalIds: string[];
   reviewedAt: string;
 }
 
@@ -1316,12 +1317,23 @@ export interface ResumeReviewFeedbackListResponse {
   feedbackSignals: TailoringFeedbackSignal[];
 }
 
+const TailoringLearningSignalIdSchema = z
+  .string()
+  .min(1)
+  .max(240)
+  .regex(/^tailoring-feedback:[A-Za-z0-9_.:-]+:[1-9][0-9]*$/);
+
 export const TailoringFeedbackSignalReviewRequestSchema = z.discriminatedUnion("decision", [
   z
     .object({
       decision: z.literal("accepted"),
       ruleKey: z.enum(TAILORING_FEEDBACK_RULE_KEYS),
       ruleValue: z.enum(TAILORING_FEEDBACK_RULE_VALUES),
+      contradictsSignalIds: z
+        .array(TailoringLearningSignalIdSchema)
+        .max(100)
+        .default([])
+        .transform((values) => [...new Set(values)].sort()),
     })
     .strict(),
   z.object({ decision: z.literal("rejected") }).strict(),

--- a/packages/contracts/src/schemas.ts
+++ b/packages/contracts/src/schemas.ts
@@ -2263,6 +2263,93 @@ export type LearningRecommendationListQuery = z.infer<
   typeof LearningRecommendationListQuerySchema
 >;
 
+export const TailoringPolicyRevisionListQuerySchema = LearningRecommendationListQuerySchema;
+export type TailoringPolicyRevisionListQuery = z.infer<
+  typeof TailoringPolicyRevisionListQuerySchema
+>;
+
+export const TailoringPolicyLearnedRuleSchema = z.discriminatedUnion("ruleKey", [
+  z
+    .object({
+      ruleKey: z.literal("style_guidance"),
+      ruleValue: z.literal("preserve_user_edit_pattern"),
+    })
+    .strict(),
+  z
+    .object({
+      ruleKey: z.literal("fact_handling"),
+      ruleValue: z.literal("require_source_match"),
+    })
+    .strict(),
+  z
+    .object({
+      ruleKey: z.literal("claim_policy"),
+      ruleValue: z.literal("omit_unsupported_claims"),
+    })
+    .strict(),
+  z
+    .object({
+      ruleKey: z.literal("keyword_strategy"),
+      ruleValue: z.literal("use_supported_terms_only"),
+    })
+    .strict(),
+  z
+    .object({
+      ruleKey: z.literal("provenance_policy"),
+      ruleValue: z.literal("require_direct_evidence"),
+    })
+    .strict(),
+]);
+export type TailoringPolicyLearnedRule = z.infer<typeof TailoringPolicyLearnedRuleSchema>;
+
+export const TailoringPolicyRevisionSummarySchema = z
+  .object({
+    context: z.literal("materials"),
+    policyKind: z.literal("tailoring_rule"),
+    version: z.number().int().positive(),
+    status: z.enum(["current", "superseded"]),
+    learnedRules: z.array(TailoringPolicyLearnedRuleSchema).max(5),
+    sourceReviewId: LearningRecommendationReviewIdSchema.nullable(),
+    sourceRecommendationId: LearningRecommendationIdSchema.nullable(),
+    rollbackOfVersion: z.number().int().positive().nullable(),
+    rollbackReasonCode: z.enum(["user_requested", "historical_or_unspecified"]).nullable(),
+    createdAt: IsoTimestampSchema,
+  })
+  .strict()
+  .refine(
+    (value) => (value.sourceReviewId === null) === (value.sourceRecommendationId === null),
+    "Policy recommendation and review provenance must be present together.",
+  )
+  .refine(
+    (value) => (value.rollbackOfVersion === null) === (value.rollbackReasonCode === null),
+    "Policy rollback version and reason must be present together.",
+  );
+export type TailoringPolicyRevisionSummary = z.infer<
+  typeof TailoringPolicyRevisionSummarySchema
+>;
+
+export const TailoringPolicyRevisionListResponseSchema = z
+  .object({
+    ok: z.literal(true),
+    revisions: z.array(TailoringPolicyRevisionSummarySchema).max(100),
+    page: z.number().int().min(1),
+    pageSize: z.number().int().min(1).max(100),
+    total: z.number().int().nonnegative(),
+    totalPages: z.number().int().nonnegative(),
+  })
+  .strict()
+  .refine(
+    (value) => value.revisions.length <= value.pageSize,
+    "Policy revision page exceeds its declared page size.",
+  )
+  .refine(
+    (value) => value.revisions.filter((revision) => revision.status === "current").length <= 1,
+    "Policy revision page contains multiple current revisions.",
+  );
+export type TailoringPolicyRevisionListResponse = z.infer<
+  typeof TailoringPolicyRevisionListResponseSchema
+>;
+
 export const LearningRecommendationSummarySchema = z
   .object({
     recommendationId: LearningRecommendationIdSchema,

--- a/packages/contracts/src/schemas.ts
+++ b/packages/contracts/src/schemas.ts
@@ -2350,6 +2350,32 @@ export type TailoringPolicyRevisionListResponse = z.infer<
   typeof TailoringPolicyRevisionListResponseSchema
 >;
 
+export const TailoringPolicyRollbackRequestSchema = z
+  .object({ targetVersion: z.number().int().positive() })
+  .strict();
+export type TailoringPolicyRollbackRequest = z.infer<
+  typeof TailoringPolicyRollbackRequestSchema
+>;
+
+export const TailoringPolicyRollbackResponseSchema = z
+  .object({
+    ok: z.literal(true),
+    context: z.literal("materials"),
+    policyKind: z.literal("tailoring_rule"),
+    version: z.number().int().positive(),
+    status: z.literal("current"),
+    learnedRules: z.array(TailoringPolicyLearnedRuleSchema).max(5),
+    sourceReviewId: z.null(),
+    sourceRecommendationId: z.null(),
+    rollbackOfVersion: z.number().int().positive(),
+    rollbackReasonCode: z.literal("user_requested"),
+    createdAt: IsoTimestampSchema,
+  })
+  .strict();
+export type TailoringPolicyRollbackResponse = z.infer<
+  typeof TailoringPolicyRollbackResponseSchema
+>;
+
 export const LearningRecommendationSummarySchema = z
   .object({
     recommendationId: LearningRecommendationIdSchema,

--- a/packages/contracts/src/schemas.ts
+++ b/packages/contracts/src/schemas.ts
@@ -4182,6 +4182,7 @@ export interface ActionCommandPayload {
     | "generate_interview_prep"
     | "apply"
     | "cancel"
+    | "rederive_learning_recommendations"
     | "mark_applied"
     | "mark_skipped"
     | "profile_import";

--- a/packages/contracts/src/schemas.ts
+++ b/packages/contracts/src/schemas.ts
@@ -2183,6 +2183,76 @@ export const ScoringKeywordAggregationResponseSchema = z
   .strict();
 export type ScoringKeywordAggregationResponse = z.infer<typeof ScoringKeywordAggregationResponseSchema>;
 
+const LearningRecommendationIdSchema = z
+  .string()
+  .regex(/^learning-recommendation:[a-f0-9]{64}$/);
+
+export const LearningRecommendationListQuerySchema = z
+  .object({
+    page: z.coerce.number().int().min(1).default(1).catch(1),
+    pageSize: z.coerce.number().int().min(1).max(100).optional().catch(undefined),
+    page_size: z.coerce.number().int().min(1).max(100).optional().catch(undefined),
+  })
+  .transform((value) => ({
+    page: value.page,
+    pageSize: value.pageSize ?? value.page_size ?? 50,
+  }));
+export type LearningRecommendationListQuery = z.infer<
+  typeof LearningRecommendationListQuerySchema
+>;
+
+export const LearningRecommendationSummarySchema = z
+  .object({
+    recommendationId: LearningRecommendationIdSchema,
+    derivationVersion: z.number().int().positive(),
+    evaluationFixtureVersion: z.number().int().positive(),
+    context: z.literal("materials"),
+    policyKind: z.literal("tailoring_rule"),
+    signalKind: z.enum([
+      "style_preference",
+      "factual_correction",
+      "claim_policy_correction",
+      "keyword_strategy",
+      "provenance_dispute",
+    ]),
+    ruleKey: z.string().min(1).max(80).regex(/^[a-z0-9_]+$/),
+    ruleValue: z.string().min(1).max(160).regex(/^[a-z0-9_]+$/),
+    allowlistVersion: z.number().int().positive(),
+    status: z.literal("pending"),
+    active: z.boolean(),
+    observedSignalCount: z.number().int().min(3),
+    observedJobCount: z.number().int().min(2),
+    minimumSignalCount: z.number().int().min(3),
+    minimumJobCount: z.number().int().min(2),
+    confidenceLimit: z.literal("sample_gated_no_population_inference"),
+    supportingEvidenceCount: z.number().int().min(3),
+    contradictingEvidenceCount: z.number().int().nonnegative(),
+    tombstoneCount: z.number().int().nonnegative(),
+    derivedAt: IsoTimestampSchema,
+  })
+  .strict();
+export type LearningRecommendationSummary = z.infer<
+  typeof LearningRecommendationSummarySchema
+>;
+
+export const LearningRecommendationListResponseSchema = z
+  .object({
+    ok: z.literal(true),
+    recommendations: z.array(LearningRecommendationSummarySchema).max(100),
+    page: z.number().int().min(1),
+    pageSize: z.number().int().min(1).max(100),
+    total: z.number().int().nonnegative(),
+    totalPages: z.number().int().nonnegative(),
+  })
+  .strict()
+  .refine(
+    (value) => value.recommendations.length <= value.pageSize,
+    "Recommendation page exceeds its declared page size.",
+  );
+export type LearningRecommendationListResponse = z.infer<
+  typeof LearningRecommendationListResponseSchema
+>;
+
 export const ArtifactListQuerySchema = z
   .object({
     page: z.coerce.number().int().min(1).default(1).catch(1),

--- a/packages/contracts/src/schemas.ts
+++ b/packages/contracts/src/schemas.ts
@@ -2199,6 +2199,44 @@ export const LearningRecommendationIdSchema = z
   .string()
   .regex(/^learning-recommendation:[a-f0-9]{64}$/);
 
+export const LearningRecommendationReviewIdSchema = z
+  .string()
+  .regex(/^learning-recommendation-review:[a-f0-9]{64}$/);
+
+export const LearningRecommendationReviewRequestSchema = z.discriminatedUnion("decision", [
+  z.object({ decision: z.literal("accepted") }).strict(),
+  z.object({ decision: z.literal("rejected") }).strict(),
+]);
+export type LearningRecommendationReviewRequest = z.infer<
+  typeof LearningRecommendationReviewRequestSchema
+>;
+
+const LearningRecommendationReviewResponseBaseSchema = z
+  .object({
+    ok: z.literal(true),
+    reviewId: LearningRecommendationReviewIdSchema,
+    recommendationId: LearningRecommendationIdSchema,
+    revision: z.number().int().positive(),
+    context: z.literal("materials"),
+    policyKind: z.literal("tailoring_rule"),
+    reviewedAt: IsoTimestampSchema,
+  })
+  .strict();
+
+export const LearningRecommendationReviewResponseSchema = z.discriminatedUnion("decision", [
+  LearningRecommendationReviewResponseBaseSchema.extend({
+    decision: z.literal("accepted"),
+    policyVersion: z.number().int().positive(),
+  }),
+  LearningRecommendationReviewResponseBaseSchema.extend({
+    decision: z.literal("rejected"),
+    policyVersion: z.null(),
+  }),
+]);
+export type LearningRecommendationReviewResponse = z.infer<
+  typeof LearningRecommendationReviewResponseSchema
+>;
+
 const LearningEvidenceIdentifierSchema = z
   .string()
   .min(1)

--- a/packages/contracts/src/schemas.ts
+++ b/packages/contracts/src/schemas.ts
@@ -2183,9 +2183,21 @@ export const ScoringKeywordAggregationResponseSchema = z
   .strict();
 export type ScoringKeywordAggregationResponse = z.infer<typeof ScoringKeywordAggregationResponseSchema>;
 
-const LearningRecommendationIdSchema = z
+export const LearningRecommendationIdSchema = z
   .string()
   .regex(/^learning-recommendation:[a-f0-9]{64}$/);
+
+const LearningEvidenceIdentifierSchema = z
+  .string()
+  .min(1)
+  .max(200)
+  .regex(/^[A-Za-z0-9_.:-]+$/);
+
+const LearningEvidenceJobIdSchema = z
+  .string()
+  .regex(
+    /^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/,
+  );
 
 export const LearningRecommendationListQuerySchema = z
   .object({
@@ -2251,6 +2263,45 @@ export const LearningRecommendationListResponseSchema = z
   );
 export type LearningRecommendationListResponse = z.infer<
   typeof LearningRecommendationListResponseSchema
+>;
+
+export const LearningRecommendationEvidenceListQuerySchema =
+  LearningRecommendationListQuerySchema;
+export type LearningRecommendationEvidenceListQuery = z.infer<
+  typeof LearningRecommendationEvidenceListQuerySchema
+>;
+
+export const LearningRecommendationEvidenceLinkSchema = z
+  .object({
+    signalId: LearningEvidenceIdentifierSchema,
+    evidenceRole: z.enum(["supporting", "contradicting"]),
+    sourceKind: z.literal("tailoring_feedback_signal"),
+    sourceRevision: z.number().int().positive(),
+    jobId: LearningEvidenceJobIdSchema,
+    recordedAt: IsoTimestampSchema,
+  })
+  .strict();
+export type LearningRecommendationEvidenceLink = z.infer<
+  typeof LearningRecommendationEvidenceLinkSchema
+>;
+
+export const LearningRecommendationEvidenceListResponseSchema = z
+  .object({
+    ok: z.literal(true),
+    recommendationId: LearningRecommendationIdSchema,
+    evidence: z.array(LearningRecommendationEvidenceLinkSchema).max(100),
+    page: z.number().int().min(1),
+    pageSize: z.number().int().min(1).max(100),
+    total: z.number().int().nonnegative(),
+    totalPages: z.number().int().nonnegative(),
+  })
+  .strict()
+  .refine(
+    (value) => value.evidence.length <= value.pageSize,
+    "Recommendation evidence page exceeds its declared page size.",
+  );
+export type LearningRecommendationEvidenceListResponse = z.infer<
+  typeof LearningRecommendationEvidenceListResponseSchema
 >;
 
 export const ArtifactListQuerySchema = z

--- a/workers/automation/src/jobctrl/domain/materials/__init__.py
+++ b/workers/automation/src/jobctrl/domain/materials/__init__.py
@@ -18,7 +18,11 @@ from jobctrl.domain.materials.aggregate import (
     MaterialsSetFactory,
 )
 from jobctrl.domain.materials.entities import Artifact
-from jobctrl.domain.materials.policy import TailoringPolicy
+from jobctrl.domain.materials.policy import (
+    LearnedTailoringRules,
+    TailoringPolicy,
+    TailoringPolicyChangedError,
+)
 from jobctrl.domain.materials.value_objects import (
     ArtifactStatus,
     ArtifactType,
@@ -34,9 +38,11 @@ __all__ = [
     "ArtifactType",
     "JudgeVerdict",
     "LlmModelSpec",
+    "LearnedTailoringRules",
     "MaterialsSet",
     "MaterialsSetFactory",
     "RenderFormat",
     "TailoringPolicy",
+    "TailoringPolicyChangedError",
     "ValidationResult",
 ]

--- a/workers/automation/src/jobctrl/domain/materials/policy.py
+++ b/workers/automation/src/jobctrl/domain/materials/policy.py
@@ -6,7 +6,7 @@ import hashlib
 import json
 from collections.abc import Mapping as MappingABC
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, Literal
 
 from jobctrl.domain.operations.feedback import TAILORING_FEEDBACK_RULE_ALLOWLIST
 from jobctrl.domain.tenant import LOCAL_TENANT, TenantId
@@ -31,6 +31,9 @@ _LEARNED_TAILORING_RULE_PROMPTS = {
 
 class TailoringPolicyChangedError(RuntimeError):
     """Raised before artifact persistence when the policy snapshot advanced."""
+
+
+TailoringPolicyRollbackReason = Literal["user_requested"]
 
 
 @dataclass(frozen=True)
@@ -695,6 +698,7 @@ __all__ = [
     "RevisionGatePolicy",
     "TailoringPolicy",
     "TailoringPolicyChangedError",
+    "TailoringPolicyRollbackReason",
     "WritingStylePolicy",
     "adapt_requirement_led_controls",
     "fingerprint_value",

--- a/workers/automation/src/jobctrl/domain/materials/policy.py
+++ b/workers/automation/src/jobctrl/domain/materials/policy.py
@@ -8,6 +8,7 @@ from collections.abc import Mapping as MappingABC
 from dataclasses import dataclass, field
 from typing import Any
 
+from jobctrl.domain.operations.feedback import TAILORING_FEEDBACK_RULE_ALLOWLIST
 from jobctrl.domain.tenant import LOCAL_TENANT, TenantId
 
 DEFAULT_TAILORING_POLICY_VERSION = 1
@@ -16,6 +17,74 @@ REQUIREMENT_LED_TAILORING_POLICY_VERSION = 2
 DEFAULT_REQUIREMENT_LED_MIN_FIT_SCORE = 8
 DEFAULT_REQUIREMENT_LED_MUST_HAVE_COVERAGE = 0.85
 DEFAULT_REQUIREMENT_LED_MAX_REVISION_ATTEMPTS = 1
+
+_LEARNED_TAILORING_RULES_RUNTIME_KEY = "learned_tailoring_rules"
+_LEARNED_TAILORING_RULE_PAIRS = frozenset(TAILORING_FEEDBACK_RULE_ALLOWLIST.values())
+_LEARNED_TAILORING_RULE_PROMPTS = {
+    "style_guidance": "Preserve the user's reviewed edit pattern and writing-style choices.",
+    "fact_handling": "Require every factual claim to match canonical source evidence.",
+    "claim_policy": "Omit claims that are not verified or explicitly confirmed.",
+    "keyword_strategy": "Use target-job terms only when supported by canonical profile evidence.",
+    "provenance_policy": "Require direct traceable evidence for every generated claim.",
+}
+
+
+class TailoringPolicyChangedError(RuntimeError):
+    """Raised before artifact persistence when the policy snapshot advanced."""
+
+
+@dataclass(frozen=True)
+class LearnedTailoringRules:
+    """Closed, privacy-safe Materials rules accepted from recommendations."""
+
+    rules: tuple[tuple[str, str], ...] = ()
+
+    def __post_init__(self) -> None:
+        normalized = tuple(
+            sorted(
+                (str(rule_key or "").strip(), str(rule_value or "").strip())
+                for rule_key, rule_value in self.rules
+            )
+        )
+        if len({rule_key for rule_key, _ in normalized}) != len(normalized):
+            raise ValueError("learned tailoring rule keys must be unique")
+        invalid = [pair for pair in normalized if pair not in _LEARNED_TAILORING_RULE_PAIRS]
+        if invalid:
+            raise ValueError("learned tailoring rules must match the versioned allowlist")
+        object.__setattr__(self, "rules", normalized)
+
+    @classmethod
+    def from_mapping(cls, value: MappingABC[str, Any] | None) -> "LearnedTailoringRules":
+        if value is None:
+            return cls()
+        if not isinstance(value, MappingABC):
+            raise ValueError("learned tailoring rules must be an object")
+        return cls(tuple((str(key), str(item)) for key, item in value.items()))
+
+    @classmethod
+    def from_runtime_settings(
+        cls,
+        runtime_settings: MappingABC[str, Any] | None,
+    ) -> "LearnedTailoringRules":
+        settings = runtime_settings or {}
+        raw = settings.get(_LEARNED_TAILORING_RULES_RUNTIME_KEY, {})
+        if not isinstance(raw, MappingABC):
+            raise ValueError("learned tailoring rules must be an object")
+        return cls.from_mapping(raw)
+
+    def with_rule(self, rule_key: str, rule_value: str) -> "LearnedTailoringRules":
+        updated = self.to_dict()
+        updated[str(rule_key or "").strip()] = str(rule_value or "").strip()
+        return type(self).from_mapping(updated)
+
+    def to_dict(self) -> dict[str, str]:
+        return dict(self.rules)
+
+    def prompt_lines(self) -> tuple[str, ...]:
+        return tuple(
+            f"- {rule_key}={rule_value}: {_LEARNED_TAILORING_RULE_PROMPTS[rule_key]}"
+            for rule_key, rule_value in self.rules
+        )
 
 
 @dataclass(frozen=True)
@@ -387,6 +456,64 @@ class TailoringPolicy:
     def policy_id(self) -> str:
         return f"{self.tenant_id}:tailoring-policy-v{self.version}"
 
+    @property
+    def learned_tailoring_rules(self) -> LearnedTailoringRules:
+        return LearnedTailoringRules.from_runtime_settings(self.runtime_settings)
+
+    def with_learned_tailoring_rules(
+        self,
+        rules: LearnedTailoringRules,
+        *,
+        version: int | None = None,
+        created_at: str | None = None,
+        rollback_of_version: int | None = None,
+        rollback_reason: str = "",
+    ) -> "TailoringPolicy":
+        runtime_settings = dict(self.runtime_settings)
+        runtime_settings[_LEARNED_TAILORING_RULES_RUNTIME_KEY] = rules.to_dict()
+        return type(self)(
+            tenant_id=self.tenant_id,
+            version=self.version if version is None else version,
+            prompt_version=self.prompt_version,
+            schema_version=self.schema_version,
+            judge_schema_version=self.judge_schema_version,
+            prompt_fingerprint=self.prompt_fingerprint,
+            config_fingerprint=_configuration_fingerprint(
+                prompt_version=self.prompt_version,
+                schema_version=self.schema_version,
+                judge_schema_version=self.judge_schema_version,
+                prompt_fingerprint=self.prompt_fingerprint,
+                profile_policy_fingerprint=self.profile_policy_fingerprint,
+                custom_prompt_fingerprint=self.custom_prompt_fingerprint,
+                generator_settings=self.generator_settings,
+                judge_settings=self.judge_settings,
+                runtime_settings=runtime_settings,
+            ),
+            profile_policy_fingerprint=self.profile_policy_fingerprint,
+            custom_prompt_fingerprint=self.custom_prompt_fingerprint,
+            generator_settings=self.generator_settings,
+            judge_settings=self.judge_settings,
+            runtime_settings=runtime_settings,
+            rollback_of_version=rollback_of_version,
+            rollback_reason=rollback_reason,
+            created_at=self.created_at if created_at is None else created_at,
+            created_from_event_id=self.created_from_event_id,
+        )
+
+    def with_learned_tailoring_rule(
+        self,
+        *,
+        rule_key: str,
+        rule_value: str,
+        version: int,
+        created_at: str,
+    ) -> "TailoringPolicy":
+        return self.with_learned_tailoring_rules(
+            self.learned_tailoring_rules.with_rule(rule_key, rule_value),
+            version=version,
+            created_at=created_at,
+        )
+
     @classmethod
     def from_runtime(
         cls,
@@ -411,18 +538,16 @@ class TailoringPolicy:
         generator = _clean_mapping(generator_settings or {})
         judge = _clean_mapping(judge_settings or {})
         runtime = _clean_mapping(runtime_settings or {})
-        config_fingerprint = fingerprint_value(
-            {
-                "prompt_version": prompt_version,
-                "schema_version": schema_version,
-                "judge_schema_version": judge_schema_version,
-                "prompt_fingerprint": prompt_fingerprint,
-                "profile_policy_fingerprint": profile_fingerprint,
-                "custom_prompt_fingerprint": custom_fingerprint,
-                "generator_settings": generator,
-                "judge_settings": judge,
-                "runtime_settings": runtime,
-            }
+        config_fingerprint = _configuration_fingerprint(
+            prompt_version=prompt_version,
+            schema_version=schema_version,
+            judge_schema_version=judge_schema_version,
+            prompt_fingerprint=prompt_fingerprint,
+            profile_policy_fingerprint=profile_fingerprint,
+            custom_prompt_fingerprint=custom_fingerprint,
+            generator_settings=generator,
+            judge_settings=judge,
+            runtime_settings=runtime,
         )
         return cls(
             tenant_id=tenant_id,
@@ -495,7 +620,35 @@ class TailoringPolicy:
             "config_fingerprint": self.config_fingerprint,
             "profile_policy_fingerprint": self.profile_policy_fingerprint,
             "custom_prompt_fingerprint": self.custom_prompt_fingerprint,
+            "learned_tailoring_rules": self.learned_tailoring_rules.to_dict(),
         }
+
+
+def _configuration_fingerprint(
+    *,
+    prompt_version: str,
+    schema_version: str,
+    judge_schema_version: str,
+    prompt_fingerprint: str,
+    profile_policy_fingerprint: str,
+    custom_prompt_fingerprint: str,
+    generator_settings: MappingABC[str, Any],
+    judge_settings: MappingABC[str, Any],
+    runtime_settings: MappingABC[str, Any],
+) -> str:
+    return fingerprint_value(
+        {
+            "prompt_version": prompt_version,
+            "schema_version": schema_version,
+            "judge_schema_version": judge_schema_version,
+            "prompt_fingerprint": prompt_fingerprint,
+            "profile_policy_fingerprint": profile_policy_fingerprint,
+            "custom_prompt_fingerprint": custom_prompt_fingerprint,
+            "generator_settings": generator_settings,
+            "judge_settings": judge_settings,
+            "runtime_settings": runtime_settings,
+        }
+    )
 
 
 def fingerprint_value(value: Any) -> str:
@@ -536,10 +689,12 @@ __all__ = [
     "DEFAULT_REQUIREMENT_LED_REVISION_GATES",
     "AutoApprovalPolicy",
     "GenerationPermissions",
+    "LearnedTailoringRules",
     "RequiredContentPins",
     "RequirementLedTailoringControls",
     "RevisionGatePolicy",
     "TailoringPolicy",
+    "TailoringPolicyChangedError",
     "WritingStylePolicy",
     "adapt_requirement_led_controls",
     "fingerprint_value",

--- a/workers/automation/src/jobctrl/domain/materials/use_cases.py
+++ b/workers/automation/src/jobctrl/domain/materials/use_cases.py
@@ -88,7 +88,7 @@ from jobctrl.domain.materials.fabrication_detector import (
     scan_prose_skill_fabrications,
     scan_resume_bullets,
 )
-from jobctrl.domain.materials.policy import TailoringPolicy
+from jobctrl.domain.materials.policy import LearnedTailoringRules, TailoringPolicy
 from jobctrl.domain.materials.provenance import BulletProvenance, BulletProvenanceSet
 from jobctrl.domain.materials.provenance_builder import (
     ProvenanceBindingError,
@@ -1075,6 +1075,7 @@ def build_master_tailor_prompt(
     snapshot: ProfileSnapshot,
     *,
     tailoring_plan: TailoringPlan | None = None,
+    learned_tailoring_rules: LearnedTailoringRules | None = None,
 ) -> str:
     """Build the master-resume tailoring prompt from the snapshot."""
     profile = snapshot.as_dict()
@@ -1154,6 +1155,14 @@ def build_master_tailor_prompt(
     quality_plan_block = (
         "\n" + tailoring_plan.to_prompt_context() + "\n"
         if tailoring_plan is not None
+        else ""
+    )
+    learned_rule_lines = (learned_tailoring_rules or LearnedTailoringRules()).prompt_lines()
+    learned_rule_block = (
+        "\nACCEPTED LEARNING RULES FOR FUTURE MATERIALS:\n"
+        + "\n".join(learned_rule_lines)
+        + "\n"
+        if learned_rule_lines
         else ""
     )
 
@@ -1238,6 +1247,7 @@ MASTER SKILL CATEGORIES:
 
 TAILORING POLICY:
 {chr(10).join(policy_lines)}
+{learned_rule_block}
 
 WRITING STYLE:
 {chr(10).join(style_lines)}
@@ -1624,12 +1634,35 @@ class TailorResumeUseCase:
             prior_generation = None
             materials = previous
 
+        current_policy = (
+            self._policy_repository.get_current(tenant_id)
+            if self._policy_repository is not None
+            else None
+        )
+        learned_tailoring_rules = (
+            current_policy.learned_tailoring_rules
+            if current_policy is not None
+            else LearnedTailoringRules()
+        )
+        tailoring_plan = build_tailoring_plan(
+            profile_snapshot.as_dict(),
+            job,
+            employer_analysis=employer_analysis,
+            requirement_fit_report=requirement_fit_report,
+        )
+        tailor_prompt_base = build_master_tailor_prompt(
+            profile_snapshot,
+            tailoring_plan=tailoring_plan,
+            learned_tailoring_rules=learned_tailoring_rules,
+        )
         report, parsed_payload, validation, verdict = self._run_attempts(
             job=job,
             profile_snapshot=profile_snapshot,
             validation_mode=validation_mode,
             employer_analysis=employer_analysis,
             requirement_fit_report=requirement_fit_report,
+            tailoring_plan=tailoring_plan,
+            tailor_prompt_base=tailor_prompt_base,
         )
         attempts = report["attempts"]
 
@@ -1677,6 +1710,15 @@ class TailorResumeUseCase:
                 warnings=validation.warnings,
             )
 
+        tailoring_policy = self._resolve_tailoring_policy(
+            profile_snapshot=profile_snapshot,
+            prompt_text=tailor_prompt_base,
+            validation_mode=validation_mode,
+            tenant_id=tenant_id,
+            learned_tailoring_rules=learned_tailoring_rules,
+            expected_current_version=0 if current_policy is None else current_policy.version,
+        )
+
         # Assemble the rendered resume text from the FINAL (voiced) payload so the
         # shipped text == the audited text == the provenance ``generated_text``.
         tailored_text = self._assembler.assemble_resume_text(final_payload, profile_snapshot)
@@ -1695,12 +1737,6 @@ class TailorResumeUseCase:
             size_bytes = None
 
         judge_record = self._judge_record(verdict)
-        tailoring_policy = self._resolve_tailoring_policy(
-            profile_snapshot=profile_snapshot,
-            report=report,
-            validation_mode=validation_mode,
-            tenant_id=tenant_id,
-        )
         resume_template = _resolve_effective_resume_template(
             self._repository,
             tenant_id,
@@ -1992,6 +2028,8 @@ class TailorResumeUseCase:
         validation_mode: str,
         employer_analysis: EmployerAnalysis,
         requirement_fit_report: "RequirementFitReport | None" = None,
+        tailoring_plan: TailoringPlan,
+        tailor_prompt_base: str,
     ) -> tuple[dict, dict | None, ValidationResult, JudgeVerdict | None]:
         """Run the LLM ⇒ validate ⇒ judge attempt loop.
 
@@ -1999,16 +2037,6 @@ class TailorResumeUseCase:
         payload (or ``None`` if every attempt failed to parse) + the last
         :class:`ValidationResult` and :class:`JudgeVerdict`.
         """
-        tailoring_plan = build_tailoring_plan(
-            profile_snapshot.as_dict(),
-            job,
-            employer_analysis=employer_analysis,
-            requirement_fit_report=requirement_fit_report,
-        )
-        tailor_prompt_base = build_master_tailor_prompt(
-            profile_snapshot,
-            tailoring_plan=tailoring_plan,
-        )
         model_policy = self._llm_policy
         report: dict = {
             "attempts": 0,
@@ -2271,18 +2299,23 @@ class TailorResumeUseCase:
         self,
         *,
         profile_snapshot: ProfileSnapshot,
-        report: dict,
+        prompt_text: str,
         validation_mode: str,
         tenant_id: TenantId,
+        learned_tailoring_rules: LearnedTailoringRules,
+        expected_current_version: int,
     ) -> TailoringPolicy:
         profile = profile_snapshot.as_dict()
+        runtime_settings: dict[str, Any] = {"validation_mode": validation_mode}
+        if learned_tailoring_rules.rules:
+            runtime_settings["learned_tailoring_rules"] = learned_tailoring_rules.to_dict()
         candidate = TailoringPolicy.from_runtime(
             tenant_id=tenant_id,
             version=1,
             prompt_version=TAILORING_PROMPT_VERSION,
             schema_version=TAILORING_SCHEMA_VERSION,
             judge_schema_version=TAILORING_JUDGE_SCHEMA_VERSION,
-            prompt_text=str(report.get("system_prompt") or ""),
+            prompt_text=prompt_text,
             profile_policy=get_tailoring_policy(profile),
             custom_prompt=get_custom_tailoring_prompt(profile),
             generator_settings={
@@ -2297,12 +2330,15 @@ class TailorResumeUseCase:
                 "max_tokens": self._llm_policy.judge_max_tokens,
                 "min_score": self._llm_policy.judge_min_score,
             },
-            runtime_settings={"validation_mode": validation_mode},
+            runtime_settings=runtime_settings,
             created_at=_utc_now(),
         )
         if self._policy_repository is None:
             return candidate
-        return self._policy_repository.resolve_current(candidate)
+        return self._policy_repository.resolve_current(
+            candidate,
+            expected_current_version=expected_current_version,
+        )
 
     def _run_candidate(
         self,

--- a/workers/automation/src/jobctrl/domain/operations/__init__.py
+++ b/workers/automation/src/jobctrl/domain/operations/__init__.py
@@ -44,6 +44,7 @@ from jobctrl.domain.operations.feedback import (
 )
 from jobctrl.domain.operations.learning import (
     LearningRecommendation,
+    LearningSourceChange,
     RecommendationEvidenceRef,
     TAILORING_RECOMMENDATION_DERIVATION_VERSION,
     TAILORING_RECOMMENDATION_EVALUATION_FIXTURE_VERSION,
@@ -71,6 +72,7 @@ __all__ = [
     "JobDetailProjection",
     "JobListProjection",
     "LearningRecommendation",
+    "LearningSourceChange",
     "RecommendationEvidenceRef",
     "RoleMatchApprovalFeedbackSignal",
     "ScoreCorrectionDirection",

--- a/workers/automation/src/jobctrl/domain/operations/learning.py
+++ b/workers/automation/src/jobctrl/domain/operations/learning.py
@@ -26,6 +26,8 @@ TAILORING_RECOMMENDATION_EVALUATION_FIXTURE_VERSION = 1
 TAILORING_RECOMMENDATION_MIN_SIGNAL_COUNT = 3
 TAILORING_RECOMMENDATION_MIN_JOB_COUNT = 2
 
+LearningRecommendationDecision = Literal["accepted", "rejected"]
+
 
 @dataclass(frozen=True, kw_only=True)
 class LearningSourceChange:
@@ -206,6 +208,43 @@ class LearningRecommendation:
             raise ValueError("one signal cannot support and contradict a recommendation")
 
 
+@dataclass(frozen=True, kw_only=True)
+class LearningRecommendationReview:
+    """Append-only explicit decision linked to the owning Materials policy."""
+
+    tenant_id: TenantId
+    review_id: str
+    recommendation_id: str
+    revision: int
+    decision: LearningRecommendationDecision
+    policy_version: int | None
+    reviewed_at: str
+    context: Literal["materials"] = field(default="materials", init=False)
+    policy_kind: Literal["tailoring_rule"] = field(
+        default="tailoring_rule", init=False
+    )
+
+    def __post_init__(self) -> None:
+        if not str(self.tenant_id).strip():
+            raise ValueError("tenant_id must not be empty")
+        for name, value in (
+            ("review_id", self.review_id),
+            ("recommendation_id", self.recommendation_id),
+            ("reviewed_at", self.reviewed_at),
+        ):
+            if not value.strip():
+                raise ValueError(f"{name} must not be empty")
+        if self.revision < 1:
+            raise ValueError("review revision must be positive")
+        if self.decision not in {"accepted", "rejected"}:
+            raise ValueError("unsupported learning recommendation decision")
+        if self.decision == "accepted":
+            if self.policy_version is None or self.policy_version < 1:
+                raise ValueError("accepted review requires a policy version")
+        elif self.policy_version is not None:
+            raise ValueError("rejected review cannot change policy")
+
+
 def derive_tailoring_recommendations(
     signals: Iterable[FeedbackSignal],
     *,
@@ -348,6 +387,8 @@ def _recommendation_id(
 
 
 __all__ = [
+    "LearningRecommendationDecision",
+    "LearningRecommendationReview",
     "LearningRecommendation",
     "LearningSourceChange",
     "RecommendationEvidenceRef",

--- a/workers/automation/src/jobctrl/domain/operations/learning.py
+++ b/workers/automation/src/jobctrl/domain/operations/learning.py
@@ -28,6 +28,36 @@ TAILORING_RECOMMENDATION_MIN_JOB_COUNT = 2
 
 
 @dataclass(frozen=True, kw_only=True)
+class LearningSourceChange:
+    """Explicit accepted-signal correction or deletion requiring re-derivation."""
+
+    tenant_id: TenantId
+    previous_signal_id: str
+    source_id: str
+    source_revision: int
+    reason_code: Literal["source_corrected", "source_deleted"]
+    changed_at: str
+    source_kind: Literal["tailoring_feedback_signal"] = field(
+        default="tailoring_feedback_signal", init=False
+    )
+
+    def __post_init__(self) -> None:
+        if not str(self.tenant_id).strip():
+            raise ValueError("tenant_id must not be empty")
+        for name, value in (
+            ("previous_signal_id", self.previous_signal_id),
+            ("source_id", self.source_id),
+            ("changed_at", self.changed_at),
+        ):
+            if not value.strip():
+                raise ValueError(f"{name} must not be empty")
+        if self.source_revision < 1:
+            raise ValueError("source_revision must be positive")
+        if self.reason_code not in {"source_corrected", "source_deleted"}:
+            raise ValueError("unsupported learning source change reason")
+
+
+@dataclass(frozen=True, kw_only=True)
 class TailoringRuleEffect:
     """Closed, allowlisted Materials policy effect proposed by learning."""
 
@@ -319,6 +349,7 @@ def _recommendation_id(
 
 __all__ = [
     "LearningRecommendation",
+    "LearningSourceChange",
     "RecommendationEvidenceRef",
     "TAILORING_RECOMMENDATION_DERIVATION_VERSION",
     "TAILORING_RECOMMENDATION_EVALUATION_FIXTURE_VERSION",

--- a/workers/automation/src/jobctrl/domain/operations/learning.py
+++ b/workers/automation/src/jobctrl/domain/operations/learning.py
@@ -268,10 +268,10 @@ def derive_tailoring_recommendations(
             else ()
         )
         support_ids = tuple(signal.signal_id for signal in support)
-        if set(support_ids) & set(contradiction_ids):
-            raise ValueError("one signal cannot support and contradict a recommendation")
         if unresolved_ids:
             continue
+        if set(support_ids) & set(contradiction_ids):
+            raise ValueError("one signal cannot support and contradict a recommendation")
 
         evidence = tuple(
             RecommendationEvidenceRef(

--- a/workers/automation/src/jobctrl/domain/ports/materials.py
+++ b/workers/automation/src/jobctrl/domain/ports/materials.py
@@ -25,7 +25,7 @@ from jobctrl.domain.materials.analysis import (
     JobAnalysisDraft,
 )
 from jobctrl.domain.materials.entities import Artifact
-from jobctrl.domain.materials.policy import TailoringPolicy
+from jobctrl.domain.materials.policy import TailoringPolicy, TailoringPolicyRollbackReason
 from jobctrl.domain.materials.provenance import BulletProvenanceSet
 from jobctrl.domain.materials.value_objects import (
     ArtifactStatus,
@@ -199,6 +199,19 @@ class TailoringPolicyRepository(Protocol):
         """Return the latest persisted tailoring policy, or ``None``."""
         ...
 
+    def get_version(self, tenant_id: TenantId, version: int) -> TailoringPolicy | None:
+        """Return one tenant-owned historical policy revision, or ``None``."""
+        ...
+
+    def list_history(
+        self,
+        tenant_id: TenantId,
+        *,
+        limit: int = 100,
+    ) -> list[TailoringPolicy]:
+        """Return the bounded append-only policy history, newest first."""
+        ...
+
     def save(self, policy: TailoringPolicy) -> None:
         """Persist a tailoring policy version."""
         ...
@@ -210,6 +223,17 @@ class TailoringPolicyRepository(Protocol):
         expected_current_version: int | None = None,
     ) -> TailoringPolicy:
         """Resolve the candidate only if the pre-generation snapshot is current."""
+        ...
+
+    def rollback_to(
+        self,
+        tenant_id: TenantId,
+        *,
+        target_version: int,
+        reason: TailoringPolicyRollbackReason,
+        rolled_back_at: str,
+    ) -> TailoringPolicy:
+        """Append a current revision that restores a prior effective policy."""
         ...
 
 

--- a/workers/automation/src/jobctrl/domain/ports/materials.py
+++ b/workers/automation/src/jobctrl/domain/ports/materials.py
@@ -33,6 +33,10 @@ from jobctrl.domain.materials.value_objects import (
     RenderFormat,
 )
 from jobctrl.domain.materials.voice import VoiceRequest, VoiceResult
+from jobctrl.domain.operations.learning import (
+    LearningRecommendationDecision,
+    LearningRecommendationReview,
+)
 from jobctrl.domain.tenant import TenantId
 
 
@@ -206,6 +210,21 @@ class TailoringPolicyRepository(Protocol):
         expected_current_version: int | None = None,
     ) -> TailoringPolicy:
         """Resolve the candidate only if the pre-generation snapshot is current."""
+        ...
+
+
+class LearningRecommendationReviewer(Protocol):
+    """Materials-owned boundary for explicit recommendation decisions."""
+
+    def review(
+        self,
+        tenant_id: TenantId,
+        *,
+        recommendation_id: str,
+        decision: LearningRecommendationDecision,
+        reviewed_at: str,
+    ) -> LearningRecommendationReview:
+        """Append a decision and its policy revision atomically."""
         ...
 
 

--- a/workers/automation/src/jobctrl/domain/ports/materials.py
+++ b/workers/automation/src/jobctrl/domain/ports/materials.py
@@ -199,8 +199,13 @@ class TailoringPolicyRepository(Protocol):
         """Persist a tailoring policy version."""
         ...
 
-    def resolve_current(self, candidate: TailoringPolicy) -> TailoringPolicy:
-        """Return current policy, creating a new version when config changed."""
+    def resolve_current(
+        self,
+        candidate: TailoringPolicy,
+        *,
+        expected_current_version: int | None = None,
+    ) -> TailoringPolicy:
+        """Resolve the candidate only if the pre-generation snapshot is current."""
         ...
 
 

--- a/workers/automation/src/jobctrl/infrastructure/learning/sqlite_repository.py
+++ b/workers/automation/src/jobctrl/infrastructure/learning/sqlite_repository.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections import defaultdict
 from collections.abc import Mapping
 from datetime import datetime
 import hashlib
@@ -14,9 +15,11 @@ from jobctrl.domain.operations.learning import (
     RecommendationEvidenceRef,
     TailoringContradictionEvidence,
     TailoringRecommendationScope,
+    TailoringRuleEffect,
     derive_tailoring_recommendations,
 )
 from jobctrl.domain.operations.feedback import TailoringFeedbackSignal
+from jobctrl.domain.identifiers import canonical_job_id
 from jobctrl.domain.tenant import TenantId
 from jobctrl.infrastructure.projections.sqlite_feedback_signals import (
     SqliteFeedbackSignalReader,
@@ -184,7 +187,7 @@ class SqliteLearningRecommendationRepository:
         self,
         tenant_id: TenantId,
         *,
-        source_changes: tuple[LearningSourceChange, ...],
+        source_changes: tuple[LearningSourceChange, ...] | None,
         rederived_at: str,
         contradictions: Mapping[
             TailoringRecommendationScope, TailoringContradictionEvidence
@@ -196,13 +199,16 @@ class SqliteLearningRecommendationRepository:
         ]
         | None = None,
     ) -> tuple[LearningRecommendation, ...]:
-        """Recompute pending proposals and tombstone changed source history."""
+        """Recompute pending proposals and tombstone changed source history.
+
+        Passing ``None`` detects stale accepted evidence from the canonical
+        review ledger in the same transaction. Explicit tuples remain
+        available for deterministic replay and migration fixtures.
+        """
 
         if not str(tenant_id).strip():
             raise ValueError("tenant_id must not be empty")
         rederived_at = _structured_timestamp(rederived_at, name="rederived_at")
-        contradiction_ledger = contradictions or {}
-        contradiction_refs = contradicting_evidence or {}
         owns_transaction = not self._conn.in_transaction
         if owns_transaction:
             self._conn.execute("BEGIN IMMEDIATE")
@@ -215,9 +221,30 @@ class SqliteLearningRecommendationRepository:
                 for signal in signals
                 if isinstance(signal, TailoringFeedbackSignal)
             )
+            effective_source_changes = source_changes
+            if effective_source_changes is None:
+                effective_source_changes = self._detect_source_changes(
+                    tenant_id,
+                    current_signals=tailoring_signals,
+                    rederived_at=rederived_at,
+                )
+            if contradictions is None:
+                if contradicting_evidence is not None:
+                    raise ValueError(
+                        "explicit contradiction evidence requires an explicit ledger"
+                    )
+                contradiction_ledger, contradiction_refs = (
+                    self._canonical_contradictions(
+                        tenant_id,
+                        current_signals=tailoring_signals,
+                    )
+                )
+            else:
+                contradiction_ledger = contradictions
+                contradiction_refs = contradicting_evidence or {}
             self._validate_source_changes(
                 tenant_id,
-                source_changes=source_changes,
+                source_changes=effective_source_changes,
                 current_signals=tailoring_signals,
             )
             recommendations = derive_tailoring_recommendations(
@@ -232,7 +259,7 @@ class SqliteLearningRecommendationRepository:
                     ),
                     derived_at=rederived_at,
                 )
-            for change in source_changes:
+            for change in effective_source_changes:
                 self._append_source_change_tombstones(
                     change,
                     recommendations=recommendations,
@@ -250,6 +277,154 @@ class SqliteLearningRecommendationRepository:
         else:
             self._conn.execute(f"RELEASE SAVEPOINT {_REDERIVE_SAVEPOINT}")
         return recommendations
+
+    def _canonical_contradictions(
+        self,
+        tenant_id: TenantId,
+        *,
+        current_signals: tuple[TailoringFeedbackSignal, ...],
+    ) -> tuple[
+        Mapping[TailoringRecommendationScope, TailoringContradictionEvidence],
+        Mapping[
+            TailoringRecommendationScope,
+            tuple[RecommendationEvidenceRef, ...],
+        ],
+    ]:
+        current_by_id = {signal.signal_id: signal for signal in current_signals}
+        contradiction_ids: dict[TailoringRecommendationScope, set[str]] = defaultdict(set)
+        unresolved_ids: dict[TailoringRecommendationScope, set[str]] = defaultdict(set)
+        evidence_by_scope: dict[
+            TailoringRecommendationScope,
+            dict[str, RecommendationEvidenceRef],
+        ] = defaultdict(dict)
+        rows = self._conn.execute(
+            """
+            SELECT contradiction.signal_id AS left_signal_id,
+                   contradiction.signal_revision AS left_revision,
+                   contradiction.signal_job_id AS left_job_id,
+                   left_review.signal_kind AS left_signal_kind,
+                   left_review.rule_key AS left_rule_key,
+                   left_review.rule_value AS left_rule_value,
+                   left_review.allowlist_version AS left_allowlist_version,
+                   left_review.reviewed_at AS left_recorded_at,
+                   contradiction.contradicting_signal_id AS right_signal_id,
+                   contradiction.contradicting_signal_revision AS right_revision,
+                   contradiction.contradicting_signal_job_id AS right_job_id,
+                   right_review.signal_kind AS right_signal_kind,
+                   right_review.rule_key AS right_rule_key,
+                   right_review.rule_value AS right_rule_value,
+                   right_review.allowlist_version AS right_allowlist_version,
+                   right_review.reviewed_at AS right_recorded_at
+            FROM tailoring_feedback_signal_contradictions AS contradiction
+            JOIN tailoring_feedback_signal_reviews AS left_review
+              ON left_review.tenant_id = contradiction.tenant_id
+             AND left_review.signal_id = contradiction.signal_id
+             AND left_review.revision = contradiction.signal_revision
+            JOIN tailoring_feedback_signal_reviews AS right_review
+              ON right_review.tenant_id = contradiction.tenant_id
+             AND right_review.signal_id = contradiction.contradicting_signal_id
+             AND right_review.revision = contradiction.contradicting_signal_revision
+            WHERE contradiction.tenant_id = ?
+            ORDER BY contradiction.contradiction_id
+            """,
+            (str(tenant_id),),
+        ).fetchall()
+        for row in rows:
+            left = _contradiction_endpoint(row, "left", tenant_id=tenant_id)
+            right = _contradiction_endpoint(row, "right", tenant_id=tenant_id)
+            for current_endpoint, other_endpoint in ((left, right), (right, left)):
+                if current_endpoint[0] not in current_by_id:
+                    continue
+                scope = current_endpoint[1]
+                other_signal_id = other_endpoint[0]
+                contradiction_ids[scope].add(other_signal_id)
+                evidence_by_scope[scope][other_signal_id] = other_endpoint[2]
+                if other_signal_id in current_by_id:
+                    unresolved_ids[scope].add(other_signal_id)
+        ledger = {
+            scope: TailoringContradictionEvidence(
+                signal_ids=tuple(sorted(signal_ids)),
+                unresolved_signal_ids=tuple(sorted(unresolved_ids[scope])),
+            )
+            for scope, signal_ids in contradiction_ids.items()
+        }
+        evidence = {
+            scope: tuple(
+                evidence_by_scope[scope][signal_id]
+                for signal_id in sorted(evidence_by_scope[scope])
+            )
+            for scope in evidence_by_scope
+        }
+        return ledger, evidence
+
+    def _detect_source_changes(
+        self,
+        tenant_id: TenantId,
+        *,
+        current_signals: tuple[TailoringFeedbackSignal, ...],
+        rederived_at: str,
+    ) -> tuple[LearningSourceChange, ...]:
+        current_by_source = {signal.source_id: signal for signal in current_signals}
+        rows = self._conn.execute(
+            """
+            SELECT DISTINCT evidence.signal_id, evidence.source_id,
+                            evidence.source_revision
+            FROM learning_recommendation_evidence AS evidence
+            WHERE evidence.tenant_id = ?
+              AND evidence.source_kind = 'tailoring_feedback_signal'
+              AND evidence.evidence_role = 'supporting'
+              AND NOT EXISTS (
+                SELECT 1
+                FROM learning_recommendation_tombstones AS tombstone
+                WHERE tombstone.tenant_id = evidence.tenant_id
+                  AND tombstone.recommendation_id = evidence.recommendation_id
+                  AND tombstone.affected_signal_id = evidence.signal_id
+                  AND tombstone.affected_source_revision = evidence.source_revision
+              )
+            ORDER BY evidence.source_id, evidence.source_revision,
+                     evidence.signal_id
+            """,
+            (str(tenant_id),),
+        ).fetchall()
+        changes: list[LearningSourceChange] = []
+        for row in rows:
+            previous_signal_id = str(row[0])
+            source_id = str(row[1])
+            source_revision = int(row[2])
+            current = current_by_source.get(source_id)
+            if current is not None and current.source_revision == source_revision:
+                continue
+            if current is not None and current.source_revision < source_revision:
+                raise LearningRecommendationConflict(
+                    "current tailoring feedback revision predates recommendation evidence"
+                )
+            if current is not None:
+                reason_code = "source_corrected"
+                changed_at = current.recorded_at
+            else:
+                reason_code = "source_deleted"
+                latest = self._conn.execute(
+                    """
+                    SELECT reviewed_at
+                    FROM tailoring_feedback_signal_reviews
+                    WHERE tenant_id = ? AND signal_id = ?
+                    ORDER BY revision DESC
+                    LIMIT 1
+                    """,
+                    (str(tenant_id), source_id),
+                ).fetchone()
+                changed_at = str(latest[0]) if latest is not None else rederived_at
+            changes.append(
+                LearningSourceChange(
+                    tenant_id=tenant_id,
+                    previous_signal_id=previous_signal_id,
+                    source_id=source_id,
+                    source_revision=source_revision,
+                    reason_code=reason_code,
+                    changed_at=changed_at,
+                )
+            )
+        return tuple(changes)
 
     def _validate_source_changes(
         self,
@@ -312,6 +487,7 @@ class SqliteLearningRecommendationRepository:
              AND evidence.recommendation_id = recommendation.recommendation_id
             WHERE recommendation.tenant_id = ?
               AND evidence.source_kind = ?
+              AND evidence.evidence_role = 'supporting'
               AND evidence.source_id = ?
               AND evidence.source_revision = ?
               AND evidence.signal_id = ?
@@ -454,6 +630,43 @@ class SqliteLearningRecommendationRepository:
         else:
             self._conn.execute(f"ROLLBACK TO SAVEPOINT {_SAVEPOINT}")
             self._conn.execute(f"RELEASE SAVEPOINT {_SAVEPOINT}")
+
+
+def _contradiction_endpoint(
+    row: sqlite3.Row,
+    prefix: str,
+    *,
+    tenant_id: TenantId,
+) -> tuple[
+    str,
+    TailoringRecommendationScope,
+    RecommendationEvidenceRef,
+]:
+    source_id = str(row[f"{prefix}_signal_id"])
+    source_revision = int(row[f"{prefix}_revision"])
+    signal_id = f"tailoring-feedback:{source_id}:{source_revision}"
+    effect = TailoringRuleEffect(
+        signal_kind=str(row[f"{prefix}_signal_kind"]),
+        rule_key=str(row[f"{prefix}_rule_key"]),
+        rule_value=str(row[f"{prefix}_rule_value"]),
+        allowlist_version=int(row[f"{prefix}_allowlist_version"]),
+    )
+    return (
+        signal_id,
+        TailoringRecommendationScope(
+            tenant_id=tenant_id,
+            proposed_effect=effect,
+        ),
+        RecommendationEvidenceRef(
+            tenant_id=tenant_id,
+            signal_id=signal_id,
+            source_kind="tailoring_feedback_signal",
+            source_id=source_id,
+            source_revision=source_revision,
+            job_ids=(canonical_job_id(str(row[f"{prefix}_job_id"])),),
+            recorded_at=str(row[f"{prefix}_recorded_at"]),
+        ),
+    )
 
 
 def _input_fingerprint(recommendation_id: str) -> str:

--- a/workers/automation/src/jobctrl/infrastructure/learning/sqlite_repository.py
+++ b/workers/automation/src/jobctrl/infrastructure/learning/sqlite_repository.py
@@ -2,16 +2,29 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from datetime import datetime
+import hashlib
+import json
 import sqlite3
 
 from jobctrl.domain.operations.learning import (
     LearningRecommendation,
+    LearningSourceChange,
     RecommendationEvidenceRef,
+    TailoringContradictionEvidence,
+    TailoringRecommendationScope,
+    derive_tailoring_recommendations,
+)
+from jobctrl.domain.operations.feedback import TailoringFeedbackSignal
+from jobctrl.domain.tenant import TenantId
+from jobctrl.infrastructure.projections.sqlite_feedback_signals import (
+    SqliteFeedbackSignalReader,
 )
 
 
 _SAVEPOINT = "append_learning_recommendation"
+_REDERIVE_SAVEPOINT = "rederive_learning_recommendations"
 _RECOMMENDATION_PREFIX = "learning-recommendation:"
 
 
@@ -166,6 +179,204 @@ class SqliteLearningRecommendationRepository:
             raise
         self._finish(owns_transaction)
         return True
+
+    def rederive_tailoring(
+        self,
+        tenant_id: TenantId,
+        *,
+        source_changes: tuple[LearningSourceChange, ...],
+        rederived_at: str,
+        contradictions: Mapping[
+            TailoringRecommendationScope, TailoringContradictionEvidence
+        ]
+        | None = None,
+        contradicting_evidence: Mapping[
+            TailoringRecommendationScope,
+            tuple[RecommendationEvidenceRef, ...],
+        ]
+        | None = None,
+    ) -> tuple[LearningRecommendation, ...]:
+        """Recompute pending proposals and tombstone changed source history."""
+
+        if not str(tenant_id).strip():
+            raise ValueError("tenant_id must not be empty")
+        rederived_at = _structured_timestamp(rederived_at, name="rederived_at")
+        contradiction_ledger = contradictions or {}
+        contradiction_refs = contradicting_evidence or {}
+        owns_transaction = not self._conn.in_transaction
+        if owns_transaction:
+            self._conn.execute("BEGIN IMMEDIATE")
+        else:
+            self._conn.execute(f"SAVEPOINT {_REDERIVE_SAVEPOINT}")
+        try:
+            signals = SqliteFeedbackSignalReader(self._conn).list_accepted(tenant_id)
+            tailoring_signals = tuple(
+                signal
+                for signal in signals
+                if isinstance(signal, TailoringFeedbackSignal)
+            )
+            self._validate_source_changes(
+                tenant_id,
+                source_changes=source_changes,
+                current_signals=tailoring_signals,
+            )
+            recommendations = derive_tailoring_recommendations(
+                tailoring_signals,
+                contradictions=contradiction_ledger,
+            )
+            for recommendation in recommendations:
+                self.append_pending(
+                    recommendation,
+                    contradicting_evidence=contradiction_refs.get(
+                        recommendation.scope, ()
+                    ),
+                    derived_at=rederived_at,
+                )
+            for change in source_changes:
+                self._append_source_change_tombstones(
+                    change,
+                    recommendations=recommendations,
+                    rederived_at=rederived_at,
+                )
+        except BaseException:
+            if owns_transaction:
+                self._conn.rollback()
+            else:
+                self._conn.execute(f"ROLLBACK TO SAVEPOINT {_REDERIVE_SAVEPOINT}")
+                self._conn.execute(f"RELEASE SAVEPOINT {_REDERIVE_SAVEPOINT}")
+            raise
+        if owns_transaction:
+            self._conn.commit()
+        else:
+            self._conn.execute(f"RELEASE SAVEPOINT {_REDERIVE_SAVEPOINT}")
+        return recommendations
+
+    def _validate_source_changes(
+        self,
+        tenant_id: TenantId,
+        *,
+        source_changes: tuple[LearningSourceChange, ...],
+        current_signals: tuple[TailoringFeedbackSignal, ...],
+    ) -> None:
+        current_by_source: dict[str, TailoringFeedbackSignal] = {}
+        for signal in current_signals:
+            existing = current_by_source.get(signal.source_id)
+            if existing is not None and existing != signal:
+                raise ValueError("one tailoring source has conflicting current signals")
+            current_by_source[signal.source_id] = signal
+        identities: set[tuple[str, int, str]] = set()
+        for change in source_changes:
+            if change.tenant_id != tenant_id:
+                raise ValueError("learning source change must belong to its tenant")
+            _structured_identifier(change.previous_signal_id, name="previous_signal_id")
+            _structured_identifier(change.source_id, name="source_id")
+            _structured_timestamp(change.changed_at, name="changed_at")
+            expected_signal_id = (
+                f"tailoring-feedback:{change.source_id}:{change.source_revision}"
+            )
+            if change.previous_signal_id != expected_signal_id:
+                raise ValueError("learning source change identity is not canonical")
+            identity = (change.source_id, change.source_revision, change.reason_code)
+            if identity in identities:
+                raise ValueError("learning source changes must be unique")
+            identities.add(identity)
+            current = current_by_source.get(change.source_id)
+            if change.reason_code == "source_corrected":
+                if current is None or current.source_revision <= change.source_revision:
+                    raise ValueError(
+                        "source correction requires a newer accepted revision"
+                    )
+            elif current is not None:
+                raise ValueError("source deletion requires no current accepted revision")
+
+    def _append_source_change_tombstones(
+        self,
+        change: LearningSourceChange,
+        *,
+        recommendations: tuple[LearningRecommendation, ...],
+        rederived_at: str,
+    ) -> None:
+        rows = self._conn.execute(
+            """
+            SELECT recommendation.recommendation_id,
+                   recommendation.derivation_version,
+                   recommendation.signal_kind,
+                   recommendation.rule_key,
+                   recommendation.rule_value,
+                   recommendation.allowlist_version,
+                   evidence.signal_id,
+                   evidence.source_revision
+            FROM learning_recommendations AS recommendation
+            JOIN learning_recommendation_evidence AS evidence
+              ON evidence.tenant_id = recommendation.tenant_id
+             AND evidence.recommendation_id = recommendation.recommendation_id
+            WHERE recommendation.tenant_id = ?
+              AND evidence.source_kind = ?
+              AND evidence.source_id = ?
+              AND evidence.source_revision = ?
+              AND evidence.signal_id = ?
+            ORDER BY recommendation.recommendation_id
+            """,
+            (
+                str(change.tenant_id),
+                change.source_kind,
+                change.source_id,
+                change.source_revision,
+                change.previous_signal_id,
+            ),
+        ).fetchall()
+        for row in rows:
+            recommendation_id = str(row[0])
+            derivation_version = int(row[1])
+            replacement_id = _replacement_recommendation_id(
+                row,
+                recommendations=recommendations,
+                change=change,
+            )
+            business_key = (
+                str(change.tenant_id),
+                recommendation_id,
+                change.previous_signal_id,
+                change.source_revision,
+                change.reason_code,
+                derivation_version,
+            )
+            if self._conn.execute(
+                """
+                SELECT 1
+                FROM learning_recommendation_tombstones
+                WHERE tenant_id = ?
+                  AND recommendation_id = ?
+                  AND affected_signal_id = ?
+                  AND affected_source_revision = ?
+                  AND reason_code = ?
+                  AND derivation_version = ?
+                """,
+                business_key,
+            ).fetchone() is not None:
+                continue
+            self._conn.execute(
+                """
+                INSERT INTO learning_recommendation_tombstones (
+                    tenant_id, tombstone_id, recommendation_id,
+                    affected_signal_id, affected_source_revision, reason_code,
+                    derivation_version, tombstoned_at, rederived_at,
+                    replacement_recommendation_id
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    str(change.tenant_id),
+                    _tombstone_id(business_key),
+                    recommendation_id,
+                    change.previous_signal_id,
+                    change.source_revision,
+                    change.reason_code,
+                    derivation_version,
+                    change.changed_at,
+                    rederived_at,
+                    replacement_id,
+                ),
+            )
 
     def _existing_rows(
         self,
@@ -351,6 +562,43 @@ def _evidence_job_rows(
             )
         )
     )
+
+
+def _replacement_recommendation_id(
+    persisted_row: sqlite3.Row | tuple[object, ...],
+    *,
+    recommendations: tuple[LearningRecommendation, ...],
+    change: LearningSourceChange,
+) -> str | None:
+    persisted_effect = (
+        str(persisted_row[2]),
+        str(persisted_row[3]),
+        str(persisted_row[4]),
+        int(persisted_row[5]),
+    )
+    for recommendation in recommendations:
+        effect = recommendation.proposed_effect
+        if (
+            effect.signal_kind,
+            effect.rule_key,
+            effect.rule_value,
+            effect.allowlist_version,
+        ) != persisted_effect:
+            continue
+        if change.reason_code == "source_corrected" and not any(
+            evidence.source_id == change.source_id
+            and evidence.source_revision > change.source_revision
+            for evidence in recommendation.evidence
+        ):
+            continue
+        return recommendation.recommendation_id
+    return None
+
+
+def _tombstone_id(business_key: tuple[object, ...]) -> str:
+    payload = json.dumps(business_key, separators=(",", ":"), ensure_ascii=True)
+    fingerprint = hashlib.sha256(payload.encode("utf-8")).hexdigest()
+    return f"learning-recommendation-tombstone:{fingerprint}"
 
 
 __all__ = [

--- a/workers/automation/src/jobctrl/infrastructure/materials/__init__.py
+++ b/workers/automation/src/jobctrl/infrastructure/materials/__init__.py
@@ -24,7 +24,9 @@ from jobctrl.infrastructure.materials.playwright_html_pdf import (
     PlaywrightHtmlPdfAdapter,
 )
 from jobctrl.infrastructure.materials.sqlite_repository import (
+    LearningRecommendationReviewError,
     MaterialsGenerationConflict,
+    SqliteLearningRecommendationReviewRepository,
     SqliteMaterialsRepository,
     SqliteTailoringPolicyRepository,
 )
@@ -32,10 +34,12 @@ from jobctrl.infrastructure.materials.unit_of_work import SqliteUnitOfWork
 
 __all__ = [
     "HtmlResumePdfAdapter",
+    "LearningRecommendationReviewError",
     "MaterialsGenerationConflict",
     "PlaywrightHtmlPdfAdapter",
     "SqliteBulletProvenanceRepository",
     "SqliteEmployerAnalysisRepository",
+    "SqliteLearningRecommendationReviewRepository",
     "SqliteMaterialsRepository",
     "SqliteTailoringPolicyRepository",
     "SqliteUnitOfWork",

--- a/workers/automation/src/jobctrl/infrastructure/materials/__init__.py
+++ b/workers/automation/src/jobctrl/infrastructure/materials/__init__.py
@@ -29,6 +29,7 @@ from jobctrl.infrastructure.materials.sqlite_repository import (
     SqliteLearningRecommendationReviewRepository,
     SqliteMaterialsRepository,
     SqliteTailoringPolicyRepository,
+    TailoringPolicyRevisionError,
 )
 from jobctrl.infrastructure.materials.unit_of_work import SqliteUnitOfWork
 
@@ -43,4 +44,5 @@ __all__ = [
     "SqliteMaterialsRepository",
     "SqliteTailoringPolicyRepository",
     "SqliteUnitOfWork",
+    "TailoringPolicyRevisionError",
 ]

--- a/workers/automation/src/jobctrl/infrastructure/materials/sqlite_repository.py
+++ b/workers/automation/src/jobctrl/infrastructure/materials/sqlite_repository.py
@@ -1311,6 +1311,7 @@ class SqliteTailoringPolicyRepository:
                 )
             if (
                 current.rollback_of_version == target.version
+                and current.rollback_reason == reason
                 and current.same_config_as(target)
             ):
                 self._conn.commit()

--- a/workers/automation/src/jobctrl/infrastructure/materials/sqlite_repository.py
+++ b/workers/automation/src/jobctrl/infrastructure/materials/sqlite_repository.py
@@ -27,7 +27,7 @@ from jobctrl.database import effective_tailoring_min_score, ensure_tailoring_pol
 from jobctrl.domain.identifiers import JobId, canonical_job_id
 from jobctrl.domain.materials.aggregate import MaterialsSet
 from jobctrl.domain.materials.entities import Artifact
-from jobctrl.domain.materials.policy import TailoringPolicy
+from jobctrl.domain.materials.policy import TailoringPolicy, TailoringPolicyChangedError
 from jobctrl.domain.materials.value_objects import (
     ArtifactStatus,
     ArtifactType,
@@ -999,10 +999,28 @@ class SqliteTailoringPolicyRepository:
             ),
         )
 
-    def resolve_current(self, candidate: TailoringPolicy) -> TailoringPolicy:
+    def resolve_current(
+        self,
+        candidate: TailoringPolicy,
+        *,
+        expected_current_version: int | None = None,
+    ) -> TailoringPolicy:
         self._conn.execute("BEGIN IMMEDIATE")
         try:
             current = self.get_current(candidate.tenant_id)
+            actual_current_version = 0 if current is None else current.version
+            if (
+                expected_current_version is not None
+                and actual_current_version != expected_current_version
+            ):
+                raise TailoringPolicyChangedError(
+                    "tailoring policy advanced before artifact persistence"
+                )
+            if current is not None and current.learned_tailoring_rules.rules:
+                candidate = candidate.with_learned_tailoring_rules(
+                    current.learned_tailoring_rules,
+                    created_at=candidate.created_at,
+                )
             if current is not None and current.same_config_as(candidate):
                 self._conn.commit()
                 return current

--- a/workers/automation/src/jobctrl/infrastructure/materials/sqlite_repository.py
+++ b/workers/automation/src/jobctrl/infrastructure/materials/sqlite_repository.py
@@ -1015,24 +1015,14 @@ class SqliteLearningRecommendationReviewRepository:
                     (str(tenant_id), recommendation_id),
                 ).fetchall()
             )
-            accepted = next(
-                (review for review in prior_reviews if review.decision == "accepted"),
-                None,
-            )
-            if accepted is not None:
-                if decision == "accepted":
+            if prior_reviews:
+                terminal = prior_reviews[0]
+                if decision == terminal.decision:
                     self._conn.commit()
-                    return accepted
+                    return terminal
                 raise LearningRecommendationReviewError(
-                    "accepted learning recommendation is terminal"
+                    "learning recommendation decision is terminal"
                 )
-            replay = next(
-                (review for review in prior_reviews if review.decision == decision),
-                None,
-            )
-            if replay is not None:
-                self._conn.commit()
-                return replay
 
             tombstoned = self._conn.execute(
                 """

--- a/workers/automation/src/jobctrl/infrastructure/materials/sqlite_repository.py
+++ b/workers/automation/src/jobctrl/infrastructure/materials/sqlite_repository.py
@@ -17,6 +17,7 @@ See ddd-target.md §7.1 / §7.2 (per-aggregate repository, schema decoupling).
 
 from __future__ import annotations
 
+import hashlib
 import json
 import math
 import sqlite3
@@ -28,6 +29,11 @@ from jobctrl.domain.identifiers import JobId, canonical_job_id
 from jobctrl.domain.materials.aggregate import MaterialsSet
 from jobctrl.domain.materials.entities import Artifact
 from jobctrl.domain.materials.policy import TailoringPolicy, TailoringPolicyChangedError
+from jobctrl.domain.operations.learning import (
+    LearningRecommendationDecision,
+    LearningRecommendationReview,
+    TailoringRuleEffect,
+)
 from jobctrl.domain.materials.value_objects import (
     ArtifactStatus,
     ArtifactType,
@@ -62,6 +68,10 @@ class MaterialsGenerationConflict(ValueError):
             f"MaterialsSet generation conflict for job_id={job_id!r}: "
             f"got generation={attempted}, expected existing generation or next generation={expected}"
         )
+
+
+class LearningRecommendationReviewError(ValueError):
+    """Raised when an explicit recommendation decision cannot be applied."""
 
 
 # ---------------------------------------------------------------------------
@@ -936,6 +946,175 @@ def _bounded_float(value: Any) -> float | None:
     return min(100.0, parsed)
 
 
+class SqliteLearningRecommendationReviewRepository:
+    """Atomically link explicit decisions to Materials policy revisions."""
+
+    def __init__(self, conn: sqlite3.Connection) -> None:
+        self._conn = conn
+        ensure_tailoring_policy_tables(conn)
+
+    def review(
+        self,
+        tenant_id: TenantId,
+        *,
+        recommendation_id: str,
+        decision: LearningRecommendationDecision,
+        reviewed_at: str,
+    ) -> LearningRecommendationReview:
+        recommendation_id = str(recommendation_id or "").strip()
+        reviewed_at = str(reviewed_at or "").strip()
+        if not recommendation_id:
+            raise LearningRecommendationReviewError(
+                "recommendation_id must not be empty"
+            )
+        if decision not in {"accepted", "rejected"}:
+            raise LearningRecommendationReviewError(
+                "decision must be accepted or rejected"
+            )
+        if not reviewed_at:
+            raise LearningRecommendationReviewError("reviewed_at must not be empty")
+
+        self._conn.execute("BEGIN IMMEDIATE")
+        try:
+            recommendation = self._conn.execute(
+                """
+                SELECT signal_kind, rule_key, rule_value, allowlist_version
+                FROM learning_recommendations
+                WHERE tenant_id = ? AND recommendation_id = ?
+                """,
+                (str(tenant_id), recommendation_id),
+            ).fetchone()
+            if recommendation is None:
+                raise LearningRecommendationReviewError(
+                    "learning recommendation does not exist for tenant"
+                )
+
+            prior_reviews = tuple(
+                self._review_from_row(row)
+                for row in self._conn.execute(
+                    """
+                    SELECT tenant_id, review_id, recommendation_id, revision,
+                           decision, policy_version, reviewed_at
+                    FROM learning_recommendation_reviews
+                    WHERE tenant_id = ? AND recommendation_id = ?
+                    ORDER BY revision
+                    """,
+                    (str(tenant_id), recommendation_id),
+                ).fetchall()
+            )
+            accepted = next(
+                (review for review in prior_reviews if review.decision == "accepted"),
+                None,
+            )
+            if accepted is not None:
+                if decision == "accepted":
+                    self._conn.commit()
+                    return accepted
+                raise LearningRecommendationReviewError(
+                    "accepted learning recommendation is terminal"
+                )
+            replay = next(
+                (review for review in prior_reviews if review.decision == decision),
+                None,
+            )
+            if replay is not None:
+                self._conn.commit()
+                return replay
+
+            tombstoned = self._conn.execute(
+                """
+                SELECT 1
+                FROM learning_recommendation_tombstones
+                WHERE tenant_id = ? AND recommendation_id = ?
+                LIMIT 1
+                """,
+                (str(tenant_id), recommendation_id),
+            ).fetchone()
+            if tombstoned is not None:
+                raise LearningRecommendationReviewError(
+                    "tombstoned learning recommendation cannot be reviewed"
+                )
+
+            revision = len(prior_reviews) + 1
+            policy_version: int | None = None
+            if decision == "accepted":
+                effect = TailoringRuleEffect(
+                    signal_kind=str(_row_value(recommendation, "signal_kind", 0)),
+                    rule_key=str(_row_value(recommendation, "rule_key", 1)),
+                    rule_value=str(_row_value(recommendation, "rule_value", 2)),
+                    allowlist_version=int(
+                        _row_value(recommendation, "allowlist_version", 3)
+                    ),
+                )
+                policy_repository = SqliteTailoringPolicyRepository(self._conn)
+                current = policy_repository.get_current(tenant_id)
+                if current is None:
+                    raise LearningRecommendationReviewError(
+                        "acceptance requires an initialized tailoring policy"
+                    )
+                policy = current.with_learned_tailoring_rule(
+                    rule_key=effect.rule_key,
+                    rule_value=effect.rule_value,
+                    version=current.version + 1,
+                    created_at=reviewed_at,
+                )
+                policy_repository._insert(policy)
+                policy_version = policy.version
+
+            review = LearningRecommendationReview(
+                tenant_id=tenant_id,
+                review_id=_learning_recommendation_review_id(
+                    tenant_id=tenant_id,
+                    recommendation_id=recommendation_id,
+                    decision=decision,
+                ),
+                recommendation_id=recommendation_id,
+                revision=revision,
+                decision=decision,
+                policy_version=policy_version,
+                reviewed_at=reviewed_at,
+            )
+            self._conn.execute(
+                """
+                INSERT INTO learning_recommendation_reviews (
+                    tenant_id, review_id, recommendation_id, revision,
+                    decision, context, policy_kind, policy_version, reviewed_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    str(review.tenant_id),
+                    review.review_id,
+                    review.recommendation_id,
+                    review.revision,
+                    review.decision,
+                    review.context,
+                    review.policy_kind,
+                    review.policy_version,
+                    review.reviewed_at,
+                ),
+            )
+            self._conn.commit()
+            return review
+        except Exception:
+            self._conn.rollback()
+            raise
+
+    @staticmethod
+    def _review_from_row(row: Any) -> LearningRecommendationReview:
+        raw_policy_version = _row_value(row, "policy_version", 5)
+        return LearningRecommendationReview(
+            tenant_id=TenantId(str(_row_value(row, "tenant_id", 0))),
+            review_id=str(_row_value(row, "review_id", 1)),
+            recommendation_id=str(_row_value(row, "recommendation_id", 2)),
+            revision=int(_row_value(row, "revision", 3)),
+            decision=str(_row_value(row, "decision", 4)),
+            policy_version=(
+                None if raw_policy_version is None else int(raw_policy_version)
+            ),
+            reviewed_at=str(_row_value(row, "reviewed_at", 6)),
+        )
+
+
 class SqliteTailoringPolicyRepository:
     """SQLite-backed current policy adapter for the Materials context."""
 
@@ -1077,6 +1256,16 @@ def _row_value(row: Any, name: str, index: int) -> Any:
     if isinstance(row, sqlite3.Row):
         return row[name]
     return row[index]
+
+
+def _learning_recommendation_review_id(
+    *,
+    tenant_id: TenantId,
+    recommendation_id: str,
+    decision: LearningRecommendationDecision,
+) -> str:
+    payload = f"{tenant_id}\0{recommendation_id}\0{decision}".encode()
+    return f"learning-recommendation-review:{hashlib.sha256(payload).hexdigest()}"
 
 
 def _utc_now() -> str:

--- a/workers/automation/src/jobctrl/infrastructure/materials/sqlite_repository.py
+++ b/workers/automation/src/jobctrl/infrastructure/materials/sqlite_repository.py
@@ -974,6 +974,11 @@ class SqliteLearningRecommendationReviewRepository:
         if not reviewed_at:
             raise LearningRecommendationReviewError("reviewed_at must not be empty")
 
+        policy_repository = (
+            SqliteTailoringPolicyRepository(self._conn)
+            if decision == "accepted"
+            else None
+        )
         self._conn.execute("BEGIN IMMEDIATE")
         try:
             recommendation = self._conn.execute(
@@ -1046,7 +1051,7 @@ class SqliteLearningRecommendationReviewRepository:
                         _row_value(recommendation, "allowlist_version", 3)
                     ),
                 )
-                policy_repository = SqliteTailoringPolicyRepository(self._conn)
+                assert policy_repository is not None
                 current = policy_repository.get_current(tenant_id)
                 if current is None:
                     raise LearningRecommendationReviewError(

--- a/workers/automation/src/jobctrl/infrastructure/materials/sqlite_repository.py
+++ b/workers/automation/src/jobctrl/infrastructure/materials/sqlite_repository.py
@@ -28,7 +28,11 @@ from jobctrl.database import effective_tailoring_min_score, ensure_tailoring_pol
 from jobctrl.domain.identifiers import JobId, canonical_job_id
 from jobctrl.domain.materials.aggregate import MaterialsSet
 from jobctrl.domain.materials.entities import Artifact
-from jobctrl.domain.materials.policy import TailoringPolicy, TailoringPolicyChangedError
+from jobctrl.domain.materials.policy import (
+    TailoringPolicy,
+    TailoringPolicyChangedError,
+    TailoringPolicyRollbackReason,
+)
 from jobctrl.domain.operations.learning import (
     LearningRecommendationDecision,
     LearningRecommendationReview,
@@ -72,6 +76,10 @@ class MaterialsGenerationConflict(ValueError):
 
 class LearningRecommendationReviewError(ValueError):
     """Raised when an explicit recommendation decision cannot be applied."""
+
+
+class TailoringPolicyRevisionError(ValueError):
+    """Raised when a requested policy history operation is not valid."""
 
 
 # ---------------------------------------------------------------------------
@@ -1147,6 +1155,49 @@ class SqliteTailoringPolicyRepository:
             return None
         return self._row_to_policy(row)
 
+    def get_version(self, tenant_id: TenantId, version: int) -> TailoringPolicy | None:
+        row = self._conn.execute(
+            """
+            SELECT tenant_id, version, prompt_version, schema_version,
+                   judge_schema_version, prompt_fingerprint, config_fingerprint,
+                   profile_policy_fingerprint, custom_prompt_fingerprint,
+                   generator_settings_json, judge_settings_json,
+                   runtime_settings_json, rollback_of_version, rollback_reason,
+                   created_at, created_from_event_id
+            FROM tailoring_policies
+            WHERE tenant_id = ? AND version = ?
+            """,
+            (str(tenant_id), version),
+        ).fetchone()
+        if row is None:
+            return None
+        return self._row_to_policy(row)
+
+    def list_history(
+        self,
+        tenant_id: TenantId,
+        *,
+        limit: int = 100,
+    ) -> list[TailoringPolicy]:
+        if limit < 1 or limit > 100:
+            raise TailoringPolicyRevisionError("policy history limit must be between 1 and 100")
+        rows = self._conn.execute(
+            """
+            SELECT tenant_id, version, prompt_version, schema_version,
+                   judge_schema_version, prompt_fingerprint, config_fingerprint,
+                   profile_policy_fingerprint, custom_prompt_fingerprint,
+                   generator_settings_json, judge_settings_json,
+                   runtime_settings_json, rollback_of_version, rollback_reason,
+                   created_at, created_from_event_id
+            FROM tailoring_policies
+            WHERE tenant_id = ?
+            ORDER BY version DESC
+            LIMIT ?
+            """,
+            (str(tenant_id), limit),
+        ).fetchall()
+        return [self._row_to_policy(row) for row in rows]
+
     def save(self, policy: TailoringPolicy) -> None:
         self._insert(policy)
         self._conn.commit()
@@ -1231,6 +1282,65 @@ class SqliteTailoringPolicyRepository:
             self._insert(policy)
             self._conn.commit()
             return policy
+        except Exception:
+            self._conn.rollback()
+            raise
+
+    def rollback_to(
+        self,
+        tenant_id: TenantId,
+        *,
+        target_version: int,
+        reason: TailoringPolicyRollbackReason,
+        rolled_back_at: str,
+    ) -> TailoringPolicy:
+        if reason != "user_requested":
+            raise TailoringPolicyRevisionError("unsupported tailoring policy rollback reason")
+        if not str(rolled_back_at or "").strip():
+            raise TailoringPolicyRevisionError("rolled_back_at must not be empty")
+
+        self._conn.execute("BEGIN IMMEDIATE")
+        try:
+            current = self.get_current(tenant_id)
+            if current is None:
+                raise TailoringPolicyRevisionError("tailoring policy is not initialized")
+            target = self.get_version(tenant_id, target_version)
+            if target is None:
+                raise TailoringPolicyRevisionError(
+                    "target tailoring policy version does not exist for tenant"
+                )
+            if (
+                current.rollback_of_version == target.version
+                and current.same_config_as(target)
+            ):
+                self._conn.commit()
+                return current
+            if target.version >= current.version:
+                raise TailoringPolicyRevisionError(
+                    "rollback target must precede the current tailoring policy"
+                )
+
+            rollback = TailoringPolicy(
+                tenant_id=tenant_id,
+                version=current.version + 1,
+                prompt_version=target.prompt_version,
+                schema_version=target.schema_version,
+                judge_schema_version=target.judge_schema_version,
+                prompt_fingerprint=target.prompt_fingerprint,
+                config_fingerprint=target.config_fingerprint,
+                profile_policy_fingerprint=target.profile_policy_fingerprint,
+                custom_prompt_fingerprint=target.custom_prompt_fingerprint,
+                generator_settings=target.generator_settings,
+                judge_settings=target.judge_settings,
+                runtime_settings=target.runtime_settings,
+                rollback_of_version=target.version,
+                rollback_reason=reason,
+                created_at=rolled_back_at,
+                created_from_event_id=None,
+            )
+            self._insert(rollback)
+            self._conn.commit()
+            return rollback
         except Exception:
             self._conn.rollback()
             raise

--- a/workers/automation/src/jobctrl/infrastructure/migrations/schema_manifest.py
+++ b/workers/automation/src/jobctrl/infrastructure/migrations/schema_manifest.py
@@ -25,7 +25,7 @@ EXACT_V7_MANIFEST = SchemaManifest(
     version=7,
     object_count=242,
     table_count=110,
-    fingerprint="55d88c87aaf9bec6c8686ee0e40dba31ca19aaaa5767042f9376f5e2756fecfd",
+    fingerprint="775312f0ec2640a2a87889602886c90e21a49e06fffc53cf26c435856247da97",
 )
 
 

--- a/workers/automation/src/jobctrl/infrastructure/migrations/schema_manifest.py
+++ b/workers/automation/src/jobctrl/infrastructure/migrations/schema_manifest.py
@@ -23,9 +23,9 @@ class SchemaManifest:
 # semantically meaningful and must never normalize to the same fingerprint.
 EXACT_V7_MANIFEST = SchemaManifest(
     version=7,
-    object_count=236,
-    table_count=109,
-    fingerprint="3b6ad22091d895ef141917e080df86b02dc21c56a1f9ffe3b70da3c9db6edad8",
+    object_count=242,
+    table_count=110,
+    fingerprint="55d88c87aaf9bec6c8686ee0e40dba31ca19aaaa5767042f9376f5e2756fecfd",
 )
 
 

--- a/workers/automation/src/jobctrl/infrastructure/migrations/schema_manifest.py
+++ b/workers/automation/src/jobctrl/infrastructure/migrations/schema_manifest.py
@@ -23,9 +23,9 @@ class SchemaManifest:
 # semantically meaningful and must never normalize to the same fingerprint.
 EXACT_V7_MANIFEST = SchemaManifest(
     version=7,
-    object_count=231,
-    table_count=108,
-    fingerprint="8b2179d91d202bf43c5463ceb7f34313a0c75f296b20335ee4364cfa8d2e78bd",
+    object_count=236,
+    table_count=109,
+    fingerprint="3b6ad22091d895ef141917e080df86b02dc21c56a1f9ffe3b70da3c9db6edad8",
 )
 
 

--- a/workers/automation/src/jobctrl/infrastructure/migrations/schema_v7.sql
+++ b/workers/automation/src/jobctrl/infrastructure/migrations/schema_v7.sql
@@ -1776,6 +1776,67 @@ BEFORE DELETE ON tailoring_feedback_signal_reviews
 BEGIN
   SELECT RAISE(ABORT, 'tailoring feedback reviews are append-only');
 END;
+CREATE TABLE tailoring_feedback_signal_contradictions (
+      tenant_id                    TEXT NOT NULL DEFAULT 'local',
+      contradiction_id            TEXT NOT NULL,
+      signal_id                    TEXT NOT NULL,
+      signal_revision              INTEGER NOT NULL CHECK(signal_revision > 0),
+      signal_job_id                TEXT NOT NULL CHECK(
+        length(signal_job_id) = 36
+        AND substr(signal_job_id, 9, 1) = '-'
+        AND substr(signal_job_id, 14, 1) = '-'
+        AND substr(signal_job_id, 19, 1) = '-'
+        AND substr(signal_job_id, 24, 1) = '-'
+        AND replace(signal_job_id, '-', '') NOT GLOB '*[^a-f0-9]*'
+      ),
+      contradicting_signal_id      TEXT NOT NULL,
+      contradicting_signal_revision INTEGER NOT NULL CHECK(
+        contradicting_signal_revision > 0
+      ),
+      contradicting_signal_job_id  TEXT NOT NULL CHECK(
+        length(contradicting_signal_job_id) = 36
+        AND substr(contradicting_signal_job_id, 9, 1) = '-'
+        AND substr(contradicting_signal_job_id, 14, 1) = '-'
+        AND substr(contradicting_signal_job_id, 19, 1) = '-'
+        AND substr(contradicting_signal_job_id, 24, 1) = '-'
+        AND replace(contradicting_signal_job_id, '-', '') NOT GLOB '*[^a-f0-9]*'
+      ),
+      recorded_at                  TEXT NOT NULL,
+      PRIMARY KEY (tenant_id, contradiction_id),
+      UNIQUE (
+        tenant_id,
+        signal_id,
+        signal_revision,
+        contradicting_signal_id,
+        contradicting_signal_revision
+      ),
+      FOREIGN KEY (tenant_id, signal_id, signal_revision)
+        REFERENCES tailoring_feedback_signal_reviews(tenant_id, signal_id, revision)
+        ON DELETE RESTRICT,
+      FOREIGN KEY (
+        tenant_id,
+        contradicting_signal_id,
+        contradicting_signal_revision
+      ) REFERENCES tailoring_feedback_signal_reviews(tenant_id, signal_id, revision)
+        ON DELETE RESTRICT,
+      CHECK (
+        signal_id < contradicting_signal_id
+        OR (
+          signal_id = contradicting_signal_id
+          AND signal_revision < contradicting_signal_revision
+        )
+      )
+    );
+CREATE TRIGGER prevent_tailoring_feedback_signal_contradiction_update
+BEFORE UPDATE ON tailoring_feedback_signal_contradictions
+BEGIN
+  SELECT RAISE(ABORT, 'tailoring feedback contradictions are append-only');
+END;
+CREATE TRIGGER prevent_tailoring_feedback_signal_contradiction_delete
+BEFORE DELETE ON tailoring_feedback_signal_contradictions
+BEGIN
+  SELECT RAISE(ABORT, 'tailoring feedback contradictions are append-only');
+END;
 CREATE TABLE tailoring_feedback_signals (
       tenant_id         TEXT NOT NULL DEFAULT 'local',
       signal_id         TEXT NOT NULL,
@@ -2461,6 +2522,18 @@ CREATE INDEX idx_tailoring_feedback_signal_reviews_signal
       ON tailoring_feedback_signal_reviews(tenant_id, signal_id, revision DESC);
 CREATE INDEX idx_tailoring_feedback_signal_reviews_decision
       ON tailoring_feedback_signal_reviews(tenant_id, decision, reviewed_at DESC);
+CREATE INDEX idx_tailoring_feedback_signal_contradictions_signal
+      ON tailoring_feedback_signal_contradictions(
+        tenant_id,
+        signal_id,
+        signal_revision
+      );
+CREATE INDEX idx_tailoring_feedback_signal_contradictions_other
+      ON tailoring_feedback_signal_contradictions(
+        tenant_id,
+        contradicting_signal_id,
+        contradicting_signal_revision
+      );
 CREATE INDEX idx_learning_recommendations_tenant_derived
       ON learning_recommendations(tenant_id, derived_at DESC, recommendation_id);
 CREATE INDEX idx_learning_recommendation_evidence_signal

--- a/workers/automation/src/jobctrl/infrastructure/migrations/schema_v7.sql
+++ b/workers/automation/src/jobctrl/infrastructure/migrations/schema_v7.sql
@@ -1945,14 +1945,7 @@ WHEN EXISTS (
   WHERE tenant_id = NEW.tenant_id
     AND (
       review_id = NEW.review_id
-      OR (
-        recommendation_id = NEW.recommendation_id
-        AND (
-          revision = NEW.revision
-          OR decision = NEW.decision
-          OR decision = 'accepted'
-        )
-      )
+      OR recommendation_id = NEW.recommendation_id
       OR (
         NEW.policy_version IS NOT NULL
         AND context = NEW.context
@@ -1972,14 +1965,7 @@ WHEN NOT EXISTS (
   WHERE tenant_id = NEW.tenant_id
     AND (
       review_id = NEW.review_id
-      OR (
-        recommendation_id = NEW.recommendation_id
-        AND (
-          revision = NEW.revision
-          OR decision = NEW.decision
-          OR decision = 'accepted'
-        )
-      )
+      OR recommendation_id = NEW.recommendation_id
       OR (
         NEW.policy_version IS NOT NULL
         AND context = NEW.context

--- a/workers/automation/src/jobctrl/infrastructure/migrations/schema_v7.sql
+++ b/workers/automation/src/jobctrl/infrastructure/migrations/schema_v7.sql
@@ -1912,6 +1912,101 @@ BEFORE DELETE ON learning_recommendations
 BEGIN
   SELECT RAISE(ABORT, 'learning recommendations are append-only');
 END;
+CREATE TABLE learning_recommendation_reviews (
+      tenant_id         TEXT NOT NULL DEFAULT 'local',
+      review_id         TEXT NOT NULL,
+      recommendation_id TEXT NOT NULL,
+      revision          INTEGER NOT NULL CHECK(revision > 0),
+      decision          TEXT NOT NULL CHECK(decision IN ('accepted', 'rejected')),
+      context           TEXT NOT NULL CHECK(context = 'materials'),
+      policy_kind       TEXT NOT NULL CHECK(policy_kind = 'tailoring_rule'),
+      policy_version    INTEGER,
+      reviewed_at       TEXT NOT NULL,
+      PRIMARY KEY (tenant_id, review_id),
+      UNIQUE (tenant_id, recommendation_id, revision),
+      UNIQUE (tenant_id, recommendation_id, decision),
+      UNIQUE (tenant_id, context, policy_kind, policy_version),
+      FOREIGN KEY (tenant_id, recommendation_id)
+        REFERENCES learning_recommendations(tenant_id, recommendation_id)
+        ON DELETE RESTRICT,
+      FOREIGN KEY (tenant_id, policy_version)
+        REFERENCES tailoring_policies(tenant_id, version)
+        ON DELETE RESTRICT,
+      CHECK(
+        (decision = 'accepted' AND policy_version IS NOT NULL AND policy_version > 0)
+        OR (decision = 'rejected' AND policy_version IS NULL)
+      )
+    );
+CREATE TRIGGER prevent_learning_recommendation_review_collision
+BEFORE INSERT ON learning_recommendation_reviews
+WHEN EXISTS (
+  SELECT 1
+  FROM learning_recommendation_reviews
+  WHERE tenant_id = NEW.tenant_id
+    AND (
+      review_id = NEW.review_id
+      OR (
+        recommendation_id = NEW.recommendation_id
+        AND (
+          revision = NEW.revision
+          OR decision = NEW.decision
+          OR decision = 'accepted'
+        )
+      )
+      OR (
+        NEW.policy_version IS NOT NULL
+        AND context = NEW.context
+        AND policy_kind = NEW.policy_kind
+        AND policy_version = NEW.policy_version
+      )
+    )
+)
+BEGIN
+  SELECT RAISE(ABORT, 'learning recommendation reviews are append-only');
+END;
+CREATE TRIGGER validate_learning_recommendation_review_revision
+BEFORE INSERT ON learning_recommendation_reviews
+WHEN NOT EXISTS (
+  SELECT 1
+  FROM learning_recommendation_reviews
+  WHERE tenant_id = NEW.tenant_id
+    AND (
+      review_id = NEW.review_id
+      OR (
+        recommendation_id = NEW.recommendation_id
+        AND (
+          revision = NEW.revision
+          OR decision = NEW.decision
+          OR decision = 'accepted'
+        )
+      )
+      OR (
+        NEW.policy_version IS NOT NULL
+        AND context = NEW.context
+        AND policy_kind = NEW.policy_kind
+        AND policy_version = NEW.policy_version
+      )
+    )
+)
+AND NEW.revision != COALESCE((
+  SELECT MAX(revision) + 1
+  FROM learning_recommendation_reviews
+  WHERE tenant_id = NEW.tenant_id
+    AND recommendation_id = NEW.recommendation_id
+), 1)
+BEGIN
+  SELECT RAISE(ABORT, 'learning recommendation review revision must be contiguous');
+END;
+CREATE TRIGGER prevent_learning_recommendation_review_update
+BEFORE UPDATE ON learning_recommendation_reviews
+BEGIN
+  SELECT RAISE(ABORT, 'learning recommendation reviews are append-only');
+END;
+CREATE TRIGGER prevent_learning_recommendation_review_delete
+BEFORE DELETE ON learning_recommendation_reviews
+BEGIN
+  SELECT RAISE(ABORT, 'learning recommendation reviews are append-only');
+END;
 CREATE TRIGGER validate_learning_recommendation_counts
 BEFORE INSERT ON learning_recommendations
 BEGIN
@@ -2536,6 +2631,12 @@ CREATE INDEX idx_tailoring_feedback_signal_contradictions_other
       );
 CREATE INDEX idx_learning_recommendations_tenant_derived
       ON learning_recommendations(tenant_id, derived_at DESC, recommendation_id);
+CREATE INDEX idx_learning_recommendation_reviews_tenant_reviewed
+      ON learning_recommendation_reviews(
+        tenant_id,
+        reviewed_at DESC,
+        review_id
+      );
 CREATE INDEX idx_learning_recommendation_evidence_signal
       ON learning_recommendation_evidence(tenant_id, signal_id, evidence_role);
 CREATE INDEX idx_learning_recommendation_evidence_jobs_job

--- a/workers/automation/src/jobctrl/infrastructure/migrations/v6_to_v7_plan.py
+++ b/workers/automation/src/jobctrl/infrastructure/migrations/v6_to_v7_plan.py
@@ -236,8 +236,9 @@ def _table_plans() -> dict[str, TablePlan]:
     )
     # Reviewed tailoring facts and derived recommendation audit records exist
     # only in exact v7. The v6 source cannot imply review, recommendation, job
-    # evidence, or tombstone rows, so all begin empty after cutover.
+    # evidence, decision, or tombstone rows, so all begin empty after cutover.
     for table in (
+        "learning_recommendation_reviews",
         "learning_recommendation_evidence",
         "learning_recommendation_evidence_jobs",
         "learning_recommendation_jobs",
@@ -518,6 +519,7 @@ _DECLARED_COLUMNS: Final[Mapping[str, frozenset[str]]] = _column_manifest(
         "jobctrl_hidden_jobs": "job_url tenant_id job_id hidden_at reason unhidden_at",
         "jobs": "url title company salary description location site strategy discovered_at full_description application_url detail_scraped_at detail_error fit_score score_reasoning scored_at tailored_resume_path tailored_at tailor_attempts cover_letter_path cover_letter_at cover_attempts applied_at apply_status apply_error apply_attempts agent_id last_attempted_at apply_duration_ms apply_task_id verification_confidence tenant_id job_id",
         "llm_spend": "day input_tokens output_tokens estimated_usd",
+        "learning_recommendation_reviews": "tenant_id review_id recommendation_id revision decision context policy_kind policy_version reviewed_at",
         "learning_recommendation_evidence": "tenant_id recommendation_id signal_id evidence_role source_kind source_id source_revision recorded_at",
         "learning_recommendation_evidence_jobs": "tenant_id recommendation_id signal_id job_id",
         "learning_recommendation_jobs": "tenant_id recommendation_id job_id",

--- a/workers/automation/src/jobctrl/infrastructure/migrations/v6_to_v7_plan.py
+++ b/workers/automation/src/jobctrl/infrastructure/migrations/v6_to_v7_plan.py
@@ -243,6 +243,7 @@ def _table_plans() -> dict[str, TablePlan]:
         "learning_recommendation_jobs",
         "learning_recommendation_tombstones",
         "learning_recommendations",
+        "tailoring_feedback_signal_contradictions",
         "tailoring_feedback_signal_reviews",
     ):
         plans[table] = TablePlan(
@@ -547,6 +548,7 @@ _DECLARED_COLUMNS: Final[Mapping[str, frozenset[str]]] = _column_manifest(
         "source_quality_stats": "tenant_id source_id window_start window_end run_count failed_run_count consecutive_failures observed_jobs new_jobs existing_jobs duplicate_jobs active_jobs stale_jobs detail_success_count detail_failure_count active_verification_rate duplicate_rate full_description_success_rate apply_url_success_rate last_run_id last_error_class recommended_state updated_at",
         "source_registry_entries": "tenant_id source_id kind display_name owner priority state policy_id seed_url created_at updated_at",
         "tailoring_feedback_signals": "tenant_id signal_id job_key job_id draft_id draft_revision_id source_kind source_id signal_kind status summary section semantic_id created_at reviewed_at",
+        "tailoring_feedback_signal_contradictions": "tenant_id contradiction_id signal_id signal_revision signal_job_id contradicting_signal_id contradicting_signal_revision contradicting_signal_job_id recorded_at",
         "tailoring_feedback_signal_reviews": "tenant_id review_id signal_id revision decision signal_kind rule_key rule_value allowlist_version reviewed_at",
         "tailoring_policies": "tenant_id version prompt_version schema_version judge_schema_version prompt_fingerprint config_fingerprint profile_policy_fingerprint custom_prompt_fingerprint generator_settings_json judge_settings_json runtime_settings_json rollback_of_version rollback_reason created_at created_from_event_id",
         "worker_runtime_heartbeats": "worker_id component pid hostname app_dir db_path task_queue started_at last_seen_at max_concurrent_activities activity_executor_max_workers active_activity_count active_activity_counts_json active_activity_details_json active_activity_details_total active_activity_details_truncated activity_duration_summary_json task_queue_observation_json heartbeat_schema_version",

--- a/workers/automation/src/jobctrl/infrastructure/rpc/handlers.py
+++ b/workers/automation/src/jobctrl/infrastructure/rpc/handlers.py
@@ -32,6 +32,10 @@ from jobctrl.infrastructure.preparation import SqlitePreparationTargetReader
 from jobctrl.infrastructure.learning.sqlite_repository import (
     SqliteLearningRecommendationRepository,
 )
+from jobctrl.infrastructure.materials import (
+    LearningRecommendationReviewError,
+    SqliteLearningRecommendationReviewRepository,
+)
 from jobctrl.infrastructure.rpc.server import JsonRpcServer, invalid_params
 from jobctrl.infrastructure.rpc.workflow_starter import WorkflowCanceler
 from jobctrl.infrastructure.runtime_identity import assert_expected_runtime
@@ -821,6 +825,42 @@ def rederive_learning_recommendations(params: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def review_learning_recommendation(params: dict[str, Any]) -> dict[str, Any]:
+    """Record one explicit recommendation decision and its policy effect."""
+
+    tenant_id = TenantId(_tenant_id(params))
+    recommendation_id = str(_require(params, "recommendationId")).strip()
+    decision = str(_require(params, "decision")).strip()
+    if decision not in {"accepted", "rejected"}:
+        raise invalid_params("decision must be accepted or rejected")
+    assert_expected_runtime(
+        expected_app_dir=params.get("expectedAppDir"),
+        expected_db_path=params.get("expectedDbPath"),
+    )
+    try:
+        review = SqliteLearningRecommendationReviewRepository(
+            get_connection()
+        ).review(
+            tenant_id,
+            recommendation_id=recommendation_id,
+            decision=decision,
+            reviewed_at=datetime.now(UTC).isoformat(),
+        )
+    except LearningRecommendationReviewError as exc:
+        raise invalid_params(str(exc)) from exc
+    return {
+        "status": "succeeded",
+        "reviewId": review.review_id,
+        "recommendationId": review.recommendation_id,
+        "revision": review.revision,
+        "decision": review.decision,
+        "context": review.context,
+        "policyKind": review.policy_kind,
+        "policyVersion": review.policy_version,
+        "reviewedAt": review.reviewed_at,
+    }
+
+
 # ---------------------------------------------------------------------------
 # Registration
 # ---------------------------------------------------------------------------
@@ -854,6 +894,11 @@ def register_default_handlers(server: JsonRpcServer, *, canceler: WorkflowCancel
     server.register(
         "rederive_learning_recommendations",
         rederive_learning_recommendations,
+        mode="sync",
+    )
+    server.register(
+        "review_learning_recommendation",
+        review_learning_recommendation,
         mode="sync",
     )
     server.register("refresh_compensation", refresh_compensation, mode="workflow")

--- a/workers/automation/src/jobctrl/infrastructure/rpc/handlers.py
+++ b/workers/automation/src/jobctrl/infrastructure/rpc/handlers.py
@@ -35,6 +35,8 @@ from jobctrl.infrastructure.learning.sqlite_repository import (
 from jobctrl.infrastructure.materials import (
     LearningRecommendationReviewError,
     SqliteLearningRecommendationReviewRepository,
+    SqliteTailoringPolicyRepository,
+    TailoringPolicyRevisionError,
 )
 from jobctrl.infrastructure.rpc.server import JsonRpcServer, invalid_params
 from jobctrl.infrastructure.rpc.workflow_starter import WorkflowCanceler
@@ -861,6 +863,45 @@ def review_learning_recommendation(params: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def rollback_tailoring_policy(params: dict[str, Any]) -> dict[str, Any]:
+    """Append a Materials policy revision that restores a prior version."""
+
+    tenant_id = TenantId(_tenant_id(params))
+    target_version = _require(params, "targetVersion")
+    if (
+        not isinstance(target_version, int)
+        or isinstance(target_version, bool)
+        or target_version < 1
+    ):
+        raise invalid_params("targetVersion must be a positive integer")
+    assert_expected_runtime(
+        expected_app_dir=params.get("expectedAppDir"),
+        expected_db_path=params.get("expectedDbPath"),
+    )
+    try:
+        policy = SqliteTailoringPolicyRepository(get_connection()).rollback_to(
+            tenant_id,
+            target_version=target_version,
+            reason="user_requested",
+            rolled_back_at=datetime.now(UTC).isoformat(),
+        )
+    except TailoringPolicyRevisionError as exc:
+        raise invalid_params(str(exc)) from exc
+    return {
+        "status": "succeeded",
+        "context": "materials",
+        "policyKind": "tailoring_rule",
+        "policyVersion": policy.version,
+        "rollbackOfVersion": policy.rollback_of_version,
+        "rollbackReasonCode": policy.rollback_reason,
+        "learnedRules": [
+            {"ruleKey": rule_key, "ruleValue": rule_value}
+            for rule_key, rule_value in policy.learned_tailoring_rules.rules
+        ],
+        "rolledBackAt": policy.created_at,
+    }
+
+
 # ---------------------------------------------------------------------------
 # Registration
 # ---------------------------------------------------------------------------
@@ -901,6 +942,7 @@ def register_default_handlers(server: JsonRpcServer, *, canceler: WorkflowCancel
         review_learning_recommendation,
         mode="sync",
     )
+    server.register("rollback_tailoring_policy", rollback_tailoring_policy, mode="sync")
     server.register("refresh_compensation", refresh_compensation, mode="workflow")
     server.register("generate_interview_prep", generate_interview_prep, mode="workflow")
     server.register("run_contact_research", run_contact_research, mode="workflow")

--- a/workers/automation/src/jobctrl/infrastructure/rpc/handlers.py
+++ b/workers/automation/src/jobctrl/infrastructure/rpc/handlers.py
@@ -19,6 +19,7 @@ target §6.5).
 from __future__ import annotations
 
 import asyncio
+from datetime import UTC, datetime
 import logging
 from typing import Any
 
@@ -28,8 +29,12 @@ from jobctrl.domain.rpc.messages import WorkflowStartSpec
 from jobctrl.domain.preparation import PreparationWorkItemKind
 from jobctrl.domain.tenant import LOCAL_TENANT, TenantId
 from jobctrl.infrastructure.preparation import SqlitePreparationTargetReader
+from jobctrl.infrastructure.learning.sqlite_repository import (
+    SqliteLearningRecommendationRepository,
+)
 from jobctrl.infrastructure.rpc.server import JsonRpcServer, invalid_params
 from jobctrl.infrastructure.rpc.workflow_starter import WorkflowCanceler
+from jobctrl.infrastructure.runtime_identity import assert_expected_runtime
 from jobctrl.model_defaults import DEFAULT_PIPELINE_LLM_MODEL_SPEC
 from jobctrl.pipeline.preparation import (
     build_preparation_workflow_spec,
@@ -792,6 +797,30 @@ def make_cancel_run(canceler: WorkflowCanceler):
     return cancel_run
 
 
+def rederive_learning_recommendations(params: dict[str, Any]) -> dict[str, Any]:
+    """Refresh pending Materials proposals after an explicit signal review."""
+
+    tenant_id = TenantId(_tenant_id(params))
+    assert_expected_runtime(
+        expected_app_dir=params.get("expectedAppDir"),
+        expected_db_path=params.get("expectedDbPath"),
+    )
+    recommendations = SqliteLearningRecommendationRepository(
+        get_connection()
+    ).rederive_tailoring(
+        tenant_id,
+        source_changes=None,
+        rederived_at=datetime.now(UTC).isoformat(),
+    )
+    return {
+        "status": "succeeded",
+        "recommendationCount": len(recommendations),
+        "recommendationIds": [
+            recommendation.recommendation_id for recommendation in recommendations
+        ],
+    }
+
+
 # ---------------------------------------------------------------------------
 # Registration
 # ---------------------------------------------------------------------------
@@ -822,6 +851,11 @@ def register_default_handlers(server: JsonRpcServer, *, canceler: WorkflowCancel
     server.register("browser_capability_enable", browser_capability_enable, mode="sync")
     server.register("browser_capability_disable", browser_capability_disable, mode="sync")
     server.register("browser_profile_copy", browser_profile_copy, mode="sync")
+    server.register(
+        "rederive_learning_recommendations",
+        rederive_learning_recommendations,
+        mode="sync",
+    )
     server.register("refresh_compensation", refresh_compensation, mode="workflow")
     server.register("generate_interview_prep", generate_interview_prep, mode="workflow")
     server.register("run_contact_research", run_contact_research, mode="workflow")

--- a/workers/automation/tests/test_exact_v7_schema.py
+++ b/workers/automation/tests/test_exact_v7_schema.py
@@ -31,6 +31,7 @@ from jobctrl.infrastructure import runtime_identity
 _CROSS_RUNTIME_DURABLE_TABLES = {
     "discovery_execution_recoveries",
     "jobctrl_hidden_jobs",
+    "learning_recommendation_reviews",
     "learning_recommendation_evidence",
     "learning_recommendation_evidence_jobs",
     "learning_recommendation_jobs",
@@ -715,6 +716,71 @@ def test_tailoring_feedback_reviews_are_structured_append_only_facts(
     close_connection(db_path)
 
 
+def _insert_learning_recommendation_fixture(
+    conn: sqlite3.Connection,
+    recommendation_id: str,
+    fingerprint_character: str,
+) -> None:
+    job_ids = (
+        "11111111-1111-4111-8111-111111111111",
+        "22222222-2222-4222-8222-222222222222",
+    )
+    for index in range(1, 4):
+        signal_id = f"{recommendation_id}-signal-{index}"
+        conn.execute(
+            """
+            INSERT INTO learning_recommendation_evidence (
+                tenant_id, recommendation_id, signal_id, evidence_role,
+                source_kind, source_id, source_revision, recorded_at
+            ) VALUES (
+                'local', ?, ?, 'supporting',
+                'tailoring_feedback_signal', ?, ?, ?
+            )
+            """,
+            (
+                recommendation_id,
+                signal_id,
+                f"source-{signal_id}",
+                index,
+                f"2026-08-01T00:00:0{index}Z",
+            ),
+        )
+        conn.execute(
+            """
+            INSERT INTO learning_recommendation_evidence_jobs (
+                tenant_id, recommendation_id, signal_id, job_id
+            ) VALUES ('local', ?, ?, ?)
+            """,
+            (recommendation_id, signal_id, job_ids[min(index - 1, 1)]),
+        )
+    for job_id in job_ids:
+        conn.execute(
+            """
+            INSERT INTO learning_recommendation_jobs (
+                tenant_id, recommendation_id, job_id
+            ) VALUES ('local', ?, ?)
+            """,
+            (recommendation_id, job_id),
+        )
+    conn.execute(
+        """
+        INSERT INTO learning_recommendations (
+            tenant_id, recommendation_id, derivation_version,
+            evaluation_fixture_version, context, policy_kind, signal_kind,
+            rule_key, rule_value, allowlist_version, status,
+            observed_signal_count, observed_job_count, minimum_signal_count,
+            minimum_job_count, confidence_limit, input_fingerprint, derived_at
+        ) VALUES (
+            'local', ?, 1, 1, 'materials', 'tailoring_rule',
+            'factual_correction', 'fact_handling', 'require_source_match',
+            1, 'pending', 3, 2, 3, 2,
+            'sample_gated_no_population_inference', ?, '2026-08-01T01:00:00Z'
+        )
+        """,
+        (recommendation_id, fingerprint_character * 64),
+    )
+
+
 def test_learning_recommendation_storage_is_structured_append_only_and_private(
     tmp_path: Path,
 ) -> None:
@@ -1109,6 +1175,7 @@ def test_learning_recommendation_storage_is_structured_append_only_and_private(
         "text",
     }
     for table in (
+        "learning_recommendation_reviews",
         "learning_recommendations",
         "learning_recommendation_evidence",
         "learning_recommendation_evidence_jobs",
@@ -1125,6 +1192,169 @@ def test_learning_recommendation_storage_is_structured_append_only_and_private(
             if column in forbidden_fragments
             or any(column.endswith(f"_{fragment}") for fragment in forbidden_fragments)
         }
+
+    assert conn.execute("PRAGMA foreign_key_check").fetchone() is None
+    close_connection(db_path)
+
+
+def test_learning_recommendation_reviews_are_append_only_and_policy_linked(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    conn = init_db(db_path)
+    conn.execute("PRAGMA foreign_keys = ON")
+    for recommendation_id, fingerprint in (
+        ("recommendation-rejected", "d"),
+        ("recommendation-accepted", "e"),
+        ("recommendation-later-accepted", "f"),
+    ):
+        _insert_learning_recommendation_fixture(
+            conn,
+            recommendation_id,
+            fingerprint,
+        )
+    conn.execute(
+        """
+        INSERT INTO tailoring_policies (
+            tenant_id, version, prompt_version, schema_version,
+            judge_schema_version, prompt_fingerprint, config_fingerprint,
+            profile_policy_fingerprint, custom_prompt_fingerprint,
+            generator_settings_json, judge_settings_json,
+            runtime_settings_json, rollback_of_version, rollback_reason,
+            created_at, created_from_event_id
+        ) VALUES (
+            'local', 1, 'prompt-v1', 'schema-v1', 'judge-v1',
+            'prompt-fingerprint', 'config-fingerprint',
+            'profile-fingerprint', 'custom-fingerprint',
+            '{}', '{}', '{}', NULL, '', '2026-08-01T02:00:00Z', NULL
+        )
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO tailoring_policies (
+            tenant_id, version, prompt_version, schema_version,
+            judge_schema_version, prompt_fingerprint, config_fingerprint,
+            profile_policy_fingerprint, custom_prompt_fingerprint,
+            generator_settings_json, judge_settings_json,
+            runtime_settings_json, rollback_of_version, rollback_reason,
+            created_at, created_from_event_id
+        ) VALUES (
+            'local', 2, 'prompt-v1', 'schema-v1', 'judge-v1',
+            'prompt-fingerprint', 'config-fingerprint-2',
+            'profile-fingerprint', 'custom-fingerprint',
+            '{}', '{}', '{}', NULL, '', '2026-08-01T02:00:01Z', NULL
+        )
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO learning_recommendation_reviews (
+            tenant_id, review_id, recommendation_id, revision, decision,
+            context, policy_kind, policy_version, reviewed_at
+        ) VALUES (
+            'local', 'review-rejected', 'recommendation-rejected', 1,
+            'rejected', 'materials', 'tailoring_rule', NULL,
+            '2026-08-01T02:01:00Z'
+        )
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO learning_recommendation_reviews (
+            tenant_id, review_id, recommendation_id, revision, decision,
+            context, policy_kind, policy_version, reviewed_at
+        ) VALUES (
+            'local', 'review-accepted', 'recommendation-accepted', 1,
+            'accepted', 'materials', 'tailoring_rule', 1,
+            '2026-08-01T02:02:00Z'
+        )
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO learning_recommendation_reviews (
+            tenant_id, review_id, recommendation_id, revision, decision,
+            context, policy_kind, policy_version, reviewed_at
+        ) VALUES (
+            'local', 'review-later-rejected', 'recommendation-later-accepted', 1,
+            'rejected', 'materials', 'tailoring_rule', NULL,
+            '2026-08-01T02:03:00Z'
+        )
+        """
+    )
+
+    with pytest.raises(sqlite3.IntegrityError, match="append-only"):
+        conn.execute(
+            """
+            INSERT OR REPLACE INTO learning_recommendation_reviews (
+                tenant_id, review_id, recommendation_id, revision, decision,
+                context, policy_kind, policy_version, reviewed_at
+            ) VALUES (
+                'local', 'review-rejected', 'recommendation-rejected', 1,
+                'rejected', 'materials', 'tailoring_rule', NULL,
+                '2026-08-01T03:00:00Z'
+            )
+            """
+        )
+    with pytest.raises(sqlite3.IntegrityError, match="contiguous"):
+        conn.execute(
+            """
+            INSERT INTO learning_recommendation_reviews (
+                tenant_id, review_id, recommendation_id, revision, decision,
+                context, policy_kind, policy_version, reviewed_at
+            ) VALUES (
+                'local', 'review-later-accepted-gap',
+                'recommendation-later-accepted', 3, 'accepted',
+                'materials', 'tailoring_rule', 2, '2026-08-01T03:01:00Z'
+            )
+            """
+        )
+    conn.execute(
+        """
+        INSERT INTO learning_recommendation_reviews (
+            tenant_id, review_id, recommendation_id, revision, decision,
+            context, policy_kind, policy_version, reviewed_at
+        ) VALUES (
+            'local', 'review-later-accepted',
+            'recommendation-later-accepted', 2, 'accepted',
+            'materials', 'tailoring_rule', 2, '2026-08-01T03:02:00Z'
+        )
+        """
+    )
+    with pytest.raises(sqlite3.IntegrityError, match="append-only"):
+        conn.execute(
+            """
+            INSERT INTO learning_recommendation_reviews (
+                tenant_id, review_id, recommendation_id, revision, decision,
+                context, policy_kind, policy_version, reviewed_at
+            ) VALUES (
+                'local', 'review-after-accepted',
+                'recommendation-later-accepted', 3, 'rejected',
+                'materials', 'tailoring_rule', NULL, '2026-08-01T03:03:00Z'
+            )
+            """
+        )
+    for decision, policy_version in (("accepted", None), ("rejected", 1)):
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute(
+                """
+                INSERT INTO learning_recommendation_reviews (
+                    tenant_id, review_id, recommendation_id, revision, decision,
+                    context, policy_kind, policy_version, reviewed_at
+                ) VALUES (
+                    'local', ?, 'recommendation-rejected', 2, ?,
+                    'materials', 'tailoring_rule', ?, '2026-08-01T04:00:00Z'
+                )
+                """,
+                (f"review-invalid-{decision}", decision, policy_version),
+            )
+    for statement in (
+        "UPDATE learning_recommendation_reviews SET reviewed_at = reviewed_at WHERE review_id = 'review-rejected'",
+        "DELETE FROM learning_recommendation_reviews WHERE review_id = 'review-accepted'",
+    ):
+        with pytest.raises(sqlite3.IntegrityError, match="append-only"):
+            conn.execute(statement)
 
     assert conn.execute("PRAGMA foreign_key_check").fetchone() is None
     close_connection(db_path)

--- a/workers/automation/tests/test_exact_v7_schema.py
+++ b/workers/automation/tests/test_exact_v7_schema.py
@@ -43,6 +43,7 @@ _CROSS_RUNTIME_DURABLE_TABLES = {
     "resume_review_drafts",
     "resume_review_edit_deltas",
     "tailoring_feedback_signals",
+    "tailoring_feedback_signal_contradictions",
     "tailoring_feedback_signal_reviews",
     "worker_runtime_heartbeats",
 }
@@ -537,6 +538,75 @@ def test_tailoring_feedback_reviews_are_structured_append_only_facts(
         """,
         ("2026-08-01T00:02:00Z",),
     )
+    conn.execute(
+        """
+        INSERT INTO tailoring_feedback_signals (
+            tenant_id, signal_id, job_id, draft_id, source_kind, source_id,
+            signal_kind, status, summary, created_at
+        ) VALUES (
+            'local', 'signal-2', ?, 'draft-1', 'comment_reply', 'reply-2',
+            'factual_correction', 'candidate', 'private contradiction text', ?
+        )
+        """,
+        (job_id, "2026-08-01T00:01:30Z"),
+    )
+    conn.execute(
+        """
+        INSERT INTO tailoring_feedback_signal_reviews (
+            tenant_id, review_id, signal_id, revision, decision, signal_kind,
+            rule_key, rule_value, allowlist_version, reviewed_at
+        ) VALUES (
+            'local', 'review-2', 'signal-2', 1, 'accepted',
+            'factual_correction', 'fact_handling', 'require_source_match', 1, ?
+        )
+        """,
+        ("2026-08-01T00:02:30Z",),
+    )
+    conn.execute(
+        """
+        INSERT INTO tailoring_feedback_signal_contradictions (
+            tenant_id, contradiction_id, signal_id, signal_revision,
+            signal_job_id, contradicting_signal_id,
+            contradicting_signal_revision, contradicting_signal_job_id,
+            recorded_at
+        ) VALUES (
+            'local', 'contradiction-1', 'signal-1', 1, ?,
+            'signal-2', 1, ?, '2026-08-01T00:03:00Z'
+        )
+        """,
+        (job_id, job_id),
+    )
+
+    with pytest.raises(sqlite3.IntegrityError):
+        conn.execute(
+            """
+            INSERT INTO tailoring_feedback_signal_contradictions (
+                tenant_id, contradiction_id, signal_id, signal_revision,
+                signal_job_id, contradicting_signal_id,
+                contradicting_signal_revision, contradicting_signal_job_id,
+                recorded_at
+            ) VALUES (
+                'local', 'contradiction-reversed', 'signal-2', 1, ?,
+                'signal-1', 1, ?, '2026-08-01T00:03:00Z'
+            )
+            """,
+            (job_id, job_id),
+        )
+    with pytest.raises(sqlite3.IntegrityError, match="append-only"):
+        conn.execute(
+            """
+            UPDATE tailoring_feedback_signal_contradictions
+            SET recorded_at = '2026-08-01T00:04:00Z'
+            WHERE contradiction_id = 'contradiction-1'
+            """
+        )
+    with pytest.raises(sqlite3.IntegrityError, match="append-only"):
+        conn.execute(
+            """
+            DELETE FROM tailoring_feedback_signal_contradictions
+            WHERE contradiction_id = 'contradiction-1'
+            """
+        )
 
     with pytest.raises(sqlite3.IntegrityError):
         conn.execute(
@@ -612,9 +682,16 @@ def test_tailoring_feedback_reviews_are_structured_append_only_facts(
     assert [
         tuple(row)
         for row in conn.execute(
-            "SELECT decision, rule_key, rule_value FROM tailoring_feedback_signal_reviews"
+            """
+            SELECT decision, rule_key, rule_value
+            FROM tailoring_feedback_signal_reviews
+            ORDER BY review_id
+            """
         ).fetchall()
-    ] == [("accepted", "fact_handling", "require_source_match")]
+    ] == [
+        ("accepted", "fact_handling", "require_source_match"),
+        ("accepted", "fact_handling", "require_source_match"),
+    ]
     assert conn.execute("PRAGMA foreign_key_check").fetchone() is None
 
     indexes = {
@@ -625,6 +702,16 @@ def test_tailoring_feedback_reviews_are_structured_append_only_facts(
         "idx_tailoring_feedback_signal_reviews_signal",
         "idx_tailoring_feedback_signal_reviews_decision",
     } <= indexes
+    contradiction_indexes = {
+        str(index[1])
+        for index in conn.execute(
+            "PRAGMA index_list(tailoring_feedback_signal_contradictions)"
+        )
+    }
+    assert {
+        "idx_tailoring_feedback_signal_contradictions_signal",
+        "idx_tailoring_feedback_signal_contradictions_other",
+    } <= contradiction_indexes
     close_connection(db_path)
 
 

--- a/workers/automation/tests/test_exact_v7_schema.py
+++ b/workers/automation/tests/test_exact_v7_schema.py
@@ -1206,7 +1206,7 @@ def test_learning_recommendation_reviews_are_append_only_and_policy_linked(
     for recommendation_id, fingerprint in (
         ("recommendation-rejected", "d"),
         ("recommendation-accepted", "e"),
-        ("recommendation-later-accepted", "f"),
+        ("recommendation-revision-gap", "f"),
     ):
         _insert_learning_recommendation_fixture(
             conn,
@@ -1271,19 +1271,6 @@ def test_learning_recommendation_reviews_are_append_only_and_policy_linked(
         )
         """
     )
-    conn.execute(
-        """
-        INSERT INTO learning_recommendation_reviews (
-            tenant_id, review_id, recommendation_id, revision, decision,
-            context, policy_kind, policy_version, reviewed_at
-        ) VALUES (
-            'local', 'review-later-rejected', 'recommendation-later-accepted', 1,
-            'rejected', 'materials', 'tailoring_rule', NULL,
-            '2026-08-01T02:03:00Z'
-        )
-        """
-    )
-
     with pytest.raises(sqlite3.IntegrityError, match="append-only"):
         conn.execute(
             """
@@ -1305,23 +1292,24 @@ def test_learning_recommendation_reviews_are_append_only_and_policy_linked(
                 context, policy_kind, policy_version, reviewed_at
             ) VALUES (
                 'local', 'review-later-accepted-gap',
-                'recommendation-later-accepted', 3, 'accepted',
+                'recommendation-revision-gap', 3, 'accepted',
                 'materials', 'tailoring_rule', 2, '2026-08-01T03:01:00Z'
             )
             """
         )
-    conn.execute(
-        """
-        INSERT INTO learning_recommendation_reviews (
-            tenant_id, review_id, recommendation_id, revision, decision,
-            context, policy_kind, policy_version, reviewed_at
-        ) VALUES (
-            'local', 'review-later-accepted',
-            'recommendation-later-accepted', 2, 'accepted',
-            'materials', 'tailoring_rule', 2, '2026-08-01T03:02:00Z'
+    with pytest.raises(sqlite3.IntegrityError, match="append-only"):
+        conn.execute(
+            """
+            INSERT INTO learning_recommendation_reviews (
+                tenant_id, review_id, recommendation_id, revision, decision,
+                context, policy_kind, policy_version, reviewed_at
+            ) VALUES (
+                'local', 'review-after-rejected',
+                'recommendation-rejected', 2, 'accepted',
+                'materials', 'tailoring_rule', 2, '2026-08-01T03:02:00Z'
+            )
+            """
         )
-        """
-    )
     with pytest.raises(sqlite3.IntegrityError, match="append-only"):
         conn.execute(
             """
@@ -1330,7 +1318,7 @@ def test_learning_recommendation_reviews_are_append_only_and_policy_linked(
                 context, policy_kind, policy_version, reviewed_at
             ) VALUES (
                 'local', 'review-after-accepted',
-                'recommendation-later-accepted', 3, 'rejected',
+                'recommendation-accepted', 2, 'rejected',
                 'materials', 'tailoring_rule', NULL, '2026-08-01T03:03:00Z'
             )
             """
@@ -1343,7 +1331,7 @@ def test_learning_recommendation_reviews_are_append_only_and_policy_linked(
                     tenant_id, review_id, recommendation_id, revision, decision,
                     context, policy_kind, policy_version, reviewed_at
                 ) VALUES (
-                    'local', ?, 'recommendation-rejected', 2, ?,
+                    'local', ?, 'recommendation-revision-gap', 1, ?,
                     'materials', 'tailoring_rule', ?, '2026-08-01T04:00:00Z'
                 )
                 """,

--- a/workers/automation/tests/test_materials_repository.py
+++ b/workers/automation/tests/test_materials_repository.py
@@ -29,7 +29,11 @@ from jobctrl.domain.materials import (
     RenderFormat,
     ValidationResult,
 )
-from jobctrl.domain.materials.policy import TailoringPolicy
+from jobctrl.domain.materials.policy import (
+    LearnedTailoringRules,
+    TailoringPolicy,
+    TailoringPolicyChangedError,
+)
 from jobctrl.domain.tenant import LOCAL_TENANT
 from jobctrl.infrastructure.materials import (
     MaterialsGenerationConflict,
@@ -843,6 +847,70 @@ def _policy(*, fingerprint: str = "sha256:a", version: int = 1) -> TailoringPoli
         runtime_settings={"validation_mode": "normal"},
         created_at="2026-05-26T00:00:00+00:00",
     )
+
+
+@pytest.mark.parametrize(
+    ("rule_key", "rule_value"),
+    [
+        ("style_guidance", "preserve_user_edit_pattern"),
+        ("fact_handling", "require_source_match"),
+        ("claim_policy", "omit_unsupported_claims"),
+        ("keyword_strategy", "use_supported_terms_only"),
+        ("provenance_policy", "require_direct_evidence"),
+    ],
+)
+def test_learned_tailoring_rules_accept_only_closed_pairs(
+    rule_key: str,
+    rule_value: str,
+) -> None:
+    rules = LearnedTailoringRules.from_mapping({rule_key: rule_value})
+    assert rules.to_dict() == {rule_key: rule_value}
+    assert f"{rule_key}={rule_value}" in rules.prompt_lines()[0]
+
+
+def test_learned_tailoring_rules_fail_closed_and_fingerprint_canonically() -> None:
+    with pytest.raises(ValueError, match="versioned allowlist"):
+        LearnedTailoringRules.from_mapping({"fact_handling": "private free text"})
+
+    left = LearnedTailoringRules.from_mapping(
+        {
+            "provenance_policy": "require_direct_evidence",
+            "fact_handling": "require_source_match",
+        }
+    )
+    right = LearnedTailoringRules.from_mapping(
+        {
+            "fact_handling": "require_source_match",
+            "provenance_policy": "require_direct_evidence",
+        }
+    )
+    left_policy = _policy().with_learned_tailoring_rules(left)
+    right_policy = _policy().with_learned_tailoring_rules(right)
+    assert left_policy.runtime_settings == right_policy.runtime_settings
+    assert left_policy.config_fingerprint == right_policy.config_fingerprint
+
+
+def test_tailoring_policy_repository_carries_learned_rules_forward(
+    conn: sqlite3.Connection,
+) -> None:
+    repo = SqliteTailoringPolicyRepository(conn)
+    learned = LearnedTailoringRules.from_mapping(
+        {"fact_handling": "require_source_match"}
+    )
+    first = repo.resolve_current(_policy().with_learned_tailoring_rules(learned))
+
+    second = repo.resolve_current(
+        _policy(fingerprint="sha256:new-runtime"),
+        expected_current_version=first.version,
+    )
+
+    assert second.version == first.version + 1
+    assert second.learned_tailoring_rules == learned
+    with pytest.raises(TailoringPolicyChangedError):
+        repo.resolve_current(
+            _policy(fingerprint="sha256:stale"),
+            expected_current_version=first.version,
+        )
 
 
 def test_tailoring_policy_repository_reuses_same_config(conn: sqlite3.Connection) -> None:

--- a/workers/automation/tests/test_rpc_learning_recommendations.py
+++ b/workers/automation/tests/test_rpc_learning_recommendations.py
@@ -1,0 +1,132 @@
+"""Learning recommendation JSON-RPC trigger contracts."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from jobctrl.database import close_connection, init_db
+from jobctrl.domain.rpc.messages import JsonRpcRequest
+from jobctrl.infrastructure.rpc import handlers as handlers_mod
+from jobctrl.infrastructure.rpc.handlers import register_default_handlers
+from jobctrl.infrastructure.rpc.server import JsonRpcServer
+
+
+async def _stub_starter(_spec):  # pragma: no cover - sync handler only
+    raise AssertionError("workflow starter must not be called")
+
+
+async def _stub_canceler(_run_id: str) -> None:  # pragma: no cover - not called
+    return None
+
+
+def test_review_trigger_derives_once_and_replays_idempotently(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    conn = init_db(db_path)
+    job_ids = (
+        "11111111-1111-4111-8111-111111111111",
+        "22222222-2222-4222-8222-222222222222",
+    )
+    for index, job_id in enumerate(job_ids, start=1):
+        conn.execute(
+            "INSERT INTO jobs (tenant_id, job_id, url) VALUES ('local', ?, ?)",
+            (job_id, f"https://jobs.example/{index}"),
+        )
+    for index, job_id in enumerate((job_ids[0], job_ids[0], job_ids[1]), start=1):
+        signal_id = f"signal-{index}"
+        conn.execute(
+            """
+            INSERT INTO resume_review_drafts (
+                tenant_id, draft_id, job_id, base_generation, renderer_format,
+                state, latest_revision_number, created_at, updated_at
+            ) VALUES ('local', ?, ?, 1, 'text', 'active', 0, ?, ?)
+            """,
+            (
+                f"draft-{index}",
+                job_id,
+                "2026-08-01T10:00:00Z",
+                "2026-08-01T10:00:00Z",
+            ),
+        )
+        conn.execute(
+            """
+            INSERT INTO tailoring_feedback_signals (
+                tenant_id, signal_id, job_id, draft_id, source_kind,
+                source_id, signal_kind, status, summary, created_at,
+                reviewed_at
+            ) VALUES (
+                'local', ?, ?, ?, 'edit_delta', ?, 'factual_correction',
+                'accepted', 'private source text', ?, ?
+            )
+            """,
+            (
+                signal_id,
+                job_id,
+                f"draft-{index}",
+                f"private-delta-{index}",
+                "2026-08-01T10:00:00Z",
+                f"2026-08-01T10:00:0{index}Z",
+            ),
+        )
+        conn.execute(
+            """
+            INSERT INTO tailoring_feedback_signal_reviews (
+                tenant_id, review_id, signal_id, revision, decision,
+                signal_kind, rule_key, rule_value, allowlist_version,
+                reviewed_at
+            ) VALUES (
+                'local', ?, ?, 1, 'accepted', 'factual_correction',
+                'fact_handling', 'require_source_match', 1, ?
+            )
+            """,
+            (f"review-{index}", signal_id, f"2026-08-01T10:00:0{index}Z"),
+        )
+    conn.commit()
+    monkeypatch.setattr(handlers_mod, "get_connection", lambda: conn)
+    server = JsonRpcServer(workflow_starter=_stub_starter)
+    register_default_handlers(server, canceler=_stub_canceler)
+
+    first = server.dispatch(
+        JsonRpcRequest(
+            method="rederive_learning_recommendations",
+            params={"tenantId": "local"},
+            id=1,
+        )
+    )
+    replay = server.dispatch(
+        JsonRpcRequest(
+            method="rederive_learning_recommendations",
+            params={"tenantId": "local"},
+            id=2,
+        )
+    )
+
+    assert first is not None
+    assert replay is not None
+    first_result = first.to_dict()["result"]
+    replay_result = replay.to_dict()["result"]
+    assert first_result["status"] == "succeeded"
+    assert first_result["recommendationCount"] == 1
+    assert replay_result["recommendationIds"] == first_result["recommendationIds"]
+    assert conn.execute("SELECT COUNT(*) FROM learning_recommendations").fetchone()[0] == 1
+    assert conn.execute(
+        "SELECT COUNT(*) FROM learning_recommendation_evidence"
+    ).fetchone()[0] == 3
+    assert conn.execute(
+        "SELECT COUNT(*) FROM learning_recommendation_jobs"
+    ).fetchone()[0] == 2
+    learning_dump = "\n".join(
+        repr(tuple(row))
+        for table in (
+            "learning_recommendations",
+            "learning_recommendation_evidence",
+            "learning_recommendation_evidence_jobs",
+            "learning_recommendation_jobs",
+        )
+        for row in conn.execute(f"SELECT * FROM {table}").fetchall()
+    )
+    assert "private source text" not in learning_dump
+    assert "private-delta" not in learning_dump
+    close_connection(db_path)

--- a/workers/automation/tests/test_rpc_learning_recommendations.py
+++ b/workers/automation/tests/test_rpc_learning_recommendations.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
 from pathlib import Path
 
 from jobctrl.database import close_connection, init_db
@@ -167,6 +168,85 @@ def test_explicit_review_accepts_atomically_and_replays(
     assert conn.execute(
         "SELECT COUNT(*) FROM learning_recommendation_reviews"
     ).fetchone()[0] == 1
+    close_connection(db_path)
+
+
+def test_explicit_policy_rollback_appends_once_and_replays(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    conn = init_db(db_path)
+    policy_repository = SqliteTailoringPolicyRepository(conn)
+    original = _tailoring_policy()
+    policy_repository.save(original)
+    policy_repository.save(
+        original.with_learned_tailoring_rule(
+            rule_key="fact_handling",
+            rule_value="require_source_match",
+            version=2,
+            created_at="2026-08-01T11:00:00Z",
+        )
+    )
+    policy_repository.save(
+        replace(
+            original,
+            version=3,
+            rollback_of_version=1,
+            rollback_reason="private historical rollback narrative",
+            created_at="2026-08-01T11:30:00Z",
+        )
+    )
+    monkeypatch.setattr(handlers_mod, "get_connection", lambda: conn)
+    runtime_expectations: list[dict[str, str | None]] = []
+    monkeypatch.setattr(
+        handlers_mod,
+        "assert_expected_runtime",
+        lambda **kwargs: runtime_expectations.append(kwargs),
+    )
+    server = JsonRpcServer(workflow_starter=_stub_starter)
+    register_default_handlers(server, canceler=_stub_canceler)
+    params = {
+        "tenantId": "local",
+        "targetVersion": 1,
+        "expectedAppDir": "/tmp/jobctrl",
+        "expectedDbPath": "/tmp/jobctrl/jobctrl.db",
+    }
+
+    first = server.dispatch(
+        JsonRpcRequest(method="rollback_tailoring_policy", params=params, id=1)
+    )
+    replay = server.dispatch(
+        JsonRpcRequest(method="rollback_tailoring_policy", params=params, id=2)
+    )
+
+    assert first is not None
+    assert replay is not None
+    first_result = first.to_dict()["result"]
+    replay_result = replay.to_dict()["result"]
+    assert first_result["policyVersion"] == 4
+    assert first_result["rollbackOfVersion"] == 1
+    assert first_result["rollbackReasonCode"] == "user_requested"
+    assert first_result["learnedRules"] == []
+    assert replay_result == first_result
+    assert runtime_expectations == [
+        {
+            "expected_app_dir": "/tmp/jobctrl",
+            "expected_db_path": "/tmp/jobctrl/jobctrl.db",
+        },
+        {
+            "expected_app_dir": "/tmp/jobctrl",
+            "expected_db_path": "/tmp/jobctrl/jobctrl.db",
+        },
+    ]
+    assert [
+        policy.version for policy in policy_repository.list_history(LOCAL_TENANT)
+    ] == [4, 3, 2, 1]
+    accepted_policy = policy_repository.get_version(LOCAL_TENANT, 2)
+    assert accepted_policy is not None
+    assert accepted_policy.learned_tailoring_rules.to_dict() == {
+        "fact_handling": "require_source_match"
+    }
     close_connection(db_path)
 
 

--- a/workers/automation/tests/test_rpc_learning_recommendations.py
+++ b/workers/automation/tests/test_rpc_learning_recommendations.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 from pathlib import Path
 
 from jobctrl.database import close_connection, init_db
-from jobctrl.domain.rpc.messages import JsonRpcRequest
+from jobctrl.domain.materials.policy import TailoringPolicy
+from jobctrl.domain.rpc.messages import INVALID_PARAMS, JsonRpcRequest
+from jobctrl.domain.tenant import LOCAL_TENANT
+from jobctrl.infrastructure.materials import SqliteTailoringPolicyRepository
 from jobctrl.infrastructure.rpc import handlers as handlers_mod
 from jobctrl.infrastructure.rpc.handlers import register_default_handlers
 from jobctrl.infrastructure.rpc.server import JsonRpcServer
@@ -25,6 +28,149 @@ def test_review_trigger_derives_once_and_replays_idempotently(
 ) -> None:
     db_path = tmp_path / "jobctrl.db"
     conn = init_db(db_path)
+    _seed_recommendation_sources(conn)
+    monkeypatch.setattr(handlers_mod, "get_connection", lambda: conn)
+    server = JsonRpcServer(workflow_starter=_stub_starter)
+    register_default_handlers(server, canceler=_stub_canceler)
+
+    first = server.dispatch(
+        JsonRpcRequest(
+            method="rederive_learning_recommendations",
+            params={"tenantId": "local"},
+            id=1,
+        )
+    )
+    replay = server.dispatch(
+        JsonRpcRequest(
+            method="rederive_learning_recommendations",
+            params={"tenantId": "local"},
+            id=2,
+        )
+    )
+
+    assert first is not None
+    assert replay is not None
+    first_result = first.to_dict()["result"]
+    replay_result = replay.to_dict()["result"]
+    assert first_result["status"] == "succeeded"
+    assert first_result["recommendationCount"] == 1
+    assert replay_result["recommendationIds"] == first_result["recommendationIds"]
+    assert conn.execute("SELECT COUNT(*) FROM learning_recommendations").fetchone()[0] == 1
+    assert conn.execute(
+        "SELECT COUNT(*) FROM learning_recommendation_evidence"
+    ).fetchone()[0] == 3
+    assert conn.execute(
+        "SELECT COUNT(*) FROM learning_recommendation_jobs"
+    ).fetchone()[0] == 2
+    learning_dump = "\n".join(
+        repr(tuple(row))
+        for table in (
+            "learning_recommendations",
+            "learning_recommendation_evidence",
+            "learning_recommendation_evidence_jobs",
+            "learning_recommendation_jobs",
+        )
+        for row in conn.execute(f"SELECT * FROM {table}").fetchall()
+    )
+    assert "private source text" not in learning_dump
+    assert "private-delta" not in learning_dump
+    close_connection(db_path)
+
+
+def test_explicit_review_accepts_atomically_and_replays(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    conn = init_db(db_path)
+    _seed_recommendation_sources(conn)
+    monkeypatch.setattr(handlers_mod, "get_connection", lambda: conn)
+    server = JsonRpcServer(workflow_starter=_stub_starter)
+    register_default_handlers(server, canceler=_stub_canceler)
+    derived = server.dispatch(
+        JsonRpcRequest(
+            method="rederive_learning_recommendations",
+            params={"tenantId": "local"},
+            id=1,
+        )
+    )
+    assert derived is not None
+    recommendation_id = derived.to_dict()["result"]["recommendationIds"][0]
+    policy_repository = SqliteTailoringPolicyRepository(conn)
+    policy_repository.save(_tailoring_policy())
+    runtime_expectations: list[dict[str, str | None]] = []
+    monkeypatch.setattr(
+        handlers_mod,
+        "assert_expected_runtime",
+        lambda **kwargs: runtime_expectations.append(kwargs),
+    )
+    params = {
+        "tenantId": "local",
+        "recommendationId": recommendation_id,
+        "decision": "accepted",
+        "expectedAppDir": "/tmp/jobctrl",
+        "expectedDbPath": "/tmp/jobctrl/jobctrl.db",
+    }
+
+    first = server.dispatch(
+        JsonRpcRequest(
+            method="review_learning_recommendation",
+            params=params,
+            id=2,
+        )
+    )
+    replay = server.dispatch(
+        JsonRpcRequest(
+            method="review_learning_recommendation",
+            params=params,
+            id=3,
+        )
+    )
+
+    assert first is not None
+    assert replay is not None
+    first_result = first.to_dict()["result"]
+    replay_result = replay.to_dict()["result"]
+    assert first_result["decision"] == "accepted"
+    assert first_result["policyVersion"] == 2
+    assert replay_result["reviewId"] == first_result["reviewId"]
+    assert replay_result["policyVersion"] == first_result["policyVersion"]
+    assert runtime_expectations == [
+        {
+            "expected_app_dir": "/tmp/jobctrl",
+            "expected_db_path": "/tmp/jobctrl/jobctrl.db",
+        },
+        {
+            "expected_app_dir": "/tmp/jobctrl",
+            "expected_db_path": "/tmp/jobctrl/jobctrl.db",
+        },
+    ]
+    current = policy_repository.get_current(LOCAL_TENANT)
+    assert current is not None
+    assert current.learned_tailoring_rules.to_dict() == {
+        "fact_handling": "require_source_match"
+    }
+    assert conn.execute(
+        "SELECT COUNT(*) FROM learning_recommendation_reviews"
+    ).fetchone()[0] == 1
+    assert conn.execute("SELECT COUNT(*) FROM tailoring_policies").fetchone()[0] == 2
+
+    rejected = server.dispatch(
+        JsonRpcRequest(
+            method="review_learning_recommendation",
+            params={**params, "decision": "rejected"},
+            id=4,
+        )
+    )
+    assert rejected is not None
+    assert rejected.to_dict()["error"]["code"] == INVALID_PARAMS
+    assert conn.execute(
+        "SELECT COUNT(*) FROM learning_recommendation_reviews"
+    ).fetchone()[0] == 1
+    close_connection(db_path)
+
+
+def _seed_recommendation_sources(conn) -> None:
     job_ids = (
         "11111111-1111-4111-8111-111111111111",
         "22222222-2222-4222-8222-222222222222",
@@ -84,49 +230,21 @@ def test_review_trigger_derives_once_and_replays_idempotently(
             (f"review-{index}", signal_id, f"2026-08-01T10:00:0{index}Z"),
         )
     conn.commit()
-    monkeypatch.setattr(handlers_mod, "get_connection", lambda: conn)
-    server = JsonRpcServer(workflow_starter=_stub_starter)
-    register_default_handlers(server, canceler=_stub_canceler)
 
-    first = server.dispatch(
-        JsonRpcRequest(
-            method="rederive_learning_recommendations",
-            params={"tenantId": "local"},
-            id=1,
-        )
-    )
-    replay = server.dispatch(
-        JsonRpcRequest(
-            method="rederive_learning_recommendations",
-            params={"tenantId": "local"},
-            id=2,
-        )
-    )
 
-    assert first is not None
-    assert replay is not None
-    first_result = first.to_dict()["result"]
-    replay_result = replay.to_dict()["result"]
-    assert first_result["status"] == "succeeded"
-    assert first_result["recommendationCount"] == 1
-    assert replay_result["recommendationIds"] == first_result["recommendationIds"]
-    assert conn.execute("SELECT COUNT(*) FROM learning_recommendations").fetchone()[0] == 1
-    assert conn.execute(
-        "SELECT COUNT(*) FROM learning_recommendation_evidence"
-    ).fetchone()[0] == 3
-    assert conn.execute(
-        "SELECT COUNT(*) FROM learning_recommendation_jobs"
-    ).fetchone()[0] == 2
-    learning_dump = "\n".join(
-        repr(tuple(row))
-        for table in (
-            "learning_recommendations",
-            "learning_recommendation_evidence",
-            "learning_recommendation_evidence_jobs",
-            "learning_recommendation_jobs",
-        )
-        for row in conn.execute(f"SELECT * FROM {table}").fetchall()
+def _tailoring_policy() -> TailoringPolicy:
+    return TailoringPolicy(
+        tenant_id=LOCAL_TENANT,
+        version=1,
+        prompt_version="tailor.v2.quality-gated",
+        schema_version="tailored-resume.v1",
+        judge_schema_version="tailor-judge.v1",
+        prompt_fingerprint="sha256:prompt",
+        config_fingerprint="sha256:config",
+        profile_policy_fingerprint="sha256:profile",
+        custom_prompt_fingerprint="sha256:custom",
+        generator_settings={"candidate_models": ["local:draft"]},
+        judge_settings={"judge_model": "local:judge", "min_score": 0.82},
+        runtime_settings={"validation_mode": "normal"},
+        created_at="2026-08-01T10:00:00Z",
     )
-    assert "private source text" not in learning_dump
-    assert "private-delta" not in learning_dump
-    close_connection(db_path)

--- a/workers/automation/tests/test_rpc_learning_recommendations.py
+++ b/workers/automation/tests/test_rpc_learning_recommendations.py
@@ -171,6 +171,73 @@ def test_explicit_review_accepts_atomically_and_replays(
     close_connection(db_path)
 
 
+def test_explicit_review_rejection_is_terminal_and_replays(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    conn = init_db(db_path)
+    _seed_recommendation_sources(conn)
+    monkeypatch.setattr(handlers_mod, "get_connection", lambda: conn)
+    server = JsonRpcServer(workflow_starter=_stub_starter)
+    register_default_handlers(server, canceler=_stub_canceler)
+    derived = server.dispatch(
+        JsonRpcRequest(
+            method="rederive_learning_recommendations",
+            params={"tenantId": "local"},
+            id=1,
+        )
+    )
+    assert derived is not None
+    recommendation_id = derived.to_dict()["result"]["recommendationIds"][0]
+    policy_repository = SqliteTailoringPolicyRepository(conn)
+    original_policy = _tailoring_policy()
+    policy_repository.save(original_policy)
+    params = {
+        "tenantId": "local",
+        "recommendationId": recommendation_id,
+        "decision": "rejected",
+    }
+
+    rejected = server.dispatch(
+        JsonRpcRequest(
+            method="review_learning_recommendation",
+            params=params,
+            id=2,
+        )
+    )
+    replay = server.dispatch(
+        JsonRpcRequest(
+            method="review_learning_recommendation",
+            params=params,
+            id=3,
+        )
+    )
+    accepted = server.dispatch(
+        JsonRpcRequest(
+            method="review_learning_recommendation",
+            params={**params, "decision": "accepted"},
+            id=4,
+        )
+    )
+
+    assert rejected is not None
+    assert replay is not None
+    assert accepted is not None
+    rejected_result = rejected.to_dict()["result"]
+    replay_result = replay.to_dict()["result"]
+    assert rejected_result["decision"] == "rejected"
+    assert rejected_result["policyVersion"] is None
+    assert replay_result["reviewId"] == rejected_result["reviewId"]
+    assert accepted.to_dict()["error"]["code"] == INVALID_PARAMS
+    assert conn.execute(
+        "SELECT COUNT(*) FROM learning_recommendation_reviews"
+    ).fetchone()[0] == 1
+    assert policy_repository.get_current(LOCAL_TENANT) == original_policy
+    assert conn.execute("SELECT COUNT(*) FROM tailoring_policies").fetchone()[0] == 1
+    close_connection(db_path)
+
+
 def test_explicit_policy_rollback_appends_once_and_replays(
     tmp_path: Path,
     monkeypatch,

--- a/workers/automation/tests/test_sqlite_learning_recommendations.py
+++ b/workers/automation/tests/test_sqlite_learning_recommendations.py
@@ -24,6 +24,7 @@ from jobctrl.infrastructure.learning.sqlite_repository import (
     LearningRecommendationConflict,
     SqliteLearningRecommendationRepository,
 )
+from jobctrl.infrastructure.materials import sqlite_repository as materials_sqlite_repository
 from jobctrl.infrastructure.materials import (
     LearningRecommendationReviewError,
     SqliteLearningRecommendationReviewRepository,
@@ -892,7 +893,21 @@ def test_review_fails_closed_without_current_policy_or_for_tombstone(
     close_connection(db_path)
 
 
-def test_concurrent_accepts_serialize_and_preserve_both_rules(tmp_path: Path) -> None:
+def test_concurrent_accepts_serialize_and_preserve_both_rules(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    original_ensure = materials_sqlite_repository.ensure_tailoring_policy_tables
+
+    def ensure_before_immediate_transaction(conn):
+        assert not conn.in_transaction
+        return original_ensure(conn)
+
+    monkeypatch.setattr(
+        materials_sqlite_repository,
+        "ensure_tailoring_policy_tables",
+        ensure_before_immediate_transaction,
+    )
     db_path = tmp_path / "jobctrl.db"
     setup_conn = init_db(db_path)
     recommendations = (

--- a/workers/automation/tests/test_sqlite_learning_recommendations.py
+++ b/workers/automation/tests/test_sqlite_learning_recommendations.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
 from dataclasses import replace
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
+import threading
 
 import pytest
 
-from jobctrl.database import close_connection, init_db
+from jobctrl.database import close_connection, get_connection, init_db
 from jobctrl.domain.identifiers import JobId, canonical_job_id
+from jobctrl.domain.materials.policy import TailoringPolicy
 from jobctrl.domain.operations.feedback import TailoringFeedbackSignal
 from jobctrl.domain.operations.learning import (
     LearningSourceChange,
@@ -20,6 +23,11 @@ from jobctrl.domain.tenant import TenantId
 from jobctrl.infrastructure.learning.sqlite_repository import (
     LearningRecommendationConflict,
     SqliteLearningRecommendationRepository,
+)
+from jobctrl.infrastructure.materials import (
+    LearningRecommendationReviewError,
+    SqliteLearningRecommendationReviewRepository,
+    SqliteTailoringPolicyRepository,
 )
 
 
@@ -744,11 +752,273 @@ def test_multiple_source_changes_each_append_a_tombstone(tmp_path: Path) -> None
     close_connection(db_path)
 
 
+def test_review_rejects_without_policy_then_accepts_once(tmp_path: Path) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    conn = init_db(db_path)
+    recommendation = _recommendation(_TENANT_A)
+    SqliteLearningRecommendationRepository(conn).append_pending(
+        recommendation,
+        derived_at="2026-08-01T10:01:00Z",
+    )
+    policy_repository = SqliteTailoringPolicyRepository(conn)
+    original_policy = _tailoring_policy(_TENANT_A)
+    policy_repository.save(original_policy)
+    reviewer = SqliteLearningRecommendationReviewRepository(conn)
+
+    rejected = reviewer.review(
+        _TENANT_A,
+        recommendation_id=recommendation.recommendation_id,
+        decision="rejected",
+        reviewed_at="2026-08-01T11:00:00Z",
+    )
+    rejected_replay = reviewer.review(
+        _TENANT_A,
+        recommendation_id=recommendation.recommendation_id,
+        decision="rejected",
+        reviewed_at="2026-08-01T11:01:00Z",
+    )
+
+    assert rejected == rejected_replay
+    assert rejected.revision == 1
+    assert rejected.policy_version is None
+    assert policy_repository.get_current(_TENANT_A) == original_policy
+
+    accepted = reviewer.review(
+        _TENANT_A,
+        recommendation_id=recommendation.recommendation_id,
+        decision="accepted",
+        reviewed_at="2026-08-01T11:02:00Z",
+    )
+    accepted_replay = reviewer.review(
+        _TENANT_A,
+        recommendation_id=recommendation.recommendation_id,
+        decision="accepted",
+        reviewed_at="2026-08-01T11:03:00Z",
+    )
+
+    assert accepted == accepted_replay
+    assert accepted.revision == 2
+    assert accepted.policy_version == 2
+    assert policy_repository.get_current(_TENANT_A).learned_tailoring_rules.to_dict() == {
+        "fact_handling": "require_source_match"
+    }
+    assert conn.execute(
+        "SELECT COUNT(*) FROM learning_recommendation_reviews"
+    ).fetchone()[0] == 2
+    assert conn.execute("SELECT COUNT(*) FROM tailoring_policies").fetchone()[0] == 2
+    with pytest.raises(
+        LearningRecommendationReviewError,
+        match="terminal",
+    ):
+        reviewer.review(
+            _TENANT_A,
+            recommendation_id=recommendation.recommendation_id,
+            decision="rejected",
+            reviewed_at="2026-08-01T11:04:00Z",
+        )
+    close_connection(db_path)
+
+
+def test_review_fails_closed_without_current_policy_or_for_tombstone(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    conn = init_db(db_path)
+    recommendation = _recommendation(_TENANT_A)
+    SqliteLearningRecommendationRepository(conn).append_pending(
+        recommendation,
+        derived_at="2026-08-01T10:01:00Z",
+    )
+    reviewer = SqliteLearningRecommendationReviewRepository(conn)
+
+    with pytest.raises(
+        LearningRecommendationReviewError,
+        match="initialized tailoring policy",
+    ):
+        reviewer.review(
+            _TENANT_A,
+            recommendation_id=recommendation.recommendation_id,
+            decision="accepted",
+            reviewed_at="2026-08-01T11:00:00Z",
+        )
+    with pytest.raises(
+        LearningRecommendationReviewError,
+        match="does not exist for tenant",
+    ):
+        reviewer.review(
+            _TENANT_B,
+            recommendation_id=recommendation.recommendation_id,
+            decision="accepted",
+            reviewed_at="2026-08-01T11:00:00Z",
+        )
+    assert conn.execute(
+        "SELECT COUNT(*) FROM learning_recommendation_reviews"
+    ).fetchone()[0] == 0
+    assert conn.execute("SELECT COUNT(*) FROM tailoring_policies").fetchone()[0] == 0
+
+    SqliteTailoringPolicyRepository(conn).save(_tailoring_policy(_TENANT_A))
+    evidence = recommendation.evidence[0]
+    conn.execute(
+        """
+        INSERT INTO learning_recommendation_tombstones (
+            tenant_id, tombstone_id, recommendation_id, affected_signal_id,
+            affected_source_revision, reason_code, derivation_version,
+            tombstoned_at, rederived_at, replacement_recommendation_id
+        ) VALUES (?, ?, ?, ?, ?, 'source_deleted', 1, ?, ?, NULL)
+        """,
+        (
+            str(_TENANT_A),
+            "tombstone-review-fixture",
+            recommendation.recommendation_id,
+            evidence.signal_id,
+            evidence.source_revision,
+            "2026-08-01T11:01:00Z",
+            "2026-08-01T11:01:00Z",
+        ),
+    )
+    conn.commit()
+
+    with pytest.raises(LearningRecommendationReviewError, match="tombstoned"):
+        reviewer.review(
+            _TENANT_A,
+            recommendation_id=recommendation.recommendation_id,
+            decision="accepted",
+            reviewed_at="2026-08-01T11:02:00Z",
+        )
+    assert conn.execute(
+        "SELECT COUNT(*) FROM learning_recommendation_reviews"
+    ).fetchone()[0] == 0
+    assert conn.execute("SELECT COUNT(*) FROM tailoring_policies").fetchone()[0] == 1
+    close_connection(db_path)
+
+
+def test_concurrent_accepts_serialize_and_preserve_both_rules(tmp_path: Path) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    setup_conn = init_db(db_path)
+    recommendations = (
+        _recommendation(_TENANT_A),
+        _recommendation_for_effect(
+            _TENANT_A,
+            signal_kind="style_preference",
+            rule_key="style_guidance",
+            rule_value="preserve_user_edit_pattern",
+        ),
+    )
+    recommendation_repository = SqliteLearningRecommendationRepository(setup_conn)
+    for recommendation in recommendations:
+        recommendation_repository.append_pending(
+            recommendation,
+            derived_at="2026-08-01T10:01:00Z",
+        )
+    SqliteTailoringPolicyRepository(setup_conn).save(_tailoring_policy(_TENANT_A))
+    close_connection(db_path)
+    start = threading.Event()
+
+    def accept(recommendation_id: str):
+        conn = get_connection(db_path)
+        try:
+            start.wait(timeout=5)
+            return SqliteLearningRecommendationReviewRepository(conn).review(
+                _TENANT_A,
+                recommendation_id=recommendation_id,
+                decision="accepted",
+                reviewed_at="2026-08-01T11:00:00Z",
+            )
+        finally:
+            close_connection(db_path)
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        futures = [
+            executor.submit(accept, recommendation.recommendation_id)
+            for recommendation in recommendations
+        ]
+        start.set()
+        reviews = [future.result(timeout=10) for future in futures]
+
+    assert sorted(review.policy_version for review in reviews) == [2, 3]
+    check_conn = get_connection(db_path)
+    try:
+        current = SqliteTailoringPolicyRepository(check_conn).get_current(_TENANT_A)
+        assert current is not None
+        assert current.learned_tailoring_rules.to_dict() == {
+            "fact_handling": "require_source_match",
+            "style_guidance": "preserve_user_edit_pattern",
+        }
+        assert check_conn.execute(
+            "SELECT COUNT(*) FROM learning_recommendation_reviews"
+        ).fetchone()[0] == 2
+        assert check_conn.execute(
+            "SELECT COUNT(*) FROM tailoring_policies"
+        ).fetchone()[0] == 3
+    finally:
+        close_connection(db_path)
+
+
 def _recommendation(tenant_id: TenantId):
     return derive_tailoring_recommendations(
         _signals(tenant_id),
         contradictions={},
     )[0]
+
+
+def _recommendation_for_effect(
+    tenant_id: TenantId,
+    *,
+    signal_kind: str,
+    rule_key: str,
+    rule_value: str,
+):
+    scope = TailoringRecommendationScope(
+        tenant_id=tenant_id,
+        proposed_effect=TailoringRuleEffect(
+            signal_kind=signal_kind,
+            rule_key=rule_key,
+            rule_value=rule_value,
+            allowlist_version=1,
+        ),
+    )
+    signals = tuple(
+        TailoringFeedbackSignal(
+            signal_id=f"{signal_kind}-signal-{index}",
+            tenant_id=tenant_id,
+            job_id=job_id,
+            source_id=f"{signal_kind}-source-{index}",
+            source_revision=index,
+            recorded_at=f"2026-08-01T10:00:0{index}Z",
+            signal_kind=signal_kind,
+            rule_key=rule_key,
+            rule_value=rule_value,
+            allowlist_version=1,
+        )
+        for index, job_id in enumerate((_JOB_A, _JOB_A, _JOB_B), start=1)
+    )
+    return derive_tailoring_recommendations(
+        signals,
+        contradictions={
+            scope: TailoringContradictionEvidence(
+                signal_ids=(),
+                unresolved_signal_ids=(),
+            )
+        },
+    )[0]
+
+
+def _tailoring_policy(tenant_id: TenantId) -> TailoringPolicy:
+    return TailoringPolicy(
+        tenant_id=tenant_id,
+        version=1,
+        prompt_version="tailor.v2.quality-gated",
+        schema_version="tailored-resume.v1",
+        judge_schema_version="tailor-judge.v1",
+        prompt_fingerprint="sha256:prompt",
+        config_fingerprint="sha256:config",
+        profile_policy_fingerprint="sha256:profile",
+        custom_prompt_fingerprint="sha256:custom",
+        generator_settings={"candidate_models": ["local:draft"]},
+        judge_settings={"judge_model": "local:judge", "min_score": 0.82},
+        runtime_settings={"validation_mode": "normal"},
+        created_at="2026-08-01T10:00:00Z",
+    )
 
 
 def _signals(tenant_id: TenantId) -> tuple[TailoringFeedbackSignal, ...]:

--- a/workers/automation/tests/test_sqlite_learning_recommendations.py
+++ b/workers/automation/tests/test_sqlite_learning_recommendations.py
@@ -458,6 +458,203 @@ def test_source_deletion_tombstones_without_inventing_a_replacement(
     close_connection(db_path)
 
 
+def test_review_ledger_automatically_rederives_corrections_and_rejections(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    conn = init_db(db_path)
+    _seed_tailoring_sources(conn)
+    conn.commit()
+    repository = SqliteLearningRecommendationRepository(conn)
+
+    original = repository.rederive_tailoring(
+        _TENANT_A,
+        source_changes=None,
+        rederived_at="2026-08-01T11:00:00Z",
+    )[0]
+    _insert_tailoring_review(
+        conn,
+        signal_id="tailoring-1",
+        revision=2,
+        decision="accepted",
+        reviewed_at="2026-08-01T11:30:00Z",
+    )
+    conn.commit()
+
+    replacement = repository.rederive_tailoring(
+        _TENANT_A,
+        source_changes=None,
+        rederived_at="2026-08-01T11:31:00Z",
+    )[0]
+    assert replacement.recommendation_id != original.recommendation_id
+    assert tuple(
+        conn.execute(
+            """
+            SELECT reason_code, affected_signal_id,
+                   replacement_recommendation_id, tombstoned_at
+            FROM learning_recommendation_tombstones
+            WHERE recommendation_id = ?
+            """,
+            (original.recommendation_id,),
+        ).fetchone()
+    ) == (
+        "source_corrected",
+        "tailoring-feedback:tailoring-1:1",
+        replacement.recommendation_id,
+        "2026-08-01T11:30:00Z",
+    )
+
+    _insert_tailoring_review(
+        conn,
+        signal_id="tailoring-2",
+        revision=2,
+        decision="rejected",
+        reviewed_at="2026-08-01T12:00:00Z",
+    )
+    conn.commit()
+    assert (
+        repository.rederive_tailoring(
+            _TENANT_A,
+            source_changes=None,
+            rederived_at="2026-08-01T12:01:00Z",
+        )
+        == ()
+    )
+    assert [
+        tuple(row)
+        for row in conn.execute(
+            """
+            SELECT recommendation_id, reason_code, tombstoned_at
+            FROM learning_recommendation_tombstones
+            WHERE affected_signal_id = 'tailoring-feedback:tailoring-2:1'
+            ORDER BY recommendation_id
+            """
+        ).fetchall()
+    ] == [
+        (original.recommendation_id, "source_deleted", "2026-08-01T12:00:00Z"),
+        (replacement.recommendation_id, "source_deleted", "2026-08-01T12:00:00Z"),
+    ]
+    close_connection(db_path)
+
+
+def test_explicit_contradiction_ledger_blocks_until_one_side_is_resolved(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    conn = init_db(db_path)
+    _seed_tailoring_sources(conn)
+    conn.execute(
+        """
+        INSERT INTO resume_review_drafts (
+            tenant_id, draft_id, job_id, base_generation, renderer_format,
+            state, latest_revision_number, created_at, updated_at
+        ) VALUES (
+            'tenant-a', 'draft-4', ?, 1, 'text', 'active', 0, ?, ?
+        )
+        """,
+        (_JOB_B, "2026-08-01T10:00:00Z", "2026-08-01T10:00:00Z"),
+    )
+    conn.execute(
+        """
+        INSERT INTO tailoring_feedback_signals (
+            tenant_id, signal_id, job_id, draft_id, source_kind, source_id,
+            signal_kind, status, summary, created_at, reviewed_at
+        ) VALUES (
+            'tenant-a', 'tailoring-4', ?, 'draft-4', 'edit_delta',
+            'private-delta-4', 'factual_correction', 'accepted',
+            'private contradiction rationale', ?, ?
+        )
+        """,
+        (_JOB_B, "2026-08-01T10:00:00Z", "2026-08-01T10:00:04Z"),
+    )
+    _insert_tailoring_review(
+        conn,
+        signal_id="tailoring-4",
+        revision=1,
+        decision="accepted",
+        reviewed_at="2026-08-01T10:00:04Z",
+    )
+    conn.execute(
+        """
+        INSERT INTO tailoring_feedback_signal_contradictions (
+            tenant_id, contradiction_id, signal_id, signal_revision,
+            signal_job_id, contradicting_signal_id,
+            contradicting_signal_revision, contradicting_signal_job_id,
+            recorded_at
+        ) VALUES (
+            'tenant-a', 'contradiction-1-4', 'tailoring-1', 1, ?,
+            'tailoring-4', 1, ?, '2026-08-01T10:05:00Z'
+        )
+        """,
+        (_JOB_A, _JOB_B),
+    )
+    conn.commit()
+    repository = SqliteLearningRecommendationRepository(conn)
+
+    assert (
+        repository.rederive_tailoring(
+            _TENANT_A,
+            source_changes=None,
+            rederived_at="2026-08-01T11:00:00Z",
+        )
+        == ()
+    )
+    assert conn.execute("SELECT COUNT(*) FROM learning_recommendations").fetchone()[0] == 0
+
+    _insert_tailoring_review(
+        conn,
+        signal_id="tailoring-4",
+        revision=2,
+        decision="rejected",
+        reviewed_at="2026-08-01T11:30:00Z",
+    )
+    conn.commit()
+    recommendation = repository.rederive_tailoring(
+        _TENANT_A,
+        source_changes=None,
+        rederived_at="2026-08-01T11:31:00Z",
+    )[0]
+    assert recommendation.contradicting_signal_ids == (
+        "tailoring-feedback:tailoring-4:1",
+    )
+    assert [
+        tuple(row)
+        for row in conn.execute(
+            """
+            SELECT signal_id, evidence_role, source_id, source_revision
+            FROM learning_recommendation_evidence
+            WHERE recommendation_id = ?
+            ORDER BY evidence_role, signal_id
+            """,
+            (recommendation.recommendation_id,),
+        ).fetchall()
+    ][0] == (
+        "tailoring-feedback:tailoring-4:1",
+        "contradicting",
+        "tailoring-4",
+        1,
+    )
+    learning_dump = "\n".join(
+        repr(tuple(row))
+        for row in conn.execute(
+            "SELECT * FROM learning_recommendation_evidence"
+        ).fetchall()
+    )
+    assert "private contradiction rationale" not in learning_dump
+    assert "private-delta-4" not in learning_dump
+    replayed = repository.rederive_tailoring(
+        _TENANT_A,
+        source_changes=None,
+        rederived_at="2026-08-01T11:32:00Z",
+    )
+    assert replayed == (recommendation,)
+    assert conn.execute("SELECT COUNT(*) FROM learning_recommendations").fetchone()[0] == 1
+    assert conn.execute(
+        "SELECT COUNT(*) FROM learning_recommendation_tombstones"
+    ).fetchone()[0] == 0
+    close_connection(db_path)
+
+
 def test_source_change_validation_rolls_back_before_audit_mutation(
     tmp_path: Path,
 ) -> None:

--- a/workers/automation/tests/test_sqlite_learning_recommendations.py
+++ b/workers/automation/tests/test_sqlite_learning_recommendations.py
@@ -753,7 +753,7 @@ def test_multiple_source_changes_each_append_a_tombstone(tmp_path: Path) -> None
     close_connection(db_path)
 
 
-def test_review_rejects_without_policy_then_accepts_once(tmp_path: Path) -> None:
+def test_review_rejection_is_terminal_and_replays_same_decision(tmp_path: Path) -> None:
     db_path = tmp_path / "jobctrl.db"
     conn = init_db(db_path)
     recommendation = _recommendation(_TENANT_A)
@@ -784,29 +784,6 @@ def test_review_rejects_without_policy_then_accepts_once(tmp_path: Path) -> None
     assert rejected.policy_version is None
     assert policy_repository.get_current(_TENANT_A) == original_policy
 
-    accepted = reviewer.review(
-        _TENANT_A,
-        recommendation_id=recommendation.recommendation_id,
-        decision="accepted",
-        reviewed_at="2026-08-01T11:02:00Z",
-    )
-    accepted_replay = reviewer.review(
-        _TENANT_A,
-        recommendation_id=recommendation.recommendation_id,
-        decision="accepted",
-        reviewed_at="2026-08-01T11:03:00Z",
-    )
-
-    assert accepted == accepted_replay
-    assert accepted.revision == 2
-    assert accepted.policy_version == 2
-    assert policy_repository.get_current(_TENANT_A).learned_tailoring_rules.to_dict() == {
-        "fact_handling": "require_source_match"
-    }
-    assert conn.execute(
-        "SELECT COUNT(*) FROM learning_recommendation_reviews"
-    ).fetchone()[0] == 2
-    assert conn.execute("SELECT COUNT(*) FROM tailoring_policies").fetchone()[0] == 2
     with pytest.raises(
         LearningRecommendationReviewError,
         match="terminal",
@@ -814,9 +791,13 @@ def test_review_rejects_without_policy_then_accepts_once(tmp_path: Path) -> None
         reviewer.review(
             _TENANT_A,
             recommendation_id=recommendation.recommendation_id,
-            decision="rejected",
-            reviewed_at="2026-08-01T11:04:00Z",
+            decision="accepted",
+            reviewed_at="2026-08-01T11:02:00Z",
         )
+    assert conn.execute(
+        "SELECT COUNT(*) FROM learning_recommendation_reviews"
+    ).fetchone()[0] == 1
+    assert conn.execute("SELECT COUNT(*) FROM tailoring_policies").fetchone()[0] == 1
     close_connection(db_path)
 
 

--- a/workers/automation/tests/test_sqlite_learning_recommendations.py
+++ b/workers/automation/tests/test_sqlite_learning_recommendations.py
@@ -9,6 +9,7 @@ from jobctrl.database import close_connection, init_db
 from jobctrl.domain.identifiers import JobId, canonical_job_id
 from jobctrl.domain.operations.feedback import TailoringFeedbackSignal
 from jobctrl.domain.operations.learning import (
+    LearningSourceChange,
     RecommendationEvidenceRef,
     TailoringContradictionEvidence,
     TailoringRecommendationScope,
@@ -313,6 +314,239 @@ def test_reused_deterministic_identity_cannot_change_persisted_facts(
     close_connection(db_path)
 
 
+def test_source_correction_tombstones_and_rederives_with_replacement(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    conn = init_db(db_path)
+    _seed_tailoring_sources(conn)
+    conn.commit()
+    repository = SqliteLearningRecommendationRepository(conn)
+
+    original = repository.rederive_tailoring(
+        _TENANT_A,
+        source_changes=(),
+        rederived_at="2026-08-01T11:00:00Z",
+    )[0]
+    _insert_tailoring_review(
+        conn,
+        signal_id="tailoring-1",
+        revision=2,
+        decision="accepted",
+        reviewed_at="2026-08-01T11:30:00Z",
+    )
+    conn.commit()
+    change = LearningSourceChange(
+        tenant_id=_TENANT_A,
+        previous_signal_id="tailoring-feedback:tailoring-1:1",
+        source_id="tailoring-1",
+        source_revision=1,
+        reason_code="source_corrected",
+        changed_at="2026-08-01T11:30:00Z",
+    )
+
+    rederived = repository.rederive_tailoring(
+        _TENANT_A,
+        source_changes=(change,),
+        rederived_at="2026-08-01T11:31:00Z",
+    )
+
+    assert len(rederived) == 1
+    replacement = rederived[0]
+    assert replacement.recommendation_id != original.recommendation_id
+    assert any(
+        evidence.source_id == "tailoring-1" and evidence.source_revision == 2
+        for evidence in replacement.evidence
+    )
+    assert tuple(
+        conn.execute(
+            """
+            SELECT recommendation_id, affected_signal_id,
+                   affected_source_revision, reason_code,
+                   replacement_recommendation_id, tombstoned_at, rederived_at
+            FROM learning_recommendation_tombstones
+            """
+        ).fetchone()
+    ) == (
+        original.recommendation_id,
+        "tailoring-feedback:tailoring-1:1",
+        1,
+        "source_corrected",
+        replacement.recommendation_id,
+        "2026-08-01T11:30:00Z",
+        "2026-08-01T11:31:00Z",
+    )
+    assert conn.execute("SELECT COUNT(*) FROM learning_recommendations").fetchone()[0] == 2
+    learning_dump = "\n".join(
+        repr(tuple(row))
+        for table in (
+            "learning_recommendations",
+            "learning_recommendation_evidence",
+            "learning_recommendation_evidence_jobs",
+            "learning_recommendation_jobs",
+            "learning_recommendation_tombstones",
+        )
+        for row in conn.execute(f"SELECT * FROM {table}").fetchall()
+    )
+    for forbidden in (
+        "private edit",
+        "resume",
+        "prompt",
+        "job description",
+        "private-delta",
+    ):
+        assert forbidden not in learning_dump
+
+    replayed = repository.rederive_tailoring(
+        _TENANT_A,
+        source_changes=(change,),
+        rederived_at="2026-08-01T11:32:00Z",
+    )
+    assert replayed == rederived
+    assert conn.execute(
+        "SELECT COUNT(*) FROM learning_recommendation_tombstones"
+    ).fetchone()[0] == 1
+    close_connection(db_path)
+
+
+def test_source_deletion_tombstones_without_inventing_a_replacement(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    conn = init_db(db_path)
+    _seed_tailoring_sources(conn)
+    conn.commit()
+    repository = SqliteLearningRecommendationRepository(conn)
+    original = repository.rederive_tailoring(
+        _TENANT_A,
+        source_changes=(),
+        rederived_at="2026-08-01T11:00:00Z",
+    )[0]
+    _insert_tailoring_review(
+        conn,
+        signal_id="tailoring-1",
+        revision=2,
+        decision="rejected",
+        reviewed_at="2026-08-01T11:30:00Z",
+    )
+    conn.commit()
+
+    assert repository.rederive_tailoring(
+        _TENANT_A,
+        source_changes=(
+            LearningSourceChange(
+                tenant_id=_TENANT_A,
+                previous_signal_id="tailoring-feedback:tailoring-1:1",
+                source_id="tailoring-1",
+                source_revision=1,
+                reason_code="source_deleted",
+                changed_at="2026-08-01T11:30:00Z",
+            ),
+        ),
+        rederived_at="2026-08-01T11:31:00Z",
+    ) == ()
+    assert tuple(
+        conn.execute(
+            """
+            SELECT recommendation_id, reason_code,
+                   replacement_recommendation_id
+            FROM learning_recommendation_tombstones
+            """
+        ).fetchone()
+    ) == (original.recommendation_id, "source_deleted", None)
+    assert conn.execute("SELECT COUNT(*) FROM learning_recommendations").fetchone()[0] == 1
+    close_connection(db_path)
+
+
+def test_source_change_validation_rolls_back_before_audit_mutation(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    conn = init_db(db_path)
+    _seed_tailoring_sources(conn)
+    conn.commit()
+    repository = SqliteLearningRecommendationRepository(conn)
+    repository.rederive_tailoring(
+        _TENANT_A,
+        source_changes=(),
+        rederived_at="2026-08-01T11:00:00Z",
+    )
+
+    with pytest.raises(ValueError, match="no current accepted revision"):
+        repository.rederive_tailoring(
+            _TENANT_A,
+            source_changes=(
+                LearningSourceChange(
+                    tenant_id=_TENANT_A,
+                    previous_signal_id="tailoring-feedback:tailoring-1:1",
+                    source_id="tailoring-1",
+                    source_revision=1,
+                    reason_code="source_deleted",
+                    changed_at="2026-08-01T11:30:00Z",
+                ),
+            ),
+            rederived_at="2026-08-01T11:31:00Z",
+        )
+    assert conn.execute(
+        "SELECT COUNT(*) FROM learning_recommendation_tombstones"
+    ).fetchone()[0] == 0
+    assert conn.execute("SELECT COUNT(*) FROM learning_recommendations").fetchone()[0] == 1
+    close_connection(db_path)
+
+
+def test_multiple_source_changes_each_append_a_tombstone(tmp_path: Path) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    conn = init_db(db_path)
+    _seed_tailoring_sources(conn)
+    conn.commit()
+    repository = SqliteLearningRecommendationRepository(conn)
+    repository.rederive_tailoring(
+        _TENANT_A,
+        source_changes=(),
+        rederived_at="2026-08-01T11:00:00Z",
+    )
+    for signal_id in ("tailoring-1", "tailoring-2"):
+        _insert_tailoring_review(
+            conn,
+            signal_id=signal_id,
+            revision=2,
+            decision="rejected",
+            reviewed_at="2026-08-01T11:30:00Z",
+        )
+    conn.commit()
+
+    changes = tuple(
+        LearningSourceChange(
+            tenant_id=_TENANT_A,
+            previous_signal_id=f"tailoring-feedback:{signal_id}:1",
+            source_id=signal_id,
+            source_revision=1,
+            reason_code="source_deleted",
+            changed_at="2026-08-01T11:30:00Z",
+        )
+        for signal_id in ("tailoring-1", "tailoring-2")
+    )
+    assert repository.rederive_tailoring(
+        _TENANT_A,
+        source_changes=changes,
+        rederived_at="2026-08-01T11:31:00Z",
+    ) == ()
+    assert [
+        str(row[0])
+        for row in conn.execute(
+            """
+            SELECT affected_signal_id
+            FROM learning_recommendation_tombstones
+            ORDER BY affected_signal_id
+            """
+        ).fetchall()
+    ] == [
+        "tailoring-feedback:tailoring-1:1",
+        "tailoring-feedback:tailoring-2:1",
+    ]
+    close_connection(db_path)
+
+
 def _recommendation(tenant_id: TenantId):
     return derive_tailoring_recommendations(
         _signals(tenant_id),
@@ -357,4 +591,87 @@ def _signal(
         rule_key="fact_handling",
         rule_value="require_source_match",
         allowlist_version=1,
+    )
+
+
+def _seed_tailoring_sources(conn) -> None:
+    for index, job_id in enumerate((_JOB_A, _JOB_B), start=1):
+        conn.execute(
+            "INSERT INTO jobs (tenant_id, job_id, url) VALUES (?, ?, ?)",
+            ("tenant-a", job_id, f"https://jobs.example.test/{index}"),
+        )
+    for index, job_id in enumerate((_JOB_A, _JOB_A, _JOB_B), start=1):
+        signal_id = f"tailoring-{index}"
+        draft_id = f"draft-{index}"
+        conn.execute(
+            """
+            INSERT INTO resume_review_drafts (
+                tenant_id, draft_id, job_id, base_generation, renderer_format,
+                state, latest_revision_number, created_at, updated_at
+            ) VALUES (?, ?, ?, 1, 'text', 'active', 0, ?, ?)
+            """,
+            (
+                "tenant-a",
+                draft_id,
+                job_id,
+                "2026-08-01T10:00:00Z",
+                "2026-08-01T10:00:00Z",
+            ),
+        )
+        conn.execute(
+            """
+            INSERT INTO tailoring_feedback_signals (
+                tenant_id, signal_id, job_id, draft_id, source_kind, source_id,
+                signal_kind, status, summary, created_at, reviewed_at
+            ) VALUES (
+                'tenant-a', ?, ?, ?, 'edit_delta', ?,
+                'factual_correction', 'accepted', ?, ?, ?
+            )
+            """,
+            (
+                signal_id,
+                job_id,
+                draft_id,
+                f"private-delta-{index}",
+                "private edit, resume, prompt, and job description",
+                "2026-08-01T10:00:00Z",
+                "2026-08-01T10:00:00Z",
+            ),
+        )
+        _insert_tailoring_review(
+            conn,
+            signal_id=signal_id,
+            revision=1,
+            decision="accepted",
+            reviewed_at=f"2026-08-01T10:00:0{index}Z",
+        )
+
+
+def _insert_tailoring_review(
+    conn,
+    *,
+    signal_id: str,
+    revision: int,
+    decision: str,
+    reviewed_at: str,
+) -> None:
+    accepted = decision == "accepted"
+    conn.execute(
+        """
+        INSERT INTO tailoring_feedback_signal_reviews (
+            tenant_id, review_id, signal_id, revision, decision, signal_kind,
+            rule_key, rule_value, allowlist_version, reviewed_at
+        ) VALUES (
+            'tenant-a', ?, ?, ?, ?, 'factual_correction', ?, ?, 1, ?
+        )
+        """,
+        (
+            f"review-{signal_id}-{revision}",
+            signal_id,
+            revision,
+            decision,
+            "fact_handling" if accepted else None,
+            "require_source_match" if accepted else None,
+            reviewed_at,
+        ),
     )

--- a/workers/automation/tests/test_tailor_retailor.py
+++ b/workers/automation/tests/test_tailor_retailor.py
@@ -19,7 +19,8 @@ from jobctrl.domain.materials import (
     RenderFormat,
     ValidationResult,
 )
-from jobctrl.domain.materials.use_cases import TailorOutcome
+from jobctrl.domain.materials.policy import LearnedTailoringRules
+from jobctrl.domain.materials.use_cases import TailorOutcome, build_master_tailor_prompt
 from jobctrl.domain.profile.aggregate import Profile
 from jobctrl.domain.profile.snapshot import ProfileSnapshot
 from jobctrl.domain.tenant import LOCAL_TENANT
@@ -743,13 +744,30 @@ def test_tailor_prompt_includes_writing_style_and_custom_guidance():
     }
 
     snapshot = ProfileSnapshot.from_profile(Profile.from_dict(LOCAL_TENANT, profile))
-    prompt = _build_master_tailor_prompt(snapshot)
+    prompt = build_master_tailor_prompt(
+        snapshot,
+        learned_tailoring_rules=LearnedTailoringRules.from_mapping(
+            {
+                "style_guidance": "preserve_user_edit_pattern",
+                "fact_handling": "require_source_match",
+                "claim_policy": "omit_unsupported_claims",
+                "keyword_strategy": "use_supported_terms_only",
+                "provenance_policy": "require_direct_evidence",
+            }
+        ),
+    )
 
     assert "WRITING STYLE:" in prompt
     assert "- Tone: technical" in prompt
     assert "- Bullet standards: impact, technical_depth, leadership" in prompt
     assert "USER ADDITIONAL TAILORING PROMPT:" in prompt
     assert "Use concise platform leadership language." in prompt
+    assert "ACCEPTED LEARNING RULES FOR FUTURE MATERIALS:" in prompt
+    assert "style_guidance=preserve_user_edit_pattern" in prompt
+    assert "fact_handling=require_source_match" in prompt
+    assert "claim_policy=omit_unsupported_claims" in prompt
+    assert "keyword_strategy=use_supported_terms_only" in prompt
+    assert "provenance_policy=require_direct_evidence" in prompt
 
 
 def test_tailor_prompt_treats_target_job_as_context_not_evidence():

--- a/workers/automation/tests/test_tailoring_policy_revisions.py
+++ b/workers/automation/tests/test_tailoring_policy_revisions.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+import threading
+
+import pytest
+
+from jobctrl.database import close_connection, get_connection, init_db
+from jobctrl.domain.materials.policy import TailoringPolicy
+from jobctrl.domain.tenant import TenantId
+from jobctrl.infrastructure.materials import (
+    SqliteTailoringPolicyRepository,
+    TailoringPolicyRevisionError,
+)
+
+
+_TENANT_A = TenantId("tenant-a")
+_TENANT_B = TenantId("tenant-b")
+
+
+def test_history_and_rollback_are_append_only_and_tenant_scoped(tmp_path: Path) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    conn = init_db(db_path)
+    repository = SqliteTailoringPolicyRepository(conn)
+    original = _policy(_TENANT_A)
+    learned = original.with_learned_tailoring_rule(
+        rule_key="fact_handling",
+        rule_value="require_source_match",
+        version=2,
+        created_at="2026-08-01T11:00:00Z",
+    )
+    repository.save(original)
+    repository.save(learned)
+    repository.save(_policy(_TENANT_B))
+
+    assert [policy.version for policy in repository.list_history(_TENANT_A)] == [2, 1]
+    assert [policy.version for policy in repository.list_history(_TENANT_B)] == [1]
+    assert repository.get_version(_TENANT_A, 2) == learned
+    assert repository.get_version(_TENANT_B, 2) is None
+
+    rollback = repository.rollback_to(
+        _TENANT_A,
+        target_version=1,
+        reason="user_requested",
+        rolled_back_at="2026-08-01T12:00:00Z",
+    )
+
+    assert rollback.version == 3
+    assert rollback.rollback_of_version == 1
+    assert rollback.rollback_reason == "user_requested"
+    assert rollback.created_at == "2026-08-01T12:00:00Z"
+    assert rollback.learned_tailoring_rules.rules == ()
+    assert repository.get_current(_TENANT_A) == rollback
+    assert repository.get_version(_TENANT_A, 2) == learned
+    assert [policy.version for policy in repository.list_history(_TENANT_A)] == [3, 2, 1]
+    close_connection(db_path)
+
+
+def test_rollback_validation_and_replay_do_not_duplicate_history(tmp_path: Path) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    conn = init_db(db_path)
+    repository = SqliteTailoringPolicyRepository(conn)
+
+    with pytest.raises(TailoringPolicyRevisionError, match="not initialized"):
+        repository.rollback_to(
+            _TENANT_A,
+            target_version=1,
+            reason="user_requested",
+            rolled_back_at="2026-08-01T12:00:00Z",
+        )
+
+    original = _policy(_TENANT_A)
+    repository.save(original)
+    with pytest.raises(TailoringPolicyRevisionError, match="must precede"):
+        repository.rollback_to(
+            _TENANT_A,
+            target_version=1,
+            reason="user_requested",
+            rolled_back_at="2026-08-01T12:00:00Z",
+        )
+
+    repository.save(
+        original.with_learned_tailoring_rule(
+            rule_key="fact_handling",
+            rule_value="require_source_match",
+            version=2,
+            created_at="2026-08-01T11:00:00Z",
+        )
+    )
+    with pytest.raises(TailoringPolicyRevisionError, match="does not exist"):
+        repository.rollback_to(
+            _TENANT_A,
+            target_version=99,
+            reason="user_requested",
+            rolled_back_at="2026-08-01T12:00:00Z",
+        )
+
+    first = repository.rollback_to(
+        _TENANT_A,
+        target_version=1,
+        reason="user_requested",
+        rolled_back_at="2026-08-01T12:00:00Z",
+    )
+    replay = repository.rollback_to(
+        _TENANT_A,
+        target_version=1,
+        reason="user_requested",
+        rolled_back_at="2026-08-01T12:01:00Z",
+    )
+
+    assert replay == first
+    assert [policy.version for policy in repository.list_history(_TENANT_A)] == [3, 2, 1]
+    close_connection(db_path)
+
+
+def test_concurrent_rollback_replay_returns_one_appended_revision(tmp_path: Path) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    setup_conn = init_db(db_path)
+    repository = SqliteTailoringPolicyRepository(setup_conn)
+    original = _policy(_TENANT_A)
+    repository.save(original)
+    repository.save(
+        original.with_learned_tailoring_rule(
+            rule_key="fact_handling",
+            rule_value="require_source_match",
+            version=2,
+            created_at="2026-08-01T11:00:00Z",
+        )
+    )
+    close_connection(db_path)
+    start = threading.Event()
+
+    def rollback():
+        conn = get_connection(db_path)
+        try:
+            start.wait(timeout=5)
+            return SqliteTailoringPolicyRepository(conn).rollback_to(
+                _TENANT_A,
+                target_version=1,
+                reason="user_requested",
+                rolled_back_at="2026-08-01T12:00:00Z",
+            )
+        finally:
+            close_connection(db_path)
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        futures = [executor.submit(rollback) for _ in range(2)]
+        start.set()
+        rollbacks = [future.result(timeout=10) for future in futures]
+
+    assert [policy.version for policy in rollbacks] == [3, 3]
+    check_conn = get_connection(db_path)
+    try:
+        assert [
+            policy.version
+            for policy in SqliteTailoringPolicyRepository(check_conn).list_history(_TENANT_A)
+        ] == [3, 2, 1]
+    finally:
+        close_connection(db_path)
+
+
+def _policy(tenant_id: TenantId) -> TailoringPolicy:
+    return TailoringPolicy(
+        tenant_id=tenant_id,
+        version=1,
+        prompt_version="tailor.v2.quality-gated",
+        schema_version="tailored-resume.v1",
+        judge_schema_version="tailor-judge.v1",
+        prompt_fingerprint="sha256:prompt",
+        config_fingerprint="sha256:config",
+        profile_policy_fingerprint="sha256:profile",
+        custom_prompt_fingerprint="sha256:custom",
+        generator_settings={"candidate_models": ["local:draft"]},
+        judge_settings={"judge_model": "local:judge", "min_score": 0.82},
+        runtime_settings={"validation_mode": "normal"},
+        created_at="2026-08-01T10:00:00Z",
+    )

--- a/workers/automation/tests/test_v6_to_v7_plan.py
+++ b/workers/automation/tests/test_v6_to_v7_plan.py
@@ -167,6 +167,11 @@ def test_identity_locator_and_sequence_roles_are_not_inferred_from_names() -> No
         classify_column("tailoring_feedback_signal_reviews", "signal_id", "target")
         is ColumnRole.PRESERVE
     )
+    assert not table_plan("tailoring_feedback_signal_contradictions").source_exists
+    assert (
+        table_plan("tailoring_feedback_signal_contradictions").disposition
+        is TableDisposition.DIRECT_COPY
+    )
     for table in (
         "learning_recommendation_evidence",
         "learning_recommendation_evidence_jobs",

--- a/workers/automation/tests/test_v6_to_v7_plan.py
+++ b/workers/automation/tests/test_v6_to_v7_plan.py
@@ -173,6 +173,7 @@ def test_identity_locator_and_sequence_roles_are_not_inferred_from_names() -> No
         is TableDisposition.DIRECT_COPY
     )
     for table in (
+        "learning_recommendation_reviews",
         "learning_recommendation_evidence",
         "learning_recommendation_evidence_jobs",
         "learning_recommendation_jobs",


### PR DESCRIPTION
## Summary

- restores the 27 commits corresponding to #680-#701 and #703-#707 onto current `main`
- preserves the exact cumulative tree from the orphaned stack merge tip `dec43760f`
- replaces #707 because GitHub does not allow a merged pull request to be reopened

## Why

After #679 merged, #680 still targeted `feat/job-id-v7-learning-recommendation-writer`. Merging the continuation stack therefore wrote its squash commits to that already-merged branch rather than to `main`. This pull request replays those exact 27 commits onto current `main` without changing their cumulative content.

## Validation

- `gh stack view --json`: trunk `main`, base `7000f5672`, `needsRebase: false`
- `git rev-list --left-right --count origin/main...HEAD`: `0 27`
- cumulative tree matches `dec43760f` with an empty `git diff`
- `git diff --check origin/main...HEAD`
- the cumulative TypeScript and Python 3.11-3.13 gates previously passed on #707