### PR TITLE
chore(deps): upgrade Codex SDK

### DIFF
--- a/packaging/distribution/provider-packs.lock.json
+++ b/packaging/distribution/provider-packs.lock.json
@@ -163,7 +163,7 @@
     },
     {
       "id": "codex-provider-runtime",
-      "version": "0.137.0a4",
+      "version": "0.144.4",
       "owner": "OpenAI",
       "source": "https://pypi.org/project/openai-codex-cli-bin/",
       "license": "Apache-2.0",
@@ -176,17 +176,17 @@
       "wheels": [
         {
           "package": "openai-codex",
-          "version": "0.1.0b3",
-          "url": "https://files.pythonhosted.org/packages/d7/ef/f77037d9ccde80a688a17a06aea5a56813ad9c365d49b3f1c7913422af8b/openai_codex-0.1.0b3-py3-none-any.whl",
-          "sha256": "8d1f9d346667aeecb435c6a45d0edb3f016187276ec452cf8094d813896276c4",
-          "sizeBytes": 65639
+          "version": "0.144.4",
+          "url": "https://files.pythonhosted.org/packages/17/35/5d2a13e38d91278019f18757ac10426d2649b7ec6f031818c792f64559e9/openai_codex-0.144.4-py3-none-any.whl",
+          "sha256": "de1513a6e94b9a8d7728a3b74298bc1469428ade10ba0ef2d5db47dd1cb606f5",
+          "sizeBytes": 76244
         },
         {
           "package": "openai-codex-cli-bin",
-          "version": "0.137.0a4",
-          "url": "https://files.pythonhosted.org/packages/92/8f/d1a5f8c87176e00ef6a85798794f4530f5eb04e5a1a13468b5b3c3a361f9/openai_codex_cli_bin-0.137.0a4-py3-none-macosx_11_0_arm64.whl",
-          "sha256": "3d0f0bc5becc88c61952fbfa9bd792ac9d74fa78b3a6bd40f545b612048b07eb",
-          "sizeBytes": 83924479
+          "version": "0.144.4",
+          "url": "https://files.pythonhosted.org/packages/65/eb/64c180514a2cc3e2500e486813f5a8d7f7e349342e9bebd78d99ddd9791a/openai_codex_cli_bin-0.144.4-py3-none-macosx_11_0_arm64.whl",
+          "sha256": "05db505a9c7f020f58b70837a94e00d32a50086986c267bcc44ea97b573d4a05",
+          "sizeBytes": 116474758
         }
       ]
     },

--- a/scripts/distribution-build.test.mjs
+++ b/scripts/distribution-build.test.mjs
@@ -588,7 +588,7 @@ test("fixture builds are bytewise reproducible in different directories", async 
     measurementStatus: "unavailable-fixture",
     packCount: 3,
     wheelCount: 46,
-    downloadBytes: 197697242,
+    downloadBytes: 230258126,
     installedBytes: null,
     fileCount: null,
     treeSha256: null,

--- a/scripts/distribution-provider-lock.mjs
+++ b/scripts/distribution-provider-lock.mjs
@@ -20,7 +20,7 @@ const PACKS = [
   },
   {
     id: "codex-provider-runtime",
-    version: "0.137.0a4",
+    version: "0.144.4",
     owner: "OpenAI",
     source: "https://pypi.org/project/openai-codex-cli-bin/",
     license: "Apache-2.0",

--- a/workers/automation/pyproject.toml
+++ b/workers/automation/pyproject.toml
@@ -61,8 +61,8 @@ dev = [
 providers = [
     "claude-agent-sdk==0.2.115",
     "mcp>=1.28.1",
-    "openai-codex==0.1.0b3",
-    "openai-codex-cli-bin==0.137.0a4",
+    "openai-codex==0.144.4",
+    "openai-codex-cli-bin==0.144.4",
     "google-antigravity==0.1.2",
     "pyasn1>=0.6.4",
 ]
@@ -73,8 +73,8 @@ providers = [
 [dependency-groups]
 provider-runtime = [
     "claude-agent-sdk==0.2.115",
-    "openai-codex==0.1.0b3",
-    "openai-codex-cli-bin==0.137.0a4",
+    "openai-codex==0.144.4",
+    "openai-codex-cli-bin==0.144.4",
     "google-antigravity==0.1.2",
 ]
 release-build = ["build==1.4.3", "hatchling==1.29.0"]
@@ -123,11 +123,9 @@ pythonVersion = "3.11"
 [tool.uv]
 default-groups = ["provider-runtime"]
 
-# The workspace dependency cutoff intentionally freezes the broad dependency
-# graph. Keep it as a fixed project value, rather than a caller-provided
-# relative `UV_EXCLUDE_NEWER` value, so locked source runtimes and release
-# workflows resolve against the same graph. Provider runtimes and the audited
-# JobStreaming integration move independently, so admit only their reviewed
-# releases without moving the global cutoff for everything else.
-exclude-newer = "2026-07-09T19:15:43.240437Z"
+# Delay broad dependency updates by seven days so new releases have a short
+# community-vetting window. uv records the resolved timestamp and P7D span in
+# the lockfile whenever the graph is refreshed. Provider runtimes and the
+# audited JobStreaming integration retain their explicit reviewed cutoffs.
+exclude-newer = "7 days"
 exclude-newer-package = { "google-antigravity" = "2026-06-04T21:19:27Z", "claude-agent-sdk" = "2026-07-10T00:00:00Z", "jobstreaming" = "2026-07-18T00:00:00Z" }

--- a/workers/automation/uv.lock
+++ b/workers/automation/uv.lock
@@ -14,7 +14,8 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-07-09T19:15:43.240437Z"
+exclude-newer = "2026-07-28T20:43:30.561404Z"
+exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
 claude-agent-sdk = "2026-07-10T00:00:00Z"
@@ -655,8 +656,8 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.24" },
     { name = "jobstreaming", specifier = "==0.0.2" },
     { name = "mcp", marker = "extra == 'providers'", specifier = ">=1.28.1" },
-    { name = "openai-codex", marker = "extra == 'providers'", specifier = "==0.1.0b3" },
-    { name = "openai-codex-cli-bin", marker = "extra == 'providers'", specifier = "==0.137.0a4" },
+    { name = "openai-codex", marker = "extra == 'providers'", specifier = "==0.144.4" },
+    { name = "openai-codex-cli-bin", marker = "extra == 'providers'", specifier = "==0.144.4" },
     { name = "opentelemetry-api", specifier = ">=1.27" },
     { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.27" },
     { name = "opentelemetry-instrumentation-httpx", specifier = ">=0.48b0" },
@@ -684,8 +685,8 @@ provides-extras = ["dev", "providers"]
 provider-runtime = [
     { name = "claude-agent-sdk", specifier = "==0.2.115" },
     { name = "google-antigravity", specifier = "==0.1.2" },
-    { name = "openai-codex", specifier = "==0.1.0b3" },
-    { name = "openai-codex-cli-bin", specifier = "==0.137.0a4" },
+    { name = "openai-codex", specifier = "==0.144.4" },
+    { name = "openai-codex-cli-bin", specifier = "==0.144.4" },
 ]
 release-build = [
     { name = "build", specifier = "==1.4.3" },
@@ -833,30 +834,30 @@ wheels = [
 
 [[package]]
 name = "openai-codex"
-version = "0.1.0b3"
+version = "0.144.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "openai-codex-cli-bin" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ae/1c/1e5e8b83ea72164d32b1f4e67fc703c8b83591f498a7aaf96f39d352b453/openai_codex-0.1.0b3.tar.gz", hash = "sha256:b76b7afe97953ac65648e9b8ca116b5ff273de91086549bd7ec88037cdc16cab", size = 58995, upload-time = "2026-06-03T19:17:34.707Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/7d/4b999b0ddd05c22d83cc2e879c95e1e92e3b7808b58ac561c4ea91fca1c4/openai_codex-0.144.4.tar.gz", hash = "sha256:91c63a7cb213441569f130e593386b34657ab9e726ae88af255f0ecb8de08ea5", size = 68324, upload-time = "2026-07-17T23:42:17.013Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d7/ef/f77037d9ccde80a688a17a06aea5a56813ad9c365d49b3f1c7913422af8b/openai_codex-0.1.0b3-py3-none-any.whl", hash = "sha256:8d1f9d346667aeecb435c6a45d0edb3f016187276ec452cf8094d813896276c4", size = 65639, upload-time = "2026-06-03T19:17:33.208Z" },
+    { url = "https://files.pythonhosted.org/packages/17/35/5d2a13e38d91278019f18757ac10426d2649b7ec6f031818c792f64559e9/openai_codex-0.144.4-py3-none-any.whl", hash = "sha256:de1513a6e94b9a8d7728a3b74298bc1469428ade10ba0ef2d5db47dd1cb606f5", size = 76244, upload-time = "2026-07-17T23:42:15.658Z" },
 ]
 
 [[package]]
 name = "openai-codex-cli-bin"
-version = "0.137.0a4"
+version = "0.144.4"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bd/60/af73ef1676cd477fa83ed4b889bf3b57c63c47dd87025b2cc4262793cff6/openai_codex_cli_bin-0.137.0a4-py3-none-macosx_10_9_x86_64.whl", hash = "sha256:b33c3917e0b58d527ee11a11a78ad390f7d8e6aa25577dd21665ab3c8bf5cf9a", size = 94300191, upload-time = "2026-06-03T18:44:36.312Z" },
-    { url = "https://files.pythonhosted.org/packages/92/8f/d1a5f8c87176e00ef6a85798794f4530f5eb04e5a1a13468b5b3c3a361f9/openai_codex_cli_bin-0.137.0a4-py3-none-macosx_11_0_arm64.whl", hash = "sha256:3d0f0bc5becc88c61952fbfa9bd792ac9d74fa78b3a6bd40f545b612048b07eb", size = 83924479, upload-time = "2026-06-03T18:44:40.854Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/3c/fc00bcdc0c302208317d5eb1d0bfaab3024f351cd0121400f19baa6b19aa/openai_codex_cli_bin-0.137.0a4-py3-none-manylinux_2_17_aarch64.whl", hash = "sha256:2f1656339e2736868c4cce59f6d9e5c633879123687169b03b1137d42bf2c11a", size = 83363315, upload-time = "2026-06-03T18:44:44.851Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/09/39362e944ebeb12fcbfb86881fbb4dd6e806f77f7541c1f1f993bb9351a0/openai_codex_cli_bin-0.137.0a4-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:6454f838d44c56c1ed07a29b391fa412785e5dd2ffd06db0b62e62478c19bb64", size = 90611239, upload-time = "2026-06-03T18:44:49.338Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/38/87b1247fdfe95cddce7f7fe8331d6843cf037e14292c0f5004e23247133b/openai_codex_cli_bin-0.137.0a4-py3-none-musllinux_1_1_aarch64.whl", hash = "sha256:f5ae7401d00c65d56a75d9645d7bf87d809566a12d238e4b2a8b328a02f2316e", size = 83363315, upload-time = "2026-06-03T18:44:53.428Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/c4/3c693ad07e587f6b3a28128c417f2e831d81a40cdbd85c0e5f0f36aaff82/openai_codex_cli_bin-0.137.0a4-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:3dcec1e649448be498d6e7ec0e1f71dca83efa76063d90890dafb41e987069b7", size = 90611238, upload-time = "2026-06-03T18:44:57.612Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/26/81e037066b9b8d312a6f9e09015e452ce17630d5ab88e02a4c1d9503e4e8/openai_codex_cli_bin-0.137.0a4-py3-none-win_amd64.whl", hash = "sha256:9e13bf68e18e36bd3a0efd51213281c83e9f6ec22bdb7a45bd2e0211822733a9", size = 94744969, upload-time = "2026-06-03T18:45:02.23Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/a3/952bc2a5d62373a51fea161effe3b338b3417c2f6e65fe467ed91b205e2b/openai_codex_cli_bin-0.137.0a4-py3-none-win_arm64.whl", hash = "sha256:5ec4303ca2dcb5f838e0de3ca7f44050b6bcdd41d281a178c3a1420a985a515d", size = 86963504, upload-time = "2026-06-03T18:45:07.131Z" },
+    { url = "https://files.pythonhosted.org/packages/79/30/7e457c007a32aa7333a78438a9f532504c3b77a1ea57e7808855712c2c0f/openai_codex_cli_bin-0.144.4-py3-none-macosx_10_9_x86_64.whl", hash = "sha256:4d587d152d5f0aa25f21ded4d08aac5150da48639b29fc3e57b2a8b413d06903", size = 126851183, upload-time = "2026-07-15T00:14:00.171Z" },
+    { url = "https://files.pythonhosted.org/packages/65/eb/64c180514a2cc3e2500e486813f5a8d7f7e349342e9bebd78d99ddd9791a/openai_codex_cli_bin-0.144.4-py3-none-macosx_11_0_arm64.whl", hash = "sha256:05db505a9c7f020f58b70837a94e00d32a50086986c267bcc44ea97b573d4a05", size = 116474758, upload-time = "2026-07-15T00:14:08.177Z" },
+    { url = "https://files.pythonhosted.org/packages/85/34/921ab692c7ed140941a91e39b84c6deafddb45072793f3a5f6dcbf86f59a/openai_codex_cli_bin-0.144.4-py3-none-manylinux_2_17_aarch64.whl", hash = "sha256:cd4bb31b8a477a3adba22139c8c493693fa5292ba21e86eef08ace3e96c41294", size = 119437596, upload-time = "2026-07-15T00:14:17.418Z" },
+    { url = "https://files.pythonhosted.org/packages/25/62/39e630cf8b7b2e2444a5a6669235a6cd88004869a25bb7f3f629ed35638c/openai_codex_cli_bin-0.144.4-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:4106229c38f37245c3eea8d904426afd45b8bf19831765715647f5402f757c06", size = 128817757, upload-time = "2026-07-15T00:14:30.539Z" },
+    { url = "https://files.pythonhosted.org/packages/23/24/318f91a95baaff845307e529d138d42a7202e6bd0e626556058eab3dead5/openai_codex_cli_bin-0.144.4-py3-none-musllinux_1_1_aarch64.whl", hash = "sha256:d2d3fada11731938e3d3e3660819d5324b7f92e825a0ed5aede63100b36ffc9a", size = 119437594, upload-time = "2026-07-15T00:14:39.327Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/a0/65e6fd3a6fba52639937801d9ce517b0c48026458723bb9f08eb07a1dd35/openai_codex_cli_bin-0.144.4-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:70fb62ed7755e332dd8b00ed48e22ee16df10f4a977335039e237cd330490df3", size = 128817755, upload-time = "2026-07-15T00:14:47.849Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/8a/3ab5fc97352e8f780d472c8dd6d7504d6a670cd7dede106d461ac1171999/openai_codex_cli_bin-0.144.4-py3-none-win_amd64.whl", hash = "sha256:56e142974467332f1f669b89f2636e06b3ada09413512abb2f24c33b4a4f59fc", size = 140595092, upload-time = "2026-07-15T00:14:58.484Z" },
+    { url = "https://files.pythonhosted.org/packages/70/1a/3aa52ab8f89e0f596b6eea835e3f3494697da51917d3231f5f48f92e2bcb/openai_codex_cli_bin-0.144.4-py3-none-win_arm64.whl", hash = "sha256:2ad01058db7181323ae7c6217e560702e38c4f107595b99ab1d0abc9f184890a", size = 130665105, upload-time = "2026-07-15T00:15:08.861Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What changed\n\n- upgrade openai-codex from 0.1.0b3 to 0.144.4\n- upgrade the matching openai-codex-cli-bin runtime from 0.137.0a4 to 0.144.4\n- express the dependency cooldown as a relative seven-day window\n- regenerate the lockfile in a clean environment so it records P7D\n\n## Why\n\nThe repository was pinned to the prerelease SDK and runtime. This moves the provider integration to the current stable, mutually matched release while retaining a reproducible dependency cooldown.\n\n## Validation\n\n- independent review: PASS, no findings\n- locked imports report both packages at 0.144.4\n- 73 focused Codex/provider tests passed\n- clean-environment uv lock --check passed with UV_EXCLUDE_NEWER unset\n- git diff --check passed\n\nThe full matrix is intentionally left to GitHub Actions.\n\n## Stack\n\nDepends on #743.