### PR TITLE
fix(scoring): bind fit reports to current posting analysis

### DIFF
--- a/workers/automation/src/jobctrl/scoring/employer_analysis.py
+++ b/workers/automation/src/jobctrl/scoring/employer_analysis.py
@@ -20,14 +20,26 @@ from jobctrl.state import record_job_event
 class EmployerAnalyzedEventRecorder:
     """Persist ``EmployerAnalyzed`` domain events into ``job_events``."""
 
-    def __init__(self, conn: sqlite3.Connection, *, stage: str) -> None:
+    def __init__(
+        self,
+        conn: sqlite3.Connection,
+        *,
+        stage: str,
+        record_cached_hits: bool = True,
+    ) -> None:
         self._conn = conn
         self._stage = stage
+        self._record_cached_hits = record_cached_hits
 
     def publish(self, event) -> None:  # noqa: ANN001 -- DomainEvent (duck-typed)
         if getattr(event, "event_type", None) != "EmployerAnalyzed":
             return
         payload = dict(getattr(event, "payload", {}) or {})
+        if not self._record_cached_hits and bool(payload.get("cached")):
+            # A cache hit re-confirms an already-recorded generation; recording
+            # it again would append a duplicate timeline row on every pass that
+            # resolves the analysis (score retries, rescore batches, ...).
+            return
         raw_job_id = str(payload.get("job_id") or "")
         if not raw_job_id:
             return
@@ -54,8 +66,15 @@ def build_analyze_use_case(
     conn: sqlite3.Connection,
     publisher: EventPublisher | None = None,
     event_stage: str,
+    record_cached_hits: bool = True,
 ):
-    """Construct the canonical employer-analysis use case for local mode."""
+    """Construct the canonical employer-analysis use case for local mode.
+
+    ``record_cached_hits=False`` keeps the default ``job_events`` recorder from
+    appending a timeline row for cache hits — callers that resolve the analysis
+    on every pass (the score stage) opt out so retries and rescore batches do
+    not duplicate the "Employer analysis generation N" row.
+    """
 
     from jobctrl.domain.materials.analyze_use_case import AnalyzeJobUseCase
     from jobctrl.infrastructure.analysis import (
@@ -111,7 +130,8 @@ def build_analyze_use_case(
         repository=SqliteEmployerAnalysisRepository(conn),
         adapters=tuple(adapters),
         synthesizer=synthesizer,
-        publisher=publisher or EmployerAnalyzedEventRecorder(conn, stage=event_stage),
+        publisher=publisher
+        or EmployerAnalyzedEventRecorder(conn, stage=event_stage, record_cached_hits=record_cached_hits),
         sdk_set_version=analysis_sdk_set_version(
             enabled_legs,
             synthesizer_provider=llm.provider_id,

--- a/workers/automation/src/jobctrl/scoring/scorer.py
+++ b/workers/automation/src/jobctrl/scoring/scorer.py
@@ -184,7 +184,14 @@ def score_job(
         if employer_analysis_repository is None:
             employer_analysis_repository = SqliteEmployerAnalysisRepository(conn)
         if analyze_use_case is None and require_employer_analysis:
-            analyze_use_case = build_analyze_use_case(conn=conn, publisher=publisher, event_stage="score")
+            analyze_use_case = build_analyze_use_case(
+                conn=conn,
+                publisher=publisher,
+                event_stage="score",
+                # Score resolves the analysis before EVERY fresh score; cache
+                # hits must not append duplicate job_events timeline rows.
+                record_cached_hits=False,
+            )
         employer_analysis = _ensure_employer_analysis_for_job(
             repository=employer_analysis_repository,
             analyze_use_case=analyze_use_case,
@@ -250,7 +257,14 @@ def run_scoring(
     if employer_analysis_repository is None:
         employer_analysis_repository = SqliteEmployerAnalysisRepository(conn)
     if analyze_use_case is None and require_employer_analysis:
-        analyze_use_case = build_analyze_use_case(conn=conn, publisher=publisher, event_stage="score")
+        analyze_use_case = build_analyze_use_case(
+            conn=conn,
+            publisher=publisher,
+            event_stage="score",
+            # Score resolves the analysis before EVERY fresh score; cache
+            # hits must not append duplicate job_events timeline rows.
+            record_cached_hits=False,
+        )
 
     use_case = _build_use_case(
         repository=repository,
@@ -763,7 +777,14 @@ def score_job_by_id(
         if employer_analysis_repository is None:
             employer_analysis_repository = SqliteEmployerAnalysisRepository(conn)
         if analyze_use_case is None and require_employer_analysis:
-            analyze_use_case = build_analyze_use_case(conn=conn, publisher=publisher, event_stage="score")
+            analyze_use_case = build_analyze_use_case(
+                conn=conn,
+                publisher=publisher,
+                event_stage="score",
+                # Score resolves the analysis before EVERY fresh score; cache
+                # hits must not append duplicate job_events timeline rows.
+                record_cached_hits=False,
+            )
         employer_analysis = _ensure_employer_analysis_for_job(
             repository=employer_analysis_repository,
             analyze_use_case=analyze_use_case,
@@ -1100,22 +1121,44 @@ def _ensure_employer_analysis_for_job(
     # available.  Loading the latest row directly can return an analysis for an
     # older posting snapshot; scoring against that row creates a requirement-fit
     # report which Tailoring must later discard after it refreshes the analysis.
+    refresh_error: Exception | None = None
     if analyze_use_case is not None:
-        outcome = analyze_use_case.execute(job=job, tenant_id=tenant_id)
-        analysis = getattr(outcome, "analysis", None)
-        if _is_usable_employer_analysis(analysis, job):
-            return analysis
-        raise ValueError("Employer analysis did not match the current grounded job snapshot.")
-    if _is_usable_employer_analysis(existing, job):
-        return existing
-    if repository is not None:
-        loaded = _load_employer_analysis_for_job(
+        try:
+            outcome = analyze_use_case.execute(job=job, tenant_id=tenant_id)
+        except Exception as exc:  # noqa: BLE001 — degrade to a same-snapshot persisted analysis below
+            refresh_error = exc
+        else:
+            analysis = getattr(outcome, "analysis", None)
+            if _is_usable_employer_analysis(analysis, job):
+                return analysis
+            # The use case hashes the same job dict scoring validates against,
+            # so on this branch the snapshot always matches — the only reachable
+            # failure is an analysis without grounded requirements.
+            raise ValueError("Employer analysis did not produce grounded requirements for this job.")
+    # Fallback tier: a persisted analysis is acceptable only when it passes the
+    # same-snapshot usability check — never score against a different posting
+    # snapshot. This keeps scoring available when the ensemble refresh fails
+    # (e.g. provider outage) and an analysis for the CURRENT snapshot exists.
+    fallback = existing if _is_usable_employer_analysis(existing, job) else None
+    if fallback is None and repository is not None:
+        fallback = _load_employer_analysis_for_job(
             repository=repository,
             tenant_id=tenant_id,
             job=job,
         )
-        if loaded is not None:
-            return loaded
+    if fallback is not None:
+        if refresh_error is not None:
+            log.warning(
+                "Employer analysis refresh failed for tenant=%s job=%s; scoring against persisted "
+                "generation %s for the current posting snapshot: %s",
+                tenant_id,
+                job.get("job_id"),
+                fallback.generation,
+                refresh_error,
+            )
+        return fallback
+    if refresh_error is not None:
+        raise refresh_error
     if require:
         raise ValueError("Scoring requires employer analysis before a fresh score can be computed.")
     return None

--- a/workers/automation/src/jobctrl/scoring/scorer.py
+++ b/workers/automation/src/jobctrl/scoring/scorer.py
@@ -35,7 +35,8 @@ from jobctrl.domain.job_content_identity import (
     role_title_has_reference_suffix,
     role_titles_match_as_repost,
 )
-from jobctrl.domain.materials.analysis import EmployerAnalysis
+from jobctrl.domain.materials.analysis import EmployerAnalysis, compute_snapshot_hash
+from jobctrl.domain.materials.analyze_use_case import build_jd_snapshot
 from jobctrl.domain.ports.events import EventPublisher
 from jobctrl.domain.ports.materials import EmployerAnalysisRepository
 from jobctrl.domain.ports.scoring import (
@@ -1094,6 +1095,17 @@ def _ensure_employer_analysis_for_job(
 ) -> EmployerAnalysis | None:
     """Resolve the canonical requirement source before a fresh score attempt."""
 
+    # ``AnalyzeJobUseCase`` owns the complete cache identity: posting snapshot,
+    # prompt version, and enabled SDK/model set.  Always ask it first when it is
+    # available.  Loading the latest row directly can return an analysis for an
+    # older posting snapshot; scoring against that row creates a requirement-fit
+    # report which Tailoring must later discard after it refreshes the analysis.
+    if analyze_use_case is not None:
+        outcome = analyze_use_case.execute(job=job, tenant_id=tenant_id)
+        analysis = getattr(outcome, "analysis", None)
+        if _is_usable_employer_analysis(analysis, job):
+            return analysis
+        raise ValueError("Employer analysis did not match the current grounded job snapshot.")
     if _is_usable_employer_analysis(existing, job):
         return existing
     if repository is not None:
@@ -1104,12 +1116,6 @@ def _ensure_employer_analysis_for_job(
         )
         if loaded is not None:
             return loaded
-    if analyze_use_case is not None:
-        outcome = analyze_use_case.execute(job=job, tenant_id=tenant_id)
-        analysis = getattr(outcome, "analysis", None)
-        if _is_usable_employer_analysis(analysis, job):
-            return analysis
-        raise ValueError("Employer analysis did not produce grounded requirements for this job.")
     if require:
         raise ValueError("Scoring requires employer analysis before a fresh score can be computed.")
     return None
@@ -1128,6 +1134,16 @@ def _is_usable_employer_analysis(
             "Ignoring employer analysis for tenant=%s job=%s while scoring tenant=%s job=%s",
             analysis.tenant_id,
             analysis.job_id,
+            tenant_id,
+            job_id,
+        )
+        return False
+    expected_snapshot_hash = compute_snapshot_hash(build_jd_snapshot(job))
+    if analysis.snapshot_hash != expected_snapshot_hash:
+        log.info(
+            "Ignoring employer analysis generation %s for tenant=%s job=%s because its "
+            "posting snapshot is stale",
+            analysis.generation,
             tenant_id,
             job_id,
         )

--- a/workers/automation/tests/test_scorer.py
+++ b/workers/automation/tests/test_scorer.py
@@ -115,12 +115,21 @@ class _CriteriaProvider:
 
 
 class _AnalyzeUseCase:
-    def __init__(self) -> None:
+    def __init__(self, *, generation: int = 1) -> None:
         self.calls: list[dict] = []
+        self.generation = generation
 
     def execute(self, *, job: dict, tenant_id=LOCAL_TENANT, force: bool = False):
         self.calls.append({"job": job, "tenant_id": tenant_id, "force": force})
-        return SimpleNamespace(analysis=_employer_analysis(str(job["url"])))
+        return SimpleNamespace(
+            analysis=_employer_analysis(
+                str(job["url"]),
+                job_id=JobId(str(job["job_id"])),
+                title=str(job.get("title") or ""),
+                description=str(job.get("full_description") or job.get("description") or ""),
+                generation=self.generation,
+            )
+        )
 
 
 class _FailingAnalyzeUseCase:
@@ -188,7 +197,14 @@ def _seed_pending_job(conn: sqlite3.Connection, url: str) -> None:
     conn.commit()
 
 
-def _employer_analysis(job_url: str) -> EmployerAnalysis:
+def _employer_analysis(
+    job_url: str,
+    *,
+    job_id: JobId | None = None,
+    title: str = "Engineer",
+    description: str = "Need Python.",
+    generation: int = 1,
+) -> EmployerAnalysis:
     canonical = JobAnalysis(
         role_framing="Platform ownership.",
         inferred_seniority="senior",
@@ -212,9 +228,9 @@ def _employer_analysis(job_url: str) -> EmployerAnalysis:
     )
     return EmployerAnalysis.build(
         tenant_id=LOCAL_TENANT,
-        job_id=_job_id(job_url),
-        generation=1,
-        snapshot_hash=compute_snapshot_hash("Need Python."),
+        job_id=job_id or _job_id(job_url),
+        generation=generation,
+        snapshot_hash=compute_snapshot_hash(f"{title.strip()}\n\n{description.strip()}"),
         canonical=canonical,
         sub_analyses=(),
         failures=(),
@@ -815,6 +831,60 @@ def test_run_scoring_loads_persisted_employer_analysis_into_prompt(
     assert report.score_version == 1
     assert report.employer_analysis_generation == 1
     assert report.assessments[0].fit.kind == "missing"
+
+
+def test_run_scoring_refreshes_stale_posting_analysis_before_persisting_fit_report(
+    conn: sqlite3.Connection,
+    profile_snapshot,
+    monkeypatch,
+) -> None:
+    url = "https://example.com/job/analysis-snapshot-refreshed"
+    _seed_pending_job(conn, url)
+    SqliteEmployerAnalysisRepository(conn).save(
+        _employer_analysis(url, description="Need Python. Previous posting snapshot.")
+    )
+    analyze = _AnalyzeUseCase(generation=2)
+    llm = _ScriptedLlm(
+        {
+            "score": 8,
+            "technical_fit": 8,
+            "experience_fit": 7,
+            "role_fit": 8,
+            "fit_band": "strong",
+            "confidence": "high",
+            "eligibility": {"status": "eligible", "hard_blockers": [], "warnings": []},
+            "matched_signals": ["Python"],
+            "missing_signals": [],
+            "transferable_signals": [],
+            "keywords": ["python"],
+            "reasoning": "ok",
+            "requirement_assessments": [
+                {
+                    "requirement_id": "req-python-platform",
+                    "requirement_text": "Own Python platform reliability.",
+                    "tier": "must_have",
+                    "weight": 0.9,
+                    "job_evidence_span": "Need Python.",
+                    "fit": {"kind": "matched", "evidence_ids": ["platform"]},
+                }
+            ],
+        }
+    )
+    monkeypatch.setattr(scorer_module, "get_connection", lambda: conn)
+
+    summary = scorer_module.run_scoring(
+        profile_snapshot=profile_snapshot,
+        repository=SqliteScoreRepository(conn),
+        llm_port=llm,
+        resume_text="Engineer with Python.",
+        analyze_use_case=analyze,
+    )
+
+    assert summary["errors"] == 0
+    assert len(analyze.calls) == 1
+    report = SqliteRequirementFitReportRepository(conn).load(LOCAL_TENANT, _job_id(url))
+    assert report is not None
+    assert report.employer_analysis_generation == 2
 
 
 def test_run_scoring_generates_employer_analysis_before_prompt(

--- a/workers/automation/tests/test_scorer.py
+++ b/workers/automation/tests/test_scorer.py
@@ -153,7 +153,7 @@ def _stub_default_analyzer(monkeypatch) -> None:
     monkeypatch.setattr(
         scorer_module,
         "build_analyze_use_case",
-        lambda *, conn, publisher=None, event_stage: _AnalyzeUseCase(),
+        lambda *, conn, publisher=None, event_stage, record_cached_hits=True: _AnalyzeUseCase(),
     )
 
 
@@ -782,9 +782,20 @@ def test_run_scoring_loads_persisted_employer_analysis_into_prompt(
     profile_snapshot,
     monkeypatch,
 ) -> None:
+    """The repository fallback's success path (``_load_employer_analysis_for_job``).
+
+    With ``require_employer_analysis=False`` and no analyze use case, scoring
+    must read the persisted analysis row — the guard patch below fails the test
+    if a reordering routes this scenario through a built analyzer instead.
+    """
     url = "https://example.com/job/analysis-loaded"
     _seed_pending_job(conn, url)
     SqliteEmployerAnalysisRepository(conn).save(_employer_analysis(url))
+    monkeypatch.setattr(
+        scorer_module,
+        "build_analyze_use_case",
+        lambda **_kwargs: pytest.fail("must not build an analyzer when require_employer_analysis=False"),
+    )
     repo = SqliteScoreRepository(conn)
     llm = _ScriptedLlm(
         {
@@ -819,6 +830,7 @@ def test_run_scoring_loads_persisted_employer_analysis_into_prompt(
         repository=repo,
         llm_port=llm,
         resume_text="Engineer with Python.",
+        require_employer_analysis=False,
     )
 
     assert summary["errors"] == 0
@@ -831,6 +843,142 @@ def test_run_scoring_loads_persisted_employer_analysis_into_prompt(
     assert report.score_version == 1
     assert report.employer_analysis_generation == 1
     assert report.assessments[0].fit.kind == "missing"
+
+
+def test_run_scoring_falls_back_to_persisted_analysis_when_refresh_fails(
+    conn: sqlite3.Connection,
+    profile_snapshot,
+    monkeypatch,
+) -> None:
+    """An ensemble outage must not fail the stage when a persisted analysis
+    for the CURRENT posting snapshot exists — scoring degrades to that row."""
+    url = "https://example.com/job/analysis-refresh-outage"
+    _seed_pending_job(conn, url)
+    SqliteEmployerAnalysisRepository(conn).save(_employer_analysis(url))
+    analyze = _FailingAnalyzeUseCase(RuntimeError("provider outage"))
+    llm = _ScriptedLlm(
+        {
+            "score": 8,
+            "technical_fit": 8,
+            "experience_fit": 7,
+            "role_fit": 8,
+            "fit_band": "strong",
+            "confidence": "high",
+            "eligibility": {"status": "eligible", "hard_blockers": [], "warnings": []},
+            "matched_signals": ["Python"],
+            "missing_signals": [],
+            "transferable_signals": [],
+            "keywords": ["python"],
+            "reasoning": "ok",
+            "requirement_assessments": [
+                {
+                    "requirement_id": "req-python-platform",
+                    "requirement_text": "Own Python platform reliability.",
+                    "tier": "must_have",
+                    "weight": 0.9,
+                    "job_evidence_span": "Need Python.",
+                    "fit": {"kind": "missing", "reason": "No profile evidence."},
+                }
+            ],
+        }
+    )
+    monkeypatch.setattr(scorer_module, "get_connection", lambda: conn)
+
+    summary = scorer_module.run_scoring(
+        profile_snapshot=profile_snapshot,
+        repository=SqliteScoreRepository(conn),
+        llm_port=llm,
+        resume_text="Engineer with Python.",
+        analyze_use_case=analyze,
+    )
+
+    assert summary["scored"] == 1
+    assert summary["errors"] == 0
+    assert analyze.calls == 1
+    prompt_payload = llm.messages[0][1].content
+    assert '"id": "req-python-platform"' in prompt_payload
+    report = SqliteRequirementFitReportRepository(conn).load(LOCAL_TENANT, _job_id(url))
+    assert report is not None
+    assert report.employer_analysis_generation == 1
+
+
+def test_run_scoring_fails_when_refresh_fails_and_persisted_analysis_is_stale(
+    conn: sqlite3.Connection,
+    profile_snapshot,
+    monkeypatch,
+) -> None:
+    """The outage fallback must never cross posting snapshots: with only a
+    stale-snapshot row persisted, the refresh failure still fails the stage."""
+    url = "https://example.com/job/analysis-refresh-outage-stale"
+    _seed_pending_job(conn, url)
+    SqliteEmployerAnalysisRepository(conn).save(
+        _employer_analysis(url, description="Need Python. Previous posting snapshot.")
+    )
+    analyze = _FailingAnalyzeUseCase(RuntimeError("provider outage"))
+    llm = _ScriptedLlm({"score": 9, "keywords": [], "reasoning": "should not be called"})
+    monkeypatch.setattr(scorer_module, "get_connection", lambda: conn)
+
+    summary = scorer_module.run_scoring(
+        profile_snapshot=profile_snapshot,
+        repository=SqliteScoreRepository(conn),
+        llm_port=llm,
+        resume_text="Engineer with Python.",
+        analyze_use_case=analyze,
+    )
+
+    assert summary["scored"] == 0
+    assert summary["errors"] == 1
+    assert analyze.calls == 1
+    assert llm.calls == 0
+    stage_row = _stage_row(conn, url, "score")
+    assert stage_row["state"] == "failed"
+    assert "provider outage" in stage_row["error_message"]
+
+
+def test_run_scoring_builds_score_stage_analyzer_without_cached_event_rows(
+    conn: sqlite3.Connection,
+    profile_snapshot,
+    monkeypatch,
+) -> None:
+    """The score stage resolves the analysis on every pass, so its default
+    recorder must opt out of cache-hit rows (no duplicate timeline entries)."""
+    url = "https://example.com/job/analysis-cached-event-suppressed"
+    _seed_pending_job(conn, url)
+    captured: dict[str, Any] = {}
+
+    def _capture_build(*, conn, publisher=None, event_stage, record_cached_hits=True):
+        captured["event_stage"] = event_stage
+        captured["record_cached_hits"] = record_cached_hits
+        return _AnalyzeUseCase()
+
+    monkeypatch.setattr(scorer_module, "build_analyze_use_case", _capture_build)
+    llm = _ScriptedLlm(
+        {
+            "score": 8,
+            "technical_fit": 8,
+            "experience_fit": 7,
+            "role_fit": 8,
+            "fit_band": "strong",
+            "confidence": "high",
+            "eligibility": {"status": "eligible", "hard_blockers": [], "warnings": []},
+            "matched_signals": ["Python"],
+            "missing_signals": [],
+            "transferable_signals": [],
+            "keywords": ["python"],
+            "reasoning": "ok",
+        }
+    )
+    monkeypatch.setattr(scorer_module, "get_connection", lambda: conn)
+
+    summary = scorer_module.run_scoring(
+        profile_snapshot=profile_snapshot,
+        repository=SqliteScoreRepository(conn),
+        llm_port=llm,
+        resume_text="Engineer with Python.",
+    )
+
+    assert summary["errors"] == 0
+    assert captured == {"event_stage": "score", "record_cached_hits": False}
 
 
 def test_run_scoring_refreshes_stale_posting_analysis_before_persisting_fit_report(

--- a/workers/automation/tests/test_v7_score_runtime.py
+++ b/workers/automation/tests/test_v7_score_runtime.py
@@ -374,3 +374,47 @@ def test_employer_analysis_event_preserves_tenant_and_job_id(
         "score",
         "EmployerAnalyzed",
     )
+
+
+def _employer_analyzed_event(*, cached: bool):
+    return create_employer_analyzed(
+        _TENANT_B,
+        EmployerAnalyzedPayload(
+            job_id=str(_JOB_ID_B),
+            generation=2,
+            snapshot_hash="snapshot",
+            cache_key="cache-key",
+            legs_attempted=3,
+            legs_succeeded=2,
+            analyzed_at="2026-07-30T10:00:00+00:00",
+            cached=cached,
+        ),
+    )
+
+
+def test_employer_analysis_recorder_skips_cache_hits_when_opted_out(
+    conn: sqlite3.Connection,
+) -> None:
+    """``record_cached_hits=False`` records fresh analyses but never cache
+    hits — the score stage resolves the analysis on every pass and must not
+    duplicate the timeline row per retry/rescore."""
+    recorder = EmployerAnalyzedEventRecorder(conn, stage="score", record_cached_hits=False)
+
+    recorder.publish(_employer_analyzed_event(cached=True))
+    count = conn.execute("SELECT COUNT(*) FROM job_events WHERE event_type = 'EmployerAnalyzed'").fetchone()
+    assert count[0] == 0
+
+    recorder.publish(_employer_analyzed_event(cached=False))
+    recorder.publish(_employer_analyzed_event(cached=True))
+    count = conn.execute("SELECT COUNT(*) FROM job_events WHERE event_type = 'EmployerAnalyzed'").fetchone()
+    assert count[0] == 1
+
+
+def test_employer_analysis_recorder_records_cache_hits_by_default(
+    conn: sqlite3.Connection,
+) -> None:
+    """The default recorder (tailor path) keeps recording cache hits."""
+    EmployerAnalyzedEventRecorder(conn, stage="tailor").publish(_employer_analyzed_event(cached=True))
+
+    count = conn.execute("SELECT COUNT(*) FROM job_events WHERE event_type = 'EmployerAnalyzed'").fetchone()
+    assert count[0] == 1


### PR DESCRIPTION
## Summary

- resolve employer analysis through its cache-owning use case before every fresh score
- reject analyses whose posting snapshot hash no longer matches the current job
- persist requirement-fit reports against the refreshed analysis generation
- fall back to a persisted analysis for the current posting snapshot when the fresh ensemble refresh fails, instead of failing the score stage
- suppress duplicate cache-hit `EmployerAnalyzed` timeline rows on the score stage (tailor path unchanged)

## Why

Scoring could reuse the latest persisted employer analysis even after the posting changed. Tailoring then refreshed the analysis independently and received a requirement-fit report from the previous generation, producing an incoherent coverage plan.

Because the analyze use case owns the full cache identity (posting snapshot + `PROMPT_VERSION` + SDK-set version), resolving through it means a prompt or enabled-leg change intentionally invalidates cached analyses at score time: the next scoring/rescore pass re-runs the 3-SDK ensemble once per selected job (a one-time cost/latency hit after such an upgrade). When that refresh fails (e.g. provider outage), scoring degrades to a persisted analysis for the SAME posting snapshot rather than failing the stage; it still never scores against a different snapshot.

## Validation

- `uv --project workers/automation run --extra dev python -m pytest workers/automation/tests/test_scorer.py workers/automation/tests/test_v7_score_runtime.py -q` — 30 passed
- adjacent suites (`test_analyze_job_use_case`, `test_score_use_cases`, `test_activity_score`, `test_score_activity_recovery`, `test_employer_analysis_leg_config`, `test_v7_tailor_runtime`) — 81 passed
- focused Ruff checks — passed
- `git diff --check` — passed

## Checklist

- [ ] External contributor commits include a DCO `Signed-off-by:` trailer (`git commit -s`).
- [x] I ran the relevant local checks and listed them above.
- [x] I did not include secrets, private profile data, resumes, generated application materials, raw logs, browser profiles, SQLite databases, or local paths.
