### PR TITLE
fix(ci): stop API schema seeding from timing out its hook

### DIFF
--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -1,12 +1,18 @@
 name: TypeScript CI
 
-# The TypeScript suite reads real files from outside apps/ and packages/:
-# `workers/**` supplies schema_v7.sql, schema_manifest.py, and config.py to the
-# cross-runtime parity and schema-guard tests, and `scripts/**` supplies the
-# install script executed by the install contract test. Both lists must stay in
-# sync and must keep those directories, or a change that breaks TypeScript CI
-# could merge without ever running it. No `branches` filter on `pull_request`:
-# stacked PRs target their parent branch, not main.
+# `push` is filtered to the files this suite actually reads. Beyond apps/ and
+# packages/, `workers/**` supplies schema_v7.sql, schema_manifest.py, and
+# config.py to the cross-runtime parity and schema-guard tests, and `scripts/**`
+# supplies the install script the install contract test executes. A push that
+# changed either without those entries would skip the suite covering it.
+#
+# `pull_request` deliberately takes no filter at all — no `branches`, no
+# `paths`. Every layer of a GitHub stack must instantiate this workflow so it
+# produces a check record for that layer; a filtered-out workflow reports
+# nothing rather than reporting a skip. Cost is controlled at the job level
+# instead, by the `if:` below that admits only a trusted cumulative head, which
+# is the pattern GitHub documents for stacked pull requests. Enforced by
+# scripts/stacked-ci-workflows.test.mjs — do not add a filter here.
 on:
   push:
     branches: ["main"]
@@ -20,15 +26,6 @@ on:
       - "pnpm-workspace.yaml"
       - ".github/workflows/typescript.yml"
   pull_request:
-    paths:
-      - "apps/**"
-      - "packages/**"
-      - "workers/**"
-      - "scripts/**"
-      - "pnpm-lock.yaml"
-      - "package.json"
-      - "pnpm-workspace.yaml"
-      - ".github/workflows/typescript.yml"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -1,16 +1,34 @@
 name: TypeScript CI
 
+# The TypeScript suite reads real files from outside apps/ and packages/:
+# `workers/**` supplies schema_v7.sql, schema_manifest.py, and config.py to the
+# cross-runtime parity and schema-guard tests, and `scripts/**` supplies the
+# install script executed by the install contract test. Both lists must stay in
+# sync and must keep those directories, or a change that breaks TypeScript CI
+# could merge without ever running it. No `branches` filter on `pull_request`:
+# stacked PRs target their parent branch, not main.
 on:
   push:
     branches: ["main"]
     paths:
       - "apps/**"
       - "packages/**"
+      - "workers/**"
+      - "scripts/**"
       - "pnpm-lock.yaml"
       - "package.json"
       - "pnpm-workspace.yaml"
       - ".github/workflows/typescript.yml"
   pull_request:
+    paths:
+      - "apps/**"
+      - "packages/**"
+      - "workers/**"
+      - "scripts/**"
+      - "pnpm-lock.yaml"
+      - "package.json"
+      - "pnpm-workspace.yaml"
+      - ".github/workflows/typescript.yml"
   workflow_dispatch:
 
 jobs:

--- a/apps/api/test/typescript-ci-workflow-contract.test.ts
+++ b/apps/api/test/typescript-ci-workflow-contract.test.ts
@@ -40,7 +40,15 @@ describe("TypeScript CI trigger contract", () => {
 
   it("leaves pull requests entirely unfiltered", () => {
     const block = onBlock();
-    const pullRequest = block.slice(block.indexOf("\n  pull_request:"));
+    const triggerStart = block.indexOf("\n  pull_request:");
+
+    // Deleting the trigger outright is the strongest violation of this
+    // invariant — the workflow would stop instantiating for pull requests
+    // altogether — so an absent trigger must fail here, not pass vacuously
+    // (indexOf would return -1, slicing the block's last character, and
+    // triggerPaths would report an absent trigger as "no filter").
+    expect(triggerStart).toBeGreaterThanOrEqual(0);
+    const pullRequest = block.slice(triggerStart);
 
     // Every layer of a GitHub stack must instantiate this workflow so that layer
     // gets a check record; a filtered-out workflow reports nothing at all rather

--- a/apps/api/test/typescript-ci-workflow-contract.test.ts
+++ b/apps/api/test/typescript-ci-workflow-contract.test.ts
@@ -4,6 +4,79 @@ import { describe, expect, it } from "vitest";
 
 const workflowPath = new URL("../../../.github/workflows/typescript.yml", import.meta.url);
 
+/**
+ * Collects the `paths` filter of a single `on:` trigger without a YAML parser,
+ * which `apps/api` does not depend on. Returns an empty list when the trigger is
+ * absent or carries no filter, so a bare `pull_request:` fails the contract.
+ */
+function triggerPaths(onBlock: string, trigger: string): string[] {
+  const triggerStart = onBlock.indexOf(`\n  ${trigger}:`);
+  if (triggerStart < 0) {
+    return [];
+  }
+  const rest = onBlock.slice(triggerStart + 1);
+  const nextTrigger = rest.slice(1).search(/\n {2}\S/);
+  const section = nextTrigger === -1 ? rest : rest.slice(0, nextTrigger + 1);
+  const pathsStart = section.indexOf("\n    paths:");
+  if (pathsStart < 0) {
+    return [];
+  }
+  const entries: string[] = [];
+  for (const line of section.slice(pathsStart + 1).split("\n").slice(1)) {
+    const entry = /^ {6}- "(.+)"$/.exec(line)?.[1];
+    if (entry === undefined) {
+      break;
+    }
+    entries.push(entry);
+  }
+  return entries;
+}
+
+describe("TypeScript CI trigger contract", () => {
+  const onBlock = () => {
+    const workflow = readFileSync(workflowPath, "utf8");
+    return workflow.slice(workflow.indexOf("\non:"), workflow.indexOf("\njobs:"));
+  };
+
+  it("filters pull requests to the same paths as pushes", () => {
+    const block = onBlock();
+    const pullRequestPaths = triggerPaths(block, "pull_request");
+
+    // A bare `pull_request:` trigger ran the full suite - Playwright E2E and
+    // Storybook included - on documentation-only pull requests, exposing them to
+    // failures they could not have caused.
+    expect(pullRequestPaths).not.toHaveLength(0);
+    expect(pullRequestPaths).toEqual(triggerPaths(block, "push"));
+  });
+
+  it("runs whenever a file the suite reads can change", () => {
+    const pullRequestPaths = triggerPaths(onBlock(), "pull_request");
+
+    // `workers/**` supplies schema_v7.sql, schema_manifest.py, and config.py to
+    // the cross-runtime parity and schema-guard tests; `scripts/**` supplies the
+    // install script the install contract test executes. Dropping either would
+    // let a change that breaks this suite merge without ever running it.
+    for (const required of [
+      "apps/**",
+      "packages/**",
+      "workers/**",
+      "scripts/**",
+      ".github/workflows/typescript.yml",
+    ]) {
+      expect(pullRequestPaths).toContain(required);
+    }
+  });
+
+  it("does not restrict pull requests to a base branch", () => {
+    const block = onBlock();
+    const pullRequest = block.slice(block.indexOf("\n  pull_request:"));
+
+    // Stacked pull requests target their parent branch rather than main, so a
+    // `branches` filter here would silently skip every stacked layer.
+    expect(pullRequest).not.toContain("branches:");
+  });
+});
+
 describe("TypeScript CI browser provisioning contract", () => {
   it("installs the Python Playwright Chromium revision before browser E2E", () => {
     const workflow = readFileSync(workflowPath, "utf8");

--- a/apps/api/test/typescript-ci-workflow-contract.test.ts
+++ b/apps/api/test/typescript-ci-workflow-contract.test.ts
@@ -7,7 +7,7 @@ const workflowPath = new URL("../../../.github/workflows/typescript.yml", import
 /**
  * Collects the `paths` filter of a single `on:` trigger without a YAML parser,
  * which `apps/api` does not depend on. Returns an empty list when the trigger is
- * absent or carries no filter, so a bare `pull_request:` fails the contract.
+ * absent or carries no filter.
  */
 function triggerPaths(onBlock: string, trigger: string): string[] {
   const triggerStart = onBlock.indexOf(`\n  ${trigger}:`);
@@ -38,24 +38,28 @@ describe("TypeScript CI trigger contract", () => {
     return workflow.slice(workflow.indexOf("\non:"), workflow.indexOf("\njobs:"));
   };
 
-  it("filters pull requests to the same paths as pushes", () => {
+  it("leaves pull requests entirely unfiltered", () => {
     const block = onBlock();
-    const pullRequestPaths = triggerPaths(block, "pull_request");
+    const pullRequest = block.slice(block.indexOf("\n  pull_request:"));
 
-    // A bare `pull_request:` trigger ran the full suite - Playwright E2E and
-    // Storybook included - on documentation-only pull requests, exposing them to
-    // failures they could not have caused.
-    expect(pullRequestPaths).not.toHaveLength(0);
-    expect(pullRequestPaths).toEqual(triggerPaths(block, "push"));
+    // Every layer of a GitHub stack must instantiate this workflow so that layer
+    // gets a check record; a filtered-out workflow reports nothing at all rather
+    // than reporting a skip. Cost belongs at the job level, on the trusted
+    // cumulative-head `if:`, which is the pattern GitHub documents for stacks.
+    // scripts/stacked-ci-workflows.test.mjs asserts the same invariant by
+    // parsing the YAML; this keeps it visible to the suite that owns the file.
+    expect(pullRequest).not.toContain("branches:");
+    expect(triggerPaths(block, "pull_request")).toHaveLength(0);
   });
 
-  it("runs whenever a file the suite reads can change", () => {
-    const pullRequestPaths = triggerPaths(onBlock(), "pull_request");
+  it("pushes run whenever a file the suite reads can change", () => {
+    const pushPaths = triggerPaths(onBlock(), "push");
 
     // `workers/**` supplies schema_v7.sql, schema_manifest.py, and config.py to
     // the cross-runtime parity and schema-guard tests; `scripts/**` supplies the
-    // install script the install contract test executes. Dropping either would
-    // let a change that breaks this suite merge without ever running it.
+    // install script the install contract test executes. Both sit outside apps/
+    // and packages/, so without them a push that breaks this suite would land on
+    // main without ever running it.
     for (const required of [
       "apps/**",
       "packages/**",
@@ -63,17 +67,8 @@ describe("TypeScript CI trigger contract", () => {
       "scripts/**",
       ".github/workflows/typescript.yml",
     ]) {
-      expect(pullRequestPaths).toContain(required);
+      expect(pushPaths).toContain(required);
     }
-  });
-
-  it("does not restrict pull requests to a base branch", () => {
-    const block = onBlock();
-    const pullRequest = block.slice(block.indexOf("\n  pull_request:"));
-
-    // Stacked pull requests target their parent branch rather than main, so a
-    // `branches` filter here would silently skip every stacked layer.
-    expect(pullRequest).not.toContain("branches:");
   });
 });
 

--- a/apps/api/test/v7-schema.ts
+++ b/apps/api/test/v7-schema.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -6,15 +7,39 @@ import Database from "better-sqlite3";
 
 import { SUPPORTED_SCHEMA_VERSION } from "../src/db.js";
 
-export function initializeExactV7Database(dbPath: string): void {
-  const schemaPath = fileURLToPath(
-    new URL(
-      "../../../workers/automation/src/jobctrl/infrastructure/migrations/schema_v7.sql",
-      import.meta.url,
-    ),
-  );
-  const db = new Database(dbPath);
+const schemaPath = fileURLToPath(
+  new URL(
+    "../../../workers/automation/src/jobctrl/infrastructure/migrations/schema_v7.sql",
+    import.meta.url,
+  ),
+);
+
+// schema_v7.sql is pure DDL (110 tables, 108 indexes, 24 triggers, no seed rows
+// and no PRAGMAs), and the seeding hooks across this suite call it once per
+// test. Re-executing it every time made those hooks the slowest thing in CI and
+// pushed them past Vitest's hook deadline on loaded runners. Build it once per
+// worker process and copy the closed file instead: with no PRAGMAs the database
+// is a single self-contained file, so the copy is byte-identical to a fresh
+// build, `user_version` included.
+let templatePath: string | undefined;
+
+function schemaTemplate(): string {
+  if (templatePath !== undefined) {
+    return templatePath;
+  }
+  const templateDir = fs.mkdtempSync(path.join(os.tmpdir(), "jobctrl-v7-schema-"));
+  const template = path.join(templateDir, "schema-v7.db");
+  const db = new Database(template);
   db.exec(fs.readFileSync(path.resolve(schemaPath), "utf8"));
   db.pragma(`user_version = ${SUPPORTED_SCHEMA_VERSION}`);
   db.close();
+  process.on("exit", () => {
+    fs.rmSync(templateDir, { force: true, recursive: true });
+  });
+  templatePath = template;
+  return template;
+}
+
+export function initializeExactV7Database(dbPath: string): void {
+  fs.copyFileSync(schemaTemplate(), dbPath);
 }

--- a/apps/api/vitest.config.ts
+++ b/apps/api/vitest.config.ts
@@ -3,5 +3,9 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     testTimeout: 15_000,
+    // Seeding hooks do real filesystem and SQLite work, so they must not carry a
+    // tighter deadline than the tests they set up. Vitest defaults hookTimeout to
+    // 10s, which made `beforeEach` the first thing to fail on a loaded CI runner.
+    hookTimeout: 15_000,
   },
 });


### PR DESCRIPTION
## What changed

- `apps/api/test/v7-schema.ts` — build the exact-v7 database **once per worker process** and copy the closed file, instead of re-executing 2,651 lines of DDL on every seeding call.
- `apps/api/vitest.config.ts` — `hookTimeout: 15_000`, matching the existing `testTimeout`.
- `.github/workflows/typescript.yml` — add `workers/**` and `scripts/**` to the **`push`** path filter only.
- `apps/api/test/typescript-ci-workflow-contract.test.ts` — two trigger tests.

## Why: the #749 failure

#749 deletes only markdown, and TypeScript CI failed on it. Re-running the identical SHA passed — 55/55 in 92s wall / 210s tests, against 679s / 1571s for the failure. A 7.5× runner swing on unchanged code.

The `beforeEach` in `apps/api/test/server.test.ts:117` re-executed the full `schema_v7.sql` — 110 tables, 108 indexes, 24 triggers — once per test, across 30 test files. Vitest defaults `hookTimeout` to 10s while this project sets `testTimeout` to 15s, so the setup hook carried a *tighter* deadline than the tests it existed to set up, and it was the first thing to blow on a loaded runner.

`schema_v7.sql` is pure DDL: no seed rows, no PRAGMAs. So the built database is a single self-contained file and a byte copy is indistinguishable from a fresh build, `user_version` included. Building it once and copying takes the local full-suite run from **174.38s to 33.72s** of test time (~72ms saved per hook). Reaching the 10s hook deadline now requires roughly a 140× slowdown rather than a 7.5× one.

Measurement note: I never instrumented the hook directly. The defensible number is that controlled local A/B, not a per-hook profile.

## Correction: the trigger scoping in this PR was wrong

The first commit on this branch added a `paths:` filter to `pull_request`. **That was a mistake and the third commit reverts it.**

`scripts/stacked-ci-workflows.test.mjs:44` requires `typescript.yml` to have `on.pull_request == null`, and PR #644 deleted precisely this filter after #640 introduced it. [GitHub's stacked-pull-request documentation](https://docs.github.com/en/pull-requests/how-tos/merge-and-close-pull-requests/optimizing-ci-for-stacked-pull-requests) gives the reason: a workflow must instantiate for **every** layer of a stack so each layer produces a check record, and cost is meant to be gated on a job-level `if:` over `stack.position` — not on the trigger. A filtered-out workflow reports *nothing*, where a job-gated one reports a skip.

CI did not catch this here, only because `launcher.yml`'s own path filter does not match this changeset. Running `node --test scripts/stacked-ci-workflows.test.mjs` on the pre-revert commit fails assertion 1; it passes now.

**The `push` filter additions are kept**, because they are a real and separate gap that the stacked-PR contract does not constrain. `workers/**` supplies `schema_v7.sql`, `schema_manifest.py`, and `config.py` to the cross-runtime parity and schema-guard tests; `scripts/**` supplies the install script the install contract test executes. Both sit outside `apps/` and `packages/`, so a push touching either skipped the suite covering it.

## Validation

- `pnpm --filter @jobctrl/api check` → clean.
- `pnpm --filter @jobctrl/api test` → **55 files, 742 tests passed**, 9.40s wall / 41.46s tests.
- `node --test scripts/stacked-ci-workflows.test.mjs` → 4 passed, 0 failed.
- `git diff --check` clean.
- **Three mutation tests** against the committed baseline, each firing its own assertion: adding a `paths` filter to `pull_request`, adding `branches:` to `pull_request`, and dropping `workers/**` from the `push` list.

Per session instruction, no `reviewer` subagent gate was run.