### PR TITLE
fix: synchronize exact v7 schema manifests

### DIFF
--- a/apps/api/test/schema-version-guard.test.ts
+++ b/apps/api/test/schema-version-guard.test.ts
@@ -149,7 +149,7 @@ describe("schema version guard at DB open", () => {
       version: SUPPORTED_SCHEMA_VERSION,
       objectCount: 242,
       tableCount: 110,
-      fingerprint: "55d88c87aaf9bec6c8686ee0e40dba31ca19aaaa5767042f9376f5e2756fecfd",
+      fingerprint: "775312f0ec2640a2a87889602886c90e21a49e06fffc53cf26c435856247da97",
     });
   });
 });


### PR DESCRIPTION
## Recovery

- Restores the exact single-commit diff from original PR #707 as its own reviewable layer in new GitHub Stack #738.
- No implementation content was added, removed, or combined during recovery.

## Why

The original PR was marked merged into an already-merged parent branch, so its commit did not reach `main`. This reconstructed stack roots the first recovered layer on current `main` and preserves the original order through PR #707.

## Validation

- Original focused implementation and validation record: #707
- Content-equivalent cumulative recovery head: #710 (full CI passed before this individual stack was published)
- This PR contains exactly one recovered commit.