### PR TITLE
fix: keep reviewed learning recommendations terminal

### DIFF
--- a/apps/api/src/learning-recommendations.ts
+++ b/apps/api/src/learning-recommendations.ts
@@ -64,7 +64,14 @@ function listLearningRecommendationsInSnapshot(
       db,
       `SELECT COUNT(*) AS count
          FROM learning_recommendations
-        WHERE tenant_id = ?`,
+        WHERE tenant_id = ?
+          AND NOT EXISTS (
+            SELECT 1
+              FROM learning_recommendation_reviews AS review
+             WHERE review.tenant_id = learning_recommendations.tenant_id
+               AND review.recommendation_id = learning_recommendations.recommendation_id
+               AND review.decision IN ('accepted', 'rejected')
+          )`,
       [DEFAULT_TENANT],
     )?.count ?? 0,
   );
@@ -109,6 +116,13 @@ function listLearningRecommendationsInSnapshot(
             ) AS tombstone_count
        FROM learning_recommendations AS recommendation
       WHERE recommendation.tenant_id = ?
+        AND NOT EXISTS (
+          SELECT 1
+            FROM learning_recommendation_reviews AS review
+           WHERE review.tenant_id = recommendation.tenant_id
+             AND review.recommendation_id = recommendation.recommendation_id
+             AND review.decision IN ('accepted', 'rejected')
+        )
       ORDER BY recommendation.derived_at DESC,
                recommendation.recommendation_id ASC
       LIMIT ? OFFSET ?`,

--- a/apps/api/test/qa-seed.ts
+++ b/apps/api/test/qa-seed.ts
@@ -322,6 +322,7 @@ export function seedQaDatabase(dbPath: string, options: QaSeedOptions = {}): voi
     resumeTxt,
   });
   seedResumeReviewDraft(db);
+  seedLearningPolicyFixture(db);
 
   insertEvent(db, "https://boards.greenhouse.io/gitlab/jobs/qa-platform-director", "apply", "info", "QA apply run queued");
   insertEvent(db, "https://linkedin.com/jobs/view/qa-risk-manager", "score", "error", "QA score action failed");
@@ -1232,6 +1233,229 @@ function seedResumeReviewDraft(db: Database.Database): void {
     "qa-platform-resume-pdf",
     QA_NOW,
     QA_NOW,
+  );
+}
+
+function seedLearningPolicyFixture(db: Database.Database): void {
+  const policyCreatedAt = "2026-05-04T11:00:00.000Z";
+  const styleRecommendationId = `learning-recommendation:${"a".repeat(64)}`;
+  const factualRecommendationId = `learning-recommendation:${"b".repeat(64)}`;
+  const signals = [
+    {
+      signalId: "qa-learning-style-1",
+      jobId: QA_PLATFORM_JOB_ID,
+      draftId: "qa-platform-resume-draft",
+      signalKind: "style_preference",
+      ruleKey: "style_guidance",
+      ruleValue: "preserve_user_edit_pattern",
+      reviewedAt: "2026-05-04T11:01:00.000Z",
+    },
+    {
+      signalId: "qa-learning-style-2",
+      jobId: QA_RISK_JOB_ID,
+      draftId: "qa-risk-resume-draft",
+      signalKind: "style_preference",
+      ruleKey: "style_guidance",
+      ruleValue: "preserve_user_edit_pattern",
+      reviewedAt: "2026-05-04T11:02:00.000Z",
+    },
+    {
+      signalId: "qa-learning-style-3",
+      jobId: QA_PLATFORM_JOB_ID,
+      draftId: "qa-platform-resume-draft",
+      signalKind: "style_preference",
+      ruleKey: "style_guidance",
+      ruleValue: "preserve_user_edit_pattern",
+      reviewedAt: "2026-05-04T11:03:00.000Z",
+    },
+    {
+      signalId: "qa-learning-factual-1",
+      jobId: QA_PLATFORM_JOB_ID,
+      draftId: "qa-platform-resume-draft",
+      signalKind: "factual_correction",
+      ruleKey: "fact_handling",
+      ruleValue: "require_source_match",
+      reviewedAt: "2026-05-04T11:04:00.000Z",
+    },
+    {
+      signalId: "qa-learning-factual-2",
+      jobId: QA_RISK_JOB_ID,
+      draftId: "qa-risk-resume-draft",
+      signalKind: "factual_correction",
+      ruleKey: "fact_handling",
+      ruleValue: "require_source_match",
+      reviewedAt: "2026-05-04T11:05:00.000Z",
+    },
+    {
+      signalId: "qa-learning-factual-3",
+      jobId: QA_RISK_JOB_ID,
+      draftId: "qa-risk-resume-draft",
+      signalKind: "factual_correction",
+      ruleKey: "fact_handling",
+      ruleValue: "require_source_match",
+      reviewedAt: "2026-05-04T11:06:00.000Z",
+    },
+  ] as const;
+
+  db.transaction(() => {
+    db.prepare(
+      `INSERT INTO resume_review_drafts (
+        tenant_id, draft_id, job_id, base_generation, renderer_format,
+        state, latest_revision_number, created_at, updated_at
+      ) VALUES ('local', 'qa-risk-resume-draft', ?, 1, 'text', 'active', 0, ?, ?)`,
+    ).run(QA_RISK_JOB_ID, policyCreatedAt, policyCreatedAt);
+    insertQaTailoringPolicy(db, {
+      version: 1,
+      learnedRules: {},
+      createdAt: policyCreatedAt,
+    });
+
+    const insertSignal = db.prepare(
+      `INSERT INTO tailoring_feedback_signals (
+        tenant_id, signal_id, job_id, draft_id, source_kind, source_id,
+        signal_kind, status, summary, created_at, reviewed_at
+      ) VALUES ('local', ?, ?, ?, 'edit_delta', ?, ?, 'accepted', ?, ?, ?)`,
+    );
+    const insertSignalReview = db.prepare(
+      `INSERT INTO tailoring_feedback_signal_reviews (
+        tenant_id, review_id, signal_id, revision, decision, signal_kind,
+        rule_key, rule_value, allowlist_version, reviewed_at
+      ) VALUES ('local', ?, ?, 1, 'accepted', ?, ?, ?, 1, ?)`,
+    );
+    for (const signal of signals) {
+      insertSignal.run(
+        signal.signalId,
+        signal.jobId,
+        signal.draftId,
+        `qa-source-${signal.signalId}`,
+        signal.signalKind,
+        "Synthetic accepted feedback for learning policy browser QA.",
+        signal.reviewedAt,
+        signal.reviewedAt,
+      );
+      insertSignalReview.run(
+        `qa-learning-review-${signal.signalId}`,
+        signal.signalId,
+        signal.signalKind,
+        signal.ruleKey,
+        signal.ruleValue,
+        signal.reviewedAt,
+      );
+    }
+
+    insertQaLearningRecommendation(db, {
+      recommendationId: styleRecommendationId,
+      signalKind: "style_preference",
+      ruleKey: "style_guidance",
+      ruleValue: "preserve_user_edit_pattern",
+      inputFingerprint: "c".repeat(64),
+      derivedAt: "2026-05-04T11:10:00.000Z",
+      signals: signals.slice(0, 3),
+    });
+    insertQaLearningRecommendation(db, {
+      recommendationId: factualRecommendationId,
+      signalKind: "factual_correction",
+      ruleKey: "fact_handling",
+      ruleValue: "require_source_match",
+      inputFingerprint: "d".repeat(64),
+      derivedAt: "2026-05-04T11:09:00.000Z",
+      signals: signals.slice(3),
+    });
+  })();
+}
+
+function insertQaTailoringPolicy(
+  db: Database.Database,
+  input: {
+    version: number;
+    learnedRules: Record<string, string>;
+    createdAt: string;
+    rollbackOfVersion?: number;
+    rollbackReason?: string;
+  },
+): void {
+  db.prepare(
+    `INSERT INTO tailoring_policies (
+      tenant_id, version, prompt_version, schema_version, judge_schema_version,
+      prompt_fingerprint, config_fingerprint, profile_policy_fingerprint,
+      custom_prompt_fingerprint, generator_settings_json, judge_settings_json,
+      runtime_settings_json, rollback_of_version, rollback_reason, created_at,
+      created_from_event_id
+    ) VALUES ('local', ?, 'tailor.v2', 'resume.v1', 'judge.v1',
+              'qa-prompt', ?, 'qa-profile', 'qa-custom', '{}', '{}', ?, ?, ?, ?, NULL)`,
+  ).run(
+    input.version,
+    `qa-config-${input.version}`,
+    JSON.stringify({ learned_tailoring_rules: input.learnedRules }),
+    input.rollbackOfVersion ?? null,
+    input.rollbackReason ?? "",
+    input.createdAt,
+  );
+}
+
+function insertQaLearningRecommendation(
+  db: Database.Database,
+  input: {
+    recommendationId: string;
+    signalKind: "style_preference" | "factual_correction";
+    ruleKey: "style_guidance" | "fact_handling";
+    ruleValue: "preserve_user_edit_pattern" | "require_source_match";
+    inputFingerprint: string;
+    derivedAt: string;
+    signals: readonly {
+      signalId: string;
+      jobId: string;
+      reviewedAt: string;
+    }[];
+  },
+): void {
+  const insertEvidence = db.prepare(
+    `INSERT INTO learning_recommendation_evidence (
+      tenant_id, recommendation_id, signal_id, evidence_role, source_kind,
+      source_id, source_revision, recorded_at
+    ) VALUES ('local', ?, ?, 'supporting', 'tailoring_feedback_signal', ?, 1, ?)`,
+  );
+  const insertEvidenceJob = db.prepare(
+    `INSERT INTO learning_recommendation_evidence_jobs (
+      tenant_id, recommendation_id, signal_id, job_id
+    ) VALUES ('local', ?, ?, ?)`,
+  );
+  const jobIds = new Set<string>();
+  for (const signal of input.signals) {
+    const evidenceSignalId = `tailoring-feedback:${signal.signalId}:1`;
+    insertEvidence.run(
+      input.recommendationId,
+      evidenceSignalId,
+      signal.signalId,
+      signal.reviewedAt,
+    );
+    insertEvidenceJob.run(input.recommendationId, evidenceSignalId, signal.jobId);
+    jobIds.add(signal.jobId);
+  }
+  const insertJob = db.prepare(
+    `INSERT INTO learning_recommendation_jobs (
+      tenant_id, recommendation_id, job_id
+    ) VALUES ('local', ?, ?)`,
+  );
+  for (const jobId of jobIds) {
+    insertJob.run(input.recommendationId, jobId);
+  }
+  db.prepare(
+    `INSERT INTO learning_recommendations (
+      tenant_id, recommendation_id, derivation_version,
+      evaluation_fixture_version, context, policy_kind, signal_kind,
+      rule_key, rule_value, allowlist_version, status, observed_signal_count,
+      observed_job_count, minimum_signal_count, minimum_job_count,
+      confidence_limit, input_fingerprint, derived_at
+    ) VALUES ('local', ?, 1, 1, 'materials', 'tailoring_rule', ?, ?, ?, 1,
+              'pending', 3, 2, 3, 2, 'sample_gated_no_population_inference', ?, ?)`,
+  ).run(
+    input.recommendationId,
+    input.signalKind,
+    input.ruleKey,
+    input.ruleValue,
+    input.inputFingerprint,
+    input.derivedAt,
   );
 }
 

--- a/apps/api/test/server.test.ts
+++ b/apps/api/test/server.test.ts
@@ -2547,6 +2547,100 @@ describe("local TypeScript API", () => {
     await app.close();
   });
 
+  it("excludes terminal learning recommendations from tenant-scoped pages without hiding evidence", async () => {
+    const acceptedRecommendationId = `learning-recommendation:${"a".repeat(64)}`;
+    const rejectedRecommendationId = `learning-recommendation:${"b".repeat(64)}`;
+    const pendingRecommendationId = `learning-recommendation:${"c".repeat(64)}`;
+    const otherTenantRecommendationId = `learning-recommendation:${"d".repeat(64)}`;
+    const db = new Database(options.dbPath);
+    insertLearningRecommendationFixture(db, {
+      tenantId: "local",
+      recommendationId: acceptedRecommendationId,
+      tombstoned: false,
+    });
+    insertLearningRecommendationFixture(db, {
+      tenantId: "local",
+      recommendationId: rejectedRecommendationId,
+      tombstoned: false,
+    });
+    insertLearningRecommendationFixture(db, {
+      tenantId: "local",
+      recommendationId: pendingRecommendationId,
+      tombstoned: false,
+    });
+    insertLearningRecommendationFixture(db, {
+      tenantId: "other",
+      recommendationId: otherTenantRecommendationId,
+      tombstoned: false,
+    });
+    insertTailoringPolicyFixture(db, {
+      tenantId: "local",
+      version: 1,
+      learnedRules: {},
+      createdAt: "2026-08-01T10:00:00Z",
+    });
+    db.prepare(
+      `INSERT INTO learning_recommendation_reviews (
+         tenant_id, review_id, recommendation_id, revision, decision,
+         context, policy_kind, policy_version, reviewed_at
+       ) VALUES ('local', ?, ?, 1, 'accepted', 'materials', 'tailoring_rule', 1, ?)`,
+    ).run(
+      `learning-recommendation-review:${"e".repeat(64)}`,
+      acceptedRecommendationId,
+      "2026-08-01T10:01:00Z",
+    );
+    db.prepare(
+      `INSERT INTO learning_recommendation_reviews (
+         tenant_id, review_id, recommendation_id, revision, decision,
+         context, policy_kind, policy_version, reviewed_at
+       ) VALUES ('local', ?, ?, 1, 'rejected', 'materials', 'tailoring_rule', NULL, ?)`,
+    ).run(
+      `learning-recommendation-review:${"f".repeat(64)}`,
+      rejectedRecommendationId,
+      "2026-08-01T10:02:00Z",
+    );
+    db.close();
+
+    const app = buildApp(options);
+    const firstPage = LearningRecommendationListResponseSchema.parse(
+      (
+        await app.inject({
+          method: "GET",
+          url: "/v1/learning/recommendations?page=1&pageSize=1",
+        })
+      ).json(),
+    );
+    const secondPage = LearningRecommendationListResponseSchema.parse(
+      (
+        await app.inject({
+          method: "GET",
+          url: "/v1/learning/recommendations?page=2&pageSize=1",
+        })
+      ).json(),
+    );
+    const acceptedEvidence = LearningRecommendationEvidenceListResponseSchema.parse(
+      (
+        await app.inject({
+          method: "GET",
+          url: `/v1/learning/recommendations/${encodeURIComponent(acceptedRecommendationId)}/evidence`,
+        })
+      ).json(),
+    );
+
+    expect(firstPage).toMatchObject({ page: 1, pageSize: 1, total: 1, totalPages: 1 });
+    expect(firstPage.recommendations).toEqual([
+      expect.objectContaining({ recommendationId: pendingRecommendationId }),
+    ]);
+    expect(secondPage).toMatchObject({ page: 2, pageSize: 1, total: 1, totalPages: 1 });
+    expect(secondPage.recommendations).toEqual([]);
+    expect(acceptedEvidence).toMatchObject({
+      recommendationId: acceptedRecommendationId,
+      total: 4,
+    });
+
+    await app.close();
+  });
+
   it("serves privacy-bounded tailoring policy revision history", async () => {
     const recommendationId = `learning-recommendation:${"a".repeat(64)}`;
     const reviewId = `learning-recommendation-review:${"b".repeat(64)}`;

--- a/apps/web/e2e/tests/learning-policy.spec.ts
+++ b/apps/web/e2e/tests/learning-policy.spec.ts
@@ -1,0 +1,295 @@
+import { expect, type Page, test } from "@playwright/test";
+import Database from "better-sqlite3";
+
+import { loadE2eDbPath } from "../fixtures/e2e-state.js";
+
+const STYLE_RECOMMENDATION_ID = `learning-recommendation:${"a".repeat(64)}`;
+const FACTUAL_RECOMMENDATION_ID = `learning-recommendation:${"b".repeat(64)}`;
+const ACCEPTED_REVIEW_ID = `learning-recommendation-review:${"c".repeat(64)}`;
+const REJECTED_REVIEW_ID = `learning-recommendation-review:${"d".repeat(64)}`;
+const ACCEPTED_AT = "2026-05-04T11:20:00.000Z";
+const REJECTED_AT = "2026-05-04T11:21:00.000Z";
+const ROLLED_BACK_AT = "2026-05-04T11:22:00.000Z";
+
+test("Dashboard learning review keeps evidence, terminal decisions, and policy rollback auditable", async ({
+  page,
+}) => {
+  const dbPath = loadE2eDbPath();
+  await installDeterministicLearningWrites(page, dbPath);
+
+  const initialRecommendations = page.waitForResponse(
+    (response) =>
+      response.url().includes("/v1/learning/recommendations") &&
+      response.request().method() === "GET",
+  );
+  const initialPolicyHistory = page.waitForResponse(
+    (response) =>
+      response.url().includes("/v1/learning/policies/materials") &&
+      response.request().method() === "GET",
+  );
+  await page.goto("/dashboard");
+  expect((await initialRecommendations).status()).toBe(200);
+  expect((await initialPolicyHistory).status()).toBe(200);
+
+  const recommendations = page.locator(".learning-review-panel");
+  const policyHistory = page.locator(".tailoring-policy-history-panel");
+  const styleRecommendation = recommendations.getByRole("article", {
+    name: "style_guidance → preserve_user_edit_pattern",
+  });
+  const factualRecommendation = recommendations.getByRole("article", {
+    name: "fact_handling → require_source_match",
+  });
+
+  await expect(styleRecommendation).toBeVisible({ timeout: 30_000 });
+  await expect(factualRecommendation).toBeVisible();
+  await expect(
+    styleRecommendation.getByText("3 of 3 required accepted signals across 2 of 2 required jobs"),
+  ).toBeVisible();
+  await expect(policyHistory.getByRole("article", { name: "Version 1" })).toBeVisible();
+  await expect(
+    policyHistory.getByRole("button", { name: "Restore tailoring policy version 1" }),
+  ).toHaveCount(0);
+
+  await styleRecommendation
+    .getByRole("button", { name: "Inspect evidence for style_guidance → preserve_user_edit_pattern" })
+    .click();
+  const evidence = styleRecommendation.getByRole("list", {
+    name: "Evidence for style_guidance → preserve_user_edit_pattern",
+  });
+  await expect(evidence.getByText("tailoring-feedback:qa-learning-style-1:1")).toBeVisible();
+  await expect(
+    evidence.getByText(/revision 1 · job abaf847c-43cd-40ad-8dc3-76685694ff29/i),
+  ).toHaveCount(2);
+  await expect(
+    evidence.getByText(/revision 1 · job 1b34c69a-9c9f-4f67-8bd1-9682a6ff492a/i),
+  ).toHaveCount(1);
+
+  await styleRecommendation
+    .getByRole("button", {
+      name: "Accept learning recommendation style_guidance → preserve_user_edit_pattern",
+    })
+    .click();
+  await expect(styleRecommendation).toHaveCount(0);
+  const acceptedRecommendations = page.waitForResponse(
+    (response) =>
+      response.url().includes("/v1/learning/recommendations") &&
+      response.request().method() === "GET",
+  );
+  const acceptedHistory = page.waitForResponse(
+    (response) =>
+      response.url().includes("/v1/learning/policies/materials") &&
+      response.request().method() === "GET",
+  );
+  await page.reload();
+  expect((await acceptedRecommendations).status()).toBe(200);
+  expect((await acceptedHistory).status()).toBe(200);
+  const acceptedPolicy = policyHistory.getByRole("article", { name: "Version 2" });
+  await expect(acceptedPolicy).toBeVisible();
+  await expect(acceptedPolicy.getByText("Current")).toBeVisible();
+  await expect(
+    acceptedPolicy.getByText(`Accepted recommendation ${STYLE_RECOMMENDATION_ID}`),
+  ).toBeVisible();
+  await expect(acceptedPolicy.getByText(`Review ${ACCEPTED_REVIEW_ID}`)).toBeVisible();
+
+  await factualRecommendation
+    .getByRole("button", {
+      name: "Reject learning recommendation fact_handling → require_source_match",
+    })
+    .click();
+  await expect(factualRecommendation).toHaveCount(0);
+  expect(currentPolicyVersion(dbPath)).toBe(2);
+
+  const rejectedRecommendations = page.waitForResponse(
+    (response) =>
+      response.url().includes("/v1/learning/recommendations") &&
+      response.request().method() === "GET",
+  );
+  const rejectedHistory = page.waitForResponse(
+    (response) =>
+      response.url().includes("/v1/learning/policies/materials") &&
+      response.request().method() === "GET",
+  );
+  await page.reload();
+  expect((await rejectedRecommendations).status()).toBe(200);
+  expect((await rejectedHistory).status()).toBe(200);
+  await expect(recommendations.getByText("No learning recommendations to review.")).toBeVisible();
+  await expect(policyHistory.getByRole("article", { name: "Version 2" })).toBeVisible();
+  await expect(policyHistory.getByRole("article", { name: "Version 3" })).toHaveCount(0);
+
+  const rollbackHistory = page.waitForResponse(
+    (response) =>
+      response.url().includes("/v1/learning/policies/materials") &&
+      response.request().method() === "GET",
+  );
+  await policyHistory
+    .getByRole("button", { name: "Restore tailoring policy version 1" })
+    .click();
+  expect((await rollbackHistory).status()).toBe(200);
+  const rolledBackPolicy = policyHistory.getByRole("article", { name: "Version 3" });
+  await expect(rolledBackPolicy).toBeVisible();
+  await expect(rolledBackPolicy.getByText("Current")).toBeVisible();
+  await expect(rolledBackPolicy.getByText("Restored from version 1")).toBeVisible();
+  await expect(rolledBackPolicy.getByText("Reason: user requested")).toBeVisible();
+  await expect(
+    policyHistory.getByRole("button", { name: "Restore tailoring policy version 3" }),
+  ).toHaveCount(0);
+});
+
+async function installDeterministicLearningWrites(page: Page, dbPath: string): Promise<void> {
+  await page.route("**/v1/learning/recommendations/*/reviews", async (route) => {
+    const request = route.request();
+    const recommendationId = decodeURIComponent(
+      new URL(request.url()).pathname.split("/").at(-2) ?? "",
+    );
+    const body = request.postDataJSON() as { decision?: string };
+    if (recommendationId === STYLE_RECOMMENDATION_ID && body.decision === "accepted") {
+      appendAcceptedRecommendation(dbPath);
+      await route.fulfill({
+        json: {
+          ok: true,
+          reviewId: ACCEPTED_REVIEW_ID,
+          recommendationId,
+          revision: 1,
+          decision: "accepted",
+          context: "materials",
+          policyKind: "tailoring_rule",
+          policyVersion: 2,
+          reviewedAt: ACCEPTED_AT,
+        },
+      });
+      return;
+    }
+    if (recommendationId === FACTUAL_RECOMMENDATION_ID && body.decision === "rejected") {
+      appendRejectedRecommendation(dbPath);
+      await route.fulfill({
+        json: {
+          ok: true,
+          reviewId: REJECTED_REVIEW_ID,
+          recommendationId,
+          revision: 1,
+          decision: "rejected",
+          context: "materials",
+          policyKind: "tailoring_rule",
+          policyVersion: null,
+          reviewedAt: REJECTED_AT,
+        },
+      });
+      return;
+    }
+    throw new Error(`Unexpected learning review request for ${recommendationId}.`);
+  });
+
+  await page.route("**/v1/learning/policies/materials/rollbacks", async (route) => {
+    const body = route.request().postDataJSON() as { targetVersion?: number };
+    if (body.targetVersion !== 1) {
+      throw new Error(`Unexpected tailoring policy rollback target ${body.targetVersion}.`);
+    }
+    appendRollback(dbPath);
+    await route.fulfill({
+      json: {
+        ok: true,
+        context: "materials",
+        policyKind: "tailoring_rule",
+        version: 3,
+        status: "current",
+        learnedRules: [],
+        sourceReviewId: null,
+        sourceRecommendationId: null,
+        rollbackOfVersion: 1,
+        rollbackReasonCode: "user_requested",
+        createdAt: ROLLED_BACK_AT,
+      },
+    });
+  });
+}
+
+function appendAcceptedRecommendation(dbPath: string): void {
+  const db = new Database(dbPath);
+  try {
+    db.transaction(() => {
+      insertPolicy(db, {
+        version: 2,
+        learnedRules: { style_guidance: "preserve_user_edit_pattern" },
+        createdAt: ACCEPTED_AT,
+      });
+      db.prepare(
+        `INSERT INTO learning_recommendation_reviews (
+          tenant_id, review_id, recommendation_id, revision, decision,
+          context, policy_kind, policy_version, reviewed_at
+        ) VALUES ('local', ?, ?, 1, 'accepted', 'materials', 'tailoring_rule', 2, ?)`,
+      ).run(ACCEPTED_REVIEW_ID, STYLE_RECOMMENDATION_ID, ACCEPTED_AT);
+    })();
+  } finally {
+    db.close();
+  }
+}
+
+function appendRejectedRecommendation(dbPath: string): void {
+  const db = new Database(dbPath);
+  try {
+    db.prepare(
+      `INSERT INTO learning_recommendation_reviews (
+        tenant_id, review_id, recommendation_id, revision, decision,
+        context, policy_kind, policy_version, reviewed_at
+      ) VALUES ('local', ?, ?, 1, 'rejected', 'materials', 'tailoring_rule', NULL, ?)`,
+    ).run(REJECTED_REVIEW_ID, FACTUAL_RECOMMENDATION_ID, REJECTED_AT);
+  } finally {
+    db.close();
+  }
+}
+
+function appendRollback(dbPath: string): void {
+  const db = new Database(dbPath);
+  try {
+    insertPolicy(db, {
+      version: 3,
+      learnedRules: {},
+      createdAt: ROLLED_BACK_AT,
+      rollbackOfVersion: 1,
+      rollbackReason: "user_requested",
+    });
+  } finally {
+    db.close();
+  }
+}
+
+function insertPolicy(
+  db: Database.Database,
+  input: {
+    version: number;
+    learnedRules: Record<string, string>;
+    createdAt: string;
+    rollbackOfVersion?: number;
+    rollbackReason?: string;
+  },
+): void {
+  db.prepare(
+    `INSERT INTO tailoring_policies (
+      tenant_id, version, prompt_version, schema_version, judge_schema_version,
+      prompt_fingerprint, config_fingerprint, profile_policy_fingerprint,
+      custom_prompt_fingerprint, generator_settings_json, judge_settings_json,
+      runtime_settings_json, rollback_of_version, rollback_reason, created_at,
+      created_from_event_id
+    ) VALUES ('local', ?, 'tailor.v2', 'resume.v1', 'judge.v1',
+              'qa-prompt', ?, 'qa-profile', 'qa-custom', '{}', '{}', ?, ?, ?, ?, NULL)`,
+  ).run(
+    input.version,
+    `qa-config-${input.version}`,
+    JSON.stringify({ learned_tailoring_rules: input.learnedRules }),
+    input.rollbackOfVersion ?? null,
+    input.rollbackReason ?? "",
+    input.createdAt,
+  );
+}
+
+function currentPolicyVersion(dbPath: string): number {
+  const db = new Database(dbPath, { readonly: true });
+  try {
+    const row = db
+      .prepare("SELECT MAX(version) AS version FROM tailoring_policies WHERE tenant_id = 'local'")
+      .get() as { version: number | null } | undefined;
+    return Number(row?.version);
+  } finally {
+    db.close();
+  }
+}


### PR DESCRIPTION
## Recovery

- Restores the exact single-commit diff from original PR #705 as its own reviewable layer in new GitHub Stack #738.
- No implementation content was added, removed, or combined during recovery.

## Why

The original PR was marked merged into an already-merged parent branch, so its commit did not reach `main`. This reconstructed stack roots the first recovered layer on current `main` and preserves the original order through PR #707.

## Validation

- Original focused implementation and validation record: #705
- Content-equivalent cumulative recovery head: #710 (full CI passed before this individual stack was published)
- This PR contains exactly one recovered commit.