### PR TITLE
ci: scan every pull request with the release privacy gate

### DIFF
--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -1,10 +1,15 @@
 name: Release Privacy Gate
 
+# This is the privacy gate for a public repository: any file anywhere can carry
+# owner PII or a secret, so `pull_request` deliberately takes no `paths` filter.
+# It takes no `branches` filter either — stacked pull requests target their
+# parent branch rather than main, and restricting to main skipped the scan on
+# every stacked layer. `push` stays scoped to main, where it backstops the
+# merged result.
 on:
   push:
     branches: ["main"]
   pull_request:
-    branches: ["main"]
   workflow_dispatch:
 
 jobs:

--- a/workers/automation/tests/test_release_check.py
+++ b/workers/automation/tests/test_release_check.py
@@ -1199,13 +1199,20 @@ def test_release_privacy_workflow_enforces_strict_prompt_gate() -> None:
 
 
 def test_release_privacy_workflow_scans_every_pull_request() -> None:
-    """The privacy gate must not be narrowed by base branch or by path.
+    """The privacy gate's ``pull_request`` trigger must stay exactly bare.
 
     A ``branches: ["main"]`` filter skipped the scan on every stacked pull
     request, because a stacked layer targets its parent branch rather than
     main. A ``paths`` filter would be self-defeating: any file in the
     repository can carry owner PII or a secret, so every excluded path is a
-    path a leak can land in unscanned.
+    path a leak can land in unscanned. Requiring the block to be exactly bare
+    also rejects the ``branches-ignore``/``paths-ignore`` spellings and
+    ``types`` narrowing such as ``types: [opened]``, which would leave every
+    later push to an open pull request unscanned. A bare ``pull_request:`` key
+    parses to YAML null, the same invariant ``scripts/stacked-ci-workflows.test.mjs``
+    asserts as ``on.pull_request === null``; string equality is used here
+    because this suite also runs in the gate workflow itself, whose
+    environment installs only pytest and has no YAML parser.
     """
     workflow = (
         release_check.ROOT / ".github/workflows/release-check.yml"
@@ -1215,8 +1222,11 @@ def test_release_privacy_workflow_scans_every_pull_request() -> None:
         on_block.index("  pull_request:") : on_block.index("  workflow_dispatch:")
     ]
 
-    assert "branches:" not in pull_request
-    assert "paths:" not in pull_request
+    assert pull_request == "  pull_request:\n", (
+        "the pull_request trigger must stay exactly bare (YAML null): any "
+        "branches/paths/types filter or -ignore variant narrows which pull "
+        "requests or files the privacy gate scans"
+    )
 
 
 def test_old_product_name_gate_blocks_shipping_surfaces(tmp_path: Path) -> None:

--- a/workers/automation/tests/test_release_check.py
+++ b/workers/automation/tests/test_release_check.py
@@ -1198,6 +1198,27 @@ def test_release_privacy_workflow_enforces_strict_prompt_gate() -> None:
     assert "python3 scripts/release_check.py --strict-prompt" in workflow
 
 
+def test_release_privacy_workflow_scans_every_pull_request() -> None:
+    """The privacy gate must not be narrowed by base branch or by path.
+
+    A ``branches: ["main"]`` filter skipped the scan on every stacked pull
+    request, because a stacked layer targets its parent branch rather than
+    main. A ``paths`` filter would be self-defeating: any file in the
+    repository can carry owner PII or a secret, so every excluded path is a
+    path a leak can land in unscanned.
+    """
+    workflow = (
+        release_check.ROOT / ".github/workflows/release-check.yml"
+    ).read_text(encoding="utf-8")
+    on_block = workflow[workflow.index("\non:") : workflow.index("\njobs:")]
+    pull_request = on_block[
+        on_block.index("  pull_request:") : on_block.index("  workflow_dispatch:")
+    ]
+
+    assert "branches:" not in pull_request
+    assert "paths:" not in pull_request
+
+
 def test_old_product_name_gate_blocks_shipping_surfaces(tmp_path: Path) -> None:
     old_names = ("Job" + "Hunter", "Job" + "Ctl")
     _write(


### PR DESCRIPTION
## What changed

`.github/workflows/release-check.yml`: removed `branches: ["main"]` from the `pull_request` trigger. Added `test_release_privacy_workflow_scans_every_pull_request` to `workers/automation/tests/test_release_check.py`.

## What the gate is, and why its trigger matters

This repository is public and is developed against real personal data. `scripts/release_check.py` is what stands between that and a published commit: forbidden path names and file suffixes (browser profile artifacts, private runtime files), PII and secret needles scanned in source *and inside minified build output and demo build artifacts* so a bundled chunk cannot smuggle them, non-placeholder secret assignments, "private planning corpus must not be tracked", demo PDF fixtures pinned to content digests so a real resume cannot be swapped for the demo one, the old-product-name gate, version parity, and release-distribution/PyPI/Homebrew safety. The second workflow step re-runs the scanner's own tests so the gate cannot be quietly weakened.

It is the most consequential check in the repository and it takes 12s. Its trigger should be the widest one here, not a narrow one.

## The observation

The Release Privacy Gate produced **no workflow run at all** on two recent pull requests:

| PR | Base | Stack | `Release check` |
| --- | --- | --- | --- |
| #747 | `chore/upgrade-codex-sdk` | — | **absent** |
| #741 | `main` | `stack != null`, not top (Python/TypeScript both `skipped`) | **absent** |
| #765–#768 | `main` | not stacked | present, 12–17s |

Every workflow in this repository *without* a `branches` filter (`python`, `typescript`, `launcher`, `demo-site`, `dco`) ran on #741. The two *with* one (`release-check`, `docs-site`) did not — though `docs-site` is separately explained by its `paths` filter, so `release-check` is the only clean data point.

## Honest limitation

[GitHub's documentation](https://docs.github.com/en/pull-requests/how-tos/merge-and-close-pull-requests/optimizing-ci-for-stacked-pull-requests) states that each PR in a stack "is treated as if it targets the base of the stack, such as `main`", so a `branches: ["main"]` filter should match *every* layer. That contradicts the #741 observation, and I cannot reconcile the two. Stacked pull requests are in public preview and flagged subject to change.

**The change is correct under either reading.** Removing `branches` makes the trigger a strict superset of what it matched before: a no-op if the documentation holds, and a real fix if the observed behavior is what actually happens. It also brings this workflow in line with the five that already carry no `branches` filter, and with the direction #644 took for `python.yml` and `typescript.yml`.

## On the absence of a `paths` filter

This PR deliberately does not add one, and the new test forbids it. Any file can carry PII or a secret, so every excluded path is a path a leak lands in unscanned. That reasoning is now a comment on the trigger plus an assertion, so it does not get "optimized" back in.

## Validation

- `ruff check workers/automation/src workers/automation/tests` with the pinned `ruff==0.15.8` from `workers/automation/pyproject.toml:59` → `All checks passed!`. (Unpinned 0.16.0 reports pre-existing findings in untouched files; none from this change.)
- `pytest -q --noconftest workers/automation/tests/test_release_check.py` → **53 passed**, the exact command in the workflow's self-test step.
- `python3 scripts/release_check.py --strict-prompt` → `Release check passed.`
- `node --test scripts/stacked-ci-workflows.test.mjs` → 4 passed, 0 failed.
- PyYAML parse confirming `pull_request` resolves to `None`, `push` still `{'branches': ['main']}`, all 5 steps unchanged.
- `git diff --check` clean.
- **Two mutation tests** against the committed baseline: restoring `branches: ["main"]` and adding a `paths` filter each fail the new test.

Per session instruction, no `reviewer` subagent gate was run.