### PR TITLE
fix(operations): preserve run and activity context

### DIFF
--- a/apps/api/src/read-model.ts
+++ b/apps/api/src/read-model.ts
@@ -5564,6 +5564,16 @@ function progressStatus(value: unknown, eventType: string | null): DashboardSumm
   return "running";
 }
 
+const ACTIVITY_WORKFLOW_ID_SQL = `CASE
+  WHEN e.payload_json IS NOT NULL AND json_valid(e.payload_json)
+  THEN COALESCE(
+    json_extract(e.payload_json, '$.workflowId'),
+    json_extract(e.payload_json, '$.workflow_id'),
+    json_extract(e.payload_json, '$.execution.workflowId')
+  )
+  ELSE NULL
+END`;
+
 function listActivityFromEvents(
   db: SqliteDatabase,
   query: ActivityListQuery,
@@ -5600,10 +5610,22 @@ function listActivityFromEvents(
       OR LOWER(COALESCE(jp.title, '')) LIKE ?
       OR LOWER(COALESCE(jp.employer, '')) LIKE ?
       OR LOWER(COALESCE(e.job_id, '')) LIKE ?
+      OR LOWER(COALESCE(${ACTIVITY_WORKFLOW_ID_SQL}, '')) LIKE ?
       OR LOWER(CAST(e.event_id AS TEXT)) LIKE ?
       OR LOWER(COALESCE(e.occurred_at, '')) LIKE ?
     )`);
-    params.push(search, search, search, search, search, search, search, search, search);
+    params.push(
+      search,
+      search,
+      search,
+      search,
+      search,
+      search,
+      search,
+      search,
+      search,
+      search,
+    );
   }
   const activityWhere = `WHERE ${activityClauses.join(" AND ")}`;
   const fromSql = `
@@ -5629,6 +5651,7 @@ function listActivityFromEvents(
     SELECT
       e.event_id,
       ${eventTypeSelect},
+      ${ACTIVITY_WORKFLOW_ID_SQL} AS workflow_id,
       e.job_id,
       e.stage,
       e.level,
@@ -5669,6 +5692,7 @@ function getActivityEventFromEvents(db: SqliteDatabase, eventId: string): Activi
     `SELECT
        e.event_id,
        ${eventTypeSelect},
+       ${ACTIVITY_WORKFLOW_ID_SQL} AS workflow_id,
        e.job_id,
        e.stage,
        e.level,
@@ -5707,6 +5731,7 @@ function activityRowToSummary(row: Record<string, unknown>): ActivityEventSummar
   return {
     eventId: stringField(row.event_id),
     eventType: stringField(row.event_type) || "Event",
+    workflowId: nullableString(row.workflow_id),
     jobKey: nullableString(row.job_id),
     title: nullableString(row.title),
     company: nullableString(row.employer),
@@ -5961,8 +5986,9 @@ function applyWorkflowLifecycleFold(
  * `loadWorkflowRunLifecycleFolds`) so a stale terminal outcome from a superseded
  * execution never leaks onto a run the current execution has restarted.
  * Apply rows are enriched with job context via `apply_run_projections` (the
- * apply-specific detail projection). Preparation rows resolve the canonical
- * JobId in their input summary against the tenant-scoped job read model. The
+ * apply-specific detail projection). Job-scoped preparation and pipeline rows
+ * resolve the canonical JobId in their input summary against the tenant-scoped
+ * job read model. The
  * `runId` equals the Temporal `workflow_id`, so the Temporal Web UI deep-link
  * uses it verbatim.
  */
@@ -5977,7 +6003,7 @@ export function listWorkflowRuns(
        arp.job_employer AS job_employer, arp.dry_run AS apply_dry_run,
        arp.model AS apply_model, arp.result AS apply_result`;
   const relatedJobJoin = ` LEFT JOIN job_list_projections rjp
-    ON wrp.workflow_type = 'JobPreparationWorkflow'
+    ON wrp.workflow_type IN ('JobPreparationWorkflow', 'JobPipelineWorkflow')
    AND rjp.tenant_id = wrp.tenant_id
    AND rjp.job_id = CASE
      WHEN json_valid(wrp.input_summary_json)
@@ -6034,9 +6060,9 @@ function workflowRunsFilterPayload(query: WorkflowRunsListQuery): Record<string,
 /**
  * Workflow run detail (Temporal loop closure — P0). Reads one
  * `workflow_run_projections` row (enriched with canonical job context when the
- * run is an apply or preparation workflow) and returns the full
- * `WorkflowRunDetail` shape, including the folded lifecycle timeline. Returns
- * `null` when the run id is unknown.
+ * run is an apply or job-scoped preparation/pipeline workflow) and returns the
+ * full `WorkflowRunDetail` shape, including the folded lifecycle timeline.
+ * Returns `null` when the run id is unknown.
  */
 export function getWorkflowRunDetail(
   db: SqliteDatabase,
@@ -6049,7 +6075,7 @@ export function getWorkflowRunDetail(
        arp.job_employer AS job_employer, arp.dry_run AS apply_dry_run,
        arp.model AS apply_model, arp.result AS apply_result`;
   const relatedJobJoin = ` LEFT JOIN job_list_projections rjp
-    ON wrp.workflow_type = 'JobPreparationWorkflow'
+    ON wrp.workflow_type IN ('JobPreparationWorkflow', 'JobPipelineWorkflow')
    AND rjp.tenant_id = wrp.tenant_id
    AND rjp.job_id = CASE
      WHEN json_valid(wrp.input_summary_json)
@@ -6153,9 +6179,9 @@ function rowToWorkflowRunSummary(row: WorkflowRunProjectionRow): WorkflowRunSumm
     workflowType === "ApplyWorkflow" &&
     (inputSummary.autoApplyLoop === true || inputSummary.auto_apply_loop === true) &&
     inputSummary.continuous === true;
-  // Apply context remains authoritative for apply runs. Preparation context
-  // comes only from the canonical JobId join; job-independent runs continue to
-  // surface their workflow type.
+  // Apply context remains authoritative for apply runs. Preparation and
+  // single-job pipeline contexts come only from the canonical JobId join;
+  // job-independent runs continue to surface their workflow type.
   const hasApplyJob = Boolean(stringField(row.apply_job_id));
   const jobKey = stringField(row.apply_job_id) || stringField(row.related_job_id);
   const hasJob = Boolean(jobKey);

--- a/apps/api/test/server.test.ts
+++ b/apps/api/test/server.test.ts
@@ -2166,8 +2166,10 @@ describe("local TypeScript API", () => {
 
   it("finds workflow activity by its canonical workflow id and exposes that run reference", async () => {
     const workflowId = "run-activity-search-regression";
+    const jobKey = jobIdFor("https://example.com/jobs/ready");
     const db = new Database(options.dbPath);
     let eventId = "";
+    let stageEventId = "";
     try {
       insertPipelineWorkflowEvent(db, {
         eventType: "WorkflowStarted",
@@ -2176,11 +2178,25 @@ describe("local TypeScript API", () => {
         temporalRunId: "temporal-activity-search-regression",
         startedAt: "2026-04-29T11:30:00+00:00",
       });
+      // Worker stage runners stamp the owning run into per-job stage events
+      // (jobctrl.infrastructure.workflow_run_context), so run-scoped review
+      // returns the run's actual work — not only lifecycle markers.
+      const stageRow = db
+        .prepare(
+          `INSERT INTO job_events (
+             tenant_id, job_id, identity_version, stage, event_type, level,
+             message, occurred_at, payload_json
+           ) VALUES ('local', ?, 1, 'score', 'StageCompleted', 'info',
+                     'Fit score 9/10', '2026-04-29T11:31:00+00:00', ?)`,
+        )
+        .run(jobKey, JSON.stringify({ workflowId, jobId: jobKey, stage: "score" }));
+      stageEventId = String(stageRow.lastInsertRowid);
       const row = db
         .prepare(
           `SELECT event_id
              FROM job_events
-            WHERE json_extract(payload_json, '$.workflowId') = ?`,
+            WHERE json_extract(payload_json, '$.workflowId') = ?
+              AND event_type = 'WorkflowStarted'`,
         )
         .get(workflowId) as { event_id: number };
       eventId = String(row.event_id);
@@ -2196,6 +2212,14 @@ describe("local TypeScript API", () => {
       });
       expect(activity.statusCode, activity.body).toBe(200);
       expect(activity.json().items).toEqual([
+        expect.objectContaining({
+          eventId: stageEventId,
+          eventType: "StageCompleted",
+          workflowId,
+          jobKey,
+          title: "Platform Engineer",
+          company: "ExampleCo",
+        }),
         expect.objectContaining({
           eventId,
           eventType: "WorkflowStarted",

--- a/apps/api/test/server.test.ts
+++ b/apps/api/test/server.test.ts
@@ -2164,6 +2164,56 @@ describe("local TypeScript API", () => {
     await app.close();
   });
 
+  it("finds workflow activity by its canonical workflow id and exposes that run reference", async () => {
+    const workflowId = "run-activity-search-regression";
+    const db = new Database(options.dbPath);
+    let eventId = "";
+    try {
+      insertPipelineWorkflowEvent(db, {
+        eventType: "WorkflowStarted",
+        occurredAt: "2026-04-29T11:30:00+00:00",
+        workflowId,
+        temporalRunId: "temporal-activity-search-regression",
+        startedAt: "2026-04-29T11:30:00+00:00",
+      });
+      const row = db
+        .prepare(
+          `SELECT event_id
+             FROM job_events
+            WHERE json_extract(payload_json, '$.workflowId') = ?`,
+        )
+        .get(workflowId) as { event_id: number };
+      eventId = String(row.event_id);
+    } finally {
+      db.close();
+    }
+
+    const app = buildApp(options);
+    try {
+      const activity = await app.inject({
+        method: "GET",
+        url: `/v1/debug/activity?q=${workflowId}`,
+      });
+      expect(activity.statusCode, activity.body).toBe(200);
+      expect(activity.json().items).toEqual([
+        expect.objectContaining({
+          eventId,
+          eventType: "WorkflowStarted",
+          workflowId,
+        }),
+      ]);
+
+      const detail = await app.inject({
+        method: "GET",
+        url: `/v1/debug/activity/${eventId}`,
+      });
+      expect(detail.statusCode, detail.body).toBe(200);
+      expect(detail.json().event).toMatchObject({ eventId, workflowId });
+    } finally {
+      await app.close();
+    }
+  });
+
   it("does not expose dashboard activity links for events whose job no longer exists", async () => {
     const db = new Database(options.dbPath);
     db.pragma("foreign_keys = OFF");
@@ -6215,7 +6265,7 @@ describe("local TypeScript API", () => {
     }
   });
 
-  it("enriches preparation workflow list and detail from its canonical tenant-scoped JobId", async () => {
+  it("enriches job-scoped preparation and pipeline runs from their canonical tenant-scoped JobId", async () => {
     const jobId = jobIdFor("https://example.com/jobs/ready");
     const db = new Database(options.dbPath);
     db.prepare(
@@ -6254,6 +6304,14 @@ describe("local TypeScript API", () => {
       startedAt: "2026-04-29T10:25:00+00:00",
     });
     insertDiscoverWorkflowRunRow(db, {
+      workflowId: "pipeline-job-local",
+      workflowType: "JobPipelineWorkflow",
+      status: "in_progress",
+      inputSummary: { jobId, stages: ["tailor", "cover"] },
+      startedAt: "2026-04-29T10:25:30+00:00",
+      temporalRunId: "temporal-pipeline-job-run",
+    });
+    insertDiscoverWorkflowRunRow(db, {
       workflowId: "discover-with-job-id",
       status: "queued",
       inputSummary: { jobId },
@@ -6285,6 +6343,16 @@ describe("local TypeScript API", () => {
         title: "JobPreparationWorkflow",
         company: "",
       });
+      const pipelineSummary = listResponse
+        .json()
+        .items.find((item: { workflowId: string }) => item.workflowId === "pipeline-job-local");
+      expect(pipelineSummary).toMatchObject({
+        workflowId: "pipeline-job-local",
+        workflowType: "JobPipelineWorkflow",
+        jobKey: jobId,
+        title: "Platform Engineer",
+        company: "ExampleCo",
+      });
       const discoverSummary = listResponse
         .json()
         .items.find((item: { workflowId: string }) => item.workflowId === "discover-with-job-id");
@@ -6307,6 +6375,20 @@ describe("local TypeScript API", () => {
           { eventType: "WorkflowStarted", status: "in_progress" },
           { eventType: "WorkflowCompleted", status: "succeeded" },
         ],
+      });
+
+      const pipelineDetail = await app.inject({
+        method: "GET",
+        url: "/v1/workflow-runs/pipeline-job-local",
+      });
+      expect(pipelineDetail.statusCode, pipelineDetail.body).toBe(200);
+      expect(pipelineDetail.json()).toMatchObject({
+        workflowId: "pipeline-job-local",
+        workflowType: "JobPipelineWorkflow",
+        jobKey: jobId,
+        title: "Platform Engineer",
+        company: "ExampleCo",
+        inputSummary: { jobId, stages: ["tailor", "cover"] },
       });
     } finally {
       await app.close();

--- a/apps/web/src/contexts/pipeline/components/StageTriggerPanel.test.tsx
+++ b/apps/web/src/contexts/pipeline/components/StageTriggerPanel.test.tsx
@@ -616,6 +616,7 @@ describe("StageTriggerPanel", () => {
               {
                 eventId: "538",
                 eventType: "StageStarted",
+                workflowId: null,
                 jobKey: "pipeline",
                 title: null,
                 company: null,
@@ -650,6 +651,7 @@ describe("StageTriggerPanel", () => {
               {
                 eventId: "539",
                 eventType: "StageStarted",
+                workflowId: null,
                 jobKey: "pipeline",
                 title: null,
                 company: null,

--- a/apps/web/src/demo/DemoApiClientAdapter.test.ts
+++ b/apps/web/src/demo/DemoApiClientAdapter.test.ts
@@ -649,9 +649,19 @@ describe("DemoApiClientAdapter", () => {
       items: [{ eventId: "event-demo-score" }],
     });
     await expect(adapter.activity({ stage: "apply" })).resolves.toMatchObject({
-      pagination: { page: 1, total: 0, pages: 1 },
-      items: [],
+      pagination: { page: 1, total: 1, pages: 1 },
+      items: [{ workflowId: "run-application-rehearsal" }],
     });
+
+    const visibleRuns = await adapter.workflowRuns();
+    for (const run of visibleRuns.items) {
+      await expect(
+        adapter.activity({ q: run.workflowId }),
+      ).resolves.toMatchObject({
+        pagination: { total: 1 },
+        items: [{ workflowId: run.workflowId }],
+      });
+    }
 
     const artifacts = await adapter.artifacts({
       q: "Platform systems lead",

--- a/apps/web/src/demo/DemoApiClientAdapter.ts
+++ b/apps/web/src/demo/DemoApiClientAdapter.ts
@@ -179,6 +179,7 @@ export class DemoApiClientAdapter implements ApiClientPort {
         event.message,
         event.title ?? "",
         event.company ?? "",
+        event.workflowId ?? "",
         event.jobKey ?? "",
         event.eventId,
         event.at,

--- a/apps/web/src/demo/DemoScenarioEngine.test.ts
+++ b/apps/web/src/demo/DemoScenarioEngine.test.ts
@@ -26,17 +26,32 @@ describe("DemoScenarioEngine", () => {
       status: "queued",
       jobKey: "job-fabrikam-systems",
     });
-    expect((await fixture.repository.snapshot()).state.readModel.runs.list.items[0]).toMatchObject({
+    let snapshot = await fixture.repository.snapshot();
+    expect(snapshot.state.readModel.runs.list.items[0]).toMatchObject({
       status: "starting",
     });
+    const workflowId = snapshot.state.readModel.runs.list.items[0]!.workflowId;
+    expect(
+      snapshot.state.readModel.dashboard.activity.items.filter(
+        (event) => event.workflowId === workflowId,
+      ),
+    ).toEqual([
+      expect.objectContaining({ eventType: "WorkflowQueued", workflowId }),
+    ]);
 
     await fixture.advance(150);
-    expect((await fixture.repository.snapshot()).state.readModel.jobs.details["job-fabrikam-systems"]!.stages).toContainEqual(
+    snapshot = await fixture.repository.snapshot();
+    expect(snapshot.state.readModel.jobs.details["job-fabrikam-systems"]!.stages).toContainEqual(
       expect.objectContaining({ stage: "score", state: "running" }),
     );
+    expect(
+      snapshot.state.readModel.dashboard.activity.items
+        .filter((event) => event.workflowId === workflowId)
+        .map((event) => event.eventType),
+    ).toEqual(["WorkflowStarted", "WorkflowQueued"]);
     await fixture.advance(550);
 
-    const snapshot = await fixture.repository.snapshot();
+    snapshot = await fixture.repository.snapshot();
     const job = snapshot.state.readModel.jobs.details["job-fabrikam-systems"]!.job;
     expect(job.scoreVersion).toBe(oldVersion + 1);
     expect(job.scoreStaleness).toMatchObject({ isStale: false, pendingExplicitRescore: false });
@@ -46,6 +61,19 @@ describe("DemoScenarioEngine", () => {
       version: job.scoreVersion,
     });
     expect(snapshot.state.readModel.runs.list.items[0]).toMatchObject({ status: "succeeded", result: "scored" });
+    const workflowActivity = snapshot.state.readModel.dashboard.activity.items.filter(
+      (event) => event.workflowId === workflowId,
+    );
+    expect(workflowActivity.map((event) => event.eventType)).toEqual([
+      "WorkflowCompleted",
+      "WorkflowStarted",
+      "WorkflowQueued",
+    ]);
+    expect(
+      workflowActivity.every(
+        (event) => snapshot.state.readModel.dashboard.activityEvents[event.eventId]?.event === event,
+      ),
+    ).toBe(true);
     fixture.dispose();
   });
 

--- a/apps/web/src/demo/DemoScenarioEngine.ts
+++ b/apps/web/src/demo/DemoScenarioEngine.ts
@@ -516,6 +516,14 @@ export class DemoScenarioEngine {
     });
     updateStageProjection(draft, pending, "queued", pending.requestedAt);
     appendRequestedEvents(pending, context, pending.requestedAt);
+    appendWorkflowActivity(
+      draft,
+      pending,
+      "WorkflowQueued",
+      "info",
+      pending.definition.queuedMessage,
+      pending.requestedAt,
+    );
   }
 
   private applyRunning(
@@ -553,6 +561,14 @@ export class DemoScenarioEngine {
       startedAt: now,
       temporalRunId: null,
     }, now);
+    appendWorkflowActivity(
+      draft,
+      pending,
+      "WorkflowStarted",
+      "info",
+      pending.definition.runningMessage,
+      now,
+    );
     if (pending.targetRefs.stage) {
       appendEvent(context, "StageStarted", {
         jobId: pending.targetRefs.jobKey ?? "pipeline",
@@ -630,6 +646,14 @@ export class DemoScenarioEngine {
           durationMs,
           temporalRunId: null,
         }, now);
+    appendWorkflowActivity(
+      draft,
+      pending,
+      failed ? "WorkflowFailed" : "WorkflowCompleted",
+      failed ? "error" : "info",
+      pending.definition.outcome.summary,
+      now,
+    );
     if (pending.targetRefs.stage) {
       appendEvent(context, failed ? "StageFailed" : "StageCompleted", failed
         ? {
@@ -736,6 +760,45 @@ export class DemoScenarioEngine {
       check();
     });
   }
+}
+
+function appendWorkflowActivity(
+  draft: DemoWorkspaceSnapshot,
+  pending: DemoScenarioInvocation,
+  eventType: "WorkflowQueued" | "WorkflowStarted" | "WorkflowCompleted" | "WorkflowFailed",
+  level: "info" | "error",
+  message: string,
+  at: string,
+): void {
+  const job = jobForInvocation(draft, pending);
+  const event = {
+    eventId: `activity-${pending.runId}-${eventType.toLowerCase()}`,
+    eventType,
+    workflowId: pending.runId,
+    jobKey: pending.targetRefs.jobKey,
+    title: job?.title ?? null,
+    company: job?.company ?? null,
+    stage: pending.targetRefs.stage ?? "workflow",
+    level,
+    message,
+    at,
+  };
+  const dashboard = draft.state.readModel.dashboard;
+  const activityEvents = dashboard.activityEvents as Mutable<
+    typeof dashboard.activityEvents
+  >;
+  if (activityEvents[event.eventId]) return;
+  dashboard.summary.activity.unshift(event);
+  dashboard.activity.items.unshift(event);
+  dashboard.activity.pagination.total = dashboard.activity.items.length;
+  dashboard.activity.pagination.pages = Math.max(
+    1,
+    Math.ceil(
+      dashboard.activity.pagination.total /
+        dashboard.activity.pagination.pageSize,
+    ),
+  );
+  activityEvents[event.eventId] = { ok: true, event };
 }
 
 function actionForTarget(

--- a/apps/web/src/demo/demo-seed.test.ts
+++ b/apps/web/src/demo/demo-seed.test.ts
@@ -24,7 +24,7 @@ describe("canonical public demo seed", () => {
 
   it("is deterministic, immutable by type, and covers the required lifecycle arms", () => {
     expect(() => assertDemoSeedInvariants(DEMO_SEED)).not.toThrow();
-    expect(demoSeedDigest(DEMO_SEED)).toBe("fnv1a-3e6d6ec9");
+    expect(demoSeedDigest(DEMO_SEED)).toBe("fnv1a-ab8210bc");
     expect(demoSeedDigest({ b: 2, a: ["seed", true] })).toBe(demoSeedDigest({ a: ["seed", true], b: 2 }));
   });
 

--- a/apps/web/src/demo/invariants.ts
+++ b/apps/web/src/demo/invariants.ts
@@ -279,6 +279,9 @@ function assertDemoReadModelInvariants(seed: DemoSeed): void {
   for (const run of runs) {
     const runId = readString(run, "runId", "workflow run");
     requireDetail(model.runs.details, runId, "workflow run", { envelope: false });
+    if (!activityItems.some((item) => asRecord(item, "activity item").workflowId === runId)) {
+      throw new TypeError(`Demo workflow run ${runId} is missing its reviewable activity.`);
+    }
     const jobId = readString(run, "jobKey", `workflow run ${runId}`);
     if (jobId && !jobIds.includes(jobId)) {
       throw new TypeError(`Demo workflow run ${runId} references a missing job.`);

--- a/apps/web/src/demo/portFactory.test.ts
+++ b/apps/web/src/demo/portFactory.test.ts
@@ -78,9 +78,6 @@ describe("port factory", () => {
     expect(direct.openInOs).toBeInstanceOf(OpenArtifactAdapter);
     expect(direct.telemetry).toBeInstanceOf(ConsoleTelemetryAdapter);
     expect(direct.featureFlags).toBeInstanceOf(StaticFeatureFlagAdapter);
-    expect(direct.featureFlags.get("activityDetailDirectLoad", false)).toBe(
-      false,
-    );
     expect(direct.featureFlags.get("demoMode", false)).toBe(false);
     expect(composition.ports.api).toBeInstanceOf(FetchApiClientAdapter);
   });
@@ -116,9 +113,6 @@ describe("port factory", () => {
       expect(composition.ports.featureFlags).toBeInstanceOf(
         DemoFeatureFlagAdapter,
       );
-      expect(
-        composition.ports.featureFlags.get("activityDetailDirectLoad", false),
-      ).toBe(true);
       expect(composition.ports.featureFlags.get("demoMode", false)).toBe(true);
       expect(composition.ports.telemetry).toBe(telemetry);
       expect(composition.ports.api).toBeInstanceOf(DemoApiClientAdapter);

--- a/apps/web/src/demo/ports.ts
+++ b/apps/web/src/demo/ports.ts
@@ -45,12 +45,6 @@ export class DemoFeatureFlagAdapter implements FeatureFlagPort {
     if (key === "demoMode" && typeof defaultValue === "boolean") {
       return true as T;
     }
-    if (
-      key === "activityDetailDirectLoad" &&
-      typeof defaultValue === "boolean"
-    ) {
-      return true as T;
-    }
     for (const operation of Object.keys(
       DEMO_CAPABILITY_MANIFEST,
     ) as (keyof typeof DEMO_CAPABILITY_MANIFEST)[]) {

--- a/apps/web/src/demo/purgeDemoJobProjections.test.ts
+++ b/apps/web/src/demo/purgeDemoJobProjections.test.ts
@@ -85,9 +85,18 @@ describe("purgeDemoJobProjections", () => {
       rejection: 1,
     });
 
-    expect(model.dashboard.summary.activity).toEqual([]);
-    expect(model.dashboard.activity.items).toEqual([]);
-    expect(model.dashboard.activityEvents).toEqual({});
+    expect(model.dashboard.summary.activity).toEqual(
+      model.dashboard.activity.items,
+    );
+    expect(model.dashboard.activity.items).toHaveLength(2);
+    expect(
+      model.dashboard.activity.items.every(
+        (event) => event.jobKey === "job-fabrikam-systems",
+      ),
+    ).toBe(true);
+    expect(Object.keys(model.dashboard.activityEvents)).toEqual(
+      model.dashboard.activity.items.map((event) => event.eventId),
+    );
     expect(model.dashboard.summary.progress).toEqual([]);
     expect(model.dashboard.summary.applyRuns).toEqual([]);
     expect(model.evidence.entries[0]?.requirementUsages).toEqual([]);

--- a/apps/web/src/demo/read-model.ts
+++ b/apps/web/src/demo/read-model.ts
@@ -141,14 +141,83 @@ const staleJob = {
 const activity = {
   eventId: "event-demo-score",
   eventType: "JobScored",
-  jobKey: job.jobKey,
-  title: job.title,
-  company: job.company,
+  workflowId: "run-score-succeeded",
+  jobKey: staleJob.jobKey,
+  title: staleJob.title,
+  company: staleJob.company,
   stage: "score",
   level: "info",
-  message: "Synthetic score recorded.",
-  at: at("2026-07-09T09:30:00.000Z"),
+  message: "Synthetic score completed.",
+  at: at("2026-07-10T07:31:00.000Z"),
 } satisfies DemoReadModel["dashboard"]["summary"]["activity"][number];
+
+const workflowActivities = [
+  {
+    eventId: "event-demo-materials-progress",
+    eventType: "WorkflowStarted",
+    workflowId: "run-materials-progress",
+    jobKey: job.jobKey,
+    title: job.title,
+    company: job.company,
+    stage: "tailor",
+    level: "info",
+    message: "Synthetic material review is in progress.",
+    at: at("2026-07-11T08:58:00.000Z"),
+  },
+  {
+    eventId: "event-demo-application-rehearsal",
+    eventType: "WorkflowCompleted",
+    workflowId: "run-application-rehearsal",
+    jobKey: job.jobKey,
+    title: job.title,
+    company: job.company,
+    stage: "apply",
+    level: "info",
+    message: "No application was submitted.",
+    at: at("2026-07-11T08:31:00.000Z"),
+  },
+  {
+    eventId: "event-demo-discovery-completed",
+    eventType: "WorkflowCompleted",
+    workflowId: "run-discovery-demo",
+    jobKey: job.jobKey,
+    title: job.title,
+    company: job.company,
+    stage: "discover",
+    level: "info",
+    message: "Synthetic discovery completed.",
+    at: at("2026-07-11T08:30:00.000Z"),
+  },
+  {
+    eventId: "event-demo-quality-gate-failed",
+    eventType: "WorkflowFailed",
+    workflowId: "run-failed-quality-gate",
+    jobKey: staleJob.jobKey,
+    title: staleJob.title,
+    company: staleJob.company,
+    stage: "score",
+    level: "error",
+    message: "The synthetic rescore quality gate requested a retry.",
+    at: at("2026-07-11T08:22:00.000Z"),
+  },
+  {
+    eventId: "event-demo-discovery-cancelled",
+    eventType: "WorkflowCanceled",
+    workflowId: "run-discovery-cancelled",
+    jobKey: job.jobKey,
+    title: job.title,
+    company: job.company,
+    stage: "discover",
+    level: "warning",
+    message: "Synthetic discovery cancelled.",
+    at: at("2026-07-11T08:02:00.000Z"),
+  },
+  activity,
+] satisfies DemoReadModel["dashboard"]["summary"]["activity"];
+
+const workflowActivityEvents = Object.fromEntries(
+  workflowActivities.map((event) => [event.eventId, { ok: true as const, event }]),
+) satisfies DemoReadModel["dashboard"]["activityEvents"];
 
 const funnel = {
   applied: 3,
@@ -415,7 +484,7 @@ export const DEMO_READ_MODEL = {
         bySource: [{ source: "bundled-capture", ...funnel }],
         byBand: [{ band: "strong", ...funnel }],
       },
-      activity: [activity],
+      activity: workflowActivities,
       progress: [
         {
           stage: "tailor",
@@ -508,14 +577,12 @@ export const DEMO_READ_MODEL = {
     },
     activity: {
       ok: true,
-      items: [activity],
-      pagination: { page: 1, pageSize: 50, total: 1, pages: 1 },
+      items: workflowActivities,
+      pagination: { page: 1, pageSize: 50, total: workflowActivities.length, pages: 1 },
       sort: { field: "at", dir: "desc" },
       filter: {},
     },
-    activityEvents: {
-      [activity.eventId]: { ok: true, event: activity },
-    },
+    activityEvents: workflowActivityEvents,
   },
   jobs: {
     list: {
@@ -1324,7 +1391,7 @@ export const DEMO_READ_MODEL = {
         durationMs: 120_000,
         events: [
           { eventType: "WorkflowStarted", occurredAt: at("2026-07-11T08:00:00.000Z"), status: "in_progress", message: "Synthetic discovery started." },
-          { eventType: "WorkflowCancelled", occurredAt: at("2026-07-11T08:02:00.000Z"), status: "canceled", message: "Synthetic discovery cancelled." },
+          { eventType: "WorkflowCanceled", occurredAt: at("2026-07-11T08:02:00.000Z"), status: "canceled", message: "Synthetic discovery cancelled." },
         ],
       },
       "run-discovery-demo": {

--- a/apps/web/src/routes/-list-detail-route-composition.test.tsx
+++ b/apps/web/src/routes/-list-detail-route-composition.test.tsx
@@ -105,4 +105,21 @@ describe("list and detail route composition", () => {
       screen.queryByRole("article", { name: "Job details" }),
     ).not.toBeInTheDocument();
   });
+
+  it("keeps a job-scoped activity route on event details with a separate job link", async () => {
+    renderRoute("/activity/evt-1");
+
+    expect(
+      await screen.findByRole("heading", {
+        level: 1,
+        name: "Job scored 8/10",
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "Open related job" }),
+    ).toHaveAttribute("href", "/jobs/job-1");
+    expect(
+      screen.queryByRole("article", { name: "Job details" }),
+    ).not.toBeInTheDocument();
+  });
 });

--- a/apps/web/src/routes/activity.$eventId.tsx
+++ b/apps/web/src/routes/activity.$eventId.tsx
@@ -1,28 +1,17 @@
-import { createFileRoute, redirect } from "@tanstack/react-router";
+import { createFileRoute } from "@tanstack/react-router";
 
 import { activityKeys } from "../contexts/operations/activityKeys.js";
 import { ActivityDetailDrawer } from "../views/debug/ActivityDetailDrawer.js";
 
 export const Route = createFileRoute("/activity/$eventId")({
   loader: async ({ params, context }): Promise<void> => {
-    const event = await context.queryClient.ensureQueryData({
+    await context.queryClient.ensureQueryData({
       queryKey: activityKeys.detail(context.tenantId, params.eventId),
       queryFn: async () => {
         const response = await context.ports.api.activityEvent(params.eventId);
         return response.event;
       },
     });
-    const directDetail = context.ports.featureFlags.get(
-      "activityDetailDirectLoad",
-      false,
-    );
-    if (event.jobKey && !directDetail) {
-      throw redirect({
-        to: "/jobs/$jobId",
-        params: { jobId: event.jobKey },
-        replace: true,
-      });
-    }
   },
   component: ActivityRoute,
 });

--- a/apps/web/src/test/fixtures/projections.ts
+++ b/apps/web/src/test/fixtures/projections.ts
@@ -1203,6 +1203,7 @@ export const sampleDashboardSummary: DashboardSummary = {
     {
       eventId: "evt-1",
       eventType: "JobScored",
+      workflowId: "run-pipeline-1",
       jobKey: "job-1",
       title: sampleJob.title,
       company: sampleJob.company,

--- a/apps/web/src/views/debug/ActivityDetailDrawer.test.tsx
+++ b/apps/web/src/views/debug/ActivityDetailDrawer.test.tsx
@@ -24,6 +24,9 @@ describe("<ActivityDetailDrawer>", () => {
       "href",
       "/jobs/job-1",
     );
+    expect(
+      screen.getByRole("link", { name: "Open related run" }),
+    ).toHaveAttribute("href", "/runs/run-pipeline-1");
 
     const inspector = screen.getByRole("complementary", {
       name: "Activity event facts",
@@ -36,7 +39,7 @@ describe("<ActivityDetailDrawer>", () => {
       "job-1",
       "Staff Software Engineer",
       "Acme Corp",
-      "Not exposed by the activity projection",
+      "run-pipeline-1",
     ]) {
       expect(within(inspector).getByText(fact)).toBeInTheDocument();
     }
@@ -49,6 +52,7 @@ describe("<ActivityDetailDrawer>", () => {
       name: "Projected event payload",
     });
     expect(payload).toHaveTextContent('"eventId": "evt-1"');
+    expect(payload).toHaveTextContent('"workflowId": "run-pipeline-1"');
     expect(payload).toHaveTextContent('"message": "Job scored 8/10"');
 
     const timeline = screen.getByRole("region", {

--- a/apps/web/src/views/debug/ActivityDetailDrawer.tsx
+++ b/apps/web/src/views/debug/ActivityDetailDrawer.tsx
@@ -79,18 +79,32 @@ export function ActivityDetailDrawer({ eventId }: ActivityDetailDrawerProps) {
                   {activity.company ? ` at ${activity.company}` : ""}
                 </p>
               </div>
-              {activity.jobKey ? (
+              {activity.jobKey || activity.workflowId ? (
                 <div className="activity-detail-workspace__actions">
-                  <Link
-                    className={buttonVariants({
-                      size: "sm",
-                      variant: "outline",
-                    })}
-                    to="/jobs/$jobId"
-                    params={{ jobId: activity.jobKey }}
-                  >
-                    Open related job
-                  </Link>
+                  {activity.jobKey ? (
+                    <Link
+                      className={buttonVariants({
+                        size: "sm",
+                        variant: "outline",
+                      })}
+                      to="/jobs/$jobId"
+                      params={{ jobId: activity.jobKey }}
+                    >
+                      Open related job
+                    </Link>
+                  ) : null}
+                  {activity.workflowId ? (
+                    <Link
+                      className={buttonVariants({
+                        size: "sm",
+                        variant: "outline",
+                      })}
+                      to="/runs/$runId"
+                      params={{ runId: activity.workflowId }}
+                    >
+                      Open related run
+                    </Link>
+                  ) : null}
                 </div>
               ) : null}
             </div>
@@ -144,7 +158,19 @@ export function ActivityDetailDrawer({ eventId }: ActivityDetailDrawerProps) {
                 />
                 <InspectorLedgerItem
                   label="Run reference"
-                  source="Not exposed by the activity projection"
+                  value={
+                    activity.workflowId ? (
+                      <Link
+                        aria-label={`Open run ${activity.workflowId}`}
+                        className="mono"
+                        params={{ runId: activity.workflowId }}
+                        to="/runs/$runId"
+                      >
+                        {activity.workflowId}
+                      </Link>
+                    ) : undefined
+                  }
+                  source="Activity projection"
                 />
               </InspectorLedger>
             </div>

--- a/apps/web/src/views/debug/DebugActivityTable.test.tsx
+++ b/apps/web/src/views/debug/DebugActivityTable.test.tsx
@@ -13,6 +13,7 @@ import { DebugActivityTable } from "./DebugActivityTable.js";
 const baseActivity: ActivityEventSummary = {
   eventId: "evt-0",
   eventType: "JobScored",
+  workflowId: null,
   jobKey: "job-1",
   title: "Staff Software Engineer",
   company: "Acme Corp",

--- a/apps/web/src/views/runs/WorkflowRunDrawer.test.tsx
+++ b/apps/web/src/views/runs/WorkflowRunDrawer.test.tsx
@@ -162,6 +162,57 @@ describe("<WorkflowRunDrawer>", () => {
     expect(within(details!).getByText("Cover letter")).toBeInTheDocument();
   });
 
+  it("identifies a job-scoped pipeline run and reviews activity by the exact workflow", async () => {
+    const workflowRun = vi.fn(async () =>
+      makeWorkflowRunDetail({
+        jobKey: "job-1",
+        title: "Staff Software Engineer",
+        company: "Acme Corp",
+        status: "in_progress",
+        errorCode: null,
+        errorMessage: null,
+        retryable: false,
+        inputSummary: { jobId: "job-1", stages: ["tailor", "cover"] },
+      }),
+    );
+    const harness = buildProviderHarness({
+      ports: buildTestPorts({ api: { workflowRun } }),
+    });
+    const router = buildRouter();
+    render(<RouterProvider router={router} />, { wrapper: harness.Wrapper });
+
+    const workspace = await screen.findByRole("article", {
+      name: "Workflow run details",
+    });
+    expect(
+      within(workspace).getByRole("heading", {
+        level: 1,
+        name: "Tailor → Cover letter run",
+      }),
+    ).toBeInTheDocument();
+    expect(
+      within(workspace).getByRole("link", {
+        name: "View job: Staff Software Engineer at Acme Corp",
+      }),
+    ).toHaveAttribute("href", "/jobs/job-1");
+    expect(
+      within(workspace).getByRole("link", {
+        name: "Open job Staff Software Engineer at Acme Corp",
+      }),
+    ).toHaveAttribute("href", "/jobs/job-1");
+    const activityLink = within(workspace).getByRole("link", {
+      name: "Review activity",
+    });
+    expect(activityLink).toHaveAttribute(
+      "href",
+      expect.stringContaining("q=run-pipeline-1"),
+    );
+    expect(activityLink).not.toHaveAttribute(
+      "href",
+      expect.stringContaining("q=job-1"),
+    );
+  });
+
   it("copies both run identities through the clipboard port", async () => {
     const user = userEvent.setup();
     const harness = buildProviderHarness();

--- a/apps/web/src/views/runs/WorkflowRunDrawer.tsx
+++ b/apps/web/src/views/runs/WorkflowRunDrawer.tsx
@@ -53,6 +53,11 @@ function workflowTitle(run: WorkflowRunDetail): string {
   return title === run.workflowType ? humanizeIdentifier(title) : title;
 }
 
+function runJobLabel(run: WorkflowRunDetail): string {
+  const title = run.title || run.jobKey;
+  return run.company ? `${title} at ${run.company}` : title;
+}
+
 const PIPELINE_STAGE_LABELS: Readonly<Record<string, string>> = {
   discover: "Discover",
   enrich: "Enrich",
@@ -218,7 +223,7 @@ function RunActions({ run }: { readonly run: WorkflowRunDetail }) {
           level: "",
           page: 1,
           pageSize: 50,
-          q: run.jobKey || run.workflowId,
+          q: run.workflowId,
           sort: "occurred_at",
           stage: "",
         }}
@@ -278,8 +283,14 @@ function RunMetadata({ run }: { readonly run: WorkflowRunDetail }) {
           <div>
             <dt data-typography="label">Job</dt>
             <dd data-typography="body">
-              {run.title || run.jobKey}
-              {run.company ? ` · ${run.company}` : ""}
+              <Link
+                aria-label={`Open job ${runJobLabel(run)}`}
+                params={{ jobId: run.jobKey }}
+                to="/jobs/$jobId"
+              >
+                {run.title || run.jobKey}
+                {run.company ? ` · ${run.company}` : ""}
+              </Link>
             </dd>
           </div>
         ) : null}
@@ -467,6 +478,17 @@ export function WorkflowRunDrawer({ runId }: WorkflowRunDrawerProps) {
                 <div className="workflow-run-workspace__title">
                   <small data-typography="metadata">Workflow run</small>
                   <h1 data-typography="page-title">{workflowTitle(run)}</h1>
+                  {run.jobKey ? (
+                    <p data-typography="body">
+                      <Link
+                        aria-label={`View job: ${runJobLabel(run)}`}
+                        params={{ jobId: run.jobKey }}
+                        to="/jobs/$jobId"
+                      >
+                        {runJobLabel(run)}
+                      </Link>
+                    </p>
+                  ) : null}
                   <p data-typography="body">
                     {run.dryRun ? "Dry run" : "Live"} · Started{" "}
                     {formatDateTime(run.startedAt)}

--- a/docs/api/complete-contract.md
+++ b/docs/api/complete-contract.md
@@ -1376,11 +1376,15 @@ a JSON-RPC error response.)
 
 `GET /v1/dashboard/summary` includes a bounded recent `activity[]` slice with
 `activity[].eventType` so the web app can render started, completed, and failed
-stage states from backend events instead of local button state alone. The
+stage states from backend events instead of local button state alone.
+`activity[].workflowId` is nullable and comes from canonical workflow ownership
+in the event payload; it is not inferred from the job. The
 Dashboard renders a bounded subset of those events alongside active runs from
 the unified `/v1/workflow-runs` read model. The top-level Debug tab uses
 `GET /v1/debug/activity` for the full activity log as a paginated, sortable
-table; this keeps Dashboard lightweight without imposing an event-history cap.
+table; its free-text `q` filter also searches the canonical workflow ID. This
+keeps Dashboard lightweight without imposing an event-history cap and lets a
+run link to its exact activity stream.
 
 ## Settings And Credentials
 

--- a/docs/api/operations-and-events.md
+++ b/docs/api/operations-and-events.md
@@ -194,6 +194,11 @@ vocabulary, ordered lifecycle timeline, terminal-state interpretation, and
 cancellation boundary. Product views may present different workflow details,
 but they do not maintain separate run-state rules.
 
+When a `JobPreparationWorkflow` or `JobPipelineWorkflow` input contains one
+canonical `jobId`, the list and detail responses resolve `jobKey`, `title`, and
+`company` from the tenant-scoped job projection. The Runs workspace keeps the
+workflow as the page identity and exposes that related job as a separate link.
+
 The list accepts an exact `workflowType`, inclusive UTC `startedSince`, and
 exclusive UTC `startedBefore` in addition to status, sorting, and pagination.
 Filtering happens after lifecycle folding and before pagination, so restarted
@@ -217,6 +222,18 @@ outside JobCtrl are backfilled from Temporal's requester identity (for example,
 after the dev namespace retention window has purged that execution, the audit
 uses the distinct `recovered_temporal_history` evidence kind and says so in the
 timeline; it is never presented as a fresh history read or a JobCtrl request.
+
+## Debug Activity
+
+`GET /v1/debug/activity` and `GET /v1/debug/activity/:eventId` expose a nullable
+`workflowId` derived from the canonical event payload. Free-text `q` search
+includes that workflow ID, so a run's **Review activity** action returns the
+events for that exact workflow instead of broad job history or an empty result.
+
+The activity detail route always preserves the selected event as its page
+identity. When the projection has related job or workflow identity, the page
+renders explicit **Open related job** and **Open related run** links; activating
+an event row never silently replaces the event view with a job redirect.
 
 ## Health And JSON-RPC
 

--- a/docs/api/operations-and-events.md
+++ b/docs/api/operations-and-events.md
@@ -229,6 +229,11 @@ timeline; it is never presented as a fresh history read or a JobCtrl request.
 `workflowId` derived from the canonical event payload. Free-text `q` search
 includes that workflow ID, so a run's **Review activity** action returns the
 events for that exact workflow instead of broad job history or an empty result.
+Worker stage runners stamp that ownership at the source: pipeline-level stage
+events and per-job stage events recorded while a Temporal run executes carry
+the run's canonical workflow ID in their payload, across the activity's
+blocking executor and per-stage thread fan-out. Events recorded outside a run
+(CLI one-offs) carry no workflow ID and stay job-scoped only.
 
 The activity detail route always preserves the selected event as its page
 identity. When the projection has related job or workflow identity, the page

--- a/packages/contracts/src/schemas.ts
+++ b/packages/contracts/src/schemas.ts
@@ -3096,6 +3096,8 @@ export interface PaginatedResponse<T> {
 export interface ActivityEventSummary {
   eventId: string;
   eventType: string;
+  /** Canonical workflow id when the event payload carries run ownership. */
+  workflowId: string | null;
   jobKey: string | null;
   title: string | null;
   company: string | null;

--- a/workers/automation/src/jobctrl/infrastructure/temporal/run_in_activity.py
+++ b/workers/automation/src/jobctrl/infrastructure/temporal/run_in_activity.py
@@ -32,6 +32,8 @@ from typing import Callable, TypeVar
 
 from temporalio import activity
 
+from jobctrl.infrastructure.workflow_run_context import carry_workflow_run_context
+
 _T = TypeVar("_T")
 log = logging.getLogger(__name__)
 _ACTIVITY_EXECUTOR: ThreadPoolExecutor | None = None
@@ -153,7 +155,10 @@ async def run_blocking_with_heartbeat(
     activity.heartbeat(starting_message)
     loop = asyncio.get_running_loop()
     blocking_executor = _activity_executor()
-    task = loop.run_in_executor(blocking_executor, fn)
+    # ``run_in_executor`` does not carry this coroutine's context into the
+    # worker thread, so bind the owning workflow id explicitly. Durable events
+    # recorded by the blocking stage runner then keep canonical run ownership.
+    task = loop.run_in_executor(blocking_executor, carry_workflow_run_context(fn))
     activity_label = activity_name or activity.info().activity_type
     try:
         while True:

--- a/workers/automation/src/jobctrl/infrastructure/workflow_run_context.py
+++ b/workers/automation/src/jobctrl/infrastructure/workflow_run_context.py
@@ -1,0 +1,87 @@
+"""Ambient canonical workflow ownership for events emitted during a run.
+
+The workflow-run read model, the activity log, and the run drawer's
+"Review activity" query all identify a Temporal run by its canonical
+``workflow_id``. Worker code that persists durable events (``record_job_event``)
+runs far below the activity boundary — in the blocking executor thread and in
+per-stage fan-out threads — where ``temporalio.activity.info()`` is not
+available. This module carries the owning workflow id across those thread
+hops so every event emitted while a run is executing can be stamped with its
+canonical run ownership.
+
+Resolution order for :func:`current_workflow_id`:
+
+1. an explicit binding made with :func:`workflow_run_context` (set when work
+   crosses a thread boundary), then
+2. the enclosing Temporal activity context, when the caller is still on a
+   thread that has one.
+
+Outside any Temporal run both sources are empty and the helpers are no-ops,
+so CLI one-offs and unit tests keep their existing event payloads.
+"""
+
+from __future__ import annotations
+
+import contextvars
+from contextlib import contextmanager
+from typing import Callable, Iterator, TypeVar
+
+_T = TypeVar("_T")
+
+_WORKFLOW_ID: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "jobctrl_workflow_run_context",
+    default=None,
+)
+
+
+def current_workflow_id() -> str | None:
+    """Canonical Temporal workflow id owning the current work, if any."""
+    bound = _WORKFLOW_ID.get()
+    if bound:
+        return bound
+    try:
+        from temporalio import activity
+
+        info = activity.info()
+    except Exception:  # noqa: BLE001 — no activity context on this thread
+        return None
+    workflow_id = getattr(info, "workflow_id", None)
+    return str(workflow_id) if workflow_id else None
+
+
+@contextmanager
+def workflow_run_context(workflow_id: str | None) -> Iterator[None]:
+    """Bind ``workflow_id`` as the owning run for the enclosed work."""
+    if not workflow_id:
+        yield
+        return
+    token = _WORKFLOW_ID.set(str(workflow_id))
+    try:
+        yield
+    finally:
+        _WORKFLOW_ID.reset(token)
+
+
+def carry_workflow_run_context(fn: Callable[..., _T]) -> Callable[..., _T]:
+    """Bind the caller's resolved workflow id into work run on other threads.
+
+    The id is resolved once, on the calling thread (which may still have the
+    Temporal activity context). The returned callable re-binds it wherever it
+    executes, so executor fan-out keeps the owning run of the submitting
+    activity. Safe to share across pool threads: the binding is scoped to each
+    invocation's thread context.
+    """
+    workflow_id = current_workflow_id()
+
+    def bound(*args: object, **kwargs: object) -> _T:
+        with workflow_run_context(workflow_id):
+            return fn(*args, **kwargs)
+
+    return bound
+
+
+__all__ = [
+    "carry_workflow_run_context",
+    "current_workflow_id",
+    "workflow_run_context",
+]

--- a/workers/automation/src/jobctrl/materials/activities.py
+++ b/workers/automation/src/jobctrl/materials/activities.py
@@ -694,6 +694,11 @@ def _run_selected_material_jobs(
         return results
 
     ensure_active()
+    # Pool threads lose the activity's run context; re-bind it so per-job
+    # stage events emitted inside the material runners keep run ownership.
+    from jobctrl.infrastructure.workflow_run_context import carry_workflow_run_context
+
+    run_one_owned = carry_workflow_run_context(run_one)
     executor = ThreadPoolExecutor(
         max_workers=worker_count,
         thread_name_prefix=f"selected-{stage}",
@@ -708,7 +713,7 @@ def _run_selected_material_jobs(
             ensure_active()
             job_id = job_ids[next_index]
             next_index += 1
-            in_flight[executor.submit(run_one, job_id)] = job_id
+            in_flight[executor.submit(run_one_owned, job_id)] = job_id
 
     try:
         fill_worker_slots()

--- a/workers/automation/src/jobctrl/pipeline/runner.py
+++ b/workers/automation/src/jobctrl/pipeline/runner.py
@@ -49,6 +49,7 @@ from jobctrl.infrastructure.enrichment.execution_lease import (
 from jobctrl.infrastructure.discovery.sqlite_run_repository import (
     SqliteDiscoveryRunRepository,
 )
+from jobctrl.infrastructure.workflow_run_context import current_workflow_id
 from jobctrl.infrastructure.discovery.production_wiring import (
     enqueue_manual_action_for_sources,
     retire_invalid_source_jobs,
@@ -67,7 +68,6 @@ log = logging.getLogger(__name__)
 console = Console()
 
 _PIPELINE_JOB_ID = "pipeline"
-_PIPELINE_RUN_CONTEXT = threading.local()
 
 
 # ---------------------------------------------------------------------------
@@ -97,8 +97,12 @@ def _pipeline_tracer():
 
 
 def _current_workflow_id() -> str | None:
-    value = getattr(_PIPELINE_RUN_CONTEXT, "workflow_id", None)
-    return value if isinstance(value, str) and value else None
+    """Canonical workflow id owning this stage execution, if any.
+
+    Resolved through :mod:`jobctrl.infrastructure.workflow_run_context`, which
+    ``run_blocking_with_heartbeat`` binds from the enclosing Temporal activity.
+    """
+    return current_workflow_id()
 
 
 def _record_pipeline_event(

--- a/workers/automation/src/jobctrl/scoring/activities.py
+++ b/workers/automation/src/jobctrl/scoring/activities.py
@@ -247,8 +247,15 @@ def _run_selected_scores(
     if worker_count == 1 or len(job_ids) <= 1:
         results = [score_one(job_id) for job_id in job_ids]
     else:
+        # Pool threads lose the activity's run context; re-bind it so per-job
+        # stage events emitted inside ``score_job_by_id`` keep run ownership.
+        from jobctrl.infrastructure.workflow_run_context import (
+            carry_workflow_run_context,
+        )
+
+        score_one_owned = carry_workflow_run_context(score_one)
         with ThreadPoolExecutor(max_workers=worker_count) as executor:
-            futures = [executor.submit(score_one, job_id) for job_id in job_ids]
+            futures = [executor.submit(score_one_owned, job_id) for job_id in job_ids]
             results = [future.result() for future in as_completed(futures)]
 
     for job_id, outcome in results:

--- a/workers/automation/src/jobctrl/scoring/tailor.py
+++ b/workers/automation/src/jobctrl/scoring/tailor.py
@@ -620,11 +620,16 @@ def run_tailoring(
             message="Tailoring started",
         )
 
+    # Pool threads lose the activity's run context; re-bind it so events the
+    # per-job tailoring worker records keep run ownership.
+    from jobctrl.infrastructure.workflow_run_context import carry_workflow_run_context
+
+    tailor_one_owned = carry_workflow_run_context(_tailor_one_job)
     future_to_job: dict = {}
     with ThreadPoolExecutor(max_workers=worker_count) as executor:
         for job in jobs:
             future = executor.submit(
-                _tailor_one_job,
+                tailor_one_owned,
                 job,
                 "",  # legacy resume_text param — unused
                 snapshot,

--- a/workers/automation/src/jobctrl/state.py
+++ b/workers/automation/src/jobctrl/state.py
@@ -29,6 +29,7 @@ from jobctrl.domain.scoring.eligibility import (
 from jobctrl.domain.scoring.value_objects import EligibilityAssessment
 from jobctrl.domain.tenant import LOCAL_TENANT, TenantId
 from jobctrl.domain.pipeline_types import deserialize_stage_state_kind
+from jobctrl.infrastructure.workflow_run_context import current_workflow_id
 
 log = logging.getLogger(__name__)
 
@@ -1223,6 +1224,14 @@ def record_job_event(
     )
     if stable_job_id is not None:
         current_payload["jobId"] = str(stable_job_id)
+    # Stamp canonical run ownership so run-scoped activity review can find the
+    # per-job and pipeline-stage events a workflow actually produced. Callers
+    # that already declare ownership (Workflow* lifecycle events, discovery
+    # runs) keep their explicit value.
+    if "workflowId" not in current_payload and "workflow_id" not in current_payload:
+        ambient_workflow_id = current_workflow_id()
+        if ambient_workflow_id:
+            current_payload["workflowId"] = ambient_workflow_id
     ts = occurred_at or utc_now()
     cursor = conn.execute(
         """

--- a/workers/automation/tests/test_v7_score_runtime.py
+++ b/workers/automation/tests/test_v7_score_runtime.py
@@ -375,6 +375,44 @@ def test_score_by_id_rejects_url_shaped_identity_before_llm(
     assert llm.calls == 0
 
 
+def test_score_stage_events_carry_owning_workflow_id_under_a_run(
+    conn: sqlite3.Connection,
+) -> None:
+    """Per-job stage events emitted during a pipeline run carry the workflow id.
+
+    Regression for run-scoped activity review (PR #764): the run drawer's
+    "Review activity" queries by the exact canonical workflow id, so scoring
+    events produced under a run must stamp that ownership into their payload.
+    """
+    from jobctrl.infrastructure.workflow_run_context import workflow_run_context
+
+    _seed_target(conn, tenant_id=_TENANT_A, job_id=_JOB_ID_A)
+
+    with workflow_run_context("pipeline-run-ownership-regression"):
+        outcome = _score_by_id(
+            conn,
+            tenant_id=_TENANT_A,
+            job_id=_JOB_ID_A,
+            llm=_StrongLlm(),
+        )
+
+    assert outcome.ok is True
+    rows = conn.execute(
+        """
+        SELECT event_type, json_extract(payload_json, '$.workflowId') AS workflow_id
+        FROM job_events
+        WHERE tenant_id = ? AND job_id = ? AND stage = 'score'
+          AND event_type IN ('StageStarted', 'StageCompleted')
+        ORDER BY event_id
+        """,
+        (str(_TENANT_A), str(_JOB_ID_A)),
+    ).fetchall()
+    assert [(row["event_type"], row["workflow_id"]) for row in rows] == [
+        ("StageStarted", "pipeline-run-ownership-regression"),
+        ("StageCompleted", "pipeline-run-ownership-regression"),
+    ]
+
+
 def test_employer_analysis_event_preserves_tenant_and_job_id(
     conn: sqlite3.Connection,
 ) -> None:

--- a/workers/automation/tests/test_workflow_run_context.py
+++ b/workers/automation/tests/test_workflow_run_context.py
@@ -1,0 +1,139 @@
+"""Canonical run ownership on events emitted during Temporal-run work.
+
+Regression coverage for the run-drawer "Review activity" invariant: events a
+workflow run actually produces must carry that run's canonical ``workflowId``
+in their payload, across the activity's blocking executor hop and per-stage
+thread fan-out.
+"""
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+import dataclasses
+from pathlib import Path
+
+import pytest
+from temporalio.testing import ActivityEnvironment
+
+from jobctrl.database import init_db
+from jobctrl.infrastructure.temporal.run_in_activity import run_blocking_with_heartbeat
+from jobctrl.infrastructure.workflow_run_context import (
+    carry_workflow_run_context,
+    current_workflow_id,
+    workflow_run_context,
+)
+from jobctrl.state import record_job_event
+
+
+class _NullPublisher:
+    def publish(self, _event) -> None:  # noqa: ANN001 — matches EventPublisher port
+        return None
+
+
+def _event_payload_workflow_ids(conn) -> list[tuple[str, str | None]]:
+    rows = conn.execute(
+        """
+        SELECT event_type, json_extract(payload_json, '$.workflowId') AS workflow_id
+        FROM job_events
+        ORDER BY event_id
+        """
+    ).fetchall()
+    return [(row["event_type"], row["workflow_id"]) for row in rows]
+
+
+def test_current_workflow_id_is_none_outside_any_run() -> None:
+    assert current_workflow_id() is None
+
+
+def test_workflow_run_context_binds_and_restores() -> None:
+    with workflow_run_context("pipeline-outer"):
+        assert current_workflow_id() == "pipeline-outer"
+        with workflow_run_context("pipeline-inner"):
+            assert current_workflow_id() == "pipeline-inner"
+        assert current_workflow_id() == "pipeline-outer"
+    assert current_workflow_id() is None
+
+
+def test_carry_workflow_run_context_rebinds_in_pool_threads() -> None:
+    with workflow_run_context("pipeline-fanout-wf"):
+        probe = carry_workflow_run_context(current_workflow_id)
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        # Fresh pool threads have no ambient context of their own.
+        assert executor.submit(current_workflow_id).result() is None
+        # The wrapper carries the submitting activity's owning run across.
+        assert executor.submit(probe).result() == "pipeline-fanout-wf"
+
+
+def test_record_job_event_stamps_ambient_run_ownership(tmp_path: Path) -> None:
+    conn = init_db(tmp_path / "run-context.db")
+    publisher = _NullPublisher()
+    with workflow_run_context("pipeline-run-owner"):
+        record_job_event(
+            conn,
+            None,
+            "score",
+            "StageStarted",
+            message="score stage started",
+            publisher=publisher,
+        )
+        record_job_event(
+            conn,
+            None,
+            "score",
+            "StageCompleted",
+            message="explicit ownership wins",
+            payload={"workflowId": "explicit-owner"},
+            publisher=publisher,
+        )
+        record_job_event(
+            conn,
+            None,
+            "score",
+            "StageFailed",
+            message="snake-case ownership is respected",
+            payload={"workflow_id": "explicit-snake-owner"},
+            publisher=publisher,
+        )
+    record_job_event(
+        conn,
+        None,
+        "score",
+        "StageProgress",
+        message="outside any run",
+        publisher=publisher,
+    )
+    conn.commit()
+
+    assert _event_payload_workflow_ids(conn) == [
+        ("StageStarted", "pipeline-run-owner"),
+        ("StageCompleted", "explicit-owner"),
+        ("StageFailed", None),
+        ("StageProgress", None),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_run_blocking_with_heartbeat_carries_the_owning_workflow_id() -> None:
+    env = ActivityEnvironment()
+    env.info = dataclasses.replace(env.info, workflow_id="pipeline-blocking-wf")
+
+    async def probe() -> tuple[str | None, str | None]:
+        blocking = await run_blocking_with_heartbeat(
+            current_workflow_id,
+            starting_message="ownership probe starting",
+            activity_name="ownership_probe",
+        )
+
+        def fanout() -> str | None:
+            owned = carry_workflow_run_context(current_workflow_id)
+            with ThreadPoolExecutor(max_workers=1) as executor:
+                return executor.submit(owned).result()
+
+        nested = await run_blocking_with_heartbeat(
+            fanout,
+            starting_message="fanout probe starting",
+            activity_name="ownership_fanout_probe",
+        )
+        return blocking, nested
+
+    assert await env.run(probe) == ("pipeline-blocking-wf", "pipeline-blocking-wf")


### PR DESCRIPTION
## Summary

- resolve canonical job context for single-job preparation and pipeline workflow runs, then expose linked job identity on run details
- search and inspect activity by canonical workflow ID so Review activity returns the owning run events
- preserve event-detail navigation for job-scoped rows and provide explicit related job and run links
- keep seeded and dynamically created demo runs aligned with the same inspectable activity invariant

## Why

Run details previously discarded the JobPipelineWorkflow job ID, activity search ignored workflow ownership, and job-scoped Debug rows bypassed event details. Together those gaps made run ownership unclear and could make Review activity appear empty.

## Validation

- API unit suite: 55 files, 751 tests passed
- Web unit suite: 324 files, 2,007 tests passed
- Focused dynamic demo lifecycle and purge suites: 45 tests passed
- API and web typechecks passed
- Web production build and docs build passed
- Live read-only product QA passed for linked job context, exact workflow activity filtering, and event-first navigation
- Independent reviewer and QA gates passed with zero findings

## Stack

Depends on #763.