### PR TITLE
feat(api): add tailoring policy rollback command

### DIFF
--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -74,6 +74,7 @@ import {
   RoleMatchFeedbackDecisionSchema,
   RetailorJobRequestSchema,
   ReviewLearningRecommendationResultSchema,
+  RollbackTailoringPolicyResultSchema,
   RpcMethods,
   ResumeTemplateDefaultSelectionRequestSchema,
   ResumeTemplateVersionSaveRequestSchema,
@@ -83,6 +84,8 @@ import {
   ResumeReviewDraftRenderRequestSchema,
   ResumeReviewDraftRevisionSaveRequestSchema,
   TailoringFeedbackSignalReviewRequestSchema,
+  TailoringPolicyRollbackRequestSchema,
+  TailoringPolicyRollbackResponseSchema,
   RunPipelineStagesRequestSchema,
   SettingsUpdateRequestSchema,
   type ExtensionCapabilityTokenResponse,
@@ -601,6 +604,52 @@ export function buildApp(options: BuildAppOptions): FastifyInstance {
       ),
     ),
   );
+
+  app.post("/v1/learning/policies/materials/rollbacks", async (request, reply) => {
+    const body = parseBody(reply, TailoringPolicyRollbackRequestSchema, request.body ?? {});
+    if (!body) {
+      return undefined;
+    }
+
+    let response;
+    try {
+      response = await providerDispatcher.call(RpcMethods.RollbackTailoringPolicy, {
+        tenantId: "local",
+        targetVersion: body.targetVersion,
+        expectedAppDir: appDir,
+        expectedDbPath: options.dbPath,
+      });
+    } catch {
+      return tailoringPolicyRollbackFailure(reply, 503);
+    }
+    if (response.error) {
+      return tailoringPolicyRollbackFailure(
+        reply,
+        response.error.code === JsonRpcErrorCodes.InvalidParams ? 409 : 502,
+      );
+    }
+
+    const parsedResult = RollbackTailoringPolicyResultSchema.safeParse(response.result);
+    if (
+      !parsedResult.success ||
+      parsedResult.data.rollbackOfVersion !== body.targetVersion
+    ) {
+      return tailoringPolicyRollbackFailure(reply, 502);
+    }
+    return TailoringPolicyRollbackResponseSchema.parse({
+      ok: true,
+      context: parsedResult.data.context,
+      policyKind: parsedResult.data.policyKind,
+      version: parsedResult.data.policyVersion,
+      status: "current",
+      learnedRules: parsedResult.data.learnedRules,
+      sourceReviewId: null,
+      sourceRecommendationId: null,
+      rollbackOfVersion: parsedResult.data.rollbackOfVersion,
+      rollbackReasonCode: parsedResult.data.rollbackReasonCode,
+      createdAt: parsedResult.data.rolledBackAt,
+    });
+  });
 
   app.get<{ Params: { recommendationId: string } }>(
     "/v1/learning/recommendations/:recommendationId/evidence",
@@ -3367,6 +3416,15 @@ function learningRecommendationReviewFailure(reply: FastifyReply, statusCode: 40
     ok: false as const,
     error: "learning_recommendation_review_failed" as const,
     message: "The learning recommendation review could not be completed.",
+  };
+}
+
+function tailoringPolicyRollbackFailure(reply: FastifyReply, statusCode: 409 | 502 | 503) {
+  void reply.code(statusCode);
+  return {
+    ok: false as const,
+    error: "tailoring_policy_rollback_failed" as const,
+    message: "The tailoring policy rollback could not be completed.",
   };
 }
 

--- a/apps/api/test/rpc-contracts.test.ts
+++ b/apps/api/test/rpc-contracts.test.ts
@@ -21,6 +21,8 @@ import {
   RederiveLearningRecommendationsResultSchema,
   ReviewLearningRecommendationParamsSchema,
   ReviewLearningRecommendationResultSchema,
+  RollbackTailoringPolicyParamsSchema,
+  RollbackTailoringPolicyResultSchema,
   RefreshCompensationParamsSchema,
   RefreshCompensationResultSchema,
   RescoreJobParamsSchema,
@@ -149,6 +151,55 @@ describe("learning recommendation review RPC contract", () => {
         policyKind: "tailoring_rule",
         policyVersion: 2,
         reviewedAt: "2026-08-01T12:34:56Z",
+      }),
+    ).toThrow();
+  });
+});
+
+describe("tailoring policy rollback RPC contract", () => {
+  it("registers a runtime-scoped rollback with closed policy metadata", () => {
+    expect(RpcMethods.RollbackTailoringPolicy).toBe("rollback_tailoring_policy");
+    expect(
+      RollbackTailoringPolicyParamsSchema.parse({
+        targetVersion: 1,
+        expectedAppDir: "/tmp/jobctrl",
+        expectedDbPath: "/tmp/jobctrl/jobctrl.db",
+      }),
+    ).toEqual({
+      tenantId: "local",
+      targetVersion: 1,
+      expectedAppDir: "/tmp/jobctrl",
+      expectedDbPath: "/tmp/jobctrl/jobctrl.db",
+    });
+    expect(
+      RollbackTailoringPolicyResultSchema.parse({
+        status: "succeeded",
+        context: "materials",
+        policyKind: "tailoring_rule",
+        policyVersion: 3,
+        rollbackOfVersion: 1,
+        rollbackReasonCode: "user_requested",
+        learnedRules: [],
+        rolledBackAt: "2026-08-01T12:34:56+00:00",
+      }),
+    ).toMatchObject({
+      policyVersion: 3,
+      rollbackOfVersion: 1,
+      rolledBackAt: "2026-08-01T12:34:56.000Z",
+    });
+    expect(() =>
+      RollbackTailoringPolicyParamsSchema.parse({ targetVersion: 0 }),
+    ).toThrow();
+    expect(() =>
+      RollbackTailoringPolicyResultSchema.parse({
+        status: "succeeded",
+        context: "materials",
+        policyKind: "tailoring_rule",
+        policyVersion: 3,
+        rollbackOfVersion: 1,
+        rollbackReasonCode: "private narrative",
+        learnedRules: [],
+        rolledBackAt: "2026-08-01T12:34:56Z",
       }),
     ).toThrow();
   });

--- a/apps/api/test/server.test.ts
+++ b/apps/api/test/server.test.ts
@@ -13,6 +13,7 @@ import {
   LearningRecommendationListResponseSchema,
   LearningRecommendationReviewResponseSchema,
   TailoringPolicyRevisionListResponseSchema,
+  TailoringPolicyRollbackResponseSchema,
   PipelineOperationsSnapshotSchema,
   ProviderConfigurationKeys,
   RpcMethods,
@@ -2683,6 +2684,111 @@ describe("local TypeScript API", () => {
     ).toBe(before);
     unchanged.close();
     await app.close();
+  });
+
+  it("rolls back tailoring policy through the runtime-scoped RPC boundary", async () => {
+    const call = vi.fn<JsonRpcDispatcher["call"]>(async () => ({
+      jsonrpc: "2.0" as const,
+      id: 1,
+      result: {
+        status: "succeeded",
+        context: "materials",
+        policyKind: "tailoring_rule",
+        policyVersion: 3,
+        rollbackOfVersion: 1,
+        rollbackReasonCode: "user_requested",
+        learnedRules: [],
+        rolledBackAt: "2026-08-01T12:34:56+00:00",
+      },
+    }));
+    const app = buildApp({
+      ...options,
+      providerDispatcher: { call, close: vi.fn(async () => undefined) },
+    });
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/v1/learning/policies/materials/rollbacks",
+      payload: { targetVersion: 1 },
+    });
+
+    expect(response.statusCode, response.body).toBe(200);
+    const parsed = TailoringPolicyRollbackResponseSchema.parse(response.json());
+    expect(parsed).toEqual({
+      ok: true,
+      context: "materials",
+      policyKind: "tailoring_rule",
+      version: 3,
+      status: "current",
+      learnedRules: [],
+      sourceReviewId: null,
+      sourceRecommendationId: null,
+      rollbackOfVersion: 1,
+      rollbackReasonCode: "user_requested",
+      createdAt: "2026-08-01T12:34:56.000Z",
+    });
+    expect(call).toHaveBeenCalledWith(RpcMethods.RollbackTailoringPolicy, {
+      tenantId: "local",
+      targetVersion: 1,
+      expectedAppDir: tempDir,
+      expectedDbPath: options.dbPath,
+    });
+
+    const invalid = await app.inject({
+      method: "POST",
+      url: "/v1/learning/policies/materials/rollbacks",
+      payload: { targetVersion: 0 },
+    });
+    expect(invalid.statusCode, invalid.body).toBe(400);
+    expect(call).toHaveBeenCalledTimes(1);
+    await app.close();
+
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(response.body, { status: 200, statusText: "OK" }),
+    );
+    await expect(
+      createJobCtrlApiClient().rollbackTailoringPolicy({ targetVersion: 1 }),
+    ).resolves.toEqual(parsed);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://127.0.0.1:8766/v1/learning/policies/materials/rollbacks",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ targetVersion: 1 }),
+      }),
+    );
+    fetchMock.mockRestore();
+
+    const badCall = vi.fn<JsonRpcDispatcher["call"]>(async () => ({
+      jsonrpc: "2.0" as const,
+      id: 1,
+      result: {
+        status: "succeeded",
+        context: "materials",
+        policyKind: "tailoring_rule",
+        policyVersion: 3,
+        rollbackOfVersion: 1,
+        rollbackReasonCode: "private rollback narrative",
+        learnedRules: [],
+        rolledBackAt: "2026-08-01T12:34:56Z",
+      },
+    }));
+    const badApp = buildApp({
+      ...options,
+      providerDispatcher: { call: badCall, close: vi.fn(async () => undefined) },
+    });
+    const badResponse = await badApp.inject({
+      method: "POST",
+      url: "/v1/learning/policies/materials/rollbacks",
+      payload: { targetVersion: 1 },
+    });
+    expect(badResponse.statusCode, badResponse.body).toBe(502);
+    expect(badResponse.json()).toEqual({
+      ok: false,
+      error: "tailoring_policy_rollback_failed",
+      message: "The tailoring policy rollback could not be completed.",
+    });
+    expect(badResponse.body).not.toContain("private rollback narrative");
+    await badApp.close();
   });
 
   it("serves paginated recommendation evidence links without source content", async () => {

--- a/packages/api-client/src/client.ts
+++ b/packages/api-client/src/client.ts
@@ -91,6 +91,8 @@ import type {
   LearningRecommendationReviewResponse,
   TailoringPolicyRevisionListQuery,
   TailoringPolicyRevisionListResponse,
+  TailoringPolicyRollbackRequest,
+  TailoringPolicyRollbackResponse,
   JobMutationResponse,
   JobSummary,
   MarkJobActionRequest,
@@ -167,6 +169,7 @@ import {
   LearningRecommendationListResponseSchema,
   LearningRecommendationReviewResponseSchema,
   TailoringPolicyRevisionListResponseSchema,
+  TailoringPolicyRollbackResponseSchema,
 } from "@jobctrl/contracts";
 
 type QueryValue = boolean | number | string | null | undefined;
@@ -296,6 +299,14 @@ export class JobCtrlApiClient {
   ): Promise<TailoringPolicyRevisionListResponse> {
     return TailoringPolicyRevisionListResponseSchema.parse(
       await this.get("/v1/learning/policies/materials", query),
+    );
+  }
+
+  async rollbackTailoringPolicy(
+    body: TailoringPolicyRollbackRequest,
+  ): Promise<TailoringPolicyRollbackResponse> {
+    return TailoringPolicyRollbackResponseSchema.parse(
+      await this.post("/v1/learning/policies/materials/rollbacks", body),
     );
   }
 

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -13,6 +13,7 @@ import {
   LearningRecommendationReviewIdSchema,
   MANUAL_CAPTURE_MODE_VALUES,
   STAGES,
+  TailoringPolicyLearnedRuleSchema,
 } from "./schemas.js";
 
 /* ------------------------------------------------------------------ codes */
@@ -90,6 +91,7 @@ export const RpcMethods = {
   BrowserProfileCopy: "browser_profile_copy",
   RederiveLearningRecommendations: "rederive_learning_recommendations",
   ReviewLearningRecommendation: "review_learning_recommendation",
+  RollbackTailoringPolicy: "rollback_tailoring_policy",
 } as const;
 export type RpcMethod = (typeof RpcMethods)[keyof typeof RpcMethods];
 
@@ -586,6 +588,34 @@ export const ReviewLearningRecommendationResultSchema = z.discriminatedUnion("de
 ]);
 export type ReviewLearningRecommendationResult = z.infer<
   typeof ReviewLearningRecommendationResultSchema
+>;
+
+export const RollbackTailoringPolicyParamsSchema = z
+  .object({
+    tenantId: TenantParam,
+    expectedAppDir: z.string().trim().min(1).optional(),
+    expectedDbPath: z.string().trim().min(1).optional(),
+    targetVersion: z.number().int().positive(),
+  })
+  .strict();
+export type RollbackTailoringPolicyParams = z.infer<
+  typeof RollbackTailoringPolicyParamsSchema
+>;
+
+export const RollbackTailoringPolicyResultSchema = z
+  .object({
+    status: z.literal("succeeded"),
+    context: z.literal("materials"),
+    policyKind: z.literal("tailoring_rule"),
+    policyVersion: z.number().int().positive(),
+    rollbackOfVersion: z.number().int().positive(),
+    rollbackReasonCode: z.literal("user_requested"),
+    learnedRules: z.array(TailoringPolicyLearnedRuleSchema).max(5),
+    rolledBackAt: WorkerUtcTimestampSchema,
+  })
+  .strict();
+export type RollbackTailoringPolicyResult = z.infer<
+  typeof RollbackTailoringPolicyResultSchema
 >;
 
 export const ProfileImportParamsSchema = z

--- a/packages/contracts/src/schemas.ts
+++ b/packages/contracts/src/schemas.ts
@@ -2350,6 +2350,32 @@ export type TailoringPolicyRevisionListResponse = z.infer<
   typeof TailoringPolicyRevisionListResponseSchema
 >;
 
+export const TailoringPolicyRollbackRequestSchema = z
+  .object({ targetVersion: z.number().int().positive() })
+  .strict();
+export type TailoringPolicyRollbackRequest = z.infer<
+  typeof TailoringPolicyRollbackRequestSchema
+>;
+
+export const TailoringPolicyRollbackResponseSchema = z
+  .object({
+    ok: z.literal(true),
+    context: z.literal("materials"),
+    policyKind: z.literal("tailoring_rule"),
+    version: z.number().int().positive(),
+    status: z.literal("current"),
+    learnedRules: z.array(TailoringPolicyLearnedRuleSchema).max(5),
+    sourceReviewId: z.null(),
+    sourceRecommendationId: z.null(),
+    rollbackOfVersion: z.number().int().positive(),
+    rollbackReasonCode: z.literal("user_requested"),
+    createdAt: IsoTimestampSchema,
+  })
+  .strict();
+export type TailoringPolicyRollbackResponse = z.infer<
+  typeof TailoringPolicyRollbackResponseSchema
+>;
+
 export const LearningRecommendationSummarySchema = z
   .object({
     recommendationId: LearningRecommendationIdSchema,

--- a/workers/automation/src/jobctrl/infrastructure/materials/sqlite_repository.py
+++ b/workers/automation/src/jobctrl/infrastructure/materials/sqlite_repository.py
@@ -1311,6 +1311,7 @@ class SqliteTailoringPolicyRepository:
                 )
             if (
                 current.rollback_of_version == target.version
+                and current.rollback_reason == reason
                 and current.same_config_as(target)
             ):
                 self._conn.commit()

--- a/workers/automation/src/jobctrl/infrastructure/rpc/handlers.py
+++ b/workers/automation/src/jobctrl/infrastructure/rpc/handlers.py
@@ -35,6 +35,8 @@ from jobctrl.infrastructure.learning.sqlite_repository import (
 from jobctrl.infrastructure.materials import (
     LearningRecommendationReviewError,
     SqliteLearningRecommendationReviewRepository,
+    SqliteTailoringPolicyRepository,
+    TailoringPolicyRevisionError,
 )
 from jobctrl.infrastructure.rpc.server import JsonRpcServer, invalid_params
 from jobctrl.infrastructure.rpc.workflow_starter import WorkflowCanceler
@@ -861,6 +863,45 @@ def review_learning_recommendation(params: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def rollback_tailoring_policy(params: dict[str, Any]) -> dict[str, Any]:
+    """Append a Materials policy revision that restores a prior version."""
+
+    tenant_id = TenantId(_tenant_id(params))
+    target_version = _require(params, "targetVersion")
+    if (
+        not isinstance(target_version, int)
+        or isinstance(target_version, bool)
+        or target_version < 1
+    ):
+        raise invalid_params("targetVersion must be a positive integer")
+    assert_expected_runtime(
+        expected_app_dir=params.get("expectedAppDir"),
+        expected_db_path=params.get("expectedDbPath"),
+    )
+    try:
+        policy = SqliteTailoringPolicyRepository(get_connection()).rollback_to(
+            tenant_id,
+            target_version=target_version,
+            reason="user_requested",
+            rolled_back_at=datetime.now(UTC).isoformat(),
+        )
+    except TailoringPolicyRevisionError as exc:
+        raise invalid_params(str(exc)) from exc
+    return {
+        "status": "succeeded",
+        "context": "materials",
+        "policyKind": "tailoring_rule",
+        "policyVersion": policy.version,
+        "rollbackOfVersion": policy.rollback_of_version,
+        "rollbackReasonCode": policy.rollback_reason,
+        "learnedRules": [
+            {"ruleKey": rule_key, "ruleValue": rule_value}
+            for rule_key, rule_value in policy.learned_tailoring_rules.rules
+        ],
+        "rolledBackAt": policy.created_at,
+    }
+
+
 # ---------------------------------------------------------------------------
 # Registration
 # ---------------------------------------------------------------------------
@@ -901,6 +942,7 @@ def register_default_handlers(server: JsonRpcServer, *, canceler: WorkflowCancel
         review_learning_recommendation,
         mode="sync",
     )
+    server.register("rollback_tailoring_policy", rollback_tailoring_policy, mode="sync")
     server.register("refresh_compensation", refresh_compensation, mode="workflow")
     server.register("generate_interview_prep", generate_interview_prep, mode="workflow")
     server.register("run_contact_research", run_contact_research, mode="workflow")

--- a/workers/automation/tests/test_rpc_learning_recommendations.py
+++ b/workers/automation/tests/test_rpc_learning_recommendations.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
 from pathlib import Path
 
 from jobctrl.database import close_connection, init_db
@@ -167,6 +168,85 @@ def test_explicit_review_accepts_atomically_and_replays(
     assert conn.execute(
         "SELECT COUNT(*) FROM learning_recommendation_reviews"
     ).fetchone()[0] == 1
+    close_connection(db_path)
+
+
+def test_explicit_policy_rollback_appends_once_and_replays(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    conn = init_db(db_path)
+    policy_repository = SqliteTailoringPolicyRepository(conn)
+    original = _tailoring_policy()
+    policy_repository.save(original)
+    policy_repository.save(
+        original.with_learned_tailoring_rule(
+            rule_key="fact_handling",
+            rule_value="require_source_match",
+            version=2,
+            created_at="2026-08-01T11:00:00Z",
+        )
+    )
+    policy_repository.save(
+        replace(
+            original,
+            version=3,
+            rollback_of_version=1,
+            rollback_reason="private historical rollback narrative",
+            created_at="2026-08-01T11:30:00Z",
+        )
+    )
+    monkeypatch.setattr(handlers_mod, "get_connection", lambda: conn)
+    runtime_expectations: list[dict[str, str | None]] = []
+    monkeypatch.setattr(
+        handlers_mod,
+        "assert_expected_runtime",
+        lambda **kwargs: runtime_expectations.append(kwargs),
+    )
+    server = JsonRpcServer(workflow_starter=_stub_starter)
+    register_default_handlers(server, canceler=_stub_canceler)
+    params = {
+        "tenantId": "local",
+        "targetVersion": 1,
+        "expectedAppDir": "/tmp/jobctrl",
+        "expectedDbPath": "/tmp/jobctrl/jobctrl.db",
+    }
+
+    first = server.dispatch(
+        JsonRpcRequest(method="rollback_tailoring_policy", params=params, id=1)
+    )
+    replay = server.dispatch(
+        JsonRpcRequest(method="rollback_tailoring_policy", params=params, id=2)
+    )
+
+    assert first is not None
+    assert replay is not None
+    first_result = first.to_dict()["result"]
+    replay_result = replay.to_dict()["result"]
+    assert first_result["policyVersion"] == 4
+    assert first_result["rollbackOfVersion"] == 1
+    assert first_result["rollbackReasonCode"] == "user_requested"
+    assert first_result["learnedRules"] == []
+    assert replay_result == first_result
+    assert runtime_expectations == [
+        {
+            "expected_app_dir": "/tmp/jobctrl",
+            "expected_db_path": "/tmp/jobctrl/jobctrl.db",
+        },
+        {
+            "expected_app_dir": "/tmp/jobctrl",
+            "expected_db_path": "/tmp/jobctrl/jobctrl.db",
+        },
+    ]
+    assert [
+        policy.version for policy in policy_repository.list_history(LOCAL_TENANT)
+    ] == [4, 3, 2, 1]
+    accepted_policy = policy_repository.get_version(LOCAL_TENANT, 2)
+    assert accepted_policy is not None
+    assert accepted_policy.learned_tailoring_rules.to_dict() == {
+        "fact_handling": "require_source_match"
+    }
     close_connection(db_path)
 
 


### PR DESCRIPTION
## Recovery

- Restores the exact single-commit diff from original PR #698 as its own reviewable layer in new GitHub Stack #738.
- No implementation content was added, removed, or combined during recovery.

## Why

The original PR was marked merged into an already-merged parent branch, so its commit did not reach `main`. This reconstructed stack roots the first recovered layer on current `main` and preserves the original order through PR #707.

## Validation

- Original focused implementation and validation record: #698
- Content-equivalent cumulative recovery head: #710 (full CI passed before this individual stack was published)
- This PR contains exactly one recovered commit.