### PR TITLE
fix(enrichment): separate content trust from apply readiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,9 +177,11 @@ evidence, qualifications, and the complete capability matrix.
   gateway that honors `robots.txt`, paces each host, bounds each run's request
   budget, and sends an honest `User-Agent` that never impersonates a browser.
   A separately enabled, explicitly consented authenticated LinkedIn profile may
-  recover the full posting and external application URL without applying the
-  anonymous robots verdict; public-destination checks, host pacing, run budgets,
-  audit history, and the no-submission boundary still apply (details in
+  recover the full posting and inspect its application target without applying
+  the anonymous robots verdict. An external URL is stored when one exists;
+  LinkedIn on-site apply and other unresolved-target cases receive distinct,
+  auditable reasons. Public-destination checks, host pacing, run budgets, audit
+  history, and the no-submission boundary still apply (details in
   [Local Data And Safety](#local-data-and-safety)).
 - Capture a current browser job page through the optional local browser
   extension, which feeds the existing manual-capture import path.
@@ -454,9 +456,13 @@ before content extraction or LLM enrichment. JobCtrl does not evade login,
 paywall, CAPTCHA, rate-limit, or bot-control gates. The one explicit carve-out
 is owner-authenticated LinkedIn recovery: after the capability is enabled and a
 profile copy is separately consented, JobCtrl may use that existing session to
-recover the full posting and external application URL without applying the
-anonymous robots verdict. It retains public-route validation, pacing, request
-budgets, and audit history, and it cannot submit an application.
+recover the full posting and inspect its application target without applying
+the anonymous robots verdict. It records whether an external URL was recovered,
+LinkedIn owns the application flow, the control or external target was missing,
+navigation failed, or the target was unsafe. Missing an external URL does not
+downgrade a readable posting or block Tailor. The recovery retains public-route
+validation, pacing, request budgets, and audit history, and it cannot submit an
+application.
 
 ### Back Up And Restore
 

--- a/apps/api/src/projections.ts
+++ b/apps/api/src/projections.ts
@@ -20,8 +20,9 @@
  * refresher reads the projection table directly and no longer
  * materialises it.
  */
-import { PROJECTION_WATERMARK_NAME, STAGES } from "./contracts.js";
+import { APPLY_URL_OUTCOME_CODES, PROJECTION_WATERMARK_NAME, STAGES } from "./contracts.js";
 import type {
+  ApplyUrlOutcomeCode,
   JobCompensationAuditMarketResponse,
   JobCompensationAuditPostedResponse,
   MarketCompensationEstimateResponse,
@@ -2366,6 +2367,14 @@ interface StageRow extends Record<string, unknown> {
   retryable: number | null;
   blocked_by_json: string | null;
   next_action: string | null;
+  metadata_json: string | null;
+}
+
+interface NormalizedApplyUrlOutcome {
+  code: ApplyUrlOutcomeCode;
+  message: string;
+  retryable: boolean;
+  method: string | null;
 }
 
 interface NormalizedStage {
@@ -2382,6 +2391,79 @@ interface NormalizedStage {
   retryable: boolean;
   blocked_by: string[];
   next_action: string | null;
+  apply_url_outcome: NormalizedApplyUrlOutcome | null;
+}
+
+const APPLY_URL_OUTCOME_DETAILS: Readonly<
+  Record<ApplyUrlOutcomeCode, { message: string; retryable: boolean }>
+> = {
+  APPLY_URL_EXTERNAL_RECOVERED: {
+    message: "An external application URL was recovered.",
+    retryable: false,
+  },
+  APPLY_URL_LINKEDIN_ONSITE: {
+    message:
+      "LinkedIn uses an on-site application flow for this posting; no external application URL exists.",
+    retryable: false,
+  },
+  APPLY_URL_CONTROL_MISSING: {
+    message: "No application control was visible on the authenticated LinkedIn page.",
+    retryable: true,
+  },
+  APPLY_URL_EXTERNAL_TARGET_MISSING: {
+    message: "An application control was visible, but no external application URL could be verified.",
+    retryable: true,
+  },
+  APPLY_URL_NAVIGATION_FAILED: {
+    message: "The authenticated LinkedIn page could not be inspected.",
+    retryable: true,
+  },
+  APPLY_URL_UNSAFE_TARGET: {
+    message:
+      "JobCtrl rejected the discovered application target because it is not a safe public HTTP(S) destination.",
+    retryable: false,
+  },
+};
+const APPLY_URL_OUTCOME_CODE_SET = new Set<string>(APPLY_URL_OUTCOME_CODES);
+const APPLY_URL_OUTCOME_METHODS = new Set([
+  "authenticated_browser",
+  "current_url",
+  "href_redirect",
+  "href",
+  "click",
+  "linkedin_onsite_apply",
+  "apply_button_missing",
+  "external_url_missing",
+  "navigation_error",
+  "resolver_error",
+  "unsafe_url",
+]);
+
+function applyUrlOutcomeFromStageMetadata(value: string | null): NormalizedApplyUrlOutcome | null {
+  if (!value) return null;
+  let metadata: unknown;
+  try {
+    metadata = JSON.parse(value);
+  } catch {
+    return null;
+  }
+  if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) return null;
+  const record = metadata as Record<string, unknown>;
+  const codeValue =
+    typeof record.applyUrlOutcomeCode === "string" ? record.applyUrlOutcomeCode.trim() : "";
+  if (!APPLY_URL_OUTCOME_CODE_SET.has(codeValue)) return null;
+  const code = codeValue as ApplyUrlOutcomeCode;
+  const details = APPLY_URL_OUTCOME_DETAILS[code];
+  const methodValue =
+    typeof record.authenticatedApplyUrlMethod === "string"
+      ? record.authenticatedApplyUrlMethod.trim()
+      : "";
+  return {
+    code,
+    message: details.message,
+    retryable: details.retryable,
+    method: APPLY_URL_OUTCOME_METHODS.has(methodValue) ? methodValue : null,
+  };
 }
 
 function loadStages(db: SqliteDatabase, tenantId: string, jobId: string): NormalizedStage[] {
@@ -2412,6 +2494,7 @@ function loadStages(db: SqliteDatabase, tenantId: string, jobId: string): Normal
         retryable: true,
         blocked_by: [],
         next_action: null,
+        apply_url_outcome: null,
       };
     }
     let blockedBy: string[] = [];
@@ -2440,6 +2523,7 @@ function loadStages(db: SqliteDatabase, tenantId: string, jobId: string): Normal
       retryable: row.retryable === null || row.retryable === undefined ? true : Boolean(row.retryable),
       blocked_by: blockedBy,
       next_action: nullableString(row.next_action),
+      apply_url_outcome: applyUrlOutcomeFromStageMetadata(row.metadata_json),
     };
   });
 }

--- a/apps/api/src/read-model.ts
+++ b/apps/api/src/read-model.ts
@@ -22,6 +22,7 @@ import type {
   ActivityEventSummary,
   ActivityListQuery,
   ActiveState,
+  ApplyUrlOutcomeCode,
   ArtifactDetail,
   ArtifactListQuery,
   ArtifactSummary,
@@ -66,6 +67,7 @@ import type {
   WorkflowRunsListQuery,
 } from "./contracts.js";
 import {
+  APPLY_URL_OUTCOME_CODES,
   DIGEST_DAY_BOUNDARY,
   DIGEST_FOLLOW_UP_THRESHOLD_DAYS,
   PIPELINE_RUN_STAGES,
@@ -88,6 +90,7 @@ import { readWorkerHealth } from "./worker-health.js";
 import { readJobCtrlSettings } from "./settings-config.js";
 
 const DEFAULT_TENANT = "local";
+const APPLY_URL_OUTCOME_CODE_SET = new Set<string>(APPLY_URL_OUTCOME_CODES);
 const DEFAULT_PROFILE_ID = "default";
 const CANONICAL_JOB_ID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
 const CLOSED_ACTIVE_STATES = ["closed", "expired", "removed", "location_incompatible"] as const satisfies readonly ActiveState[];
@@ -4521,9 +4524,26 @@ function parseStages(stagesJson: string | undefined): StageSummary[] {
       retryable: item.retryable === undefined || item.retryable === null ? true : Boolean(item.retryable),
       blockedBy: Array.isArray(item.blocked_by) ? item.blocked_by.map((it) => String(it)) : [],
       nextAction: nullableString(item.next_action),
+      applyUrlOutcome: parseApplyUrlOutcome(item.apply_url_outcome),
     });
   }
   return STAGES.map((stage) => byStage.get(stage) ?? defaultStage(stage, "pending"));
+}
+
+function parseApplyUrlOutcome(
+  value: unknown,
+): NonNullable<StageSummary["applyUrlOutcome"]> | null {
+  if (!isRecord(value)) return null;
+  const codeValue = nullableString(value.code);
+  const message = nullableString(value.message);
+  if (!codeValue || !APPLY_URL_OUTCOME_CODE_SET.has(codeValue) || !message) return null;
+  const code = codeValue as ApplyUrlOutcomeCode;
+  return {
+    code,
+    message,
+    retryable: value.retryable === true,
+    method: nullableString(value.method),
+  };
 }
 
 function reconcileStageRetryability(
@@ -4583,6 +4603,7 @@ function defaultStage(stage: Stage, state: StageState, errorMessage = ""): Stage
     retryable: state !== "blocked",
     blockedBy: [],
     nextAction: null,
+    applyUrlOutcome: null,
   };
 }
 

--- a/apps/api/test/audit-projection-parity.test.ts
+++ b/apps/api/test/audit-projection-parity.test.ts
@@ -228,12 +228,14 @@ function seedRows(dbPath: string): void {
     `INSERT INTO job_stage_states (
        job_id, stage, state, attempt_count, max_attempts, started_at, updated_at,
        finished_at, duration_ms, error_code, error_message, retryable,
-       blocked_by_json, next_action
+       blocked_by_json, next_action, metadata_json
      ) VALUES (@job_id, @stage, @state, @attempt_count, @max_attempts, @started_at, @updated_at,
        @finished_at, @duration_ms, @error_code, @error_message, @retryable,
-       @blocked_by_json, @next_action)`,
+       @blocked_by_json, @next_action, @metadata_json)`,
   );
-  for (const stage of fixture.rows.jobStageStates) insertStage.run({ job_id: jobId, ...stage });
+  for (const stage of fixture.rows.jobStageStates) {
+    insertStage.run({ job_id: jobId, metadata_json: null, ...stage });
+  }
 
   const insertAnalysis = db.prepare(
     `INSERT INTO job_employer_analysis (

--- a/apps/api/test/discovery-controls.test.ts
+++ b/apps/api/test/discovery-controls.test.ts
@@ -148,6 +148,55 @@ describe("discovery product controls API", () => {
     }
   });
 
+  it("preserves posting-inactive as an explicit quarantine reason", async () => {
+    const { dbPath, dir, cleanup } = withTempDb();
+    const app = buildApp(options(dbPath, dir));
+    try {
+      const db = new Database(dbPath);
+      insertExactV7Job(
+        db,
+        QUARANTINE_JOB_ID,
+        "https://example.com/jobs/inactive",
+        "Inactive Lead",
+      );
+      db.prepare(
+        `INSERT INTO discovery_quarantine_entries (
+           tenant_id, job_id, title, company, source_id, posting_url,
+           reason, confidence, snapshot_version, captured_at, notice_text, status
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      ).run(
+        "local",
+        QUARANTINE_JOB_ID,
+        "Inactive Lead",
+        "ExampleCo",
+        "example:inactive",
+        "https://example.com/jobs/inactive",
+        "posting_inactive",
+        0.7,
+        1,
+        "2026-05-12T09:00:00+00:00",
+        null,
+        "pending",
+      );
+      db.close();
+
+      const response = await app.inject({
+        method: "GET",
+        url: "/v1/discovery/quarantine",
+      });
+      expect(response.statusCode, response.body).toBe(200);
+      expect(response.json().entries).toEqual([
+        expect.objectContaining({
+          jobId: QUARANTINE_JOB_ID,
+          reason: "posting_inactive",
+        }),
+      ]);
+    } finally {
+      await app.close();
+      cleanup();
+    }
+  });
+
   it("upserts source registry entries and emits source registry events", async () => {
     const { dbPath, dir, cleanup } = withTempDb();
     const app = buildApp(options(dbPath, dir));

--- a/apps/api/test/projections.test.ts
+++ b/apps/api/test/projections.test.ts
@@ -832,6 +832,108 @@ describe("apply_run_projections without legacy apply_runs table", () => {
     }
   });
 
+  it.each([
+    [
+      "APPLY_URL_EXTERNAL_RECOVERED",
+      "An external application URL was recovered.",
+      false,
+      "click",
+    ],
+    [
+      "APPLY_URL_LINKEDIN_ONSITE",
+      "LinkedIn uses an on-site application flow for this posting; no external application URL exists.",
+      false,
+      "linkedin_onsite_apply",
+    ],
+    [
+      "APPLY_URL_CONTROL_MISSING",
+      "No application control was visible on the authenticated LinkedIn page.",
+      true,
+      "apply_button_missing",
+    ],
+    [
+      "APPLY_URL_EXTERNAL_TARGET_MISSING",
+      "An application control was visible, but no external application URL could be verified.",
+      true,
+      "external_url_missing",
+    ],
+    [
+      "APPLY_URL_NAVIGATION_FAILED",
+      "The authenticated LinkedIn page could not be inspected.",
+      true,
+      "navigation_error",
+    ],
+    [
+      "APPLY_URL_UNSAFE_TARGET",
+      "JobCtrl rejected the discovered application target because it is not a safe public HTTP(S) destination.",
+      false,
+      "unsafe_url",
+    ],
+  ])(
+    "projects allow-listed outcome %s independently of Enrich success",
+    async (code, message, retryable, method) => {
+      const { dbPath, cleanup } = withTempDb();
+      try {
+        seedSchema(dbPath);
+        const db = new Database(dbPath);
+        db.prepare(
+          `INSERT INTO job_stage_states (
+             tenant_id, job_id, stage, state, updated_at, finished_at, metadata_json
+           ) VALUES ('local', ?, 'enrich', 'succeeded', ?, ?, ?)
+           ON CONFLICT(tenant_id, job_id, stage) DO UPDATE SET
+             state = excluded.state,
+             updated_at = excluded.updated_at,
+             finished_at = excluded.finished_at,
+             metadata_json = excluded.metadata_json`,
+        ).run(
+          EVENT_JOB_ID,
+          "2026-05-04T13:05:00+00:00",
+          "2026-05-04T13:05:00+00:00",
+          JSON.stringify({
+            authenticatedApplyUrlMethod: method,
+            authenticatedApplyUrlError: "/private/path/must-not-project",
+            applyUrlOutcomeCode: code,
+            applyUrlOutcomeMessage: `${message} /private/path/must-not-project`,
+            applyUrlOutcomeRetryable: !retryable,
+          }),
+        );
+        db.close();
+
+        const app = buildApp({
+          dbPath,
+          configPath: path.join(path.dirname(dbPath), "config.json"),
+        });
+        try {
+          const response = await app.inject({
+            method: "GET",
+            url: `/v1/jobs/${encodeURIComponent(EVENT_JOB_URL)}`,
+          });
+          expect(response.statusCode, response.body).toBe(200);
+          const enrich = response
+            .json()
+            .stages.find((stage: { stage: string }) => stage.stage === "enrich");
+          expect(enrich).toMatchObject({
+            state: "succeeded",
+            applyUrlOutcome: {
+              code,
+              message,
+              retryable,
+              method,
+            },
+          });
+          expect(JSON.stringify(enrich)).not.toContain("/private/path");
+          expect(JSON.stringify(enrich)).not.toContain(
+            "authenticatedApplyUrlError",
+          );
+        } finally {
+          await app.close();
+        }
+      } finally {
+        cleanup();
+      }
+    },
+  );
+
   it("refreshes stale stage projections after workflow-scoped stage events", async () => {
     const { dbPath, cleanup } = withTempDb();
     const jobUrl = "https://example.com/jobs/event-driven";

--- a/apps/web/src/contexts/pipeline/components/StageTimeline.test.tsx
+++ b/apps/web/src/contexts/pipeline/components/StageTimeline.test.tsx
@@ -167,6 +167,75 @@ describe("<StageTimeline>", () => {
     expect(screen.queryByText(/jobctrl retry enrich/i)).not.toBeInTheDocument();
   });
 
+  it.each([
+    [
+      "APPLY_URL_EXTERNAL_RECOVERED",
+      "An external application URL was recovered.",
+      false,
+      "click",
+    ],
+    [
+      "APPLY_URL_LINKEDIN_ONSITE",
+      "LinkedIn uses an on-site application flow for this posting; no external application URL exists.",
+      false,
+      "linkedin_onsite_apply",
+    ],
+    [
+      "APPLY_URL_CONTROL_MISSING",
+      "No application control was visible on the authenticated LinkedIn page.",
+      true,
+      "apply_button_missing",
+    ],
+    [
+      "APPLY_URL_EXTERNAL_TARGET_MISSING",
+      "An application control was visible, but no external application URL could be verified.",
+      true,
+      "external_url_missing",
+    ],
+    [
+      "APPLY_URL_NAVIGATION_FAILED",
+      "The authenticated LinkedIn page could not be inspected.",
+      true,
+      "navigation_error",
+    ],
+    [
+      "APPLY_URL_UNSAFE_TARGET",
+      "JobCtrl rejected the discovered application target because it is not a safe public HTTP(S) destination.",
+      false,
+      "unsafe_url",
+    ],
+  ] as const)(
+    "shows %s as an explicit non-blocking Enrich outcome",
+    async (code, message, retryable, method) => {
+      const user = userEvent.setup();
+      renderWithProviders(
+        <StageTimeline
+          stages={[
+            {
+              ...makeStage("enrich", "succeeded"),
+              applyUrlOutcome: { code, message, retryable, method },
+            },
+          ]}
+        />,
+      );
+
+      expect(screen.getByText("succeeded", { exact: true })).toBeInTheDocument();
+      const applicationTarget = screen.getByText(message).closest("p");
+      expect(applicationTarget).not.toBeNull();
+      expect(applicationTarget!).toHaveTextContent("Application target:");
+      expect(screen.queryByText("blocked", { exact: true })).not.toBeInTheDocument();
+      await user.click(
+        screen.getByRole("button", { name: "Technical details" }),
+      );
+      const diagnostics = screen.getByLabelText("enrich diagnostics");
+      expect(diagnostics).toHaveTextContent(code);
+      expect(diagnostics).toHaveTextContent(method);
+      expect(diagnostics).toHaveTextContent(
+        retryable ? /automatic retry\s*available/ : /automatic retry\s*not automatic/,
+      );
+    },
+  );
+
   it("explains a robots block and offers audited manual capture for the posting", async () => {
     const user = userEvent.setup();
     const postingUrl = "https://www.linkedin.com/jobs/view/123";

--- a/apps/web/src/contexts/pipeline/components/StageTimeline.tsx
+++ b/apps/web/src/contexts/pipeline/components/StageTimeline.tsx
@@ -54,6 +54,15 @@ export function StageTimeline({
               </span>
               <StageBadge state={stage.state} />
             </div>
+            {stage.stage === "enrich" && stage.applyUrlOutcome ? (
+              <p
+                className="stage-timeline__apply-outcome"
+                data-typography="body"
+              >
+                <strong>Application target:</strong>{" "}
+                {stage.applyUrlOutcome.message}
+              </p>
+            ) : null}
             {guidance ? (
               <Alert className="stage-timeline__guidance">
                 <IconAlertTriangle aria-hidden="true" />
@@ -257,26 +266,37 @@ function stageLabel(stage: StageSummary["stage"]): string {
 }
 
 function stageDiagnostics(stage: StageSummary): Array<[string, string]> {
-  if (!["failed", "exhausted", "blocked"].includes(stage.state)) return [];
   const diagnostics: Array<[string, string]> = [];
-  if (stage.errorCode) diagnostics.push(["code", stage.errorCode]);
-  if (stage.errorMessage) diagnostics.push(["message", stage.errorMessage]);
-  if (stage.attemptCount || stage.maxAttempts) {
+  if (["failed", "exhausted", "blocked"].includes(stage.state)) {
+    if (stage.errorCode) diagnostics.push(["code", stage.errorCode]);
+    if (stage.errorMessage) diagnostics.push(["message", stage.errorMessage]);
+    if (stage.attemptCount || stage.maxAttempts) {
+      diagnostics.push([
+        "attempts",
+        `${stage.attemptCount}/${stage.maxAttempts}`,
+      ]);
+    }
+    if (stage.durationMs !== null) {
+      diagnostics.push(["duration", formatDuration(stage.durationMs)]);
+    }
+    if (stage.blockedBy.length) {
+      diagnostics.push(["blocked by", stage.blockedBy.join(", ")]);
+    }
+    if (["failed", "exhausted"].includes(stage.state)) {
+      diagnostics.push([
+        "retry",
+        stage.retryable ? "available" : "not automatic",
+      ]);
+    }
+  }
+  if (stage.stage === "enrich" && stage.applyUrlOutcome) {
+    diagnostics.push(["application target code", stage.applyUrlOutcome.code]);
+    if (stage.applyUrlOutcome.method) {
+      diagnostics.push(["recovery method", stage.applyUrlOutcome.method]);
+    }
     diagnostics.push([
-      "attempts",
-      `${stage.attemptCount}/${stage.maxAttempts}`,
-    ]);
-  }
-  if (stage.durationMs !== null) {
-    diagnostics.push(["duration", formatDuration(stage.durationMs)]);
-  }
-  if (stage.blockedBy.length) {
-    diagnostics.push(["blocked by", stage.blockedBy.join(", ")]);
-  }
-  if (["failed", "exhausted"].includes(stage.state)) {
-    diagnostics.push([
-      "retry",
-      stage.retryable ? "available" : "not automatic",
+      "automatic retry",
+      stage.applyUrlOutcome.retryable ? "available" : "not automatic",
     ]);
   }
   return diagnostics;

--- a/apps/web/src/styles/redesign-job-detail.css
+++ b/apps/web/src/styles/redesign-job-detail.css
@@ -692,6 +692,17 @@
   margin-top: 1px;
 }
 
+:is(.job-detail-drawer, .job-detail-workspace) .stage-timeline__apply-outcome {
+  margin: 0;
+  color: var(--muted-foreground);
+}
+
+:is(.job-detail-drawer, .job-detail-workspace)
+  .stage-timeline__apply-outcome
+  strong {
+  color: var(--foreground);
+}
+
 :is(.job-detail-drawer, .job-detail-workspace)
   .stage-timeline__diagnostic-disclosure {
   min-width: 0;

--- a/docs/api/jobs-and-materials.md
+++ b/docs/api/jobs-and-materials.md
@@ -21,6 +21,14 @@ For field-level schemas and every route variant, use the
 List and detail endpoints read projection rows. They do not recompute scores,
 parse salary text, or replay events during a request.
 
+Each job-detail stage may include an optional `applyUrlOutcome` object with the
+allow-listed `code`, user-facing `message`, `retryable`, and resolver `method`
+fields. It is populated on Enrich when application-target discovery has an
+auditable result. The object is independent of the Enrich stage state: a
+LinkedIn on-site application flow is a successful terminal outcome even though
+there is no external URL. Raw resolver errors and browser-local paths are not
+projected.
+
 `jobKey` resolves at the browser API boundary to the tenant-scoped stable
 `JobId`. Canonical clients send that ID; the explicit API/import boundary may
 also accept a posting or application URL as an external locator and resolve it

--- a/docs/architecture/pipeline/operations.md
+++ b/docs/architecture/pipeline/operations.md
@@ -223,9 +223,13 @@ concurrent trigger attaches to the active execution, while a later resolution
 episode may reuse the identity after it closes. These continuations use the
 normal idempotent workflow path and do not rerun Discover.
 A low-confidence posting keeps Tailor explicitly `blocked` by Enrich rather
-than leaving it as unexplained `pending`; when authenticated apply-URL recovery
-produces a trustworthy snapshot, Enrich resets that exact condition-blocked
-Tailor row to `pending` before the continuation reaches it.
+than leaving it as unexplained `pending`. Description trust and application-
+target readiness are independent: a missing external application URL alone
+cannot create this blocker. For legacy rows where it did, Enrich appends a
+corrected immutable snapshot and resets that exact condition-blocked Tailor row
+to `pending` before any optional authenticated URL lookup. LinkedIn on-site
+apply is persisted as a terminal target-readiness outcome rather than retried as
+a generic unresolved URL.
 
 Score, Tailor, and Cover stage rows record the Temporal run ID that owns every
 `running` write. Rescore/retailor rows also preserve the score version or

--- a/docs/architecture/pipeline/stages.md
+++ b/docs/architecture/pipeline/stages.md
@@ -158,7 +158,7 @@ sequenceDiagram
     Run->>Fetch: fetch posting detail pages
     Fetch->>DB: full description, apply URL, attempts/errors
     Run->>Chrome: LinkedIn misses -> authenticated pass
-    Chrome->>DB: external company apply URL (stops before submission)
+    Chrome->>DB: external URL or explicit no-external-URL outcome
     Enr->>DB: StageCompleted/StageFailed + PostingContentSnapshotCaptured, projections refresh
 ```
 
@@ -180,7 +180,12 @@ For LinkedIn rows that are failed or enriched without an application URL, a
 bounded authenticated Chrome pass may click the LinkedIn apply control to
 capture an external company URL **only when the separately enabled, explicitly
 consented authenticated-LinkedIn browser capability is ready** — and it **stops
-before any form or submission**.
+before any form or submission**. A LinkedIn on-site application control is a
+terminal, non-retryable result: the application flow exists, but there is no
+external ATS URL to capture. Missing controls, missing external targets,
+navigation failures, and unsafe targets retain separate auditable codes and
+retry policies. These application-target outcomes do not determine description
+confidence and cannot quarantine otherwise trustworthy posting content.
 Detail enrichment isolates faults at two levels. A crash while processing one
 site's batch is recorded in `site_errors`, healthy sites keep running, and the
 enrichment run ends `partial` rather than `failed`. Within a site, a single

--- a/docs/local-reliability-qa.md
+++ b/docs/local-reliability-qa.md
@@ -254,6 +254,13 @@ The gate must also prove that no feedback decision or restore automatically
 starts scoring, tailoring, Apply, or artifact work. Do not perform a real
 application submission or mutate a real user database during this QA.
 
+The same product path must prove that a successful Enrich row can display an
+explicit non-blocking application-target outcome, including LinkedIn on-site
+apply, and that its technical details expose only the allow-listed outcome
+rather than raw resolver metadata. The regression fixtures must cover every
+application-target outcome, redact a resolver error containing a private local
+path, and repair a legacy non-LinkedIn snapshot without browser navigation.
+
 The browser-local public demo may cover realtime state preservation, but its
 learning capabilities are intentionally unavailable. Recommendation review,
 policy acceptance/rejection, and rollback must therefore run through the seeded

--- a/docs/local-ts-api.md
+++ b/docs/local-ts-api.md
@@ -63,6 +63,11 @@ The jobs list and detail routes read stable projections. Lifecycle changes—hid
 restore, delete, score correction, stage retry, and per-job actions—are explicit
 commands. See [Jobs & Materials](api/jobs-and-materials.md).
 
+On job detail, Enrich stage summaries can carry a separate, allow-listed
+`applyUrlOutcome` (`code`, `message`, `retryable`, and `method`). It reports
+application-target readiness without changing posting-content trust or stage
+success; raw browser/resolver errors are not exposed.
+
 Internal list/detail identity is the tenant-scoped stable `JobId`; posting URLs
 are locators resolved only at explicit import or API boundaries. Employer and
 Source remain independent facts. `GET /v1/scoring/keywords` aggregates indexed,

--- a/docs/user/enrichment-and-extraction.md
+++ b/docs/user/enrichment-and-extraction.md
@@ -53,6 +53,26 @@ A failed fetch or exhausted cascade records a retryable attempt without
 manufacturing a snapshot. Failure remains isolated to that job, so useful
 results from the rest of the source batch survive.
 
+Application-target discovery has its own explicit outcome and retry policy:
+
+| Outcome | What it means | Automatic retry |
+| --- | --- | --- |
+| External URL recovered | A public external application destination was verified and stored. | No |
+| LinkedIn on-site apply | LinkedIn owns the application flow, so no external ATS URL exists. | No |
+| Application control missing | No visible application control was found on the authenticated posting page. | Yes |
+| External target missing | An application control was visible, but no external destination could be verified. | Yes |
+| Navigation failed | The authenticated posting page could not be inspected. | Yes |
+| Unsafe target rejected | The discovered destination failed the public-URL safety check. | No |
+
+These outcomes describe application readiness; they do not change the posting
+snapshot's content confidence. LinkedIn on-site apply is a successful terminal
+discovery, while transient inspection failures remain eligible for recovery.
+When an older snapshot was quarantined only because it lacked an application
+URL, the next Enrich maintenance pass appends a corrected snapshot for any
+source and resumes Tailor without requiring browser access. Resolver exception
+details remain local diagnostics; the product surfaces only the stable outcome
+code, message, method, and retry policy.
+
 ## What You Can See And Control
 
 Enrichment is internal work under the user-facing **Discover** stage, not a
@@ -62,7 +82,8 @@ separate primary page or pipeline stage. Its results remain inspectable:
   active, closed, failed, or awaiting further work.
 - `/jobs/:jobId` opens the Job Detail route workspace with the full posting,
   source and enrichment evidence, snapshot confidence or quarantine state,
-  application URL, and allow-listed audit history.
+  application URL, an explicit application-target outcome even when Enrich
+  succeeded, and allow-listed audit history.
 - `/discovery` owns source review, quarantined leads, locator candidates, and
   manual-capture decisions.
 - `/runs` shows the durable Discover and preparation workflows. A failed

--- a/docs/user/enrichment-and-extraction.md
+++ b/docs/user/enrichment-and-extraction.md
@@ -24,22 +24,26 @@ posting detail to use it.” The current decision path is:
 2. **Verify active state independently.** Extraction quality and whether the job
    still appears active are separate findings, so a well-extracted but
    unverifiable posting is not silently treated as active.
-3. **Assign confidence from the extraction evidence.** Description length,
-   extraction tier, and presence of an application URL determine the current
-   bucket:
+3. **Assign confidence from the posting-content evidence.** Description length
+   and extraction tier determine whether the posting text is trustworthy. An
+   application URL can strengthen structured extraction, but its absence never
+   downgrades an otherwise complete description:
 
    | Extraction result | High | Medium | Low |
    | --- | --- | --- | --- |
    | JSON-LD | Application URL and at least 200 characters | At least 200 characters without the URL | Fewer than 200 characters |
    | CSS selectors | Application URL and at least 400 characters | At least 200 characters | Fewer than 200 characters |
-   | LLM-assisted | — | Application URL and at least 400 characters | Every other result |
+   | LLM-assisted | — | At least 400 characters, with or without an application URL | Fewer than 400 characters |
    | Other configured tier | — | At least 200 characters | Fewer than 200 characters |
 
-4. **Quarantine instead of guessing.** Unknown active state, low confidence
-   without an override, or an active posting with no application URL is held for
-   review. An explicit operator override can admit a low-confidence or
-   URL-missing snapshot and is persisted with the audit trail; unknown active
-   state remains quarantined.
+4. **Quarantine instead of guessing.** Unknown active state or low content
+   confidence without an override is held for review. An explicit operator
+   override can admit a low-confidence snapshot and is persisted with the audit
+   trail; unknown active state remains quarantined. Application-target readiness
+   is a separate fact, so a missing external application URL cannot quarantine
+   readable posting content or block Tailor. A posting verified as closed,
+   expired, or removed is recorded separately as `posting_inactive` rather than
+   mislabeled as a low-confidence extraction.
 5. **Surface duplicate candidates from content evidence.** An exact description
    hash is a `1.0` signal, the same normalized application URL is `0.95`, and
    token-Jaccard content similarity must reach `0.85`. These signals propose a
@@ -87,9 +91,30 @@ and consent ownership remains documented under
 When that capability becomes fully ready, JobCtrl immediately continues the
 browser-conditioned Enrich → Score → Tailor → Cover path for the affected
 LinkedIn jobs only; unrelated robots blocks and ordinary pending jobs are not
-retriggered, and another Discover run is not required. A successfully recovered apply URL creates a new immutable posting
-snapshot version, recomputes confidence, and clears a low-confidence quarantine
-only when the new evidence passes the same quality policy.
+retriggered, and another Discover run is not required. Legacy snapshots that
+coupled readable content to a missing application URL are repaired by appending
+a new immutable snapshot version and releasing only the stale
+`ENRICHMENT_QUARANTINED` Tailor blocker. This content-trust repair does not need
+a browser navigation and does not invent an application URL. A successfully
+recovered external URL also creates a new immutable snapshot version.
+
+Authenticated Apply-URL inspection records one explicit outcome instead of a
+generic “unresolved” message:
+
+| Outcome | Meaning | Automatic retry |
+| --- | --- | --- |
+| External URL recovered | LinkedIn points to a verified public company or ATS URL. | No further lookup needed |
+| LinkedIn on-site apply | LinkedIn owns the application flow, so no external URL exists. | No |
+| Apply control missing | The authenticated page did not expose an application control. | Yes, within the bounded recovery budget |
+| External target missing | A control was visible, but no external URL could be verified. | Yes, within the bounded recovery budget |
+| Navigation failed | The authenticated page could not be inspected. | Yes, within the bounded recovery budget |
+| Unsafe target | The discovered target failed JobCtrl's public-URL safety policy. | No |
+
+The outcome code, plain-language reason, resolver method, and retryability are
+kept in Enrich stage metadata and append-only job events. “LinkedIn on-site
+apply” is a successful terminal discovery about target readiness, not an
+Enrichment or Tailor failure. JobCtrl still stops before any application form or
+submission.
 
 ## Source Of Truth And Ownership
 

--- a/packages/contracts/src/schemas.ts
+++ b/packages/contracts/src/schemas.ts
@@ -2634,6 +2634,16 @@ export interface WorkflowRunDetail {
   readonly events: readonly WorkflowRunTimelineEvent[];
 }
 
+export const APPLY_URL_OUTCOME_CODES = [
+  "APPLY_URL_EXTERNAL_RECOVERED",
+  "APPLY_URL_LINKEDIN_ONSITE",
+  "APPLY_URL_CONTROL_MISSING",
+  "APPLY_URL_EXTERNAL_TARGET_MISSING",
+  "APPLY_URL_NAVIGATION_FAILED",
+  "APPLY_URL_UNSAFE_TARGET",
+] as const;
+export type ApplyUrlOutcomeCode = (typeof APPLY_URL_OUTCOME_CODES)[number];
+
 export interface StageSummary {
   stage: Stage;
   state: StageState;
@@ -2648,6 +2658,17 @@ export interface StageSummary {
   retryable: boolean;
   blockedBy: string[];
   nextAction: string | null;
+  /**
+   * Allow-listed application-target readiness fact captured by Enrichment.
+   * This stays separate from stage failure state because LinkedIn on-site
+   * apply is a successful terminal discovery, not an Enrich failure.
+  */
+  applyUrlOutcome?: {
+    code: ApplyUrlOutcomeCode;
+    message: string;
+    retryable: boolean;
+    method: string | null;
+  } | null;
 }
 
 export interface ScoreBreakdown {
@@ -5149,6 +5170,7 @@ export const QUARANTINE_REASONS = [
   "policy_overridden",
   "broad_board_only",
   "unknown_active_state",
+  "posting_inactive",
   "user_review_requested",
 ] as const;
 export type QuarantineReason = (typeof QUARANTINE_REASONS)[number];

--- a/packages/domain-types/test/fixtures/audit_projection_parity.json
+++ b/packages/domain-types/test/fixtures/audit_projection_parity.json
@@ -60,7 +60,8 @@
         "error_message": null,
         "retryable": 1,
         "blocked_by_json": null,
-        "next_action": null
+        "next_action": null,
+        "metadata_json": "{\"applyUrlOutcomeCode\":\"APPLY_URL_LINKEDIN_ONSITE\",\"applyUrlOutcomeMessage\":\"untrusted raw message\",\"applyUrlOutcomeRetryable\":true,\"authenticatedApplyUrlMethod\":\"linkedin_onsite_apply\"}"
       },
       {
         "stage": "score",
@@ -796,6 +797,7 @@
       "scored_at": "2026-06-08T12:05:00+00:00",
       "stages_json": [
         {
+          "apply_url_outcome": null,
           "attempt_count": 1,
           "blocked_by": [],
           "duration_ms": 5000,
@@ -811,6 +813,12 @@
           "updated_at": "2026-06-08T10:00:05+00:00"
         },
         {
+          "apply_url_outcome": {
+            "code": "APPLY_URL_LINKEDIN_ONSITE",
+            "message": "LinkedIn uses an on-site application flow for this posting; no external application URL exists.",
+            "method": "linkedin_onsite_apply",
+            "retryable": false
+          },
           "attempt_count": 1,
           "blocked_by": [],
           "duration_ms": 10000,
@@ -826,6 +834,7 @@
           "updated_at": "2026-06-08T10:01:10+00:00"
         },
         {
+          "apply_url_outcome": null,
           "attempt_count": 1,
           "blocked_by": [],
           "duration_ms": 30000,
@@ -841,6 +850,7 @@
           "updated_at": "2026-06-08T12:05:30+00:00"
         },
         {
+          "apply_url_outcome": null,
           "attempt_count": 2,
           "blocked_by": [],
           "duration_ms": 120000,
@@ -856,6 +866,7 @@
           "updated_at": "2026-06-08T12:12:00+00:00"
         },
         {
+          "apply_url_outcome": null,
           "attempt_count": 1,
           "blocked_by": [],
           "duration_ms": 60000,
@@ -871,6 +882,7 @@
           "updated_at": "2026-06-08T12:16:00+00:00"
         },
         {
+          "apply_url_outcome": null,
           "attempt_count": 1,
           "blocked_by": [],
           "duration_ms": 30000,

--- a/workers/automation/src/jobctrl/domain/enrichment/aggregate.py
+++ b/workers/automation/src/jobctrl/domain/enrichment/aggregate.py
@@ -291,7 +291,7 @@ class JobEnrichment:
     def record_apply_url_recovery(
         self,
         *,
-        application_url: ApplicationUrl | None,
+        result: ApplicationUrl | EnrichmentError,
         extraction_tier: ExtractionTier,
         started_at: str,
         finished_at: str,
@@ -300,10 +300,12 @@ class JobEnrichment:
 
         A terminal ``EnrichmentAttempt`` is appended for every authenticated
         pass, so repeated recoveries stay bounded by attempt count exactly
-        like the extraction cascade. The ``enriched`` status,
-        ``full_description``, ``enriched_at``, and top-level extraction tier
-        are always preserved — a recovery that finds an external apply target
-        attaches it and records a succeeded attempt, one that finds none
+        like the extraction cascade. ``result`` is an explicit sum type: either
+        the recovered ``ApplicationUrl`` or the precise ``EnrichmentError``
+        explaining why no external target was recovered. The ``enriched``
+        status, ``full_description``, ``enriched_at``, and top-level extraction
+        tier are always preserved — a recovery that finds an external apply
+        target attaches it and records a succeeded attempt, one that finds none
         records a failed attempt but leaves the reviewable material intact.
         The aggregate never transitions to ``failed``: a missing external
         apply URL is not an enrichment failure.
@@ -312,27 +314,19 @@ class JobEnrichment:
             raise ValueError(
                 "record_apply_url_recovery requires an enriched aggregate"
             )
-        resolved = application_url is not None
+        resolved = isinstance(result, ApplicationUrl)
         attempt = EnrichmentAttempt(
             attempt_number=len(self.attempts) + 1,
             extraction_tier=extraction_tier,
             status=AttemptStatus.SUCCEEDED if resolved else AttemptStatus.FAILED,
             started_at=started_at,
             finished_at=finished_at,
-            error=(
-                None
-                if resolved
-                else EnrichmentError(
-                    code="APPLY_URL_UNRESOLVED",
-                    message="authenticated apply URL not found",
-                    retryable=True,
-                )
-            ),
+            error=None if resolved else result,
         )
         return replace(
             self,
             attempts=self.attempts + (attempt,),
-            application_url=application_url if resolved else self.application_url,
+            application_url=result if resolved else self.application_url,
             updated_at=finished_at,
         )
 

--- a/workers/automation/src/jobctrl/domain/enrichment/snapshot_services.py
+++ b/workers/automation/src/jobctrl/domain/enrichment/snapshot_services.py
@@ -236,8 +236,10 @@ def judge_snapshot_confidence(
     """Heuristic three-bucket judgement consistent with the RFC schema.
 
     JSON-LD with apply URL and a long description is HIGH; CSS without
-    apply URL is MEDIUM; LLM fallback or short descriptions are LOW
-    unless an apply URL is also present.
+    apply URL is MEDIUM; a sufficiently complete LLM-assisted description
+    is MEDIUM whether or not an application URL was recovered. Application
+    target readiness is a separate fact and must not downgrade readable
+    posting content.
     """
     length = len(description.text)
     if tier is ExtractionTier.JSON_LD and apply_url_present and length >= _MEDIUM_CONFIDENCE_MIN_LEN:
@@ -249,7 +251,7 @@ def judge_snapshot_confidence(
             return SnapshotConfidence.MEDIUM
         return SnapshotConfidence.LOW
     if tier is ExtractionTier.LLM_ASSISTED:
-        if length >= _HIGH_CONFIDENCE_MIN_LEN and apply_url_present:
+        if length >= _HIGH_CONFIDENCE_MIN_LEN:
             return SnapshotConfidence.MEDIUM
         return SnapshotConfidence.LOW
     if length < _MEDIUM_CONFIDENCE_MIN_LEN:
@@ -451,14 +453,16 @@ def _quarantine_for_capture(
       * LOW confidence WITH an explicit filter override → admit; the
         override audit will be persisted on the snapshot, and the
         admission is logged via ``FilterOverrideLogger``.
+      * Missing application URL → does not change description trust;
+        application-target readiness is tracked separately.
       * Otherwise NONE.
     """
     if active_state is ActiveState.UNKNOWN:
         return QuarantineReason.UNKNOWN_ACTIVE_STATE
     if confidence is SnapshotConfidence.LOW and filter_override is None:
         return QuarantineReason.LOW_CONFIDENCE_EXTRACTION
-    if not has_apply_url and active_state is ActiveState.ACTIVE and filter_override is None:
-        return QuarantineReason.LOW_CONFIDENCE_EXTRACTION
+    if not has_apply_url:
+        return QuarantineReason.NONE
     return QuarantineReason.NONE
 
 

--- a/workers/automation/src/jobctrl/domain/enrichment/snapshot_value_objects.py
+++ b/workers/automation/src/jobctrl/domain/enrichment/snapshot_value_objects.py
@@ -92,6 +92,7 @@ class QuarantineReason(str, Enum):
     POLICY_OVERRIDE_PENDING = "policy_override_pending"
     DUPLICATE_CANDIDATE = "duplicate_candidate"
     SHORT_DESCRIPTION = "short_description"
+    POSTING_INACTIVE = "posting_inactive"
 
     @classmethod
     def from_optional(cls, value: object) -> "QuarantineReason | None":

--- a/workers/automation/src/jobctrl/domain/operations/__init__.py
+++ b/workers/automation/src/jobctrl/domain/operations/__init__.py
@@ -13,6 +13,7 @@ types — never in raw rows.
 """
 
 from jobctrl.domain.operations.projections import (
+    ApplyUrlOutcomeProjection,
     ApplyRunProjection,
     ArtifactListProjection,
     DashboardFunnelStage,
@@ -57,6 +58,7 @@ from jobctrl.domain.operations.learning import (
 )
 
 __all__ = [
+    "ApplyUrlOutcomeProjection",
     "ApplyRunProjection",
     "ArtifactListProjection",
     "DashboardFunnelStage",

--- a/workers/automation/src/jobctrl/domain/operations/projections.py
+++ b/workers/automation/src/jobctrl/domain/operations/projections.py
@@ -35,6 +35,16 @@ from jobctrl.domain.tenant import TenantId
 
 
 @dataclass(frozen=True)
+class ApplyUrlOutcomeProjection:
+    """Allow-listed application-target readiness fact captured by Enrichment."""
+
+    code: str
+    message: str
+    retryable: bool
+    method: str | None = None
+
+
+@dataclass(frozen=True)
 class StageProjection:
     """Denormalised stage row inside a ``JobDetailProjection.stages`` list."""
 
@@ -51,6 +61,7 @@ class StageProjection:
     retryable: bool = True
     blocked_by: tuple[str, ...] = ()
     next_action: str | None = None
+    apply_url_outcome: ApplyUrlOutcomeProjection | None = None
 
 
 @dataclass(frozen=True)

--- a/workers/automation/src/jobctrl/enrichment/detail.py
+++ b/workers/automation/src/jobctrl/enrichment/detail.py
@@ -719,7 +719,11 @@ def _apply_authenticated_linkedin_apply_url(
         else:
             return cascade_result
     except Exception as exc:  # noqa: BLE001 - resolver is best-effort
-        log.warning("LinkedIn apply URL resolver failed for %s: %s", url, exc)
+        log.warning(
+            "LinkedIn apply URL resolver failed for %s (%s)",
+            url,
+            type(exc).__name__,
+        )
         return {
             **cascade_result,
             "authenticated_apply_url_method": "resolver_error",
@@ -1675,10 +1679,6 @@ def scrape_site_batch(
                             stage_metadata["authenticatedApplyUrlMethod"] = cascade_result.get(
                                 "authenticated_apply_url_method"
                             )
-                        if cascade_result.get("authenticated_apply_url_error"):
-                            stage_metadata["authenticatedApplyUrlError"] = cascade_result.get(
-                                "authenticated_apply_url_error"
-                            )
                         stage_metadata.update(_authenticated_apply_url_outcome_metadata(cascade_result))
                         if activity_lease is not None:
                             stage_metadata.update(
@@ -1740,10 +1740,6 @@ def scrape_site_batch(
                         if cascade_result.get("authenticated_apply_url_method"):
                             completed_payload["authenticatedApplyUrlMethod"] = cascade_result.get(
                                 "authenticated_apply_url_method"
-                            )
-                        if cascade_result.get("authenticated_apply_url_error"):
-                            completed_payload["authenticatedApplyUrlError"] = cascade_result.get(
-                                "authenticated_apply_url_error"
                             )
                         completed_payload.update(_authenticated_apply_url_outcome_metadata(cascade_result))
                         if fallback_source:
@@ -2393,7 +2389,10 @@ def _authenticated_apply_url_recovery_error(
     """Translate resolver mechanics into one auditable application-target fact."""
 
     method_value = str(method or "external_url_missing")
-    detail = str(raw_error or "").strip()
+    # Resolver exceptions may contain browser-profile paths, signed URLs, or
+    # other local diagnostics. Stable outcome messages are code-owned and must
+    # never copy that raw detail into stage metadata or user-facing events.
+    del raw_error
     if method_value == "linkedin_onsite_apply":
         return EnrichmentError(
             code="APPLY_URL_LINKEDIN_ONSITE",
@@ -2407,17 +2406,18 @@ def _authenticated_apply_url_recovery_error(
             retryable=True,
         )
     if method_value == "unsafe_url":
-        suffix = f" {detail}" if detail else ""
         return EnrichmentError(
             code="APPLY_URL_UNSAFE_TARGET",
-            message=f"JobCtrl rejected the discovered application target as unsafe.{suffix}",
+            message=(
+                "JobCtrl rejected the discovered application target because it is not "
+                "a safe public HTTP(S) destination."
+            ),
             retryable=False,
         )
     if method_value in {"navigation_error", "resolver_error"}:
-        suffix = f" {detail}" if detail else ""
         return EnrichmentError(
             code="APPLY_URL_NAVIGATION_FAILED",
-            message=f"The authenticated LinkedIn page could not be inspected.{suffix}",
+            message="The authenticated LinkedIn page could not be inspected.",
             retryable=True,
         )
     if method_value == "external_url_missing":
@@ -2439,6 +2439,7 @@ def _authenticated_apply_url_outcome_metadata(result: dict) -> dict[str, object]
         return {}
     if result.get("application_url"):
         return {
+            "authenticatedApplyUrlMethod": str(method),
             "applyUrlOutcomeCode": "APPLY_URL_EXTERNAL_RECOVERED",
             "applyUrlOutcomeMessage": "An external application URL was recovered.",
             "applyUrlOutcomeRetryable": False,
@@ -2448,6 +2449,7 @@ def _authenticated_apply_url_outcome_metadata(result: dict) -> dict[str, object]
         raw_error=result.get("authenticated_apply_url_error"),
     )
     return {
+        "authenticatedApplyUrlMethod": str(method),
         "applyUrlOutcomeCode": error.code,
         "applyUrlOutcomeMessage": error.message,
         "applyUrlOutcomeRetryable": error.retryable,
@@ -2744,6 +2746,86 @@ def _record_missing_apply_url_content_trust_recovery(
     return True
 
 
+def _repair_legacy_missing_apply_url_content_trust_candidates(
+    conn: sqlite3.Connection,
+    *,
+    job_ids: tuple[JobId, ...] = (),
+    activity_lease: EnrichmentExecutionLease | None = None,
+    cancel_event: threading.Event | None = None,
+) -> int:
+    """Reclassify legacy readable snapshots independently of their source.
+
+    The retired confidence rule coupled a missing external application URL to
+    posting-content trust for every source. This repair is therefore a local,
+    source-agnostic migration pass. LinkedIn browser recovery remains a later,
+    separate concern and is never required to restore readable content.
+    """
+
+    where = [
+        "j.tenant_id = ?",
+        "e.current_status = 'enriched'",
+        "(e.application_url IS NULL OR e.application_url = '')",
+    ]
+    params: list[object] = [str(LOCAL_TENANT)]
+    selected_job_ids = tuple(dict.fromkeys(canonical_job_id(str(job_id)) for job_id in job_ids))
+    if selected_job_ids:
+        placeholders = ", ".join("?" for _ in selected_job_ids)
+        where.append(f"j.job_id IN ({placeholders})")
+        params.extend(str(job_id) for job_id in selected_job_ids)
+    rows = conn.execute(
+        f"""
+        SELECT j.tenant_id, j.job_id
+        FROM jobs j
+        JOIN job_enrichments e
+          ON e.tenant_id = j.tenant_id AND e.job_id = j.job_id
+        WHERE {" AND ".join(where)}
+        ORDER BY e.updated_at DESC
+        """,
+        params,
+    ).fetchall()
+
+    from jobctrl.state import utc_now
+
+    repo = SqliteEnrichmentRepository(conn)
+    repaired_count = 0
+    for row in rows:
+        try:
+            if cancel_event is not None and cancel_event.is_set():
+                raise TransientNetworkError("enrichment canceled")
+            tenant_id = TenantId(str(row["tenant_id"] if isinstance(row, sqlite3.Row) else row[0]))
+            job_id = canonical_job_id(str(row["job_id"] if isinstance(row, sqlite3.Row) else row[1]))
+            aggregate = repo.load(tenant_id, job_id)
+            if aggregate is None or not aggregate.is_enriched:
+                continue
+            if activity_lease is not None:
+                _fence_execution_enrichment_lease(conn, activity_lease)
+            if _record_missing_apply_url_content_trust_recovery(
+                conn,
+                tenant_id=tenant_id,
+                job_id=job_id,
+                enrichment=aggregate,
+                captured_at=utc_now(),
+            ):
+                repaired_count += 1
+            conn.commit()
+        except StaleEnrichmentExecutionLease:
+            conn.rollback()
+            raise
+        except TransientNetworkError:
+            conn.rollback()
+            raise
+        except Exception:  # noqa: BLE001 - one legacy row must not abort the repair
+            conn.rollback()
+            log.exception("Legacy posting content-trust repair failed for a row")
+
+    if repaired_count:
+        log.info(
+            "Posting content trust reclassified for %d job(s)",
+            repaired_count,
+        )
+    return repaired_count
+
+
 def _reset_authenticated_linkedin_retry_candidates(
     conn: sqlite3.Connection,
     *,
@@ -2757,12 +2839,14 @@ def _reset_authenticated_linkedin_retry_candidates(
     workflow_id: str | None = None,
     workflow_run_id: str | None = None,
 ) -> int:
-    """Retry LinkedIn rows that need authenticated enrichment follow-up.
+    """Repair legacy content trust, then retry LinkedIn browser follow-up.
 
-    The normal enrichment queue excludes failed aggregates and already
-    enriched rows. LinkedIn is the exception because a logged-in browser can
-    expose data hidden from the first unauthenticated pass, especially the
-    external apply target. Two disjoint groups are handled:
+    The source-independent local repair runs first because the retired
+    missing-URL confidence rule affected every source. The normal enrichment
+    queue then excludes failed aggregates and already enriched rows. LinkedIn
+    is the browser-recovery exception because a logged-in session can expose
+    data hidden from the first unauthenticated pass, especially the external
+    apply target. Two disjoint LinkedIn groups are handled:
 
       * **Enriched but missing the apply URL** — resolved non-destructively.
         Only ``application_url`` is backfilled; the canonical
@@ -2780,6 +2864,13 @@ def _reset_authenticated_linkedin_retry_candidates(
     never-resolving posting) when the profile is not logged in or the posting
     has no external apply target. Returns the number of rows reset (re-queued).
     """
+    selected_job_ids = tuple(dict.fromkeys(canonical_job_id(str(job_id)) for job_id in job_ids))
+    _repair_legacy_missing_apply_url_content_trust_candidates(
+        conn,
+        job_ids=selected_job_ids,
+        activity_lease=activity_lease,
+        cancel_event=cancel_event,
+    )
     resolver_enabled = linkedin_apply_resolver_enabled()
 
     if session is None and resolver_enabled:
@@ -2804,7 +2895,6 @@ def _reset_authenticated_linkedin_retry_candidates(
         "(e.current_status = 'failed' OR e.application_url IS NULL OR e.application_url = '')",
     ]
     params: list[object] = []
-    selected_job_ids = tuple(dict.fromkeys(canonical_job_id(str(job_id)) for job_id in job_ids))
     if selected_job_ids:
         placeholders = ", ".join("?" for _ in selected_job_ids)
         where.append(f"j.tenant_id = ? AND j.job_id IN ({placeholders})")
@@ -2834,7 +2924,6 @@ def _reset_authenticated_linkedin_retry_candidates(
     reset_count = 0
     recovery_count = 0
     backfill_count = 0
-    trust_reclassification_count = 0
     resolver: object | None = None
     try:
         for row in rows:
@@ -2859,20 +2948,10 @@ def _reset_authenticated_linkedin_retry_candidates(
                 if aggregate.is_enriched:
                     if activity_lease is not None:
                         _fence_execution_enrichment_lease(conn, activity_lease)
-                    trust_reclassified = _record_missing_apply_url_content_trust_recovery(
-                        conn,
-                        tenant_id=tenant_id,
-                        job_id=job_id,
-                        enrichment=aggregate,
-                        captured_at=now,
-                    )
-                    if trust_reclassified:
-                        trust_reclassification_count += 1
-                    # The lease fence and any legacy trust repair must be
-                    # durable before browser navigation. Holding their SQLite
-                    # write transaction across a potentially slow resolver
-                    # would prevent cancellation reconciliation from
-                    # terminalizing this workflow's owned cohort.
+                    # The lease fence must be durable before browser navigation.
+                    # Holding its SQLite write transaction across a potentially
+                    # slow resolver would prevent cancellation reconciliation
+                    # from terminalizing this workflow's owned cohort.
                     conn.commit()
                     if attempt_count >= _MAX_AUTHENTICATED_LINKEDIN_RETRY_ATTEMPTS:
                         continue
@@ -2969,7 +3048,6 @@ def _reset_authenticated_linkedin_retry_candidates(
                             "reason": "linkedin_authenticated_apply_url",
                             "applicationUrlFound": recovered is not None,
                             "authenticatedApplyUrlMethod": resolved.get("authenticated_apply_url_method"),
-                            "authenticatedApplyUrlError": resolved.get("authenticated_apply_url_error"),
                             **outcome_metadata,
                             "retryable": recovery_error.retryable if recovery_error else False,
                             "automated": True,
@@ -3095,7 +3173,7 @@ def _reset_authenticated_linkedin_retry_candidates(
             except Exception:
                 log.debug("LinkedIn apply resolver close failed", exc_info=True)
 
-    if reset_count or recovery_count or trust_reclassification_count:
+    if reset_count or recovery_count:
         conn.commit()
         if reset_count:
             log.info(
@@ -3106,11 +3184,6 @@ def _reset_authenticated_linkedin_retry_candidates(
             log.info(
                 "LinkedIn authenticated apply URL backfilled for %d job(s)",
                 backfill_count,
-            )
-        if trust_reclassification_count:
-            log.info(
-                "LinkedIn posting content trust reclassified for %d job(s)",
-                trust_reclassification_count,
             )
     return reset_count
 

--- a/workers/automation/src/jobctrl/enrichment/detail.py
+++ b/workers/automation/src/jobctrl/enrichment/detail.py
@@ -2842,11 +2842,14 @@ def _reset_authenticated_linkedin_retry_candidates(
     """Repair legacy content trust, then retry LinkedIn browser follow-up.
 
     The source-independent local repair runs first because the retired
-    missing-URL confidence rule affected every source. The normal enrichment
-    queue then excludes failed aggregates and already enriched rows. LinkedIn
-    is the browser-recovery exception because a logged-in session can expose
-    data hidden from the first unauthenticated pass, especially the external
-    apply target. Two disjoint LinkedIn groups are handled:
+    missing-URL confidence rule affected every source; it is the only part of
+    this pass that runs while the authenticated-LinkedIn capability is not
+    ready, so a disabled capability can never burn the bounded authenticated
+    retry budgets with anonymous retries. The normal enrichment queue then
+    excludes failed aggregates and already enriched rows. LinkedIn is the
+    browser-recovery exception because a logged-in session can expose data
+    hidden from the first unauthenticated pass, especially the external apply
+    target. Two disjoint LinkedIn groups are handled:
 
       * **Enriched but missing the apply URL** — resolved non-destructively.
         Only ``application_url`` is backfilled; the canonical
@@ -2871,9 +2874,18 @@ def _reset_authenticated_linkedin_retry_candidates(
         activity_lease=activity_lease,
         cancel_event=cancel_event,
     )
-    resolver_enabled = linkedin_apply_resolver_enabled()
+    if not linkedin_apply_resolver_enabled():
+        # Only the source-agnostic content-trust repair above is
+        # capability-independent. Both LinkedIn groups below exist to re-drive
+        # rows through the owner-authenticated browser, so with the capability
+        # not ready nothing may be recovered or reset: resetting a failed row
+        # here would retry it anonymously on every run and, because ``reset()``
+        # preserves attempt history, consume the bounded attempt budget the
+        # authenticated recovery needs once the capability is enabled —
+        # permanently skipping the row.
+        return 0
 
-    if session is None and resolver_enabled:
+    if session is None:
         # Owner-authenticated recovery navigations are robots-off (D1/D3), but the
         # shared per-host limiter + the run's request budget still pace and bound
         # them, exactly like the batch path — so build (or reuse) an
@@ -2956,8 +2968,6 @@ def _reset_authenticated_linkedin_retry_candidates(
                     if attempt_count >= _MAX_AUTHENTICATED_LINKEDIN_RETRY_ATTEMPTS:
                         continue
                     if not _last_authenticated_apply_url_recovery_retryable(attempts_json):
-                        continue
-                    if not resolver_enabled:
                         continue
                     if cancel_event is not None and cancel_event.is_set():
                         raise TransientNetworkError("enrichment canceled")

--- a/workers/automation/src/jobctrl/enrichment/detail.py
+++ b/workers/automation/src/jobctrl/enrichment/detail.py
@@ -722,6 +722,7 @@ def _apply_authenticated_linkedin_apply_url(
         log.warning("LinkedIn apply URL resolver failed for %s: %s", url, exc)
         return {
             **cascade_result,
+            "authenticated_apply_url_method": "resolver_error",
             "authenticated_apply_url_error": str(exc)[:300],
         }
 
@@ -1678,6 +1679,7 @@ def scrape_site_batch(
                             stage_metadata["authenticatedApplyUrlError"] = cascade_result.get(
                                 "authenticated_apply_url_error"
                             )
+                        stage_metadata.update(_authenticated_apply_url_outcome_metadata(cascade_result))
                         if activity_lease is not None:
                             stage_metadata.update(
                                 {
@@ -1743,6 +1745,7 @@ def scrape_site_batch(
                             completed_payload["authenticatedApplyUrlError"] = cascade_result.get(
                                 "authenticated_apply_url_error"
                             )
+                        completed_payload.update(_authenticated_apply_url_outcome_metadata(cascade_result))
                         if fallback_source:
                             completed_payload.update(
                                 {
@@ -1961,12 +1964,12 @@ def _resume_tailoring_after_trustworthy_snapshot(
     snapshot_version: int,
     tenant_id: TenantId,
     resolved_at: str,
-) -> None:
+) -> bool:
     """Release the stale quarantine blocker after canonical trust recovers."""
 
     from jobctrl.state import record_job_event, set_stage_state
 
-    conn.execute(
+    resolved_quarantines = conn.execute(
         "UPDATE discovery_quarantine_entries "
         "SET status = 'resolved', decision_reason = ?, decided_at = ? "
         "WHERE tenant_id = ? AND job_id = ? AND status = 'pending'",
@@ -1987,7 +1990,7 @@ def _resume_tailoring_after_trustworthy_snapshot(
         or str(tailor_state[0]) != "blocked"
         or str(tailor_state[1] or "") != "ENRICHMENT_QUARANTINED"
     ):
-        return
+        return resolved_quarantines.rowcount > 0
     set_stage_state(
         conn,
         job_id,
@@ -2009,6 +2012,7 @@ def _resume_tailoring_after_trustworthy_snapshot(
             "automated": True,
         },
     )
+    return True
 
 
 def _record_posting_snapshot_from_cascade(
@@ -2058,9 +2062,19 @@ def _record_posting_snapshot_from_cascade(
             apply_url_present=apply_url is not None,
         )
         quarantine_reason = (
-            QuarantineReason.NONE
-            if confidence is not SnapshotConfidence.LOW and apply_url is not None
-            else QuarantineReason.LOW_CONFIDENCE_EXTRACTION
+            QuarantineReason.POSTING_INACTIVE
+            if active_state
+            in {
+                ActiveState.CLOSED,
+                ActiveState.EXPIRED,
+                ActiveState.REMOVED,
+            }
+            else _quarantine_for_capture(
+                confidence=confidence,
+                active_state=active_state,
+                has_apply_url=apply_url is not None,
+                filter_override=None,
+            )
         )
         snapshot_set, snapshot = snapshot_set.record_snapshot(
             source_id=resolved_source_id,
@@ -2075,6 +2089,11 @@ def _record_posting_snapshot_from_cascade(
                 f"tier:{tier.value}",
                 f"description_length:{len(description)}",
                 f"apply_url_present:{str(apply_url is not None).lower()}",
+                *(
+                    ("apply_url_outcome:" + str(cascade_result["authenticated_apply_url_method"]),)
+                    if cascade_result.get("authenticated_apply_url_method")
+                    else ()
+                ),
             ),
         )
         # Snapshot trust, quarantine resolution, downstream release, and their
@@ -2349,9 +2368,149 @@ def _authenticated_apply_url_recovery_attempt_count(
         if not isinstance(attempt, dict):
             continue
         error = attempt.get("error")
-        if isinstance(error, dict) and error.get("code") == "APPLY_URL_UNRESOLVED":
+        if isinstance(error, dict) and str(error.get("code") or "") in _APPLY_URL_RECOVERY_ERROR_CODES:
             count += 1
     return count
+
+
+_APPLY_URL_RECOVERY_ERROR_CODES = frozenset(
+    {
+        "APPLY_URL_UNRESOLVED",
+        "APPLY_URL_LINKEDIN_ONSITE",
+        "APPLY_URL_CONTROL_MISSING",
+        "APPLY_URL_EXTERNAL_TARGET_MISSING",
+        "APPLY_URL_NAVIGATION_FAILED",
+        "APPLY_URL_UNSAFE_TARGET",
+    }
+)
+
+
+def _authenticated_apply_url_recovery_error(
+    *,
+    method: object,
+    raw_error: object,
+) -> EnrichmentError:
+    """Translate resolver mechanics into one auditable application-target fact."""
+
+    method_value = str(method or "external_url_missing")
+    detail = str(raw_error or "").strip()
+    if method_value == "linkedin_onsite_apply":
+        return EnrichmentError(
+            code="APPLY_URL_LINKEDIN_ONSITE",
+            message=("LinkedIn uses an on-site application flow for this posting; no external application URL exists."),
+            retryable=False,
+        )
+    if method_value == "apply_button_missing":
+        return EnrichmentError(
+            code="APPLY_URL_CONTROL_MISSING",
+            message="No application control was visible on the authenticated LinkedIn page.",
+            retryable=True,
+        )
+    if method_value == "unsafe_url":
+        suffix = f" {detail}" if detail else ""
+        return EnrichmentError(
+            code="APPLY_URL_UNSAFE_TARGET",
+            message=f"JobCtrl rejected the discovered application target as unsafe.{suffix}",
+            retryable=False,
+        )
+    if method_value in {"navigation_error", "resolver_error"}:
+        suffix = f" {detail}" if detail else ""
+        return EnrichmentError(
+            code="APPLY_URL_NAVIGATION_FAILED",
+            message=f"The authenticated LinkedIn page could not be inspected.{suffix}",
+            retryable=True,
+        )
+    if method_value == "external_url_missing":
+        return EnrichmentError(
+            code="APPLY_URL_EXTERNAL_TARGET_MISSING",
+            message=("An application control was visible, but no external application URL could be verified."),
+            retryable=True,
+        )
+    return EnrichmentError(
+        code="APPLY_URL_UNRESOLVED",
+        message="The authenticated browser did not recover an external application URL.",
+        retryable=True,
+    )
+
+
+def _authenticated_apply_url_outcome_metadata(result: dict) -> dict[str, object]:
+    method = result.get("authenticated_apply_url_method")
+    if not method:
+        return {}
+    if result.get("application_url"):
+        return {
+            "applyUrlOutcomeCode": "APPLY_URL_EXTERNAL_RECOVERED",
+            "applyUrlOutcomeMessage": "An external application URL was recovered.",
+            "applyUrlOutcomeRetryable": False,
+        }
+    error = _authenticated_apply_url_recovery_error(
+        method=method,
+        raw_error=result.get("authenticated_apply_url_error"),
+    )
+    return {
+        "applyUrlOutcomeCode": error.code,
+        "applyUrlOutcomeMessage": error.message,
+        "applyUrlOutcomeRetryable": error.retryable,
+    }
+
+
+def _merge_enrich_apply_url_outcome_metadata(
+    conn: sqlite3.Connection,
+    *,
+    tenant_id: TenantId,
+    job_id: JobId,
+    outcome_metadata: dict[str, object],
+    updated_at: str,
+) -> None:
+    """Persist application-target readiness without changing Enrich success."""
+
+    if not outcome_metadata:
+        return
+    row = conn.execute(
+        "SELECT metadata_json FROM job_stage_states WHERE tenant_id = ? AND job_id = ? AND stage = 'enrich'",
+        (str(tenant_id), str(job_id)),
+    ).fetchone()
+    current: dict[str, object] = {}
+    if row is not None:
+        raw = row["metadata_json"] if isinstance(row, sqlite3.Row) else row[0]
+        try:
+            parsed = json.loads(str(raw or "{}"))
+        except Exception:
+            parsed = {}
+        if isinstance(parsed, dict):
+            current = parsed
+    current.update(outcome_metadata)
+    conn.execute(
+        "UPDATE job_stage_states SET metadata_json = ?, updated_at = ?, version = version + 1 "
+        "WHERE tenant_id = ? AND job_id = ? AND stage = 'enrich'",
+        (
+            json.dumps(current, sort_keys=True),
+            updated_at,
+            str(tenant_id),
+            str(job_id),
+        ),
+    )
+
+
+def _last_authenticated_apply_url_recovery_retryable(attempts_json: str | None) -> bool:
+    if not attempts_json:
+        return True
+    try:
+        attempts = json.loads(attempts_json)
+    except Exception:
+        return True
+    if not isinstance(attempts, list):
+        return True
+    for attempt in reversed(attempts):
+        if not isinstance(attempt, dict):
+            continue
+        error = attempt.get("error")
+        if not isinstance(error, dict):
+            continue
+        if str(error.get("code") or "") not in _APPLY_URL_RECOVERY_ERROR_CODES:
+            continue
+        return bool(error.get("retryable", True))
+    return True
 
 
 def _last_failed_attempt_retryable(attempts_json: str | None) -> bool:
@@ -2490,6 +2649,101 @@ def _record_authenticated_apply_url_snapshot_recovery(
     return True
 
 
+def _record_missing_apply_url_content_trust_recovery(
+    conn: sqlite3.Connection,
+    *,
+    tenant_id: TenantId,
+    job_id: JobId,
+    enrichment: JobEnrichment,
+    captured_at: str,
+) -> bool:
+    """Repair legacy snapshots that coupled content trust to apply-URL readiness.
+
+    Earlier policy labeled every LLM-assisted snapshot without an application
+    URL LOW, even when the canonical description was complete. Reclassifying
+    that existing content appends an immutable snapshot version; it never
+    invents an application URL or rewrites the original capture.
+    """
+
+    from jobctrl.state import record_job_event
+
+    if enrichment.full_description is None or enrichment.application_url is not None:
+        return False
+    repo = SqlitePostingSnapshotSetRepository(conn)
+    snapshot_set = repo.load(tenant_id, job_id)
+    if snapshot_set is None or snapshot_set.latest_snapshot is None:
+        return False
+    latest = snapshot_set.latest_snapshot
+    if latest.apply_url is not None or latest.active_state is not ActiveState.ACTIVE:
+        return False
+    try:
+        tier = ExtractionTier(latest.extraction_tier)
+    except ValueError:
+        tier = enrichment.extraction_tier or ExtractionTier.LLM_ASSISTED
+    confidence = judge_snapshot_confidence(
+        tier=tier,
+        description=enrichment.full_description,
+        apply_url_present=False,
+    )
+    quarantine_reason = _quarantine_for_capture(
+        confidence=confidence,
+        active_state=latest.active_state,
+        has_apply_url=False,
+        filter_override=latest.filter_override,
+    )
+    if confidence is SnapshotConfidence.LOW or quarantine_reason is not QuarantineReason.NONE:
+        return False
+    if latest.confidence is confidence and latest.quarantine_reason is quarantine_reason:
+        return _resume_tailoring_after_trustworthy_snapshot(
+            conn,
+            job_id=job_id,
+            snapshot_version=latest.snapshot_version,
+            tenant_id=tenant_id,
+            resolved_at=captured_at,
+        )
+
+    snapshot_set, snapshot = snapshot_set.record_snapshot(
+        source_id=latest.source_id,
+        extraction_tier=latest.extraction_tier,
+        description_hash=latest.description_hash,
+        apply_url=None,
+        active_state=latest.active_state,
+        confidence=confidence,
+        quarantine_reason=quarantine_reason,
+        captured_at=captured_at,
+        raw_text_hash=latest.raw_text_hash,
+        filter_override=latest.filter_override,
+        evidence=(
+            *latest.evidence,
+            "content_trust_reclassified:apply_url_independent",
+        ),
+    )
+    repo.save(snapshot_set, commit=False)
+    _resume_tailoring_after_trustworthy_snapshot(
+        conn,
+        job_id=job_id,
+        snapshot_version=snapshot.snapshot_version,
+        tenant_id=tenant_id,
+        resolved_at=captured_at,
+    )
+    record_job_event(
+        conn,
+        job_id,
+        "enrich",
+        "PostingContentSnapshotCaptured",
+        tenant_id=tenant_id,
+        message="Posting content trust reclassified independently of apply URL readiness.",
+        payload={
+            "snapshotVersion": snapshot.snapshot_version,
+            "snapshotRef": f"{job_id}:{snapshot.snapshot_version}",
+            "confidence": confidence.value,
+            "quarantineReason": quarantine_reason.value,
+            "reason": "missing_apply_url_content_trust_recovery",
+        },
+    )
+    return True
+
+
 def _reset_authenticated_linkedin_retry_candidates(
     conn: sqlite3.Connection,
     *,
@@ -2526,10 +2780,9 @@ def _reset_authenticated_linkedin_retry_candidates(
     never-resolving posting) when the profile is not logged in or the posting
     has no external apply target. Returns the number of rows reset (re-queued).
     """
-    if not linkedin_apply_resolver_enabled():
-        return 0
+    resolver_enabled = linkedin_apply_resolver_enabled()
 
-    if session is None:
+    if session is None and resolver_enabled:
         # Owner-authenticated recovery navigations are robots-off (D1/D3), but the
         # shared per-host limiter + the run's request budget still pace and bound
         # them, exactly like the batch path — so build (or reuse) an
@@ -2581,6 +2834,7 @@ def _reset_authenticated_linkedin_retry_candidates(
     reset_count = 0
     recovery_count = 0
     backfill_count = 0
+    trust_reclassification_count = 0
     resolver: object | None = None
     try:
         for row in rows:
@@ -2594,14 +2848,6 @@ def _reset_authenticated_linkedin_retry_candidates(
                     if str(current_status) == "enriched"
                     else _attempt_count_from_json(attempts_json)
                 )
-                if attempt_count >= _MAX_AUTHENTICATED_LINKEDIN_RETRY_ATTEMPTS:
-                    continue
-                if (
-                    str(current_status) == "failed"
-                    and not _last_failed_attempt_retryable(attempts_json)
-                    and not _last_failed_attempt_is_legacy_public_write_guard(attempts_json)
-                ):
-                    continue
                 tenant_id = TenantId(str(row["tenant_id"] if isinstance(row, sqlite3.Row) else row[0]))
                 job_id = canonical_job_id(str(row["job_id"] if isinstance(row, sqlite3.Row) else row[1]))
                 url = str(row["url"] if isinstance(row, sqlite3.Row) else row[2])
@@ -2611,6 +2857,29 @@ def _reset_authenticated_linkedin_retry_candidates(
                     continue
 
                 if aggregate.is_enriched:
+                    if activity_lease is not None:
+                        _fence_execution_enrichment_lease(conn, activity_lease)
+                    trust_reclassified = _record_missing_apply_url_content_trust_recovery(
+                        conn,
+                        tenant_id=tenant_id,
+                        job_id=job_id,
+                        enrichment=aggregate,
+                        captured_at=now,
+                    )
+                    if trust_reclassified:
+                        trust_reclassification_count += 1
+                    # The lease fence and any legacy trust repair must be
+                    # durable before browser navigation. Holding their SQLite
+                    # write transaction across a potentially slow resolver
+                    # would prevent cancellation reconciliation from
+                    # terminalizing this workflow's owned cohort.
+                    conn.commit()
+                    if attempt_count >= _MAX_AUTHENTICATED_LINKEDIN_RETRY_ATTEMPTS:
+                        continue
+                    if not _last_authenticated_apply_url_recovery_retryable(attempts_json):
+                        continue
+                    if not resolver_enabled:
+                        continue
                     if cancel_event is not None and cancel_event.is_set():
                         raise TransientNetworkError("enrichment canceled")
                     if resolver is None and resolver_factory is not None:
@@ -2653,13 +2922,29 @@ def _reset_authenticated_linkedin_retry_candidates(
                     # touched.
                     if activity_lease is not None:
                         _fence_execution_enrichment_lease(conn, activity_lease)
+                    recovery_error = (
+                        None
+                        if recovered is not None
+                        else _authenticated_apply_url_recovery_error(
+                            method=resolved.get("authenticated_apply_url_method"),
+                            raw_error=resolved.get("authenticated_apply_url_error"),
+                        )
+                    )
                     updated_aggregate = aggregate.record_apply_url_recovery(
-                        application_url=recovered,
+                        result=recovered if recovered is not None else recovery_error,
                         extraction_tier=ExtractionTier.CSS_SELECTORS,
                         started_at=now,
                         finished_at=utc_now(),
                     )
                     repo.save(updated_aggregate, commit=False)
+                    outcome_metadata = _authenticated_apply_url_outcome_metadata(resolved)
+                    _merge_enrich_apply_url_outcome_metadata(
+                        conn,
+                        tenant_id=tenant_id,
+                        job_id=job_id,
+                        outcome_metadata=outcome_metadata,
+                        updated_at=updated_aggregate.updated_at,
+                    )
                     if recovered is not None:
                         _record_authenticated_apply_url_snapshot_recovery(
                             conn,
@@ -2678,13 +2963,15 @@ def _reset_authenticated_linkedin_retry_candidates(
                         message=(
                             "LinkedIn authenticated apply URL recovered"
                             if recovered is not None
-                            else "LinkedIn authenticated apply URL unresolved"
+                            else recovery_error.message
                         ),
                         payload={
                             "reason": "linkedin_authenticated_apply_url",
                             "applicationUrlFound": recovered is not None,
                             "authenticatedApplyUrlMethod": resolved.get("authenticated_apply_url_method"),
                             "authenticatedApplyUrlError": resolved.get("authenticated_apply_url_error"),
+                            **outcome_metadata,
+                            "retryable": recovery_error.retryable if recovery_error else False,
                             "automated": True,
                         },
                     )
@@ -2694,6 +2981,15 @@ def _reset_authenticated_linkedin_retry_candidates(
                     conn.commit()
                     if limit and limit > 0 and (reset_count + recovery_count) >= limit:
                         break
+                    continue
+
+                if attempt_count >= _MAX_AUTHENTICATED_LINKEDIN_RETRY_ATTEMPTS:
+                    continue
+                if (
+                    str(current_status) == "failed"
+                    and not _last_failed_attempt_retryable(attempts_json)
+                    and not _last_failed_attempt_is_legacy_public_write_guard(attempts_json)
+                ):
                     continue
 
                 ownership = _activity_ownership_metadata(
@@ -2799,7 +3095,7 @@ def _reset_authenticated_linkedin_retry_candidates(
             except Exception:
                 log.debug("LinkedIn apply resolver close failed", exc_info=True)
 
-    if reset_count or recovery_count:
+    if reset_count or recovery_count or trust_reclassification_count:
         conn.commit()
         if reset_count:
             log.info(
@@ -2810,6 +3106,11 @@ def _reset_authenticated_linkedin_retry_candidates(
             log.info(
                 "LinkedIn authenticated apply URL backfilled for %d job(s)",
                 backfill_count,
+            )
+        if trust_reclassification_count:
+            log.info(
+                "LinkedIn posting content trust reclassified for %d job(s)",
+                trust_reclassification_count,
             )
     return reset_count
 

--- a/workers/automation/src/jobctrl/infrastructure/enrichment/linkedin_apply_resolver.py
+++ b/workers/automation/src/jobctrl/infrastructure/enrichment/linkedin_apply_resolver.py
@@ -282,6 +282,9 @@ class LinkedInApplyUrlResolver:
         if locator is None:
             return LinkedInApplyResolution(None, "apply_button_missing")
 
+        if _locator_indicates_linkedin_onsite_apply(locator):
+            return LinkedInApplyResolution(None, "linkedin_onsite_apply")
+
         href = _locator_href(locator, getattr(page, "url", "") or job_url)
         if href:
             direct = _extract_external_from_redirect_url(
@@ -324,6 +327,36 @@ def _first_visible_apply_locator(page: Any) -> Any | None:
         except Exception:
             continue
     return None
+
+
+def _locator_indicates_linkedin_onsite_apply(locator: Any) -> bool:
+    """Return whether LinkedIn explicitly owns the application flow.
+
+    LinkedIn's public job page identifies its on-site apply control with a
+    stable tracking attribute such as ``public_jobs_apply-link-onsite``.
+    Authenticated Easy Apply controls use an equivalent ``inapply`` marker or
+    an explicit accessible label. These are successful terminal discoveries:
+    no external ATS URL exists to recover, so the resolver must not click the
+    control repeatedly and report a generic failure.
+    """
+
+    for attribute in (
+        "data-tracking-control-name",
+        "data-control-name",
+        "aria-label",
+    ):
+        try:
+            value = locator.get_attribute(attribute)
+        except Exception:
+            value = None
+        normalized = str(value or "").strip().lower()
+        if "onsite" in normalized or "inapply" in normalized or "easy apply" in normalized:
+            return True
+    try:
+        text = str(locator.inner_text() or "").strip().lower()
+    except Exception:
+        text = ""
+    return "easy apply" in text
 
 
 def _install_public_route_guard(page: Any, *, context: Any | None = None) -> PublicHttpUrlRouteGuard:

--- a/workers/automation/src/jobctrl/infrastructure/projections/projection_builder.py
+++ b/workers/automation/src/jobctrl/infrastructure/projections/projection_builder.py
@@ -48,6 +48,7 @@ from typing import Any, Callable
 from jobctrl.domain.events.base import DomainEvent
 from jobctrl.domain.identifiers import JobId
 from jobctrl.domain.operations.projections import (
+    ApplyUrlOutcomeProjection,
     ApplyRunProjection,
     ArtifactListProjection,
     ContactProjection,
@@ -105,6 +106,80 @@ PROJECTION_NAME = "operations_projections"
 # targeted rebuild of those rows, independent of column creation.
 SCORE_AUDIT_BACKFILL = "score_audit_columns_v1"
 COMPENSATION_PROJECTION_VERSION = 1
+
+_APPLY_URL_OUTCOME_DETAILS: dict[str, tuple[str, bool]] = {
+    "APPLY_URL_EXTERNAL_RECOVERED": (
+        "An external application URL was recovered.",
+        False,
+    ),
+    "APPLY_URL_LINKEDIN_ONSITE": (
+        "LinkedIn uses an on-site application flow for this posting; "
+        "no external application URL exists.",
+        False,
+    ),
+    "APPLY_URL_CONTROL_MISSING": (
+        "No application control was visible on the authenticated LinkedIn page.",
+        True,
+    ),
+    "APPLY_URL_EXTERNAL_TARGET_MISSING": (
+        "An application control was visible, but no external application URL "
+        "could be verified.",
+        True,
+    ),
+    "APPLY_URL_NAVIGATION_FAILED": (
+        "The authenticated LinkedIn page could not be inspected.",
+        True,
+    ),
+    "APPLY_URL_UNSAFE_TARGET": (
+        "JobCtrl rejected the discovered application target because it is not "
+        "a safe public HTTP(S) destination.",
+        False,
+    ),
+}
+_APPLY_URL_OUTCOME_METHODS = frozenset(
+    {
+        "authenticated_browser",
+        "current_url",
+        "href_redirect",
+        "href",
+        "click",
+        "linkedin_onsite_apply",
+        "apply_button_missing",
+        "external_url_missing",
+        "navigation_error",
+        "resolver_error",
+        "unsafe_url",
+    }
+)
+
+
+def _apply_url_outcome_from_stage_metadata(
+    value: str | None,
+) -> ApplyUrlOutcomeProjection | None:
+    """Project only stable, code-owned application-target diagnostics."""
+
+    if not value:
+        return None
+    try:
+        metadata = json.loads(value)
+    except (TypeError, ValueError):
+        return None
+    if not isinstance(metadata, dict):
+        return None
+    code_value = metadata.get("applyUrlOutcomeCode")
+    code = code_value.strip() if isinstance(code_value, str) else ""
+    details = _APPLY_URL_OUTCOME_DETAILS.get(code)
+    if details is None:
+        return None
+    method_value = metadata.get("authenticatedApplyUrlMethod")
+    method = method_value.strip() if isinstance(method_value, str) else ""
+    message, retryable = details
+    return ApplyUrlOutcomeProjection(
+        code=code,
+        message=message,
+        retryable=retryable,
+        method=method if method in _APPLY_URL_OUTCOME_METHODS else None,
+    )
 
 # State-bearing workflow lifecycle events fold into
 # ``workflow_run_projections`` keyed by ``workflowId``. The ``WorkflowStarted``
@@ -2193,6 +2268,9 @@ class ProjectionBuilder:
                     if isinstance(blocked_by, list)
                     else (),
                     next_action=_row_nullable_str(row, "next_action"),
+                    apply_url_outcome=_apply_url_outcome_from_stage_metadata(
+                        _row_nullable_str(row, "metadata_json")
+                    ),
                 )
             )
         return result

--- a/workers/automation/src/jobctrl/infrastructure/projections/sqlite_projection_store.py
+++ b/workers/automation/src/jobctrl/infrastructure/projections/sqlite_projection_store.py
@@ -813,6 +813,16 @@ class SqliteProjectionStore:
                             "retryable": stage.retryable,
                             "blocked_by": list(stage.blocked_by),
                             "next_action": stage.next_action,
+                            "apply_url_outcome": (
+                                {
+                                    "code": stage.apply_url_outcome.code,
+                                    "message": stage.apply_url_outcome.message,
+                                    "retryable": stage.apply_url_outcome.retryable,
+                                    "method": stage.apply_url_outcome.method,
+                                }
+                                if stage.apply_url_outcome is not None
+                                else None
+                            ),
                         }
                         for stage in projection.stages
                     ]

--- a/workers/automation/tests/test_audit_projection_parity.py
+++ b/workers/automation/tests/test_audit_projection_parity.py
@@ -202,8 +202,8 @@ def _seed_rows(conn: sqlite3.Connection, fixture: dict[str, Any]) -> None:
             INSERT INTO job_stage_states (
                 tenant_id, job_id, stage, state, attempt_count, max_attempts, started_at,
                 updated_at, finished_at, duration_ms, error_code, error_message,
-                retryable, blocked_by_json, next_action
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                retryable, blocked_by_json, next_action, metadata_json
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 LOCAL_TENANT,
@@ -221,6 +221,7 @@ def _seed_rows(conn: sqlite3.Connection, fixture: dict[str, Any]) -> None:
                 stage["retryable"],
                 stage["blocked_by_json"],
                 stage["next_action"],
+                stage.get("metadata_json"),
             ),
         )
 

--- a/workers/automation/tests/test_enrichment_aggregate.py
+++ b/workers/automation/tests/test_enrichment_aggregate.py
@@ -291,7 +291,7 @@ def _enriched_without_apply_url() -> JobEnrichment:
 def test_record_apply_url_recovery_attaches_url_and_preserves_description() -> None:
     agg = _enriched_without_apply_url()
     recovered = agg.record_apply_url_recovery(
-        application_url=ApplicationUrl(value="https://apply.example/role"),
+        result=ApplicationUrl(value="https://apply.example/role"),
         extraction_tier=ExtractionTier.CSS_SELECTORS,
         started_at="t2",
         finished_at="t3",
@@ -311,7 +311,11 @@ def test_record_apply_url_recovery_attaches_url_and_preserves_description() -> N
 def test_record_apply_url_recovery_missing_url_bounds_without_failing_row() -> None:
     agg = _enriched_without_apply_url()
     recovered = agg.record_apply_url_recovery(
-        application_url=None,
+        result=EnrichmentError(
+            code="APPLY_URL_LINKEDIN_ONSITE",
+            message="LinkedIn uses an on-site application flow.",
+            retryable=False,
+        ),
         extraction_tier=ExtractionTier.CSS_SELECTORS,
         started_at="t2",
         finished_at="t3",
@@ -325,13 +329,14 @@ def test_record_apply_url_recovery_missing_url_bounds_without_failing_row() -> N
     assert recovered.last_attempt is not None
     assert recovered.last_attempt.failed
     assert recovered.last_attempt.error is not None
-    assert recovered.last_attempt.error.code == "APPLY_URL_UNRESOLVED"
+    assert recovered.last_attempt.error.code == "APPLY_URL_LINKEDIN_ONSITE"
+    assert recovered.last_attempt.error.retryable is False
 
 
 def test_record_apply_url_recovery_requires_enriched_aggregate() -> None:
     with pytest.raises(ValueError, match="requires an enriched aggregate"):
         _empty().record_apply_url_recovery(
-            application_url=ApplicationUrl(value="https://apply.example/role"),
+            result=ApplicationUrl(value="https://apply.example/role"),
             extraction_tier=ExtractionTier.CSS_SELECTORS,
             started_at="t0",
             finished_at="t1",

--- a/workers/automation/tests/test_enrichment_detail_staleness.py
+++ b/workers/automation/tests/test_enrichment_detail_staleness.py
@@ -625,7 +625,7 @@ def test_inactive_cascade_snapshot_uses_current_job_id_and_keeps_url_as_locator(
 
         quarantine = conn.execute(
             """
-            SELECT job_id, posting_url
+            SELECT job_id, posting_url, reason
             FROM discovery_quarantine_entries
             WHERE tenant_id = 'local' AND job_id = ?
             """,
@@ -642,6 +642,7 @@ def test_inactive_cascade_snapshot_uses_current_job_id_and_keeps_url_as_locator(
         assert quarantine is not None
         assert quarantine["job_id"] == str(job_id)
         assert quarantine["posting_url"] == url
+        assert quarantine["reason"] == "posting_inactive"
         assert "job_url" not in {row["name"] for row in conn.execute("PRAGMA table_info(posting_snapshot_sets)")}
         assert "job_key" not in {row["name"] for row in conn.execute("PRAGMA table_info(discovery_quarantine_entries)")}
     finally:

--- a/workers/automation/tests/test_enrichment_snapshot_pr3.py
+++ b/workers/automation/tests/test_enrichment_snapshot_pr3.py
@@ -12,7 +12,12 @@ from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanE
 from opentelemetry.trace import set_tracer_provider
 
 from jobctrl.domain.discovery.source_registry import ContentFilterOverridePolicy
-from jobctrl.domain.enrichment import DetailPage, ExtractionTier, JobEnrichment
+from jobctrl.domain.enrichment import (
+    DetailPage,
+    ExtractionTier,
+    JobEnrichment,
+    SnapshotConfidence,
+)
 from jobctrl.domain.enrichment.filter_override import FilterOverrideError, FilterOverrideLogger
 from jobctrl.domain.enrichment.services import ExtractionResult, JsonLdExtractor
 from jobctrl.domain.enrichment.snapshot_services import (
@@ -20,6 +25,7 @@ from jobctrl.domain.enrichment.snapshot_services import (
     ContentAcquisitionService,
     DedupeIndexEntry,
     TierExtractor,
+    judge_snapshot_confidence,
 )
 from jobctrl.domain.enrichment.snapshot_set import PostingSnapshotSet
 from jobctrl.domain.enrichment.snapshot_use_case import CapturePostingSnapshotUseCase
@@ -126,6 +132,27 @@ class _StaticExtractor:
 
 def _long_description() -> str:
     return "Build distributed recruiting systems with Python, Postgres, and TypeScript. " * 8
+
+
+def test_llm_description_trust_does_not_depend_on_application_url() -> None:
+    description = FullDescription(text=_long_description())
+
+    assert (
+        judge_snapshot_confidence(
+            tier=ExtractionTier.LLM_ASSISTED,
+            description=description,
+            apply_url_present=False,
+        )
+        is SnapshotConfidence.MEDIUM
+    )
+    assert (
+        judge_snapshot_confidence(
+            tier=ExtractionTier.LLM_ASSISTED,
+            description=FullDescription(text="Short but non-empty description"),
+            apply_url_present=True,
+        )
+        is SnapshotConfidence.LOW
+    )
 
 
 def _json_ld_page(

--- a/workers/automation/tests/test_linkedin_apply_resolver.py
+++ b/workers/automation/tests/test_linkedin_apply_resolver.py
@@ -344,3 +344,54 @@ def test_resolve_loaded_page_rejects_unsafe_href_before_returning_it() -> None:
 
     assert result.application_url is None
     assert result.method == "external_url_missing"
+
+
+class _LinkedInOnsiteApplyLocator:
+    clicked = False
+
+    def wait_for(self, *_args: object, **_kwargs: object) -> None:
+        return None
+
+    def get_attribute(self, attribute: str) -> str | None:
+        if attribute == "data-tracking-control-name":
+            return "public_jobs_apply-link-onsite"
+        return None
+
+    def inner_text(self) -> str:
+        return "Apply"
+
+    def click(self, *_args: object, **_kwargs: object) -> None:
+        self.clicked = True
+
+
+class _LoadedPageWithLinkedInOnsiteApply:
+    url = "https://www.linkedin.com/jobs/view/4448147529"
+
+    def __init__(self) -> None:
+        self.apply = _LinkedInOnsiteApplyLocator()
+
+    def route(self, *_args: object, **_kwargs: object) -> None:
+        return None
+
+    def unroute(self, *_args: object, **_kwargs: object) -> None:
+        return None
+
+    def locator(self, *_args: object, **_kwargs: object) -> SimpleNamespace:
+        return SimpleNamespace(first=self.apply)
+
+    def get_by_role(self, *_args: object, **_kwargs: object) -> SimpleNamespace:
+        return SimpleNamespace(first=self.apply)
+
+
+def test_resolve_loaded_page_reports_linkedin_onsite_apply_without_clicking() -> None:
+    page = _LoadedPageWithLinkedInOnsiteApply()
+    resolver = LinkedInApplyUrlResolver(url_safety_checker=_allow_public_url)
+
+    result = resolver.resolve_loaded_page(
+        page,
+        "https://www.linkedin.com/jobs/view/4448147529",
+    )
+
+    assert result.application_url is None
+    assert result.method == "linkedin_onsite_apply"
+    assert page.apply.clicked is False

--- a/workers/automation/tests/test_linkedin_authenticated_enrichment_retry.py
+++ b/workers/automation/tests/test_linkedin_authenticated_enrichment_retry.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import sqlite3
 from datetime import datetime, timezone
 from pathlib import Path
@@ -14,20 +15,26 @@ from jobctrl.domain.enrichment import (
     ExtractionTier,
     FullDescription,
     JobEnrichment,
+    PostingSnapshotSet,
     QuarantineReason,
     SnapshotConfidence,
+    SnapshotDescriptionHash,
 )
 from jobctrl.domain.identifiers import JobId, generate_job_id
 from jobctrl.domain.tenant import LOCAL_TENANT
 from jobctrl.enrichment.detail import (
     _MAX_AUTHENTICATED_LINKEDIN_RETRY_ATTEMPTS,
     _apply_authenticated_linkedin_apply_url,
+    _authenticated_apply_url_recovery_error,
     _is_linkedin_job,
     _record_posting_snapshot_from_cascade,
     _reset_authenticated_linkedin_retry_candidates,
 )
 from jobctrl.enrichment import detail
 from jobctrl.infrastructure.enrichment import SqliteEnrichmentRepository
+from jobctrl.infrastructure.enrichment.sqlite_repository import (
+    SqlitePostingSnapshotSetRepository,
+)
 from jobctrl.infrastructure.enrichment.linkedin_apply_resolver import (
     LinkedInApplyResolution,
 )
@@ -295,6 +302,88 @@ def test_enriched_missing_apply_url_preserves_description_on_failed_recovery(
     # A bounding attempt is recorded so a never-resolving row cannot be
     # re-driven through the authenticated browser forever.
     assert aggregate.attempt_count == 2
+    assert aggregate.last_attempt is not None
+    assert aggregate.last_attempt.error is not None
+    assert aggregate.last_attempt.error.code == "APPLY_URL_EXTERNAL_TARGET_MISSING"
+
+
+@pytest.mark.parametrize(
+    ("method", "expected_code", "retryable"),
+    [
+        ("linkedin_onsite_apply", "APPLY_URL_LINKEDIN_ONSITE", False),
+        ("apply_button_missing", "APPLY_URL_CONTROL_MISSING", True),
+        ("external_url_missing", "APPLY_URL_EXTERNAL_TARGET_MISSING", True),
+        ("navigation_error", "APPLY_URL_NAVIGATION_FAILED", True),
+        ("unsafe_url", "APPLY_URL_UNSAFE_TARGET", False),
+    ],
+)
+def test_apply_url_recovery_outcomes_are_explicit(
+    method: str,
+    expected_code: str,
+    retryable: bool,
+) -> None:
+    error = _authenticated_apply_url_recovery_error(
+        method=method,
+        raw_error="resolver detail",
+    )
+
+    assert error.code == expected_code
+    assert error.message
+    assert error.retryable is retryable
+
+
+def test_linkedin_onsite_apply_is_audited_and_not_retried(
+    conn: sqlite3.Connection,
+) -> None:
+    url = "https://www.linkedin.com/jobs/view/4448147529"
+    _seed_discovered(conn, url, "linkedin")
+    _save_enriched(conn, url, application_url=None)
+    job_id = _job_id(conn, url)
+    ensure_job_stage_rows(conn, job_id, tenant_id=LOCAL_TENANT)
+    set_stage_state(
+        conn,
+        job_id,
+        "enrich",
+        "succeeded",
+        tenant_id=LOCAL_TENANT,
+        validate_transition=False,
+    )
+    conn.commit()
+    resolver = _RecoveryResolver(LinkedInApplyResolution(None, "linkedin_onsite_apply"))
+
+    for _ in range(2):
+        _reset_authenticated_linkedin_retry_candidates(
+            conn,
+            job_ids=(job_id,),
+            resolver_factory=lambda: resolver,
+            session=offline_session(conn, site="linkedin"),
+        )
+
+    assert resolver.calls == [url]
+    aggregate = SqliteEnrichmentRepository(conn).load(LOCAL_TENANT, job_id)
+    assert aggregate is not None
+    assert aggregate.is_enriched
+    assert aggregate.last_attempt is not None
+    assert aggregate.last_attempt.error is not None
+    assert aggregate.last_attempt.error.code == "APPLY_URL_LINKEDIN_ONSITE"
+    assert aggregate.last_attempt.error.retryable is False
+    stage = conn.execute(
+        "SELECT state, metadata_json FROM job_stage_states WHERE tenant_id = ? AND job_id = ? AND stage = 'enrich'",
+        (str(LOCAL_TENANT), str(job_id)),
+    ).fetchone()
+    assert stage is not None
+    assert stage["state"] == "succeeded"
+    metadata = json.loads(stage["metadata_json"])
+    assert metadata["applyUrlOutcomeCode"] == "APPLY_URL_LINKEDIN_ONSITE"
+    assert "no external application URL exists" in metadata["applyUrlOutcomeMessage"]
+    events = conn.execute(
+        "SELECT message, payload_json FROM job_events "
+        "WHERE tenant_id = ? AND job_id = ? AND event_type = 'StageProgress'",
+        (str(LOCAL_TENANT), str(job_id)),
+    ).fetchall()
+    assert len(events) == 1
+    assert "no external application URL exists" in events[0]["message"]
+    assert json.loads(events[0]["payload_json"])["applyUrlOutcomeCode"] == ("APPLY_URL_LINKEDIN_ONSITE")
 
 
 def test_enriched_missing_apply_url_preserves_description_when_resolver_raises(
@@ -351,8 +440,8 @@ def test_enriched_missing_apply_url_backfills_on_successful_recovery(
         (str(LOCAL_TENANT), str(job_id)),
     ).fetchone()
     assert before is not None
-    assert before["latest_confidence"] == SnapshotConfidence.LOW.value
-    assert before["latest_quarantine_reason"] == QuarantineReason.LOW_CONFIDENCE_EXTRACTION.value
+    assert before["latest_confidence"] == SnapshotConfidence.MEDIUM.value
+    assert before["latest_quarantine_reason"] == QuarantineReason.NONE.value
     ensure_job_stage_rows(conn, job_id, tenant_id=LOCAL_TENANT)
     set_stage_state(
         conn,
@@ -400,6 +489,93 @@ def test_enriched_missing_apply_url_backfills_on_successful_recovery(
     ).fetchone()
     assert tailor_state is not None
     assert dict(tailor_state) == {"state": "pending", "error_code": None}
+
+
+def test_legacy_missing_apply_url_snapshot_is_reclassified_without_browser_retry(
+    conn: sqlite3.Connection,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    url = "https://www.linkedin.com/jobs/view/legacy-content-trust"
+    description = " ".join(["Senior platform engineering responsibilities with Python and distributed systems"] * 20)
+    _seed_discovered(conn, url, "linkedin")
+    _save_enriched(conn, url, application_url=None, description=description)
+    job_id = _job_id(conn, url)
+    snapshot_set = PostingSnapshotSet.empty(
+        tenant_id=LOCAL_TENANT,
+        job_id=job_id,
+        updated_at="2026-01-01T00:00:00+00:00",
+    )
+    snapshot_set, _ = snapshot_set.record_snapshot(
+        source_id="jobspy:linkedin",
+        extraction_tier=ExtractionTier.LLM_ASSISTED.value,
+        description_hash=SnapshotDescriptionHash.from_text(description),
+        apply_url=None,
+        active_state=ActiveState.ACTIVE,
+        confidence=SnapshotConfidence.LOW,
+        quarantine_reason=QuarantineReason.LOW_CONFIDENCE_EXTRACTION,
+        captured_at="2026-01-01T00:00:00+00:00",
+    )
+    SqlitePostingSnapshotSetRepository(conn).save(snapshot_set)
+    ensure_job_stage_rows(conn, job_id, tenant_id=LOCAL_TENANT)
+    set_stage_state(
+        conn,
+        job_id,
+        "enrich",
+        "succeeded",
+        tenant_id=LOCAL_TENANT,
+        validate_transition=False,
+    )
+    set_stage_state(
+        conn,
+        job_id,
+        "tailor",
+        "blocked",
+        tenant_id=LOCAL_TENANT,
+        error_code="ENRICHMENT_QUARANTINED",
+        error_message="Tailoring is waiting for a trustworthy posting snapshot.",
+        retryable=True,
+        blocked_by=["enrich"],
+        validate_transition=False,
+    )
+    conn.commit()
+    monkeypatch.setattr(detail, "linkedin_apply_resolver_enabled", lambda: False)
+
+    def unexpected_resolver() -> object:
+        raise AssertionError("content-trust repair must not require browser navigation")
+
+    for _ in range(2):
+        _reset_authenticated_linkedin_retry_candidates(
+            conn,
+            job_ids=(job_id,),
+            resolver_factory=unexpected_resolver,
+        )
+
+    repaired = SqlitePostingSnapshotSetRepository(conn).load(LOCAL_TENANT, job_id)
+    assert repaired is not None
+    assert repaired.latest_snapshot is not None
+    assert repaired.latest_snapshot.snapshot_version == 2
+    assert repaired.latest_snapshot.confidence is SnapshotConfidence.MEDIUM
+    assert repaired.latest_snapshot.quarantine_reason is QuarantineReason.NONE
+    assert "content_trust_reclassified:apply_url_independent" in (repaired.latest_snapshot.evidence)
+    tailor_state = conn.execute(
+        "SELECT state, error_code, error_message FROM job_stage_states "
+        "WHERE tenant_id = ? AND job_id = ? AND stage = 'tailor'",
+        (str(LOCAL_TENANT), str(job_id)),
+    ).fetchone()
+    assert tailor_state is not None
+    assert dict(tailor_state) == {
+        "state": "pending",
+        "error_code": None,
+        "error_message": None,
+    }
+    events = conn.execute(
+        "SELECT COUNT(*) FROM job_events WHERE tenant_id = ? AND job_id = ? "
+        "AND event_type = 'PostingContentSnapshotCaptured' "
+        "AND json_extract(payload_json, '$.reason') = 'missing_apply_url_content_trust_recovery'",
+        (str(LOCAL_TENANT), str(job_id)),
+    ).fetchone()
+    assert events is not None
+    assert events[0] == 1
 
 
 def test_enriched_missing_apply_url_recovery_is_bounded_across_runs(

--- a/workers/automation/tests/test_linkedin_authenticated_enrichment_retry.py
+++ b/workers/automation/tests/test_linkedin_authenticated_enrichment_retry.py
@@ -25,6 +25,7 @@ from jobctrl.domain.tenant import LOCAL_TENANT
 from jobctrl.enrichment.detail import (
     _MAX_AUTHENTICATED_LINKEDIN_RETRY_ATTEMPTS,
     _apply_authenticated_linkedin_apply_url,
+    _authenticated_apply_url_outcome_metadata,
     _authenticated_apply_url_recovery_error,
     _is_linkedin_job,
     _record_posting_snapshot_from_cascade,
@@ -308,28 +309,42 @@ def test_enriched_missing_apply_url_preserves_description_on_failed_recovery(
 
 
 @pytest.mark.parametrize(
-    ("method", "expected_code", "retryable"),
+    ("method", "application_url", "expected_code", "retryable"),
     [
-        ("linkedin_onsite_apply", "APPLY_URL_LINKEDIN_ONSITE", False),
-        ("apply_button_missing", "APPLY_URL_CONTROL_MISSING", True),
-        ("external_url_missing", "APPLY_URL_EXTERNAL_TARGET_MISSING", True),
-        ("navigation_error", "APPLY_URL_NAVIGATION_FAILED", True),
-        ("unsafe_url", "APPLY_URL_UNSAFE_TARGET", False),
+        ("click", "https://apply.example/jobs/1", "APPLY_URL_EXTERNAL_RECOVERED", False),
+        ("linkedin_onsite_apply", None, "APPLY_URL_LINKEDIN_ONSITE", False),
+        ("apply_button_missing", None, "APPLY_URL_CONTROL_MISSING", True),
+        ("external_url_missing", None, "APPLY_URL_EXTERNAL_TARGET_MISSING", True),
+        ("navigation_error", None, "APPLY_URL_NAVIGATION_FAILED", True),
+        ("unsafe_url", None, "APPLY_URL_UNSAFE_TARGET", False),
     ],
 )
 def test_apply_url_recovery_outcomes_are_explicit(
     method: str,
+    application_url: str | None,
     expected_code: str,
     retryable: bool,
 ) -> None:
-    error = _authenticated_apply_url_recovery_error(
-        method=method,
-        raw_error="resolver detail",
+    private_detail = "/Users/private/LinkedIn/Profile/Default?token=secret"
+    metadata = _authenticated_apply_url_outcome_metadata(
+        {
+            "authenticated_apply_url_method": method,
+            "authenticated_apply_url_error": private_detail,
+            "application_url": application_url,
+        }
     )
 
-    assert error.code == expected_code
-    assert error.message
-    assert error.retryable is retryable
+    assert metadata["authenticatedApplyUrlMethod"] == method
+    assert metadata["applyUrlOutcomeCode"] == expected_code
+    assert metadata["applyUrlOutcomeRetryable"] is retryable
+    assert private_detail not in json.dumps(metadata)
+    if application_url is None:
+        error = _authenticated_apply_url_recovery_error(
+            method=method,
+            raw_error=private_detail,
+        )
+        assert error.code == expected_code
+        assert error.message == metadata["applyUrlOutcomeMessage"]
 
 
 def test_linkedin_onsite_apply_is_audited_and_not_retried(
@@ -374,6 +389,7 @@ def test_linkedin_onsite_apply_is_audited_and_not_retried(
     assert stage is not None
     assert stage["state"] == "succeeded"
     metadata = json.loads(stage["metadata_json"])
+    assert metadata["authenticatedApplyUrlMethod"] == "linkedin_onsite_apply"
     assert metadata["applyUrlOutcomeCode"] == "APPLY_URL_LINKEDIN_ONSITE"
     assert "no external application URL exists" in metadata["applyUrlOutcomeMessage"]
     events = conn.execute(
@@ -390,9 +406,21 @@ def test_enriched_missing_apply_url_preserves_description_when_resolver_raises(
     conn: sqlite3.Connection,
 ) -> None:
     url = "https://www.linkedin.com/jobs/view/raise"
+    private_detail = "/Users/private/LinkedIn/Profile/Default?token=secret"
     _seed_discovered(conn, url, "linkedin")
     _save_enriched(conn, url, application_url=None)
-    resolver = _RecoveryResolver(RuntimeError("login wall"))
+    job_id = _job_id(conn, url)
+    ensure_job_stage_rows(conn, job_id, tenant_id=LOCAL_TENANT)
+    set_stage_state(
+        conn,
+        job_id,
+        "enrich",
+        "succeeded",
+        tenant_id=LOCAL_TENANT,
+        validate_transition=False,
+    )
+    conn.commit()
+    resolver = _RecoveryResolver(RuntimeError(private_detail))
 
     reset_count = _reset_authenticated_linkedin_retry_candidates(
         conn,
@@ -402,12 +430,26 @@ def test_enriched_missing_apply_url_preserves_description_when_resolver_raises(
 
     assert reset_count == 0
     repo = SqliteEnrichmentRepository(conn)
-    aggregate = repo.load(LOCAL_TENANT, _job_id(conn, url))
+    aggregate = repo.load(LOCAL_TENANT, job_id)
     assert aggregate is not None
     assert aggregate.is_enriched
     assert aggregate.full_description is not None
     assert aggregate.full_description.text == "A complete LinkedIn description"
     assert aggregate.application_url is None
+    assert aggregate.last_attempt is not None
+    assert aggregate.last_attempt.error is not None
+    assert private_detail not in aggregate.last_attempt.error.message
+    stage = conn.execute(
+        "SELECT metadata_json FROM job_stage_states WHERE tenant_id = ? AND job_id = ? AND stage = 'enrich'",
+        (str(LOCAL_TENANT), str(job_id)),
+    ).fetchone()
+    assert stage is not None
+    assert private_detail not in (stage["metadata_json"] or "")
+    events = conn.execute(
+        "SELECT payload_json FROM job_events WHERE tenant_id = ? AND job_id = ?",
+        (str(LOCAL_TENANT), str(job_id)),
+    ).fetchall()
+    assert private_detail not in json.dumps([row["payload_json"] for row in events])
 
 
 def test_enriched_missing_apply_url_backfills_on_successful_recovery(
@@ -491,13 +533,21 @@ def test_enriched_missing_apply_url_backfills_on_successful_recovery(
     assert dict(tailor_state) == {"state": "pending", "error_code": None}
 
 
-def test_legacy_missing_apply_url_snapshot_is_reclassified_without_browser_retry(
+@pytest.mark.parametrize(
+    ("site", "url"),
+    [
+        ("linkedin", "https://www.linkedin.com/jobs/view/legacy-content-trust"),
+        ("remoteok", "https://remoteok.com/remote-jobs/legacy-content-trust"),
+    ],
+)
+def test_legacy_missing_apply_url_snapshot_is_reclassified_for_every_source_without_browser_retry(
     conn: sqlite3.Connection,
     monkeypatch: pytest.MonkeyPatch,
+    site: str,
+    url: str,
 ) -> None:
-    url = "https://www.linkedin.com/jobs/view/legacy-content-trust"
     description = " ".join(["Senior platform engineering responsibilities with Python and distributed systems"] * 20)
-    _seed_discovered(conn, url, "linkedin")
+    _seed_discovered(conn, url, site)
     _save_enriched(conn, url, application_url=None, description=description)
     job_id = _job_id(conn, url)
     snapshot_set = PostingSnapshotSet.empty(
@@ -506,7 +556,7 @@ def test_legacy_missing_apply_url_snapshot_is_reclassified_without_browser_retry
         updated_at="2026-01-01T00:00:00+00:00",
     )
     snapshot_set, _ = snapshot_set.record_snapshot(
-        source_id="jobspy:linkedin",
+        source_id=f"jobspy:{site}",
         extraction_tier=ExtractionTier.LLM_ASSISTED.value,
         description_hash=SnapshotDescriptionHash.from_text(description),
         apply_url=None,

--- a/workers/automation/tests/test_linkedin_authenticated_enrichment_retry.py
+++ b/workers/automation/tests/test_linkedin_authenticated_enrichment_retry.py
@@ -589,17 +589,26 @@ def test_legacy_missing_apply_url_snapshot_is_reclassified_for_every_source_with
     )
     conn.commit()
     monkeypatch.setattr(detail, "linkedin_apply_resolver_enabled", lambda: False)
+    # Production wraps ``resolver_factory()`` in ``except Exception``, so a
+    # raising factory would be swallowed and could never fail this test.
+    # Record construction and navigation instead, and assert below that the
+    # content-trust repair never touched the browser resolver.
+    resolver = _RecoveryResolver(LinkedInApplyResolution("https://apply.example/unexpected", "click"))
+    resolver_factory_calls: list[str] = []
 
-    def unexpected_resolver() -> object:
-        raise AssertionError("content-trust repair must not require browser navigation")
+    def recording_resolver_factory() -> object:
+        resolver_factory_calls.append("built")
+        return resolver
 
     for _ in range(2):
         _reset_authenticated_linkedin_retry_candidates(
             conn,
             job_ids=(job_id,),
-            resolver_factory=unexpected_resolver,
+            resolver_factory=recording_resolver_factory,
         )
 
+    assert resolver_factory_calls == []
+    assert resolver.calls == []
     repaired = SqlitePostingSnapshotSetRepository(conn).load(LOCAL_TENANT, job_id)
     assert repaired is not None
     assert repaired.latest_snapshot is not None
@@ -703,6 +712,51 @@ def test_failed_row_still_reset_for_authenticated_retry(
     # Non-enriched rows never touch the apply-URL resolver.
     assert resolver.calls == []
     repo = SqliteEnrichmentRepository(conn)
+    aggregate = repo.load(LOCAL_TENANT, _job_id(conn, url))
+    assert aggregate is not None
+    assert aggregate.is_pending
+
+
+def test_failed_rows_are_not_reset_while_authenticated_capability_is_disabled(
+    conn: sqlite3.Connection,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Out-of-box state: no capability, no anonymous budget-burning retries.
+
+    Resetting a failed LinkedIn row exists solely to re-scrape it under the
+    owner-authenticated browser. While the capability is disabled, repeated
+    enrichment runs must leave failed rows untouched — anonymous retries
+    would consume the shared bounded attempt budget and permanently skip the
+    row once the user enables the capability.
+    """
+    url = "https://www.linkedin.com/jobs/view/capability-disabled"
+    _seed_discovered(conn, url, "linkedin")
+    _save_failed(conn, url, retryable=True)
+    monkeypatch.setattr(detail, "linkedin_apply_resolver_enabled", lambda: False)
+    resolver_factory_calls: list[str] = []
+
+    def recording_resolver_factory() -> object:
+        resolver_factory_calls.append("built")
+        return _RecoveryResolver(LinkedInApplyResolution("https://apply.example/x", "click"))
+
+    for _ in range(_MAX_AUTHENTICATED_LINKEDIN_RETRY_ATTEMPTS + 1):
+        reset_count = _reset_authenticated_linkedin_retry_candidates(
+            conn,
+            resolver_factory=recording_resolver_factory,
+        )
+        assert reset_count == 0
+
+    assert resolver_factory_calls == []
+    repo = SqliteEnrichmentRepository(conn)
+    aggregate = repo.load(LOCAL_TENANT, _job_id(conn, url))
+    assert aggregate is not None
+    assert aggregate.is_failed
+    assert aggregate.attempt_count == 1
+
+    # Enabling the capability later still finds the row eligible: no attempt
+    # budget was consumed while the capability was off.
+    monkeypatch.setattr(detail, "linkedin_apply_resolver_enabled", lambda: True)
+    assert _reset_authenticated_linkedin_retry_candidates(conn) == 1
     aggregate = repo.load(LOCAL_TENANT, _job_id(conn, url))
     assert aggregate is not None
     assert aggregate.is_pending


### PR DESCRIPTION
## What changed

- separates posting-description confidence from application-target readiness
- repairs legacy readable snapshots with an immutable reclassification and releases only stale Enrichment quarantine blockers
- detects LinkedIn on-site application controls without clicking them or retrying forever
- persists distinct outcomes for recovered, on-site, missing-control, missing-target, navigation, and unsafe-target cases
- projects the same privacy-safe, allow-listed outcome through both Python and TypeScript read-model writers
- keeps cancellation reconciliation outside slow authenticated browser transactions
- documents the user-facing confidence, retry, and audit contracts

## Why

A complete posting description could be labeled low confidence solely because no external application URL was available. That incorrectly blocked Tailor, and URL recovery collapsed legitimate LinkedIn on-site flows together with transient failures as a generic unresolved result.

## Validation

- independent reviewer gate: PASS (Blocker 0, High 0, Medium 0, Low 0)
- independent QA gate: PASS (Blocker 0, High 0, Medium 0, Low 0)
- full Python suite: 3383 passed, 2 skipped
- full API suite outside the localhost sandbox: 750 passed
- shared Python/TypeScript projection parity: 3 passed / 2 passed
- focused Enrichment, content-trust, and cancellation regressions: 35 passed
- focused API outcome and inactive-posting projections: 56 passed
- rendered application-target diagnostics: 17 passed
- full web unit suite: 2004 passed
- aggregate cross-stack check: passed
- documentation build and link checks: passed, 9651 references resolved
- Ruff and `git diff --check`: passed

## Checklist

- [x] Relevant local checks are listed above.
- [x] No secrets, private profile data, generated application materials, raw logs, browser profiles, SQLite databases, or local paths are included.
