### PR TITLE
fix(materials): restore requirement-led tailoring

### DIFF
--- a/docs/architecture/tailoring.md
+++ b/docs/architecture/tailoring.md
@@ -64,7 +64,9 @@ mapping:
 - generated_claim_mappings that link each generated claim to coverage edges,
   requirement IDs, evidence IDs, or a non-requirement reason such as pinned or
   positioning content; exactly one bound mapping is required for every summary
-  sentence, generated experience bullet, and complete rendered skill group
+  sentence, generated experience bullet, and complete rendered skill group;
+  executive_profile is valid only for a one-sentence summary, while multi-sentence
+  summaries use executive_profile.sentence[N] for every sentence
 ```
 
 The target job and employer analysis decide what to emphasize. The existing

--- a/docs/architecture/tailoring.md
+++ b/docs/architecture/tailoring.md
@@ -63,7 +63,8 @@ mapping:
 - skill_category_updates for existing profile skill category IDs
 - generated_claim_mappings that link each generated claim to coverage edges,
   requirement IDs, evidence IDs, or a non-requirement reason such as pinned or
-  positioning content
+  positioning content; exactly one bound mapping is required for every summary
+  sentence, generated experience bullet, and complete rendered skill group
 ```
 
 The target job and employer analysis decide what to emphasize. The existing
@@ -200,12 +201,12 @@ The generator must return JSON matching `TAILORED_RESUME_RESPONSE_SCHEMA`:
 
 ```json
 {
-  "executive_profile": "2-4 sentences tailored to the target role.",
+  "executive_profile": "Grounded executive profile.",
   "experience_updates": [
     {
       "id": "existing_profile_experience_id",
       "title": "",
-      "bullets": ["bullet 1", "bullet 2"]
+      "bullets": ["Generated bullet text."]
     }
   ],
   "skill_category_updates": [
@@ -216,6 +217,17 @@ The generator must return JSON matching `TAILORED_RESUME_RESPONSE_SCHEMA`:
   ],
   "generated_claim_mappings": [
     {
+      "claim_id": "claim_summary_1",
+      "location": "executive_profile.sentence[0]",
+      "text": "Grounded executive profile.",
+      "claim_label": "positioning",
+      "coverage_edge_ids": [],
+      "requirement_ids": [],
+      "evidence_ids": [],
+      "non_requirement_reason": "positioning",
+      "review_required": false
+    },
+    {
       "claim_id": "claim_1",
       "location": "experience.existing_profile_experience_id.bullets[0]",
       "text": "Generated bullet text.",
@@ -223,7 +235,18 @@ The generator must return JSON matching `TAILORED_RESUME_RESPONSE_SCHEMA`:
       "coverage_edge_ids": ["edge_req_1_ev_1_direct"],
       "requirement_ids": ["req_1"],
       "evidence_ids": ["ev_1"],
-      "non_requirement_reason": "",
+      "non_requirement_reason": "positioning",
+      "review_required": false
+    },
+    {
+      "claim_id": "claim_skills_1",
+      "location": "skills.existing_profile_skill_category_id",
+      "text": "existing skill 1, existing skill 2",
+      "claim_label": "structure",
+      "coverage_edge_ids": [],
+      "requirement_ids": [],
+      "evidence_ids": [],
+      "non_requirement_reason": "structure",
       "review_required": false
     }
   ]
@@ -232,7 +255,9 @@ The generator must return JSON matching `TAILORED_RESUME_RESPONSE_SCHEMA`:
 
 The model cannot return contact info, education rows, new sections, comments,
 warnings, or PDFs. The claim map is a sidecar audit contract; code still owns
-assembly, provenance rows, final artifact metadata, and read models.
+assembly, provenance rows, final artifact metadata, and read models. Mapping
+locations are range-checked, complete rendered skill groups bind by exact text,
+and the schema-valid raw response is retained unchanged in attempt audit.
 
 ## What "Profile-Row Based" Means
 

--- a/docs/architecture/tailoring.md
+++ b/docs/architecture/tailoring.md
@@ -112,7 +112,7 @@ Tailoring combines several inputs. Each input has a different authority.
 | Writing style | Profile writing preferences | Tone, bullet standards, verbosity, advisory keyword emphasis, first-person preference |
 | Target job | Job record | The target role, description, responsibilities, skills, and company context |
 | Employer analysis | `EmployerAnalysis` aggregate | Grounded role framing, inferred seniority, requirements, and reasoned keywords |
-| Requirement fit report | Scoring context, when available | Pre-tailoring fit by requirement, allowed evidence IDs, target keywords, prohibited claims, tailoring directives |
+| Requirement fit report | Scoring context | Pre-tailoring fit by requirement, allowed evidence IDs, target keywords, prohibited claims, tailoring directives; its employer-analysis generation must match the current posting analysis |
 | Requirement-led coverage graph | Deterministic target-profile adapter plus constrained planner | Which profile achievements can cover which target requirements, which requirements are uncovered, which achievements are unused, and what claim policy each edge requires |
 | Previous attempt outcome | Tailoring retry loop | Typed, code-owned retry reason only; free-form validator, judge, adversarial, and prior-output text remains audit data |
 
@@ -678,6 +678,13 @@ durable attempt, and recorded time, so a later retry or a rerun of the same
 durable attempt cannot overwrite earlier prompts, candidates, validation, or
 judge evidence. A fifth failed durable execution is
 stored as non-retryable `exhausted` until an explicit attempt reset.
+
+Tailoring does not silently discard a missing, cross-job, or stale-generation
+requirement-fit report. That condition blocks Tailor on Score before candidate
+generation, preserves the durable Tailor attempt count, records both generation
+identities, and asks for a fresh score. Scoring resolves employer analysis
+through its complete cache identity first, so the replacement fit report and
+the Tailoring coverage graph describe the same posting snapshot.
 
 ## How To Change Tailoring Safely
 

--- a/docs/architecture/tailoring.md
+++ b/docs/architecture/tailoring.md
@@ -59,14 +59,17 @@ profile evidence, allowed skills, verified metrics, and the quality plan.
 Rewrite only these mutable resume fields and return JSON plus generated claim
 mapping:
 - executive_profile
+- executive_profile_sentences (ordered explicit sentence boundaries whose
+  one-space join exactly equals executive_profile)
 - experience_updates for existing profile experience IDs
 - skill_category_updates for existing profile skill category IDs
 - generated_claim_mappings that link each generated claim to coverage edges,
   requirement IDs, evidence IDs, or a non-requirement reason such as pinned or
   positioning content; exactly one bound mapping is required for every summary
   sentence, generated experience bullet, and complete rendered skill group;
-  executive_profile is valid only for a one-sentence summary, while multi-sentence
-  summaries use executive_profile.sentence[N] for every sentence
+  executive_profile is valid only when executive_profile_sentences contains one
+  item, while multi-sentence summaries use executive_profile.sentence[N] for every
+  explicit item
 ```
 
 The target job and employer analysis decide what to emphasize. The existing
@@ -204,6 +207,7 @@ The generator must return JSON matching `TAILORED_RESUME_RESPONSE_SCHEMA`:
 ```json
 {
   "executive_profile": "Grounded executive profile.",
+  "executive_profile_sentences": ["Grounded executive profile."],
   "experience_updates": [
     {
       "id": "existing_profile_experience_id",

--- a/docs/developer/qa/regression-catalog.md
+++ b/docs/developer/qa/regression-catalog.md
@@ -84,6 +84,14 @@ attempt reset. Repeated durable executions of one materials generation must
 append audit entries keyed by execution and durable attempt rather than replace
 the prior prompt/candidate/validator/judge record.
 
+The Score-to-Tailor evidence handoff is one generation-bound contract. Change a
+posting after an earlier employer analysis, then prove Score refreshes through
+the analysis cache owner and writes fit evidence for the refreshed generation.
+Tailor must never turn a missing or mismatched fit report into a zero-edge plan:
+it blocks on Score without spending a durable attempt. The claim-mapping fixture
+also covers sentence-level summary aliases, exact rendered skill-group text,
+and mandatory coverage-edge evidence before any judge call.
+
 The [complete matrix](complete-checklist.md#temporal-fault-injection-matrix)
 lists the exact tests for Discover, Pipeline, Preparation, Apply, Profile Import,
 Compensation Refresh, and Interview Prep workflows.

--- a/docs/developer/qa/regression-catalog.md
+++ b/docs/developer/qa/regression-catalog.md
@@ -90,7 +90,8 @@ the analysis cache owner and writes fit evidence for the refreshed generation.
 Tailor must never turn a missing or mismatched fit report into a zero-edge plan:
 it blocks on Score without spending a durable attempt. The claim-mapping fixture
 also covers sentence-level summary aliases, exact rendered skill-group text,
-and mandatory coverage-edge evidence before any judge call.
+mandatory coverage-edge evidence, missing or duplicate generated surfaces, and
+immutable raw audit payloads before any judge call.
 
 The [complete matrix](complete-checklist.md#temporal-fault-injection-matrix)
 lists the exact tests for Discover, Pipeline, Preparation, Apply, Profile Import,

--- a/docs/developer/qa/regression-catalog.md
+++ b/docs/developer/qa/regression-catalog.md
@@ -89,9 +89,10 @@ posting after an earlier employer analysis, then prove Score refreshes through
 the analysis cache owner and writes fit evidence for the refreshed generation.
 Tailor must never turn a missing or mismatched fit report into a zero-edge plan:
 it blocks on Score without spending a durable attempt. The claim-mapping fixture
-also covers sentence-level summary aliases, exact rendered skill-group text,
-mandatory coverage-edge evidence, missing or duplicate generated surfaces, and
-immutable raw audit payloads before any judge call.
+also covers explicit ordered summary-sentence identity and reconstruction,
+sentence-level aliases, exact rendered bullet and skill-group text, mandatory
+coverage-edge evidence, missing or duplicate generated surfaces, and immutable
+raw audit payloads before any judge call.
 
 The [complete matrix](complete-checklist.md#temporal-fault-injection-matrix)
 lists the exact tests for Discover, Pipeline, Preparation, Apply, Profile Import,

--- a/docs/local-reliability-qa.md
+++ b/docs/local-reliability-qa.md
@@ -138,6 +138,14 @@ non-retryable `exhausted`, and a later pickup cannot restart it without an
 explicit attempt reset. Run at least two durable failures against the same
 materials generation and assert that both complete inner-attempt reports remain
 in the append-only audit history.
+Change the enriched posting snapshot after an employer analysis exists, then
+run Score and Tailor. Score must resolve the current analysis cache identity and
+persist a requirement-fit report for that exact generation. A deliberately
+missing or generation-mismatched report must block Tailor on Score before an LLM
+candidate call, preserve the Tailor attempt count, and emit an auditable
+`StageBlocked`. With coherent inputs, sentence-level executive-profile mapping
+locations must bind to the rendered summary and skill-group mappings must use
+the exact rendered item sequence.
 The focused deterministic gate is:
 
 ```bash

--- a/docs/user/materials-and-tailoring.md
+++ b/docs/user/materials-and-tailoring.md
@@ -136,7 +136,7 @@ The inputs have intentionally different authority:
 | --- | --- | --- |
 | Candidate facts and achievements | Candidate Profile snapshot | Experience, skills, metrics, dates, titles, employers, and other claims about you. |
 | Job requirements and employer wording | Enrichment snapshot plus canonical employer analysis | What the employer asks for and which language appears in the posting. It is target context, never candidate evidence. |
-| Requirement fit | Scoring | Which requirements are matched, transferable, missing, or blocked, with allowed evidence links. |
+| Requirement fit | Scoring | Which requirements are matched, transferable, missing, or blocked, with allowed evidence links. It must describe the same posting-analysis generation Tailoring uses. |
 | Tailoring and model policy | Preferences, Settings, and versioned Materials policy | What transformations and gates may run. Policy cannot create a fact. |
 | Accepted output | Materials generation and registered artifacts | The exact text/HTML/PDF selected for review or Apply, plus its audit data. |
 
@@ -145,6 +145,12 @@ canonical profile evidence. Keyword coverage is computed from the actual
 rendered, grounded text and persisted with the generation. The artifact read
 model does not infer a missing list from the job description later, and it
 reports absent audit data as unrecorded rather than as zero coverage.
+
+If requirement-fit evidence is missing or belongs to an older posting-analysis
+generation, JobCtrl shows Tailor as blocked by Score and asks you to rescore the
+job. This prerequisite block does not consume a Tailor retry. It prevents an
+empty coverage plan from being retried as though it were a model-quality
+failure.
 
 Generated files stay under the local JobCtrl workspace and are served only
 through registered artifact rows. An artifact route cannot open an arbitrary

--- a/packages/domain-types/test/fixtures/audit_projection_parity.json
+++ b/packages/domain-types/test/fixtures/audit_projection_parity.json
@@ -209,7 +209,7 @@
         "position": 0,
         "created_at": "2026-06-08T12:10:00+00:00",
         "coverage_json": "{\"computed_against\": \"rendered_text\", \"planned\": [\"developer platform\", \"kafka\"], \"covered\": [\"developer platform\"], \"declared\": [], \"missing\": [\"kafka\"], \"covered_by\": {\"developer platform\": \"experience:acme#0\"}, \"declared_by\": {}, \"counts\": {\"planned\": 2, \"covered\": 1, \"declared\": 0, \"missing\": 1}}",
-        "voice_json": "{\"ran\": true, \"accepted\": true, \"model\": \"claude-opus-4-8\", \"prompt_version\": \"voice-pass-v1\", \"proxy_delta\": {\"improved\": true}, \"reason\": \"\"}"
+        "voice_json": "{\"ran\": true, \"accepted\": true, \"model\": \"claude-opus-4-8\", \"prompt_version\": \"voice-pass-v1\", \"proxy_delta\": {\"improved\": true}, \"reason\": \"\", \"summary_rejection_reason\": \"\"}"
       },
       {
         "generation": 2,
@@ -227,7 +227,7 @@
         "position": 1,
         "created_at": "2026-06-08T12:10:00+00:00",
         "coverage_json": "{\"computed_against\": \"rendered_text\", \"planned\": [\"developer platform\", \"kafka\"], \"covered\": [\"developer platform\"], \"declared\": [], \"missing\": [\"kafka\"], \"covered_by\": {\"developer platform\": \"experience:acme#0\"}, \"declared_by\": {}, \"counts\": {\"planned\": 2, \"covered\": 1, \"declared\": 0, \"missing\": 1}}",
-        "voice_json": "{\"ran\": true, \"accepted\": true, \"model\": \"claude-opus-4-8\", \"prompt_version\": \"voice-pass-v1\", \"proxy_delta\": {\"improved\": true}, \"reason\": \"\"}"
+        "voice_json": "{\"ran\": true, \"accepted\": true, \"model\": \"claude-opus-4-8\", \"prompt_version\": \"voice-pass-v1\", \"proxy_delta\": {\"improved\": true}, \"reason\": \"\", \"summary_rejection_reason\": \"\"}"
       }
     ],
     "jobInterviewPrep": [
@@ -1279,7 +1279,8 @@
       "proxy_delta": {
         "improved": true
       },
-      "reason": ""
+      "reason": "",
+      "summary_rejection_reason": ""
     }
   },
   "locationCases": [

--- a/workers/automation/src/jobctrl/domain/materials/claim_grounding.py
+++ b/workers/automation/src/jobctrl/domain/materials/claim_grounding.py
@@ -44,14 +44,22 @@ from jobctrl.domain.materials.services import sanitize_text
 
 GROUNDED_COVERAGE_BASIS = "grounded_shipped_text_v1"
 
+# Ids may contain dots ("node.js", "acme.co"); the trailing component shapes
+# (".bullets[N]", ".items[N]") are unambiguous, so backtracking splits correctly.
 _EXPERIENCE_LOCATION_RE = re.compile(
-    r"^(?:experience|experience_updates)\.(?P<entry_id>[^.\[\]]+)\.bullets\[(?P<index>\d+)\]$"
+    r"^(?:experience|experience_updates)\.(?P<entry_id>[^\[\]]+)\.bullets\[(?P<index>\d+)\]$"
 )
 _SKILLS_LOCATION_RE = re.compile(
-    r"^(?:skills|skill_categories|skill_category_updates)\.(?P<category_id>[^.\[\]]+)"
+    r"^(?:skills|skill_categories|skill_category_updates)\.(?P<category_id>[^\[\]]+)"
     r"(?:\.items\[\d+\])?$"
 )
 _SUMMARY_LOCATIONS = frozenset({"executive_profile", "summary", "resume.executive_profile"})
+# Mirrors the sentence-indexed alias spellings the payload-surface validator
+# canonicalises (``_canonical_claim_location``): "executive_profile.sentence[N]"
+# plus the "summary"/"profile."-prefixed and bare-index variants.
+_SUMMARY_SENTENCE_LOCATION_RE = re.compile(
+    r"^(?:(?:profile\.)?(?:executive_profile|summary))(?:\.sentences?)?\[\d+\]$"
+)
 
 
 @dataclass(frozen=True)
@@ -147,10 +155,12 @@ def bullet_id_for_claim_location(location: str) -> str | None:
     Mirrors the alias forms accepted by the payload-surface validator
     (``_generated_claim_surfaces``) and the bullet ids minted by
     ``build_bullet_provenance``. Skill item locations map to the category line —
-    provenance audits skills one row per rendered category.
+    provenance audits skills one row per rendered category — and summary
+    sentence locations (``executive_profile.sentence[N]`` and its aliases) map
+    to the single shipped executive-profile line.
     """
     canonical = re.sub(r"\.bullet\[(\d+)\]$", r".bullets[\1]", str(location or "").strip())
-    if canonical in _SUMMARY_LOCATIONS:
+    if canonical in _SUMMARY_LOCATIONS or _SUMMARY_SENTENCE_LOCATION_RE.match(canonical):
         return "executive_profile#0"
     match = _EXPERIENCE_LOCATION_RE.match(canonical)
     if match:

--- a/workers/automation/src/jobctrl/domain/materials/quality.py
+++ b/workers/automation/src/jobctrl/domain/materials/quality.py
@@ -469,6 +469,42 @@ class TailoringChangeAnnotation:
         }
 
 
+class TailoringPrerequisiteError(ValueError):
+    """Tailoring inputs are not bound to one coherent scoring generation."""
+
+    def __init__(
+        self,
+        *,
+        reason: str,
+        job_id: str,
+        analysis_generation: int,
+        report_generation: int | None = None,
+    ) -> None:
+        self.reason = reason
+        self.job_id = job_id
+        self.analysis_generation = analysis_generation
+        self.report_generation = report_generation
+        if reason == "requirement_fit_missing":
+            detail = "no requirement-fit report exists"
+        elif reason == "requirement_fit_job_mismatch":
+            detail = "the requirement-fit report belongs to a different job"
+        else:
+            detail = (
+                "requirement-fit generation "
+                f"{report_generation} does not match employer-analysis generation "
+                f"{analysis_generation}"
+            )
+        super().__init__(
+            f"Tailoring requires a fresh score for job {job_id}: {detail}."
+        )
+
+    @property
+    def error_code(self) -> str:
+        if self.reason == "requirement_fit_missing":
+            return "REQUIREMENT_FIT_MISSING"
+        return "REQUIREMENT_FIT_STALE"
+
+
 def build_tailoring_plan(
     profile: dict,
     job: dict,
@@ -499,11 +535,27 @@ def build_tailoring_plan(
         *tuple(_evidence_item(item) for item in get_achievement_evidence(profile)),
         *_education_evidence_items(profile),
     )
-    matched_requirement_fit_report = (
-        requirement_fit_report
-        if _requirement_fit_report_matches(requirement_fit_report, job, employer_analysis)
-        else None
-    )
+    if requirement_fit_report is not None and not _requirement_fit_report_matches(
+        requirement_fit_report,
+        job,
+        employer_analysis,
+    ):
+        job_id = canonical_job_id(str(job["job_id"]))
+        report_job_id = getattr(requirement_fit_report, "job_id", None)
+        report_generation = int(
+            getattr(requirement_fit_report, "employer_analysis_generation", 0) or 0
+        )
+        raise TailoringPrerequisiteError(
+            reason=(
+                "requirement_fit_job_mismatch"
+                if report_job_id != job_id
+                else "requirement_fit_generation_mismatch"
+            ),
+            job_id=str(job_id),
+            analysis_generation=employer_analysis.generation,
+            report_generation=report_generation,
+        )
+    matched_requirement_fit_report = requirement_fit_report
     requirement_directives = _requirement_directive_items(
         requirement_fit_report=matched_requirement_fit_report,
         job=job,

--- a/workers/automation/src/jobctrl/domain/materials/use_cases.py
+++ b/workers/automation/src/jobctrl/domain/materials/use_cases.py
@@ -563,9 +563,18 @@ def _claim_mapping_binding_errors(
                 "does not exist in the generated payload."
             )
             continue
-        if not _claim_text_is_bound(actual_text, mapping.text):
+        if _skill_group_claim_location(location):
+            text_is_bound = actual_text == mapping.text
+        else:
+            text_is_bound = _claim_text_is_bound(actual_text, mapping.text)
+        if not text_is_bound:
+            relationship = (
+                "does not exactly match"
+                if _skill_group_claim_location(location)
+                else "is not present at"
+            )
             errors.append(
-                f"Generated claim {mapping.claim_id} text is not present at "
+                f"Generated claim {mapping.claim_id} text {relationship} "
                 f"generated payload location {mapping.location!r}."
             )
     return tuple(errors)
@@ -671,6 +680,17 @@ def _canonical_claim_location(location: str) -> str:
     ):
         return "executive_profile"
     return re.sub(r"\.bullet\[(\d+)\]$", r".bullets[\1]", normalized)
+
+
+def _skill_group_claim_location(location: str) -> bool:
+    """Return whether a mapping targets one complete rendered skill group."""
+    return bool(
+        re.fullmatch(
+            r"(?:skills|skill_categories|skill_category_updates)\.[^.\[]+",
+            location,
+        )
+        or re.fullmatch(r"skill_category_updates\[\d+\]", location)
+    )
 
 
 def _claim_text_is_bound(actual_text: str, mapped_text: str) -> bool:

--- a/workers/automation/src/jobctrl/domain/materials/use_cases.py
+++ b/workers/automation/src/jobctrl/domain/materials/use_cases.py
@@ -271,9 +271,10 @@ TAILORED_RESUME_RESPONSE_SCHEMA: dict[str, Any] = {
                     "location": {
                         "type": "string",
                         "description": (
-                            "Use executive_profile or executive_profile.sentence[N] for summary "
-                            "sentences, experience.<id>.bullets[N] for bullets, and skills.<id> "
-                            "for one complete rendered skill group."
+                            "Use executive_profile only for a one-sentence summary; otherwise use "
+                            "executive_profile.sentence[N] for each summary sentence. Use "
+                            "experience.<id>.bullets[N] for bullets and skills.<id> for one "
+                            "complete rendered skill group."
                         ),
                     },
                     "text": {
@@ -730,18 +731,21 @@ def _required_claim_surface_groups(
 
     groups: list[tuple[str, frozenset[str]]] = []
     executive_profile = str(payload.get("executive_profile") or "").strip()
-    for index, _sentence in enumerate(_generated_summary_sentences(executive_profile)):
+    summary_sentences = _generated_summary_sentences(executive_profile)
+    for index, _sentence in enumerate(summary_sentences):
+        locations = {f"executive_profile.sentence[{index}]"}
+        if len(summary_sentences) == 1:
+            locations.update(
+                {
+                    "executive_profile",
+                    "summary",
+                    "resume.executive_profile",
+                }
+            )
         groups.append(
             (
                 f"executive profile sentence {index}",
-                frozenset(
-                    {
-                        "executive_profile",
-                        "summary",
-                        "resume.executive_profile",
-                        f"executive_profile.sentence[{index}]",
-                    }
-                ),
+                frozenset(locations),
             )
         )
 
@@ -1431,7 +1435,8 @@ HARD RULES:
   group, emit a generated_claim_mappings entry that references valid
   coverage_edge_ids, requirement_ids, and evidence_ids; use non_requirement_reason
   only for pinned, positioning, or structure claims
-- A summary sentence location may be executive_profile.sentence[N]; N is zero-based
+- Use executive_profile only when the generated summary has exactly one sentence;
+  otherwise map every sentence with executive_profile.sentence[N], where N is zero-based
 - For a skills.<category-id> mapping, text must be the exact selected items in
   rendered order joined with ", " (comma plus one space), not the category label
 - Every achievement_evidence_id present on any COVERAGE_GRAPH edge must appear

--- a/workers/automation/src/jobctrl/domain/materials/use_cases.py
+++ b/workers/automation/src/jobctrl/domain/materials/use_cases.py
@@ -712,6 +712,10 @@ def _claim_location_requires_exact_text(location: str) -> bool:
     return bool(
         location in {"executive_profile", "summary", "resume.executive_profile"}
         or re.fullmatch(r"executive_profile\.sentence\[\d+\]", location)
+        or re.fullmatch(
+            r"(?:experience|experience_updates)(?:\.[^.\[]+|\[\d+\])\.bullets\[\d+\]",
+            location,
+        )
         or _skill_group_claim_location(location)
     )
 

--- a/workers/automation/src/jobctrl/domain/materials/use_cases.py
+++ b/workers/automation/src/jobctrl/domain/materials/use_cases.py
@@ -176,8 +176,8 @@ from jobctrl.resume_profile import (
 
 log = logging.getLogger(__name__)
 
-TAILORING_PROMPT_VERSION = "tailor.v4.claim-mapping"
-TAILORING_SCHEMA_VERSION = "tailored-resume.v2"
+TAILORING_PROMPT_VERSION = "tailor.v5.explicit-summary-sentences"
+TAILORING_SCHEMA_VERSION = "tailored-resume.v3"
 TAILORING_JUDGE_SCHEMA_VERSION = "tailor-judge.v1"
 TAILORING_JUDGE_CRITERIA: tuple[str, ...] = (
     "relevance_to_job",
@@ -208,12 +208,23 @@ TAILORED_RESUME_RESPONSE_SCHEMA: dict[str, Any] = {
     "additionalProperties": False,
     "required": [
         "executive_profile",
+        "executive_profile_sentences",
         "experience_updates",
         "skill_category_updates",
         "generated_claim_mappings",
     ],
     "properties": {
         "executive_profile": {"type": "string"},
+        "executive_profile_sentences": {
+            "type": "array",
+            "minItems": 1,
+            "maxItems": 4,
+            "description": (
+                "The ordered grammatical sentences that form executive_profile. Joining these "
+                "items with one space must reproduce executive_profile exactly."
+            ),
+            "items": {"type": "string"},
+        },
         "experience_updates": {
             "type": "array",
             "minItems": 1,
@@ -271,10 +282,10 @@ TAILORED_RESUME_RESPONSE_SCHEMA: dict[str, Any] = {
                     "location": {
                         "type": "string",
                         "description": (
-                            "Use executive_profile only for a one-sentence summary; otherwise use "
-                            "executive_profile.sentence[N] for each summary sentence. Use "
-                            "experience.<id>.bullets[N] for bullets and skills.<id> for one "
-                            "complete rendered skill group."
+                            "Use executive_profile only when executive_profile_sentences has one "
+                            "item; otherwise use executive_profile.sentence[N] for each explicit "
+                            "sentence. Use experience.<id>.bullets[N] for bullets and skills.<id> "
+                            "for one complete rendered skill group."
                         ),
                     },
                     "text": {
@@ -554,7 +565,8 @@ def _claim_mapping_binding_errors(
 ) -> tuple[str, ...]:
     surfaces = _generated_claim_surfaces(payload, tailoring_plan=tailoring_plan)
     mappings = tuple(mappings)
-    errors: list[str] = []
+    _summary_sentences, summary_contract_errors = _generated_summary_sentence_contract(payload)
+    errors = list(summary_contract_errors)
     bound_locations: list[str] = []
     for mapping in mappings:
         location = _canonical_claim_location(mapping.location)
@@ -602,7 +614,8 @@ def _generated_claim_surfaces(
     if executive_profile:
         for location in ("executive_profile", "summary", "resume.executive_profile"):
             surfaces[location] = executive_profile
-        for index, sentence in enumerate(_generated_summary_sentences(executive_profile)):
+        summary_sentences, _errors = _generated_summary_sentence_contract(payload)
+        for index, sentence in enumerate(summary_sentences):
             surfaces[f"executive_profile.sentence[{index}]"] = sentence
     updates = payload.get("experience_updates")
     for update_index, update in enumerate(updates if isinstance(updates, list) else ()):
@@ -720,47 +733,34 @@ def _claim_location_requires_exact_text(location: str) -> bool:
     )
 
 
-_SUMMARY_TITLE_ABBREVIATIONS = frozenset({"dr.", "mr.", "mrs.", "ms.", "prof."})
-_SUMMARY_ALWAYS_INLINE_ABBREVIATIONS = frozenset({"e.g.", "i.e."})
-
-
-def _summary_period_is_abbreviation(text: str, boundary_end: int) -> bool:
-    prefix_match = re.search(r"([^\s]+)$", text[:boundary_end])
-    if prefix_match is None:
-        return False
-    token = prefix_match.group(1).strip("()[]{}\"'").lower()
-    continuation = text[boundary_end:].lstrip()
-    if not continuation:
-        return False
-    return bool(
-        token in _SUMMARY_TITLE_ABBREVIATIONS | _SUMMARY_ALWAYS_INLINE_ABBREVIATIONS
-        or re.fullmatch(r"(?:[a-z]\.){2,}", token)
-        or token in {"ph.d.", "u.s.", "u.k."}
-    )
-
-
-def _generated_summary_sentences(text: str) -> tuple[str, ...]:
-    normalized = text.strip()
-    if not normalized:
-        return ()
+def _generated_summary_sentence_contract(
+    payload: dict,
+) -> tuple[tuple[str, ...], tuple[str, ...]]:
+    raw_sentences = payload.get("executive_profile_sentences")
+    if not isinstance(raw_sentences, list):
+        return (), ("executive_profile_sentences must be an ordered array.",)
+    errors: list[str] = []
+    if not 1 <= len(raw_sentences) <= 4:
+        errors.append("executive_profile_sentences must contain between 1 and 4 items.")
     sentences: list[str] = []
-    start = 0
-    for boundary in re.finditer(r"[.!?]+(?:[\"')\]}]+)?(?=\s+|$)", normalized):
-        punctuation = re.match(r"[.!?]+", boundary.group())
-        if (
-            punctuation is not None
-            and punctuation.group().endswith(".")
-            and _summary_period_is_abbreviation(normalized, boundary.end())
-        ):
+    for index, value in enumerate(raw_sentences):
+        if not isinstance(value, str) or not value.strip():
+            errors.append(
+                f"executive_profile_sentences[{index}] must be a non-empty string."
+            )
             continue
-        sentence = normalized[start : boundary.end()].strip()
-        if sentence:
-            sentences.append(sentence)
-        start = boundary.end()
-    remainder = normalized[start:].strip()
-    if remainder:
-        sentences.append(remainder)
-    return tuple(sentences)
+        if value != value.strip():
+            errors.append(
+                f"executive_profile_sentences[{index}] must not contain outer whitespace."
+            )
+        sentences.append(value.strip())
+    executive_profile = str(payload.get("executive_profile") or "").strip()
+    if sentences and " ".join(sentences) != executive_profile:
+        errors.append(
+            "Joining executive_profile_sentences with one space must reproduce "
+            "executive_profile exactly."
+        )
+    return tuple(sentences), tuple(errors)
 
 
 def _required_claim_surface_groups(
@@ -769,8 +769,7 @@ def _required_claim_surface_groups(
     """Return every generated surface that must have exactly one bound mapping."""
 
     groups: list[tuple[str, frozenset[str]]] = []
-    executive_profile = str(payload.get("executive_profile") or "").strip()
-    summary_sentences = _generated_summary_sentences(executive_profile)
+    summary_sentences, _errors = _generated_summary_sentence_contract(payload)
     for index, _sentence in enumerate(summary_sentences):
         locations = {f"executive_profile.sentence[{index}]"}
         if len(summary_sentences) == 1:
@@ -1474,8 +1473,11 @@ HARD RULES:
   group, emit a generated_claim_mappings entry that references valid
   coverage_edge_ids, requirement_ids, and evidence_ids; use non_requirement_reason
   only for pinned, positioning, or structure claims
-- Use executive_profile only when the generated summary has exactly one sentence;
-  otherwise map every sentence with executive_profile.sentence[N], where N is zero-based
+- Return executive_profile_sentences as the ordered 1-4 grammatical sentences
+  that form executive_profile; joining them with one space must reproduce
+  executive_profile exactly
+- Use executive_profile only when executive_profile_sentences has exactly one item;
+  otherwise map every explicit item with executive_profile.sentence[N], where N is zero-based
 - For a skills.<category-id> mapping, text must be the exact selected items in
   rendered order joined with ", " (comma plus one space), not the category label
 - Every achievement_evidence_id present on any COVERAGE_GRAPH edge must appear
@@ -1535,6 +1537,7 @@ REQUIRED BULLETS BY EXPERIENCE ID:
 OUTPUT ONLY VALID JSON:
 {{
   "executive_profile": "2-4 sentences tailored to the target role.",
+  "executive_profile_sentences": ["Sentence 1.", "Sentence 2."],
   "experience_updates": [
     {{"id": "{required_experience_ids[0] if required_experience_ids else 'experience_entry_id'}", "title": "", "bullets": ["bullet 1", "bullet 2"]}}
   ],

--- a/workers/automation/src/jobctrl/domain/materials/use_cases.py
+++ b/workers/automation/src/jobctrl/domain/materials/use_cases.py
@@ -729,13 +729,12 @@ def _summary_period_is_abbreviation(text: str, boundary_end: int) -> bool:
     if prefix_match is None:
         return False
     token = prefix_match.group(1).strip("()[]{}\"'").lower()
-    if token in _SUMMARY_TITLE_ABBREVIATIONS | _SUMMARY_ALWAYS_INLINE_ABBREVIATIONS:
-        return True
     continuation = text[boundary_end:].lstrip()
-    if not continuation or not continuation[0].islower():
+    if not continuation:
         return False
     return bool(
-        re.fullmatch(r"(?:[a-z]\.){2,}", token)
+        token in _SUMMARY_TITLE_ABBREVIATIONS | _SUMMARY_ALWAYS_INLINE_ABBREVIATIONS
+        or re.fullmatch(r"(?:[a-z]\.){2,}", token)
         or token in {"ph.d.", "u.s.", "u.k."}
     )
 
@@ -746,9 +745,12 @@ def _generated_summary_sentences(text: str) -> tuple[str, ...]:
         return ()
     sentences: list[str] = []
     start = 0
-    for boundary in re.finditer(r"[.!?]+(?=\s+|$)", normalized):
-        if boundary.group().endswith(".") and _summary_period_is_abbreviation(
-            normalized, boundary.end()
+    for boundary in re.finditer(r"[.!?]+(?:[\"')\]}]+)?(?=\s+|$)", normalized):
+        punctuation = re.match(r"[.!?]+", boundary.group())
+        if (
+            punctuation is not None
+            and punctuation.group().endswith(".")
+            and _summary_period_is_abbreviation(normalized, boundary.end())
         ):
             continue
         sentence = normalized[start : boundary.end()].strip()

--- a/workers/automation/src/jobctrl/domain/materials/use_cases.py
+++ b/workers/automation/src/jobctrl/domain/materials/use_cases.py
@@ -610,11 +610,12 @@ def _generated_claim_surfaces(
     tailoring_plan: TailoringPlan | None = None,
 ) -> dict[str, str]:
     surfaces: dict[str, str] = {}
-    executive_profile = str(payload.get("executive_profile") or "").strip()
+    executive_profile = str(payload.get("executive_profile") or "")
     if executive_profile:
-        for location in ("executive_profile", "summary", "resume.executive_profile"):
-            surfaces[location] = executive_profile
         summary_sentences, _errors = _generated_summary_sentence_contract(payload)
+        if len(summary_sentences) == 1:
+            for location in ("executive_profile", "summary", "resume.executive_profile"):
+                surfaces[location] = executive_profile
         for index, sentence in enumerate(summary_sentences):
             surfaces[f"executive_profile.sentence[{index}]"] = sentence
     updates = payload.get("experience_updates")
@@ -754,7 +755,7 @@ def _generated_summary_sentence_contract(
                 f"executive_profile_sentences[{index}] must not contain outer whitespace."
             )
         sentences.append(value.strip())
-    executive_profile = str(payload.get("executive_profile") or "").strip()
+    executive_profile = str(payload.get("executive_profile") or "")
     if sentences and " ".join(sentences) != executive_profile:
         errors.append(
             "Joining executive_profile_sentences with one space must reproduce "

--- a/workers/automation/src/jobctrl/domain/materials/use_cases.py
+++ b/workers/automation/src/jobctrl/domain/materials/use_cases.py
@@ -113,6 +113,7 @@ from jobctrl.domain.materials.claim_grounding import (
 )
 from jobctrl.domain.materials.quality import (
     TailoringPlan,
+    TailoringPrerequisiteError,
     build_tailoring_change_annotations,
     build_tailoring_plan,
     evaluate_tailoring_quality,
@@ -175,8 +176,8 @@ from jobctrl.resume_profile import (
 
 log = logging.getLogger(__name__)
 
-TAILORING_PROMPT_VERSION = "tailor.v3.writer-method"
-TAILORING_SCHEMA_VERSION = "tailored-resume.v1"
+TAILORING_PROMPT_VERSION = "tailor.v4.claim-mapping"
+TAILORING_SCHEMA_VERSION = "tailored-resume.v2"
 TAILORING_JUDGE_SCHEMA_VERSION = "tailor-judge.v1"
 TAILORING_JUDGE_CRITERIA: tuple[str, ...] = (
     "relevance_to_job",
@@ -250,6 +251,7 @@ TAILORED_RESUME_RESPONSE_SCHEMA: dict[str, Any] = {
         },
         "generated_claim_mappings": {
             "type": "array",
+            "minItems": 1,
             "items": {
                 "type": "object",
                 "additionalProperties": False,
@@ -266,8 +268,21 @@ TAILORED_RESUME_RESPONSE_SCHEMA: dict[str, Any] = {
                 ],
                 "properties": {
                     "claim_id": {"type": "string"},
-                    "location": {"type": "string"},
-                    "text": {"type": "string"},
+                    "location": {
+                        "type": "string",
+                        "description": (
+                            "Use executive_profile or executive_profile.sentence[N] for summary "
+                            "sentences, experience.<id>.bullets[N] for bullets, and skills.<id> "
+                            "for one complete rendered skill group."
+                        ),
+                    },
+                    "text": {
+                        "type": "string",
+                        "description": (
+                            "Exact text at location. For skills.<id>, join every selected item "
+                            "in rendered order with comma-space separators."
+                        ),
+                    },
                     "claim_label": {
                         "type": "string",
                         "enum": [
@@ -285,7 +300,11 @@ TAILORED_RESUME_RESPONSE_SCHEMA: dict[str, Any] = {
                     "evidence_ids": {"type": "array", "items": {"type": "string"}},
                     "non_requirement_reason": {
                         "type": "string",
-                        "enum": ["", "pinned", "positioning", "structure"],
+                        "enum": ["pinned", "positioning", "structure"],
+                        "description": (
+                            "Required fallback classification. It is ignored when coverage_edge_ids "
+                            "is non-empty; when no edge is used it must describe the claim."
+                        ),
                     },
                     "review_required": {"type": "boolean"},
                 },
@@ -645,7 +664,13 @@ def _generated_claim_surfaces(
 
 
 def _canonical_claim_location(location: str) -> str:
-    return re.sub(r"\.bullet\[(\d+)\]$", r".bullets[\1]", str(location or "").strip())
+    normalized = str(location or "").strip()
+    if re.fullmatch(
+        r"(?:(?:profile\.)?(?:executive_profile|summary))(?:\.sentences?)?\[\d+\]",
+        normalized,
+    ):
+        return "executive_profile"
+    return re.sub(r"\.bullet\[(\d+)\]$", r".bullets[\1]", normalized)
 
 
 def _claim_text_is_bound(actual_text: str, mapped_text: str) -> bool:
@@ -1280,6 +1305,14 @@ HARD RULES:
   group, emit a generated_claim_mappings entry that references valid
   coverage_edge_ids, requirement_ids, and evidence_ids; use non_requirement_reason
   only for pinned, positioning, or structure claims
+- A summary sentence location may be executive_profile.sentence[N]; N is zero-based
+- For a skills.<category-id> mapping, text must be the exact selected items in
+  rendered order joined with ", " (comma plus one space), not the category label
+- Every achievement_evidence_id present on any COVERAGE_GRAPH edge must appear
+  in at least one bound mapping that cites that edge and its requirement_id
+- non_requirement_reason is a required fallback classification. Choose pinned,
+  positioning, or structure. When coverage_edge_ids is non-empty it is ignored;
+  when coverage_edge_ids is empty it must truthfully classify the claim
 - Adjacent or draft claims must be labeled adjacent_translation or
   draft_requires_confirmation and marked review_required unless the advanced
   auto-approval policy explicitly allows the claim label
@@ -1347,7 +1380,7 @@ OUTPUT ONLY VALID JSON:
       "coverage_edge_ids": ["edge id from COVERAGE_GRAPH"],
       "requirement_ids": ["requirement id from TARGET_PROFILE"],
       "evidence_ids": ["achievement evidence id from TARGET_PROFILE"],
-      "non_requirement_reason": "",
+      "non_requirement_reason": "positioning",
       "review_required": false
     }}
   ]
@@ -1668,6 +1701,12 @@ class TailorResumeUseCase:
             requirement_fit_report = self._requirement_fit_repository.load(
                 tenant_id,
                 job_id,
+            )
+        if self._requirement_fit_repository is not None and requirement_fit_report is None:
+            raise TailoringPrerequisiteError(
+                reason="requirement_fit_missing",
+                job_id=str(job_id),
+                analysis_generation=employer_analysis.generation,
             )
         previous = self._repository.load(tenant_id, job_id)
         created_at = _utc_now()
@@ -4059,6 +4098,7 @@ __all__ = [
     "SuppressTailoredArtifactsOutcome",
     "SuppressTailoredArtifactsUseCase",
     "TailorOutcome",
+    "TailoringPrerequisiteError",
     "TailorResumeUseCase",
     "build_cover_letter_prompt",
     "build_judge_prompt",

--- a/workers/automation/src/jobctrl/domain/materials/use_cases.py
+++ b/workers/automation/src/jobctrl/domain/materials/use_cases.py
@@ -526,7 +526,6 @@ def _claim_mappings_from_payload(
             )
             non_requirement_reason = str(raw.get("non_requirement_reason") or "")
             if coverage_edge_ids and non_requirement_reason:
-                raw["non_requirement_reason"] = ""
                 non_requirement_reason = ""
             mappings.append(
                 GeneratedClaimMapping(
@@ -553,7 +552,9 @@ def _claim_mapping_binding_errors(
     tailoring_plan: TailoringPlan | None = None,
 ) -> tuple[str, ...]:
     surfaces = _generated_claim_surfaces(payload, tailoring_plan=tailoring_plan)
+    mappings = tuple(mappings)
     errors: list[str] = []
+    bound_locations: list[str] = []
     for mapping in mappings:
         location = _canonical_claim_location(mapping.location)
         actual_text = surfaces.get(location)
@@ -563,19 +564,29 @@ def _claim_mapping_binding_errors(
                 "does not exist in the generated payload."
             )
             continue
-        if _skill_group_claim_location(location):
+        if _claim_location_requires_exact_text(location):
             text_is_bound = actual_text == mapping.text
         else:
             text_is_bound = _claim_text_is_bound(actual_text, mapping.text)
         if not text_is_bound:
             relationship = (
                 "does not exactly match"
-                if _skill_group_claim_location(location)
+                if _claim_location_requires_exact_text(location)
                 else "is not present at"
             )
             errors.append(
                 f"Generated claim {mapping.claim_id} text {relationship} "
                 f"generated payload location {mapping.location!r}."
+            )
+            continue
+        bound_locations.append(location)
+    for label, locations in _required_claim_surface_groups(payload):
+        count = sum(location in locations for location in bound_locations)
+        if count == 0:
+            errors.append(f"Generated claim mapping is missing for {label}.")
+        elif count > 1:
+            errors.append(
+                f"Generated claim surface {label} has {count} mappings; expected exactly one."
             )
     return tuple(errors)
 
@@ -590,6 +601,8 @@ def _generated_claim_surfaces(
     if executive_profile:
         for location in ("executive_profile", "summary", "resume.executive_profile"):
             surfaces[location] = executive_profile
+        for index, sentence in enumerate(_generated_summary_sentences(executive_profile)):
+            surfaces[f"executive_profile.sentence[{index}]"] = sentence
     updates = payload.get("experience_updates")
     for update_index, update in enumerate(updates if isinstance(updates, list) else ()):
         if not isinstance(update, dict):
@@ -674,11 +687,12 @@ def _generated_claim_surfaces(
 
 def _canonical_claim_location(location: str) -> str:
     normalized = str(location or "").strip()
-    if re.fullmatch(
-        r"(?:(?:profile\.)?(?:executive_profile|summary))(?:\.sentences?)?\[\d+\]",
+    sentence_match = re.fullmatch(
+        r"(?:(?:profile\.)?(?:executive_profile|summary))(?:\.sentences?)?\[(\d+)\]",
         normalized,
-    ):
-        return "executive_profile"
+    )
+    if sentence_match:
+        return f"executive_profile.sentence[{sentence_match.group(1)}]"
     return re.sub(r"\.bullet\[(\d+)\]$", r".bullets[\1]", normalized)
 
 
@@ -691,6 +705,98 @@ def _skill_group_claim_location(location: str) -> bool:
         )
         or re.fullmatch(r"skill_category_updates\[\d+\]", location)
     )
+
+
+def _claim_location_requires_exact_text(location: str) -> bool:
+    return bool(
+        location in {"executive_profile", "summary", "resume.executive_profile"}
+        or re.fullmatch(r"executive_profile\.sentence\[\d+\]", location)
+        or _skill_group_claim_location(location)
+    )
+
+
+def _generated_summary_sentences(text: str) -> tuple[str, ...]:
+    return tuple(
+        sentence.strip()
+        for sentence in re.split(r"(?<=[.!?])\s+", text.strip())
+        if sentence.strip()
+    )
+
+
+def _required_claim_surface_groups(
+    payload: dict,
+) -> tuple[tuple[str, frozenset[str]], ...]:
+    """Return every generated surface that must have exactly one bound mapping."""
+
+    groups: list[tuple[str, frozenset[str]]] = []
+    executive_profile = str(payload.get("executive_profile") or "").strip()
+    for index, _sentence in enumerate(_generated_summary_sentences(executive_profile)):
+        groups.append(
+            (
+                f"executive profile sentence {index}",
+                frozenset(
+                    {
+                        "executive_profile",
+                        "summary",
+                        "resume.executive_profile",
+                        f"executive_profile.sentence[{index}]",
+                    }
+                ),
+            )
+        )
+
+    updates = payload.get("experience_updates")
+    for update_index, update in enumerate(updates if isinstance(updates, list) else ()):
+        if not isinstance(update, dict):
+            continue
+        entry_id = str(update.get("id") or "").strip()
+        if not entry_id:
+            continue
+        bullets = update.get("bullets")
+        for bullet_index, bullet in enumerate(bullets if isinstance(bullets, list) else ()):
+            if not str(bullet or "").strip():
+                continue
+            groups.append(
+                (
+                    f"experience {entry_id} bullet {bullet_index}",
+                    frozenset(
+                        {
+                            f"experience.{entry_id}.bullets[{bullet_index}]",
+                            f"experience_updates.{entry_id}.bullets[{bullet_index}]",
+                            f"experience_updates[{update_index}].bullets[{bullet_index}]",
+                        }
+                    ),
+                )
+            )
+
+    skill_updates = payload.get("skill_category_updates")
+    for update_index, update in enumerate(
+        skill_updates if isinstance(skill_updates, list) else ()
+    ):
+        if not isinstance(update, dict):
+            continue
+        category_id = str(update.get("id") or "").strip()
+        items = [
+            str(item or "").strip()
+            for item in update.get("items") or []
+            if str(item or "").strip()
+        ]
+        if not category_id or not items:
+            continue
+        groups.append(
+            (
+                f"skill group {category_id}",
+                frozenset(
+                    {
+                        f"skills.{category_id}",
+                        f"skill_categories.{category_id}",
+                        f"skill_category_updates.{category_id}",
+                        f"skill_category_updates[{update_index}]",
+                    }
+                ),
+            )
+        )
+    return tuple(groups)
 
 
 def _claim_text_is_bound(actual_text: str, mapped_text: str) -> bool:

--- a/workers/automation/src/jobctrl/domain/materials/use_cases.py
+++ b/workers/automation/src/jobctrl/domain/materials/use_cases.py
@@ -104,6 +104,7 @@ from jobctrl.domain.materials.voice import (
     VoiceResult,
     apply_voice_to_payload,
     build_voice_request,
+    summary_voice_rejection_reason,
 )
 from jobctrl.domain.materials.voice_metrics import measure_voice_delta
 from jobctrl.domain.materials.claim_grounding import (
@@ -712,10 +713,15 @@ def _canonical_claim_location(location: str) -> str:
 
 
 def _skill_group_claim_location(location: str) -> bool:
-    """Return whether a mapping targets one complete rendered skill group."""
+    """Return whether a mapping targets one complete rendered skill group.
+
+    Ids may contain dots ("node.js"): any bracket-free remainder after the
+    section prefix is the category id, while item locations always carry an
+    ``.items[N]`` bracket suffix and therefore never match.
+    """
     return bool(
         re.fullmatch(
-            r"(?:skills|skill_categories|skill_category_updates)\.[^.\[]+",
+            r"(?:skills|skill_categories|skill_category_updates)\.[^\[\]]+",
             location,
         )
         or re.fullmatch(r"skill_category_updates\[\d+\]", location)
@@ -723,11 +729,13 @@ def _skill_group_claim_location(location: str) -> bool:
 
 
 def _claim_location_requires_exact_text(location: str) -> bool:
+    # Entry ids may contain dots ("acme.co"); the trailing ".bullets[N]"
+    # component is unambiguous, so backtracking splits the id correctly.
     return bool(
         location in {"executive_profile", "summary", "resume.executive_profile"}
         or re.fullmatch(r"executive_profile\.sentence\[\d+\]", location)
         or re.fullmatch(
-            r"(?:experience|experience_updates)(?:\.[^.\[]+|\[\d+\])\.bullets\[\d+\]",
+            r"(?:experience|experience_updates)(?:\.[^\[\]]+|\[\d+\])\.bullets\[\d+\]",
             location,
         )
         or _skill_group_claim_location(location)
@@ -3502,6 +3510,7 @@ class TailorResumeUseCase:
                 model=voice_record.model,
                 proxy_delta=voice_record.proxy_delta,
                 reason=f"voice_introduced_fabrication: {voiced_error}",
+                summary_rejection_reason=voice_record.summary_rejection_reason,
             )
             coverage = self._coverage_for(base_rows, employer_analysis, None, corpus)
             return tailored_payload, base_rows, coverage, rejected, None, base_grounding
@@ -3543,6 +3552,14 @@ class TailorResumeUseCase:
             )
 
         voiced_payload = apply_voice_to_payload(tailored_payload, result)
+        # Sentence-identity gate audit: when the voiced summary broke identity the
+        # last accepted summary shipped instead — record why, never drop silently.
+        summary_rejection = summary_voice_rejection_reason(tailored_payload, result)
+        if summary_rejection:
+            log.warning(
+                "Voice pass summary rejected (%s); keeping the pre-voice summary.",
+                summary_rejection,
+            )
         # Deterministic acceptance gate (VOICE-01): voice must MEASURABLY reduce
         # buzzword density OR raise structural variety over the bullets that ship.
         before_bullets = [row.generated_text for row in base_rows if row.section == "experience"]
@@ -3557,6 +3574,7 @@ class TailorResumeUseCase:
             model=self._voice.model_id,
             proxy_delta=delta.to_dict(),
             reason="" if delta.improved else "voice_did_not_improve_proxies",
+            summary_rejection_reason=summary_rejection,
         )
         if not delta.improved:
             return None, record

--- a/workers/automation/src/jobctrl/domain/materials/use_cases.py
+++ b/workers/automation/src/jobctrl/domain/materials/use_cases.py
@@ -720,12 +720,45 @@ def _claim_location_requires_exact_text(location: str) -> bool:
     )
 
 
-def _generated_summary_sentences(text: str) -> tuple[str, ...]:
-    return tuple(
-        sentence.strip()
-        for sentence in re.split(r"(?<=[.!?])\s+", text.strip())
-        if sentence.strip()
+_SUMMARY_TITLE_ABBREVIATIONS = frozenset({"dr.", "mr.", "mrs.", "ms.", "prof."})
+_SUMMARY_ALWAYS_INLINE_ABBREVIATIONS = frozenset({"e.g.", "i.e."})
+
+
+def _summary_period_is_abbreviation(text: str, boundary_end: int) -> bool:
+    prefix_match = re.search(r"([^\s]+)$", text[:boundary_end])
+    if prefix_match is None:
+        return False
+    token = prefix_match.group(1).strip("()[]{}\"'").lower()
+    if token in _SUMMARY_TITLE_ABBREVIATIONS | _SUMMARY_ALWAYS_INLINE_ABBREVIATIONS:
+        return True
+    continuation = text[boundary_end:].lstrip()
+    if not continuation or not continuation[0].islower():
+        return False
+    return bool(
+        re.fullmatch(r"(?:[a-z]\.){2,}", token)
+        or token in {"ph.d.", "u.s.", "u.k."}
     )
+
+
+def _generated_summary_sentences(text: str) -> tuple[str, ...]:
+    normalized = text.strip()
+    if not normalized:
+        return ()
+    sentences: list[str] = []
+    start = 0
+    for boundary in re.finditer(r"[.!?]+(?=\s+|$)", normalized):
+        if boundary.group().endswith(".") and _summary_period_is_abbreviation(
+            normalized, boundary.end()
+        ):
+            continue
+        sentence = normalized[start : boundary.end()].strip()
+        if sentence:
+            sentences.append(sentence)
+        start = boundary.end()
+    remainder = normalized[start:].strip()
+    if remainder:
+        sentences.append(remainder)
+    return tuple(sentences)
 
 
 def _required_claim_surface_groups(

--- a/workers/automation/src/jobctrl/domain/materials/voice.py
+++ b/workers/automation/src/jobctrl/domain/materials/voice.py
@@ -72,7 +72,8 @@ class VoicePayload(BaseModel):
         description="The voiced executive profile — de-buzzworded, same facts.",
     )
     executive_profile_sentences: list[str] = Field(
-        default_factory=list,
+        ...,
+        min_length=1,
         description=(
             "The voiced executive profile's ordered sentences; the one-space join must equal "
             "executive_profile and the item count must match the input."
@@ -159,38 +160,55 @@ def build_voice_request(
     )
 
 
+def summary_voice_rejection_reason(tailored_payload: dict, result: VoiceResult) -> str:
+    """Why the voiced summary cannot replace the source summary, or "" when it can.
+
+    This is the sentence-identity gate ``apply_voice_to_payload`` applies before
+    adopting the voiced executive profile. A non-empty reason means the original
+    (last accepted) summary is preserved and only bullets may be voiced — callers
+    must record that reason on the voice audit trail so the drop is inspectable
+    rather than silent.
+    """
+    source_summary_sentences = tuple(
+        str(sentence)
+        for sentence in tailored_payload.get("executive_profile_sentences") or ()
+        if str(sentence).strip()
+    )
+    voiced_summary_sentences = tuple(
+        str(sentence) for sentence in result.executive_profile_sentences
+    )
+    if not result.executive_profile:
+        return "voiced_summary_missing"
+    if not all(
+        sentence and sentence == sentence.strip() for sentence in voiced_summary_sentences
+    ):
+        return "voiced_summary_sentence_outer_whitespace"
+    if len(voiced_summary_sentences) != len(source_summary_sentences):
+        return "voiced_summary_sentence_count_mismatch"
+    if " ".join(voiced_summary_sentences) != result.executive_profile:
+        return "voiced_summary_sentence_join_mismatch"
+    return ""
+
+
 def apply_voice_to_payload(tailored_payload: dict, result: VoiceResult) -> dict:
     """Fold the voiced prose back onto the SELECTED payload (deterministic).
 
     Produces a NEW payload (a deep copy — the input is never mutated) whose
     executive profile and experience bullets are the voiced versions, and whose
     skills + structure are unchanged. The voiced executive profile is applied only
-    when non-empty; an experience entry's bullets are replaced ONLY when the voice
-    result supplies a matching id with a bullet count equal to the source's — a
-    mismatched/partial voice response leaves that entry's original bullets intact
-    so the audit's per-bullet identity is never silently corrupted.
+    when it passes the sentence-identity gate (``summary_voice_rejection_reason``);
+    an experience entry's bullets are replaced ONLY when the voice result supplies
+    a matching id with a bullet count equal to the source's — a mismatched/partial
+    voice response leaves that entry's original bullets intact so the audit's
+    per-bullet identity is never silently corrupted.
     """
     voiced = copy.deepcopy(tailored_payload)
 
-    source_summary_sentences = tuple(
-        str(sentence)
-        for sentence in voiced.get("executive_profile_sentences") or ()
-        if str(sentence).strip()
-    )
-    voiced_summary_sentences = tuple(
-        str(sentence) for sentence in result.executive_profile_sentences
-    )
-    if (
-        result.executive_profile
-        and all(
-            sentence and sentence == sentence.strip()
-            for sentence in voiced_summary_sentences
-        )
-        and len(voiced_summary_sentences) == len(source_summary_sentences)
-        and " ".join(voiced_summary_sentences) == result.executive_profile
-    ):
+    if not summary_voice_rejection_reason(tailored_payload, result):
         voiced["executive_profile"] = result.executive_profile
-        voiced["executive_profile_sentences"] = list(voiced_summary_sentences)
+        voiced["executive_profile_sentences"] = [
+            str(sentence) for sentence in result.executive_profile_sentences
+        ]
 
     voiced_by_id = {entry_id: bullets for entry_id, bullets in result.experience_bullets}
     for update in voiced.get("experience_updates") or []:
@@ -219,7 +237,11 @@ class VoicePassRecord:
     and the deterministic proxy delta (buzzword density / structural variety) that
     justified accepting the voiced payload. ``accepted`` records whether the voiced
     payload was kept (the proxies improved AND grounding re-validated) or rolled
-    back to the pre-voice candidate.
+    back to the pre-voice candidate. ``summary_rejection_reason`` labels the
+    post-generation sentence-identity gate: when non-empty, the voiced summary was
+    dropped for that reason and the last accepted summary shipped, even though
+    voiced bullets may still have been adopted (``accepted`` alone reflects the
+    bullet proxies, not the summary).
     """
 
     ran: bool
@@ -228,6 +250,7 @@ class VoicePassRecord:
     prompt_version: str = VOICE_PROMPT_VERSION
     proxy_delta: dict[str, Any] = field(default_factory=dict)
     reason: str = ""
+    summary_rejection_reason: str = ""
 
     @classmethod
     def skipped(cls, reason: str) -> VoicePassRecord:
@@ -241,6 +264,7 @@ class VoicePassRecord:
             "prompt_version": self.prompt_version,
             "proxy_delta": dict(self.proxy_delta),
             "reason": self.reason,
+            "summary_rejection_reason": self.summary_rejection_reason,
         }
 
     @classmethod
@@ -256,6 +280,7 @@ class VoicePassRecord:
             prompt_version=str(data.get("prompt_version") or VOICE_PROMPT_VERSION),
             proxy_delta=dict(proxy_delta) if isinstance(proxy_delta, dict) else {},
             reason=str(data.get("reason") or ""),
+            summary_rejection_reason=str(data.get("summary_rejection_reason") or ""),
         )
 
 
@@ -268,4 +293,5 @@ __all__ = [
     "VoicedExperience",
     "apply_voice_to_payload",
     "build_voice_request",
+    "summary_voice_rejection_reason",
 ]

--- a/workers/automation/src/jobctrl/domain/materials/voice.py
+++ b/workers/automation/src/jobctrl/domain/materials/voice.py
@@ -178,14 +178,16 @@ def apply_voice_to_payload(tailored_payload: dict, result: VoiceResult) -> dict:
         if str(sentence).strip()
     )
     voiced_summary_sentences = tuple(
-        sentence.strip()
-        for sentence in result.executive_profile_sentences
-        if sentence.strip()
+        str(sentence) for sentence in result.executive_profile_sentences
     )
     if (
-        result.executive_profile.strip()
+        result.executive_profile
+        and all(
+            sentence and sentence == sentence.strip()
+            for sentence in voiced_summary_sentences
+        )
         and len(voiced_summary_sentences) == len(source_summary_sentences)
-        and " ".join(voiced_summary_sentences) == result.executive_profile.strip()
+        and " ".join(voiced_summary_sentences) == result.executive_profile
     ):
         voiced["executive_profile"] = result.executive_profile
         voiced["executive_profile_sentences"] = list(voiced_summary_sentences)

--- a/workers/automation/src/jobctrl/domain/materials/voice.py
+++ b/workers/automation/src/jobctrl/domain/materials/voice.py
@@ -36,7 +36,7 @@ from pydantic import BaseModel, ConfigDict, Field
 
 # Bump when the voice system prompt / contract changes so audits can tell which
 # voice contract produced a given generation (mirrors ``PROMPT_VERSION``).
-VOICE_PROMPT_VERSION = "voice-pass-v1"
+VOICE_PROMPT_VERSION = "voice-pass-v2-explicit-summary-sentences"
 
 
 # ---------------------------------------------------------------------------
@@ -71,6 +71,13 @@ class VoicePayload(BaseModel):
         default="",
         description="The voiced executive profile — de-buzzworded, same facts.",
     )
+    executive_profile_sentences: list[str] = Field(
+        default_factory=list,
+        description=(
+            "The voiced executive profile's ordered sentences; the one-space join must equal "
+            "executive_profile and the item count must match the input."
+        ),
+    )
     experience_updates: list[VoicedExperience] = Field(default_factory=list)
 
 
@@ -91,6 +98,7 @@ class VoiceRequest:
 
     executive_profile: str
     experience_bullets: tuple[tuple[str, tuple[str, ...]], ...]  # (experience_id, bullets)
+    executive_profile_sentences: tuple[str, ...] = ()
     banned_terms: tuple[str, ...] = ()
 
 
@@ -100,11 +108,15 @@ class VoiceResult:
 
     executive_profile: str
     experience_bullets: tuple[tuple[str, tuple[str, ...]], ...]  # (experience_id, bullets)
+    executive_profile_sentences: tuple[str, ...] = ()
 
     @classmethod
     def from_payload(cls, payload: VoicePayload) -> VoiceResult:
         return cls(
             executive_profile=payload.executive_profile or "",
+            executive_profile_sentences=tuple(
+                str(sentence) for sentence in payload.executive_profile_sentences
+            ),
             experience_bullets=tuple(
                 (entry.id, tuple(str(bullet) for bullet in entry.bullets))
                 for entry in payload.experience_updates
@@ -137,6 +149,11 @@ def build_voice_request(
             experience_bullets.append((entry_id, bullets))
     return VoiceRequest(
         executive_profile=str(tailored_payload.get("executive_profile") or ""),
+        executive_profile_sentences=tuple(
+            str(sentence)
+            for sentence in tailored_payload.get("executive_profile_sentences") or ()
+            if str(sentence).strip()
+        ),
         experience_bullets=tuple(experience_bullets),
         banned_terms=banned_terms,
     )
@@ -155,8 +172,23 @@ def apply_voice_to_payload(tailored_payload: dict, result: VoiceResult) -> dict:
     """
     voiced = copy.deepcopy(tailored_payload)
 
-    if result.executive_profile.strip():
+    source_summary_sentences = tuple(
+        str(sentence)
+        for sentence in voiced.get("executive_profile_sentences") or ()
+        if str(sentence).strip()
+    )
+    voiced_summary_sentences = tuple(
+        sentence.strip()
+        for sentence in result.executive_profile_sentences
+        if sentence.strip()
+    )
+    if (
+        result.executive_profile.strip()
+        and len(voiced_summary_sentences) == len(source_summary_sentences)
+        and " ".join(voiced_summary_sentences) == result.executive_profile.strip()
+    ):
         voiced["executive_profile"] = result.executive_profile
+        voiced["executive_profile_sentences"] = list(voiced_summary_sentences)
 
     voiced_by_id = {entry_id: bullets for entry_id, bullets in result.experience_bullets}
     for update in voiced.get("experience_updates") or []:

--- a/workers/automation/src/jobctrl/infrastructure/materials/voice_prompts.py
+++ b/workers/automation/src/jobctrl/infrastructure/materials/voice_prompts.py
@@ -52,9 +52,11 @@ that is not already in the input. Do NOT change any existing number/date/title/ 
 employer. If a bullet has no metric, do NOT invent one. Removing a buzzword must \
 never become adding a claim.
 
-Output the SAME structure you received: the voiced executive_profile and, for each \
-experience entry, the SAME id and the SAME number of bullets, voiced. Preserve \
-bullet order so each voiced bullet corresponds to its source bullet.\
+Output the SAME structure you received: the voiced executive_profile, the SAME \
+number of ordered executive_profile_sentences whose one-space join exactly equals \
+executive_profile, and, for each experience entry, the SAME id and the SAME number \
+of bullets, voiced. Preserve bullet order so each voiced bullet corresponds to its \
+source bullet.\
 """
 
 
@@ -69,6 +71,7 @@ def build_voice_user_prompt(request: VoiceRequest) -> str:
     """
     payload = {
         "executive_profile": request.executive_profile,
+        "executive_profile_sentences": list(request.executive_profile_sentences),
         "experience_updates": [
             {"id": entry_id, "bullets": list(bullets)}
             for entry_id, bullets in request.experience_bullets

--- a/workers/automation/src/jobctrl/scoring/tailor.py
+++ b/workers/automation/src/jobctrl/scoring/tailor.py
@@ -41,6 +41,7 @@ from jobctrl.domain.materials.services import ContentValidator, ResumeAssembler
 from jobctrl.domain.materials.use_cases import (
     TailorOutcome,
     TailoringLlmPolicy,
+    TailoringPrerequisiteError,
     TailorResumeUseCase,
     build_master_tailor_prompt,
 )
@@ -1033,6 +1034,24 @@ def tailor_job_by_id(
             durable_attempt=current_attempt,
         )
         commit_guard()
+    except TailoringPrerequisiteError as exc:
+        with SqliteUnitOfWork(conn):
+            commit_guard()
+            _record_tailor_requirement_fit_block(
+                conn,
+                job_id=stable_job_id,
+                tenant_id=tenant_id,
+                error=exc,
+                attempt_count=prior_attempts,
+                metadata=metadata,
+            )
+        return {
+            "url": target["url"],
+            "job_id": str(stable_job_id),
+            "status": "skipped",
+            "reason": exc.reason,
+            "error": str(exc),
+        }
     except Exception as exc:  # noqa: BLE001 - one item must terminalize its stage
         # A cancellation/successor fence must escape this item runner. Turning
         # it into an ordinary generation failure would let this stale owner
@@ -1368,6 +1387,60 @@ def _record_tailor_enrichment_block(
         payload={"reason": "enrichment_quarantined", "condition": quarantine_reason},
     )
     return True
+
+
+def _record_tailor_requirement_fit_block(
+    conn: sqlite3.Connection,
+    *,
+    job_id: JobId,
+    tenant_id: TenantId,
+    error: TailoringPrerequisiteError,
+    attempt_count: int,
+    metadata: dict[str, object] | None,
+) -> None:
+    """Block Tailor on incoherent Score evidence without consuming a retry."""
+
+    message = (
+        "Tailoring is waiting for Scoring to refresh requirement-fit evidence "
+        "for the current posting analysis."
+    )
+    block_metadata = {
+        **(metadata or {}),
+        "condition": error.reason,
+        "employerAnalysisGeneration": error.analysis_generation,
+        "requirementFitGeneration": error.report_generation,
+    }
+    set_stage_state(
+        conn,
+        job_id,
+        "tailor",
+        "blocked",
+        tenant_id=tenant_id,
+        attempt_count=attempt_count,
+        max_attempts=MAX_ATTEMPTS,
+        error_code=error.error_code,
+        error_message=message,
+        retryable=True,
+        blocked_by=["score"],
+        next_action="Rescore this job, then run Tailor again.",
+        metadata=block_metadata,
+        validate_transition=False,
+    )
+    record_job_event(
+        conn,
+        job_id,
+        "tailor",
+        "StageBlocked",
+        tenant_id=tenant_id,
+        level="warning",
+        message=message,
+        payload={
+            "reason": error.reason,
+            "errorCode": error.error_code,
+            "employerAnalysisGeneration": error.analysis_generation,
+            "requirementFitGeneration": error.report_generation,
+        },
+    )
 
 
 def _record_tailor_skip(

--- a/workers/automation/src/jobctrl/scoring/tailor.py
+++ b/workers/automation/src/jobctrl/scoring/tailor.py
@@ -643,6 +643,19 @@ def run_tailoring(
             job = future_to_job[future]
             try:
                 result = future.result()
+            except TailoringPrerequisiteError as error:
+                result = {
+                    "job_id": str(canonical_job_id(str(job["job_id"]))),
+                    "url": job["url"],
+                    "title": job["title"],
+                    "site": job.get("site"),
+                    "status": "blocked_prerequisite",
+                    "attempts": 0,
+                    "path": None,
+                    "pdf_path": None,
+                    "materials": None,
+                    "prerequisite_error": error,
+                }
             except Exception as e:
                 result = {
                     "job_id": str(canonical_job_id(str(job["job_id"]))),
@@ -687,7 +700,17 @@ def run_tailoring(
         url = r["url"]
         current_attempt = stage_attempts[stage_key]
         generation_attempts = r.get("attempts") or 1
-        if r.get("status") in _success_statuses:
+        prerequisite_error = r.get("prerequisite_error")
+        if isinstance(prerequisite_error, TailoringPrerequisiteError):
+            _record_tailor_requirement_fit_block(
+                conn,
+                job_id=stable_job_id,
+                tenant_id=tenant_id,
+                error=prerequisite_error,
+                attempt_count=current_attempt - 1,
+                metadata=activity_metadata.get(stage_key) or None,
+            )
+        elif r.get("status") in _success_statuses:
             set_stage_state(
                 conn,
                 stable_job_id,
@@ -769,10 +792,11 @@ def run_tailoring(
     failed = sum(
         count
         for status, count in stats.items()
-        if status not in {"approved", "error"}
+        if status not in {"approved", "blocked_prerequisite", "error"}
     )
     return {
         "approved": stats.get("approved", 0),
+        "blocked": stats.get("blocked_prerequisite", 0),
         "failed": failed,
         "errors": errors,
         "exhausted": durable_exhausted,

--- a/workers/automation/tests/test_claim_grounding.py
+++ b/workers/automation/tests/test_claim_grounding.py
@@ -68,6 +68,60 @@ def test_location_maps_every_payload_surface_alias_to_a_bullet_id() -> None:
     assert bullet_id_for_claim_location("unknown.surface") is None
 
 
+def test_location_maps_summary_sentence_aliases_to_the_profile_line() -> None:
+    """Sentence-indexed summary locations mirror the surface validator's aliases."""
+    assert bullet_id_for_claim_location("executive_profile.sentence[0]") == "executive_profile#0"
+    assert bullet_id_for_claim_location("executive_profile.sentences[1]") == "executive_profile#0"
+    assert bullet_id_for_claim_location("summary.sentence[2]") == "executive_profile#0"
+    assert bullet_id_for_claim_location("profile.summary[3]") == "executive_profile#0"
+    assert (
+        bullet_id_for_claim_location("profile.executive_profile.sentence[1]")
+        == "executive_profile#0"
+    )
+
+
+def test_location_maps_dotted_profile_ids() -> None:
+    """Ids containing dots ("node.js", "acme.co") still resolve by location."""
+    assert bullet_id_for_claim_location("skills.node.js") == "skills:node.js#0"
+    assert bullet_id_for_claim_location("skill_categories.node.js.items[1]") == "skills:node.js#0"
+    assert bullet_id_for_claim_location("experience.acme.co.bullets[2]") == "experience:acme.co#2"
+
+
+def test_summary_sentence_claim_grounds_via_location_without_cross_binding() -> None:
+    """A sentence-indexed summary claim binds the shipped profile line via its
+    location — never through the text_scan drift fallback that would multi-bind
+    an unrelated experience row carrying the same sentence and let enrichment
+    stamp summary requirement chips onto that row."""
+    sentence = "Owned Python API reliability."
+    rows = (
+        _row("executive_profile#0", f"Backend engineer. {sentence}"),
+        _row("experience:acme#0", f"{sentence} Cut p99 latency 40%."),
+    )
+    grounding = ground_claim_mappings(
+        (_mapping(location="executive_profile.sentence[1]", text=sentence),),
+        tuple((row.bullet_id, row.generated_text) for row in rows),
+    )
+
+    assert grounding.grounded_requirement_ids == ("r1",)
+    assert grounding.bindings[0].via == "location"
+    assert grounding.bindings[0].bullet_ids == ("executive_profile#0",)
+
+    enriched = enrich_provenance_requirements(rows, grounding)
+    assert enriched[0].requirement_ids == ("r1",)
+    assert enriched[1].requirement_ids == ()
+
+
+def test_dotted_skill_category_claim_grounds_via_location() -> None:
+    grounding = ground_claim_mappings(
+        (_mapping(location="skills.node.js", text="Node.js, Express"),),
+        (("skills:node.js#0", "Node.js, Express"),),
+    )
+
+    assert grounding.grounded_requirement_ids == ("r1",)
+    assert grounding.bindings[0].via == "location"
+    assert grounding.bindings[0].bullet_ids == ("skills:node.js#0",)
+
+
 def test_claim_grounds_via_location_when_shipped_line_carries_its_text() -> None:
     grounding = ground_claim_mappings(
         (_mapping(),),

--- a/workers/automation/tests/test_materials_quality.py
+++ b/workers/automation/tests/test_materials_quality.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
+
+import pytest
+
 from jobctrl.domain.identifiers import JobId, canonical_job_id
 from jobctrl.domain.materials.analysis import (
     AnalysisAgreement,
@@ -12,6 +16,7 @@ from jobctrl.domain.materials.analysis import (
     compute_snapshot_hash,
 )
 from jobctrl.domain.materials.quality import (
+    TailoringPrerequisiteError,
     build_tailoring_change_annotations,
     build_tailoring_plan,
     evaluate_tailoring_quality,
@@ -519,25 +524,39 @@ def test_build_tailoring_plan_uses_requirement_fit_directives() -> None:
     ]
 
 
-def test_build_tailoring_plan_ignores_stale_requirement_fit_report_for_coverage() -> None:
+def test_build_tailoring_plan_rejects_cross_job_requirement_fit_report() -> None:
     analysis = _requirement_analysis()
     stale_report = _requirement_fit_report(_OTHER_JOB_ID)
 
-    plan = build_tailoring_plan(
-        _profile(),
-        _senior_job(),
-        employer_analysis=analysis,
-        requirement_fit_report=stale_report,
+    with pytest.raises(TailoringPrerequisiteError) as raised:
+        build_tailoring_plan(
+            _profile(),
+            _senior_job(),
+            employer_analysis=analysis,
+            requirement_fit_report=stale_report,
+        )
+
+    assert raised.value.reason == "requirement_fit_job_mismatch"
+    assert raised.value.error_code == "REQUIREMENT_FIT_STALE"
+
+
+def test_build_tailoring_plan_rejects_stale_requirement_fit_generation() -> None:
+    analysis = _requirement_analysis()
+    stale_report = replace(
+        _requirement_fit_report(),
+        employer_analysis_generation=analysis.generation + 1,
     )
 
-    assert plan.requirement_directives == ()
-    assert plan.target_profile is not None
-    assert [requirement.requirement_id for requirement in plan.target_profile.requirements] == [
-        "req_latency",
-        "req_salesforce",
-    ]
-    assert plan.coverage_graph is not None
-    assert plan.coverage_graph.coverage_edges == ()
+    with pytest.raises(TailoringPrerequisiteError) as raised:
+        build_tailoring_plan(
+            _profile(),
+            _senior_job(),
+            employer_analysis=analysis,
+            requirement_fit_report=stale_report,
+        )
+
+    assert raised.value.reason == "requirement_fit_generation_mismatch"
+    assert raised.value.report_generation == 2
 
 
 def test_quality_rejects_prohibited_missing_requirement_claim() -> None:

--- a/workers/automation/tests/test_materials_use_cases.py
+++ b/workers/automation/tests/test_materials_use_cases.py
@@ -1075,6 +1075,44 @@ def test_tailor_use_case_rejects_partial_skill_group_claim_mapping(
     assert any("does not exactly match" in error for error in errors)
 
 
+def test_tailor_use_case_rejects_partial_experience_bullet_claim_mapping(
+    tmp_path: Path, job: dict
+) -> None:
+    snapshot = ProfileSnapshot.from_profile(
+        Profile.from_dict(LOCAL_TENANT, _profile_with_evidence_dict())
+    )
+    job = {
+        **job,
+        "title": "Senior Backend Engineer",
+        "skills": ["Python", "Go"],
+        "full_description": "Own Python API reliability.",
+    }
+    analysis, requirement_fit_report = _coherent_requirement_analysis_and_report(job)
+    payload = json.loads(_coherent_requirement_payload())
+    payload["generated_claim_mappings"][1]["text"] = "Reduced latency 35%"
+    llm = _ScriptedLlm([json.dumps(payload)])
+    use_case = TailorResumeUseCase(
+        repository=_FakeRepository(),
+        llm=llm,
+        validator=ContentValidator(),
+        assembler=ResumeAssembler(),
+        analyze_use_case=_FakeAnalyzeUseCase(),
+    )
+
+    outcome = use_case.execute(
+        job=job,
+        profile_snapshot=snapshot,
+        tailored_dir=tmp_path,
+        employer_analysis=analysis,
+        requirement_fit_report=requirement_fit_report,
+    )
+
+    assert outcome.status == "failed_validation"
+    assert outcome.report["judge"] is None
+    errors = outcome.report["candidate_summaries"][0]["validation"]["errors"]
+    assert any("does not exactly match" in error for error in errors)
+
+
 def test_tailor_use_case_rejects_one_whole_profile_mapping_for_multiple_sentences(
     tmp_path: Path, job: dict
 ) -> None:

--- a/workers/automation/tests/test_materials_use_cases.py
+++ b/workers/automation/tests/test_materials_use_cases.py
@@ -1265,12 +1265,90 @@ def test_tailor_use_case_accepts_indexed_mappings_for_explicit_multiple_sentence
     assert len(llm.calls) == 2
 
 
+def test_tailor_use_case_rejects_coverage_bearing_aggregate_mapping_for_multiple_sentences(
+    tmp_path: Path, job: dict
+) -> None:
+    snapshot = ProfileSnapshot.from_profile(
+        Profile.from_dict(LOCAL_TENANT, _profile_with_evidence_dict())
+    )
+    job = {
+        **job,
+        "title": "Senior Backend Engineer",
+        "skills": ["Python", "Go"],
+        "full_description": "Own Python API reliability.",
+    }
+    analysis, requirement_fit_report = _coherent_requirement_analysis_and_report(job)
+    payload = json.loads(_coherent_requirement_payload())
+    first_sentence = 'Senior backend engineer known for "reliable APIs."'
+    second_sentence = "Reduced API latency 35% with Python."
+    summary = f"{first_sentence} {second_sentence}"
+    payload["executive_profile"] = summary
+    payload["executive_profile_sentences"] = [first_sentence, second_sentence]
+    payload["generated_claim_mappings"][0].update(
+        location="executive_profile.sentence[0]",
+        text=first_sentence,
+    )
+    payload["generated_claim_mappings"].insert(
+        1,
+        {
+            **payload["generated_claim_mappings"][0],
+            "claim_id": "claim-summary-second",
+            "location": "executive_profile.sentence[1]",
+            "text": second_sentence,
+        },
+    )
+    payload["generated_claim_mappings"][2].update(
+        claim_label="positioning",
+        coverage_edge_ids=[],
+        requirement_ids=[],
+        evidence_ids=[],
+        non_requirement_reason="positioning",
+    )
+    payload["generated_claim_mappings"].append(
+        {
+            "claim_id": "claim-summary-aggregate",
+            "location": "executive_profile",
+            "text": summary,
+            "claim_label": "verified",
+            "coverage_edge_ids": ["edge_req_latency_ev_latency_direct"],
+            "requirement_ids": ["req_latency"],
+            "evidence_ids": ["ev_latency"],
+            "non_requirement_reason": "",
+            "review_required": False,
+        }
+    )
+    llm = _ScriptedLlm([json.dumps(payload)])
+    use_case = TailorResumeUseCase(
+        repository=_FakeRepository(),
+        llm=llm,
+        validator=ContentValidator(),
+        assembler=ResumeAssembler(),
+        analyze_use_case=_FakeAnalyzeUseCase(),
+    )
+
+    outcome = use_case.execute(
+        job=job,
+        profile_snapshot=snapshot,
+        tailored_dir=tmp_path,
+        employer_analysis=analysis,
+        requirement_fit_report=requirement_fit_report,
+    )
+
+    assert outcome.status == "failed_validation"
+    assert outcome.report["judge"] is None
+    errors = outcome.report["candidate_summaries"][0]["validation"]["errors"]
+    assert any(
+        "location 'executive_profile' does not exist" in error for error in errors
+    )
+
+
 @pytest.mark.parametrize(
     ("case", "expected_error"),
     [
         ("wrong_summary_index", "does not exist in the generated payload"),
         ("missing_summary_sentences", "must be an ordered array"),
         ("mismatched_summary_sentences", "must reproduce executive_profile exactly"),
+        ("outer_whitespace_summary", "must reproduce executive_profile exactly"),
         ("missing_skill_group", "mapping is missing for skill group languages"),
         ("duplicate_skill_group", "has 2 mappings; expected exactly one"),
     ],
@@ -1298,6 +1376,8 @@ def test_tailor_use_case_rejects_incomplete_or_ambiguous_claim_surfaces(
         payload.pop("executive_profile_sentences")
     elif case == "mismatched_summary_sentences":
         payload["executive_profile_sentences"] = ["Different summary."]
+    elif case == "outer_whitespace_summary":
+        payload["executive_profile"] = f" {payload['executive_profile']} "
     elif case == "missing_skill_group":
         payload["generated_claim_mappings"].pop(2)
     else:

--- a/workers/automation/tests/test_materials_use_cases.py
+++ b/workers/automation/tests/test_materials_use_cases.py
@@ -33,7 +33,10 @@ from jobctrl.domain.materials import (
 from jobctrl.domain.materials.adversarial import ADVERSARIAL_REVIEW_RESPONSE_SCHEMA
 from jobctrl.domain.materials.aggregate import MaterialsLifecycle
 from jobctrl.domain.materials.policy import LearnedTailoringRules, fingerprint_value
-from jobctrl.domain.materials.requirement_coverage import COVERAGE_PLANNER_RESPONSE_SCHEMA
+from jobctrl.domain.materials.requirement_coverage import (
+    COVERAGE_PLANNER_RESPONSE_SCHEMA,
+    GeneratedClaimMapping,
+)
 from jobctrl.domain.materials.services import ContentValidator, ResumeAssembler
 from jobctrl.domain.materials.use_cases import (
     COVER_LETTER_COMPLETION_MARKER,
@@ -45,6 +48,7 @@ from jobctrl.domain.materials.use_cases import (
     TailorResumeUseCase,
     _bullet_limit_overflow_metadata,
     _canonical_claim_location,
+    _claim_mapping_binding_errors,
     _claim_mappings_from_payload,
     _safe_filename_prefix,
 )
@@ -954,6 +958,61 @@ def test_claim_location_normalizes_summary_sentence_aliases(
     location: str, expected: str
 ) -> None:
     assert _canonical_claim_location(location) == expected
+
+
+def test_claim_binding_requires_exact_text_for_dotted_ids() -> None:
+    """Dotted profile ids ("node.js", "acme.co") keep the exact-binding contract.
+
+    Regression: the exact-text location regexes rejected ids containing dots, so
+    those surfaces silently downgraded to substring matching and a partial item
+    list could pass binding while satisfying the one-mapping-per-group count.
+    """
+    payload = {
+        "executive_profile": "Backend engineer.",
+        "executive_profile_sentences": ["Backend engineer."],
+        "experience_updates": [{"id": "acme.co", "bullets": ["Cut latency 40% with Python."]}],
+        "skill_category_updates": [{"id": "node.js", "items": ["Node.js", "Express"]}],
+    }
+
+    def _mappings(bullet_text: str, skill_text: str) -> tuple[GeneratedClaimMapping, ...]:
+        return (
+            GeneratedClaimMapping(
+                claim_id="claim-summary",
+                location="executive_profile",
+                text="Backend engineer.",
+                claim_label="evidence_reframed",
+            ),
+            GeneratedClaimMapping(
+                claim_id="claim-bullet",
+                location="experience.acme.co.bullets[0]",
+                text=bullet_text,
+                claim_label="evidence_reframed",
+            ),
+            GeneratedClaimMapping(
+                claim_id="claim-skills",
+                location="skills.node.js",
+                text=skill_text,
+                claim_label="evidence_reframed",
+            ),
+        )
+
+    assert (
+        _claim_mapping_binding_errors(
+            payload=payload,
+            mappings=_mappings("Cut latency 40% with Python.", "Node.js, Express"),
+        )
+        == ()
+    )
+
+    errors = _claim_mapping_binding_errors(
+        payload=payload, mappings=_mappings("Cut latency 40%", "Node.js")
+    )
+    assert any(
+        "claim-bullet text does not exactly match" in error for error in errors
+    )
+    assert any(
+        "claim-skills text does not exactly match" in error for error in errors
+    )
 
 
 def test_claim_mapping_parser_preserves_raw_fallback_while_clearing_domain_reason() -> None:

--- a/workers/automation/tests/test_materials_use_cases.py
+++ b/workers/automation/tests/test_materials_use_cases.py
@@ -46,7 +46,6 @@ from jobctrl.domain.materials.use_cases import (
     _bullet_limit_overflow_metadata,
     _canonical_claim_location,
     _claim_mappings_from_payload,
-    _generated_summary_sentences,
     _safe_filename_prefix,
 )
 from jobctrl.domain.ports.events import EventPublisher
@@ -499,6 +498,7 @@ def _good_json_payload() -> str:
     return json.dumps(
         {
             "executive_profile": "Senior engineer focused on systems.",
+            "executive_profile_sentences": ["Senior engineer focused on systems."],
             "experience_updates": [
                 {"id": "acme_swe", "title": "", "bullets": ["Cut latency 40%."]},
             ],
@@ -531,6 +531,9 @@ def _unbound_claim_mapping_payload() -> str:
 def _review_required_claim_payload() -> str:
     payload = json.loads(_quality_json_payload())
     payload["executive_profile"] = "Draft developer-experience translation requires confirmation."
+    payload["executive_profile_sentences"] = [
+        "Draft developer-experience translation requires confirmation."
+    ]
     bullet = payload["experience_updates"][0]["bullets"][0]
     payload["generated_claim_mappings"] = [
         {
@@ -574,7 +577,7 @@ def _positioning_claim_mappings(
             }
         )
     if include_summary:
-        summary_sentences = _generated_summary_sentences(summary)
+        summary_sentences = (summary,)
         for index, sentence in enumerate(summary_sentences):
             mappings.append(
                 {
@@ -616,6 +619,7 @@ def _payload_with_bullet(bullet: str, *, summary: str = "Senior engineer focused
     return json.dumps(
         {
             "executive_profile": summary,
+            "executive_profile_sentences": [summary],
             "experience_updates": [{"id": "acme_swe", "title": "", "bullets": [bullet]}],
             "skill_category_updates": [{"id": "languages", "items": ["Python", "Go"]}],
             "generated_claim_mappings": _positioning_claim_mappings(
@@ -631,6 +635,7 @@ def _keyword_stuffed_json_payload() -> str:
     return json.dumps(
         {
             "executive_profile": f"Senior engineer focused on {stuffed}.",
+            "executive_profile_sentences": [f"Senior engineer focused on {stuffed}."],
             "experience_updates": [
                 {"id": "acme_swe", "title": "", "bullets": [f"Built {stuffed}."]},
             ],
@@ -649,6 +654,9 @@ def _quality_json_payload(*, metric: str = "35%") -> str:
     return json.dumps(
         {
             "executive_profile": "Senior backend engineer focused on Python API reliability.",
+            "executive_profile_sentences": [
+                "Senior backend engineer focused on Python API reliability."
+            ],
             "experience_updates": [
                 {
                     "id": "acme_swe",
@@ -675,6 +683,7 @@ def _coherent_requirement_payload() -> str:
     return json.dumps(
         {
             "executive_profile": summary,
+            "executive_profile_sentences": [summary],
             "experience_updates": [
                 {"id": "acme_swe", "title": "", "bullets": [bullet]},
             ],
@@ -724,6 +733,9 @@ def _stock_phrase_json_payload() -> str:
     return json.dumps(
         {
             "executive_profile": "Senior backend engineer focused on Python API reliability.",
+            "executive_profile_sentences": [
+                "Senior backend engineer focused on Python API reliability."
+            ],
             "experience_updates": [
                 {
                     "id": "acme_swe",
@@ -944,18 +956,6 @@ def test_claim_location_normalizes_summary_sentence_aliases(
     assert _canonical_claim_location(location) == expected
 
 
-@pytest.mark.parametrize(
-    "summary",
-    [
-        "U.S. backend engineer focused on Python API reliability.",
-        "Senior engineer focused on U.S. API systems.",
-        "U.S. Python backend engineer focused on API reliability.",
-    ],
-)
-def test_summary_sentence_segmentation_preserves_dotted_abbreviation(summary: str) -> None:
-    assert _generated_summary_sentences(summary) == (summary,)
-
-
 def test_claim_mapping_parser_preserves_raw_fallback_while_clearing_domain_reason() -> None:
     payload = _good_json_payload_dict()
     payload["generated_claim_mappings"][0]["coverage_edge_ids"] = ["edge_req_latency"]
@@ -1011,6 +1011,7 @@ def test_tailor_use_case_accepts_aggregate_mapping_for_abbreviated_one_sentence_
     summary = "U.S. Python backend engineer focused on API reliability."
     payload = _good_json_payload_dict()
     payload["executive_profile"] = summary
+    payload["executive_profile_sentences"] = [summary]
     payload["generated_claim_mappings"][1]["text"] = summary
     llm = _ScriptedLlm([json.dumps(payload), _judge_pass()])
     use_case = TailorResumeUseCase(
@@ -1153,12 +1154,19 @@ def test_tailor_use_case_rejects_partial_experience_bullet_claim_mapping(
     assert any("does not exactly match" in error for error in errors)
 
 
+@pytest.mark.parametrize(
+    "first_sentence",
+    [
+        'Senior backend engineer known for "reliable APIs."',
+        "Senior backend engineer based in the U.S.",
+    ],
+)
 def test_tailor_use_case_rejects_one_whole_profile_mapping_for_multiple_sentences(
-    tmp_path: Path, job: dict
+    tmp_path: Path, job: dict, first_sentence: str
 ) -> None:
-    snapshot = ProfileSnapshot.from_profile(
-        Profile.from_dict(LOCAL_TENANT, _profile_with_evidence_dict())
-    )
+    profile = _profile_with_evidence_dict()
+    profile["resume"]["experience_entries"][0]["location"] = "U.S."
+    snapshot = ProfileSnapshot.from_profile(Profile.from_dict(LOCAL_TENANT, profile))
     job = {
         **job,
         "title": "Senior Backend Engineer",
@@ -1167,11 +1175,10 @@ def test_tailor_use_case_rejects_one_whole_profile_mapping_for_multiple_sentence
     }
     analysis, requirement_fit_report = _coherent_requirement_analysis_and_report(job)
     payload = json.loads(_coherent_requirement_payload())
-    summary = (
-        'Senior backend engineer known for "reliable APIs." '
-        "Reduced API latency 35% with Python."
-    )
+    second_sentence = "Reduced API latency 35% with Python."
+    summary = f"{first_sentence} {second_sentence}"
     payload["executive_profile"] = summary
+    payload["executive_profile_sentences"] = [first_sentence, second_sentence]
     payload["generated_claim_mappings"][0].update(
         location="executive_profile",
         text=summary,
@@ -1200,12 +1207,19 @@ def test_tailor_use_case_rejects_one_whole_profile_mapping_for_multiple_sentence
     assert "Generated claim mapping is missing for executive profile sentence 1." in errors
 
 
-def test_tailor_use_case_accepts_indexed_mappings_for_quoted_multiple_sentences(
-    tmp_path: Path, job: dict
+@pytest.mark.parametrize(
+    "first_sentence",
+    [
+        'Senior backend engineer known for "reliable APIs."',
+        "Senior backend engineer based in the U.S.",
+    ],
+)
+def test_tailor_use_case_accepts_indexed_mappings_for_explicit_multiple_sentences(
+    tmp_path: Path, job: dict, first_sentence: str
 ) -> None:
-    snapshot = ProfileSnapshot.from_profile(
-        Profile.from_dict(LOCAL_TENANT, _profile_with_evidence_dict())
-    )
+    profile = _profile_with_evidence_dict()
+    profile["resume"]["experience_entries"][0]["location"] = "U.S."
+    snapshot = ProfileSnapshot.from_profile(Profile.from_dict(LOCAL_TENANT, profile))
     job = {
         **job,
         "title": "Senior Backend Engineer",
@@ -1214,9 +1228,9 @@ def test_tailor_use_case_accepts_indexed_mappings_for_quoted_multiple_sentences(
     }
     analysis, requirement_fit_report = _coherent_requirement_analysis_and_report(job)
     payload = json.loads(_coherent_requirement_payload())
-    first_sentence = 'Senior backend engineer known for "reliable APIs."'
     second_sentence = "Reduced API latency 35% with Python."
     payload["executive_profile"] = f"{first_sentence} {second_sentence}"
+    payload["executive_profile_sentences"] = [first_sentence, second_sentence]
     payload["generated_claim_mappings"][0].update(
         location="executive_profile.sentence[0]",
         text=first_sentence,
@@ -1255,6 +1269,8 @@ def test_tailor_use_case_accepts_indexed_mappings_for_quoted_multiple_sentences(
     ("case", "expected_error"),
     [
         ("wrong_summary_index", "does not exist in the generated payload"),
+        ("missing_summary_sentences", "must be an ordered array"),
+        ("mismatched_summary_sentences", "must reproduce executive_profile exactly"),
         ("missing_skill_group", "mapping is missing for skill group languages"),
         ("duplicate_skill_group", "has 2 mappings; expected exactly one"),
     ],
@@ -1278,6 +1294,10 @@ def test_tailor_use_case_rejects_incomplete_or_ambiguous_claim_surfaces(
     payload = json.loads(_coherent_requirement_payload())
     if case == "wrong_summary_index":
         payload["generated_claim_mappings"][0]["location"] = "summary.sentence[999]"
+    elif case == "missing_summary_sentences":
+        payload.pop("executive_profile_sentences")
+    elif case == "mismatched_summary_sentences":
+        payload["executive_profile_sentences"] = ["Different summary."]
     elif case == "missing_skill_group":
         payload["generated_claim_mappings"].pop(2)
     else:
@@ -2638,6 +2658,7 @@ def test_tailor_use_case_allows_versioned_declared_skill(tmp_path: Path, job: di
     payload = json.dumps(
         {
             "executive_profile": "Senior engineer.",
+            "executive_profile_sentences": ["Senior engineer."],
             "experience_updates": [
                 {"id": "acme_swe", "title": "", "bullets": ["Cut API latency 40% with Python."]}
             ],

--- a/workers/automation/tests/test_materials_use_cases.py
+++ b/workers/automation/tests/test_materials_use_cases.py
@@ -543,25 +543,64 @@ def _review_required_claim_payload() -> str:
             "non_requirement_reason": "positioning",
             "review_required": True,
         },
-        *_positioning_claim_mappings(bullet),
+        *_positioning_claim_mappings(bullet, include_summary=False),
     ]
     return json.dumps(payload)
 
 
-def _positioning_claim_mappings(text: str) -> list[dict[str, Any]]:
-    return [
-        {
-            "claim_id": "claim-positioning-1",
-            "location": "experience.acme_swe.bullets[0]",
-            "text": text,
-            "claim_label": "positioning",
-            "coverage_edge_ids": [],
-            "requirement_ids": [],
-            "evidence_ids": [],
-            "non_requirement_reason": "positioning",
-            "review_required": False,
-        }
-    ]
+def _positioning_claim_mappings(
+    text: str,
+    *,
+    summary: str = "Senior engineer focused on systems.",
+    skill_items: tuple[str, ...] = ("Python", "Go"),
+    include_bullet: bool = True,
+    include_summary: bool = True,
+    include_skills: bool = True,
+) -> list[dict[str, Any]]:
+    mappings: list[dict[str, Any]] = []
+    if include_bullet:
+        mappings.append(
+            {
+                "claim_id": "claim-positioning-1",
+                "location": "experience.acme_swe.bullets[0]",
+                "text": text,
+                "claim_label": "positioning",
+                "coverage_edge_ids": [],
+                "requirement_ids": [],
+                "evidence_ids": [],
+                "non_requirement_reason": "positioning",
+                "review_required": False,
+            }
+        )
+    if include_summary:
+        mappings.append(
+            {
+                "claim_id": "claim-summary-1",
+                "location": "executive_profile",
+                "text": summary,
+                "claim_label": "positioning",
+                "coverage_edge_ids": [],
+                "requirement_ids": [],
+                "evidence_ids": [],
+                "non_requirement_reason": "positioning",
+                "review_required": False,
+            }
+        )
+    if include_skills:
+        mappings.append(
+            {
+                "claim_id": "claim-skills-1",
+                "location": "skills.languages",
+                "text": ", ".join(skill_items),
+                "claim_label": "structure",
+                "coverage_edge_ids": [],
+                "requirement_ids": [],
+                "evidence_ids": [],
+                "non_requirement_reason": "structure",
+                "review_required": False,
+            }
+        )
+    return mappings
 
 
 def _payload_with_bullet(bullet: str, *, summary: str = "Senior engineer focused on systems.") -> str:
@@ -572,7 +611,10 @@ def _payload_with_bullet(bullet: str, *, summary: str = "Senior engineer focused
             "executive_profile": summary,
             "experience_updates": [{"id": "acme_swe", "title": "", "bullets": [bullet]}],
             "skill_category_updates": [{"id": "languages", "items": ["Python", "Go"]}],
-            "generated_claim_mappings": _positioning_claim_mappings(bullet),
+            "generated_claim_mappings": _positioning_claim_mappings(
+                bullet,
+                summary=summary,
+            ),
         }
     )
 
@@ -588,7 +630,10 @@ def _keyword_stuffed_json_payload() -> str:
             "skill_category_updates": [
                 {"id": "languages", "items": ["Python", "Go"]},
             ],
-            "generated_claim_mappings": _positioning_claim_mappings(f"Built {stuffed}."),
+            "generated_claim_mappings": _positioning_claim_mappings(
+                f"Built {stuffed}.",
+                summary=f"Senior engineer focused on {stuffed}.",
+            ),
         }
     )
 
@@ -610,7 +655,8 @@ def _quality_json_payload(*, metric: str = "35%") -> str:
                 {"id": "languages", "items": ["Python", "Go"]},
             ],
             "generated_claim_mappings": _positioning_claim_mappings(
-                f"Owned API latency improvements and reduced latency {metric} with Python."
+                f"Owned API latency improvements and reduced latency {metric} with Python.",
+                summary="Senior backend engineer focused on Python API reliability.",
             ),
         }
     )
@@ -688,7 +734,8 @@ def _stock_phrase_json_payload() -> str:
                 {"id": "languages", "items": ["Python", "Go"]},
             ],
             "generated_claim_mappings": _positioning_claim_mappings(
-                "Owned results-driven backend initiatives, leveraged dynamic professional impactful solutions to drive value while reducing API latency 35% with Python."
+                "Owned results-driven backend initiatives, leveraged dynamic professional impactful solutions to drive value while reducing API latency 35% with Python.",
+                summary="Senior backend engineer focused on Python API reliability.",
             ),
         }
     )
@@ -876,19 +923,21 @@ def test_tailored_resume_schema_constrains_non_requirement_reason_enum() -> None
 
 
 @pytest.mark.parametrize(
-    "location",
+    ("location", "expected"),
     [
-        "executive_profile.sentence[0]",
-        "summary.sentence[1]",
-        "profile.summary.sentence[2]",
-        "profile.executive_profile.sentences[3]",
+        ("executive_profile.sentence[0]", "executive_profile.sentence[0]"),
+        ("summary.sentence[1]", "executive_profile.sentence[1]"),
+        ("profile.summary.sentence[2]", "executive_profile.sentence[2]"),
+        ("profile.executive_profile.sentences[3]", "executive_profile.sentence[3]"),
     ],
 )
-def test_claim_location_normalizes_summary_sentence_aliases(location: str) -> None:
-    assert _canonical_claim_location(location) == "executive_profile"
+def test_claim_location_normalizes_summary_sentence_aliases(
+    location: str, expected: str
+) -> None:
+    assert _canonical_claim_location(location) == expected
 
 
-def test_claim_mapping_parser_clears_redundant_non_requirement_reason() -> None:
+def test_claim_mapping_parser_preserves_raw_fallback_while_clearing_domain_reason() -> None:
     payload = _good_json_payload_dict()
     payload["generated_claim_mappings"][0]["coverage_edge_ids"] = ["edge_req_latency"]
     payload["generated_claim_mappings"][0]["requirement_ids"] = ["req_latency"]
@@ -900,7 +949,7 @@ def test_claim_mapping_parser_clears_redundant_non_requirement_reason() -> None:
     assert errors == ()
     assert mappings[0].coverage_edge_ids == ("edge_req_latency",)
     assert mappings[0].non_requirement_reason == ""
-    assert payload["generated_claim_mappings"][0]["non_requirement_reason"] == ""
+    assert payload["generated_claim_mappings"][0]["non_requirement_reason"] == "positioning"
 
 
 def test_tailoring_policy_defaults_to_pipeline_gemini_flash() -> None:
@@ -1017,6 +1066,62 @@ def test_tailor_use_case_rejects_partial_skill_group_claim_mapping(
     assert outcome.report["judge"] is None
     errors = outcome.report["candidate_summaries"][0]["validation"]["errors"]
     assert any("does not exactly match" in error for error in errors)
+
+
+@pytest.mark.parametrize(
+    ("case", "expected_error"),
+    [
+        ("wrong_summary_index", "does not exist in the generated payload"),
+        ("missing_skill_group", "mapping is missing for skill group languages"),
+        ("duplicate_skill_group", "has 2 mappings; expected exactly one"),
+    ],
+)
+def test_tailor_use_case_rejects_incomplete_or_ambiguous_claim_surfaces(
+    tmp_path: Path,
+    job: dict,
+    case: str,
+    expected_error: str,
+) -> None:
+    snapshot = ProfileSnapshot.from_profile(
+        Profile.from_dict(LOCAL_TENANT, _profile_with_evidence_dict())
+    )
+    job = {
+        **job,
+        "title": "Senior Backend Engineer",
+        "skills": ["Python", "Go"],
+        "full_description": "Own Python API reliability.",
+    }
+    analysis, requirement_fit_report = _coherent_requirement_analysis_and_report(job)
+    payload = json.loads(_coherent_requirement_payload())
+    if case == "wrong_summary_index":
+        payload["generated_claim_mappings"][0]["location"] = "summary.sentence[999]"
+    elif case == "missing_skill_group":
+        payload["generated_claim_mappings"].pop(2)
+    else:
+        payload["generated_claim_mappings"].append(
+            dict(payload["generated_claim_mappings"][2], claim_id="claim-skills-copy")
+        )
+    llm = _ScriptedLlm([json.dumps(payload)])
+    use_case = TailorResumeUseCase(
+        repository=_FakeRepository(),
+        llm=llm,
+        validator=ContentValidator(),
+        assembler=ResumeAssembler(),
+        analyze_use_case=_FakeAnalyzeUseCase(),
+    )
+
+    outcome = use_case.execute(
+        job=job,
+        profile_snapshot=snapshot,
+        tailored_dir=tmp_path,
+        employer_analysis=analysis,
+        requirement_fit_report=requirement_fit_report,
+    )
+
+    assert outcome.status == "failed_validation"
+    assert outcome.report["judge"] is None
+    errors = outcome.report["candidate_summaries"][0]["validation"]["errors"]
+    assert any(expected_error in error for error in errors)
 
 
 def test_tailor_use_case_injects_quality_plan_and_persists_metadata(
@@ -1190,7 +1295,10 @@ def test_bullet_limit_overflow_metadata_matches_index_based_claim_locations(
             "review_required": False,
         }
         for index, bullet in enumerate(payload["experience_updates"][0]["bullets"])
-    ]
+    ] + _positioning_claim_mappings(
+        "",
+        include_bullet=False,
+    )
 
     metadata = _bullet_limit_overflow_metadata(
         payload=payload,
@@ -2351,7 +2459,11 @@ def test_tailor_use_case_allows_versioned_declared_skill(tmp_path: Path, job: di
                 {"id": "acme_swe", "title": "", "bullets": ["Cut API latency 40% with Python."]}
             ],
             "skill_category_updates": [{"id": "languages", "items": ["Python", "Java 17"]}],
-            "generated_claim_mappings": _positioning_claim_mappings("Cut API latency 40% with Python."),
+            "generated_claim_mappings": _positioning_claim_mappings(
+                "Cut API latency 40% with Python.",
+                summary="Senior engineer.",
+                skill_items=("Python", "Java 17"),
+            ),
         }
     )
     llm = _ScriptedLlm([payload, _judge_pass()])

--- a/workers/automation/tests/test_materials_use_cases.py
+++ b/workers/automation/tests/test_materials_use_cases.py
@@ -944,9 +944,15 @@ def test_claim_location_normalizes_summary_sentence_aliases(
     assert _canonical_claim_location(location) == expected
 
 
-def test_summary_sentence_segmentation_preserves_dotted_abbreviation() -> None:
-    summary = "U.S. backend engineer focused on Python API reliability."
-
+@pytest.mark.parametrize(
+    "summary",
+    [
+        "U.S. backend engineer focused on Python API reliability.",
+        "Senior engineer focused on U.S. API systems.",
+        "U.S. Python backend engineer focused on API reliability.",
+    ],
+)
+def test_summary_sentence_segmentation_preserves_dotted_abbreviation(summary: str) -> None:
     assert _generated_summary_sentences(summary) == (summary,)
 
 
@@ -1002,7 +1008,7 @@ def test_tailor_use_case_happy_path(tmp_path: Path, snapshot: ProfileSnapshot, j
 def test_tailor_use_case_accepts_aggregate_mapping_for_abbreviated_one_sentence_summary(
     tmp_path: Path, snapshot: ProfileSnapshot, job: dict
 ) -> None:
-    summary = "Senior engineer focused on U.S. backend systems."
+    summary = "U.S. Python backend engineer focused on API reliability."
     payload = _good_json_payload_dict()
     payload["executive_profile"] = summary
     payload["generated_claim_mappings"][1]["text"] = summary
@@ -1162,7 +1168,7 @@ def test_tailor_use_case_rejects_one_whole_profile_mapping_for_multiple_sentence
     analysis, requirement_fit_report = _coherent_requirement_analysis_and_report(job)
     payload = json.loads(_coherent_requirement_payload())
     summary = (
-        "Senior backend engineer focused on Python API reliability. "
+        'Senior backend engineer known for "reliable APIs." '
         "Reduced API latency 35% with Python."
     )
     payload["executive_profile"] = summary
@@ -1192,6 +1198,57 @@ def test_tailor_use_case_rejects_one_whole_profile_mapping_for_multiple_sentence
     errors = outcome.report["candidate_summaries"][0]["validation"]["errors"]
     assert "Generated claim mapping is missing for executive profile sentence 0." in errors
     assert "Generated claim mapping is missing for executive profile sentence 1." in errors
+
+
+def test_tailor_use_case_accepts_indexed_mappings_for_quoted_multiple_sentences(
+    tmp_path: Path, job: dict
+) -> None:
+    snapshot = ProfileSnapshot.from_profile(
+        Profile.from_dict(LOCAL_TENANT, _profile_with_evidence_dict())
+    )
+    job = {
+        **job,
+        "title": "Senior Backend Engineer",
+        "skills": ["Python", "Go"],
+        "full_description": "Own Python API reliability.",
+    }
+    analysis, requirement_fit_report = _coherent_requirement_analysis_and_report(job)
+    payload = json.loads(_coherent_requirement_payload())
+    first_sentence = 'Senior backend engineer known for "reliable APIs."'
+    second_sentence = "Reduced API latency 35% with Python."
+    payload["executive_profile"] = f"{first_sentence} {second_sentence}"
+    payload["generated_claim_mappings"][0].update(
+        location="executive_profile.sentence[0]",
+        text=first_sentence,
+    )
+    second_mapping = dict(
+        payload["generated_claim_mappings"][1],
+        claim_id="claim-summary-latency",
+        location="executive_profile.sentence[1]",
+        text=second_sentence,
+    )
+    payload["generated_claim_mappings"].insert(1, second_mapping)
+    llm = _ScriptedLlm([json.dumps(payload), _judge_pass()])
+    use_case = TailorResumeUseCase(
+        repository=_FakeRepository(),
+        llm=llm,
+        validator=ContentValidator(),
+        assembler=ResumeAssembler(),
+        analyze_use_case=_FakeAnalyzeUseCase(),
+    )
+
+    outcome = use_case.execute(
+        job=job,
+        profile_snapshot=snapshot,
+        tailored_dir=tmp_path,
+        employer_analysis=analysis,
+        requirement_fit_report=requirement_fit_report,
+    )
+
+    assert outcome.status == "approved"
+    assert outcome.materials is not None
+    assert outcome.materials.is_resume_approved
+    assert len(llm.calls) == 2
 
 
 @pytest.mark.parametrize(

--- a/workers/automation/tests/test_materials_use_cases.py
+++ b/workers/automation/tests/test_materials_use_cases.py
@@ -44,6 +44,7 @@ from jobctrl.domain.materials.use_cases import (
     TailoringLlmPolicy,
     TailorResumeUseCase,
     _bullet_limit_overflow_metadata,
+    _canonical_claim_location,
     _claim_mappings_from_payload,
     _safe_filename_prefix,
 )
@@ -51,6 +52,15 @@ from jobctrl.domain.ports.events import EventPublisher
 from jobctrl.domain.ports.llm import LlmMessage, LlmPort
 from jobctrl.domain.profile.aggregate import Profile
 from jobctrl.domain.profile.snapshot import ProfileSnapshot
+from jobctrl.domain.scoring import (
+    FitScore,
+    RequirementFitAssessment,
+    RequirementFitReport,
+    RequirementFitStatus,
+    RequirementFitSummary,
+    RequirementScoreContribution,
+    RequirementTailoringDirective,
+)
 from jobctrl.domain.tenant import LOCAL_TENANT
 from jobctrl.model_defaults import DEFAULT_PIPELINE_LLM_MODEL_SPEC
 
@@ -240,6 +250,91 @@ def _analysis_with_keywords(job: dict, keywords: list[str]):
         agreement=AnalysisAgreement(score=1.0),
         legs_attempted=1,
     )
+
+
+def _coherent_requirement_analysis_and_report(
+    job: dict,
+) -> tuple[Any, RequirementFitReport]:
+    """Build the generation-bound Score input that Tailor must consume."""
+    from jobctrl.domain.materials.analysis import (
+        AnalysisAgreement,
+        EmployerAnalysis,
+        JobAnalysis,
+        ReasonedKeyword,
+        Requirement,
+        compute_snapshot_hash,
+    )
+
+    job_id = canonical_job_id(str(job["job_id"]))
+    requirement = Requirement(
+        id="req_latency",
+        text="Own Python API reliability.",
+        tier="must_have",
+        weight=0.9,
+        evidence_span="Own Python API reliability.",
+    )
+    analysis = EmployerAnalysis.build(
+        tenant_id=LOCAL_TENANT,
+        job_id=job_id,
+        generation=2,
+        snapshot_hash=compute_snapshot_hash(str(job["full_description"])),
+        canonical=JobAnalysis(
+            role_framing="Backend ownership.",
+            inferred_seniority="senior",
+            ideal_candidate_narrative="A hands-on backend owner.",
+            requirements=[requirement],
+            keywords=[
+                ReasonedKeyword(
+                    keyword="Python API reliability",
+                    evidence_span="Own Python API reliability.",
+                    requirement_ref=requirement.id,
+                )
+            ],
+        ),
+        sub_analyses=(),
+        failures=(),
+        agreement=AnalysisAgreement(score=1.0),
+        legs_attempted=2,
+    )
+    report = RequirementFitReport(
+        job_id=job_id,
+        score_version=2,
+        employer_analysis_generation=analysis.generation,
+        profile_snapshot_version=1,
+        scoring_policy_version=1,
+        formula_version="requirement-fit-v1",
+        resolved_fit_score=FitScore.create(9),
+        fit_band="excellent",
+        confidence="high",
+        summary=RequirementFitSummary(weighted_fit=1.0, must_have_coverage=1.0),
+        assessments=(
+            RequirementFitAssessment(
+                requirement_id=requirement.id,
+                requirement_text=requirement.text,
+                tier=requirement.tier,
+                weight=requirement.weight,
+                job_evidence_span=requirement.evidence_span,
+                fit=RequirementFitStatus(
+                    kind="matched",
+                    evidence_ids=("ev_latency",),
+                    strength="direct",
+                ),
+                contribution=RequirementScoreContribution(
+                    max_points=1.125,
+                    awarded_points=1.125,
+                    weighted_impact=1.125,
+                ),
+                tailoring=RequirementTailoringDirective(
+                    action="double_down",
+                    priority=0.9,
+                    allowed_evidence_ids=("ev_latency",),
+                    target_keywords=("Python API reliability",),
+                    instruction="Emphasize the verified latency evidence.",
+                ),
+            ),
+        ),
+    )
+    return analysis, report
 
 
 class _FakeRepository:
@@ -521,6 +616,57 @@ def _quality_json_payload(*, metric: str = "35%") -> str:
     )
 
 
+def _coherent_requirement_payload() -> str:
+    summary = "Senior backend engineer focused on Python API reliability."
+    bullet = "Owned API latency improvements and reduced latency 35% with Python."
+    return json.dumps(
+        {
+            "executive_profile": summary,
+            "experience_updates": [
+                {"id": "acme_swe", "title": "", "bullets": [bullet]},
+            ],
+            "skill_category_updates": [
+                {"id": "languages", "items": ["Python", "Go"]},
+            ],
+            "generated_claim_mappings": [
+                {
+                    "claim_id": "claim-summary",
+                    "location": "summary.sentence[0]",
+                    "text": summary,
+                    "claim_label": "positioning",
+                    "coverage_edge_ids": [],
+                    "requirement_ids": [],
+                    "evidence_ids": [],
+                    "non_requirement_reason": "positioning",
+                    "review_required": False,
+                },
+                {
+                    "claim_id": "claim-latency",
+                    "location": "experience.acme_swe.bullets[0]",
+                    "text": bullet,
+                    "claim_label": "verified",
+                    "coverage_edge_ids": ["edge_req_latency_ev_latency_direct"],
+                    "requirement_ids": ["req_latency"],
+                    "evidence_ids": ["ev_latency"],
+                    "non_requirement_reason": "positioning",
+                    "review_required": False,
+                },
+                {
+                    "claim_id": "claim-skills",
+                    "location": "skills.languages",
+                    "text": "Python, Go",
+                    "claim_label": "structure",
+                    "coverage_edge_ids": [],
+                    "requirement_ids": [],
+                    "evidence_ids": [],
+                    "non_requirement_reason": "structure",
+                    "review_required": False,
+                },
+            ],
+        }
+    )
+
+
 def _stock_phrase_json_payload() -> str:
     return json.dumps(
         {
@@ -723,7 +869,23 @@ def test_tailored_resume_schema_constrains_non_requirement_reason_enum() -> None
         "items"
     ]["properties"]["non_requirement_reason"]
 
-    assert mapping_schema["enum"] == ["", "pinned", "positioning", "structure"]
+    assert mapping_schema["enum"] == ["pinned", "positioning", "structure"]
+    assert TAILORED_RESUME_RESPONSE_SCHEMA["properties"]["generated_claim_mappings"][
+        "minItems"
+    ] == 1
+
+
+@pytest.mark.parametrize(
+    "location",
+    [
+        "executive_profile.sentence[0]",
+        "summary.sentence[1]",
+        "profile.summary.sentence[2]",
+        "profile.executive_profile.sentences[3]",
+    ],
+)
+def test_claim_location_normalizes_summary_sentence_aliases(location: str) -> None:
+    assert _canonical_claim_location(location) == "executive_profile"
 
 
 def test_claim_mapping_parser_clears_redundant_non_requirement_reason() -> None:
@@ -773,6 +935,50 @@ def test_tailor_use_case_happy_path(tmp_path: Path, snapshot: ProfileSnapshot, j
     assert outcome.materials.last_verdict.criterion_scores["fabrication_safety"] == 1.0
     assert outcome.text_path is not None and Path(outcome.text_path).exists()
     assert any(getattr(e, "event_type", "") == "ResumeApproved" for e in publisher.events)
+
+
+def test_tailor_use_case_approves_generation_bound_requirement_claims(
+    tmp_path: Path, job: dict
+) -> None:
+    """Regression: coherent Score evidence reaches the judge and ships materials."""
+    snapshot = ProfileSnapshot.from_profile(
+        Profile.from_dict(LOCAL_TENANT, _profile_with_evidence_dict())
+    )
+    job = {
+        **job,
+        "title": "Senior Backend Engineer",
+        "skills": ["Python", "Go"],
+        "full_description": "Own Python API reliability.",
+    }
+    analysis, requirement_fit_report = _coherent_requirement_analysis_and_report(job)
+    repo = _FakeRepository()
+    llm = _ScriptedLlm([_coherent_requirement_payload(), _judge_pass()])
+    use_case = TailorResumeUseCase(
+        repository=repo,
+        llm=llm,
+        validator=ContentValidator(),
+        assembler=ResumeAssembler(),
+        analyze_use_case=_FakeAnalyzeUseCase(),
+    )
+
+    outcome = use_case.execute(
+        job=job,
+        profile_snapshot=snapshot,
+        tailored_dir=tmp_path,
+        employer_analysis=analysis,
+        requirement_fit_report=requirement_fit_report,
+    )
+
+    assert outcome.status == "approved"
+    assert outcome.materials is not None
+    assert outcome.materials.is_resume_approved
+    assert len(llm.calls) == 2
+    assert outcome.materials.last_verdict is not None
+    assert outcome.materials.last_verdict.approved is True
+    quality_plan = outcome.materials.tailored_resume.metadata["quality_plan"]
+    assert quality_plan["coverage_graph"]["coverage_edge_count"] == 1
+    fit_decision = outcome.report["post_generation_fit"]["revision_decision"]
+    assert fit_decision["threshold_failed"] is False
 
 
 def test_tailor_use_case_injects_quality_plan_and_persists_metadata(

--- a/workers/automation/tests/test_materials_use_cases.py
+++ b/workers/automation/tests/test_materials_use_cases.py
@@ -944,6 +944,12 @@ def test_claim_location_normalizes_summary_sentence_aliases(
     assert _canonical_claim_location(location) == expected
 
 
+def test_summary_sentence_segmentation_preserves_dotted_abbreviation() -> None:
+    summary = "U.S. backend engineer focused on Python API reliability."
+
+    assert _generated_summary_sentences(summary) == (summary,)
+
+
 def test_claim_mapping_parser_preserves_raw_fallback_while_clearing_domain_reason() -> None:
     payload = _good_json_payload_dict()
     payload["generated_claim_mappings"][0]["coverage_edge_ids"] = ["edge_req_latency"]
@@ -991,6 +997,34 @@ def test_tailor_use_case_happy_path(tmp_path: Path, snapshot: ProfileSnapshot, j
     assert outcome.materials.last_verdict.criterion_scores["fabrication_safety"] == 1.0
     assert outcome.text_path is not None and Path(outcome.text_path).exists()
     assert any(getattr(e, "event_type", "") == "ResumeApproved" for e in publisher.events)
+
+
+def test_tailor_use_case_accepts_aggregate_mapping_for_abbreviated_one_sentence_summary(
+    tmp_path: Path, snapshot: ProfileSnapshot, job: dict
+) -> None:
+    summary = "Senior engineer focused on U.S. backend systems."
+    payload = _good_json_payload_dict()
+    payload["executive_profile"] = summary
+    payload["generated_claim_mappings"][1]["text"] = summary
+    llm = _ScriptedLlm([json.dumps(payload), _judge_pass()])
+    use_case = TailorResumeUseCase(
+        repository=_FakeRepository(),
+        llm=llm,
+        validator=ContentValidator(),
+        assembler=ResumeAssembler(),
+        analyze_use_case=_FakeAnalyzeUseCase(),
+    )
+
+    outcome = use_case.execute(
+        job=job,
+        profile_snapshot=snapshot,
+        tailored_dir=tmp_path,
+    )
+
+    assert outcome.status == "approved"
+    assert outcome.materials is not None
+    assert outcome.materials.is_resume_approved
+    assert len(llm.calls) == 2
 
 
 def test_tailor_use_case_approves_generation_bound_requirement_claims(

--- a/workers/automation/tests/test_materials_use_cases.py
+++ b/workers/automation/tests/test_materials_use_cases.py
@@ -46,6 +46,7 @@ from jobctrl.domain.materials.use_cases import (
     _bullet_limit_overflow_metadata,
     _canonical_claim_location,
     _claim_mappings_from_payload,
+    _generated_summary_sentences,
     _safe_filename_prefix,
 )
 from jobctrl.domain.ports.events import EventPublisher
@@ -573,19 +574,25 @@ def _positioning_claim_mappings(
             }
         )
     if include_summary:
-        mappings.append(
-            {
-                "claim_id": "claim-summary-1",
-                "location": "executive_profile",
-                "text": summary,
-                "claim_label": "positioning",
-                "coverage_edge_ids": [],
-                "requirement_ids": [],
-                "evidence_ids": [],
-                "non_requirement_reason": "positioning",
-                "review_required": False,
-            }
-        )
+        summary_sentences = _generated_summary_sentences(summary)
+        for index, sentence in enumerate(summary_sentences):
+            mappings.append(
+                {
+                    "claim_id": f"claim-summary-{index + 1}",
+                    "location": (
+                        "executive_profile"
+                        if len(summary_sentences) == 1
+                        else f"executive_profile.sentence[{index}]"
+                    ),
+                    "text": sentence,
+                    "claim_label": "positioning",
+                    "coverage_edge_ids": [],
+                    "requirement_ids": [],
+                    "evidence_ids": [],
+                    "non_requirement_reason": "positioning",
+                    "review_required": False,
+                }
+            )
     if include_skills:
         mappings.append(
             {
@@ -1066,6 +1073,53 @@ def test_tailor_use_case_rejects_partial_skill_group_claim_mapping(
     assert outcome.report["judge"] is None
     errors = outcome.report["candidate_summaries"][0]["validation"]["errors"]
     assert any("does not exactly match" in error for error in errors)
+
+
+def test_tailor_use_case_rejects_one_whole_profile_mapping_for_multiple_sentences(
+    tmp_path: Path, job: dict
+) -> None:
+    snapshot = ProfileSnapshot.from_profile(
+        Profile.from_dict(LOCAL_TENANT, _profile_with_evidence_dict())
+    )
+    job = {
+        **job,
+        "title": "Senior Backend Engineer",
+        "skills": ["Python", "Go"],
+        "full_description": "Own Python API reliability.",
+    }
+    analysis, requirement_fit_report = _coherent_requirement_analysis_and_report(job)
+    payload = json.loads(_coherent_requirement_payload())
+    summary = (
+        "Senior backend engineer focused on Python API reliability. "
+        "Reduced API latency 35% with Python."
+    )
+    payload["executive_profile"] = summary
+    payload["generated_claim_mappings"][0].update(
+        location="executive_profile",
+        text=summary,
+    )
+    llm = _ScriptedLlm([json.dumps(payload)])
+    use_case = TailorResumeUseCase(
+        repository=_FakeRepository(),
+        llm=llm,
+        validator=ContentValidator(),
+        assembler=ResumeAssembler(),
+        analyze_use_case=_FakeAnalyzeUseCase(),
+    )
+
+    outcome = use_case.execute(
+        job=job,
+        profile_snapshot=snapshot,
+        tailored_dir=tmp_path,
+        employer_analysis=analysis,
+        requirement_fit_report=requirement_fit_report,
+    )
+
+    assert outcome.status == "failed_validation"
+    assert outcome.report["judge"] is None
+    errors = outcome.report["candidate_summaries"][0]["validation"]["errors"]
+    assert "Generated claim mapping is missing for executive profile sentence 0." in errors
+    assert "Generated claim mapping is missing for executive profile sentence 1." in errors
 
 
 @pytest.mark.parametrize(

--- a/workers/automation/tests/test_materials_use_cases.py
+++ b/workers/automation/tests/test_materials_use_cases.py
@@ -981,6 +981,44 @@ def test_tailor_use_case_approves_generation_bound_requirement_claims(
     assert fit_decision["threshold_failed"] is False
 
 
+def test_tailor_use_case_rejects_partial_skill_group_claim_mapping(
+    tmp_path: Path, job: dict
+) -> None:
+    snapshot = ProfileSnapshot.from_profile(
+        Profile.from_dict(LOCAL_TENANT, _profile_with_evidence_dict())
+    )
+    job = {
+        **job,
+        "title": "Senior Backend Engineer",
+        "skills": ["Python", "Go"],
+        "full_description": "Own Python API reliability.",
+    }
+    analysis, requirement_fit_report = _coherent_requirement_analysis_and_report(job)
+    payload = json.loads(_coherent_requirement_payload())
+    payload["generated_claim_mappings"][2]["text"] = "Python"
+    llm = _ScriptedLlm([json.dumps(payload)])
+    use_case = TailorResumeUseCase(
+        repository=_FakeRepository(),
+        llm=llm,
+        validator=ContentValidator(),
+        assembler=ResumeAssembler(),
+        analyze_use_case=_FakeAnalyzeUseCase(),
+    )
+
+    outcome = use_case.execute(
+        job=job,
+        profile_snapshot=snapshot,
+        tailored_dir=tmp_path,
+        employer_analysis=analysis,
+        requirement_fit_report=requirement_fit_report,
+    )
+
+    assert outcome.status == "failed_validation"
+    assert outcome.report["judge"] is None
+    errors = outcome.report["candidate_summaries"][0]["validation"]["errors"]
+    assert any("does not exactly match" in error for error in errors)
+
+
 def test_tailor_use_case_injects_quality_plan_and_persists_metadata(
     tmp_path: Path, job: dict
 ) -> None:

--- a/workers/automation/tests/test_requirement_led_tailoring.py
+++ b/workers/automation/tests/test_requirement_led_tailoring.py
@@ -529,7 +529,20 @@ def test_education_requirement_fit_evidence_is_claimable_in_coverage_graph() -> 
     assert (
         _claim_mapping_validation_errors(
             payload={
+                "executive_profile": "Engineering leader.",
+                "executive_profile_sentences": ["Engineering leader."],
                 "generated_claim_mappings": [
+                    {
+                        "claim_id": "summary_claim",
+                        "location": "executive_profile",
+                        "text": "Engineering leader.",
+                        "claim_label": "positioning",
+                        "coverage_edge_ids": (),
+                        "requirement_ids": (),
+                        "evidence_ids": (),
+                        "non_requirement_reason": "positioning",
+                        "review_required": False,
+                    },
                     {
                         "claim_id": "degree_claim",
                         "location": "education_updates[0]",
@@ -550,7 +563,20 @@ def test_education_requirement_fit_evidence_is_claimable_in_coverage_graph() -> 
     assert (
         _claim_mapping_validation_errors(
             payload={
+                "executive_profile": "Engineering leader.",
+                "executive_profile_sentences": ["Engineering leader."],
                 "generated_claim_mappings": [
+                    {
+                        "claim_id": "summary_claim",
+                        "location": "executive_profile",
+                        "text": "Engineering leader.",
+                        "claim_label": "positioning",
+                        "coverage_edge_ids": (),
+                        "requirement_ids": (),
+                        "evidence_ids": (),
+                        "non_requirement_reason": "positioning",
+                        "review_required": False,
+                    },
                     {
                         "claim_id": "degree_section_claim",
                         "location": "education",

--- a/workers/automation/tests/test_tailor_provenance_integration.py
+++ b/workers/automation/tests/test_tailor_provenance_integration.py
@@ -536,6 +536,9 @@ def _payload(
     return json.dumps(
         {
             "executive_profile": "Senior backend engineer focused on Python API reliability.",
+            "executive_profile_sentences": [
+                "Senior backend engineer focused on Python API reliability."
+            ],
             "experience_updates": [{"id": "acme_swe", "title": "", "bullets": [bullet]}],
             "skill_category_updates": [{"id": "languages", "items": ["Python", "Go"]}],
             "generated_claim_mappings": _claim_mapping(

--- a/workers/automation/tests/test_tailor_provenance_integration.py
+++ b/workers/automation/tests/test_tailor_provenance_integration.py
@@ -486,10 +486,22 @@ def _coverage_planner_response(
 def _claim_mapping(
     bullet: str,
     *,
+    summary: str = "Senior backend engineer focused on Python API reliability.",
     requirement_ids: tuple[str, ...] = ("req_latency",),
     coverage_edge_ids: tuple[str, ...] = ("edge_req_latency_ev_latency_direct",),
 ) -> list[dict[str, object]]:
     return [
+        {
+            "claim_id": "claim_summary",
+            "location": "executive_profile.sentence[0]",
+            "text": summary,
+            "claim_label": "positioning",
+            "coverage_edge_ids": [],
+            "requirement_ids": [],
+            "evidence_ids": [],
+            "non_requirement_reason": "positioning",
+            "review_required": False,
+        },
         {
             "claim_id": "claim_latency",
             "location": "experience.acme_swe.bullets[0]",
@@ -498,6 +510,18 @@ def _claim_mapping(
             "coverage_edge_ids": list(coverage_edge_ids),
             "requirement_ids": list(requirement_ids),
             "evidence_ids": ["ev_latency"],
+            "non_requirement_reason": "positioning",
+            "review_required": False,
+        },
+        {
+            "claim_id": "claim_skills",
+            "location": "skills.languages",
+            "text": "Python, Go",
+            "claim_label": "structure",
+            "coverage_edge_ids": [],
+            "requirement_ids": [],
+            "evidence_ids": [],
+            "non_requirement_reason": "structure",
             "review_required": False,
         }
     ]
@@ -516,6 +540,7 @@ def _payload(
             "skill_category_updates": [{"id": "languages", "items": ["Python", "Go"]}],
             "generated_claim_mappings": _claim_mapping(
                 bullet,
+                summary="Senior backend engineer focused on Python API reliability.",
                 requirement_ids=requirement_ids,
                 coverage_edge_ids=coverage_edge_ids,
             ),

--- a/workers/automation/tests/test_tailor_voice_audit_integration.py
+++ b/workers/automation/tests/test_tailor_voice_audit_integration.py
@@ -348,8 +348,19 @@ def _coverage_planner_response() -> str:
     )
 
 
-def _claim_mapping(bullet: str) -> list[dict[str, object]]:
+def _claim_mapping(bullet: str, *, summary: str) -> list[dict[str, object]]:
     return [
+        {
+            "claim_id": "claim_summary",
+            "location": "executive_profile.sentence[0]",
+            "text": summary,
+            "claim_label": "positioning",
+            "coverage_edge_ids": [],
+            "requirement_ids": [],
+            "evidence_ids": [],
+            "non_requirement_reason": "positioning",
+            "review_required": False,
+        },
         {
             "claim_id": "claim_latency",
             "location": "experience.acme_swe.bullets[0]",
@@ -358,6 +369,18 @@ def _claim_mapping(bullet: str) -> list[dict[str, object]]:
             "coverage_edge_ids": ["edge_req_latency_ev_latency_direct"],
             "requirement_ids": ["req_latency"],
             "evidence_ids": ["ev_latency"],
+            "non_requirement_reason": "positioning",
+            "review_required": False,
+        },
+        {
+            "claim_id": "claim_skills",
+            "location": "skills.languages",
+            "text": "Python, Go",
+            "claim_label": "structure",
+            "coverage_edge_ids": [],
+            "requirement_ids": [],
+            "evidence_ids": [],
+            "non_requirement_reason": "structure",
             "review_required": False,
         }
     ]
@@ -369,7 +392,7 @@ def _payload(bullet: str, *, summary: str) -> str:
             "executive_profile": summary,
             "experience_updates": [{"id": "acme_swe", "title": "", "bullets": [bullet]}],
             "skill_category_updates": [{"id": "languages", "items": ["Python", "Go"]}],
-            "generated_claim_mappings": _claim_mapping(bullet),
+            "generated_claim_mappings": _claim_mapping(bullet, summary=summary),
         }
     )
 

--- a/workers/automation/tests/test_tailor_voice_audit_integration.py
+++ b/workers/automation/tests/test_tailor_voice_audit_integration.py
@@ -390,6 +390,7 @@ def _payload(bullet: str, *, summary: str) -> str:
     return json.dumps(
         {
             "executive_profile": summary,
+            "executive_profile_sentences": [summary],
             "experience_updates": [{"id": "acme_swe", "title": "", "bullets": [bullet]}],
             "skill_category_updates": [{"id": "languages", "items": ["Python", "Go"]}],
             "generated_claim_mappings": _claim_mapping(bullet, summary=summary),
@@ -451,6 +452,9 @@ def test_voice_runs_before_audit_and_provenance_anchors_to_voiced_text(tmp_path:
         # De-buzzword: keep the grounded "40%"/"Python", drop "spearheaded/robust".
         return VoiceResult(
             executive_profile="Backend engineer who cut API latency with Python.",
+            executive_profile_sentences=(
+                "Backend engineer who cut API latency with Python.",
+            ),
             experience_bullets=(
                 ("acme_swe", ("Owned the API and cut latency 40% with Python.",)),
             ),
@@ -488,6 +492,9 @@ def test_gate_grounding_and_shipped_fit_persist_with_lifecycle_labels(tmp_path: 
     def voice_fn(request: VoiceRequest) -> VoiceResult:
         return VoiceResult(
             executive_profile="Backend engineer who cut API latency with Python.",
+            executive_profile_sentences=(
+                "Backend engineer who cut API latency with Python.",
+            ),
             experience_bullets=(
                 ("acme_swe", ("Owned the API and cut latency 40% with Python.",)),
             ),
@@ -536,6 +543,9 @@ def test_voiced_bullet_is_recorded_as_voice_transform(tmp_path: Path) -> None:
     def voice_fn(request: VoiceRequest) -> VoiceResult:
         return VoiceResult(
             executive_profile="Backend engineer who cut API latency with Python.",
+            executive_profile_sentences=(
+                "Backend engineer who cut API latency with Python.",
+            ),
             experience_bullets=(
                 ("acme_swe", ("Owned the API and cut latency 40% with Python.",)),
             ),
@@ -568,6 +578,7 @@ def test_voice_introduced_fabrication_is_rejected_and_pre_voice_ships(tmp_path: 
         # The voice pass invents "10M users" — unsourced; the profile has no such number.
         return VoiceResult(
             executive_profile="Backend engineer who scaled to 10M users.",
+            executive_profile_sentences=("Backend engineer who scaled to 10M users.",),
             experience_bullets=(
                 ("acme_swe", ("Owned the API and cut latency 40%, scaling to 10M users.",)),
             ),
@@ -605,6 +616,7 @@ def test_coverage_is_computed_against_rendered_text_and_provenance_backed(tmp_pa
         # Voiced bullet keeps "latency" + "Python" (both analysis keywords).
         return VoiceResult(
             executive_profile="Backend engineer focused on API latency.",
+            executive_profile_sentences=("Backend engineer focused on API latency.",),
             experience_bullets=(
                 ("acme_swe", ("Owned the API and cut latency 40% with Python.",)),
             ),
@@ -636,6 +648,9 @@ def test_round_trip_audited_bullet_text_equals_rendered_text(tmp_path: Path) -> 
     def voice_fn(request: VoiceRequest) -> VoiceResult:
         return VoiceResult(
             executive_profile="Backend engineer who cut API latency with Python.",
+            executive_profile_sentences=(
+                "Backend engineer who cut API latency with Python.",
+            ),
             experience_bullets=(
                 ("acme_swe", ("Owned the API and cut latency 40% with Python.",)),
             ),
@@ -681,6 +696,9 @@ def test_round_trip_audited_bullet_text_equals_rendered_html_resume(tmp_path: Pa
     def voice_fn(request: VoiceRequest) -> VoiceResult:
         return VoiceResult(
             executive_profile="Backend engineer who cut API latency with Python.",
+            executive_profile_sentences=(
+                "Backend engineer who cut API latency with Python.",
+            ),
             experience_bullets=(
                 ("acme_swe", ("Owned the API and cut latency 40% with Python.",)),
             ),

--- a/workers/automation/tests/test_tailor_voice_audit_integration.py
+++ b/workers/automation/tests/test_tailor_voice_audit_integration.py
@@ -567,6 +567,43 @@ def test_voiced_bullet_is_recorded_as_voice_transform(tmp_path: Path) -> None:
     # The voice audit record is persisted on the set and marked accepted.
     assert saved.voice is not None and saved.voice.ran and saved.voice.accepted
     assert saved.voice.model == "fake-voice-model"
+    assert saved.voice.summary_rejection_reason == ""
+
+
+def test_summary_identity_break_is_recorded_on_the_voice_audit(tmp_path: Path) -> None:
+    """A voiced summary that breaks sentence identity ships the last accepted
+    summary — and the drop is labeled on the voice audit record, never silent,
+    even while the voiced bullets are adopted and the pass reads accepted."""
+
+    def voice_fn(request: VoiceRequest) -> VoiceResult:
+        # Bullets improve the proxies, but the result omits the sentence array,
+        # so the voiced summary cannot prove sentence identity.
+        return VoiceResult(
+            executive_profile="Backend engineer who cut API latency with Python.",
+            executive_profile_sentences=(),
+            experience_bullets=(
+                ("acme_swe", ("Owned the API and cut latency 40% with Python.",)),
+            ),
+        )
+
+    materials_repo = _FakeMaterialsRepo()
+    provenance_repo = _FakeProvenanceRepo()
+    llm = _ScriptedLlm([_payload(_GENERATOR_BULLET, summary=_GENERATOR_SUMMARY), _judge_pass()] * 4)
+    outcome = _use_case(
+        materials_repo, provenance_repo, llm, _RecordingPublisher(), _FunctionVoice(voice_fn)
+    ).execute(job=_job(), profile_snapshot=_snapshot(), tailored_dir=tmp_path)
+
+    assert outcome.status == "approved"
+    saved = provenance_repo.load(LOCAL_TENANT, JOB_ID)
+    assert saved is not None
+    assert saved.voice is not None and saved.voice.ran and saved.voice.accepted
+    assert saved.voice.summary_rejection_reason == "voiced_summary_sentence_count_mismatch"
+    # The last accepted (pre-voice) summary shipped; the bullets are the voiced ones.
+    profile_row = next(row for row in saved.bullets if row.bullet_id == "executive_profile#0")
+    assert "Results-driven" in profile_row.generated_text
+    assert "Backend engineer who cut API latency" not in profile_row.generated_text
+    experience = next(row for row in saved.bullets if row.section == "experience")
+    assert experience.generated_text == "Owned the API and cut latency 40% with Python."
 
 
 def test_voice_introduced_fabrication_is_rejected_and_pre_voice_ships(tmp_path: Path) -> None:

--- a/workers/automation/tests/test_v7_tailor_runtime.py
+++ b/workers/automation/tests/test_v7_tailor_runtime.py
@@ -18,6 +18,7 @@ from jobctrl.domain.materials.analysis import (
     ReasonedKeyword,
     compute_snapshot_hash,
 )
+from jobctrl.domain.materials.use_cases import TailoringPrerequisiteError
 from jobctrl.domain.profile.aggregate import Profile
 from jobctrl.domain.profile.snapshot import ProfileSnapshot
 from jobctrl.domain.tenant import LOCAL_TENANT, TenantId
@@ -220,6 +221,18 @@ def test_tailor_default_runner_fences_cancellation_before_material_or_terminal_w
     """The production runner and default shared UOW retain the cancel fence."""
 
     _seed_job(conn, tenant_id=_TENANT_A, url="https://example.com/canceled-tailor")
+    conn.execute(
+        """
+        INSERT INTO job_requirement_fit_reports (
+            tenant_id, job_id, score_version, employer_analysis_generation,
+            profile_snapshot_version, scoring_policy_version, formula_version,
+            resolved_fit_score, fit_band, confidence, summary_json, created_at
+        ) VALUES (?, ?, 1, 1, 1, 1, 'requirement-fit-v1', 8, 'strong',
+                  'high', '{}', '2026-07-31T12:00:00+00:00')
+        """,
+        (str(_TENANT_A), str(_JOB_ID)),
+    )
+    conn.commit()
     cancel_event = threading.Event()
     llm = _CancelingTailorLlm(cancel_event)
     monkeypatch.setattr(tailor_module, "get_connection", lambda: conn)
@@ -361,6 +374,61 @@ def test_tailor_job_by_id_terminalizes_unhandled_item_exception(
         (str(_TENANT_A), str(_JOB_ID)),
     ).fetchone()
     assert event["event_type"] == "StageFailed"
+
+
+def test_tailor_job_by_id_blocks_stale_requirement_fit_without_consuming_retry(
+    conn: sqlite3.Connection,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _seed_job(conn, tenant_id=_TENANT_A, url="https://example.com/stale-fit")
+    monkeypatch.setattr(tailor_module, "get_connection", lambda: conn)
+    monkeypatch.setattr(tailor_module, "TAILORED_DIR", tmp_path / "tailored")
+    monkeypatch.setattr(tailor_module, "_build_pdf_renderer", lambda: object())
+    monkeypatch.setattr(
+        tailor_module,
+        "_tailor_one_job",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            TailoringPrerequisiteError(
+                reason="requirement_fit_generation_mismatch",
+                job_id=str(_JOB_ID),
+                analysis_generation=2,
+                report_generation=1,
+            )
+        ),
+    )
+
+    result = tailor_module.tailor_job_by_id(
+        _JOB_ID,
+        tenant_id=_TENANT_A,
+        snapshot=SimpleNamespace(),
+        llm_model=None,
+        workflow_id="workflow-run-stale-fit",
+    )
+
+    assert result["status"] == "skipped"
+    assert result["reason"] == "requirement_fit_generation_mismatch"
+    state = conn.execute(
+        "SELECT state, attempt_count, error_code, retryable, blocked_by_json, next_action "
+        "FROM job_stage_states WHERE tenant_id = ? AND job_id = ? AND stage = 'tailor'",
+        (str(_TENANT_A), str(_JOB_ID)),
+    ).fetchone()
+    assert tuple(state) == (
+        "blocked",
+        0,
+        "REQUIREMENT_FIT_STALE",
+        1,
+        '["score"]',
+        "Rescore this job, then run Tailor again.",
+    )
+    event = conn.execute(
+        "SELECT event_type, payload_json FROM job_events "
+        "WHERE tenant_id = ? AND job_id = ? AND stage = 'tailor' "
+        "ORDER BY event_id DESC LIMIT 1",
+        (str(_TENANT_A), str(_JOB_ID)),
+    ).fetchone()
+    assert event["event_type"] == "StageBlocked"
+    assert json.loads(event["payload_json"])["errorCode"] == "REQUIREMENT_FIT_STALE"
 
 
 def test_tailor_job_replay_closes_running_state_from_committed_approved_resume(

--- a/workers/automation/tests/test_v7_tailor_runtime.py
+++ b/workers/automation/tests/test_v7_tailor_runtime.py
@@ -1119,6 +1119,71 @@ def test_legacy_tailor_batch_counts_all_failures_and_exhausts_durable_budget(
     ) == ("exhausted", 5, 0)
 
 
+def test_legacy_tailor_batch_blocks_stale_fit_without_consuming_retry(
+    conn: sqlite3.Connection,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    url = "https://example.com/legacy-batch-stale-fit"
+    _seed_job(conn, tenant_id=LOCAL_TENANT, job_id=_JOB_ID, url=url)
+    job = {
+        "tenant_id": str(LOCAL_TENANT),
+        "job_id": str(_JOB_ID),
+        "url": url,
+        "title": "Platform Engineer",
+        "site": None,
+        "discovered_at": "2026-07-31T12:00:00+00:00",
+    }
+
+    def stale_fit(*_args, **_kwargs) -> dict:
+        raise TailoringPrerequisiteError(
+            reason="requirement_fit_generation_mismatch",
+            job_id=str(_JOB_ID),
+            analysis_generation=2,
+            report_generation=1,
+        )
+
+    monkeypatch.setattr(tailor_module, "get_connection", lambda: conn)
+    monkeypatch.setattr(tailor_module, "get_jobs_by_stage", lambda **_kwargs: [job])
+    monkeypatch.setattr(
+        tailor_module.db_module,
+        "effective_tailoring_min_score",
+        lambda score: score,
+    )
+    monkeypatch.setattr(tailor_module, "TAILORED_DIR", tmp_path / "tailored")
+    monkeypatch.setattr(tailor_module, "_build_pdf_renderer", lambda: object())
+    monkeypatch.setattr(tailor_module, "_tailor_one_job", stale_fit)
+
+    result = tailor_module.run_tailoring(
+        snapshot=SimpleNamespace(),
+        tenant_id=LOCAL_TENANT,
+        llm_model=None,
+    )
+
+    assert result["blocked"] == 1
+    assert result["failed"] == 0
+    assert result["errors"] == 0
+    assert result["exhausted"] == 0
+    state = conn.execute(
+        "SELECT state, attempt_count, error_code, retryable, blocked_by_json "
+        "FROM job_stage_states WHERE tenant_id = ? AND job_id = ? AND stage = 'tailor'",
+        (str(LOCAL_TENANT), str(_JOB_ID)),
+    ).fetchone()
+    assert tuple(state) == (
+        "blocked",
+        0,
+        "REQUIREMENT_FIT_STALE",
+        1,
+        '["score"]',
+    )
+    event = conn.execute(
+        "SELECT event_type FROM job_events WHERE tenant_id = ? AND job_id = ? "
+        "AND stage = 'tailor' ORDER BY event_id DESC LIMIT 1",
+        (str(LOCAL_TENANT), str(_JOB_ID)),
+    ).fetchone()
+    assert event["event_type"] == "StageBlocked"
+
+
 def test_tailor_job_by_id_rejects_deleted_and_url_shaped_targets_before_generation(
     conn: sqlite3.Connection,
     monkeypatch: pytest.MonkeyPatch,

--- a/workers/automation/tests/test_voice_adapter.py
+++ b/workers/automation/tests/test_voice_adapter.py
@@ -84,6 +84,7 @@ def _fake_query(
 def _request() -> VoiceRequest:
     return VoiceRequest(
         executive_profile="Spearheaded robust scalable solutions.",
+        executive_profile_sentences=("Spearheaded robust scalable solutions.",),
         experience_bullets=(("acme", ("Leveraged synergy to drive value.",)),),
         banned_terms=("spearheaded", "robust", "synergy"),
     )
@@ -92,6 +93,9 @@ def _request() -> VoiceRequest:
 def _voiced_structured() -> dict[str, Any]:
     return {
         "executive_profile": "Rebuilt the deploy pipeline so releases dropped to ten minutes.",
+        "executive_profile_sentences": [
+            "Rebuilt the deploy pipeline so releases dropped to ten minutes."
+        ],
         "experience_updates": [
             {"id": "acme", "bullets": ["Cut API latency 40% by batching writes."]}
         ],
@@ -106,6 +110,9 @@ async def test_parses_structured_output_into_voice_result() -> None:
     )
     result = await adapter.rewrite("system", _request())
     assert result.executive_profile.startswith("Rebuilt the deploy pipeline")
+    assert result.executive_profile_sentences == (
+        "Rebuilt the deploy pipeline so releases dropped to ten minutes.",
+    )
     assert result.experience_bullets == (("acme", ("Cut API latency 40% by batching writes.",)),)
 
 
@@ -125,9 +132,13 @@ async def test_passes_voice_schema_empty_tools_and_no_turn_cap() -> None:
     assert opts["setting_sources"] == []
     assert opts["extra_args"] == {"bare": None}
     assert opts["env"]["CLAUDE_CODE_OAUTH_TOKEN"] == ""
-    # The schema is the VoicePayload schema (prose-only: executive_profile + experience).
+    # The schema is the VoicePayload schema (summary sentences + experience prose).
     props = opts["output_format"]["schema"]["properties"]
-    assert "executive_profile" in props and "experience_updates" in props
+    assert {
+        "executive_profile",
+        "executive_profile_sentences",
+        "experience_updates",
+    }.issubset(props)
 
 
 @pytest.mark.asyncio

--- a/workers/automation/tests/test_voice_adapter.py
+++ b/workers/automation/tests/test_voice_adapter.py
@@ -133,12 +133,17 @@ async def test_passes_voice_schema_empty_tools_and_no_turn_cap() -> None:
     assert opts["extra_args"] == {"bare": None}
     assert opts["env"]["CLAUDE_CODE_OAUTH_TOKEN"] == ""
     # The schema is the VoicePayload schema (summary sentences + experience prose).
-    props = opts["output_format"]["schema"]["properties"]
+    schema = opts["output_format"]["schema"]
+    props = schema["properties"]
     assert {
         "executive_profile",
         "executive_profile_sentences",
         "experience_updates",
     }.issubset(props)
+    # The sentence array is REQUIRED with at least one item: a voice model that
+    # omitted it would otherwise silently disable summary voicing forever.
+    assert "executive_profile_sentences" in schema["required"]
+    assert props["executive_profile_sentences"]["minItems"] == 1
 
 
 @pytest.mark.asyncio

--- a/workers/automation/tests/test_voice_payload.py
+++ b/workers/automation/tests/test_voice_payload.py
@@ -20,6 +20,7 @@ from jobctrl.domain.materials.voice import (
 def _payload() -> dict:
     return {
         "executive_profile": "Spearheaded robust solutions.",
+        "executive_profile_sentences": ["Spearheaded robust solutions."],
         "experience_updates": [
             {"id": "acme", "title": "", "bullets": ["Leveraged synergy.", "Drove value."]},
         ],
@@ -30,6 +31,7 @@ def _payload() -> dict:
 def test_build_request_extracts_prose_grouped_by_id() -> None:
     request = build_voice_request(_payload(), banned_terms=("spearheaded",))
     assert request.executive_profile == "Spearheaded robust solutions."
+    assert request.executive_profile_sentences == ("Spearheaded robust solutions.",)
     assert request.experience_bullets == (("acme", ("Leveraged synergy.", "Drove value.")),)
     assert request.banned_terms == ("spearheaded",)
 
@@ -37,10 +39,16 @@ def test_build_request_extracts_prose_grouped_by_id() -> None:
 def test_apply_replaces_prose_and_preserves_skills_and_structure() -> None:
     result = VoiceResult(
         executive_profile="Cut deploy time to ten minutes by rebuilding the pipeline.",
+        executive_profile_sentences=(
+            "Cut deploy time to ten minutes by rebuilding the pipeline.",
+        ),
         experience_bullets=(("acme", ("Cut latency 40%.", "Owned billing end to end.")),),
     )
     voiced = apply_voice_to_payload(_payload(), result)
     assert voiced["executive_profile"].startswith("Cut deploy time")
+    assert voiced["executive_profile_sentences"] == [
+        "Cut deploy time to ten minutes by rebuilding the pipeline."
+    ]
     assert voiced["experience_updates"][0]["bullets"] == [
         "Cut latency 40%.",
         "Owned billing end to end.",
@@ -55,6 +63,7 @@ def test_apply_does_not_mutate_the_input_payload() -> None:
     original = _payload()
     result = VoiceResult(
         executive_profile="Rebuilt the pipeline.",
+        executive_profile_sentences=("Rebuilt the pipeline.",),
         experience_bullets=(("acme", ("A.", "B.")),),
     )
     apply_voice_to_payload(original, result)
@@ -79,11 +88,26 @@ def test_apply_skips_empty_executive_profile() -> None:
     assert voiced["executive_profile"] == "Spearheaded robust solutions."
 
 
+def test_apply_keeps_original_summary_when_sentence_contract_does_not_reconstruct() -> None:
+    result = VoiceResult(
+        executive_profile="Rebuilt the pipeline. Cut deploy time.",
+        executive_profile_sentences=("Rebuilt the pipeline.",),
+        experience_bullets=(),
+    )
+
+    voiced = apply_voice_to_payload(_payload(), result)
+
+    assert voiced["executive_profile"] == "Spearheaded robust solutions."
+    assert voiced["executive_profile_sentences"] == ["Spearheaded robust solutions."]
+
+
 def test_voice_result_from_payload_maps_ids() -> None:
     payload = VoicePayload(
         executive_profile="Voiced summary.",
+        executive_profile_sentences=["Voiced summary."],
         experience_updates=[{"id": "acme", "bullets": ["b1", "b2"]}],
     )
     result = VoiceResult.from_payload(payload)
     assert result.executive_profile == "Voiced summary."
+    assert result.executive_profile_sentences == ("Voiced summary.",)
     assert result.experience_bullets == (("acme", ("b1", "b2")),)

--- a/workers/automation/tests/test_voice_payload.py
+++ b/workers/automation/tests/test_voice_payload.py
@@ -9,11 +9,16 @@ never silently corrupted).
 
 from __future__ import annotations
 
+import pytest
+from pydantic import ValidationError
+
 from jobctrl.domain.materials.voice import (
+    VoicePassRecord,
     VoicePayload,
     VoiceResult,
     apply_voice_to_payload,
     build_voice_request,
+    summary_voice_rejection_reason,
 )
 
 
@@ -99,6 +104,10 @@ def test_apply_keeps_original_summary_when_sentence_contract_does_not_reconstruc
 
     assert voiced["executive_profile"] == "Spearheaded robust solutions."
     assert voiced["executive_profile_sentences"] == ["Spearheaded robust solutions."]
+    assert (
+        summary_voice_rejection_reason(_payload(), result)
+        == "voiced_summary_sentence_join_mismatch"
+    )
 
 
 def test_apply_keeps_original_summary_when_voiced_profile_has_outer_whitespace() -> None:
@@ -112,6 +121,102 @@ def test_apply_keeps_original_summary_when_voiced_profile_has_outer_whitespace()
 
     assert voiced["executive_profile"] == "Spearheaded robust solutions."
     assert voiced["executive_profile_sentences"] == ["Spearheaded robust solutions."]
+    assert (
+        summary_voice_rejection_reason(_payload(), result)
+        == "voiced_summary_sentence_join_mismatch"
+    )
+
+
+@pytest.mark.parametrize(
+    ("result", "expected_reason"),
+    [
+        (
+            VoiceResult(
+                executive_profile="Rebuilt the pipeline.",
+                experience_bullets=(),
+                executive_profile_sentences=("Rebuilt the pipeline.",),
+            ),
+            "",
+        ),
+        (
+            VoiceResult(
+                executive_profile="",
+                experience_bullets=(),
+                executive_profile_sentences=(),
+            ),
+            "voiced_summary_missing",
+        ),
+        (
+            VoiceResult(
+                executive_profile="Rebuilt the pipeline.",
+                experience_bullets=(),
+                executive_profile_sentences=(" Rebuilt the pipeline.",),
+            ),
+            "voiced_summary_sentence_outer_whitespace",
+        ),
+        (
+            VoiceResult(
+                executive_profile="Rebuilt the pipeline.",
+                experience_bullets=(),
+                executive_profile_sentences=(),
+            ),
+            "voiced_summary_sentence_count_mismatch",
+        ),
+        (
+            VoiceResult(
+                executive_profile="Rebuilt the pipeline. Cut deploy time.",
+                experience_bullets=(),
+                executive_profile_sentences=("Rebuilt the pipeline.",),
+            ),
+            "voiced_summary_sentence_join_mismatch",
+        ),
+    ],
+)
+def test_summary_voice_rejection_reason_labels_every_identity_gate_branch(
+    result: VoiceResult, expected_reason: str
+) -> None:
+    """The gate that keeps the last accepted summary is never silent: each branch
+    yields an inspectable reason, and "" means the voiced summary is adopted."""
+    assert summary_voice_rejection_reason(_payload(), result) == expected_reason
+
+    voiced = apply_voice_to_payload(_payload(), result)
+    if expected_reason:
+        assert voiced["executive_profile"] == "Spearheaded robust solutions."
+    else:
+        assert voiced["executive_profile"] == "Rebuilt the pipeline."
+
+
+def test_voice_payload_schema_requires_summary_sentences() -> None:
+    """The SDK output_format uses this schema verbatim: a voice model may not omit
+    the sentence array, or summary voicing would be silently disabled forever."""
+    schema = VoicePayload.model_json_schema()
+
+    assert "executive_profile_sentences" in schema["required"]
+    assert schema["properties"]["executive_profile_sentences"]["minItems"] == 1
+    with pytest.raises(ValidationError):
+        VoicePayload.model_validate({"executive_profile": "x", "experience_updates": []})
+    with pytest.raises(ValidationError):
+        VoicePayload.model_validate(
+            {"executive_profile": "x", "executive_profile_sentences": []}
+        )
+
+
+def test_voice_pass_record_round_trips_summary_rejection_reason() -> None:
+    record = VoicePassRecord(
+        ran=True,
+        accepted=True,
+        summary_rejection_reason="voiced_summary_sentence_count_mismatch",
+    )
+
+    data = record.to_dict()
+    assert data["summary_rejection_reason"] == "voiced_summary_sentence_count_mismatch"
+    rehydrated = VoicePassRecord.from_dict(data)
+    assert rehydrated is not None
+    assert rehydrated.summary_rejection_reason == "voiced_summary_sentence_count_mismatch"
+    # Older persisted records without the key rehydrate to the empty label.
+    legacy = VoicePassRecord.from_dict({"ran": True, "accepted": True})
+    assert legacy is not None
+    assert legacy.summary_rejection_reason == ""
 
 
 def test_voice_result_from_payload_maps_ids() -> None:

--- a/workers/automation/tests/test_voice_payload.py
+++ b/workers/automation/tests/test_voice_payload.py
@@ -101,6 +101,19 @@ def test_apply_keeps_original_summary_when_sentence_contract_does_not_reconstruc
     assert voiced["executive_profile_sentences"] == ["Spearheaded robust solutions."]
 
 
+def test_apply_keeps_original_summary_when_voiced_profile_has_outer_whitespace() -> None:
+    result = VoiceResult(
+        executive_profile=" Rebuilt the pipeline. ",
+        executive_profile_sentences=("Rebuilt the pipeline.",),
+        experience_bullets=(),
+    )
+
+    voiced = apply_voice_to_payload(_payload(), result)
+
+    assert voiced["executive_profile"] == "Spearheaded robust solutions."
+    assert voiced["executive_profile_sentences"] == ["Spearheaded robust solutions."]
+
+
 def test_voice_result_from_payload_maps_ids() -> None:
     payload = VoicePayload(
         executive_profile="Voiced summary.",


### PR DESCRIPTION
## Summary

- block Tailor on Score when requirement-fit evidence is missing, cross-job, or from a different employer-analysis generation
- preserve Tailor retry counters for prerequisite failures and record auditable `StageBlocked` events in both per-job and legacy batch runners
- require exactly one bound claim mapping for every generated summary sentence, experience bullet, and complete rendered skill group
- require the model and voice pass to return an ordered `executive_profile_sentences` array whose exact one-space join reproduces the stored summary
- accept documented aggregate summary aliases only for one-sentence summaries; require indexed mappings for every sentence in multi-sentence summaries and reject extra aggregate mappings
- require exact rendered text for summary, bullet, and skill-group mappings, while rejecting missing, duplicate, partial, and out-of-range mappings before the judge
- reject outer-whitespace normalization and preserve the last accepted summary when voice output breaks sentence identity
- preserve the raw model payload for audit while normalizing only the parsed domain representation
- add end-to-end fixtures proving coherent Score evidence reaches the judge and produces approved material

## Why

Requirement-led Tailoring silently dropped stale fit evidence, built a zero-edge coverage graph, and spent durable retries on candidates that could not pass validation. Coherent jobs could also fail before the judge—or pass with incomplete audit coverage—when generated summary, bullet, and skill mappings did not match the validator's surface contract.

## Validation

- focused final Tailoring contract slice — 118 passed
- `uv --project workers/automation run python -m pytest -q` — 3,371 passed, 2 skipped
- `corepack pnpm check` — passed
- `corepack pnpm docs:build` — passed; 9,651 links resolved
- focused Ruff checks — passed
- independent QA gate — passed with no findings: coverage-bearing aggregate rejection for multi-sentence summaries; indexed multi-sentence and one-sentence aggregate happy paths; byte-exact generator/voice reconstruction; education coverage; prerequisite retry preservation
- `git diff --check` — passed

## Checklist

- [ ] External contributor commits include a DCO `Signed-off-by:` trailer (`git commit -s`).
- [x] I ran the relevant local checks and listed them above.
- [x] I did not include secrets, private profile data, resumes, generated application materials, raw logs, browser profiles, SQLite databases, or local paths.
