### PR TITLE
fix: make learning decisions terminal

### DIFF
--- a/apps/api/src/schema-manifest.ts
+++ b/apps/api/src/schema-manifest.ts
@@ -16,7 +16,7 @@ export const EXACT_V7_SCHEMA_MANIFEST: SchemaManifest = {
   version: 7,
   objectCount: 242,
   tableCount: 110,
-  fingerprint: "55d88c87aaf9bec6c8686ee0e40dba31ca19aaaa5767042f9376f5e2756fecfd",
+  fingerprint: "775312f0ec2640a2a87889602886c90e21a49e06fffc53cf26c435856247da97",
 };
 
 type SqliteMasterRow = [type: string, name: string, tableName: string, sql: string];

--- a/workers/automation/src/jobctrl/infrastructure/materials/sqlite_repository.py
+++ b/workers/automation/src/jobctrl/infrastructure/materials/sqlite_repository.py
@@ -1015,24 +1015,14 @@ class SqliteLearningRecommendationReviewRepository:
                     (str(tenant_id), recommendation_id),
                 ).fetchall()
             )
-            accepted = next(
-                (review for review in prior_reviews if review.decision == "accepted"),
-                None,
-            )
-            if accepted is not None:
-                if decision == "accepted":
+            if prior_reviews:
+                terminal = prior_reviews[0]
+                if decision == terminal.decision:
                     self._conn.commit()
-                    return accepted
+                    return terminal
                 raise LearningRecommendationReviewError(
-                    "accepted learning recommendation is terminal"
+                    "learning recommendation decision is terminal"
                 )
-            replay = next(
-                (review for review in prior_reviews if review.decision == decision),
-                None,
-            )
-            if replay is not None:
-                self._conn.commit()
-                return replay
 
             tombstoned = self._conn.execute(
                 """

--- a/workers/automation/src/jobctrl/infrastructure/migrations/schema_manifest.py
+++ b/workers/automation/src/jobctrl/infrastructure/migrations/schema_manifest.py
@@ -25,7 +25,7 @@ EXACT_V7_MANIFEST = SchemaManifest(
     version=7,
     object_count=242,
     table_count=110,
-    fingerprint="55d88c87aaf9bec6c8686ee0e40dba31ca19aaaa5767042f9376f5e2756fecfd",
+    fingerprint="775312f0ec2640a2a87889602886c90e21a49e06fffc53cf26c435856247da97",
 )
 
 

--- a/workers/automation/src/jobctrl/infrastructure/migrations/schema_v7.sql
+++ b/workers/automation/src/jobctrl/infrastructure/migrations/schema_v7.sql
@@ -1945,14 +1945,7 @@ WHEN EXISTS (
   WHERE tenant_id = NEW.tenant_id
     AND (
       review_id = NEW.review_id
-      OR (
-        recommendation_id = NEW.recommendation_id
-        AND (
-          revision = NEW.revision
-          OR decision = NEW.decision
-          OR decision = 'accepted'
-        )
-      )
+      OR recommendation_id = NEW.recommendation_id
       OR (
         NEW.policy_version IS NOT NULL
         AND context = NEW.context
@@ -1972,14 +1965,7 @@ WHEN NOT EXISTS (
   WHERE tenant_id = NEW.tenant_id
     AND (
       review_id = NEW.review_id
-      OR (
-        recommendation_id = NEW.recommendation_id
-        AND (
-          revision = NEW.revision
-          OR decision = NEW.decision
-          OR decision = 'accepted'
-        )
-      )
+      OR recommendation_id = NEW.recommendation_id
       OR (
         NEW.policy_version IS NOT NULL
         AND context = NEW.context

--- a/workers/automation/tests/test_exact_v7_schema.py
+++ b/workers/automation/tests/test_exact_v7_schema.py
@@ -1206,7 +1206,7 @@ def test_learning_recommendation_reviews_are_append_only_and_policy_linked(
     for recommendation_id, fingerprint in (
         ("recommendation-rejected", "d"),
         ("recommendation-accepted", "e"),
-        ("recommendation-later-accepted", "f"),
+        ("recommendation-revision-gap", "f"),
     ):
         _insert_learning_recommendation_fixture(
             conn,
@@ -1271,19 +1271,6 @@ def test_learning_recommendation_reviews_are_append_only_and_policy_linked(
         )
         """
     )
-    conn.execute(
-        """
-        INSERT INTO learning_recommendation_reviews (
-            tenant_id, review_id, recommendation_id, revision, decision,
-            context, policy_kind, policy_version, reviewed_at
-        ) VALUES (
-            'local', 'review-later-rejected', 'recommendation-later-accepted', 1,
-            'rejected', 'materials', 'tailoring_rule', NULL,
-            '2026-08-01T02:03:00Z'
-        )
-        """
-    )
-
     with pytest.raises(sqlite3.IntegrityError, match="append-only"):
         conn.execute(
             """
@@ -1305,23 +1292,24 @@ def test_learning_recommendation_reviews_are_append_only_and_policy_linked(
                 context, policy_kind, policy_version, reviewed_at
             ) VALUES (
                 'local', 'review-later-accepted-gap',
-                'recommendation-later-accepted', 3, 'accepted',
+                'recommendation-revision-gap', 3, 'accepted',
                 'materials', 'tailoring_rule', 2, '2026-08-01T03:01:00Z'
             )
             """
         )
-    conn.execute(
-        """
-        INSERT INTO learning_recommendation_reviews (
-            tenant_id, review_id, recommendation_id, revision, decision,
-            context, policy_kind, policy_version, reviewed_at
-        ) VALUES (
-            'local', 'review-later-accepted',
-            'recommendation-later-accepted', 2, 'accepted',
-            'materials', 'tailoring_rule', 2, '2026-08-01T03:02:00Z'
+    with pytest.raises(sqlite3.IntegrityError, match="append-only"):
+        conn.execute(
+            """
+            INSERT INTO learning_recommendation_reviews (
+                tenant_id, review_id, recommendation_id, revision, decision,
+                context, policy_kind, policy_version, reviewed_at
+            ) VALUES (
+                'local', 'review-after-rejected',
+                'recommendation-rejected', 2, 'accepted',
+                'materials', 'tailoring_rule', 2, '2026-08-01T03:02:00Z'
+            )
+            """
         )
-        """
-    )
     with pytest.raises(sqlite3.IntegrityError, match="append-only"):
         conn.execute(
             """
@@ -1330,7 +1318,7 @@ def test_learning_recommendation_reviews_are_append_only_and_policy_linked(
                 context, policy_kind, policy_version, reviewed_at
             ) VALUES (
                 'local', 'review-after-accepted',
-                'recommendation-later-accepted', 3, 'rejected',
+                'recommendation-accepted', 2, 'rejected',
                 'materials', 'tailoring_rule', NULL, '2026-08-01T03:03:00Z'
             )
             """
@@ -1343,7 +1331,7 @@ def test_learning_recommendation_reviews_are_append_only_and_policy_linked(
                     tenant_id, review_id, recommendation_id, revision, decision,
                     context, policy_kind, policy_version, reviewed_at
                 ) VALUES (
-                    'local', ?, 'recommendation-rejected', 2, ?,
+                    'local', ?, 'recommendation-revision-gap', 1, ?,
                     'materials', 'tailoring_rule', ?, '2026-08-01T04:00:00Z'
                 )
                 """,

--- a/workers/automation/tests/test_rpc_learning_recommendations.py
+++ b/workers/automation/tests/test_rpc_learning_recommendations.py
@@ -171,6 +171,73 @@ def test_explicit_review_accepts_atomically_and_replays(
     close_connection(db_path)
 
 
+def test_explicit_review_rejection_is_terminal_and_replays(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    conn = init_db(db_path)
+    _seed_recommendation_sources(conn)
+    monkeypatch.setattr(handlers_mod, "get_connection", lambda: conn)
+    server = JsonRpcServer(workflow_starter=_stub_starter)
+    register_default_handlers(server, canceler=_stub_canceler)
+    derived = server.dispatch(
+        JsonRpcRequest(
+            method="rederive_learning_recommendations",
+            params={"tenantId": "local"},
+            id=1,
+        )
+    )
+    assert derived is not None
+    recommendation_id = derived.to_dict()["result"]["recommendationIds"][0]
+    policy_repository = SqliteTailoringPolicyRepository(conn)
+    original_policy = _tailoring_policy()
+    policy_repository.save(original_policy)
+    params = {
+        "tenantId": "local",
+        "recommendationId": recommendation_id,
+        "decision": "rejected",
+    }
+
+    rejected = server.dispatch(
+        JsonRpcRequest(
+            method="review_learning_recommendation",
+            params=params,
+            id=2,
+        )
+    )
+    replay = server.dispatch(
+        JsonRpcRequest(
+            method="review_learning_recommendation",
+            params=params,
+            id=3,
+        )
+    )
+    accepted = server.dispatch(
+        JsonRpcRequest(
+            method="review_learning_recommendation",
+            params={**params, "decision": "accepted"},
+            id=4,
+        )
+    )
+
+    assert rejected is not None
+    assert replay is not None
+    assert accepted is not None
+    rejected_result = rejected.to_dict()["result"]
+    replay_result = replay.to_dict()["result"]
+    assert rejected_result["decision"] == "rejected"
+    assert rejected_result["policyVersion"] is None
+    assert replay_result["reviewId"] == rejected_result["reviewId"]
+    assert accepted.to_dict()["error"]["code"] == INVALID_PARAMS
+    assert conn.execute(
+        "SELECT COUNT(*) FROM learning_recommendation_reviews"
+    ).fetchone()[0] == 1
+    assert policy_repository.get_current(LOCAL_TENANT) == original_policy
+    assert conn.execute("SELECT COUNT(*) FROM tailoring_policies").fetchone()[0] == 1
+    close_connection(db_path)
+
+
 def test_explicit_policy_rollback_appends_once_and_replays(
     tmp_path: Path,
     monkeypatch,

--- a/workers/automation/tests/test_sqlite_learning_recommendations.py
+++ b/workers/automation/tests/test_sqlite_learning_recommendations.py
@@ -753,7 +753,7 @@ def test_multiple_source_changes_each_append_a_tombstone(tmp_path: Path) -> None
     close_connection(db_path)
 
 
-def test_review_rejects_without_policy_then_accepts_once(tmp_path: Path) -> None:
+def test_review_rejection_is_terminal_and_replays_same_decision(tmp_path: Path) -> None:
     db_path = tmp_path / "jobctrl.db"
     conn = init_db(db_path)
     recommendation = _recommendation(_TENANT_A)
@@ -784,29 +784,6 @@ def test_review_rejects_without_policy_then_accepts_once(tmp_path: Path) -> None
     assert rejected.policy_version is None
     assert policy_repository.get_current(_TENANT_A) == original_policy
 
-    accepted = reviewer.review(
-        _TENANT_A,
-        recommendation_id=recommendation.recommendation_id,
-        decision="accepted",
-        reviewed_at="2026-08-01T11:02:00Z",
-    )
-    accepted_replay = reviewer.review(
-        _TENANT_A,
-        recommendation_id=recommendation.recommendation_id,
-        decision="accepted",
-        reviewed_at="2026-08-01T11:03:00Z",
-    )
-
-    assert accepted == accepted_replay
-    assert accepted.revision == 2
-    assert accepted.policy_version == 2
-    assert policy_repository.get_current(_TENANT_A).learned_tailoring_rules.to_dict() == {
-        "fact_handling": "require_source_match"
-    }
-    assert conn.execute(
-        "SELECT COUNT(*) FROM learning_recommendation_reviews"
-    ).fetchone()[0] == 2
-    assert conn.execute("SELECT COUNT(*) FROM tailoring_policies").fetchone()[0] == 2
     with pytest.raises(
         LearningRecommendationReviewError,
         match="terminal",
@@ -814,9 +791,13 @@ def test_review_rejects_without_policy_then_accepts_once(tmp_path: Path) -> None
         reviewer.review(
             _TENANT_A,
             recommendation_id=recommendation.recommendation_id,
-            decision="rejected",
-            reviewed_at="2026-08-01T11:04:00Z",
+            decision="accepted",
+            reviewed_at="2026-08-01T11:02:00Z",
         )
+    assert conn.execute(
+        "SELECT COUNT(*) FROM learning_recommendation_reviews"
+    ).fetchone()[0] == 1
+    assert conn.execute("SELECT COUNT(*) FROM tailoring_policies").fetchone()[0] == 1
     close_connection(db_path)
 
 


### PR DESCRIPTION
## Recovery

- Restores the exact single-commit diff from original PR #706 as its own reviewable layer in new GitHub Stack #738.
- No implementation content was added, removed, or combined during recovery.

## Why

The original PR was marked merged into an already-merged parent branch, so its commit did not reach `main`. This reconstructed stack roots the first recovered layer on current `main` and preserves the original order through PR #707.

## Validation

- Original focused implementation and validation record: #706
- Content-equivalent cumulative recovery head: #710 (full CI passed before this individual stack was published)
- This PR contains exactly one recovered commit.