### PR TITLE
fix(ci): run Python CI on pushes that touch the files its suite reads

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,14 +1,31 @@
 name: Python CI
 
+# The Python suite reads real files from outside workers/ and scripts/:
+# `packages/**` holds the shared cross-runtime parity fixtures and the
+# domain-event sources, `packaging/**` holds provider-packs.lock.json and
+# capability-policy.json, and the release-scan tests read workflow files under
+# `.github/workflows/**`. Both lists must stay in sync and must keep those
+# directories, or a change that breaks Python CI could merge without ever
+# running it. No `branches` filter on `pull_request`: stacked PRs target their
+# parent branch, not main.
 on:
   push:
     branches: ["main"]
     paths:
       - "workers/**"
       - "scripts/**"
+      - "packages/**"
+      - "packaging/**"
       - "pyproject.toml"
-      - ".github/workflows/python.yml"
+      - ".github/workflows/**"
   pull_request:
+    paths:
+      - "workers/**"
+      - "scripts/**"
+      - "packages/**"
+      - "packaging/**"
+      - "pyproject.toml"
+      - ".github/workflows/**"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -3,7 +3,10 @@ name: Python CI
 # `push` is filtered to the files this suite actually reads. Beyond workers/ and
 # scripts/, `packages/**` holds the shared cross-runtime parity fixtures and the
 # domain-event sources, `packaging/**` holds provider-packs.lock.json and
-# capability-policy.json, and the release-scan tests read workflow files under
+# capability-policy.json, the INV-1 no-send-transport guard
+# (test_outreach_no_send_transport.py) scans the TypeScript outreach sources
+# under apps/, the byline/attribution tests read root package.json, README.md,
+# LICENSE, and NOTICE, and the release-scan tests read workflow files under
 # `.github/workflows/**`. A push that changed any of those without these entries
 # would skip the suite covering it.
 #
@@ -22,6 +25,13 @@ on:
       - "scripts/**"
       - "packages/**"
       - "packaging/**"
+      - "apps/web/src/contexts/outreach/**"
+      - "apps/web/src/views/outreach/**"
+      - "apps/api/src/outreach.ts"
+      - "package.json"
+      - "README.md"
+      - "LICENSE"
+      - "NOTICE"
       - "pyproject.toml"
       - ".github/workflows/**"
   pull_request:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,13 +1,19 @@
 name: Python CI
 
-# The Python suite reads real files from outside workers/ and scripts/:
-# `packages/**` holds the shared cross-runtime parity fixtures and the
+# `push` is filtered to the files this suite actually reads. Beyond workers/ and
+# scripts/, `packages/**` holds the shared cross-runtime parity fixtures and the
 # domain-event sources, `packaging/**` holds provider-packs.lock.json and
 # capability-policy.json, and the release-scan tests read workflow files under
-# `.github/workflows/**`. Both lists must stay in sync and must keep those
-# directories, or a change that breaks Python CI could merge without ever
-# running it. No `branches` filter on `pull_request`: stacked PRs target their
-# parent branch, not main.
+# `.github/workflows/**`. A push that changed any of those without these entries
+# would skip the suite covering it.
+#
+# `pull_request` deliberately takes no filter at all — no `branches`, no
+# `paths`. Every layer of a GitHub stack must instantiate this workflow so it
+# produces a check record for that layer; a filtered-out workflow reports
+# nothing rather than reporting a skip. Cost is controlled at the job level
+# instead, by the `if:` below that admits only a trusted cumulative head, which
+# is the pattern GitHub documents for stacked pull requests. Enforced by
+# scripts/stacked-ci-workflows.test.mjs — do not add a filter here.
 on:
   push:
     branches: ["main"]
@@ -19,13 +25,6 @@ on:
       - "pyproject.toml"
       - ".github/workflows/**"
   pull_request:
-    paths:
-      - "workers/**"
-      - "scripts/**"
-      - "packages/**"
-      - "packaging/**"
-      - "pyproject.toml"
-      - ".github/workflows/**"
   workflow_dispatch:
 
 jobs:

--- a/scripts/check-python-workflow-contract.mjs
+++ b/scripts/check-python-workflow-contract.mjs
@@ -1,66 +1,71 @@
 import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
 import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
 
-const workflow = await readFile(new URL("../.github/workflows/python.yml", import.meta.url), "utf8");
+const workflowPath = fileURLToPath(new URL("../.github/workflows/python.yml", import.meta.url));
+const workflow = await readFile(workflowPath, "utf8");
 
-const onBlock = workflow.slice(workflow.indexOf("\non:"), workflow.indexOf("\njobs:"));
-
-/**
- * Collects the `paths` filter of a single `on:` trigger. Returns an empty list
- * when the trigger is absent or carries no filter, so a bare `pull_request:`
- * fails the contract.
- */
-function triggerPaths(trigger) {
-  const triggerStart = onBlock.indexOf(`\n  ${trigger}:`);
-  if (triggerStart < 0) {
-    return [];
-  }
-  const rest = onBlock.slice(triggerStart + 1);
-  const nextTrigger = rest.slice(1).search(/\n {2}\S/);
-  const section = nextTrigger === -1 ? rest : rest.slice(0, nextTrigger + 1);
-  const pathsStart = section.indexOf("\n    paths:");
-  if (pathsStart < 0) {
-    return [];
-  }
-  const entries = [];
-  for (const line of section.slice(pathsStart + 1).split("\n").slice(1)) {
-    const entry = /^ {6}- "(.+)"$/.exec(line)?.[1];
-    if (entry === undefined) {
-      break;
-    }
-    entries.push(entry);
-  }
-  return entries;
-}
+// Parse the real YAML the same way scripts/stacked-ci-workflows.test.mjs does
+// (Ruby ships on the hosted runners; this step installs no Node dependencies),
+// so the trigger contract holds for what GitHub will actually evaluate rather
+// than for one canonical spelling. A string match false-passes on flow-style
+// lists, unquoted entries, or reordered keys.
+const execFileAsync = promisify(execFile);
+const rubyYamlToJson = String.raw`
+document = YAML.safe_load(
+  File.read(ARGV.fetch(0)),
+  permitted_classes: [],
+  permitted_symbols: [],
+  aliases: false,
+)
+events = document.delete("on") || document.delete(true)
+document["on"] = events
+puts JSON.generate(document)
+`;
+const { stdout } = await execFileAsync(
+  "ruby",
+  ["-ryaml", "-rjson", "-e", rubyYamlToJson, workflowPath],
+  { maxBuffer: 1024 * 1024 },
+);
+const parsed = JSON.parse(stdout);
 
 // Every layer of a GitHub stack must instantiate this workflow so that layer
 // gets a check record; a filtered-out workflow reports nothing at all rather
 // than reporting a skip. Cost belongs on the job-level trusted-cumulative-head
 // `if:`, which is the pattern GitHub documents for stacks.
-// scripts/stacked-ci-workflows.test.mjs asserts the same invariant by parsing
-// the YAML; this keeps it enforced by the workflow's own contract step too.
+// scripts/stacked-ci-workflows.test.mjs asserts the same invariant; this keeps
+// it enforced by the workflow's own contract step too. A bare `pull_request:`
+// parses to null; a missing trigger or any filter (`branches`, `paths`,
+// `types`, ...) parses to something else and fails.
 assert.equal(
-  triggerPaths("pull_request").length,
-  0,
-  "Python CI must not filter pull requests by path; every stack layer needs a check record.",
-);
-assert.doesNotMatch(
-  onBlock.slice(onBlock.indexOf("\n  pull_request:")),
-  /branches:/,
-  "Python CI must not restrict pull requests to a base branch.",
+  parsed.on.pull_request,
+  null,
+  "Python CI must trigger on every pull request, with no branches or paths filter; every stack layer needs a check record.",
 );
 
 // `packages/**` holds the shared cross-runtime parity fixtures and the
 // domain-event sources; `packaging/**` holds provider-packs.lock.json and
-// capability-policy.json; the release-scan tests read workflow files. All sit
-// outside workers/ and scripts/, so dropping any of them would let a push that
-// breaks Python CI land on main without ever running it.
-const pushPaths = triggerPaths("push");
+// capability-policy.json; the apps/ entries are the outreach sources scanned by
+// the INV-1 no-send-transport guard; package.json, README.md, LICENSE, and
+// NOTICE feed the byline/attribution tests; the release-scan tests read
+// workflow files. All sit outside workers/ and scripts/, so dropping any of
+// them would let a push that breaks Python CI land on main without ever
+// running it.
+const pushPaths = parsed.on.push?.paths ?? [];
 for (const required of [
   "workers/**",
   "scripts/**",
   "packages/**",
   "packaging/**",
+  "apps/web/src/contexts/outreach/**",
+  "apps/web/src/views/outreach/**",
+  "apps/api/src/outreach.ts",
+  "package.json",
+  "README.md",
+  "LICENSE",
+  "NOTICE",
   ".github/workflows/**",
 ]) {
   assert.ok(

--- a/scripts/check-python-workflow-contract.mjs
+++ b/scripts/check-python-workflow-contract.mjs
@@ -2,6 +2,76 @@ import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 
 const workflow = await readFile(new URL("../.github/workflows/python.yml", import.meta.url), "utf8");
+
+const onBlock = workflow.slice(workflow.indexOf("\non:"), workflow.indexOf("\njobs:"));
+
+/**
+ * Collects the `paths` filter of a single `on:` trigger. Returns an empty list
+ * when the trigger is absent or carries no filter, so a bare `pull_request:`
+ * fails the contract.
+ */
+function triggerPaths(trigger) {
+  const triggerStart = onBlock.indexOf(`\n  ${trigger}:`);
+  if (triggerStart < 0) {
+    return [];
+  }
+  const rest = onBlock.slice(triggerStart + 1);
+  const nextTrigger = rest.slice(1).search(/\n {2}\S/);
+  const section = nextTrigger === -1 ? rest : rest.slice(0, nextTrigger + 1);
+  const pathsStart = section.indexOf("\n    paths:");
+  if (pathsStart < 0) {
+    return [];
+  }
+  const entries = [];
+  for (const line of section.slice(pathsStart + 1).split("\n").slice(1)) {
+    const entry = /^ {6}- "(.+)"$/.exec(line)?.[1];
+    if (entry === undefined) {
+      break;
+    }
+    entries.push(entry);
+  }
+  return entries;
+}
+
+const pullRequestPaths = triggerPaths("pull_request");
+
+// A bare `pull_request:` trigger ran all three matrix lanes on every pull
+// request, including ones that changed no Python at all.
+assert.ok(
+  pullRequestPaths.length > 0,
+  "Python CI must filter pull requests by path, not run on every pull request.",
+);
+assert.deepEqual(
+  pullRequestPaths,
+  triggerPaths("push"),
+  "Python CI must filter pull requests and pushes by the same paths.",
+);
+
+// `packages/**` holds the shared cross-runtime parity fixtures and the
+// domain-event sources; `packaging/**` holds provider-packs.lock.json and
+// capability-policy.json; the release-scan tests read workflow files. Dropping
+// any of these would let a change that breaks Python CI merge without running it.
+for (const required of [
+  "workers/**",
+  "scripts/**",
+  "packages/**",
+  "packaging/**",
+  ".github/workflows/**",
+]) {
+  assert.ok(
+    pullRequestPaths.includes(required),
+    `Python CI must run when ${required} changes; the suite reads files from it.`,
+  );
+}
+
+// Stacked pull requests target their parent branch rather than main, so a
+// `branches` filter here would silently skip every stacked layer.
+assert.doesNotMatch(
+  onBlock.slice(onBlock.indexOf("\n  pull_request:")),
+  /branches:/,
+  "Python CI must not restrict pull requests to a base branch; stacked PRs target their parent.",
+);
+
 assert.doesNotMatch(
   workflow,
   /(?:Install LaTeX|texlive-)/,

--- a/scripts/check-python-workflow-contract.mjs
+++ b/scripts/check-python-workflow-contract.mjs
@@ -33,24 +33,29 @@ function triggerPaths(trigger) {
   return entries;
 }
 
-const pullRequestPaths = triggerPaths("pull_request");
-
-// A bare `pull_request:` trigger ran all three matrix lanes on every pull
-// request, including ones that changed no Python at all.
-assert.ok(
-  pullRequestPaths.length > 0,
-  "Python CI must filter pull requests by path, not run on every pull request.",
+// Every layer of a GitHub stack must instantiate this workflow so that layer
+// gets a check record; a filtered-out workflow reports nothing at all rather
+// than reporting a skip. Cost belongs on the job-level trusted-cumulative-head
+// `if:`, which is the pattern GitHub documents for stacks.
+// scripts/stacked-ci-workflows.test.mjs asserts the same invariant by parsing
+// the YAML; this keeps it enforced by the workflow's own contract step too.
+assert.equal(
+  triggerPaths("pull_request").length,
+  0,
+  "Python CI must not filter pull requests by path; every stack layer needs a check record.",
 );
-assert.deepEqual(
-  pullRequestPaths,
-  triggerPaths("push"),
-  "Python CI must filter pull requests and pushes by the same paths.",
+assert.doesNotMatch(
+  onBlock.slice(onBlock.indexOf("\n  pull_request:")),
+  /branches:/,
+  "Python CI must not restrict pull requests to a base branch.",
 );
 
 // `packages/**` holds the shared cross-runtime parity fixtures and the
 // domain-event sources; `packaging/**` holds provider-packs.lock.json and
-// capability-policy.json; the release-scan tests read workflow files. Dropping
-// any of these would let a change that breaks Python CI merge without running it.
+// capability-policy.json; the release-scan tests read workflow files. All sit
+// outside workers/ and scripts/, so dropping any of them would let a push that
+// breaks Python CI land on main without ever running it.
+const pushPaths = triggerPaths("push");
 for (const required of [
   "workers/**",
   "scripts/**",
@@ -59,18 +64,10 @@ for (const required of [
   ".github/workflows/**",
 ]) {
   assert.ok(
-    pullRequestPaths.includes(required),
-    `Python CI must run when ${required} changes; the suite reads files from it.`,
+    pushPaths.includes(required),
+    `Python CI must run when a push changes ${required}; the suite reads files from it.`,
   );
 }
-
-// Stacked pull requests target their parent branch rather than main, so a
-// `branches` filter here would silently skip every stacked layer.
-assert.doesNotMatch(
-  onBlock.slice(onBlock.indexOf("\n  pull_request:")),
-  /branches:/,
-  "Python CI must not restrict pull requests to a base branch; stacked PRs target their parent.",
-);
 
 assert.doesNotMatch(
   workflow,


### PR DESCRIPTION
## What changed

- `.github/workflows/python.yml` — add `packages/**`, `packaging/**`, `.github/workflows/**`, the outreach sources scanned by the INV-1 guard (`apps/web/src/contexts/outreach/**`, `apps/web/src/views/outreach/**`, `apps/api/src/outreach.ts`), and root `package.json`, `README.md`, `LICENSE`, `NOTICE` to the **`push`** path filter. `pull_request` stays completely unfiltered.
- `scripts/check-python-workflow-contract.mjs` — parse the workflow as real YAML (Ruby `YAML.safe_load`, the same mechanism as `scripts/stacked-ci-workflows.test.mjs`; python.yml's contract step installs no Node dependencies, so js-yaml is not an option there) and assert `on.pull_request` is exactly `null` — no `branches`, no `paths`, in any YAML spelling — plus assert the `push` list covers every directory and file the suite reads.

## Why

The Python suite reads real files from outside `workers/` and `scripts/`, and the `push` filter did not list them:

| Path | Read by |
| --- | --- |
| `packages/**` | 11 parity tests resolve `packages/domain-types/test/fixtures/…` via `parents[3]`; `test_domain_event_parity.py:22` reads `packages/domain-types/src/events` |
| `packaging/**` | `test_provider_packs.py:145,446` reads `provider-packs.lock.json`; `test_doctor_playwright.py:23` reads `capability-policy.json` |
| `.github/workflows/**` | `test_release_check.py:1195` reads `release-check.yml` |
| `apps/web/src/contexts/outreach/**`, `apps/web/src/views/outreach/**`, `apps/api/src/outreach.ts` | `test_outreach_no_send_transport.py:22-31` scans these sources for transport-shaped symbols — the only cross-runtime source-level INV-1 enforcement |
| `package.json`, `README.md` (root) | `test_release_check.py:20-30` reads both through `release_check.ROOT` |
| `LICENSE`, `NOTICE` | `test_python_package_attribution.py:18-19` reads both verbatim |

A push to `main` touching only one of these could break the suite — or, for the outreach paths, land an INV-1 violation — without Python CI ever running.

**Correction (review follow-up):** an earlier revision of this description claimed `apps/**` was "deliberately excluded" because `test_release_check.py:189,196` only passes `apps/web/public/demo/*.pdf` paths to `scan_name()` as strings. That statement was true of `test_release_check.py` but the audit behind it was incomplete: `test_outreach_no_send_transport.py` does read apps outreach sources. The three outreach paths are now in the filter; the rest of `apps/**` remains excluded because nothing else in the suite reads it.

## Correction: the trigger scoping in the first commit was wrong

The first commit also applied this list to `pull_request`. **That was a mistake and the second commit reverts it.**

`scripts/stacked-ci-workflows.test.mjs:44` requires `python.yml` to have `on.pull_request == null`, and PR #644 deleted precisely this filter after #640 introduced it. [GitHub's stacked-pull-request documentation](https://docs.github.com/en/pull-requests/how-tos/merge-and-close-pull-requests/optimizing-ci-for-stacked-pull-requests) gives the reason: a workflow must instantiate for **every** layer of a stack so each layer produces a check record, and cost is meant to be gated on a job-level `if:` over `stack.position` — not on the trigger. A filtered-out workflow reports *nothing*, where a job-gated one reports a skip.

CI caught it: `Darwin launcher (vet + race)` → `not ok 122 - stacked pull requests always instantiate the Python and TypeScript admission workflows`. It now passes.

`push` filters are unconstrained by that contract, so the genuine gap above is still fixed.

## Correction: the first contract check was format-dependent (review follow-up)

The initial `triggerPaths` helper string-matched one canonical spelling (`\n    paths:` + six-space quoted entries). Flow-style `paths: ["workers/**"]` or unquoted block entries under `pull_request:` parsed as zero entries and false-passed, even though GitHub would honor the filter — and this script is the sole PR-time guard for python.yml-only changes (launcher.yml's filter does not match them). The third commit replaces the string matching with a real YAML parse and a strict `on.pull_request === null` assertion, which also fails when the trigger is absent entirely.

## Validation

- `node scripts/check-python-workflow-contract.mjs` → exit 0.
- `node --test scripts/stacked-ci-workflows.test.mjs` → 4 passed, 0 failed.
- `python3 scripts/release_check.py` → `Release check passed.`
- Ruby `YAML.safe_load` diff of the workflow before/after the third commit: `pull_request` and `workflow_dispatch` still `null`, `push.branches` unchanged, `push.paths` gained exactly the 7 new entries, all jobs byte-identical.
- `git diff --check` clean.
- **Eight mutation tests** against the contract check, each run on a sandboxed copy: flow-style `paths` under `pull_request` → fail; unquoted block `paths` under `pull_request` → fail; canonical quoted `paths` under `pull_request` → fail; `pull_request` trigger absent → fail; `branches:` under `pull_request` → fail; dropping `apps/api/src/outreach.ts` from the `push` list → fail; unmutated baseline → pass; `push.paths` rewritten flow-style with the same entries → pass.

Per session instruction, no `reviewer` subagent gate was run.
