### PR TITLE
refactor(apply): single-source the approval-gate vocabulary

### DIFF
--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -338,13 +338,18 @@ import {
   writeSettingsConfig,
 } from "./write-model.js";
 
+import type { ApplyReviewApprovalGateReason } from "./contracts.js";
+
 const UNSAFE_METHODS = new Set(["DELETE", "PATCH", "POST", "PUT"]);
-const APPLY_REVIEW_PRECONDITION_ERRORS = new Set([
+const APPLY_REVIEW_GATE_PRECONDITIONS: readonly ApplyReviewApprovalGateReason[] = [
   "awaiting_dry_run",
   "approval_stale_materials",
   "approval_stale_profile",
   "approval_stale_url",
   "approval_stale_email_candidate",
+];
+const APPLY_REVIEW_PRECONDITION_ERRORS = new Set<string>([
+  ...APPLY_REVIEW_GATE_PRECONDITIONS,
   "partial_override_evidence_invalid",
   "repeat_application_blocked",
   "repeat_application_confirmation_required",

--- a/apps/api/test/apply-approval-vocabulary-parity.test.ts
+++ b/apps/api/test/apply-approval-vocabulary-parity.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Cross-runtime pin for the apply-review approval-gate vocabulary.
+ *
+ * The TypeScript source of truth is APPLY_REVIEW_APPROVAL_GATE_REASONS in
+ * packages/contracts; the Python launcher's refusal subset is pinned to the
+ * same fixture by workers/automation/tests/test_apply_approval_vocabulary.py.
+ */
+import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { APPLY_REVIEW_APPROVAL_GATE_REASONS } from "../src/contracts.js";
+
+const FIXTURE_PATH = path.join(
+  fileURLToPath(new URL("../../..", import.meta.url)),
+  "packages/domain-types/test/fixtures/apply_approval_gate_reasons.json",
+);
+
+describe("apply approval-gate vocabulary parity", () => {
+  const fixture = JSON.parse(fs.readFileSync(FIXTURE_PATH, "utf8")) as {
+    reasons: string[];
+    launcherRefusalReasons: string[];
+  };
+
+  it("matches the shared fixture exactly", () => {
+    expect([...APPLY_REVIEW_APPROVAL_GATE_REASONS]).toEqual(fixture.reasons);
+  });
+
+  it("keeps the launcher refusal subset inside the vocabulary", () => {
+    const reasons = new Set(fixture.reasons);
+    for (const refusal of fixture.launcherRefusalReasons) {
+      expect(reasons.has(refusal), refusal).toBe(true);
+    }
+  });
+});

--- a/apps/web/src/demo/DemoLocalCommandExecutor.ts
+++ b/apps/web/src/demo/DemoLocalCommandExecutor.ts
@@ -1,3 +1,4 @@
+import type { ApplyReviewApprovalGateReason } from "@jobctrl/contracts";
 import {
   LOCAL_TENANT,
   createContactCreated,
@@ -632,13 +633,13 @@ export class DemoLocalCommandExecutor {
         const gate = item.approvalGate;
         if (decision === "approve_submit") {
           if (numberValue(body.materialsGeneration) !== gate.materialsGeneration) {
-            throw new TypeError("approval_stale_materials");
+            throw new TypeError("approval_stale_materials" satisfies ApplyReviewApprovalGateReason);
           }
           if (numberValue(body.profileVersion) !== gate.profileVersion) {
-            throw new TypeError("approval_stale_profile");
+            throw new TypeError("approval_stale_profile" satisfies ApplyReviewApprovalGateReason);
           }
           if (stringValue(body.applicationUrl) !== gate.applicationUrl) {
-            throw new TypeError("approval_stale_url");
+            throw new TypeError("approval_stale_url" satisfies ApplyReviewApprovalGateReason);
           }
           const partialOverrideRunId = stringValue(body.partialOverrideRunId);
           if (partialOverrideRunId) {
@@ -646,14 +647,14 @@ export class DemoLocalCommandExecutor {
               throw new TypeError("partial_override_evidence_invalid");
             }
           } else if (!gate.dryRunEvidence || gate.dryRunEvidence.coverage !== "full") {
-            throw new TypeError("awaiting_dry_run");
+            throw new TypeError("awaiting_dry_run" satisfies ApplyReviewApprovalGateReason);
           }
           if (item.emailApplication) {
             if (
               stringValue(body.emailRecipient)?.toLowerCase() !== item.emailApplication.recipient.toLowerCase() ||
               stringValue(body.emailAttachmentArtifactId) !== item.emailApplication.attachmentArtifactId
             ) {
-              throw new TypeError("approval_stale_email_candidate");
+              throw new TypeError("approval_stale_email_candidate" satisfies ApplyReviewApprovalGateReason);
             }
           }
         }

--- a/packages/contracts/src/schemas.ts
+++ b/packages/contracts/src/schemas.ts
@@ -872,14 +872,22 @@ export interface RepeatApplicationOverrideResponse {
 }
 
 export type ApplyReviewDryRunCoverage = "full" | "partial";
-export type ApplyReviewApprovalGateReason =
-  | "awaiting_approval"
-  | "awaiting_dry_run"
-  | "approval_stale_materials"
-  | "approval_stale_profile"
-  | "approval_stale_url"
-  | "approval_stale_email_candidate"
-  | "override_evidence_invalid";
+/**
+ * The apply-review approval-gate vocabulary. This constant is the single
+ * TypeScript source for the gate reasons; the Python launcher's refusal
+ * reasons are pinned to the same fixture
+ * (packages/domain-types/test/fixtures/apply_approval_gate_reasons.json).
+ */
+export const APPLY_REVIEW_APPROVAL_GATE_REASONS = [
+  "awaiting_approval",
+  "awaiting_dry_run",
+  "approval_stale_materials",
+  "approval_stale_profile",
+  "approval_stale_url",
+  "approval_stale_email_candidate",
+  "override_evidence_invalid",
+] as const;
+export type ApplyReviewApprovalGateReason = (typeof APPLY_REVIEW_APPROVAL_GATE_REASONS)[number];
 
 export interface ApplyReviewDryRunEvidence {
   runId: string;

--- a/packages/domain-types/test/fixtures/apply_approval_gate_reasons.json
+++ b/packages/domain-types/test/fixtures/apply_approval_gate_reasons.json
@@ -1,0 +1,20 @@
+{
+  "reasons": [
+    "awaiting_approval",
+    "awaiting_dry_run",
+    "approval_stale_materials",
+    "approval_stale_profile",
+    "approval_stale_url",
+    "approval_stale_email_candidate",
+    "override_evidence_invalid"
+  ],
+  "launcherRefusalReasons": [
+    "awaiting_approval",
+    "awaiting_dry_run",
+    "approval_stale_materials",
+    "approval_stale_profile",
+    "approval_stale_url",
+    "approval_stale_email_candidate",
+    "override_evidence_invalid"
+  ]
+}

--- a/workers/automation/src/jobctrl/domain/apply/value_objects.py
+++ b/workers/automation/src/jobctrl/domain/apply/value_objects.py
@@ -283,6 +283,7 @@ def submission_result_kind(result: SubmissionResult) -> str:
 
 
 __all__ = [
+    "APPROVAL_GATE_REFUSAL_REASONS",
     "Applied",
     "ApplyPrompt",
     "ApplyRunId",

--- a/workers/automation/src/jobctrl/domain/apply/value_objects.py
+++ b/workers/automation/src/jobctrl/domain/apply/value_objects.py
@@ -300,3 +300,21 @@ __all__ = [
     "new_apply_run_id",
     "submission_result_kind",
 ]
+
+
+# The launcher's approval-gate refusal vocabulary. Pinned cross-runtime to
+# packages/domain-types/test/fixtures/apply_approval_gate_reasons.json (the
+# TypeScript source is APPLY_REVIEW_APPROVAL_GATE_REASONS in
+# packages/contracts); tests/test_apply_approval_vocabulary.py enforces that
+# every literal _approval_refusal_reason can return stays inside this set.
+APPROVAL_GATE_REFUSAL_REASONS: frozenset[str] = frozenset(
+    {
+        "awaiting_approval",
+        "awaiting_dry_run",
+        "approval_stale_materials",
+        "approval_stale_profile",
+        "approval_stale_url",
+        "approval_stale_email_candidate",
+        "override_evidence_invalid",
+    }
+)

--- a/workers/automation/tests/test_apply_approval_vocabulary.py
+++ b/workers/automation/tests/test_apply_approval_vocabulary.py
@@ -1,0 +1,40 @@
+"""Cross-runtime pin for the apply approval-gate refusal vocabulary.
+
+The TypeScript source of truth is ``APPLY_REVIEW_APPROVAL_GATE_REASONS`` in
+``packages/contracts``; both runtimes pin to the shared fixture. The
+source-scan test keeps ``_approval_refusal_reason`` honest: any new literal
+refusal reason must enter the shared vocabulary (and the fixture) first.
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+import re
+from pathlib import Path
+
+from jobctrl.apply import launcher
+from jobctrl.domain.apply.value_objects import APPROVAL_GATE_REFUSAL_REASONS
+
+_FIXTURE = (
+    Path(__file__).resolve().parents[3]
+    / "packages/domain-types/test/fixtures/apply_approval_gate_reasons.json"
+)
+
+
+def _fixture() -> dict[str, list[str]]:
+    return json.loads(_FIXTURE.read_text(encoding="utf-8"))
+
+
+def test_refusal_reasons_match_shared_fixture() -> None:
+    fixture = _fixture()
+    assert APPROVAL_GATE_REFUSAL_REASONS == frozenset(fixture["launcherRefusalReasons"])
+    assert APPROVAL_GATE_REFUSAL_REASONS <= frozenset(fixture["reasons"])
+
+
+def test_launcher_refusal_literals_stay_inside_the_vocabulary() -> None:
+    source = inspect.getsource(launcher._approval_refusal_reason)
+    literals = set(re.findall(r'return "([a-z_]+)"', source))
+    assert literals, "expected _approval_refusal_reason to return literal reasons"
+    unknown = literals - APPROVAL_GATE_REFUSAL_REASONS
+    assert not unknown, f"unpinned refusal reasons: {sorted(unknown)}"


### PR DESCRIPTION
## Summary
Single-sources the apply-review approval-gate vocabulary. `packages/contracts` now exports `APPLY_REVIEW_APPROVAL_GATE_REASONS` as the runtime constant with the `ApplyReviewApprovalGateReason` type derived from it; the server's precondition set builds its gate subset from the typed vocabulary; the demo executor's thrown literals are compile-fenced with `satisfies`; Python gains `APPROVAL_GATE_REFUSAL_REASONS` in `domain/apply/value_objects.py` (exported via `__all__`), pinned to the shared fixture `apply_approval_gate_reasons.json` together with a source-scan test over `_approval_refusal_reason`'s return literals.

## Why
The gate reasons were spelled independently in five places across two runtimes with no cross-check. The new pin proved its worth immediately: the launcher's refusal vocabulary is the full seven reasons (including `awaiting_dry_run` and `override_evidence_invalid`), not the five the earlier review pass had catalogued — the fixture now records the truth.

## Validation
TS parity test (constant == fixture) and Python tests (constant == fixture; every launcher return literal inside the constant) green; server precondition set unchanged as a set; contracts/api/web typechecks green.