### PR TITLE
docs(agents): reuse task validation agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,6 +93,11 @@ and explain any intentional stacked deferral in the PR body.
 - **Subagent spawning:** Use subagents only for genuinely independent work or
   for the review/QA gates required by the validation tiers below. Do not add
   coordination overhead to work that is faster to complete directly.
+  Within one task, create at most one agent of each required type/role and
+  reuse that agent via follow-up turns for related work, fixes, and reruns.
+  Replace an agent only when it is unavailable/terminated or the new work is
+  genuinely a different task; never use a replacement to obtain another
+  opinion or avoid continuity.
 
 ### Root-Cause And Auditability Discipline
 
@@ -179,9 +184,9 @@ gate across the whole stack. A phase that changes an active high-risk path or is
 released independently follows its normal tier immediately.
 
 Run independent gates once after implementation and focused verification. Rerun
-a failed gate after addressing its Blocker/High findings; do not repeat passing
-gates for cosmetic edits or unresolved Medium/Low observations unless the edit
-could affect the verified behavior.
+a failed gate with the same reviewer/QA agent after addressing its Blocker/High
+findings; do not repeat passing gates for cosmetic edits or unresolved Medium/
+Low observations unless the edit could affect the verified behavior.
 
 Before calling work done:
 


### PR DESCRIPTION
## Recovery

- Restores the exact single-commit diff from original PR #690 as its own reviewable layer in new GitHub Stack #738.
- No implementation content was added, removed, or combined during recovery.

## Why

The original PR was marked merged into an already-merged parent branch, so its commit did not reach `main`. This reconstructed stack roots the first recovered layer on current `main` and preserves the original order through PR #707.

## Validation

- Original focused implementation and validation record: #690
- Content-equivalent cumulative recovery head: #710 (full CI passed before this individual stack was published)
- This PR contains exactly one recovered commit.