### PR TITLE
feat(api): refresh recommendations after review

### DIFF
--- a/apps/api/src/local-actions.ts
+++ b/apps/api/src/local-actions.ts
@@ -25,6 +25,7 @@ import { randomUUID } from "node:crypto";
 import {
   DEFAULT_PIPELINE_LLM_MODEL,
   PIPELINE_ACTION_JOB_KEY,
+  RederiveLearningRecommendationsResultSchema,
   type ActionCommandPayload,
   type ActionRunResponse,
   type ResumeTemplateTheme,
@@ -196,6 +197,12 @@ export function createActionDispatcher(
       const message = status === "failed" ? extractResultMessage(response.result) : null;
       if (message) result.message = message;
       return result;
+    }
+    if (rpcCall.method === "rederive_learning_recommendations") {
+      const result = RederiveLearningRecommendationsResultSchema.parse(
+        response.result,
+      );
+      return { status: result.status, result };
     }
     return {
       status: "queued",
@@ -475,6 +482,16 @@ interface RpcCall {
 }
 
 function mapCommandToRpc(command: ActionCommandPayload, context: ActionDispatchContext): RpcCall | null {
+  if (command.action === "rederive_learning_recommendations") {
+    return {
+      method: "rederive_learning_recommendations",
+      params: {
+        tenantId: "local",
+        expectedAppDir: context.appDir,
+        expectedDbPath: context.dbPath,
+      },
+    };
+  }
   if (command.action === "run_stage") {
     if (!command.stage) return null;
     return { method: "run_stage", params: runStageRpcParams(command, context) };

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -1107,9 +1107,39 @@ export function buildApp(options: BuildAppOptions): FastifyInstance {
       if (!body) {
         return undefined;
       }
-      return withWritableDb(reply, options.dbPath, (db) =>
+      const reviewResponse = await withWritableDb(reply, options.dbPath, (db) =>
         reviewResumeFeedbackSignal(db, decodeRouteParam(request.params.signalId), body),
       );
+      if (!reviewResponse || reviewResponse.ok !== true) {
+        return reviewResponse;
+      }
+      try {
+        const derivation = await actionDispatcher(
+          {
+            action: "rederive_learning_recommendations",
+            jobKey: "learning",
+          },
+          actionContext,
+        );
+        if (derivation.status !== "succeeded") {
+          void reply.code(503);
+          return {
+            ok: false,
+            error: "learning_rederivation_failed",
+            message:
+              "The feedback review was saved, but pending learning recommendations could not be refreshed. Retry the same review.",
+          };
+        }
+      } catch {
+        void reply.code(503);
+        return {
+          ok: false,
+          error: "learning_rederivation_failed",
+          message:
+            "The feedback review was saved, but pending learning recommendations could not be refreshed. Retry the same review.",
+        };
+      }
+      return reviewResponse;
     },
   );
 

--- a/apps/api/test/json-rpc-adapter.test.ts
+++ b/apps/api/test/json-rpc-adapter.test.ts
@@ -111,6 +111,45 @@ describe("createContactResearchStarter (JSON-RPC adapter)", () => {
 });
 
 describe("createActionDispatcher (JSON-RPC adapter)", () => {
+  it("maps learning rederivation to one runtime-scoped synchronous RPC", async () => {
+    const fake = new FakeDispatcher();
+    const recommendationId = `learning-recommendation:${"a".repeat(64)}`;
+    fake.setResponse({
+      jsonrpc: "2.0",
+      id: 1,
+      result: {
+        status: "succeeded",
+        recommendationCount: 1,
+        recommendationIds: [recommendationId],
+      },
+    });
+    const dispatcher = createActionDispatcher(fake);
+
+    const result = await dispatcher(
+      { action: "rederive_learning_recommendations", jobKey: "learning" },
+      { appDir: "/tmp/jobctrl", dbPath: "/tmp/jobctrl/jobctrl.db" },
+    );
+
+    expect(fake.calls).toEqual([
+      {
+        method: "rederive_learning_recommendations",
+        params: {
+          tenantId: "local",
+          expectedAppDir: "/tmp/jobctrl",
+          expectedDbPath: "/tmp/jobctrl/jobctrl.db",
+        },
+      },
+    ]);
+    expect(result).toEqual({
+      status: "succeeded",
+      result: {
+        status: "succeeded",
+        recommendationCount: 1,
+        recommendationIds: [recommendationId],
+      },
+    });
+  });
+
   it("preserves the cancel_run RPC canceling status and run id", async () => {
     const fake = new FakeDispatcher();
     fake.setResponse({

--- a/apps/api/test/resume-review-drafts.test.ts
+++ b/apps/api/test/resume-review-drafts.test.ts
@@ -34,8 +34,12 @@ beforeEach(() => {
     configPath: path.join(tempDir, "config.json"),
     resumePdfRenderer,
     actionDispatcher: vi.fn(async (): Promise<ActionDispatchResult> => ({
-      status: "queued",
-      runId: "unexpected-run",
+      status: "succeeded",
+      result: {
+        status: "succeeded",
+        recommendationCount: 0,
+        recommendationIds: [],
+      },
     })) as ReturnType<typeof vi.fn> & ActionDispatcher,
   };
   seedDatabase(options.dbPath);
@@ -335,6 +339,35 @@ describe("resume review draft API", () => {
 
   it("reviews tailoring feedback through the versioned allowlist without exposing source text", async () => {
     const privateSource = "private source text must never enter the review response";
+    const decisionsObservedByDerivation: string[] = [];
+    const actionDispatcher = options.actionDispatcher as ReturnType<typeof vi.fn> &
+      ActionDispatcher;
+    actionDispatcher.mockImplementation(
+      async (...[, context]: Parameters<ActionDispatcher>): Promise<ActionDispatchResult> => {
+        const persisted = new Database(context.dbPath);
+        try {
+          const row = persisted
+            .prepare(
+              `SELECT decision
+                 FROM tailoring_feedback_signal_reviews
+                ORDER BY revision DESC
+                LIMIT 1`,
+            )
+            .get() as { decision: string };
+          decisionsObservedByDerivation.push(row.decision);
+        } finally {
+          persisted.close();
+        }
+        return {
+          status: "succeeded",
+          result: {
+            status: "succeeded",
+            recommendationCount: 0,
+            recommendationIds: [],
+          },
+        };
+      },
+    );
     const app = buildApp(options);
     const createResponse = await app.inject({
       method: "POST",
@@ -435,6 +468,18 @@ describe("resume review draft API", () => {
       ruleValue: null,
       contradictsSignalIds: [],
     });
+    expect(options.actionDispatcher).toHaveBeenCalledTimes(3);
+    expect(decisionsObservedByDerivation).toEqual([
+      "accepted",
+      "accepted",
+      "rejected",
+    ]);
+    expect(options.actionDispatcher).toHaveBeenNthCalledWith(
+      1,
+      { action: "rederive_learning_recommendations", jobKey: "learning" },
+      expect.objectContaining({ dbPath: options.dbPath }),
+    );
+
     const db = new Database(options.dbPath);
     try {
       const reviews = db
@@ -588,6 +633,91 @@ describe("resume review draft API", () => {
     } finally {
       persisted.close();
     }
+    await app.close();
+  });
+
+  it("retries idempotent derivation when a saved review refresh initially fails", async () => {
+    const actionDispatcher = options.actionDispatcher as ReturnType<typeof vi.fn> &
+      ActionDispatcher;
+    actionDispatcher
+      .mockResolvedValueOnce({ status: "failed" })
+      .mockResolvedValueOnce({
+        status: "succeeded",
+        result: {
+          status: "succeeded",
+          recommendationCount: 0,
+          recommendationIds: [],
+        },
+      });
+    const app = buildApp(options);
+    const createResponse = await app.inject({
+      method: "POST",
+      url: `/v1/jobs/${encodeURIComponent(JOB_KEY)}/resume-review/draft`,
+      payload: {},
+    });
+    const draftId = createResponse.json().draft.draftId as string;
+    const revisionResponse = await app.inject({
+      method: "POST",
+      url: `/v1/resume-review/drafts/${encodeURIComponent(draftId)}/revisions`,
+      payload: {
+        editedText: "Led 4 platform reliability projects.",
+        editDeltas: [
+          {
+            kind: "replace_text",
+            section: "experience",
+            beforeText: "Led 3 projects.",
+            afterText: "Led 4 platform reliability projects.",
+          },
+        ],
+      },
+    });
+    const signalId = revisionResponse.json().draft.feedbackSignals[0].signalId as string;
+    const payload = {
+      decision: "accepted",
+      ruleKey: "fact_handling",
+      ruleValue: "require_source_match",
+    } as const;
+
+    const failed = await app.inject({
+      method: "POST",
+      url: `/v1/resume-review/feedback-signals/${encodeURIComponent(signalId)}/reviews`,
+      payload,
+    });
+    expect(failed.statusCode, failed.body).toBe(503);
+    expect(failed.json()).toEqual({
+      ok: false,
+      error: "learning_rederivation_failed",
+      message:
+        "The feedback review was saved, but pending learning recommendations could not be refreshed. Retry the same review.",
+    });
+
+    const retried = await app.inject({
+      method: "POST",
+      url: `/v1/resume-review/feedback-signals/${encodeURIComponent(signalId)}/reviews`,
+      payload,
+    });
+    expect(retried.statusCode, retried.body).toBe(200);
+    expect(retried.json().review).toMatchObject({
+      signalId,
+      revision: 1,
+      decision: "accepted",
+      contradictsSignalIds: [],
+    });
+    const persisted = new Database(options.dbPath);
+    try {
+      expect(
+        persisted
+          .prepare(
+            `SELECT COUNT(*) AS count
+               FROM tailoring_feedback_signal_reviews
+              WHERE signal_id = ?`,
+          )
+          .get(signalId),
+      ).toEqual({ count: 1 });
+    } finally {
+      persisted.close();
+    }
+    expect(actionDispatcher).toHaveBeenCalledTimes(2);
     await app.close();
   });
 

--- a/apps/api/test/rpc-contracts.test.ts
+++ b/apps/api/test/rpc-contracts.test.ts
@@ -17,6 +17,8 @@ import {
   ManualCaptureImportParamsSchema,
   ManualCaptureImportWorkflowResultSchema,
   ProviderModelCatalogResultSchema,
+  RederiveLearningRecommendationsParamsSchema,
+  RederiveLearningRecommendationsResultSchema,
   RefreshCompensationParamsSchema,
   RefreshCompensationResultSchema,
   RescoreJobParamsSchema,
@@ -31,6 +33,50 @@ import {
 } from "../src/contracts.js";
 
 const CANONICAL_JOB_ID = "11111111-1111-4111-8111-111111111111";
+
+describe("learning recommendation derivation RPC contract", () => {
+  it("registers bounded runtime-scoped request and result shapes", () => {
+    expect(RpcMethods.RederiveLearningRecommendations).toBe(
+      "rederive_learning_recommendations",
+    );
+    expect(
+      RederiveLearningRecommendationsParamsSchema.parse({
+        expectedAppDir: "/tmp/jobctrl",
+        expectedDbPath: "/tmp/jobctrl/jobctrl.db",
+      }),
+    ).toEqual({
+      tenantId: "local",
+      expectedAppDir: "/tmp/jobctrl",
+      expectedDbPath: "/tmp/jobctrl/jobctrl.db",
+    });
+    const recommendationId = `learning-recommendation:${"a".repeat(64)}`;
+    expect(
+      RederiveLearningRecommendationsResultSchema.parse({
+        status: "succeeded",
+        recommendationCount: 1,
+        recommendationIds: [recommendationId],
+      }),
+    ).toEqual({
+      status: "succeeded",
+      recommendationCount: 1,
+      recommendationIds: [recommendationId],
+    });
+    expect(() =>
+      RederiveLearningRecommendationsResultSchema.parse({
+        status: "succeeded",
+        recommendationCount: 0,
+        recommendationIds: [recommendationId],
+      }),
+    ).toThrow();
+    expect(() =>
+      RederiveLearningRecommendationsResultSchema.parse({
+        status: "succeeded",
+        recommendationCount: 1,
+        recommendationIds: ["private free text"],
+      }),
+    ).toThrow();
+  });
+});
 
 describe("cancel_run RPC contract", () => {
   it("registers cancel_run in RpcMethods", () => {

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -86,6 +86,7 @@ export const RpcMethods = {
   BrowserCapabilityEnable: "browser_capability_enable",
   BrowserCapabilityDisable: "browser_capability_disable",
   BrowserProfileCopy: "browser_profile_copy",
+  RederiveLearningRecommendations: "rederive_learning_recommendations",
 } as const;
 export type RpcMethod = (typeof RpcMethods)[keyof typeof RpcMethods];
 
@@ -471,6 +472,34 @@ export const CancelRunResultSchema = z
   })
   .strict();
 export type CancelRunResult = z.infer<typeof CancelRunResultSchema>;
+
+export const RederiveLearningRecommendationsParamsSchema = z
+  .object({
+    tenantId: TenantParam,
+    expectedAppDir: z.string().trim().min(1).optional(),
+    expectedDbPath: z.string().trim().min(1).optional(),
+  })
+  .strict();
+export type RederiveLearningRecommendationsParams = z.infer<
+  typeof RederiveLearningRecommendationsParamsSchema
+>;
+
+export const RederiveLearningRecommendationsResultSchema = z
+  .object({
+    status: z.literal("succeeded"),
+    recommendationCount: z.number().int().nonnegative(),
+    recommendationIds: z
+      .array(z.string().regex(/^learning-recommendation:[a-f0-9]{64}$/))
+      .max(100),
+  })
+  .strict()
+  .refine(
+    (value) => value.recommendationIds.length === value.recommendationCount,
+    "Recommendation count must match recommendation IDs.",
+  );
+export type RederiveLearningRecommendationsResult = z.infer<
+  typeof RederiveLearningRecommendationsResultSchema
+>;
 
 export const ProfileImportParamsSchema = z
   .object({

--- a/packages/contracts/src/schemas.ts
+++ b/packages/contracts/src/schemas.ts
@@ -4182,6 +4182,7 @@ export interface ActionCommandPayload {
     | "generate_interview_prep"
     | "apply"
     | "cancel"
+    | "rederive_learning_recommendations"
     | "mark_applied"
     | "mark_skipped"
     | "profile_import";

--- a/workers/automation/src/jobctrl/infrastructure/rpc/handlers.py
+++ b/workers/automation/src/jobctrl/infrastructure/rpc/handlers.py
@@ -19,6 +19,7 @@ target §6.5).
 from __future__ import annotations
 
 import asyncio
+from datetime import UTC, datetime
 import logging
 from typing import Any
 
@@ -28,8 +29,12 @@ from jobctrl.domain.rpc.messages import WorkflowStartSpec
 from jobctrl.domain.preparation import PreparationWorkItemKind
 from jobctrl.domain.tenant import LOCAL_TENANT, TenantId
 from jobctrl.infrastructure.preparation import SqlitePreparationTargetReader
+from jobctrl.infrastructure.learning.sqlite_repository import (
+    SqliteLearningRecommendationRepository,
+)
 from jobctrl.infrastructure.rpc.server import JsonRpcServer, invalid_params
 from jobctrl.infrastructure.rpc.workflow_starter import WorkflowCanceler
+from jobctrl.infrastructure.runtime_identity import assert_expected_runtime
 from jobctrl.model_defaults import DEFAULT_PIPELINE_LLM_MODEL_SPEC
 from jobctrl.pipeline.preparation import (
     build_preparation_workflow_spec,
@@ -792,6 +797,30 @@ def make_cancel_run(canceler: WorkflowCanceler):
     return cancel_run
 
 
+def rederive_learning_recommendations(params: dict[str, Any]) -> dict[str, Any]:
+    """Refresh pending Materials proposals after an explicit signal review."""
+
+    tenant_id = TenantId(_tenant_id(params))
+    assert_expected_runtime(
+        expected_app_dir=params.get("expectedAppDir"),
+        expected_db_path=params.get("expectedDbPath"),
+    )
+    recommendations = SqliteLearningRecommendationRepository(
+        get_connection()
+    ).rederive_tailoring(
+        tenant_id,
+        source_changes=None,
+        rederived_at=datetime.now(UTC).isoformat(),
+    )
+    return {
+        "status": "succeeded",
+        "recommendationCount": len(recommendations),
+        "recommendationIds": [
+            recommendation.recommendation_id for recommendation in recommendations
+        ],
+    }
+
+
 # ---------------------------------------------------------------------------
 # Registration
 # ---------------------------------------------------------------------------
@@ -822,6 +851,11 @@ def register_default_handlers(server: JsonRpcServer, *, canceler: WorkflowCancel
     server.register("browser_capability_enable", browser_capability_enable, mode="sync")
     server.register("browser_capability_disable", browser_capability_disable, mode="sync")
     server.register("browser_profile_copy", browser_profile_copy, mode="sync")
+    server.register(
+        "rederive_learning_recommendations",
+        rederive_learning_recommendations,
+        mode="sync",
+    )
     server.register("refresh_compensation", refresh_compensation, mode="workflow")
     server.register("generate_interview_prep", generate_interview_prep, mode="workflow")
     server.register("run_contact_research", run_contact_research, mode="workflow")

--- a/workers/automation/tests/test_rpc_learning_recommendations.py
+++ b/workers/automation/tests/test_rpc_learning_recommendations.py
@@ -1,0 +1,132 @@
+"""Learning recommendation JSON-RPC trigger contracts."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from jobctrl.database import close_connection, init_db
+from jobctrl.domain.rpc.messages import JsonRpcRequest
+from jobctrl.infrastructure.rpc import handlers as handlers_mod
+from jobctrl.infrastructure.rpc.handlers import register_default_handlers
+from jobctrl.infrastructure.rpc.server import JsonRpcServer
+
+
+async def _stub_starter(_spec):  # pragma: no cover - sync handler only
+    raise AssertionError("workflow starter must not be called")
+
+
+async def _stub_canceler(_run_id: str) -> None:  # pragma: no cover - not called
+    return None
+
+
+def test_review_trigger_derives_once_and_replays_idempotently(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    conn = init_db(db_path)
+    job_ids = (
+        "11111111-1111-4111-8111-111111111111",
+        "22222222-2222-4222-8222-222222222222",
+    )
+    for index, job_id in enumerate(job_ids, start=1):
+        conn.execute(
+            "INSERT INTO jobs (tenant_id, job_id, url) VALUES ('local', ?, ?)",
+            (job_id, f"https://jobs.example/{index}"),
+        )
+    for index, job_id in enumerate((job_ids[0], job_ids[0], job_ids[1]), start=1):
+        signal_id = f"signal-{index}"
+        conn.execute(
+            """
+            INSERT INTO resume_review_drafts (
+                tenant_id, draft_id, job_id, base_generation, renderer_format,
+                state, latest_revision_number, created_at, updated_at
+            ) VALUES ('local', ?, ?, 1, 'text', 'active', 0, ?, ?)
+            """,
+            (
+                f"draft-{index}",
+                job_id,
+                "2026-08-01T10:00:00Z",
+                "2026-08-01T10:00:00Z",
+            ),
+        )
+        conn.execute(
+            """
+            INSERT INTO tailoring_feedback_signals (
+                tenant_id, signal_id, job_id, draft_id, source_kind,
+                source_id, signal_kind, status, summary, created_at,
+                reviewed_at
+            ) VALUES (
+                'local', ?, ?, ?, 'edit_delta', ?, 'factual_correction',
+                'accepted', 'private source text', ?, ?
+            )
+            """,
+            (
+                signal_id,
+                job_id,
+                f"draft-{index}",
+                f"private-delta-{index}",
+                "2026-08-01T10:00:00Z",
+                f"2026-08-01T10:00:0{index}Z",
+            ),
+        )
+        conn.execute(
+            """
+            INSERT INTO tailoring_feedback_signal_reviews (
+                tenant_id, review_id, signal_id, revision, decision,
+                signal_kind, rule_key, rule_value, allowlist_version,
+                reviewed_at
+            ) VALUES (
+                'local', ?, ?, 1, 'accepted', 'factual_correction',
+                'fact_handling', 'require_source_match', 1, ?
+            )
+            """,
+            (f"review-{index}", signal_id, f"2026-08-01T10:00:0{index}Z"),
+        )
+    conn.commit()
+    monkeypatch.setattr(handlers_mod, "get_connection", lambda: conn)
+    server = JsonRpcServer(workflow_starter=_stub_starter)
+    register_default_handlers(server, canceler=_stub_canceler)
+
+    first = server.dispatch(
+        JsonRpcRequest(
+            method="rederive_learning_recommendations",
+            params={"tenantId": "local"},
+            id=1,
+        )
+    )
+    replay = server.dispatch(
+        JsonRpcRequest(
+            method="rederive_learning_recommendations",
+            params={"tenantId": "local"},
+            id=2,
+        )
+    )
+
+    assert first is not None
+    assert replay is not None
+    first_result = first.to_dict()["result"]
+    replay_result = replay.to_dict()["result"]
+    assert first_result["status"] == "succeeded"
+    assert first_result["recommendationCount"] == 1
+    assert replay_result["recommendationIds"] == first_result["recommendationIds"]
+    assert conn.execute("SELECT COUNT(*) FROM learning_recommendations").fetchone()[0] == 1
+    assert conn.execute(
+        "SELECT COUNT(*) FROM learning_recommendation_evidence"
+    ).fetchone()[0] == 3
+    assert conn.execute(
+        "SELECT COUNT(*) FROM learning_recommendation_jobs"
+    ).fetchone()[0] == 2
+    learning_dump = "\n".join(
+        repr(tuple(row))
+        for table in (
+            "learning_recommendations",
+            "learning_recommendation_evidence",
+            "learning_recommendation_evidence_jobs",
+            "learning_recommendation_jobs",
+        )
+        for row in conn.execute(f"SELECT * FROM {table}").fetchall()
+    )
+    assert "private source text" not in learning_dump
+    assert "private-delta" not in learning_dump
+    close_connection(db_path)


### PR DESCRIPTION
## Recovery

- Restores the exact single-commit diff from original PR #686 as its own reviewable layer in new GitHub Stack #738.
- No implementation content was added, removed, or combined during recovery.

## Why

The original PR was marked merged into an already-merged parent branch, so its commit did not reach `main`. This reconstructed stack roots the first recovered layer on current `main` and preserves the original order through PR #707.

## Validation

- Original focused implementation and validation record: #686
- Content-equivalent cumulative recovery head: #710 (full CI passed before this individual stack was published)
- This PR contains exactly one recovered commit.