### PR TITLE
fix(enrichment): recover robots-blocked jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -672,7 +672,12 @@ from **Settings → Browser & extension**. JobCtrl can list supported local
 Chrome/Chromium installations by label, but detection is read-only: it does not
 launch, enable, or persist a browser. Choosing a detected browser and clicking
 Enable explicitly adopts it; an advanced manual executable path remains
-available. Browser enable/disable and pairing-token rotation are live, and
+available. For authenticated LinkedIn, JobCtrl can also detect a standard local
+default profile and copy it by browser label after separate affirmative consent;
+no filesystem path entry is required. That detected flow copies only the
+`Default` profile plus sanitized root metadata needed by Chrome; sibling
+profiles are excluded. A write-only manual profile path remains an advanced
+fallback. Browser enable/disable and pairing-token rotation are live, and
 extension pairing remains separate from browser adoption.
 
 ## Development

--- a/apps/api/test/server.test.ts
+++ b/apps/api/test/server.test.ts
@@ -10347,7 +10347,7 @@ describe("local TypeScript API", () => {
     await app.close();
   });
 
-  it("lists detected browsers and forwards an explicit detected-browser enable selection", async () => {
+  it("lists detected browsers and forwards explicit browser and profile selections", async () => {
     const browserResult = {
       capabilities: [
         {
@@ -10376,8 +10376,8 @@ describe("local TypeScript API", () => {
         },
       ],
       detectedBrowsers: [
-        { id: "google-chrome", label: "Google Chrome" },
-        { id: "chromium", label: "Chromium" },
+        { id: "google-chrome", label: "Google Chrome", defaultProfileAvailable: true },
+        { id: "chromium", label: "Chromium", defaultProfileAvailable: false },
       ],
     };
     const call = vi.fn<JsonRpcDispatcher["call"]>(async () => ({
@@ -10401,11 +10401,21 @@ describe("local TypeScript API", () => {
       url: "/v1/browser-capabilities/auto-apply-browser/enable",
       payload: { executablePath: "/Applications/Chromium" },
     });
+    const copiedProfile = await app.inject({
+      method: "POST",
+      url: "/v1/browser-capabilities/authenticated-linkedin-browser/profile-copy",
+      payload: {
+        detectedBrowserId: "google-chrome",
+        consent: true,
+        consentMethod: "explicit-ui-v1",
+      },
+    });
 
     expect(listed.statusCode, listed.body).toBe(200);
     expect(listed.json()).toMatchObject({ ok: true, detectedBrowsers: browserResult.detectedBrowsers });
     expect(enabled.statusCode, enabled.body).toBe(200);
     expect(manuallyEnabled.statusCode, manuallyEnabled.body).toBe(200);
+    expect(copiedProfile.statusCode, copiedProfile.body).toBe(200);
     expect(call).toHaveBeenNthCalledWith(1, "browser_capabilities_list", {});
     expect(call).toHaveBeenNthCalledWith(2, "browser_capability_enable", {
       capabilityId: "auto-apply-browser",
@@ -10414,6 +10424,11 @@ describe("local TypeScript API", () => {
     expect(call).toHaveBeenNthCalledWith(3, "browser_capability_enable", {
       capabilityId: "auto-apply-browser",
       executablePath: "/Applications/Chromium",
+    });
+    expect(call).toHaveBeenNthCalledWith(4, "browser_profile_copy", {
+      detectedBrowserId: "google-chrome",
+      consent: true,
+      consentMethod: "explicit-ui-v1",
     });
 
     await app.close();

--- a/apps/web/e2e/tests/browser-capabilities-layout.spec.ts
+++ b/apps/web/e2e/tests/browser-capabilities-layout.spec.ts
@@ -3,8 +3,12 @@ import { expect, type Page, test } from "@playwright/test";
 const browserCapabilitiesResponse = {
   ok: true,
   detectedBrowsers: [
-    { id: "google-chrome", label: "Google Chrome" },
-    { id: "chromium", label: "Chromium" },
+    {
+      id: "google-chrome",
+      label: "Google Chrome",
+      defaultProfileAvailable: true,
+    },
+    { id: "chromium", label: "Chromium", defaultProfileAvailable: false },
   ],
   capabilities: [
     {

--- a/apps/web/e2e/tests/docs-screenshots.spec.ts
+++ b/apps/web/e2e/tests/docs-screenshots.spec.ts
@@ -99,8 +99,12 @@ const syntheticProviderModelsResponse = {
 const syntheticBrowserCapabilitiesResponse = {
   ok: true,
   detectedBrowsers: [
-    { id: "google-chrome", label: "Google Chrome" },
-    { id: "chromium", label: "Chromium" },
+    {
+      id: "google-chrome",
+      label: "Google Chrome",
+      defaultProfileAvailable: true,
+    },
+    { id: "chromium", label: "Chromium", defaultProfileAvailable: false },
   ],
   capabilities: [
     {

--- a/apps/web/src/contexts/operations/components/BrowserCapabilitiesPanel.test.tsx
+++ b/apps/web/src/contexts/operations/components/BrowserCapabilitiesPanel.test.tsx
@@ -91,13 +91,17 @@ describe("<BrowserCapabilitiesPanel>", () => {
     expect(input).toHaveValue("/Applications/Safari.app");
   });
 
-  it("requires separate consent before copying an authenticated profile", async () => {
+  it("copies a detected authenticated profile without requiring a filesystem path", async () => {
     const user = userEvent.setup();
     const copyLinkedInBrowserProfile = vi.fn();
     const browserCapabilities = vi.fn(async () => ({
       ok: true as const,
       detectedBrowsers: [
-        { id: "google-chrome" as const, label: "Google Chrome" },
+        {
+          id: "google-chrome" as const,
+          label: "Google Chrome",
+          defaultProfileAvailable: true,
+        },
       ],
       capabilities: [
         {
@@ -118,8 +122,8 @@ describe("<BrowserCapabilitiesPanel>", () => {
         },
         {
           id: "authenticated-linkedin-browser" as const,
-          status: "ready" as const,
-          detail: "Browser access is enabled.",
+          status: "missing" as const,
+          detail: "Profile copy is missing.",
           mutable: true,
           enabled: true,
           profileCopyReady: false,
@@ -132,18 +136,22 @@ describe("<BrowserCapabilitiesPanel>", () => {
       }),
     });
 
-    const source = await screen.findByLabelText(
-      "Existing browser profile directory",
+    expect(
+      await screen.findByLabelText("Detected browser profile"),
+    ).toHaveTextContent(
+      "Google Chrome · Default",
     );
+    expect(screen.getByText("Profile copy missing")).toBeInTheDocument();
+    expect(
+      screen.queryByLabelText("Existing browser user-data directory"),
+    ).not.toBeInTheDocument();
     const consent = screen.getByRole("checkbox", {
       name: /I explicitly consent to copy this profile/i,
     });
     const copy = screen.getByRole("button", {
-      name: "Copy selected profile",
+      name: "Copy Google Chrome profile",
     });
 
-    expect(copy).toBeDisabled();
-    await user.type(source, "/synthetic/chrome-profile");
     expect(copy).toBeDisabled();
     await user.click(consent);
     expect(copy).toBeEnabled();
@@ -153,7 +161,7 @@ describe("<BrowserCapabilitiesPanel>", () => {
       expect(copyLinkedInBrowserProfile).toHaveBeenCalledOnce(),
     );
     expect(copyLinkedInBrowserProfile).toHaveBeenCalledWith({
-      sourceProfilePath: "/synthetic/chrome-profile",
+      detectedBrowserId: "google-chrome",
       consent: true,
       consentMethod: "explicit-ui-v1",
     });

--- a/apps/web/src/contexts/operations/components/BrowserCapabilitiesPanel.tsx
+++ b/apps/web/src/contexts/operations/components/BrowserCapabilitiesPanel.tsx
@@ -76,6 +76,8 @@ export function BrowserCapabilitiesPanel() {
   const [manualPathErrors, setManualPathErrors] = useState<
     Record<string, string>
   >({});
+  const [selectedProfileBrowserId, setSelectedProfileBrowserId] =
+    useState<DetectedBrowserId | null>(null);
   const [sourceProfilePath, setSourceProfilePath] = useState("");
   const [profileConsent, setProfileConsent] = useState(false);
   const [message, setMessage] = useState("");
@@ -128,13 +130,36 @@ export function BrowserCapabilitiesPanel() {
     }
   }
 
-  async function copyLinkedInProfile() {
+  async function copyDetectedLinkedInProfile(
+    detectedBrowserId: DetectedBrowserId,
+    label: string,
+  ) {
+    if (!profileConsent) {
+      setMessage("Grant the separate profile-copy consent first.");
+      return;
+    }
+    setProfileConsent(false);
+    try {
+      await copyProfile.mutateAsync({
+        detectedBrowserId,
+        consent: true,
+        consentMethod: "explicit-ui-v1",
+      });
+      setMessage(
+        `${label}'s default profile was copied into JobCtrl-owned storage.`,
+      );
+    } catch {
+      setMessage("The detected browser profile could not be copied.");
+    }
+  }
+
+  async function copyManualLinkedInProfile() {
     const selectedPath = sourceProfilePath.trim();
     setSourceProfilePath("");
     setProfileConsent(false);
     if (!selectedPath || !profileConsent)
       return setMessage(
-        "Select a profile directory and grant the separate copy consent.",
+        "Enter a profile directory and grant the separate copy consent.",
       );
     try {
       await copyProfile.mutateAsync({
@@ -169,6 +194,19 @@ export function BrowserCapabilitiesPanel() {
       null;
     const selectItems = detectedBrowsers.map((browser) => ({
       label: browser.label,
+      value: browser.id,
+    }));
+    const detectedProfileBrowsers = detectedBrowsers.filter(
+      (browser) => browser.defaultProfileAvailable,
+    );
+    const selectedProfileBrowser =
+      detectedProfileBrowsers.find(
+        (browser) => browser.id === selectedProfileBrowserId,
+      ) ??
+      detectedProfileBrowsers[0] ??
+      null;
+    const profileSelectItems = detectedProfileBrowsers.map((browser) => ({
+      label: `${browser.label} · Default`,
       value: browser.id,
     }));
     const manualError = manualPathErrors[capabilityId] ?? "";
@@ -340,25 +378,49 @@ export function BrowserCapabilitiesPanel() {
             <FieldSet>
               <FieldLegend>Separate authenticated profile copy</FieldLegend>
               <FieldGroup>
-                <Field>
-                  <FieldLabel htmlFor="linkedin-profile-source">
-                    Existing browser profile directory
-                  </FieldLabel>
-                  <Input
-                    id="linkedin-profile-source"
-                    name="linkedin-profile-source"
-                    type="password"
-                    autoComplete="off"
-                    value={sourceProfilePath}
-                    onChange={(event) =>
-                      setSourceProfilePath(event.target.value)
-                    }
-                  />
+                {selectedProfileBrowser ? (
+                  <Field>
+                    <FieldLabel htmlFor="linkedin-detected-profile">
+                      Detected browser profile
+                    </FieldLabel>
+                    <Select
+                      items={profileSelectItems}
+                      value={selectedProfileBrowser.id}
+                      disabled={demo || copyProfile.isPending}
+                      onValueChange={(value) => {
+                        if (value === "google-chrome" || value === "chromium") {
+                          setSelectedProfileBrowserId(value);
+                        }
+                      }}
+                    >
+                      <SelectTrigger
+                        id="linkedin-detected-profile"
+                        aria-label="Detected browser profile for authenticated LinkedIn"
+                        className="max-w-xl"
+                      >
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent alignItemWithTrigger={false}>
+                        <SelectGroup>
+                          {profileSelectItems.map((profile) => (
+                            <SelectItem key={profile.value} value={profile.value}>
+                              {profile.label}
+                            </SelectItem>
+                          ))}
+                        </SelectGroup>
+                      </SelectContent>
+                    </Select>
+                    <FieldDescription>
+                      Detected locally. No folder navigation or path entry is
+                      required.
+                    </FieldDescription>
+                  </Field>
+                ) : (
                   <FieldDescription>
-                    Request-only. Cleared after submission and never returned or
-                    logged.
+                    No standard Chrome or Chromium default profile was detected.
+                    Use the advanced path only for a non-standard profile location.
                   </FieldDescription>
-                </Field>
+                )}
                 <Field orientation="horizontal">
                   <Checkbox
                     id="linkedin-profile-consent"
@@ -371,18 +433,62 @@ export function BrowserCapabilitiesPanel() {
                     storage.
                   </FieldLabel>
                 </Field>
-                <Button
-                  className="w-fit max-w-xs whitespace-normal"
-                  type="button"
-                  disabled={
-                    copyProfile.isPending ||
-                    !profileConsent ||
-                    !sourceProfilePath.trim()
-                  }
-                  onClick={() => void copyLinkedInProfile()}
-                >
-                  Copy selected profile
-                </Button>
+                {selectedProfileBrowser ? (
+                  <Button
+                    className="w-fit max-w-xs whitespace-normal"
+                    type="button"
+                    disabled={copyProfile.isPending || !profileConsent}
+                    onClick={() =>
+                      void copyDetectedLinkedInProfile(
+                        selectedProfileBrowser.id,
+                        selectedProfileBrowser.label,
+                      )
+                    }
+                  >
+                    Copy {selectedProfileBrowser.label} profile
+                  </Button>
+                ) : null}
+                <Collapsible defaultOpen={!selectedProfileBrowser}>
+                  <CollapsibleTrigger
+                    render={<Button variant="ghost" size="sm" type="button" />}
+                  >
+                    Advanced profile path
+                  </CollapsibleTrigger>
+                  <CollapsibleContent className="pt-3">
+                    <Field>
+                      <FieldLabel htmlFor="linkedin-profile-source">
+                        Existing browser user-data directory
+                      </FieldLabel>
+                      <Input
+                        id="linkedin-profile-source"
+                        name="linkedin-profile-source"
+                        type="password"
+                        autoComplete="off"
+                        value={sourceProfilePath}
+                        onChange={(event) =>
+                          setSourceProfilePath(event.target.value)
+                        }
+                      />
+                      <FieldDescription>
+                        Request-only fallback for non-standard locations. Cleared
+                        after submission and never returned or logged.
+                      </FieldDescription>
+                    </Field>
+                    <Button
+                      className="mt-3 w-fit max-w-xs whitespace-normal"
+                      variant="outline"
+                      type="button"
+                      disabled={
+                        copyProfile.isPending ||
+                        !profileConsent ||
+                        !sourceProfilePath.trim()
+                      }
+                      onClick={() => void copyManualLinkedInProfile()}
+                    >
+                      Copy profile from manual path
+                    </Button>
+                  </CollapsibleContent>
+                </Collapsible>
               </FieldGroup>
             </FieldSet>
           </div>
@@ -454,7 +560,7 @@ export function BrowserCapabilitiesPanel() {
                     icon={false}
                     tone={browserStatusTone(capability.status)}
                   >
-                    {browserStatusLabel(capability.status)}
+                    {browserStatusLabel(capability.id, capability.status)}
                   </StatusBadge>
                 </header>
                 {renderCapabilityControls(capability)}
@@ -490,10 +596,17 @@ function browserAccessLabel(capabilityId: BrowserCapabilityId): string {
   return "Optional browser access";
 }
 
-function browserStatusLabel(status: BrowserCapabilityItem["status"]): string {
+function browserStatusLabel(
+  capabilityId: BrowserCapabilityId,
+  status: BrowserCapabilityItem["status"],
+): string {
   if (status === "ready") return "Ready";
   if (status === "disabled") return "Off";
-  if (status === "missing") return "Browser missing";
+  if (status === "missing") {
+    return capabilityId === "authenticated-linkedin-browser"
+      ? "Profile copy missing"
+      : "Browser missing";
+  }
   if (status === "failed") return "Failed";
   return "Unavailable";
 }

--- a/apps/web/src/contexts/operations/hooks/useBrowserCapabilityMutations.test.ts
+++ b/apps/web/src/contexts/operations/hooks/useBrowserCapabilityMutations.test.ts
@@ -10,7 +10,13 @@ import { useDisableBrowserCapabilityMutation } from "./useBrowserCapabilityMutat
 
 const initial = {
   ok: true as const,
-  detectedBrowsers: [{ id: "google-chrome" as const, label: "Google Chrome" }],
+  detectedBrowsers: [
+    {
+      id: "google-chrome" as const,
+      label: "Google Chrome",
+      defaultProfileAvailable: true,
+    },
+  ],
   capabilities: [
     {
       id: "core-browser" as const,

--- a/apps/web/src/contexts/pipeline/components/StageTimeline.test.tsx
+++ b/apps/web/src/contexts/pipeline/components/StageTimeline.test.tsx
@@ -35,7 +35,13 @@ function makeStage(
 function readyAuthenticatedLinkedInBrowser(): BrowserCapabilitiesResponse {
   return {
     ok: true,
-    detectedBrowsers: [{ id: "google-chrome", label: "Google Chrome" }],
+    detectedBrowsers: [
+      {
+        id: "google-chrome",
+        label: "Google Chrome",
+        defaultProfileAvailable: true,
+      },
+    ],
     capabilities: [
       {
         id: "core-browser",

--- a/apps/web/src/test/testPorts.ts
+++ b/apps/web/src/test/testPorts.ts
@@ -278,7 +278,11 @@ export function buildTestPorts(overrides: BuildTestPortsOptions = {}): Ports {
     browserCapabilities: vi.fn(async () => ({
       ok: true as const,
       detectedBrowsers: [
-        { id: "google-chrome" as const, label: "Google Chrome" },
+        {
+          id: "google-chrome" as const,
+          label: "Google Chrome",
+          defaultProfileAvailable: true,
+        },
       ],
       capabilities: [
         {

--- a/docs/api/complete-contract.md
+++ b/docs/api/complete-contract.md
@@ -1486,9 +1486,9 @@ table; this keeps Dashboard lightweight without imposing an event-history cap.
   or `{ sourceProfilePath }`. The detected-ID arm resolves the standard default
   profile again at mutation time and copies only `Default` plus sanitized root
   metadata required by Chrome; sibling profile directories and metadata are
-  excluded. The manual path is cleared after the request and never returned,
-  logged, or persisted. A detected candidate becomes adopted only through the
-  separate explicit enable mutation.
+  excluded. The manual path is cleared after the request; JobCtrl never
+  returns, logs, or persists it. A detected candidate becomes adopted only
+  through the separate explicit enable mutation.
 - Authenticated extension routes under `/v1/extension/*` require `Authorization:
   Bearer <token>`. A valid token allows a `chrome-extension://` origin through
   the route-scoped CORS and unsafe-mutation guards, but only after the loopback

--- a/docs/api/complete-contract.md
+++ b/docs/api/complete-contract.md
@@ -1469,10 +1469,12 @@ table; this keeps Dashboard lightweight without imposing an event-history cap.
 - `GET /v1/browser-capabilities` returns `core-browser`,
   `auto-apply-browser`, and `authenticated-linkedin-browser` state without
   returning a saved executable or source-profile path. It also returns
-  `detectedBrowsers: Array<{ id: "google-chrome" | "chromium", label: string }>`
-  for currently detected supported installations. Detection is read-only: it
-  does not launch, adopt, copy, or persist the browser, and no filesystem path
-  crosses the RPC/API boundary. The core browser is managed and read-only.
+  `detectedBrowsers: Array<{ id: "google-chrome" | "chromium", label: string,
+  defaultProfileAvailable: boolean }>` for currently detected supported
+  installations. Detection checks only the standard default-profile directory;
+  it does not read profile contents, launch, adopt, copy, or persist the browser,
+  and no filesystem path crosses the RPC/API boundary. The core browser is
+  managed and read-only.
   `POST /v1/browser-capabilities/:capabilityId/enable` accepts exactly one of
   `{ detectedBrowserId }` or `{ executablePath }`; the strict union rejects
   both/neither. The path is write-only. The detected-ID arm resolves the
@@ -1480,9 +1482,13 @@ table; this keeps Dashboard lightweight without imposing an event-history cap.
   closed with sanitized `400 browser_capability_failed` without adopting any
   fallback. The matching `/disable` route applies
   immediately. `POST /v1/browser-capabilities/authenticated-linkedin-browser/profile-copy`
-  requires explicit consent, clears the source path after the request, and
-  never returns, logs, or persists it. A detected candidate becomes adopted
-  only through this explicit enable mutation.
+  requires explicit consent and accepts exactly one of `{ detectedBrowserId }`
+  or `{ sourceProfilePath }`. The detected-ID arm resolves the standard default
+  profile again at mutation time and copies only `Default` plus sanitized root
+  metadata required by Chrome; sibling profile directories and metadata are
+  excluded. The manual path is cleared after the request and never returned,
+  logged, or persisted. A detected candidate becomes adopted only through the
+  separate explicit enable mutation.
 - Authenticated extension routes under `/v1/extension/*` require `Authorization:
   Bearer <token>`. A valid token allows a `chrome-extension://` origin through
   the route-scoped CORS and unsafe-mutation guards, but only after the loopback

--- a/docs/api/profile-and-settings.md
+++ b/docs/api/profile-and-settings.md
@@ -48,10 +48,10 @@ enter the system. They do not hold provider credentials or raw feed contents.
 | `POST /v1/providers/codex/verify` | Explicitly validate and import a reusable normal Codex CLI `auth.json` once when isolated auth is absent, then verify isolated auth without a model call. |
 | `GET /v1/extension/pairing-token` | Read the local extension pairing state. |
 | `POST /v1/extension/pairing-token/rotate` | Rotate the token immediately and disconnect existing extension clients. |
-| `GET /v1/browser-capabilities` | Read managed/optional capability states plus transient supported-browser candidates as ID/label pairs; no local path is returned or adopted. |
+| `GET /v1/browser-capabilities` | Read managed/optional capability states plus transient supported-browser candidates as ID/label/profile-availability records; no local path is returned or adopted. |
 | `POST /v1/browser-capabilities/:capabilityId/enable` | Explicitly adopt exactly one transient `detectedBrowserId` or one write-only `executablePath` for an optional capability. |
 | `POST /v1/browser-capabilities/:capabilityId/disable` | Disable an optional capability immediately. |
-| `POST /v1/browser-capabilities/authenticated-linkedin-browser/profile-copy` | Copy a profile only with explicit consent; the source path is request-only. |
+| `POST /v1/browser-capabilities/authenticated-linkedin-browser/profile-copy` | Copy exactly one detected default profile by opaque browser ID or one write-only manual source path, only with explicit consent. |
 
 Credential responses expose enough state for the UI to show whether a provider
 is configured, but do not return stored secret material. Guided provider

--- a/docs/local-ts-api.md
+++ b/docs/local-ts-api.md
@@ -186,7 +186,9 @@ provider without requiring it to be ready.
 for launch controls. Environment-owned fields are read-only. Discovery runtime
 and schedule controls use `GET/PATCH /v1/discovery/settings`; browser adoption
 uses `GET /v1/browser-capabilities` plus capability-specific `POST` enable,
-disable, and profile-copy routes; extension pairing uses
+disable, and profile-copy routes. Standard default profiles can be selected by
+opaque detected-browser ID; write-only filesystem paths are an advanced
+fallback. Extension pairing uses
 `GET /v1/extension/pairing-token` and `POST /v1/extension/pairing-token/rotate`.
 
 ## Related Packages

--- a/docs/user/apply.md
+++ b/docs/user/apply.md
@@ -200,12 +200,17 @@ The provider key and returned token stay outside the model prompt. An
 unsupported challenge, missing configuration, or failed solve stops the apply
 path; solving a challenge never grants form-entry or final-submit authority.
 
-A source profile path is cleared after the copy request and is never returned,
-logged, or persisted. Profile copying retains its separate affirmative consent;
-selecting or enabling a browser does not grant that consent. Rotating the
-pairing token takes effect immediately. Existing extensions are disconnected;
-the UI never exposes the token's file path. The CLI commands below remain an
-equivalent manual-path operator surface.
+When Chrome or Chromium has a standard local default profile, Settings lists it
+by browser label and can copy it without asking you to navigate to or paste a
+filesystem path. Only the opaque detected-browser ID crosses the API boundary;
+the worker resolves the standard profile location again at copy time, copies
+only `Default`, and sanitizes the required Chrome root metadata so sibling
+profiles are excluded. A manual source profile path remains an advanced
+fallback, is cleared after the request, and is never returned, logged, or
+persisted. Both paths retain separate affirmative consent: selecting or enabling
+a browser does not grant profile-copy consent. Rotating the pairing token takes effect immediately. Existing
+extensions are disconnected; the UI never exposes the token's file path. The
+CLI commands below remain an equivalent manual-path operator surface.
 
 The same explicitly enabled and separately consented authenticated LinkedIn
 profile can recover a full LinkedIn posting and its external application URL.

--- a/packages/contracts/src/schemas.ts
+++ b/packages/contracts/src/schemas.ts
@@ -4922,6 +4922,7 @@ export const DetectedBrowserSchema = z
   .object({
     id: z.enum(DetectedBrowserIds),
     label: z.string().trim().min(1).max(80),
+    defaultProfileAvailable: z.boolean(),
   })
   .strict();
 export type DetectedBrowser = z.infer<typeof DetectedBrowserSchema>;
@@ -4955,12 +4956,18 @@ export const BrowserCapabilityEnableRequestSchema = z
 export type BrowserCapabilityEnableRequest = z.infer<typeof BrowserCapabilityEnableRequestSchema>;
 
 export const BrowserProfileCopyRequestSchema = z
-  .object({
-    sourceProfilePath: z.string().trim().min(1).max(4096),
-    consent: z.literal(true),
-    consentMethod: z.literal("explicit-ui-v1"),
-  })
-  .strict();
+  .union([
+    z.object({
+      detectedBrowserId: z.enum(DetectedBrowserIds),
+      consent: z.literal(true),
+      consentMethod: z.literal("explicit-ui-v1"),
+    }).strict(),
+    z.object({
+      sourceProfilePath: z.string().trim().min(1).max(4096),
+      consent: z.literal(true),
+      consentMethod: z.literal("explicit-ui-v1"),
+    }).strict(),
+  ]);
 export type BrowserProfileCopyRequest = z.infer<typeof BrowserProfileCopyRequestSchema>;
 
 export interface BrowserCapabilityErrorResponse {

--- a/workers/automation/src/jobctrl/browser_capabilities.py
+++ b/workers/automation/src/jobctrl/browser_capabilities.py
@@ -74,6 +74,10 @@ class DetectedBrowserUnavailableError(BrowserCapabilityError):
     """Raised when an explicitly selected transient browser is no longer installed."""
 
 
+class DetectedBrowserProfileUnavailableError(BrowserCapabilityError):
+    """Raised when a detected browser's default profile is no longer available."""
+
+
 class BrowserProfileConsentRequiredError(BrowserCapabilityError):
     """Raised when a caller tries to copy a profile without affirmative consent."""
 
@@ -486,6 +490,53 @@ def detect_supported_browsers() -> tuple[DetectedBrowser, ...]:
     return tuple(detected)
 
 
+def _default_browser_profile_locations(browser_id: str) -> tuple[Path, ...]:
+    """Return known user-data roots without reading browser profile contents."""
+
+    if browser_id not in {"google-chrome", "chromium"}:
+        return ()
+    if sys.platform == "darwin":
+        relative = (
+            Path("Library/Application Support/Google/Chrome")
+            if browser_id == "google-chrome"
+            else Path("Library/Application Support/Chromium")
+        )
+        return (Path.home() / relative,)
+    if sys.platform == "win32":
+        local_app_data = os.environ.get("LOCALAPPDATA")
+        if not local_app_data:
+            return ()
+        relative = (
+            Path("Google/Chrome/User Data")
+            if browser_id == "google-chrome"
+            else Path("Chromium/User Data")
+        )
+        return (Path(local_app_data) / relative,)
+    relative = (
+        Path(".config/google-chrome")
+        if browser_id == "google-chrome"
+        else Path(".config/chromium")
+    )
+    return (Path.home() / relative,)
+
+
+def detect_default_browser_profile(browser_id: str) -> Path | None:
+    """Resolve a standard default-profile source without returning it over RPC."""
+
+    if not any(browser.id == browser_id for browser in detect_supported_browsers()):
+        return None
+    for root in _default_browser_profile_locations(browser_id):
+        default_profile = root / "Default"
+        if (
+            root.is_dir()
+            and not root.is_symlink()
+            and default_profile.is_dir()
+            and not default_profile.is_symlink()
+        ):
+            return root
+    return None
+
+
 def browser_capability_status(
     capability_id: str,
     *,
@@ -722,6 +773,8 @@ def copy_authenticated_linkedin_profile(
     consent_method: str = "explicit-cli",
     app_dir: Path | None = None,
     catalog: BrowserCapabilityCatalog | None = None,
+    _root_entries: frozenset[str] | None = None,
+    _sanitize_default_local_state: bool = False,
 ) -> Path:
     """Copy a profile only after separate affirmative consent.
 
@@ -771,7 +824,13 @@ def copy_authenticated_linkedin_profile(
                 )
             return _owned_profile_path(destination, app_dir=app_dir, require_existing=True)
 
-    _copy_profile_tree(source, destination, app_dir=app_dir)
+    _copy_profile_tree(
+        source,
+        destination,
+        app_dir=app_dir,
+        root_entries=_root_entries,
+        sanitize_default_local_state=_sanitize_default_local_state,
+    )
     try:
         with _browser_capability_state_transaction(app_dir=app_dir, catalog=resolved_catalog) as state:
             record = _record_for(state, "authenticated-linkedin-browser")
@@ -795,6 +854,35 @@ def copy_authenticated_linkedin_profile(
         _discard_owned_profile_copy(destination, app_dir=app_dir)
         raise
     return destination
+
+
+def copy_detected_authenticated_linkedin_profile(
+    detected_browser_id: str,
+    *,
+    consent: bool,
+    consent_method: str = "explicit-cli",
+    app_dir: Path | None = None,
+    catalog: BrowserCapabilityCatalog | None = None,
+) -> Path:
+    """Copy a standard detected profile while keeping its host path worker-local."""
+
+    source = detect_default_browser_profile(detected_browser_id)
+    if source is None:
+        raise DetectedBrowserProfileUnavailableError(
+            "the selected detected browser profile is no longer available"
+        )
+    return copy_authenticated_linkedin_profile(
+        source,
+        consent=consent,
+        consent_method=consent_method,
+        app_dir=app_dir,
+        catalog=catalog,
+        # The detected-profile contract names exactly one profile. Chrome's
+        # root Local State is needed for platform encryption metadata, but
+        # sibling profile directories and their sessions are outside consent.
+        _root_entries=frozenset({"Default", "Local State"}),
+        _sanitize_default_local_state=True,
+    )
 
 
 def _app_dir() -> Path:
@@ -856,9 +944,16 @@ def _same_entry(first: os.stat_result, second: os.stat_result) -> bool:
     return (first.st_dev, first.st_ino) == (second.st_dev, second.st_ino)
 
 
-def _copy_profile_directory(source_descriptor: int, destination_descriptor: int) -> None:
+def _copy_profile_directory(
+    source_descriptor: int,
+    destination_descriptor: int,
+    *,
+    root_entries: frozenset[str] | None = None,
+) -> None:
     for name in os.listdir(source_descriptor):
-        if name in _PROFILE_COPY_SKIP:
+        if name in _PROFILE_COPY_SKIP or (
+            root_entries is not None and name not in root_entries
+        ):
             continue
         source_status = os.stat(name, dir_fd=source_descriptor, follow_symlinks=False)
         if stat.S_ISDIR(source_status.st_mode):
@@ -937,7 +1032,106 @@ def _discard_owned_profile_copy(destination: Path, *, app_dir: Path | None) -> N
         raise BrowserCapabilityError("the copied browser profile could not be discarded") from exc
 
 
-def _copy_profile_tree(source: Path, destination: Path, *, app_dir: Path | None) -> None:
+def _sanitize_detected_default_local_state_at(directory_descriptor: int) -> None:
+    """Sanitize Local State inside an unpublished Default-profile staging tree."""
+
+    source_file = -1
+    replacement_file = -1
+    replacement_name = f".Local State.sanitized-{secrets.token_hex(8)}"
+    try:
+        try:
+            source_status = os.stat(
+                "Local State",
+                dir_fd=directory_descriptor,
+                follow_symlinks=False,
+            )
+        except FileNotFoundError:
+            return
+        if not stat.S_ISREG(source_status.st_mode):
+            raise BrowserCapabilityError(
+                "the detected browser metadata could not be copied safely"
+            )
+        source_file = os.open(
+            "Local State",
+            os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0),
+            dir_fd=directory_descriptor,
+        )
+        if not _same_entry(source_status, os.fstat(source_file)):
+            raise BrowserCapabilityError(
+                "the detected browser metadata changed while being copied"
+            )
+        chunks: list[bytes] = []
+        size = 0
+        while chunk := os.read(source_file, 1024 * 1024):
+            size += len(chunk)
+            if size > 16 * 1024 * 1024:
+                raise BrowserCapabilityError("the detected browser metadata is too large")
+            chunks.append(chunk)
+        payload = json.loads(b"".join(chunks).decode("utf-8"))
+        if not isinstance(payload, dict):
+            raise ValueError("Local State must be an object")
+        sanitized: dict[str, object] = {}
+        os_crypt = payload.get("os_crypt")
+        if isinstance(os_crypt, dict):
+            sanitized["os_crypt"] = os_crypt
+        profile = payload.get("profile")
+        if isinstance(profile, dict):
+            sanitized_profile: dict[str, object] = {
+                "last_used": "Default",
+                "last_active_profiles": ["Default"],
+                "profiles_order": ["Default"],
+            }
+            info_cache = profile.get("info_cache")
+            if isinstance(info_cache, dict) and isinstance(info_cache.get("Default"), dict):
+                sanitized_profile["info_cache"] = {"Default": info_cache["Default"]}
+            sanitized["profile"] = sanitized_profile
+        encoded = json.dumps(
+            sanitized,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("utf-8")
+        replacement_file = os.open(
+            replacement_name,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0),
+            stat.S_IRUSR | stat.S_IWUSR,
+            dir_fd=directory_descriptor,
+        )
+        remaining = memoryview(encoded)
+        while remaining:
+            written = os.write(replacement_file, remaining)
+            remaining = remaining[written:]
+        os.fsync(replacement_file)
+        os.close(replacement_file)
+        replacement_file = -1
+        os.rename(
+            replacement_name,
+            "Local State",
+            src_dir_fd=directory_descriptor,
+            dst_dir_fd=directory_descriptor,
+        )
+    except Exception as exc:
+        raise BrowserCapabilityError(
+            "the detected browser metadata could not be copied safely"
+        ) from exc
+    finally:
+        if replacement_file >= 0:
+            os.close(replacement_file)
+        try:
+            os.unlink(replacement_name, dir_fd=directory_descriptor)
+        except FileNotFoundError:
+            pass
+        if source_file >= 0:
+            os.close(source_file)
+
+
+def _copy_profile_tree(
+    source: Path,
+    destination: Path,
+    *,
+    app_dir: Path | None,
+    root_entries: frozenset[str] | None = None,
+    sanitize_default_local_state: bool = False,
+) -> None:
     """Copy through no-follow directory FDs and publish with an anchored rename."""
 
     _owned_profile_path(destination, app_dir=app_dir, require_existing=False)
@@ -965,7 +1159,13 @@ def _copy_profile_tree(source: Path, destination: Path, *, app_dir: Path | None)
             )
             try:
                 os.fchmod(staging_descriptor, 0o700)
-                _copy_profile_directory(source_descriptor, staging_descriptor)
+                _copy_profile_directory(
+                    source_descriptor,
+                    staging_descriptor,
+                    root_entries=root_entries,
+                )
+                if sanitize_default_local_state:
+                    _sanitize_detected_default_local_state_at(staging_descriptor)
             finally:
                 os.close(staging_descriptor)
             os.rename(
@@ -1001,6 +1201,7 @@ __all__ = [
     "BrowserCapabilityUnavailableError",
     "BrowserProfileConsentRequiredError",
     "DetectedBrowser",
+    "DetectedBrowserProfileUnavailableError",
     "DetectedBrowserUnavailableError",
     "BROWSER_CAPABILITIES_CONFIG_KEY",
     "browser_capability_status",
@@ -1008,6 +1209,8 @@ __all__ = [
     "capability_profile_dir",
     "browser_capability_config_path",
     "copy_authenticated_linkedin_profile",
+    "copy_detected_authenticated_linkedin_profile",
+    "detect_default_browser_profile",
     "detect_supported_browsers",
     "disable_browser_capability",
     "enable_detected_browser_capability",

--- a/workers/automation/src/jobctrl/database.py
+++ b/workers/automation/src/jobctrl/database.py
@@ -2654,6 +2654,15 @@ _ENRICHMENT_PENDING: str = (
     "(je.job_id IS NULL OR je.current_status = 'pending') "
     "AND COALESCE(jss_enrich.state, 'pending') = 'pending'"
 )
+_ENRICHMENT_RETRYABLE_ROBOTS_BLOCKED: str = (
+    "(je.job_id IS NULL OR je.current_status = 'pending') "
+    "AND jss_enrich.state = 'blocked' "
+    "AND jss_enrich.error_code = 'ENRICH_ROBOTS_DISALLOWED' "
+    "AND COALESCE(jss_enrich.retryable, 1) = 1"
+)
+_ENRICHMENT_RUNNABLE: str = (
+    f"(({_ENRICHMENT_PENDING}) OR ({_ENRICHMENT_RETRYABLE_ROBOTS_BLOCKED}))"
+)
 
 # Closed/removed posting states are Enrichment-owned facts, not user
 # tombstones. Work queues treat them as non-actionable while leaving the

--- a/workers/automation/src/jobctrl/discovery/activities.py
+++ b/workers/automation/src/jobctrl/discovery/activities.py
@@ -319,6 +319,12 @@ async def discovery_enrichment_activity(
                 progress_completed=payload.progress_completed,
                 progress_total=payload.progress_total,
                 on_job_enriched=on_job_enriched,
+                recovery_key=(
+                    f"{payload.discovery_execution.workflow_id}:"
+                    f"{payload.discovery_execution.temporal_run_id}"
+                    if payload.discovery_execution is not None
+                    else None
+                ),
             ),
             starting_message="discovery enrichment starting",
             progress_message="discovery enrichment still running",

--- a/workers/automation/src/jobctrl/enrichment/activities.py
+++ b/workers/automation/src/jobctrl/enrichment/activities.py
@@ -24,6 +24,7 @@ class EnrichActivityInput:
     dry_run: bool = False
     job_ids: tuple[JobId, ...] = ()
     workflow_id: str | None = None
+    workflow_run_id: str | None = None
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "job_ids", _canonical_job_ids(self.job_ids))
@@ -92,6 +93,16 @@ async def enrich_activity(payload: EnrichActivityInput) -> EnrichActivityOutput:
                     "workers": payload.workers,
                     "limit": payload.limit,
                     "cancel_event": cancel_event,
+                    **(
+                        {
+                            "recovery_key": (
+                                f"{payload.workflow_id}:"
+                                f"{payload.workflow_run_id or 'initial'}"
+                            )
+                        }
+                        if payload.workflow_id
+                        else {}
+                    ),
                 },
                 mode="workflow",
                 pass_number=1,

--- a/workers/automation/src/jobctrl/enrichment/detail.py
+++ b/workers/automation/src/jobctrl/enrichment/detail.py
@@ -28,6 +28,7 @@ import logging
 import sqlite3
 import threading
 import time
+import uuid
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timezone
@@ -772,6 +773,7 @@ def _record_enrich_robots_blocked(
     decision: PolitenessDecision,
     *,
     tenant_id: TenantId = LOCAL_TENANT,
+    recovery_key: str | None = None,
 ) -> None:
     """Fold a robots-disallowed navigation into the enrichment lifecycle.
 
@@ -803,7 +805,15 @@ def _record_enrich_robots_blocked(
         retryable=True,
         next_action=f"Import this posting manually — robots.txt disallows automated fetch: {url}",
         finished_at=finished_at,
-        metadata={"reason": "robots_disallowed", "politenessOutcome": decision.outcome.value},
+        metadata={
+            "reason": "robots_disallowed",
+            "politenessOutcome": decision.outcome.value,
+            **(
+                {"lastRobotsRetryWorkflow": recovery_key}
+                if recovery_key
+                else {}
+            ),
+        },
         validate_transition=False,
         tenant_id=tenant_id,
     )
@@ -868,6 +878,61 @@ def _unblock_enrich_stage_if_blocked(
         payload={"reason": "robots_recheck", "previousState": "blocked"},
         tenant_id=tenant_id,
     )
+
+
+def _claim_robots_retry_for_workflow(
+    conn: sqlite3.Connection,
+    job_id: JobId,
+    recovery_key: str,
+    *,
+    tenant_id: TenantId,
+) -> bool:
+    """Atomically claim one robots-blocked row for one workflow execution.
+
+    Ordinary pending rows return ``True`` without mutation. A robots-blocked
+    row is admitted only when this workflow key has not claimed it before.
+    The claim lives on the canonical stage row, so a Temporal activity retry
+    cannot repeat the same owner-authenticated navigation.
+    """
+
+    row = conn.execute(
+        """
+        SELECT state, error_code, metadata_json, version
+        FROM job_stage_states
+        WHERE tenant_id = ? AND job_id = ? AND stage = 'enrich'
+        """,
+        (str(tenant_id), str(job_id)),
+    ).fetchone()
+    if row is None or row[0] != "blocked" or row[1] != "ENRICH_ROBOTS_DISALLOWED":
+        return True
+    try:
+        metadata = json.loads(row[2] or "{}")
+    except (TypeError, ValueError):
+        metadata = {}
+    if not isinstance(metadata, dict):
+        metadata = {}
+    if metadata.get("lastRobotsRetryWorkflow") == recovery_key:
+        return False
+    metadata["lastRobotsRetryWorkflow"] = recovery_key
+    updated = conn.execute(
+        """
+        UPDATE job_stage_states
+        SET metadata_json = ?, updated_at = ?, version = version + 1
+        WHERE tenant_id = ? AND job_id = ? AND stage = 'enrich'
+          AND state = 'blocked'
+          AND error_code = 'ENRICH_ROBOTS_DISALLOWED'
+          AND version = ?
+        """,
+        (
+            json.dumps(metadata, sort_keys=True),
+            datetime.now(timezone.utc).isoformat(),
+            str(tenant_id),
+            str(job_id),
+            int(row[3] or 0),
+        ),
+    )
+    conn.commit()
+    return updated.rowcount == 1
 
 
 def _record_enrich_politeness_deferral(
@@ -1031,6 +1096,7 @@ def scrape_site_batch(
     gateway: PolitenessGateway | None = None,
     run_budget: RunBudgetCounter | None = None,
     on_job_enriched: Callable[[JobId], None] | None = None,
+    recovery_key: str | None = None,
 ) -> dict:
     """Process all jobs for one site using a shared browser context.
 
@@ -1215,6 +1281,7 @@ def scrape_site_batch(
                         url,
                         gate,
                         tenant_id=tenant_id,
+                        recovery_key=recovery_key,
                     )
                     stats["blocked"] += 1
                     continue
@@ -2217,6 +2284,7 @@ def _run_detail_scraper(
     cancel_event: threading.Event | None = None,
     reset_linkedin_candidates: bool = True,
     on_job_enriched: Callable[[JobId], None] | None = None,
+    recovery_key: str | None = None,
 ) -> dict:
     """Group pending jobs by site and process each batch.
 
@@ -2233,7 +2301,17 @@ def _run_detail_scraper(
     # ``detail_scraped_at IS NULL`` gate was redundant AND blocked the
     # post-``reset_job_stage("enrich")`` re-pickup.
     stable_tenant_id = TenantId(str(tenant_id))
-    where_parts = [db_module._ENRICHMENT_PENDING, skip_filter]
+    if reset_linkedin_candidates and not job_ids and not recovery_key:
+        recovery_key = f"local-enrich:{uuid.uuid4().hex}"
+    # A later enrichment workflow must reconsider robots-blocked rows, but only
+    # on its first pass.  Keeping them out of the steady-state pending selector
+    # prevents a still-disallowed URL from looping within the same workflow.
+    enrichment_selector = (
+        db_module._ENRICHMENT_RUNNABLE
+        if reset_linkedin_candidates and not job_ids
+        else db_module._ENRICHMENT_PENDING
+    )
+    where_parts = [enrichment_selector, skip_filter]
     params: list[object] = []
     selected_job_ids = tuple(
         dict.fromkeys(canonical_job_id(str(job_id)) for job_id in job_ids)
@@ -2259,9 +2337,15 @@ def _run_detail_scraper(
         )
 
     rows = conn.execute(
-        f"SELECT jobs.job_id, jobs.title, jobs.site FROM jobs {db_module._ENRICHMENT_JOIN} "
+        f"SELECT jobs.job_id, jobs.title, jobs.site, "
+        "jss_enrich.state, jss_enrich.error_code, jss_enrich.metadata_json "
+        f"FROM jobs {db_module._ENRICHMENT_JOIN} {db_module._ACTIVE_STATE_JOIN} "
         f"WHERE {' AND '.join(where_parts)} "
-        "ORDER BY jobs.site",
+        f"AND {db_module._NOT_CLOSED_ACTIVE_STATE} "
+        "ORDER BY jobs.site, "
+        "CASE WHEN jss_enrich.state = 'blocked' "
+        "AND jss_enrich.error_code = 'ENRICH_ROBOTS_DISALLOWED' THEN 0 ELSE 1 END, "
+        "jobs.job_id",
         params,
     ).fetchall()
 
@@ -2274,6 +2358,17 @@ def _run_detail_scraper(
         job_id, title, site = canonical_job_id(str(row[0])), row[1], row[2]
         if sites and site not in sites:
             continue
+        if row[3] == "blocked" and row[4] == "ENRICH_ROBOTS_DISALLOWED":
+            try:
+                metadata = json.loads(row[5] or "{}")
+            except (TypeError, ValueError):
+                metadata = {}
+            if (
+                recovery_key
+                and isinstance(metadata, dict)
+                and metadata.get("lastRobotsRetryWorkflow") == recovery_key
+            ):
+                continue
         site_jobs.setdefault(site, []).append((job_id, title))
 
     log.info("Pending: %d jobs across %d sites (workers=%d)", len(rows), len(site_jobs), workers)
@@ -2321,6 +2416,23 @@ def _run_detail_scraper(
     # every site batch, in both sequential and parallel modes.
     gateway = PolitenessGateway()
 
+    def _jobs_for_site(site: str, site_conn: sqlite3.Connection) -> list[tuple]:
+        jobs = site_jobs[site]
+        if max_per_site and max_per_site > 0:
+            jobs = jobs[:max_per_site]
+        if not recovery_key:
+            return jobs
+        return [
+            job
+            for job in jobs
+            if _claim_robots_retry_for_workflow(
+                site_conn,
+                canonical_job_id(str(job[0])),
+                recovery_key,
+                tenant_id=stable_tenant_id,
+            )
+        ]
+
     if workers > 1 and len(order) > 1:
         database_path = next(
             str(row[2])
@@ -2331,32 +2443,34 @@ def _run_detail_scraper(
         def _scrape_site(site: str) -> dict:
             if cancel_event is not None and cancel_event.is_set():
                 raise TransientNetworkError("enrichment canceled")
-            jobs = site_jobs[site]
-            log.info("%s -- %d jobs", site, len(jobs))
             thread_conn = db_module.get_connection(database_path)
             try:
+                jobs = _jobs_for_site(site, thread_conn)
+                log.info("%s -- %d jobs", site, len(jobs))
                 if cancel_event is None:
                     stats = scrape_site_batch(
                         thread_conn,
                         site,
                         jobs,
-                        max_jobs=max_per_site,
+                        max_jobs=None,
                         tenant_id=stable_tenant_id,
                         gateway=gateway,
                         run_budget=run_budget,
                         on_job_enriched=on_job_enriched,
+                        recovery_key=recovery_key,
                     )
                 else:
                     stats = scrape_site_batch(
                         thread_conn,
                         site,
                         jobs,
-                        max_jobs=max_per_site,
+                        max_jobs=None,
                         cancel_event=cancel_event,
                         tenant_id=stable_tenant_id,
                         gateway=gateway,
                         run_budget=run_budget,
                         on_job_enriched=on_job_enriched,
+                        recovery_key=recovery_key,
                     )
             finally:
                 db_module.close_connection(database_path)
@@ -2391,7 +2505,7 @@ def _run_detail_scraper(
         for site in order:
             if cancel_event is not None and cancel_event.is_set():
                 raise TransientNetworkError("enrichment canceled")
-            jobs = site_jobs[site]
+            jobs = _jobs_for_site(site, conn)
             log.info("%s -- %d jobs", site, len(jobs))
             try:
                 if cancel_event is None:
@@ -2399,23 +2513,25 @@ def _run_detail_scraper(
                         conn,
                         site,
                         jobs,
-                        max_jobs=max_per_site,
+                        max_jobs=None,
                         tenant_id=stable_tenant_id,
                         gateway=gateway,
                         run_budget=run_budget,
                         on_job_enriched=on_job_enriched,
+                        recovery_key=recovery_key,
                     )
                 else:
                     stats = scrape_site_batch(
                         conn,
                         site,
                         jobs,
-                        max_jobs=max_per_site,
+                        max_jobs=None,
                         cancel_event=cancel_event,
                         tenant_id=stable_tenant_id,
                         gateway=gateway,
                         run_budget=run_budget,
                         on_job_enriched=on_job_enriched,
+                        recovery_key=recovery_key,
                     )
             except TransientNetworkError:
                 raise
@@ -2563,6 +2679,7 @@ def run_enrichment(
     cancel_event: threading.Event | None = None,
     reset_linkedin_candidates: bool = True,
     on_job_enriched: Callable[[JobId], None] | None = None,
+    recovery_key: str | None = None,
 ) -> dict:
     """Main entry point for detail page enrichment.
 
@@ -2600,6 +2717,16 @@ def run_enrichment(
             updated = resolve_wttj_urls(conn)
             log.info("WTTJ: %d URLs updated", updated)
 
+    if recovery_key:
+        return _run_detail_scraper(
+            conn,
+            max_per_site=limit,
+            workers=workers,
+            cancel_event=cancel_event,
+            reset_linkedin_candidates=reset_linkedin_candidates,
+            on_job_enriched=on_job_enriched,
+            recovery_key=recovery_key,
+        )
     return _run_detail_scraper(
         conn,
         max_per_site=limit,

--- a/workers/automation/src/jobctrl/infrastructure/rpc/handlers.py
+++ b/workers/automation/src/jobctrl/infrastructure/rpc/handlers.py
@@ -464,11 +464,24 @@ def _browser_status_payload(status: Any) -> dict[str, object]:
 def _browser_capabilities_payload() -> dict[str, object]:
     """Serialize capability state and transient candidates without local paths."""
 
-    from jobctrl.browser_capabilities import detect_supported_browsers, list_browser_capabilities
+    from jobctrl.browser_capabilities import (
+        detect_default_browser_profile,
+        detect_supported_browsers,
+        list_browser_capabilities,
+    )
+
+    detected_browsers = detect_supported_browsers()
 
     return {
         "capabilities": [_browser_status_payload(item) for item in list_browser_capabilities()],
-        "detectedBrowsers": [{"id": browser.id, "label": browser.label} for browser in detect_supported_browsers()],
+        "detectedBrowsers": [
+            {
+                "id": browser.id,
+                "label": browser.label,
+                "defaultProfileAvailable": detect_default_browser_profile(browser.id) is not None,
+            }
+            for browser in detected_browsers
+        ],
     }
 
 
@@ -525,19 +538,36 @@ def browser_capability_disable(params: dict[str, Any]) -> dict[str, object]:
 def browser_profile_copy(params: dict[str, Any]) -> dict[str, object]:
     """Copy a caller-selected profile only through the versioned explicit UI consent arm."""
 
-    source_profile_path = str(_require(params, "sourceProfilePath"))
+    has_source_profile_path = "sourceProfilePath" in params
+    has_detected_browser_id = "detectedBrowserId" in params
+    if has_source_profile_path == has_detected_browser_id:
+        raise invalid_params("Select exactly one detected browser profile or manual profile path.")
     consent = params.get("consent")
     consent_method = params.get("consentMethod")
     if consent is not True or consent_method != "explicit-ui-v1":
         raise invalid_params("A separate explicit profile-copy consent is required.")
-    from jobctrl.browser_capabilities import BrowserCapabilityError, copy_authenticated_linkedin_profile
+    from jobctrl.browser_capabilities import (
+        BrowserCapabilityError,
+        DetectedBrowserProfileUnavailableError,
+        copy_authenticated_linkedin_profile,
+        copy_detected_authenticated_linkedin_profile,
+    )
 
     try:
-        copy_authenticated_linkedin_profile(
-            source_profile_path,
-            consent=True,
-            consent_method="explicit-ui-v1",
-        )
+        if has_detected_browser_id:
+            copy_detected_authenticated_linkedin_profile(
+                str(_require(params, "detectedBrowserId")),
+                consent=True,
+                consent_method="explicit-ui-v1",
+            )
+        else:
+            copy_authenticated_linkedin_profile(
+                str(_require(params, "sourceProfilePath")),
+                consent=True,
+                consent_method="explicit-ui-v1",
+            )
+    except DetectedBrowserProfileUnavailableError as exc:
+        raise invalid_params("The selected detected browser profile is no longer available.") from exc
     except BrowserCapabilityError as exc:
         raise invalid_params("The selected browser profile could not be copied.") from exc
     return _browser_capabilities_payload()

--- a/workers/automation/src/jobctrl/pipeline/runner.py
+++ b/workers/automation/src/jobctrl/pipeline/runner.py
@@ -1668,6 +1668,7 @@ def run_discovery_enrichment_stage(
     progress_completed: int = 0,
     progress_total: int = 0,
     on_job_enriched: Callable[[JobId], None] | None = None,
+    recovery_key: str | None = None,
 ) -> dict[str, Any]:
     emit_progress = progress_total > 0
     if emit_progress:
@@ -1687,13 +1688,18 @@ def run_discovery_enrichment_stage(
     result: dict[str, Any] = {}
     discovery_done = threading.Event()
     discovery_done.set()
+    drain_kwargs: dict[str, Any] = {
+        "workers": max(1, workers),
+        "limit": limit,
+        "cancel_event": cancel_event,
+        "on_job_enriched": on_job_enriched,
+    }
+    if recovery_key:
+        drain_kwargs["recovery_key"] = recovery_key
     _run_discovery_enrichment_until_idle(
         discovery_done,
         result,
-        workers=max(1, workers),
-        limit=limit,
-        cancel_event=cancel_event,
-        on_job_enriched=on_job_enriched,
+        **drain_kwargs,
     )
     final = result or {"status": "ok", "passes": 0, "pending": 0}
 
@@ -2308,26 +2314,24 @@ def _run_enrich(
     cancel_event: threading.Event | None = None,
     reset_linkedin_candidates: bool = True,
     on_job_enriched: Callable[[JobId], None] | None = None,
+    recovery_key: str | None = None,
 ) -> dict:
     """Stage: Detail enrichment — scrape full descriptions and apply URLs."""
     if cancel_event is not None and cancel_event.is_set():
         raise TransientNetworkError("enrichment canceled before start")
     from jobctrl.enrichment.detail import run_enrichment
+    enrich_kwargs: dict[str, Any] = {
+        "limit": limit,
+        "workers": workers,
+        "reset_linkedin_candidates": reset_linkedin_candidates,
+        "on_job_enriched": on_job_enriched,
+    }
+    if recovery_key:
+        enrich_kwargs["recovery_key"] = recovery_key
     if cancel_event is None:
-        stats = run_enrichment(
-            limit=limit,
-            workers=workers,
-            reset_linkedin_candidates=reset_linkedin_candidates,
-            on_job_enriched=on_job_enriched,
-        )
+        stats = run_enrichment(**enrich_kwargs)
     else:
-        stats = run_enrichment(
-            limit=limit,
-            workers=workers,
-            cancel_event=cancel_event,
-            reset_linkedin_candidates=reset_linkedin_candidates,
-            on_job_enriched=on_job_enriched,
-        )
+        stats = run_enrichment(cancel_event=cancel_event, **enrich_kwargs)
     if cancel_event is not None and cancel_event.is_set():
         raise TransientNetworkError("enrichment canceled")
     site_errors = stats.get("site_errors") or {}
@@ -2649,6 +2653,18 @@ def _count_pending(stage: str, min_score: int = 7, retailor: bool = False) -> in
     return conn.execute(sql).fetchone()[0]
 
 
+def _count_retryable_enrichment_blocked() -> int:
+    """Count robots-blocked jobs eligible for one first-pass recheck."""
+
+    conn = get_connection()
+    return conn.execute(
+        f"SELECT COUNT(*) FROM jobs {db_module._ENRICHMENT_JOIN} "
+        f"{db_module._ACTIVE_STATE_JOIN} "
+        f"WHERE {db_module._ENRICHMENT_RETRYABLE_ROBOTS_BLOCKED} "
+        f"AND {db_module._NOT_CLOSED_ACTIVE_STATE}"
+    ).fetchone()[0]
+
+
 def _default_retryable(exc: Exception) -> bool:
     """Classify an uncaught enrichment-worker exception when it carries no code.
 
@@ -2668,6 +2684,7 @@ def _run_discovery_enrichment_until_idle(
     limit: int,
     cancel_event: threading.Event | None = None,
     on_job_enriched: Callable[[JobId], None] | None = None,
+    recovery_key: str | None = None,
 ) -> None:
     """Drain the detail-enrichment queue while discovery is still producing jobs.
 
@@ -2685,6 +2702,13 @@ def _run_discovery_enrichment_until_idle(
             if cancel_event is not None and cancel_event.is_set():
                 raise TransientNetworkError("discovery enrichment canceled")
             pending = _count_pending("enrich")
+            if pending <= 0 and passes == 0:
+                # Robots-blocked is deliberately not steady-state pending: if
+                # robots still disallows the URL, counting it forever would
+                # spin the drain. Admit it once at the start of a later
+                # workflow so an authenticated profile (or changed policy)
+                # gets a fresh chance.
+                pending = _count_retryable_enrichment_blocked()
             if pending <= 0:
                 if discovery_done.is_set():
                     drained: dict[str, Any] = {
@@ -2699,13 +2723,16 @@ def _run_discovery_enrichment_until_idle(
                 discovery_done.wait(timeout=_DISCOVERY_ENRICH_POLL_INTERVAL)
                 continue
 
-            enrichment_result = _run_enrich(
-                workers=workers,
-                limit=limit,
-                cancel_event=cancel_event,
-                reset_linkedin_candidates=(passes == 0),
-                on_job_enriched=on_job_enriched,
-            )
+            enrich_kwargs: dict[str, Any] = {
+                "workers": workers,
+                "limit": limit,
+                "cancel_event": cancel_event,
+                "reset_linkedin_candidates": passes == 0,
+                "on_job_enriched": on_job_enriched,
+            }
+            if recovery_key:
+                enrich_kwargs["recovery_key"] = recovery_key
+            enrichment_result = _run_enrich(**enrich_kwargs)
             passes += 1
             pass_site_errors = enrichment_result.get("site_errors") or {}
             if pass_site_errors:

--- a/workers/automation/src/jobctrl/pipeline/workflow.py
+++ b/workers/automation/src/jobctrl/pipeline/workflow.py
@@ -277,6 +277,7 @@ async def _execute_stage(stage: str, payload: JobPipelineWorkflowInput) -> Any:
             id=f"{workflow_id}-discover",
         )
     if stage == "enrich":
+        workflow_run_id = workflow.info().run_id
         return await workflow.execute_activity(
             enrich_activity,
             EnrichActivityInput(
@@ -288,6 +289,7 @@ async def _execute_stage(stage: str, payload: JobPipelineWorkflowInput) -> Any:
                 dry_run=payload.dry_run,
                 job_ids=_selected_job_ids(payload),
                 workflow_id=workflow_id,
+                workflow_run_id=workflow_run_id,
             ),
             start_to_close_timeout=_DEFAULT_TIMEOUT,
             heartbeat_timeout=_DEFAULT_HEARTBEAT_TIMEOUT,

--- a/workers/automation/tests/test_activity_enrich.py
+++ b/workers/automation/tests/test_activity_enrich.py
@@ -51,7 +51,13 @@ async def test_enrich_activity_invokes_observed_enrich_core():
             ):
                 output: EnrichActivityOutput = await env.client.execute_workflow(
                     _EnrichHarness.run,
-                    EnrichActivityInput(tenant_id="local", limit=5, workers=2),
+                    EnrichActivityInput(
+                        tenant_id="local",
+                        limit=5,
+                        workers=2,
+                        workflow_id="pipeline-workflow-1",
+                        workflow_run_id="pipeline-run-1",
+                    ),
                     id=f"enrich-wf-{uuid.uuid4()}",
                     task_queue=queue,
                 )
@@ -61,9 +67,51 @@ async def test_enrich_activity_invokes_observed_enrich_core():
     assert args[0] == "enrich"
     assert args[2]["workers"] == 2
     assert args[2]["limit"] == 5
+    assert args[2]["recovery_key"] == "pipeline-workflow-1:pipeline-run-1"
     assert kwargs["mode"] == "workflow"
     assert output.status == "ok"
     assert output.elapsed == pytest.approx(0.2)
+
+
+@pytest.mark.asyncio
+async def test_enrich_activity_reuses_recovery_key_across_activity_retries(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "jobctrl.infrastructure.temporal.runtime_guard.assert_activity_runtime",
+        lambda **_kwargs: None,
+    )
+
+    async def fake_run_blocking(fn, **_kwargs):
+        return fn()
+
+    monkeypatch.setattr(
+        "jobctrl.infrastructure.temporal.run_in_activity.run_blocking_with_heartbeat",
+        fake_run_blocking,
+    )
+    observed: list[str | None] = []
+
+    def fake_observed(_stage, _run, kwargs, **_options):
+        observed.append(kwargs.get("recovery_key"))
+        return {"status": "ok"}, 0.1, "ok"
+
+    monkeypatch.setattr(
+        "jobctrl.pipeline.runner._run_stage_observed",
+        fake_observed,
+    )
+    payload = EnrichActivityInput(
+        tenant_id="local",
+        workflow_id="pipeline-workflow-1",
+        workflow_run_id="pipeline-run-1",
+    )
+
+    await enrich_activity(payload)
+    await enrich_activity(payload)
+
+    assert observed == [
+        "pipeline-workflow-1:pipeline-run-1",
+        "pipeline-workflow-1:pipeline-run-1",
+    ]
 
 
 def test_selected_enrichment_uses_only_the_requested_v7_job_id_at_fetch_boundary(

--- a/workers/automation/tests/test_browser_capabilities.py
+++ b/workers/automation/tests/test_browser_capabilities.py
@@ -23,6 +23,8 @@ from jobctrl.browser_capabilities import (
     capability_profile_dir,
     browser_capability_config_path,
     copy_authenticated_linkedin_profile,
+    copy_detected_authenticated_linkedin_profile,
+    detect_default_browser_profile,
     detect_supported_browsers,
     disable_browser_capability,
     enable_detected_browser_capability,
@@ -110,6 +112,148 @@ def test_macos_candidate_order_prefers_google_chrome(monkeypatch: pytest.MonkeyP
     assert ids.index("chromium") > max(
         index for index, browser_id in enumerate(ids) if browser_id == "google-chrome"
     )
+
+
+def test_default_profile_detection_requires_a_supported_browser_and_standard_default_directory(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from jobctrl import browser_capabilities
+
+    profile_root = tmp_path / "Chrome"
+    (profile_root / "Default").mkdir(parents=True)
+    monkeypatch.setattr(
+        browser_capabilities,
+        "detect_supported_browsers",
+        lambda: (
+            DetectedBrowser(
+                "google-chrome",
+                "Google Chrome",
+                tmp_path / "Chrome executable",
+            ),
+        ),
+    )
+    monkeypatch.setattr(
+        browser_capabilities,
+        "_default_browser_profile_locations",
+        lambda browser_id: (profile_root,) if browser_id == "google-chrome" else (),
+    )
+
+    assert detect_default_browser_profile("google-chrome") == profile_root
+    assert detect_default_browser_profile("chromium") is None
+
+
+def test_detected_profile_copy_resolves_the_host_path_without_a_caller_path(
+    tmp_path: Path, browser_executable: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from jobctrl import browser_capabilities
+
+    profile_root = tmp_path / "Chrome profile"
+    default_profile = profile_root / "Default"
+    default_profile.mkdir(parents=True)
+    (default_profile / "Preferences").write_text("{}", encoding="utf-8")
+    (profile_root / "Local State").write_text(
+        json.dumps(
+            {
+                "os_crypt": {"encrypted_key": "required"},
+                "profile": {
+                    "last_used": "Profile 1",
+                    "info_cache": {
+                        "Default": {"name": "Default"},
+                        "Profile 1": {"name": "Private sibling"},
+                    },
+                },
+                "unrelated_root_metadata": {"account": "outside consent"},
+            }
+        ),
+        encoding="utf-8",
+    )
+    sibling_profile = profile_root / "Profile 1"
+    sibling_profile.mkdir()
+    (sibling_profile / "Cookies").write_text("sibling session", encoding="utf-8")
+    monkeypatch.setattr(
+        browser_capabilities,
+        "detect_supported_browsers",
+        lambda: (
+            DetectedBrowser("google-chrome", "Google Chrome", browser_executable),
+        ),
+    )
+    monkeypatch.setattr(
+        browser_capabilities,
+        "_default_browser_profile_locations",
+        lambda _browser_id: (profile_root,),
+    )
+    enable_system_browser_capability(
+        "authenticated-linkedin-browser", browser_executable, app_dir=tmp_path
+    )
+
+    destination = copy_detected_authenticated_linkedin_profile(
+        "google-chrome", consent=True, app_dir=tmp_path
+    )
+
+    assert (destination / "Default" / "Preferences").read_text(encoding="utf-8") == "{}"
+    copied_local_state = json.loads(
+        (destination / "Local State").read_text(encoding="utf-8")
+    )
+    assert copied_local_state == {
+        "os_crypt": {"encrypted_key": "required"},
+        "profile": {
+            "info_cache": {"Default": {"name": "Default"}},
+            "last_active_profiles": ["Default"],
+            "last_used": "Default",
+            "profiles_order": ["Default"],
+        },
+    }
+    assert not (destination / "Profile 1").exists()
+
+
+def test_detected_profile_metadata_is_sanitized_before_destination_publish(
+    tmp_path: Path,
+    browser_executable: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from jobctrl import browser_capabilities
+
+    profile_root = tmp_path / "Chrome profile"
+    (profile_root / "Default").mkdir(parents=True)
+    (profile_root / "Local State").write_text(
+        '{"profile":{"info_cache":{"Profile 1":{"name":"Private"}}}}',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        browser_capabilities,
+        "detect_supported_browsers",
+        lambda: (
+            DetectedBrowser("google-chrome", "Google Chrome", browser_executable),
+        ),
+    )
+    monkeypatch.setattr(
+        browser_capabilities,
+        "_default_browser_profile_locations",
+        lambda _browser_id: (profile_root,),
+    )
+    enable_system_browser_capability(
+        "authenticated-linkedin-browser",
+        browser_executable,
+        app_dir=tmp_path,
+    )
+    monkeypatch.setattr(
+        browser_capabilities,
+        "_sanitize_detected_default_local_state_at",
+        lambda _descriptor: (_ for _ in ()).throw(RuntimeError("interrupted")),
+    )
+
+    with pytest.raises(BrowserCapabilityError):
+        copy_detected_authenticated_linkedin_profile(
+            "google-chrome",
+            consent=True,
+            app_dir=tmp_path,
+        )
+
+    assert not capability_profile_dir(
+        "authenticated-linkedin-browser",
+        app_dir=tmp_path,
+    ).exists()
+    assert list((tmp_path / "browser-profiles").glob(".*.copy-*")) == []
 
 
 def test_explicit_detected_browser_id_is_resolved_and_enabled(

--- a/workers/automation/tests/test_browser_capabilities_rpc.py
+++ b/workers/automation/tests/test_browser_capabilities_rpc.py
@@ -42,13 +42,27 @@ def test_capability_list_never_returns_executable_paths(monkeypatch: pytest.Monk
             ),
         ),
     )
+    monkeypatch.setattr(
+        browser_capabilities,
+        "detect_default_browser_profile",
+        lambda browser_id: (
+            "/secret/detected/profile/path" if browser_id == "google-chrome" else None
+        ),
+    )
 
     result = handlers.browser_capabilities_list({})
 
-    assert result["detectedBrowsers"] == [{"id": "google-chrome", "label": "Google Chrome"}]
+    assert result["detectedBrowsers"] == [
+        {
+            "id": "google-chrome",
+            "label": "Google Chrome",
+            "defaultProfileAvailable": True,
+        }
+    ]
     assert "executable" not in json.dumps(result)
     assert "/secret/host/path" not in json.dumps(result)
     assert "/secret/detected/browser/path" not in json.dumps(result)
+    assert "/secret/detected/profile/path" not in json.dumps(result)
 
 
 def test_enable_accepts_an_explicit_detected_browser_id(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -161,6 +175,73 @@ def test_profile_copy_requires_separate_versioned_ui_consent(
     )
     assert called == [("/private/profile", True, "explicit-ui-v1")]
     assert "/private/profile" not in json.dumps(response)
+
+
+def test_profile_copy_accepts_a_detected_browser_without_crossing_a_host_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from jobctrl import browser_capabilities
+
+    called: list[tuple[str, bool, str]] = []
+    monkeypatch.setattr(
+        browser_capabilities,
+        "copy_detected_authenticated_linkedin_profile",
+        lambda browser_id, *, consent, consent_method: called.append(
+            (browser_id, consent, consent_method)
+        ),
+    )
+    monkeypatch.setattr(
+        browser_capabilities,
+        "list_browser_capabilities",
+        lambda: (
+            _status("core-browser", "ready"),
+            _status("auto-apply-browser"),
+            _status("authenticated-linkedin-browser", "ready"),
+        ),
+    )
+    monkeypatch.setattr(browser_capabilities, "detect_supported_browsers", lambda: ())
+
+    response = handlers.browser_profile_copy(
+        {
+            "detectedBrowserId": "google-chrome",
+            "consent": True,
+            "consentMethod": "explicit-ui-v1",
+        }
+    )
+
+    assert called == [("google-chrome", True, "explicit-ui-v1")]
+    assert "sourceProfilePath" not in json.dumps(response)
+
+
+def test_stale_detected_profile_error_does_not_expose_a_host_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from jobctrl import browser_capabilities
+
+    secret_path = "/secret/browser/profile/path"
+
+    def stale_profile(*_args, **_kwargs):
+        raise browser_capabilities.DetectedBrowserProfileUnavailableError(
+            f"missing: {secret_path}"
+        )
+
+    monkeypatch.setattr(
+        browser_capabilities,
+        "copy_detected_authenticated_linkedin_profile",
+        stale_profile,
+    )
+
+    with pytest.raises(Exception) as caught:
+        handlers.browser_profile_copy(
+            {
+                "detectedBrowserId": "google-chrome",
+                "consent": True,
+                "consentMethod": "explicit-ui-v1",
+            }
+        )
+
+    assert "no longer available" in str(caught.value)
+    assert secret_path not in str(caught.value)
 
 
 def test_disable_hot_revokes_without_returning_adopted_state(

--- a/workers/automation/tests/test_discover_reliability.py
+++ b/workers/automation/tests/test_discover_reliability.py
@@ -27,6 +27,7 @@ from jobctrl.discovery.activities import (
     _stage_failure_error,
 )
 from jobctrl.domain.errors import ConfigurationError, TransientNetworkError
+from jobctrl.domain.discovery.execution import DiscoveryExecutionRef
 from jobctrl.domain.identifiers import JobId
 from jobctrl.domain.tenant import LOCAL_TENANT
 from jobctrl.enrichment import detail
@@ -231,6 +232,54 @@ async def test_discovery_enrichment_activity_reports_partial_with_site_errors(
 
     assert result.status == "partial"
     assert result.site_errors == {"linkedin": {"error_class": "Error", "error_message": "boom"}}
+
+
+@pytest.mark.asyncio
+async def test_discovery_enrichment_activity_reuses_execution_key_across_activity_retries(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "jobctrl.infrastructure.temporal.runtime_guard.assert_activity_runtime",
+        lambda **_kwargs: None,
+    )
+
+    async def fake_run_blocking(fn, **_kwargs):
+        return fn()
+
+    monkeypatch.setattr(
+        "jobctrl.infrastructure.temporal.run_in_activity.run_blocking_with_heartbeat",
+        fake_run_blocking,
+    )
+    captured: list[str | None] = []
+
+    def fake_run_stage(**kwargs):
+        captured.append(kwargs.get("recovery_key"))
+        return {"status": "ok", "passes": 1, "pending": 0}
+
+    monkeypatch.setattr(
+        "jobctrl.pipeline.runner.run_discovery_enrichment_stage",
+        fake_run_stage,
+    )
+    monkeypatch.setattr("jobctrl.pipeline.runner.run_discovery_hygiene", lambda _label: 0)
+    monkeypatch.setattr(activities.activity, "heartbeat", lambda *_a, **_k: None)
+    monkeypatch.setattr(activities, "begin_pipeline_step_attempt", lambda _scope: None)
+    execution = DiscoveryExecutionRef(
+        tenant_id="local",
+        workflow_id="discover-workflow-1",
+        temporal_run_id="temporal-run-1",
+    )
+    payload = DiscoveryEnrichmentActivityInput(
+        tenant_id="local",
+        discovery_execution=execution,
+    )
+
+    await activities.discovery_enrichment_activity(payload)
+    await activities.discovery_enrichment_activity(payload)
+
+    assert captured == [
+        "discover-workflow-1:temporal-run-1",
+        "discover-workflow-1:temporal-run-1",
+    ]
 
 
 @pytest.mark.asyncio
@@ -768,6 +817,37 @@ def test_until_idle_resets_linkedin_candidates_only_on_first_pass(
 
     assert reset_flags == [True, False]
     assert result["status"] == "ok"
+
+
+def test_until_idle_runs_one_recovery_pass_for_retryable_robots_blocks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pending = iter([0, 0, 0])
+    monkeypatch.setattr(runner, "_count_pending", lambda *_a, **_k: next(pending))
+    monkeypatch.setattr(runner, "_count_retryable_enrichment_blocked", lambda: 4)
+
+    reset_flags: list[bool] = []
+
+    def fake_enrich(
+        *,
+        workers,
+        limit,
+        cancel_event=None,
+        reset_linkedin_candidates=True,
+        on_job_enriched=None,
+    ):
+        reset_flags.append(reset_linkedin_candidates)
+        return {"status": "ok"}
+
+    monkeypatch.setattr(runner, "_run_enrich", fake_enrich)
+
+    done = threading.Event()
+    done.set()
+    result: dict = {}
+    runner._run_discovery_enrichment_until_idle(done, result, workers=1, limit=0)
+
+    assert reset_flags == [True]
+    assert result == {"status": "ok", "passes": 1, "pending": 0}
 
 
 # ---------------------------------------------------------------------------

--- a/workers/automation/tests/test_enrichment_queue_selectors.py
+++ b/workers/automation/tests/test_enrichment_queue_selectors.py
@@ -90,6 +90,23 @@ def _mark_closed(conn: sqlite3.Connection, job_id: JobId, state: str = "removed"
     conn.commit()
 
 
+def _mark_robots_blocked(conn: sqlite3.Connection, job_id: JobId) -> None:
+    from jobctrl.state import ensure_job_stage_rows, set_stage_state
+
+    ensure_job_stage_rows(conn, job_id)
+    set_stage_state(
+        conn,
+        job_id,
+        "enrich",
+        "blocked",
+        error_code="ENRICH_ROBOTS_DISALLOWED",
+        error_message="robots.txt disallows this path",
+        retryable=True,
+        validate_transition=False,
+    )
+    conn.commit()
+
+
 def _save_enriched(
     conn: sqlite3.Connection,
     job_id: JobId,
@@ -346,6 +363,138 @@ def test_reset_job_stage_enrich_is_noop_when_no_aggregate_exists(
     # Queue selector still reports the job as pending (it always was).
     pending = get_jobs_by_stage(conn, "pending_detail")
     assert {row["url"] for row in pending} == {url}
+
+
+def test_run_detail_scraper_retries_robots_blocked_only_on_first_workflow_pass(
+    conn: sqlite3.Connection,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The production queue must reach the existing blocked-to-pending path."""
+
+    from jobctrl.enrichment import detail
+    url = "https://www.linkedin.com/jobs/view/robots-blocked"
+    job_id = _seed_discovered(conn, url)
+    _mark_robots_blocked(conn, job_id)
+
+    batches: list[list[tuple[str, str]]] = []
+
+    def fake_scrape_site_batch(
+        _conn: sqlite3.Connection | None,
+        _site: str,
+        jobs: list[tuple[str, str]],
+        **_kwargs: object,
+    ) -> dict:
+        batches.append(jobs)
+        return {
+            "processed": len(jobs),
+            "ok": 0,
+            "partial": 0,
+            "error": 0,
+            "tiers": {},
+        }
+
+    monkeypatch.setattr(detail, "scrape_site_batch", fake_scrape_site_batch)
+
+    detail._run_detail_scraper(
+        conn,
+        workers=1,
+        reset_linkedin_candidates=True,
+        recovery_key="workflow-1:run-1",
+    )
+    assert batches == [[(str(job_id), "Engineer")]]
+
+    batches.clear()
+    detail._run_detail_scraper(
+        conn,
+        workers=1,
+        reset_linkedin_candidates=True,
+        recovery_key="workflow-1:run-1",
+    )
+    assert batches == []
+
+    detail._run_detail_scraper(
+        conn,
+        workers=1,
+        reset_linkedin_candidates=True,
+        recovery_key="workflow-2:run-1",
+    )
+    assert batches == [[(str(job_id), "Engineer")]]
+
+
+def test_run_detail_scraper_prioritizes_blocked_retry_within_site_limit(
+    conn: sqlite3.Connection,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from jobctrl.enrichment import detail
+
+    _seed_discovered(conn, "https://example.com/jobs/ordinary-pending")
+    blocked_id = _seed_discovered(conn, "https://example.com/jobs/robots-blocked")
+    _mark_robots_blocked(conn, blocked_id)
+    batches: list[list[tuple[str, str]]] = []
+
+    def fake_scrape_site_batch(
+        _conn: sqlite3.Connection | None,
+        _site: str,
+        jobs: list[tuple[str, str]],
+        **_kwargs: object,
+    ) -> dict:
+        batches.append(jobs)
+        return {
+            "processed": len(jobs),
+            "ok": 0,
+            "partial": 0,
+            "error": 0,
+            "tiers": {},
+        }
+
+    monkeypatch.setattr(detail, "scrape_site_batch", fake_scrape_site_batch)
+
+    detail._run_detail_scraper(
+        conn,
+        max_per_site=1,
+        workers=1,
+        recovery_key="workflow-limit:run-1",
+    )
+
+    assert batches == [[(str(blocked_id), "Engineer")]]
+
+
+def test_run_detail_scraper_excludes_closed_robots_blocked_rows(
+    conn: sqlite3.Connection,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from jobctrl.enrichment import detail
+
+    active_id = _seed_discovered(conn, "https://example.com/jobs/active-pending")
+    closed_id = _seed_discovered(conn, "https://example.com/jobs/closed-blocked")
+    _mark_robots_blocked(conn, closed_id)
+    _mark_closed(conn, closed_id)
+    batches: list[list[tuple[str, str]]] = []
+
+    def fake_scrape_site_batch(
+        _conn: sqlite3.Connection | None,
+        _site: str,
+        jobs: list[tuple[str, str]],
+        **_kwargs: object,
+    ) -> dict:
+        batches.append(jobs)
+        return {
+            "processed": len(jobs),
+            "ok": 0,
+            "partial": 0,
+            "error": 0,
+            "tiers": {},
+        }
+
+    monkeypatch.setattr(detail, "scrape_site_batch", fake_scrape_site_batch)
+
+    detail._run_detail_scraper(
+        conn,
+        workers=1,
+        recovery_key="workflow-closed:run-1",
+    )
+
+    assert batches == [[(str(active_id), "Engineer")]]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- let users select an installed browser and copy its default authenticated profile with explicit consent, without manually pasting filesystem paths
- keep the manual profile-directory flow as an advanced fallback
- include recoverable robots-blocked rows in enrichment queue selection
- retry each recoverable blocked job once per workflow recovery key, using the authenticated browser path when available
- preserve accepted artifacts and durable workflow accounting while preventing retry loops
- document the browser/profile-copy and recovery contracts

## Validation

- `corepack pnpm --filter @jobctrl/api exec vitest run test/server.test.ts -t "lists detected browsers and forwards explicit browser and profile selections"` — 1 passed
- `corepack pnpm --filter @jobctrl/web exec vitest run src/contexts/operations/components/BrowserCapabilitiesPanel.test.tsx src/contexts/operations/hooks/useBrowserCapabilityMutations.test.ts src/contexts/pipeline/components/StageTimeline.test.tsx` — 17 passed
- focused Python browser/enrichment/discovery suite — 97 passed
- `corepack pnpm web:check`
- focused Ruff check — passed
- independent product QA: PASS, 0 findings
- independent review: PASS, 0 findings

## Stack

Root of the open stack. #740 is merged into `main`; this PR now targets `main`.

E2E execution was intentionally omitted at the user's request; the focused unit, API, workflow, type, review, and QA gates above cover the changed paths.