### PR TITLE
fix(pipeline): block terminal tailor dependents

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,13 @@ evidence, qualifications, and the complete capability matrix.
   A score hard blocker remains **blocked**. Lowering the threshold, recording a
   higher score, or deliberately choosing **Tailor this job** clears only that
   threshold-owned skip; it does not consume a failed-generation retry.
+- Treat dependency failures just as explicitly. If Tailor fails or exhausts
+  its durable attempt budget, unstarted Cover and Apply rows show **blocked**
+  with `UPSTREAM_TAILOR_FAILED` or `UPSTREAM_TAILOR_EXHAUSTED`, the Tailor
+  dependency, and the required retry/reset action. A later Tailor success
+  clears only those Tailor-owned blocks. Claimed, skipped, and canceled
+  dependent work is never moved backward; an accepted new resume may invalidate
+  a completed or failed Cover from the superseded material generation.
 - Review privacy-bounded learning recommendations on the Dashboard. JobCtrl
   derives them only from explicit reviewed signals, requires compatible
   evidence across jobs, and changes Materials behavior only after you accept a

--- a/docs/architecture/pipeline/stages.md
+++ b/docs/architecture/pipeline/stages.md
@@ -266,6 +266,15 @@ Behavior notes:
   are preserved. A score hard blocker takes precedence and remains `blocked`.
 - There is no local preparation reaper. Rows already claimed by a fast worker are
   not moved backward; Temporal owns in-flight recovery.
+- A failed or exhausted Tailor is also canonical dependency state, not pending
+  downstream work. Unstarted Cover and Apply rows become non-retryable
+  `blocked` rows owned by `tailor`, with `UPSTREAM_TAILOR_FAILED` or
+  `UPSTREAM_TAILOR_EXHAUSTED` and the required retry/reset action. The guarded
+  reconciliation never overwrites queued, running, succeeded, skipped,
+  or canceled dependents while establishing the block. Tailor success resets
+  only Tailor-owned blocks; after a new resume is accepted it may also reset a
+  completed, failed, or exhausted Cover tied to the superseded material
+  generation, but never a queued/running claim or a skipped/canceled decision.
 
 ## Score
 
@@ -341,7 +350,9 @@ Tailoring is where the fabrication gate and per-bullet claim grounding live.
 adversarial personas, and repair loop — see [Resume Tailoring Logic](../tailoring.md).**
 The Tailor stage emits `EmployerAnalyzed` (shared with scoring), `ResumeApproved`
 / `ResumeFailed`, and `BulletProvenanceRecorded`; successful tailoring proceeds
-into the Cover step.
+into the Cover step. A terminal Tailor failure instead blocks unstarted Cover
+and Apply rows with the exact upstream state; they cannot remain ownerless
+`pending`.
 
 ## Cover
 

--- a/docs/local-reliability-qa.md
+++ b/docs/local-reliability-qa.md
@@ -138,6 +138,12 @@ non-retryable `exhausted`, and a later pickup cannot restart it without an
 explicit attempt reset. Run at least two durable failures against the same
 materials generation and assert that both complete inner-attempt reports remain
 in the append-only audit history.
+When Tailor fails or reaches that exhausted boundary, assert that unstarted
+Cover and Apply rows become non-retryable `blocked` dependencies with the exact
+`UPSTREAM_TAILOR_FAILED` or `UPSTREAM_TAILOR_EXHAUSTED` code and a Tailor-owned
+next action. Repeat reconciliation to prove idempotence, interleave a dependent
+claim immediately before the guarded update to prove ownership preservation,
+and then complete Tailor to prove only the Tailor-owned blocks reset.
 For a current score below the live materials threshold, preparation must persist
 Tailor, Cover, and Apply as non-retryable `skipped` rows with `MIN_SCORE` and the
 exact score/threshold pair. No row may remain `pending` after the workflow has

--- a/docs/user/materials-and-tailoring.md
+++ b/docs/user/materials-and-tailoring.md
@@ -165,6 +165,16 @@ Lowering the threshold or recording a qualifying current score restores only
 these threshold-owned skips. The per-job **Tailor this job** action is an
 explicit low-fit override and does not weaken score hard blockers.
 
+Tailor failures also own their downstream state. If Tailor is retryably failed
+or has exhausted its durable attempt budget, Cover and Apply show `blocked`
+with the exact Tailor failure/exhaustion reason instead of implying pending
+work. Retry or reset Tailor first. Once Tailor succeeds, JobCtrl restores only
+those Tailor-owned dependency blocks and does not disturb a Cover another
+worker already queued or claimed, or a skipped/canceled decision. When an
+accepted replacement resume supersedes the material input, JobCtrl may reset a
+completed, failed, or exhausted Cover so it can generate against the current
+resume; the older artifact remains in its audit history.
+
 Generated files stay under the local JobCtrl workspace and are served only
 through registered artifact rows. An artifact route cannot open an arbitrary
 filesystem path. See [Data, Privacy & Safety](data-and-safety.md#local-data) for

--- a/workers/automation/src/jobctrl/database.py
+++ b/workers/automation/src/jobctrl/database.py
@@ -623,9 +623,13 @@ def ensure_state_tables(conn: sqlite3.Connection | None = None) -> list[str]:
     # directive, the read-side projection refreshers (TS + Python) must
     # NOT carry a "derive stage state from legacy columns" compat shim
     # — the canonical source has to be ``job_stage_states``.  This
-    from jobctrl.state import reconcile_dependency_blockers
+    from jobctrl.state import (
+        reconcile_dependency_blockers,
+        reconcile_tailor_terminal_dependents,
+    )
 
     reconcile_dependency_blockers(conn)
+    reconcile_tailor_terminal_dependents(conn)
     conn.commit()
     return ["job_stage_states", "job_events", "job_artifacts", "event_watermarks", "digest_state"]
 

--- a/workers/automation/src/jobctrl/infrastructure/pipeline/sqlite_repository.py
+++ b/workers/automation/src/jobctrl/infrastructure/pipeline/sqlite_repository.py
@@ -34,7 +34,12 @@ from jobctrl.domain.pipeline_types import (
     serialize_stage_state,
 )
 from jobctrl.domain.tenant import TenantId
-from jobctrl.state import reconcile_dependency_blockers, record_job_event, set_stage_state
+from jobctrl.state import (
+    reconcile_dependency_blockers,
+    reconcile_tailor_terminal_dependents,
+    record_job_event,
+    set_stage_state,
+)
 
 
 def _json_loads(value: str | None, default: Any) -> Any:
@@ -283,6 +288,7 @@ class SqlitePipelineStateRepository:
         )
 
         completed_stages: list[str] = []
+        tailor_terminal = False
         for stage, stage_state in state.stages.items():
             stage_str = serialize_stage(stage)
             new_state_str = serialize_stage_state(stage_state)
@@ -297,6 +303,9 @@ class SqlitePipelineStateRepository:
                 validate_transition=False,
                 **_stage_state_to_kwargs(stage_state),
             )
+
+            if stage_str == "tailor" and new_state_str in ("failed", "exhausted"):
+                tailor_terminal = True
 
             if existing_states.get(stage_str) == new_state_str:
                 continue
@@ -319,6 +328,18 @@ class SqlitePipelineStateRepository:
                 tenant_id=state.tenant_id,
                 job_id=stable_job_id,
                 completed_stage=stage_str,
+            )
+        if tailor_terminal:
+            # set_stage_state's tailor-terminal hook fires mid-loop, so this
+            # aggregate's own still-pending cover/apply upserts later in the
+            # same loop can overwrite the dependency blocks it just wrote.
+            # Re-run the reconcile after the loop (mirroring the
+            # reconcile_dependency_blockers pass above) so the persisted
+            # outcome never depends on stage iteration order.
+            reconcile_tailor_terminal_dependents(
+                self._conn,
+                tenant_id=state.tenant_id,
+                job_id=stable_job_id,
             )
         state.version = state.version + 1
 

--- a/workers/automation/src/jobctrl/pipeline/preparation.py
+++ b/workers/automation/src/jobctrl/pipeline/preparation.py
@@ -49,7 +49,11 @@ from jobctrl.scoring.eligibility_sql import (
     register_score_eligibility_sql,
     score_eligible_for_downstream_sql,
 )
-from jobctrl.state import reconcile_all_score_threshold_skips, utc_now
+from jobctrl.state import (
+    reconcile_all_score_threshold_skips,
+    reconcile_tailor_terminal_dependents,
+    utc_now,
+)
 
 log = logging.getLogger(__name__)
 
@@ -119,11 +123,16 @@ def derive_preparation_targets(payload: DerivePreparationTargetsInput) -> list[P
     conn = get_connection()
     tenant_id = TenantId(payload.tenant_id)
     min_score = db_module.effective_tailoring_min_score(payload.min_score)
-    if reconcile_all_score_threshold_skips(
+    state_changes = reconcile_all_score_threshold_skips(
         conn,
         tenant_id=tenant_id,
         min_score=min_score,
-    ):
+    )
+    state_changes += reconcile_tailor_terminal_dependents(
+        conn,
+        tenant_id=tenant_id,
+    )
+    if state_changes:
         conn.commit()
     _suppress_ineligible_artifacts(conn, tenant_id=tenant_id, min_score=min_score)
     targets = _derive_targets(

--- a/workers/automation/src/jobctrl/scoring/tailor.py
+++ b/workers/automation/src/jobctrl/scoring/tailor.py
@@ -299,7 +299,7 @@ def _mark_cover_pending_after_tailor_success_by_id(
     *,
     tenant_id: TenantId,
     reason: str,
-) -> None:
+) -> bool:
     """Invalidate downstream cover readiness after a new resume generation.
 
     A stale ``cover=succeeded`` row is unsafe after re-tailoring because it can
@@ -312,8 +312,9 @@ def _mark_cover_pending_after_tailor_success_by_id(
         {"invalidated_at": now, "reason": reason},
         sort_keys=True,
     )
-    conn.execute(
+    transition = conn.execute(
         """
+        /* cover_invalidation_after_tailor_success */
         UPDATE job_stage_states
         SET state = 'pending',
             attempt_count = 0,
@@ -329,9 +330,12 @@ def _mark_cover_pending_after_tailor_success_by_id(
             next_action = NULL,
             metadata_json = ?
         WHERE tenant_id = ? AND job_id = ? AND stage = 'cover'
+          AND state IN ('succeeded', 'failed', 'exhausted')
         """,
         (now, metadata, str(tenant_id), str(canonical_job_id(str(job_id)))),
     )
+    if transition.rowcount != 1:
+        return False
     record_job_event(
         conn,
         job_id,
@@ -341,6 +345,7 @@ def _mark_cover_pending_after_tailor_success_by_id(
         message="Cover stage reset after tailored resume generation",
         payload={"reason": reason},
     )
+    return True
 
 
 # ---------------------------------------------------------------------------

--- a/workers/automation/src/jobctrl/state.py
+++ b/workers/automation/src/jobctrl/state.py
@@ -70,6 +70,9 @@ _DEPENDENCY_BLOCKER_MESSAGES: dict[str, tuple[tuple[str, tuple[str, ...]], ...]]
         ("apply", ("Materials are not ready.",)),
     ),
 }
+_DEPENDENCY_TERMINAL_ERROR_CODES: dict[str, tuple[str, ...]] = {
+    "tailor": ("UPSTREAM_TAILOR_FAILED", "UPSTREAM_TAILOR_EXHAUSTED"),
+}
 SCORE_ELIGIBILITY_BLOCKED_ERROR_CODE = "SCORE_ELIGIBILITY_BLOCKED"
 SCORE_ELIGIBILITY_BLOCKED_MESSAGE_PREFIX = "Score eligibility blocks tailoring"
 SCORE_THRESHOLD_SKIPPED_ERROR_CODE = "MIN_SCORE"
@@ -415,6 +418,13 @@ def set_stage_state(
             completed_stage=stage,
             now=now,
         )
+    elif stage == "tailor" and state in {"failed", "exhausted"}:
+        reconcile_tailor_terminal_dependents(
+            conn,
+            tenant_id=tenant_id,
+            job_id=stable_job_id,
+            now=now,
+        )
 
 
 def reconcile_dependency_blockers(
@@ -443,7 +453,14 @@ def reconcile_dependency_blockers(
     for upstream in completed_stages:
         for downstream, messages in _DEPENDENCY_BLOCKER_MESSAGES[upstream]:
             message_placeholders = ", ".join("?" for _ in messages)
+            terminal_codes = _DEPENDENCY_TERMINAL_ERROR_CODES.get(upstream, ())
+            terminal_clause = ""
             params: list[Any] = [str(tenant_id), downstream, *messages]
+            if terminal_codes:
+                terminal_clause = (
+                    f" OR downstream.error_code IN ({', '.join('?' for _ in terminal_codes)})"
+                )
+                params.extend(terminal_codes)
             job_filter = ""
             if stable_job_id is not None:
                 job_filter = "AND downstream.job_id = ?"
@@ -456,8 +473,13 @@ def reconcile_dependency_blockers(
                  WHERE downstream.tenant_id = ?
                    AND downstream.stage = ?
                    AND downstream.state = 'blocked'
-                   AND downstream.error_code = 'BLOCKED'
-                   AND downstream.error_message IN ({message_placeholders})
+                   AND (
+                       (
+                           downstream.error_code = 'BLOCKED'
+                           AND downstream.error_message IN ({message_placeholders})
+                       )
+                       {terminal_clause}
+                   )
                    {job_filter}
                    AND EXISTS (
                        SELECT 1
@@ -496,6 +518,138 @@ def reconcile_dependency_blockers(
                 )
                 repaired += 1
     return repaired
+
+
+def reconcile_tailor_terminal_dependents(
+    conn,
+    *,
+    tenant_id: TenantId = LOCAL_TENANT,
+    job_id: JobId | None = None,
+    now: str | None = None,
+) -> int:
+    """Block unstarted Cover and Apply rows behind failed terminal Tailor state.
+
+    ``pending`` means runnable work with no known prerequisite failure. A
+    failed or exhausted Tailor cannot leave its dependents in that state. The
+    guarded writes preserve any stage another owner already queued, started,
+    completed, skipped, canceled, or exhausted.
+    """
+
+    stable_job_id = canonical_job_id(str(job_id)) if job_id is not None else None
+    job_filter = ""
+    params: list[Any] = [str(tenant_id)]
+    if stable_job_id is not None:
+        job_filter = "AND job_id = ?"
+        params.append(str(stable_job_id))
+    terminal_rows = conn.execute(
+        f"""
+        SELECT job_id, state, error_code
+          FROM job_stage_states
+         WHERE tenant_id = ?
+           AND stage = 'tailor'
+           AND state IN ('failed', 'exhausted')
+           {job_filter}
+        """,
+        params,
+    ).fetchall()
+
+    updated_at = now or utc_now()
+    changed = 0
+    for terminal in terminal_rows:
+        blocked_job_id = canonical_job_id(str(terminal["job_id"]))
+        upstream_state = str(terminal["state"])
+        upstream_error_code = str(terminal["error_code"] or "") or None
+        error_code = f"UPSTREAM_TAILOR_{upstream_state.upper()}"
+        next_action = (
+            "Reset Tailor's attempt budget and retry Tailor."
+            if upstream_state == "exhausted"
+            else "Retry Tailor."
+        )
+        for downstream in ("cover", "apply"):
+            display_name = "Cover letter" if downstream == "cover" else "Apply"
+            message = (
+                f"{display_name} cannot start because Tailor is {upstream_state}."
+            )
+            metadata_json = _json_dumps(
+                {
+                    "reason": "upstream_tailor_terminal",
+                    "upstreamStage": "tailor",
+                    "upstreamState": upstream_state,
+                    "upstreamErrorCode": upstream_error_code,
+                }
+            )
+            transition = conn.execute(
+                """
+                /* tailor_terminal_dependent_block */
+                UPDATE job_stage_states
+                   SET state = 'blocked',
+                       updated_at = ?,
+                       error_code = ?,
+                       error_message = ?,
+                       retryable = 0,
+                       blocked_by_json = '["tailor"]',
+                       next_action = ?,
+                       metadata_json = ?
+                 WHERE tenant_id = ?
+                   AND job_id = ?
+                   AND stage = ?
+                   AND (
+                       state = 'pending'
+                       OR (
+                           state = 'blocked'
+                           AND error_code IN (
+                               'BLOCKED',
+                               'UPSTREAM_TAILOR_FAILED',
+                               'UPSTREAM_TAILOR_EXHAUSTED'
+                           )
+                       )
+                   )
+                   AND NOT (
+                       state = 'blocked'
+                       AND error_code = ?
+                       AND error_message = ?
+                       AND retryable = 0
+                       AND blocked_by_json = '["tailor"]'
+                       AND next_action = ?
+                       AND metadata_json = ?
+                   )
+                """,
+                (
+                    updated_at,
+                    error_code,
+                    message,
+                    next_action,
+                    metadata_json,
+                    str(tenant_id),
+                    str(blocked_job_id),
+                    downstream,
+                    error_code,
+                    message,
+                    next_action,
+                    metadata_json,
+                ),
+            )
+            if transition.rowcount != 1:
+                continue
+            record_job_event(
+                conn,
+                blocked_job_id,
+                downstream,
+                "StageBlocked",
+                tenant_id=tenant_id,
+                level="warning",
+                message=message,
+                occurred_at=updated_at,
+                payload={
+                    "reason": "upstream_tailor_terminal",
+                    "upstreamStage": "tailor",
+                    "upstreamState": upstream_state,
+                    "upstreamErrorCode": upstream_error_code,
+                    "downstreamStage": downstream,
+                },
+            )
+            changed += 1
+    return changed
 
 
 def reconcile_score_eligibility_blockers(

--- a/workers/automation/tests/test_pipeline_repository.py
+++ b/workers/automation/tests/test_pipeline_repository.py
@@ -518,6 +518,60 @@ def test_save_blocked_state_round_trip(db):
     assert ("StageBlocked", "enrich", "warn") in events
 
 
+def test_save_blocks_tailor_terminal_dependents_regardless_of_stage_order(db):
+    """Terminal Tailor blocks unstarted dependents even when Tailor saves first.
+
+    load() selects rows without ORDER BY, and the PK index happens to return
+    stages alphabetically (Tailor last), which incidentally protects the
+    mid-loop dependency blocks written by set_stage_state's tailor-terminal
+    hook from being overwritten by this same aggregate's still-pending
+    Cover/Apply upserts.  This regression forces the opposite iteration order
+    — Tailor persisted before its dependents, as new_for_job()'s Stage-enum
+    order does — so it fails if save() ever relies on that ordering accident
+    instead of reconciling after the loop.
+    """
+    repo = SqlitePipelineStateRepository(db)
+    agg = repo.load(LOCAL_TENANT, JOB_ID)
+    assert agg is not None
+    agg.set_stage_state(
+        Stage.Tailor,
+        Failed(
+            attempt_count=1,
+            max_attempts=5,
+            error_code="FAILED_VALIDATION",
+            error_message="Tailoring ended with status failed_validation",
+            retryable=True,
+        ),
+    )
+    reordered = {Stage.Tailor: agg.stages[Stage.Tailor]}
+    for stage, stage_state in agg.stages.items():
+        reordered.setdefault(stage, stage_state)
+    agg.stages = reordered
+    assert list(agg.stages)[0] is Stage.Tailor
+    assert {Stage.Cover, Stage.Apply} <= set(list(agg.stages)[1:])
+
+    repo.save(agg)
+
+    rows = db.execute(
+        "SELECT stage, state, error_code, retryable, blocked_by_json "
+        "FROM job_stage_states "
+        "WHERE tenant_id = ? AND job_id = ? AND stage IN ('cover', 'apply') "
+        "ORDER BY stage",
+        (str(LOCAL_TENANT), str(JOB_ID)),
+    ).fetchall()
+    assert [(row["stage"], row["state"], row["error_code"]) for row in rows] == [
+        ("apply", "blocked", "UPSTREAM_TAILOR_FAILED"),
+        ("cover", "blocked", "UPSTREAM_TAILOR_FAILED"),
+    ]
+    assert {row["retryable"] for row in rows} == {0}
+    assert {row["blocked_by_json"] for row in rows} == {'["tailor"]'}
+
+    reloaded = repo.load(LOCAL_TENANT, JOB_ID)
+    assert reloaded is not None
+    assert isinstance(reloaded.get_stage_state(Stage.Cover), Blocked)
+    assert isinstance(reloaded.get_stage_state(Stage.Apply), Blocked)
+
+
 def test_save_skipped_state_emits_stage_skipped(db):
     repo = SqlitePipelineStateRepository(db)
     db.execute("DELETE FROM job_events")

--- a/workers/automation/tests/test_state_dashboard.py
+++ b/workers/automation/tests/test_state_dashboard.py
@@ -10,6 +10,7 @@ from jobctrl.state import (
     ensure_job_stage_rows,
     get_job_stage_states,
     reconcile_dependency_blockers,
+    reconcile_tailor_terminal_dependents,
     set_stage_state,
 )
 
@@ -620,5 +621,233 @@ def test_dependency_reconciliation_repairs_existing_apply_material_blocker(tmp_p
         assert repaired == 1
         assert row["state"] == "pending"
         assert row["error_message"] is None
+    finally:
+        close_connection(db_path)
+
+
+def test_tailor_exhaustion_blocks_unstarted_dependents_with_exact_reason(tmp_path):
+    db_path = Path(tmp_path) / "jobs.db"
+    conn = init_db(db_path)
+
+    try:
+        job = _insert_job(conn)
+        ensure_job_stage_rows(
+            conn,
+            job["job_id"],
+            tenant_id=job["tenant_id"],
+            discovered_at=job["discovered_at"],
+        )
+
+        set_stage_state(
+            conn,
+            job["job_id"],
+            "tailor",
+            "exhausted",
+            tenant_id=job["tenant_id"],
+            attempt_count=5,
+            error_code="FAILED_VALIDATION",
+            error_message="Tailoring ended with status failed_validation",
+            retryable=False,
+            validate_transition=False,
+        )
+        conn.commit()
+
+        rows = conn.execute(
+            "SELECT stage, state, error_code, error_message, retryable, "
+            "blocked_by_json, next_action FROM job_stage_states "
+            "WHERE tenant_id = ? AND job_id = ? AND stage IN ('cover', 'apply') "
+            "ORDER BY stage",
+            (job["tenant_id"], job["job_id"]),
+        ).fetchall()
+        assert [(row["stage"], row["state"]) for row in rows] == [
+            ("apply", "blocked"),
+            ("cover", "blocked"),
+        ]
+        assert {row["error_code"] for row in rows} == {
+            "UPSTREAM_TAILOR_EXHAUSTED"
+        }
+        assert {row["retryable"] for row in rows} == {0}
+        assert {row["blocked_by_json"] for row in rows} == {'["tailor"]'}
+        assert all("Tailor is exhausted" in row["error_message"] for row in rows)
+        assert {row["next_action"] for row in rows} == {
+            "Reset Tailor's attempt budget and retry Tailor."
+        }
+        events = conn.execute(
+            "SELECT stage, event_type FROM job_events "
+            "WHERE tenant_id = ? AND job_id = ? AND event_type = 'StageBlocked' "
+            "ORDER BY stage",
+            (job["tenant_id"], job["job_id"]),
+        ).fetchall()
+        assert [(row["stage"], row["event_type"]) for row in events] == [
+            ("apply", "StageBlocked"),
+            ("cover", "StageBlocked"),
+        ]
+    finally:
+        close_connection(db_path)
+
+
+def test_tailor_success_clears_only_tailor_owned_terminal_blocks(tmp_path):
+    db_path = Path(tmp_path) / "jobs.db"
+    conn = init_db(db_path)
+
+    try:
+        job = _insert_job(conn)
+        ensure_job_stage_rows(
+            conn,
+            job["job_id"],
+            tenant_id=job["tenant_id"],
+            discovered_at=job["discovered_at"],
+        )
+        set_stage_state(
+            conn,
+            job["job_id"],
+            "tailor",
+            "failed",
+            tenant_id=job["tenant_id"],
+            error_code="FAILED_VALIDATION",
+            validate_transition=False,
+        )
+        set_stage_state(
+            conn,
+            job["job_id"],
+            "tailor",
+            "succeeded",
+            tenant_id=job["tenant_id"],
+            validate_transition=False,
+        )
+        conn.commit()
+
+        rows = conn.execute(
+            "SELECT stage, state, error_code FROM job_stage_states "
+            "WHERE tenant_id = ? AND job_id = ? AND stage IN ('cover', 'apply') "
+            "ORDER BY stage",
+            (job["tenant_id"], job["job_id"]),
+        ).fetchall()
+        assert [(row["stage"], row["state"], row["error_code"]) for row in rows] == [
+            ("apply", "pending", None),
+            ("cover", "pending", None),
+        ]
+    finally:
+        close_connection(db_path)
+
+
+def test_terminal_dependency_reconciliation_preserves_claimed_and_terminal_rows(tmp_path):
+    db_path = Path(tmp_path) / "jobs.db"
+    conn = init_db(db_path)
+
+    try:
+        job = _insert_job(conn)
+        ensure_job_stage_rows(
+            conn,
+            job["job_id"],
+            tenant_id=job["tenant_id"],
+            discovered_at=job["discovered_at"],
+        )
+        conn.execute(
+            "UPDATE job_stage_states SET state = 'exhausted', "
+            "error_code = 'FAILED_VALIDATION' "
+            "WHERE tenant_id = ? AND job_id = ? AND stage = 'tailor'",
+            (job["tenant_id"], job["job_id"]),
+        )
+        set_stage_state(
+            conn,
+            job["job_id"],
+            "cover",
+            "running",
+            tenant_id=job["tenant_id"],
+            validate_transition=False,
+        )
+        set_stage_state(
+            conn,
+            job["job_id"],
+            "apply",
+            "canceled",
+            tenant_id=job["tenant_id"],
+            validate_transition=False,
+        )
+
+        assert (
+            reconcile_tailor_terminal_dependents(
+                conn,
+                tenant_id=job["tenant_id"],
+                job_id=job["job_id"],
+            )
+            == 0
+        )
+        rows = conn.execute(
+            "SELECT stage, state FROM job_stage_states "
+            "WHERE tenant_id = ? AND job_id = ? AND stage IN ('cover', 'apply') "
+            "ORDER BY stage",
+            (job["tenant_id"], job["job_id"]),
+        ).fetchall()
+        assert [(row["stage"], row["state"]) for row in rows] == [
+            ("apply", "canceled"),
+            ("cover", "running"),
+        ]
+    finally:
+        close_connection(db_path)
+
+
+def test_terminal_dependency_reconciliation_does_not_overwrite_concurrent_claim(tmp_path):
+    db_path = Path(tmp_path) / "jobs.db"
+    conn = init_db(db_path)
+
+    try:
+        job = _insert_job(conn)
+        ensure_job_stage_rows(
+            conn,
+            job["job_id"],
+            tenant_id=job["tenant_id"],
+            discovered_at=job["discovered_at"],
+        )
+        conn.execute(
+            "UPDATE job_stage_states SET state = 'exhausted', "
+            "error_code = 'FAILED_VALIDATION' "
+            "WHERE tenant_id = ? AND job_id = ? AND stage = 'tailor'",
+            (job["tenant_id"], job["job_id"]),
+        )
+
+        class ClaimBeforeDependentBlock:
+            def __init__(self, wrapped):
+                self.wrapped = wrapped
+                self.injected = False
+
+            def execute(self, sql, parameters=()):
+                if "tailor_terminal_dependent_block" in sql and not self.injected:
+                    self.injected = True
+                    self.wrapped.execute(
+                        "UPDATE job_stage_states SET state = 'running', "
+                        "metadata_json = '{\"claim\":\"cover-worker\"}' "
+                        "WHERE tenant_id = ? AND job_id = ? AND stage = 'cover'",
+                        (job["tenant_id"], job["job_id"]),
+                    )
+                return self.wrapped.execute(sql, parameters)
+
+        interleaved = ClaimBeforeDependentBlock(conn)
+        assert (
+            reconcile_tailor_terminal_dependents(
+                interleaved,
+                tenant_id=job["tenant_id"],
+                job_id=job["job_id"],
+            )
+            == 1
+        )
+        rows = conn.execute(
+            "SELECT stage, state, metadata_json FROM job_stage_states "
+            "WHERE tenant_id = ? AND job_id = ? AND stage IN ('cover', 'apply') "
+            "ORDER BY stage",
+            (job["tenant_id"], job["job_id"]),
+        ).fetchall()
+        assert [(row["stage"], row["state"]) for row in rows] == [
+            ("apply", "blocked"),
+            ("cover", "running"),
+        ]
+        assert rows[1]["metadata_json"] == '{"claim":"cover-worker"}'
+        cover_events = conn.execute(
+            "SELECT COUNT(*) FROM job_events WHERE tenant_id = ? AND job_id = ? "
+            "AND stage = 'cover' AND event_type = 'StageBlocked'",
+            (job["tenant_id"], job["job_id"]),
+        ).fetchone()[0]
+        assert cover_events == 0
     finally:
         close_connection(db_path)

--- a/workers/automation/tests/test_v7_tailor_runtime.py
+++ b/workers/automation/tests/test_v7_tailor_runtime.py
@@ -286,6 +286,16 @@ def test_tailor_job_by_id_is_tenant_scoped_and_writes_canonical_state(
 ) -> None:
     _seed_job(conn, tenant_id=_TENANT_A, url="https://example.com/a")
     _seed_job(conn, tenant_id=_TENANT_B, url="https://example.com/b")
+    conn.execute(
+        """
+        UPDATE job_stage_states
+           SET state = 'running', attempt_count = 2,
+               metadata_json = '{"activityOwner":"cover-run-2"}'
+         WHERE tenant_id = ? AND job_id = ? AND stage = 'cover'
+        """,
+        (str(_TENANT_A), str(_JOB_ID)),
+    )
+    conn.commit()
     calls: list[tuple[str, str]] = []
 
     def fake_tailor(job: dict, *_args, **_kwargs) -> dict:
@@ -314,6 +324,27 @@ def test_tailor_job_by_id_is_tenant_scoped_and_writes_canonical_state(
         (str(_TENANT_A), str(_JOB_ID)),
     ).fetchone()
     assert state["state"] == "succeeded"
+    cover_state = conn.execute(
+        """
+        SELECT state, attempt_count, metadata_json
+          FROM job_stage_states
+         WHERE tenant_id = ? AND job_id = ? AND stage = 'cover'
+        """,
+        (str(_TENANT_A), str(_JOB_ID)),
+    ).fetchone()
+    assert tuple(cover_state) == (
+        "running",
+        2,
+        '{"activityOwner":"cover-run-2"}',
+    )
+    assert conn.execute(
+        """
+        SELECT COUNT(*) FROM job_events
+         WHERE tenant_id = ? AND job_id = ?
+           AND stage = 'cover' AND event_type = 'StageReset'
+        """,
+        (str(_TENANT_A), str(_JOB_ID)),
+    ).fetchone()[0] == 0
     other_tenant_state = conn.execute(
         """
         SELECT state FROM job_stage_states
@@ -335,6 +366,64 @@ def test_tailor_job_by_id_is_tenant_scoped_and_writes_canonical_state(
         "job_id": str(_JOB_ID),
         "event_type": "StageCompleted",
     }
+
+
+def test_tailor_job_by_id_resets_tailor_owned_cover_block_exactly_once(
+    conn: sqlite3.Connection,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _seed_job(conn, tenant_id=_TENANT_A, url="https://example.com/recovered-tailor")
+    tailor_module.set_stage_state(
+        conn,
+        _JOB_ID,
+        "tailor",
+        "failed",
+        tenant_id=_TENANT_A,
+        attempt_count=1,
+        error_code="FAILED_VALIDATION",
+        validate_transition=False,
+    )
+    conn.commit()
+    assert conn.execute(
+        "SELECT state FROM job_stage_states "
+        "WHERE tenant_id = ? AND job_id = ? AND stage = 'cover'",
+        (str(_TENANT_A), str(_JOB_ID)),
+    ).fetchone()[0] == "blocked"
+
+    monkeypatch.setattr(tailor_module, "get_connection", lambda: conn)
+    monkeypatch.setattr(tailor_module, "TAILORED_DIR", tmp_path / "tailored")
+    monkeypatch.setattr(tailor_module, "_build_pdf_renderer", lambda: object())
+    monkeypatch.setattr(
+        tailor_module,
+        "_tailor_one_job",
+        lambda job, *_args, **_kwargs: _fake_approved_result(job),
+    )
+
+    result = tailor_module.tailor_job_by_id(
+        _JOB_ID,
+        tenant_id=_TENANT_A,
+        snapshot=SimpleNamespace(),
+        llm_model=None,
+    )
+
+    assert result["status"] == "approved"
+    cover_state = conn.execute(
+        "SELECT state, error_code FROM job_stage_states "
+        "WHERE tenant_id = ? AND job_id = ? AND stage = 'cover'",
+        (str(_TENANT_A), str(_JOB_ID)),
+    ).fetchone()
+    assert tuple(cover_state) == ("pending", None)
+    reset_events = conn.execute(
+        """
+        SELECT payload_json FROM job_events
+         WHERE tenant_id = ? AND job_id = ?
+           AND stage = 'cover' AND event_type = 'StageReset'
+        """,
+        (str(_TENANT_A), str(_JOB_ID)),
+    ).fetchall()
+    assert len(reset_events) == 1
+    assert json.loads(reset_events[0]["payload_json"])["reason"] == "upstream_completed"
 
 
 def test_tailor_job_by_id_terminalizes_unhandled_item_exception(


### PR DESCRIPTION
## Summary

- block unstarted Cover and Apply rows when Tailor is retryably failed or durably exhausted, with exact upstream codes, dependency metadata, and recovery actions
- reconcile historical rows during database/preparation startup so old ownerless `pending` dependents become truthful
- clear only Tailor-owned dependency blocks after success and preserve concurrent queued/running claims, attempts, metadata, skips, and cancellations
- invalidate an older completed/failed Cover only after a replacement resume is accepted, using a guarded transition and rowcount-gated event

## Why

Cover and Apply could remain `pending` after Tailor had exhausted all durable attempts. That state falsely implied runnable work without a satisfiable prerequisite. An older Cover invalidation helper could also overwrite a live Cover owner during Tailor success.

## Validation

- focused Tailor, preparation, and canonical stage-state suites — 56 passed
- production Tailor-success ownership and exactly-once reset regressions — passed
- deterministic concurrent dependent-claim regression — passed
- focused Ruff and `git diff --check` — passed
- docs build and link/redirect checks — passed (9,651 references)
- independent review gate — PASS; zero Blocker, High, or Medium findings; one documentation Low corrected before commit
- no Apply execution or application submission behavior was added

## Stack

Depends on #759.
