### PR TITLE
ci: build the docs site only when the published site can change

### DIFF
--- a/.github/workflows/docs-site.yml
+++ b/.github/workflows/docs-site.yml
@@ -1,19 +1,32 @@
 name: Docs Site
 
+# This workflow exists to build the published site and gate its dead links, so
+# it should run exactly when the published site can change. The directories
+# negated below are listed in the `srcExclude` of docs/.vitepress/config.ts:
+# VitePress never builds a page from them, links into them are rewritten to
+# absolute GitHub URLs, and check-docs-site-links.mjs only walks the emitted
+# dist and skips absolute URLs. Nothing under them can reach the artifact, so
+# building for them is pure cost. Both lists must stay in sync, and the
+# negations must stay in step with `srcExclude` — the workflow contract check
+# below enforces both. No `branches` filter on `pull_request`: stacked PRs
+# target their parent branch, not main, and would otherwise skip this gate.
 on:
   push:
     branches: ["main"]
     paths:
       - "docs/**"
+      - "!docs/plans/**"
+      - "!docs/incidents/**"
       - "package.json"
       - "pnpm-lock.yaml"
       - "scripts/check-install-asset.mjs"
       - "scripts/get"
       - ".github/workflows/docs-site.yml"
   pull_request:
-    branches: ["main"]
     paths:
       - "docs/**"
+      - "!docs/plans/**"
+      - "!docs/incidents/**"
       - "package.json"
       - "pnpm-lock.yaml"
       - "scripts/check-install-asset.mjs"
@@ -45,6 +58,9 @@ jobs:
         with:
           node-version: "20.19"
           cache: pnpm
+
+      - name: Validate docs workflow contract
+        run: node scripts/check-docs-workflow-contract.mjs
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/scripts/check-docs-workflow-contract.mjs
+++ b/scripts/check-docs-workflow-contract.mjs
@@ -1,0 +1,85 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const workflow = await readFile(new URL("../.github/workflows/docs-site.yml", import.meta.url), "utf8");
+const config = await readFile(new URL("../docs/.vitepress/config.ts", import.meta.url), "utf8");
+
+const onBlock = workflow.slice(workflow.indexOf("\non:"), workflow.indexOf("\npermissions:"));
+
+/**
+ * Collects the `paths` filter of a single `on:` trigger. Returns an empty list
+ * when the trigger is absent or carries no filter, so a bare `pull_request:`
+ * fails the contract.
+ */
+function triggerPaths(trigger) {
+  const triggerStart = onBlock.indexOf(`\n  ${trigger}:`);
+  if (triggerStart < 0) {
+    return [];
+  }
+  const rest = onBlock.slice(triggerStart + 1);
+  const nextTrigger = rest.slice(1).search(/\n {2}\S/);
+  const section = nextTrigger === -1 ? rest : rest.slice(0, nextTrigger + 1);
+  const pathsStart = section.indexOf("\n    paths:");
+  if (pathsStart < 0) {
+    return [];
+  }
+  const entries = [];
+  for (const line of section.slice(pathsStart + 1).split("\n").slice(1)) {
+    const entry = /^ {6}- "(.+)"$/.exec(line)?.[1];
+    if (entry === undefined) {
+      break;
+    }
+    entries.push(entry);
+  }
+  return entries;
+}
+
+const pullRequestPaths = triggerPaths("pull_request");
+
+// A bare `pull_request:` trigger would build the site for every pull request,
+// including ones that change no documentation at all.
+assert.ok(
+  pullRequestPaths.length > 0,
+  "Docs Site must filter pull requests by path, not run on every pull request.",
+);
+assert.deepEqual(
+  pullRequestPaths,
+  triggerPaths("push"),
+  "Docs Site must filter pull requests and pushes by the same paths.",
+);
+
+// Dropping `docs/**` would leave the published site with no dead-link gate.
+assert.ok(
+  pullRequestPaths.includes("docs/**"),
+  "Docs Site must run when docs/** changes; that is the tree it builds.",
+);
+
+// The excluded directories must be exactly the directories VitePress refuses to
+// build. Excluding a directory the site *does* publish would ship dead links;
+// leaving a never-published directory in the trigger burns CI on an artifact it
+// cannot change. Either drift breaks this equality.
+const srcExclude = config.slice(
+  config.indexOf("srcExclude: ["),
+  config.indexOf("]", config.indexOf("srcExclude: [")),
+);
+assert.ok(srcExclude.startsWith("srcExclude: ["), "docs/.vitepress/config.ts must declare srcExclude.");
+
+const unpublishedDirs = [...srcExclude.matchAll(/"([^"]+\/\*\*)"/g)].map((match) => `!docs/${match[1]}`);
+assert.ok(unpublishedDirs.length > 0, "srcExclude must list at least one unpublished directory.");
+assert.deepEqual(
+  pullRequestPaths.filter((entry) => entry.startsWith("!")).sort(),
+  [...unpublishedDirs].sort(),
+  "Docs Site must exclude exactly the directories srcExclude keeps out of the built site.",
+);
+
+// Stacked pull requests target their parent branch rather than main, so a
+// `branches` filter here would silently skip every stacked layer.
+assert.doesNotMatch(
+  onBlock.slice(onBlock.indexOf("\n  pull_request:")),
+  /branches:/,
+  "Docs Site must not restrict pull requests to a base branch; stacked PRs target their parent.",
+);
+
+console.log(
+  `docs workflow contract passed: ${pullRequestPaths.length} path filters, ${unpublishedDirs.length} unpublished directories excluded.`,
+);


### PR DESCRIPTION
## What changed

`.github/workflows/docs-site.yml`:

- Negated `docs/plans/**` and `docs/incidents/**` in the `push` and `pull_request` path filters.
- Removed `branches: ["main"]` from `pull_request`.
- Added a `Validate docs workflow contract` step running the new `scripts/check-docs-workflow-contract.mjs`.

## Why: the excluded directories cannot affect the artifact this workflow gates

Both are listed in the `srcExclude` of `docs/.vitepress/config.ts:365`, so VitePress never builds a page from them. Links from published docs into them are rewritten to absolute GitHub URLs by `rewriteEscapingLink`, and the post-build gate `scripts/check-docs-site-links.mjs` walks only the emitted `dist` and skips absolute URLs (`SKIP = /^(?:[a-z][a-z0-9+.-]*:|#)/i`).

So a change under `docs/plans/**` triggered a full `pnpm install` + VitePress build + dead-link gate that had nothing new to check. `docs/plans/` alone is 46 markdown files and the most frequently edited tree under `docs/`.

## Why the `branches` filter goes

This is the smaller half of the change and the evidence for it is weaker, so stating it plainly: [GitHub's documentation](https://docs.github.com/en/pull-requests/how-tos/merge-and-close-pull-requests/optimizing-ci-for-stacked-pull-requests) says each PR in a stack "is treated as if it targets the base of the stack", which would make `branches: ["main"]` match every layer and this removal a no-op. I did observe stacked #741 receiving no run from either workflow that carries a `branches` filter, but for `docs-site` that is fully explained by its `paths` filter, so it is not evidence.

The removal is kept because it is a strict widening with no downside, and because it aligns this workflow with the five that already carry no `branches` filter and with the direction #644 took. The `deploy` job keeps its own `github.ref == 'refs/heads/main'` guard, so deployment is unaffected.

## The contract check

Path filters rot silently: a wrong one produces no failure, it produces a *missing run*. `scripts/check-docs-workflow-contract.mjs` (same shape as `scripts/check-python-workflow-contract.mjs`) asserts:

1. `pull_request` carries a non-empty `paths` filter.
2. The `push` and `pull_request` lists are identical.
3. `docs/**` is still present.
4. `pull_request` carries no `branches` filter.
5. The negated directories equal **exactly** the directories `srcExclude` keeps out of the site.

Assertion 5 catches drift both ways: publishing `plans/` without re-enabling its builds fails, and excluding a directory the site still ships fails. Because `docs/.vitepress/config.ts` matches `docs/**` and is not negated, any change to `srcExclude` triggers this workflow and runs the check.

Note this workflow is *not* one of the two admission workflows constrained by `scripts/stacked-ci-workflows.test.mjs` (which covers only `python` and `typescript` and requires `on.pull_request == null` for them). `docs-site` is a build gate, not a per-layer admission record, so a `paths` filter is appropriate here. Verified: that contract passes on this branch.

## Validation

- `node scripts/check-docs-workflow-contract.mjs` → `docs workflow contract passed: 8 path filters, 2 unpublished directories excluded.`
- `node --test scripts/stacked-ci-workflows.test.mjs` → 4 passed, 0 failed.
- CI on this PR: `Build (dead-link gate)` **passed in 55s** with the new step in place.
- PyYAML parse confirming both triggers resolve to identical 8-entry lists, `pull_request` has no `branches` key, the build steps are unchanged apart from the inserted validation step, and `deploy.if` is untouched.
- `python3 scripts/release_check.py --strict-prompt` → `Release check passed.`
- `git diff --check` clean.
- **Five mutation tests** against the committed baseline, each firing its own distinct assertion: dropping both negations, restoring `branches: ["main"]`, removing `plans/**` from `srcExclude` only, desyncing the two lists, and dropping `docs/**`.

Per session instruction, no `reviewer` subagent gate was run.