### PR TITLE
fix(operations): identify selected run stages

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,9 @@ evidence, qualifications, and the complete capability matrix.
   requests are harmless, the requester/source remains in the run timeline, and
   an already-terminal result remains inspectable. Canceling Enrich terminalizes
   only that run's unfinished selected jobs; unrelated pending work is untouched.
+  Run detail names the selected stage scope from the workflow input, so a
+  cover-only maintenance run is labeled **Cover letter run** instead of the
+  generic pipeline workflow name.
 - Review privacy-bounded learning recommendations on the Dashboard. JobCtrl
   derives them only from explicit reviewed signals, requires compatible
   evidence across jobs, and changes Materials behavior only after you accept a

--- a/apps/web/src/views/runs/WorkflowRunDrawer.test.tsx
+++ b/apps/web/src/views/runs/WorkflowRunDrawer.test.tsx
@@ -51,7 +51,7 @@ describe("<WorkflowRunDrawer>", () => {
     expect(
       within(workspace).getByRole("heading", {
         level: 1,
-        name: "Job pipeline workflow",
+        name: "Discover run",
       }),
     ).toHaveAttribute("data-typography", "page-title");
     expect(
@@ -109,6 +109,8 @@ describe("<WorkflowRunDrawer>", () => {
     expect(
       within(metadata!).queryByText("Status", { exact: true }),
     ).not.toBeInTheDocument();
+    expect(within(metadata!).getByText("Selected stages")).toBeInTheDocument();
+    expect(within(metadata!).getByText("Discover")).toBeInTheDocument();
 
     expect(
       within(workspace).getByRole("link", {
@@ -125,6 +127,39 @@ describe("<WorkflowRunDrawer>", () => {
       within(workspace).getByRole("link", { name: "Open pipeline controls" }),
     ).toHaveAttribute("href", "/pipelines");
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("names a maintenance pipeline from its selected stage scope", async () => {
+    const workflowRun = vi.fn(async () =>
+      makeWorkflowRunDetail({
+        status: "succeeded",
+        errorCode: null,
+        errorMessage: null,
+        retryable: false,
+        inputSummary: { stages: ["cover"] },
+      }),
+    );
+    const harness = buildProviderHarness({
+      ports: buildTestPorts({ api: { workflowRun } }),
+    });
+    const router = buildRouter();
+    render(<RouterProvider router={router} />, { wrapper: harness.Wrapper });
+
+    const workspace = await screen.findByRole("article", {
+      name: "Workflow run details",
+    });
+    expect(
+      within(workspace).getByRole("heading", {
+        level: 1,
+        name: "Cover letter run",
+      }),
+    ).toBeInTheDocument();
+    const details = within(workspace)
+      .getByRole("heading", { level: 2, name: "Run details" })
+      .closest("section");
+    expect(details).not.toBeNull();
+    expect(within(details!).getByText("Selected stages")).toBeInTheDocument();
+    expect(within(details!).getByText("Cover letter")).toBeInTheDocument();
   });
 
   it("copies both run identities through the clipboard port", async () => {

--- a/apps/web/src/views/runs/WorkflowRunDrawer.tsx
+++ b/apps/web/src/views/runs/WorkflowRunDrawer.tsx
@@ -45,8 +45,34 @@ function humanizeIdentifier(value: string): string {
 }
 
 function workflowTitle(run: WorkflowRunDetail): string {
+  const stages = selectedStageLabels(run);
+  if (run.workflowType === "JobPipelineWorkflow" && stages.length > 0) {
+    return `${stages.join(" → ")} run`;
+  }
   const title = run.title || run.workflowType || "Workflow run";
   return title === run.workflowType ? humanizeIdentifier(title) : title;
+}
+
+const PIPELINE_STAGE_LABELS: Readonly<Record<string, string>> = {
+  discover: "Discover",
+  enrich: "Enrich",
+  score: "Score",
+  tailor: "Tailor",
+  cover: "Cover letter",
+  apply: "Apply",
+};
+
+function selectedStageLabels(run: WorkflowRunDetail): string[] {
+  const stages = run.inputSummary.stages;
+  if (!Array.isArray(stages)) return [];
+  const labels: string[] = [];
+  for (const stage of stages) {
+    if (typeof stage !== "string" || !stage.trim()) continue;
+    const normalized = stage.trim().toLowerCase();
+    const label = PIPELINE_STAGE_LABELS[normalized] ?? humanizeIdentifier(stage);
+    if (!labels.includes(label)) labels.push(label);
+  }
+  return labels;
 }
 
 function formatDuration(value: number | null): string {
@@ -206,6 +232,7 @@ function RunActions({ run }: { readonly run: WorkflowRunDetail }) {
 }
 
 function RunMetadata({ run }: { readonly run: WorkflowRunDetail }) {
+  const selectedStages = selectedStageLabels(run);
   return (
     <RunSection id="workflow-run-details-title" title="Run details">
       <dl className="workflow-run-metadata">
@@ -241,6 +268,12 @@ function RunMetadata({ run }: { readonly run: WorkflowRunDetail }) {
           <dt data-typography="label">Workflow type</dt>
           <dd data-typography="code">{run.workflowType || "Not available"}</dd>
         </div>
+        {selectedStages.length > 0 ? (
+          <div>
+            <dt data-typography="label">Selected stages</dt>
+            <dd data-typography="body">{selectedStages.join(" → ")}</dd>
+          </div>
+        ) : null}
         {run.jobKey ? (
           <div>
             <dt data-typography="label">Job</dt>

--- a/docs/local-reliability-qa.md
+++ b/docs/local-reliability-qa.md
@@ -260,6 +260,8 @@ apply, and that its technical details expose only the allow-listed outcome
 rather than raw resolver metadata. The regression fixtures must cover every
 application-target outcome, redact a resolver error containing a private local
 path, and repair a legacy non-LinkedIn snapshot without browser navigation.
+A targeted workflow run must also identify its selected stage scope in the run
+heading and details.
 
 The browser-local public demo may cover realtime state preservation, but its
 learning capabilities are intentionally unavailable. Recommendation review,

--- a/docs/user/normal-flows.md
+++ b/docs/user/normal-flows.md
@@ -541,7 +541,8 @@ Useful web app views:
 - Jobs for triage and the bookmarkable Job Detail workspace.
 - Runs for the shared Discover, preparation, and Apply history, using one status
   vocabulary, terminal-state contract, cancellation control, and route-level
-  timeline.
+  timeline. A run's heading and **Selected stages** field identify the exact
+  stage scope recorded in its workflow input.
 - Evidence for profile-evidence reuse, generated-material usage, and gaps.
 - Artifacts for generated files and same-job artifact comparisons.
 - Apply Review for approval and resume edits.
@@ -567,7 +568,7 @@ you pass `--acknowledge`, which marks the displayed digest as reviewed.
 <WorkflowSurfacePanel surface="web">
 
 ![JobCtrl Runs page listing workflow runs with status and mode](../assets/screenshots/runs.png)
-*The Runs page lists workflow runs with status, mode, timing, and a link into the web interface of Temporal, the workflow engine. Filter the complete history by status, exact workflow type, or an inclusive date range before opening a run timeline.*
+*The Runs page lists workflow runs with status, mode, timing, and a link into the web interface of Temporal, the workflow engine. Filter the complete history by status, exact workflow type, or an inclusive date range before opening a run timeline. Run detail names the exact selected stage scope from the workflow input.*
 
 </WorkflowSurfacePanel>
 

--- a/docs/user/product-tour.md
+++ b/docs/user/product-tour.md
@@ -190,14 +190,17 @@ logs, and follow-up reminders remain inspectable as separate decisions.
 
 Runs is the durable workflow index. Filter by status, inspect start/update/end
 time and progress, cancel eligible work, or open the run route for its complete
-timeline and failure facts.
+timeline and failure facts. Run detail derives its heading and **Selected
+stages** field from the canonical workflow input, so a targeted maintenance run
+identifies the pipeline stages that actually ran.
 
 ### Run Detail
 
 ![JobCtrl Run Detail route workspace with workflow facts, failure diagnostics, and lifecycle timeline](../assets/screenshots/run-detail.png)
 
 Run Detail shows workflow and Temporal identities, job relationship, mode,
-status, timestamps, retryability, failure code/message, and lifecycle events.
+selected stage scope, status, timestamps, retryability, failure code/message,
+and lifecycle events.
 
 ### Debug
 


### PR DESCRIPTION
## What changed

- derives JobPipelineWorkflow detail headings from the canonical selected stage input
- shows the selected stage scope in Run details
- labels targeted maintenance runs precisely, including cover-only runs as Cover letter run
- documents the run-scope audit contract and regression expectation

## Why

The generic Job pipeline workflow heading did not tell an operator which pipeline stages actually ran. The run already persisted the authoritative stage selection in `inputSummary.stages`; this change renders that source of truth.

## Validation

- independent reviewer gate: PASS (Blocker 0, High 0, Medium 0, Low 0)
- independent QA gate: PASS (Blocker 0, High 0, Medium 0, Low 0)
- focused WorkflowRunDrawer suite: 7 passed
- disposable rendered drawer matrix: 4 passed
- web TypeScript check: passed
- cumulative full Python suite: 3383 passed, 2 skipped
- cumulative full API suite outside the localhost sandbox: 750 passed
- documentation build and link checks: passed, 9651 references resolved
- exact child diff and `git diff --check`: passed

## Checklist

- [x] Relevant local checks are listed above.
- [x] No secrets, private profile data, generated application materials, raw logs, browser profiles, SQLite databases, or local paths are included.
