### PR TITLE
feat(materials): add tailoring policy rollback history

### DIFF
--- a/workers/automation/src/jobctrl/domain/materials/policy.py
+++ b/workers/automation/src/jobctrl/domain/materials/policy.py
@@ -6,7 +6,7 @@ import hashlib
 import json
 from collections.abc import Mapping as MappingABC
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, Literal
 
 from jobctrl.domain.operations.feedback import TAILORING_FEEDBACK_RULE_ALLOWLIST
 from jobctrl.domain.tenant import LOCAL_TENANT, TenantId
@@ -31,6 +31,9 @@ _LEARNED_TAILORING_RULE_PROMPTS = {
 
 class TailoringPolicyChangedError(RuntimeError):
     """Raised before artifact persistence when the policy snapshot advanced."""
+
+
+TailoringPolicyRollbackReason = Literal["user_requested"]
 
 
 @dataclass(frozen=True)
@@ -695,6 +698,7 @@ __all__ = [
     "RevisionGatePolicy",
     "TailoringPolicy",
     "TailoringPolicyChangedError",
+    "TailoringPolicyRollbackReason",
     "WritingStylePolicy",
     "adapt_requirement_led_controls",
     "fingerprint_value",

--- a/workers/automation/src/jobctrl/domain/ports/materials.py
+++ b/workers/automation/src/jobctrl/domain/ports/materials.py
@@ -25,7 +25,7 @@ from jobctrl.domain.materials.analysis import (
     JobAnalysisDraft,
 )
 from jobctrl.domain.materials.entities import Artifact
-from jobctrl.domain.materials.policy import TailoringPolicy
+from jobctrl.domain.materials.policy import TailoringPolicy, TailoringPolicyRollbackReason
 from jobctrl.domain.materials.provenance import BulletProvenanceSet
 from jobctrl.domain.materials.value_objects import (
     ArtifactStatus,
@@ -199,6 +199,19 @@ class TailoringPolicyRepository(Protocol):
         """Return the latest persisted tailoring policy, or ``None``."""
         ...
 
+    def get_version(self, tenant_id: TenantId, version: int) -> TailoringPolicy | None:
+        """Return one tenant-owned historical policy revision, or ``None``."""
+        ...
+
+    def list_history(
+        self,
+        tenant_id: TenantId,
+        *,
+        limit: int = 100,
+    ) -> list[TailoringPolicy]:
+        """Return the bounded append-only policy history, newest first."""
+        ...
+
     def save(self, policy: TailoringPolicy) -> None:
         """Persist a tailoring policy version."""
         ...
@@ -210,6 +223,17 @@ class TailoringPolicyRepository(Protocol):
         expected_current_version: int | None = None,
     ) -> TailoringPolicy:
         """Resolve the candidate only if the pre-generation snapshot is current."""
+        ...
+
+    def rollback_to(
+        self,
+        tenant_id: TenantId,
+        *,
+        target_version: int,
+        reason: TailoringPolicyRollbackReason,
+        rolled_back_at: str,
+    ) -> TailoringPolicy:
+        """Append a current revision that restores a prior effective policy."""
         ...
 
 

--- a/workers/automation/src/jobctrl/infrastructure/materials/__init__.py
+++ b/workers/automation/src/jobctrl/infrastructure/materials/__init__.py
@@ -29,6 +29,7 @@ from jobctrl.infrastructure.materials.sqlite_repository import (
     SqliteLearningRecommendationReviewRepository,
     SqliteMaterialsRepository,
     SqliteTailoringPolicyRepository,
+    TailoringPolicyRevisionError,
 )
 from jobctrl.infrastructure.materials.unit_of_work import SqliteUnitOfWork
 
@@ -43,4 +44,5 @@ __all__ = [
     "SqliteMaterialsRepository",
     "SqliteTailoringPolicyRepository",
     "SqliteUnitOfWork",
+    "TailoringPolicyRevisionError",
 ]

--- a/workers/automation/src/jobctrl/infrastructure/materials/sqlite_repository.py
+++ b/workers/automation/src/jobctrl/infrastructure/materials/sqlite_repository.py
@@ -28,7 +28,11 @@ from jobctrl.database import effective_tailoring_min_score, ensure_tailoring_pol
 from jobctrl.domain.identifiers import JobId, canonical_job_id
 from jobctrl.domain.materials.aggregate import MaterialsSet
 from jobctrl.domain.materials.entities import Artifact
-from jobctrl.domain.materials.policy import TailoringPolicy, TailoringPolicyChangedError
+from jobctrl.domain.materials.policy import (
+    TailoringPolicy,
+    TailoringPolicyChangedError,
+    TailoringPolicyRollbackReason,
+)
 from jobctrl.domain.operations.learning import (
     LearningRecommendationDecision,
     LearningRecommendationReview,
@@ -72,6 +76,10 @@ class MaterialsGenerationConflict(ValueError):
 
 class LearningRecommendationReviewError(ValueError):
     """Raised when an explicit recommendation decision cannot be applied."""
+
+
+class TailoringPolicyRevisionError(ValueError):
+    """Raised when a requested policy history operation is not valid."""
 
 
 # ---------------------------------------------------------------------------
@@ -1147,6 +1155,49 @@ class SqliteTailoringPolicyRepository:
             return None
         return self._row_to_policy(row)
 
+    def get_version(self, tenant_id: TenantId, version: int) -> TailoringPolicy | None:
+        row = self._conn.execute(
+            """
+            SELECT tenant_id, version, prompt_version, schema_version,
+                   judge_schema_version, prompt_fingerprint, config_fingerprint,
+                   profile_policy_fingerprint, custom_prompt_fingerprint,
+                   generator_settings_json, judge_settings_json,
+                   runtime_settings_json, rollback_of_version, rollback_reason,
+                   created_at, created_from_event_id
+            FROM tailoring_policies
+            WHERE tenant_id = ? AND version = ?
+            """,
+            (str(tenant_id), version),
+        ).fetchone()
+        if row is None:
+            return None
+        return self._row_to_policy(row)
+
+    def list_history(
+        self,
+        tenant_id: TenantId,
+        *,
+        limit: int = 100,
+    ) -> list[TailoringPolicy]:
+        if limit < 1 or limit > 100:
+            raise TailoringPolicyRevisionError("policy history limit must be between 1 and 100")
+        rows = self._conn.execute(
+            """
+            SELECT tenant_id, version, prompt_version, schema_version,
+                   judge_schema_version, prompt_fingerprint, config_fingerprint,
+                   profile_policy_fingerprint, custom_prompt_fingerprint,
+                   generator_settings_json, judge_settings_json,
+                   runtime_settings_json, rollback_of_version, rollback_reason,
+                   created_at, created_from_event_id
+            FROM tailoring_policies
+            WHERE tenant_id = ?
+            ORDER BY version DESC
+            LIMIT ?
+            """,
+            (str(tenant_id), limit),
+        ).fetchall()
+        return [self._row_to_policy(row) for row in rows]
+
     def save(self, policy: TailoringPolicy) -> None:
         self._insert(policy)
         self._conn.commit()
@@ -1231,6 +1282,65 @@ class SqliteTailoringPolicyRepository:
             self._insert(policy)
             self._conn.commit()
             return policy
+        except Exception:
+            self._conn.rollback()
+            raise
+
+    def rollback_to(
+        self,
+        tenant_id: TenantId,
+        *,
+        target_version: int,
+        reason: TailoringPolicyRollbackReason,
+        rolled_back_at: str,
+    ) -> TailoringPolicy:
+        if reason != "user_requested":
+            raise TailoringPolicyRevisionError("unsupported tailoring policy rollback reason")
+        if not str(rolled_back_at or "").strip():
+            raise TailoringPolicyRevisionError("rolled_back_at must not be empty")
+
+        self._conn.execute("BEGIN IMMEDIATE")
+        try:
+            current = self.get_current(tenant_id)
+            if current is None:
+                raise TailoringPolicyRevisionError("tailoring policy is not initialized")
+            target = self.get_version(tenant_id, target_version)
+            if target is None:
+                raise TailoringPolicyRevisionError(
+                    "target tailoring policy version does not exist for tenant"
+                )
+            if (
+                current.rollback_of_version == target.version
+                and current.same_config_as(target)
+            ):
+                self._conn.commit()
+                return current
+            if target.version >= current.version:
+                raise TailoringPolicyRevisionError(
+                    "rollback target must precede the current tailoring policy"
+                )
+
+            rollback = TailoringPolicy(
+                tenant_id=tenant_id,
+                version=current.version + 1,
+                prompt_version=target.prompt_version,
+                schema_version=target.schema_version,
+                judge_schema_version=target.judge_schema_version,
+                prompt_fingerprint=target.prompt_fingerprint,
+                config_fingerprint=target.config_fingerprint,
+                profile_policy_fingerprint=target.profile_policy_fingerprint,
+                custom_prompt_fingerprint=target.custom_prompt_fingerprint,
+                generator_settings=target.generator_settings,
+                judge_settings=target.judge_settings,
+                runtime_settings=target.runtime_settings,
+                rollback_of_version=target.version,
+                rollback_reason=reason,
+                created_at=rolled_back_at,
+                created_from_event_id=None,
+            )
+            self._insert(rollback)
+            self._conn.commit()
+            return rollback
         except Exception:
             self._conn.rollback()
             raise

--- a/workers/automation/tests/test_tailoring_policy_revisions.py
+++ b/workers/automation/tests/test_tailoring_policy_revisions.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+import threading
+
+import pytest
+
+from jobctrl.database import close_connection, get_connection, init_db
+from jobctrl.domain.materials.policy import TailoringPolicy
+from jobctrl.domain.tenant import TenantId
+from jobctrl.infrastructure.materials import (
+    SqliteTailoringPolicyRepository,
+    TailoringPolicyRevisionError,
+)
+
+
+_TENANT_A = TenantId("tenant-a")
+_TENANT_B = TenantId("tenant-b")
+
+
+def test_history_and_rollback_are_append_only_and_tenant_scoped(tmp_path: Path) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    conn = init_db(db_path)
+    repository = SqliteTailoringPolicyRepository(conn)
+    original = _policy(_TENANT_A)
+    learned = original.with_learned_tailoring_rule(
+        rule_key="fact_handling",
+        rule_value="require_source_match",
+        version=2,
+        created_at="2026-08-01T11:00:00Z",
+    )
+    repository.save(original)
+    repository.save(learned)
+    repository.save(_policy(_TENANT_B))
+
+    assert [policy.version for policy in repository.list_history(_TENANT_A)] == [2, 1]
+    assert [policy.version for policy in repository.list_history(_TENANT_B)] == [1]
+    assert repository.get_version(_TENANT_A, 2) == learned
+    assert repository.get_version(_TENANT_B, 2) is None
+
+    rollback = repository.rollback_to(
+        _TENANT_A,
+        target_version=1,
+        reason="user_requested",
+        rolled_back_at="2026-08-01T12:00:00Z",
+    )
+
+    assert rollback.version == 3
+    assert rollback.rollback_of_version == 1
+    assert rollback.rollback_reason == "user_requested"
+    assert rollback.created_at == "2026-08-01T12:00:00Z"
+    assert rollback.learned_tailoring_rules.rules == ()
+    assert repository.get_current(_TENANT_A) == rollback
+    assert repository.get_version(_TENANT_A, 2) == learned
+    assert [policy.version for policy in repository.list_history(_TENANT_A)] == [3, 2, 1]
+    close_connection(db_path)
+
+
+def test_rollback_validation_and_replay_do_not_duplicate_history(tmp_path: Path) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    conn = init_db(db_path)
+    repository = SqliteTailoringPolicyRepository(conn)
+
+    with pytest.raises(TailoringPolicyRevisionError, match="not initialized"):
+        repository.rollback_to(
+            _TENANT_A,
+            target_version=1,
+            reason="user_requested",
+            rolled_back_at="2026-08-01T12:00:00Z",
+        )
+
+    original = _policy(_TENANT_A)
+    repository.save(original)
+    with pytest.raises(TailoringPolicyRevisionError, match="must precede"):
+        repository.rollback_to(
+            _TENANT_A,
+            target_version=1,
+            reason="user_requested",
+            rolled_back_at="2026-08-01T12:00:00Z",
+        )
+
+    repository.save(
+        original.with_learned_tailoring_rule(
+            rule_key="fact_handling",
+            rule_value="require_source_match",
+            version=2,
+            created_at="2026-08-01T11:00:00Z",
+        )
+    )
+    with pytest.raises(TailoringPolicyRevisionError, match="does not exist"):
+        repository.rollback_to(
+            _TENANT_A,
+            target_version=99,
+            reason="user_requested",
+            rolled_back_at="2026-08-01T12:00:00Z",
+        )
+
+    first = repository.rollback_to(
+        _TENANT_A,
+        target_version=1,
+        reason="user_requested",
+        rolled_back_at="2026-08-01T12:00:00Z",
+    )
+    replay = repository.rollback_to(
+        _TENANT_A,
+        target_version=1,
+        reason="user_requested",
+        rolled_back_at="2026-08-01T12:01:00Z",
+    )
+
+    assert replay == first
+    assert [policy.version for policy in repository.list_history(_TENANT_A)] == [3, 2, 1]
+    close_connection(db_path)
+
+
+def test_concurrent_rollback_replay_returns_one_appended_revision(tmp_path: Path) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    setup_conn = init_db(db_path)
+    repository = SqliteTailoringPolicyRepository(setup_conn)
+    original = _policy(_TENANT_A)
+    repository.save(original)
+    repository.save(
+        original.with_learned_tailoring_rule(
+            rule_key="fact_handling",
+            rule_value="require_source_match",
+            version=2,
+            created_at="2026-08-01T11:00:00Z",
+        )
+    )
+    close_connection(db_path)
+    start = threading.Event()
+
+    def rollback():
+        conn = get_connection(db_path)
+        try:
+            start.wait(timeout=5)
+            return SqliteTailoringPolicyRepository(conn).rollback_to(
+                _TENANT_A,
+                target_version=1,
+                reason="user_requested",
+                rolled_back_at="2026-08-01T12:00:00Z",
+            )
+        finally:
+            close_connection(db_path)
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        futures = [executor.submit(rollback) for _ in range(2)]
+        start.set()
+        rollbacks = [future.result(timeout=10) for future in futures]
+
+    assert [policy.version for policy in rollbacks] == [3, 3]
+    check_conn = get_connection(db_path)
+    try:
+        assert [
+            policy.version
+            for policy in SqliteTailoringPolicyRepository(check_conn).list_history(_TENANT_A)
+        ] == [3, 2, 1]
+    finally:
+        close_connection(db_path)
+
+
+def _policy(tenant_id: TenantId) -> TailoringPolicy:
+    return TailoringPolicy(
+        tenant_id=tenant_id,
+        version=1,
+        prompt_version="tailor.v2.quality-gated",
+        schema_version="tailored-resume.v1",
+        judge_schema_version="tailor-judge.v1",
+        prompt_fingerprint="sha256:prompt",
+        config_fingerprint="sha256:config",
+        profile_policy_fingerprint="sha256:profile",
+        custom_prompt_fingerprint="sha256:custom",
+        generator_settings={"candidate_models": ["local:draft"]},
+        judge_settings={"judge_model": "local:judge", "min_score": 0.82},
+        runtime_settings={"validation_mode": "normal"},
+        created_at="2026-08-01T10:00:00Z",
+    )


### PR DESCRIPTION
## Recovery

- Restores the exact single-commit diff from original PR #696 as its own reviewable layer in new GitHub Stack #738.
- No implementation content was added, removed, or combined during recovery.

## Why

The original PR was marked merged into an already-merged parent branch, so its commit did not reach `main`. This reconstructed stack roots the first recovered layer on current `main` and preserves the original order through PR #707.

## Validation

- Original focused implementation and validation record: #696
- Content-equivalent cumulative recovery head: #710 (full CI passed before this individual stack was published)
- This PR contains exactly one recovered commit.