### PR TITLE
fix(pipeline): freeze global material cohorts

### DIFF
--- a/docs/local-reliability-qa.md
+++ b/docs/local-reliability-qa.md
@@ -105,7 +105,10 @@ accepted artifact without another model call. Profile and browser-setting
 continuations must also survive an API stop after their durable write and
 before dispatch. A selected batch must honor its bounded worker count; item
 failures remain attached to their own rows while the approved Tailor subset
-continues to Cover. An activity timeout or worker shutdown is retryable and
+continues to Cover. A global Tailor or Cover command must freeze its eligible
+JobIds before Temporal starts, so it uses the same bounded per-job fan-out,
+ownership fence, and worker-wave deadline instead of the legacy unscoped batch
+runner. An activity timeout or worker shutdown is retryable and
 must not be projected as user cancellation. For an explicitly selected batch,
 the replay-versioned activity deadline is 30 minutes per worker wave, capped at
 6 hours; the 2-minute heartbeat still detects a dead worker promptly. Parallel

--- a/docs/local-reliability-qa.md
+++ b/docs/local-reliability-qa.md
@@ -105,13 +105,18 @@ accepted artifact without another model call. Profile and browser-setting
 continuations must also survive an API stop after their durable write and
 before dispatch. A selected batch must honor its bounded worker count; item
 failures remain attached to their own rows while the approved Tailor subset
-continues to Cover. A global Tailor or Cover command must freeze its eligible
-JobIds before Temporal starts, so it uses the same bounded per-job fan-out,
-ownership fence, and worker-wave deadline instead of the legacy unscoped batch
-runner. Prove the zero-row selection is an explicit no-op rather than an
-unscoped fallback, a mixed Tailor/Cover/Apply request retains batch-Apply
-semantics, and global current-policy re-tailoring freezes the policy-aware
-cohort before dispatch. An activity timeout or worker shutdown is retryable and
+continues to Cover. A global command that includes Tailor or Cover — including
+score-led maintenance runs such as `run score tailor cover` — must freeze each
+requested material stage's backlog into exact JobIds before Temporal starts,
+so material stages use the same bounded per-job fan-out, ownership fence, and
+worker-wave deadline instead of the legacy unscoped batch runner. Inside the
+run, Score's newly scored jobs join the frozen Tailor cohort and Tailor's
+approved subset joins the frozen Cover cohort. Prove each zero-row cohort is
+an explicit per-stage no-op rather than an unscoped fallback — an empty Tailor
+cohort must not skip a non-empty Cover backlog — that a mixed
+Tailor/Cover/Apply request retains batch-Apply semantics, and that global
+current-policy re-tailoring freezes the policy-aware cohort before dispatch.
+An activity timeout or worker shutdown is retryable and
 must not be projected as user cancellation. For an explicitly selected batch,
 the replay-versioned activity deadline is 30 minutes per worker wave, capped at
 6 hours; the 2-minute heartbeat still detects a dead worker promptly. Parallel

--- a/docs/local-reliability-qa.md
+++ b/docs/local-reliability-qa.md
@@ -108,7 +108,10 @@ failures remain attached to their own rows while the approved Tailor subset
 continues to Cover. A global Tailor or Cover command must freeze its eligible
 JobIds before Temporal starts, so it uses the same bounded per-job fan-out,
 ownership fence, and worker-wave deadline instead of the legacy unscoped batch
-runner. An activity timeout or worker shutdown is retryable and
+runner. Prove the zero-row selection is an explicit no-op rather than an
+unscoped fallback, a mixed Tailor/Cover/Apply request retains batch-Apply
+semantics, and global current-policy re-tailoring freezes the policy-aware
+cohort before dispatch. An activity timeout or worker shutdown is retryable and
 must not be projected as user cancellation. For an explicitly selected batch,
 the replay-versioned activity deadline is 30 minutes per worker wave, capped at
 6 hours; the 2-minute heartbeat still detects a dead worker promptly. Parallel

--- a/docs/plans/2026-08-04-pipeline-reliability-chaos.md
+++ b/docs/plans/2026-08-04-pipeline-reliability-chaos.md
@@ -200,7 +200,10 @@ The campaign reproduced independent reliability defects:
     material starts now freeze the eligible canonical JobIds before Temporal
     starts. They therefore use the existing bounded per-job fan-out, scaled
     worker-wave deadline, cooperative cancellation token, and exact ownership
-    fence.
+    fence. The frozen-selection marker distinguishes a resolved empty cohort
+    from an unscoped legacy batch, preserves independent batch-Apply semantics
+    in mixed requests, and makes the global current-policy maintenance action
+    resolve its policy-aware cohort before workflow dispatch.
 
 No timer or second scheduler was added. Recovery is one idempotent step in the
 workflow that owns the work, plus a durable event dispatch when a setting

--- a/docs/plans/2026-08-04-pipeline-reliability-chaos.md
+++ b/docs/plans/2026-08-04-pipeline-reliability-chaos.md
@@ -197,13 +197,19 @@ The campaign reproduced independent reliability defects:
     the selected-batch safeguards. A global Tailor/Cover command left
     `jobIds` empty, so a 30-minute activity timeout could abandon the unscoped
     batch and allow its late result to race a newer selected owner. Global
-    material starts now freeze the eligible canonical JobIds before Temporal
-    starts. They therefore use the existing bounded per-job fan-out, scaled
-    worker-wave deadline, cooperative cancellation token, and exact ownership
-    fence. The frozen-selection marker distinguishes a resolved empty cohort
-    from an unscoped legacy batch, preserves independent batch-Apply semantics
-    in mixed requests, and makes the global current-policy maintenance action
-    resolve its policy-aware cohort before workflow dispatch.
+    material starts now freeze each requested material stage's eligible
+    canonical JobIds before Temporal starts — the `pending_cover` backlog is
+    frozen independently of `pending_tailor`, and score-led maintenance runs
+    freeze their material cohorts too, with Score's newly scored jobs joining
+    the frozen Tailor cohort and Tailor's approved subset joining the frozen
+    Cover cohort inside the run. Material stages therefore use the existing
+    bounded per-job fan-out, scaled worker-wave deadline, cooperative
+    cancellation token, and exact ownership fence. The frozen-selection marker
+    distinguishes a resolved empty cohort from an unscoped legacy batch — one
+    empty material queue no-ops only its own stage — preserves independent
+    batch-Apply semantics in mixed requests, and makes the global
+    current-policy maintenance action resolve its policy-aware cohort before
+    workflow dispatch.
 
 No timer or second scheduler was added. Recovery is one idempotent step in the
 workflow that owns the work, plus a durable event dispatch when a setting

--- a/docs/plans/2026-08-04-pipeline-reliability-chaos.md
+++ b/docs/plans/2026-08-04-pipeline-reliability-chaos.md
@@ -1,6 +1,6 @@
 # Pipeline Reliability Chaos Campaign
 
-- **Status:** R01-R25 campaign completed; R26 code and fixture verification passed, with live read-model reconciliation pending
+- **Status:** R01-R26 completed, including live read-model reconciliation
 - **Authored:** 2026-08-04
 - **Environment:** Production-shaped local stack with disposable non-production data
 - **Safety boundary:** Never use `~/.jobctrl/jobctrl.db`, real applications, or real submission targets
@@ -193,6 +193,14 @@ The campaign reproduced independent reliability defects:
     `MIN_SCORE` skips, preserve in-flight and accepted work, let score hard
     blockers take precedence, and reset only threshold-owned skips when a later
     score, threshold, or explicit low-fit override permits work.
+20. The final live material drain exposed one legacy entry path that bypassed
+    the selected-batch safeguards. A global Tailor/Cover command left
+    `jobIds` empty, so a 30-minute activity timeout could abandon the unscoped
+    batch and allow its late result to race a newer selected owner. Global
+    material starts now freeze the eligible canonical JobIds before Temporal
+    starts. They therefore use the existing bounded per-job fan-out, scaled
+    worker-wave deadline, cooperative cancellation token, and exact ownership
+    fence.
 
 No timer or second scheduler was added. Recovery is one idempotent step in the
 workflow that owns the work, plus a durable event dispatch when a setting
@@ -215,7 +223,7 @@ is already canceled; it never mutates ownerless or unrelated pending work.
 | R23 | Real Enrich/Tailor/Cover `JobPipelineWorkflow` cancellation; exact selected/unrelated assertions; authenticated pre-pass child-process kill; abandoned-producer and successor-owner races; mixed local/Temporal requester audit; atomic snapshot/Tailor release; canonical restart pickup and exact execution-ID handoff; activity-timeout retry; successful-subset handoff; authenticated-recovery budget and extension-noise guard; selected-material incremental fan-out, cooperative commit fencing, committed-fact preservation, partial continuation, replay-versioned worker-wave deadline, atomic profile/policy comparison, and exact selected-message artifact fingerprints | PASS: focused and cumulative regressions, authorized live recovery, independent review/QA, and refreshed UI proof completed. |
 | R24 | Ignored-cancellation thread held past the grace window; distinct Temporal-sync and blocking executors; executor-generation rotation; immediate subsequent activity | Pass: focused abandoned-thread and worker-construction regressions; live recovery exposed and reproduced the zero-dispatch backlog before the fix |
 | R25 | Inner Tailor retry exhaustion followed by repeated durable executions, including the fifth-failure boundary | PASS: inner exhaustion leaves outer attempt 1 retryable; two executions retain both complete audit reports; retry re-entry advances cumulatively; durable attempt 5 is `exhausted` and non-retryable; cumulative gates passed. |
-| R26 | Below-threshold workflow completion, repeated reconciliation, hard-blocker precedence, threshold lowering, explicit low-fit override, guarded concurrent claim races, and rendered diagnostics | Automated verification PASS: 3,389 Python tests, 2 skipped; 2,005 web tests; web/type/lint/docs checks; deterministic creation and reversal race fixtures; independent review and QA. Live read-model reconciliation remains. |
+| R26 | Below-threshold workflow completion, repeated reconciliation, hard-blocker precedence, threshold lowering, explicit low-fit override, guarded concurrent claim races, and rendered diagnostics | PASS: automated creation/reversal fixtures plus live reconciliation of the active cohort to explicit `MIN_SCORE` skips; no Apply attempt started. |
 | Worker composition | Clean import of the complete Temporal workflow/activity registry | Pass: 10 workflows and 23 activities compose without an import cycle |
 | API cumulative | Server, profile-event, and JSON-RPC adapter suites, including loopback SSE and startup recovery | Pass: 263 tests |
 | Live Pipelines UI | Browser DOM, console, screenshot, and disclosure interaction against the running app | Pass: Enrich precedes Enrichment reconciliation; Render PDF follows Cover letter; no relevant console warning/error |

--- a/workers/automation/src/jobctrl/infrastructure/rpc/handlers.py
+++ b/workers/automation/src/jobctrl/infrastructure/rpc/handlers.py
@@ -598,13 +598,28 @@ def refresh_compensation(params: dict[str, Any]) -> WorkflowStartSpec:
 
 
 def retailor_current_policy(params: dict[str, Any]) -> WorkflowStartSpec:
+    requested_job_ids = _job_ids(params)
+    material_selection_resolved = not requested_job_ids
+    job_ids = requested_job_ids
+    if material_selection_resolved:
+        from jobctrl.pipeline.current_policy_selectors import (
+            tailoring_current_policy_job_ids,
+        )
+
+        job_ids = tailoring_current_policy_job_ids(
+            get_connection(),
+            tenant_id=_tenant_id(params),
+            min_score=int(params.get("minScore", 7)),
+            limit=int(params.get("limit", 100)),
+        )
     return _pipeline_workflow_spec(
         params,
         stages=["tailor", "cover"],
         limit=int(params.get("limit", 100)),
         retailor=True,
-        job_ids=_job_ids(params),
+        job_ids=job_ids,
         tailor_current_policy_only=True,
+        material_selection_resolved=material_selection_resolved,
         suppress_existing_artifacts=_bool_param(params, "suppressExistingArtifacts", default=False),
     )
 
@@ -620,6 +635,7 @@ def _pipeline_workflow_spec(
     job_ids: tuple[JobId, ...] = (),
     score_current_policy_only: bool = False,
     tailor_current_policy_only: bool = False,
+    material_selection_resolved: bool = False,
     suppress_existing_artifacts: bool = False,
     allow_low_fit_override: bool = False,
 ) -> WorkflowStartSpec:
@@ -634,6 +650,7 @@ def _pipeline_workflow_spec(
             job_ids=job_ids,
             score_current_policy_only=score_current_policy_only,
             tailor_current_policy_only=tailor_current_policy_only,
+            material_selection_resolved=material_selection_resolved,
             suppress_existing_artifacts=suppress_existing_artifacts,
             allow_low_fit_override=allow_low_fit_override,
         )

--- a/workers/automation/src/jobctrl/pipeline/runner.py
+++ b/workers/automation/src/jobctrl/pipeline/runner.py
@@ -2460,7 +2460,7 @@ def _run_score(
     if cancel_event is not None and cancel_event.is_set():
         raise LlmTransientError("scoring canceled before start")
     from jobctrl.scoring.scorer import run_scoring
-    run_scoring(
+    result = run_scoring(
         limit=limit,
         rescore=rescore,
         workers=workers,
@@ -2469,7 +2469,10 @@ def _run_score(
     )
     if cancel_event is not None and cancel_event.is_set():
         raise LlmTransientError("scoring canceled")
-    return {"status": "ok"}
+    # ``scoredJobIds`` reaches the pipeline workflow through the score stage
+    # result so a resolved global material run can union this run's newly
+    # scored jobs into its frozen Tailor cohort.
+    return {"status": "ok", "scoredJobIds": list(result.get("scoredJobIds") or [])}
 
 
 def _run_tailor(

--- a/workers/automation/src/jobctrl/pipeline/workflow.py
+++ b/workers/automation/src/jobctrl/pipeline/workflow.py
@@ -73,6 +73,11 @@ class JobPipelineWorkflowInput:
     tailor_judge_min_score: float | None = None
     job_id: JobId | None = None
     job_ids: tuple[JobId, ...] = ()
+    # Independently frozen ``pending_cover`` backlog for a resolved global
+    # material run whose stages also include Tailor. ``job_ids`` carries the
+    # frozen Tailor backlog there, so Cover keeps its own cohort and unions it
+    # with the subset Tailor approves during the run.
+    cover_job_ids: tuple[JobId, ...] = ()
     apply_selector_keys: tuple[str, ...] = ()
     source_ids: tuple[str, ...] = ()
     score_current_policy_only: bool = False
@@ -89,6 +94,7 @@ class JobPipelineWorkflowInput:
         if self.job_id is not None:
             object.__setattr__(self, "job_id", canonical_job_id(str(self.job_id)))
         object.__setattr__(self, "job_ids", _canonical_job_ids(self.job_ids))
+        object.__setattr__(self, "cover_job_ids", _canonical_job_ids(self.cover_job_ids))
 
 
 @dataclass(frozen=True)
@@ -222,17 +228,32 @@ class JobPipelineWorkflow:
         failure: str | None = None
         error_code: str | None = None
         derived_preparation_job_ids: tuple[JobId, ...] | None = None
+        scored_job_ids: tuple[JobId, ...] = ()
 
         for stage in payload.stages:
             stage_payload = payload
-            if (
-                stage in {"tailor", "cover"}
-                and payload.material_selection_resolved
-                and not _selected_job_ids(payload)
-            ):
-                completed.append(stage)
-                continue
-            if stage in {"score", "tailor", "cover"} and derived_preparation_job_ids is not None:
+            if stage in {"tailor", "cover"} and payload.material_selection_resolved:
+                dispatch_job_ids = _resolved_material_dispatch_job_ids(
+                    stage,
+                    payload,
+                    derived_preparation_job_ids=derived_preparation_job_ids,
+                    scored_job_ids=scored_job_ids,
+                )
+                if not dispatch_job_ids:
+                    completed.append(stage)
+                    continue
+                stage_payload = replace(
+                    payload,
+                    job_id=None,
+                    job_ids=dispatch_job_ids,
+                    limit=_resolved_material_limit(stage, payload),
+                )
+            elif stage == "score" and payload.material_selection_resolved:
+                # ``job_ids`` carries a frozen material cohort in resolved
+                # runs; Score is not a material stage and keeps its legacy
+                # global sweep with an unscoped selection.
+                stage_payload = replace(payload, job_id=None, job_ids=())
+            elif stage in {"score", "tailor", "cover"} and derived_preparation_job_ids is not None:
                 if not derived_preparation_job_ids:
                     completed.append(stage)
                     continue
@@ -273,6 +294,10 @@ class JobPipelineWorkflow:
                 enriched_job_ids = _enriched_job_ids(result)
                 if enriched_job_ids is not None:
                     derived_preparation_job_ids = enriched_job_ids
+            elif stage == "score":
+                run_scored_job_ids = _scored_job_ids(result)
+                if run_scored_job_ids is not None:
+                    scored_job_ids = run_scored_job_ids
             elif stage == "tailor":
                 approved_job_ids = _approved_tailor_job_ids(result)
                 if approved_job_ids is not None:
@@ -284,6 +309,51 @@ class JobPipelineWorkflow:
             failure=failure,
             error_code=error_code,
         )
+
+
+def _resolved_material_dispatch_job_ids(
+    stage: str,
+    payload: JobPipelineWorkflowInput,
+    *,
+    derived_preparation_job_ids: tuple[JobId, ...] | None,
+    scored_job_ids: tuple[JobId, ...],
+) -> tuple[JobId, ...]:
+    """Dispatch set for one material stage of a resolved global run.
+
+    Each material stage owns an independently frozen backlog cohort, so an
+    empty Tailor cohort must not skip a non-empty Cover backlog. Within the
+    run, a queue only grows through upstream stage output: Score's
+    ``scoredJobIds`` feed Tailor and Tailor's ``approvedJobIds`` feed Cover,
+    so each stage dispatches the union of its frozen backlog and the upstream
+    subset this run produced. An empty union is an explicit no-op.
+    """
+
+    if stage == "tailor":
+        return _canonical_job_ids((*_selected_job_ids(payload), *scored_job_ids))
+    if "tailor" in payload.stages:
+        # ``job_ids`` holds the frozen Tailor backlog in these runs; Cover
+        # unions its own frozen backlog with the subset Tailor approved. A
+        # ``None`` derived value means Tailor no-opped on an empty cohort.
+        return _canonical_job_ids(
+            (*payload.cover_job_ids, *(derived_preparation_job_ids or ()))
+        )
+    # Cover is the only requested material stage: its frozen backlog rides in
+    # ``job_ids`` like any other single-cohort selection.
+    return _canonical_job_ids((*payload.cover_job_ids, *_selected_job_ids(payload)))
+
+
+def _resolved_material_limit(stage: str, payload: JobPipelineWorkflowInput) -> int:
+    """Keep the request limit on frozen single-queue cohorts only.
+
+    A frozen backlog was already limit-capped by its selection query, so
+    re-applying ``limit`` there is a no-op that preserves the pre-union
+    activity inputs. A Cover union that follows Tailor mirrors the derived
+    approved-subset handoff, which never re-truncates.
+    """
+
+    if stage == "cover" and "tailor" in payload.stages:
+        return 0
+    return payload.limit
 
 
 async def _recover_stage_state(
@@ -539,6 +609,7 @@ def _pipeline_spends(payload: JobPipelineWorkflowInput) -> bool:
             stage in {"tailor", "cover"}
             and payload.material_selection_resolved
             and not _selected_job_ids(payload)
+            and not payload.cover_job_ids
         )
         for stage in payload.stages
     )
@@ -621,6 +692,31 @@ def _approved_tailor_job_ids(result: Any) -> tuple[JobId, ...] | None:
         if "approvedJobIds" not in stage_result:
             return None
         raw_job_ids = stage_result.get("approvedJobIds")
+        if not isinstance(raw_job_ids, list):
+            return ()
+        return _canonical_job_ids(tuple(canonical_job_id(str(job_id)) for job_id in raw_job_ids))
+    return None
+
+
+def _scored_job_ids(result: Any) -> tuple[JobId, ...] | None:
+    """Read the canonical job ids Score persisted during this run.
+
+    Only the legacy global Score sweep reports ``scoredJobIds``; a resolved
+    material run unions them into the frozen Tailor cohort so jobs the run
+    itself qualifies are not stranded until the next command.
+    """
+
+    stages = _result_value(result, "stages")
+    if not isinstance(stages, list):
+        return None
+    for stage_result in stages:
+        if not isinstance(stage_result, dict):
+            continue
+        if stage_result.get("stage") != "score":
+            continue
+        if "scoredJobIds" not in stage_result:
+            return None
+        raw_job_ids = stage_result.get("scoredJobIds")
         if not isinstance(raw_job_ids, list):
             return ()
         return _canonical_job_ids(tuple(canonical_job_id(str(job_id)) for job_id in raw_job_ids))

--- a/workers/automation/src/jobctrl/pipeline/workflow.py
+++ b/workers/automation/src/jobctrl/pipeline/workflow.py
@@ -77,6 +77,7 @@ class JobPipelineWorkflowInput:
     source_ids: tuple[str, ...] = ()
     score_current_policy_only: bool = False
     tailor_current_policy_only: bool = False
+    material_selection_resolved: bool = False
     suppress_existing_artifacts: bool = False
     allow_low_fit_override: bool = False
     headless: bool = False
@@ -224,6 +225,13 @@ class JobPipelineWorkflow:
 
         for stage in payload.stages:
             stage_payload = payload
+            if (
+                stage in {"tailor", "cover"}
+                and payload.material_selection_resolved
+                and not _selected_job_ids(payload)
+            ):
+                completed.append(stage)
+                continue
             if stage in {"score", "tailor", "cover"} and derived_preparation_job_ids is not None:
                 if not derived_preparation_job_ids:
                     completed.append(stage)
@@ -405,7 +413,10 @@ async def _execute_stage(stage: str, payload: JobPipelineWorkflowInput) -> Any:
                 dry_run=payload.dry_run,
                 retailor=payload.retailor,
                 job_ids=_selected_job_ids(payload),
-                current_policy_only=payload.tailor_current_policy_only,
+                current_policy_only=(
+                    payload.tailor_current_policy_only
+                    and not payload.material_selection_resolved
+                ),
                 suppress_existing_artifacts=payload.suppress_existing_artifacts,
                 allow_low_fit_override=payload.allow_low_fit_override,
                 tailor_models=payload.tailor_models,
@@ -522,7 +533,15 @@ async def _cancel_owned_enrichment(payload: JobPipelineWorkflowInput) -> None:
 
 
 def _pipeline_spends(payload: JobPipelineWorkflowInput) -> bool:
-    return any(stage in _SPENDFUL_STAGES for stage in payload.stages)
+    return any(
+        stage in _SPENDFUL_STAGES
+        and not (
+            stage in {"tailor", "cover"}
+            and payload.material_selection_resolved
+            and not _selected_job_ids(payload)
+        )
+        for stage in payload.stages
+    )
 
 
 def _pipeline_input_summary(payload: JobPipelineWorkflowInput) -> dict[str, Any]:
@@ -576,6 +595,8 @@ def _apply_child_job_id(payload: JobPipelineWorkflowInput) -> JobId | None:
 
     selector_keys = tuple(payload.apply_selector_keys)
     if not selector_keys:
+        if payload.material_selection_resolved:
+            return None
         if payload.job_id is None and not payload.job_ids:
             return None
     elif selector_keys == ("jobId",):

--- a/workers/automation/src/jobctrl/scoring/scorer.py
+++ b/workers/automation/src/jobctrl/scoring/scorer.py
@@ -290,7 +290,7 @@ def run_scoring(
 
     if not jobs:
         log.info("No unscored jobs with descriptions found.")
-        return {"scored": 0, "errors": 0, "elapsed": 0.0, "distribution": []}
+        return {"scored": 0, "errors": 0, "elapsed": 0.0, "distribution": [], "scoredJobIds": []}
 
     jobs = [
         dict(job)
@@ -315,7 +315,7 @@ def run_scoring(
             )
         ]
     if not jobs:
-        return {"scored": 0, "errors": 0, "elapsed": 0.0, "distribution": []}
+        return {"scored": 0, "errors": 0, "elapsed": 0.0, "distribution": [], "scoredJobIds": []}
 
     worker_count = max(1, workers)
     log.info("Scoring %d jobs with %d worker(s)...", len(jobs), worker_count)
@@ -624,11 +624,23 @@ def run_scoring(
     )
 
     distribution = _score_distribution(repository, tenant_id)
+    # Canonical ids this run persisted a score for (computed, reused, and
+    # duplicate-propagated outcomes). A resolved global material run unions
+    # them into its frozen Tailor cohort so newly qualified jobs are tailored
+    # in the same command instead of stranding until the next pickup.
+    scored_job_ids = list(
+        dict.fromkeys(
+            str(canonical_job_id(str(job["job_id"])))
+            for job, outcome in results
+            if outcome.ok and outcome.score is not None
+        )
+    )
     return {
         "scored": scored_count,
         "errors": errors,
         "elapsed": elapsed,
         "distribution": distribution,
+        "scoredJobIds": scored_job_ids,
     }
 
 

--- a/workers/automation/src/jobctrl/workflow_specs.py
+++ b/workers/automation/src/jobctrl/workflow_specs.py
@@ -113,6 +113,11 @@ def build_run_stage_workflow_spec(params: dict[str, Any]) -> WorkflowStartSpec:
             if apply_selector is not None and apply_selector.job_id is not None
             else _job_ids(params)
         ),
+        # ``coverJobIds`` is an internal key written only by the material
+        # cohort freeze above; ignore it on unresolved requests.
+        cover_job_ids=(
+            _job_ids(params, key="coverJobIds") if material_selection_resolved else ()
+        ),
         apply_selector_keys=apply_selector.keys if apply_selector else (),
         material_selection_resolved=material_selection_resolved,
         source_ids=_source_ids(params),
@@ -136,35 +141,62 @@ def _scope_global_material_batch(
     stages: list[str],
     tenant_id: str,
 ) -> tuple[dict[str, Any], bool]:
-    """Freeze a global Tailor/Cover pickup into the workflow input.
+    """Freeze a global Tailor/Cover pickup into per-stage workflow cohorts.
 
     Material activities need an exact cohort so their bounded per-job fan-out,
     cancellation fence, and scaled timeout apply. Leaving ``jobIds`` empty
     selects the legacy global runner, whose blocking work can outlive a Temporal
     timeout and write after a newer owner has taken over.
+
+    Each requested material stage freezes its own backlog when the command
+    starts, wherever the material stages sit in the run: the first material
+    stage's cohort rides in ``jobIds`` and a Cover stage that follows Tailor
+    keeps its independently frozen ``pending_cover`` backlog in
+    ``coverJobIds``. Queue growth inside the run flows through stage-output
+    unions instead of an unscoped fallback — Score's ``scoredJobIds`` join the
+    frozen Tailor cohort and Tailor's ``approvedJobIds`` join the frozen Cover
+    cohort. Enrich-led runs are not frozen here because the Enrich stage
+    already hands its enriched subset to every later preparation stage.
     """
 
-    if not stages or stages[0] not in {"tailor", "cover"}:
+    if not any(stage in {"tailor", "cover"} for stage in stages):
+        return params, False
+    if "enrich" in stages:
         return params, False
     if params.get("jobId") or params.get("jobIds"):
         return params, False
 
     from jobctrl.database import get_connection, get_jobs_by_stage
 
-    first_stage = stages[0]
-    jobs = get_jobs_by_stage(
-        conn=get_connection(),
-        stage="pending_tailor" if first_stage == "tailor" else "pending_cover",
-        min_score=int(params.get("minScore", 7)),
-        limit=int(params.get("limit", 0)),
-        retailor=bool(params.get("retailor", False)) if first_stage == "tailor" else False,
-    )
-    job_ids = [
-        str(canonical_job_id(str(job["job_id"])))
-        for job in jobs
-        if str(job.get("tenant_id") or tenant_id) == tenant_id
-    ]
-    return {**params, "jobIds": list(dict.fromkeys(job_ids))}, True
+    conn = get_connection()
+
+    def frozen_cohort(queue_stage: str, *, retailor: bool) -> list[str]:
+        jobs = get_jobs_by_stage(
+            conn=conn,
+            stage=queue_stage,
+            min_score=int(params.get("minScore", 7)),
+            limit=int(params.get("limit", 0)),
+            retailor=retailor,
+        )
+        return list(
+            dict.fromkeys(
+                str(canonical_job_id(str(job["job_id"])))
+                for job in jobs
+                if str(job.get("tenant_id") or tenant_id) == tenant_id
+            )
+        )
+
+    scoped = dict(params)
+    if "tailor" in stages:
+        scoped["jobIds"] = frozen_cohort(
+            "pending_tailor",
+            retailor=bool(params.get("retailor", False)),
+        )
+        if "cover" in stages:
+            scoped["coverJobIds"] = frozen_cohort("pending_cover", retailor=False)
+    else:
+        scoped["jobIds"] = frozen_cohort("pending_cover", retailor=False)
+    return scoped, True
 
 
 def build_pipeline_workflow_spec(
@@ -569,12 +601,12 @@ def _stage_list(params: dict[str, Any]) -> list[str]:
     return [stage for stage in _WORKFLOW_STAGE_ORDER if stage in unique]
 
 
-def _job_ids(params: dict[str, Any]) -> tuple[JobId, ...]:
-    raw = params.get("jobIds") or ()
+def _job_ids(params: dict[str, Any], key: str = "jobIds") -> tuple[JobId, ...]:
+    raw = params.get(key) or ()
     if not raw:
         return ()
     if not isinstance(raw, list):
-        raise ValueError("jobIds must be an array")
+        raise ValueError(f"{key} must be an array")
     return tuple(dict.fromkeys(canonical_job_id(str(item)) for item in raw))
 
 

--- a/workers/automation/src/jobctrl/workflow_specs.py
+++ b/workers/automation/src/jobctrl/workflow_specs.py
@@ -56,10 +56,14 @@ class StartedWorkflowResult:
 def build_run_stage_workflow_spec(params: dict[str, Any]) -> WorkflowStartSpec:
     tenant_id = _tenant_id(params)
     stages = _stage_list(params)
-    params = _scope_global_material_batch(params, stages=stages, tenant_id=tenant_id)
     apply_selector = _apply_selector(params) if "apply" in stages else None
     if "apply" in stages:
         _require_auto_apply_browser_capability()
+    params, material_selection_resolved = _scope_global_material_batch(
+        params,
+        stages=stages,
+        tenant_id=tenant_id,
+    )
     raw_judge_min_score = params.get("tailorJudgeMinScore")
     if stages == ["discover"]:
         payload = DiscoverWorkflowInput(
@@ -101,11 +105,16 @@ def build_run_stage_workflow_spec(params: dict[str, Any]) -> WorkflowStartSpec:
         ),
         job_id=(
             apply_selector.job_id
-            if apply_selector is not None
+            if apply_selector is not None and apply_selector.job_id is not None
             else _optional_job_id(params, "jobId")
         ),
-        job_ids=() if apply_selector is not None else _job_ids(params),
+        job_ids=(
+            ()
+            if apply_selector is not None and apply_selector.job_id is not None
+            else _job_ids(params)
+        ),
         apply_selector_keys=apply_selector.keys if apply_selector else (),
+        material_selection_resolved=material_selection_resolved,
         source_ids=_source_ids(params),
         headless=bool(params.get("headless", False)),
         model=str(params.get("model", "default")),
@@ -126,7 +135,7 @@ def _scope_global_material_batch(
     *,
     stages: list[str],
     tenant_id: str,
-) -> dict[str, Any]:
+) -> tuple[dict[str, Any], bool]:
     """Freeze a global Tailor/Cover pickup into the workflow input.
 
     Material activities need an exact cohort so their bounded per-job fan-out,
@@ -136,9 +145,9 @@ def _scope_global_material_batch(
     """
 
     if not stages or stages[0] not in {"tailor", "cover"}:
-        return params
+        return params, False
     if params.get("jobId") or params.get("jobIds"):
-        return params
+        return params, False
 
     from jobctrl.database import get_connection, get_jobs_by_stage
 
@@ -155,7 +164,7 @@ def _scope_global_material_batch(
         for job in jobs
         if str(job.get("tenant_id") or tenant_id) == tenant_id
     ]
-    return {**params, "jobIds": list(dict.fromkeys(job_ids))}
+    return {**params, "jobIds": list(dict.fromkeys(job_ids))}, True
 
 
 def build_pipeline_workflow_spec(
@@ -169,6 +178,7 @@ def build_pipeline_workflow_spec(
     job_ids: tuple[JobId, ...] = (),
     score_current_policy_only: bool = False,
     tailor_current_policy_only: bool = False,
+    material_selection_resolved: bool = False,
     suppress_existing_artifacts: bool = False,
     allow_low_fit_override: bool = False,
 ) -> WorkflowStartSpec:
@@ -204,6 +214,7 @@ def build_pipeline_workflow_spec(
         apply_selector_keys=apply_selector.keys if apply_selector else (),
         score_current_policy_only=score_current_policy_only,
         tailor_current_policy_only=tailor_current_policy_only,
+        material_selection_resolved=material_selection_resolved,
         suppress_existing_artifacts=suppress_existing_artifacts,
         allow_low_fit_override=allow_low_fit_override,
         llm_model=str(params.get("llmModel") or DEFAULT_PIPELINE_LLM_MODEL_SPEC),

--- a/workers/automation/src/jobctrl/workflow_specs.py
+++ b/workers/automation/src/jobctrl/workflow_specs.py
@@ -56,6 +56,7 @@ class StartedWorkflowResult:
 def build_run_stage_workflow_spec(params: dict[str, Any]) -> WorkflowStartSpec:
     tenant_id = _tenant_id(params)
     stages = _stage_list(params)
+    params = _scope_global_material_batch(params, stages=stages, tenant_id=tenant_id)
     apply_selector = _apply_selector(params) if "apply" in stages else None
     if "apply" in stages:
         _require_auto_apply_browser_capability()
@@ -118,6 +119,43 @@ def build_run_stage_workflow_spec(params: dict[str, Any]) -> WorkflowStartSpec:
         workflow_id=workflow_id,
         id_reuse_policy=id_reuse_policy,
     )
+
+
+def _scope_global_material_batch(
+    params: dict[str, Any],
+    *,
+    stages: list[str],
+    tenant_id: str,
+) -> dict[str, Any]:
+    """Freeze a global Tailor/Cover pickup into the workflow input.
+
+    Material activities need an exact cohort so their bounded per-job fan-out,
+    cancellation fence, and scaled timeout apply. Leaving ``jobIds`` empty
+    selects the legacy global runner, whose blocking work can outlive a Temporal
+    timeout and write after a newer owner has taken over.
+    """
+
+    if not stages or stages[0] not in {"tailor", "cover"}:
+        return params
+    if params.get("jobId") or params.get("jobIds"):
+        return params
+
+    from jobctrl.database import get_connection, get_jobs_by_stage
+
+    first_stage = stages[0]
+    jobs = get_jobs_by_stage(
+        conn=get_connection(),
+        stage="pending_tailor" if first_stage == "tailor" else "pending_cover",
+        min_score=int(params.get("minScore", 7)),
+        limit=int(params.get("limit", 0)),
+        retailor=bool(params.get("retailor", False)) if first_stage == "tailor" else False,
+    )
+    job_ids = [
+        str(canonical_job_id(str(job["job_id"])))
+        for job in jobs
+        if str(job.get("tenant_id") or tenant_id) == tenant_id
+    ]
+    return {**params, "jobIds": list(dict.fromkeys(job_ids))}
 
 
 def build_pipeline_workflow_spec(

--- a/workers/automation/tests/test_jsonrpc_handlers.py
+++ b/workers/automation/tests/test_jsonrpc_handlers.py
@@ -7,7 +7,7 @@ import uuid
 from dataclasses import fields
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import pytest
 from temporalio.common import WorkflowIDConflictPolicy
@@ -1415,6 +1415,39 @@ def test_current_policy_maintenance_methods_start_pipeline_workflows(
     for name, value in expected_payload.items():
         assert getattr(payload, name) == value
     assert payload.tenant_id == "local"
+
+
+def test_global_retailor_current_policy_freezes_policy_selected_cohort(monkeypatch) -> None:
+    connection = object()
+    selected_job_ids = (
+        JobId("23000000-0000-4000-8000-000000000001"),
+        JobId("23000000-0000-4000-8000-000000000002"),
+    )
+    monkeypatch.setattr(handlers_mod, "get_connection", lambda: connection)
+
+    with patch(
+        "jobctrl.pipeline.current_policy_selectors.tailoring_current_policy_job_ids",
+        return_value=selected_job_ids,
+    ) as selector:
+        spec = handlers_mod.retailor_current_policy(
+            {
+                "tenantId": "local",
+                "jobIds": [],
+                "limit": 12,
+                "minScore": 8,
+            }
+        )
+
+    payload = spec.args[0]
+    assert payload.job_ids == selected_job_ids
+    assert payload.material_selection_resolved is True
+    assert payload.tailor_current_policy_only is True
+    selector.assert_called_once_with(
+        connection,
+        tenant_id="local",
+        min_score=8,
+        limit=12,
+    )
 
 
 def test_v7_canonical_job_ids_disambiguate_the_same_url_by_tenant(

--- a/workers/automation/tests/test_scorer.py
+++ b/workers/automation/tests/test_scorer.py
@@ -712,6 +712,7 @@ def test_run_scoring_persists_via_repository_only(
     assert summary["scored"] == 1
     assert summary["errors"] == 0
     assert summary["distribution"] == [(7, 1)]
+    assert summary["scoredJobIds"] == [str(_job_id(url))]
 
     # New aggregate persisted.
     loaded = repo.load(LOCAL_TENANT, _job_id(url))
@@ -1183,6 +1184,9 @@ def test_run_scoring_reuses_same_content_score_for_duplicate_jobs(
 
     assert summary["scored"] == 2
     assert summary["errors"] == 0
+    assert sorted(summary["scoredJobIds"]) == sorted(
+        [str(_job_id(first_url)), str(_job_id(duplicate_url))]
+    )
     assert llm.calls == 1
     first_score = repo.load(LOCAL_TENANT, _job_id(first_url))
     duplicate_score = repo.load(LOCAL_TENANT, _job_id(duplicate_url))
@@ -1478,7 +1482,13 @@ def test_run_scoring_increments_score_attempts_until_cap(
         llm_port=drained,
         resume_text="anything",
     )
-    assert summary == {"scored": 0, "errors": 0, "elapsed": 0.0, "distribution": []}
+    assert summary == {
+        "scored": 0,
+        "errors": 0,
+        "elapsed": 0.0,
+        "distribution": [],
+        "scoredJobIds": [],
+    }
     assert drained.calls == 0
     assert _score_attempt_count(conn, url) == 5
 

--- a/workers/automation/tests/test_workflow_job_pipeline.py
+++ b/workers/automation/tests/test_workflow_job_pipeline.py
@@ -56,8 +56,10 @@ from jobctrl.pipeline.workflow import (
     _SCORE_RETRY,
     _TAILOR_RETRY,
     _activity_timeout,
+    _apply_child_job_id,
     _cancel_material_stage_state,
     _cancel_owned_enrichment,
+    _pipeline_spends,
     _selected_batch_timeout,
     JobPipelineWorkflow,
     JobPipelineWorkflowInput,
@@ -171,6 +173,7 @@ def test_global_material_run_freezes_exact_selected_cohort(
 
     payload = spec.args[0]
     assert payload.job_ids == tuple(JobId(job_id) for job_id in job_ids)
+    assert payload.material_selection_resolved is True
     connection.assert_called_once_with()
     selector.assert_called_once_with(
         conn=connection.return_value,
@@ -179,6 +182,52 @@ def test_global_material_run_freezes_exact_selected_cohort(
         limit=25,
         retailor=retailor,
     )
+
+
+@pytest.mark.parametrize("stage", ["tailor", "cover"])
+@pytest.mark.asyncio
+async def test_resolved_empty_material_batch_is_a_no_op(stage: str) -> None:
+    payload = JobPipelineWorkflowInput(
+        tenant_id="local",
+        stages=[stage],
+        material_selection_resolved=True,
+    )
+
+    with patch(
+        "jobctrl.pipeline.workflow._execute_stage",
+        side_effect=AssertionError("an empty frozen cohort must not dispatch an activity"),
+    ):
+        result = await JobPipelineWorkflow()._execute_stages(payload)
+
+    assert result.stages_completed == [stage]
+    assert result.stages_failed == []
+    assert _pipeline_spends(payload) is False
+
+
+def test_global_material_run_preserves_batch_apply_selector() -> None:
+    job_ids = [
+        "22000000-0000-4000-8000-000000000001",
+        "22000000-0000-4000-8000-000000000002",
+    ]
+    rows = [{"tenant_id": "local", "job_id": job_id} for job_id in job_ids]
+
+    with (
+        patch("jobctrl.database.get_connection", return_value=object()),
+        patch("jobctrl.database.get_jobs_by_stage", return_value=rows),
+    ):
+        spec = build_run_stage_workflow_spec(
+            {
+                "tenantId": "local",
+                "stages": ["tailor", "cover", "apply"],
+                "dryRun": True,
+            }
+        )
+
+    payload = spec.args[0]
+    assert payload.job_ids == tuple(JobId(job_id) for job_id in job_ids)
+    assert payload.material_selection_resolved is True
+    assert payload.apply_selector_keys == ()
+    assert _apply_child_job_id(payload) is None
 
 
 @pytest.fixture(autouse=True)
@@ -902,6 +951,50 @@ async def test_current_policy_tailor_continuation_covers_only_approved_jobs():
     assert result.stages_failed == []
     assert tailored_job_ids == [selected_job_id]
     assert cover_job_ids == [selected_job_id]
+
+
+@pytest.mark.asyncio
+async def test_frozen_current_policy_cohort_uses_selected_tailor_path():
+    queue = f"pipeline-frozen-current-policy-{uuid.uuid4()}"
+    selected_job_id = JobId("10000000-0000-4000-8000-000000000004")
+    tailored_job_ids: list[JobId] = []
+
+    def fake_tailor_job_by_id(job_id: JobId, **_kwargs):
+        tailored_job_ids.append(job_id)
+        return {"status": "approved"}
+
+    with (
+        patch(
+            "jobctrl.pipeline.current_policy_selectors.tailoring_current_policy_job_ids",
+            side_effect=AssertionError("a frozen policy cohort must not be selected again"),
+        ),
+        patch("jobctrl.scoring.tailor.tailor_job_by_id", side_effect=fake_tailor_job_by_id),
+    ):
+        async with await WorkflowEnvironment.start_time_skipping() as env:
+            async with Worker(
+                env.client,
+                task_queue=queue,
+                workflows=[JobPipelineWorkflow, DiscoverWorkflow],
+                activities=_all_activities(),
+                workflow_runner=UnsandboxedWorkflowRunner(),
+            ):
+                result = await env.client.execute_workflow(
+                    JobPipelineWorkflow.run,
+                    JobPipelineWorkflowInput(
+                        tenant_id="local",
+                        stages=["tailor"],
+                        job_ids=(selected_job_id,),
+                        retailor=True,
+                        tailor_current_policy_only=True,
+                        material_selection_resolved=True,
+                    ),
+                    id=f"pipeline-frozen-current-policy-wf-{uuid.uuid4()}",
+                    task_queue=queue,
+                )
+
+    assert result.stages_completed == ["tailor"]
+    assert result.stages_failed == []
+    assert tailored_job_ids == [selected_job_id]
 
 
 @pytest.mark.asyncio

--- a/workers/automation/tests/test_workflow_job_pipeline.py
+++ b/workers/automation/tests/test_workflow_job_pipeline.py
@@ -133,6 +133,54 @@ def test_selected_batch_timeout_scales_by_worker_waves_and_is_capped() -> None:
         patched.assert_called_once_with(_SELECTED_BATCH_TIMEOUT_PATCH)
 
 
+@pytest.mark.parametrize(
+    ("stage", "queue_stage", "retailor"),
+    [
+        ("tailor", "pending_tailor", True),
+        ("cover", "pending_cover", False),
+    ],
+)
+def test_global_material_run_freezes_exact_selected_cohort(
+    stage: str,
+    queue_stage: str,
+    retailor: bool,
+) -> None:
+    job_ids = [
+        f"21000000-0000-4000-8000-{index:012d}"
+        for index in range(3)
+    ]
+    rows = [
+        {"tenant_id": "local", "job_id": job_id}
+        for job_id in job_ids
+    ]
+
+    with (
+        patch("jobctrl.database.get_connection", return_value=object()) as connection,
+        patch("jobctrl.database.get_jobs_by_stage", return_value=rows) as selector,
+    ):
+        spec = build_run_stage_workflow_spec(
+            {
+                "tenantId": "local",
+                "stage": stage,
+                "limit": 25,
+                "workers": 2,
+                "minScore": 8,
+                "retailor": True,
+            }
+        )
+
+    payload = spec.args[0]
+    assert payload.job_ids == tuple(JobId(job_id) for job_id in job_ids)
+    connection.assert_called_once_with()
+    selector.assert_called_once_with(
+        conn=connection.return_value,
+        stage=queue_stage,
+        min_score=8,
+        limit=25,
+        retailor=retailor,
+    )
+
+
 @pytest.fixture(autouse=True)
 def permit_browser_for_existing_pipeline_workflow_tests(monkeypatch: pytest.MonkeyPatch) -> None:
     """Pipeline workflow tests exercise child-workflow behavior after policy validation."""

--- a/workers/automation/tests/test_workflow_job_pipeline.py
+++ b/workers/automation/tests/test_workflow_job_pipeline.py
@@ -230,6 +230,199 @@ def test_global_material_run_preserves_batch_apply_selector() -> None:
     assert _apply_child_job_id(payload) is None
 
 
+def test_multi_stage_global_material_run_freezes_each_queue_independently() -> None:
+    tailor_ids = [f"24000000-0000-4000-8000-{index:012d}" for index in range(2)]
+    cover_ids = [f"25000000-0000-4000-8000-{index:012d}" for index in range(2)]
+    rows_by_queue = {
+        "pending_tailor": [{"tenant_id": "local", "job_id": job_id} for job_id in tailor_ids],
+        "pending_cover": [{"tenant_id": "local", "job_id": job_id} for job_id in cover_ids],
+    }
+
+    with (
+        patch("jobctrl.database.get_connection", return_value=object()),
+        patch(
+            "jobctrl.database.get_jobs_by_stage",
+            side_effect=lambda **kwargs: rows_by_queue[kwargs["stage"]],
+        ) as selector,
+    ):
+        spec = build_run_stage_workflow_spec(
+            {
+                "tenantId": "local",
+                "stages": ["tailor", "cover"],
+                "minScore": 8,
+                "limit": 25,
+            }
+        )
+
+    payload = spec.args[0]
+    assert payload.job_ids == tuple(JobId(job_id) for job_id in tailor_ids)
+    assert payload.cover_job_ids == tuple(JobId(job_id) for job_id in cover_ids)
+    assert payload.material_selection_resolved is True
+    assert [call.kwargs["stage"] for call in selector.call_args_list] == [
+        "pending_tailor",
+        "pending_cover",
+    ]
+
+
+def test_score_first_global_run_freezes_material_cohorts() -> None:
+    """``run score tailor cover`` must not reach the legacy unscoped material runner."""
+
+    tailor_ids = ["27000000-0000-4000-8000-000000000001"]
+    cover_ids = ["28000000-0000-4000-8000-000000000001"]
+    rows_by_queue = {
+        "pending_tailor": [{"tenant_id": "local", "job_id": job_id} for job_id in tailor_ids],
+        "pending_cover": [{"tenant_id": "local", "job_id": job_id} for job_id in cover_ids],
+    }
+
+    with (
+        patch("jobctrl.database.get_connection", return_value=object()),
+        patch(
+            "jobctrl.database.get_jobs_by_stage",
+            side_effect=lambda **kwargs: rows_by_queue[kwargs["stage"]],
+        ) as selector,
+    ):
+        spec = build_run_stage_workflow_spec(
+            {
+                "tenantId": "local",
+                "stages": ["score", "tailor", "cover"],
+            }
+        )
+
+    payload = spec.args[0]
+    assert payload.stages == ["score", "tailor", "cover"]
+    assert payload.job_ids == tuple(JobId(job_id) for job_id in tailor_ids)
+    assert payload.cover_job_ids == tuple(JobId(job_id) for job_id in cover_ids)
+    assert payload.material_selection_resolved is True
+    assert [call.kwargs["stage"] for call in selector.call_args_list] == [
+        "pending_tailor",
+        "pending_cover",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_empty_tailor_cohort_still_covers_frozen_cover_backlog() -> None:
+    """An empty Tailor queue must not no-op a Cover stage with frozen backlog."""
+
+    cover_backlog = (
+        JobId("26000000-0000-4000-8000-000000000001"),
+        JobId("26000000-0000-4000-8000-000000000002"),
+    )
+    payload = JobPipelineWorkflowInput(
+        tenant_id="local",
+        stages=["tailor", "cover"],
+        material_selection_resolved=True,
+        cover_job_ids=cover_backlog,
+        limit=25,
+    )
+    dispatched: list[tuple[str, tuple[JobId, ...], int]] = []
+
+    async def fake_execute_stage(stage: str, stage_payload: JobPipelineWorkflowInput):
+        dispatched.append((stage, stage_payload.job_ids, stage_payload.limit))
+        return {"status": "ok", "stages": [{"stage": stage}]}
+
+    with patch("jobctrl.pipeline.workflow._execute_stage", side_effect=fake_execute_stage):
+        result = await JobPipelineWorkflow()._execute_stages(payload)
+
+    assert result.stages_completed == ["tailor", "cover"]
+    assert result.stages_failed == []
+    assert dispatched == [("cover", cover_backlog, 0)]
+    assert _pipeline_spends(payload) is True
+
+
+@pytest.mark.asyncio
+async def test_cover_unions_frozen_backlog_with_approved_tailor_subset() -> None:
+    """Cover must keep pre-existing pending_cover stragglers alongside approved Tailor output."""
+
+    tailor_cohort = (
+        JobId("29000000-0000-4000-8000-000000000001"),
+        JobId("29000000-0000-4000-8000-000000000002"),
+    )
+    cover_backlog = (JobId("29000000-0000-4000-8000-000000000009"),)
+    approved_job_id = tailor_cohort[0]
+    payload = JobPipelineWorkflowInput(
+        tenant_id="local",
+        stages=["tailor", "cover"],
+        material_selection_resolved=True,
+        job_ids=tailor_cohort,
+        cover_job_ids=cover_backlog,
+        limit=25,
+    )
+    dispatched: list[tuple[str, tuple[JobId, ...], int]] = []
+
+    async def fake_execute_stage(stage: str, stage_payload: JobPipelineWorkflowInput):
+        dispatched.append((stage, stage_payload.job_ids, stage_payload.limit))
+        if stage == "tailor":
+            return {
+                "status": "ok",
+                "stages": [{"stage": "tailor", "approvedJobIds": [str(approved_job_id)]}],
+            }
+        return {"status": "ok", "stages": [{"stage": stage}]}
+
+    with patch("jobctrl.pipeline.workflow._execute_stage", side_effect=fake_execute_stage):
+        result = await JobPipelineWorkflow()._execute_stages(payload)
+
+    assert result.stages_completed == ["tailor", "cover"]
+    assert result.stages_failed == []
+    assert dispatched == [
+        ("tailor", tailor_cohort, 25),
+        ("cover", (*cover_backlog, approved_job_id), 0),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_resolved_empty_multi_stage_material_run_is_a_no_op() -> None:
+    payload = JobPipelineWorkflowInput(
+        tenant_id="local",
+        stages=["tailor", "cover"],
+        material_selection_resolved=True,
+    )
+
+    with patch(
+        "jobctrl.pipeline.workflow._execute_stage",
+        side_effect=AssertionError("empty frozen cohorts must not dispatch an activity"),
+    ):
+        result = await JobPipelineWorkflow()._execute_stages(payload)
+
+    assert result.stages_completed == ["tailor", "cover"]
+    assert result.stages_failed == []
+    assert _pipeline_spends(payload) is False
+
+
+@pytest.mark.asyncio
+async def test_score_first_resolved_run_keeps_score_unscoped_and_feeds_tailor() -> None:
+    """Score keeps its global sweep and its newly scored jobs join the frozen Tailor cohort."""
+
+    frozen_tailor = (JobId("2a000000-0000-4000-8000-000000000001"),)
+    scored_job_id = JobId("2a000000-0000-4000-8000-000000000002")
+    payload = JobPipelineWorkflowInput(
+        tenant_id="local",
+        stages=["score", "tailor"],
+        material_selection_resolved=True,
+        job_ids=frozen_tailor,
+        limit=25,
+    )
+    dispatched: list[tuple[str, tuple[JobId, ...]]] = []
+
+    async def fake_execute_stage(stage: str, stage_payload: JobPipelineWorkflowInput):
+        dispatched.append((stage, stage_payload.job_ids))
+        if stage == "score":
+            return {
+                "status": "ok",
+                "stages": [{"stage": "score", "scoredJobIds": [str(scored_job_id)]}],
+            }
+        return {"status": "ok", "stages": [{"stage": stage}]}
+
+    with patch("jobctrl.pipeline.workflow._execute_stage", side_effect=fake_execute_stage):
+        result = await JobPipelineWorkflow()._execute_stages(payload)
+
+    assert result.stages_completed == ["score", "tailor"]
+    assert result.stages_failed == []
+    assert dispatched == [
+        ("score", ()),
+        ("tailor", (*frozen_tailor, scored_job_id)),
+    ]
+
+
 @pytest.fixture(autouse=True)
 def permit_browser_for_existing_pipeline_workflow_tests(monkeypatch: pytest.MonkeyPatch) -> None:
     """Pipeline workflow tests exercise child-workflow behavior after policy validation."""


### PR DESCRIPTION
## What changed
- resolve global Tailor and Cover pickup into canonical job IDs before Temporal starts
- distinguish an explicitly empty frozen cohort from an unscoped legacy batch, completing the empty cohort as a no-op
- keep mixed Tailor/Cover/Apply material ownership separate from Apply selector semantics
- resolve global current-policy re-tailoring with its policy-aware selector before workflow dispatch
- route frozen cohorts through the existing bounded per-job fan-out, ownership fencing, and worker-wave timeout
- record the final chaos finding and completed live threshold reconciliation

## Why
A global material command left its job selection empty and therefore used the legacy unscoped batch runner. When its 30-minute activity timed out, abandoned work could finish late and race a newer selected owner. The same missing ownership distinction affected empty cohorts, mixed Apply workflows, and the global current-policy maintenance action.

## Validation
- `uv --project workers/automation run pytest workers/automation/tests/test_workflow_job_pipeline.py -q` (48 passed)
- `uv --project workers/automation run pytest workers/automation/tests/test_jsonrpc_handlers.py workers/automation/tests/test_actions.py -q` (102 passed)
- touched-file Ruff check
- `corepack pnpm docs:build` (9,651 links and redirects passed)
- `git diff --check`
- independent review and QA gates: PASS, no findings
- local Temporal, API, web, and worker stack restarted and healthy on `793e86949`
