### PR TITLE
feat(web): add tailoring policy revision data hooks

### DIFF
--- a/apps/web/src/contexts/materials/hooks/useRollbackTailoringPolicyMutation.test.ts
+++ b/apps/web/src/contexts/materials/hooks/useRollbackTailoringPolicyMutation.test.ts
@@ -1,0 +1,125 @@
+import type {
+  TailoringPolicyRevisionListResponse,
+  TailoringPolicyRevisionSummary,
+  TailoringPolicyRollbackResponse,
+} from "@jobctrl/contracts";
+import { LOCAL_TENANT } from "@jobctrl/domain-types";
+import { act, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { renderHookWithProviders } from "../../../test/render.js";
+import { buildTestPorts } from "../../../test/testPorts.js";
+import { learningKeys } from "../../operations/learningKeys.js";
+import { useRollbackTailoringPolicyMutation } from "./useRollbackTailoringPolicyMutation.js";
+
+const original: TailoringPolicyRevisionSummary = {
+  context: "materials",
+  policyKind: "tailoring_rule",
+  version: 1,
+  status: "superseded",
+  learnedRules: [],
+  sourceReviewId: null,
+  sourceRecommendationId: null,
+  rollbackOfVersion: null,
+  rollbackReasonCode: null,
+  createdAt: "2026-08-01T10:00:00.000Z",
+};
+
+const learned: TailoringPolicyRevisionSummary = {
+  ...original,
+  version: 2,
+  status: "current",
+  learnedRules: [{ ruleKey: "fact_handling", ruleValue: "require_source_match" }],
+  sourceReviewId: `learning-recommendation-review:${"b".repeat(64)}`,
+  sourceRecommendationId: `learning-recommendation:${"a".repeat(64)}`,
+  createdAt: "2026-08-01T11:00:00.000Z",
+};
+
+const pageInput = { page: 1, pageSize: 50 } as const;
+const history: TailoringPolicyRevisionListResponse = {
+  ok: true,
+  revisions: [learned, original],
+  page: 1,
+  pageSize: 50,
+  total: 2,
+  totalPages: 1,
+};
+
+const rollback: TailoringPolicyRollbackResponse = {
+  ok: true,
+  context: "materials",
+  policyKind: "tailoring_rule",
+  version: 3,
+  status: "current",
+  learnedRules: [],
+  sourceReviewId: null,
+  sourceRecommendationId: null,
+  rollbackOfVersion: 1,
+  rollbackReasonCode: "user_requested",
+  createdAt: "2026-08-01T12:00:00.000Z",
+};
+
+describe("useRollbackTailoringPolicyMutation", () => {
+  it("patches the cached audit history with the exact rollback response", async () => {
+    const rollbackTailoringPolicy = vi.fn(async () => rollback);
+    const { result, queryClient } = renderHookWithProviders(
+      () => useRollbackTailoringPolicyMutation(),
+      { ports: buildTestPorts({ api: { rollbackTailoringPolicy } }) },
+    );
+    const key = learningKeys.policyRevisionList(LOCAL_TENANT, pageInput);
+    queryClient.setQueryData(key, history);
+
+    await act(async () => {
+      await expect(result.current.mutateAsync(1)).resolves.toBe(rollback);
+    });
+
+    expect(rollbackTailoringPolicy).toHaveBeenCalledWith({ targetVersion: 1 });
+    expect(queryClient.getQueryData<TailoringPolicyRevisionListResponse>(key)).toEqual({
+      ...history,
+      revisions: [
+        {
+          context: rollback.context,
+          policyKind: rollback.policyKind,
+          version: rollback.version,
+          status: rollback.status,
+          learnedRules: rollback.learnedRules,
+          sourceReviewId: null,
+          sourceRecommendationId: null,
+          rollbackOfVersion: rollback.rollbackOfVersion,
+          rollbackReasonCode: rollback.rollbackReasonCode,
+          createdAt: rollback.createdAt,
+        },
+        { ...learned, status: "superseded" },
+        original,
+      ],
+      total: 3,
+      totalPages: 1,
+    });
+  });
+
+  it("restores the exact cached history when rollback fails", async () => {
+    let rejectRollback: ((error: Error) => void) | undefined;
+    const rollbackTailoringPolicy = vi.fn(
+      () =>
+        new Promise<TailoringPolicyRollbackResponse>((_resolve, reject) => {
+          rejectRollback = reject;
+        }),
+    );
+    const { result, queryClient } = renderHookWithProviders(
+      () => useRollbackTailoringPolicyMutation(),
+      { ports: buildTestPorts({ api: { rollbackTailoringPolicy } }) },
+    );
+    const key = learningKeys.policyRevisionList(LOCAL_TENANT, pageInput);
+    queryClient.setQueryData(key, history);
+
+    act(() => result.current.mutate(1));
+    await waitFor(() =>
+      expect(
+        queryClient.getQueryData<TailoringPolicyRevisionListResponse>(key)?.revisions[0],
+      ).toMatchObject({ version: 3, status: "current", rollbackOfVersion: 1 }),
+    );
+    act(() => rejectRollback?.(new Error("rollback unavailable")));
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(queryClient.getQueryData<TailoringPolicyRevisionListResponse>(key)).toEqual(history);
+  });
+});

--- a/apps/web/src/contexts/materials/hooks/useRollbackTailoringPolicyMutation.ts
+++ b/apps/web/src/contexts/materials/hooks/useRollbackTailoringPolicyMutation.ts
@@ -1,0 +1,165 @@
+import type {
+  TailoringPolicyRevisionListResponse,
+  TailoringPolicyRevisionSummary,
+  TailoringPolicyRollbackResponse,
+} from "@jobctrl/contracts";
+import {
+  useMutation,
+  useQueryClient,
+  type QueryKey,
+  type UseMutationResult,
+} from "@tanstack/react-query";
+
+import { usePorts } from "../../../shared/providers/PortsProvider.js";
+import { useTenantId } from "../../../shared/providers/TenantProvider.js";
+import { learningKeys } from "../../operations/learningKeys.js";
+
+interface PolicyRevisionSnapshot {
+  readonly queryKey: QueryKey;
+  readonly data: TailoringPolicyRevisionListResponse | undefined;
+}
+
+interface RollbackTailoringPolicyContext {
+  readonly snapshots: readonly PolicyRevisionSnapshot[];
+  readonly patched: boolean;
+}
+
+export function useRollbackTailoringPolicyMutation(): UseMutationResult<
+  TailoringPolicyRollbackResponse,
+  Error,
+  number,
+  RollbackTailoringPolicyContext
+> {
+  const tenantId = useTenantId();
+  const { api } = usePorts();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (targetVersion) => api.rollbackTailoringPolicy({ targetVersion }),
+    onMutate: async (targetVersion) => {
+      const queryKey = learningKeys.policyRevisions(tenantId);
+      await queryClient.cancelQueries({ queryKey });
+      const snapshots = queryClient
+        .getQueriesData<TailoringPolicyRevisionListResponse>({ queryKey })
+        .map(([cachedKey, data]) => ({ queryKey: cachedKey, data }));
+      const target = snapshots
+        .flatMap(({ data }) => data?.revisions ?? [])
+        .find((revision) => revision.version === targetVersion);
+      const current = snapshots
+        .flatMap(({ data }) => data?.revisions ?? [])
+        .find((revision) => revision.status === "current");
+      const provisional =
+        target && current
+          ? rollbackRevision(target, current.version + 1, new Date().toISOString())
+          : null;
+      const patched = provisional ? patchSnapshots(queryClient, snapshots, provisional) : false;
+      return { snapshots, patched };
+    },
+    onSuccess: (response, _targetVersion, context) => {
+      const revision: TailoringPolicyRevisionSummary = {
+        context: response.context,
+        policyKind: response.policyKind,
+        version: response.version,
+        status: response.status,
+        learnedRules: response.learnedRules,
+        sourceReviewId: response.sourceReviewId,
+        sourceRecommendationId: response.sourceRecommendationId,
+        rollbackOfVersion: response.rollbackOfVersion,
+        rollbackReasonCode: response.rollbackReasonCode,
+        createdAt: response.createdAt,
+      };
+      patchSnapshots(queryClient, context.snapshots, revision);
+    },
+    onError: (_error, _targetVersion, context) => {
+      for (const { queryKey, data } of context?.snapshots ?? []) {
+        queryClient.setQueryData(queryKey, data);
+      }
+    },
+    onSettled: async () => {
+      await queryClient.invalidateQueries({ queryKey: learningKeys.policyRevisions(tenantId) });
+    },
+  });
+}
+
+function rollbackRevision(
+  target: TailoringPolicyRevisionSummary,
+  version: number,
+  createdAt: string,
+): TailoringPolicyRevisionSummary {
+  return {
+    ...target,
+    version,
+    status: "current",
+    sourceReviewId: null,
+    sourceRecommendationId: null,
+    rollbackOfVersion: target.version,
+    rollbackReasonCode: "user_requested",
+    createdAt,
+  };
+}
+
+function patchSnapshots(
+  queryClient: ReturnType<typeof useQueryClient>,
+  snapshots: readonly PolicyRevisionSnapshot[],
+  revision: TailoringPolicyRevisionSummary,
+): boolean {
+  const pages = snapshots
+    .filter(
+      (snapshot): snapshot is PolicyRevisionSnapshot & {
+        data: TailoringPolicyRevisionListResponse;
+      } => snapshot.data !== undefined,
+    )
+    .toSorted((left, right) => left.data.page - right.data.page);
+  if (!isCompleteCache(pages)) {
+    return false;
+  }
+  const firstPage = pages[0];
+  if (!firstPage) {
+    return false;
+  }
+  const pageSize = firstPage.data.pageSize;
+  const prior = pages.flatMap(({ data }) => data.revisions);
+  const revisions = [
+    revision,
+    ...prior
+      .filter((item) => item.version !== revision.version)
+      .map((item) => (item.status === "current" ? { ...item, status: "superseded" as const } : item)),
+  ];
+  const total = prior.some((item) => item.version === revision.version)
+    ? firstPage.data.total
+    : firstPage.data.total + 1;
+  const totalPages = total === 0 ? 0 : Math.ceil(total / pageSize);
+  if (totalPages > pages.length) {
+    return false;
+  }
+  for (const { queryKey, data } of pages) {
+    const offset = (data.page - 1) * pageSize;
+    queryClient.setQueryData<TailoringPolicyRevisionListResponse>(queryKey, {
+      ...data,
+      revisions: revisions.slice(offset, offset + pageSize),
+      total,
+      totalPages,
+    });
+  }
+  return true;
+}
+
+function isCompleteCache(
+  pages: readonly { readonly data: TailoringPolicyRevisionListResponse }[],
+): boolean {
+  if (pages.length === 0 || pages[0]?.data.page !== 1) {
+    return false;
+  }
+  const first = pages[0].data;
+  return (
+    pages.length === first.totalPages &&
+    pages.every(
+      ({ data }, index) =>
+        data.page === index + 1 &&
+        data.pageSize === first.pageSize &&
+        data.total === first.total &&
+        data.totalPages === first.totalPages,
+    ) &&
+    pages.reduce((count, { data }) => count + data.revisions.length, 0) === first.total
+  );
+}

--- a/apps/web/src/contexts/materials/index.ts
+++ b/apps/web/src/contexts/materials/index.ts
@@ -7,6 +7,7 @@ export {
   useReviewLearningRecommendationMutation,
   type ReviewLearningRecommendationVariables,
 } from "./hooks/useReviewLearningRecommendationMutation.js";
+export { useRollbackTailoringPolicyMutation } from "./hooks/useRollbackTailoringPolicyMutation.js";
 export {
   useRetailorCurrentPolicyMutation,
   useRetailorJobMutation,

--- a/apps/web/src/contexts/operations/hooks/useLearningRecommendationsQuery.test.ts
+++ b/apps/web/src/contexts/operations/hooks/useLearningRecommendationsQuery.test.ts
@@ -1,6 +1,7 @@
 import type {
   LearningRecommendationEvidenceListResponse,
   LearningRecommendationListResponse,
+  TailoringPolicyRevisionListResponse,
 } from "@jobctrl/contracts";
 import { waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
@@ -10,6 +11,7 @@ import { buildTestPorts } from "../../../test/testPorts.js";
 import {
   useLearningRecommendationEvidenceQuery,
   useLearningRecommendationsQuery,
+  useTailoringPolicyRevisionsQuery,
 } from "./useLearningRecommendationsQuery.js";
 
 const recommendationId = `learning-recommendation:${"a".repeat(64)}`;
@@ -27,6 +29,15 @@ const evidenceList: LearningRecommendationEvidenceListResponse = {
   ok: true,
   recommendationId,
   evidence: [],
+  page: 1,
+  pageSize: 25,
+  total: 0,
+  totalPages: 0,
+};
+
+const policyHistory: TailoringPolicyRevisionListResponse = {
+  ok: true,
+  revisions: [],
   page: 1,
   pageSize: 25,
   total: 0,
@@ -79,5 +90,16 @@ describe("learning recommendation queries", () => {
     rerender({ enabled: true });
     await waitFor(() => expect(result.current.data).toBe(evidenceList));
     expect(learningRecommendationEvidence).toHaveBeenCalledTimes(1);
+  });
+
+  it("reads tenant-scoped Materials policy history through the API port", async () => {
+    const tailoringPolicyRevisions = vi.fn(async () => policyHistory);
+    const { result } = renderHookWithProviders(
+      () => useTailoringPolicyRevisionsQuery({ page: 1, pageSize: 25 }),
+      { ports: buildTestPorts({ api: { tailoringPolicyRevisions } }) },
+    );
+
+    await waitFor(() => expect(result.current.data).toBe(policyHistory));
+    expect(tailoringPolicyRevisions).toHaveBeenCalledWith({ page: 1, pageSize: 25 });
   });
 });

--- a/apps/web/src/contexts/operations/hooks/useLearningRecommendationsQuery.ts
+++ b/apps/web/src/contexts/operations/hooks/useLearningRecommendationsQuery.ts
@@ -3,6 +3,8 @@ import type {
   LearningRecommendationEvidenceListResponse,
   LearningRecommendationListQuery,
   LearningRecommendationListResponse,
+  TailoringPolicyRevisionListQuery,
+  TailoringPolicyRevisionListResponse,
 } from "@jobctrl/contracts";
 import { useQuery, type UseQueryResult } from "@tanstack/react-query";
 
@@ -34,5 +36,16 @@ export function useLearningRecommendationEvidenceQuery(
     queryKey: learningKeys.evidenceList(tenantId, recommendationId, input),
     queryFn: () => api.learningRecommendationEvidence(recommendationId, input),
     enabled,
+  });
+}
+
+export function useTailoringPolicyRevisionsQuery(
+  input: Partial<TailoringPolicyRevisionListQuery> = DEFAULT_PAGE,
+): UseQueryResult<TailoringPolicyRevisionListResponse> {
+  const tenantId = useTenantId();
+  const { api } = usePorts();
+  return useQuery({
+    queryKey: learningKeys.policyRevisionList(tenantId, input),
+    queryFn: () => api.tailoringPolicyRevisions(input),
   });
 }

--- a/apps/web/src/contexts/operations/index.ts
+++ b/apps/web/src/contexts/operations/index.ts
@@ -133,6 +133,7 @@ export { useJobsListQuery } from "./hooks/useJobsListQuery.js";
 export {
   useLearningRecommendationEvidenceQuery,
   useLearningRecommendationsQuery,
+  useTailoringPolicyRevisionsQuery,
 } from "./hooks/useLearningRecommendationsQuery.js";
 export { usePipelineOperationsQuery } from "./hooks/usePipelineOperationsQuery.js";
 export { useWorkflowRunsListQuery } from "./hooks/useWorkflowRunsListQuery.js";

--- a/apps/web/src/contexts/operations/learningKeys.ts
+++ b/apps/web/src/contexts/operations/learningKeys.ts
@@ -1,6 +1,7 @@
 import type {
   LearningRecommendationEvidenceListQuery,
   LearningRecommendationListQuery,
+  TailoringPolicyRevisionListQuery,
 } from "@jobctrl/contracts";
 import type { TenantId } from "@jobctrl/domain-types";
 
@@ -15,4 +16,10 @@ export const learningKeys = {
     recommendationId: string,
     input: Partial<LearningRecommendationEvidenceListQuery>,
   ) => [...learningKeys.evidence(tenantId), recommendationId, input] as const,
+  policyRevisions: (tenantId: TenantId) =>
+    [...learningKeys.all(tenantId), "policies", "materials"] as const,
+  policyRevisionList: (
+    tenantId: TenantId,
+    input: Partial<TailoringPolicyRevisionListQuery>,
+  ) => [...learningKeys.policyRevisions(tenantId), input] as const,
 };

--- a/apps/web/src/demo/DemoApiClientAdapter.ts
+++ b/apps/web/src/demo/DemoApiClientAdapter.ts
@@ -142,6 +142,8 @@ export class DemoApiClientAdapter implements ApiClientPort {
   learningRecommendations = this.unsupported("learningRecommendations");
   learningRecommendationEvidence = this.unsupported("learningRecommendationEvidence");
   reviewLearningRecommendation = this.unsupported("reviewLearningRecommendation");
+  tailoringPolicyRevisions = this.unsupported("tailoringPolicyRevisions");
+  rollbackTailoringPolicy = this.unsupported("rollbackTailoringPolicy");
 
   digest() {
     return this.read((model) => model.dashboard.digest);

--- a/apps/web/src/demo/DemoLocalCommandExecutor.test.ts
+++ b/apps/web/src/demo/DemoLocalCommandExecutor.test.ts
@@ -229,7 +229,7 @@ const LOCAL_CASES = [
 ] as const satisfies readonly LocalCase[];
 
 describe("DemoLocalCommandExecutor", () => {
-  it("keeps the 131-member capability manifest exhaustive with exact class counts", () => {
+  it("keeps the 133-member capability manifest exhaustive with exact class counts", () => {
     const counts = Object.values(DEMO_CAPABILITY_MANIFEST).reduce<Record<string, number>>(
       (result, capability) => {
         result[capability.class] = (result[capability.class] ?? 0) + 1;
@@ -237,12 +237,12 @@ describe("DemoLocalCommandExecutor", () => {
       },
       {},
     );
-    expect(Object.keys(DEMO_CAPABILITY_MANIFEST)).toHaveLength(131);
+    expect(Object.keys(DEMO_CAPABILITY_MANIFEST)).toHaveLength(133);
     expect(counts).toEqual({
       browser_local: 92,
       simulated_async: 4,
       rehearsed_external: 4,
-      unavailable: 31,
+      unavailable: 33,
     });
   });
 

--- a/apps/web/src/demo/capabilities.ts
+++ b/apps/web/src/demo/capabilities.ts
@@ -23,6 +23,12 @@ export const DEMO_CAPABILITY_MANIFEST = {
   reviewLearningRecommendation: unavailable(
     "Learning recommendation review requires the local audited database.",
   ),
+  tailoringPolicyRevisions: unavailable(
+    "Tailoring policy history requires the local audited database.",
+  ),
+  rollbackTailoringPolicy: unavailable(
+    "Tailoring policy rollback requires the local audited database.",
+  ),
   digest: local("Reads the synthetic daily digest."),
   acknowledgeDigest: local("Acknowledges a digest only in browser-local state."),
   activity: local("Reads synthetic activity history."),

--- a/apps/web/src/demo/demo-seed.test.ts
+++ b/apps/web/src/demo/demo-seed.test.ts
@@ -18,7 +18,7 @@ const CONTOSO_GENERATION_ONE_ARTIFACT_IDS = [
 
 describe("canonical public demo seed", () => {
   it("has a complete classified API capability manifest", () => {
-    expect(Object.keys(DEMO_CAPABILITY_MANIFEST)).toHaveLength(131);
+    expect(Object.keys(DEMO_CAPABILITY_MANIFEST)).toHaveLength(133);
     expect(Object.values(DEMO_CAPABILITY_MANIFEST).every((entry) => entry.reason.length > 0)).toBe(true);
   });
 

--- a/apps/web/src/shared/adapters/local/FetchApiClientAdapter.ts
+++ b/apps/web/src/shared/adapters/local/FetchApiClientAdapter.ts
@@ -45,6 +45,16 @@ export class FetchApiClientAdapter implements ApiClientPort {
   ) {
     return this.client.reviewLearningRecommendation(recommendationId, body);
   }
+  tailoringPolicyRevisions(
+    query: Parameters<JobCtrlApiClient["tailoringPolicyRevisions"]>[0] = {},
+  ) {
+    return this.client.tailoringPolicyRevisions(query);
+  }
+  rollbackTailoringPolicy(
+    body: Parameters<JobCtrlApiClient["rollbackTailoringPolicy"]>[0],
+  ) {
+    return this.client.rollbackTailoringPolicy(body);
+  }
   digest() {
     return this.client.digest();
   }

--- a/apps/web/src/shared/ports/ApiClientPort.ts
+++ b/apps/web/src/shared/ports/ApiClientPort.ts
@@ -89,6 +89,10 @@ import type {
   LearningRecommendationListResponse,
   LearningRecommendationReviewRequest,
   LearningRecommendationReviewResponse,
+  TailoringPolicyRevisionListQuery,
+  TailoringPolicyRevisionListResponse,
+  TailoringPolicyRollbackRequest,
+  TailoringPolicyRollbackResponse,
   MarkJobActionRequest,
   ManualCaptureDismissRequest,
   ManualCaptureDismissResponse,
@@ -209,6 +213,12 @@ export interface ApiClientPort {
     recommendationId: string,
     body: LearningRecommendationReviewRequest,
   ): Promise<LearningRecommendationReviewResponse>;
+  tailoringPolicyRevisions(
+    query?: Partial<TailoringPolicyRevisionListQuery>,
+  ): Promise<TailoringPolicyRevisionListResponse>;
+  rollbackTailoringPolicy(
+    body: TailoringPolicyRollbackRequest,
+  ): Promise<TailoringPolicyRollbackResponse>;
   digest(): Promise<DailyDigest>;
   acknowledgeDigest(body?: DigestAcknowledgeRequest): Promise<DigestAcknowledgeResponse>;
   activity(query?: Partial<ActivityListQuery>): Promise<PaginatedResponse<ActivityEventSummary>>;


### PR DESCRIPTION
## Recovery

- Restores the exact single-commit diff from original PR #699 as its own reviewable layer in new GitHub Stack #738.
- No implementation content was added, removed, or combined during recovery.

## Why

The original PR was marked merged into an already-merged parent branch, so its commit did not reach `main`. This reconstructed stack roots the first recovered layer on current `main` and preserves the original order through PR #707.

## Validation

- Original focused implementation and validation record: #699
- Content-equivalent cumulative recovery head: #710 (full CI passed before this individual stack was published)
- This PR contains exactly one recovered commit.