### PR TITLE
feat(web): add tailoring policy history controls

### DIFF
--- a/apps/web/src/contexts/materials/components/TailoringPolicyHistoryPanel.test.tsx
+++ b/apps/web/src/contexts/materials/components/TailoringPolicyHistoryPanel.test.tsx
@@ -1,0 +1,167 @@
+import type {
+  TailoringPolicyRevisionListQuery,
+  TailoringPolicyRollbackResponse,
+} from "@jobctrl/contracts";
+import { screen, waitFor, within } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import { axe } from "jest-axe";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  sampleLearningRecommendation,
+  sampleTailoringPolicyRevisionList,
+  sampleTailoringPolicyRollback,
+} from "../../../test/fixtures/learning.js";
+import { renderWithProviders } from "../../../test/render.js";
+import { buildTestPorts } from "../../../test/testPorts.js";
+import { TailoringPolicyHistoryPanel } from "./TailoringPolicyHistoryPanel.js";
+
+describe("TailoringPolicyHistoryPanel", () => {
+  it("renders truthful revision status and auditable provenance without axe violations", async () => {
+    const view = renderWithProviders(<TailoringPolicyHistoryPanel />, {
+      ports: buildTestPorts({
+        api: {
+          tailoringPolicyRevisions: vi.fn(
+            async () => sampleTailoringPolicyRevisionList,
+          ),
+        },
+      }),
+    });
+
+    const current = await screen.findByRole("article", { name: "Version 4" });
+    const learned = screen.getByRole("article", { name: "Version 3" });
+    const configured = screen.getByRole("article", { name: "Version 2" });
+    expect(within(current).getByText("Current")).toBeInTheDocument();
+    expect(
+      within(current).getByText("Restored from version 1"),
+    ).toBeInTheDocument();
+    expect(
+      within(current).getByText("Reason: user requested"),
+    ).toBeInTheDocument();
+    expect(within(learned).getByText("Superseded")).toBeInTheDocument();
+    expect(
+      within(learned).getByText("fact_handling → require_source_match"),
+    ).toBeInTheDocument();
+    expect(
+      within(learned).getByText(
+        `Accepted recommendation ${sampleLearningRecommendation.recommendationId}`,
+      ),
+    ).toBeInTheDocument();
+    expect(
+      within(learned).getByText(/^Review learning-recommendation-review:/),
+    ).toBeInTheDocument();
+    expect(
+      within(configured).getByText(
+        "No recommendation or restore provenance recorded.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", {
+        name: "Restore tailoring policy version 4",
+      }),
+    ).not.toBeInTheDocument();
+    expect(await axe(view.container)).toHaveNoViolations();
+  });
+
+  it("pages through every auditable revision", async () => {
+    const user = userEvent.setup();
+    const tailoringPolicyRevisions = vi.fn(
+      async (input: Partial<TailoringPolicyRevisionListQuery>) => ({
+        ...sampleTailoringPolicyRevisionList,
+        revisions:
+          input.page === 2
+            ? [sampleTailoringPolicyRevisionList.revisions.at(-1)!]
+            : [sampleTailoringPolicyRevisionList.revisions[0]!],
+        page: input.page ?? 1,
+        total: 101,
+        totalPages: 2,
+      }),
+    );
+    renderWithProviders(<TailoringPolicyHistoryPanel />, {
+      ports: buildTestPorts({ api: { tailoringPolicyRevisions } }),
+    });
+
+    await screen.findByRole("article", { name: "Version 4" });
+    expect(screen.getByText("Page 1 of 2")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Next page" }));
+
+    expect(
+      await screen.findByRole("article", { name: "Version 1" }),
+    ).toBeInTheDocument();
+    expect(tailoringPolicyRevisions).toHaveBeenLastCalledWith({
+      page: 2,
+      pageSize: 100,
+    });
+    expect(screen.getByText("Page 2 of 2")).toBeInTheDocument();
+  });
+
+  it("restores an older version without starting scoring, tailoring, or workflow work", async () => {
+    const user = userEvent.setup();
+    const rollbackTailoringPolicy = vi.fn(
+      async (): Promise<TailoringPolicyRollbackResponse> =>
+        sampleTailoringPolicyRollback,
+    );
+    const rescoreJob = vi.fn();
+    const retailorJob = vi.fn();
+    const runPipelineStages = vi.fn();
+    renderWithProviders(<TailoringPolicyHistoryPanel />, {
+      ports: buildTestPorts({
+        api: {
+          tailoringPolicyRevisions: vi.fn(
+            async () => sampleTailoringPolicyRevisionList,
+          ),
+          rollbackTailoringPolicy,
+          rescoreJob,
+          retailorJob,
+          runPipelineStages,
+        },
+      }),
+    });
+
+    await screen.findByRole("article", { name: "Version 1" });
+    await user.click(
+      screen.getByRole("button", {
+        name: "Restore tailoring policy version 1",
+      }),
+    );
+
+    await waitFor(() =>
+      expect(rollbackTailoringPolicy).toHaveBeenCalledWith({
+        targetVersion: 1,
+      }),
+    );
+    expect(rescoreJob).not.toHaveBeenCalled();
+    expect(retailorJob).not.toHaveBeenCalled();
+    expect(runPipelineStages).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a policy restore failure", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<TailoringPolicyHistoryPanel />, {
+      ports: buildTestPorts({
+        api: {
+          tailoringPolicyRevisions: vi.fn(
+            async () => sampleTailoringPolicyRevisionList,
+          ),
+          rollbackTailoringPolicy: vi.fn(async () => {
+            throw new Error("The policy restore could not be completed.");
+          }),
+        },
+      }),
+    });
+
+    await screen.findByRole("article", { name: "Version 2" });
+    await user.click(
+      screen.getByRole("button", {
+        name: "Restore tailoring policy version 2",
+      }),
+    );
+
+    expect(
+      await screen.findByText("Policy restore failed"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("The policy restore could not be completed."),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/contexts/materials/components/TailoringPolicyHistoryPanel.tsx
+++ b/apps/web/src/contexts/materials/components/TailoringPolicyHistoryPanel.tsx
@@ -1,0 +1,213 @@
+import type { TailoringPolicyRevisionSummary } from "@jobctrl/contracts";
+import { IconAlertTriangle } from "@tabler/icons-react";
+import { useState } from "react";
+
+import { formatDateTime } from "../../../shared/lib/formatters.js";
+import {
+  Alert,
+  AlertDescription,
+  AlertTitle,
+} from "../../../shared/ui/alert.js";
+import { Button } from "../../../shared/ui/button.js";
+import { CardHeader } from "../../../shared/ui/card-header.js";
+import { Empty } from "../../../shared/ui/empty.js";
+import { StatusBadge } from "../../../shared/ui/status-badge.js";
+import { useTailoringPolicyRevisionsQuery } from "../../operations/index.js";
+import { useRollbackTailoringPolicyMutation } from "../hooks/useRollbackTailoringPolicyMutation.js";
+
+const HISTORY_PAGE_SIZE = 100;
+
+export function TailoringPolicyHistoryPanel() {
+  const [page, setPage] = useState(1);
+  const history = useTailoringPolicyRevisionsQuery({
+    page,
+    pageSize: HISTORY_PAGE_SIZE,
+  });
+  const rollback = useRollbackTailoringPolicyMutation();
+  const revisions = history.data?.revisions ?? [];
+  const readError =
+    history.error instanceof Error ? history.error.message : null;
+  const rollbackError =
+    rollback.error instanceof Error ? rollback.error.message : null;
+
+  return (
+    <section className="card col-span-full tailoring-policy-history-panel">
+      <CardHeader
+        title="Tailoring policy history"
+        meta={
+          history.data
+            ? `${history.data.total} revision${history.data.total === 1 ? "" : "s"}`
+            : "loading"
+        }
+      />
+      {readError ? (
+        <Alert variant="destructive">
+          <IconAlertTriangle aria-hidden="true" />
+          <AlertTitle>Tailoring policy history unavailable</AlertTitle>
+          <AlertDescription>{readError}</AlertDescription>
+        </Alert>
+      ) : null}
+      {rollbackError ? (
+        <Alert variant="destructive">
+          <IconAlertTriangle aria-hidden="true" />
+          <AlertTitle>Policy restore failed</AlertTitle>
+          <AlertDescription>{rollbackError}</AlertDescription>
+        </Alert>
+      ) : null}
+      {history.isFetching && !history.data ? (
+        <Empty title="Loading policy history." />
+      ) : null}
+      {history.data && revisions.length === 0 ? (
+        <Empty title="No tailoring policy revisions recorded." />
+      ) : null}
+      {revisions.length > 0 ? (
+        <div
+          className="tailoring-policy-revisions"
+          aria-label="Tailoring policy revisions"
+        >
+          {revisions.map((revision) => (
+            <TailoringPolicyRevisionCard
+              key={revision.version}
+              revision={revision}
+              restoring={rollback.isPending}
+              onRestore={(targetVersion) => {
+                rollback.reset();
+                rollback.mutate(targetVersion);
+              }}
+            />
+          ))}
+        </div>
+      ) : null}
+      {history.data && history.data.totalPages > 1 ? (
+        <nav
+          className="row-actions tailoring-policy-pagination"
+          aria-label="Tailoring policy history pages"
+        >
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            disabled={history.isFetching || history.data.page <= 1}
+            onClick={() => setPage((current) => Math.max(1, current - 1))}
+          >
+            Previous page
+          </Button>
+          <span className="meta" aria-live="polite">
+            Page {history.data.page} of {history.data.totalPages}
+          </span>
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            disabled={
+              history.isFetching || history.data.page >= history.data.totalPages
+            }
+            onClick={() => setPage((current) => current + 1)}
+          >
+            Next page
+          </Button>
+        </nav>
+      ) : null}
+    </section>
+  );
+}
+
+function TailoringPolicyRevisionCard({
+  revision,
+  restoring,
+  onRestore,
+}: {
+  readonly revision: TailoringPolicyRevisionSummary;
+  readonly restoring: boolean;
+  readonly onRestore: (targetVersion: number) => void;
+}) {
+  const titleId = `tailoring-policy-version-${revision.version}`;
+  const current = revision.status === "current";
+
+  return (
+    <article
+      className="tailoring-policy-revision-card"
+      aria-labelledby={titleId}
+    >
+      <header className="tailoring-policy-revision-head">
+        <span>
+          <b id={titleId}>Version {revision.version}</b>
+          <span className="meta">
+            Materials tailoring policy · {formatDateTime(revision.createdAt)}
+          </span>
+        </span>
+        <StatusBadge tone={current ? "ok" : "muted"}>
+          {current ? "Current" : "Superseded"}
+        </StatusBadge>
+      </header>
+
+      <dl className="tailoring-policy-revision-facts">
+        <div>
+          <dt>Learned rules</dt>
+          <dd>
+            {revision.learnedRules.length > 0 ? (
+              <ul>
+                {revision.learnedRules.map((rule) => (
+                  <li key={`${rule.ruleKey}:${rule.ruleValue}`}>
+                    {rule.ruleKey} → {rule.ruleValue}
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              "Baseline policy; no accepted learned rules."
+            )}
+          </dd>
+        </div>
+        <div>
+          <dt>Provenance</dt>
+          <dd>{revisionProvenance(revision)}</dd>
+        </div>
+      </dl>
+
+      {!current ? (
+        <div className="row-actions">
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            disabled={restoring}
+            aria-label={`Restore tailoring policy version ${revision.version}`}
+            onClick={() => onRestore(revision.version)}
+          >
+            {restoring ? "Restoring…" : `Restore version ${revision.version}`}
+          </Button>
+        </div>
+      ) : null}
+    </article>
+  );
+}
+
+function revisionProvenance(revision: TailoringPolicyRevisionSummary) {
+  if (revision.sourceReviewId && revision.sourceRecommendationId) {
+    return (
+      <span className="tailoring-policy-provenance">
+        <span>Accepted recommendation {revision.sourceRecommendationId}</span>
+        <span className="meta">Review {revision.sourceReviewId}</span>
+      </span>
+    );
+  }
+  if (revision.rollbackOfVersion && revision.rollbackReasonCode) {
+    return (
+      <span className="tailoring-policy-provenance">
+        <span>Restored from version {revision.rollbackOfVersion}</span>
+        <span className="meta">
+          Reason: {rollbackReason(revision.rollbackReasonCode)}
+        </span>
+      </span>
+    );
+  }
+  return "No recommendation or restore provenance recorded.";
+}
+
+function rollbackReason(
+  reason: NonNullable<TailoringPolicyRevisionSummary["rollbackReasonCode"]>,
+) {
+  return reason === "user_requested"
+    ? "user requested"
+    : "historical or unspecified";
+}

--- a/apps/web/src/contexts/materials/index.ts
+++ b/apps/web/src/contexts/materials/index.ts
@@ -38,6 +38,7 @@ export {
   type EmployerAnalysisPanelProps,
 } from "./components/EmployerAnalysisPanel.js";
 export { LearningRecommendationReviewPanel } from "./components/LearningRecommendationReviewPanel.js";
+export { TailoringPolicyHistoryPanel } from "./components/TailoringPolicyHistoryPanel.js";
 export {
   ArtifactTypeBadge,
   type ArtifactTypeBadgeProps,

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -3829,6 +3829,73 @@ input[type="radio"] {
   grid-column: 2;
 }
 
+.tailoring-policy-revisions {
+  display: grid;
+  gap: 10px;
+  padding: 12px 16px;
+}
+
+.tailoring-policy-revision-card {
+  display: grid;
+  gap: 10px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--card);
+  padding: 12px;
+}
+
+.tailoring-policy-revision-head {
+  display: flex;
+  min-width: 0;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.tailoring-policy-revision-head > span:first-child,
+.tailoring-policy-provenance {
+  display: grid;
+  min-width: 0;
+  gap: 2px;
+  overflow-wrap: anywhere;
+}
+
+.tailoring-policy-revision-facts {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 8px 16px;
+  margin: 0;
+}
+
+.tailoring-policy-revision-facts div {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+}
+
+.tailoring-policy-revision-facts dt {
+  color: var(--muted-foreground);
+  font-size: var(--jh-type-caption-size);
+}
+
+.tailoring-policy-revision-facts dd {
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+
+.tailoring-policy-revision-facts ul {
+  display: grid;
+  gap: 2px;
+  margin: 0;
+  padding-left: 18px;
+}
+
+.tailoring-policy-pagination {
+  display: flex;
+  align-items: center;
+  padding: 0 16px 12px;
+}
+
 .discovery-control-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));

--- a/apps/web/src/test/fixtures/learning.ts
+++ b/apps/web/src/test/fixtures/learning.ts
@@ -2,6 +2,8 @@ import type {
   LearningRecommendationEvidenceListResponse,
   LearningRecommendationListResponse,
   LearningRecommendationSummary,
+  TailoringPolicyRevisionListResponse,
+  TailoringPolicyRollbackResponse,
 } from "@jobctrl/contracts";
 
 export const sampleLearningRecommendation: LearningRecommendationSummary = {
@@ -71,4 +73,76 @@ export const sampleLearningRecommendationEvidence: LearningRecommendationEvidenc
   pageSize: 100,
   total: 2,
   totalPages: 1,
+};
+
+export const sampleTailoringPolicyRevisionList: TailoringPolicyRevisionListResponse = {
+  ok: true,
+  revisions: [
+    {
+      context: "materials",
+      policyKind: "tailoring_rule",
+      version: 4,
+      status: "current",
+      learnedRules: [],
+      sourceReviewId: null,
+      sourceRecommendationId: null,
+      rollbackOfVersion: 1,
+      rollbackReasonCode: "user_requested",
+      createdAt: "2026-08-01T12:15:00.000Z",
+    },
+    {
+      context: "materials",
+      policyKind: "tailoring_rule",
+      version: 3,
+      status: "superseded",
+      learnedRules: [{ ruleKey: "fact_handling", ruleValue: "require_source_match" }],
+      sourceReviewId: `learning-recommendation-review:${"c".repeat(64)}`,
+      sourceRecommendationId: sampleLearningRecommendation.recommendationId,
+      rollbackOfVersion: null,
+      rollbackReasonCode: null,
+      createdAt: "2026-08-01T12:05:00.000Z",
+    },
+    {
+      context: "materials",
+      policyKind: "tailoring_rule",
+      version: 2,
+      status: "superseded",
+      learnedRules: [],
+      sourceReviewId: null,
+      sourceRecommendationId: null,
+      rollbackOfVersion: null,
+      rollbackReasonCode: null,
+      createdAt: "2026-08-01T11:00:00.000Z",
+    },
+    {
+      context: "materials",
+      policyKind: "tailoring_rule",
+      version: 1,
+      status: "superseded",
+      learnedRules: [],
+      sourceReviewId: null,
+      sourceRecommendationId: null,
+      rollbackOfVersion: null,
+      rollbackReasonCode: null,
+      createdAt: "2026-08-01T10:00:00.000Z",
+    },
+  ],
+  page: 1,
+  pageSize: 100,
+  total: 4,
+  totalPages: 1,
+};
+
+export const sampleTailoringPolicyRollback: TailoringPolicyRollbackResponse = {
+  ok: true,
+  context: "materials",
+  policyKind: "tailoring_rule",
+  version: 5,
+  status: "current",
+  learnedRules: [],
+  sourceReviewId: null,
+  sourceRecommendationId: null,
+  rollbackOfVersion: 1,
+  rollbackReasonCode: "user_requested",
+  createdAt: "2026-08-01T12:30:00.000Z",
 };

--- a/apps/web/src/test/msw/handlers.ts
+++ b/apps/web/src/test/msw/handlers.ts
@@ -31,6 +31,8 @@ import {
 import {
   sampleLearningRecommendationEvidence,
   sampleLearningRecommendationList,
+  sampleTailoringPolicyRevisionList,
+  sampleTailoringPolicyRollback,
 } from "../fixtures/learning.js";
 import {
   makeArtifactDetail,
@@ -291,6 +293,12 @@ export const handlers = [
         reviewedAt: "2026-08-01T12:05:00.000Z",
       });
     },
+  ),
+  http.get("*/v1/learning/policies/materials", () =>
+    HttpResponse.json(sampleTailoringPolicyRevisionList),
+  ),
+  http.post("*/v1/learning/policies/materials/rollbacks", () =>
+    HttpResponse.json(sampleTailoringPolicyRollback),
   ),
   http.get("*/v1/digest", () => HttpResponse.json(sampleDailyDigest)),
   http.post("*/v1/digest/acknowledge", async ({ request }) => {

--- a/apps/web/src/views/dashboard/DashboardView.test.tsx
+++ b/apps/web/src/views/dashboard/DashboardView.test.tsx
@@ -30,6 +30,9 @@ describe("DashboardView", () => {
     expect(
       await screen.findByRole("heading", { name: "Learning recommendations" }),
     ).toBeInTheDocument();
+    expect(
+      await screen.findByRole("heading", { name: "Tailoring policy history" }),
+    ).toBeInTheDocument();
     expect(screen.getByText("Recruiter reply indicates an interview request.")).toBeInTheDocument();
     expect(screen.getByText("stuck").querySelector("svg")).toHaveClass("tabler-icon-ban");
     expect(screen.getByText("in progress").querySelector("svg")).toHaveClass("tabler-icon-clock");

--- a/apps/web/src/views/dashboard/DashboardView.tsx
+++ b/apps/web/src/views/dashboard/DashboardView.tsx
@@ -1,7 +1,10 @@
 import { IconAlertTriangle } from "@tabler/icons-react";
 
 import { OutcomeSuggestionsPanel } from "../../contexts/apply/components/ApplicationOutcomes.js";
-import { LearningRecommendationReviewPanel } from "../../contexts/materials/index.js";
+import {
+  LearningRecommendationReviewPanel,
+  TailoringPolicyHistoryPanel,
+} from "../../contexts/materials/index.js";
 import { useApplicationOutcomesQuery } from "../../contexts/operations/hooks/useApplicationOutcomesQuery.js";
 import { useDashboardSummaryQuery } from "../../contexts/operations/hooks/useDashboardSummaryQuery.js";
 import { useWorkflowRunsListQuery } from "../../contexts/operations/hooks/useWorkflowRunsListQuery.js";
@@ -80,6 +83,7 @@ export function DashboardView() {
             <RecentActivityCard summary={summary} />
             <ApplyRunsCard summary={summary} />
             <LearningRecommendationReviewPanel />
+            <TailoringPolicyHistoryPanel />
             <section className="card col-span-full">
               <CardHeader
                 title="Outcome suggestions"


### PR DESCRIPTION
## Recovery

- Restores the exact single-commit diff from original PR #700 as its own reviewable layer in new GitHub Stack #738.
- No implementation content was added, removed, or combined during recovery.

## Why

The original PR was marked merged into an already-merged parent branch, so its commit did not reach `main`. This reconstructed stack roots the first recovered layer on current `main` and preserves the original order through PR #707.

## Validation

- Original focused implementation and validation record: #700
- Content-equivalent cumulative recovery head: #710 (full CI passed before this individual stack was published)
- This PR contains exactly one recovered commit.