### PR TITLE
fix(api): render resume PDFs through the JSON-RPC worker seam

### DIFF
--- a/apps/api/src/resume-pdf-render.ts
+++ b/apps/api/src/resume-pdf-render.ts
@@ -23,7 +23,16 @@ export class ResumeRenderError extends Error {
 
 export function createResumeHtmlPdfRenderer(dispatcher: JsonRpcDispatcher): ResumeHtmlPdfRenderer {
   return async ({ htmlPath, pdfPath }) => {
-    const response = await dispatcher.call(RpcMethods.RenderResumePdf, { htmlPath, pdfPath });
+    let response: Awaited<ReturnType<JsonRpcDispatcher["call"]>>;
+    try {
+      response = await dispatcher.call(RpcMethods.RenderResumePdf, { htmlPath, pdfPath });
+    } catch (error) {
+      // Transport-level failures (spawn/write errors, the request timeout,
+      // child exit) reject instead of returning a JSON-RPC error envelope.
+      throw new ResumeRenderError(
+        `Resume HTML-to-PDF render failed: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
     if (response.error) {
       // The RPC server wraps handler exceptions as a generic "Internal
       // error" message and puts the real cause in error.data.

--- a/apps/api/src/resume-pdf-render.ts
+++ b/apps/api/src/resume-pdf-render.ts
@@ -1,73 +1,31 @@
-import { execFileSync } from "node:child_process";
-import { defaultSourcePythonRuntime, type PythonRuntimeCommandResolver } from "./python-runtime.js";
-
-// The render is synchronous so it can run inside the better-sqlite3 write
-// transaction. Bound the subprocess so a hung runtime resolve or Chromium launch
-// cannot freeze the Node event loop indefinitely; on timeout execFileSync throws
-// and the caller's catch turns it into a preserved-generation render failure.
-// Generous enough for a cold Chromium start.
-const RESUME_RENDER_TIMEOUT_MS = 120_000;
-const RESUME_RENDER_MAX_BUFFER_BYTES = 64 * 1024 * 1024;
+import type { JsonRpcDispatcher } from "./json-rpc-adapter.js";
+import { getDefaultJsonRpcDispatcher } from "./json-rpc-adapter.js";
+import { RenderResumePdfResultSchema, RpcMethods } from "./contracts.js";
 
 export interface ResumeHtmlPdfRenderInput {
   readonly htmlPath: string;
   readonly pdfPath: string;
 }
 
-export type ResumeHtmlPdfRenderer = (input: ResumeHtmlPdfRenderInput) => void;
+export type ResumeHtmlPdfRenderer = (input: ResumeHtmlPdfRenderInput) => Promise<void>;
 
-export const RESUME_HTML_PDF_SCRIPT = `
-import sys
-from pathlib import Path
-
-from jobctrl.infrastructure.materials.html_resume_pdf import render_resume_html_to_pdf
-
-html_path = Path(sys.argv[1])
-output_path = Path(sys.argv[2])
-
-render_resume_html_to_pdf(html_path.read_text(encoding="utf-8"), str(output_path))
-`;
-
-// Renders pre-built resume HTML to a full, paginated PDF via the same Playwright
-// adapter the Python worker uses, so the reviewed/submitted resume matches the
-// edited HTML instead of a truncated single-page fallback. Synchronous so it can
-// run inside the better-sqlite3 write transactions that persist the artifact.
-export function createResumeHtmlPdfRenderer(
-  pythonRuntime: PythonRuntimeCommandResolver = defaultSourcePythonRuntime,
-  appDir = process.cwd(),
-): ResumeHtmlPdfRenderer {
-  return ({ htmlPath, pdfPath }) => {
-    const command = pythonRuntime.resolve(
-      {
-        kind: "script",
-        script: RESUME_HTML_PDF_SCRIPT,
-        args: [htmlPath, pdfPath],
-      },
-      { appDir },
-    );
-    try {
-      execFileSync(command.executable, command.argv, {
-        cwd: command.cwd,
-        env: command.env,
-        stdio: ["ignore", "pipe", "pipe"],
-        timeout: RESUME_RENDER_TIMEOUT_MS,
-        maxBuffer: RESUME_RENDER_MAX_BUFFER_BYTES,
-      });
-    } catch (error) {
-      throw new Error(resumeRenderErrorMessage(error));
+// Renders pre-built resume HTML to a full, paginated PDF via the same
+// Playwright adapter the Python worker uses — through the long-lived JSON-RPC
+// worker child rather than a synchronous subprocess, so the API's event loop
+// keeps serving during Chromium renders. Callers persist database rows only
+// after the awaited render returns, never around it.
+export function createResumeHtmlPdfRenderer(dispatcher: JsonRpcDispatcher): ResumeHtmlPdfRenderer {
+  return async ({ htmlPath, pdfPath }) => {
+    const response = await dispatcher.call(RpcMethods.RenderResumePdf, { htmlPath, pdfPath });
+    if (response.error) {
+      throw new Error(`Resume HTML-to-PDF render failed: ${response.error.message}`);
+    }
+    const parsed = RenderResumePdfResultSchema.safeParse(response.result);
+    if (!parsed.success) {
+      throw new Error("Resume HTML-to-PDF render returned an invalid result.");
     }
   };
 }
 
-export const defaultResumeHtmlPdfRenderer: ResumeHtmlPdfRenderer = createResumeHtmlPdfRenderer();
-
-function resumeRenderErrorMessage(error: unknown): string {
-  if (error && typeof error === "object" && "stderr" in error) {
-    const { stderr } = error as { stderr?: Buffer | string | null };
-    const text = (typeof stderr === "string" ? stderr : stderr?.toString("utf8"))?.trim();
-    if (text) {
-      return `Resume HTML-to-PDF render failed: ${text}`;
-    }
-  }
-  return `Resume HTML-to-PDF render failed: ${error instanceof Error ? error.message : String(error)}`;
-}
+export const defaultResumeHtmlPdfRenderer: ResumeHtmlPdfRenderer = (input) =>
+  createResumeHtmlPdfRenderer(getDefaultJsonRpcDispatcher())(input);

--- a/apps/api/src/resume-pdf-render.ts
+++ b/apps/api/src/resume-pdf-render.ts
@@ -14,15 +14,28 @@ export type ResumeHtmlPdfRenderer = (input: ResumeHtmlPdfRenderInput) => Promise
 // worker child rather than a synchronous subprocess, so the API's event loop
 // keeps serving during Chromium renders. Callers persist database rows only
 // after the awaited render returns, never around it.
+export class ResumeRenderError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ResumeRenderError";
+  }
+}
+
 export function createResumeHtmlPdfRenderer(dispatcher: JsonRpcDispatcher): ResumeHtmlPdfRenderer {
   return async ({ htmlPath, pdfPath }) => {
     const response = await dispatcher.call(RpcMethods.RenderResumePdf, { htmlPath, pdfPath });
     if (response.error) {
-      throw new Error(`Resume HTML-to-PDF render failed: ${response.error.message}`);
+      // The RPC server wraps handler exceptions as a generic "Internal
+      // error" message and puts the real cause in error.data.
+      const detail =
+        typeof response.error.data === "string" && response.error.data.trim()
+          ? response.error.data
+          : response.error.message;
+      throw new ResumeRenderError(`Resume HTML-to-PDF render failed: ${detail}`);
     }
     const parsed = RenderResumePdfResultSchema.safeParse(response.result);
     if (!parsed.success) {
-      throw new Error("Resume HTML-to-PDF render returned an invalid result.");
+      throw new ResumeRenderError("Resume HTML-to-PDF render returned an invalid result.");
     }
   };
 }

--- a/apps/api/src/resume-review-drafts.ts
+++ b/apps/api/src/resume-review-drafts.ts
@@ -522,6 +522,7 @@ export async function renderResumeReviewDraft(
   // that goes stale against concurrent worker commits and then fails the
   // write upgrade with SQLITE_BUSY_SNAPSHOT.
   const rendered = await renderDraftArtifactFiles(db, draft, revision, renderPdf);
+  let promoted = false;
   try {
     const tx = db.transaction(() => {
       const current = getDraftRow(db, draft.draft_id);
@@ -535,6 +536,10 @@ export async function renderResumeReviewDraft(
       if (nextMaterialGeneration(db, draft.job_id) !== rendered.generation) {
         throw new DraftRenderConflictError("Job materials changed while rendering; retry the render.");
       }
+      promoted = true;
+      fs.renameSync(rendered.tmpTextPath, rendered.textPath);
+      fs.renameSync(rendered.tmpHtmlPath, rendered.htmlPath);
+      fs.renameSync(rendered.tmpPdfPath, rendered.pdfPath);
       insertRenderedDraftArtifacts(db, draft, revision, validation, rendered);
       const now = new Date().toISOString();
       markResidualCommentThreadsAfterAcceptance(db, draft.draft_id, now);
@@ -572,9 +577,14 @@ export async function renderResumeReviewDraft(
     });
     return tx();
   } catch (error) {
-    // The files rendered but the rows did not commit: remove the orphans so
-    // a failed render leaves no artifacts without database rows.
-    for (const orphan of [rendered.textPath, rendered.htmlPath, rendered.pdfPath]) {
+    // The files rendered but the rows did not commit: remove this attempt's
+    // temp files, plus the promoted finals when the failure happened after
+    // the renames (the commit guards make those finals this attempt's own).
+    const orphans = [rendered.tmpTextPath, rendered.tmpHtmlPath, rendered.tmpPdfPath];
+    if (promoted) {
+      orphans.push(rendered.textPath, rendered.htmlPath, rendered.pdfPath);
+    }
+    for (const orphan of orphans) {
       try {
         fs.rmSync(orphan, { force: true });
       } catch {
@@ -1135,6 +1145,9 @@ interface RenderedDraftArtifactFiles {
   readonly textPath: string;
   readonly htmlPath: string;
   readonly pdfPath: string;
+  readonly tmpTextPath: string;
+  readonly tmpHtmlPath: string;
+  readonly tmpPdfPath: string;
   readonly layoutBoxes: ResumeLayoutBoxDraft[];
 }
 
@@ -1157,15 +1170,23 @@ async function renderDraftArtifactFiles(
   const textPath = path.join(outputDir, `${baseName}.txt`);
   const htmlPath = path.join(outputDir, `${baseName}.html`);
   const pdfPath = path.join(outputDir, `${baseName}.pdf`);
+  // Concurrent renders of the same revision compute identical deterministic
+  // final paths; each attempt writes to its own suffixed temp files and only
+  // the transaction that wins the commit guards promotes them, so a losing
+  // attempt's cleanup can never touch a winner's registered files.
+  const attemptId = crypto.randomUUID().slice(0, 8);
+  const tmpTextPath = `${textPath}.${attemptId}.tmp`;
+  const tmpHtmlPath = `${htmlPath}.${attemptId}.tmp`;
+  const tmpPdfPath = `${pdfPath}.${attemptId}.tmp`;
   const editedText = revision.edited_text.replace(/\r\n/g, "\n");
   const layoutBoxes = layoutBoxesForEditedText(editedText);
 
-  fs.writeFileSync(textPath, editedText, "utf8");
-  fs.writeFileSync(htmlPath, htmlForEditedResume(editedText, parseJson(revision.plate_document_json)), "utf8");
+  fs.writeFileSync(tmpTextPath, editedText, "utf8");
+  fs.writeFileSync(tmpHtmlPath, htmlForEditedResume(editedText, parseJson(revision.plate_document_json)), "utf8");
   try {
-    await renderPdf({ htmlPath, pdfPath });
+    await renderPdf({ htmlPath: tmpHtmlPath, pdfPath: tmpPdfPath });
   } catch (error) {
-    for (const orphan of [textPath, htmlPath, pdfPath]) {
+    for (const orphan of [tmpTextPath, tmpHtmlPath, tmpPdfPath]) {
       try {
         fs.rmSync(orphan, { force: true });
       } catch {
@@ -1181,6 +1202,9 @@ async function renderDraftArtifactFiles(
     textPath,
     htmlPath,
     pdfPath,
+    tmpTextPath,
+    tmpHtmlPath,
+    tmpPdfPath,
     layoutBoxes,
   };
 }

--- a/apps/api/src/resume-review-drafts.ts
+++ b/apps/api/src/resume-review-drafts.ts
@@ -488,6 +488,13 @@ export function seedResumeReviewCommentThreads(
   return tx();
 }
 
+export class DraftRenderConflictError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "DraftRenderConflictError";
+  }
+}
+
 export async function renderResumeReviewDraft(
   db: SqliteDatabase,
   draftId: string,
@@ -523,10 +530,10 @@ export async function renderResumeReviewDraft(
         current.state !== draft.state ||
         current.current_revision_id !== draft.current_revision_id
       ) {
-        throw new InputError("Resume review draft changed while rendering; retry the render.");
+        throw new DraftRenderConflictError("Resume review draft changed while rendering; retry the render.");
       }
       if (nextMaterialGeneration(db, draft.job_id) !== rendered.generation) {
-        throw new InputError("Job materials changed while rendering; retry the render.");
+        throw new DraftRenderConflictError("Job materials changed while rendering; retry the render.");
       }
       insertRenderedDraftArtifacts(db, draft, revision, validation, rendered);
       const now = new Date().toISOString();
@@ -1155,7 +1162,18 @@ async function renderDraftArtifactFiles(
 
   fs.writeFileSync(textPath, editedText, "utf8");
   fs.writeFileSync(htmlPath, htmlForEditedResume(editedText, parseJson(revision.plate_document_json)), "utf8");
-  await renderPdf({ htmlPath, pdfPath });
+  try {
+    await renderPdf({ htmlPath, pdfPath });
+  } catch (error) {
+    for (const orphan of [textPath, htmlPath, pdfPath]) {
+      try {
+        fs.rmSync(orphan, { force: true });
+      } catch {
+        // Best-effort cleanup only; the render error is what matters.
+      }
+    }
+    throw error;
+  }
   return {
     generation,
     resumeTextArtifactId,

--- a/apps/api/src/resume-review-drafts.ts
+++ b/apps/api/src/resume-review-drafts.ts
@@ -212,13 +212,6 @@ interface ResumeReviewDraftValidation {
   warnings: string[];
 }
 
-interface RenderedResumeArtifacts {
-  generation: number;
-  resumeTextArtifactId: string;
-  resumePdfArtifactId: string;
-  layoutBoxCount: number;
-}
-
 interface ResumeLayoutBoxDraft {
   semanticId: string;
   pageNumber: number;
@@ -247,14 +240,14 @@ export function getResumeReviewDraftForJob(
   return row ? { ok: true, draft: draftFromRow(db, row) } : null;
 }
 
-export function createOrLoadResumeReviewDraft(
+export async function createOrLoadResumeReviewDraft(
   db: SqliteDatabase,
   jobLocator: string,
   request: ResumeReviewDraftCreateRequest = {},
   renderPdf: ResumeHtmlPdfRenderer = defaultResumeHtmlPdfRenderer,
-): ResumeReviewDraftResponse {
+): Promise<ResumeReviewDraftResponse> {
   const jobId = requireExistingJobId(db, jobLocator);
-  const refresh = ensureCurrentResumeTemplateMaterials(db, jobId, {}, renderPdf);
+  const refresh = await ensureCurrentResumeTemplateMaterials(db, jobId, {}, renderPdf);
   if (refresh.status === "failed" || refresh.status === "unavailable") {
     throw new InputError(refresh.message ?? "Resume template refresh did not complete.");
   }
@@ -495,65 +488,94 @@ export function seedResumeReviewCommentThreads(
   return tx();
 }
 
-export function renderResumeReviewDraft(
+export async function renderResumeReviewDraft(
   db: SqliteDatabase,
   draftId: string,
   request: ResumeReviewDraftRenderRequest = {},
   renderPdf: ResumeHtmlPdfRenderer = defaultResumeHtmlPdfRenderer,
-): ResumeReviewDraftRenderResponse {
-  const tx = db.transaction(() => {
-    const draft = getDraftRow(db, draftId);
-    if (!draft) {
-      throw new InputError(`Resume review draft not found: ${draftId}`);
-    }
-    const revisionId = request.draftRevisionId ?? draft.current_revision_id;
-    const revision = revisionId ? getRevisionRow(db, revisionId) : undefined;
-    const validation = validateDraftRevisionForRender(revision);
-    if (!validation.passed || !revision) {
-      return {
-        ok: false as const,
-        error: "resume_review_draft_invalid" as const,
-        draft: draftFromRow(db, draft),
-        validation,
-      };
-    }
-
-    const artifacts = persistRenderedDraftArtifacts(db, draft, revision, validation, renderPdf);
-    const now = new Date().toISOString();
-    markResidualCommentThreadsAfterAcceptance(db, draft.draft_id, now);
-    db.prepare(
-      `UPDATE resume_review_drafts
-          SET state = 'promoted',
-              updated_at = ?
-        WHERE tenant_id = ? AND draft_id = ?`,
-    ).run(now, DEFAULT_TENANT, draft.draft_id);
-
-    const promotedDraft = getDraftRow(db, draft.draft_id);
-    if (!promotedDraft) {
-      throw new Error("Resume review draft was not promoted.");
-    }
+): Promise<ResumeReviewDraftRenderResponse> {
+  const draft = getDraftRow(db, draftId);
+  if (!draft) {
+    throw new InputError(`Resume review draft not found: ${draftId}`);
+  }
+  const revisionId = request.draftRevisionId ?? draft.current_revision_id;
+  const revision = revisionId ? getRevisionRow(db, revisionId) : undefined;
+  const validation = validateDraftRevisionForRender(revision);
+  if (!validation.passed || !revision) {
     return {
-      ok: true as const,
-      draft: draftFromRow(db, promotedDraft),
+      ok: false as const,
+      error: "resume_review_draft_invalid" as const,
+      draft: draftFromRow(db, draft),
       validation,
-      artifacts: {
-        resumeText: {
-          artifactId: artifacts.resumeTextArtifactId,
-          artifactType: "tailored_resume" as const,
-          generation: artifacts.generation,
-          renderFormat: "text" as const,
-        },
-        resumePdf: {
-          artifactId: artifacts.resumePdfArtifactId,
-          artifactType: "resume_pdf" as const,
-          generation: artifacts.generation,
-          renderFormat: "html_pdf" as const,
-        },
-      },
-      layoutBoxCount: artifacts.layoutBoxCount,
     };
-  });
-  return tx();
+  }
+
+  // Render before the transaction: the awaited render must never sit inside
+  // a better-sqlite3 transaction, whose deferred BEGIN pins a read snapshot
+  // that goes stale against concurrent worker commits and then fails the
+  // write upgrade with SQLITE_BUSY_SNAPSHOT.
+  const rendered = await renderDraftArtifactFiles(db, draft, revision, renderPdf);
+  try {
+    const tx = db.transaction(() => {
+      const current = getDraftRow(db, draft.draft_id);
+      if (
+        !current ||
+        current.state !== draft.state ||
+        current.current_revision_id !== draft.current_revision_id
+      ) {
+        throw new InputError("Resume review draft changed while rendering; retry the render.");
+      }
+      if (nextMaterialGeneration(db, draft.job_id) !== rendered.generation) {
+        throw new InputError("Job materials changed while rendering; retry the render.");
+      }
+      insertRenderedDraftArtifacts(db, draft, revision, validation, rendered);
+      const now = new Date().toISOString();
+      markResidualCommentThreadsAfterAcceptance(db, draft.draft_id, now);
+      db.prepare(
+        `UPDATE resume_review_drafts
+            SET state = 'promoted',
+                updated_at = ?
+          WHERE tenant_id = ? AND draft_id = ?`,
+      ).run(now, DEFAULT_TENANT, draft.draft_id);
+
+      const promotedDraft = getDraftRow(db, draft.draft_id);
+      if (!promotedDraft) {
+        throw new Error("Resume review draft was not promoted.");
+      }
+      return {
+        ok: true as const,
+        draft: draftFromRow(db, promotedDraft),
+        validation,
+        artifacts: {
+          resumeText: {
+            artifactId: rendered.resumeTextArtifactId,
+            artifactType: "tailored_resume" as const,
+            generation: rendered.generation,
+            renderFormat: "text" as const,
+          },
+          resumePdf: {
+            artifactId: rendered.resumePdfArtifactId,
+            artifactType: "resume_pdf" as const,
+            generation: rendered.generation,
+            renderFormat: "html_pdf" as const,
+          },
+        },
+        layoutBoxCount: rendered.layoutBoxes.length,
+      };
+    });
+    return tx();
+  } catch (error) {
+    // The files rendered but the rows did not commit: remove the orphans so
+    // a failed render leaves no artifacts without database rows.
+    for (const orphan of [rendered.textPath, rendered.htmlPath, rendered.pdfPath]) {
+      try {
+        fs.rmSync(orphan, { force: true });
+      } catch {
+        // Best-effort cleanup only; the original error is what matters.
+      }
+    }
+    throw error;
+  }
 }
 
 export function replyToResumeReviewComment(
@@ -1099,13 +1121,22 @@ function validateDraftRevisionForRender(
   return { passed: errors.length === 0, errors, warnings };
 }
 
-function persistRenderedDraftArtifacts(
+interface RenderedDraftArtifactFiles {
+  readonly generation: number;
+  readonly resumeTextArtifactId: string;
+  readonly resumePdfArtifactId: string;
+  readonly textPath: string;
+  readonly htmlPath: string;
+  readonly pdfPath: string;
+  readonly layoutBoxes: ResumeLayoutBoxDraft[];
+}
+
+async function renderDraftArtifactFiles(
   db: SqliteDatabase,
   draft: ResumeReviewDraftRow,
   revision: ResumeReviewDraftRevisionRow,
-  validation: ResumeReviewDraftValidation,
   renderPdf: ResumeHtmlPdfRenderer,
-): RenderedResumeArtifacts {
+): Promise<RenderedDraftArtifactFiles> {
   const outputDir = renderOutputDirectory(db, draft);
   if (!outputDir) {
     throw new InputError("No base resume artifact path is available for rendering the edited draft.");
@@ -1121,11 +1152,31 @@ function persistRenderedDraftArtifacts(
   const pdfPath = path.join(outputDir, `${baseName}.pdf`);
   const editedText = revision.edited_text.replace(/\r\n/g, "\n");
   const layoutBoxes = layoutBoxesForEditedText(editedText);
-  const now = new Date().toISOString();
 
   fs.writeFileSync(textPath, editedText, "utf8");
   fs.writeFileSync(htmlPath, htmlForEditedResume(editedText, parseJson(revision.plate_document_json)), "utf8");
-  renderPdf({ htmlPath, pdfPath });
+  await renderPdf({ htmlPath, pdfPath });
+  return {
+    generation,
+    resumeTextArtifactId,
+    resumePdfArtifactId,
+    textPath,
+    htmlPath,
+    pdfPath,
+    layoutBoxes,
+  };
+}
+
+function insertRenderedDraftArtifacts(
+  db: SqliteDatabase,
+  draft: ResumeReviewDraftRow,
+  revision: ResumeReviewDraftRevisionRow,
+  validation: ResumeReviewDraftValidation,
+  rendered: RenderedDraftArtifactFiles,
+): void {
+  const { generation, resumeTextArtifactId, resumePdfArtifactId, textPath, htmlPath, pdfPath, layoutBoxes } =
+    rendered;
+  const now = new Date().toISOString();
 
   db.prepare(
     `INSERT INTO job_materials (
@@ -1190,13 +1241,6 @@ function persistRenderedDraftArtifacts(
     now,
   );
   replaceLayoutBoxes(db, draft.job_id, generation, resumePdfArtifactId, layoutBoxes, now);
-
-  return {
-    generation,
-    resumeTextArtifactId,
-    resumePdfArtifactId,
-    layoutBoxCount: layoutBoxes.length,
-  };
 }
 
 function renderOutputDirectory(db: SqliteDatabase, draft: ResumeReviewDraftRow): string | null {

--- a/apps/api/src/resume-templates.ts
+++ b/apps/api/src/resume-templates.ts
@@ -929,16 +929,20 @@ async function persistRenderOnlyRefresh(
   const textPath = path.join(outputDir, `${baseName}.txt`);
   const htmlPath = path.join(outputDir, `${baseName}.html`);
   const pdfPath = path.join(outputDir, `${baseName}.pdf`);
+  const attemptId = crypto.randomUUID().slice(0, 8);
+  const tmpTextPath = `${textPath}.${attemptId}.tmp`;
+  const tmpHtmlPath = `${htmlPath}.${attemptId}.tmp`;
+  const tmpPdfPath = `${pdfPath}.${attemptId}.tmp`;
   const layoutBoxes = layoutBoxesForText(text);
   const now = new Date().toISOString();
   const templateMetadata = templateMetadataPayload(effective);
 
-  fs.writeFileSync(textPath, text, "utf8");
-  fs.writeFileSync(htmlPath, htmlForTemplateRefresh(text, effective), "utf8");
+  fs.writeFileSync(tmpTextPath, text, "utf8");
+  fs.writeFileSync(tmpHtmlPath, htmlForTemplateRefresh(text, effective), "utf8");
   try {
-    await renderPdf({ htmlPath, pdfPath });
+    await renderPdf({ htmlPath: tmpHtmlPath, pdfPath: tmpPdfPath });
   } catch (error) {
-    for (const orphan of [textPath, htmlPath, pdfPath]) {
+    for (const orphan of [tmpTextPath, tmpHtmlPath, tmpPdfPath]) {
       try {
         fs.rmSync(orphan, { force: true });
       } catch {
@@ -948,6 +952,93 @@ async function persistRenderOnlyRefresh(
     throw error;
   }
 
+  // Generation, source material, and effective template were captured before
+  // the awaited render; a concurrent material write, refresh, or template
+  // assignment can land in that gap. Revalidate and persist in one short
+  // transaction, promoting this attempt's temp files only after the guards.
+  let promoted = false;
+  try {
+    const tx = db.transaction(() => {
+      if (nextMaterialGeneration(db, jobId) !== generation) {
+        throw new ResumeTemplateInputError("Job materials changed while refreshing; retry the refresh.");
+      }
+      const currentMaterial = latestResumeMaterial(db, jobId);
+      if (!currentMaterial || currentMaterial.generation !== material.generation) {
+        throw new ResumeTemplateInputError("The source resume changed while refreshing; retry the refresh.");
+      }
+      const currentState = resumeTemplateStateForJobId(db, jobId);
+      if (
+        !currentState ||
+        currentState.effective.templateVersionId !== effective.templateVersionId ||
+        currentState.effective.templateHash !== effective.templateHash
+      ) {
+        throw new ResumeTemplateInputError("The effective template changed while refreshing; retry the refresh.");
+      }
+      promoted = true;
+      fs.renameSync(tmpTextPath, textPath);
+      fs.renameSync(tmpHtmlPath, htmlPath);
+      fs.renameSync(tmpPdfPath, pdfPath);
+      persistRefreshRows(db, {
+        jobId,
+        generation,
+        now,
+        textPath,
+        htmlPath,
+        pdfPath,
+        textArtifactId,
+        pdfArtifactId,
+        layoutBoxes,
+        material,
+        templateMetadata,
+      });
+    });
+    tx();
+  } catch (error) {
+    const orphans = [tmpTextPath, tmpHtmlPath, tmpPdfPath];
+    if (promoted) {
+      orphans.push(textPath, htmlPath, pdfPath);
+    }
+    for (const orphan of orphans) {
+      try {
+        fs.rmSync(orphan, { force: true });
+      } catch {
+        // Best-effort cleanup only; the original error is what matters.
+      }
+    }
+    throw error;
+  }
+  return { generation };
+}
+
+function persistRefreshRows(
+  db: SqliteDatabase,
+  input: {
+    jobId: JobId;
+    generation: number;
+    now: string;
+    textPath: string;
+    htmlPath: string;
+    pdfPath: string;
+    textArtifactId: string;
+    pdfArtifactId: string;
+    layoutBoxes: ReturnType<typeof layoutBoxesForText>;
+    material: { generation: number; text: MaterialArtifactRow; pdf: MaterialArtifactRow | null };
+    templateMetadata: unknown;
+  },
+): void {
+  const {
+    jobId,
+    generation,
+    now,
+    textPath,
+    htmlPath,
+    pdfPath,
+    textArtifactId,
+    pdfArtifactId,
+    layoutBoxes,
+    material,
+    templateMetadata,
+  } = input;
   db.prepare(
     `INSERT INTO job_materials (
        tenant_id, job_id, generation, status, created_at, updated_at,
@@ -1000,7 +1091,6 @@ async function persistRenderOnlyRefresh(
     createdAt: now,
   });
   replaceLayoutBoxes(db, jobId, generation, pdfArtifactId, layoutBoxes, now);
-  return { generation };
 }
 
 function insertMaterialArtifact(

--- a/apps/api/src/resume-templates.ts
+++ b/apps/api/src/resume-templates.ts
@@ -376,12 +376,12 @@ export function templateMetadataPayload(metadata: ResumeTemplateMetadata): Recor
   };
 }
 
-export function ensureCurrentResumeTemplateMaterials(
+export async function ensureCurrentResumeTemplateMaterials(
   db: SqliteDatabase,
   jobId: string,
   options: { force?: boolean } = {},
   renderPdf: ResumeHtmlPdfRenderer = defaultResumeHtmlPdfRenderer,
-): EnsureCurrentResumeMaterialsResponse {
+): Promise<EnsureCurrentResumeMaterialsResponse> {
   const stableJobId = requireJobId(jobId);
   assertJobExists(db, stableJobId);
 
@@ -440,7 +440,7 @@ export function ensureCurrentResumeTemplateMaterials(
   });
 
   try {
-    const refreshed = persistRenderOnlyRefresh(db, stableJobId, reusableMaterial, initialState.effective, renderPdf);
+    const refreshed = await persistRenderOnlyRefresh(db, stableJobId, reusableMaterial, initialState.effective, renderPdf);
     const attempt = recordRefreshAttempt(db, {
       jobId: stableJobId,
       status: "completed",
@@ -505,11 +505,11 @@ export function ensureCurrentResumeTemplateMaterials(
   }
 }
 
-export function resolveCurrentResumeArtifactIdForOpen(
+export async function resolveCurrentResumeArtifactIdForOpen(
   db: SqliteDatabase,
   artifactId: string,
   renderPdf: ResumeHtmlPdfRenderer = defaultResumeHtmlPdfRenderer,
-): string {
+): Promise<string> {
   const row = getRow<{
     job_id: string;
     artifact_type: string;
@@ -526,7 +526,7 @@ export function resolveCurrentResumeArtifactIdForOpen(
   }
 
   const jobId = requireJobId(row.job_id);
-  const refresh = ensureCurrentResumeTemplateMaterials(db, jobId, {}, renderPdf);
+  const refresh = await ensureCurrentResumeTemplateMaterials(db, jobId, {}, renderPdf);
   if (refresh.status !== "completed" && refresh.status !== "not_required") {
     return artifactId;
   }
@@ -904,13 +904,13 @@ function refreshAttemptFromRow(row: RefreshAttemptRow, jobId: JobId): ResumeTemp
   };
 }
 
-function persistRenderOnlyRefresh(
+async function persistRenderOnlyRefresh(
   db: SqliteDatabase,
   jobId: JobId,
   material: { generation: number; text: MaterialArtifactRow; pdf: MaterialArtifactRow | null },
   effective: ResumeTemplateMetadata,
   renderPdf: ResumeHtmlPdfRenderer,
-): { generation: number } {
+): Promise<{ generation: number }> {
   if (!material.text.path || !fs.existsSync(material.text.path) || !fs.statSync(material.text.path).isFile()) {
     throw new ResumeTemplateInputError("Latest accepted resume text artifact is not readable.");
   }
@@ -935,7 +935,7 @@ function persistRenderOnlyRefresh(
 
   fs.writeFileSync(textPath, text, "utf8");
   fs.writeFileSync(htmlPath, htmlForTemplateRefresh(text, effective), "utf8");
-  renderPdf({ htmlPath, pdfPath });
+  await renderPdf({ htmlPath, pdfPath });
 
   db.prepare(
     `INSERT INTO job_materials (

--- a/apps/api/src/resume-templates.ts
+++ b/apps/api/src/resume-templates.ts
@@ -935,7 +935,18 @@ async function persistRenderOnlyRefresh(
 
   fs.writeFileSync(textPath, text, "utf8");
   fs.writeFileSync(htmlPath, htmlForTemplateRefresh(text, effective), "utf8");
-  await renderPdf({ htmlPath, pdfPath });
+  try {
+    await renderPdf({ htmlPath, pdfPath });
+  } catch (error) {
+    for (const orphan of [textPath, htmlPath, pdfPath]) {
+      try {
+        fs.rmSync(orphan, { force: true });
+      } catch {
+        // Best-effort cleanup only; the render error is what matters.
+      }
+    }
+    throw error;
+  }
 
   db.prepare(
     `INSERT INTO job_materials (

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -262,12 +262,13 @@ import {
 } from "./learning-recommendations.js";
 import { listTailoringPolicyRevisions } from "./tailoring-policy-revisions.js";
 import { refreshProjections } from "./projections.js";
-import { createResumeHtmlPdfRenderer, type ResumeHtmlPdfRenderer } from "./resume-pdf-render.js";
+import { createResumeHtmlPdfRenderer, ResumeRenderError, type ResumeHtmlPdfRenderer } from "./resume-pdf-render.js";
 import {
   defaultSourcePythonRuntime,
   type PythonRuntimeCommandResolver,
 } from "./python-runtime.js";
 import {
+  DraftRenderConflictError,
   createOrLoadResumeReviewDraft,
   getResumeReviewDraftForJob,
   listResumeReviewFeedback,
@@ -4389,6 +4390,14 @@ async function withWritableDb<T>(
         error: "invalid_tailoring_feedback_review",
         message: error.message,
       };
+    }
+    if (error instanceof DraftRenderConflictError) {
+      void reply.code(409);
+      return { ok: false, error: "resume_render_conflict", message: error.message };
+    }
+    if (error instanceof ResumeRenderError) {
+      void reply.code(502);
+      return { ok: false, error: "resume_render_failed", message: error.message };
     }
     if (error instanceof InputError) {
       if (APPLY_REVIEW_PRECONDITION_ERRORS.has(error.message)) {

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -446,7 +446,7 @@ export function buildApp(options: BuildAppOptions): FastifyInstance {
     options.gmailFeedbackScanner ?? createWorkerGmailFeedbackScanner({ pythonRuntime });
   const profileImporter = options.profileImporter ?? createProfileImporter(pythonRuntime);
   const profilePreviewRenderer = options.profilePreviewRenderer ?? createProfilePreviewRenderer(pythonRuntime);
-  const resumePdfRenderer = options.resumePdfRenderer ?? createResumeHtmlPdfRenderer(pythonRuntime, appDir);
+  const resumePdfRenderer = options.resumePdfRenderer ?? createResumeHtmlPdfRenderer(providerDispatcher);
   const requireHealthyWorkerForActions =
     options.requireHealthyWorkerForActions ?? !options.actionDispatcher;
   ensureLocalCapabilityToken(appDir);
@@ -1345,8 +1345,8 @@ export function buildApp(options: BuildAppOptions): FastifyInstance {
       if (!body) {
         return undefined;
       }
-      return withWritableDb(reply, options.dbPath, (db) => {
-        const result = renderResumeReviewDraft(db, decodeRouteParam(request.params.draftId), body, resumePdfRenderer);
+      return withWritableDb(reply, options.dbPath, async (db) => {
+        const result = await renderResumeReviewDraft(db, decodeRouteParam(request.params.draftId), body, resumePdfRenderer);
         if (result.ok) {
           refreshProjections(db);
         }

--- a/apps/api/test/qa-workflow.test.ts
+++ b/apps/api/test/qa-workflow.test.ts
@@ -33,7 +33,7 @@ beforeEach(() => {
       pdfBytes: Buffer.from("%PDF-1.4\n% QA preview\n"),
       htmlText: '<main class="resume-page">QA preview</main>',
     }),
-    resumePdfRenderer: ({ htmlPath, pdfPath }) => {
+    resumePdfRenderer: async ({ htmlPath, pdfPath }) => {
       fs.writeFileSync(pdfPath, `%PDF-1.4 rendered\n${fs.readFileSync(htmlPath, "utf8")}`);
     },
   };

--- a/apps/api/test/resume-pdf-render.test.ts
+++ b/apps/api/test/resume-pdf-render.test.ts
@@ -1,44 +1,63 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 
-vi.mock("node:child_process", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("node:child_process")>();
-  return { ...actual, execFileSync: vi.fn() };
-});
+import type { JsonRpcDispatcher } from "../src/json-rpc-adapter.js";
+import { createResumeHtmlPdfRenderer, ResumeRenderError } from "../src/resume-pdf-render.js";
 
-import { execFileSync } from "node:child_process";
-
-import { defaultResumeHtmlPdfRenderer } from "../src/resume-pdf-render.js";
-
-const execFileSyncMock = vi.mocked(execFileSync);
-
-beforeEach(() => {
-  execFileSyncMock.mockReset();
-});
-
-describe("defaultResumeHtmlPdfRenderer", () => {
-  it("bounds the synchronous render subprocess with a timeout and generous maxBuffer", () => {
-    execFileSyncMock.mockReturnValue(Buffer.from(""));
-
-    defaultResumeHtmlPdfRenderer({ htmlPath: "/tmp/resume.html", pdfPath: "/tmp/resume.pdf" });
-
-    expect(execFileSyncMock).toHaveBeenCalledTimes(1);
-    const options = execFileSyncMock.mock.calls[0]![2] as { timeout?: number; maxBuffer?: number };
-    expect(options.timeout).toBe(120_000);
-    expect(options.maxBuffer).toBeGreaterThanOrEqual(10 * 1024 * 1024);
+describe("resume pdf renderer", () => {
+  it("dispatches render_resume_pdf and resolves on a valid result", async () => {
+    const calls: Array<{ method: string; params: Record<string, unknown> }> = [];
+    const dispatcher: JsonRpcDispatcher = {
+      call: async (method, params) => {
+        calls.push({ method, params });
+        return {
+          jsonrpc: "2.0" as const,
+          id: 1,
+          result: { status: "succeeded", pdfPath: String(params.pdfPath) },
+        };
+      },
+      close: async () => {},
+    };
+    await createResumeHtmlPdfRenderer(dispatcher)({ htmlPath: "/tmp/in.html", pdfPath: "/tmp/out.pdf" });
+    expect(calls).toEqual([
+      { method: "render_resume_pdf", params: { htmlPath: "/tmp/in.html", pdfPath: "/tmp/out.pdf" } },
+    ]);
   });
 
-  it("surfaces a subprocess timeout as a render failure the persist path can catch", () => {
-    const timeoutError = Object.assign(new Error("spawnSync uv ETIMEDOUT"), {
-      code: "ETIMEDOUT",
-      killed: true,
-      stderr: Buffer.from(""),
-    });
-    execFileSyncMock.mockImplementation(() => {
-      throw timeoutError;
-    });
+  it("wraps dispatcher rejections in ResumeRenderError", async () => {
+    const dispatcher: JsonRpcDispatcher = {
+      call: async () => {
+        throw new Error("JSON-RPC request timed out after 600000ms");
+      },
+      close: async () => {},
+    };
+    const render = createResumeHtmlPdfRenderer(dispatcher);
+    await expect(render({ htmlPath: "/tmp/in.html", pdfPath: "/tmp/out.pdf" })).rejects.toThrow(
+      ResumeRenderError,
+    );
+    await expect(render({ htmlPath: "/tmp/in.html", pdfPath: "/tmp/out.pdf" })).rejects.toThrow(
+      "Resume HTML-to-PDF render failed: JSON-RPC request timed out after 600000ms",
+    );
+  });
 
-    expect(() =>
-      defaultResumeHtmlPdfRenderer({ htmlPath: "/tmp/resume.html", pdfPath: "/tmp/resume.pdf" }),
-    ).toThrow(/Resume HTML-to-PDF render failed/);
+  it("wraps error envelopes preferring error.data and rejects invalid results", async () => {
+    const errorDispatcher: JsonRpcDispatcher = {
+      call: async () => ({
+        jsonrpc: "2.0" as const,
+        id: 1,
+        error: { code: -32603, message: "Internal error", data: "[Errno 21] Is a directory" },
+      }),
+      close: async () => {},
+    };
+    await expect(
+      createResumeHtmlPdfRenderer(errorDispatcher)({ htmlPath: "a", pdfPath: "b" }),
+    ).rejects.toThrow("Resume HTML-to-PDF render failed: [Errno 21] Is a directory");
+
+    const invalidDispatcher: JsonRpcDispatcher = {
+      call: async () => ({ jsonrpc: "2.0" as const, id: 1, result: { nope: true } }),
+      close: async () => {},
+    };
+    await expect(
+      createResumeHtmlPdfRenderer(invalidDispatcher)({ htmlPath: "a", pdfPath: "b" }),
+    ).rejects.toThrow(ResumeRenderError);
   });
 });

--- a/apps/api/test/resume-review-drafts.test.ts
+++ b/apps/api/test/resume-review-drafts.test.ts
@@ -1181,7 +1181,10 @@ describe("resume review draft API", () => {
     });
     expect(renderResponse.statusCode, renderResponse.body).toBe(200);
     const body = renderResponse.json();
-    const renderedHtml = fs.readFileSync(renderedPdfInputs[0]!.htmlPath, "utf8");
+    const renderedHtml = fs.readFileSync(
+      renderedPdfInputs[0]!.htmlPath.replace(/\.[0-9a-f]{8}\.tmp$/, ""),
+      "utf8",
+    );
     expect(renderedHtml).toContain('href="https://portfolio.example.test"');
     expect(renderedHtml).toContain(">Portfolio</a>");
     expect(renderedHtml).not.toContain("javascript:");
@@ -1235,7 +1238,10 @@ describe("resume review draft API", () => {
     expect(body.artifacts.resumePdf.renderFormat).toBe("html_pdf");
 
     expect(renderedPdfInputs).toHaveLength(1);
-    const renderedHtml = fs.readFileSync(renderedPdfInputs[0]!.htmlPath, "utf8");
+    const renderedHtml = fs.readFileSync(
+      renderedPdfInputs[0]!.htmlPath.replace(/\.[0-9a-f]{8}\.tmp$/, ""),
+      "utf8",
+    );
     expect(renderedHtml).toContain("Delivered platform outcome number 70 across critical services.");
     expect(renderedHtml).toContain(longBullet.replace(/^- /, ""));
 
@@ -1377,6 +1383,72 @@ describe("resume review draft API", () => {
     });
     expect(retry.statusCode, retry.body).toBe(200);
     expect(retry.json().ok).toBe(true);
+
+    await app.close();
+  });
+
+  it("keeps the winner's files intact when concurrent renders race the same revision", async () => {
+    let releaseFirst!: () => void;
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    let renderCalls = 0;
+    const renderer: ResumeHtmlPdfRenderer = async ({ htmlPath, pdfPath }) => {
+      renderCalls += 1;
+      const call = renderCalls;
+      fs.writeFileSync(pdfPath, `%PDF-1.4 rendered\n${fs.readFileSync(htmlPath, "utf8")}`);
+      if (call === 1) {
+        await firstGate;
+      }
+    };
+    const app = buildApp({ ...options, resumePdfRenderer: renderer });
+    const createResponse = await app.inject({
+      method: "POST",
+      url: `/v1/jobs/${encodeURIComponent(JOB_KEY)}/resume-review/draft`,
+      payload: {},
+    });
+    const draftId = createResponse.json().draft.draftId as string;
+    const saveResponse = await app.inject({
+      method: "POST",
+      url: `/v1/resume-review/drafts/${encodeURIComponent(draftId)}/revisions`,
+      payload: { editedText: "Jordan Example\nExperience\n- Led racing work.", editDeltas: [] },
+    });
+    const revisionId = saveResponse.json().revision.revisionId as string;
+
+    // Both attempts compute the same generation and deterministic final
+    // paths; the first stalls in its render while the second commits.
+    const firstAttempt = app.inject({
+      method: "POST",
+      url: `/v1/resume-review/drafts/${encodeURIComponent(draftId)}/render`,
+      payload: { draftRevisionId: revisionId },
+    });
+    await vi.waitFor(() => expect(renderCalls).toBe(1));
+    const second = await app.inject({
+      method: "POST",
+      url: `/v1/resume-review/drafts/${encodeURIComponent(draftId)}/render`,
+      payload: { draftRevisionId: revisionId },
+    });
+    expect(second.statusCode, second.body).toBe(200);
+    const winnerPdf = second.json().artifacts.resumePdf.artifactId as string;
+
+    releaseFirst();
+    const first = await firstAttempt;
+    expect(first.statusCode, first.body).toBe(409);
+    expect(first.json().error).toBe("resume_render_conflict");
+
+    const db = new Database(options.dbPath);
+    try {
+      const winnerRow = db
+        .prepare("SELECT path FROM job_materials_artifacts WHERE artifact_id = ?")
+        .get(winnerPdf) as { path: string };
+      expect(fs.existsSync(winnerRow.path), winnerRow.path).toBe(true);
+    } finally {
+      db.close();
+    }
+    const tmpStrays = fs
+      .readdirSync(path.dirname(options.dbPath), { recursive: true })
+      .filter((entry) => String(entry).endsWith(".tmp"));
+    expect(tmpStrays).toEqual([]);
 
     await app.close();
   });

--- a/apps/api/test/resume-review-drafts.test.ts
+++ b/apps/api/test/resume-review-drafts.test.ts
@@ -21,7 +21,7 @@ let renderedPdfInputs: ResumeHtmlPdfRenderInput[] = [];
 // Stand-in for the Playwright HTML-to-PDF subprocess: records the render inputs
 // and writes the exact HTML the flow built so tests inspect the full resume
 // content instead of spawning a browser.
-const resumePdfRenderer: ResumeHtmlPdfRenderer = (input) => {
+const resumePdfRenderer: ResumeHtmlPdfRenderer = async (input) => {
   renderedPdfInputs.push(input);
   fs.writeFileSync(input.pdfPath, `%PDF-1.4 rendered\n${fs.readFileSync(input.htmlPath, "utf8")}`);
 };

--- a/apps/api/test/resume-review-drafts.test.ts
+++ b/apps/api/test/resume-review-drafts.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import Database from "better-sqlite3";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { ResumeRenderError } from "../src/resume-pdf-render.js";
 import type { ResumeHtmlPdfRenderInput, ResumeHtmlPdfRenderer } from "../src/resume-pdf-render.js";
 import { BUILT_IN_RESUME_TEMPLATE_THEME } from "../src/resume-templates.js";
 import { buildApp, type BuildAppOptions } from "../src/server.js";
@@ -1259,7 +1260,7 @@ describe("resume review draft API", () => {
     const app = buildApp({
       ...options,
       resumePdfRenderer: () => {
-        throw new Error("chromium unavailable");
+        throw new ResumeRenderError("Resume HTML-to-PDF render failed: chromium unavailable");
       },
     });
     const createResponse = await app.inject({
@@ -1286,7 +1287,14 @@ describe("resume review draft API", () => {
       url: `/v1/resume-review/drafts/${encodeURIComponent(draftId)}/render`,
       payload: { draftRevisionId: revisionId },
     });
-    expect(renderResponse.statusCode).toBe(500);
+    expect(renderResponse.statusCode).toBe(502);
+    expect(renderResponse.json().error).toBe("resume_render_failed");
+    expect(renderResponse.json().message).toContain("chromium unavailable");
+
+    const strays = fs
+      .readdirSync(path.dirname(options.dbPath), { recursive: true })
+      .filter((entry) => String(entry).includes("resume-review-"));
+    expect(strays).toEqual([]);
 
     const db = new Database(options.dbPath);
     try {
@@ -1306,6 +1314,69 @@ describe("resume review draft API", () => {
     } finally {
       db.close();
     }
+
+    await app.close();
+  });
+
+  it("returns a retryable 409 when materials change while rendering", async () => {
+    let conflictInjected = false;
+    const app = buildApp({
+      ...options,
+      resumePdfRenderer: async ({ htmlPath, pdfPath }) => {
+        if (!conflictInjected) {
+          conflictInjected = true;
+          const db = new Database(options.dbPath);
+          try {
+            const jobId = db
+              .prepare("SELECT job_id FROM resume_review_drafts LIMIT 1")
+              .get() as { job_id: string };
+            db.prepare(
+              `INSERT INTO job_materials (
+                 tenant_id, job_id, generation, status, created_at, updated_at,
+                 last_validation_json, last_verdict_json, metadata_json
+               ) SELECT tenant_id, job_id, MAX(generation) + 1, 'resume_approved', ?, ?, '{}', '{}', '{}'
+               FROM job_materials WHERE job_id = ? GROUP BY tenant_id, job_id`,
+            ).run(new Date().toISOString(), new Date().toISOString(), jobId.job_id);
+          } finally {
+            db.close();
+          }
+        }
+        fs.writeFileSync(pdfPath, `%PDF-1.4 rendered\n${fs.readFileSync(htmlPath, "utf8")}`);
+      },
+    });
+    const createResponse = await app.inject({
+      method: "POST",
+      url: `/v1/jobs/${encodeURIComponent(JOB_KEY)}/resume-review/draft`,
+      payload: {},
+    });
+    const draftId = createResponse.json().draft.draftId as string;
+    const saveResponse = await app.inject({
+      method: "POST",
+      url: `/v1/resume-review/drafts/${encodeURIComponent(draftId)}/revisions`,
+      payload: { editedText: "Jordan Example\nExperience\n- Led work.", editDeltas: [] },
+    });
+    const revisionId = saveResponse.json().revision.revisionId as string;
+
+    const conflicted = await app.inject({
+      method: "POST",
+      url: `/v1/resume-review/drafts/${encodeURIComponent(draftId)}/render`,
+      payload: { draftRevisionId: revisionId },
+    });
+    expect(conflicted.statusCode, conflicted.body).toBe(409);
+    expect(conflicted.json().error).toBe("resume_render_conflict");
+
+    const straysAfterConflict = fs
+      .readdirSync(path.dirname(options.dbPath), { recursive: true })
+      .filter((entry) => String(entry).includes("resume-review-"));
+    expect(straysAfterConflict).toEqual([]);
+
+    const retry = await app.inject({
+      method: "POST",
+      url: `/v1/resume-review/drafts/${encodeURIComponent(draftId)}/render`,
+      payload: { draftRevisionId: revisionId },
+    });
+    expect(retry.statusCode, retry.body).toBe(200);
+    expect(retry.json().ok).toBe(true);
 
     await app.close();
   });

--- a/apps/api/test/resume-templates.test.ts
+++ b/apps/api/test/resume-templates.test.ts
@@ -361,6 +361,31 @@ describe("resume template service", () => {
     ]);
   });
 
+  it("fails the refresh cleanly when a material write races the render", async () => {
+    const racingRenderer: ResumeHtmlPdfRenderer = async ({ htmlPath, pdfPath }) => {
+      db.prepare(
+        `INSERT INTO job_materials (
+           tenant_id, job_id, generation, status, created_at, updated_at,
+           last_validation_json, last_verdict_json, metadata_json
+         ) SELECT tenant_id, job_id, MAX(generation) + 1, 'resume_approved', ?, ?, '{}', '{}', '{}'
+         FROM job_materials WHERE job_id = ? GROUP BY tenant_id, job_id`,
+      ).run(new Date().toISOString(), new Date().toISOString(), JOB_ID);
+      fs.writeFileSync(pdfPath, `%PDF-1.4 rendered\n${fs.readFileSync(htmlPath, "utf8")}`);
+    };
+
+    const refresh = await ensureCurrentResumeTemplateMaterials(db, JOB_ID, { force: true }, racingRenderer);
+    expect(refresh.status).toBe("failed");
+    expect(refresh.message).toContain("retry the refresh");
+
+    const tmpStrays = fs
+      .readdirSync(tempDir, { recursive: true })
+      .filter((entry) => String(entry).endsWith(".tmp"));
+    expect(tmpStrays).toEqual([]);
+
+    const retry = await ensureCurrentResumeTemplateMaterials(db, JOB_ID, { force: true }, renderHtmlToPdf);
+    expect(retry.status).toBe("completed");
+  });
+
   it("refuses invalid UUIDs and never treats posting or application URLs as identity", async () => {
     expect(() => setJobResumeTemplateAssignment(db, JOB_URL, { templateId: null })).toThrow(
       "jobId must be a canonical lowercase UUID",

--- a/apps/api/test/resume-templates.test.ts
+++ b/apps/api/test/resume-templates.test.ts
@@ -27,7 +27,7 @@ const NOW = "2026-06-24T10:00:00.000Z";
 // Stand-in for the Playwright HTML-to-PDF subprocess: it renders the exact HTML
 // the refresh built, so tests inspect the full resume content instead of spawning
 // a browser.
-const renderHtmlToPdf: ResumeHtmlPdfRenderer = ({ htmlPath, pdfPath }) => {
+const renderHtmlToPdf: ResumeHtmlPdfRenderer = async ({ htmlPath, pdfPath }) => {
   fs.writeFileSync(pdfPath, `%PDF-1.4 rendered\n${fs.readFileSync(htmlPath, "utf8")}`);
 };
 
@@ -46,7 +46,7 @@ afterEach(() => {
 });
 
 describe("resume template service", () => {
-  it("saves style-only template versions, default selection, and per-job overrides", () => {
+  it("saves style-only template versions, default selection, and per-job overrides", async () => {
     const initial = listResumeTemplates(db);
     expect(initial.templates).toHaveLength(1);
     expect(initial.templates[0]).toMatchObject({ builtIn: true, displayName: "Modern HTML" });
@@ -86,7 +86,7 @@ describe("resume template service", () => {
     expect(assignment.templateState?.state).toBe("template_stale");
   });
 
-  it("returns the exact pinned default version when a newer version exists", () => {
+  it("returns the exact pinned default version when a newer version exists", async () => {
     const first = createResumeTemplateVersion(db, {
       displayName: "Pinned template",
       theme: {
@@ -125,7 +125,7 @@ describe("resume template service", () => {
     });
   });
 
-  it("rejects template payloads that contain profile or job facts", () => {
+  it("rejects template payloads that contain profile or job facts", async () => {
     expect(() =>
       createResumeTemplateVersion(db, {
         displayName: "Jordan Candidate",
@@ -143,7 +143,7 @@ describe("resume template service", () => {
     ).toThrow(ResumeTemplateInputError);
   });
 
-  it("lazily creates a render-only generation when the effective template changes", () => {
+  it("lazily creates a render-only generation when the effective template changes", async () => {
     const saved = createResumeTemplateVersion(db, {
       displayName: "Spacious serif",
       theme: {
@@ -159,7 +159,7 @@ describe("resume template service", () => {
       versionId: saved.template.activeVersion.versionId,
     });
 
-    const refresh = ensureCurrentResumeTemplateMaterials(db, JOB_ID, {}, renderHtmlToPdf);
+    const refresh = await ensureCurrentResumeTemplateMaterials(db, JOB_ID, {}, renderHtmlToPdf);
     expect(refresh.status).toBe("completed");
     expect(refresh.generation).toBe(2);
     expect(refresh.templateState?.state).toBe("template_current");
@@ -189,7 +189,7 @@ describe("resume template service", () => {
     expect(event?.payload_json).toContain(saved.template.activeVersion.versionId);
   });
 
-  it("opens the refreshed resume artifact when a stale artifact id is requested", () => {
+  it("opens the refreshed resume artifact when a stale artifact id is requested", async () => {
     const saved = createResumeTemplateVersion(db, {
       displayName: "Current open template",
       theme: {
@@ -203,12 +203,12 @@ describe("resume template service", () => {
       versionId: saved.template.activeVersion.versionId,
     });
 
-    const resolved = resolveCurrentResumeArtifactIdForOpen(db, "resume-pdf-v1", renderHtmlToPdf);
+    const resolved = await resolveCurrentResumeArtifactIdForOpen(db, "resume-pdf-v1", renderHtmlToPdf);
     expect(resolved).not.toBe("resume-pdf-v1");
     expect(resolved).toMatch(/^template_refresh_pdf_/);
   });
 
-  it("reports refresh unavailable without hiding the last accepted artifact", () => {
+  it("reports refresh unavailable without hiding the last accepted artifact", async () => {
     db.prepare("DELETE FROM job_materials_artifacts WHERE artifact_type = 'tailored_resume'").run();
     const saved = createResumeTemplateVersion(db, {
       displayName: "Unavailable refresh template",
@@ -223,7 +223,7 @@ describe("resume template service", () => {
       versionId: saved.template.activeVersion.versionId,
     });
 
-    const refresh = ensureCurrentResumeTemplateMaterials(db, JOB_ID, {}, renderHtmlToPdf);
+    const refresh = await ensureCurrentResumeTemplateMaterials(db, JOB_ID, {}, renderHtmlToPdf);
     expect(refresh.status).toBe("unavailable");
     expect(refresh.generation).toBeNull();
     expect(refresh.templateState?.state).toBe("refresh_unavailable");
@@ -244,7 +244,7 @@ describe("resume template service", () => {
     expect(event?.payload_json).toContain("unavailable");
   });
 
-  it("renders every line of a long resume across the refreshed PDF without truncation", () => {
+  it("renders every line of a long resume across the refreshed PDF without truncation", async () => {
     const longBullet =
       "- Drove a company-wide reliability program spanning ingestion, streaming, and storage tiers while mentoring a distributed platform and product engineering team.";
     const lines = ["Jordan Candidate", "Platform Engineering Leader", "Experience"];
@@ -265,7 +265,7 @@ describe("resume template service", () => {
       versionId: saved.template.activeVersion.versionId,
     });
 
-    const refresh = ensureCurrentResumeTemplateMaterials(db, JOB_ID, {}, renderHtmlToPdf);
+    const refresh = await ensureCurrentResumeTemplateMaterials(db, JOB_ID, {}, renderHtmlToPdf);
     expect(refresh.status).toBe("completed");
 
     const refreshedPdf = db
@@ -279,7 +279,7 @@ describe("resume template service", () => {
     expect(pdf).not.toContain("72 750 Td");
   });
 
-  it("keeps the last accepted resume artifact when the PDF render fails", () => {
+  it("keeps the last accepted resume artifact when the PDF render fails", async () => {
     const saved = createResumeTemplateVersion(db, {
       displayName: "Failing render template",
       theme: { ...BUILT_IN_RESUME_TEMPLATE_THEME, fontFamily: "serif" },
@@ -293,7 +293,7 @@ describe("resume template service", () => {
     const failingRenderer: ResumeHtmlPdfRenderer = () => {
       throw new Error("chromium unavailable");
     };
-    const refresh = ensureCurrentResumeTemplateMaterials(db, JOB_ID, {}, failingRenderer);
+    const refresh = await ensureCurrentResumeTemplateMaterials(db, JOB_ID, {}, failingRenderer);
     expect(refresh.status).toBe("failed");
     expect(refresh.generation).toBeNull();
     expect(refresh.templateState?.state).toBe("refresh_failed");
@@ -313,7 +313,7 @@ describe("resume template service", () => {
     expect(failedEvent?.payload_json).toContain("failed");
   });
 
-  it("uses exact-v7 tenant and JobId keys for assignments, materials, layout, attempts, and events", () => {
+  it("uses exact-v7 tenant and JobId keys for assignments, materials, layout, attempts, and events", async () => {
     const saved = createResumeTemplateVersion(db, {
       displayName: "Tenant-isolated template",
       theme: { ...BUILT_IN_RESUME_TEMPLATE_THEME, fontFamily: "serif" },
@@ -330,7 +330,7 @@ describe("resume template service", () => {
     ).run(JOB_ID, NOW);
 
     expect(resumeTemplateStateForJob(db, JOB_ID)?.effective.templateId).toBe(saved.template.templateId);
-    const refresh = ensureCurrentResumeTemplateMaterials(db, JOB_ID, {}, renderHtmlToPdf);
+    const refresh = await ensureCurrentResumeTemplateMaterials(db, JOB_ID, {}, renderHtmlToPdf);
     expect(refresh.status).toBe("completed");
 
     expect(
@@ -361,14 +361,14 @@ describe("resume template service", () => {
     ]);
   });
 
-  it("refuses invalid UUIDs and never treats posting or application URLs as identity", () => {
+  it("refuses invalid UUIDs and never treats posting or application URLs as identity", async () => {
     expect(() => setJobResumeTemplateAssignment(db, JOB_URL, { templateId: null })).toThrow(
       "jobId must be a canonical lowercase UUID",
     );
     expect(() => resumeTemplateStateForJob(db, JOB_ID.toUpperCase())).toThrow(
       "jobId must be a canonical lowercase UUID",
     );
-    expect(() => ensureCurrentResumeTemplateMaterials(db, UUID_SHAPED_URL, {}, renderHtmlToPdf)).toThrow(
+    await expect(ensureCurrentResumeTemplateMaterials(db, UUID_SHAPED_URL, {}, renderHtmlToPdf)).rejects.toThrow(
       `Job not found: ${UUID_SHAPED_URL}`,
     );
   });

--- a/apps/api/test/server.test.ts
+++ b/apps/api/test/server.test.ts
@@ -120,7 +120,7 @@ beforeEach(() => {
     dbPath: path.join(tempDir, "jobctrl.db"),
     configPath: path.join(tempDir, "config.json"),
     actionDispatcher: vi.fn(async (): Promise<ActionDispatchResult> => ({ status: "queued", runId: "run-profile-retailor" })),
-    resumePdfRenderer: ({ htmlPath, pdfPath }) => {
+    resumePdfRenderer: async ({ htmlPath, pdfPath }) => {
       fs.writeFileSync(pdfPath, `%PDF-1.4 rendered\n${fs.readFileSync(htmlPath, "utf8")}`);
     },
   };

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -92,6 +92,7 @@ export const RpcMethods = {
   RederiveLearningRecommendations: "rederive_learning_recommendations",
   ReviewLearningRecommendation: "review_learning_recommendation",
   RollbackTailoringPolicy: "rollback_tailoring_policy",
+  RenderResumePdf: "render_resume_pdf",
 } as const;
 export type RpcMethod = (typeof RpcMethods)[keyof typeof RpcMethods];
 
@@ -617,6 +618,22 @@ export const RollbackTailoringPolicyResultSchema = z
 export type RollbackTailoringPolicyResult = z.infer<
   typeof RollbackTailoringPolicyResultSchema
 >;
+
+export const RenderResumePdfParamsSchema = z
+  .object({
+    htmlPath: z.string().trim().min(1),
+    pdfPath: z.string().trim().min(1),
+  })
+  .strict();
+export type RenderResumePdfParams = z.infer<typeof RenderResumePdfParamsSchema>;
+
+export const RenderResumePdfResultSchema = z
+  .object({
+    status: z.literal("succeeded"),
+    pdfPath: z.string().min(1),
+  })
+  .strict();
+export type RenderResumePdfResult = z.infer<typeof RenderResumePdfResultSchema>;
 
 export const ProfileImportParamsSchema = z
   .object({

--- a/workers/automation/src/jobctrl/infrastructure/rpc/handlers.py
+++ b/workers/automation/src/jobctrl/infrastructure/rpc/handlers.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import asyncio
 from datetime import UTC, datetime
 import logging
+from pathlib import Path
 from typing import Any
 
 from jobctrl.database import get_connection
@@ -902,6 +903,29 @@ def make_cancel_run(canceler: WorkflowCanceler):
     return cancel_run
 
 
+def render_resume_pdf(params: dict[str, Any]) -> dict[str, Any]:
+    """Render pre-built resume HTML to a paginated PDF for the TS API.
+
+    Runs inside the long-lived rpc child so the API's event loop keeps
+    serving during Chromium renders; the API persists database rows only
+    after this returns.
+    """
+
+    html_path_raw = str(_require(params, "htmlPath")).strip()
+    pdf_path = str(_require(params, "pdfPath")).strip()
+    if not pdf_path:
+        raise invalid_params("pdfPath must be non-empty")
+    html_path = Path(html_path_raw)
+    if not html_path.is_file():
+        raise invalid_params(f"htmlPath does not exist: {html_path_raw}")
+    from jobctrl.infrastructure.materials.html_resume_pdf import (
+        render_resume_html_to_pdf,
+    )
+
+    render_resume_html_to_pdf(html_path.read_text(encoding="utf-8"), pdf_path)
+    return {"status": "succeeded", "pdfPath": pdf_path}
+
+
 def rederive_learning_recommendations(params: dict[str, Any]) -> dict[str, Any]:
     """Refresh pending Materials proposals after an explicit signal review."""
 
@@ -1042,6 +1066,7 @@ def register_default_handlers(server: JsonRpcServer, *, canceler: WorkflowCancel
         mode="sync",
     )
     server.register("rollback_tailoring_policy", rollback_tailoring_policy, mode="sync")
+    server.register("render_resume_pdf", render_resume_pdf, mode="sync")
     server.register("refresh_compensation", refresh_compensation, mode="workflow")
     server.register("generate_interview_prep", generate_interview_prep, mode="workflow")
     server.register("run_contact_research", run_contact_research, mode="workflow")

--- a/workers/automation/tests/test_render_resume_pdf_handler.py
+++ b/workers/automation/tests/test_render_resume_pdf_handler.py
@@ -1,0 +1,45 @@
+"""The render_resume_pdf sync RPC handler used by the TS API's PDF seam."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from jobctrl.infrastructure.rpc import handlers
+from jobctrl.infrastructure.rpc.server import _RpcParamError
+
+
+def test_renders_html_file_via_the_playwright_adapter(tmp_path, monkeypatch):
+    calls: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        "jobctrl.infrastructure.materials.html_resume_pdf.render_resume_html_to_pdf",
+        lambda html, pdf_path: calls.append((html, pdf_path)),
+    )
+    html_path = tmp_path / "resume.html"
+    html_path.write_text("<main>resume</main>", encoding="utf-8")
+    pdf_path = str(tmp_path / "resume.pdf")
+
+    result = handlers.render_resume_pdf({"htmlPath": str(html_path), "pdfPath": pdf_path})
+
+    assert result == {"status": "succeeded", "pdfPath": pdf_path}
+    assert calls == [("<main>resume</main>", pdf_path)]
+
+
+def test_rejects_missing_html_file(tmp_path):
+    with pytest.raises(_RpcParamError):
+        handlers.render_resume_pdf(
+            {"htmlPath": str(tmp_path / "absent.html"), "pdfPath": str(tmp_path / "out.pdf")}
+        )
+
+
+def test_rejects_empty_pdf_path(tmp_path):
+    html_path = tmp_path / "resume.html"
+    html_path.write_text("x", encoding="utf-8")
+    with pytest.raises(_RpcParamError):
+        handlers.render_resume_pdf({"htmlPath": str(html_path), "pdfPath": "  "})
+
+
+def test_registered_as_a_sync_method():
+    source = Path(handlers.__file__).read_text(encoding="utf-8")
+    assert 'server.register("render_resume_pdf", render_resume_pdf, mode="sync")' in source

--- a/workers/automation/uv.lock
+++ b/workers/automation/uv.lock
@@ -14,8 +14,8 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-07-28T20:43:30.561404Z"
-exclude-newer-span = "P7D"
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P8D"
 
 [options.exclude-newer-package]
 claude-agent-sdk = "2026-07-10T00:00:00Z"


### PR DESCRIPTION
## Summary
Resume PDF rendering moves from a synchronous `execFileSync` Python+Chromium subprocess (up to 120s inside the API's event loop) to a `render_resume_pdf` sync JSON-RPC method on the API's long-lived `jobctrl rpc` child. `ResumeHtmlPdfRenderer` becomes async; the templates render-only refresh and the drafts flow await it with database rows persisted only after artifact files exist. `renderResumeReviewDraft` renders **before** its transaction, re-validates the draft and the materials generation inside a short write transaction, and removes orphaned artifact files when the commit fails.

## Why
Every render froze the whole API — every route, `/v1/health`, the SSE tick — for its duration, and the draft path additionally wrapped the subprocess in a deferred-BEGIN transaction whose write upgrade failed with `SQLITE_BUSY_SNAPSHOT` whenever the worker heartbeat committed mid-render (500 + stranded files). Architecture review R1 finding.

## Validation
api/web/contracts typechecks; 233-test server suite; resume-templates, resume-review-drafts, qa-workflow, projections suites; new Python handler tests (param validation, adapter dispatch, sync registration). Tier-2 product QA (real end-to-end render through the rpc child + health-during-render probe + orphan check) runs as a separate gate on this stack.