### PR TITLE
fix(pipeline): persist score threshold skips

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,12 @@ evidence, qualifications, and the complete capability matrix.
   Run detail names the selected stage scope from the workflow input, so a
   cover-only maintenance run is labeled **Cover letter run** instead of the
   generic pipeline workflow name.
+- Treat `pending` as work that can still start. When a current score is below
+  the live materials threshold, Tailor, Cover, and Apply instead show
+  **skipped** with the `MIN_SCORE` reason and the exact score/threshold pair.
+  A score hard blocker remains **blocked**. Lowering the threshold, recording a
+  higher score, or deliberately choosing **Tailor this job** clears only that
+  threshold-owned skip; it does not consume a failed-generation retry.
 - Review privacy-bounded learning recommendations on the Dashboard. JobCtrl
   derives them only from explicit reviewed signals, requires compatible
   evidence across jobs, and changes Materials behavior only after you accept a

--- a/apps/web/src/contexts/pipeline/components/StageTimeline.test.tsx
+++ b/apps/web/src/contexts/pipeline/components/StageTimeline.test.tsx
@@ -167,6 +167,38 @@ describe("<StageTimeline>", () => {
     expect(screen.queryByText(/jobctrl retry enrich/i)).not.toBeInTheDocument();
   });
 
+  it("explains a score-threshold skip without presenting it as retryable work", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(
+      <StageTimeline
+        jobId="job-low-fit"
+        stages={[
+          {
+            ...makeStage("tailor", "skipped"),
+            errorCode: "MIN_SCORE",
+            errorMessage:
+              "Fit score 6/10 is below the materials threshold 7/10.",
+            retryable: false,
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("skipped")).toBeInTheDocument();
+    await user.click(
+      screen.getByRole("button", { name: "Technical details" }),
+    );
+    const diagnostics = screen.getByLabelText("tailor diagnostics");
+    expect(diagnostics).toHaveTextContent("MIN_SCORE");
+    expect(diagnostics).toHaveTextContent(
+      "Fit score 6/10 is below the materials threshold 7/10.",
+    );
+    expect(diagnostics).not.toHaveTextContent(/attempts|retry/i);
+    expect(
+      screen.getByRole("button", { name: "Tailor this job" }),
+    ).toBeInTheDocument();
+  });
+
   it.each([
     [
       "APPLY_URL_EXTERNAL_RECOVERED",

--- a/apps/web/src/contexts/pipeline/components/StageTimeline.tsx
+++ b/apps/web/src/contexts/pipeline/components/StageTimeline.tsx
@@ -267,10 +267,10 @@ function stageLabel(stage: StageSummary["stage"]): string {
 
 function stageDiagnostics(stage: StageSummary): Array<[string, string]> {
   const diagnostics: Array<[string, string]> = [];
-  if (["failed", "exhausted", "blocked"].includes(stage.state)) {
+  if (["failed", "exhausted", "blocked", "skipped"].includes(stage.state)) {
     if (stage.errorCode) diagnostics.push(["code", stage.errorCode]);
     if (stage.errorMessage) diagnostics.push(["message", stage.errorMessage]);
-    if (stage.attemptCount || stage.maxAttempts) {
+    if (stage.state !== "skipped" && (stage.attemptCount || stage.maxAttempts)) {
       diagnostics.push([
         "attempts",
         `${stage.attemptCount}/${stage.maxAttempts}`,

--- a/docs/architecture/pipeline/stages.md
+++ b/docs/architecture/pipeline/stages.md
@@ -257,6 +257,13 @@ Behavior notes:
   the scoring LLM. Scoring-policy and tailoring-policy changes never silently
   rescore or regenerate — that is what the explicit `rescore_*` / `retailor_*`
   actions are for.
+- A current score below the live threshold transitions Tailor, Cover, and Apply
+  to terminal `skipped` rows owned by `MIN_SCORE`, with the score and threshold
+  persisted in diagnostic metadata. This is a policy exclusion, not a blocked
+  dependency and not pending work. Reconciliation is idempotent and clears only
+  `MIN_SCORE` skips when the threshold or score later permits work; accepted or
+  in-flight stages, unrelated failures/blocks, and skips owned by another reason
+  are preserved. A score hard blocker takes precedence and remains `blocked`.
 - There is no local preparation reaper. Rows already claimed by a fast worker are
   not moved backward; Temporal owns in-flight recovery.
 

--- a/docs/local-reliability-qa.md
+++ b/docs/local-reliability-qa.md
@@ -138,6 +138,15 @@ non-retryable `exhausted`, and a later pickup cannot restart it without an
 explicit attempt reset. Run at least two durable failures against the same
 materials generation and assert that both complete inner-attempt reports remain
 in the append-only audit history.
+For a current score below the live materials threshold, preparation must persist
+Tailor, Cover, and Apply as non-retryable `skipped` rows with `MIN_SCORE` and the
+exact score/threshold pair. No row may remain `pending` after the workflow has
+made that terminal policy decision. Repeating reconciliation must add no event;
+a hard eligibility blocker must replace the threshold skip with `blocked`; and
+lowering the threshold or using the explicit per-job low-fit override must clear
+only `MIN_SCORE` rows and restore dependency-aware stage state. The rendered Job
+Detail timeline must expose that reason while retaining **Tailor this job** and
+must not present attempts or a retry action for the skip.
 Change the enriched posting snapshot after an employer analysis exists, then
 run Score and Tailor. Score must resolve the current analysis cache identity and
 persist a requirement-fit report for that exact generation. A deliberately

--- a/docs/plans/2026-08-04-pipeline-reliability-chaos.md
+++ b/docs/plans/2026-08-04-pipeline-reliability-chaos.md
@@ -1,6 +1,6 @@
 # Pipeline Reliability Chaos Campaign
 
-- **Status:** R01-R24 campaign completed; R25 and live incident recovery are under final cumulative verification
+- **Status:** R01-R25 campaign completed; R26 code and fixture verification passed, with live read-model reconciliation pending
 - **Authored:** 2026-08-04
 - **Environment:** Production-shaped local stack with disposable non-production data
 - **Safety boundary:** Never use `~/.jobctrl/jobctrl.db`, real applications, or real submission targets
@@ -18,8 +18,13 @@ Reliability remains simple when ownership is explicit:
    member of its exact selected cohort without mutating unrelated pending work.
 7. Inner model-repair attempts and durable stage executions have separate,
    bounded counters; retrying a failed stage must converge to `exhausted`.
+8. A workflow's terminal policy exclusion must be persisted as an explicit,
+   reversible `skipped` stage decision; it cannot remain ownerless `pending`.
 
-Every scenario below must prove those seven invariants through the database, Temporal history, API operations snapshot, and rendered Pipelines UI. A scenario fails if it needs a manual retry button unless the terminal condition is explicitly non-retryable.
+Every scenario below must prove those eight invariants through the database,
+Temporal history, API operations snapshot, and rendered Pipelines UI. A
+scenario fails if it needs a manual retry button unless the terminal condition
+is explicitly non-retryable.
 
 ## Test Topology
 
@@ -54,6 +59,7 @@ The campaign owns an isolated `JOBCTRL_DIR`, SQLite database, Temporal data dire
 | R23 | Global or explicitly selected Enrich cohort running | Request cancellation through JobCtrl or Temporal, then restart the worker before/after cooperative cleanup | Requester/source is auditable; the workflow is canceled; every unfinished owned row is canceled; accepted and unrelated pending jobs are untouched; no row remains falsely pending with zero live owner. |
 | R24 | Blocking activity call ignores cancellation after its Temporal attempt ends | Hold the provider seam past the cooperative grace window while another activity waits | The late writer remains fenced; the abandoned executor generation is observable and retired; fresh bounded capacity runs the next retry/reconciliation activity without a worker restart. |
 | R25 | Tailor repeatedly fails after using its inner model-repair budget | Redeliver the activity and start a later retry workflow | Each durable execution advances the outer counter exactly once, inner attempts remain separately auditable, the fifth durable failure becomes non-retryable `exhausted`, and later pickup does not create an infinite retry/spend loop. |
+| R26 | Current score is below the live materials threshold | Complete or replay preparation, then lower the threshold or request an explicit per-job low-fit override | Tailor, Cover, and Apply persist non-retryable `skipped` rows with `MIN_SCORE` and the exact score/threshold pair; replay is idempotent; hard blockers take precedence; only threshold-owned skips reset when policy permits work; no Apply attempt starts. |
 
 ## Execution Order
 
@@ -64,7 +70,8 @@ The campaign owns an isolated `JOBCTRL_DIR`, SQLite database, Temporal data dire
 5. Run persistence/supervisor/restart-order faults R19-R21.
 6. Finish with mixed-state streaming scenario R22, explicit Enrich cancellation
    R23, abandoned-thread capacity recovery R24, retry-budget convergence R25,
-   and rerun every previously failing scenario.
+   threshold-state convergence R26, and rerun every previously failing
+   scenario.
 
 ## Evidence Per Scenario
 
@@ -178,6 +185,14 @@ The campaign reproduced independent reliability defects:
     generation attempts in an append-only audit keyed by execution and durable
     attempt, and becomes non-retryable `exhausted` on the fifth durable failure,
     matching the established Cover contract.
+19. The recovered cohort exposed a terminal policy decision that existed only
+    in workflow history. A below-threshold Tailor returned `skipped` and emitted
+    `StageSkipped`, but the canonical Tailor, Cover, and Apply rows stayed
+    `pending`, so the UI advertised work with no possible owner. Score and
+    preparation now reconcile the current non-stale score into explicit
+    `MIN_SCORE` skips, preserve in-flight and accepted work, let score hard
+    blockers take precedence, and reset only threshold-owned skips when a later
+    score, threshold, or explicit low-fit override permits work.
 
 No timer or second scheduler was added. Recovery is one idempotent step in the
 workflow that owns the work, plus a durable event dispatch when a setting
@@ -197,9 +212,10 @@ is already canceled; it never mutates ownerless or unrelated pending work.
 | R14, R20 | SSE reconnect, operations/projection telemetry, launcher conflict, stale-process, and heartbeat coverage | Pass |
 | R16 | LLM retry, timeout, malformed-output, budget, and spend-limit coverage | Pass |
 | R18 | Renderer-unavailable retry and hard process-loss seam | Pass |
-| R23 | Real Enrich/Tailor/Cover `JobPipelineWorkflow` cancellation; exact selected/unrelated assertions; authenticated pre-pass child-process kill; abandoned-producer and successor-owner races; mixed local/Temporal requester audit; atomic snapshot/Tailor release; canonical restart pickup and exact execution-ID handoff; activity-timeout retry; successful-subset handoff; authenticated-recovery budget and extension-noise guard; selected-material incremental fan-out, cooperative commit fencing, committed-fact preservation, partial continuation, replay-versioned worker-wave deadline, atomic profile/policy comparison, and exact selected-message artifact fingerprints | Final verification in progress: focused automated regressions pass; authorized live recovery is still running; final independent review/QA and refreshed UI proof remain |
+| R23 | Real Enrich/Tailor/Cover `JobPipelineWorkflow` cancellation; exact selected/unrelated assertions; authenticated pre-pass child-process kill; abandoned-producer and successor-owner races; mixed local/Temporal requester audit; atomic snapshot/Tailor release; canonical restart pickup and exact execution-ID handoff; activity-timeout retry; successful-subset handoff; authenticated-recovery budget and extension-noise guard; selected-material incremental fan-out, cooperative commit fencing, committed-fact preservation, partial continuation, replay-versioned worker-wave deadline, atomic profile/policy comparison, and exact selected-message artifact fingerprints | PASS: focused and cumulative regressions, authorized live recovery, independent review/QA, and refreshed UI proof completed. |
 | R24 | Ignored-cancellation thread held past the grace window; distinct Temporal-sync and blocking executors; executor-generation rotation; immediate subsequent activity | Pass: focused abandoned-thread and worker-construction regressions; live recovery exposed and reproduced the zero-dispatch backlog before the fix |
-| R25 | Inner Tailor retry exhaustion followed by repeated durable executions, including the fifth-failure boundary | Focused proof passes: inner exhaustion leaves outer attempt 1 retryable; two executions retain both complete audit reports; retry re-entry advances cumulatively; durable attempt 5 is `exhausted` and non-retryable. Final cumulative gates remain. |
+| R25 | Inner Tailor retry exhaustion followed by repeated durable executions, including the fifth-failure boundary | PASS: inner exhaustion leaves outer attempt 1 retryable; two executions retain both complete audit reports; retry re-entry advances cumulatively; durable attempt 5 is `exhausted` and non-retryable; cumulative gates passed. |
+| R26 | Below-threshold workflow completion, repeated reconciliation, hard-blocker precedence, threshold lowering, explicit low-fit override, guarded concurrent claim races, and rendered diagnostics | Automated verification PASS: 3,389 Python tests, 2 skipped; 2,005 web tests; web/type/lint/docs checks; deterministic creation and reversal race fixtures; independent review and QA. Live read-model reconciliation remains. |
 | Worker composition | Clean import of the complete Temporal workflow/activity registry | Pass: 10 workflows and 23 activities compose without an import cycle |
 | API cumulative | Server, profile-event, and JSON-RPC adapter suites, including loopback SSE and startup recovery | Pass: 263 tests |
 | Live Pipelines UI | Browser DOM, console, screenshot, and disclosure interaction against the running app | Pass: Enrich precedes Enrichment reconciliation; Render PDF follows Cover letter; no relevant console warning/error |

--- a/docs/user/materials-and-tailoring.md
+++ b/docs/user/materials-and-tailoring.md
@@ -157,6 +157,14 @@ job. This prerequisite block does not consume a Tailor retry. It prevents an
 empty coverage plan from being retried as though it were a model-quality
 failure.
 
+The minimum-fit policy is a different terminal decision. When the current
+score is below the live materials threshold, Tailor, Cover, and Apply are
+persisted as `skipped` with the `MIN_SCORE` code and the exact score/threshold
+pair. They do not remain `pending`, because no automatic work owns them.
+Lowering the threshold or recording a qualifying current score restores only
+these threshold-owned skips. The per-job **Tailor this job** action is an
+explicit low-fit override and does not weaken score hard blockers.
+
 Generated files stay under the local JobCtrl workspace and are served only
 through registered artifact rows. An artifact route cannot open an arbitrary
 filesystem path. See [Data, Privacy & Safety](data-and-safety.md#local-data) for

--- a/docs/user/scoring-and-employer-analysis.md
+++ b/docs/user/scoring-and-employer-analysis.md
@@ -97,7 +97,9 @@ applies the same score bands.
   parsed amount and source, while the job continues through materials.
 - **The minimum-fit threshold does not change the saved score.** It decides
   whether an existing score is eligible for materials. Changing it does not
-  call the model or recalculate the score.
+  call the model or recalculate the score. A below-threshold decision is shown
+  on Tailor, Cover, and Apply as `skipped` with `MIN_SCORE` and the exact
+  score/threshold pair; it is not pending work or a generation failure.
 - **A correction is not a hidden weight change.** Your correction creates a new
   reviewed score version and a calibration anchor. An explicit re-score runs
   the current policy again against the current canonical inputs.

--- a/workers/automation/src/jobctrl/pipeline/preparation.py
+++ b/workers/automation/src/jobctrl/pipeline/preparation.py
@@ -49,7 +49,7 @@ from jobctrl.scoring.eligibility_sql import (
     register_score_eligibility_sql,
     score_eligible_for_downstream_sql,
 )
-from jobctrl.state import utc_now
+from jobctrl.state import reconcile_all_score_threshold_skips, utc_now
 
 log = logging.getLogger(__name__)
 
@@ -119,6 +119,12 @@ def derive_preparation_targets(payload: DerivePreparationTargetsInput) -> list[P
     conn = get_connection()
     tenant_id = TenantId(payload.tenant_id)
     min_score = db_module.effective_tailoring_min_score(payload.min_score)
+    if reconcile_all_score_threshold_skips(
+        conn,
+        tenant_id=tenant_id,
+        min_score=min_score,
+    ):
+        conn.commit()
     _suppress_ineligible_artifacts(conn, tenant_id=tenant_id, min_score=min_score)
     targets = _derive_targets(
         conn,

--- a/workers/automation/src/jobctrl/scoring/scorer.py
+++ b/workers/automation/src/jobctrl/scoring/scorer.py
@@ -26,7 +26,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Any, Mapping, Protocol
 
 from jobctrl.config import RESUME_PATH
-from jobctrl.database import get_connection, get_jobs_by_stage
+from jobctrl.database import effective_tailoring_min_score, get_connection, get_jobs_by_stage
 from jobctrl.domain.discovery.value_objects import PostingUrl
 from jobctrl.domain.identifiers import JobId, canonical_job_id
 from jobctrl.domain.job_content_identity import (
@@ -47,6 +47,7 @@ from jobctrl.domain.ports.scoring import (
 )
 from jobctrl.domain.profile.snapshot import ProfileSnapshot
 from jobctrl.domain.scoring.aggregate import JobScore
+from jobctrl.domain.scoring.eligibility import eligibility_blocks_downstream
 from jobctrl.domain.scoring.retrieval import (
     HybridSearchIndex,
     preselect_jobs_for_scoring,
@@ -72,6 +73,7 @@ from jobctrl.infrastructure.scoring import (
 )
 from jobctrl.state import (
     ensure_job_stage_rows,
+    reconcile_score_threshold_skips,
     reconcile_score_eligibility_blockers,
     record_job_event,
     set_stage_state,
@@ -1047,6 +1049,15 @@ def _sync_score_eligibility_stage_state(
         hard_blockers=list(eligibility.hard_blockers),
         now=now,
     )
+    if not eligibility_blocks_downstream(eligibility):
+        reconcile_score_threshold_skips(
+            conn,
+            tenant_id=tenant_id,
+            job_id=job_id,
+            fit_score=score.fit_score.value,
+            min_score=effective_tailoring_min_score(score.criteria.min_fit_score),
+            now=now,
+        )
 
 
 def _has_unresolved_score_staleness(

--- a/workers/automation/src/jobctrl/scoring/tailor.py
+++ b/workers/automation/src/jobctrl/scoring/tailor.py
@@ -82,6 +82,7 @@ from jobctrl.scoring.employer_analysis import build_analyze_use_case
 from jobctrl.state import (
     ensure_job_stage_rows,
     reconcile_score_eligibility_blockers,
+    reconcile_score_threshold_skips,
     record_job_event,
     set_stage_state,
     utc_now,
@@ -890,17 +891,20 @@ def tailor_job_by_id(
     # salary-only scores may still carry SCORE_ELIGIBILITY_BLOCKED rows from
     # the old policy; clearing them after selection would skip this invocation
     # and strand the preparation workflow until another external trigger.
-    if _reconcile_score_eligibility_skip(
+    score_skip_reason = _reconcile_score_eligibility_skip(
         conn,
         job_id=stable_job_id,
         tenant_id=tenant_id,
-    ):
+        min_score=min_score,
+        allow_low_fit_override=allow_low_fit_override,
+    )
+    if score_skip_reason is not None:
         conn.commit()
         return {
             "url": target["url"],
             "job_id": str(stable_job_id),
             "status": "skipped",
-            "reason": "score_eligibility_blocked",
+            "reason": score_skip_reason,
         }
 
     existing_materials = _reconcile_existing_approved_resume(
@@ -1323,11 +1327,13 @@ def _reconcile_score_eligibility_skip(
     *,
     job_id: JobId,
     tenant_id: TenantId,
-) -> bool:
+    min_score: int,
+    allow_low_fit_override: bool,
+) -> str | None:
     stable_job_id = canonical_job_id(str(job_id))
     score = SqliteScoreRepository(conn).load(tenant_id, stable_job_id)
     if score is None:
-        return False
+        return None
     eligibility = normalize_eligibility_for_downstream(score.breakdown.eligibility)
     if not eligibility_blocks_downstream(eligibility):
         reconcile_score_eligibility_blockers(
@@ -1337,17 +1343,41 @@ def _reconcile_score_eligibility_skip(
             eligibility_status=eligibility.status,
             hard_blockers=list(eligibility.hard_blockers),
         )
-        return False
+        effective_min_score = (
+            0
+            if allow_low_fit_override
+            else db_module.effective_tailoring_min_score(min_score)
+        )
+        if score.fit_score.value < effective_min_score:
+            row = conn.execute(
+                "SELECT discovered_at FROM jobs WHERE tenant_id = ? AND job_id = ?",
+                (str(tenant_id), str(score.job_id)),
+            ).fetchone()
+            ensure_job_stage_rows(
+                conn,
+                score.job_id,
+                tenant_id=tenant_id,
+                discovered_at=row["discovered_at"] if row is not None else None,
+            )
+        reconcile_score_threshold_skips(
+            conn,
+            tenant_id=tenant_id,
+            job_id=score.job_id,
+            fit_score=score.fit_score.value,
+            min_score=effective_min_score,
+        )
+        if score.fit_score.value < effective_min_score:
+            return "score_below_threshold"
+        return None
     row = conn.execute(
         "SELECT discovered_at FROM jobs WHERE tenant_id = ? AND job_id = ?",
         (str(tenant_id), str(score.job_id)),
     ).fetchone()
-    discovered_at = row["discovered_at"] if row is not None else None
     ensure_job_stage_rows(
         conn,
         score.job_id,
         tenant_id=tenant_id,
-        discovered_at=discovered_at,
+        discovered_at=row["discovered_at"] if row is not None else None,
     )
     reconcile_score_eligibility_blockers(
         conn,
@@ -1356,7 +1386,7 @@ def _reconcile_score_eligibility_skip(
         eligibility_status=eligibility.status,
         hard_blockers=list(eligibility.hard_blockers),
     )
-    return True
+    return "score_eligibility_blocked"
 
 
 def _record_tailor_enrichment_block(

--- a/workers/automation/src/jobctrl/state.py
+++ b/workers/automation/src/jobctrl/state.py
@@ -72,6 +72,7 @@ _DEPENDENCY_BLOCKER_MESSAGES: dict[str, tuple[tuple[str, tuple[str, ...]], ...]]
 }
 SCORE_ELIGIBILITY_BLOCKED_ERROR_CODE = "SCORE_ELIGIBILITY_BLOCKED"
 SCORE_ELIGIBILITY_BLOCKED_MESSAGE_PREFIX = "Score eligibility blocks tailoring"
+SCORE_THRESHOLD_SKIPPED_ERROR_CODE = "MIN_SCORE"
 _SCORE_ELIGIBILITY_DOWNSTREAM_STAGES: tuple[str, ...] = ("tailor", "cover", "apply")
 _TERMINAL_DOWNSTREAM_STATES: frozenset[str] = frozenset({"succeeded", "skipped", "exhausted", "canceled"})
 
@@ -532,7 +533,7 @@ def reconcile_score_eligibility_blockers(
     changed = 0
     rows = conn.execute(
         f"""
-        SELECT stage, state, attempt_count
+        SELECT stage, state, attempt_count, error_code
           FROM job_stage_states
          WHERE tenant_id = ?
            AND job_id = ?
@@ -543,7 +544,11 @@ def reconcile_score_eligibility_blockers(
     for row in rows:
         stage = str(row["stage"])
         state = str(row["state"])
-        if state in _TERMINAL_DOWNSTREAM_STATES:
+        if state in _TERMINAL_DOWNSTREAM_STATES and not (
+            state == "skipped"
+            and str(row["error_code"] or "")
+            == SCORE_THRESHOLD_SKIPPED_ERROR_CODE
+        ):
             continue
         attempt_count = int(row["attempt_count"] or 0)
         set_stage_state(
@@ -584,6 +589,280 @@ def reconcile_score_eligibility_blockers(
     return changed
 
 
+def reconcile_score_threshold_skips(
+    conn,
+    *,
+    tenant_id: TenantId,
+    job_id: JobId,
+    fit_score: int,
+    min_score: int,
+    now: str | None = None,
+) -> int:
+    """Persist or clear the downstream decision made by the fit threshold.
+
+    A score below the active materials threshold is a terminal policy decision,
+    not pending work and not a retryable generation failure. Only skips owned by
+    this policy are cleared when a later threshold or score admits the job.
+    """
+
+    stable_job_id = canonical_job_id(str(job_id))
+    normalized_fit_score = int(fit_score)
+    normalized_min_score = int(min_score)
+    updated_at = now or utc_now()
+    if normalized_fit_score >= normalized_min_score:
+        return _clear_score_threshold_skips(
+            conn,
+            tenant_id=tenant_id,
+            job_id=stable_job_id,
+            now=updated_at,
+        )
+
+    message = (
+        f"Fit score {normalized_fit_score}/10 is below the materials threshold "
+        f"{normalized_min_score}/10."
+    )
+    next_action = "Lower the materials threshold or record a higher current score."
+    metadata = {
+        "reason": "score_below_threshold",
+        "fitScore": normalized_fit_score,
+        "minScore": normalized_min_score,
+        "upstreamStage": "score",
+    }
+    metadata_json = _json_dumps(metadata)
+    changed = 0
+    for stage in _SCORE_ELIGIBILITY_DOWNSTREAM_STAGES:
+        transition = conn.execute(
+            """
+            /* score_threshold_skip */
+            UPDATE job_stage_states
+               SET state = 'skipped',
+                   updated_at = ?,
+                   error_code = ?,
+                   error_message = ?,
+                   retryable = 0,
+                   blocked_by_json = NULL,
+                   next_action = ?,
+                   metadata_json = ?
+             WHERE tenant_id = ?
+               AND job_id = ?
+               AND stage = ?
+               AND (
+                   state = 'pending'
+                   OR (
+                       state = 'blocked'
+                       AND error_code IN ('BLOCKED', ?)
+                   )
+                   OR (
+                       state = 'skipped'
+                       AND error_code = ?
+                   )
+               )
+               AND NOT (
+                   state = 'skipped'
+                   AND error_code = ?
+                   AND error_message = ?
+                   AND retryable = 0
+                   AND blocked_by_json IS NULL
+                   AND next_action = ?
+                   AND metadata_json = ?
+               )
+            """,
+            (
+                updated_at,
+                SCORE_THRESHOLD_SKIPPED_ERROR_CODE,
+                message,
+                next_action,
+                metadata_json,
+                str(tenant_id),
+                str(stable_job_id),
+                stage,
+                SCORE_ELIGIBILITY_BLOCKED_ERROR_CODE,
+                SCORE_THRESHOLD_SKIPPED_ERROR_CODE,
+                SCORE_THRESHOLD_SKIPPED_ERROR_CODE,
+                message,
+                next_action,
+                metadata_json,
+            ),
+        )
+        if transition.rowcount != 1:
+            continue
+        record_job_event(
+            conn,
+            stable_job_id,
+            stage,
+            "StageSkipped",
+            tenant_id=tenant_id,
+            level="info",
+            message=message,
+            occurred_at=updated_at,
+            payload={
+                "reason": "score_below_threshold",
+                "fitScore": normalized_fit_score,
+                "minScore": normalized_min_score,
+                "upstreamStage": "score",
+                "downstreamStage": stage,
+            },
+        )
+        changed += 1
+    return changed
+
+
+def reconcile_all_score_threshold_skips(
+    conn,
+    *,
+    tenant_id: TenantId,
+    min_score: int,
+    now: str | None = None,
+) -> int:
+    """Reconcile every current, non-stale score against one live threshold."""
+
+    rows = conn.execute(
+        """
+        SELECT scores.job_id, scores.fit_score, scores.breakdown_json
+          FROM job_scores scores
+          INNER JOIN jobs
+            ON jobs.tenant_id = scores.tenant_id
+           AND jobs.job_id = scores.job_id
+          INNER JOIN (
+              SELECT tenant_id, job_id, MAX(version) AS version
+                FROM job_scores
+               WHERE tenant_id = ?
+               GROUP BY tenant_id, job_id
+          ) latest
+            ON latest.tenant_id = scores.tenant_id
+           AND latest.job_id = scores.job_id
+           AND latest.version = scores.version
+          INNER JOIN job_stage_states score_stage
+            ON score_stage.tenant_id = scores.tenant_id
+           AND score_stage.job_id = scores.job_id
+           AND score_stage.stage = 'score'
+           AND score_stage.state = 'succeeded'
+          LEFT JOIN posting_snapshot_sets snapshots
+            ON snapshots.tenant_id = scores.tenant_id
+           AND snapshots.job_id = scores.job_id
+         WHERE scores.tenant_id = ?
+           AND NOT EXISTS (
+               SELECT 1
+                 FROM jobctrl_deleted_jobs deleted
+                WHERE deleted.tenant_id = scores.tenant_id
+                  AND deleted.job_id = scores.job_id
+                  AND (
+                      deleted.restored_at IS NULL
+                      OR julianday(deleted.restored_at) <= julianday(deleted.deleted_at)
+                  )
+           )
+           AND (
+               snapshots.latest_active_state IS NULL
+               OR snapshots.latest_active_state NOT IN (
+                   'closed', 'expired', 'removed', 'location_incompatible'
+               )
+           )
+           AND NOT EXISTS (
+               SELECT 1
+                 FROM job_score_staleness stale
+                WHERE stale.tenant_id = scores.tenant_id
+                  AND stale.job_id = scores.job_id
+                  AND stale.resolved = 0
+           )
+        """,
+        (str(tenant_id), str(tenant_id)),
+    ).fetchall()
+    changed = 0
+    for row in rows:
+        breakdown = _json_loads(row["breakdown_json"], {})
+        eligibility_payload = breakdown.get("eligibility") if isinstance(breakdown, dict) else None
+        eligibility = EligibilityAssessment.from_dict(
+            eligibility_payload if isinstance(eligibility_payload, dict) else None
+        )
+        if eligibility_blocks_downstream(eligibility):
+            continue
+        changed += reconcile_score_threshold_skips(
+            conn,
+            tenant_id=tenant_id,
+            job_id=canonical_job_id(str(row["job_id"])),
+            fit_score=int(row["fit_score"]),
+            min_score=int(min_score),
+            now=now,
+        )
+    return changed
+
+
+def _clear_score_threshold_skips(
+    conn,
+    *,
+    tenant_id: TenantId,
+    job_id: JobId,
+    now: str,
+) -> int:
+    rows = conn.execute(
+        """
+        SELECT stage
+          FROM job_stage_states
+         WHERE tenant_id = ?
+           AND job_id = ?
+           AND state = 'skipped'
+           AND error_code = ?
+        """,
+        (str(tenant_id), str(job_id), SCORE_THRESHOLD_SKIPPED_ERROR_CODE),
+    ).fetchall()
+    cleared = 0
+    for row in rows:
+        stage = str(row["stage"])
+        restored = _restored_state_after_score_gate_cleared(
+            conn,
+            tenant_id=tenant_id,
+            job_id=job_id,
+            stage=stage,
+        )
+        transition = conn.execute(
+            """
+            /* score_threshold_clear */
+            UPDATE job_stage_states
+               SET state = ?,
+                   updated_at = ?,
+                   error_code = ?,
+                   error_message = ?,
+                   retryable = 1,
+                   blocked_by_json = NULL,
+                   next_action = NULL,
+                   metadata_json = NULL
+             WHERE tenant_id = ?
+               AND job_id = ?
+               AND stage = ?
+               AND state = 'skipped'
+               AND error_code = ?
+            """,
+            (
+                str(restored["state"]),
+                now,
+                restored.get("error_code"),
+                restored.get("error_message"),
+                str(tenant_id),
+                str(job_id),
+                stage,
+                SCORE_THRESHOLD_SKIPPED_ERROR_CODE,
+            ),
+        )
+        if transition.rowcount != 1:
+            continue
+        record_job_event(
+            conn,
+            job_id,
+            stage,
+            "StageReset",
+            tenant_id=tenant_id,
+            message=f"{stage} restored after the score threshold allowed materials.",
+            occurred_at=now,
+            payload={
+                "reason": "score_threshold_cleared",
+                "upstreamStage": "score",
+                "downstreamStage": stage,
+            },
+        )
+        cleared += 1
+    return cleared
+
+
 def _clear_score_eligibility_blockers(
     conn,
     *,
@@ -606,7 +885,7 @@ def _clear_score_eligibility_blockers(
     for row in rows:
         stage = str(row["stage"])
         attempt_count = int(row["attempt_count"] or 0)
-        restored = _restored_state_after_score_eligibility_cleared(
+        restored = _restored_state_after_score_gate_cleared(
             conn,
             tenant_id=tenant_id,
             job_id=job_id,
@@ -639,7 +918,7 @@ def _clear_score_eligibility_blockers(
     return cleared
 
 
-def _restored_state_after_score_eligibility_cleared(
+def _restored_state_after_score_gate_cleared(
     conn,
     *,
     tenant_id: TenantId,

--- a/workers/automation/tests/test_score_eligibility_stage_state.py
+++ b/workers/automation/tests/test_score_eligibility_stage_state.py
@@ -9,7 +9,9 @@ from jobctrl.domain.tenant import TenantId
 from jobctrl.infrastructure.migrations.schema_v7 import create_exact_v7_schema
 from jobctrl.state import (
     ensure_job_stage_rows,
+    reconcile_all_score_threshold_skips,
     reconcile_score_eligibility_blockers,
+    reconcile_score_threshold_skips,
     set_stage_state,
 )
 
@@ -83,7 +85,8 @@ def _stage_rows(
 ) -> dict[str, sqlite3.Row]:
     rows = conn.execute(
         """
-        SELECT stage, state, error_code, error_message, retryable, blocked_by_json
+        SELECT stage, state, error_code, error_message, retryable, blocked_by_json,
+               next_action, metadata_json
         FROM job_stage_states
         WHERE tenant_id = ? AND job_id = ?
         """,
@@ -249,6 +252,353 @@ def test_score_eligibility_clear_restores_dependency_states(conn: sqlite3.Connec
     assert rows["cover"]["error_message"] == "tailor has not completed."
     assert rows["apply"]["state"] == "blocked"
     assert rows["apply"]["error_message"] == "Materials are not ready."
+
+
+def test_score_threshold_skip_is_explicit_idempotent_and_reversible(
+    conn: sqlite3.Connection,
+) -> None:
+    _seed_scored_job(
+        conn,
+        tenant_id=_TENANT_A,
+        job_id=_JOB_ID,
+        url="https://example.com/job/below-threshold",
+    )
+
+    changed = reconcile_score_threshold_skips(
+        conn,
+        tenant_id=_TENANT_A,
+        job_id=_JOB_ID,
+        fit_score=6,
+        min_score=7,
+        now="2024-01-02T00:00:00+00:00",
+    )
+
+    assert changed == 3
+    rows = _stage_rows(conn, tenant_id=_TENANT_A, job_id=_JOB_ID)
+    for stage in ("tailor", "cover", "apply"):
+        assert rows[stage]["state"] == "skipped"
+        assert rows[stage]["error_code"] == "MIN_SCORE"
+        assert rows[stage]["error_message"] == (
+            "Fit score 6/10 is below the materials threshold 7/10."
+        )
+        assert rows[stage]["retryable"] == 0
+        assert rows[stage]["next_action"] == (
+            "Lower the materials threshold or record a higher current score."
+        )
+        assert '"reason": "score_below_threshold"' in rows[stage]["metadata_json"]
+
+    assert (
+        reconcile_score_threshold_skips(
+            conn,
+            tenant_id=_TENANT_A,
+            job_id=_JOB_ID,
+            fit_score=6,
+            min_score=7,
+            now="2024-01-02T00:00:00+00:00",
+        )
+        == 0
+    )
+    event_count = conn.execute(
+        "SELECT COUNT(*) FROM job_events WHERE tenant_id = ? AND job_id = ? AND event_type = 'StageSkipped'",
+        (str(_TENANT_A), str(_JOB_ID)),
+    ).fetchone()[0]
+    assert event_count == 3
+
+    assert (
+        reconcile_score_eligibility_blockers(
+            conn,
+            tenant_id=_TENANT_A,
+            job_id=_JOB_ID,
+            eligibility_status="blocked",
+            hard_blockers=["required work authorization is missing"],
+            now="2024-01-02T12:00:00+00:00",
+        )
+        == 3
+    )
+    rows = _stage_rows(conn, tenant_id=_TENANT_A, job_id=_JOB_ID)
+    assert {rows[stage]["state"] for stage in ("tailor", "cover", "apply")} == {
+        "blocked"
+    }
+    assert {
+        rows[stage]["error_code"] for stage in ("tailor", "cover", "apply")
+    } == {"SCORE_ELIGIBILITY_BLOCKED"}
+
+    assert (
+        reconcile_score_eligibility_blockers(
+            conn,
+            tenant_id=_TENANT_A,
+            job_id=_JOB_ID,
+            eligibility_status="eligible",
+            hard_blockers=[],
+            now="2024-01-02T18:00:00+00:00",
+        )
+        == 3
+    )
+    assert (
+        reconcile_score_threshold_skips(
+            conn,
+            tenant_id=_TENANT_A,
+            job_id=_JOB_ID,
+            fit_score=6,
+            min_score=7,
+            now="2024-01-02T18:00:00+00:00",
+        )
+        == 3
+    )
+
+    assert (
+        reconcile_score_threshold_skips(
+            conn,
+            tenant_id=_TENANT_A,
+            job_id=_JOB_ID,
+            fit_score=6,
+            min_score=6,
+            now="2024-01-03T00:00:00+00:00",
+        )
+        == 3
+    )
+    rows = _stage_rows(conn, tenant_id=_TENANT_A, job_id=_JOB_ID)
+    assert rows["tailor"]["state"] == "pending"
+    assert rows["tailor"]["error_code"] is None
+    assert rows["cover"]["state"] == "blocked"
+    assert rows["cover"]["error_message"] == "tailor has not completed."
+    assert rows["apply"]["state"] == "blocked"
+    assert rows["apply"]["error_message"] == "Materials are not ready."
+
+
+def test_batch_score_threshold_reconciliation_uses_latest_current_score(
+    conn: sqlite3.Connection,
+) -> None:
+    _seed_scored_job(
+        conn,
+        tenant_id=_TENANT_A,
+        job_id=_JOB_ID,
+        url="https://example.com/job/current-below-threshold",
+    )
+    conn.executemany(
+        """
+        INSERT INTO job_scores (
+            tenant_id, job_id, version, fit_score, breakdown_json,
+            keywords_json, scored_at
+        ) VALUES (?, ?, ?, ?, ?, '[]', ?)
+        """,
+        [
+            (
+                str(_TENANT_A),
+                str(_JOB_ID),
+                1,
+                9,
+                '{"eligibility":{"status":"eligible","hard_blockers":[]}}',
+                "2024-01-01T00:00:00+00:00",
+            ),
+            (
+                str(_TENANT_A),
+                str(_JOB_ID),
+                2,
+                5,
+                '{"eligibility":{"status":"warning","hard_blockers":[]}}',
+                "2024-01-02T00:00:00+00:00",
+            ),
+        ],
+    )
+    conn.commit()
+
+    changed = reconcile_all_score_threshold_skips(
+        conn,
+        tenant_id=_TENANT_A,
+        min_score=7,
+        now="2024-01-03T00:00:00+00:00",
+    )
+
+    assert changed == 3
+    rows = _stage_rows(conn, tenant_id=_TENANT_A, job_id=_JOB_ID)
+    assert {rows[stage]["state"] for stage in ("tailor", "cover", "apply")} == {
+        "skipped"
+    }
+    assert {
+        rows[stage]["error_code"] for stage in ("tailor", "cover", "apply")
+    } == {"MIN_SCORE"}
+
+
+def test_score_threshold_skip_preserves_owned_work_and_unrelated_failures(
+    conn: sqlite3.Connection,
+) -> None:
+    _seed_scored_job(
+        conn,
+        tenant_id=_TENANT_A,
+        job_id=_JOB_ID,
+        url="https://example.com/job/preserved-stage-owners",
+    )
+    set_stage_state(
+        conn,
+        _JOB_ID,
+        "tailor",
+        "blocked",
+        tenant_id=_TENANT_A,
+        error_code="REQUIREMENT_FIT_STALE",
+        error_message="Scoring must refresh requirement-fit evidence.",
+        validate_transition=False,
+    )
+    set_stage_state(
+        conn,
+        _JOB_ID,
+        "cover",
+        "queued",
+        tenant_id=_TENANT_A,
+        validate_transition=False,
+    )
+
+    assert (
+        reconcile_score_threshold_skips(
+            conn,
+            tenant_id=_TENANT_A,
+            job_id=_JOB_ID,
+            fit_score=5,
+            min_score=7,
+            now="2024-01-04T00:00:00+00:00",
+        )
+        == 1
+    )
+    rows = _stage_rows(conn, tenant_id=_TENANT_A, job_id=_JOB_ID)
+    assert (rows["tailor"]["state"], rows["tailor"]["error_code"]) == (
+        "blocked",
+        "REQUIREMENT_FIT_STALE",
+    )
+    assert rows["cover"]["state"] == "queued"
+    assert (rows["apply"]["state"], rows["apply"]["error_code"]) == (
+        "skipped",
+        "MIN_SCORE",
+    )
+
+
+def test_score_threshold_skip_does_not_overwrite_a_concurrent_claim(
+    conn: sqlite3.Connection,
+) -> None:
+    _seed_scored_job(
+        conn,
+        tenant_id=_TENANT_A,
+        job_id=_JOB_ID,
+        url="https://example.com/job/concurrent-tailor-claim",
+    )
+
+    class ClaimBeforeThresholdUpdate:
+        def __init__(self, wrapped: sqlite3.Connection) -> None:
+            self.wrapped = wrapped
+            self.injected = False
+
+        def execute(self, sql: str, parameters=()):
+            if "score_threshold_skip" in sql and not self.injected:
+                self.injected = True
+                self.wrapped.execute(
+                    """
+                    UPDATE job_stage_states
+                       SET state = 'running', error_code = NULL,
+                           error_message = NULL, retryable = 1
+                     WHERE tenant_id = ? AND job_id = ? AND stage = 'tailor'
+                    """,
+                    (str(_TENANT_A), str(_JOB_ID)),
+                )
+            return self.wrapped.execute(sql, parameters)
+
+    interleaved = ClaimBeforeThresholdUpdate(conn)
+    assert (
+        reconcile_score_threshold_skips(
+            interleaved,
+            tenant_id=_TENANT_A,
+            job_id=_JOB_ID,
+            fit_score=5,
+            min_score=7,
+            now="2024-01-05T00:00:00+00:00",
+        )
+        == 2
+    )
+
+    rows = _stage_rows(conn, tenant_id=_TENANT_A, job_id=_JOB_ID)
+    assert rows["tailor"]["state"] == "running"
+    assert rows["tailor"]["error_code"] is None
+    assert {rows[stage]["state"] for stage in ("cover", "apply")} == {"skipped"}
+    tailor_skip_events = conn.execute(
+        """
+        SELECT COUNT(*)
+          FROM job_events
+         WHERE tenant_id = ? AND job_id = ?
+           AND stage = 'tailor' AND event_type = 'StageSkipped'
+        """,
+        (str(_TENANT_A), str(_JOB_ID)),
+    ).fetchone()[0]
+    assert tailor_skip_events == 0
+
+
+def test_score_threshold_clear_does_not_overwrite_a_concurrent_claim(
+    conn: sqlite3.Connection,
+) -> None:
+    _seed_scored_job(
+        conn,
+        tenant_id=_TENANT_A,
+        job_id=_JOB_ID,
+        url="https://example.com/job/concurrent-tailor-claim-on-clear",
+    )
+    assert (
+        reconcile_score_threshold_skips(
+            conn,
+            tenant_id=_TENANT_A,
+            job_id=_JOB_ID,
+            fit_score=5,
+            min_score=7,
+            now="2024-01-05T00:00:00+00:00",
+        )
+        == 3
+    )
+
+    class ClaimBeforeThresholdClear:
+        def __init__(self, wrapped: sqlite3.Connection) -> None:
+            self.wrapped = wrapped
+            self.injected = False
+
+        def execute(self, sql: str, parameters=()):
+            if "score_threshold_clear" in sql and not self.injected:
+                self.injected = True
+                self.wrapped.execute(
+                    """
+                    UPDATE job_stage_states
+                       SET state = 'running', attempt_count = 1,
+                           error_code = NULL, error_message = NULL,
+                           retryable = 1, metadata_json = '{"claim":"manual"}'
+                     WHERE tenant_id = ? AND job_id = ? AND stage = 'tailor'
+                    """,
+                    (str(_TENANT_A), str(_JOB_ID)),
+                )
+            return self.wrapped.execute(sql, parameters)
+
+    interleaved = ClaimBeforeThresholdClear(conn)
+    assert (
+        reconcile_score_threshold_skips(
+            interleaved,
+            tenant_id=_TENANT_A,
+            job_id=_JOB_ID,
+            fit_score=7,
+            min_score=7,
+            now="2024-01-06T00:00:00+00:00",
+        )
+        == 2
+    )
+
+    rows = _stage_rows(conn, tenant_id=_TENANT_A, job_id=_JOB_ID)
+    assert rows["tailor"]["state"] == "running"
+    assert rows["tailor"]["error_code"] is None
+    assert rows["tailor"]["metadata_json"] == '{"claim":"manual"}'
+    assert rows["cover"]["state"] == "blocked"
+    assert rows["apply"]["state"] == "blocked"
+    tailor_reset_events = conn.execute(
+        """
+        SELECT COUNT(*)
+          FROM job_events
+         WHERE tenant_id = ? AND job_id = ?
+           AND stage = 'tailor' AND event_type = 'StageReset'
+        """,
+        (str(_TENANT_A), str(_JOB_ID)),
+    ).fetchone()[0]
+    assert tailor_reset_events == 0
 
 
 def test_score_eligibility_blockers_are_tenant_scoped(conn: sqlite3.Connection) -> None:

--- a/workers/automation/tests/test_tailor_retailor.py
+++ b/workers/automation/tests/test_tailor_retailor.py
@@ -479,8 +479,24 @@ def test_tailor_job_by_url_skips_score_five_by_default(tmp_path, monkeypatch):
             "url": target_url,
             "job_id": str(target_job_id),
             "status": "skipped",
-            "reason": "not_eligible",
+            "reason": "score_below_threshold",
         }
+        rows = conn.execute(
+            """
+            SELECT stage, state, error_code, error_message, retryable
+              FROM job_stage_states
+             WHERE tenant_id = ? AND job_id = ?
+               AND stage IN ('tailor', 'cover', 'apply')
+             ORDER BY stage
+            """,
+            (str(LOCAL_TENANT), str(target_job_id)),
+        ).fetchall()
+        assert {row["state"] for row in rows} == {"skipped"}
+        assert {row["error_code"] for row in rows} == {"MIN_SCORE"}
+        assert {row["error_message"] for row in rows} == {
+            "Fit score 5/10 is below the materials threshold 6/10."
+        }
+        assert {row["retryable"] for row in rows} == {0}
     finally:
         close_connection(db_path)
 

--- a/workers/automation/tests/test_v7_score_runtime.py
+++ b/workers/automation/tests/test_v7_score_runtime.py
@@ -144,13 +144,14 @@ def _score_by_id(
     tenant_id: TenantId,
     job_id: JobId,
     llm: _StrongLlm,
+    criteria: ScoringCriteria | None = None,
 ):
     return scorer_module.score_job_by_id(
         job_id,
         tenant_id=tenant_id,
         profile_snapshot=_profile_snapshot(tenant_id),
         resume_text="Python platform engineer.",
-        criteria=ScoringCriteria(),
+        criteria=criteria or ScoringCriteria(),
         repository=SqliteScoreRepository(conn),
         llm_port=llm,
         require_employer_analysis=False,
@@ -248,6 +249,37 @@ def test_score_by_id_blocks_downstream_stages_for_hard_blocker(
     assert state_by_stage["score"] == ("succeeded", None)
     for stage in ("tailor", "cover", "apply"):
         assert state_by_stage[stage] == ("blocked", "SCORE_ELIGIBILITY_BLOCKED")
+
+
+def test_score_by_id_persists_the_current_criteria_threshold_decision(
+    conn: sqlite3.Connection,
+) -> None:
+    _seed_target(conn, tenant_id=_TENANT_A, job_id=_JOB_ID_A)
+
+    outcome = _score_by_id(
+        conn,
+        tenant_id=_TENANT_A,
+        job_id=_JOB_ID_A,
+        llm=_StrongLlm(),
+        criteria=ScoringCriteria(min_fit_score=9),
+    )
+
+    assert outcome.ok is True
+    rows = conn.execute(
+        """
+        SELECT stage, state, error_code, error_message
+        FROM job_stage_states
+        WHERE tenant_id = ? AND job_id = ?
+          AND stage IN ('tailor', 'cover', 'apply')
+        ORDER BY stage
+        """,
+        (str(_TENANT_A), str(_JOB_ID_A)),
+    ).fetchall()
+    assert {row["state"] for row in rows} == {"skipped"}
+    assert {row["error_code"] for row in rows} == {"MIN_SCORE"}
+    assert {row["error_message"] for row in rows} == {
+        "Fit score 8/10 is below the materials threshold 9/10."
+    }
 
 
 def test_existing_score_repairs_stage_only_when_not_stale(

--- a/workers/automation/tests/test_v7_tailor_runtime.py
+++ b/workers/automation/tests/test_v7_tailor_runtime.py
@@ -537,6 +537,23 @@ def test_tailor_job_by_id_enforces_score_boundary_before_generation(
         snapshot=SimpleNamespace(),
         llm_model=None,
     )
+
+    assert skipped["reason"] == "score_below_threshold"
+    skipped_rows = conn.execute(
+        """
+        SELECT stage, state, error_code, error_message, retryable
+          FROM job_stage_states
+         WHERE tenant_id = ? AND job_id = ?
+           AND stage IN ('tailor', 'cover', 'apply')
+         ORDER BY stage
+        """,
+        (str(_TENANT_A), str(_JOB_ID)),
+    ).fetchall()
+    assert {row["state"] for row in skipped_rows} == {"skipped"}
+    assert {row["error_code"] for row in skipped_rows} == {"MIN_SCORE"}
+    assert all("6/10" in row["error_message"] for row in skipped_rows)
+    assert {row["retryable"] for row in skipped_rows} == {0}
+
     approved = tailor_module.tailor_job_by_id(
         _JOB_ID,
         tenant_id=_TENANT_A,
@@ -546,9 +563,24 @@ def test_tailor_job_by_id_enforces_score_boundary_before_generation(
         llm_model=None,
     )
 
-    assert skipped["reason"] == "not_eligible"
     assert approved["status"] == "approved"
     assert calls == [str(_JOB_ID)]
+    restored_rows = conn.execute(
+        """
+        SELECT stage, state, error_code
+          FROM job_stage_states
+         WHERE tenant_id = ? AND job_id = ?
+           AND stage IN ('tailor', 'cover', 'apply')
+         ORDER BY stage
+        """,
+        (str(_TENANT_A), str(_JOB_ID)),
+    ).fetchall()
+    assert {row["stage"]: row["state"] for row in restored_rows} == {
+        "apply": "pending",
+        "cover": "pending",
+        "tailor": "succeeded",
+    }
+    assert {row["error_code"] for row in restored_rows} == {None}
 
 
 def test_tailor_job_by_id_skips_blocked_scores_without_generation(


### PR DESCRIPTION
## Summary

- persist below-threshold Tailor, Cover, and Apply decisions as non-retryable `skipped` states with `MIN_SCORE` and the exact score/threshold pair
- reconcile every active, current, non-stale score during preparation, while preserving hard-blocker precedence and explicit manual low-fit overrides
- render the policy reason without misleading attempts or retry controls, while retaining the manual Tailor action
- guard both threshold-skip creation and reversal so reconciliation cannot overwrite a concurrent stage claim

## Why

Below-threshold jobs were left as `pending`, which falsely implied that work had a live owner. The policy decision must be explicit, reversible only by the owning policy, and safe when reconciliation races with a worker or manual Tailor claim.

## Validation

- `uv --project workers/automation run python -m pytest workers/automation/tests -q` — 3,389 passed, 2 skipped
- focused score/Tailor state suites — 65 passed
- deterministic concurrent-claim creation and reversal regressions — passed
- web unit suite — 2,005 passed
- rendered StageTimeline suite — 18 passed
- web TypeScript check, Ruff, repository check, docs build, and diff check — passed
- independent review and QA gates — PASS with zero Blocker, High, Medium, or Low findings
- no Apply execution or live application-data mutation was performed by the test suite

## Stack

Depends on #758.
