### PR TITLE
fix(api): canonicalize policy history timestamps

### DIFF
--- a/apps/api/src/tailoring-policy-revisions.ts
+++ b/apps/api/src/tailoring-policy-revisions.ts
@@ -6,6 +6,8 @@ import {
 import { allRows, getRow, type SqliteDatabase } from "./db.js";
 
 const DEFAULT_TENANT = "local";
+const WORKER_UTC_TIMESTAMP_PATTERN =
+  /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.(\d{1,6}))?(?:Z|\+00:00)$/;
 
 interface TailoringPolicyRevisionRow extends Record<string, unknown> {
   version: number;
@@ -78,7 +80,7 @@ export function listTailoringPolicyRevisions(
             : row.rollback_reason === "user_requested"
               ? "user_requested"
               : "historical_or_unspecified",
-        createdAt: row.created_at,
+        createdAt: canonicalizeWorkerUtcTimestamp(row.created_at),
       })),
       page: query.page,
       pageSize: query.pageSize,
@@ -86,6 +88,22 @@ export function listTailoringPolicyRevisions(
       totalPages: total === 0 ? 0 : Math.ceil(total / query.pageSize),
     });
   })();
+}
+
+function canonicalizeWorkerUtcTimestamp(value: string): string {
+  const candidate = value.trim();
+  const match = WORKER_UTC_TIMESTAMP_PATTERN.exec(candidate);
+  if (!match) {
+    return candidate;
+  }
+  const parsed = Date.parse(candidate);
+  if (!Number.isFinite(parsed)) {
+    return candidate;
+  }
+  const milliseconds = (match[7] ?? "").padEnd(3, "0").slice(0, 3);
+  const normalized = `${match[1]}-${match[2]}-${match[3]}T${match[4]}:${match[5]}:${match[6]}.${milliseconds}Z`;
+  const canonical = new Date(parsed).toISOString();
+  return canonical === normalized ? canonical : candidate;
 }
 
 function learnedRules(rawRuntimeSettings: string): Array<{

--- a/apps/api/test/server.test.ts
+++ b/apps/api/test/server.test.ts
@@ -2721,7 +2721,7 @@ describe("local TypeScript API", () => {
     await app.close();
   });
 
-  it("serves privacy-bounded tailoring policy revision history", async () => {
+  it("serves privacy-bounded tailoring policy history with canonical timestamps", async () => {
     const recommendationId = `learning-recommendation:${"a".repeat(64)}`;
     const reviewId = `learning-recommendation-review:${"b".repeat(64)}`;
     const db = new Database(options.dbPath);
@@ -2740,7 +2740,7 @@ describe("local TypeScript API", () => {
       tenantId: "local",
       version: 2,
       learnedRules: { fact_handling: "require_source_match" },
-      createdAt: "2026-08-01T11:00:00Z",
+      createdAt: "2026-08-01T11:00:00.123456+00:00",
     });
     db.prepare(
       `INSERT INTO learning_recommendation_reviews (
@@ -2819,7 +2819,7 @@ describe("local TypeScript API", () => {
         sourceRecommendationId: recommendationId,
         rollbackOfVersion: null,
         rollbackReasonCode: null,
-        createdAt: "2026-08-01T11:00:00.000Z",
+        createdAt: "2026-08-01T11:00:00.123Z",
       },
       {
         context: "materials",


### PR DESCRIPTION
## Summary

- Canonicalize valid worker UTC timestamps at the Materials policy-history SQLite-to-wire boundary.
- Preserve the strict public response contract and rejection of malformed or non-UTC timestamps.
- Cover Python's six-digit `+00:00` timestamp format with a regression fixture.

## Root cause

The Python worker persists valid UTC values using `datetime.isoformat()`, which can produce timestamps such as `...123456+00:00`. The policy-history endpoint passed those values unchanged into a public response schema that accepts only canonical millisecond `Z` timestamps. Mixed historical rows therefore caused a `500 db_read_failed` response and exposed the validator issue list on the dashboard.

## User impact

Tailoring policy history now loads across mixed valid UTC storage formats without rewriting the SQLite database. Current and superseded revisions remain inspectable and paginated.

## Validation

- `corepack pnpm api:check`
- `corepack pnpm api:test` — 55 files, 754 tests passed
- `git diff --check`
- Live API — 196 revisions across two pages, all emitted with canonical UTC timestamps
- Browser — dashboard and both policy-history pages rendered with no raw validation error, framework overlay, console warning, or console error
- Independent review and QA gates — PASS with no findings