### PR TITLE
fix(web): clarify jobs bulk action controls

### DIFF
--- a/apps/web/e2e/tests/jobs-bulk.spec.ts
+++ b/apps/web/e2e/tests/jobs-bulk.spec.ts
@@ -9,17 +9,12 @@ test("Bulk soft-delete + restore: select 3 → delete → confirm → switch to 
   page.on("dialog", (dialog) => void dialog.accept());
 
   await page.goto("/jobs");
-  const moreActions = page.getByRole("button", { name: "More actions" });
-  await expect(moreActions).toBeVisible({
+  await expect(page.getByRole("button", { name: "Select page" })).toBeVisible({
     timeout: 30_000,
   });
-  await moreActions.click();
   await expect(
-    page
-      .getByRole("menu", { name: "More actions" })
-      .getByRole("menuitem", { name: "Select page" }),
+    page.getByRole("button", { name: "Select all matching" }),
   ).toBeVisible();
-  await page.keyboard.press("Escape");
   await expect(page.getByText(/Director of Platform Engineering/i)).toBeVisible(
     {
       timeout: 30_000,

--- a/apps/web/src/views/jobs/JobBulkActions.test.tsx
+++ b/apps/web/src/views/jobs/JobBulkActions.test.tsx
@@ -274,24 +274,19 @@ describe("<JobBulkActions>", () => {
       }),
     ).toBeInTheDocument();
 
-    const moreActions = screen.getByRole("button", { name: "More actions" });
-    moreActions.focus();
-    await user.keyboard("{Enter}");
-    const menu = screen.getByRole("menu", { name: "More actions" });
+    expect(
+      screen.queryByRole("button", { name: "More actions" }),
+    ).not.toBeInTheDocument();
     await user.click(
-      within(menu).getByRole("menuitem", { name: "Select all matching" }),
+      screen.getByRole("button", { name: "Select all matching" }),
     );
     expect(onSelectAllMatching).toHaveBeenCalledTimes(1);
 
-    moreActions.focus();
-    await user.keyboard("{Enter}");
-    await user.click(
-      within(screen.getByRole("menu", { name: "More actions" })).getByRole(
-        "menuitem",
-        { name: "Clear selection" },
-      ),
-    );
+    await user.click(screen.getByRole("button", { name: "Clear selection" }));
     expect(onClearSelection).toHaveBeenCalledTimes(1);
+    expect(
+      jobOperations.querySelector('[data-icon="inline-end"]'),
+    ).not.toBeNull();
   });
 
   it("invokes onMutateSelected when the danger button is clicked", async () => {

--- a/apps/web/src/views/jobs/JobBulkActions.tsx
+++ b/apps/web/src/views/jobs/JobBulkActions.tsx
@@ -1,3 +1,4 @@
+import { IconChevronDown } from "@tabler/icons-react";
 import { useId } from "react";
 
 import { RefreshAllCompensationButton } from "../../contexts/enrichment/index.js";
@@ -158,32 +159,34 @@ export function JobBulkActions({
           {selectedCount ? (
             <span data-typography="metadata">{selectedCount} selected</span>
           ) : null}
-          <DropdownMenu>
-            <DropdownMenuTrigger
-              render={<Button size="sm" type="button" variant="outline" />}
+          <Button
+            disabled={!hasItems}
+            size="sm"
+            type="button"
+            variant="outline"
+            onClick={onSelectPage}
+          >
+            Select page
+          </Button>
+          <Button
+            disabled={!hasAnyMatching || hasLocalFilters}
+            size="sm"
+            type="button"
+            variant="outline"
+            onClick={onSelectAllMatching}
+          >
+            Select all matching
+          </Button>
+          {selectedCount ? (
+            <Button
+              size="sm"
+              type="button"
+              variant="ghost"
+              onClick={onClearSelection}
             >
-              More actions
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="start" aria-label="More actions">
-              <DropdownMenuGroup>
-                <DropdownMenuLabel>Selection</DropdownMenuLabel>
-                <DropdownMenuItem disabled={!hasItems} onClick={onSelectPage}>
-                  Select page
-                </DropdownMenuItem>
-                <DropdownMenuItem
-                  disabled={!hasAnyMatching || hasLocalFilters}
-                  onClick={onSelectAllMatching}
-                >
-                  Select all matching
-                </DropdownMenuItem>
-                {selectedCount ? (
-                  <DropdownMenuItem onClick={onClearSelection}>
-                    Clear selection
-                  </DropdownMenuItem>
-                ) : null}
-              </DropdownMenuGroup>
-            </DropdownMenuContent>
-          </DropdownMenu>
+              Clear selection
+            </Button>
+          ) : null}
         </div>
         {hasUnavailableDemoAutomation ? (
           <span data-typography="body" id={unavailableReasonId} role="status">
@@ -202,6 +205,7 @@ export function JobBulkActions({
               render={<Button size="sm" type="button" variant="outline" />}
             >
               Job operations
+              <IconChevronDown aria-hidden="true" data-icon="inline-end" />
             </DropdownMenuTrigger>
             <DropdownMenuContent align="start" aria-label="Job operations">
               {retrySelectedFailures || retryAllFailures ? (

--- a/apps/web/src/views/jobs/JobsView.test.tsx
+++ b/apps/web/src/views/jobs/JobsView.test.tsx
@@ -294,7 +294,9 @@ describe("<JobsView> realtime UI state", () => {
         )?.artifact.status,
       ).toBe("approved");
       expect(
-        harness.queryClient.getQueryData<ReturnType<typeof makeWorkflowRunDetail>>(
+        harness.queryClient.getQueryData<
+          ReturnType<typeof makeWorkflowRunDetail>
+        >(
           workflowRunsKeys.detail(
             LOCAL_TENANT,
             eventByType.WorkflowCompleted.payload.workflowId,
@@ -308,7 +310,9 @@ describe("<JobsView> realtime UI state", () => {
         artifactsKeys.list(LOCAL_TENANT, { status: "candidate", page: 3 }),
       )?.isInvalidated,
     ).toBe(true);
-    expect(harness.queryClient.getQueryState(unrelatedKey)?.isInvalidated).toBe(false);
+    expect(harness.queryClient.getQueryState(unrelatedKey)?.isInvalidated).toBe(
+      false,
+    );
     expect(screen.getByText("1 selected")).toBeInTheDocument();
     expect(
       screen.getByRole("checkbox", { name: `Select ${latestJob.title}` }),
@@ -1193,16 +1197,8 @@ describe("<JobsView> bulk delete integration", () => {
     render(<RouterProvider router={router} />, { wrapper: Wrapper });
 
     expect(await screen.findByText("discover candidate")).toBeInTheDocument();
-    const firstMoreActions = screen.getByRole("button", {
-      name: "More actions",
-    });
-    firstMoreActions.focus();
-    await user.keyboard("{Enter}");
     await user.click(
-      within(screen.getByRole("menu", { name: "More actions" })).getByRole(
-        "menuitem",
-        { name: "Select all matching" },
-      ),
+      screen.getByRole("button", { name: "Select all matching" }),
     );
     await waitFor(() =>
       expect(screen.getByText("1 selected")).toBeInTheDocument(),
@@ -1232,16 +1228,8 @@ describe("<JobsView> bulk delete integration", () => {
       },
     );
 
-    const secondMoreActions = screen.getByRole("button", {
-      name: "More actions",
-    });
-    secondMoreActions.focus();
-    await user.keyboard("{Enter}");
     await user.click(
-      within(screen.getByRole("menu", { name: "More actions" })).getByRole(
-        "menuitem",
-        { name: "Select all matching" },
-      ),
+      screen.getByRole("button", { name: "Select all matching" }),
     );
     await waitFor(() =>
       expect(screen.getByText(/2 selected/i)).toBeInTheDocument(),
@@ -1312,24 +1300,11 @@ describe("<JobsView> bulk delete integration", () => {
       ).not.toBeInTheDocument(),
     );
     await user.keyboard("{Escape}");
-    const filteredMoreActions = screen.getByRole("button", {
-      name: "More actions",
-    });
-    filteredMoreActions.focus();
-    await user.keyboard("{Enter}");
     expect(
-      within(screen.getByRole("menu", { name: "More actions" })).getByRole(
-        "menuitem",
-        { name: "Select all matching" },
-      ),
-    ).toHaveAttribute("aria-disabled", "true");
+      screen.getByRole("button", { name: "Select all matching" }),
+    ).toBeDisabled();
 
-    await user.click(
-      within(screen.getByRole("menu", { name: "More actions" })).getByRole(
-        "menuitem",
-        { name: /select page/i },
-      ),
-    );
+    await user.click(screen.getByRole("button", { name: /select page/i }));
     await waitFor(() =>
       expect(screen.getByText(/1 selected/i)).toBeInTheDocument(),
     );


### PR DESCRIPTION
## Summary

- promote Select page and Select all matching from a two-item overflow menu to direct toolbar actions
- show Clear selection directly when a selection exists
- add a chevron to Job operations so its dropdown behavior is explicit
- update focused component, integration, and browser-flow coverage

## Validation

- `corepack pnpm --filter @jobctrl/web test -- --run src/views/jobs/JobBulkActions.test.tsx src/views/jobs/JobsView.test.tsx`
- `corepack pnpm web:check`
- `corepack pnpm web:build`
- full web unit suite: 324 files, 1,990 tests passed
- manual local browser verification of direct actions and Job operations dropdown
- independent product QA: PASS
- independent review: PASS

## Notes

This is the base PR in a feature-split stack.