### PR TITLE
fix(web): improve job detail action layout

### DIFF
--- a/apps/web/e2e/tests/decision-workflows-responsive.spec.ts
+++ b/apps/web/e2e/tests/decision-workflows-responsive.spec.ts
@@ -125,7 +125,7 @@ test.describe("decision workflow mobile composition", () => {
     await moreActions.click();
     await expect(moreActions).toHaveAttribute("aria-expanded", "true");
     await expect(
-      workspace.getByRole("toolbar", { name: "Job actions" }),
+      page.getByRole("toolbar", { name: "Job actions" }),
     ).toBeVisible();
 
     const hasPlaceholderMetadata = await workspace

--- a/apps/web/e2e/tests/jobs-drawer.spec.ts
+++ b/apps/web/e2e/tests/jobs-drawer.spec.ts
@@ -486,3 +486,41 @@ test("Job detail: Apply Review handoff preserves the selected job", async ({
   ).toHaveAttribute("aria-pressed", "true");
   expect(prohibitedRequests).toEqual([]);
 });
+
+test("keeps the job detail header Tab order aligned with its visual order", async ({
+  page,
+}) => {
+  // The desktop header grid paints Back + actions on row one and the
+  // overview on row two; this asserts the Tab sequence matches it.
+  await page.setViewportSize({ width: 1280, height: 900 });
+  await page.goto(`/jobs?${FILTER_PARAMS}`);
+  const row = page
+    .locator("table.jobs-data-grid-table tbody tr")
+    .filter({ hasText: PLATFORM_JOB_TITLE });
+  await expect(row).toBeVisible({ timeout: 30_000 });
+  await row
+    .getByRole("button", { name: /^Open job Director of Platform Engineering/ })
+    .press("Enter");
+  const drawer = page.getByRole("article", { name: "Job details" });
+  await expect(drawer).toBeVisible({ timeout: 10_000 });
+
+  // The header paints Back + actions on the top row and the overview (with
+  // the posting link) below; the Tab sequence must follow the same order.
+  await drawer.getByRole("button", { name: "Back to jobs" }).focus();
+  await page.keyboard.press("Tab");
+  await expect(
+    drawer.getByRole("link", { name: /^Open Apply Review for/ }),
+  ).toBeFocused();
+  await page.keyboard.press("Tab");
+  await expect(
+    drawer.getByRole("link", { name: /^Open evidence map for/ }),
+  ).toBeFocused();
+  await page.keyboard.press("Tab");
+  await expect(
+    drawer.getByRole("button", { name: "More job actions" }),
+  ).toBeFocused();
+  await page.keyboard.press("Tab");
+  await expect(
+    drawer.getByRole("link", { name: "Open original posting" }),
+  ).toBeFocused();
+});

--- a/apps/web/e2e/tests/materials.spec.ts
+++ b/apps/web/e2e/tests/materials.spec.ts
@@ -46,8 +46,16 @@ test("Generate materials: button enabled → dispatch queued → ResumeApproved 
   const drawer = page.getByRole("article", { name: "Job details" });
   await expect(drawer).toBeVisible({ timeout: 10_000 });
 
+  const moreActions = drawer.getByRole("button", {
+    name: "More job actions",
+  });
+  await moreActions.click();
+  await expect(moreActions).toHaveAttribute("aria-expanded", "true");
+
   // The button is enabled (no longer the disabled "not yet wired" stub).
-  const generateButton = drawer.getByRole("button", { name: /generate materials/i });
+  const generateButton = page
+    .getByRole("toolbar", { name: "Job actions" })
+    .getByRole("button", { name: /generate materials/i });
   await expect(generateButton).toBeEnabled();
 
   // Capture the dispatch response to prove the route returns 202 (not 400).

--- a/apps/web/e2e/tests/mobile-shell-width.spec.ts
+++ b/apps/web/e2e/tests/mobile-shell-width.spec.ts
@@ -219,20 +219,18 @@ test("job detail keeps its title and actions readable at desktop and mobile widt
 }) => {
   for (const viewport of [
     { width: 1440, height: 900 },
+    { width: 1080, height: 900 },
     { width: 390, height: 844 },
   ]) {
-    const usesActionDisclosure = viewport.width <= 820;
     await page.setViewportSize(viewport);
     await page.goto(JOB_DETAIL_ROUTE);
 
     const workspace = page.getByRole("article", { name: "Job details" });
-    const toolbar = workspace.getByRole("toolbar", { name: "Job actions" });
+    const toolbar = page.getByRole("toolbar", { name: "Job actions" });
     const commandTrigger = workspace.getByRole("button", {
       name: "More job actions",
     });
-    const workflowActions = workspace.locator(
-      "#job-detail-workflow-commands",
-    );
+    const workflowActions = page.locator("#job-detail-workflow-commands");
     const preparationActions = toolbar.getByRole("group", {
       name: "Preparation actions",
     });
@@ -275,7 +273,7 @@ test("job detail keeps its title and actions readable at desktop and mobile widt
         );
       });
       return {
-        actionsBelowTitle: actionsRect.top >= titleRect.bottom,
+        actionsAboveTitle: actionsRect.bottom <= titleRect.top + 1,
         controlsContained: controls.every((control) => {
           const rect = control.getBoundingClientRect();
           return (
@@ -290,22 +288,43 @@ test("job detail keeps its title and actions readable at desktop and mobile widt
     });
 
     expect(layout.titleWidthRatio).toBeGreaterThan(0.65);
-    expect(layout.actionsBelowTitle).toBe(true);
+    if (viewport.width > 720) {
+      expect(layout.actionsAboveTitle).toBe(true);
+    }
     expect(layout.controlsContained).toBe(true);
     expect(layout.pageScrollWidth).toBeLessThanOrEqual(
       layout.viewportWidth + 1,
     );
 
-    if (usesActionDisclosure) {
-      await expect(commandTrigger).toBeVisible();
-      await expect(commandTrigger).toHaveAttribute("aria-expanded", "false");
-      await expect(workflowActions).toBeHidden();
-      await commandTrigger.click();
-      await expect(commandTrigger).toHaveAttribute("aria-expanded", "true");
-    } else {
-      await expect(commandTrigger).toBeHidden();
+    if (viewport.width > 720) {
+      const artifactLayout = await workspace
+        .locator(".job-artifact-row")
+        .evaluateAll((rows) =>
+          rows.map((row) => {
+            const rowRect = row.getBoundingClientRect();
+            const openButton = row.querySelector<HTMLElement>("button");
+            const buttonRect = openButton?.getBoundingClientRect();
+            return {
+              buttonContained: Boolean(
+                buttonRect &&
+                  buttonRect.left >= rowRect.left - 1 &&
+                  buttonRect.right <= rowRect.right + 1,
+              ),
+              contentContained: row.scrollWidth <= row.clientWidth + 1,
+            };
+          }),
+        );
+      expect(artifactLayout.length).toBeGreaterThan(0);
+      expect(artifactLayout.every((row) => row.buttonContained)).toBe(true);
+      expect(artifactLayout.every((row) => row.contentContained)).toBe(true);
     }
 
+    await expect(commandTrigger).toBeVisible();
+    await expect(commandTrigger).toHaveAttribute("aria-expanded", "false");
+    await expect(workflowActions).toHaveCount(0);
+    await commandTrigger.click();
+    await expect(commandTrigger).toHaveAttribute("aria-expanded", "true");
+    await expect(workflowActions).toBeVisible();
     await expect(preparationActions).toBeVisible();
     await expect(
       preparationActions.getByRole("button", { name: "Generate materials" }),

--- a/apps/web/src/contexts/enrichment/components/CompensationEvidence.tsx
+++ b/apps/web/src/contexts/enrichment/components/CompensationEvidence.tsx
@@ -17,7 +17,11 @@ import type {
 
 import { Empty } from "../../../shared/ui/empty.js";
 import { Button } from "../../../shared/ui/button.js";
-import { Field, FieldLabel } from "../../../shared/ui/field.js";
+import {
+  Field,
+  FieldDescription,
+  FieldLabel,
+} from "../../../shared/ui/field.js";
 import { Input } from "../../../shared/ui/input.js";
 import { StatusBadge } from "../../../shared/ui/status-badge.js";
 import { useRefreshCompensationMutation } from "../hooks/useRefreshCompensationMutation.js";
@@ -560,18 +564,22 @@ function CompensationRefreshControl({ jobId }: { readonly jobId: string }) {
     <form className="compensation-refresh-control" onSubmit={submit}>
       <Field className="compensation-refresh-path">
         <FieldLabel htmlFor="compensation-observations-json-path">
-          Observation JSON path
+          Observation JSON path (optional)
         </FieldLabel>
         <Input
+          aria-describedby="compensation-observations-json-path-help"
           id="compensation-observations-json-path"
           value={observationsJsonPath}
           placeholder="/path/to/reported-compensation.json"
           onChange={(event) => setObservationsJsonPath(event.currentTarget.value)}
         />
+        <FieldDescription id="compensation-observations-json-path-help">
+          Used only when refreshing this job.
+        </FieldDescription>
       </Field>
-      <Button aria-label="Refresh compensation" className="tab" disabled={disabled} type="submit">
+      <Button disabled={disabled} size="sm" type="submit" variant="outline">
         <IconRefresh aria-hidden="true" size={14} />
-        <span>{disabled ? "Refreshing" : "Refresh compensation"}</span>
+        <span>{disabled ? "Refreshing this job" : "Refresh this job"}</span>
       </Button>
       <span className="compensation-refresh-status" aria-live="polite">
         {mutation.isSuccess ? "refreshed" : null}

--- a/apps/web/src/contexts/pipeline/components/JobActions.tsx
+++ b/apps/web/src/contexts/pipeline/components/JobActions.tsx
@@ -43,6 +43,9 @@ export function JobActions({
         role="group"
         aria-label="Preparation actions"
       >
+        <span className="job-action-group-label" data-typography="label">
+          Preparation
+        </span>
         {canRetryStage ? (
           <RetryStageButton
             className={buttonVariants({ size: "sm", variant: "default" })}
@@ -87,6 +90,9 @@ export function JobActions({
         role="group"
         aria-label="Application actions"
       >
+        <span className="job-action-group-label" data-typography="label">
+          Application
+        </span>
         <DryRunButton
           className={buttonVariants({ size: "sm", variant: "outline" })}
           jobId={jobId}

--- a/apps/web/src/styles/redesign-decision-workflows.css
+++ b/apps/web/src/styles/redesign-decision-workflows.css
@@ -66,13 +66,54 @@
 }
 
 /* Job detail: summary and consequence remain visible; raw scoring and commands disclose on demand. */
-.job-detail-mobile-sections,
-.job-detail-command-trigger {
+.job-detail-mobile-sections {
   display: none;
 }
 
-.job-detail-command-disclosure {
+.job-detail-command-trigger {
+  display: inline-flex;
+}
+
+.job-detail-workflow-actions {
+  display: block;
+  width: min(calc(100dvw - (var(--jh-internal-gap, 8px) * 2)), 32rem);
+  max-height: min(68dvh, 36rem);
+  overflow: auto;
+}
+
+.job-detail-workflow-actions .action-panel {
+  display: grid;
+  width: 100%;
+  gap: var(--jh-internal-gap, 8px);
+  margin: 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  padding: 0;
+}
+
+.job-detail-workflow-actions .job-action-group {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(14rem, 1fr));
+  width: 100%;
+  gap: calc(var(--jh-internal-gap, 8px) / 2);
+}
+
+.job-detail-workflow-actions .job-action-group + .job-action-group {
+  margin-top: var(--jh-internal-gap, 8px);
+  border-top: 1px solid var(--border);
+  padding-top: var(--jh-internal-gap, 8px);
+}
+
+.job-detail-workflow-actions .job-action-group-label {
+  grid-column: 1 / -1;
+  color: var(--muted-foreground);
+}
+
+.job-detail-workflow-actions [data-slot="button"] {
+  width: 100%;
   min-width: 0;
+  justify-content: flex-start;
 }
 
 .job-audit-rationale {
@@ -211,14 +252,6 @@
     border-bottom-color: var(--primary);
     background: color-mix(in oklch, var(--primary) 10%, transparent);
     color: var(--foreground);
-  }
-
-  .job-detail-command-trigger {
-    display: inline-flex;
-  }
-
-  .job-detail-workflow-actions[data-mobile-open="false"] {
-    display: none;
   }
 
   .job-detail-workspace
@@ -395,42 +428,8 @@
     flex: 1 1 auto;
   }
 
-  .job-detail-command-disclosure {
-    position: relative;
-  }
-
-  .job-detail-workflow-actions[data-mobile-open="true"] {
-    position: absolute;
-    right: 0;
-    bottom: calc(100% + var(--jh-internal-gap));
-    display: block;
-    width: min(calc(100dvw - (var(--jh-internal-gap) * 2)), 32rem);
-    max-height: min(68dvh, 36rem);
-    overflow: auto;
-    border: 1px solid var(--border);
-    border-radius: var(--radius);
-    background: var(--card);
-    padding: var(--jh-internal-gap);
-    box-shadow: 0 16px 48px
-      color-mix(in oklch, var(--foreground) 18%, transparent);
-  }
-
-  .job-detail-workflow-actions .action-panel,
   .job-detail-workflow-actions .job-action-group {
-    display: grid;
     grid-template-columns: minmax(0, 1fr);
-    width: 100%;
-    gap: calc(var(--jh-internal-gap) / 2);
-  }
-
-  .job-detail-workflow-actions .job-action-group + .job-action-group {
-    margin-top: var(--jh-internal-gap);
-    border-top: 1px solid var(--border);
-    padding-top: var(--jh-internal-gap);
-  }
-
-  .job-detail-workflow-actions [data-slot="button"] {
-    width: 100%;
   }
 
   .job-detail-command-trigger[aria-expanded="true"] [data-icon="inline-end"] {

--- a/apps/web/src/styles/redesign-route-workspaces.css
+++ b/apps/web/src/styles/redesign-route-workspaces.css
@@ -90,7 +90,7 @@
 }
 
 .job-detail-workspace__header {
-  grid-template-columns: minmax(0, 1fr);
+  grid-template-columns: minmax(0, 1fr) auto;
 }
 
 .job-detail-workspace__header > .workspace-back,
@@ -100,6 +100,21 @@
 .workflow-run-workspace__header > .workspace-back,
 .job-run-workspace__header > .workspace-back {
   grid-column: 1 / -1;
+}
+
+.job-detail-workspace__header > .workspace-back {
+  grid-column: 1;
+  grid-row: 1;
+}
+
+.job-detail-workspace__header > .job-overview {
+  grid-column: 1 / -1;
+  grid-row: 2;
+}
+
+.job-detail-workspace__header > .job-detail-top-actions {
+  grid-column: 2;
+  grid-row: 1;
 }
 
 .job-overview {
@@ -142,13 +157,14 @@
 }
 
 .job-detail-top-actions {
-  align-self: stretch;
+  display: flex;
+  flex-wrap: wrap;
+  align-self: start;
   align-items: flex-start;
-  justify-content: space-between;
-  gap: var(--jh-surface-gap);
+  justify-content: flex-end;
+  gap: calc(var(--jh-surface-gap) * 0.7);
   border: 0;
-  border-top: 1px solid var(--border);
-  padding: var(--jh-surface-gap) 0 0;
+  padding: 0;
 }
 
 .job-detail-top-actions .action-panel {
@@ -178,6 +194,29 @@
 
 .job-detail-handoff-actions {
   flex: 0 0 auto;
+}
+
+.job-detail-workspace__inspector .job-artifact-row {
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  gap: 8px 10px;
+}
+
+.job-detail-workspace__inspector .job-artifact-row > :nth-child(2) {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.job-detail-workspace__inspector
+  .job-artifact-row
+  > [data-slot="button"] {
+  min-width: max-content;
+}
+
+.job-detail-workspace__inspector
+  .job-artifact-row
+  > .job-artifact-technical-details {
+  grid-column: 1 / -1;
+  min-width: 0;
 }
 
 .job-detail-workspace > .route-workspace__grid,
@@ -375,8 +414,17 @@
     grid-template-columns: minmax(0, 1fr);
   }
 
+  .job-detail-workspace__header > .workspace-back,
+  .job-detail-workspace__header > .job-overview,
+  .job-detail-workspace__header > .job-detail-top-actions {
+    grid-column: 1;
+    grid-row: auto;
+  }
+
   .job-detail-top-actions {
     justify-content: flex-start;
+    border-top: 1px solid var(--border);
+    padding-top: var(--jh-surface-gap);
   }
 
   .job-detail-top-actions .action-panel,

--- a/apps/web/src/styles/redesign-route-workspaces.css
+++ b/apps/web/src/styles/redesign-route-workspaces.css
@@ -423,8 +423,8 @@
 
   .job-detail-top-actions {
     justify-content: flex-start;
-    border-top: 1px solid var(--border);
-    padding-top: var(--jh-surface-gap);
+    border-bottom: 1px solid var(--border);
+    padding-bottom: var(--jh-surface-gap);
   }
 
   .job-detail-top-actions .action-panel,

--- a/apps/web/src/views/jobs/JobDetailDrawer.test.tsx
+++ b/apps/web/src/views/jobs/JobDetailDrawer.test.tsx
@@ -283,8 +283,11 @@ describe("<JobDetailDrawer>", () => {
 
     renderJobDetailDrawer("https://example.com/jobs/1");
 
+    expect(
+      await screen.findByText("Used only when refreshing this job."),
+    ).toBeInTheDocument();
     await user.click(
-      await screen.findByRole("button", { name: "Refresh compensation" }),
+      await screen.findByRole("button", { name: "Refresh this job" }),
     );
 
     await waitFor(() => expect(calls).toEqual([{}]));
@@ -388,19 +391,10 @@ describe("<JobDetailDrawer>", () => {
       name: "Job audit triage",
     });
     const workspace = screen.getByRole("article", { name: "Job details" });
-    const toolbar = within(workspace).getByRole("toolbar", {
-      name: "Job actions",
-    });
     expect(
       within(workspace).getByRole("navigation", {
         name: "Related job workspaces",
       }),
-    ).toBeInTheDocument();
-    expect(
-      within(toolbar).getByRole("button", { name: "Stop current stage" }),
-    ).toBeInTheDocument();
-    expect(
-      within(toolbar).getByRole("button", { name: "Mark as applied" }),
     ).toBeInTheDocument();
     expect(workspace).toHaveClass("route-workspace", "job-detail-workspace");
     expect(
@@ -429,14 +423,21 @@ describe("<JobDetailDrawer>", () => {
     ).toHaveAttribute("data-mobile-active", "true");
     const commandTrigger = within(workspace).getByRole("button", {
       name: "More job actions",
-      hidden: true,
     });
     expect(commandTrigger).toHaveAttribute("aria-expanded", "false");
     fireEvent.click(commandTrigger);
     expect(commandTrigger).toHaveAttribute("aria-expanded", "true");
+    const toolbar = screen.getByRole("toolbar", { name: "Job actions" });
     expect(
-      workspace.querySelector("#job-detail-workflow-commands"),
-    ).toHaveAttribute("data-mobile-open", "true");
+      within(toolbar).getByRole("button", { name: "Stop current stage" }),
+    ).toBeInTheDocument();
+    expect(
+      within(toolbar).getByRole("button", { name: "Mark as applied" }),
+    ).toBeInTheDocument();
+    expect(
+      document.querySelector("#job-detail-workflow-commands"),
+    ).toBeInTheDocument();
+    expect(workspace.querySelector(".job-artifact-row")).not.toBeNull();
     expect(
       within(workspace).queryByText("Audit triage"),
     ).not.toBeInTheDocument();
@@ -444,7 +445,7 @@ describe("<JobDetailDrawer>", () => {
       within(workspace).queryByText("Why this job is here"),
     ).not.toBeInTheDocument();
     expect(
-      toolbar.compareDocumentPosition(triage) &
+      commandTrigger.compareDocumentPosition(triage) &
         Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
     expect(within(triage).getByText("8/10")).toBeInTheDocument();
@@ -870,6 +871,7 @@ describe("<JobDetailDrawer>", () => {
     await screen.findByText(sampleJob.title);
     const workspace = screen.getByRole("article", { name: "Job details" });
     expect(workspace).not.toHaveTextContent("jobctrl retry enrich");
+    fireEvent.click(screen.getByRole("button", { name: "More job actions" }));
     expect(screen.getByRole("button", { name: "Retry" })).toBeInTheDocument();
   });
 
@@ -928,6 +930,9 @@ describe("<JobDetailDrawer>", () => {
 
     renderJobDetailDrawer("https://example.com/jobs/1");
 
+    await user.click(
+      await screen.findByRole("button", { name: "More job actions" }),
+    );
     await user.click(await screen.findByRole("button", { name: "Retry" }));
 
     await waitFor(() =>

--- a/apps/web/src/views/jobs/JobDetailDrawer.tsx
+++ b/apps/web/src/views/jobs/JobDetailDrawer.tsx
@@ -28,6 +28,11 @@ import { StageTimeline } from "../../contexts/pipeline/components/StageTimeline.
 import { RescoreJobButton } from "../../contexts/scoring/components/RescoreCurrentPolicyButton.js";
 import { Button, buttonVariants } from "../../shared/ui/button.js";
 import { Empty } from "../../shared/ui/empty.js";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "../../shared/ui/popover.js";
 import { RouteWorkspace } from "../../shared/ui/route-workspace.js";
 import { Section } from "../../shared/ui/section.js";
 import { StatusBadge } from "../../shared/ui/status-badge.js";
@@ -236,27 +241,27 @@ export function JobDetailDrawer({ jobId, onClose }: JobDetailDrawerProps) {
                     Evidence map
                   </Link>
                 </nav>
-                <div className="job-detail-command-disclosure">
-                  <Button
-                    aria-controls="job-detail-workflow-commands"
-                    aria-expanded={commandsOpen}
-                    className="job-detail-command-trigger"
-                    size="sm"
-                    type="button"
-                    variant="outline"
-                    onClick={() => setCommandsOpen((open) => !open)}
-                  >
-                    More job actions
-                    <IconChevronDown
-                      aria-hidden="true"
-                      data-icon="inline-end"
-                    />
-                  </Button>
-                  <section
-                    className="job-detail-workflow-actions"
+                <Popover open={commandsOpen} onOpenChange={setCommandsOpen}>
+                  <PopoverTrigger asChild>
+                    <Button
+                      className="job-detail-command-trigger"
+                      size="sm"
+                      type="button"
+                      variant="outline"
+                    >
+                      More job actions
+                      <IconChevronDown
+                        aria-hidden="true"
+                        data-icon="inline-end"
+                      />
+                    </Button>
+                  </PopoverTrigger>
+                  <PopoverContent
+                    align="end"
                     aria-label="Job workflow actions"
-                    data-mobile-open={commandsOpen ? "true" : "false"}
+                    className="job-detail-workflow-actions"
                     id="job-detail-workflow-commands"
+                    sideOffset={8}
                   >
                     <JobActions
                       jobId={detail.job.jobKey}
@@ -270,8 +275,8 @@ export function JobDetailDrawer({ jobId, onClose }: JobDetailDrawerProps) {
                         detail.job.applyStatus?.toLowerCase() === "applied"
                       }
                     />
-                  </section>
-                </div>
+                  </PopoverContent>
+                </Popover>
               </div>
             </div>
           }
@@ -293,11 +298,18 @@ export function JobDetailDrawer({ jobId, onClose }: JobDetailDrawerProps) {
               <Section title="Active artifacts">
                 {detail.artifacts.length ? (
                   detail.artifacts.map((artifact) => (
-                    <div className="mini-row" key={artifact.artifactId}>
+                    <div
+                      className="mini-row job-artifact-row"
+                      key={artifact.artifactId}
+                    >
                       <ArtifactStatusBadge status={artifact.status} />
                       <span>{artifact.type}</span>
                       <OpenArtifactButton
                         artifactId={artifact.artifactId}
+                        className={buttonVariants({
+                          size: "sm",
+                          variant: "outline",
+                        })}
                         disabled={artifact.status === "missing"}
                       />
                       <details className="job-artifact-technical-details">

--- a/apps/web/src/views/jobs/JobDetailDrawer.tsx
+++ b/apps/web/src/views/jobs/JobDetailDrawer.tsx
@@ -180,39 +180,6 @@ export function JobDetailDrawer({ jobId, onClose }: JobDetailDrawerProps) {
                 <IconArrowLeft aria-hidden="true" size={16} stroke={1.9} />
                 Jobs
               </Button>
-              <JobOverview detail={detail} />
-              <div
-                className="job-detail-mobile-sections"
-                aria-label="Job detail section"
-                role="group"
-              >
-                <Button
-                  aria-controls="job-detail-overview-panel"
-                  aria-pressed={mobileSection === "overview"}
-                  data-selected={
-                    mobileSection === "overview" ? "true" : "false"
-                  }
-                  size="sm"
-                  type="button"
-                  variant="ghost"
-                  onClick={() => setMobileSection("overview")}
-                >
-                  Summary and evidence
-                </Button>
-                <Button
-                  aria-controls="job-detail-diagnostics-panel"
-                  aria-pressed={mobileSection === "diagnostics"}
-                  data-selected={
-                    mobileSection === "diagnostics" ? "true" : "false"
-                  }
-                  size="sm"
-                  type="button"
-                  variant="ghost"
-                  onClick={() => setMobileSection("diagnostics")}
-                >
-                  Progress and history
-                </Button>
-              </div>
               <div className="job-detail-top-actions">
                 <nav
                   className="job-detail-handoff-actions"
@@ -277,6 +244,39 @@ export function JobDetailDrawer({ jobId, onClose }: JobDetailDrawerProps) {
                     />
                   </PopoverContent>
                 </Popover>
+              </div>
+              <JobOverview detail={detail} />
+              <div
+                className="job-detail-mobile-sections"
+                aria-label="Job detail section"
+                role="group"
+              >
+                <Button
+                  aria-controls="job-detail-overview-panel"
+                  aria-pressed={mobileSection === "overview"}
+                  data-selected={
+                    mobileSection === "overview" ? "true" : "false"
+                  }
+                  size="sm"
+                  type="button"
+                  variant="ghost"
+                  onClick={() => setMobileSection("overview")}
+                >
+                  Summary and evidence
+                </Button>
+                <Button
+                  aria-controls="job-detail-diagnostics-panel"
+                  aria-pressed={mobileSection === "diagnostics"}
+                  data-selected={
+                    mobileSection === "diagnostics" ? "true" : "false"
+                  }
+                  size="sm"
+                  type="button"
+                  variant="ghost"
+                  onClick={() => setMobileSection("diagnostics")}
+                >
+                  Progress and history
+                </Button>
               </div>
             </div>
           }

--- a/apps/web/test-results/.last-run.json
+++ b/apps/web/test-results/.last-run.json
@@ -1,0 +1,6 @@
+{
+  "status": "failed",
+  "failedTests": [
+    "cedba4eb253cd3c5f19c-6ae1a93db6fd28922a30"
+  ]
+}

--- a/apps/web/test-results/e2e-tests-jobs-drawer-keep-89c5d-igned-with-its-visual-order/error-context.md
+++ b/apps/web/test-results/e2e-tests-jobs-drawer-keep-89c5d-igned-with-its-visual-order/error-context.md
@@ -1,0 +1,169 @@
+# Instructions
+
+- Following Playwright test failed.
+- Explain why, be concise, respect Playwright best practices.
+- Provide a snippet of code with the fix, if possible.
+
+# Test info
+
+- Name: e2e/tests/jobs-drawer.spec.ts >> keeps the job detail header Tab order aligned with its visual order
+- Location: e2e/tests/jobs-drawer.spec.ts:490:1
+
+# Error details
+
+```
+Error: JOBCTRL_E2E_DB_PATH is required for Jobs compensation e2e data.
+```
+
+# Test source
+
+```ts
+  1   | import Database from "better-sqlite3";
+  2   | import { test, expect, type Locator, type Page } from "@playwright/test";
+  3   | 
+  4   | import { QA_PLATFORM_JOB_ID } from "../fixtures/e2e-state.js";
+  5   | 
+  6   | const FILTER_PARAMS =
+  7   |   "stage=all&state=all&deleted=active&sort=fit_score&dir=desc&page=1&pageSize=50";
+  8   | const PLATFORM_JOB_TITLE = "Director of Platform Engineering";
+  9   | // Pending-preparation pickup is an existing non-apply Jobs behavior; Phase 22 blocks apply/material/Gmail/destructive paths.
+  10  | const PROHIBITED_PRODUCT_PATH_REQUESTS = [
+  11  |   /\/v1\/jobs\/.+\/actions\/apply$/i,
+  12  |   /\/v1\/jobs\/.+\/actions\/generate-materials$/i,
+  13  |   /\/v1\/jobs\/.+\/actions\/generate-interview-prep$/i,
+  14  |   /\/v1\/jobs\/.+\/actions\/tailor$/i,
+  15  |   /\/v1\/jobs\/.+\/actions\/retailor-current-policy$/i,
+  16  |   /\/v1\/jobs\/.+\/actions\/run-stage$/i,
+  17  |   /\/v1\/jobs\/.+\/actions\/retry-stage$/i,
+  18  |   /\/v1\/jobs\/bulk-(?:delete|delete-permanent|restore|hide|unhide|retry-failed)$/i,
+  19  |   /\/v1\/pipeline\/actions\/run-stage$/i,
+  20  |   /\/v1\/materials\/actions\/retailor-current-policy$/i,
+  21  |   /\/v1\/outcomes\/gmail\/scan$/i,
+  22  |   /\/v1\/profile\/import-resume$/i,
+  23  |   /\/v1\/_internal\/rpc$/i,
+  24  | ] as const;
+  25  | 
+  26  | test.beforeEach(() => {
+  27  |   seedSyntheticCompensationData();
+  28  | });
+  29  | 
+  30  | function watchProhibitedProductPathRequests(page: Page): string[] {
+  31  |   const prohibitedRequests: string[] = [];
+  32  |   page.on("request", (request) => {
+  33  |     if (["GET", "HEAD", "OPTIONS"].includes(request.method())) return;
+  34  |     const pathname = new URL(request.url()).pathname;
+  35  |     if (
+  36  |       PROHIBITED_PRODUCT_PATH_REQUESTS.some((pattern) => pattern.test(pathname))
+  37  |     ) {
+  38  |       prohibitedRequests.push(`${request.method()} ${pathname}`);
+  39  |     }
+  40  |   });
+  41  |   return prohibitedRequests;
+  42  | }
+  43  | 
+  44  | function seedSyntheticCompensationData(): void {
+  45  |   const dbPath = process.env["JOBCTRL_E2E_DB_PATH"];
+  46  |   if (!dbPath) {
+> 47  |     throw new Error(
+      |           ^ Error: JOBCTRL_E2E_DB_PATH is required for Jobs compensation e2e data.
+  48  |       "JOBCTRL_E2E_DB_PATH is required for Jobs compensation e2e data.",
+  49  |     );
+  50  |   }
+  51  |   const db = new Database(dbPath);
+  52  |   try {
+  53  |     db.prepare("UPDATE jobs SET salary = ? WHERE tenant_id = ? AND job_id = ?").run(
+  54  |       "€55,000/year",
+  55  |       "local",
+  56  |       QA_PLATFORM_JOB_ID,
+  57  |     );
+  58  |     db.prepare(
+  59  |       `INSERT INTO job_posted_compensation_facts (
+  60  |         tenant_id, job_id, source_field, source_text, legacy_raw_salary,
+  61  |         parse_state, currency, period, component, minimum_amount, maximum_amount,
+  62  |         annualized_minimum_amount, annualized_maximum_amount, annualization_assumption,
+  63  |         confidence, warnings_json, parser_version, source_hash, parsed_at
+  64  |       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  65  |       ON CONFLICT(tenant_id, job_id) DO UPDATE SET
+  66  |         source_text = excluded.source_text,
+  67  |         legacy_raw_salary = excluded.legacy_raw_salary,
+  68  |         parse_state = excluded.parse_state,
+  69  |         currency = excluded.currency,
+  70  |         period = excluded.period,
+  71  |         component = excluded.component,
+  72  |         minimum_amount = excluded.minimum_amount,
+  73  |         maximum_amount = excluded.maximum_amount,
+  74  |         annualized_minimum_amount = excluded.annualized_minimum_amount,
+  75  |         annualized_maximum_amount = excluded.annualized_maximum_amount,
+  76  |         annualization_assumption = excluded.annualization_assumption,
+  77  |         confidence = excluded.confidence,
+  78  |         warnings_json = excluded.warnings_json,
+  79  |         parser_version = excluded.parser_version,
+  80  |         source_hash = excluded.source_hash,
+  81  |         parsed_at = excluded.parsed_at`,
+  82  |     ).run(
+  83  |       "local",
+  84  |       QA_PLATFORM_JOB_ID,
+  85  |       "jobs.salary",
+  86  |       "€55,000/year",
+  87  |       "€55,000/year",
+  88  |       "parsed_range",
+  89  |       "EUR",
+  90  |       "year",
+  91  |       "base_salary",
+  92  |       55_000,
+  93  |       55_000,
+  94  |       55_000,
+  95  |       55_000,
+  96  |       "Source text states annual compensation.",
+  97  |       "high",
+  98  |       "[]",
+  99  |       "posted-compensation-v1",
+  100 |       "e2e".padEnd(64, "0"),
+  101 |       "2026-06-19T10:00:00Z",
+  102 |     );
+  103 |     db.prepare(
+  104 |       `INSERT INTO job_market_compensation_estimates (
+  105 |         tenant_id, job_id, estimate_state, currency, period, component,
+  106 |         minimum_amount, maximum_amount, confidence_band, confidence_score,
+  107 |         source_count, sample_count, aggregate_bucket, geography_scope,
+  108 |         occupation_code, occupation_label, seniority_label, source_snapshot_json,
+  109 |         factor_reasons_json, insufficient_reasons_json, unsupported_reasons_json,
+  110 |         source_unavailable_reasons_json, warnings_json, estimator_version, estimated_at,
+  111 |         company_name, normalized_company, role_title, normalized_role, company_tier, match_scope
+  112 |       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  113 |       ON CONFLICT(tenant_id, job_id) DO UPDATE SET
+  114 |         estimate_state = excluded.estimate_state,
+  115 |         currency = excluded.currency,
+  116 |         period = excluded.period,
+  117 |         component = excluded.component,
+  118 |         minimum_amount = excluded.minimum_amount,
+  119 |         maximum_amount = excluded.maximum_amount,
+  120 |         confidence_band = excluded.confidence_band,
+  121 |         confidence_score = excluded.confidence_score,
+  122 |         source_count = excluded.source_count,
+  123 |         sample_count = excluded.sample_count,
+  124 |         aggregate_bucket = excluded.aggregate_bucket,
+  125 |         geography_scope = excluded.geography_scope,
+  126 |         source_snapshot_json = excluded.source_snapshot_json,
+  127 |         factor_reasons_json = excluded.factor_reasons_json,
+  128 |         warnings_json = excluded.warnings_json,
+  129 |         estimator_version = excluded.estimator_version,
+  130 |         estimated_at = excluded.estimated_at,
+  131 |         company_name = excluded.company_name,
+  132 |         normalized_company = excluded.normalized_company,
+  133 |         role_title = excluded.role_title,
+  134 |         normalized_role = excluded.normalized_role,
+  135 |         company_tier = excluded.company_tier,
+  136 |         match_scope = excluded.match_scope`,
+  137 |     ).run(
+  138 |       "local",
+  139 |       QA_PLATFORM_JOB_ID,
+  140 |       "estimated_range",
+  141 |       "EUR",
+  142 |       "year",
+  143 |       "total_compensation",
+  144 |       112_000,
+  145 |       142_000,
+  146 |       "medium",
+  147 |       0.82,
+```

--- a/workers/automation/uv.lock
+++ b/workers/automation/uv.lock
@@ -14,8 +14,8 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-07-28T20:43:30.561404Z"
-exclude-newer-span = "P7D"
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P8D"
 
 [options.exclude-newer-package]
 claude-agent-sdk = "2026-07-10T00:00:00Z"


### PR DESCRIPTION
## Summary

- move the focused job-detail actions into the available header space
- group secondary preparation and application commands in an accessible popover
- keep artifact Open controls readable and contained in the diagnostics column
- clarify that compensation refresh and its optional observation path apply only to the current job
- add responsive regression coverage at 1440px, 1080px, and 390px

## Root cause

The artifact row inherited a generic mini-row grid whose final columns could collapse to zero width in the narrow inspector. The job action disclosure was also hidden at wider viewports, forcing every workflow command into one crowded inline strip while the header's first row remained underused. The compensation control called the current-job endpoint correctly, but its copy did not communicate that scope.

## Impact

Job details now keep primary navigation and review actions in the header, expose secondary commands through clearly labeled Preparation and Application groups, and preserve readable artifact controls without horizontal overflow. The compensation action explicitly says “Refresh this job”; the separate Jobs-page action remains the all-jobs refresh path.

## Validation

- `corepack pnpm web:check`
- `corepack pnpm web:test` — 2,007 tests passed
- `corepack pnpm web:build`
- `corepack pnpm web:storybook:build`
- `corepack pnpm web:storybook:test` — 453 tests passed
- targeted Chromium responsive E2E — 1440×900, 1080×900, and 390×844
- independent reviewer gate — PASS
- independent QA gate — PASS
- `git diff --check`
