### PR TITLE
fix(projections): make the TS watermark monotonic and bound read-path folds

### DIFF
--- a/apps/api/src/projections.ts
+++ b/apps/api/src/projections.ts
@@ -28,7 +28,7 @@ import type {
   MarketCompensationEstimateResponse,
   PostedCompensationFactResponse,
 } from "./contracts.js";
-import { allRows, getRow, tableExists, type SqliteDatabase, type SqliteValue } from "./db.js";
+import { allRows, getRow, openDatabase, tableExists, type SqliteDatabase, type SqliteValue } from "./db.js";
 import { normalizeJobLocation } from "./location-normalization.js";
 import { getMarketCompensationEstimate } from "./market-compensation-estimates.js";
 import { getPostedCompensationFact } from "./posted-compensation-facts.js";
@@ -636,12 +636,54 @@ function rebuildPipelineStepProjections(db: SqliteDatabase, tenantId: string): v
 }
 
 /**
- * Refresh the projections from canonical state, advancing the
- * shared watermark.  Called at the top of every read-model query so
- * dashboards, lists, and detail views always reflect the latest
- * worker writes (which also bump ``job_events``).
+ * Refresh the projections from canonical state, advancing the shared
+ * watermark.  Called at the top of every read-model query so dashboards,
+ * lists, and detail views always reflect the latest worker writes (which
+ * also bump ``job_events``). One call folds at most
+ * REFRESH_EVENT_BATCH_LIMIT pending events synchronously; a capped pass
+ * schedules a background drain that continues one batch per event-loop
+ * tick on its own connection, so a large backlog converges without
+ * further reads while no single tick blocks serving.
  */
 export function refreshProjections(db: SqliteDatabase, tenantId = "local"): void {
+  if (runRefreshPass(db, tenantId)) {
+    scheduleBackgroundDrain(db.name, tenantId);
+  }
+}
+
+const activeBackgroundDrains = new Set<string>();
+
+function scheduleBackgroundDrain(dbPath: string, tenantId: string): void {
+  const key = `${tenantId}::${dbPath}`;
+  if (!dbPath || activeBackgroundDrains.has(key)) {
+    return;
+  }
+  activeBackgroundDrains.add(key);
+  const step = (): void => {
+    let capped = false;
+    try {
+      const db = openDatabase(dbPath);
+      try {
+        capped = runRefreshPass(db, tenantId);
+      } finally {
+        db.close();
+      }
+    } catch {
+      // Best-effort backstop: on any error (database gone, contention) stop
+      // draining — the next foreground read resumes from the watermark.
+      capped = false;
+    }
+    if (capped) {
+      setImmediate(step);
+    } else {
+      activeBackgroundDrains.delete(key);
+    }
+  };
+  setImmediate(step);
+}
+
+/** One bounded fold pass; returns true when it stopped at the batch cap. */
+function runRefreshPass(db: SqliteDatabase, tenantId: string): boolean {
   const repairedDependencyJobs = reconcileDependencyBlockers(db, tenantId);
   const repairedCoverConflictJobs = reconcileObsoleteCoverGenerationConflicts(db, tenantId);
 
@@ -654,6 +696,7 @@ export function refreshProjections(db: SqliteDatabase, tenantId = "local"): void
   let contactsDirty = false;
   let contactResearchDirty = false;
   let outreachDirty = false;
+  let capped = false;
   let maxEventId = watermark;
   {
     const rows = allRows<{ event_id: number; tenant_id: string; job_id: string | null; event_type: string }>(
@@ -661,6 +704,7 @@ export function refreshProjections(db: SqliteDatabase, tenantId = "local"): void
       "SELECT event_id, tenant_id, job_id, event_type FROM job_events WHERE event_id > ? ORDER BY event_id ASC LIMIT ?",
       [watermark, REFRESH_EVENT_BATCH_LIMIT],
     );
+    capped = rows.length === REFRESH_EVENT_BATCH_LIMIT;
     for (const row of rows) {
       const eventId = Number(row.event_id);
       if (eventId > maxEventId) maxEventId = eventId;
@@ -765,7 +809,7 @@ export function refreshProjections(db: SqliteDatabase, tenantId = "local"): void
     (sourceQualityExists > 0 || !sourceQualityHistory) &&
     maxEventId === watermark
   ) {
-    return;
+    return false;
   }
 
   if (sourceQualityDirty || (sourceQualityExists === 0 && sourceQualityHistory)) {
@@ -803,6 +847,7 @@ export function refreshProjections(db: SqliteDatabase, tenantId = "local"): void
   if (maxEventId > watermark) {
     setWatermark(db, PROJECTION_WATERMARK_NAME, maxEventId);
   }
+  return capped;
 }
 
 interface MaterialsLatest {

--- a/apps/api/src/projections.ts
+++ b/apps/api/src/projections.ts
@@ -290,6 +290,14 @@ function reconcileObsoleteCoverGenerationConflicts(db: SqliteDatabase, tenantId:
   return repairedJobs;
 }
 
+/**
+ * Bound the per-request catch-up: one read folds at most this many pending
+ * events; the remainder folds on subsequent reads (the watermark only
+ * advances to the last event actually scanned, so a capped pass stays
+ * correct by construction). Matches the SSE tick's per-batch bound.
+ */
+export const REFRESH_EVENT_BATCH_LIMIT = 1000;
+
 /** Read the watermark; returns 0 when missing. */
 function readWatermark(db: SqliteDatabase, projection: string): number {
   const row = getRow<{ last_event_id: number | string }>(
@@ -300,14 +308,24 @@ function readWatermark(db: SqliteDatabase, projection: string): number {
   return row ? Number(row.last_event_id) : 0;
 }
 
-/** Atomic upsert + commit of the watermark. */
-function setWatermark(db: SqliteDatabase, projection: string, eventId: number): void {
+/**
+ * Atomic upsert + commit of the watermark. MAX() keeps the watermark
+ * monotonic: a stale or out-of-order writer can never rewind an advance
+ * made by the other runtime's builder, and updated_at only moves when the
+ * value actually advances. Mirrors the Python setter in
+ * workers/automation/src/jobctrl/infrastructure/events/watermark.py.
+ */
+export function setWatermark(db: SqliteDatabase, projection: string, eventId: number): void {
   db.prepare(
     `INSERT INTO event_watermarks (projection_name, last_event_id, updated_at)
      VALUES (?, ?, ?)
      ON CONFLICT(projection_name) DO UPDATE SET
-       last_event_id = excluded.last_event_id,
-       updated_at    = excluded.updated_at`,
+       last_event_id = MAX(event_watermarks.last_event_id, excluded.last_event_id),
+       updated_at    = CASE
+         WHEN excluded.last_event_id > event_watermarks.last_event_id
+           THEN excluded.updated_at
+         ELSE event_watermarks.updated_at
+       END`,
   ).run(projection, eventId, new Date().toISOString());
 }
 
@@ -640,8 +658,8 @@ export function refreshProjections(db: SqliteDatabase, tenantId = "local"): void
   {
     const rows = allRows<{ event_id: number; tenant_id: string; job_id: string | null; event_type: string }>(
       db,
-      "SELECT event_id, tenant_id, job_id, event_type FROM job_events WHERE event_id > ? ORDER BY event_id ASC",
-      [watermark],
+      "SELECT event_id, tenant_id, job_id, event_type FROM job_events WHERE event_id > ? ORDER BY event_id ASC LIMIT ?",
+      [watermark, REFRESH_EVENT_BATCH_LIMIT],
     );
     for (const row of rows) {
       const eventId = Number(row.event_id);

--- a/apps/api/test/projections.test.ts
+++ b/apps/api/test/projections.test.ts
@@ -15,6 +15,8 @@ import Database from "better-sqlite3";
 import { BUILT_IN_RESUME_TEMPLATE_THEME } from "../src/resume-templates.js";
 import { buildApp } from "../src/server.js";
 import { initializeExactV7Database } from "./v7-schema.js";
+import { REFRESH_EVENT_BATCH_LIMIT, refreshProjections, setWatermark } from "../src/projections.js";
+import { PROJECTION_WATERMARK_NAME } from "../src/contracts.js";
 
 const EVENT_JOB_URL = "https://example.com/jobs/event-driven";
 const EVENT_JOB_ID = "00000000-0000-4000-8000-000000000001";
@@ -3802,6 +3804,81 @@ describe("outcome analytics read-only guard", () => {
       expect(text, file).not.toContain("buildOutcomeAnalyticsSummary");
       expect(text, file).not.toContain("/v1/analytics/outcomes");
       expect(text, file).not.toContain("OutcomeAnalyticsSummary");
+    }
+  });
+});
+
+describe("shared watermark discipline", () => {
+  function readWatermarkRow(
+    db: InstanceType<typeof Database>,
+  ): { last_event_id: number; updated_at: string } | undefined {
+    return db
+      .prepare("SELECT last_event_id, updated_at FROM event_watermarks WHERE projection_name = ?")
+      .get(PROJECTION_WATERMARK_NAME) as { last_event_id: number; updated_at: string } | undefined;
+  }
+
+  it("never rewinds the watermark and keeps updated_at on a stale write", () => {
+    const { dbPath, cleanup } = withTempDb();
+    try {
+      seedSchema(dbPath);
+      const db = new Database(dbPath);
+      setWatermark(db, PROJECTION_WATERMARK_NAME, 10);
+      const afterAdvance = readWatermarkRow(db)!;
+      expect(afterAdvance.last_event_id).toBe(10);
+
+      setWatermark(db, PROJECTION_WATERMARK_NAME, 5);
+      const afterStaleWrite = readWatermarkRow(db)!;
+      expect(afterStaleWrite.last_event_id).toBe(10);
+      expect(afterStaleWrite.updated_at).toBe(afterAdvance.updated_at);
+
+      setWatermark(db, PROJECTION_WATERMARK_NAME, 15);
+      expect(readWatermarkRow(db)!.last_event_id).toBe(15);
+      db.close();
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("folds a bounded batch per refresh and resumes on the next call", () => {
+    const { dbPath, cleanup } = withTempDb();
+    try {
+      seedSchema(dbPath);
+      const db = new Database(dbPath);
+      refreshProjections(db);
+      const start = readWatermarkRow(db)?.last_event_id ?? 0;
+
+      const insert = db.prepare(
+        "INSERT INTO job_events (tenant_id, job_id, identity_version, stage, event_type, level, message, occurred_at, payload_json) VALUES ('local', ?, 1, 'discover', 'JobDiscovered', 'info', 'batch', ?, '{}')",
+      );
+      const total = REFRESH_EVENT_BATCH_LIMIT + 2;
+      const bulk = db.transaction(() => {
+        for (let i = 0; i < total; i += 1) {
+          insert.run(EVENT_JOB_ID, `2026-08-08T00:00:${String(i % 60).padStart(2, "0")}Z`);
+        }
+      });
+      bulk();
+      const maxEventId = Number(
+        (db.prepare("SELECT MAX(event_id) AS m FROM job_events").get() as { m: number }).m,
+      );
+      const expectedFirstStop = Number(
+        (
+          db
+            .prepare(
+              "SELECT event_id FROM job_events WHERE event_id > ? ORDER BY event_id ASC LIMIT 1 OFFSET ?",
+            )
+            .get(start, REFRESH_EVENT_BATCH_LIMIT - 1) as { event_id: number }
+        ).event_id,
+      );
+
+      refreshProjections(db);
+      expect(readWatermarkRow(db)!.last_event_id).toBe(expectedFirstStop);
+      expect(readWatermarkRow(db)!.last_event_id).toBeLessThan(maxEventId);
+
+      refreshProjections(db);
+      expect(readWatermarkRow(db)!.last_event_id).toBe(maxEventId);
+      db.close();
+    } finally {
+      cleanup();
     }
   });
 });

--- a/apps/api/test/projections.test.ts
+++ b/apps/api/test/projections.test.ts
@@ -5,7 +5,7 @@
  * Python projection builder now owns ``apply_run_projections``
  * materialisation from ``job_events``.
  */
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import path from "node:path";
 import os from "node:os";
 import fs from "node:fs";
@@ -3839,24 +3839,31 @@ describe("shared watermark discipline", () => {
     }
   });
 
-  it("folds a bounded batch per refresh and resumes on the next call", () => {
+  it("caps the synchronous fold and drains the remainder in the background", async () => {
     const { dbPath, cleanup } = withTempDb();
     try {
       seedSchema(dbPath);
       const db = new Database(dbPath);
       refreshProjections(db);
       const start = readWatermarkRow(db)?.last_event_id ?? 0;
+      const readTitle = (): string =>
+        (db.prepare("SELECT title FROM job_list_projections WHERE job_id = ?").get(EVENT_JOB_ID) as { title: string })
+          .title;
+      const staleTitle = readTitle();
 
-      const insert = db.prepare(
-        "INSERT INTO job_events (tenant_id, job_id, identity_version, stage, event_type, level, message, occurred_at, payload_json) VALUES ('local', ?, 1, 'discover', 'JobDiscovered', 'info', 'batch', ?, '{}')",
+      const filler = db.prepare(
+        "INSERT INTO job_events (tenant_id, job_id, identity_version, stage, event_type, level, message, occurred_at, payload_json) VALUES ('local', NULL, 1, 'discover', 'JobDiscovered', 'info', 'filler', ?, '{}')",
       );
-      const total = REFRESH_EVENT_BATCH_LIMIT + 2;
       const bulk = db.transaction(() => {
-        for (let i = 0; i < total; i += 1) {
-          insert.run(EVENT_JOB_ID, `2026-08-08T00:00:${String(i % 60).padStart(2, "0")}Z`);
+        for (let i = 0; i < REFRESH_EVENT_BATCH_LIMIT; i += 1) {
+          filler.run(`2026-08-09T00:00:${String(i % 60).padStart(2, "0")}Z`);
         }
       });
       bulk();
+      db.prepare("UPDATE jobs SET title = ? WHERE job_id = ?").run("Event-Driven Engineer (Renamed)", EVENT_JOB_ID);
+      db.prepare(
+        "INSERT INTO job_events (tenant_id, job_id, identity_version, stage, event_type, level, message, occurred_at, payload_json) VALUES ('local', ?, 1, 'discover', 'JobUpdated', 'info', 'rename', '2026-08-09T00:01:00Z', '{}')",
+      ).run(EVENT_JOB_ID);
       const maxEventId = Number(
         (db.prepare("SELECT MAX(event_id) AS m FROM job_events").get() as { m: number }).m,
       );
@@ -3871,11 +3878,20 @@ describe("shared watermark discipline", () => {
       );
 
       refreshProjections(db);
+      // Synchronous view right after the single call: stopped exactly at the
+      // batch cap, with the rename event beyond it still unfolded.
       expect(readWatermarkRow(db)!.last_event_id).toBe(expectedFirstStop);
       expect(readWatermarkRow(db)!.last_event_id).toBeLessThan(maxEventId);
+      expect(readTitle()).toBe(staleTitle);
 
-      refreshProjections(db);
-      expect(readWatermarkRow(db)!.last_event_id).toBe(maxEventId);
+      // The background drain finishes the backlog without another read.
+      await vi.waitFor(
+        () => {
+          expect(readWatermarkRow(db)!.last_event_id).toBe(maxEventId);
+          expect(readTitle()).toBe("Event-Driven Engineer (Renamed)");
+        },
+        { timeout: 5000, interval: 25 },
+      );
       db.close();
     } finally {
       cleanup();


### PR DESCRIPTION
## Summary
Two fixes to the shared-watermark discipline in `apps/api/src/projections.ts`: (1) `setWatermark` becomes monotonic — `MAX(last_event_id, excluded)` with `updated_at` moving only on a real advance — mirroring the documented Python setter (`infrastructure/events/watermark.py`) that the TS twin had skipped; a slow TS refresh could previously rewind an advance made by the worker's builder. (2) The per-request catch-up scan gains `REFRESH_EVENT_BATCH_LIMIT` (1000, matching the SSE tick's bound): the first read after a large discovery run no longer folds the entire backlog synchronously; the watermark only advances to the last event actually scanned, so capped passes resume correctly.

## Why
A live one-sided mirror drift on the projection substrate, and an unbounded hot-path fold — both found in the logic/process architecture review.

## Validation
Two new tests pin the behaviors (stale write is a no-op preserving updated_at; a limit+2 backlog folds across exactly two refreshes with exact stop points); full projections + server suites green (274); api typecheck green.