### PR TITLE
fix(materials): bound retries and preserve recovery audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,9 @@ evidence, qualifications, and the complete capability matrix.
   detail workspaces keep record-specific evidence and actions adjacent.
 - Inspect Discover, preparation, and Apply through the same Runs vocabulary,
   timeline, terminal-state rules, and cancellation control. Repeated cancel
-  requests are harmless, and an already-terminal result remains inspectable.
+  requests are harmless, the requester/source remains in the run timeline, and
+  an already-terminal result remains inspectable. Canceling Enrich terminalizes
+  only that run's unfinished selected jobs; unrelated pending work is untouched.
 - Review privacy-bounded learning recommendations on the Dashboard. JobCtrl
   derives them only from explicit reviewed signals, requires compatible
   evidence across jobs, and changes Materials behavior only after you accept a

--- a/docs/api/operations-and-events.md
+++ b/docs/api/operations-and-events.md
@@ -26,6 +26,30 @@ reset (`runAfter: false`) is local and synchronous. A reset-and-run
 (`runAfter: true`) checks worker readiness before the reset; on
 `503 worker_runtime_unavailable`, the failed/blocked stage and its event history
 are preserved exactly so a dispatch precondition cannot erase retry evidence.
+An accepted reset clears prior execution-owner metadata before returning the
+stage to `pending`, so a canceled predecessor cannot reclaim explicitly retried
+work before its replacement workflow is queued. Pending Enrich pickup reads the
+canonical `job_enrichments.current_status`; a stale legacy or list-projection
+description cannot falsely classify a reset aggregate as already enriched. A
+repeated pickup cannot skip a queued or running upstream preparation stage to
+start a downstream stage concurrently. Score, Tailor, and Cover pickup also
+require the canonical enrichment aggregate to be `enriched` with a non-empty
+canonical description; projected legacy text cannot unlock downstream work.
+The compatibility `runId` returned by workflow-start RPC remains the workflow
+handle ID. Durable stage ownership and workflow audit use
+`firstExecutionRunId`, the exact Temporal execution ID; they never substitute
+the compatibility handle for execution identity. If a legacy dispatcher omits
+an exact execution ID, the API leaves Enrich pending for the selected worker
+activity to claim with its runtime identity instead of persisting a fake owner.
+Activity timeout, worker shutdown, and workflow cancellation are not synonyms:
+the first two release unfinished Enrich ownership for Temporal retry, while an
+explicit cancellation terminalizes only the exact owned cohort. Each selected
+stage passes only its canonical successful JobIds downstream. Selected Tailor
+and Cover batches honor the requested bounded worker count; durable item
+failures remain on their rows while the approved subset continues. Explicitly
+selected batches receive a replay-versioned activity deadline of 30 minutes per
+worker wave, capped at 6 hours, while the separate 2-minute heartbeat timeout
+continues to detect worker loss.
 
 ## Pipeline Operations Snapshot
 
@@ -181,6 +205,18 @@ is not the same thing as observing terminal `canceled`, and repeating the
 request cannot overwrite an already-terminal result or emit duplicate
 cancellation transitions. Terminal results remain inspectable through the same
 run detail after cancellation wins or loses the race with completion.
+`WorkflowCancellationRequested` is a separate timeline fact containing the
+requester, source boundary, optional reason, request time, and exact Temporal
+run. A delivered JobCtrl request is recorded as `request_intent`; the immutable
+Temporal history requester is recorded separately as `temporal_history`, so a
+failed local delivery can neither masquerade as the cancellation nor suppress
+the authoritative requester. Local mode records `local_operator` through
+`jobctrl_api`; it does not invent an authenticated account. Cancellations issued
+outside JobCtrl are backfilled from Temporal's requester identity (for example,
+`temporal_cli`). If a previously observed Temporal requester must be restored
+after the dev namespace retention window has purged that execution, the audit
+uses the distinct `recovered_temporal_history` evidence kind and says so in the
+timeline; it is never presented as a fresh history read or a JobCtrl request.
 
 ## Health And JSON-RPC
 

--- a/docs/architecture/pipeline/concurrency.md
+++ b/docs/architecture/pipeline/concurrency.md
@@ -17,7 +17,10 @@ flowchart LR
     CLI -->|"start workflows"| TQ --> W
     subgraph W2["Worker capacity"]
         SLOTS@{ icon: "tabler:layout-grid", form: "rounded", label: "Activity slots<br/>default 4", h: 64 }
-        EXEC@{ icon: "tabler:cpu", form: "rounded", label: "Thread pool<br/>slots + 2", h: 64 }
+        SYNC@{ icon: "tabler:cpu", form: "rounded", label: "Temporal sync pool<br/>slots + 2", h: 64 }
+        BLOCK@{ icon: "tabler:refresh", form: "rounded", label: "Blocking-stage pool<br/>slots + 2 · rotating", h: 64 }
+        SLOTS --- SYNC
+        SLOTS --- BLOCK
     end
     D@{ icon: "tabler:radar", form: "rounded", label: "Discover workflow<br/>per-source family", h: 64 }
     P@{ icon: "tabler:git-merge", form: "rounded", label: "Job pipeline<br/>ordered stages", h: 64 }
@@ -29,7 +32,7 @@ flowchart LR
     W --> A
     BUDGET -.->|"blocks over-budget starts"| D & P & A
 
-    class CLI,W,SLOTS,EXEC,D,P,A,BUDGET py
+    class CLI,W,SLOTS,SYNC,BLOCK,D,P,A,BUDGET py
     class TQ infra
 ```
 
@@ -45,11 +48,15 @@ worker startup in
 - **Activity slots** — the `worker_activity_slots` Setting in `config.json`
   (default `4`): the maximum number of Temporal activities running at once,
   across all workflows.
-- **Executor threads** — a worker-owned `ThreadPoolExecutor` sized
-  `slots + 2`, so blocking stage work never spills into the process default
-  executor.
+- **Executor threads** — separate worker-owned Temporal-sync and blocking-stage
+  `ThreadPoolExecutor` pools, each sized `slots + 2`, so blocking stage work
+  never spills into the process default executor or starves Temporal's own
+  synchronous activities. Cancellation retires the affected blocking pool
+  generation before its grace wait, so a fresh bounded generation accepts an
+  immediate retry even when the old provider call ignores cancellation.
 
-The worker heartbeat records both values. `GET /v1/health` exposes the health
+The worker heartbeat records the activity slots and configured executor width.
+`GET /v1/health` exposes the health
 boundary, while `GET /v1/pipeline/operations` derives the app directory from
 its configured database path, filters heartbeats to that resolved
 database/app-dir identity, selects the task queue named by the newest matching
@@ -145,7 +152,7 @@ Two knobs that look like Temporal concurrency but are not:
 
 | Bound | Mechanism | Where |
 | --- | --- | --- |
-| Activity slots | Settings `worker_activity_slots`, executor `slots + 2` | `config.json`, `infrastructure/temporal/worker.py` |
+| Activity slots and executor pools | Settings `worker_activity_slots`; Temporal-sync and blocking-stage executors each `slots + 2`; canceled blocking generations retire before grace | `config.json`, `infrastructure/temporal/worker.py`, `infrastructure/temporal/run_in_activity.py` |
 | Parallel discovery families | Discovery Runtime `max_parallel_families` (default `1`) | SQLite, `infrastructure/temporal/concurrency.py`, `discovery/workflow.py` |
 | LLM spend | `check_spend_budget` preflight stops spendful workflows at the daily ceiling | [Spend Ceiling](operations.md#spend-ceiling) |
 | Retries | per-activity retry policies from the error taxonomy | [Envelope & Activities](envelope.md) |

--- a/docs/architecture/pipeline/envelope.md
+++ b/docs/architecture/pipeline/envelope.md
@@ -22,7 +22,13 @@ The helpers live in
    [Spend Ceiling](operations.md#spend-ceiling)). It runs with `maximum_attempts=1`, so a
    depleted budget fails the run before any paid work.
 3. **Business activities** run (stages, per-job steps, apply, import, refresh).
-4. **`record_workflow_outcome`** emits exactly one terminal event on every exit
+4. **`WorkflowCancellationRequested`** records requester, source, optional
+   reason, exact Temporal run, and whether the evidence is delivered
+   `request_intent`, immutable `temporal_history`, or explicitly labeled
+   `recovered_temporal_history`. It is an audit fact, not a
+   terminal outcome. Local intent is appended only after Temporal accepts the
+   request; exact execution history is always reconciled as distinct evidence.
+5. **`record_workflow_outcome`** emits exactly one terminal event on every exit
    path — `WorkflowCompleted`, `WorkflowFailed`, `WorkflowCanceled`,
    `WorkflowTimedOut`, or `WorkflowTerminated`. On the cancel path the finalize
    activity uses `ActivityCancellationType.ABANDON` so the tiny SQLite write can
@@ -150,6 +156,13 @@ incompatibility is terminal and explicit. Cooperative cancellation interrupts
 the provider and terminalizes unfinished units; it is never treated as a
 resumable crash.
 
+For batch Enrich, selection is a durable `StageQueued` ownership fact carrying
+the workflow and Temporal run IDs. Cooperative cancellation terminalizes only
+unfinished members of that exact cohort. If the worker disappears before its
+cleanup finishes, the restarted reconciler uses the persisted owner metadata to
+perform the same idempotent `StageCanceled` transition. Accepted enrichment and
+unrelated pending jobs are never overwritten.
+
 ### Pipeline-Step Lifecycle Envelope
 
 Execution-owned orchestration uses a narrower lifecycle envelope alongside the
@@ -238,16 +251,30 @@ stage — defeating heartbeats and starving every other activity on the worker.
 `infrastructure/temporal/run_in_activity.py` solves this with
 `run_blocking_with_heartbeat`, which every long-running activity uses:
 
-- It offloads the synchronous function to a **bounded, worker-owned
-  `ThreadPoolExecutor`** and emits a heartbeat every `poll_interval` (default
-  **15 s**) while waiting.
+- It offloads the synchronous function to a **bounded, worker-owned blocking
+  `ThreadPoolExecutor`**, separate from Temporal's synchronous-activity
+  executor, and emits a heartbeat every `poll_interval` (default **15 s**)
+  while waiting.
 - On `asyncio.CancelledError` (a Temporal cancel) it invokes the supplied
-  cooperative `on_cancel` hook, waits up to `cancel_wait_seconds` (default
-  **30 s**) for the thread to stop, and re-raises.
+  cooperative `on_cancel` hook, immediately retires that blocking-executor
+  generation so a server-dispatched retry cannot enter it during cleanup,
+  waits up to `cancel_wait_seconds` (default **30 s**) for the thread to stop,
+  and re-raises.
 - If the thread ignores cancellation past that grace window, it logs
   `abandoned_thread` and records an `operational_attempt_metric`
   (`stage="operations"`, `attempt_kind="temporal_activity_thread"`,
-  `error_class="abandoned_thread"`) so a wedged thread is observable.
+  `error_class="abandoned_thread"`) so a wedged thread is observable. The
+  log marks the already-retired executor generation as abandoned. A fresh
+  bounded generation has already taken over before the grace wait, while the
+  old thread remains fenced by its cancel token and exact activity ownership;
+  the old call cannot consume the capacity needed for Temporal retry and owner
+  reconciliation.
+
+Explicitly selected pipeline batches use a replay-versioned activity deadline:
+30 minutes per bounded worker wave, capped at 6 hours. The separate 2-minute
+heartbeat timeout remains fixed, so more legitimate batch work does not delay
+dead-worker detection. Histories created before the Temporal patch marker retain
+their recorded 30-minute timer when replayed.
 
 This is why the discovery source-family and enrichment activities (and the apply
 activity) accept a `threading.Event` cancel token: the workflow-level cancel

--- a/docs/architecture/pipeline/stages.md
+++ b/docs/architecture/pipeline/stages.md
@@ -479,8 +479,16 @@ workflow handle (`handle.cancel()` via the default canceler) — this is a Tempo
 cancellation, not an application signal. The cancel propagates through
 `run_blocking_with_heartbeat`'s `on_cancel` hook so the launcher stops
 cooperatively; the terminal state is recorded as `WorkflowCanceled` (by finalize
-on the cancel path, or by the reconciler). The post-hoc SQLite stage-canceled
-write is the API's `cancelJobAction`.
+on the cancel path, or by the reconciler). `WorkflowCancellationRequested`
+separately preserves who requested the cancel and through which boundary. Batch
+Enrich persists its exact selected cohort before navigation, marks every
+unfinished owned row `canceled`, and lets a restarted worker reconcile the same
+ownership if cooperative cleanup was interrupted. Its terminal cancellation
+lease supersedes every producer attempt, while conditional workflow/run metadata
+prevents an old cleanup from canceling or overwriting a successor's row. A
+trustworthy posting snapshot, quarantine resolution, Tailor release, and their
+audit events commit atomically. The post-hoc SQLite stage-canceled write is the
+API's `cancelJobAction`.
 
 ## Contact Research (supervised, off-pipeline)
 

--- a/docs/architecture/runtime.md
+++ b/docs/architecture/runtime.md
@@ -564,18 +564,21 @@ lives under `workers/automation/src/jobctrl/infrastructure/temporal/`:
   boundary (the sandbox proxy mechanism otherwise refuses to instantiate
   frozen dataclasses imported through `imports_passed_through()`). Activity
   execution is bounded by the `worker_activity_slots` value saved in
-  `config.json` (default `4`) and a worker-owned
-  `ThreadPoolExecutor(max_workers = slots + 2)`, so blocking stage work no
-  longer spills into the process default executor. The worker heartbeat records
-  both values, exact all-activity slot use, bounded allowlisted active detail,
+  `config.json` (default `4`) and two worker-owned
+  `ThreadPoolExecutor(max_workers = slots + 2)` pools: one for Temporal's
+  synchronous activities and one for blocking stage helpers. Cancellation
+  retires the affected blocking-pool generation before its grace wait, so an
+  immediate retry uses fresh bounded capacity without affecting Temporal's
+  synchronous pool. The worker heartbeat records the activity slots and
+  configured executor width, exact all-activity slot use, bounded active detail,
   completed-activity duration summaries, and an approximate task-queue
   observation for `GET /v1/health` and `GET /v1/pipeline/operations` (see
   [Concurrency & Fan-out](pipeline/concurrency.md)).
 - `run_in_activity.py` — shared helper for running synchronous domain work from
   async Temporal activities while heartbeating. Cancellation sets a cooperative
-  `threading.Event`, waits up to the activity's cancel deadline for the worker
-  thread to exit, and records an `abandoned_thread` operational metric if the
-  thread ignores cancellation.
+  `threading.Event`, retires that blocking executor generation before waiting up
+  to the activity's cancel deadline, and records an `abandoned_thread`
+  operational metric if the old thread ignores cancellation.
 - `task_queues.py` — single `JOBCTRL_TASK_QUEUE = "jobctrl-default"`.
 - `registry.py` — single source of truth for `WORKFLOWS` and `ACTIVITIES`.
   The CLI imports both lists and passes them to `build_worker`; new

--- a/docs/architecture/tailoring.md
+++ b/docs/architecture/tailoring.md
@@ -673,9 +673,10 @@ repair-loop history.
 acceptable candidate within its retry budget. The durable preparation queue has
 its own retry budget outside this inner loop. The stage `attempt_count` advances
 once per durable Tailor execution, not once per candidate-repair call; inner
-attempts remain in an append-only generation audit keyed by workflow execution
-and durable attempt, so a later retry cannot overwrite earlier prompts,
-candidates, validation, or judge evidence. A fifth failed durable execution is
+attempts remain in an append-only generation audit keyed by workflow execution,
+durable attempt, and recorded time, so a later retry or a rerun of the same
+durable attempt cannot overwrite earlier prompts, candidates, validation, or
+judge evidence. A fifth failed durable execution is
 stored as non-retryable `exhausted` until an explicit attempt reset.
 
 ## How To Change Tailoring Safely

--- a/docs/architecture/tailoring.md
+++ b/docs/architecture/tailoring.md
@@ -116,6 +116,28 @@ Tailoring combines several inputs. Each input has a different authority.
 | Requirement-led coverage graph | Deterministic target-profile adapter plus constrained planner | Which profile achievements can cover which target requirements, which requirements are uncovered, which achievements are unused, and what claim policy each edge requires |
 | Previous attempt outcome | Tailoring retry loop | Typed, code-owned retry reason only; free-form validator, judge, adversarial, and prior-output text remains audit data |
 
+The rollbackable tailoring-policy revision contains only tenant-wide generation
+controls: the complete tailoring-relevant `ProfileSnapshot` projection,
+profile/custom policy, learned rules, prompt/schema versions, generator and
+judge settings, and validation mode. The projection covers rendered contact
+fields, experience metadata, resume facts and evidence, constraints, and
+tailoring rules. It deliberately excludes application-only sections such as
+compensation, work authorization, availability, EEO answers, application
+preferences, and the stored application password. The target-job plan is not a
+global policy revision. Every artifact records its own job-prompt fingerprint
+separately from the global
+policy fingerprint and version. That artifact fingerprint hashes the exact
+role/content message set sent for the selected candidate, including its target
+job and any typed retry guidance; it is not a digest of only the reusable
+system-prompt base. Parallel jobs with identical generation controls therefore
+reuse one global policy version while retaining distinct job-prompt audit facts.
+A tailoring-relevant profile or control change advances the global version;
+an application-only edit does not. Immediately before artifact persistence,
+the same SQLite write transaction derives the current canonical
+tailoring-relevant projection and compares its fingerprint plus the policy
+against the generation inputs, so a concurrent resume-evidence or policy change
+rejects the stale artifact rather than committing it after the user's change.
+
 The target job is context, not candidate evidence. The prompt explicitly tells
 the model not to copy target-job tools, systems, responsibilities, or business
 claims into the candidate resume unless the same fact appears in the candidate's
@@ -649,7 +671,12 @@ repair-loop history.
 
 `exhausted_retries` means the inner tailoring loop could not produce an
 acceptable candidate within its retry budget. The durable preparation queue has
-its own retry budget outside this inner loop.
+its own retry budget outside this inner loop. The stage `attempt_count` advances
+once per durable Tailor execution, not once per candidate-repair call; inner
+attempts remain in an append-only generation audit keyed by workflow execution
+and durable attempt, so a later retry cannot overwrite earlier prompts,
+candidates, validation, or judge evidence. A fifth failed durable execution is
+stored as non-retryable `exhausted` until an explicit attempt reset.
 
 ## How To Change Tailoring Safely
 

--- a/docs/developer/qa/regression-catalog.md
+++ b/docs/developer/qa/regression-catalog.md
@@ -26,11 +26,63 @@ For the affected workflow, prove four outcomes:
 
 1. Kill the worker mid-activity: the same workflow resumes from durable history
    or reaches its designed verification state.
-2. Cancel the run: cancellation propagates and the read model eventually shows a
-   terminal state without deleting completed facts.
+2. Cancel the run: cancellation propagates, the requester/source is auditable,
+   and the read model eventually shows a terminal state without deleting
+   completed facts. For batch Enrich, every unfinished selected row is
+   `canceled`, unrelated pending rows stay pending, and a restarted reconciler
+   reaches the same result from persisted ownership.
 3. Make Temporal unavailable at start: the caller receives a clear error and no
    in-process fallback runs.
 4. Lose local dev-server history: the reconciler terminalizes orphaned open rows.
+
+An Enrich restart also proves the API-to-worker ownership handoff: canonical
+`job_enrichments` state, not stale projected text, selects the reset row; a
+repeat pickup cannot bypass queued/running Enrich; and queued metadata carries
+the exact Temporal execution ID (`firstExecutionRunId`). A workflow handle is
+never accepted as an execution owner. Matching and foreign-owner worker probes
+must respectively process and reject the same prequeued fixture.
+
+Timeout and explicit cancellation are separate fault classes. A timeout,
+worker shutdown, or reset releases unfinished Enrich ownership for the same
+Temporal execution to retry; only an explicit cancellation request
+terminalizes the exact owned cohort. The successful canonical Enrich IDs, not
+the original selection, become the Score/Tailor/Cover subset. For authenticated
+LinkedIn recovery, ordinary extraction attempts do not consume the independent
+three-pass apply-URL budget, and browser extension requests remain blocked
+without being misreported as an unsafe posting redirect.
+
+Selected Tailor and Cover batches must use their requested bounded worker count.
+A durable item failure yields a partial batch with inspectable item diagnostics;
+it does not retry approved jobs or prevent Cover from running for the exact
+approved Tailor subset. Their selected-batch activity deadline scales at 30
+minutes per worker wave, capped at 6 hours and protected by a Temporal patch
+marker so replay of older open histories retains its recorded 30-minute timer.
+The heartbeat timeout remains 2 minutes. Concurrent job-specific prompt
+snapshots must retain distinct artifact fingerprints while reusing one global
+policy revision when the complete tailoring-relevant profile projection,
+profile/custom controls, learned rules, prompt/schema versions, models, judge
+settings, and validation mode are identical. A tailoring-relevant profile or
+control change advances the global revision and rejects stale artifact
+persistence; an application-only compensation/authorization/defaults edit does
+not. The canonical projection/policy comparison and artifact save share one
+SQLite write transaction. The artifact audit digest
+must match the exact role/content messages for the selected candidate, including
+target-job and retry content. Canceling a real selected Tailor or Cover batch
+after its first worker wave starts must prevent later waves, fence every
+in-flight write, cancel only unfinished rows still owned by that execution, and
+preserve both successor-owned rows and artifacts committed before cancellation.
+If a blocking runner ignores the cooperative cancel token, the worker must
+record `abandoned_thread`, retire that blocking-executor generation, and prove a
+subsequent activity can execute immediately on fresh bounded capacity. The
+abandoned generation must be distinct from Temporal's synchronous-activity
+executor so capacity recovery cannot break marker or reconciliation activities.
+Tailor's inner candidate-repair attempts are audit metadata, not the durable
+stage retry counter. Each durable activity execution increments that outer
+counter exactly once; repeated failures reach non-retryable `exhausted` at the
+configured maximum and are excluded from automatic pickup until an explicit
+attempt reset. Repeated durable executions of one materials generation must
+append audit entries keyed by execution and durable attempt rather than replace
+the prior prompt/candidate/validator/judge record.
 
 The [complete matrix](complete-checklist.md#temporal-fault-injection-matrix)
 lists the exact tests for Discover, Pipeline, Preparation, Apply, Profile Import,

--- a/docs/local-reliability-qa.md
+++ b/docs/local-reliability-qa.md
@@ -43,6 +43,36 @@ cancellation reaches a terminal observable state, an unavailable Temporal path
 fails clearly at start, and a lost dev-server history is reconciled rather than
 left open forever.
 
+Batch Enrich adds a cohort-level cancellation assertion: cancel a real
+`JobPipelineWorkflow` after its activity starts, then prove all and only its
+selected unfinished rows are `canceled`, the request identity is in the Runs
+timeline, and a fresh reconciler closes persisted ownership left by a stopped
+worker. The focused gate is:
+
+```bash
+uv --project workers/automation run python -m pytest -q \
+  workers/automation/tests/test_workflow_job_pipeline.py::test_pipeline_enrich_cancel_terminalizes_exact_selected_cohort \
+  workers/automation/tests/test_worker_reconciler.py::test_reconciler_maps_canceled_execution_to_workflow_canceled \
+  workers/automation/tests/test_worker_reconciler.py::test_reconciler_cancels_persisted_enrich_ownership_after_worker_restart
+```
+
+Restart pickup is a separate regression boundary. An Enrich reset must clear
+the predecessor owner and set the canonical enrichment aggregate to `pending`.
+Bulk pickup must ignore stale projected descriptions, must not skip an active
+Enrich owner to start Score, and must persist `firstExecutionRunId` rather than
+the workflow-handle compatibility ID. The selected worker may process a queued
+row only when both identifiers match; a foreign execution must leave it alone.
+The focused gate is:
+
+```bash
+corepack pnpm --filter @jobctrl/api exec vitest run \
+  test/server.test.ts \
+  test/write-model-state.test.ts
+uv --project workers/automation run --extra dev python -m pytest -q \
+  workers/automation/tests/test_discover_reliability.py \
+  -k 'selected_enrich_workflow_picks_up_api_prequeued_job or selected_enrich_workflow_does_not_steal_another_queued_owner'
+```
+
 Use the workflow-by-workflow matrix in the
 [Regression Catalog](developer/qa/regression-catalog.md#temporal-fault-injection)
 or the [complete checklist](developer/qa/complete-checklist.md#temporal-fault-injection-matrix).
@@ -73,12 +103,57 @@ an interrupted activity before persistence leaves one retryable owned row, and
 an interrupted acknowledgement after persistence reuses the committed score or
 accepted artifact without another model call. Profile and browser-setting
 continuations must also survive an API stop after their durable write and
-before dispatch. The focused deterministic gate is:
+before dispatch. A selected batch must honor its bounded worker count; item
+failures remain attached to their own rows while the approved Tailor subset
+continues to Cover. An activity timeout or worker shutdown is retryable and
+must not be projected as user cancellation. For an explicitly selected batch,
+the replay-versioned activity deadline is 30 minutes per worker wave, capped at
+6 hours; the 2-minute heartbeat still detects a dead worker promptly. Parallel
+Tailor jobs generated from identical safety controls must persist distinct
+job-prompt fingerprints under the same global policy revision. Changing the
+complete tailoring-relevant profile projection, learned rules, model, judge,
+schema, or validation mode must advance that global revision and fail stale
+artifact persistence closed. A compensation-, authorization-, availability-,
+EEO-, or application-preference-only profile edit must not advance the global
+tailoring policy or reject an otherwise current artifact.
+Cancel a real selected Tailor and Cover workflow after the first worker wave
+starts. No later wave may start; in-flight jobs must receive the cooperative
+cancel token; the final artifact and stage-state writes must be fenced inside
+their SQLite transactions; and the exact unfinished cohort must become
+`canceled` without overwriting a successor owner. A result committed before the
+cancel boundary remains `succeeded`. Also pause a generation after it reads the
+profile, save a new profile revision, and prove the stale generation cannot
+commit. The selected artifact's prompt fingerprint must equal a digest of the
+exact selected candidate message list. Exercise the production single-job
+Tailor and Cover runners with their default SQLite repositories as well as the
+batch workflow: cancellation during generation must leave no artifact and no
+false completed/failed terminal event for the interrupted owner. Also hold a
+blocking activity thread past its cancellation grace window: the abandoned
+generation must be recorded and fenced, and the next activity must run on fresh
+bounded executor capacity without restarting the worker.
+Repeated Tailor validation/model-repair failures must also keep the inner LLM
+attempt count separate from the durable stage execution count. Each activity
+execution advances the durable count once; the fifth durable failure becomes
+non-retryable `exhausted`, and a later pickup cannot restart it without an
+explicit attempt reset. Run at least two durable failures against the same
+materials generation and assert that both complete inner-attempt reports remain
+in the append-only audit history.
+The focused deterministic gate is:
 
 ```bash
 uv --project workers/automation run pytest -q \
   workers/automation/tests/test_score_activity_recovery.py \
   workers/automation/tests/test_material_activity_recovery.py \
+  workers/automation/tests/test_materials_unit_of_work.py \
+  workers/automation/tests/test_materials_use_cases.py \
+  workers/automation/tests/test_linkedin_authenticated_enrichment_retry.py \
+  workers/automation/tests/test_linkedin_apply_resolver.py \
+  workers/automation/tests/test_enrichment_url_safety.py \
+  workers/automation/tests/test_materials_repository.py \
+  workers/automation/tests/test_v7_tailor_runtime.py \
+  workers/automation/tests/test_v7_cover_runtime.py \
+  workers/automation/tests/test_p1b_error_inversion.py \
+  workers/automation/tests/test_temporal_worker.py \
   workers/automation/tests/test_workflow_job_preparation.py \
   workers/automation/tests/test_workflow_job_pipeline.py
 corepack pnpm --filter @jobctrl/api exec vitest run \
@@ -102,7 +177,7 @@ JOBCTRL_RELIABILITY_TEMPORAL_FIRST=1 \
 
 Both passes must retain the original Temporal run ID, complete it exactly once,
 and converge in Temporal history, the SQLite read model, API health, and the
-web-origin proxy. The complete R01-R22 scenario definitions and stop conditions
+web-origin proxy. The complete R01-R25 scenario definitions and stop conditions
 live in
 [`plans/2026-08-04-pipeline-reliability-chaos.md`](plans/2026-08-04-pipeline-reliability-chaos.md).
 

--- a/docs/plans/2026-08-04-pipeline-reliability-chaos.md
+++ b/docs/plans/2026-08-04-pipeline-reliability-chaos.md
@@ -1,6 +1,6 @@
 # Pipeline Reliability Chaos Campaign
 
-- **Status:** Implementation, complete isolated chaos campaign, and live Pipelines UI smoke pass; final independent QA gate pending
+- **Status:** R01-R24 campaign completed; R25 and live incident recovery are under final cumulative verification
 - **Authored:** 2026-08-04
 - **Environment:** Production-shaped local stack with disposable non-production data
 - **Safety boundary:** Never use `~/.jobctrl/jobctrl.db`, real applications, or real submission targets
@@ -14,8 +14,12 @@ Reliability remains simple when ownership is explicit:
 3. Recovery resumes at the earliest incomplete stage and reuses valid upstream work.
 4. Accepted scores and artifacts remain available until a replacement succeeds.
 5. Runtime inventory and durable stage state converge; zero live work cannot coexist indefinitely with `running` rows.
+6. Canceling a batch records who requested it and terminalizes every unfinished
+   member of its exact selected cohort without mutating unrelated pending work.
+7. Inner model-repair attempts and durable stage executions have separate,
+   bounded counters; retrying a failed stage must converge to `exhausted`.
 
-Every scenario below must prove those five invariants through the database, Temporal history, API operations snapshot, and rendered Pipelines UI. A scenario fails if it needs a manual retry button unless the terminal condition is explicitly non-retryable.
+Every scenario below must prove those seven invariants through the database, Temporal history, API operations snapshot, and rendered Pipelines UI. A scenario fails if it needs a manual retry button unless the terminal condition is explicitly non-retryable.
 
 ## Test Topology
 
@@ -47,6 +51,9 @@ The campaign owns an isolated `JOBCTRL_DIR`, SQLite database, Temporal data dire
 | R20 | Existing listener, stale heartbeat rows, or orphan child process | Start the supervisor again | Health identifies the actual listener/poller; the supervisor replaces or reports the conflict rather than duplicating processes. |
 | R21 | Queued and in-flight work | Restart Temporal, worker, API, and web in varied orders | Every order converges to the same durable result with no manual recovery. |
 | R22 | Mixed jobs with valid scores, missing scores, and pending materials | Trigger profile/preference continuation | Valid scores are reused, only missing/stale scores run, and downstream work begins as soon as each job is ready. |
+| R23 | Global or explicitly selected Enrich cohort running | Request cancellation through JobCtrl or Temporal, then restart the worker before/after cooperative cleanup | Requester/source is auditable; the workflow is canceled; every unfinished owned row is canceled; accepted and unrelated pending jobs are untouched; no row remains falsely pending with zero live owner. |
+| R24 | Blocking activity call ignores cancellation after its Temporal attempt ends | Hold the provider seam past the cooperative grace window while another activity waits | The late writer remains fenced; the abandoned executor generation is observable and retired; fresh bounded capacity runs the next retry/reconciliation activity without a worker restart. |
+| R25 | Tailor repeatedly fails after using its inner model-repair budget | Redeliver the activity and start a later retry workflow | Each durable execution advances the outer counter exactly once, inner attempts remain separately auditable, the fifth durable failure becomes non-retryable `exhausted`, and later pickup does not create an infinite retry/spend loop. |
 
 ## Execution Order
 
@@ -55,7 +62,9 @@ The campaign owns an isolated `JOBCTRL_DIR`, SQLite database, Temporal data dire
 3. Run dispatch/history/transport faults R11-R14.
 4. Run concurrent setting and dependency faults R15-R18.
 5. Run persistence/supervisor/restart-order faults R19-R21.
-6. Finish with mixed-state streaming scenario R22 and rerun every previously failing scenario.
+6. Finish with mixed-state streaming scenario R22, explicit Enrich cancellation
+   R23, abandoned-thread capacity recovery R24, retry-budget convergence R25,
+   and rerun every previously failing scenario.
 
 ## Evidence Per Scenario
 
@@ -67,7 +76,7 @@ Stop and fix immediately when a scenario produces orphaned `running` rows, dupli
 
 ## Findings And Repairs
 
-The campaign reproduced four independent reliability defects:
+The campaign reproduced independent reliability defects:
 
 1. Profile/preference submissions treated every submitted section as changed. A compensation-only update could therefore enqueue a broad `score -> tailor -> cover` continuation and recompute scores that already existed. Profile writes now compare the requested sections with their persisted values, suppress true no-ops, and continue preparation without forcing rescore.
 2. Condition recovery was not durably claimed before dispatch. Concurrent browser-ready notifications could start equivalent recovery work, and a shrinking cohort could change the workflow identity. Matching blocked rows now record a per-row recovery claim transactionally while every episode uses the stable resolved-condition workflow ID; concurrent starts attach to that execution and a later resolved episode may reuse the ID only after completion.
@@ -77,8 +86,104 @@ The campaign reproduced four independent reliability defects:
 6. A profile change could commit without its continuation event, or dispatch before the API recorded that intent. The profile mutation and outbox event now share one SQLite transaction. A dispatch-intent event commits before Temporal start; startup reattaches and awaits any older intended execution, coalesces only revisions proven never dispatched, and uses a deterministic workflow identity to survive acknowledgement loss.
 7. Recovery failure was initially allowed to be swallowed after a finite retry count, which could let a workflow terminalize while its rows remained `running`. Owner reconciliation is now a mandatory durable workflow step. Temporal may keep that step pending while its dependency is unavailable, but the workflow cannot publish a terminal outcome before reconciliation succeeds.
 8. The first consolidation of preparation recovery placed the shared activity under a package whose initializer imports the preparation workflow. A clean worker-registry import exposed the resulting circular initialization before deployment. The activity now lives at the neutral infrastructure boundary, and clean worker startup is a required regression check.
+9. The campaign's cancellation check proved only that `CancelledError` reached a
+   generic activity. It never asserted selected Enrich rows through SQLite, the
+   API read model, or the UI. A canceled global Enrich run therefore reset its
+   interrupted row to `pending` and left unstarted selected rows untouched. R23
+   now persists exact workflow/run ownership, terminalizes the cohort
+   cooperatively, reconciles it after restart, and records the Temporal
+   requester/source as a separate audit event.
+10. Follow-up fault injection exposed four narrower cancellation boundaries:
+    the authenticated LinkedIn pre-pass could reset before ownership; an
+    abandoned producer could write after cancellation; a failed local cancel
+    intent could suppress Temporal's requester; and a trustworthy snapshot
+    could commit before Tailor release. Enrich now owns pre-pass rows before
+    navigation, seals canceled executions with a terminal lease, conditions
+    cleanup on exact workflow/run metadata, records intent and history as
+    distinct evidence, and commits snapshot trust plus downstream release in
+    one transaction.
+11. The guarded restart path exposed two additional preparation handoff gaps.
+    Pending pickup used a stale list projection instead of the canonical
+    enrichment aggregate, so a reset cohort could be skipped; a repeated bulk
+    request could then bypass queued Enrich and start Score. The API also wrote
+    the workflow-handle compatibility ID where the worker required the exact
+    Temporal execution ID. Pickup now reads canonical enrichment status and
+    text, active upstream preparation blocks downstream pickup, and durable
+    ownership uses `firstExecutionRunId`. If that execution ID is unavailable,
+    Enrich stays pending until the selected activity claims its runtime identity.
+12. The authorized recovery exposed a 30-minute Enrich activity timeout that
+    was incorrectly interpreted as terminal cancellation. A retry could then
+    mark the interrupted row canceled and send the entire selected cohort to
+    Score, including rows without usable enrichment. Timeout, worker shutdown,
+    and reset now release unfinished ownership for retry; only an explicit
+    workflow cancellation terminalizes the exact cohort through a separate
+    durable cleanup activity. Downstream selected stages receive only the
+    canonical successful job IDs returned by the preceding stage.
+13. Authenticated LinkedIn apply-URL recovery shared its attempt cap with the
+    normal extraction cascade, so ordinary history could exhaust recovery
+    before the authenticated browser ran. Adopted Chrome extensions were also
+    blocked correctly but misattributed to the posting as a fatal unsafe URL.
+    Apply-URL recovery now has its own three-pass budget. Extension resources
+    remain blocked without poisoning the remote navigation, while loopback,
+    file, and other non-public destinations remain fatal. The exact live probe
+    upgraded a low quarantined snapshot to trusted and released Tailor before
+    the bounded cohort recovery was allowed to fan out.
+14. Selected Tailor and Cover activities ignored the requested worker count and
+    processed large cohorts serially under the same 30-minute activity ceiling.
+    They now use bounded deterministic fan-out. Per-job material failures are
+    recorded as item diagnostics and a partial batch result, allowing Cover to
+    continue only for the Tailor-approved subset instead of retrying or
+    stranding successful rows. Explicitly selected batches now receive 30
+    minutes per worker wave, capped at 6 hours, while the 2-minute heartbeat
+    remains fixed. A Temporal patch marker preserves the old 30-minute timer
+    when an already-open history replays.
+15. The per-job continuation exposed a Tailoring Policy compare-and-swap that
+    treated another job's prompt fingerprint as a user policy change. Parallel
+    jobs could therefore pay for generation and then invalidate one another at
+    artifact persistence. The rollbackable policy now fingerprints only global
+    generation controls, including the complete tailoring-relevant profile
+    projection; each artifact records its target-job prompt fingerprint
+    separately. Parallel jobs with the same controls reuse one global version,
+    while any tailoring-relevant profile or control change advances it and still
+    fails stale persistence closed. Application-only profile edits such as
+    compensation do not invalidate generated Materials.
+16. Adversarial review of that repair exposed three final commit-boundary gaps:
+    a profile save could land after generation loaded its snapshot but before
+    artifact persistence; selected Tailor/Cover cancellation had already queued
+    the full cohort and did not pass a cooperative token into each job; and the
+    per-artifact digest covered only a reusable prompt base rather than the exact
+    selected message set. Artifact persistence now compares the generation's
+    tailoring-relevant profile projection and global policy against canonical
+    current data inside the same SQLite write transaction. Selected material
+    fan-out schedules one bounded
+    worker wave at a time, stops filling slots on cancellation, fences final
+    writes and stage transitions against exact ownership, preserves a result
+    committed before cancellation, and leaves a successor owner untouched. The
+    artifact stores the digest of the exact selected role/content messages,
+    including job and retry content.
+17. The live per-job recovery then exposed a worker-capacity failure outside the
+    durable state machine: provider calls that ignored cancellation survived
+    their 30-minute Temporal attempts inside the shared executor. Four such
+    threads filled every activity slot, leaving a two-hour queue with a healthy
+    poller but zero dispatch. Blocking async activities now use a dedicated
+    bounded executor. Cancellation now retires that executor generation before
+    its grace wait, closing the race where a server-dispatched retry could enter
+    the poisoned generation. A thread that survives the grace window is then
+    recorded as abandoned, while exact ownership fences the late writer.
+18. The same recovery exposed two Tailor counters being collapsed into one.
+    Every generation invocation may use several inner model-repair attempts,
+    but the durable stage row repeatedly overwrote its outer execution count
+    with that inner count. Failed jobs could therefore remain eligible forever.
+    Tailor now advances the durable counter once per execution, records inner
+    generation attempts in an append-only audit keyed by execution and durable
+    attempt, and becomes non-retryable `exhausted` on the fifth durable failure,
+    matching the established Cover contract.
 
-No timer, polling reaper, or broad database sweep was added. Recovery is one idempotent step in the workflow that owns the work, plus a durable event dispatch when a setting resolves an explicit blocking condition. Temporal supplies delivery; the application does not add a second scheduler.
+No timer or second scheduler was added. Recovery is one idempotent step in the
+workflow that owns the work, plus a durable event dispatch when a setting
+resolves an explicit blocking condition. Worker reconciliation also checks only
+nonterminal Enrich rows carrying an exact workflow/run owner whose projected run
+is already canceled; it never mutates ownerless or unrelated pending work.
 
 ## Execution Ledger
 
@@ -92,10 +197,18 @@ No timer, polling reaper, or broad database sweep was added. Recovery is one ide
 | R14, R20 | SSE reconnect, operations/projection telemetry, launcher conflict, stale-process, and heartbeat coverage | Pass |
 | R16 | LLM retry, timeout, malformed-output, budget, and spend-limit coverage | Pass |
 | R18 | Renderer-unavailable retry and hard process-loss seam | Pass |
+| R23 | Real Enrich/Tailor/Cover `JobPipelineWorkflow` cancellation; exact selected/unrelated assertions; authenticated pre-pass child-process kill; abandoned-producer and successor-owner races; mixed local/Temporal requester audit; atomic snapshot/Tailor release; canonical restart pickup and exact execution-ID handoff; activity-timeout retry; successful-subset handoff; authenticated-recovery budget and extension-noise guard; selected-material incremental fan-out, cooperative commit fencing, committed-fact preservation, partial continuation, replay-versioned worker-wave deadline, atomic profile/policy comparison, and exact selected-message artifact fingerprints | Final verification in progress: focused automated regressions pass; authorized live recovery is still running; final independent review/QA and refreshed UI proof remain |
+| R24 | Ignored-cancellation thread held past the grace window; distinct Temporal-sync and blocking executors; executor-generation rotation; immediate subsequent activity | Pass: focused abandoned-thread and worker-construction regressions; live recovery exposed and reproduced the zero-dispatch backlog before the fix |
+| R25 | Inner Tailor retry exhaustion followed by repeated durable executions, including the fifth-failure boundary | Focused proof passes: inner exhaustion leaves outer attempt 1 retryable; two executions retain both complete audit reports; retry re-entry advances cumulatively; durable attempt 5 is `exhausted` and non-retryable. Final cumulative gates remain. |
 | Worker composition | Clean import of the complete Temporal workflow/activity registry | Pass: 10 workflows and 23 activities compose without an import cycle |
 | API cumulative | Server, profile-event, and JSON-RPC adapter suites, including loopback SSE and startup recovery | Pass: 263 tests |
 | Live Pipelines UI | Browser DOM, console, screenshot, and disclosure interaction against the running app | Pass: Enrich precedes Enrichment reconciliation; Render PDF follows Cover letter; no relevant console warning/error |
 
 The process-chaos harness owns exact PID trees, treats zombies as stopped, isolates Temporal persistence and application data, and can vary whether Temporal or the worker dies first. The first harness iterations themselves exposed two false-positive hazards—broad process matching and zombie liveness—which are now regression-protected by the stricter harness.
 
-The remaining live-runtime operation is intentionally separate from this isolated campaign: repairing legacy ownerless rows in the user's database and restarting its stack require explicit approval because those rows predate the new owner identity. The non-destructive Pipelines presentation smoke has passed on the currently running app.
+Live-runtime incident recovery remains intentionally separate from this
+isolated campaign and requires explicit authorization plus an exact backup and
+cohort guard. The authorized recovery verification exercised the repaired
+pickup and ownership handoff without adding personal row content or workflow
+identifiers to this plan. The non-destructive Pipelines, job-detail, and
+cancellation-audit presentation smoke passed on the running app.

--- a/workers/automation/src/jobctrl/domain/errors.py
+++ b/workers/automation/src/jobctrl/domain/errors.py
@@ -39,6 +39,13 @@ class LlmTransientError(JobCtrlError):
     code = "llm_transient"
 
 
+class AttemptBudgetExhaustedError(JobCtrlError):
+    """A durable stage used every configured execution attempt."""
+
+    retryable = False
+    code = "attempt_budget_exhausted"
+
+
 class BudgetExceededError(JobCtrlError):
     retryable = False
     code = "budget_exceeded"
@@ -60,6 +67,7 @@ def to_application_error(exc: Exception) -> ApplicationError:
 
 
 __all__ = [
+    "AttemptBudgetExhaustedError",
     "AuthenticationError",
     "BrowserTransientError",
     "BudgetExceededError",

--- a/workers/automation/src/jobctrl/domain/materials/policy.py
+++ b/workers/automation/src/jobctrl/domain/materials/policy.py
@@ -622,6 +622,9 @@ class TailoringPolicy:
             "prompt_fingerprint": self.prompt_fingerprint,
             "config_fingerprint": self.config_fingerprint,
             "profile_policy_fingerprint": self.profile_policy_fingerprint,
+            "profile_snapshot_fingerprint": str(
+                self.runtime_settings.get("profile_snapshot_fingerprint") or ""
+            ),
             "custom_prompt_fingerprint": self.custom_prompt_fingerprint,
             "learned_tailoring_rules": self.learned_tailoring_rules.to_dict(),
         }
@@ -657,6 +660,56 @@ def _configuration_fingerprint(
 def fingerprint_value(value: Any) -> str:
     encoded = json.dumps(value, sort_keys=True, separators=(",", ":"), default=str)
     return "sha256:" + hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+_TAILORING_PERSONAL_FIELDS = (
+    "full_name",
+    "preferred_name",
+    "email",
+    "phone",
+    "address",
+    "city",
+    "province_state",
+    "country",
+    "postal_code",
+    "linkedin_url",
+    "github_url",
+    "portfolio_url",
+    "website_url",
+)
+
+
+def tailoring_profile_projection(snapshot: Any) -> dict[str, Any]:
+    """Return every canonical profile field that can affect Materials output.
+
+    The projection deliberately excludes profile sections used only for job
+    selection or application submission (for example compensation, work
+    authorization, availability, EEO answers, application preferences, and the
+    stored application password). Those edits must not invalidate an otherwise
+    current tailored resume or cover letter.
+    """
+
+    data = snapshot.as_dict()
+    personal = data.get("personal")
+    if not isinstance(personal, MappingABC):
+        personal = {}
+    return {
+        "tenant_id": str(snapshot.tenant_id),
+        "profile_id": str(snapshot.profile_id),
+        "personal": {
+            field_name: personal.get(field_name)
+            for field_name in _TAILORING_PERSONAL_FIELDS
+        },
+        "experience": _clean_mapping(data.get("experience")),
+        "resume": _clean_mapping(data.get("resume")),
+        "resume_constraints": _clean_mapping(data.get("resume_constraints")),
+    }
+
+
+def fingerprint_profile_snapshot(snapshot: Any) -> str:
+    """Fingerprint the complete tailoring-relevant profile projection."""
+
+    return fingerprint_value(tailoring_profile_projection(snapshot))
 
 
 def _clean_mapping(value: Any) -> dict[str, Any]:
@@ -701,5 +754,7 @@ __all__ = [
     "TailoringPolicyRollbackReason",
     "WritingStylePolicy",
     "adapt_requirement_led_controls",
+    "fingerprint_profile_snapshot",
     "fingerprint_value",
+    "tailoring_profile_projection",
 ]

--- a/workers/automation/src/jobctrl/domain/materials/use_cases.py
+++ b/workers/automation/src/jobctrl/domain/materials/use_cases.py
@@ -31,7 +31,7 @@ import json
 import logging
 import re
 import uuid
-from collections.abc import Iterable, Mapping as MappingABC
+from collections.abc import Callable, Iterable, Mapping as MappingABC
 from contextlib import nullcontext
 from dataclasses import dataclass, field, replace
 from datetime import datetime, timezone
@@ -88,7 +88,12 @@ from jobctrl.domain.materials.fabrication_detector import (
     scan_prose_skill_fabrications,
     scan_resume_bullets,
 )
-from jobctrl.domain.materials.policy import LearnedTailoringRules, TailoringPolicy
+from jobctrl.domain.materials.policy import (
+    LearnedTailoringRules,
+    TailoringPolicy,
+    fingerprint_profile_snapshot,
+    fingerprint_value,
+)
 from jobctrl.domain.materials.provenance import BulletProvenance, BulletProvenanceSet
 from jobctrl.domain.materials.provenance_builder import (
     ProvenanceBindingError,
@@ -968,6 +973,7 @@ def _safe_candidate_summary(record: dict[str, Any]) -> dict[str, Any]:
         "generator": record.get("model"),
         "status": record.get("status"),
         "schema_version": record.get("schema_version"),
+        "prompt_fingerprint": record.get("prompt_fingerprint"),
         "validation": record.get("validator"),
         "judge": record.get("judge"),
         "fabrication_gate": record.get("fabrication_gate"),
@@ -976,6 +982,59 @@ def _safe_candidate_summary(record: dict[str, Any]) -> dict[str, Any]:
         "bullet_limit_overflows": record.get("bullet_limit_overflows") or [],
         "summary": _candidate_payload_summary(payload),
     }
+
+
+def _with_tailoring_attempt_audit(
+    materials: MaterialsSet,
+    *,
+    report: dict[str, Any],
+    recorded_at: str,
+    execution_id: str | None,
+    durable_attempt: int | None,
+) -> MaterialsSet:
+    """Append one durable execution's complete inner-attempt audit idempotently."""
+
+    metadata = dict(materials.metadata)
+    history: list[dict[str, Any]] = []
+    raw_history = metadata.get("tailoring_attempt_audits")
+    if isinstance(raw_history, list):
+        history = [dict(entry) for entry in raw_history if isinstance(entry, MappingABC)]
+    elif isinstance(metadata.get("tailoring_attempt_audit"), MappingABC):
+        # Preserve the singular pre-R25 record when an existing generation is
+        # first saved by the append-only writer.
+        history.append(
+            {
+                "audit_key": f"legacy:{materials.updated_at}",
+                "execution_id": None,
+                "durable_attempt": None,
+                "recorded_at": materials.updated_at,
+                "report": dict(metadata["tailoring_attempt_audit"]),
+            }
+        )
+
+    normalized_execution_id = str(execution_id or "local")
+    attempt_key = str(durable_attempt) if durable_attempt is not None else recorded_at
+    audit_key = f"{normalized_execution_id}:{attempt_key}"
+    if not any(str(entry.get("audit_key") or "") == audit_key for entry in history):
+        history.append(
+            {
+                "audit_key": audit_key,
+                "execution_id": execution_id,
+                "durable_attempt": durable_attempt,
+                "recorded_at": recorded_at,
+                "report": report,
+            }
+        )
+
+    return materials.with_metadata(
+        {
+            **metadata,
+            # Singular latest-record compatibility plus append-only history.
+            "tailoring_attempt_audit": report,
+            "tailoring_attempt_audits": history,
+        },
+        updated_at=recorded_at,
+    )
 
 
 def _voice_system_prompt() -> str:
@@ -1583,7 +1642,12 @@ class TailorResumeUseCase:
         suppress_existing_artifacts: bool = False,
         employer_analysis: EmployerAnalysis | None = None,
         requirement_fit_report: "RequirementFitReport | None" = None,
+        commit_guard: Callable[[], None] | None = None,
+        audit_execution_id: str | None = None,
+        durable_attempt: int | None = None,
     ) -> TailorOutcome:
+        if commit_guard is not None:
+            commit_guard()
         stable_job_id = job_id if job_id is not None else job.get("job_id")
         job_id = canonical_job_id(str(stable_job_id))
         # D-20: run/reuse the canonical employer analysis as the front-half
@@ -1655,6 +1719,10 @@ class TailorResumeUseCase:
             tailoring_plan=tailoring_plan,
             learned_tailoring_rules=learned_tailoring_rules,
         )
+        tailoring_policy_prompt = build_master_tailor_prompt(
+            profile_snapshot,
+            learned_tailoring_rules=learned_tailoring_rules,
+        )
         report, parsed_payload, validation, verdict = self._run_attempts(
             job=job,
             profile_snapshot=profile_snapshot,
@@ -1663,14 +1731,27 @@ class TailorResumeUseCase:
             requirement_fit_report=requirement_fit_report,
             tailoring_plan=tailoring_plan,
             tailor_prompt_base=tailor_prompt_base,
+            execution_guard=commit_guard,
         )
+        if commit_guard is not None:
+            commit_guard()
         attempts = report["attempts"]
 
         if not parsed_payload:
             # Nothing to persist beyond the empty aggregate; surface the
             # failure to the caller and emit ``ResumeFailed`` so downstream
             # observers see the attempt counter advance.
-            self._repository.save(materials)
+            materials = _with_tailoring_attempt_audit(
+                materials,
+                report=report,
+                recorded_at=created_at,
+                execution_id=audit_execution_id,
+                durable_attempt=durable_attempt,
+            )
+            with self._unit_of_work if self._unit_of_work is not None else nullcontext():
+                if commit_guard is not None:
+                    commit_guard()
+                self._repository.save(materials)
             self._publish_failed(materials, validation_errors=("exhausted_retries",), attempt=attempts)
             return TailorOutcome(
                 materials=materials,
@@ -1690,6 +1771,8 @@ class TailorResumeUseCase:
         # ``generated_text`` is byte-identical to the rendered/PDF text, and
         # ``coverage`` is the honest generation-time keyword coverage over that same
         # grounded text (GROUND-06 / success criterion 4).
+        if commit_guard is not None:
+            commit_guard()
         (
             final_payload,
             provenance_rows,
@@ -1704,6 +1787,8 @@ class TailorResumeUseCase:
             employer_analysis=employer_analysis,
             requirement_fit_report=requirement_fit_report,
         )
+        if commit_guard is not None:
+            commit_guard()
         if fabrication_error is not None:
             validation = ValidationResult.failure(
                 (*validation.errors, fabrication_error),
@@ -1712,7 +1797,7 @@ class TailorResumeUseCase:
 
         tailoring_policy = self._resolve_tailoring_policy(
             profile_snapshot=profile_snapshot,
-            prompt_text=tailor_prompt_base,
+            prompt_text=tailoring_policy_prompt,
             validation_mode=validation_mode,
             tenant_id=tenant_id,
             learned_tailoring_rules=learned_tailoring_rules,
@@ -1749,6 +1834,9 @@ class TailorResumeUseCase:
             "tailoring_policy_id": tailoring_policy.policy_id,
             "tailoring_policy_version": tailoring_policy.version,
             "tailoring_policy": policy_metadata,
+            "job_prompt_fingerprint": str(
+                report.get("selected_prompt_fingerprint") or ""
+            ),
             "prompt_version": report.get("prompt_version"),
             "schema_version": report.get("schema_version"),
             "candidate_models": report.get("candidate_models") or [],
@@ -1803,6 +1891,13 @@ class TailorResumeUseCase:
             review_required=review_required,
             updated_at=_utc_now(),
         )
+        materials = _with_tailoring_attempt_audit(
+            materials,
+            report=report,
+            recorded_at=materials.updated_at,
+            execution_id=audit_execution_id,
+            durable_attempt=durable_attempt,
+        )
         materials = materials.with_metadata(
             {
                 **dict(materials.metadata),
@@ -1838,7 +1933,13 @@ class TailorResumeUseCase:
                     verdict=verdict,
                     updated_at=_utc_now(),
                 )
-                self._repository.save(rejected)
+                with self._unit_of_work if self._unit_of_work is not None else nullcontext():
+                    self._assert_generation_persistable(
+                        policy=tailoring_policy,
+                        profile_snapshot=profile_snapshot,
+                        commit_guard=commit_guard,
+                    )
+                    self._repository.save(rejected)
                 self._publish_failed(
                     rejected,
                     validation_errors=(render,),
@@ -1877,6 +1978,11 @@ class TailorResumeUseCase:
         # writes and reopens the crash window A9 closed. Event publication and
         # projection refresh (which do commit) stay OUTSIDE the block, below.
         with self._unit_of_work if self._unit_of_work is not None else nullcontext():
+            self._assert_generation_persistable(
+                policy=tailoring_policy,
+                profile_snapshot=profile_snapshot,
+                commit_guard=commit_guard,
+            )
             if materials.is_resume_approved and prior_generation is not None:
                 self._repository.save(prior_generation)
             self._repository.save(materials)
@@ -2030,6 +2136,7 @@ class TailorResumeUseCase:
         requirement_fit_report: "RequirementFitReport | None" = None,
         tailoring_plan: TailoringPlan,
         tailor_prompt_base: str,
+        execution_guard: Callable[[], None] | None = None,
     ) -> tuple[dict, dict | None, ValidationResult, JudgeVerdict | None]:
         """Run the LLM ⇒ validate ⇒ judge attempt loop.
 
@@ -2089,6 +2196,9 @@ class TailorResumeUseCase:
             report["adversarial_review"] = selected.record.get("adversarial_review")
             report["selected_candidate"] = selected.record.get("candidate_id")
             report["selected_model"] = selected.model
+            report["selected_prompt_fingerprint"] = selected.record.get(
+                "prompt_fingerprint"
+            )
             report["post_generation_fit"] = selected.record.get("post_generation_fit")
             report["review_required"] = review_required
             report["review_blockers"] = selected.record.get("review_blockers") or []
@@ -2118,6 +2228,8 @@ class TailorResumeUseCase:
             return report, selected.payload, selected.validation, selected.verdict
 
         for attempt in range(self._max_retries + 1):
+            if execution_guard is not None:
+                execution_guard()
             report["attempts"] = attempt + 1
 
             prompt = _retry_system_prompt(tailor_prompt_base, retry_reasons)
@@ -2145,6 +2257,8 @@ class TailorResumeUseCase:
 
             approved_candidates: list[_TailorCandidate] = []
             for model in model_policy.effective_candidate_models:
+                if execution_guard is not None:
+                    execution_guard()
                 candidate = self._run_candidate(
                     messages=messages,
                     model=model,
@@ -2159,6 +2273,9 @@ class TailorResumeUseCase:
                 last_payload = candidate.payload or last_payload
                 last_validation = candidate.validation
                 last_verdict = candidate.verdict
+                report["selected_prompt_fingerprint"] = candidate.record.get(
+                    "prompt_fingerprint"
+                )
 
                 if candidate.validation.passed and (
                     candidate.verdict is None or candidate.verdict.approved
@@ -2290,6 +2407,9 @@ class TailorResumeUseCase:
             report["adversarial_review"] = best_rejected.record.get("adversarial_review")
             report["selected_candidate"] = best_rejected.record.get("candidate_id")
             report["selected_model"] = best_rejected.model
+            report["selected_prompt_fingerprint"] = best_rejected.record.get(
+                "prompt_fingerprint"
+            )
             return report, best_rejected.payload, best_rejected.validation, best_rejected.verdict
         if last_payload is not None and not last_validation.passed:
             report["status"] = "failed_validation"
@@ -2306,7 +2426,12 @@ class TailorResumeUseCase:
         expected_current_version: int,
     ) -> TailoringPolicy:
         profile = profile_snapshot.as_dict()
-        runtime_settings: dict[str, Any] = {"validation_mode": validation_mode}
+        runtime_settings: dict[str, Any] = {
+            "validation_mode": validation_mode,
+            "profile_snapshot_fingerprint": fingerprint_profile_snapshot(
+                profile_snapshot
+            ),
+        }
         if learned_tailoring_rules.rules:
             runtime_settings["learned_tailoring_rules"] = learned_tailoring_rules.to_dict()
         candidate = TailoringPolicy.from_runtime(
@@ -2340,6 +2465,23 @@ class TailorResumeUseCase:
             expected_current_version=expected_current_version,
         )
 
+    def _assert_generation_persistable(
+        self,
+        *,
+        policy: TailoringPolicy,
+        profile_snapshot: ProfileSnapshot,
+        commit_guard: Callable[[], None] | None,
+    ) -> None:
+        """Fence the final artifact write inside its transaction."""
+
+        if commit_guard is not None:
+            commit_guard()
+        if self._unit_of_work is not None and self._policy_repository is not None:
+            self._policy_repository.assert_generation_current(
+                policy,
+                profile_snapshot,
+            )
+
     def _run_candidate(
         self,
         *,
@@ -2357,6 +2499,12 @@ class TailorResumeUseCase:
             "candidate_id": candidate_id,
             "model": model,
             "schema_version": TAILORING_SCHEMA_VERSION,
+            "prompt_fingerprint": fingerprint_value(
+                [
+                    {"role": message.role, "content": message.content}
+                    for message in messages
+                ]
+            ),
         }
         empty_validation = ValidationResult.failure(("no candidate generated",))
         try:
@@ -3458,6 +3606,7 @@ class GenerateCoverLetterUseCase:
         publisher: EventPublisher | None = None,
         analysis_repository: EmployerAnalysisRepository | None = None,
         max_retries: int = 3,
+        unit_of_work: UnitOfWork | None = None,
     ) -> None:
         self._repository = repository
         self._llm = llm
@@ -3465,6 +3614,7 @@ class GenerateCoverLetterUseCase:
         self._publisher = publisher
         self._analysis_repository = analysis_repository
         self._max_retries = max_retries
+        self._unit_of_work = unit_of_work
 
     def execute(
         self,
@@ -3475,7 +3625,10 @@ class GenerateCoverLetterUseCase:
         cover_letter_dir: Path,
         validation_mode: str = "normal",
         tenant_id: TenantId = LOCAL_TENANT,
+        commit_guard: Callable[[], None] | None = None,
     ) -> CoverLetterOutcome:
+        if commit_guard is not None:
+            commit_guard()
         stable_job_id = canonical_job_id(str(job_id))
         materials = _load_current_approved_materials(self._repository, tenant_id, stable_job_id)
         if materials is None:
@@ -3524,7 +3677,10 @@ class GenerateCoverLetterUseCase:
             profile_snapshot=profile_snapshot,
             validation_mode=validation_mode,
             target_skill_terms=target_skill_terms,
+            execution_guard=commit_guard,
         )
+        if commit_guard is not None:
+            commit_guard()
 
         generated_at = _utc_now()
         prefix = _safe_filename_prefix(job)
@@ -3592,7 +3748,10 @@ class GenerateCoverLetterUseCase:
                         "cover_letter_attempts": attempt_history,
                     }
                 )
-        self._repository.save(materials)
+        with self._unit_of_work if self._unit_of_work is not None else nullcontext():
+            if commit_guard is not None:
+                commit_guard()
+            self._repository.save(materials)
 
         if validation.passed:
             self._publish_generated(materials)
@@ -3635,6 +3794,7 @@ class GenerateCoverLetterUseCase:
         profile_snapshot: ProfileSnapshot,
         validation_mode: str,
         target_skill_terms: list[str],
+        execution_guard: Callable[[], None] | None = None,
     ) -> tuple[str, ValidationResult, list[FabricationFinding]]:
         cl_prompt_base = build_cover_letter_prompt(profile_snapshot)
         # The deterministic grounding context is fixed across attempts — build it
@@ -3652,6 +3812,8 @@ class GenerateCoverLetterUseCase:
         findings: list[FabricationFinding] = []
         last_validation: ValidationResult = ValidationResult.failure(("no attempt yet",))
         for attempt in range(self._max_retries + 1):
+            if execution_guard is not None:
+                execution_guard()
             prompt = _retry_system_prompt(cl_prompt_base, retry_reasons)
             messages = [
                 LlmMessage(role="system", content=prompt),

--- a/workers/automation/src/jobctrl/domain/materials/use_cases.py
+++ b/workers/automation/src/jobctrl/domain/materials/use_cases.py
@@ -1013,8 +1013,16 @@ def _with_tailoring_attempt_audit(
         )
 
     normalized_execution_id = str(execution_id or "local")
-    attempt_key = str(durable_attempt) if durable_attempt is not None else recorded_at
-    audit_key = f"{normalized_execution_id}:{attempt_key}"
+    # The key is unique per recorded execution: a rerun of the same durable
+    # attempt (a post-``--reset-attempts`` CLI execution, or an activity retry
+    # after a crash between the materials save and the stage-count increment)
+    # must append its own report rather than silently dropping the newer one.
+    # Re-merging already persisted metadata stays idempotent because an
+    # identical ``recorded_at`` can only come from the same recorded execution.
+    if durable_attempt is not None:
+        audit_key = f"{normalized_execution_id}:{durable_attempt}:{recorded_at}"
+    else:
+        audit_key = f"{normalized_execution_id}:{recorded_at}"
     if not any(str(entry.get("audit_key") or "") == audit_key for entry in history):
         history.append(
             {

--- a/workers/automation/src/jobctrl/domain/ports/materials.py
+++ b/workers/automation/src/jobctrl/domain/ports/materials.py
@@ -37,6 +37,7 @@ from jobctrl.domain.operations.learning import (
     LearningRecommendationDecision,
     LearningRecommendationReview,
 )
+from jobctrl.domain.profile.snapshot import ProfileSnapshot
 from jobctrl.domain.tenant import TenantId
 
 
@@ -223,6 +224,14 @@ class TailoringPolicyRepository(Protocol):
         expected_current_version: int | None = None,
     ) -> TailoringPolicy:
         """Resolve the candidate only if the pre-generation snapshot is current."""
+        ...
+
+    def assert_generation_current(
+        self,
+        policy: TailoringPolicy,
+        profile_snapshot: ProfileSnapshot,
+    ) -> None:
+        """Fence artifact persistence against profile or policy advancement."""
         ...
 
     def rollback_to(

--- a/workers/automation/src/jobctrl/infrastructure/materials/sqlite_repository.py
+++ b/workers/automation/src/jobctrl/infrastructure/materials/sqlite_repository.py
@@ -32,6 +32,7 @@ from jobctrl.domain.materials.policy import (
     TailoringPolicy,
     TailoringPolicyChangedError,
     TailoringPolicyRollbackReason,
+    fingerprint_profile_snapshot,
 )
 from jobctrl.domain.operations.learning import (
     LearningRecommendationDecision,
@@ -46,6 +47,7 @@ from jobctrl.domain.materials.value_objects import (
     ValidationResult,
 )
 from jobctrl.domain.tenant import LOCAL_TENANT, TenantId
+from jobctrl.domain.profile.snapshot import ProfileSnapshot
 from jobctrl.infrastructure.materials.unit_of_work import SqliteUnitOfWork
 from jobctrl.scoring.eligibility_sql import (
     register_score_eligibility_sql,
@@ -1108,8 +1110,14 @@ class SqliteLearningRecommendationReviewRepository:
 class SqliteTailoringPolicyRepository:
     """SQLite-backed current policy adapter for the Materials context."""
 
-    def __init__(self, conn: sqlite3.Connection) -> None:
+    def __init__(
+        self,
+        conn: sqlite3.Connection,
+        *,
+        unit_of_work: SqliteUnitOfWork | None = None,
+    ) -> None:
         self._conn = conn
+        self._unit_of_work = unit_of_work
         ensure_tailoring_policy_tables(conn)
 
     def get_current(self, tenant_id: TenantId) -> TailoringPolicy | None:
@@ -1217,13 +1225,21 @@ class SqliteTailoringPolicyRepository:
         *,
         expected_current_version: int | None = None,
     ) -> TailoringPolicy:
-        self._conn.execute("BEGIN IMMEDIATE")
+        owns_transaction = not (
+            self._unit_of_work is not None and self._unit_of_work.active
+        )
+        if owns_transaction:
+            self._conn.execute("BEGIN IMMEDIATE")
         try:
             current = self.get_current(candidate.tenant_id)
             actual_current_version = 0 if current is None else current.version
             if (
                 expected_current_version is not None
                 and actual_current_version != expected_current_version
+                and (
+                    current is None
+                    or not current.same_config_as(candidate)
+                )
             ):
                 raise TailoringPolicyChangedError(
                     "tailoring policy advanced before artifact persistence"
@@ -1234,7 +1250,8 @@ class SqliteTailoringPolicyRepository:
                     created_at=candidate.created_at,
                 )
             if current is not None and current.same_config_as(candidate):
-                self._conn.commit()
+                if owns_transaction:
+                    self._conn.commit()
                 return current
 
             next_version = 1 if current is None else current.version + 1
@@ -1257,11 +1274,62 @@ class SqliteTailoringPolicyRepository:
                 created_from_event_id=candidate.created_from_event_id,
             )
             self._insert(policy)
-            self._conn.commit()
+            if owns_transaction:
+                self._conn.commit()
             return policy
         except Exception:
-            self._conn.rollback()
+            if owns_transaction:
+                self._conn.rollback()
             raise
+
+    def assert_generation_current(
+        self,
+        policy: TailoringPolicy,
+        profile_snapshot: ProfileSnapshot,
+    ) -> None:
+        """Assert tailoring-relevant profile and policy identity atomically."""
+
+        if self._unit_of_work is None or not self._unit_of_work.active:
+            raise RuntimeError(
+                "tailoring generation fence requires an active unit of work"
+            )
+        if policy.runtime_settings.get(
+            "profile_snapshot_fingerprint"
+        ) != fingerprint_profile_snapshot(profile_snapshot):
+            raise TailoringPolicyChangedError(
+                "tailoring profile snapshot changed before artifact persistence"
+            )
+        from jobctrl.infrastructure.events.in_process_bus import InProcessEventBus
+        from jobctrl.infrastructure.profile.sqlite_repository import (
+            SqliteProfileRepository,
+        )
+
+        try:
+            current_profile_snapshot = SqliteProfileRepository(
+                self._conn,
+                publisher=InProcessEventBus(),
+                profile_id=str(profile_snapshot.profile_id),
+                initialize_schema=False,
+            ).load_snapshot(profile_snapshot.tenant_id)
+        except FileNotFoundError as exc:
+            raise TailoringPolicyChangedError(
+                "tailoring profile disappeared before artifact persistence"
+            ) from exc
+        if fingerprint_profile_snapshot(
+            current_profile_snapshot
+        ) != fingerprint_profile_snapshot(profile_snapshot):
+            raise TailoringPolicyChangedError(
+                "tailoring-relevant profile data changed before artifact persistence"
+            )
+        current = self.get_current(policy.tenant_id)
+        if (
+            current is None
+            or current.version != policy.version
+            or not current.same_config_as(policy)
+        ):
+            raise TailoringPolicyChangedError(
+                "tailoring policy advanced before artifact persistence"
+            )
 
     def rollback_to(
         self,

--- a/workers/automation/src/jobctrl/infrastructure/preparation_recovery.py
+++ b/workers/automation/src/jobctrl/infrastructure/preparation_recovery.py
@@ -26,6 +26,22 @@ class RecoverPreparationStateOutput:
     failed: int = 0
 
 
+@dataclass(frozen=True)
+class CancelPreparationStateInput:
+    tenant_id: str
+    workflow_id: str
+    stage: str
+    job_ids: tuple[str, ...]
+    expected_app_dir: str | None = None
+    expected_db_path: str | None = None
+
+
+@dataclass(frozen=True)
+class CancelPreparationStateOutput:
+    canceled: int = 0
+    restored: int = 0
+
+
 @activity.defn(name="recover_preparation_state")
 async def recover_preparation_state_activity(
     payload: RecoverPreparationStateInput,
@@ -40,6 +56,122 @@ async def recover_preparation_state_activity(
     return recover_preparation_state_rows(get_connection(), payload)
 
 
+@activity.defn(name="cancel_preparation_state")
+async def cancel_preparation_state_activity(
+    payload: CancelPreparationStateInput,
+) -> CancelPreparationStateOutput:
+    from jobctrl.database import get_connection
+    from jobctrl.infrastructure.temporal.runtime_guard import assert_activity_runtime
+
+    assert_activity_runtime(
+        expected_app_dir=payload.expected_app_dir,
+        expected_db_path=payload.expected_db_path,
+    )
+    return cancel_preparation_state_rows(get_connection(), payload)
+
+
+def cancel_preparation_state_rows(
+    conn: Any,
+    payload: CancelPreparationStateInput,
+) -> CancelPreparationStateOutput:
+    """Cancel only unfinished selected material rows still owned by this run."""
+
+    if payload.stage not in {"tailor", "cover"}:
+        raise ValueError("material cancellation supports tailor or cover")
+    from jobctrl.domain.tenant import TenantId
+    from jobctrl.state import record_job_event, set_stage_state, utc_now
+
+    job_ids = tuple(dict.fromkeys(str(canonical_job_id(value)) for value in payload.job_ids))
+    if job_ids:
+        placeholders = ", ".join("?" for _ in job_ids)
+        rows = conn.execute(
+            "SELECT job_id, state, attempt_count, started_at, metadata_json "
+            "FROM job_stage_states WHERE tenant_id = ? AND stage = ? "
+            f"AND job_id IN ({placeholders})",
+            (payload.tenant_id, payload.stage, *job_ids),
+        ).fetchall()
+    else:
+        rows = conn.execute(
+            "SELECT job_id, state, attempt_count, started_at, metadata_json "
+            "FROM job_stage_states WHERE tenant_id = ? AND stage = ? "
+            "AND json_extract(metadata_json, '$.activityOwner') = ?",
+            (payload.tenant_id, payload.stage, payload.workflow_id),
+        ).fetchall()
+    tenant_id = TenantId(payload.tenant_id)
+    finished_at = utc_now()
+    canceled = 0
+    restored = 0
+    try:
+        for row in rows:
+            state = str(row["state"])
+            metadata = _metadata(row["metadata_json"])
+            owner = str(metadata.get("activityOwner") or "")
+            if state in {"succeeded", "skipped", "exhausted", "canceled"}:
+                continue
+            if state in {"queued", "running"} and owner != payload.workflow_id:
+                continue
+            if state not in {"pending", "queued", "running"}:
+                continue
+            job_id = canonical_job_id(str(row["job_id"]))
+            if state == "running" and owner == payload.workflow_id and _material_commit_exists(
+                conn,
+                payload=payload,
+                tenant_id=tenant_id,
+                job_id=job_id,
+                metadata=metadata,
+            ):
+                _restore_committed(
+                    conn,
+                    payload=payload,
+                    tenant_id=tenant_id,
+                    job_id=job_id,
+                    row=row,
+                    finished_at=finished_at,
+                    reason=f"canceled_activity_preserved_committed_{payload.stage}",
+                    message="Committed result preserved while its workflow was canceled.",
+                )
+                restored += 1
+                continue
+            set_stage_state(
+                conn,
+                job_id,
+                payload.stage,
+                "canceled",
+                tenant_id=tenant_id,
+                attempt_count=int(row["attempt_count"] or 0),
+                finished_at=finished_at,
+                error_code="WORKFLOW_CANCELED",
+                error_message="Stage canceled with its owning workflow.",
+                retryable=True,
+                next_action=f"retry {payload.stage}",
+                metadata={
+                    "activityOwner": payload.workflow_id,
+                    "cancellationReason": "workflow_canceled",
+                },
+                validate_transition=False,
+            )
+            record_job_event(
+                conn,
+                job_id,
+                payload.stage,
+                "StageCanceled",
+                tenant_id=tenant_id,
+                level="warning",
+                message="Stage canceled with its owning workflow.",
+                payload={
+                    "reason": "workflow_canceled",
+                    "workflowId": payload.workflow_id,
+                    "canceledAt": finished_at,
+                },
+            )
+            canceled += 1
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
+    return CancelPreparationStateOutput(canceled=canceled, restored=restored)
+
+
 def recover_preparation_state_rows(
     conn: Any,
     payload: RecoverPreparationStateInput,
@@ -47,14 +179,12 @@ def recover_preparation_state_rows(
     """Accept committed work or fail only rows owned by the stopped workflow."""
     if payload.stage not in {"score", "tailor", "cover"}:
         raise ValueError("preparation recovery supports score, tailor, or cover")
-    from jobctrl.domain.materials.value_objects import ArtifactStatus
     from jobctrl.domain.tenant import TenantId
-    from jobctrl.infrastructure.materials import SqliteMaterialsRepository
     from jobctrl.state import utc_now
 
     rows = conn.execute(
         """
-        SELECT job_id, attempt_count, started_at, metadata_json
+        SELECT job_id, attempt_count, max_attempts, started_at, metadata_json
           FROM job_stage_states
          WHERE tenant_id = ?
            AND stage = ?
@@ -64,39 +194,19 @@ def recover_preparation_state_rows(
         (payload.tenant_id, payload.stage, payload.workflow_id),
     ).fetchall()
     tenant_id = TenantId(payload.tenant_id)
-    repository = SqliteMaterialsRepository(conn) if payload.stage != "score" else None
     finished_at = utc_now()
     restored = 0
     failed = 0
     for row in rows:
         job_id = canonical_job_id(str(row["job_id"]))
         metadata = _metadata(row["metadata_json"])
-        committed = False
-        if payload.stage == "score":
-            score_row = conn.execute(
-                "SELECT COALESCE(MAX(version), 0) AS version FROM job_scores WHERE tenant_id = ? AND job_id = ?",
-                (payload.tenant_id, str(job_id)),
-            ).fetchone()
-            current_version = int(score_row["version"] if score_row else 0)
-            prior_version = int(metadata.get("priorScoreVersion") or 0)
-            committed = current_version > prior_version if bool(metadata.get("rescore")) else current_version > 0
-        elif payload.stage == "tailor":
-            assert repository is not None
-            materials = repository.load_current_approved(tenant_id, job_id)
-            if materials is not None and materials.is_resume_approved:
-                prior_generation = int(metadata.get("priorApprovedGeneration") or 0)
-                committed = (
-                    not bool(metadata.get("retailor"))
-                    or int(materials.generation) > prior_generation
-                )
-        else:
-            assert repository is not None
-            materials = repository.load_current_approved(tenant_id, job_id)
-            committed = (
-                materials is not None
-                and materials.cover_letter is not None
-                and materials.cover_letter.status is ArtifactStatus.APPROVED
-            )
+        committed = _preparation_commit_exists(
+            conn,
+            payload=payload,
+            tenant_id=tenant_id,
+            job_id=job_id,
+            metadata=metadata,
+        )
         if committed:
             _restore_committed(
                 conn,
@@ -138,17 +248,116 @@ def stage_completed_by_activity_owner(
     return _metadata(row["metadata_json"]).get("activityOwner") == workflow_id
 
 
-def _restore_committed(conn, *, payload, tenant_id, job_id, row, finished_at) -> None:
+def assert_material_activity_commit_allowed(
+    conn: Any,
+    *,
+    tenant_id: str,
+    job_id: str,
+    stage: str,
+    workflow_id: str | None,
+    cancel_event: Any | None = None,
+) -> None:
+    """Fence a material write against cancellation or a successor owner."""
+
+    if cancel_event is not None and cancel_event.is_set():
+        raise RuntimeError(f"{stage} activity canceled before persistence")
+    if not workflow_id:
+        return
+    row = conn.execute(
+        "SELECT state, metadata_json FROM job_stage_states "
+        "WHERE tenant_id = ? AND job_id = ? AND stage = ?",
+        (tenant_id, job_id, stage),
+    ).fetchone()
+    if (
+        row is None
+        or str(row["state"]) != "running"
+        or _metadata(row["metadata_json"]).get("activityOwner") != workflow_id
+    ):
+        raise RuntimeError(f"{stage} activity no longer owns artifact persistence")
+
+
+def _preparation_commit_exists(
+    conn,
+    *,
+    payload,
+    tenant_id,
+    job_id,
+    metadata: dict[str, Any],
+) -> bool:
+    if payload.stage == "score":
+        score_row = conn.execute(
+            "SELECT COALESCE(MAX(version), 0) AS version FROM job_scores "
+            "WHERE tenant_id = ? AND job_id = ?",
+            (payload.tenant_id, str(job_id)),
+        ).fetchone()
+        current_version = int(score_row["version"] if score_row else 0)
+        prior_version = int(metadata.get("priorScoreVersion") or 0)
+        return (
+            current_version > prior_version
+            if bool(metadata.get("rescore"))
+            else current_version > 0
+        )
+    return _material_commit_exists(
+        conn,
+        payload=payload,
+        tenant_id=tenant_id,
+        job_id=job_id,
+        metadata=metadata,
+    )
+
+
+def _material_commit_exists(
+    conn,
+    *,
+    payload,
+    tenant_id,
+    job_id,
+    metadata: dict[str, Any],
+) -> bool:
+    from jobctrl.domain.materials.value_objects import ArtifactStatus
+    from jobctrl.infrastructure.materials import SqliteMaterialsRepository
+
+    repository = SqliteMaterialsRepository(conn)
+    materials = repository.load_current_approved(tenant_id, job_id)
+    if payload.stage == "tailor":
+        if materials is None or not materials.is_resume_approved:
+            return False
+        prior_generation = int(metadata.get("priorApprovedGeneration") or 0)
+        return (
+            not bool(metadata.get("retailor"))
+            or int(materials.generation) > prior_generation
+        )
+    if payload.stage == "cover":
+        return bool(
+            materials is not None
+            and materials.cover_letter is not None
+            and materials.cover_letter.status is ArtifactStatus.APPROVED
+        )
+    raise ValueError("material commit check supports tailor or cover")
+
+
+def _restore_committed(
+    conn,
+    *,
+    payload,
+    tenant_id,
+    job_id,
+    row,
+    finished_at,
+    reason: str | None = None,
+    message: str = "Committed result restored after its activity owner stopped.",
+) -> None:
     from jobctrl.state import record_job_event, set_stage_state
 
-    reason = f"orphaned_activity_restored_committed_{payload.stage}"
+    reason = reason or f"orphaned_activity_restored_committed_{payload.stage}"
+    recovered_attempt_count = _recovered_attempt_count(payload=payload, row=row)
     set_stage_state(
         conn,
         job_id,
         payload.stage,
         "succeeded",
         tenant_id=tenant_id,
-        attempt_count=max(1, int(row["attempt_count"] or 0)),
+        attempt_count=recovered_attempt_count,
         started_at=str(row["started_at"] or finished_at),
         finished_at=finished_at,
         metadata={
@@ -164,7 +373,7 @@ def _restore_committed(conn, *, payload, tenant_id, job_id, row, finished_at) ->
         payload.stage,
         "StageCompleted",
         tenant_id=tenant_id,
-        message="Committed result restored after its activity owner stopped.",
+        message=message,
         payload={"reason": reason, "workflowId": payload.workflow_id},
     )
 
@@ -173,19 +382,26 @@ def _fail_uncommitted(conn, *, payload, tenant_id, job_id, row, finished_at) -> 
     from jobctrl.state import record_job_event, set_stage_state
 
     error_code = f"{payload.stage.upper()}_ACTIVITY_OWNER_STOPPED"
+    recovered_attempt_count = _recovered_attempt_count(payload=payload, row=row)
+    max_attempts = int(row["max_attempts"]) if row["max_attempts"] is not None else None
+    exhausted = max_attempts is not None and recovered_attempt_count >= max_attempts
     set_stage_state(
         conn,
         job_id,
         payload.stage,
-        "failed",
+        "exhausted" if exhausted else "failed",
         tenant_id=tenant_id,
-        attempt_count=int(row["attempt_count"] or 0) + 1,
+        attempt_count=recovered_attempt_count,
         started_at=str(row["started_at"] or finished_at),
         finished_at=finished_at,
         error_code=error_code,
         error_message="The activity stopped before committing its result.",
-        retryable=True,
-        next_action=f"retry {payload.stage}",
+        retryable=not exhausted,
+        next_action=(
+            f"retry {payload.stage} --reset-attempts"
+            if exhausted
+            else f"retry {payload.stage}"
+        ),
         metadata={
             "recoveredFromWorkflowId": payload.workflow_id,
             "reason": "orphaned_activity_failed",
@@ -196,16 +412,34 @@ def _fail_uncommitted(conn, *, payload, tenant_id, job_id, row, finished_at) -> 
         conn,
         job_id,
         payload.stage,
-        "StageFailed",
+        "StageExhausted" if exhausted else "StageFailed",
         tenant_id=tenant_id,
         level="error",
-        message="Activity stopped before completion.",
+        message=(
+            "Activity stopped after exhausting the durable retry budget."
+            if exhausted
+            else "Activity stopped before completion."
+        ),
         payload={
             "reason": "orphaned_activity_failed",
-            "retryable": True,
+            "retryable": not exhausted,
+            "attemptCount": recovered_attempt_count,
+            "maxAttempts": max_attempts,
             "workflowId": payload.workflow_id,
         },
     )
+
+
+def _recovered_attempt_count(*, payload, row) -> int:
+    """Count an interrupted durable execution once across worker versions."""
+    current = int(row["attempt_count"] or 0)
+    metadata = _metadata(row["metadata_json"])
+    # Cover historically pre-incremented its running row. New material runners
+    # mark the row as a completed-count basis, matching Score and Tailor. Keep
+    # old open Cover histories replay-safe while advancing all new executions.
+    if payload.stage == "cover" and metadata.get("attemptCountBasis") != "completed":
+        return max(1, current)
+    return current + 1
 
 
 def _metadata(value: object) -> dict[str, Any]:

--- a/workers/automation/src/jobctrl/infrastructure/temporal/registry.py
+++ b/workers/automation/src/jobctrl/infrastructure/temporal/registry.py
@@ -25,7 +25,10 @@ from jobctrl.discovery.manual_capture_workflow import (
     manual_capture_import_activity,
 )
 from jobctrl.discovery.workflow import DiscoverWorkflow
-from jobctrl.enrichment.activities import enrich_activity
+from jobctrl.enrichment.activities import (
+    cancel_enrichment_cohort_activity,
+    enrich_activity,
+)
 from jobctrl.infrastructure.compensation.workflow import (
     CompensationRefreshWorkflow,
     refresh_compensation_activity,
@@ -47,7 +50,10 @@ from jobctrl.materials.activities import (
 )
 from jobctrl.pipeline.workflow import JobPipelineWorkflow
 from jobctrl.pipeline.preparation import derive_preparation_targets
-from jobctrl.infrastructure.preparation_recovery import recover_preparation_state_activity
+from jobctrl.infrastructure.preparation_recovery import (
+    cancel_preparation_state_activity,
+    recover_preparation_state_activity,
+)
 from jobctrl.preparation.workflow import JobPreparationWorkflow
 from jobctrl.profile.activities import profile_import_activity
 from jobctrl.profile.workflow import ProfileImportWorkflow
@@ -72,9 +78,11 @@ ACTIVITIES: list[Callable[..., Any]] = [
     discovery_enrichment_activity,
     discovery_preparation_fanout_activity,
     enrich_activity,
+    cancel_enrichment_cohort_activity,
     score_activity,
     score_job_activity,
     recover_preparation_state_activity,
+    cancel_preparation_state_activity,
     tailor_activity,
     tailor_job_activity,
     cover_activity,

--- a/workers/automation/src/jobctrl/materials/activities.py
+++ b/workers/automation/src/jobctrl/materials/activities.py
@@ -2,15 +2,21 @@
 
 from __future__ import annotations
 
+from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
 from dataclasses import dataclass, field, replace
 import threading
 import time
-from typing import Any
+from typing import Any, Callable
 
 from temporalio import activity
 
 from jobctrl.domain.discovery.execution import DiscoveryExecutionRef
-from jobctrl.domain.errors import JobCtrlError, LlmTransientError, to_application_error
+from jobctrl.domain.errors import (
+    AttemptBudgetExhaustedError,
+    JobCtrlError,
+    LlmTransientError,
+    to_application_error,
+)
 from jobctrl.domain.identifiers import JobId, canonical_job_id
 from jobctrl.infrastructure.temporal.pipeline_step_lifecycle import (
     PipelineStepScope,
@@ -261,10 +267,9 @@ def _run_selected_tailoring(
     skipped = 0
     failed = 0
     errors: dict[str, str] = {}
-    for job_id in job_ids:
-        if cancel_event is not None and cancel_event.is_set():
-            raise LlmTransientError("tailor activity canceled")
-        result = tailor_job_by_id(
+
+    def run_one(job_id: JobId) -> dict[str, Any]:
+        return tailor_job_by_id(
             job_id,
             min_score=payload.min_score,
             validation_mode=payload.validation_mode,
@@ -278,7 +283,16 @@ def _run_selected_tailoring(
             tailor_judge_model=payload.tailor_judge_model,
             tailor_judge_min_score=payload.tailor_judge_min_score,
             workflow_id=payload.workflow_id,
+            cancel_event=cancel_event,
         )
+
+    for job_id, result in _run_selected_material_jobs(
+        job_ids,
+        workers=payload.workers,
+        cancel_event=cancel_event,
+        stage="tailor",
+        run_one=run_one,
+    ):
         status = str(result.get("status") or "error")
         if status in {"approved", "already_done"}:
             approved += 1
@@ -290,11 +304,14 @@ def _run_selected_tailoring(
             errors[str(job_id)] = str(result.get("error") or f"Tailoring ended with status {status}")
 
     elapsed = time.time() - t0
-    status = "failed" if errors else "ok"
+    status = "partial" if errors else "ok"
     return {
         "status": status,
         "elapsed": elapsed,
-        "errors": errors,
+        # Per-job failures are terminal item outcomes, not a systemic activity
+        # failure. Keep them on the stage detail so approved jobs can continue
+        # to Cover without retrying or hiding the failed rows.
+        "errors": {},
         "stages": [
             {
                 "stage": "tailor",
@@ -306,6 +323,7 @@ def _run_selected_tailoring(
                 "approvedJobIds": approved_job_ids,
                 "skipped": skipped,
                 "failed": failed,
+                "itemErrors": errors,
             }
         ],
     }
@@ -334,14 +352,20 @@ async def tailor_job_activity(payload: TailorJobActivityInput) -> TailorJobActiv
             workflow_id=owned_payload.workflow_id or "",
             stage="tailor",
         )
+    cancel_event = threading.Event()
     try:
         result = await run_blocking_with_heartbeat(
-            lambda: _tailor_one_job(owned_payload),
+            lambda: _tailor_one_job(owned_payload, cancel_event=cancel_event),
             starting_message="tailor-job starting",
             progress_message="tailor-job still running",
+            on_cancel=cancel_event.set,
             activity_name="tailor_job",
         )
         status = str(result.get("status") or "error")
+        if status == "exhausted":
+            raise AttemptBudgetExhaustedError(
+                str(result.get("error") or "Tailor durable attempt budget exhausted")
+            )
         if status not in {"approved", "skipped", "not_eligible", "already_done"}:
             raise LlmTransientError(str(result.get("error") or f"Tailoring ended with status {status}"))
         materials = result.get("materials")
@@ -358,7 +382,11 @@ async def tailor_job_activity(payload: TailorJobActivityInput) -> TailorJobActiv
         raise to_application_error(exc) from exc
 
 
-def _tailor_one_job(payload: TailorJobActivityInput) -> dict[str, Any]:
+def _tailor_one_job(
+    payload: TailorJobActivityInput,
+    *,
+    cancel_event: threading.Event | None = None,
+) -> dict[str, Any]:
     from jobctrl.domain.tenant import TenantId
     from jobctrl.scoring.tailor import tailor_job_by_id
 
@@ -376,6 +404,7 @@ def _tailor_one_job(payload: TailorJobActivityInput) -> dict[str, Any]:
         tailor_judge_model=payload.tailor_judge_model,
         tailor_judge_min_score=payload.tailor_judge_min_score,
         workflow_id=payload.workflow_id,
+        cancel_event=cancel_event,
     )
 
 
@@ -393,6 +422,7 @@ class CoverActivityInput:
     expected_db_path: str | None = None
     min_score: int = 7
     limit: int = 0
+    workers: int = 1
     validation_mode: str = "normal"
     dry_run: bool = False
     job_ids: tuple[JobId, ...] = ()
@@ -588,17 +618,25 @@ def _run_selected_cover(
     failed = 0
     errors: dict[str, str] = {}
     results: list[dict[str, Any]] = []
-    for job_id in job_ids:
-        if cancel_event is not None and cancel_event.is_set():
-            raise LlmTransientError("cover activity canceled")
-        result = cover_letter_by_id(
+
+    def run_one(job_id: JobId) -> dict[str, Any]:
+        return cover_letter_by_id(
             job_id,
             min_score=payload.min_score,
             validation_mode=payload.validation_mode,
             llm_model=payload.llm_model,
             tenant_id=TenantId(payload.tenant_id),
             workflow_id=payload.workflow_id,
+            cancel_event=cancel_event,
         )
+
+    for job_id, result in _run_selected_material_jobs(
+        job_ids,
+        workers=payload.workers,
+        cancel_event=cancel_event,
+        stage="cover",
+        run_one=run_one,
+    ):
         results.append(result)
         result_status = str(result.get("status") or "error")
         if result_status in {"ok", "already_done"}:
@@ -609,11 +647,11 @@ def _run_selected_cover(
             failed += 1
             errors[str(job_id)] = str(result.get("error") or f"Cover ended with status {result_status}")
     elapsed = time.time() - t0
-    status = "failed" if errors else "ok"
+    status = "partial" if errors else "ok"
     return {
         "status": status,
         "elapsed": elapsed,
-        "errors": errors,
+        "errors": {},
         "stages": [
             {
                 "stage": "cover",
@@ -623,10 +661,79 @@ def _run_selected_cover(
                 "generated": generated,
                 "skipped": skipped,
                 "failed": failed,
+                "itemErrors": errors,
                 "results": results,
             }
         ],
     }
+
+
+def _run_selected_material_jobs(
+    job_ids: tuple[JobId, ...],
+    *,
+    workers: int,
+    cancel_event: threading.Event | None,
+    stage: str,
+    run_one: Callable[[JobId], dict[str, Any]],
+) -> list[tuple[JobId, dict[str, Any]]]:
+    """Run selected material jobs with bounded, deterministic fan-out."""
+
+    if not job_ids:
+        return []
+    worker_count = min(max(1, int(workers or 1)), len(job_ids))
+
+    def ensure_active() -> None:
+        if cancel_event is not None and cancel_event.is_set():
+            raise LlmTransientError(f"{stage} activity canceled")
+
+    if worker_count == 1:
+        results: list[tuple[JobId, dict[str, Any]]] = []
+        for job_id in job_ids:
+            ensure_active()
+            results.append((job_id, run_one(job_id)))
+        return results
+
+    ensure_active()
+    executor = ThreadPoolExecutor(
+        max_workers=worker_count,
+        thread_name_prefix=f"selected-{stage}",
+    )
+    in_flight: dict[Future[dict[str, Any]], JobId] = {}
+    completed: dict[JobId, dict[str, Any]] = {}
+    next_index = 0
+
+    def fill_worker_slots() -> None:
+        nonlocal next_index
+        while next_index < len(job_ids) and len(in_flight) < worker_count:
+            ensure_active()
+            job_id = job_ids[next_index]
+            next_index += 1
+            in_flight[executor.submit(run_one, job_id)] = job_id
+
+    try:
+        fill_worker_slots()
+        while in_flight:
+            ensure_active()
+            done, _pending = wait(
+                tuple(in_flight),
+                timeout=0.1,
+                return_when=FIRST_COMPLETED,
+            )
+            for future in done:
+                job_id = in_flight.pop(future)
+                completed[job_id] = future.result()
+            fill_worker_slots()
+        return [(job_id, completed[job_id]) for job_id in job_ids]
+    finally:
+        canceled = cancel_event is not None and cancel_event.is_set()
+        if canceled:
+            for future in in_flight:
+                future.cancel()
+        # A cooperative cancellation must release the parent activity thread
+        # promptly. Already-running calls may finish in the background, but
+        # their per-item commit guard observes the same token and durable owner
+        # row before any artifact or terminal-state write.
+        executor.shutdown(wait=not canceled, cancel_futures=True)
 
 
 _SUCCESS_STATUSES = {"ok", "partial", "skipped", "already_done"}
@@ -652,11 +759,13 @@ async def cover_letter_activity(payload: CoverLetterActivityInput) -> CoverLette
             workflow_id=owned_payload.workflow_id or "",
             stage="cover",
         )
+    cancel_event = threading.Event()
     try:
         result = await run_blocking_with_heartbeat(
-            lambda: _cover_one_job(owned_payload),
+            lambda: _cover_one_job(owned_payload, cancel_event=cancel_event),
             starting_message="cover-letter starting",
             progress_message="cover-letter still running",
+            on_cancel=cancel_event.set,
             activity_name="cover_letter",
         )
         status = str(result.get("status") or "error")
@@ -674,7 +783,11 @@ async def cover_letter_activity(payload: CoverLetterActivityInput) -> CoverLette
         raise to_application_error(exc) from exc
 
 
-def _cover_one_job(payload: CoverLetterActivityInput) -> dict[str, Any]:
+def _cover_one_job(
+    payload: CoverLetterActivityInput,
+    *,
+    cancel_event: threading.Event | None = None,
+) -> dict[str, Any]:
     from jobctrl.domain.tenant import TenantId
     from jobctrl.scoring.cover_letter import cover_letter_by_id
 
@@ -685,6 +798,7 @@ def _cover_one_job(payload: CoverLetterActivityInput) -> dict[str, Any]:
         llm_model=payload.llm_model,
         tenant_id=TenantId(payload.tenant_id),
         workflow_id=payload.workflow_id,
+        cancel_event=cancel_event,
     )
 
 

--- a/workers/automation/src/jobctrl/pipeline/runner.py
+++ b/workers/automation/src/jobctrl/pipeline/runner.py
@@ -30,7 +30,12 @@ from jobctrl.domain.discovery.scheduler import (
 )
 from jobctrl.domain.discovery.execution import DiscoveryExecutionRef
 from jobctrl.domain.discovery.source_registry import SourceKind, SourcePriority, SourceState
-from jobctrl.domain.errors import LlmTransientError, SourceUnavailableError, TransientNetworkError
+from jobctrl.domain.errors import (
+    AttemptBudgetExhaustedError,
+    LlmTransientError,
+    SourceUnavailableError,
+    TransientNetworkError,
+)
 from jobctrl.domain.enrichment import (
     EnrichmentExecutionLease,
     StaleEnrichmentExecutionLease,
@@ -2500,6 +2505,11 @@ def _run_tailor(
         raise LlmTransientError("tailoring canceled")
     failed = int(result.get("failed") or 0)
     errors = int(result.get("errors") or 0)
+    exhausted = int(result.get("exhausted") or 0)
+    if exhausted:
+        raise AttemptBudgetExhaustedError(
+            f"{exhausted} tailored resume(s) exhausted the durable attempt budget"
+        )
     if errors:
         raise LlmTransientError(
             f"{errors} tailoring error(s), {failed} failed quality gate(s)"

--- a/workers/automation/src/jobctrl/pipeline/workflow.py
+++ b/workers/automation/src/jobctrl/pipeline/workflow.py
@@ -22,7 +22,9 @@ with workflow.unsafe.imports_passed_through():
     )
     from jobctrl.llm import SpendBudgetInput, check_spend_budget
     from jobctrl.enrichment.activities import (
+        CancelEnrichmentCohortInput,
         EnrichActivityInput,
+        cancel_enrichment_cohort_activity,
         enrich_activity,
     )
     from jobctrl.materials.activities import (
@@ -33,7 +35,9 @@ with workflow.unsafe.imports_passed_through():
     )
     from jobctrl.model_defaults import DEFAULT_PIPELINE_LLM_MODEL_SPEC
     from jobctrl.infrastructure.preparation_recovery import (
+        CancelPreparationStateInput,
         RecoverPreparationStateInput,
+        cancel_preparation_state_activity,
         recover_preparation_state_activity,
     )
     from jobctrl.scoring.activities import ScoreActivityInput, score_activity
@@ -125,6 +129,8 @@ _COVER_RETRY = RetryPolicy(
     non_retryable_error_types=_NON_RETRYABLE_ERROR_TYPES,
 )
 _DEFAULT_TIMEOUT = timedelta(minutes=30)
+_MAX_SELECTED_BATCH_TIMEOUT = timedelta(hours=6)
+_SELECTED_BATCH_TIMEOUT_PATCH = "pipeline-selected-batch-timeout-v1"
 # Discovery does long-running external crawls and owns source-level retry,
 # dedupe, and progress persistence below the workflow boundary. Retrying the
 # entire activity can overlap with a still-running adapter thread after timeout
@@ -162,6 +168,7 @@ class JobPipelineWorkflow:
                 await _check_spend(payload)
             result = await self._execute_stages(payload)
         except CancelledError:
+            await _cancel_owned_enrichment(payload)
             await emit_workflow_outcome(
                 tenant_id=payload.tenant_id,
                 workflow_type="JobPipelineWorkflow",
@@ -213,21 +220,31 @@ class JobPipelineWorkflow:
         failed: list[str] = []
         failure: str | None = None
         error_code: str | None = None
-        derived_cover_job_ids: tuple[JobId, ...] | None = None
+        derived_preparation_job_ids: tuple[JobId, ...] | None = None
 
         for stage in payload.stages:
             stage_payload = payload
-            if stage == "cover" and derived_cover_job_ids is not None and not _has_selected_job_scope(payload):
-                if not derived_cover_job_ids:
+            if stage in {"score", "tailor", "cover"} and derived_preparation_job_ids is not None:
+                if not derived_preparation_job_ids:
                     completed.append(stage)
-                    derived_cover_job_ids = None
                     continue
-                stage_payload = replace(payload, job_ids=derived_cover_job_ids, limit=0)
+                stage_payload = replace(
+                    payload,
+                    job_id=None,
+                    job_ids=derived_preparation_job_ids,
+                    limit=0,
+                )
 
             try:
                 result = await _execute_stage(stage, stage_payload)
+            except CancelledError:
+                if stage in {"tailor", "cover"}:
+                    await _cancel_material_stage_state(stage, stage_payload)
+                raise
             except ActivityError as exc:
                 if _activity_error_was_cancelled(exc):
+                    if stage in {"tailor", "cover"}:
+                        await _cancel_material_stage_state(stage, stage_payload)
                     raise CancelledError("Workflow canceled by request.") from exc
                 if stage in {"score", "tailor", "cover"}:
                     await _recover_stage_state(stage, stage_payload)
@@ -244,10 +261,14 @@ class JobPipelineWorkflow:
                 break
 
             completed.append(stage)
-            if stage == "tailor" and not _has_selected_job_scope(payload):
-                derived_cover_job_ids = _approved_tailor_job_ids(result)
-            elif stage != "cover":
-                derived_cover_job_ids = None
+            if stage == "enrich":
+                enriched_job_ids = _enriched_job_ids(result)
+                if enriched_job_ids is not None:
+                    derived_preparation_job_ids = enriched_job_ids
+            elif stage == "tailor":
+                approved_job_ids = _approved_tailor_job_ids(result)
+                if approved_job_ids is not None:
+                    derived_preparation_job_ids = approved_job_ids
 
         return JobPipelineWorkflowResult(
             stages_completed=completed,
@@ -268,6 +289,30 @@ async def _recover_stage_state(
             tenant_id=payload.tenant_id,
             workflow_id=workflow.info().run_id,
             stage=stage,
+            expected_app_dir=payload.expected_app_dir,
+            expected_db_path=payload.expected_db_path,
+        ),
+        start_to_close_timeout=timedelta(seconds=30),
+        retry_policy=RetryPolicy(maximum_attempts=0),
+        cancellation_type=workflow.ActivityCancellationType.ABANDON,
+    )
+
+
+async def _cancel_material_stage_state(
+    stage: str,
+    payload: JobPipelineWorkflowInput,
+) -> None:
+    """Terminalize the exact selected material cohort after cancellation."""
+
+    if not workflow.patched("pipeline-material-cancellation-v1"):
+        return
+    await workflow.execute_activity(
+        cancel_preparation_state_activity,
+        CancelPreparationStateInput(
+            tenant_id=payload.tenant_id,
+            workflow_id=workflow.info().run_id,
+            stage=stage,
+            job_ids=tuple(str(job_id) for job_id in _selected_job_ids(payload)),
             expected_app_dir=payload.expected_app_dir,
             expected_db_path=payload.expected_db_path,
         ),
@@ -315,7 +360,7 @@ async def _execute_stage(stage: str, payload: JobPipelineWorkflowInput) -> Any:
                 workflow_id=workflow_id,
                 workflow_run_id=workflow_run_id,
             ),
-            start_to_close_timeout=_DEFAULT_TIMEOUT,
+            start_to_close_timeout=_activity_timeout(payload),
             heartbeat_timeout=_DEFAULT_HEARTBEAT_TIMEOUT,
             retry_policy=_ENRICH_RETRY,
         )
@@ -335,7 +380,7 @@ async def _execute_stage(stage: str, payload: JobPipelineWorkflowInput) -> Any:
                 llm_model=payload.llm_model,
                 workflow_id=activity_owner,
             ),
-            start_to_close_timeout=_DEFAULT_TIMEOUT,
+            start_to_close_timeout=_activity_timeout(payload),
             heartbeat_timeout=_DEFAULT_HEARTBEAT_TIMEOUT,
             retry_policy=_SCORE_RETRY,
         )
@@ -362,7 +407,7 @@ async def _execute_stage(stage: str, payload: JobPipelineWorkflowInput) -> Any:
                 llm_model=payload.llm_model,
                 workflow_id=activity_owner,
             ),
-            start_to_close_timeout=_DEFAULT_TIMEOUT,
+            start_to_close_timeout=_activity_timeout(payload),
             heartbeat_timeout=_DEFAULT_HEARTBEAT_TIMEOUT,
             retry_policy=_TAILOR_RETRY,
         )
@@ -375,13 +420,14 @@ async def _execute_stage(stage: str, payload: JobPipelineWorkflowInput) -> Any:
                 expected_db_path=payload.expected_db_path,
                 min_score=payload.min_score,
                 limit=payload.limit,
+                workers=payload.workers,
                 validation_mode=payload.validation_mode,
                 dry_run=payload.dry_run,
                 job_ids=_selected_job_ids(payload),
                 llm_model=payload.llm_model,
                 workflow_id=activity_owner,
             ),
-            start_to_close_timeout=_DEFAULT_TIMEOUT,
+            start_to_close_timeout=_activity_timeout(payload),
             heartbeat_timeout=_DEFAULT_HEARTBEAT_TIMEOUT,
             retry_policy=_COVER_RETRY,
         )
@@ -416,6 +462,51 @@ async def _check_spend(payload: JobPipelineWorkflowInput) -> None:
         SpendBudgetInput(tenant_id=payload.tenant_id),
         start_to_close_timeout=timedelta(seconds=30),
         retry_policy=RetryPolicy(maximum_attempts=1),
+    )
+
+
+def _activity_timeout(payload: JobPipelineWorkflowInput) -> timedelta:
+    if len(_selected_job_ids(payload)) <= 1:
+        return _DEFAULT_TIMEOUT
+    if not workflow.patched(_SELECTED_BATCH_TIMEOUT_PATCH):
+        return _DEFAULT_TIMEOUT
+    return _selected_batch_timeout(payload)
+
+
+def _selected_batch_timeout(payload: JobPipelineWorkflowInput) -> timedelta:
+    """Scale selected batch deadlines by bounded worker waves."""
+
+    selected_count = len(_selected_job_ids(payload))
+    if selected_count <= 1:
+        return _DEFAULT_TIMEOUT
+    worker_count = max(1, int(payload.workers or 1))
+    waves = (selected_count + worker_count - 1) // worker_count
+    return min(_MAX_SELECTED_BATCH_TIMEOUT, _DEFAULT_TIMEOUT * waves)
+
+
+async def _cancel_owned_enrichment(payload: JobPipelineWorkflowInput) -> None:
+    """Durably close the exact Enrich cohort before a canceled workflow exits."""
+
+    if "enrich" not in payload.stages:
+        return
+    info = workflow.info()
+    await workflow.execute_activity(
+        cancel_enrichment_cohort_activity,
+        CancelEnrichmentCohortInput(
+            tenant_id=payload.tenant_id,
+            workflow_id=info.workflow_id,
+            workflow_run_id=info.run_id,
+            job_ids=_selected_job_ids(payload),
+            expected_app_dir=payload.expected_app_dir,
+            expected_db_path=payload.expected_db_path,
+        ),
+        start_to_close_timeout=timedelta(seconds=30),
+        retry_policy=RetryPolicy(
+            initial_interval=timedelta(seconds=1),
+            maximum_interval=timedelta(seconds=10),
+            maximum_attempts=5,
+        ),
+        cancellation_type=workflow.ActivityCancellationType.ABANDON,
     )
 
 
@@ -469,10 +560,6 @@ def _selected_job_ids(payload: JobPipelineWorkflowInput) -> tuple[JobId, ...]:
     return ()
 
 
-def _has_selected_job_scope(payload: JobPipelineWorkflowInput) -> bool:
-    return payload.job_id is not None or bool(payload.job_ids)
-
-
 def _apply_child_job_id(payload: JobPipelineWorkflowInput) -> JobId | None:
     """Validate the preserved selector shape before starting an Apply child."""
 
@@ -502,6 +589,26 @@ def _approved_tailor_job_ids(result: Any) -> tuple[JobId, ...] | None:
         if "approvedJobIds" not in stage_result:
             return None
         raw_job_ids = stage_result.get("approvedJobIds")
+        if not isinstance(raw_job_ids, list):
+            return ()
+        return _canonical_job_ids(tuple(canonical_job_id(str(job_id)) for job_id in raw_job_ids))
+    return None
+
+
+def _enriched_job_ids(result: Any) -> tuple[JobId, ...] | None:
+    """Read the canonical downstream-eligible subset from Enrich output."""
+
+    stages = _result_value(result, "stages")
+    if not isinstance(stages, list):
+        return None
+    for stage_result in stages:
+        if not isinstance(stage_result, dict):
+            continue
+        if stage_result.get("stage") != "enrich":
+            continue
+        if "enrichedJobIds" not in stage_result:
+            return None
+        raw_job_ids = stage_result.get("enrichedJobIds")
         if not isinstance(raw_job_ids, list):
             return ()
         return _canonical_job_ids(tuple(canonical_job_id(str(job_id)) for job_id in raw_job_ids))

--- a/workers/automation/src/jobctrl/pipeline/workflow.py
+++ b/workers/automation/src/jobctrl/pipeline/workflow.py
@@ -317,7 +317,14 @@ async def _cancel_material_stage_state(
             expected_db_path=payload.expected_db_path,
         ),
         start_to_close_timeout=timedelta(seconds=30),
-        retry_policy=RetryPolicy(maximum_attempts=0),
+        # Bounded like ``_cancel_owned_enrichment``: cancellation liveness beats
+        # at-all-costs terminalization — rows left running by an exhausted
+        # cancel are still recoverable via ``recover_preparation_state``.
+        retry_policy=RetryPolicy(
+            initial_interval=timedelta(seconds=1),
+            maximum_interval=timedelta(seconds=10),
+            maximum_attempts=5,
+        ),
         cancellation_type=workflow.ActivityCancellationType.ABANDON,
     )
 
@@ -488,6 +495,10 @@ async def _cancel_owned_enrichment(payload: JobPipelineWorkflowInput) -> None:
     """Durably close the exact Enrich cohort before a canceled workflow exits."""
 
     if "enrich" not in payload.stages:
+        return
+    if not workflow.patched("pipeline-enrich-cancellation-v1"):
+        # Replay safety: a cancellation recorded by a pre-patch release has no
+        # cancel-cohort activity ahead of ``emit_workflow_outcome``.
         return
     info = workflow.info()
     await workflow.execute_activity(

--- a/workers/automation/src/jobctrl/preparation/workflow.py
+++ b/workers/automation/src/jobctrl/preparation/workflow.py
@@ -240,7 +240,15 @@ async def _cancel_material_stage_state(
             expected_db_path=payload.expected_db_path,
         ),
         start_to_close_timeout=timedelta(seconds=30),
-        retry_policy=RetryPolicy(maximum_attempts=0),
+        # Bounded like the pipeline cancel activities: cancellation liveness
+        # beats at-all-costs terminalization — rows left running by an
+        # exhausted cancel are still recoverable via
+        # ``recover_preparation_state``.
+        retry_policy=RetryPolicy(
+            initial_interval=timedelta(seconds=1),
+            maximum_interval=timedelta(seconds=10),
+            maximum_attempts=5,
+        ),
         cancellation_type=workflow.ActivityCancellationType.ABANDON,
     )
 

--- a/workers/automation/src/jobctrl/preparation/workflow.py
+++ b/workers/automation/src/jobctrl/preparation/workflow.py
@@ -38,7 +38,9 @@ with workflow.unsafe.imports_passed_through():
     )
     from jobctrl.model_defaults import DEFAULT_PIPELINE_LLM_MODEL_SPEC
     from jobctrl.infrastructure.preparation_recovery import (
+        CancelPreparationStateInput,
         RecoverPreparationStateInput,
+        cancel_preparation_state_activity,
         recover_preparation_state_activity,
     )
     from jobctrl.scoring.activities import ScoreJobActivityInput, score_job_activity
@@ -166,8 +168,14 @@ class JobPreparationWorkflow:
         for step in _ordered_steps(payload.steps):
             try:
                 output = await _execute_step(step, payload)
+            except CancelledError:
+                if step in {"tailor", "cover"}:
+                    await _cancel_material_stage_state(step, payload)
+                raise
             except ActivityError as exc:
                 if _activity_error_was_cancelled(exc):
+                    if step in {"tailor", "cover"}:
+                        await _cancel_material_stage_state(step, payload)
                     raise CancelledError("Workflow canceled by request.") from exc
                 if step in {"score", "tailor", "cover"}:
                     await _recover_stage_state(step, payload)
@@ -206,6 +214,28 @@ async def _recover_stage_state(
             tenant_id=payload.tenant_id,
             workflow_id=workflow.info().run_id,
             stage=stage,
+            expected_app_dir=payload.expected_app_dir,
+            expected_db_path=payload.expected_db_path,
+        ),
+        start_to_close_timeout=timedelta(seconds=30),
+        retry_policy=RetryPolicy(maximum_attempts=0),
+        cancellation_type=workflow.ActivityCancellationType.ABANDON,
+    )
+
+
+async def _cancel_material_stage_state(
+    stage: str,
+    payload: JobPreparationInput,
+) -> None:
+    if not workflow.patched("preparation-material-cancellation-v1"):
+        return
+    await workflow.execute_activity(
+        cancel_preparation_state_activity,
+        CancelPreparationStateInput(
+            tenant_id=payload.tenant_id,
+            workflow_id=workflow.info().run_id,
+            stage=stage,
+            job_ids=(str(payload.job_id),),
             expected_app_dir=payload.expected_app_dir,
             expected_db_path=payload.expected_db_path,
         ),

--- a/workers/automation/src/jobctrl/scoring/cover_letter.py
+++ b/workers/automation/src/jobctrl/scoring/cover_letter.py
@@ -17,6 +17,7 @@ module is a thin adapter around :class:`GenerateCoverLetterUseCase`
 from __future__ import annotations
 
 import logging
+import threading
 import time
 from pathlib import Path
 
@@ -46,6 +47,10 @@ from jobctrl.infrastructure.materials import (
     PlaywrightHtmlPdfAdapter,
     SqliteEmployerAnalysisRepository,
     SqliteMaterialsRepository,
+    SqliteUnitOfWork,
+)
+from jobctrl.infrastructure.preparation_recovery import (
+    assert_material_activity_commit_allowed,
 )
 from jobctrl.infrastructure.preparation.sqlite_repository import SqlitePreparationTargetReader
 from jobctrl.infrastructure.scoring import SqliteScoreRepository
@@ -76,9 +81,16 @@ def _build_use_case(
     publisher: EventPublisher | None = None,
     validator: ContentValidator | None = None,
     analysis_repository: EmployerAnalysisRepository | None = None,
+    unit_of_work: SqliteUnitOfWork | None = None,
 ) -> GenerateCoverLetterUseCase:
+    conn = get_connection()
+    shared_unit_of_work = unit_of_work or SqliteUnitOfWork(conn)
+    default_repository = repository is None
     if repository is None:
-        repository = SqliteMaterialsRepository(get_connection())
+        repository = SqliteMaterialsRepository(
+            conn,
+            unit_of_work=shared_unit_of_work,
+        )
     if llm_port is None:
         llm_port = (
             LlmAdapter(default_model=llm_model)
@@ -88,13 +100,18 @@ def _build_use_case(
     if validator is None:
         validator = ContentValidator()
     if analysis_repository is None:
-        analysis_repository = SqliteEmployerAnalysisRepository(get_connection())
+        analysis_repository = SqliteEmployerAnalysisRepository(conn)
     return GenerateCoverLetterUseCase(
         repository=repository,
         llm=llm_port,
         validator=validator,
         publisher=publisher,
         analysis_repository=analysis_repository,
+        unit_of_work=(
+            shared_unit_of_work
+            if default_repository or unit_of_work is not None
+            else None
+        ),
     )
 
 
@@ -173,6 +190,7 @@ def cover_letter_by_id(
     pdf_renderer: PdfRendererPort | None = None,
     tenant_id: TenantId = LOCAL_TENANT,
     workflow_id: str | None = None,
+    cancel_event: threading.Event | None = None,
 ) -> dict:
     """Generate exactly one eligible cover letter by tenant-scoped JobId."""
     stable_job_id = canonical_job_id(str(job_id))
@@ -181,8 +199,13 @@ def cover_letter_by_id(
     if job is None:
         return _skipped_result(stable_job_id, reason="job_not_found")
 
+    material_unit_of_work: SqliteUnitOfWork | None = None
     if repository is None:
-        repository = SqliteMaterialsRepository(conn)
+        material_unit_of_work = SqliteUnitOfWork(conn)
+        repository = SqliteMaterialsRepository(
+            conn,
+            unit_of_work=material_unit_of_work,
+        )
     min_score = effective_tailoring_min_score(min_score)
 
     eligibility_reason = _cover_eligibility_reason(
@@ -236,6 +259,7 @@ def cover_letter_by_id(
         llm_port=llm_port,
         llm_model=llm_model,
         publisher=publisher,
+        unit_of_work=material_unit_of_work,
     )
     if pdf_renderer is None:
         pdf_renderer = _build_pdf_renderer()
@@ -260,9 +284,19 @@ def cover_letter_by_id(
         "cover",
         "running",
         tenant_id=tenant_id,
-        attempt_count=current_attempt,
+        # Owner recovery advances an interrupted execution. Preserve the
+        # completed count while running so timeout and normal completion each
+        # count this execution exactly once.
+        attempt_count=prior_attempts,
         started_at=started_at,
-        metadata={"activityOwner": workflow_id} if workflow_id else None,
+        metadata=(
+            {
+                "activityOwner": workflow_id,
+                "attemptCountBasis": "completed",
+            }
+            if workflow_id
+            else None
+        ),
         validate_transition=False,
     )
     record_job_event(
@@ -275,6 +309,16 @@ def cover_letter_by_id(
     )
     conn.commit()
 
+    def commit_guard() -> None:
+        assert_material_activity_commit_allowed(
+            conn,
+            tenant_id=str(tenant_id),
+            job_id=str(stable_job_id),
+            stage="cover",
+            workflow_id=workflow_id,
+            cancel_event=cancel_event,
+        )
+
     try:
         outcome = use_case.execute(
             job=job,
@@ -283,6 +327,7 @@ def cover_letter_by_id(
             validation_mode=validation_mode,
             tenant_id=tenant_id,
             job_id=stable_job_id,
+            commit_guard=commit_guard,
         )
     except Exception as exc:  # noqa: BLE001
         outcome = CoverLetterOutcome(
@@ -294,6 +339,7 @@ def cover_letter_by_id(
 
     finished_at = utc_now()
     elapsed = time.time() - t0
+    commit_guard()
     if outcome.status == "ok":
         # Best-effort PDF render. Failure is non-fatal: the cover letter text
         # is the canonical artifact and the PDF is an optional sibling.
@@ -309,29 +355,36 @@ def cover_letter_by_id(
                 materials = outcome.materials.with_cover_letter_pdf(
                     pdf_artifact, updated_at=utc_now()
                 )
-                repository.save(materials)
+                if material_unit_of_work is not None:
+                    with material_unit_of_work:
+                        commit_guard()
+                        repository.save(materials)
+                else:
+                    commit_guard()
+                    repository.save(materials)
             except Exception:
                 log.debug("PDF generation failed for cover letter", exc_info=True)
 
-        set_stage_state(
-            conn,
-            stable_job_id,
-            "cover",
-            "succeeded",
-            tenant_id=tenant_id,
-            attempt_count=current_attempt,
-            started_at=started_at,
-            finished_at=finished_at,
-        )
-        record_job_event(
-            conn,
-            stable_job_id,
-            "cover",
-            "StageCompleted",
-            tenant_id=tenant_id,
-            message="Cover letter generated",
-        )
-        conn.commit()
+        with SqliteUnitOfWork(conn):
+            commit_guard()
+            set_stage_state(
+                conn,
+                stable_job_id,
+                "cover",
+                "succeeded",
+                tenant_id=tenant_id,
+                attempt_count=current_attempt,
+                started_at=started_at,
+                finished_at=finished_at,
+            )
+            record_job_event(
+                conn,
+                stable_job_id,
+                "cover",
+                "StageCompleted",
+                tenant_id=tenant_id,
+                message="Cover letter generated",
+            )
         log.info("Cover letter done in %.1fs: generated for %s", elapsed, url)
         return {
             "jobId": str(stable_job_id),
@@ -345,36 +398,39 @@ def cover_letter_by_id(
 
     failed_attempts = current_attempt
     exhausted = failed_attempts >= _COVER_MAX_ATTEMPTS
-    set_stage_state(
-        conn,
-        stable_job_id,
-        "cover",
-        "exhausted" if exhausted else "failed",
-        tenant_id=tenant_id,
-        attempt_count=failed_attempts,
-        max_attempts=_COVER_MAX_ATTEMPTS,
-        started_at=started_at,
-        finished_at=finished_at,
-        error_code="COVER_FAILED",
-        error_message=outcome.error or f"Cover letter generation failed ({outcome.status})",
-        retryable=not exhausted,
-        next_action=(
-            f"jobctrl retry cover {url or stable_job_id} --reset-attempts"
-            if exhausted
-            else f"jobctrl retry cover {url or stable_job_id}"
-        ),
-        validate_transition=False,
-    )
-    record_job_event(
-        conn,
-        stable_job_id,
-        "cover",
-        "StageFailed",
-        tenant_id=tenant_id,
-        level="error",
-        message=outcome.error or f"Cover letter generation failed ({outcome.status})",
-    )
-    conn.commit()
+    with SqliteUnitOfWork(conn):
+        commit_guard()
+        set_stage_state(
+            conn,
+            stable_job_id,
+            "cover",
+            "exhausted" if exhausted else "failed",
+            tenant_id=tenant_id,
+            attempt_count=failed_attempts,
+            max_attempts=_COVER_MAX_ATTEMPTS,
+            started_at=started_at,
+            finished_at=finished_at,
+            error_code="COVER_FAILED",
+            error_message=outcome.error
+            or f"Cover letter generation failed ({outcome.status})",
+            retryable=not exhausted,
+            next_action=(
+                f"jobctrl retry cover {url or stable_job_id} --reset-attempts"
+                if exhausted
+                else f"jobctrl retry cover {url or stable_job_id}"
+            ),
+            validate_transition=False,
+        )
+        record_job_event(
+            conn,
+            stable_job_id,
+            "cover",
+            "StageFailed",
+            tenant_id=tenant_id,
+            level="error",
+            message=outcome.error
+            or f"Cover letter generation failed ({outcome.status})",
+        )
     return {
         "jobId": str(stable_job_id),
         "url": url,

--- a/workers/automation/src/jobctrl/scoring/tailor.py
+++ b/workers/automation/src/jobctrl/scoring/tailor.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 import json
 import logging
 import sqlite3
+import threading
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
@@ -67,7 +68,10 @@ from jobctrl.infrastructure.materials import (
     SqliteUnitOfWork,
 )
 from jobctrl.infrastructure.preparation import SqlitePreparationTargetReader
-from jobctrl.infrastructure.preparation_recovery import stage_completed_by_activity_owner
+from jobctrl.infrastructure.preparation_recovery import (
+    assert_material_activity_commit_allowed,
+    stage_completed_by_activity_owner,
+)
 from jobctrl.infrastructure.scoring import (
     SqliteRequirementFitReportRepository,
     SqliteScoreRepository,
@@ -84,7 +88,7 @@ from jobctrl.state import (
 
 log = logging.getLogger(__name__)
 
-MAX_ATTEMPTS = 5  # max cross-run retries before giving up
+MAX_ATTEMPTS = config.DEFAULTS["max_tailor_attempts"]  # durable executions
 
 
 def _split_model_specs(value: str | None) -> tuple[str, ...]:
@@ -172,7 +176,10 @@ def _build_use_case(
     if repository is None:
         repository = SqliteMaterialsRepository(conn, unit_of_work=unit_of_work)
     if policy_repository is None:
-        policy_repository = SqliteTailoringPolicyRepository(conn)
+        policy_repository = SqliteTailoringPolicyRepository(
+            conn,
+            unit_of_work=unit_of_work,
+        )
     if provenance_repository is None:
         provenance_repository = SqliteBulletProvenanceRepository(conn, unit_of_work=unit_of_work)
     if requirement_fit_repository is None:
@@ -351,6 +358,9 @@ def _tailor_one_job(
     suppress_existing_artifacts: bool = False,
     tenant_id: TenantId = LOCAL_TENANT,
     llm_policy: TailoringLlmPolicy | None = None,
+    commit_guard=None,
+    audit_execution_id: str | None = None,
+    durable_attempt: int | None = None,
 ) -> dict:
     """Tailor one job and return the legacy-shaped result dict.
 
@@ -382,9 +392,13 @@ def _tailor_one_job(
         retailor=retailor,
         suppress_existing_artifacts=suppress_existing_artifacts,
         requirement_fit_report=requirement_fit_report,
+        commit_guard=commit_guard,
+        audit_execution_id=audit_execution_id,
+        durable_attempt=durable_attempt,
     )
 
     return {
+        "job_id": str(canonical_job_id(str(job["job_id"]))),
         "url": job["url"],
         "path": outcome.text_path,
         "pdf_path": outcome.pdf_path,
@@ -392,6 +406,7 @@ def _tailor_one_job(
         "site": job.get("site"),
         "status": outcome.status,
         "attempts": outcome.attempts,
+        "report": getattr(outcome, "report", {}),
         "materials": outcome.materials,
         "error": outcome.error,
     }
@@ -491,6 +506,11 @@ def run_tailoring(
         limit=limit,
         retailor=retailor,
     )
+    jobs = [
+        job
+        for job in jobs
+        if str(job.get("tenant_id") or tenant_id) == str(tenant_id)
+    ]
     if workflow_id:
         jobs = [
             job
@@ -538,11 +558,26 @@ def run_tailoring(
     )
 
     started_ats: dict[str, str] = {}
+    stage_attempts: dict[str, int] = {}
     activity_metadata: dict[str, dict[str, object]] = {}
     for job in jobs:
-        ensure_job_stage_rows(conn, job["url"], discovered_at=job.get("discovered_at"))
+        stable_job_id = canonical_job_id(str(job["job_id"]))
+        stage_key = str(stable_job_id)
+        ensure_job_stage_rows(
+            conn,
+            stable_job_id,
+            tenant_id=tenant_id,
+            discovered_at=job.get("discovered_at"),
+        )
         started_at = utc_now()
-        started_ats[job["url"]] = started_at
+        started_ats[stage_key] = started_at
+        prior_attempts = _tailor_attempt_count(
+            conn,
+            tenant_id=tenant_id,
+            job_id=stable_job_id,
+        )
+        current_attempt = prior_attempts + 1
+        stage_attempts[stage_key] = current_attempt
         # The runner owns the restart policy: a job that failed last time is
         # eligible for retailoring per ``get_jobs_by_stage``, so the
         # transition Failed -> Running needs to be permitted even though
@@ -551,21 +586,32 @@ def run_tailoring(
         metadata = _tailor_activity_metadata(
             repository,
             tenant_id=tenant_id,
-            job_id=canonical_job_id(str(job["job_id"])),
+            job_id=stable_job_id,
             workflow_id=workflow_id,
             retailor=retailor,
         )
-        activity_metadata[job["url"]] = metadata or {}
+        activity_metadata[stage_key] = metadata or {}
         set_stage_state(
             conn,
-            job["url"],
+            stable_job_id,
             "tailor",
             "running",
+            tenant_id=tenant_id,
+            # Running exposes the completed durable count. Normal completion
+            # or owner recovery advances this execution exactly once.
+            attempt_count=prior_attempts,
             started_at=started_at,
             metadata=metadata,
             validate_transition=False,
         )
-        record_job_event(conn, job["url"], "tailor", "StageStarted", message="Tailoring started")
+        record_job_event(
+            conn,
+            stable_job_id,
+            "tailor",
+            "StageStarted",
+            tenant_id=tenant_id,
+            message="Tailoring started",
+        )
 
     future_to_job: dict = {}
     with ThreadPoolExecutor(max_workers=worker_count) as executor:
@@ -585,6 +631,10 @@ def run_tailoring(
                 retailor=retailor,
                 tenant_id=tenant_id,
                 llm_policy=llm_policy,
+                audit_execution_id=workflow_id,
+                durable_attempt=stage_attempts[
+                    str(canonical_job_id(str(job["job_id"])))
+                ],
             )
             future_to_job[future] = job
 
@@ -594,6 +644,7 @@ def run_tailoring(
                 result = future.result()
             except Exception as e:
                 result = {
+                    "job_id": str(canonical_job_id(str(job["job_id"]))),
                     "url": job["url"],
                     "title": job["title"],
                     "site": job.get("site"),
@@ -605,6 +656,7 @@ def run_tailoring(
                 }
                 log.error("%d/%d [ERROR] %s -- %s", completed, len(jobs), job["title"][:40], e)
 
+            result.setdefault("job_id", str(canonical_job_id(str(job["job_id"]))))
             results.append(result)
             stats[result.get("status", "error")] = stats.get(result.get("status", "error"), 0) + 1
 
@@ -627,58 +679,78 @@ def run_tailoring(
     # those columns are read-only fallbacks now.
     finished_at = utc_now()
     _success_statuses = {"approved"}
+    durable_exhausted = 0
     for r in results:
+        stable_job_id = canonical_job_id(str(r["job_id"]))
+        stage_key = str(stable_job_id)
         url = r["url"]
-        attempts = r.get("attempts") or 1
+        current_attempt = stage_attempts[stage_key]
+        generation_attempts = r.get("attempts") or 1
         if r.get("status") in _success_statuses:
             set_stage_state(
                 conn,
-                url,
+                stable_job_id,
                 "tailor",
                 "succeeded",
-                attempt_count=attempts,
-                started_at=started_ats.get(url),
+                tenant_id=tenant_id,
+                attempt_count=current_attempt,
+                started_at=started_ats.get(stage_key),
                 finished_at=finished_at,
-                metadata=activity_metadata.get(url) or None,
+                metadata=activity_metadata.get(stage_key) or None,
             )
             record_job_event(
                 conn,
-                url,
+                stable_job_id,
                 "tailor",
                 "StageCompleted",
+                tenant_id=tenant_id,
                 message=f"Tailoring {r.get('status')}",
-                payload={"attempts": attempts},
+                payload={
+                    "attempts": current_attempt,
+                    "generationAttempts": generation_attempts,
+                },
             )
-            _mark_cover_pending_after_tailor_success(
+            _mark_cover_pending_after_tailor_success_by_id(
                 conn,
-                url,
+                stable_job_id,
+                tenant_id=tenant_id,
                 reason="tailor_stage_completed",
             )
         else:
-            exhausted = attempts >= config.DEFAULTS["max_tailor_attempts"] or r.get("status") == "exhausted_retries"
+            exhausted = current_attempt >= MAX_ATTEMPTS
+            durable_exhausted += int(exhausted)
             set_stage_state(
                 conn,
-                url,
+                stable_job_id,
                 "tailor",
                 "exhausted" if exhausted else "failed",
-                attempt_count=attempts,
-                max_attempts=config.DEFAULTS["max_tailor_attempts"],
-                started_at=started_ats.get(url),
+                tenant_id=tenant_id,
+                attempt_count=current_attempt,
+                max_attempts=MAX_ATTEMPTS,
+                started_at=started_ats.get(stage_key),
                 finished_at=finished_at,
                 error_code=str(r.get("status", "error")).upper(),
                 error_message=f"Tailoring ended with status {r.get('status', 'error')}",
-                retryable=True,
+                retryable=not exhausted,
                 next_action=(
                     f"jobctrl retry tailor {url} --reset-attempts" if exhausted else f"jobctrl retry tailor {url}"
                 ),
+                validate_transition=False,
             )
             record_job_event(
                 conn,
-                url,
+                stable_job_id,
                 "tailor",
-                "StageFailed",
+                "StageExhausted" if exhausted else "StageFailed",
+                tenant_id=tenant_id,
                 level="error",
                 message=f"Tailoring ended with status {r.get('status', 'error')}",
+                payload={
+                    "attempts": current_attempt,
+                    "generationAttempts": generation_attempts,
+                    "generationStatus": str(r.get("status") or "error"),
+                    "retryable": not exhausted,
+                },
             )
     conn.commit()
 
@@ -692,10 +764,17 @@ def run_tailoring(
         stats.get("error", 0),
     )
 
+    errors = stats.get("error", 0)
+    failed = sum(
+        count
+        for status, count in stats.items()
+        if status not in {"approved", "error"}
+    )
     return {
         "approved": stats.get("approved", 0),
-        "failed": stats.get("failed_validation", 0) + stats.get("failed_judge", 0),
-        "errors": stats.get("error", 0),
+        "failed": failed,
+        "errors": errors,
+        "exhausted": durable_exhausted,
         "elapsed": elapsed,
     }
 
@@ -762,6 +841,7 @@ def tailor_job_by_id(
     suppress_existing_artifacts: bool = False,
     allow_low_fit_override: bool = False,
     workflow_id: str | None = None,
+    cancel_event: threading.Event | None = None,
 ) -> dict:
     """Tailor one active, eligible JobId for its tenant-scoped preparation step.
 
@@ -812,6 +892,19 @@ def tailor_job_by_id(
             "status": "already_done",
             "reason": "approved_resume_already_committed",
             "materials": existing_materials,
+        }
+
+    if _tailor_attempt_budget_exhausted(
+        conn,
+        tenant_id=tenant_id,
+        job_id=stable_job_id,
+    ):
+        return {
+            "url": target["url"],
+            "job_id": str(stable_job_id),
+            "status": "exhausted",
+            "reason": "durable_attempt_budget_exhausted",
+            "error": "Tailor durable attempt budget exhausted.",
         }
 
     job = _load_tailor_eligible_job_by_id(
@@ -877,6 +970,12 @@ def tailor_job_by_id(
         discovered_at=job.get("discovered_at"),
     )
     started_at = utc_now()
+    prior_attempts = _tailor_attempt_count(
+        conn,
+        tenant_id=tenant_id,
+        job_id=stable_job_id,
+    )
+    current_attempt = prior_attempts + 1
     metadata = _tailor_activity_metadata(
         SqliteMaterialsRepository(conn),
         tenant_id=tenant_id,
@@ -890,6 +989,9 @@ def tailor_job_by_id(
         "tailor",
         "running",
         tenant_id=tenant_id,
+        # Owner recovery increments an interrupted running row, so the start
+        # write must preserve the completed count instead of pre-incrementing.
+        attempt_count=prior_attempts,
         started_at=started_at,
         metadata=metadata,
         validate_transition=False,
@@ -904,82 +1006,184 @@ def tailor_job_by_id(
     )
     conn.commit()
 
-    result = _tailor_one_job(
-        job,
-        "",
-        snapshot,
-        validation_mode,
-        use_case=None,
-        pdf_renderer=pdf_renderer,
-        retailor=retailor,
-        suppress_existing_artifacts=suppress_existing_artifacts,
-        tenant_id=tenant_id,
-        llm_policy=llm_policy,
-    )
+    def commit_guard() -> None:
+        assert_material_activity_commit_allowed(
+            conn,
+            tenant_id=str(tenant_id),
+            job_id=str(stable_job_id),
+            stage="tailor",
+            workflow_id=workflow_id,
+            cancel_event=cancel_event,
+        )
+
+    try:
+        result = _tailor_one_job(
+            job,
+            "",
+            snapshot,
+            validation_mode,
+            use_case=None,
+            pdf_renderer=pdf_renderer,
+            retailor=retailor,
+            suppress_existing_artifacts=suppress_existing_artifacts,
+            tenant_id=tenant_id,
+            llm_policy=llm_policy,
+            commit_guard=commit_guard,
+            audit_execution_id=workflow_id,
+            durable_attempt=current_attempt,
+        )
+        commit_guard()
+    except Exception as exc:  # noqa: BLE001 - one item must terminalize its stage
+        # A cancellation/successor fence must escape this item runner. Turning
+        # it into an ordinary generation failure would let this stale owner
+        # overwrite the durable canceled/successor-owned row below.
+        commit_guard()
+        committed = _reconcile_existing_approved_resume(
+            conn,
+            tenant_id=tenant_id,
+            job_id=stable_job_id,
+            retailor=retailor,
+            workflow_id=workflow_id,
+            commit_guard=commit_guard,
+        )
+        if committed is not None:
+            return {
+                "url": target["url"],
+                "job_id": str(stable_job_id),
+                "status": "already_done",
+                "reason": "approved_resume_committed_before_exception",
+                "materials": committed,
+            }
+        result = {
+            "url": target["url"],
+            "job_id": str(stable_job_id),
+            "status": "error",
+            "attempts": 1,
+            "error": str(exc),
+        }
     finished_at = utc_now()
-    attempts = result.get("attempts") or 1
-    if result.get("status") == "approved":
-        set_stage_state(
-            conn,
-            stable_job_id,
-            "tailor",
-            "succeeded",
-            tenant_id=tenant_id,
-            attempt_count=attempts,
-            started_at=started_at,
-            finished_at=finished_at,
-            metadata=metadata,
-        )
-        record_job_event(
-            conn,
-            stable_job_id,
-            "tailor",
-            "StageCompleted",
-            tenant_id=tenant_id,
-            message="Tailoring approved",
-            payload={"attempts": attempts},
-        )
-        _mark_cover_pending_after_tailor_success_by_id(
-            conn,
-            stable_job_id,
-            tenant_id=tenant_id,
-            reason="tailor_stage_completed",
-        )
-    else:
-        exhausted = attempts >= config.DEFAULTS["max_tailor_attempts"] or result.get("status") == "exhausted_retries"
-        set_stage_state(
-            conn,
-            stable_job_id,
-            "tailor",
-            "exhausted" if exhausted else "failed",
-            tenant_id=tenant_id,
-            attempt_count=attempts,
-            max_attempts=config.DEFAULTS["max_tailor_attempts"],
-            started_at=started_at,
-            finished_at=finished_at,
-            error_code=str(result.get("status", "error")).upper(),
-            error_message=f"Tailoring ended with status {result.get('status', 'error')}",
-            retryable=True,
-            next_action=(
-                (
+    generation_attempts = result.get("attempts") or 1
+    # The final owner check and stage transition share SQLite's write-lock
+    # boundary, so cancellation or a successor cannot slip between them.
+    durable_exhausted = False
+    with SqliteUnitOfWork(conn):
+        commit_guard()
+        if result.get("status") == "approved":
+            set_stage_state(
+                conn,
+                stable_job_id,
+                "tailor",
+                "succeeded",
+                tenant_id=tenant_id,
+                attempt_count=current_attempt,
+                started_at=started_at,
+                finished_at=finished_at,
+                metadata=metadata,
+            )
+            record_job_event(
+                conn,
+                stable_job_id,
+                "tailor",
+                "StageCompleted",
+                tenant_id=tenant_id,
+                message="Tailoring approved",
+                payload={
+                    "attempts": current_attempt,
+                    "generationAttempts": generation_attempts,
+                },
+            )
+            _mark_cover_pending_after_tailor_success_by_id(
+                conn,
+                stable_job_id,
+                tenant_id=tenant_id,
+                reason="tailor_stage_completed",
+            )
+        else:
+            exhausted = current_attempt >= MAX_ATTEMPTS
+            durable_exhausted = exhausted
+            set_stage_state(
+                conn,
+                stable_job_id,
+                "tailor",
+                "exhausted" if exhausted else "failed",
+                tenant_id=tenant_id,
+                attempt_count=current_attempt,
+                max_attempts=MAX_ATTEMPTS,
+                started_at=started_at,
+                finished_at=finished_at,
+                error_code=str(result.get("status", "error")).upper(),
+                error_message=f"Tailoring ended with status {result.get('status', 'error')}",
+                retryable=not exhausted,
+                next_action=(
                     f"jobctrl retry tailor {job['url']} --reset-attempts"
                     if exhausted
                     else f"jobctrl retry tailor {job['url']}"
-                )
-            ),
-            validate_transition=False,
-        )
-        record_job_event(
-            conn,
-            stable_job_id,
-            "tailor",
-            "StageFailed",
-            tenant_id=tenant_id,
-            level="error",
-            message=f"Tailoring ended with status {result.get('status', 'error')}",
-        )
-    conn.commit()
+                ),
+                validate_transition=False,
+            )
+            record_job_event(
+                conn,
+                stable_job_id,
+                "tailor",
+                "StageExhausted" if exhausted else "StageFailed",
+                tenant_id=tenant_id,
+                level="error",
+                message=f"Tailoring ended with status {result.get('status', 'error')}",
+                payload={
+                    "attempts": current_attempt,
+                    "generationAttempts": generation_attempts,
+                    "generationStatus": str(result.get("status") or "error"),
+                    "retryable": not exhausted,
+                },
+            )
+    if durable_exhausted:
+        return {
+            **result,
+            "status": "exhausted",
+            "reason": "durable_attempt_budget_exhausted",
+            "inner_status": str(result.get("status") or "error"),
+        }
     return result
+
+
+def _tailor_attempt_count(
+    conn: sqlite3.Connection,
+    *,
+    tenant_id: TenantId,
+    job_id: JobId,
+) -> int:
+    """Return durable Tailor executions, separate from inner LLM attempts."""
+    row = conn.execute(
+        """
+        SELECT attempt_count
+        FROM job_stage_states
+        WHERE tenant_id = ? AND job_id = ? AND stage = 'tailor'
+        """,
+        (str(tenant_id), str(canonical_job_id(str(job_id)))),
+    ).fetchone()
+    if row is None:
+        return 0
+    return int(row["attempt_count"] if hasattr(row, "keys") else row[0] or 0)
+
+
+def _tailor_attempt_budget_exhausted(
+    conn: sqlite3.Connection,
+    *,
+    tenant_id: TenantId,
+    job_id: JobId,
+) -> bool:
+    row = conn.execute(
+        """
+        SELECT state, attempt_count, max_attempts
+        FROM job_stage_states
+        WHERE tenant_id = ? AND job_id = ? AND stage = 'tailor'
+        """,
+        (str(tenant_id), str(canonical_job_id(str(job_id)))),
+    ).fetchone()
+    if row is None:
+        return False
+    max_attempts = int(row["max_attempts"] or MAX_ATTEMPTS)
+    return str(row["state"]) == "exhausted" or int(row["attempt_count"] or 0) >= max_attempts
 
 
 def _tailor_activity_metadata(
@@ -995,6 +1199,7 @@ def _tailor_activity_metadata(
     current = repository.load_current_approved(tenant_id, job_id)
     return {
         "activityOwner": workflow_id,
+        "attemptCountBasis": "completed",
         "retailor": retailor,
         "priorApprovedGeneration": int(current.generation) if current is not None else 0,
     }
@@ -1007,6 +1212,7 @@ def _reconcile_existing_approved_resume(
     job_id: JobId,
     retailor: bool,
     workflow_id: str | None,
+    commit_guard=None,
 ):
     """Treat the committed resume as authoritative after activity replay."""
     materials = SqliteMaterialsRepository(conn).load_current_approved(
@@ -1044,26 +1250,28 @@ def _reconcile_existing_approved_resume(
     if retailor and not (completed_by_owner or committed_retailor):
         return None
     if row is None or str(row["state"]) != "succeeded":
-        set_stage_state(
-            conn,
-            job_id,
-            "tailor",
-            "succeeded",
-            tenant_id=tenant_id,
-            finished_at=utc_now(),
-            metadata={"activityOwner": workflow_id} if workflow_id else None,
-            validate_transition=False,
-        )
-        record_job_event(
-            conn,
-            job_id,
-            "tailor",
-            "StageCompleted",
-            tenant_id=tenant_id,
-            message="Tailoring recovered from the committed approved resume.",
-            payload={"recoveredAfterActivityReplay": True},
-        )
-        conn.commit()
+        with SqliteUnitOfWork(conn):
+            if commit_guard is not None:
+                commit_guard()
+            set_stage_state(
+                conn,
+                job_id,
+                "tailor",
+                "succeeded",
+                tenant_id=tenant_id,
+                finished_at=utc_now(),
+                metadata={"activityOwner": workflow_id} if workflow_id else None,
+                validate_transition=False,
+            )
+            record_job_event(
+                conn,
+                job_id,
+                "tailor",
+                "StageCompleted",
+                tenant_id=tenant_id,
+                message="Tailoring recovered from the committed approved resume.",
+                payload={"recoveredAfterActivityReplay": True},
+            )
     return materials
 
 
@@ -1257,7 +1465,7 @@ def _load_tailor_eligible_job_by_id(
     if tailor_stage is not None:
         tailor_state = str(tailor_stage["state"])
         attempt_count = int(tailor_stage["attempt_count"] or 0)
-        if tailor_state == "exhausted" or attempt_count >= 5:
+        if tailor_state == "exhausted" or attempt_count >= MAX_ATTEMPTS:
             return None
         if not retailor and tailor_state not in {
             "pending",

--- a/workers/automation/tests/test_jsonrpc_handlers.py
+++ b/workers/automation/tests/test_jsonrpc_handlers.py
@@ -2236,6 +2236,100 @@ def test_selected_tailor_activity_accepts_committed_acknowledgement_replay(monke
     assert result["stages"][0]["approvedJobIds"] == [job_id]
 
 
+def test_selected_tailor_activity_uses_bounded_requested_workers(monkeypatch) -> None:
+    job_ids = (
+        JobId("50000000-0000-4000-8000-000000000011"),
+        JobId("50000000-0000-4000-8000-000000000012"),
+        JobId("50000000-0000-4000-8000-000000000013"),
+    )
+    real_executor = materials_activities_mod.ThreadPoolExecutor
+    observed_workers: list[int] = []
+
+    def recording_executor(*, max_workers: int, thread_name_prefix: str):
+        observed_workers.append(max_workers)
+        return real_executor(
+            max_workers=max_workers,
+            thread_name_prefix=thread_name_prefix,
+        )
+
+    monkeypatch.setattr(materials_activities_mod, "ThreadPoolExecutor", recording_executor)
+    monkeypatch.setattr(
+        "jobctrl.scoring.tailor.tailor_job_by_id",
+        lambda _job_id, **_kwargs: {"status": "approved"},
+    )
+
+    result = materials_activities_mod._run_selected_tailoring(
+        TailorActivityInput(
+            tenant_id="local",
+            job_ids=job_ids,
+            workers=2,
+        )
+    )
+
+    assert observed_workers == [2]
+    assert result["stages"][0]["approved"] == 3
+    assert result["stages"][0]["approvedJobIds"] == list(job_ids)
+
+
+def test_selected_cover_activity_uses_bounded_requested_workers(monkeypatch) -> None:
+    job_ids = (
+        JobId("50000000-0000-4000-8000-000000000021"),
+        JobId("50000000-0000-4000-8000-000000000022"),
+        JobId("50000000-0000-4000-8000-000000000023"),
+    )
+    real_executor = materials_activities_mod.ThreadPoolExecutor
+    observed_workers: list[int] = []
+
+    def recording_executor(*, max_workers: int, thread_name_prefix: str):
+        observed_workers.append(max_workers)
+        return real_executor(
+            max_workers=max_workers,
+            thread_name_prefix=thread_name_prefix,
+        )
+
+    monkeypatch.setattr(materials_activities_mod, "ThreadPoolExecutor", recording_executor)
+    monkeypatch.setattr(
+        "jobctrl.scoring.cover_letter.cover_letter_by_id",
+        lambda _job_id, **_kwargs: {"status": "ok", "generated": 1},
+    )
+
+    result = materials_activities_mod._run_selected_cover(
+        CoverActivityInput(
+            tenant_id="local",
+            job_ids=job_ids,
+            workers=2,
+        )
+    )
+
+    assert observed_workers == [2]
+    assert result["stages"][0]["generated"] == 3
+
+
+def test_selected_tailor_activity_keeps_item_failures_partial(monkeypatch) -> None:
+    approved_job_id = JobId("50000000-0000-4000-8000-000000000031")
+    failed_job_id = JobId("50000000-0000-4000-8000-000000000032")
+
+    def fake_tailor(job_id: JobId, **_kwargs: object) -> dict[str, object]:
+        if job_id == approved_job_id:
+            return {"status": "approved"}
+        return {"status": "error", "error": "validation exhausted"}
+
+    monkeypatch.setattr("jobctrl.scoring.tailor.tailor_job_by_id", fake_tailor)
+
+    result = materials_activities_mod._run_selected_tailoring(
+        TailorActivityInput(
+            tenant_id="local",
+            job_ids=(approved_job_id, failed_job_id),
+        )
+    )
+
+    assert result["status"] == "partial"
+    assert result["errors"] == {}
+    assert result["stages"][0]["approvedJobIds"] == [approved_job_id]
+    assert result["stages"][0]["failed"] == 1
+    assert result["stages"][0]["itemErrors"] == {str(failed_job_id): "validation exhausted"}
+
+
 def test_current_policy_tailor_activity_skips_current_policy_artifacts(
     tmp_db: Path,
     monkeypatch,

--- a/workers/automation/tests/test_material_activity_recovery.py
+++ b/workers/automation/tests/test_material_activity_recovery.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import sqlite3
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -13,9 +15,13 @@ from jobctrl.domain.identifiers import canonical_job_id
 from jobctrl.domain.materials.value_objects import ArtifactStatus
 from jobctrl.domain.tenant import LOCAL_TENANT
 from jobctrl.infrastructure.preparation_recovery import (
+    CancelPreparationStateInput,
     RecoverPreparationStateInput,
+    assert_material_activity_commit_allowed,
+    cancel_preparation_state_rows,
     recover_preparation_state_rows,
 )
+from jobctrl.materials.activities import _run_selected_material_jobs
 from jobctrl.state import ensure_job_stage_rows, set_stage_state
 
 
@@ -28,6 +34,7 @@ def _seed_owned_stage(
     *,
     stage: str,
     workflow_id: str,
+    attempt_count: int = 0,
     metadata: dict[str, object] | None = None,
 ) -> str:
     job_id = str(canonical_job_id(f"00000000-0000-4000-8000-{suffix:012d}"))
@@ -52,6 +59,7 @@ def _seed_owned_stage(
         stage,
         "running",
         tenant_id=LOCAL_TENANT,
+        attempt_count=attempt_count,
         started_at=_STARTED_AT,
         metadata={"activityOwner": workflow_id, **(metadata or {})},
         validate_transition=False,
@@ -70,14 +78,23 @@ def test_tailor_recovery_accepts_only_a_newly_committed_retailor_generation(
         1,
         stage="tailor",
         workflow_id="workflow-owned",
-        metadata={"retailor": True, "priorApprovedGeneration": 2},
+        attempt_count=1,
+        metadata={
+            "attemptCountBasis": "completed",
+            "retailor": True,
+            "priorApprovedGeneration": 2,
+        },
     )
     failed_job = _seed_owned_stage(
         conn,
         2,
         stage="tailor",
         workflow_id="workflow-owned",
-        metadata={"retailor": True, "priorApprovedGeneration": 3},
+        metadata={
+            "attemptCountBasis": "completed",
+            "retailor": True,
+            "priorApprovedGeneration": 3,
+        },
     )
     generations = {restored_job: 3, failed_job: 3}
     repository = SimpleNamespace(
@@ -101,11 +118,65 @@ def test_tailor_recovery_accepts_only_a_newly_committed_retailor_generation(
     )
 
     assert (result.restored, result.failed) == (1, 1)
-    states = dict(conn.execute(
-        "SELECT job_id, state FROM job_stage_states WHERE stage = 'tailor'"
-    ).fetchall())
-    assert states[restored_job] == "succeeded"
-    assert states[failed_job] == "failed"
+    states = {
+        row["job_id"]: (row["state"], row["attempt_count"])
+        for row in conn.execute(
+            "SELECT job_id, state, attempt_count FROM job_stage_states "
+            "WHERE stage = 'tailor'"
+        ).fetchall()
+    }
+    assert states[restored_job] == ("succeeded", 2)
+    assert states[failed_job] == ("failed", 1)
+
+
+@pytest.mark.parametrize("stage", ("tailor", "cover"))
+def test_material_recovery_marks_fifth_interrupted_execution_exhausted(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    stage: str,
+) -> None:
+    conn = init_db(tmp_path / f"{stage}-owner-exhausted.db")
+    job_id = _seed_owned_stage(
+        conn,
+        20 if stage == "tailor" else 21,
+        stage=stage,
+        workflow_id="workflow-owned",
+        attempt_count=4,
+        metadata={"attemptCountBasis": "completed"},
+    )
+    repository = SimpleNamespace(load_current_approved=lambda *_args: None)
+    monkeypatch.setattr(
+        "jobctrl.infrastructure.materials.SqliteMaterialsRepository",
+        lambda _conn: repository,
+    )
+
+    result = recover_preparation_state_rows(
+        conn,
+        RecoverPreparationStateInput(
+            tenant_id="local",
+            workflow_id="workflow-owned",
+            stage=stage,
+        ),
+    )
+
+    assert (result.restored, result.failed) == (0, 1)
+    row = conn.execute(
+        "SELECT state, attempt_count, retryable, next_action "
+        "FROM job_stage_states WHERE tenant_id = 'local' AND job_id = ? AND stage = ?",
+        (job_id, stage),
+    ).fetchone()
+    assert tuple(row) == (
+        "exhausted",
+        5,
+        0,
+        f"retry {stage} --reset-attempts",
+    )
+    event = conn.execute(
+        "SELECT event_type FROM job_events WHERE tenant_id = 'local' "
+        "AND job_id = ? AND stage = ? ORDER BY event_id DESC LIMIT 1",
+        (job_id, stage),
+    ).fetchone()
+    assert event["event_type"] == "StageExhausted"
 
 
 def test_cover_recovery_reuses_committed_cover_and_ignores_another_owner(
@@ -151,3 +222,154 @@ def test_cover_recovery_reuses_committed_cover_and_ignores_another_owner(
     ).fetchall())
     assert states[owned] == "succeeded"
     assert states[other] == "running"
+
+
+def test_selected_material_fanout_stops_scheduling_after_cancellation() -> None:
+    job_ids = tuple(
+        canonical_job_id(f"10000000-0000-4000-8000-{index:012d}")
+        for index in range(4)
+    )
+    cancel_event = threading.Event()
+    first_wave_started = threading.Event()
+    release_first_wave = threading.Event()
+    lock = threading.Lock()
+    started: list[str] = []
+
+    def run_one(job_id) -> dict:
+        with lock:
+            started.append(str(job_id))
+            if len(started) == 2:
+                first_wave_started.set()
+        assert release_first_wave.wait(timeout=5)
+        if cancel_event.is_set():
+            raise RuntimeError("in-flight material write fenced after cancellation")
+        return {"status": "ok"}
+
+    def run_batch() -> Exception | None:
+        try:
+            _run_selected_material_jobs(
+                job_ids,
+                workers=2,
+                cancel_event=cancel_event,
+                stage="tailor",
+                run_one=run_one,
+            )
+        except Exception as exc:  # noqa: BLE001 - asserting cancellation boundary
+            return exc
+        return None
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        future = executor.submit(run_batch)
+        assert first_wave_started.wait(timeout=5)
+        cancel_event.set()
+        release_first_wave.set()
+        error = future.result(timeout=10)
+
+    assert error is not None
+    assert "cancel" in str(error)
+    assert started == [str(job_ids[0]), str(job_ids[1])]
+
+
+def test_material_cancellation_preserves_successor_owner_and_cancels_pending(
+    tmp_path: Path,
+) -> None:
+    conn = init_db(tmp_path / "material-cancel-owner.db")
+    owned = _seed_owned_stage(
+        conn,
+        11,
+        stage="cover",
+        workflow_id="workflow-old",
+    )
+    successor = _seed_owned_stage(
+        conn,
+        12,
+        stage="cover",
+        workflow_id="workflow-successor",
+    )
+    pending = _seed_owned_stage(
+        conn,
+        13,
+        stage="cover",
+        workflow_id="workflow-old",
+    )
+    set_stage_state(
+        conn,
+        canonical_job_id(pending),
+        "cover",
+        "pending",
+        tenant_id=LOCAL_TENANT,
+        metadata={},
+        validate_transition=False,
+    )
+    conn.commit()
+
+    result = cancel_preparation_state_rows(
+        conn,
+        CancelPreparationStateInput(
+            tenant_id="local",
+            workflow_id="workflow-old",
+            stage="cover",
+            job_ids=(owned, successor, pending),
+        ),
+    )
+
+    states = dict(
+        conn.execute(
+            "SELECT job_id, state FROM job_stage_states WHERE stage = 'cover'"
+        ).fetchall()
+    )
+    assert result.canceled == 2
+    assert result.restored == 0
+    assert states[owned] == "canceled"
+    assert states[pending] == "canceled"
+    assert states[successor] == "running"
+    with pytest.raises(RuntimeError, match="no longer owns"):
+        assert_material_activity_commit_allowed(
+            conn,
+            tenant_id="local",
+            job_id=successor,
+            stage="cover",
+            workflow_id="workflow-old",
+        )
+
+
+def test_material_cancellation_preserves_result_committed_before_cancel(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    conn = init_db(tmp_path / "material-cancel-committed.db")
+    committed = _seed_owned_stage(
+        conn,
+        14,
+        stage="cover",
+        workflow_id="workflow-owned",
+    )
+    approved = SimpleNamespace(status=ArtifactStatus.APPROVED)
+    repository = SimpleNamespace(
+        load_current_approved=lambda _tenant, _job_id: SimpleNamespace(
+            cover_letter=approved,
+        )
+    )
+    monkeypatch.setattr(
+        "jobctrl.infrastructure.materials.SqliteMaterialsRepository",
+        lambda _conn: repository,
+    )
+
+    result = cancel_preparation_state_rows(
+        conn,
+        CancelPreparationStateInput(
+            tenant_id="local",
+            workflow_id="workflow-owned",
+            stage="cover",
+            job_ids=(committed,),
+        ),
+    )
+
+    row = conn.execute(
+        "SELECT state, metadata_json FROM job_stage_states "
+        "WHERE tenant_id = 'local' AND job_id = ? AND stage = 'cover'",
+        (committed,),
+    ).fetchone()
+    assert (result.canceled, result.restored) == (0, 1)
+    assert row["state"] == "succeeded"
+    assert "canceled_activity_preserved_committed_cover" in row["metadata_json"]

--- a/workers/automation/tests/test_materials_repository.py
+++ b/workers/automation/tests/test_materials_repository.py
@@ -831,7 +831,12 @@ def test_suppress_active_artifacts_removes_canonical_paths_from_selectors(
 # ---------------------------------------------------------------------------
 
 
-def _policy(*, fingerprint: str = "sha256:a", version: int = 1) -> TailoringPolicy:
+def _policy(
+    *,
+    fingerprint: str = "sha256:a",
+    version: int = 1,
+    profile_fingerprint: str = "sha256:profile",
+) -> TailoringPolicy:
     return TailoringPolicy(
         tenant_id=LOCAL_TENANT,
         version=version,
@@ -840,7 +845,7 @@ def _policy(*, fingerprint: str = "sha256:a", version: int = 1) -> TailoringPoli
         judge_schema_version="tailor-judge.v1",
         prompt_fingerprint=fingerprint,
         config_fingerprint=fingerprint,
-        profile_policy_fingerprint="sha256:profile",
+        profile_policy_fingerprint=profile_fingerprint,
         custom_prompt_fingerprint="sha256:custom",
         generator_settings={"candidate_models": ["local:draft"]},
         judge_settings={"judge_model": "local:judge", "min_score": 0.82},
@@ -906,11 +911,100 @@ def test_tailoring_policy_repository_carries_learned_rules_forward(
 
     assert second.version == first.version + 1
     assert second.learned_tailoring_rules == learned
+
     with pytest.raises(TailoringPolicyChangedError):
         repo.resolve_current(
-            _policy(fingerprint="sha256:stale"),
+            _policy(
+                fingerprint="sha256:changed-controls",
+                profile_fingerprint="sha256:changed-profile-policy",
+            ).with_learned_tailoring_rules(learned),
             expected_current_version=first.version,
         )
+
+
+def test_tailoring_policy_repository_reuses_global_revision_for_concurrent_job_prompts(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    setup_conn = init_db(db_path)
+    baseline = SqliteTailoringPolicyRepository(setup_conn).resolve_current(
+        _policy(fingerprint="sha256:baseline-prompt")
+    )
+    close_connection(db_path)
+    start = threading.Event()
+
+    def resolve(job_prompt_fingerprint: str) -> tuple[TailoringPolicy, str]:
+        conn = get_connection(db_path)
+        try:
+            repository = SqliteTailoringPolicyRepository(conn)
+            start.wait(timeout=5)
+            return (
+                repository.resolve_current(
+                    _policy(fingerprint="sha256:stable-generation-controls"),
+                    expected_current_version=baseline.version,
+                ),
+                job_prompt_fingerprint,
+            )
+        finally:
+            close_connection(db_path)
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        futures = [
+            executor.submit(resolve, "sha256:job-a-prompt"),
+            executor.submit(resolve, "sha256:job-b-prompt"),
+        ]
+        start.set()
+        resolved = [future.result(timeout=10) for future in futures]
+
+    assert [policy.version for policy, _ in resolved] == [2, 2]
+    assert {policy.prompt_fingerprint for policy, _ in resolved} == {
+        "sha256:stable-generation-controls"
+    }
+    assert {job_prompt_fingerprint for _, job_prompt_fingerprint in resolved} == {
+        "sha256:job-a-prompt",
+        "sha256:job-b-prompt",
+    }
+    check_conn = get_connection(db_path)
+    try:
+        count = check_conn.execute("SELECT COUNT(*) FROM tailoring_policies").fetchone()[0]
+        assert count == 2
+    finally:
+        close_connection(db_path)
+
+
+def test_tailoring_policy_profile_snapshot_fingerprint_is_generation_control() -> None:
+    common = {
+        "tenant_id": LOCAL_TENANT,
+        "version": 1,
+        "prompt_version": "tailor.v2.quality-gated",
+        "schema_version": "tailored-resume.v1",
+        "judge_schema_version": "tailor-judge.v1",
+        "prompt_text": "stable global control prompt",
+        "profile_policy": {"claim_mode": "verified_only"},
+        "custom_prompt": "",
+        "generator_settings": {"candidate_models": ["local:draft"]},
+        "judge_settings": {"judge_model": "local:judge", "min_score": 0.82},
+        "created_at": "2026-05-26T00:00:00+00:00",
+    }
+    first = TailoringPolicy.from_runtime(
+        **common,
+        runtime_settings={
+            "validation_mode": "normal",
+            "profile_snapshot_fingerprint": "sha256:profile-v1",
+        },
+    )
+    second = TailoringPolicy.from_runtime(
+        **common,
+        runtime_settings={
+            "validation_mode": "normal",
+            "profile_snapshot_fingerprint": "sha256:profile-v2",
+        },
+    )
+
+    assert first.config_fingerprint != second.config_fingerprint
+    assert first.as_artifact_metadata()["profile_snapshot_fingerprint"] == (
+        "sha256:profile-v1"
+    )
 
 
 def test_tailoring_policy_repository_reuses_same_config(conn: sqlite3.Connection) -> None:

--- a/workers/automation/tests/test_materials_unit_of_work.py
+++ b/workers/automation/tests/test_materials_unit_of_work.py
@@ -21,7 +21,10 @@ incidental.
 
 from __future__ import annotations
 
+from copy import deepcopy
 import sqlite3
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import pytest
@@ -39,13 +42,22 @@ from jobctrl.domain.materials import (
     ValidationResult,
 )
 from jobctrl.domain.materials.provenance import BulletProvenance, BulletProvenanceSet
+from jobctrl.domain.materials.policy import (
+    TailoringPolicy,
+    TailoringPolicyChangedError,
+    fingerprint_profile_snapshot,
+)
 from jobctrl.domain.materials.value_objects import ControlRule, TransformType
+from jobctrl.domain.profile.aggregate import Profile
 from jobctrl.domain.tenant import LOCAL_TENANT
+from jobctrl.infrastructure.events.in_process_bus import InProcessEventBus
 from jobctrl.infrastructure.materials import (
     SqliteBulletProvenanceRepository,
     SqliteMaterialsRepository,
+    SqliteTailoringPolicyRepository,
     SqliteUnitOfWork,
 )
+from jobctrl.infrastructure.profile.sqlite_repository import SqliteProfileRepository
 
 JOB_URL = "https://example.com/job/uow"
 JOB_ID = JobId("00000000-0000-4000-8000-000000000044")
@@ -300,6 +312,305 @@ def test_flip_holds_one_explicit_transaction_and_locks_out_competitors(
     current = materials.load_current_approved(LOCAL_TENANT, JOB_ID)
     assert current is not None and current.generation == 2 and current.is_resume_approved
     assert provenance.load(LOCAL_TENANT, JOB_ID, generation=2) is not None
+
+
+def test_profile_update_during_generation_rejects_stale_artifact_commit(
+    conn: sqlite3.Connection,
+    tmp_path: Path,
+) -> None:
+    """A profile save after generation starts must win before artifact commit."""
+
+    profile_data = {
+        "personal": {"full_name": "Jordan Candidate", "email": "j@example.com"},
+        "resume": {
+            "executive_profile": {"baseline_text": "Backend engineer."},
+            "experience_entries": [
+                {
+                    "id": "role_1",
+                    "title": "Engineer",
+                    "company": "Acme",
+                    "date_range": "2022 -- Present",
+                    "location": "Remote",
+                    "bullets": ["Built APIs."],
+                }
+            ],
+            "education_entries": [],
+            "skill_categories": [
+                {"id": "skills", "label": "Skills", "items": ["Python"]}
+            ],
+            "tailoring_rules": {
+                "required_experience_entry_ids": ["role_1"],
+                "required_skill_category_ids": ["skills"],
+                "writing_style": {"tone": "direct"},
+            },
+        },
+        "resume_constraints": {"real_metrics": []},
+    }
+    bus = InProcessEventBus()
+    profile_repository = SqliteProfileRepository(conn, publisher=bus)
+    profile_repository.save(
+        LOCAL_TENANT,
+        Profile.from_dict(LOCAL_TENANT, profile_data),
+    )
+    db_path = tmp_path / "jobctrl.db"
+    generation_loaded = threading.Event()
+    allow_persist = threading.Event()
+
+    def generate_from_loaded_snapshot() -> str:
+        worker_conn = sqlite3.connect(db_path, timeout=5)
+        worker_conn.row_factory = sqlite3.Row
+        worker_uow = SqliteUnitOfWork(worker_conn)
+        worker_profiles = SqliteProfileRepository(
+            worker_conn,
+            publisher=InProcessEventBus(),
+        )
+        snapshot = worker_profiles.load_snapshot(LOCAL_TENANT)
+        policy_repository = SqliteTailoringPolicyRepository(
+            worker_conn,
+            unit_of_work=worker_uow,
+        )
+        policy = policy_repository.resolve_current(
+            TailoringPolicy.from_runtime(
+                tenant_id=LOCAL_TENANT,
+                version=1,
+                prompt_version="tailor.v2.quality-gated",
+                schema_version="tailored-resume.v1",
+                judge_schema_version="tailor-judge.v1",
+                prompt_text="stable global control prompt",
+                profile_policy={},
+                custom_prompt="",
+                generator_settings={"candidate_models": ["local:draft"]},
+                judge_settings={"judge_model": "local:judge"},
+                runtime_settings={
+                    "validation_mode": "normal",
+                    "profile_snapshot_fingerprint": fingerprint_profile_snapshot(
+                        snapshot
+                    ),
+                },
+                created_at="2026-08-06T00:00:00+00:00",
+            )
+        )
+        generation_loaded.set()
+        assert allow_persist.wait(timeout=5)
+        try:
+            with worker_uow:
+                policy_repository.assert_generation_current(policy, snapshot)
+                SqliteMaterialsRepository(
+                    worker_conn,
+                    unit_of_work=worker_uow,
+                ).save(_gen1_approved())
+        except TailoringPolicyChangedError as exc:
+            return str(exc)
+        finally:
+            worker_conn.close()
+        return "committed"
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        future = executor.submit(generate_from_loaded_snapshot)
+        assert generation_loaded.wait(timeout=5)
+        changed_profile = deepcopy(profile_data)
+        changed_profile["resume"]["tailoring_rules"] = {
+            **profile_data["resume"]["tailoring_rules"],
+            "writing_style": {"tone": "technical"},
+        }
+        profile_repository.save(
+            LOCAL_TENANT,
+            Profile.from_dict(LOCAL_TENANT, changed_profile),
+        )
+        allow_persist.set()
+        result = future.result(timeout=10)
+
+    assert result == "tailoring-relevant profile data changed before artifact persistence"
+    assert conn.execute(
+        "SELECT COUNT(*) FROM job_materials WHERE tenant_id = ? AND job_id = ?",
+        (str(LOCAL_TENANT), str(JOB_ID)),
+    ).fetchone()[0] == 0
+
+
+def test_compensation_only_profile_update_does_not_reject_tailoring_commit(
+    conn: sqlite3.Connection,
+) -> None:
+    """An application-only edit must not invalidate generated Materials."""
+
+    profile_data = {
+        "personal": {"full_name": "Jordan Candidate", "email": "j@example.com"},
+        "compensation": {"salary_expectation": "100000"},
+        "experience": {"years_of_experience_total": 8},
+        "resume": {
+            "executive_profile": {"baseline_text": "Backend engineer."},
+            "experience_entries": [
+                {
+                    "id": "role_1",
+                    "title": "Engineer",
+                    "company": "Acme",
+                    "date_range": "2022 -- Present",
+                    "location": "Remote",
+                    "bullets": ["Built APIs."],
+                }
+            ],
+            "education_entries": [],
+            "skill_categories": [
+                {"id": "skills", "label": "Skills", "items": ["Python"]}
+            ],
+            "tailoring_rules": {
+                "required_experience_entry_ids": ["role_1"],
+                "required_skill_category_ids": ["skills"],
+            },
+        },
+        "resume_constraints": {"real_metrics": []},
+    }
+    profiles = SqliteProfileRepository(conn, publisher=InProcessEventBus())
+    profiles.save(
+        LOCAL_TENANT,
+        Profile.from_dict(LOCAL_TENANT, profile_data),
+    )
+    generation_snapshot = profiles.load_snapshot(LOCAL_TENANT)
+    uow = SqliteUnitOfWork(conn)
+    policies = SqliteTailoringPolicyRepository(conn, unit_of_work=uow)
+    policy = policies.resolve_current(
+        TailoringPolicy.from_runtime(
+            tenant_id=LOCAL_TENANT,
+            version=1,
+            prompt_version="tailor.v2.quality-gated",
+            schema_version="tailored-resume.v1",
+            judge_schema_version="tailor-judge.v1",
+            prompt_text="stable global control prompt",
+            profile_policy={},
+            custom_prompt="",
+            generator_settings={"candidate_models": ["local:draft"]},
+            judge_settings={"judge_model": "local:judge"},
+            runtime_settings={
+                "validation_mode": "normal",
+                "profile_snapshot_fingerprint": fingerprint_profile_snapshot(
+                    generation_snapshot
+                ),
+            },
+            created_at="2026-08-06T00:00:00+00:00",
+        )
+    )
+
+    compensation_update = deepcopy(profile_data)
+    compensation_update["compensation"] = {"salary_expectation": "125000"}
+    profiles.save(
+        LOCAL_TENANT,
+        Profile.from_dict(LOCAL_TENANT, compensation_update),
+    )
+    updated_snapshot = profiles.load_snapshot(LOCAL_TENANT)
+    assert updated_snapshot.version == generation_snapshot.version + 1
+    assert fingerprint_profile_snapshot(updated_snapshot) == fingerprint_profile_snapshot(
+        generation_snapshot
+    )
+
+    with uow:
+        policies.assert_generation_current(policy, generation_snapshot)
+        assert conn.in_transaction is True
+        SqliteMaterialsRepository(conn, unit_of_work=uow).save(_gen1_approved())
+
+    committed = SqliteMaterialsRepository(conn).load_current_approved(
+        LOCAL_TENANT,
+        JOB_ID,
+    )
+    assert committed is not None
+    assert committed.generation == 1
+
+
+def test_profile_comparison_holds_write_lock_through_artifact_commit(
+    conn: sqlite3.Connection,
+    tmp_path: Path,
+) -> None:
+    """A profile writer cannot enter after the fence and before artifact save."""
+
+    profile_data = {
+        "personal": {"full_name": "Jordan Candidate", "email": "j@example.com"},
+        "resume": {
+            "executive_profile": {"baseline_text": "Backend engineer."},
+            "experience_entries": [
+                {
+                    "id": "role_1",
+                    "title": "Engineer",
+                    "company": "Acme",
+                    "date_range": "2022 -- Present",
+                    "location": "Remote",
+                    "bullets": ["Built APIs."],
+                }
+            ],
+            "education_entries": [],
+            "skill_categories": [
+                {"id": "skills", "label": "Skills", "items": ["Python"]}
+            ],
+            "tailoring_rules": {
+                "required_experience_entry_ids": ["role_1"],
+                "required_skill_category_ids": ["skills"],
+                "writing_style": {"tone": "direct"},
+            },
+        },
+        "resume_constraints": {"real_metrics": []},
+    }
+    profiles = SqliteProfileRepository(conn, publisher=InProcessEventBus())
+    profiles.save(LOCAL_TENANT, Profile.from_dict(LOCAL_TENANT, profile_data))
+    generation_snapshot = profiles.load_snapshot(LOCAL_TENANT)
+    uow = SqliteUnitOfWork(conn)
+    policies = SqliteTailoringPolicyRepository(conn, unit_of_work=uow)
+    policy = policies.resolve_current(
+        TailoringPolicy.from_runtime(
+            tenant_id=LOCAL_TENANT,
+            version=1,
+            prompt_version="tailor.v2.quality-gated",
+            schema_version="tailored-resume.v1",
+            judge_schema_version="tailor-judge.v1",
+            prompt_text="stable global control prompt",
+            profile_policy={},
+            custom_prompt="",
+            generator_settings={"candidate_models": ["local:draft"]},
+            judge_settings={"judge_model": "local:judge"},
+            runtime_settings={
+                "validation_mode": "normal",
+                "profile_snapshot_fingerprint": fingerprint_profile_snapshot(
+                    generation_snapshot
+                ),
+            },
+            created_at="2026-08-06T00:00:00+00:00",
+        )
+    )
+    changed_profile = deepcopy(profile_data)
+    changed_profile["resume"]["tailoring_rules"]["writing_style"] = {
+        "tone": "technical"
+    }
+
+    competitor = sqlite3.connect(tmp_path / "jobctrl.db", timeout=0.2)
+    competitor.row_factory = sqlite3.Row
+    competitor_profiles = SqliteProfileRepository(
+        competitor,
+        publisher=InProcessEventBus(),
+    )
+    try:
+        with uow:
+            policies.assert_generation_current(policy, generation_snapshot)
+            assert conn.in_transaction is True
+            with pytest.raises(sqlite3.OperationalError, match="lock"):
+                competitor_profiles.save(
+                    LOCAL_TENANT,
+                    Profile.from_dict(LOCAL_TENANT, changed_profile),
+                )
+            assert conn.in_transaction is True
+            SqliteMaterialsRepository(conn, unit_of_work=uow).save(_gen1_approved())
+
+        competitor_profiles.save(
+            LOCAL_TENANT,
+            Profile.from_dict(LOCAL_TENANT, changed_profile),
+        )
+    finally:
+        competitor.close()
+
+    committed = SqliteMaterialsRepository(conn).load_current_approved(
+        LOCAL_TENANT,
+        JOB_ID,
+    )
+    assert committed is not None
+    assert committed.generation == 1
+    assert profiles.load_snapshot(LOCAL_TENANT).version == (
+        generation_snapshot.version + 1
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/workers/automation/tests/test_materials_use_cases.py
+++ b/workers/automation/tests/test_materials_use_cases.py
@@ -1656,12 +1656,54 @@ def test_tailor_use_case_preserves_attempt_audit_across_durable_executions(
     assert first.status == second.status == "exhausted_retries"
     history = repo.saved[-1].metadata["tailoring_attempt_audits"]
     assert [entry["audit_key"] for entry in history] == [
-        "workflow-run-one:1",
-        "workflow-run-two:2",
+        f"workflow-run-one:1:{history[0]['recorded_at']}",
+        f"workflow-run-two:2:{history[1]['recorded_at']}",
     ]
     assert [entry["durable_attempt"] for entry in history] == [1, 2]
     assert all(entry["report"]["attempts"] == 4 for entry in history)
     assert all(len(entry["report"]["attempt_history"]) == 4 for entry in history)
+
+
+def test_tailor_use_case_appends_rerun_of_same_durable_attempt(
+    tmp_path: Path, snapshot: ProfileSnapshot, job: dict
+) -> None:
+    """A rerun of the same durable attempt must append, not drop, its report.
+
+    Reachable via a post-``--reset-attempts`` CLI execution (execution id and
+    durable attempt both repeat) or an activity retry after a crash between the
+    materials save and the stage-count increment (same run id, same attempt).
+    """
+
+    repo = _FakeRepository()
+    use_case = TailorResumeUseCase(
+        repository=repo,
+        llm=_ScriptedLlm(["not json"] * 8),
+        validator=ContentValidator(),
+        assembler=ResumeAssembler(),
+        analyze_use_case=_FakeAnalyzeUseCase(),
+    )
+
+    first = use_case.execute(
+        job=job,
+        profile_snapshot=snapshot,
+        tailored_dir=tmp_path,
+        audit_execution_id="workflow-run-one",
+        durable_attempt=1,
+    )
+    second = use_case.execute(
+        job=job,
+        profile_snapshot=snapshot,
+        tailored_dir=tmp_path,
+        audit_execution_id="workflow-run-one",
+        durable_attempt=1,
+    )
+
+    assert first.status == second.status == "exhausted_retries"
+    history = repo.saved[-1].metadata["tailoring_attempt_audits"]
+    assert [entry["durable_attempt"] for entry in history] == [1, 1]
+    assert len({entry["audit_key"] for entry in history}) == 2
+    # The singular latest-record field stays consistent with the history tail.
+    assert repo.saved[-1].metadata["tailoring_attempt_audit"] == history[-1]["report"]
 
 
 def test_tailor_use_case_does_not_promote_invalid_prior_output_into_retry_prompt(

--- a/workers/automation/tests/test_materials_use_cases.py
+++ b/workers/automation/tests/test_materials_use_cases.py
@@ -32,6 +32,7 @@ from jobctrl.domain.materials import (
 )
 from jobctrl.domain.materials.adversarial import ADVERSARIAL_REVIEW_RESPONSE_SCHEMA
 from jobctrl.domain.materials.aggregate import MaterialsLifecycle
+from jobctrl.domain.materials.policy import LearnedTailoringRules, fingerprint_value
 from jobctrl.domain.materials.requirement_coverage import COVERAGE_PLANNER_RESPONSE_SCHEMA
 from jobctrl.domain.materials.services import ContentValidator, ResumeAssembler
 from jobctrl.domain.materials.use_cases import (
@@ -1360,9 +1361,111 @@ def test_tailor_use_case_routes_multiple_candidate_models_and_persists_safe_meta
     assert metadata["tailoring_policy_version"] == 1
     assert metadata["tailoring_policy"]["prompt_fingerprint"].startswith("sha256:")
     assert metadata["tailoring_policy"]["config_fingerprint"].startswith("sha256:")
+    assert metadata["tailoring_policy"]["profile_snapshot_fingerprint"].startswith(
+        "sha256:"
+    )
+    assert metadata["job_prompt_fingerprint"].startswith("sha256:")
+    assert metadata["job_prompt_fingerprint"] != metadata["tailoring_policy"][
+        "prompt_fingerprint"
+    ]
+    selected_summary = next(
+        summary
+        for summary in metadata["candidate_summaries"]
+        if summary["candidate_id"] == outcome.report["selected_candidate"]
+    )
+    assert metadata["job_prompt_fingerprint"] == selected_summary[
+        "prompt_fingerprint"
+    ]
+    assert metadata["job_prompt_fingerprint"] == fingerprint_value(
+        [
+            {"role": message.role, "content": message.content}
+            for message in llm.calls[1]
+        ]
+    )
     assert metadata["candidate_summaries"][0]["generator"] == "codex:draft-a"
     assert "api_key" not in json.dumps(metadata).lower()
     assert "platform leadership language" not in json.dumps(metadata).lower()
+
+
+def test_tailoring_policy_fails_closed_when_tailoring_profile_projection_changes(
+    snapshot: ProfileSnapshot,
+) -> None:
+    use_case = TailorResumeUseCase(
+        repository=_FakeRepository(),
+        llm=_ScriptedLlm([]),
+        validator=ContentValidator(),
+        assembler=ResumeAssembler(),
+        analyze_use_case=_FakeAnalyzeUseCase(),
+    )
+    original = use_case._resolve_tailoring_policy(
+        profile_snapshot=snapshot,
+        prompt_text="stable global control prompt",
+        validation_mode="normal",
+        tenant_id=LOCAL_TENANT,
+        learned_tailoring_rules=LearnedTailoringRules(),
+        expected_current_version=0,
+    )
+    changed_profile = _profile_dict()
+    changed_profile["resume"]["tailoring_rules"]["writing_style"] = {
+        "tone": "technical"
+    }
+    changed_snapshot = ProfileSnapshot.from_profile(
+        Profile.from_dict(LOCAL_TENANT, changed_profile),
+        version=snapshot.version + 1,
+    )
+    changed = use_case._resolve_tailoring_policy(
+        profile_snapshot=changed_snapshot,
+        prompt_text="stable global control prompt",
+        validation_mode="normal",
+        tenant_id=LOCAL_TENANT,
+        learned_tailoring_rules=LearnedTailoringRules(),
+        expected_current_version=0,
+    )
+
+    assert original.prompt_fingerprint == changed.prompt_fingerprint
+    assert original.runtime_settings["profile_snapshot_fingerprint"] != (
+        changed.runtime_settings["profile_snapshot_fingerprint"]
+    )
+    assert original.config_fingerprint != changed.config_fingerprint
+
+
+def test_tailoring_policy_ignores_compensation_only_profile_update(
+    snapshot: ProfileSnapshot,
+) -> None:
+    use_case = TailorResumeUseCase(
+        repository=_FakeRepository(),
+        llm=_ScriptedLlm([]),
+        validator=ContentValidator(),
+        assembler=ResumeAssembler(),
+        analyze_use_case=_FakeAnalyzeUseCase(),
+    )
+    original = use_case._resolve_tailoring_policy(
+        profile_snapshot=snapshot,
+        prompt_text="stable global control prompt",
+        validation_mode="normal",
+        tenant_id=LOCAL_TENANT,
+        learned_tailoring_rules=LearnedTailoringRules(),
+        expected_current_version=0,
+    )
+    changed_profile = _profile_dict()
+    changed_profile["compensation"] = {"salary_expectation": "125000"}
+    changed_snapshot = ProfileSnapshot.from_profile(
+        Profile.from_dict(LOCAL_TENANT, changed_profile),
+        version=snapshot.version + 1,
+    )
+    changed = use_case._resolve_tailoring_policy(
+        profile_snapshot=changed_snapshot,
+        prompt_text="stable global control prompt",
+        validation_mode="normal",
+        tenant_id=LOCAL_TENANT,
+        learned_tailoring_rules=LearnedTailoringRules(),
+        expected_current_version=0,
+    )
+
+    assert original.runtime_settings["profile_snapshot_fingerprint"] == (
+        changed.runtime_settings["profile_snapshot_fingerprint"]
+    )
+    assert original.config_fingerprint == changed.config_fingerprint
 
 
 def test_tailor_use_case_lenient_skips_judge(
@@ -1407,6 +1510,10 @@ def test_tailor_use_case_failed_validation_persists_rejected_artifact(
         job=job, profile_snapshot=snapshot, tailored_dir=tmp_path
     )
     assert outcome.status == "failed_validation"
+    audit = repo.saved[-1].metadata["tailoring_attempt_audit"]
+    assert audit["status"] == "failed_validation"
+    assert audit["attempts"] == 4
+    assert len(audit["attempt_history"]) == 4
 
 
 def test_tailor_use_case_tries_multiple_candidate_models_and_separate_judge(
@@ -1510,7 +1617,51 @@ def test_tailor_use_case_exhausted_when_no_parseable_json(
         job=job, profile_snapshot=snapshot, tailored_dir=tmp_path
     )
     assert outcome.status == "exhausted_retries"
+    audit = repo.saved[-1].metadata["tailoring_attempt_audit"]
+    assert audit["status"] == "exhausted_retries"
+    assert audit["attempts"] == 4
+    assert len(audit["attempt_history"]) == 4
+    assert audit["attempt_history"][0]["system_prompt"]
+    assert audit["attempt_history"][0]["candidates"][0]["status"] == "parse_error"
     assert any(getattr(e, "event_type", "") == "ResumeFailed" for e in publisher.events)
+
+
+def test_tailor_use_case_preserves_attempt_audit_across_durable_executions(
+    tmp_path: Path, snapshot: ProfileSnapshot, job: dict
+) -> None:
+    repo = _FakeRepository()
+    use_case = TailorResumeUseCase(
+        repository=repo,
+        llm=_ScriptedLlm(["not json"] * 8),
+        validator=ContentValidator(),
+        assembler=ResumeAssembler(),
+        analyze_use_case=_FakeAnalyzeUseCase(),
+    )
+
+    first = use_case.execute(
+        job=job,
+        profile_snapshot=snapshot,
+        tailored_dir=tmp_path,
+        audit_execution_id="workflow-run-one",
+        durable_attempt=1,
+    )
+    second = use_case.execute(
+        job=job,
+        profile_snapshot=snapshot,
+        tailored_dir=tmp_path,
+        audit_execution_id="workflow-run-two",
+        durable_attempt=2,
+    )
+
+    assert first.status == second.status == "exhausted_retries"
+    history = repo.saved[-1].metadata["tailoring_attempt_audits"]
+    assert [entry["audit_key"] for entry in history] == [
+        "workflow-run-one:1",
+        "workflow-run-two:2",
+    ]
+    assert [entry["durable_attempt"] for entry in history] == [1, 2]
+    assert all(entry["report"]["attempts"] == 4 for entry in history)
+    assert all(len(entry["report"]["attempt_history"]) == 4 for entry in history)
 
 
 def test_tailor_use_case_does_not_promote_invalid_prior_output_into_retry_prompt(

--- a/workers/automation/tests/test_p1b_error_inversion.py
+++ b/workers/automation/tests/test_p1b_error_inversion.py
@@ -32,6 +32,7 @@ from jobctrl.database import init_db
 from jobctrl.discovery import smartextract, workday
 from jobctrl.discovery.jobspy import DiscoveryCancelled, run_discovery
 from jobctrl.domain.errors import (
+    AttemptBudgetExhaustedError,
     AuthenticationError,
     BrowserTransientError,
     ConfigurationError,
@@ -42,6 +43,7 @@ from jobctrl.domain.errors import (
     TransientNetworkError,
     to_application_error,
 )
+from jobctrl.domain.identifiers import JobId
 from jobctrl.enrichment.activities import EnrichActivityInput, EnrichActivityOutput, enrich_activity
 from jobctrl.infrastructure.discovery import production_wiring
 from jobctrl.infrastructure.temporal.run_in_activity import (
@@ -222,6 +224,7 @@ _ACTIVITY_CASES = (
 
 def test_error_taxonomy_maps_to_temporal_application_errors() -> None:
     cases: tuple[tuple[type[JobCtrlError], str, bool], ...] = (
+        (AttemptBudgetExhaustedError, "attempt_budget_exhausted", True),
         (ConfigurationError, "configuration", True),
         (AuthenticationError, "authentication", True),
         (MissingInputError, "missing_input", True),
@@ -248,6 +251,46 @@ def _application_error_from_failure(exc: WorkflowFailureError) -> ApplicationErr
     if isinstance(cause, ApplicationError):
         return cause
     raise AssertionError(f"Expected ApplicationError cause, got {cause!r}")
+
+
+@pytest.mark.asyncio
+async def test_tailor_job_durable_attempt_exhaustion_is_non_retryable() -> None:
+    attempts = 0
+
+    def _exhausted(*_args, **_kwargs) -> dict[str, str]:
+        nonlocal attempts
+        attempts += 1
+        return {
+            "status": "exhausted",
+            "error": "Tailor durable attempt budget exhausted",
+        }
+
+    queue = f"p1b-tailor-job-exhausted-{uuid.uuid4()}"
+    payload = TailorJobActivityInput(
+        tenant_id="local",
+        job_id=JobId("00000000-0000-4000-8000-000000000001"),
+    )
+    with patch("jobctrl.materials.activities._tailor_one_job", side_effect=_exhausted):
+        async with await WorkflowEnvironment.start_time_skipping() as env:
+            async with Worker(
+                env.client,
+                task_queue=queue,
+                workflows=[_P1bTailorJobHarness],
+                activities=[tailor_job_activity],
+                workflow_runner=UnsandboxedWorkflowRunner(),
+            ):
+                with pytest.raises(WorkflowFailureError) as exc_info:
+                    await env.client.execute_workflow(
+                        _P1bTailorJobHarness.run,
+                        payload,
+                        id=f"p1b-tailor-job-exhausted-wf-{uuid.uuid4()}",
+                        task_queue=queue,
+                    )
+
+    app_error = _application_error_from_failure(exc_info.value)
+    assert attempts == 1
+    assert app_error.type == "attempt_budget_exhausted"
+    assert app_error.non_retryable is True
 
 
 @pytest.mark.asyncio

--- a/workers/automation/tests/test_tailor_retailor.py
+++ b/workers/automation/tests/test_tailor_retailor.py
@@ -19,12 +19,14 @@ from jobctrl.domain.materials import (
     RenderFormat,
     ValidationResult,
 )
-from jobctrl.domain.materials.policy import LearnedTailoringRules
+from jobctrl.domain.materials.policy import LearnedTailoringRules, TailoringPolicy
 from jobctrl.domain.materials.use_cases import TailorOutcome, build_master_tailor_prompt
 from jobctrl.domain.profile.aggregate import Profile
 from jobctrl.domain.profile.snapshot import ProfileSnapshot
 from jobctrl.domain.tenant import LOCAL_TENANT
+from jobctrl.infrastructure.materials import SqliteTailoringPolicyRepository
 from jobctrl.pipeline import _count_pending
+from jobctrl.pipeline.current_policy_selectors import tailoring_current_policy_job_ids
 from jobctrl.state import ensure_job_stage_rows, set_stage_state
 from jobctrl.scoring.tailor import (
     _build_pdf_renderer,
@@ -48,6 +50,7 @@ def _insert_job(
     url: str,
     fit_score: int = 9,
     material_path: str | None = None,
+    material_metadata: dict | None = None,
 ):
     job_id = _job_id_for_url(url)
     timestamp = "2026-06-01T00:00:00+00:00"
@@ -110,19 +113,43 @@ def _insert_job(
             """
             INSERT INTO job_materials_artifacts (
                 tenant_id, job_id, generation, artifact_type, artifact_id,
-                status, path, render_format, created_at
-            ) VALUES (?, ?, 1, 'tailored_resume', ?, 'approved', ?, 'text', ?)
+                status, path, render_format, metadata_json, created_at
+            ) VALUES (?, ?, 1, 'tailored_resume', ?, 'approved', ?, 'text', ?, ?)
             """,
             (
                 str(LOCAL_TENANT),
                 str(job_id),
                 f"{job_id}:tailored_resume",
                 material_path,
+                json.dumps(material_metadata or {}, sort_keys=True),
                 timestamp,
             ),
         )
     conn.commit()
     return job_id
+
+
+def _tailoring_policy(
+    *,
+    profile_snapshot_fingerprint: str = "sha256:profile-v1",
+) -> TailoringPolicy:
+    return TailoringPolicy.from_runtime(
+        tenant_id=LOCAL_TENANT,
+        version=1,
+        prompt_version="tailor.v2.quality-gated",
+        schema_version="tailored-resume.v1",
+        judge_schema_version="tailor-judge.v1",
+        prompt_text="stable global control prompt",
+        profile_policy={"claim_mode": "verified_only"},
+        custom_prompt="",
+        generator_settings={"candidate_models": ["local:draft"]},
+        judge_settings={"judge_model": "local:judge", "min_score": 0.82},
+        runtime_settings={
+            "validation_mode": "normal",
+            "profile_snapshot_fingerprint": profile_snapshot_fingerprint,
+        },
+        created_at="2026-06-01T00:00:00+00:00",
+    )
 
 
 def _insert_blocked_score(conn, *, url: str, blocker: str = "No sponsorship.") -> None:
@@ -194,6 +221,52 @@ def test_get_jobs_by_stage_retailor_includes_already_tailored_jobs(tmp_path):
             str(new_job_id),
             str(existing_job_id),
         }
+    finally:
+        close_connection(db_path)
+
+
+def test_parallel_job_prompts_share_global_policy_until_profile_revision(tmp_path):
+    db_path = Path(tmp_path) / "jobs.db"
+    conn = init_db(db_path)
+
+    try:
+        policy_repository = SqliteTailoringPolicyRepository(conn)
+        current = policy_repository.resolve_current(_tailoring_policy())
+        first_job_id = _insert_job(
+            conn,
+            url="https://example.com/policy-job-a",
+            material_path="/tmp/policy-job-a.txt",
+            material_metadata={
+                "tailoring_policy_version": current.version,
+                "job_prompt_fingerprint": "sha256:job-a-prompt",
+            },
+        )
+        second_job_id = _insert_job(
+            conn,
+            url="https://example.com/policy-job-b",
+            material_path="/tmp/policy-job-b.txt",
+            material_metadata={
+                "tailoring_policy_version": current.version,
+                "job_prompt_fingerprint": "sha256:job-b-prompt",
+            },
+        )
+
+        assert tailoring_current_policy_job_ids(
+            conn,
+            tenant_id=str(LOCAL_TENANT),
+        ) == ()
+
+        revised = policy_repository.resolve_current(
+            _tailoring_policy(profile_snapshot_fingerprint="sha256:profile-v2"),
+            expected_current_version=current.version,
+        )
+        assert revised.version == current.version + 1
+        assert set(
+            tailoring_current_policy_job_ids(
+                conn,
+                tenant_id=str(LOCAL_TENANT),
+            )
+        ) == {first_job_id, second_job_id}
     finally:
         close_connection(db_path)
 

--- a/workers/automation/tests/test_v7_cover_runtime.py
+++ b/workers/automation/tests/test_v7_cover_runtime.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import json
 import sqlite3
+import threading
 from pathlib import Path
 
 import pytest
@@ -83,6 +85,16 @@ class _FailingCoverLlm:
     def chat(self, *_args, **_kwargs) -> str:
         self.calls += 1
         raise RuntimeError("LLM outage")
+
+
+class _CancelingCoverLlm(_CoverLlm):
+    def __init__(self, cancel_event: threading.Event) -> None:
+        super().__init__()
+        self._cancel_event = cancel_event
+
+    def chat(self, *_args, **_kwargs) -> str:
+        self._cancel_event.set()
+        return super().chat(*_args, **_kwargs)
 
 
 @pytest.fixture()
@@ -278,6 +290,55 @@ def test_cover_by_id_persists_artifacts_and_isolates_same_job_id_across_tenants(
         "SELECT tenant_id, job_id FROM job_events WHERE event_type = 'StageCompleted' AND stage = 'cover'"
     ).fetchone()
     assert tuple(event) == (str(_TENANT_A), str(_JOB_ID))
+
+
+def test_cover_default_runner_fences_cancellation_before_artifact_or_terminal_write(
+    conn: sqlite3.Connection,
+    tmp_path: Path,
+) -> None:
+    """The production runner's default repository shares the guarded UOW."""
+
+    _seed_target(conn, tenant_id=_TENANT_A)
+    _seed_eligible_score(conn, tenant_id=_TENANT_A)
+    _seed_approved_resume(conn, tmp_path, tenant_id=_TENANT_A)
+    cancel_event = threading.Event()
+    llm = _CancelingCoverLlm(cancel_event)
+
+    with pytest.raises(RuntimeError, match="cover activity canceled before persistence"):
+        cover_letter_module.cover_letter_by_id(
+            _JOB_ID,
+            tenant_id=_TENANT_A,
+            snapshot=_snapshot(_TENANT_A),
+            llm_port=llm,
+            pdf_renderer=_PdfRenderer(),
+            workflow_id="workflow-run-canceled",
+            cancel_event=cancel_event,
+        )
+
+    assert llm.calls == 1
+    materials = SqliteMaterialsRepository(conn).load_current_approved(
+        _TENANT_A,
+        _JOB_ID,
+    )
+    assert materials is not None
+    assert materials.cover_letter is None
+    assert materials.cover_letter_pdf is None
+    state = conn.execute(
+        "SELECT state, attempt_count, metadata_json FROM job_stage_states "
+        "WHERE tenant_id = ? AND job_id = ? AND stage = 'cover'",
+        (str(_TENANT_A), str(_JOB_ID)),
+    ).fetchone()
+    assert state["state"] == "running"
+    assert state["attempt_count"] == 0
+    assert json.loads(state["metadata_json"])["activityOwner"] == (
+        "workflow-run-canceled"
+    )
+    terminal_events = conn.execute(
+        "SELECT COUNT(*) FROM job_events WHERE tenant_id = ? AND job_id = ? "
+        "AND stage = 'cover' AND event_type IN ('StageCompleted', 'StageFailed')",
+        (str(_TENANT_A), str(_JOB_ID)),
+    ).fetchone()[0]
+    assert terminal_events == 0
 
 
 def test_cover_job_replay_closes_running_state_from_committed_approved_artifact(

--- a/workers/automation/tests/test_v7_tailor_runtime.py
+++ b/workers/automation/tests/test_v7_tailor_runtime.py
@@ -4,13 +4,23 @@ from __future__ import annotations
 
 import json
 import sqlite3
+import threading
 from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
 
 from jobctrl.domain.identifiers import JobId, canonical_job_id
-from jobctrl.domain.tenant import TenantId
+from jobctrl.domain.materials.analysis import (
+    AnalysisAgreement,
+    EmployerAnalysis,
+    JobAnalysis,
+    ReasonedKeyword,
+    compute_snapshot_hash,
+)
+from jobctrl.domain.profile.aggregate import Profile
+from jobctrl.domain.profile.snapshot import ProfileSnapshot
+from jobctrl.domain.tenant import LOCAL_TENANT, TenantId
 from jobctrl.infrastructure.migrations.schema_v7 import create_exact_v7_schema
 from jobctrl.materials import activities as activities_module
 from jobctrl.materials.activities import TailorJobActivityInput
@@ -134,6 +144,128 @@ def _fake_approved_result(job: dict) -> dict:
     }
 
 
+def _snapshot(tenant_id: TenantId) -> ProfileSnapshot:
+    return ProfileSnapshot.from_profile(
+        Profile.from_dict(
+            tenant_id,
+            {
+                "personal": {"full_name": "Candidate"},
+                "resume": {
+                    "executive_profile": {
+                        "baseline_text": "Python platform engineer."
+                    },
+                    "experience_entries": [
+                        {
+                            "id": "platform",
+                            "title": "Platform Engineer",
+                            "company": "Previous Co",
+                            "bullets": ["Built Python platform services."],
+                        }
+                    ],
+                    "education_entries": [],
+                    "skill_categories": [
+                        {"id": "skills", "label": "Skills", "items": ["Python"]}
+                    ],
+                },
+            },
+        )
+    )
+
+
+class _FakeAnalyzeUseCase:
+    def execute(self, *, job: dict, tenant_id: TenantId, force: bool = False):
+        _ = force
+        analysis = JobAnalysis(
+            role_framing="Platform engineering.",
+            inferred_seniority="senior",
+            ideal_candidate_narrative="A Python platform engineer.",
+            requirements=[],
+            keywords=[ReasonedKeyword(keyword="Python", evidence_span="Python")],
+        )
+        return SimpleNamespace(
+            analysis=EmployerAnalysis.build(
+                tenant_id=tenant_id,
+                job_id=canonical_job_id(str(job["job_id"])),
+                generation=1,
+                snapshot_hash=compute_snapshot_hash(
+                    str(job.get("full_description") or "")
+                ),
+                canonical=analysis,
+                sub_analyses=(),
+                failures=(),
+                agreement=AnalysisAgreement(score=1.0),
+                legs_attempted=2,
+            )
+        )
+
+
+class _CancelingTailorLlm:
+    model = "test-model"
+
+    def __init__(self, cancel_event: threading.Event) -> None:
+        self._cancel_event = cancel_event
+        self.calls = 0
+
+    def chat(self, *_args, **_kwargs) -> str:
+        self.calls += 1
+        self._cancel_event.set()
+        return "{}"
+
+
+def test_tailor_default_runner_fences_cancellation_before_material_or_terminal_write(
+    conn: sqlite3.Connection,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The production runner and default shared UOW retain the cancel fence."""
+
+    _seed_job(conn, tenant_id=_TENANT_A, url="https://example.com/canceled-tailor")
+    cancel_event = threading.Event()
+    llm = _CancelingTailorLlm(cancel_event)
+    monkeypatch.setattr(tailor_module, "get_connection", lambda: conn)
+    monkeypatch.setattr(tailor_module, "TAILORED_DIR", tmp_path / "tailored")
+    monkeypatch.setattr(tailor_module, "get_llm_adapter", lambda: llm)
+    monkeypatch.setattr(
+        tailor_module,
+        "_build_analyze_use_case",
+        lambda **_kwargs: _FakeAnalyzeUseCase(),
+    )
+    monkeypatch.setattr(tailor_module, "_build_voice_port", lambda: None)
+
+    with pytest.raises(RuntimeError, match="tailor activity canceled before persistence"):
+        tailor_module.tailor_job_by_id(
+            _JOB_ID,
+            tenant_id=_TENANT_A,
+            snapshot=_snapshot(_TENANT_A),
+            tailor_models=("codex:test-model",),
+            llm_model=None,
+            pdf_renderer=object(),
+            workflow_id="workflow-run-canceled",
+            cancel_event=cancel_event,
+        )
+
+    assert llm.calls == 1
+    assert conn.execute(
+        "SELECT COUNT(*) FROM job_materials WHERE tenant_id = ? AND job_id = ?",
+        (str(_TENANT_A), str(_JOB_ID)),
+    ).fetchone()[0] == 0
+    state = conn.execute(
+        "SELECT state, metadata_json FROM job_stage_states "
+        "WHERE tenant_id = ? AND job_id = ? AND stage = 'tailor'",
+        (str(_TENANT_A), str(_JOB_ID)),
+    ).fetchone()
+    assert state["state"] == "running"
+    assert json.loads(state["metadata_json"])["activityOwner"] == (
+        "workflow-run-canceled"
+    )
+    terminal_events = conn.execute(
+        "SELECT COUNT(*) FROM job_events WHERE tenant_id = ? AND job_id = ? "
+        "AND stage = 'tailor' AND event_type IN ('StageCompleted', 'StageFailed')",
+        (str(_TENANT_A), str(_JOB_ID)),
+    ).fetchone()[0]
+    assert terminal_events == 0
+
+
 def test_tailor_job_by_id_is_tenant_scoped_and_writes_canonical_state(
     conn: sqlite3.Connection,
     tmp_path: Path,
@@ -190,6 +322,45 @@ def test_tailor_job_by_id_is_tenant_scoped_and_writes_canonical_state(
         "job_id": str(_JOB_ID),
         "event_type": "StageCompleted",
     }
+
+
+def test_tailor_job_by_id_terminalizes_unhandled_item_exception(
+    conn: sqlite3.Connection,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _seed_job(conn, tenant_id=_TENANT_A, url="https://example.com/exception")
+    monkeypatch.setattr(tailor_module, "get_connection", lambda: conn)
+    monkeypatch.setattr(tailor_module, "TAILORED_DIR", tmp_path / "tailored")
+    monkeypatch.setattr(tailor_module, "_build_pdf_renderer", lambda: object())
+    monkeypatch.setattr(
+        tailor_module,
+        "_tailor_one_job",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("provider failed")),
+    )
+
+    result = tailor_module.tailor_job_by_id(
+        _JOB_ID,
+        tenant_id=_TENANT_A,
+        snapshot=SimpleNamespace(),
+        llm_model=None,
+        workflow_id="workflow-run-owned",
+    )
+
+    assert result["status"] == "error"
+    state = conn.execute(
+        "SELECT state, error_code, metadata_json FROM job_stage_states "
+        "WHERE tenant_id = ? AND job_id = ? AND stage = 'tailor'",
+        (str(_TENANT_A), str(_JOB_ID)),
+    ).fetchone()
+    assert state["state"] == "failed"
+    assert state["error_code"] == "ERROR"
+    event = conn.execute(
+        "SELECT event_type FROM job_events WHERE tenant_id = ? AND job_id = ? "
+        "AND stage = 'tailor' ORDER BY event_id DESC LIMIT 1",
+        (str(_TENANT_A), str(_JOB_ID)),
+    ).fetchone()
+    assert event["event_type"] == "StageFailed"
 
 
 def test_tailor_job_replay_closes_running_state_from_committed_approved_resume(
@@ -591,9 +762,19 @@ def test_tailor_job_by_id_allows_temporal_retry_to_reenter_generation(
     )
     conn.commit()
     calls: list[str] = []
+    running_attempt_counts: list[int] = []
 
     def fake_tailor(job: dict, *_args, **_kwargs) -> dict:
         calls.append(str(job["job_id"]))
+        running_attempt_counts.append(
+            int(
+                conn.execute(
+                    "SELECT attempt_count FROM job_stage_states "
+                    "WHERE tenant_id = ? AND job_id = ? AND stage = 'tailor'",
+                    (str(_TENANT_A), str(_JOB_ID)),
+                ).fetchone()[0]
+            )
+        )
         return _fake_approved_result(job)
 
     monkeypatch.setattr(tailor_module, "get_connection", lambda: conn)
@@ -610,6 +791,264 @@ def test_tailor_job_by_id_allows_temporal_retry_to_reenter_generation(
 
     assert result["status"] == "approved"
     assert calls == [str(_JOB_ID)]
+    assert running_attempt_counts == [1]
+    state = conn.execute(
+        """
+        SELECT state, attempt_count
+        FROM job_stage_states
+        WHERE tenant_id = ? AND job_id = ? AND stage = 'tailor'
+        """,
+        (str(_TENANT_A), str(_JOB_ID)),
+    ).fetchone()
+    assert tuple(state) == ("succeeded", 2)
+
+
+def test_tailor_job_by_id_keeps_inner_retry_exhaustion_outer_retryable(
+    conn: sqlite3.Connection,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _seed_job(conn, tenant_id=_TENANT_A, url="https://example.com/inner-retries")
+
+    def fake_tailor(job: dict, *_args, **_kwargs) -> dict:
+        return {
+            "url": job["url"],
+            "status": "exhausted_retries",
+            "attempts": 4,
+            "error": "No parseable candidate",
+        }
+
+    monkeypatch.setattr(tailor_module, "get_connection", lambda: conn)
+    monkeypatch.setattr(tailor_module, "TAILORED_DIR", tmp_path / "tailored")
+    monkeypatch.setattr(tailor_module, "_build_pdf_renderer", lambda: object())
+    monkeypatch.setattr(tailor_module, "_tailor_one_job", fake_tailor)
+
+    result = tailor_module.tailor_job_by_id(
+        _JOB_ID,
+        tenant_id=_TENANT_A,
+        snapshot=SimpleNamespace(),
+        llm_model=None,
+    )
+
+    assert result["status"] == "exhausted_retries"
+    state = conn.execute(
+        """
+        SELECT state, attempt_count, retryable, next_action
+        FROM job_stage_states
+        WHERE tenant_id = ? AND job_id = ? AND stage = 'tailor'
+        """,
+        (str(_TENANT_A), str(_JOB_ID)),
+    ).fetchone()
+    assert tuple(state) == (
+        "failed",
+        1,
+        1,
+        "jobctrl retry tailor https://example.com/inner-retries",
+    )
+    event_payload = json.loads(
+        conn.execute(
+            "SELECT payload_json FROM job_events "
+            "WHERE tenant_id = ? AND job_id = ? AND stage = 'tailor' "
+            "AND event_type = 'StageFailed' ORDER BY event_id DESC LIMIT 1",
+            (str(_TENANT_A), str(_JOB_ID)),
+        ).fetchone()[0]
+    )
+    assert {
+        key: event_payload[key]
+        for key in (
+            "attempts",
+            "generationAttempts",
+            "generationStatus",
+            "retryable",
+        )
+    } == {
+        "attempts": 1,
+        "generationAttempts": 4,
+        "generationStatus": "exhausted_retries",
+        "retryable": True,
+    }
+
+
+def test_tailor_job_by_id_marks_fifth_durable_failure_exhausted(
+    conn: sqlite3.Connection,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _seed_job(conn, tenant_id=_TENANT_A, url="https://example.com/outer-retries")
+    conn.execute(
+        """
+        UPDATE job_stage_states
+        SET state = 'failed', attempt_count = 4
+        WHERE tenant_id = ? AND job_id = ? AND stage = 'tailor'
+        """,
+        (str(_TENANT_A), str(_JOB_ID)),
+    )
+    conn.commit()
+
+    def fake_tailor(job: dict, *_args, **_kwargs) -> dict:
+        return {
+            "url": job["url"],
+            "status": "failed_validation",
+            "attempts": 4,
+            "error": "Candidate did not pass validation",
+        }
+
+    monkeypatch.setattr(tailor_module, "get_connection", lambda: conn)
+    monkeypatch.setattr(tailor_module, "TAILORED_DIR", tmp_path / "tailored")
+    monkeypatch.setattr(tailor_module, "_build_pdf_renderer", lambda: object())
+    monkeypatch.setattr(tailor_module, "_tailor_one_job", fake_tailor)
+
+    result = tailor_module.tailor_job_by_id(
+        _JOB_ID,
+        tenant_id=_TENANT_A,
+        snapshot=SimpleNamespace(),
+        llm_model=None,
+    )
+
+    assert result["status"] == "exhausted"
+    assert result["inner_status"] == "failed_validation"
+    assert result["reason"] == "durable_attempt_budget_exhausted"
+    state = conn.execute(
+        """
+        SELECT state, attempt_count, retryable, next_action
+        FROM job_stage_states
+        WHERE tenant_id = ? AND job_id = ? AND stage = 'tailor'
+        """,
+        (str(_TENANT_A), str(_JOB_ID)),
+    ).fetchone()
+    assert tuple(state) == (
+        "exhausted",
+        5,
+        0,
+        "jobctrl retry tailor https://example.com/outer-retries --reset-attempts",
+    )
+
+
+def test_tailor_job_by_id_does_not_reenter_generation_after_exhaustion(
+    conn: sqlite3.Connection,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _seed_job(conn, tenant_id=_TENANT_A, url="https://example.com/already-exhausted")
+    conn.execute(
+        "UPDATE job_stage_states SET state = 'exhausted', attempt_count = 5, retryable = 0 "
+        "WHERE tenant_id = ? AND job_id = ? AND stage = 'tailor'",
+        (str(_TENANT_A), str(_JOB_ID)),
+    )
+    conn.commit()
+    prior_events = conn.execute(
+        "SELECT COUNT(*) FROM job_events WHERE tenant_id = ? AND job_id = ? AND stage = 'tailor'",
+        (str(_TENANT_A), str(_JOB_ID)),
+    ).fetchone()[0]
+    monkeypatch.setattr(tailor_module, "get_connection", lambda: conn)
+    monkeypatch.setattr(tailor_module, "TAILORED_DIR", tmp_path / "tailored")
+    monkeypatch.setattr(
+        tailor_module,
+        "_tailor_one_job",
+        lambda *_args, **_kwargs: pytest.fail("exhausted job re-entered generation"),
+    )
+
+    result = tailor_module.tailor_job_by_id(
+        _JOB_ID,
+        tenant_id=_TENANT_A,
+        snapshot=SimpleNamespace(),
+        llm_model=None,
+    )
+
+    assert result == {
+        "url": "https://example.com/already-exhausted",
+        "job_id": str(_JOB_ID),
+        "status": "exhausted",
+        "reason": "durable_attempt_budget_exhausted",
+        "error": "Tailor durable attempt budget exhausted.",
+    }
+    state = conn.execute(
+        "SELECT state, attempt_count, retryable FROM job_stage_states "
+        "WHERE tenant_id = ? AND job_id = ? AND stage = 'tailor'",
+        (str(_TENANT_A), str(_JOB_ID)),
+    ).fetchone()
+    assert tuple(state) == ("exhausted", 5, 0)
+    assert conn.execute(
+        "SELECT COUNT(*) FROM job_events WHERE tenant_id = ? AND job_id = ? AND stage = 'tailor'",
+        (str(_TENANT_A), str(_JOB_ID)),
+    ).fetchone()[0] == prior_events
+
+
+def test_legacy_tailor_batch_counts_all_failures_and_exhausts_durable_budget(
+    conn: sqlite3.Connection,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    url = "https://example.com/legacy-batch-exhaustion"
+    job_id = _JOB_ID
+    _seed_job(conn, tenant_id=LOCAL_TENANT, job_id=job_id, url=url)
+    job = {
+        "tenant_id": str(LOCAL_TENANT),
+        "job_id": str(job_id),
+        "url": url,
+        "title": "Platform Engineer",
+        "site": None,
+        "discovered_at": "2026-07-31T12:00:00+00:00",
+    }
+
+    def fake_tailor(candidate: dict, *_args, **_kwargs) -> dict:
+        return {
+            "url": candidate["url"],
+            "title": candidate["title"],
+            "site": candidate.get("site"),
+            "status": "exhausted_retries",
+            "attempts": 4,
+            "error": "No parseable candidate",
+        }
+
+    monkeypatch.setattr(tailor_module, "get_connection", lambda: conn)
+    monkeypatch.setattr(tailor_module, "get_jobs_by_stage", lambda **_kwargs: [job])
+    monkeypatch.setattr(
+        tailor_module.db_module,
+        "effective_tailoring_min_score",
+        lambda score: score,
+    )
+    monkeypatch.setattr(tailor_module, "TAILORED_DIR", tmp_path / "tailored")
+    monkeypatch.setattr(tailor_module, "_build_pdf_renderer", lambda: object())
+    monkeypatch.setattr(tailor_module, "_tailor_one_job", fake_tailor)
+
+    first = tailor_module.run_tailoring(
+        snapshot=SimpleNamespace(),
+        tenant_id=LOCAL_TENANT,
+        llm_model=None,
+    )
+    assert first["failed"] == 1
+    assert first["errors"] == 0
+    assert first["exhausted"] == 0
+    assert tuple(
+        conn.execute(
+            "SELECT state, attempt_count, retryable FROM job_stage_states "
+            "WHERE tenant_id = ? AND job_id = ? AND stage = 'tailor'",
+            (str(LOCAL_TENANT), str(job_id)),
+        ).fetchone()
+    ) == ("failed", 1, 1)
+
+    conn.execute(
+        "UPDATE job_stage_states SET state = 'failed', attempt_count = 4, retryable = 1 "
+        "WHERE tenant_id = ? AND job_id = ? AND stage = 'tailor'",
+        (str(LOCAL_TENANT), str(job_id)),
+    )
+    conn.commit()
+    fifth = tailor_module.run_tailoring(
+        snapshot=SimpleNamespace(),
+        tenant_id=LOCAL_TENANT,
+        llm_model=None,
+    )
+    assert fifth["failed"] == 1
+    assert fifth["errors"] == 0
+    assert fifth["exhausted"] == 1
+    assert tuple(
+        conn.execute(
+            "SELECT state, attempt_count, retryable FROM job_stage_states "
+            "WHERE tenant_id = ? AND job_id = ? AND stage = 'tailor'",
+            (str(LOCAL_TENANT), str(job_id)),
+        ).fetchone()
+    ) == ("exhausted", 5, 0)
 
 
 def test_tailor_job_by_id_rejects_deleted_and_url_shaped_targets_before_generation(

--- a/workers/automation/tests/test_workflow_job_pipeline.py
+++ b/workers/automation/tests/test_workflow_job_pipeline.py
@@ -7,9 +7,11 @@ the underlying stage runners stubbed so the test stays fast and hermetic.
 from __future__ import annotations
 
 import asyncio
+import threading
 import uuid
 from datetime import timedelta
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -28,11 +30,19 @@ from jobctrl.discovery.activities import (
     PlanDiscoverySourcesOutput,
 )
 from jobctrl.discovery.workflow import DiscoverWorkflow
-from jobctrl.enrichment.activities import enrich_activity
+from jobctrl.enrichment.activities import (
+    cancel_enrichment_cohort_activity,
+    enrich_activity,
+)
+from jobctrl.database import get_connection
 from jobctrl.domain.identifiers import JobId
 from jobctrl.infrastructure.temporal.finalize import (
     record_workflow_outcome,
     record_workflow_started,
+)
+from jobctrl.infrastructure.preparation_recovery import (
+    assert_material_activity_commit_allowed,
+    cancel_preparation_state_activity,
 )
 from jobctrl.materials.activities import (
     cover_activity,
@@ -41,8 +51,12 @@ from jobctrl.materials.activities import (
 from jobctrl.pipeline.workflow import (
     _COVER_RETRY,
     _ENRICH_RETRY,
+    _MAX_SELECTED_BATCH_TIMEOUT,
+    _SELECTED_BATCH_TIMEOUT_PATCH,
     _SCORE_RETRY,
     _TAILOR_RETRY,
+    _activity_timeout,
+    _selected_batch_timeout,
     JobPipelineWorkflow,
     JobPipelineWorkflowInput,
 )
@@ -52,6 +66,69 @@ from jobctrl.workflow_specs import (
     build_pipeline_workflow_spec,
     build_run_stage_workflow_spec,
 )
+from jobctrl.state import ensure_job_stage_rows, set_stage_state
+
+
+def test_selected_batch_timeout_scales_by_worker_waves_and_is_capped() -> None:
+    job_ids = tuple(
+        JobId(f"20000000-0000-4000-8000-{index:012d}") for index in range(20)
+    )
+
+    assert _selected_batch_timeout(
+        JobPipelineWorkflowInput(
+            tenant_id="local",
+            stages=["tailor"],
+            job_ids=job_ids[:9],
+            workers=4,
+        )
+    ) == timedelta(minutes=90)
+    assert _selected_batch_timeout(
+        JobPipelineWorkflowInput(
+            tenant_id="local",
+            stages=["tailor"],
+            job_ids=job_ids[:1],
+            workers=4,
+        )
+    ) == timedelta(minutes=30)
+    assert _selected_batch_timeout(
+        JobPipelineWorkflowInput(
+            tenant_id="local",
+            stages=["tailor"],
+            job_ids=job_ids,
+            workers=1,
+        )
+    ) == _MAX_SELECTED_BATCH_TIMEOUT
+
+    selected_payload = JobPipelineWorkflowInput(
+        tenant_id="local",
+        stages=["tailor"],
+        job_ids=job_ids[:9],
+        workers=4,
+    )
+    with patch(
+        "jobctrl.pipeline.workflow.workflow.patched",
+        side_effect=AssertionError("single-item batches do not need a patch marker"),
+    ):
+        assert _activity_timeout(
+            JobPipelineWorkflowInput(
+                tenant_id="local",
+                stages=["tailor"],
+                job_ids=job_ids[:1],
+                workers=4,
+            )
+        ) == timedelta(minutes=30)
+    with patch(
+        "jobctrl.pipeline.workflow.workflow.patched",
+        return_value=False,
+    ) as patched:
+        assert _activity_timeout(selected_payload) == timedelta(minutes=30)
+        patched.assert_called_once_with(_SELECTED_BATCH_TIMEOUT_PATCH)
+    with patch(
+        "jobctrl.pipeline.workflow.workflow.patched",
+        return_value=True,
+    ) as patched:
+        assert _activity_timeout(selected_payload) == timedelta(minutes=90)
+        patched.assert_called_once_with(_SELECTED_BATCH_TIMEOUT_PATCH)
 
 
 @pytest.fixture(autouse=True)
@@ -91,6 +168,7 @@ def _all_activities():
         _discovery_enrichment,
         _discovery_preparation_fanout,
         enrich_activity,
+        cancel_enrichment_cohort_activity,
         score_activity,
         tailor_activity,
         cover_activity,
@@ -98,6 +176,7 @@ def _all_activities():
         record_workflow_started,
         record_workflow_outcome,
         _recover_preparation_state,
+        cancel_preparation_state_activity,
     ]
 
 
@@ -165,6 +244,69 @@ async def test_pipeline_workflow_runs_requested_stages_in_order():
 
     invoked_stages = [call.args[0] for call in observed_mock.call_args_list]
     assert invoked_stages == ["enrich", "score"]
+
+
+@pytest.mark.asyncio
+async def test_selected_pipeline_scores_only_canonically_enriched_subset():
+    """Blocked/failed Enrich rows never poison the downstream Score batch."""
+
+    queue = f"pipeline-enrich-subset-{uuid.uuid4()}"
+    selected = tuple(JobId(str(uuid.uuid4())) for _ in range(3))
+    enriched = (selected[0], selected[2])
+    score_calls: list[JobId] = []
+
+    def fake_selected_enrichment(_payload, **_kwargs):
+        return {
+            "status": "partial",
+            "elapsed": 0.01,
+            "errors": {},
+            "stages": [
+                {
+                    "stage": "enrich",
+                    "status": "partial",
+                    "selected": len(selected),
+                    "enrichedJobIds": [str(job_id) for job_id in enriched],
+                }
+            ],
+        }
+
+    def fake_score_job_by_id(job_id: JobId, **_kwargs):
+        score_calls.append(job_id)
+        return SimpleNamespace(ok=True, error=None)
+
+    with (
+        patch(
+            "jobctrl.enrichment.activities._run_selected_enrichment",
+            side_effect=fake_selected_enrichment,
+        ),
+        patch(
+            "jobctrl.scoring.scorer.score_job_by_id",
+            side_effect=fake_score_job_by_id,
+        ),
+    ):
+        async with await WorkflowEnvironment.start_time_skipping() as env:
+            async with Worker(
+                env.client,
+                task_queue=queue,
+                workflows=[JobPipelineWorkflow, DiscoverWorkflow],
+                activities=_all_activities(),
+                workflow_runner=UnsandboxedWorkflowRunner(),
+            ):
+                result = await env.client.execute_workflow(
+                    JobPipelineWorkflow.run,
+                    JobPipelineWorkflowInput(
+                        tenant_id="local",
+                        stages=["enrich", "score"],
+                        job_ids=selected,
+                        workers=1,
+                    ),
+                    id=f"pipeline-enrich-subset-wf-{uuid.uuid4()}",
+                    task_queue=queue,
+                )
+
+    assert result.stages_completed == ["enrich", "score"]
+    assert result.stages_failed == []
+    assert score_calls == list(enriched)
 
 
 @pytest.mark.asyncio
@@ -333,9 +475,7 @@ def test_pipeline_apply_spec_boundaries_reject_present_unsupported_or_empty_sele
     selector: dict[str, object],
 ) -> None:
     with pytest.raises(ValueError, match="apply (accepts|jobId)"):
-        build_run_stage_workflow_spec(
-            {"tenantId": "local", "stage": "apply", **selector}
-        )
+        build_run_stage_workflow_spec({"tenantId": "local", "stage": "apply", **selector})
     with pytest.raises(ValueError, match="apply (accepts|jobId)"):
         build_pipeline_workflow_spec(
             {"tenantId": "local", **selector},
@@ -362,12 +502,8 @@ def test_pipeline_apply_spec_boundaries_preserve_batch_and_canonical_target() ->
 
 def test_condition_recovery_run_stage_uses_a_stable_reusable_workflow_id() -> None:
     reason = "condition_resolved:authenticated_linkedin_browser_unavailable"
-    first = build_run_stage_workflow_spec(
-        {"tenantId": "local", "stage": "enrich", "reason": reason}
-    )
-    replay = build_run_stage_workflow_spec(
-        {"tenantId": "local", "stage": "enrich", "reason": reason}
-    )
+    first = build_run_stage_workflow_spec({"tenantId": "local", "stage": "enrich", "reason": reason})
+    replay = build_run_stage_workflow_spec({"tenantId": "local", "stage": "enrich", "reason": reason})
 
     assert first.workflow_id == replay.workflow_id
     assert first.workflow_id is not None
@@ -376,12 +512,8 @@ def test_condition_recovery_run_stage_uses_a_stable_reusable_workflow_id() -> No
 
 
 def test_profile_continuation_uses_exactly_once_durable_event_identity() -> None:
-    first = build_run_stage_workflow_spec(
-        {"tenantId": "local", "stage": "score", "reason": "profile_updated:42"}
-    )
-    replay = build_run_stage_workflow_spec(
-        {"tenantId": "local", "stage": "score", "reason": "profile_updated:42"}
-    )
+    first = build_run_stage_workflow_spec({"tenantId": "local", "stage": "score", "reason": "profile_updated:42"})
+    replay = build_run_stage_workflow_spec({"tenantId": "local", "stage": "score", "reason": "profile_updated:42"})
 
     assert first.workflow_id == replay.workflow_id
     assert first.workflow_id is not None
@@ -622,7 +754,10 @@ async def test_current_policy_tailor_continuation_covers_only_approved_jobs():
         # dummy), so stub the finalize writer — the finalize wiring itself is
         # covered by test_workflow_finalize.py.
         patch("jobctrl.infrastructure.temporal.finalize._emit"),
-        patch("jobctrl.pipeline.current_policy_selectors.tailoring_current_policy_job_ids", side_effect=fake_current_policy_job_ids),
+        patch(
+            "jobctrl.pipeline.current_policy_selectors.tailoring_current_policy_job_ids",
+            side_effect=fake_current_policy_job_ids,
+        ),
         patch("jobctrl.scoring.tailor.tailor_job_by_id", side_effect=fake_tailor_job_by_id),
         patch("jobctrl.scoring.cover_letter.cover_letter_by_id", side_effect=fake_cover_letter_by_id),
     ):
@@ -651,6 +786,50 @@ async def test_current_policy_tailor_continuation_covers_only_approved_jobs():
     assert result.stages_failed == []
     assert tailored_job_ids == [selected_job_id]
     assert cover_job_ids == [selected_job_id]
+
+
+@pytest.mark.asyncio
+async def test_selected_tailor_partial_continues_cover_for_approved_subset():
+    queue = f"pipeline-tailor-partial-{uuid.uuid4()}"
+    approved_job_id = JobId("10000000-0000-4000-8000-000000000011")
+    failed_job_id = JobId("10000000-0000-4000-8000-000000000012")
+    cover_job_ids: list[JobId] = []
+
+    def fake_tailor_job_by_id(job_id: JobId, **_kwargs):
+        if job_id == approved_job_id:
+            return {"status": "approved"}
+        return {"status": "error", "error": "validation exhausted"}
+
+    def fake_cover_letter_by_id(job_id: JobId, **_kwargs):
+        cover_job_ids.append(job_id)
+        return {"status": "ok", "generated": 1, "errors": 0, "elapsed": 0.01}
+
+    with (
+        patch("jobctrl.scoring.tailor.tailor_job_by_id", side_effect=fake_tailor_job_by_id),
+        patch("jobctrl.scoring.cover_letter.cover_letter_by_id", side_effect=fake_cover_letter_by_id),
+    ):
+        async with await WorkflowEnvironment.start_time_skipping() as env:
+            async with Worker(
+                env.client,
+                task_queue=queue,
+                workflows=[JobPipelineWorkflow, DiscoverWorkflow],
+                activities=_all_activities(),
+                workflow_runner=UnsandboxedWorkflowRunner(),
+            ):
+                result = await env.client.execute_workflow(
+                    JobPipelineWorkflow.run,
+                    JobPipelineWorkflowInput(
+                        tenant_id="local",
+                        stages=["tailor", "cover"],
+                        job_ids=(approved_job_id, failed_job_id),
+                    ),
+                    id=f"pipeline-tailor-partial-wf-{uuid.uuid4()}",
+                    task_queue=queue,
+                )
+
+    assert result.stages_completed == ["tailor", "cover"]
+    assert result.stages_failed == []
+    assert cover_job_ids == [approved_job_id]
 
 
 @pytest.mark.asyncio
@@ -763,3 +942,340 @@ async def test_workflow_cancel_propagates_to_activity_as_cancelled_error():
     # The workflow surfaces the cancellation as CancelledError.
     assert isinstance(exc_info.value.cause, CancelledError)
     assert _cancel_observed is True
+
+
+@pytest.mark.asyncio
+async def test_pipeline_enrich_cancel_terminalizes_exact_selected_cohort():
+    """A real pipeline cancel cannot leave its selected Enrich rows pending."""
+
+    from jobctrl.domain.errors import TransientNetworkError
+
+    conn = get_connection()
+    selected = tuple(JobId(str(uuid.uuid4())) for _ in range(2))
+    unrelated = JobId(str(uuid.uuid4()))
+    discovered_at = "2026-08-05T00:00:00+00:00"
+    for index, job_id in enumerate((*selected, unrelated)):
+        url = f"https://example.test/cancel-cohort/{job_id}"
+        conn.execute(
+            "INSERT INTO jobs (tenant_id, job_id, url, title, site, discovered_at) "
+            "VALUES ('local', ?, ?, 'Engineer', ?, ?)",
+            (
+                str(job_id),
+                url,
+                "RemoteOK" if index != 1 else "Job Bank Canada",
+                discovered_at,
+            ),
+        )
+        conn.execute(
+            "INSERT INTO job_locators (tenant_id, job_id, locator_kind, locator_value, "
+            "is_current, first_seen_at, last_seen_at) "
+            "VALUES ('local', ?, 'posting_url', ?, 1, ?, ?)",
+            (str(job_id), url, discovered_at, discovered_at),
+        )
+        ensure_job_stage_rows(conn, job_id)
+    conn.commit()
+
+    started = threading.Event()
+
+    def blocking_batch(
+        _conn,
+        _site,
+        _jobs,
+        *,
+        cancel_event=None,
+        **_kwargs,
+    ):
+        started.set()
+        assert cancel_event is not None
+        assert cancel_event.wait(timeout=15)
+        raise TransientNetworkError("enrichment canceled")
+
+    queue = f"pipeline-enrich-cancel-{uuid.uuid4()}"
+    workflow_id = f"pipeline-enrich-cancel-wf-{uuid.uuid4()}"
+    with patch("jobctrl.enrichment.detail.scrape_site_batch", side_effect=blocking_batch):
+        async with await WorkflowEnvironment.start_time_skipping() as env:
+            async with Worker(
+                env.client,
+                task_queue=queue,
+                workflows=[JobPipelineWorkflow, DiscoverWorkflow],
+                activities=_all_activities(),
+                workflow_runner=UnsandboxedWorkflowRunner(),
+            ):
+                handle = await env.client.start_workflow(
+                    JobPipelineWorkflow.run,
+                    JobPipelineWorkflowInput(
+                        tenant_id="local",
+                        stages=["enrich"],
+                        job_ids=selected,
+                        workers=2,
+                    ),
+                    id=workflow_id,
+                    task_queue=queue,
+                )
+                observed = await asyncio.wait_for(
+                    asyncio.to_thread(started.wait, 10),
+                    timeout=12,
+                )
+                assert observed is True
+                await handle.cancel()
+                with pytest.raises(WorkflowFailureError) as exc_info:
+                    await handle.result()
+
+    assert isinstance(exc_info.value.cause, CancelledError)
+    states = {
+        str(row[0]): str(row[1])
+        for row in conn.execute(
+            "SELECT job_id, state FROM job_stage_states "
+            "WHERE tenant_id = 'local' AND stage = 'enrich' "
+            "AND job_id IN (?, ?, ?)",
+            (str(selected[0]), str(selected[1]), str(unrelated)),
+        ).fetchall()
+    }
+    assert states[str(selected[0])] == "canceled"
+    assert states[str(selected[1])] == "canceled"
+    assert states[str(unrelated)] == "pending"
+
+
+@pytest.mark.parametrize(
+    ("stage", "runner_patch"),
+    (
+        ("tailor", "jobctrl.scoring.tailor.tailor_job_by_id"),
+        ("cover", "jobctrl.scoring.cover_letter.cover_letter_by_id"),
+    ),
+)
+@pytest.mark.asyncio
+async def test_pipeline_material_cancel_stops_fanout_and_fences_late_writes(
+    stage: str,
+    runner_patch: str,
+):
+    """Real workflow cancellation closes the exact cohort without late writes."""
+
+    conn = get_connection()
+    selected = tuple(JobId(str(uuid.uuid4())) for _ in range(4))
+    discovered_at = "2026-08-06T00:00:00+00:00"
+    for job_id in selected:
+        conn.execute(
+            "INSERT INTO jobs (tenant_id, job_id, url, title, site, discovered_at) "
+            "VALUES ('local', ?, ?, 'Engineer', 'synthetic', ?)",
+            (
+                str(job_id),
+                f"https://example.test/material-cancel/{stage}/{job_id}",
+                discovered_at,
+            ),
+        )
+        ensure_job_stage_rows(conn, job_id)
+    conn.commit()
+
+    first_wave_started = threading.Event()
+    first_wave_fenced = threading.Event()
+    started: list[str] = []
+    fenced: list[str] = []
+    late_writes: list[str] = []
+    lock = threading.Lock()
+
+    def blocking_material_job(job_id: JobId, **kwargs):
+        cancel_event = kwargs.get("cancel_event")
+        workflow_id = str(kwargs.get("workflow_id") or "")
+        assert cancel_event is not None
+        assert workflow_id
+        thread_conn = get_connection()
+        set_stage_state(
+            thread_conn,
+            job_id,
+            stage,
+            "running",
+            metadata={"activityOwner": workflow_id},
+            validate_transition=False,
+        )
+        thread_conn.commit()
+        with lock:
+            started.append(str(job_id))
+            if len(started) == 2:
+                first_wave_started.set()
+        assert cancel_event.wait(timeout=15)
+        try:
+            assert_material_activity_commit_allowed(
+                thread_conn,
+                tenant_id="local",
+                job_id=str(job_id),
+                stage=stage,
+                workflow_id=workflow_id,
+                cancel_event=cancel_event,
+            )
+        except RuntimeError:
+            with lock:
+                fenced.append(str(job_id))
+                if len(fenced) == 2:
+                    first_wave_fenced.set()
+            raise
+        late_writes.append(str(job_id))
+        thread_conn.execute(
+            "INSERT INTO job_events "
+            "(tenant_id, job_id, stage, event_type, occurred_at, payload_json) "
+            "VALUES ('local', ?, ?, 'ForbiddenLateMaterialCommit', ?, '{}')",
+            (str(job_id), stage, discovered_at),
+        )
+        thread_conn.commit()
+        return {"status": "approved" if stage == "tailor" else "ok"}
+
+    queue = f"pipeline-{stage}-cancel-{uuid.uuid4()}"
+    workflow_id = f"pipeline-{stage}-cancel-wf-{uuid.uuid4()}"
+    with patch(runner_patch, side_effect=blocking_material_job):
+        async with await WorkflowEnvironment.start_time_skipping() as env:
+            async with Worker(
+                env.client,
+                task_queue=queue,
+                workflows=[JobPipelineWorkflow, DiscoverWorkflow],
+                activities=_all_activities(),
+                workflow_runner=UnsandboxedWorkflowRunner(),
+            ):
+                handle = await env.client.start_workflow(
+                    JobPipelineWorkflow.run,
+                    JobPipelineWorkflowInput(
+                        tenant_id="local",
+                        stages=[stage],
+                        job_ids=selected,
+                        workers=2,
+                    ),
+                    id=workflow_id,
+                    task_queue=queue,
+                )
+                observed = await asyncio.wait_for(
+                    asyncio.to_thread(first_wave_started.wait, 10),
+                    timeout=12,
+                )
+                assert observed is True
+                await handle.cancel()
+                with pytest.raises(WorkflowFailureError) as exc_info:
+                    await handle.result()
+
+    assert isinstance(exc_info.value.cause, CancelledError)
+    assert first_wave_fenced.wait(timeout=5)
+    assert len(started) == 2
+    assert set(started) == {str(selected[0]), str(selected[1])}
+    assert sorted(fenced) == sorted(started)
+    assert late_writes == []
+    rows = conn.execute(
+        "SELECT job_id, state FROM job_stage_states "
+        "WHERE tenant_id = 'local' AND stage = ? AND job_id IN (?, ?, ?, ?)",
+        (stage, *(str(job_id) for job_id in selected)),
+    ).fetchall()
+    assert {str(row["job_id"]): str(row["state"]) for row in rows} == {
+        str(job_id): "canceled" for job_id in selected
+    }
+    assert conn.execute(
+        "SELECT COUNT(*) FROM job_events "
+        "WHERE tenant_id = 'local' AND event_type = 'ForbiddenLateMaterialCommit' "
+        "AND job_id IN (?, ?, ?, ?)",
+        tuple(str(job_id) for job_id in selected),
+    ).fetchone()[0] == 0
+    assert conn.execute(
+        "SELECT COUNT(*) FROM job_materials WHERE tenant_id = 'local' "
+        "AND job_id IN (?, ?, ?, ?)",
+        tuple(str(job_id) for job_id in selected),
+    ).fetchone()[0] == 0
+
+
+@pytest.mark.asyncio
+async def test_pipeline_enrich_timeout_retries_without_false_cancellation():
+    """An activity timeout releases its cohort; only user cancel terminalizes it."""
+
+    from jobctrl.domain.errors import TransientNetworkError
+    from jobctrl.infrastructure.temporal.run_in_activity import (
+        run_blocking_with_heartbeat as production_run_blocking,
+    )
+
+    conn = get_connection()
+    job_id = JobId(str(uuid.uuid4()))
+    discovered_at = "2026-08-06T00:00:00+00:00"
+    url = f"https://example.test/timeout-cohort/{job_id}"
+    conn.execute(
+        "INSERT INTO jobs (tenant_id, job_id, url, title, site, discovered_at) "
+        "VALUES ('local', ?, ?, 'Engineer', 'RemoteOK', ?)",
+        (str(job_id), url, discovered_at),
+    )
+    conn.execute(
+        "INSERT INTO job_locators (tenant_id, job_id, locator_kind, locator_value, "
+        "is_current, first_seen_at, last_seen_at) "
+        "VALUES ('local', ?, 'posting_url', ?, 1, ?, ?)",
+        (str(job_id), url, discovered_at, discovered_at),
+    )
+    ensure_job_stage_rows(conn, job_id)
+    conn.commit()
+
+    calls = 0
+
+    def timeout_once(
+        _conn,
+        _site,
+        _jobs,
+        *,
+        cancel_event=None,
+        **_kwargs,
+    ):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            assert cancel_event is not None
+            assert cancel_event.wait(timeout=10)
+            raise TransientNetworkError("attempt interrupted")
+        return {
+            "processed": 0,
+            "ok": 0,
+            "partial": 0,
+            "error": 0,
+            "blocked": 0,
+            "tiers": {1: 0, 2: 0, 3: 0},
+        }
+
+    async def fast_heartbeat(fn, **kwargs):
+        kwargs["poll_interval"] = 0.05
+        kwargs["cancel_wait_seconds"] = 1.0
+        return await production_run_blocking(fn, **kwargs)
+
+    queue = f"pipeline-enrich-timeout-{uuid.uuid4()}"
+    workflow_id = f"pipeline-enrich-timeout-wf-{uuid.uuid4()}"
+    with (
+        patch("jobctrl.enrichment.detail.scrape_site_batch", side_effect=timeout_once),
+        patch(
+            "jobctrl.infrastructure.temporal.run_in_activity.run_blocking_with_heartbeat",
+            side_effect=fast_heartbeat,
+        ),
+        patch(
+            "jobctrl.pipeline.workflow._DEFAULT_TIMEOUT",
+            timedelta(seconds=1),
+        ),
+    ):
+        async with await WorkflowEnvironment.start_time_skipping() as env:
+            async with Worker(
+                env.client,
+                task_queue=queue,
+                workflows=[JobPipelineWorkflow, DiscoverWorkflow],
+                activities=_all_activities(),
+                workflow_runner=UnsandboxedWorkflowRunner(),
+            ):
+                result = await env.client.execute_workflow(
+                    JobPipelineWorkflow.run,
+                    JobPipelineWorkflowInput(
+                        tenant_id="local",
+                        stages=["enrich"],
+                        job_ids=(job_id,),
+                    ),
+                    id=workflow_id,
+                    task_queue=queue,
+                )
+
+    row = conn.execute(
+        "SELECT state FROM job_stage_states WHERE tenant_id = 'local' AND job_id = ? AND stage = 'enrich'",
+        (str(job_id),),
+    ).fetchone()
+    canceled_events = conn.execute(
+        "SELECT COUNT(*) FROM job_events WHERE tenant_id = 'local' "
+        "AND job_id = ? AND stage = 'enrich' AND event_type = 'StageCanceled'",
+        (str(job_id),),
+    ).fetchone()[0]
+    assert result.stages_completed == ["enrich"]
+    assert result.stages_failed == []
+    assert calls == 2
+    assert row is not None and str(row[0]) == "pending"
+    assert canceled_events == 0

--- a/workers/automation/tests/test_workflow_job_pipeline.py
+++ b/workers/automation/tests/test_workflow_job_pipeline.py
@@ -12,7 +12,7 @@ import uuid
 from datetime import timedelta
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from temporalio import activity, workflow
@@ -56,6 +56,8 @@ from jobctrl.pipeline.workflow import (
     _SCORE_RETRY,
     _TAILOR_RETRY,
     _activity_timeout,
+    _cancel_material_stage_state,
+    _cancel_owned_enrichment,
     _selected_batch_timeout,
     JobPipelineWorkflow,
     JobPipelineWorkflowInput,
@@ -159,6 +161,72 @@ def test_stage_retry_policies_are_stage_specific():
     assert _COVER_RETRY.initial_interval == timedelta(seconds=10)
     assert _TAILOR_RETRY.maximum_interval == timedelta(seconds=120)
     assert _COVER_RETRY.maximum_interval == timedelta(seconds=120)
+
+
+@pytest.mark.asyncio
+async def test_cancel_owned_enrichment_is_patch_gated_for_replay_safety() -> None:
+    """A cancellation recorded pre-patch must not schedule the cancel activity on replay."""
+
+    payload = JobPipelineWorkflowInput(
+        tenant_id="local",
+        stages=["enrich"],
+        job_ids=(JobId("20000000-0000-4000-8000-000000000001"),),
+        workers=1,
+    )
+    with (
+        patch(
+            "jobctrl.pipeline.workflow.workflow.patched", return_value=False
+        ) as patched,
+        patch(
+            "jobctrl.pipeline.workflow.workflow.execute_activity",
+            side_effect=AssertionError(
+                "unpatched replay must not schedule cancel_enrichment_cohort"
+            ),
+        ),
+    ):
+        await _cancel_owned_enrichment(payload)
+    patched.assert_called_once_with("pipeline-enrich-cancellation-v1")
+
+    with (
+        patch("jobctrl.pipeline.workflow.workflow.patched", return_value=True),
+        patch(
+            "jobctrl.pipeline.workflow.workflow.info",
+            return_value=SimpleNamespace(workflow_id="wf-cancel", run_id="run-cancel"),
+        ),
+        patch(
+            "jobctrl.pipeline.workflow.workflow.execute_activity",
+            new=AsyncMock(),
+        ) as execute_activity,
+    ):
+        await _cancel_owned_enrichment(payload)
+    assert execute_activity.await_count == 1
+    assert execute_activity.call_args.kwargs["retry_policy"].maximum_attempts == 5
+
+
+@pytest.mark.asyncio
+async def test_pipeline_material_cancel_activity_retries_are_bounded() -> None:
+    """A persistently failing cancel-cohort activity must not hang cancellation."""
+
+    payload = JobPipelineWorkflowInput(
+        tenant_id="local",
+        stages=["tailor"],
+        job_ids=(JobId("20000000-0000-4000-8000-000000000002"),),
+        workers=1,
+    )
+    with (
+        patch("jobctrl.pipeline.workflow.workflow.patched", return_value=True),
+        patch(
+            "jobctrl.pipeline.workflow.workflow.info",
+            return_value=SimpleNamespace(run_id="run-cancel"),
+        ),
+        patch(
+            "jobctrl.pipeline.workflow.workflow.execute_activity",
+            new=AsyncMock(),
+        ) as execute_activity,
+    ):
+        await _cancel_material_stage_state("tailor", payload)
+    assert execute_activity.await_count == 1
+    assert execute_activity.call_args.kwargs["retry_policy"].maximum_attempts == 5
 
 
 def _all_activities():

--- a/workers/automation/tests/test_workflow_job_preparation.py
+++ b/workers/automation/tests/test_workflow_job_preparation.py
@@ -98,6 +98,40 @@ async def test_preparation_workflow_treats_already_done_step_as_complete(
 
 
 @pytest.mark.asyncio
+async def test_preparation_material_cancel_activity_retries_are_bounded(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A persistently failing cancel-cohort activity must not hang cancellation."""
+
+    captured: dict[str, object] = {}
+
+    async def fake_execute_activity(_activity_fn, _payload, **kwargs):
+        captured.update(kwargs)
+
+    monkeypatch.setattr(prep_workflow_mod.workflow, "patched", lambda _patch_id: True)
+    monkeypatch.setattr(
+        prep_workflow_mod.workflow,
+        "info",
+        lambda: SimpleNamespace(run_id="run-cancel"),
+    )
+    monkeypatch.setattr(prep_workflow_mod.workflow, "execute_activity", fake_execute_activity)
+
+    await prep_workflow_mod._cancel_material_stage_state(
+        "tailor",
+        JobPreparationInput(
+            tenant_id="local",
+            job_id=_JOB_ID,
+            steps=["tailor"],
+            target_version="1",
+            idempotency_key="preparation:cancel-bound",
+        ),
+    )
+
+    retry_policy = captured["retry_policy"]
+    assert retry_policy.maximum_attempts == 5
+
+
+@pytest.mark.asyncio
 async def test_preparation_workflow_stops_dependents_when_tailor_is_skipped(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/workers/automation/tests/test_workflow_job_preparation.py
+++ b/workers/automation/tests/test_workflow_job_preparation.py
@@ -479,11 +479,11 @@ async def test_preparation_workflow_resumes_at_cover_after_worker_restart(
         calls.append("score")
         return {"status": "ok", "score_version": 1}
 
-    def fake_tailor_job(_payload) -> dict[str, object]:
+    def fake_tailor_job(_payload, **_kwargs) -> dict[str, object]:
         calls.append("tailor")
         return {"status": "approved", "materials": SimpleNamespace(generation=1)}
 
-    def fake_cover_letter(_payload) -> dict[str, object]:
+    def fake_cover_letter(_payload, **_kwargs) -> dict[str, object]:
         nonlocal cover_attempts
         cover_attempts += 1
         calls.append("cover")
@@ -746,7 +746,7 @@ async def test_preparation_workflow_retries_transient_tailor_failure(
     async def record_outcome(_payload) -> None:
         return None
 
-    def fake_tailor_job(_payload) -> dict[str, object]:
+    def fake_tailor_job(_payload, **_kwargs) -> dict[str, object]:
         nonlocal attempts
         attempts += 1
         if attempts == 1:


### PR DESCRIPTION
## Summary

- separate inner generation retries from the durable Tailor attempt budget and terminalize the fifth durable failure as non-retryable exhaustion
- expose batch exhaustion to the Temporal boundary so a partially failed batch cannot be reported as successful
- preserve accepted materials and their audit history while retries, recovery, and replacement generation run
- use canonical JobId ownership and bounded material execution across worker restart and redelivery

## Why

Material generation could repeat an impossible repair, lose retry ownership across restarts, or hide exhaustion behind a retryable batch result. This phase owns the complete Tailor retry contract; the preceding Enrichment PR no longer carries partial consumers or tests from this layer.

## Validation

- P1b error inversion, production Tailor runtime, and pipeline workflow suites — 80 passed
- direct regressions cover inner retry exhaustion, fifth durable-attempt exhaustion, no re-entry after exhaustion, batch exhaustion count, non-retryable Temporal mapping, and preserved prior artifacts
- focused Ruff and `git diff --check` — passed
- synchronized tree is byte-identical to previously green head `b53ac7f91`; only ancestry changed to include the corrected #751 base
- prior hosted Python 3.11/3.12/3.13, TypeScript, docs, and release checks passed; cumulative stack head #763 remains green

## Checklist

- [ ] External contributor commits include a DCO `Signed-off-by:` trailer (`git commit -s`).
- [x] I ran the relevant local checks and listed them above.
- [x] I did not include secrets, private profile data, resumes, generated application materials, raw logs, browser profiles, SQLite databases, or local paths.
