### PR TITLE
fix(tailor): separate requirement coverage scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,12 @@ evidence, qualifications, and the complete capability matrix.
   clears only those Tailor-owned blocks. Claimed, skipped, and canceled
   dependent work is never moved backward; an accepted new resume may invalidate
   a completed or failed Cover from the superseded material generation.
+- Keep requirement purposes separate. Technical qualifications and role
+  responsibilities may enter grounded resume coverage; work arrangements,
+  work-authorization checks, and employer-side conditions remain visible as
+  context-only eligibility/Apply facts. A hybrid or office-attendance rule can
+  warn or request confirmation, but it cannot fail resume generation or consume
+  a Tailor retry because the resume does not assert it.
 - Review privacy-bounded learning recommendations on the Dashboard. JobCtrl
   derives them only from explicit reviewed signals, requires compatible
   evidence across jobs, and changes Materials behavior only after you accept a

--- a/apps/api/src/projections.ts
+++ b/apps/api/src/projections.ts
@@ -1218,6 +1218,13 @@ function loadEmployerAnalysisJson(db: SqliteDatabase, tenantId: string, jobId: s
     [tenantId, jobId, generation],
   );
 
+  const normalizeRequirements = (value: unknown): unknown[] =>
+    (Array.isArray(value) ? value : []).map((requirement) =>
+      isRecord(requirement)
+        ? { ...requirement, coverage_scope: requirement.coverage_scope ?? null }
+        : requirement,
+    );
+
   const readModel = {
     generation,
     snapshot_hash: row.snapshot_hash,
@@ -1233,12 +1240,16 @@ function loadEmployerAnalysisJson(db: SqliteDatabase, tenantId: string, jobId: s
     role_framing: row.role_framing,
     inferred_seniority: row.inferred_seniority,
     ideal_candidate_narrative: row.ideal_candidate_narrative,
-    requirements: parseJsonArray(row.requirements_json),
+    requirements: normalizeRequirements(parseJsonArray(row.requirements_json)),
     keywords: parseJsonArray(row.keywords_json),
-    sub_analyses: subRows.map((sub) => ({
-      model_id: sub.model_id,
-      ...(parseJsonObject(sub.analysis_json) as Record<string, unknown>),
-    })),
+    sub_analyses: subRows.map((sub) => {
+      const analysis = parseJsonObject(sub.analysis_json) as Record<string, unknown>;
+      return {
+        model_id: sub.model_id,
+        ...analysis,
+        requirements: normalizeRequirements(analysis.requirements),
+      };
+    }),
     failures: failureRows.map((f) => ({
       model_id: f.model_id,
       error: f.error,

--- a/apps/api/test/projections.test.ts
+++ b/apps/api/test/projections.test.ts
@@ -1889,6 +1889,7 @@ describe("apply_run_projections without legacy apply_runs table", () => {
           tier: "must_have",
           weight: 0.9,
           evidence_span: "5+ years Python",
+          coverage_scope: "resume",
         },
       ];
       const keywords = [
@@ -1963,7 +1964,11 @@ describe("apply_run_projections without legacy apply_runs table", () => {
           role_framing: "Own the event platform.",
           inferred_seniority: "senior",
         });
-        expect(analysis.requirements[0]).toMatchObject({ tier: "must_have", weight: 0.9 });
+        expect(analysis.requirements[0]).toMatchObject({
+          tier: "must_have",
+          weight: 0.9,
+          coverage_scope: "resume",
+        });
         expect(analysis.keywords[0]).toMatchObject({ keyword: "Python", requirement_ref: "r1" });
         expect(analysis.agreement.flagged_keywords).toEqual(["kafka"]);
         expect(analysis.sub_analyses[0].model_id).toBe("claude-opus-4-8");

--- a/apps/web/src/contexts/materials/components/InterviewPrepPanel.a11y.test.tsx
+++ b/apps/web/src/contexts/materials/components/InterviewPrepPanel.a11y.test.tsx
@@ -30,6 +30,7 @@ describe("<InterviewPrepPanel> a11y", () => {
               tier: "must_have",
               weight: 0.9,
               evidence_span: "Own our API platform reliability program",
+              coverage_scope: "resume",
             },
           ]}
           resolveEvidenceReference={(evidenceId) => ({

--- a/apps/web/src/contexts/materials/components/InterviewPrepPanel.test.tsx
+++ b/apps/web/src/contexts/materials/components/InterviewPrepPanel.test.tsx
@@ -15,6 +15,7 @@ const interviewRequirements: readonly EmployerAnalysisRequirement[] = [
     tier: "must_have",
     weight: 0.9,
     evidence_span: "Own our API platform reliability program",
+    coverage_scope: "resume",
   },
 ];
 

--- a/apps/web/src/test/fixtures/materials-inspector.ts
+++ b/apps/web/src/test/fixtures/materials-inspector.ts
@@ -39,6 +39,7 @@ export const populatedEmployerAnalysis: EmployerAnalysis = {
       tier: "must_have",
       weight: 0.9,
       evidence_span: "Lead our platform reliability initiatives across the engineering org",
+      coverage_scope: "resume",
     },
     {
       id: "req-2",
@@ -46,6 +47,7 @@ export const populatedEmployerAnalysis: EmployerAnalysis = {
       tier: "nice_to_have",
       weight: 0.55,
       evidence_span: "Familiarity with Kubernetes and internal developer platforms is a plus",
+      coverage_scope: "resume",
     },
   ],
   keywords: [

--- a/docs/architecture/tailoring.md
+++ b/docs/architecture/tailoring.md
@@ -119,7 +119,7 @@ Tailoring combines several inputs. Each input has a different authority.
 | Target job | Job record | The target role, description, responsibilities, skills, and company context |
 | Employer analysis | `EmployerAnalysis` aggregate | Grounded role framing, inferred seniority, requirements, and reasoned keywords |
 | Requirement fit report | Scoring context | Pre-tailoring fit by requirement, allowed evidence IDs, target keywords, prohibited claims, tailoring directives; its employer-analysis generation must match the current posting analysis |
-| Requirement-led coverage graph | Deterministic target-profile adapter plus constrained planner | Which profile achievements can cover which target requirements, which requirements are uncovered, which achievements are unused, and what claim policy each edge requires |
+| Requirement-led coverage graph | Deterministic target-profile adapter plus constrained planner | Which profile achievements can cover resume-scoped target requirements, which resume requirements are uncovered, which achievements are unused, and what claim policy each edge requires. Logistics, eligibility, and employer conditions remain context-only outside the resume denominator. |
 | Previous attempt outcome | Tailoring retry loop | Typed, code-owned retry reason only; free-form validator, judge, adversarial, and prior-output text remains audit data |
 
 The rollbackable tailoring-policy revision contains only tenant-wide generation
@@ -307,8 +307,16 @@ The plan includes:
 - `requirement_led_controls`: claim policy, generation permissions, required
   pins, writing style, revision gates, and advanced auto-approval policy after
   migrating legacy Preferences values.
-- `target_profile`: must-have and nice-to-have requirements with safe excerpts,
-  weights, keywords, and profile achievement IDs.
+- `target_profile`: every must-have and nice-to-have requirement with a safe
+  excerpt and explicit `resume`, `logistics`, `eligibility`, or
+  `employer_condition` scope, plus weights, keywords, and profile achievement
+  IDs. Only `resume` requirements enter the generation/coverage lists; the
+  others remain inspectable as context-only requirements. Employer-analysis
+  prompt v2 asks every leg and the synthesizer to declare this scope. The
+  target-profile adapter uses that reconciled declaration for ambiguous wording
+  and applies deterministic non-resume safety rules plus an old-analysis
+  fallback, so an obvious office/work-authorization/employer condition cannot
+  be promoted to resume coverage by one bad declaration.
 - `coverage_graph`: requirement nodes, achievement nodes, coverage edges,
   uncovered requirements, and unused achievements. Existing
   `RequirementFitReport.fit.evidence_ids` seed direct/transferable edges before
@@ -321,6 +329,8 @@ can say, for example:
 - double down on a matched requirement,
 - bridge a transferable gap using specific evidence,
 - avoid claiming a missing or blocked requirement,
+- retain logistics, eligibility, and employer conditions as context-only facts
+  for review rather than résumé claims,
 - target specific grounded keywords.
 
 ## Attempt Loop And Candidate Selection
@@ -663,6 +673,8 @@ The current implementation can safely:
   positioning reasons,
 - score generated output against the target profile and route one gated
   revision/enhancement pass,
+- keep non-resume requirements visible without counting them in grounded resume
+  coverage or its retry gate,
 - compute post-generation provenance and requirement coverage.
 
 The current implementation cannot safely:
@@ -674,6 +686,8 @@ The current implementation cannot safely:
 - remove education or required experience,
 - treat a keyword as covered unless it appears in the generated resume text or
   generation-time provenance.
+- treat office attendance, remote/hybrid arrangements, work authorization, or
+  employer compensation/benefits as achievements the resume must cover.
 
 ## Common Failure Reasons
 

--- a/docs/local-reliability-qa.md
+++ b/docs/local-reliability-qa.md
@@ -158,7 +158,15 @@ run Score and Tailor. Score must resolve the current analysis cache identity and
 persist a requirement-fit report for that exact generation. A deliberately
 missing or generation-mismatched report must block Tailor on Score before an LLM
 candidate call, preserve the Tailor attempt count, and emit an auditable
-`StageBlocked`. With coherent inputs, sentence-level executive-profile mapping
+`StageBlocked` prerequisite reason. Include a requirement-scope fixture with
+one grounded technical must-have and one missing hybrid/office-attendance
+must-have. The
+logistics item must remain present in safe plan metadata and prompt context,
+must be excluded from coverage nodes, weighted/must-have resume denominators,
+and prioritized fixes, and must not consume a Tailor retry. Pair it with
+negative controls such as “leading remote engineering teams” and “hybrid cloud
+infrastructure” so the classifier cannot become a blunt remote/hybrid keyword
+filter. With coherent inputs, sentence-level executive-profile mapping
 locations must bind to the rendered summary and skill-group mappings must use
 the exact rendered item sequence.
 The focused deterministic gate is:

--- a/docs/local-ts-api.md
+++ b/docs/local-ts-api.md
@@ -68,6 +68,11 @@ On job detail, Enrich stage summaries can carry a separate, allow-listed
 application-target readiness without changing posting-content trust or stage
 success; raw browser/resolver errors are not exposed.
 
+Employer-analysis requirements on job detail expose `coverage_scope` as
+`resume`, `eligibility`, `logistics`, `employer_condition`, or `null` for
+historical analyses. Both projection builders normalize missing historical
+values to `null`, so the TypeScript and Python read models remain identical.
+
 Internal list/detail identity is the tenant-scoped stable `JobId`; posting URLs
 are locators resolved only at explicit import or API boundaries. Employer and
 Source remain independent facts. `GET /v1/scoring/keywords` aggregates indexed,

--- a/docs/user/materials-and-tailoring.md
+++ b/docs/user/materials-and-tailoring.md
@@ -146,6 +146,16 @@ rendered, grounded text and persisted with the generation. The artifact read
 model does not infer a missing list from the job description later, and it
 reports absent audit data as unrecorded rather than as zero coverage.
 
+JobCtrl also records what each posting requirement is for. Technical
+qualifications and responsibilities are `resume` requirements and can enter
+the grounded coverage gate. Work arrangements such as remote/hybrid or office
+attendance are `logistics`; work authorization and screening are
+`eligibility`; salary, benefits, and other employer terms are
+`employer_condition`. Those context-only requirements remain visible for fit
+and Apply Review, but the resume is never required to claim them. An unknown
+office-attendance preference can therefore warn or ask for confirmation; it
+cannot reject a resume candidate or spend Tailor retries.
+
 Cover letters follow the same evidence boundary. They may describe employer
 priorities from the posting, but posting-only numbers and dates are omitted or
 expressed qualitatively. Only numeric/date facts already grounded in the

--- a/docs/user/scoring-and-employer-analysis.md
+++ b/docs/user/scoring-and-employer-analysis.md
@@ -167,6 +167,11 @@ reason to correct or investigate it.
   trace. `scoring_policies` owns rubric/policy versions and calibration anchors;
   stale markers record when an older score awaits deliberate adoption of a
   newer policy.
+- **Tailoring owns requirement use, not requirement existence.** The accepted
+  analysis and requirement-fit report retain every employer requirement.
+  Tailoring classifies whether each one is resume-coverable or context-only;
+  logistics, eligibility, and employer conditions remain available to fit and
+  Apply Review without becoming resume-coverage failures.
 - **Operations owns display projections.** Jobs reads expose persisted analysis
   and score evidence. They do not call a model or recompute a score on request.
 - **Explicit feedback remains history until an owning policy says otherwise.**

--- a/packages/contracts/src/schemas.ts
+++ b/packages/contracts/src/schemas.ts
@@ -3921,6 +3921,7 @@ export interface EmployerAnalysisRequirement {
   tier: "must_have" | "nice_to_have";
   weight: number;
   evidence_span: string;
+  coverage_scope: "resume" | "eligibility" | "logistics" | "employer_condition" | null;
 }
 
 export interface EmployerAnalysisKeyword {

--- a/packages/domain-types/test/fixtures/audit_projection_parity.json
+++ b/packages/domain-types/test/fixtures/audit_projection_parity.json
@@ -645,7 +645,8 @@
             "id": "r1",
             "text": "5+ years platform engineering",
             "tier": "must_have",
-            "weight": 0.9
+            "weight": 0.9,
+            "coverage_scope": null
           }
         ],
         "role_framing": "Own the developer platform.",
@@ -671,7 +672,8 @@
                 "id": "r1",
                 "text": "5+ years platform engineering",
                 "tier": "must_have",
-                "weight": 0.9
+                "weight": 0.9,
+                "coverage_scope": null
               }
             ],
             "role_framing": "Own the developer platform."
@@ -1135,7 +1137,8 @@
           "text": "5+ years platform engineering",
           "tier": "must_have",
           "weight": 0.9,
-          "evidence_span": "5+ years building developer platforms"
+          "evidence_span": "5+ years building developer platforms",
+          "coverage_scope": null
         }
       ],
       "keywords": [
@@ -1159,7 +1162,8 @@
               "text": "5+ years platform engineering",
               "tier": "must_have",
               "weight": 0.9,
-              "evidence_span": "5+ years building developer platforms"
+              "evidence_span": "5+ years building developer platforms",
+              "coverage_scope": null
             }
           ],
           "keywords": [

--- a/workers/automation/src/jobctrl/domain/materials/analysis.py
+++ b/workers/automation/src/jobctrl/domain/materials/analysis.py
@@ -45,7 +45,7 @@ from jobctrl.domain.tenant import LOCAL_TENANT, TenantId
 # Bump whenever the analysis system prompt changes so stale cached analyses are
 # recomputed rather than silently served (D-12). The cache key combines this
 # with the JD snapshot hash and the SDK-set version.
-PROMPT_VERSION = "employer-analysis-v1"
+PROMPT_VERSION = "employer-analysis-v2"
 
 # Identifies the default ensemble model/SDK set. Bump when the default leg set
 # or model ids change so the cache invalidates (D-12). The config.json
@@ -54,6 +54,12 @@ PROMPT_VERSION = "employer-analysis-v1"
 SDK_SET_VERSION = "claude+codex+antigravity-v2-synth-default"
 
 RequirementTier = Literal["must_have", "nice_to_have"]
+RequirementCoverageScope = Literal[
+    "resume",
+    "eligibility",
+    "logistics",
+    "employer_condition",
+]
 
 
 # ---------------------------------------------------------------------------
@@ -106,6 +112,13 @@ class Requirement(BaseModel):
     evidence_span: str = Field(
         ...,
         description="LITERAL substring of the JD snapshot supporting this requirement (D-15).",
+    )
+    coverage_scope: RequirementCoverageScope | None = Field(
+        default=None,
+        description=(
+            "How Tailoring may use this requirement: resume for candidate qualifications/"
+            "responsibilities; eligibility, logistics, or employer_condition remain context-only."
+        ),
     )
 
 
@@ -417,6 +430,7 @@ __all__ = [
     "Requirement",
     "JobAnalysis",
     "JobAnalysisDraft",
+    "RequirementCoverageScope",
     "AnalysisFailure",
     "AnalysisAgreement",
     "EeoScreenHit",

--- a/workers/automation/src/jobctrl/domain/materials/quality.py
+++ b/workers/automation/src/jobctrl/domain/materials/quality.py
@@ -565,6 +565,7 @@ def build_tailoring_plan(
         requirement_fit_report=matched_requirement_fit_report,
         job=job,
         employer_analysis=employer_analysis,
+        evidence_items=evidence_items,
     )
     directive_keywords = tuple(
         keyword
@@ -993,6 +994,7 @@ def _requirement_directive_items(
     requirement_fit_report: "RequirementFitReport | None",
     job: dict,
     employer_analysis: EmployerAnalysis,
+    evidence_items: tuple[EvidencePlanItem, ...] = (),
 ) -> tuple[RequirementDirectivePlanItem, ...]:
     if not _requirement_fit_report_matches(requirement_fit_report, job, employer_analysis):
         return ()
@@ -1001,9 +1003,10 @@ def _requirement_directive_items(
         str(getattr(requirement, "id", "") or ""): requirement
         for requirement in employer_analysis.canonical.requirements
     }
-    for assessment in getattr(requirement_fit_report, "assessments", ()) or ():
-        fit = getattr(assessment, "fit", None)
-        directive = getattr(assessment, "tailoring", None)
+    assessments = tuple(getattr(requirement_fit_report, "assessments", ()) or ())
+    coverage_scopes: dict[str, str] = {}
+    requirement_texts: dict[str, str] = {}
+    for assessment in assessments:
         requirement_id = str(getattr(assessment, "requirement_id", "") or "").strip()
         canonical_requirement = canonical_requirements.get(requirement_id)
         requirement_text = str(
@@ -1013,12 +1016,30 @@ def _requirement_directive_items(
         ).strip()
         if not requirement_id or not requirement_text:
             continue
-        fit_kind = str(getattr(fit, "kind", "not_assessed") or "not_assessed")
-        action = str(getattr(directive, "action", "low_priority") or "low_priority")
-        coverage_scope = resolve_requirement_coverage_scope(
+        requirement_texts[requirement_id] = requirement_text
+        coverage_scopes[requirement_id] = resolve_requirement_coverage_scope(
             requirement_text,
             getattr(canonical_requirement, "coverage_scope", None),
         )
+    legitimate_claim_corpus = _legitimate_claim_corpus(
+        evidence_items=evidence_items,
+        employer_analysis=employer_analysis,
+        resume_requirement_texts=tuple(
+            text
+            for requirement_id, text in requirement_texts.items()
+            if coverage_scopes.get(requirement_id) == "resume"
+        ),
+    )
+    for assessment in assessments:
+        fit = getattr(assessment, "fit", None)
+        directive = getattr(assessment, "tailoring", None)
+        requirement_id = str(getattr(assessment, "requirement_id", "") or "").strip()
+        requirement_text = requirement_texts.get(requirement_id, "")
+        if not requirement_id or not requirement_text:
+            continue
+        fit_kind = str(getattr(fit, "kind", "not_assessed") or "not_assessed")
+        action = str(getattr(directive, "action", "low_priority") or "low_priority")
+        coverage_scope = coverage_scopes[requirement_id]
         allowed_evidence_ids = _merge_strings(
             tuple(getattr(fit, "evidence_ids", ()) or ()),
             tuple(getattr(directive, "allowed_evidence_ids", ()) or ()),
@@ -1032,10 +1053,20 @@ def _requirement_directive_items(
             action = "context_only"
             allowed_evidence_ids = ()
             target_keywords = ()
-            # Use the canonical posting sentence, not a model-supplied token
-            # fragment such as "hybrid" that could reject legitimate profile
-            # evidence about hybrid-cloud or remote-team experience.
-            prohibited_claims = (requirement_text,)
+            # The canonical posting sentence is always prohibited verbatim.
+            # Model-supplied fragments stay in force only when they cannot
+            # collide with text a grounded resume may legitimately contain: a
+            # bare token such as "hybrid" would otherwise reject legitimate
+            # hybrid-cloud or remote-team evidence, while a fragment such as
+            # "on-site three days" keeps the deterministic net against
+            # fabricated work-arrangement claims.
+            prohibited_claims = (
+                requirement_text,
+                *_collision_safe_prohibited_claims(
+                    prohibited_claims,
+                    legitimate_claim_corpus=legitimate_claim_corpus,
+                ),
+            )
         if fit_kind in {"missing", "blocked"} and not prohibited_claims:
             prohibited_claims = (requirement_text,)
         instruction = str(getattr(directive, "instruction", "") or "").strip()
@@ -1101,6 +1132,67 @@ def _directive_evidence_ids(
             continue
         ids.extend(directive.allowed_evidence_ids)
     return tuple(dict.fromkeys(ids))
+
+
+def _legitimate_claim_corpus(
+    *,
+    evidence_items: tuple[EvidencePlanItem, ...],
+    employer_analysis: EmployerAnalysis,
+    resume_requirement_texts: tuple[str, ...],
+) -> tuple[str, ...]:
+    """Normalized text a grounded resume may legitimately contain.
+
+    Prohibited-claim fragments are substring-matched against generated text, so
+    any fragment that already appears in profile evidence, the analysis's
+    reconciled keywords, or resume-scoped requirement wording would flag
+    legitimate grounded output as a fabricated claim.
+    """
+    entries: list[str] = []
+    for item in evidence_items:
+        entries.extend(
+            (
+                item.source_text,
+                item.scope,
+                item.action,
+                item.outcome,
+                *item.tools,
+                *item.metrics,
+                *item.tags,
+            )
+        )
+    entries.extend(_analysis_job_keywords(employer_analysis))
+    entries.extend(resume_requirement_texts)
+    return tuple(
+        dict.fromkeys(
+            normalized
+            for entry in entries
+            if (normalized := _normalize_claim_phrase(str(entry or "")))
+        )
+    )
+
+
+def _collision_safe_prohibited_claims(
+    model_prohibited_claims: tuple[str, ...],
+    *,
+    legitimate_claim_corpus: tuple[str, ...],
+) -> tuple[str, ...]:
+    """Keep model-supplied prohibited fragments that cannot misfire.
+
+    A fragment is dropped when its normalized form appears inside any
+    legitimate corpus entry: the deterministic prohibited-claim gate would then
+    reject grounded resume content (the "hybrid" false positive). Surviving
+    fragments keep the gate armed against fabricated work-arrangement and
+    eligibility claims.
+    """
+    kept: list[str] = []
+    for claim in model_prohibited_claims:
+        normalized = _normalize_claim_phrase(str(claim or ""))
+        if len(normalized) < 3:
+            continue
+        if any(normalized in entry for entry in legitimate_claim_corpus):
+            continue
+        kept.append(str(claim).strip())
+    return tuple(dict.fromkeys(kept))
 
 
 def _directive_prohibited_claims(

--- a/workers/automation/src/jobctrl/domain/materials/quality.py
+++ b/workers/automation/src/jobctrl/domain/materials/quality.py
@@ -22,6 +22,7 @@ from jobctrl.domain.materials.requirement_coverage import (
     CoverageGraph,
     TargetProfile,
     build_target_profile,
+    resolve_requirement_coverage_scope,
     seed_coverage_graph,
 )
 from jobctrl.domain.materials.value_objects import ValidationResult
@@ -260,6 +261,7 @@ class RequirementDirectivePlanItem:
     weight: float
     fit_kind: str
     action: str
+    coverage_scope: str = "resume"
     priority: float = 0.0
     allowed_evidence_ids: tuple[str, ...] = ()
     target_keywords: tuple[str, ...] = ()
@@ -275,6 +277,7 @@ class RequirementDirectivePlanItem:
             "weight": self.weight,
             "pre_tailor_fit": self.fit_kind,
             "action": self.action,
+            "coverage_scope": self.coverage_scope,
             "priority": self.priority,
             "allowed_evidence_ids": list(self.allowed_evidence_ids),
             "target_keywords": list(self.target_keywords),
@@ -289,6 +292,7 @@ class RequirementDirectivePlanItem:
             "requirement_text": self.requirement_text,
             "fit": self.fit_kind,
             "action": self.action,
+            "coverage_scope": self.coverage_scope,
             "priority": self.priority,
             "allowed_evidence_ids": list(self.allowed_evidence_ids),
             "target_keywords": list(self.target_keywords),
@@ -348,6 +352,7 @@ class TailoringPlan:
                 "Use standard sections: EXECUTIVE PROFILE, EXPERIENCE, EDUCATION, SKILLS.",
                 "Use only verified profile metrics or evidence metrics.",
                 "Use requirement directives to decide which evidence to emphasize or bridge.",
+                "Treat context-only requirements as eligibility/apply-review facts, never resume coverage.",
                 "Do not claim prohibited missing requirements unless grounded evidence exists.",
                 "Cover relevant job keywords naturally; do not stuff repeated keywords.",
                 "Match seniority to the job title and responsibilities.",
@@ -992,15 +997,28 @@ def _requirement_directive_items(
     if not _requirement_fit_report_matches(requirement_fit_report, job, employer_analysis):
         return ()
     items: list[RequirementDirectivePlanItem] = []
+    canonical_requirements = {
+        str(getattr(requirement, "id", "") or ""): requirement
+        for requirement in employer_analysis.canonical.requirements
+    }
     for assessment in getattr(requirement_fit_report, "assessments", ()) or ():
         fit = getattr(assessment, "fit", None)
         directive = getattr(assessment, "tailoring", None)
         requirement_id = str(getattr(assessment, "requirement_id", "") or "").strip()
-        requirement_text = str(getattr(assessment, "requirement_text", "") or "").strip()
+        canonical_requirement = canonical_requirements.get(requirement_id)
+        requirement_text = str(
+            getattr(canonical_requirement, "text", "")
+            or getattr(assessment, "requirement_text", "")
+            or ""
+        ).strip()
         if not requirement_id or not requirement_text:
             continue
         fit_kind = str(getattr(fit, "kind", "not_assessed") or "not_assessed")
         action = str(getattr(directive, "action", "low_priority") or "low_priority")
+        coverage_scope = resolve_requirement_coverage_scope(
+            requirement_text,
+            getattr(canonical_requirement, "coverage_scope", None),
+        )
         allowed_evidence_ids = _merge_strings(
             tuple(getattr(fit, "evidence_ids", ()) or ()),
             tuple(getattr(directive, "allowed_evidence_ids", ()) or ()),
@@ -1010,9 +1028,22 @@ def _requirement_directive_items(
             _requirement_keywords(employer_analysis, requirement_id),
         )
         prohibited_claims = tuple(getattr(directive, "prohibited_claims", ()) or ())
+        if coverage_scope != "resume":
+            action = "context_only"
+            allowed_evidence_ids = ()
+            target_keywords = ()
+            # Use the canonical posting sentence, not a model-supplied token
+            # fragment such as "hybrid" that could reject legitimate profile
+            # evidence about hybrid-cloud or remote-team experience.
+            prohibited_claims = (requirement_text,)
         if fit_kind in {"missing", "blocked"} and not prohibited_claims:
             prohibited_claims = (requirement_text,)
         instruction = str(getattr(directive, "instruction", "") or "").strip()
+        if coverage_scope != "resume":
+            instruction = (
+                f"Keep this {coverage_scope.replace('_', ' ')} requirement in "
+                "eligibility/apply review; do not claim it as resume evidence."
+            )
         items.append(
             RequirementDirectivePlanItem(
                 requirement_id=requirement_id,
@@ -1021,6 +1052,7 @@ def _requirement_directive_items(
                 weight=float(getattr(assessment, "weight", 0.0) or 0.0),
                 fit_kind=fit_kind,
                 action=action,
+                coverage_scope=coverage_scope,
                 priority=float(getattr(directive, "priority", 0.0) or 0.0),
                 allowed_evidence_ids=allowed_evidence_ids,
                 target_keywords=target_keywords,
@@ -1076,7 +1108,7 @@ def _directive_prohibited_claims(
 ) -> tuple[str, ...]:
     claims: list[str] = []
     for directive in directives:
-        if directive.action != "avoid_claim":
+        if directive.action not in {"avoid_claim", "context_only"}:
             continue
         claims.extend(directive.prohibited_claims)
     return tuple(dict.fromkeys(_normalize_space(claim) for claim in claims if claim))

--- a/workers/automation/src/jobctrl/domain/materials/requirement_coverage.py
+++ b/workers/automation/src/jobctrl/domain/materials/requirement_coverage.py
@@ -40,6 +40,134 @@ BULLET_LIMIT_OVERFLOW_REASONS = (
     "requirement_coverage",
     "enhancement_coverage",
 )
+REQUIREMENT_COVERAGE_SCOPES = (
+    "resume",
+    "eligibility",
+    "logistics",
+    "employer_condition",
+)
+
+_RESUME_SPONSORSHIP_PATTERNS = tuple(
+    re.compile(pattern, re.IGNORECASE)
+    for pattern in (
+        r"\b(?:executive|stakeholder|leadership|senior\s+stakeholder)\s+sponsorship\b",
+        r"\bsponsorship\s+(?:from|among)\s+(?:executives?|stakeholders?|leadership)\b",
+    )
+)
+
+_ELIGIBILITY_REQUIREMENT_PATTERNS = tuple(
+    re.compile(pattern, re.IGNORECASE)
+    for pattern in (
+        r"\b(?:work|employment)\s+authori[sz]ation\b",
+        r"\bauthori[sz]ed\s+to\s+work\b",
+        r"\bright\s+to\s+work\b",
+        r"\bvisa(?:\s+sponsorship)?\b",
+        r"\b(?:visa|work|employment)\s+sponsorship\b",
+        r"\b(?:without|not\s+require|does\s+not\s+require|do\s+not\s+require)\s+"
+        r"(?:visa\s+|work\s+|employment\s+)?sponsorship\b",
+        r"\bsponsorship\s+(?:for|to)\s+(?:work|employment|a\s+visa)\b",
+        r"\bbackground\s+check\b",
+        r"\bsecurity\s+clearance\b",
+        r"\bdrug\s+(?:test|screen(?:ing)?)\b",
+    )
+)
+_LOGISTICS_REQUIREMENT_PATTERNS = tuple(
+    re.compile(pattern, re.IGNORECASE)
+    for pattern in (
+        r"\b(?:hybrid|on[- ]?site|in[- ]?office|office[- ]based)\s+"
+        r"(?:work|working|role|position|schedule|setup|arrangement|model|environment)\b",
+        r"\b(?:work|working|role|position|schedule|setup|arrangement|model)\s+"
+        r"(?:is\s+|will\s+be\s+|must\s+be\s+)?"
+        r"(?:hybrid|on[- ]?site|in[- ]?office|office[- ]based|remote)\b",
+        r"\b(?:work|working)\s+remotely\b",
+        r"\b(?:requires?|required|expects?|expected|mandatory)\b.{0,40}"
+        r"\b(?:on[- ]?site|in[- ]?office|office|in[- ]?person)\s+"
+        r"(?:presence|attendance|work|schedule)\b",
+        r"\b(?:on[- ]?site|in[- ]?office|office|in[- ]?person)\s+"
+        r"(?:presence|attendance)\b",
+        r"\b(?:attend|attendance|present|presence)\b.{0,40}"
+        r"\b(?:office|on[- ]?site|in[- ]?person)\b",
+        r"\bhybrid\b[\s,:;()/-]{0,12}"
+        r"(?:one|two|three|four|five|six|seven|\d+)\s+days?\b",
+        r"\b(?:one|two|three|four|five|six|seven|\d+)\s+days?\s+"
+        r"(?:per|a|each)\s+week\b.{0,48}"
+        r"\b(?:office|on[- ]?site)\b",
+        r"\b(?:office|on[- ]?site)\b.{0,48}"
+        r"\b(?:one|two|three|four|five|six|seven|\d+)\s+days?\s+"
+        r"(?:per|a|each)\s+week\b",
+        r"\b(?:one|two|three|four|five|six|seven|\d+)\s+"
+        r"(?:office|on[- ]?site|in[- ]?office)\s+days?\b",
+        r"\b(?:office|on[- ]?site|in[- ]?office)\s+"
+        r"(?:one|two|three|four|five|six|seven|\d+)\s+days?\b",
+        r"\b(?:one|two|three|four|five|six|seven|\d+)\s+days?\s+weekly\b"
+        r".{0,48}\b(?:office|on[- ]?site|presence|attendance)\b",
+        r"\b(?:office|on[- ]?site|presence|attendance)\b.{0,48}"
+        r"\b(?:one|two|three|four|five|six|seven|\d+)\s+days?\s+weekly\b",
+        r"\b(?:must|should|able|willing|required)\s+to\s+"
+        r"(?:work\s+(?:from|in|at)\s+.{0,40}\boffice|commute|relocate|travel)\b",
+        r"\b(?:relocation|commuting|commute)\b",
+        r"\btravel\s+(?:up\s+to\s+)?\d+\s*%",
+        r"\b\d+\s*%\s+(?:of\s+)?travel\b",
+        r"\b(?:time\s*zone|working\s+hours?|night\s+shifts?|weekend\s+shifts?|"
+        r"on[- ]call\s+rotation)\b",
+        r"^\s*remote(?:\s+(?:within|from|in)\b|\s*$)",
+        r"^\s*(?:must\s+be\s+)?(?:based|located)\s+in\b",
+        r"\b(?:candidate|applicant|you)\b.{0,24}\b(?:based|located)\s+in\b",
+    )
+)
+_EMPLOYER_CONDITION_PATTERNS = tuple(
+    re.compile(pattern, re.IGNORECASE)
+    for pattern in (
+        r"\b(?:salary|pay|compensation)\s+(?:range|package|is|of|from|up\s+to)\b",
+        r"\b(?:benefits?|perks?)\s+(?:include|package)\b",
+        r"\b(?:stock\s+options?|equity\s+package|annual\s+bonus|paid\s+leave|"
+        r"vacation\s+allowance|probation\s+period|contract\s+duration|notice\s+period)\b",
+    )
+)
+
+
+def classify_requirement_coverage_scope(requirement_text: Any) -> str:
+    """Classify how a posting requirement may influence resume generation.
+
+    The posting remains the source of truth for every requirement. This scope
+    only decides whether absence from grounded candidate evidence is a resume
+    coverage gap. Work arrangement and employer-side conditions belong to
+    eligibility/apply review and must never force an invented resume claim.
+    """
+
+    text = " ".join(str(requirement_text or "").split())
+    if any(pattern.search(text) for pattern in _ELIGIBILITY_REQUIREMENT_PATTERNS):
+        return "eligibility"
+    if any(pattern.search(text) for pattern in _LOGISTICS_REQUIREMENT_PATTERNS):
+        return "logistics"
+    if any(pattern.search(text) for pattern in _EMPLOYER_CONDITION_PATTERNS):
+        return "employer_condition"
+    return "resume"
+
+
+def resolve_requirement_coverage_scope(
+    requirement_text: Any,
+    declared_scope: Any = None,
+) -> str:
+    """Resolve ensemble semantics with deterministic non-resume safety rules.
+
+    New employer analyses declare the scope explicitly. Existing analyses do
+    not, so deterministic classification remains the compatibility path. An
+    unmistakable non-resume pattern always wins over an erroneous `resume`
+    declaration; otherwise the reconciled ensemble declaration supplies the
+    semantic judgment for wording that a bounded classifier cannot enumerate.
+    """
+
+    text = " ".join(str(requirement_text or "").split())
+    if any(pattern.search(text) for pattern in _RESUME_SPONSORSHIP_PATTERNS):
+        return "resume"
+    deterministic_scope = classify_requirement_coverage_scope(text)
+    if deterministic_scope != "resume":
+        return deterministic_scope
+    normalized_declared_scope = str(declared_scope or "").strip()
+    if normalized_declared_scope in REQUIREMENT_COVERAGE_SCOPES:
+        return normalized_declared_scope
+    return "resume"
 
 _POLICY_RANK = {
     "verified_only": 0,
@@ -75,6 +203,7 @@ class TargetRequirement:
     keywords: tuple[str, ...] = ()
     fit_kind: str = "not_assessed"
     prohibited_claims: tuple[str, ...] = ()
+    coverage_scope: str = "resume"
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "requirement_id", _required_text(self.requirement_id, "requirement_id"))
@@ -94,6 +223,17 @@ class TargetRequirement:
         object.__setattr__(self, "keywords", _clean_string_tuple(self.keywords))
         object.__setattr__(self, "fit_kind", str(self.fit_kind or "not_assessed").strip())
         object.__setattr__(self, "prohibited_claims", _clean_string_tuple(self.prohibited_claims))
+        coverage_scope = str(self.coverage_scope or "resume").strip()
+        if coverage_scope not in REQUIREMENT_COVERAGE_SCOPES:
+            raise ValueError(
+                "TargetRequirement.coverage_scope must be resume, eligibility, "
+                "logistics, or employer_condition"
+            )
+        object.__setattr__(self, "coverage_scope", coverage_scope)
+
+    @property
+    def is_resume_coverable(self) -> bool:
+        return self.coverage_scope == "resume"
 
     def to_prompt_dict(self) -> dict[str, Any]:
         return {
@@ -105,6 +245,7 @@ class TargetRequirement:
             "keywords": list(self.keywords),
             "pre_tailor_fit": self.fit_kind,
             "prohibited_claims": list(self.prohibited_claims),
+            "coverage_scope": self.coverage_scope,
         }
 
     def to_safe_metadata(self) -> dict[str, Any]:
@@ -115,6 +256,7 @@ class TargetRequirement:
             "weight": self.weight,
             "keywords": list(self.keywords),
             "pre_tailor_fit": self.fit_kind,
+            "coverage_scope": self.coverage_scope,
         }
 
 
@@ -134,6 +276,30 @@ class TargetProfile:
     @property
     def requirements(self) -> tuple[TargetRequirement, ...]:
         return (*self.must_have_requirements, *self.nice_to_have_requirements)
+
+    @property
+    def resume_requirements(self) -> tuple[TargetRequirement, ...]:
+        return tuple(
+            requirement
+            for requirement in self.requirements
+            if requirement.is_resume_coverable
+        )
+
+    @property
+    def context_only_requirements(self) -> tuple[TargetRequirement, ...]:
+        return tuple(
+            requirement
+            for requirement in self.requirements
+            if not requirement.is_resume_coverable
+        )
+
+    @property
+    def resume_must_have_requirements(self) -> tuple[TargetRequirement, ...]:
+        return tuple(
+            requirement
+            for requirement in self.must_have_requirements
+            if requirement.is_resume_coverable
+        )
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "job_id", str(self.job_id or "").strip())
@@ -158,10 +324,24 @@ class TargetProfile:
             "target_role": self.target_role,
             "seniority": self.seniority,
             "must_have_requirements": [
-                requirement.to_prompt_dict() for requirement in self.must_have_requirements
+                requirement.to_prompt_dict()
+                for requirement in self.must_have_requirements
+                if requirement.is_resume_coverable
             ],
             "nice_to_have_requirements": [
-                requirement.to_prompt_dict() for requirement in self.nice_to_have_requirements
+                requirement.to_prompt_dict()
+                for requirement in self.nice_to_have_requirements
+                if requirement.is_resume_coverable
+            ],
+            "context_only_requirements": [
+                {
+                    **requirement.to_prompt_dict(),
+                    "instruction": (
+                        "Keep this visible for eligibility/apply review; do not represent "
+                        "it as resume evidence or requirement coverage."
+                    ),
+                }
+                for requirement in self.context_only_requirements
             ],
             "hard_skills": list(self.hard_skills),
             "ats_keywords": list(self.ats_keywords),
@@ -184,6 +364,12 @@ class TargetProfile:
             "hard_skills": list(self.hard_skills[:24]),
             "ats_keywords": list(self.ats_keywords[:32]),
             "requirements": [requirement.to_safe_metadata() for requirement in self.requirements],
+            "resume_requirement_ids": [
+                requirement.requirement_id for requirement in self.resume_requirements
+            ],
+            "context_only_requirement_ids": [
+                requirement.requirement_id for requirement in self.context_only_requirements
+            ],
             "profile_achievement_ids": [
                 achievement.achievement_evidence_id for achievement in self.profile_achievements
             ],
@@ -692,6 +878,7 @@ def build_target_profile(
     requirements: list[TargetRequirement] = []
     for requirement in source_requirements:
         requirement_id = str(getattr(requirement, "id", "") or "")
+        requirement_text = str(getattr(requirement, "text", ""))
         assessment = assessment_by_requirement.get(requirement_id)
         fit = getattr(assessment, "fit", None)
         tailoring = getattr(assessment, "tailoring", None)
@@ -707,7 +894,7 @@ def build_target_profile(
         requirements.append(
             TargetRequirement(
                 requirement_id=requirement_id,
-                text=str(getattr(requirement, "text", "")),
+                text=requirement_text,
                 tier=str(getattr(requirement, "tier", "nice_to_have")),
                 weight=float(getattr(requirement, "weight", 0.0) or 0.0),
                 source_span=str(getattr(requirement, "evidence_span", "")),
@@ -715,6 +902,10 @@ def build_target_profile(
                 fit_kind=str(getattr(fit, "kind", "not_assessed") or "not_assessed"),
                 prohibited_claims=tuple(
                     getattr(tailoring, "prohibited_claims", ()) if tailoring is not None else ()
+                ),
+                coverage_scope=resolve_requirement_coverage_scope(
+                    requirement_text,
+                    getattr(requirement, "coverage_scope", None),
                 ),
             )
         )
@@ -757,8 +948,11 @@ def seed_coverage_graph(
             keywords=requirement.keywords,
             blocker=requirement.fit_kind == "blocked",
         )
-        for requirement in target_profile.requirements
+        for requirement in target_profile.resume_requirements
     )
+    resume_requirement_ids = {
+        requirement.requirement_id for requirement in target_profile.resume_requirements
+    }
     achievements = target_profile.profile_achievements
     edges: list[CoverageEdge] = []
     fit_by_requirement: dict[str, Any] = {}
@@ -766,6 +960,8 @@ def seed_coverage_graph(
         for assessment in getattr(requirement_fit_report, "assessments", ()) or ():
             requirement_id = str(getattr(assessment, "requirement_id", "") or "")
             fit_by_requirement[requirement_id] = assessment
+            if requirement_id not in resume_requirement_ids:
+                continue
             fit = getattr(assessment, "fit", None)
             fit_kind = str(getattr(fit, "kind", "") or "")
             if fit_kind not in {"matched", "transferable"}:
@@ -790,7 +986,7 @@ def seed_coverage_graph(
                 )
     covered_requirements = {edge.requirement_id for edge in edges}
     uncovered = []
-    for requirement in target_profile.requirements:
+    for requirement in target_profile.resume_requirements:
         if requirement.requirement_id in covered_requirements:
             continue
         assessment = fit_by_requirement.get(requirement.requirement_id)
@@ -1104,7 +1300,7 @@ def score_generated_resume_against_target(
     mapping_tuple = tuple(mappings)
     covered_set = set(grounding.grounded_requirement_ids)
     claimed_only_set = set(grounding.claimed_only_requirement_ids)
-    all_requirements = target_profile.requirements
+    all_requirements = target_profile.resume_requirements
     covered = tuple(
         requirement.requirement_id
         for requirement in all_requirements
@@ -1120,7 +1316,7 @@ def score_generated_resume_against_target(
         for requirement in all_requirements
         if requirement.requirement_id not in covered_set
     )
-    must_have = target_profile.must_have_requirements
+    must_have = target_profile.resume_must_have_requirements
     covered_must_have = [
         requirement
         for requirement in must_have
@@ -1449,9 +1645,11 @@ __all__ = [
     "bullet_limit_overflows",
     "build_coverage_planner_prompt",
     "build_target_profile",
+    "classify_requirement_coverage_scope",
     "decide_score_gated_revision",
     "seed_coverage_graph",
     "score_generated_resume_against_target",
+    "resolve_requirement_coverage_scope",
     "validate_coverage_graph",
     "validate_generated_claim_mappings",
     "validate_mandatory_covered_achievements",

--- a/workers/automation/src/jobctrl/domain/materials/requirement_coverage.py
+++ b/workers/automation/src/jobctrl/domain/materials/requirement_coverage.py
@@ -55,23 +55,51 @@ _RESUME_SPONSORSHIP_PATTERNS = tuple(
     )
 )
 
-_ELIGIBILITY_REQUIREMENT_PATTERNS = tuple(
+# Unmistakable eligibility phrasing: authorization/immigration/screening
+# condition context accompanies the keyword, so a match may override even a
+# declared `resume` scope from the ensemble.
+_ELIGIBILITY_CONDITION_PATTERNS = tuple(
     re.compile(pattern, re.IGNORECASE)
     for pattern in (
         r"\b(?:work|employment)\s+authori[sz]ation\b",
         r"\bauthori[sz]ed\s+to\s+work\b",
         r"\bright\s+to\s+work\b",
-        r"\bvisa(?:\s+sponsorship)?\b",
+        r"\b(?:work|employment|immigration)\s+visa\b",
+        r"\bvisa\s+(?:sponsorship|status|holders?|permits?|requirements?)\b",
         r"\b(?:visa|work|employment)\s+sponsorship\b",
         r"\b(?:without|not\s+require|does\s+not\s+require|do\s+not\s+require)\s+"
         r"(?:visa\s+|work\s+|employment\s+)?sponsorship\b",
         r"\bsponsorship\s+(?:for|to)\s+(?:work|employment|a\s+visa)\b",
-        r"\bbackground\s+check\b",
         r"\bsecurity\s+clearance\b",
+        r"\b(?:pass|passes|passing|complete|completes|completing|completion\s+of|"
+        r"undergo|undergoes|undergoing|subject\s+to|contingent\s+(?:up)?on|"
+        r"consent\s+to|clear|clears|clearing)\b.{0,32}"
+        r"\b(?:background\s+check|drug\s+(?:test|screen(?:ing)?))\b",
+        r"\b(?:require|requires|required|requiring)\b.{0,32}"
+        r"\b(?:background\s+check|drug\s+(?:test|screen(?:ing)?))\b",
+        r"\b(?:background\s+check|drug\s+(?:test|screen(?:ing)?))s?\b.{0,24}"
+        r"\b(?:required|mandatory|will\s+be\s+conducted)\b",
+    )
+)
+# Ambiguous bare keywords: legitimate resume evidence can contain them (Visa
+# the payment network, background-check tooling, drug-screening assays), so a
+# reconciled ensemble `resume` declaration wins over these matches alone.
+_ELIGIBILITY_KEYWORD_PATTERNS = tuple(
+    re.compile(pattern, re.IGNORECASE)
+    for pattern in (
+        r"\bvisa(?:\s+sponsorship)?\b",
+        r"\bbackground\s+check\b",
         r"\bdrug\s+(?:test|screen(?:ing)?)\b",
     )
 )
-_LOGISTICS_REQUIREMENT_PATTERNS = tuple(
+_ELIGIBILITY_REQUIREMENT_PATTERNS = (
+    *_ELIGIBILITY_CONDITION_PATTERNS,
+    *_ELIGIBILITY_KEYWORD_PATTERNS,
+)
+# Unmistakable logistics phrasing: work-arrangement or willingness/condition
+# context accompanies the keyword, so a match may override even a declared
+# `resume` scope from the ensemble.
+_LOGISTICS_CONDITION_PATTERNS = tuple(
     re.compile(pattern, re.IGNORECASE)
     for pattern in (
         r"\b(?:hybrid|on[- ]?site|in[- ]?office|office[- ]based)\s+"
@@ -105,15 +133,36 @@ _LOGISTICS_REQUIREMENT_PATTERNS = tuple(
         r"\b(?:one|two|three|four|five|six|seven|\d+)\s+days?\s+weekly\b",
         r"\b(?:must|should|able|willing|required)\s+to\s+"
         r"(?:work\s+(?:from|in|at)\s+.{0,40}\boffice|commute|relocate|travel)\b",
-        r"\b(?:relocation|commuting|commute)\b",
+        r"\b(?:relocation|commuting|commute)\s+(?:is\s+)?"
+        r"(?:required|mandatory|expected)\b",
+        r"\b(?:participate|participates|participating|participation|join|joins|"
+        r"joining|share|shares|sharing|available|availability|willing|"
+        r"willingness)\b.{0,32}\bon[- ]call\s+rotation\b",
+        r"\bon[- ]call\s+rotation\s+(?:is\s+)?(?:required|mandatory|expected)\b",
+        r"\b(?:work|works|working|willing\s+to\s+work)\b.{0,24}"
+        r"\b(?:night|weekend)\s+shifts?\b",
         r"\btravel\s+(?:up\s+to\s+)?\d+\s*%",
         r"\b\d+\s*%\s+(?:of\s+)?travel\b",
-        r"\b(?:time\s*zone|working\s+hours?|night\s+shifts?|weekend\s+shifts?|"
-        r"on[- ]call\s+rotation)\b",
         r"^\s*remote(?:\s+(?:within|from|in)\b|\s*$)",
         r"^\s*(?:must\s+be\s+)?(?:based|located)\s+in\b",
         r"\b(?:candidate|applicant|you)\b.{0,24}\b(?:based|located)\s+in\b",
     )
+)
+# Ambiguous bare keywords: legitimate resume evidence can contain them (running
+# an on-call rotation, managing relocation programs, coordinating shift
+# coverage), so a reconciled ensemble `resume` declaration wins over these
+# matches alone.
+_LOGISTICS_KEYWORD_PATTERNS = tuple(
+    re.compile(pattern, re.IGNORECASE)
+    for pattern in (
+        r"\b(?:relocation|commuting|commute)\b",
+        r"\b(?:time\s*zone|working\s+hours?|night\s+shifts?|weekend\s+shifts?|"
+        r"on[- ]call\s+rotation)\b",
+    )
+)
+_LOGISTICS_REQUIREMENT_PATTERNS = (
+    *_LOGISTICS_CONDITION_PATTERNS,
+    *_LOGISTICS_KEYWORD_PATTERNS,
 )
 _EMPLOYER_CONDITION_PATTERNS = tuple(
     re.compile(pattern, re.IGNORECASE)
@@ -153,20 +202,47 @@ def resolve_requirement_coverage_scope(
 
     New employer analyses declare the scope explicitly. Existing analyses do
     not, so deterministic classification remains the compatibility path. An
-    unmistakable non-resume pattern always wins over an erroneous `resume`
-    declaration; otherwise the reconciled ensemble declaration supplies the
-    semantic judgment for wording that a bounded classifier cannot enumerate.
+    unmistakable non-resume pattern (keyword plus condition/arrangement
+    context) always wins over an erroneous `resume` declaration. An ambiguous
+    bare-keyword match alone (Visa the payment network, on-call rotation
+    ownership, drug-screening assays, relocation programs, background-check
+    tooling) defers to a declared `resume` scope: there the reconciled
+    ensemble declaration supplies the semantic judgment a bounded keyword
+    classifier cannot.
     """
 
     text = " ".join(str(requirement_text or "").split())
     if any(pattern.search(text) for pattern in _RESUME_SPONSORSHIP_PATTERNS):
         return "resume"
+    normalized_declared_scope = str(declared_scope or "").strip()
+    if normalized_declared_scope not in REQUIREMENT_COVERAGE_SCOPES:
+        normalized_declared_scope = ""
+    unmistakable_scope = _classify_unmistakable_non_resume_scope(text)
+    if unmistakable_scope != "resume":
+        return unmistakable_scope
     deterministic_scope = classify_requirement_coverage_scope(text)
     if deterministic_scope != "resume":
+        if normalized_declared_scope == "resume":
+            return "resume"
         return deterministic_scope
-    normalized_declared_scope = str(declared_scope or "").strip()
-    if normalized_declared_scope in REQUIREMENT_COVERAGE_SCOPES:
+    if normalized_declared_scope:
         return normalized_declared_scope
+    return "resume"
+
+
+def _classify_unmistakable_non_resume_scope(text: str) -> str:
+    """Classify with the high-precision condition patterns only.
+
+    These matches are strong enough to override an erroneous ensemble `resume`
+    declaration; the ambiguous bare-keyword patterns are deliberately excluded.
+    """
+
+    if any(pattern.search(text) for pattern in _ELIGIBILITY_CONDITION_PATTERNS):
+        return "eligibility"
+    if any(pattern.search(text) for pattern in _LOGISTICS_CONDITION_PATTERNS):
+        return "logistics"
+    if any(pattern.search(text) for pattern in _EMPLOYER_CONDITION_PATTERNS):
+        return "employer_condition"
     return "resume"
 
 _POLICY_RANK = {
@@ -1033,11 +1109,16 @@ def build_coverage_planner_prompt(
         "Task: propose additional coverage edges between existing job requirement IDs "
         "and existing profile achievement evidence IDs.\n\n"
         "Hard constraints:\n"
-        "- Use only requirement_id values present in TARGET_PROFILE.\n"
+        "- Use only requirement_id values from must_have_requirements or "
+        "nice_to_have_requirements in TARGET_PROFILE.\n"
+        "- context_only_requirements are eligibility/apply-review background, not "
+        "coverage targets: never propose edges for them and never list them in "
+        "uncovered_requirements.\n"
         "- Use only achievement_evidence_id values present in TARGET_PROFILE.\n"
         "- Do not invent tools, metrics, titles, credentials, dates, employers, or direct experience.\n"
         "- Classify direct evidence as direct, adjacent support as adjacent, and transferable experience as transferable.\n"
-        "- If a requirement has no safe edge, list it in uncovered_requirements with prohibited claims.\n"
+        "- If a must_have or nice_to_have requirement has no safe edge, list it in "
+        "uncovered_requirements with prohibited claims.\n"
         "- If an achievement covers no target requirement, list it in unused_achievements.\n"
         "- Keep rationale concise and evidence-grounded.\n\n"
         "TARGET_PROFILE:\n"

--- a/workers/automation/src/jobctrl/infrastructure/analysis/prompts.py
+++ b/workers/automation/src/jobctrl/infrastructure/analysis/prompts.py
@@ -35,7 +35,7 @@ years-of-experience bands, NOT from a single salient token.
 - ideal_candidate_narrative: "what they're really looking for" — the role's \
 center of gravity and the genuinely-implied core needs.
 - requirements: each with id (stable, e.g. "r1"), text, tier, weight, \
-evidence_span.
+evidence_span, coverage_scope.
 - keywords: the genuine screened-on skills/tools/qualifications, each with \
 keyword, evidence_span, requirement_ref, rationale.
 
@@ -49,17 +49,28 @@ clearance/license/degree, a core competency the role is built on). \
 nice_to_have = "preferred", "a plus", "bonus", "ideally", "familiarity with". \
 Do NOT inflate an aspirational wishlist item to must_have; do NOT demote a true \
 gate to nice_to_have.
-3. WEIGHT (0.0-1.0): rank importance. The core competency the role is really \
+3. COVERAGE SCOPE: classify what the requirement is FOR. Use `resume` only for \
+candidate qualifications, credentials, experience, skills, and role \
+responsibilities that a resume can truthfully evidence. Use `logistics` for \
+remote/hybrid/on-site arrangements, office attendance, travel, relocation, \
+time-zone, shift, or availability constraints. Use `eligibility` for work \
+authorization, visa/work/employment sponsorship, checks, or clearance gates. \
+Executive or stakeholder sponsorship is leadership experience, not immigration \
+sponsorship, and must be `resume`. Use \
+`employer_condition` for compensation, benefits, contract, or other \
+employer-side terms. Do not label remote-team leadership or hybrid-cloud \
+experience as logistics; those are resume qualifications.
+4. WEIGHT (0.0-1.0): rank importance. The core competency the role is really \
 hired for carries the top weight; table-stakes items rank lower. Weights reflect \
 what a hiring manager screens on first, NOT word-frequency or posting order.
-4. KEYWORDS: real skills/tools/quals, deduplicated. Link each to the \
+5. KEYWORDS: real skills/tools/quals, deduplicated. Link each to the \
 requirement it supports via requirement_ref (use the matching requirement id). \
 A keyword with no clear parent requirement may set requirement_ref to null. Do \
 NOT produce a bag of every noun, near-duplicate padding, or soft-skill filler.
-5. IGNORE BOILERPLATE: "fast-paced", "rockstar/ninja", "wear many hats", \
+6. IGNORE BOILERPLATE: "fast-paced", "rockstar/ninja", "wear many hats", \
 "passionate self-starter", EEO/benefits/"about us"/legal sections are NOT \
 requirements or keywords.
-6. EEO: NEVER convert protected-class signals ("recent grad", "digital native", \
+7. EEO: NEVER convert protected-class signals ("recent grad", "digital native", \
 "young/energetic", gendered language) into a requirement, keyword, or an "ideal \
 candidate" attribute.
 
@@ -80,11 +91,16 @@ on; if a draft's span is not verbatim in the JD, do not carry it.
 trustworthy core — keep them. Where drafts disagree, use your own expert \
 judgment grounded in the JD; do not blindly union everything (that produces \
 keyword bloat).
-3. Preserve the must_have/nice_to_have tiering and 0.0-1.0 weighting discipline \
+3. Preserve or resolve each requirement's coverage_scope using the same \
+resume/eligibility/logistics/employer_condition discipline as the analysis \
+rubric. Never turn a work arrangement or employer condition into resume \
+coverage. Visa/work/employment sponsorship is eligibility; executive or \
+stakeholder sponsorship is resume-scoped leadership experience.
+4. Preserve the must_have/nice_to_have tiering and 0.0-1.0 weighting discipline \
 from the analysis rubric; re-rank if the drafts disagree.
-4. Deduplicate keywords and keep requirement_ref links consistent with your \
+5. Deduplicate keywords and keep requirement_ref links consistent with your \
 final requirement ids.
-5. Honor the same boilerplate-filtering and EEO rules as the drafts.
+6. Honor the same boilerplate-filtering and EEO rules as the drafts.
 
 Return ONLY the reconciled canonical structured analysis.\
 """

--- a/workers/automation/tests/test_employer_analysis_model.py
+++ b/workers/automation/tests/test_employer_analysis_model.py
@@ -542,8 +542,26 @@ class TestEmployerAnalysisAggregate:
         assert read["is_degraded"] is True
         assert read["agreement"]["flagged_keywords"] == ["Go"]
         assert read["requirements"][0]["tier"] == "must_have"
+        assert read["requirements"][0]["coverage_scope"] is None
         assert read["sub_analyses"][0]["model_id"] == "claude-opus-4-8"
+        assert read["sub_analyses"][0]["requirements"][0]["coverage_scope"] is None
         assert read["failures"][0]["model_id"] == "gpt-5.4"
+
+    def test_read_model_carries_declared_requirement_coverage_scope(self) -> None:
+        analysis = _analysis(requirements=[_requirement(coverage_scope="logistics")])
+        record = EmployerAnalysis.build(
+            tenant_id=LOCAL_TENANT,
+            job_id=JobId("https://example.com/job/1"),
+            generation=1,
+            snapshot_hash=compute_snapshot_hash(JD_SNAPSHOT),
+            canonical=analysis,
+            sub_analyses=(),
+            failures=(),
+            agreement=AnalysisAgreement(score=1.0),
+            legs_attempted=1,
+        )
+
+        assert record.to_read_model()["requirements"][0]["coverage_scope"] == "logistics"
 
     def test_generation_must_be_positive(self) -> None:
         with pytest.raises(ValueError):

--- a/workers/automation/tests/test_requirement_led_tailoring.py
+++ b/workers/automation/tests/test_requirement_led_tailoring.py
@@ -19,6 +19,7 @@ from jobctrl.domain.materials.policy import (
     RevisionGatePolicy,
     adapt_requirement_led_controls,
 )
+from jobctrl.domain.materials.provenance import BulletProvenance
 from jobctrl.domain.materials.claim_grounding import (
     GROUNDED_COVERAGE_BASIS,
     ground_claim_mappings,
@@ -38,7 +39,9 @@ from jobctrl.domain.materials.requirement_coverage import (
     append_enhancement_claim_mappings,
     bullet_limit_overflows,
     build_coverage_planner_prompt,
+    classify_requirement_coverage_scope,
     decide_score_gated_revision,
+    resolve_requirement_coverage_scope,
     score_generated_resume_against_target,
     validate_coverage_graph,
     validate_generated_claim_mappings,
@@ -47,7 +50,11 @@ from jobctrl.domain.materials.requirement_coverage import (
     validate_pinned_content_preserved,
     validate_prohibited_claims,
 )
-from jobctrl.domain.materials.use_cases import _claim_mapping_validation_errors
+from jobctrl.domain.materials.use_cases import (
+    _claim_mapping_validation_errors,
+    _post_generation_fit_gate,
+)
+from jobctrl.domain.materials.value_objects import ControlRule, TransformType
 from jobctrl.domain.scoring import (
     FitScore,
     RequirementFitAssessment,
@@ -412,6 +419,378 @@ def test_target_profile_adapter_uses_analysis_fit_and_profile_evidence() -> None
     assert target_profile.profile_achievements[0].achievement_evidence_id == "ev_latency"
     assert target_profile.profile_achievements[0].pinned is True
     assert "python api reliability" in target_profile.ats_keywords
+
+
+@pytest.mark.parametrize(
+    ("requirement_text", "expected_scope"),
+    (
+        (
+            "Able to work a hybrid setup from the assigned city (3 days a week in the office).",
+            "logistics",
+        ),
+        ("This role is remote within Spain.", "logistics"),
+        ("Must be willing to travel up to 25%.", "logistics"),
+        ("This position requires on-site presence three days weekly.", "logistics"),
+        ("Hybrid, three days in our office.", "logistics"),
+        ("Attend the office 3 days each week.", "logistics"),
+        ("The role includes 25% travel.", "logistics"),
+        ("Must be authorized to work in Spain without visa sponsorship.", "eligibility"),
+        ("Offer includes a salary range from EUR 100k to EUR 120k.", "employer_condition"),
+        ("5+ years building distributed systems in Python.", "resume"),
+        ("Experience leading remote engineering teams.", "resume"),
+        ("Experience designing hybrid cloud infrastructure.", "resume"),
+        ("Build executive sponsorship for strategic transformation initiatives.", "resume"),
+        ("Secure senior stakeholder sponsorship for the platform migration.", "resume"),
+    ),
+)
+def test_requirement_coverage_scope_separates_context_from_resume_evidence(
+    requirement_text: str,
+    expected_scope: str,
+) -> None:
+    assert classify_requirement_coverage_scope(requirement_text) == expected_scope
+
+
+def test_requirement_coverage_scope_combines_ensemble_semantics_with_safety_override() -> None:
+    assert (
+        resolve_requirement_coverage_scope(
+            "Join quarterly team gatherings in the assigned region.",
+            "logistics",
+        )
+        == "logistics"
+    )
+    assert (
+        resolve_requirement_coverage_scope(
+            "Hybrid work arrangement with three office days per week.",
+            "resume",
+        )
+        == "logistics"
+    )
+    assert (
+        resolve_requirement_coverage_scope(
+            "Experience designing hybrid cloud infrastructure.",
+            "resume",
+        )
+        == "resume"
+    )
+    assert (
+        resolve_requirement_coverage_scope(
+            "Secure senior stakeholder sponsorship for the platform migration.",
+            "eligibility",
+        )
+        == "resume"
+    )
+
+
+def test_logistics_requirement_stays_auditable_but_cannot_fail_resume_coverage() -> None:
+    logistics_text = "This position requires on-site presence three days weekly."
+    canonical = JobAnalysis(
+        role_framing="Backend ownership.",
+        inferred_seniority="senior",
+        ideal_candidate_narrative="A hands-on backend owner.",
+        requirements=[
+            Requirement(
+                id="req_python",
+                text="Own Python API reliability.",
+                tier="must_have",
+                weight=0.9,
+                evidence_span="Own Python API reliability.",
+            ),
+            Requirement(
+                id="req_hybrid",
+                text=logistics_text,
+                tier="must_have",
+                weight=1.0,
+                evidence_span=logistics_text,
+                coverage_scope="resume",
+            ),
+        ],
+        keywords=[
+            ReasonedKeyword(
+                keyword="Python API reliability",
+                evidence_span="Python API reliability",
+                requirement_ref="req_python",
+            )
+        ],
+    )
+    analysis = EmployerAnalysis.build(
+        tenant_id=LOCAL_TENANT,
+        job_id=_JOB_ID,
+        generation=1,
+        snapshot_hash=compute_snapshot_hash(logistics_text),
+        canonical=canonical,
+        sub_analyses=(),
+        failures=(),
+        agreement=AnalysisAgreement(score=1.0),
+        legs_attempted=1,
+    )
+    report = RequirementFitReport(
+        job_id=_JOB_ID,
+        score_version=1,
+        employer_analysis_generation=1,
+        profile_snapshot_version=1,
+        scoring_policy_version=1,
+        formula_version="requirement-fit-v1",
+        resolved_fit_score=FitScore.create(7),
+        fit_band="strong",
+        confidence="high",
+        summary=RequirementFitSummary(weighted_fit=0.5, must_have_coverage=0.5),
+        assessments=(
+            RequirementFitAssessment(
+                requirement_id="req_python",
+                requirement_text="Own Python API reliability.",
+                tier="must_have",
+                weight=0.9,
+                job_evidence_span="Own Python API reliability.",
+                fit=RequirementFitStatus(
+                    kind="matched",
+                    evidence_ids=("ev_latency",),
+                    strength="direct",
+                ),
+                contribution=RequirementScoreContribution(
+                    max_points=1.0,
+                    awarded_points=1.0,
+                    weighted_impact=1.0,
+                ),
+                tailoring=RequirementTailoringDirective(
+                    action="double_down",
+                    priority=0.9,
+                    allowed_evidence_ids=("ev_latency",),
+                    target_keywords=("Python API reliability",),
+                ),
+            ),
+            RequirementFitAssessment(
+                requirement_id="req_hybrid",
+                requirement_text=logistics_text,
+                tier="must_have",
+                weight=1.0,
+                job_evidence_span=logistics_text,
+                fit=RequirementFitStatus(
+                    kind="missing",
+                    reason="No grounded profile evidence for office attendance.",
+                ),
+                contribution=RequirementScoreContribution(
+                    max_points=1.0,
+                    awarded_points=0.0,
+                    weighted_impact=0.0,
+                ),
+                tailoring=RequirementTailoringDirective(
+                    action="avoid_claim",
+                    priority=1.0,
+                    prohibited_claims=("hybrid",),
+                ),
+            ),
+        ),
+    )
+
+    plan = build_tailoring_plan(
+        _profile(),
+        _senior_job(),
+        employer_analysis=analysis,
+        requirement_fit_report=report,
+    )
+    target_profile = plan.target_profile
+    graph = plan.coverage_graph
+    assert target_profile is not None
+    assert graph is not None
+    assert [item.requirement_id for item in target_profile.requirements] == [
+        "req_python",
+        "req_hybrid",
+    ]
+    assert [item.requirement_id for item in target_profile.resume_requirements] == [
+        "req_python"
+    ]
+    assert [item.requirement_id for item in target_profile.context_only_requirements] == [
+        "req_hybrid"
+    ]
+    assert target_profile.context_only_requirements[0].coverage_scope == "logistics"
+    assert graph.requirement_ids == {"req_python"}
+    assert all(item.requirement_id != "req_hybrid" for item in graph.uncovered_requirements)
+
+    hybrid_directive = next(
+        item for item in plan.requirement_directives if item.requirement_id == "req_hybrid"
+    )
+    assert hybrid_directive.coverage_scope == "logistics"
+    assert hybrid_directive.action == "context_only"
+    assert hybrid_directive.allowed_evidence_ids == ()
+    assert hybrid_directive.target_keywords == ()
+    assert hybrid_directive.prohibited_claims == (logistics_text,)
+    assert plan.prohibited_claims == (logistics_text,)
+
+    prompt_target = target_profile.to_prompt_dict()
+    assert [item["requirement_id"] for item in prompt_target["must_have_requirements"]] == [
+        "req_python"
+    ]
+    assert [item["requirement_id"] for item in prompt_target["context_only_requirements"]] == [
+        "req_hybrid"
+    ]
+
+    edge = graph.coverage_edges[0]
+    generated_bullet = "Reduced API latency 35% by replacing synchronous calls."
+    mapping = GeneratedClaimMapping(
+        claim_id="python_claim",
+        location="experience.acme_swe.bullets[0]",
+        text=generated_bullet,
+        claim_label="verified",
+        coverage_edge_ids=(edge.edge_id,),
+        requirement_ids=("req_python",),
+        evidence_ids=("ev_latency",),
+    )
+    grounding = ground_claim_mappings(
+        (mapping,),
+        (("bullet-1", "Reduced API latency 35% by replacing synchronous calls."),),
+    )
+    fit = score_generated_resume_against_target(
+        target_profile=target_profile,
+        mappings=(mapping,),
+        grounding=grounding,
+    )
+    assert fit.must_have_coverage == 1.0
+    assert fit.score == 10
+    assert all("hybrid" not in fix.lower() for fix in fit.prioritized_fixes)
+
+    summary_mapping = GeneratedClaimMapping(
+        claim_id="summary_claim",
+        location="executive_profile",
+        text="Senior backend engineer.",
+        claim_label="positioning",
+        non_requirement_reason="positioning",
+    )
+    fit_gate, fit_gate_errors, review_blockers = _post_generation_fit_gate(
+        payload={
+            "executive_profile": "Senior backend engineer.",
+            "executive_profile_sentences": ["Senior backend engineer."],
+            "experience_updates": [
+                {"id": "acme_swe", "title": "", "bullets": [generated_bullet]}
+            ],
+            "skill_category_updates": [],
+            "generated_claim_mappings": [
+                summary_mapping.to_dict(),
+                mapping.to_dict(),
+            ],
+        },
+        tailoring_plan=plan,
+        attempt=1,
+        shipped_rows=(
+            BulletProvenance(
+                bullet_id="bullet-1",
+                section="experience",
+                source_id="acme_swe",
+                evidence_ids=("ev_latency",),
+                requirement_ids=("req_python",),
+                matched_keywords=("Python API reliability",),
+                transform_type=TransformType.REPHRASE,
+                control=ControlRule.REPHRASE_ALLOWED,
+                rationale="Grounded rephrasing of the recorded achievement.",
+                generated_text=generated_bullet,
+            ),
+        ),
+    )
+    assert fit_gate is not None
+    assert fit_gate_errors == ()
+    assert review_blockers == ()
+    assert fit_gate["fit_score"]["score"] == 10
+    assert fit_gate["revision_decision"]["threshold_failed"] is False
+    assert fit_gate["revision_decision"]["should_revise"] is False
+
+
+def test_stakeholder_sponsorship_remains_resume_scoped_end_to_end() -> None:
+    requirement_text = "Secure senior stakeholder sponsorship for the platform migration."
+    canonical = JobAnalysis(
+        role_framing="Transformation leadership.",
+        inferred_seniority="senior",
+        ideal_candidate_narrative="A transformation leader.",
+        requirements=[
+            Requirement(
+                id="req_stakeholder_sponsorship",
+                text=requirement_text,
+                tier="must_have",
+                weight=1.0,
+                evidence_span=requirement_text,
+                coverage_scope="resume",
+            )
+        ],
+        keywords=[],
+    )
+    analysis = EmployerAnalysis.build(
+        tenant_id=LOCAL_TENANT,
+        job_id=_JOB_ID,
+        generation=1,
+        snapshot_hash=compute_snapshot_hash(requirement_text),
+        canonical=canonical,
+        sub_analyses=(),
+        failures=(),
+        agreement=AnalysisAgreement(score=1.0),
+        legs_attempted=1,
+    )
+    assert analysis.prompt_version == "employer-analysis-v2"
+    report = RequirementFitReport(
+        job_id=_JOB_ID,
+        score_version=1,
+        employer_analysis_generation=1,
+        profile_snapshot_version=1,
+        scoring_policy_version=1,
+        formula_version="requirement-fit-v1",
+        resolved_fit_score=FitScore.create(7),
+        fit_band="strong",
+        confidence="high",
+        summary=RequirementFitSummary(weighted_fit=0.0, must_have_coverage=0.0),
+        assessments=(
+            RequirementFitAssessment(
+                requirement_id="req_stakeholder_sponsorship",
+                requirement_text=requirement_text,
+                tier="must_have",
+                weight=1.0,
+                job_evidence_span=requirement_text,
+                fit=RequirementFitStatus(
+                    kind="missing",
+                    reason="No grounded stakeholder-sponsorship evidence.",
+                ),
+                contribution=RequirementScoreContribution(
+                    max_points=1.0,
+                    awarded_points=0.0,
+                    weighted_impact=0.0,
+                ),
+                tailoring=RequirementTailoringDirective(
+                    action="avoid_claim",
+                    priority=1.0,
+                    prohibited_claims=(requirement_text,),
+                ),
+            ),
+        ),
+    )
+
+    plan = build_tailoring_plan(
+        _profile(),
+        _senior_job(),
+        employer_analysis=analysis,
+        requirement_fit_report=report,
+    )
+    target_profile = plan.target_profile
+    graph = plan.coverage_graph
+    assert target_profile is not None
+    assert graph is not None
+    assert [item.requirement_id for item in target_profile.resume_requirements] == [
+        "req_stakeholder_sponsorship"
+    ]
+    assert target_profile.context_only_requirements == ()
+    assert graph.requirement_ids == {"req_stakeholder_sponsorship"}
+    assert [item.requirement_id for item in graph.uncovered_requirements] == [
+        "req_stakeholder_sponsorship"
+    ]
+    prompt_target = target_profile.to_prompt_dict()
+    assert [item["requirement_id"] for item in prompt_target["must_have_requirements"]] == [
+        "req_stakeholder_sponsorship"
+    ]
+    assert prompt_target["context_only_requirements"] == []
+
+    fit = score_generated_resume_against_target(
+        target_profile=target_profile,
+        mappings=(),
+        grounding=ground_claim_mappings((), ()),
+    )
+    assert fit.must_have_coverage == 0.0
+    assert fit.score == 1
+    assert any("stakeholder sponsorship" in fix.lower() for fix in fit.prioritized_fixes)
 
 
 def test_seed_coverage_graph_builds_direct_and_transferable_edges() -> None:

--- a/workers/automation/tests/test_requirement_led_tailoring.py
+++ b/workers/automation/tests/test_requirement_led_tailoring.py
@@ -481,6 +481,61 @@ def test_requirement_coverage_scope_combines_ensemble_semantics_with_safety_over
     )
 
 
+@pytest.mark.parametrize(
+    ("requirement_text", "undeclared_scope"),
+    (
+        (
+            "Deep experience with Visa and Mastercard payment network integrations.",
+            "eligibility",
+        ),
+        ("Experience with card scheme rules (Visa, Mastercard).", "eligibility"),
+        (
+            "Experience running a healthy on-call rotation and incident response program.",
+            "logistics",
+        ),
+        ("Experience with high-throughput drug screening assays.", "eligibility"),
+        (
+            "Manage employee relocation programs for our global mobility team.",
+            "logistics",
+        ),
+        ("Own background check vendor integrations for our HR platform.", "eligibility"),
+    ),
+)
+def test_declared_resume_scope_survives_ambiguous_keyword_patterns(
+    requirement_text: str,
+    undeclared_scope: str,
+) -> None:
+    """A bare keyword match must not override the ensemble's resume judgment."""
+
+    assert resolve_requirement_coverage_scope(requirement_text, "resume") == "resume"
+    # Without an ensemble declaration the conservative keyword reading stands
+    # (compatibility path for historical analyses).
+    assert resolve_requirement_coverage_scope(requirement_text, None) == undeclared_scope
+    assert classify_requirement_coverage_scope(requirement_text) == undeclared_scope
+
+
+@pytest.mark.parametrize(
+    ("requirement_text", "expected_scope"),
+    (
+        ("Must pass a background check before starting.", "eligibility"),
+        ("Employment is contingent on completing a background check.", "eligibility"),
+        ("This role requires a drug screening.", "eligibility"),
+        ("Candidates need a valid work visa; visa sponsorship is not available.", "eligibility"),
+        ("Participate in the on-call rotation, including weekends.", "logistics"),
+        ("Must be willing to relocate to Berlin.", "logistics"),
+    ),
+)
+def test_unmistakable_conditions_override_erroneous_resume_declaration(
+    requirement_text: str,
+    expected_scope: str,
+) -> None:
+    """Condition-context phrasing stays non-resume even against a bad declaration."""
+
+    assert resolve_requirement_coverage_scope(requirement_text, "resume") == expected_scope
+    assert resolve_requirement_coverage_scope(requirement_text, None) == expected_scope
+    assert classify_requirement_coverage_scope(requirement_text) == expected_scope
+
+
 def test_logistics_requirement_stays_auditable_but_cannot_fail_resume_coverage() -> None:
     logistics_text = "This position requires on-site presence three days weekly."
     canonical = JobAnalysis(
@@ -613,8 +668,10 @@ def test_logistics_requirement_stays_auditable_but_cannot_fail_resume_coverage()
     assert hybrid_directive.action == "context_only"
     assert hybrid_directive.allowed_evidence_ids == ()
     assert hybrid_directive.target_keywords == ()
-    assert hybrid_directive.prohibited_claims == (logistics_text,)
-    assert plan.prohibited_claims == (logistics_text,)
+    # The canonical sentence is always prohibited; the model fragment "hybrid"
+    # survives because this profile carries no hybrid evidence it could reject.
+    assert hybrid_directive.prohibited_claims == (logistics_text, "hybrid")
+    assert plan.prohibited_claims == (logistics_text, "hybrid")
 
     prompt_target = target_profile.to_prompt_dict()
     assert [item["requirement_id"] for item in prompt_target["must_have_requirements"]] == [
@@ -691,6 +748,195 @@ def test_logistics_requirement_stays_auditable_but_cannot_fail_resume_coverage()
     assert fit_gate["fit_score"]["score"] == 10
     assert fit_gate["revision_decision"]["threshold_failed"] is False
     assert fit_gate["revision_decision"]["should_revise"] is False
+
+
+def _logistics_analysis_and_report(
+    logistics_text: str,
+    *,
+    model_prohibited_claims: tuple[str, ...],
+) -> tuple[EmployerAnalysis, RequirementFitReport]:
+    canonical = JobAnalysis(
+        role_framing="Backend ownership.",
+        inferred_seniority="senior",
+        ideal_candidate_narrative="A hands-on backend owner.",
+        requirements=[
+            Requirement(
+                id="req_python",
+                text="Own Python API reliability.",
+                tier="must_have",
+                weight=0.9,
+                evidence_span="Own Python API reliability.",
+            ),
+            Requirement(
+                id="req_hybrid",
+                text=logistics_text,
+                tier="must_have",
+                weight=1.0,
+                evidence_span=logistics_text,
+            ),
+        ],
+        keywords=[
+            ReasonedKeyword(
+                keyword="Python API reliability",
+                evidence_span="Python API reliability",
+                requirement_ref="req_python",
+            )
+        ],
+    )
+    analysis = EmployerAnalysis.build(
+        tenant_id=LOCAL_TENANT,
+        job_id=_JOB_ID,
+        generation=1,
+        snapshot_hash=compute_snapshot_hash(logistics_text),
+        canonical=canonical,
+        sub_analyses=(),
+        failures=(),
+        agreement=AnalysisAgreement(score=1.0),
+        legs_attempted=1,
+    )
+    report = RequirementFitReport(
+        job_id=_JOB_ID,
+        score_version=1,
+        employer_analysis_generation=1,
+        profile_snapshot_version=1,
+        scoring_policy_version=1,
+        formula_version="requirement-fit-v1",
+        resolved_fit_score=FitScore.create(7),
+        fit_band="strong",
+        confidence="high",
+        summary=RequirementFitSummary(weighted_fit=0.5, must_have_coverage=0.5),
+        assessments=(
+            RequirementFitAssessment(
+                requirement_id="req_python",
+                requirement_text="Own Python API reliability.",
+                tier="must_have",
+                weight=0.9,
+                job_evidence_span="Own Python API reliability.",
+                fit=RequirementFitStatus(
+                    kind="matched",
+                    evidence_ids=("ev_latency",),
+                    strength="direct",
+                ),
+                contribution=RequirementScoreContribution(
+                    max_points=1.0,
+                    awarded_points=1.0,
+                    weighted_impact=1.0,
+                ),
+                tailoring=RequirementTailoringDirective(
+                    action="double_down",
+                    priority=0.9,
+                    allowed_evidence_ids=("ev_latency",),
+                    target_keywords=("Python API reliability",),
+                ),
+            ),
+            RequirementFitAssessment(
+                requirement_id="req_hybrid",
+                requirement_text=logistics_text,
+                tier="must_have",
+                weight=1.0,
+                job_evidence_span=logistics_text,
+                fit=RequirementFitStatus(
+                    kind="missing",
+                    reason="No grounded profile evidence for office attendance.",
+                ),
+                contribution=RequirementScoreContribution(
+                    max_points=1.0,
+                    awarded_points=0.0,
+                    weighted_impact=0.0,
+                ),
+                tailoring=RequirementTailoringDirective(
+                    action="avoid_claim",
+                    priority=1.0,
+                    prohibited_claims=model_prohibited_claims,
+                ),
+            ),
+        ),
+    )
+    return analysis, report
+
+
+def test_context_only_directive_keeps_fragment_that_catches_ungrounded_onsite_claim() -> None:
+    logistics_text = "Able to work a hybrid setup with on-site presence three days a week."
+    analysis, report = _logistics_analysis_and_report(
+        logistics_text,
+        model_prohibited_claims=("hybrid", "on-site three days a week"),
+    )
+
+    plan = build_tailoring_plan(
+        _profile(),
+        _senior_job(),
+        employer_analysis=analysis,
+        requirement_fit_report=report,
+    )
+
+    hybrid_directive = next(
+        item for item in plan.requirement_directives if item.requirement_id == "req_hybrid"
+    )
+    assert hybrid_directive.action == "context_only"
+    assert hybrid_directive.prohibited_claims == (
+        logistics_text,
+        "hybrid",
+        "on-site three days a week",
+    )
+    # The deterministic net still fires on an ungrounded work-arrangement claim.
+    caught = validate_prohibited_claims(
+        "Senior engineer available on-site three days a week for the platform team.",
+        plan.prohibited_claims,
+    )
+    assert caught == ("on-site three days a week",)
+
+
+def test_context_only_directive_drops_fragment_colliding_with_hybrid_cloud_evidence() -> None:
+    logistics_text = "Able to work a hybrid setup with on-site presence three days a week."
+    analysis, report = _logistics_analysis_and_report(
+        logistics_text,
+        model_prohibited_claims=("hybrid", "on-site three days a week"),
+    )
+    profile = _profile()
+    profile["resume"]["experience_entries"][0]["achievement_evidence"].append(
+        {
+            "id": "ev_hybrid_cloud",
+            "source_text": "Designed hybrid cloud infrastructure spanning AWS and on-prem clusters.",
+            "scope": "platform team",
+            "action": "designed hybrid cloud infrastructure",
+            "tools": ["AWS", "Kubernetes"],
+            "metrics": [],
+            "outcome": "portable workloads",
+            "seniority_signal": "",
+            "evidence_strength": "verified",
+            "claim_confidence": 0.9,
+            "user_confirmed": True,
+            "tags": ["hybrid cloud", "infrastructure"],
+        }
+    )
+
+    plan = build_tailoring_plan(
+        profile,
+        _senior_job(),
+        employer_analysis=analysis,
+        requirement_fit_report=report,
+    )
+
+    hybrid_directive = next(
+        item for item in plan.requirement_directives if item.requirement_id == "req_hybrid"
+    )
+    # The bare token collides with grounded hybrid-cloud evidence and is dropped;
+    # the canonical sentence and the arrangement-specific fragment stay armed.
+    assert hybrid_directive.prohibited_claims == (
+        logistics_text,
+        "on-site three days a week",
+    )
+    assert (
+        validate_prohibited_claims(
+            "Designed hybrid cloud infrastructure spanning AWS and on-prem clusters.",
+            plan.prohibited_claims,
+        )
+        == ()
+    )
+    assert validate_prohibited_claims(
+        "Available on-site three days a week.",
+        plan.prohibited_claims,
+    ) == ("on-site three days a week",)
 
 
 def test_stakeholder_sponsorship_remains_resume_scoped_end_to_end() -> None:
@@ -989,7 +1235,21 @@ def test_build_coverage_planner_prompt_constrains_ids_and_output() -> None:
     )
 
     assert "Return ONLY JSON" in prompt
-    assert "Use only requirement_id values present in TARGET_PROFILE" in prompt
+    # The planner's id universe is scoped to the resume-coverable lists so a
+    # compliant response never references context-only ids absent from the
+    # seeded graph.
+    assert (
+        "Use only requirement_id values from must_have_requirements or "
+        "nice_to_have_requirements in TARGET_PROFILE" in prompt
+    )
+    assert (
+        "never propose edges for them and never list them in "
+        "uncovered_requirements" in prompt
+    )
+    assert (
+        "If a must_have or nice_to_have requirement has no safe edge, list it in "
+        "uncovered_requirements" in prompt
+    )
     assert "Use only achievement_evidence_id values present in TARGET_PROFILE" in prompt
     assert "Do not invent tools, metrics, titles" in prompt
     assert "req_python" in prompt


### PR DESCRIPTION
## Summary

- add a typed employer-analysis `coverage_scope` for resume qualifications, eligibility, logistics, and employer-side conditions
- keep every posting requirement auditable while allowing only resume-scoped requirements into Tailor prompts, coverage graphs, score denominators, and repair instructions
- protect office-attendance, travel, and immigration conditions from consuming Tailor retries while preserving remote-team, hybrid-cloud, executive-sponsorship, and stakeholder-sponsorship experience as resume evidence
- normalize historical missing scopes to `null` across the Python and TypeScript projections and expose the field in the shared API contract

## Why

Tailor treated a three-days-in-office condition as content the generated resume had to prove. Because no grounded candidate evidence should claim an office-attendance commitment, the post-generation fit gate repeatedly rejected otherwise valid resumes until the durable attempts were exhausted. This change separates candidate logistics from resume evidence at the owning analysis layer and enforces that distinction throughout Tailor.

## Validation

- `corepack pnpm python:test` — 3,412 passed, 2 skipped
- `corepack pnpm check` — passed
- targeted API projection and cross-runtime parity suites — 41 passed
- focused requirement-scope, employer-analysis, and projection suites — 96 passed
- focused rendered and accessibility fixtures — 5 passed
- `corepack pnpm docs:build` — 9,651 references resolved
- independent review and product QA gates — passed with no findings

## Stack

- stacked on #760 (`fix(pipeline): block terminal tailor dependents`)
- stack #753

## Checklist

- [x] Relevant local checks are listed above.
- [x] No secrets, private profile data, resumes, generated materials, raw logs, browser profiles, SQLite databases, or local paths are included.
