### PR TITLE
fix(api): run the Gmail outcome scan through the JSON-RPC worker seam

### DIFF
--- a/apps/api/src/gmail-feedback-worker.ts
+++ b/apps/api/src/gmail-feedback-worker.ts
@@ -32,7 +32,9 @@ export class GmailFeedbackScanError extends Error {
 // the status mapping below stays behavior-identical.
 export function createWorkerGmailFeedbackScanner(dispatcher: JsonRpcDispatcher): GmailFeedbackScanner {
   return async (input, context) => {
-    const response = await dispatcher.call(RpcMethods.GmailFeedbackScan, {
+    let response: Awaited<ReturnType<JsonRpcDispatcher["call"]>>;
+    try {
+      response = await dispatcher.call(RpcMethods.GmailFeedbackScan, {
       expectedAppDir: context.appDir,
       expectedDbPath: context.dbPath,
       ...(input.recipientEmail !== undefined ? { recipientEmail: input.recipientEmail } : {}),
@@ -41,7 +43,14 @@ export function createWorkerGmailFeedbackScanner(dispatcher: JsonRpcDispatcher):
         ? { maxResultsPerAnchor: Number(input.maxResultsPerAnchor) }
         : {}),
       ...(input.windowDays !== undefined ? { windowDays: Number(input.windowDays) } : {}),
-    });
+      });
+    } catch (error) {
+      // Transport-level failures (spawn/write errors, the request timeout,
+      // child exit) reject instead of returning a JSON-RPC error envelope;
+      // keep them on the route's typed error path.
+      const message = `Gmail feedback scan failed: ${error instanceof Error ? error.message : String(error)}`;
+      throw new GmailFeedbackScanError(message, gmailFeedbackErrorStatus(message));
+    }
     if (response.error) {
       // The RPC server hides handler exceptions behind a generic "Internal
       // error" message with the cause in error.data; the handler converts

--- a/apps/api/src/gmail-feedback-worker.ts
+++ b/apps/api/src/gmail-feedback-worker.ts
@@ -43,7 +43,11 @@ export function createWorkerGmailFeedbackScanner(dispatcher: JsonRpcDispatcher):
       ...(input.windowDays !== undefined ? { windowDays: Number(input.windowDays) } : {}),
     });
     if (response.error) {
-      const message = response.error.message || "Gmail feedback scan failed.";
+      // The RPC server hides handler exceptions behind a generic "Internal
+      // error" message with the cause in error.data; the handler converts
+      // scan failures to ok:false, so this path is dispatch-level only.
+      const message =
+        optionalText(response.error.data) ?? optionalText(response.error.message) ?? "Gmail feedback scan failed.";
       throw new GmailFeedbackScanError(message, gmailFeedbackErrorStatus(message));
     }
     const parsed = response.result;

--- a/apps/api/src/gmail-feedback-worker.ts
+++ b/apps/api/src/gmail-feedback-worker.ts
@@ -1,12 +1,10 @@
-import { spawn } from "node:child_process";
-
 import type {
   ApplicationOutcomeKind,
   GmailOutcomeScanRequest,
   GmailOutcomeScanResponse,
 } from "./contracts.js";
-import { APPLICATION_OUTCOME_KINDS } from "./contracts.js";
-import { createSourcePythonRuntime, type PythonRuntimeCommandResolver } from "./python-runtime.js";
+import { APPLICATION_OUTCOME_KINDS, RpcMethods } from "./contracts.js";
+import type { JsonRpcDispatcher } from "./json-rpc-adapter.js";
 
 export interface GmailFeedbackScanContext {
   appDir: string;
@@ -18,12 +16,6 @@ export type GmailFeedbackScanner = (
   context: GmailFeedbackScanContext,
 ) => Promise<unknown>;
 
-export interface WorkerGmailFeedbackScannerOptions {
-  projectDir?: string;
-  uvBinary?: string;
-  pythonRuntime?: PythonRuntimeCommandResolver;
-}
-
 export class GmailFeedbackScanError extends Error {
   readonly statusCode: number;
 
@@ -34,22 +26,36 @@ export class GmailFeedbackScanError extends Error {
   }
 }
 
-export function createWorkerGmailFeedbackScanner(
-  options: WorkerGmailFeedbackScannerOptions = {},
-): GmailFeedbackScanner {
-  const pythonRuntime =
-    options.pythonRuntime ??
-    createSourcePythonRuntime({
-      ...(options.projectDir ? { projectDir: options.projectDir } : {}),
-      ...(options.uvBinary ? { uvBinary: options.uvBinary } : {}),
+// Runs the bounded Gmail outcome scan through the long-lived JSON-RPC worker
+// child instead of a bespoke one-shot subprocess with stdout line-parsing.
+// Auth failures still travel as { ok: false, message } inside the result so
+// the status mapping below stays behavior-identical.
+export function createWorkerGmailFeedbackScanner(dispatcher: JsonRpcDispatcher): GmailFeedbackScanner {
+  return async (input, context) => {
+    const response = await dispatcher.call(RpcMethods.GmailFeedbackScan, {
+      expectedAppDir: context.appDir,
+      expectedDbPath: context.dbPath,
+      ...(input.recipientEmail !== undefined ? { recipientEmail: input.recipientEmail } : {}),
+      ...(input.limit !== undefined ? { limit: Number(input.limit) } : {}),
+      ...(input.maxResultsPerAnchor !== undefined
+        ? { maxResultsPerAnchor: Number(input.maxResultsPerAnchor) }
+        : {}),
+      ...(input.windowDays !== undefined ? { windowDays: Number(input.windowDays) } : {}),
     });
-
-  return async (input, context) =>
-    runWorkerScan(input, {
-      appDir: context.appDir,
-      dbPath: context.dbPath,
-      pythonRuntime,
-    });
+    if (response.error) {
+      const message = response.error.message || "Gmail feedback scan failed.";
+      throw new GmailFeedbackScanError(message, gmailFeedbackErrorStatus(message));
+    }
+    const parsed = response.result;
+    if (!isRecord(parsed)) {
+      throw new GmailFeedbackScanError("Worker response was not a JSON object.", 500);
+    }
+    if (parsed.ok === false) {
+      const message = optionalText(parsed.message) ?? "Gmail feedback scan failed.";
+      throw new GmailFeedbackScanError(message, gmailFeedbackErrorStatus(message));
+    }
+    return sanitizeGmailFeedbackScanResponse(parsed);
+  };
 }
 
 export function sanitizeGmailFeedbackScanResponse(output: unknown): GmailOutcomeScanResponse {
@@ -82,94 +88,6 @@ export function sanitizeGmailFeedbackScanResponse(output: unknown): GmailOutcome
       };
     }),
   };
-}
-
-interface WorkerRunOptions extends GmailFeedbackScanContext {
-  pythonRuntime: PythonRuntimeCommandResolver;
-}
-
-function runWorkerScan(
-  payload: GmailOutcomeScanRequest,
-  options: WorkerRunOptions,
-): Promise<GmailOutcomeScanResponse> {
-  return new Promise((resolve, reject) => {
-    const command = options.pythonRuntime.resolve(
-      {
-        kind: "module",
-        module: "jobctrl.infrastructure.gmail.feedback",
-        args: ["--db-path", options.dbPath],
-      },
-      { appDir: options.appDir },
-    );
-    const child = spawn(command.executable, command.argv, {
-      cwd: command.cwd,
-      env: command.env,
-      stdio: ["pipe", "pipe", "pipe"],
-    });
-    let stdout = "";
-    let stderr = "";
-    child.stdout.setEncoding("utf8");
-    child.stderr.setEncoding("utf8");
-    child.stdout.on("data", (chunk: string) => {
-      stdout += chunk;
-    });
-    child.stderr.on("data", (chunk: string) => {
-      stderr += chunk;
-    });
-    child.on("error", reject);
-    child.on("close", (code) => {
-      if (code !== 0) {
-        const parsed = tryParseWorkerOutput(stdout);
-        const message =
-          (isRecord(parsed) && optionalText(parsed.message)) ||
-          stderr.trim() ||
-          stdout.trim() ||
-          `Worker exited with code ${code ?? "unknown"}.`;
-        reject(new GmailFeedbackScanError(message, gmailFeedbackErrorStatus(message)));
-        return;
-      }
-      try {
-        const parsed = parseWorkerOutput(stdout);
-        if (!isRecord(parsed)) {
-          throw new Error("Worker response was not a JSON object.");
-        }
-        if (parsed.ok === false) {
-          const message = optionalText(parsed.message) ?? "Gmail feedback scan failed.";
-          throw new GmailFeedbackScanError(message, gmailFeedbackErrorStatus(message));
-        }
-        resolve(sanitizeGmailFeedbackScanResponse(parsed));
-      } catch (error) {
-        reject(
-          error instanceof GmailFeedbackScanError
-            ? error
-            : new GmailFeedbackScanError(
-                error instanceof Error ? error.message : "Unable to parse worker response.",
-                500,
-              ),
-        );
-      }
-    });
-    child.stdin.end(`${JSON.stringify(payload)}\n`);
-  });
-}
-
-function parseWorkerOutput(stdout: string): unknown {
-  const line = stdout
-    .trim()
-    .split("\n")
-    .findLast((candidate) => candidate.trim().startsWith("{"));
-  if (!line) {
-    throw new Error("Worker did not return a JSON object.");
-  }
-  return JSON.parse(line) as unknown;
-}
-
-function tryParseWorkerOutput(stdout: string): unknown {
-  try {
-    return parseWorkerOutput(stdout);
-  } catch {
-    return null;
-  }
 }
 
 function gmailFeedbackErrorStatus(message: string): number {

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -444,7 +444,7 @@ export function buildApp(options: BuildAppOptions): FastifyInstance {
   const manualCaptureImporter =
     options.manualCaptureImporter ?? createWorkerManualCaptureImporter({ pythonRuntime });
   const gmailFeedbackScanner =
-    options.gmailFeedbackScanner ?? createWorkerGmailFeedbackScanner({ pythonRuntime });
+    options.gmailFeedbackScanner ?? createWorkerGmailFeedbackScanner(providerDispatcher);
   const profileImporter = options.profileImporter ?? createProfileImporter(pythonRuntime);
   const profilePreviewRenderer = options.profilePreviewRenderer ?? createProfilePreviewRenderer(pythonRuntime);
   const resumePdfRenderer = options.resumePdfRenderer ?? createResumeHtmlPdfRenderer(providerDispatcher);

--- a/apps/api/test/application-feedback.test.ts
+++ b/apps/api/test/application-feedback.test.ts
@@ -7,7 +7,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { ensureApplicationFeedbackTables } from "../src/application-feedback.js";
 import type { ApplyReviewQueueResponse } from "../src/contracts.js";
-import { GmailFeedbackScanError, type GmailFeedbackScanner } from "../src/gmail-feedback-worker.js";
+import {
+  createWorkerGmailFeedbackScanner,
+  GmailFeedbackScanError,
+  type GmailFeedbackScanner,
+} from "../src/gmail-feedback-worker.js";
+import type { JsonRpcDispatcher } from "../src/json-rpc-adapter.js";
 import { type ActionDispatcher, type ActionDispatchResult } from "../src/local-actions.js";
 import { BUILT_IN_RESUME_TEMPLATE_THEME } from "../src/resume-templates.js";
 import { type BuildAppOptions, buildApp } from "../src/server.js";
@@ -1869,6 +1874,34 @@ describe("application feedback API", () => {
       ok: false,
       error: "gmail_feedback_scan_failed",
       message: "missing Gmail token at local auth path",
+    });
+
+    await app.close();
+  });
+
+  it("keeps dispatcher transport rejections on the typed scan error path", async () => {
+    const rejectingDispatcher: JsonRpcDispatcher = {
+      call: async () => {
+        throw new Error("JSON-RPC request timed out after 600000ms");
+      },
+      close: async () => {},
+    };
+    const app = buildApp({
+      ...options,
+      gmailFeedbackScanner: createWorkerGmailFeedbackScanner(rejectingDispatcher),
+    });
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/v1/outcomes/gmail/scan",
+      payload: { limit: 1 },
+    });
+
+    expect(response.statusCode, response.body).toBe(500);
+    expect(response.json()).toEqual({
+      ok: false,
+      error: "gmail_feedback_scan_failed",
+      message: "Gmail feedback scan failed: JSON-RPC request timed out after 600000ms",
     });
 
     await app.close();

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -93,6 +93,7 @@ export const RpcMethods = {
   ReviewLearningRecommendation: "review_learning_recommendation",
   RollbackTailoringPolicy: "rollback_tailoring_policy",
   RenderResumePdf: "render_resume_pdf",
+  GmailFeedbackScan: "gmail_feedback_scan",
 } as const;
 export type RpcMethod = (typeof RpcMethods)[keyof typeof RpcMethods];
 
@@ -634,6 +635,25 @@ export const RenderResumePdfResultSchema = z
   })
   .strict();
 export type RenderResumePdfResult = z.infer<typeof RenderResumePdfResultSchema>;
+
+export const GmailFeedbackScanParamsSchema = z
+  .object({
+    expectedAppDir: z.string().trim().min(1).optional(),
+    expectedDbPath: z.string().trim().min(1).optional(),
+    recipientEmail: z.string().trim().min(1).optional(),
+    limit: z.number().int().min(1).max(100).optional(),
+    maxResultsPerAnchor: z.number().int().min(1).max(20).optional(),
+    windowDays: z.number().int().min(1).max(180).optional(),
+  })
+  .strict();
+export type GmailFeedbackScanParams = z.infer<typeof GmailFeedbackScanParamsSchema>;
+
+// The scan result deliberately passes through: the TS caller sanitizes the
+// payload field-by-field, and auth failures travel as { ok: false, message }
+// so the route's status mapping stays behavior-identical to the old
+// subprocess protocol.
+export const GmailFeedbackScanResultSchema = z.object({ ok: z.boolean() }).passthrough();
+export type GmailFeedbackScanResult = z.infer<typeof GmailFeedbackScanResultSchema>;
 
 export const ProfileImportParamsSchema = z
   .object({

--- a/workers/automation/src/jobctrl/infrastructure/rpc/handlers.py
+++ b/workers/automation/src/jobctrl/infrastructure/rpc/handlers.py
@@ -926,6 +926,36 @@ def render_resume_pdf(params: dict[str, Any]) -> dict[str, Any]:
     return {"status": "succeeded", "pdfPath": pdf_path}
 
 
+def gmail_feedback_scan(params: dict[str, Any]) -> dict[str, Any]:
+    """Run the bounded Gmail outcome scan for the TS API.
+
+    The result dict passes through verbatim - auth failures travel as
+    ``{"ok": False, "message": ...}`` so the API's status mapping keeps the
+    same behavior it had over the old one-shot subprocess protocol.
+    """
+
+    assert_expected_runtime(
+        expected_app_dir=params.get("expectedAppDir"),
+        expected_db_path=params.get("expectedDbPath"),
+    )
+    from jobctrl.config import DB_PATH
+    from jobctrl.infrastructure.gmail.feedback import scan_gmail_feedback
+
+    kwargs: dict[str, Any] = {}
+    recipient = str(params.get("recipientEmail") or "").strip()
+    if recipient:
+        kwargs["recipient_email"] = recipient
+    for param_name, kwarg_name in (
+        ("limit", "limit"),
+        ("maxResultsPerAnchor", "max_results_per_anchor"),
+        ("windowDays", "window_days"),
+    ):
+        value = params.get(param_name)
+        if value is not None:
+            kwargs[kwarg_name] = int(value)
+    return scan_gmail_feedback(db_path=DB_PATH, **kwargs)
+
+
 def rederive_learning_recommendations(params: dict[str, Any]) -> dict[str, Any]:
     """Refresh pending Materials proposals after an explicit signal review."""
 
@@ -1067,6 +1097,7 @@ def register_default_handlers(server: JsonRpcServer, *, canceler: WorkflowCancel
     )
     server.register("rollback_tailoring_policy", rollback_tailoring_policy, mode="sync")
     server.register("render_resume_pdf", render_resume_pdf, mode="sync")
+    server.register("gmail_feedback_scan", gmail_feedback_scan, mode="sync")
     server.register("refresh_compensation", refresh_compensation, mode="workflow")
     server.register("generate_interview_prep", generate_interview_prep, mode="workflow")
     server.register("run_contact_research", run_contact_research, mode="workflow")

--- a/workers/automation/src/jobctrl/infrastructure/rpc/handlers.py
+++ b/workers/automation/src/jobctrl/infrastructure/rpc/handlers.py
@@ -953,7 +953,14 @@ def gmail_feedback_scan(params: dict[str, Any]) -> dict[str, Any]:
         value = params.get(param_name)
         if value is not None:
             kwargs[kwarg_name] = int(value)
-    return scan_gmail_feedback(db_path=DB_PATH, **kwargs)
+    try:
+        return scan_gmail_feedback(db_path=DB_PATH, **kwargs)
+    except Exception as exc:  # noqa: BLE001 - protocol boundary, see docstring
+        # scan_gmail_feedback raises on failure; only the deleted CLI main()
+        # converted exceptions into the ok:false envelope. Without this the
+        # RPC server flattens every failure to a generic "Internal error"
+        # and the API's message-based 400/503 mapping goes dead.
+        return {"ok": False, "message": str(exc)}
 
 
 def rederive_learning_recommendations(params: dict[str, Any]) -> dict[str, Any]:

--- a/workers/automation/tests/test_gmail_feedback_scan_handler.py
+++ b/workers/automation/tests/test_gmail_feedback_scan_handler.py
@@ -58,6 +58,19 @@ def test_auth_failures_pass_through_as_ok_false(monkeypatch):
     }
 
 
+def test_scan_exceptions_become_ok_false_with_the_real_message(monkeypatch):
+    def raising_scan(**_kwargs):
+        raise RuntimeError("Gmail auth required: run jobctrl gmail-auth")
+
+    monkeypatch.setattr(
+        "jobctrl.infrastructure.gmail.feedback.scan_gmail_feedback", raising_scan
+    )
+    assert handlers.gmail_feedback_scan({}) == {
+        "ok": False,
+        "message": "Gmail auth required: run jobctrl gmail-auth",
+    }
+
+
 def test_registered_as_a_sync_method():
     source = Path(handlers.__file__).read_text(encoding="utf-8")
     assert 'server.register("gmail_feedback_scan", gmail_feedback_scan, mode="sync")' in source

--- a/workers/automation/tests/test_gmail_feedback_scan_handler.py
+++ b/workers/automation/tests/test_gmail_feedback_scan_handler.py
@@ -1,0 +1,63 @@
+"""The gmail_feedback_scan sync RPC handler used by the TS API's scan route."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from jobctrl.infrastructure.rpc import handlers
+
+
+def test_maps_camel_case_params_and_passes_result_through(monkeypatch):
+    captured: dict[str, object] = {}
+
+    def fake_scan(*, db_path, **kwargs):
+        captured["db_path"] = str(db_path)
+        captured.update(kwargs)
+        return {"ok": True, "scannedAnchorCount": 3}
+
+    monkeypatch.setattr(
+        "jobctrl.infrastructure.gmail.feedback.scan_gmail_feedback", fake_scan
+    )
+    result = handlers.gmail_feedback_scan(
+        {
+            "recipientEmail": "user@example.com",
+            "limit": 10,
+            "maxResultsPerAnchor": 4,
+            "windowDays": 30,
+        }
+    )
+    assert result == {"ok": True, "scannedAnchorCount": 3}
+    assert captured["recipient_email"] == "user@example.com"
+    assert captured["limit"] == 10
+    assert captured["max_results_per_anchor"] == 4
+    assert captured["window_days"] == 30
+
+
+def test_omits_unset_params_so_scan_defaults_apply(monkeypatch):
+    captured: dict[str, object] = {}
+
+    def fake_scan(*, db_path, **kwargs):
+        captured.update(kwargs)
+        return {"ok": True}
+
+    monkeypatch.setattr(
+        "jobctrl.infrastructure.gmail.feedback.scan_gmail_feedback", fake_scan
+    )
+    assert handlers.gmail_feedback_scan({}) == {"ok": True}
+    assert captured == {}
+
+
+def test_auth_failures_pass_through_as_ok_false(monkeypatch):
+    monkeypatch.setattr(
+        "jobctrl.infrastructure.gmail.feedback.scan_gmail_feedback",
+        lambda **_kwargs: {"ok": False, "message": "gmail auth required"},
+    )
+    assert handlers.gmail_feedback_scan({}) == {
+        "ok": False,
+        "message": "gmail auth required",
+    }
+
+
+def test_registered_as_a_sync_method():
+    source = Path(handlers.__file__).read_text(encoding="utf-8")
+    assert 'server.register("gmail_feedback_scan", gmail_feedback_scan, mode="sync")' in source


### PR DESCRIPTION
## Summary
The Gmail outcome scan moves from a bespoke one-shot Python spawn (stdout line-scraping, no timeout, no overlap protection) to a `gmail_feedback_scan` sync JSON-RPC method on the long-lived rpc child. Auth failures still travel as `ok:false + message` inside the result, so the route's 400/503/500 status mapping is byte-identical; unset scan parameters keep their Python-side defaults; the route's injected-scanner test seam is untouched.

## Why
This was the last bespoke transport to Python. With the render seam (#777), the API now invokes Python exactly one way: the JSON-RPC adapter.

## Validation
New Python handler tests (camelCase mapping, unset-param defaults, ok:false passthrough, sync registration) — 92 handler-suite tests green; api/contracts typechecks; 233-test server suite green (the scan route's stub seam is unchanged).