### PR TITLE
fix(cover): guide retries away from unsupported skills

### DIFF
--- a/workers/automation/src/jobctrl/domain/materials/use_cases.py
+++ b/workers/automation/src/jobctrl/domain/materials/use_cases.py
@@ -1070,6 +1070,11 @@ _RETRY_GUIDANCE: dict[str, str] = {
         "resume; describe target-job timelines, team sizes, goals, and requirements "
         "qualitatively."
     ),
+    "cover_letter_skill_grounding_failed": (
+        "Remove every named skill or tool that appears only in the target job. Use "
+        "a named skill or tool only when it appears in the provided resume; otherwise "
+        "describe grounded work without naming that target-only technology."
+    ),
     "fabrication_detected": (
         "Remove unsupported claims and use only metrics, tools, roles, employers, "
         "and dates present in canonical profile evidence."
@@ -4105,6 +4110,8 @@ class GenerateCoverLetterUseCase:
                 return letter, validation, findings
             if any(finding.kind in {"numeric", "date"} for finding in findings):
                 retry_reasons.append("cover_letter_numeric_grounding_failed")
+            if any(finding.kind == "skill" for finding in findings):
+                retry_reasons.append("cover_letter_skill_grounding_failed")
             retry_reasons.append("cover_letter_validation_failed")
             log.debug(
                 "Cover letter attempt %d/%d failed: %s",

--- a/workers/automation/tests/test_materials_use_cases.py
+++ b/workers/automation/tests/test_materials_use_cases.py
@@ -3500,6 +3500,50 @@ def test_cover_letter_retries_posting_only_number_with_qualitative_guidance(
     assert cover.metadata["fabrication_audit"]["findings"] == []
 
 
+def test_cover_letter_retries_target_only_skill_with_grounded_guidance(
+    tmp_path: Path, snapshot: ProfileSnapshot, job: dict
+) -> None:
+    """A target-only skill gets typed, code-owned retry guidance.
+
+    The rejected output is not echoed back into the prompt, and the strict
+    fabrication gate remains unchanged.
+    """
+    repo = _FakeRepository()
+    _seed_approved_cover_materials(repo, job, tmp_path)
+    llm = _ScriptedLlm([
+        _cover_letter_text("I automated backend deployments with Kubernetes."),
+        _cover_letter_text("I automated backend delivery with Python."),
+    ])
+    use_case = GenerateCoverLetterUseCase(
+        repository=repo,
+        llm=llm,
+        validator=ContentValidator(),
+        analysis_repository=_FakeAnalysisRepository(
+            _analysis_with_keywords(job, ["python", "backend", "Kubernetes"])
+        ),
+        max_retries=1,
+    )
+
+    outcome = use_case.execute(
+        job=job,
+        job_id=job["job_id"],
+        profile_snapshot=snapshot,
+        cover_letter_dir=tmp_path,
+    )
+
+    assert outcome.status == "ok"
+    assert len(llm.calls) == 2
+    retry_system = llm.calls[1][0].content
+    assert "cover_letter_skill_grounding_failed" in retry_system
+    assert "appears only in the target job" in retry_system
+    assert "Kubernetes" not in retry_system
+    assert outcome.materials is not None
+    cover = outcome.materials.cover_letter
+    assert cover is not None
+    assert cover.status is ArtifactStatus.APPROVED
+    assert cover.metadata["fabrication_audit"]["findings"] == []
+
+
 def test_cover_letter_use_case_rejects_fabricated_employer(
     tmp_path: Path, snapshot: ProfileSnapshot, job: dict
 ) -> None:


### PR DESCRIPTION
## What changed
- classify target-only skill and tool findings with a typed retry reason
- give the next bounded attempt code-owned grounding guidance
- keep the strict fabrication validator unchanged and avoid echoing rejected output

## Why
A cover-letter attempt could repeatedly copy target-only technology terms. The validator correctly rejected each attempt, but later attempts received only generic validation guidance and could exhaust without learning which grounding rule to repair.

## Validation
- workers/automation/.venv/bin/ruff check workers/automation/src/jobctrl/domain/materials/use_cases.py workers/automation/tests/test_materials_use_cases.py
- workers/automation/.venv/bin/python -m pytest workers/automation/tests/test_materials_use_cases.py -q (87 passed)
- workers/automation/.venv/bin/python -m pytest workers/automation/tests/test_activity_cover.py workers/automation/tests/test_cover_requirements.py workers/automation/tests/test_v7_cover_runtime.py -q (24 passed)