### PR TITLE
fix(browser): let users choose Chrome profiles

### DIFF
--- a/apps/api/test/server.test.ts
+++ b/apps/api/test/server.test.ts
@@ -10689,8 +10689,23 @@ describe("local TypeScript API", () => {
         },
       ],
       detectedBrowsers: [
-        { id: "google-chrome", label: "Google Chrome", defaultProfileAvailable: true },
-        { id: "chromium", label: "Chromium", defaultProfileAvailable: false },
+        {
+          id: "google-chrome",
+          label: "Google Chrome",
+          defaultProfileAvailable: true,
+          profiles: [
+            {
+              id: "profile-0123456789abcdef0123456789abcdef",
+              label: "Signed in",
+            },
+          ],
+        },
+        {
+          id: "chromium",
+          label: "Chromium",
+          defaultProfileAvailable: false,
+          profiles: [],
+        },
       ],
     };
     const call = vi.fn<JsonRpcDispatcher["call"]>(async () => ({
@@ -10719,6 +10734,7 @@ describe("local TypeScript API", () => {
       url: "/v1/browser-capabilities/authenticated-linkedin-browser/profile-copy",
       payload: {
         detectedBrowserId: "google-chrome",
+        detectedProfileId: "profile-0123456789abcdef0123456789abcdef",
         consent: true,
         consentMethod: "explicit-ui-v1",
       },
@@ -10740,6 +10756,7 @@ describe("local TypeScript API", () => {
     });
     expect(call).toHaveBeenNthCalledWith(4, "browser_profile_copy", {
       detectedBrowserId: "google-chrome",
+      detectedProfileId: "profile-0123456789abcdef0123456789abcdef",
       consent: true,
       consentMethod: "explicit-ui-v1",
     });

--- a/apps/web/e2e/tests/browser-capabilities-layout.spec.ts
+++ b/apps/web/e2e/tests/browser-capabilities-layout.spec.ts
@@ -7,8 +7,19 @@ const browserCapabilitiesResponse = {
       id: "google-chrome",
       label: "Google Chrome",
       defaultProfileAvailable: true,
+      profiles: [
+        {
+          id: "profile-0123456789abcdef0123456789abcdef",
+          label: "Signed in",
+        },
+      ],
     },
-    { id: "chromium", label: "Chromium", defaultProfileAvailable: false },
+    {
+      id: "chromium",
+      label: "Chromium",
+      defaultProfileAvailable: false,
+      profiles: [],
+    },
   ],
   capabilities: [
     {

--- a/apps/web/e2e/tests/docs-screenshots.spec.ts
+++ b/apps/web/e2e/tests/docs-screenshots.spec.ts
@@ -103,8 +103,19 @@ const syntheticBrowserCapabilitiesResponse = {
       id: "google-chrome",
       label: "Google Chrome",
       defaultProfileAvailable: true,
+      profiles: [
+        {
+          id: "profile-0123456789abcdef0123456789abcdef",
+          label: "Signed in",
+        },
+      ],
     },
-    { id: "chromium", label: "Chromium", defaultProfileAvailable: false },
+    {
+      id: "chromium",
+      label: "Chromium",
+      defaultProfileAvailable: false,
+      profiles: [],
+    },
   ],
   capabilities: [
     {

--- a/apps/web/src/contexts/operations/components/BrowserCapabilitiesPanel.test.tsx
+++ b/apps/web/src/contexts/operations/components/BrowserCapabilitiesPanel.test.tsx
@@ -101,6 +101,16 @@ describe("<BrowserCapabilitiesPanel>", () => {
           id: "google-chrome" as const,
           label: "Google Chrome",
           defaultProfileAvailable: true,
+          profiles: [
+            {
+              id: "profile-0123456789abcdef0123456789abcdef",
+              label: "Default",
+            },
+            {
+              id: "profile-fedcba9876543210fedcba9876543210",
+              label: "E",
+            },
+          ],
         },
       ],
       capabilities: [
@@ -145,11 +155,15 @@ describe("<BrowserCapabilitiesPanel>", () => {
     expect(
       screen.queryByLabelText("Existing browser user-data directory"),
     ).not.toBeInTheDocument();
+    const profileSelect = screen.getByLabelText("Detected browser profile");
+    await user.click(profileSelect);
+    await user.click(await screen.findByRole("option", { name: "Google Chrome · E" }));
+    expect(profileSelect).toHaveTextContent("Google Chrome · E");
     const consent = screen.getByRole("checkbox", {
       name: /I explicitly consent to copy this profile/i,
     });
     const copy = screen.getByRole("button", {
-      name: "Copy Google Chrome profile",
+      name: "Copy E profile",
     });
 
     expect(copy).toBeDisabled();
@@ -162,6 +176,7 @@ describe("<BrowserCapabilitiesPanel>", () => {
     );
     expect(copyLinkedInBrowserProfile).toHaveBeenCalledWith({
       detectedBrowserId: "google-chrome",
+      detectedProfileId: "profile-fedcba9876543210fedcba9876543210",
       consent: true,
       consentMethod: "explicit-ui-v1",
     });

--- a/apps/web/src/contexts/operations/components/BrowserCapabilitiesPanel.tsx
+++ b/apps/web/src/contexts/operations/components/BrowserCapabilitiesPanel.tsx
@@ -2,6 +2,7 @@ import type {
   BrowserCapabilityId,
   BrowserCapabilityItem,
   DetectedBrowserId,
+  DetectedBrowserProfileId,
 } from "@jobctrl/contracts";
 import { Fragment, useState } from "react";
 
@@ -76,8 +77,8 @@ export function BrowserCapabilitiesPanel() {
   const [manualPathErrors, setManualPathErrors] = useState<
     Record<string, string>
   >({});
-  const [selectedProfileBrowserId, setSelectedProfileBrowserId] =
-    useState<DetectedBrowserId | null>(null);
+  const [selectedProfileId, setSelectedProfileId] =
+    useState<DetectedBrowserProfileId | null>(null);
   const [sourceProfilePath, setSourceProfilePath] = useState("");
   const [profileConsent, setProfileConsent] = useState(false);
   const [message, setMessage] = useState("");
@@ -132,6 +133,7 @@ export function BrowserCapabilitiesPanel() {
 
   async function copyDetectedLinkedInProfile(
     detectedBrowserId: DetectedBrowserId,
+    detectedProfileId: DetectedBrowserProfileId,
     label: string,
   ) {
     if (!profileConsent) {
@@ -142,12 +144,11 @@ export function BrowserCapabilitiesPanel() {
     try {
       await copyProfile.mutateAsync({
         detectedBrowserId,
+        detectedProfileId,
         consent: true,
         consentMethod: "explicit-ui-v1",
       });
-      setMessage(
-        `${label}'s default profile was copied into JobCtrl-owned storage.`,
-      );
+      setMessage(`${label} was copied into JobCtrl-owned storage.`);
     } catch {
       setMessage("The detected browser profile could not be copied.");
     }
@@ -196,18 +197,20 @@ export function BrowserCapabilitiesPanel() {
       label: browser.label,
       value: browser.id,
     }));
-    const detectedProfileBrowsers = detectedBrowsers.filter(
-      (browser) => browser.defaultProfileAvailable,
+    const detectedProfiles = detectedBrowsers.flatMap((browser) =>
+      browser.profiles.map((profile) => ({
+        ...profile,
+        browserId: browser.id,
+        displayLabel: `${browser.label} · ${profile.label}`,
+      })),
     );
-    const selectedProfileBrowser =
-      detectedProfileBrowsers.find(
-        (browser) => browser.id === selectedProfileBrowserId,
-      ) ??
-      detectedProfileBrowsers[0] ??
+    const selectedProfile =
+      detectedProfiles.find((profile) => profile.id === selectedProfileId) ??
+      detectedProfiles[0] ??
       null;
-    const profileSelectItems = detectedProfileBrowsers.map((browser) => ({
-      label: `${browser.label} · Default`,
-      value: browser.id,
+    const profileSelectItems = detectedProfiles.map((profile) => ({
+      label: profile.displayLabel,
+      value: profile.id,
     }));
     const manualError = manualPathErrors[capabilityId] ?? "";
 
@@ -378,18 +381,18 @@ export function BrowserCapabilitiesPanel() {
             <FieldSet>
               <FieldLegend>Separate authenticated profile copy</FieldLegend>
               <FieldGroup>
-                {selectedProfileBrowser ? (
+                {selectedProfile ? (
                   <Field>
                     <FieldLabel htmlFor="linkedin-detected-profile">
                       Detected browser profile
                     </FieldLabel>
                     <Select
                       items={profileSelectItems}
-                      value={selectedProfileBrowser.id}
+                      value={selectedProfile.id}
                       disabled={demo || copyProfile.isPending}
                       onValueChange={(value) => {
-                        if (value === "google-chrome" || value === "chromium") {
-                          setSelectedProfileBrowserId(value);
+                        if (value?.startsWith("profile-")) {
+                          setSelectedProfileId(value as DetectedBrowserProfileId);
                         }
                       }}
                     >
@@ -417,8 +420,8 @@ export function BrowserCapabilitiesPanel() {
                   </Field>
                 ) : (
                   <FieldDescription>
-                    No standard Chrome or Chromium default profile was detected.
-                    Use the advanced path only for a non-standard profile location.
+                    No standard Chrome or Chromium profile was detected. Use
+                    the advanced path only for a non-standard profile location.
                   </FieldDescription>
                 )}
                 <Field orientation="horizontal">
@@ -433,22 +436,23 @@ export function BrowserCapabilitiesPanel() {
                     storage.
                   </FieldLabel>
                 </Field>
-                {selectedProfileBrowser ? (
+                {selectedProfile ? (
                   <Button
                     className="w-fit max-w-xs whitespace-normal"
                     type="button"
                     disabled={copyProfile.isPending || !profileConsent}
                     onClick={() =>
                       void copyDetectedLinkedInProfile(
-                        selectedProfileBrowser.id,
-                        selectedProfileBrowser.label,
+                        selectedProfile.browserId,
+                        selectedProfile.id,
+                        selectedProfile.displayLabel,
                       )
                     }
                   >
-                    Copy {selectedProfileBrowser.label} profile
+                    Copy {selectedProfile.label} profile
                   </Button>
                 ) : null}
-                <Collapsible defaultOpen={!selectedProfileBrowser}>
+                <Collapsible defaultOpen={!selectedProfile}>
                   <CollapsibleTrigger
                     render={<Button variant="ghost" size="sm" type="button" />}
                   >

--- a/apps/web/src/contexts/operations/hooks/useBrowserCapabilityMutations.test.ts
+++ b/apps/web/src/contexts/operations/hooks/useBrowserCapabilityMutations.test.ts
@@ -15,6 +15,12 @@ const initial = {
       id: "google-chrome" as const,
       label: "Google Chrome",
       defaultProfileAvailable: true,
+      profiles: [
+        {
+          id: "profile-0123456789abcdef0123456789abcdef",
+          label: "Signed in",
+        },
+      ],
     },
   ],
   capabilities: [

--- a/apps/web/src/contexts/pipeline/components/StageTimeline.test.tsx
+++ b/apps/web/src/contexts/pipeline/components/StageTimeline.test.tsx
@@ -40,6 +40,12 @@ function readyAuthenticatedLinkedInBrowser(): BrowserCapabilitiesResponse {
         id: "google-chrome",
         label: "Google Chrome",
         defaultProfileAvailable: true,
+        profiles: [
+          {
+            id: "profile-0123456789abcdef0123456789abcdef",
+            label: "Signed in",
+          },
+        ],
       },
     ],
     capabilities: [

--- a/apps/web/src/test/testPorts.ts
+++ b/apps/web/src/test/testPorts.ts
@@ -282,6 +282,12 @@ export function buildTestPorts(overrides: BuildTestPortsOptions = {}): Ports {
           id: "google-chrome" as const,
           label: "Google Chrome",
           defaultProfileAvailable: true,
+          profiles: [
+            {
+              id: "profile-0123456789abcdef0123456789abcdef",
+              label: "Signed in",
+            },
+          ],
         },
       ],
       capabilities: [

--- a/docs/api/complete-contract.md
+++ b/docs/api/complete-contract.md
@@ -1470,11 +1470,12 @@ table; this keeps Dashboard lightweight without imposing an event-history cap.
   `auto-apply-browser`, and `authenticated-linkedin-browser` state without
   returning a saved executable or source-profile path. It also returns
   `detectedBrowsers: Array<{ id: "google-chrome" | "chromium", label: string,
-  defaultProfileAvailable: boolean }>` for currently detected supported
-  installations. Detection checks only the standard default-profile directory;
-  it does not read profile contents, launch, adopt, copy, or persist the browser,
-  and no filesystem path crosses the RPC/API boundary. The core browser is
-  managed and read-only.
+  defaultProfileAvailable: boolean, profiles: Array<{ id: string, label: string }> }>`
+  for currently detected supported installations. Profile IDs are opaque and
+  transient; labels come only from bounded Chrome display metadata. Detection
+  does not read cookies or session contents, launch, adopt, copy, or persist the
+  browser, and no filesystem path crosses the RPC/API boundary. The core
+  browser is managed and read-only.
   `POST /v1/browser-capabilities/:capabilityId/enable` accepts exactly one of
   `{ detectedBrowserId }` or `{ executablePath }`; the strict union rejects
   both/neither. The path is write-only. The detected-ID arm resolves the
@@ -1482,11 +1483,14 @@ table; this keeps Dashboard lightweight without imposing an event-history cap.
   closed with sanitized `400 browser_capability_failed` without adopting any
   fallback. The matching `/disable` route applies
   immediately. `POST /v1/browser-capabilities/authenticated-linkedin-browser/profile-copy`
-  requires explicit consent and accepts exactly one of `{ detectedBrowserId }`
-  or `{ sourceProfilePath }`. The detected-ID arm resolves the standard default
-  profile again at mutation time and copies only `Default` plus sanitized root
-  metadata required by Chrome; sibling profile directories and metadata are
-  excluded. The manual path is cleared after the request; JobCtrl never
+  requires explicit consent and accepts an explicit
+  `{ detectedBrowserId, detectedProfileId }`, the compatible browser-only
+  Default selection, or `{ sourceProfilePath }`. The explicit detected-profile
+  arm resolves both opaque IDs again at mutation time, copies only that profile
+  plus sanitized root metadata required by Chrome, normalizes it to the owned
+  `Default` directory, and safely replaces a prior consented copy only after the
+  new copy has staged successfully. Sibling profile directories and metadata
+  are excluded. The manual path is cleared after the request; JobCtrl never
   returns, logs, or persists it. A detected candidate becomes adopted only
   through the separate explicit enable mutation.
 - Authenticated extension routes under `/v1/extension/*` require `Authorization:

--- a/docs/api/profile-and-settings.md
+++ b/docs/api/profile-and-settings.md
@@ -48,10 +48,10 @@ enter the system. They do not hold provider credentials or raw feed contents.
 | `POST /v1/providers/codex/verify` | Explicitly validate and import a reusable normal Codex CLI `auth.json` once when isolated auth is absent, then verify isolated auth without a model call. |
 | `GET /v1/extension/pairing-token` | Read the local extension pairing state. |
 | `POST /v1/extension/pairing-token/rotate` | Rotate the token immediately and disconnect existing extension clients. |
-| `GET /v1/browser-capabilities` | Read managed/optional capability states plus transient supported-browser candidates as ID/label/profile-availability records; no local path is returned or adopted. |
+| `GET /v1/browser-capabilities` | Read managed/optional capability states plus transient supported-browser candidates and their selectable profiles as opaque IDs and safe labels; no local path is returned or adopted. |
 | `POST /v1/browser-capabilities/:capabilityId/enable` | Explicitly adopt exactly one transient `detectedBrowserId` or one write-only `executablePath` for an optional capability. |
 | `POST /v1/browser-capabilities/:capabilityId/disable` | Disable an optional capability immediately. |
-| `POST /v1/browser-capabilities/authenticated-linkedin-browser/profile-copy` | Copy exactly one detected default profile by opaque browser ID or one write-only manual source path, only with explicit consent. |
+| `POST /v1/browser-capabilities/authenticated-linkedin-browser/profile-copy` | Copy exactly one explicitly selected detected profile by opaque browser/profile IDs, retain the legacy browser-only Default arm, or accept one write-only manual source path; every arm requires explicit consent. |
 
 Credential responses expose enough state for the UI to show whether a provider
 is configured, but do not return stored secret material. Guided provider
@@ -65,9 +65,10 @@ never overwrites JobCtrl's existing isolated auth or changes the normal Codex
 home. It invokes the same copy-once behavior retained by setup and generation.
 
 Browser detection is read-only discovery, not consent. The list response may
-offer supported Chrome/Chromium candidates as bounded `{ id, label }` values;
-the executable path stays inside the worker and nothing is launched, copied,
-or persisted. Enablement is a strict XOR input: send either
+offer supported Chrome/Chromium candidates as bounded `{ id, label, profiles }`
+values. Each profile contains only an opaque transient ID and Chrome's bounded
+display label; executable, user-data, and profile paths stay inside the worker,
+and nothing is launched, copied, or persisted. Enablement is a strict XOR input: send either
 `{ detectedBrowserId }` or `{ executablePath }`, never both or neither. A
 detected ID is resolved again at mutation time. If it is stale or no longer
 available, enablement fails closed with `400 browser_capability_failed` and

--- a/docs/local-reliability-qa.md
+++ b/docs/local-reliability-qa.md
@@ -327,7 +327,14 @@ not launch, adopt, or persist a browser. Enabling requires an explicit detected
 selection or one advanced manual path, re-resolves a detected selection at
 mutation time, and fails closed when the installation disappeared. Profile-copy
 consent remains a separate affirmative action; capability enablement must not
-imply it.
+imply it. With Default plus at least one `Profile N` fixture, prove Settings
+renders every safe Chrome display label, forwards the chosen opaque profile ID,
+copies only that profile as the isolated owned Default, and never returns a host
+path. Replacing a prior consented copy must stage the new profile first, preserve
+the old copy on pre-publish or post-publish state-validation failure, and exclude
+every sibling profile. Concurrent replacements must serialize through publish,
+state validation, rollback, and cleanup so a stale failure cannot overwrite a
+newer successful selection.
 
 <a id="scoring-policy-eval-gate"></a>
 <a id="saved-views-smoke"></a>

--- a/docs/user/enrichment-and-extraction.md
+++ b/docs/user/enrichment-and-extraction.md
@@ -72,9 +72,12 @@ origin as provenance. Protected or login-walled pages stay on a manual path
 unless they use the explicit owner-authenticated LinkedIn recovery below.
 
 After the authenticated-LinkedIn browser capability is explicitly enabled and
-the user separately consents to copy an existing LinkedIn profile, JobCtrl may
-use that owned session to recover the full posting and external application
-URL. The anonymous `robots.txt` verdict is not applied to this
+the user selects one detected Chrome profile and separately consents to copy
+it, JobCtrl may use that isolated owned session to recover the full posting and
+external application URL. Settings shows Chrome's profile display labels while
+keeping executable and profile paths private; choosing another profile stages
+the new copy before replacing the prior JobCtrl-owned copy. The anonymous
+`robots.txt` verdict is not applied to this
 owner-authenticated request. Public-destination validation, per-host pacing,
 the shared run request budget, and audit history remain enforced. Recovery
 stops before the application form and cannot submit an application; capability

--- a/packages/contracts/src/schemas.ts
+++ b/packages/contracts/src/schemas.ts
@@ -4918,11 +4918,25 @@ export type BrowserCapabilityItem = z.infer<typeof BrowserCapabilityItemSchema>;
 export const DetectedBrowserIds = ["google-chrome", "chromium"] as const;
 export type DetectedBrowserId = (typeof DetectedBrowserIds)[number];
 
+export const DetectedBrowserProfileIdSchema = z
+  .string()
+  .regex(/^profile-[a-f0-9]{32}$/);
+export type DetectedBrowserProfileId = z.infer<typeof DetectedBrowserProfileIdSchema>;
+
+export const DetectedBrowserProfileSchema = z
+  .object({
+    id: DetectedBrowserProfileIdSchema,
+    label: z.string().trim().min(1).max(80),
+  })
+  .strict();
+export type DetectedBrowserProfile = z.infer<typeof DetectedBrowserProfileSchema>;
+
 export const DetectedBrowserSchema = z
   .object({
     id: z.enum(DetectedBrowserIds),
     label: z.string().trim().min(1).max(80),
     defaultProfileAvailable: z.boolean(),
+    profiles: z.array(DetectedBrowserProfileSchema).max(64),
   })
   .strict();
 export type DetectedBrowser = z.infer<typeof DetectedBrowserSchema>;
@@ -4957,6 +4971,12 @@ export type BrowserCapabilityEnableRequest = z.infer<typeof BrowserCapabilityEna
 
 export const BrowserProfileCopyRequestSchema = z
   .union([
+    z.object({
+      detectedBrowserId: z.enum(DetectedBrowserIds),
+      detectedProfileId: DetectedBrowserProfileIdSchema,
+      consent: z.literal(true),
+      consentMethod: z.literal("explicit-ui-v1"),
+    }).strict(),
     z.object({
       detectedBrowserId: z.enum(DetectedBrowserIds),
       consent: z.literal(true),

--- a/workers/automation/src/jobctrl/browser_capabilities.py
+++ b/workers/automation/src/jobctrl/browser_capabilities.py
@@ -8,6 +8,7 @@ implicitly adopted merely because it can be discovered on the host.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import secrets
@@ -15,7 +16,7 @@ import shutil
 import stat
 import subprocess
 import sys
-from contextlib import contextmanager
+from contextlib import ExitStack, contextmanager
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -30,6 +31,7 @@ _CORE_BROWSER = "core-browser"
 _OPTIONAL_SYSTEM_BROWSER_CAPABILITIES = frozenset(
     {"auto-apply-browser", "authenticated-linkedin-browser"}
 )
+_PROFILE_COPY_LOCK_NAME = ".linkedin-profile-copy.lock"
 _PROFILE_COPY_SKIP = frozenset(
     {
         "ShaderCache",
@@ -75,7 +77,7 @@ class DetectedBrowserUnavailableError(BrowserCapabilityError):
 
 
 class DetectedBrowserProfileUnavailableError(BrowserCapabilityError):
-    """Raised when a detected browser's default profile is no longer available."""
+    """Raised when an explicitly selected detected profile is no longer available."""
 
 
 class BrowserProfileConsentRequiredError(BrowserCapabilityError):
@@ -121,6 +123,17 @@ class DetectedBrowser:
     id: Literal["google-chrome", "chromium"]
     label: str
     executable: Path
+
+
+@dataclass(frozen=True)
+class DetectedBrowserProfile:
+    """One transient browser profile; host paths stay worker-local."""
+
+    id: str
+    browser_id: Literal["google-chrome", "chromium"]
+    label: str
+    user_data_root: Path
+    directory_name: str
 
 
 def browser_capability_config_path(*, app_dir: Path | None = None) -> Path:
@@ -520,21 +533,174 @@ def _default_browser_profile_locations(browser_id: str) -> tuple[Path, ...]:
     return (Path.home() / relative,)
 
 
-def detect_default_browser_profile(browser_id: str) -> Path | None:
-    """Resolve a standard default-profile source without returning it over RPC."""
+def _detected_profile_id(browser_id: str, root: Path, directory_name: str) -> str:
+    """Build a stable opaque ID without returning a host path or directory name."""
 
-    if not any(browser.id == browser_id for browser in detect_supported_browsers()):
-        return None
+    identity = "\0".join(
+        (
+            browser_id,
+            os.path.abspath(os.fspath(root.expanduser())),
+            directory_name,
+        )
+    )
+    digest = hashlib.sha256(identity.encode("utf-8")).hexdigest()[:32]
+    return f"profile-{digest}"
+
+
+def _safe_profile_label(value: object, fallback: str) -> str:
+    if not isinstance(value, str):
+        return fallback
+    label = "".join(character for character in value.strip() if character.isprintable())
+    if not label:
+        return fallback
+    result: list[str] = []
+    utf16_units = 0
+    for character in label:
+        character_units = 2 if ord(character) > 0xFFFF else 1
+        if utf16_units + character_units > 80:
+            break
+        result.append(character)
+        utf16_units += character_units
+    return "".join(result) or fallback
+
+
+def _profile_metadata(root: Path) -> tuple[dict[str, object], tuple[str, ...]]:
+    """Read bounded Chrome display metadata without following a Local State symlink."""
+
+    root_descriptor = -1
+    source_file = -1
+    try:
+        root_descriptor = _open_directory_no_symlinks(root)
+        status = os.stat("Local State", dir_fd=root_descriptor, follow_symlinks=False)
+    except OSError:
+        if root_descriptor >= 0:
+            os.close(root_descriptor)
+        return {}, ()
+    if not stat.S_ISREG(status.st_mode) or status.st_size > 16 * 1024 * 1024:
+        os.close(root_descriptor)
+        return {}, ()
+    try:
+        source_file = os.open(
+            "Local State",
+            os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0),
+            dir_fd=root_descriptor,
+        )
+        if not _same_entry(status, os.fstat(source_file)):
+            return {}, ()
+        chunks: list[bytes] = []
+        size = 0
+        while chunk := os.read(source_file, 1024 * 1024):
+            size += len(chunk)
+            if size > 16 * 1024 * 1024:
+                return {}, ()
+            chunks.append(chunk)
+        payload = json.loads(b"".join(chunks).decode("utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return {}, ()
+    finally:
+        if source_file >= 0:
+            os.close(source_file)
+        if root_descriptor >= 0:
+            os.close(root_descriptor)
+    if not isinstance(payload, dict):
+        return {}, ()
+    profile = payload.get("profile")
+    if not isinstance(profile, dict):
+        return {}, ()
+    info_cache = profile.get("info_cache")
+    metadata = info_cache if isinstance(info_cache, dict) else {}
+    ordered_names: list[str] = []
+    last_used = profile.get("last_used")
+    if isinstance(last_used, str):
+        ordered_names.append(last_used)
+    profiles_order = profile.get("profiles_order")
+    if isinstance(profiles_order, list):
+        ordered_names.extend(name for name in profiles_order if isinstance(name, str))
+    ordered_names.extend(name for name in metadata if isinstance(name, str))
+    return metadata, tuple(dict.fromkeys(ordered_names))
+
+
+def _is_profile_directory_name(name: str) -> bool:
+    return (
+        name == "Default"
+        or name.startswith("Profile ")
+    ) and name not in {"Guest Profile", "System Profile"}
+
+
+def detect_browser_profiles(browser_id: str) -> tuple[DetectedBrowserProfile, ...]:
+    """Discover selectable profiles without adopting, launching, or returning paths."""
+
+    browser = next(
+        (candidate for candidate in detect_supported_browsers() if candidate.id == browser_id),
+        None,
+    )
+    if browser is None:
+        return ()
+    detected: list[DetectedBrowserProfile] = []
     for root in _default_browser_profile_locations(browser_id):
-        default_profile = root / "Default"
-        if (
-            root.is_dir()
-            and not root.is_symlink()
-            and default_profile.is_dir()
-            and not default_profile.is_symlink()
-        ):
-            return root
-    return None
+        if not root.is_dir() or root.is_symlink():
+            continue
+        metadata, metadata_order = _profile_metadata(root)
+        names = list(metadata_order)
+        try:
+            names.extend(
+                entry.name
+                for entry in sorted(root.iterdir(), key=lambda item: item.name)
+                if _is_profile_directory_name(entry.name)
+            )
+        except OSError:
+            continue
+        for directory_name in dict.fromkeys(names):
+            if not _is_profile_directory_name(directory_name):
+                continue
+            profile_directory = root / directory_name
+            if not profile_directory.is_dir() or profile_directory.is_symlink():
+                continue
+            record = metadata.get(directory_name)
+            display_name = record.get("name") if isinstance(record, dict) else None
+            fallback = "Default" if directory_name == "Default" else directory_name
+            detected.append(
+                DetectedBrowserProfile(
+                    id=_detected_profile_id(browser.id, root, directory_name),
+                    browser_id=browser.id,
+                    label=_safe_profile_label(display_name, fallback),
+                    user_data_root=root,
+                    directory_name=directory_name,
+                )
+            )
+
+    label_counts: dict[str, int] = {}
+    for profile in detected:
+        label_counts[profile.label] = label_counts.get(profile.label, 0) + 1
+    return tuple(
+        profile
+        if label_counts[profile.label] == 1
+        else DetectedBrowserProfile(
+            id=profile.id,
+            browser_id=profile.browser_id,
+            label=_safe_profile_label(
+                f"{profile.label} ({profile.directory_name})",
+                profile.label,
+            ),
+            user_data_root=profile.user_data_root,
+            directory_name=profile.directory_name,
+        )
+        for profile in detected
+    )
+
+
+def detect_default_browser_profile(browser_id: str) -> Path | None:
+    """Resolve the legacy default-profile source without returning it over RPC."""
+
+    profile = next(
+        (
+            candidate
+            for candidate in detect_browser_profiles(browser_id)
+            if candidate.directory_name == "Default"
+        ),
+        None,
+    )
+    return profile.user_data_root if profile is not None else None
 
 
 def browser_capability_status(
@@ -774,7 +940,10 @@ def copy_authenticated_linkedin_profile(
     app_dir: Path | None = None,
     catalog: BrowserCapabilityCatalog | None = None,
     _root_entries: frozenset[str] | None = None,
+    _root_entry_renames: dict[str, str] | None = None,
     _sanitize_default_local_state: bool = False,
+    _sanitize_profile_name: str = "Default",
+    _replace_existing: bool = False,
 ) -> Path:
     """Copy a profile only after separate affirmative consent.
 
@@ -790,6 +959,37 @@ def copy_authenticated_linkedin_profile(
         raise BrowserProfileConsentRequiredError("browser profile-copy consent must be explicit")
     resolved_catalog = catalog or load_browser_capability_catalog()
 
+    # The dedicated OS lock has no stale timeout, so a large profile copy cannot
+    # overlap another request or be mistaken for an abandoned lock. Config
+    # transactions remain short and retain their normal stale-lock behavior.
+    with _browser_profile_copy_lock(app_dir=app_dir):
+        return _copy_authenticated_linkedin_profile_locked(
+            source_profile,
+            consent_method=consent_method,
+            app_dir=app_dir,
+            catalog=resolved_catalog,
+            root_entries=_root_entries,
+            root_entry_renames=_root_entry_renames,
+            sanitize_default_local_state=_sanitize_default_local_state,
+            sanitize_profile_name=_sanitize_profile_name,
+            replace_existing=_replace_existing,
+        )
+
+
+def _copy_authenticated_linkedin_profile_locked(
+    source_profile: Path | str,
+    *,
+    consent_method: str,
+    app_dir: Path | None,
+    catalog: BrowserCapabilityCatalog,
+    root_entries: frozenset[str] | None,
+    root_entry_renames: dict[str, str] | None,
+    sanitize_default_local_state: bool,
+    sanitize_profile_name: str,
+    replace_existing: bool,
+) -> Path:
+    """Copy and commit one profile while the dedicated copy lock is held."""
+
     # A profile can be large enough that copying it takes longer than the
     # config-lock stale threshold.  Keep the config transaction limited to
     # inspecting and later recording capability state; the no-follow copy has
@@ -800,7 +1000,7 @@ def copy_authenticated_linkedin_profile(
     destination = capability_profile_dir("authenticated-linkedin-browser", app_dir=app_dir)
     _owned_profile_path(destination, app_dir=app_dir, require_existing=False)
 
-    with _browser_capability_state_transaction(app_dir=app_dir, catalog=resolved_catalog) as state:
+    with _browser_capability_state_transaction(app_dir=app_dir, catalog=catalog) as state:
         record = _record_for(state, "authenticated-linkedin-browser")
         if record is None or not record["enabled"] or record["systemBrowser"] is None:
             raise BrowserCapabilityError("enable authenticated-linkedin-browser before copying a browser profile")
@@ -822,17 +1022,22 @@ def copy_authenticated_linkedin_profile(
                 raise BrowserCapabilityError(
                     "an existing JobCtrl browser-profile destination cannot be adopted without a prior explicit copy"
                 )
-            return _owned_profile_path(destination, app_dir=app_dir, require_existing=True)
+            _owned_profile_path(destination, app_dir=app_dir, require_existing=True)
+            if not replace_existing:
+                return destination
 
-    _copy_profile_tree(
+    replaced_profile_name = _copy_profile_tree(
         source,
         destination,
         app_dir=app_dir,
-        root_entries=_root_entries,
-        sanitize_default_local_state=_sanitize_default_local_state,
+        root_entries=root_entries,
+        root_entry_renames=root_entry_renames,
+        sanitize_default_local_state=sanitize_default_local_state,
+        sanitize_profile_name=sanitize_profile_name,
+        replace_existing=replace_existing,
     )
     try:
-        with _browser_capability_state_transaction(app_dir=app_dir, catalog=resolved_catalog) as state:
+        with _browser_capability_state_transaction(app_dir=app_dir, catalog=catalog) as state:
             record = _record_for(state, "authenticated-linkedin-browser")
             if (
                 record is None
@@ -851,28 +1056,55 @@ def copy_authenticated_linkedin_profile(
                 "method": consent_method,
             }
     except Exception:
-        _discard_owned_profile_copy(destination, app_dir=app_dir)
+        if replaced_profile_name is None:
+            _discard_owned_profile_copy(destination, app_dir=app_dir)
+        else:
+            _restore_replaced_profile_copy(
+                destination,
+                replaced_profile_name,
+                app_dir=app_dir,
+            )
         raise
+    if replaced_profile_name is not None:
+        _discard_replaced_profile_copy(
+            destination,
+            replaced_profile_name,
+            app_dir=app_dir,
+        )
     return destination
 
 
 def copy_detected_authenticated_linkedin_profile(
     detected_browser_id: str,
     *,
+    detected_profile_id: str | None = None,
     consent: bool,
     consent_method: str = "explicit-cli",
     app_dir: Path | None = None,
     catalog: BrowserCapabilityCatalog | None = None,
+    replace_existing: bool = False,
 ) -> Path:
-    """Copy a standard detected profile while keeping its host path worker-local."""
+    """Copy one detected profile while keeping its host path worker-local."""
 
-    source = detect_default_browser_profile(detected_browser_id)
-    if source is None:
+    profiles = detect_browser_profiles(detected_browser_id)
+    selected = next(
+        (
+            profile
+            for profile in profiles
+            if (
+                profile.id == detected_profile_id
+                if detected_profile_id is not None
+                else profile.directory_name == "Default"
+            )
+        ),
+        None,
+    )
+    if selected is None:
         raise DetectedBrowserProfileUnavailableError(
             "the selected detected browser profile is no longer available"
         )
     return copy_authenticated_linkedin_profile(
-        source,
+        selected.user_data_root,
         consent=consent,
         consent_method=consent_method,
         app_dir=app_dir,
@@ -880,8 +1112,11 @@ def copy_detected_authenticated_linkedin_profile(
         # The detected-profile contract names exactly one profile. Chrome's
         # root Local State is needed for platform encryption metadata, but
         # sibling profile directories and their sessions are outside consent.
-        _root_entries=frozenset({"Default", "Local State"}),
+        _root_entries=frozenset({selected.directory_name, "Local State"}),
+        _root_entry_renames={selected.directory_name: "Default"},
         _sanitize_default_local_state=True,
+        _sanitize_profile_name=selected.directory_name,
+        _replace_existing=replace_existing,
     )
 
 
@@ -940,6 +1175,76 @@ def _open_owned_profile_parent(*, app_dir: Path | None):
         os.close(root_descriptor)
 
 
+@contextmanager
+def _browser_profile_copy_lock(*, app_dir: Path | None):
+    """Serialize profile copies with a crash-releasing OS advisory lock."""
+
+    with ExitStack() as stack:
+        try:
+            parent_descriptor = stack.enter_context(
+                _open_owned_profile_parent(app_dir=app_dir)
+            )
+        except OSError as exc:
+            raise BrowserCapabilityError(
+                "JobCtrl browser-profile storage must not use symlinks or invalid ancestors"
+            ) from exc
+        lock_descriptor = -1
+        try:
+            lock_descriptor = os.open(
+                _PROFILE_COPY_LOCK_NAME,
+                os.O_RDWR | os.O_CREAT | getattr(os, "O_NOFOLLOW", 0),
+                stat.S_IRUSR | stat.S_IWUSR,
+                dir_fd=parent_descriptor,
+            )
+            lock_status = os.stat(
+                _PROFILE_COPY_LOCK_NAME,
+                dir_fd=parent_descriptor,
+                follow_symlinks=False,
+            )
+            if not stat.S_ISREG(lock_status.st_mode) or not _same_entry(
+                lock_status,
+                os.fstat(lock_descriptor),
+            ):
+                raise OSError("profile-copy lock is not a regular owned file")
+            os.fchmod(lock_descriptor, 0o600)
+            if sys.platform == "win32":
+                import msvcrt
+
+                if os.fstat(lock_descriptor).st_size == 0:
+                    os.write(lock_descriptor, b"\0")
+                    os.fsync(lock_descriptor)
+                os.lseek(lock_descriptor, 0, os.SEEK_SET)
+                msvcrt.locking(lock_descriptor, msvcrt.LK_LOCK, 1)
+            else:
+                import fcntl
+
+                fcntl.flock(lock_descriptor, fcntl.LOCK_EX)
+        except OSError as exc:
+            if lock_descriptor >= 0:
+                os.close(lock_descriptor)
+            raise BrowserCapabilityError(
+                "the browser profile copy lock is unavailable"
+            ) from exc
+
+        try:
+            yield
+        finally:
+            try:
+                if sys.platform == "win32":
+                    import msvcrt
+
+                    os.lseek(lock_descriptor, 0, os.SEEK_SET)
+                    msvcrt.locking(lock_descriptor, msvcrt.LK_UNLCK, 1)
+                else:
+                    import fcntl
+
+                    fcntl.flock(lock_descriptor, fcntl.LOCK_UN)
+            except OSError:
+                # Closing the descriptor releases the process-owned lock.
+                pass
+            os.close(lock_descriptor)
+
+
 def _same_entry(first: os.stat_result, second: os.stat_result) -> bool:
     return (first.st_dev, first.st_ino) == (second.st_dev, second.st_ino)
 
@@ -949,21 +1254,25 @@ def _copy_profile_directory(
     destination_descriptor: int,
     *,
     root_entries: frozenset[str] | None = None,
+    root_entry_renames: dict[str, str] | None = None,
 ) -> None:
     for name in os.listdir(source_descriptor):
         if name in _PROFILE_COPY_SKIP or (
             root_entries is not None and name not in root_entries
         ):
             continue
+        destination_name = (
+            root_entry_renames.get(name, name) if root_entry_renames else name
+        )
         source_status = os.stat(name, dir_fd=source_descriptor, follow_symlinks=False)
         if stat.S_ISDIR(source_status.st_mode):
             child_source = os.open(name, _directory_open_flags(), dir_fd=source_descriptor)
             try:
                 if not _same_entry(source_status, os.fstat(child_source)):
                     raise BrowserCapabilityError("the selected browser profile changed while being copied")
-                os.mkdir(name, mode=0o700, dir_fd=destination_descriptor)
+                os.mkdir(destination_name, mode=0o700, dir_fd=destination_descriptor)
                 child_destination = os.open(
-                    name,
+                    destination_name,
                     _directory_open_flags(),
                     dir_fd=destination_descriptor,
                 )
@@ -986,7 +1295,7 @@ def _copy_profile_directory(
             destination_flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
             destination_flags |= getattr(os, "O_NOFOLLOW", 0)
             destination_file = os.open(
-                name,
+                destination_name,
                 destination_flags,
                 stat.S_IRUSR | stat.S_IWUSR,
                 dir_fd=destination_descriptor,
@@ -1032,8 +1341,63 @@ def _discard_owned_profile_copy(destination: Path, *, app_dir: Path | None) -> N
         raise BrowserCapabilityError("the copied browser profile could not be discarded") from exc
 
 
-def _sanitize_detected_default_local_state_at(directory_descriptor: int) -> None:
-    """Sanitize Local State inside an unpublished Default-profile staging tree."""
+def _restore_replaced_profile_copy(
+    destination: Path,
+    replaced_name: str,
+    *,
+    app_dir: Path | None,
+) -> None:
+    """Restore the prior owned copy when post-publish state validation fails."""
+
+    expected_prefix = f".{destination.name}.replaced-"
+    if (
+        not replaced_name.startswith(expected_prefix)
+        or Path(replaced_name).name != replaced_name
+    ):
+        raise BrowserCapabilityError("the previous browser profile copy could not be restored")
+    _owned_profile_path(destination, app_dir=app_dir, require_existing=True)
+    try:
+        with _open_owned_profile_parent(app_dir=app_dir) as parent_descriptor:
+            _remove_profile_tree_at(parent_descriptor, destination.name)
+            os.rename(
+                replaced_name,
+                destination.name,
+                src_dir_fd=parent_descriptor,
+                dst_dir_fd=parent_descriptor,
+            )
+    except OSError as exc:
+        raise BrowserCapabilityError("the previous browser profile copy could not be restored") from exc
+    _owned_profile_path(destination, app_dir=app_dir, require_existing=True)
+
+
+def _discard_replaced_profile_copy(
+    destination: Path,
+    replaced_name: str,
+    *,
+    app_dir: Path | None,
+) -> None:
+    """Remove the prior copy after the replacement and state transaction succeed."""
+
+    expected_prefix = f".{destination.name}.replaced-"
+    if (
+        not replaced_name.startswith(expected_prefix)
+        or Path(replaced_name).name != replaced_name
+    ):
+        return
+    try:
+        with _open_owned_profile_parent(app_dir=app_dir) as parent_descriptor:
+            _remove_profile_tree_at(parent_descriptor, replaced_name)
+    except OSError:
+        # The active copy is already committed. Preserve the inactive owned
+        # recovery copy instead of risking damage to the working profile.
+        pass
+
+
+def _sanitize_detected_profile_local_state_at(
+    directory_descriptor: int,
+    source_profile_name: str,
+) -> None:
+    """Sanitize Local State inside an unpublished single-profile staging tree."""
 
     source_file = -1
     replacement_file = -1
@@ -1082,8 +1446,13 @@ def _sanitize_detected_default_local_state_at(directory_descriptor: int) -> None
                 "profiles_order": ["Default"],
             }
             info_cache = profile.get("info_cache")
-            if isinstance(info_cache, dict) and isinstance(info_cache.get("Default"), dict):
-                sanitized_profile["info_cache"] = {"Default": info_cache["Default"]}
+            selected_info = (
+                info_cache.get(source_profile_name)
+                if isinstance(info_cache, dict)
+                else None
+            )
+            if isinstance(selected_info, dict):
+                sanitized_profile["info_cache"] = {"Default": selected_info}
             sanitized["profile"] = sanitized_profile
         encoded = json.dumps(
             sanitized,
@@ -1130,24 +1499,39 @@ def _copy_profile_tree(
     *,
     app_dir: Path | None,
     root_entries: frozenset[str] | None = None,
+    root_entry_renames: dict[str, str] | None = None,
     sanitize_default_local_state: bool = False,
-) -> None:
+    sanitize_profile_name: str = "Default",
+    replace_existing: bool = False,
+) -> str | None:
     """Copy through no-follow directory FDs and publish with an anchored rename."""
 
     _owned_profile_path(destination, app_dir=app_dir, require_existing=False)
     source_descriptor = -1
     parent_descriptor = -1
     staging_name = f".{destination.name}.copy-{secrets.token_hex(12)}"
+    replaced_name = f".{destination.name}.replaced-{secrets.token_hex(12)}"
     published = False
+    replaced_existing = False
     try:
         source_descriptor = _open_directory_no_symlinks(source)
         with _open_owned_profile_parent(app_dir=app_dir) as opened_parent:
             parent_descriptor = os.dup(opened_parent)
+            destination_exists = False
             try:
-                os.stat(destination.name, dir_fd=parent_descriptor, follow_symlinks=False)
+                destination_status = os.stat(
+                    destination.name,
+                    dir_fd=parent_descriptor,
+                    follow_symlinks=False,
+                )
+                destination_exists = True
             except FileNotFoundError:
-                pass
-            else:
+                destination_status = None
+            if destination_exists and (
+                not replace_existing
+                or destination_status is None
+                or not stat.S_ISDIR(destination_status.st_mode)
+            ):
                 raise BrowserCapabilityError(
                     "an existing JobCtrl browser-profile destination cannot be adopted without a prior explicit copy"
                 )
@@ -1163,11 +1547,23 @@ def _copy_profile_tree(
                     source_descriptor,
                     staging_descriptor,
                     root_entries=root_entries,
+                    root_entry_renames=root_entry_renames,
                 )
                 if sanitize_default_local_state:
-                    _sanitize_detected_default_local_state_at(staging_descriptor)
+                    _sanitize_detected_profile_local_state_at(
+                        staging_descriptor,
+                        sanitize_profile_name,
+                    )
             finally:
                 os.close(staging_descriptor)
+            if destination_exists:
+                os.rename(
+                    destination.name,
+                    replaced_name,
+                    src_dir_fd=parent_descriptor,
+                    dst_dir_fd=parent_descriptor,
+                )
+                replaced_existing = True
             os.rename(
                 staging_name,
                 destination.name,
@@ -1176,8 +1572,23 @@ def _copy_profile_tree(
             )
             published = True
             _owned_profile_path(destination, app_dir=app_dir, require_existing=True)
+            return replaced_name if replaced_existing else None
     except Exception as exc:
         if parent_descriptor >= 0:
+            if replaced_existing:
+                try:
+                    if published:
+                        _remove_profile_tree_at(parent_descriptor, destination.name)
+                    os.rename(
+                        replaced_name,
+                        destination.name,
+                        src_dir_fd=parent_descriptor,
+                        dst_dir_fd=parent_descriptor,
+                    )
+                    replaced_existing = False
+                    published = False
+                except OSError:
+                    pass
             cleanup_name = destination.name if published else staging_name
             try:
                 _remove_profile_tree_at(parent_descriptor, cleanup_name)
@@ -1201,6 +1612,7 @@ __all__ = [
     "BrowserCapabilityUnavailableError",
     "BrowserProfileConsentRequiredError",
     "DetectedBrowser",
+    "DetectedBrowserProfile",
     "DetectedBrowserProfileUnavailableError",
     "DetectedBrowserUnavailableError",
     "BROWSER_CAPABILITIES_CONFIG_KEY",
@@ -1210,6 +1622,7 @@ __all__ = [
     "browser_capability_config_path",
     "copy_authenticated_linkedin_profile",
     "copy_detected_authenticated_linkedin_profile",
+    "detect_browser_profiles",
     "detect_default_browser_profile",
     "detect_supported_browsers",
     "disable_browser_capability",

--- a/workers/automation/src/jobctrl/infrastructure/rpc/handlers.py
+++ b/workers/automation/src/jobctrl/infrastructure/rpc/handlers.py
@@ -465,12 +465,15 @@ def _browser_capabilities_payload() -> dict[str, object]:
     """Serialize capability state and transient candidates without local paths."""
 
     from jobctrl.browser_capabilities import (
-        detect_default_browser_profile,
+        detect_browser_profiles,
         detect_supported_browsers,
         list_browser_capabilities,
     )
 
     detected_browsers = detect_supported_browsers()
+    detected_profiles = {
+        browser.id: detect_browser_profiles(browser.id) for browser in detected_browsers
+    }
 
     return {
         "capabilities": [_browser_status_payload(item) for item in list_browser_capabilities()],
@@ -478,7 +481,14 @@ def _browser_capabilities_payload() -> dict[str, object]:
             {
                 "id": browser.id,
                 "label": browser.label,
-                "defaultProfileAvailable": detect_default_browser_profile(browser.id) is not None,
+                "defaultProfileAvailable": any(
+                    profile.directory_name == "Default"
+                    for profile in detected_profiles[browser.id]
+                ),
+                "profiles": [
+                    {"id": profile.id, "label": profile.label}
+                    for profile in detected_profiles[browser.id]
+                ],
             }
             for browser in detected_browsers
         ],
@@ -557,8 +567,14 @@ def browser_profile_copy(params: dict[str, Any]) -> dict[str, object]:
         if has_detected_browser_id:
             copy_detected_authenticated_linkedin_profile(
                 str(_require(params, "detectedBrowserId")),
+                detected_profile_id=(
+                    str(_require(params, "detectedProfileId"))
+                    if "detectedProfileId" in params
+                    else None
+                ),
                 consent=True,
                 consent_method="explicit-ui-v1",
+                replace_existing="detectedProfileId" in params,
             )
         else:
             copy_authenticated_linkedin_profile(

--- a/workers/automation/tests/test_browser_capabilities.py
+++ b/workers/automation/tests/test_browser_capabilities.py
@@ -24,6 +24,7 @@ from jobctrl.browser_capabilities import (
     browser_capability_config_path,
     copy_authenticated_linkedin_profile,
     copy_detected_authenticated_linkedin_profile,
+    detect_browser_profiles,
     detect_default_browser_profile,
     detect_supported_browsers,
     disable_browser_capability,
@@ -142,6 +143,102 @@ def test_default_profile_detection_requires_a_supported_browser_and_standard_def
     assert detect_default_browser_profile("chromium") is None
 
 
+def test_profile_detection_lists_safe_labels_with_opaque_ids(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from jobctrl import browser_capabilities
+
+    profile_root = tmp_path / "Chrome"
+    (profile_root / "Default").mkdir(parents=True)
+    (profile_root / "Profile 1").mkdir()
+    (profile_root / "System Profile").mkdir()
+    (profile_root / "Local State").write_text(
+        json.dumps(
+            {
+                "profile": {
+                    "last_used": "Profile 1",
+                    "profiles_order": ["Profile 1", "Default"],
+                    "info_cache": {
+                        "Default": {"name": "Personal"},
+                        "Profile 1": {"name": "Work"},
+                        "System Profile": {"name": "Private system data"},
+                    },
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        browser_capabilities,
+        "detect_supported_browsers",
+        lambda: (
+            DetectedBrowser(
+                "google-chrome",
+                "Google Chrome",
+                tmp_path / "Chrome executable",
+            ),
+        ),
+    )
+    monkeypatch.setattr(
+        browser_capabilities,
+        "_default_browser_profile_locations",
+        lambda browser_id: (profile_root,) if browser_id == "google-chrome" else (),
+    )
+
+    profiles = detect_browser_profiles("google-chrome")
+
+    assert [profile.label for profile in profiles] == ["Work", "Personal"]
+    assert all(
+        profile.id.startswith("profile-") and len(profile.id) == 40
+        for profile in profiles
+    )
+    assert str(profile_root) not in repr(
+        [(profile.id, profile.label) for profile in profiles]
+    )
+
+
+def test_profile_detection_bounds_non_bmp_labels_to_the_rpc_contract(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from jobctrl import browser_capabilities
+
+    profile_root = tmp_path / "Chrome"
+    (profile_root / "Default").mkdir(parents=True)
+    (profile_root / "Local State").write_text(
+        json.dumps(
+            {
+                "profile": {
+                    "info_cache": {
+                        "Default": {"name": "🚀" * 80},
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        browser_capabilities,
+        "detect_supported_browsers",
+        lambda: (
+            DetectedBrowser(
+                "google-chrome",
+                "Google Chrome",
+                tmp_path / "Chrome executable",
+            ),
+        ),
+    )
+    monkeypatch.setattr(
+        browser_capabilities,
+        "_default_browser_profile_locations",
+        lambda _browser_id: (profile_root,),
+    )
+
+    (profile,) = detect_browser_profiles("google-chrome")
+
+    assert len(profile.label.encode("utf-16-le")) // 2 == 80
+    assert profile.label == "🚀" * 40
+
+
 def test_detected_profile_copy_resolves_the_host_path_without_a_caller_path(
     tmp_path: Path, browser_executable: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -206,6 +303,69 @@ def test_detected_profile_copy_resolves_the_host_path_without_a_caller_path(
     assert not (destination / "Profile 1").exists()
 
 
+def test_detected_profile_copy_normalizes_the_explicitly_selected_profile(
+    tmp_path: Path, browser_executable: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from jobctrl import browser_capabilities
+
+    profile_root = tmp_path / "Chrome profile"
+    (profile_root / "Default").mkdir(parents=True)
+    (profile_root / "Default" / "Cookies").write_text("default", encoding="utf-8")
+    (profile_root / "Profile 1").mkdir()
+    (profile_root / "Profile 1" / "Cookies").write_text("selected", encoding="utf-8")
+    (profile_root / "Local State").write_text(
+        json.dumps(
+            {
+                "os_crypt": {"encrypted_key": "required"},
+                "profile": {
+                    "last_used": "Profile 1",
+                    "info_cache": {
+                        "Default": {"name": "Default"},
+                        "Profile 1": {"name": "Signed in"},
+                    },
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        browser_capabilities,
+        "detect_supported_browsers",
+        lambda: (
+            DetectedBrowser("google-chrome", "Google Chrome", browser_executable),
+        ),
+    )
+    monkeypatch.setattr(
+        browser_capabilities,
+        "_default_browser_profile_locations",
+        lambda _browser_id: (profile_root,),
+    )
+    enable_system_browser_capability(
+        "authenticated-linkedin-browser", browser_executable, app_dir=tmp_path
+    )
+    selected = next(
+        profile
+        for profile in detect_browser_profiles("google-chrome")
+        if profile.label == "Signed in"
+    )
+
+    destination = copy_detected_authenticated_linkedin_profile(
+        "google-chrome",
+        detected_profile_id=selected.id,
+        consent=True,
+        app_dir=tmp_path,
+    )
+
+    assert (destination / "Default" / "Cookies").read_text(encoding="utf-8") == "selected"
+    assert not (destination / "Profile 1").exists()
+    copied_local_state = json.loads(
+        (destination / "Local State").read_text(encoding="utf-8")
+    )
+    assert copied_local_state["profile"]["info_cache"] == {
+        "Default": {"name": "Signed in"}
+    }
+
+
 def test_detected_profile_metadata_is_sanitized_before_destination_publish(
     tmp_path: Path,
     browser_executable: Path,
@@ -238,8 +398,10 @@ def test_detected_profile_metadata_is_sanitized_before_destination_publish(
     )
     monkeypatch.setattr(
         browser_capabilities,
-        "_sanitize_detected_default_local_state_at",
-        lambda _descriptor: (_ for _ in ()).throw(RuntimeError("interrupted")),
+        "_sanitize_detected_profile_local_state_at",
+        lambda _descriptor, _profile_name: (_ for _ in ()).throw(
+            RuntimeError("interrupted")
+        ),
     )
 
     with pytest.raises(BrowserCapabilityError):
@@ -254,6 +416,345 @@ def test_detected_profile_metadata_is_sanitized_before_destination_publish(
         app_dir=tmp_path,
     ).exists()
     assert list((tmp_path / "browser-profiles").glob(".*.copy-*")) == []
+
+
+def test_explicit_detected_profile_replaces_an_existing_owned_copy_after_staging(
+    tmp_path: Path, browser_executable: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from jobctrl import browser_capabilities
+
+    profile_root = tmp_path / "Chrome profile"
+    (profile_root / "Default").mkdir(parents=True)
+    (profile_root / "Default" / "Cookies").write_text("old", encoding="utf-8")
+    (profile_root / "Profile 1").mkdir()
+    (profile_root / "Profile 1" / "Cookies").write_text("new", encoding="utf-8")
+    (profile_root / "Local State").write_text(
+        json.dumps(
+            {
+                "profile": {
+                    "info_cache": {
+                        "Default": {"name": "Old"},
+                        "Profile 1": {"name": "New"},
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        browser_capabilities,
+        "detect_supported_browsers",
+        lambda: (
+            DetectedBrowser("google-chrome", "Google Chrome", browser_executable),
+        ),
+    )
+    monkeypatch.setattr(
+        browser_capabilities,
+        "_default_browser_profile_locations",
+        lambda _browser_id: (profile_root,),
+    )
+    enable_system_browser_capability(
+        "authenticated-linkedin-browser", browser_executable, app_dir=tmp_path
+    )
+    copy_detected_authenticated_linkedin_profile(
+        "google-chrome", consent=True, app_dir=tmp_path
+    )
+    selected = next(
+        profile
+        for profile in detect_browser_profiles("google-chrome")
+        if profile.label == "New"
+    )
+
+    destination = copy_detected_authenticated_linkedin_profile(
+        "google-chrome",
+        detected_profile_id=selected.id,
+        consent=True,
+        app_dir=tmp_path,
+        replace_existing=True,
+    )
+
+    assert (destination / "Default" / "Cookies").read_text(encoding="utf-8") == "new"
+    assert list((tmp_path / "browser-profiles").glob(".*.replaced-*")) == []
+
+
+def test_failed_detected_profile_replacement_preserves_the_existing_copy(
+    tmp_path: Path, browser_executable: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from jobctrl import browser_capabilities
+
+    profile_root = tmp_path / "Chrome profile"
+    (profile_root / "Default").mkdir(parents=True)
+    (profile_root / "Default" / "Cookies").write_text("old", encoding="utf-8")
+    (profile_root / "Profile 1").mkdir()
+    (profile_root / "Profile 1" / "Cookies").write_text("new", encoding="utf-8")
+    (profile_root / "Local State").write_text(
+        json.dumps(
+            {
+                "profile": {
+                    "info_cache": {
+                        "Default": {"name": "Old"},
+                        "Profile 1": {"name": "New"},
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        browser_capabilities,
+        "detect_supported_browsers",
+        lambda: (
+            DetectedBrowser("google-chrome", "Google Chrome", browser_executable),
+        ),
+    )
+    monkeypatch.setattr(
+        browser_capabilities,
+        "_default_browser_profile_locations",
+        lambda _browser_id: (profile_root,),
+    )
+    enable_system_browser_capability(
+        "authenticated-linkedin-browser", browser_executable, app_dir=tmp_path
+    )
+    destination = copy_detected_authenticated_linkedin_profile(
+        "google-chrome", consent=True, app_dir=tmp_path
+    )
+    selected = next(
+        profile
+        for profile in detect_browser_profiles("google-chrome")
+        if profile.label == "New"
+    )
+    original_copy_directory = browser_capabilities._copy_profile_directory
+
+    def interrupted_copy(*args, **kwargs) -> None:
+        original_copy_directory(*args, **kwargs)
+        raise RuntimeError("interrupted before publish")
+
+    monkeypatch.setattr(browser_capabilities, "_copy_profile_directory", interrupted_copy)
+
+    with pytest.raises(BrowserCapabilityError):
+        copy_detected_authenticated_linkedin_profile(
+            "google-chrome",
+            detected_profile_id=selected.id,
+            consent=True,
+            app_dir=tmp_path,
+            replace_existing=True,
+        )
+
+    assert (destination / "Default" / "Cookies").read_text(encoding="utf-8") == "old"
+    assert list((tmp_path / "browser-profiles").glob(".*.copy-*")) == []
+
+
+def test_profile_replacement_restores_existing_copy_when_capability_changes_after_publish(
+    tmp_path: Path, browser_executable: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from jobctrl import browser_capabilities
+
+    profile_root = tmp_path / "Chrome profile"
+    (profile_root / "Default").mkdir(parents=True)
+    (profile_root / "Default" / "Cookies").write_text("old", encoding="utf-8")
+    (profile_root / "Profile 1").mkdir()
+    (profile_root / "Profile 1" / "Cookies").write_text("new", encoding="utf-8")
+    (profile_root / "Local State").write_text(
+        json.dumps(
+            {
+                "profile": {
+                    "info_cache": {
+                        "Default": {"name": "Old"},
+                        "Profile 1": {"name": "New"},
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        browser_capabilities,
+        "detect_supported_browsers",
+        lambda: (
+            DetectedBrowser("google-chrome", "Google Chrome", browser_executable),
+        ),
+    )
+    monkeypatch.setattr(
+        browser_capabilities,
+        "_default_browser_profile_locations",
+        lambda _browser_id: (profile_root,),
+    )
+    enable_system_browser_capability(
+        "authenticated-linkedin-browser", browser_executable, app_dir=tmp_path
+    )
+    destination = copy_detected_authenticated_linkedin_profile(
+        "google-chrome", consent=True, app_dir=tmp_path
+    )
+    selected = next(
+        profile
+        for profile in detect_browser_profiles("google-chrome")
+        if profile.label == "New"
+    )
+    original_copy_profile_tree = browser_capabilities._copy_profile_tree
+
+    def copied_then_revoked(*args, **kwargs):
+        replaced_name = original_copy_profile_tree(*args, **kwargs)
+        disable_browser_capability(
+            "authenticated-linkedin-browser",
+            app_dir=tmp_path,
+        )
+        return replaced_name
+
+    monkeypatch.setattr(browser_capabilities, "_copy_profile_tree", copied_then_revoked)
+
+    with pytest.raises(
+        BrowserCapabilityError,
+        match="changed while the profile was copied",
+    ):
+        copy_detected_authenticated_linkedin_profile(
+            "google-chrome",
+            detected_profile_id=selected.id,
+            consent=True,
+            app_dir=tmp_path,
+            replace_existing=True,
+        )
+
+    assert (destination / "Default" / "Cookies").read_text(encoding="utf-8") == "old"
+    assert list((tmp_path / "browser-profiles").glob(".*.replaced-*")) == []
+
+
+def test_concurrent_profile_replacement_waits_for_failed_rollback_before_publishing(
+    tmp_path: Path, browser_executable: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from jobctrl import browser_capabilities
+
+    profile_root = tmp_path / "Chrome profile"
+    for directory_name, cookie in (
+        ("Default", "old"),
+        ("Profile 1", "replacement-a"),
+        ("Profile 2", "replacement-b"),
+    ):
+        profile_directory = profile_root / directory_name
+        profile_directory.mkdir(parents=True)
+        (profile_directory / "Cookies").write_text(cookie, encoding="utf-8")
+    (profile_root / "Local State").write_text(
+        json.dumps(
+            {
+                "profile": {
+                    "info_cache": {
+                        "Default": {"name": "Old"},
+                        "Profile 1": {"name": "Replacement A"},
+                        "Profile 2": {"name": "Replacement B"},
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        browser_capabilities,
+        "detect_supported_browsers",
+        lambda: (
+            DetectedBrowser("google-chrome", "Google Chrome", browser_executable),
+        ),
+    )
+    monkeypatch.setattr(
+        browser_capabilities,
+        "_default_browser_profile_locations",
+        lambda _browser_id: (profile_root,),
+    )
+    enable_system_browser_capability(
+        "authenticated-linkedin-browser", browser_executable, app_dir=tmp_path
+    )
+    destination = copy_detected_authenticated_linkedin_profile(
+        "google-chrome", consent=True, app_dir=tmp_path
+    )
+    profiles = detect_browser_profiles("google-chrome")
+    selected_a = next(
+        profile for profile in profiles if profile.label == "Replacement A"
+    )
+    selected_b = next(
+        profile for profile in profiles if profile.label == "Replacement B"
+    )
+
+    a_validation_started = threading.Event()
+    allow_a_failure = threading.Event()
+    b_attempted = threading.Event()
+    b_copy_started = threading.Event()
+    errors: dict[str, Exception] = {}
+    a_state_transactions = 0
+    original_state_transaction = browser_capabilities._browser_capability_state_transaction
+    original_copy_profile_tree = browser_capabilities._copy_profile_tree
+
+    @contextmanager
+    def controlled_state_transaction(*args, **kwargs):
+        nonlocal a_state_transactions
+        if threading.current_thread().name == "replacement-a":
+            a_state_transactions += 1
+            if a_state_transactions == 2:
+                a_validation_started.set()
+                assert allow_a_failure.wait(timeout=5)
+                raise browser_capabilities.BrowserCapabilityStateError(
+                    "forced post-publish validation failure"
+                )
+        with original_state_transaction(*args, **kwargs) as state:
+            yield state
+
+    def observed_copy_profile_tree(*args, **kwargs):
+        if threading.current_thread().name == "replacement-b":
+            b_copy_started.set()
+        return original_copy_profile_tree(*args, **kwargs)
+
+    monkeypatch.setattr(
+        browser_capabilities,
+        "_browser_capability_state_transaction",
+        controlled_state_transaction,
+    )
+    monkeypatch.setattr(
+        browser_capabilities,
+        "_copy_profile_tree",
+        observed_copy_profile_tree,
+    )
+
+    def replace(name: str, profile_id: str) -> None:
+        if name == "replacement-b":
+            b_attempted.set()
+        try:
+            copy_detected_authenticated_linkedin_profile(
+                "google-chrome",
+                detected_profile_id=profile_id,
+                consent=True,
+                app_dir=tmp_path,
+                replace_existing=True,
+            )
+        except Exception as exc:
+            errors[name] = exc
+
+    replacement_a = threading.Thread(
+        target=replace,
+        args=("replacement-a", selected_a.id),
+        name="replacement-a",
+    )
+    replacement_b = threading.Thread(
+        target=replace,
+        args=("replacement-b", selected_b.id),
+        name="replacement-b",
+    )
+
+    replacement_a.start()
+    assert a_validation_started.wait(timeout=5)
+    replacement_b.start()
+    assert b_attempted.wait(timeout=5)
+    assert not b_copy_started.wait(timeout=0.2)
+    allow_a_failure.set()
+    replacement_a.join(timeout=5)
+    replacement_b.join(timeout=5)
+
+    assert not replacement_a.is_alive()
+    assert not replacement_b.is_alive()
+    assert isinstance(errors.get("replacement-a"), BrowserCapabilityError)
+    assert "replacement-b" not in errors
+    assert b_copy_started.is_set()
+    assert (
+        destination / "Default" / "Cookies"
+    ).read_text(encoding="utf-8") == "replacement-b"
+    assert list((tmp_path / "browser-profiles").glob(".*.copy-*")) == []
+    assert list((tmp_path / "browser-profiles").glob(".*.replaced-*")) == []
 
 
 def test_explicit_detected_browser_id_is_resolved_and_enabled(

--- a/workers/automation/tests/test_browser_capabilities_rpc.py
+++ b/workers/automation/tests/test_browser_capabilities_rpc.py
@@ -10,6 +10,9 @@ import pytest
 from jobctrl.infrastructure.rpc import handlers
 
 
+PROFILE_ID = "profile-0123456789abcdef0123456789abcdef"
+
+
 def _status(capability_id: str, status: str = "disabled") -> SimpleNamespace:
     return SimpleNamespace(
         id=capability_id,
@@ -44,9 +47,18 @@ def test_capability_list_never_returns_executable_paths(monkeypatch: pytest.Monk
     )
     monkeypatch.setattr(
         browser_capabilities,
-        "detect_default_browser_profile",
+        "detect_browser_profiles",
         lambda browser_id: (
-            "/secret/detected/profile/path" if browser_id == "google-chrome" else None
+            (
+                SimpleNamespace(
+                    id=PROFILE_ID,
+                    label="Signed in",
+                    directory_name="Profile 1",
+                    user_data_root="/secret/detected/profile/path",
+                ),
+            )
+            if browser_id == "google-chrome"
+            else ()
         ),
     )
 
@@ -56,7 +68,8 @@ def test_capability_list_never_returns_executable_paths(monkeypatch: pytest.Monk
         {
             "id": "google-chrome",
             "label": "Google Chrome",
-            "defaultProfileAvailable": True,
+            "defaultProfileAvailable": False,
+            "profiles": [{"id": PROFILE_ID, "label": "Signed in"}],
         }
     ]
     assert "executable" not in json.dumps(result)
@@ -182,12 +195,12 @@ def test_profile_copy_accepts_a_detected_browser_without_crossing_a_host_path(
 ) -> None:
     from jobctrl import browser_capabilities
 
-    called: list[tuple[str, bool, str]] = []
+    called: list[tuple[str, str | None, bool, str, bool]] = []
     monkeypatch.setattr(
         browser_capabilities,
         "copy_detected_authenticated_linkedin_profile",
-        lambda browser_id, *, consent, consent_method: called.append(
-            (browser_id, consent, consent_method)
+        lambda browser_id, *, detected_profile_id, consent, consent_method, replace_existing: called.append(
+            (browser_id, detected_profile_id, consent, consent_method, replace_existing)
         ),
     )
     monkeypatch.setattr(
@@ -204,12 +217,13 @@ def test_profile_copy_accepts_a_detected_browser_without_crossing_a_host_path(
     response = handlers.browser_profile_copy(
         {
             "detectedBrowserId": "google-chrome",
+            "detectedProfileId": PROFILE_ID,
             "consent": True,
             "consentMethod": "explicit-ui-v1",
         }
     )
 
-    assert called == [("google-chrome", True, "explicit-ui-v1")]
+    assert called == [("google-chrome", PROFILE_ID, True, "explicit-ui-v1", True)]
     assert "sourceProfilePath" not in json.dumps(response)
 
 
@@ -235,6 +249,7 @@ def test_stale_detected_profile_error_does_not_expose_a_host_path(
         handlers.browser_profile_copy(
             {
                 "detectedBrowserId": "google-chrome",
+                "detectedProfileId": PROFILE_ID,
                 "consent": True,
                 "consentMethod": "explicit-ui-v1",
             }


### PR DESCRIPTION
## Summary

- enumerate usable Chrome and Chromium profiles with opaque IDs and bounded display labels
- let Settings select and copy the chosen profile without exposing host paths or sibling sessions
- stage replacements safely and serialize concurrent copy, validation, rollback, and cleanup
- retain the legacy browser-only Default path and separate explicit consent boundary

## Validation

- `workers/automation/.venv/bin/ruff check workers/automation/src/jobctrl/browser_capabilities.py workers/automation/src/jobctrl/infrastructure/rpc/handlers.py workers/automation/tests/test_browser_capabilities.py workers/automation/tests/test_browser_capabilities_rpc.py`
- `workers/automation/.venv/bin/python -m pytest workers/automation/tests/test_browser_capabilities.py workers/automation/tests/test_browser_capabilities_rpc.py -q` (43 passed)
- `corepack pnpm --filter @jobctrl/contracts check`
- `corepack pnpm api:check`
- `corepack pnpm web:check`
- `corepack pnpm --filter @jobctrl/web exec vitest run src/contexts/operations/components/BrowserCapabilitiesPanel.test.tsx src/contexts/operations/hooks/useBrowserCapabilityMutations.test.ts` (6 passed)
- `corepack pnpm --filter @jobctrl/api exec vitest run test/server.test.ts -t "lists detected browsers and forwards explicit browser and profile selections"` (1 passed)
- rendered Settings QA confirmed the detected Chrome profile label is selectable, consent remains unchecked by default, and no console errors are present

Stacked on #745.
