### PR TITLE
docs: clarify agent workflow guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,50 +1,39 @@
 ## Reference Routing
 
-Start with `docs/README.md`, the canonical documentation map, then read only the
-documents that own the behavior being changed. Do not scan the entire reference
-tree by default.
+Start with `docs/README.md`, the canonical documentation map, then read only the documents that own the behavior being changed. Do not scan the entire reference tree by default.
 
-- Product behavior, commands, runtime requirements, artifacts, or safety:
-  `README.md` and the relevant page under `docs/user/`.
-- Contributor workflow and validation: `docs/developer/README.md`,
-  `docs/local-development.md`, and `docs/local-reliability-qa.md`.
+- Product behavior, commands, runtime requirements, artifacts, or safety: `README.md` and the relevant page under `docs/user/`.
+- Contributor workflow and validation: `docs/developer/README.md`, `docs/local-development.md`, and `docs/local-reliability-qa.md`.
 - API routes, JSON-RPC, or SSE: `docs/local-ts-api.md`.
-- Architecture: the relevant page under `docs/architecture/`, plus
-  `docs/requirements.md` and `docs/decisions.md` when the contract or decision
-  itself changes.
-- Plans and status: the relevant active file under `docs/plans/`; use
-  `implemented/` only for historical context.
-- TypeScript scripts/dependencies: `package.json`; Python package metadata and
-  tooling: `workers/automation/pyproject.toml`.
+- Architecture: the relevant page under `docs/architecture/`, plus `docs/requirements.md` and `docs/decisions.md` when the contract or decision itself changes.
+- Plans and status: the relevant active file under `docs/plans/`; use `implemented/` only for historical context.
+- TypeScript scripts/dependencies: `package.json`; Python package metadata and tooling: `workers/automation/pyproject.toml`.
 
-Follow links beyond the owning document only when they are needed to resolve a
-specific contract, dependency, or QA risk.
+Follow links beyond the owning document only when they are needed to resolve a specific contract, dependency, or QA risk.
 
 ## How To Run The Project
 
-Use `pnpm dev` for the full local development stack. It stops previously tracked JobCtrl process trees for the selected components, then runs the Temporal dev server, TypeScript API, React/Vite web app, and JobCtrl Temporal worker in the foreground so supervised terminals keep the child processes alive. Keep the terminal session open while using the app and stop it with Ctrl-C. Use `pnpm dev:start` only when an explicitly detached background stack is desired in a normal shell.
+**Corepack pnpm requirement:** Always invoke pnpm through Corepack as `corepack pnpm ...`. Never run bare `pnpm ...`, even when a global pnpm binary is installed.
+
+Use `corepack pnpm dev` for the full local development stack. It stops previously tracked JobCtrl process trees for the selected components, then runs the Temporal dev server, TypeScript API, React/Vite web app, and JobCtrl Temporal worker in the foreground so supervised terminals keep the child processes alive. Keep the terminal session open while using the app and stop it with Ctrl-C. Use `corepack pnpm dev:start` only when an explicitly detached background stack is desired in a normal shell.
 
 Known local commands:
 
-- First-run setup: `scripts/install` (guided system checks, including standalone Corepack remediation, plus Node/Python dependencies and Playwright Chromium) or `pnpm dev:setup` (non-interactive dependency sync for already-provisioned machines), then `uv --project workers/automation run jobctrl init` and `uv --project workers/automation run jobctrl doctor`.
+- First-run setup: `scripts/install` (guided system checks, including standalone Corepack remediation, plus Node/Python dependencies and Playwright Chromium) or `corepack pnpm dev:setup` (non-interactive dependency sync for already-provisioned machines), then `uv --project workers/automation run jobctrl init` and `uv --project workers/automation run jobctrl doctor`.
 - Python CLI: `uv --project workers/automation run jobctrl doctor`, `uv --project workers/automation run jobctrl run`, or targeted `uv --project workers/automation run jobctrl <command>` after dependencies are installed. The full command tree (per-stage runs, `job <url>`, `backup`, `gmail-auth`, `migrate-resume-html`, …) is documented in `README.md` and `docs/user/`. Work-starting commands start Temporal workflows and require the Temporal dev server plus a running JobCtrl worker.
-- Full local stack: `pnpm dev` (attached foreground supervisor; preferred for agents and annotation).
-- Detached local stack: `pnpm dev:start`, then `pnpm dev:status`, `pnpm dev:logs <name>`, and `pnpm dev:stop`.
+- Full local stack: `corepack pnpm dev` (attached foreground supervisor; preferred for agents and annotation).
+- Detached local stack: `corepack pnpm dev:start`, then `corepack pnpm dev:status`, `corepack pnpm dev:logs <name>`, and `corepack pnpm dev:stop`.
 - Temporal worker: `uv --project workers/automation run jobctrl worker` (long-lived workflow worker; needs `temporal server start-dev` running).
-- TypeScript API: `pnpm api:dev`.
-- Web app: `pnpm web:dev`.
-- Web preview after build: `pnpm web:preview`.
-- Docs site (VitePress over `docs/`): `pnpm docs:dev`, `pnpm docs:build` (fails on dead internal links), `pnpm docs:preview`.
+- TypeScript API: `corepack pnpm api:dev`.
+- Web app: `corepack pnpm web:dev`.
+- Web preview after build: `corepack pnpm web:preview`.
+- Docs site (VitePress over `docs/`): `corepack pnpm docs:dev`, `corepack pnpm docs:build` (fails on dead internal links), `corepack pnpm docs:preview`.
 
 Do not run auto-apply, browser submission, destructive profile/database actions, or commands that submit applications unless the user explicitly asks for that behavior.
 
 ## Build, Test, And Lint Commands
 
-Choose the smallest command set from `docs/local-reliability-qa.md` that proves
-the touched behavior. Reserve `pnpm check` and `pnpm test` for cross-stack,
-release/high-risk, or explicitly plan-required work. Frontend changes must run
-their separate web unit/type/E2E/Storybook checks when the touched risk calls
-for them; the aggregate does not include those suites.
+Choose the smallest command set from `docs/local-reliability-qa.md` that proves the touched behavior. Reserve `corepack pnpm check` and `corepack pnpm test` for cross-stack, release/high-risk, or explicitly plan-required work. Frontend changes must run their separate web unit/type/E2E/Storybook checks when the touched risk calls for them; the aggregate does not include those suites.
 
 When changing behavior, add or update unit tests for the changed logic. When changing user-facing behavior, local API behavior, browser flows, or UI/UX, include a QA stage that exercises the product path, not only unit tests.
 
@@ -52,12 +41,7 @@ Any major UI/UX regression found by the human must become a QA regression test o
 
 ## Documentation Requirements
 
-Standalone PRs that add meaningful capabilities must update their owning docs.
-For an approved feature stack that is not released between phases, defer
-canonical product docs to the final PR; intermediate PRs update only plan or
-contract material needed for review. Phases released independently or changing
-active high-risk paths document immediately. Internal refactors, tests, and
-behavior-neutral fixes do not need doc churn.
+Standalone PRs that add meaningful capabilities must update their owning docs. For an approved feature stack that is not released between phases, defer canonical product docs to the final PR; intermediate PRs update only plan or contract material needed for review. Phases released independently or changing active high-risk paths document immediately. Internal refactors, tests, and behavior-neutral fixes do not need doc churn.
 
 When a doc update is warranted:
 
@@ -77,27 +61,21 @@ When a doc update is warranted:
 | Python package metadata, CLI entry point, Python version, optional dev dependencies, or Ruff config | `workers/automation/pyproject.toml` |
 | Agent workflow rules, PR expectations, repo-specific constraints, or automation guidance | `AGENTS.md` |
 
-If multiple surfaces changed, update every owning document. Keep edits narrow
-and explain any intentional stacked deferral in the PR body.
+If multiple surfaces changed, update every owning document. Keep edits narrow and explain any intentional stacked deferral in the PR body.
 
 ## Agent Behavior
 
-- Do not resolve material ambiguity by assumption. Ask for clarification when the goal, scope, constraints, or expected validation are unclear.
-- If a reasonable assumption is low-risk and needed to make progress, state it explicitly before acting.
+### Special Declaration: Always Ask When In Doubt
+
+- **Always ask a clarifying question for any doubt, however slight.** This applies to issue interpretation, intended behavior, implementation choices, scope, constraints, acceptance criteria, and validation. Never resolve uncertainty by assumption, even when the assumption appears low-risk.
+- Before starting any implementation, test, refactor, cleanup, documentation, tooling, or QA action, perform a necessity check: is this action essential to completing the user's stated request? An action is essential only when the user explicitly requested it, the requested behavior strictly requires it, or an applicable repository safety or validation rule requires it.
+- If an action is not essential, or if there is any doubt about its necessity, pause and ask the user whether they want it before doing it. This explicitly includes E2E tests, adjacent fixes, and extra improvements.
+- Do not begin optional work while waiting for an answer. Best practice, convenience, or possible future value does not constitute user authorization.
+
 - Treat payloads, local generated artifacts, and job/application data as sensitive. Do not expose secrets, profile data, API keys, resumes, cover letters, generated PDFs, browser profiles, SQLite databases, or application logs unless the user explicitly requests them.
-- Treat owner-only launch/growth strategy, campaign sequencing, targeting,
-  unpublished messaging, and private traffic or conversion analysis as private.
-  Never commit those materials to this public repository; commit only
-  owner-approved public copy/assets and factual product documentation.
+- Treat owner-only launch/growth strategy, campaign sequencing, targeting, unpublished messaging, and private traffic or conversion analysis as private. Never commit those materials to this public repository; commit only owner-approved public copy/assets and factual product documentation.
 - Prefer repo-grounded answers and edits over generic advice. Check the referenced docs and current code before making architectural claims.
-- **Subagent spawning:** Use subagents only for genuinely independent work or
-  for the review/QA gates required by the validation tiers below. Do not add
-  coordination overhead to work that is faster to complete directly.
-  Within one task, create at most one agent of each required type/role and
-  reuse that agent via follow-up turns for related work, fixes, and reruns.
-  Replace an agent only when it is unavailable/terminated or the new work is
-  genuinely a different task; never use a replacement to obtain another
-  opinion or avoid continuity.
+- **Subagent spawning:** Use subagents only for genuinely independent work or for the review/QA gates required by the validation tiers below. Do not add coordination overhead to work that is faster to complete directly. Within one task, create at most one agent of each required type/role and reuse that agent via follow-up turns for related work, fixes, and reruns. Replace an agent only when it is unavailable/terminated or the new work is genuinely a different task; never use a replacement to obtain another opinion or avoid continuity.
 
 ### Root-Cause And Auditability Discipline
 
@@ -121,49 +99,34 @@ Before claiming "fixed" on these surfaces, add or update a regression fixture th
 - PR descriptions must clearly and unambiguously explain what changed, why it changed, and how it was validated.
 - Keep changes as small as possible while still fully satisfying the goal.
 - Use stacked PRs when functionality builds on prior functionality or when a large change should be broken into reviewable steps.
-- Every implementation task must run off `main` in a dedicated worktree or
-  task branch. If the current task already has a dedicated worktree, use it;
-  do not create a nested/replacement worktree or refresh `main` solely for
-  compliance.
+- Every implementation task must run off `main` in a dedicated worktree or task branch. If the current task already has a dedicated worktree, use it; do not create a nested/replacement worktree or refresh `main` solely for compliance.
 - Never edit code on `main` or leave `main` dirty.
-- Resolve the base before creating a worktree: use updated `main` for standalone
-  work, or the explicit parent branch/commit for an approved stacked change.
-  Fetch the relevant remote ref and verify that chosen base is current.
-- Before coding, confirm the current branch/worktree. If you are on `main`, stop
-  and create or switch to the correct worktree first.
+- Resolve the base before creating a worktree: use updated `main` for standalone work, or the explicit parent branch/commit for an approved stacked change. Fetch the relevant remote ref and verify that chosen base is current.
+- Before coding, confirm the current branch/worktree. If you are on `main`, stop and create or switch to the correct worktree first.
 - Do not remove existing compatibility behavior unless the assigned goal explicitly authorizes that breaking change.
 
 When a new worktree is actually needed:
 
 1. Ensure no unrelated dirty changes block setup.
-2. Choose `<base-ref>`: updated `main` for standalone work, or the explicit
-   parent branch/commit for an approved stack.
-3. Fetch the relevant remote ref. If `<base-ref>` is `main`, fast-forward the
-   main checkout with `git pull --ff-only origin main`.
-4. Create the task worktree with
-   `git worktree add <worktree-path> -b <branch-name> <base-ref>`.
+2. Choose `<base-ref>`: updated `main` for standalone work, or the explicit parent branch/commit for an approved stack.
+3. Fetch the relevant remote ref. If `<base-ref>` is `main`, fast-forward the main checkout with `git pull --ff-only origin main`.
+4. Create the task worktree with `git worktree add <worktree-path> -b <branch-name> <base-ref>`.
 5. Do all coding, testing, commits, and PR work from that task worktree.
 
 ## Constraints And Do-Not Rules
 
 - Never edit code in the main branch.
 - Never leave `main` dirty.
-- Never create a worktree from stale `main` or a stale stack parent; fetch and
-  verify the selected base first.
+- Never create a worktree from stale `main` or a stale stack parent; fetch and verify the selected base first.
 - Never mark work complete while Blocker or High PR review findings remain.
 - Never mark work complete while Blocker or High QA findings remain.
-- Never skip required QA. For an approved unreleased stack, run it once on the
-  cumulative final branch after canonical docs are complete.
+- Never skip required QA. For an approved unreleased stack, run it once on the cumulative final branch after canonical docs are complete.
 - Never broaden scope silently. If the correct fix exceeds the assigned scope, stop and raise the scope issue.
 - Never commit local secrets, generated user data, resumes, cover letters, PDFs, browser profiles, worker directories, logs, or SQLite databases.
 
 ## What Done Means And How To Verify Work
 
-Done means the user's instruction or goal has been fully achieved, the changeset
-is as small as practical, and verification is proportional to its actual risk.
-Use the lowest tier that fully covers the change; an active plan or explicit user
-instruction may raise the tier. Never lower the tier for security, privacy, data
-integrity, destructive actions, migrations, releases, or application submission.
+Done means the user's instruction or goal has been fully achieved, the changeset is as small as practical, and verification is proportional to its actual risk. Use the lowest tier that fully covers the change; an active plan or explicit user instruction may raise the tier. Never lower the tier for security, privacy, data integrity, destructive actions, migrations, releases, or application submission.
 
 | Tier | Applies to | Minimum verification | Independent gates |
 | --- | --- | --- | --- |
@@ -172,21 +135,11 @@ integrity, destructive actions, migrations, releases, or application submission.
 | 2 — Product | User-facing UI, CLI, API, browser flow, integration, or workflow behavior | Tier 1 plus the smallest product-path QA that proves the change | `reviewer`/`pr-reviewer` and `qa` must return `Gate: PASS` |
 | 3 — High risk | Security/privacy controls, credentials, user data, apply/submission, destructive actions, migrations, release/distribution, or cross-stack critical invariants | Relevant full matrix, regression fixture, and product/operational proof | `reviewer`/`pr-reviewer` and `qa` must return `Gate: PASS`; fix and rerun until no Blocker/High remains |
 
-If Tier 3 groundwork changes only contracts or fixtures and no executable
-product/operational path exists yet, do not fabricate product QA. Require one
-independent review plus the focused safety checks, record why QA is deferred,
-and make QA mandatory in the first phase that exposes the executable path.
+If Tier 3 groundwork changes only contracts or fixtures and no executable product/operational path exists yet, do not fabricate product QA. Require one independent review plus the focused safety checks, record why QA is deferred, and make QA mandatory in the first phase that exposes the executable path.
 
-For an approved stack whose intermediate phases are not released independently,
-each intermediate PR runs focused checks and one review. The final PR updates
-canonical docs first, then runs cumulative product QA and any final high-risk
-gate across the whole stack. A phase that changes an active high-risk path or is
-released independently follows its normal tier immediately.
+For an approved stack whose intermediate phases are not released independently, each intermediate PR runs focused checks and one review. The final PR updates canonical docs first, then runs cumulative product QA and any final high-risk gate across the whole stack. A phase that changes an active high-risk path or is released independently follows its normal tier immediately.
 
-Run independent gates once after implementation and focused verification. Rerun
-a failed gate with the same reviewer/QA agent after addressing its Blocker/High
-findings; do not repeat passing gates for cosmetic edits or unresolved Medium/
-Low observations unless the edit could affect the verified behavior.
+Run independent gates once after implementation and focused verification. Rerun a failed gate with the same reviewer/QA agent after addressing its Blocker/High findings; do not repeat passing gates for cosmetic edits or unresolved Medium/ Low observations unless the edit could affect the verified behavior.
 
 Before calling work done:
 
@@ -194,13 +147,10 @@ Before calling work done:
 2. Confirm the goal and acceptance criteria are satisfied.
 3. Classify the validation tier and run its focused commands.
 4. Run only the independent gates required by that tier.
-5. Report exact commands and results, the tier, unresolved Medium/Low risks, any
-   skipped verification with a concrete reason, and the PR number when a PR
-   exists or was requested.
+5. Report exact commands and results, the tier, unresolved Medium/Low risks, any skipped verification with a concrete reason, and the PR number when a PR exists or was requested.
 
 If any required verification cannot be run, the final status is not done. Report it as blocked or partially verified and explain what remains.
 
 ## Scoped Instructions
 
-Changes under `apps/web/` must also follow `apps/web/AGENTS.md`. Read those
-frontend-specific rules only for work that touches the web application.
+Changes under `apps/web/` must also follow `apps/web/AGENTS.md`. Read those frontend-specific rules only for work that touches the web application.


### PR DESCRIPTION
## Summary

- require every pnpm command to be invoked through Corepack
- require clarification whenever implementation, scope, validation, or necessity is uncertain
- require a necessity check before optional tests, refactors, cleanup, documentation, tooling, or QA
- remove hard-wrapped prose throughout AGENTS.md so editors handle visual wrapping

## Validation

- `git diff --cached --check`

## Stack

Depends on #741. This final editorial PR targets `fix/browser-enrichment-recovery` so its diff contains only AGENTS.md.