### PR TITLE
feat(web): add learning review data hooks

### DIFF
--- a/apps/web/src/contexts/materials/hooks/useReviewLearningRecommendationMutation.test.ts
+++ b/apps/web/src/contexts/materials/hooks/useReviewLearningRecommendationMutation.test.ts
@@ -1,0 +1,157 @@
+import type {
+  LearningRecommendationListResponse,
+  LearningRecommendationReviewResponse,
+  LearningRecommendationSummary,
+} from "@jobctrl/contracts";
+import { LOCAL_TENANT } from "@jobctrl/domain-types";
+import { act, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { renderHookWithProviders } from "../../../test/render.js";
+import { buildTestPorts } from "../../../test/testPorts.js";
+import { learningKeys } from "../../operations/learningKeys.js";
+import { useReviewLearningRecommendationMutation } from "./useReviewLearningRecommendationMutation.js";
+
+const recommendation: LearningRecommendationSummary = {
+  recommendationId: `learning-recommendation:${"a".repeat(64)}`,
+  derivationVersion: 1,
+  evaluationFixtureVersion: 1,
+  context: "materials",
+  policyKind: "tailoring_rule",
+  signalKind: "style_preference",
+  ruleKey: "style_guidance",
+  ruleValue: "preserve_user_edit_pattern",
+  allowlistVersion: 1,
+  status: "pending",
+  active: true,
+  observedSignalCount: 3,
+  observedJobCount: 2,
+  minimumSignalCount: 3,
+  minimumJobCount: 2,
+  confidenceLimit: "sample_gated_no_population_inference",
+  supportingEvidenceCount: 3,
+  contradictingEvidenceCount: 0,
+  tombstoneCount: 0,
+  derivedAt: "2026-08-01T12:00:00.000Z",
+};
+
+const otherRecommendation: LearningRecommendationSummary = {
+  ...recommendation,
+  recommendationId: `learning-recommendation:${"c".repeat(64)}`,
+  ruleKey: "fact_handling",
+  ruleValue: "require_source_match",
+};
+
+const pageOneInput = { page: 1, pageSize: 50 } as const;
+const pageTwoInput = { page: 2, pageSize: 50 } as const;
+const pageOne: LearningRecommendationListResponse = {
+  ok: true,
+  recommendations: [otherRecommendation],
+  page: 1,
+  pageSize: 50,
+  total: 51,
+  totalPages: 2,
+};
+const pageTwo: LearningRecommendationListResponse = {
+  ok: true,
+  recommendations: [recommendation],
+  page: 2,
+  pageSize: 50,
+  total: 51,
+  totalPages: 2,
+};
+
+const accepted: LearningRecommendationReviewResponse = {
+  ok: true,
+  reviewId: `learning-recommendation-review:${"b".repeat(64)}`,
+  recommendationId: recommendation.recommendationId,
+  revision: 1,
+  decision: "accepted",
+  context: "materials",
+  policyKind: "tailoring_rule",
+  policyVersion: 2,
+  reviewedAt: "2026-08-01T12:05:00.000Z",
+};
+
+describe("useReviewLearningRecommendationMutation", () => {
+  it("reviews through the Materials API port and removes the terminal recommendation", async () => {
+    const reviewLearningRecommendation = vi.fn(async () => accepted);
+    const { result, queryClient } = renderHookWithProviders(
+      () => useReviewLearningRecommendationMutation(),
+      { ports: buildTestPorts({ api: { reviewLearningRecommendation } }) },
+    );
+    const pageOneKey = learningKeys.list(LOCAL_TENANT, pageOneInput);
+    const pageTwoKey = learningKeys.list(LOCAL_TENANT, pageTwoInput);
+    queryClient.setQueryData(pageOneKey, pageOne);
+    queryClient.setQueryData(pageTwoKey, pageTwo);
+
+    await act(async () => {
+      await expect(
+        result.current.mutateAsync({
+          recommendationId: recommendation.recommendationId,
+          decision: "accepted",
+        }),
+      ).resolves.toBe(accepted);
+    });
+
+    expect(reviewLearningRecommendation).toHaveBeenCalledWith(recommendation.recommendationId, {
+      decision: "accepted",
+    });
+    expect(queryClient.getQueryData<LearningRecommendationListResponse>(pageOneKey)).toMatchObject({
+      recommendations: [otherRecommendation],
+      total: 50,
+      totalPages: 1,
+    });
+    expect(queryClient.getQueryData<LearningRecommendationListResponse>(pageTwoKey)).toMatchObject({
+      recommendations: [],
+      total: 50,
+      totalPages: 1,
+    });
+  });
+
+  it("restores every optimistic recommendation snapshot when review fails", async () => {
+    let rejectReview: ((error: Error) => void) | undefined;
+    const reviewLearningRecommendation = vi.fn(
+      () =>
+        new Promise<LearningRecommendationReviewResponse>((_resolve, reject) => {
+          rejectReview = reject;
+        }),
+    );
+    const { result, queryClient } = renderHookWithProviders(
+      () => useReviewLearningRecommendationMutation(),
+      { ports: buildTestPorts({ api: { reviewLearningRecommendation } }) },
+    );
+    const pageOneKey = learningKeys.list(LOCAL_TENANT, pageOneInput);
+    const pageTwoKey = learningKeys.list(LOCAL_TENANT, pageTwoInput);
+    queryClient.setQueryData(pageOneKey, pageOne);
+    queryClient.setQueryData(pageTwoKey, pageTwo);
+
+    act(() => {
+      result.current.mutate({
+        recommendationId: recommendation.recommendationId,
+        decision: "rejected",
+      });
+    });
+
+    await waitFor(() =>
+      expect(
+        queryClient.getQueryData<LearningRecommendationListResponse>(pageTwoKey)?.recommendations,
+      ).toEqual([]),
+    );
+    expect(queryClient.getQueryData<LearningRecommendationListResponse>(pageOneKey)).toMatchObject({
+      recommendations: [otherRecommendation],
+      total: 50,
+      totalPages: 1,
+    });
+    act(() => rejectReview?.(new Error("review unavailable")));
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    await waitFor(() =>
+      expect(queryClient.getQueryData<LearningRecommendationListResponse>(pageOneKey)).toEqual(
+        pageOne,
+      ),
+    );
+    expect(queryClient.getQueryData<LearningRecommendationListResponse>(pageTwoKey)).toEqual(
+      pageTwo,
+    );
+  });
+});

--- a/apps/web/src/contexts/materials/hooks/useReviewLearningRecommendationMutation.ts
+++ b/apps/web/src/contexts/materials/hooks/useReviewLearningRecommendationMutation.ts
@@ -1,0 +1,81 @@
+import type {
+  LearningRecommendationListResponse,
+  LearningRecommendationReviewRequest,
+  LearningRecommendationReviewResponse,
+} from "@jobctrl/contracts";
+import {
+  useMutation,
+  useQueryClient,
+  type QueryKey,
+  type UseMutationResult,
+} from "@tanstack/react-query";
+
+import { usePorts } from "../../../shared/providers/PortsProvider.js";
+import { useTenantId } from "../../../shared/providers/TenantProvider.js";
+import { learningKeys } from "../../operations/learningKeys.js";
+
+export interface ReviewLearningRecommendationVariables {
+  readonly recommendationId: string;
+  readonly decision: LearningRecommendationReviewRequest["decision"];
+}
+
+interface ReviewLearningRecommendationContext {
+  readonly snapshots: readonly (readonly [QueryKey, LearningRecommendationListResponse | undefined])[];
+}
+
+export function useReviewLearningRecommendationMutation(): UseMutationResult<
+  LearningRecommendationReviewResponse,
+  Error,
+  ReviewLearningRecommendationVariables,
+  ReviewLearningRecommendationContext
+> {
+  const tenantId = useTenantId();
+  const { api } = usePorts();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ recommendationId, decision }) =>
+      api.reviewLearningRecommendation(recommendationId, { decision }),
+    onMutate: async ({ recommendationId }) => {
+      await queryClient.cancelQueries({ queryKey: learningKeys.lists(tenantId) });
+      const snapshots = queryClient.getQueriesData<LearningRecommendationListResponse>({
+        queryKey: learningKeys.lists(tenantId),
+      });
+      const isCached = snapshots.some(([, snapshot]) =>
+        snapshot?.recommendations.some((item) => item.recommendationId === recommendationId),
+      );
+      for (const [queryKey] of isCached ? snapshots : []) {
+        queryClient.setQueryData<LearningRecommendationListResponse>(queryKey, (current) =>
+          removePendingRecommendation(current, recommendationId),
+        );
+      }
+      return { snapshots };
+    },
+    onError: (_error, _variables, context) => {
+      for (const [queryKey, snapshot] of context?.snapshots ?? []) {
+        queryClient.setQueryData(queryKey, snapshot);
+      }
+    },
+    onSettled: async () => {
+      await queryClient.invalidateQueries({ queryKey: learningKeys.lists(tenantId) });
+    },
+  });
+}
+
+function removePendingRecommendation(
+  current: LearningRecommendationListResponse | undefined,
+  recommendationId: string,
+): LearningRecommendationListResponse | undefined {
+  if (!current) {
+    return current;
+  }
+  const total = Math.max(0, current.total - 1);
+  return {
+    ...current,
+    recommendations: current.recommendations.filter(
+      (item) => item.recommendationId !== recommendationId,
+    ),
+    total,
+    totalPages: total === 0 ? 0 : Math.ceil(total / current.pageSize),
+  };
+}

--- a/apps/web/src/contexts/materials/index.ts
+++ b/apps/web/src/contexts/materials/index.ts
@@ -4,6 +4,10 @@ export { useGenerateMaterialsMutation } from "./hooks/useGenerateMaterialsMutati
 export { useGenerateInterviewPrepMutation } from "./hooks/useGenerateInterviewPrepMutation.js";
 export { useOpenArtifactMutation } from "./hooks/useOpenArtifactMutation.js";
 export {
+  useReviewLearningRecommendationMutation,
+  type ReviewLearningRecommendationVariables,
+} from "./hooks/useReviewLearningRecommendationMutation.js";
+export {
   useRetailorCurrentPolicyMutation,
   useRetailorJobMutation,
   useTailorJobMutation,

--- a/apps/web/src/contexts/operations/hooks/useLearningRecommendationsQuery.test.ts
+++ b/apps/web/src/contexts/operations/hooks/useLearningRecommendationsQuery.test.ts
@@ -1,0 +1,61 @@
+import type {
+  LearningRecommendationEvidenceListResponse,
+  LearningRecommendationListResponse,
+} from "@jobctrl/contracts";
+import { waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { renderHookWithProviders } from "../../../test/render.js";
+import { buildTestPorts } from "../../../test/testPorts.js";
+import {
+  useLearningRecommendationEvidenceQuery,
+  useLearningRecommendationsQuery,
+} from "./useLearningRecommendationsQuery.js";
+
+const recommendationId = `learning-recommendation:${"a".repeat(64)}`;
+
+const recommendationList: LearningRecommendationListResponse = {
+  ok: true,
+  recommendations: [],
+  page: 2,
+  pageSize: 10,
+  total: 0,
+  totalPages: 0,
+};
+
+const evidenceList: LearningRecommendationEvidenceListResponse = {
+  ok: true,
+  recommendationId,
+  evidence: [],
+  page: 1,
+  pageSize: 25,
+  total: 0,
+  totalPages: 0,
+};
+
+describe("learning recommendation queries", () => {
+  it("reads one tenant-scoped recommendation page through the API port", async () => {
+    const learningRecommendations = vi.fn(async () => recommendationList);
+    const { result } = renderHookWithProviders(
+      () => useLearningRecommendationsQuery({ page: 2, pageSize: 10 }),
+      { ports: buildTestPorts({ api: { learningRecommendations } }) },
+    );
+
+    await waitFor(() => expect(result.current.data).toBe(recommendationList));
+    expect(learningRecommendations).toHaveBeenCalledWith({ page: 2, pageSize: 10 });
+  });
+
+  it("reads bounded evidence for one recommendation through the API port", async () => {
+    const learningRecommendationEvidence = vi.fn(async () => evidenceList);
+    const { result } = renderHookWithProviders(
+      () => useLearningRecommendationEvidenceQuery(recommendationId, { page: 1, pageSize: 25 }),
+      { ports: buildTestPorts({ api: { learningRecommendationEvidence } }) },
+    );
+
+    await waitFor(() => expect(result.current.data).toBe(evidenceList));
+    expect(learningRecommendationEvidence).toHaveBeenCalledWith(recommendationId, {
+      page: 1,
+      pageSize: 25,
+    });
+  });
+});

--- a/apps/web/src/contexts/operations/hooks/useLearningRecommendationsQuery.ts
+++ b/apps/web/src/contexts/operations/hooks/useLearningRecommendationsQuery.ts
@@ -1,0 +1,36 @@
+import type {
+  LearningRecommendationEvidenceListQuery,
+  LearningRecommendationEvidenceListResponse,
+  LearningRecommendationListQuery,
+  LearningRecommendationListResponse,
+} from "@jobctrl/contracts";
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+
+import { usePorts } from "../../../shared/providers/PortsProvider.js";
+import { useTenantId } from "../../../shared/providers/TenantProvider.js";
+import { learningKeys } from "../learningKeys.js";
+
+const DEFAULT_PAGE = { page: 1, pageSize: 50 } as const;
+
+export function useLearningRecommendationsQuery(
+  input: Partial<LearningRecommendationListQuery> = DEFAULT_PAGE,
+): UseQueryResult<LearningRecommendationListResponse> {
+  const tenantId = useTenantId();
+  const { api } = usePorts();
+  return useQuery({
+    queryKey: learningKeys.list(tenantId, input),
+    queryFn: () => api.learningRecommendations(input),
+  });
+}
+
+export function useLearningRecommendationEvidenceQuery(
+  recommendationId: string,
+  input: Partial<LearningRecommendationEvidenceListQuery> = DEFAULT_PAGE,
+): UseQueryResult<LearningRecommendationEvidenceListResponse> {
+  const tenantId = useTenantId();
+  const { api } = usePorts();
+  return useQuery({
+    queryKey: learningKeys.evidenceList(tenantId, recommendationId, input),
+    queryFn: () => api.learningRecommendationEvidence(recommendationId, input),
+  });
+}

--- a/apps/web/src/contexts/operations/index.ts
+++ b/apps/web/src/contexts/operations/index.ts
@@ -85,6 +85,7 @@ export { healthKeys } from "./healthKeys.js";
 export { settingsKeys } from "./settingsKeys.js";
 export { browserCapabilityKeys } from "./browserCapabilityKeys.js";
 export { jobsKeys } from "./jobsKeys.js";
+export { learningKeys } from "./learningKeys.js";
 export { outcomesKeys } from "./outcomesKeys.js";
 export { workflowRunsKeys } from "./workflowRunsKeys.js";
 
@@ -129,6 +130,10 @@ export {
 export { useJobApplicationOutcomesQuery } from "./hooks/useJobApplicationOutcomesQuery.js";
 export { useJobDetailQuery } from "./hooks/useJobDetailQuery.js";
 export { useJobsListQuery } from "./hooks/useJobsListQuery.js";
+export {
+  useLearningRecommendationEvidenceQuery,
+  useLearningRecommendationsQuery,
+} from "./hooks/useLearningRecommendationsQuery.js";
 export { usePipelineOperationsQuery } from "./hooks/usePipelineOperationsQuery.js";
 export { useWorkflowRunsListQuery } from "./hooks/useWorkflowRunsListQuery.js";
 

--- a/apps/web/src/contexts/operations/learningKeys.ts
+++ b/apps/web/src/contexts/operations/learningKeys.ts
@@ -1,0 +1,18 @@
+import type {
+  LearningRecommendationEvidenceListQuery,
+  LearningRecommendationListQuery,
+} from "@jobctrl/contracts";
+import type { TenantId } from "@jobctrl/domain-types";
+
+export const learningKeys = {
+  all: (tenantId: TenantId) => ["tenant", tenantId, "operations", "learning"] as const,
+  lists: (tenantId: TenantId) => [...learningKeys.all(tenantId), "recommendations"] as const,
+  list: (tenantId: TenantId, input: Partial<LearningRecommendationListQuery>) =>
+    [...learningKeys.lists(tenantId), input] as const,
+  evidence: (tenantId: TenantId) => [...learningKeys.all(tenantId), "evidence"] as const,
+  evidenceList: (
+    tenantId: TenantId,
+    recommendationId: string,
+    input: Partial<LearningRecommendationEvidenceListQuery>,
+  ) => [...learningKeys.evidence(tenantId), recommendationId, input] as const,
+};

--- a/apps/web/src/contexts/operations/queryKeys.ts
+++ b/apps/web/src/contexts/operations/queryKeys.ts
@@ -11,6 +11,7 @@ export { applyReviewKeys } from "./applyReviewKeys.js";
 export { outcomesKeys } from "./outcomesKeys.js";
 export { workflowRunsKeys } from "./workflowRunsKeys.js";
 export { healthKeys } from "./healthKeys.js";
+export { learningKeys } from "./learningKeys.js";
 export { profileKeys } from "../profile/queryKeys.js";
 export { discoveryKeys } from "../discovery/queryKeys.js";
 export { enrichmentKeys } from "../enrichment/queryKeys.js";

--- a/apps/web/src/demo/DemoApiClientAdapter.ts
+++ b/apps/web/src/demo/DemoApiClientAdapter.ts
@@ -139,6 +139,10 @@ export class DemoApiClientAdapter implements ApiClientPort {
     return this.read((model) => model.analytics.summary);
   }
 
+  learningRecommendations = this.unsupported("learningRecommendations");
+  learningRecommendationEvidence = this.unsupported("learningRecommendationEvidence");
+  reviewLearningRecommendation = this.unsupported("reviewLearningRecommendation");
+
   digest() {
     return this.read((model) => model.dashboard.digest);
   }

--- a/apps/web/src/demo/capabilities.ts
+++ b/apps/web/src/demo/capabilities.ts
@@ -14,6 +14,15 @@ export const DEMO_CAPABILITY_MANIFEST = {
   dashboardSummary: local("Reads the synthetic dashboard projection."),
   pipelineOperations: unavailable("Pipeline operations telemetry is unavailable in the public demo."),
   outcomeAnalytics: local("Reads synthetic conversion analytics."),
+  learningRecommendations: unavailable(
+    "Learning recommendations require the local audited database.",
+  ),
+  learningRecommendationEvidence: unavailable(
+    "Learning evidence requires the local audited database.",
+  ),
+  reviewLearningRecommendation: unavailable(
+    "Learning recommendation review requires the local audited database.",
+  ),
   digest: local("Reads the synthetic daily digest."),
   acknowledgeDigest: local("Acknowledges a digest only in browser-local state."),
   activity: local("Reads synthetic activity history."),

--- a/apps/web/src/shared/adapters/local/FetchApiClientAdapter.ts
+++ b/apps/web/src/shared/adapters/local/FetchApiClientAdapter.ts
@@ -30,6 +30,21 @@ export class FetchApiClientAdapter implements ApiClientPort {
   outcomeAnalytics() {
     return this.client.outcomeAnalytics();
   }
+  learningRecommendations(query: Parameters<JobCtrlApiClient["learningRecommendations"]>[0] = {}) {
+    return this.client.learningRecommendations(query);
+  }
+  learningRecommendationEvidence(
+    recommendationId: string,
+    query: Parameters<JobCtrlApiClient["learningRecommendationEvidence"]>[1] = {},
+  ) {
+    return this.client.learningRecommendationEvidence(recommendationId, query);
+  }
+  reviewLearningRecommendation(
+    recommendationId: string,
+    body: Parameters<JobCtrlApiClient["reviewLearningRecommendation"]>[1],
+  ) {
+    return this.client.reviewLearningRecommendation(recommendationId, body);
+  }
   digest() {
     return this.client.digest();
   }

--- a/apps/web/src/shared/ports/ApiClientPort.ts
+++ b/apps/web/src/shared/ports/ApiClientPort.ts
@@ -83,6 +83,12 @@ import type {
   JobListQuery,
   JobMutationResponse,
   JobSummary,
+  LearningRecommendationEvidenceListQuery,
+  LearningRecommendationEvidenceListResponse,
+  LearningRecommendationListQuery,
+  LearningRecommendationListResponse,
+  LearningRecommendationReviewRequest,
+  LearningRecommendationReviewResponse,
   MarkJobActionRequest,
   ManualCaptureDismissRequest,
   ManualCaptureDismissResponse,
@@ -192,6 +198,17 @@ export interface ApiClientPort {
   dashboardSummary(): Promise<DashboardSummary>;
   pipelineOperations(): Promise<PipelineOperationsSnapshot>;
   outcomeAnalytics(): Promise<OutcomeAnalyticsSummary>;
+  learningRecommendations(
+    query?: Partial<LearningRecommendationListQuery>,
+  ): Promise<LearningRecommendationListResponse>;
+  learningRecommendationEvidence(
+    recommendationId: string,
+    query?: Partial<LearningRecommendationEvidenceListQuery>,
+  ): Promise<LearningRecommendationEvidenceListResponse>;
+  reviewLearningRecommendation(
+    recommendationId: string,
+    body: LearningRecommendationReviewRequest,
+  ): Promise<LearningRecommendationReviewResponse>;
   digest(): Promise<DailyDigest>;
   acknowledgeDigest(body?: DigestAcknowledgeRequest): Promise<DigestAcknowledgeResponse>;
   activity(query?: Partial<ActivityListQuery>): Promise<PaginatedResponse<ActivityEventSummary>>;


### PR DESCRIPTION
## Recovery

- Restores the exact single-commit diff from original PR #693 as its own reviewable layer in new GitHub Stack #738.
- No implementation content was added, removed, or combined during recovery.

## Why

The original PR was marked merged into an already-merged parent branch, so its commit did not reach `main`. This reconstructed stack roots the first recovered layer on current `main` and preserves the original order through PR #707.

## Validation

- Original focused implementation and validation record: #693
- Content-equivalent cumulative recovery head: #710 (full CI passed before this individual stack was published)
- This PR contains exactly one recovered commit.