### PR TITLE
fix(discovery): improve JobStreaming source controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -516,9 +516,9 @@ fixtures are never a production upgrade path.
    preferences. In Settings, opt into tokenless public Levels.fyi salary pages,
    a licensed Levels.fyi feed, or Glassdoor only when you have the matching
    permitted access.
-3. Run Discover from Pipelines, optionally targeting one source for a lighter
-   run. Keep the same workspace open to distinguish the selected execution,
-   its execution sweep, and unrelated global backlog while watching capacity,
+3. Run Discover from Pipelines, optionally targeting one or more sources for a
+   lighter run. Keep the same workspace open to distinguish the selected
+   execution, its execution sweep, and unrelated global backlog while watching capacity,
    task-queue pressure, freshness, active work, and ETA. Stop the active run
    there when needed; after a failure, start over only when the runtime
    inventory confirms no work is still active.

--- a/apps/api/src/discovery-controls.ts
+++ b/apps/api/src/discovery-controls.ts
@@ -1508,7 +1508,7 @@ function rowToSourceSummary(
   return {
     sourceId: row.source_id,
     kind: sourceKind(row.kind),
-    displayName: row.display_name,
+    displayName: canonicalSourceDisplayName(row.source_id, row.display_name),
     owner: row.owner === "system" ? "system" : "user",
     priority: sourcePriority(row.priority),
     state: sourceState(row.state),
@@ -1538,7 +1538,7 @@ function qualityOnlySourceSummary(
   return {
     sourceId,
     kind: sourceKindFromId(sourceId),
-    displayName: sourceId,
+    displayName: canonicalSourceDisplayName(sourceId, sourceId),
     owner: "system",
     priority: "standard",
     state: sourceStateFromRecommended(recommended),
@@ -1607,6 +1607,17 @@ function sourcePriority(value: string): SourcePriorityValue {
   return SOURCE_PRIORITY_VALUES.includes(value as SourcePriorityValue)
     ? (value as SourcePriorityValue)
     : "standard";
+}
+
+const JOBSTREAMING_SOURCE_DISPLAY_NAMES: Readonly<Record<string, string>> = {
+  "jobspy:glassdoor": "JobStreaming Glassdoor",
+  "jobspy:indeed": "JobStreaming Indeed",
+  "jobspy:linkedin": "JobStreaming LinkedIn",
+  "jobspy:zip-recruiter": "JobStreaming ZipRecruiter",
+};
+
+function canonicalSourceDisplayName(sourceId: string, fallback: string): string {
+  return JOBSTREAMING_SOURCE_DISPLAY_NAMES[sourceId] ?? fallback;
 }
 
 function sourceKindFromId(sourceId: string): SourceKindValue {

--- a/apps/api/test/discovery-controls.test.ts
+++ b/apps/api/test/discovery-controls.test.ts
@@ -192,6 +192,65 @@ describe("discovery product controls API", () => {
     }
   });
 
+  it("projects legacy broad-board source IDs with JobStreaming display names", async () => {
+    const { dbPath, dir, cleanup } = withTempDb();
+    const app = buildApp(options(dbPath, dir));
+    try {
+      await app.inject({ method: "GET", url: "/v1/discovery/sources" });
+      const db = new Database(dbPath);
+      const insert = db.prepare(
+        `INSERT INTO source_registry_entries (
+           tenant_id, source_id, kind, display_name, owner, priority, state,
+           policy_id, seed_url, created_at, updated_at
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      );
+      const now = "2026-05-15T10:00:00+00:00";
+      for (const [sourceId, displayName] of [
+        ["jobspy:glassdoor", "JobSpy glassdoor"],
+        ["jobspy:indeed", "JobSpy indeed"],
+        ["jobspy:linkedin", "JobSpy linkedin"],
+        ["jobspy:zip-recruiter", "JobSpy zip_recruiter"],
+      ]) {
+        insert.run(
+          "local",
+          sourceId,
+          "broad_board",
+          displayName,
+          "system",
+          "lead_generator",
+          "experimental",
+          "broad_board_lead_generator",
+          null,
+          now,
+          now,
+        );
+      }
+      db.close();
+
+      const response = await app.inject({
+        method: "GET",
+        url: "/v1/discovery/sources",
+      });
+      expect(response.statusCode, response.body).toBe(200);
+      expect(
+        response.json().sources.map(
+          (source: { sourceId: string; displayName: string }) => [
+            source.sourceId,
+            source.displayName,
+          ],
+        ),
+      ).toEqual([
+        ["jobspy:glassdoor", "JobStreaming Glassdoor"],
+        ["jobspy:indeed", "JobStreaming Indeed"],
+        ["jobspy:linkedin", "JobStreaming LinkedIn"],
+        ["jobspy:zip-recruiter", "JobStreaming ZipRecruiter"],
+      ]);
+    } finally {
+      await app.close();
+      cleanup();
+    }
+  });
+
   it("filters America-only source registry rows when profile target search is Europe-focused", async () => {
     const { dbPath, dir, cleanup } = withTempDb();
     const app = buildApp(options(dbPath, dir));

--- a/apps/web/e2e/tests/jobs-bulk.spec.ts
+++ b/apps/web/e2e/tests/jobs-bulk.spec.ts
@@ -9,17 +9,12 @@ test("Bulk soft-delete + restore: select 3 → delete → confirm → switch to 
   page.on("dialog", (dialog) => void dialog.accept());
 
   await page.goto("/jobs");
-  const moreActions = page.getByRole("button", { name: "More actions" });
-  await expect(moreActions).toBeVisible({
+  await expect(page.getByRole("button", { name: "Select page" })).toBeVisible({
     timeout: 30_000,
   });
-  await moreActions.click();
   await expect(
-    page
-      .getByRole("menu", { name: "More actions" })
-      .getByRole("menuitem", { name: "Select page" }),
+    page.getByRole("button", { name: "Select all matching" }),
   ).toBeVisible();
-  await page.keyboard.press("Escape");
   await expect(page.getByText(/Director of Platform Engineering/i)).toBeVisible(
     {
       timeout: 30_000,

--- a/apps/web/src/contexts/discovery/components/DiscoveryProductControls.test.tsx
+++ b/apps/web/src/contexts/discovery/components/DiscoveryProductControls.test.tsx
@@ -31,7 +31,7 @@ describe("DiscoveryProductControls", () => {
   it("renders source health, quarantine review, and manual capture queues", async () => {
     renderWithProviders(<DiscoveryProductControls />);
 
-    await screen.findByText("LinkedIn");
+    await screen.findByText("JobStreaming LinkedIn");
     expect(screen.getByText("jobspy:linkedin")).toBeInTheDocument();
     expect(screen.getByText("Engineering Manager")).toBeInTheDocument();
     expect(
@@ -41,7 +41,9 @@ describe("DiscoveryProductControls", () => {
     expect(screen.getByText("rate limited")).toBeInTheDocument();
 
     const user = userEvent.setup();
-    await user.click(screen.getByRole("button", { name: /preview linkedin/i }));
+    await user.click(
+      screen.getByRole("button", { name: /preview jobstreaming linkedin/i }),
+    );
     expect(await screen.findByText("Product Engineer")).toBeInTheDocument();
   });
 

--- a/apps/web/src/contexts/pipeline/components/StageTriggerPanel.test.tsx
+++ b/apps/web/src/contexts/pipeline/components/StageTriggerPanel.test.tsx
@@ -16,6 +16,37 @@ import { buildTestPorts } from "../../../test/testPorts.js";
 import { useStageTriggerStore } from "../stores/stage-trigger-store.js";
 import { StageTriggerPanel } from "./StageTriggerPanel.js";
 
+function jobStreamingSource(sourceId: string, displayName: string) {
+  return {
+    sourceId,
+    kind: "broad_board" as const,
+    displayName,
+    owner: "system" as const,
+    priority: "standard" as const,
+    state: "active" as const,
+    policyId: "jobspy_default",
+    recommendedState: "normal" as const,
+    lastRunId: null,
+    lastRunCompletedAt: null,
+    lastErrorClass: null,
+    consecutiveFailures: 0,
+    observedJobs: 0,
+    newJobs: 0,
+    duplicateRate: null,
+    activeVerificationRate: null,
+    fullDescriptionSuccessRate: null,
+    applyUrlSuccessRate: null,
+    politeness: {
+      robotsDisallowedCount: 0,
+      rateLimitedCount: 0,
+      budgetExhaustedCount: 0,
+      lastBlockedReason: null,
+      lastBlockedAt: null,
+    },
+    qualityTrend: "unknown" as const,
+  };
+}
+
 describe("StageTriggerPanel", () => {
   beforeEach(() => {
     window.localStorage.removeItem?.("jh:stage-trigger-config");
@@ -222,7 +253,7 @@ describe("StageTriggerPanel", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("submits a bounded Discover run from the stage tab", async () => {
+  it("submits a bounded Discover run for multiple selected JobStreaming sources", async () => {
     const user = userEvent.setup();
     const runPipelineStages = vi.fn(
       async (_request: unknown): Promise<PipelineStageRunResponse> => ({
@@ -250,15 +281,40 @@ describe("StageTriggerPanel", () => {
       }),
     );
     renderWithProviders(<StageTriggerPanel />, {
-      ports: buildTestPorts({ api: { runPipelineStages } }),
+      ports: buildTestPorts({
+        api: {
+          runPipelineStages,
+          discoverySources: vi.fn(async () => ({
+            ok: true as const,
+            sources: [
+              jobStreamingSource("jobspy:linkedin", "JobStreaming LinkedIn"),
+              jobStreamingSource("jobspy:indeed", "JobStreaming Indeed"),
+            ],
+          })),
+        },
+      }),
     });
 
     const limitInput = screen.getByLabelText("Limit");
     expect(limitInput).toHaveAttribute("max", "1000");
     await user.clear(limitInput);
     await user.type(limitInput, "1000");
-    await user.click(await screen.findByRole("combobox", { name: "Source" }));
-    await user.click(await screen.findByRole("option", { name: /LinkedIn/ }));
+    await user.click(await screen.findByRole("button", { name: "Sources" }));
+    await user.click(
+      await screen.findByRole("checkbox", { name: /JobStreaming LinkedIn/ }),
+    );
+    expect(
+      screen.getByRole("checkbox", { name: /JobStreaming Indeed/ }),
+    ).toBeVisible();
+    await user.click(
+      screen.getByRole("checkbox", { name: /JobStreaming Indeed/ }),
+    );
+    expect(screen.getByRole("button", { name: "Sources" })).toHaveTextContent(
+      "2 sources selected",
+    );
+    expect(
+      screen.getByRole("button", { name: "Sources" }),
+    ).toHaveAccessibleDescription("2 sources selected");
     await user.click(screen.getByRole("checkbox", { name: "Dry run" }));
     await user.click(
       await screen.findByRole("button", { name: "Run Discover" }),
@@ -281,10 +337,69 @@ describe("StageTriggerPanel", () => {
       model: "default",
       llmModel: DEFAULT_PIPELINE_LLM_MODEL,
       continuous: false,
-      sourceIds: ["jobspy:linkedin"],
+      sourceIds: ["jobspy:linkedin", "jobspy:indeed"],
     });
     expect(request).not.toHaveProperty("tailorJudgeMinScore");
   }, 10_000);
+
+  it("caps explicit discovery source selection at the API limit", async () => {
+    const user = userEvent.setup();
+    const sources = Array.from({ length: 51 }, (_, index) =>
+      jobStreamingSource(
+        `jobspy:board-${index + 1}`,
+        `JobStreaming Board ${index + 1}`,
+      ),
+    );
+    useStageTriggerStore.getState().patchStageConfig("discover", {
+      discoverySourceIds: sources
+        .slice(0, 50)
+        .map((source) => source.sourceId),
+    });
+    renderWithProviders(<StageTriggerPanel />, {
+      ports: buildTestPorts({
+        api: {
+          discoverySources: vi.fn(async () => ({
+            ok: true as const,
+            sources,
+          })),
+        },
+      }),
+    });
+
+    const picker = await screen.findByRole("button", { name: "Sources" });
+    expect(picker).toHaveAccessibleDescription("50 sources selected");
+    await user.click(picker);
+    expect(screen.getByText("Select up to 50 sources.")).toBeVisible();
+    const fiftyFirstSource = screen.getByRole("checkbox", {
+      name: /^JobStreaming Board 51 ·/,
+    });
+    expect(fiftyFirstSource).toHaveAttribute("aria-disabled", "true");
+    await user.click(fiftyFirstSource);
+    expect(
+      useStageTriggerStore.getState().configs.discover.discoverySourceIds,
+    ).toHaveLength(50);
+  });
+
+  it("migrates the persisted single-source trigger selection", async () => {
+    window.localStorage.setItem(
+      "jh:stage-trigger-config",
+      JSON.stringify({
+        state: {
+          activeStage: "discover",
+          configs: {
+            discover: { discoverySourceId: "jobspy:linkedin" },
+          },
+        },
+        version: 1,
+      }),
+    );
+
+    await useStageTriggerStore.persist.rehydrate();
+
+    expect(
+      useStageTriggerStore.getState().configs.discover.discoverySourceIds,
+    ).toEqual(["jobspy:linkedin"]);
+  });
 
   it("shows a stop control for queued pipeline stage runs", async () => {
     const user = userEvent.setup();

--- a/apps/web/src/contexts/pipeline/components/StageTriggerPanel.tsx
+++ b/apps/web/src/contexts/pipeline/components/StageTriggerPanel.tsx
@@ -9,7 +9,7 @@ import {
   type PipelineValidationMode,
   type Stage,
 } from "@jobctrl/contracts";
-import { IconPlayerPlay } from "@tabler/icons-react";
+import { IconChevronDown, IconPlayerPlay } from "@tabler/icons-react";
 import { type FormEvent, type ReactNode, useId, useState } from "react";
 
 import {
@@ -28,6 +28,11 @@ import {
 import { Checkbox } from "../../../shared/ui/checkbox.js";
 import { Field, FieldLabel } from "../../../shared/ui/field.js";
 import { Input } from "../../../shared/ui/input.js";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "../../../shared/ui/popover.js";
 import {
   Select,
   SelectContent,
@@ -58,6 +63,8 @@ import {
 
 type StageActivity = DashboardSummary["activity"][number];
 type StageProgress = DashboardSummary["progress"][number];
+
+const MAX_DISCOVERY_SOURCE_SELECTIONS = 50;
 
 function labelForStage(stage: Stage): string {
   return `${stage.charAt(0).toUpperCase()}${stage.slice(1)}`;
@@ -234,6 +241,20 @@ function isRunningActivity(activity: StageActivity): boolean {
     activity.eventType === "ActionStarted" ||
     activity.eventType === "StageStarted"
   );
+}
+
+function discoverySourceSelectionLabel(
+  selectedSourceIds: readonly string[],
+  sources: readonly SourceRegistryEntrySummary[],
+): string {
+  if (selectedSourceIds.length === 0) return "All runnable sources";
+  if (selectedSourceIds.length > 1) {
+    return `${selectedSourceIds.length} sources selected`;
+  }
+  const selected = sources.find(
+    (source) => source.sourceId === selectedSourceIds[0],
+  );
+  return selected ? sourceOptionLabel(selected) : "Selected source unavailable";
 }
 
 function isFailedActivity(activity: StageActivity): boolean {
@@ -547,12 +568,16 @@ export function StageTriggerPanel({
   const discoverySources = controls.discoverySource
     ? selectableDiscoverySources(sourceRegistry.data?.sources ?? [])
     : [];
-  const selectedDiscoverySourceId = config.discoverySourceId.trim();
-  const selectedDiscoverySourceAvailable =
-    !selectedDiscoverySourceId ||
-    discoverySources.some(
-      (source) => source.sourceId === selectedDiscoverySourceId,
-    );
+  const selectedDiscoverySourceIds = config.discoverySourceIds.slice(
+    0,
+    MAX_DISCOVERY_SOURCE_SELECTIONS,
+  );
+  const availableDiscoverySourceIds = new Set(
+    discoverySources.map((source) => source.sourceId),
+  );
+  const unavailableDiscoverySourceIds = selectedDiscoverySourceIds.filter(
+    (sourceId) => !availableDiscoverySourceIds.has(sourceId),
+  );
   const selectedApplyModel = applyModelValue(config.model);
   const statusStage = submittedStage ?? activeStage;
   const stageActivity = latestStageActivity(dashboardSummary.data, statusStage);
@@ -590,7 +615,26 @@ export function StageTriggerPanel({
   const patchConfig = (patch: Partial<StageTriggerConfig>) => {
     patchStageConfig(activeStage, patch);
   };
+  const toggleDiscoverySource = (sourceId: string, checked: boolean) => {
+    if (
+      checked &&
+      selectedDiscoverySourceIds.length >= MAX_DISCOVERY_SOURCE_SELECTIONS &&
+      !selectedDiscoverySourceIds.includes(sourceId)
+    ) {
+      return;
+    }
+    const nextSourceIds = checked
+      ? [...new Set([...selectedDiscoverySourceIds, sourceId])]
+      : selectedDiscoverySourceIds.filter((selected) => selected !== sourceId);
+    patchConfig({ discoverySourceIds: nextSourceIds });
+  };
   const fieldId = (name: string) => `stage-trigger-${activeStage}-${name}`;
+  const selectedDiscoverySourceLabel = discoverySourceSelectionLabel(
+    selectedDiscoverySourceIds,
+    discoverySources,
+  );
+  const discoverySourceLimitReached =
+    selectedDiscoverySourceIds.length >= MAX_DISCOVERY_SOURCE_SELECTIONS;
 
   const submit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -627,8 +671,8 @@ export function StageTriggerPanel({
       headless: controls.headless ? config.headless : false,
       model: controls.applyModel ? selectedApplyModel : "default",
       continuous: controls.continuous ? config.continuous : false,
-      ...(controls.discoverySource && selectedDiscoverySourceId
-        ? { sourceIds: [selectedDiscoverySourceId] }
+      ...(controls.discoverySource && selectedDiscoverySourceIds.length > 0
+        ? { sourceIds: selectedDiscoverySourceIds }
         : {}),
     });
   };
@@ -673,67 +717,100 @@ export function StageTriggerPanel({
         ) : null}
         {controls.discoverySource ? (
           <Field className="field stage-trigger-source-field">
-            <FieldLabel htmlFor={fieldId("source")}>Source</FieldLabel>
-            <Select
-              items={[
-                { label: "All runnable sources", value: null },
-                ...(sourceRegistry.isLoading
-                  ? [{ label: "Loading sources", value: "__loading" }]
-                  : []),
-                ...(sourceRegistry.isError
-                  ? [{ label: "Source list unavailable", value: "__error" }]
-                  : []),
-                ...(!selectedDiscoverySourceAvailable
-                  ? [
-                      {
-                        label: "Selected source unavailable",
-                        value: selectedDiscoverySourceId,
-                      },
-                    ]
-                  : []),
-                ...discoverySources.map((source) => ({
-                  label: sourceOptionLabel(source),
-                  value: source.sourceId,
-                })),
-              ]}
-              value={selectedDiscoverySourceId || null}
-              onValueChange={(value) =>
-                patchConfig({ discoverySourceId: value ?? "" })
-              }
-            >
-              <SelectTrigger
-                id={fieldId("source")}
-                aria-label="Source"
-                className="w-full"
+            <FieldLabel htmlFor={fieldId("sources")}>Sources</FieldLabel>
+            <Popover>
+              <PopoverTrigger
+                render={
+                  <Button
+                    id={fieldId("sources")}
+                    aria-label="Sources"
+                    aria-describedby={fieldId("sources-summary")}
+                    className="w-full justify-between overflow-hidden font-normal"
+                    type="button"
+                    variant="outline"
+                  />
+                }
               >
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectGroup>
-                  <SelectItem value={null}>All runnable sources</SelectItem>
+                <span
+                  className="truncate text-left"
+                  id={fieldId("sources-summary")}
+                >
+                  {selectedDiscoverySourceLabel}
+                </span>
+                <IconChevronDown aria-hidden />
+              </PopoverTrigger>
+              <PopoverContent
+                align="start"
+                aria-label="Discovery sources"
+                className="w-[min(32rem,calc(100vw-2rem))] p-2"
+              >
+                <div
+                  aria-label="Select discovery sources"
+                  className="grid max-h-80 gap-1 overflow-y-auto"
+                  role="group"
+                >
+                  <p className="px-2 py-1 text-muted-foreground">
+                    Select up to {MAX_DISCOVERY_SOURCE_SELECTIONS} sources.
+                  </p>
+                  <label className="flex min-h-9 cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 hover:bg-muted">
+                    <Checkbox
+                      checked={selectedDiscoverySourceIds.length === 0}
+                      onCheckedChange={() =>
+                        patchConfig({ discoverySourceIds: [] })
+                      }
+                    />
+                    <span>All runnable sources</span>
+                  </label>
                   {sourceRegistry.isLoading ? (
-                    <SelectItem disabled value="__loading">
+                    <span className="px-2 py-1.5 text-muted-foreground">
                       Loading sources
-                    </SelectItem>
+                    </span>
                   ) : null}
                   {sourceRegistry.isError ? (
-                    <SelectItem disabled value="__error">
+                    <span className="px-2 py-1.5 text-destructive">
                       Source list unavailable
-                    </SelectItem>
+                    </span>
                   ) : null}
-                  {!selectedDiscoverySourceAvailable ? (
-                    <SelectItem value={selectedDiscoverySourceId}>
-                      Selected source unavailable
-                    </SelectItem>
-                  ) : null}
-                  {discoverySources.map((source) => (
-                    <SelectItem key={source.sourceId} value={source.sourceId}>
-                      {sourceOptionLabel(source)}
-                    </SelectItem>
+                  {unavailableDiscoverySourceIds.map((sourceId) => (
+                    <label
+                      className="flex min-h-9 cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 hover:bg-muted"
+                      key={sourceId}
+                    >
+                      <Checkbox
+                        checked
+                        onCheckedChange={(checked) =>
+                          toggleDiscoverySource(sourceId, checked)
+                        }
+                      />
+                      <span>Selected source unavailable: {sourceId}</span>
+                    </label>
                   ))}
-                </SelectGroup>
-              </SelectContent>
-            </Select>
+                  {discoverySources.map((source) => {
+                    const label = sourceOptionLabel(source);
+                    return (
+                      <label
+                        className="flex min-h-9 cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 hover:bg-muted"
+                        key={source.sourceId}
+                      >
+                        <Checkbox
+                          checked={selectedDiscoverySourceIds.includes(
+                            source.sourceId,
+                          )}
+                          disabled={
+                            discoverySourceLimitReached &&
+                            !selectedDiscoverySourceIds.includes(source.sourceId)
+                          }
+                          onCheckedChange={(checked) =>
+                            toggleDiscoverySource(source.sourceId, checked)
+                          }
+                        />
+                        <span>{label}</span>
+                      </label>
+                    );
+                  })}
+                </div>
+              </PopoverContent>
+            </Popover>
           </Field>
         ) : null}
         {controls.minScore ? (

--- a/apps/web/src/contexts/pipeline/stores/stage-trigger-store.ts
+++ b/apps/web/src/contexts/pipeline/stores/stage-trigger-store.ts
@@ -18,7 +18,7 @@ export interface StageTriggerConfig {
   tailorModels: string;
   tailorJudgeModel: string;
   tailorJudgeMinScore: string;
-  discoverySourceId: string;
+  discoverySourceIds: string[];
   headless: boolean;
   model: string;
   continuous: boolean;
@@ -45,7 +45,7 @@ const defaultConfig: StageTriggerConfig = {
   tailorModels: "",
   tailorJudgeModel: "",
   tailorJudgeMinScore: "",
-  discoverySourceId: "",
+  discoverySourceIds: [],
   headless: false,
   model: "default",
   continuous: false,
@@ -95,10 +95,29 @@ function isValidationMode(value: unknown): value is PipelineValidationMode {
 }
 
 function mergeConfig(value: unknown): StageTriggerConfig {
-  const source = typeof value === "object" && value !== null ? (value as Partial<StageTriggerConfig>) : {};
+  const source =
+    typeof value === "object" && value !== null
+      ? (value as Partial<StageTriggerConfig> & { discoverySourceId?: unknown })
+      : {};
+  const { discoverySourceId, ...currentSource } = source;
+  const legacyDiscoverySourceId =
+    typeof discoverySourceId === "string" ? discoverySourceId.trim() : "";
+  const discoverySourceIds = Array.isArray(source.discoverySourceIds)
+    ? [
+        ...new Set(
+          source.discoverySourceIds
+            .filter((sourceId): sourceId is string => typeof sourceId === "string")
+            .map((sourceId) => sourceId.trim())
+            .filter(Boolean),
+        ),
+      ].slice(0, 50)
+    : legacyDiscoverySourceId
+      ? [legacyDiscoverySourceId]
+      : [];
   return {
     ...defaultConfig,
-    ...source,
+    ...currentSource,
+    discoverySourceIds,
     validationMode: isValidationMode(source.validationMode) ? source.validationMode : defaultConfig.validationMode,
   };
 }
@@ -131,7 +150,8 @@ export const useStageTriggerStore = create<StageTriggerState>()(
     {
       name: "jh:stage-trigger-config",
       storage: createJSONStorage(getStorage),
-      version: 1,
+      version: 2,
+      migrate: (persisted) => persisted,
       partialize: ({ activeStage, configs }) => ({ activeStage, configs }),
       merge: (persisted, current) => {
         const source =

--- a/apps/web/src/test/testPorts.ts
+++ b/apps/web/src/test/testPorts.ts
@@ -30,7 +30,7 @@ const sampleDiscoverySourceRegistry = {
     {
       sourceId: "jobspy:linkedin",
       kind: "broad_board" as const,
-      displayName: "LinkedIn",
+      displayName: "JobStreaming LinkedIn",
       owner: "system" as const,
       priority: "standard" as const,
       state: "active" as const,

--- a/apps/web/src/views/jobs/JobBulkActions.test.tsx
+++ b/apps/web/src/views/jobs/JobBulkActions.test.tsx
@@ -274,24 +274,19 @@ describe("<JobBulkActions>", () => {
       }),
     ).toBeInTheDocument();
 
-    const moreActions = screen.getByRole("button", { name: "More actions" });
-    moreActions.focus();
-    await user.keyboard("{Enter}");
-    const menu = screen.getByRole("menu", { name: "More actions" });
+    expect(
+      screen.queryByRole("button", { name: "More actions" }),
+    ).not.toBeInTheDocument();
     await user.click(
-      within(menu).getByRole("menuitem", { name: "Select all matching" }),
+      screen.getByRole("button", { name: "Select all matching" }),
     );
     expect(onSelectAllMatching).toHaveBeenCalledTimes(1);
 
-    moreActions.focus();
-    await user.keyboard("{Enter}");
-    await user.click(
-      within(screen.getByRole("menu", { name: "More actions" })).getByRole(
-        "menuitem",
-        { name: "Clear selection" },
-      ),
-    );
+    await user.click(screen.getByRole("button", { name: "Clear selection" }));
     expect(onClearSelection).toHaveBeenCalledTimes(1);
+    expect(
+      jobOperations.querySelector('[data-icon="inline-end"]'),
+    ).not.toBeNull();
   });
 
   it("invokes onMutateSelected when the danger button is clicked", async () => {

--- a/apps/web/src/views/jobs/JobBulkActions.tsx
+++ b/apps/web/src/views/jobs/JobBulkActions.tsx
@@ -1,3 +1,4 @@
+import { IconChevronDown } from "@tabler/icons-react";
 import { useId } from "react";
 
 import { RefreshAllCompensationButton } from "../../contexts/enrichment/index.js";
@@ -158,32 +159,34 @@ export function JobBulkActions({
           {selectedCount ? (
             <span data-typography="metadata">{selectedCount} selected</span>
           ) : null}
-          <DropdownMenu>
-            <DropdownMenuTrigger
-              render={<Button size="sm" type="button" variant="outline" />}
+          <Button
+            disabled={!hasItems}
+            size="sm"
+            type="button"
+            variant="outline"
+            onClick={onSelectPage}
+          >
+            Select page
+          </Button>
+          <Button
+            disabled={!hasAnyMatching || hasLocalFilters}
+            size="sm"
+            type="button"
+            variant="outline"
+            onClick={onSelectAllMatching}
+          >
+            Select all matching
+          </Button>
+          {selectedCount ? (
+            <Button
+              size="sm"
+              type="button"
+              variant="ghost"
+              onClick={onClearSelection}
             >
-              More actions
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="start" aria-label="More actions">
-              <DropdownMenuGroup>
-                <DropdownMenuLabel>Selection</DropdownMenuLabel>
-                <DropdownMenuItem disabled={!hasItems} onClick={onSelectPage}>
-                  Select page
-                </DropdownMenuItem>
-                <DropdownMenuItem
-                  disabled={!hasAnyMatching || hasLocalFilters}
-                  onClick={onSelectAllMatching}
-                >
-                  Select all matching
-                </DropdownMenuItem>
-                {selectedCount ? (
-                  <DropdownMenuItem onClick={onClearSelection}>
-                    Clear selection
-                  </DropdownMenuItem>
-                ) : null}
-              </DropdownMenuGroup>
-            </DropdownMenuContent>
-          </DropdownMenu>
+              Clear selection
+            </Button>
+          ) : null}
         </div>
         {hasUnavailableDemoAutomation ? (
           <span data-typography="body" id={unavailableReasonId} role="status">
@@ -202,6 +205,7 @@ export function JobBulkActions({
               render={<Button size="sm" type="button" variant="outline" />}
             >
               Job operations
+              <IconChevronDown aria-hidden="true" data-icon="inline-end" />
             </DropdownMenuTrigger>
             <DropdownMenuContent align="start" aria-label="Job operations">
               {retrySelectedFailures || retryAllFailures ? (

--- a/apps/web/src/views/jobs/JobsView.test.tsx
+++ b/apps/web/src/views/jobs/JobsView.test.tsx
@@ -294,7 +294,9 @@ describe("<JobsView> realtime UI state", () => {
         )?.artifact.status,
       ).toBe("approved");
       expect(
-        harness.queryClient.getQueryData<ReturnType<typeof makeWorkflowRunDetail>>(
+        harness.queryClient.getQueryData<
+          ReturnType<typeof makeWorkflowRunDetail>
+        >(
           workflowRunsKeys.detail(
             LOCAL_TENANT,
             eventByType.WorkflowCompleted.payload.workflowId,
@@ -308,7 +310,9 @@ describe("<JobsView> realtime UI state", () => {
         artifactsKeys.list(LOCAL_TENANT, { status: "candidate", page: 3 }),
       )?.isInvalidated,
     ).toBe(true);
-    expect(harness.queryClient.getQueryState(unrelatedKey)?.isInvalidated).toBe(false);
+    expect(harness.queryClient.getQueryState(unrelatedKey)?.isInvalidated).toBe(
+      false,
+    );
     expect(screen.getByText("1 selected")).toBeInTheDocument();
     expect(
       screen.getByRole("checkbox", { name: `Select ${latestJob.title}` }),
@@ -1193,16 +1197,8 @@ describe("<JobsView> bulk delete integration", () => {
     render(<RouterProvider router={router} />, { wrapper: Wrapper });
 
     expect(await screen.findByText("discover candidate")).toBeInTheDocument();
-    const firstMoreActions = screen.getByRole("button", {
-      name: "More actions",
-    });
-    firstMoreActions.focus();
-    await user.keyboard("{Enter}");
     await user.click(
-      within(screen.getByRole("menu", { name: "More actions" })).getByRole(
-        "menuitem",
-        { name: "Select all matching" },
-      ),
+      screen.getByRole("button", { name: "Select all matching" }),
     );
     await waitFor(() =>
       expect(screen.getByText("1 selected")).toBeInTheDocument(),
@@ -1232,16 +1228,8 @@ describe("<JobsView> bulk delete integration", () => {
       },
     );
 
-    const secondMoreActions = screen.getByRole("button", {
-      name: "More actions",
-    });
-    secondMoreActions.focus();
-    await user.keyboard("{Enter}");
     await user.click(
-      within(screen.getByRole("menu", { name: "More actions" })).getByRole(
-        "menuitem",
-        { name: "Select all matching" },
-      ),
+      screen.getByRole("button", { name: "Select all matching" }),
     );
     await waitFor(() =>
       expect(screen.getByText(/2 selected/i)).toBeInTheDocument(),
@@ -1312,24 +1300,11 @@ describe("<JobsView> bulk delete integration", () => {
       ).not.toBeInTheDocument(),
     );
     await user.keyboard("{Escape}");
-    const filteredMoreActions = screen.getByRole("button", {
-      name: "More actions",
-    });
-    filteredMoreActions.focus();
-    await user.keyboard("{Enter}");
     expect(
-      within(screen.getByRole("menu", { name: "More actions" })).getByRole(
-        "menuitem",
-        { name: "Select all matching" },
-      ),
-    ).toHaveAttribute("aria-disabled", "true");
+      screen.getByRole("button", { name: "Select all matching" }),
+    ).toBeDisabled();
 
-    await user.click(
-      within(screen.getByRole("menu", { name: "More actions" })).getByRole(
-        "menuitem",
-        { name: /select page/i },
-      ),
-    );
+    await user.click(screen.getByRole("button", { name: /select page/i }));
     await waitFor(() =>
       expect(screen.getByText(/1 selected/i)).toBeInTheDocument(),
     );

--- a/apps/web/src/views/pipelines/PipelinesView.test.tsx
+++ b/apps/web/src/views/pipelines/PipelinesView.test.tsx
@@ -94,7 +94,7 @@ describe("PipelinesView", () => {
     ).toBeEnabled();
     expect(within(tools).getByLabelText("Limit")).toBeInTheDocument();
     expect(within(tools).getByLabelText("Internal concurrency")).toBeInTheDocument();
-    expect(within(tools).getByLabelText("Source")).toBeInTheDocument();
+    expect(within(tools).getByLabelText("Sources")).toBeInTheDocument();
     expect(within(tools).getByRole("checkbox", { name: "Dry run" })).toBeChecked();
 
     await user.click(within(tools).getByRole("tab", { name: "Apply" }));
@@ -104,7 +104,7 @@ describe("PipelinesView", () => {
     expect(within(tools).getByLabelText("Apply model")).toBeInTheDocument();
     expect(within(tools).getByRole("checkbox", { name: "Headless browser" })).toBeInTheDocument();
     expect(within(tools).getByRole("checkbox", { name: "Continuous" })).toBeInTheDocument();
-    expect(within(tools).queryByLabelText("Source")).not.toBeInTheDocument();
+    expect(within(tools).queryByLabelText("Sources")).not.toBeInTheDocument();
   });
 
   it("renders current execution as status-first stage rows and keeps details collapsed", async () => {

--- a/docs/user/discovery.md
+++ b/docs/user/discovery.md
@@ -126,8 +126,10 @@ not merge the jobs or turn either record into application history. See
 
 Discovery owns the controls that decide what may enter a run; **Pipelines** owns
 starting and observing that run. In Pipelines, choose the Discover action, set a
-bounded result limit, internal source concurrency, optional source, and dry-run
-mode, then keep the operations workspace open while work proceeds.
+bounded result limit, internal source concurrency, optional sources, and dry-run
+mode, then keep the operations workspace open while work proceeds. The source
+picker supports up to 50 selections and labels broad-board adapters as
+JobStreaming; the persisted `jobspy:` prefix remains only a compatibility ID.
 
 The workspace deliberately keeps different scopes and units separate:
 

--- a/docs/user/normal-flows.md
+++ b/docs/user/normal-flows.md
@@ -130,7 +130,9 @@ model policy, and the shared spend ceiling remain in
 <WorkflowSurfacePanel surface="web">
 
 Open Pipelines, choose the `Discover` tab, set the run limit, internal
-concurrency, source, and dry-run mode, then start the run.
+concurrency, optional source selection, and dry-run mode, then start the run.
+The source picker accepts up to 50 sources; leave it on **All runnable sources**
+to use the complete enabled registry.
 
 </WorkflowSurfacePanel>
 

--- a/workers/automation/src/jobctrl/config.py
+++ b/workers/automation/src/jobctrl/config.py
@@ -1073,6 +1073,22 @@ def _source_slug(value: str) -> str:
     return slug or "source"
 
 
+_JOBSTREAMING_BOARD_DISPLAY_NAMES = {
+    "glassdoor": "Glassdoor",
+    "indeed": "Indeed",
+    "linkedin": "LinkedIn",
+    "zip_recruiter": "ZipRecruiter",
+}
+
+
+def _jobstreaming_source_display_name(board: str) -> str:
+    display_board = _JOBSTREAMING_BOARD_DISPLAY_NAMES.get(
+        board.strip().lower(),
+        board.replace("_", " ").strip().title(),
+    )
+    return f"JobStreaming {display_board}"
+
+
 def _validated_source(entry: SourceRegistryEntry) -> SourceRegistryEntry:
     with source_validation_span(
         tenant_id=entry.tenant_id,
@@ -1165,7 +1181,7 @@ def _jobspy_sources(search_cfg: dict | None) -> list[SourceRegistryEntry]:
                     tenant_id=LOCAL_TENANT,
                     source_id=f"jobspy:{_source_slug(board)}",
                     kind=SourceKind.BROAD_BOARD,
-                    display_name=f"Broad board: {board}",
+                    display_name=_jobstreaming_source_display_name(board),
                     owner="system",
                     priority=SourcePriority.LEAD_GENERATOR,
                     state=SourceState.EXPERIMENTAL,
@@ -1334,8 +1350,12 @@ def _merge_local_source_registry(
         adapter_config = dict(existing.adapter_config) if existing else {}
         if _row_overrides_adapter_config(row, existing):
             adapter_config.update(_adapter_config_from_row(row))
-        display_name = str(row["display_name"] or (existing.display_name if existing else source_id))
         owner = str(row["owner"] or (existing.owner if existing else "user"))
+        display_name = (
+            existing.display_name
+            if existing and owner == "system" and source_id.startswith("jobspy:")
+            else str(row["display_name"] or (existing.display_name if existing else source_id))
+        )
         merged[source_id] = _validated_source(
             SourceRegistryEntry(
                 tenant_id=LOCAL_TENANT,

--- a/workers/automation/src/jobctrl/infrastructure/discovery/jobstreaming_gateway.py
+++ b/workers/automation/src/jobctrl/infrastructure/discovery/jobstreaming_gateway.py
@@ -10,6 +10,7 @@ stream without teaching the domain layer about provider classes.
 
 from __future__ import annotations
 
+import math
 import threading
 from dataclasses import dataclass
 from typing import Any
@@ -19,15 +20,18 @@ from jobstreaming import (
     AckMode,
     AdapterRegistry,
     CheckpointStore,
+    Scraper,
     ErrorEvent,
     JobEvent,
     ProgressEvent,
     SearchCompleteEvent,
     SearchRequest,
     SearchStream,
+    Site,
     SiteCompleteEvent,
     WarningEvent,
     build_search_request,
+    default_registry,
     stream_search,
 )
 from jobstreaming.result import jobs_to_dataframe
@@ -107,6 +111,57 @@ class JobStreamingSearchError(RuntimeError):
         super().__init__(f"{failure.site} failed [{failure.code}]: {failure.error_type}: {failure.message}")
 
 
+_TLS_CLIENT_SITES = frozenset({Site.GLASSDOOR, Site.ZIP_RECRUITER})
+
+
+class _IntegralTlsTimeoutAdapter(Scraper):
+    """Normalize JobStreaming 0.0.2's float timeout for tls-client adapters."""
+
+    def __init__(self, delegate: Scraper) -> None:
+        super().__init__(
+            delegate.site,
+            proxies=delegate.proxies,
+            ca_cert=delegate.ca_cert,
+            user_agent=delegate.user_agent,
+        )
+        self._delegate = delegate
+        self.capabilities = delegate.capabilities
+
+    def scrape(
+        self,
+        scraper_input: SearchRequest,
+        context: Any | None = None,
+    ) -> Any:
+        timeout = max(1, math.ceil(scraper_input.request_timeout))
+        normalized = scraper_input.model_copy(
+            update={"request_timeout": timeout},
+        )
+        return self._delegate.scrape(normalized, context=context)
+
+
+def _normalize_tls_adapter_timeouts(
+    registry: AdapterRegistry | None,
+) -> AdapterRegistry:
+    """Keep the pinned provider fingerprint while satisfying tls-client's int ABI."""
+
+    source = registry or default_registry()
+    normalized = source.copy()
+    for site in _TLS_CLIENT_SITES:
+        if site not in source.sites:
+            continue
+
+        def factory(*, _site: Site = site, **kwargs: Any) -> Scraper:
+            return _IntegralTlsTimeoutAdapter(source.create(_site, **kwargs))
+
+        normalized.register(
+            site,
+            factory,
+            replace=True,
+            cursor_schema_version=source.cursor_schema_version(site),
+        )
+    return normalized
+
+
 class JobStreamingGateway:
     """Build and consume the pinned JobStreaming 0.0.2 event contract."""
 
@@ -154,7 +209,7 @@ class JobStreamingGateway:
             retry_backoff=retry_backoff,
             ack_mode=AckMode.EXPLICIT,
             cancel_event=cancel_event,
-            registry=registry,
+            registry=_normalize_tls_adapter_timeouts(registry),
         )
 
     @classmethod

--- a/workers/automation/tests/test_jobstreaming_gateway.py
+++ b/workers/automation/tests/test_jobstreaming_gateway.py
@@ -52,6 +52,20 @@ class _RateLimitedAdapter(Scraper):
         raise RateLimitError("slow down")
 
 
+class _TlsTimeoutInspectingAdapter(Scraper):
+    seen_timeouts: list[object] = []
+
+    def __init__(self, **_: object) -> None:
+        super().__init__(Site.GLASSDOOR)
+
+    def scrape(self, request, context=None) -> JobResponse:
+        del context
+        type(self).seen_timeouts.append(request.request_timeout)
+        if not isinstance(request.request_timeout, int):
+            raise ValueError("TLS timeout must be an integer")
+        return JobResponse()
+
+
 def test_request_translation_is_immutable_and_preserves_search_options() -> None:
     spec = JobStreamingSearchSpec(
         sites=("indeed", "linkedin"),
@@ -105,6 +119,31 @@ def test_collect_preserves_partial_results_and_projects_typed_failure() -> None:
     assert result.failures[0].code == "rate_limited"
     assert result.failures[0].retryable is True
     assert result.completed is False
+
+
+def test_tls_backed_adapters_receive_an_integral_request_timeout() -> None:
+    _TlsTimeoutInspectingAdapter.seen_timeouts = []
+    registry = AdapterRegistry()
+    registry.register(Site.GLASSDOOR, _TlsTimeoutInspectingAdapter)
+
+    result = JobStreamingGateway().collect(
+        JobStreamingSearchSpec(
+            sites=("glassdoor",),
+            query="Director of Engineering",
+            location="Remote",
+            results_per_site=10,
+            remote_only=True,
+        ),
+        registry=registry,
+        max_retries=0,
+    )
+
+    assert [
+        (type(timeout), timeout)
+        for timeout in _TlsTimeoutInspectingAdapter.seen_timeouts
+    ] == [(int, 30)]
+    assert result.failures == ()
+    assert result.completed is True
 
 
 def test_durable_stream_does_not_checkpoint_until_the_consumer_acknowledges() -> None:

--- a/workers/automation/tests/test_source_registry.py
+++ b/workers/automation/tests/test_source_registry.py
@@ -263,7 +263,9 @@ def test_load_source_registry_generates_entries_from_packaged_yaml_shapes(tmp_pa
     assert greenhouse.adapter_config["board_token"] == "acme"
 
     assert by_id["jobspy:linkedin"].kind is SourceKind.BROAD_BOARD
+    assert by_id["jobspy:linkedin"].display_name == "JobStreaming LinkedIn"
     assert by_id["jobspy:indeed"].adapter_config["board"] == "indeed"
+    assert by_id["jobspy:indeed"].display_name == "JobStreaming Indeed"
 
 
 def test_load_source_registry_applies_local_product_control_overrides(tmp_path, monkeypatch) -> None:
@@ -317,6 +319,27 @@ def test_load_source_registry_applies_local_product_control_overrides(tmp_path, 
         """,
         (
             str(LOCAL_TENANT),
+            "jobspy:linkedin",
+            "broad_board",
+            "JobSpy linkedin",
+            "system",
+            "lead_generator",
+            "disabled",
+            "broad_board_lead_generator",
+            None,
+            "2026-05-13T00:00:00Z",
+            "2026-05-13T00:00:00Z",
+        ),
+    )
+    conn.execute(
+        """
+        INSERT INTO source_registry_entries (
+          tenant_id, source_id, kind, display_name, owner, priority,
+          state, policy_id, seed_url, created_at, updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            str(LOCAL_TENANT),
             "custom-careers",
             "employer_careers_page",
             "Custom Careers",
@@ -353,6 +376,8 @@ def test_load_source_registry_applies_local_product_control_overrides(tmp_path, 
     assert by_id["smart_extract:remoteok"].adapter_config["url"] == "https://remoteok.example/jobs"
     assert by_id["custom-careers"].kind is SourceKind.EMPLOYER_CAREERS_PAGE
     assert by_id["custom-careers"].adapter_config["url"] == "https://example.com/careers"
+    assert by_id["jobspy:linkedin"].display_name == "JobStreaming LinkedIn"
+    assert by_id["jobspy:linkedin"].state is SourceState.DISABLED
 
 
 def test_load_source_registry_coalesces_known_workday_host_aliases(tmp_path, monkeypatch) -> None:


### PR DESCRIPTION
## Summary

- present broad-board adapters as JobStreaming while preserving legacy `jobspy:` compatibility IDs
- replace the single-source selector with a bounded multi-select picker supporting up to 50 sources
- migrate persisted single-source UI state to the new array representation
- normalize request timeouts for TLS-backed JobStreaming 0.0.2 adapters so Glassdoor and ZipRecruiter receive integer values
- document the updated source-selection behavior

## Validation

- `corepack pnpm --filter @jobctrl/api exec vitest run test/discovery-controls.test.ts` — 16 passed
- `corepack pnpm --filter @jobctrl/web exec vitest run src/contexts/discovery/components/DiscoveryProductControls.test.tsx src/contexts/pipeline/components/StageTriggerPanel.test.tsx src/views/pipelines/PipelinesView.test.tsx` — 63 passed
- `uv --project workers/automation run pytest -q workers/automation/tests/test_jobstreaming_gateway.py workers/automation/tests/test_source_registry.py` — 18 passed
- `git diff --cached --check`

## Stack

Depends on #739. This PR targets `fix/jobs-toolbar-actions` so its diff remains feature-scoped.